### PR TITLE
chore(yarn-workspaces): remove dated instruction from readme

### DIFF
--- a/packages/expo-yarn-workspaces/README.md
+++ b/packages/expo-yarn-workspaces/README.md
@@ -26,7 +26,7 @@ The postinstall script determines the location of the generated entry module by 
 
 You can specify other paths too. The `.expo` directory is convenient since it already contains auto-generated files and is .gitignore'd.
 
-### Create a file named `metro.config.js` and reference it from app.json
+### Create a file named `metro.config.js`
 
 **Create a file named `metro.config.js` in the app's base directory with these contents:**
 


### PR DESCRIPTION
# Why

The part the heading referred to was removed in https://github.com/expo/expo/pull/8217/files#diff-0204fc2ff7dd141673b7ffbb6397672418e41b1dd38ef0d1372cc70805fadfbeL41

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

GH Editor

# Test Plan

Just a readme change

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->
