### PR TITLE
[expo-dev-launcher][Android] Apply user interface style

### DIFF
--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/helpers/DevLauncherReflectionExtensions.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/helpers/DevLauncherReflectionExtensions.kt
@@ -2,6 +2,7 @@ package expo.modules.devlauncher.helpers
 
 import java.lang.Exception
 import java.lang.reflect.Field
+import java.lang.reflect.Modifier
 
 fun <T> Class<T>.getFieldInClassHierarchy(fieldName: String): Field? {
   var currentClass: Class<*>? = this
@@ -9,8 +10,28 @@ fun <T> Class<T>.getFieldInClassHierarchy(fieldName: String): Field? {
   while (currentClass != null && result == null) {
     try {
       result = currentClass.getDeclaredField(fieldName)
-    } catch (e: Exception) {}
+    } catch (e: Exception) {
+    }
     currentClass = currentClass.superclass
   }
   return result
+}
+
+fun <T> Class<out T>.setProtectedDeclaredField(obj: T, filedName: String, newValue: Any, predicate: (Any?) -> Boolean = { true }) {
+  val field = getDeclaredField(filedName)
+  val modifiersField = Field::class.java.getDeclaredField("accessFlags")
+
+  field.isAccessible = true
+  modifiersField.isAccessible = true
+
+  modifiersField.setInt(
+    field,
+    field.modifiers and Modifier.FINAL.inv()
+  )
+
+  if (!predicate.invoke(field.get(obj))) {
+    return
+  }
+
+  field.set(obj, newValue)
 }

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/configurators/DevLauncherExpoActivityConfigurator.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/configurators/DevLauncherExpoActivityConfigurator.kt
@@ -48,23 +48,6 @@ class DevLauncherExpoActivityConfigurator(
     }
   }
 
-  fun applyUiMode(activity: ReactActivity) {
-    val uiMode = manifest
-      .userInterfaceStyle
-      ?.let {
-        when (it) {
-          DevLauncherUserInterface.AUTOMATIC -> {
-            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
-              AppCompatDelegate.MODE_NIGHT_AUTO_BATTERY
-            } else AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
-          }
-          DevLauncherUserInterface.DARK -> AppCompatDelegate.MODE_NIGHT_YES
-          DevLauncherUserInterface.LIGHT -> AppCompatDelegate.MODE_NIGHT_NO
-        }
-      } ?: AppCompatDelegate.MODE_NIGHT_NO
-    activity.delegate.localNightMode = uiMode
-  }
-
   fun applyStatusBarConfiguration(activity: ReactActivity) {
     val style = manifest.androidStatusBar?.barStyle
     val backgroundColor = manifest.androidStatusBar?.backgroundColor

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/loaders/DevLauncherExpoAppLoader.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/loaders/DevLauncherExpoAppLoader.kt
@@ -2,12 +2,16 @@ package expo.modules.devlauncher.launcher.loaders
 
 import android.content.Context
 import android.graphics.Color
+import android.util.Log
 import android.view.View
 import com.facebook.react.ReactActivity
 import com.facebook.react.ReactNativeHost
 import com.facebook.react.bridge.ReactContext
+import com.facebook.react.modules.appearance.AppearanceModule
 import expo.modules.devlauncher.helpers.isValidColor
+import expo.modules.devlauncher.helpers.setProtectedDeclaredField
 import expo.modules.devlauncher.launcher.configurators.DevLauncherExpoActivityConfigurator
+import expo.modules.devlauncher.launcher.manifest.DevLauncherUserInterface
 import expo.modules.devlauncher.launcher.manifest.DevelopmentClientManifest
 
 class DevLauncherExpoAppLoader(
@@ -23,7 +27,6 @@ class DevLauncherExpoAppLoader(
 
   override fun onCreate(activity: ReactActivity) = with(activityConfigurator) {
     applyOrientation(activity)
-    applyUiMode(activity)
     applyStatusBarConfiguration(activity)
     applyTaskDescription(activity)
   }
@@ -32,6 +35,39 @@ class DevLauncherExpoAppLoader(
     context.currentActivity?.run {
       val rootView = findViewById<View>(android.R.id.content).rootView
       applyBackgroundColor(rootView)
+    }
+
+    applyUserInterfaceStyle(context)
+  }
+
+  private fun applyUserInterfaceStyle(context: ReactContext) {
+    val userInterfaceStyle = when (manifest.userInterfaceStyle) {
+      DevLauncherUserInterface.DARK -> "dark"
+      DevLauncherUserInterface.LIGHT -> "light"
+      else -> return
+    }
+
+    context.getNativeModule(AppearanceModule::class.java)?.let { appearanceModule ->
+      try {
+        appearanceModule::class.java.setProtectedDeclaredField(
+          obj = appearanceModule,
+          filedName = "mOverrideColorScheme",
+          newValue = object : AppearanceModule.OverrideColorScheme {
+            override fun getScheme(): String {
+              return userInterfaceStyle
+            }
+          },
+          predicate = { currentValue -> currentValue == null }
+        )
+
+        appearanceModule::class.java.setProtectedDeclaredField(
+          obj = appearanceModule,
+          filedName = "mColorScheme",
+          newValue = userInterfaceStyle
+        )
+      } catch (e: Exception) {
+        Log.w("DevLauncher", e)
+      }
     }
   }
 


### PR DESCRIPTION
# Why

Applies the user interface style from the app.json when the app is loaded on iOS.
It's similar to https://github.com/expo/expo/pull/11277.

# How

We need to change the local variable in the `AppearanceModule`. Unfortunately, it's the only solution, because the `AppearanceModule` normally reads the system settings which we can't change. 
It's worth mentioning that we can't change the theme of the Android UI - the user should force it by his `AndroidManifest.xml` (by Android UI, I meant, for example, data picker or image picker).  

Moreover, this won't work with the `expo/react-native-appearance` module - https://github.com/expo/react-native-appearance.

# Test Plan

- bare-expo ✅