### PR TITLE
[docs] Fix Payments example expYear

### DIFF
--- a/docs/pages/versions/unversioned/sdk/payments.md
+++ b/docs/pages/versions/unversioned/sdk/payments.md
@@ -111,7 +111,7 @@ const params = {
   // mandatory
   number: '4242424242424242',
   expMonth: 11,
-  expYear: 17,
+  expYear: 2025,
   cvc: '223',
   // optional
   name: 'Test User',


### PR DESCRIPTION
# Why

The 'creating token' example in the [Stripe Payments docs](https://docs.expo.io/versions/latest/sdk/payments/) uses a year in the past (2017) which fails when running the code.

# How

i updated the year value from the example code to be 2025; in the future and hence allowing the example request to succeed.

# Test Plan

N/A

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).