### PR TITLE
[dev] Add config plugins for `expo-dev-menu` and `expo-dev-launcher`

### DIFF
--- a/.github/workflows/development-client.yml
+++ b/.github/workflows/development-client.yml
@@ -1,0 +1,99 @@
+name: Development Client
+
+on:
+  workflow_dispatch: {}
+  pull_request:
+    branches: [master]
+    paths:
+      - .github/workflows/development-client.yml
+      - packages/expo-dev-*/**
+
+jobs:
+  android:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+        with:
+          submodules: false
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v1
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - run: yarn install --frozen-lockfile
+      - uses: actions/cache@v1
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('android/*.gradle*') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+      - uses: actions/cache@v2
+        id: cache-android-ndk
+        with:
+          path: /usr/local/lib/android/sdk/ndk/19.2.5345600/
+          key: ${{ runner.os }}-ndk-19.2.5345600
+          restore-keys: |
+            ${{ runner.os }}-ndk-
+      - name: Install NDK
+        if: steps.cache-android-ndk.outputs.cache-hit != 'true'
+        run: |
+          sudo $ANDROID_HOME/tools/bin/sdkmanager --install "ndk;19.2.5345600"
+      - run: yarn global add expo-cli
+      - run: echo "$(yarn global bin)" >> $GITHUB_PATH
+      - name: Init new expo app
+        working-directory: ../
+        run: expo-cli init development-client-android-test --name development-client-android-test --yes
+      - name: Add dependencies
+        working-directory: ../development-client-android-test
+        run: yarn add file:../expo/packages/expo-dev-menu file:../expo/packages/expo-dev-menu-interface file:../expo/packages/expo-dev-launcher
+      - name: Setup app.config.json
+        working-directory: ../development-client-android-test
+        run: echo "{\"name\":\"development-client-android-test\",\"plugins\":[\"expo-dev-menu\",\"expo-dev-launcher\"],\"android\":{\"package\":\"com.devclient.test\"},\"ios\":{\"bundleIdentifier\":\"com.devclient.test\"}}" > app.config.json
+      - name: Eject
+        working-directory: ../development-client-android-test
+        run: expo-cli eject
+      - name: Build debug
+        env:
+          ANDROID_NDK_HOME: /usr/local/lib/android/sdk/ndk/19.2.5345600/
+        working-directory: ../development-client-android-test/android
+        run: ./gradlew assembleDebug
+
+  ios:
+    runs-on: macos-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+        with:
+          submodules: false
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v1
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - run: yarn install --frozen-lockfile
+      - run: yarn global add expo-cli
+      - run: echo "$(yarn global bin)" >> $GITHUB_PATH
+      - name: Init new expo app
+        working-directory: ../
+        run: expo-cli init development-client-ios-test --name development-client-ios-test --yes
+      - name: Add dependencies
+        working-directory: ../development-client-ios-test
+        run: yarn add file:../expo/packages/expo-dev-menu file:../expo/packages/expo-dev-menu-interface file:../expo/packages/expo-dev-launcher
+      - name: Setup app.config.json
+        working-directory: ../development-client-ios-test
+        run: echo "{\"name\":\"development-client-ios-test\",\"plugins\":[\"expo-dev-menu\",\"expo-dev-launcher\"],\"android\":{\"package\":\"com.devclient.test\"},\"ios\":{\"bundleIdentifier\":\"com.devclient.test\"}}" > app.config.json
+      - name: Eject
+        working-directory: ../development-client-ios-test
+        run: expo-cli eject
+      - name: Build debug
+        working-directory: ../development-client-ios-test
+        run: xcodebuild -workspace ios/developmentclientiostest.xcworkspace -scheme developmentclientiostest -configuration debug -sdk iphonesimulator -arch x86_64

--- a/packages/expo-dev-launcher/app.plugin.js
+++ b/packages/expo-dev-launcher/app.plugin.js
@@ -1,0 +1,1 @@
+module.exports = require('./plugin/build/withDevLauncher');

--- a/packages/expo-dev-launcher/plugin/build/withDevLauncher.d.ts
+++ b/packages/expo-dev-launcher/plugin/build/withDevLauncher.d.ts
@@ -1,0 +1,3 @@
+import { ExpoConfig } from '@expo/config-types';
+declare const withDevLauncher: (config: ExpoConfig) => ExpoConfig;
+export default withDevLauncher;

--- a/packages/expo-dev-launcher/plugin/build/withDevLauncher.js
+++ b/packages/expo-dev-launcher/plugin/build/withDevLauncher.js
@@ -1,0 +1,210 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const config_plugins_1 = require("@expo/config-plugins");
+const fs_1 = __importDefault(require("fs"));
+const path_1 = __importDefault(require("path"));
+const DEV_LAUNCHER_ANDROID_IMPORT = 'expo.modules.devlauncher.DevLauncherController';
+const DEV_LAUNCHER_ON_NEW_INTENT = `
+  @Override
+  public void onNewIntent(Intent intent) {
+      if (DevLauncherController.tryToHandleIntent(this, intent)) {
+         return;
+      }
+      super.onNewIntent(intent);
+  }
+`;
+const DEV_LAUNCHER_WRAPPED_ACTIVITY_DELEGATE = `DevLauncherController.wrapReactActivityDelegate(this, () -> $1);`;
+const DEV_LAUNCHER_ANDROID_INIT = 'DevLauncherController.initialize(this, getReactNativeHost());';
+const DEV_LAUNCHER_POD_IMPORT = "pod 'expo-dev-menu', path: '../node_modules/expo-dev-menu', :configurations => :debug";
+const DEV_LAUNCHER_APP_DELEGATE_SOURCE_FOR_URL = `  #if defined(EX_DEV_LAUNCHER_ENABLED)
+return [[EXDevLauncherController sharedInstance] sourceUrl];
+#else
+return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index" fallbackResource:nil];
+#endif`;
+const DEV_LAUNCHER_APP_DELEGATE_ON_DEEP_LINK = `#if defined(EX_DEV_LAUNCHER_ENABLED)
+if ([EXDevLauncherController.sharedInstance onDeepLink:url options:options]) {
+return true;
+}
+#endif
+return [RCTLinkingManager application:application openURL:url options:options];`;
+const DEV_LAUNCHER_APP_DELEGATE_IOS_IMPORT = `
+#if defined(EX_DEV_LAUNCHER_ENABLED)
+#include <EXDevLauncher/EXDevLauncherController.h>
+#endif`;
+const DEV_LAUNCHER_APP_DELEGATE_CONTROLLER_DELEGATE = `
+#if defined(EX_DEV_LAUNCHER_ENABLED)
+@implementation AppDelegate (EXDevLauncherControllerDelegate)
+
+- (void)devLauncherController:(EXDevLauncherController *)developmentClientController
+      didStartWithSuccess:(BOOL)success
+{
+developmentClientController.appBridge = [self initializeReactNativeApp];
+EXSplashScreenService *splashScreenService = (EXSplashScreenService *)[UMModuleRegistryProvider getSingletonModuleForClass:[EXSplashScreenService class]];
+[splashScreenService showSplashScreenFor:self.window.rootViewController];
+}
+
+@end
+#endif
+`;
+const DEV_LAUNCHER_APP_DELEGATE_INIT = `#if defined(EX_DEV_LAUNCHER_ENABLED)
+      EXDevLauncherController *contoller = [EXDevLauncherController sharedInstance];
+      [contoller startWithWindow:self.window delegate:self launchOptions:launchOptions];
+    #else
+      [self initializeReactNativeApp];
+    #endif`;
+const DEV_LAUNCHER_APP_DELEGATE_BRIDGE = `#if defined(EX_DEV_LAUNCHER_ENABLED)
+  NSDictionary *launchOptions = [EXDevLauncherController.sharedInstance getLaunchOptions];
+#else
+  NSDictionary *launchOptions = self.launchOptions;
+#endif
+
+  RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:launchOptions];`;
+async function readFileAsync(path) {
+    return fs_1.default.promises.readFile(path, 'utf8');
+}
+async function saveFileAsync(path, content) {
+    return fs_1.default.promises.writeFile(path, content, 'utf8');
+}
+function addLines(content, find, offset, toAdd) {
+    const lines = content.split('\n');
+    let lineIndex = lines.findIndex(line => line.match(find));
+    for (const newLine of toAdd) {
+        if (!content.includes(newLine)) {
+            lines.splice(lineIndex + offset, 0, newLine);
+            lineIndex++;
+        }
+    }
+    return lines.join('\n');
+}
+function addJavaImports(javaSource, javaImports) {
+    const lines = javaSource.split('\n');
+    const lineIndexWithPackageDeclaration = lines.findIndex(line => line.match(/^package .*;$/));
+    for (const javaImport of javaImports) {
+        if (!javaSource.includes(javaImport)) {
+            const importStatement = `import ${javaImport};`;
+            lines.splice(lineIndexWithPackageDeclaration + 1, 0, importStatement);
+        }
+    }
+    return lines.join('\n');
+}
+async function editMainApplication(config, action) {
+    const mainApplicationPath = path_1.default.join(config.modRequest.platformProjectRoot, 'app', 'src', 'main', 'java', ...config.android.package.split('.'), 'MainApplication.java');
+    try {
+        const mainApplication = action(await readFileAsync(mainApplicationPath));
+        return await saveFileAsync(mainApplicationPath, mainApplication);
+    }
+    catch (e) {
+        config_plugins_1.WarningAggregator.addWarningIOS('ios-devMenu', `Couldn't modified MainApplication.java - ${e}.`);
+    }
+}
+async function editPodfile(config, action) {
+    const podfilePath = path_1.default.join(config.modRequest.platformProjectRoot, 'Podfile');
+    try {
+        const podfile = action(await readFileAsync(podfilePath));
+        return await saveFileAsync(podfilePath, podfile);
+    }
+    catch (e) {
+        config_plugins_1.WarningAggregator.addWarningIOS('ios-devMenu', `Couldn't modified AppDelegate.m - ${e}.`);
+    }
+}
+async function editAppDelegate(config, action) {
+    const appDelegatePath = path_1.default.join(config.modRequest.platformProjectRoot, config.modRequest.projectName, 'AppDelegate.m');
+    try {
+        const appDelegate = action(await readFileAsync(appDelegatePath));
+        return await saveFileAsync(appDelegatePath, appDelegate);
+    }
+    catch (e) {
+        config_plugins_1.WarningAggregator.addWarningIOS('ios-devMenu', `Couldn't modified AppDelegate.m - ${e}.`);
+    }
+}
+const withDevLauncherApplication = config => {
+    return config_plugins_1.withDangerousMod(config, [
+        'android',
+        async (config) => {
+            await editMainApplication(config, mainApplication => {
+                mainApplication = addJavaImports(mainApplication, [DEV_LAUNCHER_ANDROID_IMPORT]);
+                mainApplication = addLines(mainApplication, 'super.onCreate()', 1, [
+                    `    ${DEV_LAUNCHER_ANDROID_INIT}`,
+                ]);
+                return mainApplication;
+            });
+            return config;
+        },
+    ]);
+};
+const withDevLauncherActivity = config => {
+    return config_plugins_1.withMainActivity(config, config => {
+        if (config.modResults.language === 'java') {
+            let content = addJavaImports(config.modResults.contents, [DEV_LAUNCHER_ANDROID_IMPORT]);
+            if (!content.includes(DEV_LAUNCHER_ON_NEW_INTENT)) {
+                const lines = content.split('\n');
+                const onCreateIndex = lines.findIndex(line => line.includes('public class MainActivity'));
+                lines.splice(onCreateIndex + 1, 0, DEV_LAUNCHER_ON_NEW_INTENT);
+                content = lines.join('\n');
+            }
+            if (!content.includes('DevLauncherController.wrapReactActivityDelegate')) {
+                content = content.replace(/(new ReactActivityDelegate(.*|\s)*});$/m, DEV_LAUNCHER_WRAPPED_ACTIVITY_DELEGATE);
+            }
+            config.modResults.contents = content;
+        }
+        else {
+            config_plugins_1.WarningAggregator.addWarningAndroid('android-devLauncher', `Cannot automatically configure MainActivity if it's not java`);
+        }
+        return config;
+    });
+};
+const withDevLauncherPodfile = config => {
+    return config_plugins_1.withDangerousMod(config, [
+        'ios',
+        async (config) => {
+            await editPodfile(config, podfile => {
+                podfile = podfile.replace("platform :ios, '10.0'", "platform :ios, '11.0'");
+                podfile = addLines(podfile, 'use_react_native', 0, [`  ${DEV_LAUNCHER_POD_IMPORT}`]);
+                return podfile;
+            });
+            return config;
+        },
+    ]);
+};
+const withDevLauncherAppDelegate = config => {
+    return config_plugins_1.withDangerousMod(config, [
+        'ios',
+        async (config) => {
+            await editAppDelegate(config, appDelegate => {
+                if (!appDelegate.includes(DEV_LAUNCHER_APP_DELEGATE_IOS_IMPORT)) {
+                    const lines = appDelegate.split('\n');
+                    lines.splice(1, 0, DEV_LAUNCHER_APP_DELEGATE_IOS_IMPORT);
+                    appDelegate = lines.join('\n');
+                }
+                if (!appDelegate.includes(DEV_LAUNCHER_APP_DELEGATE_INIT)) {
+                    appDelegate = appDelegate.replace(/(didFinishLaunchingWithOptions([^}])*)\[self initializeReactNativeApp\];(([^}])*})/, `$1${DEV_LAUNCHER_APP_DELEGATE_INIT}$3`);
+                }
+                if (!appDelegate.includes(DEV_LAUNCHER_APP_DELEGATE_BRIDGE)) {
+                    appDelegate = appDelegate.replace('RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:self.launchOptions];', DEV_LAUNCHER_APP_DELEGATE_BRIDGE);
+                }
+                if (!appDelegate.includes(DEV_LAUNCHER_APP_DELEGATE_SOURCE_FOR_URL)) {
+                    appDelegate = appDelegate.replace('return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index" fallbackResource:nil];', DEV_LAUNCHER_APP_DELEGATE_SOURCE_FOR_URL);
+                }
+                if (!appDelegate.includes(DEV_LAUNCHER_APP_DELEGATE_ON_DEEP_LINK)) {
+                    appDelegate = appDelegate.replace('return [RCTLinkingManager application:application openURL:url options:options];', DEV_LAUNCHER_APP_DELEGATE_ON_DEEP_LINK);
+                }
+                if (!appDelegate.includes(DEV_LAUNCHER_APP_DELEGATE_CONTROLLER_DELEGATE)) {
+                    appDelegate += DEV_LAUNCHER_APP_DELEGATE_CONTROLLER_DELEGATE;
+                }
+                return appDelegate;
+            });
+            return config;
+        },
+    ]);
+};
+const withDevLauncher = (config) => {
+    config = withDevLauncherActivity(config);
+    config = withDevLauncherApplication(config);
+    config = withDevLauncherPodfile(config);
+    config = withDevLauncherAppDelegate(config);
+    return config;
+};
+exports.default = withDevLauncher;

--- a/packages/expo-dev-launcher/plugin/build/withDevLauncher.js
+++ b/packages/expo-dev-launcher/plugin/build/withDevLauncher.js
@@ -138,7 +138,10 @@ const withDevLauncherApplication = config => {
 const withDevLauncherActivity = config => {
     return config_plugins_1.withMainActivity(config, config => {
         if (config.modResults.language === 'java') {
-            let content = addJavaImports(config.modResults.contents, [DEV_LAUNCHER_ANDROID_IMPORT]);
+            let content = addJavaImports(config.modResults.contents, [
+                DEV_LAUNCHER_ANDROID_IMPORT,
+                'android.content.Intent',
+            ]);
             if (!content.includes(DEV_LAUNCHER_ON_NEW_INTENT)) {
                 const lines = content.split('\n');
                 const onCreateIndex = lines.findIndex(line => line.includes('public class MainActivity'));

--- a/packages/expo-dev-launcher/plugin/jest.config.js
+++ b/packages/expo-dev-launcher/plugin/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = require('expo-module-scripts/jest-preset-plugin');

--- a/packages/expo-dev-launcher/plugin/src/withDevLauncher.ts
+++ b/packages/expo-dev-launcher/plugin/src/withDevLauncher.ts
@@ -1,0 +1,288 @@
+import {
+  ConfigPlugin,
+  withDangerousMod,
+  withMainActivity,
+  WarningAggregator,
+  ExportedConfigWithProps,
+} from '@expo/config-plugins';
+import { ExpoConfig } from '@expo/config-types';
+import fs from 'fs';
+import path from 'path';
+
+const DEV_LAUNCHER_ANDROID_IMPORT = 'expo.modules.devlauncher.DevLauncherController';
+const DEV_LAUNCHER_ON_NEW_INTENT = `
+  @Override
+  public void onNewIntent(Intent intent) {
+      if (DevLauncherController.tryToHandleIntent(this, intent)) {
+         return;
+      }
+      super.onNewIntent(intent);
+  }
+`;
+const DEV_LAUNCHER_WRAPPED_ACTIVITY_DELEGATE = `DevLauncherController.wrapReactActivityDelegate(this, () -> $1);`;
+const DEV_LAUNCHER_ANDROID_INIT = 'DevLauncherController.initialize(this, getReactNativeHost());';
+
+const DEV_LAUNCHER_POD_IMPORT =
+  "pod 'expo-dev-menu', path: '../node_modules/expo-dev-menu', :configurations => :debug";
+const DEV_LAUNCHER_APP_DELEGATE_SOURCE_FOR_URL = `  #if defined(EX_DEV_LAUNCHER_ENABLED)
+return [[EXDevLauncherController sharedInstance] sourceUrl];
+#else
+return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index" fallbackResource:nil];
+#endif`;
+const DEV_LAUNCHER_APP_DELEGATE_ON_DEEP_LINK = `#if defined(EX_DEV_LAUNCHER_ENABLED)
+if ([EXDevLauncherController.sharedInstance onDeepLink:url options:options]) {
+return true;
+}
+#endif
+return [RCTLinkingManager application:application openURL:url options:options];`;
+const DEV_LAUNCHER_APP_DELEGATE_IOS_IMPORT = `
+#if defined(EX_DEV_LAUNCHER_ENABLED)
+#include <EXDevLauncher/EXDevLauncherController.h>
+#endif`;
+const DEV_LAUNCHER_APP_DELEGATE_CONTROLLER_DELEGATE = `
+#if defined(EX_DEV_LAUNCHER_ENABLED)
+@implementation AppDelegate (EXDevLauncherControllerDelegate)
+
+- (void)devLauncherController:(EXDevLauncherController *)developmentClientController
+      didStartWithSuccess:(BOOL)success
+{
+developmentClientController.appBridge = [self initializeReactNativeApp];
+EXSplashScreenService *splashScreenService = (EXSplashScreenService *)[UMModuleRegistryProvider getSingletonModuleForClass:[EXSplashScreenService class]];
+[splashScreenService showSplashScreenFor:self.window.rootViewController];
+}
+
+@end
+#endif
+`;
+const DEV_LAUNCHER_APP_DELEGATE_INIT = `#if defined(EX_DEV_LAUNCHER_ENABLED)
+      EXDevLauncherController *contoller = [EXDevLauncherController sharedInstance];
+      [contoller startWithWindow:self.window delegate:self launchOptions:launchOptions];
+    #else
+      [self initializeReactNativeApp];
+    #endif`;
+
+const DEV_LAUNCHER_APP_DELEGATE_BRIDGE = `#if defined(EX_DEV_LAUNCHER_ENABLED)
+  NSDictionary *launchOptions = [EXDevLauncherController.sharedInstance getLaunchOptions];
+#else
+  NSDictionary *launchOptions = self.launchOptions;
+#endif
+
+  RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:launchOptions];`;
+
+async function readFileAsync(path: string): Promise<string> {
+  return fs.promises.readFile(path, 'utf8');
+}
+
+async function saveFileAsync(path: string, content: string): Promise<void> {
+  return fs.promises.writeFile(path, content, 'utf8');
+}
+
+function addLines(content: string, find: string | RegExp, offset: number, toAdd: string[]) {
+  const lines = content.split('\n');
+
+  let lineIndex = lines.findIndex(line => line.match(find));
+
+  for (const newLine of toAdd) {
+    if (!content.includes(newLine)) {
+      lines.splice(lineIndex + offset, 0, newLine);
+      lineIndex++;
+    }
+  }
+
+  return lines.join('\n');
+}
+
+function addJavaImports(javaSource: string, javaImports: string[]): string {
+  const lines = javaSource.split('\n');
+  const lineIndexWithPackageDeclaration = lines.findIndex(line => line.match(/^package .*;$/));
+  for (const javaImport of javaImports) {
+    if (!javaSource.includes(javaImport)) {
+      const importStatement = `import ${javaImport};`;
+      lines.splice(lineIndexWithPackageDeclaration + 1, 0, importStatement);
+    }
+  }
+  return lines.join('\n');
+}
+
+async function editMainApplication(
+  config: ExportedConfigWithProps,
+  action: (mainApplication: string) => string
+): Promise<void> {
+  const mainApplicationPath = path.join(
+    config.modRequest.platformProjectRoot,
+    'app',
+    'src',
+    'main',
+    'java',
+    ...config.android!.package!.split('.'),
+    'MainApplication.java'
+  );
+
+  try {
+    const mainApplication = action(await readFileAsync(mainApplicationPath));
+    return await saveFileAsync(mainApplicationPath, mainApplication);
+  } catch (e) {
+    WarningAggregator.addWarningIOS(
+      'ios-devMenu',
+      `Couldn't modified MainApplication.java - ${e}.`
+    );
+  }
+}
+
+async function editPodfile(config: ExportedConfigWithProps, action: (podfile: string) => string) {
+  const podfilePath = path.join(config.modRequest.platformProjectRoot, 'Podfile');
+  try {
+    const podfile = action(await readFileAsync(podfilePath));
+
+    return await saveFileAsync(podfilePath, podfile);
+  } catch (e) {
+    WarningAggregator.addWarningIOS('ios-devMenu', `Couldn't modified AppDelegate.m - ${e}.`);
+  }
+}
+
+async function editAppDelegate(
+  config: ExportedConfigWithProps,
+  action: (appDelegate: string) => string
+) {
+  const appDelegatePath = path.join(
+    config.modRequest.platformProjectRoot,
+    config.modRequest.projectName!,
+    'AppDelegate.m'
+  );
+
+  try {
+    const appDelegate = action(await readFileAsync(appDelegatePath));
+    return await saveFileAsync(appDelegatePath, appDelegate);
+  } catch (e) {
+    WarningAggregator.addWarningIOS('ios-devMenu', `Couldn't modified AppDelegate.m - ${e}.`);
+  }
+}
+
+const withDevLauncherApplication: ConfigPlugin = config => {
+  return withDangerousMod(config, [
+    'android',
+    async config => {
+      await editMainApplication(config, mainApplication => {
+        mainApplication = addJavaImports(mainApplication, [DEV_LAUNCHER_ANDROID_IMPORT]);
+
+        mainApplication = addLines(mainApplication, 'super.onCreate()', 1, [
+          `    ${DEV_LAUNCHER_ANDROID_INIT}`,
+        ]);
+
+        return mainApplication;
+      });
+      return config;
+    },
+  ]);
+};
+
+const withDevLauncherActivity: ConfigPlugin = config => {
+  return withMainActivity(config, config => {
+    if (config.modResults.language === 'java') {
+      let content = addJavaImports(config.modResults.contents, [
+        DEV_LAUNCHER_ANDROID_IMPORT,
+        'android.content.Intent',
+      ]);
+
+      if (!content.includes(DEV_LAUNCHER_ON_NEW_INTENT)) {
+        const lines = content.split('\n');
+        const onCreateIndex = lines.findIndex(line => line.includes('public class MainActivity'));
+
+        lines.splice(onCreateIndex + 1, 0, DEV_LAUNCHER_ON_NEW_INTENT);
+
+        content = lines.join('\n');
+      }
+
+      if (!content.includes('DevLauncherController.wrapReactActivityDelegate')) {
+        content = content.replace(
+          /(new ReactActivityDelegate(.*|\s)*});$/m,
+          DEV_LAUNCHER_WRAPPED_ACTIVITY_DELEGATE
+        );
+      }
+
+      config.modResults.contents = content;
+    } else {
+      WarningAggregator.addWarningAndroid(
+        'android-devLauncher',
+        `Cannot automatically configure MainActivity if it's not java`
+      );
+    }
+
+    return config;
+  });
+};
+
+const withDevLauncherPodfile: ConfigPlugin = config => {
+  return withDangerousMod(config, [
+    'ios',
+    async config => {
+      await editPodfile(config, podfile => {
+        podfile = podfile.replace("platform :ios, '10.0'", "platform :ios, '11.0'");
+        podfile = addLines(podfile, 'use_react_native', 0, [`  ${DEV_LAUNCHER_POD_IMPORT}`]);
+        return podfile;
+      });
+      return config;
+    },
+  ]);
+};
+
+const withDevLauncherAppDelegate: ConfigPlugin = config => {
+  return withDangerousMod(config, [
+    'ios',
+    async config => {
+      await editAppDelegate(config, appDelegate => {
+        if (!appDelegate.includes(DEV_LAUNCHER_APP_DELEGATE_IOS_IMPORT)) {
+          const lines = appDelegate.split('\n');
+          lines.splice(1, 0, DEV_LAUNCHER_APP_DELEGATE_IOS_IMPORT);
+
+          appDelegate = lines.join('\n');
+        }
+
+        if (!appDelegate.includes(DEV_LAUNCHER_APP_DELEGATE_INIT)) {
+          appDelegate = appDelegate.replace(
+            /(didFinishLaunchingWithOptions([^}])*)\[self initializeReactNativeApp\];(([^}])*})/,
+            `$1${DEV_LAUNCHER_APP_DELEGATE_INIT}$3`
+          );
+        }
+
+        if (!appDelegate.includes(DEV_LAUNCHER_APP_DELEGATE_BRIDGE)) {
+          appDelegate = appDelegate.replace(
+            'RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:self.launchOptions];',
+            DEV_LAUNCHER_APP_DELEGATE_BRIDGE
+          );
+        }
+
+        if (!appDelegate.includes(DEV_LAUNCHER_APP_DELEGATE_SOURCE_FOR_URL)) {
+          appDelegate = appDelegate.replace(
+            'return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index" fallbackResource:nil];',
+            DEV_LAUNCHER_APP_DELEGATE_SOURCE_FOR_URL
+          );
+        }
+
+        if (!appDelegate.includes(DEV_LAUNCHER_APP_DELEGATE_ON_DEEP_LINK)) {
+          appDelegate = appDelegate.replace(
+            'return [RCTLinkingManager application:application openURL:url options:options];',
+            DEV_LAUNCHER_APP_DELEGATE_ON_DEEP_LINK
+          );
+        }
+
+        if (!appDelegate.includes(DEV_LAUNCHER_APP_DELEGATE_CONTROLLER_DELEGATE)) {
+          appDelegate += DEV_LAUNCHER_APP_DELEGATE_CONTROLLER_DELEGATE;
+        }
+
+        return appDelegate;
+      });
+
+      return config;
+    },
+  ]);
+};
+const withDevLauncher = (config: ExpoConfig) => {
+  config = withDevLauncherActivity(config);
+  config = withDevLauncherApplication(config);
+  config = withDevLauncherPodfile(config);
+  config = withDevLauncherAppDelegate(config);
+  return config;
+};
+
+export default withDevLauncher;

--- a/packages/expo-dev-launcher/plugin/tsconfig.json
+++ b/packages/expo-dev-launcher/plugin/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "extends": "expo-module-scripts/tsconfig.plugin",
+    "compilerOptions": {
+      "outDir": "build",
+      "rootDir": "src",
+
+    },
+    "include": ["./src"],
+    "exclude": ["**/__mocks__/*", "**/__tests__/*"],
+  }

--- a/packages/expo-dev-menu/app.plugin.js
+++ b/packages/expo-dev-menu/app.plugin.js
@@ -1,0 +1,1 @@
+module.exports = require('./plugin/build/withDevMenu');

--- a/packages/expo-dev-menu/plugin/build/withDevMenu.d.ts
+++ b/packages/expo-dev-menu/plugin/build/withDevMenu.d.ts
@@ -1,0 +1,3 @@
+import { ExpoConfig } from '@expo/config-types';
+declare const withDevMenu: (config: ExpoConfig) => ExpoConfig;
+export default withDevMenu;

--- a/packages/expo-dev-menu/plugin/build/withDevMenu.js
+++ b/packages/expo-dev-menu/plugin/build/withDevMenu.js
@@ -1,0 +1,124 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const config_plugins_1 = require("@expo/config-plugins");
+const fs_1 = __importDefault(require("fs"));
+const path_1 = __importDefault(require("path"));
+const DEV_MENU_ANDROID_IMPORT = 'expo.modules.devmenu.react.DevMenuAwareReactActivity';
+const DEV_MENU_ACTIVITY_CLASS = 'public class MainActivity extends DevMenuAwareReactActivity {';
+const DEV_MENU_POD_IMPORT = "pod 'expo-dev-menu', path: '../node_modules/expo-dev-menu', :configurations => :debug";
+const DEV_MENU_IOS_IMPORT = `
+#if defined(EX_DEV_MENU_ENABLED)
+@import EXDevMenu;
+#endif`;
+const DEV_MENU_IOS_INIT = `
+#if defined(EX_DEV_MENU_ENABLED)
+  [DevMenuManager configureWithBridge:bridge];
+#endif`;
+async function readFileAsync(path) {
+    return fs_1.default.promises.readFile(path, 'utf8');
+}
+async function saveFileAsync(path, content) {
+    return fs_1.default.promises.writeFile(path, content, 'utf8');
+}
+function addJavaImports(javaSource, javaImports) {
+    const lines = javaSource.split('\n');
+    const lineIndexWithPackageDeclaration = lines.findIndex(line => line.match(/^package .*;$/));
+    for (const javaImport of javaImports) {
+        if (!javaSource.includes(javaImport)) {
+            const importStatement = `import ${javaImport};`;
+            lines.splice(lineIndexWithPackageDeclaration + 1, 0, importStatement);
+        }
+    }
+    return lines.join('\n');
+}
+function addLines(content, find, offset, toAdd) {
+    const lines = content.split('\n');
+    let lineIndex = lines.findIndex(line => line.match(find));
+    for (const newLine of toAdd) {
+        if (!content.includes(newLine)) {
+            lines.splice(lineIndex + offset, 0, newLine);
+            lineIndex++;
+        }
+    }
+    return lines.join('\n');
+}
+async function editPodfile(config, action) {
+    const podfilePath = path_1.default.join(config.modRequest.platformProjectRoot, 'Podfile');
+    try {
+        const podfile = action(await readFileAsync(podfilePath));
+        return await saveFileAsync(podfilePath, podfile);
+    }
+    catch (e) {
+        config_plugins_1.WarningAggregator.addWarningIOS('ios-devMenu', `Couldn't modified AppDelegate.m - ${e}.`);
+    }
+}
+async function editAppDelegate(config, action) {
+    const appDelegatePath = path_1.default.join(config.modRequest.platformProjectRoot, config.modRequest.projectName, 'AppDelegate.m');
+    try {
+        const appDelegate = action(await readFileAsync(appDelegatePath));
+        return await saveFileAsync(appDelegatePath, appDelegate);
+    }
+    catch (e) {
+        config_plugins_1.WarningAggregator.addWarningIOS('ios-devMenu', `Couldn't modified AppDelegate.m - ${e}.`);
+    }
+}
+const withDevMenuActivity = config => {
+    return config_plugins_1.withMainActivity(config, config => {
+        if (config.modResults.language === 'java') {
+            let content = config.modResults.contents;
+            content = addJavaImports(content, [DEV_MENU_ANDROID_IMPORT]);
+            content = content.replace('public class MainActivity extends ReactActivity {', DEV_MENU_ACTIVITY_CLASS);
+            config.modResults.contents = content;
+        }
+        else {
+            config_plugins_1.WarningAggregator.addWarningAndroid('android-devMenu', `Cannot automatically configure MainActivity if it's not java`);
+        }
+        return config;
+    });
+};
+const withDevMenuPodfile = config => {
+    return config_plugins_1.withDangerousMod(config, [
+        'ios',
+        async (config) => {
+            await editPodfile(config, podfile => {
+                podfile = podfile.replace("platform :ios, '10.0'", "platform :ios, '11.0'");
+                podfile = addLines(podfile, 'use_react_native', 0, [`  ${DEV_MENU_POD_IMPORT}`]);
+                return podfile;
+            });
+            return config;
+        },
+    ]);
+};
+const withDevMenuAppDelegate = config => {
+    return config_plugins_1.withDangerousMod(config, [
+        'ios',
+        async (config) => {
+            await editAppDelegate(config, appDelegate => {
+                if (!appDelegate.includes(DEV_MENU_IOS_IMPORT)) {
+                    const lines = appDelegate.split('\n');
+                    lines.splice(1, 0, DEV_MENU_IOS_IMPORT);
+                    appDelegate = lines.join('\n');
+                }
+                if (!appDelegate.includes(DEV_MENU_IOS_INIT)) {
+                    const lines = appDelegate.split('\n');
+                    const initializeReactNativeAppIndex = lines.findIndex(line => line.includes('- (RCTBridge *)initializeReactNativeApp'));
+                    const rootViewControllerIndex = lines.findIndex((line, index) => initializeReactNativeAppIndex < index && line.includes('rootViewController'));
+                    lines.splice(rootViewControllerIndex - 1, 0, DEV_MENU_IOS_INIT);
+                    appDelegate = lines.join('\n');
+                }
+                return appDelegate;
+            });
+            return config;
+        },
+    ]);
+};
+const withDevMenu = (config) => {
+    config = withDevMenuActivity(config);
+    config = withDevMenuPodfile(config);
+    config = withDevMenuAppDelegate(config);
+    return config;
+};
+exports.default = withDevMenu;

--- a/packages/expo-dev-menu/plugin/jest.config.js
+++ b/packages/expo-dev-menu/plugin/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = require('expo-module-scripts/jest-preset-plugin');

--- a/packages/expo-dev-menu/plugin/src/withDevMenu.ts
+++ b/packages/expo-dev-menu/plugin/src/withDevMenu.ts
@@ -1,0 +1,171 @@
+import {
+  ConfigPlugin,
+  withDangerousMod,
+  withMainActivity,
+  WarningAggregator,
+  ExportedConfigWithProps,
+} from '@expo/config-plugins';
+import { ExpoConfig } from '@expo/config-types';
+import fs from 'fs';
+import path from 'path';
+
+const DEV_MENU_ANDROID_IMPORT = 'expo.modules.devmenu.react.DevMenuAwareReactActivity';
+const DEV_MENU_ACTIVITY_CLASS = 'public class MainActivity extends DevMenuAwareReactActivity {';
+
+const DEV_MENU_POD_IMPORT =
+  "pod 'expo-dev-menu', path: '../node_modules/expo-dev-menu', :configurations => :debug";
+
+const DEV_MENU_IOS_IMPORT = `
+#if defined(EX_DEV_MENU_ENABLED)
+@import EXDevMenu;
+#endif`;
+
+const DEV_MENU_IOS_INIT = `
+#if defined(EX_DEV_MENU_ENABLED)
+  [DevMenuManager configureWithBridge:bridge];
+#endif`;
+
+async function readFileAsync(path: string): Promise<string> {
+  return fs.promises.readFile(path, 'utf8');
+}
+
+async function saveFileAsync(path: string, content: string): Promise<void> {
+  return fs.promises.writeFile(path, content, 'utf8');
+}
+
+function addJavaImports(javaSource: string, javaImports: string[]): string {
+  const lines = javaSource.split('\n');
+  const lineIndexWithPackageDeclaration = lines.findIndex(line => line.match(/^package .*;$/));
+  for (const javaImport of javaImports) {
+    if (!javaSource.includes(javaImport)) {
+      const importStatement = `import ${javaImport};`;
+      lines.splice(lineIndexWithPackageDeclaration + 1, 0, importStatement);
+    }
+  }
+  return lines.join('\n');
+}
+
+function addLines(content: string, find: string | RegExp, offset: number, toAdd: string[]) {
+  const lines = content.split('\n');
+
+  let lineIndex = lines.findIndex(line => line.match(find));
+
+  for (const newLine of toAdd) {
+    if (!content.includes(newLine)) {
+      lines.splice(lineIndex + offset, 0, newLine);
+      lineIndex++;
+    }
+  }
+
+  return lines.join('\n');
+}
+
+async function editPodfile(config: ExportedConfigWithProps, action: (podfile: string) => string) {
+  const podfilePath = path.join(config.modRequest.platformProjectRoot, 'Podfile');
+  try {
+    const podfile = action(await readFileAsync(podfilePath));
+
+    return await saveFileAsync(podfilePath, podfile);
+  } catch (e) {
+    WarningAggregator.addWarningIOS('ios-devMenu', `Couldn't modified AppDelegate.m - ${e}.`);
+  }
+}
+
+async function editAppDelegate(
+  config: ExportedConfigWithProps,
+  action: (appDelegate: string) => string
+) {
+  const appDelegatePath = path.join(
+    config.modRequest.platformProjectRoot,
+    config.modRequest.projectName!,
+    'AppDelegate.m'
+  );
+
+  try {
+    const appDelegate = action(await readFileAsync(appDelegatePath));
+    return await saveFileAsync(appDelegatePath, appDelegate);
+  } catch (e) {
+    WarningAggregator.addWarningIOS('ios-devMenu', `Couldn't modified AppDelegate.m - ${e}.`);
+  }
+}
+
+const withDevMenuActivity: ConfigPlugin = config => {
+  return withMainActivity(config, config => {
+    if (config.modResults.language === 'java') {
+      let content = config.modResults.contents;
+      content = addJavaImports(content, [DEV_MENU_ANDROID_IMPORT]);
+      content = content.replace(
+        'public class MainActivity extends ReactActivity {',
+        DEV_MENU_ACTIVITY_CLASS
+      );
+      config.modResults.contents = content;
+    } else {
+      WarningAggregator.addWarningAndroid(
+        'android-devMenu',
+        `Cannot automatically configure MainActivity if it's not java`
+      );
+    }
+
+    return config;
+  });
+};
+
+const withDevMenuPodfile: ConfigPlugin = config => {
+  return withDangerousMod(config, [
+    'ios',
+    async config => {
+      await editPodfile(config, podfile => {
+        podfile = podfile.replace("platform :ios, '10.0'", "platform :ios, '11.0'");
+        podfile = addLines(podfile, 'use_react_native', 0, [`  ${DEV_MENU_POD_IMPORT}`]);
+        return podfile;
+      });
+      return config;
+    },
+  ]);
+};
+
+const withDevMenuAppDelegate: ConfigPlugin = config => {
+  return withDangerousMod(config, [
+    'ios',
+    async config => {
+      await editAppDelegate(config, appDelegate => {
+        if (!appDelegate.includes(DEV_MENU_IOS_IMPORT)) {
+          const lines = appDelegate.split('\n');
+          lines.splice(1, 0, DEV_MENU_IOS_IMPORT);
+
+          appDelegate = lines.join('\n');
+        }
+
+        if (!appDelegate.includes(DEV_MENU_IOS_INIT)) {
+          const lines = appDelegate.split('\n');
+
+          const initializeReactNativeAppIndex = lines.findIndex(line =>
+            line.includes('- (RCTBridge *)initializeReactNativeApp')
+          );
+
+          const rootViewControllerIndex = lines.findIndex(
+            (line, index) =>
+              initializeReactNativeAppIndex < index && line.includes('rootViewController')
+          );
+
+          lines.splice(rootViewControllerIndex - 1, 0, DEV_MENU_IOS_INIT);
+
+          appDelegate = lines.join('\n');
+        }
+
+        return appDelegate;
+      });
+
+      return config;
+    },
+  ]);
+};
+
+const withDevMenu = (config: ExpoConfig) => {
+  config = withDevMenuActivity(config);
+  config = withDevMenuPodfile(config);
+  config = withDevMenuAppDelegate(config);
+  return config;
+};
+
+export default withDevMenu;

--- a/packages/expo-dev-menu/plugin/tsconfig.json
+++ b/packages/expo-dev-menu/plugin/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "extends": "expo-module-scripts/tsconfig.plugin",
+    "compilerOptions": {
+      "outDir": "build",
+      "rootDir": "src",
+
+    },
+    "include": ["./src"],
+    "exclude": ["**/__mocks__/*", "**/__tests__/*"],
+  }


### PR DESCRIPTION
# Why

Adds config plugins for `expo-dev-menu` and `expo-dev-launcher`.

# How

Added plugins according to https://github.com/expo/expo-cli/tree/master/packages/config-plugins.

# Test Plan

- expo init
- add plugins to `app.config.json`
- expo eject