### PR TITLE
[et] Prebuild packages before publishing

### DIFF
--- a/tools/expotools/src/publish-packages/tasks/cleanPrebuildsTask.ts
+++ b/tools/expotools/src/publish-packages/tasks/cleanPrebuildsTask.ts
@@ -1,0 +1,24 @@
+import logger from '../../Logger';
+import { Task } from '../../TasksRunner';
+import { Parcel, TaskArgs } from '../types';
+
+import { canPrebuildPackage, cleanFrameworksAsync } from '../../prebuilds/Prebuilder';
+
+/**
+ * Cleans up after building prebuilds and publishing them.
+ */
+export const cleanPrebuildsTask = new Task<TaskArgs>(
+  {
+    name: 'cleanPrebuildsTask',
+  },
+  async (parcels: Parcel[]) => {
+    logger.log();
+
+    const packagesToClean = parcels.map(({ pkg }) => pkg).filter(canPrebuildPackage);
+
+    if (packagesToClean.length) {
+      logger.info('🧹 Cleaning prebuilt resources');
+      await cleanFrameworksAsync(packagesToClean);
+    }
+  }
+);

--- a/tools/expotools/src/publish-packages/tasks/prebuildPackagesTask.ts
+++ b/tools/expotools/src/publish-packages/tasks/prebuildPackagesTask.ts
@@ -1,0 +1,27 @@
+import chalk from 'chalk';
+
+import logger from '../../Logger';
+import { Task } from '../../TasksRunner';
+import { Parcel, TaskArgs } from '../types';
+
+import { canPrebuildPackage, prebuildPackageAsync } from '../../prebuilds/Prebuilder';
+
+/**
+ * Prebuilds iOS packages that are being distributed with prebuilt binaries.
+ */
+export const prebuildPackagesTask = new Task<TaskArgs>(
+  {
+    name: 'prebuildPackagesTask',
+    required: true,
+    backupable: false,
+  },
+  async (parcels: Parcel[]) => {
+    for (const { pkg } of parcels) {
+      if (!canPrebuildPackage(pkg)) {
+        continue;
+      }
+      logger.info('\n👷‍♀️ Prebuilding %s', chalk.green(pkg.packageName));
+      await prebuildPackageAsync(pkg, { quiet: true });
+    }
+  }
+);

--- a/tools/expotools/src/publish-packages/tasks/publishPackagesPipeline.ts
+++ b/tools/expotools/src/publish-packages/tasks/publishPackagesPipeline.ts
@@ -5,9 +5,11 @@ import { Task } from '../../TasksRunner';
 import { CommandOptions, Parcel, TaskArgs } from '../types';
 import { checkPackagesIntegrity } from './checkPackagesIntegrity';
 import { checkRepositoryStatus } from './checkRepositoryStatus';
+import { cleanPrebuildsTask } from './cleanPrebuildsTask';
 import { commitStagedChanges } from './commitStagedChanges';
 import { cutOffChangelogs } from './cutOffChangelogs';
 import { grantTeamAccessToPackages } from './grantTeamAccessToPackages';
+import { prebuildPackagesTask } from './prebuildPackagesTask';
 import { prepareParcels } from './prepareParcels';
 import { publishPackages } from './publishPackages';
 import { pushCommittedChanges } from './pushCommittedChanges';
@@ -39,7 +41,9 @@ export const publishPackagesPipeline = new Task<TaskArgs>(
       cutOffChangelogs,
       commitStagedChanges,
       pushCommittedChanges,
+      prebuildPackagesTask,
       publishPackages,
+      cleanPrebuildsTask,
       grantTeamAccessToPackages,
     ],
   },


### PR DESCRIPTION
# Why

Followup #11224 
`et publish-packages` should prebuild module before publishing and clear `.xcframework` artifacts after all.

# How

Added new tasks to publishing pipeline.

# Test Plan

Already published `@unimodules/core`, `@unimodules/react-native-adapter`, `expo-gl` and `expo-gl-cpp` (under `prebuild` tag) and confirmed these packages contain `.xcframework` file. 
