### PR TITLE
Created plugin for apple authentication

### DIFF
--- a/packages/expo-apple-authentication/CHANGELOG.md
+++ b/packages/expo-apple-authentication/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Created config plugin ([#11979](https://github.com/expo/expo/pull/11979) by [@EvanBacon](https://github.com/EvanBacon))
+
 ### 🐛 Bug fixes
 
 ## 3.0.0 — 2021-01-15

--- a/packages/expo-apple-authentication/app.plugin.js
+++ b/packages/expo-apple-authentication/app.plugin.js
@@ -1,0 +1,1 @@
+module.exports = require('./plugin/build/withAppleAuth')

--- a/packages/expo-apple-authentication/package.json
+++ b/packages/expo-apple-authentication/package.json
@@ -39,7 +39,9 @@
     "react": "*",
     "react-native": "*"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@expo/config-plugins": "^1.0.18"
+  },
   "devDependencies": {
     "expo-module-scripts": "~1.2.0"
   }

--- a/packages/expo-apple-authentication/plugin/build/withAppleAuth.d.ts
+++ b/packages/expo-apple-authentication/plugin/build/withAppleAuth.d.ts
@@ -1,0 +1,3 @@
+import { ConfigPlugin } from '@expo/config-plugins';
+declare const _default: ConfigPlugin<void>;
+export default _default;

--- a/packages/expo-apple-authentication/plugin/build/withAppleAuth.js
+++ b/packages/expo-apple-authentication/plugin/build/withAppleAuth.js
@@ -1,0 +1,10 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const config_plugins_1 = require("@expo/config-plugins");
+const withAppleAuthIOS_1 = require("./withAppleAuthIOS");
+const pkg = require('expo-apple-authentication/package.json');
+const withAppleAuth = config => {
+    config = withAppleAuthIOS_1.withAppleAuthIOS(config);
+    return config;
+};
+exports.default = config_plugins_1.createRunOncePlugin(withAppleAuth, pkg.name, pkg.version);

--- a/packages/expo-apple-authentication/plugin/build/withAppleAuthIOS.d.ts
+++ b/packages/expo-apple-authentication/plugin/build/withAppleAuthIOS.d.ts
@@ -1,0 +1,4 @@
+import { ConfigPlugin } from '@expo/config-plugins';
+import { ExpoConfig } from '@expo/config-types';
+export declare const withAppleAuthIOS: ConfigPlugin;
+export declare function setAppleAuthEntitlements(config: Pick<ExpoConfig, 'ios'>, entitlements: Record<string, any>): Record<string, any>;

--- a/packages/expo-apple-authentication/plugin/build/withAppleAuthIOS.js
+++ b/packages/expo-apple-authentication/plugin/build/withAppleAuthIOS.js
@@ -1,0 +1,18 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.setAppleAuthEntitlements = exports.withAppleAuthIOS = void 0;
+const config_plugins_1 = require("@expo/config-plugins");
+exports.withAppleAuthIOS = config => {
+    return config_plugins_1.withEntitlementsPlist(config, config => {
+        config.modResults = setAppleAuthEntitlements(config, config.modResults);
+        return config;
+    });
+};
+function setAppleAuthEntitlements(config, entitlements) {
+    var _a;
+    if ((_a = config.ios) === null || _a === void 0 ? void 0 : _a.usesAppleSignIn) {
+        entitlements['com.apple.developer.applesignin'] = ['Default'];
+    }
+    return entitlements;
+}
+exports.setAppleAuthEntitlements = setAppleAuthEntitlements;

--- a/packages/expo-apple-authentication/plugin/jest.config.js
+++ b/packages/expo-apple-authentication/plugin/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = require('expo-module-scripts/jest-preset-plugin');

--- a/packages/expo-apple-authentication/plugin/src/__tests__/withAppleAuthIOS-test.ts
+++ b/packages/expo-apple-authentication/plugin/src/__tests__/withAppleAuthIOS-test.ts
@@ -1,0 +1,9 @@
+import { setAppleAuthEntitlements } from '../withAppleAuthIOS';
+
+describe(setAppleAuthEntitlements, () => {
+  it(`sets the apple auth entitlements`, () => {
+    expect(setAppleAuthEntitlements({ ios: { usesAppleSignIn: true } }, {})).toMatchObject({
+      'com.apple.developer.applesignin': ['Default'],
+    });
+  });
+});

--- a/packages/expo-apple-authentication/plugin/src/withAppleAuth.ts
+++ b/packages/expo-apple-authentication/plugin/src/withAppleAuth.ts
@@ -1,0 +1,12 @@
+import { ConfigPlugin, createRunOncePlugin } from '@expo/config-plugins';
+
+import { withAppleAuthIOS } from './withAppleAuthIOS';
+
+const pkg = require('expo-apple-authentication/package.json');
+
+const withAppleAuth: ConfigPlugin = config => {
+  config = withAppleAuthIOS(config);
+  return config;
+};
+
+export default createRunOncePlugin(withAppleAuth, pkg.name, pkg.version);

--- a/packages/expo-apple-authentication/plugin/src/withAppleAuthIOS.ts
+++ b/packages/expo-apple-authentication/plugin/src/withAppleAuthIOS.ts
@@ -1,0 +1,20 @@
+import { ConfigPlugin, withEntitlementsPlist } from '@expo/config-plugins';
+import { ExpoConfig } from '@expo/config-types';
+
+export const withAppleAuthIOS: ConfigPlugin = config => {
+  return withEntitlementsPlist(config, config => {
+    config.modResults = setAppleAuthEntitlements(config, config.modResults);
+
+    return config;
+  });
+};
+
+export function setAppleAuthEntitlements(
+  config: Pick<ExpoConfig, 'ios'>,
+  entitlements: Record<string, any>
+): Record<string, any> {
+  if (config.ios?.usesAppleSignIn) {
+    entitlements['com.apple.developer.applesignin'] = ['Default'];
+  }
+  return entitlements;
+}

--- a/packages/expo-apple-authentication/plugin/tsconfig.json
+++ b/packages/expo-apple-authentication/plugin/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "expo-module-scripts/tsconfig.plugin",
+  "compilerOptions": {
+    "outDir": "build",
+    "rootDir": "src"
+  },
+  "include": ["./src"],
+  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+}


### PR DESCRIPTION
# Why

- https://linear.app/expo/issue/ENG-235/expo-document-picker-and-expo-apple-authentication-support
<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How

- Created a basic plugin

# Test Plan

- Added unit tests
- Added document-picker plugin to NCL, ran `expo prebuild --no-install` and checked to ensure the entitlements file had the required changes.
