### PR TITLE
[location] Backport background location permission validation fix

### DIFF
--- a/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/expo/modules/location/LocationModule.java
+++ b/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/expo/modules/location/LocationModule.java
@@ -15,6 +15,7 @@ import android.hardware.Sensor;
 import android.hardware.SensorEvent;
 import android.hardware.SensorEventListener;
 import android.hardware.SensorManager;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Looper;
 
@@ -517,7 +518,8 @@ public class LocationModule extends ExportedModule implements LifecycleEventList
    * Checks if the background location permission is granted by the user.
    */
   private boolean isMissingBackgroundPermissions() {
-    return mPermissionsManager == null || !mPermissionsManager.hasGrantedPermissions(Manifest.permission.ACCESS_BACKGROUND_LOCATION);
+    return mPermissionsManager == null ||
+      (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && !mPermissionsManager.hasGrantedPermissions(Manifest.permission.ACCESS_BACKGROUND_LOCATION));
   }
 
   /**


### PR DESCRIPTION
# Why

This backports PR #11399 to the versioned abis code, after this is merged we can cherrypick this and commit [`304cd01`](https://github.com/expo/expo/commit/304cd013d8337f97012c76d2ffb09601f508339e) into `sdk-40` and push out the fix.

# How

- Merged PR #11399
- Backported it to versioned abis code on `master`

# Test Plan

See PR #11399
