### PR TITLE
[docs] Add Snack examples for expo-keep-awake and fix typo

### DIFF
--- a/docs/pages/versions/unversioned/sdk/keep-awake.md
+++ b/docs/pages/versions/unversioned/sdk/keep-awake.md
@@ -42,7 +42,6 @@ export default function KeepAwakeExample() {
 
 ### Example: functions
 
-
 <SnackInline label='Keep Awake functions' dependencies={['expo-keep-awake']}>
 
 ```javascript
@@ -61,13 +60,13 @@ export default class KeepAwakeExample extends React.Component {
   }
 
   _activate = () => {
-    /* @info Screen will remain on after called until <strong>deactivateKeepAwake()</strong> is called. */activateKeepAwake();/* @end */
+    /* @info Screen will remain on after called until <strong>deactivateKeepAwake()</strong> is called. */ activateKeepAwake(); /* @end */
 
     alert('Activated!');
   };
 
   _deactivate = () => {
-    /* @info Deactivates KeepAwake, or does nothing if it was never activated. */deactivateKeepAwake();/* @end */
+    /* @info Deactivates KeepAwake, or does nothing if it was never activated. */ deactivateKeepAwake(); /* @end */
 
     alert('Deactivated!');
   };

--- a/docs/pages/versions/unversioned/sdk/keep-awake.md
+++ b/docs/pages/versions/unversioned/sdk/keep-awake.md
@@ -5,6 +5,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-keep-awak
 
 import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
+import SnackInline from '~/components/plugins/SnackInline';
 
 **`expo-keep-awake`** provides a React hook that prevents the screen from sleeping and a pair of functions to enable this behavior imperatively.
 
@@ -18,13 +19,14 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 ### Example: hook
 
-<!-- prettier-ignore -->
+<SnackInline label='Keep Awake hook' dependencies={['expo-keep-awake']}>
+
 ```javascript
 import { useKeepAwake } from 'expo-keep-awake';
 import React from 'react';
 import { Text, View } from 'react-native';
 
-export default function KeepAwakeExample {
+export default function KeepAwakeExample() {
   /* @info As long as this component is mounted, the screen will not turn off from being idle. */
   useKeepAwake();
   /* @end */
@@ -36,9 +38,13 @@ export default function KeepAwakeExample {
 }
 ```
 
+</SnackInline>
+
 ### Example: functions
 
-<!-- prettier-ignore -->
+
+<SnackInline label='Keep Awake functions' dependencies={['expo-keep-awake']}>
+
 ```javascript
 import { activateKeepAwake, deactivateKeepAwake } from 'expo-keep-awake';
 import React from 'react';
@@ -67,6 +73,8 @@ export default class KeepAwakeExample extends React.Component {
   };
 }
 ```
+
+</SnackInline>
 
 ## API
 

--- a/docs/pages/versions/v39.0.0/sdk/keep-awake.md
+++ b/docs/pages/versions/v39.0.0/sdk/keep-awake.md
@@ -5,6 +5,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-39/packages/expo-keep-awak
 
 import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
+import SnackInline from '~/components/plugins/SnackInline';
 
 **`expo-keep-awake`** provides a React hook that prevents the screen from sleeping and a pair of functions to enable this behavior imperatively.
 
@@ -18,13 +19,14 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 ### Example: hook
 
-<!-- prettier-ignore -->
+<SnackInline label='Keep Awake hook' dependencies={['expo-keep-awake']}>
+
 ```javascript
 import { useKeepAwake } from 'expo-keep-awake';
 import React from 'react';
 import { Text, View } from 'react-native';
 
-export default function KeepAwakeExample {
+export default function KeepAwakeExample() {
   /* @info As long as this component is mounted, the screen will not turn off from being idle. */
   useKeepAwake();
   /* @end */
@@ -36,9 +38,13 @@ export default function KeepAwakeExample {
 }
 ```
 
+</SnackInline>
+
 ### Example: functions
 
-<!-- prettier-ignore -->
+
+<SnackInline label='Keep Awake functions' dependencies={['expo-keep-awake']}>
+
 ```javascript
 import { activateKeepAwake, deactivateKeepAwake } from 'expo-keep-awake';
 import React from 'react';
@@ -67,6 +73,8 @@ export default class KeepAwakeExample extends React.Component {
   };
 }
 ```
+
+</SnackInline>
 
 ## API
 

--- a/docs/pages/versions/v39.0.0/sdk/keep-awake.md
+++ b/docs/pages/versions/v39.0.0/sdk/keep-awake.md
@@ -42,7 +42,6 @@ export default function KeepAwakeExample() {
 
 ### Example: functions
 
-
 <SnackInline label='Keep Awake functions' dependencies={['expo-keep-awake']}>
 
 ```javascript
@@ -61,13 +60,13 @@ export default class KeepAwakeExample extends React.Component {
   }
 
   _activate = () => {
-    /* @info Screen will remain on after called until <strong>deactivateKeepAwake()</strong> is called. */activateKeepAwake();/* @end */
+    /* @info Screen will remain on after called until <strong>deactivateKeepAwake()</strong> is called. */ activateKeepAwake(); /* @end */
 
     alert('Activated!');
   };
 
   _deactivate = () => {
-    /* @info Deactivates KeepAwake, or does nothing if it was never activated. */deactivateKeepAwake();/* @end */
+    /* @info Deactivates KeepAwake, or does nothing if it was never activated. */ deactivateKeepAwake(); /* @end */
 
     alert('Deactivated!');
   };

--- a/docs/pages/versions/v40.0.0/sdk/keep-awake.md
+++ b/docs/pages/versions/v40.0.0/sdk/keep-awake.md
@@ -42,7 +42,6 @@ export default function KeepAwakeExample() {
 
 ### Example: functions
 
-
 <SnackInline label='Keep Awake functions' dependencies={['expo-keep-awake']}>
 
 ```javascript
@@ -61,13 +60,13 @@ export default class KeepAwakeExample extends React.Component {
   }
 
   _activate = () => {
-    /* @info Screen will remain on after called until <strong>deactivateKeepAwake()</strong> is called. */activateKeepAwake();/* @end */
+    /* @info Screen will remain on after called until <strong>deactivateKeepAwake()</strong> is called. */ activateKeepAwake(); /* @end */
 
     alert('Activated!');
   };
 
   _deactivate = () => {
-    /* @info Deactivates KeepAwake, or does nothing if it was never activated. */deactivateKeepAwake();/* @end */
+    /* @info Deactivates KeepAwake, or does nothing if it was never activated. */ deactivateKeepAwake(); /* @end */
 
     alert('Deactivated!');
   };

--- a/docs/pages/versions/v40.0.0/sdk/keep-awake.md
+++ b/docs/pages/versions/v40.0.0/sdk/keep-awake.md
@@ -5,6 +5,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-40/packages/expo-keep-awak
 
 import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
+import SnackInline from '~/components/plugins/SnackInline';
 
 **`expo-keep-awake`** provides a React hook that prevents the screen from sleeping and a pair of functions to enable this behavior imperatively.
 
@@ -18,13 +19,14 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 ### Example: hook
 
-<!-- prettier-ignore -->
+<SnackInline label='Keep Awake hook' dependencies={['expo-keep-awake']}>
+
 ```javascript
 import { useKeepAwake } from 'expo-keep-awake';
 import React from 'react';
 import { Text, View } from 'react-native';
 
-export default function KeepAwakeExample {
+export default function KeepAwakeExample() {
   /* @info As long as this component is mounted, the screen will not turn off from being idle. */
   useKeepAwake();
   /* @end */
@@ -36,9 +38,13 @@ export default function KeepAwakeExample {
 }
 ```
 
+</SnackInline>
+
 ### Example: functions
 
-<!-- prettier-ignore -->
+
+<SnackInline label='Keep Awake functions' dependencies={['expo-keep-awake']}>
+
 ```javascript
 import { activateKeepAwake, deactivateKeepAwake } from 'expo-keep-awake';
 import React from 'react';
@@ -67,6 +73,8 @@ export default class KeepAwakeExample extends React.Component {
   };
 }
 ```
+
+</SnackInline>
 
 ## API
 


### PR DESCRIPTION
# Why

Fixes a typo in the hooks example and makes the example instantly testable using Snack.

![image](https://user-images.githubusercontent.com/6184593/100631062-9fa60500-332b-11eb-8746-c05f174ee4c4.png)

# How

- Fix typo in hooks example (missing '()`)
- Convert examples to inlined Snacks
- Update for Unversioned, SDK40 and SDK39

# Test Plan

- `yarn lint`
- `yarn prettier`
- Verified hooks example runs correctly on web-player and native
- Verified functions example runs correctly on web-player and native