### PR TITLE
[expoview] show correct error message when using new SDK version

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/Constants.java
+++ b/android/expoview/src/main/java/host/exp/exponent/Constants.java
@@ -71,7 +71,7 @@ public class Constants {
   }
 
   static {
-    Set<String> abiVersions = new HashSet<>();
+    List<String> abiVersions = new ArrayList<>();
     // WHEN_DISTRIBUTING_REMOVE_FROM_HERE
     // WHEN_PREPARING_SHELL_REMOVE_FROM_HERE
     // ADD ABI VERSIONS HERE DO NOT MODIFY
@@ -91,7 +91,7 @@ public class Constants {
       abiVersions.add(TEMPORARY_ABI_VERSION);
     }
 
-    setSdkVersions(new ArrayList<>(abiVersions));
+    setSdkVersions(abiVersions);
 
     List<EmbeddedResponse> embeddedResponses = new ArrayList<>();
     // WHEN_PREPARING_SHELL_REMOVE_FROM_HERE

--- a/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.java
+++ b/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.java
@@ -465,12 +465,16 @@ public class ExpoUpdatesAppLoader {
   private ManifestException formatExceptionForIncompatibleSdk(String sdkVersion) {
     JSONObject errorJson = new JSONObject();
     try {
-      errorJson.put("errorCode", "EXPERIENCE_SDK_VERSION_OUTDATED");
       errorJson.put("message", "Invalid SDK version");
-      errorJson.put("metadata", new JSONObject().put(
-        "availableSDKVersions",
-        new JSONArray().put(sdkVersion))
-      );
+      if (ABIVersion.toNumber(sdkVersion) > ABIVersion.toNumber(Constants.SDK_VERSIONS_LIST.get(0))) {
+        errorJson.put("errorCode", "EXPERIENCE_SDK_VERSION_TOO_NEW");
+      } else {
+        errorJson.put("errorCode", "EXPERIENCE_SDK_VERSION_OUTDATED");
+        errorJson.put("metadata", new JSONObject().put(
+          "availableSDKVersions",
+          new JSONArray().put(sdkVersion))
+        );
+      }
     } catch (Exception e) {
       Log.e(TAG, "Failed to format error message for incompatible SDK version", e);
     }

--- a/android/expoview/src/main/java/host/exp/exponent/exceptions/ManifestException.java
+++ b/android/expoview/src/main/java/host/exp/exponent/exceptions/ManifestException.java
@@ -57,7 +57,7 @@ public class ManifestException extends ExponentException {
               JSONObject metadata = mErrorJSON.getJSONObject("metadata");
               JSONArray availableSDKVersions = metadata.getJSONArray("availableSDKVersions");
               String sdkVersionRequired = availableSDKVersions.getString(0);
-              formattedMessage = "This project uses SDK v" + sdkVersionRequired + " , but this Expo client requires at least v" + Constants.SDK_VERSIONS_LIST.get(Constants.SDK_VERSIONS_LIST.size() - 1) + ".";
+              formattedMessage = "This project uses SDK v" + sdkVersionRequired + " , but this version of the Expo client requires at least v" + Constants.SDK_VERSIONS_LIST.get(Constants.SDK_VERSIONS_LIST.size() - 1) + ".";
               break;
             case "EXPERIENCE_SDK_VERSION_TOO_NEW":
               formattedMessage = "This project requires a newer version of the Expo client - please download the latest version from the Play Store.";


### PR DESCRIPTION
# Why

Error message was confusing

# How

add appropriate error code based on if the sdk version being used is greater than the greatest sdk version supported

the new error code doesn't take into account if someone is beta testing, but since you need to actively be _trying_ to beta test, I think they are much less likely to be using an older version of the expo client
# Test Plan

before:
<img src="https://user-images.githubusercontent.com/35579283/100772095-3080ed00-33cd-11eb-951f-84785ff3ad9d.png" width="200" />
after:

<img src="https://user-images.githubusercontent.com/35579283/100772311-6aea8a00-33cd-11eb-8150-d291c0b9bdba.png" width="200" />


