### PR TITLE
[expo-updates][ios] use NSURLCache for manifest public key instead of rolling our own

### DIFF
--- a/ios/Exponent/Kernel/Services/EXUpdatesManager.m
+++ b/ios/Exponent/Kernel/Services/EXUpdatesManager.m
@@ -161,7 +161,6 @@ didRequestManifestWithCacheBehavior:(EXManifestCacheBehavior)cacheBehavior
   EXUpdatesFileDownloader *fileDownloader = [[EXUpdatesFileDownloader alloc] initWithUpdatesConfig:appLoader.config];
   [fileDownloader downloadManifestFromURL:appLoader.config.updateUrl
                              withDatabase:databaseKernelService.database
-                           cacheDirectory:databaseKernelService.updatesDirectory
                              successBlock:^(EXUpdatesUpdate *update) {
     success(update.rawManifest);
   } errorBlock:^(NSError *error, NSURLResponse *response) {

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- On iOS, use default NSURLCache for manifest public key rather than caching it manually.
+
 ## 0.4.1 — 2020-11-25
 
 ### 🛠 Breaking changes

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesCrypto.h
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesCrypto.h
@@ -12,7 +12,6 @@ typedef void (^EXUpdatesVerifySignatureErrorBlock)(NSError *error);
 + (void)verifySignatureWithData:(NSString *)data
                       signature:(NSString *)signature
                          config:(EXUpdatesConfig *)config
-                 cacheDirectory:(NSURL *)cacheDirectory
                    successBlock:(EXUpdatesVerifySignatureSuccessBlock)successBlock
                      errorBlock:(EXUpdatesVerifySignatureErrorBlock)errorBlock;
 

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesCrypto.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesCrypto.m
@@ -19,58 +19,53 @@ static NSString * const EXUpdatesCryptoPublicKeyFilename = @"manifestPublicKey.p
                    successBlock:(EXUpdatesVerifySignatureSuccessBlock)successBlock
                      errorBlock:(EXUpdatesVerifySignatureErrorBlock)errorBlock
 {
-  [self fetchAndVerifySignatureWithData:data
-                              signature:signature
-                                 config:config
-                         cacheDirectory:cacheDirectory
-                               useCache:YES
-                           successBlock:successBlock
-                             errorBlock:errorBlock];
-}
-
-+ (void)fetchAndVerifySignatureWithData:(NSString *)data
-                              signature:(NSString *)signature
-                                 config:(EXUpdatesConfig *)config
-                         cacheDirectory:(NSURL *)cacheDirectory
-                               useCache:(BOOL)useCache
-                           successBlock:(EXUpdatesVerifySignatureSuccessBlock)successBlock
-                             errorBlock:(EXUpdatesVerifySignatureErrorBlock)errorBlock
-{
   if (!data || !signature) {
     errorBlock([NSError errorWithDomain:@"EXUpdatesCrypto" code:1001 userInfo:@{ NSLocalizedDescriptionKey: @"Cannot verify the manifest because it is empty or has no signature." }]);
     return;
   }
 
-  NSURL *cachedPublicKeyUrl = [cacheDirectory URLByAppendingPathComponent:EXUpdatesCryptoPublicKeyFilename];
-  if (useCache) {
-    NSData *publicKeyData = [NSData dataWithContentsOfFile:[cachedPublicKeyUrl absoluteString]];
-    [[self class] verifyWithPublicKey:publicKeyData signature:signature signedString:data callback:^(BOOL isValid) {
-      if (isValid) {
-        successBlock(isValid);
-      } else {
-        [[self class] fetchAndVerifySignatureWithData:data
-                                            signature:signature
-                                               config:config
-                                       cacheDirectory:cacheDirectory
-                                             useCache:NO
-                                         successBlock:successBlock
-                                           errorBlock:errorBlock];
-      }
-    }];
-  } else {
-    NSURLSessionConfiguration *configuration = NSURLSessionConfiguration.defaultSessionConfiguration;
-    configuration.requestCachePolicy = NSURLRequestReloadIgnoringCacheData;
-    EXUpdatesFileDownloader *fileDownloader = [[EXUpdatesFileDownloader alloc] initWithUpdatesConfig:config URLSessionConfiguration:configuration];
-    [fileDownloader downloadFileFromURL:[NSURL URLWithString:EXUpdatesCryptoPublicKeyUrl]
-                                 toPath:[cachedPublicKeyUrl path]
-                           successBlock:^(NSData *publicKeyData, NSURLResponse *response) {
-                                          [[self class] verifyWithPublicKey:publicKeyData signature:signature signedString:data callback:successBlock];
-                                        }
-                             errorBlock:^(NSError *error, NSURLResponse *response) {
-                                          errorBlock(error);
-                                        }
-    ];
-  }
+  NSURLSessionConfiguration *configuration = NSURLSessionConfiguration.defaultSessionConfiguration;
+  configuration.requestCachePolicy = NSURLRequestReturnCacheDataDontLoad;
+
+  void (^fetchRemotelyBlock)(void) = ^{
+    [[self class] fetchAndVerifySignatureWithData:data signature:signature config:config successBlock:successBlock errorBlock:errorBlock];
+  };
+
+  EXUpdatesFileDownloader *fileDownloader = [[EXUpdatesFileDownloader alloc] initWithUpdatesConfig:config URLSessionConfiguration:configuration];
+  [fileDownloader downloadDataFromURL:[NSURL URLWithString:EXUpdatesCryptoPublicKeyUrl]
+                         successBlock:^(NSData *publicKeyData, NSURLResponse *response) {
+                                        [[self class] verifyWithPublicKey:publicKeyData signature:signature signedString:data callback:^(BOOL isValid) {
+                                          if (isValid) {
+                                            successBlock(isValid);
+                                          } else {
+                                            fetchRemotelyBlock();
+                                          }
+                                        }];
+                                      }
+                           errorBlock:^(NSError *error, NSURLResponse *response) {
+                                        fetchRemotelyBlock();
+                                      }
+   ];
+}
+
++ (void)fetchAndVerifySignatureWithData:(NSString *)data
+                              signature:(NSString *)signature
+                                 config:(EXUpdatesConfig *)config
+                           successBlock:(EXUpdatesVerifySignatureSuccessBlock)successBlock
+                             errorBlock:(EXUpdatesVerifySignatureErrorBlock)errorBlock
+{
+  NSURLSessionConfiguration *configuration = NSURLSessionConfiguration.defaultSessionConfiguration;
+  configuration.requestCachePolicy = NSURLRequestReloadIgnoringCacheData;
+
+  EXUpdatesFileDownloader *fileDownloader = [[EXUpdatesFileDownloader alloc] initWithUpdatesConfig:config URLSessionConfiguration:configuration];
+  [fileDownloader downloadDataFromURL:[NSURL URLWithString:EXUpdatesCryptoPublicKeyUrl]
+                         successBlock:^(NSData *publicKeyData, NSURLResponse *response) {
+                                        [[self class] verifyWithPublicKey:publicKeyData signature:signature signedString:data callback:successBlock];
+                                      }
+                           errorBlock:^(NSError *error, NSURLResponse *response) {
+                                        errorBlock(error);
+                                      }
+  ];
 }
 
 + (void)verifyWithPublicKey:(NSData *)publicKeyData

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesCrypto.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesCrypto.m
@@ -15,7 +15,6 @@ static NSString * const EXUpdatesCryptoPublicKeyFilename = @"manifestPublicKey.p
 + (void)verifySignatureWithData:(NSString *)data
                       signature:(NSString *)signature
                          config:(EXUpdatesConfig *)config
-                 cacheDirectory:(NSURL *)cacheDirectory
                    successBlock:(EXUpdatesVerifySignatureSuccessBlock)successBlock
                      errorBlock:(EXUpdatesVerifySignatureErrorBlock)errorBlock
 {

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesCrypto.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesCrypto.m
@@ -55,7 +55,7 @@ static NSString * const EXUpdatesCryptoPublicKeyFilename = @"manifestPublicKey.p
                              errorBlock:(EXUpdatesVerifySignatureErrorBlock)errorBlock
 {
   NSURLSessionConfiguration *configuration = NSURLSessionConfiguration.defaultSessionConfiguration;
-  configuration.requestCachePolicy = NSURLRequestReloadIgnoringCacheData;
+  configuration.requestCachePolicy = NSURLRequestReloadIgnoringLocalCacheData;
 
   EXUpdatesFileDownloader *fileDownloader = [[EXUpdatesFileDownloader alloc] initWithUpdatesConfig:config URLSessionConfiguration:configuration];
   [fileDownloader downloadDataFromURL:[NSURL URLWithString:EXUpdatesCryptoPublicKeyUrl]

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.h
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.h
@@ -26,7 +26,6 @@ typedef void (^EXUpdatesFileDownloaderErrorBlock)(NSError *error, NSURLResponse 
 
 - (void)downloadManifestFromURL:(NSURL *)url
                    withDatabase:(EXUpdatesDatabase *)database
-                 cacheDirectory:(NSURL *)cacheDirectory
                    successBlock:(EXUpdatesFileDownloaderManifestSuccessBlock)successBlock
                      errorBlock:(EXUpdatesFileDownloaderErrorBlock)errorBlock;
 

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.m
@@ -76,12 +76,11 @@ NSTimeInterval const EXUpdatesDefaultTimeoutInterval = 60;
 
 - (void)downloadManifestFromURL:(NSURL *)url
                    withDatabase:(EXUpdatesDatabase *)database
-                 cacheDirectory:(NSURL *)cacheDirectory
                    successBlock:(EXUpdatesFileDownloaderManifestSuccessBlock)successBlock
                      errorBlock:(EXUpdatesFileDownloaderErrorBlock)errorBlock
 {
   NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url
-                                                         cachePolicy:NSURLRequestReloadIgnoringCacheData
+                                                         cachePolicy:NSURLRequestReloadIgnoringLocalCacheData
                                                      timeoutInterval:EXUpdatesDefaultTimeoutInterval];
   [self _setManifestHTTPHeaderFields:request];
   [self _downloadDataWithRequest:request successBlock:^(NSData *data, NSURLResponse *response) {

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.m
@@ -120,7 +120,6 @@ NSTimeInterval const EXUpdatesDefaultTimeoutInterval = 60;
       [EXUpdatesCrypto verifySignatureWithData:(NSString *)innerManifestString
                                      signature:(NSString *)signature
                                         config:self->_config
-                                cacheDirectory:cacheDirectory
                                   successBlock:^(BOOL isValid) {
                                                   if (isValid) {
                                                     NSError *err;

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesRemoteAppLoader.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesRemoteAppLoader.m
@@ -34,7 +34,7 @@ static NSString * const EXUpdatesRemoteAppLoaderErrorDomain = @"EXUpdatesRemoteA
   self.manifestBlock = manifestBlock;
   self.successBlock = success;
   self.errorBlock = error;
-  [_downloader downloadManifestFromURL:url withDatabase:self.database cacheDirectory:self.directory successBlock:^(EXUpdatesUpdate *update) {
+  [_downloader downloadManifestFromURL:url withDatabase:self.database successBlock:^(EXUpdatesUpdate *update) {
     [self startLoadingFromManifest:update];
   } errorBlock:^(NSError *error, NSURLResponse *response) {
     if (self.errorBlock) {

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesModule.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesModule.m
@@ -79,7 +79,6 @@ UM_EXPORT_METHOD_AS(checkForUpdateAsync,
   EXUpdatesFileDownloader *fileDownloader = [[EXUpdatesFileDownloader alloc] initWithUpdatesConfig:_updatesService.config];
   [fileDownloader downloadManifestFromURL:_updatesService.config.updateUrl
                              withDatabase:_updatesService.database
-                           cacheDirectory:_updatesService.directory
                              successBlock:^(EXUpdatesUpdate *update) {
     EXUpdatesUpdate *launchedUpdate = self->_updatesService.launchedUpdate;
     id<EXUpdatesSelectionPolicy> selectionPolicy = self->_updatesService.selectionPolicy;


### PR DESCRIPTION
# Why

fix for #10623, supersedes #11327.

Switch to relying on default NSURLCache for the manifest public key rather than caching it ourselves.

# How

Replicated the logic used for our manual cache by using `NSURLRequestReturnCacheDataDontLoad` and `NSURLRequestReloadIgnoringLocalCacheData`.

I decided against creating a separate NSURLCache specifically for the manifest public key as we had discussed @ide, for the following reasons:
- it seems like an NSURLCache needs to be significantly larger than any single piece of data it caches, meaning it's inefficient to make a separate cache for one piece of data
- it's also highly asynchronous and cannot be used immediately after creation
- source: https://stackoverflow.com/a/22994514
- finally, it seems really unlikely for an update to be large enough to immediately cause this public key to be evicted from the cache, and even if that were to happen, it wouldn't be a big deal -- we would just need to re-request the public key next time we check for an update. (If we have verified an update, we store the manifest as verified on disk, so this wouldn't prevent the app from running an update it's already downloaded.)

# Test Plan

run a bare app & use breakpoints to verify that:
- on first update check, the public key is fetched remotely
- on subsequent check, the cached version is used
- if the app is closed and restarted, the cached version is still used (persists across restarts)
