### PR TITLE
[test-suite] Replace background location with background fetch

### DIFF
--- a/apps/test-suite/package.json
+++ b/apps/test-suite/package.json
@@ -18,6 +18,7 @@
     "expo-application": "~3.1.0",
     "expo-asset": "~8.3.0",
     "expo-av": "~9.1.0",
+    "expo-background-fetch": "~9.1.0",
     "expo-barcode-scanner": "~10.1.0",
     "expo-brightness": "~9.1.0",
     "expo-calendar": "~9.1.0",

--- a/apps/test-suite/tests/TaskManager.js
+++ b/apps/test-suite/tests/TaskManager.js
@@ -1,7 +1,5 @@
+import * as BackgroundFetch from 'expo-background-fetch';
 import * as TaskManager from 'expo-task-manager';
-import * as Location from 'expo-location';
-
-import * as TestUtils from '../TestUtils';
 
 const DEFINED_TASK_NAME = 'defined task';
 const UNDEFINED_TASK_NAME = 'undefined task';
@@ -9,20 +7,12 @@ const UNDEFINED_TASK_NAME = 'undefined task';
 export const name = 'TaskManager';
 
 export async function test(t) {
-  const shouldSkipTestsRequiringPermissions = await TestUtils.shouldSkipTestsRequiringPermissionsAsync();
-  const describeWithPermissions = shouldSkipTestsRequiringPermissions ? t.xdescribe : t.describe;
-  const locationOptions = {
-    accuracy: Location.Accuracy.Low,
-    showsBackgroundLocationIndicator: false,
+  const backgroundFetchOptions = {
+    minimumInterval: 15 * 60, // 15min in sec
+    stopOnTerminate: false,
+    startOnBoot: true,
   };
-  /*
-  Some of these tests cause Expo to crash on device farm with the following error:
-  "sdkUnversionedTestSuite failed: java.lang.NullPointerException: Attempt to invoke interface method
-  'java.util.Map org.unimodules.interfaces.taskManager.TaskInterface.getOptions()' on a null object reference"
 
-  getOptions() is being called from within LocationTaskConsumer.java in the expo-location module
-  several times without checking for null
-  */
   t.describe('TaskManager', () => {
     t.describe('isTaskDefined()', () => {
       t.it('returns true if task is defined', () => {
@@ -33,9 +23,9 @@ export async function test(t) {
       });
     });
 
-    describeWithPermissions('isTaskRegisteredAsync()', async () => {
+    t.describe('isTaskRegisteredAsync()', async () => {
       t.beforeAll(async () => {
-        await Location.startLocationUpdatesAsync(DEFINED_TASK_NAME);
+        await BackgroundFetch.registerTaskAsync(DEFINED_TASK_NAME);
       });
 
       t.it('returns true for registered tasks', async () => {
@@ -47,11 +37,11 @@ export async function test(t) {
       });
 
       t.afterAll(async () => {
-        await Location.stopLocationUpdatesAsync(DEFINED_TASK_NAME);
+        await BackgroundFetch.unregisterTaskAsync(DEFINED_TASK_NAME);
       });
     });
 
-    describeWithPermissions('getTaskOptionsAsync()', async () => {
+    t.describe('getTaskOptionsAsync()', async () => {
       let taskOptions;
 
       t.it('returns null for unregistered tasks', async () => {
@@ -60,19 +50,19 @@ export async function test(t) {
       });
 
       t.it('returns correct options after register', async () => {
-        await Location.startLocationUpdatesAsync(DEFINED_TASK_NAME, locationOptions);
+        await BackgroundFetch.registerTaskAsync(DEFINED_TASK_NAME, backgroundFetchOptions);
         taskOptions = await TaskManager.getTaskOptionsAsync(DEFINED_TASK_NAME);
-        t.expect(taskOptions).toEqual(t.jasmine.objectContaining(locationOptions));
+        t.expect(taskOptions).toEqual(t.jasmine.objectContaining(backgroundFetchOptions));
       });
 
       t.it('returns null when unregistered', async () => {
-        await Location.stopLocationUpdatesAsync(DEFINED_TASK_NAME);
+        await BackgroundFetch.unregisterTaskAsync(DEFINED_TASK_NAME);
         taskOptions = await TaskManager.getTaskOptionsAsync(DEFINED_TASK_NAME);
         t.expect(taskOptions).toBe(null);
       });
     });
 
-    describeWithPermissions('getRegisteredTasksAsync()', async () => {
+    t.describe('getRegisteredTasksAsync()', async () => {
       let registeredTasks;
 
       t.it('returns empty array if there are no tasks', async () => {
@@ -82,7 +72,7 @@ export async function test(t) {
       });
 
       t.it('returns correct array after registering the task', async () => {
-        await Location.startLocationUpdatesAsync(DEFINED_TASK_NAME, locationOptions);
+        await BackgroundFetch.registerTaskAsync(DEFINED_TASK_NAME, backgroundFetchOptions);
 
         registeredTasks = await TaskManager.getRegisteredTasksAsync();
 
@@ -91,46 +81,46 @@ export async function test(t) {
         t.expect(registeredTasks.find(task => task.taskName === DEFINED_TASK_NAME)).toEqual(
           t.jasmine.objectContaining({
             taskName: DEFINED_TASK_NAME,
-            taskType: 'location',
-            options: locationOptions,
+            taskType: 'backgroundFetch',
+            options: backgroundFetchOptions,
           })
         );
       });
 
       t.afterAll(async () => {
-        await Location.stopLocationUpdatesAsync(DEFINED_TASK_NAME);
+        await BackgroundFetch.unregisterTaskAsync(DEFINED_TASK_NAME);
       });
     });
 
-    describeWithPermissions('unregisterAllTasksAsync()', () => {
+    t.describe('unregisterAllTasksAsync()', () => {
       t.it('unregisters tasks correctly', async () => {
-        await Location.startLocationUpdatesAsync(DEFINED_TASK_NAME, locationOptions);
+        await BackgroundFetch.registerTaskAsync(DEFINED_TASK_NAME, backgroundFetchOptions);
         await TaskManager.unregisterAllTasksAsync();
 
         t.expect(await TaskManager.isTaskRegisteredAsync(DEFINED_TASK_NAME)).toBe(false);
         t.expect((await TaskManager.getRegisteredTasksAsync()).length).toBe(0);
-        t.expect(await Location.hasStartedLocationUpdatesAsync(DEFINED_TASK_NAME)).toBe(false);
       });
     });
 
-    describeWithPermissions('rejections', () => {
-      t.it('should reject when trying to unregister task with different consumer', async () => {
-        await Location.startLocationUpdatesAsync(DEFINED_TASK_NAME, locationOptions);
+    t.describe('rejections', () => {
+      t.it('should reject when trying to unregister non-existing tasks', async () => {
+        await BackgroundFetch.registerTaskAsync(DEFINED_TASK_NAME, backgroundFetchOptions);
 
         let error;
         try {
-          await Location.stopGeofencingAsync(DEFINED_TASK_NAME, locationOptions);
+          await BackgroundFetch.unregisterTaskAsync(UNDEFINED_TASK_NAME);
         } catch (e) {
           error = e;
         }
         t.expect(error).toBeDefined();
-        t.expect(error.message).toMatch(/Invalid task consumer/);
+        t.expect(error.message).toMatch(/not found/);
 
-        await Location.stopLocationUpdatesAsync(DEFINED_TASK_NAME);
+        await BackgroundFetch.unregisterTaskAsync(DEFINED_TASK_NAME);
       });
     });
   });
 }
 
 // Empty task so we can properly test some methods.
-TaskManager.defineTask(DEFINED_TASK_NAME, () => {});
+// We are telling iOS that we successfully fetched new data, to prevent possible throttle from iOS
+TaskManager.defineTask(DEFINED_TASK_NAME, () => BackgroundFetch.Result.NewData);


### PR DESCRIPTION
# Why

Using the location background tasks implies a lot more permission than necessary. This replaces the background location tests in the task manager tests with background fetch. 

# How

- Added `expo-background-fetch` to the test suite
- Swapped out `expo-location` for `expo-background-fetch` in the test suite

# Test Plan

- Run the test suite
