### PR TITLE
[expo-updates] switch to SelectionPolicyFilterAware and use saved manifest filters

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.java
+++ b/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.java
@@ -27,7 +27,7 @@ import expo.modules.updates.db.entity.UpdateEntity;
 import expo.modules.updates.launcher.Launcher;
 import expo.modules.updates.launcher.NoDatabaseLauncher;
 import expo.modules.updates.launcher.SelectionPolicy;
-import expo.modules.updates.launcher.SelectionPolicyNewest;
+import expo.modules.updates.launcher.SelectionPolicyFilterAware;
 import expo.modules.updates.loader.EmbeddedLoader;
 import expo.modules.updates.loader.LoaderTask;
 import expo.modules.updates.manifest.Manifest;
@@ -186,7 +186,7 @@ public class ExpoUpdatesAppLoader {
 
     List<String> sdkVersionsList = new ArrayList<>(Constants.SDK_VERSIONS_LIST);
     sdkVersionsList.add(RNObject.UNVERSIONED);
-    SelectionPolicy selectionPolicy = new SelectionPolicyNewest(sdkVersionsList);
+    SelectionPolicy selectionPolicy = new SelectionPolicyFilterAware(sdkVersionsList);
 
     File directory;
     try {

--- a/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
+++ b/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
@@ -19,7 +19,7 @@
 #import <EXUpdates/EXUpdatesDatabase.h>
 #import <EXUpdates/EXUpdatesFileDownloader.h>
 #import <EXUpdates/EXUpdatesReaper.h>
-#import <EXUpdates/EXUpdatesSelectionPolicyNewest.h>
+#import <EXUpdates/EXUpdatesSelectionPolicyFilterAware.h>
 #import <EXUpdates/EXUpdatesUtils.h>
 #import <React/RCTUtils.h>
 #import <sys/utsname.h>
@@ -326,7 +326,7 @@ NS_ASSUME_NONNULL_BEGIN
 
   NSMutableArray *sdkVersions = [[EXVersions sharedInstance].versions[@"sdkVersions"] ?: @[[EXVersions sharedInstance].temporarySdkVersion] mutableCopy];
   [sdkVersions addObject:@"UNVERSIONED"];
-  _selectionPolicy = [[EXUpdatesSelectionPolicyNewest alloc] initWithRuntimeVersions:sdkVersions];
+  _selectionPolicy = [[EXUpdatesSelectionPolicyFilterAware alloc] initWithRuntimeVersions:sdkVersions];
 
   EXUpdatesAppLoaderTask *loaderTask = [[EXUpdatesAppLoaderTask alloc] initWithConfig:_config
                                                                              database:updatesDatabaseManager.database

--- a/ios/Exponent/Kernel/Services/EXUpdatesManager.m
+++ b/ios/Exponent/Kernel/Services/EXUpdatesManager.m
@@ -185,7 +185,7 @@ didRequestBundleWithCompletionQueue:(dispatch_queue_t)completionQueue
 
   EXUpdatesRemoteAppLoader *remoteAppLoader = [[EXUpdatesRemoteAppLoader alloc] initWithConfig:appLoader.config database:databaseKernelService.database directory:databaseKernelService.updatesDirectory completionQueue:completionQueue];
   [remoteAppLoader loadUpdateFromUrl:appLoader.config.updateUrl onManifest:^BOOL(EXUpdatesUpdate * _Nonnull update) {
-    BOOL shouldLoad = [appLoader.selectionPolicy shouldLoadNewUpdate:update withLaunchedUpdate:appLoader.appLauncher.launchedUpdate filters:nil];
+    BOOL shouldLoad = [appLoader.selectionPolicy shouldLoadNewUpdate:update withLaunchedUpdate:appLoader.appLauncher.launchedUpdate filters:update.manifestFilters];
     if (shouldLoad) {
       startBlock();
     }

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Added `SelectionPolicyFilterAware` to support EAS Update's manifest filters feature ([#11748](https://github.com/expo/expo/pull/11748) by [@esamelson](https://github.com/esamelson))
 - Parse & persist data from EAS Update manifest headers ([#11961](https://github.com/expo/expo/pull/11961) and [#11967](https://github.com/expo/expo/pull/11967) by [@esamelson](https://github.com/esamelson))
 - Accept signature in header (iOS). ([#11930](https://github.com/expo/expo/pull/11930) by [@jkhales](https://github.com/jkhales))
+- Switch to SelectionPolicyFilterAware and use persisted manifest filters ([#11993](https://github.com/expo/expo/pull/11993) by [@esamelson](https://github.com/esamelson))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.java
@@ -24,7 +24,7 @@ import expo.modules.updates.launcher.DatabaseLauncher;
 import expo.modules.updates.launcher.NoDatabaseLauncher;
 import expo.modules.updates.launcher.Launcher;
 import expo.modules.updates.launcher.SelectionPolicy;
-import expo.modules.updates.launcher.SelectionPolicyNewest;
+import expo.modules.updates.launcher.SelectionPolicyFilterAware;
 import expo.modules.updates.loader.LoaderTask;
 import expo.modules.updates.manifest.Manifest;
 
@@ -59,7 +59,7 @@ public class UpdatesController {
   private UpdatesController(Context context, UpdatesConfiguration updatesConfiguration) {
     mUpdatesConfiguration = updatesConfiguration;
     mDatabaseHolder = new DatabaseHolder(UpdatesDatabase.getInstance(context));
-    mSelectionPolicy = new SelectionPolicyNewest(UpdatesUtils.getRuntimeVersion(updatesConfiguration));
+    mSelectionPolicy = new SelectionPolicyFilterAware(UpdatesUtils.getRuntimeVersion(updatesConfiguration));
     if (context instanceof ReactApplication) {
       mReactNativeHost = new WeakReference<>(((ReactApplication) context).getReactNativeHost());
     }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.java
@@ -149,7 +149,7 @@ public class UpdatesModule extends ExportedModule {
             return;
           }
 
-          if (updatesService.getSelectionPolicy().shouldLoadNewUpdate(manifest.getUpdateEntity(), launchedUpdate, null)) {
+          if (updatesService.getSelectionPolicy().shouldLoadNewUpdate(manifest.getUpdateEntity(), launchedUpdate, manifest.getManifestFilters())) {
             updateInfo.putBoolean("isAvailable", true);
             updateInfo.putString("manifestString", manifest.getRawManifestJson().toString());
             promise.resolve(updateInfo);
@@ -193,7 +193,7 @@ public class UpdatesModule extends ExportedModule {
                 return updatesService.getSelectionPolicy().shouldLoadNewUpdate(
                   manifest.getUpdateEntity(),
                   updatesService.getLaunchedUpdate(),
-                  null);
+                  manifest.getManifestFilters());
               }
 
               @Override

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/Reaper.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/Reaper.java
@@ -2,10 +2,13 @@ package expo.modules.updates.db;
 
 import android.util.Log;
 
+import org.json.JSONObject;
+
 import expo.modules.updates.UpdatesConfiguration;
 import expo.modules.updates.launcher.SelectionPolicy;
 import expo.modules.updates.db.entity.AssetEntity;
 import expo.modules.updates.db.entity.UpdateEntity;
+import expo.modules.updates.manifest.ManifestMetadata;
 
 import java.io.File;
 import java.util.LinkedList;
@@ -23,7 +26,8 @@ public class Reaper {
 
     List<UpdateEntity> allUpdates = database.updateDao().loadAllUpdatesForScope(configuration.getScopeKey());
 
-    List<UpdateEntity> updatesToDelete = selectionPolicy.selectUpdatesToDelete(allUpdates, launchedUpdate, null);
+    JSONObject manifestFilters = ManifestMetadata.getManifestFilters(database, configuration);
+    List<UpdateEntity> updatesToDelete = selectionPolicy.selectUpdatesToDelete(allUpdates, launchedUpdate, manifestFilters);
     database.updateDao().deleteUpdates(updatesToDelete);
 
     List<AssetEntity> assetsToDelete = database.assetDao().deleteUnusedAssets();

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/DatabaseLauncher.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/DatabaseLauncher.java
@@ -3,6 +3,8 @@ package expo.modules.updates.launcher;
 import android.content.Context;
 import android.util.Log;
 
+import org.json.JSONObject;
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -19,6 +21,7 @@ import expo.modules.updates.db.enums.UpdateStatus;
 import expo.modules.updates.loader.EmbeddedLoader;
 import expo.modules.updates.loader.FileDownloader;
 import expo.modules.updates.manifest.Manifest;
+import expo.modules.updates.manifest.ManifestMetadata;
 
 public class DatabaseLauncher implements Launcher {
 
@@ -143,7 +146,8 @@ public class DatabaseLauncher implements Launcher {
       filteredLaunchableUpdates.add(update);
     }
 
-    return mSelectionPolicy.selectUpdateToLaunch(filteredLaunchableUpdates, null);
+    JSONObject manifestFilters = ManifestMetadata.getManifestFilters(database, mConfiguration);
+    return mSelectionPolicy.selectUpdateToLaunch(filteredLaunchableUpdates, manifestFilters);
   }
 
   private File ensureAssetExists(AssetEntity asset, UpdatesDatabase database, Context context) {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/LoaderTask.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/LoaderTask.java
@@ -6,6 +6,8 @@ import android.os.Handler;
 import android.os.HandlerThread;
 import android.util.Log;
 
+import org.json.JSONObject;
+
 import java.io.File;
 
 import androidx.annotation.Nullable;
@@ -19,6 +21,7 @@ import expo.modules.updates.launcher.DatabaseLauncher;
 import expo.modules.updates.launcher.Launcher;
 import expo.modules.updates.launcher.SelectionPolicy;
 import expo.modules.updates.manifest.Manifest;
+import expo.modules.updates.manifest.ManifestMetadata;
 
 public class LoaderTask {
 
@@ -224,7 +227,8 @@ public class LoaderTask {
       // so we can launch it
       UpdateEntity embeddedUpdate = EmbeddedLoader.readEmbeddedManifest(context, mConfiguration).getUpdateEntity();
       UpdateEntity launchableUpdate = launcher.getLaunchableUpdate(database, context);
-      if (mSelectionPolicy.shouldLoadNewUpdate(embeddedUpdate, launchableUpdate, null)) {
+      JSONObject manifestFilters = ManifestMetadata.getManifestFilters(database, mConfiguration);
+      if (mSelectionPolicy.shouldLoadNewUpdate(embeddedUpdate, launchableUpdate, manifestFilters)) {
         new EmbeddedLoader(context, mConfiguration, database, mDirectory).loadEmbeddedUpdate();
       }
     }
@@ -261,7 +265,8 @@ public class LoaderTask {
           public boolean onManifestLoaded(Manifest manifest) {
             if (mSelectionPolicy.shouldLoadNewUpdate(
                   manifest.getUpdateEntity(),
-                  mCandidateLauncher == null ? null : mCandidateLauncher.getLaunchedUpdate(), null)) {
+                  mCandidateLauncher == null ? null : mCandidateLauncher.getLaunchedUpdate(),
+                  manifest.getManifestFilters())) {
               mIsUpToDate = false;
               mCallback.onRemoteManifestLoaded(manifest);
               return true;

--- a/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesAppLauncherWithDatabase.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesAppLauncherWithDatabase.m
@@ -57,9 +57,16 @@ static NSString * const EXUpdatesAppLauncherErrorDomain = @"AppLauncher";
   dispatch_async(database.databaseQueue, ^{
     NSError *error;
     NSArray<EXUpdatesUpdate *> *launchableUpdates = [database launchableUpdatesWithConfig:config error:&error];
+    NSError *manifestFiltersError;
+    NSDictionary *manifestFilters = [database manifestFiltersWithScopeKey:config.scopeKey error:&manifestFiltersError];
     dispatch_async(completionQueue, ^{
       if (!launchableUpdates) {
         completion(error, nil);
+        return;
+      }
+      if (manifestFiltersError) {
+        completion(manifestFiltersError, nil);
+        return;
       }
 
       // We can only run an update marked as embedded if it's actually the update embedded in the
@@ -76,7 +83,7 @@ static NSString * const EXUpdatesAppLauncherErrorDomain = @"AppLauncher";
         [filteredLaunchableUpdates addObject:update];
       }
 
-      completion(nil, [selectionPolicy launchableUpdateWithUpdates:filteredLaunchableUpdates filters:nil]);
+      completion(nil, [selectionPolicy launchableUpdateWithUpdates:filteredLaunchableUpdates filters:manifestFilters]);
     });
   });
 }

--- a/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesReaper.m
+++ b/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesReaper.m
@@ -28,7 +28,15 @@ NS_ASSUME_NONNULL_BEGIN
       NSLog(@"Error reaping updates: %@", error.localizedDescription);
       return;
     }
-    NSArray<EXUpdatesUpdate *> *updatesToDelete = [selectionPolicy updatesToDeleteWithLaunchedUpdate:launchedUpdate updates:allUpdates filters:nil];
+
+    NSError *manifestFiltersError;
+    NSDictionary *manifestFilters = [database manifestFiltersWithScopeKey:config.scopeKey error:&manifestFiltersError];
+    if (manifestFiltersError) {
+      NSLog(@"Error selecting manifest filters while reaping updates: %@", error.localizedDescription);
+      return;
+    }
+
+    NSArray<EXUpdatesUpdate *> *updatesToDelete = [selectionPolicy updatesToDeleteWithLaunchedUpdate:launchedUpdate updates:allUpdates filters:manifestFilters];
     [database deleteUpdates:updatesToDelete error:&error];
     if (error) {
       NSLog(@"Error reaping updates: %@", error.localizedDescription);

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesAppController.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesAppController.m
@@ -5,7 +5,7 @@
 #import <EXUpdates/EXUpdatesAppLauncherNoDatabase.h>
 #import <EXUpdates/EXUpdatesAppLauncherWithDatabase.h>
 #import <EXUpdates/EXUpdatesReaper.h>
-#import <EXUpdates/EXUpdatesSelectionPolicyNewest.h>
+#import <EXUpdates/EXUpdatesSelectionPolicyFilterAware.h>
 #import <EXUpdates/EXUpdatesUtils.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -56,7 +56,7 @@ static NSString * const EXUpdatesErrorEventName = @"error";
   if (self = [super init]) {
     _config = [self _loadConfigFromExpoPlist];
     _database = [[EXUpdatesDatabase alloc] init];
-    _selectionPolicy = [[EXUpdatesSelectionPolicyNewest alloc] initWithRuntimeVersion:[EXUpdatesUtils getRuntimeVersionWithConfig:_config]];
+    _selectionPolicy = [[EXUpdatesSelectionPolicyFilterAware alloc] initWithRuntimeVersion:[EXUpdatesUtils getRuntimeVersionWithConfig:_config]];
     _assetFilesQueue = dispatch_queue_create("expo.controller.AssetFilesQueue", DISPATCH_QUEUE_SERIAL);
     _controllerQueue = dispatch_queue_create("expo.controller.ControllerQueue", DISPATCH_QUEUE_SERIAL);
     _isStarted = NO;
@@ -72,7 +72,7 @@ static NSString * const EXUpdatesErrorEventName = @"error";
                                  userInfo:@{}];
   }
   [_config loadConfigFromDictionary:configuration];
-  _selectionPolicy = [[EXUpdatesSelectionPolicyNewest alloc] initWithRuntimeVersion:[EXUpdatesUtils getRuntimeVersionWithConfig:_config]];
+  _selectionPolicy = [[EXUpdatesSelectionPolicyFilterAware alloc] initWithRuntimeVersion:[EXUpdatesUtils getRuntimeVersionWithConfig:_config]];
 }
 
 - (void)start

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesModule.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesModule.m
@@ -85,7 +85,7 @@ UM_EXPORT_METHOD_AS(checkForUpdateAsync,
                              successBlock:^(EXUpdatesUpdate *update) {
     EXUpdatesUpdate *launchedUpdate = self->_updatesService.launchedUpdate;
     id<EXUpdatesSelectionPolicy> selectionPolicy = self->_updatesService.selectionPolicy;
-    if ([selectionPolicy shouldLoadNewUpdate:update withLaunchedUpdate:launchedUpdate filters:nil]) {
+    if ([selectionPolicy shouldLoadNewUpdate:update withLaunchedUpdate:launchedUpdate filters:update.manifestFilters]) {
       resolve(@{
         @"isAvailable": @(YES),
         @"manifest": update.rawManifest
@@ -111,7 +111,7 @@ UM_EXPORT_METHOD_AS(fetchUpdateAsync,
 
   EXUpdatesRemoteAppLoader *remoteAppLoader = [[EXUpdatesRemoteAppLoader alloc] initWithConfig:_updatesService.config database:_updatesService.database directory:_updatesService.directory completionQueue:self.methodQueue];
   [remoteAppLoader loadUpdateFromUrl:_updatesService.config.updateUrl onManifest:^BOOL(EXUpdatesUpdate * _Nonnull update) {
-    return [self->_updatesService.selectionPolicy shouldLoadNewUpdate:update withLaunchedUpdate:self->_updatesService.launchedUpdate filters:nil];
+    return [self->_updatesService.selectionPolicy shouldLoadNewUpdate:update withLaunchedUpdate:self->_updatesService.launchedUpdate filters:update.manifestFilters];
   } success:^(EXUpdatesUpdate * _Nullable update) {
     if (update) {
       resolve(@{


### PR DESCRIPTION
# Why

resolves [ENG-262](https://linear.app/expo/issue/ENG-262/retrieve-stored-filters-in-correct-places-and-switch-to)

# How

Switch to SelectionPolicyFilterAware and read persisted manifest filters when:
- selecting an update to launch
- deciding whether to read the embedded update into the local db
- reaping

When deciding whether or not to load a new manifest from the server, we will use the manifest filters included in the response, rather than the previously persisted filters.

# Test Plan

Will need to test this e2e with a server that has manifest filters implemented -- @jkhales is this possible yet?
