### PR TITLE
[eslint-config-universe] Add warning for no-var rule

### DIFF
--- a/packages/eslint-config-universe/CHANGELOG.md
+++ b/packages/eslint-config-universe/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- Warn when `var` is used by enabling the eslint `no-var` rule.
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/packages/eslint-config-universe/shared/core.js
+++ b/packages/eslint-config-universe/shared/core.js
@@ -121,6 +121,7 @@ module.exports = {
     'no-useless-escape': 'warn',
     'no-useless-rename': 'warn',
     'no-useless-return': 'warn',
+    'no-var': 'warn',
     'no-void': 'warn',
     'no-whitespace-before-property': 'warn',
     'no-with': 'warn',


### PR DESCRIPTION
# Why

`let` and `const` are block scoped, which is a bit safer than `var` which is function scoped. There's an endless stream of articles talking about the differences and why `var` should never need to be used any more. 

It looks like we've been doing this pretty consistently anyways naturally (no violations of the rule in this repo), so it's worth adding the enforcement. In our other repos there are violations that should warn though, so this PR updates the core config.

# How

Add enforcement to core eslint config.

# Test Plan

`expotools check-packages`
