### PR TITLE
[android] Upgrade Lottie to v3

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -124,7 +124,7 @@ dependencies {
   implementation 'com.segment.analytics.android:analytics:4.3.0'
   implementation 'com.google.zxing:core:3.3.3'
   implementation 'net.openid:appauth:0.4.1'
-  implementation 'com.airbnb.android:lottie:2.5.6'
+  implementation 'com.airbnb.android:lottie:3.4.0'
   implementation('io.nlopez.smartlocation:library:3.2.11') {
     transitive = false
   }

--- a/android/expoview/build.gradle
+++ b/android/expoview/build.gradle
@@ -263,7 +263,7 @@ dependencies {
   api 'com.theartofdev.edmodo:android-image-cropper:2.7.0'
   api 'commons-codec:commons-codec:1.10'
   api 'net.openid:appauth:0.7.1'
-  api 'com.airbnb.android:lottie:2.5.6'
+  api 'com.airbnb.android:lottie:3.4.0'
   compileOnly 'io.branch.sdk.android:library:4.1.0'
   api "androidx.exifinterface:exifinterface:1.0.0"
   api "androidx.legacy:legacy-support-v4:1.0.0"

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/lottie/LottieAnimationViewManager.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/lottie/LottieAnimationViewManager.java
@@ -11,6 +11,7 @@ import android.view.View.OnAttachStateChangeListener;
 import android.view.View;
 
 import com.airbnb.lottie.LottieAnimationView;
+import com.airbnb.lottie.RenderMode;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReadableArray;
@@ -31,6 +32,8 @@ class LottieAnimationViewManager extends SimpleViewManager<LottieAnimationView> 
   private static final int VERSION = 1;
   private static final int COMMAND_PLAY = 1;
   private static final int COMMAND_RESET = 2;
+  private static final int COMMAND_PAUSE = 3;
+  private static final int COMMAND_RESUME = 4;
 
   private Map<LottieAnimationView, LottieAnimationViewPropertyManager> propManagersMap = new WeakHashMap<>();
 
@@ -100,7 +103,9 @@ class LottieAnimationViewManager extends SimpleViewManager<LottieAnimationView> 
   @Override public Map<String, Integer> getCommandsMap() {
     return MapBuilder.of(
         "play", COMMAND_PLAY,
-        "reset", COMMAND_RESET
+        "reset", COMMAND_RESET,
+        "pause", COMMAND_PAUSE,
+        "resume", COMMAND_RESUME
     );
   }
 
@@ -113,7 +118,12 @@ class LottieAnimationViewManager extends SimpleViewManager<LottieAnimationView> 
             int startFrame = args.getInt(0);
             int endFrame = args.getInt(1);
             if (startFrame != -1 && endFrame != -1) {
-              view.setMinAndMaxFrame(args.getInt(0), args.getInt(1));
+               if(startFrame > endFrame){
+                view.setMinAndMaxFrame(endFrame, startFrame);
+                view.reverseAnimationSpeed();
+              } else {
+                view.setMinAndMaxFrame(startFrame, endFrame);
+              }
             }
             if (ViewCompat.isAttachedToWindow(view)) {
               view.setProgress(0f);
@@ -149,41 +159,47 @@ class LottieAnimationViewManager extends SimpleViewManager<LottieAnimationView> 
         });
       }
       break;
+      case COMMAND_PAUSE: {
+        new Handler(Looper.getMainLooper()).post(new Runnable() {
+            @Override
+            public void run() {
+            if (ViewCompat.isAttachedToWindow(view)) {
+                view.pauseAnimation();
+            }
+            }
+        });
+      }
+      break;
+      case COMMAND_RESUME: {
+        new Handler(Looper.getMainLooper()).post(new Runnable() {
+          @Override
+          public void run() {
+            if (ViewCompat.isAttachedToWindow(view)) {
+              view.resumeAnimation();
+            }
+          }
+        });
+      }
+      break;
     }
   }
 
   @ReactProp(name = "sourceName")
   public void setSourceName(LottieAnimationView view, String name) {
+    // To match the behaviour on iOS we expect the source name to be
+    // extensionless. This means "myAnimation" corresponds to a file
+    // named `myAnimation.json` in `main/assets`. To maintain backwards
+    // compatibility we only add the .json extension if no extension is
+    // passed.
+    if (!name.contains(".")) {
+      name = name + ".json";
+    }
     getOrCreatePropertyManager(view).setAnimationName(name);
   }
 
   @ReactProp(name = "sourceJson")
   public void setSourceJson(LottieAnimationView view, String json) {
     getOrCreatePropertyManager(view).setAnimationJson(json);
-  }
-
-  /**
-   *
-   * @param view
-   * @param name
-   */
-  @ReactProp(name = "cacheStrategy")
-  public void setCacheStrategy(LottieAnimationView view, String name) {
-    if (name != null) {
-      LottieAnimationView.CacheStrategy strategy = LottieAnimationView.DEFAULT_CACHE_STRATEGY;
-      switch (name) {
-        case "none":
-          strategy = LottieAnimationView.CacheStrategy.None;
-          break;
-        case "weak":
-           strategy = LottieAnimationView.CacheStrategy.Weak;
-           break;
-        case "strong":
-          strategy = LottieAnimationView.CacheStrategy.Strong;
-          break;
-      }
-      getOrCreatePropertyManager(view).setCacheStrategy(strategy);
-    }
   }
 
   @ReactProp(name = "resizeMode")
@@ -197,6 +213,19 @@ class LottieAnimationViewManager extends SimpleViewManager<LottieAnimationView> 
       mode = ImageView.ScaleType.CENTER;
     }
     getOrCreatePropertyManager(view).setScaleType(mode);
+  }
+
+  @ReactProp(name = "renderMode")
+  public void setRenderMode(LottieAnimationView view, String renderMode) {
+    RenderMode mode = null;
+    if ("AUTOMATIC".equals(renderMode) ){
+      mode = RenderMode.AUTOMATIC;
+    }else if ("HARDWARE".equals(renderMode)){
+      mode = RenderMode.HARDWARE;
+    }else if ("SOFTWARE".equals(renderMode)){
+      mode = RenderMode.SOFTWARE;
+    }
+    getOrCreatePropertyManager(view).setRenderMode(mode);
   }
 
   @ReactProp(name = "progress")
@@ -214,11 +243,6 @@ class LottieAnimationViewManager extends SimpleViewManager<LottieAnimationView> 
     getOrCreatePropertyManager(view).setLoop(loop);
   }
 
-  @ReactProp(name = "hardwareAccelerationAndroid")
-  public void setHardwareAcceleration(LottieAnimationView view, boolean use) {
-    getOrCreatePropertyManager(view).setUseHardwareAcceleration(use);
-  }
-
   @ReactProp(name = "imageAssetsFolder")
   public void setImageAssetsFolder(LottieAnimationView view, String imageAssetsFolder) {
     getOrCreatePropertyManager(view).setImageAssetsFolder(imageAssetsFolder);
@@ -227,6 +251,11 @@ class LottieAnimationViewManager extends SimpleViewManager<LottieAnimationView> 
   @ReactProp(name = "enableMergePathsAndroidForKitKatAndAbove")
   public void setEnableMergePaths(LottieAnimationView view, boolean enableMergePaths) {
     getOrCreatePropertyManager(view).setEnableMergePaths(enableMergePaths);
+  }
+
+  @ReactProp(name = "colorFilters")
+  public void setColorFilters(LottieAnimationView view, ReadableArray colorFilters) {
+    getOrCreatePropertyManager(view).setColorFilters(colorFilters);
   }
 
   @Override

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/lottie/LottieAnimationViewPropertyManager.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/lottie/LottieAnimationViewPropertyManager.java
@@ -1,14 +1,20 @@
 package versioned.host.exp.exponent.modules.api.components.lottie;
 
-import android.util.JsonReader;
+import android.graphics.Color;
+import android.graphics.ColorFilter;
 import android.widget.ImageView;
 
 import com.airbnb.lottie.LottieAnimationView;
 import com.airbnb.lottie.LottieDrawable;
-
-import java.io.StringReader;
+import com.airbnb.lottie.LottieProperty;
+import com.airbnb.lottie.RenderMode;
+import com.airbnb.lottie.SimpleColorFilter;
+import com.airbnb.lottie.model.KeyPath;
+import com.airbnb.lottie.value.LottieValueCallback;
+import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.bridge.ReadableMap;
 import java.lang.ref.WeakReference;
-
+import java.util.regex.Pattern;
 /**
  * Class responsible for applying the properties to the LottieView.
  * The way react-native works makes it impossible to predict in which order properties will be set,
@@ -33,11 +39,11 @@ public class LottieAnimationViewPropertyManager {
   private boolean animationNameDirty;
 
   private String animationName;
-  private LottieAnimationView.CacheStrategy cacheStrategy;
-  private Boolean useHardwareAcceleration;
   private ImageView.ScaleType scaleType;
   private String imageAssetsFolder;
   private Boolean enableMergePaths;
+  private ReadableArray colorFilters;
+  private RenderMode renderMode;
 
   public LottieAnimationViewPropertyManager(LottieAnimationView view) {
     this.viewWeakReference = new WeakReference<>(view);
@@ -52,11 +58,6 @@ public class LottieAnimationViewPropertyManager {
     this.animationJson = json;
   }
 
-  public void setCacheStrategy(LottieAnimationView.CacheStrategy strategy) {
-    this.cacheStrategy = strategy;
-    this.animationNameDirty = true;
-  }
-
   public void setProgress(Float progress) {
     this.progress = progress;
   }
@@ -69,12 +70,12 @@ public class LottieAnimationViewPropertyManager {
     this.loop = loop;
   }
 
-  public void setUseHardwareAcceleration(boolean useHardwareAcceleration) {
-    this.useHardwareAcceleration = useHardwareAcceleration;
-  }
-
   public void setScaleType(ImageView.ScaleType scaleType) {
     this.scaleType = scaleType;
+  }
+
+  public void setRenderMode(RenderMode renderMode) {
+    this.renderMode = renderMode;
   }
 
   public void setImageAssetsFolder(String imageAssetsFolder) {
@@ -83,6 +84,10 @@ public class LottieAnimationViewPropertyManager {
 
   public void setEnableMergePaths(boolean enableMergePaths) {
     this.enableMergePaths = enableMergePaths;
+  }
+
+  public void setColorFilters(ReadableArray colorFilters) {
+    this.colorFilters = colorFilters;
   }
 
   /**
@@ -101,12 +106,12 @@ public class LottieAnimationViewPropertyManager {
     }
 
     if (animationJson != null) {
-      view.setAnimation(new JsonReader(new StringReader(animationJson)));
+      view.setAnimationFromJson(animationJson, Integer.toString(animationJson.hashCode()));
       animationJson = null;
     }
 
     if (animationNameDirty) {
-      view.setAnimation(animationName, cacheStrategy);
+      view.setAnimation(animationName);
       animationNameDirty = false;
     }
 
@@ -125,14 +130,14 @@ public class LottieAnimationViewPropertyManager {
       speed = null;
     }
 
-    if (useHardwareAcceleration != null) {
-      view.useHardwareAcceleration(useHardwareAcceleration);
-      useHardwareAcceleration = null;
-    }
-
     if (scaleType != null) {
       view.setScaleType(scaleType);
       scaleType = null;
+    }
+
+    if (renderMode != null) {
+      view.setRenderMode(renderMode);
+      renderMode = null;
     }
 
     if (imageAssetsFolder != null) {
@@ -141,8 +146,22 @@ public class LottieAnimationViewPropertyManager {
     }
 
     if (enableMergePaths != null) {
-        view.enableMergePathsForKitKatAndAbove(enableMergePaths);
-        enableMergePaths = null;
+      view.enableMergePathsForKitKatAndAbove(enableMergePaths);
+      enableMergePaths = null;
+    }
+
+    if (colorFilters != null && colorFilters.size() > 0) {
+      for (int i = 0 ; i < colorFilters.size() ; i++) {
+        ReadableMap current = colorFilters.getMap(i);
+        String color = current.getString("color");
+        String path = current.getString("keypath");
+        SimpleColorFilter colorFilter = new SimpleColorFilter(Color.parseColor(color));
+        String pathWithGlobstar = path +".**";
+        String[] keys = pathWithGlobstar.split(Pattern.quote("."));
+        KeyPath keyPath = new  KeyPath(keys);
+        LottieValueCallback<ColorFilter> callback = new LottieValueCallback<>(colorFilter);
+        view.addValueCallback(keyPath, LottieProperty.COLOR_FILTER, callback);
+      }
     }
   }
 }

--- a/android/versioned-abis/expoview-abi38_0_0/build.gradle
+++ b/android/versioned-abis/expoview-abi38_0_0/build.gradle
@@ -106,7 +106,7 @@ dependencies {
   api 'com.theartofdev.edmodo:android-image-cropper:2.7.0'
   api 'commons-codec:commons-codec:1.10'
   api 'net.openid:appauth:0.7.1'
-  api 'com.airbnb.android:lottie:2.5.6'
+  api 'com.airbnb.android:lottie:3.4.0'
   compileOnly 'io.branch.sdk.android:library:4.1.0'
   api "androidx.exifinterface:exifinterface:1.0.0"
   api "androidx.legacy:legacy-support-v4:1.0.0"

--- a/android/versioned-abis/expoview-abi38_0_0/src/main/java/abi38_0_0/host/exp/exponent/modules/api/components/lottie/LottieAnimationViewManager.java
+++ b/android/versioned-abis/expoview-abi38_0_0/src/main/java/abi38_0_0/host/exp/exponent/modules/api/components/lottie/LottieAnimationViewManager.java
@@ -6,11 +6,13 @@ import android.content.ContextWrapper;
 import android.os.Handler;
 import android.os.Looper;
 import androidx.core.view.ViewCompat;
+
 import android.widget.ImageView;
 import android.view.View.OnAttachStateChangeListener;
 import android.view.View;
 
 import com.airbnb.lottie.LottieAnimationView;
+import com.airbnb.lottie.RenderMode;
 import abi38_0_0.com.facebook.react.bridge.Arguments;
 import abi38_0_0.com.facebook.react.bridge.ReactContext;
 import abi38_0_0.com.facebook.react.bridge.ReadableArray;
@@ -31,13 +33,15 @@ class LottieAnimationViewManager extends SimpleViewManager<LottieAnimationView> 
   private static final int VERSION = 1;
   private static final int COMMAND_PLAY = 1;
   private static final int COMMAND_RESET = 2;
+  private static final int COMMAND_PAUSE = 3;
+  private static final int COMMAND_RESUME = 4;
 
   private Map<LottieAnimationView, LottieAnimationViewPropertyManager> propManagersMap = new WeakHashMap<>();
 
   @Override public Map<String, Object> getExportedViewConstants() {
     return MapBuilder.<String, Object>builder()
-        .put("VERSION", VERSION)
-        .build();
+      .put("VERSION", VERSION)
+      .build();
   }
 
   @Override public String getName() {
@@ -81,26 +85,28 @@ class LottieAnimationViewManager extends SimpleViewManager<LottieAnimationView> 
     }
     if (reactContext != null) {
       reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(
-          view.getId(),
-          "animationFinish",
-          event);
+        view.getId(),
+        "animationFinish",
+        event);
     }
   }
 
   @Override public Map getExportedCustomBubblingEventTypeConstants() {
     return MapBuilder.builder()
-        .put(
-            "animationFinish",
-            MapBuilder.of(
-                "phasedRegistrationNames",
-                MapBuilder.of("bubbled", "onAnimationFinish")))
-        .build();
+      .put(
+        "animationFinish",
+        MapBuilder.of(
+          "phasedRegistrationNames",
+          MapBuilder.of("bubbled", "onAnimationFinish")))
+      .build();
   }
 
   @Override public Map<String, Integer> getCommandsMap() {
     return MapBuilder.of(
-        "play", COMMAND_PLAY,
-        "reset", COMMAND_RESET
+      "play", COMMAND_PLAY,
+      "reset", COMMAND_RESET,
+      "pause", COMMAND_PAUSE,
+      "resume", COMMAND_RESUME
     );
   }
 
@@ -113,26 +119,31 @@ class LottieAnimationViewManager extends SimpleViewManager<LottieAnimationView> 
             int startFrame = args.getInt(0);
             int endFrame = args.getInt(1);
             if (startFrame != -1 && endFrame != -1) {
-              view.setMinAndMaxFrame(args.getInt(0), args.getInt(1));
+              if(startFrame > endFrame){
+                view.setMinAndMaxFrame(endFrame, startFrame);
+                view.reverseAnimationSpeed();
+              } else {
+                view.setMinAndMaxFrame(startFrame, endFrame);
+              }
             }
             if (ViewCompat.isAttachedToWindow(view)) {
               view.setProgress(0f);
               view.playAnimation();
             } else {
               view.addOnAttachStateChangeListener(new OnAttachStateChangeListener() {
-                   @Override
-                   public void onViewAttachedToWindow(View v) {
-                      LottieAnimationView view = (LottieAnimationView)v;
-                      view.setProgress(0f);
-                      view.playAnimation();
-                      view.removeOnAttachStateChangeListener(this);
-                   }
+                @Override
+                public void onViewAttachedToWindow(View v) {
+                  LottieAnimationView view = (LottieAnimationView)v;
+                  view.setProgress(0f);
+                  view.playAnimation();
+                  view.removeOnAttachStateChangeListener(this);
+                }
 
-                   @Override
-                   public void onViewDetachedFromWindow(View v) {
-                      view.removeOnAttachStateChangeListener(this);
-                   }
-               });
+                @Override
+                public void onViewDetachedFromWindow(View v) {
+                  view.removeOnAttachStateChangeListener(this);
+                }
+              });
             }
           }
         });
@@ -149,41 +160,47 @@ class LottieAnimationViewManager extends SimpleViewManager<LottieAnimationView> 
         });
       }
       break;
+      case COMMAND_PAUSE: {
+        new Handler(Looper.getMainLooper()).post(new Runnable() {
+          @Override
+          public void run() {
+            if (ViewCompat.isAttachedToWindow(view)) {
+              view.pauseAnimation();
+            }
+          }
+        });
+      }
+      break;
+      case COMMAND_RESUME: {
+        new Handler(Looper.getMainLooper()).post(new Runnable() {
+          @Override
+          public void run() {
+            if (ViewCompat.isAttachedToWindow(view)) {
+              view.resumeAnimation();
+            }
+          }
+        });
+      }
+      break;
     }
   }
 
   @ReactProp(name = "sourceName")
   public void setSourceName(LottieAnimationView view, String name) {
+    // To match the behaviour on iOS we expect the source name to be
+    // extensionless. This means "myAnimation" corresponds to a file
+    // named `myAnimation.json` in `main/assets`. To maintain backwards
+    // compatibility we only add the .json extension if no extension is
+    // passed.
+    if (!name.contains(".")) {
+      name = name + ".json";
+    }
     getOrCreatePropertyManager(view).setAnimationName(name);
   }
 
   @ReactProp(name = "sourceJson")
   public void setSourceJson(LottieAnimationView view, String json) {
     getOrCreatePropertyManager(view).setAnimationJson(json);
-  }
-
-  /**
-   *
-   * @param view
-   * @param name
-   */
-  @ReactProp(name = "cacheStrategy")
-  public void setCacheStrategy(LottieAnimationView view, String name) {
-    if (name != null) {
-      LottieAnimationView.CacheStrategy strategy = LottieAnimationView.DEFAULT_CACHE_STRATEGY;
-      switch (name) {
-        case "none":
-          strategy = LottieAnimationView.CacheStrategy.None;
-          break;
-        case "weak":
-           strategy = LottieAnimationView.CacheStrategy.Weak;
-           break;
-        case "strong":
-          strategy = LottieAnimationView.CacheStrategy.Strong;
-          break;
-      }
-      getOrCreatePropertyManager(view).setCacheStrategy(strategy);
-    }
   }
 
   @ReactProp(name = "resizeMode")
@@ -197,6 +214,19 @@ class LottieAnimationViewManager extends SimpleViewManager<LottieAnimationView> 
       mode = ImageView.ScaleType.CENTER;
     }
     getOrCreatePropertyManager(view).setScaleType(mode);
+  }
+
+  @ReactProp(name = "renderMode")
+  public void setRenderMode(LottieAnimationView view, String renderMode) {
+    RenderMode mode = null;
+    if ("AUTOMATIC".equals(renderMode) ){
+      mode = RenderMode.AUTOMATIC;
+    }else if ("HARDWARE".equals(renderMode)){
+      mode = RenderMode.HARDWARE;
+    }else if ("SOFTWARE".equals(renderMode)){
+      mode = RenderMode.SOFTWARE;
+    }
+    getOrCreatePropertyManager(view).setRenderMode(mode);
   }
 
   @ReactProp(name = "progress")
@@ -214,11 +244,6 @@ class LottieAnimationViewManager extends SimpleViewManager<LottieAnimationView> 
     getOrCreatePropertyManager(view).setLoop(loop);
   }
 
-  @ReactProp(name = "hardwareAccelerationAndroid")
-  public void setHardwareAcceleration(LottieAnimationView view, boolean use) {
-    getOrCreatePropertyManager(view).setUseHardwareAcceleration(use);
-  }
-
   @ReactProp(name = "imageAssetsFolder")
   public void setImageAssetsFolder(LottieAnimationView view, String imageAssetsFolder) {
     getOrCreatePropertyManager(view).setImageAssetsFolder(imageAssetsFolder);
@@ -227,6 +252,11 @@ class LottieAnimationViewManager extends SimpleViewManager<LottieAnimationView> 
   @ReactProp(name = "enableMergePathsAndroidForKitKatAndAbove")
   public void setEnableMergePaths(LottieAnimationView view, boolean enableMergePaths) {
     getOrCreatePropertyManager(view).setEnableMergePaths(enableMergePaths);
+  }
+
+  @ReactProp(name = "colorFilters")
+  public void setColorFilters(LottieAnimationView view, ReadableArray colorFilters) {
+    getOrCreatePropertyManager(view).setColorFilters(colorFilters);
   }
 
   @Override

--- a/android/versioned-abis/expoview-abi38_0_0/src/main/java/abi38_0_0/host/exp/exponent/modules/api/components/lottie/LottieAnimationViewPropertyManager.java
+++ b/android/versioned-abis/expoview-abi38_0_0/src/main/java/abi38_0_0/host/exp/exponent/modules/api/components/lottie/LottieAnimationViewPropertyManager.java
@@ -1,14 +1,20 @@
 package abi38_0_0.host.exp.exponent.modules.api.components.lottie;
 
-import android.util.JsonReader;
+import android.graphics.Color;
+import android.graphics.ColorFilter;
 import android.widget.ImageView;
 
 import com.airbnb.lottie.LottieAnimationView;
 import com.airbnb.lottie.LottieDrawable;
-
-import java.io.StringReader;
+import com.airbnb.lottie.LottieProperty;
+import com.airbnb.lottie.RenderMode;
+import com.airbnb.lottie.SimpleColorFilter;
+import com.airbnb.lottie.model.KeyPath;
+import com.airbnb.lottie.value.LottieValueCallback;
+import abi38_0_0.com.facebook.react.bridge.ReadableArray;
+import abi38_0_0.com.facebook.react.bridge.ReadableMap;
 import java.lang.ref.WeakReference;
-
+import java.util.regex.Pattern;
 /**
  * Class responsible for applying the properties to the LottieView.
  * The way react-native works makes it impossible to predict in which order properties will be set,
@@ -33,11 +39,11 @@ public class LottieAnimationViewPropertyManager {
   private boolean animationNameDirty;
 
   private String animationName;
-  private LottieAnimationView.CacheStrategy cacheStrategy;
-  private Boolean useHardwareAcceleration;
   private ImageView.ScaleType scaleType;
   private String imageAssetsFolder;
   private Boolean enableMergePaths;
+  private ReadableArray colorFilters;
+  private RenderMode renderMode;
 
   public LottieAnimationViewPropertyManager(LottieAnimationView view) {
     this.viewWeakReference = new WeakReference<>(view);
@@ -52,11 +58,6 @@ public class LottieAnimationViewPropertyManager {
     this.animationJson = json;
   }
 
-  public void setCacheStrategy(LottieAnimationView.CacheStrategy strategy) {
-    this.cacheStrategy = strategy;
-    this.animationNameDirty = true;
-  }
-
   public void setProgress(Float progress) {
     this.progress = progress;
   }
@@ -69,12 +70,12 @@ public class LottieAnimationViewPropertyManager {
     this.loop = loop;
   }
 
-  public void setUseHardwareAcceleration(boolean useHardwareAcceleration) {
-    this.useHardwareAcceleration = useHardwareAcceleration;
-  }
-
   public void setScaleType(ImageView.ScaleType scaleType) {
     this.scaleType = scaleType;
+  }
+
+  public void setRenderMode(RenderMode renderMode) {
+    this.renderMode = renderMode;
   }
 
   public void setImageAssetsFolder(String imageAssetsFolder) {
@@ -83,6 +84,10 @@ public class LottieAnimationViewPropertyManager {
 
   public void setEnableMergePaths(boolean enableMergePaths) {
     this.enableMergePaths = enableMergePaths;
+  }
+
+  public void setColorFilters(ReadableArray colorFilters) {
+    this.colorFilters = colorFilters;
   }
 
   /**
@@ -101,12 +106,12 @@ public class LottieAnimationViewPropertyManager {
     }
 
     if (animationJson != null) {
-      view.setAnimation(new JsonReader(new StringReader(animationJson)));
+      view.setAnimationFromJson(animationJson, Integer.toString(animationJson.hashCode()));
       animationJson = null;
     }
 
     if (animationNameDirty) {
-      view.setAnimation(animationName, cacheStrategy);
+      view.setAnimation(animationName);
       animationNameDirty = false;
     }
 
@@ -125,14 +130,14 @@ public class LottieAnimationViewPropertyManager {
       speed = null;
     }
 
-    if (useHardwareAcceleration != null) {
-      view.useHardwareAcceleration(useHardwareAcceleration);
-      useHardwareAcceleration = null;
-    }
-
     if (scaleType != null) {
       view.setScaleType(scaleType);
       scaleType = null;
+    }
+
+    if (renderMode != null) {
+      view.setRenderMode(renderMode);
+      renderMode = null;
     }
 
     if (imageAssetsFolder != null) {
@@ -141,8 +146,22 @@ public class LottieAnimationViewPropertyManager {
     }
 
     if (enableMergePaths != null) {
-        view.enableMergePathsForKitKatAndAbove(enableMergePaths);
-        enableMergePaths = null;
+      view.enableMergePathsForKitKatAndAbove(enableMergePaths);
+      enableMergePaths = null;
+    }
+
+    if (colorFilters != null && colorFilters.size() > 0) {
+      for (int i = 0 ; i < colorFilters.size() ; i++) {
+        ReadableMap current = colorFilters.getMap(i);
+        String color = current.getString("color");
+        String path = current.getString("keypath");
+        SimpleColorFilter colorFilter = new SimpleColorFilter(Color.parseColor(color));
+        String pathWithGlobstar = path +".**";
+        String[] keys = pathWithGlobstar.split(Pattern.quote("."));
+        KeyPath keyPath = new  KeyPath(keys);
+        LottieValueCallback<ColorFilter> callback = new LottieValueCallback<>(colorFilter);
+        view.addValueCallback(keyPath, LottieProperty.COLOR_FILTER, callback);
+      }
     }
   }
 }

--- a/android/versioned-abis/expoview-abi39_0_0/build.gradle
+++ b/android/versioned-abis/expoview-abi39_0_0/build.gradle
@@ -123,7 +123,7 @@ dependencies {
   api 'com.theartofdev.edmodo:android-image-cropper:2.7.0'
   api 'commons-codec:commons-codec:1.10'
   api 'net.openid:appauth:0.7.1'
-  api 'com.airbnb.android:lottie:2.5.6'
+  api 'com.airbnb.android:lottie:3.4.0'
   compileOnly 'io.branch.sdk.android:library:4.1.0'
   api "androidx.exifinterface:exifinterface:1.0.0"
   api "androidx.legacy:legacy-support-v4:1.0.0"

--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/host/exp/exponent/modules/api/components/lottie/LottieAnimationViewManager.java
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/host/exp/exponent/modules/api/components/lottie/LottieAnimationViewManager.java
@@ -6,11 +6,13 @@ import android.content.ContextWrapper;
 import android.os.Handler;
 import android.os.Looper;
 import androidx.core.view.ViewCompat;
+
 import android.widget.ImageView;
 import android.view.View.OnAttachStateChangeListener;
 import android.view.View;
 
 import com.airbnb.lottie.LottieAnimationView;
+import com.airbnb.lottie.RenderMode;
 import abi39_0_0.com.facebook.react.bridge.Arguments;
 import abi39_0_0.com.facebook.react.bridge.ReactContext;
 import abi39_0_0.com.facebook.react.bridge.ReadableArray;
@@ -31,13 +33,15 @@ class LottieAnimationViewManager extends SimpleViewManager<LottieAnimationView> 
   private static final int VERSION = 1;
   private static final int COMMAND_PLAY = 1;
   private static final int COMMAND_RESET = 2;
+  private static final int COMMAND_PAUSE = 3;
+  private static final int COMMAND_RESUME = 4;
 
   private Map<LottieAnimationView, LottieAnimationViewPropertyManager> propManagersMap = new WeakHashMap<>();
 
   @Override public Map<String, Object> getExportedViewConstants() {
     return MapBuilder.<String, Object>builder()
-        .put("VERSION", VERSION)
-        .build();
+      .put("VERSION", VERSION)
+      .build();
   }
 
   @Override public String getName() {
@@ -81,26 +85,28 @@ class LottieAnimationViewManager extends SimpleViewManager<LottieAnimationView> 
     }
     if (reactContext != null) {
       reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(
-          view.getId(),
-          "animationFinish",
-          event);
+        view.getId(),
+        "animationFinish",
+        event);
     }
   }
 
   @Override public Map getExportedCustomBubblingEventTypeConstants() {
     return MapBuilder.builder()
-        .put(
-            "animationFinish",
-            MapBuilder.of(
-                "phasedRegistrationNames",
-                MapBuilder.of("bubbled", "onAnimationFinish")))
-        .build();
+      .put(
+        "animationFinish",
+        MapBuilder.of(
+          "phasedRegistrationNames",
+          MapBuilder.of("bubbled", "onAnimationFinish")))
+      .build();
   }
 
   @Override public Map<String, Integer> getCommandsMap() {
     return MapBuilder.of(
-        "play", COMMAND_PLAY,
-        "reset", COMMAND_RESET
+      "play", COMMAND_PLAY,
+      "reset", COMMAND_RESET,
+      "pause", COMMAND_PAUSE,
+      "resume", COMMAND_RESUME
     );
   }
 
@@ -113,26 +119,31 @@ class LottieAnimationViewManager extends SimpleViewManager<LottieAnimationView> 
             int startFrame = args.getInt(0);
             int endFrame = args.getInt(1);
             if (startFrame != -1 && endFrame != -1) {
-              view.setMinAndMaxFrame(args.getInt(0), args.getInt(1));
+              if(startFrame > endFrame){
+                view.setMinAndMaxFrame(endFrame, startFrame);
+                view.reverseAnimationSpeed();
+              } else {
+                view.setMinAndMaxFrame(startFrame, endFrame);
+              }
             }
             if (ViewCompat.isAttachedToWindow(view)) {
               view.setProgress(0f);
               view.playAnimation();
             } else {
               view.addOnAttachStateChangeListener(new OnAttachStateChangeListener() {
-                   @Override
-                   public void onViewAttachedToWindow(View v) {
-                      LottieAnimationView view = (LottieAnimationView)v;
-                      view.setProgress(0f);
-                      view.playAnimation();
-                      view.removeOnAttachStateChangeListener(this);
-                   }
+                @Override
+                public void onViewAttachedToWindow(View v) {
+                  LottieAnimationView view = (LottieAnimationView)v;
+                  view.setProgress(0f);
+                  view.playAnimation();
+                  view.removeOnAttachStateChangeListener(this);
+                }
 
-                   @Override
-                   public void onViewDetachedFromWindow(View v) {
-                      view.removeOnAttachStateChangeListener(this);
-                   }
-               });
+                @Override
+                public void onViewDetachedFromWindow(View v) {
+                  view.removeOnAttachStateChangeListener(this);
+                }
+              });
             }
           }
         });
@@ -149,41 +160,47 @@ class LottieAnimationViewManager extends SimpleViewManager<LottieAnimationView> 
         });
       }
       break;
+      case COMMAND_PAUSE: {
+        new Handler(Looper.getMainLooper()).post(new Runnable() {
+          @Override
+          public void run() {
+            if (ViewCompat.isAttachedToWindow(view)) {
+              view.pauseAnimation();
+            }
+          }
+        });
+      }
+      break;
+      case COMMAND_RESUME: {
+        new Handler(Looper.getMainLooper()).post(new Runnable() {
+          @Override
+          public void run() {
+            if (ViewCompat.isAttachedToWindow(view)) {
+              view.resumeAnimation();
+            }
+          }
+        });
+      }
+      break;
     }
   }
 
   @ReactProp(name = "sourceName")
   public void setSourceName(LottieAnimationView view, String name) {
+    // To match the behaviour on iOS we expect the source name to be
+    // extensionless. This means "myAnimation" corresponds to a file
+    // named `myAnimation.json` in `main/assets`. To maintain backwards
+    // compatibility we only add the .json extension if no extension is
+    // passed.
+    if (!name.contains(".")) {
+      name = name + ".json";
+    }
     getOrCreatePropertyManager(view).setAnimationName(name);
   }
 
   @ReactProp(name = "sourceJson")
   public void setSourceJson(LottieAnimationView view, String json) {
     getOrCreatePropertyManager(view).setAnimationJson(json);
-  }
-
-  /**
-   *
-   * @param view
-   * @param name
-   */
-  @ReactProp(name = "cacheStrategy")
-  public void setCacheStrategy(LottieAnimationView view, String name) {
-    if (name != null) {
-      LottieAnimationView.CacheStrategy strategy = LottieAnimationView.DEFAULT_CACHE_STRATEGY;
-      switch (name) {
-        case "none":
-          strategy = LottieAnimationView.CacheStrategy.None;
-          break;
-        case "weak":
-           strategy = LottieAnimationView.CacheStrategy.Weak;
-           break;
-        case "strong":
-          strategy = LottieAnimationView.CacheStrategy.Strong;
-          break;
-      }
-      getOrCreatePropertyManager(view).setCacheStrategy(strategy);
-    }
   }
 
   @ReactProp(name = "resizeMode")
@@ -197,6 +214,19 @@ class LottieAnimationViewManager extends SimpleViewManager<LottieAnimationView> 
       mode = ImageView.ScaleType.CENTER;
     }
     getOrCreatePropertyManager(view).setScaleType(mode);
+  }
+
+  @ReactProp(name = "renderMode")
+  public void setRenderMode(LottieAnimationView view, String renderMode) {
+    RenderMode mode = null;
+    if ("AUTOMATIC".equals(renderMode) ){
+      mode = RenderMode.AUTOMATIC;
+    }else if ("HARDWARE".equals(renderMode)){
+      mode = RenderMode.HARDWARE;
+    }else if ("SOFTWARE".equals(renderMode)){
+      mode = RenderMode.SOFTWARE;
+    }
+    getOrCreatePropertyManager(view).setRenderMode(mode);
   }
 
   @ReactProp(name = "progress")
@@ -214,11 +244,6 @@ class LottieAnimationViewManager extends SimpleViewManager<LottieAnimationView> 
     getOrCreatePropertyManager(view).setLoop(loop);
   }
 
-  @ReactProp(name = "hardwareAccelerationAndroid")
-  public void setHardwareAcceleration(LottieAnimationView view, boolean use) {
-    getOrCreatePropertyManager(view).setUseHardwareAcceleration(use);
-  }
-
   @ReactProp(name = "imageAssetsFolder")
   public void setImageAssetsFolder(LottieAnimationView view, String imageAssetsFolder) {
     getOrCreatePropertyManager(view).setImageAssetsFolder(imageAssetsFolder);
@@ -227,6 +252,11 @@ class LottieAnimationViewManager extends SimpleViewManager<LottieAnimationView> 
   @ReactProp(name = "enableMergePathsAndroidForKitKatAndAbove")
   public void setEnableMergePaths(LottieAnimationView view, boolean enableMergePaths) {
     getOrCreatePropertyManager(view).setEnableMergePaths(enableMergePaths);
+  }
+
+  @ReactProp(name = "colorFilters")
+  public void setColorFilters(LottieAnimationView view, ReadableArray colorFilters) {
+    getOrCreatePropertyManager(view).setColorFilters(colorFilters);
   }
 
   @Override

--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/host/exp/exponent/modules/api/components/lottie/LottieAnimationViewPropertyManager.java
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/host/exp/exponent/modules/api/components/lottie/LottieAnimationViewPropertyManager.java
@@ -1,14 +1,20 @@
 package abi39_0_0.host.exp.exponent.modules.api.components.lottie;
 
-import android.util.JsonReader;
+import android.graphics.Color;
+import android.graphics.ColorFilter;
 import android.widget.ImageView;
 
 import com.airbnb.lottie.LottieAnimationView;
 import com.airbnb.lottie.LottieDrawable;
-
-import java.io.StringReader;
+import com.airbnb.lottie.LottieProperty;
+import com.airbnb.lottie.RenderMode;
+import com.airbnb.lottie.SimpleColorFilter;
+import com.airbnb.lottie.model.KeyPath;
+import com.airbnb.lottie.value.LottieValueCallback;
+import abi39_0_0.com.facebook.react.bridge.ReadableArray;
+import abi39_0_0.com.facebook.react.bridge.ReadableMap;
 import java.lang.ref.WeakReference;
-
+import java.util.regex.Pattern;
 /**
  * Class responsible for applying the properties to the LottieView.
  * The way react-native works makes it impossible to predict in which order properties will be set,
@@ -33,11 +39,11 @@ public class LottieAnimationViewPropertyManager {
   private boolean animationNameDirty;
 
   private String animationName;
-  private LottieAnimationView.CacheStrategy cacheStrategy;
-  private Boolean useHardwareAcceleration;
   private ImageView.ScaleType scaleType;
   private String imageAssetsFolder;
   private Boolean enableMergePaths;
+  private ReadableArray colorFilters;
+  private RenderMode renderMode;
 
   public LottieAnimationViewPropertyManager(LottieAnimationView view) {
     this.viewWeakReference = new WeakReference<>(view);
@@ -52,11 +58,6 @@ public class LottieAnimationViewPropertyManager {
     this.animationJson = json;
   }
 
-  public void setCacheStrategy(LottieAnimationView.CacheStrategy strategy) {
-    this.cacheStrategy = strategy;
-    this.animationNameDirty = true;
-  }
-
   public void setProgress(Float progress) {
     this.progress = progress;
   }
@@ -69,12 +70,12 @@ public class LottieAnimationViewPropertyManager {
     this.loop = loop;
   }
 
-  public void setUseHardwareAcceleration(boolean useHardwareAcceleration) {
-    this.useHardwareAcceleration = useHardwareAcceleration;
-  }
-
   public void setScaleType(ImageView.ScaleType scaleType) {
     this.scaleType = scaleType;
+  }
+
+  public void setRenderMode(RenderMode renderMode) {
+    this.renderMode = renderMode;
   }
 
   public void setImageAssetsFolder(String imageAssetsFolder) {
@@ -83,6 +84,10 @@ public class LottieAnimationViewPropertyManager {
 
   public void setEnableMergePaths(boolean enableMergePaths) {
     this.enableMergePaths = enableMergePaths;
+  }
+
+  public void setColorFilters(ReadableArray colorFilters) {
+    this.colorFilters = colorFilters;
   }
 
   /**
@@ -101,12 +106,12 @@ public class LottieAnimationViewPropertyManager {
     }
 
     if (animationJson != null) {
-      view.setAnimation(new JsonReader(new StringReader(animationJson)));
+      view.setAnimationFromJson(animationJson, Integer.toString(animationJson.hashCode()));
       animationJson = null;
     }
 
     if (animationNameDirty) {
-      view.setAnimation(animationName, cacheStrategy);
+      view.setAnimation(animationName);
       animationNameDirty = false;
     }
 
@@ -125,14 +130,14 @@ public class LottieAnimationViewPropertyManager {
       speed = null;
     }
 
-    if (useHardwareAcceleration != null) {
-      view.useHardwareAcceleration(useHardwareAcceleration);
-      useHardwareAcceleration = null;
-    }
-
     if (scaleType != null) {
       view.setScaleType(scaleType);
       scaleType = null;
+    }
+
+    if (renderMode != null) {
+      view.setRenderMode(renderMode);
+      renderMode = null;
     }
 
     if (imageAssetsFolder != null) {
@@ -141,8 +146,22 @@ public class LottieAnimationViewPropertyManager {
     }
 
     if (enableMergePaths != null) {
-        view.enableMergePathsForKitKatAndAbove(enableMergePaths);
-        enableMergePaths = null;
+      view.enableMergePathsForKitKatAndAbove(enableMergePaths);
+      enableMergePaths = null;
+    }
+
+    if (colorFilters != null && colorFilters.size() > 0) {
+      for (int i = 0 ; i < colorFilters.size() ; i++) {
+        ReadableMap current = colorFilters.getMap(i);
+        String color = current.getString("color");
+        String path = current.getString("keypath");
+        SimpleColorFilter colorFilter = new SimpleColorFilter(Color.parseColor(color));
+        String pathWithGlobstar = path +".**";
+        String[] keys = pathWithGlobstar.split(Pattern.quote("."));
+        KeyPath keyPath = new  KeyPath(keys);
+        LottieValueCallback<ColorFilter> callback = new LottieValueCallback<>(colorFilter);
+        view.addValueCallback(keyPath, LottieProperty.COLOR_FILTER, callback);
+      }
     }
   }
 }

--- a/android/versioned-abis/expoview-abi40_0_0/build.gradle
+++ b/android/versioned-abis/expoview-abi40_0_0/build.gradle
@@ -123,7 +123,7 @@ dependencies {
   api 'com.theartofdev.edmodo:android-image-cropper:2.7.0'
   api 'commons-codec:commons-codec:1.10'
   api 'net.openid:appauth:0.7.1'
-  api 'com.airbnb.android:lottie:2.5.6'
+  api 'com.airbnb.android:lottie:3.4.0'
   compileOnly 'io.branch.sdk.android:library:4.1.0'
   api "androidx.exifinterface:exifinterface:1.0.0"
   api "androidx.legacy:legacy-support-v4:1.0.0"

--- a/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/host/exp/exponent/modules/api/components/lottie/LottieAnimationViewManager.java
+++ b/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/host/exp/exponent/modules/api/components/lottie/LottieAnimationViewManager.java
@@ -11,6 +11,7 @@ import android.view.View.OnAttachStateChangeListener;
 import android.view.View;
 
 import com.airbnb.lottie.LottieAnimationView;
+import com.airbnb.lottie.RenderMode;
 import abi40_0_0.com.facebook.react.bridge.Arguments;
 import abi40_0_0.com.facebook.react.bridge.ReactContext;
 import abi40_0_0.com.facebook.react.bridge.ReadableArray;
@@ -31,13 +32,15 @@ class LottieAnimationViewManager extends SimpleViewManager<LottieAnimationView> 
   private static final int VERSION = 1;
   private static final int COMMAND_PLAY = 1;
   private static final int COMMAND_RESET = 2;
+  private static final int COMMAND_PAUSE = 3;
+  private static final int COMMAND_RESUME = 4;
 
   private Map<LottieAnimationView, LottieAnimationViewPropertyManager> propManagersMap = new WeakHashMap<>();
 
   @Override public Map<String, Object> getExportedViewConstants() {
     return MapBuilder.<String, Object>builder()
-        .put("VERSION", VERSION)
-        .build();
+      .put("VERSION", VERSION)
+      .build();
   }
 
   @Override public String getName() {
@@ -81,26 +84,28 @@ class LottieAnimationViewManager extends SimpleViewManager<LottieAnimationView> 
     }
     if (reactContext != null) {
       reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(
-          view.getId(),
-          "animationFinish",
-          event);
+        view.getId(),
+        "animationFinish",
+        event);
     }
   }
 
   @Override public Map getExportedCustomBubblingEventTypeConstants() {
     return MapBuilder.builder()
-        .put(
-            "animationFinish",
-            MapBuilder.of(
-                "phasedRegistrationNames",
-                MapBuilder.of("bubbled", "onAnimationFinish")))
-        .build();
+      .put(
+        "animationFinish",
+        MapBuilder.of(
+          "phasedRegistrationNames",
+          MapBuilder.of("bubbled", "onAnimationFinish")))
+      .build();
   }
 
   @Override public Map<String, Integer> getCommandsMap() {
     return MapBuilder.of(
-        "play", COMMAND_PLAY,
-        "reset", COMMAND_RESET
+      "play", COMMAND_PLAY,
+      "reset", COMMAND_RESET,
+      "pause", COMMAND_PAUSE,
+      "resume", COMMAND_RESUME
     );
   }
 
@@ -113,26 +118,31 @@ class LottieAnimationViewManager extends SimpleViewManager<LottieAnimationView> 
             int startFrame = args.getInt(0);
             int endFrame = args.getInt(1);
             if (startFrame != -1 && endFrame != -1) {
-              view.setMinAndMaxFrame(args.getInt(0), args.getInt(1));
+              if(startFrame > endFrame){
+                view.setMinAndMaxFrame(endFrame, startFrame);
+                view.reverseAnimationSpeed();
+              } else {
+                view.setMinAndMaxFrame(startFrame, endFrame);
+              }
             }
             if (ViewCompat.isAttachedToWindow(view)) {
               view.setProgress(0f);
               view.playAnimation();
             } else {
               view.addOnAttachStateChangeListener(new OnAttachStateChangeListener() {
-                   @Override
-                   public void onViewAttachedToWindow(View v) {
-                      LottieAnimationView view = (LottieAnimationView)v;
-                      view.setProgress(0f);
-                      view.playAnimation();
-                      view.removeOnAttachStateChangeListener(this);
-                   }
+                @Override
+                public void onViewAttachedToWindow(View v) {
+                  LottieAnimationView view = (LottieAnimationView)v;
+                  view.setProgress(0f);
+                  view.playAnimation();
+                  view.removeOnAttachStateChangeListener(this);
+                }
 
-                   @Override
-                   public void onViewDetachedFromWindow(View v) {
-                      view.removeOnAttachStateChangeListener(this);
-                   }
-               });
+                @Override
+                public void onViewDetachedFromWindow(View v) {
+                  view.removeOnAttachStateChangeListener(this);
+                }
+              });
             }
           }
         });
@@ -149,41 +159,47 @@ class LottieAnimationViewManager extends SimpleViewManager<LottieAnimationView> 
         });
       }
       break;
+      case COMMAND_PAUSE: {
+        new Handler(Looper.getMainLooper()).post(new Runnable() {
+          @Override
+          public void run() {
+            if (ViewCompat.isAttachedToWindow(view)) {
+              view.pauseAnimation();
+            }
+          }
+        });
+      }
+      break;
+      case COMMAND_RESUME: {
+        new Handler(Looper.getMainLooper()).post(new Runnable() {
+          @Override
+          public void run() {
+            if (ViewCompat.isAttachedToWindow(view)) {
+              view.resumeAnimation();
+            }
+          }
+        });
+      }
+      break;
     }
   }
 
   @ReactProp(name = "sourceName")
   public void setSourceName(LottieAnimationView view, String name) {
+    // To match the behaviour on iOS we expect the source name to be
+    // extensionless. This means "myAnimation" corresponds to a file
+    // named `myAnimation.json` in `main/assets`. To maintain backwards
+    // compatibility we only add the .json extension if no extension is
+    // passed.
+    if (!name.contains(".")) {
+      name = name + ".json";
+    }
     getOrCreatePropertyManager(view).setAnimationName(name);
   }
 
   @ReactProp(name = "sourceJson")
   public void setSourceJson(LottieAnimationView view, String json) {
     getOrCreatePropertyManager(view).setAnimationJson(json);
-  }
-
-  /**
-   *
-   * @param view
-   * @param name
-   */
-  @ReactProp(name = "cacheStrategy")
-  public void setCacheStrategy(LottieAnimationView view, String name) {
-    if (name != null) {
-      LottieAnimationView.CacheStrategy strategy = LottieAnimationView.DEFAULT_CACHE_STRATEGY;
-      switch (name) {
-        case "none":
-          strategy = LottieAnimationView.CacheStrategy.None;
-          break;
-        case "weak":
-           strategy = LottieAnimationView.CacheStrategy.Weak;
-           break;
-        case "strong":
-          strategy = LottieAnimationView.CacheStrategy.Strong;
-          break;
-      }
-      getOrCreatePropertyManager(view).setCacheStrategy(strategy);
-    }
   }
 
   @ReactProp(name = "resizeMode")
@@ -197,6 +213,19 @@ class LottieAnimationViewManager extends SimpleViewManager<LottieAnimationView> 
       mode = ImageView.ScaleType.CENTER;
     }
     getOrCreatePropertyManager(view).setScaleType(mode);
+  }
+
+  @ReactProp(name = "renderMode")
+  public void setRenderMode(LottieAnimationView view, String renderMode) {
+    RenderMode mode = null;
+    if ("AUTOMATIC".equals(renderMode) ){
+      mode = RenderMode.AUTOMATIC;
+    }else if ("HARDWARE".equals(renderMode)){
+      mode = RenderMode.HARDWARE;
+    }else if ("SOFTWARE".equals(renderMode)){
+      mode = RenderMode.SOFTWARE;
+    }
+    getOrCreatePropertyManager(view).setRenderMode(mode);
   }
 
   @ReactProp(name = "progress")
@@ -214,11 +243,6 @@ class LottieAnimationViewManager extends SimpleViewManager<LottieAnimationView> 
     getOrCreatePropertyManager(view).setLoop(loop);
   }
 
-  @ReactProp(name = "hardwareAccelerationAndroid")
-  public void setHardwareAcceleration(LottieAnimationView view, boolean use) {
-    getOrCreatePropertyManager(view).setUseHardwareAcceleration(use);
-  }
-
   @ReactProp(name = "imageAssetsFolder")
   public void setImageAssetsFolder(LottieAnimationView view, String imageAssetsFolder) {
     getOrCreatePropertyManager(view).setImageAssetsFolder(imageAssetsFolder);
@@ -227,6 +251,11 @@ class LottieAnimationViewManager extends SimpleViewManager<LottieAnimationView> 
   @ReactProp(name = "enableMergePathsAndroidForKitKatAndAbove")
   public void setEnableMergePaths(LottieAnimationView view, boolean enableMergePaths) {
     getOrCreatePropertyManager(view).setEnableMergePaths(enableMergePaths);
+  }
+
+  @ReactProp(name = "colorFilters")
+  public void setColorFilters(LottieAnimationView view, ReadableArray colorFilters) {
+    getOrCreatePropertyManager(view).setColorFilters(colorFilters);
   }
 
   @Override

--- a/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/host/exp/exponent/modules/api/components/lottie/LottieAnimationViewPropertyManager.java
+++ b/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/host/exp/exponent/modules/api/components/lottie/LottieAnimationViewPropertyManager.java
@@ -1,14 +1,20 @@
 package abi40_0_0.host.exp.exponent.modules.api.components.lottie;
 
-import android.util.JsonReader;
+import android.graphics.Color;
+import android.graphics.ColorFilter;
 import android.widget.ImageView;
 
 import com.airbnb.lottie.LottieAnimationView;
 import com.airbnb.lottie.LottieDrawable;
-
-import java.io.StringReader;
+import com.airbnb.lottie.LottieProperty;
+import com.airbnb.lottie.RenderMode;
+import com.airbnb.lottie.SimpleColorFilter;
+import com.airbnb.lottie.model.KeyPath;
+import com.airbnb.lottie.value.LottieValueCallback;
+import abi40_0_0.com.facebook.react.bridge.ReadableArray;
+import abi40_0_0.com.facebook.react.bridge.ReadableMap;
 import java.lang.ref.WeakReference;
-
+import java.util.regex.Pattern;
 /**
  * Class responsible for applying the properties to the LottieView.
  * The way react-native works makes it impossible to predict in which order properties will be set,
@@ -33,11 +39,11 @@ public class LottieAnimationViewPropertyManager {
   private boolean animationNameDirty;
 
   private String animationName;
-  private LottieAnimationView.CacheStrategy cacheStrategy;
-  private Boolean useHardwareAcceleration;
   private ImageView.ScaleType scaleType;
   private String imageAssetsFolder;
   private Boolean enableMergePaths;
+  private ReadableArray colorFilters;
+  private RenderMode renderMode;
 
   public LottieAnimationViewPropertyManager(LottieAnimationView view) {
     this.viewWeakReference = new WeakReference<>(view);
@@ -52,11 +58,6 @@ public class LottieAnimationViewPropertyManager {
     this.animationJson = json;
   }
 
-  public void setCacheStrategy(LottieAnimationView.CacheStrategy strategy) {
-    this.cacheStrategy = strategy;
-    this.animationNameDirty = true;
-  }
-
   public void setProgress(Float progress) {
     this.progress = progress;
   }
@@ -69,12 +70,12 @@ public class LottieAnimationViewPropertyManager {
     this.loop = loop;
   }
 
-  public void setUseHardwareAcceleration(boolean useHardwareAcceleration) {
-    this.useHardwareAcceleration = useHardwareAcceleration;
-  }
-
   public void setScaleType(ImageView.ScaleType scaleType) {
     this.scaleType = scaleType;
+  }
+
+  public void setRenderMode(RenderMode renderMode) {
+    this.renderMode = renderMode;
   }
 
   public void setImageAssetsFolder(String imageAssetsFolder) {
@@ -83,6 +84,10 @@ public class LottieAnimationViewPropertyManager {
 
   public void setEnableMergePaths(boolean enableMergePaths) {
     this.enableMergePaths = enableMergePaths;
+  }
+
+  public void setColorFilters(ReadableArray colorFilters) {
+    this.colorFilters = colorFilters;
   }
 
   /**
@@ -101,12 +106,12 @@ public class LottieAnimationViewPropertyManager {
     }
 
     if (animationJson != null) {
-      view.setAnimation(new JsonReader(new StringReader(animationJson)));
+      view.setAnimationFromJson(animationJson, Integer.toString(animationJson.hashCode()));
       animationJson = null;
     }
 
     if (animationNameDirty) {
-      view.setAnimation(animationName, cacheStrategy);
+      view.setAnimation(animationName);
       animationNameDirty = false;
     }
 
@@ -125,14 +130,14 @@ public class LottieAnimationViewPropertyManager {
       speed = null;
     }
 
-    if (useHardwareAcceleration != null) {
-      view.useHardwareAcceleration(useHardwareAcceleration);
-      useHardwareAcceleration = null;
-    }
-
     if (scaleType != null) {
       view.setScaleType(scaleType);
       scaleType = null;
+    }
+
+    if (renderMode != null) {
+      view.setRenderMode(renderMode);
+      renderMode = null;
     }
 
     if (imageAssetsFolder != null) {
@@ -141,8 +146,22 @@ public class LottieAnimationViewPropertyManager {
     }
 
     if (enableMergePaths != null) {
-        view.enableMergePathsForKitKatAndAbove(enableMergePaths);
-        enableMergePaths = null;
+      view.enableMergePathsForKitKatAndAbove(enableMergePaths);
+      enableMergePaths = null;
+    }
+
+    if (colorFilters != null && colorFilters.size() > 0) {
+      for (int i = 0 ; i < colorFilters.size() ; i++) {
+        ReadableMap current = colorFilters.getMap(i);
+        String color = current.getString("color");
+        String path = current.getString("keypath");
+        SimpleColorFilter colorFilter = new SimpleColorFilter(Color.parseColor(color));
+        String pathWithGlobstar = path +".**";
+        String[] keys = pathWithGlobstar.split(Pattern.quote("."));
+        KeyPath keyPath = new  KeyPath(keys);
+        LottieValueCallback<ColorFilter> callback = new LottieValueCallback<>(colorFilter);
+        view.addValueCallback(keyPath, LottieProperty.COLOR_FILTER, callback);
+      }
     }
   }
 }


### PR DESCRIPTION
# Why

Followup #11586 
This PR upgrades Lottie to v3 on Android (iOS is already upgraded)

# How

- `et update-module -m lottie-react-native -p android`
- Updated `com.airbnb.android:lottie` dependency to `3.4.0` (newer versions are available, but `lottie-react-native` uses that one)
- Reversioned SDK38, SDK39 and SDK40 because there were some breaking changes in the implementation of the native dependency.

# Test Plan

Confirmed that it works as expected on all SDKs (used https://snack.expo.io/@tsapeta/lottie-v3.5). Also there is no need to tell people to update JS on existing SDKs because native and JS sides are still compatible.
