### PR TITLE
[docs] Import missing install section on app-loading

### DIFF
--- a/docs/pages/versions/v40.0.0/sdk/app-loading.md
+++ b/docs/pages/versions/v40.0.0/sdk/app-loading.md
@@ -3,6 +3,7 @@ title: AppLoading
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-40/packages/expo/src/launch'
 ---
 
+import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`expo-app-loading`** tells `expo-splash-screen` to keep the splash screen visible while the AppLoading component is mounted.


### PR DESCRIPTION
# Why

Fixes #11582

# How

Imports missing `InstallSection` component.

# Test Plan

- Open [App Loading docs page locally](http://0.0.0.0:3002/versions/v40.0.0/sdk/app-loading/)
- See if Installation contains the steps
