### PR TITLE
[tools] A few improvements to publish script

### DIFF
--- a/tools/src/Npm.ts
+++ b/tools/src/Npm.ts
@@ -93,3 +93,15 @@ export async function grantReadWriteAccessAsync(
 ): Promise<void> {
   await spawnAsync('npm', ['access', 'grant', 'read-write', teamName, packageName]);
 }
+
+/**
+ * Returns a name of the currently logged in user or `null` if logged out.
+ */
+export async function whoamiAsync(): Promise<string | null> {
+  try {
+    const { stdout } = await spawnAsync('npm', ['whoami']);
+    return stdout.trim();
+  } catch (e) {
+    return null;
+  }
+}

--- a/tools/src/publish-packages/tasks/checkEnvironmentTask.ts
+++ b/tools/src/publish-packages/tasks/checkEnvironmentTask.ts
@@ -1,0 +1,37 @@
+import chalk from 'chalk';
+
+import logger from '../../Logger';
+import * as Npm from '../../Npm';
+import { Task } from '../../TasksRunner';
+import { TaskArgs } from '../types';
+
+const { cyan } = chalk;
+
+/**
+ * Checks whether the environment allows to proceed with any further tasks.
+ */
+export const checkEnvironmentTask = new Task<TaskArgs>(
+  {
+    name: 'checkEnvironmentTask',
+    required: true,
+  },
+  async (): Promise<void | symbol> => {
+    const npmUser = await Npm.whoamiAsync();
+
+    if (!npmUser) {
+      logger.error(
+        '❗️ You must be logged in to NPM to publish packages, please run `npm login` first'
+      );
+      return Task.STOP;
+    }
+
+    const teamMembers = await Npm.getTeamMembersAsync(Npm.EXPO_DEVELOPERS_TEAM_NAME);
+
+    if (!teamMembers.includes(npmUser)) {
+      logger.error(
+        `❗️ You must be in ${cyan(Npm.EXPO_DEVELOPERS_TEAM_NAME)} team to publish packages`
+      );
+      return Task.STOP;
+    }
+  }
+);

--- a/tools/src/publish-packages/tasks/publishPackagesPipeline.ts
+++ b/tools/src/publish-packages/tasks/publishPackagesPipeline.ts
@@ -3,6 +3,7 @@ import chalk from 'chalk';
 import logger from '../../Logger';
 import { Task } from '../../TasksRunner';
 import { CommandOptions, Parcel, TaskArgs } from '../types';
+import { checkEnvironmentTask } from './checkEnvironmentTask';
 import { checkPackagesIntegrity } from './checkPackagesIntegrity';
 import { checkRepositoryStatus } from './checkRepositoryStatus';
 import { cleanPrebuildsTask } from './cleanPrebuildsTask';
@@ -30,6 +31,7 @@ export const publishPackagesPipeline = new Task<TaskArgs>(
   {
     name: 'publishPackagesPipeline',
     dependsOn: [
+      checkEnvironmentTask,
       checkRepositoryStatus,
       prepareParcels,
       checkPackagesIntegrity,

--- a/tools/src/publish-packages/tasks/updateAndroidProjects.ts
+++ b/tools/src/publish-packages/tasks/updateAndroidProjects.ts
@@ -33,25 +33,13 @@ export const updateAndroidProjects = new Task<TaskArgs>(
 
       const relativeGradlePath = path.relative(EXPO_DIR, gradlePath);
 
-      logger.log(
-        '  ',
-        `Updating ${yellow('version')} and ${yellow('versionCode')} in ${magenta(
-          relativeGradlePath
-        )}`
-      );
+      logger.log('  ', `Updating ${yellow('version')} in ${magenta(relativeGradlePath)}`);
 
       await transformFileAsync(gradlePath, [
         {
           // update version and versionName in android/build.gradle
           find: /\b(version\s*=\s*|versionName\s+)(['"])(.*?)\2/g,
           replaceWith: `$1$2${state.releaseVersion}$2`,
-        },
-        {
-          find: /\bversionCode\s+(\d+)\b/g,
-          replaceWith: (match, p1) => {
-            const versionCode = parseInt(p1, 10);
-            return `versionCode ${versionCode + 1}`;
-          },
         },
       ]);
     }


### PR DESCRIPTION
# Why

Recently we've encountered some new problems with publishing, so here are some improvements

# How

- Added additional task that checks the environment — for now it's just checking if you're logged in to npm and you're a member of `expo:developers` team.
- Some tasks have no effect on what is being published and some of them are error-prone, so I make the pipeline continue when:
	- granting access to the team fails
	- reinstalling CocoaPods fails
- There was a silly bug in filtering the packages to grant access, so I fixed this too.
- We used to be bumping Android's `versionCode` in `build.gradle`s, but because of this the task was doing some unnecessary changes when the package version was already committed but not published. Generally, Android libraries don't have to have this property so it's probably fine to stop upgrading it, and maybe also remove it from all packages.
- In the same scenario as above — if the version that is going to be published already exists in the changelog, then this task should be no-op.

# Test Plan

On the package with unpublished changes (`expo-gl`) I tried the following:
- Used `et publish expo-gl --dry` which bumped versions, committed appropriate changes, but didn't push nor publish them because of `--dry` flag
- Ran `et publish expo-gl --dry --skip-repo-checks` once again and chose to publish the package using the currently set version (but not published yet). Then the command made an attempt to publish the package, but there were no changes to commit which was expected 🎉 
