### PR TITLE
[android][location] Fix background location permission check

### DIFF
--- a/packages/expo-location/android/src/main/java/expo/modules/location/LocationModule.java
+++ b/packages/expo-location/android/src/main/java/expo/modules/location/LocationModule.java
@@ -15,6 +15,7 @@ import android.hardware.Sensor;
 import android.hardware.SensorEvent;
 import android.hardware.SensorEventListener;
 import android.hardware.SensorManager;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Looper;
 
@@ -517,7 +518,8 @@ public class LocationModule extends ExportedModule implements LifecycleEventList
    * Checks if the background location permission is granted by the user.
    */
   private boolean isMissingBackgroundPermissions() {
-    return mPermissionsManager == null || !mPermissionsManager.hasGrantedPermissions(Manifest.permission.ACCESS_BACKGROUND_LOCATION);
+    return mPermissionsManager == null ||
+        (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && !mPermissionsManager.hasGrantedPermissions(Manifest.permission.ACCESS_BACKGROUND_LOCATION));
   }
 
   /**


### PR DESCRIPTION
# Why

The `ACCESS_BACKGROUND_LOCATION` permission was introduced in Android version Q. It is not recognised on older versions which implicitly receive background location access permissions at the same time as foreground permissions.

As the `isMissingBackgroundPermissions` method explicitly checks for this permission, it always returns false on older Android versions. This results in `Location.startLocationUpdatesAsync` always failing with error `Unhandled promise rejection: Error: Not authorized to use background location services.` (and even when `ACCESS_BACKGROUND_LOCATION` is specified in `app.json`).

I believe this is at least one cause of #11330.

# How

This fix adds a check for the Android version before explicitly checking for the `ACCESS_BACKGROUND_LOCATION` permission.

# Test Plan

Built the reproducible demo from #11330 on a Samsung Galaxy S7 with Android 8 (API level 26). Without this fix, the usual error occurs and no background location is available:

```
Finished building JavaScript bundle in 40ms.
Running application on SM-G930F.

[Unhandled promise rejection: Error: Not authorized to use background location services.]
- node_modules/react-native/Libraries/BatchedBridge/NativeModules.js:103:50 in promiseMethodWrapper
- node_modules/@unimodules/react-native-adapter/build/NativeModulesProxy.native.js:15:23 in moduleName.methodInfo.name
...
```

With this fix, the background task works as expected and we see the `send to api` message every so often.

I do not have access to a newer Android device >= Q to test on.