### PR TITLE
[bare-expo] Fix `dev-launcher` wasn't initialized

### DIFF
--- a/apps/bare-expo/android/app/src/main/java/dev/expo/payments/MainActivity.java
+++ b/apps/bare-expo/android/app/src/main/java/dev/expo/payments/MainActivity.java
@@ -44,8 +44,10 @@ public class MainActivity extends DevMenuAwareReactActivity {
 
   @Override
   public void onNewIntent(Intent intent) {
-    if (DevLauncherController.tryToHandleIntent(this, intent)) {
-      return;
+    if (MainApplication.USE_DEV_CLIENT) {
+      if (DevLauncherController.tryToHandleIntent(this, intent)) {
+        return;
+      }
     }
     super.onNewIntent(intent);
   }

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
@@ -201,6 +201,9 @@ class DevLauncherController private constructor(
     private var sLauncherClass: Class<*>? = null
 
     @JvmStatic
+    fun wasInitialized() = sInstance != null
+    
+    @JvmStatic
     val instance: DevLauncherController
       get() = checkNotNull(sInstance) {
         "DevelopmentClientController.getInstance() was called before the module was initialized"

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/modules/DevLauncherModule.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/modules/DevLauncherModule.kt
@@ -10,6 +10,7 @@ import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.modules.core.DeviceEventManagerModule.RCTDeviceEventEmitter
 import expo.modules.devlauncher.DevLauncherController.Companion.instance
+import expo.modules.devlauncher.DevLauncherController.Companion.wasInitialized
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 
@@ -19,12 +20,16 @@ private const val CLIENT_PACKAGE_NAME = "host.exp.exponent"
 class DevLauncherModule(reactContext: ReactApplicationContext?) : ReactContextBaseJavaModule(reactContext) {
   override fun initialize() {
     super.initialize()
-    instance.pendingIntentRegistry.subscribe(this::onNewPendingIntent)
+    if (wasInitialized()) {
+      instance.pendingIntentRegistry.subscribe(this::onNewPendingIntent)
+    }
   }
 
   override fun invalidate() {
     super.invalidate()
-    instance.pendingIntentRegistry.unsubscribe(this::onNewPendingIntent)
+    if (wasInitialized()) {
+      instance.pendingIntentRegistry.unsubscribe(this::onNewPendingIntent)
+    }
   }
 
   override fun getName(): String {
@@ -78,7 +83,7 @@ class DevLauncherModule(reactContext: ReactApplicationContext?) : ReactContextBa
     if (openLink(Uri.parse("https://play.google.com/store/apps/details?id=$CLIENT_PACKAGE_NAME"))) {
       return
     }
-    
+
     promise.reject("ERR_DEVELOPMENT_CLIENT_CANNOT_OPEN_CAMERA", "Couldn't find the Expo Go app.")
   }
 


### PR DESCRIPTION
# Why

 Fix `dev-launcher` wasn't initialized error when launching `bare-expo` without `dev-launcher`.

# Test Plan

- bare-expo ✅