### PR TITLE
[eslint] add rule to restrict fbjs imports

### DIFF
--- a/packages/expo-module-scripts/README.md
+++ b/packages/expo-module-scripts/README.md
@@ -52,6 +52,7 @@ Add the following scripts to your `package.json` and run `yarn`
 ```
 
 Running `yarn` will now run the `prepare` script, which generates any missing files:
+
 - [`.eslintrc.js`](./templates/.eslintrc.js) ([docs](https://eslint.org/docs/user-guide/configuring)) this extends [`eslint-config-universe`](https://github.com/expo/expo/tree/master/packages/eslint-config-universe).
   - Optionally you can customize Prettier too: [.prettierrc guide](https://github.com/expo/expo/tree/master/packages/eslint-config-universe#customizing-prettier).
 - [`.npmignore`](./templates/.npmignore) ([docs](https://docs.npmjs.com/misc/developers)) currently only ignores the `babel.config.js` in your module. You might also want to also add tests and docs.
@@ -199,6 +200,15 @@ If we were to use just Babel with the TypeScript plugin for the `build` command,
 ### lint
 
 This runs ESLint over the source JS and TypeScript files.
+
+One of the rules enforced is restricting any imports from the `fbjs` library. As stated in that [library's readme](https://github.com/facebook/fbjs#purpose):
+
+> If you are consuming the code here and you are not also a Facebook project, be prepared for a bad time.
+
+Replacements for common `fbjs` uses-cases are listed below:
+
+- `invariant`- replace with [`invariant`](https://www.npmjs.com/package/invariant)
+- `ExecutionEnvironment`- replace with [`Platform` from `@unimodules/core`](https://github.com/expo/expo/blob/master/packages/%40unimodules/react-native-adapter/src/Platform.ts)
 
 ### clean
 

--- a/packages/expo-module-scripts/eslintrc.base.js
+++ b/packages/expo-module-scripts/eslintrc.base.js
@@ -8,4 +8,13 @@ module.exports = {
       globals: { __DEV__: true },
     },
   ],
+  rules: {
+    'no-restricted-imports': [
+      'warn',
+      {
+        // fbjs is a Facebook-internal package not intended to be a public API
+        patterns: ['fbjs/*', 'fbjs'],
+      },
+    ],
+  },
 };


### PR DESCRIPTION
# Why

follow-up to https://github.com/expo/expo/pull/11396

to match imports of `fbjs/foo`, need to use `patterns`, which unfortunately [doesn't support custom warning/error messages right now](https://github.com/eslint/eslint/issues/11843)

# How

added rule, tested it locally and it was triggered for both `'fbjs'` imports, and `'fbjs/deeper/path'` imports:

```
warning  'fbjs/lib/ExecutionEnvironment' import is restricted from being used by a pattern                                             no-restricted-imports
```
# Test Plan

it should pass in CI
