### PR TITLE
[iOS][expotools] Inject code for auto per-project RCTAppearance pre-configuration during SDK versioning/drop

### DIFF
--- a/ios/Exponent/Kernel/Views/EXAppViewController.m
+++ b/ios/Exponent/Kernel/Views/EXAppViewController.m
@@ -32,12 +32,12 @@
 
 #import <React/RCTAppearance.h>
 
-#if __has_include(<ABI39_0_0React/ABI39_0_0RCTAppearance.h>)
-#import <ABI39_0_0React/ABI39_0_0RCTAppearance.h>
-#endif
-
 #if __has_include(<ABI40_0_0React/ABI40_0_0RCTAppearance.h>)
 #import <ABI40_0_0React/ABI40_0_0RCTAppearance.h>
+#endif
+
+#if __has_include(<ABI39_0_0React/ABI39_0_0RCTAppearance.h>)
+#import <ABI39_0_0React/ABI39_0_0RCTAppearance.h>
 #endif
 
 #define EX_INTERFACE_ORIENTATION_USE_MANIFEST 0
@@ -639,11 +639,11 @@ NS_ASSUME_NONNULL_BEGIN
     appearancePreference = nil;
   }
   RCTOverrideAppearancePreference(appearancePreference);
-#if __has_include(<ABI39_0_0React/ABI39_0_0RCTAppearance.h>)
-  ABI39_0_0RCTOverrideAppearancePreference(appearancePreference);
-#endif
 #if __has_include(<ABI40_0_0React/ABI40_0_0RCTAppearance.h>)
   ABI40_0_0RCTOverrideAppearancePreference(appearancePreference);
+#endif
+#if __has_include(<ABI39_0_0React/ABI39_0_0RCTAppearance.h>)
+  ABI39_0_0RCTOverrideAppearancePreference(appearancePreference);
 #endif
 }
 

--- a/ios/Exponent/Kernel/Views/EXAppViewController.m
+++ b/ios/Exponent/Kernel/Views/EXAppViewController.m
@@ -31,11 +31,9 @@
 #endif
 
 #import <React/RCTAppearance.h>
-
 #if __has_include(<ABI40_0_0React/ABI40_0_0RCTAppearance.h>)
 #import <ABI40_0_0React/ABI40_0_0RCTAppearance.h>
 #endif
-
 #if __has_include(<ABI39_0_0React/ABI39_0_0RCTAppearance.h>)
 #import <ABI39_0_0React/ABI39_0_0RCTAppearance.h>
 #endif

--- a/tools/expotools/src/versioning/ios/transforms/kernelFilesTransforms.ts
+++ b/tools/expotools/src/versioning/ios/transforms/kernelFilesTransforms.ts
@@ -1,0 +1,24 @@
+import { TransformPipeline } from '.';
+
+/**
+ * These modification will be run against `ios/Exponent/kernel` directory.
+ * If you need to modify other files from the `ios` directory then find
+ * a better place for it or refactor the function that depends on this list.
+ * @param versionName e.g. 21.0.0, 37.0.0, etc.
+ */
+export function kernelFilesTransforms(versionName: string): TransformPipeline {
+  return {
+    transforms: [
+      {
+        paths: ['EXAppViewController.m'],
+        replace: /(#import <React\/RCTAppearance\.h>)/,
+        with: `$1\n\n#if __has_include(<${versionName}React/${versionName}RCTAppearance.h>)\n#import <${versionName}React/${versionName}RCTAppearance.h>\n#endif`,
+      },
+      {
+        paths: ['EXAppViewController.m'],
+        replace: /(\sRCTOverrideAppearancePreference\(appearancePreference\);)/,
+        with: `$1\n#if __has_include(<${versionName}React/${versionName}RCTAppearance.h>)\n  ${versionName}RCTOverrideAppearancePreference(appearancePreference);\n#endif`,
+      },
+    ],
+  };
+}

--- a/tools/expotools/src/versioning/ios/transforms/kernelFilesTransforms.ts
+++ b/tools/expotools/src/versioning/ios/transforms/kernelFilesTransforms.ts
@@ -4,21 +4,51 @@ import { TransformPipeline } from '.';
  * These modification will be run against `ios/Exponent/kernel` directory.
  * If you need to modify other files from the `ios` directory then find
  * a better place for it or refactor the function that depends on this list.
+ * The nature of these changes is that they're not permanent and at one point
+ * of time (SDK drop) these should be rollbacked.
  * @param versionName e.g. 21.0.0, 37.0.0, etc.
+ * @param rollback This flag indicates whether the change should be rollbacked.
  */
-export function kernelFilesTransforms(versionName: string): TransformPipeline {
+export function kernelFilesTransforms(
+  versionName: string,
+  rollback: boolean = false
+): TransformPipeline {
   return {
     transforms: [
       {
         paths: ['EXAppViewController.m'],
-        replace: /(#import <React\/RCTAppearance\.h>)/,
-        with: `$1\n\n#if __has_include(<${versionName}React/${versionName}RCTAppearance.h>)\n#import <${versionName}React/${versionName}RCTAppearance.h>\n#endif`,
+        ...withRollback(rollback, {
+          replace: /(?<=#import <React\/RCTAppearance\.h>)/,
+          with: `\n\n#if __has_include(<${versionName}React/${versionName}RCTAppearance.h>)\n#import <${versionName}React/${versionName}RCTAppearance.h>\n#endif`,
+        }),
       },
       {
         paths: ['EXAppViewController.m'],
-        replace: /(\sRCTOverrideAppearancePreference\(appearancePreference\);)/,
-        with: `$1\n#if __has_include(<${versionName}React/${versionName}RCTAppearance.h>)\n  ${versionName}RCTOverrideAppearancePreference(appearancePreference);\n#endif`,
+        ...withRollback(rollback, {
+          replace: /(?<=\sRCTOverrideAppearancePreference\(appearancePreference\);)/,
+          with: `\n#if __has_include(<${versionName}React/${versionName}RCTAppearance.h>)\n  ${versionName}RCTOverrideAppearancePreference(appearancePreference);\n#endif`,
+        }),
       },
     ],
   };
+}
+
+type Replacement = {
+  replace: RegExp | string;
+  with: string;
+};
+
+/**
+ * If `rollback = true` then this function either return `rollbackReplacement`
+ * or if it's not provided it used `replace` from `replacement` argument.
+ * For the latter case, ensure you're not constructing `replacement.with` field with
+ * any capture group from `replacement.replace` part, because it will be inlined directly
+ * and additionally ensure if you don't want to escape some characters 🤔.
+ */
+function withRollback(
+  rollback: boolean,
+  replacement: Replacement,
+  rollbackReplacement?: Replacement
+): Replacement {
+  return rollback ? rollbackReplacement ?? { replace: replacement.with, with: '' } : replacement;
 }

--- a/tools/expotools/src/versioning/ios/transforms/kernelFilesTransforms.ts
+++ b/tools/expotools/src/versioning/ios/transforms/kernelFilesTransforms.ts
@@ -19,7 +19,7 @@ export function kernelFilesTransforms(
         paths: ['EXAppViewController.m'],
         ...withRollback(rollback, {
           replace: /(?<=#import <React\/RCTAppearance\.h>)/,
-          with: `\n\n#if __has_include(<${versionName}React/${versionName}RCTAppearance.h>)\n#import <${versionName}React/${versionName}RCTAppearance.h>\n#endif`,
+          with: `\n#if __has_include(<${versionName}React/${versionName}RCTAppearance.h>)\n#import <${versionName}React/${versionName}RCTAppearance.h>\n#endif`,
         }),
       },
       {


### PR DESCRIPTION
Followup of https://github.com/expo/expo/pull/11225

# How

I've created another category/phase of `changes` that are performed/applied during `versioning`/`SDK drop` - namely `kernel files modifications` (only files in `ios/Exponents/kernel` directory are being targeted).
These modifications are kind of special - I treat them as a database migration: there is a `setup` part as well as `rollback` part. 

# Test Plan

I've tested both `setup`/`apply` via `et add-sdk-version -p ios -s 21.0.0` and `rollback` via `et remove-sdk-version -p ios -s 37.0.0`. In both cases I've obtained proper files modifications.
