### PR TITLE
[expo-local-authentication] LocalAuthentication.isEnrolledAsync() returns false When you write incorrect password several times.

### DIFF
--- a/packages/expo-local-authentication/ios/EXLocalAuthentication/EXLocalAuthentication.m
+++ b/packages/expo-local-authentication/ios/EXLocalAuthentication/EXLocalAuthentication.m
@@ -58,11 +58,7 @@ UM_EXPORT_METHOD_AS(isEnrolledAsync,
   BOOL isSupported = [context canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:&error];
   BOOL isEnrolled;
   
-  if (@available(iOS 11.0, *)) {
-    isEnrolled = (isSupported && error == nil) || error.code == LAErrorBiometryLockout ;
-  } else {
-    isEnrolled = (isSupported && error == nil) || error.code == LAErrorTouchIDLockout ;
-  }
+  isEnrolled = (isSupported && error == nil) || error.code == LAErrorBiometryLockout;
   
   resolve(@(isEnrolled));
 }

--- a/packages/expo-local-authentication/ios/EXLocalAuthentication/EXLocalAuthentication.m
+++ b/packages/expo-local-authentication/ios/EXLocalAuthentication/EXLocalAuthentication.m
@@ -56,8 +56,14 @@ UM_EXPORT_METHOD_AS(isEnrolledAsync,
   NSError *error = nil;
 
   BOOL isSupported = [context canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:&error];
-  BOOL isEnrolled = isSupported && error == nil;
-
+  BOOL isEnrolled;
+  
+  if (@available(iOS 11.0, *)) {
+    isEnrolled = (isSupported && error == nil) || error.code == LAErrorBiometryLockout ;
+  } else {
+    isEnrolled = (isSupported && error == nil) || error.code == LAErrorTouchIDLockout ;
+  }
+  
   resolve(@(isEnrolled));
 }
 


### PR DESCRIPTION

# Why

LocalAuthentication.isEnrolledAsync() returns false When you write incorrect password several times(Lockout mode) ,even when device has saved fingerprints or facial data.


# Test Plan

1. check for LocalAuthentication.isEnrolledAsync() returns true, if you enable biometric.
2. use LocalAuthentication.authenticateAsync() and write wrong password until this screen appears(Lockout mode).

<details>
  <summary>screenshot</summary>

 ![authentication-fail](https://user-images.githubusercontent.com/56818655/103476021-e5d30600-4dba-11eb-9fd4-eadea784caba.jpeg)

</details>

4. check for LocalAuthentication.isEnrolledAsync() again, it returns true.

# Platform

iOS 

