### PR TITLE
[home] Fix intent filter manifest specification for browsable auth callback

### DIFF
--- a/template-files/android/AndroidManifest.xml
+++ b/template-files/android/AndroidManifest.xml
@@ -129,13 +129,17 @@
       android:theme="@style/Theme.Exponent.HomeActivity">
       <!-- START HOME INTENT FILTERS -->
       <intent-filter>
-        <data android:scheme="expauth"/>
-
         <action android:name="android.intent.action.MAIN"/>
-        <action android:name="android.intent.action.VIEW"/>
 
         <category android:name="android.intent.category.DEFAULT"/>
         <category android:name="android.intent.category.LAUNCHER"/>
+      </intent-filter>
+      <intent-filter>
+        <data android:scheme="expauth"/>
+
+        <action android:name="android.intent.action.VIEW"/>
+
+        <category android:name="android.intent.category.DEFAULT"/>
         <category android:name="android.intent.category.BROWSABLE"/>
       </intent-filter>
       <!-- END HOME INTENT FILTERS -->


### PR DESCRIPTION
# Why

https://github.com/expo/expo/commit/26cfe7f36445ed298336bf09e8dd4072c77f781d#diff-6779a56e8527da39344f5f0c084cd4384690f423772510d138f4b09e9ff426c4R135-R139 broke the specification here as I forgot that intent filters were "filters", and that multiple filters should be specified.

# How

This PR reverts the original filter back to pre-blame and instead adds a new filter for the auth callback.

# Test Plan

1. Run `expo start` in `home` directory
2. Run android app from android studio
3. Verify that login works (auth redirect)
4. Check that "Expo Go" is present in the launcher.
