### PR TITLE
[ios] Add ReactCommon to ExpoKit dependencies to fix Reanimated v2 compilation problem

### DIFF
--- a/ios/ExpoKit.podspec
+++ b/ios/ExpoKit.podspec
@@ -36,6 +36,7 @@ Pod::Spec.new do |s|
     ss.dependency 'lottie-ios', '~> 2.5.0'
     ss.dependency 'JKBigInteger2', '0.0.5'
     ss.dependency 'React-Core' # explicit dependency required for CocoaPods >= 1.5.0
+    ss.dependency 'ReactCommon' # needed for react-native-reanimated, see https://github.com/expo/expo/pull/11096#how
 
     # Universal modules required by ExpoKit so the code compiles
     ss.dependency 'UMCore'

--- a/template-files/ios/ExpoKit.podspec
+++ b/template-files/ios/ExpoKit.podspec
@@ -31,6 +31,7 @@ Pod::Spec.new do |s|
 
 ${IOS_EXPOKIT_DEPS}
     ss.dependency 'React-Core' # explicit dependency required for CocoaPods >= 1.5.0
+    ss.dependency 'ReactCommon' # needed for react-native-reanimated, see https://github.com/expo/expo/pull/11096#how
 
     # Universal modules required by ExpoKit so the code compiles
     ss.dependency 'UMCore'


### PR DESCRIPTION
…mpile problem

See https://github.com/expo/expo/pull/11096/commits/98bff7706ae722e66ad7b390c92af5ec0bd83d5b and https://github.com/expo/expo/pull/11096#how.

# Why

See https://github.com/expo/expo/pull/11148.

# How

See https://github.com/expo/expo/pull/11148.

# Test Plan

- [x] iOS shell app builds properly — waiting for job status — https://github.com/expo/expo/runs/1463549439?check_suite_focus=true