### PR TITLE
[android][workflow] Change adb binaries location to usr/local/bin

### DIFF
--- a/docs/pages/workflow/android-studio-emulator.md
+++ b/docs/pages/workflow/android-studio-emulator.md
@@ -65,6 +65,6 @@ This is because the adb version on your system is different from the adb version
 
 `$./adb version`
 
-- Copy `adb` from Android SDK directory to `usr/bin` directory:
+- Copy `adb` from Android SDK directory to `/usr/local/bin` directory:
 
-`$sudo cp ~/Library/Android/sdk/platform-tools/adb /usr/bin`
+`$sudo cp ~/Library/Android/sdk/platform-tools/adb /usr/local/bin`


### PR DESCRIPTION
# Why

 /usr/bin is protected under System Integrity Protection. User-supplied binaries should be put in /usr/local/bin. Only OS supplied ones should be in /usr/bin.

# How

It was just a matter of changing /usr/bin to /usr/local/bin.

# Test Plan

No extensive tests are required since binaries are searched by the shell in both directories. So adding adb to either of them does the job. As proof that it works, here is a screenshot - 

<img width="743" alt="Screenshot 2020-12-31 at 5 53 16 PM" src="https://user-images.githubusercontent.com/23443586/103405167-23ece180-4b91-11eb-8201-65ced2d7ee72.png">

At 17:24, `adb` was not added to /usr/local/bin and after adding it at 17:32, I was able to run my emulator. 
