### PR TITLE
[docs] Add Snack example for Clipboard API

### DIFF
--- a/docs/pages/versions/unversioned/sdk/clipboard.md
+++ b/docs/pages/versions/unversioned/sdk/clipboard.md
@@ -90,6 +90,6 @@ Sets the content of the user's clipboard.
 
 - **value (_string_)** -- The string to save to the clipboard.
 
-## Returns
+#### Returns
 
 On web, this retuns a boolean value indicating whether or not the string was saved to the user's clipboard. On iOS and Android, nothing is returned.

--- a/docs/pages/versions/unversioned/sdk/clipboard.md
+++ b/docs/pages/versions/unversioned/sdk/clipboard.md
@@ -28,7 +28,8 @@ export default function App() {
   const [copiedText, setCopiedText] = React.useState('');
 
   const copyToClipboard = () => {
-    /* @info */ Clipboard.setString('hello world'); /* @end */
+    /* @info */ Clipboard.setString('hello world');
+  /* @end */
   };
 
   const fetchCopiedText = async () => {

--- a/docs/pages/versions/unversioned/sdk/clipboard.md
+++ b/docs/pages/versions/unversioned/sdk/clipboard.md
@@ -5,6 +5,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-clipboard
 
 import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
+import SnackInline from '~/components/plugins/SnackInline';
 
 **`expo-clipboard`** provides an interface for getting and setting Clipboard content on Android, iOS, and Web.
 
@@ -14,6 +15,54 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 <InstallSection packageName="expo-clipboard" />
 
+## Usage
+
+<SnackInline label='Clipboard' dependencies={['expo-clipboard']} platforms={['ios', 'android']}>
+
+```jsx
+import * as React from 'react';
+import { View, Text, Button, StyleSheet } from 'react-native';
+import Clipboard from 'expo-clipboard';
+
+export default function App() {
+  const [copiedText, setCopiedText] = React.useState('');
+
+  const copyToClipboard = () => {
+    /* @info */ Clipboard.setString('hello world'); /* @end */
+  };
+
+  const fetchCopiedText = async () => {
+    const text = /* @info */ await Clipboard.getStringAsync();
+    /* @end */
+    setCopiedText(text);
+  };
+
+  return (
+    <View style={styles.container}>
+      <Button title="Click here to copy to Clipboard" onPress={copyToClipboard} />
+      <Button title="View copied text" onPress={fetchCopiedText} />
+      <Text style={styles.copiedText}>{copiedText}</Text>
+    </View>
+  );
+}
+
+/* @hide const styles = StyleSheet.create({ ... }); */
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  copiedText: {
+    marginTop: 10,
+    color: 'red',
+  },
+});
+/* @end */
+```
+
+</SnackInline>
+
 ## API
 
 ```js
@@ -22,12 +71,11 @@ import Clipboard from 'expo-clipboard';
 
 ## Methods
 
-- [`Clipboard.getStringAsync()`](#clipboardgetstringasync)
-- [`Clipboard.setString(value: string)`](#clipboardsetstringvalue-string)
-
 ### `Clipboard.getStringAsync()`
 
-Gets the content of the user's clipboard. Please note that calling this method on web will prompt the user to grant your app permission to "see text and images copied to the clipboard."
+Gets the content of the user's clipboard.
+
+> Please note that calling this method on **web** will prompt the user to grant your app permission to "see text and images copied to the clipboard."
 
 #### Returns
 
@@ -41,6 +89,6 @@ Sets the content of the user's clipboard.
 
 - **value (_string_)** -- The string to save to the clipboard.
 
-#### Returns
+## Returns
 
 On web, this retuns a boolean value indicating whether or not the string was saved to the user's clipboard. On iOS and Android, nothing is returned.

--- a/docs/pages/versions/v40.0.0/sdk/clipboard.md
+++ b/docs/pages/versions/v40.0.0/sdk/clipboard.md
@@ -90,6 +90,6 @@ Sets the content of the user's clipboard.
 
 - **value (_string_)** -- The string to save to the clipboard.
 
-## Returns
+#### Returns
 
 On web, this retuns a boolean value indicating whether or not the string was saved to the user's clipboard. On iOS and Android, nothing is returned.

--- a/docs/pages/versions/v40.0.0/sdk/clipboard.md
+++ b/docs/pages/versions/v40.0.0/sdk/clipboard.md
@@ -5,6 +5,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-40/packages/expo-clipboard
 
 import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
+import SnackInline from '~/components/plugins/SnackInline';
 
 **`expo-clipboard`** provides an interface for getting and setting Clipboard content on Android, iOS, and Web.
 
@@ -14,6 +15,54 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 <InstallSection packageName="expo-clipboard" />
 
+## Usage
+
+<SnackInline label='Clipboard' dependencies={['expo-clipboard']} platforms={['ios', 'android']}>
+
+```jsx
+import * as React from 'react';
+import { View, Text, Button, StyleSheet } from 'react-native';
+import Clipboard from 'expo-clipboard';
+
+export default function App() {
+  const [copiedText, setCopiedText] = React.useState('');
+
+  const copyToClipboard = () => {
+    /* @info */ Clipboard.setString('hello world'); /* @end */
+  };
+
+  const fetchCopiedText = async () => {
+    const text = /* @info */ await Clipboard.getStringAsync();
+    /* @end */
+    setCopiedText(text);
+  };
+
+  return (
+    <View style={styles.container}>
+      <Button title="Click here to copy to Clipboard" onPress={copyToClipboard} />
+      <Button title="View copied text" onPress={fetchCopiedText} />
+      <Text style={styles.copiedText}>{copiedText}</Text>
+    </View>
+  );
+}
+
+/* @hide const styles = StyleSheet.create({ ... }); */
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  copiedText: {
+    marginTop: 10,
+    color: 'red',
+  },
+});
+/* @end */
+```
+
+</SnackInline>
+
 ## API
 
 ```js
@@ -22,12 +71,11 @@ import Clipboard from 'expo-clipboard';
 
 ## Methods
 
-- [`Clipboard.getStringAsync()`](#clipboardgetstringasync)
-- [`Clipboard.setString(value: string)`](#clipboardsetstringvalue-string)
-
 ### `Clipboard.getStringAsync()`
 
-Gets the content of the user's clipboard. Please note that calling this method on web will prompt the user to grant your app permission to "see text and images copied to the clipboard."
+Gets the content of the user's clipboard.
+
+> Please note that calling this method on **web** will prompt the user to grant your app permission to "see text and images copied to the clipboard."
 
 #### Returns
 

--- a/docs/pages/versions/v40.0.0/sdk/clipboard.md
+++ b/docs/pages/versions/v40.0.0/sdk/clipboard.md
@@ -28,7 +28,8 @@ export default function App() {
   const [copiedText, setCopiedText] = React.useState('');
 
   const copyToClipboard = () => {
-    /* @info */ Clipboard.setString('hello world'); /* @end */
+    /* @info */ Clipboard.setString('hello world');
+  /* @end */
   };
 
   const fetchCopiedText = async () => {


### PR DESCRIPTION
# Why

Add working Snack example for `expo-clipboard`.

![image](https://user-images.githubusercontent.com/6184593/107490955-d6e62d00-6b8a-11eb-9e30-f695c0d6ab53.png)

![image](https://user-images.githubusercontent.com/6184593/107490986-df3e6800-6b8a-11eb-8fa2-1e9031c862a3.png)


# How

- Add Snack example
- Make it clear that calling `getStringAsync` on web will display a permissions prompt
- For unversioned and SDK 40
- 
# Test Plan

- See why screenshots
- https://snack.expo.io/@hein_expo/clipboard