### PR TITLE
[rn-adapter] Rename moduleRegistry to umModuleRegistry to avoid conflicts

### DIFF
--- a/packages/@unimodules/react-native-adapter/ios/UMReactNativeAdapter/Services/UMReactNativeEventEmitter.m
+++ b/packages/@unimodules/react-native-adapter/ios/UMReactNativeAdapter/Services/UMReactNativeEventEmitter.m
@@ -8,7 +8,7 @@
 @interface UMReactNativeEventEmitter ()
 
 @property (nonatomic, assign) int listenersCount;
-@property (nonatomic, weak) UMModuleRegistry *moduleRegistry;
+@property (nonatomic, weak) UMModuleRegistry *umModuleRegistry;
 @property (nonatomic, strong) NSMutableDictionary<NSString *, NSNumber *> *modulesListenersCounts;
 
 @end
@@ -39,7 +39,7 @@ UM_REGISTER_MODULE();
 - (NSArray<NSString *> *)supportedEvents
 {
   NSMutableSet<NSString *> *eventsAccumulator = [NSMutableSet set];
-  for (UMExportedModule *exportedModule in [_moduleRegistry getAllExportedModules]) {
+  for (UMExportedModule *exportedModule in [_umModuleRegistry getAllExportedModules]) {
     if ([exportedModule conformsToProtocol:@protocol(UMEventEmitter)]) {
       id<UMEventEmitter> eventEmitter = (id<UMEventEmitter>)exportedModule;
       [eventsAccumulator addObjectsFromArray:[eventEmitter supportedEvents]];
@@ -52,8 +52,8 @@ RCT_EXPORT_METHOD(addProxiedListener:(NSString *)moduleName eventName:(NSString 
 {
   [self addListener:eventName];
   // Validate module
-  UMExportedModule *module = [_moduleRegistry getExportedModuleForName:moduleName];
-  
+  UMExportedModule *module = [_umModuleRegistry getExportedModuleForName:moduleName];
+
   if (RCT_DEBUG && module == nil) {
     UMLogError(@"Module for name `%@` has not been found.", moduleName);
     return;
@@ -88,8 +88,8 @@ RCT_EXPORT_METHOD(removeProxiedListeners:(NSString *)moduleName count:(double)co
 {
   [self removeListeners:count];
   // Validate module
-  UMExportedModule *module = [_moduleRegistry getExportedModuleForName:moduleName];
-  
+  UMExportedModule *module = [_umModuleRegistry getExportedModuleForName:moduleName];
+
   if (RCT_DEBUG && module == nil) {
     UMLogError(@"Module for name `%@` has not been found.", moduleName);
     return;
@@ -139,7 +139,7 @@ RCT_EXPORT_METHOD(removeProxiedListeners:(NSString *)moduleName count:(double)co
 
 - (void)setModuleRegistry:(UMModuleRegistry *)moduleRegistry
 {
-  _moduleRegistry = moduleRegistry;
+  _umModuleRegistry = moduleRegistry;
 }
 
 @end

--- a/packages/@unimodules/react-native-adapter/ios/UMReactNativeAdapter/UMModuleRegistryAdapter/UMModuleRegistryHolderReactModule.h
+++ b/packages/@unimodules/react-native-adapter/ios/UMReactNativeAdapter/UMModuleRegistryAdapter/UMModuleRegistryHolderReactModule.h
@@ -7,6 +7,6 @@
 @interface UMModuleRegistryHolderReactModule : NSObject <RCTBridgeModule>
 
 - (instancetype)initWithModuleRegistry:(UMModuleRegistry *)moduleRegistry;
-- (UMModuleRegistry *)moduleRegistry;
+- (UMModuleRegistry *)umModuleRegistry;
 
 @end

--- a/packages/@unimodules/react-native-adapter/ios/UMReactNativeAdapter/UMModuleRegistryAdapter/UMModuleRegistryHolderReactModule.m
+++ b/packages/@unimodules/react-native-adapter/ios/UMReactNativeAdapter/UMModuleRegistryAdapter/UMModuleRegistryHolderReactModule.m
@@ -4,7 +4,7 @@
 
 @interface UMModuleRegistryHolderReactModule ()
 
-@property (nonatomic, weak) UMModuleRegistry *moduleRegistry;
+@property (nonatomic, weak) UMModuleRegistry *umModuleRegistry;
 
 @end
 
@@ -13,14 +13,14 @@
 - (instancetype)initWithModuleRegistry:(UMModuleRegistry *)moduleRegistry
 {
   if (self = [super init]) {
-    _moduleRegistry = moduleRegistry;
+    _umModuleRegistry = moduleRegistry;
   }
   return self;
 }
 
-- (UMModuleRegistry *)moduleRegistry
+- (UMModuleRegistry *)umModuleRegistry
 {
-  return _moduleRegistry;
+  return _umModuleRegistry;
 }
 
 + (NSString *)moduleName {


### PR DESCRIPTION
# Why

RN introduced a moduleRegistry prop on native modules (https://github.com/facebook/react-native/commit/0ed81b28d3d786ea3b1cf0b932a008ef1f806ec4#diff-01fad993ff61aca9a1f2f07100c95eb1559d8b6440a00cb974a92810a6b5a2dc, https://github.com/facebook/react-native/commit/6f02942dc12fe95a153c2a4cc17ae9bcaa7b0154#diff-01fad993ff61aca9a1f2f07100c95eb1559d8b6440a00cb974a92810a6b5a2dc) so this conflicts with UM moduleRegistry.

# How

Rename moduleRegistry to umModuleRegistry where it conflicts.

# Test Plan

Tested in my app that uses unimodules with RN master
