### PR TITLE
Update to latest AdMob iOS SDK iOS 14.5 (#11934)

### DIFF
--- a/packages/expo-ads-admob/ios/EXAdsAdMob.podspec
+++ b/packages/expo-ads-admob/ios/EXAdsAdMob.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.source         = { git: 'https://github.com/expo/expo.git' }
 
   s.dependency 'UMCore'
-  s.dependency 'Google-Mobile-Ads-SDK', "8.1.0"
+  s.dependency 'Google-Mobile-Ads-SDK', "7.69.0"
 
   if !$ExpoUseSources&.include?(package['name']) && ENV['EXPO_USE_SOURCE'].to_i == 0 && File.exist?("#{s.name}.xcframework") && Gem::Version.new(Pod::VERSION) >= Gem::Version.new('1.10.0')
     s.source_files = "#{s.name}/**/*.h"

--- a/packages/expo-ads-admob/ios/EXAdsAdMob.podspec
+++ b/packages/expo-ads-admob/ios/EXAdsAdMob.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.source         = { git: 'https://github.com/expo/expo.git' }
 
   s.dependency 'UMCore'
-  s.dependency 'Google-Mobile-Ads-SDK', "7.55.1"
+  s.dependency 'Google-Mobile-Ads-SDK', "8.1.0"
 
   if !$ExpoUseSources&.include?(package['name']) && ENV['EXPO_USE_SOURCE'].to_i == 0 && File.exist?("#{s.name}.xcframework") && Gem::Version.new(Pod::VERSION) >= Gem::Version.new('1.10.0')
     s.source_files = "#{s.name}/**/*.h"


### PR DESCRIPTION
# Why

Issue #11934 - support AdMob on iOS 14.5 

# How
Changed the Cocopod Admob dependency version to the latest version as seen on Google's developers site

# Test Plan

Add all currently supported Admob components as seen on the documentation  
https://docs.expo.io/versions/latest/sdk/admob/ 
