### PR TITLE
[test-suite] fix test by resolving identifier from notification result

### DIFF
--- a/apps/test-suite/package.json
+++ b/apps/test-suite/package.json
@@ -18,6 +18,7 @@
     "expo-application": "~3.1.0",
     "expo-asset": "~8.3.0",
     "expo-av": "~9.1.0",
+    "expo-background-fetch": "~9.1.0",
     "expo-barcode-scanner": "~10.1.0",
     "expo-brightness": "~9.1.0",
     "expo-calendar": "~9.1.0",

--- a/apps/test-suite/tests/AuthSession.js
+++ b/apps/test-suite/tests/AuthSession.js
@@ -26,7 +26,7 @@ export async function test({ describe, it, expect, jasmine }) {
 
   describe('PKCE', () => {
     it(`creates the expected challenge for a valid code`, async () => {
-      const code = await PKCE.generateRandomAsync(43);
+      const code = PKCE.generateRandom(43);
       const challenge = await PKCE.deriveChallengeAsync(code);
       expect(challenge).toBeTruthy();
       // No `==` in the base64 encoded result.
@@ -34,8 +34,8 @@ export async function test({ describe, it, expect, jasmine }) {
     });
 
     it(`generateRandom produces different values`, async () => {
-      const code1 = await PKCE.generateRandomAsync(10);
-      const code2 = await PKCE.generateRandomAsync(10);
+      const code1 = PKCE.generateRandom(10);
+      const code2 = PKCE.generateRandom(10);
       expect(code1).not.toEqual(code2);
     });
 

--- a/apps/test-suite/tests/BarCodeScanner.js
+++ b/apps/test-suite/tests/BarCodeScanner.js
@@ -2,7 +2,6 @@
 
 import { Asset } from 'expo-asset';
 import { BarCodeScanner } from 'expo-barcode-scanner';
-import * as Permissions from 'expo-permissions';
 import React from 'react';
 import { Platform } from 'react-native';
 
@@ -46,12 +45,12 @@ export async function test(t, { setPortalChild, cleanupPortal }) {
 
     t.beforeAll(async () => {
       await TestUtils.acceptPermissionsAndRunCommandAsync(() => {
-        return Permissions.askAsync(Permissions.CAMERA);
+        return BarCodeScanner.requestPermissionsAsync();
       });
     });
 
     t.beforeEach(async () => {
-      const { status } = await Permissions.getAsync(Permissions.CAMERA);
+      const { status } = await BarCodeScanner.getPermissionsAsync();
       t.expect(status).toEqual('granted');
     });
 

--- a/apps/test-suite/tests/Brightness.js
+++ b/apps/test-suite/tests/Brightness.js
@@ -1,6 +1,6 @@
-import * as Permissions from 'expo-permissions';
 import * as Brightness from 'expo-brightness';
 import { Platform } from 'react-native';
+
 import * as TestUtils from '../TestUtils';
 
 export const name = 'Brightness';
@@ -84,7 +84,7 @@ export async function test(t) {
         () => {
           t.beforeAll(async () => {
             await TestUtils.acceptPermissionsAndRunCommandAsync(() => {
-              return Permissions.askAsync(Permissions.SYSTEM_BRIGHTNESS);
+              return Brightness.requestPermissionsAsync();
             });
           });
 
@@ -148,7 +148,7 @@ export async function test(t) {
       describeWithPermissions(`Brightness.useSystemBrightnessAsync`, () => {
         t.beforeAll(async () => {
           await TestUtils.acceptPermissionsAndRunCommandAsync(() => {
-            return Permissions.askAsync(Permissions.SYSTEM_BRIGHTNESS);
+            return Brightness.requestPermissionsAsync();
           });
         });
 
@@ -194,7 +194,7 @@ export async function test(t) {
       describeWithPermissions(`Brightness.isUsingSystemBrightnessAsync`, () => {
         t.beforeAll(async () => {
           await TestUtils.acceptPermissionsAndRunCommandAsync(() => {
-            return Permissions.askAsync(Permissions.SYSTEM_BRIGHTNESS);
+            return Brightness.requestPermissionsAsync();
           });
         });
 
@@ -225,7 +225,7 @@ export async function test(t) {
       describeWithPermissions(`Brightness Mode`, () => {
         t.beforeAll(async () => {
           await TestUtils.acceptPermissionsAndRunCommandAsync(() => {
-            return Permissions.askAsync(Permissions.SYSTEM_BRIGHTNESS);
+            return Brightness.requestPermissionsAsync();
           });
         });
 

--- a/apps/test-suite/tests/Camera.js
+++ b/apps/test-suite/tests/Camera.js
@@ -1,8 +1,5 @@
-'use strict';
-
-import { Video } from 'expo-av';
+import { Audio, Video } from 'expo-av';
 import { Camera } from 'expo-camera';
-import * as Permissions from 'expo-permissions';
 import React from 'react';
 import { Platform } from 'react-native';
 
@@ -32,10 +29,10 @@ export async function test(t, { setPortalChild, cleanupPortal }) {
 
     t.beforeAll(async () => {
       await TestUtils.acceptPermissionsAndRunCommandAsync(() => {
-        return Permissions.askAsync(Permissions.CAMERA);
+        return Camera.requestPermissionsAsync();
       });
       await TestUtils.acceptPermissionsAndRunCommandAsync(() => {
-        return Permissions.askAsync(Permissions.AUDIO_RECORDING);
+        return Audio.requestPermissionsAsync();
       });
 
       originalTimeout = t.jasmine.DEFAULT_TIMEOUT_INTERVAL;
@@ -47,7 +44,7 @@ export async function test(t, { setPortalChild, cleanupPortal }) {
     });
 
     t.beforeEach(async () => {
-      const { status } = await Permissions.getAsync(Permissions.CAMERA);
+      const { status } = await Camera.getPermissionsAsync();
       t.expect(status).toEqual('granted');
     });
 

--- a/apps/test-suite/tests/ImagePicker.js
+++ b/apps/test-suite/tests/ImagePicker.js
@@ -1,6 +1,5 @@
 import Constants from 'expo-constants';
 import * as ImagePicker from 'expo-image-picker';
-import * as Permissions from 'expo-permissions';
 import { Platform } from 'react-native';
 
 import * as TestUtils from '../TestUtils';
@@ -43,11 +42,11 @@ export async function test({ it, beforeAll, expect, jasmine, describe, afterAll 
     let originalTimeout;
 
     beforeAll(async () => {
-      await Permissions.askAsync(Permissions.MEDIA_LIBRARY);
-      await Permissions.askAsync(Permissions.CAMERA);
-
       await TestUtils.acceptPermissionsAndRunCommandAsync(() => {
-        return Permissions.askAsync(Permissions.MEDIA_LIBRARY);
+        return ImagePicker.requestMediaLibraryPermissionsAsync();
+      });
+      await TestUtils.acceptPermissionsAndRunCommandAsync(() => {
+        return ImagePicker.requestCameraPermissionsAsync();
       });
       originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
       jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout * 10;

--- a/apps/test-suite/tests/Location.js
+++ b/apps/test-suite/tests/Location.js
@@ -2,7 +2,6 @@
 
 import Constants from 'expo-constants';
 import * as Location from 'expo-location';
-import * as Permissions from 'expo-permissions';
 import * as TaskManager from 'expo-task-manager';
 import { Platform } from 'react-native';
 
@@ -21,7 +20,7 @@ export async function test(t) {
     const providerStatus = await Location.getProviderStatusAsync();
     if (providerStatus.locationServicesEnabled) {
       const { status } = await TestUtils.acceptPermissionsAndRunCommandAsync(() => {
-        return Permissions.askAsync(Permissions.LOCATION);
+        return Location.requestForegroundPermissionsAsync();
       });
       if (status === 'granted') {
         const location = await testFunction();
@@ -63,17 +62,34 @@ export async function test(t) {
   }
 
   t.describe('Location', () => {
-    describeWithPermissions('Location.requestPermissionsAsync()', () => {
-      t.it('requests for permissions', async () => {
-        const permission = await Location.requestPermissionsAsync();
+    // On Android, foreground permission needs to be asked before the background permissions
+    describeWithPermissions('Location.requestForegroundPermissionsAsync()', () => {
+      t.it('requests foreground location permissions', async () => {
+        const permission = await Location.requestForegroundPermissionsAsync();
         t.expect(permission.granted).toBe(true);
         t.expect(permission.status).toBe(Location.PermissionStatus.GRANTED);
       });
     });
 
-    describeWithPermissions('Location.getPermissionsAsync()', () => {
-      t.it('gets location permissions', async () => {
-        const permission = await Location.getPermissionsAsync();
+    describeWithPermissions('Location.getForegroundPermissionsAsync()', () => {
+      t.it('gets foreground location permissions', async () => {
+        const permission = await Location.getForegroundPermissionsAsync();
+        t.expect(permission.granted).toBe(true);
+        t.expect(permission.status).toBe(Location.PermissionStatus.GRANTED);
+      });
+    });
+
+    describeWithPermissions('Location.requestBackgroundPermissionsAsync()', () => {
+      t.it('requests background location permissions', async () => {
+        const permission = await Location.requestBackgroundPermissionsAsync();
+        t.expect(permission.granted).toBe(true);
+        t.expect(permission.status).toBe(Location.PermissionStatus.GRANTED);
+      });
+    });
+
+    describeWithPermissions('Location.getBackgroundPermissionsAsync()', () => {
+      t.it('gets background location permissions', async () => {
+        const permission = await Location.getBackgroundPermissionsAsync();
         t.expect(permission.granted).toBe(true);
         t.expect(permission.status).toBe(Location.PermissionStatus.GRANTED);
       });
@@ -349,7 +365,7 @@ export async function test(t) {
           // Disable Compass Test if in simulator
           if (Constants.isDevice) {
             const { status } = await TestUtils.acceptPermissionsAndRunCommandAsync(() => {
-              return Permissions.askAsync(Permissions.LOCATION);
+              return Location.requestForegroundPermissionsAsync();
             });
             if (status === 'granted') {
               const heading = await Location.getHeadingAsync();

--- a/apps/test-suite/tests/Notifications.js
+++ b/apps/test-suite/tests/Notifications.js
@@ -527,7 +527,7 @@ export async function test(t) {
         }
       });
 
-      t.xdescribe('setNotificationChannelGroupsAsync()', () => {
+      t.describe('setNotificationChannelGroupsAsync()', () => {
         t.afterEach(async () => {
           await Notifications.deleteNotificationChannelGroupAsync(testChannelGroupId);
         });

--- a/apps/test-suite/tests/Notifications.js
+++ b/apps/test-suite/tests/Notifications.js
@@ -527,7 +527,7 @@ export async function test(t) {
         }
       });
 
-      t.describe('setNotificationChannelGroupsAsync()', () => {
+      t.xdescribe('setNotificationChannelGroupsAsync()', () => {
         t.afterEach(async () => {
           await Notifications.deleteNotificationChannelGroupAsync(testChannelGroupId);
         });
@@ -705,7 +705,12 @@ export async function test(t) {
             testCategory1.options
           );
 
-          t.expect(testCategory1.identifier).toEqual(resultCategory.identifier);
+          // remove information in environment
+          // e.g "@andrew123/test-suite/testIdentifier" -> "testIdentifier"
+          const identifierSlug = resultCategory.identifier.split('/').pop();
+
+          t.expect(testCategory1.identifier).toEqual(identifierSlug);
+
           testCategory1.actions.forEach((action, i) => {
             t.expect(action.identifier).toEqual(resultCategory.actions[i].identifier);
             t.expect(action.buttonTitle).toEqual(resultCategory.actions[i].buttonTitle);
@@ -725,7 +730,11 @@ export async function test(t) {
             testCategory2.options
           );
 
-          t.expect(testCategory2.identifier).toEqual(resultCategory.identifier);
+          // remove information in environment
+          // e.g "@andrew123/test-suite/testIdentifier" -> "testIdentifier"
+          const identifierSlug = resultCategory.identifier.split('/').pop();
+
+          t.expect(testCategory2.identifier).toEqual(identifierSlug);
           testCategory2.actions.forEach((action, i) => {
             t.expect(action.identifier).toEqual(resultCategory.actions[i].identifier);
             t.expect(action.buttonTitle).toEqual(resultCategory.actions[i].buttonTitle);

--- a/apps/test-suite/tests/Recording.js
+++ b/apps/test-suite/tests/Recording.js
@@ -1,8 +1,5 @@
-'use strict';
-
-import { Platform } from 'react-native';
-import * as Permissions from 'expo-permissions';
 import { Audio } from 'expo-av';
+import { Platform } from 'react-native';
 
 import * as TestUtils from '../TestUtils';
 import { retryForStatus, waitFor } from './helpers';
@@ -65,7 +62,7 @@ export async function test(t) {
       });
 
       await TestUtils.acceptPermissionsAndRunCommandAsync(() => {
-        return Permissions.askAsync(Permissions.AUDIO_RECORDING);
+        return Audio.requestPermissionsAsync();
       });
     });
 
@@ -75,7 +72,7 @@ export async function test(t) {
     let recordingObject = null;
 
     t.beforeEach(async () => {
-      const { status } = await Permissions.getAsync(Permissions.AUDIO_RECORDING);
+      const { status } = await Audio.getPermissionsAsync();
       t.expect(status).toEqual('granted');
       recordingObject = new Audio.Recording();
     });

--- a/apps/test-suite/tests/Segment.js
+++ b/apps/test-suite/tests/Segment.js
@@ -93,7 +93,7 @@ export function test(t) {
           error = e;
         }
         t.expect(error).not.toBeNull();
-        t.expect(error).toMatch('not supported in Expo Client');
+        t.expect(error).toMatch('not supported in Expo Go');
       });
     }
   });

--- a/apps/test-suite/tests/TaskManager.js
+++ b/apps/test-suite/tests/TaskManager.js
@@ -1,7 +1,5 @@
+import * as BackgroundFetch from 'expo-background-fetch';
 import * as TaskManager from 'expo-task-manager';
-import * as Location from 'expo-location';
-
-import * as TestUtils from '../TestUtils';
 
 const DEFINED_TASK_NAME = 'defined task';
 const UNDEFINED_TASK_NAME = 'undefined task';
@@ -9,20 +7,12 @@ const UNDEFINED_TASK_NAME = 'undefined task';
 export const name = 'TaskManager';
 
 export async function test(t) {
-  const shouldSkipTestsRequiringPermissions = await TestUtils.shouldSkipTestsRequiringPermissionsAsync();
-  const describeWithPermissions = shouldSkipTestsRequiringPermissions ? t.xdescribe : t.describe;
-  const locationOptions = {
-    accuracy: Location.Accuracy.Low,
-    showsBackgroundLocationIndicator: false,
+  const backgroundFetchOptions = {
+    minimumInterval: 15 * 60, // 15min in sec
+    stopOnTerminate: false,
+    startOnBoot: true,
   };
-  /*
-  Some of these tests cause Expo to crash on device farm with the following error:
-  "sdkUnversionedTestSuite failed: java.lang.NullPointerException: Attempt to invoke interface method
-  'java.util.Map org.unimodules.interfaces.taskManager.TaskInterface.getOptions()' on a null object reference"
 
-  getOptions() is being called from within LocationTaskConsumer.java in the expo-location module
-  several times without checking for null
-  */
   t.describe('TaskManager', () => {
     t.describe('isTaskDefined()', () => {
       t.it('returns true if task is defined', () => {
@@ -33,9 +23,9 @@ export async function test(t) {
       });
     });
 
-    describeWithPermissions('isTaskRegisteredAsync()', async () => {
+    t.describe('isTaskRegisteredAsync()', async () => {
       t.beforeAll(async () => {
-        await Location.startLocationUpdatesAsync(DEFINED_TASK_NAME);
+        await BackgroundFetch.registerTaskAsync(DEFINED_TASK_NAME);
       });
 
       t.it('returns true for registered tasks', async () => {
@@ -47,11 +37,11 @@ export async function test(t) {
       });
 
       t.afterAll(async () => {
-        await Location.stopLocationUpdatesAsync(DEFINED_TASK_NAME);
+        await BackgroundFetch.unregisterTaskAsync(DEFINED_TASK_NAME);
       });
     });
 
-    describeWithPermissions('getTaskOptionsAsync()', async () => {
+    t.describe('getTaskOptionsAsync()', async () => {
       let taskOptions;
 
       t.it('returns null for unregistered tasks', async () => {
@@ -60,19 +50,19 @@ export async function test(t) {
       });
 
       t.it('returns correct options after register', async () => {
-        await Location.startLocationUpdatesAsync(DEFINED_TASK_NAME, locationOptions);
+        await BackgroundFetch.registerTaskAsync(DEFINED_TASK_NAME, backgroundFetchOptions);
         taskOptions = await TaskManager.getTaskOptionsAsync(DEFINED_TASK_NAME);
-        t.expect(taskOptions).toEqual(t.jasmine.objectContaining(locationOptions));
+        t.expect(taskOptions).toEqual(t.jasmine.objectContaining(backgroundFetchOptions));
       });
 
       t.it('returns null when unregistered', async () => {
-        await Location.stopLocationUpdatesAsync(DEFINED_TASK_NAME);
+        await BackgroundFetch.unregisterTaskAsync(DEFINED_TASK_NAME);
         taskOptions = await TaskManager.getTaskOptionsAsync(DEFINED_TASK_NAME);
         t.expect(taskOptions).toBe(null);
       });
     });
 
-    describeWithPermissions('getRegisteredTasksAsync()', async () => {
+    t.describe('getRegisteredTasksAsync()', async () => {
       let registeredTasks;
 
       t.it('returns empty array if there are no tasks', async () => {
@@ -82,7 +72,7 @@ export async function test(t) {
       });
 
       t.it('returns correct array after registering the task', async () => {
-        await Location.startLocationUpdatesAsync(DEFINED_TASK_NAME, locationOptions);
+        await BackgroundFetch.registerTaskAsync(DEFINED_TASK_NAME, backgroundFetchOptions);
 
         registeredTasks = await TaskManager.getRegisteredTasksAsync();
 
@@ -91,46 +81,46 @@ export async function test(t) {
         t.expect(registeredTasks.find(task => task.taskName === DEFINED_TASK_NAME)).toEqual(
           t.jasmine.objectContaining({
             taskName: DEFINED_TASK_NAME,
-            taskType: 'location',
-            options: locationOptions,
+            taskType: 'backgroundFetch',
+            options: backgroundFetchOptions,
           })
         );
       });
 
       t.afterAll(async () => {
-        await Location.stopLocationUpdatesAsync(DEFINED_TASK_NAME);
+        await BackgroundFetch.unregisterTaskAsync(DEFINED_TASK_NAME);
       });
     });
 
-    describeWithPermissions('unregisterAllTasksAsync()', () => {
+    t.describe('unregisterAllTasksAsync()', () => {
       t.it('unregisters tasks correctly', async () => {
-        await Location.startLocationUpdatesAsync(DEFINED_TASK_NAME, locationOptions);
+        await BackgroundFetch.registerTaskAsync(DEFINED_TASK_NAME, backgroundFetchOptions);
         await TaskManager.unregisterAllTasksAsync();
 
         t.expect(await TaskManager.isTaskRegisteredAsync(DEFINED_TASK_NAME)).toBe(false);
         t.expect((await TaskManager.getRegisteredTasksAsync()).length).toBe(0);
-        t.expect(await Location.hasStartedLocationUpdatesAsync(DEFINED_TASK_NAME)).toBe(false);
       });
     });
 
-    describeWithPermissions('rejections', () => {
-      t.it('should reject when trying to unregister task with different consumer', async () => {
-        await Location.startLocationUpdatesAsync(DEFINED_TASK_NAME, locationOptions);
+    t.describe('rejections', () => {
+      t.it('should reject when trying to unregister non-existing tasks', async () => {
+        await BackgroundFetch.registerTaskAsync(DEFINED_TASK_NAME, backgroundFetchOptions);
 
         let error;
         try {
-          await Location.stopGeofencingAsync(DEFINED_TASK_NAME, locationOptions);
+          await BackgroundFetch.unregisterTaskAsync(UNDEFINED_TASK_NAME);
         } catch (e) {
           error = e;
         }
         t.expect(error).toBeDefined();
-        t.expect(error.message).toMatch(/Invalid task consumer/);
+        t.expect(error.message).toMatch(/not found/);
 
-        await Location.stopLocationUpdatesAsync(DEFINED_TASK_NAME);
+        await BackgroundFetch.unregisterTaskAsync(DEFINED_TASK_NAME);
       });
     });
   });
 }
 
 // Empty task so we can properly test some methods.
-TaskManager.defineTask(DEFINED_TASK_NAME, () => {});
+// We are telling iOS that we successfully fetched new data, to prevent possible throttle from iOS
+TaskManager.defineTask(DEFINED_TASK_NAME, () => BackgroundFetch.Result.NewData);


### PR DESCRIPTION
# Why

It seems as though some extra information is appended to notification identifiers, for example user account and app name - I think this is because I installed the Expo Go client on my phone which had cached my previous user data

For example: 
```
    const resultCategory = await Notifications.setNotificationCategoryAsync(
            testCategory1.identifier,
            testCategory1.actions,
            testCategory1.options
          );
          
          resultCategory.identifier = '@andrew123/test-suite/testIdentifier1'
```



# How

Parsing out the extra data from notification identifiers
