### PR TITLE
[expo-updates] keep current update and one older update

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 🎉 New features
 
 - Added alpha support for EAS update manifest format ([#11050](https://github.com/expo/expo/pull/11050) by [@esamelson](https://github.com/esamelson))
+- Keep current update and one older update, for safety and to make rollbacks faster ([#11449](https://github.com/expo/expo/pull/11449) by [@esamelson](https://github.com/esamelson))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/launcher/SelectionPolicyNewestTest.java
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/launcher/SelectionPolicyNewestTest.java
@@ -1,0 +1,71 @@
+package expo.modules.updates.launcher;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+
+import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner;
+import expo.modules.updates.db.entity.UpdateEntity;
+
+@RunWith(AndroidJUnit4ClassRunner.class)
+public class SelectionPolicyNewestTest {
+  String runtimeVersion = "1.0";
+  String scopeKey = "dummyScope";
+  UpdateEntity update1 = new UpdateEntity(UUID.randomUUID(), new Date(1608667857774L), runtimeVersion, scopeKey);
+  UpdateEntity update2 = new UpdateEntity(UUID.randomUUID(), new Date(1608667857775L), runtimeVersion, scopeKey);
+  UpdateEntity update3 = new UpdateEntity(UUID.randomUUID(), new Date(1608667857776L), runtimeVersion, scopeKey);
+  UpdateEntity update4 = new UpdateEntity(UUID.randomUUID(), new Date(1608667857777L), runtimeVersion, scopeKey);
+  UpdateEntity update5 = new UpdateEntity(UUID.randomUUID(), new Date(1608667857778L), runtimeVersion, scopeKey);
+  SelectionPolicy selectionPolicy = new SelectionPolicyNewest(runtimeVersion);
+
+  @Test
+  public void testSelectUpdatesToDelete_onlyOneUpdate() {
+    List<UpdateEntity> updatesToDelete = selectionPolicy.selectUpdatesToDelete(Collections.singletonList(update1), update1);
+
+    Assert.assertEquals(0, updatesToDelete.size());
+  }
+
+  @Test
+  public void testSelectUpdatesToDelete_olderUpdates() {
+    List<UpdateEntity> updatesToDelete = selectionPolicy.selectUpdatesToDelete(
+      Arrays.asList(update1, update2, update3),
+      update3
+    );
+
+    Assert.assertEquals(1, updatesToDelete.size());
+    Assert.assertTrue(updatesToDelete.contains(update1));
+    Assert.assertFalse(updatesToDelete.contains(update2));
+    Assert.assertFalse(updatesToDelete.contains(update3));
+  }
+
+  @Test
+  public void testSelectUpdatesToDelete_newerUpdates() {
+    List<UpdateEntity> updatesToDelete = selectionPolicy.selectUpdatesToDelete(
+      Arrays.asList(update1, update2),
+      update1
+    );
+
+    Assert.assertEquals(0, updatesToDelete.size());
+  }
+
+  @Test
+  public void testSelectUpdatesToDelete_olderAndNewerUpdates() {
+    List<UpdateEntity> updatesToDelete = selectionPolicy.selectUpdatesToDelete(
+      Arrays.asList(update1, update2, update3, update4, update5),
+      update4
+    );
+
+    Assert.assertEquals(2, updatesToDelete.size());
+    Assert.assertTrue(updatesToDelete.contains(update1));
+    Assert.assertTrue(updatesToDelete.contains(update2));
+    Assert.assertFalse(updatesToDelete.contains(update3));
+    Assert.assertFalse(updatesToDelete.contains(update4));
+    Assert.assertFalse(updatesToDelete.contains(update5));
+  }
+}

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/SelectionPolicyNewest.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/SelectionPolicyNewest.java
@@ -48,10 +48,19 @@ public class SelectionPolicyNewest implements SelectionPolicy {
     }
 
     List<UpdateEntity> updatesToDelete = new ArrayList<>();
+    // keep the launched update and one other, the next newest, to be safe
+    UpdateEntity nextNewestUpdate = null;
     for (UpdateEntity update : updates) {
       if (update.commitTime.before(launchedUpdate.commitTime)) {
         updatesToDelete.add(update);
+        if (nextNewestUpdate == null || nextNewestUpdate.commitTime.before(update.commitTime)) {
+          nextNewestUpdate = update;
+        }
       }
+    }
+
+    if (nextNewestUpdate != null) {
+      updatesToDelete.remove(nextNewestUpdate);
     }
     return updatesToDelete;
   }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/SelectionPolicyNewest.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/SelectionPolicyNewest.java
@@ -48,7 +48,7 @@ public class SelectionPolicyNewest implements SelectionPolicy {
     }
 
     List<UpdateEntity> updatesToDelete = new ArrayList<>();
-    // keep the launched update and one other, the next newest, to be safe
+    // keep the launched update and one other, the next newest, to be safe and make rollbacks faster
     UpdateEntity nextNewestUpdate = null;
     for (UpdateEntity update : updates) {
       if (update.commitTime.before(launchedUpdate.commitTime)) {

--- a/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesSelectionPolicyNewest.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesSelectionPolicyNewest.m
@@ -50,7 +50,7 @@ NS_ASSUME_NONNULL_BEGIN
   }
 
   NSMutableArray<EXUpdatesUpdate *> *updatesToDelete = [NSMutableArray new];
-  // keep the launched update and one other, the next newest, to be safe
+  // keep the launched update and one other, the next newest, to be safe and make rollbacks faster
   EXUpdatesUpdate *nextNewestUpdate;
   for (EXUpdatesUpdate *update in updates) {
     if ([launchedUpdate.commitTime compare:update.commitTime] == NSOrderedDescending) {

--- a/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesSelectionPolicyNewest.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesSelectionPolicyNewest.m
@@ -50,10 +50,19 @@ NS_ASSUME_NONNULL_BEGIN
   }
 
   NSMutableArray<EXUpdatesUpdate *> *updatesToDelete = [NSMutableArray new];
+  // keep the launched update and one other, the next newest, to be safe
+  EXUpdatesUpdate *nextNewestUpdate;
   for (EXUpdatesUpdate *update in updates) {
     if ([launchedUpdate.commitTime compare:update.commitTime] == NSOrderedDescending) {
       [updatesToDelete addObject:update];
+      if (!nextNewestUpdate || [update.commitTime compare:nextNewestUpdate.commitTime] == NSOrderedDescending) {
+        nextNewestUpdate = update;
+      }
     }
+  }
+
+  if (nextNewestUpdate) {
+    [updatesToDelete removeObject:nextNewestUpdate];
   }
   return updatesToDelete;
 }

--- a/packages/expo-updates/ios/Tests/EXUpdatesSelectionPolicyNewestTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesSelectionPolicyNewestTests.m
@@ -1,0 +1,75 @@
+//  Copyright (c) 2020 650 Industries, Inc. All rights reserved.
+
+#import <XCTest/XCTest.h>
+
+#import <EXUpdates/EXUpdatesConfig.h>
+#import <EXUpdates/EXUpdatesDatabase.h>
+#import <EXUpdates/EXUpdatesSelectionPolicyNewest.h>
+#import <EXUpdates/EXUpdatesUpdate.h>
+
+@interface EXUpdatesSelectionPolicyNewestTests : XCTestCase
+
+@property (nonatomic, strong) EXUpdatesUpdate *update1;
+@property (nonatomic, strong) EXUpdatesUpdate *update2;
+@property (nonatomic, strong) EXUpdatesUpdate *update3;
+@property (nonatomic, strong) EXUpdatesUpdate *update4;
+@property (nonatomic, strong) EXUpdatesUpdate *update5;
+@property (nonatomic, strong) id<EXUpdatesSelectionPolicy> selectionPolicy;
+
+@end
+
+@implementation EXUpdatesSelectionPolicyNewestTests
+
+- (void)setUp
+{
+  [super setUp];
+  NSString *runtimeVersion = @"1.0";
+  NSString *scopeKey = @"dummyScope";
+  EXUpdatesConfig *config = [EXUpdatesConfig new];
+  EXUpdatesDatabase *database = [EXUpdatesDatabase new];
+  _update1 = [EXUpdatesUpdate updateWithId:NSUUID.UUID scopeKey:scopeKey commitTime:[NSDate dateWithTimeIntervalSince1970:1608667851] runtimeVersion:runtimeVersion metadata:nil status:EXUpdatesUpdateStatusReady keep:YES config:config database:database];
+  _update2 = [EXUpdatesUpdate updateWithId:NSUUID.UUID scopeKey:scopeKey commitTime:[NSDate dateWithTimeIntervalSince1970:1608667852] runtimeVersion:runtimeVersion metadata:nil status:EXUpdatesUpdateStatusReady keep:YES config:config database:database];
+  _update3 = [EXUpdatesUpdate updateWithId:NSUUID.UUID scopeKey:scopeKey commitTime:[NSDate dateWithTimeIntervalSince1970:1608667853] runtimeVersion:runtimeVersion metadata:nil status:EXUpdatesUpdateStatusReady keep:YES config:config database:database];
+  _update4 = [EXUpdatesUpdate updateWithId:NSUUID.UUID scopeKey:scopeKey commitTime:[NSDate dateWithTimeIntervalSince1970:1608667854] runtimeVersion:runtimeVersion metadata:nil status:EXUpdatesUpdateStatusReady keep:YES config:config database:database];
+  _update5 = [EXUpdatesUpdate updateWithId:NSUUID.UUID scopeKey:scopeKey commitTime:[NSDate dateWithTimeIntervalSince1970:1608667855] runtimeVersion:runtimeVersion metadata:nil status:EXUpdatesUpdateStatusReady keep:YES config:config database:database];
+  _selectionPolicy = [[EXUpdatesSelectionPolicyNewest alloc] initWithRuntimeVersion:runtimeVersion];
+}
+
+- (void)tearDown
+{
+  [super tearDown];
+}
+
+- (void)testUpdatesToDelete_onlyOneUpdate
+{
+  NSArray<EXUpdatesUpdate *>* updatesToDelete = [_selectionPolicy updatesToDeleteWithLaunchedUpdate:_update1 updates:@[_update1]];
+  XCTAssert(0 == updatesToDelete.count);
+}
+
+- (void)testUpdatesToDelete_olderUpdates
+{
+  NSArray<EXUpdatesUpdate *>* updatesToDelete = [_selectionPolicy updatesToDeleteWithLaunchedUpdate:_update3 updates:@[_update1, _update2, _update3]];
+  XCTAssert(1 == updatesToDelete.count);
+  XCTAssert([updatesToDelete containsObject:_update1]);
+  XCTAssert(![updatesToDelete containsObject:_update2]);
+  XCTAssert(![updatesToDelete containsObject:_update3]);
+}
+
+- (void)testUpdatesToDelete_newerUpdates
+{
+  NSArray<EXUpdatesUpdate *>* updatesToDelete = [_selectionPolicy updatesToDeleteWithLaunchedUpdate:_update1 updates:@[_update1, _update2]];
+  XCTAssert(0 == updatesToDelete.count);
+}
+
+- (void)testUpdatesToDelete_olderAndNewerUpdates
+{
+  NSArray<EXUpdatesUpdate *>* updatesToDelete = [_selectionPolicy updatesToDeleteWithLaunchedUpdate:_update4 updates:@[_update1, _update2, _update3, _update4, _update5]];
+  XCTAssert(2 == updatesToDelete.count);
+  XCTAssert([updatesToDelete containsObject:_update1]);
+  XCTAssert([updatesToDelete containsObject:_update2]);
+  XCTAssert(![updatesToDelete containsObject:_update3]);
+  XCTAssert(![updatesToDelete containsObject:_update4]);
+  XCTAssert(![updatesToDelete containsObject:_update5]);
+}
+
+@end


### PR DESCRIPTION
# Why

See https://github.com/expo/expo/pull/11447. 

As an extra safeguard, we can keep one update older than the currently running update. This is something we’ve talked about doing anyway, and in the situation described in https://github.com/expo/expo/pull/11447, this means that the reaper would not delete the existing update in the race condition.

# How

Added logic to SelectionPolicy to keep the next newest update along with the currently running one.

In the future, we could have allow the number of old updates kept to be configurable (though I don’t envision many scenarios in which it would be beneficial to keep more than one), but I think this is a fine first step.

# Test Plan

Added native unit tests on both platforms. Ran some manual tests to ensure everything worked e2e.