### PR TITLE
Use expo/metro-config in templates

### DIFF
--- a/docs/pages/guides/customizing-metro.md
+++ b/docs/pages/guides/customizing-metro.md
@@ -37,13 +37,9 @@ const { getDefaultConfig } = require('@expo/metro-config');
 
 const defaultConfig = getDefaultConfig(__dirname);
 
-module.exports = {
-  ...defaultConfig,
-  resolver: {
-    ...defaultConfig.resolver,
-    assetExts: [...defaultConfig.resolver.assetExts, 'db'],
-  },
-};
+defaultConfig.resolver.assetExts.push('db');
+
+module.exports = defaultConfig;
 ```
 
 (This example adds `.db`, the extension of SQLite database files to `assetExts`).

--- a/docs/pages/guides/customizing-metro.md
+++ b/docs/pages/guides/customizing-metro.md
@@ -40,6 +40,7 @@ const defaultConfig = getDefaultConfig(__dirname);
 module.exports = {
   ...defaultConfig,
   resolver: {
+    ...defaultConfig.resolver,
     assetExts: [...defaultConfig.resolver.assetExts, 'db'],
   },
 };

--- a/docs/pages/guides/customizing-metro.md
+++ b/docs/pages/guides/customizing-metro.md
@@ -38,6 +38,7 @@ const { getDefaultConfig } = require('@expo/metro-config');
 const defaultConfig = getDefaultConfig(__dirname);
 
 module.exports = {
+  ...defaultConfig,
   resolver: {
     assetExts: [...defaultConfig.resolver.assetExts, 'db'],
   },

--- a/templates/expo-template-bare-minimum/metro.config.js
+++ b/templates/expo-template-bare-minimum/metro.config.js
@@ -1,5 +1,4 @@
-module.exports = {
-  transformer: {
-    assetPlugins: ['expo-asset/tools/hashAssetFiles'],
-  },
-};
+// Learn more https://docs.expo.io/guides/customizing-metro
+const { getDefaultConfig } = require('expo/metro-config');
+
+module.exports = getDefaultConfig(__dirname);

--- a/templates/expo-template-bare-typescript/metro.config.js
+++ b/templates/expo-template-bare-typescript/metro.config.js
@@ -1,5 +1,4 @@
-module.exports = {
-  transformer: {
-    assetPlugins: ['expo-asset/tools/hashAssetFiles'],
-  },
-};
+// Learn more https://docs.expo.io/guides/customizing-metro
+const { getDefaultConfig } = require('expo/metro-config');
+
+module.exports = getDefaultConfig(__dirname);


### PR DESCRIPTION
# Why

- Resolve ENG-58
- Supports jsx and other features that managed expo apps support. 
- This makes bare a little closer to managed workflow.

# How

- This shouldn't be released until after SDK 41.

# Test Plan

- Verified that templates are versioned in expo-cli, so the correct template should be used when ejecting.
