### PR TITLE
[notifications][ios] migrate scoped categories to unscoped in standalone apps

### DIFF
--- a/ios/ExpoNotificationServiceExtension/Info.plist
+++ b/ios/ExpoNotificationServiceExtension/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>ExpoNotificationServiceExtension</string>
+	<string>ExpoGoNotificationServiceExtension</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/ios/ExpoNotificationServiceExtension/NotificationService.swift
+++ b/ios/ExpoNotificationServiceExtension/NotificationService.swift
@@ -23,7 +23,7 @@ class NotificationService: UNNotificationServiceExtension {
     if let bestAttemptContent = bestAttemptContent {
       // Modify notification content here...
       if (!request.content.categoryIdentifier.isEmpty && (request.content.userInfo["experienceId"]) != nil) {
-        bestAttemptContent.categoryIdentifier = "\(request.content.userInfo["experienceId"] as! String)-\(request.content.categoryIdentifier)"
+        bestAttemptContent.categoryIdentifier = "\(request.content.userInfo["experienceId"] as! String)/\(request.content.categoryIdentifier)"
       }
       contentHandler(bestAttemptContent)
     }

--- a/ios/ExpoNotificationServiceExtension/NotificationService.swift
+++ b/ios/ExpoNotificationServiceExtension/NotificationService.swift
@@ -1,7 +1,7 @@
 /*
  * This class allows you to intercept and mutate incoming remote notifications.
  * didReceive() has ~30 seconds to modify the payload and call the contentHandler,
- * otherwise serviceExtensionTimeWillExpire() will be triggered.
+ * otherwise the system will display the notification’s original content.
  *
  * The notification payload must contain:
  *    "mutable-content" : 1
@@ -25,13 +25,6 @@ class NotificationService: UNNotificationServiceExtension {
       if (!request.content.categoryIdentifier.isEmpty && (request.content.userInfo["experienceId"]) != nil) {
         bestAttemptContent.categoryIdentifier = "\(request.content.userInfo["experienceId"] as! String)-\(request.content.categoryIdentifier)"
       }
-      contentHandler(bestAttemptContent)
-    }
-  }
-  
-  override func serviceExtensionTimeWillExpire() {
-    // Called just before the extension will be terminated by the system.
-    if let contentHandler = contentHandler, let bestAttemptContent =  bestAttemptContent {
       contentHandler(bestAttemptContent)
     }
   }

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationBuilder.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationBuilder.m
@@ -33,7 +33,7 @@
   [content setUserInfo:userInfo];
   
   if (content.categoryIdentifier && _isInExpoGo) {
-    NSString *categoryIdentifier = [NSString stringWithFormat:@"%@-%@", _experienceId, content.categoryIdentifier];
+    NSString *categoryIdentifier = [NSString stringWithFormat:@"%@/%@", _experienceId, content.categoryIdentifier];
     [content setCategoryIdentifier:categoryIdentifier];
   }
   

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationCategoriesModule.h
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationCategoriesModule.h
@@ -3,12 +3,14 @@
 #if __has_include(<EXNotifications/EXNotificationCategoriesModule.h>)
 
 #import <EXNotifications/EXNotificationCategoriesModule.h>
+#import "EXConstantsBinding.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface EXScopedNotificationCategoriesModule : EXNotificationCategoriesModule
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId;
+- (instancetype)initWithExperienceId:(NSString *)experienceId
+                 andConstantsBinding:(EXConstantsBinding *)constantsBinding;
 
 @end
 

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationCategoriesModule.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationCategoriesModule.m
@@ -18,12 +18,11 @@
     _experienceId = experienceId;
     _isInExpoGo = [@"expo" isEqualToString:constantsBinding.appOwnership];
     if (!_isInExpoGo) {
-      // Since it is possible to skip the upgrade to SDK 41 in standalone apps (go straight from 39 -> 42),
-      // we must look for both "experienceId-" and "experienceId/" prefixes.
-      NSString *pattern = [NSString stringWithFormat:@"^%@(/|-)", self->_experienceId];
+      // Used to prefix with "experienceId-" even in standalone apps in SDKs <= 40, so we need to unscope those
+      NSString *pattern = [NSString stringWithFormat:@"^%@-", self->_experienceId];
       [self replaceAllCategoryIdPrefixesMatching:pattern withString:@""];
     } else {
-      // Used to prefix with "experienceId-", but as of SDK 41 we prefix with "experienceId/"
+      // Changed scoping prefix in SDK 41 FROM "experienceId-" TO "experienceId/"
       NSString *pattern = [NSString stringWithFormat:@"^%@-", self->_experienceId];
       [self replaceAllCategoryIdPrefixesMatching:pattern withString:[NSString stringWithFormat:@"%@/", _experienceId]];
     }

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationSerializer.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationSerializer.m
@@ -37,7 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
   NSString *experienceId = userInfo[@"experienceId"] ?: [NSNull null];
   if (experienceId) {
-    NSString *scopedCategoryPrefix = [NSString stringWithFormat:@"%@-", experienceId];
+    NSString *scopedCategoryPrefix = [NSString stringWithFormat:@"%@/", experienceId];
     return [identifier stringByReplacingOccurrencesOfString:scopedCategoryPrefix withString:@""];
   }
   return identifier;

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXScopedModuleRegistryAdapter.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXScopedModuleRegistryAdapter.m
@@ -170,11 +170,8 @@
 #endif
   
 #if __has_include(<EXNotifications/EXNotificationCategoriesModule.h>)
-  // only override in Expo Go
-  if ([params[@"constants"][@"appOwnership"] isEqualToString:@"expo"]) {
-    EXScopedNotificationCategoriesModule *scopedCategoriesModule = [[EXScopedNotificationCategoriesModule alloc] initWithExperienceId:experienceId];
-    [moduleRegistry registerExportedModule:scopedCategoriesModule];
-  }
+  EXScopedNotificationCategoriesModule *scopedCategoriesModule = [[EXScopedNotificationCategoriesModule alloc] initWithExperienceId:experienceId andConstantsBinding:constantsBinding];
+  [moduleRegistry registerExportedModule:scopedCategoriesModule];
 #endif
   
 #if __has_include(<EXNotifications/EXServerRegistrationModule.h>)

--- a/packages/expo-notifications/ios/EXNotifications/Notifications/Categories/EXNotificationCategoriesModule.h
+++ b/packages/expo-notifications/ios/EXNotifications/Notifications/Categories/EXNotificationCategoriesModule.h
@@ -14,6 +14,10 @@
 - (void)deleteNotificationCategoryWithCategoryId:(NSString *)categoryId
                                          resolve:(UMPromiseResolveBlock)resolve 
                                           reject:(UMPromiseRejectBlock)reject;
+
+- (UNNotificationCategory *)createCategoryWithId:(NSString*)categoryId
+                                         actions:(NSArray *)actions
+                                         options:(NSDictionary *)options;
 - (NSMutableDictionary *)serializeCategoryOptions:(UNNotificationCategory *)category;
 - (NSMutableArray *)serializeActions:(NSArray<UNNotificationAction *>*)actions;
 - (NSMutableDictionary *)serializeActionOptions:(NSUInteger)options;

--- a/packages/expo-notifications/ios/EXNotifications/Notifications/Categories/EXNotificationCategoriesModule.m
+++ b/packages/expo-notifications/ios/EXNotifications/Notifications/Categories/EXNotificationCategoriesModule.m
@@ -27,35 +27,8 @@ UM_EXPORT_METHOD_AS(setNotificationCategoryAsync,
                  options:(NSDictionary *)options
                  resolve:(UMPromiseResolveBlock)resolve reject:(UMPromiseRejectBlock)reject)
 {
-  NSArray<NSString *> *intentIdentifiers = options[@"intentIdentifiers"];
-  NSString *previewPlaceholder = options[@"previewPlaceholder"];
-  NSString *categorySummaryFormat = options[@"categorySummaryFormat"];
-
-  NSMutableArray<UNNotificationAction *> *actionsArray = [[NSMutableArray alloc] init];
-  for (NSDictionary<NSString *, id> *actionParams in actions) {
-    [actionsArray addObject:[self parseNotificationActionFromParams:actionParams]];
-  }
-  UNNotificationCategoryOptions categoryOptions = [self parseNotificationCategoryOptionsFromParams: options];
-  UNNotificationCategory *newCategory;
-  if (@available(iOS 12, *)) {
-    newCategory = [UNNotificationCategory categoryWithIdentifier:categoryId
-                                                         actions:actionsArray
-                                               intentIdentifiers:intentIdentifiers
-                                   hiddenPreviewsBodyPlaceholder:previewPlaceholder
-                                           categorySummaryFormat:categorySummaryFormat
-                                                         options:categoryOptions];
-  } else if (@available(iOS 11, *)) {
-    newCategory = [UNNotificationCategory categoryWithIdentifier:categoryId
-                                                         actions:actionsArray
-                                               intentIdentifiers:intentIdentifiers
-                                   hiddenPreviewsBodyPlaceholder:previewPlaceholder
-                                                         options:categoryOptions];
-  } else {
-    newCategory = [UNNotificationCategory categoryWithIdentifier:categoryId
-                                                         actions:actionsArray
-                                               intentIdentifiers:intentIdentifiers
-                                                         options:categoryOptions];
-  }
+  UNNotificationCategory *newCategory = [self createCategoryWithId:categoryId actions:actions options:options];
+  
   [[UNUserNotificationCenter currentNotificationCenter] getNotificationCategoriesWithCompletionHandler:^(NSSet<UNNotificationCategory *> *categories) {
     NSMutableSet<UNNotificationCategory *> *newCategories = [categories mutableCopy] ?: [[NSMutableSet alloc] init];
     for (UNNotificationCategory *category in newCategories) {
@@ -90,6 +63,42 @@ UM_EXPORT_METHOD_AS(deleteNotificationCategoryAsync,
 }
 
 # pragma mark- Internal
+
+- (UNNotificationCategory *)createCategoryWithId:(NSString*)categoryId
+                                         actions:(NSArray *)actions
+                                         options:(NSDictionary *)options
+{
+  NSArray<NSString *> *intentIdentifiers = options[@"intentIdentifiers"];
+  NSString *previewPlaceholder = options[@"previewPlaceholder"];
+  NSString *categorySummaryFormat = options[@"categorySummaryFormat"];
+
+  NSMutableArray<UNNotificationAction *> *actionsArray = [[NSMutableArray alloc] init];
+  for (NSDictionary<NSString *, id> *actionParams in actions) {
+    [actionsArray addObject:[self parseNotificationActionFromParams:actionParams]];
+  }
+  UNNotificationCategoryOptions categoryOptions = [self parseNotificationCategoryOptionsFromParams: options];
+  UNNotificationCategory *newCategory;
+  if (@available(iOS 12, *)) {
+    newCategory = [UNNotificationCategory categoryWithIdentifier:categoryId
+                                                         actions:actionsArray
+                                               intentIdentifiers:intentIdentifiers
+                                   hiddenPreviewsBodyPlaceholder:previewPlaceholder
+                                           categorySummaryFormat:categorySummaryFormat
+                                                         options:categoryOptions];
+  } else if (@available(iOS 11, *)) {
+    newCategory = [UNNotificationCategory categoryWithIdentifier:categoryId
+                                                         actions:actionsArray
+                                               intentIdentifiers:intentIdentifiers
+                                   hiddenPreviewsBodyPlaceholder:previewPlaceholder
+                                                         options:categoryOptions];
+  } else {
+    newCategory = [UNNotificationCategory categoryWithIdentifier:categoryId
+                                                         actions:actionsArray
+                                               intentIdentifiers:intentIdentifiers
+                                                         options:categoryOptions];
+  }
+  return newCategory;
+}
 
 - (UNNotificationAction *)parseNotificationActionFromParams:(NSDictionary *)params
 {


### PR DESCRIPTION
# Why

https://github.com/expo/expo/pull/11651#discussion_r560583410

# How

on startup, if we're in a standalone context, we loop through all notification categories and for any that have the `_experienceId` prefix (i.e. they are scoped) we:
- create a new `UNNotificationCategory` with the same content _except_ for an **unscoped** identifier
- remove the old category
- add the new, unscoped, category

We'll have to keep this code around for a while since people don't always upgrade SDK by SDK

# Test Plan

Tested by specifying categories in app without these changes, then applying these changes (including the [changes in this PR](https://github.com/expo/expo/pull/11651))- categories functionality remained the same 
