### PR TITLE
Add application name after init

### DIFF
--- a/docs/pages/guides/typescript.md
+++ b/docs/pages/guides/typescript.md
@@ -10,7 +10,7 @@ Expo has first-class support for [TypeScript](https://www.typescriptlang.org/). 
 
 ## Starting from scratch: using a TypeScript template
 
-<TerminalBlock cmd={['expo init -t expo-template-blank-typescript']} />
+<TerminalBlock cmd={['expo init appName -t expo-template-blank-typescript']} />
 
 The easiest way to get started is to initialize your new project using a TypeScript template. When you run `expo init` choose one of the templates with TypeScript in the name and then run `yarn tsc` or `npx tsc` to typecheck the project.
 


### PR DESCRIPTION
# Why

**Using just ```bash expo init  -t expo-template-blank-typescript``` will throw this error: ```The project dir argument is required in non-interactive mode.```

# How

I solved that by adding the app name: ```bash expo init [theAppName] -t expo-template-blank-typescript```

# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->
