### PR TITLE
[docs] Indicate mailto and tel linking schemes not supported on iOS Simulators

### DIFF
--- a/docs/pages/workflow/linking.md
+++ b/docs/pages/workflow/linking.md
@@ -29,7 +29,7 @@ As mentioned in the introduction, there are some URL schemes for core functional
 | `sms`            | Open SMS app, eg: `sms:+123456789`           | ✅  | ✅      |
 | `https` / `http` | Open web browser app, eg: `https://expo.io`  | ✅  | ✅      |
 
-> ⚠️ iOS Simulators do not support the `mailto` and `tel` schemes.
+> ⚠️ iOS Simulators do not support the `mailto` and `tel` schemes because they do not include the Phone or Mail applications.
 
 ### Opening links from your app
 

--- a/docs/pages/workflow/linking.md
+++ b/docs/pages/workflow/linking.md
@@ -29,6 +29,8 @@ As mentioned in the introduction, there are some URL schemes for core functional
 | `sms`            | Open SMS app, eg: `sms:+123456789`           | ✅  | ✅      |
 | `https` / `http` | Open web browser app, eg: `https://expo.io`  | ✅  | ✅      |
 
+> ⚠️ iOS Simulators do not support the `mailto` and `tel` schemes.
+
 ### Opening links from your app
 
 There is no anchor tag in React Native, so we can't write `<a href="https://expo.io">`, instead we have to use `Linking.openURL`.


### PR DESCRIPTION
# Why

Mailto and tel schemes will not work on ios simulators since they do not have the Phone and Mail apps available.

# Test Plan

Ran locally and the note rendered as expected.
