### PR TITLE
[ios] Add missing imports causing compilation errors

### DIFF
--- a/ios/Exponent/Versioned/Core/EXVersionManager.mm
+++ b/ios/Exponent/Versioned/Core/EXVersionManager.mm
@@ -5,7 +5,6 @@
 #import "EXDisabledDevLoadingView.h"
 #import "EXDisabledDevMenu.h"
 #import "EXDisabledRedBox.h"
-#import "EXFileSystem.h"
 #import "EXVersionManager.h"
 #import "EXScopedBridgeModule.h"
 #import "EXStatusBarManager.h"
@@ -41,6 +40,7 @@
 #import <UMCore/UMModuleRegistryDelegate.h>
 #import <UMReactNativeAdapter/UMNativeModulesProxy.h>
 #import <EXMediaLibrary/EXMediaLibraryImageLoader.h>
+#import <EXFileSystem/EXFileSystem.h>
 #import "EXScopedModuleRegistry.h"
 #import "EXScopedModuleRegistryAdapter.h"
 #import "EXScopedModuleRegistryDelegate.h"

--- a/packages/@unimodules/core/ios/UMCore/UMAppDelegateWrapper.h
+++ b/packages/@unimodules/core/ios/UMCore/UMAppDelegateWrapper.h
@@ -1,5 +1,6 @@
 // Copyright © 2018 650 Industries. All rights reserved.
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/packages/@unimodules/core/ios/UMCore/UMErrorCodes.h
+++ b/packages/@unimodules/core/ios/UMCore/UMErrorCodes.h
@@ -1,3 +1,5 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
+#import <Foundation/Foundation.h>
+
 extern NSString *const UMErrorCodeCanceled;

--- a/packages/expo-barcode-scanner/ios/EXBarCodeScanner/Utilities/EXBarCodeScannerUtils.m
+++ b/packages/expo-barcode-scanner/ios/EXBarCodeScanner/Utilities/EXBarCodeScannerUtils.m
@@ -1,5 +1,6 @@
 // Copyright 2016-present 650 Industries. All rights reserved.
 
+#import <UIKit/UIKit.h>
 #import <AVFoundation/AVFoundation.h>
 #import <EXBarCodeScanner/EXBarCodeScannerUtils.h>
 

--- a/packages/expo-face-detector/ios/EXFaceDetector/EXCSBufferOrientationCalculator.h
+++ b/packages/expo-face-detector/ios/EXFaceDetector/EXCSBufferOrientationCalculator.h
@@ -6,6 +6,7 @@
 //  Copyright © 2017 650 Industries. All rights reserved.
 //
 
+#import <UIKit/UIKit.h>
 #import <Foundation/Foundation.h>
 #import <AVFoundation/AVFoundation.h>
 

--- a/packages/expo-face-detector/ios/EXFaceDetector/EXFaceDetector.h
+++ b/packages/expo-face-detector/ios/EXFaceDetector/EXFaceDetector.h
@@ -5,16 +5,17 @@
 //  Created by Michał Czernek on 12/04/2019.
 //
 
+#import <UIKit/UIKit.h>
 #import <Foundation/Foundation.h>
-#import <Firebase/Firebase.h>
+#import <FirebaseMLVision/FirebaseMLVision.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface EXFaceDetector : NSObject
 
--(instancetype) initWithOptions:(FIRVisionFaceDetectorOptions *)options;
--(void) detectFromImage:(UIImage *)image completionListener:(void(^)(NSArray<FIRVisionFace *> *faces, NSError* error)) completion;
--(void) detectFromBuffer:(CMSampleBufferRef)buffer metadata:(FIRVisionImageMetadata *)metadata completionListener:(void(^)(NSArray<FIRVisionFace *> *faces, NSError *error))completion;
+- (instancetype)initWithOptions:(FIRVisionFaceDetectorOptions *)options;
+- (void)detectFromImage:(UIImage *)image completionListener:(void(^)(NSArray<FIRVisionFace *> *faces, NSError* error)) completion;
+- (void)detectFromBuffer:(CMSampleBufferRef)buffer metadata:(FIRVisionImageMetadata *)metadata completionListener:(void(^)(NSArray<FIRVisionFace *> *faces, NSError *error))completion;
 
 @end
 

--- a/packages/expo-face-detector/ios/EXFaceDetector/EXFaceDetectorAppDelegate.h
+++ b/packages/expo-face-detector/ios/EXFaceDetector/EXFaceDetectorAppDelegate.h
@@ -1,5 +1,6 @@
 // Copyright 2016-present 650 Industries. All rights reserved.
 
+#import <UIKit/UIKit.h>
 #import <Foundation/Foundation.h>
 #import <UMCore/UMSingletonModule.h>
 

--- a/packages/expo-facebook/ios/EXFacebook/EXFacebookAppDelegate.h
+++ b/packages/expo-facebook/ios/EXFacebook/EXFacebookAppDelegate.h
@@ -1,5 +1,6 @@
 // Copyright 2016-present 650 Industries. All rights reserved.
 
+#import <UIKit/UIKit.h>
 #import <Foundation/Foundation.h>
 #import <UMCore/UMSingletonModule.h>
 

--- a/packages/expo-file-system/ios/EXFileSystem/NSData+EXFileSystem.h
+++ b/packages/expo-file-system/ios/EXFileSystem/NSData+EXFileSystem.h
@@ -1,5 +1,7 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
+#import <Foundation/Foundation.h>
+
 @interface NSData (EXFileSystem)
 
 - (NSString *)md5String;

--- a/packages/expo-firebase-analytics/ios/EXFirebaseAnalytics/EXFirebaseAnalytics.m
+++ b/packages/expo-firebase-analytics/ios/EXFirebaseAnalytics/EXFirebaseAnalytics.m
@@ -4,7 +4,7 @@
 #import <EXFirebaseCore/UMFirebaseCoreInterface.h>
 #import <EXFirebaseAnalytics/EXFirebaseAnalytics.h>
 #import <UIKit/UIKit.h>
-#import <Firebase/Firebase.h>
+#import <FirebaseAnalytics/FirebaseAnalytics.h>
 
 @interface NSObject (Private)
 - (NSString*)_methodDescription;

--- a/packages/expo-font/ios/EXFont/EXFont.h
+++ b/packages/expo-font/ios/EXFont/EXFont.h
@@ -1,5 +1,6 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
+#import <UIKit/UIKit.h>
 #import <Foundation/Foundation.h>
 
 static const char *EXFontAssocKey = "EXFont";

--- a/packages/expo-gl/ios/EXGL/EXGLObject.h
+++ b/packages/expo-gl/ios/EXGL/EXGLObject.h
@@ -1,5 +1,6 @@
 // Copyright 2016-present 650 Industries. All rights reserved.
 
+#import <Foundation/Foundation.h>
 #import <EXGL_CPP/UEXGL.h>
 
 @interface EXGLObject : NSObject

--- a/packages/expo-google-sign-in/ios/EXGoogleSignIn/EXGoogleSignIn.m
+++ b/packages/expo-google-sign-in/ios/EXGoogleSignIn/EXGoogleSignIn.m
@@ -5,6 +5,7 @@
 #import <EXGoogleSignIn/EXGoogleSignIn+Serialization.h>
 #import <UMCore/UMUtilitiesInterface.h>
 #import <UMCore/UMUtilities.h>
+#import <GoogleSignIn/GIDSignIn.h>
 
 @interface EXGoogleSignIn ()
 

--- a/packages/expo-google-sign-in/ios/EXGoogleSignIn/EXGoogleSignInAppDelegate.m
+++ b/packages/expo-google-sign-in/ios/EXGoogleSignIn/EXGoogleSignInAppDelegate.m
@@ -1,5 +1,6 @@
 // Copyright 2016-present 650 Industries. All rights reserved.
 
+#import <GoogleSignIn/GIDSignIn.h>
 #import <UMCore/UMAppDelegateWrapper.h>
 #import <EXGoogleSignIn/EXGoogleSignInAppDelegate.h>
 #import <UMCore/UMModuleRegistryConsumer.h>

--- a/packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibrary.m
+++ b/packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibrary.m
@@ -2,7 +2,8 @@
 
 #import <Photos/Photos.h>
 #import <PhotosUI/PhotosUI.h>
-#import <MobileCoreServices/MobileCoreServices.h>
+#import <AVFoundation/AVFoundation.h>
+#import <CoreServices/CoreServices.h>
 
 #import <EXMediaLibrary/EXMediaLibrary.h>
 #import <EXMediaLibrary/EXSaveToLibraryDelegate.h>

--- a/packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibraryImageLoader.m
+++ b/packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibraryImageLoader.m
@@ -7,7 +7,9 @@
 #if __has_include(<React/RCTImageURLLoader.h>)
 
 #import <Photos/Photos.h>
+#import <React/RCTDefines.h>
 #import <React/RCTUtils.h>
+#import <React/RCTBridgeModule.h>
 #import <EXMediaLibrary/EXMediaLibraryImageLoader.h>
 
 @implementation EXMediaLibraryImageLoader

--- a/packages/expo-screen-orientation/ios/EXScreenOrientation/EXScreenOrientationRegistry.h
+++ b/packages/expo-screen-orientation/ios/EXScreenOrientation/EXScreenOrientationRegistry.h
@@ -1,5 +1,6 @@
 //  Copyright © 2019-present 650 Industries. All rights reserved.
 
+#import <UIKit/UIKit.h>
 #import <Foundation/Foundation.h>
 #import <UMCore/UMSingletonModule.h>
 

--- a/packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenService.h
+++ b/packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenService.h
@@ -1,5 +1,6 @@
 // Copyright 2016-present 650 Industries. All rights reserved.
 
+#import <UIKit/UIKit.h>
 #import <Foundation/Foundation.h>
 #import <UMCore/UMSingletonModule.h>
 #import <EXSplashScreen/EXSplashScreenController.h>

--- a/packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenViewProvider.h
+++ b/packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenViewProvider.h
@@ -1,5 +1,6 @@
 // Copyright © 2018 650 Industries. All rights reserved.
 
+#import <UIKit/UIKit.h>
 #import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.h
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.h
@@ -1,5 +1,7 @@
 //  Copyright © 2019 650 Industries. All rights reserved.
 
+#import <Foundation/Foundation.h>
+
 NS_ASSUME_NONNULL_BEGIN
 
 typedef NS_ENUM(NSInteger, EXUpdatesCheckAutomaticallyConfig) {

--- a/packages/unimodules-app-loader/ios/UMAppLoader/UMAppLoaderProvider.h
+++ b/packages/unimodules-app-loader/ios/UMAppLoader/UMAppLoaderProvider.h
@@ -1,5 +1,6 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
+#import <Foundation/Foundation.h>
 #import <UMAppLoader/UMAppLoaderInterface.h>
 
 #define UM_REGISTER_APP_LOADER_WITH_CUSTOM_LOAD(loader_name, _custom_load_code) \

--- a/packages/unimodules-constants-interface/ios/UMConstantsInterface/UMConstantsInterface.h
+++ b/packages/unimodules-constants-interface/ios/UMConstantsInterface/UMConstantsInterface.h
@@ -1,5 +1,8 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
+#import <Foundation/Foundation.h>
+#import <CoreGraphics/CoreGraphics.h>
+
 @protocol UMConstantsInterface
 
 - (NSDictionary *)constants;

--- a/packages/unimodules-font-interface/ios/UMFontInterface/UMFontProcessorInterface.h
+++ b/packages/unimodules-font-interface/ios/UMFontInterface/UMFontProcessorInterface.h
@@ -1,5 +1,7 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
+#import <UIKit/UIKit.h>
+
 @protocol UMFontProcessorInterface
 
 - (UIFont *)updateFont:(UIFont *)uiFont

--- a/packages/unimodules-font-interface/ios/UMFontInterface/UMFontScalerInterface.h
+++ b/packages/unimodules-font-interface/ios/UMFontInterface/UMFontScalerInterface.h
@@ -1,5 +1,7 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
+#import <UIKit/UIKit.h>
+
 @protocol UMFontScalerInterface
 
 - (UIFont *)scaledFont:(UIFont *)font toSize:(CGFloat)fontSize;

--- a/packages/unimodules-task-manager-interface/ios/UMTaskManagerInterface/UMTaskInterface.h
+++ b/packages/unimodules-task-manager-interface/ios/UMTaskManagerInterface/UMTaskInterface.h
@@ -1,5 +1,7 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
+#import <Foundation/Foundation.h>
+
 // forward declaration for consumer interface
 @protocol UMTaskConsumerInterface;
 

--- a/packages/unimodules-task-manager-interface/ios/UMTaskManagerInterface/UMTaskManagerInterface.h
+++ b/packages/unimodules-task-manager-interface/ios/UMTaskManagerInterface/UMTaskManagerInterface.h
@@ -1,5 +1,6 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
+#import <Foundation/Foundation.h>
 #import <UMTaskManagerInterface/UMTaskInterface.h>
 
 NS_ASSUME_NONNULL_BEGIN


### PR DESCRIPTION
# Why

We haven't noticed these issues because we always build the entire app (workspace) where frameworks provided by the system (such as Foundation, UIKit, AVFoundation) and our CocoaPods dependencies are automatically linked to the app. Things are completely different when we want to build just the specific library where such frameworks and pods must be explicitly imported.

I had to apply all these changes to build static libraries for our modules (prebuilds).

# How

Just added and fixed some headers at which the compiler has failed.

# Test Plan

What could go wrong? 😂 Expo Go compiles without issues and all modules can now be built using my script that prebuilds our modules (separate PR later).


Changelog entries not necessary — it isn't a user-facing change.