### PR TITLE
[location] remove sticky notification on app killing

### DIFF
--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### 🐛 Bug fixes
 
+- Remove sticky notification on service stop on Android. ([#11775](https://github.com/expo/expo/pull/11775) by [@zaguiini](https://github.com/zaguiini))
+
 ## 11.0.0 — 2021-01-15
 
 ### ⚠️ Notices

--- a/packages/expo-location/android/src/main/java/expo/modules/location/services/LocationTaskService.java
+++ b/packages/expo-location/android/src/main/java/expo/modules/location/services/LocationTaskService.java
@@ -62,6 +62,12 @@ public class LocationTaskService extends Service {
     stopSelf();
   }
 
+  @Override
+  public void onTaskRemoved(Intent rootIntent) {
+    super.onTaskRemoved(rootIntent);
+    stop();
+  }
+
   public void startForeground(Bundle serviceOptions) {
     Notification notification = buildServiceNotification(serviceOptions);
     startForeground(mServiceId, notification);


### PR DESCRIPTION
# Why

Sticky notification was not being removed when the app was killed.

[Some folks](https://stackoverflow.com/questions/65323555/expo-problem-unable-to-close-foreground-service-notification-after-android-app) are having this problem.

# How

I'm not so good at Android development so I'll try my best to explain it. Basically I added a listener to the service stop which allowed to remove the sticky notification from the taskbar.

# Test Plan

Try starting background location and killing the app from the task manager. The notification should be destroyed. It doesn't happen like that on the latest published version.