### PR TITLE
[expo-dev-launcher][ios] Apply user interface style

### DIFF
--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -268,7 +268,7 @@ NSString *fakeLauncherBundleUrl = @"embedded://EXDevLauncher/dummy";
 }
 
 /**
- * We need that function to sync the dev-menu interface  with the main application.
+ * We need that function to sync the dev-menu user interface with the main application.
  */
 - (void)_ensureUserInterfaceStyleIsInSyncWithViewController:(UIViewController *)controller
 {
@@ -298,4 +298,3 @@ NSString *fakeLauncherBundleUrl = @"embedded://EXDevLauncher/dummy";
 }
 
 @end
-

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -6,6 +6,8 @@
 #import <React/RCTAsyncLocalStorage.h>
 #import <React/RCTDevSettings.h>
 #import <React/RCTRootContentView.h>
+#import <React/RCTAppearance.h>
+#import <React/RCTConstants.h>
 
 #import "EXDevLauncherBundle.h"
 #import "EXDevLauncherBundleSource.h"
@@ -107,12 +109,17 @@ NSString *fakeLauncherBundleUrl = @"embedded://EXDevLauncher/dummy";
 - (void)navigateToLauncher {
   [_appBridge invalidate];
 
+
+  [self _applyUserInterfaceStyle:UIUserInterfaceStyleUnspecified];
+  
   _launcherBridge = [[EXDevLauncherRCTBridge alloc] initWithDelegate:self launchOptions:_launchOptions];
 
   RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:_launcherBridge
                                                    moduleName:@"main"
                                             initialProperties:nil];
 
+  [self _ensureUserInterfaceStyleIsInSyncWithViewController:rootView];
+  
   [[NSNotificationCenter defaultCenter] addObserver:self
                                            selector:@selector(onAppContentDidAppear)
                                                name:RCTContentDidAppearNotification
@@ -209,7 +216,22 @@ NSString *fakeLauncherBundleUrl = @"embedded://EXDevLauncher/dummy";
   
   dispatch_async(dispatch_get_main_queue(), ^{
     self.sourceUrl = bundleUrl;
+    
+    [self _applyUserInterfaceStyle:manifest.userInterfaceStyle];
+    if (@available(iOS 12, *)) {
+      // Fix for the community react-native-appearance.
+      // RNC appearance checks the global trait collection and doesn't have another way to override the user interface.
+      // So we swap `currentTraitCollection` with one from the root view controller.
+      // Note that the root view controller will have the correct value of `userInterfaceStyle`.
+      if (manifest.userInterfaceStyle != UIUserInterfaceStyleUnspecified) {
+        UITraitCollection.currentTraitCollection = [_window.rootViewController.traitCollection copy];
+      }
+    }
+    
     [self.delegate devLauncherController:self didStartWithSuccess:YES];
+    
+    [self _ensureUserInterfaceStyleIsInSyncWithViewController:_window.rootViewController];
+
     [[UIDevice currentDevice] setValue:@(orientation) forKey:@"orientation"];
     [UIViewController attemptRotationToDeviceOrientation];
     
@@ -243,6 +265,36 @@ NSString *fakeLauncherBundleUrl = @"embedded://EXDevLauncher/dummy";
       }
     }
   });
+}
+
+/**
+ * We need that function to sync the dev-menu interface  with the main application.
+ */
+- (void)_ensureUserInterfaceStyleIsInSyncWithViewController:(UIViewController *)controller
+{
+  [[NSNotificationCenter defaultCenter] postNotificationName:RCTUserInterfaceStyleDidChangeNotification
+                                                      object:controller
+                                                    userInfo:@{
+                                                      RCTUserInterfaceStyleDidChangeNotificationTraitCollectionKey : controller.traitCollection
+                                                    }];
+}
+
+- (void)_applyUserInterfaceStyle:(UIUserInterfaceStyle)userInterfaceStyle
+{
+  NSString *colorSchema = nil;
+  if (@available(iOS 12, *)) {
+    if (userInterfaceStyle == UIUserInterfaceStyleDark) {
+      colorSchema = @"dark";
+    } else if (userInterfaceStyle == UIUserInterfaceStyleLight) {
+      colorSchema = @"light";
+    }
+    
+    // change system window appearance
+    _window.overrideUserInterfaceStyle = userInterfaceStyle;
+  }
+  
+  // change RN appearance
+  RCTOverrideAppearancePreference(colorSchema);
 }
 
 @end

--- a/packages/expo-dev-launcher/ios/Manifest/EXDevLauncherManifest.swift
+++ b/packages/expo-dev-launcher/ios/Manifest/EXDevLauncherManifest.swift
@@ -8,6 +8,12 @@ enum EXDevLauncherOrientation: String, Decodable {
   case landscape = "landscape"
 }
 
+enum EXDevLauncherUserInterfaceStyle: String, Decodable {
+  case automatic = "automatic"
+  case light = "light"
+  case dark = "dark"
+}
+
 @propertyWrapper
 public class CanHavePlatformSpecificValue<T> : Decodable where T : Decodable {
   public var wrappedValue: T
@@ -42,7 +48,16 @@ public class EXDevLauncherManifest: NSObject, Decodable {
   public var bundleUrl: String
   
   @CanHavePlatformSpecificValue
-  public var _backgroundColor: String?
+  var _userInterfaceStyle: EXDevLauncherUserInterfaceStyle?
+  
+  @objc
+  @available(iOS 12.0, *)
+  public var userInterfaceStyle: UIUserInterfaceStyle {
+    return EXDevLauncherManifestHelper.exportManifestUserInterfaceStyle(_userInterfaceStyle);
+  }
+  
+  @CanHavePlatformSpecificValue
+  var _backgroundColor: String?
   
   @objc
   public var backgroundColor: UIColor? {
@@ -63,6 +78,7 @@ public class EXDevLauncherManifest: NSObject, Decodable {
     case name, slug, version, ios, bundleUrl
     case _backgroundColor = "backgroundColor"
     case _orientation = "orientation"
+    case _userInterfaceStyle = "userInterfaceStyle"
   }
 
   @objc

--- a/packages/expo-dev-launcher/ios/Manifest/EXDevLauncherManifestHelper.swift
+++ b/packages/expo-dev-launcher/ios/Manifest/EXDevLauncherManifestHelper.swift
@@ -48,4 +48,16 @@ class EXDevLauncherManifestHelper {
                    blue: CGFloat(rgbValue & 0x0000FF) / 255.0,
                    alpha: 1.0)
   }
+  
+  @available(iOS 12.0, *)
+  static func exportManifestUserInterfaceStyle(_ userInterfaceStyle: EXDevLauncherUserInterfaceStyle?) -> UIUserInterfaceStyle {
+    switch (userInterfaceStyle){
+      case .light:
+        return .light
+      case .dark:
+        return .dark
+      default:
+        return .unspecified
+    }
+  }
 }


### PR DESCRIPTION
# Why

Applies the user interface style from the `app.json` when the app is loaded on iOS.

# How

- Added the `userInterfaceStyle` property into manifest. 
- Called `RCTOverrideAppearancePreference` to override the RN appearance.
- Synced the style of all views (need to make sure that `expo-dev-menu` has the same user interface as the current root view).
- Added fix for the `react-native-appearance` package from the community.

# Test Plan

- bare-expo with different combinations of system color scheme and app.json values ✅
