### PR TITLE
[docs] Change Application Loader links to Transporter

### DIFF
--- a/docs/pages/introduction/walkthrough.md
+++ b/docs/pages/introduction/walkthrough.md
@@ -95,7 +95,7 @@ Now when we run `expo build:ios` it will kick off a build with the Expo build se
 
 > _Note: Running `expo build:[ios/android]` uses the Expo build service &mdash; if you would rather run builds on your own infrastructure, read about how to do this in [Building Standalone Apps on Your CI](../distribution/turtle-cli.md)_
 
-Now you can use [Application Loader](https://help.apple.com/itc/apploader/) to upload the app to App Store Connect, but we find that it’s a bit easier to run `expo upload:ios` instead. Once it's up on App Store Connect, you'll have to do some manual work within their web interface. [Read more about deploying to app stores](../distribution/app-stores.md).
+Now you can use [Transporter](https://apps.apple.com/app/transporter/id1450874784) to upload the app to App Store Connect, but we find that it’s a bit easier to run `expo upload:ios` instead. Once it's up on App Store Connect, you'll have to do some manual work within their web interface. [Read more about deploying to app stores](../distribution/app-stores.md).
 
 <Video file="exploring-managed/uploadios.mp4" spaceAfter />
 

--- a/docs/pages/workflow/already-used-react-native.md
+++ b/docs/pages/workflow/already-used-react-native.md
@@ -48,7 +48,7 @@ Apps are served from Expo CLI through a tunnel service by default (we currently 
 
 ## Deploying to the App / Play Store
 
-When you're ready, you can run `expo build:ios` or `expo build:android` and Expo will build your app and output a link to the binary required for you to submit. Then you can use something like Application Loader for iOS, or directly upload an APK for Android.
+When you're ready, you can run `expo build:ios` or `expo build:android` and Expo will build your app and output a link to the binary required for you to submit. Then you can use something like [Transporter](https://apps.apple.com/app/transporter/id1450874784) for iOS, or directly upload an APK for Android.
 
 If you prefer to build your app on your own machine, you can [follow these steps](https://github.com/expo/expo#standalone-apps).
 


### PR DESCRIPTION
# Why

Application Loader is no longer a thing and has been superseded by Transporter.

Closes ENG-383.

# How

Replace links and link text in documents.

# Test Plan

Inspect.
