### PR TITLE
[dev-menu][ios] Fix loading indicator

### DIFF
--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.h
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.h
@@ -29,7 +29,7 @@
 
 - (BOOL)onDeepLink:(NSURL *)url options:(NSDictionary *)options;
 
-- (void)loadApp:(NSString *)url onSuccess:(void (^)())onSuccess onError:(void (^)(NSError *error))onError;
+- (void)loadApp:(NSURL *)url onSuccess:(void (^)())onSuccess onError:(void (^)(NSError *error))onError;
 
 - (NSDictionary *)recentlyOpenedApps;
 

--- a/packages/expo-dev-launcher/ios/ReactNative/EXDevLauncherLoadingView.m
+++ b/packages/expo-dev-launcher/ios/ReactNative/EXDevLauncherLoadingView.m
@@ -10,7 +10,7 @@
 
 + (NSString *)moduleName
 {
-  return @"RCTDevLoadingView";
+  return @"DevLoadingView";
 }
 
 + (void)setEnabled:(BOOL)enabled {}

--- a/packages/expo-dev-menu/ios/DevMenuLoadingView.m
+++ b/packages/expo-dev-menu/ios/DevMenuLoadingView.m
@@ -8,7 +8,7 @@
 
 + (NSString *)moduleName
 {
-  return @"RCTDevLoadingView";
+  return @"DevLoadingView";
 }
 
 + (void)setEnabled:(BOOL)enabled {}

--- a/packages/expo-dev-menu/ios/DevMenuManager.swift
+++ b/packages/expo-dev-menu/ios/DevMenuManager.swift
@@ -64,7 +64,7 @@ open class DevMenuManager: NSObject, DevMenuManagerProtocol {
   /**
    `DevMenuAppInstance` instance that is responsible for initializing and managing React Native context for the dev menu.
    */
-  var appInstance: DevMenuAppInstance?
+  lazy var appInstance: DevMenuAppInstance = DevMenuAppInstance(manager: self)
 
   /**
    Instance of `DevMenuSession` that keeps the details of the currently opened dev menu session.
@@ -109,8 +109,7 @@ open class DevMenuManager: NSObject, DevMenuManagerProtocol {
   override init() {
     super.init()
     self.window = DevMenuWindow(manager: self)
-    self.appInstance = DevMenuAppInstance(manager: self)
-
+    
     DevMenuSettings.setup()
   }
 
@@ -137,9 +136,6 @@ open class DevMenuManager: NSObject, DevMenuManagerProtocol {
   @objc
   @discardableResult
   public func closeMenu() -> Bool {
-    guard let appInstance = appInstance else {
-      return false
-    }
     appInstance.sendCloseEvent()
     return true
   }

--- a/packages/expo-dev-menu/ios/DevMenuManager.swift
+++ b/packages/expo-dev-menu/ios/DevMenuManager.swift
@@ -136,8 +136,12 @@ open class DevMenuManager: NSObject, DevMenuManagerProtocol {
   @objc
   @discardableResult
   public func closeMenu() -> Bool {
-    appInstance.sendCloseEvent()
-    return true
+    if (isVisible) {
+      appInstance.sendCloseEvent()
+      return true
+    }
+    
+    return false
   }
 
   /**

--- a/packages/expo-dev-menu/ios/DevMenuViewController.swift
+++ b/packages/expo-dev-menu/ios/DevMenuViewController.swift
@@ -85,7 +85,7 @@ class DevMenuViewController: UIViewController {
   // RCTRootView assumes it is created on a loading bridge.
   // in our case, the bridge has usually already loaded. so we need to prod the view.
   private func forceRootViewToRenderHack() {
-    if !hasCalledJSLoadedNotification, let bridge = manager.appInstance?.bridge {
+    if !hasCalledJSLoadedNotification, let bridge = manager.appInstance.bridge {
       let notification = Notification(name: DevMenuViewController.JavaScriptDidLoadNotification, object: nil, userInfo: ["bridge": bridge])
 
       reactRootView?.javaScriptDidLoad(notification)
@@ -94,7 +94,7 @@ class DevMenuViewController: UIViewController {
   }
 
   private func maybeRebuildRootView() {
-    guard let bridge = manager.appInstance?.bridge else {
+    guard let bridge = manager.appInstance.bridge else {
       return
     }
     if reactRootView?.bridge != bridge {


### PR DESCRIPTION
# Why

Fix loading indicator on iOS (no progress, only splash screen displayed while building js) - mentioned in https://www.notion.so/expo/1-14-20-Dev-Client-Sync-0fa32f76ba9345c99f6ca57918528b1c. 

# How

- `RCTDevLoadingView` -> `DevLoadingView
- Made `appInstance` lazy. It'll be initialized after the app is loaded (not at the same time) to not interfere with loading the main app (which causes a lot of problems with the progress indicator). 

# Test Plan

- bare-expo ✅