### PR TITLE
[expo-dev-launcher] Downgrade okhttp version to v3

### DIFF
--- a/packages/expo-dev-launcher/android/build.gradle
+++ b/packages/expo-dev-launcher/android/build.gradle
@@ -82,7 +82,7 @@ dependencies {
 
   implementation 'commons-io:commons-io:2.6'
 
-  implementation("com.squareup.okhttp3:okhttp:4.9.0")
+  implementation("com.squareup.okhttp3:okhttp:3.12.1")
   implementation 'com.google.code.gson:gson:2.8.5'
 
   // Fixes

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/manifest/DevLauncherManifestParser.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/manifest/DevLauncherManifestParser.kt
@@ -19,7 +19,7 @@ class DevLauncherManifestParser(
   private suspend fun downloadManifest(): Reader {
     val response = fetch(url, "GET").await(httpClient)
     require(response.isSuccessful)
-    return response.body!!.charStream()
+    return response.body()!!.charStream()
   }
 
   suspend fun parseManifest(): DevelopmentClientManifest {


### PR DESCRIPTION
# Why

When an Android app is built, at most one version of a dependency is included in the bundle. If there are multiple dependency requirements on a single dependency, only the highest is included.

[React Native as of end of 2020 depends on `okhttp` and `okhttp-urlconnection` v3](https://github.com/facebook/react-native/blob/1e78e0655d53ac947f523bcadf9c5339ab07bbb8/ReactAndroid/gradle.properties#L15). If we depend on `okhttp@4` in `expo-dev-launcher`, Android projects using `expo-dev-launcher` will include: `okhttp@4`, `okhttp-urlconnection@3`.

It turns out this set of dependencies is not compatible, because when:
- a cookie is being saved to cookie jar, `ReactCookieJarContainer#saveFromResponse` is called,
- which causes [`JavaNetCookieJar#saveFromResponse` to be called](https://github.com/facebook/react-native/blob/811ccec74e5b898e9304f86f85f390908f8d317f/ReactAndroid/src/main/java/com/facebook/react/modules/network/ReactCookieJarContainer.java#L37) 
- which in `okhttp-urlconnection@3` causes [`Cookie#toString(boolean)` to be called](https://github.com/square/okhttp/blob/46de1ffdf83bd0793954740d404535cd55c053b8/okhttp-urlconnection/src/main/java/okhttp3/JavaNetCookieJar.java#L45)
- and in `okhttp@4`, [`Cookie` does not have a `#toString(boolean)` method](https://square.github.io/okhttp/4.x/okhttp/okhttp3/-cookie/#functions) (while in `okhttp@3` [`Cookie` had this method implemented](https://github.com/square/okhttp/blob/46de1ffdf83bd0793954740d404535cd55c053b8/okhttp/src/main/java/okhttp3/Cookie.java#L550)).

This causes a native crash eg. when showing an image from a response which sets a cookie.

# How

Downgraded `okhttp` to v3. A single compilation error arose, fixed it (`body` ➡️ `body()`), verified it runs.

I would have added this change to changelog, but it seems `expo-dev-launcher` doesn't have one.

# Test Plan

Verified application runs and downloading an image, which on `master` causes a native crash doesn't do so anymore.
