### PR TITLE
[expo-updates][ios] parse and persist data from EAS update headers

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1843,6 +1843,7 @@ PODS:
     - UMCore
     - UMTaskManagerInterface
   - EXUpdates (0.5.0-rc.1):
+    - EXStructuredHeaders
     - React-Core
     - UMCore
   - EXVideoThumbnails (5.0.0):
@@ -3927,7 +3928,7 @@ SPEC CHECKSUMS:
   EXStoreReview: b552c0d512e1b5c2c7371041a033a2827dc01d46
   EXStructuredHeaders: 99b4a74850058a7eaeb7e4fe27f5cb605276c1f3
   EXTaskManager: e1956fd45bc301cbe852ebffccb9fd0b4ab78494
-  EXUpdates: b6fd75d347a9ca61b198a80a77164e33f71b0ee7
+  EXUpdates: 3ae108ae5771c177946017d209972a25c3649a89
   EXVideoThumbnails: 0be939563a5d46ce0d1fa9baea7d454b99475763
   EXWebBrowser: 2e708935a91ae0f51f5f8ffc85ba673950f34833
   FBAudienceNetwork: 648648b13d8ea3d39676542dece2b04dbe867497

--- a/packages/expo-structured-headers/ios/EXStructuredHeaders/EXStructuredHeadersParser.m
+++ b/packages/expo-structured-headers/ios/EXStructuredHeaders/EXStructuredHeadersParser.m
@@ -9,6 +9,8 @@ typedef NS_ENUM(NSInteger, EXStructuredHeadersParserNumberType) {
   EXStructuredHeadersParserNumberTypeDecimal
 };
 
+static NSString * const EXStructuredHeadersParserErrorDomain = @"EXStructuredHeadersParser";
+
 @interface EXStructuredHeadersParser ()
 
 @property (nonatomic, strong) NSString *raw;
@@ -534,8 +536,9 @@ typedef NS_ENUM(NSInteger, EXStructuredHeadersParserNumberType) {
 
 - (NSError *)errorWithMessage:(NSString *)message
 {
-  // TODO: implement this
-  return [NSError new];
+  return [NSError errorWithDomain:EXStructuredHeadersParserErrorDomain code:1 userInfo:@{
+    NSLocalizedDescriptionKey: message
+  }];
 }
 
 @end

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -16,7 +16,7 @@
 - Added alpha support for EAS update manifest format ([#11050](https://github.com/expo/expo/pull/11050) by [@esamelson](https://github.com/esamelson))
 - add ability for android clients to handle header signatures. ([#11897](https://github.com/expo/expo/pull/11897) by [@jkhales](https://github.com/jkhales))
 - Added `SelectionPolicyFilterAware` to support EAS Update's manifest filters feature ([#11748](https://github.com/expo/expo/pull/11748) by [@esamelson](https://github.com/esamelson))
-- Parse & persist data from EAS Update manifest headers ([#11961](https://github.com/expo/expo/pull/11961) by [@esamelson](https://github.com/esamelson))
+- Parse & persist data from EAS Update manifest headers ([#11961](https://github.com/expo/expo/pull/11961) and [#11967](https://github.com/expo/expo/pull/11967) by [@esamelson](https://github.com/esamelson))
 - Accept signature in header (iOS). ([#11930](https://github.com/expo/expo/pull/11930) by [@jkhales](https://github.com/jkhales))
 
 ### 🐛 Bug fixes

--- a/packages/expo-updates/ios/EXUpdates.podspec
+++ b/packages/expo-updates/ios/EXUpdates.podspec
@@ -15,6 +15,7 @@ Pod::Spec.new do |s|
 
   s.dependency 'UMCore'
   s.dependency 'React-Core'
+  s.dependency 'EXStructuredHeaders'
 
   if !$ExpoUseSources&.include?(package['name']) && ENV['EXPO_USE_SOURCE'].to_i == 0 && File.exist?("#{s.name}.xcframework") && Gem::Version.new(Pod::VERSION) >= Gem::Version.new('1.10.0')
     s.source_files = "#{s.name}/**/*.h"

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.m
@@ -170,6 +170,7 @@ NSTimeInterval const EXUpdatesDefaultTimeoutInterval = 60;
                                                   if (isValid) {
                                                     mutableManifest[@"isVerified"] = @(YES);
                                                     EXUpdatesUpdate *update = [EXUpdatesUpdate updateWithManifest:[mutableManifest copy]
+                                                                                                         response:response
                                                                                                            config:self->_config
                                                                                                          database:database];
                                                     successBlock(update);
@@ -185,6 +186,7 @@ NSTimeInterval const EXUpdatesDefaultTimeoutInterval = 60;
     } else {
       mutableManifest[@"isVerified"] = @(NO);
       EXUpdatesUpdate *update = [EXUpdatesUpdate updateWithManifest:[(NSDictionary *)mutableManifest copy]
+                                                           response:response
                                                              config:self->_config
                                                            database:database];
       successBlock(update);

--- a/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.h
+++ b/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.h
@@ -34,6 +34,11 @@ typedef NS_ENUM(NSInteger, EXUpdatesDatabaseHashType) {
 - (nullable NSArray<EXUpdatesAsset *> *)assetsWithUpdateId:(NSUUID *)updateId error:(NSError ** _Nullable)error;
 - (nullable EXUpdatesAsset *)assetWithKey:(NSString *)key error:(NSError ** _Nullable)error;
 
+- (nullable NSDictionary *)serverDefinedHeadersWithScopeKey:(NSString *)scopeKey error:(NSError ** _Nullable)error;
+- (nullable NSDictionary *)manifestFiltersWithScopeKey:(NSString *)scopeKey error:(NSError ** _Nullable)error;
+- (void)setServerDefinedHeaders:(NSDictionary *)serverDefinedHeaders withScopeKey:(NSString *)scopeKey error:(NSError ** _Nullable)error;
+- (void)setManifestFilters:(NSDictionary *)manifestFilters withScopeKey:(NSString *)scopeKey error:(NSError ** _Nullable)error;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.h
+++ b/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.h
@@ -38,6 +38,7 @@ typedef NS_ENUM(NSInteger, EXUpdatesDatabaseHashType) {
 - (nullable NSDictionary *)manifestFiltersWithScopeKey:(NSString *)scopeKey error:(NSError ** _Nullable)error;
 - (void)setServerDefinedHeaders:(NSDictionary *)serverDefinedHeaders withScopeKey:(NSString *)scopeKey error:(NSError ** _Nullable)error;
 - (void)setManifestFilters:(NSDictionary *)manifestFilters withScopeKey:(NSString *)scopeKey error:(NSError ** _Nullable)error;
+- (void)setServerDataWithManifest:(EXUpdatesUpdate *)updateManifest error:(NSError ** _Nullable)error;
 
 @end
 

--- a/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.m
+++ b/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.m
@@ -461,9 +461,9 @@ static NSString * const EXUpdatesDatabaseServerDefinedHeadersKey = @"serverDefin
   if (rows && [rows count]) {
     id value = rows[0][@"value"];
     if (value && [value isKindOfClass:[NSString class]]) {
-      NSDictionary *serverDefinedHeaders = [NSJSONSerialization JSONObjectWithData:[(NSString *)value dataUsingEncoding:NSUTF8StringEncoding] options:kNilOptions error:error];
-      if (!error && serverDefinedHeaders && [serverDefinedHeaders isKindOfClass:[NSDictionary class]]) {
-        return serverDefinedHeaders;
+      NSDictionary *jsonObject = [NSJSONSerialization JSONObjectWithData:[(NSString *)value dataUsingEncoding:NSUTF8StringEncoding] options:kNilOptions error:error];
+      if (!error && jsonObject && [jsonObject isKindOfClass:[NSDictionary class]]) {
+        return jsonObject;
       }
     }
   }

--- a/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.m
+++ b/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.m
@@ -496,6 +496,26 @@ static NSString * const EXUpdatesDatabaseServerDefinedHeadersKey = @"serverDefin
   [self _setJsonData:manifestFilters withKey:EXUpdatesDatabaseManifestFiltersKey scopeKey:scopeKey error:error];
 }
 
+- (void)setServerDataWithManifest:(EXUpdatesUpdate *)updateManifest error:(NSError ** _Nullable)error
+{
+  sqlite3_exec(_db, "BEGIN;", NULL, NULL, NULL);
+  if (updateManifest.serverDefinedHeaders) {
+    [self setServerDefinedHeaders:updateManifest.serverDefinedHeaders withScopeKey:updateManifest.scopeKey error:error];
+    if (*error) {
+      sqlite3_exec(_db, "ROLLBACK;", NULL, NULL, NULL);
+      return;
+    }
+  }
+  if (updateManifest.manifestFilters) {
+    [self setManifestFilters:updateManifest.manifestFilters withScopeKey:updateManifest.scopeKey error:error];
+    if (*error) {
+      sqlite3_exec(_db, "ROLLBACK;", NULL, NULL, NULL);
+      return;
+    }
+  }
+  sqlite3_exec(_db, "COMMIT;", NULL, NULL, NULL);
+}
+
 # pragma mark - helper methods
 
 - (nullable NSArray<NSDictionary *> *)_executeSql:(NSString *)sql withArgs:(nullable NSArray *)args error:(NSError ** _Nullable)error

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesNewUpdate.h
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesNewUpdate.h
@@ -11,6 +11,8 @@ NS_ASSUME_NONNULL_BEGIN
                                     config:(EXUpdatesConfig *)config
                                   database:(EXUpdatesDatabase *)database;
 
++ (nullable NSDictionary *)dictionaryWithStructuredHeader:(NSString *)headerString;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesNewUpdate.h
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesNewUpdate.h
@@ -7,6 +7,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface EXUpdatesNewUpdate : NSObject
 
 + (EXUpdatesUpdate *)updateWithNewManifest:(NSDictionary *)rootManifest
+                                  response:(nullable NSURLResponse *)response
                                     config:(EXUpdatesConfig *)config
                                   database:(EXUpdatesDatabase *)database;
 

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesNewUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesNewUpdate.m
@@ -1,5 +1,6 @@
 //  Copyright © 2019 650 Industries. All rights reserved.
 
+#import <EXStructuredHeaders/EXStructuredHeadersParser.h>
 #import <EXUpdates/EXUpdatesEmbeddedAppLoader.h>
 #import <EXUpdates/EXUpdatesNewUpdate.h>
 #import <EXUpdates/EXUpdatesUpdate+Private.h>
@@ -11,6 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation EXUpdatesNewUpdate
 
 + (EXUpdatesUpdate *)updateWithNewManifest:(NSDictionary *)rootManifest
+                                  response:(nullable NSURLResponse *)response
                                     config:(EXUpdatesConfig *)config
                                   database:(EXUpdatesDatabase *)database
 {
@@ -92,7 +94,34 @@ NS_ASSUME_NONNULL_BEGIN
   update.assets = processedAssets;
   update.metadata = manifest;
 
+  if ([response isKindOfClass:[NSHTTPURLResponse class]]) {
+    NSDictionary *headersDictionary = ((NSHTTPURLResponse *)response).allHeaderFields;
+    update.serverDefinedHeaders = [[self class] dictionaryWithStructuredHeader:headersDictionary[@"expo-server-defined-headers"]];
+    update.manifestFilters = [[self class] dictionaryWithStructuredHeader:headersDictionary[@"expo-manifest-filters"]];
+  }
+
   return update;
+}
+
++ (nullable NSDictionary *)dictionaryWithStructuredHeader:(NSString *)headerString
+{
+  EXStructuredHeadersParser *parser = [[EXStructuredHeadersParser alloc] initWithRawInput:headerString fieldType:EXStructuredHeadersParserFieldTypeDictionary ignoringParameters:YES];
+  NSError *error;
+  NSDictionary *parserOutput = [parser parseStructuredFieldsWithError:&error];
+  if (!parserOutput || error || ![parserOutput isKindOfClass:[NSDictionary class]]) {
+    NSLog(@"Error parsing header value: %@", error.localizedDescription ?: @"Header was not a structured fields dictionary");
+    return nil;
+  }
+
+  NSMutableDictionary *mutableDict = [NSMutableDictionary dictionaryWithCapacity:parserOutput.count];
+  [parserOutput enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
+    // ignore any dictionary entries whose type is not string, number, or boolean
+    // since this will be re-serialized to JSON
+    if ([obj isKindOfClass:[NSString class]] || [obj isKindOfClass:[NSNumber class]]) {
+      mutableDict[key] = obj;
+    }
+  }];
+  return mutableDict.copy;
 }
 
 @end

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesNewUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesNewUpdate.m
@@ -105,11 +105,15 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (nullable NSDictionary *)dictionaryWithStructuredHeader:(NSString *)headerString
 {
+  if (!headerString) {
+    return nil;
+  }
+
   EXStructuredHeadersParser *parser = [[EXStructuredHeadersParser alloc] initWithRawInput:headerString fieldType:EXStructuredHeadersParserFieldTypeDictionary ignoringParameters:YES];
   NSError *error;
   NSDictionary *parserOutput = [parser parseStructuredFieldsWithError:&error];
   if (!parserOutput || error || ![parserOutput isKindOfClass:[NSDictionary class]]) {
-    NSLog(@"Error parsing header value: %@", error.localizedDescription ?: @"Header was not a structured fields dictionary");
+    NSLog(@"Error parsing header value: %@", error ? error.localizedDescription : @"Header was not a structured fields dictionary");
     return nil;
   }
 

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate+Private.h
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate+Private.h
@@ -17,8 +17,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readwrite) NSArray<EXUpdatesAsset *> *assets;
 @property (nonatomic, assign, readwrite) BOOL isDevelopmentMode;
 
-@property (nonatomic, assign, readwrite) NSDictionary *serverDefinedHeaders;
-@property (nonatomic, assign, readwrite) NSDictionary *manifestFilters;
+@property (nonatomic, strong, readwrite, nullable) NSDictionary *serverDefinedHeaders;
+@property (nonatomic, strong, readwrite, nullable) NSDictionary *manifestFilters;
 
 @property (nonatomic, strong) EXUpdatesConfig *config;
 @property (nonatomic, strong, nullable) EXUpdatesDatabase *database;

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate+Private.h
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate+Private.h
@@ -17,6 +17,9 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readwrite) NSArray<EXUpdatesAsset *> *assets;
 @property (nonatomic, assign, readwrite) BOOL isDevelopmentMode;
 
+@property (nonatomic, assign, readwrite) NSDictionary *serverDefinedHeaders;
+@property (nonatomic, assign, readwrite) NSDictionary *manifestFilters;
+
 @property (nonatomic, strong) EXUpdatesConfig *config;
 @property (nonatomic, strong, nullable) EXUpdatesDatabase *database;
 

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate.h
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate.h
@@ -28,6 +28,9 @@ typedef NS_ENUM(NSInteger, EXUpdatesUpdateStatus) {
 @property (nonatomic, strong, readonly) NSArray<EXUpdatesAsset *> *assets;
 @property (nonatomic, assign, readonly) BOOL isDevelopmentMode;
 
+@property (nonatomic, assign, readonly) NSDictionary *serverDefinedHeaders;
+@property (nonatomic, assign, readonly) NSDictionary *manifestFilters;
+
 @property (nonatomic, strong, readonly) NSDictionary *rawManifest;
 
 @property (nonatomic, assign) EXUpdatesUpdateStatus status;
@@ -43,6 +46,7 @@ typedef NS_ENUM(NSInteger, EXUpdatesUpdateStatus) {
                     database:(EXUpdatesDatabase *)database;
 
 + (instancetype)updateWithManifest:(NSDictionary *)manifest
+                          response:(nullable NSURLResponse *)response
                             config:(EXUpdatesConfig *)config
                           database:(EXUpdatesDatabase *)database;
 

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate.h
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate.h
@@ -28,8 +28,8 @@ typedef NS_ENUM(NSInteger, EXUpdatesUpdateStatus) {
 @property (nonatomic, strong, readonly) NSArray<EXUpdatesAsset *> *assets;
 @property (nonatomic, assign, readonly) BOOL isDevelopmentMode;
 
-@property (nonatomic, assign, readonly) NSDictionary *serverDefinedHeaders;
-@property (nonatomic, assign, readonly) NSDictionary *manifestFilters;
+@property (nonatomic, strong, readonly, nullable) NSDictionary *serverDefinedHeaders;
+@property (nonatomic, strong, readonly, nullable) NSDictionary *manifestFilters;
 
 @property (nonatomic, strong, readonly) NSDictionary *rawManifest;
 

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate.m
@@ -55,6 +55,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 + (instancetype)updateWithManifest:(NSDictionary *)manifest
+                          response:(nullable NSURLResponse *)response
                             config:(EXUpdatesConfig *)config
                           database:(EXUpdatesDatabase *)database
 {
@@ -64,6 +65,7 @@ NS_ASSUME_NONNULL_BEGIN
                                                   database:database];
   } else {
     return [EXUpdatesNewUpdate updateWithNewManifest:manifest
+                                            response:response
                                               config:config
                                             database:database];
   }
@@ -87,6 +89,7 @@ NS_ASSUME_NONNULL_BEGIN
     // bare (embedded) manifests should never have a runtimeVersion field
     if (manifest[@"manifest"] || manifest[@"runtimeVersion"]) {
       return [EXUpdatesNewUpdate updateWithNewManifest:manifest
+                                              response:nil
                                                 config:config
                                               database:database];
     } else {

--- a/packages/expo-updates/ios/Tests/EXUpdatesDatabaseTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesDatabaseTests.m
@@ -59,7 +59,7 @@
 - (void)testSetServerData_OverwriteAllFields
 {
   NSHTTPURLResponse *response1 = [[NSHTTPURLResponse alloc] initWithURL:[NSURL URLWithString:@"https://exp.host/"] statusCode:200 HTTPVersion:@"HTTP/2" headerFields:@{
-    @"expo-manifest-filters": @"branch=\"rollout-1\",test=\"value\""
+    @"expo-manifest-filters": @"branch-name=\"rollout-1\",test=\"value\""
   }];
   EXUpdatesUpdate *update1 = [EXUpdatesNewUpdate updateWithNewManifest:_manifest response:response1 config:_config database:_db];
   __block NSError *error1;
@@ -69,7 +69,7 @@
   XCTAssertNil(error1);
 
   NSHTTPURLResponse *response2 = [[NSHTTPURLResponse alloc] initWithURL:[NSURL URLWithString:@"https://exp.host/"] statusCode:200 HTTPVersion:@"HTTP/2" headerFields:@{
-    @"expo-manifest-filters": @"branch=\"rollout-2\""
+    @"expo-manifest-filters": @"branch-name=\"rollout-2\""
   }];
   EXUpdatesUpdate *update2 = [EXUpdatesNewUpdate updateWithNewManifest:_manifest response:response2 config:_config database:_db];
   __block NSError *error2;
@@ -78,7 +78,7 @@
   });
   XCTAssertNil(error2);
 
-  NSDictionary *expected = @{@"branch": @"rollout-2"};
+  NSDictionary *expected = @{@"branch-name": @"rollout-2"};
   __block NSDictionary *actual;
   __block NSError *readError;
   dispatch_sync(_db.databaseQueue, ^{
@@ -92,7 +92,7 @@
 - (void)testSetServerData_OverwriteEmpty
 {
   NSHTTPURLResponse *response1 = [[NSHTTPURLResponse alloc] initWithURL:[NSURL URLWithString:@"https://exp.host/"] statusCode:200 HTTPVersion:@"HTTP/2" headerFields:@{
-    @"expo-manifest-filters": @"branch=\"rollout-1\""
+    @"expo-manifest-filters": @"branch-name=\"rollout-1\""
   }];
   EXUpdatesUpdate *update1 = [EXUpdatesNewUpdate updateWithNewManifest:_manifest response:response1 config:_config database:_db];
   __block NSError *error1;
@@ -125,7 +125,7 @@
 - (void)testSetServerData_OverwriteNull
 {
   NSHTTPURLResponse *response1 = [[NSHTTPURLResponse alloc] initWithURL:[NSURL URLWithString:@"https://exp.host/"] statusCode:200 HTTPVersion:@"HTTP/2" headerFields:@{
-    @"expo-manifest-filters": @"branch=\"rollout-1\""
+    @"expo-manifest-filters": @"branch-name=\"rollout-1\""
   }];
   EXUpdatesUpdate *update1 = [EXUpdatesNewUpdate updateWithNewManifest:_manifest response:response1 config:_config database:_db];
   __block NSError *error1;
@@ -142,7 +142,7 @@
   });
   XCTAssertNil(error2);
   
-  NSDictionary *expected = @{@"branch": @"rollout-1"};
+  NSDictionary *expected = @{@"branch-name": @"rollout-1"};
   __block NSDictionary *actual;
   __block NSError *readError;
   dispatch_sync(_db.databaseQueue, ^{

--- a/packages/expo-updates/ios/Tests/EXUpdatesDatabaseTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesDatabaseTests.m
@@ -1,0 +1,156 @@
+//  Copyright (c) 2021 650 Industries, Inc. All rights reserved.
+
+#import <XCTest/XCTest.h>
+
+#import <EXUpdates/EXUpdatesConfig.h>
+#import <EXUpdates/EXUpdatesDatabase.h>
+#import <EXUpdates/EXUpdatesNewUpdate.h>
+
+@interface EXUpdatesDatabaseTests : XCTestCase
+
+@property (nonatomic, strong) EXUpdatesDatabase *db;
+@property (nonatomic, strong) NSURL *testDatabaseDir;
+@property (nonatomic, strong) NSDictionary *manifest;
+@property (nonatomic, strong) EXUpdatesConfig *config;
+
+@end
+
+@implementation EXUpdatesDatabaseTests
+
+- (void)setUp
+{
+  NSURL *applicationSupportDir = [NSFileManager.defaultManager URLsForDirectory:NSApplicationSupportDirectory inDomains:NSUserDomainMask].lastObject;
+  _testDatabaseDir = [applicationSupportDir URLByAppendingPathComponent:@"EXUpdatesDatabaseTests"];
+  if (![NSFileManager.defaultManager fileExistsAtPath:_testDatabaseDir.path]) {
+    NSError *error;
+    [NSFileManager.defaultManager createDirectoryAtPath:_testDatabaseDir.path withIntermediateDirectories:YES attributes:nil error:&error];
+    XCTAssertNil(error);
+  }
+
+  _db = [[EXUpdatesDatabase alloc] init];
+  dispatch_sync(_db.databaseQueue, ^{
+    NSError *dbOpenError;
+    [_db openDatabaseInDirectory:_testDatabaseDir withError:&dbOpenError];
+    XCTAssertNil(dbOpenError);
+  });
+
+  _manifest = @{
+    @"runtimeVersion": @"1",
+    @"id": @"0eef8214-4833-4089-9dff-b4138a14f196",
+    @"createdAt": @"2020-11-11T00:17:54.797Z",
+    @"launchAsset": @{@"url": @"https://url.to/bundle.js", @"contentType": @"application/javascript"}
+  };
+  _config = [EXUpdatesConfig configWithDictionary:@{
+    @"EXUpdatesURL": @"https://exp.host/@test/test",
+    @"EXUpdatesUsesLegacyManifest": @(NO)
+  }];
+}
+
+- (void)tearDown
+{
+  dispatch_sync(_db.databaseQueue, ^{
+    [_db closeDatabase];
+  });
+  NSError *error;
+  [NSFileManager.defaultManager removeItemAtPath:_testDatabaseDir.path error:&error];
+  XCTAssertNil(error);
+}
+
+- (void)testSetServerData_OverwriteAllFields
+{
+  NSHTTPURLResponse *response1 = [[NSHTTPURLResponse alloc] initWithURL:[NSURL URLWithString:@"https://exp.host/"] statusCode:200 HTTPVersion:@"HTTP/2" headerFields:@{
+    @"expo-manifest-filters": @"branch=\"rollout-1\",test=\"value\""
+  }];
+  EXUpdatesUpdate *update1 = [EXUpdatesNewUpdate updateWithNewManifest:_manifest response:response1 config:_config database:_db];
+  __block NSError *error1;
+  dispatch_sync(_db.databaseQueue, ^{
+    [_db setServerDataWithManifest:update1 error:&error1];
+  });
+  XCTAssertNil(error1);
+
+  NSHTTPURLResponse *response2 = [[NSHTTPURLResponse alloc] initWithURL:[NSURL URLWithString:@"https://exp.host/"] statusCode:200 HTTPVersion:@"HTTP/2" headerFields:@{
+    @"expo-manifest-filters": @"branch=\"rollout-2\""
+  }];
+  EXUpdatesUpdate *update2 = [EXUpdatesNewUpdate updateWithNewManifest:_manifest response:response2 config:_config database:_db];
+  __block NSError *error2;
+  dispatch_sync(_db.databaseQueue, ^{
+    [_db setServerDataWithManifest:update2 error:&error2];
+  });
+  XCTAssertNil(error2);
+
+  NSDictionary *expected = @{@"branch": @"rollout-2"};
+  __block NSDictionary *actual;
+  __block NSError *readError;
+  dispatch_sync(_db.databaseQueue, ^{
+    actual = [_db manifestFiltersWithScopeKey:update2.scopeKey error:&readError];
+  });
+  XCTAssertNil(readError);
+  XCTAssertNotNil(actual);
+  XCTAssertEqualObjects(expected, actual);
+}
+
+- (void)testSetServerData_OverwriteEmpty
+{
+  NSHTTPURLResponse *response1 = [[NSHTTPURLResponse alloc] initWithURL:[NSURL URLWithString:@"https://exp.host/"] statusCode:200 HTTPVersion:@"HTTP/2" headerFields:@{
+    @"expo-manifest-filters": @"branch=\"rollout-1\""
+  }];
+  EXUpdatesUpdate *update1 = [EXUpdatesNewUpdate updateWithNewManifest:_manifest response:response1 config:_config database:_db];
+  __block NSError *error1;
+  dispatch_sync(_db.databaseQueue, ^{
+    [_db setServerDataWithManifest:update1 error:&error1];
+  });
+  XCTAssertNil(error1);
+  
+  NSHTTPURLResponse *response2 = [[NSHTTPURLResponse alloc] initWithURL:[NSURL URLWithString:@"https://exp.host/"] statusCode:200 HTTPVersion:@"HTTP/2" headerFields:@{
+    @"expo-manifest-filters": @""
+  }];
+  EXUpdatesUpdate *update2 = [EXUpdatesNewUpdate updateWithNewManifest:_manifest response:response2 config:_config database:_db];
+  __block NSError *error2;
+  dispatch_sync(_db.databaseQueue, ^{
+    [_db setServerDataWithManifest:update2 error:&error2];
+  });
+  XCTAssertNil(error2);
+  
+  NSDictionary *expected = @{};
+  __block NSDictionary *actual;
+  __block NSError *readError;
+  dispatch_sync(_db.databaseQueue, ^{
+    actual = [_db manifestFiltersWithScopeKey:update2.scopeKey error:&readError];
+  });
+  XCTAssertNil(readError);
+  XCTAssertNotNil(actual);
+  XCTAssertEqualObjects(expected, actual);
+}
+
+- (void)testSetServerData_OverwriteNull
+{
+  NSHTTPURLResponse *response1 = [[NSHTTPURLResponse alloc] initWithURL:[NSURL URLWithString:@"https://exp.host/"] statusCode:200 HTTPVersion:@"HTTP/2" headerFields:@{
+    @"expo-manifest-filters": @"branch=\"rollout-1\""
+  }];
+  EXUpdatesUpdate *update1 = [EXUpdatesNewUpdate updateWithNewManifest:_manifest response:response1 config:_config database:_db];
+  __block NSError *error1;
+  dispatch_sync(_db.databaseQueue, ^{
+    [_db setServerDataWithManifest:update1 error:&error1];
+  });
+  XCTAssertNil(error1);
+  
+  NSHTTPURLResponse *response2 = [[NSHTTPURLResponse alloc] initWithURL:[NSURL URLWithString:@"https://exp.host/"] statusCode:200 HTTPVersion:@"HTTP/2" headerFields:@{}];
+  EXUpdatesUpdate *update2 = [EXUpdatesNewUpdate updateWithNewManifest:_manifest response:response2 config:_config database:_db];
+  __block NSError *error2;
+  dispatch_sync(_db.databaseQueue, ^{
+    [_db setServerDataWithManifest:update2 error:&error2];
+  });
+  XCTAssertNil(error2);
+  
+  NSDictionary *expected = @{@"branch": @"rollout-1"};
+  __block NSDictionary *actual;
+  __block NSError *readError;
+  dispatch_sync(_db.databaseQueue, ^{
+    actual = [_db manifestFiltersWithScopeKey:update2.scopeKey error:&readError];
+  });
+  XCTAssertNil(readError);
+  XCTAssertNotNil(actual);
+  XCTAssertEqualObjects(expected, actual);
+}
+
+@end

--- a/packages/expo-updates/ios/Tests/EXUpdatesNewUpdateTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesNewUpdateTests.m
@@ -40,7 +40,7 @@
     @"createdAt": @"2020-11-11T00:17:54.797Z",
     @"launchAsset": @{@"url": @"https://url.to/bundle.js", @"contentType": @"application/javascript"}
   };
-  XCTAssert([EXUpdatesNewUpdate updateWithNewManifest:manifest config:_config database:_database] != nil);
+  XCTAssert([EXUpdatesNewUpdate updateWithNewManifest:manifest response:nil config:_config database:_database] != nil);
 }
 
 - (void)testUpdateWithNewManifest_NoRuntimeVersion
@@ -50,7 +50,7 @@
     @"createdAt": @"2020-11-11T00:17:54.797Z",
     @"launchAsset": @{@"url": @"https://url.to/bundle.js", @"contentType": @"application/javascript"}
   };
-  XCTAssertThrows([EXUpdatesNewUpdate updateWithNewManifest:manifest config:_config database:_database]);
+  XCTAssertThrows([EXUpdatesNewUpdate updateWithNewManifest:manifest response:nil config:_config database:_database]);
 }
 
 - (void)testUpdateWithNewManifest_NoId
@@ -60,7 +60,7 @@
     @"createdAt": @"2020-11-11T00:17:54.797Z",
     @"launchAsset": @{@"url": @"https://url.to/bundle.js", @"contentType": @"application/javascript"}
   };
-  XCTAssertThrows([EXUpdatesNewUpdate updateWithNewManifest:manifest config:_config database:_database]);
+  XCTAssertThrows([EXUpdatesNewUpdate updateWithNewManifest:manifest response:nil config:_config database:_database]);
 }
 
 - (void)testUpdateWithNewManifest_NoCreatedAt
@@ -70,7 +70,7 @@
     @"id": @"0eef8214-4833-4089-9dff-b4138a14f196",
     @"launchAsset": @{@"url": @"https://url.to/bundle.js", @"contentType": @"application/javascript"}
   };
-  XCTAssertThrows([EXUpdatesNewUpdate updateWithNewManifest:manifest config:_config database:_database]);
+  XCTAssertThrows([EXUpdatesNewUpdate updateWithNewManifest:manifest response:nil config:_config database:_database]);
 }
 
 - (void)testUpdateWithNewManifest_NoLaunchAsset
@@ -80,7 +80,7 @@
     @"id": @"0eef8214-4833-4089-9dff-b4138a14f196",
     @"createdAt": @"2020-11-11T00:17:54.797Z"
   };
-  XCTAssertThrows([EXUpdatesNewUpdate updateWithNewManifest:manifest config:_config database:_database]);
+  XCTAssertThrows([EXUpdatesNewUpdate updateWithNewManifest:manifest response:nil config:_config database:_database]);
 }
 
 - (void)testUpdateWithNewManifest_StripsOptionalRootLevelKeys
@@ -95,10 +95,58 @@
     @"manifest": manifestNoRootLevelKeys
   };
 
-  EXUpdatesUpdate *update1 = [EXUpdatesNewUpdate updateWithNewManifest:manifestNoRootLevelKeys config:_config database:_database];
-  EXUpdatesUpdate *update2 = [EXUpdatesNewUpdate updateWithNewManifest:manifestWithRootLevelKeys config:_config database:_database];
+  EXUpdatesUpdate *update1 = [EXUpdatesNewUpdate updateWithNewManifest:manifestNoRootLevelKeys response:nil config:_config database:_database];
+  EXUpdatesUpdate *update2 = [EXUpdatesNewUpdate updateWithNewManifest:manifestWithRootLevelKeys response:nil config:_config database:_database];
 
   XCTAssert([update1.updateId isEqual:update2.updateId]);
+}
+
+- (void)testDictionaryWithStructuredHeader_SupportedTypes
+{
+  NSString *header = @"string=\"string-0000\", true=?1, false=?0, integer=47, decimal=47.5";
+  NSDictionary *expected = @{
+    @"string": @"string-0000",
+    @"true": @(YES),
+    @"false": @(NO),
+    @"integer": @(47),
+    @"decimal": @(47.5)
+  };
+  NSDictionary *actual = [EXUpdatesNewUpdate dictionaryWithStructuredHeader:header];
+  XCTAssertEqualObjects(expected, actual);
+}
+
+- (void)testDictionaryWithStructuredHeader_IgnoresOtherTypes
+{
+  NSString *header = @"branch=\"rollout-1\", data=:w4ZibGV0w6ZydGUK:, list=(1 2)";
+  NSDictionary *expected = @{
+    @"branch": @"rollout-1"
+  };
+  NSDictionary *actual = [EXUpdatesNewUpdate dictionaryWithStructuredHeader:header];
+  XCTAssertEqualObjects(expected, actual);
+}
+
+- (void)testDictionaryWithStructuredHeader_IgnoresParameters
+{
+  NSString *header = @"abc=123;a=1;b=2";
+  NSDictionary *expected = @{
+    @"abc": @(123)
+  };
+  NSDictionary *actual = [EXUpdatesNewUpdate dictionaryWithStructuredHeader:header];
+  XCTAssertEqualObjects(expected, actual);
+}
+
+- (void)testDictionaryWithStructuredHeader_Empty
+{
+  NSString *header = @"";
+  NSDictionary *expected = @{};
+  NSDictionary *actual = [EXUpdatesNewUpdate dictionaryWithStructuredHeader:header];
+  XCTAssertEqualObjects(expected, actual);
+}
+
+- (void)testDictionaryWithStructuredHeader_ParsingError
+{
+  NSString *header = @"bad dictionary";
+  XCTAssertNil([EXUpdatesNewUpdate dictionaryWithStructuredHeader:header]);
 }
 
 @end

--- a/packages/expo-updates/ios/Tests/EXUpdatesNewUpdateTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesNewUpdateTests.m
@@ -117,9 +117,9 @@
 
 - (void)testDictionaryWithStructuredHeader_IgnoresOtherTypes
 {
-  NSString *header = @"branch=\"rollout-1\", data=:w4ZibGV0w6ZydGUK:, list=(1 2)";
+  NSString *header = @"branch-name=\"rollout-1\", data=:w4ZibGV0w6ZydGUK:, list=(1 2)";
   NSDictionary *expected = @{
-    @"branch": @"rollout-1"
+    @"branch-name": @"rollout-1"
   };
   NSDictionary *actual = [EXUpdatesNewUpdate dictionaryWithStructuredHeader:header];
   XCTAssertEqualObjects(expected, actual);

--- a/packages/expo-updates/ios/Tests/EXUpdatesSelectionPolicyFilterAwareTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesSelectionPolicyFilterAwareTests.m
@@ -51,7 +51,7 @@
     @"launchAsset": launchAsset,
     @"assets": @[imageAsset],
     @"updateMetadata": @{@"branchName": @"rollout"}
-  } config:config database:database];
+  } response:nil config:config database:database];
 
   _updateDefault1 = [EXUpdatesNewUpdate updateWithNewManifest:@{
     @"id": @"079cde35-8433-4c17-81c8-7117c1513e72",
@@ -60,7 +60,7 @@
     @"launchAsset": launchAsset,
     @"assets": @[imageAsset],
     @"updateMetadata": @{@"branchName": @"default"}
-  } config:config database:database];
+  } response:nil config:config database:database];
   
   _updateRollout1 = [EXUpdatesNewUpdate updateWithNewManifest:@{
     @"id": @"079cde35-8433-4c17-81c8-7117c1513e73",
@@ -69,7 +69,7 @@
     @"launchAsset": launchAsset,
     @"assets": @[imageAsset],
     @"updateMetadata": @{@"branchName": @"rollout"}
-  } config:config database:database];
+  } response:nil config:config database:database];
   
   _updateDefault2 = [EXUpdatesNewUpdate updateWithNewManifest:@{
     @"id": @"079cde35-8433-4c17-81c8-7117c1513e74",
@@ -78,7 +78,7 @@
     @"launchAsset": launchAsset,
     @"assets": @[imageAsset],
     @"updateMetadata": @{@"branchName": @"default"}
-  } config:config database:database];
+  } response:nil config:config database:database];
   
   _updateRollout2 = [EXUpdatesNewUpdate updateWithNewManifest:@{
     @"id": @"079cde35-8433-4c17-81c8-7117c1513e75",
@@ -87,7 +87,7 @@
     @"launchAsset": launchAsset,
     @"assets": @[imageAsset],
     @"updateMetadata": @{@"branchName": @"rollout"}
-  } config:config database:database];
+  } response:nil config:config database:database];
 
   _updateMultipleFilters = [EXUpdatesNewUpdate updateWithNewManifest:@{
     @"id": @"079cde35-8433-4c17-81c8-7117c1513e72",
@@ -96,7 +96,7 @@
     @"launchAsset": launchAsset,
     @"assets": @[imageAsset],
     @"updateMetadata": @{@"key1": @"value1", @"key2": @"value2"}
-  } config:config database:database];
+  } response:nil config:config database:database];
 
   _selectionPolicy = [[EXUpdatesSelectionPolicyFilterAware alloc] initWithRuntimeVersion:runtimeVersion];
   _manifestFilters = @{@"branchName": @"rollout"};

--- a/packages/expo-updates/ios/Tests/EXUpdatesUpdateTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesUpdateTests.m
@@ -66,13 +66,13 @@
 
 - (void)testUpdateWithManifest_Legacy
 {
-  EXUpdatesUpdate *update = [EXUpdatesUpdate updateWithManifest:_legacyManifest config:_configUsesLegacyManifestTrue database:_database];
+  EXUpdatesUpdate *update = [EXUpdatesUpdate updateWithManifest:_legacyManifest response:nil config:_configUsesLegacyManifestTrue database:_database];
   XCTAssert(update != nil);
 }
 
 - (void)testUpdateWithManifest_New
 {
-  EXUpdatesUpdate *update = [EXUpdatesUpdate updateWithManifest:_easNewManifest config:_configUsesLegacyManifestFalse database:_database];
+  EXUpdatesUpdate *update = [EXUpdatesUpdate updateWithManifest:_easNewManifest response:nil config:_configUsesLegacyManifestFalse database:_database];
   XCTAssert(update != nil);
 }
 


### PR DESCRIPTION
# Why

iOS side of https://github.com/expo/expo/pull/11961.

# How

Parallel steps to what is listed in #11961.

# Test Plan

Added the same unit tests, all expo-updates iOS tests pass as of this PR.
