### PR TITLE
[docs] Fix guides using AppLoading

### DIFF
--- a/docs/pages/guides/preloading-and-caching-assets.md
+++ b/docs/pages/guides/preloading-and-caching-assets.md
@@ -2,6 +2,8 @@
 title: Handling Assets
 ---
 
+import SnackInline from '~/components/plugins/SnackInline';
+
 This section covers all things related to handling assets with Expo here including bundling, caching, pre-loading and publishing.
 
 ### Bundling Assets
@@ -31,10 +33,15 @@ For web images, use `Image.prefetch(image)`. Continue referencing the image norm
 Fonts are pre-loaded using `Font.loadAsync(font)`. The `font`
 argument in this case is an object such as the following: `{OpenSans: require('./assets/fonts/OpenSans.ttf')}`. `@expo/vector-icons` provides a helpful shortcut for this object, which you see below as `FontAwesome.font`.
 
-```javascript
+<SnackInline
+label="Pre-loading and Caching Assets"
+dependencies={['expo-font', 'expo-asset', 'expo-app-loading', '@expo/vector-icons']}
+files={{'assets/images/circle.jpg': 'https://snack-code-uploads.s3.us-west-1.amazonaws.com/~asset/42f59672cb9eb70368b00921c0cc60b7'}}>
+
+```jsx
 import * as React from 'react';
 import { View, Text, Image } from 'react-native';
-import { AppLoading } from 'expo';
+import AppLoading from 'expo-app-loading';
 import * as Font from 'expo-font';
 import { Asset } from 'expo-asset';
 import { FontAwesome } from '@expo/vector-icons';
@@ -88,6 +95,8 @@ export default class AppContainer extends React.Component {
   }
 }
 ```
+
+</SnackInline>
 
 See a full working example in [this Expo template project](https://github.com/expo/expo/blob/sdk-36/templates/expo-template-tabs/App.js). You can also run `expo init --template tabs`, which will set you up locally with the same template.
 

--- a/docs/pages/guides/using-custom-fonts.md
+++ b/docs/pages/guides/using-custom-fonts.md
@@ -19,8 +19,10 @@ $ expo install expo-font @expo-google-fonts/inter
 
 After that, you can integrate this in your project by using the `useFonts` hook in the root of your app.
 
-```js
+```jsx
 import React from 'react';
+import { Text } from 'react-native';
+import AppLoading from 'expo-app-loading';
 import { useFonts, Inter_900Black } from '@expo-google-fonts/inter';
 
 export default function App() {
@@ -42,15 +44,15 @@ To create a new project including this example, run `npx create-react-native-app
 
 <SnackInline
 label="Custom Font"
-dependencies={['expo-font']}
+dependencies={['expo-font', 'expo-app-loading']}
 files={{
     'assets/fonts/Inter-Black.otf': 'https://snack-code-uploads.s3.us-west-1.amazonaws.com/~asset/44b1541a96341780b29112665c66ac67'
   }}>
 
-```js
+```jsx
 import React from 'react';
 import { Text, View } from 'react-native';
-import { AppLoading } from 'expo';
+import AppLoading from 'expo-app-loading';
 import { useFonts } from 'expo-font';
 
 export default props => {
@@ -158,12 +160,12 @@ To do this, just replace the `require('./assets/fonts/MyFont.otf')` with the URL
 
 Here is a minimal, complete example.
 
-<SnackInline label='Remote Font' dependencies={['expo-font']}>
+<SnackInline label='Remote Font' dependencies={['expo-font', 'expo-app-loading']}>
 
-```js
+```jsx
 import React from 'react';
 import { Text, View } from 'react-native';
-import { AppLoading } from 'expo';
+import AppLoading from 'expo-app-loading';
 import { useFonts } from 'expo-font';
 
 export default props => {
@@ -193,15 +195,15 @@ If you don't want to use the `useFonts` hook (for example, maybe you prefer clas
 
 <SnackInline
 label="Font loadAsync"
-dependencies={['expo-font']}
+dependencies={['expo-font', 'expo-app-loading']}
 files={{
     'assets/fonts/Inter-Black.otf': 'https://snack-code-uploads.s3.us-west-1.amazonaws.com/~asset/44b1541a96341780b29112665c66ac67'
   }}>
 
-```js
+```jsx
 import React from 'react';
 import { Text, View, StyleSheet } from 'react-native';
-import { AppLoading } from 'expo';
+import AppLoading from 'expo-app-loading';
 import * as Font from 'expo-font';
 
 let customFonts = {


### PR DESCRIPTION
# Why

Fixes Snack examples still using AppLoading from "expo".

![image](https://user-images.githubusercontent.com/6184593/101795017-befd1900-3b07-11eb-98fa-c64db91338ee.png)

# How

- Use "expo-app-loading" in Custom fonts guide
- Use "expo-app-loading" in Preloading and caching assets guide
- Replace `js` by `jsx` to fix JSX code highlighting
- Update example in "Preloading and caching assets guide" to be an inlined working Snack

# Test Plan

- Verified all Snack examples work