### PR TITLE
created document-picker plugin

### DIFF
--- a/packages/expo-document-picker/app.plugin.js
+++ b/packages/expo-document-picker/app.plugin.js
@@ -1,0 +1,1 @@
+module.exports = require('./plugin/build/withFacebook');

--- a/packages/expo-document-picker/plugin/build/withDocumentPicker.d.ts
+++ b/packages/expo-document-picker/plugin/build/withDocumentPicker.d.ts
@@ -1,0 +1,5 @@
+import { ConfigPlugin } from '@expo/config-plugins';
+declare const _default: ConfigPlugin<{
+    appleTeamId: string;
+}>;
+export default _default;

--- a/packages/expo-document-picker/plugin/build/withDocumentPicker.d.ts
+++ b/packages/expo-document-picker/plugin/build/withDocumentPicker.d.ts
@@ -1,5 +1,3 @@
 import { ConfigPlugin } from '@expo/config-plugins';
-declare const _default: ConfigPlugin<{
-    appleTeamId: string;
-}>;
+declare const _default: ConfigPlugin<void>;
 export default _default;

--- a/packages/expo-document-picker/plugin/build/withDocumentPicker.js
+++ b/packages/expo-document-picker/plugin/build/withDocumentPicker.js
@@ -1,0 +1,32 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const config_plugins_1 = require("@expo/config-plugins");
+const assert_1 = __importDefault(require("assert"));
+const pkg = require('expo-document-picker/package.json');
+const withDocumentPicker = (config, 
+// This cannot be a default plugin because it has required properties.
+props) => {
+    var _a;
+    const { bundleIdentifier } = (_a = config.ios) !== null && _a !== void 0 ? _a : {};
+    assert_1.default(bundleIdentifier, 'expo-document-picker plugin requires `ios.bundleIdentifier` to be defined for iCloud entitlements. Learn more: https://docs.expo.io/versions/latest/sdk/document-picker/#configuration');
+    assert_1.default(props.appleTeamId, 'expo-document-picker plugin requires the property `appleTeamId` to be defined for iCloud entitlements. Learn more: https://docs.expo.io/versions/latest/sdk/document-picker/#configuration');
+    // TODO: Should we ignore if `config.ios?.usesIcloudStorage` is false?
+    return config_plugins_1.withEntitlementsPlist(config, config => {
+        const { modResults: entitlements } = config;
+        entitlements['com.apple.developer.icloud-container-identifiers'] = [
+            'iCloud.' + bundleIdentifier,
+        ];
+        entitlements['com.apple.developer.ubiquity-container-identifiers'] = [
+            'iCloud.' + bundleIdentifier,
+        ];
+        entitlements['com.apple.developer.ubiquity-kvstore-identifier'] =
+            props.appleTeamId + '.' + bundleIdentifier;
+        entitlements['com.apple.developer.icloud-services'] = ['CloudDocuments'];
+        config.modResults = entitlements;
+        return config;
+    });
+};
+exports.default = config_plugins_1.createRunOncePlugin(withDocumentPicker, pkg.name, pkg.version);

--- a/packages/expo-document-picker/plugin/build/withDocumentPicker.js
+++ b/packages/expo-document-picker/plugin/build/withDocumentPicker.js
@@ -6,13 +6,12 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const config_plugins_1 = require("@expo/config-plugins");
 const assert_1 = __importDefault(require("assert"));
 const pkg = require('expo-document-picker/package.json');
-const withDocumentPicker = (config, 
-// This cannot be a default plugin because it has required properties.
-props) => {
+const withDocumentPicker = config => {
     var _a;
     const { bundleIdentifier } = (_a = config.ios) !== null && _a !== void 0 ? _a : {};
     assert_1.default(bundleIdentifier, 'expo-document-picker plugin requires `ios.bundleIdentifier` to be defined for iCloud entitlements. Learn more: https://docs.expo.io/versions/latest/sdk/document-picker/#configuration');
-    assert_1.default(props.appleTeamId, 'expo-document-picker plugin requires the property `appleTeamId` to be defined for iCloud entitlements. Learn more: https://docs.expo.io/versions/latest/sdk/document-picker/#configuration');
+    const appleTeamId = process.env.EXPO_APPLE_TEAM_ID;
+    assert_1.default(appleTeamId, 'expo-document-picker plugin requires the environment variable `EXPO_APPLE_TEAM_ID` to be defined for iCloud entitlements. Learn more: https://docs.expo.io/versions/latest/sdk/document-picker/#configuration');
     // TODO: Should we ignore if `config.ios?.usesIcloudStorage` is false?
     return config_plugins_1.withEntitlementsPlist(config, config => {
         const { modResults: entitlements } = config;
@@ -23,7 +22,7 @@ props) => {
             'iCloud.' + bundleIdentifier,
         ];
         entitlements['com.apple.developer.ubiquity-kvstore-identifier'] =
-            props.appleTeamId + '.' + bundleIdentifier;
+            appleTeamId + '.' + bundleIdentifier;
         entitlements['com.apple.developer.icloud-services'] = ['CloudDocuments'];
         config.modResults = entitlements;
         return config;

--- a/packages/expo-document-picker/plugin/jest.config.js
+++ b/packages/expo-document-picker/plugin/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = require('expo-module-scripts/jest-preset-plugin');

--- a/packages/expo-document-picker/plugin/src/__tests__/withDocumentPicker-test.ts
+++ b/packages/expo-document-picker/plugin/src/__tests__/withDocumentPicker-test.ts
@@ -1,22 +1,19 @@
 import withDocumentPicker from '../withDocumentPicker';
 
 describe(withDocumentPicker, () => {
+  beforeEach(() => {
+    delete process.env.EXPO_APPLE_TEAM_ID;
+  });
   it(`asserts bundle id`, () => {
-    expect(() =>
-      withDocumentPicker(
-        { name: 'hey', slug: 'hey' },
-        // @ts-ignore
-        {}
-      )
-    ).toThrow('ios.bundleIdentifier');
+    expect(() => withDocumentPicker({ name: 'hey', slug: 'hey' })).toThrow('ios.bundleIdentifier');
   });
   it(`asserts apple team id`, () => {
     expect(() =>
-      withDocumentPicker(
-        { name: 'hey', slug: 'hey', ios: { bundleIdentifier: 'foo' } },
-        // @ts-ignore
-        {}
-      )
-    ).toThrow('appleTeamId');
+      withDocumentPicker({ name: 'hey', slug: 'hey', ios: { bundleIdentifier: 'foo' } })
+    ).toThrow('EXPO_APPLE_TEAM_ID');
+  });
+  it(`works when the props are all defined`, () => {
+    process.env.EXPO_APPLE_TEAM_ID = 'FOOBAR';
+    withDocumentPicker({ name: 'hey', slug: 'hey', ios: { bundleIdentifier: 'foo' } });
   });
 });

--- a/packages/expo-document-picker/plugin/src/__tests__/withDocumentPicker-test.ts
+++ b/packages/expo-document-picker/plugin/src/__tests__/withDocumentPicker-test.ts
@@ -1,0 +1,22 @@
+import withDocumentPicker from '../withDocumentPicker';
+
+describe(withDocumentPicker, () => {
+  it(`asserts bundle id`, () => {
+    expect(() =>
+      withDocumentPicker(
+        { name: 'hey', slug: 'hey' },
+        // @ts-ignore
+        {}
+      )
+    ).toThrow('ios.bundleIdentifier');
+  });
+  it(`asserts apple team id`, () => {
+    expect(() =>
+      withDocumentPicker(
+        { name: 'hey', slug: 'hey', ios: { bundleIdentifier: 'foo' } },
+        // @ts-ignore
+        {}
+      )
+    ).toThrow('appleTeamId');
+  });
+});

--- a/packages/expo-document-picker/plugin/src/withDocumentPicker.ts
+++ b/packages/expo-document-picker/plugin/src/withDocumentPicker.ts
@@ -1,0 +1,40 @@
+import { ConfigPlugin, createRunOncePlugin, withEntitlementsPlist } from '@expo/config-plugins';
+import assert from 'assert';
+
+const pkg = require('expo-document-picker/package.json');
+
+const withDocumentPicker: ConfigPlugin<{ appleTeamId: string }> = (
+  config,
+  // This cannot be a default plugin because it has required properties.
+  props
+) => {
+  const { bundleIdentifier } = config.ios ?? {};
+  assert(
+    bundleIdentifier,
+    'expo-document-picker plugin requires `ios.bundleIdentifier` to be defined for iCloud entitlements. Learn more: https://docs.expo.io/versions/latest/sdk/document-picker/#configuration'
+  );
+  assert(
+    props.appleTeamId,
+    'expo-document-picker plugin requires the property `appleTeamId` to be defined for iCloud entitlements. Learn more: https://docs.expo.io/versions/latest/sdk/document-picker/#configuration'
+  );
+  // TODO: Should we ignore if `config.ios?.usesIcloudStorage` is false?
+  return withEntitlementsPlist(config, config => {
+    const { modResults: entitlements } = config;
+
+    entitlements['com.apple.developer.icloud-container-identifiers'] = [
+      'iCloud.' + bundleIdentifier,
+    ];
+    entitlements['com.apple.developer.ubiquity-container-identifiers'] = [
+      'iCloud.' + bundleIdentifier,
+    ];
+    entitlements['com.apple.developer.ubiquity-kvstore-identifier'] =
+      props.appleTeamId + '.' + bundleIdentifier;
+
+    entitlements['com.apple.developer.icloud-services'] = ['CloudDocuments'];
+
+    config.modResults = entitlements;
+    return config;
+  });
+};
+
+export default createRunOncePlugin(withDocumentPicker, pkg.name, pkg.version);

--- a/packages/expo-document-picker/plugin/src/withDocumentPicker.ts
+++ b/packages/expo-document-picker/plugin/src/withDocumentPicker.ts
@@ -3,19 +3,17 @@ import assert from 'assert';
 
 const pkg = require('expo-document-picker/package.json');
 
-const withDocumentPicker: ConfigPlugin<{ appleTeamId: string }> = (
-  config,
-  // This cannot be a default plugin because it has required properties.
-  props
-) => {
+const withDocumentPicker: ConfigPlugin = config => {
   const { bundleIdentifier } = config.ios ?? {};
   assert(
     bundleIdentifier,
     'expo-document-picker plugin requires `ios.bundleIdentifier` to be defined for iCloud entitlements. Learn more: https://docs.expo.io/versions/latest/sdk/document-picker/#configuration'
   );
+
+  const appleTeamId = process.env.EXPO_APPLE_TEAM_ID;
   assert(
-    props.appleTeamId,
-    'expo-document-picker plugin requires the property `appleTeamId` to be defined for iCloud entitlements. Learn more: https://docs.expo.io/versions/latest/sdk/document-picker/#configuration'
+    appleTeamId,
+    'expo-document-picker plugin requires the environment variable `EXPO_APPLE_TEAM_ID` to be defined for iCloud entitlements. Learn more: https://docs.expo.io/versions/latest/sdk/document-picker/#configuration'
   );
   // TODO: Should we ignore if `config.ios?.usesIcloudStorage` is false?
   return withEntitlementsPlist(config, config => {
@@ -28,7 +26,7 @@ const withDocumentPicker: ConfigPlugin<{ appleTeamId: string }> = (
       'iCloud.' + bundleIdentifier,
     ];
     entitlements['com.apple.developer.ubiquity-kvstore-identifier'] =
-      props.appleTeamId + '.' + bundleIdentifier;
+      appleTeamId + '.' + bundleIdentifier;
 
     entitlements['com.apple.developer.icloud-services'] = ['CloudDocuments'];
 

--- a/packages/expo-document-picker/plugin/tsconfig.json
+++ b/packages/expo-document-picker/plugin/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "expo-module-scripts/tsconfig.plugin",
+  "compilerOptions": {
+    "outDir": "build",
+    "rootDir": "src"
+  },
+  "include": ["./src"],
+  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+}


### PR DESCRIPTION
# How

- Created a plugin for document-picker -- https://github.com/expo/expo/issues/11561
  - The unversioned copy for this feature doesn't exist yet.
  - Feature pending some method for defining the Apple team ID statically.

# Test Plan

- Created unit tests for the assertions.