### PR TITLE
Update expo-speech documentation for Android

### DIFF
--- a/docs/pages/versions/unversioned/sdk/speech.md
+++ b/docs/pages/versions/unversioned/sdk/speech.md
@@ -95,11 +95,11 @@ Interrupts current speech and deletes all in queue.
 
 ### `Speech.pause()`
 
-Pauses current speech.
+Pauses current speech. This method is not available on Android.
 
 ### `Speech.resume()`
 
-Resumes speaking previously paused speech or does nothing if there's none.
+Resumes speaking previously paused speech or does nothing if there's none. This method is not available on Android.
 
 ### `Speech.isSpeakingAsync()`
 


### PR DESCRIPTION
Mention that Android doesn't support Speech `pause()` and `resume()`.

# Why

Prevent some confusion as seen in https://github.com/expo/expo/issues/1192 and https://github.com/expo/expo/issues/8551

# How

Updated documentation.

# Test Plan

N/A