### PR TITLE
[task-manager] Make TaskManagerTaskBody data generic

### DIFF
--- a/packages/expo-task-manager/CHANGELOG.md
+++ b/packages/expo-task-manager/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Dropped support for iOS 10.0 ([#11344](https://github.com/expo/expo/pull/11344) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🎉 New features
+- Improve TypeScript defintion of TaskManagerTaskBody to accept generic ([#11669](https://github.com/expo/expo/pull/11669) by [@Noitidart](https://github.com/Noitidart))
 
 - Created config plugins ([#11538](https://github.com/expo/expo/pull/11538) by [@EvanBacon](https://github.com/EvanBacon))
 

--- a/packages/expo-task-manager/src/TaskManager.ts
+++ b/packages/expo-task-manager/src/TaskManager.ts
@@ -13,11 +13,11 @@ export interface TaskManagerError {
 /**
  * Represents the object that is passed to the task executor.
  */
-export interface TaskManagerTaskBody {
+export interface TaskManagerTaskBody<T = object> {
   /**
    * An object of data passed to the task executor. Its properties depends on the type of the task.
    */
-  data: object;
+  data: T;
 
   /**
    * Error object if the task failed or `null` otherwise.


### PR DESCRIPTION
For instance, this now becomes possible:

```
import { LocationObject } from 'expo-location';
import { TaskManagerTaskBody } from 'expo-task-manager';

function handleLocationChange(input: TaskManagerTaskBody<{ locations: LocationObject[] }>) {

}
```

# Why

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

Improved Typescript

# How
Just types, no build.
<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

Just types, not needed.
<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->
