### PR TITLE
[et] Automatic comments on closed issues after publish

### DIFF
--- a/.github/workflows/commentator.yml
+++ b/.github/workflows/commentator.yml
@@ -1,0 +1,17 @@
+name: Comments on issues
+
+on:
+  workflow_dispatch:
+    inputs:
+      payload:
+        description: 'Serialized and escaped JSON describing what and where to comment.'
+        required: true
+
+jobs:
+  comment:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Comment on issues as github-actions bot
+        run: bin/expotools commentator --payload "${{ github.event.inputs.payload }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/commentator.yml
+++ b/.github/workflows/commentator.yml
@@ -11,6 +11,10 @@ jobs:
   comment:
     runs-on: ubuntu-18.04
     steps:
+      - name: Checkout a ref for the event
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
       - name: Comment on issues as github-actions bot
         run: bin/expotools commentator --payload "${{ github.event.inputs.payload }}"
         env:

--- a/.github/workflows/commentator.yml
+++ b/.github/workflows/commentator.yml
@@ -1,4 +1,4 @@
-name: Comments on issues
+name: Comments on GitHub issues
 
 on:
   workflow_dispatch:
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 1
-      - name: Comment on issues as github-actions bot
+      - name: Comment on GitHub issues as github-actions bot
         run: bin/expotools commentator --payload "${{ github.event.inputs.payload }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/tools/src/Changelogs.ts
+++ b/tools/src/Changelogs.ts
@@ -3,6 +3,7 @@ import semver from 'semver';
 import semverRegex from 'semver-regex';
 
 import * as Markdown from './Markdown';
+import { execAll } from './Utils';
 
 /**
  * Type of the objects representing single changelog entry.

--- a/tools/src/GitHubActions.ts
+++ b/tools/src/GitHubActions.ts
@@ -7,7 +7,7 @@ import { request } from '@octokit/request';
 import fs from 'fs-extra';
 import path from 'path';
 
-import { filterAsync } from './Utils';
+import { execAll, filterAsync } from './Utils';
 import { EXPO_DIR } from './Constants';
 import logger from './Logger';
 

--- a/tools/src/GitHubActions.ts
+++ b/tools/src/GitHubActions.ts
@@ -92,26 +92,22 @@ export async function getJobsForWorkflowRunAsync(workflowRunId: number): Promise
 }
 
 /**
- * Dispatches an event that triggers a workflow with given ID.
+ * Dispatches an event that triggers a workflow with given ID or workflow filename (including extension).
  */
 export async function dispatchWorkflowEventAsync(
-  workflowId: number,
+  workflowId: number | string,
   ref: string,
   inputs?: WorkflowDispatchEventInputs
 ): Promise<void> {
-  const response = await request(
+  await request(
     'POST /repos/:owner/:repo/actions/workflows/:workflow_id/dispatches',
+    // @ts-ignore It expects workflow_id to be a number, however workflow filename (string) is also supported.
     makeExpoOptions({
       workflow_id: workflowId,
       ref,
       inputs: inputs ?? {},
     })
   );
-  if (response.status !== 204) {
-    logger.error('💥 Dispatching workflow failed with response', JSON.stringify(response, null, 2));
-    process.exit(1);
-  }
-  logger.success('🎉 Successfully dispatched workflow event ');
 }
 
 /**

--- a/tools/src/GitHubActions.ts
+++ b/tools/src/GitHubActions.ts
@@ -11,7 +11,6 @@ import path from 'path';
 
 import { execAll, filterAsync } from './Utils';
 import { EXPO_DIR } from './Constants';
-import logger from './Logger';
 
 export type Workflow = ActionsListRepoWorkflowsResponseData['workflows'][0] & {
   slug: string;

--- a/tools/src/Utils.ts
+++ b/tools/src/Utils.ts
@@ -122,3 +122,16 @@ export async function retryAsync<T = any>(
     timeoutCallback();
   });
 }
+
+/**
+ * Executes regular expression against a string until the last match is found.
+ */
+export function execAll(rgx: RegExp, str: string, index: number = 0): string[] {
+  const globalRgx = new RegExp(rgx.source, 'g' + rgx.flags.replace('g', ''));
+  const matches: string[] = [];
+  let match;
+  while ((match = globalRgx.exec(str))) {
+    matches.push(match[index]);
+  }
+  return matches;
+}

--- a/tools/src/commands/CommentatorCommand.ts
+++ b/tools/src/commands/CommentatorCommand.ts
@@ -1,0 +1,62 @@
+import { Command } from '@expo/commander';
+import chalk from 'chalk';
+import { link } from '../Formatter';
+
+import { commentOnIssueAsync } from '../GitHubActions';
+import logger from '../Logger';
+
+type ActionOptions = {
+  payload: string;
+};
+
+export type CommentatorComment = {
+  issue: number;
+  body: string;
+};
+
+export type CommentatorPayload = CommentatorComment[];
+
+export default (program: Command) => {
+  program
+    .command('commentator')
+    .alias('comment')
+    .option(
+      '-p, --payload <payload>',
+      'Serialized and escaped JSON describing what and where to comment.'
+    )
+    .asyncAction(main);
+};
+
+async function main(options: ActionOptions) {
+  const payload = parsePayload(options.payload);
+  const commentedIssues: number[] = [];
+
+  if (!Array.isArray(payload)) {
+    throw new Error(`Payload must be an array.`);
+  }
+  for (const comment of payload) {
+    if (!comment.issue || !comment.body) {
+      logger.error('Comment payload is incomplete:', comment);
+      continue;
+    }
+    await commentOnIssueAsync(comment.issue, comment.body);
+    commentedIssues.push(comment.issue);
+  }
+  if (commentedIssues.length > 0) {
+    logger.log(
+      '✍️  Commented on the following issues: %s',
+      commentedIssues
+        .map((issue) =>
+          link(chalk.blue('#' + issue), `https://github.com/expo/expo/issues/${issue}`)
+        )
+        .join(', ')
+    );
+  } else {
+    logger.log('✍️  Nothing to comment.');
+  }
+}
+
+function parsePayload(payloadString: string): CommentatorPayload {
+  const payload = JSON.parse(payloadString);
+  return payload;
+}

--- a/tools/src/commands/CommentatorCommand.ts
+++ b/tools/src/commands/CommentatorCommand.ts
@@ -39,8 +39,12 @@ async function main(options: ActionOptions) {
       logger.error('Comment payload is incomplete:', comment);
       continue;
     }
-    await commentOnIssueAsync(comment.issue, comment.body);
-    commentedIssues.push(comment.issue);
+    try {
+      await commentOnIssueAsync(comment.issue, comment.body);
+      commentedIssues.push(comment.issue);
+    } catch (e) {
+      logger.error(`Failed to comment on issue #${comment.issue}:`, e);
+    }
   }
   if (commentedIssues.length > 0) {
     logger.log(

--- a/tools/src/commands/CommentatorCommand.ts
+++ b/tools/src/commands/CommentatorCommand.ts
@@ -22,7 +22,12 @@ export default (program: Command) => {
     .alias('comment')
     .option(
       '-p, --payload <payload>',
-      'Serialized and escaped JSON describing what and where to comment.'
+      'Serialized and escaped JSON array describing what and where to comment.'
+    )
+    .description(
+      `To add "Hello!" comment on issue #1234, run it with ${chalk.blue.italic(
+        `--payload "[{\\"issue\\": 1234, \\"body\\": \\"Hello!\\"}]"`
+      )}`
     )
     .asyncAction(main);
 };

--- a/tools/src/commands/WorkflowDispatch.ts
+++ b/tools/src/commands/WorkflowDispatch.ts
@@ -117,6 +117,8 @@ async function main(workflowSlug: string | undefined, options: CommandOptions) {
   // Dispatch `workflow_dispatch` event.
   await dispatchWorkflowEventAsync(workflow.id, ref, workflow.inputs);
 
+  logger.success('🎉 Successfully dispatched workflow event ');
+
   // Let's wait a little bit for the new workflow run to start and appear in the API response.
   logger.info('⏳ Waiting for the new workflow run to start...');
   const newWorkflowRun = await retryAsync(2000, 10, async () => {

--- a/tools/src/publish-packages/helpers.ts
+++ b/tools/src/publish-packages/helpers.ts
@@ -110,7 +110,7 @@ export function printPackageParcel(parcel: Parcel): void {
       logger.log('  ', magenta(`${Formatter.stripNonAsciiChars(changeType).trim()}:`));
 
       for (const change of unpublishedChanges[changeType]) {
-        logger.log('    ', Formatter.formatChangelogEntry(change));
+        logger.log('    ', Formatter.formatChangelogEntry(change.message));
       }
     }
   }

--- a/tools/src/publish-packages/tasks/commentOnIssuesTask.ts
+++ b/tools/src/publish-packages/tasks/commentOnIssuesTask.ts
@@ -1,0 +1,135 @@
+import {
+  // dispatchWorkflowEventAsync,
+  getClosedIssuesAsync,
+  // getWorkflowsAsync,
+} from '../../GitHubActions';
+import { Task } from '../../TasksRunner';
+import { CommandOptions, Parcel, TaskArgs } from '../types';
+import logger from '../../Logger';
+// import Git from '../../Git';
+import { ChangelogEntry, UNPUBLISHED_VERSION_NAME } from '../../Changelogs';
+import { CommentatorPayload } from '../../commands/CommentatorCommand';
+import { selectPackagesToPublish } from './selectPackagesToPublish';
+
+type CommentRowObject = {
+  packageName: string;
+  version: string;
+  tag: string;
+  pullRequests: number[];
+};
+
+/**
+ * Dispatches GitHub Actions workflow that adds comments to the issues
+ * that were closed by pull requests mentioned in the changelog changes.
+ */
+export const commentOnIssuesTask = new Task<TaskArgs>(
+  {
+    name: 'commentOnIssuesTask',
+    dependsOn: [selectPackagesToPublish],
+    backupable: true,
+  },
+  async (parcels: Parcel[], options: CommandOptions) => {
+    if (!process.env.GITHUB_TOKEN) {
+      logger.error(
+        'Environment variable `GITHUB_TOKEN` must be set to dispatch a commentator workflow.'
+      );
+      // should prompt for it?
+      return;
+    }
+
+    // const workflows = await getWorkflowsAsync();
+    // const workflow = workflows.find((workflow) => workflow.slug === 'commentator');
+
+    // if (!workflow) {
+    //   logger.error(`Commentator workflow not found 😠`);
+    //   return;
+    // }
+
+    // const currentBranchName = await Git.getCurrentBranchNameAsync();
+
+    // An object whose key is the issue number and value is an array of rows to put in the comment's body.
+    const commentRows: Record<number, CommentRowObject[]> = {};
+
+    // An object whose key is the pull request number and value is an array of issues it closes.
+    const closedIssuesRegistry: Record<number, number[]> = {};
+
+    for (const { pkg, state } of parcels) {
+      const versionChanges = state.changelogChanges?.versions[UNPUBLISHED_VERSION_NAME];
+
+      if (!versionChanges) {
+        continue;
+      }
+      const allEntries = ([] as ChangelogEntry[]).concat(...Object.values(versionChanges));
+      const allPullRequests = new Set(
+        ([] as number[]).concat(...allEntries.map((entry) => entry.pullRequests ?? []))
+      );
+
+      // Visit all pull requests mentioned in the changelog.
+      for (const pullRequest of allPullRequests) {
+        // Look for closed issues just once per pull request to reduce number of GitHub API calls.
+        if (!closedIssuesRegistry[pullRequest]) {
+          closedIssuesRegistry[pullRequest] = await getClosedIssuesAsync(pullRequest);
+        }
+        const closedIssues = closedIssuesRegistry[pullRequest];
+
+        console.log(pullRequest, ':', closedIssues);
+
+        // Visit all issues that have been closed by this pull request.
+        for (const issue of closedIssues) {
+          if (!commentRows[issue]) {
+            commentRows[issue] = [];
+          }
+
+          // Check if the row for the package already exists. If it does, then just add
+          // another pull request reference into that row instead of creating a new one.
+          // This is to prevent duplicating packages within the comment's body.
+          const existingRowForPackage = commentRows[issue].find(
+            (entry) => entry.packageName === pkg.packageName
+          );
+
+          if (existingRowForPackage) {
+            existingRowForPackage.pullRequests.push(pullRequest);
+          } else {
+            commentRows[issue].push({
+              packageName: pkg.packageName,
+              version: state.releaseVersion!,
+              tag: options.tag,
+              pullRequests: [pullRequest],
+            });
+          }
+        }
+      }
+    }
+
+    const payload: CommentatorPayload = Object.entries(commentRows).map(([issue, entries]) => {
+      return {
+        issue: +issue,
+        body: generateCommentBody(entries),
+      };
+    });
+
+    console.log(payload);
+
+    // await dispatchWorkflowEventAsync(workflow.id, currentBranchName, {
+    //   payload: JSON.stringify(payload).replace(/"/g, '\\"'),
+    // });
+  }
+);
+
+function generateCommentBody(entries: CommentRowObject[]): string {
+  const rows = entries.map(({ packageName, version, tag, pullRequests }) => {
+    const prs = pullRequests.map((pr) => '#' + pr).join(', ');
+    return `| ${packageName} | ${version} | ${tag} | ${prs} |`;
+  });
+
+  return `Some changes in the following packages that may fix this issue have just been published 🥳
+
+| 📦 Package | 🔢 Version | 🏷 NPM tag | ↖️ Pull requests |
+|:--:|:--:|:--:|:--:|
+${rows.join('\n')}
+
+If you're using bare workflow you can install them right away with \`yarn upgrade <package>@<npm tag>\`.
+We kindly ask you for feedback whether they fixed this issue or not 🙏
+
+For managed workflow they will become available with the next SDK release.`;
+}

--- a/tools/src/publish-packages/tasks/commentOnIssuesTask.ts
+++ b/tools/src/publish-packages/tasks/commentOnIssuesTask.ts
@@ -1,20 +1,21 @@
-import {
-  // dispatchWorkflowEventAsync,
-  getClosedIssuesAsync,
-  // getWorkflowsAsync,
-} from '../../GitHubActions';
-import { Task } from '../../TasksRunner';
-import { CommandOptions, Parcel, TaskArgs } from '../types';
-import logger from '../../Logger';
-// import Git from '../../Git';
+import chalk from 'chalk';
+import path from 'path';
+
 import { ChangelogEntry, UNPUBLISHED_VERSION_NAME } from '../../Changelogs';
+import { EXPO_DIR } from '../../Constants';
+import { link } from '../../Formatter';
+import Git from '../../Git';
+import { dispatchWorkflowEventAsync, getClosedIssuesAsync } from '../../GitHubActions';
+import logger from '../../Logger';
+import { Package } from '../../Packages';
+import { Task } from '../../TasksRunner';
 import { CommentatorPayload } from '../../commands/CommentatorCommand';
+import { CommandOptions, Parcel, TaskArgs } from '../types';
 import { selectPackagesToPublish } from './selectPackagesToPublish';
 
 type CommentRowObject = {
-  packageName: string;
+  pkg: Package;
   version: string;
-  tag: string;
   pullRequests: number[];
 };
 
@@ -29,107 +30,170 @@ export const commentOnIssuesTask = new Task<TaskArgs>(
     backupable: true,
   },
   async (parcels: Parcel[], options: CommandOptions) => {
+    logger.info('\n🐙 Commenting on issues closed by published changes');
+
+    const payload = await generatePayloadForCommentatorAsync(parcels, options.tag);
+
+    if (!payload.length) {
+      logger.log('There are no closed issues to comment on\n');
+      return;
+    }
+    if (options.dry) {
+      logger.debug('Skipping due to --dry flag');
+      logManualFallback(payload);
+      return;
+    }
     if (!process.env.GITHUB_TOKEN) {
       logger.error(
-        'Environment variable `GITHUB_TOKEN` must be set to dispatch a commentator workflow.'
+        'Environment variable `%s` must be set to dispatch a commentator workflow',
+        chalk.magenta('GITHUB_TOKEN')
       );
-      // should prompt for it?
+      logManualFallback(payload);
       return;
     }
 
-    // const workflows = await getWorkflowsAsync();
-    // const workflow = workflows.find((workflow) => workflow.slug === 'commentator');
+    const currentBranchName = await Git.getCurrentBranchNameAsync();
 
-    // if (!workflow) {
-    //   logger.error(`Commentator workflow not found 😠`);
-    //   return;
-    // }
-
-    // const currentBranchName = await Git.getCurrentBranchNameAsync();
-
-    // An object whose key is the issue number and value is an array of rows to put in the comment's body.
-    const commentRows: Record<number, CommentRowObject[]> = {};
-
-    // An object whose key is the pull request number and value is an array of issues it closes.
-    const closedIssuesRegistry: Record<number, number[]> = {};
-
-    for (const { pkg, state } of parcels) {
-      const versionChanges = state.changelogChanges?.versions[UNPUBLISHED_VERSION_NAME];
-
-      if (!versionChanges) {
-        continue;
-      }
-      const allEntries = ([] as ChangelogEntry[]).concat(...Object.values(versionChanges));
-      const allPullRequests = new Set(
-        ([] as number[]).concat(...allEntries.map((entry) => entry.pullRequests ?? []))
-      );
-
-      // Visit all pull requests mentioned in the changelog.
-      for (const pullRequest of allPullRequests) {
-        // Look for closed issues just once per pull request to reduce number of GitHub API calls.
-        if (!closedIssuesRegistry[pullRequest]) {
-          closedIssuesRegistry[pullRequest] = await getClosedIssuesAsync(pullRequest);
-        }
-        const closedIssues = closedIssuesRegistry[pullRequest];
-
-        console.log(pullRequest, ':', closedIssues);
-
-        // Visit all issues that have been closed by this pull request.
-        for (const issue of closedIssues) {
-          if (!commentRows[issue]) {
-            commentRows[issue] = [];
-          }
-
-          // Check if the row for the package already exists. If it does, then just add
-          // another pull request reference into that row instead of creating a new one.
-          // This is to prevent duplicating packages within the comment's body.
-          const existingRowForPackage = commentRows[issue].find(
-            (entry) => entry.packageName === pkg.packageName
-          );
-
-          if (existingRowForPackage) {
-            existingRowForPackage.pullRequests.push(pullRequest);
-          } else {
-            commentRows[issue].push({
-              packageName: pkg.packageName,
-              version: state.releaseVersion!,
-              tag: options.tag,
-              pullRequests: [pullRequest],
-            });
-          }
-        }
-      }
+    // Sometimes we publish from different branches (especially for testing) where comments are not advisable.
+    if (currentBranchName !== 'master') {
+      logger.warn('This feature is disabled on branches other than master');
+      logManualFallback(payload);
+      return;
     }
 
-    const payload: CommentatorPayload = Object.entries(commentRows).map(([issue, entries]) => {
-      return {
-        issue: +issue,
-        body: generateCommentBody(entries),
-      };
+    // Dispatch commentator workflow on GitHub Actions with stringified and escaped payload.
+    await dispatchWorkflowEventAsync('commentator.yml', currentBranchName, {
+      payload: JSON.stringify(payload).replace(/("|`)/g, '\\$1'),
     });
-
-    console.log(payload);
-
-    // await dispatchWorkflowEventAsync(workflow.id, currentBranchName, {
-    //   payload: JSON.stringify(payload).replace(/"/g, '\\"'),
-    // });
+    logger.success(
+      'Successfully dispatched commentator action for the following issues: %s',
+      linksToClosedIssues(payload.map(({ issue }) => issue))
+    );
   }
 );
 
-function generateCommentBody(entries: CommentRowObject[]): string {
-  const rows = entries.map(({ packageName, version, tag, pullRequests }) => {
-    const prs = pullRequests.map((pr) => '#' + pr).join(', ');
-    return `| ${packageName} | ${version} | ${tag} | ${prs} |`;
+/**
+ * Generates payload for `expotools commentator` command.
+ */
+async function generatePayloadForCommentatorAsync(
+  parcels: Parcel[],
+  tag: string
+): Promise<CommentatorPayload> {
+  // An object whose key is the issue number and value is an array of rows to put in the comment's body.
+  const commentRows: Record<number, CommentRowObject[]> = {};
+
+  // An object whose key is the pull request number and value is an array of issues it closes.
+  const closedIssuesRegistry: Record<number, number[]> = {};
+
+  for (const { pkg, state } of parcels) {
+    const versionChanges = state.changelogChanges?.versions[UNPUBLISHED_VERSION_NAME];
+
+    if (!versionChanges) {
+      continue;
+    }
+    const allEntries = ([] as ChangelogEntry[]).concat(...Object.values(versionChanges));
+    const allPullRequests = new Set(
+      ([] as number[]).concat(...allEntries.map((entry) => entry.pullRequests ?? []))
+    );
+
+    // Visit all pull requests mentioned in the changelog.
+    for (const pullRequest of allPullRequests) {
+      // Look for closed issues just once per pull request to reduce number of GitHub API calls.
+      if (!closedIssuesRegistry[pullRequest]) {
+        closedIssuesRegistry[pullRequest] = await getClosedIssuesAsync(pullRequest);
+      }
+      const closedIssues = closedIssuesRegistry[pullRequest];
+
+      // Visit all issues that have been closed by this pull request.
+      for (const issue of closedIssues) {
+        if (!commentRows[issue]) {
+          commentRows[issue] = [];
+        }
+
+        // Check if the row for the package already exists. If it does, then just add
+        // another pull request reference into that row instead of creating a new one.
+        // This is to prevent duplicating packages within the comment's body.
+        const existingRowForPackage = commentRows[issue].find((entry) => entry.pkg === pkg);
+
+        if (existingRowForPackage) {
+          existingRowForPackage.pullRequests.push(pullRequest);
+        } else {
+          commentRows[issue].push({
+            pkg,
+            version: state.releaseVersion!,
+            pullRequests: [pullRequest],
+          });
+        }
+      }
+    }
+  }
+
+  return Object.entries(commentRows).map(([issue, entries]) => {
+    return {
+      issue: +issue,
+      body: generateCommentBody(entries, tag),
+    };
+  });
+}
+
+/**
+ * Logs a list of closed issues. We use it as a fallback in several places, so it's extracted.
+ */
+function logManualFallback(payload: CommentatorPayload): void {
+  logger.log(
+    'If necessary, you can still do this manually on the following issues: %s',
+    linksToClosedIssues(payload.map(({ issue }) => issue))
+  );
+}
+
+/**
+ * Returns a string with concatenated links to all given issues.
+ */
+function linksToClosedIssues(issues: number[]): string {
+  return issues
+    .map((issue) => link(chalk.blue('#' + issue), `https://github.com/expo/expo/issues/${issue}`))
+    .join(', ');
+}
+
+/**
+ * Generates comment body based on given entries.
+ */
+function generateCommentBody(entries: CommentRowObject[], tag: string): string {
+  const rows = entries.map(({ pkg, version, pullRequests }) => {
+    const items = [
+      linkToNpmPackage(pkg.packageName, version),
+      version,
+      pullRequests.map((pr) => '#' + pr).join(', '),
+      linkToChangelog(pkg),
+    ];
+    return `| ${items.join(' | ')} |`;
   });
 
-  return `Some changes in the following packages that may fix this issue have just been published 🥳
+  return `<!-- Generated by \`expotools publish\` -->
+Some changes in the following packages that may fix this issue have just been published to npm under \`${tag}\` tag 🚀
 
-| 📦 Package | 🔢 Version | 🏷 NPM tag | ↖️ Pull requests |
+| 📦 Package | 🔢 Version | ↖️ Pull requests | 📝 Release notes |
 |:--:|:--:|:--:|:--:|
 ${rows.join('\n')}
 
-If you're using bare workflow you can install them right away with \`yarn upgrade <package>@<npm tag>\`.
-We kindly ask you for feedback whether they fixed this issue or not 🙏
+If you're using bare workflow you can upgrade them right away. We kindly ask you for some feedback—even if it works 🙏
 
-For managed workflow they will become available with the next SDK release.`;
+They will become available in managed workflow with the next SDK release 👀
+
+Happy Coding! 🎉`;
+}
+
+/**
+ * Returns markdown link to the package on npm.
+ */
+function linkToNpmPackage(packageName: string, version: string): string {
+  return `[${packageName}](https://www.npmjs.com/package/${packageName}/v/${version})`;
+}
+
+/**
+ * Returns markdown link to package's changelog.
+ */
+function linkToChangelog(pkg: Package): string {
+  const changelogRelativePath = path.relative(EXPO_DIR, pkg.changelogPath);
+  return `[CHANGELOG.md](https://github.com/expo/expo/blob/master/${changelogRelativePath})`;
 }

--- a/tools/src/publish-packages/tasks/publishPackagesPipeline.ts
+++ b/tools/src/publish-packages/tasks/publishPackagesPipeline.ts
@@ -6,6 +6,7 @@ import { CommandOptions, Parcel, TaskArgs } from '../types';
 import { checkPackagesIntegrity } from './checkPackagesIntegrity';
 import { checkRepositoryStatus } from './checkRepositoryStatus';
 import { cleanPrebuildsTask } from './cleanPrebuildsTask';
+import { commentOnIssuesTask } from './commentOnIssuesTask';
 import { commitStagedChanges } from './commitStagedChanges';
 import { cutOffChangelogs } from './cutOffChangelogs';
 import { grantTeamAccessToPackages } from './grantTeamAccessToPackages';
@@ -45,6 +46,7 @@ export const publishPackagesPipeline = new Task<TaskArgs>(
       publishPackages,
       cleanPrebuildsTask,
       grantTeamAccessToPackages,
+      commentOnIssuesTask,
     ],
   },
   async (parcels: Parcel[], options: CommandOptions) => {


### PR DESCRIPTION
# Why

I thought it would be cool to have a bot that automatically lets the developers know once the changes fixing an issue are published to NPM.
We usually publish packages under `next` tag instead of `latest` so we give ourselves and others a chance to test them before they come out to everyone. That's good for some reasons, but one connecting piece is still missing — we don't inform anyone once we do a release, so have almost no feedback.

It may look like this: https://github.com/semantic-release/semantic-release/pull/1650#issuecomment-706774587

# How

This PR consists of a few components:
- Expotools command (called `commentator`) that comments on issues, based on given payload. It's not very useful locally as uses your own GitHub account, and requires serialized and escaped JSON passed through `--payload` flag. But what if we do this on GitHub Actions when the payload is a workflow input?
- Commentator workflow on GitHub Actions that receives a payload as an input and passes it to the aforementioned expotools command with `github-actions` bot credentials.
- Post-publish task that dispatches an event to run the commentator workflow on GitHub Actions. It gets all pull requests referenced in published changelog entries, then looks for issues closed by these pull requests and finally dispatches a workflow with appropriate input/payload that leaves a comment there.
 
Side note: It requires `GITHUB_TOKEN` env variable to be present (with `workflow` permission) so I recommend to generate it and add it to your shell profiles.

# Test Plan

Removed some tasks from publish pipeline so it's actually just trying to comment on hardcoded issues (see #5516) without any other important work and then tried to publish one package.

Also see this workflow run https://github.com/expo/expo/runs/1594829929 which was dispatched by the publish task.

# Further idea

What would you say if we also add `published`/`released` label to such closed issues?
