### PR TITLE
[expo-structured-headers][expo-updates] add missing Foundation imports, fix warnings

### DIFF
--- a/packages/expo-structured-headers/ios/EXStructuredHeaders/EXStructuredHeadersParser.h
+++ b/packages/expo-structured-headers/ios/EXStructuredHeaders/EXStructuredHeadersParser.h
@@ -1,5 +1,7 @@
 //  Copyright © 2021 650 Industries. All rights reserved.
 
+#import <Foundation/Foundation.h>
+
 NS_ASSUME_NONNULL_BEGIN
 
 typedef NS_ENUM(NSInteger, EXStructuredHeadersParserFieldType) {

--- a/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabaseInitialization+Tests.h
+++ b/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabaseInitialization+Tests.h
@@ -10,7 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
                             filename:(NSString *)filename
                          inDirectory:(NSURL *)directory
                        shouldMigrate:(BOOL)shouldMigrate
-                            database:(struct sqlite3 **)database
+                            database:(struct sqlite3 * _Nullable * _Nonnull)database
                                error:(NSError ** _Nullable)error;
 
 @end

--- a/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabaseInitialization.h
+++ b/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabaseInitialization.h
@@ -1,5 +1,6 @@
 // Copyright 2021-present 650 Industries. All rights reserved.
 
+#import <Foundation/Foundation.h>
 #import <sqlite3.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -7,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface EXUpdatesDatabaseInitialization : NSObject
 
 + (BOOL)initializeDatabaseWithLatestSchemaInDirectory:(NSURL *)directory
-                                             database:(struct sqlite3 **)database
+                                             database:(struct sqlite3 * _Nullable * _Nonnull)database
                                                 error:(NSError ** _Nullable)error;
 
 @end

--- a/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabaseInitialization.m
+++ b/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabaseInitialization.m
@@ -57,7 +57,7 @@ CREATE INDEX \"index_json_data_scope_key\" ON \"json_data\" (\"scope_key\")\
 @implementation EXUpdatesDatabaseInitialization
 
 + (BOOL)initializeDatabaseWithLatestSchemaInDirectory:(NSURL *)directory
-                                             database:(struct sqlite3 **)database
+                                             database:(struct sqlite3 * _Nullable * _Nonnull)database
                                                 error:(NSError ** _Nullable)error
 {
   return [[self class] initializeDatabaseWithSchema:EXUpdatesDatabaseInitializationLatestSchema
@@ -72,7 +72,7 @@ CREATE INDEX \"index_json_data_scope_key\" ON \"json_data\" (\"scope_key\")\
                             filename:(NSString *)filename
                          inDirectory:(NSURL *)directory
                        shouldMigrate:(BOOL)shouldMigrate
-                            database:(struct sqlite3 **)database
+                            database:(struct sqlite3 * _Nullable * _Nonnull)database
                                error:(NSError ** _Nullable)error
 {
   sqlite3 *db;
@@ -186,7 +186,7 @@ CREATE INDEX \"index_json_data_scope_key\" ON \"json_data\" (\"scope_key\")\
       return NO;
     }
 
-    for (int i = startingMigrationIndex; i < migrations.count; i++) {
+    for (NSUInteger i = startingMigrationIndex; i < migrations.count; i++) {
       NSError *migrationError;
       id<EXUpdatesDatabaseMigration> migration = migrations[i];
       if (![migration runMigrationOnDatabase:db error:&migrationError]) {

--- a/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabaseUtils.h
+++ b/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabaseUtils.h
@@ -1,5 +1,6 @@
 // Copyright 2021-present 650 Industries. All rights reserved.
 
+#import <Foundation/Foundation.h>
 #import <sqlite3.h>
 
 NS_ASSUME_NONNULL_BEGIN

--- a/packages/expo-updates/ios/EXUpdates/Database/Migrations/EXUpdatesDatabaseMigration.h
+++ b/packages/expo-updates/ios/EXUpdates/Database/Migrations/EXUpdatesDatabaseMigration.h
@@ -1,5 +1,6 @@
 //  Copyright © 2021 650 Industries. All rights reserved.
 
+#import <Foundation/Foundation.h>
 #import <sqlite3.h>
 
 NS_ASSUME_NONNULL_BEGIN


### PR DESCRIPTION
# Why

`et prebuild expo-updates` was broken and blocking publishing.

# How

- Add missing Foundation imports until the prebuild succeeded locally.
- Also fixed a few warnings that were showing up in Xcode. Adding @ide mostly to sanity check that https://github.com/expo/expo/pull/12175/files#diff-8c464989cba1f91a34108b881a5b5744e1b2809a0032266970f4b49856dd681bR13 is correct (the pointer should always be defined, but it can point to `nil`).

# Test Plan

`et prebuild expo-updates` works locally.

cc @brentvatne 
