### PR TITLE
[expo-notifications] Register emitter as center delegate's delegate only once JS subscribes to it

### DIFF
--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### 🐛 Bug fixes
 
 - Fixed migration process to **not** use `expo-constants` installation ID if there is a notifications-specific identifier. ([#11287](https://github.com/expo/expo/pull/11287) by [@sjchmiela](https://github.com/sjchmiela))
+- Native iOS notifications emitter module no longer registers for notification events as soon as module registry is ready which fixes initial notification response not being delivered to JS in standalone (Expo managed workflow) iOS apps. ([#11382](https://github.com/expo/expo/pull/11382) by [@sjchmiela](https://github.com/sjchmiela))
 - Changed the visibility of Android's `InstallationId#getNonBackedUpUuidFile` method so it's easier to override by custom implementations. ([#11249](https://github.com/expo/expo/pull/11249) by [@sjchmiela](https://github.com/sjchmiela))
 
 ## 0.8.2 — 2020-11-30

--- a/packages/expo-notifications/ios/EXNotifications/Notifications/Emitter/EXNotificationsEmitter.m
+++ b/packages/expo-notifications/ios/EXNotifications/Notifications/Emitter/EXNotificationsEmitter.m
@@ -92,6 +92,10 @@ UM_EXPORT_METHOD_AS(getLastNotificationResponseAsync,
 {
   // Silence React Native warning: "Sending ... with no listeners registered."
   // See: https://github.com/expo/expo/pull/10883#pullrequestreview-529183413
+  // While in practice we don't need to verify this, as as of the end of 2020
+  // we wouldn't send any event to JS if we weren't being observed because
+  // we wouldn't be subscribed to the notification center delegate it's nice
+  // to be sure this problem won't ever arise.
   if (_isBeingObserved) {
     [_eventEmitter sendEventWithName:eventName body:body];
   }


### PR DESCRIPTION
# Why

Fixes a bug introduced in https://github.com/expo/expo/pull/10883 which causes initial notification responses to get lost in standalone iOS apps.

Along with #11378 I believe it fixes #11343 and may also finally fix #9866.

# How

Using native breakpoints I've noticed `EXNotificationCenterDelegate`'s `addDelegate:` is called more times than I would expect it to.

It turned out before `EXScopedNotificationsEmitter` was subscribing to `EXNotificationCenterDelegate` (it would then receive pending notification response) an unscoped `EXNotificationsEmitter` was subscribing and consuming pending responses. Since unscoped emitter wasn't being used and exposed to the app later, it consumed the response into the void.

Most probably unimodules have a bug where instances of overridden modules are still kept in memory (since `setModuleRegistry:` is called on them). Fixing this bug is out of the scope of this pull request.

These changes are based on how it was implemented before https://github.com/expo/expo/pull/10883/commits/dfda625f3e7c51fa6c766b60c26dbf09c2987523. I can't see any reason why `EXNotificationsEmitter` would need to register for notifications as soon as module registry is ready, so let's roll back to what we know worked well.

# Test Plan

I have verified in an ExpoKit workspace that when the app is opened from a notification, the notification response is delivered to `useLastNotificationResponse`:

https://www.loom.com/share/586a906c538f47f0940b2cc83582fb29