### PR TITLE
[ci] Fix cached node_module paths

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -44,10 +44,10 @@ jobs:
             # which node_modules are affected by the root yarn.lock
             node_modules
             apps/*/node_modules
-            home/*/node_modules
+            home/node_modules
             packages/*/node_modules
             packages/@unimodules/*/node_modules
-            react-native-lab/react-native/*/node_modules
+            react-native-lab/react-native/node_modules
           key: ${{ runner.os }}-modules-${{ hashFiles('yarn.lock') }}
       - name: 🧶 Install node modules in root dir
         # if: steps.node-modules-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
# Why
Some of the cached node_module paths weren't correct.

I don't think this will fix the CI failures that are related to node_modules caching, but we'd want to fix this anyway.

# How
Make them match the workspace package patterns in package.json.
