### PR TITLE
[expo-notifications] Make bare InstallationId read from managed storage

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/notifications/ScopedInstallationId.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/notifications/ScopedInstallationId.java
@@ -18,8 +18,6 @@ import expo.modules.notifications.serverregistration.InstallationId;
  * or {@link host.exp.exponent.storage.ExponentSharedPreferences}
  */
 public class ScopedInstallationId extends InstallationId {
-  public static final String UUID_FILE_NAME = "expo_notifications_installation_id.txt";
-
   private Context mContext;
 
   public ScopedInstallationId(Context context) {
@@ -28,7 +26,9 @@ public class ScopedInstallationId extends InstallationId {
   }
 
   @Override
-  protected File getNonBackedUpUuidFile() {
-    return new File(mContext.getNoBackupFilesDir(), UUID_FILE_NAME);
+  protected File getFileToWriteIdTo() {
+    // By using a well-known location for ID in standalone managed apps
+    // we let ourselves fetch the same ID in bare apps too.
+    return new File(mContext.getNoBackupFilesDir(), SCOPED_UUID_FILE_NAME);
   }
 }

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Changed the visility of Android's `InstallationId#getNonBackedUpUuidFile` method so it's easier to override by custom implementations. ([#11249](https://github.com/expo/expo/pull/11249) by [@sjchmiela](https://github.com/sjchmiela))
+- Added support for reading installation identifiers used in managed apps in bare too (on Android). This way `expo-notification`'s installation identifier (and thanks to this, Expo push token) should not change when ejecting an SDK40 app to bare. ([#11253](https://github.com/expo/expo/pull/11253) by [@sjchmiela](https://github.com/sjchmiela))
 
 ## 0.8.2 — 2020-11-30
 


### PR DESCRIPTION
# Why

Since [we no longer think](https://github.com/expo/expo/pull/11249) we have to let `ScopedContext` take care of scoping installation identifier in managed apps and we know we do it ourselves, we can use it as an advantage and implement code that will make sure we don't change Expo push token when an SDK40+ app is being ejected to bare too!

# How

Instead of using a single file fetched from `getNonBackedUpUuidFile` as storage (read and write) for the installation ID, let's split this notion into to:
- a single file the class is supposed to **write** to
- one or more files that the class is supposed to **read** the ID from.

This way we:
- can use managed identifier if a project is ejected to bare (by checking if there's an ID under the managed location)
- maintain the ability to not interfere with shared managed identifier in managed `expo-notifications` (by overriding the "write to" location in managed).

## ⚠️ Note
This changes the order of reads/migrations from:
- migrated storage read
- optional migration from legacy storage

to:
- migrated storage number 1 read
- optional migration from legacy storage
- migrated storage number 2 read.

I could not think of any scenario which would cause erroneous behavior with such an implementation, but it diverts from the [original proposal](https://github.com/expo/expo/pull/10261#issuecomment-725396140), so noting that.

# Test Plan

I have confirmed that running an SDK40 app with these changes included, the ID gets migrated from scoped `SharedPreferences` to `expo_notifications_installation_id.txt`.