### PR TITLE
[expo-dev-manu] Add auto-linking support

### DIFF
--- a/packages/expo-dev-menu-interface/react-native.config.js
+++ b/packages/expo-dev-menu-interface/react-native.config.js
@@ -4,7 +4,7 @@ module.exports = {
       ios: {
         /**
          * We need this property to trick `react-native-cli`. Normally, this tool looks for the XCode project.
-         * However, this package is a library so we don't have a project file.
+         * We can generate it using `XcodeGen` but we don't want to add the project file to this library.
          */
         project: 'ios/EXDevMenuInterface.xcodeproj/project.pbxproj',
       },

--- a/packages/expo-dev-menu/react-native.config.js
+++ b/packages/expo-dev-menu/react-native.config.js
@@ -1,0 +1,13 @@
+module.exports = {
+  dependency: {
+    platforms: {
+      ios: {
+        /**
+         * We need this property to trick `react-native-cli`. Normally, this tool looks for the XCode project.
+         * However, this package is a library so we don't have a project file.
+         */
+        project: 'ios/EXDevMenu.xcodeproj/project.pbxproj',
+      },
+    },
+  },
+};

--- a/packages/expo-dev-menu/react-native.config.js
+++ b/packages/expo-dev-menu/react-native.config.js
@@ -4,7 +4,7 @@ module.exports = {
       ios: {
         /**
          * We need this property to trick `react-native-cli`. Normally, this tool looks for the XCode project.
-         * However, this package is a library so we don't have a project file.
+         * We can generate it using `XcodeGen` but we don't want to add the project file to this library.
          */
         project: 'ios/EXDevMenu.xcodeproj/project.pbxproj',
       },


### PR DESCRIPTION
# Why

We want to make sure that the installation process for `dev-menu` is as trivial as possible. So I've added the auto-linking support into expo-dev-menu-interface.

# Test Plan

- bare-expo
  - iOS ✅
  - Android ✅