### PR TITLE
[docs] Auto-fix link headers in docs

### DIFF
--- a/docs/pages/guides/adhoc-builds.md
+++ b/docs/pages/guides/adhoc-builds.md
@@ -24,7 +24,7 @@ Push Notifications are currently unavailable with ad hoc clients until we comple
 
 #### Google Maps
 
-You will need to run `expo client:ios` in a project directory with a valid `app.json`, or pass in the flag to your custom configuration file with `--config <path-to-file.json>`. Make sure you set your Google API key in `ios.config.googleMapsApiKey` as described [here](../versions/latest/sdk/map-view.md#deploying-google-maps-to-a-standalone-app).
+You will need to run `expo client:ios` in a project directory with a valid `app.json`, or pass in the flag to your custom configuration file with `--config <path-to-file.json>`. Make sure you set your Google API key in `ios.config.googleMapsApiKey` as described [here](../versions/latest/sdk/map-view.md#deploying-google-maps-to-a-standalone-app-on-ios).
 
 #### Facebook
 

--- a/docs/pages/guides/configuring-ota-updates.md
+++ b/docs/pages/guides/configuring-ota-updates.md
@@ -4,7 +4,7 @@ title: Configuring OTA Updates
 
 Expo provides various settings to configure how your app receives over-the-air (OTA) JavaScript updates. OTA updates allow you to publish a new version of your app JavaScript and assets without building a new version of your standalone app and re-submitting to app stores ([read more about the limitations](../workflow/publishing.md)).
 
-To perform an over-the-air update of your app, you simply run `expo publish`. If you're using release channels, specify one with `--release-channel <channel-name>` option. **Please note**- if you wish to update the SDK version of your app, or make [any of the these changes](../workflow/publishing.md#some-native-configuration-cant-be-updated-by), you'll need to rebuild your app with `expo build:*` command and upload the binary file to the appropriate app store ([see the docs here](../distribution/building-standalone-apps.md)).
+To perform an over-the-air update of your app, you simply run `expo publish`. If you're using release channels, specify one with `--release-channel <channel-name>` option. **Please note**- if you wish to update the SDK version of your app, or make [any of the these changes](../workflow/publishing.md#some-native-configuration-cant-be-updated-by-publishing), you'll need to rebuild your app with `expo build:*` command and upload the binary file to the appropriate app store ([see the docs here](../distribution/building-standalone-apps.md)).
 
 OTA updates are controlled by the [`updates` settings in app.json](../workflow/configuration.md#updates), which handle the initial app load, and the [Updates SDK module](../versions/latest/sdk/updates.md), which allows you to fetch updates asynchronously from your JS.
 
@@ -14,7 +14,7 @@ By default, Expo will check for updates automatically when your app is launched 
 
 With this automatic configuration, calling [`Updates.reloadAsync()`](../versions/latest/sdk/updates.md#updatesreloadasync) will also result in Expo attempting to fetch the most up-to-date version of your app, so there is no need to use any of the other methods in the Updates module.
 
-The timeout length is configurable by setting `updates.fallbackToCacheTimeout` (ms) in app.json. For example, a common pattern is to set `updates.fallbackToCacheTimeout` to `0`. This will allow your app to start immediately with a cached bundle while downloading a newer one in the background for future use. [`Updates.addListener`](../versions/latest/sdk/updates.md#expoupdatesaddlistenereventlistener) provides a hook to let you respond when the new bundle is finished downloading.
+The timeout length is configurable by setting `updates.fallbackToCacheTimeout` (ms) in app.json. For example, a common pattern is to set `updates.fallbackToCacheTimeout` to `0`. This will allow your app to start immediately with a cached bundle while downloading a newer one in the background for future use. [`Updates.addListener`](../versions/latest/sdk/updates.md#updatesaddlistenereventlistener) provides a hook to let you respond when the new bundle is finished downloading.
 
 ## Manual Updates
 

--- a/docs/pages/guides/icons.md
+++ b/docs/pages/guides/icons.md
@@ -31,7 +31,7 @@ First, make sure you import your custom icon font. [Read more about loading cust
 
 ### createIconSet
 
-Returns your own custom font based on the `glyphMap` where the key is the icon name and the value is either a UTF-8 character or it's character code. `fontFamily` is the name of the font **NOT** the filename. The `expoAssetId` can be anything that you can pass in to [Font.loadAsync](../versions/latest/sdk/font.md#fontloadasyncobject). See [react-native-vector-icons](https://github.com/oblador/react-native-vector-icons/blob/master/README.md#custom-fonts) for more details.
+Returns your own custom font based on the `glyphMap` where the key is the icon name and the value is either a UTF-8 character or it's character code. `fontFamily` is the name of the font **NOT** the filename. The `expoAssetId` can be anything that you can pass in to [Font.loadAsync](../versions/latest/sdk/font.md#loadasyncobject). See [react-native-vector-icons](https://github.com/oblador/react-native-vector-icons/blob/master/README.md#custom-fonts) for more details.
 
 ```javascript
 import * as React from 'react';

--- a/docs/pages/guides/preloading-and-caching-assets.md
+++ b/docs/pages/guides/preloading-and-caching-assets.md
@@ -24,7 +24,7 @@ Images with paths matching the given patterns will be bundled into your native b
 
 Assets are cached differently depending on where they're stored and how they're used. This guide offers best practices for making sure you only download assets when you need to. In order to keep the loading screen visible while caching assets, it's also a good idea to render [AppLoading](../versions/latest/sdk/app-loading.md#app-loading) and only that component until everything is ready.
 
-For images that saved to the local filesytem, use [`Asset.fromModule(image).downloadAsync()`](../versions/latest/sdk/asset.md) to download and cache the image. There is also a [loadAsync()](../versions/latest/sdk/asset.md#expoassetloadasyncmodules) helper method to cache a batch of assets.
+For images that saved to the local filesytem, use [`Asset.fromModule(image).downloadAsync()`](../versions/latest/sdk/asset.md) to download and cache the image. There is also a [loadAsync()](../versions/latest/sdk/asset.md#assetloadasyncmodules) helper method to cache a batch of assets.
 
 For web images, use `Image.prefetch(image)`. Continue referencing the image normally, e.g. with `<Image source={require('path/to/image.png')} />`.
 

--- a/docs/pages/guides/splash-screens.md
+++ b/docs/pages/guides/splash-screens.md
@@ -30,7 +30,7 @@ Open your `app.json` and add the following inside of the `"expo"` field:
 }
 ```
 
-Now re-open the Expo client and open your app, and you should see your beautiful splash screen. There may be a delay before it shows up, see ["Differences between environments" below](#differences-between-environments) for more information on that.
+Now re-open the Expo client and open your app, and you should see your beautiful splash screen. There may be a delay before it shows up, see ["Differences between environments" below](#differences-between-environments---ios) for more information on that.
 
 > **Note**: It's required to close and re-open the Expo client app on iOS in order to see changes to the splash screen in the manifest. This is a known issue that we are working to resolve. On Android, you need to press the refresh button from the notification drawer.
 

--- a/docs/pages/guides/using-electron.md
+++ b/docs/pages/guides/using-electron.md
@@ -9,11 +9,11 @@ title: Using Electron with Expo for Web
 To simplify this we created the package `@expo/electron-adapter` which wraps [`electron-webpack`][electron-webpack] and adds support for Expo web and other universal React packages.
 
 - [🏁 Setup](#-setup)
-- [⚽️ Usage](#-usage)
+- [⚽️ Usage](#️-usage)
   - [Starting a project](#starting-a-project)
   - [Customizing the main process](#customizing-the-main-process)
   - [Building your project](#building-your-project)
-- [🧸 Behavior](#-behavior)
+- [🧸 Behavior](#🧸-behavior)
 - [Contributing](#contributing)
 - [Learn More](#learn-more-about-electron)
 

--- a/docs/pages/introduction/faq.md
+++ b/docs/pages/introduction/faq.md
@@ -55,7 +55,7 @@ However, if you need something custom that isn't possible with the native module
 
 The fastest way to share your managed Expo project is to publish it. You can do this by clicking 'Publish' in Expo Dev Tools or running `expo publish` in your project. This gives your app a URL; you can share this URL with anybody who has the Expo client for Android and they can open your app immediately. [Read more about publishing on Expo](https://blog.expo.io/publishing-on-exponent-790493660d24). To share with iOS users, you can use Apple TestFlight or sign up for the [Priority Plan](https://expo.io/developer-services) in order to share your app with teammates through the Expo client.
 
-When you're ready, you can create a standalone app (`.ipa` and `.apk`) for submission to Apple and Google's app stores. Expo will build the binary for you when you run one command; see [Building Standalone Apps](../distribution/building-standalone-apps.md#building-standalone-apps). Apple charges $99/year to publish your app in the App Store and Google charges a $25 one-time fee for the Play Store.
+When you're ready, you can create a standalone app (`.ipa` and `.apk`) for submission to Apple and Google's app stores. Expo will build the binary for you when you run one command; see [Building Standalone Apps](../distribution/building-standalone-apps.md#3-start-the-build). Apple charges $99/year to publish your app in the App Store and Google charges a $25 one-time fee for the Play Store.
 
 </p>
 </details>

--- a/docs/pages/versions/unversioned/react-native/checkbox.md
+++ b/docs/pages/versions/unversioned/react-native/checkbox.md
@@ -58,7 +58,7 @@ export default App;
 
 ## Props
 
-Inherits [View Props](view#props).
+Inherits [View Props](view.md#props).
 
 ---
 

--- a/docs/pages/versions/unversioned/sdk/auth-session.md
+++ b/docs/pages/versions/unversioned/sdk/auth-session.md
@@ -547,7 +547,7 @@ A hook used for opinionated Google authentication that works across platforms.
 
 #### Returns
 
-- **request (_GoogleAuthRequest | null_)** -- An instance of [`GoogleAuthRequest`](#googleauthrequest) that can be used to prompt the user for authorization. This will be `null` until the auth request has finished loading.
+- **request (_GoogleAuthRequest | null_)** -- An instance of [`GoogleAuthRequest`](#useauthrequest) that can be used to prompt the user for authorization. This will be `null` until the auth request has finished loading.
 - **response (_AuthSessionResult | null_)** -- This is `null` until `promptAsync` has been invoked. Once fulfilled it will return information about the authorization.
 - **promptAsync (_function_)** -- When invoked, a web browser will open up and prompt the user for authentication. Accepts an [`AuthRequestPromptOptions`](#authrequestpromptoptions) object with options about how the prompt will execute. This **should not** be used to enable the Expo proxy service `auth.expo.io`, as the proxy will be automatically enabled based on the platform.
 

--- a/docs/pages/versions/unversioned/sdk/auth-session.md
+++ b/docs/pages/versions/unversioned/sdk/auth-session.md
@@ -114,7 +114,7 @@ const [request, response, promptAsync] = useAuthRequest({ ... }, { ... });
 Load an authorization request for a code. Returns a loaded request, a response, and a prompt method.
 When the prompt method completes then the response will be fulfilled.
 
-> 🚨 In order to close the popup window on web, you need to invoke `WebBrowser.maybeCompleteAuthSession()`. See the [Identity example](../../../guides/authentication.md#identity-4) for more info.
+> 🚨 In order to close the popup window on web, you need to invoke `WebBrowser.maybeCompleteAuthSession()`. See the [Identity example](../../../guides/authentication.md#identityserver-4) for more info.
 
 If an Implicit grant flow was used, you can pass the `response.params` to `TokenResponse.fromQueryParams()` to get a `TokenResponse` instance which you can use to easily refresh the token.
 

--- a/docs/pages/versions/unversioned/sdk/auth-session.md
+++ b/docs/pages/versions/unversioned/sdk/auth-session.md
@@ -504,7 +504,7 @@ Access token type [Section 7.1](https://tools.ietf.org/html/rfc6749#section-7.1)
 
 ### `GoogleAuthRequestConfig`
 
-An extension of the [`AuthRequestConfig`][#authrequestconfig] for use with the built-in Google provider.
+An extension of the [`AuthRequestConfig`](#authrequestconfig) for use with the built-in Google provider.
 
 | Name                   | Type       | Description                                                                           |
 | ---------------------- | ---------- | ------------------------------------------------------------------------------------- |

--- a/docs/pages/versions/unversioned/sdk/bar-code-scanner.md
+++ b/docs/pages/versions/unversioned/sdk/bar-code-scanner.md
@@ -168,7 +168,7 @@ Object of type `BarCodeScannerResult` contains following keys:
 
 - **type (_BarCodeScanner.Constants.BarCodeType_)** -- The barcode type.
 - **data (_string_)** -- The information encoded in the bar code.
-- **bounds : [BarCodeScanner.BarCodeBounds](#barcodescannerbarcodebounds)** -- (_Optional_) The `BarCodeBounds` object.
+- **bounds : [BarCodeScanner.BarCodeBounds](#barcodescannerbarcodepoint)** -- (_Optional_) The `BarCodeBounds` object.
 - **cornerPoints : Array<[BarCodeScanner.BarCodePoint](#barcodescannerbarcodepoint)\>** -- (_Optional_) Corner points of the bounding box.
 
 > **NOTE** `bounds` and `cornerPoints` are not always available. On iOS, for `code39` and `pdf417` you don't get those values. Moreover, on iOS, those values don't have to bounds the whole barcode. For some types, they will represent the area used by the scanner.

--- a/docs/pages/versions/unversioned/sdk/bar-code-scanner.md
+++ b/docs/pages/versions/unversioned/sdk/bar-code-scanner.md
@@ -155,7 +155,7 @@ Object of type `BarCodeSize` contains following keys:
 - **height (_number_)** -- The height value.
 - **width (_number_)** -- The width value.
 
-### `BarCodeBounds`
+### `BarCodeScanner.BarCodeBounds`
 
 Object of type `BarCodeBounds` contains following keys:
 
@@ -168,7 +168,7 @@ Object of type `BarCodeScannerResult` contains following keys:
 
 - **type (_BarCodeScanner.Constants.BarCodeType_)** -- The barcode type.
 - **data (_string_)** -- The information encoded in the bar code.
-- **bounds : [BarCodeScanner.BarCodeBounds](#barcodescannerbarcodepoint)** -- (_Optional_) The `BarCodeBounds` object.
+- **bounds : [BarCodeScanner.BarCodeBounds](#barcodescannerbarcodebounds)** -- (_Optional_) The `BarCodeBounds` object.
 - **cornerPoints : Array<[BarCodeScanner.BarCodePoint](#barcodescannerbarcodepoint)\>** -- (_Optional_) Corner points of the bounding box.
 
 > **NOTE** `bounds` and `cornerPoints` are not always available. On iOS, for `code39` and `pdf417` you don't get those values. Moreover, on iOS, those values don't have to bounds the whole barcode. For some types, they will represent the area used by the scanner.

--- a/docs/pages/versions/unversioned/sdk/brightness.md
+++ b/docs/pages/versions/unversioned/sdk/brightness.md
@@ -108,7 +108,7 @@ A `Promise` that is resolved when the brightness has been successfully set.
 
 #### Error Codes
 
-- [`ERR_BRIGHTNESS`](#errbrightness)
+- [`ERR_BRIGHTNESS`](#err_brightness)
 
 ---
 
@@ -132,7 +132,7 @@ A `Promise` that resolves with `true` when the current activity is using the sys
 
 #### Error Codes
 
-- [`ERR_BRIGHTNESS`](#errbrightness)
+- [`ERR_BRIGHTNESS`](#err_brightness)
 
 ---
 
@@ -146,7 +146,7 @@ A `Promise` that is resolved with a number between 0 and 1, inclusive, represent
 
 #### Error Codes
 
-- [`ERR_BRIGHTNESS_SYSTEM`](#errbrightnesssystem)
+- [`ERR_BRIGHTNESS_SYSTEM`](#err_brightness_system)
 
 ---
 
@@ -166,8 +166,8 @@ A `Promise` that is resolved when the brightness has been successfully set.
 
 #### Error Codes
 
-- [`ERR_BRIGHTNESS_MODE`](#errbrightnessmode)
-- [`ERR_BRIGHTNESS_PERMISSIONS_DENIED`](#errbrightnesspermissionsdenied)
+- [`ERR_BRIGHTNESS_MODE`](#err_brightness_mode)
+- [`ERR_BRIGHTNESS_PERMISSIONS_DENIED`](#err_brightness_permissions_denied)
 
 ### `Brightness.getSystemBrightnessModeAsync()`
 
@@ -179,7 +179,7 @@ A `Promise` that is resolved with a [`BrightnessMode`](#brightnessbrightnessmode
 
 #### Error Codes
 
-- [`ERR_BRIGHTNESS_MODE`](#errbrightnessmode)
+- [`ERR_BRIGHTNESS_MODE`](#err_brightness_mode)
 
 ---
 
@@ -197,9 +197,9 @@ A `Promise` that is resolved when the brightness mode has been successfully set.
 
 #### Error Codes
 
-- [`ERR_INVALID_ARGUMENT`](#errinvalidargument)
-- [`ERR_BRIGHTNESS_MODE`](#errbrightnessmode)
-- [`ERR_BRIGHTNESS_PERMISSIONS_DENIED`](#errbrightnesspermissionsdenied)
+- [`ERR_INVALID_ARGUMENT`](#err_invalid_argument)
+- [`ERR_BRIGHTNESS_MODE`](#err_brightness_mode)
+- [`ERR_BRIGHTNESS_PERMISSIONS_DENIED`](#err_brightness_permissions_denied)
 
 ## Enum Types
 

--- a/docs/pages/versions/unversioned/sdk/camera.md
+++ b/docs/pages/versions/unversioned/sdk/camera.md
@@ -245,7 +245,7 @@ Takes a picture and saves it to app's cache directory. Photos are rotated to mat
 
 Returns a Promise that resolves to an object: `{ uri, width, height, exif, base64 }` where `uri` is a URI to the local image file on iOS, Android, and a base64 string on web (useable as the source for an `Image` element). The `width, height` properties specify the dimensions of the image. `base64` is included if the `base64` option was truthy, and is a string containing the JPEG data of the image in Base64--prepend that with `'data:image/jpg;base64,'` to get a data URI, which you can use as the source for an `Image` element for example. `exif` is included if the `exif` option was truthy, and is an object containing EXIF data for the image--the names of its properties are EXIF tags and their values are the values for those tags.
 
-On native platforms, the local image URI is temporary. Use [`FileSystem.copyAsync`](filesystem.md#expofilesystemcopyasyncoptions) to make a permanent copy of the image.
+On native platforms, the local image URI is temporary. Use [`FileSystem.copyAsync`](filesystem.md#filesystemcopyasyncoptions) to make a permanent copy of the image.
 
 On web, the `uri` is a base64 representation of the image because file system URLs are not supported in the browser. The `exif` data returned on web is a partial representation of the [`MediaTrackSettings`](https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackSettings), if available.
 

--- a/docs/pages/versions/unversioned/sdk/constants.md
+++ b/docs/pages/versions/unversioned/sdk/constants.md
@@ -24,7 +24,7 @@ import Constants from 'expo-constants';
 
 ### `Constants.appOwnership`
 
-Returns `expo`, `standalone`, or `guest`. If `expo`, the experience is running inside of the Expo client. If `standalone`, it is a [standalone app](../../../distribution/building-standalone-apps.md#building-standalone-apps). If `guest`, it has been opened through a link from a standalone app.
+Returns `expo`, `standalone`, or `guest`. If `expo`, the experience is running inside of the Expo client. If `standalone`, it is a [standalone app](../../../distribution/building-standalone-apps.md). If `guest`, it has been opened through a link from a standalone app.
 
 ### `Constants.deviceName`
 

--- a/docs/pages/versions/unversioned/sdk/document-picker.md
+++ b/docs/pages/versions/unversioned/sdk/document-picker.md
@@ -45,7 +45,7 @@ import * as DocumentPicker from 'expo-document-picker';
 
 ### `DocumentPicker.getDocumentAsync(options)`
 
-Display the system UI for choosing a document. By default, the chosen file is copied to [the app's internal cache directory](filesystem.md#expofilesystemcachedirectory).
+Display the system UI for choosing a document. By default, the chosen file is copied to [the app's internal cache directory](filesystem.md#filesystemcachedirectory).
 
 > **Note for Web:** The system UI can only be shown after user activation (e.g. a `Button` press). Therefore, calling `getDocumentAsync` in `componentDidMount`, for example, will **not** work as intended.
 
@@ -56,7 +56,7 @@ Display the system UI for choosing a document. By default, the chosen file is co
   A map of options:
 
   - **type (_string_)** -- The [MIME type](https://en.wikipedia.org/wiki/Media_type) of the documents that are available to be picked. Is also supports wildcards like `image/*` to choose any image. To allow any type of document you can use `*/*`. Defaults to `*/*`.
-  - **copyToCacheDirectory (_boolean_)** -- If `true`, the picked file is copied to [`FileSystem.CacheDirectory`](filesystem.md#expofilesystemcachedirectory), which allows other Expo APIs to read the file immediately. Defaults to `true`. This may impact performance for large files, so you should consider setting this to `false` if you expect users to pick particularly large files and your app does not need immediate read access.
+  - **copyToCacheDirectory (_boolean_)** -- If `true`, the picked file is copied to [`FileSystem.CacheDirectory`](filesystem.md#filesystemcachedirectory), which allows other Expo APIs to read the file immediately. Defaults to `true`. This may impact performance for large files, so you should consider setting this to `false` if you expect users to pick particularly large files and your app does not need immediate read access.
   - **multiple (_boolean_)** -- (Web Only) Allows multiple files to be selected from the system UI. Defaults to `false`.
 
 #### Returns

--- a/docs/pages/versions/unversioned/sdk/facebook.md
+++ b/docs/pages/versions/unversioned/sdk/facebook.md
@@ -22,7 +22,7 @@ For bare apps, here are links to the [iOS Installation Walkthrough](https://deve
 
 > 💡 When following these steps you will find on the Facebook Developer site that there are many fields and steps that you don't actually care about. Just look for the information that we ask you for and you will be OK!
 
-Follow [Facebook's developer documentation](https://developers.facebook.com/docs/apps/register) to register an application with Facebook's API and get an application ID. Take note of this application ID because it will be used as the `appId` option in your [`Facebook.logInWithReadPermissionsAsync`](#expofacebookloginwithreadpermissionsasync 'Facebook.logInWithReadPermissionsAsync') call.
+Follow [Facebook's developer documentation](https://developers.facebook.com/docs/apps/register) to register an application with Facebook's API and get an application ID. Take note of this application ID because it will be used as the `appId` option in your [`Facebook.logInWithReadPermissionsAsync`](#facebookloginwithreadpermissionsasyncoptions 'Facebook.logInWithReadPermissionsAsync') call.
 
 Then follow these steps based on the platforms you're targetting. This will need to be done from the [Facebook developer site](https://developers.facebook.com/).
 

--- a/docs/pages/versions/unversioned/sdk/facebook.md
+++ b/docs/pages/versions/unversioned/sdk/facebook.md
@@ -52,7 +52,7 @@ The Android Play Store Expo client will use the Facebook App ID that you provide
 
 #### Android standalone app
 
-- [Build your standalone app](../../../distribution/building-standalone-apps.md#building-standalone-apps) for Android.
+- [Build your standalone app](../../../distribution/building-standalone-apps.md) for Android.
 - Run `expo fetch:android:hashes`.
 - Copy `Facebook Key Hash` and paste it as a key hash in your Facebook developer page pictured below.
 

--- a/docs/pages/versions/unversioned/sdk/google-sign-in.md
+++ b/docs/pages/versions/unversioned/sdk/google-sign-in.md
@@ -169,7 +169,7 @@ Returns true after the user successfully updates.
 
 Configures how the `GoogleSignIn` module will attempt to sign in. You can call this method multiple times.
 
-See all the available options under the [`GoogleSignInOptions`](#googlesigninerrors) type.
+See all the available options under the [`GoogleSignInOptions`](#types) type.
 
 ### `GoogleSignIn.isSignedInAsync()`
 

--- a/docs/pages/versions/unversioned/sdk/google-sign-in.md
+++ b/docs/pages/versions/unversioned/sdk/google-sign-in.md
@@ -169,7 +169,7 @@ Returns true after the user successfully updates.
 
 Configures how the `GoogleSignIn` module will attempt to sign in. You can call this method multiple times.
 
-See all the available options under the [`GoogleSignInOptions`](#googlesigninoptions) type.
+See all the available options under the [`GoogleSignInOptions`](#googlesigninerrors) type.
 
 ### `GoogleSignIn.isSignedInAsync()`
 

--- a/docs/pages/versions/unversioned/sdk/imagepicker.md
+++ b/docs/pages/versions/unversioned/sdk/imagepicker.md
@@ -107,7 +107,7 @@ Asks the user to grant permissions for accessing user's photo. Alias for `Permis
 
 #### Returns
 
-A promise that resolves to an object of type [MediaLibraryPermissionResponse](#imagepickercamerapermissionresponse).
+A promise that resolves to an object of type [MediaLibraryPermissionResponse](#imagepickermedialibrarypermissionresponse).
 
 ### `ImagePicker.getCameraPermissionsAsync()`
 

--- a/docs/pages/versions/unversioned/sdk/imagepicker.md
+++ b/docs/pages/versions/unversioned/sdk/imagepicker.md
@@ -107,7 +107,7 @@ Asks the user to grant permissions for accessing user's photo. Alias for `Permis
 
 #### Returns
 
-A promise that resolves to an object of type [MediaLibraryPermissionResponse](#imagepickercamerarollpermissionresponse).
+A promise that resolves to an object of type [MediaLibraryPermissionResponse](#imagepickercamerapermissionresponse).
 
 ### `ImagePicker.getCameraPermissionsAsync()`
 
@@ -197,7 +197,7 @@ Display the system UI for taking a photo with the camera. Requires `Permissions.
     - **On Android**, effect of this option depends on support of installed camera app.
     - **On Web** this option has no effect - the limit is browser-dependant.
   - **videoExportPreset (_[ImagePicker.VideoExportPreset](#imagepickervideoexportpreset)_)** -- **Available on iOS 11+ only, but Deprecated.** Specify preset which will be used to compress selected video. Defaults to `ImagePicker.VideoExportPreset.Passthrough`.
-  - **videoQuality (\_[ImagePicker.UIImagePickerControllerQualityType](#imagepickeruiimagepickercontrollerqualitytype)\_)** -- **iOS only**. Specify the quality of recorded videos. Defaults to `ImagePicker.UIImagePickerControllerQualityType.High`, which is the highest available for the device.
+  - **videoQuality (\_[ImagePicker.UIImagePickerControllerQualityType](#imagepickeruiimagepickercontrollertype)\_)** -- **iOS only**. Specify the quality of recorded videos. Defaults to `ImagePicker.UIImagePickerControllerQualityType.High`, which is the highest available for the device.
 
 #### Returns
 

--- a/docs/pages/versions/unversioned/sdk/intent-launcher.md
+++ b/docs/pages/versions/unversioned/sdk/intent-launcher.md
@@ -38,11 +38,11 @@ Starts the specified activity. The method will return a promise which resolves w
 #### Arguments
 
 - **activityAction (_string_)** -- The action to be performed, e.g. `IntentLauncher.ACTION_WIRELESS_SETTINGS`. There are a few pre-defined constants you can use for this parameter. You can find them at [expo-intent-launcher/src/IntentLauncher.ts](https://github.com/expo/expo/blob/master/packages/expo-intent-launcher/src/IntentLauncher.ts). **Required**
-- **intentParams ([`IntentLauncherParams`](#typeintentlauncherparams))** -- An object of intent parameters.
+- **intentParams ([`IntentLauncherParams`](#intentlauncherparams))** -- An object of intent parameters.
 
 #### Returns
 
-A promise resolving to an object of type [IntentLauncherResult](#typeintentlauncherresult).
+A promise resolving to an object of type [IntentLauncherResult](#intentlauncherresult).
 
 ## Types
 
@@ -62,7 +62,7 @@ A promise resolving to an object of type [IntentLauncherResult](#typeintentlaunc
 
 | Key        |  Type  | Description                                                                               |
 | ---------- | :----: | ----------------------------------------------------------------------------------------- |
-| resultCode | number | Result code returned by the activity. See [ResultCode](#enumresultcode) for more details. |
+| resultCode | number | Result code returned by the activity. See [ResultCode](#resultcode) for more details. |
 | data       | string | Optional data URI that can be returned by the activity.                                   |
 | extra      | object | Optional extras object that can be returned by the activity.                              |
 

--- a/docs/pages/versions/unversioned/sdk/media-library.md
+++ b/docs/pages/versions/unversioned/sdk/media-library.md
@@ -90,10 +90,10 @@ Fetches a page of assets matching the provided criteria.
   - **first (_number_)** -- The maximum number of items on a single page. Defaults to 20.
   - **after (_string_)** -- Asset ID of the last item returned on the previous page.
   - **album (_string_ | _Album_)** -- [Album](#album) or its ID to get assets from specific album.
-  - **sortBy (_array_)** -- An array of [SortBy](#expomedialibrarysortby) keys. By default, all keys are sorted in descending order, however you can also pass a pair `[key, ascending]` where the second item is a `boolean` value that means whether to use ascending order. Note that if the `SortBy.default` key is used, then `ascending` argument will not matter.
+  - **sortBy (_array_)** -- An array of [SortBy](#medialibrarysortby) keys. By default, all keys are sorted in descending order, however you can also pass a pair `[key, ascending]` where the second item is a `boolean` value that means whether to use ascending order. Note that if the `SortBy.default` key is used, then `ascending` argument will not matter.
     Earlier items have higher priority when sorting out the results.
     If empty, this method will use the default sorting that is provided by the platform.
-  - **mediaType (_array_)** -- An array of [MediaType](#expomedialibrarymediatype) types. By default `MediaType.photo` is set.
+  - **mediaType (_array_)** -- An array of [MediaType](#medialibrarymediatype) types. By default `MediaType.photo` is set.
   - **createdAfter (_Date_ | _number_)** -- Date object or Unix timestamp in milliseconds limiting returned assets only to those that were created after this date.
   - **createdBefore (_Date_ | _number_)** -- Similarly as `createdAfter`, but limits assets only to those that were created before specified date.
 
@@ -195,7 +195,7 @@ In case they're copied you should keep in mind that `getAssetsAsync` will return
 
 #### Arguments
 
-- **assets (_array_)** -- Array of [assets](#assets) to add.
+- **assets (_array_)** -- Array of [assets](#asset) to add.
 - **album (_string_ | _Album_)** -- [Album](#album) or its ID, to which the assets will be added.
 - **copyAssets (_boolean_)** -- Whether to copy assets to the new album instead of move them. Defaults to `true`. (**Android only**)
 
@@ -211,7 +211,7 @@ On Android, album will be automatically deleted if there are no more assets insi
 
 #### Arguments
 
-- **assets (_array_)** -- Array of [assets](#assets) to remove from album.
+- **assets (_array_)** -- Array of [assets](#asset) to remove from album.
 - **album (_string_ | _Album_)** -- [Album](#album) or its ID, from which the assets will be removed.
 
 #### Returns
@@ -237,9 +237,9 @@ Subscribes for updates in user's media library.
 
   Available only if `hasIncrementalChanges` is `true`:
 
-  - **insertedAssets (_array_)** -- Array of [assets](#assets) that have been inserted to the library.
-  - **deletedAssets (_array_)** -- Array of [assets](#assets) that have been deleted from the library.
-  - **updatedAssets (_array_)** -- Array of [assets](#assets) that have been updated or completed downloading from network storage (iCloud in iOS).
+  - **insertedAssets (_array_)** -- Array of [assets](#asset) that have been inserted to the library.
+  - **deletedAssets (_array_)** -- Array of [assets](#asset) that have been deleted from the library.
+  - **updatedAssets (_array_)** -- Array of [assets](#asset) that have been updated or completed downloading from network storage (iCloud in iOS).
 
 #### Returns
 

--- a/docs/pages/versions/unversioned/sdk/notifications.md
+++ b/docs/pages/versions/unversioned/sdk/notifications.md
@@ -182,7 +182,7 @@ The following methods are exported by the `expo-notifications` module:
   - [`setNotificationChannelGroupAsync`](#setnotificationchannelgroupasyncidentifier-string-channel-notificationchannelgroupinput-promisenotificationchannelgroup--null) -- saves a notification channel group configuration
   - [`deleteNotificationChannelGroupAsync`](#deletenotificationchannelgroupasyncidentifier-string-promisevoid) -- deletes a notification channel group
   - **managing notification categories (interactive notifications)**
-  - [`setNotificationCategoryAsync`](#setnotificationcategoryasyncidentifier-string-actions-notificationaction-options-categoryoptions-promisenotificationcategory) -- creates a new notification category for interactive notifications
+  - [`setNotificationCategoryAsync`](#setnotificationcategoryasyncidentifier-string-actions-notificationaction-options-categoryoptions-promisenotificationcategory--null) -- creates a new notification category for interactive notifications
   - [`getNotificationCategoriesAsync`](#getnotificationcategoriesasync-promisenotificationcategory) -- fetches information about all active notification categories
   - [`deleteNotificationCategoryAsync`](#deletenotificationcategoryasyncidentifier-string-promiseboolean) -- deletes a notification category
 

--- a/docs/pages/versions/unversioned/sdk/print.md
+++ b/docs/pages/versions/unversioned/sdk/print.md
@@ -43,7 +43,7 @@ Prints a document or HTML, on web this prints the HTML from the page.
 
 ### `Print.printToFileAsync(options)`
 
-Prints HTML to PDF file and saves it to [app's cache directory](filesystem.md#expofilesystemcachedirectory). On web this method opens the print dialog.
+Prints HTML to PDF file and saves it to [app's cache directory](filesystem.md#filesystemcachedirectory). On web this method opens the print dialog.
 
 #### Arguments
 

--- a/docs/pages/versions/unversioned/sdk/sqlite.md
+++ b/docs/pages/versions/unversioned/sdk/sqlite.md
@@ -98,7 +98,7 @@ A `Transaction` object is passed in as a parameter to the `callback` parameter f
 In order to open a new SQLite database using an existing `.db` file you already have, you need to do three things:
 
 - `expo install expo-file-system expo-asset @expo/metro-config`
-- create a `metro.config.js` file in the root of your project with the following contents ([curious why? read here](../../../guides/customizing-metro.md#adding-more-file-extensions-to--assetexts)):
+- create a `metro.config.js` file in the root of your project with the following contents ([curious why? read here](../../../guides/customizing-metro.md#adding-more-file-extensions-to-assetexts)):
 
 ```ts
 const { getDefaultConfig } = require('@expo/metro-config');

--- a/docs/pages/versions/unversioned/sdk/storereview.md
+++ b/docs/pages/versions/unversioned/sdk/storereview.md
@@ -29,7 +29,7 @@ If the users device is running a version of iOS lower than 10.3, or the user is 
 
 #### Error Codes
 
-- [`ERR_STORE_REVIEW_UNSUPPORTED`](#err_store_review_unsupported)
+- [`ERR_STORE_REVIEW_UNSUPPORTED`](#e_store_review_unsupported)
 
 #### Example
 

--- a/docs/pages/versions/unversioned/sdk/task-manager.md
+++ b/docs/pages/versions/unversioned/sdk/task-manager.md
@@ -139,7 +139,7 @@ Example:
 ### `TaskManager.unregisterTaskAsync(taskName)`
 
 Unregisters task from the app, so the app will not be receiving updates for that task anymore.
-_It is recommended to use methods specialized by modules that registered the task, eg. [Location.stopLocationUpdatesAsync](location.md#expolocationstoplocationupdatesasynctaskname)._
+_It is recommended to use methods specialized by modules that registered the task, eg. [Location.stopLocationUpdatesAsync](location.md#locationstoplocationupdatesasynctaskname)._
 
 #### Arguments
 

--- a/docs/pages/versions/unversioned/sdk/webbrowser.md
+++ b/docs/pages/versions/unversioned/sdk/webbrowser.md
@@ -81,7 +81,7 @@ Opens the url with Safari in a modal on iOS using [`SFSafariViewController`](htt
   - **dismissButtonStyle (_optional_) (_string_)** -- (_iOS only_) The style of the dismiss button. Should be one of: `done`, `close`, or `cancel`.
   - **enableBarCollapsing (_optional_) (_boolean_)** -- a boolean determining whether the toolbar should be hiding when a user scrolls the website.
   - **enableDefaultShare (_optional_) (_boolean_)** -- (_Android only_) a boolean determining whether a default share item should be added to the menu.
-  - **browserPackage (_optional_) (_string_)** -- (_Android only_). Package name of a browser to be used to handle Custom Tabs. List of available packages is to be queried by [getCustomTabsSupportingBrowsers](#webbrowsergetcustomtabssupportingbrowsers) method.
+  - **browserPackage (_optional_) (_string_)** -- (_Android only_). Package name of a browser to be used to handle Custom Tabs. List of available packages is to be queried by [getCustomTabsSupportingBrowsers](#webbrowsergetcustomtabssupportingbrowsersasync) method.
   - **readerMode (_optional_) (_boolean_)** -- (_iOS only_) a boolean determining whether Safari should enter Reader mode, if it is available.
   - **secondaryToolbarColor (_optional_) (_string_)** -- (_Android only_) color of the secondary toolbar in either `#AARRGGBB` or `#RRGGBB` format.
   - **showInRecents (_optional_) (_boolean_)** -- (_Android only_) a boolean determining whether browsed website should be shown as separate entry in Android recents/multitasking view. Default: `false`
@@ -113,7 +113,7 @@ This will be done using a "custom Chrome tabs" browser, [AppState][d-appstate], 
 
 **On web:**
 
-> 🚨 This API can only be used in a secure environment (`https`). You can use `expo start:web --https` to test this. Otherwise an error with code [`ERR_WEB_BROWSER_CRYPTO`](#errwebbrowsercrypto) will be thrown.
+> 🚨 This API can only be used in a secure environment (`https`). You can use `expo start:web --https` to test this. Otherwise an error with code [`ERR_WEB_BROWSER_CRYPTO`](#err_web_browser_crypto) will be thrown.
 
 This will use the browser's [`window.open()`][d-windowopen] API.
 
@@ -127,7 +127,7 @@ How this works on web:
 - The state will be added to the window's `localstorage`. This ensures that auth cannot complete unless it's done from a page running with the same origin as it was started. Ex: if `openAuthSessionAsync` is invoked on `https://localhost:19006`, then `maybeCompleteAuthSession` must be invoked on a page hosted from the origin `https://localhost:19006`. Using a different website, or even a different host like `https://128.0.0.*:19006` for example will not work.
 - A timer will be started to check for every 1000 milliseconds (1 second) to detect if the window has been closed by the user. If this happens then a promise will resolve with `{ type: 'dismiss' }`.
 
-🚨 On mobile web, Chrome and Safari will block any call to [`window.open()`][d-windowopen] which takes too long to fire after a user interaction. This method must be invoked immediately after a user interaction. If the event is blocked, an error with code [`ERR_WEB_BROWSER_BLOCKED`](#errwebbrowserblocked) will be thrown.
+🚨 On mobile web, Chrome and Safari will block any call to [`window.open()`][d-windowopen] which takes too long to fire after a user interaction. This method must be invoked immediately after a user interaction. If the event is blocked, an error with code [`ERR_WEB_BROWSER_BLOCKED`](#err_web_browser_blocked) will be thrown.
 
 [d-windowopen]: https://developer.mozilla.org/en-US/docs/Web/API/Window/open
 [d-appstate]: https://docs.expo.io/versions/latest/react-native/appstate/
@@ -147,9 +147,9 @@ Returns a Promise:
 
 #### Error Codes
 
-- [`ERR_WEB_BROWSER_REDIRECT`](#errwebbrowserredirect)
-- [`ERR_WEB_BROWSER_BLOCKED`](#errwebbrowserblocked)
-- [`ERR_WEB_BROWSER_CRYPTO`](#errwebbrowsercrypto)
+- [`ERR_WEB_BROWSER_REDIRECT`](#err_web_browser_redirect)
+- [`ERR_WEB_BROWSER_BLOCKED`](#err_web_browser_blocked)
+- [`ERR_WEB_BROWSER_CRYPTO`](#err_web_browser_crypto)
 
 ### `WebBrowser.maybeCompleteAuthSession(options)`
 
@@ -204,7 +204,7 @@ The promise resolves with `{ package: string }`.
 
 _Android only_
 
-This methods removes all bindings to services created by [`warmUpAsync`](#webbrowserwarmupasyncnbrowserpackage) or [`mayInitWithUrlAsync`](#webbrowseramayinitwithurlsyncurl-package). You should call this method once you don't need them to avoid potential memory leaks. However, those binding would be cleared once your application is destroyed, which might be sufficient in most cases.
+This methods removes all bindings to services created by [`warmUpAsync`](#webbrowserwarmupasyncbrowserpackage) or [`mayInitWithUrlAsync`](#webbrowsermayinitwithurlasyncurl-package). You should call this method once you don't need them to avoid potential memory leaks. However, those binding would be cleared once your application is destroyed, which might be sufficient in most cases.
 
 #### Arguments
 
@@ -236,10 +236,10 @@ The promise resolves with `{ browserPackages: string[], defaultBrowserPackage: s
 
 - **browserPackages (_string[]_)** : All packages recognized by `PackageManager` as capable of handling Custom Tabs. Empty array means there is no supporting browsers on device.
 - **defaultBrowserPackage (_string_ | null)** : Default package chosen by user. Null if there is no such packages. Null usually means, that user will be prompted to choose from available packages.
-- **servicePackages (_string[]_)** : All packages recognized by `PackageManager` as capable of handling Custom Tabs Service. This service is used by [`warmUpAsync`](#webbrowserwarmupasyncnbrowserpackage), [`mayInitWithUrlAsync`](#webbrowsermayinitwithurlasyncurl-package) and [`coolDownAsync`](#webbrowsercooldownasyncbrowserpackage).
+- **servicePackages (_string[]_)** : All packages recognized by `PackageManager` as capable of handling Custom Tabs Service. This service is used by [`warmUpAsync`](#webbrowserwarmupasyncbrowserpackage), [`mayInitWithUrlAsync`](#webbrowsermayinitwithurlasyncurl-package) and [`coolDownAsync`](#webbrowsercooldownasyncbrowserpackage).
 - **preferredBrowserPackage (_string_ | null)** : Package preferred by `CustomTabsClient` to be used to handle Custom Tabs. It favors browser chosen by user as default, as long as it is present on both `browserPackages` and `servicePackages` lists. Only such browsers are considered as fully supporting Custom Tabs. It might be `null` when there is no such browser installed or when default browser is not in `servicePackages` list.
 
-In general, services are used to perform background tasks. If a browser is available in `servicePackage` list, it should be capable of performing [`warmUpAsync`](#webbrowserwarmupasyncnbrowserpackage), [`mayInitWithUrlAsync`](#webbrowsermayinitwithurlasyncurl-package) and [`coolDownAsync`](#webbrowsercooldownasyncbrowserpackage). For opening an actual web page, browser must be in `browserPackages` list. A browser has to be present in both lists to be considered as fully supporting Custom Tabs.
+In general, services are used to perform background tasks. If a browser is available in `servicePackage` list, it should be capable of performing [`warmUpAsync`](#webbrowserwarmupasyncbrowserpackage), [`mayInitWithUrlAsync`](#webbrowsermayinitwithurlasyncurl-package) and [`coolDownAsync`](#webbrowsercooldownasyncbrowserpackage). For opening an actual web page, browser must be in `browserPackages` list. A browser has to be present in both lists to be considered as fully supporting Custom Tabs.
 
 ## Error Codes
 

--- a/docs/pages/versions/v36.0.0/sdk/amplitude.md
+++ b/docs/pages/versions/v36.0.0/sdk/amplitude.md
@@ -60,7 +60,7 @@ Set properties for the current user. See [here for details](https://amplitude.ze
 
 ### `Amplitude.clearUserProperties()`
 
-Clear properties set by [`Amplitude.setUserProperties()`](#expoamplitudesetuserproperties 'Amplitude.setUserProperties').
+Clear properties set by [`Amplitude.setUserProperties()`](#amplitudeclearuserproperties 'Amplitude.setUserProperties').
 
 ### `Amplitude.logEvent(eventName)`
 

--- a/docs/pages/versions/v36.0.0/sdk/brightness.md
+++ b/docs/pages/versions/v36.0.0/sdk/brightness.md
@@ -100,7 +100,7 @@ A `Promise` that is resolved when the brightness has been successfully set.
 
 #### Error Codes
 
-- [`ERR_BRIGHTNESS`](#errbrightness)
+- [`ERR_BRIGHTNESS`](#err_brightness)
 
 ---
 
@@ -124,7 +124,7 @@ A `Promise` that resolves with `true` when the current activity is using the sys
 
 #### Error Codes
 
-- [`ERR_BRIGHTNESS`](#errbrightness)
+- [`ERR_BRIGHTNESS`](#err_brightness)
 
 ---
 
@@ -138,7 +138,7 @@ A `Promise` that is resolved with a number between 0 and 1, inclusive, represent
 
 #### Error Codes
 
-- [`ERR_BRIGHTNESS_SYSTEM`](#errbrightnesssystem)
+- [`ERR_BRIGHTNESS_SYSTEM`](#err_brightness_system)
 
 ---
 
@@ -158,8 +158,8 @@ A `Promise` that is resolved when the brightness has been successfully set.
 
 #### Error Codes
 
-- [`ERR_BRIGHTNESS_MODE`](#errbrightnessmode)
-- [`ERR_BRIGHTNESS_PERMISSIONS_DENIED`](#errbrightnesspermissionsdenied)
+- [`ERR_BRIGHTNESS_MODE`](#err_brightness_mode)
+- [`ERR_BRIGHTNESS_PERMISSIONS_DENIED`](#err_brightness_permissions_denied)
 
 ### `Brightness.getSystemBrightnessModeAsync()`
 
@@ -171,7 +171,7 @@ A `Promise` that is resolved with a [`BrightnessMode`](#brightnessbrightnessmode
 
 #### Error Codes
 
-- [`ERR_BRIGHTNESS_MODE`](#errbrightnessmode)
+- [`ERR_BRIGHTNESS_MODE`](#err_brightness_mode)
 
 ---
 
@@ -189,9 +189,9 @@ A `Promise` that is resolved when the brightness mode has been successfully set.
 
 #### Error Codes
 
-- [`ERR_INVALID_ARGUMENT`](#errinvalidargument)
-- [`ERR_BRIGHTNESS_MODE`](#errbrightnessmode)
-- [`ERR_BRIGHTNESS_PERMISSIONS_DENIED`](#errbrightnesspermissionsdenied)
+- [`ERR_INVALID_ARGUMENT`](#err_invalid_argument)
+- [`ERR_BRIGHTNESS_MODE`](#err_brightness_mode)
+- [`ERR_BRIGHTNESS_PERMISSIONS_DENIED`](#err_brightness_permissions_denied)
 
 ## Enum Types
 

--- a/docs/pages/versions/v36.0.0/sdk/constants.md
+++ b/docs/pages/versions/v36.0.0/sdk/constants.md
@@ -24,7 +24,7 @@ import Constants from 'expo-constants';
 
 ### `Constants.appOwnership`
 
-Returns `expo`, `standalone`, or `guest`. If `expo`, the experience is running inside of the Expo client. If `standalone`, it is a [standalone app](../../../distribution/building-standalone-apps.md#building-standalone-apps). If `guest`, it has been opened through a link from a standalone app.
+Returns `expo`, `standalone`, or `guest`. If `expo`, the experience is running inside of the Expo client. If `standalone`, it is a [standalone app](../../../distribution/building-standalone-apps.md). If `guest`, it has been opened through a link from a standalone app.
 
 ### `Constants.expoVersion`
 

--- a/docs/pages/versions/v36.0.0/sdk/document-picker.md
+++ b/docs/pages/versions/v36.0.0/sdk/document-picker.md
@@ -37,7 +37,7 @@ import * as DocumentPicker from 'expo-document-picker';
 
 ### `DocumentPicker.getDocumentAsync(options)`
 
-Display the system UI for choosing a document. By default, the chosen file is copied to [the app's internal cache directory](filesystem.md#expofilesystemcachedirectory).
+Display the system UI for choosing a document. By default, the chosen file is copied to [the app's internal cache directory](filesystem.md#filesystemcachedirectory).
 
 > **Note for Web:** The system UI can only be shown after user activation (e.g. a `Button` press). Therefore, calling `getDocumentAsync` in `componentDidMount`, for example, will **not** work as intended.
 
@@ -48,7 +48,7 @@ Display the system UI for choosing a document. By default, the chosen file is co
   A map of options:
 
   - **type (_string_)** -- The [MIME type](https://en.wikipedia.org/wiki/Media_type) of the documents that are available to be picked. Is also supports wildcards like `image/*` to choose any image. To allow any type of document you can use `*/*`. Defaults to `*/*`.
-  - **copyToCacheDirectory (_boolean_)** -- If `true`, the picked file is copied to [`FileSystem.CacheDirectory`](filesystem.md#expofilesystemcachedirectory), which allows other Expo APIs to read the file immediately. Defaults to `true`. This may impact performance for large files, so you should consider setting this to `false` if you expect users to pick particularly large files and your app does not need immediate read access.
+  - **copyToCacheDirectory (_boolean_)** -- If `true`, the picked file is copied to [`FileSystem.CacheDirectory`](filesystem.md#filesystemcachedirectory), which allows other Expo APIs to read the file immediately. Defaults to `true`. This may impact performance for large files, so you should consider setting this to `false` if you expect users to pick particularly large files and your app does not need immediate read access.
   - **multiple (_boolean_)** -- (Web Only) Allows multiple files to be selected from the system UI. Defaults to `false`.
 
 #### Returns

--- a/docs/pages/versions/v36.0.0/sdk/facebook.md
+++ b/docs/pages/versions/v36.0.0/sdk/facebook.md
@@ -19,7 +19,7 @@ For ejected (see: [ExpoKit](../../../expokit/overview.md)) apps, here are links 
 
 ### Registering your app with Facebook
 
-Follow [Facebook's developer documentation](https://developers.facebook.com/docs/apps/register) to register an application with Facebook's API and get an application ID. Take note of this application ID because it will be used as the `appId` option in your [`Facebook.logInWithReadPermissionsAsync`](#expofacebookloginwithreadpermissionsasync 'Facebook.logInWithReadPermissionsAsync') call. Then follow these steps based on the platforms you're targetting. This will need to be done from the [Facebook developer site](https://developers.facebook.com/):
+Follow [Facebook's developer documentation](https://developers.facebook.com/docs/apps/register) to register an application with Facebook's API and get an application ID. Take note of this application ID because it will be used as the `appId` option in your [`Facebook.logInWithReadPermissionsAsync`](#facebookloginwithreadpermissionsasyncoptions 'Facebook.logInWithReadPermissionsAsync') call. Then follow these steps based on the platforms you're targetting. This will need to be done from the [Facebook developer site](https://developers.facebook.com/):
 
 - **The Expo client app**
 

--- a/docs/pages/versions/v36.0.0/sdk/facebook.md
+++ b/docs/pages/versions/v36.0.0/sdk/facebook.md
@@ -35,7 +35,7 @@ Follow [Facebook's developer documentation](https://developers.facebook.com/docs
 
 - **Android standalone app**
 
-  - [Build your standalone app](../../../distribution/building-standalone-apps.md#building-standalone-apps) for Android.
+  - [Build your standalone app](../../../distribution/building-standalone-apps.md) for Android.
   - Run `expo fetch:android:hashes`.
   - Copy `Facebook Key Hash` and paste it as an additional key hash in your Facebook developer page pictured above.
 

--- a/docs/pages/versions/v36.0.0/sdk/gl-view.md
+++ b/docs/pages/versions/v36.0.0/sdk/gl-view.md
@@ -36,7 +36,7 @@ A function that will be called when the OpenGL ES context is created. The functi
 
 ### `takeSnapshotAsync(options)`
 
-Same as [GLView.takeSnapshotAsync](#expoglviewtakesnapshotasyncgl-options) but uses WebGL context that is associated with the view on which the method is called.
+Same as [GLView.takeSnapshotAsync](#glviewtakesnapshotasyncgl-options) but uses WebGL context that is associated with the view on which the method is called.
 
 ## Static methods
 

--- a/docs/pages/versions/v36.0.0/sdk/google-sign-in.md
+++ b/docs/pages/versions/v36.0.0/sdk/google-sign-in.md
@@ -167,7 +167,7 @@ Returns true after the user successfully updates.
 
 Configures how the `GoogleSignIn` module will attempt to sign in. You can call this method multiple times.
 
-See all the available options under the [`GoogleSignInOptions`](#googlesigninoptions) type.
+See all the available options under the [`GoogleSignInOptions`](#googlesigninerrors) type.
 
 ### `GoogleSignIn.isSignedInAsync()`
 

--- a/docs/pages/versions/v36.0.0/sdk/google-sign-in.md
+++ b/docs/pages/versions/v36.0.0/sdk/google-sign-in.md
@@ -167,7 +167,7 @@ Returns true after the user successfully updates.
 
 Configures how the `GoogleSignIn` module will attempt to sign in. You can call this method multiple times.
 
-See all the available options under the [`GoogleSignInOptions`](#googlesigninerrors) type.
+See all the available options under the [`GoogleSignInOptions`](#types) type.
 
 ### `GoogleSignIn.isSignedInAsync()`
 

--- a/docs/pages/versions/v36.0.0/sdk/intent-launcher.md
+++ b/docs/pages/versions/v36.0.0/sdk/intent-launcher.md
@@ -38,11 +38,11 @@ Starts the specified activity. The method will return a promise which resolves w
 #### Arguments
 
 - **activityAction (_string_)** -- The action to be performed, e.g. `IntentLauncher.ACTION_WIRELESS_SETTINGS`. There are a few pre-defined constants you can use for this parameter. You can find them at [expo-intent-launcher/src/IntentLauncher.ts](https://github.com/expo/expo/blob/master/packages/expo-intent-launcher/src/IntentLauncher.ts). **Required**
-- **intentParams ([`IntentParams`](#typeintentparams))** -- An object of intent parameters.
+- **intentParams ([`IntentParams`](#intentparams))** -- An object of intent parameters.
 
 #### Returns
 
-A promise resolving to an object of type [IntentResult](#typeintentresult).
+A promise resolving to an object of type [IntentResult](#intentresult).
 
 ## Types
 
@@ -62,7 +62,7 @@ A promise resolving to an object of type [IntentResult](#typeintentresult).
 
 | Key        |  Type  | Description                                                                               |
 | ---------- | :----: | ----------------------------------------------------------------------------------------- |
-| resultCode | number | Result code returned by the activity. See [ResultCode](#enumresultcode) for more details. |
+| resultCode | number | Result code returned by the activity. See [ResultCode](#resultcode) for more details. |
 | data       | string | Optional data URI that can be returned by the activity.                                   |
 | extra      | object | Optional extras object that can be returned by the activity.                              |
 

--- a/docs/pages/versions/v36.0.0/sdk/location.md
+++ b/docs/pages/versions/v36.0.0/sdk/location.md
@@ -374,7 +374,7 @@ A promise resolving as soon as the task is registered.
 Geofencing task will be receiving following data:
 
 - **eventType : [Location.GeofencingEventType](#locationgeofencingeventtype)** -- Indicates the reason for calling the task, which can be triggered by entering or exiting the region. See [Location.GeofencingEventType](#locationgeofencingeventtype).
-- **region : [LocationRegion](#type-location-region)** -- Object containing details about updated region. See [LocationRegion](#type-region) for more details.
+- **region : [LocationRegion](#locationregion)** -- Object containing details about updated region. See [LocationRegion](#type-region) for more details.
 
 ```javascript
 import * as Location from 'expo-location';

--- a/docs/pages/versions/v36.0.0/sdk/media-library.md
+++ b/docs/pages/versions/v36.0.0/sdk/media-library.md
@@ -80,10 +80,10 @@ Fetches a page of assets matching the provided criteria.
   - **first (_number_)** -- The maximum number of items on a single page. Defaults to 20.
   - **after (_string_)** -- Asset ID of the last item returned on the previous page.
   - **album (_string_ | _Album_)** -- [Album](#album) or its ID to get assets from specific album.
-  - **sortBy (_array_)** -- An array of [SortBy](#expomedialibrarysortby) keys. By default, all keys are sorted in descending order, however you can also pass a pair `[key, ascending]` where the second item is a `boolean` value that means whether to use ascending order. Note that if the `SortBy.default` key is used, then `ascending` argument will not matter.
+  - **sortBy (_array_)** -- An array of [SortBy](#medialibrarysortby) keys. By default, all keys are sorted in descending order, however you can also pass a pair `[key, ascending]` where the second item is a `boolean` value that means whether to use ascending order. Note that if the `SortBy.default` key is used, then `ascending` argument will not matter.
     Earlier items have higher priority when sorting out the results.
     If empty, this method will use the default sorting that is provided by the platform.
-  - **mediaType (_array_)** -- An array of [MediaType](#expomedialibrarymediatype) types. By default `MediaType.photo` is set.
+  - **mediaType (_array_)** -- An array of [MediaType](#medialibrarymediatype) types. By default `MediaType.photo` is set.
   - **createdAfter (_Date_ | _number_)** -- Date object or Unix timestamp in milliseconds limiting returned assets only to those that were created after this date.
   - **createdBefore (_Date_ | _number_)** -- Similarly as `createdAfter`, but limits assets only to those that were created before specified date.
 
@@ -183,7 +183,7 @@ In case they're copied you should keep in mind that `getAssetsAsync` will return
 
 #### Arguments
 
-- **assets (_array_)** -- Array of [assets](#assets) to add.
+- **assets (_array_)** -- Array of [assets](#asset) to add.
 - **album (_string_ | _Album_)** -- [Album](#album) or its ID, to which the assets will be added.
 - **copyAssets (_boolean_)** -- Whether to copy assets to the new album instead of move them. Defaults to `true`. (**Android only**)
 
@@ -199,7 +199,7 @@ On Android, album will be automatically deleted if there are no more assets insi
 
 #### Arguments
 
-- **assets (_array_)** -- Array of [assets](#assets) to remove from album.
+- **assets (_array_)** -- Array of [assets](#asset) to remove from album.
 - **album (_string_ | _Album_)** -- [Album](#album) or its ID, from which the assets will be removed.
 
 #### Returns
@@ -221,8 +221,8 @@ Subscribes for updates in user's media library.
 #### Arguments
 
 - **listener (_function_)** -- A callback that is called when any assets have been inserted or deleted from the library. **On Android** it's invoked with an empty object. **On iOS** it's invoked with an object that contains following keys:
-  - **insertedAssets (_array_)** -- Array of [assets](#assets) that have been inserted to the library.
-  - **deletedAssets (_array_)** -- Array of [assets](#assets) that have been deleted from the library.
+  - **insertedAssets (_array_)** -- Array of [assets](#asset) that have been inserted to the library.
+  - **deletedAssets (_array_)** -- Array of [assets](#asset) that have been deleted from the library.
 
 #### Returns
 

--- a/docs/pages/versions/v36.0.0/sdk/print.md
+++ b/docs/pages/versions/v36.0.0/sdk/print.md
@@ -41,7 +41,7 @@ Prints a document or HTML.
 
 ### `Print.printToFileAsync(options)`
 
-Prints HTML to PDF file and saves it to [app's cache directory](filesystem.md#expofilesystemcachedirectory).
+Prints HTML to PDF file and saves it to [app's cache directory](filesystem.md#filesystemcachedirectory).
 
 #### Arguments
 

--- a/docs/pages/versions/v36.0.0/sdk/task-manager.md
+++ b/docs/pages/versions/v36.0.0/sdk/task-manager.md
@@ -115,7 +115,7 @@ Example:
 ### `TaskManager.unregisterTaskAsync(taskName)`
 
 Unregisters task from the app, so the app will not be receiving updates for that task anymore.
-_It is recommended to use methods specialized by modules that registered the task, eg. [Location.stopLocationUpdatesAsync](location.md#expolocationstoplocationupdatesasynctaskname)._
+_It is recommended to use methods specialized by modules that registered the task, eg. [Location.stopLocationUpdatesAsync](location.md#locationstoplocationupdatesasynctaskname)._
 
 #### Arguments
 

--- a/docs/pages/versions/v36.0.0/sdk/updates.md
+++ b/docs/pages/versions/v36.0.0/sdk/updates.md
@@ -46,7 +46,7 @@ Downloads the most recent published version of your experience to the device's l
 
 An optional `params` object with the following keys:
 
-- **eventListener (_function_)** -- A callback to receive updates events. Will be called with the same events as a function passed into [`Updates.addListener`](#expoupdatesaddlistenereventlistener) but will be subscribed and unsubscribed from events automatically.
+- **eventListener (_function_)** -- A callback to receive updates events. Will be called with the same events as a function passed into [`Updates.addListener`](#updatesaddlistenereventlistener) but will be subscribed and unsubscribed from events automatically.
 
 #### Returns
 

--- a/docs/pages/versions/v36.0.0/sdk/webbrowser.md
+++ b/docs/pages/versions/v36.0.0/sdk/webbrowser.md
@@ -72,7 +72,7 @@ Opens the url with Safari in a modal on iOS using [`SFSafariViewController`](htt
   - **showInRecents (_optional_) (_boolean_)** -- (_Android only_) a boolean determining whether browsed website should be shown as separate entry in Android recents/multitasking view. Default: `false`
   - **controlsColor (_optional_) (_string_)** -- (_iOS only_) tint color for controls in SKSafariViewController in `#AARRGGBB` or `#RRGGBB` format.
   - **showTitle (_optional_) (_boolean_)** -- (_Android only_) a boolean determining whether the browser should show the title of website on the toolbar
-  - **browserPackage (_optional_) (_string_)** -- (_Android only_). Package name of a browser to be used to handle Custom Tabs. List of available packages is to be queried by [getCustomTabsSupportingBrowsers](#webbrowsergetcustomtabssupportingbrowsers) method.
+  - **browserPackage (_optional_) (_string_)** -- (_Android only_). Package name of a browser to be used to handle Custom Tabs. List of available packages is to be queried by [getCustomTabsSupportingBrowsers](#webbrowsergetcustomtabssupportingbrowsersasync) method.
 
   Note that behavior customization options depend on the actual browser and its version. Some or all of the arguments may be ignored.
 
@@ -135,7 +135,7 @@ The promise resolves with `{ package: string }`.
 
 _Android only_
 
-This methods removes all bindings to services created by [`warmUpAsync`](#webbrowserwarmupasyncnbrowserpackage) or [`mayInitWithUrlAsync`](#webbrowseramayinitwithurlsyncurl-package). You should call this method once you don't need them to avoid potential memory leaks. However, those binding would be cleared once your application is destroyed, which might be sufficient in most cases.
+This methods removes all bindings to services created by [`warmUpAsync`](#webbrowserwarmupasyncbrowserpackage) or [`mayInitWithUrlAsync`](#webbrowsermayinitwithurlasyncurl-package). You should call this method once you don't need them to avoid potential memory leaks. However, those binding would be cleared once your application is destroyed, which might be sufficient in most cases.
 
 #### Arguments
 
@@ -167,9 +167,9 @@ The promise resolves with `{ browserPackages: string[], defaultBrowserPackage: s
 
 - **browserPackages (_string[]_)** : All packages recognized by `PackageManager` as capable of handling Custom Tabs. Empty array means there is no supporting browsers on device.
 - **defaultBrowserPackage (_string_ | null)** : Default package chosen by user. Null if there is no such packages. Null usually means, that user will be prompted to choose from available packages.
-- **servicePackages (_string[]_)** : All packages recognized by `PackageManager` as capable of handling Custom Tabs Service. This service is used by [`warmUpAsync`](#webbrowserwarmupasyncnbrowserpackage), [`mayInitWithUrlAsync`](#webbrowsermayinitwithurlasyncurl-package) and [`coolDownAsync`](#webbrowsercooldownasyncbrowserpackage).
+- **servicePackages (_string[]_)** : All packages recognized by `PackageManager` as capable of handling Custom Tabs Service. This service is used by [`warmUpAsync`](#webbrowserwarmupasyncbrowserpackage), [`mayInitWithUrlAsync`](#webbrowsermayinitwithurlasyncurl-package) and [`coolDownAsync`](#webbrowsercooldownasyncbrowserpackage).
 - **preferredBrowserPackage (_string_ | null)** : Package preferred by `CustomTabsClient` to be used to handle Custom Tabs. It favors browser chosen by user as default, as long as it is present on both `browserPackages` and `servicePackages` lists. Only such browsers are considered as fully supporting Custom Tabs. It might be `null` when there is no such browser installed or when default browser is not in `servicePackages` list.
 
-In general, services are used to perform background tasks. If a browser is available in `servicePackage` list, it should be capable of performing [`warmUpAsync`](#webbrowserwarmupasyncnbrowserpackage), [`mayInitWithUrlAsync`](#webbrowsermayinitwithurlasyncurl-package) and [`coolDownAsync`](#webbrowsercooldownasyncbrowserpackage). For opening an actual web page, browser must be in `browserPackages` list. A browser has to be present in both lists to be considered as fully supporting Custom Tabs.
+In general, services are used to perform background tasks. If a browser is available in `servicePackage` list, it should be capable of performing [`warmUpAsync`](#webbrowserwarmupasyncbrowserpackage), [`mayInitWithUrlAsync`](#webbrowsermayinitwithurlasyncurl-package) and [`coolDownAsync`](#webbrowsercooldownasyncbrowserpackage). For opening an actual web page, browser must be in `browserPackages` list. A browser has to be present in both lists to be considered as fully supporting Custom Tabs.
 
 #

--- a/docs/pages/versions/v37.0.0/sdk/amplitude.md
+++ b/docs/pages/versions/v37.0.0/sdk/amplitude.md
@@ -60,7 +60,7 @@ Set properties for the current user. See [here for details](https://amplitude.ze
 
 ### `Amplitude.clearUserProperties()`
 
-Clear properties set by [`Amplitude.setUserProperties()`](#expoamplitudesetuserproperties 'Amplitude.setUserProperties').
+Clear properties set by [`Amplitude.setUserProperties()`](#amplitudeclearuserproperties 'Amplitude.setUserProperties').
 
 ### `Amplitude.logEvent(eventName)`
 

--- a/docs/pages/versions/v37.0.0/sdk/brightness.md
+++ b/docs/pages/versions/v37.0.0/sdk/brightness.md
@@ -100,7 +100,7 @@ A `Promise` that is resolved when the brightness has been successfully set.
 
 #### Error Codes
 
-- [`ERR_BRIGHTNESS`](#errbrightness)
+- [`ERR_BRIGHTNESS`](#err_brightness)
 
 ---
 
@@ -124,7 +124,7 @@ A `Promise` that resolves with `true` when the current activity is using the sys
 
 #### Error Codes
 
-- [`ERR_BRIGHTNESS`](#errbrightness)
+- [`ERR_BRIGHTNESS`](#err_brightness)
 
 ---
 
@@ -138,7 +138,7 @@ A `Promise` that is resolved with a number between 0 and 1, inclusive, represent
 
 #### Error Codes
 
-- [`ERR_BRIGHTNESS_SYSTEM`](#errbrightnesssystem)
+- [`ERR_BRIGHTNESS_SYSTEM`](#err_brightness_system)
 
 ---
 
@@ -158,8 +158,8 @@ A `Promise` that is resolved when the brightness has been successfully set.
 
 #### Error Codes
 
-- [`ERR_BRIGHTNESS_MODE`](#errbrightnessmode)
-- [`ERR_BRIGHTNESS_PERMISSIONS_DENIED`](#errbrightnesspermissionsdenied)
+- [`ERR_BRIGHTNESS_MODE`](#err_brightness_mode)
+- [`ERR_BRIGHTNESS_PERMISSIONS_DENIED`](#err_brightness_permissions_denied)
 
 ### `Brightness.getSystemBrightnessModeAsync()`
 
@@ -171,7 +171,7 @@ A `Promise` that is resolved with a [`BrightnessMode`](#brightnessbrightnessmode
 
 #### Error Codes
 
-- [`ERR_BRIGHTNESS_MODE`](#errbrightnessmode)
+- [`ERR_BRIGHTNESS_MODE`](#err_brightness_mode)
 
 ---
 
@@ -189,9 +189,9 @@ A `Promise` that is resolved when the brightness mode has been successfully set.
 
 #### Error Codes
 
-- [`ERR_INVALID_ARGUMENT`](#errinvalidargument)
-- [`ERR_BRIGHTNESS_MODE`](#errbrightnessmode)
-- [`ERR_BRIGHTNESS_PERMISSIONS_DENIED`](#errbrightnesspermissionsdenied)
+- [`ERR_INVALID_ARGUMENT`](#err_invalid_argument)
+- [`ERR_BRIGHTNESS_MODE`](#err_brightness_mode)
+- [`ERR_BRIGHTNESS_PERMISSIONS_DENIED`](#err_brightness_permissions_denied)
 
 ## Enum Types
 

--- a/docs/pages/versions/v37.0.0/sdk/constants.md
+++ b/docs/pages/versions/v37.0.0/sdk/constants.md
@@ -24,7 +24,7 @@ import Constants from 'expo-constants';
 
 ### `Constants.appOwnership`
 
-Returns `expo`, `standalone`, or `guest`. If `expo`, the experience is running inside of the Expo client. If `standalone`, it is a [standalone app](../../../distribution/building-standalone-apps.md#building-standalone-apps). If `guest`, it has been opened through a link from a standalone app.
+Returns `expo`, `standalone`, or `guest`. If `expo`, the experience is running inside of the Expo client. If `standalone`, it is a [standalone app](../../../distribution/building-standalone-apps.md). If `guest`, it has been opened through a link from a standalone app.
 
 ### `Constants.expoVersion`
 

--- a/docs/pages/versions/v37.0.0/sdk/document-picker.md
+++ b/docs/pages/versions/v37.0.0/sdk/document-picker.md
@@ -45,7 +45,7 @@ import * as DocumentPicker from 'expo-document-picker';
 
 ### `DocumentPicker.getDocumentAsync(options)`
 
-Display the system UI for choosing a document. By default, the chosen file is copied to [the app's internal cache directory](filesystem.md#expofilesystemcachedirectory).
+Display the system UI for choosing a document. By default, the chosen file is copied to [the app's internal cache directory](filesystem.md#filesystemcachedirectory).
 
 > **Note for Web:** The system UI can only be shown after user activation (e.g. a `Button` press). Therefore, calling `getDocumentAsync` in `componentDidMount`, for example, will **not** work as intended.
 
@@ -56,7 +56,7 @@ Display the system UI for choosing a document. By default, the chosen file is co
   A map of options:
 
   - **type (_string_)** -- The [MIME type](https://en.wikipedia.org/wiki/Media_type) of the documents that are available to be picked. Is also supports wildcards like `image/*` to choose any image. To allow any type of document you can use `*/*`. Defaults to `*/*`.
-  - **copyToCacheDirectory (_boolean_)** -- If `true`, the picked file is copied to [`FileSystem.CacheDirectory`](filesystem.md#expofilesystemcachedirectory), which allows other Expo APIs to read the file immediately. Defaults to `true`. This may impact performance for large files, so you should consider setting this to `false` if you expect users to pick particularly large files and your app does not need immediate read access.
+  - **copyToCacheDirectory (_boolean_)** -- If `true`, the picked file is copied to [`FileSystem.CacheDirectory`](filesystem.md#filesystemcachedirectory), which allows other Expo APIs to read the file immediately. Defaults to `true`. This may impact performance for large files, so you should consider setting this to `false` if you expect users to pick particularly large files and your app does not need immediate read access.
   - **multiple (_boolean_)** -- (Web Only) Allows multiple files to be selected from the system UI. Defaults to `false`.
 
 #### Returns

--- a/docs/pages/versions/v37.0.0/sdk/facebook.md
+++ b/docs/pages/versions/v37.0.0/sdk/facebook.md
@@ -22,7 +22,7 @@ For ejected (see: [bare](../../../introduction/managed-vs-bare.md)) apps, here a
 
 > 💡 When following these steps you will find on the Facebook Developer site that there are many fields and steps that you don't actually care about. Just look for the information that we ask you for and you will be OK!
 
-Follow [Facebook's developer documentation](https://developers.facebook.com/docs/apps/register) to register an application with Facebook's API and get an application ID. Take note of this application ID because it will be used as the `appId` option in your [`Facebook.logInWithReadPermissionsAsync`](#expofacebookloginwithreadpermissionsasync 'Facebook.logInWithReadPermissionsAsync') call.
+Follow [Facebook's developer documentation](https://developers.facebook.com/docs/apps/register) to register an application with Facebook's API and get an application ID. Take note of this application ID because it will be used as the `appId` option in your [`Facebook.logInWithReadPermissionsAsync`](#facebookloginwithreadpermissionsasyncoptions 'Facebook.logInWithReadPermissionsAsync') call.
 
 Then follow these steps based on the platforms you're targetting. This will need to be done from the [Facebook developer site](https://developers.facebook.com/). You don't need to set up the iOS and Android standalone apps right away, you can do that at any time in the future if you just want to get the Expo client version running first.
 

--- a/docs/pages/versions/v37.0.0/sdk/facebook.md
+++ b/docs/pages/versions/v37.0.0/sdk/facebook.md
@@ -52,7 +52,7 @@ Then follow these steps based on the platforms you're targetting. This will need
 
 #### Android standalone app
 
-- [Build your standalone app](../../../distribution/building-standalone-apps.md#building-standalone-apps) for Android.
+- [Build your standalone app](../../../distribution/building-standalone-apps.md) for Android.
 - Run `expo fetch:android:hashes`.
 - Copy `Facebook Key Hash` and paste it as a key hash in your Facebook developer page pictured below.
 

--- a/docs/pages/versions/v37.0.0/sdk/gl-view.md
+++ b/docs/pages/versions/v37.0.0/sdk/gl-view.md
@@ -36,7 +36,7 @@ A function that will be called when the OpenGL ES context is created. The functi
 
 ### `takeSnapshotAsync(options)`
 
-Same as [GLView.takeSnapshotAsync](#expoglviewtakesnapshotasyncgl-options) but uses WebGL context that is associated with the view on which the method is called.
+Same as [GLView.takeSnapshotAsync](#glviewtakesnapshotasyncgl-options) but uses WebGL context that is associated with the view on which the method is called.
 
 ## Static methods
 

--- a/docs/pages/versions/v37.0.0/sdk/google-sign-in.md
+++ b/docs/pages/versions/v37.0.0/sdk/google-sign-in.md
@@ -169,7 +169,7 @@ Returns true after the user successfully updates.
 
 Configures how the `GoogleSignIn` module will attempt to sign in. You can call this method multiple times.
 
-See all the available options under the [`GoogleSignInOptions`](#googlesigninerrors) type.
+See all the available options under the [`GoogleSignInOptions`](#types) type.
 
 ### `GoogleSignIn.isSignedInAsync()`
 

--- a/docs/pages/versions/v37.0.0/sdk/google-sign-in.md
+++ b/docs/pages/versions/v37.0.0/sdk/google-sign-in.md
@@ -169,7 +169,7 @@ Returns true after the user successfully updates.
 
 Configures how the `GoogleSignIn` module will attempt to sign in. You can call this method multiple times.
 
-See all the available options under the [`GoogleSignInOptions`](#googlesigninoptions) type.
+See all the available options under the [`GoogleSignInOptions`](#googlesigninerrors) type.
 
 ### `GoogleSignIn.isSignedInAsync()`
 

--- a/docs/pages/versions/v37.0.0/sdk/intent-launcher.md
+++ b/docs/pages/versions/v37.0.0/sdk/intent-launcher.md
@@ -38,11 +38,11 @@ Starts the specified activity. The method will return a promise which resolves w
 #### Arguments
 
 - **activityAction (_string_)** -- The action to be performed, e.g. `IntentLauncher.ACTION_WIRELESS_SETTINGS`. There are a few pre-defined constants you can use for this parameter. You can find them at [expo-intent-launcher/src/IntentLauncher.ts](https://github.com/expo/expo/blob/master/packages/expo-intent-launcher/src/IntentLauncher.ts). **Required**
-- **intentParams ([`IntentLauncherParams`](#typeintentlauncherparams))** -- An object of intent parameters.
+- **intentParams ([`IntentLauncherParams`](#intentlauncherparams))** -- An object of intent parameters.
 
 #### Returns
 
-A promise resolving to an object of type [IntentLauncherResult](#typeintentlauncherresult).
+A promise resolving to an object of type [IntentLauncherResult](#intentlauncherresult).
 
 ## Types
 
@@ -62,7 +62,7 @@ A promise resolving to an object of type [IntentLauncherResult](#typeintentlaunc
 
 | Key        |  Type  | Description                                                                               |
 | ---------- | :----: | ----------------------------------------------------------------------------------------- |
-| resultCode | number | Result code returned by the activity. See [ResultCode](#enumresultcode) for more details. |
+| resultCode | number | Result code returned by the activity. See [ResultCode](#resultcode) for more details. |
 | data       | string | Optional data URI that can be returned by the activity.                                   |
 | extra      | object | Optional extras object that can be returned by the activity.                              |
 

--- a/docs/pages/versions/v37.0.0/sdk/location.md
+++ b/docs/pages/versions/v37.0.0/sdk/location.md
@@ -379,7 +379,7 @@ A promise resolving as soon as the task is registered.
 Geofencing task will be receiving following data:
 
 - **eventType : [Location.GeofencingEventType](#locationgeofencingeventtype)** -- Indicates the reason for calling the task, which can be triggered by entering or exiting the region. See [Location.GeofencingEventType](#locationgeofencingeventtype).
-- **region : [LocationRegion](#type-location-region)** -- Object containing details about updated region. See [LocationRegion](#type-region) for more details.
+- **region : [LocationRegion](#locationregion)** -- Object containing details about updated region. See [LocationRegion](#type-region) for more details.
 
 ```javascript
 import * as Location from 'expo-location';

--- a/docs/pages/versions/v37.0.0/sdk/media-library.md
+++ b/docs/pages/versions/v37.0.0/sdk/media-library.md
@@ -80,10 +80,10 @@ Fetches a page of assets matching the provided criteria.
   - **first (_number_)** -- The maximum number of items on a single page. Defaults to 20.
   - **after (_string_)** -- Asset ID of the last item returned on the previous page.
   - **album (_string_ | _Album_)** -- [Album](#album) or its ID to get assets from specific album.
-  - **sortBy (_array_)** -- An array of [SortBy](#expomedialibrarysortby) keys. By default, all keys are sorted in descending order, however you can also pass a pair `[key, ascending]` where the second item is a `boolean` value that means whether to use ascending order. Note that if the `SortBy.default` key is used, then `ascending` argument will not matter.
+  - **sortBy (_array_)** -- An array of [SortBy](#medialibrarysortby) keys. By default, all keys are sorted in descending order, however you can also pass a pair `[key, ascending]` where the second item is a `boolean` value that means whether to use ascending order. Note that if the `SortBy.default` key is used, then `ascending` argument will not matter.
     Earlier items have higher priority when sorting out the results.
     If empty, this method will use the default sorting that is provided by the platform.
-  - **mediaType (_array_)** -- An array of [MediaType](#expomedialibrarymediatype) types. By default `MediaType.photo` is set.
+  - **mediaType (_array_)** -- An array of [MediaType](#medialibrarymediatype) types. By default `MediaType.photo` is set.
   - **createdAfter (_Date_ | _number_)** -- Date object or Unix timestamp in milliseconds limiting returned assets only to those that were created after this date.
   - **createdBefore (_Date_ | _number_)** -- Similarly as `createdAfter`, but limits assets only to those that were created before specified date.
 
@@ -183,7 +183,7 @@ In case they're copied you should keep in mind that `getAssetsAsync` will return
 
 #### Arguments
 
-- **assets (_array_)** -- Array of [assets](#assets) to add.
+- **assets (_array_)** -- Array of [assets](#asset) to add.
 - **album (_string_ | _Album_)** -- [Album](#album) or its ID, to which the assets will be added.
 - **copyAssets (_boolean_)** -- Whether to copy assets to the new album instead of move them. Defaults to `true`. (**Android only**)
 
@@ -199,7 +199,7 @@ On Android, album will be automatically deleted if there are no more assets insi
 
 #### Arguments
 
-- **assets (_array_)** -- Array of [assets](#assets) to remove from album.
+- **assets (_array_)** -- Array of [assets](#asset) to remove from album.
 - **album (_string_ | _Album_)** -- [Album](#album) or its ID, from which the assets will be removed.
 
 #### Returns
@@ -221,8 +221,8 @@ Subscribes for updates in user's media library.
 #### Arguments
 
 - **listener (_function_)** -- A callback that is called when any assets have been inserted or deleted from the library. **On Android** it's invoked with an empty object. **On iOS** it's invoked with an object that contains following keys:
-  - **insertedAssets (_array_)** -- Array of [assets](#assets) that have been inserted to the library.
-  - **deletedAssets (_array_)** -- Array of [assets](#assets) that have been deleted from the library.
+  - **insertedAssets (_array_)** -- Array of [assets](#asset) that have been inserted to the library.
+  - **deletedAssets (_array_)** -- Array of [assets](#asset) that have been deleted from the library.
 
 #### Returns
 

--- a/docs/pages/versions/v37.0.0/sdk/print.md
+++ b/docs/pages/versions/v37.0.0/sdk/print.md
@@ -41,7 +41,7 @@ Prints a document or HTML, on web this prints the HTML from the page.
 
 ### `Print.printToFileAsync(options)`
 
-Prints HTML to PDF file and saves it to [app's cache directory](filesystem.md#expofilesystemcachedirectory). On web this method opens the print dialog.
+Prints HTML to PDF file and saves it to [app's cache directory](filesystem.md#filesystemcachedirectory). On web this method opens the print dialog.
 
 #### Arguments
 

--- a/docs/pages/versions/v37.0.0/sdk/sqlite.md
+++ b/docs/pages/versions/v37.0.0/sdk/sqlite.md
@@ -98,7 +98,7 @@ A `Transaction` object is passed in as a parameter to the `callback` parameter f
 In order to open a new SQLite database using an existing `.db` file you already have, you need to do three things:
 
 - `expo install expo-file-system expo-asset @expo/metro-config`
-- create a `metro.config.js` file in the root of your project with the following contents ([curious why? read here](../../../guides/customizing-metro.md#adding-more-file-extensions-to--assetexts)):
+- create a `metro.config.js` file in the root of your project with the following contents ([curious why? read here](../../../guides/customizing-metro.md#adding-more-file-extensions-to-assetexts)):
 
 ```ts
 const { getDefaultConfig } = require('@expo/metro-config');

--- a/docs/pages/versions/v37.0.0/sdk/task-manager.md
+++ b/docs/pages/versions/v37.0.0/sdk/task-manager.md
@@ -129,7 +129,7 @@ Example:
 ### `TaskManager.unregisterTaskAsync(taskName)`
 
 Unregisters task from the app, so the app will not be receiving updates for that task anymore.
-_It is recommended to use methods specialized by modules that registered the task, eg. [Location.stopLocationUpdatesAsync](location.md#expolocationstoplocationupdatesasynctaskname)._
+_It is recommended to use methods specialized by modules that registered the task, eg. [Location.stopLocationUpdatesAsync](location.md#locationstoplocationupdatesasynctaskname)._
 
 #### Arguments
 

--- a/docs/pages/versions/v37.0.0/sdk/webbrowser.md
+++ b/docs/pages/versions/v37.0.0/sdk/webbrowser.md
@@ -99,7 +99,7 @@ This will be done using a "custom Chrome tabs" browser, [AppState][d-appstate], 
 
 **On web:**
 
-> 🚨 This API can only be used in a secure environment (`https`). You can use `expo start:web --https` to test this. Otherwise an error with code [`ERR_WEB_BROWSER_CRYPTO`](#errwebbrowsercrypto) will be thrown.
+> 🚨 This API can only be used in a secure environment (`https`). You can use `expo start:web --https` to test this. Otherwise an error with code [`ERR_WEB_BROWSER_CRYPTO`](#err_web_browser_crypto) will be thrown.
 
 This will use the browser's [`window.open()`][d-windowopen] API.
 
@@ -113,7 +113,7 @@ How this works on web:
 - The state will be added to the window's `localstorage`. This ensures that auth cannot complete unless it's done from a page running with the same origin as it was started. Ex: if `openAuthSessionAsync` is invoked on `https://localhost:19006`, then `maybeCompleteAuthSession` must be invoked on a page hosted from the origin `https://localhost:19006`. Using a different website, or even a different host like `https://128.0.0.*:19006` for example will not work.
 - A timer will be started to check for every 1000 milliseconds (1 second) to detect if the window has been closed by the user. If this happens then a promise will resolve with `{ type: 'dismiss' }`.
 
-🚨 On mobile web, Chrome and Safari will block any call to [`window.open()`][d-windowopen] which takes too long to fire after a user interaction. This method must be invoked immediately after a user interaction. If the event is blocked, an error with code [`ERR_WEB_BROWSER_BLOCKED`](#errwebbrowserblocked) will be thrown.
+🚨 On mobile web, Chrome and Safari will block any call to [`window.open()`][d-windowopen] which takes too long to fire after a user interaction. This method must be invoked immediately after a user interaction. If the event is blocked, an error with code [`ERR_WEB_BROWSER_BLOCKED`](#err_web_browser_blocked) will be thrown.
 
 [d-windowopen]: https://developer.mozilla.org/en-US/docs/Web/API/Window/open
 [d-appstate]: https://docs.expo.io/versions/latest/react-native/appstate/
@@ -133,9 +133,9 @@ Returns a Promise:
 
 #### Error Codes
 
-- [`ERR_WEB_BROWSER_REDIRECT`](#errwebbrowserredirect)
-- [`ERR_WEB_BROWSER_BLOCKED`](#errwebbrowserblocked)
-- [`ERR_WEB_BROWSER_CRYPTO`](#errwebbrowsercrypto)
+- [`ERR_WEB_BROWSER_REDIRECT`](#err_web_browser_redirect)
+- [`ERR_WEB_BROWSER_BLOCKED`](#err_web_browser_blocked)
+- [`ERR_WEB_BROWSER_CRYPTO`](#err_web_browser_crypto)
 
 ### `WebBrowser.maybeCompleteAuthSession(options)`
 
@@ -190,7 +190,7 @@ The promise resolves with `{ package: string }`.
 
 _Android only_
 
-This methods removes all bindings to services created by [`warmUpAsync`](#webbrowserwarmupasyncnbrowserpackage) or [`mayInitWithUrlAsync`](#webbrowseramayinitwithurlsyncurl-package). You should call this method once you don't need them to avoid potential memory leaks. However, those binding would be cleared once your application is destroyed, which might be sufficient in most cases.
+This methods removes all bindings to services created by [`warmUpAsync`](#webbrowserwarmupasyncbrowserpackage) or [`mayInitWithUrlAsync`](#webbrowsermayinitwithurlasyncurl-package). You should call this method once you don't need them to avoid potential memory leaks. However, those binding would be cleared once your application is destroyed, which might be sufficient in most cases.
 
 #### Arguments
 
@@ -222,10 +222,10 @@ The promise resolves with `{ browserPackages: string[], defaultBrowserPackage: s
 
 - **browserPackages (_string[]_)** : All packages recognized by `PackageManager` as capable of handling Custom Tabs. Empty array means there is no supporting browsers on device.
 - **defaultBrowserPackage (_string_ | null)** : Default package chosen by user. Null if there is no such packages. Null usually means, that user will be prompted to choose from available packages.
-- **servicePackages (_string[]_)** : All packages recognized by `PackageManager` as capable of handling Custom Tabs Service. This service is used by [`warmUpAsync`](#webbrowserwarmupasyncnbrowserpackage), [`mayInitWithUrlAsync`](#webbrowsermayinitwithurlasyncurl-package) and [`coolDownAsync`](#webbrowsercooldownasyncbrowserpackage).
+- **servicePackages (_string[]_)** : All packages recognized by `PackageManager` as capable of handling Custom Tabs Service. This service is used by [`warmUpAsync`](#webbrowserwarmupasyncbrowserpackage), [`mayInitWithUrlAsync`](#webbrowsermayinitwithurlasyncurl-package) and [`coolDownAsync`](#webbrowsercooldownasyncbrowserpackage).
 - **preferredBrowserPackage (_string_ | null)** : Package preferred by `CustomTabsClient` to be used to handle Custom Tabs. It favors browser chosen by user as default, as long as it is present on both `browserPackages` and `servicePackages` lists. Only such browsers are considered as fully supporting Custom Tabs. It might be `null` when there is no such browser installed or when default browser is not in `servicePackages` list.
 
-In general, services are used to perform background tasks. If a browser is available in `servicePackage` list, it should be capable of performing [`warmUpAsync`](#webbrowserwarmupasyncnbrowserpackage), [`mayInitWithUrlAsync`](#webbrowsermayinitwithurlasyncurl-package) and [`coolDownAsync`](#webbrowsercooldownasyncbrowserpackage). For opening an actual web page, browser must be in `browserPackages` list. A browser has to be present in both lists to be considered as fully supporting Custom Tabs.
+In general, services are used to perform background tasks. If a browser is available in `servicePackage` list, it should be capable of performing [`warmUpAsync`](#webbrowserwarmupasyncbrowserpackage), [`mayInitWithUrlAsync`](#webbrowsermayinitwithurlasyncurl-package) and [`coolDownAsync`](#webbrowsercooldownasyncbrowserpackage). For opening an actual web page, browser must be in `browserPackages` list. A browser has to be present in both lists to be considered as fully supporting Custom Tabs.
 
 ## Error Codes
 

--- a/docs/pages/versions/v38.0.0/sdk/amplitude.md
+++ b/docs/pages/versions/v38.0.0/sdk/amplitude.md
@@ -60,7 +60,7 @@ Set properties for the current user. See [here for details](https://amplitude.ze
 
 ### `Amplitude.clearUserProperties()`
 
-Clear properties set by [`Amplitude.setUserProperties()`](#expoamplitudesetuserproperties 'Amplitude.setUserProperties').
+Clear properties set by [`Amplitude.setUserProperties()`](#amplitudeclearuserproperties 'Amplitude.setUserProperties').
 
 ### `Amplitude.logEvent(eventName)`
 

--- a/docs/pages/versions/v38.0.0/sdk/brightness.md
+++ b/docs/pages/versions/v38.0.0/sdk/brightness.md
@@ -100,7 +100,7 @@ A `Promise` that is resolved when the brightness has been successfully set.
 
 #### Error Codes
 
-- [`ERR_BRIGHTNESS`](#errbrightness)
+- [`ERR_BRIGHTNESS`](#err_brightness)
 
 ---
 
@@ -124,7 +124,7 @@ A `Promise` that resolves with `true` when the current activity is using the sys
 
 #### Error Codes
 
-- [`ERR_BRIGHTNESS`](#errbrightness)
+- [`ERR_BRIGHTNESS`](#err_brightness)
 
 ---
 
@@ -138,7 +138,7 @@ A `Promise` that is resolved with a number between 0 and 1, inclusive, represent
 
 #### Error Codes
 
-- [`ERR_BRIGHTNESS_SYSTEM`](#errbrightnesssystem)
+- [`ERR_BRIGHTNESS_SYSTEM`](#err_brightness_system)
 
 ---
 
@@ -158,8 +158,8 @@ A `Promise` that is resolved when the brightness has been successfully set.
 
 #### Error Codes
 
-- [`ERR_BRIGHTNESS_MODE`](#errbrightnessmode)
-- [`ERR_BRIGHTNESS_PERMISSIONS_DENIED`](#errbrightnesspermissionsdenied)
+- [`ERR_BRIGHTNESS_MODE`](#err_brightness_mode)
+- [`ERR_BRIGHTNESS_PERMISSIONS_DENIED`](#err_brightness_permissions_denied)
 
 ### `Brightness.getSystemBrightnessModeAsync()`
 
@@ -171,7 +171,7 @@ A `Promise` that is resolved with a [`BrightnessMode`](#brightnessbrightnessmode
 
 #### Error Codes
 
-- [`ERR_BRIGHTNESS_MODE`](#errbrightnessmode)
+- [`ERR_BRIGHTNESS_MODE`](#err_brightness_mode)
 
 ---
 
@@ -189,9 +189,9 @@ A `Promise` that is resolved when the brightness mode has been successfully set.
 
 #### Error Codes
 
-- [`ERR_INVALID_ARGUMENT`](#errinvalidargument)
-- [`ERR_BRIGHTNESS_MODE`](#errbrightnessmode)
-- [`ERR_BRIGHTNESS_PERMISSIONS_DENIED`](#errbrightnesspermissionsdenied)
+- [`ERR_INVALID_ARGUMENT`](#err_invalid_argument)
+- [`ERR_BRIGHTNESS_MODE`](#err_brightness_mode)
+- [`ERR_BRIGHTNESS_PERMISSIONS_DENIED`](#err_brightness_permissions_denied)
 
 ## Enum Types
 

--- a/docs/pages/versions/v38.0.0/sdk/constants.md
+++ b/docs/pages/versions/v38.0.0/sdk/constants.md
@@ -24,7 +24,7 @@ import Constants from 'expo-constants';
 
 ### `Constants.appOwnership`
 
-Returns `expo`, `standalone`, or `guest`. If `expo`, the experience is running inside of the Expo client. If `standalone`, it is a [standalone app](../../../distribution/building-standalone-apps.md#building-standalone-apps). If `guest`, it has been opened through a link from a standalone app.
+Returns `expo`, `standalone`, or `guest`. If `expo`, the experience is running inside of the Expo client. If `standalone`, it is a [standalone app](../../../distribution/building-standalone-apps.md). If `guest`, it has been opened through a link from a standalone app.
 
 ### `Constants.deviceName`
 

--- a/docs/pages/versions/v38.0.0/sdk/document-picker.md
+++ b/docs/pages/versions/v38.0.0/sdk/document-picker.md
@@ -37,7 +37,7 @@ import * as DocumentPicker from 'expo-document-picker';
 
 ### `DocumentPicker.getDocumentAsync(options)`
 
-Display the system UI for choosing a document. By default, the chosen file is copied to [the app's internal cache directory](filesystem.md#expofilesystemcachedirectory).
+Display the system UI for choosing a document. By default, the chosen file is copied to [the app's internal cache directory](filesystem.md#filesystemcachedirectory).
 
 > **Note for Web:** The system UI can only be shown after user activation (e.g. a `Button` press). Therefore, calling `getDocumentAsync` in `componentDidMount`, for example, will **not** work as intended.
 
@@ -48,7 +48,7 @@ Display the system UI for choosing a document. By default, the chosen file is co
   A map of options:
 
   - **type (_string_)** -- The [MIME type](https://en.wikipedia.org/wiki/Media_type) of the documents that are available to be picked. Is also supports wildcards like `image/*` to choose any image. To allow any type of document you can use `*/*`. Defaults to `*/*`.
-  - **copyToCacheDirectory (_boolean_)** -- If `true`, the picked file is copied to [`FileSystem.CacheDirectory`](filesystem.md#expofilesystemcachedirectory), which allows other Expo APIs to read the file immediately. Defaults to `true`. This may impact performance for large files, so you should consider setting this to `false` if you expect users to pick particularly large files and your app does not need immediate read access.
+  - **copyToCacheDirectory (_boolean_)** -- If `true`, the picked file is copied to [`FileSystem.CacheDirectory`](filesystem.md#filesystemcachedirectory), which allows other Expo APIs to read the file immediately. Defaults to `true`. This may impact performance for large files, so you should consider setting this to `false` if you expect users to pick particularly large files and your app does not need immediate read access.
   - **multiple (_boolean_)** -- (Web Only) Allows multiple files to be selected from the system UI. Defaults to `false`.
 
 #### Returns

--- a/docs/pages/versions/v38.0.0/sdk/facebook.md
+++ b/docs/pages/versions/v38.0.0/sdk/facebook.md
@@ -52,7 +52,7 @@ The Android Play Store Expo client will use the Facebook App ID that you provide
 
 #### Android standalone app
 
-- [Build your standalone app](../../../distribution/building-standalone-apps.md#building-standalone-apps) for Android.
+- [Build your standalone app](../../../distribution/building-standalone-apps.md) for Android.
 - Run `expo fetch:android:hashes`.
 - Copy `Facebook Key Hash` and paste it as a key hash in your Facebook developer page pictured below.
 

--- a/docs/pages/versions/v38.0.0/sdk/facebook.md
+++ b/docs/pages/versions/v38.0.0/sdk/facebook.md
@@ -22,7 +22,7 @@ For ejected (see: [ExpoKit](../../../expokit/overview.md)) apps, here are links 
 
 > 💡 When following these steps you will find on the Facebook Developer site that there are many fields and steps that you don't actually care about. Just look for the information that we ask you for and you will be OK!
 
-Follow [Facebook's developer documentation](https://developers.facebook.com/docs/apps/register) to register an application with Facebook's API and get an application ID. Take note of this application ID because it will be used as the `appId` option in your [`Facebook.logInWithReadPermissionsAsync`](#expofacebookloginwithreadpermissionsasync 'Facebook.logInWithReadPermissionsAsync') call.
+Follow [Facebook's developer documentation](https://developers.facebook.com/docs/apps/register) to register an application with Facebook's API and get an application ID. Take note of this application ID because it will be used as the `appId` option in your [`Facebook.logInWithReadPermissionsAsync`](#facebookloginwithreadpermissionsasyncoptions 'Facebook.logInWithReadPermissionsAsync') call.
 
 Then follow these steps based on the platforms you're targetting. This will need to be done from the [Facebook developer site](https://developers.facebook.com/).
 

--- a/docs/pages/versions/v38.0.0/sdk/google-sign-in.md
+++ b/docs/pages/versions/v38.0.0/sdk/google-sign-in.md
@@ -169,7 +169,7 @@ Returns true after the user successfully updates.
 
 Configures how the `GoogleSignIn` module will attempt to sign in. You can call this method multiple times.
 
-See all the available options under the [`GoogleSignInOptions`](#googlesigninerrors) type.
+See all the available options under the [`GoogleSignInOptions`](#types) type.
 
 ### `GoogleSignIn.isSignedInAsync()`
 

--- a/docs/pages/versions/v38.0.0/sdk/google-sign-in.md
+++ b/docs/pages/versions/v38.0.0/sdk/google-sign-in.md
@@ -169,7 +169,7 @@ Returns true after the user successfully updates.
 
 Configures how the `GoogleSignIn` module will attempt to sign in. You can call this method multiple times.
 
-See all the available options under the [`GoogleSignInOptions`](#googlesigninoptions) type.
+See all the available options under the [`GoogleSignInOptions`](#googlesigninerrors) type.
 
 ### `GoogleSignIn.isSignedInAsync()`
 

--- a/docs/pages/versions/v38.0.0/sdk/intent-launcher.md
+++ b/docs/pages/versions/v38.0.0/sdk/intent-launcher.md
@@ -38,11 +38,11 @@ Starts the specified activity. The method will return a promise which resolves w
 #### Arguments
 
 - **activityAction (_string_)** -- The action to be performed, e.g. `IntentLauncher.ACTION_WIRELESS_SETTINGS`. There are a few pre-defined constants you can use for this parameter. You can find them at [expo-intent-launcher/src/IntentLauncher.ts](https://github.com/expo/expo/blob/master/packages/expo-intent-launcher/src/IntentLauncher.ts). **Required**
-- **intentParams ([`IntentLauncherParams`](#typeintentlauncherparams))** -- An object of intent parameters.
+- **intentParams ([`IntentLauncherParams`](#intentlauncherparams))** -- An object of intent parameters.
 
 #### Returns
 
-A promise resolving to an object of type [IntentLauncherResult](#typeintentlauncherresult).
+A promise resolving to an object of type [IntentLauncherResult](#intentlauncherresult).
 
 ## Types
 
@@ -62,7 +62,7 @@ A promise resolving to an object of type [IntentLauncherResult](#typeintentlaunc
 
 | Key        |  Type  | Description                                                                               |
 | ---------- | :----: | ----------------------------------------------------------------------------------------- |
-| resultCode | number | Result code returned by the activity. See [ResultCode](#enumresultcode) for more details. |
+| resultCode | number | Result code returned by the activity. See [ResultCode](#resultcode) for more details. |
 | data       | string | Optional data URI that can be returned by the activity.                                   |
 | extra      | object | Optional extras object that can be returned by the activity.                              |
 

--- a/docs/pages/versions/v38.0.0/sdk/location.md
+++ b/docs/pages/versions/v38.0.0/sdk/location.md
@@ -379,7 +379,7 @@ A promise resolving as soon as the task is registered.
 Geofencing task will be receiving following data:
 
 - **eventType : [Location.GeofencingEventType](#locationgeofencingeventtype)** -- Indicates the reason for calling the task, which can be triggered by entering or exiting the region. See [Location.GeofencingEventType](#locationgeofencingeventtype).
-- **region : [LocationRegion](#type-location-region)** -- Object containing details about updated region. See [LocationRegion](#type-region) for more details.
+- **region : [LocationRegion](#locationregion)** -- Object containing details about updated region. See [LocationRegion](#type-region) for more details.
 
 ```javascript
 import * as Location from 'expo-location';

--- a/docs/pages/versions/v38.0.0/sdk/media-library.md
+++ b/docs/pages/versions/v38.0.0/sdk/media-library.md
@@ -80,10 +80,10 @@ Fetches a page of assets matching the provided criteria.
   - **first (_number_)** -- The maximum number of items on a single page. Defaults to 20.
   - **after (_string_)** -- Asset ID of the last item returned on the previous page.
   - **album (_string_ | _Album_)** -- [Album](#album) or its ID to get assets from specific album.
-  - **sortBy (_array_)** -- An array of [SortBy](#expomedialibrarysortby) keys. By default, all keys are sorted in descending order, however you can also pass a pair `[key, ascending]` where the second item is a `boolean` value that means whether to use ascending order. Note that if the `SortBy.default` key is used, then `ascending` argument will not matter.
+  - **sortBy (_array_)** -- An array of [SortBy](#medialibrarysortby) keys. By default, all keys are sorted in descending order, however you can also pass a pair `[key, ascending]` where the second item is a `boolean` value that means whether to use ascending order. Note that if the `SortBy.default` key is used, then `ascending` argument will not matter.
     Earlier items have higher priority when sorting out the results.
     If empty, this method will use the default sorting that is provided by the platform.
-  - **mediaType (_array_)** -- An array of [MediaType](#expomedialibrarymediatype) types. By default `MediaType.photo` is set.
+  - **mediaType (_array_)** -- An array of [MediaType](#medialibrarymediatype) types. By default `MediaType.photo` is set.
   - **createdAfter (_Date_ | _number_)** -- Date object or Unix timestamp in milliseconds limiting returned assets only to those that were created after this date.
   - **createdBefore (_Date_ | _number_)** -- Similarly as `createdAfter`, but limits assets only to those that were created before specified date.
 
@@ -183,7 +183,7 @@ In case they're copied you should keep in mind that `getAssetsAsync` will return
 
 #### Arguments
 
-- **assets (_array_)** -- Array of [assets](#assets) to add.
+- **assets (_array_)** -- Array of [assets](#asset) to add.
 - **album (_string_ | _Album_)** -- [Album](#album) or its ID, to which the assets will be added.
 - **copyAssets (_boolean_)** -- Whether to copy assets to the new album instead of move them. Defaults to `true`. (**Android only**)
 
@@ -199,7 +199,7 @@ On Android, album will be automatically deleted if there are no more assets insi
 
 #### Arguments
 
-- **assets (_array_)** -- Array of [assets](#assets) to remove from album.
+- **assets (_array_)** -- Array of [assets](#asset) to remove from album.
 - **album (_string_ | _Album_)** -- [Album](#album) or its ID, from which the assets will be removed.
 
 #### Returns
@@ -221,8 +221,8 @@ Subscribes for updates in user's media library.
 #### Arguments
 
 - **listener (_function_)** -- A callback that is called when any assets have been inserted or deleted from the library. **On Android** it's invoked with an empty object. **On iOS** it's invoked with an object that contains following keys:
-  - **insertedAssets (_array_)** -- Array of [assets](#assets) that have been inserted to the library.
-  - **deletedAssets (_array_)** -- Array of [assets](#assets) that have been deleted from the library.
+  - **insertedAssets (_array_)** -- Array of [assets](#asset) that have been inserted to the library.
+  - **deletedAssets (_array_)** -- Array of [assets](#asset) that have been deleted from the library.
 
 #### Returns
 

--- a/docs/pages/versions/v38.0.0/sdk/print.md
+++ b/docs/pages/versions/v38.0.0/sdk/print.md
@@ -41,7 +41,7 @@ Prints a document or HTML, on web this prints the HTML from the page.
 
 ### `Print.printToFileAsync(options)`
 
-Prints HTML to PDF file and saves it to [app's cache directory](filesystem.md#expofilesystemcachedirectory). On web this method opens the print dialog.
+Prints HTML to PDF file and saves it to [app's cache directory](filesystem.md#filesystemcachedirectory). On web this method opens the print dialog.
 
 #### Arguments
 

--- a/docs/pages/versions/v38.0.0/sdk/sqlite.md
+++ b/docs/pages/versions/v38.0.0/sdk/sqlite.md
@@ -98,7 +98,7 @@ A `Transaction` object is passed in as a parameter to the `callback` parameter f
 In order to open a new SQLite database using an existing `.db` file you already have, you need to do three things:
 
 - `expo install expo-file-system expo-asset @expo/metro-config`
-- create a `metro.config.js` file in the root of your project with the following contents ([curious why? read here](../../../guides/customizing-metro.md#adding-more-file-extensions-to--assetexts)):
+- create a `metro.config.js` file in the root of your project with the following contents ([curious why? read here](../../../guides/customizing-metro.md#adding-more-file-extensions-to-assetexts)):
 
 ```ts
 const { getDefaultConfig } = require('@expo/metro-config');

--- a/docs/pages/versions/v38.0.0/sdk/task-manager.md
+++ b/docs/pages/versions/v38.0.0/sdk/task-manager.md
@@ -129,7 +129,7 @@ Example:
 ### `TaskManager.unregisterTaskAsync(taskName)`
 
 Unregisters task from the app, so the app will not be receiving updates for that task anymore.
-_It is recommended to use methods specialized by modules that registered the task, eg. [Location.stopLocationUpdatesAsync](location.md#expolocationstoplocationupdatesasynctaskname)._
+_It is recommended to use methods specialized by modules that registered the task, eg. [Location.stopLocationUpdatesAsync](location.md#locationstoplocationupdatesasynctaskname)._
 
 #### Arguments
 

--- a/docs/pages/versions/v38.0.0/sdk/webbrowser.md
+++ b/docs/pages/versions/v38.0.0/sdk/webbrowser.md
@@ -71,7 +71,7 @@ Opens the url with Safari in a modal on iOS using [`SFSafariViewController`](htt
   - **dismissButtonStyle (_optional_) (_string_)** -- (_iOS only_) The style of the dismiss button. Should be one of: `done`, `close`, or `cancel`.
   - **enableBarCollapsing (_optional_) (_boolean_)** -- a boolean determining whether the toolbar should be hiding when a user scrolls the website.
   - **enableDefaultShare (_optional_) (_boolean_)** -- (_Android only_) a boolean determining whether a default share item should be added to the menu.
-  - **package (_optional_) (_string_)** -- (_Android only_). Package name of a browser to be used to handle Custom Tabs. List of available packages is to be queried by [getCustomTabsSupportingBrowsers](#webbrowsergetcustomtabssupportingbrowsers) method.
+  - **package (_optional_) (_string_)** -- (_Android only_). Package name of a browser to be used to handle Custom Tabs. List of available packages is to be queried by [getCustomTabsSupportingBrowsers](#webbrowsergetcustomtabssupportingbrowsersasync) method.
   - **readerMode (_optional_) (_boolean_)** -- (_iOS only_) a boolean determining whether Safari should enter Reader mode, if it is available.
   - **showInRecents (_optional_) (_boolean_)** -- (_Android only_) a boolean determining whether browsed website should be shown as separate entry in Android recents/multitasking view. Default: `false`
   - **showTitle (_optional_) (_boolean_)** -- (_Android only_) a boolean determining whether the browser should show the title of website on the toolbar.
@@ -102,7 +102,7 @@ This will be done using a "custom Chrome tabs" browser, [AppState][d-appstate], 
 
 **On web:**
 
-> 🚨 This API can only be used in a secure environment (`https`). You can use `expo start:web --https` to test this. Otherwise an error with code [`ERR_WEB_BROWSER_CRYPTO`](#errwebbrowsercrypto) will be thrown.
+> 🚨 This API can only be used in a secure environment (`https`). You can use `expo start:web --https` to test this. Otherwise an error with code [`ERR_WEB_BROWSER_CRYPTO`](#err_web_browser_crypto) will be thrown.
 
 This will use the browser's [`window.open()`][d-windowopen] API.
 
@@ -116,7 +116,7 @@ How this works on web:
 - The state will be added to the window's `localstorage`. This ensures that auth cannot complete unless it's done from a page running with the same origin as it was started. Ex: if `openAuthSessionAsync` is invoked on `https://localhost:19006`, then `maybeCompleteAuthSession` must be invoked on a page hosted from the origin `https://localhost:19006`. Using a different website, or even a different host like `https://128.0.0.*:19006` for example will not work.
 - A timer will be started to check for every 1000 milliseconds (1 second) to detect if the window has been closed by the user. If this happens then a promise will resolve with `{ type: 'dismiss' }`.
 
-🚨 On mobile web, Chrome and Safari will block any call to [`window.open()`][d-windowopen] which takes too long to fire after a user interaction. This method must be invoked immediately after a user interaction. If the event is blocked, an error with code [`ERR_WEB_BROWSER_BLOCKED`](#errwebbrowserblocked) will be thrown.
+🚨 On mobile web, Chrome and Safari will block any call to [`window.open()`][d-windowopen] which takes too long to fire after a user interaction. This method must be invoked immediately after a user interaction. If the event is blocked, an error with code [`ERR_WEB_BROWSER_BLOCKED`](#err_web_browser_blocked) will be thrown.
 
 [d-windowopen]: https://developer.mozilla.org/en-US/docs/Web/API/Window/open
 [d-appstate]: https://docs.expo.io/versions/latest/react-native/appstate/
@@ -136,9 +136,9 @@ Returns a Promise:
 
 #### Error Codes
 
-- [`ERR_WEB_BROWSER_REDIRECT`](#errwebbrowserredirect)
-- [`ERR_WEB_BROWSER_BLOCKED`](#errwebbrowserblocked)
-- [`ERR_WEB_BROWSER_CRYPTO`](#errwebbrowsercrypto)
+- [`ERR_WEB_BROWSER_REDIRECT`](#err_web_browser_redirect)
+- [`ERR_WEB_BROWSER_BLOCKED`](#err_web_browser_blocked)
+- [`ERR_WEB_BROWSER_CRYPTO`](#err_web_browser_crypto)
 
 ### `WebBrowser.maybeCompleteAuthSession(options)`
 
@@ -193,7 +193,7 @@ The promise resolves with `{ package: string }`.
 
 _Android only_
 
-This methods removes all bindings to services created by [`warmUpAsync`](#webbrowserwarmupasyncnbrowserpackage) or [`mayInitWithUrlAsync`](#webbrowseramayinitwithurlsyncurl-package). You should call this method once you don't need them to avoid potential memory leaks. However, those binding would be cleared once your application is destroyed, which might be sufficient in most cases.
+This methods removes all bindings to services created by [`warmUpAsync`](#webbrowserwarmupasyncbrowserpackage) or [`mayInitWithUrlAsync`](#webbrowsermayinitwithurlasyncurl-package). You should call this method once you don't need them to avoid potential memory leaks. However, those binding would be cleared once your application is destroyed, which might be sufficient in most cases.
 
 #### Arguments
 
@@ -225,10 +225,10 @@ The promise resolves with `{ browserPackages: string[], defaultBrowserPackage: s
 
 - **browserPackages (_string[]_)** : All packages recognized by `PackageManager` as capable of handling Custom Tabs. Empty array means there is no supporting browsers on device.
 - **defaultBrowserPackage (_string_ | null)** : Default package chosen by user. Null if there is no such packages. Null usually means, that user will be prompted to choose from available packages.
-- **servicePackages (_string[]_)** : All packages recognized by `PackageManager` as capable of handling Custom Tabs Service. This service is used by [`warmUpAsync`](#webbrowserwarmupasyncnbrowserpackage), [`mayInitWithUrlAsync`](#webbrowsermayinitwithurlasyncurl-package) and [`coolDownAsync`](#webbrowsercooldownasyncbrowserpackage).
+- **servicePackages (_string[]_)** : All packages recognized by `PackageManager` as capable of handling Custom Tabs Service. This service is used by [`warmUpAsync`](#webbrowserwarmupasyncbrowserpackage), [`mayInitWithUrlAsync`](#webbrowsermayinitwithurlasyncurl-package) and [`coolDownAsync`](#webbrowsercooldownasyncbrowserpackage).
 - **preferredBrowserPackage (_string_ | null)** : Package preferred by `CustomTabsClient` to be used to handle Custom Tabs. It favors browser chosen by user as default, as long as it is present on both `browserPackages` and `servicePackages` lists. Only such browsers are considered as fully supporting Custom Tabs. It might be `null` when there is no such browser installed or when default browser is not in `servicePackages` list.
 
-In general, services are used to perform background tasks. If a browser is available in `servicePackage` list, it should be capable of performing [`warmUpAsync`](#webbrowserwarmupasyncnbrowserpackage), [`mayInitWithUrlAsync`](#webbrowsermayinitwithurlasyncurl-package) and [`coolDownAsync`](#webbrowsercooldownasyncbrowserpackage). For opening an actual web page, browser must be in `browserPackages` list. A browser has to be present in both lists to be considered as fully supporting Custom Tabs.
+In general, services are used to perform background tasks. If a browser is available in `servicePackage` list, it should be capable of performing [`warmUpAsync`](#webbrowserwarmupasyncbrowserpackage), [`mayInitWithUrlAsync`](#webbrowsermayinitwithurlasyncurl-package) and [`coolDownAsync`](#webbrowsercooldownasyncbrowserpackage). For opening an actual web page, browser must be in `browserPackages` list. A browser has to be present in both lists to be considered as fully supporting Custom Tabs.
 
 ## Error Codes
 

--- a/docs/pages/versions/v39.0.0/sdk/amplitude.md
+++ b/docs/pages/versions/v39.0.0/sdk/amplitude.md
@@ -60,7 +60,7 @@ Set properties for the current user. See [here for details](https://amplitude.ze
 
 ### `Amplitude.clearUserProperties()`
 
-Clear properties set by [`Amplitude.setUserProperties()`](#expoamplitudesetuserproperties 'Amplitude.setUserProperties').
+Clear properties set by [`Amplitude.setUserProperties()`](#amplitudeclearuserproperties 'Amplitude.setUserProperties').
 
 ### `Amplitude.logEvent(eventName)`
 

--- a/docs/pages/versions/v39.0.0/sdk/bar-code-scanner.md
+++ b/docs/pages/versions/v39.0.0/sdk/bar-code-scanner.md
@@ -168,7 +168,7 @@ Object of type `BarCodeScannerResult` contains following keys:
 
 - **type (_BarCodeScanner.Constants.BarCodeType_)** -- The barcode type.
 - **data (_string_)** -- The information encoded in the bar code.
-- **bounds : [BarCodeScanner.BarCodeBounds](#barcodescannerbarcodebounds)** -- (_Optional_) The `BarCodeBounds` object.
+- **bounds : [BarCodeScanner.BarCodeBounds](#barcodescannerbarcodepoint)** -- (_Optional_) The `BarCodeBounds` object.
 - **cornerPoints : Array<[BarCodeScanner.BarCodePoint](#barcodescannerbarcodepoint)\>** -- (_Optional_) Corner points of the bounding box.
 
 > **NOTE** `bounds` and `cornerPoints` are not always available. On iOS, for `code39` and `pdf417` you don't get those values. Moreover, on iOS, those values don't have to bounds the whole barcode. For some types, they will represent the area used by the scanner.

--- a/docs/pages/versions/v39.0.0/sdk/bar-code-scanner.md
+++ b/docs/pages/versions/v39.0.0/sdk/bar-code-scanner.md
@@ -155,7 +155,7 @@ Object of type `BarCodeSize` contains following keys:
 - **height (_number_)** -- The height value.
 - **width (_number_)** -- The width value.
 
-### `BarCodeBounds`
+### `BarCodeScanner.BarCodeBounds`
 
 Object of type `BarCodeBounds` contains following keys:
 
@@ -168,7 +168,7 @@ Object of type `BarCodeScannerResult` contains following keys:
 
 - **type (_BarCodeScanner.Constants.BarCodeType_)** -- The barcode type.
 - **data (_string_)** -- The information encoded in the bar code.
-- **bounds : [BarCodeScanner.BarCodeBounds](#barcodescannerbarcodepoint)** -- (_Optional_) The `BarCodeBounds` object.
+- **bounds : [BarCodeScanner.BarCodeBounds](#barcodescannerbarcodebounds)** -- (_Optional_) The `BarCodeBounds` object.
 - **cornerPoints : Array<[BarCodeScanner.BarCodePoint](#barcodescannerbarcodepoint)\>** -- (_Optional_) Corner points of the bounding box.
 
 > **NOTE** `bounds` and `cornerPoints` are not always available. On iOS, for `code39` and `pdf417` you don't get those values. Moreover, on iOS, those values don't have to bounds the whole barcode. For some types, they will represent the area used by the scanner.

--- a/docs/pages/versions/v39.0.0/sdk/brightness.md
+++ b/docs/pages/versions/v39.0.0/sdk/brightness.md
@@ -108,7 +108,7 @@ A `Promise` that is resolved when the brightness has been successfully set.
 
 #### Error Codes
 
-- [`ERR_BRIGHTNESS`](#errbrightness)
+- [`ERR_BRIGHTNESS`](#err_brightness)
 
 ---
 
@@ -132,7 +132,7 @@ A `Promise` that resolves with `true` when the current activity is using the sys
 
 #### Error Codes
 
-- [`ERR_BRIGHTNESS`](#errbrightness)
+- [`ERR_BRIGHTNESS`](#err_brightness)
 
 ---
 
@@ -146,7 +146,7 @@ A `Promise` that is resolved with a number between 0 and 1, inclusive, represent
 
 #### Error Codes
 
-- [`ERR_BRIGHTNESS_SYSTEM`](#errbrightnesssystem)
+- [`ERR_BRIGHTNESS_SYSTEM`](#err_brightness_system)
 
 ---
 
@@ -166,8 +166,8 @@ A `Promise` that is resolved when the brightness has been successfully set.
 
 #### Error Codes
 
-- [`ERR_BRIGHTNESS_MODE`](#errbrightnessmode)
-- [`ERR_BRIGHTNESS_PERMISSIONS_DENIED`](#errbrightnesspermissionsdenied)
+- [`ERR_BRIGHTNESS_MODE`](#err_brightness_mode)
+- [`ERR_BRIGHTNESS_PERMISSIONS_DENIED`](#err_brightness_permissions_denied)
 
 ### `Brightness.getSystemBrightnessModeAsync()`
 
@@ -179,7 +179,7 @@ A `Promise` that is resolved with a [`BrightnessMode`](#brightnessbrightnessmode
 
 #### Error Codes
 
-- [`ERR_BRIGHTNESS_MODE`](#errbrightnessmode)
+- [`ERR_BRIGHTNESS_MODE`](#err_brightness_mode)
 
 ---
 
@@ -197,9 +197,9 @@ A `Promise` that is resolved when the brightness mode has been successfully set.
 
 #### Error Codes
 
-- [`ERR_INVALID_ARGUMENT`](#errinvalidargument)
-- [`ERR_BRIGHTNESS_MODE`](#errbrightnessmode)
-- [`ERR_BRIGHTNESS_PERMISSIONS_DENIED`](#errbrightnesspermissionsdenied)
+- [`ERR_INVALID_ARGUMENT`](#err_invalid_argument)
+- [`ERR_BRIGHTNESS_MODE`](#err_brightness_mode)
+- [`ERR_BRIGHTNESS_PERMISSIONS_DENIED`](#err_brightness_permissions_denied)
 
 ## Enum Types
 

--- a/docs/pages/versions/v39.0.0/sdk/camera.md
+++ b/docs/pages/versions/v39.0.0/sdk/camera.md
@@ -241,7 +241,7 @@ Takes a picture and saves it to app's cache directory. Photos are rotated to mat
 
 Returns a Promise that resolves to an object: `{ uri, width, height, exif, base64 }` where `uri` is a URI to the local image file on iOS, Android, and a base64 string on web (useable as the source for an `Image` element). The `width, height` properties specify the dimensions of the image. `base64` is included if the `base64` option was truthy, and is a string containing the JPEG data of the image in Base64--prepend that with `'data:image/jpg;base64,'` to get a data URI, which you can use as the source for an `Image` element for example. `exif` is included if the `exif` option was truthy, and is an object containing EXIF data for the image--the names of its properties are EXIF tags and their values are the values for those tags.
 
-On native platforms, the local image URI is temporary. Use [`FileSystem.copyAsync`](filesystem.md#expofilesystemcopyasyncoptions) to make a permanent copy of the image.
+On native platforms, the local image URI is temporary. Use [`FileSystem.copyAsync`](filesystem.md#filesystemcopyasyncoptions) to make a permanent copy of the image.
 
 On web, the `uri` is a base64 representation of the image because file system URLs are not supported in the browser. The `exif` data returned on web is a partial representation of the [`MediaTrackSettings`](https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackSettings), if available.
 

--- a/docs/pages/versions/v39.0.0/sdk/constants.md
+++ b/docs/pages/versions/v39.0.0/sdk/constants.md
@@ -24,7 +24,7 @@ import Constants from 'expo-constants';
 
 ### `Constants.appOwnership`
 
-Returns `expo`, `standalone`, or `guest`. If `expo`, the experience is running inside of the Expo client. If `standalone`, it is a [standalone app](../../../distribution/building-standalone-apps.md#building-standalone-apps). If `guest`, it has been opened through a link from a standalone app.
+Returns `expo`, `standalone`, or `guest`. If `expo`, the experience is running inside of the Expo client. If `standalone`, it is a [standalone app](../../../distribution/building-standalone-apps.md). If `guest`, it has been opened through a link from a standalone app.
 
 ### `Constants.deviceName`
 

--- a/docs/pages/versions/v39.0.0/sdk/document-picker.md
+++ b/docs/pages/versions/v39.0.0/sdk/document-picker.md
@@ -45,7 +45,7 @@ import * as DocumentPicker from 'expo-document-picker';
 
 ### `DocumentPicker.getDocumentAsync(options)`
 
-Display the system UI for choosing a document. By default, the chosen file is copied to [the app's internal cache directory](filesystem.md#expofilesystemcachedirectory).
+Display the system UI for choosing a document. By default, the chosen file is copied to [the app's internal cache directory](filesystem.md#filesystemcachedirectory).
 
 > **Note for Web:** The system UI can only be shown after user activation (e.g. a `Button` press). Therefore, calling `getDocumentAsync` in `componentDidMount`, for example, will **not** work as intended.
 
@@ -56,7 +56,7 @@ Display the system UI for choosing a document. By default, the chosen file is co
   A map of options:
 
   - **type (_string_)** -- The [MIME type](https://en.wikipedia.org/wiki/Media_type) of the documents that are available to be picked. Is also supports wildcards like `image/*` to choose any image. To allow any type of document you can use `*/*`. Defaults to `*/*`.
-  - **copyToCacheDirectory (_boolean_)** -- If `true`, the picked file is copied to [`FileSystem.CacheDirectory`](filesystem.md#expofilesystemcachedirectory), which allows other Expo APIs to read the file immediately. Defaults to `true`. This may impact performance for large files, so you should consider setting this to `false` if you expect users to pick particularly large files and your app does not need immediate read access.
+  - **copyToCacheDirectory (_boolean_)** -- If `true`, the picked file is copied to [`FileSystem.CacheDirectory`](filesystem.md#filesystemcachedirectory), which allows other Expo APIs to read the file immediately. Defaults to `true`. This may impact performance for large files, so you should consider setting this to `false` if you expect users to pick particularly large files and your app does not need immediate read access.
   - **multiple (_boolean_)** -- (Web Only) Allows multiple files to be selected from the system UI. Defaults to `false`.
 
 #### Returns

--- a/docs/pages/versions/v39.0.0/sdk/facebook.md
+++ b/docs/pages/versions/v39.0.0/sdk/facebook.md
@@ -22,7 +22,7 @@ For bare apps, here are links to the [iOS Installation Walkthrough](https://deve
 
 > 💡 When following these steps you will find on the Facebook Developer site that there are many fields and steps that you don't actually care about. Just look for the information that we ask you for and you will be OK!
 
-Follow [Facebook's developer documentation](https://developers.facebook.com/docs/apps/register) to register an application with Facebook's API and get an application ID. Take note of this application ID because it will be used as the `appId` option in your [`Facebook.logInWithReadPermissionsAsync`](#expofacebookloginwithreadpermissionsasync 'Facebook.logInWithReadPermissionsAsync') call.
+Follow [Facebook's developer documentation](https://developers.facebook.com/docs/apps/register) to register an application with Facebook's API and get an application ID. Take note of this application ID because it will be used as the `appId` option in your [`Facebook.logInWithReadPermissionsAsync`](#facebookloginwithreadpermissionsasyncoptions 'Facebook.logInWithReadPermissionsAsync') call.
 
 Then follow these steps based on the platforms you're targetting. This will need to be done from the [Facebook developer site](https://developers.facebook.com/).
 

--- a/docs/pages/versions/v39.0.0/sdk/facebook.md
+++ b/docs/pages/versions/v39.0.0/sdk/facebook.md
@@ -52,7 +52,7 @@ The Android Play Store Expo client will use the Facebook App ID that you provide
 
 #### Android standalone app
 
-- [Build your standalone app](../../../distribution/building-standalone-apps.md#building-standalone-apps) for Android.
+- [Build your standalone app](../../../distribution/building-standalone-apps.md) for Android.
 - Run `expo fetch:android:hashes`.
 - Copy `Facebook Key Hash` and paste it as a key hash in your Facebook developer page pictured below.
 

--- a/docs/pages/versions/v39.0.0/sdk/google-sign-in.md
+++ b/docs/pages/versions/v39.0.0/sdk/google-sign-in.md
@@ -169,7 +169,7 @@ Returns true after the user successfully updates.
 
 Configures how the `GoogleSignIn` module will attempt to sign in. You can call this method multiple times.
 
-See all the available options under the [`GoogleSignInOptions`](#googlesigninerrors) type.
+See all the available options under the [`GoogleSignInOptions`](#types) type.
 
 ### `GoogleSignIn.isSignedInAsync()`
 

--- a/docs/pages/versions/v39.0.0/sdk/google-sign-in.md
+++ b/docs/pages/versions/v39.0.0/sdk/google-sign-in.md
@@ -169,7 +169,7 @@ Returns true after the user successfully updates.
 
 Configures how the `GoogleSignIn` module will attempt to sign in. You can call this method multiple times.
 
-See all the available options under the [`GoogleSignInOptions`](#googlesigninoptions) type.
+See all the available options under the [`GoogleSignInOptions`](#googlesigninerrors) type.
 
 ### `GoogleSignIn.isSignedInAsync()`
 

--- a/docs/pages/versions/v39.0.0/sdk/intent-launcher.md
+++ b/docs/pages/versions/v39.0.0/sdk/intent-launcher.md
@@ -38,11 +38,11 @@ Starts the specified activity. The method will return a promise which resolves w
 #### Arguments
 
 - **activityAction (_string_)** -- The action to be performed, e.g. `IntentLauncher.ACTION_WIRELESS_SETTINGS`. There are a few pre-defined constants you can use for this parameter. You can find them at [expo-intent-launcher/src/IntentLauncher.ts](https://github.com/expo/expo/blob/master/packages/expo-intent-launcher/src/IntentLauncher.ts). **Required**
-- **intentParams ([`IntentLauncherParams`](#typeintentlauncherparams))** -- An object of intent parameters.
+- **intentParams ([`IntentLauncherParams`](#intentlauncherparams))** -- An object of intent parameters.
 
 #### Returns
 
-A promise resolving to an object of type [IntentLauncherResult](#typeintentlauncherresult).
+A promise resolving to an object of type [IntentLauncherResult](#intentlauncherresult).
 
 ## Types
 
@@ -62,7 +62,7 @@ A promise resolving to an object of type [IntentLauncherResult](#typeintentlaunc
 
 | Key        |  Type  | Description                                                                               |
 | ---------- | :----: | ----------------------------------------------------------------------------------------- |
-| resultCode | number | Result code returned by the activity. See [ResultCode](#enumresultcode) for more details. |
+| resultCode | number | Result code returned by the activity. See [ResultCode](#resultcode) for more details. |
 | data       | string | Optional data URI that can be returned by the activity.                                   |
 | extra      | object | Optional extras object that can be returned by the activity.                              |
 

--- a/docs/pages/versions/v39.0.0/sdk/media-library.md
+++ b/docs/pages/versions/v39.0.0/sdk/media-library.md
@@ -80,10 +80,10 @@ Fetches a page of assets matching the provided criteria.
   - **first (_number_)** -- The maximum number of items on a single page. Defaults to 20.
   - **after (_string_)** -- Asset ID of the last item returned on the previous page.
   - **album (_string_ | _Album_)** -- [Album](#album) or its ID to get assets from specific album.
-  - **sortBy (_array_)** -- An array of [SortBy](#expomedialibrarysortby) keys. By default, all keys are sorted in descending order, however you can also pass a pair `[key, ascending]` where the second item is a `boolean` value that means whether to use ascending order. Note that if the `SortBy.default` key is used, then `ascending` argument will not matter.
+  - **sortBy (_array_)** -- An array of [SortBy](#medialibrarysortby) keys. By default, all keys are sorted in descending order, however you can also pass a pair `[key, ascending]` where the second item is a `boolean` value that means whether to use ascending order. Note that if the `SortBy.default` key is used, then `ascending` argument will not matter.
     Earlier items have higher priority when sorting out the results.
     If empty, this method will use the default sorting that is provided by the platform.
-  - **mediaType (_array_)** -- An array of [MediaType](#expomedialibrarymediatype) types. By default `MediaType.photo` is set.
+  - **mediaType (_array_)** -- An array of [MediaType](#medialibrarymediatype) types. By default `MediaType.photo` is set.
   - **createdAfter (_Date_ | _number_)** -- Date object or Unix timestamp in milliseconds limiting returned assets only to those that were created after this date.
   - **createdBefore (_Date_ | _number_)** -- Similarly as `createdAfter`, but limits assets only to those that were created before specified date.
 
@@ -185,7 +185,7 @@ In case they're copied you should keep in mind that `getAssetsAsync` will return
 
 #### Arguments
 
-- **assets (_array_)** -- Array of [assets](#assets) to add.
+- **assets (_array_)** -- Array of [assets](#asset) to add.
 - **album (_string_ | _Album_)** -- [Album](#album) or its ID, to which the assets will be added.
 - **copyAssets (_boolean_)** -- Whether to copy assets to the new album instead of move them. Defaults to `true`. (**Android only**)
 
@@ -201,7 +201,7 @@ On Android, album will be automatically deleted if there are no more assets insi
 
 #### Arguments
 
-- **assets (_array_)** -- Array of [assets](#assets) to remove from album.
+- **assets (_array_)** -- Array of [assets](#asset) to remove from album.
 - **album (_string_ | _Album_)** -- [Album](#album) or its ID, from which the assets will be removed.
 
 #### Returns
@@ -223,9 +223,9 @@ Subscribes for updates in user's media library.
 #### Arguments
 
 - **listener (_function_)** -- A callback that is called when any assets have been inserted or deleted from the library. **On Android** it's invoked with an empty object. **On iOS** it's invoked with an object that contains following keys:
-  - **insertedAssets (_array_)** -- Array of [assets](#assets) that have been inserted to the library.
-  - **deletedAssets (_array_)** -- Array of [assets](#assets) that have been deleted from the library.
-  - **updatedAssets (_array_)** -- Array of [assets](#assets) that have been updated or completed downloading from network storage (iCloud in iOS).
+  - **insertedAssets (_array_)** -- Array of [assets](#asset) that have been inserted to the library.
+  - **deletedAssets (_array_)** -- Array of [assets](#asset) that have been deleted from the library.
+  - **updatedAssets (_array_)** -- Array of [assets](#asset) that have been updated or completed downloading from network storage (iCloud in iOS).
 
 #### Returns
 

--- a/docs/pages/versions/v39.0.0/sdk/notifications.md
+++ b/docs/pages/versions/v39.0.0/sdk/notifications.md
@@ -180,7 +180,7 @@ The following methods are exported by the `expo-notifications` module:
   - [`setNotificationChannelGroupAsync`](#setnotificationchannelgroupasyncidentifier-string-channel-notificationchannelgroupinput-promisenotificationchannelgroup--null) -- saves a notification channel group configuration
   - [`deleteNotificationChannelGroupAsync`](#deletenotificationchannelgroupasyncidentifier-string-promisevoid) -- deletes a notification channel group
   - **managing notification categories (interactive notifications)**
-  - [`setNotificationCategoryAsync`](#setnotificationcategoryasyncidentifier-string-actions-notificationaction-options-categoryoptions-promisenotificationcategory) -- creates a new notification category for interactive notifications
+  - [`setNotificationCategoryAsync`](#setnotificationcategoryasyncidentifier-string-actions-notificationaction-options-categoryoptions-promisenotificationcategory--null) -- creates a new notification category for interactive notifications
   - [`getNotificationCategoriesAsync`](#getnotificationcategoriesasync-promisenotificationcategory) -- fetches information about all active notification categories
   - [`deleteNotificationCategoryAsync`](#deletenotificationcategoryasyncidentifier-string-promiseboolean) -- deletes a notification category
 

--- a/docs/pages/versions/v39.0.0/sdk/print.md
+++ b/docs/pages/versions/v39.0.0/sdk/print.md
@@ -43,7 +43,7 @@ Prints a document or HTML, on web this prints the HTML from the page.
 
 ### `Print.printToFileAsync(options)`
 
-Prints HTML to PDF file and saves it to [app's cache directory](filesystem.md#expofilesystemcachedirectory). On web this method opens the print dialog.
+Prints HTML to PDF file and saves it to [app's cache directory](filesystem.md#filesystemcachedirectory). On web this method opens the print dialog.
 
 #### Arguments
 

--- a/docs/pages/versions/v39.0.0/sdk/sqlite.md
+++ b/docs/pages/versions/v39.0.0/sdk/sqlite.md
@@ -98,7 +98,7 @@ A `Transaction` object is passed in as a parameter to the `callback` parameter f
 In order to open a new SQLite database using an existing `.db` file you already have, you need to do three things:
 
 - `expo install expo-file-system expo-asset @expo/metro-config`
-- create a `metro.config.js` file in the root of your project with the following contents ([curious why? read here](../../../guides/customizing-metro.md#adding-more-file-extensions-to--assetexts)):
+- create a `metro.config.js` file in the root of your project with the following contents ([curious why? read here](../../../guides/customizing-metro.md#adding-more-file-extensions-to-assetexts)):
 
 ```ts
 const { getDefaultConfig } = require('@expo/metro-config');

--- a/docs/pages/versions/v39.0.0/sdk/storereview.md
+++ b/docs/pages/versions/v39.0.0/sdk/storereview.md
@@ -31,7 +31,7 @@ If the users device is running a version of iOS lower than 10.3, or the user is 
 
 #### Error Codes
 
-- [`ERR_STORE_REVIEW_UNSUPPORTED`](#err_store_review_unsupported)
+- [`ERR_STORE_REVIEW_UNSUPPORTED`](#e_store_review_unsupported)
 
 #### Example
 

--- a/docs/pages/versions/v39.0.0/sdk/task-manager.md
+++ b/docs/pages/versions/v39.0.0/sdk/task-manager.md
@@ -129,7 +129,7 @@ Example:
 ### `TaskManager.unregisterTaskAsync(taskName)`
 
 Unregisters task from the app, so the app will not be receiving updates for that task anymore.
-_It is recommended to use methods specialized by modules that registered the task, eg. [Location.stopLocationUpdatesAsync](location.md#expolocationstoplocationupdatesasynctaskname)._
+_It is recommended to use methods specialized by modules that registered the task, eg. [Location.stopLocationUpdatesAsync](location.md#locationstoplocationupdatesasynctaskname)._
 
 #### Arguments
 

--- a/docs/pages/versions/v39.0.0/sdk/webbrowser.md
+++ b/docs/pages/versions/v39.0.0/sdk/webbrowser.md
@@ -71,7 +71,7 @@ Opens the url with Safari in a modal on iOS using [`SFSafariViewController`](htt
   - **dismissButtonStyle (_optional_) (_string_)** -- (_iOS only_) The style of the dismiss button. Should be one of: `done`, `close`, or `cancel`.
   - **enableBarCollapsing (_optional_) (_boolean_)** -- a boolean determining whether the toolbar should be hiding when a user scrolls the website.
   - **enableDefaultShare (_optional_) (_boolean_)** -- (_Android only_) a boolean determining whether a default share item should be added to the menu.
-  - **browserPackage (_optional_) (_string_)** -- (_Android only_). Package name of a browser to be used to handle Custom Tabs. List of available packages is to be queried by [getCustomTabsSupportingBrowsers](#webbrowsergetcustomtabssupportingbrowsers) method.
+  - **browserPackage (_optional_) (_string_)** -- (_Android only_). Package name of a browser to be used to handle Custom Tabs. List of available packages is to be queried by [getCustomTabsSupportingBrowsers](#webbrowsergetcustomtabssupportingbrowsersasync) method.
   - **readerMode (_optional_) (_boolean_)** -- (_iOS only_) a boolean determining whether Safari should enter Reader mode, if it is available.
   - **secondaryToolbarColor (_optional_) (_string_)** -- (_Android only_) color of the secondary toolbar in either `#AARRGGBB` or `#RRGGBB` format.
   - **showInRecents (_optional_) (_boolean_)** -- (_Android only_) a boolean determining whether browsed website should be shown as separate entry in Android recents/multitasking view. Default: `false`
@@ -103,7 +103,7 @@ This will be done using a "custom Chrome tabs" browser, [AppState][d-appstate], 
 
 **On web:**
 
-> 🚨 This API can only be used in a secure environment (`https`). You can use `expo start:web --https` to test this. Otherwise an error with code [`ERR_WEB_BROWSER_CRYPTO`](#errwebbrowsercrypto) will be thrown.
+> 🚨 This API can only be used in a secure environment (`https`). You can use `expo start:web --https` to test this. Otherwise an error with code [`ERR_WEB_BROWSER_CRYPTO`](#err_web_browser_crypto) will be thrown.
 
 This will use the browser's [`window.open()`][d-windowopen] API.
 
@@ -117,7 +117,7 @@ How this works on web:
 - The state will be added to the window's `localstorage`. This ensures that auth cannot complete unless it's done from a page running with the same origin as it was started. Ex: if `openAuthSessionAsync` is invoked on `https://localhost:19006`, then `maybeCompleteAuthSession` must be invoked on a page hosted from the origin `https://localhost:19006`. Using a different website, or even a different host like `https://128.0.0.*:19006` for example will not work.
 - A timer will be started to check for every 1000 milliseconds (1 second) to detect if the window has been closed by the user. If this happens then a promise will resolve with `{ type: 'dismiss' }`.
 
-🚨 On mobile web, Chrome and Safari will block any call to [`window.open()`][d-windowopen] which takes too long to fire after a user interaction. This method must be invoked immediately after a user interaction. If the event is blocked, an error with code [`ERR_WEB_BROWSER_BLOCKED`](#errwebbrowserblocked) will be thrown.
+🚨 On mobile web, Chrome and Safari will block any call to [`window.open()`][d-windowopen] which takes too long to fire after a user interaction. This method must be invoked immediately after a user interaction. If the event is blocked, an error with code [`ERR_WEB_BROWSER_BLOCKED`](#err_web_browser_blocked) will be thrown.
 
 [d-windowopen]: https://developer.mozilla.org/en-US/docs/Web/API/Window/open
 [d-appstate]: https://docs.expo.io/versions/latest/react-native/appstate/
@@ -137,9 +137,9 @@ Returns a Promise:
 
 #### Error Codes
 
-- [`ERR_WEB_BROWSER_REDIRECT`](#errwebbrowserredirect)
-- [`ERR_WEB_BROWSER_BLOCKED`](#errwebbrowserblocked)
-- [`ERR_WEB_BROWSER_CRYPTO`](#errwebbrowsercrypto)
+- [`ERR_WEB_BROWSER_REDIRECT`](#err_web_browser_redirect)
+- [`ERR_WEB_BROWSER_BLOCKED`](#err_web_browser_blocked)
+- [`ERR_WEB_BROWSER_CRYPTO`](#err_web_browser_crypto)
 
 ### `WebBrowser.maybeCompleteAuthSession(options)`
 
@@ -194,7 +194,7 @@ The promise resolves with `{ package: string }`.
 
 _Android only_
 
-This methods removes all bindings to services created by [`warmUpAsync`](#webbrowserwarmupasyncnbrowserpackage) or [`mayInitWithUrlAsync`](#webbrowseramayinitwithurlsyncurl-package). You should call this method once you don't need them to avoid potential memory leaks. However, those binding would be cleared once your application is destroyed, which might be sufficient in most cases.
+This methods removes all bindings to services created by [`warmUpAsync`](#webbrowserwarmupasyncbrowserpackage) or [`mayInitWithUrlAsync`](#webbrowsermayinitwithurlasyncurl-package). You should call this method once you don't need them to avoid potential memory leaks. However, those binding would be cleared once your application is destroyed, which might be sufficient in most cases.
 
 #### Arguments
 
@@ -226,10 +226,10 @@ The promise resolves with `{ browserPackages: string[], defaultBrowserPackage: s
 
 - **browserPackages (_string[]_)** : All packages recognized by `PackageManager` as capable of handling Custom Tabs. Empty array means there is no supporting browsers on device.
 - **defaultBrowserPackage (_string_ | null)** : Default package chosen by user. Null if there is no such packages. Null usually means, that user will be prompted to choose from available packages.
-- **servicePackages (_string[]_)** : All packages recognized by `PackageManager` as capable of handling Custom Tabs Service. This service is used by [`warmUpAsync`](#webbrowserwarmupasyncnbrowserpackage), [`mayInitWithUrlAsync`](#webbrowsermayinitwithurlasyncurl-package) and [`coolDownAsync`](#webbrowsercooldownasyncbrowserpackage).
+- **servicePackages (_string[]_)** : All packages recognized by `PackageManager` as capable of handling Custom Tabs Service. This service is used by [`warmUpAsync`](#webbrowserwarmupasyncbrowserpackage), [`mayInitWithUrlAsync`](#webbrowsermayinitwithurlasyncurl-package) and [`coolDownAsync`](#webbrowsercooldownasyncbrowserpackage).
 - **preferredBrowserPackage (_string_ | null)** : Package preferred by `CustomTabsClient` to be used to handle Custom Tabs. It favors browser chosen by user as default, as long as it is present on both `browserPackages` and `servicePackages` lists. Only such browsers are considered as fully supporting Custom Tabs. It might be `null` when there is no such browser installed or when default browser is not in `servicePackages` list.
 
-In general, services are used to perform background tasks. If a browser is available in `servicePackage` list, it should be capable of performing [`warmUpAsync`](#webbrowserwarmupasyncnbrowserpackage), [`mayInitWithUrlAsync`](#webbrowsermayinitwithurlasyncurl-package) and [`coolDownAsync`](#webbrowsercooldownasyncbrowserpackage). For opening an actual web page, browser must be in `browserPackages` list. A browser has to be present in both lists to be considered as fully supporting Custom Tabs.
+In general, services are used to perform background tasks. If a browser is available in `servicePackage` list, it should be capable of performing [`warmUpAsync`](#webbrowserwarmupasyncbrowserpackage), [`mayInitWithUrlAsync`](#webbrowsermayinitwithurlasyncurl-package) and [`coolDownAsync`](#webbrowsercooldownasyncbrowserpackage). For opening an actual web page, browser must be in `browserPackages` list. A browser has to be present in both lists to be considered as fully supporting Custom Tabs.
 
 ## Error Codes
 

--- a/docs/pages/versions/v40.0.0/react-native/checkbox.md
+++ b/docs/pages/versions/v40.0.0/react-native/checkbox.md
@@ -58,7 +58,7 @@ export default App;
 
 ## Props
 
-Inherits [View Props](view#props).
+Inherits [View Props](view.md#props).
 
 ---
 

--- a/docs/pages/versions/v40.0.0/sdk/auth-session.md
+++ b/docs/pages/versions/v40.0.0/sdk/auth-session.md
@@ -547,7 +547,7 @@ A hook used for opinionated Google authentication that works across platforms.
 
 #### Returns
 
-- **request (_GoogleAuthRequest | null_)** -- An instance of [`GoogleAuthRequest`](#googleauthrequest) that can be used to prompt the user for authorization. This will be `null` until the auth request has finished loading.
+- **request (_GoogleAuthRequest | null_)** -- An instance of [`GoogleAuthRequest`](#useauthrequest) that can be used to prompt the user for authorization. This will be `null` until the auth request has finished loading.
 - **response (_AuthSessionResult | null_)** -- This is `null` until `promptAsync` has been invoked. Once fulfilled it will return information about the authorization.
 - **promptAsync (_function_)** -- When invoked, a web browser will open up and prompt the user for authentication. Accepts an [`AuthRequestPromptOptions`](#authrequestpromptoptions) object with options about how the prompt will execute. This **should not** be used to enable the Expo proxy service `auth.expo.io`, as the proxy will be automatically enabled based on the platform.
 

--- a/docs/pages/versions/v40.0.0/sdk/auth-session.md
+++ b/docs/pages/versions/v40.0.0/sdk/auth-session.md
@@ -504,7 +504,7 @@ Access token type [Section 7.1](https://tools.ietf.org/html/rfc6749#section-7.1)
 
 ### `GoogleAuthRequestConfig`
 
-An extension of the [`AuthRequestConfig`][#authrequestconfig] for use with the built-in Google provider.
+An extension of the [`AuthRequestConfig`](#authrequestconfig) for use with the built-in Google provider.
 
 | Name                   | Type       | Description                                                                           |
 | ---------------------- | ---------- | ------------------------------------------------------------------------------------- |

--- a/docs/pages/versions/v40.0.0/sdk/bar-code-scanner.md
+++ b/docs/pages/versions/v40.0.0/sdk/bar-code-scanner.md
@@ -168,7 +168,7 @@ Object of type `BarCodeScannerResult` contains following keys:
 
 - **type (_BarCodeScanner.Constants.BarCodeType_)** -- The barcode type.
 - **data (_string_)** -- The information encoded in the bar code.
-- **bounds : [BarCodeScanner.BarCodeBounds](#barcodescannerbarcodebounds)** -- (_Optional_) The `BarCodeBounds` object.
+- **bounds : [BarCodeScanner.BarCodeBounds](#barcodescannerbarcodepoint)** -- (_Optional_) The `BarCodeBounds` object.
 - **cornerPoints : Array<[BarCodeScanner.BarCodePoint](#barcodescannerbarcodepoint)\>** -- (_Optional_) Corner points of the bounding box.
 
 > **NOTE** `bounds` and `cornerPoints` are not always available. On iOS, for `code39` and `pdf417` you don't get those values. Moreover, on iOS, those values don't have to bounds the whole barcode. For some types, they will represent the area used by the scanner.

--- a/docs/pages/versions/v40.0.0/sdk/bar-code-scanner.md
+++ b/docs/pages/versions/v40.0.0/sdk/bar-code-scanner.md
@@ -155,7 +155,7 @@ Object of type `BarCodeSize` contains following keys:
 - **height (_number_)** -- The height value.
 - **width (_number_)** -- The width value.
 
-### `BarCodeBounds`
+### `BarCodeScanner.BarCodeBounds`
 
 Object of type `BarCodeBounds` contains following keys:
 
@@ -168,7 +168,7 @@ Object of type `BarCodeScannerResult` contains following keys:
 
 - **type (_BarCodeScanner.Constants.BarCodeType_)** -- The barcode type.
 - **data (_string_)** -- The information encoded in the bar code.
-- **bounds : [BarCodeScanner.BarCodeBounds](#barcodescannerbarcodepoint)** -- (_Optional_) The `BarCodeBounds` object.
+- **bounds : [BarCodeScanner.BarCodeBounds](#barcodescannerbarcodebounds)** -- (_Optional_) The `BarCodeBounds` object.
 - **cornerPoints : Array<[BarCodeScanner.BarCodePoint](#barcodescannerbarcodepoint)\>** -- (_Optional_) Corner points of the bounding box.
 
 > **NOTE** `bounds` and `cornerPoints` are not always available. On iOS, for `code39` and `pdf417` you don't get those values. Moreover, on iOS, those values don't have to bounds the whole barcode. For some types, they will represent the area used by the scanner.

--- a/docs/pages/versions/v40.0.0/sdk/brightness.md
+++ b/docs/pages/versions/v40.0.0/sdk/brightness.md
@@ -108,7 +108,7 @@ A `Promise` that is resolved when the brightness has been successfully set.
 
 #### Error Codes
 
-- [`ERR_BRIGHTNESS`](#errbrightness)
+- [`ERR_BRIGHTNESS`](#err_brightness)
 
 ---
 
@@ -132,7 +132,7 @@ A `Promise` that resolves with `true` when the current activity is using the sys
 
 #### Error Codes
 
-- [`ERR_BRIGHTNESS`](#errbrightness)
+- [`ERR_BRIGHTNESS`](#err_brightness)
 
 ---
 
@@ -146,7 +146,7 @@ A `Promise` that is resolved with a number between 0 and 1, inclusive, represent
 
 #### Error Codes
 
-- [`ERR_BRIGHTNESS_SYSTEM`](#errbrightnesssystem)
+- [`ERR_BRIGHTNESS_SYSTEM`](#err_brightness_system)
 
 ---
 
@@ -166,8 +166,8 @@ A `Promise` that is resolved when the brightness has been successfully set.
 
 #### Error Codes
 
-- [`ERR_BRIGHTNESS_MODE`](#errbrightnessmode)
-- [`ERR_BRIGHTNESS_PERMISSIONS_DENIED`](#errbrightnesspermissionsdenied)
+- [`ERR_BRIGHTNESS_MODE`](#err_brightness_mode)
+- [`ERR_BRIGHTNESS_PERMISSIONS_DENIED`](#err_brightness_permissions_denied)
 
 ### `Brightness.getSystemBrightnessModeAsync()`
 
@@ -179,7 +179,7 @@ A `Promise` that is resolved with a [`BrightnessMode`](#brightnessbrightnessmode
 
 #### Error Codes
 
-- [`ERR_BRIGHTNESS_MODE`](#errbrightnessmode)
+- [`ERR_BRIGHTNESS_MODE`](#err_brightness_mode)
 
 ---
 
@@ -197,9 +197,9 @@ A `Promise` that is resolved when the brightness mode has been successfully set.
 
 #### Error Codes
 
-- [`ERR_INVALID_ARGUMENT`](#errinvalidargument)
-- [`ERR_BRIGHTNESS_MODE`](#errbrightnessmode)
-- [`ERR_BRIGHTNESS_PERMISSIONS_DENIED`](#errbrightnesspermissionsdenied)
+- [`ERR_INVALID_ARGUMENT`](#err_invalid_argument)
+- [`ERR_BRIGHTNESS_MODE`](#err_brightness_mode)
+- [`ERR_BRIGHTNESS_PERMISSIONS_DENIED`](#err_brightness_permissions_denied)
 
 ## Enum Types
 

--- a/docs/pages/versions/v40.0.0/sdk/camera.md
+++ b/docs/pages/versions/v40.0.0/sdk/camera.md
@@ -245,7 +245,7 @@ Takes a picture and saves it to app's cache directory. Photos are rotated to mat
 
 Returns a Promise that resolves to an object: `{ uri, width, height, exif, base64 }` where `uri` is a URI to the local image file on iOS, Android, and a base64 string on web (useable as the source for an `Image` element). The `width, height` properties specify the dimensions of the image. `base64` is included if the `base64` option was truthy, and is a string containing the JPEG data of the image in Base64--prepend that with `'data:image/jpg;base64,'` to get a data URI, which you can use as the source for an `Image` element for example. `exif` is included if the `exif` option was truthy, and is an object containing EXIF data for the image--the names of its properties are EXIF tags and their values are the values for those tags.
 
-On native platforms, the local image URI is temporary. Use [`FileSystem.copyAsync`](filesystem.md#expofilesystemcopyasyncoptions) to make a permanent copy of the image.
+On native platforms, the local image URI is temporary. Use [`FileSystem.copyAsync`](filesystem.md#filesystemcopyasyncoptions) to make a permanent copy of the image.
 
 On web, the `uri` is a base64 representation of the image because file system URLs are not supported in the browser. The `exif` data returned on web is a partial representation of the [`MediaTrackSettings`](https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackSettings), if available.
 

--- a/docs/pages/versions/v40.0.0/sdk/constants.md
+++ b/docs/pages/versions/v40.0.0/sdk/constants.md
@@ -24,7 +24,7 @@ import Constants from 'expo-constants';
 
 ### `Constants.appOwnership`
 
-Returns `expo`, `standalone`, or `guest`. If `expo`, the experience is running inside of the Expo client. If `standalone`, it is a [standalone app](../../../distribution/building-standalone-apps.md#building-standalone-apps). If `guest`, it has been opened through a link from a standalone app.
+Returns `expo`, `standalone`, or `guest`. If `expo`, the experience is running inside of the Expo client. If `standalone`, it is a [standalone app](../../../distribution/building-standalone-apps.md). If `guest`, it has been opened through a link from a standalone app.
 
 ### `Constants.deviceName`
 

--- a/docs/pages/versions/v40.0.0/sdk/document-picker.md
+++ b/docs/pages/versions/v40.0.0/sdk/document-picker.md
@@ -45,7 +45,7 @@ import * as DocumentPicker from 'expo-document-picker';
 
 ### `DocumentPicker.getDocumentAsync(options)`
 
-Display the system UI for choosing a document. By default, the chosen file is copied to [the app's internal cache directory](filesystem.md#expofilesystemcachedirectory).
+Display the system UI for choosing a document. By default, the chosen file is copied to [the app's internal cache directory](filesystem.md#filesystemcachedirectory).
 
 > **Note for Web:** The system UI can only be shown after user activation (e.g. a `Button` press). Therefore, calling `getDocumentAsync` in `componentDidMount`, for example, will **not** work as intended.
 
@@ -56,7 +56,7 @@ Display the system UI for choosing a document. By default, the chosen file is co
   A map of options:
 
   - **type (_string_)** -- The [MIME type](https://en.wikipedia.org/wiki/Media_type) of the documents that are available to be picked. Is also supports wildcards like `image/*` to choose any image. To allow any type of document you can use `*/*`. Defaults to `*/*`.
-  - **copyToCacheDirectory (_boolean_)** -- If `true`, the picked file is copied to [`FileSystem.CacheDirectory`](filesystem.md#expofilesystemcachedirectory), which allows other Expo APIs to read the file immediately. Defaults to `true`. This may impact performance for large files, so you should consider setting this to `false` if you expect users to pick particularly large files and your app does not need immediate read access.
+  - **copyToCacheDirectory (_boolean_)** -- If `true`, the picked file is copied to [`FileSystem.CacheDirectory`](filesystem.md#filesystemcachedirectory), which allows other Expo APIs to read the file immediately. Defaults to `true`. This may impact performance for large files, so you should consider setting this to `false` if you expect users to pick particularly large files and your app does not need immediate read access.
   - **multiple (_boolean_)** -- (Web Only) Allows multiple files to be selected from the system UI. Defaults to `false`.
 
 #### Returns

--- a/docs/pages/versions/v40.0.0/sdk/facebook.md
+++ b/docs/pages/versions/v40.0.0/sdk/facebook.md
@@ -22,7 +22,7 @@ For bare apps, here are links to the [iOS Installation Walkthrough](https://deve
 
 > 💡 When following these steps you will find on the Facebook Developer site that there are many fields and steps that you don't actually care about. Just look for the information that we ask you for and you will be OK!
 
-Follow [Facebook's developer documentation](https://developers.facebook.com/docs/apps/register) to register an application with Facebook's API and get an application ID. Take note of this application ID because it will be used as the `appId` option in your [`Facebook.logInWithReadPermissionsAsync`](#expofacebookloginwithreadpermissionsasync 'Facebook.logInWithReadPermissionsAsync') call.
+Follow [Facebook's developer documentation](https://developers.facebook.com/docs/apps/register) to register an application with Facebook's API and get an application ID. Take note of this application ID because it will be used as the `appId` option in your [`Facebook.logInWithReadPermissionsAsync`](#facebookloginwithreadpermissionsasyncoptions 'Facebook.logInWithReadPermissionsAsync') call.
 
 Then follow these steps based on the platforms you're targetting. This will need to be done from the [Facebook developer site](https://developers.facebook.com/).
 

--- a/docs/pages/versions/v40.0.0/sdk/facebook.md
+++ b/docs/pages/versions/v40.0.0/sdk/facebook.md
@@ -52,7 +52,7 @@ The Android Play Store Expo client will use the Facebook App ID that you provide
 
 #### Android standalone app
 
-- [Build your standalone app](../../../distribution/building-standalone-apps.md#building-standalone-apps) for Android.
+- [Build your standalone app](../../../distribution/building-standalone-apps.md) for Android.
 - Run `expo fetch:android:hashes`.
 - Copy `Facebook Key Hash` and paste it as a key hash in your Facebook developer page pictured below.
 

--- a/docs/pages/versions/v40.0.0/sdk/google-sign-in.md
+++ b/docs/pages/versions/v40.0.0/sdk/google-sign-in.md
@@ -169,7 +169,7 @@ Returns true after the user successfully updates.
 
 Configures how the `GoogleSignIn` module will attempt to sign in. You can call this method multiple times.
 
-See all the available options under the [`GoogleSignInOptions`](#googlesigninerrors) type.
+See all the available options under the [`GoogleSignInOptions`](#types) type.
 
 ### `GoogleSignIn.isSignedInAsync()`
 

--- a/docs/pages/versions/v40.0.0/sdk/google-sign-in.md
+++ b/docs/pages/versions/v40.0.0/sdk/google-sign-in.md
@@ -169,7 +169,7 @@ Returns true after the user successfully updates.
 
 Configures how the `GoogleSignIn` module will attempt to sign in. You can call this method multiple times.
 
-See all the available options under the [`GoogleSignInOptions`](#googlesigninoptions) type.
+See all the available options under the [`GoogleSignInOptions`](#googlesigninerrors) type.
 
 ### `GoogleSignIn.isSignedInAsync()`
 

--- a/docs/pages/versions/v40.0.0/sdk/imagepicker.md
+++ b/docs/pages/versions/v40.0.0/sdk/imagepicker.md
@@ -107,7 +107,7 @@ Asks the user to grant permissions for accessing user's photo. Alias for `Permis
 
 #### Returns
 
-A promise that resolves to an object of type [MediaLibraryPermissionResponse](#imagepickercamerapermissionresponse).
+A promise that resolves to an object of type [MediaLibraryPermissionResponse](#imagepickermedialibrarypermissionresponse).
 
 ### `ImagePicker.getCameraPermissionsAsync()`
 

--- a/docs/pages/versions/v40.0.0/sdk/imagepicker.md
+++ b/docs/pages/versions/v40.0.0/sdk/imagepicker.md
@@ -107,7 +107,7 @@ Asks the user to grant permissions for accessing user's photo. Alias for `Permis
 
 #### Returns
 
-A promise that resolves to an object of type [MediaLibraryPermissionResponse](#imagepickercamerarollpermissionresponse).
+A promise that resolves to an object of type [MediaLibraryPermissionResponse](#imagepickercamerapermissionresponse).
 
 ### `ImagePicker.getCameraPermissionsAsync()`
 
@@ -197,7 +197,7 @@ Display the system UI for taking a photo with the camera. Requires `Permissions.
     - **On Android**, effect of this option depends on support of installed camera app.
     - **On Web** this option has no effect - the limit is browser-dependant.
   - **videoExportPreset (_[ImagePicker.VideoExportPreset](#imagepickervideoexportpreset)_)** -- **Available on iOS 11+ only, but Deprecated.** Specify preset which will be used to compress selected video. Defaults to `ImagePicker.VideoExportPreset.Passthrough`.
-  - **videoQuality (\_[ImagePicker.UIImagePickerControllerQualityType](#imagepickeruiimagepickercontrollerqualitytype)\_)** -- **iOS only**. Specify the quality of recorded videos. Defaults to `ImagePicker.UIImagePickerControllerQualityType.High`, which is the highest available for the device.
+  - **videoQuality (\_[ImagePicker.UIImagePickerControllerQualityType](#imagepickeruiimagepickercontrollertype)\_)** -- **iOS only**. Specify the quality of recorded videos. Defaults to `ImagePicker.UIImagePickerControllerQualityType.High`, which is the highest available for the device.
 
 #### Returns
 

--- a/docs/pages/versions/v40.0.0/sdk/intent-launcher.md
+++ b/docs/pages/versions/v40.0.0/sdk/intent-launcher.md
@@ -38,11 +38,11 @@ Starts the specified activity. The method will return a promise which resolves w
 #### Arguments
 
 - **activityAction (_string_)** -- The action to be performed, e.g. `IntentLauncher.ACTION_WIRELESS_SETTINGS`. There are a few pre-defined constants you can use for this parameter. You can find them at [expo-intent-launcher/src/IntentLauncher.ts](https://github.com/expo/expo/blob/master/packages/expo-intent-launcher/src/IntentLauncher.ts). **Required**
-- **intentParams ([`IntentLauncherParams`](#typeintentlauncherparams))** -- An object of intent parameters.
+- **intentParams ([`IntentLauncherParams`](#intentlauncherparams))** -- An object of intent parameters.
 
 #### Returns
 
-A promise resolving to an object of type [IntentLauncherResult](#typeintentlauncherresult).
+A promise resolving to an object of type [IntentLauncherResult](#intentlauncherresult).
 
 ## Types
 
@@ -62,7 +62,7 @@ A promise resolving to an object of type [IntentLauncherResult](#typeintentlaunc
 
 | Key        |  Type  | Description                                                                               |
 | ---------- | :----: | ----------------------------------------------------------------------------------------- |
-| resultCode | number | Result code returned by the activity. See [ResultCode](#enumresultcode) for more details. |
+| resultCode | number | Result code returned by the activity. See [ResultCode](#resultcode) for more details. |
 | data       | string | Optional data URI that can be returned by the activity.                                   |
 | extra      | object | Optional extras object that can be returned by the activity.                              |
 

--- a/docs/pages/versions/v40.0.0/sdk/media-library.md
+++ b/docs/pages/versions/v40.0.0/sdk/media-library.md
@@ -90,10 +90,10 @@ Fetches a page of assets matching the provided criteria.
   - **first (_number_)** -- The maximum number of items on a single page. Defaults to 20.
   - **after (_string_)** -- Asset ID of the last item returned on the previous page.
   - **album (_string_ | _Album_)** -- [Album](#album) or its ID to get assets from specific album.
-  - **sortBy (_array_)** -- An array of [SortBy](#expomedialibrarysortby) keys. By default, all keys are sorted in descending order, however you can also pass a pair `[key, ascending]` where the second item is a `boolean` value that means whether to use ascending order. Note that if the `SortBy.default` key is used, then `ascending` argument will not matter.
+  - **sortBy (_array_)** -- An array of [SortBy](#medialibrarysortby) keys. By default, all keys are sorted in descending order, however you can also pass a pair `[key, ascending]` where the second item is a `boolean` value that means whether to use ascending order. Note that if the `SortBy.default` key is used, then `ascending` argument will not matter.
     Earlier items have higher priority when sorting out the results.
     If empty, this method will use the default sorting that is provided by the platform.
-  - **mediaType (_array_)** -- An array of [MediaType](#expomedialibrarymediatype) types. By default `MediaType.photo` is set.
+  - **mediaType (_array_)** -- An array of [MediaType](#medialibrarymediatype) types. By default `MediaType.photo` is set.
   - **createdAfter (_Date_ | _number_)** -- Date object or Unix timestamp in milliseconds limiting returned assets only to those that were created after this date.
   - **createdBefore (_Date_ | _number_)** -- Similarly as `createdAfter`, but limits assets only to those that were created before specified date.
 
@@ -195,7 +195,7 @@ In case they're copied you should keep in mind that `getAssetsAsync` will return
 
 #### Arguments
 
-- **assets (_array_)** -- Array of [assets](#assets) to add.
+- **assets (_array_)** -- Array of [assets](#asset) to add.
 - **album (_string_ | _Album_)** -- [Album](#album) or its ID, to which the assets will be added.
 - **copyAssets (_boolean_)** -- Whether to copy assets to the new album instead of move them. Defaults to `true`. (**Android only**)
 
@@ -211,7 +211,7 @@ On Android, album will be automatically deleted if there are no more assets insi
 
 #### Arguments
 
-- **assets (_array_)** -- Array of [assets](#assets) to remove from album.
+- **assets (_array_)** -- Array of [assets](#asset) to remove from album.
 - **album (_string_ | _Album_)** -- [Album](#album) or its ID, from which the assets will be removed.
 
 #### Returns
@@ -237,9 +237,9 @@ Subscribes for updates in user's media library.
 
   Available only if `hasIncrementalChanges` is `true`:
 
-  - **insertedAssets (_array_)** -- Array of [assets](#assets) that have been inserted to the library.
-  - **deletedAssets (_array_)** -- Array of [assets](#assets) that have been deleted from the library.
-  - **updatedAssets (_array_)** -- Array of [assets](#assets) that have been updated or completed downloading from network storage (iCloud in iOS).
+  - **insertedAssets (_array_)** -- Array of [assets](#asset) that have been inserted to the library.
+  - **deletedAssets (_array_)** -- Array of [assets](#asset) that have been deleted from the library.
+  - **updatedAssets (_array_)** -- Array of [assets](#asset) that have been updated or completed downloading from network storage (iCloud in iOS).
 
 #### Returns
 

--- a/docs/pages/versions/v40.0.0/sdk/notifications.md
+++ b/docs/pages/versions/v40.0.0/sdk/notifications.md
@@ -180,7 +180,7 @@ The following methods are exported by the `expo-notifications` module:
   - [`setNotificationChannelGroupAsync`](#setnotificationchannelgroupasyncidentifier-string-channel-notificationchannelgroupinput-promisenotificationchannelgroup--null) -- saves a notification channel group configuration
   - [`deleteNotificationChannelGroupAsync`](#deletenotificationchannelgroupasyncidentifier-string-promisevoid) -- deletes a notification channel group
   - **managing notification categories (interactive notifications)**
-  - [`setNotificationCategoryAsync`](#setnotificationcategoryasyncidentifier-string-actions-notificationaction-options-categoryoptions-promisenotificationcategory) -- creates a new notification category for interactive notifications
+  - [`setNotificationCategoryAsync`](#setnotificationcategoryasyncidentifier-string-actions-notificationaction-options-categoryoptions-promisenotificationcategory--null) -- creates a new notification category for interactive notifications
   - [`getNotificationCategoriesAsync`](#getnotificationcategoriesasync-promisenotificationcategory) -- fetches information about all active notification categories
   - [`deleteNotificationCategoryAsync`](#deletenotificationcategoryasyncidentifier-string-promiseboolean) -- deletes a notification category
 

--- a/docs/pages/versions/v40.0.0/sdk/print.md
+++ b/docs/pages/versions/v40.0.0/sdk/print.md
@@ -43,7 +43,7 @@ Prints a document or HTML, on web this prints the HTML from the page.
 
 ### `Print.printToFileAsync(options)`
 
-Prints HTML to PDF file and saves it to [app's cache directory](filesystem.md#expofilesystemcachedirectory). On web this method opens the print dialog.
+Prints HTML to PDF file and saves it to [app's cache directory](filesystem.md#filesystemcachedirectory). On web this method opens the print dialog.
 
 #### Arguments
 

--- a/docs/pages/versions/v40.0.0/sdk/storereview.md
+++ b/docs/pages/versions/v40.0.0/sdk/storereview.md
@@ -29,7 +29,7 @@ If the users device is running a version of iOS lower than 10.3, or the user is 
 
 #### Error Codes
 
-- [`ERR_STORE_REVIEW_UNSUPPORTED`](#err_store_review_unsupported)
+- [`ERR_STORE_REVIEW_UNSUPPORTED`](#e_store_review_unsupported)
 
 #### Example
 

--- a/docs/pages/versions/v40.0.0/sdk/task-manager.md
+++ b/docs/pages/versions/v40.0.0/sdk/task-manager.md
@@ -139,7 +139,7 @@ Example:
 ### `TaskManager.unregisterTaskAsync(taskName)`
 
 Unregisters task from the app, so the app will not be receiving updates for that task anymore.
-_It is recommended to use methods specialized by modules that registered the task, eg. [Location.stopLocationUpdatesAsync](location.md#expolocationstoplocationupdatesasynctaskname)._
+_It is recommended to use methods specialized by modules that registered the task, eg. [Location.stopLocationUpdatesAsync](location.md#locationstoplocationupdatesasynctaskname)._
 
 #### Arguments
 

--- a/docs/pages/versions/v40.0.0/sdk/webbrowser.md
+++ b/docs/pages/versions/v40.0.0/sdk/webbrowser.md
@@ -81,7 +81,7 @@ Opens the url with Safari in a modal on iOS using [`SFSafariViewController`](htt
   - **dismissButtonStyle (_optional_) (_string_)** -- (_iOS only_) The style of the dismiss button. Should be one of: `done`, `close`, or `cancel`.
   - **enableBarCollapsing (_optional_) (_boolean_)** -- a boolean determining whether the toolbar should be hiding when a user scrolls the website.
   - **enableDefaultShare (_optional_) (_boolean_)** -- (_Android only_) a boolean determining whether a default share item should be added to the menu.
-  - **browserPackage (_optional_) (_string_)** -- (_Android only_). Package name of a browser to be used to handle Custom Tabs. List of available packages is to be queried by [getCustomTabsSupportingBrowsers](#webbrowsergetcustomtabssupportingbrowsers) method.
+  - **browserPackage (_optional_) (_string_)** -- (_Android only_). Package name of a browser to be used to handle Custom Tabs. List of available packages is to be queried by [getCustomTabsSupportingBrowsers](#webbrowsergetcustomtabssupportingbrowsersasync) method.
   - **readerMode (_optional_) (_boolean_)** -- (_iOS only_) a boolean determining whether Safari should enter Reader mode, if it is available.
   - **secondaryToolbarColor (_optional_) (_string_)** -- (_Android only_) color of the secondary toolbar in either `#AARRGGBB` or `#RRGGBB` format.
   - **showInRecents (_optional_) (_boolean_)** -- (_Android only_) a boolean determining whether browsed website should be shown as separate entry in Android recents/multitasking view. Default: `false`
@@ -113,7 +113,7 @@ This will be done using a "custom Chrome tabs" browser, [AppState][d-appstate], 
 
 **On web:**
 
-> 🚨 This API can only be used in a secure environment (`https`). You can use `expo start:web --https` to test this. Otherwise an error with code [`ERR_WEB_BROWSER_CRYPTO`](#errwebbrowsercrypto) will be thrown.
+> 🚨 This API can only be used in a secure environment (`https`). You can use `expo start:web --https` to test this. Otherwise an error with code [`ERR_WEB_BROWSER_CRYPTO`](#err_web_browser_crypto) will be thrown.
 
 This will use the browser's [`window.open()`][d-windowopen] API.
 
@@ -127,7 +127,7 @@ How this works on web:
 - The state will be added to the window's `localstorage`. This ensures that auth cannot complete unless it's done from a page running with the same origin as it was started. Ex: if `openAuthSessionAsync` is invoked on `https://localhost:19006`, then `maybeCompleteAuthSession` must be invoked on a page hosted from the origin `https://localhost:19006`. Using a different website, or even a different host like `https://128.0.0.*:19006` for example will not work.
 - A timer will be started to check for every 1000 milliseconds (1 second) to detect if the window has been closed by the user. If this happens then a promise will resolve with `{ type: 'dismiss' }`.
 
-🚨 On mobile web, Chrome and Safari will block any call to [`window.open()`][d-windowopen] which takes too long to fire after a user interaction. This method must be invoked immediately after a user interaction. If the event is blocked, an error with code [`ERR_WEB_BROWSER_BLOCKED`](#errwebbrowserblocked) will be thrown.
+🚨 On mobile web, Chrome and Safari will block any call to [`window.open()`][d-windowopen] which takes too long to fire after a user interaction. This method must be invoked immediately after a user interaction. If the event is blocked, an error with code [`ERR_WEB_BROWSER_BLOCKED`](#err_web_browser_blocked) will be thrown.
 
 [d-windowopen]: https://developer.mozilla.org/en-US/docs/Web/API/Window/open
 [d-appstate]: https://docs.expo.io/versions/latest/react-native/appstate/
@@ -147,9 +147,9 @@ Returns a Promise:
 
 #### Error Codes
 
-- [`ERR_WEB_BROWSER_REDIRECT`](#errwebbrowserredirect)
-- [`ERR_WEB_BROWSER_BLOCKED`](#errwebbrowserblocked)
-- [`ERR_WEB_BROWSER_CRYPTO`](#errwebbrowsercrypto)
+- [`ERR_WEB_BROWSER_REDIRECT`](#err_web_browser_redirect)
+- [`ERR_WEB_BROWSER_BLOCKED`](#err_web_browser_blocked)
+- [`ERR_WEB_BROWSER_CRYPTO`](#err_web_browser_crypto)
 
 ### `WebBrowser.maybeCompleteAuthSession(options)`
 
@@ -204,7 +204,7 @@ The promise resolves with `{ package: string }`.
 
 _Android only_
 
-This methods removes all bindings to services created by [`warmUpAsync`](#webbrowserwarmupasyncnbrowserpackage) or [`mayInitWithUrlAsync`](#webbrowseramayinitwithurlsyncurl-package). You should call this method once you don't need them to avoid potential memory leaks. However, those binding would be cleared once your application is destroyed, which might be sufficient in most cases.
+This methods removes all bindings to services created by [`warmUpAsync`](#webbrowserwarmupasyncbrowserpackage) or [`mayInitWithUrlAsync`](#webbrowsermayinitwithurlasyncurl-package). You should call this method once you don't need them to avoid potential memory leaks. However, those binding would be cleared once your application is destroyed, which might be sufficient in most cases.
 
 #### Arguments
 
@@ -236,10 +236,10 @@ The promise resolves with `{ browserPackages: string[], defaultBrowserPackage: s
 
 - **browserPackages (_string[]_)** : All packages recognized by `PackageManager` as capable of handling Custom Tabs. Empty array means there is no supporting browsers on device.
 - **defaultBrowserPackage (_string_ | null)** : Default package chosen by user. Null if there is no such packages. Null usually means, that user will be prompted to choose from available packages.
-- **servicePackages (_string[]_)** : All packages recognized by `PackageManager` as capable of handling Custom Tabs Service. This service is used by [`warmUpAsync`](#webbrowserwarmupasyncnbrowserpackage), [`mayInitWithUrlAsync`](#webbrowsermayinitwithurlasyncurl-package) and [`coolDownAsync`](#webbrowsercooldownasyncbrowserpackage).
+- **servicePackages (_string[]_)** : All packages recognized by `PackageManager` as capable of handling Custom Tabs Service. This service is used by [`warmUpAsync`](#webbrowserwarmupasyncbrowserpackage), [`mayInitWithUrlAsync`](#webbrowsermayinitwithurlasyncurl-package) and [`coolDownAsync`](#webbrowsercooldownasyncbrowserpackage).
 - **preferredBrowserPackage (_string_ | null)** : Package preferred by `CustomTabsClient` to be used to handle Custom Tabs. It favors browser chosen by user as default, as long as it is present on both `browserPackages` and `servicePackages` lists. Only such browsers are considered as fully supporting Custom Tabs. It might be `null` when there is no such browser installed or when default browser is not in `servicePackages` list.
 
-In general, services are used to perform background tasks. If a browser is available in `servicePackage` list, it should be capable of performing [`warmUpAsync`](#webbrowserwarmupasyncnbrowserpackage), [`mayInitWithUrlAsync`](#webbrowsermayinitwithurlasyncurl-package) and [`coolDownAsync`](#webbrowsercooldownasyncbrowserpackage). For opening an actual web page, browser must be in `browserPackages` list. A browser has to be present in both lists to be considered as fully supporting Custom Tabs.
+In general, services are used to perform background tasks. If a browser is available in `servicePackage` list, it should be capable of performing [`warmUpAsync`](#webbrowserwarmupasyncbrowserpackage), [`mayInitWithUrlAsync`](#webbrowsermayinitwithurlasyncurl-package) and [`coolDownAsync`](#webbrowsercooldownasyncbrowserpackage). For opening an actual web page, browser must be in `browserPackages` list. A browser has to be present in both lists to be considered as fully supporting Custom Tabs.
 
 ## Error Codes
 

--- a/docs/pages/workflow/linking.md
+++ b/docs/pages/workflow/linking.md
@@ -205,7 +205,7 @@ This would return something like `myapp:///path/into/app?hello=world&goodbye=now
 
 When your app is opened using the deep link, you can parse the link with `Linking.parse()` to get back the path and query parameters you passed in.
 
-When [handling the URL that is used to open/foreground your app](#handling-urls-in-your-app), it would look something like this:
+When [handling the URL that is used to open/foreground your app](#handling-links-into-your-app), it would look something like this:
 
 ```javascript
 _handleUrl = url => {


### PR DESCRIPTION
# Why

This is the result of a custom script that replaces broken headers with the `remark-validate-links`-suggested headers.

# How

Created a node script in `/docs` that replaces the output. Also used `$ yarn lint-links` to validate them.

- [You can see the script here](https://github.com/byCedric/expo/blob/%40bycedric/docs-tools/fix-headings/docs/scripts/fix-link-headings.js)
- [The output of all changed headers here](https://github.com/expo/expo/files/5666390/output.txt)

# Test Plan

- Run `$ yarn lint-links` to see if other suggestions remains
- Smoke tests links from the output to see if they still work
