### PR TITLE
[expo] Add queries to `AndroidManifest`

### DIFF
--- a/packages/expo-calendar/android/src/main/AndroidManifest.xml
+++ b/packages/expo-calendar/android/src/main/AndroidManifest.xml
@@ -1,2 +1,11 @@
-<manifest package="expo.modules.calendar">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  package="expo.modules.calendar">
+
+  <queries>
+    <intent>
+      <!-- Required for opening event in calendar if targeting API 30 -->
+      <action android:name="android.intent.action.VIEW" />
+      <data android:scheme="content" />
+    </intent>
+  </queries>
 </manifest>

--- a/packages/expo-mail-composer/android/src/main/AndroidManifest.xml
+++ b/packages/expo-mail-composer/android/src/main/AndroidManifest.xml
@@ -13,5 +13,12 @@
                 android:resource="@xml/mail_composer_provider_paths"/>
         </provider>
     </application>
+
+    <queries>
+        <intent>
+          <!-- Required for sending mails if targeting API 30 -->
+          <action android:name="android.intent.action.SENDTO" />
+          <data android:scheme="mailto" />
+        </intent>
+    </queries>
 </manifest>
-  

--- a/packages/expo-sharing/android/src/main/AndroidManifest.xml
+++ b/packages/expo-sharing/android/src/main/AndroidManifest.xml
@@ -10,5 +10,13 @@
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/sharing_provider_paths"/>
         </provider>
-    </application>
+   </application>
+
+    <queries>
+        <intent>
+            <!-- Required for file sharing if targeting API 30 -->
+            <action android:name="android.intent.action.SEND" />
+            <data android:mimeType="*/*" />
+        </intent>
+    </queries>
 </manifest>

--- a/packages/expo-speech/android/src/main/AndroidManifest.xml
+++ b/packages/expo-speech/android/src/main/AndroidManifest.xml
@@ -1,5 +1,10 @@
+<manifest package="expo.modules.speech"
+  xmlns:android="http://schemas.android.com/apk/res/android">
 
-<manifest package="expo.modules.speech">
-
+  <queries>
+    <intent>
+      <!-- Required for text-to-speech if targeting API 30 -->
+      <action android:name="android.intent.action.TTS_SERVICE" />
+    </intent>
+  </queries>
 </manifest>
-  

--- a/packages/expo-web-browser/android/src/main/AndroidManifest.xml
+++ b/packages/expo-web-browser/android/src/main/AndroidManifest.xml
@@ -1,3 +1,10 @@
-<manifest package="expo.modules.webbrowser">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  package="expo.modules.webbrowser">
 
+  <queries>
+    <intent>
+      <!-- Required for opening tabs if targeting API 30 -->
+      <action android:name="android.support.customtabs.action.CustomTabsService" />
+    </intent>
+  </queries>
 </manifest>


### PR DESCRIPTION
# Why

Followup of https://github.com/expo/expo/pull/11787.

Adds queries to AndroidManifest. Otherwise, the app can't access some system features on Android 11. 
For more information read https://developer.android.com/about/versions/11/privacy/package-visibility and  https://developer.android.com/training/basics/intents/package-visibility-use-cases#open-a-file.

# How

Searched for `resolveActivity`, `queryIntentActivities` and `queryIntentServices` and checked if `AndroidStudio` suggest adding query. If yes added. Otherwise, ignored.

> **Note**: I'm not sure if I found every place very we should add "queries", but we for sure find those in the QA. Moreover, this feature was introduced in Android 11, and not every intent query needs a manifest entry.

# Test Plan

I've tested some functionalities with the Android emulator running Android 11, but I don't have access to a real device. So I could miss something.