### PR TITLE
[expo-updates] fix origin-relative URL support in assetUrlOverride

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Use `console.warn` message rather than hard crashing if neither runtime nor SDK version are configured (requires a corresponding update to the `expo` package) ([#11367](https://github.com/expo/expo/pull/11367) by [@esamelson](https://github.com/esamelson))
 - Improved thread safety around reaping ([#11447](https://github.com/expo/expo/pull/11447) by [@esamelson](https://github.com/esamelson))
 - Fixed discrepancies across platforms regarding required fields in manifests ([#11562](https://github.com/expo/expo/pull/11562) by [@esamelson](https://github.com/esamelson))
+- Improved support for `assetUrlOverride` in legacy self-hosted apps ([#11601](https://github.com/expo/expo/pull/11601))
 
 ## 0.4.1 — 2020-11-25
 

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/manifest/LegacyManifestTest.java
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/manifest/LegacyManifestTest.java
@@ -56,6 +56,17 @@ public class LegacyManifestTest {
   }
 
   @Test
+  public void testGetAssetsUrlBase_assetUrlOverride_originRelativeUrl() throws JSONException {
+    Uri manifestUrl = Uri.parse("https://esamelson.github.io/self-hosting-test/android-index.json");
+    JSONObject manifestJson = new JSONObject();
+    manifestJson.put("assetUrlOverride", "/my_assets");
+
+    Uri expected = Uri.parse("https://esamelson.github.io/my_assets");
+    Uri actual = LegacyManifest.getAssetsUrlBase(manifestUrl, manifestJson);
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
   public void testGetAssetsUrlBase_assetUrlOverride_relativeUrlDotSlash() throws JSONException {
     Uri manifestUrl = Uri.parse("https://esamelson.github.io/self-hosting-test/android-index.json");
     JSONObject manifestJson = new JSONObject();

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/manifest/LegacyManifestTest.java
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/manifest/LegacyManifestTest.java
@@ -32,7 +32,7 @@ public class LegacyManifestTest {
   }
 
   @Test
-  public void testGetAssetsUrlBase_assetUrlOverride_absoluteUrl() throws JSONException {
+  public void testGetAssetsUrlBase_AssetUrlOverride_AbsoluteUrl() throws JSONException {
     String assetUrlBase = "https://xxx.dev/~assets";
 
     Uri manifestUrl = Uri.parse("https://esamelson.github.io/self-hosting-test/android-index.json");
@@ -45,7 +45,7 @@ public class LegacyManifestTest {
   }
 
   @Test
-  public void testGetAssetsUrlBase_assetUrlOverride_relativeUrl() throws JSONException {
+  public void testGetAssetsUrlBase_AssetUrlOverride_RelativeUrl() throws JSONException {
     Uri manifestUrl = Uri.parse("https://esamelson.github.io/self-hosting-test/android-index.json");
     JSONObject manifestJson = new JSONObject();
     manifestJson.put("assetUrlOverride", "my_assets");
@@ -56,7 +56,7 @@ public class LegacyManifestTest {
   }
 
   @Test
-  public void testGetAssetsUrlBase_assetUrlOverride_originRelativeUrl() throws JSONException {
+  public void testGetAssetsUrlBase_AssetUrlOverride_OriginRelativeUrl() throws JSONException {
     Uri manifestUrl = Uri.parse("https://esamelson.github.io/self-hosting-test/android-index.json");
     JSONObject manifestJson = new JSONObject();
     manifestJson.put("assetUrlOverride", "/my_assets");
@@ -67,7 +67,7 @@ public class LegacyManifestTest {
   }
 
   @Test
-  public void testGetAssetsUrlBase_assetUrlOverride_relativeUrlDotSlash() throws JSONException {
+  public void testGetAssetsUrlBase_AssetUrlOverride_RelativeUrlDotSlash() throws JSONException {
     Uri manifestUrl = Uri.parse("https://esamelson.github.io/self-hosting-test/android-index.json");
     JSONObject manifestJson = new JSONObject();
     manifestJson.put("assetUrlOverride", "./my_assets");
@@ -78,7 +78,7 @@ public class LegacyManifestTest {
   }
 
   @Test
-  public void testGetAssetsUrlBase_assetUrlOverride_normalize() throws JSONException {
+  public void testGetAssetsUrlBase_AssetUrlOverride_Normalize() throws JSONException {
     Uri manifestUrl = Uri.parse("https://esamelson.github.io/self-hosting-test/android-index.json");
     JSONObject manifestJson = new JSONObject();
     manifestJson.put("assetUrlOverride", "./a/../b");
@@ -89,7 +89,7 @@ public class LegacyManifestTest {
   }
 
   @Test
-  public void testGetAssetsUrlBase_assetUrlOverride_normalizeToHostname() throws JSONException {
+  public void testGetAssetsUrlBase_AssetUrlOverride_NormalizeToHostname() throws JSONException {
     Uri manifestUrl = Uri.parse("https://esamelson.github.io/self-hosting-test/android-index.json");
     JSONObject manifestJson = new JSONObject();
     manifestJson.put("assetUrlOverride", "../b");
@@ -100,7 +100,7 @@ public class LegacyManifestTest {
   }
 
   @Test
-  public void testGetAssetsUrlBase_assetUrlOverride_default() {
+  public void testGetAssetsUrlBase_AssetUrlOverride_Default() {
     Uri manifestUrl = Uri.parse("https://esamelson.github.io/self-hosting-test/android-index.json");
     JSONObject manifestJson = new JSONObject();
 

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/manifest/LegacyManifestTest.java
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/manifest/LegacyManifestTest.java
@@ -100,6 +100,17 @@ public class LegacyManifestTest {
   }
 
   @Test
+  public void testGetAssetsUrlBase_AssetUrlOverride_NormalizePastHostname() throws JSONException {
+    Uri manifestUrl = Uri.parse("https://esamelson.github.io/self-hosting-test/android-index.json");
+    JSONObject manifestJson = new JSONObject();
+    manifestJson.put("assetUrlOverride", "../../b");
+
+    Uri expected = Uri.parse("https://esamelson.github.io/b");
+    Uri actual = LegacyManifest.getAssetsUrlBase(manifestUrl, manifestJson);
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
   public void testGetAssetsUrlBase_AssetUrlOverride_Default() {
     Uri manifestUrl = Uri.parse("https://esamelson.github.io/self-hosting-test/android-index.json");
     JSONObject manifestJson = new JSONObject();

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/manifest/LegacyManifestTest.java
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/manifest/LegacyManifestTest.java
@@ -78,6 +78,28 @@ public class LegacyManifestTest {
   }
 
   @Test
+  public void testGetAssetsUrlBase_assetUrlOverride_normalize() throws JSONException {
+    Uri manifestUrl = Uri.parse("https://esamelson.github.io/self-hosting-test/android-index.json");
+    JSONObject manifestJson = new JSONObject();
+    manifestJson.put("assetUrlOverride", "./a/../b");
+
+    Uri expected = Uri.parse("https://esamelson.github.io/self-hosting-test/b");
+    Uri actual = LegacyManifest.getAssetsUrlBase(manifestUrl, manifestJson);
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void testGetAssetsUrlBase_assetUrlOverride_normalizeToHostname() throws JSONException {
+    Uri manifestUrl = Uri.parse("https://esamelson.github.io/self-hosting-test/android-index.json");
+    JSONObject manifestJson = new JSONObject();
+    manifestJson.put("assetUrlOverride", "../b");
+
+    Uri expected = Uri.parse("https://esamelson.github.io/b");
+    Uri actual = LegacyManifest.getAssetsUrlBase(manifestUrl, manifestJson);
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
   public void testGetAssetsUrlBase_assetUrlOverride_default() {
     Uri manifestUrl = Uri.parse("https://esamelson.github.io/self-hosting-test/android-index.json");
     JSONObject manifestJson = new JSONObject();

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesLegacyUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesLegacyUpdate.m
@@ -129,14 +129,7 @@ static NSString * const EXUpdatesExpoTestDomain = @"expo.test";
     NSString *assetsPathOrUrl = manifest[@"assetUrlOverride"] ?: @"assets";
     // assetUrlOverride may be an absolute or relative URL
     // if relative, we should resolve with respect to the manifest URL
-    NSURL *maybeAssetsUrl = [NSURL URLWithString:assetsPathOrUrl];
-    if (maybeAssetsUrl && maybeAssetsUrl.scheme) {
-      return maybeAssetsUrl;
-    } else if (maybeAssetsUrl && maybeAssetsUrl.standardizedURL) {
-      return [manifestUrl.URLByDeletingLastPathComponent URLByAppendingPathComponent:maybeAssetsUrl.standardizedURL.relativeString];
-    } else {
-      return [manifestUrl.URLByDeletingLastPathComponent URLByAppendingPathComponent:assetsPathOrUrl];
-    }
+    return [NSURL URLWithString:assetsPathOrUrl relativeToURL:manifestUrl.standardizedURL];
   }
 }
 

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesLegacyUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesLegacyUpdate.m
@@ -129,7 +129,7 @@ static NSString * const EXUpdatesExpoTestDomain = @"expo.test";
     NSString *assetsPathOrUrl = manifest[@"assetUrlOverride"] ?: @"assets";
     // assetUrlOverride may be an absolute or relative URL
     // if relative, we should resolve with respect to the manifest URL
-    return [NSURL URLWithString:assetsPathOrUrl relativeToURL:manifestUrl.standardizedURL];
+    return [NSURL URLWithString:assetsPathOrUrl relativeToURL:manifestUrl];
   }
 }
 

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesLegacyUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesLegacyUpdate.m
@@ -129,7 +129,7 @@ static NSString * const EXUpdatesExpoTestDomain = @"expo.test";
     NSString *assetsPathOrUrl = manifest[@"assetUrlOverride"] ?: @"assets";
     // assetUrlOverride may be an absolute or relative URL
     // if relative, we should resolve with respect to the manifest URL
-    return [NSURL URLWithString:assetsPathOrUrl relativeToURL:manifestUrl];
+    return [NSURL URLWithString:assetsPathOrUrl relativeToURL:manifestUrl].absoluteURL.standardizedURL;
   }
 }
 

--- a/packages/expo-updates/ios/Tests/EXUpdatesLegacyUpdateTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesLegacyUpdateTests.m
@@ -65,49 +65,49 @@
 {
   NSURL *relativeExpected = [NSURL URLWithString:@"https://esamelson.github.io/self-hosting-test/my_assets"];
   NSURL *relativeActual = [EXUpdatesLegacyUpdate bundledAssetBaseUrlWithManifest:@{ @"assetUrlOverride": @"my_assets" } config:_selfHostedConfig];
-  XCTAssert([relativeActual.absoluteString isEqualToString:relativeExpected.absoluteString], @"should return a URL relative to manifest URL base if it's a relative URL");
+  XCTAssert([relativeActual isEqual:relativeExpected], @"should return a URL relative to manifest URL base if it's a relative URL");
 }
 
 - (void)testBundledAssetBaseUrl_AssetUrlOverride_OriginRelativeUrl
 {
   NSURL *originRelativeExpected = [NSURL URLWithString:@"https://esamelson.github.io/my_assets"];
   NSURL *originRelativeActual = [EXUpdatesLegacyUpdate bundledAssetBaseUrlWithManifest:@{ @"assetUrlOverride": @"/my_assets" } config:_selfHostedConfig];
-  XCTAssert([originRelativeActual.absoluteString isEqualToString:originRelativeExpected.absoluteString], @"should return a URL relative to manifest URL base if it's an origin-relative URL");
+  XCTAssert([originRelativeActual isEqual:originRelativeExpected], @"should return a URL relative to manifest URL base if it's an origin-relative URL");
 }
 
 - (void)testBundledAssetBaseUrl_AssetUrlOverride_RelativeUrlDotSlash
 {
   NSURL *relativeDotSlashExpected = [NSURL URLWithString:@"https://esamelson.github.io/self-hosting-test/my_assets"];
   NSURL *relativeDotSlashActual = [EXUpdatesLegacyUpdate bundledAssetBaseUrlWithManifest:@{ @"assetUrlOverride": @"./my_assets" } config:_selfHostedConfig];
-  XCTAssert([relativeDotSlashActual.absoluteString isEqualToString:relativeDotSlashExpected.absoluteString], @"should return a URL relative to manifest URL base with `./` resolved correctly if it's a relative URL");
+  XCTAssert([relativeDotSlashActual isEqual:relativeDotSlashExpected], @"should return a URL relative to manifest URL base with `./` resolved correctly if it's a relative URL");
 }
 
 - (void)testBundledAssetBaseUrl_AssetUrlOverride_Normalize
 {
   NSURL *expected = [NSURL URLWithString:@"https://esamelson.github.io/self-hosting-test/b"];
   NSURL *actual = [EXUpdatesLegacyUpdate bundledAssetBaseUrlWithManifest:@{ @"assetUrlOverride": @"./a/../b" } config:_selfHostedConfig];
-  XCTAssert([actual.absoluteString isEqualToString:expected.absoluteString], @"should return a correctly normalized URL relative to manifest URL base");
+  XCTAssert([actual isEqual:expected], @"should return a correctly normalized URL relative to manifest URL base");
 }
 
 - (void)testBundledAssetBaseUrl_AssetUrlOverride_NormalizeToHostname
 {
   NSURL *expected = [NSURL URLWithString:@"https://esamelson.github.io/b"];
   NSURL *actual = [EXUpdatesLegacyUpdate bundledAssetBaseUrlWithManifest:@{ @"assetUrlOverride": @"../b" } config:_selfHostedConfig];
-  XCTAssert([actual.absoluteString isEqualToString:expected.absoluteString], @"should return a correctly normalized URL relative to manifest URL base if the relative path goes back to the hostname");
+  XCTAssert([actual isEqual:expected], @"should return a correctly normalized URL relative to manifest URL base if the relative path goes back to the hostname");
 }
 
 - (void)testBundledAssetBaseUrl_AssetUrlOverride_NormalizePastHostname
 {
   NSURL *expected = [NSURL URLWithString:@"https://esamelson.github.io/b"];
   NSURL *actual = [EXUpdatesLegacyUpdate bundledAssetBaseUrlWithManifest:@{ @"assetUrlOverride": @"../../b" } config:_selfHostedConfig];
-  XCTAssert([actual.absoluteString isEqualToString:expected.absoluteString], @"should return a correctly normalized URL relative to manifest URL base if the relative path goes back past the hostname");
+  XCTAssert([actual isEqual:expected], @"should return a correctly normalized URL relative to manifest URL base if the relative path goes back past the hostname");
 }
 
 - (void)testBundledAssetBaseUrl_AssetUrlOverride_Default
 {
   NSURL *defaultExpected = [NSURL URLWithString:@"https://esamelson.github.io/self-hosting-test/assets"];
   NSURL *defaultActual = [EXUpdatesLegacyUpdate bundledAssetBaseUrlWithManifest:@{} config:_selfHostedConfig];
-  XCTAssert([defaultActual.absoluteString isEqualToString:defaultExpected.absoluteString], @"should return a URL with `assets` relative to manifest URL base if unspecified");
+  XCTAssert([defaultActual isEqual:defaultExpected], @"should return a URL with `assets` relative to manifest URL base if unspecified");
 }
 
 - (void)testUpdateWithLegacyManifest_Development

--- a/packages/expo-updates/ios/Tests/EXUpdatesLegacyUpdateTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesLegacyUpdateTests.m
@@ -96,6 +96,13 @@
   XCTAssert([actual.absoluteString isEqualToString:expected.absoluteString], @"should return a correctly normalized URL relative to manifest URL base if the relative path goes back to the hostname");
 }
 
+- (void)testBundledAssetBaseUrl_AssetUrlOverride_NormalizePastHostname
+{
+  NSURL *expected = [NSURL URLWithString:@"https://esamelson.github.io/b"];
+  NSURL *actual = [EXUpdatesLegacyUpdate bundledAssetBaseUrlWithManifest:@{ @"assetUrlOverride": @"../../b" } config:_selfHostedConfig];
+  XCTAssert([actual.absoluteString isEqualToString:expected.absoluteString], @"should return a correctly normalized URL relative to manifest URL base if the relative path goes back past the hostname");
+}
+
 - (void)testBundledAssetBaseUrl_AssetUrlOverride_Default
 {
   NSURL *defaultExpected = [NSURL URLWithString:@"https://esamelson.github.io/self-hosting-test/assets"];

--- a/packages/expo-updates/ios/Tests/EXUpdatesLegacyUpdateTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesLegacyUpdateTests.m
@@ -82,6 +82,20 @@
   XCTAssert([relativeDotSlashActual.absoluteString isEqualToString:relativeDotSlashExpected.absoluteString], @"should return a URL relative to manifest URL base with `./` resolved correctly if it's a relative URL");
 }
 
+- (void)testBundledAssetBaseUrl_AssetUrlOverride_Normalize
+{
+  NSURL *expected = [NSURL URLWithString:@"https://esamelson.github.io/self-hosting-test/b"];
+  NSURL *actual = [EXUpdatesLegacyUpdate bundledAssetBaseUrlWithManifest:@{ @"assetUrlOverride": @"./a/../b" } config:_selfHostedConfig];
+  XCTAssert([actual.absoluteString isEqualToString:expected.absoluteString], @"should return a correctly normalized URL relative to manifest URL base");
+}
+
+- (void)testBundledAssetBaseUrl_AssetUrlOverride_NormalizeToHostname
+{
+  NSURL *expected = [NSURL URLWithString:@"https://esamelson.github.io/b"];
+  NSURL *actual = [EXUpdatesLegacyUpdate bundledAssetBaseUrlWithManifest:@{ @"assetUrlOverride": @"../b" } config:_selfHostedConfig];
+  XCTAssert([actual.absoluteString isEqualToString:expected.absoluteString], @"should return a correctly normalized URL relative to manifest URL base if the relative path goes back to the hostname");
+}
+
 - (void)testBundledAssetBaseUrl_AssetUrlOverride_Default
 {
   NSURL *defaultExpected = [NSURL URLWithString:@"https://esamelson.github.io/self-hosting-test/assets"];


### PR DESCRIPTION
# Why

https://github.com/expo/expo/pull/11562#pullrequestreview-564638536

# How

Got rid of all custom logic around this and now just using `java.net.URI.resolve` and `[NSURL URLWithString: relativeToURL:]` which takes care of everything (including the problematic case) for us.

# Test Plan

Added tests for the new case on both platforms. These and all existing tests pass. (Had to change the iOS tests to compare the URLs' `absoluteString` properties rather than the objects themselves, since with the new construction the `isEqual` property was not returning true even though the string representation was equal.)
