### PR TITLE
[docs] Adds video tutorial to app icon guide

### DIFF
--- a/docs/pages/guides/app-icons.md
+++ b/docs/pages/guides/app-icons.md
@@ -10,6 +10,16 @@ The most straightforward way to provide an icon for your app is to provide the [
 
 ## Icon Best Practices
 
+### Design
+
+Create an app icon and splash image with the [Figma template](https://www.figma.com/file/ddc0glVeILssZl0Dcn1lSS/App-Icon-and-Splash?node-id=0%3A1) and video below:
+
+<object width="425" height="350">
+  <param name="movie" value="https://youtu.be/mVOFvLSiJ_s" />
+  <param name="wmode" value="transparent" />
+  <embed src="https://youtu.be/mVOFvLSiJ_s" type="application/x-shockwave-flash" wmode="transparent" width="100%" height="400" />
+</object>
+
 ### iOS
 
 - The icon you use for iOS should follow the [Apple Human Interface Guidelines](https://developer.apple.com/ios/human-interface-guidelines/icons-and-images/app-icon/) for iOS Icons.

--- a/docs/pages/guides/app-icons.md
+++ b/docs/pages/guides/app-icons.md
@@ -14,7 +14,7 @@ The most straightforward way to provide an icon for your app is to provide the [
 
 Create an app icon and splash image with the [Figma template](https://www.figma.com/file/ddc0glVeILssZl0Dcn1lSS/App-Icon-and-Splash?node-id=0%3A1) and video below:
 
-<object width="425" height="350">
+<object width="100%" height="400">
   <param name="movie" value="https://youtu.be/mVOFvLSiJ_s" />
   <param name="wmode" value="transparent" />
   <embed src="https://youtu.be/mVOFvLSiJ_s" type="application/x-shockwave-flash" wmode="transparent" width="100%" height="400" />

--- a/docs/pages/guides/splash-screens.md
+++ b/docs/pages/guides/splash-screens.md
@@ -8,6 +8,16 @@ A splash screen, also known as a launch screen, is the first screen that a user 
 
 The default splash screen is a blank white screen. This might work for you, if it does, you're in luck! If not, you're also in luck because it's quite easy to customize using `app.json` and the `splash` key. Let's walk through it.
 
+### Video walkthrough
+
+Create an app icon and splash image with the [Figma template](https://www.figma.com/file/ddc0glVeILssZl0Dcn1lSS/App-Icon-and-Splash?node-id=0%3A1) and video below:
+
+<object width="425" height="350">
+  <param name="movie" value="https://youtu.be/mVOFvLSiJ_s" />
+  <param name="wmode" value="transparent" />
+  <embed src="https://youtu.be/mVOFvLSiJ_s" type="application/x-shockwave-flash" wmode="transparent" width="100%" height="400" />
+</object>
+
 ### Make a splash image
 
 The [iOS Human Interface Guidelines](https://developer.apple.com/ios/human-interface-guidelines/icons-and-images/launch-screen/) list the static launch image sizes. I'll go with `1242` pixels wide and `2436` pixels tall -- this is the width of the iPhone 8 Plus (the widest iPhone) and the height of the iPhone X (the tallest iPhone). Expo will resize the image for you depending on the size of the device, and we can specify the strategy used to resize the image with `splash.resizeMode`.

--- a/docs/pages/guides/splash-screens.md
+++ b/docs/pages/guides/splash-screens.md
@@ -12,11 +12,11 @@ The default splash screen is a blank white screen. This might work for you, if i
 
 Create an app icon and splash image with the [Figma template](https://www.figma.com/file/ddc0glVeILssZl0Dcn1lSS/App-Icon-and-Splash?node-id=0%3A1) and video below:
 
-<object width="425" height="350">
-  <param name="movie" value="https://youtu.be/mVOFvLSiJ_s" />
-  <param name="wmode" value="transparent" />
-  <embed src="https://youtu.be/mVOFvLSiJ_s" type="application/x-shockwave-flash" wmode="transparent" width="100%" height="400" />
-</object>
+<object width="100%" height="400">
+   <param name="movie" value="https://youtu.be/mVOFvLSiJ_s" />
+   <param name="wmode" value="transparent" />
+   <embed src="https://youtu.be/mVOFvLSiJ_s" type="application/x-shockwave-flash" wmode="transparent" width="100%" height="400" />
+ </object>
 
 ### Make a splash image
 


### PR DESCRIPTION
# Why

I made a video describing how to make an app icon and splash screen.

# How

- This video sits inline and is viewable from the docs.
- I chose arbitrary sizes for now (height/width). As we add more videos to the docs, we should make a video component to standardize implementation.

<img width="1574" alt="Screen Shot 2020-12-07 at 5 31 44 PM" src="https://user-images.githubusercontent.com/6455018/101413794-e4451980-38b2-11eb-9d71-d7b4f5e5b3a0.png">

