### PR TITLE
[expo-image-picker] Fix incorrect file URI on Android

### DIFF
--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - Fixed `launchCameraAsync()` with `allowsEditing` option crashing for some android users. ([#11825](https://github.com/expo/expo/pull/11825) by [@lukmccall](https://github.com/lukmccall))
 - Fixed cancelled picker dialog not resolving with expected result on web. ([#11847](https://github.com/expo/expo/pull/11847) by [@jayprado](https://github.com/jayprado))
+- Fixed incorrect file URI on Android. ([#11823](https://github.com/expo/expo/pull/11823) by [@lukmccall](https://github.com/lukmccall))
 
 ## 10.0.0 — 2021-01-15
 

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerUtils.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerUtils.kt
@@ -63,3 +63,11 @@ fun deduceExtension(type: String): String = when {
   }
   else -> ".jpg"
 }
+
+fun slashifyFilePath(path: String): String {
+  return if (!path.startsWith("file:///")) {
+    path.replace("file:/", "file:///")
+  } else {
+    path
+  }
+}

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/tasks/ImageResultTask.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/tasks/ImageResultTask.kt
@@ -11,6 +11,7 @@ import expo.modules.imagepicker.ImagePickerConstants.exifTags
 import expo.modules.imagepicker.exporters.ImageExporter
 import expo.modules.imagepicker.exporters.ImageExporter.Listener
 import expo.modules.imagepicker.fileproviders.FileProvider
+import expo.modules.imagepicker.slashifyFilePath
 import org.unimodules.core.Promise
 import java.io.ByteArrayOutputStream
 import java.io.IOException
@@ -31,7 +32,7 @@ open class ImageResultTask(private val promise: Promise,
       val imageExporterHandler = object : Listener {
         override fun onResult(out: ByteArrayOutputStream?, width: Int, height: Int) {
           val response = Bundle().apply {
-            putString("uri", outputFile.toURL().toString())
+            putString("uri", slashifyFilePath(outputFile.toURI().toString()))
             putInt("width", width)
             putInt("height", height)
             putBoolean("cancelled", false)

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/tasks/ImageResultTask.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/tasks/ImageResultTask.kt
@@ -31,7 +31,7 @@ open class ImageResultTask(private val promise: Promise,
       val imageExporterHandler = object : Listener {
         override fun onResult(out: ByteArrayOutputStream?, width: Int, height: Int) {
           val response = Bundle().apply {
-            putString("uri", outputFile.toURI().toString())
+            putString("uri", outputFile.toURL().toString())
             putInt("width", width)
             putInt("height", height)
             putBoolean("cancelled", false)

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/tasks/VideoResultTask.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/tasks/VideoResultTask.kt
@@ -25,7 +25,7 @@ class VideoResultTask(private val promise: Promise,
       val outputFile = fileProvider.generateFile()
       saveVideo(outputFile)
       val response = Bundle().apply {
-        putString("uri", outputFile.toURI().toString())
+        putString("uri", outputFile.toURL().toString())
         putBoolean("cancelled", false)
         putString("type", "video")
         putInt("width", mediaMetadataRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_WIDTH)!!.toInt())

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/tasks/VideoResultTask.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/tasks/VideoResultTask.kt
@@ -7,6 +7,7 @@ import android.os.AsyncTask
 import android.os.Bundle
 import expo.modules.imagepicker.ImagePickerConstants
 import expo.modules.imagepicker.fileproviders.FileProvider
+import expo.modules.imagepicker.slashifyFilePath
 import org.unimodules.core.Promise
 import java.io.File
 import java.io.FileOutputStream
@@ -25,7 +26,7 @@ class VideoResultTask(private val promise: Promise,
       val outputFile = fileProvider.generateFile()
       saveVideo(outputFile)
       val response = Bundle().apply {
-        putString("uri", outputFile.toURL().toString())
+        putString("uri", slashifyFilePath(outputFile.toURI().toString()))
         putBoolean("cancelled", false)
         putString("type", "video")
         putInt("width", mediaMetadataRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_WIDTH)!!.toInt())


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/11214.

# How

For some reason, `toURI` returns a different path than `toURL`. The first one returns `file:/...` and the second one `file://...`. 

# Test Plan

- Snack at docs.expo.io/versions/latest/sdk/imagepicker ✅

# Changelog

- Fixed incorrect file URI on Android