### PR TITLE
[expo-updates] send saved serverDefinedHeaders in manifest requests

### DIFF
--- a/android/versioned-abis/expoview-abi38_0_0/src/main/java/abi38_0_0/host/exp/exponent/modules/api/UpdatesModule.java
+++ b/android/versioned-abis/expoview-abi38_0_0/src/main/java/abi38_0_0/host/exp/exponent/modules/api/UpdatesModule.java
@@ -80,7 +80,7 @@ public class UpdatesModule extends ReactContextBaseJavaModule {
     try {
       String manifestUrl = (String) mExperienceProperties.get(KernelConstants.MANIFEST_URL_KEY);
       ExpoUpdatesAppLoader appLoader = KernelProvider.getInstance().getAppLoaderForManifestUrl(manifestUrl);
-      FileDownloader.downloadManifest(appLoader.getUpdatesConfiguration(), getReactApplicationContext(), new FileDownloader.ManifestDownloadCallback() {
+      FileDownloader.downloadManifest(appLoader.getUpdatesConfiguration(), null, getReactApplicationContext(), new FileDownloader.ManifestDownloadCallback() {
         @Override
         public void onFailure(String message, Exception e) {
           promise.reject("E_FETCH_MANIFEST_FAILED", e);

--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/updates/UpdatesModule.java
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/updates/UpdatesModule.java
@@ -120,7 +120,7 @@ public class UpdatesModule extends ExportedModule {
         return;
       }
 
-      FileDownloader.downloadManifest(updatesService.getConfiguration(), getContext(), new FileDownloader.ManifestDownloadCallback() {
+      FileDownloader.downloadManifest(updatesService.getConfiguration(), null, getContext(), new FileDownloader.ManifestDownloadCallback() {
         @Override
         public void onFailure(String message, Exception e) {
           promise.reject("ERR_UPDATES_CHECK", message, e);

--- a/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/expo/modules/updates/UpdatesModule.java
+++ b/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/expo/modules/updates/UpdatesModule.java
@@ -120,7 +120,7 @@ public class UpdatesModule extends ExportedModule {
         return;
       }
 
-      FileDownloader.downloadManifest(updatesService.getConfiguration(), getContext(), new FileDownloader.ManifestDownloadCallback() {
+      FileDownloader.downloadManifest(updatesService.getConfiguration(), null, getContext(), new FileDownloader.ManifestDownloadCallback() {
         @Override
         public void onFailure(String message, Exception e) {
           promise.reject("ERR_UPDATES_CHECK", message, e);

--- a/ios/Exponent/Kernel/Services/EXUpdatesManager.m
+++ b/ios/Exponent/Kernel/Services/EXUpdatesManager.m
@@ -161,6 +161,7 @@ didRequestManifestWithCacheBehavior:(EXManifestCacheBehavior)cacheBehavior
   EXUpdatesFileDownloader *fileDownloader = [[EXUpdatesFileDownloader alloc] initWithUpdatesConfig:appLoader.config];
   [fileDownloader downloadManifestFromURL:appLoader.config.updateUrl
                              withDatabase:databaseKernelService.database
+                             extraHeaders:nil
                              successBlock:^(EXUpdatesUpdate *update) {
     success(update.rawManifest);
   } errorBlock:^(NSError *error, NSURLResponse *response) {

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Accept signature in header (iOS). ([#11930](https://github.com/expo/expo/pull/11930) by [@jkhales](https://github.com/jkhales))
 - Switch to SelectionPolicyFilterAware and use persisted manifest filters ([#11993](https://github.com/expo/expo/pull/11993) by [@esamelson](https://github.com/esamelson))
 - Make manifest filters key search case-insensitive ([#12015](https://github.com/expo/expo/pull/12015) by [@esamelson](https://github.com/esamelson))
+- Send persisted serverDefinedHeaders in manifest requests ([#11994](https://github.com/expo/expo/pull/11994) by [@esamelson](https://github.com/esamelson))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/FileDownloaderTest.java
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/FileDownloaderTest.java
@@ -3,6 +3,8 @@ package expo.modules.updates.loader;
 import android.content.Context;
 import android.net.Uri;
 
+import org.json.JSONException;
+import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -33,7 +35,7 @@ public class FileDownloaderTest {
     configMap.put("usesLegacyManifest", true);
     UpdatesConfiguration config = new UpdatesConfiguration().loadValuesFromMap(configMap);
 
-    Request actual = FileDownloader.setHeadersForManifestUrl(config, context);
+    Request actual = FileDownloader.setHeadersForManifestUrl(config, null, context);
     Assert.assertEquals("no-cache", actual.header("Cache-Control"));
   }
 
@@ -45,7 +47,25 @@ public class FileDownloaderTest {
     configMap.put("usesLegacyManifest", false);
     UpdatesConfiguration config = new UpdatesConfiguration().loadValuesFromMap(configMap);
 
-    Request actual = FileDownloader.setHeadersForManifestUrl(config, context);
+    Request actual = FileDownloader.setHeadersForManifestUrl(config, null, context);
     Assert.assertNull(actual.header("Cache-Control"));
+  }
+
+  @Test
+  public void testExtraHeaders_ObjectTypes() throws JSONException {
+    HashMap<String, Object> configMap = new HashMap<>();
+    configMap.put("updateUrl", Uri.parse("https://exp.host/@test/test"));
+    configMap.put("runtimeVersion", "1.0");
+    UpdatesConfiguration config = new UpdatesConfiguration().loadValuesFromMap(configMap);
+
+    JSONObject extraHeaders = new JSONObject();
+    extraHeaders.put("expo-string", "test");
+    extraHeaders.put("expo-number", 47.5);
+    extraHeaders.put("expo-boolean", true);
+
+    Request actual = FileDownloader.setHeadersForManifestUrl(config, extraHeaders, context);
+    Assert.assertEquals("test", actual.header("expo-string"));
+    Assert.assertEquals("47.5", actual.header("expo-number"));
+    Assert.assertEquals("true", actual.header("expo-boolean"));
   }
 }

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/FileDownloaderTest.java
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/FileDownloaderTest.java
@@ -42,7 +42,7 @@ public class FileDownloaderTest {
   @Test
   public void testCacheControl_NewManifest() {
     HashMap<String, Object> configMap = new HashMap<>();
-    configMap.put("updateUrl", Uri.parse("https://exp.host/@test/test"));
+    configMap.put("updateUrl", Uri.parse("https://exp.host/manifest/00000000-0000-0000-0000-000000000000"));
     configMap.put("runtimeVersion", "1.0");
     configMap.put("usesLegacyManifest", false);
     UpdatesConfiguration config = new UpdatesConfiguration().loadValuesFromMap(configMap);
@@ -54,7 +54,7 @@ public class FileDownloaderTest {
   @Test
   public void testExtraHeaders_ObjectTypes() throws JSONException {
     HashMap<String, Object> configMap = new HashMap<>();
-    configMap.put("updateUrl", Uri.parse("https://exp.host/@test/test"));
+    configMap.put("updateUrl", Uri.parse("https://exp.host/manifest/00000000-0000-0000-0000-000000000000"));
     configMap.put("runtimeVersion", "1.0");
     UpdatesConfiguration config = new UpdatesConfiguration().loadValuesFromMap(configMap);
 

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/FileDownloaderTest.java
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/FileDownloaderTest.java
@@ -68,4 +68,25 @@ public class FileDownloaderTest {
     Assert.assertEquals("47.5", actual.header("expo-number"));
     Assert.assertEquals("true", actual.header("expo-boolean"));
   }
+
+  @Test
+  public void testExtraHeaders_OverrideOrder() throws JSONException {
+    HashMap<String, Object> configMap = new HashMap<>();
+    configMap.put("updateUrl", Uri.parse("https://exp.host/manifest/00000000-0000-0000-0000-000000000000"));
+    configMap.put("runtimeVersion", "1.0");
+
+    // custom headers configured at build-time should be able to override preset headers
+    HashMap<String, String> headersMap = new HashMap<>();
+    headersMap.put("expo-updates-environment", "custom");
+    configMap.put("requestHeaders", headersMap);
+    UpdatesConfiguration config = new UpdatesConfiguration().loadValuesFromMap(configMap);
+
+    // serverDefinedHeaders should not be able to override preset headers
+    JSONObject extraHeaders = new JSONObject();
+    extraHeaders.put("expo-platform", "ios");
+
+    Request actual = FileDownloader.setHeadersForManifestUrl(config, extraHeaders, context);
+    Assert.assertEquals("android", actual.header("expo-platform"));
+    Assert.assertEquals("custom", actual.header("expo-updates-environment"));
+  }
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.java
@@ -8,6 +8,7 @@ import android.util.Log;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.json.JSONObject;
 import org.unimodules.core.ExportedModule;
 import org.unimodules.core.ModuleRegistry;
 import org.unimodules.core.Promise;
@@ -21,6 +22,7 @@ import expo.modules.updates.launcher.Launcher;
 import expo.modules.updates.loader.FileDownloader;
 import expo.modules.updates.manifest.Manifest;
 import expo.modules.updates.loader.RemoteLoader;
+import expo.modules.updates.manifest.ManifestMetadata;
 
 public class UpdatesModule extends ExportedModule {
   private static final String NAME = "ExpoUpdates";
@@ -129,7 +131,11 @@ public class UpdatesModule extends ExportedModule {
         return;
       }
 
-      FileDownloader.downloadManifest(updatesService.getConfiguration(), getContext(), new FileDownloader.ManifestDownloadCallback() {
+      DatabaseHolder databaseHolder = updatesService.getDatabaseHolder();
+      JSONObject extraHeaders = ManifestMetadata.getServerDefinedHeaders(databaseHolder.getDatabase(), updatesService.getConfiguration());
+      databaseHolder.releaseDatabase();
+
+      FileDownloader.downloadManifest(updatesService.getConfiguration(), extraHeaders, getContext(), new FileDownloader.ManifestDownloadCallback() {
         @Override
         public void onFailure(String message, Exception e) {
           promise.reject("ERR_UPDATES_CHECK", message, e);

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.java
@@ -265,7 +265,7 @@ public class FileDownloader {
     Request.Builder requestBuilder = new Request.Builder()
             .url(url.toString())
             .header("Expo-Platform", "android")
-            .header("Expo-Api-Version", "1")
+            .header("Expo-API-Version", "1")
             .header("Expo-Updates-Environment", "BARE");
 
     for (Map.Entry<String, String> entry : configuration.getRequestHeaders().entrySet()) {
@@ -279,6 +279,9 @@ public class FileDownloader {
     Request.Builder requestBuilder = new Request.Builder()
             .url(configuration.getUpdateUrl().toString())
             .header("Accept", "application/expo+json,application/json")
+            .header("Expo-Platform", "android")
+            .header("Expo-API-Version", "1")
+            .header("Expo-Updates-Environment", "BARE")
             .header("Expo-JSON-Error", "true")
             // as of 2020-11-25, the EAS Update alpha returns an error if Expo-Accept-Signature: true is included in the request
             .header("Expo-Accept-Signature", String.valueOf(configuration.usesLegacyManifest()));
@@ -317,11 +320,6 @@ public class FileDownloader {
         requestBuilder.header(key, extraHeaders.optString(key, ""));
       }
     }
-
-    requestBuilder = requestBuilder
-      .header("Expo-Platform", "android")
-      .header("Expo-Api-Version", "1")
-      .header("Expo-Updates-Environment", "BARE");
 
     for (Map.Entry<String, String> entry : configuration.getRequestHeaders().entrySet()) {
       requestBuilder.header(entry.getKey(), entry.getValue());

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.java
@@ -277,7 +277,18 @@ public class FileDownloader {
 
   /* package */ static Request setHeadersForManifestUrl(UpdatesConfiguration configuration, JSONObject extraHeaders, Context context) {
     Request.Builder requestBuilder = new Request.Builder()
-            .url(configuration.getUpdateUrl().toString())
+            .url(configuration.getUpdateUrl().toString());
+
+    // apply extra headers before anything else, so they don't override preset headers
+    if (extraHeaders != null) {
+      Iterator<String> keySet = extraHeaders.keys();
+      while (keySet.hasNext()) {
+        String key = keySet.next();
+        requestBuilder.header(key, extraHeaders.optString(key, ""));
+      }
+    }
+
+    requestBuilder = requestBuilder
             .header("Accept", "application/expo+json,application/json")
             .header("Expo-Platform", "android")
             .header("Expo-API-Version", "1")
@@ -311,14 +322,6 @@ public class FileDownloader {
         "Expo-Fatal-Error",
         previousFatalError.substring(0, Math.min(1024, previousFatalError.length()))
       );
-    }
-
-    if (extraHeaders != null) {
-      Iterator<String> keySet = extraHeaders.keys();
-      while (keySet.hasNext()) {
-        String key = keySet.next();
-        requestBuilder.header(key, extraHeaders.optString(key, ""));
-      }
     }
 
     for (Map.Entry<String, String> entry : configuration.getRequestHeaders().entrySet()) {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/RemoteLoader.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/RemoteLoader.java
@@ -4,6 +4,8 @@ import android.content.Context;
 import android.net.Uri;
 import android.util.Log;
 
+import org.json.JSONObject;
+
 import androidx.annotation.Nullable;
 import expo.modules.updates.UpdatesConfiguration;
 import expo.modules.updates.db.enums.UpdateStatus;
@@ -67,8 +69,9 @@ public class RemoteLoader {
     }
 
     mCallback = callback;
+    JSONObject extraHeaders = ManifestMetadata.getServerDefinedHeaders(mDatabase, mConfiguration);
 
-    FileDownloader.downloadManifest(mConfiguration, mContext, new FileDownloader.ManifestDownloadCallback() {
+    FileDownloader.downloadManifest(mConfiguration, extraHeaders, mContext, new FileDownloader.ManifestDownloadCallback() {
       @Override
       public void onFailure(String message, Exception e) {
         finishWithError(message, e);

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoader.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoader.m
@@ -77,7 +77,9 @@ static NSString * const EXUpdatesAppLoaderErrorDomain = @"EXUpdatesAppLoader";
 {
   if (![self _shouldStartLoadingUpdate:updateManifest]) {
     if (_successBlock) {
-      _successBlock(nil);
+      dispatch_async(_completionQueue, ^{
+        self->_successBlock(nil);
+      });
     }
     return;
   }

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.h
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.h
@@ -26,6 +26,7 @@ typedef void (^EXUpdatesFileDownloaderErrorBlock)(NSError *error, NSURLResponse 
 
 - (void)downloadManifestFromURL:(NSURL *)url
                    withDatabase:(EXUpdatesDatabase *)database
+                   extraHeaders:(nullable NSDictionary *)extraHeaders
                    successBlock:(EXUpdatesFileDownloaderManifestSuccessBlock)successBlock
                      errorBlock:(EXUpdatesFileDownloaderErrorBlock)errorBlock;
 
@@ -34,7 +35,7 @@ typedef void (^EXUpdatesFileDownloaderErrorBlock)(NSError *error, NSURLResponse 
 /**
  * For test purposes; shouldn't be needed in application code
  */
-- (NSURLRequest *)createManifestRequestWithURL:(NSURL *)url;
+- (NSURLRequest *)createManifestRequestWithURL:(NSURL *)url extraHeaders:(nullable NSDictionary *)extraHeaders;
 
 @end
 

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.m
@@ -257,7 +257,7 @@ NSTimeInterval const EXUpdatesDefaultTimeoutInterval = 60;
 - (void)_setHTTPHeaderFields:(NSMutableURLRequest *)request
 {
   [request setValue:@"ios" forHTTPHeaderField:@"Expo-Platform"];
-  [request setValue:@"1" forHTTPHeaderField:@"Expo-Api-Version"];
+  [request setValue:@"1" forHTTPHeaderField:@"Expo-API-Version"];
   [request setValue:@"BARE" forHTTPHeaderField:@"Expo-Updates-Environment"];
 
   for (NSString *key in _config.requestHeaders) {
@@ -268,6 +268,9 @@ NSTimeInterval const EXUpdatesDefaultTimeoutInterval = 60;
 - (void)_setManifestHTTPHeaderFields:(NSMutableURLRequest *)request withExtraHeaders:(nullable NSDictionary *)extraHeaders
 {
   [request setValue:@"application/expo+json,application/json" forHTTPHeaderField:@"Accept"];
+  [request setValue:@"ios" forHTTPHeaderField:@"Expo-Platform"];
+  [request setValue:@"1" forHTTPHeaderField:@"Expo-API-Version"];
+  [request setValue:@"BARE" forHTTPHeaderField:@"Expo-Updates-Environment"];
   [request setValue:@"true" forHTTPHeaderField:@"Expo-JSON-Error"];
   // as of 2020-11-25, the EAS Update alpha returns an error if Expo-Accept-Signature: true is included in the request
   [request setValue:(_config.usesLegacyManifest ? @"true" : @"false") forHTTPHeaderField:@"Expo-Accept-Signature"];
@@ -296,13 +299,21 @@ NSTimeInterval const EXUpdatesDefaultTimeoutInterval = 60;
       id value = extraHeaders[key];
       if ([value isKindOfClass:[NSString class]]) {
         [request setValue:value forHTTPHeaderField:key];
+      } else if ([value isKindOfClass:[NSNumber class]]) {
+        if (CFGetTypeID((__bridge CFTypeRef)(value)) == CFBooleanGetTypeID()) {
+          [request setValue:((NSNumber *)value).boolValue ? @"true" : @"false" forHTTPHeaderField:key];
+        } else {
+          [request setValue:((NSNumber *)value).stringValue forHTTPHeaderField:key];
+        }
       } else {
         [request setValue:[(NSObject *)value description] forHTTPHeaderField:key];
       }
     }
   }
 
-  [self _setHTTPHeaderFields:request];
+  for (NSString *key in _config.requestHeaders) {
+    [request setValue:_config.requestHeaders[key] forHTTPHeaderField:key];
+  }
 }
 
 #pragma mark - NSURLSessionTaskDelegate

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.m
@@ -267,6 +267,24 @@ NSTimeInterval const EXUpdatesDefaultTimeoutInterval = 60;
 
 - (void)_setManifestHTTPHeaderFields:(NSMutableURLRequest *)request withExtraHeaders:(nullable NSDictionary *)extraHeaders
 {
+  // apply extra headers before anything else, so they don't override preset headers
+  if (extraHeaders) {
+    for (NSString *key in extraHeaders) {
+      id value = extraHeaders[key];
+      if ([value isKindOfClass:[NSString class]]) {
+        [request setValue:value forHTTPHeaderField:key];
+      } else if ([value isKindOfClass:[NSNumber class]]) {
+        if (CFGetTypeID((__bridge CFTypeRef)(value)) == CFBooleanGetTypeID()) {
+          [request setValue:((NSNumber *)value).boolValue ? @"true" : @"false" forHTTPHeaderField:key];
+        } else {
+          [request setValue:((NSNumber *)value).stringValue forHTTPHeaderField:key];
+        }
+      } else {
+        [request setValue:[(NSObject *)value description] forHTTPHeaderField:key];
+      }
+    }
+  }
+
   [request setValue:@"application/expo+json,application/json" forHTTPHeaderField:@"Accept"];
   [request setValue:@"ios" forHTTPHeaderField:@"Expo-Platform"];
   [request setValue:@"1" forHTTPHeaderField:@"Expo-API-Version"];
@@ -292,23 +310,6 @@ NSTimeInterval const EXUpdatesDefaultTimeoutInterval = 60;
       previousFatalError = [previousFatalError substringToIndex:1024];
     }
     [request setValue:previousFatalError forHTTPHeaderField:@"Expo-Fatal-Error"];
-  }
-
-  if (extraHeaders) {
-    for (NSString *key in extraHeaders) {
-      id value = extraHeaders[key];
-      if ([value isKindOfClass:[NSString class]]) {
-        [request setValue:value forHTTPHeaderField:key];
-      } else if ([value isKindOfClass:[NSNumber class]]) {
-        if (CFGetTypeID((__bridge CFTypeRef)(value)) == CFBooleanGetTypeID()) {
-          [request setValue:((NSNumber *)value).boolValue ? @"true" : @"false" forHTTPHeaderField:key];
-        } else {
-          [request setValue:((NSNumber *)value).stringValue forHTTPHeaderField:key];
-        }
-      } else {
-        [request setValue:[(NSObject *)value description] forHTTPHeaderField:key];
-      }
-    }
   }
 
   for (NSString *key in _config.requestHeaders) {

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesModule.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesModule.m
@@ -79,9 +79,19 @@ UM_EXPORT_METHOD_AS(checkForUpdateAsync,
     return;
   }
 
+  __block NSDictionary *extraHeaders;
+  dispatch_sync(_updatesService.database.databaseQueue, ^{
+    NSError *error;
+    extraHeaders = [self->_updatesService.database serverDefinedHeadersWithScopeKey:self->_updatesService.config.scopeKey error:&error];
+    if (error) {
+      NSLog(@"Error selecting serverDefinedHeaders from database: %@", error.localizedDescription);
+    }
+  });
+
   EXUpdatesFileDownloader *fileDownloader = [[EXUpdatesFileDownloader alloc] initWithUpdatesConfig:_updatesService.config];
   [fileDownloader downloadManifestFromURL:_updatesService.config.updateUrl
                              withDatabase:_updatesService.database
+                             extraHeaders:extraHeaders
                              successBlock:^(EXUpdatesUpdate *update) {
     EXUpdatesUpdate *launchedUpdate = self->_updatesService.launchedUpdate;
     id<EXUpdatesSelectionPolicy> selectionPolicy = self->_updatesService.selectionPolicy;

--- a/packages/expo-updates/ios/Tests/EXUpdatesFileDownloaderTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesFileDownloaderTests.m
@@ -39,13 +39,13 @@
 - (void)testCacheControl_NewManifest
 {
   EXUpdatesConfig *config = [EXUpdatesConfig configWithDictionary:@{
-    @"EXUpdatesURL": @"https://exp.host/@test/test",
+    @"EXUpdatesURL": @"https://exp.host/manifest/00000000-0000-0000-0000-000000000000",
     @"EXUpdatesRuntimeVersion": @"1.0",
     @"EXUpdatesUsesLegacyManifest": @(NO)
   }];
   EXUpdatesFileDownloader *downloader = [[EXUpdatesFileDownloader alloc] initWithUpdatesConfig:config];
 
-  NSURLRequest *actual = [downloader createManifestRequestWithURL:[NSURL URLWithString:@"https://exp.host/@test/test"] extraHeaders:nil];
+  NSURLRequest *actual = [downloader createManifestRequestWithURL:[NSURL URLWithString:@"https://exp.host/manifest/00000000-0000-0000-0000-000000000000"] extraHeaders:nil];
   XCTAssertEqual(NSURLRequestUseProtocolCachePolicy, actual.cachePolicy);
   XCTAssertNil([actual valueForHTTPHeaderField:@"Cache-Control"]);
 }
@@ -53,19 +53,21 @@
 - (void)testExtraHeaders_ObjectTypes
 {
   EXUpdatesConfig *config = [EXUpdatesConfig configWithDictionary:@{
-    @"EXUpdatesURL": @"https://exp.host/@test/test",
+    @"EXUpdatesURL": @"https://exp.host/manifest/00000000-0000-0000-0000-000000000000",
     @"EXUpdatesRuntimeVersion": @"1.0"
   }];
   EXUpdatesFileDownloader *downloader = [[EXUpdatesFileDownloader alloc] initWithUpdatesConfig:config];
 
   NSDictionary *extraHeaders = @{
     @"expo-string": @"test",
-    @"expo-number": @(47.5)
+    @"expo-number": @(47.5),
+    @"expo-boolean": @YES
   };
 
-  NSURLRequest *actual = [downloader createManifestRequestWithURL:[NSURL URLWithString:@"https://exp.host/@test/test"] extraHeaders:extraHeaders];
+  NSURLRequest *actual = [downloader createManifestRequestWithURL:[NSURL URLWithString:@"https://exp.host/manifest/00000000-0000-0000-0000-000000000000"] extraHeaders:extraHeaders];
   XCTAssertEqualObjects(@"test", [actual valueForHTTPHeaderField:@"expo-string"]);
   XCTAssertEqualObjects(@"47.5", [actual valueForHTTPHeaderField:@"expo-number"]);
+  XCTAssertEqualObjects(@"true", [actual valueForHTTPHeaderField:@"expo-boolean"]);
 }
 
 @end

--- a/packages/expo-updates/ios/Tests/EXUpdatesFileDownloaderTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesFileDownloaderTests.m
@@ -30,7 +30,7 @@
   }];
   EXUpdatesFileDownloader *downloader = [[EXUpdatesFileDownloader alloc] initWithUpdatesConfig:config];
 
-  NSURLRequest *actual = [downloader createManifestRequestWithURL:[NSURL URLWithString:@"https://exp.host/@test/test"]];
+  NSURLRequest *actual = [downloader createManifestRequestWithURL:[NSURL URLWithString:@"https://exp.host/@test/test"] extraHeaders:nil];
   XCTAssertEqual(NSURLRequestReloadIgnoringCacheData, actual.cachePolicy);
   // this fails, seems like this header isn't actually set on the object until later
   // XCTAssertEqualObjects(@"no-cache", [actual valueForHTTPHeaderField:@"Cache-Control"]);
@@ -45,9 +45,27 @@
   }];
   EXUpdatesFileDownloader *downloader = [[EXUpdatesFileDownloader alloc] initWithUpdatesConfig:config];
 
-  NSURLRequest *actual = [downloader createManifestRequestWithURL:[NSURL URLWithString:@"https://exp.host/@test/test"]];
+  NSURLRequest *actual = [downloader createManifestRequestWithURL:[NSURL URLWithString:@"https://exp.host/@test/test"] extraHeaders:nil];
   XCTAssertEqual(NSURLRequestUseProtocolCachePolicy, actual.cachePolicy);
   XCTAssertNil([actual valueForHTTPHeaderField:@"Cache-Control"]);
+}
+
+- (void)testExtraHeaders_ObjectTypes
+{
+  EXUpdatesConfig *config = [EXUpdatesConfig configWithDictionary:@{
+    @"EXUpdatesURL": @"https://exp.host/@test/test",
+    @"EXUpdatesRuntimeVersion": @"1.0"
+  }];
+  EXUpdatesFileDownloader *downloader = [[EXUpdatesFileDownloader alloc] initWithUpdatesConfig:config];
+
+  NSDictionary *extraHeaders = @{
+    @"expo-string": @"test",
+    @"expo-number": @(47.5)
+  };
+
+  NSURLRequest *actual = [downloader createManifestRequestWithURL:[NSURL URLWithString:@"https://exp.host/@test/test"] extraHeaders:extraHeaders];
+  XCTAssertEqualObjects(@"test", [actual valueForHTTPHeaderField:@"expo-string"]);
+  XCTAssertEqualObjects(@"47.5", [actual valueForHTTPHeaderField:@"expo-number"]);
 }
 
 @end

--- a/packages/expo-updates/ios/Tests/EXUpdatesFileDownloaderTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesFileDownloaderTests.m
@@ -70,4 +70,26 @@
   XCTAssertEqualObjects(@"true", [actual valueForHTTPHeaderField:@"expo-boolean"]);
 }
 
+- (void)testExtraHeaders_OverrideOrder
+{
+  EXUpdatesConfig *config = [EXUpdatesConfig configWithDictionary:@{
+    @"EXUpdatesURL": @"https://exp.host/manifest/00000000-0000-0000-0000-000000000000",
+    @"EXUpdatesRuntimeVersion": @"1.0",
+    @"EXUpdatesRequestHeaders": @{
+      // custom headers configured at build-time should be able to override preset headers
+      @"expo-updates-environment": @"custom"
+    }
+  }];
+  EXUpdatesFileDownloader *downloader = [[EXUpdatesFileDownloader alloc] initWithUpdatesConfig:config];
+
+  // serverDefinedHeaders should not be able to override preset headers
+  NSDictionary *extraHeaders = @{
+    @"expo-platform": @"android"
+  };
+
+  NSURLRequest *actual = [downloader createManifestRequestWithURL:[NSURL URLWithString:@"https://exp.host/manifest/00000000-0000-0000-0000-000000000000"] extraHeaders:extraHeaders];
+  XCTAssertEqualObjects(@"ios", [actual valueForHTTPHeaderField:@"expo-platform"]);
+  XCTAssertEqualObjects(@"custom", [actual valueForHTTPHeaderField:@"expo-updates-environment"]);
+}
+
 @end


### PR DESCRIPTION
# Why

resolves [ENG-264](https://linear.app/expo/issue/ENG-264/send-serverdefinedheaders-in-manifest-request) & makes it possible to use rollout tokens in EAS Update with expo-updates

# How

Before making a manifest request, make a database call to retrieve any headers saved from the `expo-server-defined-header` field of previous manifest requests, and include those headers in the manifest request.

Also changed the order that certain predefined header fields are set so that it's consistent across platforms.

@ide -- some of the GCD stuff on iOS side feels like it's getting unwieldy, going back and forth between the database queue & other queues. Curious what your thoughts are around this; is this just a necessary evil of the kind of thread safety we are aiming for?

# Test Plan

Added a unit test for different types of values in the saved serverDefinedHeaders; will need to test this e2e with a server that serves valid manifests with the `expo-server-defined-headers` header.
