### PR TITLE
[docs] Add Jest configuration for TypeScript users

### DIFF
--- a/docs/pages/guides/testing-with-jest.md
+++ b/docs/pages/guides/testing-with-jest.md
@@ -67,6 +67,15 @@ describe('<App />', () => {
 
 Now run `yarn test` or `npm run test`, if all went well you should see 1 test passed! Read more on [expect and conditional matchers](https://jestjs.io/docs/en/expect).
 
+For TypeScript users, your test file is named `App.test.tsx`, and you also have to configure Jest's [`moduleFileExtensions`](https://jestjs.io/docs/en/configuration#modulefileextensions-arraystring) to let Jest import `App.tsx` instead of `app.json` in `import App from './App'`.
+
+```js
+"jest": {
+  "preset": "jest-expo",
+  "moduleFileExtensions": ["ts", "tsx", "js", "json", "jsx", "node"]
+}
+```
+
 ## Snapshot Test
 
 Now let's add a snapshot test for `App.js`. **What is a snapshot test, and why is it useful?** Snapshot tests are used to make sure the UI stays consistent, especially when a project is working with global styles that are potentially shared across components. Read more about it on Jest's site [snapshot testing](https://jestjs.io/docs/en/snapshot-testing).


### PR DESCRIPTION
# Why

I have found that TypeScript users fall into a trap if they follow this guide ([Testing with Jest - Expo Documentation](https://docs.expo.io/guides/testing-with-jest/)). I encountered the following JSX error when running `npm run test` in my TypeScript project.

```
$ npm run test

> @ test /Users/ishikawasonkyou/Developer/Workspace/ExpoJestDoc/my-typescript-app
> jest

 FAIL  ./App.test.tsx
  <App />
    ✕ has 1 child (50ms)

  ● <App /> › has 1 child

    Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: object.

      at createFiberFromTypeAndProps (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:16180:21)
      at createFiberFromElement (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:16208:15)
      at reconcileSingleElement (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:5358:23)
      at reconcileChildFibers (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:5418:35)
      at reconcileChildren (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:7991:28)
      at updateHostRoot (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:8547:5)
      at beginWork (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:9994:14)
      at performUnitOfWork (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:13800:12)
      at workLoopSync (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:13728:5)
      at renderRootSync (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:13691:7)
```

Because Jest tries to import `app.json` rather than `App.test.tsx` in`import App from 'import App from ./App'`, `App` variable refers Expo configuration object which is obviously not a JSX element.

# How

I added a notice which lets users add `moduleFileExtensions` configuration properly.

```json
"jest": {
  "preset": "jest-expo",
  "moduleFileExtensions": ["ts", "tsx", "js", "json", "jsx", "node"]
}
```

# Test Plan

I created a new Expo project by following the guide [Using TypeScript - Expo Documentation](https://docs.expo.io/guides/typescript/), then I followed this guide ([Testing with Jest - Expo Documentation](https://docs.expo.io/guides/testing-with-jest/)). 

