### PR TITLE
[expoview] Build expoview native libraries always for all ABIs

### DIFF
--- a/android/expoview/src/main/JNI/Application.mk
+++ b/android/expoview/src/main/JNI/Application.mk
@@ -1,4 +1,4 @@
-# [expo] We don't want to CI to build only for x86
+# [expo] We don't want the CI to build only for x86
 # because we build release versions of expoview on CI.
 APP_ABI := armeabi-v7a x86 arm64-v8a x86_64
 

--- a/android/expoview/src/main/JNI/Application.mk
+++ b/android/expoview/src/main/JNI/Application.mk
@@ -1,8 +1,6 @@
-ifdef $(CI)
-APP_ABI := x86
-else
-APP_ABI := all
-endif
+# [expo] We don't want to CI to build only for x86
+# because we build release versions of expoview on CI.
+APP_ABI := armeabi-v7a x86 arm64-v8a x86_64
 
 APP_BUILD_SCRIPT := Android.mk
 APP_PLATFORM := android-18


### PR DESCRIPTION
# Why

Right now Reanimated native libraries were only built and released by us for x86 ABI due to optimization accidentally copied from Reanimated repository. I found it while verifying that https://github.com/expo/expo/pull/11163 works properly and @tsapeta knew the reason for it.

# How

Unexcluded architectures from CI builds.

# Test Plan

I have verified that [building a shell app](https://github.com/expo/expo/actions/runs/391877515) with this change produces an `expoview` AAR that contains .so files for all architectures:

<img width="579" alt="Zrzut ekranu 2020-11-30 o 17 05 56" src="https://user-images.githubusercontent.com/1151041/100633377-51463580-332e-11eb-96e9-7dd6536284a4.png">
