### PR TITLE
update install instructions for 0.1.1

### DIFF
--- a/docs/public/static/diffs/client/app-delegate.diff
+++ b/docs/public/static/diffs/client/app-delegate.diff
@@ -1,12 +1,12 @@
 diff --git a/ios/expodevexample/AppDelegate.m b/ios/expodevexample/AppDelegate.m
-index 86b3a12..1a310cf 100644
+index 9cb91ea..a25372c 100644
 --- a/ios/expodevexample/AppDelegate.m
 +++ b/ios/expodevexample/AppDelegate.m
-@@ -19,6 +19,14 @@
- #import <SKIOSNetworkPlugin/SKIOSNetworkAdapter.h>
- #import <FlipperKitReactPlugin/FlipperKitReactPlugin.h>
+@@ -11,6 +11,14 @@
+ #import <EXSplashScreen/EXSplashScreenService.h>
+ #import <UMCore/UMModuleRegistryProvider.h>
  
-+#if __has_include(<EXDevMenu/EXDevMenu-umbrella.h>)
++#if __has_include(<EXDevMenu/EXDevMenu.h>)
 +@import EXDevMenu;
 +#endif
 +
@@ -14,10 +14,10 @@ index 86b3a12..1a310cf 100644
 +#include <EXDevLauncher/EXDevLauncherController.h>
 +#endif
 +
- static void InitializeFlipper(UIApplication *application) {
-   FlipperClient *client = [FlipperClient sharedClient];
-   SKDescriptorMapper *layoutDescriptorMapper = [[SKDescriptorMapper alloc] initWithDefaults];
-@@ -49,7 +57,12 @@ - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(
+ #if defined(FB_SONARKIT_ENABLED) && __has_include(<FlipperKit/FlipperClient.h>)
+ #import <FlipperKit/FlipperClient.h>
+ #import <FlipperKitLayoutPlugin/FlipperKitLayoutPlugin.h>
+@@ -49,7 +57,12 @@ static void InitializeFlipper(UIApplication *application) {
    self.launchOptions = launchOptions;
    self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
    #ifdef DEBUG
@@ -31,29 +31,29 @@ index 86b3a12..1a310cf 100644
    #else
      EXUpdatesAppController *controller = [EXUpdatesAppController sharedInstance];
      controller.delegate = self;
-@@ -63,10 +76,20 @@ - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(
+@@ -63,10 +76,20 @@ static void InitializeFlipper(UIApplication *application) {
  
  - (RCTBridge *)initializeReactNativeApp
  {
 -  RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:self.launchOptions];
 +#if __has_include(<EXDevLauncher/EXDevLauncherController.h>)
-+  NSDictionary *launchOptions = [EXDevLauncherController.sharedInstance getLaunchOptions];
++    NSDictionary *launchOptions = [EXDevLauncherController.sharedInstance getLaunchOptions];
 +#else
-+  NSDictionary *launchOptions = self.launchOptions;
++    NSDictionary *launchOptions = self.launchOptions;
 +#endif
-+  
++
 +  RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:launchOptions];
    RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge moduleName:@"main" initialProperties:nil];
    rootView.backgroundColor = [[UIColor alloc] initWithRed:1.0f green:1.0f blue:1.0f alpha:1];
  
-+  #if __has_include(<EXDevMenu/EXDevMenu-umbrella.h>)
++#if __has_include(<EXDevMenu/EXDevMenu.h>)
 +  [DevMenuManager configureWithBridge:bridge];
-+  #endif
-+  
++#endif
++
    UIViewController *rootViewController = [UIViewController new];
    rootViewController.view = rootView;
    self.window.rootViewController = rootViewController;
-@@ -83,11 +106,15 @@ - (RCTBridge *)initializeReactNativeApp
+@@ -83,11 +106,15 @@ static void InitializeFlipper(UIApplication *application) {
  }
  
  - (NSURL *)sourceURLForBridge:(RCTBridge *)bridge {
@@ -73,7 +73,7 @@ index 86b3a12..1a310cf 100644
  }
  
  - (void)appController:(EXUpdatesAppController *)appController didStartWithSuccess:(BOOL)success {
-@@ -98,6 +125,11 @@ - (void)appController:(EXUpdatesAppController *)appController didStartWithSucces
+@@ -98,6 +125,11 @@ static void InitializeFlipper(UIApplication *application) {
  
  // Linking API
  - (BOOL)application:(UIApplication *)application openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {
@@ -85,7 +85,7 @@ index 86b3a12..1a310cf 100644
    return [RCTLinkingManager application:application openURL:url options:options];
  }
  
-@@ -109,3 +141,17 @@ - (BOOL)application:(UIApplication *)application continueUserActivity:(nonnull N
+@@ -109,3 +141,17 @@ static void InitializeFlipper(UIApplication *application) {
  }
  
  @end

--- a/docs/public/static/diffs/client/podfile.diff
+++ b/docs/public/static/diffs/client/podfile.diff
@@ -1,13 +1,20 @@
 diff --git a/ios/Podfile b/ios/Podfile
-index 8c935a2..1b1f955 100644
+index 55100df..375d171 100644
 --- a/ios/Podfile
 +++ b/ios/Podfile
-@@ -6,10 +6,14 @@ platform :ios, '10.0'
+@@ -2,10 +2,14 @@ require_relative '../node_modules/react-native/scripts/react_native_pods'
+ require_relative '../node_modules/react-native-unimodules/cocoapods.rb'
+ require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
  
- target 'expodevexample' do
+-platform :ios, '10.0'
++platform :ios, '11.0'
+ 
+ target 'devclient201227' do
    use_unimodules!
-+  
++
 +  pod 'expo-dev-menu', path: '../node_modules/expo-dev-menu', :configurations => :debug
 +  pod 'expo-dev-launcher', path: '../node_modules/expo-dev-launcher', :configurations => :debug
-+  
++
    config = use_native_modules!
+ 
+   use_react_native!(:path => config["reactNativePath"])


### PR DESCRIPTION
# Why

The current install instructions don't quite work out of the box.

# How

Updated diffs to get a working project
(includes the changes to the appdelegate diff from https://github.com/expo/expo/pull/11459/files)

# Test Plan

- these are the diffs required to install the dev client with versions 0.1.1
- ran docs locally
