### PR TITLE
Update SQLite.types.ts

### DIFF
--- a/packages/expo-sqlite/src/SQLite.types.ts
+++ b/packages/expo-sqlite/src/SQLite.types.ts
@@ -73,6 +73,7 @@ export interface SQLResultSet {
 export interface SQLResultSetRowList {
   length: number;
   item(index: number): any;
+  _array: any[];
 }
 
 export declare class SQLError {


### PR DESCRIPTION
Should allow TypeScript users to access the array of rows without getting a TypeScript error (similar to https://stackoverflow.com/questions/54771826/get-the-actual-array-of-rows-from-sql-query-with-sqlite-and-expo). Should have been fixed with https://github.com/expo/expo/issues/5581, but still have this bug.

# Why

TypeScript users (myself included) cannot access the _array property on an SQLResultSetRowList

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->
