### PR TITLE
[rn-adapter][android] Fix compatibility with NativeModule interface changes

### DIFF
--- a/packages/@unimodules/react-native-adapter/android/src/main/java/org/unimodules/adapters/react/services/CookieManagerModule.java
+++ b/packages/@unimodules/react-native-adapter/android/src/main/java/org/unimodules/adapters/react/services/CookieManagerModule.java
@@ -37,6 +37,15 @@ public class CookieManagerModule extends ForwardingCookieHandler implements Inte
     return false;
   }
 
+  // `invalidate` replaces `onCatalystInstanceDestroy` in recent RN versions. We can't use
+  // @Override here since older versions won't have this method. If one of these methods is
+  // needed make sure to add the code to both as only one of the methods will be called depending
+  // on the RN version.
+  // See https://github.com/facebook/react-native/commit/18c8417290823e67e211bde241ae9dde27b72f17
+  public void invalidate() {
+    // do nothing
+  }
+
   @Override
   public void onCatalystInstanceDestroy() {
     // do nothing


### PR DESCRIPTION
# Why

In https://github.com/facebook/react-native/commit/18c8417290823e67e211bde241ae9dde27b72f17 an `invalidate` method was added to the `NativeModule` interface which also need to be overridden.

# How

Add an empty implementation, but without `@Override` so it still works with older version of RN that don't have this method.

# Test Plan

Test that my app builds with this change, and that CI builds here to confirm it doesn't affect older RN versions.
