### PR TITLE
[docs] Fix amplitude.md intitailize method

### DIFF
--- a/docs/pages/versions/v40.0.0/sdk/amplitude.md
+++ b/docs/pages/versions/v40.0.0/sdk/amplitude.md
@@ -34,7 +34,7 @@ import * as Amplitude from 'expo-analytics-amplitude';
 
 ## Methods
 
-### `Amplitude.initializeAsync(apiKey)`
+### `Amplitude.initialize(apiKey)`
 
 Initializes Amplitude with your Amplitude API key. If you're having trouble finding your API key, see [step 4 of these instructions](https://amplitude.zendesk.com/hc/en-us/articles/207108137-Introduction-Getting-Started#getting-started).
 


### PR DESCRIPTION
# Why

the Amplitude.d.ts typescript  file says that initialize method is defined like this : `export declare function initialize(apiKey: string): Promise<void>;`

# How

I changed the documentation

# Test Plan

 No test plan