### PR TITLE
[dev-lancher] Fix schema replacement

### DIFF
--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/DevLauncherController.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/DevLauncherController.kt
@@ -3,6 +3,7 @@ package expo.modules.devlauncher
 import android.app.Application
 import android.content.Context
 import android.content.Intent
+import android.net.Uri
 import androidx.annotation.UiThread
 import com.facebook.react.ReactActivity
 import com.facebook.react.ReactActivityDelegate
@@ -51,9 +52,11 @@ class DevLauncherController private constructor(
   suspend fun loadApp(url: String, mainActivity: ReactActivity? = null) {
     ensureHostWasCleared(mAppHost, activityToBeInvalidated = mainActivity)
 
-    val parsedUrl = url
-      .trim()
-      .replace("exp", "http")
+    val parsedUrl = Uri.parse(url.trim())
+      .buildUpon()
+      .scheme("http")
+      .build()
+      .toString()
     val manifestParser = DevLauncherManifestParser(httpClient, parsedUrl)
     val appIntent = createAppIntent()
 

--- a/packages/expo-dev-launcher/ios/Manifest/EXDevLauncherManifestParser.m
+++ b/packages/expo-dev-launcher/ios/Manifest/EXDevLauncherManifestParser.m
@@ -8,7 +8,7 @@ typedef void (^CompletionHandler)(NSData *data, NSURLResponse *response);
 @interface EXDevLauncherManifestParser ()
 
 @property (weak, nonatomic) NSURLSession *session;
-@property (strong, nonatomic) NSString *url;
+@property (strong, nonatomic) NSURL *url;
 
 @end
 
@@ -50,7 +50,7 @@ typedef void (^CompletionHandler)(NSData *data, NSURLResponse *response);
 
 - (void)_fetch:(NSString *)method onError:(OnManifestError)onError completionHandler:(CompletionHandler)completionHandler
 {
-  NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:self.url]];
+  NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:self.url];
   [request setHTTPMethod:method];
   NSURLSessionDataTask *dataTask = [self.session dataTaskWithRequest:request completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
     if (error) {


### PR DESCRIPTION
# Why

Fixes schema replacement - we no longer can assume that URL from the bundler starts with `exp` schema. Now the user can specify his own schema.

# How 

I've parsed the URL string into a URL object and replaced the schema. 

# Test Plan

- bare-expo ✅
