### PR TITLE
[docs] Remove archived page from search results

### DIFF
--- a/docs/pages/archived/notification-channels.md
+++ b/docs/pages/archived/notification-channels.md
@@ -1,5 +1,6 @@
 ---
 title: Notification Channels
+hideFromSearch: true
 ---
 
 > 🚨 This page is archived. Please refer to the [Push Notifications guide](../../push-notifications/overview.md) for up-to-date information.


### PR DESCRIPTION
# Why

Archived pages shouldn't be searchable through Algolia. It's still getting indexed by Google.

# How

- Added the new `hideFromSearch: true` flag to the page.

# Test Plan

- Make sure `<meta name="docsearch:version" />` or any other `docsearch` meta tags is presented on the archived page.
