### PR TITLE
Re-export expo/metro-config from the expo package

### DIFF
--- a/docs/pages/guides/customizing-metro.md
+++ b/docs/pages/guides/customizing-metro.md
@@ -2,7 +2,7 @@
 title: Customizing Metro
 ---
 
-When you run `expo start`, the CLI uses [Metro](https://facebook.github.io/metro/) to bundle JavaScript for Android and iOS platforms. By default Expo CLI will use the Metro configuration defined in the [`@expo/metro-config`](https://github.com/expo/expo-cli/tree/master/packages/metro-config) package (re-exported from `expo` as `expo/metro-config`). You can add custom options for Metro by creating a file named `metro.config.js` in the project root directory.
+When you run `expo start`, the CLI uses [Metro](https://facebook.github.io/metro/) to bundle JavaScript for Android and iOS platforms. By default Expo CLI will use the Metro configuration defined in the [`@expo/metro-config`](https://github.com/expo/expo-cli/tree/master/packages/metro-config) package (re-exported from `expo` as `expo/metro-config` in SDK 41 and greater). You can add custom options for Metro by creating a file named `metro.config.js` in the project root directory.
 
 The `metro.config.js` file looks like this:
 
@@ -24,7 +24,7 @@ module.exports = async () => {
 
 You can find a complete list of supported options in the Metro docs: [Configuring Metro](https://facebook.github.io/metro/docs/configuration). Please note that you only need to specify the options that you want to customize: the custom config will be merged with the defaults from `expo/metro-config` when using Expo CLI.
 
-To add to an value, such as an array of file extensions, defined in the default configuration, you can access the defaults using the `getDefaultConfig(projectRoot)` function defined in `expo/metro-config`.
+To add to a value, such as an array of file extensions, defined in the default configuration, you can access the defaults using the `getDefaultConfig(projectRoot)` function defined in `@expo/metro-config`. Add `@expo/metro-config` to the dependencies of your project to do this. In SDK +41 you can import from `expo/metro-config`.
 
 ## Examples
 
@@ -33,7 +33,7 @@ To add to an value, such as an array of file extensions, defined in the default 
 One use case for custom `metro.config.js` is adding more file extensions that are considered to be an [asset](assets.md). Many image, video, audio and font formats (e.g. `jpg`, `png`, `mp4`, `mp3` and `ttf`) are included by default. To add more asset file extensions, create a `metro.config.js` file in the project root. In the file add the file extension (without a leading `.`) to `assetExts`:
 
 ```js
-const { getDefaultConfig } = require('expo/metro-config');
+const { getDefaultConfig } = require('@expo/metro-config');
 
 const defaultConfig = getDefaultConfig(__dirname);
 

--- a/docs/pages/guides/customizing-metro.md
+++ b/docs/pages/guides/customizing-metro.md
@@ -2,7 +2,7 @@
 title: Customizing Metro
 ---
 
-When you run `expo start`, the CLI uses [Metro](https://facebook.github.io/metro/) to bundle JavaScript for Android and iOS platforms. By default Expo CLI will use the Metro configuration defined in the [`@expo/metro-config`](https://github.com/expo/expo-cli/tree/master/packages/metro-config) package. You can add custom options for Metro by creating a file named `metro.config.js` in the project root directory.
+When you run `expo start`, the CLI uses [Metro](https://facebook.github.io/metro/) to bundle JavaScript for Android and iOS platforms. By default Expo CLI will use the Metro configuration defined in the [`@expo/metro-config`](https://github.com/expo/expo-cli/tree/master/packages/metro-config) package (re-exported from `expo` as `expo/metro-config`). You can add custom options for Metro by creating a file named `metro.config.js` in the project root directory.
 
 The `metro.config.js` file looks like this:
 
@@ -22,9 +22,9 @@ module.exports = async () => {
 };
 ```
 
-You can find a complete list of supported options in the Metro docs: [Configuring Metro](https://facebook.github.io/metro/docs/configuration). Please note that you only need to specify the options that you want to customize: the custom config will be merged with the defaults from `@expo/metro-config` when using Expo CLI.
+You can find a complete list of supported options in the Metro docs: [Configuring Metro](https://facebook.github.io/metro/docs/configuration). Please note that you only need to specify the options that you want to customize: the custom config will be merged with the defaults from `expo/metro-config` when using Expo CLI.
 
-To add to an value, such as an array of file extensions, defined in the default configuration, you can access the defaults using the `getDefaultConfig(projectRoot)` function defined in `@expo/metro-config`. Add `@expo/metro-config` to the dependencies of your project to do this.
+To add to an value, such as an array of file extensions, defined in the default configuration, you can access the defaults using the `getDefaultConfig(projectRoot)` function defined in `expo/metro-config`.
 
 ## Examples
 
@@ -33,7 +33,7 @@ To add to an value, such as an array of file extensions, defined in the default 
 One use case for custom `metro.config.js` is adding more file extensions that are considered to be an [asset](assets.md). Many image, video, audio and font formats (e.g. `jpg`, `png`, `mp4`, `mp3` and `ttf`) are included by default. To add more asset file extensions, create a `metro.config.js` file in the project root. In the file add the file extension (without a leading `.`) to `assetExts`:
 
 ```js
-const { getDefaultConfig } = require('@expo/metro-config');
+const { getDefaultConfig } = require('expo/metro-config');
 
 const defaultConfig = getDefaultConfig(__dirname);
 

--- a/docs/pages/versions/unversioned/sdk/sqlite.md
+++ b/docs/pages/versions/unversioned/sdk/sqlite.md
@@ -97,11 +97,11 @@ A `Transaction` object is passed in as a parameter to the `callback` parameter f
 
 In order to open a new SQLite database using an existing `.db` file you already have, you need to do three things:
 
-- `expo install expo-file-system expo-asset @expo/metro-config`
+- `expo install expo-file-system expo-asset`
 - create a `metro.config.js` file in the root of your project with the following contents ([curious why? read here](../../../guides/customizing-metro.md#adding-more-file-extensions-to--assetexts)):
 
 ```ts
-const { getDefaultConfig } = require('@expo/metro-config');
+const { getDefaultConfig } = require('expo/metro-config');
 
 const defaultConfig = getDefaultConfig(__dirname);
 

--- a/packages/expo/metro-config.js
+++ b/packages/expo/metro-config.js
@@ -1,0 +1,1 @@
+module.exports = require('@expo/metro-config');

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -19,7 +19,8 @@
     "tsconfig.base.json",
     "bundledNativeModules.json",
     "requiresExtraSetup.json",
-    "AppEntry.js"
+    "AppEntry.js",
+    "metro-config.js"
   ],
   "scripts": {
     "generate-lazy": "expo-module babel --config-file ./babel.config.build.js --source-maps --out-file build/ExpoLazy.js build/Expo.js",
@@ -51,6 +52,7 @@
   "homepage": "https://github.com/expo/expo/tree/master/packages/expo",
   "dependencies": {
     "@babel/runtime": "^7.1.2",
+    "@expo/metro-config": "^0.1.54",
     "@expo/vector-icons": "^12.0.0",
     "@unimodules/core": "~7.0.0",
     "@unimodules/react-native-adapter": "~6.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1306,6 +1306,26 @@
     mv "~2"
     safe-json-stringify "~1"
 
+"@expo/config-plugins@1.0.18":
+  version "1.0.18"
+  resolved "https://registry.yarnpkg.com/@expo/config-plugins/-/config-plugins-1.0.18.tgz#f0f7d36316d60ea67b4cc6394bffef6d6904345d"
+  integrity sha512-8Ey+22cEAOxK+SBJY+OazaLsPyL5FXdsykfBg/QQJE2Y/DTFebUVlr5bQyeqavbASDvmDxg3Fd71A8Se8+qT1g==
+  dependencies:
+    "@expo/config-types" "^40.0.0-beta.2"
+    "@expo/configure-splash-screen" "0.3.3"
+    "@expo/image-utils" "0.3.10"
+    "@expo/json-file" "8.2.27"
+    "@expo/plist" "0.0.11"
+    find-up "~5.0.0"
+    fs-extra "9.0.0"
+    getenv "0.7.0"
+    glob "7.1.6"
+    resolve-from "^5.0.0"
+    slash "^3.0.0"
+    slugify "^1.3.4"
+    xcode "^2.1.0"
+    xml2js "^0.4.23"
+
 "@expo/config-plugins@^1.0.12", "@expo/config-plugins@~1.0.13":
   version "1.0.13"
   resolved "https://registry.yarnpkg.com/@expo/config-plugins/-/config-plugins-1.0.13.tgz#26dab0e6280f32512492305ff1eddc5a1dc5142c"
@@ -1377,6 +1397,24 @@
     xcode "^2.1.0"
     xml2js "^0.4.23"
 
+"@expo/config@3.3.28":
+  version "3.3.28"
+  resolved "https://registry.yarnpkg.com/@expo/config/-/config-3.3.28.tgz#8d3869cf9223c35bff4f905595692cb36404c83f"
+  integrity sha512-0zJBOZIl/p4KejUkz6G6uzMjGnWsooWayDk7TeFSCxWZ84HWGCx+LIXbEkc8c/CmMm9HyjYlhESw96mwZZzpPQ==
+  dependencies:
+    "@babel/core" "7.9.0"
+    "@expo/babel-preset-cli" "0.2.18"
+    "@expo/config-plugins" "1.0.18"
+    "@expo/config-types" "^40.0.0-beta.2"
+    "@expo/json-file" "8.2.27"
+    fs-extra "9.0.0"
+    getenv "0.7.0"
+    glob "7.1.6"
+    require-from-string "^2.0.2"
+    resolve-from "^5.0.0"
+    semver "7.3.2"
+    slugify "^1.3.4"
+
 "@expo/config@3.3.4", "@expo/config@^3.2.3":
   version "3.3.4"
   resolved "https://registry.yarnpkg.com/@expo/config/-/config-3.3.4.tgz#85edb23adbdc22e6c43fbc6860653675f9197a58"
@@ -1439,6 +1477,22 @@
   integrity sha512-+KvcPWv/EpAi9ng7KWsRCHUgN8qYcbpvrY8Pc3AtfPVHBhWuy7FhTdT0HUqjhOvqvwPF2Ygr//DHl8WBVg2ICA==
   dependencies:
     "@react-native-community/cli-platform-android" "^4.10.0"
+    "@react-native-community/cli-platform-ios" "^4.10.0"
+    color-string "^1.5.3"
+    commander "^5.1.0"
+    core-js "^3.6.5"
+    deep-equal "^2.0.3"
+    fs-extra "^9.0.0"
+    lodash "^4.17.15"
+    pngjs "^5.0.0"
+    xcode "^3.0.0"
+    xml-js "^1.6.11"
+
+"@expo/configure-splash-screen@0.3.3":
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/@expo/configure-splash-screen/-/configure-splash-screen-0.3.3.tgz#ef44ba4d62443297f9d8a9326a71b40b8b413528"
+  integrity sha512-fWy6Z52Mj2a7yjdvpIJkP9G3kfkoXE79aHvTDwgggIE0KLhwnPF27v+KS0wJUf7b4JM6w0zKOlUZjQhn0kSNyA==
+  dependencies:
     "@react-native-community/cli-platform-ios" "^4.10.0"
     color-string "^1.5.3"
     commander "^5.1.0"
@@ -1579,6 +1633,17 @@
     lodash "^4.17.15"
     write-file-atomic "^2.3.0"
 
+"@expo/json-file@8.2.27":
+  version "8.2.27"
+  resolved "https://registry.yarnpkg.com/@expo/json-file/-/json-file-8.2.27.tgz#548ff0a9989f9f789cdb2b689d17a4faf491de67"
+  integrity sha512-Iyqg1jbXOTg0JfCGwMrkaaRmVFjQrWDBQAhYLTdvOD3GrXYuKI1vUV+3Wqw0NnU+TYoNUpi7aB8dNzPvLj0oag==
+  dependencies:
+    "@babel/code-frame" "~7.10.4"
+    fs-extra "9.0.0"
+    json5 "^1.0.1"
+    lodash "^4.17.19"
+    write-file-atomic "^2.3.0"
+
 "@expo/metro-config@0.1.24":
   version "0.1.24"
   resolved "https://registry.yarnpkg.com/@expo/metro-config/-/metro-config-0.1.24.tgz#ef68931929c3f88ebe6e36b31645cdc242317753"
@@ -1593,6 +1658,14 @@
   integrity sha512-wZ2IWmbawoaMcrRMDJw4t7a3siWXpWS5IdVfhZ15TiLe/xhVa9Vsnk42zsgZs/tf40i25klQhJE+fMMDulXZ0Q==
   dependencies:
     "@expo/config" "3.3.4"
+    metro-react-native-babel-transformer "^0.58.0"
+
+"@expo/metro-config@^0.1.54":
+  version "0.1.54"
+  resolved "https://registry.yarnpkg.com/@expo/metro-config/-/metro-config-0.1.54.tgz#12628d8ad0ff329e88744126348cea41dea75163"
+  integrity sha512-DOlTzNheS5IZDDmQjWt60mAmbFreH8xT3ZXc6y/k4UVq7khQ41/g5kl1AJOC9WzE6xgPtmDQqTWanBprn+OhzA==
+  dependencies:
+    "@expo/config" "3.3.28"
     metro-react-native-babel-transformer "^0.58.0"
 
 "@expo/mux@^1.0.7":


### PR DESCRIPTION
# Why

1. For EAS managed projects, the config needs to be the same as the default used in `expo-cli`, we can ensure the same metro-config is used by vendoring it in `expo`.
2. Adding a versioned `@expo/metro-config` will improve long term stability for older projects.

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How

Re-export `@expo/metro-config` from `expo/metro-config` and update docs.

<!-- 
How did you build this feature or fix this bug and why? 
-->
