### PR TITLE
[expo-font][bugfix] Put `font-family` in quotes

### DIFF
--- a/packages/expo-font/src/ExpoFontLoader.web.ts
+++ b/packages/expo-font/src/ExpoFontLoader.web.ts
@@ -110,7 +110,7 @@ function getStyleElement(): HTMLStyleElement {
 function _createWebStyle(fontFamily: string, resource: FontResource): HTMLStyleElement {
   const fontStyle = `@font-face {
     font-family: "${fontFamily}";
-    src: url("${resource.uri}");
+    src: url(${resource.uri});
     font-display: ${resource.display || FontDisplay.AUTO};
   }`;
 

--- a/packages/expo-font/src/ExpoFontLoader.web.ts
+++ b/packages/expo-font/src/ExpoFontLoader.web.ts
@@ -109,8 +109,8 @@ function getStyleElement(): HTMLStyleElement {
 
 function _createWebStyle(fontFamily: string, resource: FontResource): HTMLStyleElement {
   const fontStyle = `@font-face {
-    font-family: ${fontFamily};
-    src: url(${resource.uri});
+    font-family: "${fontFamily}";
+    src: url("${resource.uri}");
     font-display: ${resource.display || FontDisplay.AUTO};
   }`;
 


### PR DESCRIPTION
Chrome won't load the font unless the value is quoted. This is possibly true for other web browsers as well.

# Why

Chrome won't load the font unless the value is quoted.

# How

N/A

# Test Plan

N/A