### PR TITLE
fix: do not attempt to symlink non-existent packages

### DIFF
--- a/packages/expo-yarn-workspaces/bin/symlink-necessary-packages.js
+++ b/packages/expo-yarn-workspaces/bin/symlink-necessary-packages.js
@@ -62,12 +62,19 @@ function symlinkNecessaryPackage(projectPath, packageName) {
   let workspaceRootPath = findYarnWorkspaceRoot(projectPath);
   if (!workspaceRootPath) {
     debug(`Could not find Yarn workspace root; skipping symlinking package`);
+    return;
   }
   let workspacePackagePath = path.join(
     workspaceRootPath,
     'node_modules',
     packageName.replace('/', path.sep)
   );
+
+  stats = getFileStats(workspacePackagePath);
+  if (!stats || !stats.isDirectory()) {
+    debug(`%s does not exist; skipping symlinking package`, workspacePackagePath);
+    return;
+  }
 
   if (packageName.startsWith('@')) {
     let [scope, name] = packageName.split('/');
@@ -80,7 +87,6 @@ function symlinkNecessaryPackage(projectPath, packageName) {
     fs.symlinkSync(relativePackagePath, path.join(scopePath, name));
   } else {
     let relativePackagePath = path.relative(nodeModulesPath, workspacePackagePath);
-    console.log(relativePackagePath);
 
     debug(`Ensuring %s exists`, nodeModulesPath);
     mkdirp.sync(nodeModulesPath);


### PR DESCRIPTION
# Why

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

#11402 added linking of `react-native-unimodules` which doesn't exist for me (maybe because I don't have som unimodule or currently on SDK 39?). For some reason a symlink pointing to nothing makes `metro` explode during `expo publish`

# How

Check if the thing we want to symlink to actually exists before creating the symlink

# Test Plan

Tested in our project
