### PR TITLE
[notifications][ios] migrate notification categories

### DIFF
--- a/ios/ExpoNotificationServiceExtension/ExpoNotificationServiceExtension-Bridging-Header.h
+++ b/ios/ExpoNotificationServiceExtension/ExpoNotificationServiceExtension-Bridging-Header.h
@@ -1,0 +1,4 @@
+//
+//  Use this file to import your target's public headers that you would like to expose to Swift.
+//
+

--- a/ios/ExpoNotificationServiceExtension/ExpoNotificationServiceExtension-Bridging-Header.h
+++ b/ios/ExpoNotificationServiceExtension/ExpoNotificationServiceExtension-Bridging-Header.h
@@ -2,3 +2,4 @@
 //  Use this file to import your target's public headers that you would like to expose to Swift.
 //
 
+#import "EXScopedNotificationsUtils.h"

--- a/ios/ExpoNotificationServiceExtension/NotificationService.swift
+++ b/ios/ExpoNotificationServiceExtension/NotificationService.swift
@@ -24,7 +24,8 @@ class NotificationService: UNNotificationServiceExtension {
       // Modify notification content here...
       if (!request.content.categoryIdentifier.isEmpty && (request.content.userInfo["experienceId"]) != nil) {
         let escapedExperienceId = NSRegularExpression.escapedPattern(for: request.content.userInfo["experienceId"] as! String)
-        bestAttemptContent.categoryIdentifier = "\(escapedExperienceId)/\(request.content.categoryIdentifier)"
+        let escapedCategoryIdentifier = NSRegularExpression.escapedPattern(for: request.content.categoryIdentifier)
+        bestAttemptContent.categoryIdentifier = "\(escapedExperienceId)/\(escapedCategoryIdentifier)"
       }
       contentHandler(bestAttemptContent)
     }

--- a/ios/ExpoNotificationServiceExtension/NotificationService.swift
+++ b/ios/ExpoNotificationServiceExtension/NotificationService.swift
@@ -23,9 +23,7 @@ class NotificationService: UNNotificationServiceExtension {
     if let bestAttemptContent = bestAttemptContent {
       // Modify notification content here...
       if (!request.content.categoryIdentifier.isEmpty && (request.content.userInfo["experienceId"]) != nil) {
-        let escapedExperienceId = NSRegularExpression.escapedPattern(for: request.content.userInfo["experienceId"] as! String)
-        let escapedCategoryIdentifier = NSRegularExpression.escapedPattern(for: request.content.categoryIdentifier)
-        bestAttemptContent.categoryIdentifier = "\(escapedExperienceId)/\(escapedCategoryIdentifier)"
+        bestAttemptContent.categoryIdentifier = EXScopedNotificationsUtils.scopedCategoryIdentifier(withId: request.content.categoryIdentifier, forExperience: request.content.userInfo["experienceId"] as! String)
       }
       contentHandler(bestAttemptContent)
     }

--- a/ios/ExpoNotificationServiceExtension/NotificationService.swift
+++ b/ios/ExpoNotificationServiceExtension/NotificationService.swift
@@ -24,8 +24,7 @@ class NotificationService: UNNotificationServiceExtension {
       // Modify notification content here...
       if (!request.content.categoryIdentifier.isEmpty && (request.content.userInfo["experienceId"]) != nil) {
         let escapedExperienceId = NSRegularExpression.escapedPattern(for: request.content.userInfo["experienceId"] as! String)
-        let escapedCategoryIdentifier = NSRegularExpression.escapedPattern(for: request.content.categoryIdentifier)
-        bestAttemptContent.categoryIdentifier = "\(escapedExperienceId)/\(escapedCategoryIdentifier)"
+        bestAttemptContent.categoryIdentifier = "\(escapedExperienceId)/\(request.content.categoryIdentifier)"
       }
       contentHandler(bestAttemptContent)
     }

--- a/ios/Exponent.xcodeproj/project.pbxproj
+++ b/ios/Exponent.xcodeproj/project.pbxproj
@@ -386,6 +386,7 @@
 		FA526593B78C87A7E1C34561 /* libPods-Tests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7D8BAB8D6102FB06BE5BE10B /* libPods-Tests.a */; };
 		FC756CC924CB537400665AE6 /* EXScopedNotificationSerializer.m in Sources */ = {isa = PBXBuildFile; fileRef = FC756CC824CB537400665AE6 /* EXScopedNotificationSerializer.m */; };
 		FCA11CA724C1215B00C1FC54 /* EXScopedNotificationCategoriesModule.m in Sources */ = {isa = PBXBuildFile; fileRef = FCA11CA524C1215B00C1FC54 /* EXScopedNotificationCategoriesModule.m */; };
+		FCB4079725C5EF4F00326AC8 /* EXScopedNotificationCategoryMigrator.m in Sources */ = {isa = PBXBuildFile; fileRef = FCB4079625C5EF4F00326AC8 /* EXScopedNotificationCategoryMigrator.m */; };
 		FCF6D37025B34BC200808BF5 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCF6D36F25B34BC200808BF5 /* NotificationService.swift */; };
 		FCF6D37425B34BC200808BF5 /* ExpoNotificationServiceExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = FCF6D36D25B34BC200808BF5 /* ExpoNotificationServiceExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
@@ -1207,6 +1208,8 @@
 		FC756CCA24CB542800665AE6 /* EXScopedNotificationSerializer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EXScopedNotificationSerializer.h; sourceTree = "<group>"; };
 		FCA11CA524C1215B00C1FC54 /* EXScopedNotificationCategoriesModule.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EXScopedNotificationCategoriesModule.m; sourceTree = "<group>"; };
 		FCA11CA624C1215B00C1FC54 /* EXScopedNotificationCategoriesModule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EXScopedNotificationCategoriesModule.h; sourceTree = "<group>"; };
+		FCB4079525C5EF3800326AC8 /* EXScopedNotificationCategoryMigrator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EXScopedNotificationCategoryMigrator.h; sourceTree = "<group>"; };
+		FCB4079625C5EF4F00326AC8 /* EXScopedNotificationCategoryMigrator.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EXScopedNotificationCategoryMigrator.m; sourceTree = "<group>"; };
 		FCF6D36D25B34BC200808BF5 /* ExpoNotificationServiceExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = ExpoNotificationServiceExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		FCF6D36F25B34BC200808BF5 /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
 		FCF6D37125B34BC200808BF5 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -1931,6 +1934,8 @@
 				B23D9AA224758C6600D09AC8 /* EXScopedNotificationPresentationModule.m */,
 				314791EE2551CF2A00A81BA1 /* EXScopedServerRegistrationModule.h */,
 				314791EF2551CF2A00A81BA1 /* EXScopedServerRegistrationModule.m */,
+				FCB4079525C5EF3800326AC8 /* EXScopedNotificationCategoryMigrator.h */,
+				FCB4079625C5EF4F00326AC8 /* EXScopedNotificationCategoryMigrator.m */,
 			);
 			path = EXNotifications;
 			sourceTree = "<group>";
@@ -3162,6 +3167,7 @@
 				31E6D47E20B8451B0082B09F /* EXSensorManager.m in Sources */,
 				78C832EE23546BD400448582 /* RNPinchHandler.m in Sources */,
 				B5FB74B51FF6DADC001C764B /* EXUtil.m in Sources */,
+				FCB4079725C5EF4F00326AC8 /* EXScopedNotificationCategoryMigrator.m in Sources */,
 				B5576085204A423B0041D9C8 /* EXHomeModuleManager.m in Sources */,
 				31AD9A442285B53100F19090 /* AIRMapCalloutManager.m in Sources */,
 				B5FB74E01FF6DADC001C764B /* EXDevSettingsDataSource.m in Sources */,

--- a/ios/Exponent.xcodeproj/project.pbxproj
+++ b/ios/Exponent.xcodeproj/project.pbxproj
@@ -387,6 +387,7 @@
 		FC756CC924CB537400665AE6 /* EXScopedNotificationSerializer.m in Sources */ = {isa = PBXBuildFile; fileRef = FC756CC824CB537400665AE6 /* EXScopedNotificationSerializer.m */; };
 		FCA11CA724C1215B00C1FC54 /* EXScopedNotificationCategoriesModule.m in Sources */ = {isa = PBXBuildFile; fileRef = FCA11CA524C1215B00C1FC54 /* EXScopedNotificationCategoriesModule.m */; };
 		FCB4079725C5EF4F00326AC8 /* EXScopedNotificationCategoryMigrator.m in Sources */ = {isa = PBXBuildFile; fileRef = FCB4079625C5EF4F00326AC8 /* EXScopedNotificationCategoryMigrator.m */; };
+		FCB4099525C6207C00326AC8 /* EXScopedNotificationsUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = B2F7C02D246B09AE0060EE06 /* EXScopedNotificationsUtils.m */; };
 		FCF6D37025B34BC200808BF5 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCF6D36F25B34BC200808BF5 /* NotificationService.swift */; };
 		FCF6D37425B34BC200808BF5 /* ExpoNotificationServiceExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = FCF6D36D25B34BC200808BF5 /* ExpoNotificationServiceExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
@@ -1210,6 +1211,7 @@
 		FCA11CA624C1215B00C1FC54 /* EXScopedNotificationCategoriesModule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EXScopedNotificationCategoriesModule.h; sourceTree = "<group>"; };
 		FCB4079525C5EF3800326AC8 /* EXScopedNotificationCategoryMigrator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EXScopedNotificationCategoryMigrator.h; sourceTree = "<group>"; };
 		FCB4079625C5EF4F00326AC8 /* EXScopedNotificationCategoryMigrator.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EXScopedNotificationCategoryMigrator.m; sourceTree = "<group>"; };
+		FCB407C525C61D4700326AC8 /* ExpoNotificationServiceExtension-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ExpoNotificationServiceExtension-Bridging-Header.h"; sourceTree = "<group>"; };
 		FCF6D36D25B34BC200808BF5 /* ExpoNotificationServiceExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = ExpoNotificationServiceExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		FCF6D36F25B34BC200808BF5 /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
 		FCF6D37125B34BC200808BF5 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -2642,6 +2644,7 @@
 			children = (
 				FCF6D36F25B34BC200808BF5 /* NotificationService.swift */,
 				FCF6D37125B34BC200808BF5 /* Info.plist */,
+				FCB407C525C61D4700326AC8 /* ExpoNotificationServiceExtension-Bridging-Header.h */,
 			);
 			path = ExpoNotificationServiceExtension;
 			sourceTree = "<group>";
@@ -2777,6 +2780,7 @@
 					FCF6D36C25B34BC200808BF5 = {
 						CreatedOnToolsVersion = 12.2;
 						DevelopmentTeam = C8D8QTF339;
+						LastSwiftMigration = 1220;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -3372,6 +3376,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				FCF6D37025B34BC200808BF5 /* NotificationService.swift in Sources */,
+				FCB4099525C6207C00326AC8 /* EXScopedNotificationsUtils.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3701,6 +3706,7 @@
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
@@ -3719,10 +3725,12 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
+				OTHER_LDFLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = host.exp.Exponent.ExpoNotificationServiceExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OBJC_BRIDGING_HEADER = "ExpoNotificationServiceExtension/ExpoNotificationServiceExtension-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -3735,6 +3743,7 @@
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
@@ -3748,9 +3757,11 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 14.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				MTL_FAST_MATH = YES;
+				OTHER_LDFLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = host.exp.Exponent.ExpoNotificationServiceExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "ExpoNotificationServiceExtension/ExpoNotificationServiceExtension-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationBuilder.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationBuilder.m
@@ -33,8 +33,9 @@
   [content setUserInfo:userInfo];
   
   if (content.categoryIdentifier && _isInExpoGo) {
-    NSString *categoryIdentifier = [NSString stringWithFormat:@"%@/%@", _experienceId, content.categoryIdentifier];
-    [content setCategoryIdentifier:categoryIdentifier];
+    NSString *escapedExperienceId = [NSRegularExpression escapedPatternForString: _experienceId];
+    NSString *scopedCategoryIdentifier = [NSString stringWithFormat:@"%@/%@", escapedExperienceId, content.categoryIdentifier];
+    [content setCategoryIdentifier:scopedCategoryIdentifier];
   }
   
   return content;

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationBuilder.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationBuilder.m
@@ -1,6 +1,7 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
 #import "EXScopedNotificationBuilder.h"
+#import "EXScopedNotificationsUtils.h"
 
 @interface EXScopedNotificationBuilder ()
 
@@ -33,8 +34,8 @@
   [content setUserInfo:userInfo];
   
   if (content.categoryIdentifier && _isInExpoGo) {
-    NSString *escapedExperienceId = [NSRegularExpression escapedPatternForString: _experienceId];
-    NSString *scopedCategoryIdentifier = [NSString stringWithFormat:@"%@/%@", escapedExperienceId, content.categoryIdentifier];
+    NSString *scopedCategoryIdentifier = [EXScopedNotificationsUtils scopedCategoryIdentifierWithId:content.categoryIdentifier
+                                                                                      forExperience:_experienceId];
     [content setCategoryIdentifier:scopedCategoryIdentifier];
   }
   

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationCategoriesModule.h
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationCategoriesModule.h
@@ -12,6 +12,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithExperienceId:(NSString *)experienceId
                  andConstantsBinding:(EXConstantsBinding *)constantsBinding;
 
++ (void)maybeMigrateLegacyCategoryIdentifiersForProject:(NSString *)experienceId
+                                             isInExpoGo:(BOOL)isInExpoGo;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationCategoriesModule.h
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationCategoriesModule.h
@@ -3,12 +3,14 @@
 #if __has_include(<EXNotifications/EXNotificationCategoriesModule.h>)
 
 #import <EXNotifications/EXNotificationCategoriesModule.h>
+#import "EXConstantsBinding.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface EXScopedNotificationCategoriesModule : EXNotificationCategoriesModule
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId;
+- (instancetype)initWithExperienceId:(NSString *)experienceId
+                 andConstantsBinding:(EXConstantsBinding *)constantsBinding;
 
 @end
 

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationCategoriesModule.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationCategoriesModule.m
@@ -75,10 +75,10 @@
 {
   if (isInExpoGo) {
     // Changed scoping prefix in SDK 41 FROM "experienceId-" to ESCAPED "experienceId/"
-    [EXScopedNotificationCategoryMigrator migrateCategoriesToNewScopingPrefix:experienceId];
+    [EXScopedNotificationCategoryMigrator migrateLegacyScopedCategoryIdentifiersForProject:experienceId];
   } else {
     // Used to prefix with "experienceId-" even in standalone apps in SDKs <= 40, so we need to unscope those
-    [EXScopedNotificationCategoryMigrator migrateCategoriesToUnscopedIdentifiers:experienceId];
+    [EXScopedNotificationCategoryMigrator unscopeLegacyCategoryIdentifiersForProject:experienceId];
   }
 }
 

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationCategoriesModule.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationCategoriesModule.m
@@ -69,7 +69,7 @@
   return serializedCategory;
 }
 
-#pragma mark - static method for migrating categories in both Expo Go and standalones. Added in SDK 41
+#pragma mark - static method for migrating categories in both Expo Go and standalones. Added in SDK 41. TODO(Cruzan): Remove in SDK 47
 
 + (void)maybeMigrateLegacyCategoryIdentifiersForProject:(NSString *)experienceId isInExpoGo:(BOOL)isInExpoGo
 {

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationCategoriesModule.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationCategoriesModule.m
@@ -7,7 +7,6 @@
 @interface EXScopedNotificationCategoriesModule ()
 
 @property (nonatomic, strong) NSString *experienceId;
-@property (nonatomic, assign) BOOL isInExpoGo;
 
 @end
 
@@ -18,34 +17,22 @@
 {
   if (self = [super init]) {
     _experienceId = experienceId;
-    _isInExpoGo = [@"expo" isEqualToString:constantsBinding.appOwnership];
-    if (_isInExpoGo) {
-      // Changed scoping prefix in SDK 41 FROM "experienceId-" to ESCAPED "experienceId/"
-      [EXScopedNotificationCategoryMigrator migrateCategoriesToNewScopingPrefix:experienceId];
-    } else {
-      // Used to prefix with "experienceId-" even in standalone apps in SDKs <= 40, so we need to unscope those
-      [EXScopedNotificationCategoryMigrator migrateCategoriesToUnscopedIdentifiers:experienceId];
-    }
   }
   return self;
 }
 
 - (void)getNotificationCategoriesAsyncWithResolver:(UMPromiseResolveBlock)resolve reject:(UMPromiseRejectBlock)reject
 {
-  if (_isInExpoGo) {
-    [[UNUserNotificationCenter currentNotificationCenter] getNotificationCategoriesWithCompletionHandler:^(NSSet<UNNotificationCategory *> *categories) {
-      NSMutableArray* existingCategories = [NSMutableArray new];
-      NSString *escapedExperienceId = [EXScopedNotificationsUtils escapedString:self->_experienceId];
-      for (UNNotificationCategory *category in categories) {
-        if ([category.identifier hasPrefix:escapedExperienceId]) {
-          [existingCategories addObject:[self serializeCategory:category]];
-        }
+  [[UNUserNotificationCenter currentNotificationCenter] getNotificationCategoriesWithCompletionHandler:^(NSSet<UNNotificationCategory *> *categories) {
+    NSMutableArray* existingCategories = [NSMutableArray new];
+    NSString *escapedExperienceId = [EXScopedNotificationsUtils escapedString:self->_experienceId];
+    for (UNNotificationCategory *category in categories) {
+      if ([category.identifier hasPrefix:escapedExperienceId]) {
+        [existingCategories addObject:[self serializeCategory:category]];
       }
-      resolve(existingCategories);
-    }];
-  } else {
-    [super getNotificationCategoriesAsyncWithResolver:resolve reject:reject];
-  }
+    }
+    resolve(existingCategories);
+  }];
 }
 
 - (void)setNotificationCategoryWithCategoryId:(NSString *)categoryId
@@ -56,7 +43,7 @@
 {
   NSString *scopedCategoryIdentifier = [EXScopedNotificationsUtils scopedCategoryIdentifierWithId:categoryId
                                                                                     forExperience:_experienceId];
-  [super setNotificationCategoryWithCategoryId:_isInExpoGo ? scopedCategoryIdentifier : categoryId
+  [super setNotificationCategoryWithCategoryId:scopedCategoryIdentifier
                                        actions:actions
                                        options:options
                                        resolve:resolve
@@ -69,7 +56,7 @@
 {
   NSString *scopedCategoryIdentifier = [EXScopedNotificationsUtils scopedCategoryIdentifierWithId:categoryId
                                                                                     forExperience:_experienceId];
-  [super deleteNotificationCategoryWithCategoryId: _isInExpoGo ? scopedCategoryIdentifier : categoryId
+  [super deleteNotificationCategoryWithCategoryId:scopedCategoryIdentifier
                                           resolve:resolve
                                            reject:reject];
 }
@@ -77,11 +64,22 @@
 - (NSMutableDictionary *)serializeCategory:(UNNotificationCategory *)category
 {
   NSMutableDictionary* serializedCategory = [EXNotificationCategoriesModule serializeCategory:category];
-  if (_isInExpoGo) {
-    serializedCategory[@"identifier"] = [EXScopedNotificationsUtils unscopedCategoryIdentifierWithId:serializedCategory[@"identifier"]
-                                                                                       forExperience:_experienceId];
-  }
+  serializedCategory[@"identifier"] = [EXScopedNotificationsUtils unscopedCategoryIdentifierWithId:serializedCategory[@"identifier"]
+                                                                                     forExperience:_experienceId];
   return serializedCategory;
+}
+
+#pragma mark - static method for migrating categories in both Expo Go and standalones. Added in SDK 41
+
++ (void)maybeMigrateLegacyCategoryIdentifiersForProject:(NSString *)experienceId isInExpoGo:(BOOL)isInExpoGo
+{
+  if (isInExpoGo) {
+    // Changed scoping prefix in SDK 41 FROM "experienceId-" to ESCAPED "experienceId/"
+    [EXScopedNotificationCategoryMigrator migrateCategoriesToNewScopingPrefix:experienceId];
+  } else {
+    // Used to prefix with "experienceId-" even in standalone apps in SDKs <= 40, so we need to unscope those
+    [EXScopedNotificationCategoryMigrator migrateCategoriesToUnscopedIdentifiers:experienceId];
+  }
 }
 
 @end

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationCategoriesModule.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationCategoriesModule.m
@@ -5,36 +5,79 @@
 @interface EXScopedNotificationCategoriesModule ()
 
 @property (nonatomic, strong) NSString *experienceId;
+@property (nonatomic, assign) BOOL isInExpoGo;
 
 @end
 
 @implementation EXScopedNotificationCategoriesModule
 
 - (instancetype)initWithExperienceId:(NSString *)experienceId
+                 andConstantsBinding:(EXConstantsBinding *)constantsBinding
 {
   if (self = [super init]) {
     _experienceId = experienceId;
+    _isInExpoGo = [@"expo" isEqualToString:constantsBinding.appOwnership];
+    if (!_isInExpoGo) {
+      // Used to prefix with "experienceId-" even in standalone apps in SDKs <= 40, so we need to unscope those
+      NSString *pattern = [NSString stringWithFormat:@"^%@-", self->_experienceId];
+      [self replaceAllCategoryIdPrefixesMatching:pattern withString:@""];
+    } else {
+      // Changed scoping prefix in SDK 41 FROM "experienceId-" TO "experienceId/"
+      NSString *pattern = [NSString stringWithFormat:@"^%@-", self->_experienceId];
+      [self replaceAllCategoryIdPrefixesMatching:pattern withString:[NSString stringWithFormat:@"%@/", _experienceId]];
+    }
   }
   return self;
 }
 
-- (void)getNotificationCategoriesAsyncWithResolver:(UMPromiseResolveBlock)resolve reject:(UMPromiseRejectBlock)reject
+- (void)replaceAllCategoryIdPrefixesMatching:(NSString *)pattern
+                                  withString:(NSString *)newPrefix
 {
   [[UNUserNotificationCenter currentNotificationCenter] getNotificationCategoriesWithCompletionHandler:^(NSSet<UNNotificationCategory *> *categories) {
-    NSMutableArray* existingCategories = [NSMutableArray new];
-    for (UNNotificationCategory *category in categories) {
-      if ([category.identifier hasPrefix:self->_experienceId]) {
-        [existingCategories addObject:[self serializeCategory:category]];
+    NSMutableSet<UNNotificationCategory *> *newCategories = [categories mutableCopy];
+    NSError *error = nil;
+    BOOL didChangeCategories = NO;
+    NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:pattern options:NSRegularExpressionCaseInsensitive error:&error];
+    for (UNNotificationCategory *previousCategory in categories) {
+      if ([regex firstMatchInString:previousCategory.identifier options:0 range:NSMakeRange(0, [previousCategory.identifier length])]) {
+        // Serialized categories do not contain the scoping prefix
+        NSMutableDictionary *serializedCategory = [self serializeCategory:previousCategory];
+        NSString *newCategoryId = [NSString stringWithFormat: @"%@%@", newPrefix, serializedCategory[@"identifier"]];
+        UNNotificationCategory *newCategory = [super createCategoryWithId:newCategoryId
+                                                                  actions:serializedCategory[@"actions"]
+                                                                  options:serializedCategory[@"options"]];
+        [newCategories removeObject:previousCategory];
+        [newCategories addObject:newCategory];
+        didChangeCategories = YES;
       }
     }
-    resolve(existingCategories);
+    if (didChangeCategories) {
+      [[UNUserNotificationCenter currentNotificationCenter] setNotificationCategories:newCategories];
+    }
   }];
+}
+
+- (void)getNotificationCategoriesAsyncWithResolver:(UMPromiseResolveBlock)resolve reject:(UMPromiseRejectBlock)reject
+{
+  if (_isInExpoGo) {
+    [[UNUserNotificationCenter currentNotificationCenter] getNotificationCategoriesWithCompletionHandler:^(NSSet<UNNotificationCategory *> *categories) {
+      NSMutableArray* existingCategories = [NSMutableArray new];
+      for (UNNotificationCategory *category in categories) {
+        if ([category.identifier hasPrefix:self->_experienceId]) {
+          [existingCategories addObject:[self serializeCategory:category]];
+        }
+      }
+      resolve(existingCategories);
+    }];
+  } else {
+    [super getNotificationCategoriesAsyncWithResolver:resolve reject:reject];
+  }
 }
 
 - (void)setNotificationCategoryWithCategoryId:(NSString *)categoryId
                                       actions:(NSArray *)actions
                                       options:(NSDictionary *)options
-                                      resolve:(UMPromiseResolveBlock)resolve 
+                                      resolve:(UMPromiseResolveBlock)resolve
                                        reject:(UMPromiseRejectBlock)reject
 {
   NSString *scopedCategoryIdentifier = [NSString stringWithFormat:@"%@/%@", _experienceId, categoryId];
@@ -42,7 +85,7 @@
 }
 
 - (void)deleteNotificationCategoryWithCategoryId:(NSString *)categoryId
-                                         resolve:(UMPromiseResolveBlock)resolve 
+                                         resolve:(UMPromiseResolveBlock)resolve
                                           reject:(UMPromiseRejectBlock)reject
 {
   NSString *scopedCategoryIdentifier = [NSString stringWithFormat:@"%@/%@", _experienceId, categoryId];
@@ -52,8 +95,10 @@
 - (NSMutableDictionary *)serializeCategory:(UNNotificationCategory *)category
 {
   NSMutableDictionary* serializedCategory = [NSMutableDictionary dictionary];
-  NSString* experienceIdPrefix = [NSString stringWithFormat:@"%@/", _experienceId];
-  serializedCategory[@"identifier"] = [category.identifier stringByReplacingOccurrencesOfString:experienceIdPrefix withString:@""];
+  NSString* scopingPrefixPattern = [NSString stringWithFormat:@"^%@(/|-)", _experienceId];
+  NSError *error = nil;
+  NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:scopingPrefixPattern options:NSRegularExpressionCaseInsensitive error:&error];
+  serializedCategory[@"identifier"] = [regex stringByReplacingMatchesInString:category.identifier options:0 range:NSMakeRange(0, [category.identifier length]) withTemplate:@""];
   serializedCategory[@"actions"] = [super serializeActions: category.actions];
   serializedCategory[@"options"] = [super serializeCategoryOptions: category];
   return serializedCategory;

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationCategoriesModule.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationCategoriesModule.m
@@ -1,6 +1,7 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
 #import "EXScopedNotificationCategoriesModule.h"
+#import "EXScopedNotificationCategoryMigrator.h"
 
 @interface EXScopedNotificationCategoriesModule ()
 
@@ -16,47 +17,17 @@
                  andConstantsBinding:(EXConstantsBinding *)constantsBinding
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
     _escapedExperienceId = [NSRegularExpression escapedPatternForString: experienceId];
     _isInExpoGo = [@"expo" isEqualToString:constantsBinding.appOwnership];
-    if (!_isInExpoGo) {
-      // Used to prefix with "experienceId-" even in standalone apps in SDKs <= 40, so we need to unscope those
-      NSString *pattern = [NSString stringWithFormat:@"^%@-", experienceId];
-      [self replaceAllCategoryIdPrefixesMatching:pattern withString:@""];
-    } else {
+    if (_isInExpoGo) {
       // Changed scoping prefix in SDK 41 FROM "experienceId-" to ESCAPED "experienceId/"
-      NSString *pattern = [NSString stringWithFormat:@"^%@-", experienceId];
-      [self replaceAllCategoryIdPrefixesMatching:pattern withString:[NSString stringWithFormat:@"%@/", _escapedExperienceId]];
+      [EXScopedNotificationCategoryMigrator migrateCategoriesToNewScopingPrefix:experienceId];
+    } else {
+      // Used to prefix with "experienceId-" even in standalone apps in SDKs <= 40, so we need to unscope those
+      [EXScopedNotificationCategoryMigrator migrateCategoriesToUnscopedIdentifiers:experienceId];
     }
   }
   return self;
-}
-
-- (void)replaceAllCategoryIdPrefixesMatching:(NSString *)pattern
-                                  withString:(NSString *)newPrefix
-{
-  [[UNUserNotificationCenter currentNotificationCenter] getNotificationCategoriesWithCompletionHandler:^(NSSet<UNNotificationCategory *> *categories) {
-    NSMutableSet<UNNotificationCategory *> *newCategories = [categories mutableCopy];
-    NSError *error = nil;
-    BOOL didChangeCategories = NO;
-    NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:pattern options:NSRegularExpressionCaseInsensitive error:&error];
-    for (UNNotificationCategory *previousCategory in categories) {
-      if ([regex firstMatchInString:previousCategory.identifier options:0 range:NSMakeRange(0, [previousCategory.identifier length])]) {
-        // Serialized categories do not contain the scoping prefix
-        NSMutableDictionary *serializedCategory = [self serializeLegacyCategory:previousCategory];
-        NSString *newCategoryId = [NSString stringWithFormat: @"%@%@", newPrefix, serializedCategory[@"identifier"]];
-        UNNotificationCategory *newCategory = [super createCategoryWithId:newCategoryId
-                                                                  actions:serializedCategory[@"actions"]
-                                                                  options:serializedCategory[@"options"]];
-        [newCategories removeObject:previousCategory];
-        [newCategories addObject:newCategory];
-        didChangeCategories = YES;
-      }
-    }
-    if (didChangeCategories) {
-      [[UNUserNotificationCenter currentNotificationCenter] setNotificationCategories:newCategories];
-    }
-  }];
 }
 
 - (void)getNotificationCategoriesAsyncWithResolver:(UMPromiseResolveBlock)resolve reject:(UMPromiseRejectBlock)reject
@@ -102,21 +73,8 @@
   NSError *error = nil;
   NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:scopingPrefixPattern options:NSRegularExpressionCaseInsensitive error:&error];
   serializedCategory[@"identifier"] = [regex stringByReplacingMatchesInString:category.identifier options:0 range:NSMakeRange(0, [category.identifier length]) withTemplate:@""];
-  serializedCategory[@"actions"] = [super serializeActions: category.actions];
-  serializedCategory[@"options"] = [super serializeCategoryOptions: category];
-  return serializedCategory;
-}
-
-// legacy categories were stored under an unescaped experienceId
-- (NSMutableDictionary *)serializeLegacyCategory:(UNNotificationCategory *)category
-{
-  NSMutableDictionary* serializedCategory = [NSMutableDictionary dictionary];
-  NSString* scopingPrefixPattern = [NSString stringWithFormat:@"^%@(/|-)", [NSRegularExpression escapedPatternForString: _experienceId]];
-  NSError *error = nil;
-  NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:scopingPrefixPattern options:NSRegularExpressionCaseInsensitive error:&error];
-  serializedCategory[@"identifier"] = [regex stringByReplacingMatchesInString:category.identifier options:0 range:NSMakeRange(0, [category.identifier length]) withTemplate:@""];
-  serializedCategory[@"actions"] = [super serializeActions: category.actions];
-  serializedCategory[@"options"] = [super serializeCategoryOptions: category];
+  serializedCategory[@"actions"] = [EXNotificationCategoriesModule serializeActions: category.actions];
+  serializedCategory[@"options"] = [EXNotificationCategoriesModule serializeCategoryOptions: category];
   return serializedCategory;
 }
 

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationCategoryMigrator.h
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationCategoryMigrator.h
@@ -5,7 +5,7 @@
 
 @interface EXScopedNotificationCategoryMigrator : NSObject <EXNotificationsDelegate>
 
-+ (void)migrateCategoriesToUnscopedIdentifiers:(NSString *)experienceId;
-+ (void)migrateCategoriesToNewScopingPrefix:(NSString *)experienceId;
++ (void)unscopeLegacyCategoryIdentifiersForProject:(NSString *)experienceId;
++ (void)migrateLegacyScopedCategoryIdentifiersForProject:(NSString *)experienceId;
 
 @end

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationCategoryMigrator.h
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationCategoryMigrator.h
@@ -1,0 +1,11 @@
+// Copyright 2021-present 650 Industries. All rights reserved.
+
+#import <EXNotifications/EXNotificationsDelegate.h>
+#import <EXNotifications/EXNotificationCategoriesModule.h>
+
+@interface EXScopedNotificationCategoryMigrator : NSObject <EXNotificationsDelegate>
+
++ (void)migrateCategoriesToUnscopedIdentifiers:(NSString *)experienceId;
++ (void)migrateCategoriesToNewScopingPrefix:(NSString *)experienceId;
+
+@end

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationCategoryMigrator.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationCategoryMigrator.m
@@ -56,7 +56,7 @@
                                 withExperienceId:(NSString *) experienceId
 {
   NSMutableDictionary* serializedCategory = [NSMutableDictionary dictionary];
-  NSString* scopingPrefixPattern = [NSString stringWithFormat:@"^%@(/|-)", [NSRegularExpression escapedPatternForString: experienceId]];
+  NSString* scopingPrefixPattern = [NSString stringWithFormat:@"^%@-", [NSRegularExpression escapedPatternForString: experienceId]];
   NSError *error = nil;
   NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:scopingPrefixPattern options:NSRegularExpressionCaseInsensitive error:&error];
   serializedCategory[@"identifier"] = [regex stringByReplacingMatchesInString:category.identifier options:0 range:NSMakeRange(0, [category.identifier length]) withTemplate:@""];

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationCategoryMigrator.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationCategoryMigrator.m
@@ -7,7 +7,7 @@
 
 + (void)migrateCategoriesToNewScopingPrefix:(NSString *)experienceId
 {
-  NSString *prefixToReplace = [NSString stringWithFormat:@"^%@-", experienceId];
+  NSString *prefixToReplace = [NSString stringWithFormat:@"%@-", experienceId];
   NSString *escapedExperienceId = [EXScopedNotificationsUtils escapedString:experienceId];
   NSString *newScopingPrefix = [NSString stringWithFormat:@"%@/", escapedExperienceId];
   [EXScopedNotificationCategoryMigrator replaceAllCategoryIdPrefixesMatching:prefixToReplace
@@ -17,23 +17,21 @@
 
 + (void)migrateCategoriesToUnscopedIdentifiers:(NSString *)experienceId
 {
-  NSString *prefixToReplace = [NSString stringWithFormat:@"^%@-", experienceId];
+  NSString *prefixToReplace = [NSString stringWithFormat:@"%@-", experienceId];
   [EXScopedNotificationCategoryMigrator replaceAllCategoryIdPrefixesMatching:prefixToReplace
                                                                           withString:@""
                                                                        forExperience:experienceId];
 }
 
-+ (void)replaceAllCategoryIdPrefixesMatching:(NSString *)pattern
++ (void)replaceAllCategoryIdPrefixesMatching:(NSString *)oldPrefix
                                   withString:(NSString *)newPrefix
                                forExperience:(NSString *)experienceId
 {
   [[UNUserNotificationCenter currentNotificationCenter] getNotificationCategoriesWithCompletionHandler:^(NSSet<UNNotificationCategory *> *categories) {
     NSMutableSet<UNNotificationCategory *> *newCategories = [categories mutableCopy];
-    NSError *error = nil;
     BOOL didChangeCategories = NO;
-    NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:pattern options:NSRegularExpressionCaseInsensitive error:&error];
     for (UNNotificationCategory *previousCategory in categories) {
-      if ([regex firstMatchInString:previousCategory.identifier options:0 range:NSMakeRange(0, [previousCategory.identifier length])]) {
+      if ([previousCategory.identifier containsString:oldPrefix]) {
         // Serialized categories do not contain the scoping prefix
         NSMutableDictionary *serializedCategory = [self serializeLegacyCategory:previousCategory
                                                                withExperienceId:experienceId];

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationCategoryMigrator.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationCategoryMigrator.m
@@ -1,0 +1,68 @@
+// Copyright 2021-present 650 Industries. All rights reserved.
+
+#import "EXScopedNotificationCategoryMigrator.h"
+
+@implementation EXScopedNotificationCategoryMigrator
+
++ (void)migrateCategoriesToNewScopingPrefix:(NSString *)experienceId
+{
+  NSString *prefixToReplace = [NSString stringWithFormat:@"^%@-", experienceId];
+  NSString *escapedExperienceId = [NSRegularExpression escapedPatternForString:experienceId];
+  NSString *newScopingPrefix = [NSString stringWithFormat:@"%@/", escapedExperienceId];
+  [EXScopedNotificationCategoryMigrator replaceAllCategoryIdPrefixesMatching:prefixToReplace
+                                                                          withString:newScopingPrefix
+                                                                       forExperience:experienceId];
+}
+
++ (void)migrateCategoriesToUnscopedIdentifiers:(NSString *)experienceId
+{
+  NSString *prefixToReplace = [NSString stringWithFormat:@"^%@-", experienceId];
+  [EXScopedNotificationCategoryMigrator replaceAllCategoryIdPrefixesMatching:prefixToReplace
+                                                                          withString:@""
+                                                                       forExperience:experienceId];
+}
+
++ (void)replaceAllCategoryIdPrefixesMatching:(NSString *)pattern
+                                  withString:(NSString *)newPrefix
+                               forExperience:(NSString *)experienceId<
+{
+  [[UNUserNotificationCenter currentNotificationCenter] getNotificationCategoriesWithCompletionHandler:^(NSSet<UNNotificationCategory *> *categories) {
+    NSMutableSet<UNNotificationCategory *> *newCategories = [categories mutableCopy];
+    NSError *error = nil;
+    BOOL didChangeCategories = NO;
+    NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:pattern options:NSRegularExpressionCaseInsensitive error:&error];
+    for (UNNotificationCategory *previousCategory in categories) {
+      if ([regex firstMatchInString:previousCategory.identifier options:0 range:NSMakeRange(0, [previousCategory.identifier length])]) {
+        // Serialized categories do not contain the scoping prefix
+        NSMutableDictionary *serializedCategory = [self serializeLegacyCategory:previousCategory
+                                                               withExperienceId:experienceId];
+        NSString *newCategoryId = [NSString stringWithFormat: @"%@%@", newPrefix, serializedCategory[@"identifier"]];
+        UNNotificationCategory *newCategory = [EXNotificationCategoriesModule createCategoryWithId:newCategoryId
+                                                                                           actions:serializedCategory[@"actions"]
+                                                                                           options:serializedCategory[@"options"]];
+        [newCategories removeObject:previousCategory];
+        [newCategories addObject:newCategory];
+        didChangeCategories = YES;
+      }
+    }
+    if (didChangeCategories) {
+      [[UNUserNotificationCenter currentNotificationCenter] setNotificationCategories:newCategories];
+    }
+  }];
+}
+
+// legacy categories were stored under an unescaped experienceId
++ (NSMutableDictionary *)serializeLegacyCategory:(UNNotificationCategory *)category
+                                withExperienceId:(NSString *) experienceId
+{
+  NSMutableDictionary* serializedCategory = [NSMutableDictionary dictionary];
+  NSString* scopingPrefixPattern = [NSString stringWithFormat:@"^%@(/|-)", [NSRegularExpression escapedPatternForString: experienceId]];
+  NSError *error = nil;
+  NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:scopingPrefixPattern options:NSRegularExpressionCaseInsensitive error:&error];
+  serializedCategory[@"identifier"] = [regex stringByReplacingMatchesInString:category.identifier options:0 range:NSMakeRange(0, [category.identifier length]) withTemplate:@""];
+  serializedCategory[@"actions"] = [EXNotificationCategoriesModule serializeActions: category.actions];
+  serializedCategory[@"options"] = [EXNotificationCategoriesModule serializeCategoryOptions: category];
+  return serializedCategory;
+}
+
+@end

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationCategoryMigrator.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationCategoryMigrator.m
@@ -14,7 +14,6 @@
     UNNotificationCategory *newCategory = [EXScopedNotificationCategoryMigrator createNewCategoryFrom:oldCategory withNewIdentifier:newCategoryId];
     return newCategory;
   }];
-  
 }
 
 + (void)unscopeLegacyCategoryIdentifiersForProject:(NSString *)experienceId

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationCategoryMigrator.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationCategoryMigrator.m
@@ -8,9 +8,9 @@
 + (void)migrateLegacyScopedCategoryIdentifiersForProject:(NSString *)experienceId
 {
   NSString *prefixToReplace = [NSString stringWithFormat:@"%@-", experienceId];
-  [EXScopedNotificationCategoryMigrator renameCategoryIdentifiersWithPrefix:prefixToReplace withBlock:^(UNNotificationCategory *oldCategory){
-    NSString *oldCategoryId = [EXScopedNotificationsUtils unscopedLegacyCategoryIdentifierWithId:oldCategory.identifier forExperience:experienceId];
-    NSString *newCategoryId = [EXScopedNotificationsUtils scopedCategoryIdentifierWithId:oldCategoryId forExperience:experienceId];
+  [EXScopedNotificationCategoryMigrator renameCategoryIdentifiersWithPrefix:prefixToReplace withBlock:^(UNNotificationCategory *oldCategory) {
+    NSString *unscopedLegacyCategoryId = [EXScopedNotificationsUtils unscopedLegacyCategoryIdentifierWithId:oldCategory.identifier forExperience:experienceId];
+    NSString *newCategoryId = [EXScopedNotificationsUtils scopedCategoryIdentifierWithId:unscopedLegacyCategoryId forExperience:experienceId];
     UNNotificationCategory *newCategory = [EXScopedNotificationCategoryMigrator createNewCategoryFrom:oldCategory withNewIdentifier:newCategoryId];
     return newCategory;
   }];
@@ -19,7 +19,7 @@
 + (void)unscopeLegacyCategoryIdentifiersForProject:(NSString *)experienceId
 {
   NSString *prefixToReplace = [NSString stringWithFormat:@"%@-", experienceId];
-  [EXScopedNotificationCategoryMigrator renameCategoryIdentifiersWithPrefix:prefixToReplace withBlock:^(UNNotificationCategory *oldCategory){
+  [EXScopedNotificationCategoryMigrator renameCategoryIdentifiersWithPrefix:prefixToReplace withBlock:^(UNNotificationCategory *oldCategory) {
     NSString *unscopedCategoryId = [EXScopedNotificationsUtils unscopedLegacyCategoryIdentifierWithId:oldCategory.identifier forExperience:experienceId];
     UNNotificationCategory *newCategory = [EXScopedNotificationCategoryMigrator createNewCategoryFrom:oldCategory withNewIdentifier:unscopedCategoryId];
     return newCategory;
@@ -49,22 +49,22 @@
 {
   if (@available(iOS 12, *)) {
     return [UNNotificationCategory categoryWithIdentifier:newCategoryId
-                                                         actions:originalCategory.actions
-                                               intentIdentifiers:originalCategory.intentIdentifiers
-                                   hiddenPreviewsBodyPlaceholder:originalCategory.hiddenPreviewsBodyPlaceholder
-                                           categorySummaryFormat:originalCategory.categorySummaryFormat
-                                                         options:originalCategory.options];
+                                                  actions:originalCategory.actions
+                                        intentIdentifiers:originalCategory.intentIdentifiers
+                            hiddenPreviewsBodyPlaceholder:originalCategory.hiddenPreviewsBodyPlaceholder
+                                    categorySummaryFormat:originalCategory.categorySummaryFormat
+                                                  options:originalCategory.options];
   } else if (@available(iOS 11, *)) {
     return [UNNotificationCategory categoryWithIdentifier:newCategoryId
-                                                         actions:originalCategory.actions
-                                               intentIdentifiers:originalCategory.intentIdentifiers
-                                   hiddenPreviewsBodyPlaceholder:originalCategory.hiddenPreviewsBodyPlaceholder
-                                                         options:originalCategory.options];
+                                                  actions:originalCategory.actions
+                                        intentIdentifiers:originalCategory.intentIdentifiers
+                            hiddenPreviewsBodyPlaceholder:originalCategory.hiddenPreviewsBodyPlaceholder
+                                                  options:originalCategory.options];
   } else {
     return [UNNotificationCategory categoryWithIdentifier:newCategoryId
-                                                         actions:originalCategory.actions
-                                               intentIdentifiers:originalCategory.intentIdentifiers
-                                                         options:originalCategory.options];
+                                                  actions:originalCategory.actions
+                                        intentIdentifiers:originalCategory.intentIdentifiers
+                                                  options:originalCategory.options];
   }
 }
 

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationSerializer.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationSerializer.m
@@ -37,7 +37,8 @@ NS_ASSUME_NONNULL_BEGIN
 {
   NSString *experienceId = userInfo[@"experienceId"] ?: [NSNull null];
   if (experienceId) {
-    NSString *scopedCategoryPrefix = [NSString stringWithFormat:@"%@/", experienceId];
+    NSString *escapedExperienceId = [NSRegularExpression escapedPatternForString: experienceId];
+    NSString *scopedCategoryPrefix = [NSString stringWithFormat:@"%@/", escapedExperienceId];
     return [identifier stringByReplacingOccurrencesOfString:scopedCategoryPrefix withString:@""];
   }
   return identifier;

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationSerializer.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationSerializer.m
@@ -1,6 +1,7 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
 #import "EXScopedNotificationSerializer.h"
+#import "EXScopedNotificationsUtils.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -37,9 +38,8 @@ NS_ASSUME_NONNULL_BEGIN
 {
   NSString *experienceId = userInfo[@"experienceId"] ?: [NSNull null];
   if (experienceId) {
-    NSString *escapedExperienceId = [NSRegularExpression escapedPatternForString: experienceId];
-    NSString *scopedCategoryPrefix = [NSString stringWithFormat:@"%@/", escapedExperienceId];
-    return [identifier stringByReplacingOccurrencesOfString:scopedCategoryPrefix withString:@""];
+    return [EXScopedNotificationsUtils unscopedCategoryIdentifierWithId:identifier
+                                                          forExperience:experienceId];
   }
   return identifier;
 }

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationsUtils.h
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationsUtils.h
@@ -10,6 +10,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (BOOL)shouldNotification:(UNNotification *)notification beHandledByExperience:(NSString *)experienceId;
 
++ (NSString *)scopedCategoryIdentifierWithId:(NSString *)categoryId forExperience:(NSString *)experienceId;
+
++ (NSString *)unscopedCategoryIdentifierWithId:(NSString *)scopedCategoryId forExperience:(NSString *)experienceId;
+
++ (NSString *)escapedString:(NSString*)string;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationsUtils.h
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationsUtils.h
@@ -16,6 +16,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (NSString *)escapedString:(NSString*)string;
 
++ (NSString *)unscopedLegacyCategoryIdentifierWithId:(NSString *) scopedCategoryId forExperience:(NSString *) experienceId;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationsUtils.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationsUtils.m
@@ -20,7 +20,7 @@
 
 + (NSString *)scopedCategoryIdentifierWithId:(NSString *)categoryId forExperience:(NSString *)experienceId
 {
-  NSString *escapedExperienceId = [EXScopedNotificationsUtils escapedString: experienceId];
+  NSString *escapedExperienceId = [EXScopedNotificationsUtils escapedString:experienceId];
   NSString *escapedCategoryId = [EXScopedNotificationsUtils escapedString:categoryId];
   return [NSString stringWithFormat:@"%@/%@", escapedExperienceId, escapedCategoryId];
 }
@@ -30,15 +30,22 @@
   NSString* scopingPrefix = [NSString stringWithFormat:@"%@/", [EXScopedNotificationsUtils escapedString:experienceId]];
   NSString* unscopedEscapedCategoryId = [scopedCategoryId stringByReplacingOccurrencesOfString:scopingPrefix
                                                                                     withString:@""];
-  // We are certain that this string was already percent encoded
-  return [unscopedEscapedCategoryId stringByRemovingPercentEncoding];
+  return [EXScopedNotificationsUtils unescapedString:unscopedEscapedCategoryId];
 }
 
 + (NSString *)escapedString:(NSString*)string
 {
-  NSString *charactersToEscape = @"!*'();:@&=+$,/?%#[]";
-  NSCharacterSet *allowedCharacters = [[NSCharacterSet characterSetWithCharactersInString:charactersToEscape] invertedSet];
-  return [string stringByAddingPercentEncodingWithAllowedCharacters:allowedCharacters];
+  return [NSRegularExpression escapedPatternForString:string];
+}
+
++ (NSString *)unescapedString:(NSString*)string
+{
+  NSMutableString* mutableString = [string mutableCopy];
+  NSSet *escapedCharacters = [NSSet setWithArray:@[@"*",@"?",@"+",@"[",@"(",@")",@"{",@"}",@"^",@"$",@"|",@"\\",@".",@"/"]];
+  for (NSString *character in escapedCharacters) {
+    mutableString = [[mutableString stringByReplacingOccurrencesOfString: [NSString stringWithFormat:@"\\%@", character] withString:character] mutableCopy];
+  }
+  return mutableString;
 }
 
 // legacy categories were stored under an unescaped experienceId

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationsUtils.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationsUtils.m
@@ -18,4 +18,27 @@
   return [EXScopedNotificationsUtils shouldNotificationRequest:notification.request beHandledByExperience:experienceId];
 }
 
++ (NSString *)scopedCategoryIdentifierWithId:(NSString *)categoryId forExperience:(NSString *)experienceId
+{
+  NSString *escapedExperienceId = [EXScopedNotificationsUtils escapedString: experienceId];
+  NSString *escapedCategoryId = [EXScopedNotificationsUtils escapedString:categoryId];
+  return [NSString stringWithFormat:@"%@/%@", escapedExperienceId, escapedCategoryId];
+}
+
++ (NSString *)unscopedCategoryIdentifierWithId:(NSString *)scopedCategoryId forExperience:(NSString *)experienceId
+{
+  NSString* scopingPrefix = [NSString stringWithFormat:@"%@/", [EXScopedNotificationsUtils escapedString:experienceId]];
+  NSString* unscopedEscapedCategoryId = [scopedCategoryId stringByReplacingOccurrencesOfString:scopingPrefix
+                                                                                    withString:@""];
+  // We are certain that this string was already percent encoded
+  return [unscopedEscapedCategoryId stringByRemovingPercentEncoding];
+}
+
++ (NSString *)escapedString:(NSString*)string
+{
+  NSString *charactersToEscape = @"!*'();:@&=+$,/?%#[]";
+  NSCharacterSet *allowedCharacters = [[NSCharacterSet characterSetWithCharactersInString:charactersToEscape] invertedSet];
+  return [string stringByAddingPercentEncodingWithAllowedCharacters:allowedCharacters];
+}
+
 @end

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationsUtils.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationsUtils.m
@@ -35,17 +35,12 @@
 
 + (NSString *)escapedString:(NSString*)string
 {
-  return [NSRegularExpression escapedPatternForString:string];
+  return [string stringByReplacingOccurrencesOfString:@"/" withString:@"\\/"];
 }
 
 + (NSString *)unescapedString:(NSString*)string
 {
-  NSMutableString* mutableString = [string mutableCopy];
-  NSSet *escapedCharacters = [NSSet setWithArray:@[@"*",@"?",@"+",@"[",@"(",@")",@"{",@"}",@"^",@"$",@"|",@"\\",@".",@"/"]];
-  for (NSString *character in escapedCharacters) {
-    mutableString = [[mutableString stringByReplacingOccurrencesOfString: [NSString stringWithFormat:@"\\%@", character] withString:character] mutableCopy];
-  }
-  return mutableString;
+  return [string stringByReplacingOccurrencesOfString:@"\\/" withString:@"/"];
 }
 
 // legacy categories were stored under an unescaped experienceId

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationsUtils.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationsUtils.m
@@ -41,4 +41,12 @@
   return [string stringByAddingPercentEncodingWithAllowedCharacters:allowedCharacters];
 }
 
+// legacy categories were stored under an unescaped experienceId
++ (NSString *)unscopedLegacyCategoryIdentifierWithId:(NSString *) scopedCategoryId
+                                       forExperience:(NSString *) experienceId
+{
+  NSString* legacyScopingPrefix = [NSString stringWithFormat:@"%@-", experienceId];
+  return [scopedCategoryId stringByReplacingOccurrencesOfString:legacyScopingPrefix withString:@""];
+}
+
 @end

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXScopedModuleRegistryAdapter.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXScopedModuleRegistryAdapter.m
@@ -170,11 +170,8 @@
 #endif
   
 #if __has_include(<EXNotifications/EXNotificationCategoriesModule.h>)
-  // only override in Expo Go
-  if ([params[@"constants"][@"appOwnership"] isEqualToString:@"expo"]) {
-    EXScopedNotificationCategoriesModule *scopedCategoriesModule = [[EXScopedNotificationCategoriesModule alloc] initWithExperienceId:experienceId];
-    [moduleRegistry registerExportedModule:scopedCategoriesModule];
-  }
+  EXScopedNotificationCategoriesModule *scopedCategoriesModule = [[EXScopedNotificationCategoriesModule alloc] initWithExperienceId:experienceId andConstantsBinding:constantsBinding];
+  [moduleRegistry registerExportedModule:scopedCategoriesModule];
 #endif
   
 #if __has_include(<EXNotifications/EXServerRegistrationModule.h>)

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXScopedModuleRegistryAdapter.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXScopedModuleRegistryAdapter.m
@@ -160,8 +160,11 @@
 #endif
   
 #if __has_include(<EXNotifications/EXNotificationSchedulerModule.h>)
-  EXScopedNotificationSchedulerModule *schedulerModule = [[EXScopedNotificationSchedulerModule alloc] initWithExperienceId:experienceId];
-  [moduleRegistry registerExportedModule:schedulerModule];
+  // only override in Expo Go
+  if ([params[@"constants"][@"appOwnership"] isEqualToString:@"expo"]) {
+    EXScopedNotificationSchedulerModule *schedulerModule = [[EXScopedNotificationSchedulerModule alloc] initWithExperienceId:experienceId];
+    [moduleRegistry registerExportedModule:schedulerModule];
+  }
 #endif
     
 #if __has_include(<EXNotifications/EXNotificationPresentationModule.h>)

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXScopedModuleRegistryAdapter.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXScopedModuleRegistryAdapter.m
@@ -173,6 +173,7 @@
 #endif
   
 #if __has_include(<EXNotifications/EXNotificationCategoriesModule.h>)
+  // only override in Expo Go
   if ([params[@"constants"][@"appOwnership"] isEqualToString:@"expo"]) {
     EXScopedNotificationCategoriesModule *scopedCategoriesModule = [[EXScopedNotificationCategoriesModule alloc] initWithExperienceId:experienceId andConstantsBinding:constantsBinding];
     [moduleRegistry registerExportedModule:scopedCategoriesModule];

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXScopedModuleRegistryAdapter.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXScopedModuleRegistryAdapter.m
@@ -173,8 +173,12 @@
 #endif
   
 #if __has_include(<EXNotifications/EXNotificationCategoriesModule.h>)
-  EXScopedNotificationCategoriesModule *scopedCategoriesModule = [[EXScopedNotificationCategoriesModule alloc] initWithExperienceId:experienceId andConstantsBinding:constantsBinding];
-  [moduleRegistry registerExportedModule:scopedCategoriesModule];
+  if ([params[@"constants"][@"appOwnership"] isEqualToString:@"expo"]) {
+    EXScopedNotificationCategoriesModule *scopedCategoriesModule = [[EXScopedNotificationCategoriesModule alloc] initWithExperienceId:experienceId andConstantsBinding:constantsBinding];
+    [moduleRegistry registerExportedModule:scopedCategoriesModule];
+  }
+  [EXScopedNotificationCategoriesModule maybeMigrateLegacyCategoryIdentifiersForProject:experienceId
+                                                                             isInExpoGo:[params[@"constants"][@"appOwnership"] isEqualToString:@"expo"]];
 #endif
   
 #if __has_include(<EXNotifications/EXServerRegistrationModule.h>)

--- a/packages/expo-notifications/ios/EXNotifications/Notifications/Categories/EXNotificationCategoriesModule.h
+++ b/packages/expo-notifications/ios/EXNotifications/Notifications/Categories/EXNotificationCategoriesModule.h
@@ -14,11 +14,11 @@
 - (void)deleteNotificationCategoryWithCategoryId:(NSString *)categoryId
                                          resolve:(UMPromiseResolveBlock)resolve 
                                           reject:(UMPromiseRejectBlock)reject;
-- (UNNotificationCategory *)createCategoryWithId:(NSString*)categoryId
++ (UNNotificationCategory *)createCategoryWithId:(NSString*)categoryId
                                          actions:(NSArray *)actions
                                          options:(NSDictionary *)options;
-- (NSMutableDictionary *)serializeCategoryOptions:(UNNotificationCategory *)category;
-- (NSMutableArray *)serializeActions:(NSArray<UNNotificationAction *>*)actions;
-- (NSMutableDictionary *)serializeActionOptions:(NSUInteger)options;
++ (NSMutableDictionary *)serializeCategoryOptions:(UNNotificationCategory *)category;
++ (NSMutableArray *)serializeActions:(NSArray<UNNotificationAction *>*)actions;
++ (NSMutableDictionary *)serializeActionOptions:(NSUInteger)options;
 
 @end

--- a/packages/expo-notifications/ios/EXNotifications/Notifications/Categories/EXNotificationCategoriesModule.h
+++ b/packages/expo-notifications/ios/EXNotifications/Notifications/Categories/EXNotificationCategoriesModule.h
@@ -14,6 +14,10 @@
 - (void)deleteNotificationCategoryWithCategoryId:(NSString *)categoryId
                                          resolve:(UMPromiseResolveBlock)resolve 
                                           reject:(UMPromiseRejectBlock)reject;
+
+- (UNNotificationCategory *)createCategoryWithId:(NSString*)categoryId
+                                         actions:(NSArray *)actions
+                                         options:(NSDictionary *)options;
 - (NSMutableDictionary *)serializeCategoryOptions:(UNNotificationCategory *)category;
 - (NSMutableArray *)serializeActions:(NSArray<UNNotificationAction *>*)actions;
 - (NSMutableDictionary *)serializeActionOptions:(NSUInteger)options;

--- a/packages/expo-notifications/ios/EXNotifications/Notifications/Categories/EXNotificationCategoriesModule.h
+++ b/packages/expo-notifications/ios/EXNotifications/Notifications/Categories/EXNotificationCategoriesModule.h
@@ -17,6 +17,7 @@
 + (UNNotificationCategory *)createCategoryWithId:(NSString*)categoryId
                                          actions:(NSArray *)actions
                                          options:(NSDictionary *)options;
++ (NSMutableDictionary *)serializeCategory:(UNNotificationCategory *)category;
 + (NSMutableDictionary *)serializeCategoryOptions:(UNNotificationCategory *)category;
 + (NSMutableArray *)serializeActions:(NSArray<UNNotificationAction *>*)actions;
 + (NSMutableDictionary *)serializeActionOptions:(NSUInteger)options;

--- a/packages/expo-notifications/ios/EXNotifications/Notifications/Categories/EXNotificationCategoriesModule.h
+++ b/packages/expo-notifications/ios/EXNotifications/Notifications/Categories/EXNotificationCategoriesModule.h
@@ -14,7 +14,6 @@
 - (void)deleteNotificationCategoryWithCategoryId:(NSString *)categoryId
                                          resolve:(UMPromiseResolveBlock)resolve 
                                           reject:(UMPromiseRejectBlock)reject;
-
 - (UNNotificationCategory *)createCategoryWithId:(NSString*)categoryId
                                          actions:(NSArray *)actions
                                          options:(NSDictionary *)options;

--- a/packages/expo-notifications/ios/EXNotifications/Notifications/Categories/EXNotificationCategoriesModule.m
+++ b/packages/expo-notifications/ios/EXNotifications/Notifications/Categories/EXNotificationCategoriesModule.m
@@ -15,7 +15,7 @@ UM_EXPORT_METHOD_AS(getNotificationCategoriesAsync,
   [[UNUserNotificationCenter currentNotificationCenter] getNotificationCategoriesWithCompletionHandler:^(NSSet<UNNotificationCategory *> *categories) {
     NSMutableArray* existingCategories = [NSMutableArray new];
     for (UNNotificationCategory *category in categories) {
-      [existingCategories addObject:[self serializeCategory:category]];
+      [existingCategories addObject:[EXNotificationCategoriesModule serializeCategory:category]];
     }
     resolve(existingCategories);
   }];
@@ -27,7 +27,9 @@ UM_EXPORT_METHOD_AS(setNotificationCategoryAsync,
                  options:(NSDictionary *)options
                  resolve:(UMPromiseResolveBlock)resolve reject:(UMPromiseRejectBlock)reject)
 {
-  UNNotificationCategory *newCategory = [self createCategoryWithId:categoryId actions:actions options:options];
+  UNNotificationCategory *newCategory = [EXNotificationCategoriesModule createCategoryWithId:categoryId
+                                                                                     actions:actions
+                                                                                     options:options];
   
   [[UNUserNotificationCenter currentNotificationCenter] getNotificationCategoriesWithCompletionHandler:^(NSSet<UNNotificationCategory *> *categories) {
     NSMutableSet<UNNotificationCategory *> *newCategories = [categories mutableCopy] ?: [[NSMutableSet alloc] init];
@@ -39,7 +41,7 @@ UM_EXPORT_METHOD_AS(setNotificationCategoryAsync,
     }
     [newCategories addObject:newCategory];
     [[UNUserNotificationCenter currentNotificationCenter] setNotificationCategories:newCategories];
-    resolve([self serializeCategory:newCategory]);
+    resolve([EXNotificationCategoriesModule serializeCategory:newCategory]);
   }];
 }
 
@@ -64,7 +66,7 @@ UM_EXPORT_METHOD_AS(deleteNotificationCategoryAsync,
 
 # pragma mark- Internal
 
-- (UNNotificationCategory *)createCategoryWithId:(NSString*)categoryId
++ (UNNotificationCategory *)createCategoryWithId:(NSString*)categoryId
                                          actions:(NSArray *)actions
                                          options:(NSDictionary *)options
 {
@@ -100,7 +102,7 @@ UM_EXPORT_METHOD_AS(deleteNotificationCategoryAsync,
   return newCategory;
 }
 
-- (UNNotificationAction *)parseNotificationActionFromParams:(NSDictionary *)params
++ (UNNotificationAction *)parseNotificationActionFromParams:(NSDictionary *)params
 {
   NSString *identifier = params[@"identifier"];
   NSString *buttonTitle = params[@"buttonTitle"];
@@ -127,7 +129,7 @@ UM_EXPORT_METHOD_AS(deleteNotificationCategoryAsync,
   return [UNNotificationAction actionWithIdentifier:identifier title:buttonTitle options:options];
 }
 
-- (UNNotificationCategoryOptions )parseNotificationCategoryOptionsFromParams:(NSDictionary *)params
++ (UNNotificationCategoryOptions )parseNotificationCategoryOptionsFromParams:(NSDictionary *)params
 {
   UNNotificationCategoryOptions options = UNNotificationCategoryOptionNone;
   if ([params[@"customDismissAction"] boolValue]) {
@@ -153,7 +155,7 @@ UM_EXPORT_METHOD_AS(deleteNotificationCategoryAsync,
   return options;
 }
 
-- (NSMutableDictionary *)serializeCategory:(UNNotificationCategory *)category
++ (NSMutableDictionary *)serializeCategory:(UNNotificationCategory *)category
 {
   NSMutableDictionary* serializedCategory = [NSMutableDictionary dictionary];
   serializedCategory[@"identifier"] = category.identifier;
@@ -162,7 +164,7 @@ UM_EXPORT_METHOD_AS(deleteNotificationCategoryAsync,
   return serializedCategory;
 }
 
-- (NSMutableDictionary *)serializeCategoryOptions:(UNNotificationCategory *)category
++ (NSMutableDictionary *)serializeCategoryOptions:(UNNotificationCategory *)category
 {
   NSMutableDictionary* serializedOptions = [NSMutableDictionary dictionary];
   serializedOptions[@"intentIdentifiers"] = category.intentIdentifiers;
@@ -182,7 +184,7 @@ UM_EXPORT_METHOD_AS(deleteNotificationCategoryAsync,
   return serializedOptions;
 }
 
-- (NSMutableArray *)serializeActions:(NSArray<UNNotificationAction *>*)actions
++ (NSMutableArray *)serializeActions:(NSArray<UNNotificationAction *>*)actions
 {
   NSMutableArray* serializedActions = [NSMutableArray new];
   for (NSUInteger i = 0; i < [actions count]; i++)
@@ -203,7 +205,7 @@ UM_EXPORT_METHOD_AS(deleteNotificationCategoryAsync,
   return serializedActions;
 }
 
-- (NSMutableDictionary *)serializeActionOptions:(NSUInteger)options
++ (NSMutableDictionary *)serializeActionOptions:(NSUInteger)options
 {
   NSMutableDictionary* serializedOptions = [NSMutableDictionary dictionary];
   serializedOptions[@"opensAppToForeground"] =  [NSNumber numberWithBool:((options & UNNotificationActionOptionForeground) != 0)];

--- a/packages/expo-notifications/ios/EXNotifications/Notifications/Categories/EXNotificationCategoriesModule.m
+++ b/packages/expo-notifications/ios/EXNotifications/Notifications/Categories/EXNotificationCategoriesModule.m
@@ -27,35 +27,8 @@ UM_EXPORT_METHOD_AS(setNotificationCategoryAsync,
                  options:(NSDictionary *)options
                  resolve:(UMPromiseResolveBlock)resolve reject:(UMPromiseRejectBlock)reject)
 {
-  NSArray<NSString *> *intentIdentifiers = options[@"intentIdentifiers"];
-  NSString *previewPlaceholder = options[@"previewPlaceholder"];
-  NSString *categorySummaryFormat = options[@"categorySummaryFormat"];
-
-  NSMutableArray<UNNotificationAction *> *actionsArray = [[NSMutableArray alloc] init];
-  for (NSDictionary<NSString *, id> *actionParams in actions) {
-    [actionsArray addObject:[self parseNotificationActionFromParams:actionParams]];
-  }
-  UNNotificationCategoryOptions categoryOptions = [self parseNotificationCategoryOptionsFromParams: options];
-  UNNotificationCategory *newCategory;
-  if (@available(iOS 12, *)) {
-    newCategory = [UNNotificationCategory categoryWithIdentifier:categoryId
-                                                         actions:actionsArray
-                                               intentIdentifiers:intentIdentifiers
-                                   hiddenPreviewsBodyPlaceholder:previewPlaceholder
-                                           categorySummaryFormat:categorySummaryFormat
-                                                         options:categoryOptions];
-  } else if (@available(iOS 11, *)) {
-    newCategory = [UNNotificationCategory categoryWithIdentifier:categoryId
-                                                         actions:actionsArray
-                                               intentIdentifiers:intentIdentifiers
-                                   hiddenPreviewsBodyPlaceholder:previewPlaceholder
-                                                         options:categoryOptions];
-  } else {
-    newCategory = [UNNotificationCategory categoryWithIdentifier:categoryId
-                                                         actions:actionsArray
-                                               intentIdentifiers:intentIdentifiers
-                                                         options:categoryOptions];
-  }
+  UNNotificationCategory *newCategory = [self createCategoryWithId:categoryId actions:actions options:options];
+  
   [[UNUserNotificationCenter currentNotificationCenter] getNotificationCategoriesWithCompletionHandler:^(NSSet<UNNotificationCategory *> *categories) {
     NSMutableSet<UNNotificationCategory *> *newCategories = [categories mutableCopy] ?: [[NSMutableSet alloc] init];
     for (UNNotificationCategory *category in newCategories) {
@@ -90,6 +63,42 @@ UM_EXPORT_METHOD_AS(deleteNotificationCategoryAsync,
 }
 
 # pragma mark- Internal
+
+- (UNNotificationCategory *)createCategoryWithId:(NSString*)categoryId
+                                         actions:(NSArray *)actions
+                                         options:(NSDictionary *)options
+{
+  NSArray<NSString *> *intentIdentifiers = options[@"intentIdentifiers"];
+  NSString *previewPlaceholder = options[@"previewPlaceholder"];
+  NSString *categorySummaryFormat = options[@"categorySummaryFormat"];
+
+  NSMutableArray<UNNotificationAction *> *actionsArray = [[NSMutableArray alloc] init];
+  for (NSDictionary<NSString *, id> *actionParams in actions) {
+    [actionsArray addObject:[self parseNotificationActionFromParams:actionParams]];
+  }
+  UNNotificationCategoryOptions categoryOptions = [self parseNotificationCategoryOptionsFromParams: options];
+  UNNotificationCategory *newCategory;
+  if (@available(iOS 12, *)) {
+    newCategory = [UNNotificationCategory categoryWithIdentifier:categoryId
+                                                         actions:actionsArray
+                                               intentIdentifiers:intentIdentifiers
+                                   hiddenPreviewsBodyPlaceholder:previewPlaceholder
+                                           categorySummaryFormat:categorySummaryFormat
+                                                         options:categoryOptions];
+  } else if (@available(iOS 11, *)) {
+    newCategory = [UNNotificationCategory categoryWithIdentifier:categoryId
+                                                         actions:actionsArray
+                                               intentIdentifiers:intentIdentifiers
+                                   hiddenPreviewsBodyPlaceholder:previewPlaceholder
+                                                         options:categoryOptions];
+  } else {
+    newCategory = [UNNotificationCategory categoryWithIdentifier:categoryId
+                                                         actions:actionsArray
+                                               intentIdentifiers:intentIdentifiers
+                                                         options:categoryOptions];
+  }
+  return newCategory;
+}
 
 - (UNNotificationAction *)parseNotificationActionFromParams:(NSDictionary *)params
 {


### PR DESCRIPTION
# Why

replacement for https://github.com/expo/expo/pull/11710 

https://github.com/expo/expo/pull/11651#discussion_r560583410

# How

- All scoping,descoping,escaping,and unescaping logic is in `EXScopedNotificationsUtils`
- All migrating logic is in `EXScopedNotificationCategoryMigrator`
- In order to reliably know whether or not to call `stringByRemovingPercentEncoding` on a category ID when serializing (calling this on an unescaped string is dangerous), we must _only_ use `EXScopedNotificationSchedulerModule` in Expo Go, but this is actually a good change- there's no reason as far as I can tell that we need to rely on it in standalone apps (cc @lukmccall please let me know if I'm wrong about that)


on startup, if we're in a standalone context, we loop through all notification categories and for any that have the `_experienceId-` prefix (i.e. they are scoped) we:
- create a new `UNNotificationCategory` with the same content _except_ for an **unscoped** identifier
- remove the old category
- add the new, unscoped, category

on startup, if we're in Expo Go, we loop through all notification categories and for any that have the unescaped `experienceId-` prefix (i.e. the legacy one) we:
- create a new `UNNotificationCategory` with the same content _except_ we use `/` as the delimiter instead of `-`, and we escape the experience ID and category ID
- remove the old category
- add the new category

We'll have to keep this code around for a while since people don't always upgrade SDK by SDK

# Test Plan

Tested by specifying categories in app without these changes, then applying these changes (including the [changes in this PR](https://github.com/expo/expo/pull/11651))- categories functionality remained the same. Tested both in Expo Client, and in standalone apps (upgrading from SDK 40 to `unversioned`)
