### PR TITLE
[et] Prebuilding iOS libraries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,8 @@ docs/pages/versions/*/react-native/*.diff
 
 # Home
 /home/dist
+
+# Prebuilds
+/packages/**/*.xcframework
+/packages/**/*.spec.json
+/packages/**/Info-generated.plist

--- a/packages/expo-gl-cpp/cpp/EXiOSUtils.mm
+++ b/packages/expo-gl-cpp/cpp/EXiOSUtils.mm
@@ -1,3 +1,5 @@
+#import <Foundation/Foundation.h>
+
 #include <EXGL_CPP/EXPlatformUtils.h>
 
 namespace expo {

--- a/tools/expotools/package.json
+++ b/tools/expotools/package.json
@@ -26,6 +26,7 @@
     "@expo/commander": "2.21.1",
     "@expo/json-file": "^8.2.6",
     "@expo/spawn-async": "^1.5.0",
+    "@expo/xcodegen": "2.18.0-patch.1",
     "@expo/xdl": "58.0.4-alpha.1609",
     "@octokit/request": "^5.4.7",
     "@octokit/types": "^5.4.0",

--- a/tools/expotools/src/Formatter.ts
+++ b/tools/expotools/src/Formatter.ts
@@ -1,9 +1,10 @@
+import path from 'path';
 import chalk from 'chalk';
 import terminalLink from 'terminal-link';
 
 import { GitLog, GitFileLog } from './Git';
 
-const { green, yellow, blue, gray, dim, reset } = chalk;
+const { white, cyan, red, green, yellow, blue, gray, dim, reset } = chalk;
 
 /**
  * Uses `terminal-link` to create clickable link in the terminal.
@@ -74,4 +75,26 @@ export function formatFileLog(fileLog: GitFileLog): string {
  */
 export function stripNonAsciiChars(str: string): string {
   return str.replace(/[^\x00-\x7F]/gu, '');
+}
+
+/**
+ * Makes Xcode logs pretty as xcpretty :)
+ */
+export function formatXcodeBuildOutput(output: string): string {
+  return output
+    .replace(/^(\/.*)(:\d+:\d+): (error|warning|note)(:.*)$/gm, (_, p1, p2, p3, p4) => {
+      if (p3 === 'note') {
+        return gray.bold(p3) + white.bold(p4);
+      }
+      const relativePath = path.relative(process.cwd(), p1);
+      const logColor = p3 === 'error' ? red.bold : yellow.bold;
+
+      return cyan.bold(relativePath + p2) + ' ' + logColor(p3 + p4);
+    })
+    .replace(/^(In file included from )(\/[^\n]+)(:\d+:[^\n]*)$/gm, (_, p1, p2, p3) => {
+      const relativePath = path.relative(process.cwd(), p2);
+      return gray.italic(p1 + relativePath + p3);
+    })
+    .replace(/\s\^\n(\s[^\n]+)?/g, green.bold('$&\n'))
+    .replace(/\*\* BUILD FAILED \*\*/, red.bold('$&'));
 }

--- a/tools/expotools/src/commands/PrebuildPackages.ts
+++ b/tools/expotools/src/commands/PrebuildPackages.ts
@@ -1,0 +1,67 @@
+import chalk from 'chalk';
+import { performance } from 'perf_hooks';
+import { Command } from '@expo/commander';
+
+import logger from '../Logger';
+import { Package, getPackageByName } from '../Packages';
+import XcodeProject from '../prebuilds/XcodeProject';
+import {
+  buildFrameworksForProjectAsync,
+  cleanTemporaryFilesAsync,
+  cleanFrameworksAsync,
+  generateXcodeProjectSpecAsync,
+  PACKAGES_TO_PREBUILD,
+} from '../prebuilds/Prebuilder';
+
+type ActionOptions = {
+  removeArtifacts: boolean;
+  cleanCache: boolean;
+  generateSpecs: boolean;
+};
+
+async function main(packageNames: string[], options: ActionOptions) {
+  const filteredPackageNames =
+    packageNames.length > 0
+      ? packageNames.filter((name) => PACKAGES_TO_PREBUILD.includes(name))
+      : PACKAGES_TO_PREBUILD;
+
+  if (options.cleanCache) {
+    logger.info('🧹 Cleaning shared derived data directory');
+    await XcodeProject.cleanBuildFolderAsync();
+  }
+
+  const packages = filteredPackageNames.map(getPackageByName).filter(Boolean) as Package[];
+
+  if (options.removeArtifacts) {
+    logger.info('🧹 Removing existing artifacts');
+    await cleanFrameworksAsync(packages);
+    // Stop here, it doesn't make much sense to build them again ;)
+    return;
+  }
+
+  for (const pkg of packages) {
+    logger.info(`📦 Prebuilding ${chalk.green(pkg.packageName)}`);
+
+    const startTime = performance.now();
+    const xcodeProject = await generateXcodeProjectSpecAsync(pkg);
+
+    if (!options.generateSpecs) {
+      await buildFrameworksForProjectAsync(xcodeProject);
+      await cleanTemporaryFilesAsync(xcodeProject);
+    }
+
+    const endTime = performance.now();
+    const timeDiff = (endTime - startTime) / 1000;
+    logger.success('   Finished in: %s\n', chalk.magenta(timeDiff.toFixed(2) + 's'));
+  }
+}
+
+export default (program: Command) => {
+  program
+    .command('prebuild-packages [packageNames...]')
+    .alias('prebuild')
+    .option('-r, --remove-artifacts', 'Removes `.xcframework` artifacts for given packages.', false)
+    .option('-c, --clean-cache', 'Cleans the shared derived data folder before prebuilding.', false)
+    .option('-g, --generate-specs', 'Only generates project specs', false)
+    .asyncAction(main);
+};

--- a/tools/expotools/src/prebuilds/Prebuilder.ts
+++ b/tools/expotools/src/prebuilds/Prebuilder.ts
@@ -1,0 +1,240 @@
+import path from 'path';
+import fs from 'fs-extra';
+import chalk from 'chalk';
+import glob from 'glob-promise';
+
+import logger from '../Logger';
+import XcodeProject from './XcodeProject';
+import {
+  createSpecFromPodspecAsync,
+  generateXcodeProjectAsync,
+  INFO_PLIST_FILENAME,
+} from './XcodeGen';
+import { Flavor, Framework, XcodebuildSettings } from './XcodeProject.types';
+import { Package } from '../Packages';
+import { IOS_DIR } from '../Constants';
+
+const PODS_DIR = path.join(IOS_DIR, 'Pods');
+
+// We will be increasing this list slowly. Once all are enabled,
+// find a better way to ignore some packages that shouldn't be prebuilt (like interfaces).
+export const PACKAGES_TO_PREBUILD = [
+  '@unimodules/core',
+  '@unimodules/react-native-adapter',
+  // 'expo-ads-admob',
+  // 'expo-ads-facebook',
+  // 'expo-analytics-amplitude',
+  // 'expo-analytics-segment',
+  // 'expo-app-auth',
+  // 'expo-apple-authentication',
+  // 'expo-application',
+  'expo-av',
+  // 'expo-background-fetch',
+  'expo-barcode-scanner',
+  // 'expo-battery',
+  // 'expo-blur',
+  'expo-branch',
+  // 'expo-brightness',
+  // 'expo-calendar',
+  'expo-camera',
+  // 'expo-cellular',
+  // 'expo-constants',
+  'expo-contacts',
+  // 'expo-crypto',
+  // 'expo-device',
+  // 'expo-document-picker',
+  // 'expo-error-recovery',
+  'expo-face-detector',
+  // 'expo-facebook',
+  'expo-file-system',
+  // 'expo-firebase-analytics',
+  // 'expo-firebase-core',
+  // 'expo-font',
+  'expo-gl-cpp',
+  'expo-gl',
+  'expo-google-sign-in',
+  // 'expo-haptics',
+  // 'expo-image-loader',
+  // 'expo-image-manipulator',
+  // 'expo-image-picker',
+  // 'expo-keep-awake',
+  // 'expo-linear-gradient',
+  // 'expo-local-authentication',
+  // 'expo-localization',
+  'expo-location',
+  // 'expo-mail-composer',
+  'expo-media-library',
+  // 'expo-network',
+  'expo-notifications',
+  // 'expo-permissions',
+  'expo-print',
+  // 'expo-screen-capture',
+  // 'expo-screen-orientation',
+  // 'expo-secure-store',
+  'expo-sensors',
+  // 'expo-sharing',
+  // 'expo-sms',
+  // 'expo-speech',
+  'expo-splash-screen',
+  // 'expo-sqlite',
+  // 'expo-store-review',
+  // 'expo-task-manager',
+  'expo-updates',
+  // 'expo-video-thumbnails',
+  // 'expo-web-browser',
+  // 'unimodules-app-loader',
+];
+
+export function canPrebuildPackage(pkg: Package): boolean {
+  return PACKAGES_TO_PREBUILD.includes(pkg.packageName);
+}
+
+/**
+ * Automatically generates `.xcodeproj` from podspec and build frameworks.
+ */
+export async function prebuildPackageAsync(
+  pkg: Package,
+  settings?: XcodebuildSettings
+): Promise<void> {
+  if (canPrebuildPackage(pkg)) {
+    const xcodeProject = await generateXcodeProjectSpecAsync(pkg);
+    await buildFrameworksForProjectAsync(xcodeProject, settings);
+    await cleanTemporaryFilesAsync(xcodeProject);
+  }
+}
+
+export async function buildFrameworksForProjectAsync(
+  xcodeProject: XcodeProject,
+  settings?: XcodebuildSettings
+) {
+  const flavors: Flavor[] = [
+    {
+      configuration: 'Release',
+      sdk: 'iphoneos',
+      archs: ['arm64'],
+    },
+    {
+      configuration: 'Release',
+      sdk: 'iphonesimulator',
+      archs: ['x86_64', 'arm64'],
+    },
+  ];
+
+  // Builds frameworks from flavors.
+  const frameworks: Framework[] = [];
+  for (const flavor of flavors) {
+    logger.log('   Building framework for %s', chalk.yellow(flavor.sdk));
+
+    frameworks.push(
+      await xcodeProject.buildFrameworkAsync(xcodeProject.name, flavor, {
+        ONLY_ACTIVE_ARCH: false,
+        BITCODE_GENERATION_MODE: 'bitcode',
+        BUILD_LIBRARY_FOR_DISTRIBUTION: true,
+        DEAD_CODE_STRIPPING: true,
+        DEPLOYMENT_POSTPROCESSING: true,
+        STRIP_INSTALLED_PRODUCT: true,
+        STRIP_STYLE: 'non-global',
+        COPY_PHASE_STRIP: true,
+        GCC_GENERATE_DEBUGGING_SYMBOLS: false,
+        ...settings,
+      })
+    );
+  }
+
+  // Print binary sizes
+  const binarySizes = frameworks.map((framework) =>
+    chalk.magenta((framework.binarySize / 1024 / 1024).toFixed(2) + 'MB')
+  );
+  logger.log('   Binary sizes:', binarySizes.join(', '));
+
+  logger.log('   Merging frameworks to', chalk.magenta(`${xcodeProject.name}.xcframework`));
+
+  // Merge frameworks into universal xcframework
+  await xcodeProject.buildXcframeworkAsync(frameworks, settings);
+}
+
+/**
+ * Removes all temporary files that we generated in order to create `.xcframework` file.
+ */
+export async function cleanTemporaryFilesAsync(xcodeProject: XcodeProject) {
+  logger.log('   Cleaning up temporary files');
+
+  const pathsToRemove = [`${xcodeProject.name}.xcodeproj`, INFO_PLIST_FILENAME];
+
+  await Promise.all(
+    pathsToRemove.map((pathToRemove) => fs.remove(path.join(xcodeProject.rootDir, pathToRemove)))
+  );
+}
+
+/**
+ * Generates Xcode project based on the podspec of given package.
+ */
+export async function generateXcodeProjectSpecAsync(pkg: Package): Promise<XcodeProject> {
+  const podspec = await pkg.getPodspecAsync();
+
+  if (!podspec) {
+    throw new Error('Given package is not an iOS project.');
+  }
+
+  logger.log('   Generating Xcode project spec');
+
+  const spec = await createSpecFromPodspecAsync(podspec, async (dependencyName) => {
+    const frameworkPath = await findFrameworkForProjectAsync(dependencyName);
+
+    if (frameworkPath) {
+      return {
+        framework: frameworkPath,
+        link: false,
+        embed: false,
+      };
+    }
+    return null;
+  });
+
+  const xcodeprojPath = await generateXcodeProjectAsync(
+    path.join(pkg.path, pkg.iosSubdirectory),
+    spec
+  );
+  return await XcodeProject.fromXcodeprojPathAsync(xcodeprojPath);
+}
+
+/**
+ * Removes prebuilt `.xcframework` files for given packages.
+ */
+export async function cleanFrameworksAsync(packages: Package[]) {
+  for (const pkg of packages) {
+    const xcFrameworkFilename = `${pkg.podspecName}.xcframework`;
+    const xcFrameworkPath = path.join(pkg.path, pkg.iosSubdirectory, xcFrameworkFilename);
+
+    if (await fs.pathExists(xcFrameworkPath)) {
+      await fs.remove(xcFrameworkPath);
+    }
+  }
+}
+
+/**
+ * Checks whether given project name has a framework (GoogleSignIn, FBAudience) and returns its path.
+ */
+async function findFrameworkForProjectAsync(projectName: string): Promise<string | null> {
+  const searchNames = new Set([
+    projectName,
+    projectName.replace(/\/+/, ''), // Firebase/MLVision -> FirebaseMLVision
+  ]);
+
+  for (const name of searchNames) {
+    const cwd = path.join(PODS_DIR, name);
+
+    if (await fs.pathExists(cwd)) {
+      const paths = await glob(`**/*.framework`, {
+        cwd,
+      });
+
+      if (paths.length > 0) {
+        return path.join(cwd, paths[0]);
+      }
+    }
+  }
+  return null;
+}
+
+//#endregion

--- a/tools/expotools/src/prebuilds/Prebuilder.ts
+++ b/tools/expotools/src/prebuilds/Prebuilder.ts
@@ -236,5 +236,3 @@ async function findFrameworkForProjectAsync(projectName: string): Promise<string
   }
   return null;
 }
-
-//#endregion

--- a/tools/expotools/src/prebuilds/XcodeGen.ts
+++ b/tools/expotools/src/prebuilds/XcodeGen.ts
@@ -1,0 +1,280 @@
+import path from 'path';
+import fs from 'fs-extra';
+import semver from 'semver';
+
+import { spawnAsync } from '../Utils';
+import { EXPOTOOLS_DIR, IOS_DIR } from '../Constants';
+import { Podspec } from '../Packages';
+
+const PODS_DIR = path.join(IOS_DIR, 'Pods');
+const PODS_PUBLIC_HEADERS_DIR = path.join(PODS_DIR, 'Headers', 'Public');
+const PLATFORMS_MAPPING: Record<string, Platform> = {
+  ios: 'iOS',
+  osx: 'macOS',
+  macos: 'macOS',
+  tvos: 'tvOS',
+  watchos: 'watchOS',
+};
+
+export const INFO_PLIST_FILENAME = 'Info-generated.plist';
+
+// More detailed spec schema available here:
+// https://github.com/yonaskolb/XcodeGen/blob/master/Docs/ProjectSpec.md
+export type ProjectSpec = {
+  name: string;
+  projectReferences?: {
+    [key: string]: {
+      path: string;
+    };
+  };
+  targets?: {
+    [targetName: string]: {
+      type: string;
+      platform: Platform[];
+      sources?: ProjectSpecSource[];
+      dependencies?: ProjectSpecDependency[];
+      settings?: ProjectSpecSettings;
+      info?: {
+        path: string;
+        properties: Record<string, string>;
+      };
+    };
+  };
+  options?: ProjectSpecOptions;
+  settings?: ProjectSpecSettings;
+};
+
+type Platform = 'iOS' | 'macOS' | 'tvOS' | 'watchOS';
+
+export type ProjectSpecSource = {
+  path: string;
+  name?: string;
+  createIntermediateGroups?: boolean;
+  includes?: string[];
+  excludes?: string[];
+  compilerFlags?: string;
+};
+
+export type ProjectSpecDependency = {
+  // framework type
+  framework?: string;
+  implicit?: boolean;
+
+  // target/project type
+  target?: string;
+
+  // SDK framework
+  sdk?: string;
+
+  // shared options
+  embed?: boolean;
+  link?: boolean;
+  codeSign?: boolean;
+  removeHeaders?: boolean;
+  weak?: boolean;
+};
+
+export type ProjectSpecOptions = {
+  minimumXcodeGenVersion: string;
+  deploymentTarget: Record<Platform, string>;
+};
+
+export type ProjectSpecSettings = {
+  base: XcodeConfig;
+};
+
+type XcodeConfig = Record<string, string>;
+
+/**
+ * Generates `.xcodeproj` from given project spec and saves it at given dir.
+ */
+export async function generateXcodeProjectAsync(dir: string, spec: ProjectSpec): Promise<string> {
+  const specPath = path.join(dir, `${spec.name}.spec.json`);
+
+  // Save the spec to the file so `xcodegen` can use it.
+  await fs.outputJSON(specPath, spec, {
+    spaces: 2,
+  });
+
+  // Generate `.xcodeproj` from given spec. The binary is provided by `@expo/xcodegen` package.
+  await spawnAsync('yarn', ['--silent', 'run', 'xcodegen', '--quiet', '--spec', specPath], {
+    cwd: EXPOTOOLS_DIR,
+    stdio: 'inherit',
+  });
+
+  // Remove temporary spec file.
+  await fs.remove(specPath);
+
+  return path.join(dir, `${spec.name}.xcodeproj`);
+}
+
+/**
+ * Creates `xcodegen` spec from the podspec. It's very naive, but covers all our cases so far.
+ */
+export async function createSpecFromPodspecAsync(
+  podspec: Podspec,
+  dependencyResolver: (dependencyName: string) => Promise<ProjectSpecDependency | null>
+): Promise<ProjectSpec> {
+  const platforms = Object.keys(podspec.platforms);
+  const deploymentTarget = platforms.reduce((acc, platform) => {
+    acc[PLATFORMS_MAPPING[platform]] = podspec.platforms[platform];
+    return acc;
+  }, {} as Record<Platform, string>);
+
+  const dependenciesNames = podspec.dependencies ? Object.keys(podspec.dependencies) : [];
+
+  const dependencies = (
+    await Promise.all(dependenciesNames.map((dependencyName) => dependencyResolver(dependencyName)))
+  ).filter(Boolean) as ProjectSpecDependency[];
+
+  const bundleId = podNameToBundleId(podspec.name);
+
+  return {
+    name: podspec.name,
+    targets: {
+      [podspec.name]: {
+        type: 'framework',
+        platform: platforms.map((platform) => PLATFORMS_MAPPING[platform]),
+        sources: [
+          {
+            path: '',
+            name: podspec.name,
+            createIntermediateGroups: true,
+            includes: arrayize(podspec.source_files),
+            excludes: [
+              INFO_PLIST_FILENAME,
+              `${podspec.name}.spec.json`,
+              '*.xcodeproj',
+              '*.xcframework',
+              '*.podspec',
+              ...arrayize(podspec.exclude_files),
+            ],
+            compilerFlags: podspec.compiler_flags,
+          },
+        ],
+        dependencies: [
+          ...arrayize(podspec.frameworks).map((framework) => ({
+            sdk: `${framework}.framework`,
+          })),
+          ...dependencies,
+        ],
+        settings: {
+          base: mergeXcodeConfigs(podspec.pod_target_xcconfig ?? {}, {
+            MACH_O_TYPE: 'staticlib',
+          }),
+        },
+        info: {
+          path: INFO_PLIST_FILENAME,
+          properties: mergeXcodeConfigs(
+            {
+              CFBundleIdentifier: bundleId,
+              CFBundleName: podspec.name,
+              CFBundleShortVersionString: podspec.version,
+              CFBundleVersion: semver.major(podspec.version),
+            },
+            podspec.info_plist ?? {}
+          ),
+        },
+      },
+    },
+    options: {
+      minimumXcodeGenVersion: '2.18.0',
+      deploymentTarget,
+    },
+    settings: {
+      base: {
+        PRODUCT_BUNDLE_IDENTIFIER: bundleId,
+        IPHONEOS_DEPLOYMENT_TARGET: podspec.platforms.ios,
+        FRAMEWORK_SEARCH_PATHS: constructFrameworkSearchPaths(dependencies),
+        HEADER_SEARCH_PATHS: constructHeaderSearchPaths(dependenciesNames),
+
+        // Suppresses deprecation warnings coming from frameworks like OpenGLES.
+        VALIDATE_WORKSPACE_SKIPPED_SDK_FRAMEWORKS: arrayize(podspec.frameworks).join(' '),
+      },
+    },
+  };
+}
+
+function constructFrameworkSearchPaths(dependencies: ProjectSpecDependency[]): string {
+  const frameworks = dependencies.filter((dependency) => !!dependency.framework) as {
+    framework: string;
+  }[];
+
+  return (
+    '$(inherited) ' + frameworks.map((dependency) => path.dirname(dependency.framework)).join(' ')
+  ).trim();
+}
+
+function constructHeaderSearchPaths(dependencies: string[]): string {
+  // A set of pod names to include in header search paths.
+  // For simplicity, we add some more (usually transitive) than direct dependencies.
+  const podsToSearchForHeaders = new Set([
+    // Some pods' have headers at its root level (ZXingObjC and all our modules).
+    // Without this we would have to use `#import <ZXingObjC*.h>` instead of `#import <ZXingObjC/ZXingObjC*.h>`
+    '',
+
+    ...dependencies,
+
+    'DoubleConversion',
+    'React-callinvoker',
+    'React-Core',
+    'React-cxxreact',
+    'React-jsi',
+    'React-jsiexecutor',
+    'React-jsinspector',
+    'Yoga',
+    'glog',
+  ]);
+
+  // Should we add private headers too?
+  return (
+    '$(inherited) ' +
+    [...podsToSearchForHeaders]
+      .map((podName) => '"' + path.join(PODS_PUBLIC_HEADERS_DIR, podName) + '"')
+      .join(' ')
+  ).trim();
+}
+
+/**
+ * Merges Xcode config from left to right.
+ * Values containing `$(inherited)` are properly taken into account.
+ */
+function mergeXcodeConfigs(...configs: XcodeConfig[]): XcodeConfig {
+  const result: XcodeConfig = {};
+
+  for (const config of configs) {
+    for (const key in config) {
+      const value = config[key];
+      result[key] = mergeXcodeConfigValue(result[key], value);
+    }
+  }
+  return result;
+}
+
+function mergeXcodeConfigValue(prevValue: string | undefined, nextValue: string): string {
+  if (prevValue && typeof prevValue === 'string' && prevValue.includes('$(inherited)')) {
+    return '$(inherited) ' + (prevValue + ' ' + nextValue).replace(/\\s*$\(inherited\)\s*/g, ' ');
+  }
+  return nextValue;
+}
+
+/**
+ * Simple conversion from pod name to framework's bundle identifier.
+ */
+function podNameToBundleId(podName: string): string {
+  return podName
+    .replace(/^UM/, 'unimodules')
+    .replace(/^EX/, 'expo')
+    .replace(/(\_|[^\w\d\.])+/g, '.')
+    .replace(/\.*([A-Z]+)/g, (_, p1) => `.${p1.toLowerCase()}`);
+}
+
+/**
+ * Ensures the value is an array.
+ */
+function arrayize<T>(value: T | T[]): T[] {
+  if (Array.isArray(value)) {
+    return value;
+  }
+  return value != null ? [value] : [];
+}

--- a/tools/expotools/src/prebuilds/XcodeGen.types.ts
+++ b/tools/expotools/src/prebuilds/XcodeGen.types.ts
@@ -1,0 +1,66 @@
+// More detailed spec schema available here:
+// https://github.com/yonaskolb/XcodeGen/blob/master/Docs/ProjectSpec.md
+export type ProjectSpec = {
+  name: string;
+  projectReferences?: {
+    [key: string]: {
+      path: string;
+    };
+  };
+  targets?: {
+    [targetName: string]: {
+      type: string;
+      platform: ProjectSpecPlatform[];
+      sources?: ProjectSpecSource[];
+      dependencies?: ProjectSpecDependency[];
+      settings?: ProjectSpecSettings;
+      info?: {
+        path: string;
+        properties: Record<string, string>;
+      };
+    };
+  };
+  options?: ProjectSpecOptions;
+  settings?: ProjectSpecSettings;
+};
+
+export type ProjectSpecPlatform = 'iOS' | 'macOS' | 'tvOS' | 'watchOS';
+
+export type ProjectSpecSource = {
+  path: string;
+  name?: string;
+  createIntermediateGroups?: boolean;
+  includes?: string[];
+  excludes?: string[];
+  compilerFlags?: string;
+};
+
+export type ProjectSpecDependency = {
+  // framework type
+  framework?: string;
+  implicit?: boolean;
+
+  // target/project type
+  target?: string;
+
+  // SDK framework
+  sdk?: string;
+
+  // shared options
+  embed?: boolean;
+  link?: boolean;
+  codeSign?: boolean;
+  removeHeaders?: boolean;
+  weak?: boolean;
+};
+
+export type ProjectSpecOptions = {
+  minimumXcodeGenVersion: string;
+  deploymentTarget: Record<ProjectSpecPlatform, string>;
+};
+
+export type ProjectSpecSettings = {
+  base: XcodeConfig;
+};
+
+export type XcodeConfig = Record<string, string>;

--- a/tools/expotools/src/prebuilds/XcodeProject.ts
+++ b/tools/expotools/src/prebuilds/XcodeProject.ts
@@ -1,0 +1,194 @@
+import os from 'os';
+import path from 'path';
+import fs from 'fs-extra';
+
+import { spawnAsync } from '../Utils';
+import { generateXcodeProjectAsync, ProjectSpec } from './XcodeGen';
+import { Flavor, Framework, XcodebuildSettings } from './XcodeProject.types';
+import { formatXcodeBuildOutput } from '../Formatter';
+
+/**
+ * Path to the shared derived data directory.
+ */
+const SHARED_DERIVED_DATA_DIR = path.join(os.tmpdir(), 'Expo/DerivedData');
+
+/**
+ * Path to the products in derived data directory. We pick `.framework` files from there.
+ */
+const PRODUCTS_DIR = path.join(SHARED_DERIVED_DATA_DIR, 'Build/Products');
+
+/**
+ * A class representing single Xcode project and operating on its `.xcodeproj` file.
+ */
+export default class XcodeProject {
+  /**
+   * Creates `XcodeProject` instance from given path to `.xcodeproj` file.
+   */
+  static async fromXcodeprojPathAsync(xcodeprojPath: string): Promise<XcodeProject> {
+    if (!(await fs.pathExists(xcodeprojPath))) {
+      throw new Error(`Xcodeproj not found at path: ${xcodeprojPath}`);
+    }
+    return new XcodeProject(xcodeprojPath);
+  }
+
+  /**
+   * Generates `.xcodeproj` file based on given spec and returns it.
+   */
+  static async generateProjectFromSpec(dir: string, spec: ProjectSpec): Promise<XcodeProject> {
+    const xcodeprojPath = await generateXcodeProjectAsync(dir, spec);
+    return new XcodeProject(xcodeprojPath);
+  }
+
+  /**
+   * Name of the project. It should stay in sync with its filename.
+   */
+  name: string;
+
+  /**
+   * Root directory of the project and at which the `.xcodeproj` file is placed.
+   */
+  rootDir: string;
+
+  constructor(xcodeprojPath: string) {
+    this.name = path.basename(xcodeprojPath, '.xcodeproj');
+    this.rootDir = path.dirname(xcodeprojPath);
+  }
+
+  /**
+   * Returns output path to where the `.xcframework` file will be stored after running `buildXcframeworkAsync`.
+   */
+  getXcframeworkPath(): string {
+    return path.join(this.rootDir, `${this.name}.xcframework`);
+  }
+
+  /**
+   * Builds `.framework` for given target name and flavor specifying,
+   * configuration, the SDK and a list of architectures to compile against.
+   */
+  async buildFrameworkAsync(
+    target: string,
+    flavor: Flavor,
+    options?: XcodebuildSettings
+  ): Promise<Framework> {
+    await this.xcodebuildAsync(
+      [
+        'build',
+        '-project',
+        `${this.name}.xcodeproj`,
+        '-scheme',
+        `${target}_iOS`,
+        '-configuration',
+        flavor.configuration,
+        '-sdk',
+        flavor.sdk,
+        ...spreadArgs('-arch', flavor.archs),
+        '-derivedDataPath',
+        SHARED_DERIVED_DATA_DIR,
+      ],
+      options
+    );
+
+    const frameworkPath = flavorToFrameworkPath(target, flavor);
+    const stat = await fs.lstat(path.join(frameworkPath, target));
+
+    // Remove `Headers` as each our module contains headers as part of the provided source code
+    // and CocoaPods exposes them through HEADER_SEARCH_PATHS either way.
+    await fs.remove(path.join(frameworkPath, 'Headers'));
+
+    // `_CodeSignature` is apparently generated only for simulator, afaik we don't need it.
+    await fs.remove(path.join(frameworkPath, '_CodeSignature'));
+
+    return {
+      target,
+      flavor,
+      frameworkPath,
+      binarySize: stat.size,
+    };
+  }
+
+  /**
+   * Builds universal `.xcframework` from given frameworks.
+   */
+  async buildXcframeworkAsync(
+    frameworks: Framework[],
+    options?: XcodebuildSettings
+  ): Promise<string> {
+    const frameworkPaths = frameworks.map((framework) => framework.frameworkPath);
+    const outputPath = this.getXcframeworkPath();
+
+    await fs.remove(outputPath);
+
+    await this.xcodebuildAsync(
+      ['-create-xcframework', ...spreadArgs('-framework', frameworkPaths), '-output', outputPath],
+      options
+    );
+    return outputPath;
+  }
+
+  /**
+   * Removes `.xcframework` artifact produced by `buildXcframeworkAsync`.
+   */
+  async cleanXcframeworkAsync(): Promise<void> {
+    await fs.remove(this.getXcframeworkPath());
+  }
+
+  /**
+   * Generic function spawning `xcodebuild` process.
+   */
+  async xcodebuildAsync(args: string[], settings?: XcodebuildSettings) {
+    // `xcodebuild` writes error details to stdout but we don't want to pollute our output if nothing wrong happens.
+    // Spawn it quietly, pipe stderr to stdout and pass it to the current process stdout only when it fails.
+    const finalArgs = ['-quiet', ...args, '2>&1'];
+
+    if (settings) {
+      finalArgs.unshift(
+        ...Object.entries(settings).map(([key, value]) => {
+          return `${key}=${parseXcodeSettingsValue(value)}`;
+        })
+      );
+    }
+    try {
+      await spawnAsync('xcodebuild', finalArgs, {
+        cwd: this.rootDir,
+        shell: true,
+        stdio: ['ignore', 'pipe', 'inherit'],
+      });
+    } catch (e) {
+      // Print formatted Xcode logs (merged from stdout and stderr).
+      process.stdout.write(formatXcodeBuildOutput(e.stdout));
+      throw e;
+    }
+  }
+
+  /**
+   * Cleans shared derived data directory.
+   */
+  static async cleanBuildFolderAsync(): Promise<void> {
+    await fs.remove(SHARED_DERIVED_DATA_DIR);
+  }
+}
+
+/**
+ * Returns a path to the prebuilt framework for given flavor.
+ */
+function flavorToFrameworkPath(target: string, flavor: Flavor): string {
+  return path.join(PRODUCTS_DIR, `${flavor.configuration}-${flavor.sdk}`, `${target}.framework`);
+}
+
+/**
+ * Spreads given args under specific flag.
+ * Example: `spreadArgs('-arch', ['arm64', 'x86_64'])` returns `['-arch', 'arm64', '-arch', 'x86_64']`
+ */
+function spreadArgs(argName: string, args: string[]): string[] {
+  return ([] as string[]).concat(...args.map((arg) => [argName, arg]));
+}
+
+/**
+ * Converts boolean values to its Xcode build settings format. Value of other type just passes through.
+ */
+function parseXcodeSettingsValue(value: string | boolean): string {
+  if (typeof value === 'boolean') {
+    return value ? 'YES' : 'NO';
+  }
+  return value;
+}

--- a/tools/expotools/src/prebuilds/XcodeProject.ts
+++ b/tools/expotools/src/prebuilds/XcodeProject.ts
@@ -3,9 +3,10 @@ import path from 'path';
 import fs from 'fs-extra';
 
 import { spawnAsync } from '../Utils';
-import { generateXcodeProjectAsync, ProjectSpec } from './XcodeGen';
+import { generateXcodeProjectAsync } from './XcodeGen';
 import { Flavor, Framework, XcodebuildSettings } from './XcodeProject.types';
 import { formatXcodeBuildOutput } from '../Formatter';
+import { ProjectSpec } from './XcodeGen.types';
 
 /**
  * Path to the shared derived data directory.

--- a/tools/expotools/src/prebuilds/XcodeProject.types.ts
+++ b/tools/expotools/src/prebuilds/XcodeProject.types.ts
@@ -1,0 +1,46 @@
+/**
+ * Additional `xcodebuild` build settings that overrides project's and target's build settings.
+ * See https://xcodebuildsettings.com for full documentation.
+ */
+export type XcodebuildSettings = Record<string, string | boolean>;
+
+export type Flavor = {
+  /**
+   * Xcode configuration to use.
+   * Default build settings might be different depending on the configuration.
+   */
+  configuration: 'Release' | 'Debug';
+
+  /**
+   * The iOS SDK to use. The device and the simulator have different SDKs,
+   * so basically it means whether you want to build for the device or simulator.
+   */
+  sdk: 'iphoneos' | 'iphonesimulator';
+
+  /**
+   * An array of CPU architectures to build against.
+   */
+  archs: ('arm64' | 'x86_64' | 'i386')[];
+};
+
+export type Framework = {
+  /**
+   * Name of the target that the framework was built from.
+   */
+  target: string;
+
+  /**
+   * The flavor object based on which the framework was built.
+   */
+  flavor: Flavor;
+
+  /**
+   * Path to the artifact — `.framework` file.
+   */
+  frameworkPath: string;
+
+  /**
+   * Size of the artifact binary in bytes.
+   */
+  binarySize: number;
+};

--- a/tools/expotools/yarn.lock
+++ b/tools/expotools/yarn.lock
@@ -2448,6 +2448,11 @@
     workbox-webpack-plugin "^3.6.3"
     worker-loader "^2.0.0"
 
+"@expo/xcodegen@2.18.0-patch.1":
+  version "2.18.0-patch.1"
+  resolved "https://registry.yarnpkg.com/@expo/xcodegen/-/xcodegen-2.18.0-patch.1.tgz#40514e973ee6769e5abd5d1c16d40dbe85c1d9aa"
+  integrity sha512-Caz2ChzVe/U3GkaK+DKlXqYorARzLZ1yM6D03LHvasnyA4T+pW6DGXHPy7cfK5AlbsV6Fi5ZtZ9gqW4jGWIFwQ==
+
 "@expo/xdl@58.0.4-alpha.1609":
   version "58.0.4-alpha.1609"
   resolved "https://registry.yarnpkg.com/@expo/xdl/-/xdl-58.0.4-alpha.1609.tgz#60c463d3296abd07562a26e76e54b2cc15a233a7"


### PR DESCRIPTION
# Why

We want to make compilation faster by providing prebuilt binaries of our native iOS modules.
Followup #11169 #11183 

# How

Added `et prebuild-packages`/`et prebuild` expotools command that does a few things on given package:
- Takes the podspec with sources (`EXPO_USE_SOURCE=1`)
- Converts that podspec to [XcodeGen](https://github.com/yonaskolb/XcodeGen)'s project spec
- Uses XcodeGen to generate `.xcodeproj` file based on that project spec
- Builds the library to two frameworks — one for the device (arm64) and one for simulator (arm64 & x86_64) — both in release mode
- Puts these frameworks into the new `.xcframework` format which is a wrapper for the standard frameworks but built for different architectures
- Cleans up the temporary files such as `.xcodeproj`, project spec and generated Info.plist

In terms of the XcodeGen tool — there is no gem for it, so it seemed better to me to create a new package `@expo/xcodegen` that ships the newest version (2.18.0) of XcodeGen as a binary.

# Test Plan

I've run `et prebuild-packages` and confirmed that some packages now has `.xcframework` file in its iOS subdirectory. It contains, as expected, two flavored `.framework`s inside.
Then ran `EXPO_USE_SOURCE=0 pod install` in `ios` directory, confirmed those packages have only headers and `.xcframework` in project's file explorer and then successfully built Expo Go.

# Example

Standard succeeding use

<img width="902" alt="Screen Shot 2020-12-07 at 11 22 17" src="https://user-images.githubusercontent.com/1714764/101339532-daa1be80-387e-11eb-9438-2666d1cc9615.png">

Command failed due to missing `<Foundation/Foundation.h>` (`xcodebuild`'s output prettified and piped to the current process)

<img width="1112" alt="Screen Shot 2020-12-07 at 11 37 09" src="https://user-images.githubusercontent.com/1714764/101341019-c494fd80-3880-11eb-8778-bb591d0d60be.png">
