### PR TITLE
created ads-admob plugin

### DIFF
--- a/packages/expo-ads-admob/CHANGELOG.md
+++ b/packages/expo-ads-admob/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🎉 New features
 
+- Created config plugin. ([#11636](https://github.com/expo/expo/pull/11636) by [@EvanBacon](https://github.com/EvanBacon))
+
 ### 🐛 Bug fixes
 
 ## 8.4.0 — 2020-11-17

--- a/packages/expo-ads-admob/app.plugin.js
+++ b/packages/expo-ads-admob/app.plugin.js
@@ -1,0 +1,1 @@
+module.exports = require('./plugin/build/withAdMob')

--- a/packages/expo-ads-admob/package.json
+++ b/packages/expo-ads-admob/package.json
@@ -39,6 +39,9 @@
     "react": "*",
     "react-native": "*"
   },
+  "dependencies": {
+    "@expo/config-plugins": "^1.0.14"
+  },
   "devDependencies": {
     "expo-module-scripts": "~1.2.0"
   }

--- a/packages/expo-ads-admob/plugin/build/withAdMob.d.ts
+++ b/packages/expo-ads-admob/plugin/build/withAdMob.d.ts
@@ -1,0 +1,3 @@
+import { ConfigPlugin } from '@expo/config-plugins';
+declare const _default: ConfigPlugin<void>;
+export default _default;

--- a/packages/expo-ads-admob/plugin/build/withAdMob.js
+++ b/packages/expo-ads-admob/plugin/build/withAdMob.js
@@ -1,0 +1,12 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const config_plugins_1 = require("@expo/config-plugins");
+const withAdMobAndroid_1 = require("./withAdMobAndroid");
+const withAdMobIOS_1 = require("./withAdMobIOS");
+const pkg = require('expo-ads-admob/package.json');
+const withAdMob = config => {
+    config = withAdMobAndroid_1.withAdMobAndroid(config);
+    config = withAdMobIOS_1.withAdMobIOS(config);
+    return config;
+};
+exports.default = config_plugins_1.createRunOncePlugin(withAdMob, pkg.name, pkg.version);

--- a/packages/expo-ads-admob/plugin/build/withAdMobAndroid.d.ts
+++ b/packages/expo-ads-admob/plugin/build/withAdMobAndroid.d.ts
@@ -1,0 +1,6 @@
+import { AndroidConfig, ConfigPlugin } from '@expo/config-plugins';
+import { ExpoConfig } from '@expo/config-types';
+export declare const withAdMobAndroid: ConfigPlugin;
+export declare function getGoogleMobileAdsAppId(config: Pick<ExpoConfig, 'android'>): string | null;
+export declare function getGoogleMobileAdsAutoInit(config: Pick<ExpoConfig, 'android'>): boolean;
+export declare function setAdMobConfig(config: Pick<ExpoConfig, 'android'>, androidManifest: AndroidConfig.Manifest.AndroidManifest): AndroidConfig.Manifest.AndroidManifest;

--- a/packages/expo-ads-admob/plugin/build/withAdMobAndroid.js
+++ b/packages/expo-ads-admob/plugin/build/withAdMobAndroid.js
@@ -1,0 +1,38 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.setAdMobConfig = exports.getGoogleMobileAdsAutoInit = exports.getGoogleMobileAdsAppId = exports.withAdMobAndroid = void 0;
+const config_plugins_1 = require("@expo/config-plugins");
+const { addMetaDataItemToMainApplication, getMainApplicationOrThrow, removeMetaDataItemFromMainApplication, } = config_plugins_1.AndroidConfig.Manifest;
+const META_APPLICATION_ID = 'com.google.android.gms.ads.APPLICATION_ID';
+const META_DELAY_APP_MEASUREMENT_INIT = 'com.google.android.gms.ads.DELAY_APP_MEASUREMENT_INIT';
+exports.withAdMobAndroid = config => {
+    return config_plugins_1.withAndroidManifest(config, config => {
+        config.modResults = setAdMobConfig(config, config.modResults);
+        return config;
+    });
+};
+function getGoogleMobileAdsAppId(config) {
+    var _a, _b, _c;
+    return (_c = (_b = (_a = config.android) === null || _a === void 0 ? void 0 : _a.config) === null || _b === void 0 ? void 0 : _b.googleMobileAdsAppId) !== null && _c !== void 0 ? _c : null;
+}
+exports.getGoogleMobileAdsAppId = getGoogleMobileAdsAppId;
+function getGoogleMobileAdsAutoInit(config) {
+    var _a, _b, _c;
+    return (_c = (_b = (_a = config.android) === null || _a === void 0 ? void 0 : _a.config) === null || _b === void 0 ? void 0 : _b.googleMobileAdsAutoInit) !== null && _c !== void 0 ? _c : false;
+}
+exports.getGoogleMobileAdsAutoInit = getGoogleMobileAdsAutoInit;
+function setAdMobConfig(config, androidManifest) {
+    const appId = getGoogleMobileAdsAppId(config);
+    const autoInit = getGoogleMobileAdsAutoInit(config);
+    const mainApplication = getMainApplicationOrThrow(androidManifest);
+    if (appId) {
+        addMetaDataItemToMainApplication(mainApplication, META_APPLICATION_ID, appId);
+        addMetaDataItemToMainApplication(mainApplication, META_DELAY_APP_MEASUREMENT_INIT, String(!autoInit));
+    }
+    else {
+        removeMetaDataItemFromMainApplication(mainApplication, META_APPLICATION_ID);
+        removeMetaDataItemFromMainApplication(mainApplication, META_DELAY_APP_MEASUREMENT_INIT);
+    }
+    return androidManifest;
+}
+exports.setAdMobConfig = setAdMobConfig;

--- a/packages/expo-ads-admob/plugin/build/withAdMobIOS.d.ts
+++ b/packages/expo-ads-admob/plugin/build/withAdMobIOS.d.ts
@@ -1,0 +1,6 @@
+import { ConfigPlugin } from '@expo/config-plugins';
+import { InfoPlist } from '@expo/config-plugins/build/ios/IosConfig.types';
+import { ExpoConfig } from '@expo/config-types';
+export declare const withAdMobIOS: ConfigPlugin;
+export declare function getGoogleMobileAdsAppId(config: Pick<ExpoConfig, 'ios'>): string | null;
+export declare function setGoogleMobileAdsAppId(config: Pick<ExpoConfig, 'ios'>, { GADApplicationIdentifier, ...infoPlist }: InfoPlist): InfoPlist;

--- a/packages/expo-ads-admob/plugin/build/withAdMobIOS.js
+++ b/packages/expo-ads-admob/plugin/build/withAdMobIOS.js
@@ -1,0 +1,37 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.setGoogleMobileAdsAppId = exports.getGoogleMobileAdsAppId = exports.withAdMobIOS = void 0;
+const config_plugins_1 = require("@expo/config-plugins");
+exports.withAdMobIOS = config => {
+    return config_plugins_1.withInfoPlist(config, config => {
+        config.modResults = setAdMobConfig(config, config.modResults);
+        return config;
+    });
+};
+// NOTE(brentvatne): if the developer has installed the google ads sdk and does
+// not provide an app id their app will crash. Standalone apps get around this by
+// providing some default value, we will instead here assume that the user can
+// do the right thing if they have installed the package. This is a slight discrepancy
+// that arises in ejecting because it's possible for the package to be installed and
+// not crashing in the managed workflow, then you eject and the app crashes because
+// you don't have an id to fall back to.
+function getGoogleMobileAdsAppId(config) {
+    var _a, _b, _c;
+    return (_c = (_b = (_a = config.ios) === null || _a === void 0 ? void 0 : _a.config) === null || _b === void 0 ? void 0 : _b.googleMobileAdsAppId) !== null && _c !== void 0 ? _c : null;
+}
+exports.getGoogleMobileAdsAppId = getGoogleMobileAdsAppId;
+function setGoogleMobileAdsAppId(config, { GADApplicationIdentifier, ...infoPlist }) {
+    const appId = getGoogleMobileAdsAppId(config);
+    if (appId === null) {
+        return infoPlist;
+    }
+    return {
+        ...infoPlist,
+        GADApplicationIdentifier: appId,
+    };
+}
+exports.setGoogleMobileAdsAppId = setGoogleMobileAdsAppId;
+function setAdMobConfig(config, infoPlist) {
+    infoPlist = setGoogleMobileAdsAppId(config, infoPlist);
+    return infoPlist;
+}

--- a/packages/expo-ads-admob/plugin/jest.config.js
+++ b/packages/expo-ads-admob/plugin/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = require('expo-module-scripts/jest-preset-plugin');

--- a/packages/expo-ads-admob/plugin/src/__tests__/fixtures/react-native-AndroidManifest.xml
+++ b/packages/expo-ads-admob/plugin/src/__tests__/fixtures/react-native-AndroidManifest.xml
@@ -1,0 +1,24 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  package="com.expo.mycoolapp">
+    <uses-permission android:name="android.permission.INTERNET" />
+    <application
+      android:name=".MainApplication"
+      android:label="@string/app_name"
+      android:icon="@mipmap/ic_launcher"
+      android:roundIcon="@mipmap/ic_launcher_round"
+      android:allowBackup="true"
+      android:theme="@style/AppTheme">
+      <activity
+        android:name=".MainActivity"
+        android:launchMode="singleTask"
+        android:label="@string/app_name"
+        android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
+        android:windowSoftInputMode="adjustResize">
+        <intent-filter>
+            <action android:name="android.intent.action.MAIN" />
+            <category android:name="android.intent.category.LAUNCHER" />
+        </intent-filter>
+      </activity>
+      <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
+    </application>
+</manifest>

--- a/packages/expo-ads-admob/plugin/src/__tests__/withAdMobAndroid-test.ts
+++ b/packages/expo-ads-admob/plugin/src/__tests__/withAdMobAndroid-test.ts
@@ -1,0 +1,55 @@
+import { AndroidConfig } from '@expo/config-plugins';
+import { resolve } from 'path';
+
+import {
+  getGoogleMobileAdsAppId,
+  getGoogleMobileAdsAutoInit,
+  setAdMobConfig,
+} from '../withAdMobAndroid';
+
+const { getMainApplicationOrThrow, readAndroidManifestAsync } = AndroidConfig.Manifest;
+
+const fixturesPath = resolve(__dirname, 'fixtures');
+const sampleManifestPath = resolve(fixturesPath, 'react-native-AndroidManifest.xml');
+
+describe('Android permissions', () => {
+  it(`returns falsey for both if no android GoogleMobileAds config is provided`, () => {
+    expect(getGoogleMobileAdsAppId({ android: { config: {} } })).toBe(null);
+    expect(getGoogleMobileAdsAutoInit({ android: { config: {} } })).toBe(false);
+  });
+
+  it(`returns value if android google mobile ads config is provided`, () => {
+    expect(
+      getGoogleMobileAdsAppId({ android: { config: { googleMobileAdsAppId: 'MY-API-KEY' } } })
+    ).toMatch('MY-API-KEY');
+    expect(
+      getGoogleMobileAdsAutoInit({ android: { config: { googleMobileAdsAutoInit: true } } })
+    ).toBe(true);
+  });
+
+  it('add google mobile ads app config to AndroidManifest.xml', async () => {
+    let androidManifestJson = await readAndroidManifestAsync(sampleManifestPath);
+    androidManifestJson = await setAdMobConfig(
+      {
+        android: {
+          config: { googleMobileAdsAppId: 'MY-API-KEY', googleMobileAdsAutoInit: false },
+        },
+      },
+      androidManifestJson
+    );
+
+    const mainApplication = getMainApplicationOrThrow(androidManifestJson);
+
+    const apiKeyItem = mainApplication['meta-data'].filter(
+      e => e.$['android:name'] === 'com.google.android.gms.ads.APPLICATION_ID'
+    );
+    expect(apiKeyItem).toHaveLength(1);
+    expect(apiKeyItem[0].$['android:value']).toMatch('MY-API-KEY');
+
+    const usesLibraryItem = mainApplication['meta-data'].filter(
+      e => e.$['android:name'] === 'com.google.android.gms.ads.DELAY_APP_MEASUREMENT_INIT'
+    );
+    expect(usesLibraryItem).toHaveLength(1);
+    expect(usesLibraryItem[0].$['android:value']).toBe('true');
+  });
+});

--- a/packages/expo-ads-admob/plugin/src/__tests__/withAdMobIOS-test.ts
+++ b/packages/expo-ads-admob/plugin/src/__tests__/withAdMobIOS-test.ts
@@ -1,0 +1,25 @@
+import { getGoogleMobileAdsAppId, setGoogleMobileAdsAppId } from '../withAdMobIOS';
+
+describe(getGoogleMobileAdsAppId, () => {
+  it(`returns null from all getters if no value provided`, () => {
+    expect(getGoogleMobileAdsAppId({})).toBe(null);
+  });
+
+  it(`returns the correct values from all getters if a value is provided`, () => {
+    expect(getGoogleMobileAdsAppId({ ios: { config: { googleMobileAdsAppId: 'abc' } } })).toBe(
+      'abc'
+    );
+  });
+});
+
+describe(setGoogleMobileAdsAppId, () => {
+  it(`sets the google mobile ads app id if provided or returns plist`, () => {
+    expect(
+      setGoogleMobileAdsAppId({ ios: { config: { googleMobileAdsAppId: '123' } } }, {})
+    ).toMatchObject({
+      GADApplicationIdentifier: '123',
+    });
+
+    expect(setGoogleMobileAdsAppId({}, {})).toMatchObject({});
+  });
+});

--- a/packages/expo-ads-admob/plugin/src/withAdMob.ts
+++ b/packages/expo-ads-admob/plugin/src/withAdMob.ts
@@ -1,0 +1,14 @@
+import { ConfigPlugin, createRunOncePlugin } from '@expo/config-plugins';
+
+import { withAdMobAndroid } from './withAdMobAndroid';
+import { withAdMobIOS } from './withAdMobIOS';
+
+const pkg = require('expo-ads-admob/package.json');
+
+const withAdMob: ConfigPlugin = config => {
+  config = withAdMobAndroid(config);
+  config = withAdMobIOS(config);
+  return config;
+};
+
+export default createRunOncePlugin(withAdMob, pkg.name, pkg.version);

--- a/packages/expo-ads-admob/plugin/src/withAdMobAndroid.ts
+++ b/packages/expo-ads-admob/plugin/src/withAdMobAndroid.ts
@@ -1,0 +1,49 @@
+import { AndroidConfig, ConfigPlugin, withAndroidManifest } from '@expo/config-plugins';
+import { ExpoConfig } from '@expo/config-types';
+
+const {
+  addMetaDataItemToMainApplication,
+  getMainApplicationOrThrow,
+  removeMetaDataItemFromMainApplication,
+} = AndroidConfig.Manifest;
+
+const META_APPLICATION_ID = 'com.google.android.gms.ads.APPLICATION_ID';
+const META_DELAY_APP_MEASUREMENT_INIT = 'com.google.android.gms.ads.DELAY_APP_MEASUREMENT_INIT';
+
+export const withAdMobAndroid: ConfigPlugin = config => {
+  return withAndroidManifest(config, config => {
+    config.modResults = setAdMobConfig(config, config.modResults);
+    return config;
+  });
+};
+
+export function getGoogleMobileAdsAppId(config: Pick<ExpoConfig, 'android'>) {
+  return config.android?.config?.googleMobileAdsAppId ?? null;
+}
+
+export function getGoogleMobileAdsAutoInit(config: Pick<ExpoConfig, 'android'>) {
+  return config.android?.config?.googleMobileAdsAutoInit ?? false;
+}
+
+export function setAdMobConfig(
+  config: Pick<ExpoConfig, 'android'>,
+  androidManifest: AndroidConfig.Manifest.AndroidManifest
+) {
+  const appId = getGoogleMobileAdsAppId(config);
+  const autoInit = getGoogleMobileAdsAutoInit(config);
+  const mainApplication = getMainApplicationOrThrow(androidManifest);
+
+  if (appId) {
+    addMetaDataItemToMainApplication(mainApplication, META_APPLICATION_ID, appId);
+    addMetaDataItemToMainApplication(
+      mainApplication,
+      META_DELAY_APP_MEASUREMENT_INIT,
+      String(!autoInit)
+    );
+  } else {
+    removeMetaDataItemFromMainApplication(mainApplication, META_APPLICATION_ID);
+    removeMetaDataItemFromMainApplication(mainApplication, META_DELAY_APP_MEASUREMENT_INIT);
+  }
+
+  return androidManifest;
+}

--- a/packages/expo-ads-admob/plugin/src/withAdMobIOS.ts
+++ b/packages/expo-ads-admob/plugin/src/withAdMobIOS.ts
@@ -1,0 +1,43 @@
+import { ConfigPlugin, withInfoPlist } from '@expo/config-plugins';
+// TODO: export from config-plugins proper
+import { InfoPlist } from '@expo/config-plugins/build/ios/IosConfig.types';
+import { ExpoConfig } from '@expo/config-types';
+
+export const withAdMobIOS: ConfigPlugin = config => {
+  return withInfoPlist(config, config => {
+    config.modResults = setAdMobConfig(config, config.modResults);
+    return config;
+  });
+};
+
+// NOTE(brentvatne): if the developer has installed the google ads sdk and does
+// not provide an app id their app will crash. Standalone apps get around this by
+// providing some default value, we will instead here assume that the user can
+// do the right thing if they have installed the package. This is a slight discrepancy
+// that arises in ejecting because it's possible for the package to be installed and
+// not crashing in the managed workflow, then you eject and the app crashes because
+// you don't have an id to fall back to.
+export function getGoogleMobileAdsAppId(config: Pick<ExpoConfig, 'ios'>) {
+  return config.ios?.config?.googleMobileAdsAppId ?? null;
+}
+
+export function setGoogleMobileAdsAppId(
+  config: Pick<ExpoConfig, 'ios'>,
+  { GADApplicationIdentifier, ...infoPlist }: InfoPlist
+): InfoPlist {
+  const appId = getGoogleMobileAdsAppId(config);
+
+  if (appId === null) {
+    return infoPlist;
+  }
+
+  return {
+    ...infoPlist,
+    GADApplicationIdentifier: appId,
+  };
+}
+
+function setAdMobConfig(config: Pick<ExpoConfig, 'ios'>, infoPlist: InfoPlist): InfoPlist {
+  infoPlist = setGoogleMobileAdsAppId(config, infoPlist);
+  return infoPlist;
+}

--- a/packages/expo-ads-admob/plugin/tsconfig.json
+++ b/packages/expo-ads-admob/plugin/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "expo-module-scripts/tsconfig.plugin",
+  "compilerOptions": {
+    "outDir": "build",
+    "rootDir": "src"
+  },
+  "include": ["./src"],
+  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+}


### PR DESCRIPTION
# How

- Copied the unversioned plugin into the versioned expo-ads-admob package https://github.com/expo/expo/issues/11561

# Test Plan

- Migrated plugin tests from `expo/config-plugins`
- Ran `EXPO_DEBUG=1 expo prebuild` and examined that the printed config's `_internal.pluginHistory['expo-splash-screen'].version` was not `UNVERSIONED` (i.e. used the versioned plugin instead of the built-in CLI plugin).