### PR TITLE
Discussion: Note Web support for Picker component

### DIFF
--- a/docs/pages/versions/unversioned/sdk/picker.md
+++ b/docs/pages/versions/unversioned/sdk/picker.md
@@ -13,7 +13,7 @@ A component that provides access to the system UI for picking between several op
 
 > 💡 This library was formerly known as `@react-native-community/picker`. If you have that library in your SDK 40+ project, you can uninstall it and install this one instead.
 
-<PlatformsSection android emulator ios simulator />
+<PlatformsSection android emulator ios simulator web />
 
 ## Installation
 

--- a/docs/pages/versions/v40.0.0/sdk/picker.md
+++ b/docs/pages/versions/v40.0.0/sdk/picker.md
@@ -13,7 +13,7 @@ A component that provides access to the system UI for picking between several op
 
 > 💡 This library was formerly known as `@react-native-community/picker`. If you have that library in your SDK 40+ project, you can uninstall it and install this one instead.
 
-<PlatformsSection android emulator ios simulator />
+<PlatformsSection android emulator ios simulator web />
 
 ## Installation
 


### PR DESCRIPTION
# Why

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

I went to implement the `Picker` component, expecting to have to write another `Picker.web.tsx` component for the Web platform. However, the `Picker` appears to work just fine on Web?

It renders a native `<select>` tag with proper `<option>` elements. It appears, to my naive eyes, to be accessible.

**I'm creating this PR for discussion purposes, if Web support was purposely omitted from the docs for some other reason?**

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

I simply installed the `@react-native-picker/picker` package as instructed and ran it on Expo Web:

```sh
expo install @react-native-picker/picker
```

```tsx
import React, { FC } from 'react'
import { Picker } from '@react-native-picker/picker'

export const MyPickerComponent: FC = () => {
  return (
    <Picker
      selectedValue='TEST'
      onValueChange={console.log}
    >
      <Picker.Item label='Test' value='TEST' />
      <Picker.Item label='Option 2' value='OPTION_2' />
    </Picker>
  )
}
```

# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->

One should be able to run the above snippets in a fresh Expo project. I can create one in a repo with this done if preferable, however, I'm hoping that this change should be small and straightforward enough to not require a repo that describes the behaviour?

Thanks again for the lovely tool! ❤️ 