### PR TITLE
[docs][expo-av] Document that Audio web support is pending

### DIFF
--- a/docs/pages/versions/unversioned/sdk/audio.md
+++ b/docs/pages/versions/unversioned/sdk/audio.md
@@ -13,7 +13,7 @@ Note that audio automatically stops if headphones / bluetooth audio devices are 
 
 Try the [playlist example app](https://expo.io/@documentation/playlist-example) (source code is [on GitHub](https://github.com/expo/playlist-example)) to see an example usage of the media playback API, and the [recording example app](https://expo.io/@documentation/record) (source code is [on GitHub](https://github.com/expo/audio-recording-example)) to see an example usage of the recording API.
 
-<PlatformsSection android emulator ios simulator web />
+<PlatformsSection android emulator ios simulator web={{ pending: 'https://github.com/expo/expo/issues/8721' }} />
 
 ## Installation
 

--- a/docs/pages/versions/v40.0.0/sdk/audio.md
+++ b/docs/pages/versions/v40.0.0/sdk/audio.md
@@ -13,7 +13,7 @@ Note that audio automatically stops if headphones / bluetooth audio devices are 
 
 Try the [playlist example app](https://expo.io/@documentation/playlist-example) (source code is [on GitHub](https://github.com/expo/playlist-example)) to see an example usage of the media playback API, and the [recording example app](https://expo.io/@documentation/record) (source code is [on GitHub](https://github.com/expo/audio-recording-example)) to see an example usage of the recording API.
 
-<PlatformsSection android emulator ios simulator web />
+<PlatformsSection android emulator ios simulator web={{ pending: 'https://github.com/expo/expo/issues/8721' }} />
 
 ## Installation
 

--- a/docs/pages/versions/v41.0.0/sdk/audio.md
+++ b/docs/pages/versions/v41.0.0/sdk/audio.md
@@ -13,7 +13,7 @@ Note that audio automatically stops if headphones / bluetooth audio devices are 
 
 Try the [playlist example app](https://expo.io/@documentation/playlist-example) (source code is [on GitHub](https://github.com/expo/playlist-example)) to see an example usage of the media playback API, and the [recording example app](https://expo.io/@documentation/record) (source code is [on GitHub](https://github.com/expo/audio-recording-example)) to see an example usage of the recording API.
 
-<PlatformsSection android emulator ios simulator web />
+<PlatformsSection android emulator ios simulator web={{ pending: 'https://github.com/expo/expo/issues/8721' }} />
 
 ## Installation
 


### PR DESCRIPTION
## What

Updates `<PlatformsSection ...>` to pending state, with reference to https://github.com/expo/expo/issues/8721.


## Why

The docs confusingly state that web is supported at https://docs.expo.io/versions/v40.0.0/sdk/audio/, when at least some of the functionality is not supported.

This can be reverted when https://github.com/expo/expo/pull/8791/ merges.