### PR TITLE
[jest-expo] Add scheme to mocked manifest for expo-linking

### DIFF
--- a/packages/jest-expo/src/preset/createMockConstants.js
+++ b/packages/jest-expo/src/preset/createMockConstants.js
@@ -30,6 +30,7 @@ module.exports = function createMockConstants() {
       extra: expoConfig.extra,
       hostUri: mockHostUri,
       sdkVersion: mockSdkVersion,
+      scheme: expoConfig.scheme,
     },
   };
 };


### PR DESCRIPTION
# Why

Fixes #11754

See [this comment for an explanation](https://github.com/expo/expo/issues/11754#issuecomment-768322687).

# How

- Added `scheme` to mocked manifest, if it's defined in the original manifest

# Test Plan

- `$ expo init TestProject --template expo-template-tabs`
- `$ expo install expo-linking`
- Add lines below to `components/StyledText.tsx`
  - `import * as Linking from 'expo-linking';`
  - `Linking.createURL('boep');`
- `$ yarn test`, which fails because of missing `scheme`

**To fix it**
- Manually add this fix to `node_modules/jest-expo/src/preset/createMockConstants.js`
- `$ yarn test`, which succeeds because `scheme` is included in the mocked schema