### PR TITLE
[notifications][ios] fix: custom permissions options are ignored

### DIFF
--- a/docs/pages/versions/unversioned/sdk/notifications.md
+++ b/docs/pages/versions/unversioned/sdk/notifications.md
@@ -681,7 +681,7 @@ export async function allowsNotificationsAsync() {
 
 ### `requestPermissionsAsync(request?: NotificationPermissionsRequest): Promise<NotificationPermissionsStatus>`
 
-Prompts the user for notification permissions according to request. Request defaults to asking the user to allow displaying alerts, setting badge count and playing sounds.
+Prompts the user for notification permissions according to request. **Request defaults to asking the user to allow displaying alerts, setting badge count and playing sounds**.
 
 #### Arguments
 

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### 🐛 Bug fixes
 
+- Fixed a case where `requestPermissionsAsync` would ignore the provided `NotificationPermissionsRequest`. ([#11548](https://github.com/expo/expo/pull/11548) by [@cruzach](https://github.com/cruzach))
 - Fixed migration process to **not** use `expo-constants` installation ID if there is a notifications-specific identifier. ([#11287](https://github.com/expo/expo/pull/11287) by [@sjchmiela](https://github.com/sjchmiela))
 - Native iOS notifications emitter module no longer registers for notification events as soon as module registry is ready which fixes initial notification response not being delivered to JS in standalone (Expo managed workflow) iOS apps. ([#11382](https://github.com/expo/expo/pull/11382) by [@sjchmiela](https://github.com/sjchmiela))
 - Changed the visibility of Android's `InstallationId#getNonBackedUpUuidFile` method so it's easier to override by custom implementations. ([#11249](https://github.com/expo/expo/pull/11249) by [@sjchmiela](https://github.com/sjchmiela))

--- a/packages/expo-notifications/README.md
+++ b/packages/expo-notifications/README.md
@@ -648,7 +648,7 @@ export async function allowsNotificationsAsync() {
 
 ### `requestPermissionsAsync(request?: NotificationPermissionsRequest): Promise<NotificationPermissionsStatus>`
 
-Prompts the user for notification permissions according to request. Request defaults to asking the user to allow displaying alerts, setting badge count and playing sounds.
+Prompts the user for notification permissions according to request. **Request defaults to asking the user to allow displaying alerts, setting badge count and playing sounds**.
 
 #### Arguments
 

--- a/packages/expo-notifications/ios/EXNotifications/Permissions/EXNotificationPermissionsModule.m
+++ b/packages/expo-notifications/ios/EXNotifications/Permissions/EXNotificationPermissionsModule.m
@@ -45,6 +45,7 @@ UM_EXPORT_METHOD_AS(requestPermissionsAsync,
                     requester:(UMPromiseResolveBlock)resolve
                     rejecter:(UMPromiseRejectBlock)reject)
 {
+  [EXUserFacingNotificationsPermissionsRequester setRequestedPermissions:requestedPermissions];
   [UMPermissionsMethodsDelegate askForPermissionWithPermissionsManager:_permissionsManager
                                                          withRequester:[EXUserFacingNotificationsPermissionsRequester class]
                                                                resolve:resolve

--- a/packages/expo-notifications/ios/EXNotifications/Permissions/EXUserFacingNotificationsPermissionsRequester.h
+++ b/packages/expo-notifications/ios/EXNotifications/Permissions/EXUserFacingNotificationsPermissionsRequester.h
@@ -10,4 +10,6 @@
               withResolver:(UMPromiseResolveBlock)resolve
                   rejecter:(UMPromiseRejectBlock)reject;
 
++ (void)setRequestedPermissions:(NSDictionary *)permissions;
+
 @end

--- a/packages/expo-notifications/ios/EXNotifications/Permissions/EXUserFacingNotificationsPermissionsRequester.m
+++ b/packages/expo-notifications/ios/EXNotifications/Permissions/EXUserFacingNotificationsPermissionsRequester.m
@@ -12,6 +12,8 @@
 
 @implementation EXUserFacingNotificationsPermissionsRequester
 
+static NSDictionary *_requestedPermissions;
+
 + (NSString *)permissionType
 {
   return @"userFacingNotifications";
@@ -79,15 +81,14 @@
 
 - (void)requestPermissionsWithResolver:(UMPromiseResolveBlock)resolve rejecter:(UMPromiseRejectBlock)reject
 {
-  static NSDictionary *defaultPermissions;
-  if (!defaultPermissions) {
-    defaultPermissions = @{
-                           @"allowAlert": @(YES),
-                           @"allowBadge": @(YES),
-                           @"allowSound": @(YES)
-                           };
+  if (!_requestedPermissions || [_requestedPermissions count] == 0) {
+    _requestedPermissions = @{
+                              @"allowAlert": @(YES),
+                              @"allowBadge": @(YES),
+                              @"allowSound": @(YES)
+                            };
   }
-  [self requestPermissions:defaultPermissions withResolver:resolve rejecter:reject];
+  [self requestPermissions:_requestedPermissions withResolver:resolve rejecter:reject];
 }
 
 - (void)requestPermissions:(NSDictionary *)permissions withResolver:(UMPromiseResolveBlock)resolve rejecter:(UMPromiseRejectBlock)reject
@@ -193,6 +194,11 @@
     case UNNotificationSettingNotSupported:
       return nil;
   }
+}
+
++ (void)setRequestedPermissions:(NSDictionary *)permissions
+{
+  _requestedPermissions = permissions;
 }
 
 @end


### PR DESCRIPTION
# Why

fixes https://github.com/expo/expo/issues/11414

# How

this corrects a regression introduced in https://github.com/expo/expo/pull/10513 where the user-provided `requestedPermissions` would be ignored, thus the default permissions were _always_ requested.

Since `askForPermissionWithPermissionsManager` requires the requester class itself to be passed, we need to store the data as a static "class" variable 

# Test Plan

Tested locally, proper permissions are passed each time, and default works as expected (when either nothing is passed to `requestPermissionsAsync`, _or_ an empty object is passed). 
