### PR TITLE
Added env variable for setting the SDK version for NCL

### DIFF
--- a/apps/native-component-list/app.config.js
+++ b/apps/native-component-list/app.config.js
@@ -1,0 +1,9 @@
+import { string } from 'getenv';
+
+const SDK_VERSION = string('SDK_VERSION', 'UNVERSIONED');
+
+export default ({ config }) => {
+  config.version = SDK_VERSION;
+  config.sdkVersion = SDK_VERSION;
+  return config;
+};

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -115,6 +115,7 @@
     "@types/victory": "^31.0.14",
     "babel-preset-expo": "~8.3.0",
     "expo-module-scripts": "~1.2.0",
-    "expo-yarn-workspaces": "^1.2.1"
+    "expo-yarn-workspaces": "^1.2.1",
+    "getenv": "~1.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8870,7 +8870,7 @@ getenv@0.7.0, getenv@^0.7.0:
   resolved "https://registry.yarnpkg.com/getenv/-/getenv-0.7.0.tgz#39b91838707e2086fd1cf6ef8777d1c93e14649e"
   integrity sha1-ObkYOHB+IIb9HPbvh3fRyT4UZJ4=
 
-getenv@^1.0.0:
+getenv@^1.0.0, getenv@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/getenv/-/getenv-1.0.0.tgz#874f2e7544fbca53c7a4738f37de8605c3fcfc31"
   integrity sha512-7yetJWqbS9sbn0vIfliPsFgoXMKn/YMF+Wuiog97x+urnSRRRZ7xB+uVkwGKzRgq9CDFfMQnE9ruL5DHv9c6Xg==


### PR DESCRIPTION
# Why

Cannot eject a project if it has `UNVERSIONED` SDK version. This PR uses the app.config.js and SDK_VERSION variable to enable the use of `SDK_VERSION=40.0.0 expo eject` in NCL. Moved from my [WIP branch](https://github.com/expo/expo/compare/@evanbacon/ncl/auto-plugins?expand=1)
