### PR TITLE
[docs] Fallback to latest instead of first verison

### DIFF
--- a/docs/components/DocumentationPage.tsx
+++ b/docs/components/DocumentationPage.tsx
@@ -175,13 +175,9 @@ export default class DocumentationPage extends React.Component<Props, State> {
 
   private getVersion = () => {
     let version = (this.props.asPath || this.props.url.pathname).split(`/`)[2];
-    if (!version || VERSIONS.indexOf(version) === -1) {
-      version = VERSIONS[0];
-    }
-    if (!version) {
+    if (!version || !VERSIONS.includes(version)) {
       version = 'latest';
     }
-
     return version;
   };
 


### PR DESCRIPTION
# Why

fixes #11231

If no version is used, e.g. on non-versioned pages like `guides`, fallback to `latest` instead of the first version. This is not correct because we include the `BETA_VERSION` as first version in this list.

# How

- Updated `DocumentationPage` method that resolves the version based on paths

# Test Plan

- Go to non-versioned page
- Search for some API docs, e.g. `ScreenOrientation`
- Hover over the links
- Validate they don't link to `v40.0.0` versions, they should be `v39.0.0`
