### PR TITLE
[expo-updates][ios] remove EXUpdatesUsesLegacyManifest constant

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 🛠 Breaking changes
 
 - remove UPDATES_CONFIGURATION_USES_LEGACY_MANIFEST_KEY constant. ([#12181](https://github.com/expo/expo/pull/12181) by [@jkhales](https://github.com/jkhales))
+- Jonathan/e 499 remove EXUpdatesUsesLegacyManifest Plist constant (ios). ([#12249](https://github.com/expo/expo/pull/12249) by [@jkhales](https://github.com/jkhales))
 
 ### 🎉 New features
 

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.h
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.h
@@ -25,7 +25,6 @@ typedef NS_ENUM(NSInteger, EXUpdatesCheckAutomaticallyConfig) {
 @property (nullable, nonatomic, readonly) NSString *runtimeVersion;
 @property (nonatomic, readonly) BOOL isMissingRuntimeVersion;
 
-@property (nonatomic, readonly) BOOL usesLegacyManifest;
 @property (nonatomic, readonly) BOOL hasEmbeddedUpdate;
 
 + (instancetype)configWithDictionary:(NSDictionary *)config;

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.m
@@ -31,7 +31,6 @@ static NSString * const EXUpdatesConfigLaunchWaitMsKey = @"EXUpdatesLaunchWaitMs
 static NSString * const EXUpdatesConfigCheckOnLaunchKey = @"EXUpdatesCheckOnLaunch";
 static NSString * const EXUpdatesConfigSDKVersionKey = @"EXUpdatesSDKVersion";
 static NSString * const EXUpdatesConfigRuntimeVersionKey = @"EXUpdatesRuntimeVersion";
-static NSString * const EXUpdatesConfigUsesLegacyManifestKey = @"EXUpdatesUsesLegacyManifest";
 static NSString * const EXUpdatesConfigHasEmbeddedUpdateKey = @"EXUpdatesHasEmbeddedUpdate";
 
 static NSString * const EXUpdatesConfigAlwaysString = @"ALWAYS";
@@ -49,7 +48,6 @@ static NSString * const EXUpdatesConfigNeverString = @"NEVER";
     _releaseChannel = EXUpdatesDefaultReleaseChannelName;
     _launchWaitMs = @(0);
     _checkOnLaunch = EXUpdatesCheckAutomaticallyConfigAlways;
-    _usesLegacyManifest = YES;
     _hasEmbeddedUpdate = YES;
   }
   return self;
@@ -134,11 +132,6 @@ static NSString * const EXUpdatesConfigNeverString = @"NEVER";
   id runtimeVersion = config[EXUpdatesConfigRuntimeVersionKey];
   if (runtimeVersion && [runtimeVersion isKindOfClass:[NSString class]]) {
     _runtimeVersion = (NSString *)runtimeVersion;
-  }
-
-  id usesLegacyManifest = config[EXUpdatesConfigUsesLegacyManifestKey];
-  if (usesLegacyManifest && [usesLegacyManifest isKindOfClass:[NSNumber class]]) {
-    _usesLegacyManifest = [(NSNumber *)usesLegacyManifest boolValue];
   }
 
   id hasEmbeddedUpdate = config[EXUpdatesConfigHasEmbeddedUpdateKey];

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate.h
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate.h
@@ -48,7 +48,8 @@ typedef NS_ENUM(NSInteger, EXUpdatesUpdateStatus) {
 + (instancetype)updateWithManifest:(NSDictionary *)manifest
                           response:(nullable NSURLResponse *)response
                             config:(EXUpdatesConfig *)config
-                          database:(EXUpdatesDatabase *)database;
+                          database:(EXUpdatesDatabase *)database
+                             error:(NSError **)error;
 
 + (instancetype)updateWithEmbeddedManifest:(NSDictionary *)manifest
                                     config:(EXUpdatesConfig *)config

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate.m
@@ -61,12 +61,14 @@ NSString * const EXUpdatesUpdateErrorDomain = @"EXUpdatesUpdate";
                           response:(nullable NSURLResponse *)response
                             config:(EXUpdatesConfig *)config
                           database:(EXUpdatesDatabase *)database
-                             error:(NSError **)error
+                             error:(NSError ** _Nullable)error
 {
   if (![response isKindOfClass:[NSHTTPURLResponse class]]) {
-    *error = [NSError errorWithDomain:EXUpdatesUpdateErrorDomain
-                                code:1001
-                            userInfo:@{NSLocalizedDescriptionKey:@"response must be a NSHTTPURLResponse"}];
+    if(error){
+      *error = [NSError errorWithDomain:EXUpdatesUpdateErrorDomain
+                                  code:1001
+                              userInfo:@{NSLocalizedDescriptionKey:@"response must be a NSHTTPURLResponse"}];
+    }
     return nil;
   }
   
@@ -84,9 +86,11 @@ NSString * const EXUpdatesUpdateErrorDomain = @"EXUpdatesUpdate";
                                               config:config
                                             database:database];
   } else {
-    *error = [NSError errorWithDomain:EXUpdatesUpdateErrorDomain
-                                code:1000
-                            userInfo:@{NSLocalizedDescriptionKey:[NSString stringWithFormat:@"expo-protocol-version '%@' is invalid", expoProtocolVersion]}];
+    if(error){
+      *error = [NSError errorWithDomain:EXUpdatesUpdateErrorDomain
+                                  code:1000
+                              userInfo:@{NSLocalizedDescriptionKey:[NSString stringWithFormat:@"expo-protocol-version '%@' is invalid", expoProtocolVersion]}];
+    }
     return nil;
   }
 }

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate.m
@@ -72,7 +72,7 @@ NSString * const EXUpdatesUpdateErrorDomain = @"EXUpdatesUpdate";
   
   NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
   NSDictionary *headerDictionary = [httpResponse allHeaderFields];
-  NSNumber *expoProtocolVersion = headerDictionary[@"expo-protocol-version"];
+  NSString *expoProtocolVersion = headerDictionary[@"expo-protocol-version"];
 
   if (expoProtocolVersion == nil) {
     return [EXUpdatesLegacyUpdate updateWithLegacyManifest:manifest

--- a/packages/expo-updates/ios/Tests/EXUpdatesFileDownloaderTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesFileDownloaderTests.m
@@ -31,9 +31,8 @@
   EXUpdatesFileDownloader *downloader = [[EXUpdatesFileDownloader alloc] initWithUpdatesConfig:config];
 
   NSURLRequest *actual = [downloader createManifestRequestWithURL:[NSURL URLWithString:@"https://exp.host/@test/test"] extraHeaders:nil];
-  XCTAssertEqual(NSURLRequestReloadIgnoringCacheData, actual.cachePolicy);
-  // this fails, seems like this header isn't actually set on the object until later
-  // XCTAssertEqualObjects(@"no-cache", [actual valueForHTTPHeaderField:@"Cache-Control"]);
+  XCTAssertEqual(NSURLRequestUseProtocolCachePolicy, actual.cachePolicy);
+  XCTAssertEqualObjects(nil, [actual valueForHTTPHeaderField:@"Cache-Control"]);
 }
 
 - (void)testCacheControl_NewManifest

--- a/packages/expo-updates/ios/Tests/EXUpdatesUpdateTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesUpdateTests.m
@@ -15,8 +15,7 @@
 @property (nonatomic, strong) NSDictionary *easNewManifest;
 @property (nonatomic, strong) NSDictionary *bareManifest;
 
-@property (nonatomic, strong) EXUpdatesConfig *configUsesLegacyManifestTrue;
-@property (nonatomic, strong) EXUpdatesConfig *configUsesLegacyManifestFalse;
+@property (nonatomic, strong) EXUpdatesConfig *config;
 @property (nonatomic, strong) EXUpdatesDatabase *database;
 
 @end
@@ -46,14 +45,8 @@
     @"commitTime": @(1609975977832)
   };
 
-  _configUsesLegacyManifestTrue = [EXUpdatesConfig configWithDictionary:@{
+  _config = [EXUpdatesConfig configWithDictionary:@{
     @"EXUpdatesURL": @"https://exp.host/@test/test",
-    @"EXUpdatesUsesLegacyManifest": @(YES)
-  }];
-
-  _configUsesLegacyManifestFalse = [EXUpdatesConfig configWithDictionary:@{
-    @"EXUpdatesURL": @"https://exp.host/@test/test",
-    @"EXUpdatesUsesLegacyManifest": @(NO)
   }];
 
   _database = [EXUpdatesDatabase new];
@@ -66,37 +59,31 @@
 
 - (void)testUpdateWithManifest_Legacy
 {
-  EXUpdatesUpdate *update = [EXUpdatesUpdate updateWithManifest:_legacyManifest response:nil config:_configUsesLegacyManifestTrue database:_database];
+  NSError *error;
+  NSURLResponse* response =  [[NSHTTPURLResponse alloc] initWithURL:[NSURL URLWithString:@"https://example.com"] statusCode:200 HTTPVersion:nil headerFields:@{}];
+
+  EXUpdatesUpdate *update = [EXUpdatesUpdate updateWithManifest:_legacyManifest response:response config:_config database:_database error:&error];
   XCTAssert(update != nil);
 }
 
 - (void)testUpdateWithManifest_New
 {
-  EXUpdatesUpdate *update = [EXUpdatesUpdate updateWithManifest:_easNewManifest response:nil config:_configUsesLegacyManifestFalse database:_database];
+  NSError *error;
+  NSURLResponse* response =  [[NSHTTPURLResponse alloc] initWithURL:[NSURL URLWithString:@"https://example.com"] statusCode:200 HTTPVersion:nil headerFields:@{@"expo-protocol-version" : @"0"}];
+
+  EXUpdatesUpdate *update = [EXUpdatesUpdate updateWithManifest:_easNewManifest response:response config:_config database:_database error:&error];
   XCTAssert(update != nil);
 }
 
 - (void)testUpdateWithEmbeddedManifest_Legacy
 {
-  EXUpdatesUpdate *update = [EXUpdatesUpdate updateWithEmbeddedManifest:_legacyManifest config:_configUsesLegacyManifestTrue database:_database];
-  XCTAssert(update != nil);
-}
-
-- (void)testUpdateWithEmbeddedManifest_New
-{
-  EXUpdatesUpdate *update = [EXUpdatesUpdate updateWithEmbeddedManifest:_easNewManifest config:_configUsesLegacyManifestFalse database:_database];
+  EXUpdatesUpdate *update = [EXUpdatesUpdate updateWithEmbeddedManifest:_legacyManifest config:_config database:_database];
   XCTAssert(update != nil);
 }
 
 - (void)testUpdateWithEmbeddedManifest_Legacy_Bare
 {
-  EXUpdatesUpdate *update = [EXUpdatesUpdate updateWithEmbeddedManifest:_bareManifest config:_configUsesLegacyManifestTrue database:_database];
-  XCTAssert(update != nil);
-}
-
-- (void)testUpdateWithEmbeddedManifest_New_Bare
-{
-  EXUpdatesUpdate *update = [EXUpdatesUpdate updateWithEmbeddedManifest:_bareManifest config:_configUsesLegacyManifestFalse database:_database];
+  EXUpdatesUpdate *update = [EXUpdatesUpdate updateWithEmbeddedManifest:_bareManifest config:_config database:_database];
   XCTAssert(update != nil);
 }
 

--- a/packages/expo-updates/ios/Tests/EXUpdatesUpdateTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesUpdateTests.m
@@ -80,8 +80,9 @@
   NSError *error;
   NSURLResponse* response =  [[NSHTTPURLResponse alloc] initWithURL:[NSURL URLWithString:@"https://example.com"] statusCode:200 HTTPVersion:nil headerFields:@{@"expo-protocol-version" : @"1"}];
 
-  [EXUpdatesUpdate updateWithManifest:_easNewManifest response:response config:_config database:_database error:&error];
+  EXUpdatesUpdate *update = [EXUpdatesUpdate updateWithManifest:_easNewManifest response:response config:_config database:_database error:&error];
   XCTAssert(error != nil);
+  XCTAssert(update == nil);
 }
 
 - (void)testUpdateWithEmbeddedManifest_Legacy

--- a/packages/expo-updates/ios/Tests/EXUpdatesUpdateTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesUpdateTests.m
@@ -75,6 +75,15 @@
   XCTAssert(update != nil);
 }
 
+- (void)testUpdateWithManifest_UnsupportedProtocolVersion
+{
+  NSError *error;
+  NSURLResponse* response =  [[NSHTTPURLResponse alloc] initWithURL:[NSURL URLWithString:@"https://example.com"] statusCode:200 HTTPVersion:nil headerFields:@{@"expo-protocol-version" : @"1"}];
+
+  [EXUpdatesUpdate updateWithManifest:_easNewManifest response:response config:_config database:_database error:&error];
+  XCTAssert(error != nil);
+}
+
 - (void)testUpdateWithEmbeddedManifest_Legacy
 {
   EXUpdatesUpdate *update = [EXUpdatesUpdate updateWithEmbeddedManifest:_legacyManifest config:_config database:_database];


### PR DESCRIPTION
# Why
Previously we set `EXUpdatesUsesLegacyManifest` to distinguish between legacy and EAS manifest formats.

This PR changes this to check for `expo-protocol-version` instead. A null value is for legacy, `0` is for the current EAS format.

Sister PR to: https://github.com/expo/expo/pull/12181

# How

Removed `EXUpdatesUsesLegacyManifest` and related code.
Replaced with header check.

# Test Plan

tested manually

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).