### PR TITLE
[tools] Fix handling renamed files in git tools

### DIFF
--- a/tools/src/Git.ts
+++ b/tools/src/Git.ts
@@ -219,12 +219,17 @@ export class GitDirectory {
       .split(/\n/g)
       .filter(Boolean)
       .map((line) => {
-        const [status, relativePath] = line.split(/\s+/);
+        // Consecutive columns are separated by horizontal tabs.
+        // In case of `R` (rename) status, there are three columns instead of two,
+        // where the third is the new path after renaming and we should use the new one.
+        const [status, relativePath, relativePathAfterRename] = line.split(/\t+/g);
+        const newPath = relativePathAfterRename ?? relativePath;
 
         return {
-          relativePath,
-          path: path.join(this.path, relativePath),
-          status: GitFileStatus[status] ?? status,
+          relativePath: newPath,
+          path: path.join(this.path, newPath),
+          // `R` status also has a number, but we take care of only the first character.
+          status: GitFileStatus[status[0]] ?? status,
         };
       });
   }


### PR DESCRIPTION
# Why

When we wanted to publish `expo-dev-menu-interface` with just the change in one file which was then renamed, the publish script said there are no changes to publish, which of course was not correct.

# How

One thing we didn't handle correctly is the status returned by `git diff --name-status` when the file has changed.
We assumed the status is always just one letter (`A` for added files, `D` for deleted, `M` for modified and so on), but in case of renamed files, it doesn't return just one letter (`R`), but also a number which doesn't really matter for us. Also, for renamed files it returns three columns in the output instead of two — the third one is the new path after renaming and so we should use it instead.

# Test Plan

`et publish expo-dev-menu-interface` now detects changes correctly.
