### PR TITLE
[et] Add "notices" to changelog types

### DIFF
--- a/tools/expotools/src/Changelogs.ts
+++ b/tools/expotools/src/Changelogs.ts
@@ -45,6 +45,7 @@ export enum ChangeType {
   BREAKING_CHANGES = '🛠 Breaking changes',
   NEW_FEATURES = '🎉 New features',
   BUG_FIXES = '🐛 Bug fixes',
+  NOTICES = '⚠️ Notices',
 }
 
 /**

--- a/tools/expotools/src/commands/AddChangelog.ts
+++ b/tools/expotools/src/commands/AddChangelog.ts
@@ -79,7 +79,7 @@ async function checkOrAskForOptions(options: ActionOptions): Promise<ActionOptio
       type: 'list',
       name: 'type',
       message: 'What is the type?',
-      choices: ['bug-fix', 'new-feature', 'breaking-change'],
+      choices: ['bug-fix', 'new-feature', 'breaking-change', 'library-upgrade', 'notice'],
     });
   }
 
@@ -96,6 +96,10 @@ function toChangeType(type: string): Changelogs.ChangeType | null {
       return Changelogs.ChangeType.NEW_FEATURES;
     case 'breaking-change':
       return Changelogs.ChangeType.BREAKING_CHANGES;
+    case 'library-upgrade':
+      return Changelogs.ChangeType.LIBRARY_UPGRADES;
+    case 'notice':
+      return Changelogs.ChangeType.NOTICES;
   }
   return null;
 }
@@ -196,7 +200,7 @@ export default (program: Command) => {
     )
     .option(
       '-t, --type <string>',
-      'Type of change that determines the section into which the entry should be added. Possible options: bug-fix | new-feature | breaking-change.'
+      'Type of change that determines the section into which the entry should be added. Possible options: bug-fix | new-feature | breaking-change | library-upgrade | notice.'
     )
     .option(
       '-v, --version [string]',


### PR DESCRIPTION
# Why

Followup #11224 
Once we start shipping iOS native code with prebuilt binaries, it should be mentioned somewhere in the changelog. It's actually neither breaking change, nor new feature nor a bug fix. For such kind of changes I propose new "⚠️ Notices" type.

# How

Added such type to `ChangeType` enum and added it as an option to `et add-changelog` command.

# Test Plan

Tried `et add-changelog -p expo-gl -t notice` and confirmed the resulted changes in `expo-gl`'s changelog looked as expected.
