### PR TITLE
[expo-gl-cpp] implement getInternalformatParameter

### DIFF
--- a/packages/expo-gl-cpp/cpp/EXGLNativeMethods.cpp
+++ b/packages/expo-gl-cpp/cpp/EXGLNativeMethods.cpp
@@ -500,7 +500,21 @@ NATIVE_METHOD(renderbufferStorage) {
 // Renderbuffers (WebGL2)
 // ----------------------
 
-UNIMPL_NATIVE_METHOD(getInternalformatParameter)
+NATIVE_METHOD(getInternalformatParameter) {
+  auto target = ARG(0, GLenum);
+  auto internalformat = ARG(1, GLenum);
+  auto pname = ARG(2, GLenum);
+
+  std::vector<TypedArrayBase::ContentType<TypedArrayKind::Int32Array>> glResults;
+  addBlockingToNextBatch([&] {
+    GLint count;
+    glGetInternalformativ(target, internalformat, GL_NUM_SAMPLE_COUNTS, 1, &count);
+    glResults.resize(count);
+    glGetInternalformativ(target, internalformat, pname, count, glResults.data());
+  });
+
+  return TypedArray<TypedArrayKind::Int32Array>(runtime, glResults);
+}
 
 UNIMPL_NATIVE_METHOD(renderbufferStorageMultisample)
 

--- a/packages/expo-gl/CHANGELOG.md
+++ b/packages/expo-gl/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Implemented support for `getInternalformatParameter` ([#11614](https://github.com/expo/expo/pull/11614) by [@zenios](https://github.com/zenios))
+
 ### 🐛 Bug fixes
 
 - Removed `fbjs` dependency ([#11396](https://github.com/expo/expo/pull/11396) by [@cruzach](https://github.com/cruzach))


### PR DESCRIPTION
# Why

Pixi 5.3  is using it
