### PR TITLE
[docs] Add Video snack example

### DIFF
--- a/docs/pages/versions/unversioned/sdk/video.md
+++ b/docs/pages/versions/unversioned/sdk/video.md
@@ -5,6 +5,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-av'
 
 import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
+import SnackInline from '~/components/plugins/SnackInline';
 
 The `Video` component from **`expo-av`** displays a video inline with the other UI elements in your app.
 
@@ -18,20 +19,65 @@ Much of Video and Audio have common APIs that are documented in [AV documentatio
 
 ## Usage
 
-Here's a simple example of a video that autoplays and loops.
+Here's a simple example of a video with a play/pause button.
 
-```javascript
-<Video
-  source={{ uri: 'http://d23dyxeqlo5psv.cloudfront.net/big_buck_bunny.mp4' }}
-  rate={1.0}
-  volume={1.0}
-  isMuted={false}
-  resizeMode="cover"
-  shouldPlay
-  isLooping
-  style={{ width: 300, height: 300 }}
-/>
+<SnackInline label='Video' dependencies={['expo-av', 'expo-asset']}>
+
+```jsx
+import * as React from 'react';
+import { View, StyleSheet, Button } from 'react-native';
+import { Video, AVPlaybackStatus } from 'expo-av';
+
+export default function App() {
+  const video = React.useRef(null);
+  const [status, setStatus] = React.useState({});
+  return (
+    <View style={styles.container}>
+      <Video
+        ref={video}
+        style={styles.video}
+        source={{
+          uri: 'http://d23dyxeqlo5psv.cloudfront.net/big_buck_bunny.mp4',
+        }}
+        useNativeControls
+        resizeMode="contain"
+        isLooping
+        onPlaybackStatusUpdate={status => setStatus(() => status)}
+      />
+      <View style={styles.buttons}>
+        <Button
+          title={status.isPlaying ? 'Pause' : 'Play'}
+          onPress={() =>
+            status.isPlaying ? video.current.pauseAsync() : video.current.playAsync()
+          }
+        />
+      </View>
+    </View>
+  );
+}
+
+/* @hide const styles = StyleSheet.create({ ... }); */
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    backgroundColor: '#ecf0f1',
+  },
+  video: {
+    alignSelf: 'center',
+    width: 320,
+    height: 200,
+  },
+  buttons: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});
+/* @end */
 ```
+
+</SnackInline>
 
 For more advanced examples, check out the [Playlist example](https://github.com/expo/playlist-example/blob/master/App.js), and the [custom videoplayer controls component](https://github.com/ihmpavel/expo-video-player/blob/master/lib/index.tsx) that wraps `<Video>`, adds custom controls and use the `<Video>` API extensively. The videoplayer controls is used in [this app](https://github.com/expo/harvard-cs50-app).
 

--- a/docs/pages/versions/v40.0.0/sdk/video.md
+++ b/docs/pages/versions/v40.0.0/sdk/video.md
@@ -5,6 +5,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-40/packages/expo-av'
 
 import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
+import SnackInline from '~/components/plugins/SnackInline';
 
 The `Video` component from **`expo-av`** displays a video inline with the other UI elements in your app.
 
@@ -18,20 +19,65 @@ Much of Video and Audio have common APIs that are documented in [AV documentatio
 
 ## Usage
 
-Here's a simple example of a video that autoplays and loops.
+Here's a simple example of a video with a play/pause button.
 
-```javascript
-<Video
-  source={{ uri: 'http://d23dyxeqlo5psv.cloudfront.net/big_buck_bunny.mp4' }}
-  rate={1.0}
-  volume={1.0}
-  isMuted={false}
-  resizeMode="cover"
-  shouldPlay
-  isLooping
-  style={{ width: 300, height: 300 }}
-/>
+<SnackInline label='Video' dependencies={['expo-av', 'expo-asset']}>
+
+```jsx
+import * as React from 'react';
+import { View, StyleSheet, Button } from 'react-native';
+import { Video, AVPlaybackStatus } from 'expo-av';
+
+export default function App() {
+  const video = React.useRef(null);
+  const [status, setStatus] = React.useState({});
+  return (
+    <View style={styles.container}>
+      <Video
+        ref={video}
+        style={styles.video}
+        source={{
+          uri: 'http://d23dyxeqlo5psv.cloudfront.net/big_buck_bunny.mp4',
+        }}
+        useNativeControls
+        resizeMode="contain"
+        isLooping
+        onPlaybackStatusUpdate={status => setStatus(() => status)}
+      />
+      <View style={styles.buttons}>
+        <Button
+          title={status.isPlaying ? 'Pause' : 'Play'}
+          onPress={() =>
+            status.isPlaying ? video.current.pauseAsync() : video.current.playAsync()
+          }
+        />
+      </View>
+    </View>
+  );
+}
+
+/* @hide const styles = StyleSheet.create({ ... }); */
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    backgroundColor: '#ecf0f1',
+  },
+  video: {
+    alignSelf: 'center',
+    width: 320,
+    height: 200,
+  },
+  buttons: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});
+/* @end */
 ```
+
+</SnackInline>
 
 For more advanced examples, check out the [Playlist example](https://github.com/expo/playlist-example/blob/master/App.js), and the [custom videoplayer controls component](https://github.com/ihmpavel/expo-video-player/blob/master/lib/index.tsx) that wraps `<Video>`, adds custom controls and use the `<Video>` API extensively. The videoplayer controls is used in [this app](https://github.com/expo/harvard-cs50-app).
 


### PR DESCRIPTION
# Why

Adds a working Snack example for the `<Video>` component.

https://snack.expo.io/@hein_expo/video

![image](https://user-images.githubusercontent.com/6184593/107351906-7a700880-6acb-11eb-88a8-484551e06c7f.png)

# How

- Add snack example for unversioned and SDK 40

# Test Plan

- See screenshot in why
- View working Snack here https://snack.expo.io/@hein_expo/video