### PR TITLE
[bare-expo] add clean action to xcodebuild command

### DIFF
--- a/apps/bare-expo/ios/Pods/EXSplashScreen.xcodeproj/project.pbxproj
+++ b/apps/bare-expo/ios/Pods/EXSplashScreen.xcodeproj/project.pbxproj
@@ -1,0 +1,449 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		22031BB1FDEE1A9906ECCA6DC9CE4D7A /* EXSplashScreenModule.h in Headers */ = {isa = PBXBuildFile; fileRef = 773EA2CA75BCBC7F3D15DED871226998 /* EXSplashScreenModule.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		431227FF75F10472D77461528C44C748 /* EXSplashScreenViewNativeProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = B1EF6E9CE69F20BD5CDA8C8A44C24248 /* EXSplashScreenViewNativeProvider.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		4BF21E4196DCD5E196CFD912D57C9705 /* EXSplashScreenService.h in Headers */ = {isa = PBXBuildFile; fileRef = BC223AD4E506015CCB3867C19083F5AE /* EXSplashScreenService.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		54F5C2E9A7C12B7177951EDC224E9745 /* EXSplashScreen-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = E2D7A1C1FC30F626D63331A3685665B4 /* EXSplashScreen-dummy.m */; };
+		7A410CA0DAD9D66CDF34D1BA4C38E836 /* EXSplashScreenModule.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C8D018583662DCBBC5669988FD3785C /* EXSplashScreenModule.m */; };
+		878DE0719CB9A5F1E7183076E3880DD8 /* EXSplashScreenViewNativeProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = F49E2456F0F67642D94B1C6753D78346 /* EXSplashScreenViewNativeProvider.m */; };
+		A3C1293B7354176B07E3EA8B046B2767 /* EXSplashScreenViewProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = CB09FF8FAD5AA3F82F29969FD8E620CC /* EXSplashScreenViewProvider.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		DE76F0A3AC22B19291B07B01C6E528FB /* EXSplashScreenController.m in Sources */ = {isa = PBXBuildFile; fileRef = 88D538D13FE7CB756217100D655285AA /* EXSplashScreenController.m */; };
+		E4C83888EEBA1B78ECCE302D018072BD /* EXSplashScreenService.m in Sources */ = {isa = PBXBuildFile; fileRef = EC3860C1A19B7FD3217280C24CB6E4DC /* EXSplashScreenService.m */; };
+		F4E1582199B36AC1C4C49CCF300A618F /* EXSplashScreenController.h in Headers */ = {isa = PBXBuildFile; fileRef = C7390541C3E1D2D21BF57316CDFE16B5 /* EXSplashScreenController.h */; settings = {ATTRIBUTES = (Project, ); }; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		10F314D229B67F722B5A407828B284E1 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A628F6F62782F0505F3BF4A059B1CCA8 /* UMCore.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 153171642F5C5CBC05FD3EF6B23A3F36;
+			remoteInfo = UMCore;
+		};
+		E18864F712532ADD198EAF0C3E62E6FC /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = CF1F4A4540EFDAA226452BC78A803DED /* React-Core.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 5DA1A74647F652AE8E4DE074AFC4C6B7;
+			remoteInfo = "React-Core";
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		4C8D018583662DCBBC5669988FD3785C /* EXSplashScreenModule.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXSplashScreenModule.m; path = EXSplashScreen/EXSplashScreenModule.m; sourceTree = "<group>"; };
+		773EA2CA75BCBC7F3D15DED871226998 /* EXSplashScreenModule.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXSplashScreenModule.h; path = EXSplashScreen/EXSplashScreenModule.h; sourceTree = "<group>"; };
+		783BAE144108CDDC9FAABFA317982094 /* libEXSplashScreen.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = libEXSplashScreen.a; path = libEXSplashScreen.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		7F589F21E3F665B53A28304B5C4A4016 /* EXSplashScreen.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; path = EXSplashScreen.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		8322BC8C8DC48F624A078C3D024D3125 /* EXSplashScreen.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = EXSplashScreen.debug.xcconfig; sourceTree = "<group>"; };
+		88D538D13FE7CB756217100D655285AA /* EXSplashScreenController.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXSplashScreenController.m; path = EXSplashScreen/EXSplashScreenController.m; sourceTree = "<group>"; };
+		9CAE620B3B207DE4A26803C9308D0B2E /* EXSplashScreen-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "EXSplashScreen-prefix.pch"; sourceTree = "<group>"; };
+		A628F6F62782F0505F3BF4A059B1CCA8 /* UMCore */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = UMCore; path = UMCore.xcodeproj; sourceTree = "<group>"; };
+		B1EF6E9CE69F20BD5CDA8C8A44C24248 /* EXSplashScreenViewNativeProvider.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXSplashScreenViewNativeProvider.h; path = EXSplashScreen/EXSplashScreenViewNativeProvider.h; sourceTree = "<group>"; };
+		BC223AD4E506015CCB3867C19083F5AE /* EXSplashScreenService.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXSplashScreenService.h; path = EXSplashScreen/EXSplashScreenService.h; sourceTree = "<group>"; };
+		C7390541C3E1D2D21BF57316CDFE16B5 /* EXSplashScreenController.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXSplashScreenController.h; path = EXSplashScreen/EXSplashScreenController.h; sourceTree = "<group>"; };
+		CB09FF8FAD5AA3F82F29969FD8E620CC /* EXSplashScreenViewProvider.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXSplashScreenViewProvider.h; path = EXSplashScreen/EXSplashScreenViewProvider.h; sourceTree = "<group>"; };
+		CF1F4A4540EFDAA226452BC78A803DED /* React-Core */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = "React-Core"; path = "React-Core.xcodeproj"; sourceTree = "<group>"; };
+		E2D7A1C1FC30F626D63331A3685665B4 /* EXSplashScreen-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "EXSplashScreen-dummy.m"; sourceTree = "<group>"; };
+		EC3860C1A19B7FD3217280C24CB6E4DC /* EXSplashScreenService.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXSplashScreenService.m; path = EXSplashScreen/EXSplashScreenService.m; sourceTree = "<group>"; };
+		ED8CF8BEF601390CA174C8C8ECA07B0F /* EXSplashScreen.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = EXSplashScreen.release.xcconfig; sourceTree = "<group>"; };
+		F49E2456F0F67642D94B1C6753D78346 /* EXSplashScreenViewNativeProvider.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXSplashScreenViewNativeProvider.m; path = EXSplashScreen/EXSplashScreenViewNativeProvider.m; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		8D0F8D77F6AACC254FF34F8A7CFD61E4 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		2041EB017B1AF52F6AA8DA2E67CBB6A3 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		381B5F089F956926961273706F31BF20 /* EXSplashScreen */ = {
+			isa = PBXGroup;
+			children = (
+				C7390541C3E1D2D21BF57316CDFE16B5 /* EXSplashScreenController.h */,
+				88D538D13FE7CB756217100D655285AA /* EXSplashScreenController.m */,
+				773EA2CA75BCBC7F3D15DED871226998 /* EXSplashScreenModule.h */,
+				4C8D018583662DCBBC5669988FD3785C /* EXSplashScreenModule.m */,
+				BC223AD4E506015CCB3867C19083F5AE /* EXSplashScreenService.h */,
+				EC3860C1A19B7FD3217280C24CB6E4DC /* EXSplashScreenService.m */,
+				B1EF6E9CE69F20BD5CDA8C8A44C24248 /* EXSplashScreenViewNativeProvider.h */,
+				F49E2456F0F67642D94B1C6753D78346 /* EXSplashScreenViewNativeProvider.m */,
+				CB09FF8FAD5AA3F82F29969FD8E620CC /* EXSplashScreenViewProvider.h */,
+				CC952D231CC92B43C9E7ED5B0DAAFDBB /* Pod */,
+				FD4DC4F0D83C9B23D374B1502584E42D /* Support Files */,
+			);
+			name = EXSplashScreen;
+			path = "../../../../packages/expo-splash-screen/ios";
+			sourceTree = "<group>";
+		};
+		CC952D231CC92B43C9E7ED5B0DAAFDBB /* Pod */ = {
+			isa = PBXGroup;
+			children = (
+				7F589F21E3F665B53A28304B5C4A4016 /* EXSplashScreen.podspec */,
+			);
+			name = Pod;
+			sourceTree = "<group>";
+		};
+		D33DA80DF8393F21A71A71DBED1B0E29 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				783BAE144108CDDC9FAABFA317982094 /* libEXSplashScreen.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		E19D7C59937CA38D37776379FAF2B6A5 /* Dependencies */ = {
+			isa = PBXGroup;
+			children = (
+				CF1F4A4540EFDAA226452BC78A803DED /* React-Core */,
+				A628F6F62782F0505F3BF4A059B1CCA8 /* UMCore */,
+			);
+			name = Dependencies;
+			sourceTree = "<group>";
+		};
+		F40060AC85706DE3DD3F4E0674BAFB35 = {
+			isa = PBXGroup;
+			children = (
+				E19D7C59937CA38D37776379FAF2B6A5 /* Dependencies */,
+				381B5F089F956926961273706F31BF20 /* EXSplashScreen */,
+				2041EB017B1AF52F6AA8DA2E67CBB6A3 /* Frameworks */,
+				D33DA80DF8393F21A71A71DBED1B0E29 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		FD4DC4F0D83C9B23D374B1502584E42D /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				E2D7A1C1FC30F626D63331A3685665B4 /* EXSplashScreen-dummy.m */,
+				9CAE620B3B207DE4A26803C9308D0B2E /* EXSplashScreen-prefix.pch */,
+				8322BC8C8DC48F624A078C3D024D3125 /* EXSplashScreen.debug.xcconfig */,
+				ED8CF8BEF601390CA174C8C8ECA07B0F /* EXSplashScreen.release.xcconfig */,
+			);
+			name = "Support Files";
+			path = "../../../apps/bare-expo/ios/Pods/Target Support Files/EXSplashScreen";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		C6D3CF891CC10B91228D19E51F388D7E /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F4E1582199B36AC1C4C49CCF300A618F /* EXSplashScreenController.h in Headers */,
+				22031BB1FDEE1A9906ECCA6DC9CE4D7A /* EXSplashScreenModule.h in Headers */,
+				4BF21E4196DCD5E196CFD912D57C9705 /* EXSplashScreenService.h in Headers */,
+				431227FF75F10472D77461528C44C748 /* EXSplashScreenViewNativeProvider.h in Headers */,
+				A3C1293B7354176B07E3EA8B046B2767 /* EXSplashScreenViewProvider.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		DB238802456FCDBECAB3DEF87BC88AC7 /* EXSplashScreen */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 8189B39DB90DB88F101D20FF8BA6AD75 /* Build configuration list for PBXNativeTarget "EXSplashScreen" */;
+			buildPhases = (
+				C6D3CF891CC10B91228D19E51F388D7E /* Headers */,
+				8AAB63FA0124DEBCCE47F876EF3BB732 /* Sources */,
+				8D0F8D77F6AACC254FF34F8A7CFD61E4 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				45EE9E5E062BB0BA5D602A0C0F7A8B7A /* PBXTargetDependency */,
+				90E4FDC90D3353E3612D2EF84544C7EF /* PBXTargetDependency */,
+			);
+			name = EXSplashScreen;
+			productName = EXSplashScreen;
+			productReference = 783BAE144108CDDC9FAABFA317982094 /* libEXSplashScreen.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		4B68D001187318B1B8DEB8FE0C3F7FA8 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 1100;
+				LastUpgradeCheck = 1100;
+			};
+			buildConfigurationList = E735D04F0B65ECB4939F6A92628154AA /* Build configuration list for PBXProject "EXSplashScreen" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = F40060AC85706DE3DD3F4E0674BAFB35;
+			productRefGroup = D33DA80DF8393F21A71A71DBED1B0E29 /* Products */;
+			projectDirPath = "";
+			projectReferences = (
+				{
+					ProjectRef = A628F6F62782F0505F3BF4A059B1CCA8 /* UMCore */;
+				},
+				{
+					ProjectRef = CF1F4A4540EFDAA226452BC78A803DED /* React-Core */;
+				},
+			);
+			projectRoot = "";
+			targets = (
+				DB238802456FCDBECAB3DEF87BC88AC7 /* EXSplashScreen */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		8AAB63FA0124DEBCCE47F876EF3BB732 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				54F5C2E9A7C12B7177951EDC224E9745 /* EXSplashScreen-dummy.m in Sources */,
+				DE76F0A3AC22B19291B07B01C6E528FB /* EXSplashScreenController.m in Sources */,
+				7A410CA0DAD9D66CDF34D1BA4C38E836 /* EXSplashScreenModule.m in Sources */,
+				E4C83888EEBA1B78ECCE302D018072BD /* EXSplashScreenService.m in Sources */,
+				878DE0719CB9A5F1E7183076E3880DD8 /* EXSplashScreenViewNativeProvider.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		45EE9E5E062BB0BA5D602A0C0F7A8B7A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "React-Core";
+			targetProxy = E18864F712532ADD198EAF0C3E62E6FC /* PBXContainerItemProxy */;
+		};
+		90E4FDC90D3353E3612D2EF84544C7EF /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = UMCore;
+			targetProxy = 10F314D229B67F722B5A407828B284E1 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		43590903B54C87737D5DCBD15E4A8D7F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 8322BC8C8DC48F624A078C3D024D3125 /* EXSplashScreen.debug.xcconfig */;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
+				GCC_PREFIX_HEADER = "Target Support Files/EXSplashScreen/EXSplashScreen-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRIVATE_HEADERS_FOLDER_PATH = "";
+				PRODUCT_MODULE_NAME = EXSplashScreen;
+				PRODUCT_NAME = EXSplashScreen;
+				PUBLIC_HEADERS_FOLDER_PATH = "";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		4AAFADE5297AD0E88CCF387220E8B206 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = ED8CF8BEF601390CA174C8C8ECA07B0F /* EXSplashScreen.release.xcconfig */;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
+				GCC_PREFIX_HEADER = "Target Support Files/EXSplashScreen/EXSplashScreen-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRIVATE_HEADERS_FOLDER_PATH = "";
+				PRODUCT_MODULE_NAME = EXSplashScreen;
+				PRODUCT_NAME = EXSplashScreen;
+				PUBLIC_HEADERS_FOLDER_PATH = "";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		A6F1F84A08A3ED11B2C92222AD9055D9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"POD_CONFIGURATION_DEBUG=1",
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRIP_INSTALLED_PRODUCT = NO;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				SYMROOT = "${SRCROOT}/../build";
+			};
+			name = Debug;
+		};
+		F22E9C46A060B54CC78AC7FFAE3743C4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"POD_CONFIGURATION_RELEASE=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRIP_INSTALLED_PRODUCT = NO;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+				SYMROOT = "${SRCROOT}/../build";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		8189B39DB90DB88F101D20FF8BA6AD75 /* Build configuration list for PBXNativeTarget "EXSplashScreen" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				43590903B54C87737D5DCBD15E4A8D7F /* Debug */,
+				4AAFADE5297AD0E88CCF387220E8B206 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E735D04F0B65ECB4939F6A92628154AA /* Build configuration list for PBXProject "EXSplashScreen" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A6F1F84A08A3ED11B2C92222AD9055D9 /* Debug */,
+				F22E9C46A060B54CC78AC7FFAE3743C4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 4B68D001187318B1B8DEB8FE0C3F7FA8 /* Project object */;
+}

--- a/apps/bare-expo/ios/Pods/Headers/Private/EXSplashScreen/EXSplashScreenController.h
+++ b/apps/bare-expo/ios/Pods/Headers/Private/EXSplashScreen/EXSplashScreenController.h
@@ -1,0 +1,1 @@
+../../../../../../../packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenController.h

--- a/apps/bare-expo/ios/Pods/Headers/Private/EXSplashScreen/EXSplashScreenModule.h
+++ b/apps/bare-expo/ios/Pods/Headers/Private/EXSplashScreen/EXSplashScreenModule.h
@@ -1,0 +1,1 @@
+../../../../../../../packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenModule.h

--- a/apps/bare-expo/ios/Pods/Headers/Private/EXSplashScreen/EXSplashScreenService.h
+++ b/apps/bare-expo/ios/Pods/Headers/Private/EXSplashScreen/EXSplashScreenService.h
@@ -1,0 +1,1 @@
+../../../../../../../packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenService.h

--- a/apps/bare-expo/ios/Pods/Headers/Private/EXSplashScreen/EXSplashScreenViewNativeProvider.h
+++ b/apps/bare-expo/ios/Pods/Headers/Private/EXSplashScreen/EXSplashScreenViewNativeProvider.h
@@ -1,0 +1,1 @@
+../../../../../../../packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenViewNativeProvider.h

--- a/apps/bare-expo/ios/Pods/Headers/Private/EXSplashScreen/EXSplashScreenViewProvider.h
+++ b/apps/bare-expo/ios/Pods/Headers/Private/EXSplashScreen/EXSplashScreenViewProvider.h
@@ -1,0 +1,1 @@
+../../../../../../../packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenViewProvider.h

--- a/apps/bare-expo/ios/Pods/Headers/Public/EXSplashScreen/EXSplashScreenController.h
+++ b/apps/bare-expo/ios/Pods/Headers/Public/EXSplashScreen/EXSplashScreenController.h
@@ -1,0 +1,1 @@
+../../../../../../../packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenController.h

--- a/apps/bare-expo/ios/Pods/Headers/Public/EXSplashScreen/EXSplashScreenModule.h
+++ b/apps/bare-expo/ios/Pods/Headers/Public/EXSplashScreen/EXSplashScreenModule.h
@@ -1,0 +1,1 @@
+../../../../../../../packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenModule.h

--- a/apps/bare-expo/ios/Pods/Headers/Public/EXSplashScreen/EXSplashScreenService.h
+++ b/apps/bare-expo/ios/Pods/Headers/Public/EXSplashScreen/EXSplashScreenService.h
@@ -1,0 +1,1 @@
+../../../../../../../packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenService.h

--- a/apps/bare-expo/ios/Pods/Headers/Public/EXSplashScreen/EXSplashScreenViewNativeProvider.h
+++ b/apps/bare-expo/ios/Pods/Headers/Public/EXSplashScreen/EXSplashScreenViewNativeProvider.h
@@ -1,0 +1,1 @@
+../../../../../../../packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenViewNativeProvider.h

--- a/apps/bare-expo/ios/Pods/Headers/Public/EXSplashScreen/EXSplashScreenViewProvider.h
+++ b/apps/bare-expo/ios/Pods/Headers/Public/EXSplashScreen/EXSplashScreenViewProvider.h
@@ -1,0 +1,1 @@
+../../../../../../../packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenViewProvider.h

--- a/apps/bare-expo/ios/Pods/Local Podspecs/EXSplashScreen.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/EXSplashScreen.podspec.json
@@ -1,0 +1,24 @@
+{
+  "name": "EXSplashScreen",
+  "version": "0.8.1",
+  "summary": "Provides a module to allow keeping the native Splash Screen visible until you choose to hide it.",
+  "description": "Provides a module to allow keeping the native Splash Screen visible until you choose to hide it.",
+  "license": "MIT",
+  "authors": "650 Industries, Inc.",
+  "homepage": "https://docs.expo.io/versions/latest/sdk/splash-screen/",
+  "platforms": {
+    "ios": "11.0"
+  },
+  "source": {
+    "git": "https://github.com/expo/expo.git"
+  },
+  "dependencies": {
+    "UMCore": [
+
+    ],
+    "React-Core": [
+
+    ]
+  },
+  "source_files": "EXSplashScreen/**/*.{h,m}"
+}

--- a/apps/bare-expo/ios/Pods/Target Support Files/EXSplashScreen/EXSplashScreen-dummy.m
+++ b/apps/bare-expo/ios/Pods/Target Support Files/EXSplashScreen/EXSplashScreen-dummy.m
@@ -1,0 +1,5 @@
+#import <Foundation/Foundation.h>
+@interface PodsDummy_EXSplashScreen : NSObject
+@end
+@implementation PodsDummy_EXSplashScreen
+@end

--- a/apps/bare-expo/ios/Pods/Target Support Files/EXSplashScreen/EXSplashScreen-prefix.pch
+++ b/apps/bare-expo/ios/Pods/Target Support Files/EXSplashScreen/EXSplashScreen-prefix.pch
@@ -1,0 +1,12 @@
+#ifdef __OBJC__
+#import <UIKit/UIKit.h>
+#else
+#ifndef FOUNDATION_EXPORT
+#if defined(__cplusplus)
+#define FOUNDATION_EXPORT extern "C"
+#else
+#define FOUNDATION_EXPORT extern
+#endif
+#endif
+#endif
+

--- a/apps/bare-expo/ios/Pods/Target Support Files/EXSplashScreen/EXSplashScreen.debug.xcconfig
+++ b/apps/bare-expo/ios/Pods/Target Support Files/EXSplashScreen/EXSplashScreen.debug.xcconfig
@@ -1,0 +1,13 @@
+CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = NO
+CONFIGURATION_BUILD_DIR = ${PODS_CONFIGURATION_BUILD_DIR}/EXSplashScreen
+GCC_PREPROCESSOR_DEFINITIONS = $(inherited) COCOAPODS=1
+HEADER_SEARCH_PATHS = $(inherited) "${PODS_ROOT}/Headers/Private" "${PODS_ROOT}/Headers/Private/EXSplashScreen" "${PODS_ROOT}/Headers/Public" "${PODS_ROOT}/Headers/Public/DoubleConversion" "${PODS_ROOT}/Headers/Public/EXSplashScreen" "${PODS_ROOT}/Headers/Public/React-Core" "${PODS_ROOT}/Headers/Public/React-callinvoker" "${PODS_ROOT}/Headers/Public/React-cxxreact" "${PODS_ROOT}/Headers/Public/React-jsi" "${PODS_ROOT}/Headers/Public/React-jsiexecutor" "${PODS_ROOT}/Headers/Public/React-jsinspector" "${PODS_ROOT}/Headers/Public/UMCore" "${PODS_ROOT}/Headers/Public/Yoga" "${PODS_ROOT}/Headers/Public/glog"
+OTHER_CFLAGS = $(inherited) -fmodule-map-file="${PODS_ROOT}/Headers/Public/yoga/Yoga.modulemap"
+PODS_BUILD_DIR = ${BUILD_DIR}
+PODS_CONFIGURATION_BUILD_DIR = ${PODS_BUILD_DIR}/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)
+PODS_ROOT = ${SRCROOT}
+PODS_TARGET_SRCROOT = ${PODS_ROOT}/../../../../packages/expo-splash-screen/ios
+PODS_XCFRAMEWORKS_BUILD_DIR = $(PODS_CONFIGURATION_BUILD_DIR)/XCFrameworkIntermediates
+PRODUCT_BUNDLE_IDENTIFIER = org.cocoapods.${PRODUCT_NAME:rfc1034identifier}
+SKIP_INSTALL = YES
+USE_RECURSIVE_SCRIPT_INPUTS_IN_SCRIPT_PHASES = YES

--- a/apps/bare-expo/ios/Pods/Target Support Files/EXSplashScreen/EXSplashScreen.release.xcconfig
+++ b/apps/bare-expo/ios/Pods/Target Support Files/EXSplashScreen/EXSplashScreen.release.xcconfig
@@ -1,0 +1,13 @@
+CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = NO
+CONFIGURATION_BUILD_DIR = ${PODS_CONFIGURATION_BUILD_DIR}/EXSplashScreen
+GCC_PREPROCESSOR_DEFINITIONS = $(inherited) COCOAPODS=1
+HEADER_SEARCH_PATHS = $(inherited) "${PODS_ROOT}/Headers/Private" "${PODS_ROOT}/Headers/Private/EXSplashScreen" "${PODS_ROOT}/Headers/Public" "${PODS_ROOT}/Headers/Public/DoubleConversion" "${PODS_ROOT}/Headers/Public/EXSplashScreen" "${PODS_ROOT}/Headers/Public/React-Core" "${PODS_ROOT}/Headers/Public/React-callinvoker" "${PODS_ROOT}/Headers/Public/React-cxxreact" "${PODS_ROOT}/Headers/Public/React-jsi" "${PODS_ROOT}/Headers/Public/React-jsiexecutor" "${PODS_ROOT}/Headers/Public/React-jsinspector" "${PODS_ROOT}/Headers/Public/UMCore" "${PODS_ROOT}/Headers/Public/Yoga" "${PODS_ROOT}/Headers/Public/glog"
+OTHER_CFLAGS = $(inherited) -fmodule-map-file="${PODS_ROOT}/Headers/Public/yoga/Yoga.modulemap"
+PODS_BUILD_DIR = ${BUILD_DIR}
+PODS_CONFIGURATION_BUILD_DIR = ${PODS_BUILD_DIR}/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)
+PODS_ROOT = ${SRCROOT}
+PODS_TARGET_SRCROOT = ${PODS_ROOT}/../../../../packages/expo-splash-screen/ios
+PODS_XCFRAMEWORKS_BUILD_DIR = $(PODS_CONFIGURATION_BUILD_DIR)/XCFrameworkIntermediates
+PRODUCT_BUNDLE_IDENTIFIER = org.cocoapods.${PRODUCT_NAME:rfc1034identifier}
+SKIP_INSTALL = YES
+USE_RECURSIVE_SCRIPT_INPUTS_IN_SCRIPT_PHASES = YES

--- a/apps/bare-expo/scripts/build-detox-ios.sh
+++ b/apps/bare-expo/scripts/build-detox-ios.sh
@@ -12,7 +12,7 @@ configuration=$1
 # YES or NO
 UseModernBuildSystem=${2:-"NO"}
 
-xcodebuild clean build \
+xcodebuild \
   -workspace ios/BareExpo.xcworkspace \
   -scheme BareExpoDetox \
   -configuration "$configuration" \

--- a/apps/bare-expo/scripts/build-detox-ios.sh
+++ b/apps/bare-expo/scripts/build-detox-ios.sh
@@ -12,7 +12,7 @@ configuration=$1
 # YES or NO
 UseModernBuildSystem=${2:-"NO"}
 
-xcodebuild \
+xcodebuild clean build \
   -workspace ios/BareExpo.xcworkspace \
   -scheme BareExpoDetox \
   -configuration "$configuration" \


### PR DESCRIPTION
# Why

ios test suite is failing with: 
```
⚠️  ld: directory not found for option '-L/Users/runner/work/expo/expo/apps/bare-expo/ios/build/Build/Products/Release-iphonesimulator/EXSplashScreen'

❌  ld: library not found for -lEXSplashScreen
```

# How

we gitignore `ios/Pods/` not really clear to me why or if we should continue doing that

anyways, moving `expo-splash-screen` from excluded to included resulted in the relevant pod files **not** being committed thus this command was running successfully locally but failing on CI
