### PR TITLE
[docs] Clarify useFonts usage and add Snack examples

### DIFF
--- a/docs/pages/guides/icons.md
+++ b/docs/pages/guides/icons.md
@@ -20,7 +20,9 @@ import { Ionicons } from '@expo/vector-icons';
 export default function App() {
   return (
     <View style={styles.container}>
-      /* @info */<Ionicons name="md-checkmark-circle" size={32} color="green" />/* @end */ 
+      /* @info */
+      <Ionicons name="md-checkmark-circle" size={32} color="green" />
+      /* @end */
     </View>
   );
 }
@@ -31,7 +33,7 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
-  }
+  },
 });
 /* @end */
 ```
@@ -84,12 +86,12 @@ const Icon = createIconSetFromFontello(fontelloConfig, 'fontello', 'fontello.ttf
 Convenience method to create a custom font based on an [IcoMoon](https://icomoon.io/) config file. Don't forget to import the font as described above and drop the `config.json` somewhere convenient in your project, using `Font.loadAsync`.
 
 <SnackInline
-  label='Icomoon Icons'
-  files={{
+label='Icomoon Icons'
+files={{
     'assets/icomoon/icomoon.ttf': 'https://snack-code-uploads.s3.us-west-1.amazonaws.com/~asset/71ce651cbddbee5366aef87c456a80bb',
     'assets/icomoon/selection.json': 'https://snack-code-uploads.s3.us-west-1.amazonaws.com/~asset/a06aa5b6e7eb1df1fa1c8d06d4ab8463'
   }}
-  dependencies={['@expo/vector-icons', 'expo-font', 'expo-app-loading']}>
+dependencies={['@expo/vector-icons', 'expo-font', 'expo-app-loading']}>
 
 ```jsx
 import React from 'react';
@@ -102,19 +104,22 @@ import { createIconSetFromIcoMoon } from '@expo/vector-icons';
 const Icon = createIconSetFromIcoMoon(
   require('./assets/icomoon/selection.json'),
   'IcoMoon',
-  'icomoon.ttf');
+  'icomoon.ttf'
+);
 /* @end */
 
 export default function App() {
   // Load the icon font before using it
-  const [fontsLoaded] = useFonts({ 'IcoMoon': require('./assets/icomoon/icomoon.ttf') });
+  const [fontsLoaded] = useFonts({ IcoMoon: require('./assets/icomoon/icomoon.ttf') });
   if (!fontsLoaded) {
     return <AppLoading />;
   }
 
   return (
     <View style={styles.container}>
-      /* @info */<Icon name='pacman' size={50} color='red' />/* @end */ 
+      /* @info */
+      <Icon name="pacman" size={50} color="red" />
+      /* @end */
     </View>
   );
 }
@@ -125,7 +130,7 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
-  }
+  },
 });
 /* @end */
 ```
@@ -137,8 +142,8 @@ const styles = StyleSheet.create({
 If you know how to use the react-native `<Image>` component this will be a breeze.
 
 <SnackInline
-  label='Icon images'
-  files={{
+label='Icon images'
+files={{
     'assets/images/slack-icon.png': 'https://snack-code-uploads.s3.us-west-1.amazonaws.com/~asset/0397c8d3e7445a4e826705f08abdd8ef'
   }}>
 
@@ -164,7 +169,7 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
-  }
+  },
 });
 /* @end */
 ```
@@ -190,14 +195,16 @@ export default function App() {
   /* @hide const loginWithFacebook = () => { ... } */
   const loginWithFacebook = () => {
     console.log('Button pressed');
-  }
+  };
   /* @end */
 
   return (
     <View style={styles.container}>
-      /* @info */<FontAwesome.Button name="facebook" backgroundColor="#3b5998" onPress={loginWithFacebook}>/* @end */ 
-        Login with Facebook
-      /* @info */</FontAwesome.Button>/* @end */ 
+      /* @info */
+      <FontAwesome.Button name="facebook" backgroundColor="#3b5998" onPress={loginWithFacebook}>
+        /* @end */ Login with Facebook /* @info */
+      </FontAwesome.Button>
+      /* @end */
     </View>
   );
 }
@@ -208,7 +215,7 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
-  }
+  },
 });
 /* @end */
 ```

--- a/docs/pages/versions/unversioned/sdk/font.md
+++ b/docs/pages/versions/unversioned/sdk/font.md
@@ -5,6 +5,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-font'
 
 import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
+import SnackInline from '~/components/plugins/SnackInline';
 
 **`expo-font`** allows loading fonts from the web and using them in React Native components. See more detailed usage information in the [Using Custom Fonts](../../../guides/using-custom-fonts.md#using-custom-fonts) guide.
 
@@ -25,6 +26,8 @@ import * as Font from 'expo-font';
 ### `useFonts`
 
 ```ts
+import { useFonts } from 'expo-font';
+
 const [loaded, error] = useFonts({ ... });
 ```
 
@@ -41,23 +44,52 @@ Load a map of fonts with [`loadAsync`](#loadasyncobject). This returns a boolean
 
 #### Example: hook
 
+<SnackInline
+label='useFonts'
+dependencies={['expo-font']}
+files={{
+    'assets/fonts/Montserrat.ttf': 'https://snack-code-uploads.s3.us-west-1.amazonaws.com/~asset/ee6539921d713482b8ccd4d0d23961bb'
+  }}>
+
 ```tsx
-function App() {
-  const [loaded] = useFonts({
+import * as React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { useFonts } from 'expo-font';
+
+export default function App() {
+  /* @info */ const [loaded] = useFonts({
     Montserrat: require('./assets/fonts/Montserrat.ttf'),
   });
+  /* @end */
 
   if (!loaded) {
     return null;
   }
 
-  return <Text style={{ fontFamily: 'Montserrat' }} />;
+  return (
+    <View style={styles.container}>
+      <Text style={{ fontFamily: 'Montserrat', fontSize: 30 }}>Montserrat</Text>
+    </View>
+  );
 }
+
+/* @hide const styles = StyleSheet.create({ ... }); */
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});
+/* @end */
 ```
+
+</SnackInline>
 
 ## Methods
 
-### `loadAsync(object)`
+### `Font.loadAsync(object)`
 
 Highly efficient method for loading fonts from static or remote resources which can then be used with the platform's native text elements. In the browser this generates a `@font-face` block in a shared style sheet for fonts. No CSS is needed to use this method.
 
@@ -67,28 +99,80 @@ Highly efficient method for loading fonts from static or remote resources which 
 
 #### Example: functions
 
-```tsx
-await loadAsync({
-  // Load a font `Montserrat` from a static resource
-  Montserrat: require('./assets/fonts/Montserrat.ttf'),
+<SnackInline
+label='Font.loadAsync'
+dependencies={['expo-font']}
+files={{
+    'assets/fonts/Montserrat.ttf': 'https://snack-code-uploads.s3.us-west-1.amazonaws.com/~asset/ee6539921d713482b8ccd4d0d23961bb',
+    'assets/fonts/Montserrat-SemiBold.ttf': 'https://snack-code-uploads.s3.us-west-1.amazonaws.com/~asset/c641dbee1d75892e4d88bdc31560c91b'
+  }}>
 
-  // Any string can be used as the fontFamily name. Here we use an object to provide more control
-  'Montserrat-SemiBold': {
-    uri: require('./assets/fonts/Montserrat-SemiBold.ttf'),
-    fontDisplay: FontDisplay.FALLBACK,
+```tsx
+import * as React from 'react';
+import { Text, View, StyleSheet } from 'react-native';
+import * as Font from 'expo-font';
+
+export default class App extends React.Component {
+  state = {
+    fontsLoaded: false,
+  };
+
+  async loadFonts() {
+    /* @info */ await Font.loadAsync({
+      // Load a font `Montserrat` from a static resource
+      Montserrat: require('./assets/fonts/Montserrat.ttf'),
+
+      // Any string can be used as the fontFamily name. Here we use an object to provide more control
+      'Montserrat-SemiBold': {
+        uri: require('./assets/fonts/Montserrat-SemiBold.ttf'),
+        fontDisplay: Font.FontDisplay.FALLBACK,
+      },
+    });
+    /* @end */
+    this.setState({ fontsLoaded: true });
+  }
+
+  componentDidMount() {
+    this.loadFonts();
+  }
+
+  render() {
+    // Use the font with the fontFamily property after loading
+    if (this.state.fontsLoaded) {
+      return (
+        <View style={styles.container}>
+          <Text style={{ fontSize: 20 }}>Default Font</Text>
+          <Text style={{ fontFamily: 'Montserrat', fontSize: 20 }}>Montserrat</Text>
+          <Text style={{ fontFamily: 'Montserrat-SemiBold', fontSize: 20 }}>
+            Montserrat-SemiBold
+          </Text>
+        </View>
+      );
+    } else {
+      return null;
+    }
+  }
+}
+
+/* @hide const styles = StyleSheet.create({ ... }); */
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+    alignItems: 'center',
+    justifyContent: 'center',
   },
 });
-
-// Use the font with the fontFamily property
-
-return <Text style={{ fontFamily: 'Montserrat' }} />;
+/* @end */
 ```
+
+</SnackInline>
 
 #### Returns
 
 Returns a promise that resolves when the font has loaded. Often you may want to wrap the method in a `try/catch/finally` to ensure the app continues if the font fails to load.
 
-### `isLoaded`
+### `Font.isLoaded(fontFamily)`
 
 Synchronously detect if the font for `fontFamily` has finished loading.
 
@@ -100,7 +184,7 @@ Synchronously detect if the font for `fontFamily` has finished loading.
 
 `true` if the the font has fully loaded.
 
-### `isLoading`
+### `Font.isLoading(fontFamily)`
 
 Synchronously detect if the font for `fontFamily` is still being loaded
 
@@ -136,7 +220,7 @@ enum FontDisplay {
   OPTIONAL = 'optional',
 }
 
-await loadAsync({
+await Font.loadAsync({
   roboto: {
     uri: require('./roboto.ttf'),
     // Only effects web

--- a/docs/pages/versions/v39.0.0/sdk/font.md
+++ b/docs/pages/versions/v39.0.0/sdk/font.md
@@ -5,6 +5,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-39/packages/expo-font'
 
 import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
+import SnackInline from '~/components/plugins/SnackInline';
 
 **`expo-font`** allows loading fonts from the web and using them in React Native components. See more detailed usage information in the [Using Custom Fonts](../../../guides/using-custom-fonts.md#using-custom-fonts) guide.
 
@@ -25,6 +26,8 @@ import * as Font from 'expo-font';
 ### `useFonts`
 
 ```ts
+import { useFonts } from 'expo-font';
+
 const [loaded, error] = useFonts({ ... });
 ```
 
@@ -41,23 +44,52 @@ Load a map of fonts with [`loadAsync`](#loadasyncobject). This returns a boolean
 
 #### Example: hook
 
+<SnackInline
+label='useFonts'
+dependencies={['expo-font']}
+files={{
+    'assets/fonts/Montserrat.ttf': 'https://snack-code-uploads.s3.us-west-1.amazonaws.com/~asset/ee6539921d713482b8ccd4d0d23961bb'
+  }}>
+
 ```tsx
-function App() {
-  const [loaded] = useFonts({
+import * as React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { useFonts } from 'expo-font';
+
+export default function App() {
+  /* @info */ const [loaded] = useFonts({
     Montserrat: require('./assets/fonts/Montserrat.ttf'),
   });
+  /* @end */
 
   if (!loaded) {
     return null;
   }
 
-  return <Text style={{ fontFamily: 'Montserrat' }} />;
+  return (
+    <View style={styles.container}>
+      <Text style={{ fontFamily: 'Montserrat', fontSize: 30 }}>Montserrat</Text>
+    </View>
+  );
 }
+
+/* @hide const styles = StyleSheet.create({ ... }); */
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});
+/* @end */
 ```
+
+</SnackInline>
 
 ## Methods
 
-### `loadAsync(object)`
+### `Font.loadAsync(object)`
 
 Highly efficient method for loading fonts from static or remote resources which can then be used with the platform's native text elements. In the browser this generates a `@font-face` block in a shared style sheet for fonts. No CSS is needed to use this method.
 
@@ -67,28 +99,80 @@ Highly efficient method for loading fonts from static or remote resources which 
 
 #### Example: functions
 
-```tsx
-await loadAsync({
-  // Load a font `Montserrat` from a static resource
-  Montserrat: require('./assets/fonts/Montserrat.ttf'),
+<SnackInline
+label='Font.loadAsync'
+dependencies={['expo-font']}
+files={{
+    'assets/fonts/Montserrat.ttf': 'https://snack-code-uploads.s3.us-west-1.amazonaws.com/~asset/ee6539921d713482b8ccd4d0d23961bb',
+    'assets/fonts/Montserrat-SemiBold.ttf': 'https://snack-code-uploads.s3.us-west-1.amazonaws.com/~asset/c641dbee1d75892e4d88bdc31560c91b'
+  }}>
 
-  // Any string can be used as the fontFamily name. Here we use an object to provide more control
-  'Montserrat-SemiBold': {
-    uri: require('./assets/fonts/Montserrat-SemiBold.ttf'),
-    fontDisplay: FontDisplay.FALLBACK,
+```tsx
+import * as React from 'react';
+import { Text, View, StyleSheet } from 'react-native';
+import * as Font from 'expo-font';
+
+export default class App extends React.Component {
+  state = {
+    fontsLoaded: false,
+  };
+
+  async loadFonts() {
+    /* @info */ await Font.loadAsync({
+      // Load a font `Montserrat` from a static resource
+      Montserrat: require('./assets/fonts/Montserrat.ttf'),
+
+      // Any string can be used as the fontFamily name. Here we use an object to provide more control
+      'Montserrat-SemiBold': {
+        uri: require('./assets/fonts/Montserrat-SemiBold.ttf'),
+        fontDisplay: Font.FontDisplay.FALLBACK,
+      },
+    });
+    /* @end */
+    this.setState({ fontsLoaded: true });
+  }
+
+  componentDidMount() {
+    this.loadFonts();
+  }
+
+  render() {
+    // Use the font with the fontFamily property after loading
+    if (this.state.fontsLoaded) {
+      return (
+        <View style={styles.container}>
+          <Text style={{ fontSize: 20 }}>Default Font</Text>
+          <Text style={{ fontFamily: 'Montserrat', fontSize: 20 }}>Montserrat</Text>
+          <Text style={{ fontFamily: 'Montserrat-SemiBold', fontSize: 20 }}>
+            Montserrat-SemiBold
+          </Text>
+        </View>
+      );
+    } else {
+      return null;
+    }
+  }
+}
+
+/* @hide const styles = StyleSheet.create({ ... }); */
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+    alignItems: 'center',
+    justifyContent: 'center',
   },
 });
-
-// Use the font with the fontFamily property
-
-return <Text style={{ fontFamily: 'Montserrat' }} />;
+/* @end */
 ```
+
+</SnackInline>
 
 #### Returns
 
 Returns a promise that resolves when the font has loaded. Often you may want to wrap the method in a `try/catch/finally` to ensure the app continues if the font fails to load.
 
-### `isLoaded`
+### `Font.isLoaded(fontFamily)`
 
 Synchronously detect if the font for `fontFamily` has finished loading.
 
@@ -100,7 +184,7 @@ Synchronously detect if the font for `fontFamily` has finished loading.
 
 `true` if the the font has fully loaded.
 
-### `isLoading`
+### `Font.isLoading(fontFamily)`
 
 Synchronously detect if the font for `fontFamily` is still being loaded
 
@@ -136,7 +220,7 @@ enum FontDisplay {
   OPTIONAL = 'optional',
 }
 
-await loadAsync({
+await Font.loadAsync({
   roboto: {
     uri: require('./roboto.ttf'),
     // Only effects web

--- a/docs/pages/versions/v40.0.0/sdk/font.md
+++ b/docs/pages/versions/v40.0.0/sdk/font.md
@@ -5,6 +5,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-40/packages/expo-font'
 
 import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
+import SnackInline from '~/components/plugins/SnackInline';
 
 **`expo-font`** allows loading fonts from the web and using them in React Native components. See more detailed usage information in the [Using Custom Fonts](../../../guides/using-custom-fonts.md#using-custom-fonts) guide.
 
@@ -25,6 +26,8 @@ import * as Font from 'expo-font';
 ### `useFonts`
 
 ```ts
+import { useFonts } from 'expo-font';
+
 const [loaded, error] = useFonts({ ... });
 ```
 
@@ -41,23 +44,52 @@ Load a map of fonts with [`loadAsync`](#loadasyncobject). This returns a boolean
 
 #### Example: hook
 
+<SnackInline
+label='useFonts'
+dependencies={['expo-font']}
+files={{
+    'assets/fonts/Montserrat.ttf': 'https://snack-code-uploads.s3.us-west-1.amazonaws.com/~asset/ee6539921d713482b8ccd4d0d23961bb'
+  }}>
+
 ```tsx
-function App() {
-  const [loaded] = useFonts({
+import * as React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { useFonts } from 'expo-font';
+
+export default function App() {
+  /* @info */ const [loaded] = useFonts({
     Montserrat: require('./assets/fonts/Montserrat.ttf'),
   });
+  /* @end */
 
   if (!loaded) {
     return null;
   }
 
-  return <Text style={{ fontFamily: 'Montserrat' }} />;
+  return (
+    <View style={styles.container}>
+      <Text style={{ fontFamily: 'Montserrat', fontSize: 30 }}>Montserrat</Text>
+    </View>
+  );
 }
+
+/* @hide const styles = StyleSheet.create({ ... }); */
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});
+/* @end */
 ```
+
+</SnackInline>
 
 ## Methods
 
-### `loadAsync(object)`
+### `Font.loadAsync(object)`
 
 Highly efficient method for loading fonts from static or remote resources which can then be used with the platform's native text elements. In the browser this generates a `@font-face` block in a shared style sheet for fonts. No CSS is needed to use this method.
 
@@ -67,28 +99,80 @@ Highly efficient method for loading fonts from static or remote resources which 
 
 #### Example: functions
 
-```tsx
-await loadAsync({
-  // Load a font `Montserrat` from a static resource
-  Montserrat: require('./assets/fonts/Montserrat.ttf'),
+<SnackInline
+label='Font.loadAsync'
+dependencies={['expo-font']}
+files={{
+    'assets/fonts/Montserrat.ttf': 'https://snack-code-uploads.s3.us-west-1.amazonaws.com/~asset/ee6539921d713482b8ccd4d0d23961bb',
+    'assets/fonts/Montserrat-SemiBold.ttf': 'https://snack-code-uploads.s3.us-west-1.amazonaws.com/~asset/c641dbee1d75892e4d88bdc31560c91b'
+  }}>
 
-  // Any string can be used as the fontFamily name. Here we use an object to provide more control
-  'Montserrat-SemiBold': {
-    uri: require('./assets/fonts/Montserrat-SemiBold.ttf'),
-    fontDisplay: FontDisplay.FALLBACK,
+```tsx
+import * as React from 'react';
+import { Text, View, StyleSheet } from 'react-native';
+import * as Font from 'expo-font';
+
+export default class App extends React.Component {
+  state = {
+    fontsLoaded: false,
+  };
+
+  async loadFonts() {
+    /* @info */ await Font.loadAsync({
+      // Load a font `Montserrat` from a static resource
+      Montserrat: require('./assets/fonts/Montserrat.ttf'),
+
+      // Any string can be used as the fontFamily name. Here we use an object to provide more control
+      'Montserrat-SemiBold': {
+        uri: require('./assets/fonts/Montserrat-SemiBold.ttf'),
+        fontDisplay: Font.FontDisplay.FALLBACK,
+      },
+    });
+    /* @end */
+    this.setState({ fontsLoaded: true });
+  }
+
+  componentDidMount() {
+    this.loadFonts();
+  }
+
+  render() {
+    // Use the font with the fontFamily property after loading
+    if (this.state.fontsLoaded) {
+      return (
+        <View style={styles.container}>
+          <Text style={{ fontSize: 20 }}>Default Font</Text>
+          <Text style={{ fontFamily: 'Montserrat', fontSize: 20 }}>Montserrat</Text>
+          <Text style={{ fontFamily: 'Montserrat-SemiBold', fontSize: 20 }}>
+            Montserrat-SemiBold
+          </Text>
+        </View>
+      );
+    } else {
+      return null;
+    }
+  }
+}
+
+/* @hide const styles = StyleSheet.create({ ... }); */
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+    alignItems: 'center',
+    justifyContent: 'center',
   },
 });
-
-// Use the font with the fontFamily property
-
-return <Text style={{ fontFamily: 'Montserrat' }} />;
+/* @end */
 ```
+
+</SnackInline>
 
 #### Returns
 
 Returns a promise that resolves when the font has loaded. Often you may want to wrap the method in a `try/catch/finally` to ensure the app continues if the font fails to load.
 
-### `isLoaded`
+### `Font.isLoaded(fontFamily)`
 
 Synchronously detect if the font for `fontFamily` has finished loading.
 
@@ -100,7 +184,7 @@ Synchronously detect if the font for `fontFamily` has finished loading.
 
 `true` if the the font has fully loaded.
 
-### `isLoading`
+### `Font.isLoading(fontFamily)`
 
 Synchronously detect if the font for `fontFamily` is still being loaded
 
@@ -136,7 +220,7 @@ enum FontDisplay {
   OPTIONAL = 'optional',
 }
 
-await loadAsync({
+await Font.loadAsync({
   roboto: {
     uri: require('./roboto.ttf'),
     // Only effects web


### PR DESCRIPTION
# Why

It is not always clear to user how to use/import the `useFonts` hook and the other Fonts methods. This PR adds prefixes and import examples, as well as working Snack examples to demonstrate usage.

Closes #11490
Closes #11485

Snack examples
- useFonts: https://snack.expo.io/e3l1q524U
- loadAsync: https://snack.expo.io/PASc1Kn0L

![image](https://user-images.githubusercontent.com/6184593/105024971-fc30c100-5a4c-11eb-970d-54d3ceae65ed.png)

# How

- Updated docs for unversioned, SDK40 and SDK39
- Ran prettier on icons doc

# Test Plan

- Verified that both Snack examples work and have no warnings
  - useFonts: https://snack.expo.io/e3l1q524U
  - loadAsync: https://snack.expo.io/PASc1Kn0L
- Ran prettier
- All tests pass 
- :eyes: