### PR TITLE
[docs] Add Snack example for GLView

### DIFF
--- a/docs/pages/versions/unversioned/sdk/gl-view.md
+++ b/docs/pages/versions/unversioned/sdk/gl-view.md
@@ -5,6 +5,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-gl'
 
 import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
+import SnackInline from '~/components/plugins/SnackInline';
 
 **`expo-gl`** provides a `View` that acts as an OpenGL ES render target, useful for rendering 2D and 3D graphics. On mounting, an OpenGL ES context is created. Its drawing buffer is presented as the contents of the `View` every frame.
 
@@ -13,6 +14,66 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 ## Installation
 
 <InstallSection packageName="expo-gl" />
+
+## Usage
+
+<SnackInline label='Basic GL usage' dependencies={['expo-gl']}>
+
+```js
+import React from 'react';
+import { View } from 'react-native';
+import { GLView } from 'expo-gl';
+
+export default function App() {
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <GLView
+        style={{ width: 300, height: 300 }}
+        onContextCreate={onContextCreate}
+      />
+    </View>
+  );
+}
+
+function onContextCreate(gl) {
+  gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
+  gl.clearColor(0, 1, 1, 1);
+
+  // Create vertex shader (shape & position)
+  const vert = gl.createShader(gl.VERTEX_SHADER);
+  gl.shaderSource(vert, `
+    void main(void) {
+      gl_Position = vec4(0.0, 0.0, 0.0, 1.0);
+      gl_PointSize = 150.0;
+    }
+  `);
+  gl.compileShader(vert);
+
+  // Create fragment shader (color)
+  const frag = gl.createShader(gl.FRAGMENT_SHADER);
+  gl.shaderSource(frag, `
+    void main(void) {
+      gl_FragColor = vec4(0.0, 0.0, 0.0, 1.0);
+    }
+  `);
+  gl.compileShader(frag);
+
+  // Link together into a program
+  const program = gl.createProgram();
+  gl.attachShader(program, vert);
+  gl.attachShader(program, frag);
+  gl.linkProgram(program);
+  gl.useProgram(program);
+
+  gl.clear(gl.COLOR_BUFFER_BIT);
+  gl.drawArrays(gl.POINTS, 0, 1);
+
+  gl.flush();
+  gl.endFrameEXP();
+}
+```
+
+</SnackInline>
 
 ## API
 

--- a/docs/pages/versions/unversioned/sdk/gl-view.md
+++ b/docs/pages/versions/unversioned/sdk/gl-view.md
@@ -27,10 +27,7 @@ import { GLView } from 'expo-gl';
 export default function App() {
   return (
     <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
-      <GLView
-        style={{ width: 300, height: 300 }}
-        onContextCreate={onContextCreate}
-      />
+      <GLView style={{ width: 300, height: 300 }} onContextCreate={onContextCreate} />
     </View>
   );
 }
@@ -41,21 +38,27 @@ function onContextCreate(gl) {
 
   // Create vertex shader (shape & position)
   const vert = gl.createShader(gl.VERTEX_SHADER);
-  gl.shaderSource(vert, `
+  gl.shaderSource(
+    vert,
+    `
     void main(void) {
       gl_Position = vec4(0.0, 0.0, 0.0, 1.0);
       gl_PointSize = 150.0;
     }
-  `);
+  `
+  );
   gl.compileShader(vert);
 
   // Create fragment shader (color)
   const frag = gl.createShader(gl.FRAGMENT_SHADER);
-  gl.shaderSource(frag, `
+  gl.shaderSource(
+    frag,
+    `
     void main(void) {
       gl_FragColor = vec4(0.0, 0.0, 0.0, 1.0);
     }
-  `);
+  `
+  );
   gl.compileShader(frag);
 
   // Link together into a program

--- a/docs/pages/versions/v39.0.0/sdk/gl-view.md
+++ b/docs/pages/versions/v39.0.0/sdk/gl-view.md
@@ -5,6 +5,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-39/packages/expo-gl'
 
 import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
+import SnackInline from '~/components/plugins/SnackInline';
 
 **`expo-gl`** provides a `View` that acts as an OpenGL ES render target, useful for rendering 2D and 3D graphics. On mounting, an OpenGL ES context is created. Its drawing buffer is presented as the contents of the `View` every frame.
 
@@ -13,6 +14,66 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 ## Installation
 
 <InstallSection packageName="expo-gl" />
+
+## Usage
+
+<SnackInline label='Basic GL usage' dependencies={['expo-gl']}>
+
+```js
+import React from 'react';
+import { View } from 'react-native';
+import { GLView } from 'expo-gl';
+
+export default function App() {
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <GLView
+        style={{ width: 300, height: 300 }}
+        onContextCreate={onContextCreate}
+      />
+    </View>
+  );
+}
+
+function onContextCreate(gl) {
+  gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
+  gl.clearColor(0, 1, 1, 1);
+
+  // Create vertex shader (shape & position)
+  const vert = gl.createShader(gl.VERTEX_SHADER);
+  gl.shaderSource(vert, `
+    void main(void) {
+      gl_Position = vec4(0.0, 0.0, 0.0, 1.0);
+      gl_PointSize = 150.0;
+    }
+  `);
+  gl.compileShader(vert);
+
+  // Create fragment shader (color)
+  const frag = gl.createShader(gl.FRAGMENT_SHADER);
+  gl.shaderSource(frag, `
+    void main(void) {
+      gl_FragColor = vec4(0.0, 0.0, 0.0, 1.0);
+    }
+  `);
+  gl.compileShader(frag);
+
+  // Link together into a program
+  const program = gl.createProgram();
+  gl.attachShader(program, vert);
+  gl.attachShader(program, frag);
+  gl.linkProgram(program);
+  gl.useProgram(program);
+
+  gl.clear(gl.COLOR_BUFFER_BIT);
+  gl.drawArrays(gl.POINTS, 0, 1);
+
+  gl.flush();
+  gl.endFrameEXP();
+}
+```
+
+</SnackInline>
 
 ## API
 

--- a/docs/pages/versions/v39.0.0/sdk/gl-view.md
+++ b/docs/pages/versions/v39.0.0/sdk/gl-view.md
@@ -27,10 +27,7 @@ import { GLView } from 'expo-gl';
 export default function App() {
   return (
     <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
-      <GLView
-        style={{ width: 300, height: 300 }}
-        onContextCreate={onContextCreate}
-      />
+      <GLView style={{ width: 300, height: 300 }} onContextCreate={onContextCreate} />
     </View>
   );
 }
@@ -41,21 +38,27 @@ function onContextCreate(gl) {
 
   // Create vertex shader (shape & position)
   const vert = gl.createShader(gl.VERTEX_SHADER);
-  gl.shaderSource(vert, `
+  gl.shaderSource(
+    vert,
+    `
     void main(void) {
       gl_Position = vec4(0.0, 0.0, 0.0, 1.0);
       gl_PointSize = 150.0;
     }
-  `);
+  `
+  );
   gl.compileShader(vert);
 
   // Create fragment shader (color)
   const frag = gl.createShader(gl.FRAGMENT_SHADER);
-  gl.shaderSource(frag, `
+  gl.shaderSource(
+    frag,
+    `
     void main(void) {
       gl_FragColor = vec4(0.0, 0.0, 0.0, 1.0);
     }
-  `);
+  `
+  );
   gl.compileShader(frag);
 
   // Link together into a program

--- a/docs/pages/versions/v40.0.0/sdk/gl-view.md
+++ b/docs/pages/versions/v40.0.0/sdk/gl-view.md
@@ -5,6 +5,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-40/packages/expo-gl'
 
 import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
+import SnackInline from '~/components/plugins/SnackInline';
 
 **`expo-gl`** provides a `View` that acts as an OpenGL ES render target, useful for rendering 2D and 3D graphics. On mounting, an OpenGL ES context is created. Its drawing buffer is presented as the contents of the `View` every frame.
 
@@ -13,6 +14,66 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 ## Installation
 
 <InstallSection packageName="expo-gl" />
+
+## Usage
+
+<SnackInline label='Basic GL usage' dependencies={['expo-gl']}>
+
+```js
+import React from 'react';
+import { View } from 'react-native';
+import { GLView } from 'expo-gl';
+
+export default function App() {
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <GLView
+        style={{ width: 300, height: 300 }}
+        onContextCreate={onContextCreate}
+      />
+    </View>
+  );
+}
+
+function onContextCreate(gl) {
+  gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
+  gl.clearColor(0, 1, 1, 1);
+
+  // Create vertex shader (shape & position)
+  const vert = gl.createShader(gl.VERTEX_SHADER);
+  gl.shaderSource(vert, `
+    void main(void) {
+      gl_Position = vec4(0.0, 0.0, 0.0, 1.0);
+      gl_PointSize = 150.0;
+    }
+  `);
+  gl.compileShader(vert);
+
+  // Create fragment shader (color)
+  const frag = gl.createShader(gl.FRAGMENT_SHADER);
+  gl.shaderSource(frag, `
+    void main(void) {
+      gl_FragColor = vec4(0.0, 0.0, 0.0, 1.0);
+    }
+  `);
+  gl.compileShader(frag);
+
+  // Link together into a program
+  const program = gl.createProgram();
+  gl.attachShader(program, vert);
+  gl.attachShader(program, frag);
+  gl.linkProgram(program);
+  gl.useProgram(program);
+
+  gl.clear(gl.COLOR_BUFFER_BIT);
+  gl.drawArrays(gl.POINTS, 0, 1);
+
+  gl.flush();
+  gl.endFrameEXP();
+}
+```
+
+</SnackInline>
 
 ## API
 

--- a/docs/pages/versions/v40.0.0/sdk/gl-view.md
+++ b/docs/pages/versions/v40.0.0/sdk/gl-view.md
@@ -27,10 +27,7 @@ import { GLView } from 'expo-gl';
 export default function App() {
   return (
     <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
-      <GLView
-        style={{ width: 300, height: 300 }}
-        onContextCreate={onContextCreate}
-      />
+      <GLView style={{ width: 300, height: 300 }} onContextCreate={onContextCreate} />
     </View>
   );
 }
@@ -41,21 +38,27 @@ function onContextCreate(gl) {
 
   // Create vertex shader (shape & position)
   const vert = gl.createShader(gl.VERTEX_SHADER);
-  gl.shaderSource(vert, `
+  gl.shaderSource(
+    vert,
+    `
     void main(void) {
       gl_Position = vec4(0.0, 0.0, 0.0, 1.0);
       gl_PointSize = 150.0;
     }
-  `);
+  `
+  );
   gl.compileShader(vert);
 
   // Create fragment shader (color)
   const frag = gl.createShader(gl.FRAGMENT_SHADER);
-  gl.shaderSource(frag, `
+  gl.shaderSource(
+    frag,
+    `
     void main(void) {
       gl_FragColor = vec4(0.0, 0.0, 0.0, 1.0);
     }
-  `);
+  `
+  );
   gl.compileShader(frag);
 
   // Link together into a program


### PR DESCRIPTION
# Why

Adds Usage section and Snack for GLView. This facilitates testing of Snack and is more user friendly.

# How

- Add Basic GL example as inline Snack (inspired by https://github.com/expo/gl-hello-world)
- Update Unversioned, SDK 40 and SDK 39

# Test Plan

- `yarn lint`
- `yarn prettier`
- https://snack.expo.io/e4ExwYDbW

![image](https://user-images.githubusercontent.com/6184593/100719831-6fa74200-33bd-11eb-8f11-210db1394457.png)
