### PR TITLE
[admob] upgrade underlying native dependencies

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -4,7 +4,7 @@ PODS:
     - lottie-ios (~> 3.1.8)
   - ABI38_0_0EXAdsAdMob (8.2.1):
     - ABI38_0_0UMCore
-    - Google-Mobile-Ads-SDK (= 7.55.1)
+    - Google-Mobile-Ads-SDK (= 7.69.0)
   - ABI38_0_0EXAdsFacebook (8.2.1):
     - ABI38_0_0UMCore
     - FBAudienceNetwork
@@ -534,7 +534,7 @@ PODS:
     - lottie-ios (~> 3.1.8)
   - ABI39_0_0EXAdsAdMob (8.3.0):
     - ABI39_0_0UMCore
-    - Google-Mobile-Ads-SDK (= 7.55.1)
+    - Google-Mobile-Ads-SDK (= 7.69.0)
   - ABI39_0_0EXAdsFacebook (8.4.0):
     - ABI39_0_0UMCore
     - FBAudienceNetwork
@@ -1074,7 +1074,7 @@ PODS:
     - lottie-ios (~> 3.1.8)
   - ABI40_0_0EXAdsAdMob (8.4.0):
     - ABI40_0_0UMCore
-    - Google-Mobile-Ads-SDK (= 7.55.1)
+    - Google-Mobile-Ads-SDK (= 7.69.0)
   - ABI40_0_0EXAdsFacebook (8.4.1):
     - ABI40_0_0UMCore
     - FBAudienceNetwork (~> 5.9.0)
@@ -1643,7 +1643,7 @@ PODS:
   - CocoaLumberjack/Core (3.5.3)
   - DoubleConversion (1.1.6)
   - EXAdsAdMob (9.0.0):
-    - Google-Mobile-Ads-SDK (= 7.55.1)
+    - Google-Mobile-Ads-SDK (= 7.69.0)
     - UMCore
   - EXAdsFacebook (9.0.0):
     - FBAudienceNetwork (~> 5.9.0)
@@ -1947,7 +1947,7 @@ PODS:
     - GoogleMaps
   - Google-Maps-iOS-Utils/QuadTree (2.1.0):
     - GoogleMaps
-  - Google-Mobile-Ads-SDK (7.55.1):
+  - Google-Mobile-Ads-SDK (7.69.0):
     - GoogleAppMeasurement (~> 6.0)
   - GoogleAPIClientForREST/Core (1.5.1):
     - GTMSessionFetcher (>= 1.1.7)

--- a/ios/versioned-react-native/ABI38_0_0/Expo/EXAdsAdMob/ABI38_0_0EXAdsAdMob.podspec
+++ b/ios/versioned-react-native/ABI38_0_0/Expo/EXAdsAdMob/ABI38_0_0EXAdsAdMob.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   s.requires_arc   = true
 
   s.dependency 'ABI38_0_0UMCore'
-  s.dependency 'Google-Mobile-Ads-SDK', "7.55.1"
+  s.dependency 'Google-Mobile-Ads-SDK', "7.69.0"
 
 end
 

--- a/ios/versioned-react-native/ABI38_0_0/Expo/EXFirebaseAnalytics/ABI38_0_0EXFirebaseAnalytics.podspec
+++ b/ios/versioned-react-native/ABI38_0_0/Expo/EXFirebaseAnalytics/ABI38_0_0EXFirebaseAnalytics.podspec
@@ -2,7 +2,7 @@ require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
-firebase_sdk_version = '6.14.0'
+firebase_sdk_version = '7.7.0'
 if defined? $FirebaseSDKVersion
   firebase_sdk_version = $FirebaseSDKVersion
 end

--- a/ios/versioned-react-native/ABI38_0_0/Expo/EXFirebaseCore/ABI38_0_0EXFirebaseCore.podspec
+++ b/ios/versioned-react-native/ABI38_0_0/Expo/EXFirebaseCore/ABI38_0_0EXFirebaseCore.podspec
@@ -2,7 +2,7 @@ require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
-firebase_sdk_version = '6.14.0'
+firebase_sdk_version = '7.7.0'
 if defined? $FirebaseSDKVersion
   firebase_sdk_version = $FirebaseSDKVersion
 end

--- a/ios/versioned-react-native/ABI39_0_0/Expo/EXAdsAdMob/ABI39_0_0EXAdsAdMob.podspec
+++ b/ios/versioned-react-native/ABI39_0_0/Expo/EXAdsAdMob/ABI39_0_0EXAdsAdMob.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   s.requires_arc   = true
 
   s.dependency 'ABI39_0_0UMCore'
-  s.dependency 'Google-Mobile-Ads-SDK', "7.55.1"
+  s.dependency 'Google-Mobile-Ads-SDK', "7.69.0"
 
 end
 

--- a/ios/versioned-react-native/ABI39_0_0/Expo/EXFirebaseAnalytics/ABI39_0_0EXFirebaseAnalytics.podspec
+++ b/ios/versioned-react-native/ABI39_0_0/Expo/EXFirebaseAnalytics/ABI39_0_0EXFirebaseAnalytics.podspec
@@ -2,7 +2,7 @@ require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
-firebase_sdk_version = '6.14.0'
+firebase_sdk_version = '7.7.0'
 if defined? $FirebaseSDKVersion
   firebase_sdk_version = $FirebaseSDKVersion
 end

--- a/ios/versioned-react-native/ABI39_0_0/Expo/EXFirebaseCore/ABI39_0_0EXFirebaseCore.podspec
+++ b/ios/versioned-react-native/ABI39_0_0/Expo/EXFirebaseCore/ABI39_0_0EXFirebaseCore.podspec
@@ -2,7 +2,7 @@ require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
-firebase_sdk_version = '6.14.0'
+firebase_sdk_version = '7.7.0'
 if defined? $FirebaseSDKVersion
   firebase_sdk_version = $FirebaseSDKVersion
 end

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXAdsAdMob/ABI40_0_0EXAdsAdMob.podspec
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXAdsAdMob/ABI40_0_0EXAdsAdMob.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   s.requires_arc   = true
 
   s.dependency 'ABI40_0_0UMCore'
-  s.dependency 'Google-Mobile-Ads-SDK', "7.55.1"
+  s.dependency 'Google-Mobile-Ads-SDK', "7.69.0"
 
 end
 

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXFirebaseAnalytics/ABI40_0_0EXFirebaseAnalytics.podspec
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXFirebaseAnalytics/ABI40_0_0EXFirebaseAnalytics.podspec
@@ -2,7 +2,7 @@ require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
-firebase_sdk_version = '6.14.0'
+firebase_sdk_version = '7.7.0'
 if defined? $FirebaseSDKVersion
   firebase_sdk_version = $FirebaseSDKVersion
 end

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXFirebaseCore/ABI40_0_0EXFirebaseCore.podspec
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXFirebaseCore/ABI40_0_0EXFirebaseCore.podspec
@@ -2,7 +2,7 @@ require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
-firebase_sdk_version = '6.14.0'
+firebase_sdk_version = '7.7.0'
 if defined? $FirebaseSDKVersion
   firebase_sdk_version = $FirebaseSDKVersion
 end

--- a/packages/expo-ads-admob/CHANGELOG.md
+++ b/packages/expo-ads-admob/CHANGELOG.md
@@ -4,9 +4,15 @@
 
 ### 🛠 Breaking changes
 
+- Removed the `rewardedVideoWillLeaveApplication` event (use AppState instead)
+- Removed the `rewardedVideoDidStart` event
+
 ### 🎉 New features
 
 - Updated Android build configuration to target Android 11 (added support for Android SDK 30). ([#11647](https://github.com/expo/expo/pull/11647) by [@bbarthec](https://github.com/bbarthec))
+- Upgraded underlying Admob iOS SDK to v7.69.0 & Android SDK to v19.7.0
+- (iOS) Added support for SKAdNetwork(todo)
+- Added the `rewardedVideoDidFailToOpen` event
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-ads-admob/android/build.gradle
+++ b/packages/expo-ads-admob/android/build.gradle
@@ -58,5 +58,9 @@ if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
 
 dependencies {
   unimodule "unimodules-core"
-  api 'com.google.android.gms:play-services-ads:17.2.1'
+  api 'com.google.android.gms:play-services-ads:19.7.0'
+
+  // Required to avoid crash on first launch
+  com.google.android.gms:play-services-measurement:17.0.0
+  com.google.android.gms:play-services-measurement-sdk:17.0.0
 }

--- a/packages/expo-ads-admob/ios/EXAdsAdMob.podspec
+++ b/packages/expo-ads-admob/ios/EXAdsAdMob.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.source         = { git: 'https://github.com/expo/expo.git' }
 
   s.dependency 'UMCore'
-  s.dependency 'Google-Mobile-Ads-SDK', "7.55.1"
+  s.dependency 'Google-Mobile-Ads-SDK', "7.69.0"
 
   if !$ExpoUseSources&.include?(package['name']) && ENV['EXPO_USE_SOURCE'].to_i == 0 && File.exist?("#{s.name}.xcframework") && Gem::Version.new(Pod::VERSION) >= Gem::Version.new('1.10.0')
     s.source_files = "#{s.name}/**/*.h"

--- a/packages/expo-ads-admob/ios/EXAdsAdMob/EXAdsAdMobRewarded.h
+++ b/packages/expo-ads-admob/ios/EXAdsAdMob/EXAdsAdMobRewarded.h
@@ -3,5 +3,5 @@
 #import <UMCore/UMModuleRegistryConsumer.h>
 #import <GoogleMobileAds/GoogleMobileAds.h>
 
-@interface EXAdsAdMobRewarded : UMExportedModule <UMEventEmitter, UMModuleRegistryConsumer, GADRewardBasedVideoAdDelegate>
+@interface EXAdsAdMobRewarded : UMExportedModule <UMEventEmitter, UMModuleRegistryConsumer, GADRewardedAdDelegate>
 @end

--- a/packages/expo-ads-admob/ios/EXAdsAdMob/EXAdsAdMobRewarded.m
+++ b/packages/expo-ads-admob/ios/EXAdsAdMob/EXAdsAdMobRewarded.m
@@ -14,6 +14,7 @@ static NSString *const EXAdsAdMobRewardedDidClose = @"rewardedVideoDidClose";
 
 @property (nonatomic, weak) id<UMEventEmitterService> eventEmitter;
 @property (nonatomic, weak) id<UMUtilitiesInterface> utilities;
+@property (nonatomic, strong) GADRewardedAd* rewardedAd;
 
 @end
 
@@ -88,11 +89,11 @@ UM_EXPORT_METHOD_AS(requestAd,
       [self.rewardedAd loadRequest:request completionHandler:^(GADRequestError * _Nullable error) {
         if (error) {
           [self _maybeSendEventWithName:EXAdsAdMobRewardedDidFailToLoad body:@{ @"name": [error description] }];
-          _requestAdRejecter(@"E_AD_REQUEST_FAILED", [error description], error);
+          self->  _requestAdRejecter(@"E_AD_REQUEST_FAILED", [error description], error);
           [self _cleanupRequestAdPromise];
         } else {
           [self _maybeSendEventWithName:EXAdsAdMobRewardedDidLoad body:nil];
-          _requestAdResolver(nil);
+          self->  _requestAdResolver(nil);
           [self _cleanupRequestAdPromise];
         }
       }];
@@ -111,7 +112,7 @@ UM_EXPORT_METHOD_AS(showAd,
     UM_WEAKIFY(self);
     dispatch_async(dispatch_get_main_queue(), ^{
       UM_ENSURE_STRONGIFY(self);
-      [self.rewardedAd presentFromRootViewController:self.utilities.currentViewController];
+      [self.rewardedAd presentFromRootViewController:self.utilities.currentViewController delegate:self];
     });
   } else if (self.rewardedAd.isReady) {
     reject(@"E_AD_BEING_SHOWN", @"Ad is already being shown, await the previous promise.", nil);

--- a/packages/expo-firebase-analytics/ios/EXFirebaseAnalytics.podspec
+++ b/packages/expo-firebase-analytics/ios/EXFirebaseAnalytics.podspec
@@ -2,7 +2,7 @@ require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, '..', 'package.json')))
 
-firebase_sdk_version = '6.14.0'
+firebase_sdk_version = '7.7.0'
 if defined? $FirebaseSDKVersion
   firebase_sdk_version = $FirebaseSDKVersion
 end

--- a/packages/expo-firebase-core/ios/EXFirebaseCore.podspec
+++ b/packages/expo-firebase-core/ios/EXFirebaseCore.podspec
@@ -2,7 +2,7 @@ require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, '..', 'package.json')))
 
-firebase_sdk_version = '6.14.0'
+firebase_sdk_version = '7.7.0'
 if defined? $FirebaseSDKVersion
   firebase_sdk_version = $FirebaseSDKVersion
 end


### PR DESCRIPTION
# Note

CI will fail for this PR until `expo-face-detector` is upgraded and no longer depends on Firebase

# Why

closes https://github.com/expo/expo/issues/11941
closes https://github.com/expo/expo/issues/11934
maybe more? 

# How

## ios 
followed migration guide on iOS - https://developers.google.com/admob/ios/rewarded-migration?hl=zh-cn

looks through changelog, that's the only breaking change.

oh and 
```
[SKAdNetwork registerAppForAdNetworkAttribution] is now automatically called on first open by default. To opt-out of this default behavior, add the key GOOGLE_ANALYTICS_REGISTRATION_WITH_AD_NETWORK_ENABLED with Boolean value NO to your app’s Info.plist file.
```
but im not 100% sure if we want to opt out of this

we also need to add the SKAdNetwork ID in config plugin // shell app template

## android 

if we have time, still need to:
- Use `RequestConfiguration.Builder.setTestDeviceIds()` instead of `AdRequest.Builder.addTestDevice()` (there was already an existing TODO in there for this)
- replace `RewardedVideoAd` with `RewardedAd`

But those should still work, they're just deprecated

# Test Plan

NCL and test-suite pass
