### PR TITLE
Update tsconfig.json from expo start

### DIFF
--- a/apps/bare-expo/App.tsx
+++ b/apps/bare-expo/App.tsx
@@ -48,5 +48,5 @@ export default function Main() {
     }
   }, []);
 
-  return <MainNavigator uriPrefix="bareexpo://" />;
+  return <MainNavigator />;
 }

--- a/apps/bare-expo/tsconfig.json
+++ b/apps/bare-expo/tsconfig.json
@@ -1,11 +1,9 @@
 {
   "compilerOptions": {
-    "allowSyntheticDefaultImports": true,
-    "jsx": "react-native",
-    "lib": ["dom", "esnext"],
-    "moduleResolution": "node",
-    "noEmit": true,
-    "skipLibCheck": true,
-    "resolveJsonModule": true
-  }
+    "lib": [
+      "dom",
+      "esnext"
+    ]
+  },
+  "extends": "expo/tsconfig.base"
 }

--- a/apps/test-suite/tsconfig.json
+++ b/apps/test-suite/tsconfig.json
@@ -1,4 +1,0 @@
-{
-  "compilerOptions": {},
-  "extends": "expo/tsconfig.base"
-}

--- a/apps/test-suite/tsconfig.json
+++ b/apps/test-suite/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "compilerOptions": {},
+  "extends": "expo/tsconfig.base"
+}


### PR DESCRIPTION
# Why

- The CI jobs are making these modifications. https://github.com/expo/expo/runs/1875441175 

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How

- Run `expo start` in `apps/bare-expo`.
- Manually removed overlapping values that are already defined in the extended config.

<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

- `yarn tsc` in bare-expo
- ran `yarn tsc --showConfig` in bare-expo to see if anything changed between configs.