### PR TITLE
[expo-updates] stop expecting data and publicManifest root level keys for EAS manifests

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Use `console.warn` message rather than hard crashing if neither runtime nor SDK version are configured (requires a corresponding update to the `expo` package) ([#11367](https://github.com/expo/expo/pull/11367) by [@esamelson](https://github.com/esamelson))
 - Improved thread safety around reaping ([#11447](https://github.com/expo/expo/pull/11447) by [@esamelson](https://github.com/esamelson))
 - Fixed discrepancies across platforms regarding required fields in manifests ([#11562](https://github.com/expo/expo/pull/11562) by [@esamelson](https://github.com/esamelson))
+- Stop expecting data and publicManifest root level keys for EAS manifests ([#11613](https://github.com/expo/expo/pull/11613) by [@esamelson](https://github.com/esamelson))
 
 ## 0.4.1 — 2020-11-25
 

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/manifest/NewManifestTest.java
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/manifest/NewManifestTest.java
@@ -53,7 +53,7 @@ public class NewManifestTest {
 
   @Test
   public void testFromManifestJson_StripsOptionalRootLevelKeys() throws JSONException {
-    String manifestJsonWithRootLevelKeys = "{\"data\":{\"publicManifest\":{\"manifest\":{\"runtimeVersion\":\"1\",\"id\":\"0eef8214-4833-4089-9dff-b4138a14f196\",\"createdAt\":\"2020-11-11T00:17:54.797Z\",\"launchAsset\":{\"url\":\"https://url.to/bundle.js\",\"contentType\":\"application/javascript\"}}}}}";
+    String manifestJsonWithRootLevelKeys = "{\"manifest\":{\"runtimeVersion\":\"1\",\"id\":\"0eef8214-4833-4089-9dff-b4138a14f196\",\"createdAt\":\"2020-11-11T00:17:54.797Z\",\"launchAsset\":{\"url\":\"https://url.to/bundle.js\",\"contentType\":\"application/javascript\"}}}";
     Manifest manifest1 = NewManifest.fromManifestJson(new JSONObject(manifestJsonWithRootLevelKeys), createConfig());
 
     String manifestJsonNoRootLevelKeys = "{\"runtimeVersion\":\"1\",\"id\":\"0eef8214-4833-4089-9dff-b4138a14f196\",\"createdAt\":\"2020-11-11T00:17:54.797Z\",\"launchAsset\":{\"url\":\"https://url.to/bundle.js\",\"contentType\":\"application/javascript\"}}";

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ManifestFactory.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ManifestFactory.java
@@ -25,7 +25,8 @@ public class ManifestFactory {
         return BareManifest.fromManifestJson(manifestJson, configuration);
       }
     } else {
-      if (manifestJson.has("data") || manifestJson.has("publicManifest") || manifestJson.has("manifest")) {
+      // bare (embedded) manifests should never have a runtimeVersion field
+      if (manifestJson.has("manifest") || manifestJson.has("runtimeVersion")) {
         return NewManifest.fromManifestJson(manifestJson, configuration);
       } else {
         return BareManifest.fromManifestJson(manifestJson, configuration);

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/NewManifest.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/NewManifest.java
@@ -50,12 +50,6 @@ public class NewManifest implements Manifest {
 
   public static NewManifest fromManifestJson(JSONObject rootManifestJson, UpdatesConfiguration configuration) throws JSONException {
     JSONObject manifestJson = rootManifestJson;
-    if (rootManifestJson.has("data")) {
-      manifestJson = rootManifestJson.getJSONObject("data");
-    }
-    if (manifestJson.has("publicManifest")) {
-      manifestJson = manifestJson.getJSONObject("publicManifest");
-    }
     if (manifestJson.has("manifest")) {
       manifestJson = manifestJson.getJSONObject("manifest");
     }

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesNewUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesNewUpdate.m
@@ -15,12 +15,6 @@ NS_ASSUME_NONNULL_BEGIN
                                   database:(EXUpdatesDatabase *)database
 {
   NSDictionary *manifest = rootManifest;
-  if (rootManifest[@"data"]) {
-    manifest = rootManifest[@"data"];
-  }
-  if (manifest[@"publicManifest"]) {
-    manifest = manifest[@"publicManifest"];
-  }
   if (manifest[@"manifest"]) {
     manifest = manifest[@"manifest"];
   }

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate.m
@@ -84,7 +84,8 @@ NS_ASSUME_NONNULL_BEGIN
                                                 database:database];
     }
   } else {
-    if (manifest[@"data"] || manifest[@"publicManifest"] || manifest[@"manifest"]) {
+    // bare (embedded) manifests should never have a runtimeVersion field
+    if (manifest[@"manifest"] || manifest[@"runtimeVersion"]) {
       return [EXUpdatesNewUpdate updateWithNewManifest:manifest
                                                 config:config
                                               database:database];

--- a/packages/expo-updates/ios/Tests/EXUpdatesNewUpdateTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesNewUpdateTests.m
@@ -92,11 +92,7 @@
     @"launchAsset": @{@"url": @"https://url.to/bundle.js", @"contentType": @"application/javascript"}
   };
   NSDictionary *manifestWithRootLevelKeys = @{
-    @"data": @{
-      @"publicManifest": @{
-        @"manifest": manifestNoRootLevelKeys
-      }
-    }
+    @"manifest": manifestNoRootLevelKeys
   };
 
   EXUpdatesUpdate *update1 = [EXUpdatesNewUpdate updateWithNewManifest:manifestNoRootLevelKeys config:_config database:_database];


### PR DESCRIPTION
# Why

On a call with @ide / @jkhales today we decided that EAS Update manifests should be served without these root level keys to match the public specification.

# How

Remove handling of `data` and `publicManifest` root level keys. (Kept the `manifest` key for now, but can remove that if we decide to move `manifestFilters`/`protocolVersion` to headers.)

# Test Plan

Updated tests accordingly, all pass.