### PR TITLE
[expo-dev-menu] Fix first launch behavior

### DIFF
--- a/packages/expo-dev-menu-interface/android/src/main/java/expo/interfaces/devmenu/DevMenuManagerInterface.kt
+++ b/packages/expo-dev-menu-interface/android/src/main/java/expo/interfaces/devmenu/DevMenuManagerInterface.kt
@@ -76,4 +76,9 @@ interface DevMenuManagerInterface {
    * @return the dev menu application host.
    */
   fun getMenuHost(): ReactNativeHost
+
+  /**
+   * Synchronizes [ReactInstanceManager] from delegate with one saved in [DevMenuManger].
+   */
+  fun synchronizeDelegate()
 }

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/react/DevMenuAwareReactActivity.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/react/DevMenuAwareReactActivity.kt
@@ -18,6 +18,8 @@ abstract class DevMenuAwareReactActivity : ReactActivity() {
     if (currentReactNative == null || currentReactNative != reactNativeHost) {
       currentReactNative = reactNativeHost
       DevMenuManager.initializeWithReactNativeHost(reactNativeHost)
+    } else {
+      DevMenuManager.synchronizeDelegate()
     }
   }
 

--- a/packages/expo-dev-menu/android/src/release/java/expo/modules/devmenu/DevMenuManager.kt
+++ b/packages/expo-dev-menu/android/src/release/java/expo/modules/devmenu/DevMenuManager.kt
@@ -56,4 +56,6 @@ object DevMenuManager : DevMenuManagerInterface {
   override fun getMenuHost(): ReactNativeHost {
     throw IllegalStateException(DEV_MENU_IS_NOT_AVAILABLE)
   }
+
+  override fun synchronizeDelegate() = Unit
 }

--- a/packages/expo-dev-menu/ios/DevMenuManager.swift
+++ b/packages/expo-dev-menu/ios/DevMenuManager.swift
@@ -77,7 +77,7 @@ open class DevMenuManager: NSObject, DevMenuManagerProtocol {
   @objc
   public var delegate: DevMenuDelegateProtocol? {
     didSet {
-      guard DevMenuSettings.showsAtLaunch, let bridge = delegate?.appBridge?(forDevMenuManager: self) as? RCTBridge else {
+      guard DevMenuSettings.showsAtLaunch || !DevMenuSettings.isOnboardingFinished, let bridge = delegate?.appBridge?(forDevMenuManager: self) as? RCTBridge else {
         return
       }
       if bridge.isLoading {
@@ -98,7 +98,9 @@ open class DevMenuManager: NSObject, DevMenuManagerProtocol {
   }
 
   @objc
-  public func autoLaunch() {
+  public func autoLaunch(_ shouldRemoveObserver: Bool = true) {
+    NotificationCenter.default.removeObserver(self)
+  
     DispatchQueue.main.async {
       self.openMenu()
     }


### PR DESCRIPTION
# Why

Fix the first launch behavior. Now the `dev-menu` will always show on the boarding screen when it's the first launch.
Moreover, I've also fixed how the show at launch option. 

The behavior was very inconsistent. It was working differently on both platforms. Right now, the `show at launch` option and onboarding screen works in the same way on both platforms.

# Test Plan

- bare-expo 
  - iOS ✅
  - Android ✅
