### PR TITLE
created expo-branch plugin

### DIFF
--- a/packages/expo-branch/CHANGELOG.md
+++ b/packages/expo-branch/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 🎉 New features
 
+- Created config plugin. ([#11623](https://github.com/expo/expo/pull/11623) by [@EvanBacon](https://github.com/EvanBacon))
+
 ### 🐛 Bug fixes
 
 ## 3.0.0 — 2020-11-17

--- a/packages/expo-branch/app.plugin.js
+++ b/packages/expo-branch/app.plugin.js
@@ -1,0 +1,1 @@
+module.exports = require('./plugin/build/withBranch')

--- a/packages/expo-branch/package.json
+++ b/packages/expo-branch/package.json
@@ -36,6 +36,7 @@
     "@unimodules/react-native-adapter": "*"
   },
   "dependencies": {
+    "@expo/config-plugins": "^1.0.13",
     "react-native-branch": "5.0.0"
   },
   "devDependencies": {

--- a/packages/expo-branch/plugin/build/withBranch.d.ts
+++ b/packages/expo-branch/plugin/build/withBranch.d.ts
@@ -1,0 +1,3 @@
+import { ConfigPlugin } from '@expo/config-plugins';
+declare const _default: ConfigPlugin<void>;
+export default _default;

--- a/packages/expo-branch/plugin/build/withBranch.js
+++ b/packages/expo-branch/plugin/build/withBranch.js
@@ -1,0 +1,12 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const config_plugins_1 = require("@expo/config-plugins");
+const withBranchAndroid_1 = require("./withBranchAndroid");
+const withBranchIOS_1 = require("./withBranchIOS");
+const pkg = require('expo-branch/package.json');
+const withBranch = config => {
+    config = withBranchAndroid_1.withBranchAndroid(config);
+    config = withBranchIOS_1.withBranchIOS(config);
+    return config;
+};
+exports.default = config_plugins_1.createRunOncePlugin(withBranch, pkg.name, pkg.version);

--- a/packages/expo-branch/plugin/build/withBranchAndroid.d.ts
+++ b/packages/expo-branch/plugin/build/withBranchAndroid.d.ts
@@ -1,0 +1,5 @@
+import { AndroidConfig } from '@expo/config-plugins';
+import { ExpoConfig } from '@expo/config-types';
+export declare const withBranchAndroid: import("@expo/config-plugins").ConfigPlugin<void>;
+export declare function getBranchApiKey(config: ExpoConfig): string | null;
+export declare function setBranchApiKey(config: ExpoConfig, androidManifest: AndroidConfig.Manifest.AndroidManifest): AndroidConfig.Manifest.AndroidManifest;

--- a/packages/expo-branch/plugin/build/withBranchAndroid.js
+++ b/packages/expo-branch/plugin/build/withBranchAndroid.js
@@ -1,0 +1,29 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.setBranchApiKey = exports.getBranchApiKey = exports.withBranchAndroid = void 0;
+const config_plugins_1 = require("@expo/config-plugins");
+const android_plugins_1 = require("@expo/config-plugins/build/plugins/android-plugins");
+const { addMetaDataItemToMainApplication, getMainApplicationOrThrow, removeMetaDataItemFromMainApplication, } = config_plugins_1.AndroidConfig.Manifest;
+const META_BRANCH_KEY = 'io.branch.sdk.BranchKey';
+exports.withBranchAndroid = android_plugins_1.createAndroidManifestPlugin(
+// @ts-ignore: @expo/config-types version mismatch
+setBranchApiKey, 'withBranchAndroid');
+function getBranchApiKey(config) {
+    var _a, _b, _c, _d;
+    return (_d = (_c = (_b = (_a = config.android) === null || _a === void 0 ? void 0 : _a.config) === null || _b === void 0 ? void 0 : _b.branch) === null || _c === void 0 ? void 0 : _c.apiKey) !== null && _d !== void 0 ? _d : null;
+}
+exports.getBranchApiKey = getBranchApiKey;
+function setBranchApiKey(config, androidManifest) {
+    const apiKey = getBranchApiKey(config);
+    const mainApplication = getMainApplicationOrThrow(androidManifest);
+    if (apiKey) {
+        // If the item exists, add it back
+        addMetaDataItemToMainApplication(mainApplication, META_BRANCH_KEY, apiKey);
+    }
+    else {
+        // Remove any existing item
+        removeMetaDataItemFromMainApplication(mainApplication, META_BRANCH_KEY);
+    }
+    return androidManifest;
+}
+exports.setBranchApiKey = setBranchApiKey;

--- a/packages/expo-branch/plugin/build/withBranchIOS.d.ts
+++ b/packages/expo-branch/plugin/build/withBranchIOS.d.ts
@@ -1,0 +1,5 @@
+import { ExpoConfig } from '@expo/config-types';
+import { InfoPlist } from '@expo/config-plugins/build/ios/IosConfig.types';
+export declare const withBranchIOS: import("@expo/config-plugins").ConfigPlugin<void>;
+export declare function getBranchApiKey(config: Pick<ExpoConfig, 'ios'>): string | null;
+export declare function setBranchApiKey(config: Pick<ExpoConfig, 'ios'>, infoPlist: InfoPlist): InfoPlist;

--- a/packages/expo-branch/plugin/build/withBranchIOS.d.ts
+++ b/packages/expo-branch/plugin/build/withBranchIOS.d.ts
@@ -1,5 +1,5 @@
-import { ExpoConfig } from '@expo/config-types';
 import { InfoPlist } from '@expo/config-plugins/build/ios/IosConfig.types';
+import { ExpoConfig } from '@expo/config-types';
 export declare const withBranchIOS: import("@expo/config-plugins").ConfigPlugin<void>;
 export declare function getBranchApiKey(config: Pick<ExpoConfig, 'ios'>): string | null;
 export declare function setBranchApiKey(config: Pick<ExpoConfig, 'ios'>, infoPlist: InfoPlist): InfoPlist;

--- a/packages/expo-branch/plugin/build/withBranchIOS.js
+++ b/packages/expo-branch/plugin/build/withBranchIOS.js
@@ -1,0 +1,23 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.setBranchApiKey = exports.getBranchApiKey = exports.withBranchIOS = void 0;
+const ios_plugins_1 = require("@expo/config-plugins/build/plugins/ios-plugins");
+exports.withBranchIOS = ios_plugins_1.createInfoPlistPlugin(setBranchApiKey, 'withBranchIOS');
+function getBranchApiKey(config) {
+    var _a, _b, _c, _d;
+    return (_d = (_c = (_b = (_a = config.ios) === null || _a === void 0 ? void 0 : _a.config) === null || _b === void 0 ? void 0 : _b.branch) === null || _c === void 0 ? void 0 : _c.apiKey) !== null && _d !== void 0 ? _d : null;
+}
+exports.getBranchApiKey = getBranchApiKey;
+function setBranchApiKey(config, infoPlist) {
+    const apiKey = getBranchApiKey(config);
+    if (apiKey === null) {
+        return infoPlist;
+    }
+    return {
+        ...infoPlist,
+        branch_key: {
+            live: apiKey,
+        },
+    };
+}
+exports.setBranchApiKey = setBranchApiKey;

--- a/packages/expo-branch/plugin/jest.config.js
+++ b/packages/expo-branch/plugin/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = require('expo-module-scripts/jest-preset-plugin');

--- a/packages/expo-branch/plugin/src/__tests__/fixtures/react-native-AndroidManifest.xml
+++ b/packages/expo-branch/plugin/src/__tests__/fixtures/react-native-AndroidManifest.xml
@@ -1,0 +1,24 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  package="com.expo.mycoolapp">
+    <uses-permission android:name="android.permission.INTERNET" />
+    <application
+      android:name=".MainApplication"
+      android:label="@string/app_name"
+      android:icon="@mipmap/ic_launcher"
+      android:roundIcon="@mipmap/ic_launcher_round"
+      android:allowBackup="true"
+      android:theme="@style/AppTheme">
+      <activity
+        android:name=".MainActivity"
+        android:launchMode="singleTask"
+        android:label="@string/app_name"
+        android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
+        android:windowSoftInputMode="adjustResize">
+        <intent-filter>
+            <action android:name="android.intent.action.MAIN" />
+            <category android:name="android.intent.category.LAUNCHER" />
+        </intent-filter>
+      </activity>
+      <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
+    </application>
+</manifest>

--- a/packages/expo-branch/plugin/src/__tests__/withBranchAndroid-test.ts
+++ b/packages/expo-branch/plugin/src/__tests__/withBranchAndroid-test.ts
@@ -1,0 +1,45 @@
+import { AndroidConfig } from '@expo/config-plugins';
+import { resolve } from 'path';
+
+import { getBranchApiKey, setBranchApiKey } from '../withBranchAndroid';
+
+const { findMetaDataItem, getMainApplication, readAndroidManifestAsync } = AndroidConfig.Manifest;
+
+const fixturesPath = resolve(__dirname, 'fixtures');
+
+const sampleManifestPath = resolve(fixturesPath, 'react-native-AndroidManifest.xml');
+
+describe(getBranchApiKey, () => {
+  it(`returns null if no android branch api key is provided`, () => {
+    expect(getBranchApiKey({ android: { config: {} } } as any)).toBe(null);
+  });
+
+  it(`returns apikey if android branch api key is provided`, () => {
+    expect(
+      getBranchApiKey({ android: { config: { branch: { apiKey: 'MY-API-KEY' } } } } as any)
+    ).toBe('MY-API-KEY');
+  });
+});
+
+describe(setBranchApiKey, () => {
+  it('sets branch api key in AndroidManifest.xml if given', async () => {
+    let androidManifestJson = await readAndroidManifestAsync(sampleManifestPath);
+    androidManifestJson = await setBranchApiKey(
+      { android: { config: { branch: { apiKey: 'MY-API-KEY' } } } } as any,
+      androidManifestJson
+    );
+    let mainApplication = getMainApplication(androidManifestJson);
+
+    expect(findMetaDataItem(mainApplication, 'io.branch.sdk.BranchKey')).toBeGreaterThan(-1);
+
+    // Unset the item
+
+    androidManifestJson = await setBranchApiKey(
+      { android: { config: { branch: { apiKey: null } } } } as any,
+      androidManifestJson
+    );
+    mainApplication = getMainApplication(androidManifestJson);
+
+    expect(findMetaDataItem(mainApplication, 'io.branch.sdk.BranchKey')).toBe(-1);
+  });
+});

--- a/packages/expo-branch/plugin/src/__tests__/withBranchIOS-test.ts
+++ b/packages/expo-branch/plugin/src/__tests__/withBranchIOS-test.ts
@@ -1,0 +1,25 @@
+import { getBranchApiKey, setBranchApiKey } from '../withBranchIOS';
+
+describe(getBranchApiKey, () => {
+  it(`returns null if no api key is provided`, () => {
+    expect(getBranchApiKey({})).toBe(null);
+  });
+
+  it(`returns the api key if provided`, () => {
+    expect(getBranchApiKey({ ios: { config: { branch: { apiKey: '123' } } } })).toBe('123');
+  });
+});
+
+describe(setBranchApiKey, () => {
+  it(`sets branch_key.live if the api key is given`, () => {
+    expect(setBranchApiKey({ ios: { config: { branch: { apiKey: '123' } } } }, {})).toMatchObject({
+      branch_key: {
+        live: '123',
+      },
+    });
+  });
+
+  it(`makes no changes to the infoPlist no api key is provided`, () => {
+    expect(setBranchApiKey({}, {})).toMatchObject({});
+  });
+});

--- a/packages/expo-branch/plugin/src/withBranch.ts
+++ b/packages/expo-branch/plugin/src/withBranch.ts
@@ -1,0 +1,14 @@
+import { ConfigPlugin, createRunOncePlugin } from '@expo/config-plugins';
+
+import { withBranchAndroid } from './withBranchAndroid';
+import { withBranchIOS } from './withBranchIOS';
+
+const pkg = require('expo-branch/package.json');
+
+const withBranch: ConfigPlugin = config => {
+  config = withBranchAndroid(config);
+  config = withBranchIOS(config);
+  return config;
+};
+
+export default createRunOncePlugin(withBranch, pkg.name, pkg.version);

--- a/packages/expo-branch/plugin/src/withBranchAndroid.ts
+++ b/packages/expo-branch/plugin/src/withBranchAndroid.ts
@@ -1,0 +1,39 @@
+import { AndroidConfig } from '@expo/config-plugins';
+import { createAndroidManifestPlugin } from '@expo/config-plugins/build/plugins/android-plugins';
+import { ExpoConfig } from '@expo/config-types';
+
+const {
+  addMetaDataItemToMainApplication,
+  getMainApplicationOrThrow,
+  removeMetaDataItemFromMainApplication,
+} = AndroidConfig.Manifest;
+
+const META_BRANCH_KEY = 'io.branch.sdk.BranchKey';
+
+export const withBranchAndroid = createAndroidManifestPlugin(
+  // @ts-ignore: @expo/config-types version mismatch
+  setBranchApiKey,
+  'withBranchAndroid'
+);
+
+export function getBranchApiKey(config: ExpoConfig) {
+  return config.android?.config?.branch?.apiKey ?? null;
+}
+
+export function setBranchApiKey(
+  config: ExpoConfig,
+  androidManifest: AndroidConfig.Manifest.AndroidManifest
+) {
+  const apiKey = getBranchApiKey(config);
+
+  const mainApplication = getMainApplicationOrThrow(androidManifest);
+
+  if (apiKey) {
+    // If the item exists, add it back
+    addMetaDataItemToMainApplication(mainApplication, META_BRANCH_KEY, apiKey);
+  } else {
+    // Remove any existing item
+    removeMetaDataItemFromMainApplication(mainApplication, META_BRANCH_KEY);
+  }
+  return androidManifest;
+}

--- a/packages/expo-branch/plugin/src/withBranchIOS.ts
+++ b/packages/expo-branch/plugin/src/withBranchIOS.ts
@@ -1,6 +1,6 @@
-import { ExpoConfig } from '@expo/config-types';
-import { createInfoPlistPlugin } from '@expo/config-plugins/build/plugins/ios-plugins';
 import { InfoPlist } from '@expo/config-plugins/build/ios/IosConfig.types';
+import { createInfoPlistPlugin } from '@expo/config-plugins/build/plugins/ios-plugins';
+import { ExpoConfig } from '@expo/config-types';
 
 export const withBranchIOS = createInfoPlistPlugin(setBranchApiKey, 'withBranchIOS');
 

--- a/packages/expo-branch/plugin/src/withBranchIOS.ts
+++ b/packages/expo-branch/plugin/src/withBranchIOS.ts
@@ -1,0 +1,24 @@
+import { ExpoConfig } from '@expo/config-types';
+import { createInfoPlistPlugin } from '@expo/config-plugins/build/plugins/ios-plugins';
+import { InfoPlist } from '@expo/config-plugins/build/ios/IosConfig.types';
+
+export const withBranchIOS = createInfoPlistPlugin(setBranchApiKey, 'withBranchIOS');
+
+export function getBranchApiKey(config: Pick<ExpoConfig, 'ios'>) {
+  return config.ios?.config?.branch?.apiKey ?? null;
+}
+
+export function setBranchApiKey(config: Pick<ExpoConfig, 'ios'>, infoPlist: InfoPlist): InfoPlist {
+  const apiKey = getBranchApiKey(config);
+
+  if (apiKey === null) {
+    return infoPlist;
+  }
+
+  return {
+    ...infoPlist,
+    branch_key: {
+      live: apiKey,
+    },
+  };
+}

--- a/packages/expo-branch/plugin/tsconfig.json
+++ b/packages/expo-branch/plugin/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "expo-module-scripts/tsconfig.plugin",
+  "compilerOptions": {
+    "outDir": "build",
+    "rootDir": "src"
+  },
+  "include": ["./src"],
+  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+}

--- a/packages/expo-module-scripts/jest-preset-plugin.js
+++ b/packages/expo-module-scripts/jest-preset-plugin.js
@@ -1,5 +1,10 @@
-const createJestPreset = require('./createJestPreset');
+const nodePreset = {
+  testEnvironment: 'node',
+  testRegex: '/__tests__/.*(test|spec)\\.[jt]sx?$',
+  transform: {
+    '^.+\\.[jt]sx?$': ['babel-jest', { configFile: require.resolve('./babel.config.base.js') }],
+  },
+  watchPlugins: ['jest-watch-typeahead/filename', 'jest-watch-typeahead/testname'],
+};
 
-const nodePreset = createJestPreset(require('jest-expo/node/jest-preset'));
-
-module.exports = nodePreset
+module.exports = nodePreset;


### PR DESCRIPTION
# How

- Copied the unversioned plugin into the versioned expo-branch package https://github.com/expo/expo/issues/11561
- Simplified node jest preset for plugins

# Test Plan

- Created plugin tests
- Ran `EXPO_DEBUG=1 expo prebuild` and examined that the printed config's `_internal.pluginHistory['expo-branch'].version` was `3.0.0` instead of `UNVERSIONED` (i.e. used the versioned plugin instead of the built-in CLI plugin).