### PR TITLE
[notifications][android] fix: getPermissionsAsync always returns canAskAgain: true

### DIFF
--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### 🐛 Bug fixes
 
+- Fixed case on Android where `getPermissionsAsync` would always return `canAskAgain: true`. ([#11551](https://github.com/expo/expo/pull/11551) by [@cruzach](https://github.com/cruzach))
 - Fixed migration process to **not** use `expo-constants` installation ID if there is a notifications-specific identifier. ([#11287](https://github.com/expo/expo/pull/11287) by [@sjchmiela](https://github.com/sjchmiela))
 - Native iOS notifications emitter module no longer registers for notification events as soon as module registry is ready which fixes initial notification response not being delivered to JS in standalone (Expo managed workflow) iOS apps. ([#11382](https://github.com/expo/expo/pull/11382) by [@sjchmiela](https://github.com/sjchmiela))
 - Changed the visibility of Android's `InstallationId#getNonBackedUpUuidFile` method so it's easier to override by custom implementations. ([#11249](https://github.com/expo/expo/pull/11249) by [@sjchmiela](https://github.com/sjchmiela))

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/permissions/NotificationPermissionsModule.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/permissions/NotificationPermissionsModule.java
@@ -53,7 +53,7 @@ public class NotificationPermissionsModule extends ExportedModule {
     Bundle permissions = new Bundle();
 
     permissions.putString(EXPIRES_KEY, PERMISSION_EXPIRES_NEVER);
-    permissions.putBoolean(CAN_ASK_AGAIN_KEY, true);
+    permissions.putBoolean(CAN_ASK_AGAIN_KEY, areEnabled);
     permissions.putString(STATUS_KEY, status.getStatus());
     permissions.putBoolean(GRANTED_KEY, PermissionsStatus.GRANTED == status);
 

--- a/packages/expo-permissions/android/src/main/java/expo/modules/permissions/requesters/NotificationRequester.kt
+++ b/packages/expo-permissions/android/src/main/java/expo/modules/permissions/requesters/NotificationRequester.kt
@@ -19,7 +19,7 @@ class NotificationRequester(private val context: Context) : PermissionRequester 
       val areEnabled = NotificationManagerCompat.from(context).areNotificationsEnabled()
       putString(STATUS_KEY, if (areEnabled) PermissionsStatus.GRANTED.status else PermissionsStatus.DENIED.status)
       putString(EXPIRES_KEY, PERMISSION_EXPIRES_NEVER)
-      // If notifications aren't enabled, the user needs to activate them in system options. So, we should set `CAN_ASK_AGAIN_KEY` to if this is the case.
+      // If notifications aren't enabled, the user needs to activate them in system options. So, we should set `CAN_ASK_AGAIN_KEY` to false if this is the case.
       // Otherwise, it can be set to true.
       putBoolean(CAN_ASK_AGAIN_KEY, areEnabled)
       putBoolean(GRANTED_KEY, areEnabled)


### PR DESCRIPTION
# Why

closes https://github.com/expo/expo/issues/11481

# How

was previously hardcoded to return true, but as [this comment](https://github.com/expo/expo/compare/@cruzach/notifications/android-canaskagain?expand=1#diff-f5fb29450bd9bdd22c3fdac0f31f02f8f7e1e0f1c800f9617506728ef856b008R22) states, it should be false if the user has disabled notifications in system settings

# Test Plan

Results match the results from `Permissions.askAsync(Permissions.NOTIFICATIONS)`
