### PR TITLE
[android] Fix no .so hotfix by moving build artifacts clean out of packages building process

### DIFF
--- a/.github/workflows/shell-app-android.yml
+++ b/.github/workflows/shell-app-android.yml
@@ -54,7 +54,7 @@ jobs:
         env:
           ANDROID_NDK_HOME: /usr/local/lib/android/sdk/ndk/19.2.5345600/
         run: expotools android-build-packages --packages all
-      - name: Clean unneeded Android build artifacts
+      - name: Clean Android build artifacts that would needlessly bloat the shell app
         env:
           ANDROID_NDK_HOME: /usr/local/lib/android/sdk/ndk/19.2.5345600/
         run: ./gradlew clean

--- a/.github/workflows/shell-app-android.yml
+++ b/.github/workflows/shell-app-android.yml
@@ -54,6 +54,11 @@ jobs:
         env:
           ANDROID_NDK_HOME: /usr/local/lib/android/sdk/ndk/19.2.5345600/
         run: expotools android-build-packages --packages all
+      - name: Clean unneeded Android build artifacts
+        env:
+          ANDROID_NDK_HOME: /usr/local/lib/android/sdk/ndk/19.2.5345600/
+        run: ./gradlew clean
+        working-directory: android
       - name: Build shell app tarball
         run: ./buildAndroidTarballLocally.sh
       - name: Make an artifact

--- a/tools/expotools/src/commands/AndroidBuildPackages.ts
+++ b/tools/expotools/src/commands/AndroidBuildPackages.ts
@@ -220,22 +220,19 @@ async function _updateExpoViewAsync(packages: Package[], sdkVersion: string): Pr
     await fs.remove(path.join(pkg.sourceDir, 'build'));
   }
 
-  // hacky workaround for weird issue where some packages need to be built twice after cleaning
-  // in order to have .so libs included in the aar
-  const reactAndroidIndex = packages.findIndex(pkg => pkg.name === REACT_ANDROID_PKG.name);
-  if (reactAndroidIndex > -1) {
-    packages.splice(reactAndroidIndex, 0, REACT_ANDROID_PKG);
-  }
-  const expoviewIndex = packages.findIndex(pkg => pkg.name === EXPOVIEW_PKG.name);
-  if (expoviewIndex > -1) {
-    packages.splice(expoviewIndex, 0, EXPOVIEW_PKG);
-  }
-
   let failedPackages: string[] = [];
   for (const pkg of packages) {
     process.stdout.write(` 🛠   Building ${pkg.name}...`);
     try {
-      await spawnAsync('./gradlew', [`:${pkg.name}:uploadArchives`, `:${pkg.name}:clean`], {
+      // hacky workaround for weird issue where some packages need to be built twice after cleaning
+      // in order to have .so libs included in the aar
+      await spawnAsync('./gradlew', [`:${pkg.name}:uploadArchives`], {
+        cwd: ANDROID_DIR,
+      });
+      await spawnAsync('./gradlew', [`:${pkg.name}:uploadArchives`], {
+        cwd: ANDROID_DIR,
+      });
+      await spawnAsync('./gradlew', [`:${pkg.name}:clean`], {
         cwd: ANDROID_DIR,
       });
       readline.clearLine(process.stdout, 0);

--- a/tools/expotools/src/commands/AndroidBuildPackages.ts
+++ b/tools/expotools/src/commands/AndroidBuildPackages.ts
@@ -235,7 +235,7 @@ async function _updateExpoViewAsync(packages: Package[], sdkVersion: string): Pr
   for (const pkg of packages) {
     process.stdout.write(` 🛠   Building ${pkg.name}...`);
     try {
-      await spawnAsync('./gradlew', [`:${pkg.name}:uploadArchives`, `:${pkg.name}:clean`], {
+      await spawnAsync('./gradlew', [`:${pkg.name}:uploadArchives`], {
         cwd: ANDROID_DIR,
       });
       readline.clearLine(process.stdout, 0);


### PR DESCRIPTION
# Why

`react-native` AAR in Android shell apps built for this SDK apparently lack native `.so` libraries. The problem manifest itself by native crash upon opening a standalone SDK40 app:
```
AndroidRuntime: FATAL EXCEPTION: create_react_context
AndroidRuntime: Process: xyz.bront.hourpower, PID: 22569
AndroidRuntime: java.lang.UnsatisfiedLinkError: couldn't find DSO to load: libhermes.so result: 0
AndroidRuntime: 	at com.facebook.soloader.SoLoader.doLoadLibraryBySoName(SoLoader.java:32)
AndroidRuntime: 	at com.facebook.soloader.SoLoader.loadLibraryBySoName(SoLoader.java:17)
AndroidRuntime: 	at com.facebook.soloader.SoLoader.loadLibrary(SoLoader.java:19)
AndroidRuntime: 	at com.facebook.soloader.SoLoader.loadLibrary(SoLoader.java:1)
AndroidRuntime: 	at com.facebook.hermes.reactexecutor.HermesExecutor.<clinit>(HermesExecutor.java:1)
AndroidRuntime: 	at com.facebook.hermes.reactexecutor.HermesExecutorFactory.create(HermesExecutorFactory.java:1)
AndroidRuntime: 	at com.facebook.react.ReactInstanceManager$5.run(ReactInstanceManager.java:10)
AndroidRuntime: 	at java.lang.Thread.run(Thread.java:923)
ActivityTaskManager:   Force finishing activity xyz.bront.hourpower/host.exp.exponent.MainActivity
```

# How

Remembering the implementation of [`getDefaultJSExecutorFactory`](https://github.com/expo/expo/blob/8370ab335404aed4f9910ff1ca7360bb8b15f0fd/android/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManagerBuilder.java#L292-L329) I knew the issue must be laying in missing `libjscexecutor.so`. To verify that I inspected SDK40 `.apk` with Android Studio and that some `.so` files are missing. For comparison SDK40 and SDK39 APKs:

<img width="1371" alt="Zrzut ekranu 2020-11-30 o 11 25 48" src="https://user-images.githubusercontent.com/1151041/100616037-c9a1fc00-3318-11eb-91a3-5d647d6945df.png">

Then I looked into `react-native` AAR to verify it it contains the native libraries or not (to see whether the problem lays in the process of building the app or in the process of building the AAR). The AAR did not contain required `.so` files, so the problem must have laid in `et android-build-packages` process.

I rebuilt the packages on my computer and confirmed `.so` files are not put into AARs. What struck me in the process were double entries for `expoview` and `ReactAndroid`:

```
 ✅  Finished building ReactAndroid
 ✅  Finished building ReactAndroid
 ✅  Finished building unimodules-core
 ✅  Finished building unimodules-react-native-adapter
 ...
 ✅  Finished building unimodules-task-manager-interface
 ✅  Finished building expoview
 ✅  Finished building expoview
 🚚  Copying newly built packages...
```

Looking into `AndroidBuildPackages.ts` I noticed there's a hacky workaround for this specific bug in place already (h/t @esamelson):

https://github.com/expo/expo/blob/cc0bde12338c7acd13f3502404c8aaa64b04a680/tools/expotools/src/commands/AndroidBuildPackages.ts#L223-L232

~Via trial and error I tried building the AARs some different ways (using `./gradlew` in `android`, before cleaning, after cleaning, upgrading Gradle), but the only and most reliable scenario for building AARs with `.so` files included was the solution implemented in this PR.~ — this was referring to https://github.com/expo/expo/pull/11163/commits/100052fc738de1d61df1feb553a87d4641695e7d. Thanks to @wkozyra95's insight I've changed the solution to a different, faster and cleaner one:

It seems [this change](https://github.com/expo/expo/commit/6bce5f2deab78c76fa30710e9257102bd270e442#diff-79ae592b37eb104acd1b5162a3383f8e15e8510a1400c8138952aae6aa55dacd) has reintroduced this problem to Android shell app building process. I have reverted its intervention by moving `:clean` to GitHub workflow file. This not only makes the solution faster (by not running `uploadArchives` twice for **all** libraries, just for the problematic ones), but also cleaner (“why would `et abp` clean my build directories?”).

# Test Plan

- [x] Android shell app is built and prebuilt React Native AAR contains expected `.so` files ([~job~](https://github.com/expo/expo/runs/1474131564?check_suite_focus=true), [job](https://github.com/expo/expo/runs/1475286887))
- [x] ~Android shell app is built and prebuilt `expoview` AAR contains expected `.so` files ([job](https://github.com/expo/expo/runs/1474131564?check_suite_focus=true))~ (lack of them was caused by another bug, fixed in https://github.com/expo/expo/pull/11166)