### PR TITLE
[expo-updates] improve thread safety around reaping

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Removed `fbjs` dependency ([#11396](https://github.com/expo/expo/pull/11396) by [@cruzach](https://github.com/cruzach))
 - On iOS, use default NSURLCache for manifest public key rather than caching it manually.
 - Use `console.warn` message rather than hard crashing if neither runtime nor SDK version are configured (requires a corresponding update to the `expo` package) ([#11367](https://github.com/expo/expo/pull/11367) by [@esamelson](https://github.com/esamelson))
+- Improved thread safety around reaping ([#11447](https://github.com/expo/expo/pull/11447) by [@esamelson](https://github.com/esamelson))
 
 ## 0.4.1 — 2020-11-25
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/LoaderTask.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/LoaderTask.java
@@ -60,7 +60,8 @@ public class LoaderTask {
   private boolean mHasLaunched = false;
   private boolean mIsUpToDate = false;
   private HandlerThread mHandlerThread;
-  private Launcher mLauncher;
+  private Launcher mCandidateLauncher;
+  private Launcher mFinalizedLauncher;
 
   public LoaderTask(UpdatesConfiguration configuration,
                     DatabaseHolder databaseHolder,
@@ -136,11 +137,11 @@ public class LoaderTask {
 
       @Override
       public void onSuccess() {
-        if (mLauncher.getLaunchedUpdate() != null &&
-          !mCallback.onCachedUpdateLoaded(mLauncher.getLaunchedUpdate())) {
+        if (mCandidateLauncher.getLaunchedUpdate() != null &&
+          !mCallback.onCachedUpdateLoaded(mCandidateLauncher.getLaunchedUpdate())) {
           // ignore timer and other settings and force launch a remote update
           stopTimer();
-          mLauncher = null;
+          mCandidateLauncher = null;
           launchRemoteUpdate();
         } else {
           synchronized (LoaderTask.this) {
@@ -169,11 +170,12 @@ public class LoaderTask {
       return;
     }
     mHasLaunched = true;
+    mFinalizedLauncher = mCandidateLauncher;
 
-    if (!mIsReadyToLaunch || mLauncher == null || mLauncher.getLaunchedUpdate() == null) {
+    if (!mIsReadyToLaunch || mFinalizedLauncher == null || mFinalizedLauncher.getLaunchedUpdate() == null) {
       mCallback.onFailure(e != null ? e : new Exception("LoaderTask encountered an unexpected error and could not launch an update."));
     } else {
-      mCallback.onSuccess(mLauncher, mIsUpToDate);
+      mCallback.onSuccess(mFinalizedLauncher, mIsUpToDate);
     }
 
     if (!mTimeoutFinished) {
@@ -214,7 +216,7 @@ public class LoaderTask {
   private void launchFallbackUpdateFromDisk(Context context, Callback diskUpdateCallback) {
     UpdatesDatabase database = mDatabaseHolder.getDatabase();
     DatabaseLauncher launcher = new DatabaseLauncher(mConfiguration, mDirectory, mSelectionPolicy);
-    mLauncher = launcher;
+    mCandidateLauncher = launcher;
 
     if (mConfiguration.hasEmbeddedUpdate()) {
       // if the embedded update should be launched (e.g. if it's newer than any other update we have
@@ -259,7 +261,7 @@ public class LoaderTask {
           public boolean onManifestLoaded(Manifest manifest) {
             if (mSelectionPolicy.shouldLoadNewUpdate(
                   manifest.getUpdateEntity(),
-                  mLauncher == null ? null : mLauncher.getLaunchedUpdate())) {
+                  mCandidateLauncher == null ? null : mCandidateLauncher.getLaunchedUpdate())) {
               mIsUpToDate = false;
               mCallback.onRemoteManifestLoaded(manifest);
               return true;
@@ -288,7 +290,7 @@ public class LoaderTask {
 
                 boolean hasLaunched = mHasLaunched;
                 if (!hasLaunched) {
-                  mLauncher = newLauncher;
+                  mCandidateLauncher = newLauncher;
                   mIsUpToDate = true;
                 }
 
@@ -310,9 +312,9 @@ public class LoaderTask {
 
   private void runReaper() {
     AsyncTask.execute(() -> {
-      if (mLauncher != null && mLauncher.getLaunchedUpdate() != null) {
+      if (mFinalizedLauncher != null && mFinalizedLauncher.getLaunchedUpdate() != null) {
         UpdatesDatabase database = mDatabaseHolder.getDatabase();
-        Reaper.reapUnusedUpdates(mConfiguration, database, mDirectory, mLauncher.getLaunchedUpdate(), mSelectionPolicy);
+        Reaper.reapUnusedUpdates(mConfiguration, database, mDirectory, mFinalizedLauncher.getLaunchedUpdate(), mSelectionPolicy);
         mDatabaseHolder.releaseDatabase();
       }
     });


### PR DESCRIPTION
# Why

One of our partners, after setting the launch timeout setting to 1000ms (from 0), was seeing an occasional crash coming from RN, where the JS bundle file it was trying to open did not exist.

I was not able to reproduce this issue after lots of testing, but my best guess about the cause is that there might be a race condition in expo-updates’ LoaderTask class where the following could happen:

- launcher with existing update is created, set as this class’s launcher
- timer runs out, we send a message to RN to launch with existing bundle
- new update finishes downloading, launcher with new update is created
- new launcher is set as class’s launcher, even though we’ve already notified RN of the launch (<— still can’t reproduce this)
- reaper runs and deletes the old update
- RN tries to launch with the bundle that is now deleted

Even with setting breakpoints and manipulating times, I was still unable to force this situation to happen on iOS. But this PR (along with https://github.com/expo/expo/pull/11448 and https://github.com/expo/expo/pull/11449) adds more safeguards to ensure it shouldn’t ever happen.

# How

Created a separate `finalizedLauncher` field in LoaderTask, which is only written to in one spot (right before notifying RN), and which is used by the reaper to determine which update is running. This eliminates the possibility that the reaper will run using a different launcher object than the one actually used to launch the app.

Additionally, added some more synchronization blocks on Android around these methods and fields, to ensure all threads get the most up-to-date versions of them.

# Test Plan

manual testing on both platforms with a bare app:

- [x] app should launch embedded update with 0 ms delay
- [x] app should launch remote update with 1500 ms delay
- [x] app should launch either update (and run fine) with 900-1100 ms delay (tried this multiple times)
- [x] after updating, app should use the same update when launched without connectivity