### PR TITLE
[eslint-config-universe] Add missing typescript to required packages

### DIFF
--- a/packages/eslint-config-universe/README.md
+++ b/packages/eslint-config-universe/README.md
@@ -7,7 +7,7 @@ Shared ESLint configs for Node, Web, and universal Expo projects.
 yarn add --dev eslint-config-universe
 ```
 
-You will also need to install `eslint`, `prettier`, `@typescript-eslint/eslint-plugin`, and `@typescript-eslint/parser`:
+You will also need to install `eslint`, `prettier`, `typescript`, `@typescript-eslint/eslint-plugin`, and `@typescript-eslint/parser`:
 
 ```sh
 yarn add --dev eslint prettier typescript @typescript-eslint/eslint-plugin @typescript-eslint/parser

--- a/packages/eslint-config-universe/README.md
+++ b/packages/eslint-config-universe/README.md
@@ -10,7 +10,7 @@ yarn add --dev eslint-config-universe
 You will also need to install `eslint`, `prettier`, `@typescript-eslint/eslint-plugin`, and `@typescript-eslint/parser`:
 
 ```sh
-yarn add --dev eslint prettier @typescript-eslint/eslint-plugin @typescript-eslint/parser
+yarn add --dev eslint prettier typescript @typescript-eslint/eslint-plugin @typescript-eslint/parser
 ```
 
 ## Usage


### PR DESCRIPTION
# Why

Fixes #11969, #10073

# How

- Added `typescript` to the list, just before `@typescript-eslint` stuff.

# Test Plan

- Just a docs change