### PR TITLE
[dev-menu]  Add support for screens & links

### DIFF
--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/modules/DevLauncherDevMenuExtensions.java
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/modules/DevLauncherDevMenuExtensions.java
@@ -8,13 +8,13 @@ import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Collections;
 import java.util.List;
 
 import expo.interfaces.devmenu.DevMenuExtensionInterface;
-import expo.interfaces.devmenu.items.DevMenuAction;
-import expo.interfaces.devmenu.items.DevMenuItem;
 import expo.interfaces.devmenu.items.DevMenuItemImportance;
+import expo.interfaces.devmenu.items.DevMenuItemsContainer;
+import expo.interfaces.devmenu.items.DevMenuItemsContainerInterface;
+import expo.interfaces.devmenu.items.DevMenuScreen;
 import expo.interfaces.devmenu.items.KeyCommand;
 import expo.modules.devlauncher.DevLauncherController;
 import kotlin.Unit;
@@ -32,16 +32,28 @@ public class DevLauncherDevMenuExtensions extends ReactContextBaseJavaModule imp
 
   @Nullable
   @Override
-  public List<DevMenuItem> devMenuItems() {
-    DevMenuAction backToLauncher = new DevMenuAction("dev-launcher-back-to-launcher", () -> {
+  public DevMenuItemsContainerInterface devMenuItems() {
+    DevMenuItemsContainer container = new DevMenuItemsContainer();
+
+    container.action("dev-launcher-back-to-launcher", () -> {
       DevLauncherController.getInstance().navigateToLauncher();
       return Unit.INSTANCE;
+    }, devMenuAction -> {
+
+      devMenuAction.setEnabled(() -> true);
+      devMenuAction.setLabel(() -> "Back to launcher");
+      devMenuAction.setGlyphName(() -> "exit-to-app");
+      devMenuAction.setImportance(DevMenuItemImportance.HIGH.getValue());
+      devMenuAction.setKeyCommand(new KeyCommand(KeyEvent.KEYCODE_L, false));
+
+      return Unit.INSTANCE;
     });
-    backToLauncher.setEnabled(() -> true);
-    backToLauncher.setLabel(() -> "Back to launcher");
-    backToLauncher.setGlyphName(() -> "exit-to-app");
-    backToLauncher.setImportance(DevMenuItemImportance.HIGH.getValue());
-    backToLauncher.setKeyCommand(new KeyCommand(KeyEvent.KEYCODE_L, false));
-    return Collections.singletonList(backToLauncher);
+    return container;
+  }
+
+  @Nullable
+  @Override
+  public List<DevMenuScreen> devMenuScreens() {
+    return null;
   }
 }

--- a/packages/expo-dev-launcher/ios/EXDevLauncherDevMenuExtensions.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherDevMenuExtensions.m
@@ -11,11 +11,12 @@
 // Need to explicitly define `moduleName` here for dev menu to pick it up
 RCT_EXTERN void RCTRegisterModule(Class);
 
-+(NSString *)moduleName
++ (NSString *)moduleName
 {
   return @"ExpoDevelopmentClientDevMenuExtensions";
 }
-+(void)load
+
++ (void)load
 {
   RCTRegisterModule(self);
 }
@@ -24,7 +25,10 @@ RCT_EXTERN void RCTRegisterModule(Class);
   return YES;
 }
 
--(NSArray<DevMenuItem *> *)devMenuItems {
+- (id<DevMenuItemsContainerProtocol>)devMenuItems
+{
+  DevMenuItemsContainer *container = [DevMenuItemsContainer new];
+  
   DevMenuAction *backToLauncher = [[DevMenuAction alloc] initWithId:@"backToLauncher" action:^{
     dispatch_async(dispatch_get_main_queue(), ^{
       EXDevLauncherController *controller = [EXDevLauncherController sharedInstance];
@@ -35,7 +39,9 @@ RCT_EXTERN void RCTRegisterModule(Class);
   backToLauncher.glyphName = ^{ return @"exit-to-app"; };
   backToLauncher.importance = DevMenuItemImportanceHigh;
   [backToLauncher registerKeyCommandWithInput:@"L" modifiers:UIKeyModifierCommand];
-  return @[backToLauncher];
+  
+  [container addItem:backToLauncher];
+  return container;
 }
 
 @end

--- a/packages/expo-dev-menu-interface/android/src/main/java/expo/interfaces/devmenu/DevMenuExtensionInterface.kt
+++ b/packages/expo-dev-menu-interface/android/src/main/java/expo/interfaces/devmenu/DevMenuExtensionInterface.kt
@@ -10,7 +10,7 @@ interface DevMenuExtensionInterface {
   fun getName(): String
 
   /**
-   * Returns an `DevMenuItemsContainer` that contains the dev menu items to show on the main screen.
+   * Returns a `DevMenuItemsContainer` that contains the dev menu items to show on the main screen.
    * It's called only once for the extension instance — results are being cached on first dev menu launch.
    */
   fun devMenuItems(): DevMenuItemsContainerInterface?

--- a/packages/expo-dev-menu-interface/android/src/main/java/expo/interfaces/devmenu/DevMenuExtensionInterface.kt
+++ b/packages/expo-dev-menu-interface/android/src/main/java/expo/interfaces/devmenu/DevMenuExtensionInterface.kt
@@ -1,6 +1,7 @@
 package expo.interfaces.devmenu
 
-import expo.interfaces.devmenu.items.DevMenuItem
+import expo.interfaces.devmenu.items.DevMenuItemsContainerInterface
+import expo.interfaces.devmenu.items.DevMenuScreen
 
 interface DevMenuExtensionInterface {
   /**
@@ -9,8 +10,10 @@ interface DevMenuExtensionInterface {
   fun getName(): String
 
   /**
-   * Returns an array of the dev menu items to show.
+   * Returns an `DevMenuItemsContainer` that contains the dev menu items to show on the main screen.
    * It's called only once for the extension instance — results are being cached on first dev menu launch.
    */
-  fun devMenuItems(): List<DevMenuItem>?
+  fun devMenuItems(): DevMenuItemsContainerInterface?
+
+  fun devMenuScreens(): List<DevMenuScreen>? = null
 }

--- a/packages/expo-dev-menu-interface/android/src/main/java/expo/interfaces/devmenu/DevMenuManagerInterface.kt
+++ b/packages/expo-dev-menu-interface/android/src/main/java/expo/interfaces/devmenu/DevMenuManagerInterface.kt
@@ -61,6 +61,11 @@ interface DevMenuManagerInterface {
   fun serializedItems(): List<Bundle>
 
   /**
+   * @return a list of dev menu screens serialized to the [Bundle].
+   */
+  fun serializedScreens(): List<Bundle>
+
+  /**
    * @return a instance of [DevMenuSessionInterface] that keeps the details of the currently opened dev menu session,
    * or `null` if menu isn't opened.
    */
@@ -81,4 +86,9 @@ interface DevMenuManagerInterface {
    * Synchronizes [ReactInstanceManager] from delegate with one saved in [DevMenuManger].
    */
   fun synchronizeDelegate()
+
+  /**
+   * Set the current screen on which all action will be dispatched.
+   */
+  fun setCurrentScreen(screen: String?)
 }

--- a/packages/expo-dev-menu-interface/android/src/main/java/expo/interfaces/devmenu/items/DevMenuItems.kt
+++ b/packages/expo-dev-menu-interface/android/src/main/java/expo/interfaces/devmenu/items/DevMenuItems.kt
@@ -12,37 +12,65 @@ data class KeyCommand(val code: Int, val withShift: Boolean = false)
  * An abstract representation of the single dev menu item.
  */
 sealed class DevMenuItem {
-  var isAvailable = { true }
-  var isEnabled = { false }
-  var label = { "" }
-  var detail = { "" }
-  var glyphName = { "" }
-  var importance = DevMenuItemImportance.MEDIUM.value
-
   /**
    * Represent how this item will be treated by the js.
    *  1 - [DevMenuAction]
    *  2 - [DevMenuGroup]
+   *  3 - [DevMenuScreen]
+   *  4 - [DevMenuLink]
    */
   abstract fun getExportedType(): Int
 
   open fun serialize() = Bundle().apply {
     putInt("type", getExportedType())
-    putBoolean("isAvailable", isAvailable())
-    putBoolean("isEnabled", isEnabled())
-    putString("label", label())
-    putString("detail", detail())
-    putString("glyphName", glyphName())
   }
 }
 
-class DevMenuAction(val actionId: String, val action: () -> Unit) : DevMenuItem() {
+abstract class DevMenuScreenItem : DevMenuItem() {
+  var importance = DevMenuItemImportance.MEDIUM.value
+}
+
+class DevMenuScreen(
+  val screenName: String,
+  itemsContainer: DevMenuDSLItemsContainerInterface = DevMenuItemsContainer()
+) : DevMenuItem(), DevMenuDSLItemsContainerInterface by itemsContainer {
+  override fun getExportedType() = 3
+
+  override fun serialize() = super.serialize().apply {
+    putString("screenName", screenName)
+    putParcelableArray("items", serializeItems())
+  }
+}
+
+class DevMenuGroup(
+  itemsContainer: DevMenuDSLItemsContainerInterface = DevMenuItemsContainer()
+) : DevMenuScreenItem(), DevMenuDSLItemsContainerInterface by itemsContainer {
+  override fun getExportedType() = 2
+
+  override fun serialize() = super.serialize().apply {
+    putParcelableArray("items", serializeItems())
+  }
+}
+
+class DevMenuAction(val actionId: String, val action: () -> Unit) : DevMenuScreenItem() {
+  var isAvailable = { true }
+  var isEnabled = { false }
+  var label = { "" }
+  var detail = { "" }
+  var glyphName = { "" }
+
   var keyCommand: KeyCommand? = null
 
   override fun getExportedType() = 1
 
   override fun serialize() = super.serialize().apply {
     putString("actionId", actionId)
+
+    putBoolean("isAvailable", isAvailable())
+    putBoolean("isEnabled", isEnabled())
+    putString("label", label())
+    putString("detail", detail())
+    putString("glyphName", glyphName())
 
     putBundle("keyCommand", keyCommand?.let { keyCommand ->
       Bundle().apply {
@@ -60,15 +88,15 @@ class DevMenuAction(val actionId: String, val action: () -> Unit) : DevMenuItem(
   }
 }
 
-class DevMenuGroup(private val groupName: String) : DevMenuItem() {
-  private val items: ArrayList<DevMenuItem> = ArrayList()
+class DevMenuLink(private val target: String) : DevMenuScreenItem() {
+  var label = { "" }
+  var glyphName = { "" }
 
-  fun addItem(item: DevMenuItem) = items.add(item)
-
-  override fun getExportedType() = 2
+  override fun getExportedType() = 4
 
   override fun serialize() = super.serialize().apply {
-    putString("groupName", groupName)
-    putParcelableArray("items", items.map { it.serialize() }.toTypedArray())
+    putString("target", target)
+    putString("label", label())
+    putString("glyphName", glyphName())
   }
 }

--- a/packages/expo-dev-menu-interface/android/src/main/java/expo/interfaces/devmenu/items/DevMenuItems.kt
+++ b/packages/expo-dev-menu-interface/android/src/main/java/expo/interfaces/devmenu/items/DevMenuItems.kt
@@ -18,6 +18,7 @@ sealed class DevMenuItem {
    *  2 - [DevMenuGroup]
    *  3 - [DevMenuScreen]
    *  4 - [DevMenuLink]
+   *  5 - [DevMenuSelectionList]
    */
   abstract fun getExportedType(): Int
 
@@ -98,5 +99,46 @@ class DevMenuLink(private val target: String) : DevMenuScreenItem() {
     putString("target", target)
     putString("label", label())
     putString("glyphName", glyphName())
+  }
+}
+
+class DevMenuSelectionList : DevMenuScreenItem() {
+  class Item {
+    class Tag {
+      var glyphName = { "" }
+      var text = { "" }
+
+      internal fun serialize() = Bundle().apply {
+        putString("text", text())
+        putString("glyphName", glyphName())
+      }
+    }
+
+    var title = { "" }
+    var tags: () -> List<Tag> = { emptyList() }
+    var warning: () -> String? = { null }
+    var isChecked = { false }
+
+    internal fun serialize() = Bundle().apply {
+      putString("title", title())
+      putString("warning", warning())
+      putBoolean("isChecked", isChecked())
+      putParcelableArray("tags", tags().map { it.serialize() }.toTypedArray())
+
+    }
+  }
+
+  private var items = ArrayList<Item>()
+
+  fun addItem(item: Item) {
+    items.add(item)
+  }
+
+  override fun getExportedType(): Int {
+    return 5
+  }
+
+  override fun serialize() = super.serialize().apply {
+    putParcelableArray("items", items.map { it.serialize() }.toTypedArray())
   }
 }

--- a/packages/expo-dev-menu-interface/android/src/main/java/expo/interfaces/devmenu/items/DevMenuItemsContainer.kt
+++ b/packages/expo-dev-menu-interface/android/src/main/java/expo/interfaces/devmenu/items/DevMenuItemsContainer.kt
@@ -35,6 +35,8 @@ open class DevMenuItemsContainer : DevMenuDSLItemsContainerInterface {
 
   override fun link(target: String, init: DevMenuLink.() -> Unit) = addItem(DevMenuLink(target), init)
 
+  override fun selectionList(init: DevMenuSelectionList.() -> Unit) = addItem(DevMenuSelectionList(), init)
+
   override fun serializeItems() =
     getRootItems()
       .map { it.serialize() }

--- a/packages/expo-dev-menu-interface/android/src/main/java/expo/interfaces/devmenu/items/DevMenuItemsContainer.kt
+++ b/packages/expo-dev-menu-interface/android/src/main/java/expo/interfaces/devmenu/items/DevMenuItemsContainer.kt
@@ -1,0 +1,57 @@
+package expo.interfaces.devmenu.items
+
+import java.util.*
+import kotlin.collections.ArrayList
+
+open class DevMenuItemsContainer : DevMenuDSLItemsContainerInterface {
+  private val items: ArrayList<DevMenuScreenItem> = ArrayList()
+
+  override fun getRootItems(): List<DevMenuScreenItem> {
+    items.sortedBy { it.importance }
+    return items.toList()
+  }
+
+  override fun getAllItems(): List<DevMenuScreenItem> {
+    val result = LinkedList<DevMenuScreenItem>()
+
+    items.forEach {
+      result.add(it)
+
+      if (it is DevMenuDSLItemsContainerInterface) {
+        result.addAll(it.getAllItems())
+      }
+    }
+    return result
+  }
+
+  override fun addItem(item: DevMenuScreenItem) {
+    items.add(item)
+  }
+
+  override fun group(init: DevMenuGroup.() -> Unit) = addItem(DevMenuGroup(), init)
+
+  override fun action(actionId: String, action: () -> Unit, init: DevMenuAction.() -> Unit) =
+    addItem(DevMenuAction(actionId, action), init)
+
+  override fun link(target: String, init: DevMenuLink.() -> Unit) = addItem(DevMenuLink(target), init)
+
+  override fun serializeItems() =
+    getRootItems()
+      .map { it.serialize() }
+      .toTypedArray()
+
+  private fun <T : DevMenuScreenItem> addItem(item: T, init: T.() -> Unit): T {
+    item.init()
+    addItem(item)
+    return item
+  }
+
+  companion object {
+    fun export(init: DevMenuDSLItemsContainerInterface.() -> Unit): DevMenuItemsContainer {
+      val container = DevMenuItemsContainer()
+      container.init()
+      return container
+    }
+
+  }
+}

--- a/packages/expo-dev-menu-interface/android/src/main/java/expo/interfaces/devmenu/items/DevMenuItemsContainerInterface.kt
+++ b/packages/expo-dev-menu-interface/android/src/main/java/expo/interfaces/devmenu/items/DevMenuItemsContainerInterface.kt
@@ -1,0 +1,27 @@
+package expo.interfaces.devmenu.items
+
+import android.os.Bundle
+
+interface DevMenuItemsContainerInterface {
+  fun getRootItems(): List<DevMenuScreenItem>
+  fun getAllItems(): List<DevMenuScreenItem>
+  fun addItem(item: DevMenuScreenItem)
+  fun serializeItems(): Array<Bundle>
+}
+
+inline fun <reified T> DevMenuItemsContainerInterface.getItemsOfType(): List<T> {
+  return getAllItems().filterIsInstance<T>()
+}
+
+interface DevMenuDSLItemsContainerInterface : DevMenuItemsContainerInterface {
+  fun group(init: DevMenuGroup.() -> Unit): DevMenuGroup
+  fun action(actionId: String, action: () -> Unit, init: DevMenuAction.() -> Unit): DevMenuAction
+  fun link(target: String, init: DevMenuLink.() -> Unit): DevMenuLink
+}
+
+fun screen(name: String, init: DevMenuScreen.() -> Unit): DevMenuScreen {
+  val screen = DevMenuScreen(name)
+  screen.init()
+  return screen
+}
+

--- a/packages/expo-dev-menu-interface/android/src/main/java/expo/interfaces/devmenu/items/DevMenuItemsContainerInterface.kt
+++ b/packages/expo-dev-menu-interface/android/src/main/java/expo/interfaces/devmenu/items/DevMenuItemsContainerInterface.kt
@@ -17,6 +17,7 @@ interface DevMenuDSLItemsContainerInterface : DevMenuItemsContainerInterface {
   fun group(init: DevMenuGroup.() -> Unit): DevMenuGroup
   fun action(actionId: String, action: () -> Unit, init: DevMenuAction.() -> Unit): DevMenuAction
   fun link(target: String, init: DevMenuLink.() -> Unit): DevMenuLink
+  fun selectionList(init: DevMenuSelectionList.() -> Unit): DevMenuSelectionList
 }
 
 fun screen(name: String, init: DevMenuScreen.() -> Unit): DevMenuScreen {

--- a/packages/expo-dev-menu-interface/ios/DevMenuExtensionProtocol.swift
+++ b/packages/expo-dev-menu-interface/ios/DevMenuExtensionProtocol.swift
@@ -16,6 +16,9 @@ public protocol DevMenuExtensionProtocol {
    It's called only once for the extension instance — results are being cached on first dev menu launch.
    */
   @objc
-  optional func devMenuItems() -> [DevMenuItem]?
+  optional func devMenuItems() -> DevMenuItemsContainerProtocol?
+  
+  @objc
+  optional func devMenuScreens() -> [DevMenuScreen]?
 }
  

--- a/packages/expo-dev-menu-interface/ios/MenuItems/DevMenuAction.swift
+++ b/packages/expo-dev-menu-interface/ios/MenuItems/DevMenuAction.swift
@@ -1,7 +1,7 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
 @objc
-open class DevMenuAction: DevMenuItem {
+open class DevMenuAction: DevMenuScreenItem {
   @objc
   public let actionId: String
 
@@ -10,6 +10,21 @@ open class DevMenuAction: DevMenuItem {
 
   @objc
   public var keyCommand: UIKeyCommand?
+  
+  @objc
+  open var isAvailable: () -> Bool = { true }
+
+  @objc
+  open var isEnabled: () -> Bool = { false }
+
+  @objc
+  open var label: () -> String = { "" }
+
+  @objc
+  open var detail: () -> String = { "" }
+
+  @objc
+  open var glyphName: () -> String = { "" }
 
   @objc
   public init(withId id: String) {
@@ -24,6 +39,11 @@ open class DevMenuAction: DevMenuItem {
   }
 
   @objc
+  open func registerKeyCommand(input: String, modifiers: UIKeyModifierFlags) {
+    keyCommand = UIKeyCommand(input: input, modifierFlags: modifiers, action: #selector(DevMenuUIResponderExtensionProtocol.EXDevMenu_handleKeyCommand(_:)))
+  }
+  
+  @objc
   open override func serialize() -> [String : Any] {
     var dict = super.serialize()
     dict["actionId"] = actionId
@@ -31,12 +51,14 @@ open class DevMenuAction: DevMenuItem {
       "input": keyCommand!.input,
       "modifiers": exportKeyCommandModifiers()
     ]
-    return dict
-  }
+    
+    dict["isAvailable"] = isAvailable()
+    dict["isEnabled"] = isAvailable()
+    dict["label"] = label()
+    dict["detail"] = detail()
+    dict["glyphName"] = glyphName()
 
-  @objc
-  open func registerKeyCommand(input: String, modifiers: UIKeyModifierFlags) {
-    keyCommand = UIKeyCommand(input: input, modifierFlags: modifiers, action: #selector(DevMenuUIResponderExtensionProtocol.EXDevMenu_handleKeyCommand(_:)))
+    return dict
   }
   
   private func exportKeyCommandModifiers() -> Int {

--- a/packages/expo-dev-menu-interface/ios/MenuItems/DevMenuItem.swift
+++ b/packages/expo-dev-menu-interface/ios/MenuItems/DevMenuItem.swift
@@ -8,6 +8,7 @@ open class DevMenuItem: NSObject {
     case Group = 2
     case Screen = 3
     case Link = 4
+    case SelectionList = 5
   }
 
   @objc

--- a/packages/expo-dev-menu-interface/ios/MenuItems/DevMenuItem.swift
+++ b/packages/expo-dev-menu-interface/ios/MenuItems/DevMenuItem.swift
@@ -6,45 +6,12 @@ open class DevMenuItem: NSObject {
   public enum ItemType: Int {
     case Action = 1
     case Group = 2
-  }
-
-  // Static members fit better than enum as we allow any other number.
-  static public let ImportanceLowest = -200
-  static public let ImportanceLow = -100
-  static public let ImportanceMedium = 0
-  static public let ImportanceHigh = 100
-  static public let ImportanceHighest = 200
-
-  // This enum is just for Objective-C compatibility, where values are automatically casted to integers.
-  @objc(DevMenuItemImportance)
-  public enum ItemImportance: Int {
-    case Lowest = -200
-    case Low = -100
-    case Medium = 0
-    case High = 100
-    case Highest = 200
+    case Screen = 3
+    case Link = 4
   }
 
   @objc
   public let type: ItemType
-
-  @objc
-  open var isAvailable: () -> Bool = { true }
-
-  @objc
-  open var isEnabled: () -> Bool = { false }
-
-  @objc
-  open var label: () -> String = { "" }
-
-  @objc
-  open var detail: () -> String = { "" }
-
-  @objc
-  open var glyphName: () -> String = { "" }
-
-  @objc
-  open var importance: Int = ItemImportance.Medium.rawValue
 
   init(type: ItemType) {
     self.type = type
@@ -54,11 +21,6 @@ open class DevMenuItem: NSObject {
   open func serialize() -> [String : Any] {
     return [
       "type": type.rawValue,
-      "isAvailable": isAvailable(),
-      "isEnabled": isEnabled(),
-      "label": label(),
-      "detail": detail(),
-      "glyphName": glyphName()
     ]
   }
 }

--- a/packages/expo-dev-menu-interface/ios/MenuItems/DevMenuItemsContainer.swift
+++ b/packages/expo-dev-menu-interface/ios/MenuItems/DevMenuItemsContainer.swift
@@ -1,0 +1,29 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+@objc
+public class DevMenuItemsContainer: NSObject, DevMenuItemsContainerProtocol {
+  private var items: [DevMenuScreenItem] = []
+  
+  public func getRootItems() -> [DevMenuScreenItem] {
+    return items.sorted { $0.importance > $1.importance }
+  }
+  
+  public func getAllItems() -> [DevMenuScreenItem] {
+    var result: [DevMenuScreenItem] = []
+    for item in items {
+      result.append(item)
+      if let container = item as? DevMenuItemsContainerProtocol {
+        result.append(contentsOf: container.getAllItems())
+      }
+    }
+    return result.sorted { $0.importance > $1.importance }
+  }
+  
+  public func addItem(_ item: DevMenuScreenItem) {
+    items.append(item)
+  }
+  
+  public func serializeItems() -> [[String : Any]] {
+    return getRootItems().map({ $0.serialize() })
+  }
+}

--- a/packages/expo-dev-menu-interface/ios/MenuItems/DevMenuItemsContainerProtocol.swift
+++ b/packages/expo-dev-menu-interface/ios/MenuItems/DevMenuItemsContainerProtocol.swift
@@ -1,0 +1,16 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+@objc
+public protocol DevMenuItemsContainerProtocol {
+  @objc
+  func getRootItems() -> [DevMenuScreenItem]
+  
+  @objc
+  func getAllItems() -> [DevMenuScreenItem]
+  
+  @objc
+  func addItem(_ item: DevMenuScreenItem)
+  
+  @objc
+  func serializeItems() -> [[String: Any]]
+}

--- a/packages/expo-dev-menu-interface/ios/MenuItems/DevMenuLink.swift
+++ b/packages/expo-dev-menu-interface/ios/MenuItems/DevMenuLink.swift
@@ -1,0 +1,26 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+@objc
+public class DevMenuLink: DevMenuScreenItem {
+  var target: String
+  
+  @objc
+  open var label: () -> String = { "" }
+
+  @objc
+  open var glyphName: () -> String = { "" }
+
+  public init(withTarget target: String) {
+    self.target = target
+    super.init(type: .Link)
+  }
+  
+  @objc
+  open override func serialize() -> [String : Any] {
+    var dict = super.serialize()
+    dict["target"] = target
+    dict["label"] = label()
+    dict["glyphName"] = glyphName()
+    return dict
+  }
+}

--- a/packages/expo-dev-menu-interface/ios/MenuItems/DevMenuScreen.swift
+++ b/packages/expo-dev-menu-interface/ios/MenuItems/DevMenuScreen.swift
@@ -1,18 +1,9 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
 @objc
-open class DevMenuGroup: DevMenuScreenItem, DevMenuItemsContainerProtocol {
+public class DevMenuScreen : DevMenuItem, DevMenuItemsContainerProtocol {
   let container = DevMenuItemsContainer()
-  
-  @objc
-  public init() {
-    super.init(type: .Group)
-  }
-
-  @objc
-  public func addItem(_ item: DevMenuScreenItem) {
-    container.addItem(item)
-  }
+  public private(set) var screenName: String
   
   public func getRootItems() -> [DevMenuScreenItem] {
     return container.getRootItems()
@@ -22,13 +13,22 @@ open class DevMenuGroup: DevMenuScreenItem, DevMenuItemsContainerProtocol {
     return container.getAllItems()
   }
   
+  public func addItem(_ item: DevMenuScreenItem) {
+    container.addItem(item)
+  }
+  
   public func serializeItems() -> [[String : Any]] {
     return container.serializeItems()
   }
-
-  @objc
+  
+  public init(_ screenName: String) {
+    self.screenName = screenName
+    super.init(type: .Screen)
+  }
+  
   public override func serialize() -> [String : Any] {
     var dict = super.serialize()
+    dict["screenName"] = screenName
     dict["items"] = serializeItems()
     return dict
   }

--- a/packages/expo-dev-menu-interface/ios/MenuItems/DevMenuScreenItem.swift
+++ b/packages/expo-dev-menu-interface/ios/MenuItems/DevMenuScreenItem.swift
@@ -1,0 +1,24 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+@objc
+open class DevMenuScreenItem: DevMenuItem {
+  // Static members fit better than enum as we allow any other number.
+  static public let ImportanceLowest = -200
+  static public let ImportanceLow = -100
+  static public let ImportanceMedium = 0
+  static public let ImportanceHigh = 100
+  static public let ImportanceHighest = 200
+
+  // This enum is just for Objective-C compatibility, where values are automatically casted to integers.
+  @objc(DevMenuItemImportance)
+  public enum ItemImportance: Int {
+    case Lowest = -200
+    case Low = -100
+    case Medium = 0
+    case High = 100
+    case Highest = 200
+  }
+
+  @objc
+  open var importance: Int = ItemImportance.Medium.rawValue
+}

--- a/packages/expo-dev-menu-interface/ios/MenuItems/DevMenuSelectionList.swift
+++ b/packages/expo-dev-menu-interface/ios/MenuItems/DevMenuSelectionList.swift
@@ -1,0 +1,65 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+@objc
+public class DevMenuSelectionList: DevMenuScreenItem {
+
+  @objc
+  public class Item: NSObject {
+    @objc
+    public class Tag : NSObject {
+      @objc
+      public var text: () -> String = { "" }
+
+      @objc
+      public var glyphName: () -> String? = { nil }
+      
+      fileprivate func serialize() -> [String : Any] {
+        return [
+          "text": text(),
+          "glyphName": glyphName(),
+        ]
+      }
+    }
+    
+    @objc
+    public var title: () -> String = { "" }
+
+    @objc
+    public var warning: () -> String? = { nil }
+    
+    @objc
+    public var isChecked: () -> Bool = { false }
+    
+    @objc
+    public var tags: () -> [Tag] = { [] }
+    
+    fileprivate func serialize() -> [String : Any] {
+      return [
+        "title": title(),
+        "warning": warning(),
+        "isChecked": isChecked(),
+        "tags": tags().map { $0.serialize() }
+      ]
+    }
+  }
+  
+  private var items: [Item] = []
+  
+  @objc
+  public func addItem(_ item: Item) {
+    items.append(item)
+  }
+  
+  @objc
+  public init() {
+    super.init(type: .SelectionList)
+  }
+  
+  @objc
+  public override func serialize() -> [String : Any] {
+    var dict = super.serialize()
+    dict["items"] = items.map { $0.serialize() }
+    return dict
+  }
+  
+}

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/DevMenuActivity.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/DevMenuActivity.kt
@@ -24,6 +24,7 @@ class DevMenuActivity : ReactActivity() {
         putBoolean("enableDevelopmentTools", true)
         putBoolean("showOnboardingView", DevMenuManager.getSettings()?.isOnboardingFinished != true)
         putParcelableArray("devMenuItems", DevMenuManager.serializedItems().toTypedArray())
+        putParcelableArray("devMenuScreens", DevMenuManager.serializedScreens().toTypedArray())
         putString("uuid", UUID.randomUUID().toString())
         putBundle("appInfo", DevMenuManager.getSession()?.appInfo ?: Bundle.EMPTY)
       }

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/KeyValueCachedProperty.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/KeyValueCachedProperty.kt
@@ -1,0 +1,26 @@
+package expo.modules.devmenu
+
+import java.util.*
+import kotlin.properties.ReadOnlyProperty
+import kotlin.reflect.KProperty
+
+class KeyValueCachedPropertyProxy<TKey, TValue>(
+  private var loader: (TKey) -> TValue,
+  private val container: WeakHashMap<TKey, TValue>) {
+
+  operator fun get(key: TKey): TValue {
+    if (!container.containsKey(key)) {
+      container[key] = loader(key)
+    }
+
+    return container[key]!!
+  }
+}
+
+class KeyValueCachedProperty<TKey, TValue>(private val loader: (TKey) -> TValue) : ReadOnlyProperty<Any, KeyValueCachedPropertyProxy<TKey, TValue>> {
+  private val container = WeakHashMap<TKey, TValue>()
+
+  override fun getValue(thisRef: Any, property: KProperty<*>): KeyValueCachedPropertyProxy<TKey, TValue> {
+    return KeyValueCachedPropertyProxy(loader, container)
+  }
+}

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/extensions/DevMenuExtension.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/extensions/DevMenuExtension.kt
@@ -15,6 +15,7 @@ import expo.interfaces.devmenu.DevMenuExtensionInterface
 import expo.interfaces.devmenu.items.DevMenuItemImportance
 import expo.interfaces.devmenu.items.DevMenuItemsContainer
 import expo.interfaces.devmenu.items.DevMenuScreen
+import expo.interfaces.devmenu.items.DevMenuSelectionList
 import expo.interfaces.devmenu.items.KeyCommand
 import expo.interfaces.devmenu.items.screen
 import expo.modules.devmenu.DEV_MENU_TAG
@@ -137,18 +138,51 @@ class DevMenuExtension(reactContext: ReactApplicationContext)
   override fun devMenuScreens(): List<DevMenuScreen>? {
     return listOf(
       screen("testScreen") {
-        action("reload", {}) {
-          label = { "Reload" }
-          glyphName = { "reload" }
-          keyCommand = KeyCommand(KeyEvent.KEYCODE_R)
-          importance = DevMenuItemImportance.HIGHEST.value
-        }
+        group {
+          selectionList {
+            addItem(DevMenuSelectionList.Item().apply {
+              isChecked = { true }
+              title = { "release-1.0" }
+              warning = { "You are currently running an older development client version than the latest \"release-1.0\" update. To get the latest, upgrade this development client app." }
+              tags = {
+                listOf(
+                  DevMenuSelectionList.Item.Tag().apply {
+                    glyphName = { "ios-git-network" }
+                    text = { "production" }
+                  },
+                  DevMenuSelectionList.Item.Tag().apply {
+                    glyphName = { "ios-cloud" }
+                    text = { "90%" }
+                  }
+                )
+              }
+            })
 
-        action("reload", {}) {
-          label = { "Reload" }
-          glyphName = { "reload" }
-          keyCommand = KeyCommand(KeyEvent.KEYCODE_R)
-          importance = DevMenuItemImportance.HIGHEST.value
+            addItem(DevMenuSelectionList.Item().apply {
+              title = { "pr-134" }
+            })
+
+            addItem(DevMenuSelectionList.Item().apply {
+              title = { "release-1.1" }
+              warning = { "You are currently running an older development client version than the latest \"release-1.0\" update. To get the latest, upgrade this development client app." }
+              tags = {
+                listOf(
+                  DevMenuSelectionList.Item.Tag().apply {
+                    glyphName = { "ios-git-network" }
+                    text = { "production" }
+                  },
+                  DevMenuSelectionList.Item.Tag().apply {
+                    glyphName = { "ios-cloud" }
+                    text = { "10%" }
+                  }
+                )
+              }
+            })
+
+            addItem(DevMenuSelectionList.Item().apply {
+              title = { "pr-21" }
+            })
+          }
         }
       }
     )

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/modules/DevMenuInternalModule.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/modules/DevMenuInternalModule.kt
@@ -2,6 +2,7 @@ package expo.modules.devmenu.modules
 
 import android.graphics.Typeface
 import android.os.Build
+import android.util.Log
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
@@ -110,5 +111,11 @@ class DevMenuInternalModule(reactContext: ReactApplicationContext)
       it.devSupportEnabled = true
       it.showDevOptionsDialog()
     }
+  }
+
+  @ReactMethod
+  fun onScreenChangeAsync(currentScreen: String?, promise: Promise) {
+    devMenuManger.setCurrentScreen(currentScreen)
+    promise.resolve(null)
   }
 }

--- a/packages/expo-dev-menu/app/DevMenuInternal.ts
+++ b/packages/expo-dev-menu/app/DevMenuInternal.ts
@@ -13,20 +13,35 @@ export type DevMenuAppInfoType = {
 export enum DevMenuItemEnum {
   ACTION = 1,
   GROUP = 2,
+  SCREEN = 3,
+  LINK = 4,
 }
 
 type DevMenuItemBaseType<T extends DevMenuItemEnum> = {
   type: T;
+};
+
+export type DevMenuScreenType = DevMenuItemBaseType<DevMenuItemEnum.SCREEN> & {
+  screenName: string;
+  items: DevMenuItemAnyType[];
+};
+
+export type DevMenuItemActionType = DevMenuItemBaseType<DevMenuItemEnum.ACTION> & {
+  actionId: string;
+
   isAvailable: boolean;
   isEnabled: boolean;
   label: string;
   detail?: string | null;
   glyphName?: string | null;
+
+  keyCommand: DevMenuKeyCommand;
 };
 
-export type DevMenuItemActionType = DevMenuItemBaseType<DevMenuItemEnum.ACTION> & {
-  actionId: string;
-  keyCommand: DevMenuKeyCommand;
+export type DevMenuItemLinkType = DevMenuItemBaseType<DevMenuItemEnum.LINK> & {
+  target: string;
+  label: string;
+  glyphName?: string | null;
 };
 
 export type DevMenuItemGroupType = DevMenuItemBaseType<DevMenuItemEnum.GROUP> & {
@@ -34,7 +49,7 @@ export type DevMenuItemGroupType = DevMenuItemBaseType<DevMenuItemEnum.GROUP> & 
   items: DevMenuItemAnyType[];
 };
 
-export type DevMenuItemAnyType = DevMenuItemActionType | DevMenuItemGroupType;
+export type DevMenuItemAnyType = DevMenuItemActionType | DevMenuItemGroupType | DevMenuItemLinkType;
 
 export type DevMenuItemProps<ItemType = DevMenuItemAnyType> = {
   item: ItemType;
@@ -91,4 +106,8 @@ export async function loadFontsAsync(): Promise<void> {
 
 export function openDevMenuFromReactNative() {
   DevMenu.openDevMenuFromReactNative();
+}
+
+export async function onScreenChangeAsync(currentScreen: string | null): Promise<void> {
+  return await DevMenu.onScreenChangeAsync(currentScreen);
 }

--- a/packages/expo-dev-menu/app/DevMenuInternal.ts
+++ b/packages/expo-dev-menu/app/DevMenuInternal.ts
@@ -15,6 +15,7 @@ export enum DevMenuItemEnum {
   GROUP = 2,
   SCREEN = 3,
   LINK = 4,
+  SELECTION_LIST = 5,
 }
 
 type DevMenuItemBaseType<T extends DevMenuItemEnum> = {
@@ -49,7 +50,27 @@ export type DevMenuItemGroupType = DevMenuItemBaseType<DevMenuItemEnum.GROUP> & 
   items: DevMenuItemAnyType[];
 };
 
-export type DevMenuItemAnyType = DevMenuItemActionType | DevMenuItemGroupType | DevMenuItemLinkType;
+export type DevMenuSelectionListItemTag = {
+  glyphName?: string | null;
+  text: string;
+};
+
+export type DevMenuSelectionListItem = {
+  title: string;
+  warning?: string;
+  isChecked: boolean;
+  tags: DevMenuSelectionListItemTag[];
+};
+
+export type DevMenuSelectionListType = DevMenuItemBaseType<DevMenuItemEnum.SELECTION_LIST> & {
+  items: DevMenuSelectionListItem[];
+};
+
+export type DevMenuItemAnyType =
+  | DevMenuItemActionType
+  | DevMenuItemGroupType
+  | DevMenuItemLinkType
+  | DevMenuSelectionListType;
 
 export type DevMenuItemProps<ItemType = DevMenuItemAnyType> = {
   item: ItemType;

--- a/packages/expo-dev-menu/app/components/ListItem.tsx
+++ b/packages/expo-dev-menu/app/components/ListItem.tsx
@@ -7,20 +7,35 @@ import Colors from '../constants/Colors';
 import { TouchableHighlight } from './Touchables';
 
 type Props = {
-  title?: string;
+  content?: string | React.ReactNode;
   onPress?: () => void;
   disabled?: boolean;
 };
 
 class ListItem extends React.PureComponent<Props> {
   render() {
-    const { title, ...props } = this.props;
+    const { content: title, ...props } = this.props;
     const textColor = props.disabled
       ? {
           lightColor: Colors.light.grayText,
           darkColor: Colors.dark.grayText,
         }
       : {};
+
+    let titleComponent;
+    if (typeof title === 'string') {
+      titleComponent = (
+        <StyledText
+          lightColor={Colors.light.menuItemText}
+          darkColor={Colors.dark.menuItemText}
+          style={styles.title}
+          {...textColor}>
+          {title}
+        </StyledText>
+      );
+    } else {
+      titleComponent = title;
+    }
 
     return (
       <TouchableHighlight {...props}>
@@ -30,9 +45,7 @@ class ListItem extends React.PureComponent<Props> {
           lightBorderColor={Colors.light.border}
           darkBackgroundColor={Colors.dark.secondaryBackground}
           darkBorderColor={Colors.dark.border}>
-          <StyledText style={styles.title} {...textColor}>
-            {title}
-          </StyledText>
+          {titleComponent}
           {this.props.children}
         </StyledView>
       </TouchableHighlight>

--- a/packages/expo-dev-menu/app/components/ListItemButton.tsx
+++ b/packages/expo-dev-menu/app/components/ListItemButton.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { StyleSheet, View } from 'react-native';
-import { MaterialCommunityIcon } from '../components/Icon';
 
+import { DevMenuKeyCommand } from '../DevMenuInternal';
+import { MaterialCommunityIcon } from '../components/Icon';
+import Colors from '../constants/Colors';
+import DevMenuKeyCommandLabel from './DevMenuKeyCommandLabel';
 import ListItem from './ListItem';
 import { StyledText } from './Text';
-import { DevMenuKeyCommand } from '../DevMenuInternal';
-import DevMenuKeyCommandLabel from './DevMenuKeyCommandLabel';
-import Colors from '../constants/Colors';
 
 export type ListItemButtonProps = {
   name: string;
@@ -58,7 +58,7 @@ class ListItemButton extends React.PureComponent<ListItemButtonProps> {
     const { label, icon, keyCommand, ...other } = this.props;
 
     return (
-      <ListItem {...other} title="" onPress={this.onPress}>
+      <ListItem {...other} content="" onPress={this.onPress}>
         {this.renderButtonIcon(icon)}
         {this.renderLabel(label)}
         {this.renderKeyCommand(keyCommand)}

--- a/packages/expo-dev-menu/app/components/ListItemCheckbox.tsx
+++ b/packages/expo-dev-menu/app/components/ListItemCheckbox.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { StyleSheet, View } from 'react-native';
-import { Ionicon } from '../components/Icon';
 
+import { Ionicon } from '../components/Icon';
 import ListItem from './ListItem';
 
 type Props = {
-  title: string;
+  content: string | React.ReactNode;
   initialChecked?: boolean;
   onChange?: (checked: boolean) => void;
   disabled?: boolean;
@@ -54,7 +54,10 @@ class ListItemCheckbox extends React.PureComponent<Props, State> {
 }
 
 const styles = StyleSheet.create({
-  checkContainer: {},
+  checkContainer: {
+    alignSelf: 'flex-start',
+    marginTop: 5,
+  },
 });
 
 export default ListItemCheckbox;

--- a/packages/expo-dev-menu/app/components/MainOptions.tsx
+++ b/packages/expo-dev-menu/app/components/MainOptions.tsx
@@ -6,7 +6,6 @@ import ListLink from './ListLink';
 function MainOptions() {
   return (
     <View style={styles.group}>
-      <ListLink route="Screen" label="Screen" glyphName="settings-outline" />
       <ListLink route="Settings" label="Settings" glyphName="settings-outline" />
       <ListLink route="Test" label="Navigation and scroll test" glyphName="test-tube" />
     </View>
@@ -16,7 +15,7 @@ function MainOptions() {
 const pixel = 2 / PixelRatio.get();
 const styles = StyleSheet.create({
   group: {
-    marginVertical: 7,
+    marginTop: 14,
     marginHorizontal: -pixel,
   },
 });

--- a/packages/expo-dev-menu/app/components/items/DevMenuGroup.tsx
+++ b/packages/expo-dev-menu/app/components/items/DevMenuGroup.tsx
@@ -3,6 +3,7 @@ import { StyleSheet, PixelRatio, View } from 'react-native';
 
 import { DevMenuItemAnyType, DevMenuItemProps, DevMenuItemEnum } from '../../DevMenuInternal';
 import DevMenuItemAction from './DevMenuAction';
+import DevMenuItemLink from './DevMenuLink';
 
 type Props = {
   items: DevMenuItemAnyType[];
@@ -17,6 +18,8 @@ class DevMenuItem extends React.PureComponent<DevMenuItemProps> {
         return <DevMenuItemAction item={item} />;
       case DevMenuItemEnum.GROUP:
         return <DevMenuItemsList items={item.items} />;
+      case DevMenuItemEnum.LINK:
+        return <DevMenuItemLink item={item} />;
       default:
         return null;
     }
@@ -43,7 +46,7 @@ const pixel = 2 / PixelRatio.get();
 
 const styles = StyleSheet.create({
   group: {
-    marginVertical: 7,
+    marginTop: 14,
     marginHorizontal: -pixel,
   },
 });

--- a/packages/expo-dev-menu/app/components/items/DevMenuGroup.tsx
+++ b/packages/expo-dev-menu/app/components/items/DevMenuGroup.tsx
@@ -4,6 +4,7 @@ import { StyleSheet, PixelRatio, View } from 'react-native';
 import { DevMenuItemAnyType, DevMenuItemProps, DevMenuItemEnum } from '../../DevMenuInternal';
 import DevMenuItemAction from './DevMenuAction';
 import DevMenuItemLink from './DevMenuLink';
+import DevMenuSelectionList from './DevMenuSelectionList';
 
 type Props = {
   items: DevMenuItemAnyType[];
@@ -20,6 +21,8 @@ class DevMenuItem extends React.PureComponent<DevMenuItemProps> {
         return <DevMenuItemsList items={item.items} />;
       case DevMenuItemEnum.LINK:
         return <DevMenuItemLink item={item} />;
+      case DevMenuItemEnum.SELECTION_LIST:
+        return <DevMenuSelectionList item={item} />;
       default:
         return null;
     }

--- a/packages/expo-dev-menu/app/components/items/DevMenuLink.tsx
+++ b/packages/expo-dev-menu/app/components/items/DevMenuLink.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import DevMenuContext from '../../DevMenuContext';
+import { DevMenuItemProps, DevMenuItemLinkType } from '../../DevMenuInternal';
+import ListLink from '../../components/ListLink';
+
+class DevMenuItemLink extends React.PureComponent<DevMenuItemProps<DevMenuItemLinkType>> {
+  static contextType = DevMenuContext;
+
+  render() {
+    const { target, label, glyphName } = this.props.item;
+
+    return <ListLink route={target} label={label} glyphName={glyphName} />;
+  }
+}
+
+export default DevMenuItemLink;

--- a/packages/expo-dev-menu/app/components/items/DevMenuScreen.tsx
+++ b/packages/expo-dev-menu/app/components/items/DevMenuScreen.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+
+import { DevMenuItemAnyType } from '../../DevMenuInternal';
+import ListFooter from '../ListFooter';
+import DevMenuGroup from './DevMenuGroup';
+
+type Props = {
+  items: DevMenuItemAnyType[];
+};
+
+export default class DevMenuScreen extends React.PureComponent<Props> {
+  static navigationOptions = {
+    headerShown: true,
+  };
+
+  render() {
+    return (
+      <View style={styles.container}>
+        <DevMenuGroup items={this.props.items} />
+        <ListFooter label="This development menu will not be present in any release builds of this project." />
+      </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+});

--- a/packages/expo-dev-menu/app/components/items/DevMenuScreen.tsx
+++ b/packages/expo-dev-menu/app/components/items/DevMenuScreen.tsx
@@ -27,5 +27,6 @@ export default class DevMenuScreen extends React.PureComponent<Props> {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
+    paddingBottom: 50,
   },
 });

--- a/packages/expo-dev-menu/app/components/items/DevMenuSelectionList.tsx
+++ b/packages/expo-dev-menu/app/components/items/DevMenuSelectionList.tsx
@@ -1,0 +1,276 @@
+import Fuse from 'fuse.js';
+import React from 'react';
+import { StyleSheet, View, TextInput } from 'react-native';
+
+import {
+  DevMenuItemProps,
+  DevMenuSelectionListItem,
+  DevMenuSelectionListItemTag,
+  DevMenuSelectionListType,
+} from '../../DevMenuInternal';
+import Colors from '../../constants/Colors';
+import { Ionicon } from '../Icon';
+import ListItemCheckbox from '../ListItemCheckbox';
+import { StyledText } from '../Text';
+import { StyledView } from '../Views';
+
+type State = {
+  searchText: string;
+};
+
+const SearchBar = ({ onChangeText }: { onChangeText: (text: string) => void }) => {
+  return (
+    <StyledView
+      style={styles.searchContainer}
+      lightBackgroundColor={Colors.light.background}
+      darkBackgroundColor={Colors.dark.background}>
+      <TextInput
+        onChangeText={onChangeText}
+        style={styles.search}
+        placeholder="Search"
+        placeholderTextColor="#90909d"
+      />
+    </StyledView>
+  );
+};
+
+const SectionItemTag = ({ glyphName, text }: DevMenuSelectionListItemTag) => {
+  return (
+    <StyledView
+      lightBackgroundColor={Colors.light.background}
+      darkBackgroundColor={Colors.dark.background}
+      lightBorderColor={Colors.light.border}
+      darkBorderColor={Colors.dark.border}
+      style={styles.tag}>
+      <View style={styles.tagIcon}>
+        <Ionicon size={14} name={glyphName} color="tint" />
+      </View>
+
+      <StyledText
+        lightColor={Colors.light.secondaryText}
+        darkColor={Colors.dark.secondaryText}
+        style={styles.tagText}>
+        {text}
+      </StyledText>
+    </StyledView>
+  );
+};
+
+const SectionItem = ({ title, isChecked, warning, tags }: DevMenuSelectionListItem) => {
+  const tagsComponents = tags?.map(tag => <SectionItemTag key={tag.text} {...tag} />) ?? [];
+
+  const element = (
+    <View style={styles.itemContainer}>
+      <StyledText
+        lightColor={Colors.light.menuItemText}
+        darkColor={Colors.dark.menuItemText}
+        style={styles.sectionItem}>
+        {title}
+      </StyledText>
+
+      {tagsComponents.length > 0 && <View style={styles.tagsContainer}>{tagsComponents}</View>}
+
+      {warning && (
+        <StyledView
+          style={styles.warningContainer}
+          lightBackgroundColor={Colors.light.warningBackground}
+          lightBorderColor={Colors.light.warningBorders}
+          darkBackgroundColor={Colors.dark.warningBackground}
+          darkBorderColor={Colors.dark.warningBorders}>
+          <StyledText
+            style={styles.warning}
+            lightColor={Colors.light.warningColor}
+            darkColor={Colors.dark.warningColor}>
+            {warning}
+          </StyledText>
+        </StyledView>
+      )}
+    </View>
+  );
+
+  return <ListItemCheckbox content={element} initialChecked={isChecked} />;
+};
+
+const SectionDivider = () => {
+  return (
+    <StyledView
+      darkBackgroundColor={Colors.dark.border}
+      lightBackgroundColor={Colors.light.border}
+      style={{
+        height: 1,
+      }}
+    />
+  );
+};
+
+const SearchResults = ({
+  query,
+  elements,
+}: {
+  query: string;
+  elements: DevMenuSelectionListItem[];
+}) => {
+  const fuse = new Fuse(elements, {
+    keys: ['title', 'tags.text'],
+  });
+  const results = fuse.search(query);
+
+  return (
+    <>
+      <StyledText
+        lightColor={Colors.light.menuItemText}
+        darkColor={Colors.dark.menuItemText}
+        style={styles.sectionHeader}>
+        {results.length === 0 ? 'No results' : 'Results'}
+      </StyledText>
+
+      {results.map(({ item }) => (
+        <SectionItem
+          key={item.title}
+          title={item.title}
+          warning={item?.warning}
+          isChecked={item?.isChecked}
+          tags={item.tags}
+        />
+      ))}
+    </>
+  );
+};
+
+const AllItems = ({ elements }: { elements: DevMenuSelectionListItem[] }) => {
+  console.log(elements);
+  const selectedElements = elements.filter(e => e.isChecked);
+  const othersElements = elements.filter(e => !e.isChecked);
+  return (
+    <>
+      <StyledText
+        lightColor={Colors.light.menuItemText}
+        darkColor={Colors.dark.menuItemText}
+        style={styles.sectionHeader}>
+        Current development client release
+      </StyledText>
+      <SectionDivider />
+      {selectedElements.map(e => (
+        <SectionItem
+          key={e.title}
+          title={e.title}
+          warning={e?.warning}
+          isChecked={e.isChecked}
+          tags={e.tags}
+        />
+      ))}
+
+      <StyledText
+        lightColor={Colors.light.menuItemText}
+        darkColor={Colors.dark.menuItemText}
+        style={styles.sectionHeader}>
+        Recently updated release
+      </StyledText>
+      <SectionDivider />
+      {othersElements.map(e => (
+        <SectionItem
+          key={e.title}
+          title={e.title}
+          warning={e?.warning}
+          isChecked={e.isChecked}
+          tags={e.tags}
+        />
+      ))}
+    </>
+  );
+};
+
+class DevMenuSelectionList extends React.PureComponent<
+  DevMenuItemProps<DevMenuSelectionListType>,
+  State
+> {
+  state = {
+    searchText: '',
+  };
+
+  onChangeText = (text: string) => {
+    this.setState({
+      searchText: text,
+    });
+  };
+
+  render() {
+    const { items } = this.props.item;
+
+    const isSearchActive = this.state.searchText.length > 0;
+
+    return (
+      <StyledView>
+        <SearchBar onChangeText={this.onChangeText} />
+        {isSearchActive ? (
+          <SearchResults query={this.state.searchText} elements={items} />
+        ) : (
+          <AllItems elements={items} />
+        )}
+      </StyledView>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  searchContainer: {
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 20,
+  },
+  search: {
+    width: '100%',
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    borderRadius: 8,
+    backgroundColor: '#ebebed',
+    fontSize: 18,
+  },
+
+  tagsContainer: {
+    flexDirection: 'row',
+    marginTop: -4,
+    marginBottom: 10,
+  },
+  tag: {
+    paddingVertical: 4,
+    paddingHorizontal: 12,
+    marginRight: 8,
+    flexDirection: 'row',
+    alignSelf: 'center',
+    borderRadius: 4,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  tagIcon: { marginRight: 5 },
+  tagText: {
+    fontSize: 14,
+  },
+
+  sectionHeader: {
+    marginTop: 18,
+    paddingHorizontal: 20,
+    marginBottom: 5,
+    fontWeight: '700',
+    fontSize: 14,
+  },
+  sectionItem: {
+    fontSize: 15,
+    paddingVertical: 10,
+  },
+
+  itemContainer: {
+    flexShrink: 1,
+  },
+
+  warningContainer: {
+    marginTop: 4,
+    padding: 10,
+    borderWidth: 1,
+    marginBottom: 10,
+    maxWidth: '95%',
+  },
+  warning: { fontSize: 14 },
+});
+
+export default DevMenuSelectionList;

--- a/packages/expo-dev-menu/app/constants/Colors.ts
+++ b/packages/expo-dev-menu/app/constants/Colors.ts
@@ -10,6 +10,9 @@ export default {
     menuItemText: '#000020',
     appIconPlaceholderBackground: '#f5f5f5',
     appIconPlaceholderBorder: '#c5c5c5',
+    warningBackground: '#fef6d0',
+    warningColor: '#886636',
+    warningBorders: '#fceca8',
   },
   dark: {
     tint: '#aca2f6',
@@ -19,8 +22,11 @@ export default {
     background: '#000',
     secondaryBackground: '#1c1c1e',
     border: '#303033',
-    menuItemText: '#fff',
+    menuItemText: '#ddd',
     appIconPlaceholderBackground: '#333',
     appIconPlaceholderBorder: '#555',
+    warningBackground: '#feffb0',
+    warningColor: '#886636',
+    warningBorders: '#fceca8',
   },
 };

--- a/packages/expo-dev-menu/app/screens/DevMenuSettingsScreen.tsx
+++ b/packages/expo-dev-menu/app/screens/DevMenuSettingsScreen.tsx
@@ -72,22 +72,22 @@ export default class DevMenuSettingsScreen extends React.PureComponent<{}, State
 
     return (
       <View style={styles.container}>
-        <ListItem title="Open React Native dev menu" onPress={this.openReactNativeDevMenu} />
+        <ListItem content="Open React Native dev menu" onPress={this.openReactNativeDevMenu} />
         <View style={styles.group}>
           <ListItemCheckbox
-            title="Shake device"
+            content="Shake device"
             initialChecked={settings.motionGestureEnabled}
             onChange={this.toggleMotionGesture}
             disabled={shouldLockOneOption && settings.motionGestureEnabled}
           />
           <ListItemCheckbox
-            title="Three-finger long press"
+            content="Three-finger long press"
             initialChecked={settings.touchGestureEnabled}
             onChange={this.toggleTouchGesture}
             disabled={shouldLockOneOption && settings.touchGestureEnabled}
           />
           <ListItemCheckbox
-            title="Show menu at launch"
+            content="Show menu at launch"
             initialChecked={settings.showsAtLaunch}
             onChange={this.toggleAutoLaunch}
             disabled={shouldLockOneOption && settings.showsAtLaunch}

--- a/packages/expo-dev-menu/app/views/DevMenuApp.tsx
+++ b/packages/expo-dev-menu/app/views/DevMenuApp.tsx
@@ -1,8 +1,8 @@
-import React, { useEffect, useState } from 'react';
 import { NavigationContainer, DarkTheme, DefaultTheme } from '@react-navigation/native';
+import React, { useEffect, useState, useRef } from 'react';
 import { StyleSheet, View, useColorScheme } from 'react-native';
 
-import { loadFontsAsync } from '../DevMenuInternal';
+import { loadFontsAsync, onScreenChangeAsync } from '../DevMenuInternal';
 import Colors from '../constants/Colors';
 import DevMenuContainer from './DevMenuContainer';
 
@@ -33,6 +33,8 @@ const CustomDarkTheme = {
 function DevMenuApp(props) {
   const colorScheme = useColorScheme();
   const [fontsWereLoaded, didFontsLoad] = useState(false);
+  const routeNameRef = useRef<string>();
+  const navigationRef = useRef();
 
   useEffect(() => {
     const loadFonts = async () => {
@@ -49,7 +51,19 @@ function DevMenuApp(props) {
 
   return (
     <View style={styles.rootView}>
-      <NavigationContainer theme={colorScheme === 'dark' ? CustomDarkTheme : CustomLightTheme}>
+      <NavigationContainer
+        theme={colorScheme === 'dark' ? CustomDarkTheme : CustomLightTheme}
+        ref={navigationRef}
+        onStateChange={async () => {
+          const previousRouteName = routeNameRef.current;
+          const currentRouteName = navigationRef.current.getCurrentRoute().name;
+
+          if (previousRouteName !== currentRouteName) {
+            await onScreenChangeAsync(currentRouteName === 'Main' ? null : currentRouteName);
+          }
+
+          routeNameRef.current = currentRouteName;
+        }}>
         <DevMenuContainer {...props} />
       </NavigationContainer>
     </View>

--- a/packages/expo-dev-menu/app/views/DevMenuContainer.tsx
+++ b/packages/expo-dev-menu/app/views/DevMenuContainer.tsx
@@ -10,6 +10,7 @@ import DevMenuTestScreen from '../screens/DevMenuTestScreen';
 import DevMenuBottomSheet from './DevMenuBottomSheet';
 import DevMenuOnboarding from './DevMenuOnboarding';
 import NavigationHeaderButton from '../components/NavigationHeaderButton';
+import DevMenuScreen from '../components/items/DevMenuScreen';
 
 type Props = {
   uuid: string;
@@ -110,6 +111,18 @@ export default class DevMenuContainer extends React.PureComponent<Props, any> {
       ...this.providedContext,
     };
 
+    const devMenuScreens = (this.props.devMenuScreens as {
+      screenName: string;
+      items: any;
+    }[]).map(screenInfo => {
+      return {
+        name: screenInfo.screenName,
+        component: DevMenuScreen,
+        options: applyNavigationSettings(DevMenuScreen.navigationOptions),
+        props: { items: screenInfo.items },
+      };
+    });
+
     return (
       <DevMenuContext.Provider value={providedContext}>
         <View style={styles.bottomSheetContainer}>
@@ -123,7 +136,7 @@ export default class DevMenuContainer extends React.PureComponent<Props, any> {
             initialSnap={0}
             snapPoints={this.snapPoints}
             callbackNode={this.callbackNode}
-            screens={this.screens}>
+            screens={[...this.screens, ...devMenuScreens]}>
             <DevMenuOnboarding show={this.props.showOnboardingView} />
           </DevMenuBottomSheet>
         </View>

--- a/packages/expo-dev-menu/app/views/DevMenuView.tsx
+++ b/packages/expo-dev-menu/app/views/DevMenuView.tsx
@@ -41,7 +41,7 @@ class DevMenuView extends React.PureComponent<Props, undefined> {
     return (
       <>
         <DevMenuAppInfo appInfo={appInfo} />
-        <View style={styles.itemsContainer}>{this.renderItems()}</View>
+        {this.renderItems()}
       </>
     );
   }
@@ -79,9 +79,6 @@ const styles = StyleSheet.create({
   },
   appInfo: {
     borderBottomWidth: 2 / PixelRatio.get(),
-  },
-  itemsContainer: {
-    marginTop: 7,
   },
 });
 

--- a/packages/expo-dev-menu/ios/DevMenuManager.swift
+++ b/packages/expo-dev-menu/ios/DevMenuManager.swift
@@ -29,21 +29,26 @@ class Dispatch {
 }
 
 /**
- A container for dev menu items array.
- NSMapTable requires the second generic type to be a class, so `[DevMenuItem]` is not allowed.
+ A container for dev menu screens array.
+ NSMapTable requires the second generic type to be a class, so `[DevMenuScreen]` is not allowed.
  */
-class DevMenuItemsContainer {
-  fileprivate let items: [DevMenuItem]
+class DevMenuScreensContainer {
+  fileprivate let screens: [DevMenuScreen]
 
-  fileprivate init(items: [DevMenuItem]) {
-    self.items = items
+  fileprivate init(screens: [DevMenuScreen]) {
+    self.screens = screens
   }
 }
 
 /**
  A hash map storing an array of dev menu items for specific extension.
  */
-private let extensionToDevMenuItemsMap = NSMapTable<DevMenuExtensionProtocol, DevMenuItemsContainer>.weakToStrongObjects()
+private let extensionToDevMenuItemsMap = NSMapTable<DevMenuExtensionProtocol, DevMenuItemsContainerProtocol>.weakToStrongObjects()
+
+/**
+ A hash map storing an array of dev menu screens for specific extension.
+ */
+private let extensionToDevMenuScreensMap = NSMapTable<DevMenuExtensionProtocol, DevMenuScreensContainer>.weakToStrongObjects()
 
 /**
  Manages the dev menu and provides most of the public API.
@@ -71,6 +76,8 @@ open class DevMenuManager: NSObject, DevMenuManagerProtocol {
    */
   public private(set) var session: DevMenuSession?
 
+  var currentScreen: String?
+  
   /**
    The delegate of `DevMenuManager` implementing `DevMenuDelegateProtocol`.
    */
@@ -161,24 +168,22 @@ open class DevMenuManager: NSObject, DevMenuManagerProtocol {
   public func toggleMenu() -> Bool {
     return isVisible ? closeMenu() : openMenu()
   }
+  
+  @objc
+  public func setCurrentScreen(_ screenName: String?) {
+    currentScreen = screenName
+  }
 
   // MARK: internals
 
   func dispatchAction(withId actionId: String) {
-    guard let extensions = extensions else {
-      return
-    }
-    for ext in extensions {
-      guard let devMenuItems = loadDevMenuItems(forExtension: ext) else {
-        continue
-      }
-      for item in devMenuItems {
-        if let action = item as? DevMenuAction, action.actionId == actionId {
-          if delegate?.devMenuManager?(self, willDispatchAction: action) ?? true {
-            action.action()
-          }
-          return
+    for action in devMenuActions {
+      if (action.actionId == actionId) {
+        if delegate?.devMenuManager?(self, willDispatchAction: action) ?? true {
+          action.action()
         }
+        
+        return
       }
     }
   }
@@ -202,34 +207,51 @@ open class DevMenuManager: NSObject, DevMenuManagerProtocol {
   /**
    Gathers `DevMenuItem`s from all dev menu extensions and returns them as an array.
    */
-  var devMenuItems: [DevMenuItem] {
-    var items: [DevMenuItem] = []
-
-    extensions?.forEach({ ext in
-      if let extensionItems = loadDevMenuItems(forExtension: ext) {
-        items.append(contentsOf: extensionItems)
-      }
-    })
-    return items.sorted {
-      if $0.importance == $1.importance {
-        return $0.label().localizedCaseInsensitiveCompare($1.label()) == .orderedAscending
-      }
-      return $0.importance > $1.importance
-    }
+  var devMenuItems: [DevMenuScreenItem] {
+    return extensions?.map { loadDevMenuItems(forExtension: $0)?.getAllItems() ?? [] }.flatMap { $0 } ?? []
   }
-
+  
+  /**
+   Gathers root `DevMenuItem`s (elements on the main screen) from all dev menu extensions and returns them as an array.
+   */
+  var devMenuRootItems: [DevMenuScreenItem] {
+    return extensions?.map { loadDevMenuItems(forExtension: $0)?.getRootItems() ?? [] }.flatMap { $0 } ?? []
+  }
+  
+  /**
+   Gathers `DevMenuScreen`s from all dev menu extensions and returns them as an array.
+   */
+  var devMenuScreens: [DevMenuScreen] {
+    return extensions?.map { loadDevMenuScreens(forExtension: $0) ?? [] }.flatMap {$0} ?? []
+  }
+  
   /**
    Returns an array of `DevMenuAction`s returned by the dev menu extensions.
    */
   var devMenuActions: [DevMenuAction] {
-    return devMenuItems.filter { $0 is DevMenuAction } as! [DevMenuAction]
+    if currentScreen == nil {
+      return devMenuItems.filter { $0 is DevMenuAction } as! [DevMenuAction]
+    }
+    
+    return (devMenuScreens.first { $0.screenName == currentScreen }?.getAllItems() ?? [])
+      .filter { $0 is DevMenuAction } as! [DevMenuAction]
   }
 
   /**
    Returns an array of dev menu items serialized to the dictionary.
    */
   func serializedDevMenuItems() -> [[String : Any]] {
-    return devMenuItems.map({ $0.serialize() })
+    return devMenuRootItems
+      .sorted(by: { $0.importance > $1.importance })
+      .map({ $0.serialize() })
+  }
+  
+  /**
+   Returns an array of dev menu screens serialized to the dictionary.
+   */
+  func serializedDevMenuScreens() -> [[String : Any]] {
+    return devMenuScreens
+      .map({ $0.serialize() })
   }
 
   // MARK: delegate stubs
@@ -259,16 +281,31 @@ open class DevMenuManager: NSObject, DevMenuManagerProtocol {
 
   // MARK: private
 
-  private func loadDevMenuItems(forExtension ext: DevMenuExtensionProtocol) -> [DevMenuItem]? {
+  private func loadDevMenuItems(forExtension ext: DevMenuExtensionProtocol) -> DevMenuItemsContainerProtocol? {
     if let itemsContainer = extensionToDevMenuItemsMap.object(forKey: ext) {
-      return itemsContainer.items
+      return itemsContainer
     }
-    if let items = ext.devMenuItems?() {
-      let container = DevMenuItemsContainer(items: items)
-      extensionToDevMenuItemsMap.setObject(container, forKey: ext)
-      return items
+    
+    if let itemsContainer = ext.devMenuItems?() {
+      extensionToDevMenuItemsMap.setObject(itemsContainer, forKey: ext)
+      return itemsContainer
     }
+    
     return nil
+  }
+  
+  private func loadDevMenuScreens(forExtension ext: DevMenuExtensionProtocol) -> [DevMenuScreen]? {
+    if let screenContainer = extensionToDevMenuScreensMap.object(forKey: ext) {
+      return screenContainer.screens
+    }
+    
+    if let screens = ext.devMenuScreens?() {
+      let container = DevMenuScreensContainer(screens: screens)
+      extensionToDevMenuScreensMap.setObject(container, forKey: ext)
+      return screens
+    }
+    
+    return nil;
   }
 
   private func setVisibility(_ visible: Bool) -> Bool {

--- a/packages/expo-dev-menu/ios/DevMenuViewController.swift
+++ b/packages/expo-dev-menu/ios/DevMenuViewController.swift
@@ -77,6 +77,7 @@ class DevMenuViewController: UIViewController {
       "enableDevelopmentTools": true,
       "showOnboardingView": manager.shouldShowOnboarding(),
       "devMenuItems": manager.serializedDevMenuItems(),
+      "devMenuScreens": manager.serializedDevMenuScreens(),
       "appInfo": manager.session?.appInfo ?? [:],
       "uuid": UUID.init().uuidString
     ]

--- a/packages/expo-dev-menu/ios/Modules/DevMenuExtensions.swift
+++ b/packages/expo-dev-menu/ios/Modules/DevMenuExtensions.swift
@@ -22,11 +22,13 @@ open class DevMenuExtensions: NSObject, RCTBridgeModule, DevMenuExtensionProtoco
   // MARK: DevMenuExtensionProtocol
 
   @objc
-  open func devMenuItems() -> [DevMenuItem]? {
+  open func devMenuItems() -> DevMenuItemsContainerProtocol? {
     guard let devSettings = bridge?.module(forName: "DevSettings") as? RCTDevSettings else {
       return nil
     }
-
+    
+    let container = DevMenuItemsContainer()
+    
     let reload = DevMenuExtensions.reloadAction {
       // Without this the `expo-splash-screen` will reject
       // No native splash screen registered for given view controller. Call 'SplashScreen.show' for given view controller first.
@@ -65,10 +67,32 @@ open class DevMenuExtensions: NSObject, RCTBridgeModule, DevMenuExtensionProtoco
     perfMonitor.isAvailable = { self.bridge?.module(forName: "PerfMonitor") != nil }
     perfMonitor.isEnabled = { devSettings.isPerfMonitorShown }
 
-    return [reload, inspector, remoteDebug, fastRefresh, perfMonitor]
-    #else
-    return [reload, inspector]
+    container.addItem(remoteDebug)
+    container.addItem(fastRefresh)
+    container.addItem(perfMonitor)
     #endif
+  
+    container.addItem(reload)
+    container.addItem(inspector)
+  
+    let group = DevMenuGroup()
+    group.importance = DevMenuScreenItem.ImportanceLowest
+    
+    let link = DevMenuLink(withTarget: "testScreen")
+    link.label = { "Test Screen" }
+    link.glyphName = { "test-tube" }
+    
+    group.addItem(link)
+    container.addItem(group)
+    
+    return container
+  }
+  
+  @objc
+  open func devMenuScreens() -> [DevMenuScreen]? {
+    let testScreen = DevMenuScreen("testScreen")
+    testScreen.addItem(DevMenuExtensions.reloadAction {})
+    return [testScreen]
   }
 
   // MARK: static helpers
@@ -77,7 +101,7 @@ open class DevMenuExtensions: NSObject, RCTBridgeModule, DevMenuExtensionProtoco
     let reload = DevMenuAction(withId: "reload", action: action)
     reload.label = { "Reload" }
     reload.glyphName = { "reload" }
-    reload.importance = DevMenuItem.ImportanceHighest
+    reload.importance = DevMenuScreenItem.ImportanceHighest
     reload.registerKeyCommand(input: "r", modifiers: .command)
     return reload
   }
@@ -86,7 +110,7 @@ open class DevMenuExtensions: NSObject, RCTBridgeModule, DevMenuExtensionProtoco
     let inspector = DevMenuAction(withId: "inspector", action: action)
     inspector.label = { inspector.isEnabled() ? "Hide Element Inspector" : "Show Element Inspector" }
     inspector.glyphName = { "border-style" }
-    inspector.importance = DevMenuItem.ImportanceHigh
+    inspector.importance = DevMenuScreenItem.ImportanceHigh
     inspector.registerKeyCommand(input: "i", modifiers: .command)
     return inspector
   }
@@ -95,7 +119,7 @@ open class DevMenuExtensions: NSObject, RCTBridgeModule, DevMenuExtensionProtoco
     let remoteDebug = DevMenuAction(withId: "remote-debug", action: action)
     remoteDebug.label = { remoteDebug.isAvailable() ? remoteDebug.isEnabled() ? "Stop Remote Debugging" : "Debug Remote JS" : "Remote Debugger Unavailable" }
     remoteDebug.glyphName = { "remote-desktop" }
-    remoteDebug.importance = DevMenuItem.ImportanceLow
+    remoteDebug.importance = DevMenuScreenItem.ImportanceLow
     return remoteDebug
   }
 
@@ -103,7 +127,7 @@ open class DevMenuExtensions: NSObject, RCTBridgeModule, DevMenuExtensionProtoco
     let fastRefresh = DevMenuAction(withId: "fast-refresh", action: action)
     fastRefresh.label = { fastRefresh.isAvailable() ? fastRefresh.isEnabled() ? "Disable Fast Refresh" : "Enable Fast Refresh" : "Fast Refresh Unavailable" }
     fastRefresh.glyphName = { "run-fast" }
-    fastRefresh.importance = DevMenuItem.ImportanceLow
+    fastRefresh.importance = DevMenuScreenItem.ImportanceLow
     return fastRefresh
   }
 
@@ -111,7 +135,7 @@ open class DevMenuExtensions: NSObject, RCTBridgeModule, DevMenuExtensionProtoco
     let perfMonitor = DevMenuAction(withId: "performance-monitor", action: action)
     perfMonitor.label = { perfMonitor.isAvailable() ? perfMonitor.isEnabled() ? "Hide Performance Monitor" : "Show Performance Monitor" : "Performance Monitor Unavailable" }
     perfMonitor.glyphName = { "speedometer" }
-    perfMonitor.importance = DevMenuItem.ImportanceHigh
+    perfMonitor.importance = DevMenuScreenItem.ImportanceHigh
     perfMonitor.registerKeyCommand(input: "p", modifiers: .command)
     return perfMonitor
   }

--- a/packages/expo-dev-menu/ios/Modules/DevMenuExtensions.swift
+++ b/packages/expo-dev-menu/ios/Modules/DevMenuExtensions.swift
@@ -91,7 +91,48 @@ open class DevMenuExtensions: NSObject, RCTBridgeModule, DevMenuExtensionProtoco
   @objc
   open func devMenuScreens() -> [DevMenuScreen]? {
     let testScreen = DevMenuScreen("testScreen")
-    testScreen.addItem(DevMenuExtensions.reloadAction {})
+
+    let selectionList = DevMenuSelectionList()
+    let relase10 = DevMenuSelectionList.Item()
+    relase10.isChecked = { true }
+    relase10.title = { "release-1.0" }
+    relase10.warning = { "You are currently running an older development client version than the latest \"release-1.0\" update. To get the latest, upgrade this development client app." }
+    let relase10ProductionTag = DevMenuSelectionList.Item.Tag()
+    relase10ProductionTag.glyphName = { "ios-git-network" }
+    relase10ProductionTag.text = { "production" }
+    
+    let relase10ProgressTag = DevMenuSelectionList.Item.Tag()
+    relase10ProgressTag.glyphName = { "ios-cloud" }
+    relase10ProgressTag.text = { "90%" }
+    
+    relase10.tags = { [relase10ProductionTag, relase10ProgressTag] }
+    
+    let pr134 = DevMenuSelectionList.Item()
+    pr134.title = { "pr-134" }
+    
+    let relase11 = DevMenuSelectionList.Item()
+    relase11.isChecked = { false }
+    relase11.title = { "release-1.1" }
+    let relase11ProductionTag = DevMenuSelectionList.Item.Tag()
+    relase11ProductionTag.glyphName = { "ios-git-network" }
+    relase11ProductionTag.text = { "production" }
+    
+    let relase11ProgressTag = DevMenuSelectionList.Item.Tag()
+    relase11ProgressTag.glyphName = { "ios-cloud" }
+    relase11ProgressTag.text = { "10%" }
+    
+    relase11.tags = { [relase11ProductionTag, relase11ProgressTag] }
+    
+    let pr21 = DevMenuSelectionList.Item()
+    pr21.title = { "pr-21" }
+    
+    selectionList.addItem(relase10)
+    selectionList.addItem(pr134)
+    selectionList.addItem(relase11)
+    selectionList.addItem(pr21)
+    
+    testScreen.addItem(selectionList)
+    
     return [testScreen]
   }
 

--- a/packages/expo-dev-menu/ios/Modules/DevMenuInternalModule.m
+++ b/packages/expo-dev-menu/ios/Modules/DevMenuInternalModule.m
@@ -16,5 +16,6 @@ RCT_EXTERN_METHOD(getSettingsAsync:(RCTPromiseResolveBlock)resolve reject:(RCTPr
 RCT_EXTERN_METHOD(setSettingsAsync:(NSDictionary *)dict resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(loadFontsAsync:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(openDevMenuFromReactNative)
+RCT_EXTERN_METHOD(onScreenChangeAsync:(NSString *)currentScreen resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 
 @end

--- a/packages/expo-dev-menu/ios/Modules/DevMenuInternalModule.swift
+++ b/packages/expo-dev-menu/ios/Modules/DevMenuInternalModule.swift
@@ -119,4 +119,10 @@ public class DevMenuInternalModule: NSObject, RCTBridgeModule {
       rctDevMenu.show()
     }
   }
+  
+  @objc
+  func onScreenChangeAsync(_ currentScreen: String?, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
+    manager.setCurrentScreen(currentScreen)
+    resolve(nil)
+  }
 }

--- a/packages/expo-dev-menu/package.json
+++ b/packages/expo-dev-menu/package.json
@@ -41,7 +41,8 @@
     "preset": "expo-module-scripts"
   },
   "dependencies": {
-    "expo-dev-menu-interface": "0.1.1"
+    "expo-dev-menu-interface": "0.1.1",
+    "fuse.js": "^6.4.6"
   },
   "peerDependencies": {
     "react-native": ">=0.62.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9304,6 +9304,11 @@ fuse.js@^6.4.1:
   resolved "https://registry.yarnpkg.com/fuse.js/-/fuse.js-6.4.1.tgz#76f1b4ab9cd021b854a68381b35628033d27507e"
   integrity sha512-+hAS7KYgLXontDh/vqffs7wIBw0ceb9Sx8ywZQhOsiQGcSO5zInGhttWOUYQYlvV/yYMJOacQ129Xs3mP3+oZQ==
 
+fuse.js@^6.4.6:
+  version "6.4.6"
+  resolved "https://registry.yarnpkg.com/fuse.js/-/fuse.js-6.4.6.tgz#62f216c110e5aa22486aff20be7896d19a059b79"
+  integrity sha512-/gYxR/0VpXmWSfZOIPS3rWwU8SHgsRTwWuXhyb2O6s7aRuVtHtxCkR33bNYu3wyLyNx/Wpv0vU7FZy8Vj53VNw==
+
 gensync@^1.0.0-beta.1:
   version "1.0.0-beta.1"
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.1.tgz#58f4361ff987e5ff6e1e7a210827aa371eaac269"


### PR DESCRIPTION
# Why

Adds support for screens & links.

# How

- Added two new items - screen & link.
- Changed return typo of the `devMenuItems` method from `DevMenuExtensionInterface` to `DevMenuItemsContainer` (to add `DSL` to `kotlin` and making items parsing easier).
- Added a new method that returns a list of screens to `DevMenuExtensionInterface`.
- Registered screens in react-navigation
- Rewrote action dispatcher. 

# Test Plan

- bare-expo ✅
<img width="469" alt="Screenshot 2021-01-14 at 13 49 01" src="https://user-images.githubusercontent.com/9578601/104592975-51e12400-566f-11eb-8053-939753313ff9.png">
<img width="469" alt="Screenshot 2021-01-14 at 13 49 05" src="https://user-images.githubusercontent.com/9578601/104592954-4b52ac80-566f-11eb-9dd2-e4e61c4c17c8.png">
