### PR TITLE
[ios] fix persistent loading progress view

### DIFF
--- a/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
+++ b/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
@@ -37,6 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) EXAppLoaderRemoteUpdateStatus remoteUpdateStatus;
 @property (nonatomic, assign) BOOL shouldShowRemoteUpdateStatus;
 @property (nonatomic, assign) BOOL isUpToDate;
+@property (nonatomic, assign) BOOL isLoadingDevelopmentJavaScriptResource;
 
 @property (nonatomic, strong, nullable) NSError *error;
 
@@ -89,6 +90,7 @@ NS_ASSUME_NONNULL_BEGIN
   _remoteUpdateStatus = kEXAppLoaderRemoteUpdateStatusChecking;
   _shouldShowRemoteUpdateStatus = YES;
   _isUpToDate = NO;
+  _isLoadingDevelopmentJavaScriptResource = NO;
 }
 
 - (EXAppLoaderStatus)status
@@ -130,6 +132,13 @@ NS_ASSUME_NONNULL_BEGIN
                                  userInfo:@{}];
   }
   NSAssert([self supportsBundleReload], @"Tried to force a bundle reload on a non-development bundle");
+  if (self.isLoadingDevelopmentJavaScriptResource) {
+    // prevent multiple simultaneous fetches from the development server.
+    // this can happen when reloading a bundle with remote debugging enabled;
+    // RN requests the bundle multiple times for some reason.
+    // TODO: fix inside of RN
+    return;
+  }
   [self _loadDevelopmentJavaScriptResource];
 }
 
@@ -410,6 +419,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)_loadDevelopmentJavaScriptResource
 {
+  _isLoadingDevelopmentJavaScriptResource = YES;
   EXAppFetcher *appFetcher = [[EXAppFetcher alloc] initWithAppLoader:self];
   [appFetcher fetchJSBundleWithManifest:self.optimisticManifest cacheBehavior:EXCachedResourceNoCache timeoutInterval:kEXJSBundleTimeout progress:^(EXLoadingProgress *progress) {
     if (self.delegate) {
@@ -418,11 +428,13 @@ NS_ASSUME_NONNULL_BEGIN
   } success:^(NSData *bundle) {
     self.isUpToDate = YES;
     self.bundle = bundle;
+    self.isLoadingDevelopmentJavaScriptResource = NO;
     if (self.delegate) {
       [self.delegate appLoader:self didFinishLoadingManifest:self.optimisticManifest bundle:self.bundle];
     }
   } error:^(NSError *error) {
     self.error = error;
+    self.isLoadingDevelopmentJavaScriptResource = NO;
     if (self.delegate) {
       [self.delegate appLoader:self didFailWithError:error];
     }

--- a/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
+++ b/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
@@ -37,6 +37,12 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) EXAppLoaderRemoteUpdateStatus remoteUpdateStatus;
 @property (nonatomic, assign) BOOL shouldShowRemoteUpdateStatus;
 @property (nonatomic, assign) BOOL isUpToDate;
+
+/**
+ * Stateful variable to let us prevent multiple simultaneous fetches from the development server.
+ * This can happen when reloading a bundle with remote debugging enabled;
+ * RN requests the bundle multiple times for some reason.
+ */
 @property (nonatomic, assign) BOOL isLoadingDevelopmentJavaScriptResource;
 
 @property (nonatomic, strong, nullable) NSError *error;

--- a/ios/Exponent/Kernel/Views/EXAppViewController.m
+++ b/ios/Exponent/Kernel/Views/EXAppViewController.m
@@ -420,7 +420,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)appLoader:(EXAppLoader *)appLoader didLoadBundleWithProgress:(EXLoadingProgress *)progress
 {
-  [self.appLoadingProgressWindowController updateStatusWithProgress:progress];
+  if (self->_appRecord.appManager.status != kEXReactAppManagerStatusRunning) {
+    [self.appLoadingProgressWindowController updateStatusWithProgress:progress];
+  }
 }
 
 - (void)appLoader:(EXAppLoader *)appLoader didFinishLoadingManifest:(NSDictionary *)manifest bundle:(NSData *)data


### PR DESCRIPTION
# Why

Resolves (I think?) [ENG-45](https://linear.app/expo/issue/ENG-45/persistent-downloading-overlay-on-ios-client-in-certain-cases)

I saw this mostly while testing remote debugging. When we reload the bundle with remote debugging on, we actually request the bundle multiple times from metro, and so the overlay keeps getting progress updates even after the bundle finishes loading the first time.

I spent a little while looking into why we were requesting the bundle multiple times but it seemed to be coming from inside RN, no easy fix.

# How

- When the app view controller gets progress updates, check that the bridge isn't already running before showing & updating the loading progress view.
- Add some extra state to AppLoader to prevent simultaneous downloads of the same development bundle.

# Test Plan

- Turned on remote debugging, reloaded over and over again and did not see the loading progress view persisting over the app. (Without this change it happened ~75% of reloads.)
- Also toggled remote debugging on and off and tested with breakpoints in the browser console to ensure it was still getting properly turned on & off each time.