### PR TITLE
[expo-dev-menu] Polishing `dev-menu` animations

### DIFF
--- a/packages/expo-dev-menu/app/views/DevMenuScreen.tsx
+++ b/packages/expo-dev-menu/app/views/DevMenuScreen.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { StyleSheet } from 'react-native';
-import Animated from 'react-native-reanimated';
+import { StyleSheet, View } from 'react-native';
 
 import LayoutRuler from '../components/LayoutRuler';
 
@@ -11,27 +10,15 @@ type Props = {
 };
 
 export default class DevMenuScreen extends React.PureComponent<Props> {
-  containerHeightValue = new Animated.Value<number>(10000);
-  heightSet = false;
-
-  onHeightMeasure = (height: number) => {
-    console.log(this.props.ScreenComponent.name, height);
-
-    if (!this.heightSet && height > 0) {
-      this.containerHeightValue.setValue(height + BOTTOM_PADDING);
-      this.heightSet = true;
-    }
-  };
-
   render() {
     const { ScreenComponent, ...props } = this.props;
 
     return (
-      <Animated.View style={[styles.container, { height: this.containerHeightValue }]}>
-        <LayoutRuler property="height" onMeasure={this.onHeightMeasure}>
+      <View style={[styles.container]}>
+        <LayoutRuler property="height">
           <ScreenComponent {...props} />
         </LayoutRuler>
-      </Animated.View>
+      </View>
     );
   }
 }


### PR DESCRIPTION
# Why

We want to add the screen extension to the `dev-menu`, but first, we need to fix the transition between screens in the bottom sheet.  

# How

- Changed the active screen when the user navigates between screens.
- Reset the bottom sheet state.
- Changed the transition between screens on Android (now the new screen slides form right). 

# Test Plan

- bare-expo ✅