### PR TITLE
[android][bare] Issue #12002: Fix bare templates on Android to avoid potential inconsistencies when restoring from background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Package-specific changes not released in any SDK will be added here just before 
 ### 🐛 Bug fixes
 
 - Fix Expo CLI logging, which was not always limiting the length of strings to 10k characters. ([#11776](https://github.com/expo/expo/pull/11776) by [@fson](https://github.com/fson))
+- Fix bare templates on Android to pass `null` to `com/facebook/react/ReactActivity.onCreate` to [avoid potential inconsistencies when restoring from background](https://github.com/expo/expo/issues/12002).
 
 ## 40.0.0 — 2020-11-17
 

--- a/templates/expo-template-bare-minimum/android/app/src/main/java/com/helloworld/MainActivity.java
+++ b/templates/expo-template-bare-minimum/android/app/src/main/java/com/helloworld/MainActivity.java
@@ -13,7 +13,7 @@ import expo.modules.splashscreen.SplashScreenImageResizeMode;
 public class MainActivity extends ReactActivity {
   @Override
   protected void onCreate(Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
+    super.onCreate(null);
     // SplashScreen.show(...) has to be called after super.onCreate(...)
     // Below line is handled by '@expo/configure-splash-screen' command and it's discouraged to modify it manually
     SplashScreen.show(this, SplashScreenImageResizeMode.CONTAIN, ReactRootView.class, false);

--- a/templates/expo-template-bare-typescript/android/app/src/main/java/com/helloworld/MainActivity.java
+++ b/templates/expo-template-bare-typescript/android/app/src/main/java/com/helloworld/MainActivity.java
@@ -13,7 +13,7 @@ import expo.modules.splashscreen.SplashScreenImageResizeMode;
 public class MainActivity extends ReactActivity {
   @Override
   protected void onCreate(Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
+    super.onCreate(null);
     // SplashScreen.show(...) has to be called after super.onCreate(...)
     // Below line is handled by '@expo/configure-splash-screen' command and it's discouraged to modify it manually
     SplashScreen.show(this, SplashScreenImageResizeMode.CONTAIN, ReactRootView.class, false);


### PR DESCRIPTION
Unless a developer makes a conscious effort to carefully restore app state,
restoring from background generally won't work [1]; worse, it may cause
crashes [2]. Given this possibility, it's better to default the bare
template to avoid this issue.

[1] https://github.com/software-mansion/react-native-screens/issues/17#issuecomment-425027574
[2] https://github.com/software-mansion/react-native-screens/tree/2.18.0#android

# Why

https://github.com/expo/expo/issues/12002

# How

Template modifications

# Test Plan

1. `expo init testtemplate --template $PATH/expo-template-bare-minimum`
1. Review MainActivity.java
1. Test the app