### PR TITLE
[unimodules] support static config for unimodule linking

### DIFF
--- a/apps/bare-expo/android/app/build.gradle
+++ b/apps/bare-expo/android/app/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: "com.android.application"
-import groovy.json.JsonSlurper
 import com.android.build.OutputFile
 
 /**
@@ -198,18 +197,7 @@ dependencies {
     implementation project(":expo-dev-launcher")
     implementation project(":expo-dev-menu")
 
-    def packageJsonFile = new File(rootProject.projectDir, '../package.json')
-    def packageJson = new JsonSlurper().parseText(packageJsonFile.text)
-    def excludedUnimodules = packageJson.excludedUnimodules != null ? packageJson.excludedUnimodules : []
-
-    addUnimodulesDependencies([
-        modulesPaths : [
-            '../../../../packages'
-        ],
-        configuration: 'api',
-        target       : 'react-native',
-        exclude      : excludedUnimodules
-    ])
+    addUnimodulesDependencies()
 
     if (enableHermes) {
         def hermesPath = "../../node_modules/hermes-engine/android/";

--- a/apps/bare-expo/android/settings.gradle
+++ b/apps/bare-expo/android/settings.gradle
@@ -1,5 +1,3 @@
-import groovy.json.JsonSlurper
-
 apply from: '../node_modules/react-native-unimodules/gradle.groovy'
 
 apply from: file("../node_modules/@react-native-community/cli-platform-android/native_modules.gradle");
@@ -17,38 +15,8 @@ project(":expo-dev-menu-interface").projectDir = new File("../../../packages/exp
 include(":unimodules-test-core")
 project(":unimodules-test-core").projectDir = new File("../../../packages/unimodules-test-core/android")
 
-// Unimodules
-
-// [Custom] load the excluded unimodules from the package.json to ensure 
-// the iOS and Android builds have the same modules.
-def packageJsonFile = new File(rootProject.projectDir, '../package.json')
-def packageJson = new JsonSlurper().parseText(packageJsonFile.text)
-def excludedUnimodules = packageJson.excludedUnimodules != null ? packageJson.excludedUnimodules : []
-
 // Include unimodules.
-includeUnimodulesProjects(
-    modulesPaths : [
-        '../../../../packages',
-    ],
-    configuration: 'api',
-    target       : 'react-native',
-// [Custom] Remove `expo-task-manager` which doesn't work on Android
-// "expo-task-manager",
-// "unimodules-task-manager-interface",
-// "expo-background-fetch",
-// "expo-location",
-// [Custom] Remove branch
-// "expo-branch", 
-// [Custom] Remove the camera
-// "expo-payments-stripe",
-// [Custom] FBSDK adds a lot of time to the pod install 
-// "expo-facebook",
-// "expo-ads-facebook",
-// [Custom] To avoid dealing with this error: 
-// 'GADInvalidInitializationException', reason: 'The Google Mobile Ads SDK was initialized without an application ID. Google AdMob publishers, follow instructions here: https://googlemobileadssdk.page.link/admob-ios-update-plist to set GADApplicationIdentifier with a valid App ID. Google Ad Manager publishers, follow instructions here: https://googlemobileadssdk.page.link/ad-manager-ios-update-plist'
-// "expo-ads-admob",
-     exclude      : excludedUnimodules
-)
+includeUnimodulesProjects()
 
 rootProject.name = 'BareExpo'
 

--- a/apps/bare-expo/ios/Podfile
+++ b/apps/bare-expo/ios/Podfile
@@ -1,14 +1,9 @@
-require 'json'
-
 install! 'cocoapods',
          generate_multiple_pod_projects: true,
          incremental_installation: true
 source 'https://cdn.cocoapods.org/'
 platform :ios, '12.0'
 inhibit_all_warnings!
-
-# Get the package.json for the excluded modules
-package = JSON.parse(File.read(File.join(__dir__, '..', 'package.json')))
 
 # Import the auto-linking packages
 require_relative '../node_modules/react-native/scripts/react_native_pods'
@@ -17,13 +12,8 @@ require_relative '../node_modules/@react-native-community/cli-platform-ios/nativ
 
 abstract_target 'BareExpoMain' do
   # Auto-linking
-  use_unimodules!(
-    {
-      modules_paths: %w[../../../packages], # [Custom] Prevent the bundling of template code and stripe
-      exclude: package['excludedUnimodules'],
-      flags: { inhibit_warnings: false }
-    }
-  )
+  use_unimodules!
+
   config = use_native_modules!
 
   use_react_native!(path: config['reactNativePath'])

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -33,15 +33,37 @@
     "nuke": "rm -rf node_modules; rm -rf ios/Pods/ && rm -rf ios/build/ && rm -rf android/.gradle",
     "sync:tools": "cp -a ../../../react-native/React/DevSupport/ ../../react-native-lab/react-native/React/DevSupport/"
   },
-  "excludedUnimodules": [
-    "expo-branch",
-    "expo-payments-stripe",
-    "expo-ads-facebook",
-    "expo-ads-admob",
-    "expo-apple-authentication",
-    "expo-updates",
-    "expo-module-template"
-  ],
+  "unimodules": {
+    "android": {
+      "modulesPaths" : [
+        "../../../../packages"
+      ],
+      "configuration": "api",
+      "target": "react-native",
+      "exclude": [
+        "expo-branch",
+        "expo-payments-stripe",
+        "expo-ads-facebook",
+        "expo-ads-admob",
+        "expo-apple-authentication",
+        "expo-updates",
+        "expo-module-template"
+      ]
+    },
+    "ios": {
+      "modules_paths": ["../../../packages"],
+      "flags": { "inhibit_warnings": false },
+      "exclude": [
+        "expo-branch",
+        "expo-payments-stripe",
+        "expo-ads-facebook",
+        "expo-ads-admob",
+        "expo-apple-authentication",
+        "expo-updates",
+        "expo-module-template"
+      ]
+    }
+  },
   "detox": {
     "configurations": {
       "ios.sim.debug": {

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -33,7 +33,7 @@
     "nuke": "rm -rf node_modules; rm -rf ios/Pods/ && rm -rf ios/build/ && rm -rf android/.gradle",
     "sync:tools": "cp -a ../../../react-native/React/DevSupport/ ../../react-native-lab/react-native/React/DevSupport/"
   },
-  "unimodules": {
+  "react-native-unimodules": {
     "android": {
       "modulesPaths" : [
         "../../../../packages"

--- a/packages/react-native-unimodules/CHANGELOG.md
+++ b/packages/react-native-unimodules/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Added support for statically configuring linking with `react-native-unimodules` object in the `package.json`. ([#11524](https://github.com/expo/expo/pull/11524) by [@EvanBacon](https://github.com/EvanBacon))
+
 ### 🐛 Bug fixes
 
 ## 0.12.0 — 2020-11-17
@@ -121,4 +123,4 @@
 ### 🎉 New features
 
 - Automatically generated list of Android packages ([#28](https://github.com/unimodules/react-native-unimodules/pull/28))
-As of this version, you no longer need to add new packages to your `MainApplication.java` file. Just use `new BasePackageList().getPackageList()` instead 🎉. `BasePackageList` is auto-generated with a list of installed unimodules found in your `node_modules` folder during Gradle's Sync operation.
+  As of this version, you no longer need to add new packages to your `MainApplication.java` file. Just use `new BasePackageList().getPackageList()` instead 🎉. `BasePackageList` is auto-generated with a list of installed unimodules found in your `node_modules` folder during Gradle's Sync operation.

--- a/packages/react-native-unimodules/README.md
+++ b/packages/react-native-unimodules/README.md
@@ -4,11 +4,11 @@ Learn more about this library and learn how to install it on the [Installing rea
 
 ## Config with package.json
 
-You can configure the iOS and Android linking using the `unimodules` object in the `package.json`:
+You can configure the iOS and Android linking using the `react-native-unimodules` object in the `package.json`:
 
 ```json
 {
-  "unimodules": {
+  "react-native-unimodules": {
     "android": {
       "exclude": [
         // Prevent a module from being included on Android
@@ -21,3 +21,5 @@ You can configure the iOS and Android linking using the `unimodules` object in t
   }
 }
 ```
+
+`package.json` config is an experimental feature used to support monorepo managed workflow EAS build projects that need to reliably generate iOS and Android code from scratch. The `react-native-unimodules` object name is subject to change in the future.

--- a/packages/react-native-unimodules/README.md
+++ b/packages/react-native-unimodules/README.md
@@ -1,3 +1,23 @@
 # react-native-unimodules
 
 Learn more about this library and learn how to install it on the [Installing react-native-unimodules documentation page](https://docs.expo.io/bare/installing-unimodules/).
+
+## Config with package.json
+
+You can configure the iOS and Android linking using the `unimodules` object in the `package.json`:
+
+```json
+{
+  "unimodules": {
+    "android": {
+      "exclude": [
+        // Prevent a module from being included on Android
+        "expo-camera"
+      ]
+    },
+    "ios": {
+      // ...
+    }
+  }
+}
+```

--- a/packages/react-native-unimodules/cocoapods.rb
+++ b/packages/react-native-unimodules/cocoapods.rb
@@ -7,7 +7,7 @@ def use_unimodules!(custom_options = {})
     modules_paths: ['../node_modules'],
     target: 'react-native',
     exclude: [],
-    flags: {},
+    flags: {}
   }.deep_merge(custom_options)
 
   modules_paths = options.fetch(:modules_paths)
@@ -20,11 +20,11 @@ def use_unimodules!(custom_options = {})
 
   project_directory = Pod::Config.instance.project_root
 
-  modules_paths.each { |module_path|
+  modules_paths.each do |module_path|
     canonical_module_path = Pathname.new(File.join(project_directory, module_path)).cleanpath
     glob_pattern = File.join(canonical_module_path, '**/*/**', 'unimodule.json')
 
-    Dir.glob(glob_pattern) { |module_config_path|
+    Dir.glob(glob_pattern) do |module_config_path|
       unimodule_json = JSON.parse(File.read(module_config_path))
       directory = File.dirname(module_config_path)
       platforms = unimodule_json['platforms'] || ['ios']
@@ -35,13 +35,11 @@ def use_unimodules!(custom_options = {})
         package_json = JSON.parse(File.read(package_json_path))
         package_name = unimodule_json['name'] || package_json['name']
 
-        if !modules_to_exclude.include?(package_name)
+        unless modules_to_exclude.include?(package_name)
           unimodule_config = { 'subdirectory' => 'ios' }.merge(unimodule_json.fetch('ios', {}))
           unimodule_version = package_json['version']
 
-          if unimodules[package_name]
-            unimodules_duplicates.push(package_name)
-          end
+          unimodules_duplicates.push(package_name) if unimodules[package_name]
 
           if !unimodules[package_name] || Gem::Version.new(unimodule_version) >= Gem::Version.new(unimodules[package_name][:version])
             unimodules[package_name] = {
@@ -49,18 +47,18 @@ def use_unimodules!(custom_options = {})
               directory: directory,
               version: unimodule_version,
               config: unimodule_config,
-              warned: false,
+              warned: false
             }
           end
         end
       end
-    }
-  }
+    end
+  end
 
   if unimodules.values.length > 0
     puts brown 'Installing unimodules:'
 
-    unimodules.values.sort! { |x,y| x[:name] <=> y[:name] }.each { |unimodule|
+    unimodules.values.sort! { |x, y| x[:name] <=> y[:name] }.each do |unimodule|
       directory = unimodule[:directory]
       config = unimodule[:config]
 
@@ -68,22 +66,22 @@ def use_unimodules!(custom_options = {})
       pod_name = config.fetch('podName', find_pod_name(directory, subdirectory))
       podspec_directory = Pathname.new("#{directory}/#{subdirectory}").relative_path_from(project_directory)
 
-      puts " #{green unimodule[:name]}#{cyan "@"}#{magenta unimodule[:version]} from #{blue podspec_directory}"
+      puts " #{green unimodule[:name]}#{cyan '@'}#{magenta unimodule[:version]} from #{blue podspec_directory}"
 
       pod_options = flags.merge({ path: podspec_directory.to_s })
 
-      pod "#{pod_name}", pod_options
-    }
+      pod pod_name.to_s, pod_options
+    end
 
     if unimodules_duplicates.length > 0
       puts
-      puts brown "Found some duplicated unimodule packages. Installed the ones with the highest version number."
-      puts brown "Make sure following dependencies of your project are resolving to one specific version:"
+      puts brown 'Found some duplicated unimodule packages. Installed the ones with the highest version number.'
+      puts brown 'Make sure following dependencies of your project are resolving to one specific version:'
 
       puts ' ' + unimodules_duplicates
-        .uniq
-        .map { |package_name| green(package_name) }
-        .join(', ')
+                 .uniq
+                 .map { |package_name| green(package_name) }
+                 .join(', ')
     end
   else
     puts
@@ -95,33 +93,33 @@ end
 
 def find_pod_name(package_path, subdirectory)
   podspec_path = Dir.glob(File.join(package_path, subdirectory, '*.podspec')).first
-  return podspec_path && File.basename(podspec_path).chomp('.podspec')
+  podspec_path && File.basename(podspec_path).chomp('.podspec')
 end
 
 def unimodule_supports_platform(platforms, platform)
-  return platforms.class == Array && platforms.include?(platform)
+  platforms.class == Array && platforms.include?(platform)
 end
 
 def unimodule_supports_target(targets, target)
-  return targets.class == Array && targets.include?(target)
+  targets.class == Array && targets.include?(target)
 end
 
 def green(message)
-  return "\e[32m#{message}\e[0m"
+  "\e[32m#{message}\e[0m"
 end
 
 def brown(message)
-  return "\e[33m#{message}\e[0m"
+  "\e[33m#{message}\e[0m"
 end
 
 def blue(message)
-  return "\e[34m#{message}\e[0m"
+  "\e[34m#{message}\e[0m"
 end
 
 def magenta(message)
-  return "\e[35m#{message}\e[0m"
+  "\e[35m#{message}\e[0m"
 end
 
 def cyan(message)
-  return "\e[36m#{message}\e[0m"
+  "\e[36m#{message}\e[0m"
 end

--- a/packages/react-native-unimodules/cocoapods.rb
+++ b/packages/react-native-unimodules/cocoapods.rb
@@ -1,14 +1,18 @@
 require 'json'
 require 'pathname'
+require 'open3'
 require 'optparse'
 
 def use_unimodules!(custom_options = {})
+  root_package_json = JSON.parse(File.read(find_project_package_json_path))
+  json_options = root_package_json.fetch('unimodules', {}).fetch('ios', {}).transform_keys(&:to_sym)
+
   options = {
     modules_paths: ['../node_modules'],
     target: 'react-native',
     exclude: [],
     flags: {}
-  }.deep_merge(custom_options)
+  }.deep_merge(json_options).deep_merge(custom_options)
 
   modules_paths = options.fetch(:modules_paths)
   modules_to_exclude = options.fetch(:exclude)
@@ -89,6 +93,11 @@ def use_unimodules!(custom_options = {})
   end
 
   puts
+end
+
+def find_project_package_json_path
+  stdout, _stderr, _status = Open3.capture3('node -e "const findUp = require(\'find-up\'); console.log(findUp.sync(\'package.json\'));"')
+  stdout.strip!
 end
 
 def find_pod_name(package_path, subdirectory)

--- a/packages/react-native-unimodules/cocoapods.rb
+++ b/packages/react-native-unimodules/cocoapods.rb
@@ -5,7 +5,7 @@ require 'optparse'
 
 def use_unimodules!(custom_options = {})
   root_package_json = JSON.parse(File.read(find_project_package_json_path))
-  json_options = root_package_json.fetch('unimodules', {}).fetch('ios', {}).transform_keys(&:to_sym)
+  json_options = root_package_json.fetch('react-native-unimodules', {}).fetch('ios', {}).transform_keys(&:to_sym)
 
   options = {
     modules_paths: ['../node_modules'],

--- a/packages/react-native-unimodules/gradle.groovy
+++ b/packages/react-native-unimodules/gradle.groovy
@@ -35,11 +35,12 @@ def getProjectPackageJson(File projectRoot) {
   return packageJson;
 }
 
-def getAndroidConfig(File projectRoot) {
-  def packageJson = getProjectPackageJson(projectRoot);
-  def unimodulesConfig = packageJson["react-native-unimodules"] != null ? packageJson["react-native-unimodules"] : {}
-  def androidConfig = unimodulesConfig.android != null ? unimodulesConfig.android : {}
-  return androidConfig
+Map getAndroidConfig(File projectRoot) {
+  def packageJson = getProjectPackageJson(projectRoot)
+  if (packageJson == null || packageJson["react-native-unimodules"] == null || packageJson["react-native-unimodules"].android == null) {
+    return [:]
+  }
+  return packageJson["react-native-unimodules"].android
 }
 
 def spawnProcess(String[] cmd, File directory) {

--- a/packages/react-native-unimodules/gradle.groovy
+++ b/packages/react-native-unimodules/gradle.groovy
@@ -37,7 +37,7 @@ def getProjectPackageJson(File projectRoot) {
 
 def getAndroidConfig(File projectRoot) {
   def packageJson = getProjectPackageJson(projectRoot);
-  def unimodulesConfig = packageJson.unimodules != null ? packageJson.unimodules : {}
+  def unimodulesConfig = packageJson["react-native-unimodules"] != null ? packageJson["react-native-unimodules"] : {}
   def androidConfig = unimodulesConfig.android != null ? unimodulesConfig.android : {}
   return androidConfig
 }

--- a/packages/react-native-unimodules/package.json
+++ b/packages/react-native-unimodules/package.json
@@ -44,6 +44,7 @@
     "expo-file-system": "~9.3.0",
     "expo-image-loader": "~1.3.0",
     "expo-permissions": "~10.0.0",
+    "find-up": "~5.0.0",
     "unimodules-app-loader": "~1.4.0",
     "unimodules-barcode-scanner-interface": "~5.4.0",
     "unimodules-camera-interface": "~5.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8497,6 +8497,14 @@ find-up@^3.0.0:
   dependencies:
     locate-path "^3.0.0"
 
+find-up@~5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
+  integrity sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
+  dependencies:
+    locate-path "^6.0.0"
+    path-exists "^4.0.0"
+
 find-yarn-workspace-root@^2.0.0, find-yarn-workspace-root@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz#f47fb8d239c900eb78179aa81b66673eac88f7bd"
@@ -11922,6 +11930,13 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
+locate-path@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-6.0.0.tgz#55321eb309febbc59c4801d931a72452a681d286"
+  integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
+  dependencies:
+    p-locate "^5.0.0"
+
 lock@^0.1.2:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/lock/-/lock-0.1.4.tgz#fec7deaef17e7c3a0a55e1da042803e25d91745d"
@@ -13859,6 +13874,13 @@ p-locate@^4.1.0:
   integrity sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==
   dependencies:
     p-limit "^2.2.0"
+
+p-locate@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-5.0.0.tgz#83c8315c6785005e3bd021839411c9e110e6d834"
+  integrity sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==
+  dependencies:
+    p-limit "^3.0.2"
 
 p-map@3.0.0:
   version "3.0.0"


### PR DESCRIPTION
# Why

Managed EAS requires ios and android projects which can be fully generated ([POC branch](https://github.com/expo/expo/compare/@evanbacon/ncl/auto-plugins?expand=1)). We could achieve this same effect with a dangerous mod, but bubbling up the static config seemed to make more sense (especially since we already kinda do with `excludedUnimodules`).

# How

Add support for a `react-native-unimodules` (explicitly named after the package) object which has `ios` and `android` objects that get forwarded to the autolinking scripts. The static config takes a lower priority than a manually defined config in the Podfile or gradle files.

# Test Plan

We use autolinking config in bare-expo, so switching to the new system and ensuring the projects build while still excluding packages seems ample.