### PR TITLE
[android] Remove deprecated overrideUserInterfaceStyle from ExperienceActivityUtils

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/experience/HomeActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/HomeActivity.java
@@ -65,7 +65,7 @@ public class HomeActivity extends BaseExperienceActivity {
     mManifest = mExponentManifest.getKernelManifest();
     mExperienceId = ExperienceId.create(mManifest.optString(ExponentManifest.MANIFEST_ID_KEY));
 
-    ExperienceActivityUtils.overrideUserInterfaceStyle(mExponentManifest.getKernelManifest(), this);
+    ExperienceActivityUtils.overrideUiMode(mExponentManifest.getKernelManifest(), this);
     ExperienceActivityUtils.configureStatusBar(mExponentManifest.getKernelManifest(), this);
 
     EventBus.getDefault().registerSticky(this);

--- a/android/expoview/src/main/java/host/exp/exponent/experience/HomeActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/HomeActivity.java
@@ -65,7 +65,12 @@ public class HomeActivity extends BaseExperienceActivity {
     mManifest = mExponentManifest.getKernelManifest();
     mExperienceId = ExperienceId.create(mManifest.optString(ExponentManifest.MANIFEST_ID_KEY));
 
-    ExperienceActivityUtils.overrideUiMode(mExponentManifest.getKernelManifest(), this);
+    // @sjchmiela, @lukmccall: We are consciously not overriding UI mode in Home, because it has no effect.
+    // `ExpoAppearanceModule` with which `ExperienceActivityUtils#overrideUiMode` is compatible
+    // is disabled in Home as of end of 2020, to fix some issues with dev menu, see:
+    // https://github.com/expo/expo/blob/eb9bd274472e646a730fd535a4bcf360039cbd49/android/expoview/src/main/java/versioned/host/exp/exponent/ExponentPackage.java#L200-L207
+    // ExperienceActivityUtils.overrideUiMode(mExponentManifest.getKernelManifest(), this);
+
     ExperienceActivityUtils.configureStatusBar(mExponentManifest.getKernelManifest(), this);
 
     EventBus.getDefault().registerSticky(this);

--- a/android/expoview/src/main/java/host/exp/exponent/utils/ExperienceActivityUtils.java
+++ b/android/expoview/src/main/java/host/exp/exponent/utils/ExperienceActivityUtils.java
@@ -79,27 +79,6 @@ public class ExperienceActivityUtils {
 
   // region user interface style - light/dark/automatic mode
 
-
-  /**
-   * @deprecated Do not use in SDK38 and above! Use {@link ExperienceActivityUtils#overrideUiMode(JSONObject, AppCompatActivity)} instead.
-   * Returns true if activity will be reloaded after night mode change.
-   * Otherwise returns false.
-   **/
-  @Deprecated
-  public static boolean overrideUserInterfaceStyle(JSONObject manifest, AppCompatActivity activity) {
-    String userInterfaceStyle = readUserInterfaceStyleFromManifest(manifest);
-    int mode = nightModeFromString(userInterfaceStyle);
-    boolean isNightModeCurrentlyOn = activity.getResources().getBoolean(R.bool.dark_mode);
-    boolean willBeReloaded = false;
-    if (mode != AppCompatDelegate.MODE_NIGHT_AUTO) {
-      willBeReloaded = isNightModeCurrentlyOn && mode == AppCompatDelegate.MODE_NIGHT_NO
-        || !isNightModeCurrentlyOn && mode == AppCompatDelegate.MODE_NIGHT_YES;
-    }
-
-    activity.getDelegate().setLocalNightMode(mode);
-    return willBeReloaded;
-  }
-
   /**
    * Sets uiMode to according to what is being set in manifest.
    **/


### PR DESCRIPTION
# Why

- Method used in `HomeActivity` is deprecated and should not be used for experiences running SDK38+.
- As far as I know Home is running SDK40+…
- …so shouldn't we use the SDK38+ method to override UI style?

# How

Replaced one method call with another.

# Test Plan

- [x] Expo Go builds (with some unrelated fixes in place).
- [x] Home UI style is taken into account… NOT (see [comment](https://github.com/expo/expo/commit/ad3cdfdbbc1415bf32ef7adbdf4b2e0468452887)).