### PR TITLE
[docs] link out to new forum tags

### DIFF
--- a/docs/components/DocumentationFooter.test.tsx
+++ b/docs/components/DocumentationFooter.test.tsx
@@ -12,10 +12,18 @@ test('displays default links', () => {
   expect(container).toHaveTextContent('Edit this page');
 });
 
+test('displays forums link with tag', () => {
+  const { container } = render(<DocumentationFooter asPath="/sdk/" title="test-title" />);
+
+  expect(container).toHaveTextContent(
+    'Get help from the community and ask questions about test-title'
+  );
+});
+
 test('displays issues link', () => {
   const { container } = render(<DocumentationFooter asPath="/sdk/" title="test-title" />);
 
-  expect(container).toHaveTextContent('View open issues for test-title');
+  expect(container).toHaveTextContent('View open bug reports for test-title');
 });
 
 test('displays source code link', () => {

--- a/docs/components/DocumentationFooter.tsx
+++ b/docs/components/DocumentationFooter.tsx
@@ -10,6 +10,7 @@ const STYLES_FOOTER = css`
 `;
 
 const STYLES_FOOTER_LINK = css`
+  font-size: 18px;
   display: block;
   text-decoration: none;
   margin-bottom: 12px;
@@ -39,8 +40,8 @@ function githubUrl(path: string) {
   return `https://github.com/expo/expo/edit/master/docs/pages${pathAsMarkdown}`;
 }
 
-// Add any page in the /sdk/ section that should not have an issues link to this
-const ISSUES_BLACKLIST = ['Overview'];
+// Add any page in the /sdk/ section that is not an actual Expo API
+const SDK_BLACKLIST = ['Overview'];
 
 type Props = {
   asPath: string;
@@ -53,42 +54,70 @@ export default class DocumentationFooter extends React.PureComponent<Props> {
   render() {
     return (
       <footer css={STYLES_FOOTER}>
-        <a css={STYLES_FOOTER_LINK} target="_blank" rel="noopener" href="https://forums.expo.io/">
-          Ask a question on the forums
-        </a>
-        {this.maybeRenderIssuesLink()}
-        {this.maybeRenderSourceCodeLink()}
-        {this.maybeRenderGithubUrl()}
+        <ul>
+          {this.renderForumsLink()}
+          {this.maybeRenderIssuesLink()}
+          {this.maybeRenderSourceCodeLink()}
+          {this.maybeRenderGithubUrl()}
+        </ul>
       </footer>
+    );
+  }
+
+  private renderForumsLink() {
+    if (!this.props.asPath.includes('/sdk/') || SDK_BLACKLIST.includes(this.props.title)) {
+      return (
+        <li>
+          <a css={STYLES_FOOTER_LINK} target="_blank" rel="noopener" href="https://forums.expo.io/">
+            Ask a question on the forums
+          </a>
+        </li>
+      );
+    }
+
+    return (
+      <li>
+        <a
+          css={STYLES_FOOTER_LINK}
+          target="_blank"
+          rel="noopener"
+          href={'https://forums.expo.io/tag/' + this.props.title}>
+          Get help from the community and ask questions about {this.props.title}
+        </a>
+      </li>
     );
   }
 
   private maybeRenderGithubUrl() {
     if (this.props.url) {
       return (
-        <a
-          css={STYLES_FOOTER_LINK}
-          target="_blank"
-          rel="noopener"
-          href={githubUrl(this.props.url.pathname)}>
-          Edit this page
-        </a>
+        <li>
+          <a
+            css={STYLES_FOOTER_LINK}
+            target="_blank"
+            rel="noopener"
+            href={githubUrl(this.props.url.pathname)}>
+            Edit this page
+          </a>
+        </li>
       );
     }
   }
 
   private maybeRenderIssuesLink = () => {
-    if (!this.props.asPath.includes('/sdk/') || ISSUES_BLACKLIST.includes(this.props.title)) {
+    if (!this.props.asPath.includes('/sdk/') || SDK_BLACKLIST.includes(this.props.title)) {
       return;
     }
 
     return (
-      <a
-        css={STYLES_FOOTER_LINK}
-        target="_blank"
-        href={`https://github.com/expo/expo/labels/${this.props.title}`}>
-        View open issues for {this.props.title}
-      </a>
+      <li>
+        <a
+          css={STYLES_FOOTER_LINK}
+          target="_blank"
+          href={`https://github.com/expo/expo/labels/${this.props.title}`}>
+          View open bug reports for {this.props.title}
+        </a>
+      </li>
     );
   };
 
@@ -98,9 +127,11 @@ export default class DocumentationFooter extends React.PureComponent<Props> {
     }
 
     return (
-      <a css={STYLES_FOOTER_LINK} target="_blank" href={`${this.props.sourceCodeUrl}`}>
-        View source code for {this.props.title}
-      </a>
+      <li>
+        <a css={STYLES_FOOTER_LINK} target="_blank" href={`${this.props.sourceCodeUrl}`}>
+          View source code for {this.props.title}
+        </a>
+      </li>
     );
   };
 }


### PR DESCRIPTION
# Why

Instead of just linking to the forums from API pages, let's link to all the existing forum posts with that API tagged, like [this](https://forums.expo.io/tag/Contacts)

I've also added a note to the forum topic template to include the relevant tag for your issue.


Side note- i feel like there's too many links at the bottom. We don't have to remove any right now, but it would be nice to know how often they're actually clicked, so we should add some analytics there

# How

## went from this: 
<img width="1792" alt="Screen Shot 2021-01-25 at 4 00 02 PM" src="https://user-images.githubusercontent.com/35579283/105766860-42dc5a80-5f28-11eb-8a3b-4d67b6c9d2f5.png">

## to this:
<img width="1792" alt="Screen Shot 2021-01-25 at 4 13 48 PM" src="https://user-images.githubusercontent.com/35579283/105766965-699a9100-5f28-11eb-9aac-cec497d97a3a.png">

## and if we like emojis, it could look like this:
<img width="710" alt="Screen Shot 2021-01-25 at 4 08 22 PM" src="https://user-images.githubusercontent.com/35579283/105766859-4243c400-5f28-11eb-8b25-5554681d2b77.png">

# Test Plan

added test
