### PR TITLE
[expo-updates] increase http cache max size to 200MB

### DIFF
--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.java
@@ -67,7 +67,8 @@ public class FileDownloader {
   }
 
   private static Cache getCache(Context context) {
-    int cacheSize = 50 * 1024 * 1024; // 50 MiB
+    // TODO(eric): reduce cache size once we have a confident solution for snack bundles
+    int cacheSize = 200 * 1024 * 1024; // 200 MiB
     return new Cache(getCacheDirectory(context), cacheSize);
   }
 

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.m
@@ -31,6 +31,18 @@ NSTimeInterval const EXUpdatesDefaultTimeoutInterval = 60;
 {
   if (self = [super init]) {
     _sessionConfiguration = sessionConfiguration;
+
+    NSURL *cachesDirectory = [[NSFileManager.defaultManager URLsForDirectory:NSCachesDirectory inDomains:NSUserDomainMask] lastObject];
+    NSURL *cacheDirectory = [cachesDirectory URLByAppendingPathComponent:@"NSURLCache-expo-updates"];
+    BOOL cacheDirectoryExists = [NSFileManager.defaultManager fileExistsAtPath:cacheDirectory.path];
+    if (!cacheDirectoryExists) {
+      cacheDirectoryExists = [NSFileManager.defaultManager createDirectoryAtPath:cacheDirectory.path withIntermediateDirectories:YES attributes:kNilOptions error:nil];
+    }
+    if (cacheDirectoryExists) {
+      // TODO(eric): reduce cache size once we have a confident solution for snack bundles
+      _sessionConfiguration.URLCache = [[NSURLCache alloc] initWithMemoryCapacity:8*1024*1024 diskCapacity:200*1024*1024 directoryURL:cacheDirectory];
+    }
+
     _session = [NSURLSession sessionWithConfiguration:_sessionConfiguration delegate:self delegateQueue:nil];
     _config = updatesConfig;
   }


### PR DESCRIPTION
# Why

Depends on https://github.com/expo/expo/pull/12111

In case implementing `bundleKey` turns out to be difficult on the server side, this is a secondary measure to prevent Expo Go users from requesting the snack JS bundle anew each time they open a new snack. We can reduce the cache size back to 50MB on both platforms once we're confident in the `bundleKey` implementation.

# How

Added a custom NSURLCache on iOS, max memory capacity of 8MB and disk capacity of 200MB.

Bumped Android's OkHttp cache max size to 200MB as well. It looks like 50MB is actually large enough for the snack bundle to be cached; I bumped it to 200 MB anyway to keep parity across platforms.

# Test Plan

Open one snack in Expo Go, use Charles to see cloudfront request for the JS bundle, close app and reopen. Open a different snack and use Charles to verify that there is no additional cloudfront request for the JS bundle (or any other asset).