### PR TITLE
fix(expo-yarn-workspaces): add missing minimist dependency

### DIFF
--- a/packages/expo-yarn-workspaces/package.json
+++ b/packages/expo-yarn-workspaces/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "debug": "^4.1.1",
     "find-yarn-workspace-root": "~2.0.0",
+    "minimist": "^1.2.5",
     "mkdirp": "^0.5.1"
   }
 }


### PR DESCRIPTION
# Why

It's used but not declared

https://github.com/expo/expo/blob/52a1f6d03c642875b49851b127b7023e7d938799/packages/expo-yarn-workspaces/bin/expo-yarn-workspaces.js#L4

# How

GH editor. Range is already in lockfile, so shouldn't be any other diff

# Test Plan

CI?