### PR TITLE
[docs] Fix filesystem examples not opening on Snack

### DIFF
--- a/docs/pages/versions/unversioned/sdk/filesystem.md
+++ b/docs/pages/versions/unversioned/sdk/filesystem.md
@@ -88,8 +88,8 @@ try {
 label="Managing Giphy's"
 templateId="filesystem/App"
 files={{
-    'GifFetching.ts': 'filesystem/GifFetching.ts',
-    'GifManagement.ts': 'filesystem/GifManagement.ts'
+    'GifFetching.ts': 'filesystem/gifFetching.ts',
+    'GifManagement.ts': 'filesystem/gifManagement.ts'
   }}>
 
 ```typescript

--- a/docs/pages/versions/unversioned/sdk/filesystem.md
+++ b/docs/pages/versions/unversioned/sdk/filesystem.md
@@ -87,6 +87,7 @@ try {
 <SnackInline
 label="Managing Giphy's"
 templateId="filesystem/App"
+dependencies={['expo-file-system']}
 files={{
     'GifFetching.ts': 'filesystem/gifFetching.ts',
     'GifManagement.ts': 'filesystem/gifManagement.ts'

--- a/docs/pages/versions/v39.0.0/sdk/filesystem.md
+++ b/docs/pages/versions/v39.0.0/sdk/filesystem.md
@@ -88,8 +88,8 @@ try {
 label="Managing Giphy's"
 templateId="filesystem/App"
 files={{
-    'GifFetching.ts': 'filesystem/GifFetching.ts',
-    'GifManagement.ts': 'filesystem/GifManagement.ts'
+    'GifFetching.ts': 'filesystem/gifFetching.ts',
+    'GifManagement.ts': 'filesystem/gifManagement.ts'
   }}>
 
 ```typescript

--- a/docs/pages/versions/v39.0.0/sdk/filesystem.md
+++ b/docs/pages/versions/v39.0.0/sdk/filesystem.md
@@ -87,6 +87,7 @@ try {
 <SnackInline
 label="Managing Giphy's"
 templateId="filesystem/App"
+dependencies={['expo-file-system']}
 files={{
     'GifFetching.ts': 'filesystem/gifFetching.ts',
     'GifManagement.ts': 'filesystem/gifManagement.ts'

--- a/docs/pages/versions/v40.0.0/sdk/filesystem.md
+++ b/docs/pages/versions/v40.0.0/sdk/filesystem.md
@@ -88,8 +88,8 @@ try {
 label="Managing Giphy's"
 templateId="filesystem/App"
 files={{
-    'GifFetching.ts': 'filesystem/GifFetching.ts',
-    'GifManagement.ts': 'filesystem/GifManagement.ts'
+    'GifFetching.ts': 'filesystem/gifFetching.ts',
+    'GifManagement.ts': 'filesystem/gifManagement.ts'
   }}>
 
 ```typescript

--- a/docs/pages/versions/v40.0.0/sdk/filesystem.md
+++ b/docs/pages/versions/v40.0.0/sdk/filesystem.md
@@ -87,6 +87,7 @@ try {
 <SnackInline
 label="Managing Giphy's"
 templateId="filesystem/App"
+dependencies={['expo-file-system']}
 files={{
     'GifFetching.ts': 'filesystem/gifFetching.ts',
     'GifManagement.ts': 'filesystem/gifManagement.ts'


### PR DESCRIPTION
# Why

Fixes the FileSystem Giphy example on Snack.

![image](https://user-images.githubusercontent.com/6184593/103624925-86036900-4f3a-11eb-941c-8c1771d8c880.png)

# How

- Fix casing in path
- Add missing `expo-file-system` dependency

# Test Plan

- Verified locally using `yarn dev` in docs and confirmed it works and without warnings