### PR TITLE
[expo-notifications] Return after successful migration

### DIFF
--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug fixes
 
+- Fixed migration process to **not** use `expo-constants` installation ID if there is a notifications-specific identifier. ([#11287](https://github.com/expo/expo/pull/11287) by [@sjchmiela](https://github.com/sjchmiela))
 - Changed the visibility of Android's `InstallationId#getNonBackedUpUuidFile` method so it's easier to override by custom implementations. ([#11249](https://github.com/expo/expo/pull/11249) by [@sjchmiela](https://github.com/sjchmiela))
 
 ## 0.8.2 — 2020-11-30

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/serverregistration/InstallationId.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/serverregistration/InstallationId.java
@@ -66,6 +66,8 @@ public class InstallationId {
       } catch (IOException e) {
         Log.e(TAG, "Error while migrating UUID from legacy storage. " + e);
       }
+
+      return mUuid;
     }
 
     // 3. Migrate from legacy file


### PR DESCRIPTION
# Why

Without this `expo-notifications` won't use notifications-specific identifier and will fallback to shared managed identifier.

# How

Return migrated identifier if there is any.

I even did commit this, but then forgot to push. 😢 

<img width="400" alt="Zrzut ekranu 2020-12-9 o 14 48 04" src="https://user-images.githubusercontent.com/1151041/101637834-8e48b100-3a2d-11eb-81ba-de4c982aaafb.png">


# Test Plan

I noticed this while testing other PRs and even fixed in #11249, but then forgot to push the change.