### PR TITLE
[iOS][face-detector] Explicitly add missing native transitive dependencies

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -76,6 +76,9 @@ PODS:
     - UMPermissionsInterface
   - EXFaceDetector (10.0.0):
     - GoogleMLKit/FaceDetection (= 2.1.0)
+    - MLKitCommon (= 2.1.0)
+    - MLKitFaceDetection (= 1.2.0)
+    - MLKitVision (= 1.2.0)
     - UMCore
     - UMFaceDetectorInterface
     - UMFileSystemInterface
@@ -1241,7 +1244,7 @@ SPEC CHECKSUMS:
   EXDocumentPicker: 5b10e7ee57c0877738e89fdfc96ba91412834a58
   EXErrorRecovery: 720641265b8cf95e6cdeb1884ac38e794a352488
   EXFacebook: 19557469cf50cdfc844eabb14e5518db802d1130
-  EXFaceDetector: 23af13bb3329433e6422c9308388adc1699ec25a
+  EXFaceDetector: e496dcad8dee006c45b39b7d958f8c2241857a65
   EXFileSystem: b0f2bd62531acb3bc6541a5121f0b1338aaee34f
   EXFirebaseAnalytics: 0c5a4572e4ec16d188770cdb58f75818b5e2c719
   EXFirebaseCore: 7865e37021ddcff5c575a4598686a2939d6c4183

--- a/ios/Exponent.xcodeproj/project.pbxproj
+++ b/ios/Exponent.xcodeproj/project.pbxproj
@@ -5,6 +5,7 @@
 	};
 	objectVersion = 46;
 	objects = {
+
 /* Begin PBXBuildFile section */
 		0726F0592007E438004992E7 /* EXKernelAppRecord.m in Sources */ = {isa = PBXBuildFile; fileRef = 0726F0582007E438004992E7 /* EXKernelAppRecord.m */; };
 		0726F05C2007E446004992E7 /* EXKernelAppRegistry.m in Sources */ = {isa = PBXBuildFile; fileRef = 0726F05B2007E446004992E7 /* EXKernelAppRegistry.m */; };

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1717,6 +1717,9 @@ PODS:
     - UMPermissionsInterface
   - EXFaceDetector (10.0.0):
     - GoogleMLKit/FaceDetection (= 2.1.0)
+    - MLKitCommon (= 2.1.0)
+    - MLKitFaceDetection (= 1.2.0)
+    - MLKitVision (= 1.2.0)
     - UMCore
     - UMFaceDetectorInterface
     - UMFileSystemInterface
@@ -3928,7 +3931,7 @@ SPEC CHECKSUMS:
   EXDocumentPicker: 5b10e7ee57c0877738e89fdfc96ba91412834a58
   EXErrorRecovery: 720641265b8cf95e6cdeb1884ac38e794a352488
   EXFacebook: 19557469cf50cdfc844eabb14e5518db802d1130
-  EXFaceDetector: 23af13bb3329433e6422c9308388adc1699ec25a
+  EXFaceDetector: e496dcad8dee006c45b39b7d958f8c2241857a65
   EXFileSystem: b0f2bd62531acb3bc6541a5121f0b1338aaee34f
   EXFirebaseAnalytics: 0c5a4572e4ec16d188770cdb58f75818b5e2c719
   EXFirebaseCore: 7865e37021ddcff5c575a4598686a2939d6c4183

--- a/packages/expo-face-detector/ios/EXFaceDetector.podspec
+++ b/packages/expo-face-detector/ios/EXFaceDetector.podspec
@@ -16,7 +16,14 @@ Pod::Spec.new do |s|
   s.dependency 'UMCore'
   s.dependency 'UMFaceDetectorInterface'
   s.dependency 'UMFileSystemInterface'
+
+  # even though `GoogleMLKit/FaceDetection` depends on all `MLKit*` references below
+  # framework generation code (prebuilds) cannot locate them properly, so these are defined explicitly
+  # TODO: research why xcodegen fails to detect dependencies of dependencies (resulted .xcodeproj is missing them)
   s.dependency 'GoogleMLKit/FaceDetection', '2.1.0'
+  s.dependency 'MLKitFaceDetection', '1.2.0'
+  s.dependency 'MLKitCommon', '2.1.0'
+  s.dependency 'MLKitVision', '1.2.0'
 
   if !$ExpoUseSources&.include?(package['name']) && ENV['EXPO_USE_SOURCE'].to_i == 0 && File.exist?("#{s.name}.xcframework") && Gem::Version.new(Pod::VERSION) >= Gem::Version.new('1.10.0')
     s.source_files = "#{s.name}/**/*.h"

--- a/tools/src/prebuilds/Prebuilder.ts
+++ b/tools/src/prebuilds/Prebuilder.ts
@@ -44,7 +44,7 @@ export const PACKAGES_TO_PREBUILD = [
   // 'expo-device',
   // 'expo-document-picker',
   // 'expo-error-recovery',
-  // 'expo-face-detector',
+  'expo-face-detector',
   'expo-facebook',
   'expo-file-system',
   // 'expo-firebase-analytics',


### PR DESCRIPTION
It appears we need to explicitly define transitive dependencies to achieve `prebuilds` compilation without errors.

# Why

Even though main compilation succeeds (`Expo GO` project), when it comes down to `face-detector prebuild` compilation then compilation fails, because of missing headers/dependencies.
Resolves https://linear.app/expo/issue/E-492/investigate-fixing-prebuild-for-expo-face-detector

# How

I've learned how `prebuilds` process is performed and learned the differences between what should be included in `Xcode` project and what is missing in terms of dependencies & frameworks.
It allowed me to narrow down the problem to `xcodegen` tool and the fact that it is not including transitive dependencies in final `.pbxproj` file 😞
It all revolves around `GoogleMLKit/FaceDetection` cocoapod that defines it's own dependencies (e.g. `MLKitFaceDetection`) and these dependencies were omitted in generated `face-detecor .pbxproj` that is a base for `prebuild` compilation.

# Test Plan

✅  `et prebuild-packages expo-face-detector` succeeds 
