### PR TITLE
[docs] Auto TypeScript setup

### DIFF
--- a/docs/pages/guides/typescript.md
+++ b/docs/pages/guides/typescript.md
@@ -20,12 +20,12 @@ Rename files to convert them to TypeScript. For example, you would rename `App.j
 
 You can now run `yarn tsc` or `npx tsc` to typecheck the project.
 
-## Preset
+## Base Config
 
 An Expo app's `tsconfig.json` should extend the `expo/tsconfig.base` by default. This sets the following default [compiler options][tsc-compileroptions] (which can be overwritten in your project's `tsconfig.json`):
 
 - [`jsx`][tsc-jsx]: -- `"react-native"`
-  - Preserves JSX, and converts the extension `jsx` to `js`. This is because Metro bundler (default) is responsible for transforming the JSX.
+  - Preserves JSX, and converts the extension `jsx` to `js`. This is optimized for bundlers that transform the JSX internally (like Metro).
 - `allowJs`: -- `true`
   - Allow JavaScript files to be compiled. If you project requires more strictness, you can disable this.
 - `resolveJsonModule`: -- `true`

--- a/docs/pages/guides/typescript.md
+++ b/docs/pages/guides/typescript.md
@@ -29,7 +29,7 @@ An Expo app's `tsconfig.json` should extend the `expo/tsconfig.base` by default.
 - `allowJs`: -- `true`
   - Allow JavaScript files to be compiled. If you project requires more strictness, you can disable this.
 - `resolveJsonModule`: -- `true`
-  - Enables importing `.json` files. Metro's default behavior is to allow importing json files as JS objects. If your `metro.config.js` has `resolver.assetExts: ['json']` then this rule should be disabled.
+  - Enables importing `.json` files. Metro's default behavior is to allow importing json files as JS objects.
 - `noEmit`: -- `true`
   - Only typecheck, and skip generating transpiled code. Metro bundler is responsible for doing this.
 - [`moduleResolution`][tsc-moduleresolution]: -- `"node"`

--- a/docs/pages/guides/typescript.md
+++ b/docs/pages/guides/typescript.md
@@ -8,23 +8,13 @@ import TerminalBlock from '~/components/plugins/TerminalBlock';
 
 Expo has first-class support for [TypeScript](https://www.typescriptlang.org/). The JavaScript interface of the Expo SDK is completely written in TypeScript.
 
-## Starting from scratch: using a TypeScript template
+To get started, create a `tsconfig.json` in your project root:
 
-<TerminalBlock cmd={['expo init -t expo-template-blank-typescript']} />
+<TerminalBlock cmd={['touch tsconfig.json']} />
 
-The easiest way to get started is to initialize your new project using a TypeScript template. When you run `expo init` choose one of the templates with TypeScript in the name and then run `yarn tsc` or `npx tsc` to typecheck the project.
+Running `expo start` will prompt you to install the required dependencies (`typescript`, `@types/react`, `@types/react-native`), and automatically configure your `tsconfig.json`.
 
-When you create new source files in your project you should use the `.ts` extension or the `.tsx` if the file includes React components.
-
-## Integrating TypeScript in your existing project
-
-Create a config file and copy over the defaults from: [`tsconfig.json`](https://github.com/expo/expo/blob/master/templates/expo-template-blank-typescript/tsconfig.json)
-
-<TerminalBlock cmd={['curl https://raw.githubusercontent.com/expo/expo/master/templates/expo-template-blank-typescript/tsconfig.json -o tsconfig.json']} />
-
-Install types in your project.
-
-<TerminalBlock cmd={['yarn add --dev typescript @types/react @types/react-native @types/react-dom']} />
+<TerminalBlock cmd={['yarn add --dev typescript @types/react @types/react-native']} />
 
 Rename files to convert them to TypeScript. For example, you would rename `App.js` to `App.tsx`.
 
@@ -32,30 +22,62 @@ Rename files to convert them to TypeScript. For example, you would rename `App.j
 
 Use the `.tsx` extension if the file includes React components (JSX). If the file did not include any JSX, you can use the `.ts` file extension.
 
-## Code editor integration
+You can now run `yarn tsc` or `npx tsc` to typecheck the project.
 
-Visual Studio Code itself is written in TypeScript and has fantastic support for it out of the box. Other editors may require additional setup.
+## Preset
 
-## Configuring the TypeScript compiler
+An Expo app's `tsconfig.json` should extend the `expo/tsconfig.base` by default. This sets the following default [compiler options][tsc-compileroptions] (which can be overwritten in your project's `tsconfig.json`):
 
-`tsconfig.json` contains a variety of options that allow you to customize the behavior of the TypeScript compiler. For example, by default we enable `"noEmit"`, which tells the compiler only to typecheck and not to actually output the compiled JavaScript files (Metro, the default bundler for native React projects, takes care of that for you).
+- [`jsx`][tsc-jsx]: -- `"react-native"`
+  - Preserves JSX, and converts the extension `jsx` to `js`. This is because Metro bundler (default) is responsible for transforming the JSX.
+- `allowJs`: -- `true`
+  - Allow JavaScript files to be compiled. If you project requires more strictness, you can disable this.
+- `resolveJsonModule`: -- `true`
+  - Enables importing `.json` files.
+- `noEmit`: -- `true`
+  - Only typecheck, and skip generating transpiled code. Metro bundler is responsible for doing this.
+- [`moduleResolution`][tsc-moduleresolution]: -- `"node"`
+  - Emulates how Metro and Webpack resolve modules.
+- `target`: -- `"esnext"`
+  - The latest [TC39 proposed features](https://github.com/tc39/proposals).
+- `lib`: -- `["dom", "esnext"]`
+  - List of library files to be included in the compilation.
+- `skipLibCheck`: -- `true`
+  - Skip type checking of all declaration files (`*.d.ts`).
+- `forceConsistentCasingInFileNames`: -- `true`
+  - Disallow inconsistently-cased references to the same file.
+- `allowSyntheticDefaultImports`: -- `true`
+  - Allow default imports from modules with no default export. This does not affect code emit, just typechecking.
+- `esModuleInterop`: -- `true`
+  - Improves Babel ecosystem compatibility.
+
+[tsc-jsx]: https://www.typescriptlang.org/docs/handbook/jsx.html
+[tsc-compileroptions]: https://www.typescriptlang.org/docs/handbook/compiler-options.html
+[tsc-moduleresolution]: https://www.typescriptlang.org/docs/handbook/module-resolution.html
+
+## Project Config
+
+Expo CLI will automatically modify your `tsconfig.json` to the preferred default which is optimized for universal React development:
 
 ```json
 {
-  "compilerOptions": {
-    "allowSyntheticDefaultImports": true,
-    "jsx": "react-native",
-    "lib": ["dom", "esnext"],
-    "moduleResolution": "node",
-    "noEmit": true,
-    "skipLibCheck": true
-  }
+  "extends": "expo/tsconfig.base",
+  "compilerOptions": {},
+  "exclude": ["node_modules"]
 }
 ```
 
 The default configuration is forgiving and makes it easier to adopt TypeScript. If you'd like to opt-in to more strict type checking, you can add `"strict": true` to the `compilerOptions`. We recommend enabling this to minimize the chance of introducing runtime errors.
 
 Certain language features may require additional configuration, for example if you'd like to use decorators you will need to add the `experimentalDecorators` option. For more information on the available properties see the [TypeScript compiler options documentation](https://www.typescriptlang.org/docs/handbook/compiler-options.html) documentation.
+
+## Starting from scratch: using a TypeScript template
+
+<TerminalBlock cmd={['expo init -t expo-template-blank-typescript']} />
+
+The easiest way to get started is to initialize your new project using a TypeScript template. When you run `expo init` choose one of the templates with TypeScript in the name and then run `yarn tsc` or `npx tsc` to typecheck the project.
+
+When you create new source files in your project you should use the `.ts` extension or the `.tsx` if the file includes React components.
 
 ## Learning how to use TypeScript
 
@@ -65,6 +87,6 @@ A good place to start learning TypeScript is the official [TypeScript Handbook](
 
 We recommend reading over and referring to the [React TypeScript CheatSheet](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet) to learn how to type your React components in a variety of common situations.
 
-#### Advanced types
+### Advanced types
 
 If you would like to go deeper and learn how to create more expressive and powerful types, we recommend the [Advanced Static Types in TypeScript course](https://egghead.io/courses/advanced-static-types-in-typescript) (this requires an egghead.io subscription).

--- a/docs/pages/guides/typescript.md
+++ b/docs/pages/guides/typescript.md
@@ -22,6 +22,8 @@ You can now run `yarn tsc` or `npx tsc` to typecheck the project.
 
 ## Base Config
 
+> 💡 You can disable the TypeScript setup in Expo CLI with the environment variable `EXPO_NO_TYPESCRIPT_SETUP=1`
+
 An Expo app's `tsconfig.json` should extend the `expo/tsconfig.base` by default. This sets the following default [compiler options][tsc-compileroptions] (which can be overwritten in your project's `tsconfig.json`):
 
 - [`jsx`][tsc-jsx]: -- `"react-native"`

--- a/docs/pages/guides/typescript.md
+++ b/docs/pages/guides/typescript.md
@@ -14,13 +14,9 @@ To get started, create a `tsconfig.json` in your project root:
 
 Running `expo start` will prompt you to install the required dependencies (`typescript`, `@types/react`, `@types/react-native`), and automatically configure your `tsconfig.json`.
 
-<TerminalBlock cmd={['yarn add --dev typescript @types/react @types/react-native']} />
-
-Rename files to convert them to TypeScript. For example, you would rename `App.js` to `App.tsx`.
+Rename files to convert them to TypeScript. For example, you would rename `App.js` to `App.tsx`. Use the `.tsx` extension if the file includes React components (JSX). If the file did not include any JSX, you can use the `.ts` file extension.
 
 <TerminalBlock cmd={['mv App.js App.tsx']} />
-
-Use the `.tsx` extension if the file includes React components (JSX). If the file did not include any JSX, you can use the `.ts` file extension.
 
 You can now run `yarn tsc` or `npx tsc` to typecheck the project.
 
@@ -62,8 +58,7 @@ Expo CLI will automatically modify your `tsconfig.json` to the preferred default
 ```json
 {
   "extends": "expo/tsconfig.base",
-  "compilerOptions": {},
-  "exclude": ["node_modules"]
+  "compilerOptions": {}
 }
 ```
 

--- a/docs/pages/guides/typescript.md
+++ b/docs/pages/guides/typescript.md
@@ -29,19 +29,17 @@ An Expo app's `tsconfig.json` should extend the `expo/tsconfig.base` by default.
 - `allowJs`: -- `true`
   - Allow JavaScript files to be compiled. If you project requires more strictness, you can disable this.
 - `resolveJsonModule`: -- `true`
-  - Enables importing `.json` files.
+  - Enables importing `.json` files. Metro's default behavior is to allow importing json files as JS objects. If your `metro.config.js` has `assetExts: ['json']` then this rule should be disabled.
 - `noEmit`: -- `true`
   - Only typecheck, and skip generating transpiled code. Metro bundler is responsible for doing this.
 - [`moduleResolution`][tsc-moduleresolution]: -- `"node"`
   - Emulates how Metro and Webpack resolve modules.
 - `target`: -- `"esnext"`
   - The latest [TC39 proposed features](https://github.com/tc39/proposals).
-- `lib`: -- `["dom", "esnext"]`
+- `lib`: -- `["dom", "es6", "es2016.array.include", "es2017.object"]`
   - List of library files to be included in the compilation.
 - `skipLibCheck`: -- `true`
   - Skip type checking of all declaration files (`*.d.ts`).
-- `forceConsistentCasingInFileNames`: -- `true`
-  - Disallow inconsistently-cased references to the same file.
 - `allowSyntheticDefaultImports`: -- `true`
   - Allow default imports from modules with no default export. This does not affect code emit, just typechecking.
 - `esModuleInterop`: -- `true`

--- a/docs/pages/guides/typescript.md
+++ b/docs/pages/guides/typescript.md
@@ -29,7 +29,7 @@ An Expo app's `tsconfig.json` should extend the `expo/tsconfig.base` by default.
 - `allowJs`: -- `true`
   - Allow JavaScript files to be compiled. If you project requires more strictness, you can disable this.
 - `resolveJsonModule`: -- `true`
-  - Enables importing `.json` files. Metro's default behavior is to allow importing json files as JS objects. If your `metro.config.js` has `assetExts: ['json']` then this rule should be disabled.
+  - Enables importing `.json` files. Metro's default behavior is to allow importing json files as JS objects. If your `metro.config.js` has `resolver.assetExts: ['json']` then this rule should be disabled.
 - `noEmit`: -- `true`
   - Only typecheck, and skip generating transpiled code. Metro bundler is responsible for doing this.
 - [`moduleResolution`][tsc-moduleresolution]: -- `"node"`


### PR DESCRIPTION
# Why

- Update the docs to reflect the auto TypeScript setup in Expo CLI.
- Clarify what every aspect of our base config does.

