### PR TITLE
[yarn-workspaces] Use junction symlinks on windows avoiding admin rights

### DIFF
--- a/packages/expo-yarn-workspaces/CHANGELOG.md
+++ b/packages/expo-yarn-workspaces/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Use junction symlinks on Windows to avoid admin privileges ([#11739](https://github.com/expo/expo/pull/11739) by [@byCedric](https://github.com/byCedric))
+
 ## 1.3.1 — 2021-01-08
 
 ### 🐛 Bug fixes

--- a/packages/expo-yarn-workspaces/bin/symlink-necessary-packages.js
+++ b/packages/expo-yarn-workspaces/bin/symlink-necessary-packages.js
@@ -84,7 +84,7 @@ function symlinkNecessaryPackage(projectPath, packageName) {
     debug(`Ensuring %s exists`, scopePath);
     mkdirp.sync(scopePath);
     debug(`Creating symlink from %s to %s`, path.join(scopePath, name), relativePackagePath);
-    fs.symlinkSync(relativePackagePath, path.join(scopePath, name));
+    fs.symlinkSync(relativePackagePath, path.join(scopePath, name), 'junction');
   } else {
     let relativePackagePath = path.relative(nodeModulesPath, workspacePackagePath);
 
@@ -95,7 +95,7 @@ function symlinkNecessaryPackage(projectPath, packageName) {
       path.join(nodeModulesPath, packageName),
       relativePackagePath
     );
-    fs.symlinkSync(relativePackagePath, path.join(nodeModulesPath, packageName));
+    fs.symlinkSync(relativePackagePath, path.join(nodeModulesPath, packageName), 'junction');
   }
 }
 


### PR DESCRIPTION
# Why

`epxo-yarn-workspaces` doesn't work that great on Windows. To create symbolic links, you have to start CMD/Powershell with admin privileges (which could be a security risk). This adds support for symlinks on Windows, _without_ admin rights.

# How

I did a small search how Yarn and NPM both handle symlinks. They both work fine on Windows, so "How Do They Do It"(tm)

- Yarn uses it's own `src/util/fs.js` file to handle most of the io-related actions. In here, [you can see the contents of the `symlink` function](https://github.com/yarnpkg/yarn/blob/master/src/util/fs.js#L679-L711). On Windows, they switch to junction-type symlinks.
- NPM uses it's own [`Arborist` datalayer abstraction](https://github.com/npm/cli/tree/7282329512a729d05c630583c52a085bc9ecc03b/node_modules/%40npmcli/arborist) to manage most of the io operations. Also here, [it uses junction-styled symlinks](https://github.com/npm/cli/blob/653769de359b8d24f0d17b8e7e426708f49cadb8/node_modules/%40npmcli/arborist/lib/arborist/reify.js#L444).

Although Yarn adds logic around relative vs absolute paths, I don't think it's necessary. NPM doesn't [because Node actually transforms the target path to absolute when `junction` links are created](https://nodejs.org/docs/latest-v14.x/api/fs.html#fs_fs_symlink_target_path_type_callback) (our source path is already absolute). This junction type is also ignored on non-Windows systems

<img width="1406" alt="Screenshot 2021-01-25 at 14 03 33" src="https://user-images.githubusercontent.com/1203991/105709544-26372700-5f16-11eb-82e3-ce2f31ac8386.png">

# What is it?

I only did a shallow search related to these types of symlink on Windows.

- This [SuperUser post shows the main differences](https://superuser.com/questions/343074/directory-junction-vs-directory-symbolic-link/1291446#1291446) between junction and normal symlinks.
- This [blogpost shows how it actually works on NTFS systems](https://www.2brightsparks.com/resources/articles/ntfs-hard-links-junctions-and-symbolic-links.html) compared to normal symlinks

TL;DR;
- Junctions are the soft-links on windows
- Are only able to link directories, _not files_
- Can point to different mounted drives, such as references between `C:\` and `D:\`
- Can point to non-existent folders (a solid con)
- Needs to be absolute linked, moving folders around breaks them (also solid con)

# Test Plan

Because not a lot of us have access to Windows machines, I used GH Actions to test the change. You can copy this approach or run it yourself.

- This [fork contains this exact change on `expo-yarn-workspaces@1.3.1`](https://github.com/bycedric/expo-yarn-winspaces)
- This [workflow run uses the non-forked `expo-yarn-workspaces`](https://github.com/byCedric/eas-monorepo-example/pull/7/checks?check_run_id=1758481949), and fails on Windows
- This [workflow run uses the forked `expo-yarn-winspaces`](https://github.com/byCedric/eas-monorepo-example/pull/6/checks?check_run_id=1757529331), and succeeds on Windows