### PR TITLE
[templates] Fix lint warnings in tabs template

### DIFF
--- a/templates/expo-template-tabs/components/EditScreenInfo.tsx
+++ b/templates/expo-template-tabs/components/EditScreenInfo.tsx
@@ -50,40 +50,12 @@ function handleHelpPress() {
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: '#fff',
-  },
-  developmentModeText: {
-    marginBottom: 20,
-    fontSize: 14,
-    lineHeight: 19,
-    textAlign: 'center',
-  },
-  contentContainer: {
-    paddingTop: 30,
-  },
-  welcomeContainer: {
-    alignItems: 'center',
-    marginTop: 10,
-    marginBottom: 20,
-  },
-  welcomeImage: {
-    width: 100,
-    height: 80,
-    resizeMode: 'contain',
-    marginTop: 3,
-    marginLeft: -10,
-  },
   getStartedContainer: {
     alignItems: 'center',
     marginHorizontal: 50,
   },
   homeScreenFilename: {
     marginVertical: 7,
-  },
-  codeHighlightText: {
-    color: 'rgba(96,100,109, 0.8)',
   },
   codeHighlightContainer: {
     borderRadius: 3,


### PR DESCRIPTION
# Why

Fixes unused var warnings in Tabs template.

*visible when importing the app using Snack*

![image](https://user-images.githubusercontent.com/6184593/107242195-05012b00-6a2c-11eb-8534-2b85337151f6.png)

# How

- Remove unused style definitions

# Test Plan

- Manually verified all removed styles are not used