### PR TITLE
[expo-dev-menu] Add auth & profile screen

### DIFF
--- a/apps/bare-expo/ios/BareExpo/Info.plist
+++ b/apps/bare-expo/ios/BareExpo/Info.plist
@@ -27,6 +27,7 @@
 				<string>msauth.dev.expo.Payments</string>
 				<string>com.googleusercontent.apps.29635966244-v8mbqt2mtno71thelt7f2i6pob104f6e</string>
 				<string>dev.expo.Payments</string>
+				<string>expo-dev-menu</string>
 			</array>
 		</dict>
 		<dict>

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/DevLauncherClientHost.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/DevLauncherClientHost.kt
@@ -5,6 +5,7 @@ import com.facebook.react.ReactNativeHost
 import com.facebook.react.shell.MainReactPackage
 import expo.modules.devlauncher.DevLauncherPackage
 import expo.modules.devlauncher.R
+import expo.modules.devlauncher.helpers.findDevMenuPackage
 import expo.modules.devlauncher.helpers.injectDebugServerHost
 import org.apache.commons.io.IOUtils
 import java.io.File
@@ -24,9 +25,10 @@ class DevLauncherClientHost(
 
   override fun getUseDeveloperSupport() = launcherIp != null
 
-  override fun getPackages() = listOf(
+  override fun getPackages() = listOfNotNull(
     MainReactPackage(null),
-    DevLauncherPackage()
+    DevLauncherPackage(),
+    findDevMenuPackage()
   )
 
   override fun getJSMainModuleName() = "index"

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/helpers/DevLauncherReactUtils.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/helpers/DevLauncherReactUtils.kt
@@ -3,6 +3,7 @@ package expo.modules.devlauncher.helpers
 import android.content.Context
 import android.util.Log
 import com.facebook.react.ReactNativeHost
+import com.facebook.react.ReactPackage
 import expo.modules.devlauncher.react.DevLauncherInternalSettings
 
 fun injectDebugServerHost(context: Context, reactNativeHost: ReactNativeHost, debugServerHost: String): Boolean {
@@ -24,5 +25,14 @@ fun injectDebugServerHost(context: Context, reactNativeHost: ReactNativeHost, de
   } catch (e: Exception) {
     Log.e("DevLauncher", "Unable to inject debug server host settings.", e)
     false
+  }
+}
+
+fun findDevMenuPackage(): ReactPackage? {
+  return try {
+    val clazz = Class.forName("expo.modules.devmenu.DevMenuPackage")
+    clazz.newInstance() as? ReactPackage
+  } catch (e: Exception) {
+    null
   }
 }

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/DevLauncherActivity.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/DevLauncherActivity.kt
@@ -2,16 +2,24 @@ package expo.modules.devlauncher.launcher
 
 import android.os.Build
 import android.os.Bundle
+import android.view.KeyEvent
+import android.view.MotionEvent
 import com.facebook.react.ReactActivity
 import com.facebook.react.ReactActivityDelegate
+import com.facebook.react.ReactInstanceManager
+import com.facebook.react.bridge.ReactContext
+import expo.interfaces.devmenu.DevMenuManagerInterface
+import expo.interfaces.devmenu.DevMenuManagerProviderInterface
 import expo.modules.devlauncher.DevLauncherController
-import java.util.*
 
-class DevLauncherActivity : ReactActivity() {
+class DevLauncherActivity : ReactActivity(), ReactInstanceManager.ReactInstanceEventListener {
+  private var devMenuManager: DevMenuManagerInterface? = null
+
   override fun getMainComponentName() = "main"
 
   override fun createReactActivityDelegate(): ReactActivityDelegate {
     return object : ReactActivityDelegate(this, mainComponentName) {
+
       override fun getReactNativeHost() = DevLauncherController.instance.devClientHost
 
       override fun getLaunchOptions() = Bundle().apply {
@@ -25,9 +33,42 @@ class DevLauncherActivity : ReactActivity() {
     super.onStart()
   }
 
+  override fun onPostCreate(savedInstanceState: Bundle?) {
+    super.onPostCreate(savedInstanceState)
+
+    reactInstanceManager.currentReactContext?.let {
+      onReactContextInitialized(it)
+      return
+    }
+
+    reactInstanceManager.addReactInstanceEventListener(this)
+  }
+
   override fun onPause() {
     overridePendingTransition(0, 0)
     super.onPause()
+  }
+
+  override fun dispatchTouchEvent(ev: MotionEvent?): Boolean {
+    devMenuManager?.onTouchEvent(ev)
+    return super.dispatchTouchEvent(ev)
+  }
+
+  override fun onKeyUp(keyCode: Int, event: KeyEvent): Boolean {
+    return devMenuManager?.onKeyEvent(keyCode, event) == true || super.onKeyUp(keyCode, event)
+  }
+
+  override fun onReactContextInitialized(context: ReactContext) {
+    reactInstanceManager.removeReactInstanceEventListener(this)
+
+    val devMenuManagerProvider = context.catalystInstance.nativeModules.find { nativeModule ->
+      nativeModule is DevMenuManagerProviderInterface
+    } as? DevMenuManagerProviderInterface
+
+    val devMenuManager = devMenuManagerProvider?.getDevMenuManager() ?: return
+    devMenuManager.initializeWithReactNativeHost(reactNativeHost)
+
+    this.devMenuManager = devMenuManager
   }
 
   private val isSimulator

--- a/packages/expo-dev-launcher/bundle/App.tsx
+++ b/packages/expo-dev-launcher/bundle/App.tsx
@@ -12,12 +12,15 @@ import {
   StyleSheet,
   TextInput,
   Platform,
-  TouchableOpacity,
   NativeEventEmitter,
   RefreshControl,
 } from 'react-native';
 
-import ListItem from './ListItem';
+import { isDevMenuAvailable } from './DevMenu';
+import BottomTabs from './components/BottomTabs';
+import Button from './components/Button';
+import ListItem from './components/ListItem';
+
 const DevLauncher = NativeModules.EXDevLauncherInternal;
 
 // Use development client native module to load app at given URL, notifying of
@@ -32,22 +35,6 @@ const loadAppFromUrl = async (urlString: string, setLoading: (boolean) => void) 
     Alert.alert('Error loading app', e.message);
   }
 };
-
-//
-// Reusable button for below code
-//
-
-const Button = ({ label, onPress }) => (
-  <TouchableOpacity style={styles.buttonContainer} onPress={onPress}>
-    <Text style={styles.buttonText}>{label}</Text>
-  </TouchableOpacity>
-);
-
-//
-// Super barebones UI supporting at least loading an app from a QR
-// code, while we figure out what the design for this screen should be / decide
-// on features to support
-//
 
 const ON_NEW_DEEP_LINK_EVENT = 'expo.modules.devlauncher.onnewdeeplink';
 
@@ -70,6 +57,8 @@ const portsToCheck = [
   19009,
   19010,
 ];
+
+const bottomContainerHeight = isDevMenuAvailable() ? 40 : 0;
 
 const App = ({ isSimulator }) => {
   const [loading, setLoading] = useState(false);
@@ -219,7 +208,6 @@ const App = ({ isSimulator }) => {
                 ))}
               </>
             )}
-
             {recentlyProjects.length > 0 && (
               <>
                 <Text style={[styles.infoText, { marginTop: 12 }]}>Recently opened projects:</Text>
@@ -229,6 +217,7 @@ const App = ({ isSimulator }) => {
           </View>
         </>
       </ScrollView>
+      {bottomContainerHeight > 0 && <BottomTabs height={bottomContainerHeight} />}
     </SafeAreaView>
   );
 };
@@ -236,14 +225,16 @@ const App = ({ isSimulator }) => {
 const styles = StyleSheet.create({
   safeArea: {
     flex: 1,
-    backgroundColor: '#ffffff',
+    backgroundColor: '#fff',
   },
   container: {
     flex: 1,
+    marginBottom: bottomContainerHeight,
   },
 
   homeContainer: {
     paddingHorizontal: 24,
+    paddingBottom: 10,
   },
 
   pendingDeepLinkContainer: {
@@ -258,7 +249,7 @@ const styles = StyleSheet.create({
   },
   pendingDeepLink: {
     marginTop: 10,
-    color: '#ffffff',
+    color: '#fff',
     fontWeight: '700',
     fontSize: 16,
   },
@@ -270,19 +261,6 @@ const styles = StyleSheet.create({
   },
   loadingText: {
     fontSize: 24,
-  },
-
-  buttonContainer: {
-    backgroundColor: '#4630eb',
-    borderRadius: 4,
-    padding: 12,
-    marginVertical: 10,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  buttonText: {
-    color: '#ffffff',
-    fontSize: 16,
   },
 
   headingText: {

--- a/packages/expo-dev-launcher/bundle/DevMenu.ts
+++ b/packages/expo-dev-launcher/bundle/DevMenu.ts
@@ -1,0 +1,7 @@
+import { NativeModules } from 'react-native';
+
+export function isDevMenuAvailable(): boolean {
+  return !!NativeModules.ExpoDevMenu;
+}
+
+export const DevMenu = NativeModules.ExpoDevMenu;

--- a/packages/expo-dev-launcher/bundle/components/BottomTabs.tsx
+++ b/packages/expo-dev-launcher/bundle/components/BottomTabs.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { Text, View, StyleSheet, TouchableHighlight } from 'react-native';
+
+import { DevMenu } from '../DevMenu';
+
+type Props = {
+  height: number;
+};
+
+export default class BottomTabs extends React.Component<Props, object> {
+  openProfile = () => DevMenu.openProfile?.();
+  openMenu = () => DevMenu.openMenu?.();
+  openSettings = () => DevMenu.openSettings?.();
+
+  render() {
+    return (
+      <View style={[styles.bottomTabsAbsoluteContainer, { height: this.props.height }]}>
+        <View style={styles.bottomTabsContainer}>
+          <TouchableHighlight
+            underlayColor="#ddd"
+            style={styles.bottomTabsItem}
+            onPress={this.openProfile}>
+            <Text style={styles.bottomTabsItemContent}>Profile</Text>
+          </TouchableHighlight>
+
+          <TouchableHighlight
+            underlayColor="#ddd"
+            style={styles.bottomTabsItem}
+            onPress={this.openMenu}>
+            <Text style={styles.bottomTabsItemContent}>Menu</Text>
+          </TouchableHighlight>
+
+          <TouchableHighlight
+            underlayColor="#ddd"
+            style={styles.bottomTabsItem}
+            onPress={this.openSettings}>
+            <Text style={styles.bottomTabsItemContent}>Settings</Text>
+          </TouchableHighlight>
+        </View>
+      </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  bottomTabsAbsoluteContainer: {
+    position: 'absolute',
+    width: '100%',
+    bottom: 0,
+  },
+  bottomTabsContainer: {
+    width: '100%',
+    height: '100%',
+    flex: 1,
+    flexDirection: 'row',
+  },
+  bottomTabsItem: {
+    flexGrow: 1,
+    borderColor: 'rgba(0, 0, 0, 0.2)',
+    borderTopWidth: 0.8,
+    borderWidth: 0.3,
+    justifyContent: 'center',
+  },
+  bottomTabsItemContent: {
+    alignSelf: 'center',
+    color: '#000',
+    fontSize: 12,
+  },
+});

--- a/packages/expo-dev-launcher/bundle/components/Button.tsx
+++ b/packages/expo-dev-launcher/bundle/components/Button.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Text, TouchableOpacity, StyleSheet } from 'react-native';
+
+export default ({ label, onPress }) => (
+  <TouchableOpacity style={styles.buttonContainer} onPress={onPress}>
+    <Text style={styles.buttonText}>{label}</Text>
+  </TouchableOpacity>
+);
+
+const styles = StyleSheet.create({
+  buttonContainer: {
+    backgroundColor: '#4630eb',
+    borderRadius: 4,
+    padding: 12,
+    marginVertical: 10,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  buttonText: {
+    color: '#fff',
+    fontSize: 16,
+  },
+});

--- a/packages/expo-dev-launcher/bundle/components/ListItem.tsx
+++ b/packages/expo-dev-launcher/bundle/components/ListItem.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { PixelRatio, StyleSheet, TouchableOpacity, View, Text } from 'react-native';
+import { StyleSheet, TouchableOpacity, View, Text } from 'react-native';
 
 type Props = {
   title?: string;

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -17,6 +17,8 @@
 
 #import <EXDevLauncher-Swift.h>
 
+@import EXDevMenuInterface;
+
 // Uncomment the below and set it to a React Native bundler URL to develop the launcher JS
 //#define DEV_LAUNCHER_URL "http://10.0.0.176:8090/index.bundle?platform=ios&dev=true&minify=false"
 
@@ -121,7 +123,13 @@ NSString *fakeLauncherBundleUrl = @"embedded://EXDevLauncher/dummy";
   }
   
   _launcherBridge = [[EXDevLauncherRCTBridge alloc] initWithDelegate:self launchOptions:_launchOptions];
-
+  
+  id<DevMenuManagerProviderProtocol> devMenuManagerProvider = [_launcherBridge modulesConformingToProtocol:@protocol(DevMenuManagerProviderProtocol)].firstObject;
+  
+  if (devMenuManagerProvider) {
+    id<DevMenuManagerProtocol> devMenuManager = [devMenuManagerProvider getDevMenuManager];
+    devMenuManager.delegate = [[EXDevLauncherMenuDelegate alloc] initWithBridge:_launcherBridge];
+  }
   RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:_launcherBridge
                                                    moduleName:@"main"
                                             initialProperties:@{

--- a/packages/expo-dev-launcher/ios/EXDevLauncherMenuDelegate.swift
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherMenuDelegate.swift
@@ -1,0 +1,15 @@
+import EXDevMenuInterface
+
+@objc
+public class EXDevLauncherMenuDelegate : NSObject, DevMenuDelegateProtocol {
+  private let bridge: RCTBridge
+  
+  @objc
+  public init(withBridge bridge: RCTBridge) {
+    self.bridge = bridge
+  }
+  
+  public func appBridge(forDevMenuManager manager: DevMenuManagerProtocol) -> AnyObject? {
+    return self.bridge;
+  }
+}

--- a/packages/expo-dev-menu-interface/android/src/main/java/expo/interfaces/devmenu/DevMenuManagerInterface.kt
+++ b/packages/expo-dev-menu-interface/android/src/main/java/expo/interfaces/devmenu/DevMenuManagerInterface.kt
@@ -10,7 +10,7 @@ interface DevMenuManagerInterface {
   /**
    * Opens the dev menu in provided [activity]
    */
-  fun openMenu(activity: Activity)
+  fun openMenu(activity: Activity, screen: String? = null)
 
   /**
    * Closes the dev menu.

--- a/packages/expo-dev-menu-interface/android/src/main/java/expo/interfaces/devmenu/DevMenuSessionInterface.kt
+++ b/packages/expo-dev-menu-interface/android/src/main/java/expo/interfaces/devmenu/DevMenuSessionInterface.kt
@@ -10,4 +10,5 @@ import com.facebook.react.ReactInstanceManager
 interface DevMenuSessionInterface {
   val reactInstanceManager: ReactInstanceManager
   val appInfo: Bundle
+  val openScreen: String?
 }

--- a/packages/expo-dev-menu-interface/ios/DevMenuManagerProtocol.swift
+++ b/packages/expo-dev-menu-interface/ios/DevMenuManagerProtocol.swift
@@ -8,9 +8,16 @@ public protocol DevMenuManagerProtocol {
   @objc
   var isVisible: Bool { get }
   
+  @objc
+  var delegate: DevMenuDelegateProtocol? { get set }
+  
   /**
    Opens up the dev menu.
    */
+  @objc
+  @discardableResult
+  func openMenu(_ screen: String?) -> Bool
+  
   @objc
   @discardableResult
   func openMenu() -> Bool

--- a/packages/expo-dev-menu-interface/ios/DevMenuManagerProviderProtocol.swift
+++ b/packages/expo-dev-menu-interface/ios/DevMenuManagerProviderProtocol.swift
@@ -1,0 +1,9 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+@objc
+public protocol DevMenuManagerProviderProtocol {
+  
+  @objc
+  func getDevMenuManager() -> DevMenuManagerProtocol
+
+}

--- a/packages/expo-dev-menu/android/build.gradle
+++ b/packages/expo-dev-menu/android/build.gradle
@@ -117,4 +117,6 @@ dependencies {
   api "androidx.lifecycle:lifecycle-extensions:2.2.0"
 
   api "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${safeExtGet('kotlinVersion', '1.4.21')}"
+
+  api "androidx.browser:browser:1.2.0"
 }

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuManager.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuManager.kt
@@ -237,9 +237,14 @@ object DevMenuManager : DevMenuManagerInterface, LifecycleEventListener {
 
   //region DevMenuManagerProtocol
 
-  override fun openMenu(activity: Activity) {
+  override fun openMenu(activity: Activity, screen: String?) {
     setCurrentScreen(null)
-    session = DevMenuSession(delegate!!.reactInstanceManager(), delegate!!.appInfo())
+    session = DevMenuSession(
+      initReactInstanceManager = delegate!!.reactInstanceManager(),
+      initAppInfo = delegate!!.appInfo(),
+      screen = screen
+    )
+
     activity.startActivity(Intent(activity, DevMenuActivity::class.java))
   }
 

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/react/DevMenuAwareReactActivity.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/react/DevMenuAwareReactActivity.kt
@@ -1,7 +1,6 @@
 package expo.modules.devmenu.react
 
 import android.os.Bundle
-import android.os.PersistableBundle
 import android.view.KeyEvent
 import android.view.MotionEvent
 import com.facebook.react.ReactActivity

--- a/packages/expo-dev-menu/android/src/main/AndroidManifest.xml
+++ b/packages/expo-dev-menu/android/src/main/AndroidManifest.xml
@@ -14,14 +14,6 @@
       <data android:scheme="expo-dev-menu"/>
     </intent-filter>
     </activity>
-
   </application>
-
-  <queries>
-    <intent>
-      <action android:name=
-        "android.support.customtabs.action.CustomTabsService" />
-    </intent>
-  </queries>
 </manifest>
 

--- a/packages/expo-dev-menu/android/src/main/AndroidManifest.xml
+++ b/packages/expo-dev-menu/android/src/main/AndroidManifest.xml
@@ -5,7 +5,23 @@
     <activity
       android:name=".DevMenuActivity"
       android:screenOrientation="portrait"
-      android:theme="@style/Theme.AppCompat.Transparent.NoActionBar" />
+      android:theme="@style/Theme.AppCompat.Transparent.NoActionBar"
+      android:launchMode="singleTask">
+    <intent-filter>
+      <action android:name="android.intent.action.VIEW"/>
+      <category android:name="android.intent.category.DEFAULT"/>
+      <category android:name="android.intent.category.BROWSABLE"/>
+      <data android:scheme="expo-dev-menu"/>
+    </intent-filter>
+    </activity>
+
   </application>
+
+  <queries>
+    <intent>
+      <action android:name=
+        "android.support.customtabs.action.CustomTabsService" />
+    </intent>
+  </queries>
 </manifest>
 

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/DevMenuActivity.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/DevMenuActivity.kt
@@ -27,6 +27,7 @@ class DevMenuActivity : ReactActivity() {
         putParcelableArray("devMenuScreens", DevMenuManager.serializedScreens().toTypedArray())
         putString("uuid", UUID.randomUUID().toString())
         putBundle("appInfo", DevMenuManager.getSession()?.appInfo ?: Bundle.EMPTY)
+        putString("openScreen", DevMenuManager.getSession()?.openScreen)
       }
 
       override fun createRootView() = getVendoredClass<ReactRootView>("com.swmansion.gesturehandler.react.RNGestureHandlerEnabledRootView", arrayOf(Context::class.java), arrayOf(this@DevMenuActivity))

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/DevMenuSession.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/DevMenuSession.kt
@@ -14,10 +14,12 @@ import expo.interfaces.devmenu.DevMenuSessionInterface
  */
 class DevMenuSession(
   initReactInstanceManager: ReactInstanceManager,
-  initAppInfo: Bundle?
+  initAppInfo: Bundle?,
+  screen: String?
 ) : DevMenuSessionInterface {
   override val reactInstanceManager = initReactInstanceManager
   override val appInfo = initAppInfo ?: guessAppInfo()
+  override val openScreen = screen
 
   /**
    * Constructs app info `Bundle` based on the native app metadata such as `ApplicationContext`.

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/modules/DevMenuInternalModule.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/modules/DevMenuInternalModule.kt
@@ -1,8 +1,11 @@
 package expo.modules.devmenu.modules
 
+import android.content.Context
+import android.content.Intent
 import android.graphics.Typeface
+import android.net.Uri
 import android.os.Build
-import android.util.Log
+import androidx.browser.customtabs.CustomTabsIntent
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
@@ -11,6 +14,8 @@ import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.views.text.ReactFontManager
 
 private var fontsWereLoaded = false
+
+private const val DEV_MENU_STORE = "expo.modules.devmenu.store"
 
 class DevMenuInternalModule(reactContext: ReactApplicationContext)
   : ReactContextBaseJavaModule(reactContext) {
@@ -28,6 +33,8 @@ class DevMenuInternalModule(reactContext: ReactApplicationContext)
 
   private val doesDeviceSupportKeyCommands
     get() = Build.FINGERPRINT.contains("vbox") || Build.FINGERPRINT.contains("generic")
+
+  private val localStore = reactContext.getSharedPreferences(DEV_MENU_STORE, Context.MODE_PRIVATE)
 
   override fun getConstants(): Map<String, Any> {
     return mapOf(
@@ -117,5 +124,43 @@ class DevMenuInternalModule(reactContext: ReactApplicationContext)
   fun onScreenChangeAsync(currentScreen: String?, promise: Promise) {
     devMenuManger.setCurrentScreen(currentScreen)
     promise.resolve(null)
+  }
+
+  @ReactMethod
+  fun openWebBrowserAsync(startUrl: String?, promise: Promise) {
+    requireNotNull(startUrl)
+
+    val intent = createCustomTabsIntent()
+    intent.data = Uri.parse(startUrl)
+
+    reactApplicationContext.currentActivity!!.startActivity(intent)
+    promise.resolve(null)
+  }
+
+  private fun createCustomTabsIntent(): Intent {
+    val builder = CustomTabsIntent.Builder()
+    builder.setShowTitle(false)
+
+    val intent = builder.build().intent
+
+    // We cannot use builder's method enableUrlBarHiding, because there is no corresponding disable method and some browsers enables it by default.
+    intent.putExtra(CustomTabsIntent.EXTRA_ENABLE_URLBAR_HIDING, false)
+
+    return intent
+  }
+
+  @ReactMethod
+  fun saveAsync(key: String, data: String, promise: Promise) {
+    localStore
+      .edit()
+      .putString(key, data)
+      .apply()
+
+    promise.resolve(null)
+  }
+
+  @ReactMethod
+  fun getAsync(key: String, promise: Promise) {
+    promise.resolve(localStore.getString(key, null))
   }
 }

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/modules/DevMenuModule.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/modules/DevMenuModule.kt
@@ -14,12 +14,26 @@ class DevMenuModule(reactContext: ReactApplicationContext)
       .getDevMenuManager()
   }
 
-  @ReactMethod
-  fun openMenu() {
+  private fun openMenuOn(screen: String?) {
     reactApplicationContext
       .currentActivity
       ?.run {
-        devMenuManager.openMenu(this)
+        devMenuManager.openMenu(this, screen)
       }
+  }
+
+  @ReactMethod
+  fun openMenu() {
+    openMenuOn(null)
+  }
+
+  @ReactMethod
+  fun openProfile() {
+    openMenuOn("Profile")
+  }
+
+  @ReactMethod
+  fun openSettings() {
+    openMenuOn("Settings")
   }
 }

--- a/packages/expo-dev-menu/app/DevMenuContext.ts
+++ b/packages/expo-dev-menu/app/DevMenuContext.ts
@@ -2,15 +2,21 @@ import React from 'react';
 
 import { DevMenuItemAnyType } from './DevMenuInternal';
 
+type Session = {
+  sessionSecret: string;
+};
+
 export type Context = {
   expand?: () => any;
   collapse?: () => any;
+  setSession: (session: Session) => Promise<void>;
 
   appInfo?: { [key: string]: any };
   uuid?: string;
   devMenuItems?: DevMenuItemAnyType[];
   enableDevelopmentTools?: boolean;
   showOnboardingView?: boolean;
+  isAuthenticated: boolean;
 };
 
 const DevMenuContext = React.createContext<Context | null>(null);

--- a/packages/expo-dev-menu/app/DevMenuInternal.ts
+++ b/packages/expo-dev-menu/app/DevMenuInternal.ts
@@ -132,3 +132,11 @@ export function openDevMenuFromReactNative() {
 export async function onScreenChangeAsync(currentScreen: string | null): Promise<void> {
   return await DevMenu.onScreenChangeAsync(currentScreen);
 }
+
+export async function saveAsync(key: string, data: string): Promise<void> {
+  return await DevMenu.saveAsync(key, data);
+}
+
+export async function getAsync(key: string): Promise<string | null> {
+  return await DevMenu.getAsync(key);
+}

--- a/packages/expo-dev-menu/app/DevMenuWebBrowser.ts
+++ b/packages/expo-dev-menu/app/DevMenuWebBrowser.ts
@@ -1,0 +1,91 @@
+import { NativeModules, AppState, Linking } from 'react-native';
+
+const DevMenu = NativeModules.ExpoDevMenuInternal;
+
+let _redirectHandler: ((event: any) => void) | null = null;
+let _onWebBrowserCloseAndroid: null | (() => void) = null;
+let _isAppStateAvailable: boolean = AppState.currentState !== null;
+
+function _onAppStateChangeAndroid(state: any) {
+  if (!_isAppStateAvailable) {
+    _isAppStateAvailable = true;
+    return;
+  }
+
+  if (state === 'active' && _onWebBrowserCloseAndroid) {
+    _onWebBrowserCloseAndroid();
+  }
+}
+
+function _stopWaitingForRedirect() {
+  if (!_redirectHandler) {
+    throw new Error(
+      `The WebBrowser auth session is in an invalid state with no redirect handler when one should be set`
+    );
+  }
+
+  Linking.removeEventListener('url', _redirectHandler);
+  _redirectHandler = null;
+}
+
+async function _openBrowserAndWaitAndroidAsync(startUrl: string): Promise<any> {
+  const appStateChangedToActive = new Promise(resolve => {
+    _onWebBrowserCloseAndroid = resolve;
+    AppState.addEventListener('change', _onAppStateChangeAndroid);
+  });
+
+  let result = { type: 'cancel' };
+  await DevMenu.openWebBrowserAsync(startUrl);
+  const type = 'opened';
+
+  if (type === 'opened') {
+    await appStateChangedToActive;
+    result = { type: 'dissmiss' };
+  }
+
+  AppState.removeEventListener('change', _onAppStateChangeAndroid);
+  _onWebBrowserCloseAndroid = null;
+  return result;
+}
+
+function _waitForRedirectAsync(returnUrl: string): Promise<any> {
+  return new Promise(resolve => {
+    _redirectHandler = (event: any) => {
+      if (event.url.startsWith(returnUrl)) {
+        resolve({ url: event.url, type: 'success' });
+      }
+    };
+
+    Linking.addEventListener('url', _redirectHandler);
+  });
+}
+
+async function _openAuthSessionPolyfillAsync(startUrl: string, returnUrl: string): Promise<any> {
+  if (_redirectHandler) {
+    throw new Error(
+      `The WebBrowser's auth session is in an invalid state with a redirect handler set when it should not be`
+    );
+  }
+
+  if (_onWebBrowserCloseAndroid) {
+    throw new Error(`WebBrowser is already open, only one can be open at a time`);
+  }
+
+  try {
+    return await Promise.race([
+      _openBrowserAndWaitAndroidAsync(startUrl),
+      _waitForRedirectAsync(returnUrl),
+    ]);
+  } finally {
+    _stopWaitingForRedirect();
+  }
+}
+
+export async function openAuthSessionAsync(url: string, returnUrl: string): Promise<any> {
+  if (DevMenu.openAuthSessionAsync) {
+    // iOS
+    return await DevMenu.openAuthSessionAsync(url, returnUrl);
+  }
+  // Android
+  return await _openAuthSessionPolyfillAsync(url, returnUrl);
+}

--- a/packages/expo-dev-menu/app/DevMenuWebBrowser.ts
+++ b/packages/expo-dev-menu/app/DevMenuWebBrowser.ts
@@ -2,36 +2,36 @@ import { NativeModules, AppState, Linking } from 'react-native';
 
 const DevMenu = NativeModules.ExpoDevMenuInternal;
 
-let _redirectHandler: ((event: any) => void) | null = null;
-let _onWebBrowserCloseAndroid: null | (() => void) = null;
-let _isAppStateAvailable: boolean = AppState.currentState !== null;
+let redirectHandler: ((event: any) => void) | null = null;
+let onWebBrowserCloseAndroid: null | (() => void) = null;
+let isAppStateAvailable: boolean = AppState.currentState !== null;
 
-function _onAppStateChangeAndroid(state: any) {
-  if (!_isAppStateAvailable) {
-    _isAppStateAvailable = true;
+function onAppStateChangeAndroid(state: any) {
+  if (!isAppStateAvailable) {
+    isAppStateAvailable = true;
     return;
   }
 
-  if (state === 'active' && _onWebBrowserCloseAndroid) {
-    _onWebBrowserCloseAndroid();
+  if (state === 'active' && onWebBrowserCloseAndroid) {
+    onWebBrowserCloseAndroid();
   }
 }
 
-function _stopWaitingForRedirect() {
-  if (!_redirectHandler) {
+function stopWaitingForRedirect() {
+  if (!redirectHandler) {
     throw new Error(
       `The WebBrowser auth session is in an invalid state with no redirect handler when one should be set`
     );
   }
 
-  Linking.removeEventListener('url', _redirectHandler);
-  _redirectHandler = null;
+  Linking.removeEventListener('url', redirectHandler);
+  redirectHandler = null;
 }
 
-async function _openBrowserAndWaitAndroidAsync(startUrl: string): Promise<any> {
+async function openBrowserAndWaitAndroidAsync(startUrl: string): Promise<any> {
   const appStateChangedToActive = new Promise(resolve => {
-    _onWebBrowserCloseAndroid = resolve;
-    AppState.addEventListener('change', _onAppStateChangeAndroid);
+    onWebBrowserCloseAndroid = resolve;
+    AppState.addEventListener('change', onAppStateChangeAndroid);
   });
 
   let result = { type: 'cancel' };
@@ -43,41 +43,41 @@ async function _openBrowserAndWaitAndroidAsync(startUrl: string): Promise<any> {
     result = { type: 'dissmiss' };
   }
 
-  AppState.removeEventListener('change', _onAppStateChangeAndroid);
-  _onWebBrowserCloseAndroid = null;
+  AppState.removeEventListener('change', onAppStateChangeAndroid);
+  onWebBrowserCloseAndroid = null;
   return result;
 }
 
-function _waitForRedirectAsync(returnUrl: string): Promise<any> {
+function waitForRedirectAsync(returnUrl: string): Promise<any> {
   return new Promise(resolve => {
-    _redirectHandler = (event: any) => {
+    redirectHandler = (event: any) => {
       if (event.url.startsWith(returnUrl)) {
         resolve({ url: event.url, type: 'success' });
       }
     };
 
-    Linking.addEventListener('url', _redirectHandler);
+    Linking.addEventListener('url', redirectHandler);
   });
 }
 
-async function _openAuthSessionPolyfillAsync(startUrl: string, returnUrl: string): Promise<any> {
-  if (_redirectHandler) {
+async function openAuthSessionPolyfillAsync(startUrl: string, returnUrl: string): Promise<any> {
+  if (redirectHandler) {
     throw new Error(
       `The WebBrowser's auth session is in an invalid state with a redirect handler set when it should not be`
     );
   }
 
-  if (_onWebBrowserCloseAndroid) {
+  if (onWebBrowserCloseAndroid) {
     throw new Error(`WebBrowser is already open, only one can be open at a time`);
   }
 
   try {
     return await Promise.race([
-      _openBrowserAndWaitAndroidAsync(startUrl),
-      _waitForRedirectAsync(returnUrl),
+      openBrowserAndWaitAndroidAsync(startUrl),
+      waitForRedirectAsync(returnUrl),
     ]);
   } finally {
-    _stopWaitingForRedirect();
+    stopWaitingForRedirect();
   }
 }
 
@@ -87,5 +87,5 @@ export async function openAuthSessionAsync(url: string, returnUrl: string): Prom
     return await DevMenu.openAuthSessionAsync(url, returnUrl);
   }
   // Android
-  return await _openAuthSessionPolyfillAsync(url, returnUrl);
+  return await openAuthSessionPolyfillAsync(url, returnUrl);
 }

--- a/packages/expo-dev-menu/app/api/ApolloClient.ts
+++ b/packages/expo-dev-menu/app/api/ApolloClient.ts
@@ -1,0 +1,38 @@
+import ApolloClient from 'apollo-boost';
+import { InMemoryCache } from 'apollo-cache-inmemory';
+
+import Endpoints from '../constants/Endpoints';
+
+let session = null;
+const client = new ApolloClient({
+  uri: `${Endpoints.api.origin}/--/graphql`,
+
+  async request(operation): Promise<void> {
+    // TODO(lukmccall): Check if the connection is available
+    // const isConnected = await Connectivity.isAvailableAsync();
+    // if (!isConnected) {
+    //   throw new Error('No connection available');
+    // }
+
+    if (session?.sessionSecret) {
+      operation.setContext({
+        headers: {
+          'expo-session': session.sessionSecret,
+        },
+      });
+    }
+  },
+
+  cache: new InMemoryCache({
+    dataIdFromObject(value) {
+      // Make sure to return null if this object doesn't have an ID
+      return value.hasOwnProperty('id') ? value.id : null;
+    },
+  }),
+});
+
+export function setApolloSession(newSession) {
+  session = newSession;
+}
+
+export default client;

--- a/packages/expo-dev-menu/app/api/MyProfileQuery.ts
+++ b/packages/expo-dev-menu/app/api/MyProfileQuery.ts
@@ -1,0 +1,47 @@
+import { useQuery } from '@apollo/client';
+import gql from 'graphql-tag';
+
+export type Profile = {
+  id: string;
+  username: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  profilePhoto: string;
+  isLegacy: boolean;
+  appCount: number;
+};
+
+interface MyProfileData {
+  me: Profile;
+}
+
+interface MyProfileVars {}
+
+const MyProfileQuery = gql`
+  query Home_MyProfile {
+    me {
+      id
+      appCount
+      email
+      firstName
+      isLegacy
+      lastName
+      profilePhoto
+      username
+    }
+  }
+`;
+
+export function useMyProfileQuery() {
+  const query = useQuery<MyProfileData, MyProfileVars>(MyProfileQuery, {
+    fetchPolicy: 'cache-and-network',
+  });
+
+  return {
+    ...query,
+    data: {
+      user: query.data?.me,
+    },
+  };
+}

--- a/packages/expo-dev-menu/app/components/Button.tsx
+++ b/packages/expo-dev-menu/app/components/Button.tsx
@@ -1,0 +1,34 @@
+import * as React from 'react';
+import { StyleSheet } from 'react-native';
+
+import Colors from '../constants/Colors';
+import { StyledText } from './Text';
+import { TouchableOpacity } from './Touchables';
+import { StyledView } from './Views';
+
+type Props = {
+  onPress: () => void;
+  tittle: string;
+};
+
+export default function({ onPress, tittle }: Props) {
+  return (
+    <TouchableOpacity onPress={onPress}>
+      <StyledView
+        style={styles.button}
+        darkBackgroundColor={Colors.dark.tint}
+        lightBackgroundColor={Colors.light.tint}>
+        <StyledText lightColor="#fff" darkColor="#fff">
+          {tittle}
+        </StyledText>
+      </StyledView>
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  button: {
+    paddingHorizontal: 20,
+    paddingVertical: 10,
+  },
+});

--- a/packages/expo-dev-menu/app/components/Loading.tsx
+++ b/packages/expo-dev-menu/app/components/Loading.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { View, ActivityIndicator, StyleSheet } from 'react-native';
+
+import Colors from '../constants/Colors';
+
+export default () => (
+  <View style={styles.loadingContainer}>
+    <ActivityIndicator size="large" color={Colors.light.tint} />
+  </View>
+);
+
+const styles = StyleSheet.create({
+  loadingContainer: {
+    minHeight: 200,
+    padding: 50,
+  },
+});

--- a/packages/expo-dev-menu/app/components/MainOptions.tsx
+++ b/packages/expo-dev-menu/app/components/MainOptions.tsx
@@ -6,6 +6,7 @@ import ListLink from './ListLink';
 function MainOptions() {
   return (
     <View style={styles.group}>
+      <ListLink route="Profile" label="Profile" glyphName="account" />
       <ListLink route="Settings" label="Settings" glyphName="settings-outline" />
       <ListLink route="Test" label="Navigation and scroll test" glyphName="test-tube" />
     </View>

--- a/packages/expo-dev-menu/app/components/items/DevMenuSelectionList.tsx
+++ b/packages/expo-dev-menu/app/components/items/DevMenuSelectionList.tsx
@@ -138,7 +138,6 @@ const SearchResults = ({
 };
 
 const AllItems = ({ elements }: { elements: DevMenuSelectionListItem[] }) => {
-  console.log(elements);
   const selectedElements = elements.filter(e => e.isChecked);
   const othersElements = elements.filter(e => !e.isChecked);
   return (

--- a/packages/expo-dev-menu/app/components/profile/Profile.tsx
+++ b/packages/expo-dev-menu/app/components/profile/Profile.tsx
@@ -1,0 +1,114 @@
+import React, { useContext } from 'react';
+import { Image, StyleSheet, Text, View } from 'react-native';
+
+import DevMenuContext from '../../DevMenuContext';
+import { useMyProfileQuery } from '../../api/MyProfileQuery';
+import Colors from '../../constants/Colors';
+import ListItemButton from '../ListItemButton';
+import Loading from '../Loading';
+import { StyledText } from '../Text';
+import { StyledView } from '../Views';
+
+function ProfileHeader({ data }) {
+  const { firstName, lastName, username, profilePhoto, isLegacy } = data.user;
+
+  if (isLegacy) {
+    // Legacy Header
+    return (
+      <View style={styles.header}>
+        <View
+          style={[styles.headerAvatar, styles.headerAvatarContainer, styles.legacyHeaderAvatar]}
+        />
+        <View style={styles.headerAccountsList}>
+          <Text style={styles.headerAccountText}>@{username}</Text>
+        </View>
+      </View>
+    );
+  }
+
+  return (
+    <StyledView
+      style={styles.header}
+      lightBackgroundColor={Colors.light.secondaryBackground}
+      lightBorderColor={Colors.light.border}
+      darkBackgroundColor={Colors.dark.secondaryBackground}
+      darkBorderColor={Colors.dark.border}>
+      <View style={styles.headerAvatarContainer}>
+        <Image style={styles.headerAvatar} source={{ uri: profilePhoto }} />
+      </View>
+      <StyledText style={styles.headerFullNameText}>
+        {firstName} {lastName}
+      </StyledText>
+      <View style={styles.headerAccountsList}>
+        <StyledText style={styles.headerAccountText} lightColor="#232B3A" darkColor="#ccc">
+          @{username}
+        </StyledText>
+      </View>
+    </StyledView>
+  );
+}
+
+export default function Profile() {
+  const context = useContext(DevMenuContext);
+  const query = useMyProfileQuery();
+  const { loading, error, data } = query;
+
+  if (!loading && (error || !data.user)) {
+    context.setSession(null);
+    return;
+  }
+
+  if (loading) {
+    return <Loading />;
+  }
+
+  return (
+    <View>
+      <ProfileHeader {...{ data }} />
+      <ListItemButton
+        name="Sign out"
+        label="Sign out"
+        icon="logout"
+        onPress={async () => {
+          await context.setSession(null);
+        }}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  header: {
+    alignItems: 'center',
+    borderTopWidth: 1,
+    borderBottomWidth: 1,
+    marginBottom: 10,
+  },
+  headerAvatarContainer: {
+    marginTop: 25,
+    marginBottom: 12,
+    overflow: 'hidden',
+    borderRadius: 5,
+  },
+  headerAvatar: {
+    height: 64,
+    width: 64,
+    borderRadius: 5,
+  },
+  legacyHeaderAvatar: {
+    backgroundColor: '#eee',
+  },
+  headerAccountsList: {
+    paddingBottom: 20,
+  },
+  headerAccountText: {
+    fontSize: 14,
+  },
+  headerFullNameText: {
+    fontSize: 20,
+    fontWeight: '500',
+  },
+});

--- a/packages/expo-dev-menu/app/components/profile/Profile.tsx
+++ b/packages/expo-dev-menu/app/components/profile/Profile.tsx
@@ -55,7 +55,7 @@ export default function Profile() {
 
   if (!loading && (error || !data.user)) {
     context.setSession(null);
-    return;
+    return <Loading />;
   }
 
   if (loading) {

--- a/packages/expo-dev-menu/app/components/profile/UnauthenticatedProfile.tsx
+++ b/packages/expo-dev-menu/app/components/profile/UnauthenticatedProfile.tsx
@@ -1,0 +1,143 @@
+import * as React from 'react';
+import { Platform, StyleSheet, View } from 'react-native';
+import url from 'url';
+
+import DevMenuContext from '../../DevMenuContext';
+import * as DevMenuWebBrowser from '../../DevMenuWebBrowser';
+import Colors from '../../constants/Colors';
+import Endpoints from '../../constants/Endpoints';
+import Button from '../Button';
+import Loading from '../Loading';
+import { StyledText } from '../Text';
+
+export default function UnauthenticatedProfile() {
+  const context = React.useContext(DevMenuContext);
+  const [authenticationError, setAuthenticationError] = React.useState<string | null>(null);
+  const [isAuthenticating, setIsAuthenticating] = React.useState(false);
+  const mounted = React.useRef<boolean | null>(true);
+
+  React.useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+    };
+  }, []);
+
+  const _handleAuthentication = async (urlPath: string) => {
+    if (isAuthenticating || !mounted.current) {
+      return;
+    }
+    setAuthenticationError(null);
+    setIsAuthenticating(true);
+
+    try {
+      const redirectBase = 'expo-dev-menu://auth';
+      const authSessionURL = `${
+        Endpoints.website.origin
+      }/${urlPath}?app_redirect_uri=${encodeURIComponent(redirectBase)}`;
+
+      const result = await DevMenuWebBrowser.openAuthSessionAsync(authSessionURL, redirectBase);
+
+      if (result.type === 'success') {
+        const resultURL = url.parse(result.url, true);
+        const sessionSecret = decodeURIComponent(resultURL.query['session_secret'] as string);
+
+        if (mounted.current) {
+          await context.setSession({ sessionSecret });
+        }
+      }
+    } catch (e) {
+      if (mounted.current) {
+        setAuthenticationError(e.message);
+      }
+    } finally {
+      if (mounted.current) {
+        setIsAuthenticating(false);
+      }
+    }
+  };
+
+  const _handleSignInPress = async () => {
+    await _handleAuthentication('login');
+  };
+
+  const _handleSignUpPress = async () => {
+    await _handleAuthentication('signup');
+  };
+
+  const title = 'Sign in to Continue';
+  const description = 'Sign in or create an Expo account to view your projects.';
+
+  if (isAuthenticating) {
+    return <Loading />;
+  }
+
+  return (
+    <View style={styles.contentContainer}>
+      <StyledText style={styles.titleText}>{title}</StyledText>
+
+      <StyledText
+        style={styles.descriptionText}
+        darkColor={Colors.dark.secondaryText}
+        lightColor={Colors.light.secondaryText}>
+        {description}
+      </StyledText>
+
+      <Button onPress={_handleSignInPress} tittle="Sign in to your account" />
+      <View style={{ marginBottom: 15 }} />
+      <Button onPress={_handleSignUpPress} tittle="Sign up for Expo" />
+
+      {authenticationError && (
+        <StyledText
+          style={styles.errorText}
+          darkColor={Colors.dark.error}
+          lightColor={Colors.light.error}>
+          Something went wrong when authenticating: {authenticationError}
+        </StyledText>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  contentContainer: {
+    paddingTop: 30,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  titleText: {
+    marginBottom: 15,
+    fontWeight: '400',
+    fontSize: 18,
+  },
+  descriptionText: {
+    textAlign: 'center',
+    marginHorizontal: 15,
+    marginBottom: 20,
+    ...Platform.select({
+      ios: {
+        fontSize: 12,
+        lineHeight: 18,
+      },
+      android: {
+        fontSize: 14,
+        lineHeight: 20,
+      },
+    }),
+  },
+  errorText: {
+    textAlign: 'center',
+    marginHorizontal: 15,
+    marginTop: 20,
+    ...Platform.select({
+      ios: {
+        fontSize: 15,
+        lineHeight: 20,
+      },
+      android: {
+        fontSize: 16,
+        lineHeight: 24,
+      },
+    }),
+  },
+});

--- a/packages/expo-dev-menu/app/constants/Colors.ts
+++ b/packages/expo-dev-menu/app/constants/Colors.ts
@@ -13,6 +13,7 @@ export default {
     warningBackground: '#fef6d0',
     warningColor: '#886636',
     warningBorders: '#fceca8',
+    error: '#dc3545',
   },
   dark: {
     tint: '#aca2f6',
@@ -28,5 +29,6 @@ export default {
     warningBackground: '#feffb0',
     warningColor: '#886636',
     warningBorders: '#fceca8',
+    error: '#dc3545',
   },
 };

--- a/packages/expo-dev-menu/app/constants/Endpoints.ts
+++ b/packages/expo-dev-menu/app/constants/Endpoints.ts
@@ -1,0 +1,13 @@
+const host = 'exp.host';
+const origin = `https://${host}`;
+const websiteOrigin = 'https://expo.io';
+
+export default {
+  api: {
+    host,
+    origin,
+  },
+  website: {
+    origin: websiteOrigin,
+  },
+};

--- a/packages/expo-dev-menu/app/screens/DevMenuProfileScreen.tsx
+++ b/packages/expo-dev-menu/app/screens/DevMenuProfileScreen.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+
+import DevMenuContext, { Context } from '../DevMenuContext';
+import Profile from '../components/profile/Profile';
+import ProfileUnauthenticated from '../components/profile/UnauthenticatedProfile';
+
+export default class DevMenuMainScreen extends React.PureComponent {
+  static navigationOptions = {
+    headerShown: true,
+  };
+
+  static contextType = DevMenuContext;
+
+  context: Context;
+
+  render() {
+    const { isAuthenticated } = this.context;
+
+    if (!isAuthenticated) {
+      return (
+        <View style={styles.container}>
+          <ProfileUnauthenticated />
+        </View>
+      );
+    }
+
+    return (
+      <View style={styles.container}>
+        <Profile />
+      </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  loadingContainer: {
+    minHeight: 150,
+    padding: 10,
+  },
+});

--- a/packages/expo-dev-menu/app/storage/LocalStorage.ts
+++ b/packages/expo-dev-menu/app/storage/LocalStorage.ts
@@ -1,0 +1,21 @@
+import * as DevMenuInternal from '../DevMenuInternal';
+
+const SESSION_KEY = 'expo-dev-menu.session';
+
+export async function saveSessionAsync(session) {
+  await DevMenuInternal.saveAsync(SESSION_KEY, JSON.stringify(session));
+}
+
+export async function getSessionAsync() {
+  const data = await DevMenuInternal.getAsync(SESSION_KEY);
+
+  if (!data) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(data);
+  } catch (e) {
+    return null;
+  }
+}

--- a/packages/expo-dev-menu/app/views/DevMenuApp.tsx
+++ b/packages/expo-dev-menu/app/views/DevMenuApp.tsx
@@ -64,7 +64,7 @@ function DevMenuApp(props) {
 
           routeNameRef.current = currentRouteName;
         }}>
-        <DevMenuContainer {...props} />
+        <DevMenuContainer {...props} navigation={navigationRef.current} />
       </NavigationContainer>
     </View>
   );

--- a/packages/expo-dev-menu/app/views/DevMenuAppInfo.tsx
+++ b/packages/expo-dev-menu/app/views/DevMenuAppInfo.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { Image, StyleSheet, View, PixelRatio } from 'react-native';
 
+import { DevMenuAppInfoType } from '../DevMenuInternal';
 import { StyledText } from '../components/Text';
 import { StyledView } from '../components/Views';
 import Colors from '../constants/Colors';
-import { DevMenuAppInfoType } from '../DevMenuInternal';
 
 type Props = {
   appInfo: DevMenuAppInfoType;

--- a/packages/expo-dev-menu/app/views/DevMenuBottomSheet.tsx
+++ b/packages/expo-dev-menu/app/views/DevMenuBottomSheet.tsx
@@ -71,6 +71,10 @@ type Props = {
    * Refs for gesture handlers used for building bottomsheet
    */
   innerGestureHandlerRefs: [React.RefObject<PanGestureHandler>, React.RefObject<TapGestureHandler>];
+
+  openScreen?: string;
+
+  animationEnabled?: boolean;
 };
 
 type State = {
@@ -704,9 +708,10 @@ export default class BottomSheetBehavior extends React.Component<Props, State> {
                 <TapGestureHandler ref={this.tapRef} onHandlerStateChange={this.handleTap}>
                   <View style={styles.fullscreenView}>
                     <Stack.Navigator
-                      initialRouteName={this.props.screens[0].name}
+                      initialRouteName={this.props.openScreen ?? this.props.screens[0].name}
                       headerMode="screen"
                       screenOptions={{
+                        animationEnabled: this.props?.animationEnabled,
                         ...TransitionPresets.SlideFromRightIOS,
                       }}>
                       {this.props.screens.map(this.renderScreen)}

--- a/packages/expo-dev-menu/app/views/DevMenuContainer.tsx
+++ b/packages/expo-dev-menu/app/views/DevMenuContainer.tsx
@@ -110,7 +110,7 @@ export default class DevMenuContainer extends React.PureComponent<Props, any> {
     setApolloSession(session);
     await LocalStorage.saveSessionAsync(session);
 
-    this.setState({ isAuthenticated: !session });
+    this.setState({ isAuthenticated: session !== null });
     if (!session) {
       ApolloClient.resetStore();
     }

--- a/packages/expo-dev-menu/ios/DevMenuManager.swift
+++ b/packages/expo-dev-menu/ios/DevMenuManager.swift
@@ -133,8 +133,14 @@ open class DevMenuManager: NSObject, DevMenuManagerProtocol {
    */
   @objc
   @discardableResult
+  public func openMenu(_ screen: String? = nil) -> Bool {
+    return setVisibility(true, screen: screen)
+  }
+  
+  @objc
+  @discardableResult
   public func openMenu() -> Bool {
-    return setVisibility(true)
+    return openMenu(nil)
   }
 
   /**
@@ -308,7 +314,7 @@ open class DevMenuManager: NSObject, DevMenuManagerProtocol {
     return nil;
   }
 
-  private func setVisibility(_ visible: Bool) -> Bool {
+  private func setVisibility(_ visible: Bool, screen: String? = nil) -> Bool {
     if !canChangeVisibility(to: visible) {
       return false
     }
@@ -317,7 +323,7 @@ open class DevMenuManager: NSObject, DevMenuManagerProtocol {
         debugPrint("DevMenuManager: The delegate is unset or it didn't provide a bridge to render for.")
         return false
       }
-      session = DevMenuSession(bridge: bridge, appInfo: delegate?.appInfo?(forDevMenuManager: self))
+      session = DevMenuSession(bridge: bridge, appInfo: delegate?.appInfo?(forDevMenuManager: self), screen: screen)
       DispatchQueue.main.async { self.window?.makeKeyAndVisible() }
     } else {
       session = nil

--- a/packages/expo-dev-menu/ios/DevMenuSession.swift
+++ b/packages/expo-dev-menu/ios/DevMenuSession.swift
@@ -7,16 +7,19 @@ public class DevMenuSession {
   /**
    The bridge that the dev menu is currently rendered for.
    */
-  public private(set) var bridge: RCTBridge
+  public let bridge: RCTBridge
 
   /**
    A dictionary of app info corresponding to the `bridge` or guessed based on app's metadata.
    */
-  public private(set) var appInfo: [String : Any]
+  public let appInfo: [String : Any]
+  
+  public let openScreen: String?
 
-  init(bridge: RCTBridge, appInfo: [String : Any]?) {
+  init(bridge: RCTBridge, appInfo: [String : Any]?, screen: String? = nil) {
     self.bridge = bridge
     self.appInfo = appInfo ?? guessAppInfo(forBridge: bridge)
+    self.openScreen = screen
   }
 }
 

--- a/packages/expo-dev-menu/ios/DevMenuViewController.swift
+++ b/packages/expo-dev-menu/ios/DevMenuViewController.swift
@@ -79,7 +79,8 @@ class DevMenuViewController: UIViewController {
       "devMenuItems": manager.serializedDevMenuItems(),
       "devMenuScreens": manager.serializedDevMenuScreens(),
       "appInfo": manager.session?.appInfo ?? [:],
-      "uuid": UUID.init().uuidString
+      "uuid": UUID.init().uuidString,
+      "openScreen": manager.session?.openScreen
     ]
   }
 

--- a/packages/expo-dev-menu/ios/Modules/DeMenuManagerProvider.swift
+++ b/packages/expo-dev-menu/ios/Modules/DeMenuManagerProvider.swift
@@ -1,0 +1,21 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import EXDevMenuInterface
+
+@objc(DevMenuManagerProvider)
+class DevMenuManagerProvider : NSObject, RCTBridgeModule, DevMenuManagerProviderProtocol {
+  @objc
+  static func moduleName() -> String! {
+    return "ExpoDevMenuManagerProvider"
+  }
+  
+  @objc
+  public static func requiresMainQueueSetup() -> Bool {
+    return true
+  }
+  
+  @objc
+  open func getDevMenuManager() -> DevMenuManagerProtocol {
+    return DevMenuManager.shared
+  }
+}

--- a/packages/expo-dev-menu/ios/Modules/DevMenuInternalModule.m
+++ b/packages/expo-dev-menu/ios/Modules/DevMenuInternalModule.m
@@ -1,10 +1,16 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
 #import <React/RCTBridgeModule.h>
+#import <SafariServices/SafariServices.h>
 
 // Normally we would use RCT_EXTERN_MODULE macro, but in case of this internal module
 // we don't want it to be automatically registered for all bridges in the entire app.
 @interface DevMenuInternalModule : NSObject
+
+@property (nonatomic, copy) RCTPromiseResolveBlock redirectResolve;
+@property (nonatomic, copy) RCTPromiseRejectBlock redirectReject;
+@property (nonatomic, strong) SFAuthenticationSession *authSession;
+
 @end
 
 @implementation DevMenuInternalModule (RCTExternModule)
@@ -17,5 +23,72 @@ RCT_EXTERN_METHOD(setSettingsAsync:(NSDictionary *)dict resolve:(RCTPromiseResol
 RCT_EXTERN_METHOD(loadFontsAsync:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(openDevMenuFromReactNative)
 RCT_EXTERN_METHOD(onScreenChangeAsync:(NSString *)currentScreen resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(saveAsync:(NSString *)key data:(NSString *)data resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(getAsync:(NSString *)key resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+
+/**
+ * Helper that is used in openBrowserAsync and openAuthSessionAsync
+ */
+- (BOOL)initializeWebBrowserWithResolver:(RCTPromiseResolveBlock)resolve andRejecter:(RCTPromiseRejectBlock)reject {
+  
+  if (self.redirectResolve) {
+    reject(@"ERR_DEV_MENU_WEB_BROWSER", @"Another WebBrowser is already being presented.", nil);
+    return NO;
+  }
+  self.redirectReject = reject;
+  self.redirectResolve = resolve;
+  return YES;
+}
+
+RCT_EXPORT_METHOD(openAuthSessionAsync:(NSString *)authURL
+                           redirectURL:(NSString *)redirectURL
+                              resolver:(RCTPromiseResolveBlock)resolve
+                              rejecter:(RCTPromiseRejectBlock)reject)
+{
+  if (![self initializeWebBrowserWithResolver:resolve andRejecter:reject]) {
+    return;
+  }
+  
+  if (@available(iOS 11, *)) {
+    NSURL *url = [[NSURL alloc] initWithString: authURL];
+    __weak typeof(self) weakSelf = self;
+    void (^completionHandler)(NSURL * _Nullable, NSError *_Nullable) = ^(NSURL* _Nullable callbackURL, NSError* _Nullable error) {
+      __strong typeof(weakSelf) strongSelf = weakSelf;
+      //check if flow didn't already finish
+      if (strongSelf && strongSelf.redirectResolve) {
+        if (!error) {
+          NSString *url = callbackURL.absoluteString;
+          strongSelf.redirectResolve(@{
+                                         @"type" : @"success",
+                                         @"url" : url,
+                                         });
+        } else {
+          strongSelf.redirectResolve(@{
+                                         @"type" : @"cancel",
+                                         });
+        }
+        [strongSelf flowDidFinish];
+      }
+    };
+    self.authSession = [[SFAuthenticationSession alloc] initWithURL:url
+                                                  callbackURLScheme:redirectURL
+                                                  completionHandler:completionHandler];
+    [self.authSession start];
+  } else {
+    resolve(@{
+              @"type" : @"cancel",
+              @"message" : @"openAuthSessionAsync requires iOS 11 or greater"
+              });
+    [self flowDidFinish];
+  }
+}
+
+
+- (void)flowDidFinish
+{
+  self.redirectResolve = nil;
+  self.redirectReject = nil;
+}
 
 @end

--- a/packages/expo-dev-menu/ios/Modules/DevMenuInternalModule.swift
+++ b/packages/expo-dev-menu/ios/Modules/DevMenuInternalModule.swift
@@ -1,7 +1,15 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
+import SafariServices
 
 @objc(DevMenuInternalModule)
 public class DevMenuInternalModule: NSObject, RCTBridgeModule {
+  @objc
+  var redirectResolve: RCTPromiseResolveBlock?
+  @objc
+  var redirectReject: RCTPromiseRejectBlock?
+  @objc
+  var authSession: SFAuthenticationSession?
+  
   public static func moduleName() -> String! {
     return "ExpoDevMenuInternal"
   }
@@ -124,5 +132,16 @@ public class DevMenuInternalModule: NSObject, RCTBridgeModule {
   func onScreenChangeAsync(_ currentScreen: String?, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
     manager.setCurrentScreen(currentScreen)
     resolve(nil)
+  }
+  
+  @objc
+  func saveAsync(_ key: String, data: String, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
+    UserDefaults.standard.set(data, forKey: key)
+    resolve(nil)
+  }
+  
+  @objc
+  func getAsync(_ key: String, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
+    resolve(UserDefaults.standard.string(forKey: key))
   }
 }

--- a/packages/expo-dev-menu/ios/Modules/DevMenuManagerProvider.m
+++ b/packages/expo-dev-menu/ios/Modules/DevMenuManagerProvider.m
@@ -1,0 +1,7 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+#import <React/RCTBridgeModule.h>
+
+@interface RCT_EXTERN_REMAP_MODULE(ExpoDevMenuManagerProvider, DevMenuManagerProvider, NSObject)
+
+@end

--- a/packages/expo-dev-menu/ios/Modules/DevMenuModule.m
+++ b/packages/expo-dev-menu/ios/Modules/DevMenuModule.m
@@ -5,5 +5,7 @@
 @interface RCT_EXTERN_REMAP_MODULE(ExpoDevMenu, DevMenuModule, NSObject)
 
 RCT_EXTERN_METHOD(openMenu)
+RCT_EXTERN_METHOD(openProfile)
+RCT_EXTERN_METHOD(openSettings)
 
 @end

--- a/packages/expo-dev-menu/ios/Modules/DevMenuModule.swift
+++ b/packages/expo-dev-menu/ios/Modules/DevMenuModule.swift
@@ -16,4 +16,14 @@ open class DevMenuModule: NSObject, RCTBridgeModule {
   func openMenu() {
     DevMenuManager.shared.openMenu()
   }
+
+  @objc
+  func openSettings() {
+    DevMenuManager.shared.openMenu("Settings")
+  }
+  
+  @objc
+  func openProfile() {
+    DevMenuManager.shared.openMenu("Profile")
+  }
 }

--- a/packages/expo-dev-menu/package.json
+++ b/packages/expo-dev-menu/package.json
@@ -44,9 +44,9 @@
     "expo-dev-menu-interface": "0.1.2"
   },
   "devDependencies": {
-    "@react-navigation/core": "5.10.0",
-    "@react-navigation/native": "5.5.1",
-    "@react-navigation/stack": "5.4.1",
+    "@react-navigation/core": "5.15.1",
+    "@react-navigation/native": "5.9.2",
+    "@react-navigation/stack": "5.14.2",
     "babel-plugin-module-resolver": "^4.0.0",
     "expo-module-scripts": "^2.0.0",
     "react": "16.13.1",

--- a/packages/expo-dev-menu/package.json
+++ b/packages/expo-dev-menu/package.json
@@ -41,8 +41,7 @@
     "preset": "expo-module-scripts"
   },
   "dependencies": {
-    "expo-dev-menu-interface": "0.1.2",
-    "fuse.js": "^6.4.6"
+    "expo-dev-menu-interface": "0.1.2"
   },
   "devDependencies": {
     "@react-navigation/core": "5.10.0",
@@ -51,6 +50,13 @@
     "babel-plugin-module-resolver": "^4.0.0",
     "expo-module-scripts": "^2.0.0",
     "react": "16.13.1",
-    "react-native": "0.63.2"
+    "react-native": "0.63.2",
+    "fuse.js": "^6.4.6",
+    "url": "^0.11.0",
+    "graphql": "^14.2.1",
+    "graphql-tag": "^2.10.1",
+    "apollo-boost": "^0.4.4",
+    "apollo-cache-inmemory": "^1.6.3",
+    "@apollo/client": "^3.0.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3731,17 +3731,16 @@
     color "^3.1.3"
     react-native-iphone-x-helper "^1.3.0"
 
-"@react-navigation/core@5.10.0":
-  version "5.10.0"
-  resolved "https://registry.yarnpkg.com/@react-navigation/core/-/core-5.10.0.tgz#aee9e22a5f0f458ebeadc155f347b13eb5ff5212"
-  integrity sha512-cVQTj5FtZHWuymjZMP50RVXYpkQUbo1zQPjxJl+UfBUh7u9nKexknajBhjYbZq61uDE4MmPE8qAqIEJHKeR4Hg==
+"@react-navigation/core@5.15.1", "@react-navigation/core@^5.15.1":
+  version "5.15.1"
+  resolved "https://registry.yarnpkg.com/@react-navigation/core/-/core-5.15.1.tgz#dab5192277c606d9acbea511dac407c2834b5fbe"
+  integrity sha512-GDCpIVQd0NgHYCSdUMY69hrpeWKuYgj5SIRqHI2sYh9OguwGcV52ZZOafc+pQuyfuiLLIMidw34jiqb47QrlhA==
   dependencies:
-    "@react-navigation/routers" "^5.4.7"
+    "@react-navigation/routers" "^5.7.1"
     escape-string-regexp "^4.0.0"
-    nanoid "^3.1.5"
-    query-string "^6.12.1"
+    nanoid "^3.1.15"
+    query-string "^6.13.6"
     react-is "^16.13.0"
-    use-subscription "^1.4.0"
 
 "@react-navigation/core@^3.7.9":
   version "3.7.9"
@@ -3750,17 +3749,6 @@
   dependencies:
     hoist-non-react-statics "^3.3.2"
     path-to-regexp "^1.8.0"
-    query-string "^6.13.6"
-    react-is "^16.13.0"
-
-"@react-navigation/core@^5.10.0":
-  version "5.14.4"
-  resolved "https://registry.yarnpkg.com/@react-navigation/core/-/core-5.14.4.tgz#f63a2cd214bddbd25e1181f9335c32dfc3b6460f"
-  integrity sha512-MzZU9PO1a/6f9KdN04dC/E4BNl6M1Ba0Tb4sQdl/32y0hM2ToxlrKcERnTLWGFIbQV+9ZV1GTrp3mlGS6U9Jpw==
-  dependencies:
-    "@react-navigation/routers" "^5.6.2"
-    escape-string-regexp "^4.0.0"
-    nanoid "^3.1.15"
     query-string "^6.13.6"
     react-is "^16.13.0"
 
@@ -3788,13 +3776,14 @@
   resolved "https://registry.yarnpkg.com/@react-navigation/material-bottom-tabs/-/material-bottom-tabs-5.3.9.tgz#d6375b027f7ef74f00fcd8d866ac1c83dabdbcb2"
   integrity sha512-LZmFJ2EFF84ZAAvQ+rZ/w9khXTFPgIqk32ALfTillXY55+JViWBVNym1DP9vvb7ZCb03fyjFPsNLWBbK0ygmiA==
 
-"@react-navigation/native@5.5.1":
-  version "5.5.1"
-  resolved "https://registry.yarnpkg.com/@react-navigation/native/-/native-5.5.1.tgz#e669d9561e54d86b1315637b8d5630dc55ee9383"
-  integrity sha512-5pzsfvLdnvqfrWgTMCLDFaGK6Sj30p7tAMhUGneV2oGlx0OIbhgc6/04UUMpKEmAS2PaC/GZa1LQIsSVWDewvw==
+"@react-navigation/native@5.9.2":
+  version "5.9.2"
+  resolved "https://registry.yarnpkg.com/@react-navigation/native/-/native-5.9.2.tgz#2075774c3627d58a324e1b5dfc5f4f356a1ab7e9"
+  integrity sha512-O8K+Lr6Vy25gTTyXAns9BVyFvwTkKqfFH0RpOimilYndUL6tlhV56oDSp7Hryjy8xsjx6ESWqr6eIu4sS3Z9nQ==
   dependencies:
-    "@react-navigation/core" "^5.10.0"
-    nanoid "^3.1.9"
+    "@react-navigation/core" "^5.15.1"
+    escape-string-regexp "^4.0.0"
+    nanoid "^3.1.15"
 
 "@react-navigation/native@^3.8.3":
   version "3.8.3"
@@ -3813,20 +3802,27 @@
     escape-string-regexp "^4.0.0"
     nanoid "^3.1.15"
 
-"@react-navigation/routers@^5.4.7", "@react-navigation/routers@^5.6.2":
+"@react-navigation/routers@^5.6.2":
   version "5.6.2"
   resolved "https://registry.yarnpkg.com/@react-navigation/routers/-/routers-5.6.2.tgz#accc008c3b777f74d998e16cb2ea8e4c1fe8d9aa"
   integrity sha512-XBcDKXS5s4MaHFufN44LtbXqFDH/nUHfHjbwG85fP3k772oRyPRgbnUb2mbw5MFGqORla9T7uymR6Gh6uwIwVw==
   dependencies:
     nanoid "^3.1.15"
 
-"@react-navigation/stack@5.4.1":
-  version "5.4.1"
-  resolved "https://registry.yarnpkg.com/@react-navigation/stack/-/stack-5.4.1.tgz#3b4ebec52649dca77571050bb00db9ea02df61a8"
-  integrity sha512-Pi1OH1kofbYIpUJ6q+8NZ+wprrGcBmTLAE/DfgmzrC+6I+EObYq55N2ByikqVSgKaRS+TsDrQe/RNkumsOjqVA==
+"@react-navigation/routers@^5.7.1":
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/@react-navigation/routers/-/routers-5.7.1.tgz#ba56cabdaabc521ef29c26529e868590949429b1"
+  integrity sha512-M5R4AFgJZ0uBUV+DjMyNy2HXRfvo0ldM+59Gj1NQWXaYnst3m0xJTfWiln94mnrbrHEq087gMP4ZLHGIJ8D1Ig==
   dependencies:
-    color "^3.1.2"
-    react-native-iphone-x-helper "^1.2.1"
+    nanoid "^3.1.15"
+
+"@react-navigation/stack@5.14.2":
+  version "5.14.2"
+  resolved "https://registry.yarnpkg.com/@react-navigation/stack/-/stack-5.14.2.tgz#6e48efa74a9b0fc29ff0a90fcbee161039b84d78"
+  integrity sha512-tt1eFn6HClyXVZiVQsPs3Q2MgoqmJdkQsyT9P4TBLxGsdib6r/oc++eVNc+G/6ws/kCquDdHq3fz1PNSCtyrJA==
+  dependencies:
+    color "^3.1.3"
+    react-native-iphone-x-helper "^1.3.0"
 
 "@react-navigation/stack@~5.12.6":
   version "5.12.6"
@@ -14277,11 +14273,6 @@ nanoid@^3.1.15:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.16.tgz#b21f0a7d031196faf75314d7c65d36352beeef64"
   integrity sha512-+AK8MN0WHji40lj8AEuwLOvLSbWYApQpre/aFJZD71r43wVRLrOYS4FmJOPQYon1TqB462RzrrxlfA74XRES8w==
 
-nanoid@^3.1.5, nanoid@^3.1.9:
-  version "3.1.20"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.20.tgz#badc263c6b1dcf14b71efaa85f6ab4c1d6cfc788"
-  integrity sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw==
-
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -16337,7 +16328,7 @@ query-string@^5.0.1:
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
 
-query-string@^6.12.1, query-string@^6.13.6:
+query-string@^6.13.6:
   version "6.13.7"
   resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.13.7.tgz#af53802ff6ed56f3345f92d40a056f93681026ee"
   integrity sha512-CsGs8ZYb39zu0WLkeOhe0NMePqgYdAuCqxOYKDR5LVCytDZYMGx3Bb+xypvQvPHVPijRXB0HZNFllCzHRe4gEA==
@@ -16592,11 +16583,6 @@ react-native-infinite-scroll-view@^0.4.5:
     prop-types "^15.6.2"
     react-clone-referenced-element "^1.0.1"
     react-native-scrollable-mixin "^1.0.0"
-
-react-native-iphone-x-helper@^1.2.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.3.1.tgz#20c603e9a0e765fd6f97396638bdeb0e5a60b010"
-  integrity sha512-HOf0jzRnq2/aFUcdCJ9w9JGzN3gdEg0zFE4FyYlp4jtidqU03D5X7ZegGKfT1EWteR0gPBGp9ye5T5FvSWi9Yg==
 
 react-native-iphone-x-helper@^1.3.0:
   version "1.3.0"
@@ -19388,13 +19374,6 @@ use-subscription@^1.0.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/use-subscription/-/use-subscription-1.4.1.tgz#edcbcc220f1adb2dd4fa0b2f61b6cc308e620069"
   integrity sha512-7+IIwDG/4JICrWHL/Q/ZPK5yozEnvRm6vHImu0LKwQlmWGKeiF7mbAenLlK/cTNXrTtXHU/SFASQHzB6+oSJMQ==
-  dependencies:
-    object-assign "^4.1.1"
-
-use-subscription@^1.4.0:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/use-subscription/-/use-subscription-1.5.1.tgz#73501107f02fad84c6dd57965beb0b75c68c42d1"
-  integrity sha512-Xv2a1P/yReAjAbhylMfFplFKj9GssgTwN7RlcTxBujFQcloStWNDQdc4g4NRWH9xS4i/FDk04vQBptAXoF3VcA==
   dependencies:
     object-assign "^4.1.1"
 


### PR DESCRIPTION
# Why

Adds auth & profile screen to dev-menu

# How

- Reimplemented web browser functionalities in dev-menu (mostly copied the code from `expo-web-browser`)
- Implemented UI - similar to one in the home app
- Created simple local storage to store a session.
- Added the GraphQL client

# Test Plan

- bare-expo ✅   -  https://exponent-internal.slack.com/archives/C3XK84RRR/p1612967628256400
