### PR TITLE
[ios][android] Update NetInfo to 6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Package-specific changes not released in any SDK will be added here just before 
 
 - Updated `@react-native-picker/picker` from `1.9.2` to `1.9.11`. ([#11956](https://github.com/expo/expo/pull/11956) by [@tsapeta](https://github.com/tsapeta))
 - Updated `lottie-react-native` from `2.6.1` to `3.5.0`. ([#11586](https://github.com/expo/expo/pull/11586) and [#11950](https://github.com/expo/expo/pull/11950) by [@tsapeta](https://github.com/tsapeta))
-- Updated `@react-native-community/netinfo` from `5.9.7` to `5.9.10`. ([#11947](https://github.com/expo/expo/pull/11947) by [@tsapeta](https://github.com/tsapeta))
+- Updated `@react-native-community/netinfo` from `5.9.7` to `6.0.0`. ([#11947](https://github.com/expo/expo/pull/11947) by [@tsapeta](https://github.com/tsapeta)) and ([#12112](https://github.com/expo/expo/pull/12112) by [@brentvatne](https://github.com/brentvatne))
 - Updated `react-native-webview` from `10.10.2` to `11.2.3`. ([#11964](https://github.com/expo/expo/pull/11964) by [@tsapeta](https://github.com/tsapeta))
 - Updated `@react-native-segmented-control/segmented-control` from `2.2.1` to `2.3.0`. Side note: the package has changed its NPM scope from `@react-native-community/segmented-control`. ([#11996](https://github.com/expo/expo/pull/11996) by [@tsapeta](https://github.com/tsapeta))
 - Updated `@react-native-community/viewpager` from `4.2.0` to `4.2.3`. ([#12003](https://github.com/expo/expo/pull/12003) by [@tsapeta](https://github.com/tsapeta))

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/netinfo/NetworkCallbackConnectivityReceiver.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/netinfo/NetworkCallbackConnectivityReceiver.java
@@ -13,6 +13,7 @@ import android.net.LinkProperties;
 import android.net.Network;
 import android.net.NetworkCapabilities;
 import android.net.NetworkInfo;
+import android.net.NetworkRequest;
 import android.os.Build;
 
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -39,7 +40,8 @@ class NetworkCallbackConnectivityReceiver extends ConnectivityReceiver {
     @SuppressLint("MissingPermission")
     void register() {
         try {
-            getConnectivityManager().registerDefaultNetworkCallback(mNetworkCallback);
+            NetworkRequest.Builder builder = new NetworkRequest.Builder();
+            getConnectivityManager().registerNetworkCallback(builder.build(), mNetworkCallback);
         } catch (SecurityException e) {
             // TODO: Display a yellow box about this
         }

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -110,7 +110,7 @@
     "@react-native-community/async-storage": "~1.12.0",
     "@react-native-community/datetimepicker": "3.0.4",
     "@react-native-community/masked-view": "^0.1.10",
-    "@react-native-community/netinfo": "5.9.10",
+    "@react-native-community/netinfo": "6.0.0",
     "@react-native-community/slider": "3.0.3",
     "@react-native-community/viewpager": "4.2.3",
     "@react-native-picker/picker": "1.9.11",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -52,7 +52,7 @@
     "@react-native-community/slider": "3.0.3",
     "@react-native-community/masked-view": "0.1.10",
     "@react-native-community/datetimepicker": "3.0.4",
-    "@react-native-community/netinfo": "5.9.10",
+    "@react-native-community/netinfo": "6.0.0",
     "@react-native-community/viewpager": "4.2.3",
     "@react-native-picker/picker": "1.9.11",
     "@react-native-segmented-control/segmented-control": "2.3.0",

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -12,7 +12,7 @@ Install _fastlane_ using
 ```
 [sudo] gem install fastlane -NV
 ```
-or alternatively using `brew cask install fastlane`
+or alternatively using `brew install fastlane`
 
 # Available Actions
 ## iOS

--- a/home/api/Connectivity.ts
+++ b/home/api/Connectivity.ts
@@ -22,7 +22,7 @@ class Connectivity {
 
     try {
       const netInfo = await NetInfo.fetch();
-      this._isAvailable = netInfo.isConnected;
+      this._isAvailable = netInfo.isConnected ?? false;
     } catch (e) {
       this._isAvailable = false;
       console.warn(`Uncaught error when fetching connectivity status: ${e}`);
@@ -32,7 +32,7 @@ class Connectivity {
   }
 
   _handleConnectivityChange = (netInfo: NetInfoState) => {
-    this._isAvailable = netInfo.isConnected;
+    this._isAvailable = netInfo.isConnected ?? false;
     this._listeners.forEach(listener => {
       listener(this._isAvailable);
     });

--- a/home/package.json
+++ b/home/package.json
@@ -22,7 +22,7 @@
     "@expo/vector-icons": "^12.0.0",
     "@react-native-community/async-storage": "~1.12.0",
     "@react-native-community/masked-view": "0.1.10",
-    "@react-native-community/netinfo": "5.9.10",
+    "@react-native-community/netinfo": "6.0.0",
     "@react-navigation/bottom-tabs": "~5.11.1",
     "@react-navigation/material-bottom-tabs": "~5.3.9",
     "@react-navigation/native": "~5.8.9",

--- a/ios/Exponent.xcodeproj/project.pbxproj
+++ b/ios/Exponent.xcodeproj/project.pbxproj
@@ -2484,7 +2484,7 @@
 				TargetAttributes = {
 					78CEE2BF1ACD07D70095B124 = {
 						CreatedOnToolsVersion = 6.2;
-						DevelopmentTeam = C8D8QTF339;
+						DevelopmentTeam = GQ4S96SE9Z;
 						LastSwiftMigration = 1150;
 						ProvisioningStyle = Automatic;
 						SystemCapabilities = {
@@ -3239,7 +3239,7 @@
 				CODE_SIGN_ENTITLEMENTS = Exponent/Supporting/Exponent.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = C8D8QTF339;
+				DEVELOPMENT_TEAM = GQ4S96SE9Z;
 				EX_BUNDLE_NAME = Expo;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Exponent/Supporting/Exponent-Prefix.pch";

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2190,7 +2190,7 @@ PODS:
     - React-cxxreact (= 0.63.2)
     - React-jsi (= 0.63.2)
   - React-jsinspector (0.63.2)
-  - react-native-netinfo (5.9.10):
+  - react-native-netinfo (6.0.0):
     - React-Core
   - react-native-segmented-control (2.3.0):
     - React-Core
@@ -3994,7 +3994,7 @@ SPEC CHECKSUMS:
   React-jsi: 54245e1d5f4b690dec614a73a3795964eeef13a8
   React-jsiexecutor: 8ca588cc921e70590820ce72b8789b02c67cce38
   React-jsinspector: b14e62ebe7a66e9231e9581279909f2fc3db6606
-  react-native-netinfo: 30fb89fa913c342be82a887b56e96be6d71201dd
+  react-native-netinfo: e849fc21ca2f4128a5726c801a82fc6f4a6db50d
   react-native-segmented-control: 83a05d42acd1234ad5e061d603c145973a61b5ee
   react-native-viewpager: 936c67cba6e9ca19793d04321427a44cb8e43395
   react-native-webview: 6520e3e7b4933de76b95ef542c8d7115cf45b68e

--- a/ios/vendored/unversioned/@react-native-community/netinfo/react-native-netinfo.podspec.json
+++ b/ios/vendored/unversioned/@react-native-community/netinfo/react-native-netinfo.podspec.json
@@ -1,10 +1,10 @@
 {
   "name": "react-native-netinfo",
-  "version": "5.9.10",
+  "version": "6.0.0",
   "summary": "React Native Network Info API for iOS & Android",
   "license": "MIT",
   "authors": "Matt Oakes <hello@mattoakes.net>",
-  "homepage": "https://github.com/react-native-community/react-native-netinfo#readme",
+  "homepage": "https://github.com/react-native-netinfo/react-native-netinfo#readme",
   "platforms": {
     "ios": "9.0",
     "tvos": "9.2",
@@ -12,7 +12,7 @@
   },
   "source": {
     "git": "https://github.com/react-native-community/react-native-netinfo.git",
-    "tag": "v5.9.10"
+    "tag": "v6.0.0"
   },
   "source_files": "ios/**/*.{h,m}",
   "dependencies": {

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -1,6 +1,6 @@
 {
   "@expo/vector-icons": "^12.0.0",
-  "@react-native-community/netinfo": "5.9.10",
+  "@react-native-community/netinfo": "6.0.0",
   "@react-native-community/async-storage": "~1.12.0",
   "@unimodules/core": "~7.0.0",
   "@unimodules/react-native-adapter": "~6.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3686,10 +3686,10 @@
   resolved "https://registry.yarnpkg.com/@react-native-community/masked-view/-/masked-view-0.1.10.tgz#5dda643e19e587793bc2034dd9bf7398ad43d401"
   integrity sha512-rk4sWFsmtOw8oyx8SD3KSvawwaK7gRBSEIy2TAwURyGt+3TizssXP1r8nx3zY+R7v2vYYHXZ+k2/GULAT/bcaQ==
 
-"@react-native-community/netinfo@5.9.10":
-  version "5.9.10"
-  resolved "https://registry.yarnpkg.com/@react-native-community/netinfo/-/netinfo-5.9.10.tgz#97d3a9fa62a3a4838ec7a6ec91cfec5a26e365b6"
-  integrity sha512-1NPlBA2Hu/KWc3EnQcDRPRX0x8Dg9tuQlQQVWVQjlg+u+PjCq7ANEtbikOFKp5yQqfF8tqzU5+84/IfDO8zpiA==
+"@react-native-community/netinfo@6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/netinfo/-/netinfo-6.0.0.tgz#2a4d7190b508dd0c2293656c9c1aa068f6f60a71"
+  integrity sha512-Z9M8VGcF2IZVOo2x+oUStvpCW/8HjIRi4+iQCu5n+PhC7OqCQX58KYAzdBr///alIfRXiu6oMb+lK+rXQH1FvQ==
 
 "@react-native-community/slider@3.0.3":
   version "3.0.3"


### PR DESCRIPTION
# Why

https://github.com/expo/expo/pull/11947 bumped it but there has been a small update since then.

# How

- `et update-module -m @react-native-community/netinfo`

# Test Plan

Tested against NCL