### PR TITLE
@jjborie - expo-font Patch default load timeout

### DIFF
--- a/packages/expo-font/build/ExpoFontLoader.web.js
+++ b/packages/expo-font/build/ExpoFontLoader.web.js
@@ -1,5 +1,6 @@
 import { CodedError, Platform } from '@unimodules/core';
 import FontObserver from 'fontfaceobserver';
+import Constants from 'expo-constants';
 import { FontDisplay } from './Font.types';
 function getFontFaceStyleSheet() {
     if (!Platform.isDOMAvailable) {
@@ -65,7 +66,9 @@ export default {
         if (!isFontLoadingListenerSupported()) {
             return;
         }
-        return new FontObserver(fontFamilyName, { display: resource.display }).load();
+        // Change default value in app.json extra. "extra": {"expoFontTimeout": 60000}
+        const timeout = Constants.manifest.extra.expoFontTimeout || 3000;
+        return new FontObserver(fontFamilyName, { display: resource.display }).load(null, timeout);
     },
 };
 const ID = 'expo-generated-fonts';

--- a/packages/expo-font/src/ExpoFontLoader.web.ts
+++ b/packages/expo-font/src/ExpoFontLoader.web.ts
@@ -1,6 +1,6 @@
 import { CodedError, Platform } from '@unimodules/core';
 import FontObserver from 'fontfaceobserver';
-
+import Constants from 'expo-constants';
 import { UnloadFontOptions } from './Font';
 import { FontDisplay, FontResource } from './Font.types';
 
@@ -88,8 +88,9 @@ export default {
     if (!isFontLoadingListenerSupported()) {
       return;
     }
-
-    return new FontObserver(fontFamilyName, { display: resource.display }).load();
+    // Change default value in app.json extra. "extra": {"expoFontTimeout": 60000}
+    const timeout = Constants.manifest.extra.expoFontTimeout || 3000;
+    return new FontObserver(fontFamilyName, { display: resource.display }).load(null, timeout);
   },
 };
 


### PR DESCRIPTION
# Why

When you are on a slow network the default timeout to load font of 3000ms is not enough. We need a way to change this value.

# How

I propose to use an extra variable inside app.json : "extra": {"expoFontTimeout": 60000}

# Test Plan

You can use expo web and in chrome developer console change the network speed to 3s, you will see the loading the of the font is failing because of the 3000ms default timeout. When you change to a higher value, you don't have the issue anymore.
