### PR TITLE
[expo-dev-launcher] Prevent from crashing when the launcher wasn't initialized

### DIFF
--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/modules/DevLauncherModule.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/modules/DevLauncherModule.kt
@@ -9,7 +9,15 @@ class DevLauncherModule(reactContext: ReactApplicationContext?) : ReactContextBa
 
   override fun hasConstants() = true
 
-  override fun getConstants() = mapOf<String, Any?>(
-    "manifestString" to DevLauncherController.instance.manifest?.rawData
-  )
+  override fun getConstants(): Map<String, Any?> {
+    val manifestString = try {
+      DevLauncherController.instance.manifest?.rawData
+    } catch (_: IllegalStateException) {
+      null
+    }
+
+    return mapOf<String, Any?>(
+      "manifestString" to manifestString
+    )
+  }
 }


### PR DESCRIPTION
# Why

Prevent from crashing when the launcher wasn't initialized. 

# How

Wrapped `DevLauncherController.instance` in the try-catch block.

# Test Plan

- bare-expo ✅