### PR TITLE
[expo-in-app-purchases] Add defensive null checks and missing iOS SKErrorCode values

### DIFF
--- a/packages/expo-in-app-purchases/android/src/main/java/expo/modules/inapppurchases/BillingManager.java
+++ b/packages/expo-in-app-purchases/android/src/main/java/expo/modules/inapppurchases/BillingManager.java
@@ -161,7 +161,7 @@ public class BillingManager implements PurchasesUpdatedListener {
    */
   @Override
   public void onPurchasesUpdated(BillingResult result, List<Purchase> purchases) {
-    if (result.getResponseCode() == BillingResponseCode.OK) {
+    if (result.getResponseCode() == BillingResponseCode.OK && purchases != null) {
       for (Purchase purchase : purchases) {
         handlePurchase(purchase);
       }
@@ -263,11 +263,11 @@ public class BillingManager implements PurchasesUpdatedListener {
         PurchasesResult purchasesResult = mBillingClient.queryPurchases(SkuType.INAPP);
 
         // If there are subscriptions supported, we add subscription rows as well
-        if (areSubscriptionsSupported()) {
+        if (purchasesResult != null && areSubscriptionsSupported()) {
           PurchasesResult subscriptionResult
             = mBillingClient.queryPurchases(SkuType.SUBS);
 
-          if (subscriptionResult.getResponseCode() == BillingResponseCode.OK) {
+          if (subscriptionResult != null && subscriptionResult.getResponseCode() == BillingResponseCode.OK) {
             purchasesResult.getPurchasesList().addAll(
               subscriptionResult.getPurchasesList());
           }
@@ -441,7 +441,7 @@ public class BillingManager implements PurchasesUpdatedListener {
    */
   private void onQueryPurchasesFinished(PurchasesResult result, final Promise promise) {
     // Have we been disposed of in the meantime? If so, or bad result code, then quit
-    if (mBillingClient == null || result.getResponseCode() != BillingResponseCode.OK) {
+    if (mBillingClient == null || result == null || result.getResponseCode() != BillingResponseCode.OK) {
       promise.reject("E_QUERY_FAILED", "Billing client was null or query was unsuccessful");
       return;
     }
@@ -481,7 +481,7 @@ public class BillingManager implements PurchasesUpdatedListener {
               mBillingClient.querySkuDetailsAsync(subs.build(), new SkuDetailsResponseListener() {
                 @Override
                 public void onSkuDetailsResponse(BillingResult billingResult, List<SkuDetails> subscriptionDetails) {
-                  if (skuDetails != null) {
+                  if (skuDetails != null && subscriptionDetails != null) {
                     skuDetails.addAll(subscriptionDetails);
                   }
                   listener.onSkuDetailsResponse(billingResult, skuDetails);
@@ -501,9 +501,11 @@ public class BillingManager implements PurchasesUpdatedListener {
         @Override
         public void onSkuDetailsResponse(BillingResult billingResult, List<SkuDetails> skuDetailsList) {
           ArrayList<Bundle> results = new ArrayList<>();
-          for (SkuDetails skuDetails : skuDetailsList) {
-            mSkuDetailsMap.put(skuDetails.getSku(), skuDetails);
-            results.add(skuToBundle(skuDetails));
+          if (skuDetailsList != null) {
+              for (SkuDetails skuDetails : skuDetailsList) {
+                mSkuDetailsMap.put(skuDetails.getSku(), skuDetails);
+                results.add(skuToBundle(skuDetails));
+              }
           }
           Bundle response = formatResponse(billingResult, results);
           promise.resolve(response);

--- a/packages/expo-in-app-purchases/android/src/main/java/expo/modules/inapppurchases/BillingManager.java
+++ b/packages/expo-in-app-purchases/android/src/main/java/expo/modules/inapppurchases/BillingManager.java
@@ -502,10 +502,10 @@ public class BillingManager implements PurchasesUpdatedListener {
         public void onSkuDetailsResponse(BillingResult billingResult, List<SkuDetails> skuDetailsList) {
           ArrayList<Bundle> results = new ArrayList<>();
           if (skuDetailsList != null) {
-              for (SkuDetails skuDetails : skuDetailsList) {
-                mSkuDetailsMap.put(skuDetails.getSku(), skuDetails);
-                results.add(skuToBundle(skuDetails));
-              }
+            for (SkuDetails skuDetails : skuDetailsList) {
+              mSkuDetailsMap.put(skuDetails.getSku(), skuDetails);
+              results.add(skuToBundle(skuDetails));
+            }
           }
           Bundle response = formatResponse(billingResult, results);
           promise.resolve(response);

--- a/packages/expo-in-app-purchases/ios/EXInAppPurchases/EXInAppPurchasesModule.m
+++ b/packages/expo-in-app-purchases/ios/EXInAppPurchases/EXInAppPurchasesModule.m
@@ -151,7 +151,7 @@ UM_EXPORT_METHOD_AS(disconnectAsync,
   NSMutableArray *result = [NSMutableArray array];
   
   for (SKProduct *validProduct in response.products) {
-    if(!validProduct.localizedDescription) { continue; } // skip this product - this can happen if the its is in review "rejected" state
+    if(!validProduct.localizedDescription) { continue; } // skip product with nil values - this can happen if it is in review "rejected" state
     NSDictionary *productData = [self getProductData:validProduct];
     [result addObject:productData];
   }
@@ -168,7 +168,7 @@ UM_EXPORT_METHOD_AS(disconnectAsync,
   }
   
   for (SKProduct *validProduct in response.products) {
-    if(!validProduct.localizedDescription) { continue; } // skip this product - this can happen if the its is in review "rejected" state
+    if(!validProduct.localizedDescription) { continue; } // skip product with nil values - this can happen if it is in review "rejected" state
     [self purchase:validProduct];
   }
 }

--- a/packages/expo-in-app-purchases/ios/EXInAppPurchases/EXInAppPurchasesModule.m
+++ b/packages/expo-in-app-purchases/ios/EXInAppPurchases/EXInAppPurchasesModule.m
@@ -151,6 +151,7 @@ UM_EXPORT_METHOD_AS(disconnectAsync,
   NSMutableArray *result = [NSMutableArray array];
   
   for (SKProduct *validProduct in response.products) {
+    if(!validProduct.localizedDescription) { continue; } // skip this product - this can happen if the its is in review "rejected" state
     NSDictionary *productData = [self getProductData:validProduct];
     [result addObject:productData];
   }
@@ -167,6 +168,7 @@ UM_EXPORT_METHOD_AS(disconnectAsync,
   }
   
   for (SKProduct *validProduct in response.products) {
+    if(!validProduct.localizedDescription) { continue; } // skip this product - this can happen if the its is in review "rejected" state
     [self purchase:validProduct];
   }
 }
@@ -422,12 +424,14 @@ UM_EXPORT_METHOD_AS(disconnectAsync,
     case SKErrorPaymentInvalid:
     case SKErrorPaymentNotAllowed:
     case SKErrorPaymentCancelled:
+    case SKErrorOverlayCancelled:
       return 1;
     case SKErrorStoreProductNotAvailable:
       return 6;
     case SKErrorCloudServiceRevoked:
     case SKErrorCloudServicePermissionDenied:
     case SKErrorCloudServiceNetworkConnectionFailed:
+    case SKErrorOverlayTimeout:
       return 10;
     case SKErrorPrivacyAcknowledgementRequired:
       return 11;
@@ -436,8 +440,11 @@ UM_EXPORT_METHOD_AS(disconnectAsync,
     case SKErrorInvalidSignature:
     case SKErrorInvalidOfferPrice:
     case SKErrorInvalidOfferIdentifier:
+    case SKErrorOverlayInvalidConfiguration:
+    case SKErrorIneligibleForOffer:
       return 13;
     case SKErrorMissingOfferParams:
+    case SKErrorUnsupportedPlatform:
       return 14;
     default:
       return 0;

--- a/packages/expo-in-app-purchases/ios/EXInAppPurchases/EXInAppPurchasesModule.m
+++ b/packages/expo-in-app-purchases/ios/EXInAppPurchases/EXInAppPurchasesModule.m
@@ -151,7 +151,7 @@ UM_EXPORT_METHOD_AS(disconnectAsync,
   NSMutableArray *result = [NSMutableArray array];
   
   for (SKProduct *validProduct in response.products) {
-    if(!validProduct.localizedDescription) { continue; } // skip product with nil values - this can happen if it is in review "rejected" state
+    if (!validProduct.localizedDescription) { continue; } // skip product with nil values - this can happen if it is in review "rejected" state
     NSDictionary *productData = [self getProductData:validProduct];
     [result addObject:productData];
   }
@@ -168,7 +168,7 @@ UM_EXPORT_METHOD_AS(disconnectAsync,
   }
   
   for (SKProduct *validProduct in response.products) {
-    if(!validProduct.localizedDescription) { continue; } // skip product with nil values - this can happen if it is in review "rejected" state
+    if (!validProduct.localizedDescription) { continue; } // skip product with nil values - this can happen if it is in review "rejected" state
     [self purchase:validProduct];
   }
 }
@@ -414,40 +414,41 @@ UM_EXPORT_METHOD_AS(disconnectAsync,
            };
 }
 
-// Convert native error code to match TS enum
+// Convert native error code to match TS enum IAPErrorCode
 - (int)errorCodeNativeToJS:(SKErrorCode)errorCode
 {
   switch(errorCode) {
     case SKErrorUnknown:
-      return 0;
+    case SKErrorUnsupportedPlatform:
+      return 0; // UNKNOWN
     case SKErrorClientInvalid:
     case SKErrorPaymentInvalid:
     case SKErrorPaymentNotAllowed:
     case SKErrorPaymentCancelled:
     case SKErrorOverlayCancelled:
-      return 1;
+      return 1; // PAYMENT_INVALID
+    case SKErrorOverlayTimeout:
+      return 4; // SERVICE_TIMEOUT
     case SKErrorStoreProductNotAvailable:
-      return 6;
+      return 6; // ITEM_UNAVAILABLE
     case SKErrorCloudServiceRevoked:
     case SKErrorCloudServicePermissionDenied:
     case SKErrorCloudServiceNetworkConnectionFailed:
-    case SKErrorOverlayTimeout:
-      return 10;
+      return 10; // CLOUD_SERVICE
     case SKErrorPrivacyAcknowledgementRequired:
-      return 11;
+      return 11; // PRIVACY_UNACKNOWLEDGED
     case SKErrorUnauthorizedRequestData:
-      return 12;
+      return 12; // UNAUTHORIZED_REQUEST
     case SKErrorInvalidSignature:
     case SKErrorInvalidOfferPrice:
     case SKErrorInvalidOfferIdentifier:
     case SKErrorOverlayInvalidConfiguration:
     case SKErrorIneligibleForOffer:
-      return 13;
+      return 13; // INVALID_IDENTIFIER
     case SKErrorMissingOfferParams:
-    case SKErrorUnsupportedPlatform:
-      return 14;
+      return 14; // MISSING_PARAMS
     default:
-      return 0;
+      return 0; // UNKNOWN
   }
 }
 


### PR DESCRIPTION
# Why

We have seen several crash reports in production on Android and iOS due to the platform IAP code sending invalid or missing Product SKU data to `expo-in-app-purchases`.

On Android, despite the documentation implying that the parameters to methods like `onQueryPurchasesFinished()` and `onSkuDetailsResponse()` are not nullable, we have seen occasional crashes in production where they have been null. This patch adds some defensive null checks to the Android code to gracefully ignore invalid input rather than crash.

On iOS, there are cases when some fields of `SKProduct` coming from the StoreKit API can be `nil`, specifically during the app review process when your IAP product is in a "Review Rejected" state. In this case, I think it's best to ignore the invalid product SKU, otherwise the `nil` values will propagate through the EXInAppPurchases code and inevitably cause a native Objective-C crash.

(example crash report: https://sentry.io/share/issue/057be1d8c2f345c687feb82349a87adb/ - note, I believe the part of the stack trace that includes `expo::gl_cpp` is bogus due to threading or JSC issues - the actual error comes from receiving a SKProduct containing `nil` values from `[SKProductsRequest _start]` and passing it to `getProductData`)

In addition, this patch adds a few missing `SKErrorCode` values to `errorCodeNativeToJS` that were added in more recent StoreKit versions. (happy to separate this part if you'd like).

By the way, separately, I'd like to propose updating the Android Google Play Billing SDK to 2.2.0, which is the latest version that has no breaking changes relative to the version currently used by `expo-in-app-purchases` (2.0.0).

# How

Ignore invalid product SKUs at the Android/iOS API level.

# Test Plan

We've been running this patch in production on our app (https://badukpop.com) for several months with satisfactory results.

