### PR TITLE
[dev-launcher] Fix package not compiling on iOS 12

### DIFF
--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -290,11 +290,6 @@ NSString *fakeLauncherBundleUrl = @"embedded://EXDevLauncher/dummy";
     }
   }
   
-  if (@available(iOS 13, *)) {
-    // change system window appearance
-    _window.overrideUserInterfaceStyle = userInterfaceStyle;
-  }
-  
   // change RN appearance
   RCTOverrideAppearancePreference(colorSchema);
 }

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -288,7 +288,9 @@ NSString *fakeLauncherBundleUrl = @"embedded://EXDevLauncher/dummy";
     } else if (userInterfaceStyle == UIUserInterfaceStyleLight) {
       colorSchema = @"light";
     }
-    
+  }
+  
+  if (@available(iOS 13, *)) {
     // change system window appearance
     _window.overrideUserInterfaceStyle = userInterfaceStyle;
   }

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -109,8 +109,9 @@ NSString *fakeLauncherBundleUrl = @"embedded://EXDevLauncher/dummy";
 - (void)navigateToLauncher {
   [_appBridge invalidate];
 
-
-  [self _applyUserInterfaceStyle:UIUserInterfaceStyleUnspecified];
+  if (@available(iOS 12, *)) {
+    [self _applyUserInterfaceStyle:UIUserInterfaceStyleUnspecified];
+  }
   
   _launcherBridge = [[EXDevLauncherRCTBridge alloc] initWithDelegate:self launchOptions:_launchOptions];
 
@@ -217,8 +218,9 @@ NSString *fakeLauncherBundleUrl = @"embedded://EXDevLauncher/dummy";
   dispatch_async(dispatch_get_main_queue(), ^{
     self.sourceUrl = bundleUrl;
     
-    [self _applyUserInterfaceStyle:manifest.userInterfaceStyle];
     if (@available(iOS 12, *)) {
+      [self _applyUserInterfaceStyle:manifest.userInterfaceStyle];
+      
       // Fix for the community react-native-appearance.
       // RNC appearance checks the global trait collection and doesn't have another way to override the user interface.
       // So we swap `currentTraitCollection` with one from the root view controller.
@@ -279,15 +281,13 @@ NSString *fakeLauncherBundleUrl = @"embedded://EXDevLauncher/dummy";
                                                     }];
 }
 
-- (void)_applyUserInterfaceStyle:(UIUserInterfaceStyle)userInterfaceStyle
+- (void)_applyUserInterfaceStyle:(UIUserInterfaceStyle)userInterfaceStyle API_AVAILABLE(ios(12.0))
 {
   NSString *colorSchema = nil;
-  if (@available(iOS 12, *)) {
-    if (userInterfaceStyle == UIUserInterfaceStyleDark) {
-      colorSchema = @"dark";
-    } else if (userInterfaceStyle == UIUserInterfaceStyleLight) {
-      colorSchema = @"light";
-    }
+  if (userInterfaceStyle == UIUserInterfaceStyleDark) {
+    colorSchema = @"dark";
+  } else if (userInterfaceStyle == UIUserInterfaceStyleLight) {
+    colorSchema = @"light";
   }
   
   // change RN appearance


### PR DESCRIPTION
# Why

Fix package not compiling on iOS 12.

# How

```
window.overrideUserInterfaceStyle
```
is not available on iOS 12 🤦‍♂️

Moreover, we don't need that and on iOS 14 it causes crashes. 
![Untitled](https://user-images.githubusercontent.com/9578601/102914902-37a59300-4481-11eb-829b-71b88f935390.png)


# Test Plan

- bare-expo ✅
