### PR TITLE
[expo-updates][android] only require signatures with expo go

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.java
+++ b/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.java
@@ -180,6 +180,7 @@ public class ExpoUpdatesAppLoader {
     }
 
     configMap.put(UpdatesConfiguration.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY, getRequestHeaders());
+    configMap.put("isExpoGo", true);
 
     UpdatesConfiguration configuration = new UpdatesConfiguration();
     configuration.loadValuesFromMap(configMap);

--- a/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.java
+++ b/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.java
@@ -180,7 +180,7 @@ public class ExpoUpdatesAppLoader {
     }
 
     configMap.put(UpdatesConfiguration.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY, getRequestHeaders());
-    configMap.put("isExpoGo", true);
+    configMap.put("expectsSignedManifest", true);
 
     UpdatesConfiguration configuration = new UpdatesConfiguration();
     configuration.loadValuesFromMap(configMap);

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Switch to SelectionPolicyFilterAware and use persisted manifest filters ([#11993](https://github.com/expo/expo/pull/11993) by [@esamelson](https://github.com/esamelson))
 - Make manifest filters key search case-insensitive ([#12015](https://github.com/expo/expo/pull/12015) by [@esamelson](https://github.com/esamelson))
 - Send persisted serverDefinedHeaders in manifest requests ([#11994](https://github.com/expo/expo/pull/11994) by [@esamelson](https://github.com/esamelson))
+- Only require signatures with expo go (android). ([#12027](https://github.com/expo/expo/pull/12027) by [@jkhales](https://github.com/jkhales))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesConfiguration.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesConfiguration.java
@@ -145,7 +145,7 @@ public class UpdatesConfiguration {
     }
 
     Boolean isExpoGo = readValueCheckingType(map, "isExpoGo", Boolean.class);
-    if ( isExpoGo != null){
+    if (isExpoGo != null) {
       mIsExpoGo = isExpoGo;
     } else {
       mIsExpoGo = false;

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesConfiguration.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesConfiguration.java
@@ -37,7 +37,7 @@ public class UpdatesConfiguration {
   }
 
   private boolean mIsEnabled;
-  private boolean mIsExpoGo = false;
+  private boolean mExpectsSignedManifest = false;
   private String mScopeKey;
   private Uri mUpdateUrl;
   private Map<String, String> mRequestHeaders = new HashMap<>();
@@ -52,8 +52,8 @@ public class UpdatesConfiguration {
   public boolean isEnabled() {
     return mIsEnabled;
   }
-  public boolean isExpoGo() {
-    return mIsExpoGo;
+  public boolean expectsSignedManifest() {
+    return mExpectsSignedManifest;
   }
 
   public String getScopeKey() {
@@ -144,11 +144,11 @@ public class UpdatesConfiguration {
       mIsEnabled = isEnabledFromMap;
     }
 
-    Boolean isExpoGo = readValueCheckingType(map, "isExpoGo", Boolean.class);
-    if (isExpoGo != null) {
-      mIsExpoGo = isExpoGo;
+    Boolean expectsSignedManifest = readValueCheckingType(map, "expectsSignedManifest", Boolean.class);
+    if (expectsSignedManifest != null) {
+      mExpectsSignedManifest = expectsSignedManifest;
     } else {
-      mIsExpoGo = false;
+      mExpectsSignedManifest = false;
     }
 
     Uri updateUrlFromMap = readValueCheckingType(map, UPDATES_CONFIGURATION_UPDATE_URL_KEY, Uri.class);

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesConfiguration.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesConfiguration.java
@@ -37,6 +37,7 @@ public class UpdatesConfiguration {
   }
 
   private boolean mIsEnabled;
+  private boolean mIsExpoGo = false;
   private String mScopeKey;
   private Uri mUpdateUrl;
   private Map<String, String> mRequestHeaders = new HashMap<>();
@@ -50,6 +51,9 @@ public class UpdatesConfiguration {
 
   public boolean isEnabled() {
     return mIsEnabled;
+  }
+  public boolean isExpoGo() {
+    return mIsExpoGo;
   }
 
   public String getScopeKey() {
@@ -139,6 +143,8 @@ public class UpdatesConfiguration {
     if (isEnabledFromMap != null) {
       mIsEnabled = isEnabledFromMap;
     }
+
+    mIsExpoGo = !!readValueCheckingType(map, "isExpoGo", Boolean.class);
 
     Uri updateUrlFromMap = readValueCheckingType(map, UPDATES_CONFIGURATION_UPDATE_URL_KEY, Uri.class);
     if (updateUrlFromMap != null) {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesConfiguration.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesConfiguration.java
@@ -144,7 +144,12 @@ public class UpdatesConfiguration {
       mIsEnabled = isEnabledFromMap;
     }
 
-    mIsExpoGo = !!readValueCheckingType(map, "isExpoGo", Boolean.class);
+    Boolean isExpoGo = readValueCheckingType(map, "isExpoGo", Boolean.class);
+    if ( isExpoGo != null){
+      mIsExpoGo = isExpoGo;
+    } else {
+      mIsExpoGo = false;
+    }
 
     Uri updateUrlFromMap = readValueCheckingType(map, UPDATES_CONFIGURATION_UPDATE_URL_KEY, Uri.class);
     if (updateUrlFromMap != null) {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.java
@@ -166,7 +166,9 @@ public class FileDownloader {
                   }
               );
             } else {
-              preManifest.put("isVerified", false);
+              if (configuration.expectsSignedManifest()) {
+                preManifest.put("isVerified", false);
+              }
               Manifest manifest = ManifestFactory.getManifest(preManifest, new ManifestResponse(response), configuration);
               callback.onSuccess(manifest);
             }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.java
@@ -294,7 +294,7 @@ public class FileDownloader {
             .header("Expo-API-Version", "1")
             .header("Expo-Updates-Environment", "BARE")
             .header("Expo-JSON-Error", "true")
-            .header("Expo-Accept-Signature", String.valueOf(configuration.isExpoGo()));
+            .header("Expo-Accept-Signature", String.valueOf(configuration.expectsSignedManifest()));
 
     // legacy manifest loads should ignore cache-control headers from the server and always load remotely
     if (configuration.usesLegacyManifest()) {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.java
@@ -294,8 +294,7 @@ public class FileDownloader {
             .header("Expo-API-Version", "1")
             .header("Expo-Updates-Environment", "BARE")
             .header("Expo-JSON-Error", "true")
-            // as of 2020-11-25, the EAS Update alpha returns an error if Expo-Accept-Signature: true is included in the request
-            .header("Expo-Accept-Signature", String.valueOf(configuration.usesLegacyManifest()));
+            .header("Expo-Accept-Signature", String.valueOf(configuration.isExpoGo()));
 
     // legacy manifest loads should ignore cache-control headers from the server and always load remotely
     if (configuration.usesLegacyManifest()) {


### PR DESCRIPTION
# Why

Only require signatures with expo go.

# How

Add an `isExpoGo` field that is default false. Set it true when calling from Expo Go.

# Test Plan

Logged the response body of an update in Expo Go and a bare app to make sure they returned, respectively, signed and unsigned responses.
