### PR TITLE
fix: make 650 Industries the dev team in Xcode

### DIFF
--- a/ios/Exponent.xcodeproj/project.pbxproj
+++ b/ios/Exponent.xcodeproj/project.pbxproj
@@ -2197,7 +2197,7 @@
 				TargetAttributes = {
 					78CEE2BF1ACD07D70095B124 = {
 						CreatedOnToolsVersion = 6.2;
-						DevelopmentTeam = GQ4S96SE9Z;
+						DevelopmentTeam = C8D8QTF339;
 						LastSwiftMigration = 1150;
 						ProvisioningStyle = Automatic;
 						SystemCapabilities = {
@@ -2903,7 +2903,7 @@
 				CODE_SIGN_ENTITLEMENTS = Exponent/Supporting/Exponent.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = GQ4S96SE9Z;
+				DEVELOPMENT_TEAM = C8D8QTF339;
 				EX_BUNDLE_NAME = Expo;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Exponent/Supporting/Exponent-Prefix.pch";

--- a/ios/Exponent.xcodeproj/xcshareddata/xcschemes/Exponent.xcscheme
+++ b/ios/Exponent.xcodeproj/xcshareddata/xcschemes/Exponent.xcscheme
@@ -27,6 +27,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "78CEE2BF1ACD07D70095B124"
+            BuildableName = "Exponent.app"
+            BlueprintName = "Exponent"
+            ReferencedContainer = "container:Exponent.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "YES">
@@ -49,17 +58,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "78CEE2BF1ACD07D70095B124"
-            BuildableName = "Exponent.app"
-            BlueprintName = "Exponent"
-            ReferencedContainer = "container:Exponent.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -88,8 +86,6 @@
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"


### PR DESCRIPTION
# Why

Builds will fail if you pull from `master` and build in Xcode

# How

i think this was accidentally changed in https://github.com/expo/expo/pull/12112/files. It's really easy to miss bc github doesn't show the diff of that file by default

# Test Plan

build the iOS project 😄 
