### PR TITLE
[expo-updates] add SQLite migrations to make `assets.key` nullable

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -24,7 +24,7 @@
 - Send persisted serverDefinedHeaders in manifest requests ([#11994](https://github.com/expo/expo/pull/11994) by [@esamelson](https://github.com/esamelson))
 - Only require signatures with expo go (android). ([#12027](https://github.com/expo/expo/pull/12027) by [@jkhales](https://github.com/jkhales))
 - Only require signatures with expo go (iOS). ([#12072](https://github.com/expo/expo/pull/12072) by [@jkhales](https://github.com/jkhales))
-
+- Make asset keys nullable ([#12084](https://github.com/expo/expo/pull/12084) by [@esamelson](https://github.com/esamelson))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-updates/android/build.gradle
+++ b/packages/expo-updates/android/build.gradle
@@ -54,6 +54,9 @@ android {
   testOptions {
     unitTests.includeAndroidResources = true
   }
+  sourceSets {
+    androidTest.assets.srcDirs += files("$projectDir/src/androidTest/schemas".toString())
+  }
 }
 
 if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
@@ -88,4 +91,5 @@ dependencies {
   androidTestImplementation 'androidx.test:runner:1.1.0'
   androidTestImplementation 'androidx.test:rules:1.1.0'
   androidTestImplementation 'org.mockito:mockito-android:3.7.7'
+  androidTestImplementation "androidx.room:room-testing:$room_version"
 }

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/db/UpdatesDatabaseMigrationTest.java
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/db/UpdatesDatabaseMigrationTest.java
@@ -1,0 +1,103 @@
+package expo.modules.updates.db;
+
+import android.database.Cursor;
+import android.database.sqlite.SQLiteConstraintException;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+
+import androidx.room.testing.MigrationTestHelper;
+import androidx.sqlite.db.SupportSQLiteDatabase;
+import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory;
+import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner;
+import androidx.test.platform.app.InstrumentationRegistry;
+
+@RunWith(AndroidJUnit4ClassRunner.class)
+public class UpdatesDatabaseMigrationTest {
+  private static final String TEST_DB = "migration-test.db";
+
+  @Rule
+  public MigrationTestHelper helper;
+
+  public UpdatesDatabaseMigrationTest() {
+    helper = new MigrationTestHelper(InstrumentationRegistry.getInstrumentation(),
+      UpdatesDatabase.class.getCanonicalName(),
+      new FrameworkSQLiteOpenHelperFactory());
+  }
+
+  @Test
+  public void testMigrate4To5() throws IOException {
+    SupportSQLiteDatabase db = helper.createDatabase(TEST_DB, 4);
+
+    // db has schema version 4. insert some data using SQL queries.
+    // cannot use DAO classes because they expect the latest schema.
+    db.execSQL("INSERT INTO \"assets\" (\"id\",\"url\",\"key\",\"headers\",\"type\",\"metadata\",\"download_time\",\"relative_path\",\"hash\",\"hash_type\",\"marked_for_deletion\") VALUES" +
+      " (2,'https://url.to/b56cf690e0afa93bd4dc7756d01edd3e','b56cf690e0afa93bd4dc7756d01edd3e.png',NULL,'image/png',NULL,1614137309295,'b56cf690e0afa93bd4dc7756d01edd3e.png',NULL,0,0),\n" +
+      " (3,'https://url.to/bundle-1614137308871','bundle-1614137308871',NULL,'application/javascript',NULL,1614137309513,'bundle-1614137308871',NULL,0,0),\n" +
+      " (4,NULL,'bundle-1614137401950',NULL,'js',NULL,1614137406588,'bundle-1614137401950',NULL,0,0)");
+    db.execSQL("INSERT INTO \"updates\" (\"id\",\"scope_key\",\"commit_time\",\"runtime_version\",\"launch_asset_id\",\"metadata\",\"status\",\"keep\") VALUES" +
+      " (X'8C263F9DE3FF48888496E3244C788661','http://192.168.4.44:3000',1614137308871,'40.0.0',3,'{\"updateMetadata\":{\"updateGroup\":\"34993d39-57e6-46cf-8fa2-eba836f40828\",\"updateGroupCreatedAt\":\"2021-02-23T12:53:46.851Z\",\"branchName\":\"rollout\"}}',1,1),\n" +
+      " (X'594100ea066e4804b5c7c907c773f980','http://192.168.4.44:3000',1614137401950,'40.0.0',4,NULL,1,1)");
+    db.execSQL("INSERT INTO \"updates_assets\" (\"update_id\",\"asset_id\") VALUES" +
+      " (X'8C263F9DE3FF48888496E3244C788661',2),\n" +
+      " (X'8C263F9DE3FF48888496E3244C788661',3),\n" +
+      " (X'594100ea066e4804b5c7c907c773f980',4)");
+
+    // Prepare for the next version.
+    db.close();
+
+    // Re-open the database with version 5 and provide
+    // MIGRATION_4_5 as the migration process.
+    db = helper.runMigrationsAndValidate(TEST_DB, 5, true, UpdatesDatabase.MIGRATION_4_5);
+
+    db.execSQL("PRAGMA foreign_keys=ON");
+
+    // schema changes automatically verified, we just need to verify data integrity
+    Cursor cursorUpdates1 = db.query("SELECT * FROM `updates` WHERE `id` = X'8C263F9DE3FF48888496E3244C788661'");
+    Assert.assertEquals(1, cursorUpdates1.getCount());
+    Cursor cursorUpdates2 = db.query("SELECT * FROM `updates` WHERE `id` = X'594100ea066e4804b5c7c907c773f980'");
+    Assert.assertEquals(1, cursorUpdates2.getCount());
+
+    Cursor cursorAssets1 = db.query("SELECT * FROM `assets` WHERE `id` = 2 AND `url` = 'https://url.to/b56cf690e0afa93bd4dc7756d01edd3e' AND `key` = 'b56cf690e0afa93bd4dc7756d01edd3e.png' AND `headers` IS NULL AND `type` = 'image/png' AND `metadata` IS NULL AND `download_time` = 1614137309295 AND `relative_path` = 'b56cf690e0afa93bd4dc7756d01edd3e.png' AND `hash` IS NULL AND `hash_type` = 0 AND `marked_for_deletion` = 0");
+    Assert.assertEquals(1, cursorAssets1.getCount());
+    Cursor cursorAssets2 = db.query("SELECT * FROM `assets` WHERE `id` = 3 AND `url` = 'https://url.to/bundle-1614137308871' AND `key` = 'bundle-1614137308871' AND `headers` IS NULL AND `type` = 'application/javascript' AND `metadata` IS NULL AND `download_time` = 1614137309513 AND `relative_path` = 'bundle-1614137308871' AND `hash` IS NULL AND `hash_type` = 0 AND `marked_for_deletion` = 0");
+    Assert.assertEquals(1, cursorAssets2.getCount());
+    Cursor cursorAssets3 = db.query("SELECT * FROM `assets` WHERE `id` = 4 AND `url` IS NULL AND `key` = 'bundle-1614137401950' AND `headers` IS NULL AND `type` = 'js' AND `metadata` IS NULL AND `download_time` = 1614137406588 AND `relative_path` = 'bundle-1614137401950' AND `hash` IS NULL AND `hash_type` = 0 AND `marked_for_deletion` = 0");
+    Assert.assertEquals(1, cursorAssets3.getCount());
+
+    Cursor cursorUpdatesAssets1 = db.query("SELECT * FROM `updates_assets` WHERE `update_id` = X'8C263F9DE3FF48888496E3244C788661' AND `asset_id` = 2");
+    Assert.assertEquals(1, cursorUpdatesAssets1.getCount());
+    Cursor cursorUpdatesAssets2 = db.query("SELECT * FROM `updates_assets` WHERE `update_id` = X'8C263F9DE3FF48888496E3244C788661' AND `asset_id` = 3");
+    Assert.assertEquals(1, cursorUpdatesAssets2.getCount());
+    Cursor cursorUpdatesAssets3 = db.query("SELECT * FROM `updates_assets` WHERE `update_id` = X'594100ea066e4804b5c7c907c773f980' AND `asset_id` = 4");
+    Assert.assertEquals(1, cursorUpdatesAssets3.getCount());
+
+    // make sure we can insert multiple assets with null keys
+    db.execSQL("INSERT INTO \"assets\" (\"id\",\"url\",\"key\",\"headers\",\"type\",\"metadata\",\"download_time\",\"relative_path\",\"hash\",\"hash_type\",\"marked_for_deletion\") VALUES" +
+      " (5,NULL,NULL,NULL,'js',NULL,1614137406589,'bundle-1614137401951',NULL,0,0),\n" +
+      " (6,NULL,NULL,NULL,'js',NULL,1614137406580,'bundle-1614137401952',NULL,0,0)");
+
+    // make sure foreign key constraint still works
+    db.execSQL("INSERT INTO `updates_assets` (`update_id`, `asset_id`) VALUES (X'594100ea066e4804b5c7c907c773f980', 5)");
+    Cursor cursorUpdatesAssets4 = db.query("SELECT * FROM `updates_assets` WHERE `update_id` = X'594100ea066e4804b5c7c907c773f980' AND `asset_id` = 5");
+    Assert.assertEquals(1, cursorUpdatesAssets4.getCount());
+
+    boolean fails;
+    try {
+      db.execSQL("INSERT INTO `updates_assets` (`update_id`, `asset_id`) VALUES (X'594100ea066e4804b5c7c907c773f980', 13)");
+      fails = false;
+    } catch (SQLiteConstraintException e) {
+      fails = true;
+    }
+    Assert.assertTrue(fails);
+
+    // test on delete cascade
+    db.execSQL("DELETE FROM `assets` WHERE `id` = 5");
+    Cursor cursorUpdatesAssets6 = db.query("SELECT * FROM `updates_assets` WHERE `update_id` = X'594100ea066e4804b5c7c907c773f980' AND `asset_id` = 5");
+    Assert.assertEquals(0, cursorUpdatesAssets6.getCount());
+  }
+}

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/db/UpdatesDatabaseTest.java
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/db/UpdatesDatabaseTest.java
@@ -1,6 +1,7 @@
 package expo.modules.updates.db;
 
 import android.content.Context;
+import android.database.sqlite.SQLiteConstraintException;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -9,6 +10,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
@@ -19,6 +21,7 @@ import androidx.test.platform.app.InstrumentationRegistry;
 import expo.modules.updates.db.dao.AssetDao;
 import expo.modules.updates.db.dao.UpdateDao;
 import expo.modules.updates.db.entity.AssetEntity;
+import expo.modules.updates.db.entity.UpdateAssetEntity;
 import expo.modules.updates.db.entity.UpdateEntity;
 
 @RunWith(AndroidJUnit4ClassRunner.class)
@@ -60,6 +63,23 @@ public class UpdatesDatabaseTest {
 
     updateDao.deleteUpdates(Arrays.asList(testUpdate));
     Assert.assertEquals(0, updateDao.loadAllUpdatesForScope(projectId).size());
+  }
+
+  @Test(expected = SQLiteConstraintException.class)
+  public void testForeignKeys() {
+    UUID uuid = UUID.randomUUID();
+    Date date = new Date();
+    String runtimeVersion = "1.0";
+    String projectId = "https://exp.host/@esamelson/test-project";
+
+    UpdateEntity testUpdate = new UpdateEntity(uuid, date, runtimeVersion, projectId);
+    updateDao.insertUpdate(testUpdate);
+
+    try {
+      assetDao._insertUpdateAsset(new UpdateAssetEntity(uuid, 47));
+    } finally {
+      updateDao.deleteUpdates(Collections.singletonList(testUpdate));
+    }
   }
 
   @Test

--- a/packages/expo-updates/android/src/androidTest/schemas/expo.modules.updates.db.UpdatesDatabase/4.json
+++ b/packages/expo-updates/android/src/androidTest/schemas/expo.modules.updates.db.UpdatesDatabase/4.json
@@ -1,0 +1,307 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 4,
+    "identityHash": "61f9a5dd091c3aa54f5dee1a562c6d2d",
+    "entities": [
+      {
+        "tableName": "updates",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `scope_key` TEXT NOT NULL, `commit_time` INTEGER NOT NULL, `runtime_version` TEXT NOT NULL, `launch_asset_id` INTEGER, `metadata` TEXT, `status` INTEGER NOT NULL, `keep` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`launch_asset_id`) REFERENCES `assets`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scopeKey",
+            "columnName": "scope_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "commitTime",
+            "columnName": "commit_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "runtimeVersion",
+            "columnName": "runtime_version",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "launchAssetId",
+            "columnName": "launch_asset_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "metadata",
+            "columnName": "metadata",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "keep",
+            "columnName": "keep",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_updates_launch_asset_id",
+            "unique": false,
+            "columnNames": [
+              "launch_asset_id"
+            ],
+            "createSql": "CREATE  INDEX `index_updates_launch_asset_id` ON `${TABLE_NAME}` (`launch_asset_id`)"
+          },
+          {
+            "name": "index_updates_scope_key_commit_time",
+            "unique": true,
+            "columnNames": [
+              "scope_key",
+              "commit_time"
+            ],
+            "createSql": "CREATE UNIQUE INDEX `index_updates_scope_key_commit_time` ON `${TABLE_NAME}` (`scope_key`, `commit_time`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "assets",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "launch_asset_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "updates_assets",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`update_id` BLOB NOT NULL, `asset_id` INTEGER NOT NULL, PRIMARY KEY(`update_id`, `asset_id`), FOREIGN KEY(`update_id`) REFERENCES `updates`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`asset_id`) REFERENCES `assets`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "updateId",
+            "columnName": "update_id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "assetId",
+            "columnName": "asset_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "update_id",
+            "asset_id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_updates_assets_asset_id",
+            "unique": false,
+            "columnNames": [
+              "asset_id"
+            ],
+            "createSql": "CREATE  INDEX `index_updates_assets_asset_id` ON `${TABLE_NAME}` (`asset_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "updates",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "update_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "assets",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "asset_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "assets",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `url` TEXT, `key` TEXT NOT NULL, `headers` TEXT, `type` TEXT NOT NULL, `metadata` TEXT, `download_time` INTEGER, `relative_path` TEXT, `hash` BLOB, `hash_type` INTEGER NOT NULL, `marked_for_deletion` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "headers",
+            "columnName": "headers",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadata",
+            "columnName": "metadata",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "downloadTime",
+            "columnName": "download_time",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "relativePath",
+            "columnName": "relative_path",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "hash",
+            "columnName": "hash",
+            "affinity": "BLOB",
+            "notNull": false
+          },
+          {
+            "fieldPath": "hashType",
+            "columnName": "hash_type",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "markedForDeletion",
+            "columnName": "marked_for_deletion",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_assets_key",
+            "unique": true,
+            "columnNames": [
+              "key"
+            ],
+            "createSql": "CREATE UNIQUE INDEX `index_assets_key` ON `${TABLE_NAME}` (`key`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "json_data",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `key` TEXT NOT NULL, `value` TEXT NOT NULL, `last_updated` INTEGER NOT NULL, `scope_key` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUpdated",
+            "columnName": "last_updated",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scopeKey",
+            "columnName": "scope_key",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_json_data_scope_key",
+            "unique": false,
+            "columnNames": [
+              "scope_key"
+            ],
+            "createSql": "CREATE  INDEX `index_json_data_scope_key` ON `${TABLE_NAME}` (`scope_key`)"
+          }
+        ],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '61f9a5dd091c3aa54f5dee1a562c6d2d')"
+    ]
+  }
+}

--- a/packages/expo-updates/android/src/androidTest/schemas/expo.modules.updates.db.UpdatesDatabase/5.json
+++ b/packages/expo-updates/android/src/androidTest/schemas/expo.modules.updates.db.UpdatesDatabase/5.json
@@ -1,0 +1,307 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 5,
+    "identityHash": "d980514a0729c66ac31d3ca19e2ac9c8",
+    "entities": [
+      {
+        "tableName": "updates",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `scope_key` TEXT NOT NULL, `commit_time` INTEGER NOT NULL, `runtime_version` TEXT NOT NULL, `launch_asset_id` INTEGER, `metadata` TEXT, `status` INTEGER NOT NULL, `keep` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`launch_asset_id`) REFERENCES `assets`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scopeKey",
+            "columnName": "scope_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "commitTime",
+            "columnName": "commit_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "runtimeVersion",
+            "columnName": "runtime_version",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "launchAssetId",
+            "columnName": "launch_asset_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "metadata",
+            "columnName": "metadata",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "keep",
+            "columnName": "keep",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_updates_launch_asset_id",
+            "unique": false,
+            "columnNames": [
+              "launch_asset_id"
+            ],
+            "createSql": "CREATE  INDEX `index_updates_launch_asset_id` ON `${TABLE_NAME}` (`launch_asset_id`)"
+          },
+          {
+            "name": "index_updates_scope_key_commit_time",
+            "unique": true,
+            "columnNames": [
+              "scope_key",
+              "commit_time"
+            ],
+            "createSql": "CREATE UNIQUE INDEX `index_updates_scope_key_commit_time` ON `${TABLE_NAME}` (`scope_key`, `commit_time`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "assets",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "launch_asset_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "updates_assets",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`update_id` BLOB NOT NULL, `asset_id` INTEGER NOT NULL, PRIMARY KEY(`update_id`, `asset_id`), FOREIGN KEY(`update_id`) REFERENCES `updates`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`asset_id`) REFERENCES `assets`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "updateId",
+            "columnName": "update_id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "assetId",
+            "columnName": "asset_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "update_id",
+            "asset_id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_updates_assets_asset_id",
+            "unique": false,
+            "columnNames": [
+              "asset_id"
+            ],
+            "createSql": "CREATE  INDEX `index_updates_assets_asset_id` ON `${TABLE_NAME}` (`asset_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "updates",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "update_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "assets",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "asset_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "assets",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `url` TEXT, `key` TEXT, `headers` TEXT, `type` TEXT NOT NULL, `metadata` TEXT, `download_time` INTEGER, `relative_path` TEXT, `hash` BLOB, `hash_type` INTEGER NOT NULL, `marked_for_deletion` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "headers",
+            "columnName": "headers",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadata",
+            "columnName": "metadata",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "downloadTime",
+            "columnName": "download_time",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "relativePath",
+            "columnName": "relative_path",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "hash",
+            "columnName": "hash",
+            "affinity": "BLOB",
+            "notNull": false
+          },
+          {
+            "fieldPath": "hashType",
+            "columnName": "hash_type",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "markedForDeletion",
+            "columnName": "marked_for_deletion",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_assets_key",
+            "unique": true,
+            "columnNames": [
+              "key"
+            ],
+            "createSql": "CREATE UNIQUE INDEX `index_assets_key` ON `${TABLE_NAME}` (`key`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "json_data",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `key` TEXT NOT NULL, `value` TEXT NOT NULL, `last_updated` INTEGER NOT NULL, `scope_key` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUpdated",
+            "columnName": "last_updated",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scopeKey",
+            "columnName": "scope_key",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_json_data_scope_key",
+            "unique": false,
+            "columnNames": [
+              "scope_key"
+            ],
+            "createSql": "CREATE  INDEX `index_json_data_scope_key` ON `${TABLE_NAME}` (`scope_key`)"
+          }
+        ],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'd980514a0729c66ac31d3ca19e2ac9c8')"
+    ]
+  }
+}

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/UpdatesDatabase.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/UpdatesDatabase.java
@@ -1,8 +1,10 @@
 package expo.modules.updates.db;
 
 import android.content.Context;
+import android.database.Cursor;
 import android.util.Log;
 
+import androidx.room.migration.Migration;
 import expo.modules.updates.db.dao.AssetDao;
 import expo.modules.updates.db.dao.JSONDataDao;
 import expo.modules.updates.db.dao.UpdateDao;
@@ -18,7 +20,7 @@ import androidx.room.RoomDatabase;
 import androidx.room.TypeConverters;
 import androidx.sqlite.db.SupportSQLiteDatabase;
 
-@Database(entities = {UpdateEntity.class, UpdateAssetEntity.class, AssetEntity.class, JSONDataEntity.class}, exportSchema = false, version = 4)
+@Database(entities = {UpdateEntity.class, UpdateAssetEntity.class, AssetEntity.class, JSONDataEntity.class}, exportSchema = false, version = 5)
 @TypeConverters({Converters.class})
 public abstract class UpdatesDatabase extends RoomDatabase {
 
@@ -34,10 +36,35 @@ public abstract class UpdatesDatabase extends RoomDatabase {
   public static synchronized UpdatesDatabase getInstance(Context context) {
     if (sInstance == null) {
       sInstance = Room.databaseBuilder(context, UpdatesDatabase.class, DB_NAME)
+              .addMigrations(MIGRATION_4_5)
               .fallbackToDestructiveMigration()
               .allowMainThreadQueries()
               .build();
     }
     return sInstance;
   }
+
+  static final Migration MIGRATION_4_5 = new Migration(4, 5) {
+    @Override
+    public void migrate(SupportSQLiteDatabase database) {
+      // https://www.sqlite.org/lang_altertable.html#otheralter
+      database.execSQL("PRAGMA foreign_keys=OFF");
+      database.beginTransaction();
+      try {
+        try {
+          database.execSQL("CREATE TABLE `new_assets` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `url` TEXT, `key` TEXT, `headers` TEXT, `type` TEXT NOT NULL, `metadata` TEXT, `download_time` INTEGER, `relative_path` TEXT, `hash` BLOB, `hash_type` INTEGER NOT NULL, `marked_for_deletion` INTEGER NOT NULL)");
+          database.execSQL("INSERT INTO `new_assets` (`id`, `url`, `key`, `headers`, `type`, `metadata`, `download_time`, `relative_path`, `hash`, `hash_type`, `marked_for_deletion`)" +
+            " SELECT `id`, `url`, `key`, `headers`, `type`, `metadata`, `download_time`, `relative_path`, `hash`, `hash_type`, `marked_for_deletion` FROM `assets`");
+          database.execSQL("DROP TABLE `assets`");
+          database.execSQL("ALTER TABLE `new_assets` RENAME TO `assets`");
+          database.execSQL("CREATE UNIQUE INDEX `index_assets_key` ON `assets` (`key`)");
+          database.setTransactionSuccessful();
+        } finally {
+          database.endTransaction();
+        }
+      } finally {
+        database.execSQL("PRAGMA foreign_keys=ON");
+      }
+    }
+  };
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/entity/AssetEntity.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/entity/AssetEntity.java
@@ -25,7 +25,6 @@ public class AssetEntity {
   public Uri url = null;
 
   @ColumnInfo(name = "key")
-  @NonNull
   public String key;
 
   public JSONObject headers = null;

--- a/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase+Tests.h
+++ b/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase+Tests.h
@@ -1,0 +1,13 @@
+// Copyright 2021-present 650 Industries. All rights reserved.
+
+#import <EXUpdates/EXUpdatesDatabase.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface EXUpdatesDatabase (Tests)
+
+- (nullable NSArray<NSDictionary *> *)_executeSql:(NSString *)sql withArgs:(nullable NSArray *)args error:(NSError ** _Nullable)error;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.m
+++ b/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.m
@@ -1,6 +1,8 @@
 //  Copyright © 2019 650 Industries. All rights reserved.
 
-#import <EXUpdates/EXUpdatesDatabase.h>
+#import <EXUpdates/EXUpdatesDatabase+Tests.h>
+#import <EXUpdates/EXUpdatesDatabaseInitialization.h>
+#import <EXUpdates/EXUpdatesDatabaseUtils.h>
 
 #import <sqlite3.h>
 
@@ -9,12 +11,8 @@ NS_ASSUME_NONNULL_BEGIN
 @interface EXUpdatesDatabase ()
 
 @property (nonatomic, assign) sqlite3 *db;
-@property (nonatomic, readwrite, strong) NSLock *lock;
 
 @end
-
-static NSString * const EXUpdatesDatabaseErrorDomain = @"EXUpdatesDatabase";
-static NSString * const EXUpdatesDatabaseFilename = @"expo-v4.db";
 
 static NSString * const EXUpdatesDatabaseManifestFiltersKey = @"manifestFilters";
 static NSString * const EXUpdatesDatabaseServerDefinedHeadersKey = @"serverDefinedHeaders";
@@ -33,48 +31,13 @@ static NSString * const EXUpdatesDatabaseServerDefinedHeadersKey = @"serverDefin
 
 - (BOOL)openDatabaseInDirectory:(NSURL *)directory withError:(NSError ** _Nullable)error
 {
+  dispatch_assert_queue(_databaseQueue);
   sqlite3 *db;
-  NSURL *dbUrl = [directory URLByAppendingPathComponent:EXUpdatesDatabaseFilename];
-  BOOL shouldInitializeDatabase = ![[NSFileManager defaultManager] fileExistsAtPath:[dbUrl path]];
-  int resultCode = sqlite3_open([[dbUrl path] UTF8String], &db);
-  if (resultCode != SQLITE_OK) {
-    NSLog(@"Error opening SQLite db: %@", [self _errorFromSqlite:_db].localizedDescription);
-    sqlite3_close(db);
-
-    if (resultCode == SQLITE_CORRUPT || resultCode == SQLITE_NOTADB) {
-      NSString *archivedDbFilename = [NSString stringWithFormat:@"%f-%@", [[NSDate date] timeIntervalSince1970], EXUpdatesDatabaseFilename];
-      NSURL *destinationUrl = [directory URLByAppendingPathComponent:archivedDbFilename];
-      NSError *err;
-      if ([[NSFileManager defaultManager] moveItemAtURL:dbUrl toURL:destinationUrl error:&err]) {
-        NSLog(@"Moved corrupt SQLite db to %@", archivedDbFilename);
-        if (sqlite3_open([[dbUrl absoluteString] UTF8String], &db) != SQLITE_OK) {
-          if (error != nil) {
-            *error = [self _errorFromSqlite:_db];
-          }
-          return NO;
-        }
-        shouldInitializeDatabase = YES;
-      } else {
-        NSString *description = [NSString stringWithFormat:@"Could not move existing corrupt database: %@", [err localizedDescription]];
-        if (error != nil) {
-          *error = [NSError errorWithDomain:EXUpdatesDatabaseErrorDomain
-                                       code:1004
-                                   userInfo:@{ NSLocalizedDescriptionKey: description, NSUnderlyingErrorKey: err }];
-        }
-        return NO;
-      }
-    } else {
-      if (error != nil) {
-        *error = [self _errorFromSqlite:_db];
-      }
-      return NO;
-    }
+  if (![EXUpdatesDatabaseInitialization initializeDatabaseWithLatestSchemaInDirectory:directory database:&db error:error]) {
+    return NO;
   }
+  NSAssert(db, @"Database appears to have initialized successfully, but there is no handle");
   _db = db;
-
-  if (shouldInitializeDatabase) {
-    return [self _initializeDatabase:error];
-  }
   return YES;
 }
 
@@ -87,67 +50,6 @@ static NSString * const EXUpdatesDatabaseServerDefinedHeadersKey = @"serverDefin
 - (void)dealloc
 {
   [self closeDatabase];
-}
-
-- (BOOL)_initializeDatabase:(NSError **)error
-{
-  NSAssert(_db, @"Missing database handle");
-  dispatch_assert_queue(_databaseQueue);
-
-  NSString * const createTableStmts = @"\
-   PRAGMA foreign_keys = ON;\
-   CREATE TABLE \"updates\" (\
-   \"id\"  BLOB UNIQUE,\
-   \"scope_key\"  TEXT NOT NULL,\
-   \"commit_time\"  INTEGER NOT NULL,\
-   \"runtime_version\"  TEXT NOT NULL,\
-   \"launch_asset_id\" INTEGER,\
-   \"metadata\"  TEXT,\
-   \"status\"  INTEGER NOT NULL,\
-   \"keep\"  INTEGER NOT NULL,\
-   PRIMARY KEY(\"id\"),\
-   FOREIGN KEY(\"launch_asset_id\") REFERENCES \"assets\"(\"id\") ON DELETE CASCADE\
-   );\
-   CREATE TABLE \"assets\" (\
-   \"id\"  INTEGER PRIMARY KEY AUTOINCREMENT,\
-   \"url\"  TEXT,\
-   \"key\"  TEXT NOT NULL UNIQUE,\
-   \"headers\"  TEXT,\
-   \"type\"  TEXT NOT NULL,\
-   \"metadata\"  TEXT,\
-   \"download_time\"  INTEGER NOT NULL,\
-   \"relative_path\"  TEXT NOT NULL,\
-   \"hash\"  BLOB NOT NULL,\
-   \"hash_type\"  INTEGER NOT NULL,\
-   \"marked_for_deletion\"  INTEGER NOT NULL\
-   );\
-   CREATE TABLE \"updates_assets\" (\
-   \"update_id\"  BLOB NOT NULL,\
-   \"asset_id\" INTEGER NOT NULL,\
-   FOREIGN KEY(\"update_id\") REFERENCES \"updates\"(\"id\") ON DELETE CASCADE,\
-   FOREIGN KEY(\"asset_id\") REFERENCES \"assets\"(\"id\") ON DELETE CASCADE\
-   );\
-   CREATE TABLE \"json_data\" (\
-   \"id\" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,\
-   \"key\" TEXT NOT NULL,\
-   \"value\" TEXT NOT NULL,\
-   \"last_updated\" INTEGER NOT NULL,\
-   \"scope_key\" TEXT NOT NULL\
-   );\
-   CREATE UNIQUE INDEX \"index_updates_scope_key_commit_time\" ON \"updates\" (\"scope_key\", \"commit_time\");\
-   CREATE INDEX \"index_updates_launch_asset_id\" ON \"updates\" (\"launch_asset_id\");\
-   CREATE INDEX \"index_json_data_scope_key\" ON \"json_data\" (\"scope_key\")\
-   ";
-
-  char *errMsg;
-  if (sqlite3_exec(_db, [createTableStmts UTF8String], NULL, NULL, &errMsg) != SQLITE_OK) {
-    if (error != nil) {
-      *error = [self _errorFromSqlite:_db];
-    }
-    sqlite3_free(errMsg);
-    return NO;
-  };
-  return YES;
 }
 
 # pragma mark - insert and update
@@ -549,138 +451,12 @@ static NSString * const EXUpdatesDatabaseServerDefinedHeadersKey = @"serverDefin
 {
   NSAssert(_db, @"Missing database handle");
   dispatch_assert_queue(_databaseQueue);
-  sqlite3_stmt *stmt;
-  if (sqlite3_prepare_v2(_db, [sql UTF8String], -1, &stmt, NULL) != SQLITE_OK) {
-    if (error != nil) {
-      *error = [self _errorFromSqlite:_db];
-    }
-    return nil;
-  }
-  if (args) {
-    if (![self _bindStatement:stmt withArgs:args]) {
-      if (error != nil) {
-        *error = [self _errorFromSqlite:_db];
-      }
-      return nil;
-    }
-  }
-
-  NSMutableArray *rows = [NSMutableArray arrayWithCapacity:0];
-  NSMutableArray *columnNames = [NSMutableArray arrayWithCapacity:0];
-
-  int columnCount = 0;
-  BOOL didFetchColumns = NO;
-  int result;
-  BOOL hasMore = YES;
-  BOOL didError = NO;
-  while (hasMore) {
-    result = sqlite3_step(stmt);
-    switch (result) {
-      case SQLITE_ROW: {
-        if (!didFetchColumns) {
-          // get all column names once at the beginning
-          columnCount = sqlite3_column_count(stmt);
-
-          for (int i = 0; i < columnCount; i++) {
-            [columnNames addObject:[NSString stringWithUTF8String:sqlite3_column_name(stmt, i)]];
-          }
-          didFetchColumns = YES;
-        }
-        NSMutableDictionary *entry = [NSMutableDictionary dictionary];
-        for (int i = 0; i < columnCount; i++) {
-          id columnValue = [self _getValueWithStatement:stmt column:i];
-          entry[columnNames[i]] = columnValue;
-        }
-        [rows addObject:entry];
-        break;
-      }
-      case SQLITE_DONE:
-        hasMore = NO;
-        break;
-      default:
-        didError = YES;
-        hasMore = NO;
-        break;
-    }
-  }
-
-  if (didError && error != nil) {
-    *error = [self _errorFromSqlite:_db];
-  }
-
-  sqlite3_finalize(stmt);
-
-  return didError ? nil : rows;
-}
-
-- (id)_getValueWithStatement:(sqlite3_stmt *)stmt column:(int)column
-{
-  int columnType = sqlite3_column_type(stmt, column);
-  switch (columnType) {
-    case SQLITE_INTEGER:
-      return @(sqlite3_column_int64(stmt, column));
-    case SQLITE_FLOAT:
-      return @(sqlite3_column_double(stmt, column));
-    case SQLITE_BLOB:
-      NSAssert(sqlite3_column_bytes(stmt, column) == 16, @"SQLite BLOB value should be a valid UUID");
-      return [[NSUUID alloc] initWithUUIDBytes:sqlite3_column_blob(stmt, column)];
-    case SQLITE_TEXT:
-      return [[NSString alloc] initWithBytes:(char *)sqlite3_column_text(stmt, column)
-                                      length:sqlite3_column_bytes(stmt, column)
-                                    encoding:NSUTF8StringEncoding];
-  }
-  return [NSNull null];
-}
-
-- (BOOL)_bindStatement:(sqlite3_stmt *)stmt withArgs:(NSArray *)args
-{
-  __block BOOL success = YES;
-  [args enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
-    if ([obj isKindOfClass:[NSUUID class]]) {
-      uuid_t bytes;
-      [((NSUUID *)obj) getUUIDBytes:bytes];
-      if (sqlite3_bind_blob(stmt, (int)idx + 1, bytes, 16, SQLITE_TRANSIENT) != SQLITE_OK) {
-        success = NO;
-        *stop = YES;
-      }
-    } else if ([obj isKindOfClass:[NSNumber class]]) {
-      if (sqlite3_bind_int64(stmt, (int)idx + 1, [((NSNumber *)obj) longLongValue]) != SQLITE_OK) {
-        success = NO;
-        *stop = YES;
-      }
-    } else if ([obj isKindOfClass:[NSDictionary class]]) {
-      NSError *error;
-      NSData *jsonData = [NSJSONSerialization dataWithJSONObject:(NSDictionary *)obj options:kNilOptions error:&error];
-      if (!error && sqlite3_bind_text(stmt, (int)idx + 1, jsonData.bytes, (int)jsonData.length, SQLITE_TRANSIENT) != SQLITE_OK) {
-        success = NO;
-        *stop = YES;
-      }
-    } else if ([obj isKindOfClass:[NSNull class]]) {
-      if (sqlite3_bind_null(stmt, (int)idx + 1) != SQLITE_OK) {
-        success = NO;
-        *stop = YES;
-      }
-    } else {
-      // convert to string
-      NSString *string = [obj isKindOfClass:[NSString class]] ? (NSString *)obj : [obj description];
-      NSData *data = [string dataUsingEncoding:NSUTF8StringEncoding];
-      if (sqlite3_bind_text(stmt, (int)idx + 1, data.bytes, (int)data.length, SQLITE_TRANSIENT) != SQLITE_OK) {
-        success = NO;
-        *stop = YES;
-      }
-    }
-  }];
-  return success;
+  return [EXUpdatesDatabaseUtils executeSql:sql withArgs:args onDatabase:_db error:error];
 }
 
 - (NSError *)_errorFromSqlite:(struct sqlite3 *)db
 {
-  int code = sqlite3_errcode(db);
-  int extendedCode = sqlite3_extended_errcode(db);
-  NSString *message = [NSString stringWithUTF8String:sqlite3_errmsg(db)];
-  return [NSError errorWithDomain:EXUpdatesDatabaseErrorDomain
-                              code:extendedCode
-                          userInfo:@{NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Error code %i: %@ (extended error code %i)", code, message, extendedCode]}];
+  return [EXUpdatesDatabaseUtils errorFromSqlite:db];
 }
 
 - (EXUpdatesUpdate *)_updateWithRow:(NSDictionary *)row config:(EXUpdatesConfig *)config

--- a/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabaseInitialization+Tests.h
+++ b/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabaseInitialization+Tests.h
@@ -1,0 +1,18 @@
+// Copyright 2021-present 650 Industries. All rights reserved.
+
+#import <EXUpdates/EXUpdatesDatabaseInitialization.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface EXUpdatesDatabaseInitialization (Tests)
+
++ (BOOL)initializeDatabaseWithSchema:(NSString *)schema
+                            filename:(NSString *)filename
+                         inDirectory:(NSURL *)directory
+                       shouldMigrate:(BOOL)shouldMigrate
+                            database:(struct sqlite3 **)database
+                               error:(NSError ** _Nullable)error;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabaseInitialization.h
+++ b/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabaseInitialization.h
@@ -1,0 +1,15 @@
+// Copyright 2021-present 650 Industries. All rights reserved.
+
+#import <sqlite3.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface EXUpdatesDatabaseInitialization : NSObject
+
++ (BOOL)initializeDatabaseWithLatestSchemaInDirectory:(NSURL *)directory
+                                             database:(struct sqlite3 **)database
+                                                error:(NSError ** _Nullable)error;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabaseInitialization.m
+++ b/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabaseInitialization.m
@@ -79,8 +79,8 @@ CREATE INDEX \"index_json_data_scope_key\" ON \"json_data\" (\"scope_key\")\
   NSURL *dbUrl = [directory URLByAppendingPathComponent:filename];
   BOOL shouldInitializeDatabaseSchema = ![[NSFileManager defaultManager] fileExistsAtPath:[dbUrl path]];
 
-  BOOL didMigrate = [[self class] _migrateDatabaseInDirectory:directory];
-  if (!didMigrate) {
+  BOOL success = [[self class] _migrateDatabaseInDirectory:directory];
+  if (!success) {
     NSError *removeFailedMigrationError;
     if ([NSFileManager.defaultManager fileExistsAtPath:dbUrl.path] &&
         ![NSFileManager.defaultManager removeItemAtPath:dbUrl.path error:&removeFailedMigrationError]) {
@@ -157,7 +157,7 @@ CREATE INDEX \"index_json_data_scope_key\" ON \"json_data\" (\"scope_key\")\
 {
   NSURL *latestURL = [directory URLByAppendingPathComponent:EXUpdatesDatabaseLatestFilename];
   if ([NSFileManager.defaultManager fileExistsAtPath:latestURL.path]) {
-    return NO;
+    return YES;
   }
 
   // find the newest database version that exists and try to migrate that file (ignore any older ones)

--- a/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabaseInitialization.m
+++ b/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabaseInitialization.m
@@ -1,0 +1,208 @@
+// Copyright 2021-present 650 Industries. All rights reserved.
+
+#import <EXUpdates/EXUpdatesDatabaseInitialization+Tests.h>
+#import <EXUpdates/EXUpdatesDatabaseMigration.h>
+#import <EXUpdates/EXUpdatesDatabaseMigrationRegistry.h>
+#import <EXUpdates/EXUpdatesDatabaseUtils.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+static NSString * const EXUpdatesDatabaseInitializationErrorDomain = @"EXUpdatesDatabaseInitialization";
+static NSString * const EXUpdatesDatabaseLatestFilename = @"expo-v5.db";
+
+static NSString * const EXUpdatesDatabaseInitializationLatestSchema = @"\
+CREATE TABLE \"updates\" (\
+\"id\"  BLOB UNIQUE,\
+\"scope_key\"  TEXT NOT NULL,\
+\"commit_time\"  INTEGER NOT NULL,\
+\"runtime_version\"  TEXT NOT NULL,\
+\"launch_asset_id\" INTEGER,\
+\"metadata\"  TEXT,\
+\"status\"  INTEGER NOT NULL,\
+\"keep\"  INTEGER NOT NULL,\
+PRIMARY KEY(\"id\"),\
+FOREIGN KEY(\"launch_asset_id\") REFERENCES \"assets\"(\"id\") ON DELETE CASCADE\
+);\
+CREATE TABLE \"assets\" (\
+\"id\"  INTEGER PRIMARY KEY AUTOINCREMENT,\
+\"url\"  TEXT,\
+\"key\"  TEXT UNIQUE,\
+\"headers\"  TEXT,\
+\"type\"  TEXT NOT NULL,\
+\"metadata\"  TEXT,\
+\"download_time\"  INTEGER NOT NULL,\
+\"relative_path\"  TEXT NOT NULL,\
+\"hash\"  BLOB NOT NULL,\
+\"hash_type\"  INTEGER NOT NULL,\
+\"marked_for_deletion\"  INTEGER NOT NULL\
+);\
+CREATE TABLE \"updates_assets\" (\
+\"update_id\"  BLOB NOT NULL,\
+\"asset_id\" INTEGER NOT NULL,\
+FOREIGN KEY(\"update_id\") REFERENCES \"updates\"(\"id\") ON DELETE CASCADE,\
+FOREIGN KEY(\"asset_id\") REFERENCES \"assets\"(\"id\") ON DELETE CASCADE\
+);\
+CREATE TABLE \"json_data\" (\
+\"id\" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,\
+\"key\" TEXT NOT NULL,\
+\"value\" TEXT NOT NULL,\
+\"last_updated\" INTEGER NOT NULL,\
+\"scope_key\" TEXT NOT NULL\
+);\
+CREATE UNIQUE INDEX \"index_updates_scope_key_commit_time\" ON \"updates\" (\"scope_key\", \"commit_time\");\
+CREATE INDEX \"index_updates_launch_asset_id\" ON \"updates\" (\"launch_asset_id\");\
+CREATE INDEX \"index_json_data_scope_key\" ON \"json_data\" (\"scope_key\")\
+";
+
+@implementation EXUpdatesDatabaseInitialization
+
++ (BOOL)initializeDatabaseWithLatestSchemaInDirectory:(NSURL *)directory
+                                             database:(struct sqlite3 **)database
+                                                error:(NSError ** _Nullable)error
+{
+  return [[self class] initializeDatabaseWithSchema:EXUpdatesDatabaseInitializationLatestSchema
+                                           filename:EXUpdatesDatabaseLatestFilename
+                                        inDirectory:directory
+                                      shouldMigrate:YES
+                                           database:database
+                                              error:error];
+}
+
++ (BOOL)initializeDatabaseWithSchema:(NSString *)schema
+                            filename:(NSString *)filename
+                         inDirectory:(NSURL *)directory
+                       shouldMigrate:(BOOL)shouldMigrate
+                            database:(struct sqlite3 **)database
+                               error:(NSError ** _Nullable)error
+{
+  sqlite3 *db;
+  NSURL *dbUrl = [directory URLByAppendingPathComponent:filename];
+  BOOL shouldInitializeDatabaseSchema = ![[NSFileManager defaultManager] fileExistsAtPath:[dbUrl path]];
+
+  BOOL didMigrate = [[self class] _migrateDatabaseInDirectory:directory];
+  if (!didMigrate) {
+    NSError *removeFailedMigrationError;
+    if ([NSFileManager.defaultManager fileExistsAtPath:dbUrl.path] &&
+        ![NSFileManager.defaultManager removeItemAtPath:dbUrl.path error:&removeFailedMigrationError]) {
+      if (error != nil) {
+        NSString *description = [NSString stringWithFormat:@"Failed to migrate database, then failed to remove old database file: %@", removeFailedMigrationError.localizedDescription];
+        *error = [NSError errorWithDomain:EXUpdatesDatabaseInitializationErrorDomain
+                                     code:1022
+                                 userInfo:@{ NSLocalizedDescriptionKey: description, NSUnderlyingErrorKey: removeFailedMigrationError }];
+      }
+      return NO;
+    }
+    shouldInitializeDatabaseSchema = YES;
+  } else {
+    shouldInitializeDatabaseSchema = NO;
+  }
+
+  int resultCode = sqlite3_open([[dbUrl path] UTF8String], &db);
+  if (resultCode != SQLITE_OK) {
+    NSLog(@"Error opening SQLite db: %@", [EXUpdatesDatabaseUtils errorFromSqlite:db].localizedDescription);
+    sqlite3_close(db);
+
+    if (resultCode == SQLITE_CORRUPT || resultCode == SQLITE_NOTADB) {
+      NSString *archivedDbFilename = [NSString stringWithFormat:@"%f-%@", [[NSDate date] timeIntervalSince1970], filename];
+      NSURL *destinationUrl = [directory URLByAppendingPathComponent:archivedDbFilename];
+      NSError *err;
+      if ([[NSFileManager defaultManager] moveItemAtURL:dbUrl toURL:destinationUrl error:&err]) {
+        NSLog(@"Moved corrupt SQLite db to %@", archivedDbFilename);
+        if (sqlite3_open([[dbUrl absoluteString] UTF8String], &db) != SQLITE_OK) {
+          if (error != nil) {
+            *error = [EXUpdatesDatabaseUtils errorFromSqlite:db];
+          }
+          return NO;
+        }
+        shouldInitializeDatabaseSchema = YES;
+      } else {
+        NSString *description = [NSString stringWithFormat:@"Could not move existing corrupt database: %@", [err localizedDescription]];
+        if (error != nil) {
+          *error = [NSError errorWithDomain:EXUpdatesDatabaseInitializationErrorDomain
+                                       code:1004
+                                   userInfo:@{ NSLocalizedDescriptionKey: description, NSUnderlyingErrorKey: err }];
+        }
+        return NO;
+      }
+    } else {
+      if (error != nil) {
+        *error = [EXUpdatesDatabaseUtils errorFromSqlite:db];
+      }
+      return NO;
+    }
+  }
+
+  // foreign keys must be turned on explicitly for each database connection
+  NSError *pragmaForeignKeysError;
+  if (![EXUpdatesDatabaseUtils executeSql:@"PRAGMA foreign_keys=ON;" withArgs:nil onDatabase:db error:&pragmaForeignKeysError]) {
+    NSLog(@"Error turning on foreign key constraint: %@", pragmaForeignKeysError.localizedDescription);
+  }
+
+  if (shouldInitializeDatabaseSchema) {
+    char *errMsg;
+    if (sqlite3_exec(db, schema.UTF8String, NULL, NULL, &errMsg) != SQLITE_OK) {
+      if (error != nil) {
+        *error = [EXUpdatesDatabaseUtils errorFromSqlite:db];
+      }
+      sqlite3_free(errMsg);
+      return NO;
+    };
+  }
+
+  *database = db;
+  return YES;
+}
+
++ (BOOL)_migrateDatabaseInDirectory:(NSURL *)directory
+{
+  NSURL *latestURL = [directory URLByAppendingPathComponent:EXUpdatesDatabaseLatestFilename];
+  if ([NSFileManager.defaultManager fileExistsAtPath:latestURL.path]) {
+    return NO;
+  }
+
+  // find the newest database version that exists and try to migrate that file (ignore any older ones)
+  NSArray<id<EXUpdatesDatabaseMigration>> *migrations = [EXUpdatesDatabaseMigrationRegistry migrations];
+  __block NSURL *existingURL;
+  __block NSUInteger startingMigrationIndex;
+  [migrations enumerateObjectsWithOptions:NSEnumerationReverse usingBlock:^(id<EXUpdatesDatabaseMigration> migration, NSUInteger idx, BOOL *stop) {
+    NSURL *possibleURL = [directory URLByAppendingPathComponent:migration.filename];
+    if ([NSFileManager.defaultManager fileExistsAtPath:possibleURL.path]) {
+      existingURL = possibleURL;
+      startingMigrationIndex = idx;
+      *stop = YES;
+    }
+  }];
+
+  if (existingURL) {
+    NSError *fileMoveError;
+    if (![NSFileManager.defaultManager moveItemAtPath:existingURL.path toPath:latestURL.path error:&fileMoveError]) {
+      NSLog(@"Migration failed: failed to rename database file");
+      return NO;
+    }
+    sqlite3 *db;
+    if (sqlite3_open(latestURL.absoluteString.UTF8String, &db) != SQLITE_OK) {
+      NSLog(@"Error opening migrated SQLite db: %@", [EXUpdatesDatabaseUtils errorFromSqlite:db].localizedDescription);
+      sqlite3_close(db);
+      return NO;
+    }
+
+    for (int i = startingMigrationIndex; i < migrations.count; i++) {
+      NSError *migrationError;
+      id<EXUpdatesDatabaseMigration> migration = migrations[i];
+      if (![migration runMigrationOnDatabase:db error:&migrationError]) {
+        NSLog(@"Error migrating SQLite db: %@", [EXUpdatesDatabaseUtils errorFromSqlite:db].localizedDescription);
+        sqlite3_close(db);
+        return NO;
+      }
+    }
+
+    // migration was successful
+    sqlite3_close(db);
+    return YES;
+  }
+  return NO;
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabaseUtils.h
+++ b/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabaseUtils.h
@@ -1,0 +1,18 @@
+// Copyright 2021-present 650 Industries. All rights reserved.
+
+#import <sqlite3.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface EXUpdatesDatabaseUtils : NSObject
+
++ (nullable NSArray<NSDictionary *> *)executeSql:(NSString *)sql
+                                        withArgs:(nullable NSArray *)args
+                                      onDatabase:(struct sqlite3 *)db
+                                           error:(NSError ** _Nullable)error;
+
++ (NSError *)errorFromSqlite:(struct sqlite3 *)db;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabaseUtils.m
+++ b/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabaseUtils.m
@@ -1,0 +1,152 @@
+// Copyright 2021-present 650 Industries. All rights reserved.
+
+#import <EXUpdates/EXUpdatesDatabaseUtils.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+static NSString * const EXUpdatesDatabaseUtilsErrorDomain = @"EXUpdatesDatabase";
+
+@implementation EXUpdatesDatabaseUtils
+
++ (nullable NSArray<NSDictionary *> *)executeSql:(NSString *)sql
+                                        withArgs:(nullable NSArray *)args
+                                      onDatabase:(struct sqlite3 *)db
+                                           error:(NSError ** _Nullable)error
+{
+  sqlite3_stmt *stmt;
+  if (sqlite3_prepare_v2(db, [sql UTF8String], -1, &stmt, NULL) != SQLITE_OK) {
+    if (error != nil) {
+      *error = [[self class] errorFromSqlite:db];
+    }
+    return nil;
+  }
+  if (args) {
+    if (![[self class] _bindStatement:stmt withArgs:args]) {
+      if (error != nil) {
+        *error = [[self class] errorFromSqlite:db];
+      }
+      return nil;
+    }
+  }
+
+  NSMutableArray *rows = [NSMutableArray arrayWithCapacity:0];
+  NSMutableArray *columnNames = [NSMutableArray arrayWithCapacity:0];
+
+  int columnCount = 0;
+  BOOL didFetchColumns = NO;
+  int result;
+  BOOL hasMore = YES;
+  BOOL didError = NO;
+  while (hasMore) {
+    result = sqlite3_step(stmt);
+    switch (result) {
+      case SQLITE_ROW: {
+        if (!didFetchColumns) {
+          // get all column names once at the beginning
+          columnCount = sqlite3_column_count(stmt);
+
+          for (int i = 0; i < columnCount; i++) {
+            [columnNames addObject:[NSString stringWithUTF8String:sqlite3_column_name(stmt, i)]];
+          }
+          didFetchColumns = YES;
+        }
+        NSMutableDictionary *entry = [NSMutableDictionary dictionary];
+        for (int i = 0; i < columnCount; i++) {
+          id columnValue = [[self class] _getValueWithStatement:stmt column:i];
+          entry[columnNames[i]] = columnValue;
+        }
+        [rows addObject:entry];
+        break;
+      }
+      case SQLITE_DONE:
+        hasMore = NO;
+        break;
+      default:
+        didError = YES;
+        hasMore = NO;
+        break;
+    }
+  }
+
+  if (didError && error != nil) {
+    *error = [[self class] errorFromSqlite:db];
+  }
+
+  sqlite3_finalize(stmt);
+
+  return didError ? nil : rows;
+}
+
++ (id)_getValueWithStatement:(sqlite3_stmt *)stmt column:(int)column
+{
+  int columnType = sqlite3_column_type(stmt, column);
+  switch (columnType) {
+    case SQLITE_INTEGER:
+      return @(sqlite3_column_int64(stmt, column));
+    case SQLITE_FLOAT:
+      return @(sqlite3_column_double(stmt, column));
+    case SQLITE_BLOB:
+      NSAssert(sqlite3_column_bytes(stmt, column) == 16, @"SQLite BLOB value should be a valid UUID");
+      return [[NSUUID alloc] initWithUUIDBytes:sqlite3_column_blob(stmt, column)];
+    case SQLITE_TEXT:
+      return [[NSString alloc] initWithBytes:(char *)sqlite3_column_text(stmt, column)
+                                      length:sqlite3_column_bytes(stmt, column)
+                                    encoding:NSUTF8StringEncoding];
+  }
+  return [NSNull null];
+}
+
++ (BOOL)_bindStatement:(sqlite3_stmt *)stmt withArgs:(NSArray *)args
+{
+  __block BOOL success = YES;
+  [args enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
+    if ([obj isKindOfClass:[NSUUID class]]) {
+      uuid_t bytes;
+      [((NSUUID *)obj) getUUIDBytes:bytes];
+      if (sqlite3_bind_blob(stmt, (int)idx + 1, bytes, 16, SQLITE_TRANSIENT) != SQLITE_OK) {
+        success = NO;
+        *stop = YES;
+      }
+    } else if ([obj isKindOfClass:[NSNumber class]]) {
+      if (sqlite3_bind_int64(stmt, (int)idx + 1, [((NSNumber *)obj) longLongValue]) != SQLITE_OK) {
+        success = NO;
+        *stop = YES;
+      }
+    } else if ([obj isKindOfClass:[NSDictionary class]]) {
+      NSError *error;
+      NSData *jsonData = [NSJSONSerialization dataWithJSONObject:(NSDictionary *)obj options:kNilOptions error:&error];
+      if (!error && sqlite3_bind_text(stmt, (int)idx + 1, jsonData.bytes, (int)jsonData.length, SQLITE_TRANSIENT) != SQLITE_OK) {
+        success = NO;
+        *stop = YES;
+      }
+    } else if ([obj isKindOfClass:[NSNull class]]) {
+      if (sqlite3_bind_null(stmt, (int)idx + 1) != SQLITE_OK) {
+        success = NO;
+        *stop = YES;
+      }
+    } else {
+      // convert to string
+      NSString *string = [obj isKindOfClass:[NSString class]] ? (NSString *)obj : [obj description];
+      NSData *data = [string dataUsingEncoding:NSUTF8StringEncoding];
+      if (sqlite3_bind_text(stmt, (int)idx + 1, data.bytes, (int)data.length, SQLITE_TRANSIENT) != SQLITE_OK) {
+        success = NO;
+        *stop = YES;
+      }
+    }
+  }];
+  return success;
+}
+
++ (NSError *)errorFromSqlite:(struct sqlite3 *)db
+{
+  int code = sqlite3_errcode(db);
+  int extendedCode = sqlite3_extended_errcode(db);
+  NSString *message = [NSString stringWithUTF8String:sqlite3_errmsg(db)];
+  return [NSError errorWithDomain:EXUpdatesDatabaseUtilsErrorDomain
+                             code:extendedCode
+                         userInfo:@{NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Error code %i: %@ (extended error code %i)", code, message, extendedCode]}];
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/ios/EXUpdates/Database/Migrations/EXUpdatesDatabaseMigration.h
+++ b/packages/expo-updates/ios/EXUpdates/Database/Migrations/EXUpdatesDatabaseMigration.h
@@ -1,0 +1,15 @@
+//  Copyright © 2021 650 Industries. All rights reserved.
+
+#import <sqlite3.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol EXUpdatesDatabaseMigration
+
+@property (nonatomic, strong, readonly) NSString *filename;
+
+- (BOOL)runMigrationOnDatabase:(struct sqlite3 *)db error:(NSError ** _Nullable)error;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/ios/EXUpdates/Database/Migrations/EXUpdatesDatabaseMigration4To5.h
+++ b/packages/expo-updates/ios/EXUpdates/Database/Migrations/EXUpdatesDatabaseMigration4To5.h
@@ -1,0 +1,11 @@
+//  Copyright © 2021 650 Industries. All rights reserved.
+
+#import <EXUpdates/EXUpdatesDatabaseMigration.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface EXUpdatesDatabaseMigration4To5 : NSObject <EXUpdatesDatabaseMigration>
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/ios/EXUpdates/Database/Migrations/EXUpdatesDatabaseMigration4To5.m
+++ b/packages/expo-updates/ios/EXUpdates/Database/Migrations/EXUpdatesDatabaseMigration4To5.m
@@ -1,0 +1,56 @@
+//  Copyright © 2021 650 Industries. All rights reserved.
+
+#import <EXUpdates/EXUpdatesDatabaseMigration4To5.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+static NSString * const EXUpdatesDatabaseV4Filename = @"expo-v4.db";
+
+@implementation EXUpdatesDatabaseMigration4To5
+
+- (NSString *)filename
+{
+  return EXUpdatesDatabaseV4Filename;
+}
+
+- (BOOL)runMigrationOnDatabase:(struct sqlite3 *)db error:(NSError ** _Nullable)error
+{
+  // https://www.sqlite.org/lang_altertable.html#otheralter
+  if (sqlite3_exec(db, "PRAGMA foreign_keys=OFF;", NULL, NULL, NULL) != SQLITE_OK) return NO;
+  if (sqlite3_exec(db, "BEGIN;", NULL, NULL, NULL) != SQLITE_OK) return NO;
+
+  if (![self _safeExecOrRollback:db sql:@"CREATE TABLE \"new_assets\" (\
+        \"id\"  INTEGER PRIMARY KEY AUTOINCREMENT,\
+        \"url\"  TEXT,\
+        \"key\"  TEXT UNIQUE,\
+        \"headers\"  TEXT,\
+        \"type\"  TEXT NOT NULL,\
+        \"metadata\"  TEXT,\
+        \"download_time\"  INTEGER NOT NULL,\
+        \"relative_path\"  TEXT NOT NULL,\
+        \"hash\"  BLOB NOT NULL,\
+        \"hash_type\"  INTEGER NOT NULL,\
+        \"marked_for_deletion\"  INTEGER NOT NULL\
+        )"]) return NO;
+  if (![self _safeExecOrRollback:db sql:@"INSERT INTO `new_assets` (`id`, `url`, `key`, `headers`, `type`, `metadata`, `download_time`, `relative_path`, `hash`, `hash_type`, `marked_for_deletion`)\
+        SELECT `id`, `url`, `key`, `headers`, `type`, `metadata`, `download_time`, `relative_path`, `hash`, `hash_type`, `marked_for_deletion` FROM `assets`"]) return NO;
+  if (![self _safeExecOrRollback:db sql:@"DROP TABLE `assets`"]) return NO;
+  if (![self _safeExecOrRollback:db sql:@"ALTER TABLE `new_assets` RENAME TO `assets`"]) return NO;
+
+  if (sqlite3_exec(db, "COMMIT;", NULL, NULL, NULL) != SQLITE_OK) return NO;
+  if (sqlite3_exec(db, "PRAGMA foreign_keys=ON;", NULL, NULL, NULL) != SQLITE_OK) return NO;
+  return YES;
+}
+
+- (BOOL)_safeExecOrRollback:(struct sqlite3 *)db sql:(NSString *)sql
+{
+  if (sqlite3_exec(db, sql.UTF8String, NULL, NULL, NULL) != SQLITE_OK) {
+    sqlite3_exec(db, "ROLLBACK;", NULL, NULL, NULL);
+    return NO;
+  }
+  return YES;
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/ios/EXUpdates/Database/Migrations/EXUpdatesDatabaseMigrationRegistry.h
+++ b/packages/expo-updates/ios/EXUpdates/Database/Migrations/EXUpdatesDatabaseMigrationRegistry.h
@@ -1,0 +1,14 @@
+//  Copyright © 2021 650 Industries. All rights reserved.
+
+#import <EXUpdates/EXUpdatesDatabaseMigration.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface EXUpdatesDatabaseMigrationRegistry : NSObject
+
++ (NSArray<id<EXUpdatesDatabaseMigration>> *)migrations;
+
+@end
+
+NS_ASSUME_NONNULL_END
+

--- a/packages/expo-updates/ios/EXUpdates/Database/Migrations/EXUpdatesDatabaseMigrationRegistry.m
+++ b/packages/expo-updates/ios/EXUpdates/Database/Migrations/EXUpdatesDatabaseMigrationRegistry.m
@@ -1,0 +1,20 @@
+//  Copyright © 2021 650 Industries. All rights reserved.
+
+#import <EXUpdates/EXUpdatesDatabaseMigrationRegistry.h>
+
+#import <EXUpdates/EXUpdatesDatabaseMigration4To5.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@implementation EXUpdatesDatabaseMigrationRegistry
+
++ (NSArray<id<EXUpdatesDatabaseMigration>> *)migrations
+{
+  // migrations should be added here in the order they should be performed (e.g. oldest first)
+  return @[[EXUpdatesDatabaseMigration4To5 new]];
+}
+
+@end
+
+NS_ASSUME_NONNULL_END
+

--- a/packages/expo-updates/ios/Tests/EXUpdatesDatabaseInitializationTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesDatabaseInitializationTests.m
@@ -1,0 +1,169 @@
+//  Copyright (c) 2021 650 Industries, Inc. All rights reserved.
+
+#import <XCTest/XCTest.h>
+
+#import <EXUpdates/EXUpdatesDatabaseInitialization+Tests.h>
+#import <EXUpdates/EXUpdatesDatabaseUtils.h>
+
+#import <sqlite3.h>
+
+static NSString * const EXUpdatesDatabaseV4Schema = @"\
+CREATE TABLE \"updates\" (\
+\"id\"  BLOB UNIQUE,\
+\"scope_key\"  TEXT NOT NULL,\
+\"commit_time\"  INTEGER NOT NULL,\
+\"runtime_version\"  TEXT NOT NULL,\
+\"launch_asset_id\" INTEGER,\
+\"metadata\"  TEXT,\
+\"status\"  INTEGER NOT NULL,\
+\"keep\"  INTEGER NOT NULL,\
+PRIMARY KEY(\"id\"),\
+FOREIGN KEY(\"launch_asset_id\") REFERENCES \"assets\"(\"id\") ON DELETE CASCADE\
+);\
+CREATE TABLE \"assets\" (\
+\"id\"  INTEGER PRIMARY KEY AUTOINCREMENT,\
+\"url\"  TEXT,\
+\"key\"  TEXT NOT NULL UNIQUE,\
+\"headers\"  TEXT,\
+\"type\"  TEXT NOT NULL,\
+\"metadata\"  TEXT,\
+\"download_time\"  INTEGER NOT NULL,\
+\"relative_path\"  TEXT NOT NULL,\
+\"hash\"  BLOB NOT NULL,\
+\"hash_type\"  INTEGER NOT NULL,\
+\"marked_for_deletion\"  INTEGER NOT NULL\
+);\
+CREATE TABLE \"updates_assets\" (\
+\"update_id\"  BLOB NOT NULL,\
+\"asset_id\" INTEGER NOT NULL,\
+FOREIGN KEY(\"update_id\") REFERENCES \"updates\"(\"id\") ON DELETE CASCADE,\
+FOREIGN KEY(\"asset_id\") REFERENCES \"assets\"(\"id\") ON DELETE CASCADE\
+);\
+CREATE TABLE \"json_data\" (\
+\"id\" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,\
+\"key\" TEXT NOT NULL,\
+\"value\" TEXT NOT NULL,\
+\"last_updated\" INTEGER NOT NULL,\
+\"scope_key\" TEXT NOT NULL\
+);\
+CREATE UNIQUE INDEX \"index_updates_scope_key_commit_time\" ON \"updates\" (\"scope_key\", \"commit_time\");\
+CREATE INDEX \"index_updates_launch_asset_id\" ON \"updates\" (\"launch_asset_id\");\
+CREATE INDEX \"index_json_data_scope_key\" ON \"json_data\" (\"scope_key\")\
+";
+
+@interface EXUpdatesDatabaseInitializationTests : XCTestCase
+
+@property (nonatomic, strong) NSURL *testDatabaseDir;
+
+@end
+
+@implementation EXUpdatesDatabaseInitializationTests
+
+- (void)setUp
+{
+  NSURL *applicationSupportDir = [NSFileManager.defaultManager URLsForDirectory:NSApplicationSupportDirectory inDomains:NSUserDomainMask].lastObject;
+  _testDatabaseDir = [applicationSupportDir URLByAppendingPathComponent:@"EXUpdatesDatabaseTests"];
+  if (![NSFileManager.defaultManager fileExistsAtPath:_testDatabaseDir.path]) {
+    NSError *error;
+    [NSFileManager.defaultManager createDirectoryAtPath:_testDatabaseDir.path withIntermediateDirectories:YES attributes:nil error:&error];
+    XCTAssertNil(error);
+  }
+}
+
+- (void)tearDown
+{
+  NSError *error;
+  [NSFileManager.defaultManager removeItemAtPath:_testDatabaseDir.path error:&error];
+  XCTAssertNil(error);
+}
+
+- (void)testMigration4To5
+{
+  sqlite3 *db;
+  NSError *initializeError;
+  [EXUpdatesDatabaseInitialization initializeDatabaseWithSchema:EXUpdatesDatabaseV4Schema
+                                                       filename:@"expo-v4.db"
+                                                    inDirectory:_testDatabaseDir
+                                                  shouldMigrate:NO
+                                                       database:&db
+                                                          error:&initializeError];
+  XCTAssertNil(initializeError);
+
+  // insert test data
+  NSString * const insertAssetsSql = @"INSERT INTO \"assets\" (\"id\",\"url\",\"key\",\"headers\",\"type\",\"metadata\",\"download_time\",\"relative_path\",\"hash\",\"hash_type\",\"marked_for_deletion\") VALUES\
+    (2,'https://url.to/b56cf690e0afa93bd4dc7756d01edd3e','b56cf690e0afa93bd4dc7756d01edd3e.png',NULL,'image/png',NULL,1614137309295,'b56cf690e0afa93bd4dc7756d01edd3e.png','c4fdfc2ec388025067a0f755bda7731a0a868a2be79c84509f4de4e40d23161b',0,0),\
+    (3,'https://url.to/bundle-1614137308871','bundle-1614137308871',NULL,'application/javascript',NULL,1614137309513,'bundle-1614137308871','e4d658861e85e301fb89bcfc49c42738ebcc0f9d5c979e037556435f44a27aa2',0,0),\
+    (4,NULL,'bundle-1614137401950',NULL,'js',NULL,1614137406588,'bundle-1614137401950','6ff4ee75b48a21c7a9ed98015ff6bfd0a47b94cd087c5e2258262e65af239952',0,0);";
+  NSString * const insertUpdatesSql = @"INSERT INTO \"updates\" (\"id\",\"scope_key\",\"commit_time\",\"runtime_version\",\"launch_asset_id\",\"metadata\",\"status\",\"keep\") VALUES\
+  (X'8C263F9DE3FF48888496E3244C788661','http://192.168.4.44:3000',1614137308871,'40.0.0',3,'{\"updateMetadata\":{\"updateGroup\":\"34993d39-57e6-46cf-8fa2-eba836f40828\",\"updateGroupCreatedAt\":\"2021-02-23T12:53:46.851Z\",\"branchName\":\"rollout\"}}',1,1),\
+  (X'594100ea066e4804b5c7c907c773f980','http://192.168.4.44:3000',1614137401950,'40.0.0',4,NULL,1,1);";
+  NSString * const insertUpdatesAssetsSql = @"INSERT INTO \"updates_assets\" (\"update_id\",\"asset_id\") VALUES\
+    (X'8C263F9DE3FF48888496E3244C788661',2),\
+    (X'8C263F9DE3FF48888496E3244C788661',3),\
+    (X'594100ea066e4804b5c7c907c773f980',4);";
+  NSError *insertAssetsError;
+  [EXUpdatesDatabaseUtils executeSql:insertAssetsSql withArgs:nil onDatabase:db error:&insertAssetsError];
+  NSError *insertUpdatesError;
+  [EXUpdatesDatabaseUtils executeSql:insertUpdatesSql withArgs:nil onDatabase:db error:&insertUpdatesError];
+  NSError *insertUpdatesAssetsError;
+  [EXUpdatesDatabaseUtils executeSql:insertUpdatesAssetsSql withArgs:nil onDatabase:db error:&insertUpdatesAssetsError];
+  XCTAssert(!insertAssetsError && !insertUpdatesError && !insertUpdatesAssetsError);
+
+  sqlite3_close(db);
+
+  // initialize a new database object the normal way and run migrations
+  sqlite3 *migratedDb;
+  NSError *migrateError;
+  [EXUpdatesDatabaseInitialization initializeDatabaseWithLatestSchemaInDirectory:_testDatabaseDir
+                                                                        database:&migratedDb
+                                                                           error:&migrateError];
+  XCTAssertNil(migrateError);
+
+  // verify data integrity
+  NSString * const updatesSql1 = @"SELECT * FROM `updates` WHERE `id` = X'8C263F9DE3FF48888496E3244C788661'";
+  XCTAssertEqual(1, [EXUpdatesDatabaseUtils executeSql:updatesSql1 withArgs:nil onDatabase:migratedDb error:nil].count);
+  NSString * const updatesSql2 = @"SELECT * FROM `updates` WHERE `id` = X'594100ea066e4804b5c7c907c773f980'";
+  XCTAssertEqual(1, [EXUpdatesDatabaseUtils executeSql:updatesSql2 withArgs:nil onDatabase:migratedDb error:nil].count);
+
+  NSString * const assetsSql1 = @"SELECT * FROM `assets` WHERE `id` = 2 AND `url` = 'https://url.to/b56cf690e0afa93bd4dc7756d01edd3e' AND `key` = 'b56cf690e0afa93bd4dc7756d01edd3e.png' AND `headers` IS NULL AND `type` = 'image/png' AND `metadata` IS NULL AND `download_time` = 1614137309295 AND `relative_path` = 'b56cf690e0afa93bd4dc7756d01edd3e.png' AND `hash` = 'c4fdfc2ec388025067a0f755bda7731a0a868a2be79c84509f4de4e40d23161b' AND `hash_type` = 0 AND `marked_for_deletion` = 0";
+  XCTAssertEqual(1, [EXUpdatesDatabaseUtils executeSql:assetsSql1 withArgs:nil onDatabase:migratedDb error:nil].count);
+  NSString * const assetsSql2 = @"SELECT * FROM `assets` WHERE `id` = 3 AND `url` = 'https://url.to/bundle-1614137308871' AND `key` = 'bundle-1614137308871' AND `headers` IS NULL AND `type` = 'application/javascript' AND `metadata` IS NULL AND `download_time` = 1614137309513 AND `relative_path` = 'bundle-1614137308871' AND `hash` = 'e4d658861e85e301fb89bcfc49c42738ebcc0f9d5c979e037556435f44a27aa2' AND `hash_type` = 0 AND `marked_for_deletion` = 0";
+  XCTAssertEqual(1, [EXUpdatesDatabaseUtils executeSql:assetsSql2 withArgs:nil onDatabase:migratedDb error:nil].count);
+  NSString * const assetsSql3 = @"SELECT * FROM `assets` WHERE `id` = 4 AND `url` IS NULL AND `key` = 'bundle-1614137401950' AND `headers` IS NULL AND `type` = 'js' AND `metadata` IS NULL AND `download_time` = 1614137406588 AND `relative_path` = 'bundle-1614137401950' AND `hash` = '6ff4ee75b48a21c7a9ed98015ff6bfd0a47b94cd087c5e2258262e65af239952' AND `hash_type` = 0 AND `marked_for_deletion` = 0";
+  XCTAssertEqual(1, [EXUpdatesDatabaseUtils executeSql:assetsSql3 withArgs:nil onDatabase:migratedDb error:nil].count);
+
+  NSString * const updatesAssetsSql1 = @"SELECT * FROM `updates_assets` WHERE `update_id` = X'8C263F9DE3FF48888496E3244C788661' AND `asset_id` = 2";
+  XCTAssertEqual(1, [EXUpdatesDatabaseUtils executeSql:updatesAssetsSql1 withArgs:nil onDatabase:migratedDb error:nil].count);
+  NSString * const updatesAssetsSql2 = @"SELECT * FROM `updates_assets` WHERE `update_id` = X'8C263F9DE3FF48888496E3244C788661' AND `asset_id` = 3";
+  XCTAssertEqual(1, [EXUpdatesDatabaseUtils executeSql:updatesAssetsSql2 withArgs:nil onDatabase:migratedDb error:nil].count);
+  NSString * const updatesAssetsSql3 = @"SELECT * FROM `updates_assets` WHERE `update_id` = X'594100ea066e4804b5c7c907c773f980' AND `asset_id` = 4";
+  XCTAssertEqual(1, [EXUpdatesDatabaseUtils executeSql:updatesAssetsSql3 withArgs:nil onDatabase:migratedDb error:nil].count);
+
+  // make sure we can insert multiple assets with null keys
+  NSError *nullInsertError;
+  NSString * const nullInsertSql = @"INSERT INTO \"assets\" (\"id\",\"url\",\"key\",\"headers\",\"type\",\"metadata\",\"download_time\",\"relative_path\",\"hash\",\"hash_type\",\"marked_for_deletion\") VALUES\
+    (5,NULL,NULL,NULL,'js',NULL,1614137406589,'bundle-1614137401951','1234',0,0),\
+    (6,NULL,NULL,NULL,'js',NULL,1614137406580,'bundle-1614137401952','5678',0,0)";
+  [EXUpdatesDatabaseUtils executeSql:nullInsertSql withArgs:nil onDatabase:migratedDb error:&nullInsertError];
+  XCTAssertNil(nullInsertError);
+
+  // make sure foreign key constraint still works
+  NSString * const foreignKeyInsertSql = @"INSERT INTO `updates_assets` (`update_id`, `asset_id`) VALUES (X'594100ea066e4804b5c7c907c773f980', 5)";
+  NSString * const foreignKeySelectSql = @"SELECT * FROM `updates_assets` WHERE `update_id` = X'594100ea066e4804b5c7c907c773f980' AND `asset_id` = 5";
+  [EXUpdatesDatabaseUtils executeSql:foreignKeyInsertSql withArgs:nil onDatabase:migratedDb error:nil];
+  XCTAssertEqual(1, [EXUpdatesDatabaseUtils executeSql:foreignKeySelectSql withArgs:nil onDatabase:migratedDb error:nil].count);
+
+  NSString * const foreignKeyInsertBadSql = @"INSERT INTO `updates_assets` (`update_id`, `asset_id`) VALUES (X'594100ea066e4804b5c7c907c773f980', 13)";
+  NSError *foreignKeyError;
+  [EXUpdatesDatabaseUtils executeSql:foreignKeyInsertBadSql withArgs:nil onDatabase:migratedDb error:&foreignKeyError];
+  XCTAssertNotNil(foreignKeyError);
+  XCTAssertEqual(787, foreignKeyError.code); // SQLITE_CONSTRAINT_FOREIGNKEY
+
+  // test on delete cascade
+  NSString * const deleteSql = @"DELETE FROM `assets` WHERE `id` = 5";
+  NSString * const selectDeletedSql = @"SELECT * FROM `updates_assets` WHERE `update_id` = X'594100ea066e4804b5c7c907c773f980' AND `asset_id` = 5";
+  [EXUpdatesDatabaseUtils executeSql:deleteSql withArgs:nil onDatabase:migratedDb error:nil];
+  XCTAssertEqual(0, [EXUpdatesDatabaseUtils executeSql:selectDeletedSql withArgs:nil onDatabase:migratedDb error:nil].count);
+}
+
+@end


### PR DESCRIPTION
# Why

Redo of #12084 with a fix (fced7bc) for a critical bug on iOS I discovered after landing. ([ENG-425](https://linear.app/expo/issue/ENG-425/sqlite-migrations-to-make-assetskey-nullable))

# How

- un-revert #12084
- if no migration is needed, use existing DB instead of deleting and re-creating it (!)

# Test Plan

All existing tests pass, plus verified in manual testing that the bugfix works.