### PR TITLE
Typo in the example usage section

### DIFF
--- a/docs/pages/versions/unversioned/sdk/firebase-recaptcha.md
+++ b/docs/pages/versions/unversioned/sdk/firebase-recaptcha.md
@@ -103,7 +103,7 @@ export default function App() {
 
   return (
     <View style={{ padding: 20, marginTop: 50 }}>
-      <FirebaseRecaptchaModalVerifier
+      <FirebaseRecaptchaVerifierModal
         ref={recaptchaVerifier}
         firebaseConfig={firebaseConfig}
         attemptInvisibleVerification={attemptInvisibleVerification}


### PR DESCRIPTION
Renamed the tag <FirebaseRecaptchaModalVerifier/> to <FirebaseRecaptchaVerifierModal/>

# Why

<!-- 
I was using firebase in my expo app and found this error. So I thought to fix this error.
-->

# How

<!-- 
So that none of my fellow community programmer face this issue 
-->

# Test Plan

<!-- 
Tested the changes on my local machine  
-->
