### PR TITLE
[jest-expo-mock-generator] Work around logs getting truncated

### DIFF
--- a/apps/jest-expo-mock-generator/App.js
+++ b/apps/jest-expo-mock-generator/App.js
@@ -65,7 +65,7 @@ async function _sendRawLogAsync(message, logUrl) {
     headers,
     body: JSON.stringify([
       {
-        count: 1,
+        count: 0,
         level: 'info',
         body: [message],
         includesStack: false,

--- a/apps/jest-expo-mock-generator/App.js
+++ b/apps/jest-expo-mock-generator/App.js
@@ -1,10 +1,12 @@
 import mux from '@expo/mux';
-import getInstallationIdAsync from 'expo/build/environment/getInstallationIdAsync';
 import Constants from 'expo-constants';
+import getInstallationIdAsync from 'expo/build/environment/getInstallationIdAsync';
 import React from 'react';
 import { NativeModules, StyleSheet, Text, View } from 'react-native';
+import { v4 as uuidV4 } from 'uuid';
 
 const { logUrl } = Constants.manifest;
+const sessionId = uuidV4();
 
 const { ExpoNativeModuleIntrospection } = NativeModules;
 
@@ -53,7 +55,7 @@ async function _sendRawLogAsync(message, logUrl) {
     'Proxy-Connection': 'keep-alive',
     Accept: 'application/json',
     'Device-Id': await getInstallationIdAsync(),
-    'Session-Id': new Date().getTime().toString(),
+    'Session-Id': sessionId,
   };
   if (Constants.deviceName) {
     headers['Device-Name'] = Constants.deviceName;

--- a/apps/jest-expo-mock-generator/package.json
+++ b/apps/jest-expo-mock-generator/package.json
@@ -11,6 +11,7 @@
     "@expo/mux": "^1.0.7",
     "expo": "~41.0.0-alpha.0",
     "react": "16.13.1",
-    "react-native": "0.63.2"
+    "react-native": "0.63.2",
+    "uuid": "^3.4.0"
   }
 }


### PR DESCRIPTION
# Why

Expo CLI truncates log messages at 10k characters. `jest-expo-mock-generator`, an internal tool used in the SDK release process logs a message that's ~60k characters.

# How

Implemented a workaround by calling the raw HTTP logging API directly rather than logging with `console.log`.

# Test Plan

Ran the app on iOS with `expo start --ios` and verified that the whole message was printed to console.