### PR TITLE
[docs] Update in-app-purchases.md: add billing permission for Android

### DIFF
--- a/docs/pages/versions/unversioned/sdk/in-app-purchases.md
+++ b/docs/pages/versions/unversioned/sdk/in-app-purchases.md
@@ -27,7 +27,11 @@ Run `npx pod-install` after installing the npm package.
 
 ### Configure for Android
 
-No additional set up necessary.
+Add this to your `android/app/src/main/AndroidManifest.xml` file:
+
+```
+<uses-permission android:name="com.android.vending.BILLING" />
+```
 
 ## Setup
 


### PR DESCRIPTION
# Why

added billing permission. it didn't automatically add it for me. this module only works on bare workflow so I don't think you can assume that these things are already added automatically when you install the module.

I couldn't get the subscriptions I created in Google Play when this isn't added.
