### PR TITLE
Specify all required auth token scopes

### DIFF
--- a/docs/pages/guides/using-sentry.md
+++ b/docs/pages/guides/using-sentry.md
@@ -33,7 +33,7 @@ Before getting real-time updates on errors and making your app generally incredi
    - **project name** is available in your project's `Settings` > `General Settings` tab
    - **`DSN`** is avalable in your project's `Settings` > `Client Keys` tab
 
-2. Go to the [Sentry API section](https://sentry.io/settings/account/api/auth-tokens/), and create an **auth token**. The token requires the scopes: `org:read`, `project:releases`, and `project:write`.
+2. Go to the [Sentry API section](https://sentry.io/settings/account/api/auth-tokens/), and create an **auth token**. The token requires the scopes: `org:read`, `project:releases`, and `project:write`. Save this, too.
 
 Once you have each of these: organization name, project name, DSN, and auth token, you're all set!
 

--- a/docs/pages/guides/using-sentry.md
+++ b/docs/pages/guides/using-sentry.md
@@ -33,7 +33,7 @@ Before getting real-time updates on errors and making your app generally incredi
    - **project name** is available in your project's `Settings` > `General Settings` tab
    - **`DSN`** is avalable in your project's `Settings` > `Client Keys` tab
 
-2. Go to the [Sentry API section](https://sentry.io/settings/account/api/auth-tokens/), and create an **auth token** (Ensure you have `project:write` selected under scopes). Save this, too.
+2. Go to the [Sentry API section](https://sentry.io/settings/account/api/auth-tokens/), and create an **auth token**. The token requires the scopes: `org:read`, `project:releases`, and `project:write`.
 
 Once you have each of these: organization name, project name, DSN, and auth token, you're all set!
 


### PR DESCRIPTION
# Why

The docs are unclear about what scopes are required.

# How

By looking at the debug logs of a successful upload of a full-scope token, I was able to determine what's needed, and verify that.

# Test Plan

- Create a new auth token
- Add specified scopes and only those
- Verify this works

For reference, the requests made are:

```
request GET https://sentry.io/api/0/organizations/boom-pay/repos/?cursor=
request POST https://sentry.io/api/0/projects/boom-pay/boom-pay-client/releases/
request GET https://sentry.io/api/0/organizations/boom-pay/releases/1.0.0-r.i06Q1xLAJ/previous-with-commits/
```