### PR TITLE
[file-system][ios] Fix copying movies from assets not working

### DIFF
--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed copying movies from assets not working on iOS. ([#11749](https://github.com/expo/expo/pull/11749) by [@lukmccall](https://github.com/lukmccall))
+
 ## 10.0.0 — 2021-01-15
 
 ### ⚠️ Notices

--- a/packages/expo-file-system/ios/EXFileSystem/EXFileSystemAssetLibraryHandler.m
+++ b/packages/expo-file-system/ios/EXFileSystem/EXFileSystemAssetLibraryHandler.m
@@ -66,15 +66,27 @@
 
   if (fetchResult.count > 0) {
     PHAsset *asset = fetchResult[0];
-    [[PHImageManager defaultManager] requestImageDataForAsset:asset options:nil resultHandler:^(NSData * _Nullable imageData, NSString * _Nullable dataUTI, UIImageOrientation orientation, NSDictionary * _Nullable info) {
-      if ([imageData writeToFile:toPath atomically:YES]) {
-        resolve(nil);
-      } else {
-        reject(@"E_FILE_NOT_COPIED",
-               [NSString stringWithFormat:@"File '%@' could not be copied to '%@'.", from, to],
-               error);
-      }
-    }];
+    if (asset.mediaType == PHAssetMediaTypeVideo) {
+      [[PHImageManager defaultManager] requestAVAssetForVideo:asset options:nil resultHandler:^(AVAsset *asset, AVAudioMix *audioMix, NSDictionary *info) {
+        if (![asset isKindOfClass:[AVURLAsset class]]) {
+          reject(@"ERR_INCORRECT_ASSET_TYPE",
+                 [NSString stringWithFormat:@"File '%@' has incorrect asset type.", from],
+                 nil);
+          return;
+        }
+       
+        AVURLAsset* urlAsset = (AVURLAsset*)asset;
+        NSNumber *size;
+        [urlAsset.URL getResourceValue:&size forKey:NSURLFileSizeKey error:nil];
+        NSData *data = [NSData dataWithContentsOfURL:urlAsset.URL];
+         
+        [EXFileSystemAssetLibraryHandler copyData:data toPath:toPath resolver:resolve rejecter:reject];
+      }];
+    } else {
+      [[PHImageManager defaultManager] requestImageDataForAsset:asset options:nil resultHandler:^(NSData * _Nullable imageData, NSString * _Nullable dataUTI, UIImageOrientation orientation, NSDictionary * _Nullable info) {
+        [EXFileSystemAssetLibraryHandler copyData:imageData toPath:toPath resolver:resolve rejecter:reject];
+      }];
+    }
   } else {
     reject(@"E_FILE_NOT_COPIED",
            [NSString stringWithFormat:@"File '%@' could not be found.", from],
@@ -109,6 +121,21 @@
                                       code:NSURLErrorUnsupportedURL
                                   userInfo:@{NSLocalizedDescriptionKey: description}];
   return nil;
+}
+
+
++ (void)copyData:(NSData *)data
+          toPath:(NSString *)path
+        resolver:(UMPromiseResolveBlock)resolve
+        rejecter:(UMPromiseRejectBlock)reject
+{
+  if ([data writeToFile:path atomically:YES]) {
+    resolve(nil);
+  } else {
+    reject(@"E_FILE_NOT_COPIED",
+           [NSString stringWithFormat:@"File could not be copied to '%@'.", path],
+           nil);
+  }
 }
 
 @end


### PR DESCRIPTION
# Why

Fixes copying movies from assets not working.

# How

When we dealing with videos, we need to change the method that gets data from an asset. Otherwise, iOS will return data of one frame. 

# Test Plan

- https://snack.expo.io/@charliecruzan/medialibraryiosbug ✅
- test-suite ✅

# Changelog 

- Fixed copying movies from assets not working on iOS