### PR TITLE
[home] Add WebBrowserPackage to list of home packages

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/experience/HomeActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/HomeActivity.java
@@ -39,6 +39,7 @@ import expo.modules.splashscreen.singletons.SplashScreen;
 import expo.modules.splashscreen.SplashScreenImageResizeMode;
 import expo.modules.splashscreen.SplashScreenPackage;
 import expo.modules.taskManager.TaskManagerPackage;
+import expo.modules.webbrowser.WebBrowserPackage;
 import host.exp.exponent.Constants;
 import host.exp.exponent.ExponentManifest;
 import host.exp.exponent.RNObject;
@@ -164,7 +165,8 @@ public class HomeActivity extends BaseExperienceActivity {
       new NotificationsPackage(), // home doesn't use notifications, but we want the singleton modules created
       new TaskManagerPackage(), // load expo-task-manager to restore tasks once the client is opened
       new DevicePackage(),
-      new SplashScreenPackage()
+      new SplashScreenPackage(),
+      new WebBrowserPackage()
     );
   }
 }


### PR DESCRIPTION
# Why

The empty states of profile and snacks have links that pop an `expo-web-browser`, but currently are broken since this package isn't included in the home app. This PR fixes that.

# How

Add package.

# Test Plan

Run app on simulator, log in to empty account, click one of the links, see that it works.

![screen (1)](https://user-images.githubusercontent.com/189568/106030413-04a77e00-6083-11eb-8d65-89fa011c3fe5.png)

