### PR TITLE
[expo-updates] invoke error block if manifest metadata doesn't persist successfully

### DIFF
--- a/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.h
+++ b/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.h
@@ -38,7 +38,7 @@ typedef NS_ENUM(NSInteger, EXUpdatesDatabaseHashType) {
 - (nullable NSDictionary *)manifestFiltersWithScopeKey:(NSString *)scopeKey error:(NSError ** _Nullable)error;
 - (void)setServerDefinedHeaders:(NSDictionary *)serverDefinedHeaders withScopeKey:(NSString *)scopeKey error:(NSError ** _Nullable)error;
 - (void)setManifestFilters:(NSDictionary *)manifestFilters withScopeKey:(NSString *)scopeKey error:(NSError ** _Nullable)error;
-- (void)setServerDataWithManifest:(EXUpdatesUpdate *)updateManifest error:(NSError ** _Nullable)error;
+- (void)setMetadataWithManifest:(EXUpdatesUpdate *)updateManifest error:(NSError ** _Nullable)error;
 
 @end
 

--- a/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.m
+++ b/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.m
@@ -517,7 +517,7 @@ static NSString * const EXUpdatesDatabaseServerDefinedHeadersKey = @"serverDefin
   [self _setJsonData:manifestFilters withKey:EXUpdatesDatabaseManifestFiltersKey scopeKey:scopeKey isInTransaction:NO error:error];
 }
 
-- (void)setServerDataWithManifest:(EXUpdatesUpdate *)updateManifest error:(NSError ** _Nullable)error
+- (void)setMetadataWithManifest:(EXUpdatesUpdate *)updateManifest error:(NSError ** _Nullable)error
 {
   sqlite3_exec(_db, "BEGIN;", NULL, NULL, NULL);
   if (updateManifest.serverDefinedHeaders) {


### PR DESCRIPTION
# Why

follow up from https://github.com/expo/expo/pull/11967#discussion_r578956114

# How

Dispatch back to the completion queue and invoke the success or error block depending on if the database operation succeeded.

(Also renamed serverData -> metadata, which was suggested in #11961 but I forgot to do on the iOS side)

# Test Plan

Will need to test manually by trying to download a manifest with an invalid structured field header and making sure the error block is invoked.
