### PR TITLE
[docs] Update dev port to 3002

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -20,13 +20,13 @@ Then `cd` into the `docs` directory and install dependencies with:
 yarn
 ```
 
-Then you can run the app with (make sure you have no server running on port `3000`):
+Then you can run the app with (make sure you have no server running on port `3002`):
 
 ```sh
 yarn run dev
 ```
 
-Now the documentation is running at http://localhost:3000
+Now the documentation is running at http://localhost:3002
 
 ### Running in production mode
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -4,7 +4,7 @@
   "betaVersion": "40.0.0",
   "private": true,
   "scripts": {
-    "dev": "rimraf .next/preval && next dev",
+    "dev": "rimraf .next/preval && next dev -p 3002",
     "build": "cross-env NODE_OPTIONS=--max-old-space-size=8192 next build",
     "export": "yarn run build && next export && yarn run export-issue-404",
     "export-issue-404": "echo \"🛠  Patching https://github.com/vercel/next.js/issues/16528\"; cp out/404/index.html out/404.html",


### PR DESCRIPTION
# Why

Change the port for the `docs` dev-server (`yarn dev`) to `3002`, so it doesn't conflict with the local `www` server during development. This makes it possible to run the `www` and `snack` development servers side-by-side with the documentation. This allows for testing Snack (e.g. when upgrading to a new SDK) using the examples from the documentation. Which can be achieved by changing the `SNACK_URL` to `http://snack.expo.test`.

Additionally, this prevents the documentation dev-server from exiting and throwing `Error [ERR_HTTP_HEADERS_SENT]: Cannot set headers after they are sent to the client` when a local development Snack server is running (which calls various end-points on localhost:3000).

# How

- Update port to 3002
- Update README to mention new port number

# Test Plan

- Scanned code and sources for use of `3000` which referred to the docs dev server
- Run `yarn dev` and was able to connect to `http://localhost:3002` succesfully
