### PR TITLE
[av] Add androidImplementation type on Android

### DIFF
--- a/packages/expo-av/src/AV.ts
+++ b/packages/expo-av/src/AV.ts
@@ -35,12 +35,12 @@ export type AVPlaybackNativeSource = {
 export type AVPlaybackStatus =
   | {
       isLoaded: false;
-      androidImplementation?: string;
+      androidImplementation: 'MediaPlayer' | undefined;
       error?: string; // populated exactly once when an error forces the object to unload
     }
   | {
       isLoaded: true;
-      androidImplementation?: string;
+      androidImplementation: 'MediaPlayer' | undefined;
 
       uri: string;
 


### PR DESCRIPTION
# Why

I'm not a TS expert, but I think the advantage is the generated d.ts will prompt the expected keyword for `androidImplementation`; helps avoid spelling bugs & doc research ;)
https://docs.expo.io/versions/v40.0.0/sdk/av/#playback-status

I wonder if an additional type of 'ExoPlayer' would be helpful?

# How

only edit types
ref: https://stackoverflow.com/a/53474917/1324588


# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->
