### PR TITLE
[expo-updates] fail earlier if manifest doesn't match its own filters

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -17,7 +17,7 @@
 - Added alpha support for EAS update manifest format ([#11050](https://github.com/expo/expo/pull/11050) by [@esamelson](https://github.com/esamelson))
 - add ability for android clients to handle header signatures. ([#11897](https://github.com/expo/expo/pull/11897) by [@jkhales](https://github.com/jkhales))
 - Added `SelectionPolicyFilterAware` to support EAS Update's manifest filters feature ([#11748](https://github.com/expo/expo/pull/11748) by [@esamelson](https://github.com/esamelson))
-- Parse & persist data from EAS Update manifest headers ([#11961](https://github.com/expo/expo/pull/11961) and [#11967](https://github.com/expo/expo/pull/11967) by [@esamelson](https://github.com/esamelson))
+- Parse & persist data from EAS Update manifest headers ([#11961](https://github.com/expo/expo/pull/11961), [#11967](https://github.com/expo/expo/pull/11967), and [#12026](https://github.com/expo/expo/pull/12026) by [@esamelson](https://github.com/esamelson))
 - Accept signature in header (iOS). ([#11930](https://github.com/expo/expo/pull/11930) by [@jkhales](https://github.com/jkhales))
 - Switch to SelectionPolicyFilterAware and use persisted manifest filters ([#11993](https://github.com/expo/expo/pull/11993) by [@esamelson](https://github.com/esamelson))
 - Make manifest filters key search case-insensitive ([#12015](https://github.com/expo/expo/pull/12015) by [@esamelson](https://github.com/esamelson))

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/launcher/SelectionPolicyFilterAwareTest.java
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/launcher/SelectionPolicyFilterAwareTest.java
@@ -129,20 +129,20 @@ public class SelectionPolicyFilterAwareTest {
   @Test
   public void testMatchesFilters_MultipleFilters() throws JSONException {
     // if there are multiple filters, a manifest must match them all to pass
-    Assert.assertFalse(selectionPolicy.matchesFilters(updateMultipleFilters, new JSONObject("{\"firstkey\": \"value1\", \"secondkey\": \"wrong-value\"}")));
-    Assert.assertTrue(selectionPolicy.matchesFilters(updateMultipleFilters, new JSONObject("{\"firstkey\": \"value1\", \"secondkey\": \"value2\"}")));
+    Assert.assertFalse(SelectionPolicyFilterAware.matchesFilters(updateMultipleFilters, new JSONObject("{\"firstkey\": \"value1\", \"secondkey\": \"wrong-value\"}")));
+    Assert.assertTrue(SelectionPolicyFilterAware.matchesFilters(updateMultipleFilters, new JSONObject("{\"firstkey\": \"value1\", \"secondkey\": \"value2\"}")));
   }
 
   @Test
   public void testMatchesFilters_EmptyMatchesAll() throws JSONException {
     // no field is counted as a match
-    Assert.assertTrue(selectionPolicy.matchesFilters(updateDefault1, new JSONObject("{\"field-that-update-doesnt-have\": \"value\"}")));
+    Assert.assertTrue(SelectionPolicyFilterAware.matchesFilters(updateDefault1, new JSONObject("{\"field-that-update-doesnt-have\": \"value\"}")));
   }
 
   @Test
   public void testMatchesFilters_Null() throws JSONException {
     // null filters or null updateMetadata (i.e. bare or legacy manifests) is counted as a match
-    Assert.assertTrue(selectionPolicy.matchesFilters(updateDefault1, null));
-    Assert.assertTrue(selectionPolicy.matchesFilters(updateNoMetadata, manifestFilters));
+    Assert.assertTrue(SelectionPolicyFilterAware.matchesFilters(updateDefault1, null));
+    Assert.assertTrue(SelectionPolicyFilterAware.matchesFilters(updateNoMetadata, manifestFilters));
   }
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/SelectionPolicyFilterAware.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/SelectionPolicyFilterAware.java
@@ -10,7 +10,6 @@ import java.util.Iterator;
 import java.util.List;
 
 import expo.modules.updates.db.entity.UpdateEntity;
-import expo.modules.updates.manifest.Manifest;
 
 /**
  * Update selection policy which chooses an update to launch based on the manifest filters
@@ -99,7 +98,7 @@ public class SelectionPolicyFilterAware implements SelectionPolicy {
     return newUpdate.commitTime.after(launchedUpdate.commitTime);
   }
 
-  /* package */ boolean matchesFilters(UpdateEntity update, JSONObject manifestFilters) {
+  public static boolean matchesFilters(UpdateEntity update, JSONObject manifestFilters) {
     if (manifestFilters == null || update.metadata == null || !update.metadata.has("updateMetadata")) {
       // empty matches all
       return true;

--- a/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesSelectionPolicyFilterAware.h
+++ b/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesSelectionPolicyFilterAware.h
@@ -9,7 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithRuntimeVersion:(NSString *)runtimeVersion;
 - (instancetype)initWithRuntimeVersions:(NSArray<NSString *> *)runtimeVersions;
 
-- (BOOL)doesUpdate:(EXUpdatesUpdate *)update matchFilters:(nullable NSDictionary *)filters;
++ (BOOL)doesUpdate:(EXUpdatesUpdate *)update matchFilters:(nullable NSDictionary *)filters;
 
 @end
 

--- a/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesSelectionPolicyFilterAware.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesSelectionPolicyFilterAware.m
@@ -31,7 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
   EXUpdatesUpdate *runnableUpdate;
   NSDate *runnableUpdateCommitTime;
   for (EXUpdatesUpdate *update in updates) {
-    if (![_runtimeVersions containsObject:update.runtimeVersion] || ![self doesUpdate:update matchFilters:filters]) {
+    if (![_runtimeVersions containsObject:update.runtimeVersion] || ![[self class] doesUpdate:update matchFilters:filters]) {
       continue;
     }
     NSDate *commitTime = update.commitTime;
@@ -61,7 +61,7 @@ NS_ASSUME_NONNULL_BEGIN
       if (!nextNewestUpdate || [update.commitTime compare:nextNewestUpdate.commitTime] == NSOrderedDescending) {
         nextNewestUpdate = update;
       }
-      if ([self doesUpdate:update matchFilters:filters] &&
+      if ([[self class] doesUpdate:update matchFilters:filters] &&
           (!nextNewestUpdateMatchingFilters || [update.commitTime compare:nextNewestUpdateMatchingFilters.commitTime] == NSOrderedDescending)) {
         nextNewestUpdateMatchingFilters = update;
       }
@@ -82,7 +82,7 @@ NS_ASSUME_NONNULL_BEGIN
     return NO;
   }
   // if the new update doesn't match its own filters, we shouldn't load it
-  if (![self doesUpdate:newUpdate matchFilters:filters]) {
+  if (![[self class] doesUpdate:newUpdate matchFilters:filters]) {
     return NO;
   }
 
@@ -91,13 +91,13 @@ NS_ASSUME_NONNULL_BEGIN
   }
   // if the current update doesn't pass the manifest filters
   // we should load the new update no matter the commitTime
-  if (![self doesUpdate:launchedUpdate matchFilters:filters]) {
+  if (![[self class] doesUpdate:launchedUpdate matchFilters:filters]) {
     return YES;
   }
   return [launchedUpdate.commitTime compare:newUpdate.commitTime] == NSOrderedAscending;
 }
 
-- (BOOL)doesUpdate:(EXUpdatesUpdate *)update matchFilters:(nullable NSDictionary *)filters
++ (BOOL)doesUpdate:(EXUpdatesUpdate *)update matchFilters:(nullable NSDictionary *)filters
 {
   if (!filters || !update.metadata) {
     return YES;

--- a/packages/expo-updates/ios/Tests/EXUpdatesSelectionPolicyFilterAwareTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesSelectionPolicyFilterAwareTests.m
@@ -173,25 +173,25 @@
     @"firstkey": @"value1",
     @"secondkey": @"wrong-value"
   };
-  XCTAssertFalse([_selectionPolicy doesUpdate:_updateMultipleFilters matchFilters:filtersBadMatch], @"should fail unless all filters pass");
+  XCTAssertFalse([EXUpdatesSelectionPolicyFilterAware doesUpdate:_updateMultipleFilters matchFilters:filtersBadMatch], @"should fail unless all filters pass");
 
   NSDictionary *filtersGoodMatch = @{
     @"firstkey": @"value1",
     @"secondkey": @"value2"
   };
-  XCTAssertTrue([_selectionPolicy doesUpdate:_updateMultipleFilters matchFilters:filtersGoodMatch], @"should pass if all filters pass");
+  XCTAssertTrue([EXUpdatesSelectionPolicyFilterAware doesUpdate:_updateMultipleFilters matchFilters:filtersGoodMatch], @"should pass if all filters pass");
 }
 
 - (void)testDoesUpdateMatchFilters_EmptyMatchesAll
 {
-  XCTAssertTrue([_selectionPolicy doesUpdate:_updateDefault1 matchFilters:@{@"field-that-update-doesnt-have": @"value"}], @"no field counts as a match");
+  XCTAssertTrue([EXUpdatesSelectionPolicyFilterAware doesUpdate:_updateDefault1 matchFilters:@{@"field-that-update-doesnt-have": @"value"}], @"no field counts as a match");
 }
 
 - (void)testDoesUpdateMatchFilters_Null
 {
   // null filters or null updateMetadata (i.e. bare or legacy manifests) is counted as a match
-  XCTAssertTrue([_selectionPolicy doesUpdate:_updateDefault1 matchFilters:nil]);
-  XCTAssertTrue([_selectionPolicy doesUpdate:_updateNoMetadata matchFilters:_manifestFilters]);
+  XCTAssertTrue([EXUpdatesSelectionPolicyFilterAware doesUpdate:_updateDefault1 matchFilters:nil]);
+  XCTAssertTrue([EXUpdatesSelectionPolicyFilterAware doesUpdate:_updateNoMetadata matchFilters:_manifestFilters]);
 }
 
 @end


### PR DESCRIPTION
# Why

Found a couple issues while testing manifest filters (& server defined headers) e2e today that this PR addresses.

# How

Fail earlier on if the manifest doesn't match its own filters; treat it as an error rather than simply a manifest we are choosing not to load (I think this makes sense because it's technically an invalid manifest). Otherwise, if we don't do this, we will persist the bad filters despite not loading the manifest, which can lead to gnarly issues.

# Test Plan

Did the following e2e tests using a local www instance:

*Server defined headers:*
- send `expo-server-defined-headers: expo-rollout-token="47"`, load the update, observe the new header logged in future manifest requests
- send `expo-server-defined-headers: expo-rollout-token="blah"`, load the update, observe the overwritten value logged in future requests
- send `expo-server-defined-headers: ` (empty string), load the update, observe the header no longer being logged in future manifest requests

*Manifest filters:*
- send an update from www which doesn't pass its own filters (and includes a server defined header). Try to load the update, it should fail; ensure the server defined header is NOT included in future manifest requests (to verify the data has not been persisted).
- load an update with `branchName: rollout` and the corresponding filter. Make a new build, overwrite the installation and kill local www. New embedded update should load (empty updateMetadata = pass).
- edit SQLite database manually to add a different `branchName` to the embedded update. Relaunch the app, the previous update (which matches the persisted filter) should load.
- Restart www, load a new update with `branchName: rollout2`. Inspect SQLite json_data table to ensure new filter has been persisted.
