### PR TITLE
add sentry-testkit description to "testing sentry" section

### DIFF
--- a/docs/pages/guides/using-sentry.md
+++ b/docs/pages/guides/using-sentry.md
@@ -174,9 +174,37 @@ Sentry.init({
 });
 ```
 
-### Testing Sentry
+### Testing Sentry and Using [`sentry-testkit`](https://wix.github.io/sentry-testkit)
 
-If you're using `Jest`, make sure to add `@sentry/.*` and `sentry-expo` to your `transformIgnorePatterns`.
+When building tests for your application, you want to assert that the right flow-tracking or error is being sent to Sentry, but without really sending it to Sentry servers. This way you won't swamp Sentry with false reports during test running and other CI operations.
+
+[`sentry-testkit`](https://wix.github.io/sentry-testkit) enables Sentry to work natively in your application, and by overriding the default Sentry transport mechanism, the report is not really sent but rather logged locally into memory. In this way, the logged reports can be fetched later for your own usage, verification, or any other use you may have in your local developing/testing environment.
+
+**Installation**
+
+`npm install sentry-testkit --save-dev` or `yarn add sentry-testkit --dev`
+
+**Using in tests**
+```javascript
+const sentryTestkit = require('sentry-testkit')
+
+const {testkit, sentryTransport} = sentryTestkit()
+
+// initialize your Sentry instance with sentryTransport
+Sentry.init({
+    dsn: 'YOUR DSN HERE',
+    transport: sentryTransport,
+    //... other configurations
+})
+
+// then run any scenario that should call Sentry.catchException(...)
+
+expect(testkit.reports()).toHaveLength(1)
+const report = testkit.reports()[0]
+expect(report).toHaveProperty(...)
+```
+
+> If you're using `Jest`, make sure to add `@sentry/.*` and `sentry-expo` to your `transformIgnorePatterns`.
 
 ## Error reporting semantics
 

--- a/docs/pages/guides/using-sentry.md
+++ b/docs/pages/guides/using-sentry.md
@@ -174,7 +174,7 @@ Sentry.init({
 });
 ```
 
-### Testing Sentry and Using [`sentry-testkit`](https://wix.github.io/sentry-testkit)
+### Testing Sentry
 
 When building tests for your application, you want to assert that the right flow-tracking or error is being sent to Sentry, but without really sending it to Sentry servers. This way you won't swamp Sentry with false reports during test running and other CI operations.
 

--- a/docs/pages/guides/using-sentry.md
+++ b/docs/pages/guides/using-sentry.md
@@ -180,29 +180,7 @@ When building tests for your application, you want to assert that the right flow
 
 [`sentry-testkit`](https://wix.github.io/sentry-testkit) enables Sentry to work natively in your application, and by overriding the default Sentry transport mechanism, the report is not really sent but rather logged locally into memory. In this way, the logged reports can be fetched later for your own usage, verification, or any other use you may have in your local developing/testing environment.
 
-**Installation**
-
-`npm install sentry-testkit --save-dev` or `yarn add sentry-testkit --dev`
-
-**Using in tests**
-```javascript
-const sentryTestkit = require('sentry-testkit')
-
-const {testkit, sentryTransport} = sentryTestkit()
-
-// initialize your Sentry instance with sentryTransport
-Sentry.init({
-    dsn: 'YOUR DSN HERE',
-    transport: sentryTransport,
-    //... other configurations
-})
-
-// then run any scenario that should call Sentry.catchException(...)
-
-expect(testkit.reports()).toHaveLength(1)
-const report = testkit.reports()[0]
-expect(report).toHaveProperty(...)
-```
+See how to get started with `sentry-testkit` in their [documentation site here](https://wix.github.io/sentry-testkit/)
 
 > If you're using `Jest`, make sure to add `@sentry/.*` and `sentry-expo` to your `transformIgnorePatterns`.
 


### PR DESCRIPTION
# Why

In the following page of [Expo and Sentry Integration](https://docs.expo.io/guides/using-sentry/#testing-sentry) there's a section used to describe running tests with Sentry, but its pretty empty.
By adding a few words about [`sentry-testkit`](https://github.com/wix/sentry-testkit) it would be useful to provide a broader range of options how running tests along with Sentry or even test Sentry reports specifically. 