### PR TITLE
Web playback to be inline on all devices

### DIFF
--- a/packages/expo-av/src/ExponentVideo.web.tsx
+++ b/packages/expo-av/src/ExponentVideo.web.tsx
@@ -168,6 +168,7 @@ export default class ExponentVideo extends React.Component<ExponentVideoProps> {
         autoPlay={status.shouldPlay}
         controls={useNativeControls}
         style={[style, customStyle]}
+        playsInline
       />
     );
   }


### PR DESCRIPTION
# Why

By default, the react-native video is played back inline. On the web, it plays back inline as expected, with the exception of Safari iOS, which requires this html attribute. Otherwise the video is played back by default in full screen mode

# How

Simply add the expected html5 attribute specific to webkit

# Test Plan

Run a video on web on android, you will see it play inline. Run the same video on iOS, it will start fullscreen by default.