### PR TITLE
[react-native-reanimated] Upgrade to 2.0.0-rc.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ Package-specific changes not released in any SDK will be added here just before 
 - Updated `@react-native-community/viewpager` from `4.1.6` to `4.2.0`. ([#11009](https://github.com/expo/expo/pull/11009) by [@cruzach](https://github.com/cruzach))
 - Updated `@react-native-community/datetimepicker` from `3.0.0` to `3.0.4`. ([#10980](https://github.com/expo/expo/pull/10980) by [@cruzach](https://github.com/cruzach))
 - Updated `react-native-screens` from `2.10.1` to `2.15.0`. ([#10980](https://github.com/expo/expo/pull/10980) by [@bbarthec](https://github.com/bbarthec))
-- Upgraded `react-native-reanimated` v2 support from `2.0.0-alpha.6` to `2.0.0-alpha.9.2`. ([#11048](https://github.com/expo/expo/pull/11048), [#11095](https://github.com/expo/expo/pull/11095) by [@sjchmiela](https://github.com/sjchmiela))
+- Upgraded `react-native-reanimated` v2 support from `2.0.0-alpha.6` to `2.0.0-rc.0`. ([#11048](https://github.com/expo/expo/pull/11048), [#11095](https://github.com/expo/expo/pull/11095), [#11145](https://github.com/expo/expo/pull/11145) by [@sjchmiela](https://github.com/sjchmiela))
 
 ### 🛠 Breaking changes
 

--- a/android/expoview/src/main/Common/cpp/SharedItems/ShareableValue.cpp
+++ b/android/expoview/src/main/Common/cpp/SharedItems/ShareableValue.cpp
@@ -211,7 +211,7 @@ jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {
         // function is accessed from the same runtime it was crated, we just return same function obj
         return jsi::Value(rt, *hostFunction->get());
       } else {
-        // function is accessed from a different runtme, we wrap function in host func that'd enqueue
+        // function is accessed from a different runtime, we wrap function in host func that'd enqueue
         // call on an appropriate thread
         
         auto module = this->module;
@@ -294,7 +294,7 @@ jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {
                res = funPtr->call(rt, args, count);
              }
            } catch(std::exception &e) {
-               std::string str = e.what();
+             std::string str = e.what();
              this->module->errorHandler->setError(str);
              this->module->errorHandler->raise();
            }
@@ -314,16 +314,15 @@ jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {
             ) -> jsi::Value {
           // TODO: we should find thread based on runtime such that we could also call UI methods
           // from RN and not only RN methods from UI
-          
-          auto module = retain_this->module;
 
           std::vector<std::shared_ptr<ShareableValue>> params;
           for (int i = 0; i < count; ++i) {
-            params.push_back(ShareableValue::adapt(rt, args[i], module));
+            params.push_back(ShareableValue::adapt(rt, args[i], retain_this->module));
           }
           
-          module->scheduler->scheduleOnUI([retain_this, params, &module] {
-            jsi::Runtime &rt = *retain_this->module->runtime.get();
+          retain_this->module->scheduler->scheduleOnUI([retain_this, params] {
+            NativeReanimatedModule *module = retain_this->module;
+            jsi::Runtime &rt = *module->runtime.get();
             auto jsThis = createFrozenWrapper(rt, retain_this->frozenObject).getObject(rt);
             auto code = jsThis.getProperty(rt, "asString").asString(rt).utf8(rt);
             std::shared_ptr<jsi::Function> funPtr(retain_this->module->workletsCache->getFunction(rt, retain_this->frozenObject));

--- a/android/expoview/src/main/cpp/NativeProxy.cpp
+++ b/android/expoview/src/main/cpp/NativeProxy.cpp
@@ -180,7 +180,7 @@ static jni::local_ref<PropsMap> ConvertToPropsMap(jsi::Runtime &rt, const jsi::O
     }
     else if (value.isBool())
     {
-      map->put(key, jni::autobox(value.getBool()));
+      map->put(key, JBoolean::valueOf(value.getBool()));
     }
     else if (value.isNumber())
     {

--- a/docs/pages/versions/unversioned/sdk/reanimated.md
+++ b/docs/pages/versions/unversioned/sdk/reanimated.md
@@ -26,7 +26,7 @@ You also need to install the library directly with npm or yarn rather than using
 
 ```
 # This exact version is supported:
-npm install react-native-reanimated@2.0.0-alpha.9.2
+npm install react-native-reanimated@2.0.0-rc.0
 ```
 
 Finally, you'll need to add the babel plugin to `babel.config.js`:
@@ -45,7 +45,7 @@ Note that when you run the project you will get a warning about an incompatible 
 
 ```
 Some of your project's dependencies are not compatible with currently installed expo package version:
- - react-native-reanimated - expected version range: ~1.13.0 - actual version installed: 2.0.0-alpha.9.2
+ - react-native-reanimated - expected version range: ~1.13.0 - actual version installed: 2.0.0-rc.0
 ```
 
 You can ignore this, as you are intentionally opting in to an experimental feature.

--- a/docs/pages/versions/v40.0.0/sdk/reanimated.md
+++ b/docs/pages/versions/v40.0.0/sdk/reanimated.md
@@ -26,7 +26,7 @@ You also need to install the library directly with npm or yarn rather than using
 
 ```
 # This exact version is supported:
-npm install react-native-reanimated@2.0.0-alpha.9.2
+npm install react-native-reanimated@2.0.0-rc.0
 ```
 
 Finally, you'll need to add the babel plugin to `babel.config.js`:
@@ -45,7 +45,7 @@ Note that when you run the project you will get a warning about an incompatible 
 
 ```
 Some of your project's dependencies are not compatible with currently installed expo package version:
- - react-native-reanimated - expected version range: ~1.13.0 - actual version installed: 2.0.0-alpha.9.2
+ - react-native-reanimated - expected version range: ~1.13.0 - actual version installed: 2.0.0-rc.0
 ```
 
 You can ignore this, as you are intentionally opting in to an experimental feature.

--- a/ios/Exponent/Versioned/Core/Api/Reanimated/REAIOSScheduler.mm
+++ b/ios/Exponent/Versioned/Core/Api/Reanimated/REAIOSScheduler.mm
@@ -10,6 +10,10 @@ REAIOSScheduler::REAIOSScheduler(std::shared_ptr<CallInvoker> jsInvoker) {
 }
 
 void REAIOSScheduler::scheduleOnUI(std::function<void()> job) {
+  if (module.lock() == nullptr) {
+    return;
+  }
+  
   if([NSThread isMainThread]) {
     if (module.lock()) job();
     return;
@@ -20,8 +24,11 @@ void REAIOSScheduler::scheduleOnUI(std::function<void()> job) {
     if (module.lock()) triggerUI();
     return;
   }
+  
+  __block std::weak_ptr<NativeReanimatedModule> blockModule = module;
+  
   dispatch_async(dispatch_get_main_queue(), ^{
-    if (module.lock()) triggerUI();
+    if (blockModule.lock()) triggerUI();
   });
 }
 

--- a/ios/Exponent/Versioned/Core/Api/Reanimated/ShareableValue.cpp
+++ b/ios/Exponent/Versioned/Core/Api/Reanimated/ShareableValue.cpp
@@ -211,7 +211,7 @@ jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {
         // function is accessed from the same runtime it was crated, we just return same function obj
         return jsi::Value(rt, *hostFunction->get());
       } else {
-        // function is accessed from a different runtme, we wrap function in host func that'd enqueue
+        // function is accessed from a different runtime, we wrap function in host func that'd enqueue
         // call on an appropriate thread
         
         auto module = this->module;
@@ -294,7 +294,7 @@ jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {
                res = funPtr->call(rt, args, count);
              }
            } catch(std::exception &e) {
-               std::string str = e.what();
+             std::string str = e.what();
              this->module->errorHandler->setError(str);
              this->module->errorHandler->raise();
            }
@@ -314,16 +314,15 @@ jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {
             ) -> jsi::Value {
           // TODO: we should find thread based on runtime such that we could also call UI methods
           // from RN and not only RN methods from UI
-          
-          auto module = retain_this->module;
 
           std::vector<std::shared_ptr<ShareableValue>> params;
           for (int i = 0; i < count; ++i) {
-            params.push_back(ShareableValue::adapt(rt, args[i], module));
+            params.push_back(ShareableValue::adapt(rt, args[i], retain_this->module));
           }
           
-          module->scheduler->scheduleOnUI([retain_this, params, &module] {
-            jsi::Runtime &rt = *retain_this->module->runtime.get();
+          retain_this->module->scheduler->scheduleOnUI([retain_this, params] {
+            NativeReanimatedModule *module = retain_this->module;
+            jsi::Runtime &rt = *module->runtime.get();
             auto jsThis = createFrozenWrapper(rt, retain_this->frozenObject).getObject(rt);
             auto code = jsThis.getProperty(rt, "asString").asString(rt).utf8(rt);
             std::shared_ptr<jsi::Function> funPtr(retain_this->module->workletsCache->getFunction(rt, retain_this->frozenObject));


### PR DESCRIPTION
# Why

🍾 Release Candidate! 🍾 

# How

Used `expotools`, updated docs following example set in https://github.com/expo/expo/pull/11095/commits/33ab0e757207b9a1c97e9448917a71320ab5193c.

# Test Plan

Compiled Expo Go for both platforms, ensured unversioned project using `react-native-reanimated@2` to animate width of a view works as it did.