### PR TITLE
[react-native-screens] Update to 2.15.2 and backport to SDK 40

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenViewManager.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenViewManager.java
@@ -27,7 +27,14 @@ public class ScreenViewManager extends ViewGroupManager<Screen> {
   }
 
   @ReactProp(name = "activityState")
-  public void setActivityState(Screen view, int activityState) {
+  public void setActivityState(Screen view, Integer activityState) {
+    if (activityState == null) {
+      // Null will be provided when activityState is set as an animated value and we change
+      // it from JS to be a plain value (non animated).
+      // In case when null is received, we want to ignore such value and not make
+      // any updates as the actual non-null value will follow immediately.
+      return;
+    }
     if (activityState == 0) {
       view.setActivityState(Screen.ActivityState.INACTIVE);
     } else if (activityState == 1) {

--- a/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/host/exp/exponent/modules/api/screens/ScreenViewManager.java
+++ b/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/host/exp/exponent/modules/api/screens/ScreenViewManager.java
@@ -27,7 +27,14 @@ public class ScreenViewManager extends ViewGroupManager<Screen> {
   }
 
   @ReactProp(name = "activityState")
-  public void setActivityState(Screen view, int activityState) {
+  public void setActivityState(Screen view, Integer activityState) {
+    if (activityState == null) {
+      // Null will be provided when activityState is set as an animated value and we change
+      // it from JS to be a plain value (non animated).
+      // In case when null is received, we want to ignore such value and not make
+      // any updates as the actual non-null value will follow immediately.
+      return;
+    }
     if (activityState == 0) {
       view.setActivityState(Screen.ActivityState.INACTIVE);
     } else if (activityState == 1) {

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -134,7 +134,7 @@
     "react-native-gesture-handler": "~1.8.0",
     "react-native-reanimated": "~1.13.0",
     "react-native-safe-area-context": "3.1.9",
-    "react-native-screens": "~2.15.1",
+    "react-native-screens": "~2.15.2",
     "react-native-shared-element": "0.7.0",
     "react-native-svg": "12.1.0",
     "react-native-unimodules": "~0.12.0",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -147,7 +147,7 @@
     "react-native-safe-area-view": "^0.14.8",
     "react-native-svg": "~12.1.0",
     "react-native-webview": "~10.10.2",
-    "react-native-screens": "~2.15.1",
+    "react-native-screens": "~2.15.2",
     "react-native-unimodules": "~0.12.0",
     "react-native-view-shot": "3.1.2",
     "react-native-web": "~0.13.7",

--- a/home/package.json
+++ b/home/package.json
@@ -63,7 +63,7 @@
     "react-native-paper": "^4.0.1",
     "react-native-reanimated": "~1.13.0",
     "react-native-safe-area-context": "3.1.9",
-    "react-native-screens": "~2.15.1",
+    "react-native-screens": "~2.15.2",
     "react-redux": "^7.2.0",
     "react-string-replace": "^0.4.4",
     "reanimated-bottom-sheet": "^1.0.0-alpha.18",

--- a/ios/Exponent/Versioned/Core/Api/Screens/RNSScreen.m
+++ b/ios/Exponent/Versioned/Core/Api/Screens/RNSScreen.m
@@ -60,9 +60,14 @@
   [_bridge.uiManager setSize:self.bounds.size forView:self];
 }
 
-- (void)setActivityState:(int)activityState
+// Nil will be provided when activityState is set as an animated value and we change
+// it from JS to be a plain value (non animated).
+// In case when nil is received, we want to ignore such value and not make
+// any updates as the actual non-nil value will follow immediately.
+- (void)setActivityStateOrNil:(NSNumber *)activityStateOrNil
 {
-  if (activityState != _activityState) {
+  int activityState = [activityStateOrNil intValue];
+  if (activityStateOrNil != nil && activityState != _activityState) {
     _activityState = activityState;
     [_reactSuperview markChildUpdated];
   }
@@ -481,7 +486,8 @@
 
 RCT_EXPORT_MODULE()
 
-RCT_EXPORT_VIEW_PROPERTY(activityState, int)
+// we want to handle the case when activityState is nil
+RCT_REMAP_VIEW_PROPERTY(activityState, activityStateOrNil, NSNumber)
 RCT_EXPORT_VIEW_PROPERTY(gestureEnabled, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(replaceAnimation, RNSScreenReplaceAnimation)
 RCT_EXPORT_VIEW_PROPERTY(stackPresentation, RNSScreenStackPresentation)

--- a/ios/Exponent/Versioned/Core/Api/Screens/RNSScreenContainer.m
+++ b/ios/Exponent/Versioned/Core/Api/Screens/RNSScreenContainer.m
@@ -190,13 +190,13 @@
   if (screenRemoved || screenAdded) {
     // we disable interaction for the duration of the transition until one of the screens changes its state to "onTop"
     self.userInteractionEnabled = NO;
-    
-    for (RNSScreenView *screen in _reactSubviews) {
-      if (screen.activityState == RNSActivityStateOnTop) {
-        // if there is an "onTop" screen it means the transition has ended so we restore interactions
-        self.userInteractionEnabled = YES;
-        [screen notifyFinishTransitioning];
-      }
+  }
+
+  for (RNSScreenView *screen in _reactSubviews) {
+    if (screen.activityState == RNSActivityStateOnTop) {
+      // if there is an "onTop" screen it means the transition has ended so we restore interactions
+      self.userInteractionEnabled = YES;
+      [screen notifyFinishTransitioning];
     }
   }
 

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/Api/Screens/ABI40_0_0RNSScreen.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/Api/Screens/ABI40_0_0RNSScreen.m
@@ -60,9 +60,14 @@
   [_bridge.uiManager setSize:self.bounds.size forView:self];
 }
 
-- (void)setActivityState:(int)activityState
+// Nil will be provided when activityState is set as an animated value and we change
+// it from JS to be a plain value (non animated).
+// In case when nil is received, we want to ignore such value and not make
+// any updates as the actual non-nil value will follow immediately.
+- (void)setActivityStateOrNil:(NSNumber *)activityStateOrNil
 {
-  if (activityState != _activityState) {
+  int activityState = [activityStateOrNil intValue];
+  if (activityStateOrNil != nil && activityState != _activityState) {
     _activityState = activityState;
     [_ABI40_0_0ReactSuperview markChildUpdated];
   }
@@ -481,7 +486,8 @@
 
 ABI40_0_0RCT_EXPORT_MODULE()
 
-ABI40_0_0RCT_EXPORT_VIEW_PROPERTY(activityState, int)
+// we want to handle the case when activityState is nil
+ABI40_0_0RCT_REMAP_VIEW_PROPERTY(activityState, activityStateOrNil, NSNumber)
 ABI40_0_0RCT_EXPORT_VIEW_PROPERTY(gestureEnabled, BOOL)
 ABI40_0_0RCT_EXPORT_VIEW_PROPERTY(replaceAnimation, ABI40_0_0RNSScreenReplaceAnimation)
 ABI40_0_0RCT_EXPORT_VIEW_PROPERTY(stackPresentation, ABI40_0_0RNSScreenStackPresentation)

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/Api/Screens/ABI40_0_0RNSScreenContainer.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/Api/Screens/ABI40_0_0RNSScreenContainer.m
@@ -190,13 +190,13 @@
   if (screenRemoved || screenAdded) {
     // we disable interaction for the duration of the transition until one of the screens changes its state to "onTop"
     self.userInteractionEnabled = NO;
+  }
     
-    for (ABI40_0_0RNSScreenView *screen in _ABI40_0_0ReactSubviews) {
-      if (screen.activityState == ABI40_0_0RNSActivityStateOnTop) {
-        // if there is an "onTop" screen it means the transition has ended so we restore interactions
-        self.userInteractionEnabled = YES;
-        [screen notifyFinishTransitioning];
-      }
+  for (ABI40_0_0RNSScreenView *screen in _ABI40_0_0ReactSubviews) {
+    if (screen.activityState == ABI40_0_0RNSActivityStateOnTop) {
+      // if there is an "onTop" screen it means the transition has ended so we restore interactions
+      self.userInteractionEnabled = YES;
+      [screen notifyFinishTransitioning];
     }
   }
 

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -64,7 +64,7 @@
   "react-native-gesture-handler": "~1.8.0",
   "react-native-maps": "0.27.1",
   "react-native-reanimated": "~1.13.0",
-  "react-native-screens": "~2.15.1",
+  "react-native-screens": "~2.15.2",
   "react-native-svg": "12.1.0",
   "react-native-view-shot": "3.1.2",
   "react-native-webview": "11.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16053,10 +16053,10 @@ react-native-safe-modules@^1.0.0:
   dependencies:
     dedent "^0.6.0"
 
-react-native-screens@~2.15.1:
-  version "2.15.1"
-  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-2.15.1.tgz#f7512932ecff7327b57fb0bda58e49e9bf8ee5f2"
-  integrity sha512-cdcBHLizteH0RNn6QSw0ftQWWsAjolte/uuISoDBfllxka7sabT1i56C2Wus25KGGowaYT3DEz0zMFunS2GNJQ==
+react-native-screens@~2.15.2:
+  version "2.15.2"
+  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-2.15.2.tgz#a449700e895b462937211ec72ed6f09652758f06"
+  integrity sha512-CagNf2APXkVoRlF3Mugr264FbKbrBg9eXUkqhIPVeZB8EsdS8XPrnt99yj/pzmT+yJMBY0dGrjXT8+68WYh6YQ==
 
 react-native-scrollable-mixin@^1.0.0:
   version "1.0.1"
@@ -16110,39 +16110,6 @@ react-native-webview@10.10.2, react-native-webview@~10.10.2:
   dependencies:
     escape-string-regexp "2.0.0"
     invariant "2.2.4"
-
-react-native@0.63.2:
-  version "0.63.2"
-  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.63.2.tgz#eaebf3430577b37fbd66ef228a86b3408259ef8e"
-  integrity sha512-MkxHeJorUDzmQwKJrTfrFYMDRLyu9GSBpsFFMDX7X+HglVnaZi3CTzW2mRv1eIcazoseBOP2eJe+bnkyLl8Y2A==
-  dependencies:
-    "@babel/runtime" "^7.0.0"
-    "@react-native-community/cli" "^4.7.0"
-    "@react-native-community/cli-platform-android" "^4.7.0"
-    "@react-native-community/cli-platform-ios" "^4.7.0"
-    abort-controller "^3.0.0"
-    anser "^1.4.9"
-    base64-js "^1.1.2"
-    event-target-shim "^5.0.1"
-    fbjs "^1.0.0"
-    fbjs-scripts "^1.1.0"
-    hermes-engine "~0.5.0"
-    invariant "^2.2.4"
-    jsc-android "^245459.0.0"
-    metro-babel-register "0.59.0"
-    metro-react-native-babel-transformer "0.59.0"
-    metro-source-map "0.59.0"
-    nullthrows "^1.1.1"
-    pretty-format "^24.9.0"
-    promise "^8.0.3"
-    prop-types "^15.7.2"
-    react-devtools-core "^4.6.0"
-    react-refresh "^0.4.0"
-    regenerator-runtime "^0.13.2"
-    scheduler "0.19.1"
-    stacktrace-parser "^0.1.3"
-    use-subscription "^1.0.0"
-    whatwg-fetch "^3.0.0"
 
 react-navigation-shared-element@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
# Why

Fixes #11326 for patch release

# How

Get help from @WoLewicki to backport fix to a patch release compatible version with SDK 40.

# Test Plan

Run the repro app from #11326 against SDK 40 client build on this branch
