### PR TITLE
[expo-image-picker] Add queries to `AndroidManifest`

### DIFF
--- a/packages/expo-image-picker/android/src/main/AndroidManifest.xml
+++ b/packages/expo-image-picker/android/src/main/AndroidManifest.xml
@@ -20,4 +20,14 @@
                 android:resource="@xml/image_picker_provider_paths"/>
         </provider>
     </application>
+
+    <queries>
+      <intent>
+        <action android:name="android.media.action.IMAGE_CAPTURE" />
+      </intent>
+
+      <intent>
+        <action android:name="android.media.action.ACTION_VIDEO_CAPTURE" />
+      </intent>
+    </queries>
 </manifest>

--- a/packages/expo-image-picker/android/src/main/AndroidManifest.xml
+++ b/packages/expo-image-picker/android/src/main/AndroidManifest.xml
@@ -22,12 +22,13 @@
     </application>
 
     <queries>
-      <intent>
-        <action android:name="android.media.action.IMAGE_CAPTURE" />
-      </intent>
-
-      <intent>
-        <action android:name="android.media.action.ACTION_VIDEO_CAPTURE" />
-      </intent>
+        <intent>
+            <!-- Required for picking images from the camera roll if targeting API 30 -->
+            <action android:name="android.media.action.IMAGE_CAPTURE" />
+        </intent>
+        <intent>
+            <!-- Required for picking images from the camera if targeting API 30 -->
+            <action android:name="android.media.action.ACTION_VIDEO_CAPTURE" />
+        </intent>
     </queries>
 </manifest>


### PR DESCRIPTION
# Why

Adds queries to `AndroidManifest` in the `expo-image-picker` package. Otherwise, the app can't access the camera on Android 11. You can read more [here](https://developer.android.com/about/versions/11/privacy/package-visibility).

# Test Plan

- bare-expo ✅
