### PR TITLE
[expo-dev-launcher] Fix time parameter in recently opened apps registry

### DIFF
--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/DevLauncherRecentlyOpenedAppsRegistry.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/DevLauncherRecentlyOpenedAppsRegistry.kt
@@ -6,7 +6,7 @@ import com.google.gson.Gson
 
 private const val RECENTLY_OPENED_APPS_SHARED_PREFERENCES = "expo.modules.devlauncher.recentyopenedapps"
 
-private const val TIME_TO_REMOVE = 60 * 60 * 24 * 3 // 3 days
+private const val TIME_TO_REMOVE = 1000 * 60 * 60 * 24 * 3 // 3 days
 
 data class DevLauncherAppEntry(
   val timestamp: Long,

--- a/packages/expo-dev-launcher/ios/EXDevLauncherRecentlyOpenedAppsRegistry.swift
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherRecentlyOpenedAppsRegistry.swift
@@ -4,7 +4,7 @@ import Foundation
 
 let RECENTLY_OPENED_APPS_REGISTRY_KEY = "expo.devlauncher.recentlyopenedapps"
 
-let TIME_TO_REMOVE = 60 * 60 * 24 * 3 // 3 days
+let TIME_TO_REMOVE = 1000 * 60 * 60 * 24 * 3 // 3 days
 
 @objc(EXDevLauncherRecentlyOpenedAppsRegistry)
 public class EXDevLauncherRecentlyOpenedAppsRegistry : NSObject {


### PR DESCRIPTION
# Why

3 days = 1000 * 60 * 60 * 24 * 3 milliseconds **not** 60 * 60 * 24 * 3 🤦‍♂️