### PR TITLE
[expo-updates][android] remove UPDATES_CONFIGURATION_USES_LEGACY_MANIFEST_KEY constant

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- remove UPDATES_CONFIGURATION_USES_LEGACY_MANIFEST_KEY constant. ([#12181](https://github.com/expo/expo/pull/12181) by [@jkhales](https://github.com/jkhales))
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes
@@ -17,8 +19,6 @@
 ### 🛠 Breaking changes
 
 - Dropped support for iOS 10.0 ([#11344](https://github.com/expo/expo/pull/11344) by [@tsapeta](https://github.com/tsapeta))
-- remove UPDATES_CONFIGURATION_USES_LEGACY_MANIFEST_KEY constant. ([#12181](https://github.com/expo/expo/pull/12181) by [@jkhales](https://github.com/jkhales))
-
 
 ### 🎉 New features
 

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -17,6 +17,8 @@
 ### 🛠 Breaking changes
 
 - Dropped support for iOS 10.0 ([#11344](https://github.com/expo/expo/pull/11344) by [@tsapeta](https://github.com/tsapeta))
+- remove UPDATES_CONFIGURATION_USES_LEGACY_MANIFEST_KEY constant. ([#12181](https://github.com/expo/expo/pull/12181) by [@jkhales](https://github.com/jkhales))
+
 
 ### 🎉 New features
 

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/FileDownloaderTest.java
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/FileDownloaderTest.java
@@ -28,30 +28,6 @@ public class FileDownloaderTest {
   }
 
   @Test
-  public void testCacheControl_LegacyManifest() {
-    HashMap<String, Object> configMap = new HashMap<>();
-    configMap.put("updateUrl", Uri.parse("https://exp.host/@test/test"));
-    configMap.put("runtimeVersion", "1.0");
-    configMap.put("usesLegacyManifest", true);
-    UpdatesConfiguration config = new UpdatesConfiguration().loadValuesFromMap(configMap);
-
-    Request actual = FileDownloader.setHeadersForManifestUrl(config, null, context);
-    Assert.assertEquals("no-cache", actual.header("Cache-Control"));
-  }
-
-  @Test
-  public void testCacheControl_NewManifest() {
-    HashMap<String, Object> configMap = new HashMap<>();
-    configMap.put("updateUrl", Uri.parse("https://exp.host/manifest/00000000-0000-0000-0000-000000000000"));
-    configMap.put("runtimeVersion", "1.0");
-    configMap.put("usesLegacyManifest", false);
-    UpdatesConfiguration config = new UpdatesConfiguration().loadValuesFromMap(configMap);
-
-    Request actual = FileDownloader.setHeadersForManifestUrl(config, null, context);
-    Assert.assertNull(actual.header("Cache-Control"));
-  }
-
-  @Test
   public void testExtraHeaders_ObjectTypes() throws JSONException {
     HashMap<String, Object> configMap = new HashMap<>();
     configMap.put("updateUrl", Uri.parse("https://exp.host/manifest/00000000-0000-0000-0000-000000000000"));

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/FileDownloaderTest.java
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/FileDownloaderTest.java
@@ -28,6 +28,30 @@ public class FileDownloaderTest {
   }
 
   @Test
+  public void testCacheControl_LegacyManifest() {
+    HashMap<String, Object> configMap = new HashMap<>();
+    configMap.put("updateUrl", Uri.parse("https://exp.host/@test/test"));
+    configMap.put("runtimeVersion", "1.0");
+    configMap.put("usesLegacyManifest", true);
+    UpdatesConfiguration config = new UpdatesConfiguration().loadValuesFromMap(configMap);
+
+    Request actual = FileDownloader.setHeadersForManifestUrl(config, null, context);
+    Assert.assertNull(actual.header("Cache-Control"));
+  }
+
+  @Test
+  public void testCacheControl_NewManifest() {
+    HashMap<String, Object> configMap = new HashMap<>();
+    configMap.put("updateUrl", Uri.parse("https://exp.host/manifest/00000000-0000-0000-0000-000000000000"));
+    configMap.put("runtimeVersion", "1.0");
+    configMap.put("usesLegacyManifest", false);
+    UpdatesConfiguration config = new UpdatesConfiguration().loadValuesFromMap(configMap);
+
+    Request actual = FileDownloader.setHeadersForManifestUrl(config, null, context);
+    Assert.assertNull(actual.header("Cache-Control"));
+  }
+
+  @Test
   public void testExtraHeaders_ObjectTypes() throws JSONException {
     HashMap<String, Object> configMap = new HashMap<>();
     configMap.put("updateUrl", Uri.parse("https://exp.host/manifest/00000000-0000-0000-0000-000000000000"));

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/manifest/ManifestFactoryTest.java
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/manifest/ManifestFactoryTest.java
@@ -10,6 +10,7 @@ import org.junit.runner.RunWith;
 
 import java.util.HashMap;
 
+import androidx.room.Update;
 import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner;
 import expo.modules.updates.UpdatesConfiguration;
 
@@ -17,13 +18,12 @@ import expo.modules.updates.UpdatesConfiguration;
 public class ManifestFactoryTest {
 
   private String legacyManifestJson = "{\"sdkVersion\":\"39.0.0\",\"id\":\"@esamelson/native-component-list\",\"releaseId\":\"0eef8214-4833-4089-9dff-b4138a14f196\",\"commitTime\":\"2020-11-11T00:17:54.797Z\",\"bundleUrl\":\"https://d1wp6m56sqw74a.cloudfront.net/%40esamelson%2Fnative-component-list%2F39.0.0%2F01c86fd863cfee878068eebd40f165df-39.0.0-ios.js\"}";
-  private String newManifestJson = "{\"manifest\":{\"runtimeVersion\":\"1\",\"id\":\"0eef8214-4833-4089-9dff-b4138a14f196\",\"createdAt\":\"2020-11-11T00:17:54.797Z\",\"launchAsset\":{\"url\":\"https://d1wp6m56sqw74a.cloudfront.net/%40esamelson%2Fnative-component-list%2F39.0.0%2F01c86fd863cfee878068eebd40f165df-39.0.0-ios.js\",\"contentType\":\"application/javascript\"}}}";
+  private String newManifestJson = "{\"runtimeVersion\":\"1\",\"id\":\"0eef8214-4833-4089-9dff-b4138a14f196\",\"createdAt\":\"2020-11-11T00:17:54.797Z\",\"launchAsset\":{\"url\":\"https://d1wp6m56sqw74a.cloudfront.net/%40esamelson%2Fnative-component-list%2F39.0.0%2F01c86fd863cfee878068eebd40f165df-39.0.0-ios.js\",\"contentType\":\"application/javascript\"}}";
   private String bareManifestJson = "{\"id\":\"0eef8214-4833-4089-9dff-b4138a14f196\",\"commitTime\":1609975977832}";
 
-  private UpdatesConfiguration createConfig(boolean usesLegacyManifest) {
+  private UpdatesConfiguration createConfig() {
     HashMap<String, Object> configMap = new HashMap<>();
     configMap.put("updateUrl", Uri.parse("https://exp.host/@esamelson/native-component-list"));
-    configMap.put("usesLegacyManifest", usesLegacyManifest);
     return new UpdatesConfiguration().loadValuesFromMap(configMap);
   }
 
@@ -32,18 +32,21 @@ public class ManifestFactoryTest {
     Manifest actual = ManifestFactory.getManifest(
       new JSONObject(legacyManifestJson),
       null,
-      createConfig(true)
+      createConfig()
     );
     Assert.assertTrue(actual instanceof LegacyManifest);
   }
 
   @Test
   public void testGetManifest_New() throws JSONException {
+    UpdatesConfiguration config = createConfig();
+    config.setUsesLegacyManifest(false);
     Manifest actual = ManifestFactory.getManifest(
       new JSONObject(newManifestJson),
       null,
-      createConfig(false)
+      config
     );
+
     Assert.assertTrue(actual instanceof NewManifest);
   }
 
@@ -51,7 +54,7 @@ public class ManifestFactoryTest {
   public void testGetEmbeddedManifest_Legacy() throws JSONException {
     Manifest actual = ManifestFactory.getEmbeddedManifest(
       new JSONObject(legacyManifestJson),
-      createConfig(true)
+      createConfig()
     );
     Assert.assertTrue(actual instanceof LegacyManifest);
   }
@@ -60,25 +63,7 @@ public class ManifestFactoryTest {
   public void testGetEmbeddedManifest_Legacy_Bare() throws JSONException {
     Manifest actual = ManifestFactory.getEmbeddedManifest(
       new JSONObject(bareManifestJson),
-      createConfig(true)
-    );
-    Assert.assertTrue(actual instanceof BareManifest);
-  }
-
-  @Test
-  public void testGetEmbeddedManifest_New() throws JSONException {
-    Manifest actual = ManifestFactory.getEmbeddedManifest(
-      new JSONObject(newManifestJson),
-      createConfig(false)
-    );
-    Assert.assertTrue(actual instanceof NewManifest);
-  }
-
-  @Test
-  public void testGetEmbeddedManifest_New_Bare() throws JSONException {
-    Manifest actual = ManifestFactory.getEmbeddedManifest(
-      new JSONObject(bareManifestJson),
-      createConfig(false)
+      createConfig()
     );
     Assert.assertTrue(actual instanceof BareManifest);
   }

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/manifest/ManifestFactoryTest.java
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/manifest/ManifestFactoryTest.java
@@ -10,7 +10,6 @@ import org.junit.runner.RunWith;
 
 import java.util.HashMap;
 
-import androidx.room.Update;
 import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner;
 import expo.modules.updates.UpdatesConfiguration;
 

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/manifest/ManifestFactoryTest.java
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/manifest/ManifestFactoryTest.java
@@ -13,6 +13,9 @@ import java.util.HashMap;
 import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner;
 import expo.modules.updates.UpdatesConfiguration;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 @RunWith(AndroidJUnit4ClassRunner.class)
 public class ManifestFactoryTest {
 
@@ -28,9 +31,12 @@ public class ManifestFactoryTest {
 
   @Test
   public void testGetManifest_Legacy() throws JSONException {
+    ManifestResponse response = mock(ManifestResponse.class);
+    when(response.header("expo-protocol-version")).thenReturn(null);
+
     Manifest actual = ManifestFactory.getManifest(
       new JSONObject(legacyManifestJson),
-      null,
+      response,
       createConfig()
     );
     Assert.assertTrue(actual instanceof LegacyManifest);
@@ -38,15 +44,28 @@ public class ManifestFactoryTest {
 
   @Test
   public void testGetManifest_New() throws JSONException {
-    UpdatesConfiguration config = createConfig();
-    config.setUsesLegacyManifest(false);
+    ManifestResponse response = mock(ManifestResponse.class);
+    when(response.header("expo-protocol-version")).thenReturn("0");
+
     Manifest actual = ManifestFactory.getManifest(
       new JSONObject(newManifestJson),
-      null,
-      config
+      response,
+      createConfig()
     );
 
     Assert.assertTrue(actual instanceof NewManifest);
+  }
+
+  @Test(expected = Error.class)
+  public void testGetManifest_Error() throws JSONException {
+    ManifestResponse response = mock(ManifestResponse.class);
+    when(response.header("expo-protocol-version")).thenReturn("1");
+
+    ManifestFactory.getManifest(
+      new JSONObject(newManifestJson),
+      response,
+      createConfig()
+    );
   }
 
   @Test

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/manifest/ManifestFactoryTest.java
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/manifest/ManifestFactoryTest.java
@@ -56,8 +56,8 @@ public class ManifestFactoryTest {
     Assert.assertTrue(actual instanceof NewManifest);
   }
 
-  @Test(expected = Error.class)
-  public void testGetManifest_Error() throws JSONException {
+  @Test(expected = Exception.class)
+  public void testGetManifest_UnsupportedProtocolVersion() throws JSONException {
     ManifestResponse response = mock(ManifestResponse.class);
     when(response.header("expo-protocol-version")).thenReturn("1");
 

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/manifest/ManifestFactoryTest.java
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/manifest/ManifestFactoryTest.java
@@ -32,7 +32,7 @@ public class ManifestFactoryTest {
   @Test
   public void testGetManifest_Legacy() throws Exception {
     ManifestResponse response = mock(ManifestResponse.class);
-    when(response.header("expo-protocol-version")).thenReturn(null);
+    when(response.header("expo-protocol-version", null)).thenReturn(null);
 
     Manifest actual = ManifestFactory.getManifest(
       new JSONObject(legacyManifestJson),
@@ -59,6 +59,7 @@ public class ManifestFactoryTest {
   @Test(expected = Exception.class)
   public void testGetManifest_UnsupportedProtocolVersion() throws Exception {
     ManifestResponse response = mock(ManifestResponse.class);
+    when(response.header("expo-protocol-version", null)).thenReturn("1");
 
     ManifestFactory.getManifest(
       new JSONObject(newManifestJson),

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/manifest/ManifestFactoryTest.java
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/manifest/ManifestFactoryTest.java
@@ -30,7 +30,7 @@ public class ManifestFactoryTest {
   }
 
   @Test
-  public void testGetManifest_Legacy() throws JSONException {
+  public void testGetManifest_Legacy() throws Exception {
     ManifestResponse response = mock(ManifestResponse.class);
     when(response.header("expo-protocol-version")).thenReturn(null);
 
@@ -43,9 +43,9 @@ public class ManifestFactoryTest {
   }
 
   @Test
-  public void testGetManifest_New() throws JSONException {
+  public void testGetManifest_New() throws Exception {
     ManifestResponse response = mock(ManifestResponse.class);
-    when(response.header("expo-protocol-version")).thenReturn("0");
+    when(response.header("expo-protocol-version", null)).thenReturn("0");
 
     Manifest actual = ManifestFactory.getManifest(
       new JSONObject(newManifestJson),
@@ -57,9 +57,8 @@ public class ManifestFactoryTest {
   }
 
   @Test(expected = Exception.class)
-  public void testGetManifest_UnsupportedProtocolVersion() throws JSONException {
+  public void testGetManifest_UnsupportedProtocolVersion() throws Exception {
     ManifestResponse response = mock(ManifestResponse.class);
-    when(response.header("expo-protocol-version")).thenReturn("1");
 
     ManifestFactory.getManifest(
       new JSONObject(newManifestJson),

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesConfiguration.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesConfiguration.java
@@ -46,7 +46,6 @@ public class UpdatesConfiguration {
   private int mLaunchWaitMs = UPDATES_CONFIGURATION_LAUNCH_WAIT_MS_DEFAULT_VALUE;
   private CheckAutomaticallyConfiguration mCheckOnLaunch = CheckAutomaticallyConfiguration.ALWAYS;
   private boolean mHasEmbeddedUpdate = true;
-  private boolean mUsesLegacyManifest = true;
 
   public boolean isEnabled() {
     return mIsEnabled;
@@ -99,10 +98,6 @@ public class UpdatesConfiguration {
     return mHasEmbeddedUpdate;
   }
 
-  public boolean usesLegacyManifest() {
-    return mUsesLegacyManifest;
-  }
-
   public UpdatesConfiguration loadValuesFromMetadata(Context context) {
     try {
       ApplicationInfo ai = context.getPackageManager().getApplicationInfo(context.getPackageName(), PackageManager.GET_META_DATA);
@@ -134,10 +129,6 @@ public class UpdatesConfiguration {
       Log.e(TAG, "Could not read expo-updates configuration data in AndroidManifest", e);
     }
     return this;
-  }
-
-  public void setUsesLegacyManifest(Boolean usesLegacyManifest) {
-    mUsesLegacyManifest = usesLegacyManifest;
   }
 
   public UpdatesConfiguration loadValuesFromMap(Map<String, Object> map) {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesConfiguration.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesConfiguration.java
@@ -25,7 +25,6 @@ public class UpdatesConfiguration {
   public static final String UPDATES_CONFIGURATION_CHECK_ON_LAUNCH_KEY = "checkOnLaunch";
   public static final String UPDATES_CONFIGURATION_LAUNCH_WAIT_MS_KEY = "launchWaitMs";
   public static final String UPDATES_CONFIGURATION_HAS_EMBEDDED_UPDATE_KEY = "hasEmbeddedUpdate";
-  public static final String UPDATES_CONFIGURATION_USES_LEGACY_MANIFEST_KEY = "usesLegacyManifest";
 
   private static final String UPDATES_CONFIGURATION_RELEASE_CHANNEL_DEFAULT_VALUE = "default";
   private static final int UPDATES_CONFIGURATION_LAUNCH_WAIT_MS_DEFAULT_VALUE = 0;
@@ -117,7 +116,6 @@ public class UpdatesConfiguration {
       mSdkVersion = ai.metaData.getString("expo.modules.updates.EXPO_SDK_VERSION");
       mReleaseChannel = ai.metaData.getString("expo.modules.updates.EXPO_RELEASE_CHANNEL", "default");
       mLaunchWaitMs = ai.metaData.getInt("expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS", 0);
-      mUsesLegacyManifest = ai.metaData.getBoolean("expo.modules.updates.EXPO_LEGACY_MANIFEST", true);
 
       Object runtimeVersion = ai.metaData.get("expo.modules.updates.EXPO_RUNTIME_VERSION");
       mRuntimeVersion = runtimeVersion == null ? null : String.valueOf(runtimeVersion);
@@ -136,6 +134,10 @@ public class UpdatesConfiguration {
       Log.e(TAG, "Could not read expo-updates configuration data in AndroidManifest", e);
     }
     return this;
+  }
+
+  public void setUsesLegacyManifest(Boolean usesLegacyManifest) {
+    mUsesLegacyManifest = usesLegacyManifest;
   }
 
   public UpdatesConfiguration loadValuesFromMap(Map<String, Object> map) {
@@ -199,11 +201,6 @@ public class UpdatesConfiguration {
     Boolean hasEmbeddedUpdateFromMap = readValueCheckingType(map, UPDATES_CONFIGURATION_HAS_EMBEDDED_UPDATE_KEY, Boolean.class);
     if (hasEmbeddedUpdateFromMap != null) {
       mHasEmbeddedUpdate = hasEmbeddedUpdateFromMap;
-    }
-
-    Boolean usesLegacyManifestFromMap = readValueCheckingType(map, UPDATES_CONFIGURATION_USES_LEGACY_MANIFEST_KEY, Boolean.class);
-    if (usesLegacyManifestFromMap != null) {
-      mUsesLegacyManifest = usesLegacyManifestFromMap;
     }
 
     return this;

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.java
@@ -118,6 +118,9 @@ public class FileDownloader {
           }
 
           try {
+            String expoProtocolVersion = response.header("expo-protocol-version", null);
+            configuration.setUsesLegacyManifest(expoProtocolVersion == null);
+
             String updateResponseBody = response.body().string();
             JSONObject updateResponseJson = extractUpdateResponseJson(updateResponseBody, configuration);
 
@@ -311,11 +314,6 @@ public class FileDownloader {
             .header("Expo-Updates-Environment", "BARE")
             .header("Expo-JSON-Error", "true")
             .header("Expo-Accept-Signature", String.valueOf(configuration.expectsSignedManifest()));
-
-    // legacy manifest loads should ignore cache-control headers from the server and always load remotely
-    if (configuration.usesLegacyManifest()) {
-      requestBuilder = requestBuilder.cacheControl(CacheControl.FORCE_NETWORK);
-    }
 
     String runtimeVersion = configuration.getRuntimeVersion();
     String sdkVersion = configuration.getSdkVersion();

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.java
@@ -118,9 +118,6 @@ public class FileDownloader {
           }
 
           try {
-            String expoProtocolVersion = response.header("expo-protocol-version", null);
-            configuration.setUsesLegacyManifest(expoProtocolVersion == null);
-
             String updateResponseBody = response.body().string();
             JSONObject updateResponseJson = extractUpdateResponseJson(updateResponseBody, configuration);
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.java
@@ -155,7 +155,7 @@ public class FileDownloader {
                       if (isValid) {
                         try {
                           createManifest(preManifest, response, true, configuration, callback);
-                        } catch (JSONException e) {
+                        } catch (Exception e) {
                           callback.onFailure("Failed to parse manifest data", e);
                         }
                       } else {
@@ -183,7 +183,7 @@ public class FileDownloader {
     boolean isVerified,
     UpdatesConfiguration configuration,
     ManifestDownloadCallback callback
-  ) throws JSONException {
+  ) throws Exception {
     if (configuration.expectsSignedManifest()) {
       preManifest.put("isVerified", isVerified);
     }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ManifestFactory.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ManifestFactory.java
@@ -18,10 +18,19 @@ public class ManifestFactory {
   }
 
   public static Manifest getEmbeddedManifest(JSONObject manifestJson, UpdatesConfiguration configuration) throws JSONException {
-    if (manifestJson.has("releaseId")) {
-      return LegacyManifest.fromLegacyManifestJson(manifestJson, configuration);
+    if (configuration.usesLegacyManifest()) {
+      if (manifestJson.has("releaseId")) {
+        return LegacyManifest.fromLegacyManifestJson(manifestJson, configuration);
+      } else {
+        return BareManifest.fromManifestJson(manifestJson, configuration);
+      }
     } else {
-      return BareManifest.fromManifestJson(manifestJson, configuration);
+      // bare (embedded) manifests should never have a runtimeVersion field
+      if (manifestJson.has("manifest") || manifestJson.has("runtimeVersion")) {
+        return NewManifest.fromManifestJson(manifestJson, null, configuration);
+      } else {
+        return BareManifest.fromManifestJson(manifestJson, configuration);
+      }
     }
   }
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ManifestFactory.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ManifestFactory.java
@@ -14,7 +14,7 @@ public class ManifestFactory {
 
     if (expoProtocolVersion == null) {
       return LegacyManifest.fromLegacyManifestJson(manifestJson, configuration);
-    } else if ( Integer.valueOf(expoProtocolVersion) == 0) {
+    } else if (Integer.valueOf(expoProtocolVersion) == 0) {
       return NewManifest.fromManifestJson(manifestJson, httpResponse, configuration);
     } else {
       throw new Exception("Unsupported expo-protocol-version: " + expoProtocolVersion);

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ManifestFactory.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ManifestFactory.java
@@ -10,10 +10,14 @@ public class ManifestFactory {
   private static final String TAG = ManifestFactory.class.getSimpleName();
 
   public static Manifest getManifest(JSONObject manifestJson, ManifestResponse httpResponse, UpdatesConfiguration configuration) throws JSONException {
-    if (configuration.usesLegacyManifest()) {
+    String expoProtocolVersion = httpResponse.header("expo-protocol-version");
+
+    if (expoProtocolVersion == null) {
       return LegacyManifest.fromLegacyManifestJson(manifestJson, configuration);
-    } else {
+    } else if (expoProtocolVersion == "0") {
       return NewManifest.fromManifestJson(manifestJson, httpResponse, configuration);
+    } else {
+      throw new Error("Unsupported expo-protocol-version: " + expoProtocolVersion);
     }
   }
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ManifestFactory.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ManifestFactory.java
@@ -14,7 +14,7 @@ public class ManifestFactory {
 
     if (expoProtocolVersion == null) {
       return LegacyManifest.fromLegacyManifestJson(manifestJson, configuration);
-    } else if (expoProtocolVersion == "0") {
+    } else if ( Integer.valueOf(expoProtocolVersion) == 0) {
       return NewManifest.fromManifestJson(manifestJson, httpResponse, configuration);
     } else {
       throw new Error("Unsupported expo-protocol-version: " + expoProtocolVersion);

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ManifestFactory.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ManifestFactory.java
@@ -17,7 +17,7 @@ public class ManifestFactory {
     } else if ( Integer.valueOf(expoProtocolVersion) == 0) {
       return NewManifest.fromManifestJson(manifestJson, httpResponse, configuration);
     } else {
-      throw new Error("Unsupported expo-protocol-version: " + expoProtocolVersion);
+      throw new Exception("Unsupported expo-protocol-version: " + expoProtocolVersion);
     }
   }
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ManifestFactory.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ManifestFactory.java
@@ -18,19 +18,10 @@ public class ManifestFactory {
   }
 
   public static Manifest getEmbeddedManifest(JSONObject manifestJson, UpdatesConfiguration configuration) throws JSONException {
-    if (configuration.usesLegacyManifest()) {
-      if (manifestJson.has("releaseId")) {
-        return LegacyManifest.fromLegacyManifestJson(manifestJson, configuration);
-      } else {
-        return BareManifest.fromManifestJson(manifestJson, configuration);
-      }
+    if (manifestJson.has("releaseId")) {
+      return LegacyManifest.fromLegacyManifestJson(manifestJson, configuration);
     } else {
-      // bare (embedded) manifests should never have a runtimeVersion field
-      if (manifestJson.has("manifest") || manifestJson.has("runtimeVersion")) {
-        return NewManifest.fromManifestJson(manifestJson, null, configuration);
-      } else {
-        return BareManifest.fromManifestJson(manifestJson, configuration);
-      }
+      return BareManifest.fromManifestJson(manifestJson, configuration);
     }
   }
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ManifestFactory.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ManifestFactory.java
@@ -9,8 +9,8 @@ public class ManifestFactory {
 
   private static final String TAG = ManifestFactory.class.getSimpleName();
 
-  public static Manifest getManifest(JSONObject manifestJson, ManifestResponse httpResponse, UpdatesConfiguration configuration) throws JSONException {
-    String expoProtocolVersion = httpResponse.header("expo-protocol-version");
+  public static Manifest getManifest(JSONObject manifestJson, ManifestResponse httpResponse, UpdatesConfiguration configuration) throws Exception {
+    String expoProtocolVersion = httpResponse.header("expo-protocol-version", null);
 
     if (expoProtocolVersion == null) {
       return LegacyManifest.fromLegacyManifestJson(manifestJson, configuration);

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ManifestResponse.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ManifestResponse.java
@@ -1,5 +1,6 @@
 package expo.modules.updates.manifest;
 
+import androidx.annotation.Nullable;
 import okhttp3.Response;
 
 /**
@@ -18,6 +19,7 @@ public class ManifestResponse {
     return mResponse.header(name);
   }
 
+  @Nullable
   public String header(String name, String defaultValue) {
     return mResponse.header(name, defaultValue);
   }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ManifestResponse.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ManifestResponse.java
@@ -17,7 +17,7 @@ public class ManifestResponse {
 
   @Nullable
   public String header(String name) {
-    return this.header(name,null);
+    return mResponse.header(name);
   }
 
   @Nullable

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ManifestResponse.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ManifestResponse.java
@@ -15,6 +15,10 @@ public class ManifestResponse {
   }
 
   public String header(String name) {
-    return mResponse.header(name, null);
+    return mResponse.header(name);
+  }
+
+  public String header(String name, String defaultValue) {
+    return mResponse.header(name, defaultValue);
   }
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ManifestResponse.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ManifestResponse.java
@@ -15,6 +15,6 @@ public class ManifestResponse {
   }
 
   public String header(String name) {
-    return mResponse.header(name);
+    return mResponse.header(name, null);
   }
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ManifestResponse.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ManifestResponse.java
@@ -15,8 +15,9 @@ public class ManifestResponse {
     mResponse = response;
   }
 
+  @Nullable
   public String header(String name) {
-    return mResponse.header(name);
+    return this.header(name,null);
   }
 
   @Nullable


### PR DESCRIPTION
# Why

Remove UPDATES_CONFIGURATION_USES_LEGACY_MANIFEST_KEY to make setup easier. 

We check for `expo-protocol-version` instead and use the legacy manifest only if it is undefined. Legacy manifests are in some sense 'protocol version: `null`'

# How

There were 3 places that `useLegacyManifest` was called.

1. after downloading a manifest (no change needed)

However the other two were problematic as they did not assume an http response and thus a chance to check its headers:

2. when loading an embedded manifest (removed check, was unnecessary)
3. when making query headers (removed cache-control header and made it so that the server set these instead: https://github.com/expo/universe/pull/7121)

# Test Plan

Tested both new and legacy updates still work.

Deleted deprecated tests and added a new one for protocol error.
