### PR TITLE
[expo-av] Fix syntax error in AVManager

### DIFF
--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -12,12 +12,11 @@
 
 ### 🎉 New features
 
+- Add optional sound level information in `RecordingStatus` object described with `metering` key. Add `isMeteringEnabled` flag in `RecordingOptions` to enable computing this information. The flag is set to `true` by default in `RecordingOptions` presets (`RECORDING_OPTIONS_PRESET_HIGH_QUALITY`, `RECORDING_OPTIONS_PRESET_LOW_QUALITY`). ([#10759](https://github.com/expo/expo/pull/10759) by [@danieloi](https://github.com/danieloi))
+
 ### 🐛 Bug fixes
 
-
-### 🎉 New features
-
-- Add optional sound level information in `RecordingStatus` object described with `metering` key. Add `isMeteringEnabled` flag in `RecordingOptions` to enable computing this information. The flag is set to `true` by default in `RecordingOptions` presets (`RECORDING_OPTIONS_PRESET_HIGH_QUALITY`, `RECORDING_OPTIONS_PRESET_LOW_QUALITY`). ([#10759](https://github.com/expo/expo/pull/10759) by [@danieloi](https://github.com/danieloi))
+- Fixed minor syntax error in `AVManager`. ([#11375](https://github.com/expo/expo/pull/11375) by [@sjchmiela](https://github.com/sjchmiela))
 
 ## 8.7.0 — 2020-11-17
 

--- a/packages/expo-av/android/src/main/java/expo/modules/av/AVManager.java
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/AVManager.java
@@ -555,7 +555,7 @@ public class AVManager implements LifecycleEventListener, AudioManager.OnAudioFo
     // Decibels is a relative measurement.
 	// Value `32767d` gives levels info comparable to iOS's values.
 	// see: https://github.com/punarinta/react-native-sound-level/issues/20
-    return = (int) (20 * Math.log(((double) amplitude) / 32767d));
+    return (int) (20 * Math.log(((double) amplitude) / 32767d));
   }
 
   private Bundle getAudioRecorderStatus() {

--- a/packages/expo-av/android/src/main/java/expo/modules/av/AVManager.java
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/AVManager.java
@@ -29,11 +29,11 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
-import java.util.Iterator;
 
 import expo.modules.av.player.PlayerData;
 import expo.modules.av.video.VideoView;
@@ -110,7 +110,7 @@ public class AVManager implements LifecycleEventListener, AudioManager.OnAudioFo
       }
     };
     mContext.registerReceiver(mNoisyAudioStreamReceiver,
-        new IntentFilter(AudioManager.ACTION_AUDIO_BECOMING_NOISY));
+      new IntentFilter(AudioManager.ACTION_AUDIO_BECOMING_NOISY));
     mIsRegistered = true;
   }
 
@@ -270,7 +270,7 @@ public class AVManager implements LifecycleEventListener, AudioManager.OnAudioFo
     }
 
     final int audioFocusRequest = mAudioInterruptionMode == AudioInterruptionMode.DO_NOT_MIX
-        ? AudioManager.AUDIOFOCUS_GAIN : AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK;
+      ? AudioManager.AUDIOFOCUS_GAIN : AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK;
 
     int result = mAudioManager.requestAudioFocus(this, AudioManager.STREAM_MUSIC, audioFocusRequest);
     mAcquiredAudioFocus = result == AudioManager.AUDIOFOCUS_REQUEST_GRANTED;
@@ -548,13 +548,13 @@ public class AVManager implements LifecycleEventListener, AudioManager.OnAudioFo
     if (amplitude == 0) {
       return -160;
     }
-     
+
     // Amplitude to decibel conversion.
     // Code copied from https://github.com/punarinta/react-native-sound-level
     // It's supposed to be a ratio between the base sound level and the measured one.
     // Decibels is a relative measurement.
-	// Value `32767d` gives levels info comparable to iOS's values.
-	// see: https://github.com/punarinta/react-native-sound-level/issues/20
+    // Value `32767d` gives levels info comparable to iOS's values.
+    // see: https://github.com/punarinta/react-native-sound-level/issues/20
     return (int) (20 * Math.log(((double) amplitude) / 32767d));
   }
 
@@ -615,14 +615,14 @@ public class AVManager implements LifecycleEventListener, AudioManager.OnAudioFo
     }
 
     mAudioRecorderIsMeteringEnabled
- = options.getBoolean(RECORDING_OPTION_IS_METERING_ENABLED_KEY);
+      = options.getBoolean(RECORDING_OPTION_IS_METERING_ENABLED_KEY);
 
     removeAudioRecorder();
 
     final ReadableArguments androidOptions = options.getArguments(RECORDING_OPTIONS_KEY);
 
     final String filename = "recording-" + UUID.randomUUID().toString()
-        + androidOptions.getString(RECORDING_OPTION_EXTENSION_KEY);
+      + androidOptions.getString(RECORDING_OPTION_EXTENSION_KEY);
     try {
       final File directory = new File(mContext.getCacheDir() + File.separator + "Audio");
       ensureDirExists(directory);
@@ -700,7 +700,7 @@ public class AVManager implements LifecycleEventListener, AudioManager.OnAudioFo
     if (checkAudioRecorderExistsOrReject(promise)) {
       if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
         promise.reject("E_AUDIO_VERSIONINCOMPATIBLE", "Pausing an audio recording is unsupported on" +
-            " Android devices running SDK < 24.");
+          " Android devices running SDK < 24.");
       } else {
         try {
           mAudioRecorder.pause();
@@ -726,7 +726,7 @@ public class AVManager implements LifecycleEventListener, AudioManager.OnAudioFo
       } catch (final RuntimeException e) {
         mAudioRecorderIsPaused = false;
         if (!mAudioRecorderIsRecording) {
-          promise.reject("E_AUDIO_RECORDINGSTOP", "Stop encountered an error: recording not started", e);  
+          promise.reject("E_AUDIO_RECORDINGSTOP", "Stop encountered an error: recording not started", e);
         } else {
           mAudioRecorderIsRecording = false;
           promise.reject("E_AUDIO_NODATA", "Stop encountered an error: no valid audio data has been received", e);


### PR DESCRIPTION
# Why

There's a syntax error!

<img width="518" alt="Zrzut ekranu 2020-12-16 o 12 44 05" src="https://user-images.githubusercontent.com/1151041/102344575-64970900-3f9c-11eb-8358-2d9e15f45a92.png">

# How

Removed `=` causing the syntax error.

# Test Plan

Expo Go compiled.