### PR TITLE
[ios][barcode-scanner] Added support for string literal for qr code types on iOS

### DIFF
--- a/packages/expo-barcode-scanner/CHANGELOG.md
+++ b/packages/expo-barcode-scanner/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Converted plugin to TypeScript. ([#11715](https://github.com/expo/expo/pull/11715) by [@EvanBacon](https://github.com/EvanBacon))
 - Updated Android build configuration to target Android 11 (added support for Android SDK 30). ([#11647](https://github.com/expo/expo/pull/11647) by [@bbarthec](https://github.com/bbarthec))
+- Added support for string literal as bar code types input in iOS ([#00000](https://github.com/expo/expo/pull/00000) by [@jarvisluong](https://github.com/jarvisluong))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-barcode-scanner/CHANGELOG.md
+++ b/packages/expo-barcode-scanner/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 - Converted plugin to TypeScript. ([#11715](https://github.com/expo/expo/pull/11715) by [@EvanBacon](https://github.com/EvanBacon))
 - Updated Android build configuration to target Android 11 (added support for Android SDK 30). ([#11647](https://github.com/expo/expo/pull/11647) by [@bbarthec](https://github.com/bbarthec))
-- Added support for string literal as bar code types input in iOS ([#00000](https://github.com/expo/expo/pull/00000) by [@jarvisluong](https://github.com/jarvisluong))
+- Added support for string literal as bar code types input in iOS ([#11796](https://github.com/expo/expo/pull/11796) by [@jarvisluong](https://github.com/jarvisluong))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-barcode-scanner/ios/EXBarCodeScanner/EXBarCodeScanner.m
+++ b/packages/expo-barcode-scanner/ios/EXBarCodeScanner/EXBarCodeScanner.m
@@ -55,7 +55,12 @@ NSString *const EX_BARCODE_TYPES_KEY = @"barCodeTypes";
 {
   for (NSString *key in settings) {
     if ([key isEqualToString:EX_BARCODE_TYPES_KEY]) {
-      NSArray<NSString *> *value = settings[key];
+      NSMutableArray<AVMetadataObjectType> *value = [NSMutableArray array];
+      [settings[key] enumerateObjectsUsingBlock:^(id _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
+        if ([EXBarCodeScannerUtils validBarCodeTypes][obj]) {
+          [value addObject:[EXBarCodeScannerUtils validBarCodeTypes][obj]];
+        }
+      }];
       NSSet *previousTypes = [NSSet setWithArray:_settings[EX_BARCODE_TYPES_KEY]];
       NSSet *newTypes = [NSSet setWithArray:value];
       if (![previousTypes isEqualToSet:newTypes]) {

--- a/packages/expo-barcode-scanner/ios/EXBarCodeScanner/EXBarCodeScannerModule.m
+++ b/packages/expo-barcode-scanner/ios/EXBarCodeScanner/EXBarCodeScannerModule.m
@@ -29,12 +29,19 @@ UM_EXPORT_MODULE(ExpoBarCodeScannerModule);
 
 - (NSDictionary *)constantsToExport
 {
+  NSMutableDictionary* barCodeTypes = [NSMutableDictionary dictionary];
+  // We export the valid bar code types as string literal which matches the documentation.
+  // The consumer can use the string literal (e.g qr) or the constant exports
+  [[[EXBarCodeScannerUtils validBarCodeTypes] allKeys] enumerateObjectsUsingBlock:^(
+    id  _Nonnull key, NSUInteger idx, BOOL * _Nonnull stop) {
+    barCodeTypes[key] = key;
+  }];
   return @{
            @"Type": @{
                @"front": @(EXCameraTypeFront),
                @"back" : @(EXCameraTypeBack),
                },
-           @"BarCodeType": [EXBarCodeScannerUtils validBarCodeTypes],
+           @"BarCodeType": [NSDictionary dictionaryWithDictionary:barCodeTypes],
            };
 }
 


### PR DESCRIPTION
# Why

As described in https://github.com/expo/expo/issues/11726, I think we should allow user to specify string literals as the bar code types in iOS.

# How

I added the conversion of string literal to actual enum values in iOS. Also changed the constants export so that it is equivalent to the string literal.

# Test Plan

With the test app, we can use either `"qr"` or `BarCodeScanner.Constants.BarCodeType.qr` and the bar code scanner should behave similarly.