### PR TITLE
[ci] Revise shell-app-ios workflow

### DIFF
--- a/.github/workflows/shell-app-ios.yml
+++ b/.github/workflows/shell-app-ios.yml
@@ -13,6 +13,7 @@ on:
     paths:
       - .github/workflows/shell-app-ios.yml
       - .ruby-version
+      - exponent-view-template
 
 jobs:
   build:
@@ -21,38 +22,33 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
-      - name: Switch to Xcode 12.1
+      - name: 🔨 Switch to Xcode 12.1
         run: sudo xcode-select --switch /Applications/Xcode_12.1.app
-      - name: Get cache key of git lfs files
-        id: git-lfs
-        run: echo "::set-output name=sha256::$(git lfs ls-files | openssl dgst -sha256)"
-      - uses: actions/cache@v2
-        with:
-          path: .git/lfs
-          key: ${{ steps.git-lfs.outputs.sha256 }}
-      - run: git lfs pull
-      - run: echo "$(pwd)/bin" >> $GITHUB_PATH
-      - run: echo "EXPO_ROOT_DIR=$(pwd)" >> $GITHUB_ENV
-      - run: expotools ios-generate-dynamic-macros
-      - uses: ruby/setup-ruby@v1
+      - name: 🍺 Setup
+        run: |
+          echo "$(pwd)/bin" >> $GITHUB_PATH
+          echo "EXPO_ROOT_DIR=$(pwd)" >> $GITHUB_ENV
+      - name: 💎 Setup Ruby and install gems
+        uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-      - uses: actions/cache@v2
+      - name: ♻️ Restore tools/node_modules from cache
+        uses: actions/cache@v2
         with:
-          path: ios/Pods
-          key: ${{ runner.os }}-pods-${{ hashFiles('ios/Podfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-pods-
-      - name: Build iOS shell app for real devices
+          path: 'tools/node_modules'
+          key: ${{ runner.os }}-modules-${{ hashFiles('tools/yarn.lock') }}
+      - name: 🍏 Generate dynamic macros
+        run: expotools ios-generate-dynamic-macros
+      - name: 📦 Build iOS shell app for real devices
         timeout-minutes: 30
         run: expotools ios-shell-app --action build --type archive --verbose true --skipRepoUpdate --shellAppSdkVersion UNVERSIONED
-      - name: Build iOS shell app for simulators
+      - name: 📦 Build iOS shell app for simulators
         timeout-minutes: 30
         run: expotools ios-shell-app --action build --type simulator --verbose true --skipRepoUpdate --shellAppSdkVersion UNVERSIONED
-      - name: Set tarball name
+      - name: ✏️ Set tarball name
         id: tarball
         run: echo "::set-output name=filename::ios-shell-builder-sdk-latest-${{ github.sha }}.tar.gz"
-      - name: Package release tarball
+      - name: 🤐 Package release tarball
         run: |
           tar \
             -zcf ${{ steps.tarball.outputs.filename }} \
@@ -61,7 +57,7 @@ jobs:
             shellAppBase-builds \
             shellAppWorkspaces \
             ios
-      - name: Upload shell app tarball to S3
+      - name: 🚀 Upload shell app tarball to S3
         if: ${{ github.event.inputs.upload == 'upload' }}
         timeout-minutes: 40
         env:
@@ -74,12 +70,12 @@ jobs:
           echo "Then follow the deployment instructions: https://github.com/expo/turtle-deploy"
       - name: 🔔 Notify on Slack
         uses: 8398a7/action-slack@v3
-        if: failure() && (github.event.ref == 'refs/heads/master' || startsWith(github.event.ref, 'refs/heads/sdk-'))
+        if: failure() && (github.event.ref == 'refs/heads/master' || startsWith(github.event.ref, 'refs/heads/sdk-') || github.event_name == 'schedule')
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_ios }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_IOS }}
         with:
           channel: '#platform-ios'
           status: ${{ job.status }}
-          fields: job,commit,ref,eventName,author,took
+          fields: job,message,ref,eventName,author,took
           author_name: Shell App (iOS)


### PR DESCRIPTION
# Why

Followup #12005 

# How

- Made the `shell-app-ios` workflow more clear to read
- Run on changes in `exponent-view-template` dir
- Caching `tools/node_modules`
- Removed caching `ios/Pods` — they are not used by the building process
- For some reasons we haven't been receiving Slack notifications on scheduled runs, so I explicitly added proper check

# Test Plan

Let's see what CI thinks
