### PR TITLE
[expo-dev-menu] Make dev-menu available in dev-launcher

### DIFF
--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/DevLauncherClientHost.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/DevLauncherClientHost.kt
@@ -5,6 +5,7 @@ import com.facebook.react.ReactNativeHost
 import com.facebook.react.shell.MainReactPackage
 import expo.modules.devlauncher.DevLauncherPackage
 import expo.modules.devlauncher.R
+import expo.modules.devlauncher.helpers.findDevMenuPackage
 import expo.modules.devlauncher.helpers.injectDebugServerHost
 import org.apache.commons.io.IOUtils
 import java.io.File
@@ -24,9 +25,10 @@ class DevLauncherClientHost(
 
   override fun getUseDeveloperSupport() = launcherIp != null
 
-  override fun getPackages() = listOf(
+  override fun getPackages() = listOfNotNull(
     MainReactPackage(null),
-    DevLauncherPackage()
+    DevLauncherPackage(),
+    findDevMenuPackage()
   )
 
   override fun getJSMainModuleName() = "index"

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/helpers/DevLauncherReactUtils.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/helpers/DevLauncherReactUtils.kt
@@ -3,6 +3,7 @@ package expo.modules.devlauncher.helpers
 import android.content.Context
 import android.util.Log
 import com.facebook.react.ReactNativeHost
+import com.facebook.react.ReactPackage
 import expo.modules.devlauncher.react.DevLauncherInternalSettings
 
 fun injectDebugServerHost(context: Context, reactNativeHost: ReactNativeHost, debugServerHost: String): Boolean {
@@ -24,5 +25,14 @@ fun injectDebugServerHost(context: Context, reactNativeHost: ReactNativeHost, de
   } catch (e: Exception) {
     Log.e("DevLauncher", "Unable to inject debug server host settings.", e)
     false
+  }
+}
+
+fun findDevMenuPackage(): ReactPackage? {
+  return try {
+    val clazz = Class.forName("expo.modules.devmenu.DevMenuPackage")
+    clazz.newInstance() as? ReactPackage
+  } catch (e: Exception) {
+    null
   }
 }

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/DevLauncherActivity.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/DevLauncherActivity.kt
@@ -2,16 +2,24 @@ package expo.modules.devlauncher.launcher
 
 import android.os.Build
 import android.os.Bundle
+import android.view.KeyEvent
+import android.view.MotionEvent
 import com.facebook.react.ReactActivity
 import com.facebook.react.ReactActivityDelegate
+import com.facebook.react.ReactInstanceManager
+import com.facebook.react.bridge.ReactContext
+import expo.interfaces.devmenu.DevMenuManagerInterface
+import expo.interfaces.devmenu.DevMenuManagerProviderInterface
 import expo.modules.devlauncher.DevLauncherController
-import java.util.*
 
-class DevLauncherActivity : ReactActivity() {
+class DevLauncherActivity : ReactActivity(), ReactInstanceManager.ReactInstanceEventListener {
+  private var devMenuManager: DevMenuManagerInterface? = null
+
   override fun getMainComponentName() = "main"
 
   override fun createReactActivityDelegate(): ReactActivityDelegate {
     return object : ReactActivityDelegate(this, mainComponentName) {
+
       override fun getReactNativeHost() = DevLauncherController.instance.devClientHost
 
       override fun getLaunchOptions() = Bundle().apply {
@@ -25,9 +33,42 @@ class DevLauncherActivity : ReactActivity() {
     super.onStart()
   }
 
+  override fun onPostCreate(savedInstanceState: Bundle?) {
+    super.onPostCreate(savedInstanceState)
+
+    reactInstanceManager.currentReactContext?.let {
+      onReactContextInitialized(it)
+      return
+    }
+
+    reactInstanceManager.addReactInstanceEventListener(this)
+  }
+
   override fun onPause() {
     overridePendingTransition(0, 0)
     super.onPause()
+  }
+
+  override fun dispatchTouchEvent(ev: MotionEvent?): Boolean {
+    devMenuManager?.onTouchEvent(ev)
+    return super.dispatchTouchEvent(ev)
+  }
+
+  override fun onKeyUp(keyCode: Int, event: KeyEvent): Boolean {
+    return devMenuManager?.onKeyEvent(keyCode, event) == true || super.onKeyUp(keyCode, event)
+  }
+
+  override fun onReactContextInitialized(context: ReactContext) {
+    reactInstanceManager.removeReactInstanceEventListener(this)
+
+    val devMenuManagerProvider = context.catalystInstance.nativeModules.find { nativeModule ->
+      nativeModule is DevMenuManagerProviderInterface
+    } as? DevMenuManagerProviderInterface
+
+    val devMenuManager = devMenuManagerProvider?.getDevMenuManager() ?: return
+    devMenuManager.initializeWithReactNativeHost(reactNativeHost)
+
+    this.devMenuManager = devMenuManager
   }
 
   private val isSimulator

--- a/packages/expo-dev-launcher/bundle/App.tsx
+++ b/packages/expo-dev-launcher/bundle/App.tsx
@@ -12,12 +12,15 @@ import {
   StyleSheet,
   TextInput,
   Platform,
-  TouchableOpacity,
   NativeEventEmitter,
   RefreshControl,
 } from 'react-native';
 
-import ListItem from './ListItem';
+import { isDevMenuAvailable } from './DevMenu';
+import BottomTabs from './components/BottomTabs';
+import Button from './components/Button';
+import ListItem from './components/ListItem';
+
 const DevLauncher = NativeModules.EXDevLauncherInternal;
 
 // Use development client native module to load app at given URL, notifying of
@@ -32,22 +35,6 @@ const loadAppFromUrl = async (urlString: string, setLoading: (boolean) => void) 
     Alert.alert('Error loading app', e.message);
   }
 };
-
-//
-// Reusable button for below code
-//
-
-const Button = ({ label, onPress }) => (
-  <TouchableOpacity style={styles.buttonContainer} onPress={onPress}>
-    <Text style={styles.buttonText}>{label}</Text>
-  </TouchableOpacity>
-);
-
-//
-// Super barebones UI supporting at least loading an app from a QR
-// code, while we figure out what the design for this screen should be / decide
-// on features to support
-//
 
 const ON_NEW_DEEP_LINK_EVENT = 'expo.modules.devlauncher.onnewdeeplink';
 
@@ -70,6 +57,8 @@ const portsToCheck = [
   19009,
   19010,
 ];
+
+const bottomContainerHeight = isDevMenuAvailable() ? 40 : 0;
 
 const App = ({ isSimulator }) => {
   const [loading, setLoading] = useState(false);
@@ -219,7 +208,6 @@ const App = ({ isSimulator }) => {
                 ))}
               </>
             )}
-
             {recentlyProjects.length > 0 && (
               <>
                 <Text style={[styles.infoText, { marginTop: 12 }]}>Recently opened projects:</Text>
@@ -229,6 +217,7 @@ const App = ({ isSimulator }) => {
           </View>
         </>
       </ScrollView>
+      {bottomContainerHeight > 0 && <BottomTabs height={bottomContainerHeight} />}
     </SafeAreaView>
   );
 };
@@ -236,14 +225,16 @@ const App = ({ isSimulator }) => {
 const styles = StyleSheet.create({
   safeArea: {
     flex: 1,
-    backgroundColor: '#ffffff',
+    backgroundColor: '#fff',
   },
   container: {
     flex: 1,
+    marginBottom: bottomContainerHeight,
   },
 
   homeContainer: {
     paddingHorizontal: 24,
+    paddingBottom: 10,
   },
 
   pendingDeepLinkContainer: {
@@ -258,7 +249,7 @@ const styles = StyleSheet.create({
   },
   pendingDeepLink: {
     marginTop: 10,
-    color: '#ffffff',
+    color: '#fff',
     fontWeight: '700',
     fontSize: 16,
   },
@@ -270,19 +261,6 @@ const styles = StyleSheet.create({
   },
   loadingText: {
     fontSize: 24,
-  },
-
-  buttonContainer: {
-    backgroundColor: '#4630eb',
-    borderRadius: 4,
-    padding: 12,
-    marginVertical: 10,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  buttonText: {
-    color: '#ffffff',
-    fontSize: 16,
   },
 
   headingText: {

--- a/packages/expo-dev-launcher/bundle/DevMenu.ts
+++ b/packages/expo-dev-launcher/bundle/DevMenu.ts
@@ -1,0 +1,7 @@
+import { NativeModules } from 'react-native';
+
+export const DevMenu = NativeModules.ExpoDevMenu;
+
+export function isDevMenuAvailable(): boolean {
+  return !!DevMenu;
+}

--- a/packages/expo-dev-launcher/bundle/DevMenu.ts
+++ b/packages/expo-dev-launcher/bundle/DevMenu.ts
@@ -1,7 +1,7 @@
 import { NativeModules } from 'react-native';
 
-export const DevMenu = NativeModules.ExpoDevMenu;
-
 export function isDevMenuAvailable(): boolean {
-  return !!DevMenu;
+  return !!NativeModules.ExpoDevMenu;
 }
+
+export const DevMenu = NativeModules.ExpoDevMenu;

--- a/packages/expo-dev-launcher/bundle/components/BottomTabs.tsx
+++ b/packages/expo-dev-launcher/bundle/components/BottomTabs.tsx
@@ -8,6 +8,10 @@ type Props = {
 };
 
 export default class BottomTabs extends React.Component<Props, object> {
+  openProfile = () => DevMenu.openProfile?.();
+  openMenu = () => DevMenu.openMenu?.();
+  openSettings = () => DevMenu.openSettings?.();
+
   render() {
     return (
       <View style={[styles.bottomTabsAbsoluteContainer, { height: this.props.height }]}>
@@ -15,27 +19,21 @@ export default class BottomTabs extends React.Component<Props, object> {
           <TouchableHighlight
             underlayColor="#ddd"
             style={styles.bottomTabsItem}
-            onPress={() => {
-              DevMenu.openProfile?.();
-            }}>
+            onPress={this.openProfile}>
             <Text style={styles.bottomTabsItemContent}>Profile</Text>
           </TouchableHighlight>
 
           <TouchableHighlight
             underlayColor="#ddd"
             style={styles.bottomTabsItem}
-            onPress={() => {
-              DevMenu.openMenu?.();
-            }}>
+            onPress={this.openMenu}>
             <Text style={styles.bottomTabsItemContent}>Menu</Text>
           </TouchableHighlight>
 
           <TouchableHighlight
             underlayColor="#ddd"
             style={styles.bottomTabsItem}
-            onPress={() => {
-              DevMenu.openSettings?.();
-            }}>
+            onPress={this.openSettings}>
             <Text style={styles.bottomTabsItemContent}>Settings</Text>
           </TouchableHighlight>
         </View>

--- a/packages/expo-dev-launcher/bundle/components/BottomTabs.tsx
+++ b/packages/expo-dev-launcher/bundle/components/BottomTabs.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { Text, View, StyleSheet, TouchableHighlight } from 'react-native';
+
+import { DevMenu } from '../DevMenu';
+
+type Props = {
+  height: number;
+};
+
+export default class BottomTabs extends React.Component<Props, object> {
+  render() {
+    return (
+      <View style={[styles.bottomTabsAbsoluteContainer, { height: this.props.height }]}>
+        <View style={styles.bottomTabsContainer}>
+          <TouchableHighlight
+            underlayColor="#ddd"
+            style={styles.bottomTabsItem}
+            onPress={() => {
+              DevMenu.openProfile?.();
+            }}>
+            <Text style={styles.bottomTabsItemContent}>Profile</Text>
+          </TouchableHighlight>
+
+          <TouchableHighlight
+            underlayColor="#ddd"
+            style={styles.bottomTabsItem}
+            onPress={() => {
+              DevMenu.openMenu?.();
+            }}>
+            <Text style={styles.bottomTabsItemContent}>Menu</Text>
+          </TouchableHighlight>
+
+          <TouchableHighlight
+            underlayColor="#ddd"
+            style={styles.bottomTabsItem}
+            onPress={() => {
+              DevMenu.openSettings?.();
+            }}>
+            <Text style={styles.bottomTabsItemContent}>Settings</Text>
+          </TouchableHighlight>
+        </View>
+      </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  bottomTabsAbsoluteContainer: {
+    position: 'absolute',
+    width: '100%',
+    bottom: 0,
+  },
+  bottomTabsContainer: {
+    width: '100%',
+    height: '100%',
+    flex: 1,
+    flexDirection: 'row',
+  },
+  bottomTabsItem: {
+    flexGrow: 1,
+    borderColor: 'rgba(0, 0, 0, 0.2)',
+    borderTopWidth: 0.8,
+    borderWidth: 0.3,
+    justifyContent: 'center',
+  },
+  bottomTabsItemContent: {
+    alignSelf: 'center',
+    color: '#000',
+    fontSize: 12,
+  },
+});

--- a/packages/expo-dev-launcher/bundle/components/Button.tsx
+++ b/packages/expo-dev-launcher/bundle/components/Button.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Text, TouchableOpacity, StyleSheet } from 'react-native';
+
+export default ({ label, onPress }) => (
+  <TouchableOpacity style={styles.buttonContainer} onPress={onPress}>
+    <Text style={styles.buttonText}>{label}</Text>
+  </TouchableOpacity>
+);
+
+const styles = StyleSheet.create({
+  buttonContainer: {
+    backgroundColor: '#4630eb',
+    borderRadius: 4,
+    padding: 12,
+    marginVertical: 10,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  buttonText: {
+    color: '#fff',
+    fontSize: 16,
+  },
+});

--- a/packages/expo-dev-launcher/bundle/components/ListItem.tsx
+++ b/packages/expo-dev-launcher/bundle/components/ListItem.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { PixelRatio, StyleSheet, TouchableOpacity, View, Text } from 'react-native';
+import { StyleSheet, TouchableOpacity, View, Text } from 'react-native';
 
 type Props = {
   title?: string;

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -17,6 +17,8 @@
 
 #import <EXDevLauncher-Swift.h>
 
+@import EXDevMenuInterface;
+
 // Uncomment the below and set it to a React Native bundler URL to develop the launcher JS
 //#define DEV_LAUNCHER_URL "http://10.0.0.176:8090/index.bundle?platform=ios&dev=true&minify=false"
 
@@ -121,7 +123,13 @@ NSString *fakeLauncherBundleUrl = @"embedded://EXDevLauncher/dummy";
   }
   
   _launcherBridge = [[EXDevLauncherRCTBridge alloc] initWithDelegate:self launchOptions:_launchOptions];
-
+  
+  id<DevMenuManagerProviderProtocol> devMenuManagerProvider = [_launcherBridge modulesConformingToProtocol:@protocol(DevMenuManagerProviderProtocol)].firstObject;
+  
+  if (devMenuManagerProvider) {
+    id<DevMenuManagerProtocol> devMenuManager = [devMenuManagerProvider getDevMenuManager];
+    devMenuManager.delegate = [[EXDevLauncherMenuDelegate alloc] initWithBridge:_launcherBridge];
+  }
   RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:_launcherBridge
                                                    moduleName:@"main"
                                             initialProperties:@{

--- a/packages/expo-dev-launcher/ios/EXDevLauncherMenuDelegate.swift
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherMenuDelegate.swift
@@ -1,0 +1,15 @@
+import EXDevMenuInterface
+
+@objc
+public class EXDevLauncherMenuDelegate : NSObject, DevMenuDelegateProtocol {
+  private let bridge: RCTBridge
+  
+  @objc
+  public init(withBridge bridge: RCTBridge) {
+    self.bridge = bridge
+  }
+  
+  public func appBridge(forDevMenuManager manager: DevMenuManagerProtocol) -> AnyObject? {
+    return self.bridge;
+  }
+}

--- a/packages/expo-dev-menu-interface/android/src/main/java/expo/interfaces/devmenu/DevMenuManagerInterface.kt
+++ b/packages/expo-dev-menu-interface/android/src/main/java/expo/interfaces/devmenu/DevMenuManagerInterface.kt
@@ -10,7 +10,7 @@ interface DevMenuManagerInterface {
   /**
    * Opens the dev menu in provided [activity]
    */
-  fun openMenu(activity: Activity)
+  fun openMenu(activity: Activity, screen: String? = null)
 
   /**
    * Closes the dev menu.

--- a/packages/expo-dev-menu-interface/android/src/main/java/expo/interfaces/devmenu/DevMenuSessionInterface.kt
+++ b/packages/expo-dev-menu-interface/android/src/main/java/expo/interfaces/devmenu/DevMenuSessionInterface.kt
@@ -10,4 +10,5 @@ import com.facebook.react.ReactInstanceManager
 interface DevMenuSessionInterface {
   val reactInstanceManager: ReactInstanceManager
   val appInfo: Bundle
+  val openScreen: String?
 }

--- a/packages/expo-dev-menu-interface/ios/DevMenuManagerProtocol.swift
+++ b/packages/expo-dev-menu-interface/ios/DevMenuManagerProtocol.swift
@@ -8,9 +8,16 @@ public protocol DevMenuManagerProtocol {
   @objc
   var isVisible: Bool { get }
   
+  @objc
+  var delegate: DevMenuDelegateProtocol? { get set }
+  
   /**
    Opens up the dev menu.
    */
+  @objc
+  @discardableResult
+  func openMenu(_ screen: String?) -> Bool
+  
   @objc
   @discardableResult
   func openMenu() -> Bool

--- a/packages/expo-dev-menu-interface/ios/DevMenuManagerProviderProtocol.swift
+++ b/packages/expo-dev-menu-interface/ios/DevMenuManagerProviderProtocol.swift
@@ -1,0 +1,9 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+@objc
+public protocol DevMenuManagerProviderProtocol {
+  
+  @objc
+  func getDevMenuManager() -> DevMenuManagerProtocol
+
+}

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuManager.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuManager.kt
@@ -237,9 +237,14 @@ object DevMenuManager : DevMenuManagerInterface, LifecycleEventListener {
 
   //region DevMenuManagerProtocol
 
-  override fun openMenu(activity: Activity) {
+  override fun openMenu(activity: Activity, screen: String?) {
     setCurrentScreen(null)
-    session = DevMenuSession(delegate!!.reactInstanceManager(), delegate!!.appInfo())
+    session = DevMenuSession(
+      initReactInstanceManager = delegate!!.reactInstanceManager(),
+      initAppInfo = delegate!!.appInfo(),
+      screen = screen
+    )
+
     activity.startActivity(Intent(activity, DevMenuActivity::class.java))
   }
 

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/react/DevMenuAwareReactActivity.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/react/DevMenuAwareReactActivity.kt
@@ -1,7 +1,6 @@
 package expo.modules.devmenu.react
 
 import android.os.Bundle
-import android.os.PersistableBundle
 import android.view.KeyEvent
 import android.view.MotionEvent
 import com.facebook.react.ReactActivity

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/DevMenuActivity.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/DevMenuActivity.kt
@@ -27,6 +27,7 @@ class DevMenuActivity : ReactActivity() {
         putParcelableArray("devMenuScreens", DevMenuManager.serializedScreens().toTypedArray())
         putString("uuid", UUID.randomUUID().toString())
         putBundle("appInfo", DevMenuManager.getSession()?.appInfo ?: Bundle.EMPTY)
+        putString("openScreen", DevMenuManager.getSession()?.openScreen)
       }
 
       override fun createRootView() = getVendoredClass<ReactRootView>("com.swmansion.gesturehandler.react.RNGestureHandlerEnabledRootView", arrayOf(Context::class.java), arrayOf(this@DevMenuActivity))

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/DevMenuSession.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/DevMenuSession.kt
@@ -14,10 +14,12 @@ import expo.interfaces.devmenu.DevMenuSessionInterface
  */
 class DevMenuSession(
   initReactInstanceManager: ReactInstanceManager,
-  initAppInfo: Bundle?
+  initAppInfo: Bundle?,
+  screen: String?
 ) : DevMenuSessionInterface {
   override val reactInstanceManager = initReactInstanceManager
   override val appInfo = initAppInfo ?: guessAppInfo()
+  override val openScreen = screen
 
   /**
    * Constructs app info `Bundle` based on the native app metadata such as `ApplicationContext`.

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/modules/DevMenuModule.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/modules/DevMenuModule.kt
@@ -14,12 +14,26 @@ class DevMenuModule(reactContext: ReactApplicationContext)
       .getDevMenuManager()
   }
 
-  @ReactMethod
-  fun openMenu() {
+  private fun openMenuOn(screen: String?) {
     reactApplicationContext
       .currentActivity
       ?.run {
-        devMenuManager.openMenu(this)
+        devMenuManager.openMenu(this, screen)
       }
+  }
+
+  @ReactMethod
+  fun openMenu() {
+    openMenuOn(null)
+  }
+
+  @ReactMethod
+  fun openProfile() {
+    openMenuOn("Profile")
+  }
+
+  @ReactMethod
+  fun openSettings() {
+    openMenuOn("Settings")
   }
 }

--- a/packages/expo-dev-menu/app/components/profile/Profile.tsx
+++ b/packages/expo-dev-menu/app/components/profile/Profile.tsx
@@ -55,7 +55,7 @@ export default function Profile() {
 
   if (!loading && (error || !data.user)) {
     context.setSession(null);
-    return;
+    return <Loading />;
   }
 
   if (loading) {

--- a/packages/expo-dev-menu/app/views/DevMenuApp.tsx
+++ b/packages/expo-dev-menu/app/views/DevMenuApp.tsx
@@ -64,7 +64,7 @@ function DevMenuApp(props) {
 
           routeNameRef.current = currentRouteName;
         }}>
-        <DevMenuContainer {...props} />
+        <DevMenuContainer {...props} navigation={navigationRef.current} />
       </NavigationContainer>
     </View>
   );

--- a/packages/expo-dev-menu/app/views/DevMenuBottomSheet.tsx
+++ b/packages/expo-dev-menu/app/views/DevMenuBottomSheet.tsx
@@ -71,6 +71,10 @@ type Props = {
    * Refs for gesture handlers used for building bottomsheet
    */
   innerGestureHandlerRefs: [React.RefObject<PanGestureHandler>, React.RefObject<TapGestureHandler>];
+
+  openScreen?: string;
+
+  animationEnabled?: boolean;
 };
 
 type State = {
@@ -704,9 +708,10 @@ export default class BottomSheetBehavior extends React.Component<Props, State> {
                 <TapGestureHandler ref={this.tapRef} onHandlerStateChange={this.handleTap}>
                   <View style={styles.fullscreenView}>
                     <Stack.Navigator
-                      initialRouteName={this.props.screens[0].name}
+                      initialRouteName={this.props.openScreen ?? this.props.screens[0].name}
                       headerMode="screen"
                       screenOptions={{
+                        animationEnabled: this.props?.animationEnabled,
                         ...TransitionPresets.SlideFromRightIOS,
                       }}>
                       {this.props.screens.map(this.renderScreen)}

--- a/packages/expo-dev-menu/ios/DevMenuManager.swift
+++ b/packages/expo-dev-menu/ios/DevMenuManager.swift
@@ -133,8 +133,14 @@ open class DevMenuManager: NSObject, DevMenuManagerProtocol {
    */
   @objc
   @discardableResult
+  public func openMenu(_ screen: String? = nil) -> Bool {
+    return setVisibility(true, screen: screen)
+  }
+  
+  @objc
+  @discardableResult
   public func openMenu() -> Bool {
-    return setVisibility(true)
+    return openMenu(nil)
   }
 
   /**
@@ -308,7 +314,7 @@ open class DevMenuManager: NSObject, DevMenuManagerProtocol {
     return nil;
   }
 
-  private func setVisibility(_ visible: Bool) -> Bool {
+  private func setVisibility(_ visible: Bool, screen: String? = nil) -> Bool {
     if !canChangeVisibility(to: visible) {
       return false
     }
@@ -317,7 +323,7 @@ open class DevMenuManager: NSObject, DevMenuManagerProtocol {
         debugPrint("DevMenuManager: The delegate is unset or it didn't provide a bridge to render for.")
         return false
       }
-      session = DevMenuSession(bridge: bridge, appInfo: delegate?.appInfo?(forDevMenuManager: self))
+      session = DevMenuSession(bridge: bridge, appInfo: delegate?.appInfo?(forDevMenuManager: self), screen: screen)
       DispatchQueue.main.async { self.window?.makeKeyAndVisible() }
     } else {
       session = nil

--- a/packages/expo-dev-menu/ios/DevMenuSession.swift
+++ b/packages/expo-dev-menu/ios/DevMenuSession.swift
@@ -7,16 +7,19 @@ public class DevMenuSession {
   /**
    The bridge that the dev menu is currently rendered for.
    */
-  public private(set) var bridge: RCTBridge
+  public let bridge: RCTBridge
 
   /**
    A dictionary of app info corresponding to the `bridge` or guessed based on app's metadata.
    */
-  public private(set) var appInfo: [String : Any]
+  public let appInfo: [String : Any]
+  
+  public let openScreen: String?
 
-  init(bridge: RCTBridge, appInfo: [String : Any]?) {
+  init(bridge: RCTBridge, appInfo: [String : Any]?, screen: String? = nil) {
     self.bridge = bridge
     self.appInfo = appInfo ?? guessAppInfo(forBridge: bridge)
+    self.openScreen = screen
   }
 }
 

--- a/packages/expo-dev-menu/ios/DevMenuViewController.swift
+++ b/packages/expo-dev-menu/ios/DevMenuViewController.swift
@@ -79,7 +79,8 @@ class DevMenuViewController: UIViewController {
       "devMenuItems": manager.serializedDevMenuItems(),
       "devMenuScreens": manager.serializedDevMenuScreens(),
       "appInfo": manager.session?.appInfo ?? [:],
-      "uuid": UUID.init().uuidString
+      "uuid": UUID.init().uuidString,
+      "openScreen": manager.session?.openScreen
     ]
   }
 

--- a/packages/expo-dev-menu/ios/Modules/DeMenuManagerProvider.swift
+++ b/packages/expo-dev-menu/ios/Modules/DeMenuManagerProvider.swift
@@ -1,0 +1,21 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import EXDevMenuInterface
+
+@objc(DevMenuManagerProvider)
+class DevMenuManagerProvider : NSObject, RCTBridgeModule, DevMenuManagerProviderProtocol {
+  @objc
+  static func moduleName() -> String! {
+    return "ExpoDevMenuManagerProvider"
+  }
+  
+  @objc
+  public static func requiresMainQueueSetup() -> Bool {
+    return true
+  }
+  
+  @objc
+  open func getDevMenuManager() -> DevMenuManagerProtocol {
+    return DevMenuManager.shared
+  }
+}

--- a/packages/expo-dev-menu/ios/Modules/DevMenuManagerProvider.m
+++ b/packages/expo-dev-menu/ios/Modules/DevMenuManagerProvider.m
@@ -1,0 +1,7 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+#import <React/RCTBridgeModule.h>
+
+@interface RCT_EXTERN_REMAP_MODULE(ExpoDevMenuManagerProvider, DevMenuManagerProvider, NSObject)
+
+@end

--- a/packages/expo-dev-menu/ios/Modules/DevMenuModule.m
+++ b/packages/expo-dev-menu/ios/Modules/DevMenuModule.m
@@ -5,5 +5,7 @@
 @interface RCT_EXTERN_REMAP_MODULE(ExpoDevMenu, DevMenuModule, NSObject)
 
 RCT_EXTERN_METHOD(openMenu)
+RCT_EXTERN_METHOD(openProfile)
+RCT_EXTERN_METHOD(openSettings)
 
 @end

--- a/packages/expo-dev-menu/ios/Modules/DevMenuModule.swift
+++ b/packages/expo-dev-menu/ios/Modules/DevMenuModule.swift
@@ -16,4 +16,14 @@ open class DevMenuModule: NSObject, RCTBridgeModule {
   func openMenu() {
     DevMenuManager.shared.openMenu()
   }
+
+  @objc
+  func openSettings() {
+    DevMenuManager.shared.openMenu("Settings")
+  }
+  
+  @objc
+  func openProfile() {
+    DevMenuManager.shared.openMenu("Profile")
+  }
 }

--- a/packages/expo-dev-menu/package.json
+++ b/packages/expo-dev-menu/package.json
@@ -47,9 +47,9 @@
     "react-native": ">=0.62.0"
   },
   "devDependencies": {
-    "@react-navigation/core": "5.10.0",
-    "@react-navigation/native": "5.5.1",
-    "@react-navigation/stack": "5.4.1",
+    "@react-navigation/core": "5.15.1",
+    "@react-navigation/native": "5.9.2",
+    "@react-navigation/stack": "5.14.2",
     "babel-plugin-module-resolver": "^4.0.0",
     "expo-module-scripts": "~1.2.0",
     "react": "16.13.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3790,17 +3790,16 @@
     color "^3.1.3"
     react-native-iphone-x-helper "^1.3.0"
 
-"@react-navigation/core@5.10.0":
-  version "5.10.0"
-  resolved "https://registry.yarnpkg.com/@react-navigation/core/-/core-5.10.0.tgz#aee9e22a5f0f458ebeadc155f347b13eb5ff5212"
-  integrity sha512-cVQTj5FtZHWuymjZMP50RVXYpkQUbo1zQPjxJl+UfBUh7u9nKexknajBhjYbZq61uDE4MmPE8qAqIEJHKeR4Hg==
+"@react-navigation/core@5.15.1", "@react-navigation/core@^5.15.1":
+  version "5.15.1"
+  resolved "https://registry.yarnpkg.com/@react-navigation/core/-/core-5.15.1.tgz#dab5192277c606d9acbea511dac407c2834b5fbe"
+  integrity sha512-GDCpIVQd0NgHYCSdUMY69hrpeWKuYgj5SIRqHI2sYh9OguwGcV52ZZOafc+pQuyfuiLLIMidw34jiqb47QrlhA==
   dependencies:
-    "@react-navigation/routers" "^5.4.7"
+    "@react-navigation/routers" "^5.7.1"
     escape-string-regexp "^4.0.0"
-    nanoid "^3.1.5"
-    query-string "^6.12.1"
+    nanoid "^3.1.15"
+    query-string "^6.13.6"
     react-is "^16.13.0"
-    use-subscription "^1.4.0"
 
 "@react-navigation/core@^3.7.9":
   version "3.7.9"
@@ -3809,17 +3808,6 @@
   dependencies:
     hoist-non-react-statics "^3.3.2"
     path-to-regexp "^1.8.0"
-    query-string "^6.13.6"
-    react-is "^16.13.0"
-
-"@react-navigation/core@^5.10.0":
-  version "5.14.4"
-  resolved "https://registry.yarnpkg.com/@react-navigation/core/-/core-5.14.4.tgz#f63a2cd214bddbd25e1181f9335c32dfc3b6460f"
-  integrity sha512-MzZU9PO1a/6f9KdN04dC/E4BNl6M1Ba0Tb4sQdl/32y0hM2ToxlrKcERnTLWGFIbQV+9ZV1GTrp3mlGS6U9Jpw==
-  dependencies:
-    "@react-navigation/routers" "^5.6.2"
-    escape-string-regexp "^4.0.0"
-    nanoid "^3.1.15"
     query-string "^6.13.6"
     react-is "^16.13.0"
 
@@ -3847,13 +3835,14 @@
   resolved "https://registry.yarnpkg.com/@react-navigation/material-bottom-tabs/-/material-bottom-tabs-5.3.9.tgz#d6375b027f7ef74f00fcd8d866ac1c83dabdbcb2"
   integrity sha512-LZmFJ2EFF84ZAAvQ+rZ/w9khXTFPgIqk32ALfTillXY55+JViWBVNym1DP9vvb7ZCb03fyjFPsNLWBbK0ygmiA==
 
-"@react-navigation/native@5.5.1":
-  version "5.5.1"
-  resolved "https://registry.yarnpkg.com/@react-navigation/native/-/native-5.5.1.tgz#e669d9561e54d86b1315637b8d5630dc55ee9383"
-  integrity sha512-5pzsfvLdnvqfrWgTMCLDFaGK6Sj30p7tAMhUGneV2oGlx0OIbhgc6/04UUMpKEmAS2PaC/GZa1LQIsSVWDewvw==
+"@react-navigation/native@5.9.2":
+  version "5.9.2"
+  resolved "https://registry.yarnpkg.com/@react-navigation/native/-/native-5.9.2.tgz#2075774c3627d58a324e1b5dfc5f4f356a1ab7e9"
+  integrity sha512-O8K+Lr6Vy25gTTyXAns9BVyFvwTkKqfFH0RpOimilYndUL6tlhV56oDSp7Hryjy8xsjx6ESWqr6eIu4sS3Z9nQ==
   dependencies:
-    "@react-navigation/core" "^5.10.0"
-    nanoid "^3.1.9"
+    "@react-navigation/core" "^5.15.1"
+    escape-string-regexp "^4.0.0"
+    nanoid "^3.1.15"
 
 "@react-navigation/native@^3.8.3":
   version "3.8.3"
@@ -3872,20 +3861,27 @@
     escape-string-regexp "^4.0.0"
     nanoid "^3.1.15"
 
-"@react-navigation/routers@^5.4.7", "@react-navigation/routers@^5.6.2":
+"@react-navigation/routers@^5.6.2":
   version "5.6.2"
   resolved "https://registry.yarnpkg.com/@react-navigation/routers/-/routers-5.6.2.tgz#accc008c3b777f74d998e16cb2ea8e4c1fe8d9aa"
   integrity sha512-XBcDKXS5s4MaHFufN44LtbXqFDH/nUHfHjbwG85fP3k772oRyPRgbnUb2mbw5MFGqORla9T7uymR6Gh6uwIwVw==
   dependencies:
     nanoid "^3.1.15"
 
-"@react-navigation/stack@5.4.1":
-  version "5.4.1"
-  resolved "https://registry.yarnpkg.com/@react-navigation/stack/-/stack-5.4.1.tgz#3b4ebec52649dca77571050bb00db9ea02df61a8"
-  integrity sha512-Pi1OH1kofbYIpUJ6q+8NZ+wprrGcBmTLAE/DfgmzrC+6I+EObYq55N2ByikqVSgKaRS+TsDrQe/RNkumsOjqVA==
+"@react-navigation/routers@^5.7.1":
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/@react-navigation/routers/-/routers-5.7.1.tgz#ba56cabdaabc521ef29c26529e868590949429b1"
+  integrity sha512-M5R4AFgJZ0uBUV+DjMyNy2HXRfvo0ldM+59Gj1NQWXaYnst3m0xJTfWiln94mnrbrHEq087gMP4ZLHGIJ8D1Ig==
   dependencies:
-    color "^3.1.2"
-    react-native-iphone-x-helper "^1.2.1"
+    nanoid "^3.1.15"
+
+"@react-navigation/stack@5.14.2":
+  version "5.14.2"
+  resolved "https://registry.yarnpkg.com/@react-navigation/stack/-/stack-5.14.2.tgz#6e48efa74a9b0fc29ff0a90fcbee161039b84d78"
+  integrity sha512-tt1eFn6HClyXVZiVQsPs3Q2MgoqmJdkQsyT9P4TBLxGsdib6r/oc++eVNc+G/6ws/kCquDdHq3fz1PNSCtyrJA==
+  dependencies:
+    color "^3.1.3"
+    react-native-iphone-x-helper "^1.3.0"
 
 "@react-navigation/stack@~5.12.6":
   version "5.12.6"
@@ -14268,11 +14264,6 @@ nanoid@^3.1.15:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.16.tgz#b21f0a7d031196faf75314d7c65d36352beeef64"
   integrity sha512-+AK8MN0WHji40lj8AEuwLOvLSbWYApQpre/aFJZD71r43wVRLrOYS4FmJOPQYon1TqB462RzrrxlfA74XRES8w==
 
-nanoid@^3.1.5, nanoid@^3.1.9:
-  version "3.1.20"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.20.tgz#badc263c6b1dcf14b71efaa85f6ab4c1d6cfc788"
-  integrity sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw==
-
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -16328,7 +16319,7 @@ query-string@^5.0.1:
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
 
-query-string@^6.12.1, query-string@^6.13.6:
+query-string@^6.13.6:
   version "6.13.7"
   resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.13.7.tgz#af53802ff6ed56f3345f92d40a056f93681026ee"
   integrity sha512-CsGs8ZYb39zu0WLkeOhe0NMePqgYdAuCqxOYKDR5LVCytDZYMGx3Bb+xypvQvPHVPijRXB0HZNFllCzHRe4gEA==
@@ -16582,11 +16573,6 @@ react-native-infinite-scroll-view@^0.4.5:
     prop-types "^15.6.2"
     react-clone-referenced-element "^1.0.1"
     react-native-scrollable-mixin "^1.0.0"
-
-react-native-iphone-x-helper@^1.2.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.3.1.tgz#20c603e9a0e765fd6f97396638bdeb0e5a60b010"
-  integrity sha512-HOf0jzRnq2/aFUcdCJ9w9JGzN3gdEg0zFE4FyYlp4jtidqU03D5X7ZegGKfT1EWteR0gPBGp9ye5T5FvSWi9Yg==
 
 react-native-iphone-x-helper@^1.3.0:
   version "1.3.0"
@@ -19372,13 +19358,6 @@ use-subscription@^1.0.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/use-subscription/-/use-subscription-1.4.1.tgz#edcbcc220f1adb2dd4fa0b2f61b6cc308e620069"
   integrity sha512-7+IIwDG/4JICrWHL/Q/ZPK5yozEnvRm6vHImu0LKwQlmWGKeiF7mbAenLlK/cTNXrTtXHU/SFASQHzB6+oSJMQ==
-  dependencies:
-    object-assign "^4.1.1"
-
-use-subscription@^1.4.0:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/use-subscription/-/use-subscription-1.5.1.tgz#73501107f02fad84c6dd57965beb0b75c68c42d1"
-  integrity sha512-Xv2a1P/yReAjAbhylMfFplFKj9GssgTwN7RlcTxBujFQcloStWNDQdc4g4NRWH9xS4i/FDk04vQBptAXoF3VcA==
   dependencies:
     object-assign "^4.1.1"
 


### PR DESCRIPTION
# Why

Continuation of https://github.com/expo/expo/pull/11915.

# How

- Detected if the dev-menu pacackage is available
- Added a way to open dev-menu on a `Profile` or `Settings` screen
- Added a UI that opens dev-menu when user interacts with dev-launcher

# Test Plan

- bare-expo