### PR TITLE
[git] Remove CocoaPod entries from git-lfs list

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,9 +5,3 @@ nix/**/gemset.nix -diff linguist-generated
 packages/*/build/** -diff linguist-generated
 packages/*/plugin/build/** -diff linguist-generated
 packages/@*/*/build/** -diff linguist-generated
-ios/Pods/FBAudienceNetwork/Static/FBAudienceNetwork.framework/FBAudienceNetwork filter=lfs diff=lfs merge=lfs -text
-ios/Pods/GoogleMobileVision/Detector/Frameworks/GoogleMobileVision.framework/GoogleMobileVision filter=lfs diff=lfs merge=lfs -text
-ios/Pods/Google-Mobile-Ads-SDK/Frameworks/GoogleMobileAdsFramework-Current/GoogleMobileAds.framework/GoogleMobileAds filter=lfs diff=lfs merge=lfs -text
-ios/Pods/GoogleMaps/Maps/Frameworks/GoogleMapsCore.framework/GoogleMapsCore filter=lfs diff=lfs merge=lfs -text
-ios/Pods/FirebaseMLVisionFaceModel/Frameworks/FirebaseMLVisionFaceModel.framework/FirebaseMLVisionFaceModel filter=lfs diff=lfs merge=lfs -text
-apps/bare-expo/ios/Pods/FirebaseMLVisionFaceModel/Frameworks/FirebaseMLVisionFaceModel.framework/FirebaseMLVisionFaceModel filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
Why: we no longer commit pods to the repository and don't need to download the large ones from Git LFS.

How: updated .gitattributes to remove the LFS entries

Test plan: make sure `git lfs pull` doesn't break

