### PR TITLE
[notifications][ios] Scope notification identifiers

### DIFF
--- a/ios/ExpoNotificationServiceExtension/NotificationService.swift
+++ b/ios/ExpoNotificationServiceExtension/NotificationService.swift
@@ -17,7 +17,7 @@ class NotificationService: UNNotificationServiceExtension {
     if let bestAttemptContent = request.content.mutableCopy() as? UNMutableNotificationContent {
       // Modify notification content here...
       if (!request.content.categoryIdentifier.isEmpty && (request.content.userInfo["experienceId"]) != nil) {
-        bestAttemptContent.categoryIdentifier = EXScopedNotificationsUtils.scopedCategoryIdentifier(withId: request.content.categoryIdentifier, forExperience: request.content.userInfo["experienceId"] as! String)
+        bestAttemptContent.categoryIdentifier = EXScopedNotificationsUtils.scopedIdentifier(fromId: request.content.categoryIdentifier, forExperience: request.content.userInfo["experienceId"] as! String)
       }
       contentHandler(bestAttemptContent)
     }

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationBuilder.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationBuilder.m
@@ -34,8 +34,8 @@
   [content setUserInfo:userInfo];
   
   if (content.categoryIdentifier && _isInExpoGo) {
-    NSString *scopedCategoryIdentifier = [EXScopedNotificationsUtils scopedCategoryIdentifierWithId:content.categoryIdentifier
-                                                                                      forExperience:_experienceId];
+    NSString *scopedCategoryIdentifier = [EXScopedNotificationsUtils scopedIdentifierFromId:content.categoryIdentifier
+                                                                              forExperience:_experienceId];
     [content setCategoryIdentifier:scopedCategoryIdentifier];
   }
   

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationCategoriesModule.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationCategoriesModule.m
@@ -26,7 +26,7 @@
   [[UNUserNotificationCenter currentNotificationCenter] getNotificationCategoriesWithCompletionHandler:^(NSSet<UNNotificationCategory *> *categories) {
     NSMutableArray* existingCategories = [NSMutableArray new];
     for (UNNotificationCategory *category in categories) {
-      if ([EXScopedNotificationsUtils isCategoryId:category.identifier scopedByExperience:self->_experienceId]) {
+      if ([EXScopedNotificationsUtils isId:category.identifier scopedByExperience:self->_experienceId]) {
         [existingCategories addObject:[self serializeCategory:category]];
       }
     }
@@ -40,8 +40,8 @@
                                       resolve:(UMPromiseResolveBlock)resolve
                                        reject:(UMPromiseRejectBlock)reject
 {
-  NSString *scopedCategoryIdentifier = [EXScopedNotificationsUtils scopedCategoryIdentifierWithId:categoryId
-                                                                                    forExperience:_experienceId];
+  NSString *scopedCategoryIdentifier = [EXScopedNotificationsUtils scopedIdentifierFromId:categoryId
+                                                                            forExperience:_experienceId];
   [super setNotificationCategoryWithCategoryId:scopedCategoryIdentifier
                                        actions:actions
                                        options:options
@@ -53,8 +53,8 @@
                                          resolve:(UMPromiseResolveBlock)resolve
                                           reject:(UMPromiseRejectBlock)reject
 {
-  NSString *scopedCategoryIdentifier = [EXScopedNotificationsUtils scopedCategoryIdentifierWithId:categoryId
-                                                                                    forExperience:_experienceId];
+  NSString *scopedCategoryIdentifier = [EXScopedNotificationsUtils scopedIdentifierFromId:categoryId
+                                                                            forExperience:_experienceId];
   [super deleteNotificationCategoryWithCategoryId:scopedCategoryIdentifier
                                           resolve:resolve
                                            reject:reject];
@@ -63,7 +63,7 @@
 - (NSMutableDictionary *)serializeCategory:(UNNotificationCategory *)category
 {
   NSMutableDictionary* serializedCategory = [EXNotificationCategoriesModule serializeCategory:category];
-  serializedCategory[@"identifier"] = [EXScopedNotificationsUtils getScopeAndIdentifierFromScopedIdentifier:serializedCategory[@"identifier"]].categoryIdentifier;
+  serializedCategory[@"identifier"] = [EXScopedNotificationsUtils getScopeAndIdentifierFromScopedIdentifier:serializedCategory[@"identifier"]].identifier;
 
   return serializedCategory;
 }

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationCategoryMigrator.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationCategoryMigrator.m
@@ -9,7 +9,8 @@
 {
   [EXScopedNotificationCategoryMigrator renameLegacyCategoryIdentifiersForExperience:experienceId withBlock:^(UNNotificationCategory *oldCategory) {
     NSString *unscopedLegacyCategoryId = [EXScopedNotificationsUtils unscopedLegacyCategoryIdentifierWithId:oldCategory.identifier forExperience:experienceId];
-    NSString *newCategoryId = [EXScopedNotificationsUtils scopedCategoryIdentifierWithId:unscopedLegacyCategoryId forExperience:experienceId];
+    NSString *newCategoryId = [EXScopedNotificationsUtils scopedIdentifierFromId:unscopedLegacyCategoryId
+                                                                   forExperience:experienceId];
     UNNotificationCategory *newCategory = [EXScopedNotificationCategoryMigrator createNewCategoryFrom:oldCategory withNewIdentifier:newCategoryId];
     return newCategory;
   }];

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationPresentationModule.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationPresentationModule.m
@@ -3,6 +3,7 @@
 #import "EXScopedNotificationPresentationModule.h"
 #import "EXScopedNotificationsUtils.h"
 #import "EXScopedNotificationSerializer.h"
+#import "EXScopedNotificationsUtils.h"
 
 @interface EXScopedNotificationPresentationModule ()
 
@@ -37,9 +38,13 @@
   __block NSString *experienceId = _experienceId;
   [[UNUserNotificationCenter currentNotificationCenter] getDeliveredNotificationsWithCompletionHandler:^(NSArray<UNNotification *> * _Nonnull notifications) {
     for (UNNotification *notification in notifications) {
-      if ([notification.request.identifier isEqual:identifier]) {
-        if ([EXScopedNotificationsUtils shouldNotification:notification beHandledByExperience:experienceId]) {
-          [[UNUserNotificationCenter currentNotificationCenter] removeDeliveredNotificationsWithIdentifiers:@[identifier]];
+      if ([EXScopedNotificationsUtils shouldNotification:notification beHandledByExperience:experienceId]) {
+        // Usually we would scope the input ID and then check equality, but remote notifications do not
+        // have the scoping prefix, so instead let's remove the scope if there is one, then check for
+        // equality against the input
+        NSString *unscopedIdentifier = [EXScopedNotificationsUtils getScopeAndIdentifierFromScopedIdentifier:notification.request.identifier].categoryIdentifier;
+        if ([unscopedIdentifier isEqualToString:identifier]) {
+          [[UNUserNotificationCenter currentNotificationCenter] removeDeliveredNotificationsWithIdentifiers:@[notification.request.identifier]];
         }
         break;
       }

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationPresentationModule.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationPresentationModule.m
@@ -42,7 +42,7 @@
         // Usually we would scope the input ID and then check equality, but remote notifications do not
         // have the scoping prefix, so instead let's remove the scope if there is one, then check for
         // equality against the input
-        NSString *unscopedIdentifier = [EXScopedNotificationsUtils getScopeAndIdentifierFromScopedIdentifier:notification.request.identifier].categoryIdentifier;
+        NSString *unscopedIdentifier = [EXScopedNotificationsUtils getScopeAndIdentifierFromScopedIdentifier:notification.request.identifier].identifier;
         if ([unscopedIdentifier isEqualToString:identifier]) {
           [[UNUserNotificationCenter currentNotificationCenter] removeDeliveredNotificationsWithIdentifiers:@[notification.request.identifier]];
         }

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationSchedulerModule.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationSchedulerModule.m
@@ -3,6 +3,7 @@
 #import "EXScopedNotificationSchedulerModule.h"
 #import "EXScopedNotificationsUtils.h"
 #import "EXScopedNotificationSerializer.h"
+#import "EXScopedNotificationsUtils.h"
 
 @interface EXScopedNotificationSchedulerModule ()
 
@@ -10,8 +11,6 @@
 
 @end
 
-// TODO: (@lukmccall) experiences may break one another by trying to schedule notifications of the same identifier.
-// See https://github.com/expo/expo/pull/8361#discussion_r429153429.
 @implementation EXScopedNotificationSchedulerModule
 
 - (instancetype)initWithExperienceId:(NSString *)experienceId
@@ -23,31 +22,32 @@
   return self;
 }
 
+- (UNNotificationRequest *)buildNotificationRequestWithIdentifier:(NSString *)identifier
+                                                          content:(NSDictionary *)contentInput
+                                                          trigger:(NSDictionary *)triggerInput
+{
+  NSString *scopedIdentifier = [EXScopedNotificationsUtils scopedCategoryIdentifierWithId:identifier
+                                                                                    forExperience:_experienceId];
+  return [super buildNotificationRequestWithIdentifier:scopedIdentifier content:contentInput trigger:triggerInput];
+}
+
 - (NSArray * _Nonnull)serializeNotificationRequests:(NSArray<UNNotificationRequest *> * _Nonnull) requests;
 {
   NSMutableArray *serializedRequests = [NSMutableArray new];
   for (UNNotificationRequest *request in requests) {
-    if ([EXScopedNotificationsUtils shouldNotificationRequest:request beHandledByExperience:_experienceId]) {
+    if ([EXScopedNotificationsUtils isCategoryId:request.identifier scopedByExperience:_experienceId]) {
       [serializedRequests addObject:[EXScopedNotificationSerializer serializedNotificationRequest:request]];
     }
   }
   return serializedRequests;
 }
 
+
 - (void)cancelNotification:(NSString *)identifier resolve:(UMPromiseResolveBlock)resolve rejecting:(UMPromiseRejectBlock)reject
 {
-  __block NSString *experienceId = _experienceId;
-  [[UNUserNotificationCenter currentNotificationCenter] getPendingNotificationRequestsWithCompletionHandler:^(NSArray<UNNotificationRequest *> * _Nonnull requests) {
-    for (UNNotificationRequest *request in requests) {
-      if ([request.identifier isEqual:identifier]) {
-        if ([EXScopedNotificationsUtils shouldNotificationRequest:request beHandledByExperience:experienceId]) {
-          [[UNUserNotificationCenter currentNotificationCenter] removePendingNotificationRequestsWithIdentifiers:@[identifier]];
-        }
-        break;
-      }
-    }
-    resolve(nil);
-  }];
+  NSString *scopedIdentifier = [EXScopedNotificationsUtils scopedCategoryIdentifierWithId:identifier
+                                                                            forExperience:_experienceId];
+  [super cancelNotification:scopedIdentifier resolve:resolve rejecting:reject];
 }
 
 - (void)cancelAllNotificationsWithResolver:(UMPromiseResolveBlock)resolve rejecting:(UMPromiseRejectBlock)reject
@@ -56,7 +56,7 @@
   [[UNUserNotificationCenter currentNotificationCenter] getPendingNotificationRequestsWithCompletionHandler:^(NSArray<UNNotificationRequest *> * _Nonnull requests) {
     NSMutableArray<NSString *> *toRemove = [NSMutableArray new];
     for (UNNotificationRequest *request in requests) {
-      if ([EXScopedNotificationsUtils shouldNotificationRequest:request beHandledByExperience:experienceId]) {
+      if ([EXScopedNotificationsUtils isCategoryId:request.identifier scopedByExperience:experienceId]) {
         [toRemove addObject:request.identifier];
       }
     }

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationSchedulerModule.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationSchedulerModule.m
@@ -26,8 +26,8 @@
                                                           content:(NSDictionary *)contentInput
                                                           trigger:(NSDictionary *)triggerInput
 {
-  NSString *scopedIdentifier = [EXScopedNotificationsUtils scopedCategoryIdentifierWithId:identifier
-                                                                                    forExperience:_experienceId];
+  NSString *scopedIdentifier = [EXScopedNotificationsUtils scopedIdentifierFromId:identifier
+                                                                    forExperience:_experienceId];
   return [super buildNotificationRequestWithIdentifier:scopedIdentifier content:contentInput trigger:triggerInput];
 }
 
@@ -35,7 +35,7 @@
 {
   NSMutableArray *serializedRequests = [NSMutableArray new];
   for (UNNotificationRequest *request in requests) {
-    if ([EXScopedNotificationsUtils isCategoryId:request.identifier scopedByExperience:_experienceId]) {
+    if ([EXScopedNotificationsUtils isId:request.identifier scopedByExperience:_experienceId]) {
       [serializedRequests addObject:[EXScopedNotificationSerializer serializedNotificationRequest:request]];
     }
   }
@@ -45,8 +45,8 @@
 
 - (void)cancelNotification:(NSString *)identifier resolve:(UMPromiseResolveBlock)resolve rejecting:(UMPromiseRejectBlock)reject
 {
-  NSString *scopedIdentifier = [EXScopedNotificationsUtils scopedCategoryIdentifierWithId:identifier
-                                                                            forExperience:_experienceId];
+  NSString *scopedIdentifier = [EXScopedNotificationsUtils scopedIdentifierFromId:identifier
+                                                                    forExperience:_experienceId];
   [super cancelNotification:scopedIdentifier resolve:resolve rejecting:reject];
 }
 
@@ -56,7 +56,7 @@
   [[UNUserNotificationCenter currentNotificationCenter] getPendingNotificationRequestsWithCompletionHandler:^(NSArray<UNNotificationRequest *> * _Nonnull requests) {
     NSMutableArray<NSString *> *toRemove = [NSMutableArray new];
     for (UNNotificationRequest *request in requests) {
-      if ([EXScopedNotificationsUtils isCategoryId:request.identifier scopedByExperience:experienceId]) {
+      if ([EXScopedNotificationsUtils isId:request.identifier scopedByExperience:experienceId]) {
         [toRemove addObject:request.identifier];
       }
     }

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationSerializer.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationSerializer.m
@@ -29,7 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
   NSDictionary *serializedContent = [super serializedNotificationContent:request];
   NSMutableDictionary *serializedContentMutable = [serializedContent mutableCopy];
-  serializedContentMutable[@"categoryIdentifier"] = request.content.categoryIdentifier ? [EXScopedNotificationsUtils getScopeAndIdentifierFromScopedIdentifier:request.content.categoryIdentifier].categoryIdentifier : [NSNull null];
+  serializedContentMutable[@"categoryIdentifier"] = request.content.categoryIdentifier ? [EXScopedNotificationsUtils getScopeAndIdentifierFromScopedIdentifier:request.content.categoryIdentifier].identifier : [NSNull null];
   
   return [serializedContentMutable copy];
 }
@@ -38,7 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
   NSDictionary* serializedRequest = [super serializedNotificationRequest:request];
   NSMutableDictionary *serializedRequestMutable = [serializedRequest mutableCopy];
-  serializedRequestMutable[@"identifier"] = [EXScopedNotificationsUtils getScopeAndIdentifierFromScopedIdentifier:request.identifier].categoryIdentifier;
+  serializedRequestMutable[@"identifier"] = [EXScopedNotificationsUtils getScopeAndIdentifierFromScopedIdentifier:request.identifier].identifier;
 
   return [serializedRequestMutable copy];
 }

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationSerializer.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationSerializer.m
@@ -34,6 +34,15 @@ NS_ASSUME_NONNULL_BEGIN
   return [serializedContentMutable copy];
 }
 
++ (NSDictionary *)serializedNotificationRequest:(UNNotificationRequest *)request
+{
+  NSDictionary* serializedRequest = [super serializedNotificationRequest:request];
+  NSMutableDictionary *serializedRequestMutable = [serializedRequest mutableCopy];
+  serializedRequestMutable[@"identifier"] = [EXScopedNotificationsUtils getScopeAndIdentifierFromScopedIdentifier:request.identifier].categoryIdentifier;
+
+  return [serializedRequestMutable copy];
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationsUtils.h
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationsUtils.h
@@ -6,8 +6,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 typedef struct {
     NSString *scopeKey;
-    NSString *categoryIdentifier;
-} ScopedCategoryIdentifierComponents;
+    NSString *identifier;
+} ScopedIdentifierComponents;
 
 @interface EXScopedNotificationsUtils : NSObject
 
@@ -15,11 +15,11 @@ typedef struct {
 
 + (BOOL)shouldNotification:(UNNotification *)notification beHandledByExperience:(NSString *)experienceId;
 
-+ (NSString *)scopedCategoryIdentifierWithId:(NSString *)categoryId forExperience:(NSString *)experienceId;
++ (NSString *)scopedIdentifierFromId:(NSString *)unscopedId forExperience:(NSString *)experienceId;
 
-+ (BOOL)isCategoryId:(NSString *)identifier scopedByExperience:(NSString *)experienceId;
++ (BOOL)isId:(NSString *)identifier scopedByExperience:(NSString *)experienceId;
 
-+ (ScopedCategoryIdentifierComponents)getScopeAndIdentifierFromScopedIdentifier:(NSString *)scopedIdentifier;
++ (ScopedIdentifierComponents)getScopeAndIdentifierFromScopedIdentifier:(NSString *)scopedIdentifier;
 
 + (BOOL)isLegacyCategoryId:(NSString *) scopedCategoryId scopedByExperience:(NSString *) experienceId;
 

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationsUtils.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationsUtils.m
@@ -18,6 +18,7 @@
   return [EXScopedNotificationsUtils shouldNotificationRequest:notification.request beHandledByExperience:experienceId];
 }
 
+// rename method to scope identifier? or create new method
 + (NSString *)scopedCategoryIdentifierWithId:(NSString *)categoryId forExperience:(NSString *)experienceId
 {
   NSString *scope = [EXScopedNotificationsUtils escapedString:experienceId];

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationsUtils.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationsUtils.m
@@ -18,21 +18,20 @@
   return [EXScopedNotificationsUtils shouldNotificationRequest:notification.request beHandledByExperience:experienceId];
 }
 
-// rename method to scope identifier? or create new method
-+ (NSString *)scopedCategoryIdentifierWithId:(NSString *)categoryId forExperience:(NSString *)experienceId
++ (NSString *)scopedIdentifierFromId:(NSString *)unscopedId forExperience:(NSString *)experienceId
 {
   NSString *scope = [EXScopedNotificationsUtils escapedString:experienceId];
-  NSString *escapedCategoryId = [EXScopedNotificationsUtils escapedString:categoryId];
+  NSString *escapedCategoryId = [EXScopedNotificationsUtils escapedString:unscopedId];
   return [NSString stringWithFormat:@"%@/%@", scope, escapedCategoryId];
 }
 
-+ (BOOL)isCategoryId:(NSString *)identifier scopedByExperience:(NSString *)experienceId
++ (BOOL)isId:(NSString *)identifier scopedByExperience:(NSString *)experienceId
 {
   NSString *scopeFromCategoryId = [EXScopedNotificationsUtils getScopeAndIdentifierFromScopedIdentifier:identifier].scopeKey;
   return [scopeFromCategoryId isEqualToString:experienceId];
 }
 
-+ (ScopedCategoryIdentifierComponents)getScopeAndIdentifierFromScopedIdentifier:(NSString *)scopedIdentifier
++ (ScopedIdentifierComponents)getScopeAndIdentifierFromScopedIdentifier:(NSString *)scopedIdentifier
 {
   NSString *scope = @"";
   NSString *identifier = @"";
@@ -54,9 +53,9 @@
     scope = [scopedIdentifier substringWithRange:[match rangeAtIndex:1]];
     identifier = [scopedIdentifier substringWithRange:[match rangeAtIndex:2]];
   }
-  ScopedCategoryIdentifierComponents components;
+  ScopedIdentifierComponents components;
   components.scopeKey = [EXScopedNotificationsUtils unescapedString:scope];
-  components.categoryIdentifier = [EXScopedNotificationsUtils unescapedString:identifier];
+  components.identifier = [EXScopedNotificationsUtils unescapedString:identifier];
   return components;
 }
 

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXScopedModuleRegistryAdapter.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXScopedModuleRegistryAdapter.m
@@ -145,13 +145,19 @@
 #endif
 
 #if __has_include(<EXNotifications/EXNotificationsEmitter.h>)
-  EXScopedNotificationsEmitter *notificationsEmmitter = [[EXScopedNotificationsEmitter alloc] initWithExperienceId:experienceId];
-  [moduleRegistry registerExportedModule:notificationsEmmitter];
+  // only override in Expo Go
+  if ([params[@"constants"][@"appOwnership"] isEqualToString:@"expo"]) {
+    EXScopedNotificationsEmitter *notificationsEmmitter = [[EXScopedNotificationsEmitter alloc] initWithExperienceId:experienceId];
+    [moduleRegistry registerExportedModule:notificationsEmmitter];
+  }
 #endif
   
 #if __has_include(<EXNotifications/EXNotificationsHandlerModule.h>)
-  EXScopedNotificationsHandlerModule *notificationsHandler = [[EXScopedNotificationsHandlerModule alloc] initWithExperienceId:experienceId];
-  [moduleRegistry registerExportedModule:notificationsHandler];
+  // only override in Expo Go
+  if ([params[@"constants"][@"appOwnership"] isEqualToString:@"expo"]) {
+    EXScopedNotificationsHandlerModule *notificationsHandler = [[EXScopedNotificationsHandlerModule alloc] initWithExperienceId:experienceId];
+    [moduleRegistry registerExportedModule:notificationsHandler];
+  }
 #endif
   
 #if __has_include(<EXNotifications/EXNotificationsHandlerModule.h>)
@@ -168,8 +174,11 @@
 #endif
     
 #if __has_include(<EXNotifications/EXNotificationPresentationModule.h>)
-  EXScopedNotificationPresentationModule *notificationPresentationModule = [[EXScopedNotificationPresentationModule alloc] initWithExperienceId:experienceId];
-  [moduleRegistry registerExportedModule:notificationPresentationModule];
+  // only override in Expo Go
+  if ([params[@"constants"][@"appOwnership"] isEqualToString:@"expo"]) {
+    EXScopedNotificationPresentationModule *notificationPresentationModule = [[EXScopedNotificationPresentationModule alloc] initWithExperienceId:experienceId];
+    [moduleRegistry registerExportedModule:notificationPresentationModule];
+  }
 #endif
   
 #if __has_include(<EXNotifications/EXNotificationCategoriesModule.h>)

--- a/packages/expo-notifications/ios/EXNotifications/Notifications/Presenting/EXNotificationPresentationModule.h
+++ b/packages/expo-notifications/ios/EXNotifications/Notifications/Presenting/EXNotificationPresentationModule.h
@@ -8,4 +8,6 @@
 
 - (NSArray * _Nonnull)serializeNotifications:(NSArray<UNNotification *> * _Nonnull)notifications;
 
+- (void)dismissNotificationWithIdentifier:(NSString *)identifier resolve:(UMPromiseResolveBlock)resolve reject:(UMPromiseRejectBlock)reject;
+
 @end

--- a/packages/expo-notifications/ios/EXNotifications/Notifications/Scheduling/EXNotificationSchedulerModule.h
+++ b/packages/expo-notifications/ios/EXNotifications/Notifications/Scheduling/EXNotificationSchedulerModule.h
@@ -14,6 +14,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)cancelAllNotificationsWithResolver:(UMPromiseResolveBlock)resolve rejecting:(UMPromiseRejectBlock)reject;
 
+- (UNNotificationRequest *)buildNotificationRequestWithIdentifier:(NSString *)identifier content:(NSDictionary *)contentInput trigger:(NSDictionary *)triggerInput;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/packages/expo-notifications/ios/EXNotifications/Notifications/Scheduling/EXNotificationSchedulerModule.m
+++ b/packages/expo-notifications/ios/EXNotifications/Notifications/Scheduling/EXNotificationSchedulerModule.m
@@ -67,8 +67,7 @@ UM_EXPORT_METHOD_AS(scheduleNotificationAsync,
                      scheduleNotification:(NSString *)identifier notificationSpec:(NSDictionary *)notificationSpec triggerSpec:(NSDictionary *)triggerSpec resolve:(UMPromiseResolveBlock)resolve rejecting:(UMPromiseRejectBlock)reject)
 {
   @try {
-    UNNotificationContent *content = [_builder notificationContentFromRequest:notificationSpec];
-    UNNotificationRequest *request = [UNNotificationRequest requestWithIdentifier:identifier content:content trigger:[self triggerFromParams:triggerSpec]];
+    UNNotificationRequest *request = [self buildNotificationRequestWithIdentifier:identifier content:notificationSpec trigger:triggerSpec];
     [[UNUserNotificationCenter currentNotificationCenter] addNotificationRequest:request withCompletionHandler:^(NSError * _Nullable error) {
       if (error) {
         NSString *message = [NSString stringWithFormat:@"Failed to schedule notification. %@", error];
@@ -120,6 +119,15 @@ UM_EXPORT_METHOD_AS(getNextTriggerDateAsync,
     NSString *message = [NSString stringWithFormat:@"Failed to get next trigger date. %@", exception];
     reject(@"ERR_NOTIFICATIONS_FAILED_TO_GET_NEXT_TRIGGER_DATE", message, nil);
   }
+}
+
+- (UNNotificationRequest *)buildNotificationRequestWithIdentifier:(NSString *)identifier
+                                                          content:(NSDictionary *)contentInput
+                                                          trigger:(NSDictionary *)triggerInput
+{
+  UNNotificationContent *content = [_builder notificationContentFromRequest:contentInput];
+  UNNotificationRequest *request = [UNNotificationRequest requestWithIdentifier:identifier content:content trigger:[self triggerFromParams:triggerInput]];
+  return request;
 }
 
 - (NSArray * _Nonnull)serializeNotificationRequests:(NSArray<UNNotificationRequest *> * _Nonnull) requests


### PR DESCRIPTION
# Why

Companion to https://github.com/expo/expo/pull/12050

Fix bug where different experiences in Expo Go could overwrite each others' notifications (and pave the way for over writable notifications in Expo Go, although that will probably require a server-side PR)

It's possible this could be made even simpler by scoping notification identifiers on the server side, but will need to spend a bit more time looking into that

# How

- used the existing scoping logic implemented in https://github.com/expo/expo/pull/11651 to scope notification request IDs
- only do this scoping in Expo Go (`EXScopedNotificationsEmitterModule`, `EXScopedNotificationsHandlerModule`, and `EXScopedNotificationPresentationModule` are now only used in Expo Go, not standalone apps)

# Test Plan

Tested in Expo Go, local notifications from other experiences cannot over write each other, dismiss each other, or serialize each other. 

Tested in standalone, notifications handling/emitting/ and presenting all work as expected