### PR TITLE
[docs][expo-auth-session] Make expo-random a peer dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ Package-specific changes not released in any SDK will be added here just before 
   -   Upgraded native Amplitude iOS library from `4.7.1` to `6.0.0`. This removes the IDFA code that was previously included with the Amplitude library. `disableIDFA` option for `Amplitude.setTrackingOptions` is removed. If you would like to collect the IDFA, you must be in the bare workflow. ([#9880](https://github.com/expo/expo/pull/9880) by [@bbarthec](https://github.com/bbarthec))
   -   Renamed all methods to include the 'Async' suffix:
   -   All methods now return a Promise. ([#9212](https://github.com/expo/expo/pull/9212/) by [@cruzach](https://github.com/cruzach))
+- **`expo-auth-session`**
+  -  `expo-random` is now a peer dependency rather than a dependency. ([#11280](https://github.com/expo/expo/pull/11280) by [@brentvatne](https://github.com/brentvatne))
 - **`expo-blur`**
   -   Explicitly pass down only the expected props on iOS. ([#10648](https://github.com/expo/expo/pull/10648) by [@cruzach](https://github.com/cruzach))
 - **`expo-branch`**

--- a/docs/pages/versions/unversioned/sdk/auth-session.md
+++ b/docs/pages/versions/unversioned/sdk/auth-session.md
@@ -17,7 +17,9 @@ import { InlineCode } from '~/components/base/code';
 
 ## Installation
 
-<InstallSection packageName="expo-auth-session" />
+> `expo-random` is a peer dependency and must be installed alongside `expo-auth-session`.
+
+<InstallSection packageName="expo-auth-session expo-random" />
 
 In **bare-workflow** you can use the [`uri-scheme` package][n-uri-scheme] to easily add, remove, list, and open your URIs.
 

--- a/docs/pages/versions/v40.0.0/sdk/auth-session.md
+++ b/docs/pages/versions/v40.0.0/sdk/auth-session.md
@@ -17,7 +17,10 @@ import { InlineCode } from '~/components/base/code';
 
 ## Installation
 
-<InstallSection packageName="expo-auth-session" />
+> `expo-random` is a peer dependency and must be installed alongside `expo-auth-session`.
+
+<InstallSection packageName="expo-auth-session expo-random" />
+
 
 In **bare-workflow** you can use the [`uri-scheme` package][n-uri-scheme] to easily add, remove, list, and open your URIs.
 

--- a/packages/expo-auth-session/CHANGELOG.md
+++ b/packages/expo-auth-session/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- Make expo-random a peer dependency. ([#11280](https://github.com/expo/expo/pull/11280) by [@brentvatne](https://github.com/brentvatne))
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/packages/expo-auth-session/README.md
+++ b/packages/expo-auth-session/README.md
@@ -18,7 +18,7 @@ For bare React Native projects, you must ensure that you have [installed and con
 ### Add the package to your npm dependencies
 
 ```
-expo install expo-auth-session
+expo install expo-auth-session expo-random
 ```
 
 ### Configuration

--- a/packages/expo-auth-session/package.json
+++ b/packages/expo-auth-session/package.json
@@ -41,10 +41,12 @@
     "expo-constants": "^9.3.3",
     "expo-crypto": "^8.4.0",
     "expo-linking": "~2.0.0",
-    "expo-random": "^10.0.0",
     "expo-web-browser": "^8.6.0",
     "invariant": "^2.2.4",
     "qs": "6.9.1"
+  },
+  "peerDependencies": {
+    "expo-random": "^10.0.0"
   },
   "devDependencies": {
     "@types/qs": "^6.5.3",


### PR DESCRIPTION
# Why

`expo-random` uses synchronous methods, which aren't available via the unimodules API, and so we had to convert it to a regular React Native plugin. Consequently, we have to rely on the react-native-community CLI autolinking code, which does not autolink transitive dependencies, and so `expo-random` must exist as a direct dependency. This doesn't matter in the managed workflow, but without this change, a developer will encounter problems when ejecting their app with `expo-auth-session` installed if they don't also have `expo-random`.

# How

- Switch `expo-random` from a dependency to a peer dependency, update docs and README.
- Add a note about this being a breaking change to SDK 40 release notes
- Update `expo upgrade` to automatically add `expo-random` to an app if upgrading to SDK >= 40 with `expo-auth-session` installed but no `expo-random`.  

# Test Plan

Tested the changes listed in the "How" by upgrading a project and ejecting and it works as expected.
