### PR TITLE
Update EAS instructions for dev clients

### DIFF
--- a/docs/pages/clients/eas-build.md
+++ b/docs/pages/clients/eas-build.md
@@ -14,7 +14,7 @@ Once this is done, you will need to set the `Build Configuration` for your Devel
 
 ## Setting up EAS
 
-You can set up your project to use EAS by [following the instructions here](/build/walkthrough/#configure-your-project-for-eas-build)
+You can set up your project to use EAS by [following the instructions here](/build/setup/#3-configure-the-project)
 
 ## Modifying your EAS.json
 
@@ -30,7 +30,8 @@ Assuming you named your new XCode scheme `Project - Development Client`, edit yo
       },
       "development": {
         "workflow": "generic",
-        "gradleCommand": ":app:bundleDebug"
+        "distribution": "internal",
+        "gradleCommand": ":app:assembleDebug"
       }
     },
     "ios": {
@@ -40,6 +41,7 @@ Assuming you named your new XCode scheme `Project - Development Client`, edit yo
       },
       "development": {
         "workflow": "generic",
+        "distribution": "internal",
         "scheme": "Project - Development Client"
       }
     }
@@ -47,18 +49,24 @@ Assuming you named your new XCode scheme `Project - Development Client`, edit yo
 }
 ```
 
-## Running your first build
+## Generating your first build
 
 You can now generate a new build of your project from any commit through EAS.
 
-For iOS simulators:
+### For iOS simulators:
 
-<InstallSection packageName="expo-dev-launcher" cmd={["expo eas:build --profile development --platform android"]} hideBareInstructions />
+<InstallSection packageName="expo-dev-launcher" cmd={["eas build --profile development --platform ios"]} hideBareInstructions />
 
-For iOS devices:
+### For iOS devices:
 
-> ⚠️ **Coming Soon**
+Register any devices you would like to use your development client on to your ad hoc provisioning profile
+<InstallSection packageName="expo-dev-launcher" cmd={["eas device:create"]} hideBareInstructions />
 
-For Android:
+Generate the build signed with your ad hoc provisioning profile.
+<InstallSection packageName="expo-dev-launcher" cmd={["eas build --profile development --platform ios"]} hideBareInstructions />
 
-<InstallSection packageName="expo-dev-launcher" cmd={["expo eas:build --profile development --platform ios"]} hideBareInstructions />
+You will need to generate a new build to install successfully on any new builds added to your provisioning profile.  [You can find more guidance on distributing your app to your team here.](https://docs.expo.io/build/internal-distribution/)
+
+### For Android:
+
+<InstallSection packageName="expo-dev-launcher" cmd={["eas build --profile development --platform android"]} hideBareInstructions />

--- a/docs/pages/clients/troubleshooting.md
+++ b/docs/pages/clients/troubleshooting.md
@@ -2,6 +2,10 @@
 title: Troubleshooting
 ---
 
+### The --dev-client flag is not supported in expo-cli
+
+You will need to upgrade your expo-cli to version 4.0.16 or above to use your development client
+
 ### The keyboard shortcuts for the Dev Menu don't work reliably in my iOS simulator
 
-- Make sure you have `Send keyboard input to device` enabled for the simulator. This option can be found under `I/O` > `Input in the menu`.
+Make sure you have `Send keyboard input to device` enabled for the simulator. This option can be found under `I/O` > `Input in the menu`.


### PR DESCRIPTION

The linked EAS instructions have moved so the current page has a dead link.
Also updates instructions now that internal distribution is supported and addresses a couple of inaccuracies reported by testers.

# Test Plan

Ran with `yarn dev`