### PR TITLE
[ios] improve handling of Local Network permission on iOS 14

### DIFF
--- a/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
+++ b/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
@@ -328,22 +328,6 @@ NS_ASSUME_NONNULL_BEGIN
   [sdkVersions addObject:@"UNVERSIONED"];
   _selectionPolicy = [[EXUpdatesSelectionPolicyNewest alloc] initWithRuntimeVersions:sdkVersions];
 
-  if (@available(iOS 14, *)) {
-    // Try to detect if we're trying to load a local network URL so we can preemptively show the
-    // Local Network permission prompt -- otherwise the network request will fail before the user
-    // can accept or reject the permission.
-    NSString * host = httpManifestUrl.host;
-    if ([host hasPrefix:@"192.168."] || [host hasPrefix:@"172."] || [host hasPrefix:@"10."]) {
-      // We want to trigger the local network permission dialog. However, the iOS API doesn't expose a way to do it.
-      // But we can use system functionality that needs this permission to trigger prompt.
-      // See https://stackoverflow.com/questions/63940427/ios-14-how-to-trigger-local-network-dialog-and-check-user-answer
-      static dispatch_once_t once;
-      dispatch_once(&once, ^{
-        [[NSProcessInfo processInfo] hostName];
-      });
-    }
-  }
-
   EXUpdatesAppLoaderTask *loaderTask = [[EXUpdatesAppLoaderTask alloc] initWithConfig:_config
                                                                              database:updatesDatabaseManager.database
                                                                             directory:updatesDatabaseManager.updatesDirectory

--- a/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
+++ b/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
@@ -328,6 +328,22 @@ NS_ASSUME_NONNULL_BEGIN
   [sdkVersions addObject:@"UNVERSIONED"];
   _selectionPolicy = [[EXUpdatesSelectionPolicyNewest alloc] initWithRuntimeVersions:sdkVersions];
 
+  if (@available(iOS 14, *)) {
+    // Try to detect if we're trying to load a local network URL so we can preemptively show the
+    // Local Network permission prompt -- otherwise the network request will fail before the user
+    // can accept or reject the permission.
+    NSString * host = httpManifestUrl.host;
+    if ([host hasPrefix:@"192.168."] || [host hasPrefix:@"172."] || [host hasPrefix:@"10."]) {
+      // We want to trigger the local network permission dialog. However, the iOS API doesn't expose a way to do it.
+      // But we can use system functionality that needs this permission to trigger prompt.
+      // See https://stackoverflow.com/questions/63940427/ios-14-how-to-trigger-local-network-dialog-and-check-user-answer
+      static dispatch_once_t once;
+      dispatch_once(&once, ^{
+        [[NSProcessInfo processInfo] hostName];
+      });
+    }
+  }
+
   EXUpdatesAppLoaderTask *loaderTask = [[EXUpdatesAppLoaderTask alloc] initWithConfig:_config
                                                                              database:updatesDatabaseManager.database
                                                                             directory:updatesDatabaseManager.updatesDirectory

--- a/ios/Exponent/Kernel/Services/EXKernelLinkingManager.m
+++ b/ios/Exponent/Kernel/Services/EXKernelLinkingManager.m
@@ -65,6 +65,22 @@ NSString *kEXExpoLegacyDeepLinkSeparator = @"+";
       // if Home is present and running, open a new app with this url.
       // if home isn't running yet, we'll handle the LaunchOptions url after home finishes launching.
 
+      if (@available(iOS 14, *)) {
+        // Try to detect if we're trying to open a local network URL so we can preemptively show the
+        // Local Network permission prompt -- otherwise the network request will fail before the user
+        // has time to accept or reject the permission.
+        NSString *host = urlToRoute.host;
+        if ([host hasPrefix:@"192.168."] || [host hasPrefix:@"172."] || [host hasPrefix:@"10."]) {
+          // We want to trigger the local network permission dialog. However, the iOS API doesn't expose a way to do it.
+          // But we can use system functionality that needs this permission to trigger prompt.
+          // See https://stackoverflow.com/questions/63940427/ios-14-how-to-trigger-local-network-dialog-and-check-user-answer
+          static dispatch_once_t once;
+          dispatch_once(&once, ^{
+            [[NSProcessInfo processInfo] hostName];
+          });
+        }
+      }
+
       // Since this method might have been called on any thread,
       // let's make sure we create a new app on the main queue.
       RCTExecuteOnMainQueue(^{

--- a/ios/Exponent/Kernel/Views/EXAppViewController.m
+++ b/ios/Exponent/Kernel/Views/EXAppViewController.m
@@ -215,7 +215,7 @@ NS_ASSUME_NONNULL_BEGIN
   }
 
   NSString *domain = (error && error.domain) ? error.domain : @"";
-  BOOL isNetworkError = ([domain isEqualToString:(NSString *)kCFErrorDomainCFNetwork] || [domain isEqualToString:EXNetworkErrorDomain]);
+  BOOL isNetworkError = ([domain isEqualToString:(NSString *)kCFErrorDomainCFNetwork] || [domain isEqualToString:NSURLErrorDomain] || [domain isEqualToString:EXNetworkErrorDomain]);
 
   if (isNetworkError) {
     // show a human-readable reachability error

--- a/ios/Exponent/Kernel/Views/EXErrorView.m
+++ b/ios/Exponent/Kernel/Views/EXErrorView.m
@@ -96,11 +96,11 @@
         if ([self _urlLooksLikeLAN:url]) {
           NSString *extraLANPermissionText = @"";
           if (@available(iOS 14, *)) {
-            extraLANPermissionText = @", and that you have granted Expo the Local Network permission in the Settings app,";
+            extraLANPermissionText = @", and that you have granted Expo Go the Local Network permission in the Settings app,";
           }
           _lblError.text = [NSString stringWithFormat:
-                            @"%@ It looks like you may be using a LAN URL. "
-                            "Make sure your device is on the same network as the server%@ or try using a tunnel.", _lblError.text, extraLANPermissionText];
+                            @"%@\n\nIt looks like you may be using a LAN URL. "
+                            "Make sure your device is on the same network as the server%@ or try using the tunnel connection type.", _lblError.text, extraLANPermissionText];
         }
       }
       break;

--- a/ios/Exponent/Kernel/Views/EXErrorView.m
+++ b/ios/Exponent/Kernel/Views/EXErrorView.m
@@ -94,9 +94,13 @@
       } else if (_appRecord.appLoader.manifestUrl) {
         NSString *url = _appRecord.appLoader.manifestUrl.absoluteString;
         if ([self _urlLooksLikeLAN:url]) {
+          NSString *extraLANPermissionText = @"";
+          if (@available(iOS 14, *)) {
+            extraLANPermissionText = @", and that you have granted Expo the Local Network permission in the Settings app,";
+          }
           _lblError.text = [NSString stringWithFormat:
                             @"%@ It looks like you may be using a LAN URL. "
-                            "Make sure your device is on the same network as the server or try using a tunnel.", _lblError.text];
+                            "Make sure your device is on the same network as the server%@ or try using a tunnel.", _lblError.text, extraLANPermissionText];
         }
       }
       break;

--- a/ios/Exponent/Supporting/Info.plist
+++ b/ios/Exponent/Supporting/Info.plist
@@ -90,6 +90,8 @@
 	<string>Allow Expo to access your camera to take photos</string>
 	<key>NSContactsUsageDescription</key>
 	<string>Allow Expo experiences to access your contacts</string>
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>Expo needs access to your local network to load projects from your development server.</string>
 	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
 	<string>Allow Expo experiences to use your location</string>
 	<key>NSLocationAlwaysUsageDescription</key>


### PR DESCRIPTION
# Why

The Local Network permission is a little clumsy in Expo Go currently -- the system prompts the user for the permission as soon as they attempt to load an app from a LAN URL for the first time, but the network request fails in the background, so once the user accepts the alert they have to press reload, which is somewhat confusing.

Unfortunately Apple has not yet provided an API for interacting with this permission at all. It is possible to trigger the alert in a somewhat hacky way (see #11210) but it is not possible to tell whether or not the user granted or rejected the permission, and, if the user rejects the permission, NSURLSession's behavior is indistinguishable from actual lack of connectivity.

For now we will aim to provide a somewhat better experience with minimal changes, and revisit this if/when Apple provides an API for this permission.

# How

- add `NSLocalNetworkUsageDescription` to customize the alert message (see screenshot below)
- trigger the alert manually if loading from a LAN URL, before actually starting the load -- this blocks the network request from starting (and failing) before the permission is granted
- add a note about this to the error screen that's triggered when there are connectivity issues loading from a LAN URL (see screenshot)

# Test Plan

Each test case should be conducted on a fresh installation of the app.

- [x] open a local url, accept the permission, the app should start loading right away without any further interaction
- [x] open a local url, deny the permission, error screen should show the new message
- [x] open a local url, deny the permission, see error screen --> go to Settings and grant permission --> back to app, should load
- [x] open a remote url, should not see alert

# Todo

- [ ] need to make sure the new Info.plist key is filtered out of standalone apps by default (don't want this usage description for anything other than Expo Go)

# Screenshot

**Especially interested in feedback about the copy!**

<img width="1238" alt="Screen Shot 2020-12-03 at 2 32 58 PM" src="https://user-images.githubusercontent.com/19958240/101097353-e38c4a80-3575-11eb-8b76-8b20b18bde14.png">

