### PR TITLE
[home] fix polling bug

### DIFF
--- a/home/babel.config.js
+++ b/home/babel.config.js
@@ -2,5 +2,6 @@ module.exports = function(api) {
   api.cache(true);
   return {
     presets: ['babel-preset-expo'],
+    plugins: ['react-native-reanimated/plugin']
   };
 };

--- a/home/screens/ProjectsScreen.tsx
+++ b/home/screens/ProjectsScreen.tsx
@@ -94,7 +94,11 @@ class ProjectsView extends React.Component<Props, State> {
   componentDidMount() {
     AppState.addEventListener('change', this._maybeResumePollingFromAppState);
     Connectivity.addListener(this._updateConnectivity);
-    this._startPollingForProjects();
+
+    // @evanbacon: Without this setTimeout, the state doesn't update correctly and the "Recently in Development" items don't load for 10 seconds.
+    setTimeout(() => {
+      this._startPollingForProjects();
+    }, 1)
 
     // NOTE(brentvatne): if we add QR code button to the menu again, we'll need to
     // find a way to move this listener up to the root of the app in order to ensure
@@ -193,7 +197,7 @@ class ProjectsView extends React.Component<Props, State> {
   };
 
   private _startPollingForProjects = async () => {
-    this._handleRefreshAsync();
+    this._fetchProjectsAsync();
     this._projectPolling = setInterval(this._fetchProjectsAsync, PROJECT_UPDATE_INTERVAL);
   };
 

--- a/home/screens/ProjectsScreen.tsx
+++ b/home/screens/ProjectsScreen.tsx
@@ -98,7 +98,7 @@ class ProjectsView extends React.Component<Props, State> {
     // @evanbacon: Without this setTimeout, the state doesn't update correctly and the "Recently in Development" items don't load for 10 seconds.
     setTimeout(() => {
       this._startPollingForProjects();
-    }, 1)
+    }, 1);
 
     // NOTE(brentvatne): if we add QR code button to the menu again, we'll need to
     // find a way to move this listener up to the root of the app in order to ensure


### PR DESCRIPTION
# Why

- Fix reanimated bug that gets thrown whenever you load home in dev
- Fix loading bug where the app doesn't fetch "recently in development" correctly.
- Also silently polling for apps without randomly pushing content down every time the app state changes and on initial load.

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# Test Plan

- `expo start` in home.
- was able to repro the issues locally in home, so it was clear that the solutions fixed the problems.
