### PR TITLE
[docs] Fix typo in Firebase Recaptcha example

### DIFF
--- a/docs/pages/versions/unversioned/sdk/firebase-recaptcha.md
+++ b/docs/pages/versions/unversioned/sdk/firebase-recaptcha.md
@@ -103,7 +103,7 @@ export default function App() {
 
   return (
     <View style={{ padding: 20, marginTop: 50 }}>
-      <FirebaseRecaptchaModalVerifier
+      <FirebaseRecaptchaVerifierModal
         ref={recaptchaVerifier}
         firebaseConfig={firebaseConfig}
         attemptInvisibleVerification={attemptInvisibleVerification}


### PR DESCRIPTION
# Why

The name of the component does not match the import name 'FirebaseRecaptchaVerifierModal'

# How

replaced component name with FirebaseRecaptchaVerifierModal

# Test Plan
n/a
