### PR TITLE
[tools] Use new vendoring by default and fall back to legacy if needed

### DIFF
--- a/tools/src/vendoring/config/expoGoConfig.ts
+++ b/tools/src/vendoring/config/expoGoConfig.ts
@@ -13,10 +13,69 @@ const config: VendoringTargetConfig = {
   modules: {
     'lottie-react-native': {
       source: 'https://github.com/react-native-community/lottie-react-native.git',
-      android: {
-        includeFiles: 'src/android/**',
-        excludeFiles: ['src/android/gradle.properties', 'src/android/gradle-maven-push.gradle'],
-      },
+      ios: {},
+      // android: {
+      //   includeFiles: 'src/android/**',
+      //   excludeFiles: ['src/android/gradle.properties', 'src/android/gradle-maven-push.gradle'],
+      // },
+    },
+    'react-native-gesture-handler': {
+      source: 'https://github.com/software-mansion/react-native-gesture-handler.git',
+      semverPrefix: '~',
+    },
+    'react-native-reanimated': {
+      source: 'https://github.com/software-mansion/react-native-reanimated.git',
+      semverPrefix: '~',
+    },
+    'react-native-screens': {
+      source: 'https://github.com/software-mansion/react-native-screens.git',
+      semverPrefix: '~',
+    },
+    'react-native-appearance': {
+      source: 'https://github.com/expo/react-native-appearance.git',
+      semverPrefix: '~',
+    },
+    'amazon-cognito-identity-js': {
+      source: 'https://github.com/aws-amplify/amplify-js.git',
+    },
+    'react-native-view-shot': {
+      source: 'https://github.com/gre/react-native-view-shot.git',
+    },
+    'react-native-svg': {
+      source: 'https://github.com/react-native-community/react-native-svg.git',
+    },
+    'react-native-maps': {
+      source: 'https://github.com/react-native-community/react-native-maps.git',
+    },
+    '@react-native-community/netinfo': {
+      source: 'https://github.com/react-native-community/react-native-netinfo.git',
+    },
+    'react-native-webview': {
+      source: 'https://github.com/react-native-community/react-native-webview.git',
+    },
+    'react-native-safe-area-context': {
+      source: 'https://github.com/th3rdwave/react-native-safe-area-context',
+    },
+    '@react-native-community/datetimepicker': {
+      source: 'https://github.com/react-native-community/react-native-datetimepicker.git',
+    },
+    '@react-native-community/masked-view': {
+      source: 'https://github.com/react-native-community/react-native-masked-view',
+    },
+    '@react-native-community/viewpager': {
+      source: 'https://github.com/react-native-community/react-native-viewpager',
+    },
+    'react-native-shared-element': {
+      source: 'https://github.com/IjzerenHein/react-native-shared-element',
+    },
+    '@react-native-community/segmented-control': {
+      source: 'https://github.com/react-native-community/segmented-control',
+    },
+    '@react-native-picker/picker': {
+      source: 'https://github.com/react-native-picker/picker',
+    },
+    '@react-native-community/slider': {
+      source: 'https://github.com/react-native-community/react-native-slider',
     },
   },
 };


### PR DESCRIPTION
# Why

Before upgrading lottie to v3, I created a new mechanisms for vendoring 3rd party libraries. To support vendoring and versioning modules using Swift, they have to be installed as separate Swift modules (CocoaPods takes care of creating them).
Now, they could be a separate pods inside `ios/vendored/unversioned`. So far only `lottie-react-native` was using this new mechanisms and only on iOS. I'd like to start migrating the others soon.

# How

To make things easier, I merged two expotools commands into one, which falls back to legacy mode if the library wasn't migrated yet.

# Test Plan

I tested vendoring a few libraries and the results were as expected.
