### PR TITLE
[tools] Update versioning to handle modules vendored by the new script

### DIFF
--- a/ios/versioned-react-native/ABI40_0_0/dependencies.rb
+++ b/ios/versioned-react-native/ABI40_0_0/dependencies.rb
@@ -9,6 +9,8 @@ pod 'ABI40_0_0ExpoKit',
   :project_name => 'ABI40_0_0',
   :subspecs => ['Expo', 'ExpoOptional']
 
+use_pods! 'vendored/sdk40/*/*.podspec.json', 'ABI40_0_0'
+
 pod 'ABI40_0_0UMCore',
   :path => './versioned-react-native/ABI40_0_0/Expo/UMCore',
   :project_name => 'ABI40_0_0'

--- a/tools/package.json
+++ b/tools/package.json
@@ -92,7 +92,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",
-    "@types/fs-extra": "^8.1.0",
+    "@types/fs-extra": "^9.0.0",
     "@types/klaw-sync": "^6.0.0",
     "babel-preset-expo": "^8.1.0",
     "expo-module-scripts": "^1.2.0",

--- a/tools/src/versioning/ios/transforms/vendoredModulesTransforms.ts
+++ b/tools/src/versioning/ios/transforms/vendoredModulesTransforms.ts
@@ -1,0 +1,24 @@
+import { FileTransforms } from '../../../Transforms.types';
+
+type Config = {
+  [key: string]: FileTransforms;
+};
+
+export default function vendoredModulesTransformsFactory(prefix: string): Config {
+  return {
+    'lottie-react-native': {
+      content: [
+        {
+          paths: 'LRNAnimationViewManagerObjC.m',
+          find: /RCT_EXTERN_MODULE\(/,
+          replaceWith: `RCT_EXTERN_REMAP_MODULE(LottieAnimationView, ${prefix}`,
+        },
+        {
+          paths: 'ContainerView.swift',
+          find: /\breactSetFrame/g,
+          replaceWith: `${prefix.toLowerCase()}ReactSetFrame`,
+        },
+      ],
+    },
+  };
+}

--- a/tools/src/versioning/ios/versionVendoredModules.ts
+++ b/tools/src/versioning/ios/versionVendoredModules.ts
@@ -1,0 +1,97 @@
+import chalk from 'chalk';
+import fs from 'fs-extra';
+import path from 'path';
+
+import { IOS_DIR } from '../../Constants';
+import logger from '../../Logger';
+import { copyFileWithTransformsAsync } from '../../Transforms';
+import { FileTransforms } from '../../Transforms.types';
+import { searchFilesAsync } from '../../Utils';
+import vendoredModulesTransforms from './transforms/vendoredModulesTransforms';
+
+const IOS_VENDORED_DIR = path.join(IOS_DIR, 'vendored');
+
+/**
+ * Versions iOS vendored modules.
+ */
+export async function versionVendoredModulesAsync(
+  sdkNumber: number,
+  filterModules: string[] | null
+): Promise<void> {
+  const prefix = `ABI${sdkNumber}_0_0`;
+  const config = vendoredModulesTransforms(prefix);
+  const baseTransforms = baseTransformsFactory(prefix);
+  const unversionedDir = path.join(IOS_VENDORED_DIR, 'unversioned');
+  const versionedDir = path.join(IOS_VENDORED_DIR, `sdk${sdkNumber}`);
+  const sourceDirents = (await readDirents(unversionedDir)).filter((dirent) => {
+    return dirent.isDirectory() && (!filterModules || filterModules.includes(dirent.name));
+  });
+
+  for (const { name } of sourceDirents) {
+    logger.info('🔃 Versioning vendored module %s', chalk.green(name));
+
+    const moduleConfig = config[name];
+    const sourceDirectory = path.join(unversionedDir, name);
+    const targetDirectory = path.join(versionedDir, name);
+    const files = await searchFilesAsync(sourceDirectory, '**');
+
+    await fs.remove(targetDirectory);
+
+    for (const sourceFile of files) {
+      await copyFileWithTransformsAsync({
+        sourceFile,
+        sourceDirectory,
+        targetDirectory,
+        transforms: {
+          path: [...baseTransforms.path, ...(moduleConfig?.path ?? [])],
+          content: [...baseTransforms.content, ...(moduleConfig?.content ?? [])],
+        },
+      });
+    }
+  }
+}
+
+/**
+ * Generates base transforms to apply for all vendored modules.
+ */
+function baseTransformsFactory(prefix: string): Required<FileTransforms> {
+  return {
+    path: [
+      {
+        find: /^([^/]+\.podspec\.json)$\b/,
+        replaceWith: `${prefix}-$1`,
+      },
+    ],
+    content: [
+      {
+        paths: '*.podspec.json',
+        find: /"name": "([\w-]+)"/,
+        replaceWith: `"name": "${prefix}-$1"`,
+      },
+      {
+        find: /\b(React)/g,
+        replaceWith: `${prefix}$1`,
+      },
+      {
+        find: /\b(RCT\w+)\b/g,
+        replaceWith: `${prefix}$1`,
+      },
+      {
+        paths: '*.swift',
+        find: /@objc\(([^)]+)\)/g,
+        replaceWith: `@objc(${prefix}$1)`,
+      },
+    ],
+  };
+}
+
+// fs-extra doesn't have type definitions for `readdir` with options.
+type ReadDirWithOptions = (
+  path: string | Buffer,
+  options: { withFileTypes: boolean }
+) => Promise<fs.Dirent[]>;
+
+async function readDirents(path: string): Promise<fs.Dirent[]> {
+  const readdir = (fs.readdir as unknown) as ReadDirWithOptions;
+  return await readdir(path, { withFileTypes: true });
+}

--- a/tools/src/versioning/ios/versionVendoredModules.ts
+++ b/tools/src/versioning/ios/versionVendoredModules.ts
@@ -23,9 +23,11 @@ export async function versionVendoredModulesAsync(
   const baseTransforms = baseTransformsFactory(prefix);
   const unversionedDir = path.join(IOS_VENDORED_DIR, 'unversioned');
   const versionedDir = path.join(IOS_VENDORED_DIR, `sdk${sdkNumber}`);
-  const sourceDirents = (await readDirents(unversionedDir)).filter((dirent) => {
-    return dirent.isDirectory() && (!filterModules || filterModules.includes(dirent.name));
-  });
+  const sourceDirents = (await fs.readdir(unversionedDir, { withFileTypes: true })).filter(
+    (dirent) => {
+      return dirent.isDirectory() && (!filterModules || filterModules.includes(dirent.name));
+    }
+  );
 
   for (const { name } of sourceDirents) {
     logger.info('🔃 Versioning vendored module %s', chalk.green(name));
@@ -83,15 +85,4 @@ function baseTransformsFactory(prefix: string): Required<FileTransforms> {
       },
     ],
   };
-}
-
-// fs-extra doesn't have type definitions for `readdir` with options.
-type ReadDirWithOptions = (
-  path: string | Buffer,
-  options: { withFileTypes: boolean }
-) => Promise<fs.Dirent[]>;
-
-async function readDirents(path: string): Promise<fs.Dirent[]> {
-  const readdir = (fs.readdir as unknown) as ReadDirWithOptions;
-  return await readdir(path, { withFileTypes: true });
 }

--- a/tools/yarn.lock
+++ b/tools/yarn.lock
@@ -3290,10 +3290,10 @@
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
   integrity sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==
 
-"@types/fs-extra@^8.1.0":
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-8.1.0.tgz#1114834b53c3914806cd03b3304b37b3bd221a4d"
-  integrity sha512-UoOfVEzAUpeSPmjm7h1uk5MH6KZma2z2O7a75onTGjnNvAvMVrPzPL/vBbT65iIGHWj6rokwfmYcmxmlSf2uwg==
+"@types/fs-extra@^9.0.0":
+  version "9.0.6"
+  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-9.0.6.tgz#488e56b77299899a608b8269719c1d133027a6ab"
+  integrity sha512-ecNRHw4clCkowNOBJH1e77nvbPxHYnWIXMv1IAoG/9+MYGkgoyr3Ppxr7XYFNL41V422EDhyV4/4SSK8L2mlig==
   dependencies:
     "@types/node" "*"
 


### PR DESCRIPTION
# Why

Followup #11488, #11499, #11586 

# How

Added separate step in versioning process (`et add-sdk-version`) to version modules under `ios/vendored/unversioned` directory. There will be some basic transforms applied on all of those files, but each vendored module can have its own transforms in `vendoredModulesTransforms.ts` where I put just `lottie-react-native` (more will be added later).

# Test Plan

Ran `et add-sdk -p ios -s 40.0.0 -v lottie-react-native`
✅ Files at `ios/vendored/sdk40/lottie-react-native` seems to be correctly generated
✅ The client compiles
✅ Lottie examples in native-component-list (with SDK version set to 40.0.0) work as expected
