### PR TITLE
[docs] eas build: document built-in environment variables

### DIFF
--- a/docs/pages/build-reference/how-tos.md
+++ b/docs/pages/build-reference/how-tos.md
@@ -77,10 +77,11 @@ If you are not using `credentials.json` for Android/iOS credentials, it is fine 
 By default the EAS npm cache won't work with yarn v1, because `yarn.lock` files contain URLs to registries for every package and yarn does not provide any way to override it. The issue is fixed in yarn v2, but the yarn team does not plan to backport it to yarn v1. If you want to take advantage of the npm cache, you can use the `eas-build-pre-install` script to override the registry in your `yarn.lock`.
 
 e.g.
+
 ```
 {
  "scripts": {
-    "eas-build-pre-install": "bash -c \"[ ! -z \\\"NPM_CACHE_URL\\\" ] && sed -i -e \\\"s#https://registry.yarnpkg.com#$NPM_CACHE_URL#g\\\" yarn.lock\""
+    "eas-build-pre-install": "bash -c \"[ ! -z \\\"EAS_BUILD_NPM_CACHE_URL\\\" ] && sed -i -e \\\"s#https://registry.yarnpkg.com#$EAS_BUILD_NPM_CACHE_URL#g\\\" yarn.lock\""
   }
 }
 ```

--- a/docs/pages/build-reference/variables.md
+++ b/docs/pages/build-reference/variables.md
@@ -71,6 +71,6 @@ The following environment variables are exposed to each build job:
 
 - `CI=1` - indicates this is a CI environment
 - `EAS_BUILD=1` - indicates this is an EAS Build environment
-- `EAS_BUILD_PROFILE` - the name of the build profile from eas.json, e.g. `release`
+- `EAS_BUILD_PROFILE` - the name of the build profile from `eas.json`, e.g. `release`
 - `EAS_BUILD_GIT_COMMIT_HASH` - the hash of the Git commit, e.g. `88f28ab5ea39108ade978de2d0d1adeedf0ece76`
 - `EAS_BUILD_NPM_CACHE_URL` - the URL of the npm cache ([learn more](how-tos.md#using-npm-cache-with-yarn-v1))

--- a/docs/pages/build-reference/variables.md
+++ b/docs/pages/build-reference/variables.md
@@ -64,3 +64,13 @@ See the [eas.json reference](/build/eas-json.md) for more information.
 🚧 We are currently working on a secrets API that will allow developers to store generic encrypted secrets and selectively expose them to build jobs. This feature will be available before EAS Build graduates from preview.
 
 App signing credentials secrets are stored in `credentials.json`, which should not be committed to git. This file can also be used to set the `NPM_TOKEN` environment variable in order to give you access to your organization's private packages. [Learn more](how-tos.md).
+
+## Built-in environment variables
+
+The following environment variables are exposed to each build job:
+
+- `CI=1` - indicates this is a CI environment
+- `EAS_BUILD=1` - indicates this is an EAS Build environment
+- `EAS_BUILD_PROFILE` - the name of the build profile from eas.json, e.g. `release`
+- `EAS_BUILD_GIT_COMMIT_HASH` - the hash of the Git commit, e.g. `88f28ab5ea39108ade978de2d0d1adeedf0ece76`
+- `EAS_BUILD_NPM_CACHE_URL` - the URL of the npm cache ([learn more](how-tos.md#using-npm-cache-with-yarn-v1))


### PR DESCRIPTION
# Why

Part 4 of https://linear.app/expo/issue/ENG-392/expose-system-environment-variables-with-context-about-the-build

We want to expose system environment variables with context about the build.

# How

I documented the built-in environment variables.

# Test Plan

`yarn dev`
