### PR TITLE
[Expo Go] Set iOS dev menu above LogBox

### DIFF
--- a/ios/Client/Menu/EXDevMenuWindow.m
+++ b/ios/Client/Menu/EXDevMenuWindow.m
@@ -18,7 +18,8 @@
 {
   if (self = [super init]) {
     // Set it just above the LogBox so users can easily access it.
-    self.windowLevel = UIWindowLevelStatusBar - 0.5;
+    // https://github.com/facebook/react-native/blob/0.64-stable/React/CoreModules/RCTLogBoxView.mm#L38
+    self.windowLevel = UIWindowLevelStatusBar;
     self.backgroundColor = [UIColor clearColor];
     self.bounds = [[UIScreen mainScreen] bounds];
     self.hidden = YES;

--- a/ios/Client/Menu/EXDevMenuWindow.m
+++ b/ios/Client/Menu/EXDevMenuWindow.m
@@ -17,6 +17,8 @@
 - (instancetype)init
 {
   if (self = [super init]) {
+    // Set it just above the LogBox so users can easily access it.
+    self.windowLevel = UIWindowLevelStatusBar - 0.5;
     self.backgroundColor = [UIColor clearColor];
     self.bounds = [[UIScreen mainScreen] bounds];
     self.hidden = YES;


### PR DESCRIPTION
# Why

The LogBox options are unreliable, sometimes I just want to reload the app to get it out of a weird state (often caused by fast refresh). This PR sets the dev menu just barely above the LogBox.

![Simulator Screen Shot - iPhone 12 Pro Max - 2021-03-08 at 22 13 47](https://user-images.githubusercontent.com/9664363/110426831-9b406500-805b-11eb-9a0c-148d74fa4cab.png)

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# Test Plan

- Open the iOS dev menu after opening a warning or error
- Open the iOS dev menu then fast refresh an error in to ensure it comes in behind the dev menu
 
<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->
