### PR TITLE
[docs] EAS Build - workaround for npm cache for yarn v1

### DIFF
--- a/docs/pages/build-reference/how-tos.md
+++ b/docs/pages/build-reference/how-tos.md
@@ -71,3 +71,16 @@ This is an example of how your package.json might look like:
 ```
 
 If you are not using `credentials.json` for Android/iOS credentials, it is fine for `experimental.npmToken` to be the only entry in the file. Add `credentials.json` to `.gitignore` if it's not there already.
+
+## Using npm cache with yarn v1
+
+By default npm cache deployed on EAS Build won't work with yarn v1, because `yarn.lock` files contain urls to registries for every package and yarn does not provide any way to override it. The issue is fixed in yarn v2, but the yarn team does not plan to backport it to yarn v1. If you want to take advantage of the npm cache you can use the `eas-build-pre-install` script to override the registry in the `yarn.lock`.
+
+e.g.
+```
+{
+ "scripts": {
+    "eas-build-pre-install": "bash -c \"[ ! -z \\\"NPM_CACHE_URL\\\" ] && sed -i -e \\\"s#https://registry.yarnpkg.com#$NPM_CACHE_URL#g\\\" yarn.lock\""
+  }
+}
+```

--- a/docs/pages/build-reference/how-tos.md
+++ b/docs/pages/build-reference/how-tos.md
@@ -74,7 +74,7 @@ If you are not using `credentials.json` for Android/iOS credentials, it is fine 
 
 ## Using npm cache with yarn v1
 
-By default npm cache deployed on EAS Build won't work with yarn v1, because `yarn.lock` files contain urls to registries for every package and yarn does not provide any way to override it. The issue is fixed in yarn v2, but the yarn team does not plan to backport it to yarn v1. If you want to take advantage of the npm cache you can use the `eas-build-pre-install` script to override the registry in the `yarn.lock`.
+By default the EAS npm cache won't work with yarn v1, because `yarn.lock` files contain URLs to registries for every package and yarn does not provide any way to override it. The issue is fixed in yarn v2, but the yarn team does not plan to backport it to yarn v1. If you want to take advantage of the npm cache, you can use the `eas-build-pre-install` script to override the registry in your `yarn.lock`.
 
 e.g.
 ```

--- a/docs/pages/build-reference/infrastructure.md
+++ b/docs/pages/build-reference/infrastructure.md
@@ -20,7 +20,7 @@ Currently, only one image is supported per platform, more images will be availab
 - Android workers run on Kubernetes in an isolated environment
   - Every build gets its own container running on a dedicated Kubernetes node
   - Build resources: 4 CPU, 16 GB RAM (14 GB after k8s overhead)
-- NPM cache deployed with Kubernetes (works with npm and yarn v2, for compatibility with yarn v1 checkout [workaround](how-tos/#using-npm-cache-with-yarn-v1))
+- NPM cache deployed with Kubernetes (works with npm and yarn v2, and yarn v1 works with a [workaround](how-tos/#using-npm-cache-with-yarn-v1))
 - Maven cache deployed with Kubernetes, cached repositories:
   - `maven-central` - [https://repo1.maven.org/maven2/](https://repo1.maven.org/maven2/)
   - `google` - [https://maven.google.com/](https://maven.google.com/)
@@ -49,7 +49,7 @@ Currently, only one image is supported per platform, more images will be availab
   - Every build gets its own fresh macOS VM
   - Hardware: Intel(R) Xeon(R) CPU E5-2697 (12 core/24 threads), 64 GB RAM
   - Build resource limits: 6 cores, 8 GB RAM
-- NPM cache (works with npm and yarn v2, for compatibility with yarn v1 checkout [workaround](how-tos/#using-npm-cache-with-yarn-v1))
+- NPM cache (works with npm and yarn v2, and yarn v1 works with a [workaround](how-tos/#using-npm-cache-with-yarn-v1))
 
 #### Image `macos-catalina-11.15-xcode-12.1` (alias `default`, `latest`)
 

--- a/docs/pages/build-reference/infrastructure.md
+++ b/docs/pages/build-reference/infrastructure.md
@@ -20,7 +20,7 @@ Currently, only one image is supported per platform, more images will be availab
 - Android workers run on Kubernetes in an isolated environment
   - Every build gets its own container running on a dedicated Kubernetes node
   - Build resources: 4 CPU, 16 GB RAM (14 GB after k8s overhead)
-- NPM cache deployed with Kubernetes
+- NPM cache deployed with Kubernetes (works with npm and yarn v2, for compatibility with yarn v1 checkout [workaround](how-tos/#using-npm-cache-with-yarn-v1))
 - Maven cache deployed with Kubernetes, cached repositories:
   - `maven-central` - [https://repo1.maven.org/maven2/](https://repo1.maven.org/maven2/)
   - `google` - [https://maven.google.com/](https://maven.google.com/)
@@ -49,7 +49,7 @@ Currently, only one image is supported per platform, more images will be availab
   - Every build gets its own fresh macOS VM
   - Hardware: Intel(R) Xeon(R) CPU E5-2697 (12 core/24 threads), 64 GB RAM
   - Build resource limits: 6 cores, 8 GB RAM
-- NPM cache
+- NPM cache (works with npm and yarn v2, for compatibility with yarn v1 checkout [workaround](how-tos/#using-npm-cache-with-yarn-v1))
 
 #### Image `macos-catalina-11.15-xcode-12.1` (alias `default`, `latest`)
 


### PR DESCRIPTION
# Why

`yarn.lock` contain registry names for every package and npm cache is ignored when building on worker

# How

- Provide docs for a workaround for yarn-v1
- link to workaround on infrastructure page

# Test Plan

`yarn dev`