### PR TITLE
[github] Better node_modules caching in SDK workflow

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -28,24 +28,28 @@ jobs:
   check-packages:
     runs-on: ubuntu-18.04
     steps:
-      - name: Checkout a ref for the event
+      - name: 👀 Checkout a ref for the event
         uses: actions/checkout@v2
         with:
           fetch-depth: 100
-      - name: Fetch commits from base branch
+      - name: ⬇️ Fetch commits from base branch
         run: git fetch origin ${{ github.event.before || github.base_ref || 'master' }}:${{ github.event.before || github.base_ref || 'master' }} --depth 100
         if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v1
+      - name: 🧶 Restore node modules in root dir
+        uses: actions/cache@v2
+        id: node-modules-cache
         with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-      - run: yarn install --frozen-lockfile
-      - name: Check packages
+          path: node_modules
+          key: ${{ runner.os }}-modules-${{ hashFiles('yarn.lock') }}
+      - name: 🧶 Install node modules in root dir
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
+        run: yarn install --frozen-lockfile
+      - name: 🧶 Restore node modules in tools
+        uses: actions/cache@v2
+        with:
+          path: tools/node_modules
+          key: ${{ runner.os }}-modules-${{ hashFiles('tools/yarn.lock') }}
+      - name: 🧐 Check packages
         run: |
           echo "Checking packages according to the event name: ${{ github.event_name }}"
           if [[ "${{ github.event_name }}" == "schedule" || "${{ github.event.inputs.checkAll }}" == "check-all" ]]; then
@@ -56,7 +60,8 @@ jobs:
             # In pull requests and workflow_dispatch events check all packages changed in the entire PR.
             bin/expotools check-packages --since ${{ github.event.before || github.base_ref || 'master' }}
           fi
-      - uses: 8398a7/action-slack@v3
+      - name: 🔔 Notify on Slack
+        uses: 8398a7/action-slack@v3
         if: failure() && (github.event.ref == 'refs/heads/master' || startsWith(github.event.ref, 'refs/heads/sdk-'))
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -35,18 +35,20 @@ jobs:
       - name: ⬇️ Fetch commits from base branch
         run: git fetch origin ${{ github.event.before || github.base_ref || 'master' }}:${{ github.event.before || github.base_ref || 'master' }} --depth 100
         if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-      - name: 🧶 Restore node modules in root dir
+      - name: ♻️ Restore workspace node modules
         uses: actions/cache@v2
         id: node-modules-cache
         with:
           path: |
+            # See "workspaces" → "packages" in the root package.json for the source of truth of
+            # which node_modules are affected by the root yarn.lock
             **/node_modules
             !tools
           key: ${{ runner.os }}-modules-${{ hashFiles('yarn.lock') }}
       - name: 🧶 Install node modules in root dir
         if: steps.node-modules-cache.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile
-      - name: 🧶 Restore node modules in tools
+      - name: ♻️ Restore node modules in tools
         uses: actions/cache@v2
         with:
           path: tools/node_modules

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -39,7 +39,9 @@ jobs:
         uses: actions/cache@v2
         id: node-modules-cache
         with:
-          path: node_modules
+          path: |
+            **/node_modules
+            !tools
           key: ${{ runner.os }}-modules-${{ hashFiles('yarn.lock') }}
       - name: 🧶 Install node modules in root dir
         if: steps.node-modules-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
# Why

I noticed that the way to cache node modules recommended by GitHub is not so good because it still needs to run yarn that takes some time on resolving the dependencies in the workspace. Restoring yarn's cache and running yarn usually takes about 2 minutes.

However, instead of caching yarn cache, caching `node_modules` folder seems to be a better option for two reasons:
- on cache hit, we don't need to run yarn (one and a half minutes less)
- node_modules seems to be smaller than yarn's cache

Looks like someone else also noticed this thing: https://dev.to/mpocock1/how-to-cache-nodemodules-in-github-actions-with-yarn-24eh

# How

Replaced some steps in SDK workflow to cache `node_modules` instead of yarn's cache.
(also added some emojis and step names for a better look)

# Test Plan

CI job passes and is faster than previously by about 2 minutes
