### PR TITLE
[docs] eas build: update cocoapods version

### DIFF
--- a/docs/pages/build-reference/infrastructure.md
+++ b/docs/pages/build-reference/infrastructure.md
@@ -53,5 +53,5 @@ Currently, only one image is supported per platform, more images will be availab
 - Node.js 14.15.1
 - Yarn 1.22.10
 - fastlane 2.170.0
-- CocoaPods 1.10.0
+- CocoaPods 1.10.1
 - Ruby 2.6.3p62 (2019-04-16 revision 67580) [universal.x86_64-darwin19]


### PR DESCRIPTION
I bumped the cocoapods version to 1.10.1 in https://github.com/expo/turtle-v2/commit/4940eb4d30da03dd8a09e996bc99809fdb4c840f
