### PR TITLE
[docs] Replace some assorted img tags with ImageSpotlight

### DIFF
--- a/docs/components/plugins/ImageSpotlight.tsx
+++ b/docs/components/plugins/ImageSpotlight.tsx
@@ -1,0 +1,26 @@
+import { theme } from '@expo/styleguide';
+import React from 'react';
+
+type Props = {
+  alt: string;
+  style?: React.CSSProperties;
+  containerStyle?: React.CSSProperties;
+  src: string;
+};
+
+export default function ImageSpotlight({ alt, src, style, containerStyle }: Props) {
+  return (
+    <div
+      style={{
+        textAlign: 'center',
+        backgroundColor: theme.background.secondary,
+        paddingTop: 10,
+        paddingBottom: 10,
+        marginTop: 20,
+        marginBottom: 20,
+        ...containerStyle,
+      }}>
+      <img src={src} alt={alt} style={style} />
+    </div>
+  );
+}

--- a/docs/pages/app-signing/local-credentials.md
+++ b/docs/pages/app-signing/local-credentials.md
@@ -120,7 +120,7 @@ If your iOS app is using [App Extensions](https://developer.apple.com/app-extens
 
 Let's say that your project consists of a main application target (named `multitarget`) and a Share Extension target (named `shareextension`).
 
-<ImageSpotlight src="/static/images/eas-build/multi-target.png" style={{maxWidth: 360}} />
+<ImageSpotlight alt="Xcode multi target configuration" src="/static/images/eas-build/multi-target.png" style={{maxWidth: 360}} />
 
 In this case your `credentials.json` should like like this:
 

--- a/docs/pages/app-signing/local-credentials.md
+++ b/docs/pages/app-signing/local-credentials.md
@@ -2,6 +2,8 @@
 title: Using local credentials
 ---
 
+import ImageSpotlight from '~/components/plugins/ImageSpotlight'
+
 You can usually get away with not being a code signing expert by [letting EAS handle it for you](managed-credentials.md). However, there are cases where some users might want to manage their project keystore, certificates and profiles on their own.
 
 If you would like to manage your own app signing credentials, you can use `credentials.json` to give EAS Build relative paths to the credentials on your local filesystem and their associated passwords in order to use them to sign your builds.
@@ -118,7 +120,7 @@ If your iOS app is using [App Extensions](https://developer.apple.com/app-extens
 
 Let's say that your project consists of a main application target (named `multitarget`) and a Share Extension target (named `shareextension`).
 
-<center><img src="/static/images/eas-build/multi-target.png" style={{maxWidth: 360}} /></center>
+<ImageSpotlight src="/static/images/eas-build/multi-target.png" style={{maxWidth: 360}} />
 
 In this case your `credentials.json` should like like this:
 
@@ -138,7 +140,6 @@ In this case your `credentials.json` should like like this:
         "path": "ios/certs/another-dist.p12",
         "password": "ANOTHER_DISTRIBUTION_CERTIFICATE_PASSWORD"
       } /* @end */
-
     }
   }
 }

--- a/docs/pages/build-reference/build-configuration.md
+++ b/docs/pages/build-reference/build-configuration.md
@@ -2,6 +2,8 @@
 title: Build configuration process
 ---
 
+import ImageSpotlight from '~/components/plugins/ImageSpotlight'
+
 In this guide you will learn what happens when EAS CLI configures your project with `eas build:configure` (or `eas build` - which runs this same process if the project is not yet configured).
 
 EAS CLI performs the following steps when configuring your project:
@@ -10,7 +12,7 @@ EAS CLI performs the following steps when configuring your project:
 
 If you only want to use EAS Build for a single platform, that's fine. If you change your mind, you can come back and the other later.
 
-<center><img src="/static/images/eas-build/walkthrough/04-configure-platform.png" /></center>
+<ImageSpotlight src="/static/images/eas-build/walkthrough/04-configure-platform.png" containerStyle={{ paddingBottom: 0 }} />
 
 #### 2. Create eas.json
 
@@ -49,7 +51,7 @@ EAS CLI performs two steps:
 
   > This step also patches `build.gradle` by including there our custom signing configuration. The configuration itself is saved to a separate file: `eas-build.gradle`.
 
-<center><img src="/static/images/eas-build/walkthrough/05-configure-android.png" /></center>
+<ImageSpotlight src="/static/images/eas-build/walkthrough/05-configure-android.png" containerStyle={{ paddingBottom: 0 }} />
 
 #### 4. Configure the iOS project
 
@@ -57,6 +59,6 @@ Similar configuration step is performed for the iOS project. EAS Build resolved 
 
 Make sure to choose the bundle identifier defined in app.json because it'll be used to identify you app on the Apple App Store.
 
-<center><img src="/static/images/eas-build/walkthrough/06-configure-xcode.png" /></center>
+<ImageSpotlight src="/static/images/eas-build/walkthrough/06-configure-xcode.png" containerStyle={{ paddingBottom: 0 }} />
 
 That's all there is to configuring a project to be compatible with EAS Build.

--- a/docs/pages/build-reference/build-configuration.md
+++ b/docs/pages/build-reference/build-configuration.md
@@ -12,7 +12,7 @@ EAS CLI performs the following steps when configuring your project:
 
 If you only want to use EAS Build for a single platform, that's fine. If you change your mind, you can come back and the other later.
 
-<ImageSpotlight src="/static/images/eas-build/walkthrough/04-configure-platform.png" containerStyle={{ paddingBottom: 0 }} />
+<ImageSpotlight alt="Terminal running eas build command with platform iOS and Android options available" src="/static/images/eas-build/walkthrough/04-configure-platform.png" containerStyle={{ paddingBottom: 0 }} />
 
 #### 2. Create eas.json
 
@@ -51,7 +51,7 @@ EAS CLI performs two steps:
 
   > This step also patches `build.gradle` by including there our custom signing configuration. The configuration itself is saved to a separate file: `eas-build.gradle`.
 
-<ImageSpotlight src="/static/images/eas-build/walkthrough/05-configure-android.png" containerStyle={{ paddingBottom: 0 }} />
+<ImageSpotlight alt="Android configuration prompt in eas build:configure" src="/static/images/eas-build/walkthrough/05-configure-android.png" containerStyle={{ paddingBottom: 0 }} />
 
 #### 4. Configure the iOS project
 
@@ -59,6 +59,6 @@ Similar configuration step is performed for the iOS project. EAS Build resolved 
 
 Make sure to choose the bundle identifier defined in app.json because it'll be used to identify you app on the Apple App Store.
 
-<ImageSpotlight src="/static/images/eas-build/walkthrough/06-configure-xcode.png" containerStyle={{ paddingBottom: 0 }} />
+<ImageSpotlight alt="Xcode configuration prompt in eas build:configure" src="/static/images/eas-build/walkthrough/06-configure-xcode.png" containerStyle={{ paddingBottom: 0 }} />
 
 That's all there is to configuring a project to be compatible with EAS Build.

--- a/docs/pages/build/setup.md
+++ b/docs/pages/build/setup.md
@@ -21,7 +21,7 @@ Don't have a project yet? No problem: it's quick and easy to create a "Hello wor
 - Run `expo init PROJECT_NAME` (let's assume `PROJECT_NAME` is `abcd`) and choose a bare workflow template (either `minimal` or `minimal (TypeScript)`).
 - EAS Build also works well with projects created by `npx react-native`, `create-react-native-app`, `ignite-cli`, and other project bootstrapping tools.
 
-<ImageSpotlight src="/static/images/eas-build/walkthrough/01-init.png" />
+<ImageSpotlight alt="Terminal running expo init, with minimal (TypeScript) selected" src="/static/images/eas-build/walkthrough/01-init.png" />
 
 </p>
 </details>

--- a/docs/pages/build/setup.md
+++ b/docs/pages/build/setup.md
@@ -2,6 +2,8 @@
 title: Creating your first build
 ---
 
+import ImageSpotlight from '~/components/plugins/ImageSpotlight'
+
 In this guide, you'll learn how to build a ready-to-submit binary for the Apple App Store and Google Play Store using EAS Build. For a simple app, you should expect to have kicked off your builds for Android and iOS within a few minutes.
 
 ## Prerequisites
@@ -19,7 +21,7 @@ Don't have a project yet? No problem: it's quick and easy to create a "Hello wor
 - Run `expo init PROJECT_NAME` (let's assume `PROJECT_NAME` is `abcd`) and choose a bare workflow template (either `minimal` or `minimal (TypeScript)`).
 - EAS Build also works well with projects created by `npx react-native`, `create-react-native-app`, `ignite-cli`, and other project bootstrapping tools.
 
-<center><img src="/static/images/eas-build/walkthrough/01-init.png" /></center>
+<ImageSpotlight src="/static/images/eas-build/walkthrough/01-init.png" />
 
 </p>
 </details>

--- a/docs/pages/clients/introduction.md
+++ b/docs/pages/clients/introduction.md
@@ -2,17 +2,17 @@
 title: Introduction
 ---
 
-**Expo Development Client** is an open source project to improve your development experience while working on your Expo and React Native projects. It allows your team to focus on the JavaScript portion of your project, only needing to interact with XCode or Android Studio when you need to make changes to the native code used in your project.  
+import ImageSpotlight from '~/components/plugins/ImageSpotlight'
 
-<img src="/static/images/development-clients-overview.png" style={{maxWidth: 605 }} />
-<br/>
-<br/>
+**Expo Development Client** is an open source project to improve your development experience while working on your Expo and React Native projects. It allows your team to focus on the JavaScript portion of your project, only needing to interact with XCode or Android Studio when you need to make changes to the native code used in your project.
+
+<ImageSpotlight src="/static/images/development-clients-overview.png" style={{ maxWidth: 605 }} />
 
 > ⚠️ **Managed Expo projects are not yet supported**, but we are working on bringing the Development Client to the Managed Workflow! If you want to build a managed Expo project with the Development Client, you'll have to eject it first. See the [Ejecting to Bare Workflow](../workflow/customizing.md) page to learn how.
 
 ## Discover the Dev Client
 
-- [Get Started with the Dev Client](installation.md) - This step-by-step guide will take you through installing the Development Client module in your project 
+- [Get Started with the Dev Client](installation.md) - This step-by-step guide will take you through installing the Development Client module in your project
 - [Distributing to Android Devices](distribution-for-android.md) - Get your Development Client running on an Android device
 - [Distributing to iOS Devices](distribution-for-ios.md) - Get your Development Client running on an iOS device
 - [Troubleshooting](troubleshooting.md) - Solutions for common issues you might encounter with the Development Client

--- a/docs/pages/clients/introduction.md
+++ b/docs/pages/clients/introduction.md
@@ -6,7 +6,7 @@ import ImageSpotlight from '~/components/plugins/ImageSpotlight'
 
 **Expo Development Client** is an open source project to improve your development experience while working on your Expo and React Native projects. It allows your team to focus on the JavaScript portion of your project, only needing to interact with XCode or Android Studio when you need to make changes to the native code used in your project.
 
-<ImageSpotlight src="/static/images/development-clients-overview.png" style={{ maxWidth: 605 }} />
+<ImageSpotlight alt="Diagram that visualizes the difference between Expo Go and Custom development clients" src="/static/images/development-clients-overview.png" style={{ maxWidth: 605 }} />
 
 > ⚠️ **Managed Expo projects are not yet supported**, but we are working on bringing the Development Client to the Managed Workflow! If you want to build a managed Expo project with the Development Client, you'll have to eject it first. See the [Ejecting to Bare Workflow](../workflow/customizing.md) page to learn how.
 

--- a/docs/pages/faq/image-background.md
+++ b/docs/pages/faq/image-background.md
@@ -2,6 +2,8 @@
 title: Setting a component's background image
 ---
 
+import ImageSpotlight from '~/components/plugins/ImageSpotlight'
+
 The `ImageBackground` component lets you display an image as the background of another component in Expo and React Native apps. For example, you can set the background image of a screen in your app with `ImageBackground` inside the screen's container view.
 
 This component is conceptually similar to CSS's `background-image` stylesheet property and the `backgroundImage` DOM style property.
@@ -11,6 +13,7 @@ This component is conceptually similar to CSS's `background-image` stylesheet pr
 The `ImageBackground` component accepts mostly the same props as the `Image` component with a few differences. The `style` prop is applied to a view that wraps an inner image; the `imageStyle` prop is applied to the image itself. The `imageRef` prop also is applied to the inner image.
 
 ## Example
+
 <SnackInline>
 
 <!-- prettier-ignore -->
@@ -62,8 +65,6 @@ export default App;
 
 </SnackInline>
 
-The example above renders a screen like:
+The example above renders a screen like this:
 
-<img src="/static/images/imagebackground-example.png"
-     width="276" height="494"
-     style={{ display: 'block', width: 'auto', marginBottom: 30, marginLeft: 'auto', marginRight: 'auto' }}/>
+<ImageSpotlight style={{ maxWidth: 276 }} containerStyle={{ marginTop: 0 }} src="/static/images/imagebackground-example.png" alt="Text rendered on top of an image background" />

--- a/docs/pages/guides/configuring-statusbar.md
+++ b/docs/pages/guides/configuring-statusbar.md
@@ -2,15 +2,13 @@
 title: Configuring the Status Bar
 ---
 
+import ImageSpotlight from '~/components/plugins/ImageSpotlight'
+
 The status bar configuration often feels like a small detail to a developer, but it can make a big difference on the overall feel and perceived level of polish of your app by users. When you have a white status bar on a white background, you just know something isn't going quite right.
 
 This guide is intended to help you know what tools are at your disposal to configure the status bar for your iOS and Android apps.
 
-<div style={{backgroundColor: '#fafafa', flex: 1, textAlign: 'center'}}>
-  <img src="/static/images/status-bar-style-comparison.png" alt="A comparison of good and bad status bar styling" />
-</div>
-
-<br />
+<ImageSpotlight src="/static/images/status-bar-style-comparison.png" alt="A comparison of good and bad status bar styling" />
 
 > 👀 Notice how bad the contrast is between the status bar text and the background in the second image. This is what we want to try to avoid.
 

--- a/docs/pages/introduction/walkthrough.md
+++ b/docs/pages/introduction/walkthrough.md
@@ -3,6 +3,7 @@ title: Walkthrough
 sidebar_title: Walkthrough
 ---
 
+import ImageSpotlight from '~/components/plugins/ImageSpotlight'
 import Video from '~/components/plugins/Video'
 
 There's no need to install anything or even understand everything here, this page is meant to give you an overview of some of the big pieces of building a managed app. In the same way that getting a quick tour of Paris won't make you an expert on Paris, this walkthrough serves to help you identify a few landmarks and the most important areas in the managed workflow. You can do a walkthrough of the [bare workflow](../bare/exploring-bare-workflow.md) later on.
@@ -37,9 +38,8 @@ Let's scroll through the [API Reference](/versions/latest/) to find packages tha
 
 Let's say we had mockups for our app that look like the following:
 
-<div style={{flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', marginBottom: 10}}>
-<img src="/static/images/exploring-managed/mockups.png" alt="Mockups of app screens" />
-</div>
+
+<ImageSpotlight alt="Mockups of app screens" src="/static/images/exploring-managed/mockups.png" />
 
 > _Note: These are actually screenshots from [Sindre Sorhus'](https://github.com/sindresorhus) open source app [Blear](https://sindresorhus.com/blear), but let's pretend they are mockups for the sake of demonstration._
 

--- a/docs/pages/tutorial/configuration.md
+++ b/docs/pages/tutorial/configuration.md
@@ -4,6 +4,7 @@ title: Configuring a splash screen and app icon
 
 import { theme } from '@expo/styleguide'
 import Video from '~/components/plugins/Video'
+import ImageSpotlight from '~/components/plugins/ImageSpotlight'
 
 Before we can consider our app truly complete we need to add a splash screen and app icon. A splash screen is what users see when the app is launched, before it has loaded. The icon will be visible on the users' home screen when the app is installed, or inside of the Expo app when in development.
 
@@ -11,9 +12,7 @@ Before we can consider our app truly complete we need to add a splash screen and
 
 After telling our designer that we need a 1242px width by 2436px height splash screen image (more about this in [the splash screen guide](../guides/splash-screens.md)), she gave us the following file:
 
-<div style={{textAlign: 'center', backgroundColor: theme.background.secondary, paddingTop: 10, paddingBottom: 10}}>
-<img src="/static/images/tutorial/splash.png" style={{maxWidth: 150}} />
-</div>
+<ImageSpotlight src="/static/images/tutorial/splash.png" style={{ maxWidth: 150 }} containerStyle={{ marginBottom: 0 }} />
 
 <br />
 
@@ -74,12 +73,7 @@ This solves our problem!
 
 Our designer provided us with this 1024px width x 1024px height app icon:
 
-<div style={{textAlign: 'center', backgroundColor: theme.background.secondary, paddingTop: 10, paddingBottom: 10}}>
-<img src="/static/images/tutorial/icon.png" style={{maxWidth: 150}} />
-</div>
-
-<br />
-<br />
+<ImageSpotlight src="/static/images/tutorial/icon.png" style={{ maxWidth: 150 }} />
 
 Save this image to the `assets` directory inside of your project and call it `icon.png` &mdash; replace the existing file. Reload the app. That's all you need to do! You will see the icon in various places in Expo Go, and when you do a standalone app build for submission to the stores it will be used as the icon on the users' home screens.
 

--- a/docs/pages/tutorial/image.md
+++ b/docs/pages/tutorial/image.md
@@ -2,14 +2,13 @@
 title: Adding an image
 ---
 
+import ImageSpotlight from '~/components/plugins/ImageSpotlight'
 import SnackInline from '~/components/plugins/SnackInline';
 
 Let's imagine that our designer has provided us with a beautiful logo:
 
-<img src="/static/images/tutorial/logo.png" style={{maxWidth: 305, maxHeight: 159}} />
 
-<br />
-<br />
+<ImageSpotlight src="/static/images/tutorial/logo.png" style={{maxWidth: 305, maxHeight: 159}} />
 
 Save this image to the `assets` directory inside of your project and call it `logo.png`.
 

--- a/docs/pages/tutorial/image.md
+++ b/docs/pages/tutorial/image.md
@@ -8,7 +8,7 @@ import SnackInline from '~/components/plugins/SnackInline';
 Let's imagine that our designer has provided us with a beautiful logo:
 
 
-<ImageSpotlight src="/static/images/tutorial/logo.png" style={{maxWidth: 305, maxHeight: 159}} />
+<ImageSpotlight alt="A pretty bad logo with the text 'Image Share' and the emoji of the sun behind mountains" src="/static/images/tutorial/logo.png" style={{maxWidth: 305, maxHeight: 159}} />
 
 Save this image to the `assets` directory inside of your project and call it `logo.png`.
 

--- a/docs/pages/versions/unversioned/sdk/filesystem.md
+++ b/docs/pages/versions/unversioned/sdk/filesystem.md
@@ -12,7 +12,7 @@ import SnackInline from '~/components/plugins/SnackInline';
 **`expo-file-system`** provides access to a file system stored locally on the device. Within Expo Go, each project has a separate file system and has no access to the file system of other Expo projects. However, it can save content shared by other projects to the local filesystem, as well as share local files with other projects. It is also capable of uploading and downloading files from network URLs.
 
 <!-- TODO: update this image so we don't have to force a white background on it -->
-<ImageSpotlight src="/static/images/sdk/file-system/file-system-diagram.png" style={{ maxWidth: 850, maxHeight: 600 }} containerStyle={{ backgroundColor: "#fff" }} />
+<ImageSpotlight alt="Diagram of the various pieces of expo-file-system and how they interact with different resources" src="/static/images/sdk/file-system/file-system-diagram.png" style={{ maxWidth: 850, maxHeight: 600 }} containerStyle={{ backgroundColor: "#fff" }} />
 
 <PlatformsSection android emulator ios simulator />
 

--- a/docs/pages/versions/unversioned/sdk/filesystem.md
+++ b/docs/pages/versions/unversioned/sdk/filesystem.md
@@ -3,6 +3,7 @@ title: FileSystem
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-file-system'
 ---
 
+import ImageSpotlight from '~/components/plugins/ImageSpotlight'
 import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
@@ -10,7 +11,8 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 **`expo-file-system`** provides access to a file system stored locally on the device. Within Expo Go, each project has a separate file system and has no access to the file system of other Expo projects. However, it can save content shared by other projects to the local filesystem, as well as share local files with other projects. It is also capable of uploading and downloading files from network URLs.
 
-<img src="/static/images/sdk/file-system/file-system-diagram.png" style={{maxWidth: 850, maxHeight: 600, marginBottom:"5em", display: "block", marginLeft: "auto", marginRight: "auto"}} />
+<!-- TODO: update this image so we don't have to force a white background on it -->
+<ImageSpotlight src="/static/images/sdk/file-system/file-system-diagram.png" style={{ maxWidth: 850, maxHeight: 600 }} containerStyle={{ backgroundColor: "#fff" }} />
 
 <PlatformsSection android emulator ios simulator />
 

--- a/docs/pages/versions/unversioned/sdk/notifications.md
+++ b/docs/pages/versions/unversioned/sdk/notifications.md
@@ -4,6 +4,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-notificat
 ---
 
 import SnackInline from '~/components/plugins/SnackInline';
+import ImageSpotlight from '~/components/plugins/ImageSpotlight'
 import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
@@ -15,7 +16,7 @@ The **`expo-notifications`** provides an API to fetch push notification tokens a
 
 - 📣 schedule a one-off notification for a specific date, or some time from now,
 - 🔁 schedule a notification repeating in some time interval (or a calendar date match on iOS),
-- 1️⃣ get and set application badge icon number,
+- 💯 get and set application badge icon number,
 - 📲 fetch a native device push token so you can send push notifications with FCM and APNS,
 - 😎 fetch an Expo push token so you can send push notifications with Expo,
 - 📬 listen to incoming notifications,
@@ -147,7 +148,7 @@ await Notifications.scheduleNotificationAsync({
 });
 ```
 
-<img src="/static/images/notification-sound-ios.jpeg" style={{maxWidth: 305}} />
+<ImageSpotlight src="/static/images/notification-sound-ios.jpeg" style={{maxWidth: 305}} />
 
 </p>
 </details>
@@ -1084,7 +1085,7 @@ A `Promise` resolving once the channel group is removed (or if there was no chan
 
 Notification categories allow you to create interactive push notifications, so that a user can respond directly to the incoming notification either via buttons or a text response. A category defines the set of actions a user can take, and then those actions are applied to a notification by specifying the `categoryIdentifier` in the [`NotificationContent`](#notificationcontent).
 
-<img width="50%" src="/static/images/sdk/notifications/categories.png" style={{width: 800}} alt="image of notification categories on iOS and Android"/>
+<ImageSpotlight src="/static/images/sdk/notifications/categories.png" style={{maxWidth: 800}} alt="image of notification categories on iOS and Android"/>
 
 On iOS, notification categories also allow you to customize your notifications further. With each category, not only can you set interactive actions a user can take, but you can also configure things like the placeholder text to display when the user disables notification previews for your app.
 

--- a/docs/pages/versions/unversioned/sdk/notifications.md
+++ b/docs/pages/versions/unversioned/sdk/notifications.md
@@ -148,7 +148,7 @@ await Notifications.scheduleNotificationAsync({
 });
 ```
 
-<ImageSpotlight src="/static/images/notification-sound-ios.jpeg" style={{maxWidth: 305}} />
+<ImageSpotlight alt="notification.wav inside of app resources in Xcode project organizer" src="/static/images/notification-sound-ios.jpeg" style={{maxWidth: 305}} />
 
 </p>
 </details>

--- a/docs/pages/versions/v40.0.0/sdk/filesystem.md
+++ b/docs/pages/versions/v40.0.0/sdk/filesystem.md
@@ -3,6 +3,7 @@ title: FileSystem
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-40/packages/expo-file-system'
 ---
 
+import ImageSpotlight from '~/components/plugins/ImageSpotlight'
 import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
@@ -10,7 +11,7 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 **`expo-file-system`** provides access to a file system stored locally on the device. Within Expo Go, each app has a separate file system and has no access to the file system of other Expo apps. However, it can save content shared by other apps to local filesystem, as well as share local files to other apps. It is also capable of uploading and downloading files from network URLs.
 
-<img src="/static/images/sdk/file-system/file-system-diagram.png" style={{maxWidth: 850, maxHeight: 600, marginBottom:"5em", display: "block", marginLeft: "auto", marginRight: "auto"}} />
+<ImageSpotlight src="/static/images/sdk/file-system/file-system-diagram.png" style={{ maxWidth: 850, maxHeight: 600 }} containerStyle={{ backgroundColor: "#fff" }} />
 
 <PlatformsSection android emulator ios simulator />
 

--- a/docs/pages/versions/v40.0.0/sdk/filesystem.md
+++ b/docs/pages/versions/v40.0.0/sdk/filesystem.md
@@ -11,7 +11,8 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 **`expo-file-system`** provides access to a file system stored locally on the device. Within Expo Go, each app has a separate file system and has no access to the file system of other Expo apps. However, it can save content shared by other apps to local filesystem, as well as share local files to other apps. It is also capable of uploading and downloading files from network URLs.
 
-<ImageSpotlight src="/static/images/sdk/file-system/file-system-diagram.png" style={{ maxWidth: 850, maxHeight: 600 }} containerStyle={{ backgroundColor: "#fff" }} />
+<!-- TODO: update this image so we don't have to force a white background on it -->
+<ImageSpotlight alt="Diagram of the various pieces of expo-file-system and how they interact with different resources"  src="/static/images/sdk/file-system/file-system-diagram.png" style={{ maxWidth: 850, maxHeight: 600 }} containerStyle={{ backgroundColor: "#fff" }} />
 
 <PlatformsSection android emulator ios simulator />
 

--- a/docs/pages/versions/v40.0.0/sdk/notifications.md
+++ b/docs/pages/versions/v40.0.0/sdk/notifications.md
@@ -160,7 +160,7 @@ await Notifications.scheduleNotificationAsync({
 });
 ```
 
-<ImageSpotlight src="/static/images/notification-sound-ios.jpeg" style={{maxWidth: 305}} />
+<ImageSpotlight alt="notification.wav inside of app resources in Xcode project organizer" src="/static/images/notification-sound-ios.jpeg" style={{maxWidth: 305}} />
 
 </p>
 </details>

--- a/docs/pages/versions/v40.0.0/sdk/notifications.md
+++ b/docs/pages/versions/v40.0.0/sdk/notifications.md
@@ -4,6 +4,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-40/packages/expo-notificat
 ---
 
 import SnackInline from '~/components/plugins/SnackInline';
+import ImageSpotlight from '~/components/plugins/ImageSpotlight'
 import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
@@ -15,7 +16,7 @@ The **`expo-notifications`** provides an API to fetch push notification tokens a
 
 - 📣 schedule a one-off notification for a specific date, or some time from now,
 - 🔁 schedule a notification repeating in some time interval (or a calendar date match on iOS),
-- 1️⃣ get and set application badge icon number,
+- 💯 get and set application badge icon number,
 - 📲 fetch a native device push token so you can send push notifications with FCM and APNS,
 - 😎 fetch an Expo push token so you can send push notifications with Expo,
 - 📬 listen to incoming notifications,
@@ -159,7 +160,7 @@ await Notifications.scheduleNotificationAsync({
 });
 ```
 
-<img src="/static/images/notification-sound-ios.jpeg" style={{maxWidth: 305}} />
+<ImageSpotlight src="/static/images/notification-sound-ios.jpeg" style={{maxWidth: 305}} />
 
 </p>
 </details>
@@ -1098,7 +1099,7 @@ A `Promise` resolving once the channel group is removed (or if there was no chan
 
 Notification categories allow you to create interactive push notifications, so that a user can respond directly to the incoming notification either via buttons or a text response. A category defines the set of actions a user can take, and then those actions are applied to a notification by specifying the `categoryIdentifier` in the [`NotificationContent`](#notificationcontent).
 
-<img width="50%" src="/static/images/sdk/notifications/categories.png" style={{width: 800}} alt="image of notification categories on iOS and Android"/>
+<ImageSpotlight src="/static/images/sdk/notifications/categories.png" style={{maxWidth: 800}} alt="image of notification categories on iOS and Android"/>
 
 On iOS, notification categories also allow you to customize your notifications further. With each category, not only can you set interactive actions a user can take, but you can also configure things like the placeholder text to display when the user disables notification previews for your app.
 


### PR DESCRIPTION
# Why

It usually looks better to center images and give them a bit of spacing from the surrounding text. We have done this in a few places with some ad-hoc divs random styling. I pulled that out into an `ImageSpotlight` component to do this consistently and factor in theme. It's mostly a drop-in replacement for `img` with a wrapper div and centered image.

### Before

![Screen Shot 2021-03-04 at 1 41 53 PM](https://user-images.githubusercontent.com/90494/110036263-9db85d00-7cf1-11eb-9e96-78e7569b5d44.png)

### After

![Screen Shot 2021-03-04 at 1 42 46 PM](https://user-images.githubusercontent.com/90494/110036265-9f822080-7cf1-11eb-87f6-331259c2d43d.png)

### Before

![Screen Shot 2021-03-04 at 1 43 27 PM](https://user-images.githubusercontent.com/90494/110036298-ac067900-7cf1-11eb-93ba-42beabf5f4f9.png)

### After

![Screen Shot 2021-03-04 at 1 43 38 PM](https://user-images.githubusercontent.com/90494/110036308-af9a0000-7cf1-11eb-8c49-539dc75cc94a.png)

### Before

![Screen Shot 2021-03-04 at 1 46 43 PM](https://user-images.githubusercontent.com/90494/110036331-b6287780-7cf1-11eb-95e8-d8892a5a42b4.png)

### After

![Screen Shot 2021-03-04 at 2 00 38 PM](https://user-images.githubusercontent.com/90494/110036535-04d61180-7cf2-11eb-9891-4805195daaaa.png)

### Before

![Screen Shot 2021-03-04 at 1 56 33 PM](https://user-images.githubusercontent.com/90494/110036366-be80b280-7cf1-11eb-902e-09827468c6e2.png)

### After

![Screen Shot 2021-03-04 at 1 56 49 PM](https://user-images.githubusercontent.com/90494/110036383-c2acd000-7cf1-11eb-8208-dc639af9dcc3.png)

# How

See ImageSpotlight.tsx

# Test Plan

Try out docs with images