### PR TITLE
[docs] fix to find the useFonts hook

### DIFF
--- a/docs/pages/versions/v40.0.0/sdk/font.md
+++ b/docs/pages/versions/v40.0.0/sdk/font.md
@@ -25,7 +25,7 @@ import * as Font from 'expo-font';
 ### `useFonts`
 
 ```ts
-const [loaded, error] = useFonts({ ... });
+const [loaded, error] = Font.useFonts({ ... });
 ```
 
 Load a map of fonts with [`loadAsync`](#loadasyncobject). This returns a boolean if the fonts are loaded and ready to use. It also returns an error if something went wrong, to use in development.
@@ -43,7 +43,7 @@ Load a map of fonts with [`loadAsync`](#loadasyncobject). This returns a boolean
 
 ```tsx
 function App() {
-  const [loaded] = useFonts({
+  const [loaded] = Font.useFonts({
     Montserrat: require('./assets/fonts/Montserrat.ttf'),
   });
 


### PR DESCRIPTION
# Why

Due the suggested import format, the hook can't be found without this addition when following the docs...

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->
