### PR TITLE
code demo on how to navigate to a new screen from a push notification

### DIFF
--- a/docs/pages/push-notifications/receiving-notifications.md
+++ b/docs/pages/push-notifications/receiving-notifications.md
@@ -69,6 +69,48 @@ export default class App extends React.Component {
 }
 ```
 
+## Navigate to a particular screen if a push notification was tapped
+
+```
+import React, { useEffect } from 'react';
+import { View, Text } from 'react-native';
+import * as Notifications from 'expo-notifications';
+
+// the first screen component to render in our route configuration
+export default function HomeScreen({ navigation }) {
+  // A React hook always returning the notification response that was received most recently
+  const lastNotificationResponse = Notifications.useLastNotificationResponse();
+
+  useEffect(() => {
+    // if a user taps on a notification and there is data in it...
+    if (
+      lastNotificationResponse &&
+      lastNotificationResponse.notification.request.content.data &&
+      lastNotificationResponse.actionIdentifier ===
+        Notifications.DEFAULT_ACTION_IDENTIFIER
+    ) {
+      // deconstruct the data we need from the push notification
+      const {
+        questionSetId,
+        questionId
+      } = lastNotificationResponse.notification.request.content.data;
+
+      // use that data to navigate to the screen we want
+      navigation.navigate('QuestionScreen', {
+        questionSetId,
+        questionId
+      });
+    }
+  }, [lastNotificationResponse]);
+
+  return (
+    <View>
+      <Text>HomeScreen</Text>
+    </View>
+  );
+}
+```
+
 ## Foreground Notification Behavior
 
 **Important Note**: To set the behavior for when notifications are received while your app is **foregrounded**, use [`Notifications.setNotificationHandler`](../versions/latest/sdk/notifications.md#setnotificationhandlerhandler-notificationhandler--null-void). You can use the callback to set options like:


### PR DESCRIPTION
# Why

I found it confusing how to navigate to a screen from a tapped push notification.

Firstly, from React Navigation's perspective, we could [setup Deep Linking with Expo Notifications](https://reactnavigation.org/docs/deep-linking#third-party-integrations). I found that navigation did not work when the app was closed. And when adding `getInitialURL` I couldn't find a good implementation with expo-notifications API.

```
import * as Linking from 'expo-linking';
import * as Notifications from 'expo-notifications';
​
Notifications.setNotificationHandler({
  handleNotification: async () => ({
    shouldShowAlert: true,
    shouldPlaySound: true,
    shouldSetBadge: true
  })
});
​
export default {
  prefixes: [Linking.makeUrl('/'), 'https://createdeepconnections.com'],
  subscribe(listener) {
    const onReceiveURL = ({ url }: { url: string }) => listener(url);
​
    // Listen to incoming links from deep linking
    Linking.addEventListener('url', onReceiveURL);
​
    // Listen to expo push notifications
    const subscription = Notifications.addNotificationResponseReceivedListener(
      response => {
        const url = response.notification.request.content.data.url;
​
        listener(Linking.makeUrl(url));
      }
    );
​
    return () => {
      // Clean up the event listeners
      Linking.removeEventListener('url', onReceiveURL);
      subscription.remove();
    };
  },
  config: {
    screens: {
      Root: {
        screens: {
          Home: {
            initialRouteName: 'HomeScreen',
            screens: {
              QuestionScreen: 'question/:questionSetId/:questionId'
            }
          }
        }
      }
    }
  }
};
```

So instead, navigating using the expo-notification listeners as partly documented [here](https://docs.expo.io/push-notifications/receiving-notifications/) was much cleaner. Even though these docs mentioned navigating to a screen if a notification was selected, it didn't actually show how.

I also found that using the [useLastNotificationResponse](https://docs.expo.io/versions/latest/sdk/notifications/#uselastnotificationresponse-undefined--notificationresponse--null) hook much cleaner. And navigation to a screen from a push notification tap works for when the app is open and closed.
