### PR TITLE
[expo-updates] send expo-current-update-id header

### DIFF
--- a/android/versioned-abis/expoview-abi38_0_0/src/main/java/abi38_0_0/host/exp/exponent/modules/api/UpdatesModule.java
+++ b/android/versioned-abis/expoview-abi38_0_0/src/main/java/abi38_0_0/host/exp/exponent/modules/api/UpdatesModule.java
@@ -80,7 +80,7 @@ public class UpdatesModule extends ReactContextBaseJavaModule {
     try {
       String manifestUrl = (String) mExperienceProperties.get(KernelConstants.MANIFEST_URL_KEY);
       ExpoUpdatesAppLoader appLoader = KernelProvider.getInstance().getAppLoaderForManifestUrl(manifestUrl);
-      FileDownloader.downloadManifest(appLoader.getUpdatesConfiguration(), getReactApplicationContext(), new FileDownloader.ManifestDownloadCallback() {
+      FileDownloader.downloadManifest(appLoader.getUpdatesConfiguration(), null, getReactApplicationContext(), new FileDownloader.ManifestDownloadCallback() {
         @Override
         public void onFailure(String message, Exception e) {
           promise.reject("E_FETCH_MANIFEST_FAILED", e);
@@ -123,8 +123,7 @@ public class UpdatesModule extends ReactContextBaseJavaModule {
     AsyncTask.execute(() -> {
       new RemoteLoader(getReactApplicationContext(), appLoader.getUpdatesConfiguration(), mDatabaseHolder.getDatabase(), appLoader.getUpdatesDirectory())
         .start(
-          appLoader.getUpdatesConfiguration().getUpdateUrl(),
-          new RemoteLoader.LoaderCallback() {
+          null, new RemoteLoader.LoaderCallback() {
             @Override
             public void onFailure(Exception e) {
               mDatabaseHolder.releaseDatabase();

--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/updates/UpdatesModule.java
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/updates/UpdatesModule.java
@@ -15,7 +15,6 @@ import abi39_0_0.org.unimodules.core.interfaces.ExpoMethod;
 
 import androidx.annotation.Nullable;
 import expo.modules.updates.db.DatabaseHolder;
-import expo.modules.updates.db.UpdatesDatabase;
 import expo.modules.updates.db.entity.AssetEntity;
 import expo.modules.updates.db.entity.UpdateEntity;
 import expo.modules.updates.launcher.Launcher;
@@ -121,7 +120,7 @@ public class UpdatesModule extends ExportedModule {
         return;
       }
 
-      FileDownloader.downloadManifest(updatesService.getConfiguration(), getContext(), new FileDownloader.ManifestDownloadCallback() {
+      FileDownloader.downloadManifest(updatesService.getConfiguration(), null, getContext(), new FileDownloader.ManifestDownloadCallback() {
         @Override
         public void onFailure(String message, Exception e) {
           promise.reject("ERR_UPDATES_CHECK", message, e);
@@ -172,8 +171,7 @@ public class UpdatesModule extends ExportedModule {
         final DatabaseHolder databaseHolder = updatesService.getDatabaseHolder();
         new RemoteLoader(getContext(), updatesService.getConfiguration(), databaseHolder.getDatabase(), updatesService.getDirectory())
           .start(
-            updatesService.getConfiguration().getUpdateUrl(),
-            new RemoteLoader.LoaderCallback() {
+            null, new RemoteLoader.LoaderCallback() {
               @Override
               public void onFailure(Exception e) {
                 databaseHolder.releaseDatabase();

--- a/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/expo/modules/updates/UpdatesModule.java
+++ b/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/expo/modules/updates/UpdatesModule.java
@@ -15,7 +15,6 @@ import abi40_0_0.org.unimodules.core.interfaces.ExpoMethod;
 
 import androidx.annotation.Nullable;
 import expo.modules.updates.db.DatabaseHolder;
-import expo.modules.updates.db.UpdatesDatabase;
 import expo.modules.updates.db.entity.AssetEntity;
 import expo.modules.updates.db.entity.UpdateEntity;
 import expo.modules.updates.launcher.Launcher;
@@ -121,7 +120,7 @@ public class UpdatesModule extends ExportedModule {
         return;
       }
 
-      FileDownloader.downloadManifest(updatesService.getConfiguration(), getContext(), new FileDownloader.ManifestDownloadCallback() {
+      FileDownloader.downloadManifest(updatesService.getConfiguration(), null, getContext(), new FileDownloader.ManifestDownloadCallback() {
         @Override
         public void onFailure(String message, Exception e) {
           promise.reject("ERR_UPDATES_CHECK", message, e);
@@ -172,8 +171,7 @@ public class UpdatesModule extends ExportedModule {
         final DatabaseHolder databaseHolder = updatesService.getDatabaseHolder();
         new RemoteLoader(getContext(), updatesService.getConfiguration(), databaseHolder.getDatabase(), updatesService.getDirectory())
           .start(
-            updatesService.getConfiguration().getUpdateUrl(),
-            new RemoteLoader.LoaderCallback() {
+            null, new RemoteLoader.LoaderCallback() {
               @Override
               public void onFailure(Exception e) {
                 databaseHolder.releaseDatabase();

--- a/ios/Exponent/Kernel/Services/EXUpdatesManager.m
+++ b/ios/Exponent/Kernel/Services/EXUpdatesManager.m
@@ -161,6 +161,7 @@ didRequestManifestWithCacheBehavior:(EXManifestCacheBehavior)cacheBehavior
   EXUpdatesFileDownloader *fileDownloader = [[EXUpdatesFileDownloader alloc] initWithUpdatesConfig:appLoader.config];
   [fileDownloader downloadManifestFromURL:appLoader.config.updateUrl
                              withDatabase:databaseKernelService.database
+                       withLaunchedUpdate:nil
                              successBlock:^(EXUpdatesUpdate *update) {
     success(update.rawManifest);
   } errorBlock:^(NSError *error, NSURLResponse *response) {
@@ -184,7 +185,7 @@ didRequestBundleWithCompletionQueue:(dispatch_queue_t)completionQueue
   EXAppLoader *appLoader = [self _appLoaderWithScopedModule:scopedModule];
 
   EXUpdatesRemoteAppLoader *remoteAppLoader = [[EXUpdatesRemoteAppLoader alloc] initWithConfig:appLoader.config database:databaseKernelService.database directory:databaseKernelService.updatesDirectory completionQueue:completionQueue];
-  [remoteAppLoader loadUpdateFromUrl:appLoader.config.updateUrl onManifest:^BOOL(EXUpdatesUpdate * _Nonnull update) {
+  [remoteAppLoader loadUpdateFromUrl:appLoader.config.updateUrl withLaunchedUpdate:nil onManifest:^BOOL(EXUpdatesUpdate * _Nonnull update) {
     BOOL shouldLoad = [appLoader.selectionPolicy shouldLoadNewUpdate:update withLaunchedUpdate:appLoader.appLauncher.launchedUpdate];
     if (shouldLoad) {
       startBlock();

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/FileDownloaderTest.java
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/FileDownloaderTest.java
@@ -1,0 +1,52 @@
+package expo.modules.updates.loader;
+
+import android.content.Context;
+import android.net.Uri;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.UUID;
+
+import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner;
+import androidx.test.platform.app.InstrumentationRegistry;
+import expo.modules.updates.UpdatesConfiguration;
+import expo.modules.updates.db.entity.UpdateEntity;
+import okhttp3.Request;
+
+@RunWith(AndroidJUnit4ClassRunner.class)
+public class FileDownloaderTest {
+
+  private Context context;
+
+  @Before
+  public void createContext() {
+    context = InstrumentationRegistry.getInstrumentation().getTargetContext();
+  }
+
+  @Test
+  public void testSetHeadersForManifestUrl_LaunchedUpdate() {
+    UUID id = UUID.randomUUID();
+    UpdateEntity launchedUpdate = new UpdateEntity(id, new Date(), "1.0", "scopeKey");
+
+    Request request = FileDownloader.setHeadersForManifestUrl(createBasicConfig(), launchedUpdate, context);
+    Assert.assertEquals(id.toString(), request.header("expo-current-update-id"));
+  }
+
+  @Test
+  public void testSetHeadersForManifestUrl_NoLaunchedUpdate() {
+    Request request = FileDownloader.setHeadersForManifestUrl(createBasicConfig(), null, context);
+    Assert.assertNull(request.header("expo-current-update-id"));
+  }
+
+  private UpdatesConfiguration createBasicConfig() {
+    HashMap<String, Object> configMap = new HashMap<>();
+    configMap.put("updateUrl", Uri.parse("https://exp.host/@test/test"));
+    configMap.put("runtimeVersion", "1.0");
+    return new UpdatesConfiguration().loadValuesFromMap(configMap);
+  }
+}

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.java
@@ -15,7 +15,6 @@ import org.unimodules.core.interfaces.ExpoMethod;
 
 import androidx.annotation.Nullable;
 import expo.modules.updates.db.DatabaseHolder;
-import expo.modules.updates.db.UpdatesDatabase;
 import expo.modules.updates.db.entity.AssetEntity;
 import expo.modules.updates.db.entity.UpdateEntity;
 import expo.modules.updates.launcher.Launcher;
@@ -130,7 +129,7 @@ public class UpdatesModule extends ExportedModule {
         return;
       }
 
-      FileDownloader.downloadManifest(updatesService.getConfiguration(), getContext(), new FileDownloader.ManifestDownloadCallback() {
+      FileDownloader.downloadManifest(updatesService.getConfiguration(), updatesService.getLaunchedUpdate(), getContext(), new FileDownloader.ManifestDownloadCallback() {
         @Override
         public void onFailure(String message, Exception e) {
           promise.reject("ERR_UPDATES_CHECK", message, e);
@@ -181,8 +180,7 @@ public class UpdatesModule extends ExportedModule {
         final DatabaseHolder databaseHolder = updatesService.getDatabaseHolder();
         new RemoteLoader(getContext(), updatesService.getConfiguration(), databaseHolder.getDatabase(), updatesService.getDirectory())
           .start(
-            updatesService.getConfiguration().getUpdateUrl(),
-            new RemoteLoader.LoaderCallback() {
+            updatesService.getLaunchedUpdate(), new RemoteLoader.LoaderCallback() {
               @Override
               public void onFailure(Exception e) {
                 databaseHolder.releaseDatabase();

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.java
@@ -20,6 +20,7 @@ import java.util.Date;
 import java.util.Map;
 
 import expo.modules.updates.db.entity.AssetEntity;
+import expo.modules.updates.db.entity.UpdateEntity;
 import expo.modules.updates.launcher.NoDatabaseLauncher;
 import expo.modules.updates.manifest.Manifest;
 import expo.modules.updates.manifest.ManifestFactory;
@@ -78,9 +79,9 @@ public class FileDownloader {
     });
   }
 
-  public static void downloadManifest(final UpdatesConfiguration configuration, final Context context, final ManifestDownloadCallback callback) {
+  public static void downloadManifest(final UpdatesConfiguration configuration, UpdateEntity launchedUpdate, final Context context, final ManifestDownloadCallback callback) {
     try {
-      downloadData(setHeadersForManifestUrl(configuration, context), new Callback() {
+      downloadData(setHeadersForManifestUrl(configuration, launchedUpdate, context), new Callback() {
         @Override
         public void onFailure(Call call, IOException e) {
           callback.onFailure("Failed to download manifest from URL: " + configuration.getUpdateUrl(), e);
@@ -243,7 +244,7 @@ public class FileDownloader {
     return requestBuilder.build();
   }
 
-  private static Request setHeadersForManifestUrl(UpdatesConfiguration configuration, Context context) {
+  private static Request setHeadersForManifestUrl(UpdatesConfiguration configuration, UpdateEntity launchedUpdate, Context context) {
     Request.Builder requestBuilder = new Request.Builder()
             .url(configuration.getUpdateUrl().toString())
             .header("Accept", "application/expo+json,application/json")
@@ -261,6 +262,10 @@ public class FileDownloader {
       requestBuilder = requestBuilder.header("Expo-Runtime-Version", runtimeVersion);
     } else {
       requestBuilder = requestBuilder.header("Expo-SDK-Version", sdkVersion);
+    }
+
+    if (launchedUpdate != null) {
+      requestBuilder = requestBuilder.header("Expo-Current-Update-ID", launchedUpdate.id.toString());
     }
 
     String releaseChannel = configuration.getReleaseChannel();

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.java
@@ -244,7 +244,7 @@ public class FileDownloader {
     return requestBuilder.build();
   }
 
-  private static Request setHeadersForManifestUrl(UpdatesConfiguration configuration, UpdateEntity launchedUpdate, Context context) {
+  /* package */ static Request setHeadersForManifestUrl(UpdatesConfiguration configuration, UpdateEntity launchedUpdate, Context context) {
     Request.Builder requestBuilder = new Request.Builder()
             .url(configuration.getUpdateUrl().toString())
             .header("Accept", "application/expo+json,application/json")

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/LoaderTask.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/LoaderTask.java
@@ -247,8 +247,9 @@ public class LoaderTask {
   private void launchRemoteUpdateInBackground(Context context, Callback remoteUpdateCallback) {
     AsyncTask.execute(() -> {
       UpdatesDatabase database = mDatabaseHolder.getDatabase();
+      UpdateEntity launchedUpdate = mCandidateLauncher != null ? mCandidateLauncher.getLaunchedUpdate() : null;
       new RemoteLoader(context, mConfiguration, database, mDirectory)
-        .start(mConfiguration.getUpdateUrl(), new RemoteLoader.LoaderCallback() {
+        .start(launchedUpdate, new RemoteLoader.LoaderCallback() {
           @Override
           public void onFailure(Exception e) {
             mDatabaseHolder.releaseDatabase();

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/RemoteLoader.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/RemoteLoader.java
@@ -1,12 +1,10 @@
 package expo.modules.updates.loader;
 
 import android.content.Context;
-import android.net.Uri;
 import android.util.Log;
 
 import androidx.annotation.Nullable;
 import expo.modules.updates.UpdatesConfiguration;
-import expo.modules.updates.UpdatesController;
 import expo.modules.updates.db.enums.UpdateStatus;
 import expo.modules.updates.UpdatesUtils;
 import expo.modules.updates.db.UpdatesDatabase;
@@ -59,7 +57,7 @@ public class RemoteLoader {
 
   // lifecycle methods for class
 
-  public void start(Uri url, LoaderCallback callback) {
+  public void start(UpdateEntity launchedUpdate, LoaderCallback callback) {
     if (mCallback != null) {
       callback.onFailure(new Exception("RemoteLoader has already started. Create a new instance in order to load multiple URLs in parallel."));
       return;
@@ -67,7 +65,7 @@ public class RemoteLoader {
 
     mCallback = callback;
 
-    FileDownloader.downloadManifest(mConfiguration, mContext, new FileDownloader.ManifestDownloadCallback() {
+    FileDownloader.downloadManifest(mConfiguration, launchedUpdate, mContext, new FileDownloader.ManifestDownloadCallback() {
       @Override
       public void onFailure(String message, Exception e) {
         finishWithError(message, e);

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoader.h
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoader.h
@@ -26,6 +26,7 @@ typedef void (^EXUpdatesAppLoaderErrorBlock)(NSError *error);
  * update downloaded locally, and return the corresponding BOOL value.
  */
 - (void)loadUpdateFromUrl:(NSURL *)url
+       withLaunchedUpdate:(nullable EXUpdatesUpdate *)launchedUpdate
                onManifest:(EXUpdatesAppLoaderManifestBlock)manifestBlock
                   success:(EXUpdatesAppLoaderSuccessBlock)success
                     error:(EXUpdatesAppLoaderErrorBlock)error;

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoader.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoader.m
@@ -59,6 +59,7 @@ static NSString * const EXUpdatesAppLoaderErrorDomain = @"EXUpdatesAppLoader";
 # pragma mark - subclass methods
 
 - (void)loadUpdateFromUrl:(NSURL *)url
+       withLaunchedUpdate:(nullable EXUpdatesUpdate *)launchedUpdate
                onManifest:(EXUpdatesAppLoaderManifestBlock)manifestBlock
                   success:(EXUpdatesAppLoaderSuccessBlock)success
                     error:(EXUpdatesAppLoaderErrorBlock)error

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoaderTask.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoaderTask.m
@@ -220,8 +220,9 @@ static NSString * const EXUpdatesAppLoaderTaskErrorDomain = @"EXUpdatesAppLoader
 
 - (void)_loadRemoteUpdateWithCompletion:(void (^)(NSError * _Nullable error, EXUpdatesUpdate * _Nullable update))completion
 {
+  EXUpdatesUpdate *launchedUpdate = _candidateLauncher ? _candidateLauncher.launchedUpdate : nil;
   _remoteAppLoader = [[EXUpdatesRemoteAppLoader alloc] initWithConfig:_config database:_database directory:_directory completionQueue:_loaderTaskQueue];
-  [_remoteAppLoader loadUpdateFromUrl:_config.updateUrl onManifest:^BOOL(EXUpdatesUpdate * _Nonnull update) {
+  [_remoteAppLoader loadUpdateFromUrl:_config.updateUrl withLaunchedUpdate:launchedUpdate onManifest:^BOOL(EXUpdatesUpdate * _Nonnull update) {
     if ([self->_selectionPolicy shouldLoadNewUpdate:update withLaunchedUpdate:self->_candidateLauncher.launchedUpdate]) {
       self->_isUpToDate = NO;
       if (self->_delegate) {

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesEmbeddedAppLoader.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesEmbeddedAppLoader.m
@@ -113,6 +113,8 @@ static NSString * const EXUpdatesEmbeddedAppLoaderErrorDomain = @"EXUpdatesEmbed
 }
 
 - (void)loadUpdateFromUrl:(NSURL *)url
+       withLaunchedUpdate:(nullable EXUpdatesUpdate *)launchedUpdate
+               onManifest:(EXUpdatesAppLoaderManifestBlock)manifestBlock
                   success:(EXUpdatesAppLoaderSuccessBlock)success
                     error:(EXUpdatesAppLoaderErrorBlock)error
 {

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.h
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.h
@@ -26,6 +26,7 @@ typedef void (^EXUpdatesFileDownloaderErrorBlock)(NSError *error, NSURLResponse 
 
 - (void)downloadManifestFromURL:(NSURL *)url
                    withDatabase:(EXUpdatesDatabase *)database
+             withLaunchedUpdate:(nullable EXUpdatesUpdate *)launchedUpdate
                    successBlock:(EXUpdatesFileDownloaderManifestSuccessBlock)successBlock
                      errorBlock:(EXUpdatesFileDownloaderErrorBlock)errorBlock;
 

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.h
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.h
@@ -30,6 +30,9 @@ typedef void (^EXUpdatesFileDownloaderErrorBlock)(NSError *error, NSURLResponse 
                    successBlock:(EXUpdatesFileDownloaderManifestSuccessBlock)successBlock
                      errorBlock:(EXUpdatesFileDownloaderErrorBlock)errorBlock;
 
+- (void)setManifestHTTPHeaderFields:(NSMutableURLRequest *)request
+                 withLaunchedUpdate:(nullable EXUpdatesUpdate *)launchedUpdate;
+
 + (dispatch_queue_t)assetFilesQueue;
 
 @end

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.m
@@ -83,7 +83,7 @@ NSTimeInterval const EXUpdatesDefaultTimeoutInterval = 60;
   NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url
                                                          cachePolicy:NSURLRequestReloadIgnoringLocalCacheData
                                                      timeoutInterval:EXUpdatesDefaultTimeoutInterval];
-  [self _setManifestHTTPHeaderFields:request withLaunchedUpdate:launchedUpdate];
+  [self setManifestHTTPHeaderFields:request withLaunchedUpdate:launchedUpdate];
   [self _downloadDataWithRequest:request successBlock:^(NSData *data, NSURLResponse *response) {
     NSError *err;
     id parsedJson = [NSJSONSerialization JSONObjectWithData:data options:kNilOptions error:&err];
@@ -220,7 +220,7 @@ NSTimeInterval const EXUpdatesDefaultTimeoutInterval = 60;
   }
 }
 
-- (void)_setManifestHTTPHeaderFields:(NSMutableURLRequest *)request withLaunchedUpdate:(nullable EXUpdatesUpdate *)launchedUpdate
+- (void)setManifestHTTPHeaderFields:(NSMutableURLRequest *)request withLaunchedUpdate:(nullable EXUpdatesUpdate *)launchedUpdate
 {
   [request setValue:@"application/expo+json,application/json" forHTTPHeaderField:@"Accept"];
   [request setValue:@"true" forHTTPHeaderField:@"Expo-JSON-Error"];

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesRemoteAppLoader.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesRemoteAppLoader.m
@@ -27,6 +27,7 @@ static NSString * const EXUpdatesRemoteAppLoaderErrorDomain = @"EXUpdatesRemoteA
 }
 
 - (void)loadUpdateFromUrl:(NSURL *)url
+       withLaunchedUpdate:(nullable EXUpdatesUpdate *)launchedUpdate
                onManifest:(EXUpdatesAppLoaderManifestBlock)manifestBlock
                   success:(EXUpdatesAppLoaderSuccessBlock)success
                     error:(EXUpdatesAppLoaderErrorBlock)error
@@ -34,7 +35,7 @@ static NSString * const EXUpdatesRemoteAppLoaderErrorDomain = @"EXUpdatesRemoteA
   self.manifestBlock = manifestBlock;
   self.successBlock = success;
   self.errorBlock = error;
-  [_downloader downloadManifestFromURL:url withDatabase:self.database successBlock:^(EXUpdatesUpdate *update) {
+  [_downloader downloadManifestFromURL:url withDatabase:self.database withLaunchedUpdate:launchedUpdate successBlock:^(EXUpdatesUpdate *update) {
     [self startLoadingFromManifest:update];
   } errorBlock:^(NSError *error, NSURLResponse *response) {
     if (self.errorBlock) {

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesModule.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesModule.m
@@ -82,6 +82,7 @@ UM_EXPORT_METHOD_AS(checkForUpdateAsync,
   EXUpdatesFileDownloader *fileDownloader = [[EXUpdatesFileDownloader alloc] initWithUpdatesConfig:_updatesService.config];
   [fileDownloader downloadManifestFromURL:_updatesService.config.updateUrl
                              withDatabase:_updatesService.database
+                       withLaunchedUpdate:_updatesService.launchedUpdate
                              successBlock:^(EXUpdatesUpdate *update) {
     EXUpdatesUpdate *launchedUpdate = self->_updatesService.launchedUpdate;
     id<EXUpdatesSelectionPolicy> selectionPolicy = self->_updatesService.selectionPolicy;
@@ -110,7 +111,7 @@ UM_EXPORT_METHOD_AS(fetchUpdateAsync,
   }
 
   EXUpdatesRemoteAppLoader *remoteAppLoader = [[EXUpdatesRemoteAppLoader alloc] initWithConfig:_updatesService.config database:_updatesService.database directory:_updatesService.directory completionQueue:self.methodQueue];
-  [remoteAppLoader loadUpdateFromUrl:_updatesService.config.updateUrl onManifest:^BOOL(EXUpdatesUpdate * _Nonnull update) {
+  [remoteAppLoader loadUpdateFromUrl:_updatesService.config.updateUrl withLaunchedUpdate:_updatesService.launchedUpdate onManifest:^BOOL(EXUpdatesUpdate * _Nonnull update) {
     return [self->_updatesService.selectionPolicy shouldLoadNewUpdate:update withLaunchedUpdate:self->_updatesService.launchedUpdate];
   } success:^(EXUpdatesUpdate * _Nullable update) {
     if (update) {

--- a/packages/expo-updates/ios/Tests/EXUpdatesFileDownloaderTest.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesFileDownloaderTest.m
@@ -1,0 +1,56 @@
+//  Copyright (c) 2020 650 Industries, Inc. All rights reserved.
+
+#import <XCTest/XCTest.h>
+
+#import <EXUpdates/EXUpdatesConfig.h>
+#import <EXUpdates/EXUpdatesDatabase.h>
+#import <EXUpdates/EXUpdatesFileDownloader.h>
+#import <EXUpdates/EXUpdatesUpdate.h>
+
+@interface EXUpdatesFileDownloaderTest : XCTestCase
+
+@property (nonatomic, strong) EXUpdatesDatabase *database;
+
+@property (nonatomic, strong) EXUpdatesConfig *basicConfig;
+@property (nonatomic, strong) EXUpdatesFileDownloader *basicDownloader;
+
+@end
+
+@implementation EXUpdatesFileDownloaderTest
+
+- (void)setUp
+{
+  _database = [EXUpdatesDatabase new];
+
+  _basicConfig = [EXUpdatesConfig configWithDictionary:@{
+    @"EXUpdatesURL": @"https://exp.host/@test/test",
+    @"EXUpdatesRuntimeVersion": @"1.0"
+  }];
+  _basicDownloader = [[EXUpdatesFileDownloader alloc] initWithUpdatesConfig:_basicConfig];
+}
+
+- (void)tearDown
+{
+  [super tearDown];
+}
+
+- (void)testSetManifestHTTPHeaderFields_LaunchedUpdate
+{
+  NSUUID *uuid = [NSUUID UUID];
+  EXUpdatesUpdate *update = [EXUpdatesUpdate updateWithId:uuid scopeKey:@"scopeKey" commitTime:[NSDate date] runtimeVersion:@"1.0" metadata:nil status:EXUpdatesUpdateStatusReady keep:YES config:_basicConfig database:_database];
+
+  NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://test.test"]];
+  [_basicDownloader setManifestHTTPHeaderFields:request withLaunchedUpdate:update];
+
+  XCTAssertEqualObjects(uuid.UUIDString, [request valueForHTTPHeaderField:@"expo-current-update-id"]);
+}
+
+- (void)testSetManifestHTTPHeaderFields_NoLaunchedUpdate
+{
+  NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://test.test"]];
+  [_basicDownloader setManifestHTTPHeaderFields:request withLaunchedUpdate:nil];
+
+  XCTAssertNil([request valueForHTTPHeaderField:@"expo-current-update-id"]);
+}
+
+@end


### PR DESCRIPTION
# Why

Allow metering for EAS updates, cc @jkhales -- by passing the current update ID with manifest requests, we can make a pretty good guess on the service side about # of update downloads by comparing this to the served update ID.

# How

Pass the launched update through to the manifest request and include its ID in the `expo-current-update-id` header.

# Test Plan

Add logging to determine that this codepath is being triggered. Tested in managed workflow in both Android and iOS clients, automatic & manual (JS-triggered) manifest checks.

Added a few simple unit tests as well.
