### PR TITLE
[docs] Substitute deprecated requestCameraRollPermissionsAsync

### DIFF
--- a/docs/pages/tutorial/image-picker.md
+++ b/docs/pages/tutorial/image-picker.md
@@ -46,7 +46,7 @@ import { Image, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 export default function App() {
   /* @info Request permissions to access the "camera roll", then launch the picker and log the result. */
   let openImagePickerAsync = async () => {
-    let permissionResult = await ImagePicker.requestCameraRollPermissionsAsync();
+    let permissionResult = await ImagePicker.requestMediaLibraryPermissionsAsync();
 
     if (permissionResult.granted === false) {
       alert("Permission to access camera roll is required!");
@@ -96,7 +96,7 @@ export default function App() {
 
 
   let openImagePickerAsync = async () => {
-    let permissionResult = await ImagePicker.requestCameraRollPermissionsAsync();
+    let permissionResult = await ImagePicker.requestMediaLibraryPermissionsAsync();
 
     if (permissionResult.granted === false) {
       alert('Permission to access camera roll is required!');


### PR DESCRIPTION
…estMediaLibraryPermissionsAsync()

# Why

requestCameraRollPermissionsAsync() is depricated (SDK 40.0), new users may be confused and wonder if they are doing something incorrectly when the warning on their IDE / emulator arises.

# How

Just following the docs learning Expo.

# Test Plan

Open a project running SDK 40.0 and try calling requestCameraRollPermissionsAsync() from 'expo-image-picker', you will be greeted with deprecation warnings.
