### PR TITLE
[expo-constants] add getAppConfig script setup steps to README

### DIFF
--- a/packages/expo-constants/README.md
+++ b/packages/expo-constants/README.md
@@ -21,6 +21,23 @@ For bare React Native projects, you must ensure that you have [installed and con
 expo install expo-constants
 ```
 
+### Optional: set up script to get app config
+
+Optionally, you can set up a build script that will grab your app's config (from app.json or app.config.js) and embed it into your build. This will ensure `Constants.manifest` is defined on the first run of your app (before it has downloaded any OTA updates). If your app doesn't use `Constants.manifest`, you can skip this step.
+
+To set up the script on iOS, add the following line to the **Bundle React Native code and images** Build Phase in your Xcode project:
+
+```
+../node_modules/expo-constants/scripts/get-app-config-ios.sh
+```
+
+To set up the script on Android, apply the following diff to `android/app/build.gradle`:
+
+```diff
+ apply from: "../../node_modules/react-native/react.gradle"
++apply from: "../../node_modules/expo-constants/scripts/get-app-config-android.gradle"
+```
+
 # Contributing
 
 Contributions are very welcome! Please refer to guidelines described in the [contributing guide](https://github.com/expo/expo#contributing).


### PR DESCRIPTION
# Why

Since our warning when `Constants.manifest` is null refers to installation steps, we should actually document those steps 😅 

# How

Add an optional installation step for the bare workflow to setup the getAppConfig scripts.

Added this to the README, open to adding it elsewhere too if we want this to be more widely known, but for now it seems like we don't want to encourage further dependency on `Constants.manifest`.

# Test Plan

Look at the README online. Tested the steps on the bare project templates
