### PR TITLE
[bare-expo] Update main component name in Android, conforming to #11430

### DIFF
--- a/apps/bare-expo/android/app/src/main/java/dev/expo/payments/MainActivity.java
+++ b/apps/bare-expo/android/app/src/main/java/dev/expo/payments/MainActivity.java
@@ -22,7 +22,7 @@ public class MainActivity extends DevMenuAwareReactActivity {
    */
   @Override
   protected String getMainComponentName() {
-    return "BareExpo";
+    return "main";
   }
 
   @Override


### PR DESCRIPTION
# Why

Since https://github.com/expo/expo/pull/11430 landed, Android `bare-expo` doesn't register the JS app under correct name.

# How

Replaced `BareExpo` with `main` since now we use `expo`'s `registerRootComponent` which, as a helpful comment explains, registers the JS app under `main` name in bare workflow.

# Test Plan

`bare-expo` ran on Android emulator.