### PR TITLE
[docs] add docs about eas build-specific npm hooks

### DIFF
--- a/docs/pages/build-reference/how-tos.md
+++ b/docs/pages/build-reference/how-tos.md
@@ -4,6 +4,45 @@ title: Integrating with JavaScript tooling
 
 This document outlines how to configure EAS Build for some common scenarios, such as monorepos and repositories with private dependencies. The examples described here do not provide step-by-step instructions to set up EAS Build from scratch. Instead, they explain the changes from the standard process that are necessary to acommodate the given scenario.
 
+## EAS Build-specific npm hooks
+
+There are three EAS Build-specific npm hooks that you can set in your package.json. See the [Android build process](android-builds.md) and [iOS build process](ios-builds.md) docs to get a better understanding about the internals of the build process.
+
+- `eas-build-pre-install` - it's executed before EAS Build runs `yarn install`
+- `eas-build-post-install` - the behavior depends on the platform:
+  - for Android, after `yarn install` has completed
+  - for iOS, after `yarn install` and `pod install` have completed
+- `eas-build-pre-upload-artifacts` - this hook is triggered almost at the end of the build process, just before EAS Build uploads the build artifacts to AWS S3
+
+This is an example of how your package.json might look like:
+
+```json
+{
+  "main": "index.js",
+  "scripts": {
+    "eas-build-pre-install": "echo 123",
+    "eas-build-post-install": "echo 456",
+    "eas-build-pre-upload-artifacts": "echo 789",
+    "android": "react-native run-android",
+    "ios": "react-native run-ios",
+    "web": "expo start --web",
+    "start": "react-native start",
+    "test": "jest"
+  },
+  "dependencies": {
+    "expo": "~40.0.0"
+    // ...
+  },
+  "devDependencies": {
+    // ...
+  },
+  "jest": {
+    "preset": "react-native"
+  },
+  "private": true
+}
+```
+
 ## How to set up EAS Build with a monorepo
 
 - Run all EAS CLI commands from the root of the app directory. For example: if your project exists inside of your git repository at `apps/my-app`, then run `eas build` from there.

--- a/docs/pages/build-reference/how-tos.md
+++ b/docs/pages/build-reference/how-tos.md
@@ -8,7 +8,7 @@ This document outlines how to configure EAS Build for some common scenarios, suc
 
 There are three EAS Build-specific npm hooks that you can set in your package.json. See the [Android build process](android-builds.md) and [iOS build process](ios-builds.md) docs to get a better understanding about the internals of the build process.
 
-- `eas-build-pre-install` - it's executed before EAS Build runs `yarn install`
+- `eas-build-pre-install` - executed before EAS Build runs `yarn install`
 - `eas-build-post-install` - the behavior depends on the platform:
   - for Android, after `yarn install` has completed
   - for iOS, after `yarn install` and `pod install` have completed


### PR DESCRIPTION
# Why

This PR adds docs about eas build-specific npm hooks.

# How

Added a section about eas build-specifc npm hooks to the "Integrating with JavaScript tooling" page

# Test Plan

I ran `yarn dev` and verified the page renders correctly.