### PR TITLE
Update brew cask script in debugging.md

### DIFF
--- a/docs/pages/workflow/debugging.md
+++ b/docs/pages/workflow/debugging.md
@@ -98,7 +98,8 @@ We'll give a quick look at it here, but check out their [documentation](https://
 You can install it via the [release page](https://github.com/jhen0409/react-native-debugger/releases), or if you're on a mac you can run:
 
 ```sh
-brew cask install react-native-debugger
+#brew cask install react-native-debugger # home brew < 2.6.x
+brew install react-native-debugger --cask
 ```
 
 ### Startup


### PR DESCRIPTION
From 2.6, `brew cask <command>` was deprecated in favour of `brew <command> --cask` in Homebrew 2.6.0.

# Why

While following the documentation, I came across my terminal complaining about using a different way to install react native debugger.

# How

Brew is currently giving out warnings and information to fix the install command but will stop that in the coming releases. This is just to keep the documentation up to date.

# Test Plan

Not needed
