### PR TITLE
Fix missing async storage in ejected NCL

### DIFF
--- a/apps/native-component-list/app.config.js
+++ b/apps/native-component-list/app.config.js
@@ -7,6 +7,8 @@ export default ({ config }) => {
     './plugins/withNotFoundModule',
     // Add the React DevMenu back to the client.
     './plugins/withDevMenu',
+    // Add AsyncStorage
+    './plugins/withExpoAsyncStorage',
     // Set the minimum version to 11 for Google Sign-In support -- TODO: Maybe this belongs in expo-google-sign-in?
     ['./plugins/withPodfileMinVersion', '11.0'],
 

--- a/apps/native-component-list/plugins/withExpoAsyncStorage.js
+++ b/apps/native-component-list/plugins/withExpoAsyncStorage.js
@@ -38,7 +38,6 @@ const withExpoAsyncStorage = config => {
   return extraModules;`
           );
         }
-
       } else {
         throw new Error(
           `Cannot append DevMenu module to AppDelegate of language "${fileInfo.language}"`

--- a/apps/native-component-list/plugins/withExpoAsyncStorage.js
+++ b/apps/native-component-list/plugins/withExpoAsyncStorage.js
@@ -1,0 +1,54 @@
+const { withDangerousMod, IOSConfig } = require('@expo/config-plugins');
+const fs = require('fs-extra');
+
+const withExpoAsyncStorage = config => {
+  return withDangerousMod(config, [
+    'ios',
+    async config => {
+      const fileInfo = IOSConfig.Paths.getAppDelegate(config.modRequest.projectRoot);
+      let contents = await fs.readFile(fileInfo.path, 'utf-8');
+      if (fileInfo.language === 'objc') {
+        // Add DevMenu imports
+        if (!contents.includes('#import <React/RCTAsyncLocalStorage.h>')) {
+          contents = contents.replace(
+            /#import "AppDelegate.h"/g,
+            `#import "AppDelegate.h"
+#import <React/RCTAsyncLocalStorage.h>`
+          );
+        }
+
+        // Make the extraModules mutable
+        const modulesRegex = /NSArray<id<RCTBridgeModule>>\s?\*extraModules\s?=\s?\[_moduleRegistryAdapter extraModulesForBridge:bridge\];/;
+        if (contents.match(modulesRegex)) {
+          contents = contents.replace(
+            modulesRegex,
+            'NSMutableArray<id<RCTBridgeModule>> *extraModules = [NSMutableArray arrayWithArray:[_moduleRegistryAdapter extraModulesForBridge:bridge]];'
+          );
+        }
+
+        // Add AsyncStorage back
+        if (
+          !contents.includes(
+            '[extraModules addObject:[[RCTAsyncLocalStorage alloc] initWithStorageDirectory:[[NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) firstObject] stringByAppendingPathComponent:@"RCTAsyncLocalStorage_V1"]]];'
+          )
+        ) {
+          contents = contents.replace(
+            /return extraModules;/g,
+            `[extraModules addObject:[[RCTAsyncLocalStorage alloc] initWithStorageDirectory:[[NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) firstObject] stringByAppendingPathComponent:@"RCTAsyncLocalStorage_V1"]]];
+  return extraModules;`
+          );
+        }
+
+      } else {
+        throw new Error(
+          `Cannot append DevMenu module to AppDelegate of language "${fileInfo.language}"`
+        );
+      }
+      await fs.writeFile(fileInfo.path, contents);
+
+      return config;
+    },
+  ]);
+};
+
+module.exports = withExpoAsyncStorage;


### PR DESCRIPTION
# Why

Running `expo prebuild` in `apps/native-component-list`, then running the project on iOS was failing because AsyncStorage wasn't being added back (since our RN fork removes it).
This PR adds a plugin to inject the AsyncStorage module back into the project.