### PR TITLE
[expo-updates] make manifest filters key search case-insensitive

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Parse & persist data from EAS Update manifest headers ([#11961](https://github.com/expo/expo/pull/11961) and [#11967](https://github.com/expo/expo/pull/11967) by [@esamelson](https://github.com/esamelson))
 - Accept signature in header (iOS). ([#11930](https://github.com/expo/expo/pull/11930) by [@jkhales](https://github.com/jkhales))
 - Switch to SelectionPolicyFilterAware and use persisted manifest filters ([#11993](https://github.com/expo/expo/pull/11993) by [@esamelson](https://github.com/esamelson))
+- Make manifest filters key search case-insensitive ([#12015](https://github.com/expo/expo/pull/12015) by [@esamelson](https://github.com/esamelson))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/launcher/SelectionPolicyFilterAwareTest.java
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/launcher/SelectionPolicyFilterAwareTest.java
@@ -32,7 +32,7 @@ public class SelectionPolicyFilterAwareTest {
 
   @Before
   public void setup() throws JSONException {
-    manifestFilters = new JSONObject("{\"branchName\": \"rollout\"}");
+    manifestFilters = new JSONObject("{\"branchname\": \"rollout\"}");
     selectionPolicy = new SelectionPolicyFilterAware("1.0");
 
     HashMap<String, Object> configMap = new HashMap<>();
@@ -54,7 +54,7 @@ public class SelectionPolicyFilterAwareTest {
     JSONObject manifestJsonRollout2 = new JSONObject("{\"id\":\"079cde35-8433-4c17-81c8-7117c1513e75\",\"createdAt\":\"2021-01-14T19:39:22.480Z\",\"runtimeVersion\":\"1.0\",\"launchAsset\":{\"hash\":\"DW5MBgKq155wnX8rCP1lnsW6BsTbfKLXxGXRQx1RcOA\",\"key\":\"0436e5821bff7b95a84c21f22a43cb96.bundle\",\"contentType\":\"application/javascript\",\"url\":\"https://url.to/bundle\"},\"assets\":[{\"hash\":\"JSeRsPNKzhVdHP1OEsDVsLH500Zfe4j1O7xWfa14oBo\",\"key\":\"3261e570d51777be1e99116562280926.png\",\"contentType\":\"image/png\",\"url\":\"https://url.to/asset\"}],\"updateMetadata\":{\"branchName\":\"rollout\"}}");
     updateRollout2 = NewManifest.fromManifestJson(manifestJsonRollout2, null, config).getUpdateEntity();
 
-    JSONObject manifestJsonMultipleFilters = new JSONObject("{\"id\":\"079cde35-8433-4c17-81c8-7117c1513e72\",\"createdAt\":\"2021-01-11T19:39:22.480Z\",\"runtimeVersion\":\"1.0\",\"launchAsset\":{\"hash\":\"DW5MBgKq155wnX8rCP1lnsW6BsTbfKLXxGXRQx1RcOA\",\"key\":\"0436e5821bff7b95a84c21f22a43cb96.bundle\",\"contentType\":\"application/javascript\",\"url\":\"https://url.to/bundle\"},\"assets\":[{\"hash\":\"JSeRsPNKzhVdHP1OEsDVsLH500Zfe4j1O7xWfa14oBo\",\"key\":\"3261e570d51777be1e99116562280926.png\",\"contentType\":\"image/png\",\"url\":\"https://url.to/asset\"}],\"updateMetadata\":{\"key1\": \"value1\", \"key2\": \"value2\"}}");
+    JSONObject manifestJsonMultipleFilters = new JSONObject("{\"id\":\"079cde35-8433-4c17-81c8-7117c1513e72\",\"createdAt\":\"2021-01-11T19:39:22.480Z\",\"runtimeVersion\":\"1.0\",\"launchAsset\":{\"hash\":\"DW5MBgKq155wnX8rCP1lnsW6BsTbfKLXxGXRQx1RcOA\",\"key\":\"0436e5821bff7b95a84c21f22a43cb96.bundle\",\"contentType\":\"application/javascript\",\"url\":\"https://url.to/bundle\"},\"assets\":[{\"hash\":\"JSeRsPNKzhVdHP1OEsDVsLH500Zfe4j1O7xWfa14oBo\",\"key\":\"3261e570d51777be1e99116562280926.png\",\"contentType\":\"image/png\",\"url\":\"https://url.to/asset\"}],\"updateMetadata\":{\"firstKey\": \"value1\", \"secondKey\": \"value2\"}}");
     updateMultipleFilters = NewManifest.fromManifestJson(manifestJsonMultipleFilters, null, config).getUpdateEntity();
   }
 
@@ -125,13 +125,13 @@ public class SelectionPolicyFilterAwareTest {
   @Test
   public void testMatchesFilters_MultipleFilters() throws JSONException {
     // if there are multiple filters, a manifest must match them all to pass
-    Assert.assertFalse(selectionPolicy.matchesFilters(updateMultipleFilters, new JSONObject("{\"key1\": \"value1\", \"key2\": \"wrong-value\"}")));
-    Assert.assertTrue(selectionPolicy.matchesFilters(updateMultipleFilters, new JSONObject("{\"key1\": \"value1\", \"key2\": \"value2\"}")));
+    Assert.assertFalse(selectionPolicy.matchesFilters(updateMultipleFilters, new JSONObject("{\"firstkey\": \"value1\", \"secondkey\": \"wrong-value\"}")));
+    Assert.assertTrue(selectionPolicy.matchesFilters(updateMultipleFilters, new JSONObject("{\"firstkey\": \"value1\", \"secondkey\": \"value2\"}")));
   }
 
   @Test
   public void testMatchesFilters_EmptyMatchesAll() throws JSONException {
     // no field is counted as a match
-    Assert.assertTrue(selectionPolicy.matchesFilters(updateDefault1, new JSONObject("{\"fieldThatUpdateDoesntHave\": \"value\"}")));
+    Assert.assertTrue(selectionPolicy.matchesFilters(updateDefault1, new JSONObject("{\"field-that-update-doesnt-have\": \"value\"}")));
   }
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/SelectionPolicyFilterAware.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/SelectionPolicyFilterAware.java
@@ -106,11 +106,20 @@ public class SelectionPolicyFilterAware implements SelectionPolicy {
     }
     try {
       JSONObject updateMetadata = update.metadata.getJSONObject("updateMetadata");
-      Iterator<String> keySet = manifestFilters.keys();
-      while (keySet.hasNext()) {
-        String key = keySet.next();
+
+      // create lowercase copy for case-insensitive search
+      JSONObject metadataLCKeys = new JSONObject();
+      Iterator<String> metadataKeySet = updateMetadata.keys();
+      while (metadataKeySet.hasNext()) {
+        String key = metadataKeySet.next();
+        metadataLCKeys.put(key.toLowerCase(), updateMetadata.get(key));
+      }
+
+      Iterator<String> filterKeySet = manifestFilters.keys();
+      while (filterKeySet.hasNext()) {
+        String key = filterKeySet.next();
         // once an update fails one filter, break early; we don't need to check the rest
-        if (updateMetadata.has(key) && !manifestFilters.get(key).equals(updateMetadata.get(key))) {
+        if (metadataLCKeys.has(key) && !manifestFilters.get(key).equals(metadataLCKeys.get(key))) {
           return false;
         }
       }

--- a/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesSelectionPolicyFilterAware.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesSelectionPolicyFilterAware.m
@@ -108,9 +108,17 @@ NS_ASSUME_NONNULL_BEGIN
     return NO;
   }
 
+  // create lowercase copy for case-insensitive search
+  NSMutableDictionary *metadataLCKeys = [NSMutableDictionary dictionaryWithCapacity:updateMetadata.count];
+  [updateMetadata enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
+    if ([key isKindOfClass:[NSString class]]) {
+      metadataLCKeys[((NSString *)key).lowercaseString] = obj;
+    }
+  }];
+
   __block BOOL passes = YES;
   [filters enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
-    id valueFromManifest = updateMetadata[key];
+    id valueFromManifest = metadataLCKeys[key];
     if (valueFromManifest) {
       passes = [obj isEqual:valueFromManifest];
     }

--- a/packages/expo-updates/ios/Tests/EXUpdatesSelectionPolicyFilterAwareTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesSelectionPolicyFilterAwareTests.m
@@ -95,11 +95,11 @@
     @"runtimeVersion": @"1.0",
     @"launchAsset": launchAsset,
     @"assets": @[imageAsset],
-    @"updateMetadata": @{@"key1": @"value1", @"key2": @"value2"}
+    @"updateMetadata": @{@"firstKey": @"value1", @"secondKey": @"value2"}
   } response:nil config:config database:database];
 
   _selectionPolicy = [[EXUpdatesSelectionPolicyFilterAware alloc] initWithRuntimeVersion:runtimeVersion];
-  _manifestFilters = @{@"branchName": @"rollout"};
+  _manifestFilters = @{@"branchname": @"rollout"};
 }
 
 - (void)tearDown
@@ -161,21 +161,21 @@
 - (void)testDoesUpdateMatchFilters_MultipleFilters
 {
   NSDictionary *filtersBadMatch = @{
-    @"key1": @"value1",
-    @"key2": @"wrong-value"
+    @"firstkey": @"value1",
+    @"secondkey": @"wrong-value"
   };
   XCTAssertFalse([_selectionPolicy doesUpdate:_updateMultipleFilters matchFilters:filtersBadMatch], @"should fail unless all filters pass");
 
   NSDictionary *filtersGoodMatch = @{
-    @"key1": @"value1",
-    @"key2": @"value2"
+    @"firstkey": @"value1",
+    @"secondkey": @"value2"
   };
   XCTAssertTrue([_selectionPolicy doesUpdate:_updateMultipleFilters matchFilters:filtersGoodMatch], @"should pass if all filters pass");
 }
 
 - (void)testDoesUpdateMatchFilters_EmptyMatchesAll
 {
-  XCTAssertTrue([_selectionPolicy doesUpdate:_updateDefault1 matchFilters:@{@"fieldThatUpdateDoesntHave": @"value"}], @"no field counts as a match");
+  XCTAssertTrue([_selectionPolicy doesUpdate:_updateDefault1 matchFilters:@{@"field-that-update-doesnt-have": @"value"}], @"no field counts as a match");
 }
 
 @end


### PR DESCRIPTION
# Why

Structured headers dictionary keys cannot include uppercase letters; rather than forcing all possible matching keys to be lowercase only -- which goes against our usual camel case JSON style -- the simplest thing is to make the search case-insensitive. (Only the keys are case-insensitive; string values must still be an exact match.)

# How

Before searching for matching keys in the manifest's `updateMetadata` object, loop through once to create a lowercase-keyed copy of this object, and then use to compare with the filters.

# Test Plan

Updated the tests to reflect the lowercase nature of the expected manifest filters; tests failed before this change but all tests are now passing.
