### PR TITLE
[test-suite] Use permission requesters from modules instead of expo-permissions

### DIFF
--- a/apps/test-suite/tests/BarCodeScanner.js
+++ b/apps/test-suite/tests/BarCodeScanner.js
@@ -2,7 +2,6 @@
 
 import { Asset } from 'expo-asset';
 import { BarCodeScanner } from 'expo-barcode-scanner';
-import * as Permissions from 'expo-permissions';
 import React from 'react';
 import { Platform } from 'react-native';
 
@@ -46,12 +45,12 @@ export async function test(t, { setPortalChild, cleanupPortal }) {
 
     t.beforeAll(async () => {
       await TestUtils.acceptPermissionsAndRunCommandAsync(() => {
-        return Permissions.askAsync(Permissions.CAMERA);
+        return BarCodeScanner.requestPermissionsAsync();
       });
     });
 
     t.beforeEach(async () => {
-      const { status } = await Permissions.getAsync(Permissions.CAMERA);
+      const { status } = await BarCodeScanner.getPermissionsAsync();
       t.expect(status).toEqual('granted');
     });
 

--- a/apps/test-suite/tests/Brightness.js
+++ b/apps/test-suite/tests/Brightness.js
@@ -1,6 +1,6 @@
-import * as Permissions from 'expo-permissions';
 import * as Brightness from 'expo-brightness';
 import { Platform } from 'react-native';
+
 import * as TestUtils from '../TestUtils';
 
 export const name = 'Brightness';
@@ -84,7 +84,7 @@ export async function test(t) {
         () => {
           t.beforeAll(async () => {
             await TestUtils.acceptPermissionsAndRunCommandAsync(() => {
-              return Permissions.askAsync(Permissions.SYSTEM_BRIGHTNESS);
+              return Brightness.requestPermissionsAsync();
             });
           });
 
@@ -148,7 +148,7 @@ export async function test(t) {
       describeWithPermissions(`Brightness.useSystemBrightnessAsync`, () => {
         t.beforeAll(async () => {
           await TestUtils.acceptPermissionsAndRunCommandAsync(() => {
-            return Permissions.askAsync(Permissions.SYSTEM_BRIGHTNESS);
+            return Brightness.requestPermissionsAsync();
           });
         });
 
@@ -194,7 +194,7 @@ export async function test(t) {
       describeWithPermissions(`Brightness.isUsingSystemBrightnessAsync`, () => {
         t.beforeAll(async () => {
           await TestUtils.acceptPermissionsAndRunCommandAsync(() => {
-            return Permissions.askAsync(Permissions.SYSTEM_BRIGHTNESS);
+            return Brightness.requestPermissionsAsync();
           });
         });
 
@@ -225,7 +225,7 @@ export async function test(t) {
       describeWithPermissions(`Brightness Mode`, () => {
         t.beforeAll(async () => {
           await TestUtils.acceptPermissionsAndRunCommandAsync(() => {
-            return Permissions.askAsync(Permissions.SYSTEM_BRIGHTNESS);
+            return Brightness.requestPermissionsAsync();
           });
         });
 

--- a/apps/test-suite/tests/Camera.js
+++ b/apps/test-suite/tests/Camera.js
@@ -1,8 +1,5 @@
-'use strict';
-
-import { Video } from 'expo-av';
+import { Audio, Video } from 'expo-av';
 import { Camera } from 'expo-camera';
-import * as Permissions from 'expo-permissions';
 import React from 'react';
 import { Platform } from 'react-native';
 
@@ -32,10 +29,10 @@ export async function test(t, { setPortalChild, cleanupPortal }) {
 
     t.beforeAll(async () => {
       await TestUtils.acceptPermissionsAndRunCommandAsync(() => {
-        return Permissions.askAsync(Permissions.CAMERA);
+        return Camera.requestPermissionsAsync();
       });
       await TestUtils.acceptPermissionsAndRunCommandAsync(() => {
-        return Permissions.askAsync(Permissions.AUDIO_RECORDING);
+        return Audio.requestPermissionsAsync();
       });
 
       originalTimeout = t.jasmine.DEFAULT_TIMEOUT_INTERVAL;
@@ -47,7 +44,7 @@ export async function test(t, { setPortalChild, cleanupPortal }) {
     });
 
     t.beforeEach(async () => {
-      const { status } = await Permissions.getAsync(Permissions.CAMERA);
+      const { status } = await Camera.getPermissionsAsync();
       t.expect(status).toEqual('granted');
     });
 

--- a/apps/test-suite/tests/ImagePicker.js
+++ b/apps/test-suite/tests/ImagePicker.js
@@ -1,6 +1,5 @@
 import Constants from 'expo-constants';
 import * as ImagePicker from 'expo-image-picker';
-import * as Permissions from 'expo-permissions';
 import { Platform } from 'react-native';
 
 import * as TestUtils from '../TestUtils';
@@ -43,11 +42,11 @@ export async function test({ it, beforeAll, expect, jasmine, describe, afterAll 
     let originalTimeout;
 
     beforeAll(async () => {
-      await Permissions.askAsync(Permissions.MEDIA_LIBRARY);
-      await Permissions.askAsync(Permissions.CAMERA);
-
       await TestUtils.acceptPermissionsAndRunCommandAsync(() => {
-        return Permissions.askAsync(Permissions.MEDIA_LIBRARY);
+        return ImagePicker.requestMediaLibraryPermissionsAsync();
+      });
+      await TestUtils.acceptPermissionsAndRunCommandAsync(() => {
+        return ImagePicker.requestCameraPermissionsAsync();
       });
       originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
       jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout * 10;

--- a/apps/test-suite/tests/Location.js
+++ b/apps/test-suite/tests/Location.js
@@ -2,7 +2,6 @@
 
 import Constants from 'expo-constants';
 import * as Location from 'expo-location';
-import * as Permissions from 'expo-permissions';
 import * as TaskManager from 'expo-task-manager';
 import { Platform } from 'react-native';
 
@@ -21,7 +20,7 @@ export async function test(t) {
     const providerStatus = await Location.getProviderStatusAsync();
     if (providerStatus.locationServicesEnabled) {
       const { status } = await TestUtils.acceptPermissionsAndRunCommandAsync(() => {
-        return Permissions.askAsync(Permissions.LOCATION);
+        return Location.requestForegroundPermissionsAsync();
       });
       if (status === 'granted') {
         const location = await testFunction();
@@ -63,17 +62,34 @@ export async function test(t) {
   }
 
   t.describe('Location', () => {
-    describeWithPermissions('Location.requestPermissionsAsync()', () => {
-      t.it('requests for permissions', async () => {
-        const permission = await Location.requestPermissionsAsync();
+    // On Android, foreground permission needs to be asked before the background permissions
+    describeWithPermissions('Location.requestForegroundPermissionsAsync()', () => {
+      t.it('requests foreground location permissions', async () => {
+        const permission = await Location.requestForegroundPermissionsAsync();
         t.expect(permission.granted).toBe(true);
         t.expect(permission.status).toBe(Location.PermissionStatus.GRANTED);
       });
     });
 
-    describeWithPermissions('Location.getPermissionsAsync()', () => {
-      t.it('gets location permissions', async () => {
-        const permission = await Location.getPermissionsAsync();
+    describeWithPermissions('Location.getForegroundPermissionsAsync()', () => {
+      t.it('gets foreground location permissions', async () => {
+        const permission = await Location.getForegroundPermissionsAsync();
+        t.expect(permission.granted).toBe(true);
+        t.expect(permission.status).toBe(Location.PermissionStatus.GRANTED);
+      });
+    });
+
+    describeWithPermissions('Location.requestBackgroundPermissionsAsync()', () => {
+      t.it('requests background location permissions', async () => {
+        const permission = await Location.requestBackgroundPermissionsAsync();
+        t.expect(permission.granted).toBe(true);
+        t.expect(permission.status).toBe(Location.PermissionStatus.GRANTED);
+      });
+    });
+
+    describeWithPermissions('Location.getBackgroundPermissionsAsync()', () => {
+      t.it('gets background location permissions', async () => {
+        const permission = await Location.getBackgroundPermissionsAsync();
         t.expect(permission.granted).toBe(true);
         t.expect(permission.status).toBe(Location.PermissionStatus.GRANTED);
       });
@@ -349,7 +365,7 @@ export async function test(t) {
           // Disable Compass Test if in simulator
           if (Constants.isDevice) {
             const { status } = await TestUtils.acceptPermissionsAndRunCommandAsync(() => {
-              return Permissions.askAsync(Permissions.LOCATION);
+              return Location.requestForegroundPermissionsAsync();
             });
             if (status === 'granted') {
               const heading = await Location.getHeadingAsync();

--- a/apps/test-suite/tests/Recording.js
+++ b/apps/test-suite/tests/Recording.js
@@ -1,8 +1,5 @@
-'use strict';
-
-import { Platform } from 'react-native';
-import * as Permissions from 'expo-permissions';
 import { Audio } from 'expo-av';
+import { Platform } from 'react-native';
 
 import * as TestUtils from '../TestUtils';
 import { retryForStatus, waitFor } from './helpers';
@@ -65,7 +62,7 @@ export async function test(t) {
       });
 
       await TestUtils.acceptPermissionsAndRunCommandAsync(() => {
-        return Permissions.askAsync(Permissions.AUDIO_RECORDING);
+        return Audio.requestPermissionsAsync();
       });
     });
 
@@ -75,7 +72,7 @@ export async function test(t) {
     let recordingObject = null;
 
     t.beforeEach(async () => {
-      const { status } = await Permissions.getAsync(Permissions.AUDIO_RECORDING);
+      const { status } = await Audio.getPermissionsAsync();
       t.expect(status).toEqual('granted');
       recordingObject = new Audio.Recording();
     });


### PR DESCRIPTION
# Why

- `expo-permissions` is deprecated with SDK 41, this replaces the test-suite usage with the module requesters instead.
- I didn't remove the `tests/Permissions.js` from the test-suite, so if you test that one you will get the deprecation warning

# How

- Replaced with `<module>.requestPermissionAsync`
- Refactored location tests to include both foreground and background location permissions (in order, for android)

# Test Plan

- Run test suite, with any test except `Permissions` -> shouldn't show the `expo-permissions` is deprecated warning
- Run test suite, with `Permission` -> should show the `expo-permissions` is deprecated (but also pass).
