### PR TITLE
[et] More advanced prompt for custom version to publish

### DIFF
--- a/tools/expotools/src/publish-packages/tasks/selectPackagesToPublish.ts
+++ b/tools/expotools/src/publish-packages/tasks/selectPackagesToPublish.ts
@@ -9,7 +9,8 @@ import { CommandOptions, Parcel, TaskArgs } from '../types';
 import { findUnpublished } from './findUnpublished';
 import { resolveReleaseTypeAndVersion } from './resolveReleaseTypeAndVersion';
 
-const { green, cyan, red, gray } = chalk;
+const { green, cyan, red } = chalk;
+const CUSTOM_VERSION_CHOICE_VALUE = 'custom-version';
 
 /**
  * Prompts which suggested packages are going to be published.
@@ -59,29 +60,74 @@ async function selectPackageToPublishAsync(parcel: Parcel): Promise<boolean> {
     },
   ]);
   if (!selected) {
-    const { version } = await inquirer.prompt([
+    const incrementedVersions = incrementVersion(parcel.pkg.packageVersion);
+    const { version, customVersion } = await inquirer.prompt([
       {
-        type: 'input',
+        type: 'list',
         name: 'version',
         prefix: '❔',
-        message: `Do you want to use different version? ${gray('(leave empty to skip)')}`,
-        validate(input: string) {
-          if (input) {
-            if (!semver.valid(input)) {
-              return red(`${cyan.bold(input)} is not a valid semver version.`);
-            }
-            if (parcel.pkgView && parcel.pkgView.versions.includes(input)) {
-              return red(`${cyan.bold(input)} has already been published.`);
-            }
-          }
-          return true;
+        message: `What do you want to do with ${green.bold(packageName)}?`,
+        choices: [
+          {
+            name: "Don't publish",
+            value: null,
+          },
+          ...Object.keys(incrementedVersions).map((type) => {
+            return {
+              name: `Publish as ${cyan.bold(incrementedVersions[type])} (${type})`,
+              value: incrementedVersions[type],
+            };
+          }),
+          {
+            name: 'Publish as custom version',
+            value: CUSTOM_VERSION_CHOICE_VALUE,
+          },
+        ],
+        validate: validateVersion(parcel),
+      },
+      {
+        type: 'input',
+        name: 'customVersion',
+        prefix: '❔',
+        message: 'Type in custom version to publish:',
+        when(answers: Record<string, string>): boolean {
+          return answers.version === CUSTOM_VERSION_CHOICE_VALUE;
         },
+        validate: validateVersion(parcel),
       },
     ]);
-    if (version) {
-      parcel.state.releaseVersion = version;
+    if (customVersion || version) {
+      parcel.state.releaseVersion = customVersion || version;
       return true;
     }
   }
   return selected;
+}
+
+/**
+ * Creates an object with possible incrementations of given version.
+ */
+function incrementVersion(version: string): Record<string, string> {
+  const releaseTypes = ['major', 'minor', 'patch'];
+  return releaseTypes.reduce((acc, type) => {
+    acc[type] = semver.inc(version, type);
+    return acc;
+  }, {});
+}
+
+/**
+ * Returns a function that validates the version for given parcel.
+ */
+function validateVersion(parcel: Parcel) {
+  return (input: string) => {
+    if (input) {
+      if (!semver.valid(input)) {
+        return red(`${cyan.bold(input)} is not a valid semver version.`);
+      }
+      if (parcel.pkgView && parcel.pkgView.versions.includes(input)) {
+        return red(`${cyan.bold(input)} has already been published.`);
+      }
+    }
+    return true;
+  };
 }


### PR DESCRIPTION
# Why

In the publish command, it's been annoying to type in the version other than suggested.

# How

Changed that prompt question to be of `list` type instead of `input`. It allows to choose between major, minor or patch version.

# Test Plan

I've run `et publish expo-location --dry`, selected `no` at the first question and then I was asked to select the version or skip publishing that package.
