### PR TITLE
created base tsconfig for expo projects

### DIFF
--- a/apps/native-component-list/tsconfig.json
+++ b/apps/native-component-list/tsconfig.json
@@ -8,10 +8,7 @@
       "@expo/vector-icons": ["react-native-vector-icons"]
     },
     "types": ["jest"],
-    "typeRoots": [
-      "./ts-declarations",
-      "node_modules/@types"
-    ],
+    "typeRoots": ["./ts-declarations", "node_modules/@types"],
     "sourceMap": true,
     "declaration": true,
     "inlineSources": true,
@@ -21,6 +18,5 @@
     "noImplicitThis": true,
     "noImplicitReturns": true
   },
-  "include": ["App.tsx", "src/**/*", "ts-declarations/**/*"],
-  "exclude": ["node_modules"]
+  "include": ["App.tsx", "src/**/*", "ts-declarations/**/*"]
 }

--- a/apps/native-component-list/tsconfig.json
+++ b/apps/native-component-list/tsconfig.json
@@ -9,8 +9,6 @@
     },
     "types": ["jest"],
     "typeRoots": ["./ts-declarations", "node_modules/@types"],
-    "sourceMap": true,
-    "declaration": true,
     "inlineSources": true,
     "strictNullChecks": true,
     "strictPropertyInitialization": true,

--- a/apps/native-component-list/tsconfig.json
+++ b/apps/native-component-list/tsconfig.json
@@ -9,7 +9,6 @@
     },
     "types": ["jest"],
     "typeRoots": ["./ts-declarations", "node_modules/@types"],
-    "inlineSources": true,
     "strictNullChecks": true,
     "strictPropertyInitialization": true,
     "strictFunctionTypes": true,

--- a/apps/native-component-list/tsconfig.json
+++ b/apps/native-component-list/tsconfig.json
@@ -22,5 +22,5 @@
     "noImplicitReturns": true
   },
   "include": ["App.tsx", "src/**/*", "ts-declarations/**/*"],
-  "exclude": ["node_modules", "babel.config.js", "metro.config.js"]
+  "exclude": ["node_modules"]
 }

--- a/apps/native-component-list/tsconfig.json
+++ b/apps/native-component-list/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "expo-module-scripts/tsconfig.base",
+  "extends": "expo/tsconfig.base",
   "compilerOptions": {
     "noImplicitAny": true,
     "experimentalDecorators": true,
@@ -9,5 +9,5 @@
     }
   },
   "include": ["App.tsx", "src/**/*", "ts-declarations/**/*"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "babel.config.js", "metro.config.js"]
 }

--- a/apps/native-component-list/tsconfig.json
+++ b/apps/native-component-list/tsconfig.json
@@ -6,7 +6,20 @@
     "baseUrl": ".",
     "paths": {
       "@expo/vector-icons": ["react-native-vector-icons"]
-    }
+    },
+    "types": ["jest"],
+    "typeRoots": [
+      "./ts-declarations",
+      "node_modules/@types"
+    ],
+    "sourceMap": true,
+    "declaration": true,
+    "inlineSources": true,
+    "strictNullChecks": true,
+    "strictPropertyInitialization": true,
+    "strictFunctionTypes": true,
+    "noImplicitThis": true,
+    "noImplicitReturns": true
   },
   "include": ["App.tsx", "src/**/*", "ts-declarations/**/*"],
   "exclude": ["node_modules", "babel.config.js", "metro.config.js"]

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -16,7 +16,7 @@
     "bin",
     "build",
     "tools",
-    "tsconfig.app.json",
+    "tsconfig.base.json",
     "bundledNativeModules.json",
     "requiresExtraSetup.json",
     "AppEntry.js"

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -16,6 +16,7 @@
     "bin",
     "build",
     "tools",
+    "tsconfig.app.json",
     "bundledNativeModules.json",
     "requiresExtraSetup.json",
     "AppEntry.js"

--- a/packages/expo/tsconfig.base.json
+++ b/packages/expo/tsconfig.base.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "lib": ["dom", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "moduleResolution": "node",
+    "jsx": "react-native"
+  },
+  "exclude": ["node_modules", "babel.config.js", "metro.config.js"]
+}

--- a/packages/expo/tsconfig.base.json
+++ b/packages/expo/tsconfig.base.json
@@ -9,7 +9,6 @@
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "isolatedModules": true,
     "moduleResolution": "node",
     "jsx": "react-native"
   },

--- a/packages/expo/tsconfig.base.json
+++ b/packages/expo/tsconfig.base.json
@@ -1,7 +1,10 @@
 {
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "display": "Expo",
+
   "compilerOptions": {
     "target": "esnext",
-    "lib": ["dom", "esnext"],
+    "lib": ["dom", "es6", "es2016.array.include", "es2017.object"],
     "allowJs": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
@@ -10,6 +13,9 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "moduleResolution": "node",
+    "baseUrl": "./",
     "jsx": "react-native"
-  }
+  },
+
+  "exclude": ["node_modules", "babel.config.js", "metro.config.js", "jest.config.js"]
 }

--- a/packages/expo/tsconfig.base.json
+++ b/packages/expo/tsconfig.base.json
@@ -7,7 +7,6 @@
     "lib": ["dom", "es6", "es2016.array.include", "es2017.object"],
     "allowJs": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
     "noEmit": true,
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,

--- a/packages/expo/tsconfig.base.json
+++ b/packages/expo/tsconfig.base.json
@@ -12,7 +12,6 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "moduleResolution": "node",
-    "baseUrl": "./",
     "jsx": "react-native"
   },
 

--- a/packages/expo/tsconfig.base.json
+++ b/packages/expo/tsconfig.base.json
@@ -11,6 +11,5 @@
     "esModuleInterop": true,
     "moduleResolution": "node",
     "jsx": "react-native"
-  },
-  "exclude": ["node_modules"]
+  }
 }

--- a/packages/expo/tsconfig.base.json
+++ b/packages/expo/tsconfig.base.json
@@ -12,5 +12,5 @@
     "moduleResolution": "node",
     "jsx": "react-native"
   },
-  "exclude": ["node_modules", "babel.config.js", "metro.config.js"]
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
# Why

- Simplify TypeScript setup for Expo projects by creating a default `tsconfig.base` that users can extend in their projects with `"extends": "expo/tsconfig.base"`.
  - Currently the "copy over tsconfig" step of our [TS guide](https://docs.expo.io/guides/typescript/#integrating-typescript-in-your-existing-project) is kinda confusing and heavy handed.
  - We often have to provide dedicated TypeScript templates because migrating to TypeScript is a little too involved for most users.
- The _preferred_ tsconfig will also now be versioned with the SDK which will help with preserving older projects.


# Test Plan

- Migrated NCL to use the preset