### PR TITLE
Properly format expo-in-app-purchases prices with correct locale currency

### DIFF
--- a/packages/expo-in-app-purchases/ios/EXInAppPurchases/EXInAppPurchasesModule.m
+++ b/packages/expo-in-app-purchases/ios/EXInAppPurchases/EXInAppPurchasesModule.m
@@ -324,9 +324,13 @@ UM_EXPORT_METHOD_AS(disconnectAsync,
   
   NSDecimalNumber *oneMillion = [[NSDecimalNumber alloc] initWithInt:1000000];
   NSDecimalNumber *priceAmountMicros = [product.price decimalNumberByMultiplyingBy:oneMillion];
-  NSString *price = [NSString stringWithFormat:@"%@%@", product.priceLocale.currencySymbol, product.price];
   NSString *description = product.localizedDescription ?: @"";
   NSString *title = product.localizedTitle ?: @"";
+  
+  NSNumberFormatter *priceFormatter = [[NSNumberFormatter alloc]init];
+  priceFormatter.numberStyle = NSNumberFormatterCurrencyStyle;
+  priceFormatter.locale = product.priceLocale;
+  NSString *price = [priceFormatter stringFromNumber:product.price];
   
   return @{
            @"description": description,

--- a/packages/expo-in-app-purchases/ios/EXInAppPurchases/EXInAppPurchasesModule.m
+++ b/packages/expo-in-app-purchases/ios/EXInAppPurchases/EXInAppPurchasesModule.m
@@ -327,7 +327,7 @@ UM_EXPORT_METHOD_AS(disconnectAsync,
   NSString *description = product.localizedDescription ?: @"";
   NSString *title = product.localizedTitle ?: @"";
   
-  NSNumberFormatter *priceFormatter = [[NSNumberFormatter alloc]init];
+  NSNumberFormatter *priceFormatter = [[NSNumberFormatter alloc] init];
   priceFormatter.numberStyle = NSNumberFormatterCurrencyStyle;
   priceFormatter.locale = product.priceLocale;
   NSString *price = [priceFormatter stringFromNumber:product.price];


### PR DESCRIPTION
# Why

Currently, on iOS, the format for prices is always [CURRENCY_SYMBOL] + [PRICE], which is correct for USD ("$10") but incorrect for SEK ("kr10" instead of "10kr" which is the correct format).

# How

Use iOS's built-in NSNumberFormatter with NSNumberFormatterCurrencyStyle and correct locale instead of manually concatenating symbol + price.

# Test Plan

When calling getProductsAsync() on iOS with currencies where the currency symbol's location should be after the number value, for example SEK (Swedish Krona).
