### PR TITLE
[fastlane] Make xcodebuild command quiet to reduce the size of logs

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -112,7 +112,7 @@ platform :ios do
       sdk: "iphonesimulator",
       configuration: "Release",
       derivedDataPath: directory,
-      xcargs: "ARCHS=\"x86_64\" ONLY_ACTIVE_ARCH=NO",
+      xcargs: "ARCHS=\"x86_64\" ONLY_ACTIVE_ARCH=NO -quiet",
       raw_buildlog: is_ci?
     )
   end
@@ -132,7 +132,7 @@ platform :ios do
       destination: "generic/platform=iOS",
       archive: true,
       archive_path: directory + "/Exponent.xcarchive",
-      xcargs: "CODE_SIGNING_ALLOWED=NO APP_OWNER=Public"
+      xcargs: "CODE_SIGNING_ALLOWED=NO APP_OWNER=Public -quiet"
     )
   end
 


### PR DESCRIPTION
# Why

When working on #11224 I noticed there is `-quiet` flag in `xcodebuild` command. Then I thought why not to use it in our CI builds?
The artifact with fastlane logs is now pretty big—56MB (see https://github.com/expo/expo/actions/runs/425166883) and with this simple flag it's been reduced to only 624KB (see https://github.com/expo/expo/actions/runs/425193393). This flag filters out verbose logs like these that informs about files being compiled right now, but we don't need them—warnings and errors are enough to find out the cause of possible errors.

# How

Added `-quiet` to fastlane's `xcargs` parameter in both lanes building Expo Go (simulator and the release archive).

# Test Plan

CI job passed and confirmed its logs no longer contain verbose output.
