### PR TITLE
remove() function is declared over .current value

### DIFF
--- a/docs/pages/push-notifications/overview.md
+++ b/docs/pages/push-notifications/overview.md
@@ -55,8 +55,8 @@ export default function App() {
     });
 
     return () => {
-      Notifications.removeNotificationSubscription(notificationListener);
-      Notifications.removeNotificationSubscription(responseListener);
+      Notifications.removeNotificationSubscription(notificationListener.current);
+      Notifications.removeNotificationSubscription(responseListener.current);
     };
   }, []);
 


### PR DESCRIPTION
# Why

I am building a project with typescript and the ts compiler shouts at me `Property 'remove' is missing in type 'MutableRefObject<Subscription | undefined>' but required in type 'Subscription'` so I realized .current is missing from the example snippet.

# How

With the power of typescript

# Test Plan

N/A
