### PR TITLE
[screen-orientation] fix: orientationDidChange not firing when modal …

### DIFF
--- a/packages/expo-screen-orientation/CHANGELOG.md
+++ b/packages/expo-screen-orientation/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed `screenOrientationDidChange` not being called when a `Modal` was open on iOS. ([#11323](https://github.com/expo/expo/pull/11323) by [@cruzach](https://github.com/cruzach))
+
 ## 2.1.0 — 2020-11-17
 
 _This version does not introduce any user-facing changes._
@@ -24,7 +26,7 @@ _This version does not introduce any user-facing changes._
 
 ## 1.1.1 — 2020-05-29
 
-*This version does not introduce any user-facing changes.*
+_This version does not introduce any user-facing changes._
 
 ## 1.1.0 — 2020-05-27
 

--- a/packages/expo-screen-orientation/ios/EXScreenOrientation/EXScreenOrientationRegistry.m
+++ b/packages/expo-screen-orientation/ios/EXScreenOrientation/EXScreenOrientationRegistry.m
@@ -159,10 +159,10 @@ UM_REGISTER_SINGLETON_MODULE(ScreenOrientationRegistry)
       return;
     }
     
-    // on iPads, traitCollectionDidChange isn't triggered at all
-    if ([EXScreenOrientationUtilities isIPad] &&
-        ((UIInterfaceOrientationIsPortrait(newScreenOrientation) && UIInterfaceOrientationIsLandscape(_currentScreenOrientation))
-         || (UIInterfaceOrientationIsLandscape(newScreenOrientation) && UIInterfaceOrientationIsPortrait(_currentScreenOrientation)))) {
+    // Sometimes, traitCollectionDidChange isn't triggered at all.
+    // i.e. on iPads and when the view is a Modal
+    if ((UIInterfaceOrientationIsPortrait(newScreenOrientation) && UIInterfaceOrientationIsLandscape(_currentScreenOrientation))
+         || (UIInterfaceOrientationIsLandscape(newScreenOrientation) && UIInterfaceOrientationIsPortrait(_currentScreenOrientation))) {
       [self screenOrientationDidChange:newScreenOrientation];
     }
   }


### PR DESCRIPTION
…is open

# Why

Reported by a partner that they couldn't force the orientation back to portrait after closing a modal that allowed both portrait and landscape orientations. 

[Use this snack to reproduce](https://snack.expo.io/@lachlanglen/76bd6d):
- click to open modal
- rotate to landscape
- click to close modal and app _should_ reorient to portrait, but it does not

# How

Found out that `traitCollectionDidChange` isn't called when a Modal is open, which it seems is also the case on iPad, so I removed the check for `isIPad`. 

In my tests, `screenOrientationDidChange` isn't getting called twice in any scenarios (neither with the modal open nor with it closed, but maybe there are more scenarios you can imagine that I should test @lukmccall ?)

# Test Plan

ran screen-orientation test suite, all passed
