### PR TITLE
Remove peerDependencies and unimodulePeerDependencies from Expo modules

### DIFF
--- a/packages/@unimodules/react-native-adapter/package.json
+++ b/packages/@unimodules/react-native-adapter/package.json
@@ -33,17 +33,6 @@
   "jest": {
     "preset": "expo-module-scripts"
   },
-  "peerDependencies": {
-    "react-native": "*",
-    "react-native-web": "~0.13.7"
-  },
-  "unimodulePeerDependencies": {
-    "@unimodules/core": "*",
-    "unimodules-app-loader": "*",
-    "unimodules-font-interface": "*",
-    "unimodules-image-loader-interface": "*",
-    "unimodules-permissions-interface": "*"
-  },
   "dependencies": {
     "invariant": "^2.2.4",
     "lodash": "^4.5.0"

--- a/packages/expo-ads-admob/CHANGELOG.md
+++ b/packages/expo-ads-admob/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Remove peerDependencies and unimodulePeerDependencies from Expo modules. ([#11980](https://github.com/expo/expo/pull/11980) by [@brentvatne](https://github.com/brentvatne))
+
 ## 9.0.0 — 2021-01-15
 
 ### 🛠 Breaking changes

--- a/packages/expo-ads-admob/package.json
+++ b/packages/expo-ads-admob/package.json
@@ -34,11 +34,6 @@
   "jest": {
     "preset": "expo-module-scripts/ios"
   },
-  "peerDependencies": {
-    "@unimodules/core": "*",
-    "react": "*",
-    "react-native": "*"
-  },
   "dependencies": {
     "@expo/config-plugins": "^1.0.18"
   },

--- a/packages/expo-ads-facebook/CHANGELOG.md
+++ b/packages/expo-ads-facebook/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Remove peerDependencies and unimodulePeerDependencies from Expo modules. ([#11980](https://github.com/expo/expo/pull/11980) by [@brentvatne](https://github.com/brentvatne))
+
 ## 9.0.0 — 2021-01-15
 
 ### 🛠 Breaking changes

--- a/packages/expo-ads-facebook/package.json
+++ b/packages/expo-ads-facebook/package.json
@@ -34,13 +34,6 @@
     "fbemitter": "^2.1.1",
     "nullthrows": "^1.1.0"
   },
-  "unimodulePeerDependencies": {
-    "@unimodules/core": "*"
-  },
-  "peerDependencies": {
-    "react": "*",
-    "react-native": "*"
-  },
   "devDependencies": {
     "expo-module-scripts": "^2.0.0"
   }

--- a/packages/expo-analytics-segment/CHANGELOG.md
+++ b/packages/expo-analytics-segment/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Remove peerDependencies and unimodulePeerDependencies from Expo modules. ([#11980](https://github.com/expo/expo/pull/11980) by [@brentvatne](https://github.com/brentvatne))
+
 ## 10.0.0 — 2021-01-15
 
 ### 🛠 Breaking changes
@@ -50,3 +52,4 @@ _This version does not introduce any user-facing changes._
 ## 8.2.0 — 2020-05-27
 
 _This version does not introduce any user-facing changes._
+```

--- a/packages/expo-analytics-segment/package.json
+++ b/packages/expo-analytics-segment/package.json
@@ -34,14 +34,6 @@
   "jest": {
     "preset": "expo-module-scripts"
   },
-  "unimodulePeerDependencies": {
-    "@unimodules/core": "*",
-    "unimodules-constants-interface": "*"
-  },
-  "peerDependencies": {
-    "react": "*",
-    "react-native": "*"
-  },
   "devDependencies": {
     "expo-module-scripts": "^2.0.0"
   }

--- a/packages/expo-app-auth/CHANGELOG.md
+++ b/packages/expo-app-auth/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### 🐛 Bug fixes
 
+- Remove peerDependencies and unimodulePeerDependencies from Expo modules. ([#11980](https://github.com/expo/expo/pull/11980) by [@brentvatne](https://github.com/brentvatne))
+
 ## 10.0.0 — 2021-01-15
 
 ### 🛠 Breaking changes

--- a/packages/expo-app-auth/package.json
+++ b/packages/expo-app-auth/package.json
@@ -43,10 +43,6 @@
   "jest": {
     "preset": "expo-module-scripts"
   },
-  "peerDependencies": {
-    "@unimodules/core": "*",
-    "unimodules-constants-interface": "*"
-  },
   "dependencies": {
     "@expo/config-plugins": "^1.0.18",
     "invariant": "^2.2.4"

--- a/packages/expo-apple-authentication/CHANGELOG.md
+++ b/packages/expo-apple-authentication/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Remove peerDependencies and unimodulePeerDependencies from Expo modules. ([#11980](https://github.com/expo/expo/pull/11980) by [@brentvatne](https://github.com/brentvatne))
+
 ## 3.0.0 — 2021-01-15
 
 ### 🛠 Breaking changes

--- a/packages/expo-apple-authentication/package.json
+++ b/packages/expo-apple-authentication/package.json
@@ -31,14 +31,6 @@
   "author": "650 Industries, Inc.",
   "license": "MIT",
   "homepage": "https://docs.expo.io/versions/latest/sdk/apple-authentication/",
-  "unimodulePeerDependencies": {
-    "@unimodules/core": "*",
-    "@unimodules/react-native-adapter": "*"
-  },
-  "peerDependencies": {
-    "react": "*",
-    "react-native": "*"
-  },
   "dependencies": {
     "@expo/config-plugins": "^1.0.18"
   },

--- a/packages/expo-application/CHANGELOG.md
+++ b/packages/expo-application/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Remove peerDependencies and unimodulePeerDependencies from Expo modules. ([#11980](https://github.com/expo/expo/pull/11980) by [@brentvatne](https://github.com/brentvatne))
+
 ## 3.0.0 — 2021-01-15
 
 ### 🛠 Breaking changes

--- a/packages/expo-application/package.json
+++ b/packages/expo-application/package.json
@@ -31,8 +31,5 @@
   "homepage": "https://docs.expo.io/versions/latest/sdk/application/",
   "devDependencies": {
     "expo-module-scripts": "^2.0.0"
-  },
-  "peerDependencies": {
-    "@unimodules/core": "*"
   }
 }

--- a/packages/expo-asset/CHANGELOG.md
+++ b/packages/expo-asset/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Remove peerDependencies and unimodulePeerDependencies from Expo modules. ([#11980](https://github.com/expo/expo/pull/11980) by [@brentvatne](https://github.com/brentvatne))
+
 ## 8.2.2 — 2021-01-15
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-asset/package.json
+++ b/packages/expo-asset/package.json
@@ -36,16 +36,6 @@
   "jest": {
     "preset": "expo-module-scripts/ios"
   },
-  "unimodulePeerDependencies": {
-    "@unimodules/core": "*",
-    "expo-constants": "*",
-    "expo-file-system": "*",
-    "expo-updates": "*"
-  },
-  "peerDependencies": {
-    "react": "*",
-    "react-native": "*"
-  },
   "dependencies": {
     "blueimp-md5": "^2.10.0",
     "invariant": "^2.2.4",

--- a/packages/expo-auth-session/CHANGELOG.md
+++ b/packages/expo-auth-session/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Remove peerDependencies and unimodulePeerDependencies from Expo modules. ([#11980](https://github.com/expo/expo/pull/11980) by [@brentvatne](https://github.com/brentvatne))
+
 ## 3.1.0 — 2021-01-15
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-auth-session/package.json
+++ b/packages/expo-auth-session/package.json
@@ -33,9 +33,6 @@
   "author": "650 Industries, Inc.",
   "license": "MIT",
   "homepage": "https://docs.expo.io/versions/latest/sdk/auth-session",
-  "peerDependencies": {
-    "expo-random": "^10.0.0"
-  },
   "dependencies": {
     "expo-constants": "^10.0.1",
     "expo-crypto": "^9.0.0",

--- a/packages/expo-auth-session/package.json
+++ b/packages/expo-auth-session/package.json
@@ -45,6 +45,14 @@
     "@types/qs": "^6.5.3",
     "expo-module-scripts": "^2.0.0"
   },
+  "peerDependencies": {
+    "expo-random": "*"
+  },
+  "peerDependenciesMeta": {
+    "expo-random": {
+      "optional": true
+    }
+  },
   "jest": {
     "preset": "expo-module-scripts"
   }

--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### 🐛 Bug fixes
 
+- Remove peerDependencies and unimodulePeerDependencies from Expo modules. ([#11980](https://github.com/expo/expo/pull/11980) by [@brentvatne](https://github.com/brentvatne))
+
 ## 9.0.0 — 2021-01-14
 
 ### ⚠️ Notices

--- a/packages/expo-av/package.json
+++ b/packages/expo-av/package.json
@@ -31,13 +31,6 @@
   "author": "650 Industries, Inc.",
   "license": "MIT",
   "homepage": "https://docs.expo.io/versions/latest/sdk/av/",
-  "peerDependencies": {
-    "@unimodules/core": "*",
-    "expo-asset": "*",
-    "react": "*",
-    "react-native": "*",
-    "unimodules-permissions-interface": "*"
-  },
   "devDependencies": {
     "expo-module-scripts": "^2.0.0"
   },

--- a/packages/expo-barcode-scanner/CHANGELOG.md
+++ b/packages/expo-barcode-scanner/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 🐛 Bug fixes
 
+- Remove peerDependencies and unimodulePeerDependencies from Expo modules. ([#11980](https://github.com/expo/expo/pull/11980) by [@brentvatne](https://github.com/brentvatne))
+
 ## 10.0.0 — 2021-01-15
 
 ### ⚠️ Notices

--- a/packages/expo-barcode-scanner/package.json
+++ b/packages/expo-barcode-scanner/package.json
@@ -34,13 +34,6 @@
   "jest": {
     "preset": "expo-module-scripts/ios"
   },
-  "peerDependencies": {
-    "@unimodules/core": "*",
-    "react": "*",
-    "react-native": "*",
-    "unimodules-barcode-scanner-interface": "*",
-    "unimodules-permissions-interface": "*"
-  },
   "dependencies": {
     "@expo/config-plugins": "^1.0.18"
   },

--- a/packages/expo-battery/CHANGELOG.md
+++ b/packages/expo-battery/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Remove peerDependencies and unimodulePeerDependencies from Expo modules. ([#11980](https://github.com/expo/expo/pull/11980) by [@brentvatne](https://github.com/brentvatne))
+
 ## 4.0.0 — 2021-01-15
 
 ### 🛠 Breaking changes

--- a/packages/expo-battery/package.json
+++ b/packages/expo-battery/package.json
@@ -31,8 +31,5 @@
   "homepage": "https://docs.expo.io/versions/latest/sdk/battery/",
   "devDependencies": {
     "expo-module-scripts": "^2.0.0"
-  },
-  "peerDependencies": {
-    "@unimodules/core": "~5.1.2"
   }
 }

--- a/packages/expo-blur/CHANGELOG.md
+++ b/packages/expo-blur/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Remove peerDependencies and unimodulePeerDependencies from Expo modules. ([#11980](https://github.com/expo/expo/pull/11980) by [@brentvatne](https://github.com/brentvatne))
+
 ## 9.0.0 — 2021-01-15
 
 ### 🛠 Breaking changes

--- a/packages/expo-blur/package.json
+++ b/packages/expo-blur/package.json
@@ -33,11 +33,6 @@
   "author": "650 Industries, Inc.",
   "license": "MIT",
   "homepage": "https://docs.expo.io/versions/latest/sdk/blur-view/",
-  "peerDependencies": {
-    "@unimodules/core": "*",
-    "react": "*",
-    "react-native": "*"
-  },
   "devDependencies": {
     "expo-module-scripts": "^2.0.0"
   }

--- a/packages/expo-branch/CHANGELOG.md
+++ b/packages/expo-branch/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Remove peerDependencies and unimodulePeerDependencies from Expo modules. ([#11980](https://github.com/expo/expo/pull/11980) by [@brentvatne](https://github.com/brentvatne))
+
 ## 4.0.0 — 2021-01-15
 
 ### ⚠️ Notices

--- a/packages/expo-branch/package.json
+++ b/packages/expo-branch/package.json
@@ -31,10 +31,6 @@
   "author": "650 Industries, Inc.",
   "license": "MIT",
   "homepage": "https://docs.expo.io/versions/latest/sdk/branch/",
-  "peerDependencies": {
-    "@unimodules/core": "*",
-    "@unimodules/react-native-adapter": "*"
-  },
   "dependencies": {
     "@expo/config-plugins": "^1.0.18",
     "react-native-branch": "5.0.0"

--- a/packages/expo-brightness/CHANGELOG.md
+++ b/packages/expo-brightness/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### 🐛 Bug fixes
 
+- Remove peerDependencies and unimodulePeerDependencies from Expo modules. ([#11980](https://github.com/expo/expo/pull/11980) by [@brentvatne](https://github.com/brentvatne))
+
 ## 9.0.0 — 2021-01-15
 
 ### 🛠 Breaking changes

--- a/packages/expo-brightness/package.json
+++ b/packages/expo-brightness/package.json
@@ -34,14 +34,6 @@
   "jest": {
     "preset": "expo-module-scripts"
   },
-  "unimodulePeerDependencies": {
-    "@unimodules/core": "*",
-    "unimodules-permissions-interface": "*"
-  },
-  "peerDependencies": {
-    "react": "*",
-    "react-native": "*"
-  },
   "devDependencies": {
     "expo-module-scripts": "^2.0.0"
   },

--- a/packages/expo-calendar/CHANGELOG.md
+++ b/packages/expo-calendar/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### 🐛 Bug fixes
 
+- Remove peerDependencies and unimodulePeerDependencies from Expo modules. ([#11980](https://github.com/expo/expo/pull/11980) by [@brentvatne](https://github.com/brentvatne))
+
 ## 9.0.0 — 2021-01-15
 
 ### 🛠 Breaking changes

--- a/packages/expo-calendar/package.json
+++ b/packages/expo-calendar/package.json
@@ -34,14 +34,6 @@
   "jest": {
     "preset": "expo-module-scripts/ios"
   },
-  "unimodulePeerDependencies": {
-    "@unimodules/core": "*",
-    "unimodules-permissions-interface": "*"
-  },
-  "peerDependencies": {
-    "react": "*",
-    "react-native": "*"
-  },
   "devDependencies": {
     "expo-module-scripts": "^2.0.0"
   },

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 ### 🐛 Bug fixes
 
+- Remove peerDependencies and unimodulePeerDependencies from Expo modules. ([#11980](https://github.com/expo/expo/pull/11980) by [@brentvatne](https://github.com/brentvatne))
+
 ## 10.0.0 — 2021-01-15
 
 ### ⚠️ Notices

--- a/packages/expo-camera/package.json
+++ b/packages/expo-camera/package.json
@@ -33,16 +33,6 @@
   "jest": {
     "preset": "expo-module-scripts"
   },
-  "peerDependencies": {
-    "@unimodules/core": "*",
-    "react": "*",
-    "react-native": "*",
-    "unimodules-barcode-scanner-interface": "*",
-    "unimodules-camera-interface": "*",
-    "unimodules-face-detector-interface": "*",
-    "unimodules-file-system-interface": "*",
-    "unimodules-permissions-interface": "*"
-  },
   "dependencies": {
     "@expo/config-plugins": "^1.0.18",
     "@koale/useworker": "^3.2.1",

--- a/packages/expo-cellular/CHANGELOG.md
+++ b/packages/expo-cellular/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Remove peerDependencies and unimodulePeerDependencies from Expo modules. ([#11980](https://github.com/expo/expo/pull/11980) by [@brentvatne](https://github.com/brentvatne))
+
 ## 3.0.0 — 2021-01-15
 
 ### 🛠 Breaking changes

--- a/packages/expo-cellular/package.json
+++ b/packages/expo-cellular/package.json
@@ -31,8 +31,5 @@
   "homepage": "https://docs.expo.io/versions/latest/sdk/cellular/",
   "devDependencies": {
     "expo-module-scripts": "^2.0.0"
-  },
-  "peerDependencies": {
-    "@unimodules/core": "*"
   }
 }

--- a/packages/expo-checkbox/CHANGELOG.md
+++ b/packages/expo-checkbox/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Remove peerDependencies and unimodulePeerDependencies from Expo modules. ([#11980](https://github.com/expo/expo/pull/11980) by [@brentvatne](https://github.com/brentvatne))
+
 ## 1.0.2 — 2021-01-15
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-checkbox/package.json
+++ b/packages/expo-checkbox/package.json
@@ -29,10 +29,6 @@
   "author": "650 Industries, Inc.",
   "license": "MIT",
   "homepage": "https://docs.expo.io/versions/latest/sdk/checkbox",
-  "peerDependencies": {
-    "react": "*",
-    "react-native": "*"
-  },
   "devDependencies": {
     "expo-module-scripts": "^2.0.0"
   },

--- a/packages/expo-clipboard/CHANGELOG.md
+++ b/packages/expo-clipboard/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Remove peerDependencies and unimodulePeerDependencies from Expo modules. ([#11980](https://github.com/expo/expo/pull/11980) by [@brentvatne](https://github.com/brentvatne))
+
 ## 1.0.1 — 2020-12-08
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-clipboard/package.json
+++ b/packages/expo-clipboard/package.json
@@ -29,10 +29,6 @@
   "author": "650 Industries, Inc.",
   "license": "MIT",
   "homepage": "https://docs.expo.io/versions/latest/sdk/clipboard",
-  "peerDependencies": {
-    "react": "*",
-    "react-native": "*"
-  },
   "devDependencies": {
     "expo-module-scripts": "^2.0.0"
   },

--- a/packages/expo-contacts/CHANGELOG.md
+++ b/packages/expo-contacts/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### 🐛 Bug fixes
 
+- Remove peerDependencies and unimodulePeerDependencies from Expo modules. ([#11980](https://github.com/expo/expo/pull/11980) by [@brentvatne](https://github.com/brentvatne))
+
 ## 9.0.0 — 2021-01-15
 
 ### ⚠️ Notices

--- a/packages/expo-contacts/package.json
+++ b/packages/expo-contacts/package.json
@@ -33,14 +33,6 @@
   "jest": {
     "preset": "expo-module-scripts"
   },
-  "unimodulePeerDependencies": {
-    "@unimodules/core": "*",
-    "unimodules-permissions-interface": "*"
-  },
-  "peerDependencies": {
-    "react": "*",
-    "react-native": "*"
-  },
   "dependencies": {
     "@expo/config-plugins": "^1.0.18",
     "uuid": "^3.4.0"

--- a/packages/expo-dev-launcher/package.json
+++ b/packages/expo-dev-launcher/package.json
@@ -27,10 +27,6 @@
   "author": "650 Industries, Inc.",
   "license": "MIT",
   "homepage": "https://docs.expo.io",
-  "peerDependencies": {
-    "react": "^16.8.1",
-    "react-native": ">=0.60.0-rc.0 <1.0.x"
-  },
   "devDependencies": {
     "babel-preset-expo": "~8.3.0",
     "expo-module-scripts": "^2.0.0",

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Remove peerDependencies and unimodulePeerDependencies from Expo modules. ([#11980](https://github.com/expo/expo/pull/11980) by [@brentvatne](https://github.com/brentvatne))
+
 ## 0.3.1 — 2021-02-03
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-dev-menu/package.json
+++ b/packages/expo-dev-menu/package.json
@@ -44,9 +44,6 @@
     "expo-dev-menu-interface": "0.1.2",
     "fuse.js": "^6.4.6"
   },
-  "peerDependencies": {
-    "react-native": ">=0.62.0"
-  },
   "devDependencies": {
     "@react-navigation/core": "5.10.0",
     "@react-navigation/native": "5.5.1",

--- a/packages/expo-error-recovery/CHANGELOG.md
+++ b/packages/expo-error-recovery/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Remove peerDependencies and unimodulePeerDependencies from Expo modules. ([#11980](https://github.com/expo/expo/pull/11980) by [@brentvatne](https://github.com/brentvatne))
+
 ## 2.0.1 — 2021-01-15
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-error-recovery/package.json
+++ b/packages/expo-error-recovery/package.json
@@ -31,13 +31,6 @@
   "author": "650 Industries, Inc.",
   "license": "MIT",
   "homepage": "https://docs.expo.io/versions/latest/sdk/error-recovery/",
-  "unimodulePeerDependencies": {
-    "@unimodules/core": "*"
-  },
-  "peerDependencies": {
-    "react": "*",
-    "react-native": "*"
-  },
   "devDependencies": {
     "expo-module-scripts": "^2.0.0"
   },

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### 🐛 Bug fixes
 
 - Fixed copying movies from assets not working on iOS. ([#11749](https://github.com/expo/expo/pull/11749) by [@lukmccall](https://github.com/lukmccall))
+- Remove peerDependencies and unimodulePeerDependencies from Expo modules. ([#11980](https://github.com/expo/expo/pull/11980) by [@brentvatne](https://github.com/brentvatne))
 
 ## 10.0.0 — 2021-01-15
 

--- a/packages/expo-file-system/package.json
+++ b/packages/expo-file-system/package.json
@@ -34,13 +34,6 @@
   "jest": {
     "preset": "expo-module-scripts"
   },
-  "unimodulePeerDependencies": {
-    "@unimodules/core": "*"
-  },
-  "peerDependencies": {
-    "react": "*",
-    "react-native": "*"
-  },
   "dependencies": {
     "@expo/config-plugins": "^1.0.18",
     "uuid": "^3.4.0"

--- a/packages/expo-firebase-analytics/CHANGELOG.md
+++ b/packages/expo-firebase-analytics/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Remove peerDependencies and unimodulePeerDependencies from Expo modules. ([#11980](https://github.com/expo/expo/pull/11980) by [@brentvatne](https://github.com/brentvatne))
+
 ## 3.0.0 — 2021-01-15
 
 ### 🛠 Breaking changes

--- a/packages/expo-firebase-analytics/package.json
+++ b/packages/expo-firebase-analytics/package.json
@@ -35,14 +35,6 @@
   "jest": {
     "preset": "expo-module-scripts"
   },
-  "unimodulePeerDependencies": {
-    "@unimodules/core": "*",
-    "expo-constants": "*"
-  },
-  "peerDependencies": {
-    "react": "*",
-    "react-native": "*"
-  },
   "devDependencies": {
     "expo-module-scripts": "^2.0.0"
   },

--- a/packages/expo-firebase-recaptcha/CHANGELOG.md
+++ b/packages/expo-firebase-recaptcha/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Remove peerDependencies and unimodulePeerDependencies from Expo modules. ([#11980](https://github.com/expo/expo/pull/11980) by [@brentvatne](https://github.com/brentvatne))
+
 ## 1.4.0 — 2021-01-26
 
 ### 🎉 New features

--- a/packages/expo-firebase-recaptcha/package.json
+++ b/packages/expo-firebase-recaptcha/package.json
@@ -37,8 +37,5 @@
   },
   "dependencies": {
     "expo-firebase-core": "~2.0.0"
-  },
-  "peerDependencies": {
-    "react-native-webview": "*"
   }
 }

--- a/packages/expo-firebase-recaptcha/package.json
+++ b/packages/expo-firebase-recaptcha/package.json
@@ -37,5 +37,13 @@
   },
   "dependencies": {
     "expo-firebase-core": "~2.0.0"
+  },
+  "peerDependencies": {
+    "react-native-webview": "*"
+  },
+  "peerDependenciesMeta": {
+    "react-native-webview": {
+      "optional": true
+    }
   }
 }

--- a/packages/expo-font/CHANGELOG.md
+++ b/packages/expo-font/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Remove peerDependencies and unimodulePeerDependencies from Expo modules. ([#11980](https://github.com/expo/expo/pull/11980) by [@brentvatne](https://github.com/brentvatne))
+
 ## 9.0.0 — 2021-01-15
 
 ### 🛠 Breaking changes

--- a/packages/expo-font/package.json
+++ b/packages/expo-font/package.json
@@ -33,16 +33,6 @@
   "jest": {
     "preset": "expo-module-scripts"
   },
-  "unimodulePeerDependencies": {
-    "@unimodules/core": "*",
-    "expo-asset": "*",
-    "expo-constants": "*",
-    "unimodules-font-interface": "*"
-  },
-  "peerDependencies": {
-    "react": "*",
-    "react-native": "*"
-  },
   "dependencies": {
     "fontfaceobserver": "^2.1.0"
   },

--- a/packages/expo-gl/CHANGELOG.md
+++ b/packages/expo-gl/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### 🐛 Bug fixes
 
+- Remove peerDependencies and unimodulePeerDependencies from Expo modules. ([#11980](https://github.com/expo/expo/pull/11980) by [@brentvatne](https://github.com/brentvatne))
+
 ## 10.1.0 — 2021-01-15
 
 ### 🐛 Bug fixes

--- a/packages/expo-gl/package.json
+++ b/packages/expo-gl/package.json
@@ -36,13 +36,6 @@
   "jest": {
     "preset": "expo-module-scripts"
   },
-  "peerDependencies": {
-    "@unimodules/core": "*",
-    "react": "*",
-    "react-native": "*",
-    "unimodules-camera-interface": "*",
-    "unimodules-file-system-interface": "*"
-  },
   "dependencies": {
     "expo-gl-cpp": "~10.0.0",
     "invariant": "^2.2.4"

--- a/packages/expo-google-app-auth/CHANGELOG.md
+++ b/packages/expo-google-app-auth/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Remove peerDependencies and unimodulePeerDependencies from Expo modules. ([#11980](https://github.com/expo/expo/pull/11980) by [@brentvatne](https://github.com/brentvatne))
+
 ## 8.1.4 — 2020-11-17
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-google-app-auth/package.json
+++ b/packages/expo-google-app-auth/package.json
@@ -33,12 +33,6 @@
   "jest": {
     "preset": "expo-module-scripts"
   },
-  "peerDependencies": {
-    "@unimodules/core": "*",
-    "expo-constants": "*",
-    "react": "*",
-    "react-native": "*"
-  },
   "devDependencies": {
     "expo-module-scripts": "^2.0.0"
   },

--- a/packages/expo-google-sign-in/CHANGELOG.md
+++ b/packages/expo-google-sign-in/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Remove peerDependencies and unimodulePeerDependencies from Expo modules. ([#11980](https://github.com/expo/expo/pull/11980) by [@brentvatne](https://github.com/brentvatne))
+
 ## 9.0.0 — 2021-01-15
 
 ### ⚠️ Notices

--- a/packages/expo-google-sign-in/package.json
+++ b/packages/expo-google-sign-in/package.json
@@ -40,13 +40,6 @@
   "jest": {
     "preset": "expo-module-scripts/ios"
   },
-  "unimodulePeerDependencies": {
-    "@unimodules/core": "*",
-    "expo-constants": "*"
-  },
-  "peerDependencies": {
-    "react-native": "*"
-  },
   "dependencies": {
     "invariant": "^2.2.4"
   },

--- a/packages/expo-image-loader/CHANGELOG.md
+++ b/packages/expo-image-loader/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Remove peerDependencies and unimodulePeerDependencies from Expo modules. ([#11980](https://github.com/expo/expo/pull/11980) by [@brentvatne](https://github.com/brentvatne))
+
 ## 2.0.0 — 2021-01-15
 
 ### 🛠 Breaking changes

--- a/packages/expo-image-loader/package.json
+++ b/packages/expo-image-loader/package.json
@@ -19,9 +19,6 @@
   "author": "650 Industries, Inc.",
   "license": "MIT",
   "homepage": "https://github.com/expo/expo/tree/master/packages/expo-image-loader",
-  "peerDependencies": {
-    "react-native": ">= 0.60.0"
-  },
   "unimodulePeerDependencies": {
     "@unimodules/core": "*",
     "unimodules-image-loader-interface": "^5.0.0"

--- a/packages/expo-image-loader/package.json
+++ b/packages/expo-image-loader/package.json
@@ -18,9 +18,5 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://github.com/expo/expo/tree/master/packages/expo-image-loader",
-  "unimodulePeerDependencies": {
-    "@unimodules/core": "*",
-    "unimodules-image-loader-interface": "^5.0.0"
-  }
+  "homepage": "https://github.com/expo/expo/tree/master/packages/expo-image-loader"
 }

--- a/packages/expo-image/package.json
+++ b/packages/expo-image/package.json
@@ -26,10 +26,6 @@
   ],
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "peerDependencies": {
-    "react": "^16.8.1",
-    "react-native": ">=0.60.0-rc.0 <1.0.x"
-  },
   "devDependencies": {
     "expo-module-scripts": "^2.0.0"
   }

--- a/packages/expo-in-app-purchases/CHANGELOG.md
+++ b/packages/expo-in-app-purchases/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Remove peerDependencies and unimodulePeerDependencies from Expo modules. ([#11980](https://github.com/expo/expo/pull/11980) by [@brentvatne](https://github.com/brentvatne))
+
 ## 10.1.0 — 2021-02-02
 
 ### 🎉 New features

--- a/packages/expo-in-app-purchases/package.json
+++ b/packages/expo-in-app-purchases/package.json
@@ -29,13 +29,6 @@
   "author": "650 Industries, Inc.",
   "license": "MIT",
   "homepage": "https://docs.expo.io/versions/latest/sdk/in-app-purchases/",
-  "unimodulePeerDependencies": {
-    "@unimodules/core": "*"
-  },
-  "peerDependencies": {
-    "react": "*",
-    "react-native": "*"
-  },
   "devDependencies": {
     "expo-module-scripts": "^2.0.0"
   }

--- a/packages/expo-keep-awake/CHANGELOG.md
+++ b/packages/expo-keep-awake/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Remove peerDependencies and unimodulePeerDependencies from Expo modules. ([#11980](https://github.com/expo/expo/pull/11980) by [@brentvatne](https://github.com/brentvatne))
+
 ## 9.0.0 — 2021-01-15
 
 ### 🛠 Breaking changes

--- a/packages/expo-keep-awake/package.json
+++ b/packages/expo-keep-awake/package.json
@@ -31,13 +31,6 @@
   "author": "650 Industries, Inc.",
   "license": "MIT",
   "homepage": "https://docs.expo.io/versions/latest/sdk/keep-awake/",
-  "unimodulePeerDependencies": {
-    "@unimodules/core": "*"
-  },
-  "peerDependencies": {
-    "react": "*",
-    "react-native": "*"
-  },
   "devDependencies": {
     "expo-module-scripts": "^2.0.0"
   }

--- a/packages/expo-linear-gradient/CHANGELOG.md
+++ b/packages/expo-linear-gradient/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Remove peerDependencies and unimodulePeerDependencies from Expo modules. ([#11980](https://github.com/expo/expo/pull/11980) by [@brentvatne](https://github.com/brentvatne))
+
 ## 9.0.0 — 2021-01-15
 
 ### 🛠 Breaking changes

--- a/packages/expo-linear-gradient/package.json
+++ b/packages/expo-linear-gradient/package.json
@@ -33,13 +33,6 @@
   "author": "650 Industries, Inc.",
   "license": "MIT",
   "homepage": "https://docs.expo.io/versions/latest/sdk/linear-gradient/",
-  "unimodulePeerDependencies": {
-    "@unimodules/core": "*"
-  },
-  "peerDependencies": {
-    "react": "*",
-    "react-native": "*"
-  },
   "devDependencies": {
     "expo-module-scripts": "^2.0.0"
   }

--- a/packages/expo-linking/CHANGELOG.md
+++ b/packages/expo-linking/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Remove peerDependencies and unimodulePeerDependencies from Expo modules. ([#11980](https://github.com/expo/expo/pull/11980) by [@brentvatne](https://github.com/brentvatne))
+
 ## 2.1.1 — 2021-01-21
 
 ### 🎉 New features

--- a/packages/expo-linking/package.json
+++ b/packages/expo-linking/package.json
@@ -35,9 +35,6 @@
     "qs": "^6.5.0",
     "url-parse": "^1.4.4"
   },
-  "peerDependencies": {
-    "react-native": "*"
-  },
   "devDependencies": {
     "@types/qs": "^6.5.3",
     "expo-module-scripts": "^2.0.0"

--- a/packages/expo-local-authentication/CHANGELOG.md
+++ b/packages/expo-local-authentication/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### 🐛 Bug fixes
 
+- Remove peerDependencies and unimodulePeerDependencies from Expo modules. ([#11980](https://github.com/expo/expo/pull/11980) by [@brentvatne](https://github.com/brentvatne))
+
 ## 10.0.0 — 2021-01-15
 
 ### 🛠 Breaking changes

--- a/packages/expo-local-authentication/package.json
+++ b/packages/expo-local-authentication/package.json
@@ -37,14 +37,6 @@
   "jest": {
     "preset": "expo-module-scripts"
   },
-  "unimodulePeerDependencies": {
-    "@unimodules/core": "*",
-    "unimodules-constants-interface": "*"
-  },
-  "peerDependencies": {
-    "react": "*",
-    "react-native": "*"
-  },
   "dependencies": {
     "@expo/config-plugins": "^1.0.18",
     "invariant": "^2.2.4"

--- a/packages/expo-localization/CHANGELOG.md
+++ b/packages/expo-localization/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 🐛 Bug fixes
 
 - Fix invalid `region` property on Web when locale contains script or variant fields. ([#11663](https://github.com/expo/expo/pull/11663) by [@IjzerenHein](https://github.com/IjzerenHein))
+- Remove peerDependencies and unimodulePeerDependencies from Expo modules. ([#11980](https://github.com/expo/expo/pull/11980) by [@brentvatne](https://github.com/brentvatne))
 
 ## 10.0.0 — 2021-01-15
 

--- a/packages/expo-localization/package.json
+++ b/packages/expo-localization/package.json
@@ -41,9 +41,6 @@
   "dependencies": {
     "rtl-detect": "^1.0.2"
   },
-  "peerDependencies": {
-    "@unimodules/core": "~5.1.2"
-  },
   "devDependencies": {
     "expo-module-scripts": "^2.0.0"
   }

--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### 🐛 Bug fixes
 
 - Remove sticky notification on service stop on Android. ([#11775](https://github.com/expo/expo/pull/11775) by [@zaguiini](https://github.com/zaguiini))
+- Remove peerDependencies and unimodulePeerDependencies from Expo modules. ([#11980](https://github.com/expo/expo/pull/11980) by [@brentvatne](https://github.com/brentvatne))
 
 ## 11.0.0 — 2021-01-15
 

--- a/packages/expo-location/package.json
+++ b/packages/expo-location/package.json
@@ -38,11 +38,6 @@
   "jest": {
     "preset": "expo-module-scripts"
   },
-  "peerDependencies": {
-    "@unimodules/core": "*",
-    "unimodules-permissions-interface": "*",
-    "unimodules-task-manager-interface": "*"
-  },
   "devDependencies": {
     "expo-module-scripts": "^2.0.0"
   },

--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### 🐛 Bug fixes
 
+- Remove peerDependencies and unimodulePeerDependencies from Expo modules. ([#11980](https://github.com/expo/expo/pull/11980) by [@brentvatne](https://github.com/brentvatne))
+
 ## 11.0.0 — 2021-01-15
 
 ### ⚠️ Notices

--- a/packages/expo-media-library/package.json
+++ b/packages/expo-media-library/package.json
@@ -37,15 +37,6 @@
   "jest": {
     "preset": "expo-module-scripts/ios"
   },
-  "unimodulePeerDependencies": {
-    "@unimodules/core": "*",
-    "unimodules-permissions-interface": "*",
-    "unimodules-filesystem-interface": "*"
-  },
-  "peerDependencies": {
-    "react": "*",
-    "react-native": "*"
-  },
   "devDependencies": {
     "expo-module-scripts": "^2.0.0"
   },

--- a/packages/expo-module-template/CHANGELOG.md
+++ b/packages/expo-module-template/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Remove peerDependencies and unimodulePeerDependencies from Expo modules. ([#11980](https://github.com/expo/expo/pull/11980) by [@brentvatne](https://github.com/brentvatne))
+
 ## 9.0.0 — 2021-01-15
 
 ### 🛠 Breaking changes

--- a/packages/expo-module-template/package.json
+++ b/packages/expo-module-template/package.json
@@ -22,12 +22,5 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/module-template",
-  "unimodulePeerDependencies": {
-    "@unimodules/core": "*"
-  },
-  "peerDependencies": {
-    "react": "*",
-    "react-native": "*"
-  }
+  "homepage": "https://docs.expo.io/versions/latest/sdk/module-template"
 }

--- a/packages/expo-network/CHANGELOG.md
+++ b/packages/expo-network/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Remove peerDependencies and unimodulePeerDependencies from Expo modules. ([#11980](https://github.com/expo/expo/pull/11980) by [@brentvatne](https://github.com/brentvatne))
+
 ## 3.0.0 — 2021-01-15
 
 ### 🛠 Breaking changes

--- a/packages/expo-network/package.json
+++ b/packages/expo-network/package.json
@@ -26,6 +26,9 @@
   "bugs": {
     "url": "https://github.com/expo/expo/issues"
   },
+  "devDependencies": {
+    "expo-module-scripts": "~1.2.0"
+  },
   "author": "650 Industries, Inc.",
   "license": "MIT",
   "homepage": "https://docs.expo.io/versions/latest/sdk/network/",

--- a/packages/expo-network/package.json
+++ b/packages/expo-network/package.json
@@ -31,8 +31,5 @@
   "homepage": "https://docs.expo.io/versions/latest/sdk/network/",
   "devDependencies": {
     "expo-module-scripts": "^2.0.0"
-  },
-  "peerDependencies": {
-    "@unimodules/core": "*"
   }
 }

--- a/packages/expo-payments-stripe/CHANGELOG.md
+++ b/packages/expo-payments-stripe/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Remove peerDependencies and unimodulePeerDependencies from Expo modules. ([#11980](https://github.com/expo/expo/pull/11980) by [@brentvatne](https://github.com/brentvatne))
+
 ## 9.0.0 — 2021-01-15
 
 ### 🛠 Breaking changes

--- a/packages/expo-payments-stripe/package.json
+++ b/packages/expo-payments-stripe/package.json
@@ -32,13 +32,6 @@
   "author": "650 Industries, Inc.",
   "license": "MIT",
   "homepage": "https://docs.expo.io/versions/latest/sdk/payments/",
-  "unimodulePeerDependencies": {
-    "@unimodules/core": "*"
-  },
-  "peerDependencies": {
-    "react": "*",
-    "react-native": "*"
-  },
   "dependencies": {
     "@expo/config-plugins": "^1.0.18",
     "prop-types": "^15.6.0"

--- a/packages/expo-permissions/CHANGELOG.md
+++ b/packages/expo-permissions/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Remove peerDependencies and unimodulePeerDependencies from Expo modules. ([#11980](https://github.com/expo/expo/pull/11980) by [@brentvatne](https://github.com/brentvatne))
+
 ## 11.0.0 — 2021-01-15
 
 ### 🛠 Breaking changes

--- a/packages/expo-permissions/package.json
+++ b/packages/expo-permissions/package.json
@@ -33,14 +33,6 @@
   "jest": {
     "preset": "expo-module-scripts/ios"
   },
-  "unimodulePeerDependencies": {
-    "@unimodules/core": "*",
-    "unimodules-permissions-interface": "*"
-  },
-  "peerDependencies": {
-    "react": "*",
-    "react-native": "*"
-  },
   "devDependencies": {
     "@testing-library/react-hooks": "^3.3.0",
     "expo-module-scripts": "^2.0.0"

--- a/packages/expo-print/CHANGELOG.md
+++ b/packages/expo-print/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Remove peerDependencies and unimodulePeerDependencies from Expo modules. ([#11980](https://github.com/expo/expo/pull/11980) by [@brentvatne](https://github.com/brentvatne))
+
 ## 10.0.0 — 2021-01-15
 
 ### ⚠️ Notices

--- a/packages/expo-print/package.json
+++ b/packages/expo-print/package.json
@@ -33,11 +33,6 @@
   "jest": {
     "preset": "expo-module-scripts/ios"
   },
-  "peerDependencies": {
-    "@unimodules/core": "*",
-    "react": "*",
-    "react-native": "*"
-  },
   "devDependencies": {
     "expo-module-scripts": "^2.0.0"
   }

--- a/packages/expo-speech/CHANGELOG.md
+++ b/packages/expo-speech/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Remove peerDependencies and unimodulePeerDependencies from Expo modules. ([#11980](https://github.com/expo/expo/pull/11980) by [@brentvatne](https://github.com/brentvatne))
+
 ## 9.0.0 — 2021-01-15
 
 ### 🛠 Breaking changes

--- a/packages/expo-speech/package.json
+++ b/packages/expo-speech/package.json
@@ -35,13 +35,6 @@
   "jest": {
     "preset": "expo-module-scripts/ios"
   },
-  "unimodulePeerDependencies": {
-    "@unimodules/core": "*"
-  },
-  "peerDependencies": {
-    "react": "*",
-    "react-native": "*"
-  },
   "devDependencies": {
     "expo-module-scripts": "^2.0.0"
   }

--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Remove peerDependencies and unimodulePeerDependencies from Expo modules. ([#11980](https://github.com/expo/expo/pull/11980) by [@brentvatne](https://github.com/brentvatne))
+
 ## 9.0.0 — 2021-01-15
 
 ### 🛠 Breaking changes

--- a/packages/expo-sqlite/package.json
+++ b/packages/expo-sqlite/package.json
@@ -35,13 +35,6 @@
   "jest": {
     "preset": "expo-module-scripts/ios"
   },
-  "unimodulePeerDependencies": {
-    "@unimodules/core": "*"
-  },
-  "peerDependencies": {
-    "react": "*",
-    "react-native": "*"
-  },
   "dependencies": {
     "@expo/websql": "^1.0.1",
     "lodash": "^4.17.15"

--- a/packages/expo-standard-web-crypto/package.json
+++ b/packages/expo-standard-web-crypto/package.json
@@ -29,9 +29,6 @@
   ],
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "peerDependencies": {
-    "expo-random": "11.0.0"
-  },
   "devDependencies": {
     "expo-module-scripts": "^2.0.0",
     "expo-random": "~11.0.0"

--- a/packages/expo-standard-web-crypto/package.json
+++ b/packages/expo-standard-web-crypto/package.json
@@ -32,5 +32,13 @@
   "devDependencies": {
     "expo-module-scripts": "^2.0.0",
     "expo-random": "~11.0.0"
+  },
+  "peerDependencies": {
+    "expo-random": "*"
+  },
+  "peerDependenciesMeta": {
+    "expo-random": {
+      "optional": true
+    }
   }
 }

--- a/packages/expo-store-review/CHANGELOG.md
+++ b/packages/expo-store-review/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 🐛 Bug fixes
 
+- Remove peerDependencies and unimodulePeerDependencies from Expo modules. ([#11980](https://github.com/expo/expo/pull/11980) by [@brentvatne](https://github.com/brentvatne))
+
 ## 3.0.0 — 2021-01-15
 
 ### 🛠 Breaking changes

--- a/packages/expo-store-review/package.json
+++ b/packages/expo-store-review/package.json
@@ -29,13 +29,6 @@
   "author": "650 Industries, Inc.",
   "license": "MIT",
   "homepage": "https://docs.expo.io/versions/latest/sdk/storereview/",
-  "peerDependencies": {
-    "@unimodules/core": "*",
-    "expo-constants": "~9.0.0",
-    "expo-linking": "~1.0.1",
-    "react": "*",
-    "react-native": "*"
-  },
   "devDependencies": {
     "expo-module-scripts": "^2.0.0"
   }

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Improved support for `assetUrlOverride` in legacy self-hosted apps ([#11601](https://github.com/expo/expo/pull/11601))
 - Stop expecting data and publicManifest root level keys for EAS manifests ([#11613](https://github.com/expo/expo/pull/11613) by [@esamelson](https://github.com/esamelson))
 - Stop overriding cache-control headers for non-legacy manifests ([#11875](https://github.com/expo/expo/pull/11875) by [@esamelson](https://github.com/esamelson))
+- Remove peerDependencies and unimodulePeerDependencies from Expo modules. ([#11980](https://github.com/expo/expo/pull/11980) by [@brentvatne](https://github.com/brentvatne))
 
 ## 0.4.2 - 2020-02-16
 
@@ -49,8 +50,8 @@
 ### 🛠 Breaking changes
 
 - This version adds an internal database migration, which means that when a user's device upgrades from an app with `expo-updates@0.3.x` to an app with `expo-updates@0.4.x`, any updates they had previously downloaded will no longer be accessible.
-  - For **managed workflow apps**, this is inconsequential as this upgrade will be part of a major SDK version upgrade. You do not need to do anything if your app is made using the managed workflow.
-  - For **bare workflow apps**, this means updates downloaded on clients running `expo-updates@0.3.x` will need to be redownloaded in order to run after those clients are upgraded to `expo-updates@0.4.x`. We recommend incrementing your runtime/SDK version after updating to `expo-updates@0.4.x`, and republishing any OTA updates that you do not intend to distribute embedded in your application binary.
+  -   For **managed workflow apps**, this is inconsequential as this upgrade will be part of a major SDK version upgrade. You do not need to do anything if your app is made using the managed workflow.
+  -   For **bare workflow apps**, this means updates downloaded on clients running `expo-updates@0.3.x` will need to be redownloaded in order to run after those clients are upgraded to `expo-updates@0.4.x`. We recommend incrementing your runtime/SDK version after updating to `expo-updates@0.4.x`, and republishing any OTA updates that you do not intend to distribute embedded in your application binary.
 
 ## 0.4.0 — 2020-11-17
 

--- a/packages/expo-updates/package.json
+++ b/packages/expo-updates/package.json
@@ -33,11 +33,6 @@
   "jest": {
     "preset": "expo-module-scripts"
   },
-  "unimodulePeerDependencies": {
-    "@unimodules/core": "*",
-    "expo-constants": "*",
-    "expo-file-system": "*"
-  },
   "dependencies": {
     "@expo/metro-config": "^0.1.16",
     "@expo/config-plugins": "^1.0.18",

--- a/packages/expo-video-thumbnails/CHANGELOG.md
+++ b/packages/expo-video-thumbnails/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Remove peerDependencies and unimodulePeerDependencies from Expo modules. ([#11980](https://github.com/expo/expo/pull/11980) by [@brentvatne](https://github.com/brentvatne))
+
 ## 5.0.0 — 2021-01-15
 
 ### 🛠 Breaking changes

--- a/packages/expo-video-thumbnails/package.json
+++ b/packages/expo-video-thumbnails/package.json
@@ -29,9 +29,6 @@
   "author": "650 Industries, Inc.",
   "license": "MIT",
   "homepage": "https://docs.expo.io/versions/latest/sdk/video-thumbnails/",
-  "peerDependencies": {
-    "@unimodules/core": "*"
-  },
   "devDependencies": {
     "expo-module-scripts": "^2.0.0"
   }

--- a/packages/expo-web-browser/CHANGELOG.md
+++ b/packages/expo-web-browser/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Remove peerDependencies and unimodulePeerDependencies from Expo modules. ([#11980](https://github.com/expo/expo/pull/11980) by [@brentvatne](https://github.com/brentvatne))
+
 ## 9.0.0 — 2021-01-15
 
 ### 🛠 Breaking changes

--- a/packages/expo-web-browser/package.json
+++ b/packages/expo-web-browser/package.json
@@ -35,13 +35,6 @@
   "jest": {
     "preset": "expo-module-scripts"
   },
-  "unimodulePeerDependencies": {
-    "@unimodules/core": "*"
-  },
-  "peerDependencies": {
-    "react": "*",
-    "react-native": "*"
-  },
   "devDependencies": {
     "expo-module-scripts": "^2.0.0"
   },

--- a/packages/html-elements/package.json
+++ b/packages/html-elements/package.json
@@ -35,9 +35,6 @@
   "jest": {
     "preset": "expo-module-scripts/enzyme"
   },
-  "peerDependencies": {
-    "react-native-web": "~0.13.7"
-  },
   "devDependencies": {
     "expo-module-scripts": "^2.0.0"
   }

--- a/packages/jest-expo-enzyme/package.json
+++ b/packages/jest-expo-enzyme/package.json
@@ -37,11 +37,6 @@
     "prepublishOnly": "expo-module prepublishOnly",
     "expo-module": "expo-module"
   },
-  "peerDependencies": {
-    "react": "16.13.1",
-    "react-native": "*",
-    "react-native-web": "~0.13.7"
-  },
   "dependencies": {
     "chalk": "^2.4.2",
     "enzyme": "~3.11.0",

--- a/packages/jest-expo/package.json
+++ b/packages/jest-expo/package.json
@@ -30,11 +30,6 @@
   "jest": {
     "preset": "jest-expo/universal"
   },
-  "peerDependencies": {
-    "react": "16.13.1",
-    "react-native": "*",
-    "react-native-web": "~0.13.7"
-  },
   "dependencies": {
     "@expo/config": "^3.2.3",
     "babel-jest": "^25.2.0",


### PR DESCRIPTION
# Why

Fixes ENG-186

This is a sub-issue of ensuring that npm 7's new auto-installation of peerDependencies behavior is compatible with Expo modules (ENG-46).

# How

Go over all Expo modules and remove `peerDependencies` and `unimodulesPeerDependencies`

# Test Plan

Let the CI run
