### PR TITLE
Revert "[ios] Remove legacy ScreenOrientation code (#11371)"

### DIFF
--- a/ios/Exponent.xcodeproj/project.pbxproj
+++ b/ios/Exponent.xcodeproj/project.pbxproj
@@ -199,6 +199,7 @@
 		B56C65C6204768F3002B2424 /* EXRootViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B56C65C1204768F2002B2424 /* EXRootViewController.m */; };
 		B56C65C8204768F3002B2424 /* EXHomeAppManager.m in Sources */ = {isa = PBXBuildFile; fileRef = B56C65C4204768F2002B2424 /* EXHomeAppManager.m */; };
 		B56C65CC204769F9002B2424 /* EXDevMenuViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B56C65CB204769F9002B2424 /* EXDevMenuViewController.m */; };
+		B57181001F0FF41600315A66 /* EXScreenOrientationManager.m in Sources */ = {isa = PBXBuildFile; fileRef = B57180FF1F0FF41600315A66 /* EXScreenOrientationManager.m */; };
 		B575EEA41D54175B00DCABBC /* shell-app-manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = B575EEA21D54175A00DCABBC /* shell-app-manifest.json */; };
 		B575EEA51D54175B00DCABBC /* shell-app.bundle in Resources */ = {isa = PBXBuildFile; fileRef = B575EEA31D54175B00DCABBC /* shell-app.bundle */; };
 		B5854ED720D078C6001D2F6E /* EXClientTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = B5854ED620D078C6001D2F6E /* EXClientTestCase.m */; };
@@ -745,6 +746,8 @@
 		B56C65C5204768F2002B2424 /* EXHomeAppManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EXHomeAppManager.h; sourceTree = "<group>"; };
 		B56C65CA204769F9002B2424 /* EXDevMenuViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EXDevMenuViewController.h; sourceTree = "<group>"; };
 		B56C65CB204769F9002B2424 /* EXDevMenuViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EXDevMenuViewController.m; sourceTree = "<group>"; };
+		B57180FE1F0FF41600315A66 /* EXScreenOrientationManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EXScreenOrientationManager.h; sourceTree = "<group>"; };
+		B57180FF1F0FF41600315A66 /* EXScreenOrientationManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EXScreenOrientationManager.m; sourceTree = "<group>"; };
 		B575EEA21D54175A00DCABBC /* shell-app-manifest.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "shell-app-manifest.json"; sourceTree = "<group>"; };
 		B575EEA31D54175B00DCABBC /* shell-app.bundle */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "shell-app.bundle"; sourceTree = "<group>"; };
 		B5854ED620D078C6001D2F6E /* EXClientTestCase.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EXClientTestCase.m; sourceTree = "<group>"; };
@@ -1715,6 +1718,8 @@
 				B5AC39A41E95A90B00540AA7 /* EXUserNotificationManager.m */,
 				31E6D47C20B844FA0082B09F /* EXSensorManager.h */,
 				31E6D47D20B8451B0082B09F /* EXSensorManager.m */,
+				B57180FE1F0FF41600315A66 /* EXScreenOrientationManager.h */,
+				B57180FF1F0FF41600315A66 /* EXScreenOrientationManager.m */,
 				0761342224DB6395001375B6 /* EXUpdatesDatabaseManager.h */,
 				0761342324DB63AC001375B6 /* EXUpdatesDatabaseManager.m */,
 				07295CD720559E6200ED42D4 /* EXUpdatesManager.h */,
@@ -2663,6 +2668,8 @@
 				BBB83C662479C3B50004FF8E /* RNCSafeAreaViewManager.m in Sources */,
 				7043DF782283303800272D74 /* RNSVGPainter.m in Sources */,
 				7043DF922283303800272D74 /* RNSVGEllipse.m in Sources */,
+				B57181001F0FF41600315A66 /* EXScreenOrientationManager.m in Sources */,
+				78C832ED23546BD400448582 /* RNNativeViewHandler.m in Sources */,
 				31AD9A4B2285B53100F19090 /* AIRMapWMSTileManager.m in Sources */,
 				31AD9A362285B53100F19090 /* AIRMapLocalTileManager.m in Sources */,
 				B5D0D673204F4C0400DDFC99 /* EXApiUtil.m in Sources */,

--- a/ios/Exponent/ExpoKit/EXViewController.m
+++ b/ios/Exponent/ExpoKit/EXViewController.m
@@ -2,6 +2,7 @@
 
 #import "EXEnvironment.h"
 #import "EXKernel.h"
+#import "EXScreenOrientationManager.h"
 #import "EXViewController.h"
 #import "ExpoKit.h"
 #import "EXUtil.h"
@@ -60,6 +61,11 @@
 - (BOOL)shouldAutorotate
 {
   return YES;
+}
+
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations
+{
+  return [[EXKernel sharedInstance].serviceRegistry.screenOrientationManager supportedInterfaceOrientationsForVisibleApp];
 }
 
 - (void)presentViewController:(UIViewController *)viewControllerToPresent animated:(BOOL)flag completion:(void (^_Nullable)(void))completion

--- a/ios/Exponent/Kernel/Core/EXKernelServiceRegistry.h
+++ b/ios/Exponent/Kernel/Core/EXKernelServiceRegistry.h
@@ -7,6 +7,7 @@
 @class EXKernelLinkingManager;
 @class EXKernelModuleManager;
 @class EXRemoteNotificationManager;
+@class EXScreenOrientationManager;
 @class EXUpdatesDatabaseManager;
 @class EXUpdatesManager;
 @class EXUserNotificationManager;
@@ -18,6 +19,7 @@
 @property (nonatomic, readonly) EXKernelModuleManager *kernelModuleManager;
 @property (nonatomic, readonly) EXKernelLinkingManager *linkingManager;
 @property (nonatomic, readonly) EXRemoteNotificationManager *remoteNotificationManager;
+@property (nonatomic, readonly) EXScreenOrientationManager *screenOrientationManager;
 @property (nonatomic, readonly) EXUpdatesDatabaseManager *updatesDatabaseManager;
 @property (nonatomic, readonly) EXUpdatesManager *updatesManager;
 @property (nonatomic, readonly) EXUserNotificationManager *notificationsManager;

--- a/ios/Exponent/Kernel/Core/EXKernelServiceRegistry.m
+++ b/ios/Exponent/Kernel/Core/EXKernelServiceRegistry.m
@@ -8,6 +8,7 @@
 #import "EXKernelLinkingManager.h"
 #import "EXKernelService.h"
 #import "EXRemoteNotificationManager.h"
+#import "EXScreenOrientationManager.h"
 #import "EXSensorManager.h"
 #import "EXUpdatesDatabaseManager.h"
 #import "EXUpdatesManager.h"
@@ -24,6 +25,7 @@
 @property (nonatomic, strong) EXHomeModuleManager *homeModuleManager;
 @property (nonatomic, strong) EXKernelLinkingManager *linkingManager;
 @property (nonatomic, strong) EXRemoteNotificationManager *remoteNotificationManager;
+@property (nonatomic, strong) EXScreenOrientationManager *screenOrientationManager;
 @property (nonatomic, strong) EXSensorManager *sensorManager;
 @property (nonatomic, strong) EXUpdatesDatabaseManager *updatesDatabaseManager;
 @property (nonatomic, strong) EXUpdatesManager *updatesManager;
@@ -45,6 +47,7 @@
     [self remoteNotificationManager];
     [self linkingManager];
     [self homeModuleManager];
+    [self screenOrientationManager];
     [self sensorManager];
     [self updatesDatabaseManager];
     [self updatesManager];
@@ -103,6 +106,14 @@
   return _homeModuleManager;
 }
 
+- (EXScreenOrientationManager *)screenOrientationManager
+{
+  if (!_screenOrientationManager) {
+    _screenOrientationManager = [[EXScreenOrientationManager alloc] init];
+  }
+  return _screenOrientationManager;
+}
+
 - (EXSensorManager *)sensorManager
 {
   if (!_sensorManager) {
@@ -159,6 +170,7 @@
                                   self.homeModuleManager,
                                   self.linkingManager,
                                   self.remoteNotificationManager,
+                                  self.screenOrientationManager,
                                   self.sensorManager,
                                   self.updatesDatabaseManager,
                                   self.updatesManager,

--- a/ios/Exponent/Kernel/Services/EXScreenOrientationManager.h
+++ b/ios/Exponent/Kernel/Services/EXScreenOrientationManager.h
@@ -1,0 +1,35 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+// TODO: Remove once sdk 37 is phased out
+@protocol EXScreenOrientationScopedModuleDelegate
+
+- (void)screenOrientationModule:(nonnull id)scopedOrientationModule
+didChangeSupportedInterfaceOrientations:(UIInterfaceOrientationMask)supportedInterfaceOrientations;
+
+- (UIInterfaceOrientationMask)supportedInterfaceOrientationsForVisibleApp;
+
+- (void)removeOrientationChangeListener:(nonnull NSString *)experienceId;
+
+- (void)addOrientationChangeListener:(nonnull NSString *)experienceId subscriberModule:(nonnull id)subscriberModule;
+
+- (nullable UITraitCollection *)getTraitCollection;
+
+@end
+
+@protocol EXScreenOrientationListener
+
+- (void)handleScreenOrientationChange:(nullable UITraitCollection *)traitCollection;
+
+@end
+
+@interface EXScreenOrientationManager : NSObject <EXScreenOrientationScopedModuleDelegate>
+
+@property (nonatomic, strong) NSMapTable<NSString *, id> *__nonnull subscribedModules;
+
+@property (nonatomic, assign) UIInterfaceOrientationMask supportedInterfaceOrientationsForVisibleApp;
+
+- (void)setSupportInterfaceOrientations:(UIInterfaceOrientationMask)supportedInterfaceOrientations forExperienceId:(nullable NSString *)experienceId;
+
+- (void)handleScreenOrientationChange:(nullable UITraitCollection *)traitCollection;
+
+@end

--- a/ios/Exponent/Kernel/Services/EXScreenOrientationManager.m
+++ b/ios/Exponent/Kernel/Services/EXScreenOrientationManager.m
@@ -1,0 +1,68 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+#import "EXAppViewController.h"
+#import "EXKernel.h"
+#import "EXKernelAppRegistry.h"
+#import "EXScreenOrientationManager.h"
+
+NSNotificationName kEXChangeForegroundTaskSupportedOrientationsNotification = @"EXChangeForegroundTaskSupportedOrientations";
+
+@implementation EXScreenOrientationManager
+
+- (instancetype)init
+{
+  if (self = [super init]) {
+    _subscribedModules = [NSMapTable strongToWeakObjectsMapTable];
+  }
+  return self;
+}
+
+- (void)setSupportInterfaceOrientations:(UIInterfaceOrientationMask)supportedInterfaceOrientations forExperienceId:(NSString *)experienceId
+{
+  EXKernelAppRegistry *appRegistry = [EXKernel sharedInstance].appRegistry;
+  EXKernelAppRecord *recordForId = [appRegistry newestRecordWithExperienceId:experienceId];
+  if (recordForId) {
+    [recordForId.viewController setSupportedInterfaceOrientations:supportedInterfaceOrientations];
+  }
+}
+
+- (UIInterfaceOrientationMask)supportedInterfaceOrientationsForVisibleApp
+{
+  EXKernelAppRecord *visibleApp = [EXKernel sharedInstance].visibleApp;
+  return [visibleApp.viewController supportedInterfaceOrientations];
+}
+
+- (void)handleScreenOrientationChange:(UITraitCollection *)traitCollection
+{
+  for(NSString *experienceId in _subscribedModules) {
+    id<EXScreenOrientationListener> subscribedModule = [_subscribedModules objectForKey:experienceId];
+    [subscribedModule handleScreenOrientationChange:traitCollection];
+  }
+}
+
+- (UITraitCollection *)getTraitCollection
+{
+  EXKernelAppRecord *visibleApp = [EXKernel sharedInstance].visibleApp;
+  return [visibleApp.viewController traitCollection];
+}
+
+#pragma mark - scoped module delegate
+
+- (void)screenOrientationModule:(id)scopedOrientationModule
+didChangeSupportedInterfaceOrientations:(UIInterfaceOrientationMask)supportedInterfaceOrientations
+{
+  [self setSupportInterfaceOrientations:supportedInterfaceOrientations forExperienceId:((EXScopedBridgeModule *)scopedOrientationModule).experienceId];
+}
+
+
+- (void)removeOrientationChangeListener:(NSString *)experienceId
+{
+  [_subscribedModules removeObjectForKey:experienceId];
+}
+
+- (void)addOrientationChangeListener:(NSString *)experienceId subscriberModule:(id)subscriberModule
+{
+  [_subscribedModules setObject:subscriberModule forKey:experienceId];
+}
+
+@end


### PR DESCRIPTION
This reverts commit 454e16d504aee225b3bdc8ee3fedbbdc051c7209.

# Why

resolves [ENG-547](https://linear.app/expo/issue/ENG-547/[test-suite]-sdk-41-qa-screen-orientation-tests)

After #11371, `lockAsync` is broken in iOS Expo Go; it causes the current orientation to change but does **not** persist the lock, which causes various issues. Additionally, the app.json `orientation` setting has no effect either. Essentially, all apps are permanently locked to `DEFAULT` orientation.

# Test Plan

- [x] NCL tests pass
- [x] test-suite tests pass
- [x] app.json `orientation` setting has an effect
