### PR TITLE
[app-auth][ios] configure OAuthRedirect in config plugin

### DIFF
--- a/packages/expo-app-auth/CHANGELOG.md
+++ b/packages/expo-app-auth/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Configure the OAuthRedirect scheme for iOS via config plugin ([#11701](https://github.com/expo/expo/pull/11701) by [@cruzach](https://github.com/cruzach))
+
 ## 10.0.0 — 2021-01-15
 
 ### 🛠 Breaking changes

--- a/packages/expo-app-auth/app.plugin.js
+++ b/packages/expo-app-auth/app.plugin.js
@@ -40,14 +40,22 @@ const withAppAuth = (
   });
   config = withInfoPlist(config, config => {
     const infoPlist = config.modResults;
+    if (!Array.isArray(infoPlist.CFBundleURLTypes)) {
+      infoPlist.CFBundleURLTypes = [];
+    }
     const existingUrlTypes = infoPlist.CFBundleURLTypes;
-    infoPlist.CFBundleURLTypes = [
-      ...(existingUrlTypes ?? []),
-      {
-        CFBundleURLName: 'OAuthRedirect',
-        CFBundleURLSchemes: [infoPlist.CFBundleIdentifier],
-      },
-    ];
+    const OAuthRedirectSchemeExists =
+      existingUrlTypes.filter(urlType => urlType.CFBundleURLName === 'OAuthRedirect').length > 0;
+
+    if (!OAuthRedirectSchemeExists) {
+      infoPlist.CFBundleURLTypes = [
+        ...(existingUrlTypes || []),
+        {
+          CFBundleURLName: 'OAuthRedirect',
+          CFBundleURLSchemes: [infoPlist.CFBundleIdentifier],
+        },
+      ];
+    }
 
     return config;
   });


### PR DESCRIPTION
# Why

without this, behavior of `expo-app-auth` will break when ejecting if you're relying on the default `redirectUrl`

# How

copied from https://github.com/expo/expo-cli/blob/cc4613dc4d9aeedcfb3ea69d9293fb66142c7148/packages/xdl/src/detach/IosNSBundle.ts#L334-L337

# Test Plan

info.plist gets the correct changes, and re-running `expod eject` again and again doesn't duplicate them
