### PR TITLE
[ios] fix crash when opening SDK 37 and 38 projects

### DIFF
--- a/ios/versioned-react-native/ABI37_0_0/Expo/ExpoKit/Core/UniversalModules/ABI37_0_0EXScopedModuleRegistryAdapter.m
+++ b/ios/versioned-react-native/ABI37_0_0/Expo/ExpoKit/Core/UniversalModules/ABI37_0_0EXScopedModuleRegistryAdapter.m
@@ -33,7 +33,7 @@
   ABI37_0_0UMModuleRegistry *moduleRegistry = [self.moduleRegistryProvider moduleRegistry];
 
 #if __has_include(<ABI37_0_0EXConstants/ABI37_0_0EXConstantsService.h>)
-  ABI37_0_0EXConstantsBinding *constantsBinding = [[ABI37_0_0EXConstantsBinding alloc] initWithExperienceId:experienceId andParams:params deviceInstallationUUIDManager:kernelServices[@"EXDeviceInstallationUUIDManager"]];
+  ABI37_0_0EXConstantsBinding *constantsBinding = [[ABI37_0_0EXConstantsBinding alloc] initWithExperienceId:experienceId andParams:params deviceInstallationUUIDManager:kernelServices[@"EXDeviceInstallationUUIDService"]];
   [moduleRegistry registerInternalModule:constantsBinding];
 #endif
 

--- a/ios/versioned-react-native/ABI38_0_0/Expo/ExpoKit/Core/UniversalModules/ABI38_0_0EXScopedModuleRegistryAdapter.m
+++ b/ios/versioned-react-native/ABI38_0_0/Expo/ExpoKit/Core/UniversalModules/ABI38_0_0EXScopedModuleRegistryAdapter.m
@@ -39,7 +39,7 @@
   ABI38_0_0UMModuleRegistry *moduleRegistry = [self.moduleRegistryProvider moduleRegistry];
 
 #if __has_include(<ABI38_0_0EXConstants/ABI38_0_0EXConstantsService.h>)
-  ABI38_0_0EXConstantsBinding *constantsBinding = [[ABI38_0_0EXConstantsBinding alloc] initWithExperienceId:experienceId andParams:params deviceInstallationUUIDManager:kernelServices[@"EXDeviceInstallationUUIDManager"]];
+  ABI38_0_0EXConstantsBinding *constantsBinding = [[ABI38_0_0EXConstantsBinding alloc] initWithExperienceId:experienceId andParams:params deviceInstallationUUIDManager:kernelServices[@"EXDeviceInstallationUUIDService"]];
   [moduleRegistry registerInternalModule:constantsBinding];
 #endif
 


### PR DESCRIPTION
# Why

Opening SDK 37 or 38 projects in the beta version of the iOS client causes the client to crash, which comes from trying to insert a nil return value from `installationId` into the exported Constants dictionary.

# How

Turns out ABI 37 and 38 were looking for a nonexistent kernel service. `EXDeviceInstallationUUIDManager` -> `EXDeviceInstallationUUIDService` fixed the problem.

# Test Plan

Tested opening SDK 37, 38, and 39 projects, now works.
