### PR TITLE
[docs] fix typos and formatting in Readme.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -69,7 +69,7 @@ You can validate all current links by running `$ yarn lint-links`.
 
 ### Server-side redirects
 
-These redirects are limited in their expensiveness - you can map a path to another path, but no regular expressions or anything are supported. See client-side redirects for more of that. Server-side redirects are re-created on each run of `deploy.sh`.
+These redirects are limited in their expressiveness - you can map a path to another path, but no regular expressions or anything are supported. See client-side redirects for more of that. Server-side redirects are re-created on each run of `deploy.sh`.
 
 We currently do two client-side redirects, using meta tags with `http-equiv="refresh"`:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,11 +2,11 @@
 
 This is the public documentation for **Expo**, its SDK, client and services.
 
-You can access this documentation online at https://docs.expo.io/. It's built using next.js on top of the https://github.com/zeit/docs codebase.
+You can access this documentation online at https://docs.expo.io/. It's built using next.js on top of the https://github.com/vercel/docs codebase.
 
 > **Contributors:** Please make sure that you edit the docs in the `pages/versions/unversioned` directory if you want your changes to apply to the next SDK version too!
 
-### Running Locally
+## Running Locally
 
 Download the copy of this repository.
 
@@ -28,18 +28,18 @@ yarn run dev
 
 Now the documentation is running at http://localhost:3002
 
-### Running in production mode
+## Running in production mode
 
 ```sh
 yarn run export
 yarn run export-server
 ```
 
-### Editing Docs Content
+## Editing Docs Content
 
 You can find the source of the documentation inside the `pages/versions` directory. Documentation is mostly written in markdown with the help of some React components (for Snack embeds, etc). The routes and navbar are automatically inferred from the directory structure within `versions`.
 
-### Editing Code
+## Editing Code
 
 The docs are written with Next.js and TypeScript. If you need to make code changes, follow steps from the [Running locally](#running-locally) section, then open a separate terminal and run the TypeScript compiler in watch mode - it will watch your code changes and notify you about errors.
 
@@ -55,7 +55,7 @@ yarn test
 yarn lint
 ```
 
-### Internal linking
+## Internal linking
 
 If you need to link from one MDX file to another, please use the path-reference to this file including extension.
 This allows us to automatically validate these links and see if the file and/or headers still exists.
@@ -65,11 +65,11 @@ This allows us to automatically validate these links and see if the file and/or 
 
 You can validate all current links by running `$ yarn lint-links`.
 
-### Redirects
+## Redirects
 
-#### Server-side redirects
+### Server-side redirects
 
-These redirects are limited in their expresiveness - you can map a path to another path, but no regular expressions or anything are supported. See client-side redirects for more of that. Server-side redirects are re-created on each run of `deploy.sh`.
+These redirects are limited in their expensiveness - you can map a path to another path, but no regular expressions or anything are supported. See client-side redirects for more of that. Server-side redirects are re-created on each run of `deploy.sh`.
 
 We currently do two client-side redirects, using meta tags with `http-equiv="refresh"`:
 
@@ -78,21 +78,21 @@ We currently do two client-side redirects, using meta tags with `http-equiv="ref
 
 This method is not great for accessibility and should be avoided where possible.
 
-#### Client-side redirects
+### Client-side redirects
 
 Use these for more complex rules than one-to-one path-to-path redirect mapping. For example, we use client-side redirects to strip the `.html` extension off, and to identify if the request is for a version of the documentation that we no longer support.
 
 You can add your own client-side redirect rules in `pages/_error.js`.
 
-### Adding Images and Assets
+## Adding Images and Assets
 
 You can add images and assets to the `public/static` directory. They'll be served by the production and staging servers at `/static`.
 
-### New Components
+## New Components
 
 Always try to use the existing components and features in markdown. Create a new component or use a component from NPM, unless there is no other option.
 
-### Algolia Docsearch
+## Algolia Docsearch
 
 We use Algolia Docsearch as the search engine for our docs. Right now, it's searching for any keywords with the proper `version` tag based on the current location. This is set in the `components/DocumentationPage` header.
 
@@ -102,19 +102,19 @@ In `components/plugins/AlgoliaSearch`, you can see the `facetFilters` set to `[[
 - All versioned pages use the SDK version (e.g. `v40.0.0` or `v39.0.0`).
 - All `hideFromSearch: true` pages don't have the version tag.
 
-#### Excluding pages from Docsearch
+### Excluding pages from Docsearch
 
 To ignore a page from the search result, use `hideFromSearch: true` on that page. This removes the `<meta name="docsearch:version">` tag from that page and filters it from our facet-based search.
 
-### Quirks
+## Quirks
 
 - You can't have curly brace without quotes: \`{}\` -> `{}`
-- Make sure to leave a empty newline between a table and following content
+- Make sure to leave an empty newline between a table and following content
 
-## A note about versioning
+# A note about versioning
 
 Expo's SDK is versioned so that apps made on old SDKs are still supported
-when new SDKs are relased. The website documents previous SDK versions too.
+when new SDKs are released. The website documents previous SDK versions too.
 
 Version names correspond to directory names under `versions`.
 
@@ -135,9 +135,9 @@ on `v8.0.0` and `v7.0.0`, you'd do the following after editing the docs in
 Any changes in your `git diff` outside the `unversioned` directory are ignored
 so don't worry if you have code changes or such elsewhere.
 
-### Updating latest version of docs
+## Updating latest version of docs
 
-When we release a new SDK, we copy the `unversioned` directory, and rename it to the new version. Latest version of docs is read from `package.json` so make sure to update the `version` key there as well. However, if you update the `version` key there, you need to `rm -rf node_modules/.cache/` before the change is picked up (why? [read this](https://github.com/zeit/next.js/blob/4.0.0/examples/with-universal-configuration/README.md#caveats)).
+When we release a new SDK, we copy the `unversioned` directory, and rename it to the new version. Latest version of docs is read from `package.json` so make sure to update the `version` key there as well. However, if you update the `version` key there, you need to `rm -rf node_modules/.cache/` before the change is picked up (why? [read this](https://github.com/vercel/next.js/blob/4.0.0/examples/with-universal-configuration/README.md#caveats)).
 
 Make sure to also grab the upgrade instructions from the release notes blog post and put them in `upgrading-expo-sdk-walkthrough.md`.
 
@@ -145,13 +145,13 @@ That's all you need to do. The `versions` directory is listed on server start to
 
 Because the navbar is automatically generated from the directory structure, the default ordering of the links under each section is alphabetical. However, for many sections, this is not ideal UX. So, if you wish to override the alphabetical ordering, manipulate page titles in `navigation.js`.
 
-#### Syncing app.json / app.config.js with the schema
+### Syncing app.json / app.config.js with the schema
 
 To render the app.json / app.config.js properties table, we currently store a local copy of the appropriate version of the schema.
 
 If the schema is updated, in order to sync and rewrite our local copy, run `yarn run schema-sync 39` (or relevant version number) or `yarn run schema-sync unversioned`.
 
-#### Importing from the React Native docs
+### Importing from the React Native docs
 
 You can import the React Native docs in an automated way into these docs.
 
@@ -163,4 +163,7 @@ You may need to tweak the script as the source docs change; the script hackily t
 
 The React Native docs are actually versioned but we currently read off of master.
 
-TODOs: - Handle image sizing in imports better - Read from the appropriate version (configurable) of the React Native docs, not just master - Make Snack embeds work; these are marked in some of the React Native docs but they are just imported as plain JS code blocks
+#### TODOs: 
+- Handle image sizing in imports better 
+- Read from the appropriate version (configurable) of the React Native docs, not just master 
+- Make Snack embeds work; these are marked in some of the React Native docs but they are just imported as plain JS code blocks


### PR DESCRIPTION
# Why

To improve readability. 😉 

# How

* ensure headers gradation is in right order which results in sections visually better spaced
* update `zeit` links to `vercel`
* fix few typos

# Test Plan

GitHub MD visual diff.
