### PR TITLE
[docs] ensure that <code> in links is also colored

### DIFF
--- a/docs/components/base/link.tsx
+++ b/docs/components/base/link.tsx
@@ -14,6 +14,10 @@ const STYLES_EXTERNAL_LINK = css`
   :hover {
     text-decoration: underline;
   }
+
+  code {
+    color: ${theme.link.default};
+  }
 `;
 
 function isLinkAbsolute(href?: string) {


### PR DESCRIPTION
# Why

Currently inline code blocks inside link only have the underline effect, which make them harder to differentiate from the usual, non-interactable inline code blocks. Also when Link contains `code` and regular text this looks bit weird.

<img width="782" alt="Screenshot 2021-03-09 103926" src="https://user-images.githubusercontent.com/719641/110450756-ca8abc80-80c3-11eb-97f1-6a5ac9b77ce3.png">

<img width="575" alt="Screenshot 2021-03-09 103951" src="https://user-images.githubusercontent.com/719641/110450846-dd9d8c80-80c3-11eb-8468-52d4ee4c4d5d.png">

# How

This small PR ensures that text in inline code block will also be colored if the block is a part of link. This change also improves a bit readability in those cases.

<img width="720" alt="Screenshot 2021-03-09 103309" src="https://user-images.githubusercontent.com/719641/110450604-a7600d00-80c3-11eb-814a-1d0c3710ac6d.png">

<img width="540" alt="Screenshot 2021-03-09 103104" src="https://user-images.githubusercontent.com/719641/110450612-a929d080-80c3-11eb-9cbe-21091521f313.png">

# Test Plan

Expo Docs run on localhost.

CC: @jonsamp 
