### PR TITLE
[android] Update `okhttp`

### DIFF
--- a/packages/expo-av/android/build.gradle
+++ b/packages/expo-av/android/build.gradle
@@ -89,8 +89,8 @@ dependencies {
 
   api 'com.yqritc:android-scalablevideoview:1.0.1'
 
-  api "com.squareup.okhttp3:okhttp:3.10.0"
-  api "com.squareup.okhttp3:okhttp-urlconnection:3.10.0"
+  api "com.squareup.okhttp3:okhttp:3.14.9"
+  api "com.squareup.okhttp3:okhttp-urlconnection:3.14.9"
 
   api "com.android.support:support-annotations:${safeExtGet("supportLibVersion", "29.0.0")}"
 

--- a/packages/expo-dev-launcher/android/build.gradle
+++ b/packages/expo-dev-launcher/android/build.gradle
@@ -82,7 +82,7 @@ dependencies {
 
   implementation 'commons-io:commons-io:2.6'
 
-  implementation("com.squareup.okhttp3:okhttp:3.12.1")
+  implementation("com.squareup.okhttp3:okhttp:3.14.9")
   implementation 'com.google.code.gson:gson:2.8.5'
 
   // Fixes

--- a/packages/expo-image/android/build.gradle
+++ b/packages/expo-image/android/build.gradle
@@ -3,7 +3,7 @@ def DEFAULT_BUILD_TOOLS_VERSION = '28.0.3'
 def DEFAULT_MIN_SDK_VERSION = 16
 def DEFAULT_TARGET_SDK_VERSION = 28
 
-def DEFAULT_OKHTTP_VERSION = '3.14.1'
+def DEFAULT_OKHTTP_VERSION = '3.14.9'
 
 def safeExtGet(prop, fallback) {
   rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback


### PR DESCRIPTION
# Why

Fixes:

```
2021-02-03 15:08:36.858 8255-8255/dev.expo.payments E/AndroidRuntime: FATAL EXCEPTION: main
    Process: dev.expo.payments, PID: 8255
    java.lang.RuntimeException: Unable to start activity ComponentInfo{dev.expo.payments/dev.expo.payments.MainActivity}: java.lang.RuntimeException: Requested enabled DevSupportManager, but DevSupportManagerImpl class was not found or could not be created
        at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:3449)
        at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3601)
        at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:85)
        at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:135)
        at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:95)
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2066)
        at android.os.Handler.dispatchMessage(Handler.java:106)
        at android.os.Looper.loop(Looper.java:223)
        at android.app.ActivityThread.main(ActivityThread.java:7656)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:592)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:947)
 <...>
     Caused by: java.lang.IllegalStateException: Expected Android API level 21+ but was 30
        at okhttp3.internal.platform.AndroidPlatform.buildIfSupported(AndroidPlatform.java:238)
        at okhttp3.internal.platform.Platform.findPlatform(Platform.java:202)
        at okhttp3.internal.platform.Platform.<clinit>(Platform.java:79)
        at okhttp3.internal.platform.Platform.get(Platform.java:85) 
        at okhttp3.OkHttpClient.newSslSocketFactory(OkHttpClient.java:263) 
        at okhttp3.OkHttpClient.<init>(OkHttpClient.java:229) 
        at okhttp3.OkHttpClient$Builder.build(OkHttpClient.java:1015) 
        at com.facebook.react.devsupport.DevServerHelper.<init>(DevServerHelper.java:132) 
        at com.facebook.react.devsupport.DevSupportManagerBase.<init>(DevSupportManagerBase.java:157) 
        at com.facebook.react.devsupport.DevSupportManagerImpl.<init>(DevSupportManagerImpl.java:72) 
        at java.lang.reflect.Constructor.newInstance0(Native Method) 
        at java.lang.reflect.Constructor.newInstance(Constructor.java:343) 
        at com.facebook.react.devsupport.DevSupportManagerFactory.create(DevSupportManagerFactory.java:80) 
        at com.facebook.react.ReactInstanceManager.<init>(ReactInstanceManager.java:237) 
        at com.facebook.react.ReactInstanceManagerBuilder.build(ReactInstanceManagerBuilder.java:280) 
        at com.facebook.react.ReactNativeHost.createReactInstanceManager(ReactNativeHost.java:87) 
        at com.facebook.react.ReactNativeHost.getReactInstanceManager(ReactNativeHost.java:39) 
        at com.facebook.react.ReactDelegate.loadApp(ReactDelegate.java:104) 
        at com.facebook.react.ReactActivityDelegate.loadApp(ReactActivityDelegate.java:90) 
        at com.facebook.react.ReactActivityDelegate.onCreate(ReactActivityDelegate.java:85) 
        at dev.expo.payments.MainActivity$1.onCreate(MainActivity.java:40) 
        at com.facebook.react.ReactActivity.onCreate(ReactActivity.java:45) 
        at android.app.Activity.performCreate(Activity.java:8000) 
        at android.app.Activity.performCreate(Activity.java:7984) 
        at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1309) 
        at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:3422) 
        at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3601) 
        at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:85) 
        at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:135) 
        at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:95) 
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2066) 
        at android.os.Handler.dispatchMessage(Handler.java:106) 
        at android.os.Looper.loop(Looper.java:223) 
        at android.app.ActivityThread.main(ActivityThread.java:7656) 
        at java.lang.reflect.Method.invoke(Native Method) 
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:592) 
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:947) 
2021-02-03 15:08:36.886 8255-8255/dev.expo.payments I/Process: Sending signal. PID: 8255 SIG: 9
```

# How

Updated okhttp to a version that contains a fix. (See `https://square.github.io/okhttp/changelog_3x/#version-3147`).

> Note: I've only update packages that are included in the `bare-expo` because that's where the crash occurs. I think we don't need to update it in the `Expo Go` for now. 

# Test Plan

- bare-expo ✅
- NCL ✅
- expo go ✅
