### PR TITLE
[android] remove OkHttp interceptors

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/ReactNativeStaticHelpers.java
+++ b/android/expoview/src/main/java/host/exp/exponent/ReactNativeStaticHelpers.java
@@ -126,8 +126,6 @@ public class ReactNativeStaticHelpers {
         .cookieJar((CookieJar) cookieJar)
         .cache(sExponentNetwork.getCache());
 
-    sExponentNetwork.addInterceptors(client);
-
     // pass the builder through MainApplication so that detached apps can customize it
     try {
       Method m = Class.forName("host.exp.exponent.MainApplication").getMethod("okHttpClientBuilder", OkHttpClient.Builder.class);

--- a/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.java
+++ b/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.java
@@ -165,7 +165,6 @@ public class Kernel extends KernelInterface {
       // clientBuilder.addNetworkInterceptor(new StethoInterceptor());
     }
 
-    mExponentNetwork.addInterceptors(client);
     ReactNativeStaticHelpers.setExponentNetwork(mExponentNetwork);
   }
 

--- a/android/expoview/src/main/java/host/exp/exponent/network/ExponentNetwork.java
+++ b/android/expoview/src/main/java/host/exp/exponent/network/ExponentNetwork.java
@@ -3,29 +3,18 @@
 package host.exp.exponent.network;
 
 import android.content.Context;
-import android.content.res.Resources;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
-import java.net.URLConnection;
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
 import okhttp3.Cache;
-import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
-import okhttp3.Protocol;
-import okhttp3.Request;
-import okhttp3.Response;
-import okhttp3.ResponseBody;
-import okio.BufferedSource;
-import okio.Okio;
 import host.exp.exponent.storage.ExponentSharedPreferences;
 import host.exp.expoview.ExpoViewBuildConfig;
 
@@ -35,7 +24,6 @@ public class ExponentNetwork {
   public static final String IGNORE_INTERCEPTORS_HEADER = "exponentignoreinterceptors";
 
   private static final String CACHE_DIR = "okhttp";
-  private static final int ONE_YEAR_IN_SECONDS = 60 * 60 * 24 * 365;
 
   private Context mContext;
   private ExponentHttpClient mClient;
@@ -82,7 +70,6 @@ public class ExponentNetwork {
       // FIXME: 8/9/17
       // clientBuilder.addNetworkInterceptor(new StethoInterceptor());
     }
-    addInterceptors(clientBuilder);
 
     return clientBuilder;
   }
@@ -116,102 +103,5 @@ public class ExponentNetwork {
     ConnectivityManager connectivityManager = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
     NetworkInfo activeNetworkInfo = connectivityManager.getActiveNetworkInfo();
     return activeNetworkInfo != null && activeNetworkInfo.isConnected();
-  }
-
-  public void addInterceptors(OkHttpClient.Builder clientBuilder) {
-    // TODO(janic): Either backport bundled assets from sdk25 or remove
-    // when sdk24 is no longer supported.
-    Interceptor bundledAssetsInterceptor = new Interceptor() {
-      @Override
-      public Response intercept(Chain chain) throws IOException {
-        Request originalRequest = chain.request();
-        String urlString = originalRequest.url().toString();
-
-        // Check if assets loaded from the cdn were included in the bundle.
-        if (urlString.startsWith("https://d1wp6m56sqw74a.cloudfront.net/~assets/")) {
-          List<String> path = originalRequest.url().pathSegments();
-          String assetName = "asset_" + path.get(path.size() - 1);
-          InputStream inputStream = null;
-          try {
-            inputStream = mContext.getAssets().open(assetName);
-          } catch (IOException ex) {
-            // The file doesn't exists in the bundle, fallback to network.
-          }
-          if (inputStream != null) {
-            BufferedSource buffer = Okio.buffer(Okio.source(inputStream));
-            ResponseBody body = ResponseBody.create(null, -1, buffer);
-            return new Response.Builder()
-                .request(originalRequest)
-                .protocol(Protocol.HTTP_1_1)
-                // Don't cache local assets to save disk space.
-                .addHeader("Cache-Control", "no-cache")
-                .body(body)
-                .code(200)
-                .build();
-          }
-        }
-        return chain.proceed(originalRequest);
-      }
-    };
-
-    Interceptor offlineInterceptor = new Interceptor() {
-      @Override
-      public Response intercept(Chain chain) throws IOException {
-        boolean isNetworkAvailable = isNetworkAvailable();
-        // Request
-        Request originalRequest = chain.request();
-        if (originalRequest.header(IGNORE_INTERCEPTORS_HEADER) != null) {
-          return noopInterceptor(chain, originalRequest);
-        }
-
-        Request request;
-        if (isNetworkAvailable) {
-          request = originalRequest.newBuilder()
-              .removeHeader("Cache-Control")
-              .build();
-        } else {
-          // If network isn't available we don't care if the cache is stale.
-          request = originalRequest.newBuilder()
-              .header("Cache-Control", "max-stale=" + ONE_YEAR_IN_SECONDS)
-              .build();
-        }
-
-        // Response
-        Response response = chain.proceed(request);
-        String responseCacheHeaderValue;
-        if (isNetworkAvailable) {
-          String currentResponseHeader = response.header("Cache-Control");
-          if (currentResponseHeader != null && currentResponseHeader.contains("public") &&
-              (currentResponseHeader.contains("max-age") || currentResponseHeader.contains("s-maxage"))) {
-            // Server sent back caching instructions, follow them
-            responseCacheHeaderValue = currentResponseHeader;
-          } else {
-            // Server didn't send Cache-Control header or told us not to cache. Tell OkHttp
-            // to cache the response but invalidate it after 0 seconds. This will allow us
-            // to access the response with max-stale if the network is turned off.
-            responseCacheHeaderValue = "public, max-age=0";
-          }
-        } else {
-          // Only read from the cache, don't try to hit the network
-          responseCacheHeaderValue = "public, only-if-cached";
-        }
-
-        return response.newBuilder()
-            .removeHeader("Pragma")
-            .removeHeader("Cache-Control")
-            .header("Cache-Control", responseCacheHeaderValue)
-            .build();
-      }
-    };
-
-
-    clientBuilder.addInterceptor(bundledAssetsInterceptor);
-    clientBuilder.addInterceptor(offlineInterceptor);
-    clientBuilder.addNetworkInterceptor(offlineInterceptor);
-  }
-
-  private static Response noopInterceptor(Interceptor.Chain chain, Request originalRequest) throws IOException {
-    Request request = originalRequest.newBuilder().removeHeader(IGNORE_INTERCEPTORS_HEADER).build();
-    return chain.proceed(request);
   }
 }


### PR DESCRIPTION
# Why

Fix for https://github.com/expo/expo/issues/8598 . 

In expo/universe@2542e28c4b41b86824ee1f52177d911b016d4310, we added an interceptor to aggressively cache all network requests through OkHttp, presumably to have predictable caching of OTA update assets. Now that we’ve integrated expo-updates into the managed workflow, we no longer need this interceptor.

# How

Remove the interceptor, and also one other interceptor for bundled assets that has been obsolete since SDK 25.

# Test Plan

Set up a simple express server with 5 endpoints, each of which would respond with a simple JSON blob and a different cache-control header. Queried this server using `fetch` in an Expo app and verified the `response` object had the correct headers. To ensure the correct behavior of the cache, tried hitting the server two additional times -- once after terminating it on my computer, and once after shutting off wifi on the device.

Ran these tests in both the Expo Go client and a standalone app.

- [x] no `Cache-Control` header -- data was not cached
- [x] `Cache-Control: no-store` -- data was not cached
- [x] `Cache-Control: public, max-age=1` -- data expired and was not available from cache
- [x] `Cache-Control: public, max-age=100000` -- data was cached and available offline
- [x] `Cache-Control: public, max-age=100000` but overridden client-side in `fetch` request -- data was not cached

Additionally, ran the following tests on a standalone app to ensure there was no interference with OTA update assets:

- [x] Start fresh install of app with wifi off, images should show
- [x] Turn on wifi, download update with new image asset, turn off wifi, relaunch, new image should show
- [x] Delete OkHttp cache directory using Android Studio File Explorer, relaunch app (wifi still off), image assets should still show up
- [x] Add logging to ensure that embedded assets are not re-downloaded