### PR TITLE
[docs] Enable validation and fix all links in react-native docs

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -13,7 +13,7 @@
     "test-links": "node --async-stack-traces --unhandled-rejections=strict ./scripts/test-links.js",
     "prettier": "prettier --write '**/*.{js,ts,tsx,md}'",
     "lint": "tsc --noEmit && eslint .",
-    "lint-links": "remark -u validate-links ./pages --ignore-pattern 'pages/versions/*/react-native'",
+    "lint-links": "remark -u validate-links ./pages",
     "watch": "tsc --noEmit -w",
     "test": "jest",
     "schema-sync": "node --async-stack-traces --unhandled-rejections=strict ./scripts/schema-sync.js"

--- a/docs/pages/versions/unversioned/react-native/activityindicator.md
+++ b/docs/pages/versions/unversioned/react-native/activityindicator.md
@@ -39,7 +39,7 @@ const styles = StyleSheet.create({
 
 ## Props
 
-Inherits [View Props](../view/#props).
+Inherits [View Props](view.md#props).
 
 ---
 

--- a/docs/pages/versions/unversioned/react-native/animated.md
+++ b/docs/pages/versions/unversioned/react-native/animated.md
@@ -85,8 +85,8 @@ Refer to the [Animations](https://reactnative.dev/docs/animations#animated-api) 
 
 There are two value types you can use with `Animated`:
 
-- [`Animated.Value()`](../animated/#value) for single values
-- [`Animated.ValueXY()`](../animated/#valuexy) for vectors
+- [`Animated.Value()`](animated.md#value) for single values
+- [`Animated.ValueXY()`](animated.md#valuexy) for vectors
 
 `Animated.Value` can bind to style properties or other props, and can be interpolated as well. A single `Animated.Value` can drive any number of properties.
 
@@ -94,9 +94,9 @@ There are two value types you can use with `Animated`:
 
 `Animated` provides three types of animation types. Each animation type provides a particular animation curve that controls how your values animate from their initial value to the final value:
 
-- [`Animated.decay()`](../animated/#decay) starts with an initial velocity and gradually slows to a stop.
-- [`Animated.spring()`](../animated/#spring) provides a basic spring physics model.
-- [`Animated.timing()`](../animated/#timing) animates a value over time using [easing functions](../easing/).
+- [`Animated.decay()`](animated.md#decay) starts with an initial velocity and gradually slows to a stop.
+- [`Animated.spring()`](animated.md#spring) provides a basic spring physics model.
+- [`Animated.timing()`](animated.md#timing) animates a value over time using [easing functions](easing.md).
 
 In most cases, you will be using `timing()`. By default, it uses a symmetric easeInOut curve that conveys the gradual acceleration of an object to full speed and concludes by gradually decelerating to a stop.
 
@@ -120,7 +120,7 @@ You can use the native driver by specifying `useNativeDriver: true` in your anim
 
 Only animatable components can be animated. These unique components do the magic of binding the animated values to the properties, and do targeted native updates to avoid the cost of the react render and reconciliation process on every frame. They also handle cleanup on unmount so they are safe by default.
 
-- [`createAnimatedComponent()`](../animated/#createanimatedcomponent) can be used to make a component animatable.
+- [`createAnimatedComponent()`](animated.md#createanimatedcomponent) can be used to make a component animatable.
 
 `Animated` exports the following animatable components using the above wrapper:
 
@@ -135,10 +135,10 @@ Only animatable components can be animated. These unique components do the magic
 
 Animations can also be combined in complex ways using composition functions:
 
-- [`Animated.delay()`](../animated/#delay) starts an animation after a given delay.
-- [`Animated.parallel()`](../animated/#parallel) starts a number of animations at the same time.
-- [`Animated.sequence()`](../animated/#sequence) starts the animations in order, waiting for each to complete before starting the next.
-- [`Animated.stagger()`](../animated/#stagger) starts animations in order and in parallel, but with successive delays.
+- [`Animated.delay()`](animated.md#delay) starts an animation after a given delay.
+- [`Animated.parallel()`](animated.md#parallel) starts a number of animations at the same time.
+- [`Animated.sequence()`](animated.md#sequence) starts the animations in order, waiting for each to complete before starting the next.
+- [`Animated.stagger()`](animated.md#stagger) starts animations in order and in parallel, but with successive delays.
 
 Animations can also be chained together by setting the `toValue` of one animation to be another `Animated.Value`. See [Tracking dynamic values](https://reactnative.dev/docs/animations#tracking-dynamic-values) in the Animations guide.
 
@@ -148,17 +148,17 @@ By default, if one animation is stopped or interrupted, then all other animation
 
 You can combine two animated values via addition, subtraction, multiplication, division, or modulo to make a new animated value:
 
-- [`Animated.add()`](../animated/#add)
-- [`Animated.subtract()`](../animated/#subtract)
-- [`Animated.divide()`](../animated/#divide)
-- [`Animated.modulo()`](../animated/#modulo)
-- [`Animated.multiply()`](../animated/#multiply)
+- [`Animated.add()`](animated.md#add)
+- [`Animated.subtract()`](animated.md#subtract)
+- [`Animated.divide()`](animated.md#divide)
+- [`Animated.modulo()`](animated.md#modulo)
+- [`Animated.multiply()`](animated.md#multiply)
 
 ### Interpolation
 
 The `interpolate()` function allows input ranges to map to different output ranges. By default, it will extrapolate the curve beyond the ranges given, but you can also have it clamp the output value. It uses linear interpolation by default but also supports easing functions.
 
-- [`interpolate()`](../animated/#interpolate)
+- [`interpolate()`](animated.md#interpolation)
 
 Read more about interpolation in the [Animation](https://reactnative.dev/docs/animations#interpolation) guide.
 
@@ -166,7 +166,7 @@ Read more about interpolation in the [Animation](https://reactnative.dev/docs/an
 
 Gestures, like panning or scrolling, and other events can map directly to animated values using `Animated.event()`. This is done with a structured map syntax so that values can be extracted from complex event objects. The first level is an array to allow mapping across multiple args, and that array contains nested objects.
 
-- [`Animated.event()`](../animated/#event)
+- [`Animated.event()`](animated.md#event)
 
 For example, when working with horizontal scrolling gestures, you would do the following in order to map `event.nativeEvent.contentOffset.x` to `scrollX` (an `Animated.Value`):
 
@@ -213,7 +213,7 @@ Config is an object that may have the following options:
 static timing(value, config)
 ```
 
-Animates a value along a timed easing curve. The [`Easing`](../easing/) module has tons of predefined curves, or you can use your own function.
+Animates a value along a timed easing curve. The [`Easing`](easing.md) module has tons of predefined curves, or you can use your own function.
 
 Config is an object that may have the following options:
 
@@ -472,7 +472,7 @@ Stops any running animation and resets the value to its original.
 
 Standard value class for driving animations. Typically initialized with `new Animated.Value(0);`
 
-You can read more about `Animated.Value` API on the separate [page](../animatedvalue/).
+You can read more about `Animated.Value` API on the separate [page](animatedvalue.md).
 
 ---
 
@@ -480,7 +480,7 @@ You can read more about `Animated.Value` API on the separate [page](../animatedv
 
 2D value class for driving 2D animations, such as pan gestures.
 
-You can read more about `Animated.ValueXY` API on the separate [page](../animatedvaluexy/).
+You can read more about `Animated.ValueXY` API on the separate [page](animatedvaluexy.md).
 
 ---
 

--- a/docs/pages/versions/unversioned/react-native/animatedvaluexy.md
+++ b/docs/pages/versions/unversioned/react-native/animatedvaluexy.md
@@ -3,7 +3,7 @@ id: animatedvaluexy
 title: Animated.ValueXY
 ---
 
-2D Value for driving 2D animations, such as pan gestures. Almost identical API to normal [`Animated.Value`](../animatedvalue/), but multiplexed. Contains two regular `Animated.Value`s under the hood.
+2D Value for driving 2D animations, such as pan gestures. Almost identical API to normal [`Animated.Value`](animatedvalue.md), but multiplexed. Contains two regular `Animated.Value`s under the hood.
 
 ## Example
 

--- a/docs/pages/versions/unversioned/react-native/appearance.md
+++ b/docs/pages/versions/unversioned/react-native/appearance.md
@@ -28,7 +28,7 @@ if (colorScheme === 'dark') {
 }
 ```
 
-Although the color scheme is available immediately, this may change (e.g. scheduled color scheme change at sunrise or sunset). Any rendering logic or styles that depend on the user preferred color scheme should try to call this function on every render, rather than caching the value. For example, you may use the [`useColorScheme`](../usecolorscheme/) React hook as it provides and subscribes to color scheme updates, or you may use inline styles rather than setting a value in a `StyleSheet`.
+Although the color scheme is available immediately, this may change (e.g. scheduled color scheme change at sunrise or sunset). Any rendering logic or styles that depend on the user preferred color scheme should try to call this function on every render, rather than caching the value. For example, you may use the [`useColorScheme`](usecolorscheme.md) React hook as it provides and subscribes to color scheme updates, or you may use inline styles rather than setting a value in a `StyleSheet`.
 
 # Reference
 

--- a/docs/pages/versions/unversioned/react-native/backhandler.md
+++ b/docs/pages/versions/unversioned/react-native/backhandler.md
@@ -10,7 +10,7 @@ The event subscriptions are called in reverse order (i.e. the last registered su
 - **If one subscription returns true,** then subscriptions registered earlier will not be called.
 - **If no subscription returns true or none are registered,** it programmatically invokes the default back button functionality to exit the app.
 
-> **Warning for modal users:** If your app shows an opened `Modal`, `BackHandler` will not publish any events ([see `Modal` docs](../modal/#onrequestclose)).
+> **Warning for modal users:** If your app shows an opened `Modal`, `BackHandler` will not publish any events ([see `Modal` docs](modal.md#onrequestclose)).
 
 ## Pattern
 

--- a/docs/pages/versions/unversioned/react-native/button.md
+++ b/docs/pages/versions/unversioned/react-native/button.md
@@ -5,7 +5,7 @@ title: Button
 
 A basic button component that should render nicely on any platform. Supports a minimal level of customization.
 
-If this button doesn't look right for your app, you can build your own button using [TouchableOpacity](../touchableopacity/) or [TouchableWithoutFeedback](../touchablewithoutfeedback/). For inspiration, look at the [source code for this button component](https://github.com/facebook/react-native/blob/master/Libraries/Components/Button.js). Or, take a look at the [wide variety of button components built by the community](https://js.coach/?menu%5Bcollections%5D=React%20Native&page=1&query=button).
+If this button doesn't look right for your app, you can build your own button using [TouchableOpacity](touchableopacity.md) or [TouchableWithoutFeedback](touchablewithoutfeedback.md). For inspiration, look at the [source code for this button component](https://github.com/facebook/react-native/blob/master/Libraries/Components/Button.js). Or, take a look at the [wide variety of button components built by the community](https://js.coach/?menu%5Bcollections%5D=React%20Native&page=1&query=button).
 
 ```js
 <Button

--- a/docs/pages/versions/unversioned/react-native/dimensions.md
+++ b/docs/pages/versions/unversioned/react-native/dimensions.md
@@ -3,7 +3,7 @@ id: dimensions
 title: Dimensions
 ---
 
-> [`useWindowDimensions`](../usewindowdimensions/) is the preferred API for React components. Unlike `Dimensions`, it updates as the window's dimensions update. This works nicely with the React paradigm.
+> [`useWindowDimensions`](usewindowdimensions.md) is the preferred API for React components. Unlike `Dimensions`, it updates as the window's dimensions update. This works nicely with the React paradigm.
 
 ```js
 import { Dimensions } from 'react-native';

--- a/docs/pages/versions/unversioned/react-native/easing.md
+++ b/docs/pages/versions/unversioned/react-native/easing.md
@@ -3,7 +3,7 @@ id: easing
 title: Easing
 ---
 
-The `Easing` module implements common easing functions. This module is used by [Animated.timing()](../animated/#timing) to convey physically believable motion in animations.
+The `Easing` module implements common easing functions. This module is used by [Animated.timing()](animated.md#timing) to convey physically believable motion in animations.
 
 You can find a visualization of some common easing functions at http://easings.net/
 
@@ -11,35 +11,35 @@ You can find a visualization of some common easing functions at http://easings.n
 
 The `Easing` module provides several predefined animations through the following methods:
 
-- [`back`](../easing/#back) provides a basic animation where the object goes slightly back before moving forward
-- [`bounce`](../easing/#bounce) provides a bouncing animation
-- [`ease`](../easing/#ease) provides a basic inertial animation
-- [`elastic`](../easing/#elastic) provides a basic spring interaction
+- [`back`](easing.md#back) provides a basic animation where the object goes slightly back before moving forward
+- [`bounce`](easing.md#bounce) provides a bouncing animation
+- [`ease`](easing.md#ease) provides a basic inertial animation
+- [`elastic`](easing.md#elastic) provides a basic spring interaction
 
 ### Standard functions
 
 Three standard easing functions are provided:
 
-- [`linear`](../easing/#linear)
-- [`quad`](../easing/#quad)
-- [`cubic`](../easing/#cubic)
+- [`linear`](easing.md#linear)
+- [`quad`](easing.md#quad)
+- [`cubic`](easing.md#cubic)
 
-The [`poly`](../easing/#poly) function can be used to implement quartic, quintic, and other higher power functions.
+The [`poly`](easing.md#poly) function can be used to implement quartic, quintic, and other higher power functions.
 
 ### Additional functions
 
 Additional mathematical functions are provided by the following methods:
 
-- [`bezier`](../easing/#bezier) provides a cubic bezier curve
-- [`circle`](../easing/#circle) provides a circular function
-- [`sin`](../easing/#sin) provides a sinusoidal function
-- [`exp`](../easing/#exp) provides an exponential function
+- [`bezier`](easing.md#bezier) provides a cubic bezier curve
+- [`circle`](easing.md#circle) provides a circular function
+- [`sin`](easing.md#sin) provides a sinusoidal function
+- [`exp`](easing.md#exp) provides an exponential function
 
 The following helpers are used to modify other easing functions.
 
-- [`in`](../easing/#in) runs an easing function forwards
-- [`inOut`](../easing/#inout) makes any easing function symmetrical
-- [`out`](../easing/#out) runs an easing function backwards
+- [`in`](easing.md#in) runs an easing function forwards
+- [`inOut`](easing.md#inout) makes any easing function symmetrical
+- [`out`](easing.md#out) runs an easing function backwards
 
 ## Example
 

--- a/docs/pages/versions/unversioned/react-native/flatlist.md
+++ b/docs/pages/versions/unversioned/react-native/flatlist.md
@@ -16,7 +16,7 @@ A performant interface for rendering basic, flat lists, supporting the most hand
 - ScrollToIndex support.
 - Multiple column support.
 
-If you need section support, use [`<SectionList>`](../sectionlist/).
+If you need section support, use [`<SectionList>`](sectionlist.md).
 
 ## Example
 
@@ -72,7 +72,7 @@ const styles = StyleSheet.create({
 });
 ```
 
-To render multiple columns, use the [`numColumns`](../flatlist/#numcolumns) prop. Using this approach instead of a `flexWrap` layout can prevent conflicts with the item height logic.
+To render multiple columns, use the [`numColumns`](flatlist.md#numcolumns) prop. Using this approach instead of a `flexWrap` layout can prevent conflicts with the item height logic.
 
 More complex, multi-select example demonstrating `` usage for perf optimization and avoiding bugs.
 
@@ -148,7 +148,7 @@ const styles = StyleSheet.create({
 });
 ```
 
-This is a convenience wrapper around [`<VirtualizedList>`](../virtualizedlist/), and thus inherits its props (as well as those of [`<ScrollView>`](../scrollview/)) that aren't explicitly listed here, along with the following caveats:
+This is a convenience wrapper around [`<VirtualizedList>`](virtualizedlist.md), and thus inherits its props (as well as those of [`<ScrollView>`](scrollview.md)) that aren't explicitly listed here, along with the following caveats:
 
 - Internal state is not preserved when content scrolls out of the render window. Make sure all your data is captured in the item data or external stores like Flux, Redux, or Relay.
 - This is a `PureComponent` which means that it will not re-render if `props` remain shallow-equal. Make sure that everything your `renderItem` function depends on is passed as a prop (e.g. `extraData`) that is not `===` after updates, otherwise your UI may not update on changes. This includes the `data` prop and parent component state.
@@ -161,7 +161,7 @@ This is a convenience wrapper around [`<VirtualizedList>`](../virtualizedlist/),
 
 ## Props
 
-Inherits [ScrollView Props](../scrollview/#props), unless it is nested in another FlatList of same orientation.
+Inherits [ScrollView Props](scrollview.md#props), unless it is nested in another FlatList of same orientation.
 
 ### `renderItem`
 
@@ -213,7 +213,7 @@ Example usage:
 
 ### `data`
 
-For simplicity, data is a plain array. If you want to use something else, like an immutable list, use the underlying [`VirtualizedList`](../virtualizedlist/) directly.
+For simplicity, data is a plain array. If you want to use something else, like an immutable list, use the underlying [`VirtualizedList`](virtualizedlist.md) directly.
 
 | Type  | Required |
 | ----- | -------- |

--- a/docs/pages/versions/unversioned/react-native/image.md
+++ b/docs/pages/versions/unversioned/react-native/image.md
@@ -114,13 +114,13 @@ dependencies {
 | ----- | -------- |
 | style | No       |
 
-- [Image Style Props...](../image-style-props/#props)
+- [Image Style Props...](image-style-props.md#props)
 
-- [Layout Props...](../layout-props/#props)
+- [Layout Props...](layout-props.md#props)
 
-- [Shadow Props...](../shadow-props/#props)
+- [Shadow Props...](shadow-props.md#props)
 
-- [Transforms...](../transforms/#props)
+- [Transforms...](transforms.md#transform)
 
 ---
 

--- a/docs/pages/versions/unversioned/react-native/imagebackground.md
+++ b/docs/pages/versions/unversioned/react-native/imagebackground.md
@@ -51,19 +51,19 @@ const styles = StyleSheet.create({
 
 ## Props
 
-Inherits [Image Props](../image/#props).
+Inherits [Image Props](image.md#props).
 
 ### `style`
 
 | Type                                | Required |
 | ----------------------------------- | -------- |
-| [view styles](../view-style-props/) | No       |
+| [view styles](view-style-props.md) | No       |
 
 ### `imageStyle`
 
 | Type                                  | Required |
 | ------------------------------------- | -------- |
-| [image styles](../image-style-props/) | No       |
+| [image styles](image-style-props.md) | No       |
 
 ### `imageRef`
 

--- a/docs/pages/versions/unversioned/react-native/inputaccessoryview.md
+++ b/docs/pages/versions/unversioned/react-native/inputaccessoryview.md
@@ -67,7 +67,7 @@ An ID which is used to associate this `InputAccessoryView` to specified TextInpu
 
 | Type                          | Required |
 | ----------------------------- | -------- |
-| [style](../view-style-props/) | No       |
+| [style](view-style-props.md) | No       |
 
 # Known issues
 

--- a/docs/pages/versions/unversioned/react-native/keyboardavoidingview.md
+++ b/docs/pages/versions/unversioned/react-native/keyboardavoidingview.md
@@ -71,7 +71,7 @@ const styles = StyleSheet.create({
 
 ## Props
 
-Inherits [View Props](../view/#props).
+Inherits [View Props](view.md#props).
 
 ### `behavior`
 

--- a/docs/pages/versions/unversioned/react-native/layout-props.md
+++ b/docs/pages/versions/unversioned/react-native/layout-props.md
@@ -367,7 +367,7 @@ When `flex` is -1, the component is normally sized according to `width` and `hei
 
 ### `flexShrink`
 
-[`flexShrink`](../layout-props/#flexshrink) describes how to shrink children along the main axis in the case in which the total size of the children overflows the size of the container on the main axis. `flexShrink` is very similar to `flexGrow` and can be thought of in the same way if any overflowing size is considered to be negative remaining space. These two properties also work well together by allowing children to grow and shrink as needed.
+[`flexShrink`](layout-props.md#flexshrink) describes how to shrink children along the main axis in the case in which the total size of the children overflows the size of the container on the main axis. `flexShrink` is very similar to `flexGrow` and can be thought of in the same way if any overflowing size is considered to be negative remaining space. These two properties also work well together by allowing children to grow and shrink as needed.
 
 `flexShrink` accepts any floating point value >= 0, with 1 being the default value. A container will shrink its children weighted by the children’s `flexShrink` values.
 

--- a/docs/pages/versions/unversioned/react-native/layoutanimation.md
+++ b/docs/pages/versions/unversioned/react-native/layoutanimation.md
@@ -92,7 +92,7 @@ Schedules an animation to happen on the next layout.
 | config            | object   | Yes      | See config description below.                              |
 | onAnimationDidEnd | function | No       | Called when the animation finished. Only supported on iOS. |
 
-The `config` parameter is an object with the keys below. [`create`](../layoutanimation/#create) returns a valid object for `config`, and the [`Presets`](../layoutanimation/#presets) objects can also all be passed as the `config`.
+The `config` parameter is an object with the keys below. [`create`](layoutanimation.md#create) returns a valid object for `config`, and the [`Presets`](layoutanimation.md#presets) objects can also all be passed as the `config`.
 
 - `duration` in milliseconds
 - `create`, optional config for animating in new views
@@ -101,8 +101,8 @@ The `config` parameter is an object with the keys below. [`create`](../layoutani
 
 The config that's passed to `create`, `update`, or `delete` has the following keys:
 
-- `type`, the [animation type](../layoutanimation/#types) to use
-- `property`, the [layout property](../layoutanimation/#properties) to animate (optional, but recommended for `create` and `delete`)
+- `type`, the [animation type](layoutanimation.md#types) to use
+- `property`, the [layout property](layoutanimation.md#properties) to animate (optional, but recommended for `create` and `delete`)
 - `springDamping` (number, optional and only for use with `type: Type.spring`)
 - `initialVelocity` (number, optional)
 - `delay` (number, optional)
@@ -116,7 +116,7 @@ The config that's passed to `create`, `update`, or `delete` has the following ke
 static create(duration, type, creationProp)
 ```
 
-Helper that creates an object (with `create`, `update`, and `delete` fields) to pass into [`configureNext`](../layoutanimation/#configurenext). The `type` parameter is an [animation type](../layoutanimation/#types), and the `creationProp` parameter is a [layout property](../layoutanimation/#properties).
+Helper that creates an object (with `create`, `update`, and `delete` fields) to pass into [`configureNext`](layoutanimation.md#configurenext). The `type` parameter is an [animation type](layoutanimation.md#types), and the `creationProp` parameter is a [layout property](layoutanimation.md#properties).
 
 Example usage:
 
@@ -176,7 +176,7 @@ const styles = StyleSheet.create({
 
 ### Types
 
-An enumeration of animation types to be used in the [`create`](../layoutanimation/#create) method, or in the `create`/`update`/`delete` configs for [`configureNext`](../layoutanimation/#configurenext). (example usage: `LayoutAnimation.Types.easeIn`)
+An enumeration of animation types to be used in the [`create`](layoutanimation.md#create) method, or in the `create`/`update`/`delete` configs for [`configureNext`](layoutanimation.md#configurenext). (example usage: `LayoutAnimation.Types.easeIn`)
 
 | Types         |
 | ------------- |
@@ -191,7 +191,7 @@ An enumeration of animation types to be used in the [`create`](../layoutanimatio
 
 ### Properties
 
-An enumeration of layout properties to be animated to be used in the [`create`](../layoutanimation/#create) method, or in the `create`/`update`/`delete` configs for [`configureNext`](../layoutanimation/#configurenext). (example usage: `LayoutAnimation.Properties.opacity`)
+An enumeration of layout properties to be animated to be used in the [`create`](layoutanimation.md#create) method, or in the `create`/`update`/`delete` configs for [`configureNext`](layoutanimation.md#configurenext). (example usage: `LayoutAnimation.Properties.opacity`)
 
 | Properties |
 | ---------- |
@@ -204,7 +204,7 @@ An enumeration of layout properties to be animated to be used in the [`create`](
 
 ### Presets
 
-A set of predefined animation configs to pass into [`configureNext`](../layoutanimation/#configurenext).
+A set of predefined animation configs to pass into [`configureNext`](layoutanimation.md#configurenext).
 
 | Presets       | Value                                                                                                                                                                 |
 | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/pages/versions/unversioned/react-native/modal.md
+++ b/docs/pages/versions/unversioned/react-native/modal.md
@@ -96,7 +96,7 @@ const styles = StyleSheet.create({
 
 ### `animated`
 
-> **Deprecated.** Use the [`animationType`](../modal/#animationtype) prop instead.
+> **Deprecated.** Use the [`animationType`](modal.md#animationtype) prop instead.
 
 ---
 

--- a/docs/pages/versions/unversioned/react-native/panresponder.md
+++ b/docs/pages/versions/unversioned/react-native/panresponder.md
@@ -152,7 +152,7 @@ static create(config)
 | ------ | ------ | -------- | ----------- |
 | config | object | Yes      | Refer below |
 
-The config object provides enhanced versions of all of the responder callbacks that provide not only the [`PressEvent`](../pressevent/), but also the `PanResponder` gesture state, by replacing the word `Responder` with `PanResponder` in each of the typical `onResponder*` callbacks. For example, the `config` object would look like:
+The config object provides enhanced versions of all of the responder callbacks that provide not only the [`PressEvent`](pressevent.md), but also the `PanResponder` gesture state, by replacing the word `Responder` with `PanResponder` in each of the typical `onResponder*` callbacks. For example, the `config` object would look like:
 
 - `onMoveShouldSetPanResponder: (e, gestureState) => {...}`
 - `onMoveShouldSetPanResponderCapture: (e, gestureState) => {...}`

--- a/docs/pages/versions/unversioned/react-native/pressable.md
+++ b/docs/pages/versions/unversioned/react-native/pressable.md
@@ -191,7 +191,7 @@ Either view styles or a function that receives a boolean reflecting whether the 
 
 | Type                                  | Required |
 | ------------------------------------- | -------- |
-| [ViewStyleProp](../view-style-props/) | No       |
+| [ViewStyleProp](view-style-props.md) | No       |
 
 ### `testOnly_pressed`
 

--- a/docs/pages/versions/unversioned/react-native/pressevent.md
+++ b/docs/pages/versions/unversioned/react-native/pressevent.md
@@ -1,0 +1,118 @@
+---
+id: pressevent
+title: PressEvent
+---
+
+`PressEvent` object is returned in the callback as a result of user press interaction, for example `onPress` in [Button](button.md) component.
+
+## Example
+
+```js
+{
+    changedTouches: [PressEvent],
+    identifier: 1,
+    locationX: 8,
+    locationY: 4.5,
+    pageX: 24,
+    pageY: 49.5,
+    target: 1127,
+    timestamp: 85131876.58868201,
+    touches: []
+}
+```
+
+## Keys and values
+
+### `changedTouches`
+
+Array of all PressEvents that have changed since the last event.
+
+| Type                 | Optional |
+| -------------------- | -------- |
+| array of PressEvents | No       |
+
+### `force` **(iOS)**
+
+Amount of force used during the 3D Touch press. Returns the float value in range from `0.0` to `1.0`.
+
+| Type   | Optional |
+| ------ | -------- |
+| number | Yes      |
+
+### `identifier`
+
+Unique numeric identifier assigned to the event.
+
+| Type   | Optional |
+| ------ | -------- |
+| number | No       |
+
+### `locationX`
+
+Touch origin X coordinate inside touchable area (relative to the element).
+
+| Type   | Optional |
+| ------ | -------- |
+| number | No       |
+
+### `locationY`
+
+Touch origin Y coordinate inside touchable area (relative to the element).
+
+| Type   | Optional |
+| ------ | -------- |
+| number | No       |
+
+### `pageX`
+
+Touch origin X coordinate on the screen (relative to the root view).
+
+| Type   | Optional |
+| ------ | -------- |
+| number | No       |
+
+### `pageY`
+
+Touch origin Y coordinate on the screen (relative to the root view).
+
+| Type   | Optional |
+| ------ | -------- |
+| number | No       |
+
+### `target`
+
+The node id of the element receiving the PressEvent.
+
+| Type                        | Optional |
+| --------------------------- | -------- |
+| number, `null`, `undefined` | No       |
+
+### `timestamp`
+
+Timestamp value when a PressEvent occured. Value is represented in miliseconds.
+
+| Type   | Optional |
+| ------ | -------- |
+| number | No       |
+
+### `touches`
+
+Array of all current PressEvents on the screen.
+
+| Type                 | Optional |
+| -------------------- | -------- |
+| array of PressEvents | No       |
+
+## Used by
+
+- [`Button`](button.md)
+- [`PanResponder`](panresponder.md)
+- [`Pressable`](pressable.md)
+- [`ScrollView`](scrollview.md)
+- [`Text`](text.md)
+- [`TextInput`](textinput.md)
+- [`TouchableHighlight`](touchablenativefeedback.md)
+- [`TouchableOpacity`](touchablewithoutfeedback.md)
+- [`TouchableNativeFeedback`](touchablenativefeedback.md)
+- [`TouchableWithoutFeedback`](touchablewithoutfeedback.md)
+- [`View`](view.md)

--- a/docs/pages/versions/unversioned/react-native/refreshcontrol.md
+++ b/docs/pages/versions/unversioned/react-native/refreshcontrol.md
@@ -60,7 +60,7 @@ const styles = StyleSheet.create({
 
 ## Props
 
-Inherits [View Props](../view/#props).
+Inherits [View Props](view.md#props).
 
 ### `refreshing`
 

--- a/docs/pages/versions/unversioned/react-native/safeareaview.md
+++ b/docs/pages/versions/unversioned/react-native/safeareaview.md
@@ -36,7 +36,7 @@ const styles = StyleSheet.create({
 
 ## Props
 
-Inherits [View Props](../view/#props).
+Inherits [View Props](view.md#props).
 
 As padding is used to implement the behavior of the component, padding rules in styles applied to a `SafeAreaView` will be ignored and can cause different results depending on the platform. See [#22211](https://github.com/facebook/react-native/issues/22211) for details.
 

--- a/docs/pages/versions/unversioned/react-native/scrollview.md
+++ b/docs/pages/versions/unversioned/react-native/scrollview.md
@@ -9,7 +9,7 @@ Keep in mind that ScrollViews must have a bounded height in order to work, since
 
 Doesn't yet support other contained responders from blocking this scroll view from becoming the responder.
 
-`<ScrollView>` vs [`<FlatList>`](../flatlist/) - which one to use?
+`<ScrollView>` vs [`<FlatList>`](flatlist.md) - which one to use?
 
 `ScrollView` renders all its react child components at once, but this has a performance downside.
 
@@ -64,7 +64,7 @@ const styles = StyleSheet.create({
 
 ## Props
 
-Inherits [View Props](../view/#props).
+Inherits [View Props](view.md#props).
 
 ### `alwaysBounceHorizontal`
 
@@ -504,7 +504,7 @@ When true, ScrollView allows use of pinch gestures to zoom in and out. The defau
 
 A RefreshControl component, used to provide pull-to-refresh functionality for the ScrollView. Only works for vertical ScrollViews (`horizontal` prop must be `false`).
 
-See [RefreshControl](../refreshcontrol/).
+See [RefreshControl](refreshcontrol.md).
 
 | Type    | Required |
 | ------- | -------- |

--- a/docs/pages/versions/unversioned/react-native/sectionlist.md
+++ b/docs/pages/versions/unversioned/react-native/sectionlist.md
@@ -16,7 +16,7 @@ A performant interface for rendering sectioned lists, supporting the most handy 
 - Pull to Refresh.
 - Scroll loading.
 
-If you don't need section support and want a simpler interface, use [`<FlatList>`](../flatlist/).
+If you don't need section support and want a simpler interface, use [`<FlatList>`](flatlist.md).
 
 ## Example
 
@@ -84,7 +84,7 @@ const styles = StyleSheet.create({
 });
 ```
 
-This is a convenience wrapper around [`<VirtualizedList>`](../virtualizedlist/), and thus inherits its props (as well as those of [`<ScrollView>`](../scrollview/) that aren't explicitly listed here, along with the following caveats:
+This is a convenience wrapper around [`<VirtualizedList>`](virtualizedlist.md), and thus inherits its props (as well as those of [`<ScrollView>`](scrollview.md) that aren't explicitly listed here, along with the following caveats:
 
 - Internal state is not preserved when content scrolls out of the render window. Make sure all your data is captured in the item data or external stores like Flux, Redux, or Relay.
 - This is a `PureComponent` which means that it will not re-render if `props` remain shallow-equal. Make sure that everything your `renderItem` function depends on is passed as a prop (e.g. `extraData`) that is not `===` after updates, otherwise your UI may not update on changes. This includes the `data` prop and parent component state.
@@ -97,7 +97,7 @@ This is a convenience wrapper around [`<VirtualizedList>`](../virtualizedlist/),
 
 ## Props
 
-Inherits [ScrollView Props](../scrollview/#props).
+Inherits [ScrollView Props](scrollview.md#props).
 
 ### `renderItem`
 
@@ -123,11 +123,11 @@ The render function will be passed an object with the following keys:
 
 ### `sections`
 
-The actual data to render, akin to the `data` prop in [`FlatList`](../flatlist/).
+The actual data to render, akin to the `data` prop in [`FlatList`](flatlist.md).
 
 | Type                                         | Required |
 | -------------------------------------------- | -------- |
-| array of [Section](../sectionlist/#section)s | Yes      |
+| array of [Section](sectionlist.md#section)s | Yes      |
 
 ---
 
@@ -390,8 +390,8 @@ An object that identifies the data to be rendered for a given section.
 
 | Name                     | Type                         | Description                                                                                                                                                             |
 | ------------------------ | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| data                     | array                        | The data for rendering items in this section. Array of objects, much like [`FlatList`'s data prop](../flatlist/#data).                                                  |
+| data                     | array                        | The data for rendering items in this section. Array of objects, much like [`FlatList`'s data prop](flatlist.md#data).                                                  |
 | [key]                    | string                       | Optional key to keep track of section re-ordering. If you don't plan on re-ordering sections, the array index will be used by default.                                  |
-| [renderItem]             | function                     | Optionally define an arbitrary item renderer for this section, overriding the default [`renderItem`](../sectionlist/#renderitem) for the list.                          |
-| [ItemSeparatorComponent] | component, function, element | Optionally define an arbitrary item separator for this section, overriding the default [`ItemSeparatorComponent`](../sectionlist/#itemseparatorcomponent) for the list. |
-| [keyExtractor]           | function                     | Optionally define an arbitrary key extractor for this section, overriding the default [`keyExtractor`](../sectionlist/#keyextractor).                                   |
+| [renderItem]             | function                     | Optionally define an arbitrary item renderer for this section, overriding the default [`renderItem`](sectionlist.md#renderitem) for the list.                          |
+| [ItemSeparatorComponent] | component, function, element | Optionally define an arbitrary item separator for this section, overriding the default [`ItemSeparatorComponent`](sectionlist.md#itemseparatorcomponent) for the list. |
+| [keyExtractor]           | function                     | Optionally define an arbitrary key extractor for this section, overriding the default [`keyExtractor`](sectionlist.md#keyextractor).                                   |

--- a/docs/pages/versions/unversioned/react-native/shadow-props.md
+++ b/docs/pages/versions/unversioned/react-native/shadow-props.md
@@ -99,7 +99,7 @@ export default App;
 
 # Reference
 
-These properties are iOS only - for similar functionality on Android, use the [`elevation` property](../view-style-props/#elevation).
+These properties are iOS only - for similar functionality on Android, use the [`elevation` property](view-style-props.md#elevation).
 
 ## Props
 

--- a/docs/pages/versions/unversioned/react-native/switch.md
+++ b/docs/pages/versions/unversioned/react-native/switch.md
@@ -45,7 +45,7 @@ const styles = StyleSheet.create({
 
 ## Props
 
-Inherits [View Props](../view/#props).
+Inherits [View Props](view.md#props).
 
 ### `disabled`
 
@@ -101,7 +101,7 @@ Color of the foreground switch grip. If this is set on iOS, the switch grip will
 
 Custom colors for the switch track.
 
-_iOS_: When the switch value is false, the track shrinks into the border. If you want to change the color of the background exposed by the shrunken track, use [`ios_backgroundColor`](../switch/#ios_backgroundColor).
+_iOS_: When the switch value is false, the track shrinks into the border. If you want to change the color of the background exposed by the shrunken track, use [`ios_backgroundColor`](switch.md#ios_backgroundColor).
 
 | Type                                                                                                              | Required |
 | ----------------------------------------------------------------------------------------------------------------- | -------- |

--- a/docs/pages/versions/unversioned/react-native/text.md
+++ b/docs/pages/versions/unversioned/react-native/text.md
@@ -547,7 +547,7 @@ The highlight color of the text.
 | ----- | -------- |
 | style | No       |
 
-- [View Style Props...](../view-style-props/#style)
+- [View Style Props...](view-style-props.md#props)
 
 - **`textShadowOffset`**: object: {width: number,height: number}
 

--- a/docs/pages/versions/unversioned/react-native/textinput.md
+++ b/docs/pages/versions/unversioned/react-native/textinput.md
@@ -75,7 +75,7 @@ Note that on Android performing text selection in input can change app's activit
 
 ## Props
 
-Inherits [View Props](../view/#props).
+Inherits [View Props](view.md#props).
 
 ### `allowFontScaling`
 
@@ -303,7 +303,7 @@ Padding between the inline image, if any, and the text input itself.
 
 ### `inputAccessoryViewID`
 
-An optional identifier which links a custom [InputAccessoryView](../inputaccessoryview/) to this text input. The InputAccessoryView is rendered above the keyboard when this text input is focused.
+An optional identifier which links a custom [InputAccessoryView](inputaccessoryview.md) to this text input. The InputAccessoryView is rendered above the keyboard when this text input is focused.
 
 | Type   | Required | Platform |
 | ------ | -------- | -------- |
@@ -767,7 +767,7 @@ see [Issue#7070](https://github.com/facebook/react-native/issues/7070) for more 
 
 | Type                   | Required |
 | ---------------------- | -------- |
-| [Text](../text/#style) | No       |
+| [Text](text.md#style) | No       |
 
 ---
 

--- a/docs/pages/versions/unversioned/react-native/touchablehighlight.md
+++ b/docs/pages/versions/unversioned/react-native/touchablehighlight.md
@@ -3,7 +3,7 @@ id: touchablehighlight
 title: TouchableHighlight
 ---
 
-> If you're looking for a more extensive and future-proof way to handle touch-based input, check out the [Pressable](../pressable/) API.
+> If you're looking for a more extensive and future-proof way to handle touch-based input, check out the [Pressable](pressable.md) API.
 
 A wrapper for making views respond properly to touches. On press down, the opacity of the wrapped view is decreased, which allows the underlay color to show through, darkening or tinting the view.
 
@@ -78,7 +78,7 @@ export default TouchableHighlightExample;
 
 ## Props
 
-Inherits [TouchableWithoutFeedback Props](../touchablewithoutfeedback/#props).
+Inherits [TouchableWithoutFeedback Props](touchablewithoutfeedback.md#props).
 
 ### `activeOpacity`
 

--- a/docs/pages/versions/unversioned/react-native/touchablenativefeedback.md
+++ b/docs/pages/versions/unversioned/react-native/touchablenativefeedback.md
@@ -3,7 +3,7 @@ id: touchablenativefeedback
 title: TouchableNativeFeedback
 ---
 
-> If you're looking for a more extensive and future-proof way to handle touch-based input, check out the [Pressable](../pressable/) API.
+> If you're looking for a more extensive and future-proof way to handle touch-based input, check out the [Pressable](pressable.md) API.
 
 A wrapper for making views respond properly to touches (Android only). On Android this component uses native state drawable to display touch feedback.
 
@@ -64,7 +64,7 @@ export default App;
 
 ## Props
 
-Inherits [TouchableWithoutFeedback Props](../touchablewithoutfeedback/#props).
+Inherits [TouchableWithoutFeedback Props](touchablewithoutfeedback.md#props).
 
 ### `background`
 

--- a/docs/pages/versions/unversioned/react-native/touchableopacity.md
+++ b/docs/pages/versions/unversioned/react-native/touchableopacity.md
@@ -3,7 +3,7 @@ id: touchableopacity
 title: TouchableOpacity
 ---
 
-> If you're looking for a more extensive and future-proof way to handle touch-based input, check out the [Pressable](../pressable/) API.
+> If you're looking for a more extensive and future-proof way to handle touch-based input, check out the [Pressable](pressable.md) API.
 
 A wrapper for making views respond properly to touches. On press down, the opacity of the wrapped view is decreased, dimming it.
 
@@ -57,7 +57,7 @@ export default App;
 
 ## Props
 
-Inherits [TouchableWithoutFeedback Props](../touchablewithoutfeedback/#props).
+Inherits [TouchableWithoutFeedback Props](touchablewithoutfeedback.md#props).
 
 ### `style`
 

--- a/docs/pages/versions/unversioned/react-native/touchablewithoutfeedback.md
+++ b/docs/pages/versions/unversioned/react-native/touchablewithoutfeedback.md
@@ -3,7 +3,7 @@ id: touchablewithoutfeedback
 title: TouchableWithoutFeedback
 ---
 
-> If you're looking for a more extensive and future-proof way to handle touch-based input, check out the [Pressable](../pressable/) API.
+> If you're looking for a more extensive and future-proof way to handle touch-based input, check out the [Pressable](pressable.md) API.
 
 Do not use unless you have a very good reason. All elements that respond to press should have a visual feedback when touched.
 

--- a/docs/pages/versions/unversioned/react-native/transforms.md
+++ b/docs/pages/versions/unversioned/react-native/transforms.md
@@ -190,4 +190,4 @@ transform([{ skewX: '45deg' }]);
 
 ### `decomposedMatrix`, `rotation`, `scaleX`, `scaleY`, `transformMatrix`, `translateX`, `translateY`
 
-> **Deprecated.** Use the [`transform`](../transforms/#transform) prop instead.
+> **Deprecated.** Use the [`transform`](transforms.md#transform) prop instead.

--- a/docs/pages/versions/unversioned/react-native/usecolorscheme.md
+++ b/docs/pages/versions/unversioned/react-native/usecolorscheme.md
@@ -7,7 +7,7 @@ title: useColorScheme
 import { useColorScheme } from 'react-native';
 ```
 
-The `useColorScheme` React hook provides and subscribes to color scheme updates from the [`Appearance`](../../sdk/appearance/) module. The return value indicates the current user preferred color scheme. The value may be updated later, either through direct user action (e.g. theme selection in device settings) or on a schedule (e.g. light and dark themes that follow the day/night cycle).
+The `useColorScheme` React hook provides and subscribes to color scheme updates from the [`Appearance`](../sdk/appearance.md) module. The return value indicates the current user preferred color scheme. The value may be updated later, either through direct user action (e.g. theme selection in device settings) or on a schedule (e.g. light and dark themes that follow the day/night cycle).
 
 Supported color schemes:
 

--- a/docs/pages/versions/unversioned/react-native/view.md
+++ b/docs/pages/versions/unversioned/react-native/view.md
@@ -472,7 +472,7 @@ This is a reserved performance property exposed by `RCTView` and is useful for s
 
 | Type                                | Required |
 | ----------------------------------- | -------- |
-| [view styles](../view-style-props/) | No       |
+| [view styles](view-style-props.md) | No       |
 
 ---
 

--- a/docs/pages/versions/unversioned/react-native/virtualizedlist.md
+++ b/docs/pages/versions/unversioned/react-native/virtualizedlist.md
@@ -3,7 +3,7 @@ id: virtualizedlist
 title: VirtualizedList
 ---
 
-Base implementation for the more convenient [`<FlatList>`](../flatlist/) and [`<SectionList>`](../sectionlist/) components, which are also better documented. In general, this should only really be used if you need more flexibility than [`FlatList`](../flatlist/) provides, e.g. for use with immutable data instead of plain arrays.
+Base implementation for the more convenient [`<FlatList>`](flatlist.md) and [`<SectionList>`](sectionlist.md) components, which are also better documented. In general, this should only really be used if you need more flexibility than [`FlatList`](flatlist.md) provides, e.g. for use with immutable data instead of plain arrays.
 
 Virtualization massively improves memory consumption and performance of large lists by maintaining a finite render window of active items and replacing all items outside of the render window with appropriately sized blank space. The window adapts to scrolling behavior, and items are rendered incrementally with low-pri (after any running interactions) if they are far from the visible area, or with hi-pri otherwise to minimize the potential of seeing blank space.
 
@@ -88,7 +88,7 @@ Some caveats:
 
 ## Props
 
-Inherits [ScrollView Props](../scrollview/#props).
+Inherits [ScrollView Props](scrollview.md#props).
 
 ### `renderItem`
 
@@ -199,7 +199,7 @@ Reverses the direction of scroll. Uses scale transforms of -1.
 
 ### `CellRendererComponent`
 
-Each cell is rendered using this element. Can be a React Component Class,or a render function. Defaults to using [`View`](../view/).
+Each cell is rendered using this element. Can be a React Component Class,or a render function. Defaults to using [`View`](view.md).
 
 | Type                | Required |
 | ------------------- | -------- |

--- a/docs/pages/versions/v36.0.0/react-native/accessibility.md
+++ b/docs/pages/versions/v36.0.0/react-native/accessibility.md
@@ -253,7 +253,7 @@ To handle action requests, a component must implement an `onAccessibilityAction`
 
 ## Checking if a Screen Reader is Enabled
 
-The `AccessibilityInfo` API allows you to determine whether or not a screen reader is currently active. See the [AccessibilityInfo documentation](../accessibilityinfo/) for details.
+The `AccessibilityInfo` API allows you to determine whether or not a screen reader is currently active. See the [AccessibilityInfo documentation](accessibilityinfo.md) for details.
 
 ## Sending Accessibility Events (Android)
 

--- a/docs/pages/versions/v36.0.0/react-native/actionsheetios.md
+++ b/docs/pages/versions/v36.0.0/react-native/actionsheetios.md
@@ -23,7 +23,7 @@ Display an iOS action sheet. The `options` object must contain one or more of:
 - `title` (string) - a title to show above the action sheet
 - `message` (string) - a message to show below the title
 - `anchor` (number) - the node to which the action sheet should be anchored (used for iPad)
-- `tintColor` (string) - the [color](../colors/) used for non-destructive button titles
+- `tintColor` (string) - the [color](colors.md) used for non-destructive button titles
 
 The 'callback' function takes one parameter, the zero-based index of the selected item.
 

--- a/docs/pages/versions/v36.0.0/react-native/activityindicator.md
+++ b/docs/pages/versions/v36.0.0/react-native/activityindicator.md
@@ -43,7 +43,7 @@ const styles = StyleSheet.create({
 
 ## Props
 
-Inherits [View Props](../view/#props).
+Inherits [View Props](view.md#props).
 
 ### `animating`
 
@@ -61,7 +61,7 @@ The foreground color of the spinner (default is gray on iOS and dark cyan on And
 
 | Type                | Required |
 | ------------------- | -------- |
-| [color](../colors/) | No       |
+| [color](colors.md) | No       |
 
 ---
 

--- a/docs/pages/versions/v36.0.0/react-native/alertios.md
+++ b/docs/pages/versions/v36.0.0/react-native/alertios.md
@@ -3,7 +3,7 @@ id: alertios
 title: AlertIOS
 ---
 
-> **Deprecated.** `AlertIOS` has been moved to [`Alert`](../alert/)
+> **Deprecated.** `AlertIOS` has been moved to [`Alert`](alert.md)
 
 `AlertIOS` provides functionality to create an iOS alert dialog with a message or create a prompt for user input.
 
@@ -19,7 +19,7 @@ Creating an iOS prompt:
 AlertIOS.prompt('Enter a value', null, text => console.log('You entered ' + text));
 ```
 
-We recommend using the [`Alert.alert`](../alert/) method for cross-platform support if you don't need to create iOS-only prompts.
+We recommend using the [`Alert.alert`](alert.md) method for cross-platform support if you don't need to create iOS-only prompts.
 
 ---
 
@@ -43,8 +43,8 @@ Create and display a popup alert.
 | ----------------- | -------------------------------------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | title             | string                                                   | Yes      | The dialog's title. Passing null or '' will hide the title.                                                                                                                                                                                                                                                                                                      |
 | message           | string                                                   | No       | An optional message that appears below the dialog's title.                                                                                                                                                                                                                                                                                                       |
-| callbackOrButtons | ?(() =\> void),[ButtonsArray](../alertios/#buttonsarray) | No       | This optional argument should be either a single-argument function or an array of buttons. If passed a function, it will be called when the user taps 'OK'. If passed an array of button configurations, each button should include a `text` key, as well as optional `onPress` and `style` keys. `style` should be one of 'default', 'cancel' or 'destructive'. |
-| type              | [AlertType](../alertios/#alerttype)                      | No       | Deprecated, do not use.                                                                                                                                                                                                                                                                                                                                          |
+| callbackOrButtons | ?(() =\> void),[ButtonsArray](alertios.md#buttonsarray) | No       | This optional argument should be either a single-argument function or an array of buttons. If passed a function, it will be called when the user taps 'OK'. If passed an array of button configurations, each button should include a `text` key, as well as optional `onPress` and `style` keys. `style` should be one of 'default', 'cancel' or 'destructive'. |
+| type              | [AlertType](alertios.md#alerttype)                      | No       | Deprecated, do not use.                                                                                                                                                                                                                                                                                                                                          |
 
 Example with custom buttons:
 
@@ -80,8 +80,8 @@ Create and display a prompt to enter some text.
 | ----------------- | -------------------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | title             | string                                                               | Yes      | The dialog's title.                                                                                                                                                                                                                                                                                                                                                                                    |
 | message           | string                                                               | No       | An optional message that appears above the text input.                                                                                                                                                                                                                                                                                                                                                 |
-| callbackOrButtons | ?((text: string) =\> void),[ButtonsArray](../alertios/#buttonsarray) | No       | This optional argument should be either a single-argument function or an array of buttons. If passed a function, it will be called with the prompt's value when the user taps 'OK'. If passed an array of button configurations, each button should include a `text` key, as well as optional `onPress` and `style` keys (see example). `style` should be one of 'default', 'cancel' or 'destructive'. |
-| type              | [AlertType](../alertios/#alerttype)                                  | No       | This configures the text input. One of 'plain-text', 'secure-text' or 'login-password'.                                                                                                                                                                                                                                                                                                                |
+| callbackOrButtons | ?((text: string) =\> void),[ButtonsArray](alertios.md#buttonsarray) | No       | This optional argument should be either a single-argument function or an array of buttons. If passed a function, it will be called with the prompt's value when the user taps 'OK'. If passed an array of button configurations, each button should include a `text` key, as well as optional `onPress` and `style` keys (see example). `style` should be one of 'default', 'cancel' or 'destructive'. |
+| type              | [AlertType](alertios.md#alerttype)                                  | No       | This configures the text input. One of 'plain-text', 'secure-text' or 'login-password'.                                                                                                                                                                                                                                                                                                                |
 | defaultValue      | string                                                               | No       | The default text in text input.                                                                                                                                                                                                                                                                                                                                                                        |
 | keyboardType      | string                                                               | No       | The keyboard type of first text field(if exists). One of 'default', 'email-address', 'numeric', 'phone-pad', 'ascii-capable', 'numbers-and-punctuation', 'url', 'number-pad', 'name-phone-pad', 'decimal-pad', 'twitter' or 'web-search'.                                                                                                                                                              |
 
@@ -173,7 +173,7 @@ Array or buttons
 | --------- | ------------------------------------------------- | ------------------------------------- |
 | [text]    | string                                            | Button label                          |
 | [onPress] | function                                          | Callback function when button pressed |
-| [style]   | [AlertButtonStyle](../alertios/#alertbuttonstyle) | Button style                          |
+| [style]   | [AlertButtonStyle](alertios.md#alertbuttonstyle) | Button style                          |
 
 **Constants:**
 

--- a/docs/pages/versions/v36.0.0/react-native/animated.md
+++ b/docs/pages/versions/v36.0.0/react-native/animated.md
@@ -17,14 +17,14 @@ Animated.timing(
 ).start(); // Start the animation
 ```
 
-Refer to the [Animations](../animations/#animated-api) guide to see additional examples of `Animated` in action.
+Refer to the [Animations](animations.md#animated-api) guide to see additional examples of `Animated` in action.
 
 ## Overview
 
 There are two value types you can use with `Animated`:
 
-- [`Animated.Value()`](../animated/#value) for single values
-- [`Animated.ValueXY()`](../animated/#valuexy) for vectors
+- [`Animated.Value()`](animated.md#value) for single values
+- [`Animated.ValueXY()`](animated.md#valuexy) for vectors
 
 `Animated.Value` can bind to style properties or other props, and can be interpolated as well. A single `Animated.Value` can drive any number of properties.
 
@@ -32,9 +32,9 @@ There are two value types you can use with `Animated`:
 
 `Animated` provides three types of animation types. Each animation type provides a particular animation curve that controls how your values animate from their initial value to the final value:
 
-- [`Animated.decay()`](../animated/#decay) starts with an initial velocity and gradually slows to a stop.
-- [`Animated.spring()`](../animated/#spring) provides a basic spring physics model.
-- [`Animated.timing()`](../animated/#timing) animates a value over time using [easing functions](../easing/).
+- [`Animated.decay()`](animated.md#decay) starts with an initial velocity and gradually slows to a stop.
+- [`Animated.spring()`](animated.md#spring) provides a basic spring physics model.
+- [`Animated.timing()`](animated.md#timing) animates a value over time using [easing functions](easing.md).
 
 In most cases, you will be using `timing()`. By default, it uses a symmetric easeInOut curve that conveys the gradual acceleration of an object to full speed and concludes by gradually decelerating to a stop.
 
@@ -46,13 +46,13 @@ Animations are started by calling `start()` on your animation. `start()` takes a
 
 By using the native driver, we send everything about the animation to native before starting the animation, allowing native code to perform the animation on the UI thread without having to go through the bridge on every frame. Once the animation has started, the JS thread can be blocked without affecting the animation.
 
-You can use the native driver by specifying `useNativeDriver: true` in your animation configuration. See the [Animations](../animations/#using-the-native-driver) guide to learn more.
+You can use the native driver by specifying `useNativeDriver: true` in your animation configuration. See the [Animations](animations.md#using-the-native-driver) guide to learn more.
 
 ### Animatable components
 
 Only animatable components can be animated. These unique components do the magic of binding the animated values to the properties, and do targeted native updates to avoid the cost of the react render and reconciliation process on every frame. They also handle cleanup on unmount so they are safe by default.
 
-- [`createAnimatedComponent()`](../animated/#createanimatedcomponent) can be used to make a component animatable.
+- [`createAnimatedComponent()`](animated.md#createanimatedcomponent) can be used to make a component animatable.
 
 `Animated` exports the following animatable components using the above wrapper:
 
@@ -67,12 +67,12 @@ Only animatable components can be animated. These unique components do the magic
 
 Animations can also be combined in complex ways using composition functions:
 
-- [`Animated.delay()`](../animated/#delay) starts an animation after a given delay.
-- [`Animated.parallel()`](../animated/#parallel) starts a number of animations at the same time.
-- [`Animated.sequence()`](../animated/#sequence) starts the animations in order, waiting for each to complete before starting the next.
-- [`Animated.stagger()`](../animated/#stagger) starts animations in order and in parallel, but with successive delays.
+- [`Animated.delay()`](animated.md#delay) starts an animation after a given delay.
+- [`Animated.parallel()`](animated.md#parallel) starts a number of animations at the same time.
+- [`Animated.sequence()`](animated.md#sequence) starts the animations in order, waiting for each to complete before starting the next.
+- [`Animated.stagger()`](animated.md#stagger) starts animations in order and in parallel, but with successive delays.
 
-Animations can also be chained together by setting the `toValue` of one animation to be another `Animated.Value`. See [Tracking dynamic values](../animations/#tracking-dynamic-values) in the Animations guide.
+Animations can also be chained together by setting the `toValue` of one animation to be another `Animated.Value`. See [Tracking dynamic values](animations.md#tracking-dynamic-values) in the Animations guide.
 
 By default, if one animation is stopped or interrupted, then all other animations in the group are also stopped.
 
@@ -80,25 +80,25 @@ By default, if one animation is stopped or interrupted, then all other animation
 
 You can combine two animated values via addition, subtraction, multiplication, division, or modulo to make a new animated value:
 
-- [`Animated.add()`](../animated/#add)
-- [`Animated.subtract()`](../animated/#subtract)
-- [`Animated.divide()`](../animated/#divide)
-- [`Animated.modulo()`](../animated/#modulo)
-- [`Animated.multiply()`](../animated/#multiply)
+- [`Animated.add()`](animated.md#add)
+- [`Animated.subtract()`](animated.md#subtract)
+- [`Animated.divide()`](animated.md#divide)
+- [`Animated.modulo()`](animated.md#modulo)
+- [`Animated.multiply()`](animated.md#multiply)
 
 ### Interpolation
 
 The `interpolate()` function allows input ranges to map to different output ranges. By default, it will extrapolate the curve beyond the ranges given, but you can also have it clamp the output value. It uses linear interpolation by default but also supports easing functions.
 
-- [`interpolate()`](../animated/#interpolate)
+- [`interpolate()`](animated.md#interpolation)
 
-Read more about interpolation in the [Animation](../animations/#interpolation) guide.
+Read more about interpolation in the [Animation](animations.md#interpolation) guide.
 
 ### Handling gestures and other events
 
 Gestures, like panning or scrolling, and other events can map directly to animated values using `Animated.event()`. This is done with a structured map syntax so that values can be extracted from complex event objects. The first level is an array to allow mapping across multiple args, and that array contains nested objects.
 
-- [`Animated.event()`](../animated/#event)
+- [`Animated.event()`](animated.md#event)
 
 For example, when working with horizontal scrolling gestures, you would do the following in order to map `event.nativeEvent.contentOffset.x` to `scrollX` (an `Animated.Value`):
 
@@ -151,7 +151,7 @@ static timing(value, config)
 
 ```
 
-Animates a value along a timed easing curve. The [`Easing`](../easing/) module has tons of predefined curves, or you can use your own function.
+Animates a value along a timed easing curve. The [`Easing`](easing.md) module has tons of predefined curves, or you can use your own function.
 
 Config is an object that may have the following options:
 

--- a/docs/pages/versions/v36.0.0/react-native/animations.md
+++ b/docs/pages/versions/v36.0.0/react-native/animations.md
@@ -5,11 +5,11 @@ title: Animations
 
 Animations are very important to create a great user experience. Stationary objects must overcome inertia as they start moving. Objects in motion have momentum and rarely come to a stop immediately. Animations allow you to convey physically believable motion in your interface.
 
-React Native provides two complementary animation systems: [`Animated`](../animations/#animated-api) for granular and interactive control of specific values, and [`LayoutAnimation`](../animations/#layoutanimation-api) for animated global layout transactions.
+React Native provides two complementary animation systems: [`Animated`](animations.md#animated-api) for granular and interactive control of specific values, and [`LayoutAnimation`](animations.md#layoutanimation-api) for animated global layout transactions.
 
 ## `Animated` API
 
-The [`Animated`](../animated/) API is designed to concisely express a wide variety of interesting animation and interaction patterns in a very performant way. `Animated` focuses on declarative relationships between inputs and outputs, with configurable transforms in between, and `start`/`stop` methods to control time-based animation execution.
+The [`Animated`](animated.md) API is designed to concisely express a wide variety of interesting animation and interaction patterns in a very performant way. `Animated` focuses on declarative relationships between inputs and outputs, with configurable transforms in between, and `start`/`stop` methods to control time-based animation execution.
 
 `Animated` exports six animatable component types: `View`, `Text`, `Image`, `ScrollView`, `FlatList` and `SectionList`, but you can also create your own using `Animated.createAnimatedComponent()`.
 
@@ -62,7 +62,7 @@ This is done in an optimized way that is faster than calling `setState` and re-r
 
 Animations are heavily configurable. Custom and predefined easing functions, delays, durations, decay factors, spring constants, and more can all be tweaked depending on the type of animation.
 
-`Animated` provides several animation types, the most commonly used one being [`Animated.timing()`](../animated/#timing). It supports animating a value over time using one of various predefined easing functions, or you can use your own. Easing functions are typically used in animation to convey gradual acceleration and deceleration of objects.
+`Animated` provides several animation types, the most commonly used one being [`Animated.timing()`](animated.md#timing). It supports animating a value over time using one of various predefined easing functions, or you can use your own. Easing functions are typically used in animation to convey gradual acceleration and deceleration of objects.
 
 By default, `timing` will use an easeInOut curve that conveys gradual acceleration to full speed and concludes by gradually decelerating to a stop. You can specify a different easing function by passing an `easing` parameter. Custom `duration` or even a `delay` before the animation starts is also supported.
 
@@ -76,7 +76,7 @@ Animated.timing(this.state.xPosition, {
 }).start();
 ```
 
-Take a look at the [Configuring animations](../animated/#configuring-animations) section of the `Animated` API reference to learn more about all the config parameters supported by the built-in animations.
+Take a look at the [Configuring animations](animated.md#configuring-animations) section of the `Animated` API reference to learn more about all the config parameters supported by the built-in animations.
 
 ### Composing animations
 
@@ -107,11 +107,11 @@ Animated.sequence([
 
 If one animation is stopped or interrupted, then all other animations in the group are also stopped. `Animated.parallel` has a `stopTogether` option that can be set to `false` to disable this.
 
-You can find a full list of composition methods in the [Composing animations](../animated/#composing-animations) section of the `Animated` API reference.
+You can find a full list of composition methods in the [Composing animations](animated.md#composing-animations) section of the `Animated` API reference.
 
 ### Combining animated values
 
-You can [combine two animated values](../animated/#combining-animated-values) via addition, multiplication, division, or modulo to make a new animated value.
+You can [combine two animated values](animated.md#combining-animated-values) via addition, multiplication, division, or modulo to make a new animated value.
 
 There are some cases where an animated value needs to invert another animated value for calculation. An example is inverting a scale (2x --> 0.5x):
 
@@ -153,7 +153,7 @@ For example, you may want to think about your `Animated.Value` as going from 0 t
 
 ```
 
-[`interpolate()`](../animated/#interpolate) supports multiple range segments as well, which is handy for defining dead zones and other handy tricks. For example, to get a negation relationship at -300 that goes to 0 at -100, then back up to 1 at 0, and then back down to zero at 100 followed by a dead-zone that remains at 0 for everything beyond that, you could do:
+[`interpolate()`](animated.md#interpolation) supports multiple range segments as well, which is handy for defining dead zones and other handy tricks. For example, to get a negation relationship at -300 that goes to 0 at -100, then back up to 1 at 0, and then back down to zero at 100 followed by a dead-zone that remains at 0 for everything beyond that, you could do:
 
 ```jsx
 value.interpolate({
@@ -190,7 +190,7 @@ value.interpolate({
 });
 ```
 
-`interpolate()` also supports arbitrary easing functions, many of which are already implemented in the [`Easing`](../easing/) module. `interpolate()` also has configurable behavior for extrapolating the `outputRange`. You can set the extrapolation by setting the `extrapolate`, `extrapolateLeft`, or `extrapolateRight` options. The default value is `extend` but you can use `clamp` to prevent the output value from exceeding `outputRange`.
+`interpolate()` also supports arbitrary easing functions, many of which are already implemented in the [`Easing`](easing.md) module. `interpolate()` also has configurable behavior for extrapolating the `outputRange`. You can set the extrapolation by setting the `extrapolate`, `extrapolateLeft`, or `extrapolateRight` options. The default value is `extend` but you can use `clamp` to prevent the output value from exceeding `outputRange`.
 
 ### Tracking dynamic values
 
@@ -210,7 +210,7 @@ The `leader` and `follower` animated values would be implemented using `Animated
 
 ### Tracking gestures
 
-Gestures, like panning or scrolling, and other events can map directly to animated values using [`Animated.event`](../animated/#event). This is done with a structured map syntax so that values can be extracted from complex event objects. The first level is an array to allow mapping across multiple args, and that array contains nested objects.
+Gestures, like panning or scrolling, and other events can map directly to animated values using [`Animated.event`](animated.md#event). This is done with a structured map syntax so that values can be extracted from complex event objects. The first level is an array to allow mapping across multiple args, and that array contains nested objects.
 
 For example, when working with horizontal scrolling gestures, you would do the following in order to map `event.nativeEvent.contentOffset.x` to `scrollX` (an `Animated.Value`):
 
@@ -405,8 +405,8 @@ This example uses a preset value, you can customize the animations as you need, 
 
 ### `setNativeProps`
 
-As mentioned [in the Direct Manipulation section](../direct-manipulation/), `setNativeProps` allows us to modify properties of native-backed components (components that are actually backed by native views, unlike composite components) directly, without having to `setState` and re-render the component hierarchy.
+As mentioned [in the Direct Manipulation section](direct-manipulation.md), `setNativeProps` allows us to modify properties of native-backed components (components that are actually backed by native views, unlike composite components) directly, without having to `setState` and re-render the component hierarchy.
 
 We could use this in the Rebound example to update the scale - this might be helpful if the component that we are updating is deeply nested and hasn't been optimized with `shouldComponentUpdate`.
 
-If you find your animations with dropping frames (performing below 60 frames per second), look into using `setNativeProps` or `shouldComponentUpdate` to optimize them. Or you could run the animations on the UI thread rather than the JavaScript thread [with the useNativeDriver option](http://reactnative.dev/blog/2017/02/14/using-native-driver-for-animated). You may also want to defer any computationally intensive work until after animations are complete, using the [InteractionManager](../interactionmanager/). You can monitor the frame rate by using the In-App Developer Menu "FPS Monitor" tool.
+If you find your animations with dropping frames (performing below 60 frames per second), look into using `setNativeProps` or `shouldComponentUpdate` to optimize them. Or you could run the animations on the UI thread rather than the JavaScript thread [with the useNativeDriver option](http://reactnative.dev/blog/2017/02/14/using-native-driver-for-animated). You may also want to defer any computationally intensive work until after animations are complete, using the [InteractionManager](interactionmanager.md). You can monitor the frame rate by using the In-App Developer Menu "FPS Monitor" tool.

--- a/docs/pages/versions/v36.0.0/react-native/appstate.md
+++ b/docs/pages/versions/v36.0.0/react-native/appstate.md
@@ -62,7 +62,7 @@ This example will only ever appear to say "Current state is: active" because the
 
 ### `change`
 
-This event is received when the app state has changed. The listener is called with one of [the current app state values](../appstate/#app-states).
+This event is received when the app state has changed. The listener is called with one of [the current app state values](appstate.md#app-states).
 
 ### `focus`
 

--- a/docs/pages/versions/v36.0.0/react-native/button.md
+++ b/docs/pages/versions/v36.0.0/react-native/button.md
@@ -5,7 +5,7 @@ title: Button
 
 A basic button component that should render nicely on any platform. Supports a minimal level of customization.
 
-If this button doesn't look right for your app, you can build your own button using [TouchableOpacity](../touchableopacity/) or [TouchableNativeFeedback](../touchablenativefeedback/). For inspiration, look at the [source code for this button component](https://github.com/facebook/react-native/blob/master/Libraries/Components/Button.js). Or, take a look at the [wide variety of button components built by the community](https://js.coach/react-native?search=button).
+If this button doesn't look right for your app, you can build your own button using [TouchableOpacity](touchableopacity.md) or [TouchableNativeFeedback](touchablenativefeedback.md). For inspiration, look at the [source code for this button component](https://github.com/facebook/react-native/blob/master/Libraries/Components/Button.js). Or, take a look at the [wide variety of button components built by the community](https://js.coach/react-native?search=button).
 
 ### Example
 
@@ -124,7 +124,7 @@ Color of the text (iOS), or background color of the button (Android)
 
 | Type                | Required |
 | ------------------- | -------- |
-| [color](../colors/) | No       |
+| [color](colors.md) | No       |
 
 ---
 

--- a/docs/pages/versions/v36.0.0/react-native/colors.md
+++ b/docs/pages/versions/v36.0.0/react-native/colors.md
@@ -3,7 +3,7 @@ id: colors
 title: Color Reference
 ---
 
-Components in React Native are [styled using JavaScript](../style/). Color properties usually match how [CSS works on the web](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value).
+Components in React Native are [styled using JavaScript](style.md). Color properties usually match how [CSS works on the web](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value).
 
 ### Red-green-blue
 

--- a/docs/pages/versions/v36.0.0/react-native/datepickerios.md
+++ b/docs/pages/versions/v36.0.0/react-native/datepickerios.md
@@ -50,7 +50,7 @@ const styles = StyleSheet.create({
 
 ## Props
 
-Inherits [View Props](../view/#props).
+Inherits [View Props](view.md#props).
 
 ### `date`
 
@@ -112,7 +112,7 @@ Restricts the range of possible date/time values.
 | ---- | -------- |
 | Date | No       |
 
-See [`maximumDate`](../datepickerios/#maximumdate) for an example image.
+See [`maximumDate`](datepickerios.md#maximumdate) for an example image.
 
 ---
 

--- a/docs/pages/versions/v36.0.0/react-native/direct-manipulation.md
+++ b/docs/pages/versions/v36.0.0/react-native/direct-manipulation.md
@@ -126,7 +126,7 @@ export default class App extends React.Component {
 
 You can now use `MyButton` inside of `TouchableOpacity`! A sidenote for clarity: we used the [ref callback](https://reactjs.org/docs/refs-and-the-dom.html#adding-a-ref-to-a-dom-element) syntax here, rather than the traditional string-based ref.
 
-You may have noticed that we passed all of the props down to the child view using `{...this.props}`. The reason for this is that `TouchableOpacity` is actually a composite component, and so in addition to depending on `setNativeProps` on its child, it also requires that the child perform touch handling. To do this, it passes on [various props](../view/#onmoveshouldsetresponder) that call back to the `TouchableOpacity` component. `TouchableHighlight`, in contrast, is backed by a native view and only requires that we implement `setNativeProps`.
+You may have noticed that we passed all of the props down to the child view using `{...this.props}`. The reason for this is that `TouchableOpacity` is actually a composite component, and so in addition to depending on `setNativeProps` on its child, it also requires that the child perform touch handling. To do this, it passes on [various props](view.md#onmoveshouldsetresponder) that call back to the `TouchableOpacity` component. `TouchableHighlight`, in contrast, is backed by a native view and only requires that we implement `setNativeProps`.
 
 ## setNativeProps to clear TextInput value
 
@@ -186,7 +186,7 @@ Determines the location on screen, width, and height of the given view and retur
 - pageX
 - pageY
 
-Note that these measurements are not available until after the rendering has been completed in native. If you need the measurements as soon as possible, consider using the [`onLayout` prop](../view/#onlayout) instead.
+Note that these measurements are not available until after the rendering has been completed in native. If you need the measurements as soon as possible, consider using the [`onLayout` prop](view.md#onlayout) instead.
 
 ### measureInWindow(callback)
 

--- a/docs/pages/versions/v36.0.0/react-native/easing.md
+++ b/docs/pages/versions/v36.0.0/react-native/easing.md
@@ -3,7 +3,7 @@ id: easing
 title: Easing
 ---
 
-The `Easing` module implements common easing functions. This module is used by [Animated.timing()](../animated/#timing) to convey physically believable motion in animations.
+The `Easing` module implements common easing functions. This module is used by [Animated.timing()](animated.md#timing) to convey physically believable motion in animations.
 
 You can find a visualization of some common easing functions at http://easings.net/
 
@@ -11,35 +11,35 @@ You can find a visualization of some common easing functions at http://easings.n
 
 The `Easing` module provides several predefined animations through the following methods:
 
-- [`back`](../easing/#back) provides a basic animation where the object goes slightly back before moving forward
-- [`bounce`](../easing/#bounce) provides a bouncing animation
-- [`ease`](../easing/#ease) provides a basic inertial animation
-- [`elastic`](../easing/#elastic) provides a basic spring interaction
+- [`back`](easing.md#back) provides a basic animation where the object goes slightly back before moving forward
+- [`bounce`](easing.md#bounce) provides a bouncing animation
+- [`ease`](easing.md#ease) provides a basic inertial animation
+- [`elastic`](easing.md#elastic) provides a basic spring interaction
 
 ### Standard functions
 
 Three standard easing functions are provided:
 
-- [`linear`](../easing/#linear)
-- [`quad`](../easing/#quad)
-- [`cubic`](../easing/#cubic)
+- [`linear`](easing.md#linear)
+- [`quad`](easing.md#quad)
+- [`cubic`](easing.md#cubic)
 
-The [`poly`](../easing/#poly) function can be used to implement quartic, quintic, and other higher power functions.
+The [`poly`](easing.md#poly) function can be used to implement quartic, quintic, and other higher power functions.
 
 ### Additional functions
 
 Additional mathematical functions are provided by the following methods:
 
-- [`bezier`](../easing/#bezier) provides a cubic bezier curve
-- [`circle`](../easing/#circle) provides a circular function
-- [`sin`](../easing/#sin) provides a sinusoidal function
-- [`exp`](../easing/#exp) provides an exponential function
+- [`bezier`](easing.md#bezier) provides a cubic bezier curve
+- [`circle`](easing.md#circle) provides a circular function
+- [`sin`](easing.md#sin) provides a sinusoidal function
+- [`exp`](easing.md#exp) provides an exponential function
 
 The following helpers are used to modify other easing functions.
 
-- [`in`](../easing/#in) runs an easing function forwards
-- [`inOut`](../easing/#inout) makes any easing function symmetrical
-- [`out`](../easing/#out) runs an easing function backwards
+- [`in`](easing.md#in) runs an easing function forwards
+- [`inOut`](easing.md#inout) makes any easing function symmetrical
+- [`out`](easing.md#out) runs an easing function backwards
 
 ---
 

--- a/docs/pages/versions/v36.0.0/react-native/flatlist.md
+++ b/docs/pages/versions/v36.0.0/react-native/flatlist.md
@@ -16,7 +16,7 @@ A performant interface for rendering basic, flat lists, supporting the most hand
 - ScrollToIndex support.
 - Multiple column support.
 
-If you need section support, use [`<SectionList>`](../sectionlist/).
+If you need section support, use [`<SectionList>`](sectionlist.md).
 
 ### Basic Example:
 
@@ -77,7 +77,7 @@ const styles = StyleSheet.create({
 });
 ```
 
-To render multiple columns, use the [`numColumns`](../flatlist/#numcolumns) prop. Using this approach instead of a `flexWrap` layout can prevent conflicts with the item height logic.
+To render multiple columns, use the [`numColumns`](flatlist.md#numcolumns) prop. Using this approach instead of a `flexWrap` layout can prevent conflicts with the item height logic.
 
 ````
 
@@ -180,7 +180,7 @@ const styles = StyleSheet.create({
 
 ````
 
-This is a convenience wrapper around [`<VirtualizedList>`](../virtualizedlist/), and thus inherits its props (as well as those of [`<ScrollView>`](../scrollview/)) that aren't explicitly listed here, along with the following caveats:
+This is a convenience wrapper around [`<VirtualizedList>`](virtualizedlist.md), and thus inherits its props (as well as those of [`<ScrollView>`](scrollview.md)) that aren't explicitly listed here, along with the following caveats:
 
 - Internal state is not preserved when content scrolls out of the render window. Make sure all your data is captured in the item data or external stores like Flux, Redux, or Relay.
 - This is a `PureComponent` which means that it will not re-render if `props` remain shallow-equal. Make sure that everything your `renderItem` function depends on is passed as a prop (e.g. `extraData`) that is not `===` after updates, otherwise your UI may not update on changes. This includes the `data` prop and parent component state.
@@ -193,7 +193,7 @@ This is a convenience wrapper around [`<VirtualizedList>`](../virtualizedlist/),
 
 ## Props
 
-Inherits [ScrollView Props](../scrollview/#props), unless it is nested in another FlatList of same orientation.
+Inherits [ScrollView Props](scrollview.md#props), unless it is nested in another FlatList of same orientation.
 
 ### `renderItem`
 
@@ -249,7 +249,7 @@ Example usage:
 
 ### `data`
 
-For simplicity, data is a plain array. If you want to use something else, like an immutable list, use the underlying [`VirtualizedList`](../virtualizedlist/) directly.
+For simplicity, data is a plain array. If you want to use something else, like an immutable list, use the underlying [`VirtualizedList`](virtualizedlist.md) directly.
 
 | Type  | Required |
 | ----- | -------- |

--- a/docs/pages/versions/v36.0.0/react-native/flexbox.md
+++ b/docs/pages/versions/v36.0.0/react-native/flexbox.md
@@ -223,8 +223,8 @@ The `position` type of an element defines how it is positioned within its parent
 
 Check out the interactive [yoga playground](https://yogalayout.com/playground) that you can use to get a better understanding of flexbox.
 
-We've covered the basics, but there are many other styles you may need for layouts. The full list of props that control layout is documented [here](../layout-props/).
+We've covered the basics, but there are many other styles you may need for layouts. The full list of props that control layout is documented [here](layout-props.md).
 
-We're getting close to being able to build a real application. One thing we are still missing is a way to take user input, so let's move on to [learn how to handle text input with the TextInput component](../handling-text-input/).
+We're getting close to being able to build a real application. One thing we are still missing is a way to take user input, so let's move on to [learn how to handle text input with the TextInput component](handling-text-input.md).
 
 See some examples from [Wix Engineers](https://medium.com/wix-engineering/the-full-react-native-layout-cheat-sheet-a4147802405c):

--- a/docs/pages/versions/v36.0.0/react-native/gesture-responder-system.md
+++ b/docs/pages/versions/v36.0.0/react-native/gesture-responder-system.md
@@ -63,4 +63,4 @@ However, sometimes a parent will want to make sure that it becomes responder. Th
 
 ### PanResponder
 
-For higher-level gesture interpretation, check out [PanResponder](../panresponder/).
+For higher-level gesture interpretation, check out [PanResponder](panresponder.md).

--- a/docs/pages/versions/v36.0.0/react-native/handling-text-input.md
+++ b/docs/pages/versions/v36.0.0/react-native/handling-text-input.md
@@ -3,7 +3,7 @@ id: handling-text-input
 title: Handling Text Input
 ---
 
-[`TextInput`](../textinput/#content) is a basic component that allows the user to enter text. It has an `onChangeText` prop that takes a function to be called every time the text changed, and an `onSubmitEditing` prop that takes a function to be called when the text is submitted.
+[`TextInput`](textinput.md) is a basic component that allows the user to enter text. It has an `onChangeText` prop that takes a function to be called every time the text changed, and an `onSubmitEditing` prop that takes a function to be called when the text is submitted.
 
 For example, let's say that as the user types, you're translating their words into a different language. In this new language, every single word is written the same way: 🍕. So the sentence "Hello there Bob" would be translated as "🍕🍕🍕".
 
@@ -40,6 +40,6 @@ export default class PizzaTranslator extends Component {
 
 In this example, we store `text` in the state, because it changes over time.
 
-There are a lot more things you might want to do with a text input. For example, you could validate the text inside while the user types. For more detailed examples, see the [React docs on controlled components](https://reactjs.org/docs/forms.html#controlled-components), or the [reference docs for TextInput](../textinput/).
+There are a lot more things you might want to do with a text input. For example, you could validate the text inside while the user types. For more detailed examples, see the [React docs on controlled components](https://reactjs.org/docs/forms.html#controlled-components), or the [reference docs for TextInput](textinput.md).
 
-Text input is one of the ways the user interacts with the app. Next, let's look at another type of input and [learn how to handle touches](../handling-touches/).
+Text input is one of the ways the user interacts with the app. Next, let's look at another type of input and [learn how to handle touches](handling-touches.md).

--- a/docs/pages/versions/v36.0.0/react-native/handling-touches.md
+++ b/docs/pages/versions/v36.0.0/react-native/handling-touches.md
@@ -3,11 +3,11 @@ id: handling-touches
 title: Handling Touches
 ---
 
-Users interact with mobile apps mainly through touch. They can use a combination of gestures, such as tapping on a button, scrolling a list, or zooming on a map. React Native provides components to handle all sorts of common gestures, as well as a comprehensive [gesture responder system](../gesture-responder-system/) to allow for more advanced gesture recognition, but the one component you will most likely be interested in is the basic Button.
+Users interact with mobile apps mainly through touch. They can use a combination of gestures, such as tapping on a button, scrolling a list, or zooming on a map. React Native provides components to handle all sorts of common gestures, as well as a comprehensive [gesture responder system](gesture-responder-system.md) to allow for more advanced gesture recognition, but the one component you will most likely be interested in is the basic Button.
 
 ## Displaying a basic button
 
-[Button](../button/) provides a basic button component that is rendered nicely on all platforms. The minimal example to display a button looks like this:
+[Button](button.md) provides a basic button component that is rendered nicely on all platforms. The minimal example to display a button looks like this:
 
 ```jsx
 <Button
@@ -73,13 +73,13 @@ If the basic button doesn't look right for your app, you can build your own butt
 
 Which "Touchable" component you use will depend on what kind of feedback you want to provide:
 
-- Generally, you can use [**TouchableHighlight**](../touchablehighlight/) anywhere you would use a button or link on web. The view's background will be darkened when the user presses down on the button.
+- Generally, you can use [**TouchableHighlight**](touchablehighlight.md) anywhere you would use a button or link on web. The view's background will be darkened when the user presses down on the button.
 
-- You may consider using [**TouchableNativeFeedback**](../touchablenativefeedback/) on Android to display ink surface reaction ripples that respond to the user's touch.
+- You may consider using [**TouchableNativeFeedback**](touchablenativefeedback.md) on Android to display ink surface reaction ripples that respond to the user's touch.
 
-- [**TouchableOpacity**](../touchableopacity/) can be used to provide feedback by reducing the opacity of the button, allowing the background to be seen through while the user is pressing down.
+- [**TouchableOpacity**](touchableopacity.md) can be used to provide feedback by reducing the opacity of the button, allowing the background to be seen through while the user is pressing down.
 
-- If you need to handle a tap gesture but you don't want any feedback to be displayed, use [**TouchableWithoutFeedback**](../touchablewithoutfeedback/).
+- If you need to handle a tap gesture but you don't want any feedback to be displayed, use [**TouchableWithoutFeedback**](touchablewithoutfeedback.md).
 
 In some cases, you may want to detect when a user presses and holds a view for a set amount of time. These long presses can be handled by passing a function to the `onLongPress` props of any of the "Touchable" components.
 
@@ -170,4 +170,4 @@ const styles = StyleSheet.create({
 
 ## Scrolling lists, swiping pages, and pinch-to-zoom
 
-Another gesture commonly used in mobile apps is the swipe or pan. This gesture allows the user to scroll through a list of items, or swipe through pages of content. In order to handle these and other gestures, we'll learn [how to use a ScrollView](../using-a-scrollview/) next.
+Another gesture commonly used in mobile apps is the swipe or pan. This gesture allows the user to scroll through a list of items, or swipe through pages of content. In order to handle these and other gestures, we'll learn [how to use a ScrollView](using-a-scrollview.md) next.

--- a/docs/pages/versions/v36.0.0/react-native/height-and-width.md
+++ b/docs/pages/versions/v36.0.0/react-native/height-and-width.md
@@ -54,4 +54,4 @@ export default class FlexDimensionsBasics extends Component {
 }
 ```
 
-After you can control a component's size, the next step is to [learn how to lay it out on the screen](../flexbox/).
+After you can control a component's size, the next step is to [learn how to lay it out on the screen](flexbox.md).

--- a/docs/pages/versions/v36.0.0/react-native/image-style-props.md
+++ b/docs/pages/versions/v36.0.0/react-native/image-style-props.md
@@ -43,7 +43,7 @@ title: Image Style Props
 
 | Type                | Required |
 | ------------------- | -------- |
-| [color](../colors/) | No       |
+| [color](colors.md) | No       |
 
 ---
 
@@ -67,7 +67,7 @@ title: Image Style Props
 
 | Type                | Required |
 | ------------------- | -------- |
-| [color](../colors/) | No       |
+| [color](colors.md) | No       |
 
 ---
 
@@ -109,7 +109,7 @@ Changes the color of all the non-transparent pixels to the tintColor.
 
 | Type                | Required |
 | ------------------- | -------- |
-| [color](../colors/) | No       |
+| [color](colors.md) | No       |
 
 ---
 

--- a/docs/pages/versions/v36.0.0/react-native/image.md
+++ b/docs/pages/versions/v36.0.0/react-native/image.md
@@ -105,11 +105,11 @@ dependencies {
 | ----- | -------- |
 | style | No       |
 
-- [Layout Props...](../layout-props/#props)
+- [Layout Props...](layout-props.md#props)
 
-- [Shadow Props...](../shadow-props/#props)
+- [Shadow Props...](shadow-props.md#props)
 
-- [Transforms...](../transforms/#props)
+- [Transforms...](transforms.md#transform)
 
 - **`borderTopRightRadius`**: number
 
@@ -119,13 +119,13 @@ dependencies {
 
 - **`borderBottomRightRadius`**: number
 
-- **`borderColor`**: [color](../colors/)
+- **`borderColor`**: [color](colors.md)
 
 - **`borderRadius`**: number
 
 - **`borderTopLeftRadius`**: number
 
-- **`backgroundColor`**: [color](../colors/)
+- **`backgroundColor`**: [color](colors.md)
 
 - **`borderWidth`**: number
 
@@ -135,7 +135,7 @@ dependencies {
 
 - **`resizeMode`**: Object.keys(ImageResizeMode)
 
-- **`tintColor`**: [color](../colors/)
+- **`tintColor`**: [color](colors.md)
 
   Changes the color of all the non-transparent pixels to the tintColor.
 
@@ -228,7 +228,7 @@ Determines how to resize the image when the frame doesn't match the raw image di
 
 The image source (either a remote URL or a local file resource).
 
-This prop can also contain several remote URLs, specified together with their width and height and potentially with scale/other URI arguments. The native side will then choose the best `uri` to display based on the measured size of the image container. A `cache` property can be added to control how networked request interacts with the local cache. (For more information see [Cache Control for Images](../images/#cache-control-ios-only)).
+This prop can also contain several remote URLs, specified together with their width and height and potentially with scale/other URI arguments. The native side will then choose the best `uri` to display based on the measured size of the image container. A `cache` property can be added to control how networked request interacts with the local cache. (For more information see [Cache Control for Images](images.md#cache-control-ios-only)).
 
 The currently supported formats are `png`, `jpg`, `jpeg`, `bmp`, `gif`, `webp` (Android only), `psd` (iOS only). In addition, iOS supports several RAW image formats. Refer to Apple's documentation for the current list of supported camera models (for iOS 12, see https://support.apple.com/en-ca/HT208967).
 

--- a/docs/pages/versions/v36.0.0/react-native/imagebackground.md
+++ b/docs/pages/versions/v36.0.0/react-native/imagebackground.md
@@ -27,19 +27,19 @@ return (
 
 ## Props
 
-Inherits [Image Props](../image/#props).
+Inherits [Image Props](image.md#props).
 
 ### `style`
 
 | Type                                | Required |
 | ----------------------------------- | -------- |
-| [view styles](../view-style-props/) | No       |
+| [view styles](view-style-props.md) | No       |
 
 ### `imageStyle`
 
 | Type                                  | Required |
 | ------------------------------------- | -------- |
-| [image styles](../image-style-props/) | No       |
+| [image styles](image-style-props.md) | No       |
 
 ### `imageRef`
 

--- a/docs/pages/versions/v36.0.0/react-native/images.md
+++ b/docs/pages/versions/v36.0.0/react-native/images.md
@@ -200,7 +200,7 @@ On the user side, this lets you annotate the object with useful attributes such 
 
 A common feature request from developers familiar with the web is `background-image`. To handle this use case, you can use the `<ImageBackground>` component, which has the same props as `<Image>`, and add whatever children to it you would like to layer on top of it.
 
-You might not want to use `<ImageBackground>` in some cases, since the implementation is basic. Refer to `<ImageBackground>`'s [documentation](../imagebackground/) for more insight, and create your own custom component when needed.
+You might not want to use `<ImageBackground>` in some cases, since the implementation is basic. Refer to `<ImageBackground>`'s [documentation](imagebackground.md) for more insight, and create your own custom component when needed.
 
 ```jsx
 

--- a/docs/pages/versions/v36.0.0/react-native/inputaccessoryview.md
+++ b/docs/pages/versions/v36.0.0/react-native/inputaccessoryview.md
@@ -53,7 +53,7 @@ This component can also be used to create sticky text inputs (text inputs which 
 
 | Type                | Required |
 | ------------------- | -------- |
-| [color](../colors/) | No       |
+| [color](colors.md) | No       |
 
 ---
 
@@ -71,7 +71,7 @@ An ID which is used to associate this `InputAccessoryView` to specified TextInpu
 
 | Type                          | Required |
 | ----------------------------- | -------- |
-| [style](../view-style-props/) | No       |
+| [style](view-style-props.md) | No       |
 
 # Known issues
 

--- a/docs/pages/versions/v36.0.0/react-native/javascript-environment.md
+++ b/docs/pages/versions/v36.0.0/react-native/javascript-environment.md
@@ -66,8 +66,8 @@ Browser
 
 - [console.{log, warn, error, info, trace, table, group, groupEnd}](https://developer.chrome.com/devtools/docs/console-api)
 - [CommonJS require](https://nodejs.org/docs/latest/api/modules.html)
-- [XMLHttpRequest, fetch](../network/#content)
-- [{set, clear}{Timeout, Interval, Immediate}, {request, cancel}AnimationFrame](../timers/#content)
+- [XMLHttpRequest, fetch](network.md)
+- [{set, clear}{Timeout, Interval, Immediate}, {request, cancel}AnimationFrame](timers.md)
 
 ES6
 

--- a/docs/pages/versions/v36.0.0/react-native/keyboardavoidingview.md
+++ b/docs/pages/versions/v36.0.0/react-native/keyboardavoidingview.md
@@ -25,7 +25,7 @@ import { KeyboardAvoidingView } from 'react-native';
 
 ## Props
 
-Inherits [View Props](../view/#props).
+Inherits [View Props](view.md#props).
 
 ### `behavior`
 

--- a/docs/pages/versions/v36.0.0/react-native/layoutanimation.md
+++ b/docs/pages/versions/v36.0.0/react-native/layoutanimation.md
@@ -82,7 +82,7 @@ Schedules an animation to happen on the next layout.
 | config            | object   | Yes      | See config description below.                              |
 | onAnimationDidEnd | function | No       | Called when the animation finished. Only supported on iOS. |
 
-The `config` parameter is an object with the keys below. [`create`](../layoutanimation/#create) returns a valid object for `config`, and the [`Presets`](../layoutanimation/#presets) objects can also all be passed as the `config`.
+The `config` parameter is an object with the keys below. [`create`](layoutanimation.md#create) returns a valid object for `config`, and the [`Presets`](layoutanimation.md#presets) objects can also all be passed as the `config`.
 
 - `duration` in milliseconds
 - `create`, optional config for animating in new views
@@ -91,8 +91,8 @@ The `config` parameter is an object with the keys below. [`create`](../layoutani
 
 The config that's passed to `create`, `update`, or `delete` has the following keys:
 
-- `type`, the [animation type](../layoutanimation/#types) to use
-- `property`, the [layout property](../layoutanimation/#properties) to animate (optional, but recommended for `create` and `delete`)
+- `type`, the [animation type](layoutanimation.md#types) to use
+- `property`, the [layout property](layoutanimation.md#properties) to animate (optional, but recommended for `create` and `delete`)
 - `springDamping` (number, optional and only for use with `type: Type.spring`)
 - `initialVelocity` (number, optional)
 - `delay` (number, optional)
@@ -108,7 +108,7 @@ static create(duration, type, creationProp)
 
 ```
 
-Helper that creates an object (with `create`, `update`, and `delete` fields) to pass into [`configureNext`](../layoutanimation/#configurenext). The `type` parameter is an [animation type](../layoutanimation/#types), and the `creationProp` parameter is a [layout property](../layoutanimation/#properties).
+Helper that creates an object (with `create`, `update`, and `delete` fields) to pass into [`configureNext`](layoutanimation.md#configurenext). The `type` parameter is an [animation type](layoutanimation.md#types), and the `creationProp` parameter is a [layout property](layoutanimation.md#properties).
 
 Example usage:
 
@@ -122,7 +122,7 @@ LayoutAnimation.configureNext(
 
 ### Types
 
-An enumeration of animation types to be used in the [`create`](../layoutanimation/#create) method, or in the `create`/`update`/`delete` configs for [`configureNext`](../layoutanimation/#configurenext). (example usage: `LayoutAnimation.Types.easeIn`)
+An enumeration of animation types to be used in the [`create`](layoutanimation.md#create) method, or in the `create`/`update`/`delete` configs for [`configureNext`](layoutanimation.md#configurenext). (example usage: `LayoutAnimation.Types.easeIn`)
 
 | Types         |
 | ------------- |
@@ -137,7 +137,7 @@ An enumeration of animation types to be used in the [`create`](../layoutanimatio
 
 ### Properties
 
-An enumeration of layout properties to be animated to be used in the [`create`](../layoutanimation/#create) method, or in the `create`/`update`/`delete` configs for [`configureNext`](../layoutanimation/#configurenext). (example usage: `LayoutAnimation.Properties.opacity`)
+An enumeration of layout properties to be animated to be used in the [`create`](layoutanimation.md#create) method, or in the `create`/`update`/`delete` configs for [`configureNext`](layoutanimation.md#configurenext). (example usage: `LayoutAnimation.Properties.opacity`)
 
 | Properties |
 | ---------- |
@@ -150,7 +150,7 @@ An enumeration of layout properties to be animated to be used in the [`create`](
 
 ### Presets
 
-A set of predefined animation configs to pass into [`configureNext`](../layoutanimation/#configurenext).
+A set of predefined animation configs to pass into [`configureNext`](layoutanimation.md#configurenext).
 
 | Presets       | Value                                                                                                                                                                 |
 | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/pages/versions/v36.0.0/react-native/modal.md
+++ b/docs/pages/versions/v36.0.0/react-native/modal.md
@@ -55,7 +55,7 @@ export default function App() {
 
 ### `animated`
 
-> **Deprecated.** Use the [`animationType`](../modal/#animationtype) prop instead.
+> **Deprecated.** Use the [`animationType`](modal.md#animationtype) prop instead.
 
 ---
 

--- a/docs/pages/versions/v36.0.0/react-native/panresponder.md
+++ b/docs/pages/versions/v36.0.0/react-native/panresponder.md
@@ -7,7 +7,7 @@ title: PanResponder
 
 By default, `PanResponder` holds an `InteractionManager` handle to block long-running JS events from interrupting active gestures.
 
-It provides a predictable wrapper of the responder handlers provided by the [gesture responder system](../gesture-responder-system/). For each handler, it provides a new `gestureState` object alongside the native event object:
+It provides a predictable wrapper of the responder handlers provided by the [gesture responder system](gesture-responder-system.md). For each handler, it provides a new `gestureState` object alongside the native event object:
 
 ```javascript
 onPanResponderMove: (event, gestureState) => {};

--- a/docs/pages/versions/v36.0.0/react-native/picker.md
+++ b/docs/pages/versions/v36.0.0/react-native/picker.md
@@ -21,7 +21,7 @@ Renders the native picker component on Android and iOS. Example:
 
 ## Props
 
-Inherits [View Props](../view/#props).
+Inherits [View Props](view.md#props).
 
 ### `onValueChange`
 
@@ -103,4 +103,4 @@ Style to apply to each of the item labels.
 
 | Type                                | Required | Platform |
 | ----------------------------------- | -------- | -------- |
-| [text styles](../text-style-props/) | No       | iOS      |
+| [text styles](text-style-props.md) | No       | iOS      |

--- a/docs/pages/versions/v36.0.0/react-native/pickerios.md
+++ b/docs/pages/versions/v36.0.0/react-native/pickerios.md
@@ -3,7 +3,7 @@ id: pickerios
 title: PickerIOS
 ---
 
-> **Deprecated.** Use [Picker](../picker/) instead.
+> **Deprecated.** Use [Picker](picker.md) instead.
 
 ---
 
@@ -11,13 +11,13 @@ title: PickerIOS
 
 ## Props
 
-Inherits [View Props](../view/#props).
+Inherits [View Props](view.md#props).
 
 ### `itemStyle`
 
 | Type                                | Required |
 | ----------------------------------- | -------- |
-| [text styles](../text-style-props/) | No       |
+| [text styles](text-style-props.md) | No       |
 
 ---
 

--- a/docs/pages/versions/v36.0.0/react-native/platform-specific-code.md
+++ b/docs/pages/versions/v36.0.0/react-native/platform-specific-code.md
@@ -7,8 +7,8 @@ When building a cross-platform app, you'll want to re-use as much code as possib
 
 React Native provides two ways to organize your code and separate it by platform:
 
-- Using the [`Platform` module](../platform-specific-code/#platform-module).
-- Using [platform-specific file extensions](../platform-specific-code/#platform-specific-extensions).
+- Using the [`Platform` module](platform-specific-code.md#platform-module).
+- Using [platform-specific file extensions](platform-specific-code.md#platform-specific-extensions).
 
 Certain components may have properties that work on one platform only. All of these props are annotated with `@platform` and have a small badge next to them on the website.
 

--- a/docs/pages/versions/v36.0.0/react-native/progressbarandroid.md
+++ b/docs/pages/versions/v36.0.0/react-native/progressbarandroid.md
@@ -39,7 +39,7 @@ const styles = StyleSheet.create({
 
 ## Props
 
-Inherits [View Props](../view/#props).
+Inherits [View Props](view.md#props).
 
 ### `animating`
 
@@ -57,7 +57,7 @@ Color of the progress bar.
 
 | Type                | Required |
 | ------------------- | -------- |
-| [color](../colors/) | No       |
+| [color](colors.md) | No       |
 
 ---
 

--- a/docs/pages/versions/v36.0.0/react-native/progressviewios.md
+++ b/docs/pages/versions/v36.0.0/react-native/progressviewios.md
@@ -11,7 +11,7 @@ Uses `ProgressViewIOS` to render a UIProgressView on iOS.
 
 ## Props
 
-Inherits [View Props](../view/#props).
+Inherits [View Props](view.md#props).
 
 ### `progress`
 

--- a/docs/pages/versions/v36.0.0/react-native/props.md
+++ b/docs/pages/versions/v36.0.0/react-native/props.md
@@ -54,6 +54,6 @@ export default class LotsOfGreetings extends Component {
 
 Using `name` as a prop lets us customize the `Greeting` component, so we can reuse that component for each of our greetings. This example also uses the `Greeting` component in JSX, similar to the built-in components. The power to do this is what makes React so cool - if you find yourself wishing that you had a different set of UI primitives to work with, you can invent new ones.
 
-The other new thing going on here is the [`View`](../view/) component. A [`View`](../view/) is useful as a container for other components, to help control style and layout.
+The other new thing going on here is the [`View`](view.md) component. A [`View`](view.md) is useful as a container for other components, to help control style and layout.
 
-With `props` and the basic [`Text`](../text/), [`Image`](../image/), and [`View`](../view/) components, you can build a wide variety of static screens. To learn how to make your app change over time, you need to [learn about State](../state/).
+With `props` and the basic [`Text`](text.md), [`Image`](image.md), and [`View`](view.md) components, you can build a wide variety of static screens. To learn how to make your app change over time, you need to [learn about State](state.md).

--- a/docs/pages/versions/v36.0.0/react-native/refreshcontrol.md
+++ b/docs/pages/versions/v36.0.0/react-native/refreshcontrol.md
@@ -60,7 +60,7 @@ const styles = StyleSheet.create({
 
 ## Props
 
-Inherits [View Props](../view/#props).
+Inherits [View Props](view.md#props).
 
 ### `refreshing`
 
@@ -88,7 +88,7 @@ The colors (at least one) that will be used to draw the refresh indicator.
 
 | Type                         | Required | Platform |
 | ---------------------------- | -------- | -------- |
-| array of [color](../colors/) | No       | Android  |
+| array of [color](colors.md) | No       | Android  |
 
 ---
 
@@ -108,7 +108,7 @@ The background color of the refresh indicator.
 
 | Type                | Required | Platform |
 | ------------------- | -------- | -------- |
-| [color](../colors/) | No       | Android  |
+| [color](colors.md) | No       | Android  |
 
 ---
 
@@ -138,7 +138,7 @@ The color of the refresh indicator.
 
 | Type                | Required | Platform |
 | ------------------- | -------- | -------- |
-| [color](../colors/) | No       | iOS      |
+| [color](colors.md) | No       | iOS      |
 
 ---
 
@@ -158,4 +158,4 @@ Title color.
 
 | Type                | Required | Platform |
 | ------------------- | -------- | -------- |
-| [color](../colors/) | No       | iOS      |
+| [color](colors.md) | No       | iOS      |

--- a/docs/pages/versions/v36.0.0/react-native/safeareaview.md
+++ b/docs/pages/versions/v36.0.0/react-native/safeareaview.md
@@ -36,7 +36,7 @@ const styles = StyleSheet.create({
 
 ## Props
 
-Inherits [View Props](../view/#props).
+Inherits [View Props](view.md#props).
 
 ### `emulateUnlessSupported`
 

--- a/docs/pages/versions/v36.0.0/react-native/scrollview.md
+++ b/docs/pages/versions/v36.0.0/react-native/scrollview.md
@@ -9,7 +9,7 @@ Keep in mind that ScrollViews must have a bounded height in order to work, since
 
 Doesn't yet support other contained responders from blocking this scroll view from becoming the responder.
 
-`<ScrollView>` vs [`<FlatList>`](../flatlist/) - which one to use?
+`<ScrollView>` vs [`<FlatList>`](flatlist.md) - which one to use?
 
 `ScrollView` renders all its react child components at once, but this has a performance downside.
 
@@ -64,7 +64,7 @@ const styles = StyleSheet.create({
 
 ## Props
 
-Inherits [View Props](../view/#props).
+Inherits [View Props](view.md#props).
 
 ### `alwaysBounceHorizontal`
 
@@ -240,7 +240,7 @@ Sometimes a scrollview takes up more space than its content fills. When this is 
 
 | Type                | Required | Platform |
 | ------------------- | -------- | -------- |
-| [color](../colors/) | No       | Android  |
+| [color](colors.md) | No       | Android  |
 
 ---
 
@@ -483,7 +483,7 @@ When true, ScrollView allows use of pinch gestures to zoom in and out. The defau
 
 A RefreshControl component, used to provide pull-to-refresh functionality for the ScrollView. Only works for vertical ScrollViews (`horizontal` prop must be `false`).
 
-See [RefreshControl](../refreshcontrol/).
+See [RefreshControl](refreshcontrol.md).
 
 | Type    | Required |
 | ------- | -------- |

--- a/docs/pages/versions/v36.0.0/react-native/sectionlist.md
+++ b/docs/pages/versions/v36.0.0/react-native/sectionlist.md
@@ -16,7 +16,7 @@ A performant interface for rendering sectioned lists, supporting the most handy 
 - Pull to Refresh.
 - Scroll loading.
 
-If you don't need section support and want a simpler interface, use [`<FlatList>`](../flatlist/).
+If you don't need section support and want a simpler interface, use [`<FlatList>`](flatlist.md).
 
 ### Example
 
@@ -86,7 +86,7 @@ const styles = StyleSheet.create({
 });
 ```
 
-This is a convenience wrapper around [`<VirtualizedList>`](../virtualizedlist/), and thus inherits its props (as well as those of [`<ScrollView>`](../scrollview/) that aren't explicitly listed here, along with the following caveats:
+This is a convenience wrapper around [`<VirtualizedList>`](virtualizedlist.md), and thus inherits its props (as well as those of [`<ScrollView>`](scrollview.md) that aren't explicitly listed here, along with the following caveats:
 
 - Internal state is not preserved when content scrolls out of the render window. Make sure all your data is captured in the item data or external stores like Flux, Redux, or Relay.
 - This is a `PureComponent` which means that it will not re-render if `props` remain shallow-equal. Make sure that everything your `renderItem` function depends on is passed as a prop (e.g. `extraData`) that is not `===` after updates, otherwise your UI may not update on changes. This includes the `data` prop and parent component state.
@@ -95,44 +95,44 @@ This is a convenience wrapper around [`<VirtualizedList>`](../virtualizedlist/),
 
 ### Props
 
-- [`ScrollView` props...](../scrollview/#props)
+- [`ScrollView` props...](scrollview.md#props)
 
 Required props:
 
-- [`renderItem`](../sectionlist/#renderitem)
-- [`sections`](../sectionlist/#sections)
+- [`renderItem`](sectionlist.md#renderitem)
+- [`sections`](sectionlist.md#sections)
 
 Optional props:
 
-- [`extraData`](../sectionlist/#extradata)
-- [`initialNumToRender`](../sectionlist/#initialnumtorender)
-- [`inverted`](../sectionlist/#inverted)
-- [`ItemSeparatorComponent`](../sectionlist/#itemseparatorcomponent)
-- [`keyExtractor`](../sectionlist/#keyextractor)
-- [`legacyImplementation`](../sectionlist/#legacyimplementation)
-- [`ListEmptyComponent`](../sectionlist/#listemptycomponent)
-- [`ListFooterComponent`](../sectionlist/#listfootercomponent)
-- [`ListHeaderComponent`](../sectionlist/#listheadercomponent)
-- [`onEndReached`](../sectionlist/#onendreached)
-- [`onEndReachedThreshold`](../sectionlist/#onendreachedthreshold)
-- [`onRefresh`](../sectionlist/#onrefresh)
-- [`onViewableItemsChanged`](../sectionlist/#onviewableitemschanged)
-- [`refreshing`](../sectionlist/#refreshing)
-- [`removeClippedSubviews`](../sectionlist/#removeclippedsubviews)
-- [`renderSectionFooter`](../sectionlist/#rendersectionfooter)
-- [`renderSectionHeader`](../sectionlist/#rendersectionheader)
-- [`SectionSeparatorComponent`](../sectionlist/#sectionseparatorcomponent)
-- [`stickySectionHeadersEnabled`](../sectionlist/#stickysectionheadersenabled)
+- [`extraData`](sectionlist.md#extradata)
+- [`initialNumToRender`](sectionlist.md#initialnumtorender)
+- [`inverted`](sectionlist.md#inverted)
+- [`ItemSeparatorComponent`](sectionlist.md#itemseparatorcomponent)
+- [`keyExtractor`](sectionlist.md#keyextractor)
+- [`legacyImplementation`](sectionlist.md#legacyimplementation)
+- [`ListEmptyComponent`](sectionlist.md#listemptycomponent)
+- [`ListFooterComponent`](sectionlist.md#listfootercomponent)
+- [`ListHeaderComponent`](sectionlist.md#listheadercomponent)
+- [`onEndReached`](sectionlist.md#onendreached)
+- [`onEndReachedThreshold`](sectionlist.md#onendreachedthreshold)
+- [`onRefresh`](sectionlist.md#onrefresh)
+- [`onViewableItemsChanged`](sectionlist.md#onviewableitemschanged)
+- [`refreshing`](sectionlist.md#refreshing)
+- [`removeClippedSubviews`](sectionlist.md#removeclippedsubviews)
+- [`renderSectionFooter`](sectionlist.md#rendersectionfooter)
+- [`renderSectionHeader`](sectionlist.md#rendersectionheader)
+- [`SectionSeparatorComponent`](sectionlist.md#sectionseparatorcomponent)
+- [`stickySectionHeadersEnabled`](sectionlist.md#stickysectionheadersenabled)
 
 ### Methods
 
-- [`flashScrollIndicators`](../sectionlist/#flashscrollindicators)
-- [`recordInteraction`](../sectionlist/#recordinteraction)
-- [`scrollToLocation`](../sectionlist/#scrolltolocation)
+- [`flashScrollIndicators`](sectionlist.md#flashscrollindicators)
+- [`recordInteraction`](sectionlist.md#recordinteraction)
+- [`scrollToLocation`](sectionlist.md#scrolltolocation)
 
 ### Type Definitions
 
-- [`Section`](../sectionlist/#section)
+- [`Section`](sectionlist.md#section)
 
 ---
 
@@ -164,11 +164,11 @@ The render function will be passed an object with the following keys:
 
 ### `sections`
 
-The actual data to render, akin to the `data` prop in [`FlatList`](../flatlist/).
+The actual data to render, akin to the `data` prop in [`FlatList`](flatlist.md).
 
 | Type                                         | Required |
 | -------------------------------------------- | -------- |
-| array of [Section](../sectionlist/#section)s | Yes      |
+| array of [Section](sectionlist.md#section)s | Yes      |
 
 ---
 
@@ -441,8 +441,8 @@ An object that identifies the data to be rendered for a given section.
 
 | Name                     | Type                         | Description                                                                                                                                                             |
 | ------------------------ | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| data                     | array                        | The data for rendering items in this section. Array of objects, much like [`FlatList`'s data prop](../flatlist/#data).                                                  |
+| data                     | array                        | The data for rendering items in this section. Array of objects, much like [`FlatList`'s data prop](flatlist.md#data).                                                  |
 | [key]                    | string                       | Optional key to keep track of section re-ordering. If you don't plan on re-ordering sections, the array index will be used by default.                                  |
-| [renderItem]             | function                     | Optionally define an arbitrary item renderer for this section, overriding the default [`renderItem`](../sectionlist/#renderitem) for the list.                          |
-| [ItemSeparatorComponent] | component, function, element | Optionally define an arbitrary item separator for this section, overriding the default [`ItemSeparatorComponent`](../sectionlist/#itemseparatorcomponent) for the list. |
-| [keyExtractor]           | function                     | Optionally define an arbitrary key extractor for this section, overriding the default [`keyExtractor`](../sectionlist/#keyextractor).                                   |
+| [renderItem]             | function                     | Optionally define an arbitrary item renderer for this section, overriding the default [`renderItem`](sectionlist.md#renderitem) for the list.                          |
+| [ItemSeparatorComponent] | component, function, element | Optionally define an arbitrary item separator for this section, overriding the default [`ItemSeparatorComponent`](sectionlist.md#itemseparatorcomponent) for the list. |
+| [keyExtractor]           | function                     | Optionally define an arbitrary key extractor for this section, overriding the default [`keyExtractor`](sectionlist.md#keyextractor).                                   |

--- a/docs/pages/versions/v36.0.0/react-native/segmentedcontrolios.md
+++ b/docs/pages/versions/v36.0.0/react-native/segmentedcontrolios.md
@@ -31,7 +31,7 @@ The selected index can be changed on the fly by assigning the selectedIndex prop
 
 ## Props
 
-Inherits [View Props](../view/#props).
+Inherits [View Props](view.md#props).
 
 ### `enabled`
 

--- a/docs/pages/versions/v36.0.0/react-native/shadow-props.md
+++ b/docs/pages/versions/v36.0.0/react-native/shadow-props.md
@@ -13,7 +13,7 @@ Sets the drop shadow color
 
 | Type                | Required | Platform |
 | ------------------- | -------- | -------- |
-| [color](../colors/) | No       | iOS      |
+| [color](colors.md) | No       | iOS      |
 
 ---
 

--- a/docs/pages/versions/v36.0.0/react-native/slider.md
+++ b/docs/pages/versions/v36.0.0/react-native/slider.md
@@ -13,7 +13,7 @@ A component used to select a single value from a range of values.
 
 ## Props
 
-Inherits [View Props](../view/#props).
+Inherits [View Props](view.md#props).
 
 ### `style`
 
@@ -51,7 +51,7 @@ The color used for the track to the left of the button. Overrides the default bl
 
 | Type                | Required |
 | ------------------- | -------- |
-| [color](../colors/) | No       |
+| [color](colors.md) | No       |
 
 ---
 
@@ -101,7 +101,7 @@ The color used for the track to the right of the button. Overrides the default g
 
 | Type                | Required |
 | ------------------- | -------- |
-| [color](../colors/) | No       |
+| [color](colors.md) | No       |
 
 ---
 
@@ -133,7 +133,7 @@ The color used to tint the default thumb images on iOS, or the color of the fore
 
 | Type                | Required |
 | ------------------- | -------- |
-| [color](../colors/) | No       |
+| [color](colors.md) | No       |
 
 ---
 

--- a/docs/pages/versions/v36.0.0/react-native/state.md
+++ b/docs/pages/versions/v36.0.0/react-native/state.md
@@ -52,4 +52,4 @@ In a real application, you probably won't be setting state with a timer. You mig
 
 When setState is called, BlinkApp will re-render its Component. By calling setState within the Timer, the component will re-render every time the Timer ticks.
 
-State works the same way as it does in React, so for more details on handling state, you can look at the [React.Component API](https://reactjs.org/docs/react-component.html#setstate). At this point, you may have noticed that most of our examples use the default text color. To customize the text color, you will have to [learn about Style](../style/).
+State works the same way as it does in React, so for more details on handling state, you can look at the [React.Component API](https://reactjs.org/docs/react-component.html#setstate). At this point, you may have noticed that most of our examples use the default text color. To customize the text color, you will have to [learn about Style](style.md).

--- a/docs/pages/versions/v36.0.0/react-native/statusbar.md
+++ b/docs/pages/versions/v36.0.0/react-native/statusbar.md
@@ -49,7 +49,7 @@ The background color of the status bar.
 
 | Type                | Required | Platform |
 | ------------------- | -------- | -------- |
-| [color](../colors/) | No       | Android  |
+| [color](colors.md) | No       | Android  |
 
 ---
 
@@ -191,7 +191,7 @@ Set the status bar style
 
 | Name     | Type                                           | Required | Description               |
 | -------- | ---------------------------------------------- | -------- | ------------------------- |
-| style    | [StatusBarStyle](../statusbar/#statusbarstyle) | Yes      | Status bar style to set   |
+| style    | [StatusBarStyle](statusbar.md#statusbarstyle) | Yes      | Status bar style to set   |
 | animated | boolean                                        | No       | Animate the style change. |
 
 ---
@@ -211,7 +211,7 @@ Show or hide the status bar
 | Name      | Type                                                   | Required | Description                                                      |
 | --------- | ------------------------------------------------------ | -------- | ---------------------------------------------------------------- |
 | hidden    | boolean                                                | Yes      | Hide the status bar.                                             |
-| animation | [StatusBarAnimation](../statusbar/#statusbaranimation) | No       | Optional animation when changing the status bar hidden property. |
+| animation | [StatusBarAnimation](statusbar.md#statusbaranimation) | No       | Optional animation when changing the status bar hidden property. |
 
 ---
 

--- a/docs/pages/versions/v36.0.0/react-native/style.md
+++ b/docs/pages/versions/v36.0.0/react-native/style.md
@@ -3,7 +3,7 @@ id: style
 title: Style
 ---
 
-With React Native, you style your application using JavaScript. All of the core components accept a prop named `style`. The style names and [values](../colors/) usually match how CSS works on the web, except names are written using camel casing, e.g. `backgroundColor` rather than `background-color`.
+With React Native, you style your application using JavaScript. All of the core components accept a prop named `style`. The style names and [values](colors.md) usually match how CSS works on the web, except names are written using camel casing, e.g. `backgroundColor` rather than `background-color`.
 
 The `style` prop can be a plain old JavaScript object. That's what we usually use for example code. You can also pass an array of styles - the last style in the array has precedence, so you can use this to inherit styles.
 
@@ -40,6 +40,6 @@ export default class LotsOfStyles extends Component {
 
 One common pattern is to make your component accept a `style` prop which in turn is used to style subcomponents. You can use this to make styles "cascade" the way they do in CSS.
 
-There are a lot more ways to customize text style. Check out the [Text component reference](../text/) for a complete list.
+There are a lot more ways to customize text style. Check out the [Text component reference](text.md) for a complete list.
 
-Now you can make your text beautiful. The next step in becoming a style master is to [learn how to control component size](../height-and-width/).
+Now you can make your text beautiful. The next step in becoming a style master is to [learn how to control component size](height-and-width.md).

--- a/docs/pages/versions/v36.0.0/react-native/switch.md
+++ b/docs/pages/versions/v36.0.0/react-native/switch.md
@@ -32,7 +32,7 @@ export default function App() {
 
 ## Props
 
-Inherits [View Props](../view/#props).
+Inherits [View Props](view.md#props).
 
 ### `disabled`
 
@@ -50,7 +50,7 @@ On iOS, custom color for the background. This background color can be seen eithe
 
 | Type                | Required |
 | ------------------- | -------- |
-| [color](../colors/) | No       |
+| [color](colors.md) | No       |
 
 ---
 
@@ -80,7 +80,7 @@ Color of the foreground switch grip. If this is set on iOS, the switch grip will
 
 | Type                | Required |
 | ------------------- | -------- |
-| [color](../colors/) | No       |
+| [color](colors.md) | No       |
 
 ---
 
@@ -88,11 +88,11 @@ Color of the foreground switch grip. If this is set on iOS, the switch grip will
 
 Custom colors for the switch track.
 
-_iOS_: When the switch value is false, the track shrinks into the border. If you want to change the color of the background exposed by the shrunken track, use [`ios_backgroundColor`](../switch/#ios_backgroundColor).
+_iOS_: When the switch value is false, the track shrinks into the border. If you want to change the color of the background exposed by the shrunken track, use [`ios_backgroundColor`](switch.md#ios_backgroundColor).
 
 | Type                                                            | Required |
 | --------------------------------------------------------------- | -------- |
-| object: {false: [color](../colors/), true: [color](../colors/)} | No       |
+| object: {false: [color](colors.md), true: [color](colors.md)} | No       |
 
 ---
 

--- a/docs/pages/versions/v36.0.0/react-native/text-style-props.md
+++ b/docs/pages/versions/v36.0.0/react-native/text-style-props.md
@@ -19,7 +19,7 @@ title: Text Style Props
 
 | Type                | Required |
 | ------------------- | -------- |
-| [color](../colors/) | No       |
+| [color](colors.md) | No       |
 
 ---
 
@@ -79,7 +79,7 @@ Specifies text alignment. The value 'justify' is only supported on iOS and fallb
 
 | Type                | Required |
 | ------------------- | -------- |
-| [color](../colors/) | No       |
+| [color](colors.md) | No       |
 
 ---
 
@@ -137,7 +137,7 @@ Set to `false` to remove extra font padding intended to make space for certain a
 
 | Type                | Required | Platform |
 | ------------------- | -------- | -------- |
-| [color](../colors/) | No       | iOS      |
+| [color](colors.md) | No       | iOS      |
 
 ---
 

--- a/docs/pages/versions/v36.0.0/react-native/text.md
+++ b/docs/pages/versions/v36.0.0/react-native/text.md
@@ -226,7 +226,7 @@ Possible values for `AccessibilityRole` is one of:
 - `'imagebutton'` - The element has the role of both an image and also a button.
 - `'adjustable'` - The element allows adjustment over a range of values.
 
-On iOS, these roles map to corresponding Accessibility Traits. Image button has the same functionality as if the trait was set to both 'image' and 'button'. See the [Accessibility guide](../accessibility/#accessibilitytraits-ios) for more information.
+On iOS, these roles map to corresponding Accessibility Traits. Image button has the same functionality as if the trait was set to both 'image' and 'button'. See the [Accessibility guide](accessibility.md#accessibilityrole-ios-android) for more information.
 
 On Android, these roles have similar functionality on TalkBack as adding Accessibility Traits does on Voiceover in iOS
 
@@ -257,7 +257,7 @@ Possible values for `AccessibilityState` are:
 
 When set to `true`, indicates that the view is an accessibility element. The default value for a `Text` element is `true`.
 
-See the [Accessibility guide](../accessibility/#accessible-ios-android) for more information.
+See the [Accessibility guide](accessibility.md#accessible-ios-android) for more information.
 
 | Type | Required |
 | ---- | -------- |
@@ -530,7 +530,7 @@ The highlight color of the text.
 
 | Type                | Required | Platform |
 | ------------------- | -------- | -------- |
-| [color](../colors/) | No       | Android  |
+| [color](colors.md) | No       | Android  |
 
 ---
 
@@ -540,11 +540,11 @@ The highlight color of the text.
 | ----- | -------- |
 | style | No       |
 
-- [View Style Props...](../view-style-props/#style)
+- [View Style Props...](view-style-props.md#props)
 
 - **`textShadowOffset`**: object: {width: number,height: number}
 
-- **`color`**: [color](../colors/)
+- **`color`**: [color](colors.md)
 
 - **`fontSize`**: number
 
@@ -562,7 +562,7 @@ The highlight color of the text.
 
 - **`textDecorationLine`**: enum('none', 'underline', 'line-through', 'underline line-through')
 
-- **`textShadowColor`**: [color](../colors/)
+- **`textShadowColor`**: [color](colors.md)
 
 - **`fontFamily`**: string
 
@@ -584,7 +584,7 @@ The highlight color of the text.
 
   Android: Only supported since Android 5.0 - older versions will ignore this attribute. Please note that additional space will be added _around_ the glyphs (half on each side), which differs from the iOS rendering. It is possible to emulate the iOS rendering by using layout attributes, e.g. negative margins, as appropriate for your situation.
 
-* **`textDecorationColor`**: [color](../colors/) (_iOS_)
+* **`textDecorationColor`**: [color](colors.md) (_iOS_)
 
 * **`textDecorationStyle`**: enum('solid', 'double', 'dotted', 'dashed') (_iOS_)
 

--- a/docs/pages/versions/v36.0.0/react-native/textinput.md
+++ b/docs/pages/versions/v36.0.0/react-native/textinput.md
@@ -75,7 +75,7 @@ Note that on Android performing text selection in input can change app's activit
 
 ## Props
 
-Inherits [View Props](../view/#props).
+Inherits [View Props](view.md#props).
 
 ### `allowFontScaling`
 
@@ -301,7 +301,7 @@ Padding between the inline image, if any, and the text input itself.
 
 ### `inputAccessoryViewID`
 
-An optional identifier which links a custom [InputAccessoryView](../inputaccessoryview/) to this text input. The InputAccessoryView is rendered above the keyboard when this text input is focused.
+An optional identifier which links a custom [InputAccessoryView](inputaccessoryview.md) to this text input. The InputAccessoryView is rendered above the keyboard when this text input is focused.
 
 | Type   | Required | Platform |
 | ------ | -------- | -------- |
@@ -539,7 +539,7 @@ The text color of the placeholder string.
 
 | Type                | Required |
 | ------------------- | -------- |
-| [color](../colors/) | No       |
+| [color](colors.md) | No       |
 
 ---
 
@@ -637,7 +637,7 @@ The highlight and cursor color of the text input.
 
 | Type                | Required |
 | ------------------- | -------- |
-| [color](../colors/) | No       |
+| [color](colors.md) | No       |
 
 ---
 
@@ -751,11 +751,11 @@ Note that not all Text styles are supported, an incomplete list of what is not s
 
 see [Issue#7070](https://github.com/facebook/react-native/issues/7070) for more detail.
 
-[Styles](../style/)
+[Styles](style.md)
 
 | Type                   | Required |
 | ---------------------- | -------- |
-| [Text](../text/#style) | No       |
+| [Text](text.md#style) | No       |
 
 ---
 
@@ -777,7 +777,7 @@ The color of the `TextInput` underline.
 
 | Type                | Required | Platform |
 | ------------------- | -------- | -------- |
-| [color](../colors/) | No       | Android  |
+| [color](colors.md) | No       | Android  |
 
 ---
 

--- a/docs/pages/versions/v36.0.0/react-native/toolbarandroid.md
+++ b/docs/pages/versions/v36.0.0/react-native/toolbarandroid.md
@@ -38,7 +38,7 @@ onActionSelected: function(position) {
 
 ## Props
 
-Inherits [View Props](../view/#props).
+Inherits [View Props](view.md#props).
 
 ### `actions`
 
@@ -161,7 +161,7 @@ Sets the toolbar subtitle color.
 
 | Type                | Required |
 | ------------------- | -------- |
-| [color](../colors/) | No       |
+| [color](colors.md) | No       |
 
 ---
 
@@ -191,4 +191,4 @@ Sets the toolbar title color.
 
 | Type                | Required |
 | ------------------- | -------- |
-| [color](../colors/) | No       |
+| [color](colors.md) | No       |

--- a/docs/pages/versions/v36.0.0/react-native/touchablehighlight.md
+++ b/docs/pages/versions/v36.0.0/react-native/touchablehighlight.md
@@ -81,21 +81,21 @@ const styles = StyleSheet.create({
 
 ### Props
 
-- [TouchableWithoutFeedback props...](../touchablewithoutfeedback/#props)
+- [TouchableWithoutFeedback props...](touchablewithoutfeedback.md#props)
 
-* [`activeOpacity`](../touchablehighlight/#activeopacity)
-* [`onHideUnderlay`](../touchablehighlight/#onhideunderlay)
-* [`onShowUnderlay`](../touchablehighlight/#onshowunderlay)
-* [`style`](../touchablehighlight/#style)
-* [`underlayColor`](../touchablehighlight/#underlaycolor)
-* [`hasTVPreferredFocus`](../touchablehighlight/#hastvpreferredfocus)
-* [`tvParallaxProperties`](../touchablehighlight/#tvparallaxproperties)
-* [`nextFocusDown`](../touchablehighlight/#nextFocusDown)
-* [`nextFocusForward`](../touchablehighlight/#nextFocusForward)
-* [`nextFocusLeft`](../touchablehighlight/#nextFocusLeft)
-* [`nextFocusRight`](../touchablehighlight/#nextFocusRight)
-* [`nextFocusUp`](../touchablehighlight/#nextFocusUp)
-* [`testOnly_pressed`](../touchablehighlight/#testOnly_pressed)
+* [`activeOpacity`](touchablehighlight.md#activeopacity)
+* [`onHideUnderlay`](touchablehighlight.md#onhideunderlay)
+* [`onShowUnderlay`](touchablehighlight.md#onshowunderlay)
+* [`style`](touchablehighlight.md#style)
+* [`underlayColor`](touchablehighlight.md#underlaycolor)
+* [`hasTVPreferredFocus`](touchablehighlight.md#hastvpreferredfocus)
+* [`tvParallaxProperties`](touchablehighlight.md#tvparallaxproperties)
+* [`nextFocusDown`](touchablehighlight.md#nextFocusDown)
+* [`nextFocusForward`](touchablehighlight.md#nextFocusForward)
+* [`nextFocusLeft`](touchablehighlight.md#nextFocusLeft)
+* [`nextFocusRight`](touchablehighlight.md#nextFocusRight)
+* [`nextFocusUp`](touchablehighlight.md#nextFocusUp)
+* [`testOnly_pressed`](touchablehighlight.md#testOnly_pressed)
 
 ---
 
@@ -103,7 +103,7 @@ const styles = StyleSheet.create({
 
 ## Props
 
-Inherits [TouchableWithoutFeedback Props](../touchablewithoutfeedback/#props).
+Inherits [TouchableWithoutFeedback Props](touchablewithoutfeedback.md#props).
 
 ### `activeOpacity`
 
@@ -149,7 +149,7 @@ The color of the underlay that will show through when the touch is active.
 
 | Type                | Required |
 | ------------------- | -------- |
-| [color](../colors/) | No       |
+| [color](colors.md) | No       |
 
 ---
 

--- a/docs/pages/versions/v36.0.0/react-native/touchablenativefeedback.md
+++ b/docs/pages/versions/v36.0.0/react-native/touchablenativefeedback.md
@@ -33,7 +33,7 @@ renderButton: function() {
 
 ## Props
 
-Inherits [TouchableWithoutFeedback Props](../touchablewithoutfeedback/#props).
+Inherits [TouchableWithoutFeedback Props](touchablewithoutfeedback.md#props).
 
 ### `background`
 

--- a/docs/pages/versions/v36.0.0/react-native/touchableopacity.md
+++ b/docs/pages/versions/v36.0.0/react-native/touchableopacity.md
@@ -83,7 +83,7 @@ const styles = StyleSheet.create({
 
 ## Props
 
-Inherits [TouchableWithoutFeedback Props](../touchablewithoutfeedback/#props).
+Inherits [TouchableWithoutFeedback Props](touchablewithoutfeedback.md#props).
 
 ### `style`
 

--- a/docs/pages/versions/v36.0.0/react-native/touchablewithoutfeedback.md
+++ b/docs/pages/versions/v36.0.0/react-native/touchablewithoutfeedback.md
@@ -111,7 +111,7 @@ An accessibility hint helps users understand what will happen when they perform 
 
 Describes the current state of a component to the user of an assistive technology.
 
-See the [Accessibility guide](../accessibility/#accessibilitystate-ios-android) for more information.
+See the [Accessibility guide](accessibility.md#accessibilitystate-ios-android) for more information.
 
 | Type                                                                                           | Required |
 | ---------------------------------------------------------------------------------------------- | -------- |
@@ -123,7 +123,7 @@ See the [Accessibility guide](../accessibility/#accessibilitystate-ios-android) 
 
 Accessibility actions allow an assistive technology to programmatically invoke the actions of a component. The `accessibilityActions` property should contain a list of action objects. Each action object should contain the field name and label.
 
-See the [Accessibility guide](../accessibility/#accessibility-actions) for more information.
+See the [Accessibility guide](accessibility.md#accessibility-actions) for more information.
 
 | Type  | Required |
 | ----- | -------- |
@@ -135,7 +135,7 @@ See the [Accessibility guide](../accessibility/#accessibility-actions) for more 
 
 Invoked when the user performs the accessibility actions. The only argument to this function is an event containing the name of the action to perform.
 
-See the [Accessibility guide](../accessibility/#accessibility-actions) for more information.
+See the [Accessibility guide](accessibility.md#accessibility-actions) for more information.
 
 | Type     | Required |
 | -------- | -------- |
@@ -147,7 +147,7 @@ See the [Accessibility guide](../accessibility/#accessibility-actions) for more 
 
 Represents the current value of a component. It can be a textual description of a component's value, or for range-based components, such as sliders and progress bars, it contains range information (minimum, current, and maximum).
 
-See the [Accessibility guide](../accessibility/#accessibilityvalue-ios-android) for more information.
+See the [Accessibility guide](accessibility.md#accessibilityvalue-ios-android) for more information.
 
 | Type                                                          | Required |
 | ------------------------------------------------------------- | -------- |

--- a/docs/pages/versions/v36.0.0/react-native/transforms.md
+++ b/docs/pages/versions/v36.0.0/react-native/transforms.md
@@ -9,7 +9,7 @@ title: Transforms
 
 ### `decomposedMatrix`
 
-> **Deprecated.** Use the [`transform`](../transforms/#transform) prop instead.
+> **Deprecated.** Use the [`transform`](transforms.md#transform) prop instead.
 
 | Type                     | Required |
 | ------------------------ | -------- |
@@ -61,7 +61,7 @@ The skew transformations require a string so that the transform may be expressed
 
 ### `transformMatrix`
 
-> **Deprecated.** Use the [`transform`](../transforms/#transform) prop instead.
+> **Deprecated.** Use the [`transform`](transforms.md#transform) prop instead.
 
 | Type                    | Required |
 | ----------------------- | -------- |

--- a/docs/pages/versions/v36.0.0/react-native/tutorial.md
+++ b/docs/pages/versions/v36.0.0/react-native/tutorial.md
@@ -42,4 +42,4 @@ So this code is defining `HelloWorldApp`, a new `Component`. When you're buildin
 
 ## This app doesn't do very much
 
-Good point. To make components do more interesting things, you need to [learn about Props](../props/).
+Good point. To make components do more interesting things, you need to [learn about Props](props.md).

--- a/docs/pages/versions/v36.0.0/react-native/typescript.md
+++ b/docs/pages/versions/v36.0.0/react-native/typescript.md
@@ -213,12 +213,12 @@ npm install --save-dev babel-plugin-module-resolver
 [ts]: https://www.typescriptlang.org/
 [flow]: https://flow.org
 [ts-template]: https://github.com/react-native-community/react-native-template-typescript
-[babel]: ../javascript-environment/#javascript-syntax-transformers
+[babel]: javascript-environment.md#javascript-syntax-transformers
 [babel-7-caveats]: https://babeljs.io/docs/en/next/babel-plugin-transform-typescript
 [cheat]: https://github.com/typescript-cheatsheets/react-typescript-cheatsheet#reacttypescript-cheatsheets
 [ts-handbook]: http://www.typescriptlang.org/docs/home.html
-[props]: ../props/
-[state]: ../state/
+[props]: props.md
+[state]: state.md
 [path-map]: https://www.typescriptlang.org/docs/handbook/module-resolution.html#path-mapping
 [bpmr]: https://github.com/tleunen/babel-plugin-module-resolver
 [expo]: https://expo.io

--- a/docs/pages/versions/v36.0.0/react-native/using-a-listview.md
+++ b/docs/pages/versions/v36.0.0/react-native/using-a-listview.md
@@ -3,9 +3,9 @@ id: using-a-listview
 title: Using List Views
 ---
 
-React Native provides a suite of components for presenting lists of data. Generally, you'll want to use either [FlatList](../flatlist/) or [SectionList](../sectionlist/).
+React Native provides a suite of components for presenting lists of data. Generally, you'll want to use either [FlatList](flatlist.md) or [SectionList](sectionlist.md).
 
-The `FlatList` component displays a scrolling list of changing, but similarly structured, data. `FlatList` works well for long lists of data, where the number of items might change over time. Unlike the more generic [`ScrollView`](../using-a-scrollview/), the `FlatList` only renders elements that are currently showing on the screen, not all the elements at once.
+The `FlatList` component displays a scrolling list of changing, but similarly structured, data. `FlatList` works well for long lists of data, where the number of items might change over time. Unlike the more generic [`ScrollView`](using-a-scrollview.md), the `FlatList` only renders elements that are currently showing on the screen, not all the elements at once.
 
 The `FlatList` component requires two props: `data` and `renderItem`. `data` is the source of information for the list. `renderItem` takes one item from the source and returns a formatted component to render.
 
@@ -52,7 +52,7 @@ const styles = StyleSheet.create({
 });
 ```
 
-If you want to render a set of data broken into logical sections, maybe with section headers, similar to `UITableView`s on iOS, then a [SectionList](../sectionlist/) is the way to go.
+If you want to render a set of data broken into logical sections, maybe with section headers, similar to `UITableView`s on iOS, then a [SectionList](sectionlist.md) is the way to go.
 
 ```javascript
 import React, { Component } from 'react';
@@ -100,4 +100,4 @@ const styles = StyleSheet.create({
 });
 ```
 
-One of the most common uses for a list view is displaying data that you fetch from a server. To do that, you will need to [learn about networking in React Native](../network/).
+One of the most common uses for a list view is displaying data that you fetch from a server. To do that, you will need to [learn about networking in React Native](network.md).

--- a/docs/pages/versions/v36.0.0/react-native/using-a-scrollview.md
+++ b/docs/pages/versions/v36.0.0/react-native/using-a-scrollview.md
@@ -3,7 +3,7 @@ id: using-a-scrollview
 title: Using a ScrollView
 ---
 
-The [ScrollView](../scrollview/) is a generic scrolling container that can contain multiple components and views. The scrollable items need not be homogeneous, and you can scroll both vertically and horizontally (by setting the `horizontal` property).
+The [ScrollView](scrollview.md) is a generic scrolling container that can contain multiple components and views. The scrollable items need not be homogeneous, and you can scroll both vertically and horizontally (by setting the `horizontal` property).
 
 This example creates a vertical `ScrollView` with both images and text mixed together.
 
@@ -206,4 +206,4 @@ ScrollViews can be configured to allow paging through views using swiping gestur
 
 On iOS a ScrollView with a single item can be used to allow the user to zoom content. Set up the `maximumZoomScale` and `minimumZoomScale` props and your user will be able to use pinch and expand gestures to zoom in and out.
 
-The ScrollView works best to present a small amount of things of a limited size. All the elements and views of a `ScrollView` are rendered, even if they are not currently shown on the screen. If you have a long list of more items than can fit on the screen, you should use a `FlatList` instead. So let's [learn about list views](../using-a-listview/) next.
+The ScrollView works best to present a small amount of things of a limited size. All the elements and views of a `ScrollView` are rendered, even if they are not currently shown on the screen. If you have a long list of more items than can fit on the screen, you should use a `FlatList` instead. So let's [learn about list views](using-a-listview.md) next.

--- a/docs/pages/versions/v36.0.0/react-native/view-style-props.md
+++ b/docs/pages/versions/v36.0.0/react-native/view-style-props.md
@@ -11,7 +11,7 @@ title: View Style Props
 
 | Type                | Required |
 | ------------------- | -------- |
-| [color](../colors/) | No       |
+| [color](colors.md) | No       |
 
 ---
 
@@ -27,7 +27,7 @@ title: View Style Props
 
 | Type                | Required |
 | ------------------- | -------- |
-| [color](../colors/) | No       |
+| [color](colors.md) | No       |
 
 ---
 
@@ -75,7 +75,7 @@ title: View Style Props
 
 | Type                | Required |
 | ------------------- | -------- |
-| [color](../colors/) | No       |
+| [color](colors.md) | No       |
 
 ---
 
@@ -83,7 +83,7 @@ title: View Style Props
 
 | Type                | Required |
 | ------------------- | -------- |
-| [color](../colors/) | No       |
+| [color](colors.md) | No       |
 
 ---
 
@@ -91,7 +91,7 @@ title: View Style Props
 
 | Type                | Required |
 | ------------------- | -------- |
-| [color](../colors/) | No       |
+| [color](colors.md) | No       |
 
 ---
 
@@ -117,7 +117,7 @@ If the rounded border is not visible, try applying `overflow: 'hidden'` as well.
 
 | Type                | Required |
 | ------------------- | -------- |
-| [color](../colors/) | No       |
+| [color](colors.md) | No       |
 
 ---
 
@@ -133,7 +133,7 @@ If the rounded border is not visible, try applying `overflow: 'hidden'` as well.
 
 | Type                | Required |
 | ------------------- | -------- |
-| [color](../colors/) | No       |
+| [color](colors.md) | No       |
 
 ---
 
@@ -149,7 +149,7 @@ If the rounded border is not visible, try applying `overflow: 'hidden'` as well.
 
 | Type                | Required |
 | ------------------- | -------- |
-| [color](../colors/) | No       |
+| [color](colors.md) | No       |
 
 ---
 

--- a/docs/pages/versions/v36.0.0/react-native/view.md
+++ b/docs/pages/versions/v36.0.0/react-native/view.md
@@ -3,7 +3,7 @@ id: view
 title: View
 ---
 
-The most fundamental component for building a UI, `View` is a container that supports layout with [flexbox](../flexbox/), [style](../style/), [some touch handling](../handling-touches/), and [accessibility](../accessibility/) controls. `View` maps directly to the native view equivalent on whatever platform React Native is running on, whether that is a `UIView`, `<div>`, `android.view`, etc.
+The most fundamental component for building a UI, `View` is a container that supports layout with [flexbox](flexbox.md), [style](style.md), [some touch handling](handling-touches.md), and [accessibility](accessibility.md) controls. `View` maps directly to the native view equivalent on whatever platform React Native is running on, whether that is a `UIView`, `<div>`, `android.view`, etc.
 
 `View` is designed to be nested inside other views and can have 0 to many children of any type.
 
@@ -28,7 +28,7 @@ class ViewBoxesWithColorAndText extends Component {
 }
 ```
 
-> `View`s are designed to be used with [`StyleSheet`](../style/) for clarity and performance, although inline styles are also supported.
+> `View`s are designed to be used with [`StyleSheet`](style.md) for clarity and performance, although inline styles are also supported.
 
 ### Synthetic Touch Events
 
@@ -137,7 +137,7 @@ An accessibility hint helps users understand what will happen when they perform 
 
 Describes the current state of a component to the user of an assistive technology.
 
-See the [Accessibility guide](../accessibility/#accessibilitystate-ios-android) for more information.
+See the [Accessibility guide](accessibility.md#accessibilitystate-ios-android) for more information.
 
 | Type                                                                                           | Required |
 | ---------------------------------------------------------------------------------------------- | -------- |
@@ -149,7 +149,7 @@ See the [Accessibility guide](../accessibility/#accessibilitystate-ios-android) 
 
 Represents the current value of a component. It can be a textual description of a component's value, or for range-based components, such as sliders and progress bars, it contains range information (minimum, current, and maximum).
 
-See the [Accessibility guide](../accessibility/#accessibilityvalue-ios-android) for more information.
+See the [Accessibility guide](accessibility.md#accessibilityvalue-ios-android) for more information.
 
 | Type                                                          | Required |
 | ------------------------------------------------------------- | -------- |
@@ -161,7 +161,7 @@ See the [Accessibility guide](../accessibility/#accessibilityvalue-ios-android) 
 
 Accessibility actions allow an assistive technology to programmatically invoke the actions of a component. The `accessibilityActions` property should contain a list of action objects. Each action object should contain the field name and label.
 
-See the [Accessibility guide](../accessibility/#accessibility-actions) for more information.
+See the [Accessibility guide](accessibility.md#accessibility-actions) for more information.
 
 | Type  | Required |
 | ----- | -------- |
@@ -173,7 +173,7 @@ See the [Accessibility guide](../accessibility/#accessibility-actions) for more 
 
 Invoked when the user performs the accessibility actions. The only argument to this function is an event containing the name of the action to perform.
 
-See the [Accessibility guide](../accessibility/#accessibility-actions) for more information.
+See the [Accessibility guide](accessibility.md#accessibility-actions) for more information.
 
 | Type     | Required |
 | -------- | -------- |
@@ -215,7 +215,7 @@ When `accessible` is `true`, the system will invoke this function when the user 
 
 A value indicating whether VoiceOver should ignore the elements within views that are siblings of the receiver. Default is `false`.
 
-See the [Accessibility guide](../accessibility/#accessibilityviewismodal-ios) for more information.
+See the [Accessibility guide](accessibility.md#accessibilityviewismodal-ios) for more information.
 
 | Type | Required | Platform |
 | ---- | -------- | -------- |
@@ -227,7 +227,7 @@ See the [Accessibility guide](../accessibility/#accessibilityviewismodal-ios) fo
 
 A value indicating whether the accessibility elements contained within this accessibility element are hidden. Default is `false`.
 
-See the [Accessibility guide](../accessibility/#accessibilityelementshidden-ios) for more information.
+See the [Accessibility guide](accessibility.md#accessibilityelementshidden-ios) for more information.
 
 | Type | Required | Platform |
 | ---- | -------- | -------- |
@@ -239,7 +239,7 @@ See the [Accessibility guide](../accessibility/#accessibilityelementshidden-ios)
 
 A value indicating this view should or should not be inverted when color inversion is turned on. A value of `true` will tell the view to not be inverted even if color inversion is turned on.
 
-See the [Accessibility guide](../accessibility/#accessibilityignoresinvertcolors) for more information.
+See the [Accessibility guide](accessibility.md#accessibilityignoresinvertcolorsios) for more information.
 
 | Type | Required | Platform |
 | ---- | -------- | -------- |
@@ -484,7 +484,7 @@ This is a reserved performance property exposed by `RCTView` and is useful for s
 
 | Type                                | Required |
 | ----------------------------------- | -------- |
-| [view styles](../view-style-props/) | No       |
+| [view styles](view-style-props.md) | No       |
 
 ---
 

--- a/docs/pages/versions/v36.0.0/react-native/viewpagerandroid.md
+++ b/docs/pages/versions/v36.0.0/react-native/viewpagerandroid.md
@@ -49,7 +49,7 @@ const styles = {
 
 ## Props
 
-Inherits [View Props](../view/#props).
+Inherits [View Props](view.md#props).
 
 ### `initialPage`
 

--- a/docs/pages/versions/v36.0.0/react-native/virtualizedlist.md
+++ b/docs/pages/versions/v36.0.0/react-native/virtualizedlist.md
@@ -3,7 +3,7 @@ id: virtualizedlist
 title: VirtualizedList
 ---
 
-Base implementation for the more convenient [`<FlatList>`](../flatlist/) and [`<SectionList>`](../sectionlist/) components, which are also better documented. In general, this should only really be used if you need more flexibility than [`FlatList`](../flatlist/) provides, e.g. for use with immutable data instead of plain arrays.
+Base implementation for the more convenient [`<FlatList>`](flatlist.md) and [`<SectionList>`](sectionlist.md) components, which are also better documented. In general, this should only really be used if you need more flexibility than [`FlatList`](flatlist.md) provides, e.g. for use with immutable data instead of plain arrays.
 
 Virtualization massively improves memory consumption and performance of large lists by maintaining a finite render window of active items and replacing all items outside of the render window with appropriately sized blank space. The window adapts to scrolling behavior, and items are rendered incrementally with low-pri (after any running interactions) if they are far from the visible area, or with hi-pri otherwise to minimize the potential of seeing blank space.
 
@@ -20,7 +20,7 @@ Some caveats:
 
 ## Props
 
-Inherits [ScrollView Props](../scrollview/#props).
+Inherits [ScrollView Props](scrollview.md#props).
 
 ### `renderItem`
 
@@ -135,7 +135,7 @@ Reverses the direction of scroll. Uses scale transforms of -1.
 
 ### `CellRendererComponent`
 
-Each cell is rendered using this element. Can be a React Component Class,or a render function. Defaults to using [`View`](../view/).
+Each cell is rendered using this element. Can be a React Component Class,or a render function. Defaults to using [`View`](view.md).
 
 | Type                | Required |
 | ------------------- | -------- |

--- a/docs/pages/versions/v37.0.0/react-native/accessibility.md
+++ b/docs/pages/versions/v37.0.0/react-native/accessibility.md
@@ -253,7 +253,7 @@ To handle action requests, a component must implement an `onAccessibilityAction`
 
 ## Checking if a Screen Reader is Enabled
 
-The `AccessibilityInfo` API allows you to determine whether or not a screen reader is currently active. See the [AccessibilityInfo documentation](../accessibilityinfo/) for details.
+The `AccessibilityInfo` API allows you to determine whether or not a screen reader is currently active. See the [AccessibilityInfo documentation](accessibilityinfo.md) for details.
 
 ## Sending Accessibility Events (Android)
 

--- a/docs/pages/versions/v37.0.0/react-native/actionsheetios.md
+++ b/docs/pages/versions/v37.0.0/react-native/actionsheetios.md
@@ -23,7 +23,7 @@ Display an iOS action sheet. The `options` object must contain one or more of:
 - `title` (string) - a title to show above the action sheet
 - `message` (string) - a message to show below the title
 - `anchor` (number) - the node to which the action sheet should be anchored (used for iPad)
-- `tintColor` (string) - the [color](../colors/) used for non-destructive button titles
+- `tintColor` (string) - the [color](colors.md) used for non-destructive button titles
 
 The 'callback' function takes one parameter, the zero-based index of the selected item.
 

--- a/docs/pages/versions/v37.0.0/react-native/activityindicator.md
+++ b/docs/pages/versions/v37.0.0/react-native/activityindicator.md
@@ -43,7 +43,7 @@ const styles = StyleSheet.create({
 
 ## Props
 
-Inherits [View Props](../view/#props).
+Inherits [View Props](view.md#props).
 
 ### `animating`
 
@@ -61,7 +61,7 @@ The foreground color of the spinner (default is gray on iOS and dark cyan on And
 
 | Type                | Required |
 | ------------------- | -------- |
-| [color](../colors/) | No       |
+| [color](colors.md) | No       |
 
 ---
 

--- a/docs/pages/versions/v37.0.0/react-native/alertios.md
+++ b/docs/pages/versions/v37.0.0/react-native/alertios.md
@@ -3,7 +3,7 @@ id: alertios
 title: AlertIOS
 ---
 
-> **Deprecated.** `AlertIOS` has been moved to [`Alert`](../alert/)
+> **Deprecated.** `AlertIOS` has been moved to [`Alert`](alert.md)
 
 `AlertIOS` provides functionality to create an iOS alert dialog with a message or create a prompt for user input.
 
@@ -19,7 +19,7 @@ Creating an iOS prompt:
 AlertIOS.prompt('Enter a value', null, text => console.log('You entered ' + text));
 ```
 
-We recommend using the [`Alert.alert`](../alert/) method for cross-platform support if you don't need to create iOS-only prompts.
+We recommend using the [`Alert.alert`](alert.md) method for cross-platform support if you don't need to create iOS-only prompts.
 
 ---
 
@@ -43,8 +43,8 @@ Create and display a popup alert.
 | ----------------- | -------------------------------------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | title             | string                                                   | Yes      | The dialog's title. Passing null or '' will hide the title.                                                                                                                                                                                                                                                                                                      |
 | message           | string                                                   | No       | An optional message that appears below the dialog's title.                                                                                                                                                                                                                                                                                                       |
-| callbackOrButtons | ?(() =\> void),[ButtonsArray](../alertios/#buttonsarray) | No       | This optional argument should be either a single-argument function or an array of buttons. If passed a function, it will be called when the user taps 'OK'. If passed an array of button configurations, each button should include a `text` key, as well as optional `onPress` and `style` keys. `style` should be one of 'default', 'cancel' or 'destructive'. |
-| type              | [AlertType](../alertios/#alerttype)                      | No       | Deprecated, do not use.                                                                                                                                                                                                                                                                                                                                          |
+| callbackOrButtons | ?(() =\> void),[ButtonsArray](alertios.md#buttonsarray) | No       | This optional argument should be either a single-argument function or an array of buttons. If passed a function, it will be called when the user taps 'OK'. If passed an array of button configurations, each button should include a `text` key, as well as optional `onPress` and `style` keys. `style` should be one of 'default', 'cancel' or 'destructive'. |
+| type              | [AlertType](alertios.md#alerttype)                      | No       | Deprecated, do not use.                                                                                                                                                                                                                                                                                                                                          |
 
 Example with custom buttons:
 
@@ -80,8 +80,8 @@ Create and display a prompt to enter some text.
 | ----------------- | -------------------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | title             | string                                                               | Yes      | The dialog's title.                                                                                                                                                                                                                                                                                                                                                                                    |
 | message           | string                                                               | No       | An optional message that appears above the text input.                                                                                                                                                                                                                                                                                                                                                 |
-| callbackOrButtons | ?((text: string) =\> void),[ButtonsArray](../alertios/#buttonsarray) | No       | This optional argument should be either a single-argument function or an array of buttons. If passed a function, it will be called with the prompt's value when the user taps 'OK'. If passed an array of button configurations, each button should include a `text` key, as well as optional `onPress` and `style` keys (see example). `style` should be one of 'default', 'cancel' or 'destructive'. |
-| type              | [AlertType](../alertios/#alerttype)                                  | No       | This configures the text input. One of 'plain-text', 'secure-text' or 'login-password'.                                                                                                                                                                                                                                                                                                                |
+| callbackOrButtons | ?((text: string) =\> void),[ButtonsArray](alertios.md#buttonsarray) | No       | This optional argument should be either a single-argument function or an array of buttons. If passed a function, it will be called with the prompt's value when the user taps 'OK'. If passed an array of button configurations, each button should include a `text` key, as well as optional `onPress` and `style` keys (see example). `style` should be one of 'default', 'cancel' or 'destructive'. |
+| type              | [AlertType](alertios.md#alerttype)                                  | No       | This configures the text input. One of 'plain-text', 'secure-text' or 'login-password'.                                                                                                                                                                                                                                                                                                                |
 | defaultValue      | string                                                               | No       | The default text in text input.                                                                                                                                                                                                                                                                                                                                                                        |
 | keyboardType      | string                                                               | No       | The keyboard type of first text field(if exists). One of 'default', 'email-address', 'numeric', 'phone-pad', 'ascii-capable', 'numbers-and-punctuation', 'url', 'number-pad', 'name-phone-pad', 'decimal-pad', 'twitter' or 'web-search'.                                                                                                                                                              |
 
@@ -173,7 +173,7 @@ Array or buttons
 | --------- | ------------------------------------------------- | ------------------------------------- |
 | [text]    | string                                            | Button label                          |
 | [onPress] | function                                          | Callback function when button pressed |
-| [style]   | [AlertButtonStyle](../alertios/#alertbuttonstyle) | Button style                          |
+| [style]   | [AlertButtonStyle](alertios.md#alertbuttonstyle) | Button style                          |
 
 **Constants:**
 

--- a/docs/pages/versions/v37.0.0/react-native/animated.md
+++ b/docs/pages/versions/v37.0.0/react-native/animated.md
@@ -17,14 +17,14 @@ Animated.timing(
 ).start(); // Start the animation
 ```
 
-Refer to the [Animations](../animations/#animated-api) guide to see additional examples of `Animated` in action.
+Refer to the [Animations](animations.md#animated-api) guide to see additional examples of `Animated` in action.
 
 ## Overview
 
 There are two value types you can use with `Animated`:
 
-- [`Animated.Value()`](../animated/#value) for single values
-- [`Animated.ValueXY()`](../animated/#valuexy) for vectors
+- [`Animated.Value()`](animated.md#value) for single values
+- [`Animated.ValueXY()`](animated.md#valuexy) for vectors
 
 `Animated.Value` can bind to style properties or other props, and can be interpolated as well. A single `Animated.Value` can drive any number of properties.
 
@@ -32,9 +32,9 @@ There are two value types you can use with `Animated`:
 
 `Animated` provides three types of animation types. Each animation type provides a particular animation curve that controls how your values animate from their initial value to the final value:
 
-- [`Animated.decay()`](../animated/#decay) starts with an initial velocity and gradually slows to a stop.
-- [`Animated.spring()`](../animated/#spring) provides a basic spring physics model.
-- [`Animated.timing()`](../animated/#timing) animates a value over time using [easing functions](../easing/).
+- [`Animated.decay()`](animated.md#decay) starts with an initial velocity and gradually slows to a stop.
+- [`Animated.spring()`](animated.md#spring) provides a basic spring physics model.
+- [`Animated.timing()`](animated.md#timing) animates a value over time using [easing functions](easing.md).
 
 In most cases, you will be using `timing()`. By default, it uses a symmetric easeInOut curve that conveys the gradual acceleration of an object to full speed and concludes by gradually decelerating to a stop.
 
@@ -46,13 +46,13 @@ Animations are started by calling `start()` on your animation. `start()` takes a
 
 By using the native driver, we send everything about the animation to native before starting the animation, allowing native code to perform the animation on the UI thread without having to go through the bridge on every frame. Once the animation has started, the JS thread can be blocked without affecting the animation.
 
-You can use the native driver by specifying `useNativeDriver: true` in your animation configuration. See the [Animations](../animations/#using-the-native-driver) guide to learn more.
+You can use the native driver by specifying `useNativeDriver: true` in your animation configuration. See the [Animations](animations.md#using-the-native-driver) guide to learn more.
 
 ### Animatable components
 
 Only animatable components can be animated. These unique components do the magic of binding the animated values to the properties, and do targeted native updates to avoid the cost of the react render and reconciliation process on every frame. They also handle cleanup on unmount so they are safe by default.
 
-- [`createAnimatedComponent()`](../animated/#createanimatedcomponent) can be used to make a component animatable.
+- [`createAnimatedComponent()`](animated.md#createanimatedcomponent) can be used to make a component animatable.
 
 `Animated` exports the following animatable components using the above wrapper:
 
@@ -67,12 +67,12 @@ Only animatable components can be animated. These unique components do the magic
 
 Animations can also be combined in complex ways using composition functions:
 
-- [`Animated.delay()`](../animated/#delay) starts an animation after a given delay.
-- [`Animated.parallel()`](../animated/#parallel) starts a number of animations at the same time.
-- [`Animated.sequence()`](../animated/#sequence) starts the animations in order, waiting for each to complete before starting the next.
-- [`Animated.stagger()`](../animated/#stagger) starts animations in order and in parallel, but with successive delays.
+- [`Animated.delay()`](animated.md#delay) starts an animation after a given delay.
+- [`Animated.parallel()`](animated.md#parallel) starts a number of animations at the same time.
+- [`Animated.sequence()`](animated.md#sequence) starts the animations in order, waiting for each to complete before starting the next.
+- [`Animated.stagger()`](animated.md#stagger) starts animations in order and in parallel, but with successive delays.
 
-Animations can also be chained together by setting the `toValue` of one animation to be another `Animated.Value`. See [Tracking dynamic values](../animations/#tracking-dynamic-values) in the Animations guide.
+Animations can also be chained together by setting the `toValue` of one animation to be another `Animated.Value`. See [Tracking dynamic values](animations.md#tracking-dynamic-values) in the Animations guide.
 
 By default, if one animation is stopped or interrupted, then all other animations in the group are also stopped.
 
@@ -80,25 +80,25 @@ By default, if one animation is stopped or interrupted, then all other animation
 
 You can combine two animated values via addition, subtraction, multiplication, division, or modulo to make a new animated value:
 
-- [`Animated.add()`](../animated/#add)
-- [`Animated.subtract()`](../animated/#subtract)
-- [`Animated.divide()`](../animated/#divide)
-- [`Animated.modulo()`](../animated/#modulo)
-- [`Animated.multiply()`](../animated/#multiply)
+- [`Animated.add()`](animated.md#add)
+- [`Animated.subtract()`](animated.md#subtract)
+- [`Animated.divide()`](animated.md#divide)
+- [`Animated.modulo()`](animated.md#modulo)
+- [`Animated.multiply()`](animated.md#multiply)
 
 ### Interpolation
 
 The `interpolate()` function allows input ranges to map to different output ranges. By default, it will extrapolate the curve beyond the ranges given, but you can also have it clamp the output value. It uses linear interpolation by default but also supports easing functions.
 
-- [`interpolate()`](../animated/#interpolate)
+- [`interpolate()`](animated.md#interpolation)
 
-Read more about interpolation in the [Animation](../animations/#interpolation) guide.
+Read more about interpolation in the [Animation](animations.md#interpolation) guide.
 
 ### Handling gestures and other events
 
 Gestures, like panning or scrolling, and other events can map directly to animated values using `Animated.event()`. This is done with a structured map syntax so that values can be extracted from complex event objects. The first level is an array to allow mapping across multiple args, and that array contains nested objects.
 
-- [`Animated.event()`](../animated/#event)
+- [`Animated.event()`](animated.md#event)
 
 For example, when working with horizontal scrolling gestures, you would do the following in order to map `event.nativeEvent.contentOffset.x` to `scrollX` (an `Animated.Value`):
 
@@ -151,7 +151,7 @@ static timing(value, config)
 
 ```
 
-Animates a value along a timed easing curve. The [`Easing`](../easing/) module has tons of predefined curves, or you can use your own function.
+Animates a value along a timed easing curve. The [`Easing`](easing.md) module has tons of predefined curves, or you can use your own function.
 
 Config is an object that may have the following options:
 

--- a/docs/pages/versions/v37.0.0/react-native/animations.md
+++ b/docs/pages/versions/v37.0.0/react-native/animations.md
@@ -5,11 +5,11 @@ title: Animations
 
 Animations are very important to create a great user experience. Stationary objects must overcome inertia as they start moving. Objects in motion have momentum and rarely come to a stop immediately. Animations allow you to convey physically believable motion in your interface.
 
-React Native provides two complementary animation systems: [`Animated`](../animations/#animated-api) for granular and interactive control of specific values, and [`LayoutAnimation`](../animations/#layoutanimation-api) for animated global layout transactions.
+React Native provides two complementary animation systems: [`Animated`](animations.md#animated-api) for granular and interactive control of specific values, and [`LayoutAnimation`](animations.md#layoutanimation-api) for animated global layout transactions.
 
 ## `Animated` API
 
-The [`Animated`](../animated/) API is designed to concisely express a wide variety of interesting animation and interaction patterns in a very performant way. `Animated` focuses on declarative relationships between inputs and outputs, with configurable transforms in between, and `start`/`stop` methods to control time-based animation execution.
+The [`Animated`](animated.md) API is designed to concisely express a wide variety of interesting animation and interaction patterns in a very performant way. `Animated` focuses on declarative relationships between inputs and outputs, with configurable transforms in between, and `start`/`stop` methods to control time-based animation execution.
 
 `Animated` exports six animatable component types: `View`, `Text`, `Image`, `ScrollView`, `FlatList` and `SectionList`, but you can also create your own using `Animated.createAnimatedComponent()`.
 
@@ -62,7 +62,7 @@ This is done in an optimized way that is faster than calling `setState` and re-r
 
 Animations are heavily configurable. Custom and predefined easing functions, delays, durations, decay factors, spring constants, and more can all be tweaked depending on the type of animation.
 
-`Animated` provides several animation types, the most commonly used one being [`Animated.timing()`](../animated/#timing). It supports animating a value over time using one of various predefined easing functions, or you can use your own. Easing functions are typically used in animation to convey gradual acceleration and deceleration of objects.
+`Animated` provides several animation types, the most commonly used one being [`Animated.timing()`](animated.md#timing). It supports animating a value over time using one of various predefined easing functions, or you can use your own. Easing functions are typically used in animation to convey gradual acceleration and deceleration of objects.
 
 By default, `timing` will use an easeInOut curve that conveys gradual acceleration to full speed and concludes by gradually decelerating to a stop. You can specify a different easing function by passing an `easing` parameter. Custom `duration` or even a `delay` before the animation starts is also supported.
 
@@ -76,7 +76,7 @@ Animated.timing(this.state.xPosition, {
 }).start();
 ```
 
-Take a look at the [Configuring animations](../animated/#configuring-animations) section of the `Animated` API reference to learn more about all the config parameters supported by the built-in animations.
+Take a look at the [Configuring animations](animated.md#configuring-animations) section of the `Animated` API reference to learn more about all the config parameters supported by the built-in animations.
 
 ### Composing animations
 
@@ -107,11 +107,11 @@ Animated.sequence([
 
 If one animation is stopped or interrupted, then all other animations in the group are also stopped. `Animated.parallel` has a `stopTogether` option that can be set to `false` to disable this.
 
-You can find a full list of composition methods in the [Composing animations](../animated/#composing-animations) section of the `Animated` API reference.
+You can find a full list of composition methods in the [Composing animations](animated.md#composing-animations) section of the `Animated` API reference.
 
 ### Combining animated values
 
-You can [combine two animated values](../animated/#combining-animated-values) via addition, multiplication, division, or modulo to make a new animated value.
+You can [combine two animated values](animated.md#combining-animated-values) via addition, multiplication, division, or modulo to make a new animated value.
 
 There are some cases where an animated value needs to invert another animated value for calculation. An example is inverting a scale (2x --> 0.5x):
 
@@ -153,7 +153,7 @@ For example, you may want to think about your `Animated.Value` as going from 0 t
 
 ```
 
-[`interpolate()`](../animated/#interpolate) supports multiple range segments as well, which is handy for defining dead zones and other handy tricks. For example, to get a negation relationship at -300 that goes to 0 at -100, then back up to 1 at 0, and then back down to zero at 100 followed by a dead-zone that remains at 0 for everything beyond that, you could do:
+[`interpolate()`](animated.md#interpolation) supports multiple range segments as well, which is handy for defining dead zones and other handy tricks. For example, to get a negation relationship at -300 that goes to 0 at -100, then back up to 1 at 0, and then back down to zero at 100 followed by a dead-zone that remains at 0 for everything beyond that, you could do:
 
 ```jsx
 value.interpolate({
@@ -190,7 +190,7 @@ value.interpolate({
 });
 ```
 
-`interpolate()` also supports arbitrary easing functions, many of which are already implemented in the [`Easing`](../easing/) module. `interpolate()` also has configurable behavior for extrapolating the `outputRange`. You can set the extrapolation by setting the `extrapolate`, `extrapolateLeft`, or `extrapolateRight` options. The default value is `extend` but you can use `clamp` to prevent the output value from exceeding `outputRange`.
+`interpolate()` also supports arbitrary easing functions, many of which are already implemented in the [`Easing`](easing.md) module. `interpolate()` also has configurable behavior for extrapolating the `outputRange`. You can set the extrapolation by setting the `extrapolate`, `extrapolateLeft`, or `extrapolateRight` options. The default value is `extend` but you can use `clamp` to prevent the output value from exceeding `outputRange`.
 
 ### Tracking dynamic values
 
@@ -210,7 +210,7 @@ The `leader` and `follower` animated values would be implemented using `Animated
 
 ### Tracking gestures
 
-Gestures, like panning or scrolling, and other events can map directly to animated values using [`Animated.event`](../animated/#event). This is done with a structured map syntax so that values can be extracted from complex event objects. The first level is an array to allow mapping across multiple args, and that array contains nested objects.
+Gestures, like panning or scrolling, and other events can map directly to animated values using [`Animated.event`](animated.md#event). This is done with a structured map syntax so that values can be extracted from complex event objects. The first level is an array to allow mapping across multiple args, and that array contains nested objects.
 
 For example, when working with horizontal scrolling gestures, you would do the following in order to map `event.nativeEvent.contentOffset.x` to `scrollX` (an `Animated.Value`):
 
@@ -405,8 +405,8 @@ This example uses a preset value, you can customize the animations as you need, 
 
 ### `setNativeProps`
 
-As mentioned [in the Direct Manipulation section](../direct-manipulation/), `setNativeProps` allows us to modify properties of native-backed components (components that are actually backed by native views, unlike composite components) directly, without having to `setState` and re-render the component hierarchy.
+As mentioned [in the Direct Manipulation section](direct-manipulation.md), `setNativeProps` allows us to modify properties of native-backed components (components that are actually backed by native views, unlike composite components) directly, without having to `setState` and re-render the component hierarchy.
 
 We could use this in the Rebound example to update the scale - this might be helpful if the component that we are updating is deeply nested and hasn't been optimized with `shouldComponentUpdate`.
 
-If you find your animations with dropping frames (performing below 60 frames per second), look into using `setNativeProps` or `shouldComponentUpdate` to optimize them. Or you could run the animations on the UI thread rather than the JavaScript thread [with the useNativeDriver option](http://reactnative.dev/blog/2017/02/14/using-native-driver-for-animated). You may also want to defer any computationally intensive work until after animations are complete, using the [InteractionManager](../interactionmanager/). You can monitor the frame rate by using the In-App Developer Menu "FPS Monitor" tool.
+If you find your animations with dropping frames (performing below 60 frames per second), look into using `setNativeProps` or `shouldComponentUpdate` to optimize them. Or you could run the animations on the UI thread rather than the JavaScript thread [with the useNativeDriver option](http://reactnative.dev/blog/2017/02/14/using-native-driver-for-animated). You may also want to defer any computationally intensive work until after animations are complete, using the [InteractionManager](interactionmanager.md). You can monitor the frame rate by using the In-App Developer Menu "FPS Monitor" tool.

--- a/docs/pages/versions/v37.0.0/react-native/appstate.md
+++ b/docs/pages/versions/v37.0.0/react-native/appstate.md
@@ -62,7 +62,7 @@ This example will only ever appear to say "Current state is: active" because the
 
 ### `change`
 
-This event is received when the app state has changed. The listener is called with one of [the current app state values](../appstate/#app-states).
+This event is received when the app state has changed. The listener is called with one of [the current app state values](appstate.md#app-states).
 
 ### `focus`
 

--- a/docs/pages/versions/v37.0.0/react-native/button.md
+++ b/docs/pages/versions/v37.0.0/react-native/button.md
@@ -5,7 +5,7 @@ title: Button
 
 A basic button component that should render nicely on any platform. Supports a minimal level of customization.
 
-If this button doesn't look right for your app, you can build your own button using [TouchableOpacity](../touchableopacity/) or [TouchableNativeFeedback](../touchablenativefeedback/). For inspiration, look at the [source code for this button component](https://github.com/facebook/react-native/blob/master/Libraries/Components/Button.js). Or, take a look at the [wide variety of button components built by the community](https://js.coach/react-native?search=button).
+If this button doesn't look right for your app, you can build your own button using [TouchableOpacity](touchableopacity.md) or [TouchableNativeFeedback](touchablenativefeedback.md). For inspiration, look at the [source code for this button component](https://github.com/facebook/react-native/blob/master/Libraries/Components/Button.js). Or, take a look at the [wide variety of button components built by the community](https://js.coach/react-native?search=button).
 
 ### Example
 
@@ -124,7 +124,7 @@ Color of the text (iOS), or background color of the button (Android)
 
 | Type                | Required |
 | ------------------- | -------- |
-| [color](../colors/) | No       |
+| [color](colors.md) | No       |
 
 ---
 

--- a/docs/pages/versions/v37.0.0/react-native/colors.md
+++ b/docs/pages/versions/v37.0.0/react-native/colors.md
@@ -3,7 +3,7 @@ id: colors
 title: Color Reference
 ---
 
-Components in React Native are [styled using JavaScript](../style/). Color properties usually match how [CSS works on the web](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value).
+Components in React Native are [styled using JavaScript](style.md). Color properties usually match how [CSS works on the web](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value).
 
 ### Red-green-blue
 

--- a/docs/pages/versions/v37.0.0/react-native/datepickerios.md
+++ b/docs/pages/versions/v37.0.0/react-native/datepickerios.md
@@ -50,7 +50,7 @@ const styles = StyleSheet.create({
 
 ## Props
 
-Inherits [View Props](../view/#props).
+Inherits [View Props](view.md#props).
 
 ### `date`
 
@@ -112,7 +112,7 @@ Restricts the range of possible date/time values.
 | ---- | -------- |
 | Date | No       |
 
-See [`maximumDate`](../datepickerios/#maximumdate) for an example image.
+See [`maximumDate`](datepickerios.md#maximumdate) for an example image.
 
 ---
 

--- a/docs/pages/versions/v37.0.0/react-native/direct-manipulation.md
+++ b/docs/pages/versions/v37.0.0/react-native/direct-manipulation.md
@@ -126,7 +126,7 @@ export default class App extends React.Component {
 
 You can now use `MyButton` inside of `TouchableOpacity`! A sidenote for clarity: we used the [ref callback](https://reactjs.org/docs/refs-and-the-dom.html#adding-a-ref-to-a-dom-element) syntax here, rather than the traditional string-based ref.
 
-You may have noticed that we passed all of the props down to the child view using `{...this.props}`. The reason for this is that `TouchableOpacity` is actually a composite component, and so in addition to depending on `setNativeProps` on its child, it also requires that the child perform touch handling. To do this, it passes on [various props](../view/#onmoveshouldsetresponder) that call back to the `TouchableOpacity` component. `TouchableHighlight`, in contrast, is backed by a native view and only requires that we implement `setNativeProps`.
+You may have noticed that we passed all of the props down to the child view using `{...this.props}`. The reason for this is that `TouchableOpacity` is actually a composite component, and so in addition to depending on `setNativeProps` on its child, it also requires that the child perform touch handling. To do this, it passes on [various props](view.md#onmoveshouldsetresponder) that call back to the `TouchableOpacity` component. `TouchableHighlight`, in contrast, is backed by a native view and only requires that we implement `setNativeProps`.
 
 ## setNativeProps to clear TextInput value
 
@@ -186,7 +186,7 @@ Determines the location on screen, width, and height of the given view and retur
 - pageX
 - pageY
 
-Note that these measurements are not available until after the rendering has been completed in native. If you need the measurements as soon as possible, consider using the [`onLayout` prop](../view/#onlayout) instead.
+Note that these measurements are not available until after the rendering has been completed in native. If you need the measurements as soon as possible, consider using the [`onLayout` prop](view.md#onlayout) instead.
 
 ### measureInWindow(callback)
 

--- a/docs/pages/versions/v37.0.0/react-native/easing.md
+++ b/docs/pages/versions/v37.0.0/react-native/easing.md
@@ -3,7 +3,7 @@ id: easing
 title: Easing
 ---
 
-The `Easing` module implements common easing functions. This module is used by [Animated.timing()](../animated/#timing) to convey physically believable motion in animations.
+The `Easing` module implements common easing functions. This module is used by [Animated.timing()](animated.md#timing) to convey physically believable motion in animations.
 
 You can find a visualization of some common easing functions at http://easings.net/
 
@@ -11,35 +11,35 @@ You can find a visualization of some common easing functions at http://easings.n
 
 The `Easing` module provides several predefined animations through the following methods:
 
-- [`back`](../easing/#back) provides a basic animation where the object goes slightly back before moving forward
-- [`bounce`](../easing/#bounce) provides a bouncing animation
-- [`ease`](../easing/#ease) provides a basic inertial animation
-- [`elastic`](../easing/#elastic) provides a basic spring interaction
+- [`back`](easing.md#back) provides a basic animation where the object goes slightly back before moving forward
+- [`bounce`](easing.md#bounce) provides a bouncing animation
+- [`ease`](easing.md#ease) provides a basic inertial animation
+- [`elastic`](easing.md#elastic) provides a basic spring interaction
 
 ### Standard functions
 
 Three standard easing functions are provided:
 
-- [`linear`](../easing/#linear)
-- [`quad`](../easing/#quad)
-- [`cubic`](../easing/#cubic)
+- [`linear`](easing.md#linear)
+- [`quad`](easing.md#quad)
+- [`cubic`](easing.md#cubic)
 
-The [`poly`](../easing/#poly) function can be used to implement quartic, quintic, and other higher power functions.
+The [`poly`](easing.md#poly) function can be used to implement quartic, quintic, and other higher power functions.
 
 ### Additional functions
 
 Additional mathematical functions are provided by the following methods:
 
-- [`bezier`](../easing/#bezier) provides a cubic bezier curve
-- [`circle`](../easing/#circle) provides a circular function
-- [`sin`](../easing/#sin) provides a sinusoidal function
-- [`exp`](../easing/#exp) provides an exponential function
+- [`bezier`](easing.md#bezier) provides a cubic bezier curve
+- [`circle`](easing.md#circle) provides a circular function
+- [`sin`](easing.md#sin) provides a sinusoidal function
+- [`exp`](easing.md#exp) provides an exponential function
 
 The following helpers are used to modify other easing functions.
 
-- [`in`](../easing/#in) runs an easing function forwards
-- [`inOut`](../easing/#inout) makes any easing function symmetrical
-- [`out`](../easing/#out) runs an easing function backwards
+- [`in`](easing.md#in) runs an easing function forwards
+- [`inOut`](easing.md#inout) makes any easing function symmetrical
+- [`out`](easing.md#out) runs an easing function backwards
 
 ---
 

--- a/docs/pages/versions/v37.0.0/react-native/flatlist.md
+++ b/docs/pages/versions/v37.0.0/react-native/flatlist.md
@@ -16,7 +16,7 @@ A performant interface for rendering basic, flat lists, supporting the most hand
 - ScrollToIndex support.
 - Multiple column support.
 
-If you need section support, use [`<SectionList>`](../sectionlist/).
+If you need section support, use [`<SectionList>`](sectionlist.md).
 
 ### Basic Example:
 
@@ -77,7 +77,7 @@ const styles = StyleSheet.create({
 });
 ```
 
-To render multiple columns, use the [`numColumns`](../flatlist/#numcolumns) prop. Using this approach instead of a `flexWrap` layout can prevent conflicts with the item height logic.
+To render multiple columns, use the [`numColumns`](flatlist.md#numcolumns) prop. Using this approach instead of a `flexWrap` layout can prevent conflicts with the item height logic.
 
 ````
 
@@ -180,7 +180,7 @@ const styles = StyleSheet.create({
 
 ````
 
-This is a convenience wrapper around [`<VirtualizedList>`](../virtualizedlist/), and thus inherits its props (as well as those of [`<ScrollView>`](../scrollview/)) that aren't explicitly listed here, along with the following caveats:
+This is a convenience wrapper around [`<VirtualizedList>`](virtualizedlist.md), and thus inherits its props (as well as those of [`<ScrollView>`](scrollview.md)) that aren't explicitly listed here, along with the following caveats:
 
 - Internal state is not preserved when content scrolls out of the render window. Make sure all your data is captured in the item data or external stores like Flux, Redux, or Relay.
 - This is a `PureComponent` which means that it will not re-render if `props` remain shallow-equal. Make sure that everything your `renderItem` function depends on is passed as a prop (e.g. `extraData`) that is not `===` after updates, otherwise your UI may not update on changes. This includes the `data` prop and parent component state.
@@ -193,7 +193,7 @@ This is a convenience wrapper around [`<VirtualizedList>`](../virtualizedlist/),
 
 ## Props
 
-Inherits [ScrollView Props](../scrollview/#props), unless it is nested in another FlatList of same orientation.
+Inherits [ScrollView Props](scrollview.md#props), unless it is nested in another FlatList of same orientation.
 
 ### `renderItem`
 
@@ -249,7 +249,7 @@ Example usage:
 
 ### `data`
 
-For simplicity, data is a plain array. If you want to use something else, like an immutable list, use the underlying [`VirtualizedList`](../virtualizedlist/) directly.
+For simplicity, data is a plain array. If you want to use something else, like an immutable list, use the underlying [`VirtualizedList`](virtualizedlist.md) directly.
 
 | Type  | Required |
 | ----- | -------- |

--- a/docs/pages/versions/v37.0.0/react-native/flexbox.md
+++ b/docs/pages/versions/v37.0.0/react-native/flexbox.md
@@ -223,8 +223,8 @@ The `position` type of an element defines how it is positioned within its parent
 
 Check out the interactive [yoga playground](https://yogalayout.com/playground) that you can use to get a better understanding of flexbox.
 
-We've covered the basics, but there are many other styles you may need for layouts. The full list of props that control layout is documented [here](../layout-props/).
+We've covered the basics, but there are many other styles you may need for layouts. The full list of props that control layout is documented [here](layout-props.md).
 
-We're getting close to being able to build a real application. One thing we are still missing is a way to take user input, so let's move on to [learn how to handle text input with the TextInput component](../handling-text-input/).
+We're getting close to being able to build a real application. One thing we are still missing is a way to take user input, so let's move on to [learn how to handle text input with the TextInput component](handling-text-input.md).
 
 See some examples from [Wix Engineers](https://medium.com/wix-engineering/the-full-react-native-layout-cheat-sheet-a4147802405c):

--- a/docs/pages/versions/v37.0.0/react-native/gesture-responder-system.md
+++ b/docs/pages/versions/v37.0.0/react-native/gesture-responder-system.md
@@ -63,4 +63,4 @@ However, sometimes a parent will want to make sure that it becomes responder. Th
 
 ### PanResponder
 
-For higher-level gesture interpretation, check out [PanResponder](../panresponder/).
+For higher-level gesture interpretation, check out [PanResponder](panresponder.md).

--- a/docs/pages/versions/v37.0.0/react-native/handling-text-input.md
+++ b/docs/pages/versions/v37.0.0/react-native/handling-text-input.md
@@ -3,7 +3,7 @@ id: handling-text-input
 title: Handling Text Input
 ---
 
-[`TextInput`](../textinput/#content) is a basic component that allows the user to enter text. It has an `onChangeText` prop that takes a function to be called every time the text changed, and an `onSubmitEditing` prop that takes a function to be called when the text is submitted.
+[`TextInput`](textinput.md) is a basic component that allows the user to enter text. It has an `onChangeText` prop that takes a function to be called every time the text changed, and an `onSubmitEditing` prop that takes a function to be called when the text is submitted.
 
 For example, let's say that as the user types, you're translating their words into a different language. In this new language, every single word is written the same way: 🍕. So the sentence "Hello there Bob" would be translated as "🍕🍕🍕".
 
@@ -40,6 +40,6 @@ export default class PizzaTranslator extends Component {
 
 In this example, we store `text` in the state, because it changes over time.
 
-There are a lot more things you might want to do with a text input. For example, you could validate the text inside while the user types. For more detailed examples, see the [React docs on controlled components](https://reactjs.org/docs/forms.html#controlled-components), or the [reference docs for TextInput](../textinput/).
+There are a lot more things you might want to do with a text input. For example, you could validate the text inside while the user types. For more detailed examples, see the [React docs on controlled components](https://reactjs.org/docs/forms.html#controlled-components), or the [reference docs for TextInput](textinput.md).
 
-Text input is one of the ways the user interacts with the app. Next, let's look at another type of input and [learn how to handle touches](../handling-touches/).
+Text input is one of the ways the user interacts with the app. Next, let's look at another type of input and [learn how to handle touches](handling-touches.md).

--- a/docs/pages/versions/v37.0.0/react-native/handling-touches.md
+++ b/docs/pages/versions/v37.0.0/react-native/handling-touches.md
@@ -3,11 +3,11 @@ id: handling-touches
 title: Handling Touches
 ---
 
-Users interact with mobile apps mainly through touch. They can use a combination of gestures, such as tapping on a button, scrolling a list, or zooming on a map. React Native provides components to handle all sorts of common gestures, as well as a comprehensive [gesture responder system](../gesture-responder-system/) to allow for more advanced gesture recognition, but the one component you will most likely be interested in is the basic Button.
+Users interact with mobile apps mainly through touch. They can use a combination of gestures, such as tapping on a button, scrolling a list, or zooming on a map. React Native provides components to handle all sorts of common gestures, as well as a comprehensive [gesture responder system](gesture-responder-system.md) to allow for more advanced gesture recognition, but the one component you will most likely be interested in is the basic Button.
 
 ## Displaying a basic button
 
-[Button](../button/) provides a basic button component that is rendered nicely on all platforms. The minimal example to display a button looks like this:
+[Button](button.md) provides a basic button component that is rendered nicely on all platforms. The minimal example to display a button looks like this:
 
 ```jsx
 <Button
@@ -73,13 +73,13 @@ If the basic button doesn't look right for your app, you can build your own butt
 
 Which "Touchable" component you use will depend on what kind of feedback you want to provide:
 
-- Generally, you can use [**TouchableHighlight**](../touchablehighlight/) anywhere you would use a button or link on web. The view's background will be darkened when the user presses down on the button.
+- Generally, you can use [**TouchableHighlight**](touchablehighlight.md) anywhere you would use a button or link on web. The view's background will be darkened when the user presses down on the button.
 
-- You may consider using [**TouchableNativeFeedback**](../touchablenativefeedback/) on Android to display ink surface reaction ripples that respond to the user's touch.
+- You may consider using [**TouchableNativeFeedback**](touchablenativefeedback.md) on Android to display ink surface reaction ripples that respond to the user's touch.
 
-- [**TouchableOpacity**](../touchableopacity/) can be used to provide feedback by reducing the opacity of the button, allowing the background to be seen through while the user is pressing down.
+- [**TouchableOpacity**](touchableopacity.md) can be used to provide feedback by reducing the opacity of the button, allowing the background to be seen through while the user is pressing down.
 
-- If you need to handle a tap gesture but you don't want any feedback to be displayed, use [**TouchableWithoutFeedback**](../touchablewithoutfeedback/).
+- If you need to handle a tap gesture but you don't want any feedback to be displayed, use [**TouchableWithoutFeedback**](touchablewithoutfeedback.md).
 
 In some cases, you may want to detect when a user presses and holds a view for a set amount of time. These long presses can be handled by passing a function to the `onLongPress` props of any of the "Touchable" components.
 
@@ -170,4 +170,4 @@ const styles = StyleSheet.create({
 
 ## Scrolling lists, swiping pages, and pinch-to-zoom
 
-Another gesture commonly used in mobile apps is the swipe or pan. This gesture allows the user to scroll through a list of items, or swipe through pages of content. In order to handle these and other gestures, we'll learn [how to use a ScrollView](../using-a-scrollview/) next.
+Another gesture commonly used in mobile apps is the swipe or pan. This gesture allows the user to scroll through a list of items, or swipe through pages of content. In order to handle these and other gestures, we'll learn [how to use a ScrollView](using-a-scrollview.md) next.

--- a/docs/pages/versions/v37.0.0/react-native/height-and-width.md
+++ b/docs/pages/versions/v37.0.0/react-native/height-and-width.md
@@ -54,4 +54,4 @@ export default class FlexDimensionsBasics extends Component {
 }
 ```
 
-After you can control a component's size, the next step is to [learn how to lay it out on the screen](../flexbox/).
+After you can control a component's size, the next step is to [learn how to lay it out on the screen](flexbox.md).

--- a/docs/pages/versions/v37.0.0/react-native/image-style-props.md
+++ b/docs/pages/versions/v37.0.0/react-native/image-style-props.md
@@ -43,7 +43,7 @@ title: Image Style Props
 
 | Type                | Required |
 | ------------------- | -------- |
-| [color](../colors/) | No       |
+| [color](colors.md) | No       |
 
 ---
 
@@ -67,7 +67,7 @@ title: Image Style Props
 
 | Type                | Required |
 | ------------------- | -------- |
-| [color](../colors/) | No       |
+| [color](colors.md) | No       |
 
 ---
 
@@ -109,7 +109,7 @@ Changes the color of all the non-transparent pixels to the tintColor.
 
 | Type                | Required |
 | ------------------- | -------- |
-| [color](../colors/) | No       |
+| [color](colors.md) | No       |
 
 ---
 

--- a/docs/pages/versions/v37.0.0/react-native/image.md
+++ b/docs/pages/versions/v37.0.0/react-native/image.md
@@ -105,11 +105,11 @@ dependencies {
 | ----- | -------- |
 | style | No       |
 
-- [Layout Props...](../layout-props/#props)
+- [Layout Props...](layout-props.md#props)
 
-- [Shadow Props...](../shadow-props/#props)
+- [Shadow Props...](shadow-props.md#props)
 
-- [Transforms...](../transforms/#props)
+- [Transforms...](transforms.md#transform)
 
 - **`borderTopRightRadius`**: number
 
@@ -119,13 +119,13 @@ dependencies {
 
 - **`borderBottomRightRadius`**: number
 
-- **`borderColor`**: [color](../colors/)
+- **`borderColor`**: [color](colors.md)
 
 - **`borderRadius`**: number
 
 - **`borderTopLeftRadius`**: number
 
-- **`backgroundColor`**: [color](../colors/)
+- **`backgroundColor`**: [color](colors.md)
 
 - **`borderWidth`**: number
 
@@ -135,7 +135,7 @@ dependencies {
 
 - **`resizeMode`**: Object.keys(ImageResizeMode)
 
-- **`tintColor`**: [color](../colors/)
+- **`tintColor`**: [color](colors.md)
 
   Changes the color of all the non-transparent pixels to the tintColor.
 
@@ -228,7 +228,7 @@ Determines how to resize the image when the frame doesn't match the raw image di
 
 The image source (either a remote URL or a local file resource).
 
-This prop can also contain several remote URLs, specified together with their width and height and potentially with scale/other URI arguments. The native side will then choose the best `uri` to display based on the measured size of the image container. A `cache` property can be added to control how networked request interacts with the local cache. (For more information see [Cache Control for Images](../images/#cache-control-ios-only)).
+This prop can also contain several remote URLs, specified together with their width and height and potentially with scale/other URI arguments. The native side will then choose the best `uri` to display based on the measured size of the image container. A `cache` property can be added to control how networked request interacts with the local cache. (For more information see [Cache Control for Images](images.md#cache-control-ios-only)).
 
 The currently supported formats are `png`, `jpg`, `jpeg`, `bmp`, `gif`, `webp` (Android only), `psd` (iOS only). In addition, iOS supports several RAW image formats. Refer to Apple's documentation for the current list of supported camera models (for iOS 12, see https://support.apple.com/en-ca/HT208967).
 

--- a/docs/pages/versions/v37.0.0/react-native/imagebackground.md
+++ b/docs/pages/versions/v37.0.0/react-native/imagebackground.md
@@ -27,19 +27,19 @@ return (
 
 ## Props
 
-Inherits [Image Props](../image/#props).
+Inherits [Image Props](image.md#props).
 
 ### `style`
 
 | Type                                | Required |
 | ----------------------------------- | -------- |
-| [view styles](../view-style-props/) | No       |
+| [view styles](view-style-props.md) | No       |
 
 ### `imageStyle`
 
 | Type                                  | Required |
 | ------------------------------------- | -------- |
-| [image styles](../image-style-props/) | No       |
+| [image styles](image-style-props.md) | No       |
 
 ### `imageRef`
 

--- a/docs/pages/versions/v37.0.0/react-native/images.md
+++ b/docs/pages/versions/v37.0.0/react-native/images.md
@@ -164,7 +164,7 @@ In some cases you might only want to display an image if it is already in the lo
 
 ## Local Filesystem Images
 
-See [MediaLibrary](../../versions/latest/sdk/media-library) for an example of using local resources that are outside of `Images.xcassets`.
+See [MediaLibrary](../sdk/media-library.md) for an example of using local resources that are outside of `Images.xcassets`.
 
 ### Best Camera Roll Image
 
@@ -200,7 +200,7 @@ On the user side, this lets you annotate the object with useful attributes such 
 
 A common feature request from developers familiar with the web is `background-image`. To handle this use case, you can use the `<ImageBackground>` component, which has the same props as `<Image>`, and add whatever children to it you would like to layer on top of it.
 
-You might not want to use `<ImageBackground>` in some cases, since the implementation is basic. Refer to `<ImageBackground>`'s [documentation](../imagebackground/) for more insight, and create your own custom component when needed.
+You might not want to use `<ImageBackground>` in some cases, since the implementation is basic. Refer to `<ImageBackground>`'s [documentation](imagebackground.md) for more insight, and create your own custom component when needed.
 
 ```jsx
 

--- a/docs/pages/versions/v37.0.0/react-native/inputaccessoryview.md
+++ b/docs/pages/versions/v37.0.0/react-native/inputaccessoryview.md
@@ -53,7 +53,7 @@ This component can also be used to create sticky text inputs (text inputs which 
 
 | Type                | Required |
 | ------------------- | -------- |
-| [color](../colors/) | No       |
+| [color](colors.md) | No       |
 
 ---
 
@@ -71,7 +71,7 @@ An ID which is used to associate this `InputAccessoryView` to specified TextInpu
 
 | Type                          | Required |
 | ----------------------------- | -------- |
-| [style](../view-style-props/) | No       |
+| [style](view-style-props.md) | No       |
 
 # Known issues
 

--- a/docs/pages/versions/v37.0.0/react-native/javascript-environment.md
+++ b/docs/pages/versions/v37.0.0/react-native/javascript-environment.md
@@ -66,8 +66,8 @@ Browser
 
 - [console.{log, warn, error, info, trace, table, group, groupEnd}](https://developer.chrome.com/devtools/docs/console-api)
 - [CommonJS require](https://nodejs.org/docs/latest/api/modules.html)
-- [XMLHttpRequest, fetch](../network/#content)
-- [{set, clear}{Timeout, Interval, Immediate}, {request, cancel}AnimationFrame](../timers/#content)
+- [XMLHttpRequest, fetch](network.md)
+- [{set, clear}{Timeout, Interval, Immediate}, {request, cancel}AnimationFrame](timers.md)
 
 ES6
 

--- a/docs/pages/versions/v37.0.0/react-native/keyboardavoidingview.md
+++ b/docs/pages/versions/v37.0.0/react-native/keyboardavoidingview.md
@@ -25,7 +25,7 @@ import { KeyboardAvoidingView } from 'react-native';
 
 ## Props
 
-Inherits [View Props](../view/#props).
+Inherits [View Props](view.md#props).
 
 ### `behavior`
 

--- a/docs/pages/versions/v37.0.0/react-native/layoutanimation.md
+++ b/docs/pages/versions/v37.0.0/react-native/layoutanimation.md
@@ -82,7 +82,7 @@ Schedules an animation to happen on the next layout.
 | config            | object   | Yes      | See config description below.                              |
 | onAnimationDidEnd | function | No       | Called when the animation finished. Only supported on iOS. |
 
-The `config` parameter is an object with the keys below. [`create`](../layoutanimation/#create) returns a valid object for `config`, and the [`Presets`](../layoutanimation/#presets) objects can also all be passed as the `config`.
+The `config` parameter is an object with the keys below. [`create`](layoutanimation.md#create) returns a valid object for `config`, and the [`Presets`](layoutanimation.md#presets) objects can also all be passed as the `config`.
 
 - `duration` in milliseconds
 - `create`, optional config for animating in new views
@@ -91,8 +91,8 @@ The `config` parameter is an object with the keys below. [`create`](../layoutani
 
 The config that's passed to `create`, `update`, or `delete` has the following keys:
 
-- `type`, the [animation type](../layoutanimation/#types) to use
-- `property`, the [layout property](../layoutanimation/#properties) to animate (optional, but recommended for `create` and `delete`)
+- `type`, the [animation type](layoutanimation.md#types) to use
+- `property`, the [layout property](layoutanimation.md#properties) to animate (optional, but recommended for `create` and `delete`)
 - `springDamping` (number, optional and only for use with `type: Type.spring`)
 - `initialVelocity` (number, optional)
 - `delay` (number, optional)
@@ -108,7 +108,7 @@ static create(duration, type, creationProp)
 
 ```
 
-Helper that creates an object (with `create`, `update`, and `delete` fields) to pass into [`configureNext`](../layoutanimation/#configurenext). The `type` parameter is an [animation type](../layoutanimation/#types), and the `creationProp` parameter is a [layout property](../layoutanimation/#properties).
+Helper that creates an object (with `create`, `update`, and `delete` fields) to pass into [`configureNext`](layoutanimation.md#configurenext). The `type` parameter is an [animation type](layoutanimation.md#types), and the `creationProp` parameter is a [layout property](layoutanimation.md#properties).
 
 Example usage:
 
@@ -122,7 +122,7 @@ LayoutAnimation.configureNext(
 
 ### Types
 
-An enumeration of animation types to be used in the [`create`](../layoutanimation/#create) method, or in the `create`/`update`/`delete` configs for [`configureNext`](../layoutanimation/#configurenext). (example usage: `LayoutAnimation.Types.easeIn`)
+An enumeration of animation types to be used in the [`create`](layoutanimation.md#create) method, or in the `create`/`update`/`delete` configs for [`configureNext`](layoutanimation.md#configurenext). (example usage: `LayoutAnimation.Types.easeIn`)
 
 | Types         |
 | ------------- |
@@ -137,7 +137,7 @@ An enumeration of animation types to be used in the [`create`](../layoutanimatio
 
 ### Properties
 
-An enumeration of layout properties to be animated to be used in the [`create`](../layoutanimation/#create) method, or in the `create`/`update`/`delete` configs for [`configureNext`](../layoutanimation/#configurenext). (example usage: `LayoutAnimation.Properties.opacity`)
+An enumeration of layout properties to be animated to be used in the [`create`](layoutanimation.md#create) method, or in the `create`/`update`/`delete` configs for [`configureNext`](layoutanimation.md#configurenext). (example usage: `LayoutAnimation.Properties.opacity`)
 
 | Properties |
 | ---------- |
@@ -150,7 +150,7 @@ An enumeration of layout properties to be animated to be used in the [`create`](
 
 ### Presets
 
-A set of predefined animation configs to pass into [`configureNext`](../layoutanimation/#configurenext).
+A set of predefined animation configs to pass into [`configureNext`](layoutanimation.md#configurenext).
 
 | Presets       | Value                                                                                                                                                                 |
 | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/pages/versions/v37.0.0/react-native/modal.md
+++ b/docs/pages/versions/v37.0.0/react-native/modal.md
@@ -55,7 +55,7 @@ export default function App() {
 
 ### `animated`
 
-> **Deprecated.** Use the [`animationType`](../modal/#animationtype) prop instead.
+> **Deprecated.** Use the [`animationType`](modal.md#animationtype) prop instead.
 
 ---
 

--- a/docs/pages/versions/v37.0.0/react-native/panresponder.md
+++ b/docs/pages/versions/v37.0.0/react-native/panresponder.md
@@ -7,7 +7,7 @@ title: PanResponder
 
 By default, `PanResponder` holds an `InteractionManager` handle to block long-running JS events from interrupting active gestures.
 
-It provides a predictable wrapper of the responder handlers provided by the [gesture responder system](../gesture-responder-system/). For each handler, it provides a new `gestureState` object alongside the native event object:
+It provides a predictable wrapper of the responder handlers provided by the [gesture responder system](gesture-responder-system.md). For each handler, it provides a new `gestureState` object alongside the native event object:
 
 ```javascript
 onPanResponderMove: (event, gestureState) => {};

--- a/docs/pages/versions/v37.0.0/react-native/picker.md
+++ b/docs/pages/versions/v37.0.0/react-native/picker.md
@@ -21,7 +21,7 @@ Renders the native picker component on Android and iOS. Example:
 
 ## Props
 
-Inherits [View Props](../view/#props).
+Inherits [View Props](view.md#props).
 
 ### `onValueChange`
 
@@ -103,4 +103,4 @@ Style to apply to each of the item labels.
 
 | Type                                | Required | Platform |
 | ----------------------------------- | -------- | -------- |
-| [text styles](../text-style-props/) | No       | iOS      |
+| [text styles](text-style-props.md) | No       | iOS      |

--- a/docs/pages/versions/v37.0.0/react-native/pickerios.md
+++ b/docs/pages/versions/v37.0.0/react-native/pickerios.md
@@ -3,7 +3,7 @@ id: pickerios
 title: PickerIOS
 ---
 
-> **Deprecated.** Use [Picker](../picker/) instead.
+> **Deprecated.** Use [Picker](picker.md) instead.
 
 ---
 
@@ -11,13 +11,13 @@ title: PickerIOS
 
 ## Props
 
-Inherits [View Props](../view/#props).
+Inherits [View Props](view.md#props).
 
 ### `itemStyle`
 
 | Type                                | Required |
 | ----------------------------------- | -------- |
-| [text styles](../text-style-props/) | No       |
+| [text styles](text-style-props.md) | No       |
 
 ---
 

--- a/docs/pages/versions/v37.0.0/react-native/platform-specific-code.md
+++ b/docs/pages/versions/v37.0.0/react-native/platform-specific-code.md
@@ -7,8 +7,8 @@ When building a cross-platform app, you'll want to re-use as much code as possib
 
 React Native provides two ways to organize your code and separate it by platform:
 
-- Using the [`Platform` module](../platform-specific-code/#platform-module).
-- Using [platform-specific file extensions](../platform-specific-code/#platform-specific-extensions).
+- Using the [`Platform` module](platform-specific-code.md#platform-module).
+- Using [platform-specific file extensions](platform-specific-code.md#platform-specific-extensions).
 
 Certain components may have properties that work on one platform only. All of these props are annotated with `@platform` and have a small badge next to them on the website.
 

--- a/docs/pages/versions/v37.0.0/react-native/progressbarandroid.md
+++ b/docs/pages/versions/v37.0.0/react-native/progressbarandroid.md
@@ -39,7 +39,7 @@ const styles = StyleSheet.create({
 
 ## Props
 
-Inherits [View Props](../view/#props).
+Inherits [View Props](view.md#props).
 
 ### `animating`
 
@@ -57,7 +57,7 @@ Color of the progress bar.
 
 | Type                | Required |
 | ------------------- | -------- |
-| [color](../colors/) | No       |
+| [color](colors.md) | No       |
 
 ---
 

--- a/docs/pages/versions/v37.0.0/react-native/progressviewios.md
+++ b/docs/pages/versions/v37.0.0/react-native/progressviewios.md
@@ -11,7 +11,7 @@ Uses `ProgressViewIOS` to render a UIProgressView on iOS.
 
 ## Props
 
-Inherits [View Props](../view/#props).
+Inherits [View Props](view.md#props).
 
 ### `progress`
 

--- a/docs/pages/versions/v37.0.0/react-native/props.md
+++ b/docs/pages/versions/v37.0.0/react-native/props.md
@@ -54,6 +54,6 @@ export default class LotsOfGreetings extends Component {
 
 Using `name` as a prop lets us customize the `Greeting` component, so we can reuse that component for each of our greetings. This example also uses the `Greeting` component in JSX, similar to the built-in components. The power to do this is what makes React so cool - if you find yourself wishing that you had a different set of UI primitives to work with, you can invent new ones.
 
-The other new thing going on here is the [`View`](../view/) component. A [`View`](../view/) is useful as a container for other components, to help control style and layout.
+The other new thing going on here is the [`View`](view.md) component. A [`View`](view.md) is useful as a container for other components, to help control style and layout.
 
-With `props` and the basic [`Text`](../text/), [`Image`](../image/), and [`View`](../view/) components, you can build a wide variety of static screens. To learn how to make your app change over time, you need to [learn about State](../state/).
+With `props` and the basic [`Text`](text.md), [`Image`](image.md), and [`View`](view.md) components, you can build a wide variety of static screens. To learn how to make your app change over time, you need to [learn about State](state.md).

--- a/docs/pages/versions/v37.0.0/react-native/refreshcontrol.md
+++ b/docs/pages/versions/v37.0.0/react-native/refreshcontrol.md
@@ -60,7 +60,7 @@ const styles = StyleSheet.create({
 
 ## Props
 
-Inherits [View Props](../view/#props).
+Inherits [View Props](view.md#props).
 
 ### `refreshing`
 
@@ -88,7 +88,7 @@ The colors (at least one) that will be used to draw the refresh indicator.
 
 | Type                         | Required | Platform |
 | ---------------------------- | -------- | -------- |
-| array of [color](../colors/) | No       | Android  |
+| array of [color](colors.md) | No       | Android  |
 
 ---
 
@@ -108,7 +108,7 @@ The background color of the refresh indicator.
 
 | Type                | Required | Platform |
 | ------------------- | -------- | -------- |
-| [color](../colors/) | No       | Android  |
+| [color](colors.md) | No       | Android  |
 
 ---
 
@@ -138,7 +138,7 @@ The color of the refresh indicator.
 
 | Type                | Required | Platform |
 | ------------------- | -------- | -------- |
-| [color](../colors/) | No       | iOS      |
+| [color](colors.md) | No       | iOS      |
 
 ---
 
@@ -158,4 +158,4 @@ Title color.
 
 | Type                | Required | Platform |
 | ------------------- | -------- | -------- |
-| [color](../colors/) | No       | iOS      |
+| [color](colors.md) | No       | iOS      |

--- a/docs/pages/versions/v37.0.0/react-native/safeareaview.md
+++ b/docs/pages/versions/v37.0.0/react-native/safeareaview.md
@@ -36,7 +36,7 @@ const styles = StyleSheet.create({
 
 ## Props
 
-Inherits [View Props](../view/#props).
+Inherits [View Props](view.md#props).
 
 ### `emulateUnlessSupported`
 

--- a/docs/pages/versions/v37.0.0/react-native/scrollview.md
+++ b/docs/pages/versions/v37.0.0/react-native/scrollview.md
@@ -9,7 +9,7 @@ Keep in mind that ScrollViews must have a bounded height in order to work, since
 
 Doesn't yet support other contained responders from blocking this scroll view from becoming the responder.
 
-`<ScrollView>` vs [`<FlatList>`](../flatlist/) - which one to use?
+`<ScrollView>` vs [`<FlatList>`](flatlist.md) - which one to use?
 
 `ScrollView` renders all its react child components at once, but this has a performance downside.
 
@@ -64,7 +64,7 @@ const styles = StyleSheet.create({
 
 ## Props
 
-Inherits [View Props](../view/#props).
+Inherits [View Props](view.md#props).
 
 ### `alwaysBounceHorizontal`
 
@@ -240,7 +240,7 @@ Sometimes a scrollview takes up more space than its content fills. When this is 
 
 | Type                | Required | Platform |
 | ------------------- | -------- | -------- |
-| [color](../colors/) | No       | Android  |
+| [color](colors.md) | No       | Android  |
 
 ---
 
@@ -483,7 +483,7 @@ When true, ScrollView allows use of pinch gestures to zoom in and out. The defau
 
 A RefreshControl component, used to provide pull-to-refresh functionality for the ScrollView. Only works for vertical ScrollViews (`horizontal` prop must be `false`).
 
-See [RefreshControl](../refreshcontrol/).
+See [RefreshControl](refreshcontrol.md).
 
 | Type    | Required |
 | ------- | -------- |

--- a/docs/pages/versions/v37.0.0/react-native/sectionlist.md
+++ b/docs/pages/versions/v37.0.0/react-native/sectionlist.md
@@ -16,7 +16,7 @@ A performant interface for rendering sectioned lists, supporting the most handy 
 - Pull to Refresh.
 - Scroll loading.
 
-If you don't need section support and want a simpler interface, use [`<FlatList>`](../flatlist/).
+If you don't need section support and want a simpler interface, use [`<FlatList>`](flatlist.md).
 
 ### Example
 
@@ -86,7 +86,7 @@ const styles = StyleSheet.create({
 });
 ```
 
-This is a convenience wrapper around [`<VirtualizedList>`](../virtualizedlist/), and thus inherits its props (as well as those of [`<ScrollView>`](../scrollview/) that aren't explicitly listed here, along with the following caveats:
+This is a convenience wrapper around [`<VirtualizedList>`](virtualizedlist.md), and thus inherits its props (as well as those of [`<ScrollView>`](scrollview.md) that aren't explicitly listed here, along with the following caveats:
 
 - Internal state is not preserved when content scrolls out of the render window. Make sure all your data is captured in the item data or external stores like Flux, Redux, or Relay.
 - This is a `PureComponent` which means that it will not re-render if `props` remain shallow-equal. Make sure that everything your `renderItem` function depends on is passed as a prop (e.g. `extraData`) that is not `===` after updates, otherwise your UI may not update on changes. This includes the `data` prop and parent component state.
@@ -95,44 +95,44 @@ This is a convenience wrapper around [`<VirtualizedList>`](../virtualizedlist/),
 
 ### Props
 
-- [`ScrollView` props...](../scrollview/#props)
+- [`ScrollView` props...](scrollview.md#props)
 
 Required props:
 
-- [`renderItem`](../sectionlist/#renderitem)
-- [`sections`](../sectionlist/#sections)
+- [`renderItem`](sectionlist.md#renderitem)
+- [`sections`](sectionlist.md#sections)
 
 Optional props:
 
-- [`extraData`](../sectionlist/#extradata)
-- [`initialNumToRender`](../sectionlist/#initialnumtorender)
-- [`inverted`](../sectionlist/#inverted)
-- [`ItemSeparatorComponent`](../sectionlist/#itemseparatorcomponent)
-- [`keyExtractor`](../sectionlist/#keyextractor)
-- [`legacyImplementation`](../sectionlist/#legacyimplementation)
-- [`ListEmptyComponent`](../sectionlist/#listemptycomponent)
-- [`ListFooterComponent`](../sectionlist/#listfootercomponent)
-- [`ListHeaderComponent`](../sectionlist/#listheadercomponent)
-- [`onEndReached`](../sectionlist/#onendreached)
-- [`onEndReachedThreshold`](../sectionlist/#onendreachedthreshold)
-- [`onRefresh`](../sectionlist/#onrefresh)
-- [`onViewableItemsChanged`](../sectionlist/#onviewableitemschanged)
-- [`refreshing`](../sectionlist/#refreshing)
-- [`removeClippedSubviews`](../sectionlist/#removeclippedsubviews)
-- [`renderSectionFooter`](../sectionlist/#rendersectionfooter)
-- [`renderSectionHeader`](../sectionlist/#rendersectionheader)
-- [`SectionSeparatorComponent`](../sectionlist/#sectionseparatorcomponent)
-- [`stickySectionHeadersEnabled`](../sectionlist/#stickysectionheadersenabled)
+- [`extraData`](sectionlist.md#extradata)
+- [`initialNumToRender`](sectionlist.md#initialnumtorender)
+- [`inverted`](sectionlist.md#inverted)
+- [`ItemSeparatorComponent`](sectionlist.md#itemseparatorcomponent)
+- [`keyExtractor`](sectionlist.md#keyextractor)
+- [`legacyImplementation`](sectionlist.md#legacyimplementation)
+- [`ListEmptyComponent`](sectionlist.md#listemptycomponent)
+- [`ListFooterComponent`](sectionlist.md#listfootercomponent)
+- [`ListHeaderComponent`](sectionlist.md#listheadercomponent)
+- [`onEndReached`](sectionlist.md#onendreached)
+- [`onEndReachedThreshold`](sectionlist.md#onendreachedthreshold)
+- [`onRefresh`](sectionlist.md#onrefresh)
+- [`onViewableItemsChanged`](sectionlist.md#onviewableitemschanged)
+- [`refreshing`](sectionlist.md#refreshing)
+- [`removeClippedSubviews`](sectionlist.md#removeclippedsubviews)
+- [`renderSectionFooter`](sectionlist.md#rendersectionfooter)
+- [`renderSectionHeader`](sectionlist.md#rendersectionheader)
+- [`SectionSeparatorComponent`](sectionlist.md#sectionseparatorcomponent)
+- [`stickySectionHeadersEnabled`](sectionlist.md#stickysectionheadersenabled)
 
 ### Methods
 
-- [`flashScrollIndicators`](../sectionlist/#flashscrollindicators)
-- [`recordInteraction`](../sectionlist/#recordinteraction)
-- [`scrollToLocation`](../sectionlist/#scrolltolocation)
+- [`flashScrollIndicators`](sectionlist.md#flashscrollindicators)
+- [`recordInteraction`](sectionlist.md#recordinteraction)
+- [`scrollToLocation`](sectionlist.md#scrolltolocation)
 
 ### Type Definitions
 
-- [`Section`](../sectionlist/#section)
+- [`Section`](sectionlist.md#section)
 
 ---
 
@@ -164,11 +164,11 @@ The render function will be passed an object with the following keys:
 
 ### `sections`
 
-The actual data to render, akin to the `data` prop in [`FlatList`](../flatlist/).
+The actual data to render, akin to the `data` prop in [`FlatList`](flatlist.md).
 
 | Type                                         | Required |
 | -------------------------------------------- | -------- |
-| array of [Section](../sectionlist/#section)s | Yes      |
+| array of [Section](sectionlist.md#section)s | Yes      |
 
 ---
 
@@ -441,8 +441,8 @@ An object that identifies the data to be rendered for a given section.
 
 | Name                     | Type                         | Description                                                                                                                                                             |
 | ------------------------ | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| data                     | array                        | The data for rendering items in this section. Array of objects, much like [`FlatList`'s data prop](../flatlist/#data).                                                  |
+| data                     | array                        | The data for rendering items in this section. Array of objects, much like [`FlatList`'s data prop](flatlist.md#data).                                                  |
 | [key]                    | string                       | Optional key to keep track of section re-ordering. If you don't plan on re-ordering sections, the array index will be used by default.                                  |
-| [renderItem]             | function                     | Optionally define an arbitrary item renderer for this section, overriding the default [`renderItem`](../sectionlist/#renderitem) for the list.                          |
-| [ItemSeparatorComponent] | component, function, element | Optionally define an arbitrary item separator for this section, overriding the default [`ItemSeparatorComponent`](../sectionlist/#itemseparatorcomponent) for the list. |
-| [keyExtractor]           | function                     | Optionally define an arbitrary key extractor for this section, overriding the default [`keyExtractor`](../sectionlist/#keyextractor).                                   |
+| [renderItem]             | function                     | Optionally define an arbitrary item renderer for this section, overriding the default [`renderItem`](sectionlist.md#renderitem) for the list.                          |
+| [ItemSeparatorComponent] | component, function, element | Optionally define an arbitrary item separator for this section, overriding the default [`ItemSeparatorComponent`](sectionlist.md#itemseparatorcomponent) for the list. |
+| [keyExtractor]           | function                     | Optionally define an arbitrary key extractor for this section, overriding the default [`keyExtractor`](sectionlist.md#keyextractor).                                   |

--- a/docs/pages/versions/v37.0.0/react-native/segmentedcontrolios.md
+++ b/docs/pages/versions/v37.0.0/react-native/segmentedcontrolios.md
@@ -29,7 +29,7 @@ The selected index can be changed on the fly by assigning the selectedIndex prop
 
 ## Props
 
-Inherits [View Props](../view/#props).
+Inherits [View Props](view.md#props).
 
 ### `enabled`
 

--- a/docs/pages/versions/v37.0.0/react-native/shadow-props.md
+++ b/docs/pages/versions/v37.0.0/react-native/shadow-props.md
@@ -13,7 +13,7 @@ Sets the drop shadow color
 
 | Type                | Required | Platform |
 | ------------------- | -------- | -------- |
-| [color](../colors/) | No       | iOS      |
+| [color](colors.md) | No       | iOS      |
 
 ---
 

--- a/docs/pages/versions/v37.0.0/react-native/slider.md
+++ b/docs/pages/versions/v37.0.0/react-native/slider.md
@@ -11,7 +11,7 @@ A component used to select a single value from a range of values.
 
 ## Props
 
-Inherits [View Props](../view/#props).
+Inherits [View Props](view.md#props).
 
 ### `style`
 
@@ -49,7 +49,7 @@ The color used for the track to the left of the button. Overrides the default bl
 
 | Type                | Required |
 | ------------------- | -------- |
-| [color](../colors/) | No       |
+| [color](colors.md) | No       |
 
 ---
 
@@ -99,7 +99,7 @@ The color used for the track to the right of the button. Overrides the default g
 
 | Type                | Required |
 | ------------------- | -------- |
-| [color](../colors/) | No       |
+| [color](colors.md) | No       |
 
 ---
 
@@ -131,7 +131,7 @@ The color used to tint the default thumb images on iOS, or the color of the fore
 
 | Type                | Required |
 | ------------------- | -------- |
-| [color](../colors/) | No       |
+| [color](colors.md) | No       |
 
 ---
 

--- a/docs/pages/versions/v37.0.0/react-native/state.md
+++ b/docs/pages/versions/v37.0.0/react-native/state.md
@@ -52,4 +52,4 @@ In a real application, you probably won't be setting state with a timer. You mig
 
 When setState is called, BlinkApp will re-render its Component. By calling setState within the Timer, the component will re-render every time the Timer ticks.
 
-State works the same way as it does in React, so for more details on handling state, you can look at the [React.Component API](https://reactjs.org/docs/react-component.html#setstate). At this point, you may have noticed that most of our examples use the default text color. To customize the text color, you will have to [learn about Style](../style/).
+State works the same way as it does in React, so for more details on handling state, you can look at the [React.Component API](https://reactjs.org/docs/react-component.html#setstate). At this point, you may have noticed that most of our examples use the default text color. To customize the text color, you will have to [learn about Style](style.md).

--- a/docs/pages/versions/v37.0.0/react-native/statusbar.md
+++ b/docs/pages/versions/v37.0.0/react-native/statusbar.md
@@ -49,7 +49,7 @@ The background color of the status bar.
 
 | Type                | Required | Platform |
 | ------------------- | -------- | -------- |
-| [color](../colors/) | No       | Android  |
+| [color](colors.md) | No       | Android  |
 
 ---
 
@@ -191,7 +191,7 @@ Set the status bar style
 
 | Name     | Type                                           | Required | Description               |
 | -------- | ---------------------------------------------- | -------- | ------------------------- |
-| style    | [StatusBarStyle](../statusbar/#statusbarstyle) | Yes      | Status bar style to set   |
+| style    | [StatusBarStyle](statusbar.md#statusbarstyle) | Yes      | Status bar style to set   |
 | animated | boolean                                        | No       | Animate the style change. |
 
 ---
@@ -211,7 +211,7 @@ Show or hide the status bar
 | Name      | Type                                                   | Required | Description                                                      |
 | --------- | ------------------------------------------------------ | -------- | ---------------------------------------------------------------- |
 | hidden    | boolean                                                | Yes      | Hide the status bar.                                             |
-| animation | [StatusBarAnimation](../statusbar/#statusbaranimation) | No       | Optional animation when changing the status bar hidden property. |
+| animation | [StatusBarAnimation](statusbar.md#statusbaranimation) | No       | Optional animation when changing the status bar hidden property. |
 
 ---
 

--- a/docs/pages/versions/v37.0.0/react-native/style.md
+++ b/docs/pages/versions/v37.0.0/react-native/style.md
@@ -3,7 +3,7 @@ id: style
 title: Style
 ---
 
-With React Native, you style your application using JavaScript. All of the core components accept a prop named `style`. The style names and [values](../colors/) usually match how CSS works on the web, except names are written using camel casing, e.g. `backgroundColor` rather than `background-color`.
+With React Native, you style your application using JavaScript. All of the core components accept a prop named `style`. The style names and [values](colors.md) usually match how CSS works on the web, except names are written using camel casing, e.g. `backgroundColor` rather than `background-color`.
 
 The `style` prop can be a plain old JavaScript object. That's what we usually use for example code. You can also pass an array of styles - the last style in the array has precedence, so you can use this to inherit styles.
 
@@ -40,6 +40,6 @@ export default class LotsOfStyles extends Component {
 
 One common pattern is to make your component accept a `style` prop which in turn is used to style subcomponents. You can use this to make styles "cascade" the way they do in CSS.
 
-There are a lot more ways to customize text style. Check out the [Text component reference](../text/) for a complete list.
+There are a lot more ways to customize text style. Check out the [Text component reference](text.md) for a complete list.
 
-Now you can make your text beautiful. The next step in becoming a style master is to [learn how to control component size](../height-and-width/).
+Now you can make your text beautiful. The next step in becoming a style master is to [learn how to control component size](height-and-width.md).

--- a/docs/pages/versions/v37.0.0/react-native/switch.md
+++ b/docs/pages/versions/v37.0.0/react-native/switch.md
@@ -32,7 +32,7 @@ export default function App() {
 
 ## Props
 
-Inherits [View Props](../view/#props).
+Inherits [View Props](view.md#props).
 
 ### `disabled`
 
@@ -50,7 +50,7 @@ On iOS, custom color for the background. This background color can be seen eithe
 
 | Type                | Required |
 | ------------------- | -------- |
-| [color](../colors/) | No       |
+| [color](colors.md) | No       |
 
 ---
 
@@ -80,7 +80,7 @@ Color of the foreground switch grip. If this is set on iOS, the switch grip will
 
 | Type                | Required |
 | ------------------- | -------- |
-| [color](../colors/) | No       |
+| [color](colors.md) | No       |
 
 ---
 
@@ -88,11 +88,11 @@ Color of the foreground switch grip. If this is set on iOS, the switch grip will
 
 Custom colors for the switch track.
 
-_iOS_: When the switch value is false, the track shrinks into the border. If you want to change the color of the background exposed by the shrunken track, use [`ios_backgroundColor`](../switch/#ios_backgroundColor).
+_iOS_: When the switch value is false, the track shrinks into the border. If you want to change the color of the background exposed by the shrunken track, use [`ios_backgroundColor`](switch.md#ios_backgroundColor).
 
 | Type                                                            | Required |
 | --------------------------------------------------------------- | -------- |
-| object: {false: [color](../colors/), true: [color](../colors/)} | No       |
+| object: {false: [color](colors.md), true: [color](colors.md)} | No       |
 
 ---
 

--- a/docs/pages/versions/v37.0.0/react-native/text-style-props.md
+++ b/docs/pages/versions/v37.0.0/react-native/text-style-props.md
@@ -19,7 +19,7 @@ title: Text Style Props
 
 | Type                | Required |
 | ------------------- | -------- |
-| [color](../colors/) | No       |
+| [color](colors.md) | No       |
 
 ---
 
@@ -79,7 +79,7 @@ Specifies text alignment. The value 'justify' is only supported on iOS and fallb
 
 | Type                | Required |
 | ------------------- | -------- |
-| [color](../colors/) | No       |
+| [color](colors.md) | No       |
 
 ---
 
@@ -137,7 +137,7 @@ Set to `false` to remove extra font padding intended to make space for certain a
 
 | Type                | Required | Platform |
 | ------------------- | -------- | -------- |
-| [color](../colors/) | No       | iOS      |
+| [color](colors.md) | No       | iOS      |
 
 ---
 

--- a/docs/pages/versions/v37.0.0/react-native/text.md
+++ b/docs/pages/versions/v37.0.0/react-native/text.md
@@ -226,7 +226,7 @@ Possible values for `AccessibilityRole` is one of:
 - `'imagebutton'` - The element has the role of both an image and also a button.
 - `'adjustable'` - The element allows adjustment over a range of values.
 
-On iOS, these roles map to corresponding Accessibility Traits. Image button has the same functionality as if the trait was set to both 'image' and 'button'. See the [Accessibility guide](../accessibility/#accessibilitytraits-ios) for more information.
+On iOS, these roles map to corresponding Accessibility Traits. Image button has the same functionality as if the trait was set to both 'image' and 'button'. See the [Accessibility guide](accessibility.md#accessibilityrole-ios-android) for more information.
 
 On Android, these roles have similar functionality on TalkBack as adding Accessibility Traits does on Voiceover in iOS
 
@@ -257,7 +257,7 @@ Possible values for `AccessibilityState` are:
 
 When set to `true`, indicates that the view is an accessibility element. The default value for a `Text` element is `true`.
 
-See the [Accessibility guide](../accessibility/#accessible-ios-android) for more information.
+See the [Accessibility guide](accessibility.md#accessible-ios-android) for more information.
 
 | Type | Required |
 | ---- | -------- |
@@ -530,7 +530,7 @@ The highlight color of the text.
 
 | Type                | Required | Platform |
 | ------------------- | -------- | -------- |
-| [color](../colors/) | No       | Android  |
+| [color](colors.md) | No       | Android  |
 
 ---
 
@@ -540,11 +540,11 @@ The highlight color of the text.
 | ----- | -------- |
 | style | No       |
 
-- [View Style Props...](../view-style-props/#style)
+- [View Style Props...](view-style-props.md#props)
 
 - **`textShadowOffset`**: object: {width: number,height: number}
 
-- **`color`**: [color](../colors/)
+- **`color`**: [color](colors.md)
 
 - **`fontSize`**: number
 
@@ -562,7 +562,7 @@ The highlight color of the text.
 
 - **`textDecorationLine`**: enum('none', 'underline', 'line-through', 'underline line-through')
 
-- **`textShadowColor`**: [color](../colors/)
+- **`textShadowColor`**: [color](colors.md)
 
 - **`fontFamily`**: string
 
@@ -584,7 +584,7 @@ The highlight color of the text.
 
   Android: Only supported since Android 5.0 - older versions will ignore this attribute. Please note that additional space will be added _around_ the glyphs (half on each side), which differs from the iOS rendering. It is possible to emulate the iOS rendering by using layout attributes, e.g. negative margins, as appropriate for your situation.
 
-* **`textDecorationColor`**: [color](../colors/) (_iOS_)
+* **`textDecorationColor`**: [color](colors.md) (_iOS_)
 
 * **`textDecorationStyle`**: enum('solid', 'double', 'dotted', 'dashed') (_iOS_)
 

--- a/docs/pages/versions/v37.0.0/react-native/textinput.md
+++ b/docs/pages/versions/v37.0.0/react-native/textinput.md
@@ -75,7 +75,7 @@ Note that on Android performing text selection in input can change app's activit
 
 ## Props
 
-Inherits [View Props](../view/#props).
+Inherits [View Props](view.md#props).
 
 ### `allowFontScaling`
 
@@ -301,7 +301,7 @@ Padding between the inline image, if any, and the text input itself.
 
 ### `inputAccessoryViewID`
 
-An optional identifier which links a custom [InputAccessoryView](../inputaccessoryview/) to this text input. The InputAccessoryView is rendered above the keyboard when this text input is focused.
+An optional identifier which links a custom [InputAccessoryView](inputaccessoryview.md) to this text input. The InputAccessoryView is rendered above the keyboard when this text input is focused.
 
 | Type   | Required | Platform |
 | ------ | -------- | -------- |
@@ -539,7 +539,7 @@ The text color of the placeholder string.
 
 | Type                | Required |
 | ------------------- | -------- |
-| [color](../colors/) | No       |
+| [color](colors.md) | No       |
 
 ---
 
@@ -637,7 +637,7 @@ The highlight and cursor color of the text input.
 
 | Type                | Required |
 | ------------------- | -------- |
-| [color](../colors/) | No       |
+| [color](colors.md) | No       |
 
 ---
 
@@ -751,11 +751,11 @@ Note that not all Text styles are supported, an incomplete list of what is not s
 
 see [Issue#7070](https://github.com/facebook/react-native/issues/7070) for more detail.
 
-[Styles](../style/)
+[Styles](style.md)
 
 | Type                   | Required |
 | ---------------------- | -------- |
-| [Text](../text/#style) | No       |
+| [Text](text.md#style) | No       |
 
 ---
 
@@ -777,7 +777,7 @@ The color of the `TextInput` underline.
 
 | Type                | Required | Platform |
 | ------------------- | -------- | -------- |
-| [color](../colors/) | No       | Android  |
+| [color](colors.md) | No       | Android  |
 
 ---
 

--- a/docs/pages/versions/v37.0.0/react-native/toolbarandroid.md
+++ b/docs/pages/versions/v37.0.0/react-native/toolbarandroid.md
@@ -38,7 +38,7 @@ onActionSelected: function(position) {
 
 ## Props
 
-Inherits [View Props](../view/#props).
+Inherits [View Props](view.md#props).
 
 ### `actions`
 
@@ -161,7 +161,7 @@ Sets the toolbar subtitle color.
 
 | Type                | Required |
 | ------------------- | -------- |
-| [color](../colors/) | No       |
+| [color](colors.md) | No       |
 
 ---
 
@@ -191,4 +191,4 @@ Sets the toolbar title color.
 
 | Type                | Required |
 | ------------------- | -------- |
-| [color](../colors/) | No       |
+| [color](colors.md) | No       |

--- a/docs/pages/versions/v37.0.0/react-native/touchablehighlight.md
+++ b/docs/pages/versions/v37.0.0/react-native/touchablehighlight.md
@@ -81,21 +81,21 @@ const styles = StyleSheet.create({
 
 ### Props
 
-- [TouchableWithoutFeedback props...](../touchablewithoutfeedback/#props)
+- [TouchableWithoutFeedback props...](touchablewithoutfeedback.md#props)
 
-* [`activeOpacity`](../touchablehighlight/#activeopacity)
-* [`onHideUnderlay`](../touchablehighlight/#onhideunderlay)
-* [`onShowUnderlay`](../touchablehighlight/#onshowunderlay)
-* [`style`](../touchablehighlight/#style)
-* [`underlayColor`](../touchablehighlight/#underlaycolor)
-* [`hasTVPreferredFocus`](../touchablehighlight/#hastvpreferredfocus)
-* [`tvParallaxProperties`](../touchablehighlight/#tvparallaxproperties)
-* [`nextFocusDown`](../touchablehighlight/#nextFocusDown)
-* [`nextFocusForward`](../touchablehighlight/#nextFocusForward)
-* [`nextFocusLeft`](../touchablehighlight/#nextFocusLeft)
-* [`nextFocusRight`](../touchablehighlight/#nextFocusRight)
-* [`nextFocusUp`](../touchablehighlight/#nextFocusUp)
-* [`testOnly_pressed`](../touchablehighlight/#testOnly_pressed)
+* [`activeOpacity`](touchablehighlight.md#activeopacity)
+* [`onHideUnderlay`](touchablehighlight.md#onhideunderlay)
+* [`onShowUnderlay`](touchablehighlight.md#onshowunderlay)
+* [`style`](touchablehighlight.md#style)
+* [`underlayColor`](touchablehighlight.md#underlaycolor)
+* [`hasTVPreferredFocus`](touchablehighlight.md#hastvpreferredfocus)
+* [`tvParallaxProperties`](touchablehighlight.md#tvparallaxproperties)
+* [`nextFocusDown`](touchablehighlight.md#nextFocusDown)
+* [`nextFocusForward`](touchablehighlight.md#nextFocusForward)
+* [`nextFocusLeft`](touchablehighlight.md#nextFocusLeft)
+* [`nextFocusRight`](touchablehighlight.md#nextFocusRight)
+* [`nextFocusUp`](touchablehighlight.md#nextFocusUp)
+* [`testOnly_pressed`](touchablehighlight.md#testOnly_pressed)
 
 ---
 
@@ -103,7 +103,7 @@ const styles = StyleSheet.create({
 
 ## Props
 
-Inherits [TouchableWithoutFeedback Props](../touchablewithoutfeedback/#props).
+Inherits [TouchableWithoutFeedback Props](touchablewithoutfeedback.md#props).
 
 ### `activeOpacity`
 
@@ -149,7 +149,7 @@ The color of the underlay that will show through when the touch is active.
 
 | Type                | Required |
 | ------------------- | -------- |
-| [color](../colors/) | No       |
+| [color](colors.md) | No       |
 
 ---
 

--- a/docs/pages/versions/v37.0.0/react-native/touchablenativefeedback.md
+++ b/docs/pages/versions/v37.0.0/react-native/touchablenativefeedback.md
@@ -33,7 +33,7 @@ renderButton: function() {
 
 ## Props
 
-Inherits [TouchableWithoutFeedback Props](../touchablewithoutfeedback/#props).
+Inherits [TouchableWithoutFeedback Props](touchablewithoutfeedback.md#props).
 
 ### `background`
 

--- a/docs/pages/versions/v37.0.0/react-native/touchableopacity.md
+++ b/docs/pages/versions/v37.0.0/react-native/touchableopacity.md
@@ -83,7 +83,7 @@ const styles = StyleSheet.create({
 
 ## Props
 
-Inherits [TouchableWithoutFeedback Props](../touchablewithoutfeedback/#props).
+Inherits [TouchableWithoutFeedback Props](touchablewithoutfeedback.md#props).
 
 ### `style`
 

--- a/docs/pages/versions/v37.0.0/react-native/touchablewithoutfeedback.md
+++ b/docs/pages/versions/v37.0.0/react-native/touchablewithoutfeedback.md
@@ -111,7 +111,7 @@ An accessibility hint helps users understand what will happen when they perform 
 
 Describes the current state of a component to the user of an assistive technology.
 
-See the [Accessibility guide](../accessibility/#accessibilitystate-ios-android) for more information.
+See the [Accessibility guide](accessibility.md#accessibilitystate-ios-android) for more information.
 
 | Type                                                                                           | Required |
 | ---------------------------------------------------------------------------------------------- | -------- |
@@ -123,7 +123,7 @@ See the [Accessibility guide](../accessibility/#accessibilitystate-ios-android) 
 
 Accessibility actions allow an assistive technology to programmatically invoke the actions of a component. The `accessibilityActions` property should contain a list of action objects. Each action object should contain the field name and label.
 
-See the [Accessibility guide](../accessibility/#accessibility-actions) for more information.
+See the [Accessibility guide](accessibility.md#accessibility-actions) for more information.
 
 | Type  | Required |
 | ----- | -------- |
@@ -135,7 +135,7 @@ See the [Accessibility guide](../accessibility/#accessibility-actions) for more 
 
 Invoked when the user performs the accessibility actions. The only argument to this function is an event containing the name of the action to perform.
 
-See the [Accessibility guide](../accessibility/#accessibility-actions) for more information.
+See the [Accessibility guide](accessibility.md#accessibility-actions) for more information.
 
 | Type     | Required |
 | -------- | -------- |
@@ -147,7 +147,7 @@ See the [Accessibility guide](../accessibility/#accessibility-actions) for more 
 
 Represents the current value of a component. It can be a textual description of a component's value, or for range-based components, such as sliders and progress bars, it contains range information (minimum, current, and maximum).
 
-See the [Accessibility guide](../accessibility/#accessibilityvalue-ios-android) for more information.
+See the [Accessibility guide](accessibility.md#accessibilityvalue-ios-android) for more information.
 
 | Type                                                          | Required |
 | ------------------------------------------------------------- | -------- |

--- a/docs/pages/versions/v37.0.0/react-native/transforms.md
+++ b/docs/pages/versions/v37.0.0/react-native/transforms.md
@@ -9,7 +9,7 @@ title: Transforms
 
 ### `decomposedMatrix`
 
-> **Deprecated.** Use the [`transform`](../transforms/#transform) prop instead.
+> **Deprecated.** Use the [`transform`](transforms.md#transform) prop instead.
 
 | Type                     | Required |
 | ------------------------ | -------- |
@@ -61,7 +61,7 @@ The skew transformations require a string so that the transform may be expressed
 
 ### `transformMatrix`
 
-> **Deprecated.** Use the [`transform`](../transforms/#transform) prop instead.
+> **Deprecated.** Use the [`transform`](transforms.md#transform) prop instead.
 
 | Type                    | Required |
 | ----------------------- | -------- |

--- a/docs/pages/versions/v37.0.0/react-native/tutorial.md
+++ b/docs/pages/versions/v37.0.0/react-native/tutorial.md
@@ -42,4 +42,4 @@ So this code is defining `HelloWorldApp`, a new `Component`. When you're buildin
 
 ## This app doesn't do very much
 
-Good point. To make components do more interesting things, you need to [learn about Props](../props/).
+Good point. To make components do more interesting things, you need to [learn about Props](props.md).

--- a/docs/pages/versions/v37.0.0/react-native/typescript.md
+++ b/docs/pages/versions/v37.0.0/react-native/typescript.md
@@ -213,12 +213,12 @@ npm install --save-dev babel-plugin-module-resolver
 [ts]: https://www.typescriptlang.org/
 [flow]: https://flow.org
 [ts-template]: https://github.com/react-native-community/react-native-template-typescript
-[babel]: ../javascript-environment/#javascript-syntax-transformers
+[babel]: javascript-environment.md#javascript-syntax-transformers
 [babel-7-caveats]: https://babeljs.io/docs/en/next/babel-plugin-transform-typescript
 [cheats]: https://github.com/typescript-cheatsheets/react-typescript-cheatsheet#reacttypescript-cheatsheets
 [ts-handbook]: http://www.typescriptlang.org/docs/home.html
-[props]: ../props/
-[state]: ../state/
+[props]: props.md
+[state]: state.md
 [path-map]: https://www.typescriptlang.org/docs/handbook/module-resolution.html#path-mapping
 [bpmr]: https://github.com/tleunen/babel-plugin-module-resolver
 [expo]: https://expo.io

--- a/docs/pages/versions/v37.0.0/react-native/using-a-listview.md
+++ b/docs/pages/versions/v37.0.0/react-native/using-a-listview.md
@@ -3,9 +3,9 @@ id: using-a-listview
 title: Using List Views
 ---
 
-React Native provides a suite of components for presenting lists of data. Generally, you'll want to use either [FlatList](../flatlist/) or [SectionList](../sectionlist/).
+React Native provides a suite of components for presenting lists of data. Generally, you'll want to use either [FlatList](flatlist.md) or [SectionList](sectionlist.md).
 
-The `FlatList` component displays a scrolling list of changing, but similarly structured, data. `FlatList` works well for long lists of data, where the number of items might change over time. Unlike the more generic [`ScrollView`](../using-a-scrollview/), the `FlatList` only renders elements that are currently showing on the screen, not all the elements at once.
+The `FlatList` component displays a scrolling list of changing, but similarly structured, data. `FlatList` works well for long lists of data, where the number of items might change over time. Unlike the more generic [`ScrollView`](using-a-scrollview.md), the `FlatList` only renders elements that are currently showing on the screen, not all the elements at once.
 
 The `FlatList` component requires two props: `data` and `renderItem`. `data` is the source of information for the list. `renderItem` takes one item from the source and returns a formatted component to render.
 
@@ -52,7 +52,7 @@ const styles = StyleSheet.create({
 });
 ```
 
-If you want to render a set of data broken into logical sections, maybe with section headers, similar to `UITableView`s on iOS, then a [SectionList](../sectionlist/) is the way to go.
+If you want to render a set of data broken into logical sections, maybe with section headers, similar to `UITableView`s on iOS, then a [SectionList](sectionlist.md) is the way to go.
 
 ```javascript
 import React, { Component } from 'react';
@@ -100,4 +100,4 @@ const styles = StyleSheet.create({
 });
 ```
 
-One of the most common uses for a list view is displaying data that you fetch from a server. To do that, you will need to [learn about networking in React Native](../network/).
+One of the most common uses for a list view is displaying data that you fetch from a server. To do that, you will need to [learn about networking in React Native](network.md).

--- a/docs/pages/versions/v37.0.0/react-native/using-a-scrollview.md
+++ b/docs/pages/versions/v37.0.0/react-native/using-a-scrollview.md
@@ -3,7 +3,7 @@ id: using-a-scrollview
 title: Using a ScrollView
 ---
 
-The [ScrollView](../scrollview/) is a generic scrolling container that can contain multiple components and views. The scrollable items need not be homogeneous, and you can scroll both vertically and horizontally (by setting the `horizontal` property).
+The [ScrollView](scrollview.md) is a generic scrolling container that can contain multiple components and views. The scrollable items need not be homogeneous, and you can scroll both vertically and horizontally (by setting the `horizontal` property).
 
 This example creates a vertical `ScrollView` with both images and text mixed together.
 
@@ -206,4 +206,4 @@ ScrollViews can be configured to allow paging through views using swiping gestur
 
 On iOS a ScrollView with a single item can be used to allow the user to zoom content. Set up the `maximumZoomScale` and `minimumZoomScale` props and your user will be able to use pinch and expand gestures to zoom in and out.
 
-The ScrollView works best to present a small amount of things of a limited size. All the elements and views of a `ScrollView` are rendered, even if they are not currently shown on the screen. If you have a long list of more items than can fit on the screen, you should use a `FlatList` instead. So let's [learn about list views](../using-a-listview/) next.
+The ScrollView works best to present a small amount of things of a limited size. All the elements and views of a `ScrollView` are rendered, even if they are not currently shown on the screen. If you have a long list of more items than can fit on the screen, you should use a `FlatList` instead. So let's [learn about list views](using-a-listview.md) next.

--- a/docs/pages/versions/v37.0.0/react-native/view-style-props.md
+++ b/docs/pages/versions/v37.0.0/react-native/view-style-props.md
@@ -11,7 +11,7 @@ title: View Style Props
 
 | Type                | Required |
 | ------------------- | -------- |
-| [color](../colors/) | No       |
+| [color](colors.md) | No       |
 
 ---
 
@@ -27,7 +27,7 @@ title: View Style Props
 
 | Type                | Required |
 | ------------------- | -------- |
-| [color](../colors/) | No       |
+| [color](colors.md) | No       |
 
 ---
 
@@ -75,7 +75,7 @@ title: View Style Props
 
 | Type                | Required |
 | ------------------- | -------- |
-| [color](../colors/) | No       |
+| [color](colors.md) | No       |
 
 ---
 
@@ -83,7 +83,7 @@ title: View Style Props
 
 | Type                | Required |
 | ------------------- | -------- |
-| [color](../colors/) | No       |
+| [color](colors.md) | No       |
 
 ---
 
@@ -91,7 +91,7 @@ title: View Style Props
 
 | Type                | Required |
 | ------------------- | -------- |
-| [color](../colors/) | No       |
+| [color](colors.md) | No       |
 
 ---
 
@@ -117,7 +117,7 @@ If the rounded border is not visible, try applying `overflow: 'hidden'` as well.
 
 | Type                | Required |
 | ------------------- | -------- |
-| [color](../colors/) | No       |
+| [color](colors.md) | No       |
 
 ---
 
@@ -133,7 +133,7 @@ If the rounded border is not visible, try applying `overflow: 'hidden'` as well.
 
 | Type                | Required |
 | ------------------- | -------- |
-| [color](../colors/) | No       |
+| [color](colors.md) | No       |
 
 ---
 
@@ -149,7 +149,7 @@ If the rounded border is not visible, try applying `overflow: 'hidden'` as well.
 
 | Type                | Required |
 | ------------------- | -------- |
-| [color](../colors/) | No       |
+| [color](colors.md) | No       |
 
 ---
 

--- a/docs/pages/versions/v37.0.0/react-native/view.md
+++ b/docs/pages/versions/v37.0.0/react-native/view.md
@@ -3,7 +3,7 @@ id: view
 title: View
 ---
 
-The most fundamental component for building a UI, `View` is a container that supports layout with [flexbox](../flexbox/), [style](../style/), [some touch handling](../handling-touches/), and [accessibility](../accessibility/) controls. `View` maps directly to the native view equivalent on whatever platform React Native is running on, whether that is a `UIView`, `<div>`, `android.view`, etc.
+The most fundamental component for building a UI, `View` is a container that supports layout with [flexbox](flexbox.md), [style](style.md), [some touch handling](handling-touches.md), and [accessibility](accessibility.md) controls. `View` maps directly to the native view equivalent on whatever platform React Native is running on, whether that is a `UIView`, `<div>`, `android.view`, etc.
 
 `View` is designed to be nested inside other views and can have 0 to many children of any type.
 
@@ -28,7 +28,7 @@ class ViewBoxesWithColorAndText extends Component {
 }
 ```
 
-> `View`s are designed to be used with [`StyleSheet`](../style/) for clarity and performance, although inline styles are also supported.
+> `View`s are designed to be used with [`StyleSheet`](style.md) for clarity and performance, although inline styles are also supported.
 
 ### Synthetic Touch Events
 
@@ -137,7 +137,7 @@ An accessibility hint helps users understand what will happen when they perform 
 
 Describes the current state of a component to the user of an assistive technology.
 
-See the [Accessibility guide](../accessibility/#accessibilitystate-ios-android) for more information.
+See the [Accessibility guide](accessibility.md#accessibilitystate-ios-android) for more information.
 
 | Type                                                                                           | Required |
 | ---------------------------------------------------------------------------------------------- | -------- |
@@ -149,7 +149,7 @@ See the [Accessibility guide](../accessibility/#accessibilitystate-ios-android) 
 
 Represents the current value of a component. It can be a textual description of a component's value, or for range-based components, such as sliders and progress bars, it contains range information (minimum, current, and maximum).
 
-See the [Accessibility guide](../accessibility/#accessibilityvalue-ios-android) for more information.
+See the [Accessibility guide](accessibility.md#accessibilityvalue-ios-android) for more information.
 
 | Type                                                          | Required |
 | ------------------------------------------------------------- | -------- |
@@ -161,7 +161,7 @@ See the [Accessibility guide](../accessibility/#accessibilityvalue-ios-android) 
 
 Accessibility actions allow an assistive technology to programmatically invoke the actions of a component. The `accessibilityActions` property should contain a list of action objects. Each action object should contain the field name and label.
 
-See the [Accessibility guide](../accessibility/#accessibility-actions) for more information.
+See the [Accessibility guide](accessibility.md#accessibility-actions) for more information.
 
 | Type  | Required |
 | ----- | -------- |
@@ -173,7 +173,7 @@ See the [Accessibility guide](../accessibility/#accessibility-actions) for more 
 
 Invoked when the user performs the accessibility actions. The only argument to this function is an event containing the name of the action to perform.
 
-See the [Accessibility guide](../accessibility/#accessibility-actions) for more information.
+See the [Accessibility guide](accessibility.md#accessibility-actions) for more information.
 
 | Type     | Required |
 | -------- | -------- |
@@ -215,7 +215,7 @@ When `accessible` is `true`, the system will invoke this function when the user 
 
 A value indicating whether VoiceOver should ignore the elements within views that are siblings of the receiver. Default is `false`.
 
-See the [Accessibility guide](../accessibility/#accessibilityviewismodal-ios) for more information.
+See the [Accessibility guide](accessibility.md#accessibilityviewismodal-ios) for more information.
 
 | Type | Required | Platform |
 | ---- | -------- | -------- |
@@ -227,7 +227,7 @@ See the [Accessibility guide](../accessibility/#accessibilityviewismodal-ios) fo
 
 A value indicating whether the accessibility elements contained within this accessibility element are hidden. Default is `false`.
 
-See the [Accessibility guide](../accessibility/#accessibilityelementshidden-ios) for more information.
+See the [Accessibility guide](accessibility.md#accessibilityelementshidden-ios) for more information.
 
 | Type | Required | Platform |
 | ---- | -------- | -------- |
@@ -239,7 +239,7 @@ See the [Accessibility guide](../accessibility/#accessibilityelementshidden-ios)
 
 A value indicating this view should or should not be inverted when color inversion is turned on. A value of `true` will tell the view to not be inverted even if color inversion is turned on.
 
-See the [Accessibility guide](../accessibility/#accessibilityignoresinvertcolors) for more information.
+See the [Accessibility guide](accessibility.md#accessibilityignoresinvertcolorsios) for more information.
 
 | Type | Required | Platform |
 | ---- | -------- | -------- |
@@ -484,7 +484,7 @@ This is a reserved performance property exposed by `RCTView` and is useful for s
 
 | Type                                | Required |
 | ----------------------------------- | -------- |
-| [view styles](../view-style-props/) | No       |
+| [view styles](view-style-props.md) | No       |
 
 ---
 

--- a/docs/pages/versions/v37.0.0/react-native/viewpagerandroid.md
+++ b/docs/pages/versions/v37.0.0/react-native/viewpagerandroid.md
@@ -49,7 +49,7 @@ const styles = {
 
 ## Props
 
-Inherits [View Props](../view/#props).
+Inherits [View Props](view.md#props).
 
 ### `initialPage`
 

--- a/docs/pages/versions/v37.0.0/react-native/virtualizedlist.md
+++ b/docs/pages/versions/v37.0.0/react-native/virtualizedlist.md
@@ -3,7 +3,7 @@ id: virtualizedlist
 title: VirtualizedList
 ---
 
-Base implementation for the more convenient [`<FlatList>`](../flatlist/) and [`<SectionList>`](../sectionlist/) components, which are also better documented. In general, this should only really be used if you need more flexibility than [`FlatList`](../flatlist/) provides, e.g. for use with immutable data instead of plain arrays.
+Base implementation for the more convenient [`<FlatList>`](flatlist.md) and [`<SectionList>`](sectionlist.md) components, which are also better documented. In general, this should only really be used if you need more flexibility than [`FlatList`](flatlist.md) provides, e.g. for use with immutable data instead of plain arrays.
 
 Virtualization massively improves memory consumption and performance of large lists by maintaining a finite render window of active items and replacing all items outside of the render window with appropriately sized blank space. The window adapts to scrolling behavior, and items are rendered incrementally with low-pri (after any running interactions) if they are far from the visible area, or with hi-pri otherwise to minimize the potential of seeing blank space.
 
@@ -20,7 +20,7 @@ Some caveats:
 
 ## Props
 
-Inherits [ScrollView Props](../scrollview/#props).
+Inherits [ScrollView Props](scrollview.md#props).
 
 ### `renderItem`
 
@@ -135,7 +135,7 @@ Reverses the direction of scroll. Uses scale transforms of -1.
 
 ### `CellRendererComponent`
 
-Each cell is rendered using this element. Can be a React Component Class,or a render function. Defaults to using [`View`](../view/).
+Each cell is rendered using this element. Can be a React Component Class,or a render function. Defaults to using [`View`](view.md).
 
 | Type                | Required |
 | ------------------- | -------- |

--- a/docs/pages/versions/v38.0.0/react-native/actionsheetios.md
+++ b/docs/pages/versions/v38.0.0/react-native/actionsheetios.md
@@ -72,7 +72,7 @@ Display an iOS action sheet. The `options` object must contain one or more of:
 - `title` (string) - a title to show above the action sheet
 - `message` (string) - a message to show below the title
 - `anchor` (number) - the node to which the action sheet should be anchored (used for iPad)
-- `tintColor` (string) - the [color](../colors/) used for non-destructive button titles
+- `tintColor` (string) - the [color](https://reactnative.dev/docs/colors) used for non-destructive button titles
 
 The 'callback' function takes one parameter, the zero-based index of the selected item.
 

--- a/docs/pages/versions/v38.0.0/react-native/activityindicator.md
+++ b/docs/pages/versions/v38.0.0/react-native/activityindicator.md
@@ -39,7 +39,7 @@ export default App;
 
 ## Props
 
-Inherits [View Props](../view/#props).
+Inherits [View Props](view.md#props).
 
 ---
 

--- a/docs/pages/versions/v38.0.0/react-native/animated.md
+++ b/docs/pages/versions/v38.0.0/react-native/animated.md
@@ -86,8 +86,8 @@ Refer to the [Animations](https://reactnative.dev/docs/animations#animated-api) 
 
 There are two value types you can use with `Animated`:
 
-- [`Animated.Value()`](../animated/#value) for single values
-- [`Animated.ValueXY()`](../animated/#valuexy) for vectors
+- [`Animated.Value()`](animated.md#value) for single values
+- [`Animated.ValueXY()`](animated.md#valuexy) for vectors
 
 `Animated.Value` can bind to style properties or other props, and can be interpolated as well. A single `Animated.Value` can drive any number of properties.
 
@@ -95,9 +95,9 @@ There are two value types you can use with `Animated`:
 
 `Animated` provides three types of animation types. Each animation type provides a particular animation curve that controls how your values animate from their initial value to the final value:
 
-- [`Animated.decay()`](../animated/#decay) starts with an initial velocity and gradually slows to a stop.
-- [`Animated.spring()`](../animated/#spring) provides a basic spring physics model.
-- [`Animated.timing()`](../animated/#timing) animates a value over time using [easing functions](../easing/).
+- [`Animated.decay()`](animated.md#decay) starts with an initial velocity and gradually slows to a stop.
+- [`Animated.spring()`](animated.md#spring) provides a basic spring physics model.
+- [`Animated.timing()`](animated.md#timing) animates a value over time using [easing functions](easing.md).
 
 In most cases, you will be using `timing()`. By default, it uses a symmetric easeInOut curve that conveys the gradual acceleration of an object to full speed and concludes by gradually decelerating to a stop.
 
@@ -121,7 +121,7 @@ You can use the native driver by specifying `useNativeDriver: true` in your anim
 
 Only animatable components can be animated. These unique components do the magic of binding the animated values to the properties, and do targeted native updates to avoid the cost of the react render and reconciliation process on every frame. They also handle cleanup on unmount so they are safe by default.
 
-- [`createAnimatedComponent()`](../animated/#createanimatedcomponent) can be used to make a component animatable.
+- [`createAnimatedComponent()`](animated.md#createanimatedcomponent) can be used to make a component animatable.
 
 `Animated` exports the following animatable components using the above wrapper:
 
@@ -136,10 +136,10 @@ Only animatable components can be animated. These unique components do the magic
 
 Animations can also be combined in complex ways using composition functions:
 
-- [`Animated.delay()`](../animated/#delay) starts an animation after a given delay.
-- [`Animated.parallel()`](../animated/#parallel) starts a number of animations at the same time.
-- [`Animated.sequence()`](../animated/#sequence) starts the animations in order, waiting for each to complete before starting the next.
-- [`Animated.stagger()`](../animated/#stagger) starts animations in order and in parallel, but with successive delays.
+- [`Animated.delay()`](animated.md#delay) starts an animation after a given delay.
+- [`Animated.parallel()`](animated.md#parallel) starts a number of animations at the same time.
+- [`Animated.sequence()`](animated.md#sequence) starts the animations in order, waiting for each to complete before starting the next.
+- [`Animated.stagger()`](animated.md#stagger) starts animations in order and in parallel, but with successive delays.
 
 Animations can also be chained together by setting the `toValue` of one animation to be another `Animated.Value`. See [Tracking dynamic values](https://reactnative.dev/docs/animations#tracking-dynamic-values) in the Animations guide.
 
@@ -149,17 +149,17 @@ By default, if one animation is stopped or interrupted, then all other animation
 
 You can combine two animated values via addition, subtraction, multiplication, division, or modulo to make a new animated value:
 
-- [`Animated.add()`](../animated/#add)
-- [`Animated.subtract()`](../animated/#subtract)
-- [`Animated.divide()`](../animated/#divide)
-- [`Animated.modulo()`](../animated/#modulo)
-- [`Animated.multiply()`](../animated/#multiply)
+- [`Animated.add()`](animated.md#add)
+- [`Animated.subtract()`](animated.md#subtract)
+- [`Animated.divide()`](animated.md#divide)
+- [`Animated.modulo()`](animated.md#modulo)
+- [`Animated.multiply()`](animated.md#multiply)
 
 ### Interpolation
 
 The `interpolate()` function allows input ranges to map to different output ranges. By default, it will extrapolate the curve beyond the ranges given, but you can also have it clamp the output value. It uses linear interpolation by default but also supports easing functions.
 
-- [`interpolate()`](../animated/#interpolate)
+- [`interpolate()`](animated.md#interpolation)
 
 Read more about interpolation in the [Animation](https://reactnative.dev/docs/animations#interpolation) guide.
 
@@ -167,7 +167,7 @@ Read more about interpolation in the [Animation](https://reactnative.dev/docs/an
 
 Gestures, like panning or scrolling, and other events can map directly to animated values using `Animated.event()`. This is done with a structured map syntax so that values can be extracted from complex event objects. The first level is an array to allow mapping across multiple args, and that array contains nested objects.
 
-- [`Animated.event()`](../animated/#event)
+- [`Animated.event()`](animated.md#event)
 
 For example, when working with horizontal scrolling gestures, you would do the following in order to map `event.nativeEvent.contentOffset.x` to `scrollX` (an `Animated.Value`):
 
@@ -220,7 +220,7 @@ static timing(value, config)
 
 ```
 
-Animates a value along a timed easing curve. The [`Easing`](../easing/) module has tons of predefined curves, or you can use your own function.
+Animates a value along a timed easing curve. The [`Easing`](easing.md) module has tons of predefined curves, or you can use your own function.
 
 Config is an object that may have the following options:
 
@@ -512,7 +512,7 @@ Stops any running animation and resets the value to its original.
 
 Standard value class for driving animations. Typically initialized with `new Animated.Value(0);`
 
-You can read more about `Animated.Value` API on the separate [page](../animatedvalue/).
+You can read more about `Animated.Value` API on the separate [page](animatedvalue.md).
 
 ---
 
@@ -520,7 +520,7 @@ You can read more about `Animated.Value` API on the separate [page](../animatedv
 
 2D value class for driving 2D animations, such as pan gestures.
 
-+You can read more about `Animated.ValueXY` API on the separate [page](../animatedvaluexy/).
++You can read more about `Animated.ValueXY` API on the separate [page](animatedvaluexy.md).
 
 ---
 

--- a/docs/pages/versions/v38.0.0/react-native/animatedvaluexy.md
+++ b/docs/pages/versions/v38.0.0/react-native/animatedvaluexy.md
@@ -3,7 +3,7 @@ id: animatedvaluexy
 title: Animated.ValueXY
 ---
 
-2D Value for driving 2D animations, such as pan gestures. Almost identical API to normal [`Animated.Value`](../animatedvalue/), but multiplexed. Contains two regular `Animated.Value`s under the hood.
+2D Value for driving 2D animations, such as pan gestures. Almost identical API to normal [`Animated.Value`](animatedvalue.md), but multiplexed. Contains two regular `Animated.Value`s under the hood.
 
 ## Example
 

--- a/docs/pages/versions/v38.0.0/react-native/backhandler.md
+++ b/docs/pages/versions/v38.0.0/react-native/backhandler.md
@@ -10,7 +10,7 @@ The event subscriptions are called in reverse order (i.e. the last registered su
 - **If one subscription returns true,** then subscriptions registered earlier will not be called.
 - **If no subscription returns true or none are registered,** it programmatically invokes the default back button functionality to exit the app.
 
-> **Warning for modal users:** If your app shows an opened `Modal`, `BackHandler` will not publish any events ([see `Modal` docs](../modal/#onrequestclose)).
+> **Warning for modal users:** If your app shows an opened `Modal`, `BackHandler` will not publish any events ([see `Modal` docs](modal.md#onrequestclose)).
 
 ## Pattern
 

--- a/docs/pages/versions/v38.0.0/react-native/button.md
+++ b/docs/pages/versions/v38.0.0/react-native/button.md
@@ -5,7 +5,7 @@ title: Button
 
 A basic button component that should render nicely on any platform. Supports a minimal level of customization.
 
-If this button doesn't look right for your app, you can build your own button using [TouchableOpacity](../touchableopacity/) or [TouchableWithoutFeedback](../touchablewithoutfeedback/). For inspiration, look at the [source code for this button component](https://github.com/facebook/react-native/blob/master/Libraries/Components/Button.js). Or, take a look at the [wide variety of button components built by the community](https://js.coach/?menu%5Bcollections%5D=React%20Native&page=1&query=button).
+If this button doesn't look right for your app, you can build your own button using [TouchableOpacity](touchableopacity.md) or [TouchableWithoutFeedback](touchablewithoutfeedback.md). For inspiration, look at the [source code for this button component](https://github.com/facebook/react-native/blob/master/Libraries/Components/Button.js). Or, take a look at the [wide variety of button components built by the community](https://js.coach/?menu%5Bcollections%5D=React%20Native&page=1&query=button).
 
 ```js
 <Button

--- a/docs/pages/versions/v38.0.0/react-native/dimensions.md
+++ b/docs/pages/versions/v38.0.0/react-native/dimensions.md
@@ -3,7 +3,7 @@ id: dimensions
 title: Dimensions
 ---
 
-> [`useWindowDimensions`](../usewindowdimensions/) is the preffered API for React components. Unlike `Dimensions`, it updates as the window's dimensions update. This works nicely with the React paradigm.
+> [`useWindowDimensions`](usewindowdimensions.md) is the preffered API for React components. Unlike `Dimensions`, it updates as the window's dimensions update. This works nicely with the React paradigm.
 
 ```js
 import { Dimensions } from 'react-native';

--- a/docs/pages/versions/v38.0.0/react-native/easing.md
+++ b/docs/pages/versions/v38.0.0/react-native/easing.md
@@ -3,7 +3,7 @@ id: easing
 title: Easing
 ---
 
-The `Easing` module implements common easing functions. This module is used by [Animated.timing()](../animated/#timing) to convey physically believable motion in animations.
+The `Easing` module implements common easing functions. This module is used by [Animated.timing()](animated.md#timing) to convey physically believable motion in animations.
 
 You can find a visualization of some common easing functions at http://easings.net/
 
@@ -11,35 +11,35 @@ You can find a visualization of some common easing functions at http://easings.n
 
 The `Easing` module provides several predefined animations through the following methods:
 
-- [`back`](../easing/#back) provides a basic animation where the object goes slightly back before moving forward
-- [`bounce`](../easing/#bounce) provides a bouncing animation
-- [`ease`](../easing/#ease) provides a basic inertial animation
-- [`elastic`](../easing/#elastic) provides a basic spring interaction
+- [`back`](easing.md#back) provides a basic animation where the object goes slightly back before moving forward
+- [`bounce`](easing.md#bounce) provides a bouncing animation
+- [`ease`](easing.md#ease) provides a basic inertial animation
+- [`elastic`](easing.md#elastic) provides a basic spring interaction
 
 ### Standard functions
 
 Three standard easing functions are provided:
 
-- [`linear`](../easing/#linear)
-- [`quad`](../easing/#quad)
-- [`cubic`](../easing/#cubic)
+- [`linear`](easing.md#linear)
+- [`quad`](easing.md#quad)
+- [`cubic`](easing.md#cubic)
 
-The [`poly`](../easing/#poly) function can be used to implement quartic, quintic, and other higher power functions.
+The [`poly`](easing.md#poly) function can be used to implement quartic, quintic, and other higher power functions.
 
 ### Additional functions
 
 Additional mathematical functions are provided by the following methods:
 
-- [`bezier`](../easing/#bezier) provides a cubic bezier curve
-- [`circle`](../easing/#circle) provides a circular function
-- [`sin`](../easing/#sin) provides a sinusoidal function
-- [`exp`](../easing/#exp) provides an exponential function
+- [`bezier`](easing.md#bezier) provides a cubic bezier curve
+- [`circle`](easing.md#circle) provides a circular function
+- [`sin`](easing.md#sin) provides a sinusoidal function
+- [`exp`](easing.md#exp) provides an exponential function
 
 The following helpers are used to modify other easing functions.
 
-- [`in`](../easing/#in) runs an easing function forwards
-- [`inOut`](../easing/#inout) makes any easing function symmetrical
-- [`out`](../easing/#out) runs an easing function backwards
+- [`in`](easing.md#in) runs an easing function forwards
+- [`inOut`](easing.md#inout) makes any easing function symmetrical
+- [`out`](easing.md#out) runs an easing function backwards
 
 ## Example
 

--- a/docs/pages/versions/v38.0.0/react-native/flatlist.md
+++ b/docs/pages/versions/v38.0.0/react-native/flatlist.md
@@ -16,7 +16,7 @@ A performant interface for rendering basic, flat lists, supporting the most hand
 - ScrollToIndex support.
 - Multiple column support.
 
-If you need section support, use [`<SectionList>`](../sectionlist/).
+If you need section support, use [`<SectionList>`](sectionlist.md).
 
 ## Example
 
@@ -80,7 +80,7 @@ const styles = StyleSheet.create({
 export default App;
 ```
 
-To render multiple columns, use the [`numColumns`](../flatlist/#numcolumns) prop. Using this approach instead of a `flexWrap` layout can prevent conflicts with the item height logic.
+To render multiple columns, use the [`numColumns`](flatlist.md#numcolumns) prop. Using this approach instead of a `flexWrap` layout can prevent conflicts with the item height logic.
 
 More complex, multi-select example demonstrating `` usage for perf optimization and avoiding bugs.
 
@@ -157,7 +157,7 @@ const styles = StyleSheet.create({
 export default App;
 ```
 
-This is a convenience wrapper around [`<VirtualizedList>`](../virtualizedlist/), and thus inherits its props (as well as those of [`<ScrollView>`](../scrollview/)) that aren't explicitly listed here, along with the following caveats:
+This is a convenience wrapper around [`<VirtualizedList>`](virtualizedlist.md), and thus inherits its props (as well as those of [`<ScrollView>`](scrollview.md)) that aren't explicitly listed here, along with the following caveats:
 
 - Internal state is not preserved when content scrolls out of the render window. Make sure all your data is captured in the item data or external stores like Flux, Redux, or Relay.
 - This is a `PureComponent` which means that it will not re-render if `props` remain shallow-equal. Make sure that everything your `renderItem` function depends on is passed as a prop (e.g. `extraData`) that is not `===` after updates, otherwise your UI may not update on changes. This includes the `data` prop and parent component state.
@@ -170,7 +170,7 @@ This is a convenience wrapper around [`<VirtualizedList>`](../virtualizedlist/),
 
 ## Props
 
-Inherits [ScrollView Props](../scrollview/#props), unless it is nested in another FlatList of same orientation.
+Inherits [ScrollView Props](scrollview.md#props), unless it is nested in another FlatList of same orientation.
 
 ### `renderItem`
 
@@ -221,7 +221,7 @@ Example usage:
 
 ### `data`
 
-For simplicity, data is a plain array. If you want to use something else, like an immutable list, use the underlying [`VirtualizedList`](../virtualizedlist/) directly.
+For simplicity, data is a plain array. If you want to use something else, like an immutable list, use the underlying [`VirtualizedList`](virtualizedlist.md) directly.
 
 | Type  | Required |
 | ----- | -------- |

--- a/docs/pages/versions/v38.0.0/react-native/image.md
+++ b/docs/pages/versions/v38.0.0/react-native/image.md
@@ -125,13 +125,13 @@ dependencies {
 | ----- | -------- |
 | style | No       |
 
-- [Image Style Props...](../image-style-props/#props)
+- [Image Style Props...](image-style-props.md#props)
 
-- [Layout Props...](../layout-props/#props)
+- [Layout Props...](layout-props.md#props)
 
-- [Shadow Props...](../shadow-props/#props)
+- [Shadow Props...](shadow-props.md#props)
 
-- [Transforms...](../transforms/#props)
+- [Transforms...](transforms.md#transform)
 
 - **`borderTopRightRadius`**: number
 
@@ -385,7 +385,7 @@ Determines how to resize the image when the frame doesn't match the raw image di
 
 The image source (either a remote URL or a local file resource).
 
-This prop can also contain several remote URLs, specified together with their width and height and potentially with scale/other URI arguments. The native side will then choose the best `uri` to display based on the measured size of the image container. A `cache` property can be added to control how networked request interacts with the local cache. (For more information see [Cache Control for Images](../images/#cache-control-ios-only)).
+This prop can also contain several remote URLs, specified together with their width and height and potentially with scale/other URI arguments. The native side will then choose the best `uri` to display based on the measured size of the image container. A `cache` property can be added to control how networked request interacts with the local cache. (For more information see [Cache Control for Images](https://reactnative.dev/docs/images#cache-control-ios-only)).
 
 The currently supported formats are `png`, `jpg`, `jpeg`, `bmp`, `gif`, `webp` (Android only), `psd` (iOS only). In addition, iOS supports several RAW image formats. Refer to Apple's documentation for the current list of supported camera models (for iOS 12, see https://support.apple.com/en-ca/HT208967).
 

--- a/docs/pages/versions/v38.0.0/react-native/imagebackground.md
+++ b/docs/pages/versions/v38.0.0/react-native/imagebackground.md
@@ -51,19 +51,19 @@ export default App;
 
 ## Props
 
-Inherits [Image Props](../image/#props).
+Inherits [Image Props](image.md#props).
 
 ### `style`
 
 | Type                               | Required |
 | ---------------------------------- | -------- |
-| [view styles](../view-style-props/) | No       |
+| [view styles](view-style-props.md) | No       |
 
 ### `imageStyle`
 
 | Type                                 | Required |
 | ------------------------------------ | -------- |
-| [image styles](../image-style-props/) | No       |
+| [image styles](image-style-props.md) | No       |
 
 ### `imageRef`
 

--- a/docs/pages/versions/v38.0.0/react-native/inputaccessoryview.md
+++ b/docs/pages/versions/v38.0.0/react-native/inputaccessoryview.md
@@ -70,7 +70,7 @@ An ID which is used to associate this `InputAccessoryView` to specified TextInpu
 
 | Type                         | Required |
 | ---------------------------- | -------- |
-| [style](../view-style-props/) | No       |
+| [style](view-style-props.md) | No       |
 
 # Known issues
 

--- a/docs/pages/versions/v38.0.0/react-native/keyboardavoidingview.md
+++ b/docs/pages/versions/v38.0.0/react-native/keyboardavoidingview.md
@@ -64,7 +64,7 @@ export default KeyboardAvoidingComponent;
 
 ## Props
 
-Inherits [View Props](../view/#props).
+Inherits [View Props](view.md#props).
 
 ### `behavior`
 

--- a/docs/pages/versions/v38.0.0/react-native/layout-props.md
+++ b/docs/pages/versions/v38.0.0/react-native/layout-props.md
@@ -391,7 +391,7 @@ When `flex` is -1, the component is normally sized according to `width` and `hei
 
 ### `flexShrink`
 
-[`flexShrink`](../layout-props/flexshrink) describes how to shrink children along the main axis in the case in which the total size of the children overflows the size of the container on the main axis. `flexShrink` is very similar to `flexGrow` and can be thought of in the same way if any overflowing size is considered to be negative remaining space. These two properties also work well together by allowing children to grow and shrink as needed.
+[`flexShrink`](layout-props.md#flexshrink) describes how to shrink children along the main axis in the case in which the total size of the children overflows the size of the container on the main axis. `flexShrink` is very similar to `flexGrow` and can be thought of in the same way if any overflowing size is considered to be negative remaining space. These two properties also work well together by allowing children to grow and shrink as needed.
 
 `flexShrink` accepts any floating point value >= 0, with 1 being the default value. A container will shrink its children weighted by the children’s `flexShrink` values.
 

--- a/docs/pages/versions/v38.0.0/react-native/layoutanimation.md
+++ b/docs/pages/versions/v38.0.0/react-native/layoutanimation.md
@@ -88,7 +88,7 @@ Schedules an animation to happen on the next layout.
 | config            | object   | Yes      | See config description below.                              |
 | onAnimationDidEnd | function | No       | Called when the animation finished. Only supported on iOS. |
 
-The `config` parameter is an object with the keys below. [`create`](../layoutanimation/#create) returns a valid object for `config`, and the [`Presets`](../layoutanimation/#presets) objects can also all be passed as the `config`.
+The `config` parameter is an object with the keys below. [`create`](layoutanimation.md#create) returns a valid object for `config`, and the [`Presets`](layoutanimation.md#presets) objects can also all be passed as the `config`.
 
 - `duration` in milliseconds
 - `create`, optional config for animating in new views
@@ -97,8 +97,8 @@ The `config` parameter is an object with the keys below. [`create`](../layoutani
 
 The config that's passed to `create`, `update`, or `delete` has the following keys:
 
-- `type`, the [animation type](../layoutanimation/#types) to use
-- `property`, the [layout property](../layoutanimation/#properties) to animate (optional, but recommended for `create` and `delete`)
+- `type`, the [animation type](layoutanimation.md#types) to use
+- `property`, the [layout property](layoutanimation.md#properties) to animate (optional, but recommended for `create` and `delete`)
 - `springDamping` (number, optional and only for use with `type: Type.spring`)
 - `initialVelocity` (number, optional)
 - `delay` (number, optional)
@@ -114,7 +114,7 @@ static create(duration, type, creationProp)
 
 ```
 
-Helper that creates an object (with `create`, `update`, and `delete` fields) to pass into [`configureNext`](../layoutanimation/#configurenext). The `type` parameter is an [animation type](../layoutanimation/#types), and the `creationProp` parameter is a [layout property](../layoutanimation/#properties).
+Helper that creates an object (with `create`, `update`, and `delete` fields) to pass into [`configureNext`](layoutanimation.md#configurenext). The `type` parameter is an [animation type](layoutanimation.md#types), and the `creationProp` parameter is a [layout property](layoutanimation.md#properties).
 
 Example usage:
 
@@ -190,7 +190,7 @@ const styles = StyleSheet.create({
 
 ### Types
 
-An enumeration of animation types to be used in the [`create`](../layoutanimation/#create) method, or in the `create`/`update`/`delete` configs for [`configureNext`](../layoutanimation/#configurenext). (example usage: `LayoutAnimation.Types.easeIn`)
+An enumeration of animation types to be used in the [`create`](layoutanimation.md#create) method, or in the `create`/`update`/`delete` configs for [`configureNext`](layoutanimation.md#configurenext). (example usage: `LayoutAnimation.Types.easeIn`)
 
 | Types         |
 | ------------- |
@@ -205,7 +205,7 @@ An enumeration of animation types to be used in the [`create`](../layoutanimatio
 
 ### Properties
 
-An enumeration of layout properties to be animated to be used in the [`create`](../layoutanimation/#create) method, or in the `create`/`update`/`delete` configs for [`configureNext`](../layoutanimation/#configurenext). (example usage: `LayoutAnimation.Properties.opacity`)
+An enumeration of layout properties to be animated to be used in the [`create`](layoutanimation.md#create) method, or in the `create`/`update`/`delete` configs for [`configureNext`](layoutanimation.md#configurenext). (example usage: `LayoutAnimation.Properties.opacity`)
 
 | Properties |
 | ---------- |
@@ -218,7 +218,7 @@ An enumeration of layout properties to be animated to be used in the [`create`](
 
 ### Presets
 
-A set of predefined animation configs to pass into [`configureNext`](../layoutanimation/#configurenext).
+A set of predefined animation configs to pass into [`configureNext`](layoutanimation.md#configurenext).
 
 | Presets       | Value                                                                                                                                                                 |
 | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/pages/versions/v38.0.0/react-native/modal.md
+++ b/docs/pages/versions/v38.0.0/react-native/modal.md
@@ -101,7 +101,7 @@ export default App;
 
 ### `animated`
 
-> **Deprecated.** Use the [`animationType`](../modal/#animationtype) prop instead.
+> **Deprecated.** Use the [`animationType`](modal.md#animationtype) prop instead.
 
 ---
 

--- a/docs/pages/versions/v38.0.0/react-native/refreshcontrol.md
+++ b/docs/pages/versions/v38.0.0/react-native/refreshcontrol.md
@@ -65,7 +65,7 @@ export default App;
 
 ## Props
 
-Inherits [View Props](../view/#props).
+Inherits [View Props](view.md#props).
 
 ### `refreshing`
 

--- a/docs/pages/versions/v38.0.0/react-native/safeareaview.md
+++ b/docs/pages/versions/v38.0.0/react-native/safeareaview.md
@@ -38,7 +38,7 @@ export default App;
 
 ## Props
 
-Inherits [View Props](../view/props).
+Inherits [View Props](view.md#props).
 
 ### `emulateUnlessSupported`
 

--- a/docs/pages/versions/v38.0.0/react-native/scrollview.md
+++ b/docs/pages/versions/v38.0.0/react-native/scrollview.md
@@ -9,7 +9,7 @@ Keep in mind that ScrollViews must have a bounded height in order to work, since
 
 Doesn't yet support other contained responders from blocking this scroll view from becoming the responder.
 
-`<ScrollView>` vs [`<FlatList>`](../flatlist/) - which one to use?
+`<ScrollView>` vs [`<FlatList>`](flatlist.md) - which one to use?
 
 `ScrollView` renders all its react child components at once, but this has a performance downside.
 
@@ -67,7 +67,7 @@ export default App;
 
 ## Props
 
-Inherits [View Props](../view/#props).
+Inherits [View Props](view.md#props).
 
 ### `alwaysBounceHorizontal`
 
@@ -510,7 +510,7 @@ When true, ScrollView allows use of pinch gestures to zoom in and out. The defau
 
 A RefreshControl component, used to provide pull-to-refresh functionality for the ScrollView. Only works for vertical ScrollViews (`horizontal` prop must be `false`).
 
-See [RefreshControl](../refreshcontrol/).
+See [RefreshControl](refreshcontrol.md).
 
 | Type    | Required |
 | ------- | -------- |

--- a/docs/pages/versions/v38.0.0/react-native/sectionlist.md
+++ b/docs/pages/versions/v38.0.0/react-native/sectionlist.md
@@ -16,7 +16,7 @@ A performant interface for rendering sectioned lists, supporting the most handy 
 - Pull to Refresh.
 - Scroll loading.
 
-If you don't need section support and want a simpler interface, use [`<FlatList>`](../flatlist/).
+If you don't need section support and want a simpler interface, use [`<FlatList>`](flatlist.md).
 
 ## Example
 
@@ -86,7 +86,7 @@ const styles = StyleSheet.create({
 export default App;
 ```
 
-This is a convenience wrapper around [`<VirtualizedList>`](../virtualizedlist/), and thus inherits its props (as well as those of [`<ScrollView>`](../scrollview/) that aren't explicitly listed here, along with the following caveats:
+This is a convenience wrapper around [`<VirtualizedList>`](virtualizedlist.md), and thus inherits its props (as well as those of [`<ScrollView>`](scrollview.md) that aren't explicitly listed here, along with the following caveats:
 
 - Internal state is not preserved when content scrolls out of the render window. Make sure all your data is captured in the item data or external stores like Flux, Redux, or Relay.
 - This is a `PureComponent` which means that it will not re-render if `props` remain shallow-equal. Make sure that everything your `renderItem` function depends on is passed as a prop (e.g. `extraData`) that is not `===` after updates, otherwise your UI may not update on changes. This includes the `data` prop and parent component state.
@@ -99,7 +99,7 @@ This is a convenience wrapper around [`<VirtualizedList>`](../virtualizedlist/),
 
 ## Props
 
-Inherits [ScrollView Props](../scrollview/#props).
+Inherits [ScrollView Props](scrollview.md#props).
 
 ### `renderItem`
 
@@ -125,11 +125,11 @@ The render function will be passed an object with the following keys:
 
 ### `sections`
 
-The actual data to render, akin to the `data` prop in [`FlatList`](../flatlist/).
+The actual data to render, akin to the `data` prop in [`FlatList`](flatlist.md).
 
 | Type                                        | Required |
 | ------------------------------------------- | -------- |
-| array of [Section](../sectionlist/#section)s | Yes      |
+| array of [Section](sectionlist.md#section)s | Yes      |
 
 ---
 
@@ -392,8 +392,8 @@ An object that identifies the data to be rendered for a given section.
 
 | Name                     | Type                         | Description                                                                                                                                                            |
 | ------------------------ | ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| data                     | array                        | The data for rendering items in this section. Array of objects, much like [`FlatList`'s data prop](../flatlist/#data).                                                  |
+| data                     | array                        | The data for rendering items in this section. Array of objects, much like [`FlatList`'s data prop](flatlist.md#data).                                                  |
 | [key]                    | string                       | Optional key to keep track of section re-ordering. If you don't plan on re-ordering sections, the array index will be used by default.                                 |
-| [renderItem]             | function                     | Optionally define an arbitrary item renderer for this section, overriding the default [`renderItem`](../sectionlist/#renderitem) for the list.                          |
-| [ItemSeparatorComponent] | component, function, element | Optionally define an arbitrary item separator for this section, overriding the default [`ItemSeparatorComponent`](../sectionlist/#itemseparatorcomponent) for the list. |
-| [keyExtractor]           | function                     | Optionally define an arbitrary key extractor for this section, overriding the default [`keyExtractor`](../sectionlist/#keyextractor).                                   |
+| [renderItem]             | function                     | Optionally define an arbitrary item renderer for this section, overriding the default [`renderItem`](sectionlist.md#renderitem) for the list.                          |
+| [ItemSeparatorComponent] | component, function, element | Optionally define an arbitrary item separator for this section, overriding the default [`ItemSeparatorComponent`](sectionlist.md#itemseparatorcomponent) for the list. |
+| [keyExtractor]           | function                     | Optionally define an arbitrary key extractor for this section, overriding the default [`keyExtractor`](sectionlist.md#keyextractor).                                   |

--- a/docs/pages/versions/v38.0.0/react-native/shadow-props.md
+++ b/docs/pages/versions/v38.0.0/react-native/shadow-props.md
@@ -99,7 +99,7 @@ export default App;
 
 # Reference
 
-These properties are iOS only - for similar functionality on Android, use the [`elevation` property](../view-style-props/#elevation).
+These properties are iOS only - for similar functionality on Android, use the [`elevation` property](view-style-props.md#elevation).
 
 ## Props
 

--- a/docs/pages/versions/v38.0.0/react-native/switch.md
+++ b/docs/pages/versions/v38.0.0/react-native/switch.md
@@ -47,7 +47,7 @@ export default App;
 
 ## Props
 
-Inherits [View Props](../view/#props).
+Inherits [View Props](view.md#props).
 
 ### `disabled`
 
@@ -103,7 +103,7 @@ Color of the foreground switch grip. If this is set on iOS, the switch grip will
 
 Custom colors for the switch track.
 
-_iOS_: When the switch value is false, the track shrinks into the border. If you want to change the color of the background exposed by the shrunken track, use [`ios_backgroundColor`](../switch/#ios_backgroundColor).
+_iOS_: When the switch value is false, the track shrinks into the border. If you want to change the color of the background exposed by the shrunken track, use [`ios_backgroundColor`](switch.md#ios_backgroundColor).
 
 | Type                                                          | Required |
 | ------------------------------------------------------------- | -------- |

--- a/docs/pages/versions/v38.0.0/react-native/text.md
+++ b/docs/pages/versions/v38.0.0/react-native/text.md
@@ -545,7 +545,7 @@ The highlight color of the text.
 | ----- | -------- |
 | style | No       |
 
-- [View Style Props...](../view-style-props/#style)
+- [View Style Props...](view-style-props.md#props)
 
 - **`textShadowOffset`**: object: {width: number,height: number}
 

--- a/docs/pages/versions/v38.0.0/react-native/textinput.md
+++ b/docs/pages/versions/v38.0.0/react-native/textinput.md
@@ -79,7 +79,7 @@ Note that on Android performing text selection in input can change app's activit
 
 ## Props
 
-Inherits [View Props](../view/#props).
+Inherits [View Props](view.md#props).
 
 ### `allowFontScaling`
 
@@ -307,7 +307,7 @@ Padding between the inline image, if any, and the text input itself.
 
 ### `inputAccessoryViewID`
 
-An optional identifier which links a custom [InputAccessoryView](../inputaccessoryview/) to this text input. The InputAccessoryView is rendered above the keyboard when this text input is focused.
+An optional identifier which links a custom [InputAccessoryView](inputaccessoryview.md) to this text input. The InputAccessoryView is rendered above the keyboard when this text input is focused.
 
 | Type   | Required | Platform |
 | ------ | -------- | -------- |
@@ -771,7 +771,7 @@ see [Issue#7070](https://github.com/facebook/react-native/issues/7070) for more 
 
 | Type                  | Required |
 | --------------------- | -------- |
-| [Text](../text/#style) | No       |
+| [Text](text.md#style) | No       |
 
 ---
 

--- a/docs/pages/versions/v38.0.0/react-native/touchablehighlight.md
+++ b/docs/pages/versions/v38.0.0/react-native/touchablehighlight.md
@@ -82,7 +82,7 @@ export default TouchableHighlightExample;
 
 ## Props
 
-Inherits [TouchableWithoutFeedback Props](../touchablewithoutfeedback/#props).
+Inherits [TouchableWithoutFeedback Props](touchablewithoutfeedback.md#props).
 
 ### `activeOpacity`
 

--- a/docs/pages/versions/v38.0.0/react-native/touchablenativefeedback.md
+++ b/docs/pages/versions/v38.0.0/react-native/touchablenativefeedback.md
@@ -63,7 +63,7 @@ export default App;
 
 ## Props
 
-Inherits [TouchableWithoutFeedback Props](../touchablewithoutfeedback/#props).
+Inherits [TouchableWithoutFeedback Props](touchablewithoutfeedback.md#props).
 
 ### `background`
 

--- a/docs/pages/versions/v38.0.0/react-native/touchableopacity.md
+++ b/docs/pages/versions/v38.0.0/react-native/touchableopacity.md
@@ -58,7 +58,7 @@ export default App;
 
 ## Props
 
-Inherits [TouchableWithoutFeedback Props](../touchablewithoutfeedback/#props).
+Inherits [TouchableWithoutFeedback Props](touchablewithoutfeedback.md#props).
 
 ### `style`
 

--- a/docs/pages/versions/v38.0.0/react-native/transforms.md
+++ b/docs/pages/versions/v38.0.0/react-native/transforms.md
@@ -157,4 +157,4 @@ transform([{ skewX: '45deg' }]);
 
 ### `decomposedMatrix`, `rotation`, `scaleX`, `scaleY`, `transformMatrix`, `translateX`, `translateY`
 
-> **Deprecated.** Use the [`transform`](../transforms/#transform) prop instead.
+> **Deprecated.** Use the [`transform`](transforms.md#transform) prop instead.

--- a/docs/pages/versions/v38.0.0/react-native/usecolorscheme.md
+++ b/docs/pages/versions/v38.0.0/react-native/usecolorscheme.md
@@ -7,7 +7,7 @@ title: useColorScheme
 import { useColorScheme } from 'react-native';
 ```
 
-The `useColorScheme` React hook provides and subscribes to color scheme updates from the [`Appearance`](../../sdk/appearance/) module. The return value indicates the current user preferred color scheme. The value may be updated later, either through direct user action (e.g. theme selection in device settings) or on a schedule (e.g. light and dark themes that follow the day/night cycle).
+The `useColorScheme` React hook provides and subscribes to color scheme updates from the [`Appearance`](../sdk/appearance.md) module. The return value indicates the current user preferred color scheme. The value may be updated later, either through direct user action (e.g. theme selection in device settings) or on a schedule (e.g. light and dark themes that follow the day/night cycle).
 
 Supported color schemes:
 

--- a/docs/pages/versions/v38.0.0/react-native/view.md
+++ b/docs/pages/versions/v38.0.0/react-native/view.md
@@ -484,7 +484,7 @@ This is a reserved performance property exposed by `RCTView` and is useful for s
 
 | Type                               | Required |
 | ---------------------------------- | -------- |
-| [view styles](../view-style-props/) | No       |
+| [view styles](view-style-props.md) | No       |
 
 ---
 

--- a/docs/pages/versions/v38.0.0/react-native/virtualizedlist.md
+++ b/docs/pages/versions/v38.0.0/react-native/virtualizedlist.md
@@ -3,7 +3,7 @@ id: virtualizedlist
 title: VirtualizedList
 ---
 
-Base implementation for the more convenient [`<FlatList>`](../flatlist/) and [`<SectionList>`](../sectionlist/) components, which are also better documented. In general, this should only really be used if you need more flexibility than [`FlatList`](../flatlist/) provides, e.g. for use with immutable data instead of plain arrays.
+Base implementation for the more convenient [`<FlatList>`](flatlist.md) and [`<SectionList>`](sectionlist.md) components, which are also better documented. In general, this should only really be used if you need more flexibility than [`FlatList`](flatlist.md) provides, e.g. for use with immutable data instead of plain arrays.
 
 Virtualization massively improves memory consumption and performance of large lists by maintaining a finite render window of active items and replacing all items outside of the render window with appropriately sized blank space. The window adapts to scrolling behavior, and items are rendered incrementally with low-pri (after any running interactions) if they are far from the visible area, or with hi-pri otherwise to minimize the potential of seeing blank space.
 
@@ -86,7 +86,7 @@ Some caveats:
 
 ## Props
 
-Inherits [ScrollView Props](../scrollview/#props).
+Inherits [ScrollView Props](scrollview.md#props).
 
 ### `renderItem`
 
@@ -197,7 +197,7 @@ Reverses the direction of scroll. Uses scale transforms of -1.
 
 ### `CellRendererComponent`
 
-Each cell is rendered using this element. Can be a React Component Class,or a render function. Defaults to using [`View`](../view/).
+Each cell is rendered using this element. Can be a React Component Class,or a render function. Defaults to using [`View`](view.md).
 
 | Type                | Required |
 | ------------------- | -------- |

--- a/docs/pages/versions/v39.0.0/react-native/activityindicator.md
+++ b/docs/pages/versions/v39.0.0/react-native/activityindicator.md
@@ -39,7 +39,7 @@ const styles = StyleSheet.create({
 
 ## Props
 
-Inherits [View Props](../view/#props).
+Inherits [View Props](view.md#props).
 
 ---
 

--- a/docs/pages/versions/v39.0.0/react-native/animated.md
+++ b/docs/pages/versions/v39.0.0/react-native/animated.md
@@ -85,8 +85,8 @@ Refer to the [Animations](https://reactnative.dev/docs/animations#animated-api) 
 
 There are two value types you can use with `Animated`:
 
-- [`Animated.Value()`](../animated/#value) for single values
-- [`Animated.ValueXY()`](../animated/#valuexy) for vectors
+- [`Animated.Value()`](animated.md#value) for single values
+- [`Animated.ValueXY()`](animated.md#valuexy) for vectors
 
 `Animated.Value` can bind to style properties or other props, and can be interpolated as well. A single `Animated.Value` can drive any number of properties.
 
@@ -94,9 +94,9 @@ There are two value types you can use with `Animated`:
 
 `Animated` provides three types of animation types. Each animation type provides a particular animation curve that controls how your values animate from their initial value to the final value:
 
-- [`Animated.decay()`](../animated/#decay) starts with an initial velocity and gradually slows to a stop.
-- [`Animated.spring()`](../animated/#spring) provides a basic spring physics model.
-- [`Animated.timing()`](../animated/#timing) animates a value over time using [easing functions](../easing/).
+- [`Animated.decay()`](animated.md#decay) starts with an initial velocity and gradually slows to a stop.
+- [`Animated.spring()`](animated.md#spring) provides a basic spring physics model.
+- [`Animated.timing()`](animated.md#timing) animates a value over time using [easing functions](easing.md).
 
 In most cases, you will be using `timing()`. By default, it uses a symmetric easeInOut curve that conveys the gradual acceleration of an object to full speed and concludes by gradually decelerating to a stop.
 
@@ -120,7 +120,7 @@ You can use the native driver by specifying `useNativeDriver: true` in your anim
 
 Only animatable components can be animated. These unique components do the magic of binding the animated values to the properties, and do targeted native updates to avoid the cost of the react render and reconciliation process on every frame. They also handle cleanup on unmount so they are safe by default.
 
-- [`createAnimatedComponent()`](../animated/#createanimatedcomponent) can be used to make a component animatable.
+- [`createAnimatedComponent()`](animated.md#createanimatedcomponent) can be used to make a component animatable.
 
 `Animated` exports the following animatable components using the above wrapper:
 
@@ -135,10 +135,10 @@ Only animatable components can be animated. These unique components do the magic
 
 Animations can also be combined in complex ways using composition functions:
 
-- [`Animated.delay()`](../animated/#delay) starts an animation after a given delay.
-- [`Animated.parallel()`](../animated/#parallel) starts a number of animations at the same time.
-- [`Animated.sequence()`](../animated/#sequence) starts the animations in order, waiting for each to complete before starting the next.
-- [`Animated.stagger()`](../animated/#stagger) starts animations in order and in parallel, but with successive delays.
+- [`Animated.delay()`](animated.md#delay) starts an animation after a given delay.
+- [`Animated.parallel()`](animated.md#parallel) starts a number of animations at the same time.
+- [`Animated.sequence()`](animated.md#sequence) starts the animations in order, waiting for each to complete before starting the next.
+- [`Animated.stagger()`](animated.md#stagger) starts animations in order and in parallel, but with successive delays.
 
 Animations can also be chained together by setting the `toValue` of one animation to be another `Animated.Value`. See [Tracking dynamic values](https://reactnative.dev/docs/animations#tracking-dynamic-values) in the Animations guide.
 
@@ -148,17 +148,17 @@ By default, if one animation is stopped or interrupted, then all other animation
 
 You can combine two animated values via addition, subtraction, multiplication, division, or modulo to make a new animated value:
 
-- [`Animated.add()`](../animated/#add)
-- [`Animated.subtract()`](../animated/#subtract)
-- [`Animated.divide()`](../animated/#divide)
-- [`Animated.modulo()`](../animated/#modulo)
-- [`Animated.multiply()`](../animated/#multiply)
+- [`Animated.add()`](animated.md#add)
+- [`Animated.subtract()`](animated.md#subtract)
+- [`Animated.divide()`](animated.md#divide)
+- [`Animated.modulo()`](animated.md#modulo)
+- [`Animated.multiply()`](animated.md#multiply)
 
 ### Interpolation
 
 The `interpolate()` function allows input ranges to map to different output ranges. By default, it will extrapolate the curve beyond the ranges given, but you can also have it clamp the output value. It uses linear interpolation by default but also supports easing functions.
 
-- [`interpolate()`](../animated/#interpolate)
+- [`interpolate()`](#interpolation)
 
 Read more about interpolation in the [Animation](https://reactnative.dev/docs/animations#interpolation) guide.
 
@@ -166,7 +166,7 @@ Read more about interpolation in the [Animation](https://reactnative.dev/docs/an
 
 Gestures, like panning or scrolling, and other events can map directly to animated values using `Animated.event()`. This is done with a structured map syntax so that values can be extracted from complex event objects. The first level is an array to allow mapping across multiple args, and that array contains nested objects.
 
-- [`Animated.event()`](../animated/#event)
+- [`Animated.event()`](animated.md#event)
 
 For example, when working with horizontal scrolling gestures, you would do the following in order to map `event.nativeEvent.contentOffset.x` to `scrollX` (an `Animated.Value`):
 
@@ -213,7 +213,7 @@ Config is an object that may have the following options:
 static timing(value, config)
 ```
 
-Animates a value along a timed easing curve. The [`Easing`](../easing/) module has tons of predefined curves, or you can use your own function.
+Animates a value along a timed easing curve. The [`Easing`](easing.md) module has tons of predefined curves, or you can use your own function.
 
 Config is an object that may have the following options:
 
@@ -472,7 +472,7 @@ Stops any running animation and resets the value to its original.
 
 Standard value class for driving animations. Typically initialized with `new Animated.Value(0);`
 
-You can read more about `Animated.Value` API on the separate [page](../animatedvalue/).
+You can read more about `Animated.Value` API on the separate [page](animatedvalue.md).
 
 ---
 
@@ -480,7 +480,7 @@ You can read more about `Animated.Value` API on the separate [page](../animatedv
 
 2D value class for driving 2D animations, such as pan gestures.
 
-You can read more about `Animated.ValueXY` API on the separate [page](../animatedvaluexy/).
+You can read more about `Animated.ValueXY` API on the separate [page](animatedvaluexy.md).
 
 ---
 

--- a/docs/pages/versions/v39.0.0/react-native/animatedvaluexy.md
+++ b/docs/pages/versions/v39.0.0/react-native/animatedvaluexy.md
@@ -3,7 +3,7 @@ id: animatedvaluexy
 title: Animated.ValueXY
 ---
 
-2D Value for driving 2D animations, such as pan gestures. Almost identical API to normal [`Animated.Value`](../animatedvalue/), but multiplexed. Contains two regular `Animated.Value`s under the hood.
+2D Value for driving 2D animations, such as pan gestures. Almost identical API to normal [`Animated.Value`](animatedvalue.md), but multiplexed. Contains two regular `Animated.Value`s under the hood.
 
 ## Example
 

--- a/docs/pages/versions/v39.0.0/react-native/appearance.md
+++ b/docs/pages/versions/v39.0.0/react-native/appearance.md
@@ -28,7 +28,7 @@ if (colorScheme === 'dark') {
 }
 ```
 
-Although the color scheme is available immediately, this may change (e.g. scheduled color scheme change at sunrise or sunset). Any rendering logic or styles that depend on the user preferred color scheme should try to call this function on every render, rather than caching the value. For example, you may use the [`useColorScheme`](../usecolorscheme/) React hook as it provides and subscribes to color scheme updates, or you may use inline styles rather than setting a value in a `StyleSheet`.
+Although the color scheme is available immediately, this may change (e.g. scheduled color scheme change at sunrise or sunset). Any rendering logic or styles that depend on the user preferred color scheme should try to call this function on every render, rather than caching the value. For example, you may use the [`useColorScheme`](usecolorscheme.md) React hook as it provides and subscribes to color scheme updates, or you may use inline styles rather than setting a value in a `StyleSheet`.
 
 # Reference
 

--- a/docs/pages/versions/v39.0.0/react-native/backhandler.md
+++ b/docs/pages/versions/v39.0.0/react-native/backhandler.md
@@ -10,7 +10,7 @@ The event subscriptions are called in reverse order (i.e. the last registered su
 - **If one subscription returns true,** then subscriptions registered earlier will not be called.
 - **If no subscription returns true or none are registered,** it programmatically invokes the default back button functionality to exit the app.
 
-> **Warning for modal users:** If your app shows an opened `Modal`, `BackHandler` will not publish any events ([see `Modal` docs](../modal/#onrequestclose)).
+> **Warning for modal users:** If your app shows an opened `Modal`, `BackHandler` will not publish any events ([see `Modal` docs](modal.md#onrequestclose)).
 
 ## Pattern
 

--- a/docs/pages/versions/v39.0.0/react-native/button.md
+++ b/docs/pages/versions/v39.0.0/react-native/button.md
@@ -5,7 +5,7 @@ title: Button
 
 A basic button component that should render nicely on any platform. Supports a minimal level of customization.
 
-If this button doesn't look right for your app, you can build your own button using [TouchableOpacity](../touchableopacity/) or [TouchableWithoutFeedback](../touchablewithoutfeedback/). For inspiration, look at the [source code for this button component](https://github.com/facebook/react-native/blob/master/Libraries/Components/Button.js). Or, take a look at the [wide variety of button components built by the community](https://js.coach/?menu%5Bcollections%5D=React%20Native&page=1&query=button).
+If this button doesn't look right for your app, you can build your own button using [TouchableOpacity](touchableopacity.md) or [TouchableWithoutFeedback](touchablewithoutfeedback.md). For inspiration, look at the [source code for this button component](https://github.com/facebook/react-native/blob/master/Libraries/Components/Button.js). Or, take a look at the [wide variety of button components built by the community](https://js.coach/?menu%5Bcollections%5D=React%20Native&page=1&query=button).
 
 ```js
 <Button

--- a/docs/pages/versions/v39.0.0/react-native/dimensions.md
+++ b/docs/pages/versions/v39.0.0/react-native/dimensions.md
@@ -3,7 +3,7 @@ id: dimensions
 title: Dimensions
 ---
 
-> [`useWindowDimensions`](../usewindowdimensions/) is the preferred API for React components. Unlike `Dimensions`, it updates as the window's dimensions update. This works nicely with the React paradigm.
+> [`useWindowDimensions`](usewindowdimensions.md) is the preferred API for React components. Unlike `Dimensions`, it updates as the window's dimensions update. This works nicely with the React paradigm.
 
 ```js
 import { Dimensions } from 'react-native';

--- a/docs/pages/versions/v39.0.0/react-native/easing.md
+++ b/docs/pages/versions/v39.0.0/react-native/easing.md
@@ -3,7 +3,7 @@ id: easing
 title: Easing
 ---
 
-The `Easing` module implements common easing functions. This module is used by [Animated.timing()](../animated/#timing) to convey physically believable motion in animations.
+The `Easing` module implements common easing functions. This module is used by [Animated.timing()](animated.md#timing) to convey physically believable motion in animations.
 
 You can find a visualization of some common easing functions at http://easings.net/
 
@@ -11,35 +11,35 @@ You can find a visualization of some common easing functions at http://easings.n
 
 The `Easing` module provides several predefined animations through the following methods:
 
-- [`back`](../easing/#back) provides a basic animation where the object goes slightly back before moving forward
-- [`bounce`](../easing/#bounce) provides a bouncing animation
-- [`ease`](../easing/#ease) provides a basic inertial animation
-- [`elastic`](../easing/#elastic) provides a basic spring interaction
+- [`back`](easing.md#back) provides a basic animation where the object goes slightly back before moving forward
+- [`bounce`](easing.md#bounce) provides a bouncing animation
+- [`ease`](easing.md#ease) provides a basic inertial animation
+- [`elastic`](easing.md#elastic) provides a basic spring interaction
 
 ### Standard functions
 
 Three standard easing functions are provided:
 
-- [`linear`](../easing/#linear)
-- [`quad`](../easing/#quad)
-- [`cubic`](../easing/#cubic)
+- [`linear`](easing.md#linear)
+- [`quad`](easing.md#quad)
+- [`cubic`](easing.md#cubic)
 
-The [`poly`](../easing/#poly) function can be used to implement quartic, quintic, and other higher power functions.
+The [`poly`](easing.md#poly) function can be used to implement quartic, quintic, and other higher power functions.
 
 ### Additional functions
 
 Additional mathematical functions are provided by the following methods:
 
-- [`bezier`](../easing/#bezier) provides a cubic bezier curve
-- [`circle`](../easing/#circle) provides a circular function
-- [`sin`](../easing/#sin) provides a sinusoidal function
-- [`exp`](../easing/#exp) provides an exponential function
+- [`bezier`](easing.md#bezier) provides a cubic bezier curve
+- [`circle`](easing.md#circle) provides a circular function
+- [`sin`](easing.md#sin) provides a sinusoidal function
+- [`exp`](easing.md#exp) provides an exponential function
 
 The following helpers are used to modify other easing functions.
 
-- [`in`](../easing/#in) runs an easing function forwards
-- [`inOut`](../easing/#inout) makes any easing function symmetrical
-- [`out`](../easing/#out) runs an easing function backwards
+- [`in`](easing.md#in) runs an easing function forwards
+- [`inOut`](easing.md#inout) makes any easing function symmetrical
+- [`out`](easing.md#out) runs an easing function backwards
 
 ## Example
 

--- a/docs/pages/versions/v39.0.0/react-native/flatlist.md
+++ b/docs/pages/versions/v39.0.0/react-native/flatlist.md
@@ -16,7 +16,7 @@ A performant interface for rendering basic, flat lists, supporting the most hand
 - ScrollToIndex support.
 - Multiple column support.
 
-If you need section support, use [`<SectionList>`](../sectionlist/).
+If you need section support, use [`<SectionList>`](sectionlist.md).
 
 ## Example
 
@@ -72,7 +72,7 @@ const styles = StyleSheet.create({
 });
 ```
 
-To render multiple columns, use the [`numColumns`](../flatlist/#numcolumns) prop. Using this approach instead of a `flexWrap` layout can prevent conflicts with the item height logic.
+To render multiple columns, use the [`numColumns`](flatlist.md#numcolumns) prop. Using this approach instead of a `flexWrap` layout can prevent conflicts with the item height logic.
 
 More complex, multi-select example demonstrating `` usage for perf optimization and avoiding bugs.
 
@@ -148,7 +148,7 @@ const styles = StyleSheet.create({
 });
 ```
 
-This is a convenience wrapper around [`<VirtualizedList>`](../virtualizedlist/), and thus inherits its props (as well as those of [`<ScrollView>`](../scrollview/)) that aren't explicitly listed here, along with the following caveats:
+This is a convenience wrapper around [`<VirtualizedList>`](virtualizedlist.md), and thus inherits its props (as well as those of [`<ScrollView>`](scrollview.md)) that aren't explicitly listed here, along with the following caveats:
 
 - Internal state is not preserved when content scrolls out of the render window. Make sure all your data is captured in the item data or external stores like Flux, Redux, or Relay.
 - This is a `PureComponent` which means that it will not re-render if `props` remain shallow-equal. Make sure that everything your `renderItem` function depends on is passed as a prop (e.g. `extraData`) that is not `===` after updates, otherwise your UI may not update on changes. This includes the `data` prop and parent component state.
@@ -161,7 +161,7 @@ This is a convenience wrapper around [`<VirtualizedList>`](../virtualizedlist/),
 
 ## Props
 
-Inherits [ScrollView Props](../scrollview/#props), unless it is nested in another FlatList of same orientation.
+Inherits [ScrollView Props](scrollview.md#props), unless it is nested in another FlatList of same orientation.
 
 ### `renderItem`
 
@@ -213,7 +213,7 @@ Example usage:
 
 ### `data`
 
-For simplicity, data is a plain array. If you want to use something else, like an immutable list, use the underlying [`VirtualizedList`](../virtualizedlist/) directly.
+For simplicity, data is a plain array. If you want to use something else, like an immutable list, use the underlying [`VirtualizedList`](virtualizedlist.md) directly.
 
 | Type  | Required |
 | ----- | -------- |

--- a/docs/pages/versions/v39.0.0/react-native/image.md
+++ b/docs/pages/versions/v39.0.0/react-native/image.md
@@ -114,13 +114,13 @@ dependencies {
 | ----- | -------- |
 | style | No       |
 
-- [Image Style Props...](../image-style-props/#props)
+- [Image Style Props...](image-style-props.md#props)
 
-- [Layout Props...](../layout-props/#props)
+- [Layout Props...](layout-props.md#props)
 
-- [Shadow Props...](../shadow-props/#props)
+- [Shadow Props...](shadow-props.md#props)
 
-- [Transforms...](../transforms/#props)
+- [Transforms...](transforms.md#transform)
 
 ---
 

--- a/docs/pages/versions/v39.0.0/react-native/imagebackground.md
+++ b/docs/pages/versions/v39.0.0/react-native/imagebackground.md
@@ -51,19 +51,19 @@ const styles = StyleSheet.create({
 
 ## Props
 
-Inherits [Image Props](../image/#props).
+Inherits [Image Props](image.md#props).
 
 ### `style`
 
-| Type                                | Required |
-| ----------------------------------- | -------- |
-| [view styles](../view-style-props/) | No       |
+| Type                               | Required |
+| ---------------------------------- | -------- |
+| [view styles](view-style-props.md) | No       |
 
 ### `imageStyle`
 
-| Type                                  | Required |
-| ------------------------------------- | -------- |
-| [image styles](../image-style-props/) | No       |
+| Type                                 | Required |
+| ------------------------------------ | -------- |
+| [image styles](image-style-props.md) | No       |
 
 ### `imageRef`
 

--- a/docs/pages/versions/v39.0.0/react-native/inputaccessoryview.md
+++ b/docs/pages/versions/v39.0.0/react-native/inputaccessoryview.md
@@ -65,9 +65,9 @@ An ID which is used to associate this `InputAccessoryView` to specified TextInpu
 
 ### `style`
 
-| Type                          | Required |
-| ----------------------------- | -------- |
-| [style](../view-style-props/) | No       |
+| Type                         | Required |
+| ---------------------------- | -------- |
+| [style](view-style-props.md) | No       |
 
 # Known issues
 

--- a/docs/pages/versions/v39.0.0/react-native/keyboardavoidingview.md
+++ b/docs/pages/versions/v39.0.0/react-native/keyboardavoidingview.md
@@ -71,7 +71,7 @@ const styles = StyleSheet.create({
 
 ## Props
 
-Inherits [View Props](../view/#props).
+Inherits [View Props](view.md#props).
 
 ### `behavior`
 

--- a/docs/pages/versions/v39.0.0/react-native/layout-props.md
+++ b/docs/pages/versions/v39.0.0/react-native/layout-props.md
@@ -367,7 +367,7 @@ When `flex` is -1, the component is normally sized according to `width` and `hei
 
 ### `flexShrink`
 
-[`flexShrink`](../layout-props/#flexshrink) describes how to shrink children along the main axis in the case in which the total size of the children overflows the size of the container on the main axis. `flexShrink` is very similar to `flexGrow` and can be thought of in the same way if any overflowing size is considered to be negative remaining space. These two properties also work well together by allowing children to grow and shrink as needed.
+[`flexShrink`](layout-props.md#flexshrink) describes how to shrink children along the main axis in the case in which the total size of the children overflows the size of the container on the main axis. `flexShrink` is very similar to `flexGrow` and can be thought of in the same way if any overflowing size is considered to be negative remaining space. These two properties also work well together by allowing children to grow and shrink as needed.
 
 `flexShrink` accepts any floating point value >= 0, with 1 being the default value. A container will shrink its children weighted by the children’s `flexShrink` values.
 

--- a/docs/pages/versions/v39.0.0/react-native/layoutanimation.md
+++ b/docs/pages/versions/v39.0.0/react-native/layoutanimation.md
@@ -92,7 +92,7 @@ Schedules an animation to happen on the next layout.
 | config            | object   | Yes      | See config description below.                              |
 | onAnimationDidEnd | function | No       | Called when the animation finished. Only supported on iOS. |
 
-The `config` parameter is an object with the keys below. [`create`](../layoutanimation/#create) returns a valid object for `config`, and the [`Presets`](../layoutanimation/#presets) objects can also all be passed as the `config`.
+The `config` parameter is an object with the keys below. [`create`](layoutanimation.md#create) returns a valid object for `config`, and the [`Presets`](layoutanimation.md#presets) objects can also all be passed as the `config`.
 
 - `duration` in milliseconds
 - `create`, optional config for animating in new views
@@ -101,8 +101,8 @@ The `config` parameter is an object with the keys below. [`create`](../layoutani
 
 The config that's passed to `create`, `update`, or `delete` has the following keys:
 
-- `type`, the [animation type](../layoutanimation/#types) to use
-- `property`, the [layout property](../layoutanimation/#properties) to animate (optional, but recommended for `create` and `delete`)
+- `type`, the [animation type](layoutanimation.md#types) to use
+- `property`, the [layout property](layoutanimation.md#properties) to animate (optional, but recommended for `create` and `delete`)
 - `springDamping` (number, optional and only for use with `type: Type.spring`)
 - `initialVelocity` (number, optional)
 - `delay` (number, optional)
@@ -116,7 +116,7 @@ The config that's passed to `create`, `update`, or `delete` has the following ke
 static create(duration, type, creationProp)
 ```
 
-Helper that creates an object (with `create`, `update`, and `delete` fields) to pass into [`configureNext`](../layoutanimation/#configurenext). The `type` parameter is an [animation type](../layoutanimation/#types), and the `creationProp` parameter is a [layout property](../layoutanimation/#properties).
+Helper that creates an object (with `create`, `update`, and `delete` fields) to pass into [`configureNext`](layoutanimation.md#configurenext). The `type` parameter is an [animation type](layoutanimation.md#types), and the `creationProp` parameter is a [layout property](layoutanimation.md#properties).
 
 Example usage:
 
@@ -176,7 +176,7 @@ const styles = StyleSheet.create({
 
 ### Types
 
-An enumeration of animation types to be used in the [`create`](../layoutanimation/#create) method, or in the `create`/`update`/`delete` configs for [`configureNext`](../layoutanimation/#configurenext). (example usage: `LayoutAnimation.Types.easeIn`)
+An enumeration of animation types to be used in the [`create`](layoutanimation.md#create) method, or in the `create`/`update`/`delete` configs for [`configureNext`](layoutanimation.md#configurenext). (example usage: `LayoutAnimation.Types.easeIn`)
 
 | Types         |
 | ------------- |
@@ -191,7 +191,7 @@ An enumeration of animation types to be used in the [`create`](../layoutanimatio
 
 ### Properties
 
-An enumeration of layout properties to be animated to be used in the [`create`](../layoutanimation/#create) method, or in the `create`/`update`/`delete` configs for [`configureNext`](../layoutanimation/#configurenext). (example usage: `LayoutAnimation.Properties.opacity`)
+An enumeration of layout properties to be animated to be used in the [`create`](layoutanimation.md#create) method, or in the `create`/`update`/`delete` configs for [`configureNext`](layoutanimation.md#configurenext). (example usage: `LayoutAnimation.Properties.opacity`)
 
 | Properties |
 | ---------- |
@@ -204,7 +204,7 @@ An enumeration of layout properties to be animated to be used in the [`create`](
 
 ### Presets
 
-A set of predefined animation configs to pass into [`configureNext`](../layoutanimation/#configurenext).
+A set of predefined animation configs to pass into [`configureNext`](layoutanimation.md#configurenext).
 
 | Presets       | Value                                                                                                                                                                 |
 | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/pages/versions/v39.0.0/react-native/modal.md
+++ b/docs/pages/versions/v39.0.0/react-native/modal.md
@@ -96,7 +96,7 @@ const styles = StyleSheet.create({
 
 ### `animated`
 
-> **Deprecated.** Use the [`animationType`](../modal/#animationtype) prop instead.
+> **Deprecated.** Use the [`animationType`](modal.md#animationtype) prop instead.
 
 ---
 

--- a/docs/pages/versions/v39.0.0/react-native/panresponder.md
+++ b/docs/pages/versions/v39.0.0/react-native/panresponder.md
@@ -152,7 +152,7 @@ static create(config)
 | ------ | ------ | -------- | ----------- |
 | config | object | Yes      | Refer below |
 
-The config object provides enhanced versions of all of the responder callbacks that provide not only the [`PressEvent`](../pressevent/), but also the `PanResponder` gesture state, by replacing the word `Responder` with `PanResponder` in each of the typical `onResponder*` callbacks. For example, the `config` object would look like:
+The config object provides enhanced versions of all of the responder callbacks that provide not only the [`PressEvent`](pressevent.md), but also the `PanResponder` gesture state, by replacing the word `Responder` with `PanResponder` in each of the typical `onResponder*` callbacks. For example, the `config` object would look like:
 
 - `onMoveShouldSetPanResponder: (e, gestureState) => {...}`
 - `onMoveShouldSetPanResponderCapture: (e, gestureState) => {...}`

--- a/docs/pages/versions/v39.0.0/react-native/pressable.md
+++ b/docs/pages/versions/v39.0.0/react-native/pressable.md
@@ -191,7 +191,7 @@ Either view styles or a function that receives a boolean reflecting whether the 
 
 | Type                                  | Required |
 | ------------------------------------- | -------- |
-| [ViewStyleProp](../view-style-props/) | No       |
+| [ViewStyleProp](view-style-props.md) | No       |
 
 ### `testOnly_pressed`
 

--- a/docs/pages/versions/v39.0.0/react-native/refreshcontrol.md
+++ b/docs/pages/versions/v39.0.0/react-native/refreshcontrol.md
@@ -60,7 +60,7 @@ const styles = StyleSheet.create({
 
 ## Props
 
-Inherits [View Props](../view/#props).
+Inherits [View Props](view.md#props).
 
 ### `refreshing`
 

--- a/docs/pages/versions/v39.0.0/react-native/safeareaview.md
+++ b/docs/pages/versions/v39.0.0/react-native/safeareaview.md
@@ -36,7 +36,7 @@ const styles = StyleSheet.create({
 
 ## Props
 
-Inherits [View Props](../view/#props).
+Inherits [View Props](view.md#props).
 
 As padding is used to implement the behavior of the component, padding rules in styles applied to a `SafeAreaView` will be ignored and can cause different results depending on the platform. See [#22211](https://github.com/facebook/react-native/issues/22211) for details.
 

--- a/docs/pages/versions/v39.0.0/react-native/scrollview.md
+++ b/docs/pages/versions/v39.0.0/react-native/scrollview.md
@@ -9,7 +9,7 @@ Keep in mind that ScrollViews must have a bounded height in order to work, since
 
 Doesn't yet support other contained responders from blocking this scroll view from becoming the responder.
 
-`<ScrollView>` vs [`<FlatList>`](../flatlist/) - which one to use?
+`<ScrollView>` vs [`<FlatList>`](flatlist.md) - which one to use?
 
 `ScrollView` renders all its react child components at once, but this has a performance downside.
 
@@ -64,7 +64,7 @@ const styles = StyleSheet.create({
 
 ## Props
 
-Inherits [View Props](../view/#props).
+Inherits [View Props](view.md#props).
 
 ### `alwaysBounceHorizontal`
 
@@ -504,7 +504,7 @@ When true, ScrollView allows use of pinch gestures to zoom in and out. The defau
 
 A RefreshControl component, used to provide pull-to-refresh functionality for the ScrollView. Only works for vertical ScrollViews (`horizontal` prop must be `false`).
 
-See [RefreshControl](../refreshcontrol/).
+See [RefreshControl](refreshcontrol.md).
 
 | Type    | Required |
 | ------- | -------- |

--- a/docs/pages/versions/v39.0.0/react-native/sectionlist.md
+++ b/docs/pages/versions/v39.0.0/react-native/sectionlist.md
@@ -16,7 +16,7 @@ A performant interface for rendering sectioned lists, supporting the most handy 
 - Pull to Refresh.
 - Scroll loading.
 
-If you don't need section support and want a simpler interface, use [`<FlatList>`](../flatlist/).
+If you don't need section support and want a simpler interface, use [`<FlatList>`](flatlist.md).
 
 ## Example
 
@@ -84,7 +84,7 @@ const styles = StyleSheet.create({
 });
 ```
 
-This is a convenience wrapper around [`<VirtualizedList>`](../virtualizedlist/), and thus inherits its props (as well as those of [`<ScrollView>`](../scrollview/) that aren't explicitly listed here, along with the following caveats:
+This is a convenience wrapper around [`<VirtualizedList>`](virtualizedlist.md), and thus inherits its props (as well as those of [`<ScrollView>`](scrollview.md) that aren't explicitly listed here, along with the following caveats:
 
 - Internal state is not preserved when content scrolls out of the render window. Make sure all your data is captured in the item data or external stores like Flux, Redux, or Relay.
 - This is a `PureComponent` which means that it will not re-render if `props` remain shallow-equal. Make sure that everything your `renderItem` function depends on is passed as a prop (e.g. `extraData`) that is not `===` after updates, otherwise your UI may not update on changes. This includes the `data` prop and parent component state.
@@ -97,7 +97,7 @@ This is a convenience wrapper around [`<VirtualizedList>`](../virtualizedlist/),
 
 ## Props
 
-Inherits [ScrollView Props](../scrollview/#props).
+Inherits [ScrollView Props](scrollview.md#props).
 
 ### `renderItem`
 
@@ -123,11 +123,11 @@ The render function will be passed an object with the following keys:
 
 ### `sections`
 
-The actual data to render, akin to the `data` prop in [`FlatList`](../flatlist/).
+The actual data to render, akin to the `data` prop in [`FlatList`](flatlist.md).
 
 | Type                                         | Required |
 | -------------------------------------------- | -------- |
-| array of [Section](../sectionlist/#section)s | Yes      |
+| array of [Section](sectionlist.md#section)s | Yes      |
 
 ---
 
@@ -390,8 +390,8 @@ An object that identifies the data to be rendered for a given section.
 
 | Name                     | Type                         | Description                                                                                                                                                             |
 | ------------------------ | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| data                     | array                        | The data for rendering items in this section. Array of objects, much like [`FlatList`'s data prop](../flatlist/#data).                                                  |
+| data                     | array                        | The data for rendering items in this section. Array of objects, much like [`FlatList`'s data prop](flatlist.md#data).                                                  |
 | [key]                    | string                       | Optional key to keep track of section re-ordering. If you don't plan on re-ordering sections, the array index will be used by default.                                  |
-| [renderItem]             | function                     | Optionally define an arbitrary item renderer for this section, overriding the default [`renderItem`](../sectionlist/#renderitem) for the list.                          |
-| [ItemSeparatorComponent] | component, function, element | Optionally define an arbitrary item separator for this section, overriding the default [`ItemSeparatorComponent`](../sectionlist/#itemseparatorcomponent) for the list. |
-| [keyExtractor]           | function                     | Optionally define an arbitrary key extractor for this section, overriding the default [`keyExtractor`](../sectionlist/#keyextractor).                                   |
+| [renderItem]             | function                     | Optionally define an arbitrary item renderer for this section, overriding the default [`renderItem`](sectionlist.md#renderitem) for the list.                          |
+| [ItemSeparatorComponent] | component, function, element | Optionally define an arbitrary item separator for this section, overriding the default [`ItemSeparatorComponent`](sectionlist.md#itemseparatorcomponent) for the list. |
+| [keyExtractor]           | function                     | Optionally define an arbitrary key extractor for this section, overriding the default [`keyExtractor`](sectionlist.md#keyextractor).                                   |

--- a/docs/pages/versions/v39.0.0/react-native/shadow-props.md
+++ b/docs/pages/versions/v39.0.0/react-native/shadow-props.md
@@ -99,7 +99,7 @@ export default App;
 
 # Reference
 
-These properties are iOS only - for similar functionality on Android, use the [`elevation` property](../view-style-props/#elevation).
+These properties are iOS only - for similar functionality on Android, use the [`elevation` property](view-style-props.md#elevation).
 
 ## Props
 

--- a/docs/pages/versions/v39.0.0/react-native/switch.md
+++ b/docs/pages/versions/v39.0.0/react-native/switch.md
@@ -45,7 +45,7 @@ const styles = StyleSheet.create({
 
 ## Props
 
-Inherits [View Props](../view/#props).
+Inherits [View Props](view.md#props).
 
 ### `disabled`
 
@@ -101,7 +101,7 @@ Color of the foreground switch grip. If this is set on iOS, the switch grip will
 
 Custom colors for the switch track.
 
-_iOS_: When the switch value is false, the track shrinks into the border. If you want to change the color of the background exposed by the shrunken track, use [`ios_backgroundColor`](../switch/#ios_backgroundColor).
+_iOS_: When the switch value is false, the track shrinks into the border. If you want to change the color of the background exposed by the shrunken track, use [`ios_backgroundColor`](switch.md#ios_backgroundColor).
 
 | Type                                                                                                              | Required |
 | ----------------------------------------------------------------------------------------------------------------- | -------- |

--- a/docs/pages/versions/v39.0.0/react-native/text.md
+++ b/docs/pages/versions/v39.0.0/react-native/text.md
@@ -547,7 +547,7 @@ The highlight color of the text.
 | ----- | -------- |
 | style | No       |
 
-- [View Style Props...](../view-style-props/#style)
+- [View Style Props...](view-style-props.md#props)
 
 - **`textShadowOffset`**: object: {width: number,height: number}
 

--- a/docs/pages/versions/v39.0.0/react-native/textinput.md
+++ b/docs/pages/versions/v39.0.0/react-native/textinput.md
@@ -75,7 +75,7 @@ Note that on Android performing text selection in input can change app's activit
 
 ## Props
 
-Inherits [View Props](../view/#props).
+Inherits [View Props](view.md#props).
 
 ### `allowFontScaling`
 
@@ -303,7 +303,7 @@ Padding between the inline image, if any, and the text input itself.
 
 ### `inputAccessoryViewID`
 
-An optional identifier which links a custom [InputAccessoryView](../inputaccessoryview/) to this text input. The InputAccessoryView is rendered above the keyboard when this text input is focused.
+An optional identifier which links a custom [InputAccessoryView](inputaccessoryview.md) to this text input. The InputAccessoryView is rendered above the keyboard when this text input is focused.
 
 | Type   | Required | Platform |
 | ------ | -------- | -------- |
@@ -767,7 +767,7 @@ see [Issue#7070](https://github.com/facebook/react-native/issues/7070) for more 
 
 | Type                   | Required |
 | ---------------------- | -------- |
-| [Text](../text/#style) | No       |
+| [Text](text.md#style) | No       |
 
 ---
 

--- a/docs/pages/versions/v39.0.0/react-native/touchablehighlight.md
+++ b/docs/pages/versions/v39.0.0/react-native/touchablehighlight.md
@@ -3,7 +3,7 @@ id: touchablehighlight
 title: TouchableHighlight
 ---
 
-> If you're looking for a more extensive and future-proof way to handle touch-based input, check out the [Pressable](../pressable/) API.
+> If you're looking for a more extensive and future-proof way to handle touch-based input, check out the [Pressable](pressable.md) API.
 
 A wrapper for making views respond properly to touches. On press down, the opacity of the wrapped view is decreased, which allows the underlay color to show through, darkening or tinting the view.
 
@@ -78,7 +78,7 @@ export default TouchableHighlightExample;
 
 ## Props
 
-Inherits [TouchableWithoutFeedback Props](../touchablewithoutfeedback/#props).
+Inherits [TouchableWithoutFeedback Props](touchablewithoutfeedback.md#props).
 
 ### `activeOpacity`
 

--- a/docs/pages/versions/v39.0.0/react-native/touchablenativefeedback.md
+++ b/docs/pages/versions/v39.0.0/react-native/touchablenativefeedback.md
@@ -3,7 +3,7 @@ id: touchablenativefeedback
 title: TouchableNativeFeedback
 ---
 
-> If you're looking for a more extensive and future-proof way to handle touch-based input, check out the [Pressable](../pressable/) API.
+> If you're looking for a more extensive and future-proof way to handle touch-based input, check out the [Pressable](pressable.md) API.
 
 A wrapper for making views respond properly to touches (Android only). On Android this component uses native state drawable to display touch feedback.
 
@@ -64,7 +64,7 @@ export default App;
 
 ## Props
 
-Inherits [TouchableWithoutFeedback Props](../touchablewithoutfeedback/#props).
+Inherits [TouchableWithoutFeedback Props](touchablewithoutfeedback.md#props).
 
 ### `background`
 

--- a/docs/pages/versions/v39.0.0/react-native/touchableopacity.md
+++ b/docs/pages/versions/v39.0.0/react-native/touchableopacity.md
@@ -3,7 +3,7 @@ id: touchableopacity
 title: TouchableOpacity
 ---
 
-> If you're looking for a more extensive and future-proof way to handle touch-based input, check out the [Pressable](../pressable/) API.
+> If you're looking for a more extensive and future-proof way to handle touch-based input, check out the [Pressable](pressable.md) API.
 
 A wrapper for making views respond properly to touches. On press down, the opacity of the wrapped view is decreased, dimming it.
 
@@ -57,7 +57,7 @@ export default App;
 
 ## Props
 
-Inherits [TouchableWithoutFeedback Props](../touchablewithoutfeedback/#props).
+Inherits [TouchableWithoutFeedback Props](touchablewithoutfeedback.md#props).
 
 ### `style`
 

--- a/docs/pages/versions/v39.0.0/react-native/touchablewithoutfeedback.md
+++ b/docs/pages/versions/v39.0.0/react-native/touchablewithoutfeedback.md
@@ -3,7 +3,7 @@ id: touchablewithoutfeedback
 title: TouchableWithoutFeedback
 ---
 
-> If you're looking for a more extensive and future-proof way to handle touch-based input, check out the [Pressable](../pressable/) API.
+> If you're looking for a more extensive and future-proof way to handle touch-based input, check out the [Pressable](pressable.md) API.
 
 Do not use unless you have a very good reason. All elements that respond to press should have a visual feedback when touched.
 

--- a/docs/pages/versions/v39.0.0/react-native/transforms.md
+++ b/docs/pages/versions/v39.0.0/react-native/transforms.md
@@ -190,4 +190,4 @@ transform([{ skewX: '45deg' }]);
 
 ### `decomposedMatrix`, `rotation`, `scaleX`, `scaleY`, `transformMatrix`, `translateX`, `translateY`
 
-> **Deprecated.** Use the [`transform`](../transforms/#transform) prop instead.
+> **Deprecated.** Use the [`transform`](transforms.md#transform) prop instead.

--- a/docs/pages/versions/v39.0.0/react-native/usecolorscheme.md
+++ b/docs/pages/versions/v39.0.0/react-native/usecolorscheme.md
@@ -7,7 +7,7 @@ title: useColorScheme
 import { useColorScheme } from 'react-native';
 ```
 
-The `useColorScheme` React hook provides and subscribes to color scheme updates from the [`Appearance`](../../sdk/appearance/) module. The return value indicates the current user preferred color scheme. The value may be updated later, either through direct user action (e.g. theme selection in device settings) or on a schedule (e.g. light and dark themes that follow the day/night cycle).
+The `useColorScheme` React hook provides and subscribes to color scheme updates from the [`Appearance`](../sdk/appearance.md) module. The return value indicates the current user preferred color scheme. The value may be updated later, either through direct user action (e.g. theme selection in device settings) or on a schedule (e.g. light and dark themes that follow the day/night cycle).
 
 Supported color schemes:
 

--- a/docs/pages/versions/v39.0.0/react-native/view.md
+++ b/docs/pages/versions/v39.0.0/react-native/view.md
@@ -472,7 +472,7 @@ This is a reserved performance property exposed by `RCTView` and is useful for s
 
 | Type                                | Required |
 | ----------------------------------- | -------- |
-| [view styles](../view-style-props/) | No       |
+| [view styles](view-style-props.md) | No       |
 
 ---
 

--- a/docs/pages/versions/v39.0.0/react-native/virtualizedlist.md
+++ b/docs/pages/versions/v39.0.0/react-native/virtualizedlist.md
@@ -3,7 +3,7 @@ id: virtualizedlist
 title: VirtualizedList
 ---
 
-Base implementation for the more convenient [`<FlatList>`](../flatlist/) and [`<SectionList>`](../sectionlist/) components, which are also better documented. In general, this should only really be used if you need more flexibility than [`FlatList`](../flatlist/) provides, e.g. for use with immutable data instead of plain arrays.
+Base implementation for the more convenient [`<FlatList>`](flatlist.md) and [`<SectionList>`](sectionlist.md) components, which are also better documented. In general, this should only really be used if you need more flexibility than [`FlatList`](flatlist.md) provides, e.g. for use with immutable data instead of plain arrays.
 
 Virtualization massively improves memory consumption and performance of large lists by maintaining a finite render window of active items and replacing all items outside of the render window with appropriately sized blank space. The window adapts to scrolling behavior, and items are rendered incrementally with low-pri (after any running interactions) if they are far from the visible area, or with hi-pri otherwise to minimize the potential of seeing blank space.
 
@@ -88,7 +88,7 @@ Some caveats:
 
 ## Props
 
-Inherits [ScrollView Props](../scrollview/#props).
+Inherits [ScrollView Props](scrollview.md#props).
 
 ### `renderItem`
 
@@ -199,7 +199,7 @@ Reverses the direction of scroll. Uses scale transforms of -1.
 
 ### `CellRendererComponent`
 
-Each cell is rendered using this element. Can be a React Component Class,or a render function. Defaults to using [`View`](../view/).
+Each cell is rendered using this element. Can be a React Component Class,or a render function. Defaults to using [`View`](view.md).
 
 | Type                | Required |
 | ------------------- | -------- |

--- a/docs/pages/versions/v40.0.0/react-native/activityindicator.md
+++ b/docs/pages/versions/v40.0.0/react-native/activityindicator.md
@@ -39,7 +39,7 @@ const styles = StyleSheet.create({
 
 ## Props
 
-Inherits [View Props](../view/#props).
+Inherits [View Props](view.md#props).
 
 ---
 

--- a/docs/pages/versions/v40.0.0/react-native/animated.md
+++ b/docs/pages/versions/v40.0.0/react-native/animated.md
@@ -85,8 +85,8 @@ Refer to the [Animations](https://reactnative.dev/docs/animations#animated-api) 
 
 There are two value types you can use with `Animated`:
 
-- [`Animated.Value()`](../animated/#value) for single values
-- [`Animated.ValueXY()`](../animated/#valuexy) for vectors
+- [`Animated.Value()`](animated.md#value) for single values
+- [`Animated.ValueXY()`](animated.md#valuexy) for vectors
 
 `Animated.Value` can bind to style properties or other props, and can be interpolated as well. A single `Animated.Value` can drive any number of properties.
 
@@ -94,9 +94,9 @@ There are two value types you can use with `Animated`:
 
 `Animated` provides three types of animation types. Each animation type provides a particular animation curve that controls how your values animate from their initial value to the final value:
 
-- [`Animated.decay()`](../animated/#decay) starts with an initial velocity and gradually slows to a stop.
-- [`Animated.spring()`](../animated/#spring) provides a basic spring physics model.
-- [`Animated.timing()`](../animated/#timing) animates a value over time using [easing functions](../easing/).
+- [`Animated.decay()`](animated.md#decay) starts with an initial velocity and gradually slows to a stop.
+- [`Animated.spring()`](animated.md#spring) provides a basic spring physics model.
+- [`Animated.timing()`](animated.md#timing) animates a value over time using [easing functions](easing.md).
 
 In most cases, you will be using `timing()`. By default, it uses a symmetric easeInOut curve that conveys the gradual acceleration of an object to full speed and concludes by gradually decelerating to a stop.
 
@@ -120,7 +120,7 @@ You can use the native driver by specifying `useNativeDriver: true` in your anim
 
 Only animatable components can be animated. These unique components do the magic of binding the animated values to the properties, and do targeted native updates to avoid the cost of the react render and reconciliation process on every frame. They also handle cleanup on unmount so they are safe by default.
 
-- [`createAnimatedComponent()`](../animated/#createanimatedcomponent) can be used to make a component animatable.
+- [`createAnimatedComponent()`](animated.md#createanimatedcomponent) can be used to make a component animatable.
 
 `Animated` exports the following animatable components using the above wrapper:
 
@@ -135,10 +135,10 @@ Only animatable components can be animated. These unique components do the magic
 
 Animations can also be combined in complex ways using composition functions:
 
-- [`Animated.delay()`](../animated/#delay) starts an animation after a given delay.
-- [`Animated.parallel()`](../animated/#parallel) starts a number of animations at the same time.
-- [`Animated.sequence()`](../animated/#sequence) starts the animations in order, waiting for each to complete before starting the next.
-- [`Animated.stagger()`](../animated/#stagger) starts animations in order and in parallel, but with successive delays.
+- [`Animated.delay()`](animated.md#delay) starts an animation after a given delay.
+- [`Animated.parallel()`](animated.md#parallel) starts a number of animations at the same time.
+- [`Animated.sequence()`](animated.md#sequence) starts the animations in order, waiting for each to complete before starting the next.
+- [`Animated.stagger()`](animated.md#stagger) starts animations in order and in parallel, but with successive delays.
 
 Animations can also be chained together by setting the `toValue` of one animation to be another `Animated.Value`. See [Tracking dynamic values](https://reactnative.dev/docs/animations#tracking-dynamic-values) in the Animations guide.
 
@@ -148,17 +148,17 @@ By default, if one animation is stopped or interrupted, then all other animation
 
 You can combine two animated values via addition, subtraction, multiplication, division, or modulo to make a new animated value:
 
-- [`Animated.add()`](../animated/#add)
-- [`Animated.subtract()`](../animated/#subtract)
-- [`Animated.divide()`](../animated/#divide)
-- [`Animated.modulo()`](../animated/#modulo)
-- [`Animated.multiply()`](../animated/#multiply)
+- [`Animated.add()`](animated.md#add)
+- [`Animated.subtract()`](animated.md#subtract)
+- [`Animated.divide()`](animated.md#divide)
+- [`Animated.modulo()`](animated.md#modulo)
+- [`Animated.multiply()`](animated.md#multiply)
 
 ### Interpolation
 
 The `interpolate()` function allows input ranges to map to different output ranges. By default, it will extrapolate the curve beyond the ranges given, but you can also have it clamp the output value. It uses linear interpolation by default but also supports easing functions.
 
-- [`interpolate()`](../animated/#interpolate)
+- [`interpolate()`](animated.md#interpolation)
 
 Read more about interpolation in the [Animation](https://reactnative.dev/docs/animations#interpolation) guide.
 
@@ -166,7 +166,7 @@ Read more about interpolation in the [Animation](https://reactnative.dev/docs/an
 
 Gestures, like panning or scrolling, and other events can map directly to animated values using `Animated.event()`. This is done with a structured map syntax so that values can be extracted from complex event objects. The first level is an array to allow mapping across multiple args, and that array contains nested objects.
 
-- [`Animated.event()`](../animated/#event)
+- [`Animated.event()`](animated.md#event)
 
 For example, when working with horizontal scrolling gestures, you would do the following in order to map `event.nativeEvent.contentOffset.x` to `scrollX` (an `Animated.Value`):
 
@@ -213,7 +213,7 @@ Config is an object that may have the following options:
 static timing(value, config)
 ```
 
-Animates a value along a timed easing curve. The [`Easing`](../easing/) module has tons of predefined curves, or you can use your own function.
+Animates a value along a timed easing curve. The [`Easing`](easing.md) module has tons of predefined curves, or you can use your own function.
 
 Config is an object that may have the following options:
 
@@ -472,7 +472,7 @@ Stops any running animation and resets the value to its original.
 
 Standard value class for driving animations. Typically initialized with `new Animated.Value(0);`
 
-You can read more about `Animated.Value` API on the separate [page](../animatedvalue/).
+You can read more about `Animated.Value` API on the separate [page](animatedvalue.md).
 
 ---
 
@@ -480,7 +480,7 @@ You can read more about `Animated.Value` API on the separate [page](../animatedv
 
 2D value class for driving 2D animations, such as pan gestures.
 
-You can read more about `Animated.ValueXY` API on the separate [page](../animatedvaluexy/).
+You can read more about `Animated.ValueXY` API on the separate [page](animatedvaluexy.md).
 
 ---
 

--- a/docs/pages/versions/v40.0.0/react-native/animatedvaluexy.md
+++ b/docs/pages/versions/v40.0.0/react-native/animatedvaluexy.md
@@ -3,7 +3,7 @@ id: animatedvaluexy
 title: Animated.ValueXY
 ---
 
-2D Value for driving 2D animations, such as pan gestures. Almost identical API to normal [`Animated.Value`](../animatedvalue/), but multiplexed. Contains two regular `Animated.Value`s under the hood.
+2D Value for driving 2D animations, such as pan gestures. Almost identical API to normal [`Animated.Value`](animatedvalue.md), but multiplexed. Contains two regular `Animated.Value`s under the hood.
 
 ## Example
 

--- a/docs/pages/versions/v40.0.0/react-native/appearance.md
+++ b/docs/pages/versions/v40.0.0/react-native/appearance.md
@@ -28,7 +28,7 @@ if (colorScheme === 'dark') {
 }
 ```
 
-Although the color scheme is available immediately, this may change (e.g. scheduled color scheme change at sunrise or sunset). Any rendering logic or styles that depend on the user preferred color scheme should try to call this function on every render, rather than caching the value. For example, you may use the [`useColorScheme`](../usecolorscheme/) React hook as it provides and subscribes to color scheme updates, or you may use inline styles rather than setting a value in a `StyleSheet`.
+Although the color scheme is available immediately, this may change (e.g. scheduled color scheme change at sunrise or sunset). Any rendering logic or styles that depend on the user preferred color scheme should try to call this function on every render, rather than caching the value. For example, you may use the [`useColorScheme`](usecolorscheme.md) React hook as it provides and subscribes to color scheme updates, or you may use inline styles rather than setting a value in a `StyleSheet`.
 
 # Reference
 

--- a/docs/pages/versions/v40.0.0/react-native/backhandler.md
+++ b/docs/pages/versions/v40.0.0/react-native/backhandler.md
@@ -10,7 +10,7 @@ The event subscriptions are called in reverse order (i.e. the last registered su
 - **If one subscription returns true,** then subscriptions registered earlier will not be called.
 - **If no subscription returns true or none are registered,** it programmatically invokes the default back button functionality to exit the app.
 
-> **Warning for modal users:** If your app shows an opened `Modal`, `BackHandler` will not publish any events ([see `Modal` docs](../modal/#onrequestclose)).
+> **Warning for modal users:** If your app shows an opened `Modal`, `BackHandler` will not publish any events ([see `Modal` docs](modal.md#onrequestclose)).
 
 ## Pattern
 

--- a/docs/pages/versions/v40.0.0/react-native/button.md
+++ b/docs/pages/versions/v40.0.0/react-native/button.md
@@ -5,7 +5,7 @@ title: Button
 
 A basic button component that should render nicely on any platform. Supports a minimal level of customization.
 
-If this button doesn't look right for your app, you can build your own button using [TouchableOpacity](../touchableopacity/) or [TouchableWithoutFeedback](../touchablewithoutfeedback/). For inspiration, look at the [source code for this button component](https://github.com/facebook/react-native/blob/master/Libraries/Components/Button.js). Or, take a look at the [wide variety of button components built by the community](https://js.coach/?menu%5Bcollections%5D=React%20Native&page=1&query=button).
+If this button doesn't look right for your app, you can build your own button using [TouchableOpacity](touchableopacity.md) or [TouchableWithoutFeedback](touchablewithoutfeedback.md). For inspiration, look at the [source code for this button component](https://github.com/facebook/react-native/blob/master/Libraries/Components/Button.js). Or, take a look at the [wide variety of button components built by the community](https://js.coach/?menu%5Bcollections%5D=React%20Native&page=1&query=button).
 
 ```js
 <Button

--- a/docs/pages/versions/v40.0.0/react-native/dimensions.md
+++ b/docs/pages/versions/v40.0.0/react-native/dimensions.md
@@ -3,7 +3,7 @@ id: dimensions
 title: Dimensions
 ---
 
-> [`useWindowDimensions`](../usewindowdimensions/) is the preferred API for React components. Unlike `Dimensions`, it updates as the window's dimensions update. This works nicely with the React paradigm.
+> [`useWindowDimensions`](usewindowdimensions.md) is the preferred API for React components. Unlike `Dimensions`, it updates as the window's dimensions update. This works nicely with the React paradigm.
 
 ```js
 import { Dimensions } from 'react-native';

--- a/docs/pages/versions/v40.0.0/react-native/easing.md
+++ b/docs/pages/versions/v40.0.0/react-native/easing.md
@@ -3,7 +3,7 @@ id: easing
 title: Easing
 ---
 
-The `Easing` module implements common easing functions. This module is used by [Animated.timing()](../animated/#timing) to convey physically believable motion in animations.
+The `Easing` module implements common easing functions. This module is used by [Animated.timing()](animated.md#timing) to convey physically believable motion in animations.
 
 You can find a visualization of some common easing functions at http://easings.net/
 
@@ -11,35 +11,35 @@ You can find a visualization of some common easing functions at http://easings.n
 
 The `Easing` module provides several predefined animations through the following methods:
 
-- [`back`](../easing/#back) provides a basic animation where the object goes slightly back before moving forward
-- [`bounce`](../easing/#bounce) provides a bouncing animation
-- [`ease`](../easing/#ease) provides a basic inertial animation
-- [`elastic`](../easing/#elastic) provides a basic spring interaction
+- [`back`](easing.md#back) provides a basic animation where the object goes slightly back before moving forward
+- [`bounce`](easing.md#bounce) provides a bouncing animation
+- [`ease`](easing.md#ease) provides a basic inertial animation
+- [`elastic`](easing.md#elastic) provides a basic spring interaction
 
 ### Standard functions
 
 Three standard easing functions are provided:
 
-- [`linear`](../easing/#linear)
-- [`quad`](../easing/#quad)
-- [`cubic`](../easing/#cubic)
+- [`linear`](easing.md#linear)
+- [`quad`](easing.md#quad)
+- [`cubic`](easing.md#cubic)
 
-The [`poly`](../easing/#poly) function can be used to implement quartic, quintic, and other higher power functions.
+The [`poly`](easing.md#poly) function can be used to implement quartic, quintic, and other higher power functions.
 
 ### Additional functions
 
 Additional mathematical functions are provided by the following methods:
 
-- [`bezier`](../easing/#bezier) provides a cubic bezier curve
-- [`circle`](../easing/#circle) provides a circular function
-- [`sin`](../easing/#sin) provides a sinusoidal function
-- [`exp`](../easing/#exp) provides an exponential function
+- [`bezier`](easing.md#bezier) provides a cubic bezier curve
+- [`circle`](easing.md#circle) provides a circular function
+- [`sin`](easing.md#sin) provides a sinusoidal function
+- [`exp`](easing.md#exp) provides an exponential function
 
 The following helpers are used to modify other easing functions.
 
-- [`in`](../easing/#in) runs an easing function forwards
-- [`inOut`](../easing/#inout) makes any easing function symmetrical
-- [`out`](../easing/#out) runs an easing function backwards
+- [`in`](easing.md#in) runs an easing function forwards
+- [`inOut`](easing.md#inout) makes any easing function symmetrical
+- [`out`](easing.md#out) runs an easing function backwards
 
 ## Example
 

--- a/docs/pages/versions/v40.0.0/react-native/flatlist.md
+++ b/docs/pages/versions/v40.0.0/react-native/flatlist.md
@@ -16,7 +16,7 @@ A performant interface for rendering basic, flat lists, supporting the most hand
 - ScrollToIndex support.
 - Multiple column support.
 
-If you need section support, use [`<SectionList>`](../sectionlist/).
+If you need section support, use [`<SectionList>`](sectionlist.md).
 
 ## Example
 
@@ -72,7 +72,7 @@ const styles = StyleSheet.create({
 });
 ```
 
-To render multiple columns, use the [`numColumns`](../flatlist/#numcolumns) prop. Using this approach instead of a `flexWrap` layout can prevent conflicts with the item height logic.
+To render multiple columns, use the [`numColumns`](flatlist.md#numcolumns) prop. Using this approach instead of a `flexWrap` layout can prevent conflicts with the item height logic.
 
 More complex, multi-select example demonstrating `` usage for perf optimization and avoiding bugs.
 
@@ -148,7 +148,7 @@ const styles = StyleSheet.create({
 });
 ```
 
-This is a convenience wrapper around [`<VirtualizedList>`](../virtualizedlist/), and thus inherits its props (as well as those of [`<ScrollView>`](../scrollview/)) that aren't explicitly listed here, along with the following caveats:
+This is a convenience wrapper around [`<VirtualizedList>`](virtualizedlist.md), and thus inherits its props (as well as those of [`<ScrollView>`](scrollview.md)) that aren't explicitly listed here, along with the following caveats:
 
 - Internal state is not preserved when content scrolls out of the render window. Make sure all your data is captured in the item data or external stores like Flux, Redux, or Relay.
 - This is a `PureComponent` which means that it will not re-render if `props` remain shallow-equal. Make sure that everything your `renderItem` function depends on is passed as a prop (e.g. `extraData`) that is not `===` after updates, otherwise your UI may not update on changes. This includes the `data` prop and parent component state.
@@ -161,7 +161,7 @@ This is a convenience wrapper around [`<VirtualizedList>`](../virtualizedlist/),
 
 ## Props
 
-Inherits [ScrollView Props](../scrollview/#props), unless it is nested in another FlatList of same orientation.
+Inherits [ScrollView Props](scrollview.md#props), unless it is nested in another FlatList of same orientation.
 
 ### `renderItem`
 
@@ -213,7 +213,7 @@ Example usage:
 
 ### `data`
 
-For simplicity, data is a plain array. If you want to use something else, like an immutable list, use the underlying [`VirtualizedList`](../virtualizedlist/) directly.
+For simplicity, data is a plain array. If you want to use something else, like an immutable list, use the underlying [`VirtualizedList`](virtualizedlist.md) directly.
 
 | Type  | Required |
 | ----- | -------- |

--- a/docs/pages/versions/v40.0.0/react-native/image.md
+++ b/docs/pages/versions/v40.0.0/react-native/image.md
@@ -114,13 +114,13 @@ dependencies {
 | ----- | -------- |
 | style | No       |
 
-- [Image Style Props...](../image-style-props/#props)
+- [Image Style Props...](image-style-props.md#props)
 
-- [Layout Props...](../layout-props/#props)
+- [Layout Props...](layout-props.md#props)
 
-- [Shadow Props...](../shadow-props/#props)
+- [Shadow Props...](shadow-props.md#props)
 
-- [Transforms...](../transforms/#props)
+- [Transforms...](transforms.md#transform)
 
 ---
 

--- a/docs/pages/versions/v40.0.0/react-native/imagebackground.md
+++ b/docs/pages/versions/v40.0.0/react-native/imagebackground.md
@@ -51,19 +51,19 @@ const styles = StyleSheet.create({
 
 ## Props
 
-Inherits [Image Props](../image/#props).
+Inherits [Image Props](image.md#props).
 
 ### `style`
 
 | Type                                | Required |
 | ----------------------------------- | -------- |
-| [view styles](../view-style-props/) | No       |
+| [view styles](view-style-props.md) | No       |
 
 ### `imageStyle`
 
 | Type                                  | Required |
 | ------------------------------------- | -------- |
-| [image styles](../image-style-props/) | No       |
+| [image styles](image-style-props.md) | No       |
 
 ### `imageRef`
 

--- a/docs/pages/versions/v40.0.0/react-native/inputaccessoryview.md
+++ b/docs/pages/versions/v40.0.0/react-native/inputaccessoryview.md
@@ -67,7 +67,7 @@ An ID which is used to associate this `InputAccessoryView` to specified TextInpu
 
 | Type                          | Required |
 | ----------------------------- | -------- |
-| [style](../view-style-props/) | No       |
+| [style](view-style-props.md) | No       |
 
 # Known issues
 

--- a/docs/pages/versions/v40.0.0/react-native/keyboardavoidingview.md
+++ b/docs/pages/versions/v40.0.0/react-native/keyboardavoidingview.md
@@ -71,7 +71,7 @@ const styles = StyleSheet.create({
 
 ## Props
 
-Inherits [View Props](../view/#props).
+Inherits [View Props](view.md#props).
 
 ### `behavior`
 

--- a/docs/pages/versions/v40.0.0/react-native/layout-props.md
+++ b/docs/pages/versions/v40.0.0/react-native/layout-props.md
@@ -367,7 +367,7 @@ When `flex` is -1, the component is normally sized according to `width` and `hei
 
 ### `flexShrink`
 
-[`flexShrink`](../layout-props/#flexshrink) describes how to shrink children along the main axis in the case in which the total size of the children overflows the size of the container on the main axis. `flexShrink` is very similar to `flexGrow` and can be thought of in the same way if any overflowing size is considered to be negative remaining space. These two properties also work well together by allowing children to grow and shrink as needed.
+[`flexShrink`](layout-props.md#flexshrink) describes how to shrink children along the main axis in the case in which the total size of the children overflows the size of the container on the main axis. `flexShrink` is very similar to `flexGrow` and can be thought of in the same way if any overflowing size is considered to be negative remaining space. These two properties also work well together by allowing children to grow and shrink as needed.
 
 `flexShrink` accepts any floating point value >= 0, with 1 being the default value. A container will shrink its children weighted by the children’s `flexShrink` values.
 

--- a/docs/pages/versions/v40.0.0/react-native/layoutanimation.md
+++ b/docs/pages/versions/v40.0.0/react-native/layoutanimation.md
@@ -92,7 +92,7 @@ Schedules an animation to happen on the next layout.
 | config            | object   | Yes      | See config description below.                              |
 | onAnimationDidEnd | function | No       | Called when the animation finished. Only supported on iOS. |
 
-The `config` parameter is an object with the keys below. [`create`](../layoutanimation/#create) returns a valid object for `config`, and the [`Presets`](../layoutanimation/#presets) objects can also all be passed as the `config`.
+The `config` parameter is an object with the keys below. [`create`](layoutanimation.md#create) returns a valid object for `config`, and the [`Presets`](layoutanimation.md#presets) objects can also all be passed as the `config`.
 
 - `duration` in milliseconds
 - `create`, optional config for animating in new views
@@ -101,8 +101,8 @@ The `config` parameter is an object with the keys below. [`create`](../layoutani
 
 The config that's passed to `create`, `update`, or `delete` has the following keys:
 
-- `type`, the [animation type](../layoutanimation/#types) to use
-- `property`, the [layout property](../layoutanimation/#properties) to animate (optional, but recommended for `create` and `delete`)
+- `type`, the [animation type](layoutanimation.md#types) to use
+- `property`, the [layout property](layoutanimation.md#properties) to animate (optional, but recommended for `create` and `delete`)
 - `springDamping` (number, optional and only for use with `type: Type.spring`)
 - `initialVelocity` (number, optional)
 - `delay` (number, optional)
@@ -116,7 +116,7 @@ The config that's passed to `create`, `update`, or `delete` has the following ke
 static create(duration, type, creationProp)
 ```
 
-Helper that creates an object (with `create`, `update`, and `delete` fields) to pass into [`configureNext`](../layoutanimation/#configurenext). The `type` parameter is an [animation type](../layoutanimation/#types), and the `creationProp` parameter is a [layout property](../layoutanimation/#properties).
+Helper that creates an object (with `create`, `update`, and `delete` fields) to pass into [`configureNext`](layoutanimation.md#configurenext). The `type` parameter is an [animation type](layoutanimation.md#types), and the `creationProp` parameter is a [layout property](layoutanimation.md#properties).
 
 Example usage:
 
@@ -176,7 +176,7 @@ const styles = StyleSheet.create({
 
 ### Types
 
-An enumeration of animation types to be used in the [`create`](../layoutanimation/#create) method, or in the `create`/`update`/`delete` configs for [`configureNext`](../layoutanimation/#configurenext). (example usage: `LayoutAnimation.Types.easeIn`)
+An enumeration of animation types to be used in the [`create`](layoutanimation.md#create) method, or in the `create`/`update`/`delete` configs for [`configureNext`](layoutanimation.md#configurenext). (example usage: `LayoutAnimation.Types.easeIn`)
 
 | Types         |
 | ------------- |
@@ -191,7 +191,7 @@ An enumeration of animation types to be used in the [`create`](../layoutanimatio
 
 ### Properties
 
-An enumeration of layout properties to be animated to be used in the [`create`](../layoutanimation/#create) method, or in the `create`/`update`/`delete` configs for [`configureNext`](../layoutanimation/#configurenext). (example usage: `LayoutAnimation.Properties.opacity`)
+An enumeration of layout properties to be animated to be used in the [`create`](layoutanimation.md#create) method, or in the `create`/`update`/`delete` configs for [`configureNext`](layoutanimation.md#configurenext). (example usage: `LayoutAnimation.Properties.opacity`)
 
 | Properties |
 | ---------- |
@@ -204,7 +204,7 @@ An enumeration of layout properties to be animated to be used in the [`create`](
 
 ### Presets
 
-A set of predefined animation configs to pass into [`configureNext`](../layoutanimation/#configurenext).
+A set of predefined animation configs to pass into [`configureNext`](layoutanimation.md#configurenext).
 
 | Presets       | Value                                                                                                                                                                 |
 | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/pages/versions/v40.0.0/react-native/modal.md
+++ b/docs/pages/versions/v40.0.0/react-native/modal.md
@@ -96,7 +96,7 @@ const styles = StyleSheet.create({
 
 ### `animated`
 
-> **Deprecated.** Use the [`animationType`](../modal/#animationtype) prop instead.
+> **Deprecated.** Use the [`animationType`](modal.md#animationtype) prop instead.
 
 ---
 

--- a/docs/pages/versions/v40.0.0/react-native/panresponder.md
+++ b/docs/pages/versions/v40.0.0/react-native/panresponder.md
@@ -152,7 +152,7 @@ static create(config)
 | ------ | ------ | -------- | ----------- |
 | config | object | Yes      | Refer below |
 
-The config object provides enhanced versions of all of the responder callbacks that provide not only the [`PressEvent`](../pressevent/), but also the `PanResponder` gesture state, by replacing the word `Responder` with `PanResponder` in each of the typical `onResponder*` callbacks. For example, the `config` object would look like:
+The config object provides enhanced versions of all of the responder callbacks that provide not only the [`PressEvent`](pressevent.md), but also the `PanResponder` gesture state, by replacing the word `Responder` with `PanResponder` in each of the typical `onResponder*` callbacks. For example, the `config` object would look like:
 
 - `onMoveShouldSetPanResponder: (e, gestureState) => {...}`
 - `onMoveShouldSetPanResponderCapture: (e, gestureState) => {...}`

--- a/docs/pages/versions/v40.0.0/react-native/pressable.md
+++ b/docs/pages/versions/v40.0.0/react-native/pressable.md
@@ -191,7 +191,7 @@ Either view styles or a function that receives a boolean reflecting whether the 
 
 | Type                                  | Required |
 | ------------------------------------- | -------- |
-| [ViewStyleProp](../view-style-props/) | No       |
+| [ViewStyleProp](view-style-props.md) | No       |
 
 ### `testOnly_pressed`
 

--- a/docs/pages/versions/v40.0.0/react-native/refreshcontrol.md
+++ b/docs/pages/versions/v40.0.0/react-native/refreshcontrol.md
@@ -60,7 +60,7 @@ const styles = StyleSheet.create({
 
 ## Props
 
-Inherits [View Props](../view/#props).
+Inherits [View Props](view.md#props).
 
 ### `refreshing`
 

--- a/docs/pages/versions/v40.0.0/react-native/safeareaview.md
+++ b/docs/pages/versions/v40.0.0/react-native/safeareaview.md
@@ -36,7 +36,7 @@ const styles = StyleSheet.create({
 
 ## Props
 
-Inherits [View Props](../view/#props).
+Inherits [View Props](view.md#props).
 
 As padding is used to implement the behavior of the component, padding rules in styles applied to a `SafeAreaView` will be ignored and can cause different results depending on the platform. See [#22211](https://github.com/facebook/react-native/issues/22211) for details.
 

--- a/docs/pages/versions/v40.0.0/react-native/scrollview.md
+++ b/docs/pages/versions/v40.0.0/react-native/scrollview.md
@@ -9,7 +9,7 @@ Keep in mind that ScrollViews must have a bounded height in order to work, since
 
 Doesn't yet support other contained responders from blocking this scroll view from becoming the responder.
 
-`<ScrollView>` vs [`<FlatList>`](../flatlist/) - which one to use?
+`<ScrollView>` vs [`<FlatList>`](flatlist.md) - which one to use?
 
 `ScrollView` renders all its react child components at once, but this has a performance downside.
 
@@ -64,7 +64,7 @@ const styles = StyleSheet.create({
 
 ## Props
 
-Inherits [View Props](../view/#props).
+Inherits [View Props](view.md#props).
 
 ### `alwaysBounceHorizontal`
 
@@ -504,7 +504,7 @@ When true, ScrollView allows use of pinch gestures to zoom in and out. The defau
 
 A RefreshControl component, used to provide pull-to-refresh functionality for the ScrollView. Only works for vertical ScrollViews (`horizontal` prop must be `false`).
 
-See [RefreshControl](../refreshcontrol/).
+See [RefreshControl](refreshcontrol.md).
 
 | Type    | Required |
 | ------- | -------- |

--- a/docs/pages/versions/v40.0.0/react-native/sectionlist.md
+++ b/docs/pages/versions/v40.0.0/react-native/sectionlist.md
@@ -16,7 +16,7 @@ A performant interface for rendering sectioned lists, supporting the most handy 
 - Pull to Refresh.
 - Scroll loading.
 
-If you don't need section support and want a simpler interface, use [`<FlatList>`](../flatlist/).
+If you don't need section support and want a simpler interface, use [`<FlatList>`](flatlist.md).
 
 ## Example
 
@@ -84,7 +84,7 @@ const styles = StyleSheet.create({
 });
 ```
 
-This is a convenience wrapper around [`<VirtualizedList>`](../virtualizedlist/), and thus inherits its props (as well as those of [`<ScrollView>`](../scrollview/) that aren't explicitly listed here, along with the following caveats:
+This is a convenience wrapper around [`<VirtualizedList>`](virtualizedlist.md), and thus inherits its props (as well as those of [`<ScrollView>`](scrollview.md) that aren't explicitly listed here, along with the following caveats:
 
 - Internal state is not preserved when content scrolls out of the render window. Make sure all your data is captured in the item data or external stores like Flux, Redux, or Relay.
 - This is a `PureComponent` which means that it will not re-render if `props` remain shallow-equal. Make sure that everything your `renderItem` function depends on is passed as a prop (e.g. `extraData`) that is not `===` after updates, otherwise your UI may not update on changes. This includes the `data` prop and parent component state.
@@ -97,7 +97,7 @@ This is a convenience wrapper around [`<VirtualizedList>`](../virtualizedlist/),
 
 ## Props
 
-Inherits [ScrollView Props](../scrollview/#props).
+Inherits [ScrollView Props](scrollview.md#props).
 
 ### `renderItem`
 
@@ -123,11 +123,11 @@ The render function will be passed an object with the following keys:
 
 ### `sections`
 
-The actual data to render, akin to the `data` prop in [`FlatList`](../flatlist/).
+The actual data to render, akin to the `data` prop in [`FlatList`](flatlist.md).
 
 | Type                                         | Required |
 | -------------------------------------------- | -------- |
-| array of [Section](../sectionlist/#section)s | Yes      |
+| array of [Section](sectionlist.md#section)s | Yes      |
 
 ---
 
@@ -390,8 +390,8 @@ An object that identifies the data to be rendered for a given section.
 
 | Name                     | Type                         | Description                                                                                                                                                             |
 | ------------------------ | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| data                     | array                        | The data for rendering items in this section. Array of objects, much like [`FlatList`'s data prop](../flatlist/#data).                                                  |
+| data                     | array                        | The data for rendering items in this section. Array of objects, much like [`FlatList`'s data prop](flatlist.md#data).                                                  |
 | [key]                    | string                       | Optional key to keep track of section re-ordering. If you don't plan on re-ordering sections, the array index will be used by default.                                  |
-| [renderItem]             | function                     | Optionally define an arbitrary item renderer for this section, overriding the default [`renderItem`](../sectionlist/#renderitem) for the list.                          |
-| [ItemSeparatorComponent] | component, function, element | Optionally define an arbitrary item separator for this section, overriding the default [`ItemSeparatorComponent`](../sectionlist/#itemseparatorcomponent) for the list. |
-| [keyExtractor]           | function                     | Optionally define an arbitrary key extractor for this section, overriding the default [`keyExtractor`](../sectionlist/#keyextractor).                                   |
+| [renderItem]             | function                     | Optionally define an arbitrary item renderer for this section, overriding the default [`renderItem`](sectionlist.md#renderitem) for the list.                          |
+| [ItemSeparatorComponent] | component, function, element | Optionally define an arbitrary item separator for this section, overriding the default [`ItemSeparatorComponent`](sectionlist.md#itemseparatorcomponent) for the list. |
+| [keyExtractor]           | function                     | Optionally define an arbitrary key extractor for this section, overriding the default [`keyExtractor`](sectionlist.md#keyextractor).                                   |

--- a/docs/pages/versions/v40.0.0/react-native/shadow-props.md
+++ b/docs/pages/versions/v40.0.0/react-native/shadow-props.md
@@ -99,7 +99,7 @@ export default App;
 
 # Reference
 
-These properties are iOS only - for similar functionality on Android, use the [`elevation` property](../view-style-props/#elevation).
+These properties are iOS only - for similar functionality on Android, use the [`elevation` property](view-style-props.md#elevation).
 
 ## Props
 

--- a/docs/pages/versions/v40.0.0/react-native/switch.md
+++ b/docs/pages/versions/v40.0.0/react-native/switch.md
@@ -45,7 +45,7 @@ const styles = StyleSheet.create({
 
 ## Props
 
-Inherits [View Props](../view/#props).
+Inherits [View Props](view.md#props).
 
 ### `disabled`
 
@@ -101,7 +101,7 @@ Color of the foreground switch grip. If this is set on iOS, the switch grip will
 
 Custom colors for the switch track.
 
-_iOS_: When the switch value is false, the track shrinks into the border. If you want to change the color of the background exposed by the shrunken track, use [`ios_backgroundColor`](../switch/#ios_backgroundColor).
+_iOS_: When the switch value is false, the track shrinks into the border. If you want to change the color of the background exposed by the shrunken track, use [`ios_backgroundColor`](switch.md#ios_backgroundColor).
 
 | Type                                                                                                              | Required |
 | ----------------------------------------------------------------------------------------------------------------- | -------- |

--- a/docs/pages/versions/v40.0.0/react-native/text.md
+++ b/docs/pages/versions/v40.0.0/react-native/text.md
@@ -547,7 +547,7 @@ The highlight color of the text.
 | ----- | -------- |
 | style | No       |
 
-- [View Style Props...](../view-style-props/#style)
+- [View Style Props...](view-style-props.md#props)
 
 - **`textShadowOffset`**: object: {width: number,height: number}
 

--- a/docs/pages/versions/v40.0.0/react-native/textinput.md
+++ b/docs/pages/versions/v40.0.0/react-native/textinput.md
@@ -75,7 +75,7 @@ Note that on Android performing text selection in input can change app's activit
 
 ## Props
 
-Inherits [View Props](../view/#props).
+Inherits [View Props](view.md#props).
 
 ### `allowFontScaling`
 
@@ -303,7 +303,7 @@ Padding between the inline image, if any, and the text input itself.
 
 ### `inputAccessoryViewID`
 
-An optional identifier which links a custom [InputAccessoryView](../inputaccessoryview/) to this text input. The InputAccessoryView is rendered above the keyboard when this text input is focused.
+An optional identifier which links a custom [InputAccessoryView](inputaccessoryview.md) to this text input. The InputAccessoryView is rendered above the keyboard when this text input is focused.
 
 | Type   | Required | Platform |
 | ------ | -------- | -------- |
@@ -767,7 +767,7 @@ see [Issue#7070](https://github.com/facebook/react-native/issues/7070) for more 
 
 | Type                   | Required |
 | ---------------------- | -------- |
-| [Text](../text/#style) | No       |
+| [Text](text.md#style) | No       |
 
 ---
 

--- a/docs/pages/versions/v40.0.0/react-native/touchablehighlight.md
+++ b/docs/pages/versions/v40.0.0/react-native/touchablehighlight.md
@@ -3,7 +3,7 @@ id: touchablehighlight
 title: TouchableHighlight
 ---
 
-> If you're looking for a more extensive and future-proof way to handle touch-based input, check out the [Pressable](../pressable/) API.
+> If you're looking for a more extensive and future-proof way to handle touch-based input, check out the [Pressable](pressable.md) API.
 
 A wrapper for making views respond properly to touches. On press down, the opacity of the wrapped view is decreased, which allows the underlay color to show through, darkening or tinting the view.
 
@@ -78,7 +78,7 @@ export default TouchableHighlightExample;
 
 ## Props
 
-Inherits [TouchableWithoutFeedback Props](../touchablewithoutfeedback/#props).
+Inherits [TouchableWithoutFeedback Props](touchablewithoutfeedback.md#props).
 
 ### `activeOpacity`
 

--- a/docs/pages/versions/v40.0.0/react-native/touchablenativefeedback.md
+++ b/docs/pages/versions/v40.0.0/react-native/touchablenativefeedback.md
@@ -3,7 +3,7 @@ id: touchablenativefeedback
 title: TouchableNativeFeedback
 ---
 
-> If you're looking for a more extensive and future-proof way to handle touch-based input, check out the [Pressable](../pressable/) API.
+> If you're looking for a more extensive and future-proof way to handle touch-based input, check out the [Pressable](pressable.md) API.
 
 A wrapper for making views respond properly to touches (Android only). On Android this component uses native state drawable to display touch feedback.
 
@@ -64,7 +64,7 @@ export default App;
 
 ## Props
 
-Inherits [TouchableWithoutFeedback Props](../touchablewithoutfeedback/#props).
+Inherits [TouchableWithoutFeedback Props](touchablewithoutfeedback.md#props).
 
 ### `background`
 

--- a/docs/pages/versions/v40.0.0/react-native/touchableopacity.md
+++ b/docs/pages/versions/v40.0.0/react-native/touchableopacity.md
@@ -3,7 +3,7 @@ id: touchableopacity
 title: TouchableOpacity
 ---
 
-> If you're looking for a more extensive and future-proof way to handle touch-based input, check out the [Pressable](../pressable/) API.
+> If you're looking for a more extensive and future-proof way to handle touch-based input, check out the [Pressable](pressable.md) API.
 
 A wrapper for making views respond properly to touches. On press down, the opacity of the wrapped view is decreased, dimming it.
 
@@ -57,7 +57,7 @@ export default App;
 
 ## Props
 
-Inherits [TouchableWithoutFeedback Props](../touchablewithoutfeedback/#props).
+Inherits [TouchableWithoutFeedback Props](touchablewithoutfeedback.md#props).
 
 ### `style`
 

--- a/docs/pages/versions/v40.0.0/react-native/touchablewithoutfeedback.md
+++ b/docs/pages/versions/v40.0.0/react-native/touchablewithoutfeedback.md
@@ -3,7 +3,7 @@ id: touchablewithoutfeedback
 title: TouchableWithoutFeedback
 ---
 
-> If you're looking for a more extensive and future-proof way to handle touch-based input, check out the [Pressable](../pressable/) API.
+> If you're looking for a more extensive and future-proof way to handle touch-based input, check out the [Pressable](pressable.md) API.
 
 Do not use unless you have a very good reason. All elements that respond to press should have a visual feedback when touched.
 

--- a/docs/pages/versions/v40.0.0/react-native/transforms.md
+++ b/docs/pages/versions/v40.0.0/react-native/transforms.md
@@ -190,4 +190,4 @@ transform([{ skewX: '45deg' }]);
 
 ### `decomposedMatrix`, `rotation`, `scaleX`, `scaleY`, `transformMatrix`, `translateX`, `translateY`
 
-> **Deprecated.** Use the [`transform`](../transforms/#transform) prop instead.
+> **Deprecated.** Use the [`transform`](transforms.md#transform) prop instead.

--- a/docs/pages/versions/v40.0.0/react-native/usecolorscheme.md
+++ b/docs/pages/versions/v40.0.0/react-native/usecolorscheme.md
@@ -7,7 +7,7 @@ title: useColorScheme
 import { useColorScheme } from 'react-native';
 ```
 
-The `useColorScheme` React hook provides and subscribes to color scheme updates from the [`Appearance`](../../sdk/appearance/) module. The return value indicates the current user preferred color scheme. The value may be updated later, either through direct user action (e.g. theme selection in device settings) or on a schedule (e.g. light and dark themes that follow the day/night cycle).
+The `useColorScheme` React hook provides and subscribes to color scheme updates from the [`Appearance`](../sdk/appearance.md) module. The return value indicates the current user preferred color scheme. The value may be updated later, either through direct user action (e.g. theme selection in device settings) or on a schedule (e.g. light and dark themes that follow the day/night cycle).
 
 Supported color schemes:
 

--- a/docs/pages/versions/v40.0.0/react-native/view.md
+++ b/docs/pages/versions/v40.0.0/react-native/view.md
@@ -472,7 +472,7 @@ This is a reserved performance property exposed by `RCTView` and is useful for s
 
 | Type                                | Required |
 | ----------------------------------- | -------- |
-| [view styles](../view-style-props/) | No       |
+| [view styles](view-style-props.md) | No       |
 
 ---
 

--- a/docs/pages/versions/v40.0.0/react-native/virtualizedlist.md
+++ b/docs/pages/versions/v40.0.0/react-native/virtualizedlist.md
@@ -3,7 +3,7 @@ id: virtualizedlist
 title: VirtualizedList
 ---
 
-Base implementation for the more convenient [`<FlatList>`](../flatlist/) and [`<SectionList>`](../sectionlist/) components, which are also better documented. In general, this should only really be used if you need more flexibility than [`FlatList`](../flatlist/) provides, e.g. for use with immutable data instead of plain arrays.
+Base implementation for the more convenient [`<FlatList>`](flatlist.md) and [`<SectionList>`](sectionlist.md) components, which are also better documented. In general, this should only really be used if you need more flexibility than [`FlatList`](flatlist.md) provides, e.g. for use with immutable data instead of plain arrays.
 
 Virtualization massively improves memory consumption and performance of large lists by maintaining a finite render window of active items and replacing all items outside of the render window with appropriately sized blank space. The window adapts to scrolling behavior, and items are rendered incrementally with low-pri (after any running interactions) if they are far from the visible area, or with hi-pri otherwise to minimize the potential of seeing blank space.
 
@@ -88,7 +88,7 @@ Some caveats:
 
 ## Props
 
-Inherits [ScrollView Props](../scrollview/#props).
+Inherits [ScrollView Props](scrollview.md#props).
 
 ### `renderItem`
 
@@ -199,7 +199,7 @@ Reverses the direction of scroll. Uses scale transforms of -1.
 
 ### `CellRendererComponent`
 
-Each cell is rendered using this element. Can be a React Component Class,or a render function. Defaults to using [`View`](../view/).
+Each cell is rendered using this element. Can be a React Component Class,or a render function. Defaults to using [`View`](view.md).
 
 | Type                | Required |
 | ------------------- | -------- |


### PR DESCRIPTION
# Why

Some of these, especially SDK 36 and 37, had some broken links. This fixes that 😄 

# How

- Searched with `$ yarn remark --quiet -u validate-links pages/versions/*/react-native --no-color &> lint-links.txt`
- Fixed them with replace all in `docs/pages/versions/*/react-native`

# Test Plan

- `$ yarn remark --quiet -u validate-links pages/versions/*/react-native` shouldn't yield errors
