### PR TITLE
@bycedric/docs/exclude pages from search

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -99,12 +99,12 @@ We use Algolia Docsearch as the search engine for our docs. Right now, it's sear
 In `components/plugins/AlgoliaSearch`, you can see the `facetFilters` set to `[['version:none', 'version:{currentVersion}']]`. Translated to English, this means "Search on all pages where `version` is `none`, or the currently selected version.".
 
 - All unversioned pages use the version tag `none`.
-- All versioned pages use the SDK version (e.g. `40.0.0` or `39.0.0`).
-- All `searchable: false` don't have the version tag.
+- All versioned pages use the SDK version (e.g. `v40.0.0` or `v39.0.0`).
+- All `hideFromSearch: true` pages don't have the version tag.
 
 #### Excluding pages from Docsearch
 
-To ignore a page from the search result, use `searchable: false` on that page. This removes the `<meta name="docsearch:version">` tag from that page, causing it to be excluded from our tag-based search.
+To ignore a page from the search result, use `hideFromSearch: true` on that page. This removes the `<meta name="docsearch:version">` tag from that page, causing it to be excluded from our tag-based search.
 
 ### Quirks
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -92,6 +92,20 @@ You can add images and assets to the `public/static` directory. They'll be serve
 
 Always try to use the existing components and features in markdown. Create a new component or use a component from NPM, unless there is no other option.
 
+### Algolia Docsearch
+
+We use Algolia Docsearch as the search engine for our docs. Right now, it's searching for any keywords with the proper `version` tag based on the current location. This is set in the `components/DocumentationPage` header.
+
+In `components/plugins/AlgoliaSearch`, you can see the `facetFilters` set to `[['version:none', 'version:{currentVersion}']]`. Translated to English, this means "Search on all pages where `version` is `none`, or the currently selected version.".
+
+- All unversioned pages use the version tag `none`.
+- All versioned pages use the SDK version (e.g. `40.0.0` or `39.0.0`).
+- All `searchable: false` don't have the version tag.
+
+#### Excluding pages from Docsearch
+
+To ignore a page from the search result, use `searchable: false` on that page. This removes the `<meta name="docsearch:version">` tag from that page, causing it to be excluded from our tag-based search.
+
 ### Quirks
 
 - You can't have curly brace without quotes: \`{}\` -> `{}`

--- a/docs/README.md
+++ b/docs/README.md
@@ -104,7 +104,7 @@ In `components/plugins/AlgoliaSearch`, you can see the `facetFilters` set to `[[
 
 #### Excluding pages from Docsearch
 
-To ignore a page from the search result, use `hideFromSearch: true` on that page. This removes the `<meta name="docsearch:version">` tag from that page, causing it to be excluded from our tag-based search.
+To ignore a page from the search result, use `hideFromSearch: true` on that page. This removes the `<meta name="docsearch:version">` tag from that page and filters it from our facet-based search.
 
 ### Quirks
 

--- a/docs/components/DocumentationPage.tsx
+++ b/docs/components/DocumentationPage.tsx
@@ -53,6 +53,8 @@ type Props = {
   asPath: string;
   sourceCodeUrl?: string;
   tocVisible: boolean;
+  /* If the page should show up in the search results, only hide when `false` */
+  searchable?: boolean;
 };
 
 type State = {
@@ -173,6 +175,14 @@ export default class DocumentationPage extends React.Component<Props, State> {
     }
   };
 
+  private getAlgoliaTag = () => {
+    if (this.props.searchable === false) {
+      return null;
+    }
+
+    return this.isReferencePath() ? this.getVersion() : 'none';
+  };
+
   private getVersion = () => {
     let version = (this.props.asPath || this.props.url.pathname).split(`/`)[2];
     if (!version || !VERSIONS.includes(version)) {
@@ -248,6 +258,8 @@ export default class DocumentationPage extends React.Component<Props, State> {
 
     const sidebarRight = <DocumentationSidebarRight ref={this.sidebarRightRef} />;
 
+    const algoliaTag = this.getAlgoliaTag();
+
     return (
       <DocumentationNestedScrollLayout
         ref={this.layoutRef}
@@ -260,7 +272,7 @@ export default class DocumentationPage extends React.Component<Props, State> {
         onContentScroll={handleContentScroll}
         sidebarScrollPosition={sidebarScrollPosition}>
         <Head title={`${this.props.title} - Expo Documentation`}>
-          <meta name="docsearch:version" content={isReferencePath ? version : 'none'} />
+          {algoliaTag !== null && <meta name="docsearch:version" content={algoliaTag} />}
           <meta property="og:title" content={`${this.props.title} - Expo Documentation`} />
           <meta property="og:type" content="website" />
           <meta property="og:image" content="https://docs.expo.io/static/images/og.png" />

--- a/docs/components/DocumentationPage.tsx
+++ b/docs/components/DocumentationPage.tsx
@@ -53,8 +53,8 @@ type Props = {
   asPath: string;
   sourceCodeUrl?: string;
   tocVisible: boolean;
-  /* If the page should show up in the search results, only hide when `false` */
-  searchable?: boolean;
+  /* If the page should not show up in the Algolia Docsearch results */
+  hideFromSearch?: boolean;
 };
 
 type State = {
@@ -176,7 +176,7 @@ export default class DocumentationPage extends React.Component<Props, State> {
   };
 
   private getAlgoliaTag = () => {
-    if (this.props.searchable === false) {
+    if (this.props.hideFromSearch === true) {
       return null;
     }
 

--- a/docs/components/page-higher-order/withDocumentationElements.tsx
+++ b/docs/components/page-higher-order/withDocumentationElements.tsx
@@ -20,7 +20,8 @@ const withDocumentationElements = (meta: PageMetadata) => {
           url={router}
           asPath={router.asPath}
           sourceCodeUrl={meta.sourceCodeUrl}
-          tocVisible={!meta.hideTOC}>
+          tocVisible={!meta.hideTOC}
+          searchable={meta.searchable}>
           <MDXProvider components={components}>{props.children}</MDXProvider>
         </DocumentationPage>
       </HeadingsContext.Provider>

--- a/docs/components/page-higher-order/withDocumentationElements.tsx
+++ b/docs/components/page-higher-order/withDocumentationElements.tsx
@@ -21,7 +21,7 @@ const withDocumentationElements = (meta: PageMetadata) => {
           asPath={router.asPath}
           sourceCodeUrl={meta.sourceCodeUrl}
           tocVisible={!meta.hideTOC}
-          searchable={meta.searchable}>
+          hideFromSearch={meta.hideFromSearch}>
           <MDXProvider components={components}>{props.children}</MDXProvider>
         </DocumentationPage>
       </HeadingsContext.Provider>

--- a/docs/pages/versions/v36.0.0/react-native/clipboard.md
+++ b/docs/pages/versions/v36.0.0/react-native/clipboard.md
@@ -1,6 +1,7 @@
 ---
 id: clipboard
 title: Clipboard
+searchable: false
 ---
 
 `Clipboard` gives you an interface for setting and getting content from Clipboard on both Android and iOS

--- a/docs/pages/versions/v36.0.0/react-native/clipboard.md
+++ b/docs/pages/versions/v36.0.0/react-native/clipboard.md
@@ -1,7 +1,7 @@
 ---
 id: clipboard
 title: Clipboard
-searchable: false
+hideFromSearch: true
 ---
 
 `Clipboard` gives you an interface for setting and getting content from Clipboard on both Android and iOS

--- a/docs/pages/versions/v37.0.0/react-native/clipboard.md
+++ b/docs/pages/versions/v37.0.0/react-native/clipboard.md
@@ -1,6 +1,7 @@
 ---
 id: clipboard
 title: Clipboard
+searchable: false
 ---
 
 `Clipboard` gives you an interface for setting and getting content from Clipboard on both Android and iOS

--- a/docs/pages/versions/v37.0.0/react-native/clipboard.md
+++ b/docs/pages/versions/v37.0.0/react-native/clipboard.md
@@ -1,7 +1,7 @@
 ---
 id: clipboard
 title: Clipboard
-searchable: false
+hideFromSearch: true
 ---
 
 `Clipboard` gives you an interface for setting and getting content from Clipboard on both Android and iOS

--- a/docs/pages/versions/v39.0.0/react-native/clipboard.md
+++ b/docs/pages/versions/v39.0.0/react-native/clipboard.md
@@ -1,6 +1,7 @@
 ---
 id: clipboard
 title: Clipboard
+searchable: false
 ---
 
 `Clipboard` gives you an interface for setting and getting content from Clipboard on both Android and iOS

--- a/docs/pages/versions/v39.0.0/react-native/clipboard.md
+++ b/docs/pages/versions/v39.0.0/react-native/clipboard.md
@@ -1,7 +1,7 @@
 ---
 id: clipboard
 title: Clipboard
-searchable: false
+hideFromSearch: true
 ---
 
 `Clipboard` gives you an interface for setting and getting content from Clipboard on both Android and iOS

--- a/docs/pages/versions/v40.0.0/react-native/clipboard.md
+++ b/docs/pages/versions/v40.0.0/react-native/clipboard.md
@@ -1,6 +1,7 @@
 ---
 id: clipboard
 title: Clipboard
+searchable: false
 ---
 
 > This API is deprecated and will be removed from react-native in the next release. Use [expo-clipboard](../sdk/clipboard.md) instead.

--- a/docs/pages/versions/v40.0.0/react-native/clipboard.md
+++ b/docs/pages/versions/v40.0.0/react-native/clipboard.md
@@ -1,7 +1,7 @@
 ---
 id: clipboard
 title: Clipboard
-searchable: false
+hideFromSearch: true
 ---
 
 > This API is deprecated and will be removed from react-native in the next release. Use [expo-clipboard](../sdk/clipboard.md) instead.

--- a/docs/types/common.ts
+++ b/docs/types/common.ts
@@ -2,8 +2,8 @@ export type PageMetadata = {
   title: string;
   sourceCodeUrl?: string;
   maxHeadingDepth?: number;
-  /* If the page should show up in the search results, only hide when `false` */
-  searchable?: boolean;
+  /* If the page should not show up in the Algolia Docsearch results */
+  hideFromSearch?: boolean;
   hideTOC?: boolean;
   headings?: {
     title?: string;

--- a/docs/types/common.ts
+++ b/docs/types/common.ts
@@ -2,6 +2,8 @@ export type PageMetadata = {
   title: string;
   sourceCodeUrl?: string;
   maxHeadingDepth?: number;
+  /* If the page should show up in the search results, only hide when `false` */
+  searchable?: boolean;
   hideTOC?: boolean;
   headings?: {
     title?: string;


### PR DESCRIPTION
# Why

@IjzerenHein mentioned searching for "Clipboard" resulted in the outdated React Native API pages. This allows us to exclude pages from Algolia, although it might take 24h to reindex.

# How

- Added `searchable` flag to pages (through frontmatter).
- Added logic in `components/DocumentationPage.tsx` to hide docsearch metatag when `searchable: false`.
- Added doc about Algolia and how to hide pages in `README.md`

# Test Plan

- Startup docs `yarn dev`
- Open a random markdown page
- Look at header tags in browser
- Add `searchable: false` to the page's frontmatter (top yaml structure)
- Refresh page, validate that `<meta name="docsearch:version">` is removed
