### PR TITLE
[ncl] add dev menu to native-component-list

### DIFF
--- a/apps/native-component-list/app.config.js
+++ b/apps/native-component-list/app.config.js
@@ -1,12 +1,17 @@
 export default ({ config }) => {
   config.version = '40.0.0';
   config.sdkVersion = '40.0.0';
-  config.plugins = [
+
+  if (!Array.isArray(config.plugins)) {
+    config.plugins = [];
+  }
+  config.plugins.push('expo-dev-menu', 'expo-dev-launcher');
+  config.plugins.push(
     // iOS plugins
     // Add a plugin to modify the AppDelegate.
     './plugins/withNotFoundModule',
     // Add the React DevMenu back to the client.
-    './plugins/withDevMenu',
+    // './plugins/withDevMenu',
     // Set the minimum version to 11 for Google Sign-In support -- TODO: Maybe this belongs in expo-google-sign-in?
     ['./plugins/withPodfileMinVersion', '11.0'],
 
@@ -29,8 +34,8 @@ export default ({ config }) => {
         packageName: 'unimodules-test-core',
         packagePath: '../../../packages/unimodules-test-core/android',
       },
-    ],
-  ];
+    ]
+  );
 
   config.plugins.push([
     'expo-payments-stripe',

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -83,6 +83,8 @@
     "expo-constants": "~10.0.1",
     "expo-contacts": "~9.0.0",
     "expo-device": "~3.1.1",
+    "expo-dev-menu": "~0.3.1",
+    "expo-dev-menu-interface": "~0.1.2",
     "expo-document-picker": "~9.0.1",
     "expo-face-detector": "~9.0.1",
     "expo-facebook": "~10.0.0",

--- a/packages/expo-dev-launcher/plugin/build/withDevLauncher.js
+++ b/packages/expo-dev-launcher/plugin/build/withDevLauncher.js
@@ -165,7 +165,7 @@ const withDevLauncherPodfile = config => {
         async (config) => {
             await editPodfile(config, podfile => {
                 podfile = podfile.replace("platform :ios, '10.0'", "platform :ios, '11.0'");
-                podfile = addLines(podfile, 'use_react_native', 0, [`  ${DEV_LAUNCHER_POD_IMPORT}`]);
+                // podfile = addLines(podfile, 'use_react_native', 0, [`  ${DEV_LAUNCHER_POD_IMPORT}`]);
                 return podfile;
             });
             return config;

--- a/packages/expo-dev-launcher/plugin/src/withDevLauncher.ts
+++ b/packages/expo-dev-launcher/plugin/src/withDevLauncher.ts
@@ -218,7 +218,7 @@ const withDevLauncherPodfile: ConfigPlugin = config => {
     async config => {
       await editPodfile(config, podfile => {
         podfile = podfile.replace("platform :ios, '10.0'", "platform :ios, '11.0'");
-        podfile = addLines(podfile, 'use_react_native', 0, [`  ${DEV_LAUNCHER_POD_IMPORT}`]);
+        // podfile = addLines(podfile, 'use_react_native', 0, [`  ${DEV_LAUNCHER_POD_IMPORT}`]);
         return podfile;
       });
       return config;

--- a/packages/expo-dev-menu/plugin/build/withDevMenu.js
+++ b/packages/expo-dev-menu/plugin/build/withDevMenu.js
@@ -85,7 +85,7 @@ const withDevMenuPodfile = config => {
         async (config) => {
             await editPodfile(config, podfile => {
                 podfile = podfile.replace("platform :ios, '10.0'", "platform :ios, '11.0'");
-                podfile = addLines(podfile, 'use_react_native', 0, [`  ${DEV_MENU_POD_IMPORT}`]);
+                // podfile = addLines(podfile, 'use_react_native', 0, [`  ${DEV_MENU_POD_IMPORT}`]);
                 return podfile;
             });
             return config;

--- a/packages/expo-dev-menu/plugin/src/withDevMenu.ts
+++ b/packages/expo-dev-menu/plugin/src/withDevMenu.ts
@@ -116,7 +116,7 @@ const withDevMenuPodfile: ConfigPlugin = config => {
     async config => {
       await editPodfile(config, podfile => {
         podfile = podfile.replace("platform :ios, '10.0'", "platform :ios, '11.0'");
-        podfile = addLines(podfile, 'use_react_native', 0, [`  ${DEV_MENU_POD_IMPORT}`]);
+        // podfile = addLines(podfile, 'use_react_native', 0, [`  ${DEV_MENU_POD_IMPORT}`]);
         return podfile;
       });
       return config;


### PR DESCRIPTION
# Why

- Test dev-menu plugins in bare workflow
<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How

- Disable `./withDevMenu` (RCT DevMenu)
- Added `'expo-dev-menu', 'expo-dev-launcher'` plugins (first because they currently break other plugins by creating a new `@end` line).
- Added `'expo-dev-menu', 'expo-dev-launcher'`to NCL dependencies so RN autolinking would pick them up.
- Disabled cocoapods edits in plugins (temporary) because they conflict with RN autolinking it seems.

# Test Plan

- `expo prebuild --no-install` in `apps/native-component-list`
- Undo changes to package.json (breaks expo-updates by using the prod version)
- `npx react-native start --reset-cache` in `apps/native-component-list`
- `yarn ios` and `yarn android` in `apps/native-component-list`
- App should build as expected on iOS and android


