### PR TITLE
[expo-updates] allow & handle nullable asset keys in application code

### DIFF
--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/updates/UpdatesModule.java
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/updates/UpdatesModule.java
@@ -65,7 +65,9 @@ public class UpdatesModule extends ExportedModule {
         if (localAssetFiles != null) {
           Map<String, String> localAssets = new HashMap<>();
           for (AssetEntity asset : localAssetFiles.keySet()) {
-            localAssets.put(asset.key, localAssetFiles.get(asset));
+            if (asset.key != null) {
+              localAssets.put(asset.key, localAssetFiles.get(asset));
+            }
           }
           constants.put("localAssets", localAssets);
         }

--- a/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/expo/modules/updates/UpdatesModule.java
+++ b/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/expo/modules/updates/UpdatesModule.java
@@ -65,7 +65,9 @@ public class UpdatesModule extends ExportedModule {
         if (localAssetFiles != null) {
           Map<String, String> localAssets = new HashMap<>();
           for (AssetEntity asset : localAssetFiles.keySet()) {
-            localAssets.put(asset.key, localAssetFiles.get(asset));
+            if (asset.key != null) {
+              localAssets.put(asset.key, localAssetFiles.get(asset));
+            }
           }
           constants.put("localAssets", localAssets);
         }

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -24,7 +24,7 @@
 - Send persisted serverDefinedHeaders in manifest requests ([#11994](https://github.com/expo/expo/pull/11994) by [@esamelson](https://github.com/esamelson))
 - Only require signatures with expo go (android). ([#12027](https://github.com/expo/expo/pull/12027) by [@jkhales](https://github.com/jkhales))
 - Only require signatures with expo go (iOS). ([#12072](https://github.com/expo/expo/pull/12072) by [@jkhales](https://github.com/jkhales))
-- Make asset keys nullable ([#12084](https://github.com/expo/expo/pull/12084) by [@esamelson](https://github.com/esamelson))
+- Make asset keys nullable ([#12110](https://github.com/expo/expo/pull/12110) and [#12111](https://github.com/expo/expo/pull/12111) by [@esamelson](https://github.com/esamelson))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.java
@@ -68,7 +68,9 @@ public class UpdatesModule extends ExportedModule {
         if (localAssetFiles != null) {
           Map<String, String> localAssets = new HashMap<>();
           for (AssetEntity asset : localAssetFiles.keySet()) {
-            localAssets.put(asset.key, localAssetFiles.get(asset));
+            if (asset.key != null) {
+              localAssets.put(asset.key, localAssetFiles.get(asset));
+            }
           }
           constants.put("localAssets", localAssets);
         }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesUtils.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesUtils.java
@@ -28,6 +28,7 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
+import java.util.Random;
 import java.util.TimeZone;
 
 import androidx.annotation.Nullable;
@@ -98,6 +99,10 @@ public class UpdatesUtils {
   }
 
   public static String createFilenameForAsset(AssetEntity asset) {
+    if (asset.key == null) {
+      // create a filename that's unlikely to collide with any other asset
+      return "asset-" + new Date().getTime() + "-" + new Random().nextInt();
+    }
     return asset.key;
   }
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/dao/AssetDao.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/dao/AssetDao.java
@@ -76,6 +76,9 @@ public abstract class AssetDao {
   }
 
   public @Nullable AssetEntity loadAssetWithKey(String key) {
+    if (key == null) {
+      return null;
+    }
     List<AssetEntity> assets = _loadAssetWithKey(key);
     if (assets.size() > 0) {
       return assets.get(0);

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/DatabaseLauncher.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/DatabaseLauncher.java
@@ -161,7 +161,7 @@ public class DatabaseLauncher implements Launcher {
         ArrayList<AssetEntity> embeddedAssets = embeddedManifest.getAssetEntityList();
         AssetEntity matchingEmbeddedAsset = null;
         for (AssetEntity embeddedAsset : embeddedAssets) {
-          if (embeddedAsset.key.equals(asset.key)) {
+          if (embeddedAsset.key != null && embeddedAsset.key.equals(asset.key)) {
             matchingEmbeddedAsset = embeddedAsset;
             break;
           }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/EmbeddedLoader.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/EmbeddedLoader.java
@@ -99,7 +99,7 @@ public class EmbeddedLoader {
     } else if (asset.resourcesFilename != null && asset.resourcesFolder != null) {
       return copyResourceAndGetHash(asset, destination, context);
     } else {
-      throw new AssertionError("Failed to copy asset " + asset.key + " from APK assets or resources because not enough information was provided.");
+      throw new AssertionError("Failed to copy embedded asset " + asset.key + " from APK assets or resources because not enough information was provided.");
     }
   }
 
@@ -195,6 +195,7 @@ public class EmbeddedLoader {
       if (!existingAssetFound) {
         // the database and filesystem have gotten out of sync
         // do our best to create a new entry for this file even though it already existed on disk
+        // TODO: we should probably get rid of this assumption that if an asset exists on disk with the same filename, it's the same asset
         byte[] hash = null;
         try {
           hash = UpdatesUtils.sha256(new File(mUpdatesDirectory, asset.relativePath));

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/RemoteLoader.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/RemoteLoader.java
@@ -219,6 +219,7 @@ public class RemoteLoader {
           if (!existingAssetFound) {
             // the database and filesystem have gotten out of sync
             // do our best to create a new entry for this file even though it already existed on disk
+            // TODO: we should probably get rid of this assumption that if an asset exists on disk with the same filename, it's the same asset
             byte[] hash = null;
             try {
               hash = UpdatesUtils.sha256(new File(mUpdatesDirectory, asset.relativePath));

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/BareManifest.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/BareManifest.java
@@ -86,7 +86,7 @@ public class BareManifest implements Manifest {
   public ArrayList<AssetEntity> getAssetEntityList() {
     ArrayList<AssetEntity> assetList = new ArrayList<>();
 
-    AssetEntity bundleAssetEntity = new AssetEntity("bundle-" + mCommitTime.getTime(), "js");
+    AssetEntity bundleAssetEntity = new AssetEntity("bundle-" + mId, "js");
     bundleAssetEntity.isLaunchAsset = true;
     bundleAssetEntity.embeddedAssetFilename = EmbeddedLoader.BARE_BUNDLE_FILENAME;
     assetList.add(bundleAssetEntity);

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/BareManifest.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/BareManifest.java
@@ -86,7 +86,7 @@ public class BareManifest implements Manifest {
   public ArrayList<AssetEntity> getAssetEntityList() {
     ArrayList<AssetEntity> assetList = new ArrayList<>();
 
-    AssetEntity bundleAssetEntity = new AssetEntity(null, "js");
+    AssetEntity bundleAssetEntity = new AssetEntity("bundle-" + mCommitTime.getTime(), "js");
     bundleAssetEntity.isLaunchAsset = true;
     bundleAssetEntity.embeddedAssetFilename = EmbeddedLoader.BARE_BUNDLE_FILENAME;
     assetList.add(bundleAssetEntity);

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/BareManifest.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/BareManifest.java
@@ -86,7 +86,7 @@ public class BareManifest implements Manifest {
   public ArrayList<AssetEntity> getAssetEntityList() {
     ArrayList<AssetEntity> assetList = new ArrayList<>();
 
-    AssetEntity bundleAssetEntity = new AssetEntity("bundle-" + mCommitTime.getTime(), "js");
+    AssetEntity bundleAssetEntity = new AssetEntity(null, "js");
     bundleAssetEntity.isLaunchAsset = true;
     bundleAssetEntity.embeddedAssetFilename = EmbeddedLoader.BARE_BUNDLE_FILENAME;
     assetList.add(bundleAssetEntity);

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/BareManifest.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/BareManifest.java
@@ -86,7 +86,9 @@ public class BareManifest implements Manifest {
   public ArrayList<AssetEntity> getAssetEntityList() {
     ArrayList<AssetEntity> assetList = new ArrayList<>();
 
-    AssetEntity bundleAssetEntity = new AssetEntity("bundle-" + mId, "js");
+    // use unsanitized id value from manifest
+    String bundleKey = "bundle-" + mManifestJson.optString("id", mId.toString());
+    AssetEntity bundleAssetEntity = new AssetEntity(bundleKey, "js");
     bundleAssetEntity.isLaunchAsset = true;
     bundleAssetEntity.embeddedAssetFilename = EmbeddedLoader.BARE_BUNDLE_FILENAME;
     assetList.add(bundleAssetEntity);

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/LegacyManifest.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/LegacyManifest.java
@@ -122,14 +122,8 @@ public class LegacyManifest implements Manifest {
   public ArrayList<AssetEntity> getAssetEntityList() {
     ArrayList<AssetEntity> assetList = new ArrayList<>();
 
-    String key;
-    try {
-      key = "bundle-" + UpdatesUtils.sha256(mBundleUrl.toString());
-    } catch (Exception e) {
-      key = "bundle-" + mCommitTime.getTime();
-      Log.e(TAG, "Failed to get SHA-256 checksum of bundle URL");
-    }
-    AssetEntity bundleAssetEntity = new AssetEntity(key, "js");
+    // legacy manifests do not provide a key for the bundle, so we use null
+    AssetEntity bundleAssetEntity = new AssetEntity(null, "js");
     bundleAssetEntity.url = mBundleUrl;
     bundleAssetEntity.isLaunchAsset = true;
     bundleAssetEntity.embeddedAssetFilename = BUNDLE_FILENAME;

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/LegacyManifest.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/LegacyManifest.java
@@ -122,8 +122,8 @@ public class LegacyManifest implements Manifest {
   public ArrayList<AssetEntity> getAssetEntityList() {
     ArrayList<AssetEntity> assetList = new ArrayList<>();
 
-    // legacy manifests do not provide a key for the bundle, so we use null
-    AssetEntity bundleAssetEntity = new AssetEntity(null, "js");
+    String bundleKey = mManifestJson.optString("bundleKey", null);
+    AssetEntity bundleAssetEntity = new AssetEntity(bundleKey, "js");
     bundleAssetEntity.url = mBundleUrl;
     bundleAssetEntity.isLaunchAsset = true;
     bundleAssetEntity.embeddedAssetFilename = BUNDLE_FILENAME;

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/NewManifest.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/NewManifest.java
@@ -116,7 +116,7 @@ public class NewManifest implements Manifest {
     ArrayList<AssetEntity> assetList = new ArrayList<>();
 
     try {
-      AssetEntity bundleAssetEntity = new AssetEntity("bundle-" + mCommitTime.getTime(), mLaunchAsset.getString("contentType"));
+      AssetEntity bundleAssetEntity = new AssetEntity(mLaunchAsset.getString("key"), mLaunchAsset.getString("contentType"));
       bundleAssetEntity.url = Uri.parse(mLaunchAsset.getString("url"));
       bundleAssetEntity.isLaunchAsset = true;
       bundleAssetEntity.embeddedAssetFilename = BUNDLE_FILENAME;

--- a/packages/expo-updates/android/src/test/java/expo/modules/updates/UpdatesUtilsTest.java
+++ b/packages/expo-updates/android/src/test/java/expo/modules/updates/UpdatesUtilsTest.java
@@ -1,7 +1,5 @@
 package expo.modules.updates;
 
-import android.net.Uri;
-
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -17,6 +15,14 @@ public class UpdatesUtilsTest {
   public void testCreateFilenameForAsset() {
     AssetEntity assetEntity = new AssetEntity("key", "png");
     Assert.assertEquals("key", UpdatesUtils.createFilenameForAsset(assetEntity));
+  }
+
+  @Test
+  public void testCreateFilenameForAsset_NullKey() {
+    // asset filenames with null keys should be unique
+    AssetEntity asset1 = new AssetEntity(null, "bundle");
+    AssetEntity asset2 = new AssetEntity(null, "bundle");
+    Assert.assertNotEquals(UpdatesUtils.createFilenameForAsset(asset1), UpdatesUtils.createFilenameForAsset(asset2));
   }
 
   @Test

--- a/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesAppLauncherWithDatabase.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesAppLauncherWithDatabase.m
@@ -235,7 +235,7 @@ static NSString * const EXUpdatesAppLauncherErrorDomain = @"AppLauncher";
   if (embeddedManifest) {
     EXUpdatesAsset *matchingAsset;
     for (EXUpdatesAsset *embeddedAsset in embeddedManifest.assets) {
-      if ([embeddedAsset.key isEqualToString:asset.key]) {
+      if (embeddedAsset.key && [embeddedAsset.key isEqualToString:asset.key]) {
         matchingAsset = embeddedAsset;
         break;
       }

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoader.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoader.m
@@ -267,6 +267,7 @@ static NSString * const EXUpdatesAppLoaderErrorDomain = @"EXUpdatesAppLoader";
       if (!existingAssetFound) {
         // the database and filesystem have gotten out of sync
         // do our best to create a new entry for this file even though it already existed on disk
+        // TODO: we should probably get rid of this assumption that if an asset exists on disk with the same filename, it's the same asset
         NSData *contents = [NSData dataWithContentsOfURL:[self->_directory URLByAppendingPathComponent:existingAsset.filename]];
         existingAsset.contentHash = [EXUpdatesUtils sha256WithData:contents];
         existingAsset.downloadTime = [NSDate date];

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAsset.h
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAsset.h
@@ -9,7 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * properties determined by asset source
  */
-@property (nonatomic, strong) NSString *key;
+@property (nullable, nonatomic, strong) NSString *key;
 @property (nonatomic, strong) NSString *type;
 @property (nullable, nonatomic, strong) NSURL *url;
 @property (nullable, nonatomic, strong) NSDictionary *metadata;
@@ -25,7 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nullable, nonatomic, strong) NSString *contentHash;
 @property (nullable, nonatomic, strong) NSDictionary *headers;
 
-- (instancetype)initWithKey:(NSString *)key type:(NSString *)type;
+- (instancetype)initWithKey:(nullable NSString *)key type:(NSString *)type;
 
 @end
 

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAsset.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAsset.m
@@ -3,11 +3,13 @@
 #import <EXUpdates/EXUpdatesAsset.h>
 #import <EXUpdates/EXUpdatesUtils.h>
 
+#include <stdlib.h>
+
 NS_ASSUME_NONNULL_BEGIN
 
 @implementation EXUpdatesAsset
 
-- (instancetype)initWithKey:(NSString *)key type:(NSString *)type
+- (instancetype)initWithKey:(nullable NSString *)key type:(NSString *)type
 {
   if (self = [super init]) {
     _key = key;
@@ -18,7 +20,15 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (nullable NSString *)filename
 {
-  return _key;
+  if (!_filename) {
+    if (_key) {
+      _filename = _key;
+    } else {
+      // create a filename that's unlikely to collide with any other asset
+      _filename = [NSString stringWithFormat:@"asset-%d-%u", (int)[NSDate date].timeIntervalSince1970, arc4random()];
+    }
+  }
+  return _filename;
 }
 
 @end

--- a/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.h
+++ b/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.h
@@ -32,7 +32,7 @@ typedef NS_ENUM(NSInteger, EXUpdatesDatabaseHashType) {
 - (nullable NSArray<EXUpdatesUpdate *> *)launchableUpdatesWithConfig:(EXUpdatesConfig *)config error:(NSError ** _Nullable)error;
 - (nullable EXUpdatesUpdate *)updateWithId:(NSUUID *)updateId config:(EXUpdatesConfig *)config error:(NSError ** _Nullable)error;
 - (nullable NSArray<EXUpdatesAsset *> *)assetsWithUpdateId:(NSUUID *)updateId error:(NSError ** _Nullable)error;
-- (nullable EXUpdatesAsset *)assetWithKey:(NSString *)key error:(NSError ** _Nullable)error;
+- (nullable EXUpdatesAsset *)assetWithKey:(nullable NSString *)key error:(NSError ** _Nullable)error;
 
 - (nullable NSDictionary *)serverDefinedHeadersWithScopeKey:(NSString *)scopeKey error:(NSError ** _Nullable)error;
 - (nullable NSDictionary *)manifestFiltersWithScopeKey:(NSString *)scopeKey error:(NSError ** _Nullable)error;

--- a/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.h
+++ b/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.h
@@ -19,6 +19,10 @@ typedef NS_ENUM(NSInteger, EXUpdatesDatabaseHashType) {
 
 - (void)addUpdate:(EXUpdatesUpdate *)update error:(NSError ** _Nullable)error;
 - (void)addNewAssets:(NSArray<EXUpdatesAsset *> *)assets toUpdateWithId:(NSUUID *)updateId error:(NSError ** _Nullable)error;
+/**
+ * This method may return NO if a matching entry for the existing asset cannot be found in the database.
+ * In this case, the error pointer will not be set.
+ */
 - (BOOL)addExistingAsset:(EXUpdatesAsset *)asset toUpdateWithId:(NSUUID *)updateId error:(NSError ** _Nullable)error;
 - (void)updateAsset:(EXUpdatesAsset *)asset error:(NSError ** _Nullable)error;
 - (void)mergeAsset:(EXUpdatesAsset *)asset withExistingEntry:(EXUpdatesAsset *)existingAsset error:(NSError ** _Nullable)error;

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesBareUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesBareUpdate.m
@@ -32,8 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
 
   NSMutableArray<EXUpdatesAsset *> *processedAssets = [NSMutableArray new];
 
-  NSString *bundleKey = [NSString stringWithFormat:@"bundle-%@", commitTime];
-  EXUpdatesAsset *jsBundleAsset = [[EXUpdatesAsset alloc] initWithKey:bundleKey type:EXUpdatesBareEmbeddedBundleFileType];
+  EXUpdatesAsset *jsBundleAsset = [[EXUpdatesAsset alloc] initWithKey:nil type:EXUpdatesBareEmbeddedBundleFileType];
   jsBundleAsset.isLaunchAsset = YES;
   jsBundleAsset.mainBundleFilename = EXUpdatesBareEmbeddedBundleFilename;
   [processedAssets addObject:jsBundleAsset];

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesBareUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesBareUpdate.m
@@ -32,7 +32,8 @@ NS_ASSUME_NONNULL_BEGIN
 
   NSMutableArray<EXUpdatesAsset *> *processedAssets = [NSMutableArray new];
 
-  EXUpdatesAsset *jsBundleAsset = [[EXUpdatesAsset alloc] initWithKey:nil type:EXUpdatesBareEmbeddedBundleFileType];
+  NSString *bundleKey = [NSString stringWithFormat:@"bundle-%@", commitTime];
+  EXUpdatesAsset *jsBundleAsset = [[EXUpdatesAsset alloc] initWithKey:bundleKey type:EXUpdatesBareEmbeddedBundleFileType];
   jsBundleAsset.isLaunchAsset = YES;
   jsBundleAsset.mainBundleFilename = EXUpdatesBareEmbeddedBundleFilename;
   [processedAssets addObject:jsBundleAsset];

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesBareUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesBareUpdate.m
@@ -32,7 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
 
   NSMutableArray<EXUpdatesAsset *> *processedAssets = [NSMutableArray new];
 
-  NSString *bundleKey = [NSString stringWithFormat:@"bundle-%@", commitTime];
+  NSString *bundleKey = [NSString stringWithFormat:@"bundle-%@", uuid.UUIDString];
   EXUpdatesAsset *jsBundleAsset = [[EXUpdatesAsset alloc] initWithKey:bundleKey type:EXUpdatesBareEmbeddedBundleFileType];
   jsBundleAsset.isLaunchAsset = YES;
   jsBundleAsset.mainBundleFilename = EXUpdatesBareEmbeddedBundleFilename;

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesBareUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesBareUpdate.m
@@ -32,7 +32,8 @@ NS_ASSUME_NONNULL_BEGIN
 
   NSMutableArray<EXUpdatesAsset *> *processedAssets = [NSMutableArray new];
 
-  NSString *bundleKey = [NSString stringWithFormat:@"bundle-%@", uuid.UUIDString];
+  // use unsanitized id value from manifest
+  NSString *bundleKey = [NSString stringWithFormat:@"bundle-%@", updateId];
   EXUpdatesAsset *jsBundleAsset = [[EXUpdatesAsset alloc] initWithKey:bundleKey type:EXUpdatesBareEmbeddedBundleFileType];
   jsBundleAsset.isLaunchAsset = YES;
   jsBundleAsset.mainBundleFilename = EXUpdatesBareEmbeddedBundleFilename;

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesLegacyUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesLegacyUpdate.m
@@ -70,8 +70,8 @@ static NSString * const EXUpdatesExpoTestDomain = @"expo.test";
 
   NSMutableArray<EXUpdatesAsset *> *processedAssets = [NSMutableArray new];
 
-  // legacy manifests do not provide a key for the bundle, so we use nil
-  EXUpdatesAsset *jsBundleAsset = [[EXUpdatesAsset alloc] initWithKey:nil type:EXUpdatesEmbeddedBundleFileType];
+  NSString *bundleKey = manifest[@"bundleKey"] ?: nil;
+  EXUpdatesAsset *jsBundleAsset = [[EXUpdatesAsset alloc] initWithKey:bundleKey type:EXUpdatesEmbeddedBundleFileType];
   jsBundleAsset.url = bundleUrl;
   jsBundleAsset.isLaunchAsset = YES;
   jsBundleAsset.mainBundleFilename = EXUpdatesEmbeddedBundleFilename;

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesLegacyUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesLegacyUpdate.m
@@ -70,8 +70,8 @@ static NSString * const EXUpdatesExpoTestDomain = @"expo.test";
 
   NSMutableArray<EXUpdatesAsset *> *processedAssets = [NSMutableArray new];
 
-  NSString *bundleKey = [NSString stringWithFormat:@"bundle-%@", [EXUpdatesUtils sha256WithData:[(NSString *)bundleUrlString dataUsingEncoding:NSUTF8StringEncoding]]];
-  EXUpdatesAsset *jsBundleAsset = [[EXUpdatesAsset alloc] initWithKey:bundleKey type:EXUpdatesEmbeddedBundleFileType];
+  // legacy manifests do not provide a key for the bundle, so we use nil
+  EXUpdatesAsset *jsBundleAsset = [[EXUpdatesAsset alloc] initWithKey:nil type:EXUpdatesEmbeddedBundleFileType];
   jsBundleAsset.url = bundleUrl;
   jsBundleAsset.isLaunchAsset = YES;
   jsBundleAsset.mainBundleFilename = EXUpdatesEmbeddedBundleFilename;

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesNewUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesNewUpdate.m
@@ -47,7 +47,7 @@ NS_ASSUME_NONNULL_BEGIN
 
   NSMutableArray<EXUpdatesAsset *> *processedAssets = [NSMutableArray new];
 
-  NSString *bundleKey = [NSString stringWithFormat:@"bundle-%@", commitTime];
+  NSString *bundleKey = launchAsset[@"key"];
   EXUpdatesAsset *jsBundleAsset = [[EXUpdatesAsset alloc] initWithKey:bundleKey type:EXUpdatesEmbeddedBundleFileType];
   jsBundleAsset.url = bundleUrl;
   jsBundleAsset.isLaunchAsset = YES;

--- a/packages/expo-updates/ios/Tests/Tests.m
+++ b/packages/expo-updates/ios/Tests/Tests.m
@@ -2,6 +2,7 @@
 
 @import XCTest;
 
+#import <EXUpdates/EXUpdatesAsset.h>
 #import <EXUpdates/EXUpdatesConfig.h>
 #import <EXUpdates/EXUpdatesLegacyUpdate.h>
 #import <EXUpdates/EXUpdatesUtils.h>
@@ -49,6 +50,18 @@
 
   NSURL *urlOtherPort = [NSURL URLWithString:@"https://exp.host:47/test"];
   XCTAssert([@"https://exp.host:47" isEqualToString:[EXUpdatesConfig normalizedURLOrigin:urlOtherPort]], @"should return a normalized URL origin with port if non-default port is specified");
+}
+
+- (void)testAssetFilename
+{
+  EXUpdatesAsset *asset1 = [[EXUpdatesAsset alloc] initWithKey:nil type:@"bundle"];
+  EXUpdatesAsset *asset2 = [[EXUpdatesAsset alloc] initWithKey:nil type:@"bundle"];
+  XCTAssertNotEqualObjects(asset1.filename, asset2.filename, @"Asset filenames with null keys should be unique");
+
+  EXUpdatesAsset *assetSetFilename = [[EXUpdatesAsset alloc] initWithKey:nil type:@"bundle"];
+  NSString *filenameFromDatabase = @"filename.png";
+  assetSetFilename.filename = filenameFromDatabase;
+  XCTAssertEqualObjects(filenameFromDatabase, assetSetFilename.filename, @"Should be able to override the default asset filename if the database has something different");
 }
 
 @end


### PR DESCRIPTION
# Why

Depends on https://github.com/expo/expo/pull/12110. Resolves [ENG-426](https://linear.app/expo/issue/ENG-426/handle-null-assetskey-in-application-logic-always-download-such-assets).

# How

- ensure all application usages of `asset.key` can handle null values
- make legacy manifest bundle keys null, and use the existing `key` field in EAS update manifests

# Test Plan

Added a unit test for filename behavior, then ran the following manual tests in Expo Go:

- Opened published NCL, closed and re-opened, verified the bundle was only downloaded once
- Turned off wifi and opened NCL, verified it loaded
- Ran tests from https://github.com/expo/expo/issues/11844, verified bug was fixed
- Opened different snacks, **verified a new bundle is saved in the expo-updates asset cache each time** (this is an expected change, since we no longer know the bundles are the same)
- Looked in DB to ensure all bundles in the previous cases had null keys