### PR TITLE
[document-picker] created plugin

### DIFF
--- a/apps/native-component-list/app.config.js
+++ b/apps/native-component-list/app.config.js
@@ -44,7 +44,7 @@ export default ({ config }) => {
   config.plugins.push([
     'expo-document-picker',
     {
-      appleTeamId: 'XXXXXX'
+      appleTeamId: 'XXXXXX',
     },
   ]);
 

--- a/apps/native-component-list/app.config.js
+++ b/apps/native-component-list/app.config.js
@@ -41,6 +41,12 @@ export default ({ config }) => {
       merchantId: 'merchant.com.example.development',
     },
   ]);
+  config.plugins.push([
+    'expo-document-picker',
+    {
+      appleTeamId: 'XXXXXX'
+    },
+  ]);
 
   return config;
 };

--- a/apps/native-component-list/app.json
+++ b/apps/native-component-list/app.json
@@ -58,6 +58,7 @@
       "appStoreUrl": "https://itunes.apple.com/us/app/expo-client/id982107779?mt=8",
       "userInterfaceStyle": "light",
       "usesAppleSignIn": true,
+      "usesIcloudStorage": true,
       "googleServicesFile": "./GoogleService-Info.plist",
       "config": {
         "usesNonExemptEncryption": false,

--- a/packages/expo-document-picker/CHANGELOG.md
+++ b/packages/expo-document-picker/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 🎉 New features
 
+- Created config plugin. ([#11977](https://github.com/expo/expo/pull/11977) by [@EvanBacon](https://github.com/EvanBacon))
 - Updated Android build configuration to target Android 11 (added support for Android SDK 30). ([#11647](https://github.com/expo/expo/pull/11647) by [@bbarthec](https://github.com/bbarthec))
 
 ### 🐛 Bug fixes

--- a/packages/expo-document-picker/README.md
+++ b/packages/expo-document-picker/README.md
@@ -29,6 +29,31 @@ Run `npx pod-install` after installing the npm package.
 
 No additional set up necessary.
 
+### Plugin
+
+In order to enable Apple iCloud storage in managed EAS builds, you'll need to define the `appleTeamId` property in the config plugin:
+
+`app.json`
+
+```json
+{
+  "ios": {
+    "usesIcloudStorage": true,
+    "bundleIdentifier": "com.yourname.yourapp"
+  },
+  "plugins": [
+    [
+      "expo-document-picker",
+      {
+        "appleTeamId": "YOUR_TEAM_ID"
+      }
+    ]
+  ]
+}
+```
+
+> Running `expo eject` will generate a the native project locally with the applied changes in your iOS Entitlements file.
+
 # Contributing
 
 Contributions are very welcome! Please refer to guidelines described in the [contributing guide](https://github.com/expo/expo#contributing).

--- a/packages/expo-document-picker/app.plugin.js
+++ b/packages/expo-document-picker/app.plugin.js
@@ -1,0 +1,1 @@
+module.exports = require('./plugin/build/withDocumentPicker');

--- a/packages/expo-document-picker/package.json
+++ b/packages/expo-document-picker/package.json
@@ -35,6 +35,7 @@
     "preset": "expo-module-scripts/ios"
   },
   "dependencies": {
+    "@expo/config-plugins": "^1.0.18",
     "uuid": "^3.3.2"
   },
   "unimodulePeerDependencies": {

--- a/packages/expo-document-picker/plugin/build/withDocumentPicker.d.ts
+++ b/packages/expo-document-picker/plugin/build/withDocumentPicker.d.ts
@@ -1,0 +1,5 @@
+import { ConfigPlugin } from '@expo/config-plugins';
+declare const _default: ConfigPlugin<void | {
+    appleTeamId?: string | undefined;
+}>;
+export default _default;

--- a/packages/expo-document-picker/plugin/build/withDocumentPicker.js
+++ b/packages/expo-document-picker/plugin/build/withDocumentPicker.js
@@ -1,0 +1,10 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const config_plugins_1 = require("@expo/config-plugins");
+const withDocumentPickerIOS_1 = require("./withDocumentPickerIOS");
+const pkg = require('expo-document-picker/package.json');
+const withDocumentPicker = (config, { appleTeamId = process.env.EXPO_APPLE_TEAM_ID } = {}) => {
+    config = withDocumentPickerIOS_1.withDocumentPickerIOS(config, { appleTeamId });
+    return config;
+};
+exports.default = config_plugins_1.createRunOncePlugin(withDocumentPicker, pkg.name, pkg.version);

--- a/packages/expo-document-picker/plugin/build/withDocumentPickerIOS.d.ts
+++ b/packages/expo-document-picker/plugin/build/withDocumentPickerIOS.d.ts
@@ -1,0 +1,6 @@
+import { ConfigPlugin } from '@expo/config-plugins';
+import { ExpoConfig } from '@expo/config-types';
+export declare const withDocumentPickerIOS: ConfigPlugin<{
+    appleTeamId?: string;
+}>;
+export declare function setICloudEntitlments(config: Pick<ExpoConfig, 'ios'>, appleTeamId: string, entitlements: Record<string, any>): Record<string, any>;

--- a/packages/expo-document-picker/plugin/build/withDocumentPickerIOS.js
+++ b/packages/expo-document-picker/plugin/build/withDocumentPickerIOS.js
@@ -1,0 +1,31 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.setICloudEntitlments = exports.withDocumentPickerIOS = void 0;
+const config_plugins_1 = require("@expo/config-plugins");
+exports.withDocumentPickerIOS = (config, { appleTeamId }) => {
+    return config_plugins_1.withEntitlementsPlist(config, config => {
+        if (appleTeamId) {
+            config.modResults = setICloudEntitlments(config, appleTeamId, config.modResults);
+        }
+        else {
+            config_plugins_1.WarningAggregator.addWarningIOS('expo-document-picker', 'Cannot configure iOS entitlements because neither the appleTeamId property, nor the environment variable EXPO_APPLE_TEAM_ID were defined.');
+        }
+        return config;
+    });
+};
+function setICloudEntitlments(config, appleTeamId, entitlements) {
+    var _a;
+    if ((_a = config.ios) === null || _a === void 0 ? void 0 : _a.usesIcloudStorage) {
+        entitlements['com.apple.developer.icloud-container-identifiers'] = [
+            'iCloud.' + config.ios.bundleIdentifier,
+        ];
+        entitlements['com.apple.developer.ubiquity-container-identifiers'] = [
+            'iCloud.' + config.ios.bundleIdentifier,
+        ];
+        entitlements['com.apple.developer.ubiquity-kvstore-identifier'] =
+            appleTeamId + '.' + config.ios.bundleIdentifier;
+        entitlements['com.apple.developer.icloud-services'] = ['CloudDocuments'];
+    }
+    return entitlements;
+}
+exports.setICloudEntitlments = setICloudEntitlments;

--- a/packages/expo-document-picker/plugin/jest.config.js
+++ b/packages/expo-document-picker/plugin/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = require('expo-module-scripts/jest-preset-plugin');

--- a/packages/expo-document-picker/plugin/src/__tests__/withDocumentPickerIOS-test.ts
+++ b/packages/expo-document-picker/plugin/src/__tests__/withDocumentPickerIOS-test.ts
@@ -1,0 +1,21 @@
+import { setICloudEntitlments } from '../withDocumentPickerIOS';
+
+describe(setICloudEntitlments, () => {
+  it(`skips setting the iCloud entitlements if the flag isn't enabled`, () => {
+    expect(setICloudEntitlments({ ios: {} }, 'X1X2X3X4X', {})).toStrictEqual({});
+  });
+  it(`sets the iCloud entitlements`, () => {
+    expect(
+      setICloudEntitlments(
+        { ios: { usesIcloudStorage: true, bundleIdentifier: 'com.bacon.foobar' } },
+        'X1X2X3X4X',
+        {}
+      )
+    ).toStrictEqual({
+      'com.apple.developer.icloud-container-identifiers': ['iCloud.com.bacon.foobar'],
+      'com.apple.developer.icloud-services': ['CloudDocuments'],
+      'com.apple.developer.ubiquity-container-identifiers': ['iCloud.com.bacon.foobar'],
+      'com.apple.developer.ubiquity-kvstore-identifier': 'X1X2X3X4X.com.bacon.foobar',
+    });
+  });
+});

--- a/packages/expo-document-picker/plugin/src/withDocumentPicker.ts
+++ b/packages/expo-document-picker/plugin/src/withDocumentPicker.ts
@@ -1,0 +1,15 @@
+import { ConfigPlugin, createRunOncePlugin } from '@expo/config-plugins';
+
+import { withDocumentPickerIOS } from './withDocumentPickerIOS';
+
+const pkg = require('expo-document-picker/package.json');
+
+const withDocumentPicker: ConfigPlugin<{ appleTeamId?: string } | void> = (
+  config,
+  { appleTeamId = process.env.EXPO_APPLE_TEAM_ID } = {}
+) => {
+  config = withDocumentPickerIOS(config, { appleTeamId });
+  return config;
+};
+
+export default createRunOncePlugin(withDocumentPicker, pkg.name, pkg.version);

--- a/packages/expo-document-picker/plugin/src/withDocumentPickerIOS.ts
+++ b/packages/expo-document-picker/plugin/src/withDocumentPickerIOS.ts
@@ -1,0 +1,38 @@
+import { ConfigPlugin, WarningAggregator, withEntitlementsPlist } from '@expo/config-plugins';
+import { ExpoConfig } from '@expo/config-types';
+
+export const withDocumentPickerIOS: ConfigPlugin<{ appleTeamId?: string }> = (
+  config,
+  { appleTeamId }
+) => {
+  return withEntitlementsPlist(config, config => {
+    if (appleTeamId) {
+      config.modResults = setICloudEntitlments(config, appleTeamId, config.modResults);
+    } else {
+      WarningAggregator.addWarningIOS(
+        'expo-document-picker',
+        'Cannot configure iOS entitlements because neither the appleTeamId property, nor the environment variable EXPO_APPLE_TEAM_ID were defined.'
+      );
+    }
+    return config;
+  });
+};
+
+export function setICloudEntitlments(
+  config: Pick<ExpoConfig, 'ios'>,
+  appleTeamId: string,
+  entitlements: Record<string, any>
+): Record<string, any> {
+  if (config.ios?.usesIcloudStorage) {
+    entitlements['com.apple.developer.icloud-container-identifiers'] = [
+      'iCloud.' + config.ios.bundleIdentifier,
+    ];
+    entitlements['com.apple.developer.ubiquity-container-identifiers'] = [
+      'iCloud.' + config.ios.bundleIdentifier,
+    ];
+    entitlements['com.apple.developer.ubiquity-kvstore-identifier'] =
+      appleTeamId + '.' + config.ios.bundleIdentifier;
+    entitlements['com.apple.developer.icloud-services'] = ['CloudDocuments'];
+  }
+  return entitlements;
+}

--- a/packages/expo-document-picker/plugin/tsconfig.json
+++ b/packages/expo-document-picker/plugin/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "expo-module-scripts/tsconfig.plugin",
+  "compilerOptions": {
+    "outDir": "build",
+    "rootDir": "src"
+  },
+  "include": ["./src"],
+  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+}


### PR DESCRIPTION
# Why

- https://linear.app/expo/issue/ENG-235/expo-document-picker-and-expo-apple-authentication-support
<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How

- Allow document picker to accept an appleTeamId property, with optional fallback to `process.env.EXPO_APPLE_TEAM_ID`
- Plugin warns if the appleTeamId couldn't be resolved when it needed to be.
<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

- Added unit tests
- Added document-picker plugin to NCL, ran `expo prebuild --no-install` and checked to ensure the entitlements file had the required changes.
