### PR TITLE
[ci] Install pods when lockfiles mismatch and add debugging step

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -105,9 +105,12 @@ jobs:
           key: ${{ runner.os }}-bare-expo-pods-${{ hashFiles('apps/bare-expo/ios/Podfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-bare-expo-pods-
+      - name: 🕵️ Debug CocoaPods lockfiles
+        run: git diff Podfile.lock Pods/Manifest.lock
+        working-directory: apps/bare-expo/ios
       - name: 🥥 Install pods in apps/bare-expo/ios
         run: pod install
-        if: steps.pods-cache.outputs.cache-hit != 'true'
+        if: steps.pods-cache.outputs.cache-hit != 'true' || hashFiles('apps/bare-expo/ios/Podfile.lock') != hashFiles('apps/bare-expo/ios/Pods/Manifest.lock')
         working-directory: apps/bare-expo/ios
       - name: Clean Detox
         run: yarn detox:clean


### PR DESCRIPTION
# Why

> error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.

Looks like this error reappeared even though I updated CocoaPods on the CI.

# How

I'm gonna get some more info why the lockfiles are different by doing `git diff` in one of the steps. Until then, we will run `pod install` in this case as well, even on cache hit.

# Test Plan

Edited steps has passed, it's failing later but this is intermittent node's issue.
