### PR TITLE
Update running-in-the-browser.md web lib support

### DIFF
--- a/docs/pages/guides/running-in-the-browser.md
+++ b/docs/pages/guides/running-in-the-browser.md
@@ -13,6 +13,7 @@ Starting in _SDK 33_ projects bootstrapped with the Expo CLI will have web suppo
 - Install the latest version of the Expo CLI: `npm i -g expo-cli`
 - Add web dependencies: `yarn add react-native-web@~0.11 react-dom`
   - Ensure your project has at least `expo@^33.0.0` installed.
+  - If your project has at least `expo@^39.0.0` installed then you will need to install `react-native-web@~0.13`
 - Start your project with `expo start` then press `w` to start Webpack and open the project in the browser.
 
 **Tips**


### PR DESCRIPTION
# Why
After hours trying to run `react-native-web` with the latest expo sdk v40 I discovery the [docs](https://docs.expo.io/guides/running-in-the-browser/#adding-web-support-to-expo-projects) are outdated. Expo recommends to install `react-native-web@~0.11` but with expo sdk v40 not work.

# How
- Add text to explain how to run on higher expo sdk v39 according this issue [here] as @EvanBacon recommends (https://github.com/necolas/react-native-web/issues/1515#issuecomment-696763117)

# Test Plan
N/A