### PR TITLE
[docs] Add new redirect rules based on Sentry monitoring

### DIFF
--- a/docs/pages/_error.tsx
+++ b/docs/pages/_error.tsx
@@ -310,4 +310,8 @@ const RENAMED_PAGES: Record<string, string> = {
 
   // Redirect to expand Expo Accounts and permissions
   '/guides/account-permissions/': '/accounts/personal/',
+
+  // Redirects based on Sentry (11/26/2020)
+  '/guides/push-notifications/': '/push-notifications/overview/',
+  '/guides/using-fcm/': '/push-notifications/using-fcm/',
 };


### PR DESCRIPTION
# Why

Added new rules based on the [URL tag from this Sentry event](https://sentry.io/organizations/expoio/issues/1196739699/tags/?project=1526800&query=is%3Aunresolved&statsPeriod=14d).

# How

- Tested link manually, to see if a redirect was happening

# Test Plan

- On these two URLs, users should now be redirected to the proper page