### PR TITLE
[expo-updates] modernize caching behavior for manifests

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Fixed discrepancies across platforms regarding required fields in manifests ([#11562](https://github.com/expo/expo/pull/11562) by [@esamelson](https://github.com/esamelson))
 - Improved support for `assetUrlOverride` in legacy self-hosted apps ([#11601](https://github.com/expo/expo/pull/11601))
 - Stop expecting data and publicManifest root level keys for EAS manifests ([#11613](https://github.com/expo/expo/pull/11613) by [@esamelson](https://github.com/esamelson))
+- Stop overriding cache-control headers for non-legacy manifests ([#11875](https://github.com/expo/expo/pull/11875) by [@esamelson](https://github.com/esamelson))
 
 ## 0.4.2 - 2020-02-16
 

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/FileDownloaderTest.java
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/FileDownloaderTest.java
@@ -1,0 +1,51 @@
+package expo.modules.updates.loader;
+
+import android.content.Context;
+import android.net.Uri;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.HashMap;
+
+import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner;
+import androidx.test.platform.app.InstrumentationRegistry;
+import expo.modules.updates.UpdatesConfiguration;
+import okhttp3.Request;
+
+@RunWith(AndroidJUnit4ClassRunner.class)
+public class FileDownloaderTest {
+
+  private Context context;
+
+  @Before
+  public void setup() {
+    context = InstrumentationRegistry.getInstrumentation().getTargetContext();
+  }
+
+  @Test
+  public void testCacheControl_LegacyManifest() {
+    HashMap<String, Object> configMap = new HashMap<>();
+    configMap.put("updateUrl", Uri.parse("https://exp.host/@test/test"));
+    configMap.put("runtimeVersion", "1.0");
+    configMap.put("usesLegacyManifest", true);
+    UpdatesConfiguration config = new UpdatesConfiguration().loadValuesFromMap(configMap);
+
+    Request actual = FileDownloader.setHeadersForManifestUrl(config, context);
+    Assert.assertEquals("no-cache", actual.header("Cache-Control"));
+  }
+
+  @Test
+  public void testCacheControl_NewManifest() {
+    HashMap<String, Object> configMap = new HashMap<>();
+    configMap.put("updateUrl", Uri.parse("https://exp.host/@test/test"));
+    configMap.put("runtimeVersion", "1.0");
+    configMap.put("usesLegacyManifest", false);
+    UpdatesConfiguration config = new UpdatesConfiguration().loadValuesFromMap(configMap);
+
+    Request actual = FileDownloader.setHeadersForManifestUrl(config, context);
+    Assert.assertNull(actual.header("Cache-Control"));
+  }
+}

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/DatabaseLauncher.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/DatabaseLauncher.java
@@ -180,7 +180,7 @@ public class DatabaseLauncher implements Launcher {
     if (!assetFileExists) {
       // we still don't have the asset locally, so try downloading it remotely
       mAssetsToDownload++;
-      FileDownloader.downloadAsset(asset, mUpdatesDirectory, mConfiguration, new FileDownloader.AssetDownloadCallback() {
+      FileDownloader.downloadAsset(asset, mUpdatesDirectory, mConfiguration, context, new FileDownloader.AssetDownloadCallback() {
         @Override
         public void onFailure(Exception e, AssetEntity assetEntity) {
           Log.e(TAG, "Failed to load asset from disk or network", e);

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/Crypto.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/Crypto.java
@@ -1,6 +1,7 @@
 package expo.modules.updates.loader;
 
 import android.annotation.SuppressLint;
+import android.content.Context;
 import android.security.keystore.KeyProperties;
 import android.util.Base64;
 
@@ -29,14 +30,14 @@ public class Crypto {
 
   private static String PUBLIC_KEY_URL = "https://exp.host/--/manifest-public-key";
 
-  public static void verifyPublicRSASignature(final String plainText, final String cipherText, final RSASignatureListener listener) {
-    fetchPublicKeyAndVerifyPublicRSASignature(true, plainText, cipherText, listener);
+  public static void verifyPublicRSASignature(final String plainText, final String cipherText, final Context context, final RSASignatureListener listener) {
+    fetchPublicKeyAndVerifyPublicRSASignature(true, plainText, cipherText, context, listener);
   }
 
   // On first attempt use cache. If verification fails try a second attempt without
   // cache in case the keys were actually rotated.
   // On second attempt reject promise if it fails.
-  private static void fetchPublicKeyAndVerifyPublicRSASignature(final boolean isFirstAttempt, final String plainText, final String cipherText, final RSASignatureListener listener) {
+  private static void fetchPublicKeyAndVerifyPublicRSASignature(final boolean isFirstAttempt, final String plainText, final String cipherText, final Context context, final RSASignatureListener listener) {
     final CacheControl cacheControl = isFirstAttempt ? CacheControl.FORCE_CACHE : CacheControl.FORCE_NETWORK;
 
     final Request request = new Request.Builder()
@@ -44,7 +45,7 @@ public class Crypto {
             .cacheControl(cacheControl)
             .build();
 
-    FileDownloader.downloadData(request, new Callback() {
+    FileDownloader.downloadData(request, context, new Callback() {
       @Override
       public void onFailure(Call call, IOException e) {
         listener.onError(e, true);
@@ -63,7 +64,7 @@ public class Crypto {
         }
 
         if (isFirstAttempt) {
-          fetchPublicKeyAndVerifyPublicRSASignature(false, plainText, cipherText, listener);
+          fetchPublicKeyAndVerifyPublicRSASignature(false, plainText, cipherText, context, listener);
         } else {
           listener.onError(exception, false);
         }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.java
@@ -252,7 +252,7 @@ public class FileDownloader {
     return requestBuilder.build();
   }
 
-  private static Request setHeadersForManifestUrl(UpdatesConfiguration configuration, Context context) {
+  /* package */ static Request setHeadersForManifestUrl(UpdatesConfiguration configuration, Context context) {
     Request.Builder requestBuilder = new Request.Builder()
             .url(configuration.getUpdateUrl().toString())
             .header("Accept", "application/expo+json,application/json")
@@ -261,8 +261,12 @@ public class FileDownloader {
             .header("Expo-Updates-Environment", "BARE")
             .header("Expo-JSON-Error", "true")
             // as of 2020-11-25, the EAS Update alpha returns an error if Expo-Accept-Signature: true is included in the request
-            .header("Expo-Accept-Signature", String.valueOf(configuration.usesLegacyManifest()))
-            .cacheControl(CacheControl.FORCE_NETWORK);
+            .header("Expo-Accept-Signature", String.valueOf(configuration.usesLegacyManifest()));
+
+    // legacy manifest loads should ignore cache-control headers from the server and always load remotely
+    if (configuration.usesLegacyManifest()) {
+      requestBuilder = requestBuilder.cacheControl(CacheControl.FORCE_NETWORK);
+    }
 
     String runtimeVersion = configuration.getRuntimeVersion();
     String sdkVersion = configuration.getSdkVersion();

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/RemoteLoader.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/RemoteLoader.java
@@ -183,7 +183,7 @@ public class RemoteLoader {
         continue;
       }
 
-      FileDownloader.downloadAsset(assetEntity, mUpdatesDirectory, mConfiguration, new FileDownloader.AssetDownloadCallback() {
+      FileDownloader.downloadAsset(assetEntity, mUpdatesDirectory, mConfiguration, mContext, new FileDownloader.AssetDownloadCallback() {
         @Override
         public void onFailure(Exception e, AssetEntity assetEntity) {
           Log.e(TAG, "Failed to download asset from " + assetEntity.url, e);

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.h
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.h
@@ -31,6 +31,11 @@ typedef void (^EXUpdatesFileDownloaderErrorBlock)(NSError *error, NSURLResponse 
 
 + (dispatch_queue_t)assetFilesQueue;
 
+/**
+ * For test purposes; shouldn't be needed in application code
+ */
+- (NSURLRequest *)createManifestRequestWithURL:(NSURL *)url;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.m
@@ -74,15 +74,26 @@ NSTimeInterval const EXUpdatesDefaultTimeoutInterval = 60;
   } errorBlock:errorBlock];
 }
 
+- (NSURLRequest *)createManifestRequestWithURL:(NSURL *)url
+{
+  NSURLRequestCachePolicy cachePolicy = _sessionConfiguration ? _sessionConfiguration.requestCachePolicy : NSURLRequestUseProtocolCachePolicy;
+  if (_config.usesLegacyManifest) {
+    // legacy manifest loads should ignore cache-control headers from the server and always load remotely
+    cachePolicy = NSURLRequestReloadIgnoringLocalCacheData;
+  }
+
+  NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url cachePolicy:cachePolicy timeoutInterval:EXUpdatesDefaultTimeoutInterval];
+  [self _setManifestHTTPHeaderFields:request];
+
+  return request;
+}
+
 - (void)downloadManifestFromURL:(NSURL *)url
                    withDatabase:(EXUpdatesDatabase *)database
                    successBlock:(EXUpdatesFileDownloaderManifestSuccessBlock)successBlock
                      errorBlock:(EXUpdatesFileDownloaderErrorBlock)errorBlock
 {
-  NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url
-                                                         cachePolicy:NSURLRequestReloadIgnoringLocalCacheData
-                                                     timeoutInterval:EXUpdatesDefaultTimeoutInterval];
-  [self _setManifestHTTPHeaderFields:request];
+  NSURLRequest *request = [self createManifestRequestWithURL:url];
   [self _downloadDataWithRequest:request successBlock:^(NSData *data, NSURLResponse *response) {
     NSError *err;
     id parsedJson = [NSJSONSerialization JSONObjectWithData:data options:kNilOptions error:&err];

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.m
@@ -169,7 +169,7 @@ NSTimeInterval const EXUpdatesDefaultTimeoutInterval = 60;
   NSURLSessionDataTask *task = [_session dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
     if (!error && [response isKindOfClass:[NSHTTPURLResponse class]]) {
       NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
-      if (httpResponse.statusCode != 200) {
+      if (httpResponse.statusCode < 200 || httpResponse.statusCode >= 300) {
         NSStringEncoding encoding = [self _encodingFromResponse:response];
         NSString *body = [[NSString alloc] initWithData:data encoding:encoding];
         error = [self _errorFromResponse:httpResponse body:body];

--- a/packages/expo-updates/ios/Tests/EXUpdatesFileDownloaderTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesFileDownloaderTests.m
@@ -1,0 +1,53 @@
+//  Copyright (c) 2021 650 Industries, Inc. All rights reserved.
+
+#import <XCTest/XCTest.h>
+
+#import <EXUpdates/EXUpdatesConfig.h>
+#import <EXUpdates/EXUpdatesFileDownloader.h>
+
+@interface EXUpdatesFileDownloaderTests : XCTestCase
+
+@end
+
+@implementation EXUpdatesFileDownloaderTests
+
+- (void)setUp
+{
+  // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown
+{
+  // Put teardown code here. This method is called after the invocation of each test method in the class.
+}
+
+- (void)testCacheControl_LegacyManifest
+{
+  EXUpdatesConfig *config = [EXUpdatesConfig configWithDictionary:@{
+    @"EXUpdatesURL": @"https://exp.host/@test/test",
+    @"EXUpdatesRuntimeVersion": @"1.0",
+    @"EXUpdatesUsesLegacyManifest": @(YES)
+  }];
+  EXUpdatesFileDownloader *downloader = [[EXUpdatesFileDownloader alloc] initWithUpdatesConfig:config];
+
+  NSURLRequest *actual = [downloader createManifestRequestWithURL:[NSURL URLWithString:@"https://exp.host/@test/test"]];
+  XCTAssertEqual(NSURLRequestReloadIgnoringCacheData, actual.cachePolicy);
+  // this fails, seems like this header isn't actually set on the object until later
+  // XCTAssertEqualObjects(@"no-cache", [actual valueForHTTPHeaderField:@"Cache-Control"]);
+}
+
+- (void)testCacheControl_NewManifest
+{
+  EXUpdatesConfig *config = [EXUpdatesConfig configWithDictionary:@{
+    @"EXUpdatesURL": @"https://exp.host/@test/test",
+    @"EXUpdatesRuntimeVersion": @"1.0",
+    @"EXUpdatesUsesLegacyManifest": @(NO)
+  }];
+  EXUpdatesFileDownloader *downloader = [[EXUpdatesFileDownloader alloc] initWithUpdatesConfig:config];
+
+  NSURLRequest *actual = [downloader createManifestRequestWithURL:[NSURL URLWithString:@"https://exp.host/@test/test"]];
+  XCTAssertEqual(NSURLRequestUseProtocolCachePolicy, actual.cachePolicy);
+  XCTAssertNil([actual valueForHTTPHeaderField:@"Cache-Control"]);
+}
+
+@end


### PR DESCRIPTION
# Why

For EAS update manifests, we want to respect the server's specified cache-control behavior rather than always overriding it with `no-cache`.

# How

- gate the override on the `usesLegacyManifest` value -- this is safest since legacy manifests (especially some self-hosted manifests) may be relying on this behavior; we've been doing this cache-control override for years in the managed workflow clients.
- on Android, I needed to add a cache to our OkHttpClient -- you must add a cache explicitly to OkHttp, there isn't one by default, and we weren't using any OkHttp cache previously.
- made one other small change on iOS to accept responses with status code inside of [200, 300); this matches the corresponding `response.isSuccessful()` check on Android.

# Test Plan

Added tests and they pass ✅ 
