### PR TITLE
created updates plugin

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Added alpha support for EAS update manifest format ([#11050](https://github.com/expo/expo/pull/11050) by [@esamelson](https://github.com/esamelson))
 - Keep current update and one older update, for safety and to make rollbacks faster ([#11449](https://github.com/expo/expo/pull/11449) by [@esamelson](https://github.com/esamelson))
+- Created config plugin. ([#11635](https://github.com/expo/expo/pull/11635) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-updates/app.plugin.js
+++ b/packages/expo-updates/app.plugin.js
@@ -1,0 +1,1 @@
+module.exports = require('./plugin/build/withUpdates');

--- a/packages/expo-updates/package.json
+++ b/packages/expo-updates/package.json
@@ -39,6 +39,7 @@
     "expo-file-system": "*"
   },
   "dependencies": {
+    "@expo/config-plugins": "^1.0.14",
     "@expo/metro-config": "^0.1.16",
     "fbemitter": "^2.1.1",
     "uuid": "^3.4.0"

--- a/packages/expo-updates/plugin/build/withUpdates.d.ts
+++ b/packages/expo-updates/plugin/build/withUpdates.d.ts
@@ -1,0 +1,5 @@
+import { ConfigPlugin } from '@expo/config-plugins';
+declare const _default: ConfigPlugin<{
+    expoUsername: string | null;
+}>;
+export default _default;

--- a/packages/expo-updates/plugin/build/withUpdates.js
+++ b/packages/expo-updates/plugin/build/withUpdates.js
@@ -1,0 +1,12 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const config_plugins_1 = require("@expo/config-plugins");
+const withUpdatesAndroid_1 = require("./withUpdatesAndroid");
+const withUpdatesIOS_1 = require("./withUpdatesIOS");
+const pkg = require('expo-updates/package.json');
+const withUpdates = (config, props) => {
+    config = withUpdatesAndroid_1.withUpdatesAndroid(config, props);
+    config = withUpdatesIOS_1.withUpdatesIOS(config, props);
+    return config;
+};
+exports.default = config_plugins_1.createRunOncePlugin(withUpdates, pkg.name, pkg.version);

--- a/packages/expo-updates/plugin/build/withUpdatesAndroid.d.ts
+++ b/packages/expo-updates/plugin/build/withUpdatesAndroid.d.ts
@@ -1,0 +1,28 @@
+import { AndroidConfig, ConfigPlugin } from '@expo/config-plugins';
+import { ExpoConfig } from '@expo/config-types';
+declare type ExpoConfigUpdates = Pick<ExpoConfig, 'sdkVersion' | 'owner' | 'runtimeVersion' | 'nodeModulesPath' | 'updates' | 'slug'>;
+export declare enum Config {
+    ENABLED = "expo.modules.updates.ENABLED",
+    CHECK_ON_LAUNCH = "expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH",
+    LAUNCH_WAIT_MS = "expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS",
+    SDK_VERSION = "expo.modules.updates.EXPO_SDK_VERSION",
+    RUNTIME_VERSION = "expo.modules.updates.EXPO_RUNTIME_VERSION",
+    UPDATE_URL = "expo.modules.updates.EXPO_UPDATE_URL"
+}
+export declare const withUpdatesAndroid: ConfigPlugin<{
+    expoUsername: string | null;
+}>;
+export declare function getUpdateUrl(config: Pick<ExpoConfigUpdates, 'owner' | 'slug'>, username: string | null): string | null;
+export declare function getRuntimeVersion(config: Pick<ExpoConfigUpdates, 'runtimeVersion'>): string | null;
+export declare function getSDKVersion(config: Pick<ExpoConfigUpdates, 'sdkVersion'>): string | null;
+export declare function getUpdatesEnabled(config: Pick<ExpoConfigUpdates, 'updates'>): boolean;
+export declare function getUpdatesTimeout(config: Pick<ExpoConfigUpdates, 'updates'>): number;
+export declare function getUpdatesCheckOnLaunch(config: Pick<ExpoConfigUpdates, 'updates'>): 'NEVER' | 'ALWAYS';
+export declare function setUpdatesConfig(config: ExpoConfigUpdates, androidManifest: AndroidConfig.Manifest.AndroidManifest, username: string | null): AndroidConfig.Manifest.AndroidManifest;
+export declare function setVersionsConfig(config: Pick<ExpoConfigUpdates, 'sdkVersion' | 'runtimeVersion'>, androidManifest: AndroidConfig.Manifest.AndroidManifest): AndroidConfig.Manifest.AndroidManifest;
+export declare function formatApplyLineForBuildGradle(projectRoot: string, config: Pick<ExpoConfigUpdates, 'nodeModulesPath'>): string;
+export declare function isBuildGradleConfigured(buildGradleContent: string, projectRoot: string, config: Pick<ExpoConfigUpdates, 'nodeModulesPath'>): boolean;
+export declare function isMainApplicationMetaDataSet(androidManifest: AndroidConfig.Manifest.AndroidManifest): boolean;
+export declare function isMainApplicationMetaDataSynced(config: ExpoConfigUpdates, androidManifest: AndroidConfig.Manifest.AndroidManifest, username: string | null): boolean;
+export declare function areVersionsSynced(config: Pick<ExpoConfigUpdates, 'runtimeVersion' | 'sdkVersion'>, androidManifest: AndroidConfig.Manifest.AndroidManifest): boolean;
+export {};

--- a/packages/expo-updates/plugin/build/withUpdatesAndroid.js
+++ b/packages/expo-updates/plugin/build/withUpdatesAndroid.js
@@ -1,0 +1,139 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.areVersionsSynced = exports.isMainApplicationMetaDataSynced = exports.isMainApplicationMetaDataSet = exports.isBuildGradleConfigured = exports.formatApplyLineForBuildGradle = exports.setVersionsConfig = exports.setUpdatesConfig = exports.getUpdatesCheckOnLaunch = exports.getUpdatesTimeout = exports.getUpdatesEnabled = exports.getSDKVersion = exports.getRuntimeVersion = exports.getUpdateUrl = exports.withUpdatesAndroid = exports.Config = void 0;
+const config_plugins_1 = require("@expo/config-plugins");
+const modules_1 = require("@expo/config-plugins/build/utils/modules");
+const path_1 = __importDefault(require("path"));
+const { addMetaDataItemToMainApplication, getMainApplicationMetaDataValue, getMainApplicationOrThrow, removeMetaDataItemFromMainApplication, } = config_plugins_1.AndroidConfig.Manifest;
+var Config;
+(function (Config) {
+    Config["ENABLED"] = "expo.modules.updates.ENABLED";
+    Config["CHECK_ON_LAUNCH"] = "expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH";
+    Config["LAUNCH_WAIT_MS"] = "expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS";
+    Config["SDK_VERSION"] = "expo.modules.updates.EXPO_SDK_VERSION";
+    Config["RUNTIME_VERSION"] = "expo.modules.updates.EXPO_RUNTIME_VERSION";
+    Config["UPDATE_URL"] = "expo.modules.updates.EXPO_UPDATE_URL";
+})(Config = exports.Config || (exports.Config = {}));
+exports.withUpdatesAndroid = (config, { expoUsername }) => {
+    return config_plugins_1.withAndroidManifest(config, config => {
+        config.modResults = setUpdatesConfig(config, config.modResults, expoUsername);
+        return config;
+    });
+};
+function getUpdateUrl(config, username) {
+    const user = typeof config.owner === 'string' ? config.owner : username;
+    if (!user) {
+        return null;
+    }
+    return `https://exp.host/@${user}/${config.slug}`;
+}
+exports.getUpdateUrl = getUpdateUrl;
+function getRuntimeVersion(config) {
+    return typeof config.runtimeVersion === 'string' ? config.runtimeVersion : null;
+}
+exports.getRuntimeVersion = getRuntimeVersion;
+function getSDKVersion(config) {
+    return typeof config.sdkVersion === 'string' ? config.sdkVersion : null;
+}
+exports.getSDKVersion = getSDKVersion;
+function getUpdatesEnabled(config) {
+    var _a;
+    return ((_a = config.updates) === null || _a === void 0 ? void 0 : _a.enabled) !== false;
+}
+exports.getUpdatesEnabled = getUpdatesEnabled;
+function getUpdatesTimeout(config) {
+    var _a, _b;
+    return (_b = (_a = config.updates) === null || _a === void 0 ? void 0 : _a.fallbackToCacheTimeout) !== null && _b !== void 0 ? _b : 0;
+}
+exports.getUpdatesTimeout = getUpdatesTimeout;
+function getUpdatesCheckOnLaunch(config) {
+    var _a, _b;
+    if (((_a = config.updates) === null || _a === void 0 ? void 0 : _a.checkAutomatically) === 'ON_ERROR_RECOVERY') {
+        return 'NEVER';
+    }
+    else if (((_b = config.updates) === null || _b === void 0 ? void 0 : _b.checkAutomatically) === 'ON_LOAD') {
+        return 'ALWAYS';
+    }
+    return 'ALWAYS';
+}
+exports.getUpdatesCheckOnLaunch = getUpdatesCheckOnLaunch;
+function setUpdatesConfig(config, androidManifest, username) {
+    const mainApplication = getMainApplicationOrThrow(androidManifest);
+    addMetaDataItemToMainApplication(mainApplication, Config.ENABLED, String(getUpdatesEnabled(config)));
+    addMetaDataItemToMainApplication(mainApplication, Config.CHECK_ON_LAUNCH, getUpdatesCheckOnLaunch(config));
+    addMetaDataItemToMainApplication(mainApplication, Config.LAUNCH_WAIT_MS, String(getUpdatesTimeout(config)));
+    const updateUrl = getUpdateUrl(config, username);
+    if (updateUrl) {
+        addMetaDataItemToMainApplication(mainApplication, Config.UPDATE_URL, updateUrl);
+    }
+    else {
+        removeMetaDataItemFromMainApplication(mainApplication, Config.UPDATE_URL);
+    }
+    return setVersionsConfig(config, androidManifest);
+}
+exports.setUpdatesConfig = setUpdatesConfig;
+function setVersionsConfig(config, androidManifest) {
+    const mainApplication = getMainApplicationOrThrow(androidManifest);
+    const runtimeVersion = getRuntimeVersion(config);
+    const sdkVersion = getSDKVersion(config);
+    if (runtimeVersion) {
+        removeMetaDataItemFromMainApplication(mainApplication, Config.SDK_VERSION);
+        addMetaDataItemToMainApplication(mainApplication, Config.RUNTIME_VERSION, runtimeVersion);
+    }
+    else if (sdkVersion) {
+        removeMetaDataItemFromMainApplication(mainApplication, Config.RUNTIME_VERSION);
+        addMetaDataItemToMainApplication(mainApplication, Config.SDK_VERSION, sdkVersion);
+    }
+    else {
+        removeMetaDataItemFromMainApplication(mainApplication, Config.RUNTIME_VERSION);
+        removeMetaDataItemFromMainApplication(mainApplication, Config.SDK_VERSION);
+    }
+    return androidManifest;
+}
+exports.setVersionsConfig = setVersionsConfig;
+function formatApplyLineForBuildGradle(projectRoot, config) {
+    const updatesGradleScriptPath = modules_1.projectHasModule('expo-updates/scripts/create-manifest-android.gradle', projectRoot, config);
+    if (!updatesGradleScriptPath) {
+        throw new Error("Could not find the build script for Android. This could happen in case of outdated 'node_modules'. Run 'npm install' to make sure that it's up-to-date.");
+    }
+    return `apply from: ${JSON.stringify(path_1.default.relative(path_1.default.join(projectRoot, 'android', 'app'), updatesGradleScriptPath))}`;
+}
+exports.formatApplyLineForBuildGradle = formatApplyLineForBuildGradle;
+function isBuildGradleConfigured(buildGradleContent, projectRoot, config) {
+    const androidBuildScript = formatApplyLineForBuildGradle(projectRoot, config);
+    return (buildGradleContent
+        .split('\n')
+        // Check for both single and double quotes
+        .some(line => line === androidBuildScript || line === androidBuildScript.replace(/"/g, "'")));
+}
+exports.isBuildGradleConfigured = isBuildGradleConfigured;
+function isMainApplicationMetaDataSet(androidManifest) {
+    const updateUrl = getMainApplicationMetaDataValue(androidManifest, Config.UPDATE_URL);
+    const runtimeVersion = getMainApplicationMetaDataValue(androidManifest, Config.RUNTIME_VERSION);
+    const sdkVersion = getMainApplicationMetaDataValue(androidManifest, Config.SDK_VERSION);
+    return Boolean(updateUrl && (sdkVersion || runtimeVersion));
+}
+exports.isMainApplicationMetaDataSet = isMainApplicationMetaDataSet;
+function isMainApplicationMetaDataSynced(config, androidManifest, username) {
+    return (getUpdateUrl(config, username) ===
+        getMainApplicationMetaDataValue(androidManifest, Config.UPDATE_URL) &&
+        String(getUpdatesEnabled(config)) ===
+            getMainApplicationMetaDataValue(androidManifest, Config.ENABLED) &&
+        String(getUpdatesTimeout(config)) ===
+            getMainApplicationMetaDataValue(androidManifest, Config.LAUNCH_WAIT_MS) &&
+        getUpdatesCheckOnLaunch(config) ===
+            getMainApplicationMetaDataValue(androidManifest, Config.CHECK_ON_LAUNCH) &&
+        areVersionsSynced(config, androidManifest));
+}
+exports.isMainApplicationMetaDataSynced = isMainApplicationMetaDataSynced;
+function areVersionsSynced(config, androidManifest) {
+    const expectedRuntimeVersion = getRuntimeVersion(config);
+    const expectedSdkVersion = getSDKVersion(config);
+    const currentRuntimeVersion = getMainApplicationMetaDataValue(androidManifest, Config.RUNTIME_VERSION);
+    const currentSdkVersion = getMainApplicationMetaDataValue(androidManifest, Config.SDK_VERSION);
+    return (currentRuntimeVersion === expectedRuntimeVersion && currentSdkVersion === expectedSdkVersion);
+}
+exports.areVersionsSynced = areVersionsSynced;

--- a/packages/expo-updates/plugin/build/withUpdatesIOS.d.ts
+++ b/packages/expo-updates/plugin/build/withUpdatesIOS.d.ts
@@ -1,6 +1,6 @@
-import { ExpoConfig } from '@expo/config-types';
 import { ConfigPlugin } from '@expo/config-plugins';
 import { ExpoPlist } from '@expo/config-plugins/build/ios/IosConfig.types';
+import { ExpoConfig } from '@expo/config-types';
 declare type XcodeProject = any;
 declare type ExpoConfigUpdates = Pick<ExpoConfig, 'sdkVersion' | 'owner' | 'runtimeVersion' | 'nodeModulesPath' | 'updates' | 'slug'>;
 export declare enum Config {

--- a/packages/expo-updates/plugin/build/withUpdatesIOS.d.ts
+++ b/packages/expo-updates/plugin/build/withUpdatesIOS.d.ts
@@ -1,0 +1,30 @@
+import { ExpoConfig } from '@expo/config-types';
+import { ConfigPlugin } from '@expo/config-plugins';
+import { ExpoPlist } from '@expo/config-plugins/build/ios/IosConfig.types';
+declare type XcodeProject = any;
+declare type ExpoConfigUpdates = Pick<ExpoConfig, 'sdkVersion' | 'owner' | 'runtimeVersion' | 'nodeModulesPath' | 'updates' | 'slug'>;
+export declare enum Config {
+    ENABLED = "EXUpdatesEnabled",
+    CHECK_ON_LAUNCH = "EXUpdatesCheckOnLaunch",
+    LAUNCH_WAIT_MS = "EXUpdatesLaunchWaitMs",
+    RUNTIME_VERSION = "EXUpdatesRuntimeVersion",
+    SDK_VERSION = "EXUpdatesSDKVersion",
+    UPDATE_URL = "EXUpdatesURL"
+}
+export declare function getUpdateUrl(config: Pick<ExpoConfigUpdates, 'owner' | 'slug'>, username: string | null): string | null;
+export declare function getRuntimeVersion(config: Pick<ExpoConfigUpdates, 'runtimeVersion'>): string | null;
+export declare function getSDKVersion(config: Pick<ExpoConfigUpdates, 'sdkVersion'>): string | null;
+export declare function getUpdatesEnabled(config: Pick<ExpoConfigUpdates, 'updates'>): boolean;
+export declare function getUpdatesTimeout(config: Pick<ExpoConfigUpdates, 'updates'>): number;
+export declare function getUpdatesCheckOnLaunch(config: Pick<ExpoConfigUpdates, 'updates'>): 'NEVER' | 'ALWAYS';
+export declare const withUpdatesIOS: ConfigPlugin<{
+    expoUsername: string | null;
+}>;
+export declare function setUpdatesConfig(config: ExpoConfigUpdates, expoPlist: ExpoPlist, username: string | null): ExpoPlist;
+export declare function setVersionsConfig(config: ExpoConfigUpdates, expoPlist: ExpoPlist): ExpoPlist;
+export declare function ensureBundleReactNativePhaseContainsConfigurationScript(projectRoot: string, config: Pick<ExpoConfigUpdates, 'nodeModulesPath'>, project: XcodeProject): XcodeProject;
+export declare function isShellScriptBuildPhaseConfigured(projectRoot: string, config: Pick<ExpoConfigUpdates, 'nodeModulesPath'>, project: XcodeProject): boolean;
+export declare function isPlistConfigurationSet(expoPlist: ExpoPlist): boolean;
+export declare function isPlistConfigurationSynced(config: ExpoConfigUpdates, expoPlist: ExpoPlist, username: string | null): boolean;
+export declare function isPlistVersionConfigurationSynced(config: Pick<ExpoConfigUpdates, 'sdkVersion' | 'runtimeVersion'>, expoPlist: ExpoPlist): boolean;
+export {};

--- a/packages/expo-updates/plugin/build/withUpdatesIOS.js
+++ b/packages/expo-updates/plugin/build/withUpdatesIOS.js
@@ -1,0 +1,164 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.isPlistVersionConfigurationSynced = exports.isPlistConfigurationSynced = exports.isPlistConfigurationSet = exports.isShellScriptBuildPhaseConfigured = exports.ensureBundleReactNativePhaseContainsConfigurationScript = exports.setVersionsConfig = exports.setUpdatesConfig = exports.withUpdatesIOS = exports.getUpdatesCheckOnLaunch = exports.getUpdatesTimeout = exports.getUpdatesEnabled = exports.getSDKVersion = exports.getRuntimeVersion = exports.getUpdateUrl = exports.Config = void 0;
+const path = __importStar(require("path"));
+const config_plugins_1 = require("@expo/config-plugins");
+const modules_1 = require("@expo/config-plugins/build/utils/modules");
+var Config;
+(function (Config) {
+    Config["ENABLED"] = "EXUpdatesEnabled";
+    Config["CHECK_ON_LAUNCH"] = "EXUpdatesCheckOnLaunch";
+    Config["LAUNCH_WAIT_MS"] = "EXUpdatesLaunchWaitMs";
+    Config["RUNTIME_VERSION"] = "EXUpdatesRuntimeVersion";
+    Config["SDK_VERSION"] = "EXUpdatesSDKVersion";
+    Config["UPDATE_URL"] = "EXUpdatesURL";
+})(Config = exports.Config || (exports.Config = {}));
+function getUpdateUrl(config, username) {
+    const user = typeof config.owner === 'string' ? config.owner : username;
+    if (!user) {
+        return null;
+    }
+    return `https://exp.host/@${user}/${config.slug}`;
+}
+exports.getUpdateUrl = getUpdateUrl;
+function getRuntimeVersion(config) {
+    return typeof config.runtimeVersion === 'string' ? config.runtimeVersion : null;
+}
+exports.getRuntimeVersion = getRuntimeVersion;
+function getSDKVersion(config) {
+    return typeof config.sdkVersion === 'string' ? config.sdkVersion : null;
+}
+exports.getSDKVersion = getSDKVersion;
+function getUpdatesEnabled(config) {
+    var _a;
+    return ((_a = config.updates) === null || _a === void 0 ? void 0 : _a.enabled) !== false;
+}
+exports.getUpdatesEnabled = getUpdatesEnabled;
+function getUpdatesTimeout(config) {
+    var _a, _b;
+    return (_b = (_a = config.updates) === null || _a === void 0 ? void 0 : _a.fallbackToCacheTimeout) !== null && _b !== void 0 ? _b : 0;
+}
+exports.getUpdatesTimeout = getUpdatesTimeout;
+function getUpdatesCheckOnLaunch(config) {
+    var _a, _b;
+    if (((_a = config.updates) === null || _a === void 0 ? void 0 : _a.checkAutomatically) === 'ON_ERROR_RECOVERY') {
+        return 'NEVER';
+    }
+    else if (((_b = config.updates) === null || _b === void 0 ? void 0 : _b.checkAutomatically) === 'ON_LOAD') {
+        return 'ALWAYS';
+    }
+    return 'ALWAYS';
+}
+exports.getUpdatesCheckOnLaunch = getUpdatesCheckOnLaunch;
+exports.withUpdatesIOS = (config, { expoUsername }) => {
+    return config_plugins_1.withExpoPlist(config, config => {
+        config.modResults = setUpdatesConfig(config, config.modResults, expoUsername);
+        return config;
+    });
+};
+function setUpdatesConfig(config, expoPlist, username) {
+    const newExpoPlist = {
+        ...expoPlist,
+        [Config.ENABLED]: getUpdatesEnabled(config),
+        [Config.CHECK_ON_LAUNCH]: getUpdatesCheckOnLaunch(config),
+        [Config.LAUNCH_WAIT_MS]: getUpdatesTimeout(config),
+    };
+    const updateUrl = getUpdateUrl(config, username);
+    if (updateUrl) {
+        newExpoPlist[Config.UPDATE_URL] = updateUrl;
+    }
+    else {
+        delete newExpoPlist[Config.UPDATE_URL];
+    }
+    return setVersionsConfig(config, newExpoPlist);
+}
+exports.setUpdatesConfig = setUpdatesConfig;
+function setVersionsConfig(config, expoPlist) {
+    const newExpoPlist = { ...expoPlist };
+    const runtimeVersion = getRuntimeVersion(config);
+    const sdkVersion = getSDKVersion(config);
+    if (runtimeVersion) {
+        delete newExpoPlist[Config.SDK_VERSION];
+        newExpoPlist[Config.RUNTIME_VERSION] = runtimeVersion;
+    }
+    else if (sdkVersion) {
+        delete newExpoPlist[Config.RUNTIME_VERSION];
+        newExpoPlist[Config.SDK_VERSION] = sdkVersion;
+    }
+    else {
+        delete newExpoPlist[Config.SDK_VERSION];
+        delete newExpoPlist[Config.RUNTIME_VERSION];
+    }
+    return newExpoPlist;
+}
+exports.setVersionsConfig = setVersionsConfig;
+function formatConfigurationScriptPath(projectRoot, config) {
+    const buildScriptPath = modules_1.projectHasModule('expo-updates/scripts/create-manifest-ios.sh', projectRoot, config);
+    if (!buildScriptPath) {
+        throw new Error("Could not find the build script for iOS. This could happen in case of outdated 'node_modules'. Run 'npm install' to make sure that it's up-to-date.");
+    }
+    return path.relative(path.join(projectRoot, 'ios'), buildScriptPath);
+}
+function getBundleReactNativePhase(project) {
+    const shellScriptBuildPhase = project.hash.project.objects.PBXShellScriptBuildPhase;
+    const bundleReactNative = Object.values(shellScriptBuildPhase).find(buildPhase => buildPhase.name === '"Bundle React Native code and images"');
+    if (!bundleReactNative) {
+        throw new Error(`Couldn't find a build phase "Bundle React Native code and images"`);
+    }
+    return bundleReactNative;
+}
+function ensureBundleReactNativePhaseContainsConfigurationScript(projectRoot, config, project) {
+    const bundleReactNative = getBundleReactNativePhase(project);
+    const buildPhaseShellScriptPath = formatConfigurationScriptPath(projectRoot, config);
+    if (!bundleReactNative.shellScript.includes(buildPhaseShellScriptPath)) {
+        bundleReactNative.shellScript = `${bundleReactNative.shellScript.replace(/"$/, '')}${buildPhaseShellScriptPath}\\n"`;
+    }
+    return project;
+}
+exports.ensureBundleReactNativePhaseContainsConfigurationScript = ensureBundleReactNativePhaseContainsConfigurationScript;
+function isShellScriptBuildPhaseConfigured(projectRoot, config, project) {
+    const bundleReactNative = getBundleReactNativePhase(project);
+    const buildPhaseShellScriptPath = formatConfigurationScriptPath(projectRoot, config);
+    return bundleReactNative.shellScript.includes(buildPhaseShellScriptPath);
+}
+exports.isShellScriptBuildPhaseConfigured = isShellScriptBuildPhaseConfigured;
+function isPlistConfigurationSet(expoPlist) {
+    return Boolean(expoPlist.EXUpdatesURL && (expoPlist.EXUpdatesSDKVersion || expoPlist.EXUpdatesRuntimeVersion));
+}
+exports.isPlistConfigurationSet = isPlistConfigurationSet;
+function isPlistConfigurationSynced(config, expoPlist, username) {
+    return (getUpdateUrl(config, username) === expoPlist.EXUpdatesURL &&
+        getUpdatesEnabled(config) === expoPlist.EXUpdatesEnabled &&
+        getUpdatesTimeout(config) === expoPlist.EXUpdatesLaunchWaitMs &&
+        getUpdatesCheckOnLaunch(config) === expoPlist.EXUpdatesCheckOnLaunch &&
+        isPlistVersionConfigurationSynced(config, expoPlist));
+}
+exports.isPlistConfigurationSynced = isPlistConfigurationSynced;
+function isPlistVersionConfigurationSynced(config, expoPlist) {
+    var _a, _b;
+    const expectedRuntimeVersion = getRuntimeVersion(config);
+    const expectedSdkVersion = getSDKVersion(config);
+    const currentRuntimeVersion = (_a = expoPlist.EXUpdatesRuntimeVersion) !== null && _a !== void 0 ? _a : null;
+    const currentSdkVersion = (_b = expoPlist.EXUpdatesSDKVersion) !== null && _b !== void 0 ? _b : null;
+    return (currentSdkVersion === expectedSdkVersion && currentRuntimeVersion === expectedRuntimeVersion);
+}
+exports.isPlistVersionConfigurationSynced = isPlistVersionConfigurationSynced;

--- a/packages/expo-updates/plugin/build/withUpdatesIOS.js
+++ b/packages/expo-updates/plugin/build/withUpdatesIOS.js
@@ -20,9 +20,9 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.isPlistVersionConfigurationSynced = exports.isPlistConfigurationSynced = exports.isPlistConfigurationSet = exports.isShellScriptBuildPhaseConfigured = exports.ensureBundleReactNativePhaseContainsConfigurationScript = exports.setVersionsConfig = exports.setUpdatesConfig = exports.withUpdatesIOS = exports.getUpdatesCheckOnLaunch = exports.getUpdatesTimeout = exports.getUpdatesEnabled = exports.getSDKVersion = exports.getRuntimeVersion = exports.getUpdateUrl = exports.Config = void 0;
-const path = __importStar(require("path"));
 const config_plugins_1 = require("@expo/config-plugins");
 const modules_1 = require("@expo/config-plugins/build/utils/modules");
+const path = __importStar(require("path"));
 var Config;
 (function (Config) {
     Config["ENABLED"] = "EXUpdatesEnabled";

--- a/packages/expo-updates/plugin/jest.config.js
+++ b/packages/expo-updates/plugin/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = require('expo-module-scripts/jest-preset-plugin');

--- a/packages/expo-updates/plugin/src/__tests__/fixtures/react-native-AndroidManifest.xml
+++ b/packages/expo-updates/plugin/src/__tests__/fixtures/react-native-AndroidManifest.xml
@@ -1,0 +1,24 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  package="com.expo.mycoolapp">
+    <uses-permission android:name="android.permission.INTERNET" />
+    <application
+      android:name=".MainApplication"
+      android:label="@string/app_name"
+      android:icon="@mipmap/ic_launcher"
+      android:roundIcon="@mipmap/ic_launcher_round"
+      android:allowBackup="true"
+      android:theme="@style/AppTheme">
+      <activity
+        android:name=".MainActivity"
+        android:launchMode="singleTask"
+        android:label="@string/app_name"
+        android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
+        android:windowSoftInputMode="adjustResize">
+        <intent-filter>
+            <action android:name="android.intent.action.MAIN" />
+            <category android:name="android.intent.category.LAUNCHER" />
+        </intent-filter>
+      </activity>
+      <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
+    </application>
+</manifest>

--- a/packages/expo-updates/plugin/src/__tests__/withUpdatesAndroid-test.ts
+++ b/packages/expo-updates/plugin/src/__tests__/withUpdatesAndroid-test.ts
@@ -1,0 +1,82 @@
+import { AndroidConfig } from '@expo/config-plugins';
+import { ExpoConfig } from '@expo/config-types';
+import { resolve } from 'path';
+
+import * as Updates from '../withUpdatesAndroid';
+
+const { getMainApplication, readAndroidManifestAsync } = AndroidConfig.Manifest;
+const fixturesPath = resolve(__dirname, 'fixtures');
+const sampleManifestPath = resolve(fixturesPath, 'react-native-AndroidManifest.xml');
+
+describe('Android Updates config', () => {
+  it(`returns correct default values from all getters if no value provided`, () => {
+    expect(Updates.getSDKVersion({})).toBe(null);
+    expect(Updates.getUpdateUrl({ slug: 'foo' }, null)).toBe(null);
+    expect(Updates.getUpdatesCheckOnLaunch({})).toBe('ALWAYS');
+    expect(Updates.getUpdatesEnabled({})).toBe(true);
+    expect(Updates.getUpdatesTimeout({})).toBe(0);
+  });
+
+  it(`returns correct value from all getters if value provided`, () => {
+    expect(Updates.getSDKVersion({ sdkVersion: '37.0.0' })).toBe('37.0.0');
+    expect(Updates.getUpdateUrl({ slug: 'my-app' }, 'user')).toBe('https://exp.host/@user/my-app');
+    expect(Updates.getUpdateUrl({ slug: 'my-app', owner: 'owner' }, 'user')).toBe(
+      'https://exp.host/@owner/my-app'
+    );
+    expect(
+      Updates.getUpdatesCheckOnLaunch({ updates: { checkAutomatically: 'ON_ERROR_RECOVERY' } })
+    ).toBe('NEVER');
+    expect(Updates.getUpdatesCheckOnLaunch({ updates: { checkAutomatically: 'ON_LOAD' } })).toBe(
+      'ALWAYS'
+    );
+    expect(Updates.getUpdatesEnabled({ updates: { enabled: false } })).toBe(false);
+    expect(Updates.getUpdatesTimeout({ updates: { fallbackToCacheTimeout: 2000 } })).toBe(2000);
+  });
+
+  it('set correct values in AndroidManifest.xml', async () => {
+    let androidManifestJson = await readAndroidManifestAsync(sampleManifestPath);
+    const config: ExpoConfig = {
+      name: 'foo',
+      sdkVersion: '37.0.0',
+      slug: 'my-app',
+      owner: 'owner',
+      updates: {
+        enabled: false,
+        fallbackToCacheTimeout: 2000,
+        checkAutomatically: 'ON_ERROR_RECOVERY',
+      },
+    };
+    androidManifestJson = await Updates.setUpdatesConfig(config, androidManifestJson, 'user');
+    const mainApplication = getMainApplication(androidManifestJson);
+
+    const updateUrl = mainApplication['meta-data'].filter(
+      e => e.$['android:name'] === 'expo.modules.updates.EXPO_UPDATE_URL'
+    );
+    expect(updateUrl).toHaveLength(1);
+    expect(updateUrl[0].$['android:value']).toMatch('https://exp.host/@owner/my-app');
+
+    const sdkVersion = mainApplication['meta-data'].filter(
+      e => e.$['android:name'] === 'expo.modules.updates.EXPO_SDK_VERSION'
+    );
+    expect(sdkVersion).toHaveLength(1);
+    expect(sdkVersion[0].$['android:value']).toMatch('37.0.0');
+
+    const enabled = mainApplication['meta-data'].filter(
+      e => e.$['android:name'] === 'expo.modules.updates.ENABLED'
+    );
+    expect(enabled).toHaveLength(1);
+    expect(enabled[0].$['android:value']).toMatch('false');
+
+    const checkOnLaunch = mainApplication['meta-data'].filter(
+      e => e.$['android:name'] === 'expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH'
+    );
+    expect(checkOnLaunch).toHaveLength(1);
+    expect(checkOnLaunch[0].$['android:value']).toMatch('NEVER');
+
+    const timeout = mainApplication['meta-data'].filter(
+      e => e.$['android:name'] === 'expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS'
+    );
+    expect(timeout).toHaveLength(1);
+    expect(timeout[0].$['android:value']).toMatch('2000');
+  });
+});

--- a/packages/expo-updates/plugin/src/__tests__/withUpdatesIOS-test.ts
+++ b/packages/expo-updates/plugin/src/__tests__/withUpdatesIOS-test.ts
@@ -1,0 +1,52 @@
+import * as Updates from '../withUpdatesIOS';
+
+describe('iOS Updates config', () => {
+  it(`returns correct default values from all getters if no value provided`, () => {
+    expect(Updates.getSDKVersion({})).toBe(null);
+    expect(Updates.getUpdateUrl({ slug: 'foo' }, null)).toBe(null);
+    expect(Updates.getUpdatesCheckOnLaunch({})).toBe('ALWAYS');
+    expect(Updates.getUpdatesEnabled({})).toBe(true);
+    expect(Updates.getUpdatesTimeout({})).toBe(0);
+  });
+
+  it(`returns correct value from all getters if value provided`, () => {
+    expect(Updates.getSDKVersion({ sdkVersion: '37.0.0' })).toBe('37.0.0');
+    expect(Updates.getUpdateUrl({ slug: 'my-app' }, 'user')).toBe('https://exp.host/@user/my-app');
+    expect(Updates.getUpdateUrl({ slug: 'my-app', owner: 'owner' }, 'user')).toBe(
+      'https://exp.host/@owner/my-app'
+    );
+    expect(
+      Updates.getUpdatesCheckOnLaunch({ updates: { checkAutomatically: 'ON_ERROR_RECOVERY' } })
+    ).toBe('NEVER');
+    expect(Updates.getUpdatesCheckOnLaunch({ updates: { checkAutomatically: 'ON_LOAD' } })).toBe(
+      'ALWAYS'
+    );
+    expect(Updates.getUpdatesEnabled({ updates: { enabled: false } })).toBe(false);
+    expect(Updates.getUpdatesTimeout({ updates: { fallbackToCacheTimeout: 2000 } })).toBe(2000);
+  });
+
+  it('sets the correct values in Expo.plist', () => {
+    expect(
+      Updates.setUpdatesConfig(
+        {
+          sdkVersion: '37.0.0',
+          slug: 'my-app',
+          owner: 'owner',
+          updates: {
+            enabled: false,
+            fallbackToCacheTimeout: 2000,
+            checkAutomatically: 'ON_ERROR_RECOVERY',
+          },
+        },
+        {},
+        'user'
+      )
+    ).toMatchObject({
+      EXUpdatesEnabled: false,
+      EXUpdatesURL: 'https://exp.host/@owner/my-app',
+      EXUpdatesCheckOnLaunch: 'NEVER',
+      EXUpdatesLaunchWaitMs: 2000,
+      EXUpdatesSDKVersion: '37.0.0',
+    });
+  });
+});

--- a/packages/expo-updates/plugin/src/withUpdates.ts
+++ b/packages/expo-updates/plugin/src/withUpdates.ts
@@ -1,0 +1,14 @@
+import { ConfigPlugin, createRunOncePlugin } from '@expo/config-plugins';
+
+import { withUpdatesAndroid } from './withUpdatesAndroid';
+import { withUpdatesIOS } from './withUpdatesIOS';
+
+const pkg = require('expo-updates/package.json');
+
+const withUpdates: ConfigPlugin<{ expoUsername: string | null }> = (config, props) => {
+  config = withUpdatesAndroid(config, props);
+  config = withUpdatesIOS(config, props);
+  return config;
+};
+
+export default createRunOncePlugin(withUpdates, pkg.name, pkg.version);

--- a/packages/expo-updates/plugin/src/withUpdatesAndroid.ts
+++ b/packages/expo-updates/plugin/src/withUpdatesAndroid.ts
@@ -1,0 +1,211 @@
+import { AndroidConfig, ConfigPlugin, withAndroidManifest } from '@expo/config-plugins';
+import { projectHasModule } from '@expo/config-plugins/build/utils/modules';
+import { ExpoConfig } from '@expo/config-types';
+import path from 'path';
+
+const {
+  addMetaDataItemToMainApplication,
+  getMainApplicationMetaDataValue,
+  getMainApplicationOrThrow,
+  removeMetaDataItemFromMainApplication,
+} = AndroidConfig.Manifest;
+
+type ExpoConfigUpdates = Pick<
+  ExpoConfig,
+  'sdkVersion' | 'owner' | 'runtimeVersion' | 'nodeModulesPath' | 'updates' | 'slug'
+>;
+
+export enum Config {
+  ENABLED = 'expo.modules.updates.ENABLED',
+  CHECK_ON_LAUNCH = 'expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH',
+  LAUNCH_WAIT_MS = 'expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS',
+  SDK_VERSION = 'expo.modules.updates.EXPO_SDK_VERSION',
+  RUNTIME_VERSION = 'expo.modules.updates.EXPO_RUNTIME_VERSION',
+  UPDATE_URL = 'expo.modules.updates.EXPO_UPDATE_URL',
+}
+
+export const withUpdatesAndroid: ConfigPlugin<{ expoUsername: string | null }> = (
+  config,
+  { expoUsername }
+) => {
+  return withAndroidManifest(config, config => {
+    config.modResults = setUpdatesConfig(config, config.modResults, expoUsername);
+    return config;
+  });
+};
+
+export function getUpdateUrl(
+  config: Pick<ExpoConfigUpdates, 'owner' | 'slug'>,
+  username: string | null
+): string | null {
+  const user = typeof config.owner === 'string' ? config.owner : username;
+  if (!user) {
+    return null;
+  }
+  return `https://exp.host/@${user}/${config.slug}`;
+}
+
+export function getRuntimeVersion(
+  config: Pick<ExpoConfigUpdates, 'runtimeVersion'>
+): string | null {
+  return typeof config.runtimeVersion === 'string' ? config.runtimeVersion : null;
+}
+
+export function getSDKVersion(config: Pick<ExpoConfigUpdates, 'sdkVersion'>): string | null {
+  return typeof config.sdkVersion === 'string' ? config.sdkVersion : null;
+}
+
+export function getUpdatesEnabled(config: Pick<ExpoConfigUpdates, 'updates'>): boolean {
+  return config.updates?.enabled !== false;
+}
+
+export function getUpdatesTimeout(config: Pick<ExpoConfigUpdates, 'updates'>): number {
+  return config.updates?.fallbackToCacheTimeout ?? 0;
+}
+
+export function getUpdatesCheckOnLaunch(
+  config: Pick<ExpoConfigUpdates, 'updates'>
+): 'NEVER' | 'ALWAYS' {
+  if (config.updates?.checkAutomatically === 'ON_ERROR_RECOVERY') {
+    return 'NEVER';
+  } else if (config.updates?.checkAutomatically === 'ON_LOAD') {
+    return 'ALWAYS';
+  }
+  return 'ALWAYS';
+}
+
+export function setUpdatesConfig(
+  config: ExpoConfigUpdates,
+  androidManifest: AndroidConfig.Manifest.AndroidManifest,
+  username: string | null
+): AndroidConfig.Manifest.AndroidManifest {
+  const mainApplication = getMainApplicationOrThrow(androidManifest);
+
+  addMetaDataItemToMainApplication(
+    mainApplication,
+    Config.ENABLED,
+    String(getUpdatesEnabled(config))
+  );
+  addMetaDataItemToMainApplication(
+    mainApplication,
+    Config.CHECK_ON_LAUNCH,
+    getUpdatesCheckOnLaunch(config)
+  );
+  addMetaDataItemToMainApplication(
+    mainApplication,
+    Config.LAUNCH_WAIT_MS,
+    String(getUpdatesTimeout(config))
+  );
+
+  const updateUrl = getUpdateUrl(config, username);
+  if (updateUrl) {
+    addMetaDataItemToMainApplication(mainApplication, Config.UPDATE_URL, updateUrl);
+  } else {
+    removeMetaDataItemFromMainApplication(mainApplication, Config.UPDATE_URL);
+  }
+
+  return setVersionsConfig(config, androidManifest);
+}
+
+export function setVersionsConfig(
+  config: Pick<ExpoConfigUpdates, 'sdkVersion' | 'runtimeVersion'>,
+  androidManifest: AndroidConfig.Manifest.AndroidManifest
+): AndroidConfig.Manifest.AndroidManifest {
+  const mainApplication = getMainApplicationOrThrow(androidManifest);
+
+  const runtimeVersion = getRuntimeVersion(config);
+  const sdkVersion = getSDKVersion(config);
+  if (runtimeVersion) {
+    removeMetaDataItemFromMainApplication(mainApplication, Config.SDK_VERSION);
+    addMetaDataItemToMainApplication(mainApplication, Config.RUNTIME_VERSION, runtimeVersion);
+  } else if (sdkVersion) {
+    removeMetaDataItemFromMainApplication(mainApplication, Config.RUNTIME_VERSION);
+    addMetaDataItemToMainApplication(mainApplication, Config.SDK_VERSION, sdkVersion);
+  } else {
+    removeMetaDataItemFromMainApplication(mainApplication, Config.RUNTIME_VERSION);
+    removeMetaDataItemFromMainApplication(mainApplication, Config.SDK_VERSION);
+  }
+
+  return androidManifest;
+}
+
+export function formatApplyLineForBuildGradle(
+  projectRoot: string,
+  config: Pick<ExpoConfigUpdates, 'nodeModulesPath'>
+): string {
+  const updatesGradleScriptPath = projectHasModule(
+    'expo-updates/scripts/create-manifest-android.gradle',
+    projectRoot,
+    config
+  );
+
+  if (!updatesGradleScriptPath) {
+    throw new Error(
+      "Could not find the build script for Android. This could happen in case of outdated 'node_modules'. Run 'npm install' to make sure that it's up-to-date."
+    );
+  }
+
+  return `apply from: ${JSON.stringify(
+    path.relative(path.join(projectRoot, 'android', 'app'), updatesGradleScriptPath)
+  )}`;
+}
+
+export function isBuildGradleConfigured(
+  buildGradleContent: string,
+  projectRoot: string,
+  config: Pick<ExpoConfigUpdates, 'nodeModulesPath'>
+): boolean {
+  const androidBuildScript = formatApplyLineForBuildGradle(projectRoot, config);
+
+  return (
+    buildGradleContent
+      .split('\n')
+      // Check for both single and double quotes
+      .some(line => line === androidBuildScript || line === androidBuildScript.replace(/"/g, "'"))
+  );
+}
+
+export function isMainApplicationMetaDataSet(
+  androidManifest: AndroidConfig.Manifest.AndroidManifest
+): boolean {
+  const updateUrl = getMainApplicationMetaDataValue(androidManifest, Config.UPDATE_URL);
+  const runtimeVersion = getMainApplicationMetaDataValue(androidManifest, Config.RUNTIME_VERSION);
+  const sdkVersion = getMainApplicationMetaDataValue(androidManifest, Config.SDK_VERSION);
+
+  return Boolean(updateUrl && (sdkVersion || runtimeVersion));
+}
+
+export function isMainApplicationMetaDataSynced(
+  config: ExpoConfigUpdates,
+  androidManifest: AndroidConfig.Manifest.AndroidManifest,
+  username: string | null
+): boolean {
+  return (
+    getUpdateUrl(config, username) ===
+      getMainApplicationMetaDataValue(androidManifest, Config.UPDATE_URL) &&
+    String(getUpdatesEnabled(config)) ===
+      getMainApplicationMetaDataValue(androidManifest, Config.ENABLED) &&
+    String(getUpdatesTimeout(config)) ===
+      getMainApplicationMetaDataValue(androidManifest, Config.LAUNCH_WAIT_MS) &&
+    getUpdatesCheckOnLaunch(config) ===
+      getMainApplicationMetaDataValue(androidManifest, Config.CHECK_ON_LAUNCH) &&
+    areVersionsSynced(config, androidManifest)
+  );
+}
+
+export function areVersionsSynced(
+  config: Pick<ExpoConfigUpdates, 'runtimeVersion' | 'sdkVersion'>,
+  androidManifest: AndroidConfig.Manifest.AndroidManifest
+): boolean {
+  const expectedRuntimeVersion = getRuntimeVersion(config);
+  const expectedSdkVersion = getSDKVersion(config);
+  const currentRuntimeVersion = getMainApplicationMetaDataValue(
+    androidManifest,
+    Config.RUNTIME_VERSION
+  );
+  const currentSdkVersion = getMainApplicationMetaDataValue(androidManifest, Config.SDK_VERSION);
+
+  return (
+    currentRuntimeVersion === expectedRuntimeVersion && currentSdkVersion === expectedSdkVersion
+  );
+}

--- a/packages/expo-updates/plugin/src/withUpdatesIOS.ts
+++ b/packages/expo-updates/plugin/src/withUpdatesIOS.ts
@@ -1,0 +1,217 @@
+import { ExpoConfig } from '@expo/config-types';
+import * as path from 'path';
+
+import { ConfigPlugin, withExpoPlist } from '@expo/config-plugins';
+import { projectHasModule } from '@expo/config-plugins/build/utils/modules';
+import { ExpoPlist } from '@expo/config-plugins/build/ios/IosConfig.types';
+
+// TODO: Export type from expo/config-plugins
+type XcodeProject = any;
+
+type ExpoConfigUpdates = Pick<
+  ExpoConfig,
+  'sdkVersion' | 'owner' | 'runtimeVersion' | 'nodeModulesPath' | 'updates' | 'slug'
+>;
+
+export enum Config {
+  ENABLED = 'EXUpdatesEnabled',
+  CHECK_ON_LAUNCH = 'EXUpdatesCheckOnLaunch',
+  LAUNCH_WAIT_MS = 'EXUpdatesLaunchWaitMs',
+  RUNTIME_VERSION = 'EXUpdatesRuntimeVersion',
+  SDK_VERSION = 'EXUpdatesSDKVersion',
+  UPDATE_URL = 'EXUpdatesURL',
+}
+
+export function getUpdateUrl(
+  config: Pick<ExpoConfigUpdates, 'owner' | 'slug'>,
+  username: string | null
+): string | null {
+  const user = typeof config.owner === 'string' ? config.owner : username;
+  if (!user) {
+    return null;
+  }
+  return `https://exp.host/@${user}/${config.slug}`;
+}
+
+export function getRuntimeVersion(
+  config: Pick<ExpoConfigUpdates, 'runtimeVersion'>
+): string | null {
+  return typeof config.runtimeVersion === 'string' ? config.runtimeVersion : null;
+}
+
+export function getSDKVersion(config: Pick<ExpoConfigUpdates, 'sdkVersion'>): string | null {
+  return typeof config.sdkVersion === 'string' ? config.sdkVersion : null;
+}
+
+export function getUpdatesEnabled(config: Pick<ExpoConfigUpdates, 'updates'>): boolean {
+  return config.updates?.enabled !== false;
+}
+
+export function getUpdatesTimeout(config: Pick<ExpoConfigUpdates, 'updates'>) {
+  return config.updates?.fallbackToCacheTimeout ?? 0;
+}
+
+export function getUpdatesCheckOnLaunch(
+  config: Pick<ExpoConfigUpdates, 'updates'>
+): 'NEVER' | 'ALWAYS' {
+  if (config.updates?.checkAutomatically === 'ON_ERROR_RECOVERY') {
+    return 'NEVER';
+  } else if (config.updates?.checkAutomatically === 'ON_LOAD') {
+    return 'ALWAYS';
+  }
+  return 'ALWAYS';
+}
+
+export const withUpdatesIOS: ConfigPlugin<{ expoUsername: string | null }> = (
+  config,
+  { expoUsername }
+) => {
+  return withExpoPlist(config, config => {
+    config.modResults = setUpdatesConfig(config, config.modResults, expoUsername);
+    return config;
+  });
+};
+
+export function setUpdatesConfig(
+  config: ExpoConfigUpdates,
+  expoPlist: ExpoPlist,
+  username: string | null
+): ExpoPlist {
+  const newExpoPlist = {
+    ...expoPlist,
+    [Config.ENABLED]: getUpdatesEnabled(config),
+    [Config.CHECK_ON_LAUNCH]: getUpdatesCheckOnLaunch(config),
+    [Config.LAUNCH_WAIT_MS]: getUpdatesTimeout(config),
+  };
+
+  const updateUrl = getUpdateUrl(config, username);
+  if (updateUrl) {
+    newExpoPlist[Config.UPDATE_URL] = updateUrl;
+  } else {
+    delete newExpoPlist[Config.UPDATE_URL];
+  }
+
+  return setVersionsConfig(config, newExpoPlist);
+}
+
+export function setVersionsConfig(config: ExpoConfigUpdates, expoPlist: ExpoPlist): ExpoPlist {
+  const newExpoPlist = { ...expoPlist };
+
+  const runtimeVersion = getRuntimeVersion(config);
+  const sdkVersion = getSDKVersion(config);
+  if (runtimeVersion) {
+    delete newExpoPlist[Config.SDK_VERSION];
+    newExpoPlist[Config.RUNTIME_VERSION] = runtimeVersion;
+  } else if (sdkVersion) {
+    delete newExpoPlist[Config.RUNTIME_VERSION];
+    newExpoPlist[Config.SDK_VERSION] = sdkVersion;
+  } else {
+    delete newExpoPlist[Config.SDK_VERSION];
+    delete newExpoPlist[Config.RUNTIME_VERSION];
+  }
+
+  return newExpoPlist;
+}
+
+function formatConfigurationScriptPath(
+  projectRoot: string,
+  config: Pick<ExpoConfigUpdates, 'nodeModulesPath'>
+): string {
+  const buildScriptPath = projectHasModule(
+    'expo-updates/scripts/create-manifest-ios.sh',
+    projectRoot,
+    config
+  );
+
+  if (!buildScriptPath) {
+    throw new Error(
+      "Could not find the build script for iOS. This could happen in case of outdated 'node_modules'. Run 'npm install' to make sure that it's up-to-date."
+    );
+  }
+
+  return path.relative(path.join(projectRoot, 'ios'), buildScriptPath);
+}
+
+interface ShellScriptBuildPhase {
+  isa: 'PBXShellScriptBuildPhase';
+  name: string;
+  shellScript: string;
+  [key: string]: any;
+}
+
+function getBundleReactNativePhase(project: XcodeProject): ShellScriptBuildPhase {
+  const shellScriptBuildPhase = project.hash.project.objects.PBXShellScriptBuildPhase as Record<
+    string,
+    ShellScriptBuildPhase
+  >;
+  const bundleReactNative = Object.values(shellScriptBuildPhase).find(
+    buildPhase => buildPhase.name === '"Bundle React Native code and images"'
+  );
+
+  if (!bundleReactNative) {
+    throw new Error(`Couldn't find a build phase "Bundle React Native code and images"`);
+  }
+
+  return bundleReactNative;
+}
+
+export function ensureBundleReactNativePhaseContainsConfigurationScript(
+  projectRoot: string,
+  config: Pick<ExpoConfigUpdates, 'nodeModulesPath'>,
+  project: XcodeProject
+): XcodeProject {
+  const bundleReactNative = getBundleReactNativePhase(project);
+  const buildPhaseShellScriptPath = formatConfigurationScriptPath(projectRoot, config);
+
+  if (!bundleReactNative.shellScript.includes(buildPhaseShellScriptPath)) {
+    bundleReactNative.shellScript = `${bundleReactNative.shellScript.replace(
+      /"$/,
+      ''
+    )}${buildPhaseShellScriptPath}\\n"`;
+  }
+  return project;
+}
+
+export function isShellScriptBuildPhaseConfigured(
+  projectRoot: string,
+  config: Pick<ExpoConfigUpdates, 'nodeModulesPath'>,
+  project: XcodeProject
+): boolean {
+  const bundleReactNative = getBundleReactNativePhase(project);
+  const buildPhaseShellScriptPath = formatConfigurationScriptPath(projectRoot, config);
+  return bundleReactNative.shellScript.includes(buildPhaseShellScriptPath);
+}
+
+export function isPlistConfigurationSet(expoPlist: ExpoPlist): boolean {
+  return Boolean(
+    expoPlist.EXUpdatesURL && (expoPlist.EXUpdatesSDKVersion || expoPlist.EXUpdatesRuntimeVersion)
+  );
+}
+
+export function isPlistConfigurationSynced(
+  config: ExpoConfigUpdates,
+  expoPlist: ExpoPlist,
+  username: string | null
+): boolean {
+  return (
+    getUpdateUrl(config, username) === expoPlist.EXUpdatesURL &&
+    getUpdatesEnabled(config) === expoPlist.EXUpdatesEnabled &&
+    getUpdatesTimeout(config) === expoPlist.EXUpdatesLaunchWaitMs &&
+    getUpdatesCheckOnLaunch(config) === expoPlist.EXUpdatesCheckOnLaunch &&
+    isPlistVersionConfigurationSynced(config, expoPlist)
+  );
+}
+
+export function isPlistVersionConfigurationSynced(
+  config: Pick<ExpoConfigUpdates, 'sdkVersion' | 'runtimeVersion'>,
+  expoPlist: ExpoPlist
+): boolean {
+  const expectedRuntimeVersion = getRuntimeVersion(config);
+  const expectedSdkVersion = getSDKVersion(config);
+  const currentRuntimeVersion = expoPlist.EXUpdatesRuntimeVersion ?? null;
+  const currentSdkVersion = expoPlist.EXUpdatesSDKVersion ?? null;
+
+  return (
+    currentSdkVersion === expectedSdkVersion && currentRuntimeVersion === expectedRuntimeVersion
+  );
+}

--- a/packages/expo-updates/plugin/src/withUpdatesIOS.ts
+++ b/packages/expo-updates/plugin/src/withUpdatesIOS.ts
@@ -1,9 +1,8 @@
+import { ConfigPlugin, withExpoPlist } from '@expo/config-plugins';
+import { ExpoPlist } from '@expo/config-plugins/build/ios/IosConfig.types';
+import { projectHasModule } from '@expo/config-plugins/build/utils/modules';
 import { ExpoConfig } from '@expo/config-types';
 import * as path from 'path';
-
-import { ConfigPlugin, withExpoPlist } from '@expo/config-plugins';
-import { projectHasModule } from '@expo/config-plugins/build/utils/modules';
-import { ExpoPlist } from '@expo/config-plugins/build/ios/IosConfig.types';
 
 // TODO: Export type from expo/config-plugins
 type XcodeProject = any;

--- a/packages/expo-updates/plugin/tsconfig.json
+++ b/packages/expo-updates/plugin/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "expo-module-scripts/tsconfig.plugin",
+  "compilerOptions": {
+    "outDir": "build",
+    "rootDir": "src"
+  },
+  "include": ["./src"],
+  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+}


### PR DESCRIPTION
# How

- Copied the unversioned plugin into the versioned expo-updates package https://github.com/expo/expo/issues/11561
- [ ] Need to resolved some kinda "interactive" step before ejecting to get the expo username. 
- [ ] Export more types from config-plugins (XcodeProject, ExpoPlist)

# Test Plan

- Migrated plugin tests from config-plugins
- [ ] Ran `EXPO_DEBUG=1 expo prebuild` and examined that the printed config's `_internal.pluginHistory['expo-updates'].version` was not `UNVERSIONED` (i.e. used the versioned plugin instead of the built-in CLI plugin).