### PR TITLE
[expo-notifications] Do not consider pending notification response delivered unless they're delivered to expo-notifications

### DIFF
--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 - Fixed migration process to **not** use `expo-constants` installation ID if there is a notifications-specific identifier. ([#11287](https://github.com/expo/expo/pull/11287) by [@sjchmiela](https://github.com/sjchmiela))
 - Changed the visibility of Android's `InstallationId#getNonBackedUpUuidFile` method so it's easier to override by custom implementations. ([#11249](https://github.com/expo/expo/pull/11249) by [@sjchmiela](https://github.com/sjchmiela))
-- Fixed initial notification response (causing the application to start) not being delivered (only standalone applications in managed workflow). ([#11378](https://github.com/expo/expo/pull/11378) by [@sjchmiela](https://github.com/sjchmiela))
+- Added extra check for marking pending notification responses as delivered which prevents legacy Expo notifications to consume notification responses when we don't want it to which should help fix initial notification response (causing the application to start) not being delivered (only in iOS standalone applications in Expo managed workflow). ([#11378](https://github.com/expo/expo/pull/11378) by [@sjchmiela](https://github.com/sjchmiela))
 
 ## 0.8.2 — 2020-11-30
 

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 - Fixed migration process to **not** use `expo-constants` installation ID if there is a notifications-specific identifier. ([#11287](https://github.com/expo/expo/pull/11287) by [@sjchmiela](https://github.com/sjchmiela))
 - Changed the visibility of Android's `InstallationId#getNonBackedUpUuidFile` method so it's easier to override by custom implementations. ([#11249](https://github.com/expo/expo/pull/11249) by [@sjchmiela](https://github.com/sjchmiela))
+- Fixed initial notification response (causing the application to start) not being delivered (only standalone applications in managed workflow). ([#11378](https://github.com/expo/expo/pull/11378) by [@sjchmiela](https://github.com/sjchmiela))
 
 ## 0.8.2 — 2020-11-30
 

--- a/packages/expo-notifications/ios/EXNotifications/Notifications/EXNotificationCenterDelegate.m
+++ b/packages/expo-notifications/ios/EXNotifications/Notifications/EXNotificationCenterDelegate.m
@@ -191,7 +191,10 @@ UM_REGISTER_SINGLETON_MODULE(NotificationCenterDelegate);
         // completion handler doesn't need to do anything
       }];
     }
-    [_pendingNotificationResponses removeAllObjects];
+    // Remove EXUserNotificationManager check when LegacyNotifications are no longer supported
+    if (![NSStringFromClass([delegate class]) isEqual:@"EXUserNotificationManager"]) {
+      [_pendingNotificationResponses removeAllObjects];
+    }
   }
 }
 


### PR DESCRIPTION
# Why

It's a nice counterpart to https://github.com/expo/expo/pull/11382 which ensures https://github.com/expo/expo/issues/11343 and https://github.com/expo/expo/issues/9866 do not happen again.

# How

Follow-up to https://github.com/expo/expo/pull/9478. There are two places where the notification response can be "consumed" — when it is received (covered by #9478) and when it is delivered to a new delegate (covered by this PR).

# Test Plan

I have verified in https://github.com/expo/expo/pull/11382 that workspace with this and https://github.com/expo/expo/pull/11382's changes delivers initial notification response to the app.