### PR TITLE
[expo-notifications] notify all listeners of pending notification responses

### DIFF
--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Notify all listeners of pending notification responses. ([#11536](https://github.com/expo/expo/pull/11536) by [@esamelson](https://github.com/esamelson))
+
 ## 0.9.0 — 2021-01-15
 
 ### ⚠️ Notices

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/NotificationManager.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/NotificationManager.java
@@ -49,11 +49,8 @@ public class NotificationManager implements SingletonModule, expo.modules.notifi
       WeakReference<NotificationListener> listenerReference = new WeakReference<>(listener);
       mListenerReferenceMap.put(listener, listenerReference);
       if (!mPendingNotificationResponses.isEmpty()) {
-        Iterator<NotificationResponse> responseIterator = mPendingNotificationResponses.iterator();
-        while (responseIterator.hasNext()) {
-          if (listener.onNotificationResponseReceived(responseIterator.next())) {
-            responseIterator.remove();
-          }
+        for (NotificationResponse pendingResponse : mPendingNotificationResponses) {
+          listener.onNotificationResponseReceived(pendingResponse);
         }
       }
     }


### PR DESCRIPTION
# Why

Surface-level fix for https://github.com/expo/expo/issues/11470 .

Normally, when a notification is pressed to cold boot the app, the way that expo-notifications emits the notification response is by storing it in an `ArrayList`. The first emitter that's added consumes that response.

However, if a background location task is running and the app is killed, when it starts up again there are actually two instances of the JS that start: the normal one attached to the root view, and a headless instance started by the `TaskJobService` that doesn’t render any views. And if synchronous updates are turned on, the headless instance tends to execute first — meaning it adds its own Notifications emitter and swallows the notification response stored in the `ArrayList` before the main JS instance has a chance to.

Since this `addListener` method is only ever called when the JS `NotificationEmitter` and `NotificationHandler` modules are first created, **if we assume that all notification listeners should receive this first event (as is the case for all future events)**, we can fix this easily by reading from rather than consuming the response in the ArrayList, which is what this PR does.

This does create/reveal some other potentially problematic behavior, discussed in more detail in slack, which is why this PR is a draft.

# How

Do not clear pending notification responses after reading them and emitting a corresponding event. This means that all listeners that are added to the `NotificationManager` will receive the pending response, if there is one.

# Test Plan

Used the repo provided in #11470 to minimally reproduce the issue. Built a shell app locally to confirm that this fix solves it.
