### PR TITLE
[expo-updates] do manifest verification check even if we can't cache the public key to disk

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Complete manifest verification check on iOS even if we can't cache the public key to disk ([#11327](https://github.com/expo/expo/pull/11327) by [@esamelson](https://github.com/esamelson))
+
 ## 0.4.1 — 2020-11-25
 
 ### 🛠 Breaking changes

--- a/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesAppLauncherWithDatabase.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesAppLauncherWithDatabase.m
@@ -267,7 +267,7 @@ static NSString * const EXUpdatesAppLauncherErrorDomain = @"AppLauncher";
         asset.downloadTime = [NSDate date];
         completion(nil, asset, assetLocalUrl);
       });
-    } errorBlock:^(NSError *error, NSURLResponse *response) {
+    } errorBlock:^(NSError *error, NSData *data, NSURLResponse *response) {
       dispatch_async(self->_launcherQueue, ^{
         completion(error, asset, assetLocalUrl);
       });

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesCrypto.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesCrypto.m
@@ -66,8 +66,13 @@ static NSString * const EXUpdatesCryptoPublicKeyFilename = @"manifestPublicKey.p
                            successBlock:^(NSData *publicKeyData, NSURLResponse *response) {
                                           [[self class] verifyWithPublicKey:publicKeyData signature:signature signedString:data callback:successBlock];
                                         }
-                             errorBlock:^(NSError *error, NSURLResponse *response) {
-                                          errorBlock(error);
+                             errorBlock:^(NSError *error, NSData *publicKeyData, NSURLResponse *response) {
+                                          NSLog(@"Could not write manifest public key to cache; continuing without caching. Error: %@", error.localizedDescription);
+                                          if (publicKeyData) {
+                                            [[self class] verifyWithPublicKey:publicKeyData signature:signature signedString:data callback:successBlock];
+                                          } else {
+                                            errorBlock(error);
+                                          }
                                         }
     ];
   }

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.h
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.h
@@ -7,7 +7,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 typedef void (^EXUpdatesFileDownloaderSuccessBlock)(NSData *data, NSURLResponse *response);
 typedef void (^EXUpdatesFileDownloaderManifestSuccessBlock)(EXUpdatesUpdate *update);
-typedef void (^EXUpdatesFileDownloaderErrorBlock)(NSError *error, NSURLResponse *response);
+typedef void (^EXUpdatesFileDownloaderErrorBlock)(NSError *error, NSData *data, NSURLResponse *response);
 
 @interface EXUpdatesFileDownloader : NSObject
 

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.m
@@ -69,7 +69,7 @@ NSTimeInterval const EXUpdatesDefaultTimeoutInterval = 60;
                                    NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Could not write to path %@: %@", destinationPath, error.localizedDescription],
                                    NSUnderlyingErrorKey: error
                                  }
-                  ], response);
+                  ], data, response);
     }
   } errorBlock:errorBlock];
 }
@@ -88,13 +88,13 @@ NSTimeInterval const EXUpdatesDefaultTimeoutInterval = 60;
     NSError *err;
     id parsedJson = [NSJSONSerialization JSONObjectWithData:data options:kNilOptions error:&err];
     if (err) {
-      errorBlock(err, response);
+      errorBlock(err, data, response);
       return;
     }
 
     NSDictionary *manifest = [self _extractManifest:parsedJson error:&err];
     if (err) {
-      errorBlock(err, response);
+      errorBlock(err, data, response);
       return;
     }
 
@@ -135,11 +135,11 @@ NSTimeInterval const EXUpdatesDefaultTimeoutInterval = 60;
                                                     successBlock(update);
                                                   } else {
                                                     NSError *error = [NSError errorWithDomain:EXUpdatesFileDownloaderErrorDomain code:1003 userInfo:@{NSLocalizedDescriptionKey: @"Manifest verification failed"}];
-                                                    errorBlock(error, response);
+                                                    errorBlock(error, data, response);
                                                   }
                                                 }
                                     errorBlock:^(NSError *error) {
-                                                  errorBlock(error, response);
+                                                  errorBlock(error, data, response);
                                                 }
       ];
     } else {
@@ -179,7 +179,7 @@ NSTimeInterval const EXUpdatesDefaultTimeoutInterval = 60;
     }
 
     if (error) {
-      errorBlock(error, response);
+      errorBlock(error, data, response);
     } else {
       successBlock(data, response);
     }

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesRemoteAppLoader.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesRemoteAppLoader.m
@@ -36,7 +36,7 @@ static NSString * const EXUpdatesRemoteAppLoaderErrorDomain = @"EXUpdatesRemoteA
   self.errorBlock = error;
   [_downloader downloadManifestFromURL:url withDatabase:self.database cacheDirectory:self.directory successBlock:^(EXUpdatesUpdate *update) {
     [self startLoadingFromManifest:update];
-  } errorBlock:^(NSError *error, NSURLResponse *response) {
+  } errorBlock:^(NSError *error, NSData *data, NSURLResponse *response) {
     if (self.errorBlock) {
       self.errorBlock(error);
     }
@@ -63,7 +63,7 @@ static NSString * const EXUpdatesRemoteAppLoaderErrorDomain = @"EXUpdatesRemoteA
         dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
           [self handleAssetDownloadWithData:data response:response asset:asset];
         });
-      } errorBlock:^(NSError *error, NSURLResponse *response) {
+      } errorBlock:^(NSError *error, NSData *data, NSURLResponse *response) {
         dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
           [self handleAssetDownloadWithError:error asset:asset];
         });

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesModule.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesModule.m
@@ -93,7 +93,7 @@ UM_EXPORT_METHOD_AS(checkForUpdateAsync,
         @"isAvailable": @(NO)
       });
     }
-  } errorBlock:^(NSError *error, NSURLResponse *response) {
+  } errorBlock:^(NSError *error, NSData *data, NSURLResponse *response) {
     reject(@"ERR_UPDATES_CHECK", error.localizedDescription, error);
   }];
 }


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/10623

Even if we can't cache the manifest public key to disk, we should still continue trying to verify the manifest and not cause cause a rejection of whatever promise is in the call stack (in the case of the issue, `checkForUpdateAsync()`).

# How

Pass the HTTP response data through the error callback, and then in EXUpdatesCrypto use this data to continue with the verification rather than calling the error block.

# Test Plan

Was not able to replicate the exact error reported in the issue, but I *was* able to trigger a failure coming from the same location (https://github.com/expo/expo/blob/ba046bb1946ccc10ded80facdfde4bb67998e9f3/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.m#L66-L70) by attempting to write the pem file to a folder that didn't exist.

After this change, a `checkForUpdateAsync()` call resolved successfully even when an error was returned from the above location.
