### PR TITLE
[expo-intent-launcher] Handle ActivityNotFoundException error

### DIFF
--- a/packages/expo-intent-launcher/CHANGELOG.md
+++ b/packages/expo-intent-launcher/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Handle `ActivityNotFoundException` error to prevent crashes. ([#12078](https://github.com/expo/expo/pull/12078) by [@robertying](https://github.com/robertying))
+
 ## 8.4.0 — 2020-11-17
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-intent-launcher/android/src/main/java/expo/modules/intentlauncher/IntentLauncherModule.java
+++ b/packages/expo-intent-launcher/android/src/main/java/expo/modules/intentlauncher/IntentLauncherModule.java
@@ -102,7 +102,14 @@ public class IntentLauncherModule extends ExportedModule implements ActivityEven
 
     mUIManager.registerActivityEventListener(this);
     mPendingPromise = promise;
-    activity.startActivityForResult(intent, REQUEST_CODE);
+
+    try {
+      activity.startActivityForResult(intent, REQUEST_CODE);
+    }
+    catch (ActivityNotFoundException e) {
+      mPendingPromise.reject(e);
+      mPendingPromise = null;
+    }
   }
 
   //region ActivityEventListener


### PR DESCRIPTION
# Why

`expo-intent-launcher` causes crash if say a `android.intent.action.VIEW` action is started but no suitable activities found to handle the file type.

# How

Method `activity.startActivityForResult` actually throws ActivityNotFoundException and it should be handled.

# Test Plan

1. Build with the old code and use `expo-intent-launcher` to open a `rar` file. The app crashes because no app installed can handle this extension.
2. Apply the fix and redo the above. The app does not crash and the call to `IntentLauncher.startActivityAsync` rejects with an ActivityNotFoundException error.
