### PR TITLE
[packages] add androidTest dir to npmignore

### DIFF
--- a/packages/@unimodules/core/.npmignore
+++ b/packages/@unimodules/core/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/@unimodules/react-native-adapter/.npmignore
+++ b/packages/@unimodules/react-native-adapter/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-ads-admob/.npmignore
+++ b/packages/expo-ads-admob/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-ads-facebook/.npmignore
+++ b/packages/expo-ads-facebook/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-analytics-amplitude/.npmignore
+++ b/packages/expo-analytics-amplitude/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-analytics-segment/.npmignore
+++ b/packages/expo-analytics-segment/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-app-auth/.npmignore
+++ b/packages/expo-app-auth/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-apple-authentication/.npmignore
+++ b/packages/expo-apple-authentication/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-application/.npmignore
+++ b/packages/expo-application/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-asset/.npmignore
+++ b/packages/expo-asset/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-auth-session/.npmignore
+++ b/packages/expo-auth-session/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-av/.npmignore
+++ b/packages/expo-av/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-background-fetch/.npmignore
+++ b/packages/expo-background-fetch/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-barcode-scanner/.npmignore
+++ b/packages/expo-barcode-scanner/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-battery/.npmignore
+++ b/packages/expo-battery/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-blur/.npmignore
+++ b/packages/expo-blur/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-branch/.npmignore
+++ b/packages/expo-branch/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-brightness/.npmignore
+++ b/packages/expo-brightness/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-calendar/.npmignore
+++ b/packages/expo-calendar/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-camera/.npmignore
+++ b/packages/expo-camera/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-cellular/.npmignore
+++ b/packages/expo-cellular/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-checkbox/.npmignore
+++ b/packages/expo-checkbox/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-clipboard/.npmignore
+++ b/packages/expo-clipboard/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-constants/.npmignore
+++ b/packages/expo-constants/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-contacts/.npmignore
+++ b/packages/expo-contacts/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-crypto/.npmignore
+++ b/packages/expo-crypto/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-dev-menu/.npmignore
+++ b/packages/expo-dev-menu/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-device/.npmignore
+++ b/packages/expo-device/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-document-picker/.npmignore
+++ b/packages/expo-document-picker/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-error-recovery/.npmignore
+++ b/packages/expo-error-recovery/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-face-detector/.npmignore
+++ b/packages/expo-face-detector/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-facebook/.npmignore
+++ b/packages/expo-facebook/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-file-system/.npmignore
+++ b/packages/expo-file-system/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-firebase-analytics/.npmignore
+++ b/packages/expo-firebase-analytics/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-firebase-core/.npmignore
+++ b/packages/expo-firebase-core/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-firebase-recaptcha/.npmignore
+++ b/packages/expo-firebase-recaptcha/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-font/.npmignore
+++ b/packages/expo-font/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-gl/.npmignore
+++ b/packages/expo-gl/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-google-app-auth/.npmignore
+++ b/packages/expo-google-app-auth/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-google-sign-in/.npmignore
+++ b/packages/expo-google-sign-in/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-haptics/.npmignore
+++ b/packages/expo-haptics/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-image-manipulator/.npmignore
+++ b/packages/expo-image-manipulator/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-image-picker/.npmignore
+++ b/packages/expo-image-picker/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-image/.npmignore
+++ b/packages/expo-image/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-in-app-purchases/.npmignore
+++ b/packages/expo-in-app-purchases/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-intent-launcher/.npmignore
+++ b/packages/expo-intent-launcher/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-keep-awake/.npmignore
+++ b/packages/expo-keep-awake/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-linear-gradient/.npmignore
+++ b/packages/expo-linear-gradient/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-linking/.npmignore
+++ b/packages/expo-linking/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-local-authentication/.npmignore
+++ b/packages/expo-local-authentication/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-localization/.npmignore
+++ b/packages/expo-localization/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-location/.npmignore
+++ b/packages/expo-location/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-mail-composer/.npmignore
+++ b/packages/expo-mail-composer/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-media-library/.npmignore
+++ b/packages/expo-media-library/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-module-scripts/templates/.npmignore
+++ b/packages/expo-module-scripts/templates/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-network/.npmignore
+++ b/packages/expo-network/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-notifications/.npmignore
+++ b/packages/expo-notifications/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-payments-stripe/.npmignore
+++ b/packages/expo-payments-stripe/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-permissions/.npmignore
+++ b/packages/expo-permissions/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-print/.npmignore
+++ b/packages/expo-print/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-random/.npmignore
+++ b/packages/expo-random/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-screen-capture/.npmignore
+++ b/packages/expo-screen-capture/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-screen-orientation/.npmignore
+++ b/packages/expo-screen-orientation/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-secure-store/.npmignore
+++ b/packages/expo-secure-store/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-sensors/.npmignore
+++ b/packages/expo-sensors/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-sharing/.npmignore
+++ b/packages/expo-sharing/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-sms/.npmignore
+++ b/packages/expo-sms/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-speech/.npmignore
+++ b/packages/expo-speech/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-sqlite/.npmignore
+++ b/packages/expo-sqlite/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-standard-web-crypto/.npmignore
+++ b/packages/expo-standard-web-crypto/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-status-bar/.npmignore
+++ b/packages/expo-status-bar/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-store-review/.npmignore
+++ b/packages/expo-store-review/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-structured-headers/.npmignore
+++ b/packages/expo-structured-headers/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-task-manager/.npmignore
+++ b/packages/expo-task-manager/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-updates/.npmignore
+++ b/packages/expo-updates/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-video-thumbnails/.npmignore
+++ b/packages/expo-video-thumbnails/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo-web-browser/.npmignore
+++ b/packages/expo-web-browser/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/expo/.npmignore
+++ b/packages/expo/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/jest-expo-enzyme/.npmignore
+++ b/packages/jest-expo-enzyme/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/react-native-unimodules/.npmignore
+++ b/packages/react-native-unimodules/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/

--- a/packages/unimodules-permissions-interface/.npmignore
+++ b/packages/unimodules-permissions-interface/.npmignore
@@ -7,4 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
+/android/src/androidTest/
 /android/src/test/


### PR DESCRIPTION
# Why

Noticed that while `android/src/test` is npmignored in most packages, `android/src/androidTest` is not. As we add unit tests to more packages, we'll want both these directories to be ignored -- `test` is generally used for local unit tests and `androidTest` for instrumented tests.

# How

Added the line `/android/src/androidTest` to all the `.npmignore` files across all packages that already had `/android/src/test/` ignored.
