### PR TITLE
[expo-updates] add 5-second timeout before running reaper

### DIFF
--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/LoaderTask.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/LoaderTask.java
@@ -314,7 +314,9 @@ public class LoaderTask {
   }
 
   private void runReaper() {
-    AsyncTask.execute(() -> {
+    final HandlerThread reaperThread = new HandlerThread("expo-updates-reaper");
+    reaperThread.start();
+    new Handler(reaperThread.getLooper()).postDelayed(() -> {
       synchronized (LoaderTask.this) {
         if (mFinalizedLauncher != null && mFinalizedLauncher.getLaunchedUpdate() != null) {
           UpdatesDatabase database = mDatabaseHolder.getDatabase();
@@ -322,6 +324,7 @@ public class LoaderTask {
           mDatabaseHolder.releaseDatabase();
         }
       }
-    });
+      reaperThread.quitSafely();
+    }, 5000);
   }
 }

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoaderTask.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoaderTask.m
@@ -181,13 +181,15 @@ static NSString * const EXUpdatesAppLoaderTaskErrorDomain = @"EXUpdatesAppLoader
 
 - (void)_runReaper
 {
-  if (_finalizedLauncher.launchedUpdate) {
-    [EXUpdatesReaper reapUnusedUpdatesWithConfig:_config
-                                        database:_database
-                                       directory:_directory
-                                 selectionPolicy:_selectionPolicy
-                                  launchedUpdate:_finalizedLauncher.launchedUpdate];
-  }
+  dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 5 * NSEC_PER_SEC), _loaderTaskQueue, ^{
+    if (self->_finalizedLauncher.launchedUpdate) {
+      [EXUpdatesReaper reapUnusedUpdatesWithConfig:self->_config
+                                          database:self->_database
+                                         directory:self->_directory
+                                   selectionPolicy:self->_selectionPolicy
+                                    launchedUpdate:self->_finalizedLauncher.launchedUpdate];
+    }
+  });
 }
 
 - (void)_loadEmbeddedUpdateWithCompletion:(void (^)(void))completion


### PR DESCRIPTION
# Why

See https://github.com/expo/expo/pull/11447.

This PR adds a 5-second timeout between when an update is downloaded/launched and any updates are reaped. This adds an extra level of security by basically ensuring that reaping only happens once we’re already successfully running a bundle.

# How

- add a 5-second timeout
- on Android, created a new HandlerThread to ensure it runs in the background and not on the main thread

# Test Plan

Manual testing on both platforms, using logging and looking file system to verify that reaper runs 5 seconds after launching.