### PR TITLE
[expo-updates][android] add OkHttpClient context assertion

### DIFF
--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.java
@@ -56,14 +56,21 @@ public class FileDownloader {
   private static OkHttpClient getClient(Context context) {
     if (sClient == null) {
       sClient = new OkHttpClient.Builder().cache(getCache(context)).build();
+    } else {
+      if (sClient.cache() == null || !getCacheDirectory(context).getAbsolutePath().equals(sClient.cache().directory().getAbsolutePath())) {
+        throw new AssertionError("Error: trying to access static OkHttpClient that was created with a different context.");
+      }
     }
     return sClient;
   }
 
   private static Cache getCache(Context context) {
     int cacheSize = 50 * 1024 * 1024; // 50 MiB
-    final File directory = new File(context.getCacheDir(), "okhttp");
-    return new Cache(directory, cacheSize);
+    return new Cache(getCacheDirectory(context), cacheSize);
+  }
+
+  private static File getCacheDirectory(Context context) {
+    return new File(context.getCacheDir(), "okhttp");
   }
 
   public static void downloadFileToPath(Request request, final File destination, final Context context, final FileDownloadCallback callback) {


### PR DESCRIPTION
# Why

follow-up from https://github.com/expo/expo/pull/11875#discussion_r578803189

# How

Add the assertion @ide suggested

# Test Plan

This code path shouldn't be triggered, but we'll see throughout the testing process for SDK 41 if we ever run into this AssertionError.
