### PR TITLE
[ios][notifications] fix: scoped category ID returned from setNotificationCategoryAsync

### DIFF
--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationCategoriesModule.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationCategoriesModule.m
@@ -62,7 +62,7 @@
 
 - (NSMutableDictionary *)serializeCategory:(UNNotificationCategory *)category
 {
-  NSMutableDictionary* serializedCategory = [EXNotificationCategoriesModule serializeCategory:category];
+  NSMutableDictionary* serializedCategory = [super serializeCategory:category];
   serializedCategory[@"identifier"] = [EXScopedNotificationsUtils getScopeAndIdentifierFromScopedIdentifier:serializedCategory[@"identifier"]].identifier;
 
   return serializedCategory;

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Prevent scoped category IDs from being returned from `setNotificationCategoryAsync`. ([#12212](https://github.com/expo/expo/pull/12212 by [@cruzach](https://github.com/cruzach))
+
 ## 0.11.0 — 2021-03-10
 
 ### 🎉 New features

--- a/packages/expo-notifications/ios/EXNotifications/Notifications/Categories/EXNotificationCategoriesModule.h
+++ b/packages/expo-notifications/ios/EXNotifications/Notifications/Categories/EXNotificationCategoriesModule.h
@@ -14,12 +14,12 @@
 - (void)deleteNotificationCategoryWithCategoryId:(NSString *)categoryId
                                          resolve:(UMPromiseResolveBlock)resolve 
                                           reject:(UMPromiseRejectBlock)reject;
-+ (UNNotificationCategory *)createCategoryWithId:(NSString*)categoryId
+- (NSMutableDictionary *)serializeCategory:(UNNotificationCategory *)category;
+- (UNNotificationCategory *)createCategoryWithId:(NSString*)categoryId
                                          actions:(NSArray *)actions
                                          options:(NSDictionary *)options;
-+ (NSMutableDictionary *)serializeCategory:(UNNotificationCategory *)category;
-+ (NSMutableDictionary *)serializeCategoryOptions:(UNNotificationCategory *)category;
-+ (NSMutableArray *)serializeActions:(NSArray<UNNotificationAction *>*)actions;
-+ (NSMutableDictionary *)serializeActionOptions:(NSUInteger)options;
+- (NSMutableDictionary *)serializeCategoryOptions:(UNNotificationCategory *)category;
+- (NSMutableArray *)serializeActions:(NSArray<UNNotificationAction *>*)actions;
+- (NSMutableDictionary *)serializeActionOptions:(NSUInteger)options;
 
 @end

--- a/packages/expo-notifications/ios/EXNotifications/Notifications/Categories/EXNotificationCategoriesModule.m
+++ b/packages/expo-notifications/ios/EXNotifications/Notifications/Categories/EXNotificationCategoriesModule.m
@@ -15,7 +15,7 @@ UM_EXPORT_METHOD_AS(getNotificationCategoriesAsync,
   [[UNUserNotificationCenter currentNotificationCenter] getNotificationCategoriesWithCompletionHandler:^(NSSet<UNNotificationCategory *> *categories) {
     NSMutableArray* existingCategories = [NSMutableArray new];
     for (UNNotificationCategory *category in categories) {
-      [existingCategories addObject:[EXNotificationCategoriesModule serializeCategory:category]];
+      [existingCategories addObject:[self serializeCategory:category]];
     }
     resolve(existingCategories);
   }];
@@ -41,7 +41,7 @@ UM_EXPORT_METHOD_AS(setNotificationCategoryAsync,
     }
     [newCategories addObject:newCategory];
     [[UNUserNotificationCenter currentNotificationCenter] setNotificationCategories:newCategories];
-    resolve([EXNotificationCategoriesModule serializeCategory:newCategory]);
+    resolve([self serializeCategory:newCategory]);
   }];
 }
 
@@ -155,7 +155,7 @@ UM_EXPORT_METHOD_AS(deleteNotificationCategoryAsync,
   return options;
 }
 
-+ (NSMutableDictionary *)serializeCategory:(UNNotificationCategory *)category
+- (NSMutableDictionary *)serializeCategory:(UNNotificationCategory *)category
 {
   NSMutableDictionary* serializedCategory = [NSMutableDictionary dictionary];
   serializedCategory[@"identifier"] = category.identifier;
@@ -164,7 +164,7 @@ UM_EXPORT_METHOD_AS(deleteNotificationCategoryAsync,
   return serializedCategory;
 }
 
-+ (NSMutableDictionary *)serializeCategoryOptions:(UNNotificationCategory *)category
+- (NSMutableDictionary *)serializeCategoryOptions:(UNNotificationCategory *)category
 {
   NSMutableDictionary* serializedOptions = [NSMutableDictionary dictionary];
   serializedOptions[@"intentIdentifiers"] = category.intentIdentifiers;
@@ -184,7 +184,7 @@ UM_EXPORT_METHOD_AS(deleteNotificationCategoryAsync,
   return serializedOptions;
 }
 
-+ (NSMutableArray *)serializeActions:(NSArray<UNNotificationAction *>*)actions
+- (NSMutableArray *)serializeActions:(NSArray<UNNotificationAction *>*)actions
 {
   NSMutableArray* serializedActions = [NSMutableArray new];
   for (NSUInteger i = 0; i < [actions count]; i++)
@@ -205,7 +205,7 @@ UM_EXPORT_METHOD_AS(deleteNotificationCategoryAsync,
   return serializedActions;
 }
 
-+ (NSMutableDictionary *)serializeActionOptions:(NSUInteger)options
+- (NSMutableDictionary *)serializeActionOptions:(NSUInteger)options
 {
   NSMutableDictionary* serializedOptions = [NSMutableDictionary dictionary];
   serializedOptions[@"opensAppToForeground"] =  [NSNumber numberWithBool:((options & UNNotificationActionOptionForeground) != 0)];


### PR DESCRIPTION
# Why

fixes https://github.com/expo/expo/pull/12204

# How

previously, we weren't properly overriding (& using the overridden) class method for serializing the category, so only for the result of `setNotificationCategoryAsync`- the _scoped_ identifier would be returned

# Test Plan

test suite passes
