### PR TITLE
[expo] Add react-native-unimodules dependency to bundled-native-modules.json file

### DIFF
--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -106,5 +106,6 @@
   "@react-native-community/slider": "3.0.3",
   "expo-status-bar": "~1.0.4",
   "@react-native-picker/picker": "1.9.11",
-  "@react-native-segmented-control/segmented-control": "2.3.0"
+  "@react-native-segmented-control/segmented-control": "2.3.0",
+  "react-native-unimodules": "~0.13.0"
 }


### PR DESCRIPTION
# Why

Resolves https://linear.app/expo/issue/ENG-493/et-update-project-templates-should-also-update-react-native-unimodules

