### PR TITLE
[NCL] do not show IAP screen in client

### DIFF
--- a/apps/native-component-list/src/screens/ExpoApisScreen.tsx
+++ b/apps/native-component-list/src/screens/ExpoApisScreen.tsx
@@ -1,6 +1,7 @@
 import { Platform } from '@unimodules/core';
 import * as Notifications from 'expo-notifications';
 import React from 'react';
+import Constants, { ExecutionEnvironment } from 'expo-constants';
 import { Alert } from 'react-native';
 
 import ExpoAPIIcon from '../components/ExpoAPIIcon';
@@ -57,7 +58,6 @@ const screens = [
   'Haptics',
   'ImageManipulator',
   'ImagePicker',
-  'InAppPurchases',
   'IntentLauncher',
   'KeepAwake',
   'Linking',
@@ -88,6 +88,10 @@ const screens = [
   'ViewShot',
   'WebBrowser',
 ];
+
+if (Constants.executionEnvironment !== ExecutionEnvironment.StoreClient) {
+  screens.push('InAppPurchases');
+}
 
 export const ScreenItems = screens.map(name => ({
   name,

--- a/apps/native-component-list/src/screens/ExpoApisScreen.tsx
+++ b/apps/native-component-list/src/screens/ExpoApisScreen.tsx
@@ -1,7 +1,7 @@
 import { Platform } from '@unimodules/core';
+import Constants, { ExecutionEnvironment } from 'expo-constants';
 import * as Notifications from 'expo-notifications';
 import React from 'react';
-import Constants, { ExecutionEnvironment } from 'expo-constants';
 import { Alert } from 'react-native';
 
 import ExpoAPIIcon from '../components/ExpoAPIIcon';


### PR DESCRIPTION
# Why

we shouldn't show this screen in the store client

# How



# Test Plan

`yarn lint` is hanging forever locally so I'm just letting CI do it
