### PR TITLE
[expo-dev-menu][ios] Fix does device support key commands detection

### DIFF
--- a/packages/expo-dev-menu/ios/Modules/DevMenuInternalModule.swift
+++ b/packages/expo-dev-menu/ios/Modules/DevMenuInternalModule.swift
@@ -23,10 +23,10 @@ public class DevMenuInternalModule: NSObject, RCTBridgeModule {
 
   @objc
   func constantsToExport() -> [String : Any] {
-#if TARGET_IPHONE_SIMULATOR
-    let doesDeviceSupportKeyCommands = false
-#else
+#if targetEnvironment(simulator)
     let doesDeviceSupportKeyCommands = true
+#else
+    let doesDeviceSupportKeyCommands = false
 #endif
     return ["doesDeviceSupportKeyCommands": doesDeviceSupportKeyCommands]
   }


### PR DESCRIPTION
# Why

Fixes detection if the device supports key commands.
Part of https://www.notion.so/expo/Dev-Client-onboarding-UX-37bb2f69d0744b3d955cf0637e162936.

# How

`TARGET_IPHONE_SIMULATOR`  doesn't work in swift. 
Moreover, the value was inverted 🤦‍♂️

# Test Plan

- bare-expo ✅
