### PR TITLE
[expo-structured-headers] fix wrong variable type in parser implementation

### DIFF
--- a/packages/expo-structured-headers/CHANGELOG.md
+++ b/packages/expo-structured-headers/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix warning in Xcode about wrong variable return type ([#12190](https://github.com/expo/expo/pull/12190) by [@esamelson](https://github.com/esamelson))
+
 ## 1.0.0 — 2021-03-10
 
 ### 🎉 New features

--- a/packages/expo-structured-headers/ios/EXStructuredHeaders/EXStructuredHeadersParser.m
+++ b/packages/expo-structured-headers/ios/EXStructuredHeaders/EXStructuredHeadersParser.m
@@ -166,7 +166,7 @@ static NSString * const EXStructuredHeadersParserErrorDomain = @"EXStructuredHea
       member = [self _parseAnItemOrInnerListWithError:error];
       if (!member) return nil;
     } else {
-      NSArray *parameters = [self _parseParametersWithError:error];
+      NSDictionary *parameters = [self _parseParametersWithError:error];
       if (!parameters) return nil;
       member = [self _memberEntryWithValue:@(YES) parameters:parameters];
     }


### PR DESCRIPTION
# Why

Resolves [ENG-527](https://linear.app/expo/issue/ENG-527/ios-structured-field-value-parser-has-relevant-compiler-warning) (nice catch!)

This was just a typo with no bad implications, fortunately -- the `_parseParametersWithError:` method returns an NSDictionary, and the method this variable is passed into also expects an NSDictionary.

# How

Fix typo.

# Test Plan

Both Xcode warnings (line 169 and line 171) go away with this change.
