### PR TITLE
[test-suite] Add FirebaseJS functions test

### DIFF
--- a/apps/test-suite/functions/package.json
+++ b/apps/test-suite/functions/package.json
@@ -16,8 +16,8 @@
   },
   "main": "lib/index.js",
   "dependencies": {
-    "firebase-admin": "^9.2.0",
-    "firebase-functions": "^3.11.0"
+    "firebase-admin": "^9.4.2",
+    "firebase-functions": "^3.13.1"
   },
   "devDependencies": {
     "firebase-functions-test": "^0.2.0",

--- a/apps/test-suite/functions/yarn.lock
+++ b/apps/test-suite/functions/yarn.lock
@@ -571,7 +571,7 @@ finalhandler@~1.1.2:
     statuses "~1.5.0"
     unpipe "~1.0.0"
 
-firebase-admin@^9.2.0:
+firebase-admin@^9.4.2:
   version "9.4.2"
   resolved "https://registry.yarnpkg.com/firebase-admin/-/firebase-admin-9.4.2.tgz#190d5d7ca5e3f251d99503feb6e05e7ab1623851"
   integrity sha512-mRnBJbW6BAz6DJkZ0GOUTkmnmCrwVzMreMc6O+RXWukFydOzi5Xr6TKSiPKxoOQw41r9IluP2AZ3Qzvlx2SR+g==
@@ -594,10 +594,10 @@ firebase-functions-test@^0.2.0:
     "@types/lodash" "^4.14.104"
     lodash "^4.17.5"
 
-firebase-functions@^3.11.0:
-  version "3.13.0"
-  resolved "https://registry.yarnpkg.com/firebase-functions/-/firebase-functions-3.13.0.tgz#66278dbeb45f343a179814f2b1d95b383beec5e7"
-  integrity sha512-tnltJL5KlGtbeBD9scsVjoKTSTMeo6EAy1gsdOfRlrwAu6idgLRKYVdmw0YymS8N7SwJ3CXo+3fuvSSihKhXbA==
+firebase-functions@^3.13.1:
+  version "3.13.1"
+  resolved "https://registry.yarnpkg.com/firebase-functions/-/firebase-functions-3.13.1.tgz#a34e61ab328903fe88a9532d267f031d9a0d9e23"
+  integrity sha512-tmYHN9OWWIij/8xO72AD2sKHm9T8pdLPYXy5RWk9VidP8+LDOUZ68vq1g1WKeSkRR7WyVYQ3scU2QoMDfe9T8g==
   dependencies:
     "@types/express" "4.17.3"
     cors "^2.8.5"

--- a/apps/test-suite/tests/FirebaseJSSDK.js
+++ b/apps/test-suite/tests/FirebaseJSSDK.js
@@ -108,7 +108,7 @@ export async function test({ describe, it, expect, beforeAll }) {
         const functions = firebase.functions();
         expect(functions).not.toBeNull();
       });
-      /* it(`calls the echo function`, async () => {
+      it(`calls the echo function`, async () => {
         let error = null;
         try {
           const message = "I'm a unit test";
@@ -120,7 +120,7 @@ export async function test({ describe, it, expect, beforeAll }) {
           error = e;
         }
         expect(error).toBeNull();
-      }); */
+      });
     });
 
     describe('storage', () => {


### PR DESCRIPTION
# Why

Follow up to #11568 to enable the Firebase Functions test.

# How

- Uploaded test echo function to Firebase project (`firebase deploy --only functions`)
- Add FirebaseJSSDK test for calling a firebase cloud function
- Update functions dependencies

# Test Plan

- `yarn build` in `/functions`
- Test succeeds

![image](https://user-images.githubusercontent.com/6184593/105156459-285f4700-5b0c-11eb-951d-9a0b87bb13a0.png)
