### PR TITLE
Add hooks comparing remote and local CocoaPods lockfiles

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -27,5 +27,13 @@ source_secrets() {
   watch_file "$file"
 }
 
+install_git_hooks() {
+  for path in scripts/git-hooks/*; do
+    filename=$(basename $path)
+    ln -sf "../../scripts/git-hooks/$filename" ".git/hooks/$filename"
+  done
+}
+
 source_secrets secrets/expotools.env
 source_local
+install_git_hooks

--- a/scripts/check-cocoapods-lockfiles.sh
+++ b/scripts/check-cocoapods-lockfiles.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# Early exit when script is run on platforms other than macOS
+if [[ "$OSTYPE" != "darwin"* ]]; then
+  exit 0
+fi
+
+green="tput setaf 2"
+yellow="tput setaf 3"
+blue="tput setaf 4"
+reset="tput sgr0"
+
+pathsToCheck=("ios" "apps/bare-expo/ios")
+pathsToUpdate=()
+
+for path in ${pathsToCheck[@]}; do
+  podfileLockPath="$path/Podfile.lock"
+  manifestLockPath="$path/Pods/Manifest.lock"
+  podfileLock=$(md5 -q "$podfileLockPath" 2>/dev/null)
+  manifestLock=$(md5 -q $manifestLockPath 2>/dev/null)
+
+  if [ "$podfileLock" != "$manifestLock" ]; then
+    pathsToUpdate+=($path)
+  fi
+done
+
+if [ ${#pathsToUpdate[@]} -ne 0 ]; then
+  dirs=$(printf " or $($green)%s$($yellow)" "${pathsToUpdate[@]}")
+  printf "\\n⚠️  $($yellow)Update your local CocoaPods with $($blue)pod install$($yellow) if you're working in "
+  printf "${dirs:4}$($reset)\\n"
+fi

--- a/scripts/git-hooks/post-checkout
+++ b/scripts/git-hooks/post-checkout
@@ -1,0 +1,5 @@
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { echo >&2 "\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting .git/hooks/post-checkout.\n"; exit 2; }
+git lfs post-checkout "$@"
+
+./scripts/check-cocoapods-lockfiles.sh

--- a/scripts/git-hooks/post-merge
+++ b/scripts/git-hooks/post-merge
@@ -1,0 +1,5 @@
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { echo >&2 "\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting .git/hooks/post-merge.\n"; exit 2; }
+git lfs post-merge "$@"
+
+./scripts/check-cocoapods-lockfiles.sh


### PR DESCRIPTION
# Why

For easier open source contributions and to make the repository size smaller, we're going to remove folders with pods from the repository. To make sure that the contributors have up-to-date pods installed, I add `post-checkout` and `post-merge` git hooks which will be comparing remote `Podfile.lock` with the local `Pods/Manifest.lock` and log a warning if their checksums are different.

# How

- Created `scripts/git-hooks` folder to store our custom hooks in the repository
- Installing git hooks by symlinking them to `scripts/git-hook/*`
- Made a script that compares checksum of `Podfile.lock` with `Pods/Manifest.lock` and prints a warning if they differ
- Added checks of `ios` and `apps/bare-expo/ios` projects

# Test Plan

<img width="1012" alt="Screen Shot 2021-01-31 at 11 46 50" src="https://user-images.githubusercontent.com/1714764/106381575-042c2180-63ba-11eb-8a06-024aaa1b3fd9.png">
