### PR TITLE
[dev-menu][ios] Fix menu not hiding when auto launch is selected

### DIFF
--- a/packages/expo-dev-menu/ios/DevMenuManager.swift
+++ b/packages/expo-dev-menu/ios/DevMenuManager.swift
@@ -81,7 +81,7 @@ open class DevMenuManager: NSObject, DevMenuManagerProtocol {
         return
       }
       if bridge.isLoading {
-        NotificationCenter.default.addObserver(self, selector: #selector(DevMenuManager.autoLaunch), name: DevMenuViewController.JavaScriptDidLoadNotification, object: bridge)
+        NotificationCenter.default.addObserver(self, selector: #selector(DevMenuManager.autoLaunch), name: DevMenuViewController.ContentDidAppearNotification, object: nil)
       } else {
         autoLaunch()
       }

--- a/packages/expo-dev-menu/ios/DevMenuViewController.swift
+++ b/packages/expo-dev-menu/ios/DevMenuViewController.swift
@@ -4,6 +4,7 @@ import UIKit
 
 class DevMenuViewController: UIViewController {
   static let JavaScriptDidLoadNotification = Notification.Name("RCTJavaScriptDidLoadNotification")
+  static let ContentDidAppearNotification = Notification.Name("RCTContentDidAppearNotification")
 
   private let manager: DevMenuManager
   private var reactRootView: DevMenuRootView?


### PR DESCRIPTION
# Why

 Fixes menu not hiding when auto-launch is selected.

# How

Sometimes the menu doesn't hide when you have the auto-launch option selected. Why? It's because of the race condition. The RN doesn't send the `RCTContentDidAppearNotification` event to the splash screen instead it sends it to the dev-menu bridge. Also closing the `dev-menu` doesn't help. So I've delayed menu opening. 

> **Note:**  The menu is listing to every `RCTContentDidAppearNotification` event. However, this should be relatively safe here. 

# Test Plan

- tested with https://github.com/tcdavis/dev-client-ios-menu-201223 ✅