### PR TITLE
[expo-updates] add unit tests for manifest classes

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -21,6 +21,7 @@
 - On iOS, use default NSURLCache for manifest public key rather than caching it manually.
 - Use `console.warn` message rather than hard crashing if neither runtime nor SDK version are configured (requires a corresponding update to the `expo` package) ([#11367](https://github.com/expo/expo/pull/11367) by [@esamelson](https://github.com/esamelson))
 - Improved thread safety around reaping ([#11447](https://github.com/expo/expo/pull/11447) by [@esamelson](https://github.com/esamelson))
+- Fixed discrepancies across platforms regarding required fields in manifests ([#11562](https://github.com/expo/expo/pull/11562) by [@esamelson](https://github.com/esamelson))
 
 ## 0.4.1 — 2020-11-25
 

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/manifest/LegacyManifestTest.java
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/manifest/LegacyManifestTest.java
@@ -7,10 +7,30 @@ import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import java.util.HashMap;
+
 import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner;
+import expo.modules.updates.UpdatesConfiguration;
 
 @RunWith(AndroidJUnit4ClassRunner.class)
 public class LegacyManifestTest {
+  @Test
+  public void testGetAssetsUrlBase_ExpoDomain() {
+    Uri expected = Uri.parse("https://d1wp6m56sqw74a.cloudfront.net/~assets/");
+    Assert.assertEquals(expected, LegacyManifest.getAssetsUrlBase(Uri.parse("https://exp.host/@test/test"), new JSONObject()));
+    Assert.assertEquals(expected, LegacyManifest.getAssetsUrlBase(Uri.parse("https://expo.io/@test/test"), new JSONObject()));
+    Assert.assertEquals(expected, LegacyManifest.getAssetsUrlBase(Uri.parse("https://expo.test/@test/test"), new JSONObject()));
+  }
+
+  @Test
+  public void testGetAssetsUrlBase_ExpoSubdomain() {
+    Uri expected = Uri.parse("https://d1wp6m56sqw74a.cloudfront.net/~assets/");
+    Assert.assertEquals(expected, LegacyManifest.getAssetsUrlBase(Uri.parse("https://staging.exp.host/@test/test"), new JSONObject()));
+    Assert.assertEquals(expected, LegacyManifest.getAssetsUrlBase(Uri.parse("https://staging.expo.io/@test/test"), new JSONObject()));
+    Assert.assertEquals(expected, LegacyManifest.getAssetsUrlBase(Uri.parse("https://staging.expo.test/@test/test"), new JSONObject()));
+  }
+
   @Test
   public void testGetAssetsUrlBase_assetUrlOverride_absoluteUrl() throws JSONException {
     String assetUrlBase = "https://xxx.dev/~assets";
@@ -39,7 +59,17 @@ public class LegacyManifestTest {
   public void testGetAssetsUrlBase_assetUrlOverride_relativeUrlDotSlash() throws JSONException {
     Uri manifestUrl = Uri.parse("https://esamelson.github.io/self-hosting-test/android-index.json");
     JSONObject manifestJson = new JSONObject();
-    manifestJson.put("assetUrlOverride", "./assets");
+    manifestJson.put("assetUrlOverride", "./my_assets");
+
+    Uri expected = Uri.parse("https://esamelson.github.io/self-hosting-test/my_assets");
+    Uri actual = LegacyManifest.getAssetsUrlBase(manifestUrl, manifestJson);
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void testGetAssetsUrlBase_assetUrlOverride_default() {
+    Uri manifestUrl = Uri.parse("https://esamelson.github.io/self-hosting-test/android-index.json");
+    JSONObject manifestJson = new JSONObject();
 
     Uri expected = Uri.parse("https://esamelson.github.io/self-hosting-test/assets");
     Uri actual = LegacyManifest.getAssetsUrlBase(manifestUrl, manifestJson);
@@ -47,12 +77,52 @@ public class LegacyManifestTest {
   }
 
   @Test
-  public void testGetAssetsUrlBase_assetUrlOverride_default() throws JSONException {
-    Uri manifestUrl = Uri.parse("https://esamelson.github.io/self-hosting-test/android-index.json");
-    JSONObject manifestJson = new JSONObject();
+  public void testFromLegacyManifestJson_Development() throws JSONException {
+    // manifests served from a developer tool should not need the releaseId and commitTime fields
+    String legacyManifestJson = "{\"developer\":{\"tool\":\"expo-cli\"},\"sdkVersion\":\"39.0.0\",\"bundleUrl\":\"https://url.to/bundle.js\"}";
+    JSONObject manifest = new JSONObject(legacyManifestJson);
+    Assert.assertNotNull(LegacyManifest.fromLegacyManifestJson(manifest, createConfig()));
+  }
 
-    Uri expected = Uri.parse("https://esamelson.github.io/self-hosting-test/assets");
-    Uri actual = LegacyManifest.getAssetsUrlBase(manifestUrl, manifestJson);
-    Assert.assertEquals(expected, actual);
+  @Test
+  public void testFromLegacyManifestJson_Production_AllFields() throws JSONException {
+    // production manifests should require the releaseId, commitTime, sdkVersion, and bundleUrl fields
+    String legacyManifestJson = "{\"sdkVersion\":\"39.0.0\",\"releaseId\":\"0eef8214-4833-4089-9dff-b4138a14f196\",\"commitTime\":\"2020-11-11T00:17:54.797Z\",\"bundleUrl\":\"https://url.to/bundle.js\"}";
+    JSONObject manifest = new JSONObject(legacyManifestJson);
+    Assert.assertNotNull(LegacyManifest.fromLegacyManifestJson(manifest, createConfig()));
+  }
+
+  @Test(expected = Exception.class)
+  public void testFromLegacyManifestJson_Production_NoSdkVersion() throws JSONException {
+    String legacyManifestJson = "{\"releaseId\":\"0eef8214-4833-4089-9dff-b4138a14f196\",\"commitTime\":\"2020-11-11T00:17:54.797Z\",\"bundleUrl\":\"https://url.to/bundle.js\"}";
+    JSONObject manifest = new JSONObject(legacyManifestJson);
+    LegacyManifest.fromLegacyManifestJson(manifest, createConfig());
+  }
+
+  @Test(expected = Exception.class)
+  public void testFromLegacyManifestJson_Production_NoReleaseId() throws JSONException {
+    String legacyManifestJson = "{\"sdkVersion\":\"39.0.0\",\"commitTime\":\"2020-11-11T00:17:54.797Z\",\"bundleUrl\":\"https://url.to/bundle.js\"}";
+    JSONObject manifest = new JSONObject(legacyManifestJson);
+    LegacyManifest.fromLegacyManifestJson(manifest, createConfig());
+  }
+
+  @Test(expected = Exception.class)
+  public void testFromLegacyManifestJson_Production_NoCommitTime() throws JSONException {
+    String legacyManifestJson = "{\"sdkVersion\":\"39.0.0\",\"releaseId\":\"0eef8214-4833-4089-9dff-b4138a14f196\",\"bundleUrl\":\"https://url.to/bundle.js\"}";
+    JSONObject manifest = new JSONObject(legacyManifestJson);
+    LegacyManifest.fromLegacyManifestJson(manifest, createConfig());
+  }
+
+  @Test(expected = Exception.class)
+  public void testFromLegacyManifestJson_Production_NoBundleUrl() throws JSONException {
+    String legacyManifestJson = "{\"sdkVersion\":\"39.0.0\",\"releaseId\":\"0eef8214-4833-4089-9dff-b4138a14f196\",\"commitTime\":\"2020-11-11T00:17:54.797Z\"}";
+    JSONObject manifest = new JSONObject(legacyManifestJson);
+    LegacyManifest.fromLegacyManifestJson(manifest, createConfig());
+  }
+
+  private UpdatesConfiguration createConfig() {
+    HashMap<String, Object> configMap = new HashMap<>();
+    configMap.put("updateUrl", Uri.parse("https://exp.host/@test/test"));
+    return new UpdatesConfiguration().loadValuesFromMap(configMap);
   }
 }

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/manifest/ManifestFactoryTest.java
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/manifest/ManifestFactoryTest.java
@@ -17,7 +17,7 @@ import expo.modules.updates.UpdatesConfiguration;
 public class ManifestFactoryTest {
 
   private String legacyManifestJson = "{\"sdkVersion\":\"39.0.0\",\"id\":\"@esamelson/native-component-list\",\"releaseId\":\"0eef8214-4833-4089-9dff-b4138a14f196\",\"commitTime\":\"2020-11-11T00:17:54.797Z\",\"bundleUrl\":\"https://d1wp6m56sqw74a.cloudfront.net/%40esamelson%2Fnative-component-list%2F39.0.0%2F01c86fd863cfee878068eebd40f165df-39.0.0-ios.js\"}";
-  private String newManifestJson = "{\"manifest\":{\"runtimeVersion\":\"1\",\"id\":\"0eef8214-4833-4089-9dff-b4138a14f196\",\"createdAt\":\"2020-11-11T00:17:54.797Z\",\"launchAsset\":{\"url\":\"https://d1wp6m56sqw74a.cloudfront.net/%40esamelson%2Fnative-component-list%2F39.0.0%2F01c86fd863cfee878068eebd40f165df-39.0.0-ios.js\",\"contentType\":\"js\"}}}";
+  private String newManifestJson = "{\"manifest\":{\"runtimeVersion\":\"1\",\"id\":\"0eef8214-4833-4089-9dff-b4138a14f196\",\"createdAt\":\"2020-11-11T00:17:54.797Z\",\"launchAsset\":{\"url\":\"https://d1wp6m56sqw74a.cloudfront.net/%40esamelson%2Fnative-component-list%2F39.0.0%2F01c86fd863cfee878068eebd40f165df-39.0.0-ios.js\",\"contentType\":\"application/javascript\"}}}";
   private String bareManifestJson = "{\"id\":\"0eef8214-4833-4089-9dff-b4138a14f196\",\"commitTime\":1609975977832}";
 
   private UpdatesConfiguration createConfig(boolean usesLegacyManifest) {

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/manifest/ManifestFactoryTest.java
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/manifest/ManifestFactoryTest.java
@@ -1,0 +1,83 @@
+package expo.modules.updates.manifest;
+
+import android.net.Uri;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.HashMap;
+
+import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner;
+import expo.modules.updates.UpdatesConfiguration;
+
+@RunWith(AndroidJUnit4ClassRunner.class)
+public class ManifestFactoryTest {
+
+  private String legacyManifestJson = "{\"sdkVersion\":\"39.0.0\",\"id\":\"@esamelson/native-component-list\",\"releaseId\":\"0eef8214-4833-4089-9dff-b4138a14f196\",\"commitTime\":\"2020-11-11T00:17:54.797Z\",\"bundleUrl\":\"https://d1wp6m56sqw74a.cloudfront.net/%40esamelson%2Fnative-component-list%2F39.0.0%2F01c86fd863cfee878068eebd40f165df-39.0.0-ios.js\"}";
+  private String newManifestJson = "{\"manifest\":{\"runtimeVersion\":\"1\",\"id\":\"0eef8214-4833-4089-9dff-b4138a14f196\",\"createdAt\":\"2020-11-11T00:17:54.797Z\",\"launchAsset\":{\"url\":\"https://d1wp6m56sqw74a.cloudfront.net/%40esamelson%2Fnative-component-list%2F39.0.0%2F01c86fd863cfee878068eebd40f165df-39.0.0-ios.js\",\"contentType\":\"js\"}}}";
+  private String bareManifestJson = "{\"id\":\"0eef8214-4833-4089-9dff-b4138a14f196\",\"commitTime\":1609975977832}";
+
+  private UpdatesConfiguration createConfig(boolean usesLegacyManifest) {
+    HashMap<String, Object> configMap = new HashMap<>();
+    configMap.put("updateUrl", Uri.parse("https://exp.host/@esamelson/native-component-list"));
+    configMap.put("usesLegacyManifest", usesLegacyManifest);
+    return new UpdatesConfiguration().loadValuesFromMap(configMap);
+  }
+
+  @Test
+  public void testGetManifest_Legacy() throws JSONException {
+    Manifest actual = ManifestFactory.getManifest(
+      new JSONObject(legacyManifestJson),
+      createConfig(true)
+    );
+    Assert.assertTrue(actual instanceof LegacyManifest);
+  }
+
+  @Test
+  public void testGetManifest_New() throws JSONException {
+    Manifest actual = ManifestFactory.getManifest(
+      new JSONObject(newManifestJson),
+      createConfig(false)
+    );
+    Assert.assertTrue(actual instanceof NewManifest);
+  }
+
+  @Test
+  public void testGetEmbeddedManifest_Legacy() throws JSONException {
+    Manifest actual = ManifestFactory.getEmbeddedManifest(
+      new JSONObject(legacyManifestJson),
+      createConfig(true)
+    );
+    Assert.assertTrue(actual instanceof LegacyManifest);
+  }
+
+  @Test
+  public void testGetEmbeddedManifest_Legacy_Bare() throws JSONException {
+    Manifest actual = ManifestFactory.getEmbeddedManifest(
+      new JSONObject(bareManifestJson),
+      createConfig(true)
+    );
+    Assert.assertTrue(actual instanceof BareManifest);
+  }
+
+  @Test
+  public void testGetEmbeddedManifest_New() throws JSONException {
+    Manifest actual = ManifestFactory.getEmbeddedManifest(
+      new JSONObject(newManifestJson),
+      createConfig(false)
+    );
+    Assert.assertTrue(actual instanceof NewManifest);
+  }
+
+  @Test
+  public void testGetEmbeddedManifest_New_Bare() throws JSONException {
+    Manifest actual = ManifestFactory.getEmbeddedManifest(
+      new JSONObject(bareManifestJson),
+      createConfig(false)
+    );
+    Assert.assertTrue(actual instanceof BareManifest);
+  }
+}

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/manifest/NewManifestTest.java
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/manifest/NewManifestTest.java
@@ -18,33 +18,33 @@ public class NewManifestTest {
   @Test
   public void testFromManifestJson_AllFields() throws JSONException {
     // production manifests should require the id, createdAt, runtimeVersion, and launchAsset fields
-    String manifestJson = "{\"runtimeVersion\":\"1\",\"id\":\"0eef8214-4833-4089-9dff-b4138a14f196\",\"createdAt\":\"2020-11-11T00:17:54.797Z\",\"launchAsset\":{\"url\":\"https://url.to/bundle.js\",\"contentType\":\"js\"}}";
+    String manifestJson = "{\"runtimeVersion\":\"1\",\"id\":\"0eef8214-4833-4089-9dff-b4138a14f196\",\"createdAt\":\"2020-11-11T00:17:54.797Z\",\"launchAsset\":{\"url\":\"https://url.to/bundle.js\",\"contentType\":\"application/javascript\"}}";
     JSONObject manifest = new JSONObject(manifestJson);
     Assert.assertNotNull(NewManifest.fromManifestJson(manifest, createConfig()));
   }
 
-  @Test(expected = Exception.class)
+  @Test(expected = JSONException.class)
   public void testFromManifestJson_NoId() throws JSONException {
-    String manifestJson = "{\"runtimeVersion\":\"1\",\"createdAt\":\"2020-11-11T00:17:54.797Z\",\"launchAsset\":{\"url\":\"https://url.to/bundle.js\",\"contentType\":\"js\"}}";
+    String manifestJson = "{\"runtimeVersion\":\"1\",\"createdAt\":\"2020-11-11T00:17:54.797Z\",\"launchAsset\":{\"url\":\"https://url.to/bundle.js\",\"contentType\":\"application/javascript\"}}";
     JSONObject manifest = new JSONObject(manifestJson);
     NewManifest.fromManifestJson(manifest, createConfig());
   }
 
-  @Test(expected = Exception.class)
+  @Test(expected = JSONException.class)
   public void testFromManifestJson_NoCreatedAt() throws JSONException {
-    String manifestJson = "{\"runtimeVersion\":\"1\",\"id\":\"0eef8214-4833-4089-9dff-b4138a14f196\",\"launchAsset\":{\"url\":\"https://url.to/bundle.js\",\"contentType\":\"js\"}}";
+    String manifestJson = "{\"runtimeVersion\":\"1\",\"id\":\"0eef8214-4833-4089-9dff-b4138a14f196\",\"launchAsset\":{\"url\":\"https://url.to/bundle.js\",\"contentType\":\"application/javascript\"}}";
     JSONObject manifest = new JSONObject(manifestJson);
     NewManifest.fromManifestJson(manifest, createConfig());
   }
 
-  @Test(expected = Exception.class)
+  @Test(expected = JSONException.class)
   public void testFromManifestJson_NoRuntimeVersion() throws JSONException {
-    String manifestJson = "{\"id\":\"0eef8214-4833-4089-9dff-b4138a14f196\",\"createdAt\":\"2020-11-11T00:17:54.797Z\",\"launchAsset\":{\"url\":\"https://url.to/bundle.js\",\"contentType\":\"js\"}}";
+    String manifestJson = "{\"id\":\"0eef8214-4833-4089-9dff-b4138a14f196\",\"createdAt\":\"2020-11-11T00:17:54.797Z\",\"launchAsset\":{\"url\":\"https://url.to/bundle.js\",\"contentType\":\"application/javascript\"}}";
     JSONObject manifest = new JSONObject(manifestJson);
     NewManifest.fromManifestJson(manifest, createConfig());
   }
 
-  @Test(expected = Exception.class)
+  @Test(expected = JSONException.class)
   public void testFromManifestJson_NoLaunchAsset() throws JSONException {
     String manifestJson = "{\"runtimeVersion\":\"1\",\"id\":\"0eef8214-4833-4089-9dff-b4138a14f196\",\"createdAt\":\"2020-11-11T00:17:54.797Z\",}";
     JSONObject manifest = new JSONObject(manifestJson);
@@ -53,10 +53,10 @@ public class NewManifestTest {
 
   @Test
   public void testFromManifestJson_StripsOptionalRootLevelKeys() throws JSONException {
-    String manifestJsonWithRootLevelKeys = "{\"data\":{\"publicManifest\":{\"manifest\":{\"runtimeVersion\":\"1\",\"id\":\"0eef8214-4833-4089-9dff-b4138a14f196\",\"createdAt\":\"2020-11-11T00:17:54.797Z\",\"launchAsset\":{\"url\":\"https://url.to/bundle.js\",\"contentType\":\"js\"}}}}}";
+    String manifestJsonWithRootLevelKeys = "{\"data\":{\"publicManifest\":{\"manifest\":{\"runtimeVersion\":\"1\",\"id\":\"0eef8214-4833-4089-9dff-b4138a14f196\",\"createdAt\":\"2020-11-11T00:17:54.797Z\",\"launchAsset\":{\"url\":\"https://url.to/bundle.js\",\"contentType\":\"application/javascript\"}}}}}";
     Manifest manifest1 = NewManifest.fromManifestJson(new JSONObject(manifestJsonWithRootLevelKeys), createConfig());
 
-    String manifestJsonNoRootLevelKeys = "{\"runtimeVersion\":\"1\",\"id\":\"0eef8214-4833-4089-9dff-b4138a14f196\",\"createdAt\":\"2020-11-11T00:17:54.797Z\",\"launchAsset\":{\"url\":\"https://url.to/bundle.js\",\"contentType\":\"js\"}}";
+    String manifestJsonNoRootLevelKeys = "{\"runtimeVersion\":\"1\",\"id\":\"0eef8214-4833-4089-9dff-b4138a14f196\",\"createdAt\":\"2020-11-11T00:17:54.797Z\",\"launchAsset\":{\"url\":\"https://url.to/bundle.js\",\"contentType\":\"application/javascript\"}}";
     Manifest manifest2 = NewManifest.fromManifestJson(new JSONObject(manifestJsonNoRootLevelKeys), createConfig());
 
     Assert.assertEquals(manifest1.getRawManifestJson().getString("id"), manifest2.getRawManifestJson().getString("id"));

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/manifest/NewManifestTest.java
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/manifest/NewManifestTest.java
@@ -1,0 +1,70 @@
+package expo.modules.updates.manifest;
+
+import android.net.Uri;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.HashMap;
+
+import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner;
+import expo.modules.updates.UpdatesConfiguration;
+
+@RunWith(AndroidJUnit4ClassRunner.class)
+public class NewManifestTest {
+  @Test
+  public void testFromManifestJson_AllFields() throws JSONException {
+    // production manifests should require the id, createdAt, runtimeVersion, and launchAsset fields
+    String manifestJson = "{\"runtimeVersion\":\"1\",\"id\":\"0eef8214-4833-4089-9dff-b4138a14f196\",\"createdAt\":\"2020-11-11T00:17:54.797Z\",\"launchAsset\":{\"url\":\"https://url.to/bundle.js\",\"contentType\":\"js\"}}";
+    JSONObject manifest = new JSONObject(manifestJson);
+    Assert.assertNotNull(NewManifest.fromManifestJson(manifest, createConfig()));
+  }
+
+  @Test(expected = Exception.class)
+  public void testFromManifestJson_NoId() throws JSONException {
+    String manifestJson = "{\"runtimeVersion\":\"1\",\"createdAt\":\"2020-11-11T00:17:54.797Z\",\"launchAsset\":{\"url\":\"https://url.to/bundle.js\",\"contentType\":\"js\"}}";
+    JSONObject manifest = new JSONObject(manifestJson);
+    NewManifest.fromManifestJson(manifest, createConfig());
+  }
+
+  @Test(expected = Exception.class)
+  public void testFromManifestJson_NoCreatedAt() throws JSONException {
+    String manifestJson = "{\"runtimeVersion\":\"1\",\"id\":\"0eef8214-4833-4089-9dff-b4138a14f196\",\"launchAsset\":{\"url\":\"https://url.to/bundle.js\",\"contentType\":\"js\"}}";
+    JSONObject manifest = new JSONObject(manifestJson);
+    NewManifest.fromManifestJson(manifest, createConfig());
+  }
+
+  @Test(expected = Exception.class)
+  public void testFromManifestJson_NoRuntimeVersion() throws JSONException {
+    String manifestJson = "{\"id\":\"0eef8214-4833-4089-9dff-b4138a14f196\",\"createdAt\":\"2020-11-11T00:17:54.797Z\",\"launchAsset\":{\"url\":\"https://url.to/bundle.js\",\"contentType\":\"js\"}}";
+    JSONObject manifest = new JSONObject(manifestJson);
+    NewManifest.fromManifestJson(manifest, createConfig());
+  }
+
+  @Test(expected = Exception.class)
+  public void testFromManifestJson_NoLaunchAsset() throws JSONException {
+    String manifestJson = "{\"runtimeVersion\":\"1\",\"id\":\"0eef8214-4833-4089-9dff-b4138a14f196\",\"createdAt\":\"2020-11-11T00:17:54.797Z\",}";
+    JSONObject manifest = new JSONObject(manifestJson);
+    NewManifest.fromManifestJson(manifest, createConfig());
+  }
+
+  @Test
+  public void testFromManifestJson_StripsOptionalRootLevelKeys() throws JSONException {
+    String manifestJsonWithRootLevelKeys = "{\"data\":{\"publicManifest\":{\"manifest\":{\"runtimeVersion\":\"1\",\"id\":\"0eef8214-4833-4089-9dff-b4138a14f196\",\"createdAt\":\"2020-11-11T00:17:54.797Z\",\"launchAsset\":{\"url\":\"https://url.to/bundle.js\",\"contentType\":\"js\"}}}}}";
+    Manifest manifest1 = NewManifest.fromManifestJson(new JSONObject(manifestJsonWithRootLevelKeys), createConfig());
+
+    String manifestJsonNoRootLevelKeys = "{\"runtimeVersion\":\"1\",\"id\":\"0eef8214-4833-4089-9dff-b4138a14f196\",\"createdAt\":\"2020-11-11T00:17:54.797Z\",\"launchAsset\":{\"url\":\"https://url.to/bundle.js\",\"contentType\":\"js\"}}";
+    Manifest manifest2 = NewManifest.fromManifestJson(new JSONObject(manifestJsonNoRootLevelKeys), createConfig());
+
+    Assert.assertEquals(manifest1.getRawManifestJson().getString("id"), manifest2.getRawManifestJson().getString("id"));
+  }
+
+  private UpdatesConfiguration createConfig() {
+    HashMap<String, Object> configMap = new HashMap<>();
+    configMap.put("updateUrl", Uri.parse("https://exp.host/@test/test"));
+    return new UpdatesConfiguration().loadValuesFromMap(configMap);
+  }
+}

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/NewManifest.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/NewManifest.java
@@ -12,6 +12,7 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.UUID;
@@ -67,7 +68,7 @@ public class NewManifest implements Manifest {
     Date commitTime;
     try {
       commitTime = UpdatesUtils.parseDateString(manifestJson.getString("createdAt"));
-    } catch (Exception e) {
+    } catch (ParseException e) {
       Log.e(TAG, "Could not parse manifest createdAt string; falling back to current time", e);
       commitTime = new Date();
     }

--- a/packages/expo-updates/android/src/test/java/expo/modules/updates/UpdatesUtilsTest.java
+++ b/packages/expo-updates/android/src/test/java/expo/modules/updates/UpdatesUtilsTest.java
@@ -40,7 +40,6 @@ public class UpdatesUtilsTest {
 
   @Test
   public void testGetRuntimeVersion_neitherDefined() {
-    // should throw if neither are specified
     UpdatesConfiguration neitherConfig = mock(UpdatesConfiguration.class);
     when(neitherConfig.getSdkVersion()).thenReturn(null);
     when(neitherConfig.getRuntimeVersion()).thenReturn(null);

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesBareUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesBareUpdate.m
@@ -38,25 +38,27 @@ NS_ASSUME_NONNULL_BEGIN
   jsBundleAsset.mainBundleFilename = EXUpdatesBareEmbeddedBundleFilename;
   [processedAssets addObject:jsBundleAsset];
 
-  for (NSDictionary *assetDict in (NSArray *)assets) {
-    NSAssert([assetDict isKindOfClass:[NSDictionary class]], @"assets must be objects");
-    id packagerHash = assetDict[@"packagerHash"];
-    id type = assetDict[@"type"];
-    id mainBundleDir = assetDict[@"nsBundleDir"];
-    id mainBundleFilename = assetDict[@"nsBundleFilename"];
-    NSAssert(packagerHash && [packagerHash isKindOfClass:[NSString class]], @"asset key should be a nonnull string");
-    NSAssert(type && [type isKindOfClass:[NSString class]], @"asset type should be a nonnull string");
-    NSAssert(mainBundleFilename && [mainBundleFilename isKindOfClass:[NSString class]], @"asset nsBundleFilename should be a nonnull string");
-    if (mainBundleDir) {
-      NSAssert([mainBundleDir isKindOfClass:[NSString class]], @"asset nsBundleDir should be a string");
+  if (assets) {
+    for (NSDictionary *assetDict in (NSArray *)assets) {
+      NSAssert([assetDict isKindOfClass:[NSDictionary class]], @"assets must be objects");
+      id packagerHash = assetDict[@"packagerHash"];
+      id type = assetDict[@"type"];
+      id mainBundleDir = assetDict[@"nsBundleDir"];
+      id mainBundleFilename = assetDict[@"nsBundleFilename"];
+      NSAssert(packagerHash && [packagerHash isKindOfClass:[NSString class]], @"asset key should be a nonnull string");
+      NSAssert(type && [type isKindOfClass:[NSString class]], @"asset type should be a nonnull string");
+      NSAssert(mainBundleFilename && [mainBundleFilename isKindOfClass:[NSString class]], @"asset nsBundleFilename should be a nonnull string");
+      if (mainBundleDir) {
+        NSAssert([mainBundleDir isKindOfClass:[NSString class]], @"asset nsBundleDir should be a string");
+      }
+
+      NSString *key = [NSString stringWithFormat:@"%@.%@", packagerHash, type];
+      EXUpdatesAsset *asset = [[EXUpdatesAsset alloc] initWithKey:key type:(NSString *)type];
+      asset.mainBundleDir = mainBundleDir;
+      asset.mainBundleFilename = mainBundleFilename;
+
+      [processedAssets addObject:asset];
     }
-
-    NSString *key = [NSString stringWithFormat:@"%@.%@", packagerHash, type];
-    EXUpdatesAsset *asset = [[EXUpdatesAsset alloc] initWithKey:key type:(NSString *)type];
-    asset.mainBundleDir = mainBundleDir;
-    asset.mainBundleFilename = mainBundleFilename;
-
-    [processedAssets addObject:asset];
   }
 
   update.updateId = uuid;

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesBareUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesBareUpdate.m
@@ -25,7 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
   NSAssert([updateId isKindOfClass:[NSString class]], @"update ID should be a string");
   NSAssert([commitTime isKindOfClass:[NSNumber class]], @"commitTime should be a number");
   NSAssert(!metadata || [metadata isKindOfClass:[NSDictionary class]], @"metadata should be null or an object");
-  NSAssert(assets && [assets isKindOfClass:[NSArray class]], @"assets should be a nonnull array");
+  NSAssert(!assets || [assets isKindOfClass:[NSArray class]], @"assets should be null or an array");
 
   NSUUID *uuid = [[NSUUID alloc] initWithUUIDString:(NSString *)updateId];
   NSAssert(uuid, @"update ID should be a valid UUID");

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesNewUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesNewUpdate.m
@@ -39,7 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
   NSAssert([commitTime isKindOfClass:[NSString class]], @"createdAt should be a string");
   NSAssert([runtimeVersion isKindOfClass:[NSString class]], @"runtimeVersion should be a string");
   NSAssert([launchAsset isKindOfClass:[NSDictionary class]], @"launchAsset should be a dictionary");
-  NSAssert(assets && [assets isKindOfClass:[NSArray class]], @"assets should be a nonnull array");
+  NSAssert(!assets || [assets isKindOfClass:[NSArray class]], @"assets should be null or an array");
 
   NSUUID *uuid = [[NSUUID alloc] initWithUUIDString:(NSString *)updateId];
   NSAssert(uuid, @"update ID should be a valid UUID");

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesNewUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesNewUpdate.m
@@ -58,33 +58,35 @@ NS_ASSUME_NONNULL_BEGIN
   jsBundleAsset.mainBundleFilename = EXUpdatesEmbeddedBundleFilename;
   [processedAssets addObject:jsBundleAsset];
 
-  for (NSDictionary *assetDict in (NSArray *)assets) {
-    NSAssert([assetDict isKindOfClass:[NSDictionary class]], @"assets must be objects");
-    id key = assetDict[@"key"];
-    id urlString = assetDict[@"url"];
-    id type = assetDict[@"contentType"];
-    id metadata = assetDict[@"metadata"];
-    id mainBundleFilename = assetDict[@"mainBundleFilename"];
-    NSAssert(key && [key isKindOfClass:[NSString class]], @"asset key should be a nonnull string");
-    NSAssert(urlString && [urlString isKindOfClass:[NSString class]], @"asset url should be a nonnull string");
-    NSAssert(type && [type isKindOfClass:[NSString class]], @"asset contentType should be a nonnull string");
-    NSURL *url = [NSURL URLWithString:(NSString *)urlString];
-    NSAssert(url, @"asset url should be a valid URL");
+  if (assets) {
+    for (NSDictionary *assetDict in (NSArray *)assets) {
+      NSAssert([assetDict isKindOfClass:[NSDictionary class]], @"assets must be objects");
+      id key = assetDict[@"key"];
+      id urlString = assetDict[@"url"];
+      id type = assetDict[@"contentType"];
+      id metadata = assetDict[@"metadata"];
+      id mainBundleFilename = assetDict[@"mainBundleFilename"];
+      NSAssert(key && [key isKindOfClass:[NSString class]], @"asset key should be a nonnull string");
+      NSAssert(urlString && [urlString isKindOfClass:[NSString class]], @"asset url should be a nonnull string");
+      NSAssert(type && [type isKindOfClass:[NSString class]], @"asset contentType should be a nonnull string");
+      NSURL *url = [NSURL URLWithString:(NSString *)urlString];
+      NSAssert(url, @"asset url should be a valid URL");
 
-    EXUpdatesAsset *asset = [[EXUpdatesAsset alloc] initWithKey:key type:(NSString *)type];
-    asset.url = url;
+      EXUpdatesAsset *asset = [[EXUpdatesAsset alloc] initWithKey:key type:(NSString *)type];
+      asset.url = url;
 
-    if (metadata) {
-      NSAssert([metadata isKindOfClass:[NSDictionary class]], @"asset metadata should be an object");
-      asset.metadata = (NSDictionary *)metadata;
+      if (metadata) {
+        NSAssert([metadata isKindOfClass:[NSDictionary class]], @"asset metadata should be an object");
+        asset.metadata = (NSDictionary *)metadata;
+      }
+
+      if (mainBundleFilename) {
+        NSAssert([mainBundleFilename isKindOfClass:[NSString class]], @"asset localPath should be a string");
+        asset.mainBundleFilename = (NSString *)mainBundleFilename;
+      }
+
+      [processedAssets addObject:asset];
     }
-
-    if (mainBundleFilename) {
-      NSAssert([mainBundleFilename isKindOfClass:[NSString class]], @"asset localPath should be a string");
-      asset.mainBundleFilename = (NSString *)mainBundleFilename;
-    }
-
-    [processedAssets addObject:asset];
   }
 
   update.updateId = uuid;

--- a/packages/expo-updates/ios/Tests/EXUpdatesLegacyUpdateTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesLegacyUpdateTests.m
@@ -1,0 +1,136 @@
+//  Copyright (c) 2020 650 Industries, Inc. All rights reserved.
+
+#import <XCTest/XCTest.h>
+
+#import <EXUpdates/EXUpdatesConfig.h>
+#import <EXUpdates/EXUpdatesDatabase.h>
+#import <EXUpdates/EXUpdatesLegacyUpdate.h>
+#import <EXUpdates/EXUpdatesUpdate.h>
+
+@interface EXUpdatesLegacyUpdateTests : XCTestCase
+
+@property (nonatomic, strong) EXUpdatesConfig *config;
+@property (nonatomic, strong) EXUpdatesDatabase *database;
+
+@end
+
+@implementation EXUpdatesLegacyUpdateTests
+
+- (void)setUp
+{
+  _config = [EXUpdatesConfig configWithDictionary:@{
+    @"EXUpdatesURL": @"https://exp.host/@test/test",
+    @"EXUpdatesUsesLegacyManifest": @(YES)
+  }];
+
+  _database = [EXUpdatesDatabase new];
+}
+
+- (void)tearDown
+{
+  [super tearDown];
+}
+
+- (void)testBundledAssetBaseUrl_ExpoDomain
+{
+  NSURL *expected = [NSURL URLWithString:@"https://d1wp6m56sqw74a.cloudfront.net/~assets/"];
+  XCTAssert([expected isEqual:[EXUpdatesLegacyUpdate bundledAssetBaseUrlWithManifest:@{} config:[EXUpdatesConfig configWithDictionary:@{@"EXUpdatesURL": @"https://exp.host/@test/test"}]]]);
+  XCTAssert([expected isEqual:[EXUpdatesLegacyUpdate bundledAssetBaseUrlWithManifest:@{} config:[EXUpdatesConfig configWithDictionary:@{@"EXUpdatesURL": @"https://expo.io/@test/test"}]]]);
+  XCTAssert([expected isEqual:[EXUpdatesLegacyUpdate bundledAssetBaseUrlWithManifest:@{} config:[EXUpdatesConfig configWithDictionary:@{@"EXUpdatesURL": @"https://expo.test/@test/test"}]]]);
+}
+
+- (void)testBundledAssetBaseUrl_ExpoSubdomain
+{
+  NSURL *expected = [NSURL URLWithString:@"https://d1wp6m56sqw74a.cloudfront.net/~assets/"];
+  XCTAssert([expected isEqual:[EXUpdatesLegacyUpdate bundledAssetBaseUrlWithManifest:@{} config:[EXUpdatesConfig configWithDictionary:@{@"EXUpdatesURL": @"https://staging.exp.host/@test/test"}]]]);
+  XCTAssert([expected isEqual:[EXUpdatesLegacyUpdate bundledAssetBaseUrlWithManifest:@{} config:[EXUpdatesConfig configWithDictionary:@{@"EXUpdatesURL": @"https://staging.expo.io/@test/test"}]]]);
+  XCTAssert([expected isEqual:[EXUpdatesLegacyUpdate bundledAssetBaseUrlWithManifest:@{} config:[EXUpdatesConfig configWithDictionary:@{@"EXUpdatesURL": @"https://staging.expo.test/@test/test"}]]]);
+}
+
+- (void)testBundledAssetBaseUrl_AssetUrlOverride
+{
+  EXUpdatesConfig *config = [[EXUpdatesConfig alloc] init];
+  [config loadConfigFromDictionary:@{ @"EXUpdatesURL": @"https://esamelson.github.io/self-hosting-test/ios-index.json", @"EXUpdatesSDKVersion": @"38.0.0" }];
+
+  NSString *absoluteUrlString = @"https://xxx.dev/~assets";
+  NSURL *absoluteExpected = [NSURL URLWithString:absoluteUrlString];
+  NSURL *absoluteActual = [EXUpdatesLegacyUpdate bundledAssetBaseUrlWithManifest:@{ @"assetUrlOverride": absoluteUrlString } config:config];
+  XCTAssert([absoluteActual isEqual:absoluteExpected], @"should return the value of assetUrlOverride if it's an absolute URL");
+
+  NSURL *relativeExpected = [NSURL URLWithString:@"https://esamelson.github.io/self-hosting-test/my_assets"];
+  NSURL *relativeActual = [EXUpdatesLegacyUpdate bundledAssetBaseUrlWithManifest:@{ @"assetUrlOverride": @"my_assets" } config:config];
+  XCTAssert([relativeActual isEqual:relativeExpected], @"should return a URL relative to manifest URL base if it's a relative URL");
+
+  NSURL *relativeDotSlashExpected = [NSURL URLWithString:@"https://esamelson.github.io/self-hosting-test/my_assets"];
+  NSURL *relativeDotSlashActual = [EXUpdatesLegacyUpdate bundledAssetBaseUrlWithManifest:@{ @"assetUrlOverride": @"./my_assets" } config:config];
+  XCTAssert([relativeDotSlashActual isEqual:relativeDotSlashExpected], @"should return a URL relative to manifest URL base with `./` resolved correctly if it's a relative URL");
+
+  NSURL *defaultExpected = [NSURL URLWithString:@"https://esamelson.github.io/self-hosting-test/assets"];
+  NSURL *defaultActual = [EXUpdatesLegacyUpdate bundledAssetBaseUrlWithManifest:@{} config:config];
+  XCTAssert([defaultActual isEqual:defaultExpected], @"should return a URL with `assets` relative to manifest URL base if unspecified");
+}
+
+- (void)testUpdateWithLegacyManifest_Development
+{
+  // manifests served from a developer tool should not need the releaseId and commitTime fields
+  NSDictionary *manifest = @{
+    @"sdkVersion": @"39.0.0",
+    @"bundleUrl": @"https://url.to/bundle.js",
+    @"developer": @{@"tool": @"expo-cli"}
+  };
+  XCTAssert([EXUpdatesLegacyUpdate updateWithLegacyManifest:manifest config:_config database:_database] != nil);
+}
+
+- (void)testUpdateWithLegacyManifest_Production_AllFields
+{
+  // production manifests should require the releaseId, commitTime, sdkVersion, and bundleUrl fields
+  NSDictionary *manifest = @{
+    @"sdkVersion": @"39.0.0",
+    @"releaseId": @"0eef8214-4833-4089-9dff-b4138a14f196",
+    @"commitTime": @"2020-11-11T00:17:54.797Z",
+    @"bundleUrl": @"https://url.to/bundle.js"
+  };
+  XCTAssert([EXUpdatesLegacyUpdate updateWithLegacyManifest:manifest config:_config database:_database] != nil);
+}
+
+- (void)testUpdateWithLegacyManifest_Production_NoSdkVersion
+{
+  NSDictionary *manifest = @{
+    @"releaseId": @"0eef8214-4833-4089-9dff-b4138a14f196",
+    @"commitTime": @"2020-11-11T00:17:54.797Z",
+    @"bundleUrl": @"https://url.to/bundle.js"
+  };
+  XCTAssertThrows([EXUpdatesLegacyUpdate updateWithLegacyManifest:manifest config:_config database:_database]);
+}
+
+- (void)testUpdateWithLegacyManifest_Production_NoReleaseId
+{
+  NSDictionary *manifest = @{
+    @"sdkVersion": @"39.0.0",
+    @"commitTime": @"2020-11-11T00:17:54.797Z",
+    @"bundleUrl": @"https://url.to/bundle.js"
+  };
+  XCTAssertThrows([EXUpdatesLegacyUpdate updateWithLegacyManifest:manifest config:_config database:_database]);
+}
+
+- (void)testUpdateWithLegacyManifest_Production_NoCommitTime
+{
+  NSDictionary *manifest = @{
+    @"sdkVersion": @"39.0.0",
+    @"releaseId": @"0eef8214-4833-4089-9dff-b4138a14f196",
+    @"bundleUrl": @"https://url.to/bundle.js"
+  };
+  XCTAssertThrows([EXUpdatesLegacyUpdate updateWithLegacyManifest:manifest config:_config database:_database]);
+}
+
+- (void)testUpdateWithLegacyManifest_Production_NoBundleUrl
+{
+  NSDictionary *manifest = @{
+    @"sdkVersion": @"39.0.0",
+    @"releaseId": @"0eef8214-4833-4089-9dff-b4138a14f196",
+    @"commitTime": @"2020-11-11T00:17:54.797Z"
+  };
+  XCTAssertThrows([EXUpdatesLegacyUpdate updateWithLegacyManifest:manifest config:_config database:_database]);
+}
+
+@end

--- a/packages/expo-updates/ios/Tests/EXUpdatesNewUpdateTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesNewUpdateTests.m
@@ -38,7 +38,7 @@
     @"runtimeVersion": @"1",
     @"id": @"0eef8214-4833-4089-9dff-b4138a14f196",
     @"createdAt": @"2020-11-11T00:17:54.797Z",
-    @"launchAsset": @{@"url": @"https://url.to/bundle.js", @"contentType": @"js"}
+    @"launchAsset": @{@"url": @"https://url.to/bundle.js", @"contentType": @"application/javascript"}
   };
   XCTAssert([EXUpdatesNewUpdate updateWithNewManifest:manifest config:_config database:_database] != nil);
 }
@@ -48,7 +48,7 @@
   NSDictionary *manifest = @{
     @"id": @"0eef8214-4833-4089-9dff-b4138a14f196",
     @"createdAt": @"2020-11-11T00:17:54.797Z",
-    @"launchAsset": @{@"url": @"https://url.to/bundle.js", @"contentType": @"js"}
+    @"launchAsset": @{@"url": @"https://url.to/bundle.js", @"contentType": @"application/javascript"}
   };
   XCTAssertThrows([EXUpdatesNewUpdate updateWithNewManifest:manifest config:_config database:_database]);
 }
@@ -58,7 +58,7 @@
   NSDictionary *manifest = @{
     @"runtimeVersion": @"1",
     @"createdAt": @"2020-11-11T00:17:54.797Z",
-    @"launchAsset": @{@"url": @"https://url.to/bundle.js", @"contentType": @"js"}
+    @"launchAsset": @{@"url": @"https://url.to/bundle.js", @"contentType": @"application/javascript"}
   };
   XCTAssertThrows([EXUpdatesNewUpdate updateWithNewManifest:manifest config:_config database:_database]);
 }
@@ -68,7 +68,7 @@
   NSDictionary *manifest = @{
     @"runtimeVersion": @"1",
     @"id": @"0eef8214-4833-4089-9dff-b4138a14f196",
-    @"launchAsset": @{@"url": @"https://url.to/bundle.js", @"contentType": @"js"}
+    @"launchAsset": @{@"url": @"https://url.to/bundle.js", @"contentType": @"application/javascript"}
   };
   XCTAssertThrows([EXUpdatesNewUpdate updateWithNewManifest:manifest config:_config database:_database]);
 }
@@ -89,7 +89,7 @@
     @"runtimeVersion": @"1",
     @"id": @"0eef8214-4833-4089-9dff-b4138a14f196",
     @"createdAt": @"2020-11-11T00:17:54.797Z",
-    @"launchAsset": @{@"url": @"https://url.to/bundle.js", @"contentType": @"js"}
+    @"launchAsset": @{@"url": @"https://url.to/bundle.js", @"contentType": @"application/javascript"}
   };
   NSDictionary *manifestWithRootLevelKeys = @{
     @"data": @{

--- a/packages/expo-updates/ios/Tests/EXUpdatesNewUpdateTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesNewUpdateTests.m
@@ -1,0 +1,108 @@
+//  Copyright (c) 2020 650 Industries, Inc. All rights reserved.
+
+#import <XCTest/XCTest.h>
+
+#import <EXUpdates/EXUpdatesConfig.h>
+#import <EXUpdates/EXUpdatesDatabase.h>
+#import <EXUpdates/EXUpdatesNewUpdate.h>
+#import <EXUpdates/EXUpdatesUpdate.h>
+
+@interface EXUpdatesNewUpdateTests : XCTestCase
+
+@property (nonatomic, strong) EXUpdatesConfig *config;
+@property (nonatomic, strong) EXUpdatesDatabase *database;
+
+@end
+
+@implementation EXUpdatesNewUpdateTests
+
+- (void)setUp
+{
+  _config = [EXUpdatesConfig configWithDictionary:@{
+    @"EXUpdatesURL": @"https://exp.host/@test/test",
+    @"EXUpdatesUsesLegacyManifest": @(YES)
+  }];
+
+  _database = [EXUpdatesDatabase new];
+}
+
+- (void)tearDown
+{
+  [super tearDown];
+}
+
+- (void)testUpdateWithNewManifest_AllFields
+{
+  // production manifests should require the id, createdAt, runtimeVersion, and launchAsset fields
+  NSDictionary *manifest = @{
+    @"runtimeVersion": @"1",
+    @"id": @"0eef8214-4833-4089-9dff-b4138a14f196",
+    @"createdAt": @"2020-11-11T00:17:54.797Z",
+    @"launchAsset": @{@"url": @"https://url.to/bundle.js", @"contentType": @"js"}
+  };
+  XCTAssert([EXUpdatesNewUpdate updateWithNewManifest:manifest config:_config database:_database] != nil);
+}
+
+- (void)testUpdateWithNewManifest_NoRuntimeVersion
+{
+  NSDictionary *manifest = @{
+    @"id": @"0eef8214-4833-4089-9dff-b4138a14f196",
+    @"createdAt": @"2020-11-11T00:17:54.797Z",
+    @"launchAsset": @{@"url": @"https://url.to/bundle.js", @"contentType": @"js"}
+  };
+  XCTAssertThrows([EXUpdatesNewUpdate updateWithNewManifest:manifest config:_config database:_database]);
+}
+
+- (void)testUpdateWithNewManifest_NoId
+{
+  NSDictionary *manifest = @{
+    @"runtimeVersion": @"1",
+    @"createdAt": @"2020-11-11T00:17:54.797Z",
+    @"launchAsset": @{@"url": @"https://url.to/bundle.js", @"contentType": @"js"}
+  };
+  XCTAssertThrows([EXUpdatesNewUpdate updateWithNewManifest:manifest config:_config database:_database]);
+}
+
+- (void)testUpdateWithNewManifest_NoCreatedAt
+{
+  NSDictionary *manifest = @{
+    @"runtimeVersion": @"1",
+    @"id": @"0eef8214-4833-4089-9dff-b4138a14f196",
+    @"launchAsset": @{@"url": @"https://url.to/bundle.js", @"contentType": @"js"}
+  };
+  XCTAssertThrows([EXUpdatesNewUpdate updateWithNewManifest:manifest config:_config database:_database]);
+}
+
+- (void)testUpdateWithNewManifest_NoLaunchAsset
+{
+  NSDictionary *manifest = @{
+    @"runtimeVersion": @"1",
+    @"id": @"0eef8214-4833-4089-9dff-b4138a14f196",
+    @"createdAt": @"2020-11-11T00:17:54.797Z"
+  };
+  XCTAssertThrows([EXUpdatesNewUpdate updateWithNewManifest:manifest config:_config database:_database]);
+}
+
+- (void)testUpdateWithNewManifest_StripsOptionalRootLevelKeys
+{
+  NSDictionary *manifestNoRootLevelKeys = @{
+    @"runtimeVersion": @"1",
+    @"id": @"0eef8214-4833-4089-9dff-b4138a14f196",
+    @"createdAt": @"2020-11-11T00:17:54.797Z",
+    @"launchAsset": @{@"url": @"https://url.to/bundle.js", @"contentType": @"js"}
+  };
+  NSDictionary *manifestWithRootLevelKeys = @{
+    @"data": @{
+      @"publicManifest": @{
+        @"manifest": manifestNoRootLevelKeys
+      }
+    }
+  };
+
+  EXUpdatesUpdate *update1 = [EXUpdatesNewUpdate updateWithNewManifest:manifestNoRootLevelKeys config:_config database:_database];
+  EXUpdatesUpdate *update2 = [EXUpdatesNewUpdate updateWithNewManifest:manifestWithRootLevelKeys config:_config database:_database];
+
+  XCTAssert([update1.updateId isEqual:update2.updateId]);
+}
+
+@end

--- a/packages/expo-updates/ios/Tests/EXUpdatesUpdateTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesUpdateTests.m
@@ -1,0 +1,103 @@
+//  Copyright (c) 2020 650 Industries, Inc. All rights reserved.
+
+#import <XCTest/XCTest.h>
+
+#import <EXUpdates/EXUpdatesBareUpdate.h>
+#import <EXUpdates/EXUpdatesConfig.h>
+#import <EXUpdates/EXUpdatesDatabase.h>
+#import <EXUpdates/EXUpdatesLegacyUpdate.h>
+#import <EXUpdates/EXUpdatesNewUpdate.h>
+#import <EXUpdates/EXUpdatesUpdate.h>
+
+@interface EXUpdatesUpdateTests : XCTestCase
+
+@property (nonatomic, strong) NSDictionary *legacyManifest;
+@property (nonatomic, strong) NSDictionary *easNewManifest;
+@property (nonatomic, strong) NSDictionary *bareManifest;
+
+@property (nonatomic, strong) EXUpdatesConfig *configUsesLegacyManifestTrue;
+@property (nonatomic, strong) EXUpdatesConfig *configUsesLegacyManifestFalse;
+@property (nonatomic, strong) EXUpdatesDatabase *database;
+
+@end
+
+@implementation EXUpdatesUpdateTests
+
+- (void)setUp
+{
+  _legacyManifest = @{
+    @"sdkVersion": @"39.0.0",
+    @"releaseId": @"0eef8214-4833-4089-9dff-b4138a14f196",
+    @"commitTime": @"2020-11-11T00:17:54.797Z",
+    @"bundleUrl": @"https://url.to/bundle.js"
+  };
+
+  _easNewManifest = @{
+    @"manifest": @{
+      @"runtimeVersion": @"1",
+      @"id": @"0eef8214-4833-4089-9dff-b4138a14f196",
+      @"createdAt": @"2020-11-11T00:17:54.797Z",
+      @"launchAsset": @{@"url": @"https://url.to/bundle.js", @"contentType": @"js"}
+    }
+  };
+
+  _bareManifest = @{
+    @"id": @"0eef8214-4833-4089-9dff-b4138a14f196",
+    @"commitTime": @(1609975977832)
+  };
+
+  _configUsesLegacyManifestTrue = [EXUpdatesConfig configWithDictionary:@{
+    @"EXUpdatesURL": @"https://exp.host/@test/test",
+    @"EXUpdatesUsesLegacyManifest": @(YES)
+  }];
+
+  _configUsesLegacyManifestFalse = [EXUpdatesConfig configWithDictionary:@{
+    @"EXUpdatesURL": @"https://exp.host/@test/test",
+    @"EXUpdatesUsesLegacyManifest": @(NO)
+  }];
+
+  _database = [EXUpdatesDatabase new];
+}
+
+- (void)tearDown
+{
+  [super tearDown];
+}
+
+- (void)testUpdateWithManifest_Legacy
+{
+  EXUpdatesUpdate *update = [EXUpdatesUpdate updateWithManifest:_legacyManifest config:_configUsesLegacyManifestTrue database:_database];
+  XCTAssert(update != nil);
+}
+
+- (void)testUpdateWithManifest_New
+{
+  EXUpdatesUpdate *update = [EXUpdatesUpdate updateWithManifest:_easNewManifest config:_configUsesLegacyManifestFalse database:_database];
+  XCTAssert(update != nil);
+}
+
+- (void)testUpdateWithEmbeddedManifest_Legacy
+{
+  EXUpdatesUpdate *update = [EXUpdatesUpdate updateWithEmbeddedManifest:_legacyManifest config:_configUsesLegacyManifestTrue database:_database];
+  XCTAssert(update != nil);
+}
+
+- (void)testUpdateWithEmbeddedManifest_New
+{
+  EXUpdatesUpdate *update = [EXUpdatesUpdate updateWithEmbeddedManifest:_easNewManifest config:_configUsesLegacyManifestFalse database:_database];
+  XCTAssert(update != nil);
+}
+
+- (void)testUpdateWithEmbeddedManifest_Legacy_Bare
+{
+  EXUpdatesUpdate *update = [EXUpdatesUpdate updateWithEmbeddedManifest:_bareManifest config:_configUsesLegacyManifestTrue database:_database];
+  XCTAssert(update != nil);
+}
+
+- (void)testUpdateWithEmbeddedManifest_New_Bare
+{
+  EXUpdatesUpdate *update = [EXUpdatesUpdate updateWithEmbeddedManifest:_bareManifest config:_configUsesLegacyManifestFalse database:_database];
+  XCTAssert(update != nil);
+}
+
+@end

--- a/packages/expo-updates/ios/Tests/EXUpdatesUpdateTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesUpdateTests.m
@@ -37,7 +37,7 @@
       @"runtimeVersion": @"1",
       @"id": @"0eef8214-4833-4089-9dff-b4138a14f196",
       @"createdAt": @"2020-11-11T00:17:54.797Z",
-      @"launchAsset": @{@"url": @"https://url.to/bundle.js", @"contentType": @"js"}
+      @"launchAsset": @{@"url": @"https://url.to/bundle.js", @"contentType": @"application/javascript"}
     }
   };
 

--- a/packages/expo-updates/ios/Tests/Tests.m
+++ b/packages/expo-updates/ios/Tests/Tests.m
@@ -51,28 +51,5 @@
   XCTAssert([@"https://exp.host:47" isEqualToString:[EXUpdatesConfig normalizedURLOrigin:urlOtherPort]], @"should return a normalized URL origin with port if non-default port is specified");
 }
 
-- (void)testBundledAssetBaseUrl_assetUrlOverride
-{
-  EXUpdatesConfig *config = [[EXUpdatesConfig alloc] init];
-  [config loadConfigFromDictionary:@{ @"EXUpdatesURL": @"https://esamelson.github.io/self-hosting-test/ios-index.json", @"EXUpdatesSDKVersion": @"38.0.0" }];
-
-  NSString *absoluteUrlString = @"https://xxx.dev/~assets";
-  NSURL *absoluteExpected = [NSURL URLWithString:absoluteUrlString];
-  NSURL *absoluteActual = [EXUpdatesLegacyUpdate bundledAssetBaseUrlWithManifest:@{ @"assetUrlOverride": absoluteUrlString } config:config];
-  XCTAssert([absoluteActual isEqual:absoluteExpected], @"should return the value of assetUrlOverride if it's an absolute URL");
-
-  NSURL *relativeExpected = [NSURL URLWithString:@"https://esamelson.github.io/self-hosting-test/my_assets"];
-  NSURL *relativeActual = [EXUpdatesLegacyUpdate bundledAssetBaseUrlWithManifest:@{ @"assetUrlOverride": @"my_assets" } config:config];
-  XCTAssert([relativeActual isEqual:relativeExpected], @"should return a URL relative to manifest URL base if it's a relative URL");
-
-  NSURL *relativeDotSlashExpected = [NSURL URLWithString:@"https://esamelson.github.io/self-hosting-test/assets"];
-  NSURL *relativeDotSlashActual = [EXUpdatesLegacyUpdate bundledAssetBaseUrlWithManifest:@{ @"assetUrlOverride": @"./assets" } config:config];
-  XCTAssert([relativeDotSlashActual isEqual:relativeDotSlashExpected], @"should return a URL relative to manifest URL base with `./` resolved correctly if it's a relative URL");
-
-  NSURL *defaultExpected = [NSURL URLWithString:@"https://esamelson.github.io/self-hosting-test/assets"];
-  NSURL *defaultActual = [EXUpdatesLegacyUpdate bundledAssetBaseUrlWithManifest:@{} config:config];
-  XCTAssert([defaultActual isEqual:defaultExpected], @"should return a URL with `assets` relative to manifest URL base if unspecified");
-}
-
 @end
 


### PR DESCRIPTION
# Why

Slowly but surely improving the automated test coverage of this module!

# How

Added native unit tests for the following things:
- legacy manifest required fields
- new (EAS) manifest required fields
- manifest creation (that the correct class is used depending on the type of manifest)
- added a bit more coverage to the existing tests around asset base urls

Additionally, writing these tests exposed some discrepancies between/within platforms about handling possibly null manifest fields, so I fixed those. Thanks, tests!

# Test Plan

All tests pass ✅ 

# To do

- setup a CI job for Xcode unit tests
