### PR TITLE
[expo-image-picker] Fix possible unsafe call in VideoResultTask

### DIFF
--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed possible not safe call in VideoResultTask ([#11552](https://github.com/expo/expo/pull/11552) by [@Duell10111](https://github.com/Duell10111))
+- Fixed possible unsafe call in VideoResultTask. ([#11552](https://github.com/expo/expo/pull/11552) by [@Duell10111](https://github.com/Duell10111))
 
 ## 9.2.1 — 2020-12-09
 

--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed possible not safe call in VideoResultTask ([#11552](https://github.com/expo/expo/pull/11552) by [@Duell10111](https://github.com/Duell10111))
+
 ## 9.2.1 — 2020-12-09
 
 ### 🐛 Bug fixes

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/tasks/VideoResultTask.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/tasks/VideoResultTask.kt
@@ -11,6 +11,7 @@ import org.unimodules.core.Promise
 import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
+import java.lang.NullPointerException
 
 class VideoResultTask(private val promise: Promise,
                       private val uri: Uri,
@@ -27,12 +28,14 @@ class VideoResultTask(private val promise: Promise,
         putString("uri", outputFile.toURI().toString())
         putBoolean("cancelled", false)
         putString("type", "video")
-        putInt("width", mediaMetadataRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_WIDTH).toInt())
-        putInt("height", mediaMetadataRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_HEIGHT).toInt())
-        putInt("rotation", mediaMetadataRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_ROTATION).toInt())
-        putInt("duration", mediaMetadataRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION).toInt())
+        putInt("width", mediaMetadataRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_WIDTH)!!.toInt())
+        putInt("height", mediaMetadataRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_HEIGHT)!!.toInt())
+        putInt("rotation", mediaMetadataRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_ROTATION)!!.toInt())
+        putInt("duration", mediaMetadataRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)!!.toInt())
       }
       promise.resolve(response)
+    } catch (e: NullPointerException) {
+      promise.reject(ImagePickerConstants.ERR_CAN_NOT_EXTRACT_METADATA, ImagePickerConstants.CAN_NOT_EXTRACT_METADATA_MESSAGE, e)
     } catch (e: IllegalArgumentException) {
       promise.reject(ImagePickerConstants.ERR_CAN_NOT_EXTRACT_METADATA, ImagePickerConstants.CAN_NOT_EXTRACT_METADATA_MESSAGE, e)
     } catch (e: SecurityException) {


### PR DESCRIPTION
Fixed non-safe call when compiling to an Android  APK

# Why

Fixed bug on my site which already got mentioned in a issue #11100 

# How

Fixed the Bug with the !! operator and catching the possible NullPointerException

# Test Plan

Building the android apk works now with specific gradle setting mentioned in Issue #11100 
