### PR TITLE
[android] migrate OkHttp cache to application cache directory

### DIFF
--- a/android/app/src/main/java/host/exp/exponent/MainApplication.java
+++ b/android/app/src/main/java/host/exp/exponent/MainApplication.java
@@ -35,9 +35,4 @@ public class MainApplication extends ExpoApplication implements AppLoaderPackage
   public List<Package> getExpoPackages() {
     return new BasePackageList().getPackageList();
   }
-
-  public static OkHttpClient.Builder okHttpClientBuilder(OkHttpClient.Builder builder) {
-    // Customize/override OkHttp client here
-    return builder;
-  }
 }

--- a/android/expoview/src/main/java/host/exp/exponent/ReactNativeStaticHelpers.java
+++ b/android/expoview/src/main/java/host/exp/exponent/ReactNativeStaticHelpers.java
@@ -116,6 +116,7 @@ public class ReactNativeStaticHelpers {
 
   @DoNotStrip
   public static Object getOkHttpClient(Class callingClass) {
+    // we build the OkHttp client here so that one cache instance is shared by all concurrent OkHttp instances
     String version = RNObject.versionForClassname(callingClass.getName());
     Object cookieJar = new RNObject("com.facebook.react.modules.network.ReactCookieJarContainer").loadVersion(version).construct().get();
 
@@ -126,21 +127,6 @@ public class ReactNativeStaticHelpers {
         .cookieJar((CookieJar) cookieJar)
         .cache(sExponentNetwork.getCache());
 
-    // pass the builder through MainApplication so that detached apps can customize it
-    try {
-      Method m = Class.forName("host.exp.exponent.MainApplication").getMethod("okHttpClientBuilder", OkHttpClient.Builder.class);
-      Object returnVal = m.invoke(null, client);
-      if (returnVal instanceof OkHttpClient.Builder) {
-        client = (OkHttpClient.Builder) returnVal;
-      } else {
-        throw new Exception("MainApplication.okHttpClientBuilder returned an object of type " + returnVal.getClass().getName());
-      }
-    } catch (NoSuchMethodException ex) {
-      // ignore this and fall back to previous client
-    } catch (Exception e) {
-      // just fall back to previous client
-      EXL.e(TAG, "Falling back to default OkHttpClient builder: " + e.getMessage());
-    }
     return client.build();
   }
 }

--- a/android/expoview/src/main/java/host/exp/exponent/network/ExponentNetwork.java
+++ b/android/expoview/src/main/java/host/exp/exponent/network/ExponentNetwork.java
@@ -5,6 +5,7 @@ package host.exp.exponent.network;
 import android.content.Context;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
+import android.util.Log;
 
 import java.io.File;
 import java.io.IOException;
@@ -21,12 +22,15 @@ import host.exp.expoview.ExpoViewBuildConfig;
 @Singleton
 public class ExponentNetwork {
 
+  private static final String TAG = ExponentNetwork.class.getSimpleName();
+
   public static final String IGNORE_INTERCEPTORS_HEADER = "exponentignoreinterceptors";
 
   private static final String CACHE_DIR = "http-cache";
   private static final String LEGACY_CACHE_DIR = "okhttp";
 
   private Context mContext;
+  private ExponentSharedPreferences mExponentSharedPreferences;
   private ExponentHttpClient mClient;
   private ExponentHttpClient mLongTimeoutClient;
   private OkHttpClient mNoCacheClient;
@@ -43,6 +47,7 @@ public class ExponentNetwork {
   @Inject
   public ExponentNetwork(Context context, ExponentSharedPreferences exponentSharedPreferences) {
     mContext = context.getApplicationContext();
+    mExponentSharedPreferences = exponentSharedPreferences;
 
     mClient = new ExponentHttpClient(mContext, exponentSharedPreferences, new OkHttpClientFactory() {
       @Override
@@ -62,6 +67,8 @@ public class ExponentNetwork {
     });
 
     mNoCacheClient = new OkHttpClient.Builder().build();
+
+    clearLegacyCache();
   }
 
   private OkHttpClient.Builder createHttpClientBuilder() {
@@ -92,6 +99,24 @@ public class ExponentNetwork {
     int cacheSize = 50 * 1024 * 1024; // 50 MiB
     final File directory = new File(mContext.getCacheDir(), CACHE_DIR);
     return new Cache(directory, cacheSize);
+  }
+
+  private void clearLegacyCache() {
+    if (mExponentSharedPreferences.getBoolean(ExponentSharedPreferences.HAS_CLEARED_LEGACY_OKHTTP_CACHE_KEY)) {
+      return;
+    }
+
+    try {
+      File directory = new File(mContext.getFilesDir(), LEGACY_CACHE_DIR);
+      Cache legacyCache = new Cache(directory, 40 * 1024 * 1024);
+      legacyCache.delete();
+      if (directory.exists()) {
+        directory.delete();
+      }
+      mExponentSharedPreferences.setBoolean(ExponentSharedPreferences.HAS_CLEARED_LEGACY_OKHTTP_CACHE_KEY, true);
+    } catch (Exception e) {
+      Log.e(TAG, "Failed to clear legacy OkHttp class", e);
+    }
   }
 
   public boolean isNetworkAvailable() {

--- a/android/expoview/src/main/java/host/exp/exponent/network/ExponentNetwork.java
+++ b/android/expoview/src/main/java/host/exp/exponent/network/ExponentNetwork.java
@@ -23,7 +23,8 @@ public class ExponentNetwork {
 
   public static final String IGNORE_INTERCEPTORS_HEADER = "exponentignoreinterceptors";
 
-  private static final String CACHE_DIR = "okhttp";
+  private static final String CACHE_DIR = "http-cache";
+  private static final String LEGACY_CACHE_DIR = "okhttp";
 
   private Context mContext;
   private ExponentHttpClient mClient;
@@ -88,10 +89,8 @@ public class ExponentNetwork {
   }
 
   public Cache getCache() {
-    int cacheSize = 40 * 1024 * 1024; // 40 MiB
-
-    // Use getFilesDir() because it gives us much more space than getCacheDir()
-    final File directory = new File(mContext.getFilesDir(), CACHE_DIR);
+    int cacheSize = 50 * 1024 * 1024; // 50 MiB
+    final File directory = new File(mContext.getCacheDir(), CACHE_DIR);
     return new Cache(directory, cacheSize);
   }
 

--- a/android/expoview/src/main/java/host/exp/exponent/network/ExponentNetwork.java
+++ b/android/expoview/src/main/java/host/exp/exponent/network/ExponentNetwork.java
@@ -101,6 +101,7 @@ public class ExponentNetwork {
     return new Cache(directory, cacheSize);
   }
 
+  // TODO: can remove this after most apps have upgraded to SDK 41 or later
   private void clearLegacyCache() {
     if (mExponentSharedPreferences.getBoolean(ExponentSharedPreferences.HAS_CLEARED_LEGACY_OKHTTP_CACHE_KEY)) {
       return;
@@ -115,7 +116,7 @@ public class ExponentNetwork {
       }
       mExponentSharedPreferences.setBoolean(ExponentSharedPreferences.HAS_CLEARED_LEGACY_OKHTTP_CACHE_KEY, true);
     } catch (Exception e) {
-      Log.e(TAG, "Failed to clear legacy OkHttp class", e);
+      Log.e(TAG, "Failed to clear legacy OkHttp cache", e);
     }
   }
 

--- a/android/expoview/src/main/java/host/exp/exponent/network/ExponentNetwork.java
+++ b/android/expoview/src/main/java/host/exp/exponent/network/ExponentNetwork.java
@@ -103,7 +103,7 @@ public class ExponentNetwork {
 
   // TODO: can remove this after most apps have upgraded to SDK 41 or later
   private void clearLegacyCache() {
-    if (mExponentSharedPreferences.getBoolean(ExponentSharedPreferences.HAS_CLEARED_LEGACY_OKHTTP_CACHE_KEY)) {
+    if (mExponentSharedPreferences.getInteger(ExponentSharedPreferences.OKHTTP_CACHE_VERSION_KEY) == 1) {
       return;
     }
 
@@ -114,7 +114,7 @@ public class ExponentNetwork {
       if (directory.exists()) {
         directory.delete();
       }
-      mExponentSharedPreferences.setBoolean(ExponentSharedPreferences.HAS_CLEARED_LEGACY_OKHTTP_CACHE_KEY, true);
+      mExponentSharedPreferences.setInteger(ExponentSharedPreferences.OKHTTP_CACHE_VERSION_KEY, 1);
     } catch (Exception e) {
       Log.e(TAG, "Failed to clear legacy OkHttp cache", e);
     }

--- a/android/expoview/src/main/java/host/exp/exponent/storage/ExponentSharedPreferences.java
+++ b/android/expoview/src/main/java/host/exp/exponent/storage/ExponentSharedPreferences.java
@@ -56,6 +56,7 @@ public class ExponentSharedPreferences {
   public static final String SAFE_MANIFEST_KEY = "safe_manifest";
   public static final String EXPO_AUTH_SESSION = "expo_auth_session";
   public static final String EXPO_AUTH_SESSION_SECRET_KEY = "sessionSecret";
+  public static final String HAS_CLEARED_LEGACY_OKHTTP_CACHE_KEY = "has_cleared_legacy_okhttp_cache";
 
   // Metadata
   public static final String EXPERIENCE_METADATA_PREFIX = "experience_metadata_";
@@ -75,6 +76,7 @@ public class ExponentSharedPreferences {
     DEFAULT_VALUES.put(IS_ONBOARDING_FINISHED_KEY, false);
     DEFAULT_VALUES.put(NUX_HAS_FINISHED_FIRST_RUN_KEY, false);
     DEFAULT_VALUES.put(SHOULD_NOT_USE_KERNEL_CACHE, false);
+    DEFAULT_VALUES.put(HAS_CLEARED_LEGACY_OKHTTP_CACHE_KEY, false);
   }
 
   private SharedPreferences mSharedPreferences;

--- a/android/expoview/src/main/java/host/exp/exponent/storage/ExponentSharedPreferences.java
+++ b/android/expoview/src/main/java/host/exp/exponent/storage/ExponentSharedPreferences.java
@@ -56,7 +56,7 @@ public class ExponentSharedPreferences {
   public static final String SAFE_MANIFEST_KEY = "safe_manifest";
   public static final String EXPO_AUTH_SESSION = "expo_auth_session";
   public static final String EXPO_AUTH_SESSION_SECRET_KEY = "sessionSecret";
-  public static final String HAS_CLEARED_LEGACY_OKHTTP_CACHE_KEY = "has_cleared_legacy_okhttp_cache";
+  public static final String OKHTTP_CACHE_VERSION_KEY = "okhttp_cache_version";
 
   // Metadata
   public static final String EXPERIENCE_METADATA_PREFIX = "experience_metadata_";
@@ -76,7 +76,6 @@ public class ExponentSharedPreferences {
     DEFAULT_VALUES.put(IS_ONBOARDING_FINISHED_KEY, false);
     DEFAULT_VALUES.put(NUX_HAS_FINISHED_FIRST_RUN_KEY, false);
     DEFAULT_VALUES.put(SHOULD_NOT_USE_KERNEL_CACHE, false);
-    DEFAULT_VALUES.put(HAS_CLEARED_LEGACY_OKHTTP_CACHE_KEY, false);
   }
 
   private SharedPreferences mSharedPreferences;
@@ -110,6 +109,18 @@ public class ExponentSharedPreferences {
 
   public void setBoolean(String key, boolean value) {
     mSharedPreferences.edit().putBoolean(key, value).apply();
+  }
+
+  public int getInteger(String key) {
+    return getInteger(key, 0);
+  }
+
+  public int getInteger(String key, int defaultValue) {
+    return mSharedPreferences.getInt(key, defaultValue);
+  }
+
+  public void setInteger(String key, int value) {
+    mSharedPreferences.edit().putInt(key, value).apply();
   }
 
   public String getString(String key) {


### PR DESCRIPTION
# Why

Follow-up to #11599. Since OTA update assets are stored in a separate location, it's better to keep the OkHttp cache in the application cache directory, rather than the files directory -- this allows the OS to clean up files if it needs to, and reduces the chance that developers' application code will unexpectedly interfere with the OkHttp cache.

# How

- Moved OkHttp cache to `Context.getCacheDir`, and renamed it to match the name of bare RN OkHttp caches.
- Added some deletion logic for the old cache in `Context.getFilesDir`. After deleting we set a key in SharedPreferences so we don't try to delete again.
- Also increased the maximum cache size to 50Mb -- this is [recommended in the OkHttp docs](https://square.github.io/okhttp/caching/). I checked [`StorageManager.getCacheQuotaBytes`](https://developer.android.com/reference/android/os/storage/StorageManager#getCacheQuotaBytes(java.util.UUID)) for the cache directory of a fresh installation of the Expo Go client on my Pixel 2, and got 64Mb. Since the cache directory also includes a few other caches (image, picasso, home experience data) 50Mb seems like a reasonable maximum size for the OkHttp cache.
- Finally, removed some extraneous logic around the OkHttpClient builder that was specifically for ExpoKit apps.

# Test Plan

Ran the same tests from #11599 again.