### PR TITLE
[expo-updates][expo-constants] android gradle plugin 4.1+ support

### DIFF
--- a/packages/expo-constants/CHANGELOG.md
+++ b/packages/expo-constants/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed support for Android Gradle plugin 4.1+ ([#11926](https://github.com/expo/expo/pull/11926) by [@esamelson](https://github.com/esamelson))
+
 ## 10.0.1 — 2021-01-25
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-constants/scripts/get-app-config-android.gradle
+++ b/packages/expo-constants/scripts/get-app-config-android.gradle
@@ -20,26 +20,19 @@ afterEvaluate {
   def inputExcludes = ["android/**", "ios/**"]
 
   android.applicationVariants.each { variant ->
-    def folderName = variant.name
-    def targetName = folderName.capitalize()
+    def targetName = variant.name.capitalize()
+    def targetPath = variant.dirName
 
-    def assetsDir = file("$buildDir/intermediates/merged_assets/${folderName}/out")
-
-    GradleVersion gradleVersion = GradleVersion.current()
-    if (gradleVersion < GradleVersion.version('5.0')) {
-      assetsDir = file("$buildDir/intermediates/merged_assets/${folderName}/merge${targetName}Assets/out")
-    }
-
-    // Bundle task name for variant
-    def bundleAppConfigTaskName = "bundle${targetName}ExpoConfig"
+    def assetsDir = file("$buildDir/generated/assets/expo-constants/${targetPath}")
 
     def currentBundleTask = tasks.create(
-        name: bundleAppConfigTaskName,
+        name: "create${targetName}ExpoConfig",
         type: Exec) {
-      description = "expo-constants: Bundle app config for ${targetName}."
+      description = "expo-constants: Create config for ${targetName}."
 
       // Create dirs if they are not there (e.g. the "clean" task just ran)
       doFirst {
+        assetsDir.deleteDir()
         assetsDir.mkdirs()
       }
 
@@ -57,9 +50,31 @@ afterEvaluate {
       }
     }
 
-    currentBundleTask.dependsOn("merge${targetName}Resources")
-    currentBundleTask.dependsOn("merge${targetName}Assets")
+    def currentAssetsCopyTask = tasks.create(
+        name: "copy${targetName}ExpoConfig",
+        type: Copy) {
+      description = "expo-constants: Copy config into ${targetName}."
 
-    runBefore("process${targetName}Resources", currentBundleTask)
+      into ("$buildDir/intermediates")
+      into ("assets/${targetPath}") {
+        from(assetsDir)
+      }
+
+      // Workaround for Android Gradle Plugin 3.2+ new asset directory
+      into ("merged_assets/${variant.name}/merge${targetName}Assets/out") {
+        from(assetsDir)
+      }
+
+      // Workaround for Android Gradle Plugin 3.4+ new asset directory
+      into ("merged_assets/${variant.name}/out") {
+        from(assetsDir)
+      }
+
+      // mergeAssets must run first, as it clears the intermediates directory
+      dependsOn(variant.mergeAssetsProvider.get())
+      dependsOn(currentBundleTask)
+    }
+
+    runBefore("process${targetName}Resources", currentAssetsCopyTask)
   }
 }

--- a/packages/expo-constants/scripts/get-app-config-android.gradle
+++ b/packages/expo-constants/scripts/get-app-config-android.gradle
@@ -30,7 +30,6 @@ afterEvaluate {
         type: Exec) {
       description = "expo-constants: Create config for ${targetName}."
 
-      // Create dirs if they are not there (e.g. the "clean" task just ran)
       doFirst {
         assetsDir.deleteDir()
         assetsDir.mkdirs()

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Fixed discrepancies across platforms regarding required fields in manifests ([#11562](https://github.com/expo/expo/pull/11562) by [@esamelson](https://github.com/esamelson))
 - Improved support for `assetUrlOverride` in legacy self-hosted apps ([#11601](https://github.com/expo/expo/pull/11601))
 - Stop expecting data and publicManifest root level keys for EAS manifests ([#11613](https://github.com/expo/expo/pull/11613) by [@esamelson](https://github.com/esamelson))
+- Fixed support for Android Gradle plugin 4.1+ ([#11926](https://github.com/expo/expo/pull/11926) by [@esamelson](https://github.com/esamelson))
 
 ## 0.4.1 — 2020-11-25
 

--- a/packages/expo-updates/scripts/create-manifest-android.gradle
+++ b/packages/expo-updates/scripts/create-manifest-android.gradle
@@ -32,7 +32,6 @@ afterEvaluate {
         type: Exec) {
       description = "expo-updates: Create manifest for ${targetName}."
 
-      // Create dirs if they are not there (e.g. the "clean" task just ran)
       doFirst {
         assetsDir.deleteDir()
         assetsDir.mkdirs()

--- a/packages/expo-updates/scripts/create-manifest-android.gradle
+++ b/packages/expo-updates/scripts/create-manifest-android.gradle
@@ -22,26 +22,19 @@ afterEvaluate {
   def inputExcludes = ["android/**", "ios/**"]
 
   android.applicationVariants.each { variant ->
-    def folderName = variant.name
-    def targetName = folderName.capitalize()
+    def targetName = variant.name.capitalize()
+    def targetPath = variant.dirName
 
-    def assetsDir = file("$buildDir/intermediates/merged_assets/${folderName}/out")
-
-    GradleVersion gradleVersion = GradleVersion.current()
-    if (gradleVersion < GradleVersion.version('5.0')) {
-      assetsDir = file("$buildDir/intermediates/merged_assets/${folderName}/merge${targetName}Assets/out")
-    }
-
-    // Bundle task name for variant
-    def bundleExpoAssetsTaskName = "create${targetName}ExpoManifest"
+    def assetsDir = file("$buildDir/generated/assets/expo-updates/${targetPath}")
 
     def currentBundleTask = tasks.create(
-        name: bundleExpoAssetsTaskName,
+        name: "create${targetName}ExpoManifest",
         type: Exec) {
       description = "expo-updates: Create manifest for ${targetName}."
 
       // Create dirs if they are not there (e.g. the "clean" task just ran)
       doFirst {
+        assetsDir.deleteDir()
         assetsDir.mkdirs()
       }
 
@@ -63,9 +56,33 @@ afterEvaluate {
       enabled config."bundleIn${targetName}" || targetName.toLowerCase().contains("release")
     }
 
-    currentBundleTask.dependsOn("merge${targetName}Resources")
-    currentBundleTask.dependsOn("merge${targetName}Assets")
+    def currentAssetsCopyTask = tasks.create(
+        name: "copy${targetName}ExpoManifest",
+        type: Copy) {
+      description = "expo-updates: Copy manifest into ${targetName}."
 
-    runBefore("process${targetName}Resources", currentBundleTask)
+      into ("$buildDir/intermediates")
+      into ("assets/${targetPath}") {
+        from(assetsDir)
+      }
+
+      // Workaround for Android Gradle Plugin 3.2+ new asset directory
+      into ("merged_assets/${variant.name}/merge${targetName}Assets/out") {
+        from(assetsDir)
+      }
+
+      // Workaround for Android Gradle Plugin 3.4+ new asset directory
+      into ("merged_assets/${variant.name}/out") {
+        from(assetsDir)
+      }
+
+      // mergeAssets must run first, as it clears the intermediates directory
+      dependsOn(variant.mergeAssetsProvider.get())
+      dependsOn(currentBundleTask)
+
+      enabled(currentBundleTask.enabled)
+    }
+
+    runBefore("process${targetName}Resources", currentAssetsCopyTask)
   }
 }


### PR DESCRIPTION
# Why

One partner was having trouble with the `create-manifest-android.gradle` script in EAS Build; it turns out that upgrading the Android Gradle plugin to 4.1.2 (Gradle version 6.5) broke this script, as well as the corresponding expo-constants script, in their project.

# How

Made these scripts a little more robust by following the pattern established in RN's `react.gradle` for the JS bundle:
- one task runs the node script to create the json file to be embedded, and copies it to a special `generated` folder
- a separate task of type `Copy` runs afterwards to copy the files from this location to the build intermediates `merged_assets` folder. This task copies the file to all possible locations of the merged_assets folder (as opposed to the old single task, which would try to guess the one correct folder based on the gradle version).

# Test Plan

Reproduced the problem locally with a repro provided by @cruzach ; after replacing both these scripts in node_modules, running `./gradlew clean`, and rebuilding the app from scratch, it has the expected files included.
