### PR TITLE
[ios][expo-media-library] In 'getAssetInfoAsync', respect the `shouldDownloadFromNetwork` option.

### DIFF
--- a/apps/native-component-list/src/screens/MediaLibrary/MediaDetailsScreen.tsx
+++ b/apps/native-component-list/src/screens/MediaLibrary/MediaDetailsScreen.tsx
@@ -22,10 +22,14 @@ export default class MediaDetailsScreen extends React.Component<Props> {
 
   state = {
     details: null,
+    detailsWithoutDownloadingFromNetwork: null,
   };
 
   componentDidMount() {
     const { asset } = this.props.route.params;
+    MediaLibrary.getAssetInfoAsync(asset, { shouldDownloadFromNetwork: false }).then(details => {
+      this.setState({ detailsWithoutDownloadingFromNetwork: details });
+    });
     MediaLibrary.getAssetInfoAsync(asset).then(details => {
       this.setState({ details });
     });
@@ -95,7 +99,7 @@ export default class MediaDetailsScreen extends React.Component<Props> {
   }
 
   render() {
-    const { details } = this.state;
+    const { details, detailsWithoutDownloadingFromNetwork } = this.state;
     const { asset, album } = this.props.route.params!;
 
     return (
@@ -131,6 +135,13 @@ export default class MediaDetailsScreen extends React.Component<Props> {
           <View style={styles.details}>
             <HeadingText>MediaLibrary.getAssetInfoAsync(assetId)</HeadingText>
             <MonoText>{JSON.stringify(details, null, 2)}</MonoText>
+          </View>
+        )}
+
+        {detailsWithoutDownloadingFromNetwork && (
+          <View style={styles.details}>
+            <HeadingText>{`MediaLibrary.getAssetInfoAsync(assetId, { shouldDownloadFromNetwork: false })`}</HeadingText>
+            <MonoText>{JSON.stringify(detailsWithoutDownloadingFromNetwork, null, 2)}</MonoText>
           </View>
         )}
       </ScrollView>

--- a/apps/test-suite/tests/MediaLibrary.js
+++ b/apps/test-suite/tests/MediaLibrary.js
@@ -342,6 +342,94 @@ export async function test(t) {
       });
     });
 
+    t.describe('getAssetInfoAsync', async () => {
+      t.it('shouldDownloadFromNetwork: false, for photos', async () => {
+        const mediaType = MediaLibrary.MediaType.photo;
+        const options = { mediaType, album };
+        const { assets } = await MediaLibrary.getAssetsAsync(options);
+        const value = await MediaLibrary.getAssetInfoAsync(assets[0], {
+          shouldDownloadFromNetwork: false,
+        });
+        const keys = Object.keys(value);
+
+        const expectedExtraKeys = Platform.select({
+          ios: ['isNetworkAsset'],
+          default: [],
+        });
+        expectedExtraKeys.forEach(key => t.expect(keys).toContain(key));
+        if (Platform.OS === 'ios') {
+          t.expect(value['isNetworkAsset']).toBe(false);
+        }
+      });
+
+      t.it('shouldDownloadFromNetwork: true, for photos', async () => {
+        const mediaType = MediaLibrary.MediaType.photo;
+        const options = { mediaType, album };
+        const { assets } = await MediaLibrary.getAssetsAsync(options);
+        const value = await MediaLibrary.getAssetInfoAsync(assets[0], {
+          shouldDownloadFromNetwork: true,
+        });
+        const keys = Object.keys(value);
+
+        // This is inconsistent with the documentation, which states
+        // that this field is only available if flag `shouldDownloadFromNetwork`
+        // is set to `false`.
+        //
+        // TODO: Return only when `shouldDownloadFromNetwork` is false, or clarify documentation.
+        const expectedExtraKeys = Platform.select({
+          ios: ['isNetworkAsset'],
+          default: [],
+        });
+        expectedExtraKeys.forEach(key => t.expect(keys).toContain(key));
+        if (Platform.OS === 'ios') {
+          t.expect(value['isNetworkAsset']).toBe(false);
+        }
+      });
+
+      t.it('shouldDownloadFromNetwork: false, for videos', async () => {
+        const mediaType = MediaLibrary.MediaType.video;
+        const options = { mediaType, album };
+        const { assets } = await MediaLibrary.getAssetsAsync(options);
+        const value = await MediaLibrary.getAssetInfoAsync(assets[0], {
+          shouldDownloadFromNetwork: false,
+        });
+        const keys = Object.keys(value);
+
+        const expectedExtraKeys = Platform.select({
+          ios: ['isNetworkAsset'],
+          default: [],
+        });
+        expectedExtraKeys.forEach(key => t.expect(keys).toContain(key));
+        if (Platform.OS === 'ios') {
+          t.expect(value['isNetworkAsset']).toBe(false);
+        }
+      });
+
+      t.it('shouldDownloadFromNetwork: true, for videos', async () => {
+        const mediaType = MediaLibrary.MediaType.video;
+        const options = { mediaType, album };
+        const { assets } = await MediaLibrary.getAssetsAsync(options);
+        const value = await MediaLibrary.getAssetInfoAsync(assets[0], {
+          shouldDownloadFromNetwork: true,
+        });
+        const keys = Object.keys(value);
+
+        // This is inconsistent with the documentation, which states
+        // that this field is only available if flag `shouldDownloadFromNetwork`
+        // is set to `false`.
+        //
+        // TODO: Return only when `shouldDownloadFromNetwork` is false, or clarify documentation.
+        const expectedExtraKeys = Platform.select({
+          ios: ['isNetworkAsset'],
+          default: [],
+        });
+        expectedExtraKeys.forEach(key => t.expect(keys).toContain(key));
+        if (Platform.OS === 'ios') {
+          t.expect(value['isNetworkAsset']).toBe(false);
+        }
+      });
+    });
+
     t.describe('Delete tests', async () => {
       t.it('deleteAssetsAsync', async () => {
         const { assets } = await MediaLibrary.getAssetsAsync({ album, mediaType: MEDIA_TYPES });

--- a/apps/test-suite/tests/MediaLibrary.js
+++ b/apps/test-suite/tests/MediaLibrary.js
@@ -371,19 +371,11 @@ export async function test(t) {
         });
         const keys = Object.keys(value);
 
-        // This is inconsistent with the documentation, which states
-        // that this field is only available if flag `shouldDownloadFromNetwork`
-        // is set to `false`.
-        //
-        // TODO: Return only when `shouldDownloadFromNetwork` is false, or clarify documentation.
         const expectedExtraKeys = Platform.select({
           ios: ['isNetworkAsset'],
           default: [],
         });
-        expectedExtraKeys.forEach(key => t.expect(keys).toContain(key));
-        if (Platform.OS === 'ios') {
-          t.expect(value['isNetworkAsset']).toBe(false);
-        }
+        expectedExtraKeys.forEach(key => t.expect(keys).not.toContain(key));
       });
 
       t.it('shouldDownloadFromNetwork: false, for videos', async () => {
@@ -414,19 +406,11 @@ export async function test(t) {
         });
         const keys = Object.keys(value);
 
-        // This is inconsistent with the documentation, which states
-        // that this field is only available if flag `shouldDownloadFromNetwork`
-        // is set to `false`.
-        //
-        // TODO: Return only when `shouldDownloadFromNetwork` is false, or clarify documentation.
         const expectedExtraKeys = Platform.select({
           ios: ['isNetworkAsset'],
           default: [],
         });
-        expectedExtraKeys.forEach(key => t.expect(keys).toContain(key));
-        if (Platform.OS === 'ios') {
-          t.expect(value['isNetworkAsset']).toBe(false);
-        }
+        expectedExtraKeys.forEach(key => t.expect(keys).not.toContain(key));
       });
     });
 

--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -12,6 +12,8 @@
 ### 🐛 Bug fixes
 
 - Remove peerDependencies and unimodulePeerDependencies from Expo modules. ([#11980](https://github.com/expo/expo/pull/11980) by [@brentvatne](https://github.com/brentvatne))
+- In 'getAssetInfoAsync', return 'isNetworkAsset' field for photo assets as boolean, rather than number. ([#12086](https://github.com/expo/expo/pull/12086) by [@drtangible](https://github.com/drtangible))
+
 
 ## 11.0.0 — 2021-01-15
 

--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -12,7 +12,7 @@
 ### 🐛 Bug fixes
 
 - Remove peerDependencies and unimodulePeerDependencies from Expo modules. ([#11980](https://github.com/expo/expo/pull/11980) by [@brentvatne](https://github.com/brentvatne))
-- In 'getAssetInfoAsync', return 'isNetworkAsset' field for photo assets as boolean, rather than number. ([#12086](https://github.com/expo/expo/pull/12086) by [@drtangible](https://github.com/drtangible))
+- In 'getAssetInfoAsync', respect the `shouldDownloadFromNetwork` option. ([#12086](https://github.com/expo/expo/pull/12086) by [@drtangible](https://github.com/drtangible))
 
 
 ## 11.0.0 — 2021-01-15

--- a/packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibrary.m
+++ b/packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibrary.m
@@ -428,7 +428,9 @@ UM_EXPORT_METHOD_AS(getAssetInfoAsync,
   
   PHAsset *asset = [EXMediaLibrary _getAssetById:assetId];
     
-  BOOL shouldDownloadFromNetwork = [[options objectForKey:EXMediaLibraryShouldDownloadFromNetworkKey] boolValue] ?: YES;
+  BOOL shouldDownloadFromNetwork = [options objectForKey:EXMediaLibraryShouldDownloadFromNetworkKey] != nil
+    ? [[options objectForKey:EXMediaLibraryShouldDownloadFromNetworkKey] boolValue]
+    : YES;
   
   if (asset) {
     NSMutableDictionary *result = [EXMediaLibrary _exportAssetInfo:asset];
@@ -440,9 +442,11 @@ UM_EXPORT_METHOD_AS(getAssetInfoAsync,
                                  completionHandler:^(PHContentEditingInput * _Nullable contentEditingInput, NSDictionary * _Nonnull info) {
         result[@"localUri"] = [contentEditingInput.fullSizeImageURL absoluteString];
         result[@"orientation"] = @(contentEditingInput.fullSizeImageOrientation);
-        result[@"isNetworkAsset"] = [info objectForKey:PHContentEditingInputResultIsInCloudKey] != nil
-          ? @([[info objectForKey:PHContentEditingInputResultIsInCloudKey] boolValue])
-          : @(NO);
+        if (!shouldDownloadFromNetwork) {
+          result[@"isNetworkAsset"] = [info objectForKey:PHContentEditingInputResultIsInCloudKey] != nil
+            ? @([[info objectForKey:PHContentEditingInputResultIsInCloudKey] boolValue])
+            : @(NO);
+        }
         
         CIImage *ciImage = [CIImage imageWithContentsOfURL:contentEditingInput.fullSizeImageURL];
         result[@"exif"] = ciImage.properties;
@@ -471,9 +475,11 @@ UM_EXPORT_METHOD_AS(getAssetInfoAsync,
             [exporter exportAsynchronouslyWithCompletionHandler:^{
                 if (exporter.status == AVAssetExportSessionStatusCompleted) {
                     result[@"localUri"] = videoFileOutputURL.absoluteString;
-                    result[@"isNetworkAsset"] = [info objectForKey:PHImageResultIsInCloudKey] != nil
-                      ? [info objectForKey:PHImageResultIsInCloudKey]
-                      : @(NO);
+                    if (!shouldDownloadFromNetwork) {
+                      result[@"isNetworkAsset"] = [info objectForKey:PHImageResultIsInCloudKey] != nil
+                        ? [info objectForKey:PHImageResultIsInCloudKey]
+                        : @(NO);
+                    }
                     resolve(result);
                 } else if (exporter.status == AVAssetExportSessionStatusFailed) {
                     reject(@"E_EXPORT_FAILED", @"Could not export the requested video.", nil);
@@ -485,9 +491,11 @@ UM_EXPORT_METHOD_AS(getAssetInfoAsync,
         } else {
             AVURLAsset *urlAsset = (AVURLAsset *)asset;
             result[@"localUri"] = [[urlAsset URL] absoluteString];
-            result[@"isNetworkAsset"] = [info objectForKey:PHImageResultIsInCloudKey] != nil
-              ? [info objectForKey:PHImageResultIsInCloudKey]
-              : @(NO);
+            if (!shouldDownloadFromNetwork) {
+              result[@"isNetworkAsset"] = [info objectForKey:PHImageResultIsInCloudKey] != nil
+                ? [info objectForKey:PHImageResultIsInCloudKey]
+                : @(NO);
+            }
             resolve(result);
         }
       }];

--- a/packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibrary.m
+++ b/packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibrary.m
@@ -440,7 +440,7 @@ UM_EXPORT_METHOD_AS(getAssetInfoAsync,
                                  completionHandler:^(PHContentEditingInput * _Nullable contentEditingInput, NSDictionary * _Nonnull info) {
         result[@"localUri"] = [contentEditingInput.fullSizeImageURL absoluteString];
         result[@"orientation"] = @(contentEditingInput.fullSizeImageOrientation);
-        result[@"isNetworkAsset"] = [info objectForKey:PHContentEditingInputResultIsInCloudKey];
+        result[@"isNetworkAsset"] = @([[info objectForKey:PHContentEditingInputResultIsInCloudKey] boolValue]);
         
         CIImage *ciImage = [CIImage imageWithContentsOfURL:contentEditingInput.fullSizeImageURL];
         result[@"exif"] = ciImage.properties;

--- a/packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibrary.m
+++ b/packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibrary.m
@@ -440,7 +440,9 @@ UM_EXPORT_METHOD_AS(getAssetInfoAsync,
                                  completionHandler:^(PHContentEditingInput * _Nullable contentEditingInput, NSDictionary * _Nonnull info) {
         result[@"localUri"] = [contentEditingInput.fullSizeImageURL absoluteString];
         result[@"orientation"] = @(contentEditingInput.fullSizeImageOrientation);
-        result[@"isNetworkAsset"] = @([[info objectForKey:PHContentEditingInputResultIsInCloudKey] boolValue]);
+        result[@"isNetworkAsset"] = [info objectForKey:PHContentEditingInputResultIsInCloudKey] != nil
+          ? @([[info objectForKey:PHContentEditingInputResultIsInCloudKey] boolValue])
+          : @(NO);
         
         CIImage *ciImage = [CIImage imageWithContentsOfURL:contentEditingInput.fullSizeImageURL];
         result[@"exif"] = ciImage.properties;
@@ -469,7 +471,9 @@ UM_EXPORT_METHOD_AS(getAssetInfoAsync,
             [exporter exportAsynchronouslyWithCompletionHandler:^{
                 if (exporter.status == AVAssetExportSessionStatusCompleted) {
                     result[@"localUri"] = videoFileOutputURL.absoluteString;
-                    result[@"isNetworkAsset"] = [info objectForKey:PHImageResultIsInCloudKey];
+                    result[@"isNetworkAsset"] = [info objectForKey:PHImageResultIsInCloudKey] != nil
+                      ? [info objectForKey:PHImageResultIsInCloudKey]
+                      : @(NO);
                     resolve(result);
                 } else if (exporter.status == AVAssetExportSessionStatusFailed) {
                     reject(@"E_EXPORT_FAILED", @"Could not export the requested video.", nil);
@@ -481,7 +485,9 @@ UM_EXPORT_METHOD_AS(getAssetInfoAsync,
         } else {
             AVURLAsset *urlAsset = (AVURLAsset *)asset;
             result[@"localUri"] = [[urlAsset URL] absoluteString];
-            result[@"isNetworkAsset"] = [info objectForKey:PHImageResultIsInCloudKey];
+            result[@"isNetworkAsset"] = [info objectForKey:PHImageResultIsInCloudKey] != nil
+              ? [info objectForKey:PHImageResultIsInCloudKey]
+              : @(NO);
             resolve(result);
         }
       }];


### PR DESCRIPTION
# Why

* While investigating behavior around the `shouldDownloadFromNetwork` option to `MediaLibrary.getAssetInfoAsync`, noticed several unexpected things.

* In iOS 12, there is a discrepancy between the `isNetworkAsset` field returned on video & photo assets.
  * For video assets, `isNetworkAsset` is a boolean, which is consistent with documentation.
  * For photo assets, `isNetworkAsset` is a number, which is inconsistent with documentation.

* In iOS 13 & iOS 14 the `isNetworkAsset` is never returned from `MediaLibrary.getAssetInfoAsync`.

* Related to this, the `allowsNetworkAccess` option is always true when fetching photos/videos, even when the `shouldDownloadFromNetwork: false` option is given.

* https://docs.expo.io/versions/latest/sdk/media-library/#medialibrarygetassetinfoasyncasset-options


# How

* Ran `test-suite` in the `bare-expo` app, added tests to cover the behavior I was seeing.

* Render asset info returned from calling `getAssetInfoAsync` with `shouldDownloadFromNetwork: false` on the `<MediaDetailsScreen/>` in the `native-component-list` app,  verify that `isNetworkAsset` field is returned.


# Test Plan

* Ran `test-suite` in the `bare-expo` app, added tests to cover the behavior I was seeing.

* (iOS 12) Prior to change, these two tests failed, as `isNetworkAsset` is returned as a number for photo assets, rather than a boolean:

<img width="559" alt="Screen Shot 2021-03-03 at 2 37 37 PM" src="https://user-images.githubusercontent.com/169912/109883720-aeed6500-7c30-11eb-9bd1-a539219593a1.png">

* (iOS 12) After the change, tests pass:

<img width="559" alt="Screen Shot 2021-03-03 at 2 38 51 PM" src="https://user-images.githubusercontent.com/169912/109883785-c75d7f80-7c30-11eb-8b64-0d8d38a883e5.png">

---

* (iOS 13) Prior to change, these four tests failed, as `isNetworkAsset` is never returned:

<img width="559" alt="Screen Shot 2021-03-03 at 4 20 57 PM" src="https://user-images.githubusercontent.com/169912/109890768-b581d980-7c3c-11eb-942d-0f3b92763436.png">

* (iOS 13) After the change, tests pass:

<img width="559" alt="Screen Shot 2021-03-04 at 12 45 50 PM" src="https://user-images.githubusercontent.com/169912/110028167-c20f3c00-7ce7-11eb-8f0f-e0f2f12247b7.png">

---

* (iOS 14) Prior to change, these four tests failed, as `isNetworkAsset` is never returned:

<img width="559" alt="Screen Shot 2021-03-03 at 3 23 19 PM" src="https://user-images.githubusercontent.com/169912/109886348-c4fd2480-7c34-11eb-8619-99c014515f74.png">

* (iOS 14) After the change, tests pass:

<img width="559" alt="Screen Shot 2021-03-04 at 12 39 17 PM" src="https://user-images.githubusercontent.com/169912/110027570-fe8e6800-7ce6-11eb-9499-6556b1ffb7a6.png">

---

* In addition to these tests, this change adds a section to the `<MediaDetailsScreen/>` in the `native-component-list` app, showing the asset info returned when  calling `getAssetInfoAsync` with `shouldDownloadFromNetwork: false`:

<img width="559" alt="Screen Shot 2021-03-04 at 1 02 27 PM" src="https://user-images.githubusercontent.com/169912/110029899-e66c1800-7ce9-11eb-9bf9-0e6da1fea5fd.png">


* Prior to this change, this section shows that `isNetworkAsset` is not present:

<img width="559" alt="Screen Shot 2021-03-04 at 2 16 25 PM" src="https://user-images.githubusercontent.com/169912/110038485-a8c0bc80-7cf4-11eb-8945-31da0c1d015a.png">

* After this change, this section shows that `isNetworkAsset` is present, as expected:

<img width="559" alt="Screen Shot 2021-03-04 at 2 18 24 PM" src="https://user-images.githubusercontent.com/169912/110038549-baa25f80-7cf4-11eb-8942-30db36c80bae.png">



----

* In addition to testing this on the simulator, I opened `<MediaDetailsScreen/>` on my physical device to verify that my own assets stored in iCloud show `isNetworkAsset: true`, while  local assets show `isNetworkAsset: false`.


* With an asset currently only stored in iCloud, `isNetworkAsset` is `true`:

<img src="https://user-images.githubusercontent.com/169912/110039278-d6f2cc00-7cf5-11eb-8dd1-591af1a1afa7.PNG" width="559" />

* With an asset currently stored locally, `isNetworkAsset` is `false`:

<img src="https://user-images.githubusercontent.com/169912/110039383-fab61200-7cf5-11eb-9c1c-5fbc318d8bd6.PNG" width="559" />

