### PR TITLE
[expo-auth-session] Fix dependencies to align with bundledNativeModules.json

### DIFF
--- a/packages/expo-auth-session/CHANGELOG.md
+++ b/packages/expo-auth-session/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Remove peerDependencies and unimodulePeerDependencies from Expo modules. ([#11980](https://github.com/expo/expo/pull/11980) by [@brentvatne](https://github.com/brentvatne))
+- Fix dependencies to align with bundledNativeModules.json. ([#12113](https://github.com/expo/expo/pull/12113) by [@brentvatne](https://github.com/brentvatne))
 
 ## 3.1.0 — 2021-01-15
 

--- a/packages/expo-auth-session/package.json
+++ b/packages/expo-auth-session/package.json
@@ -34,10 +34,10 @@
   "license": "MIT",
   "homepage": "https://docs.expo.io/versions/latest/sdk/auth-session",
   "dependencies": {
-    "expo-constants": "^10.0.1",
-    "expo-crypto": "^9.0.0",
+    "expo-constants": "~10.0.1",
+    "expo-crypto": "~9.0.0",
     "expo-linking": "~2.1.1",
-    "expo-web-browser": "^9.0.0",
+    "expo-web-browser": "~9.0.0",
     "invariant": "^2.2.4",
     "qs": "6.9.1"
   },


### PR DESCRIPTION
# Why

We need to ensure that dependencies in Expo modules on other Expo modules line up with the version ranges specified in bundledNativeModules.json, otherwise there it's possible to end up with mismatched versions, and to get versions of a library incompatible with the SDK.

# How

- Ensure that the dependency versions line up with bundledNativeModules.json
- Verify with `et publish-packages expo-constants --dry -S` that we're still using the correct version after updating a dependency (it keeps the same semver matcher)

# Test Plan

- Check dependencies in package.json in expo-auth-session against bundledNativeModules.json

# Follow-up

- Consider adding validations to ensure that our internal dependencies don't end up in this situation again