### PR TITLE
Fix GoogleAuthRequestConfig.shouldAutoExchangeCode type

### DIFF
--- a/docs/pages/versions/unversioned/sdk/auth-session.md
+++ b/docs/pages/versions/unversioned/sdk/auth-session.md
@@ -517,7 +517,7 @@ An extension of the [`AuthRequestConfig`][#authrequestconfig] for use with the b
 | webClientId            | `?string`  | Web client ID for use in the browser (web apps).                                      |
 | iosClientId            | `?string`  | iOS native client ID for use in standalone, bare-workflow, and custom clients.        |
 | androidClientId        | `?string`  | Android native client ID for use in standalone, bare-workflow, and custom clients.    |
-| shouldAutoExchangeCode | `?string`  | Should the hook automatically exchange the response code for an authentication token. |
+| shouldAutoExchangeCode | `?boolean` | Should the hook automatically exchange the response code for an authentication token. |
 
 ## Providers
 


### PR DESCRIPTION
Correct shouldAutoExchange config type, was ?string, is actually ?boolean

# Why

The documentation is wrong.

# How

Compared with the Google.d.ts provider source and confirmed correct type

# Test Plan

Review the GoogleAuthRequestConfig.shouldAutoExchangeCode type in the code source file and confirm documentation is now correct.