### PR TITLE
[dev-launcher] Rename template name

### DIFF
--- a/docs/pages/client/installation.md
+++ b/docs/pages/client/installation.md
@@ -13,7 +13,7 @@ import ConfigurationDiff from '~/components/plugins/ConfigurationDiff';
 
 The easiest way to get started is to initialize a new project by executing the following command:
 
-<InstallSection packageName="expo-development-client" cmd={["npx crna -t with-dev-launcher"]} hideBareInstructions />
+<InstallSection packageName="expo-development-client" cmd={["npx crna -t with-development-client"]} hideBareInstructions />
 
 ## Add the Development Client to the existing project
 


### PR DESCRIPTION
# Why

After https://github.com/expo/examples/pull/236 will be merged, the name example will be `with-development-client` not `with-dev-launcher`.
