### PR TITLE
[docs] EAS Build configurable build environment

### DIFF
--- a/docs/pages/build-reference/infrastructure.md
+++ b/docs/pages/build-reference/infrastructure.md
@@ -4,21 +4,22 @@ title: Build server infrastructure
 
 This document describes the current build infrastructure as of December 15, 2020. It is likely to change over time, and this document will be updated.
 
-The software components will become customizable, but they aren't yet. So there is only one version of Node, yarn, CocoaPods, Xcode, Ruby, Fastlane, and so on currently available.
+## Configuring build environment
 
-## JavaScript environment
+Images for each platform have one specific version of Node, yarn, CocoaPods, Xcode, Ruby, Fastlane, and so on. You can override some of those values in the [eas.json](../build/eas-json) file or if it's not supported you can use the [hooks mechanism](how-tos/#eas-build-specific-npm-hooks) to install or update any system dependencies with `apt-get` or `brew` before the build starts, but take into account that those customization options are applied during the build and will increase your build times.
 
-- Node.js 14.15.1
-- Yarn 1.22.10
+When selecting an image for the build you can use the full name provided below or one of the aliases (`default`, `latest`).
+- The use of a specific name guarantees a consistent environment with only small updates.
+- `default` alias will be assigned to the environment that most closely resembles the configuration used for Expo SDK development.
+- `latest` alias will be assigned to the image with the most up to date versions of the software.
 
-## Android build server configuration
+Currently, only one image is supported per platform, more images will be available in the future.
+
+## Android build server configurations
 
 - Android workers run on Kubernetes in an isolated environment
   - Every build gets its own container running on a dedicated Kubernetes node
   - Build resources: 4 CPU, 16 GB RAM (14 GB after k8s overhead)
-- Installed software:
-  - Docker image: `ubuntu:bionic-20201119`
-  - NDK 19.2.5345600
 - NPM cache deployed with Kubernetes
 - Maven cache deployed with Kubernetes, cached repositories:
   - `maven-central` - [https://repo1.maven.org/maven2/](https://repo1.maven.org/maven2/)
@@ -26,7 +27,6 @@ The software components will become customizable, but they aren't yet. So there 
   - `android-tools` - [https://dl.bintray.com/android/android-tools/](https://dl.bintray.com/android/android-tools/)
   - `jcenter` - [https://jcenter.bintray.com/](https://jcenter.bintray.com/)
   - `plugins` - [https://plugins.gradle.org/m2/](https://plugins.gradle.org/m2/)
-
 - Global gradle configuration in `~/.gradle/gradle.properties`:
 
   ```jsx
@@ -36,16 +36,27 @@ The software components will become customizable, but they aren't yet. So there 
   org.gradle.daemon=false
   ```
 
-## iOS build server configuration
+#### Image `ubuntu-18.04-android-30-ndk-r19c` (alias `default`, `latest`)
 
-- iOS worker VMs run on Macs Pro 6.1 in an isolated environement
+- Docker image: `ubuntu:bionic-20201119`
+- NDK 19.2.5345600
+- Node.js 14.15.1
+- Yarn 1.22.10
+
+## iOS build server configurations
+
+- iOS worker VMs run on Macs Pro 6.1 in an isolated environment
   - Every build gets its own fresh macOS VM
   - Hardware: Intel(R) Xeon(R) CPU E5-2697 (12 core/24 threads), 64 GB RAM
   - Build resource limits: 6 cores, 8 GB RAM
-- Installed software:
-  - macOS Catalina 10.15.4
-  - Xcode 12.1 (12A7403)
-  - fastlane 2.170.0
-  - CocoaPods 1.10.0
-  - Ruby 2.6.3p62 (2019-04-16 revision 67580) [universal.x86_64-darwin19]
-- NPM cache (temporary disabled)
+- NPM cache
+
+#### Image `macos-catalina-11.15-xcode-12.1` (alias `default`, `latest`)
+
+- macOS Catalina 10.15.4
+- Xcode 12.1 (12A7403)
+- Node.js 14.15.1
+- Yarn 1.22.10
+- fastlane 2.170.0
+- CocoaPods 1.10.0
+- Ruby 2.6.3p62 (2019-04-16 revision 67580) [universal.x86_64-darwin19]

--- a/docs/pages/build/eas-json.md
+++ b/docs/pages/build/eas-json.md
@@ -60,22 +60,34 @@ The schema of a build profile for a generic Android project looks like this:
 ```json
 {
   "workflow": "generic",
+  "extends": string,
   "credentialsSource": "local" | "remote" | "auto", // default: "auto"
   "withoutCredentials": boolean, // default: false
   "gradleCommand": string, // default: ":app:bundleRelease"
   "artifactPath": string, // default: "android/app/build/outputs/**/*.{apk,aab}"
   "releaseChannel": string, // default: "default"
-  "distribution": "store" | "internal" // default: "store"
+  "distribution": "store" | "internal", // default: "store"
+  "image": string, // default: "default"
+  "node": string,
+  "yarn": string,
+  "ndk": string,
+  "env": Record<string, string> // default: {}
 }
 ```
 
 - `"workflow": "generic"` indicates that your project is a generic one.
+- `extends` specifies name of build profile that current profile inherits values from.
 - `credentialsSource` defines the source of credentials for this build profile. If you want to provide your own `credentials.json` file, set this to `local` ([learn more on this here](/app-signing/local-credentials.md)). If you want to use the credentials EAS already has stored for you, choose `remote`. If you're not sure what to do, choose `auto` (this is the default option).
 - `withoutCredentials`: when set to `true`, EAS CLI won't require you to configure credentials when building the app using this profile. This comes in handy when you want to build debug binaries and the debug keystore is checked in to the repository. The default is `false`.
 - `gradleCommand` defines the Gradle task to be run on EAS servers to build your project. You can set it to any valid Gradle task, e.g. `:app:assembleDebug` to build a debug binary. The default Gradle command is `:app:bundleRelease`.
 - `artifactPath` is the path (or pattern) where EAS Build is going to look for the build artifacts. EAS Build uses the `fast-glob` npm package for pattern matching ([see their README to learn more about the syntax you can use](https://github.com/mrmlnc/fast-glob#pattern-syntax)). The default value is `android/app/build/outputs/**/*.{apk,aab}`.
 - `releaseChannel` is the release channel for the `expo-updates` package ([Learn more about this](../distribution/release-channels.md)). If you do not specify a channel, your binary will pull releases from the `default` channel. If you do not use `expo-updates` in your project then this property will have no effect.
 - `distribution` is the flow of distributing your app. If you choose `internal` you'll be able to share your build URLs with anyone, and they will be able to install the builds to their devices straight from the Expo website. When using `internal`, make sure the `gradleCommand` produces an APK file (e.g. `:app:assembleRelease`). Otherwise, the sharable URL will be useless. The default is `store` which means your build URLs won't be sharable. [Learn more about internal distribution](internal-distribution.md).
+- `image` - image with build environment. [Learn more about it here](../build-reference/infrastructure).
+- `node` - version of Node.js
+- `yarn` - version of Yarn
+- `ndk` - version of Android NDK
+- `env` - environment variables that should be set during the build process (should only be used for values that you would commit to your git repository, i.e: not passwords or secrets).
 
 #### Examples
 
@@ -115,18 +127,30 @@ The schema of a build profile for a managed Android project looks like this:
 ```json
 {
   "workflow": "managed",
+  "extends": string,
   "credentialsSource": "local" | "remote" | "auto", // default: "auto"
   "buildType": "app-bundle" | "apk", // default: "app-bundle"
   "releaseChannel": string, // default: "default"
-  "distribution": "store" | "internal" // default: "store"
+  "distribution": "store" | "internal", // default: "store"
+  "image": string, // default: "default"
+  "node": string,
+  "yarn": string,
+  "ndk": string,
+  "env": Record<string, string> // default: {}
 }
 ```
 
 - `"workflow": "managed"` indicates that your project is a managed one.
+- `extends` specifies name of build profile that current profile inherits values from.
 - `credentialsSource` defines the source of credentials for this build profile. If you want to provide your own `credentials.json` file, set this to `local` ([learn more on this here](/app-signing/local-credentials.md)). If you want to use the credentials EAS already has stored for you, choose `remote`. If you're not sure what to do, choose `auto` (this is the default option).
 - `buildType` when set to `app-bundle` produces an AAB archive but when set to `apk` produces an APK instead.
 - `releaseChannel` is the release channel for the `expo-updates` package ([Learn more about this](../distribution/release-channels.md)). If you do not specify a channel, your binary will pull releases from the `default` channel. If you do not use `expo-updates` in your project then this property will have no effect.
 - `distribution` is the flow of distributing your app. If you choose `internal` you'll be able to share your build URLs with anyone, and they will be able to install the builds to their devices straight from the Expo website. When `distribution` is `internal`, `buildType` needs to be set to `apk`. The default is `store` which means your build URLs won't be sharable. [Learn more about internal distribution](internal-distribution.md).
+- `image` - image with build environment. [Learn more about it here](../build-reference/infrastructure).
+- `node` - version of Node.js
+- `yarn` - version of Yarn
+- `ndk` - version of Android NDK
+- `env` - environment variables that should be set during the build process (should only be used for values that you would commit to your git repository, i.e: not passwords or secrets).
 
 #### Examples
 
@@ -156,20 +180,34 @@ The schema of a build profile for a generic iOS project looks like this:
 ```json
 {
   "workflow": "generic",
+  "extends": string,
   "credentialsSource": "local" | "remote" | "auto", // default: "auto"
   "scheme": string,
   "artifactPath": string, // default: "ios/build/App.ipa"
   "releaseChannel": string, // default: "default"
-  "distribution": "store" | "internal" // default: "store"
+  "distribution": "store", | "internal" // default: "store"
+  "image": string, // default: "default"
+  "node": string,
+  "yarn": string,
+  "fastlane": string,
+  "cocoapods": string,
+  "env": Record<string, string> // default: {}
 }
 ```
 
 - `"workflow": "generic"` indicates that your project is a generic one.
+- `extends` specifies name of build profile that current profile inherits values from.
 - `credentialsSource` defines the source of credentials for this build profile. If you want to provide your own `credentials.json` file, set this to `local` ([learn more on this here](/app-signing/local-credentials.md)). If you want to use the credentials EAS already has stored for you, choose `remote`. If you're not sure what to do, choose `auto` (this is the default option).
 - `scheme` defines the Xcode project's scheme to build. You should set it if your project has multiple schemes. Please note that if the project has only one scheme, it will automatically be detected. However, if multiple schemes exist and this value is **not** set, EAS CLI will prompt you to select one of them.
 - `artifactPath` is the path (or pattern) where EAS Build is going to look for the build artifacts. EAS Build uses the `fast-glob` npm package for pattern matching, ([see their README to learn more about the syntax you can use](https://github.com/mrmlnc/fast-glob#pattern-syntax)). You should modify that path only if you are using a custom `Gymfile`. The default is `ios/build/App.ipa`.
 - `releaseChannel` is the release channel for the `expo-updates` package ([Learn more about this](../distribution/release-channels.md)). If you do not specify a channel, your binary will pull releases from the `default` channel. If you do not use `expo-updates` in your project then this property will have no effect.
 - `distribution` is the flow of distributing your app. If you choose `internal` you'll be able to share your build URLs with anyone, and they will be able to install the builds to their devices straight from the Expo website. The default is `store` which means your build URLs won't be sharable. [Learn more about internal distribution](internal-distribution.md).
+- `image` - image with build environment. [Learn more about it here](../build-reference/infrastructure).
+- `node` - version of Node.js
+- `yarn` - version of Yarn
+- `fastlane` - version of fastlane
+- `cocoapods` - version of CocoaPods
+- `env` - environment variables that should be set during the build process (should only be used for values that you would commit to your git repository, i.e: not passwords or secrets).
 
 #### Examples
 
@@ -199,16 +237,30 @@ The schema of a build profile for a managed iOS project looks like this:
 ```json
 {
   "workflow": "managed",
+  "extends": string,
   "credentialsSource": "local" | "remote" | "auto", // default: "auto"
   "releaseChannel": string, // default: "default"
-  "distribution": "store" | "internal" // default: "store"
+  "distribution": "store" | "internal", // default: "store"
+  "image": string, // default: "default"
+  "node": string,
+  "yarn": string,
+  "fastlane": string,
+  "cocoapods": string,
+  "env": Record<string, string> // default: {}
 }
 ```
 
 - `"workflow": "managed"` indicates that your project is a managed one.
+- `extends` specifies name of build profile that current profile inherits values from.
 - `credentialsSource` defines the source of credentials for this build profile. If you want to provide your own `credentials.json` file, set this to `local` ([learn more on this here](/app-signing/local-credentials.md)). If you want to use the credentials EAS already has stored for you, choose `remote`. If you're not sure what to do, choose `auto` (this is the default option).
 - `releaseChannel` is the release channel for the `expo-updates` package ([Learn more about this](../distribution/release-channels.md)). If you do not specify a channel, your binary will pull releases from the `default` channel. If you do not use `expo-updates` in your project then this property will have no effect.
 - `distribution` is the flow of distributing your app. If you choose `internal` you'll be able to share your build URLs with anyone, and they will be able to install the builds to their devices straight from the Expo website. The default is `store` which means your build URLs won't be sharable. [Learn more Internal Distribution](internal-distribution.md).
+- `image` - image with build environment. [Learn more about it here](../build-reference/infrastructure).
+- `node` - version of Node.js
+- `yarn` - version of Yarn
+- `fastlane` - version of fastlane
+- `cocoapods` - version of CocoaPods
+- `env` - environment variables that should be set during the build process (should only be used for values that you would commit to your git repository, i.e: not passwords or secrets).
 
 #### Examples
 
@@ -228,26 +280,44 @@ The following example of `eas.json` configures both Android and iOS builds:
 {
   "builds": {
     "android": {
+      "base": {
+        "workflow": "generic",
+        "image": "ubuntu-18.04-android-30-ndk-r19c",
+        "ndk": "21.4.7075529",
+        "env": {
+          "EXAMPLE_ENV": "example value"
+        }
+      },
       "release": {
-        "workflow": "generic"
+        "extends": "base",
+        "env": {
+          "ENVIRONMENT": "production"
+        }
       },
       "debug": {
-        "workflow": "generic",
+        "extends": "base",
         "withoutCredentials": true,
         "gradleCommand": ":app:assembleDebug",
-        "artifactPath": "android/app/build/outputs/apk/debug/app-debug.apk"
+        "artifactPath": "android/app/build/outputs/apk/debug/app-debug.apk",
+        "env": {
+          "ENVIRONMENT": "staging"
+        }
       }
     },
     "ios": {
       "release": {
         "workflow": "generic",
+        "image": "macos-catalina-11.15-xcode-12.1",
+        "node": "12.13.0",
+        "yarn": "1.22.5",
         "artifactPath": "ios/my/build/directory/RNApp.ipa"
+      },
+      "adhoc": {
+        "workflow": "generic",
+        "image": "latest",
+        "distribution": "internal"
       }
     }
   }
 }
 ```
-
-For Android, there are two build profiles - `release` and `debug`. The `release` profile is just a basic generic profile. On the other hand, `debug` will let you build a debug APK for your project. _If you want to build using the `debug` profile, run `eas build --platform android --profile debug`._
-
-For iOS, we've defined a generic profile for the project which takes advantage of a custom `Gymfile`, hence the custom `artifactPath` field.


### PR DESCRIPTION
# Why

Documentation on support for configurable build environments

# How

- Build profile  can specify base image name, config of available images is listed in `docs/pages/build-reference/infrastructure.md`
- Build profile supports overriding some of the dependencies from the selected image(node, yarn, ndk, fastlane, cocoapods)
- Build profile can be extended with values from another profile (`extends` keyword)

# Test Plan

`yarn dev`
