### PR TITLE
remove random fastlane meta from default template gitignore

### DIFF
--- a/templates/expo-template-bare-minimum/gitignore
+++ b/templates/expo-template-bare-minimum/gitignore
@@ -42,17 +42,6 @@ buck-out/
 *.keystore
 !debug.keystore
 
-# fastlane
-#
-# It is recommended to not store the screenshots in the git repo. Instead, use fastlane to re-generate the
-# screenshots whenever they are needed.
-# For more information about the recommended setup visit:
-# https://docs.fastlane.tools/best-practices/source-control/
-
-*/fastlane/report.xml
-*/fastlane/Preview.html
-*/fastlane/screenshots
-
 # Bundle artifacts
 *.jsbundle
 

--- a/templates/expo-template-bare-typescript/gitignore
+++ b/templates/expo-template-bare-typescript/gitignore
@@ -42,17 +42,6 @@ buck-out/
 *.keystore
 !debug.keystore
 
-# fastlane
-#
-# It is recommended to not store the screenshots in the git repo. Instead, use fastlane to re-generate the
-# screenshots whenever they are needed.
-# For more information about the recommended setup visit:
-# https://docs.fastlane.tools/best-practices/source-control/
-
-*/fastlane/report.xml
-*/fastlane/Preview.html
-*/fastlane/screenshots
-
 # Bundle artifacts
 *.jsbundle
 


### PR DESCRIPTION
# Why

our gitignore has some long comment on a feature that most users don't even use, it's also an opinionated way to use said feature. Better if users opt themselves in to their tooling.