### PR TITLE
Remove `activateKeepAwake` from AppEntry template

### DIFF
--- a/packages/expo-yarn-workspaces/CHANGELOG.md
+++ b/packages/expo-yarn-workspaces/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Remove `activateKeepAwake` from AppEntry template. ([#11911](https://github.com/expo/expo/pull/11911) by [@EvanBacon](https://github.com/EvanBacon))
+
 ### 🐛 Bug fixes
 
 - Use junction symlinks on Windows to avoid admin privileges ([#11739](https://github.com/expo/expo/pull/11739) by [@byCedric](https://github.com/byCedric))

--- a/packages/expo-yarn-workspaces/bin/AppEntry.template.js
+++ b/packages/expo-yarn-workspaces/bin/AppEntry.template.js
@@ -1,11 +1,6 @@
 import 'expo/build/Expo.fx';
-import { activateKeepAwake } from 'expo-keep-awake';
 import registerRootComponent from 'expo/build/launch/registerRootComponent';
 
 import App from '{{relativeProjectPath}}/App';
-
-if (__DEV__) {
-  activateKeepAwake();
-}
 
 registerRootComponent(App);

--- a/packages/expo-yarn-workspaces/bin/AppEntry.template.js
+++ b/packages/expo-yarn-workspaces/bin/AppEntry.template.js
@@ -1,4 +1,3 @@
-import 'expo/build/Expo.fx';
 import registerRootComponent from 'expo/build/launch/registerRootComponent';
 
 import App from '{{relativeProjectPath}}/App';


### PR DESCRIPTION
# Why

- Follow up to #11870 
- Remove the keep-awake side effect in favor of the keep-awake hook in `withExpoRoot`
- Remove side-effect import in favor of the import in `registerRootComponent`
