### PR TITLE
Update web-performance.md

### DIFF
--- a/docs/pages/guides/web-performance.md
+++ b/docs/pages/guides/web-performance.md
@@ -28,6 +28,17 @@ npx expo-optimize
 
 To inspect bundle sizes, you can use a Webpack plugin called [_Webpack Bundle Analyzer_](https://github.com/webpack-contrib/webpack-bundle-analyzer). This plugin will help you visualize the size of your static bundles. You can use this to identify unwanted large packages that you may not have bundled intentionally.
 
+
+### Using Bundle Analyzer for app bundle
+
+1. Install the source map explorer: `yarn add -D source-map-explorer`
+2. Create app export: `npx expo export --output-dir exported -p https://www.example.com/ --dump-sourcemap`.
+3. Analyze created bundle for iOS: `npx source-map-explorer exported/bundles/ios-*.js exported/bundles/ios-*.map`.
+4. Analyze created bundle for android: `npx source-map-explorer exported/bundles/android-*.js exported/bundles/android-*.map`.
+
+Note: Remember to delete exported folder between runs with e.g.: `rm -rf exported`
+
+
 ### Using Bundle Analyzer
 
 1. Install the bundle analyzer: `yarn add -D webpack-bundle-analyzer`


### PR DESCRIPTION
# Why

When searching for javascript bundle optimization for expo, I found the web performance page. So I followed the guidelines and analyzed the web bundle js.

But what I actually wanted was to analyze the app bundle js. As I thought this was not possible, I used the web bundle js as reference for my optimizations but that was not so effective as the web bundle differs from the app bundle.

Can we add this section for how to analyze the app bundle js explicitly somewhere in the docs?

I think web performance is not the right sections of course. Where should I move it?

