### PR TITLE
[docs] RightSidebar: apply text overflow styles only for code entries

### DIFF
--- a/docs/components/DocumentationSidebarRightLink.tsx
+++ b/docs/components/DocumentationSidebarRightLink.tsx
@@ -14,9 +14,6 @@ const STYLES_LINK = css`
   font-size: 14px;
   display: block;
   text-decoration: none;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
   margin-bottom: 6px;
   cursor: pointer;
 
@@ -32,6 +29,9 @@ const STYLES_LINK_HEADER = css`
 const STYLES_LINK_CODE = css`
   font-family: ${Constants.fontFamilies.mono};
   font-size: 13px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 `;
 
 const STYLES_LINK_ACTIVE = css`

--- a/docs/components/__snapshots__/DocumentationSidebarRight.test.tsx.snap
+++ b/docs/components/__snapshots__/DocumentationSidebarRight.test.tsx.snap
@@ -7,21 +7,21 @@ exports[`DocumentationSidebarRight correctly matches snapshot 1`] = `
     data-sidebar="true"
   >
     <a
-      class="css-3c5o2t-paragraph-paragraph-STYLES_LINK-STYLES_LINK-STYLES_LINK_HEADER-STYLES_LINK_HEADER-DocumentationSidebarRightLink"
+      class="css-y27z9n-paragraph-paragraph-STYLES_LINK-STYLES_LINK-STYLES_LINK_HEADER-STYLES_LINK_HEADER-DocumentationSidebarRightLink"
       href="#base-level-heading"
       style="padding-left: 0px;"
     >
       Base level heading
     </a>
     <a
-      class="css-m8neqe-paragraph-paragraph-STYLES_LINK-STYLES_LINK-DocumentationSidebarRightLink"
+      class="css-1eohbq0-paragraph-paragraph-STYLES_LINK-STYLES_LINK-DocumentationSidebarRightLink"
       href="#level-3-subheading"
       style="padding-left: 16px;"
     >
       Level 3 subheading
     </a>
     <a
-      class="css-3zt0fh-paragraph-paragraph-STYLES_LINK-STYLES_LINK-STYLES_LINK_CODE-STYLES_LINK_CODE-DocumentationSidebarRightLink"
+      class="css-r8pn8j-paragraph-paragraph-STYLES_LINK-STYLES_LINK-STYLES_LINK_CODE-STYLES_LINK_CODE-DocumentationSidebarRightLink"
       href="#code-heading-depth-1"
       style="padding-left: 16px;"
     >


### PR DESCRIPTION
# Why

Currently long page headers, which are a part of right sidebar, are prevented from line break. This mitigation was probably added to prevent overflow issues when a long method or type name was listed in API reference, however in case of regular headers there should not be any contraindications to let the break line (just like titles on the left sidebar).

### Preview

<img width="1278" alt="Screenshot 2021-03-10 at 16 01 43" src="https://user-images.githubusercontent.com/719641/110650408-d016fe00-81ba-11eb-878e-db765d1ecf6f.png">

# How

This small PR moves the overflow styles from all right sidebar entries, just to the code ones. Fortunately detection was already there so it's just a matter of small CSS change.

### Preview

<img width="1278" alt="Screenshot 2021-03-10 at 16 01 47" src="https://user-images.githubusercontent.com/719641/110650927-43b90b00-81bb-11eb-91e0-9653bc3a7ea7.png">

#### Second screen shows confirmation that overflow is correctly handled for the code entries:

<img width="1275" alt="Screenshot 2021-03-10 at 16 13 15" src="https://user-images.githubusercontent.com/719641/110651309-9e526700-81bb-11eb-9cbe-240156cc3e9d.png">

CC @jonsamp 

# Test Plan

I have tested the change on `localhost`.