### PR TITLE
[dev-menu] Fix import of the umbrella header

### DIFF
--- a/docs/public/static/diffs/client/app-delegate.diff
+++ b/docs/public/static/diffs/client/app-delegate.diff
@@ -6,7 +6,7 @@ index 86b3a12..1a310cf 100644
  #import <SKIOSNetworkPlugin/SKIOSNetworkAdapter.h>
  #import <FlipperKitReactPlugin/FlipperKitReactPlugin.h>
  
-+#if __has_include(<EXDevMenu/EXDevMenu-umbrella.h>)
++#if __has_include(<EXDevMenu/EXDevMenu.h>)
 +@import EXDevMenu;
 +#endif
 +
@@ -46,7 +46,7 @@ index 86b3a12..1a310cf 100644
    RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge moduleName:@"main" initialProperties:nil];
    rootView.backgroundColor = [[UIColor alloc] initWithRed:1.0f green:1.0f blue:1.0f alpha:1];
  
-+  #if __has_include(<EXDevMenu/EXDevMenu-umbrella.h>)
++  #if __has_include(<EXDevMenu/EXDevMenu.h>)
 +  [DevMenuManager configureWithBridge:bridge];
 +  #endif
 +  

--- a/packages/expo-dev-menu/ios/Headers/EXDevMenu.h
+++ b/packages/expo-dev-menu/ios/Headers/EXDevMenu.h
@@ -1,5 +1,5 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
-#if __has_include("EXDevMenu-umbrella.h")
-#import "EXDevMenu-umbrella.h"
+#if __has_include(<EXDevMenu/expo-dev-menu-umbrella.h>)
+#import <EXDevMenu/expo-dev-menu-umbrella.h>
 #endif


### PR DESCRIPTION
# Why

The umbrella header import should be changed when we renamed the podfile.
Moreover, we don't need to check if the umbrella header exists to check if the package exits.

# Test Plan

- https://github.com/tcdavis/dev-client-ios-menu-201223 compiles with those changes ✅
