### PR TITLE
[expo-dev-menu] Clear `dev-menu-packager-host` before publishing

### DIFF
--- a/packages/expo-dev-menu/package.json
+++ b/packages/expo-dev-menu/package.json
@@ -10,7 +10,7 @@
     "clean": "expo-module clean",
     "lint": "expo-module lint",
     "test": "expo-module test",
-    "prepare": "expo-module prepare",
+    "prepare": "expo-module prepare && git update-index --no-skip-worktree ./assets/dev-menu-packager-host && git checkout HEAD -- ./assets/dev-menu-packager-host",
     "prepublishOnly": "expo-module prepublishOnly",
     "expo-module": "expo-module",
     "start": "./scripts/start.sh",

--- a/packages/expo-dev-menu/package.json
+++ b/packages/expo-dev-menu/package.json
@@ -10,7 +10,7 @@
     "clean": "expo-module clean",
     "lint": "expo-module lint",
     "test": "expo-module test",
-    "prepare": "expo-module prepare && git update-index --no-skip-worktree ./assets/dev-menu-packager-host && git checkout HEAD -- ./assets/dev-menu-packager-host",
+    "prepare": "expo-module prepare && ./scripts/reset-dev-menu-packager-host.sh",
     "prepublishOnly": "expo-module prepublishOnly",
     "expo-module": "expo-module",
     "start": "./scripts/start.sh",

--- a/packages/expo-dev-menu/scripts/reset-dev-menu-packager-host.sh
+++ b/packages/expo-dev-menu/scripts/reset-dev-menu-packager-host.sh
@@ -1,0 +1,6 @@
+HOST_FILE='./assets/dev-menu-packager-host'
+
+git update-index --no-skip-worktree $HOST_FILE
+git checkout HEAD -- $HOST_FILE
+
+echo "$HOST_FILE was cleared"


### PR DESCRIPTION
# Why

Clear `dev-menu-packager-host` before publishing.

# Test Plan

- `yarn start` and then `yarn prepare` and check if the file was restored correctly. 
