### PR TITLE
[docs] Update ImagePicker API in tutorial

### DIFF
--- a/docs/pages/tutorial/image-picker.md
+++ b/docs/pages/tutorial/image-picker.md
@@ -46,7 +46,7 @@ import { Image, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 export default function App() {
   /* @info Request permissions to access the "camera roll", then launch the picker and log the result. */
   let openImagePickerAsync = async () => {
-    let permissionResult = await ImagePicker.requestCameraRollPermissionsAsync();
+    let permissionResult = await ImagePicker.requestMediaLibraryPermissionsAsync();
 
     if (permissionResult.granted === false) {
       alert("Permission to access camera roll is required!");
@@ -96,7 +96,7 @@ export default function App() {
 
 
   let openImagePickerAsync = async () => {
-    let permissionResult = await ImagePicker.requestCameraRollPermissionsAsync();
+    let permissionResult = await ImagePicker.requestMediaLibraryPermissionsAsync();
 
     if (permissionResult.granted === false) {
       alert('Permission to access camera roll is required!');

--- a/docs/pages/tutorial/platform-differences.md
+++ b/docs/pages/tutorial/platform-differences.md
@@ -36,7 +36,7 @@ export default function App() {
   const [selectedImage, setSelectedImage] = React.useState(null);
 
   let openImagePickerAsync = async () => {
-    let permissionResult = await ImagePicker.requestCameraRollPermissionsAsync();
+    let permissionResult = await ImagePicker.requestMediaLibraryPermissionsAsync();
 
     if (permissionResult.granted === false) {
       alert('Permission to access camera roll is required!');

--- a/docs/public/static/examples/unversioned/tutorial/image-picker-log.js
+++ b/docs/public/static/examples/unversioned/tutorial/image-picker-log.js
@@ -4,7 +4,7 @@ import * as ImagePicker from 'expo-image-picker';
 
 export default function App() {
   let openImagePickerAsync = async () => {
-    let permissionResult = await ImagePicker.requestCameraRollPermissionsAsync();
+    let permissionResult = await ImagePicker.requestMediaLibraryPermissionsAsync();
 
     if (permissionResult.granted === false) {
       alert('Permission to access camera roll is required!');

--- a/docs/public/static/examples/unversioned/tutorial/image-picker-show.js
+++ b/docs/public/static/examples/unversioned/tutorial/image-picker-show.js
@@ -6,7 +6,7 @@ export default function App() {
   let [selectedImage, setSelectedImage] = React.useState(null);
 
   let openImagePickerAsync = async () => {
-    let permissionResult = await ImagePicker.requestCameraRollPermissionsAsync();
+    let permissionResult = await ImagePicker.requestMediaLibraryPermissionsAsync();
 
     if (permissionResult.granted === false) {
       alert('Permission to access camera roll is required!');

--- a/docs/public/static/examples/unversioned/tutorial/sharing-simple.js
+++ b/docs/public/static/examples/unversioned/tutorial/sharing-simple.js
@@ -7,7 +7,7 @@ export default function App() {
   let [selectedImage, setSelectedImage] = React.useState(null);
 
   let openImagePickerAsync = async () => {
-    let permissionResult = await ImagePicker.requestCameraRollPermissionsAsync();
+    let permissionResult = await ImagePicker.requestMediaLibraryPermissionsAsync();
 
     if (permissionResult.granted === false) {
       alert('Permission to access camera roll is required!');

--- a/docs/public/static/examples/unversioned/tutorial/sharing-web-workaround.js
+++ b/docs/public/static/examples/unversioned/tutorial/sharing-web-workaround.js
@@ -8,7 +8,7 @@ export default function App() {
   let [selectedImage, setSelectedImage] = React.useState(null);
 
   let openImagePickerAsync = async () => {
-    let permissionResult = await ImagePicker.requestCameraRollPermissionsAsync();
+    let permissionResult = await ImagePicker.requestMediaLibraryPermissionsAsync();
 
     if (permissionResult.granted === false) {
       alert('Permission to access camera roll is required!');

--- a/docs/public/static/examples/v40.0.0/tutorial/image-picker-log.js
+++ b/docs/public/static/examples/v40.0.0/tutorial/image-picker-log.js
@@ -4,7 +4,7 @@ import * as ImagePicker from 'expo-image-picker';
 
 export default function App() {
   let openImagePickerAsync = async () => {
-    let permissionResult = await ImagePicker.requestCameraRollPermissionsAsync();
+    let permissionResult = await ImagePicker.requestMediaLibraryPermissionsAsync();
 
     if (permissionResult.granted === false) {
       alert('Permission to access camera roll is required!');

--- a/docs/public/static/examples/v40.0.0/tutorial/image-picker-show.js
+++ b/docs/public/static/examples/v40.0.0/tutorial/image-picker-show.js
@@ -6,7 +6,7 @@ export default function App() {
   let [selectedImage, setSelectedImage] = React.useState(null);
 
   let openImagePickerAsync = async () => {
-    let permissionResult = await ImagePicker.requestCameraRollPermissionsAsync();
+    let permissionResult = await ImagePicker.requestMediaLibraryPermissionsAsync();
 
     if (permissionResult.granted === false) {
       alert('Permission to access camera roll is required!');

--- a/docs/public/static/examples/v40.0.0/tutorial/sharing-simple.js
+++ b/docs/public/static/examples/v40.0.0/tutorial/sharing-simple.js
@@ -7,7 +7,7 @@ export default function App() {
   let [selectedImage, setSelectedImage] = React.useState(null);
 
   let openImagePickerAsync = async () => {
-    let permissionResult = await ImagePicker.requestCameraRollPermissionsAsync();
+    let permissionResult = await ImagePicker.requestMediaLibraryPermissionsAsync();
 
     if (permissionResult.granted === false) {
       alert('Permission to access camera roll is required!');

--- a/docs/public/static/examples/v40.0.0/tutorial/sharing-web-workaround.js
+++ b/docs/public/static/examples/v40.0.0/tutorial/sharing-web-workaround.js
@@ -8,7 +8,7 @@ export default function App() {
   let [selectedImage, setSelectedImage] = React.useState(null);
 
   let openImagePickerAsync = async () => {
-    let permissionResult = await ImagePicker.requestCameraRollPermissionsAsync();
+    let permissionResult = await ImagePicker.requestMediaLibraryPermissionsAsync();
 
     if (permissionResult.granted === false) {
       alert('Permission to access camera roll is required!');


### PR DESCRIPTION
# Why

In https://github.com/expo/expo/pull/10643, the function used to ask the user to grant permissions for accessing photos was renamed from `requestCameraRollPermissionsAsync` to `requestMediaLibraryPermissionsAsync`. Using the old function name in some text editors shows a deprecation warning, which could be confusing to new users. This PR updates the tutorial and corresponding Snack examples to use the new API.

# How

I found the references to `requestCameraRollPermissionsAsync` in the tutorial and replaced them with `requestMediaLibraryPermissionsAsync`. For Snack examples, I made the same changes in both the unversioned and v40.0.0 versions.

# Test Plan

I tested this change by running the docs locally on my machine and verifying the copy on each of the pages of the tutorial. I also ran each of the updated Snack examples on my iPhone to confirm that they still work.