### PR TITLE
[docs] Add note telling users to upgrade before ejecting

### DIFF
--- a/docs/pages/bare/customizing.md
+++ b/docs/pages/bare/customizing.md
@@ -7,3 +7,5 @@ The [managed workflow](../introduction/managed-vs-bare.md#managed-workflow) has 
 The process of ejecting is easily reversible so don't worry about experimenting with it. Just commit any changes you want to keep and then follow along with this guide. If you decide you want to abort it, just check out your most recent commit. You can also reverse it in the future by deleting the `ios` and `android` directories.
 
 To eject to the bare workflow, you can run `expo eject` and follow the instructions. Head over to the [bare workflow walkthrough](../bare/exploring-bare-workflow.md) to learn more about what the workflow will look like after ejecting.
+
+> 💡 We recommend upgrading to the latest SDK version before ejecting. It will be more difficult to upgrade your app after ejecting because you will also be responsible for native iOS and Android related upgrade steps.

--- a/docs/pages/bare/exploring-bare-workflow.md
+++ b/docs/pages/bare/exploring-bare-workflow.md
@@ -27,6 +27,8 @@ If you already have a React Native project that has been created with `react-nat
 
 If you already have an Expo managed workflow app and you need to customize the native code, you can eject to the bare workflow by running `expo eject`. This will give you a vanilla React Native app that includes all of the Expo SDK APIs that you were using already, and no more than that. The outcome is that you will be in just as good of a position as if you had started your app in the bare workflow from scratch, only you probably saved yourself some time!
 
+> 💡 We recommend upgrading to the latest SDK version before ejecting. It will be more difficult to upgrade your app after ejecting because you will also be responsible for native iOS and Android related upgrade steps.
+
 <Video file="exploring-bare/eject.mp4" spaceAfter />
 
 ## Build and open the project

--- a/docs/pages/workflow/customizing.md
+++ b/docs/pages/workflow/customizing.md
@@ -7,3 +7,5 @@ The [managed workflow](../introduction/managed-vs-bare.md#managed-workflow) has 
 The process of ejecting is easily reversible so don't worry about experimenting with it. Just commit any changes you want to keep and then follow along with this guide. If you decide you want to abort it, just check out your most recent commit. You can also reverse it in the future by deleting the `ios` and `android` directories.
 
 To eject to the bare workflow, you can run `expo eject` and follow the instructions. Head over to the [bare workflow walkthrough](../bare/exploring-bare-workflow.md) to learn more about what the workflow will look like after ejecting.
+
+> 💡 We recommend upgrading to the latest SDK version before ejecting. It will be more difficult to upgrade your app after ejecting because you will also be responsible for native iOS and Android related upgrade steps.


### PR DESCRIPTION
# Why

To give users the best "eject" experience, we should recommend they upgrade to the latest SDK version before doing so.

# How

Added a note to appropriate locations in docs/guides

# Test Plan

Ran it locally and encountered no layout or rendering issues.
