### PR TITLE
created splash-screen plugin

### DIFF
--- a/packages/expo-splash-screen/app.plugin.js
+++ b/packages/expo-splash-screen/app.plugin.js
@@ -1,0 +1,1 @@
+module.exports = require('./plugin/build/withSplashScreen');

--- a/packages/expo-splash-screen/plugin/build/withSplashScreen.d.ts
+++ b/packages/expo-splash-screen/plugin/build/withSplashScreen.d.ts
@@ -1,0 +1,3 @@
+import { ConfigPlugin } from '@expo/config-plugins';
+declare const _default: ConfigPlugin<void>;
+export default _default;

--- a/packages/expo-splash-screen/plugin/build/withSplashScreen.js
+++ b/packages/expo-splash-screen/plugin/build/withSplashScreen.js
@@ -1,0 +1,12 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const config_plugins_1 = require("@expo/config-plugins");
+const withSplashScreenAndroid_1 = require("./withSplashScreenAndroid");
+const withSplashScreenIOS_1 = require("./withSplashScreenIOS");
+const pkg = require('expo-splash-screen/package.json');
+const withSplashScreen = config => {
+    config = withSplashScreenAndroid_1.withSplashScreenAndroid(config);
+    config = withSplashScreenIOS_1.withSplashScreenIOS(config);
+    return config;
+};
+exports.default = config_plugins_1.createRunOncePlugin(withSplashScreen, pkg.name, pkg.version);

--- a/packages/expo-splash-screen/plugin/build/withSplashScreenAndroid.d.ts
+++ b/packages/expo-splash-screen/plugin/build/withSplashScreenAndroid.d.ts
@@ -1,0 +1,6 @@
+import { ConfigPlugin } from '@expo/config-plugins';
+import { ExpoConfig } from '@expo/config-types';
+import { AndroidSplashScreenConfig } from '@expo/configure-splash-screen';
+export declare const withSplashScreenAndroid: ConfigPlugin;
+export declare function getSplashScreenConfig(config: ExpoConfig): AndroidSplashScreenConfig | undefined;
+export declare function setSplashScreenAsync(config: ExpoConfig, projectRoot: string): Promise<void>;

--- a/packages/expo-splash-screen/plugin/build/withSplashScreenAndroid.js
+++ b/packages/expo-splash-screen/plugin/build/withSplashScreenAndroid.js
@@ -1,0 +1,41 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.setSplashScreenAsync = exports.getSplashScreenConfig = exports.withSplashScreenAndroid = void 0;
+const config_plugins_1 = require("@expo/config-plugins");
+const configure_splash_screen_1 = require("@expo/configure-splash-screen");
+exports.withSplashScreenAndroid = config => {
+    return config_plugins_1.withDangerousMod(config, [
+        'android',
+        async (config) => {
+            await setSplashScreenAsync(config, config.modRequest.projectRoot);
+            return config;
+        },
+    ]);
+};
+function getSplashScreenConfig(config) {
+    var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q, _r, _s, _t, _u, _v, _w, _x, _y, _z, _0, _1, _2;
+    if (!config.splash && !((_a = config.android) === null || _a === void 0 ? void 0 : _a.splash)) {
+        return;
+    }
+    const result = {
+        imageResizeMode: (_f = (_d = (_c = (_b = config.android) === null || _b === void 0 ? void 0 : _b.splash) === null || _c === void 0 ? void 0 : _c.resizeMode) !== null && _d !== void 0 ? _d : (_e = config.splash) === null || _e === void 0 ? void 0 : _e.resizeMode) !== null && _f !== void 0 ? _f : configure_splash_screen_1.SplashScreenImageResizeMode.CONTAIN,
+        backgroundColor: (_l = (_j = (_h = (_g = config.android) === null || _g === void 0 ? void 0 : _g.splash) === null || _h === void 0 ? void 0 : _h.backgroundColor) !== null && _j !== void 0 ? _j : (_k = config.splash) === null || _k === void 0 ? void 0 : _k.backgroundColor) !== null && _l !== void 0 ? _l : '#FFFFFF',
+        image: (_1 = (_y = (_v = (_s = (_p = (_o = (_m = config.android) === null || _m === void 0 ? void 0 : _m.splash) === null || _o === void 0 ? void 0 : _o.xxxhdpi) !== null && _p !== void 0 ? _p : (_r = (_q = config.android) === null || _q === void 0 ? void 0 : _q.splash) === null || _r === void 0 ? void 0 : _r.xxhdpi) !== null && _s !== void 0 ? _s : (_u = (_t = config.android) === null || _t === void 0 ? void 0 : _t.splash) === null || _u === void 0 ? void 0 : _u.xhdpi) !== null && _v !== void 0 ? _v : (_x = (_w = config.android) === null || _w === void 0 ? void 0 : _w.splash) === null || _x === void 0 ? void 0 : _x.hdpi) !== null && _y !== void 0 ? _y : (_0 = (_z = config.android) === null || _z === void 0 ? void 0 : _z.splash) === null || _0 === void 0 ? void 0 : _0.mdpi) !== null && _1 !== void 0 ? _1 : (_2 = config.splash) === null || _2 === void 0 ? void 0 : _2.image,
+    };
+    return result;
+}
+exports.getSplashScreenConfig = getSplashScreenConfig;
+async function setSplashScreenAsync(config, projectRoot) {
+    const splashConfig = getSplashScreenConfig(config);
+    if (!splashConfig) {
+        return;
+    }
+    try {
+        await configure_splash_screen_1.configureAndroidSplashScreen(projectRoot, splashConfig);
+    }
+    catch (e) {
+        // TODO: Throw errors in EXPO_DEBUG
+        config_plugins_1.WarningAggregator.addWarningAndroid('splash', e);
+    }
+}
+exports.setSplashScreenAsync = setSplashScreenAsync;

--- a/packages/expo-splash-screen/plugin/build/withSplashScreenIOS.d.ts
+++ b/packages/expo-splash-screen/plugin/build/withSplashScreenIOS.d.ts
@@ -1,0 +1,6 @@
+import { ConfigPlugin } from '@expo/config-plugins';
+import { ExpoConfig } from '@expo/config-types';
+import { IosSplashScreenConfig } from '@expo/configure-splash-screen';
+export declare const withSplashScreenIOS: ConfigPlugin;
+export declare function getSplashScreen(config: ExpoConfig): IosSplashScreenConfig | undefined;
+export declare function setSplashScreenAsync(config: ExpoConfig, projectRoot: string): Promise<void>;

--- a/packages/expo-splash-screen/plugin/build/withSplashScreenIOS.js
+++ b/packages/expo-splash-screen/plugin/build/withSplashScreenIOS.js
@@ -1,0 +1,41 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.setSplashScreenAsync = exports.getSplashScreen = exports.withSplashScreenIOS = void 0;
+const config_plugins_1 = require("@expo/config-plugins");
+const configure_splash_screen_1 = require("@expo/configure-splash-screen");
+exports.withSplashScreenIOS = config => {
+    return config_plugins_1.withDangerousMod(config, [
+        'ios',
+        async (config) => {
+            await setSplashScreenAsync(config, config.modRequest.projectRoot);
+            return config;
+        },
+    ]);
+};
+function getSplashScreen(config) {
+    var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q;
+    if (!config.splash && !((_a = config.ios) === null || _a === void 0 ? void 0 : _a.splash)) {
+        return;
+    }
+    const result = {
+        imageResizeMode: (_f = (_d = (_c = (_b = config.ios) === null || _b === void 0 ? void 0 : _b.splash) === null || _c === void 0 ? void 0 : _c.resizeMode) !== null && _d !== void 0 ? _d : (_e = config.splash) === null || _e === void 0 ? void 0 : _e.resizeMode) !== null && _f !== void 0 ? _f : configure_splash_screen_1.SplashScreenImageResizeMode.CONTAIN,
+        backgroundColor: (_l = (_j = (_h = (_g = config.ios) === null || _g === void 0 ? void 0 : _g.splash) === null || _h === void 0 ? void 0 : _h.backgroundColor) !== null && _j !== void 0 ? _j : (_k = config.splash) === null || _k === void 0 ? void 0 : _k.backgroundColor) !== null && _l !== void 0 ? _l : '#FFFFFF',
+        image: (_p = (_o = (_m = config.ios) === null || _m === void 0 ? void 0 : _m.splash) === null || _o === void 0 ? void 0 : _o.image) !== null && _p !== void 0 ? _p : (_q = config.splash) === null || _q === void 0 ? void 0 : _q.image,
+    };
+    return result;
+}
+exports.getSplashScreen = getSplashScreen;
+async function setSplashScreenAsync(config, projectRoot) {
+    const splashConfig = getSplashScreen(config);
+    if (!splashConfig) {
+        return;
+    }
+    try {
+        await configure_splash_screen_1.configureIosSplashScreen(projectRoot, splashConfig);
+    }
+    catch (e) {
+        // TODO: Throw errors in EXPO_DEBUG
+        config_plugins_1.WarningAggregator.addWarningIOS('splash', e);
+    }
+}
+exports.setSplashScreenAsync = setSplashScreenAsync;

--- a/packages/expo-splash-screen/plugin/jest.config.js
+++ b/packages/expo-splash-screen/plugin/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = require('expo-module-scripts/jest-preset-plugin');

--- a/packages/expo-splash-screen/plugin/src/withSplashScreen.ts
+++ b/packages/expo-splash-screen/plugin/src/withSplashScreen.ts
@@ -1,0 +1,14 @@
+import { ConfigPlugin, createRunOncePlugin } from '@expo/config-plugins';
+
+import { withSplashScreenAndroid } from './withSplashScreenAndroid';
+import { withSplashScreenIOS } from './withSplashScreenIOS';
+
+const pkg = require('expo-splash-screen/package.json');
+
+const withSplashScreen: ConfigPlugin = config => {
+  config = withSplashScreenAndroid(config);
+  config = withSplashScreenIOS(config);
+  return config;
+};
+
+export default createRunOncePlugin(withSplashScreen, pkg.name, pkg.version);

--- a/packages/expo-splash-screen/plugin/src/withSplashScreenAndroid.ts
+++ b/packages/expo-splash-screen/plugin/src/withSplashScreenAndroid.ts
@@ -1,0 +1,55 @@
+import { ConfigPlugin, WarningAggregator, withDangerousMod } from '@expo/config-plugins';
+import { ExpoConfig } from '@expo/config-types';
+import {
+  AndroidSplashScreenConfig,
+  configureAndroidSplashScreen,
+  SplashScreenImageResizeMode,
+} from '@expo/configure-splash-screen';
+
+export const withSplashScreenAndroid: ConfigPlugin = config => {
+  return withDangerousMod(config, [
+    'android',
+    async config => {
+      await setSplashScreenAsync(config, config.modRequest.projectRoot);
+      return config;
+    },
+  ]);
+};
+
+export function getSplashScreenConfig(config: ExpoConfig): AndroidSplashScreenConfig | undefined {
+  if (!config.splash && !config.android?.splash) {
+    return;
+  }
+
+  const result: AndroidSplashScreenConfig = {
+    imageResizeMode:
+      config.android?.splash?.resizeMode ??
+      config.splash?.resizeMode ??
+      SplashScreenImageResizeMode.CONTAIN,
+    backgroundColor:
+      config.android?.splash?.backgroundColor ?? config.splash?.backgroundColor ?? '#FFFFFF', // white
+    image:
+      config.android?.splash?.xxxhdpi ??
+      config.android?.splash?.xxhdpi ??
+      config.android?.splash?.xhdpi ??
+      config.android?.splash?.hdpi ??
+      config.android?.splash?.mdpi ??
+      config.splash?.image,
+  };
+
+  return result;
+}
+
+export async function setSplashScreenAsync(config: ExpoConfig, projectRoot: string) {
+  const splashConfig = getSplashScreenConfig(config);
+  if (!splashConfig) {
+    return;
+  }
+
+  try {
+    await configureAndroidSplashScreen(projectRoot, splashConfig);
+  } catch (e) {
+    // TODO: Throw errors in EXPO_DEBUG
+    WarningAggregator.addWarningAndroid('splash', e);
+  }
+}

--- a/packages/expo-splash-screen/plugin/src/withSplashScreenIOS.ts
+++ b/packages/expo-splash-screen/plugin/src/withSplashScreenIOS.ts
@@ -1,0 +1,49 @@
+import { ConfigPlugin, WarningAggregator, withDangerousMod } from '@expo/config-plugins';
+import { ExpoConfig } from '@expo/config-types';
+import {
+  configureIosSplashScreen,
+  IosSplashScreenConfig,
+  SplashScreenImageResizeMode,
+} from '@expo/configure-splash-screen';
+
+export const withSplashScreenIOS: ConfigPlugin = config => {
+  return withDangerousMod(config, [
+    'ios',
+    async config => {
+      await setSplashScreenAsync(config, config.modRequest.projectRoot);
+      return config;
+    },
+  ]);
+};
+
+export function getSplashScreen(config: ExpoConfig): IosSplashScreenConfig | undefined {
+  if (!config.splash && !config.ios?.splash) {
+    return;
+  }
+
+  const result: IosSplashScreenConfig = {
+    imageResizeMode:
+      config.ios?.splash?.resizeMode ??
+      config.splash?.resizeMode ??
+      SplashScreenImageResizeMode.CONTAIN,
+    backgroundColor:
+      config.ios?.splash?.backgroundColor ?? config.splash?.backgroundColor ?? '#FFFFFF', // white
+    image: config.ios?.splash?.image ?? config.splash?.image,
+  };
+
+  return result;
+}
+
+export async function setSplashScreenAsync(config: ExpoConfig, projectRoot: string) {
+  const splashConfig = getSplashScreen(config);
+
+  if (!splashConfig) {
+    return;
+  }
+  try {
+    await configureIosSplashScreen(projectRoot, splashConfig);
+  } catch (e) {
+    // TODO: Throw errors in EXPO_DEBUG
+    WarningAggregator.addWarningIOS('splash', e);
+  }
+}

--- a/packages/expo-splash-screen/plugin/tsconfig.json
+++ b/packages/expo-splash-screen/plugin/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "expo-module-scripts/tsconfig.plugin",
+  "compilerOptions": {
+    "outDir": "build",
+    "rootDir": "src"
+  },
+  "include": ["./src"],
+  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+}


### PR DESCRIPTION
# How

- Copied the unversioned plugin into the versioned expo-splash-screen package https://github.com/expo/expo/issues/11561

# Test Plan

- No plugin tests were brought over from config-plugins.
- Ran `EXPO_DEBUG=1 expo prebuild` and examined that the printed config's `_internal.pluginHistory['expo-splash-screen'].version` was `0.8.1` instead of `UNVERSIONED` (i.e. used the versioned plugin instead of the built-in CLI plugin).