### PR TITLE
[in-app-purchases] Handle nil localizedTitle

### DIFF
--- a/packages/expo-in-app-purchases/ios/EXInAppPurchases/EXInAppPurchasesModule.m
+++ b/packages/expo-in-app-purchases/ios/EXInAppPurchases/EXInAppPurchasesModule.m
@@ -324,6 +324,7 @@ UM_EXPORT_METHOD_AS(disconnectAsync,
   NSDecimalNumber *priceAmountMicros = [product.price decimalNumberByMultiplyingBy:oneMillion];
   NSString *price = [NSString stringWithFormat:@"%@%@", product.priceLocale.currencySymbol, product.price];
   NSString *description = product.localizedDescription ?: @"";
+  NSString *title = product.localizedTitle ?: @"";
   
   return @{
            @"description": description,
@@ -332,7 +333,7 @@ UM_EXPORT_METHOD_AS(disconnectAsync,
            @"priceCurrencyCode": product.priceLocale.currencyCode,
            @"productId": product.productIdentifier,
            @"subscriptionPeriod": subscriptionPeriod,
-           @"title": product.localizedTitle,
+           @"title": title,
            @"type": type
            };
 }


### PR DESCRIPTION
# Why

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

as mentioned in #6858 the product.localizedTitle can be nil in some scenarios and app will crash.

Exception:
```
NSInvalidArgumentException
*** -[__NSPlaceholderDictionary initWithObjects:forKeys:count:]: attempt to insert nil object from objects[0]
```

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

Copy the patch from https://github.com/expo/expo/issues/6858#issuecomment-679251209 (just return empty string if nil)

# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->

works fine locally