### PR TITLE
[bare-expo] Fix `require`-d NCL assets not resolving

### DIFF
--- a/apps/bare-expo/metro.config.js
+++ b/apps/bare-expo/metro.config.js
@@ -5,6 +5,8 @@ const baseConfig = createMetroConfiguration(__dirname);
 const assetsLocationsRewrites = {
   // @react-navigation/stack is hoisted to root node_modules
   '/node_modules/@react-navigation/stack': '../../node_modules/@react-navigation/stack',
+  // native-component-list is one level up from bare-expo
+  '/native-component-list': '../native-component-list',
 };
 
 module.exports = {

--- a/apps/bare-expo/metro.config.js
+++ b/apps/bare-expo/metro.config.js
@@ -2,6 +2,11 @@ const { createMetroConfiguration } = require('expo-yarn-workspaces');
 
 const baseConfig = createMetroConfiguration(__dirname);
 
+const assetsLocationsRewrites = {
+  // @react-navigation/stack is hoisted to root node_modules
+  '/node_modules/@react-navigation/stack': '../../node_modules/@react-navigation/stack',
+};
+
 module.exports = {
   ...baseConfig,
 
@@ -12,10 +17,10 @@ module.exports = {
       return (req, res, next) => {
         // When an asset is imported outside the project root, it has wrong path on Android
         // This happens for the back button in stack, so we fix the path to correct one
-        const assets = '/node_modules/@react-navigation/stack/src/views/assets';
-
-        if (req.url.startsWith(assets)) {
-          req.url = req.url.replace(assets, `/assets/../..${assets}`);
+        for (const [rewriteFrom, rewriteTo] of Object.entries(assetsLocationsRewrites)) {
+          if (req.url.startsWith(rewriteFrom)) {
+            req.url = req.url.replace(rewriteFrom, `/assets/${rewriteTo}`);
+          }
         }
 
         return middleware(req, res, next);

--- a/apps/bare-expo/metro.config.js
+++ b/apps/bare-expo/metro.config.js
@@ -17,9 +17,21 @@ module.exports = {
       return (req, res, next) => {
         // When an asset is imported outside the project root, it has wrong path on Android
         // This happens for the back button in stack, so we fix the path to correct one
+        let assetLocationAlreadyRewritten = false;
+        const originalUrl = req.url;
         for (const [rewriteFrom, rewriteTo] of Object.entries(assetsLocationsRewrites)) {
+          // While most probably this will never happen, let's guard against it and inform
+          // the developer of any unexpected behavior.
+          if (assetLocationAlreadyRewritten) {
+            console.warn(
+              `Multiple asset location rewrites matched "${originalUrl}". Applying only the first matching rule.`
+            );
+            break;
+          }
+
           if (req.url.startsWith(rewriteFrom)) {
             req.url = req.url.replace(rewriteFrom, `/assets/${rewriteTo}`);
+            assetLocationAlreadyRewritten = true;
           }
         }
 


### PR DESCRIPTION
# Why

Since [some time before April](https://github.com/expo/expo/pull/7385#pullrequestreview-386355879) NCL assets are not properly shown in `bare-expo`. This makes it difficult to develop and test some modules, eg. `expo-image`.

Related to https://github.com/expo/expo/issues/7545.

# How

- noticed that indeed requests that Android app constructs, eg.
  ```
  http://localhost:8081/assets/../native-component-list/assets/images/chapeau.png?platform=android&hash=5cd271846065f695a3a0b6467cf04b97
  ```
  result in 404 errors
- led by my guts I opened `metro.config.js` to see exactly what I needed — a solution to similar problem, `@react-navigation/stack` assets not resolving due to the same bug
- changed the implementation a little bit to accommodate for more than one asset path rewrites
- added NCL location rewrite that worked.

# Test Plan

Icons of <kbd>Components</kbd> screens show up as expected (on `master` they did not):

<img width="300" alt="Zrzut ekranu 2020-12-30 o 10 20 08" src="https://user-images.githubusercontent.com/1151041/103342710-8d35fd00-4a8a-11eb-8f1e-f6287b95b574.png">
