### PR TITLE
Created noop file plugin for facebook

### DIFF
--- a/packages/expo-facebook/CHANGELOG.md
+++ b/packages/expo-facebook/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 🎉 New features
 
+- Added noop Swift file generation to iOS plugin. ([#12251](https://github.com/expo/expo/pull/12251) by [@EvanBacon](https://github.com/EvanBacon))
 - Added SKAdNetwork identifiers to iOS plugin. ([#12243](https://github.com/expo/expo/pull/12243) by [@EvanBacon](https://github.com/EvanBacon))
 - Added user tracking permission to iOS plugin. ([#12219](https://github.com/expo/expo/pull/12219) by [@EvanBacon](https://github.com/EvanBacon))
 

--- a/packages/expo-facebook/README.md
+++ b/packages/expo-facebook/README.md
@@ -34,6 +34,8 @@ Add `NSUserTrackingUsageDescription` key to your `Info.plist`:
 
 Add the required `SKAdNetworkIdentifier` items to your `Info.plist`: [Facebook SKAdNetwork](https://developers.facebook.com/docs/SKAdNetwork).
 
+Finally, create a blank Swift file in your project (we recommend naming it `noop-file.swift`). Learn more: [FBSDK blank Swift file](https://github.com/facebook/react-native-fbsdk/issues/755).
+
 ### Configure for Android
 
 No additional set up necessary.

--- a/packages/expo-facebook/package.json
+++ b/packages/expo-facebook/package.json
@@ -40,6 +40,6 @@
     "expo-module-scripts": "^2.0.0"
   },
   "dependencies": {
-    "@expo/config-plugins": "^1.0.18"
+    "@expo/config-plugins": "^1.0.22"
   }
 }

--- a/packages/expo-facebook/plugin/build/withFacebook.js
+++ b/packages/expo-facebook/plugin/build/withFacebook.js
@@ -4,6 +4,7 @@ const config_plugins_1 = require("@expo/config-plugins");
 const withFacebookAndroid_1 = require("./withFacebookAndroid");
 const withFacebookIOS_1 = require("./withFacebookIOS");
 const withSKAdNetworkIdentifiers_1 = require("./withSKAdNetworkIdentifiers");
+const withNoopSwiftFile_1 = require("./withNoopSwiftFile");
 const pkg = require('expo-facebook/package.json');
 const withFacebook = config => {
     config = withFacebookAndroid_1.withFacebookAppIdString(config);
@@ -12,6 +13,7 @@ const withFacebook = config => {
     config = withFacebookIOS_1.withUserTrackingPermission(config);
     // https://developers.facebook.com/docs/SKAdNetwork
     config = withSKAdNetworkIdentifiers_1.withSKAdNetworkIdentifiers(config, ['v9wttpbfk9.skadnetwork', 'n38lu8286q.skadnetwork']);
+    config = withNoopSwiftFile_1.withNoopSwiftFile(config);
     return config;
 };
 exports.default = config_plugins_1.createRunOncePlugin(withFacebook, pkg.name, pkg.version);

--- a/packages/expo-facebook/plugin/build/withFacebook.js
+++ b/packages/expo-facebook/plugin/build/withFacebook.js
@@ -3,8 +3,8 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const config_plugins_1 = require("@expo/config-plugins");
 const withFacebookAndroid_1 = require("./withFacebookAndroid");
 const withFacebookIOS_1 = require("./withFacebookIOS");
-const withSKAdNetworkIdentifiers_1 = require("./withSKAdNetworkIdentifiers");
 const withNoopSwiftFile_1 = require("./withNoopSwiftFile");
+const withSKAdNetworkIdentifiers_1 = require("./withSKAdNetworkIdentifiers");
 const pkg = require('expo-facebook/package.json');
 const withFacebook = config => {
     config = withFacebookAndroid_1.withFacebookAppIdString(config);

--- a/packages/expo-facebook/plugin/build/withFacebookIOS.d.ts
+++ b/packages/expo-facebook/plugin/build/withFacebookIOS.d.ts
@@ -35,11 +35,15 @@ export declare function setFacebookAutoInitEnabled(config: ExpoConfigFacebook, {
     FacebookDisplayName?: string | undefined;
     FacebookAutoLogAppEventsEnabled?: boolean | undefined;
     FacebookAdvertiserIDCollectionEnabled?: boolean | undefined;
+    UIBackgroundModes?: string[] | undefined;
     UISupportedInterfaceOrientations?: import("@expo/config-plugins/build/ios/IosConfig.types").InterfaceOrientation[] | undefined;
     GMSApiKey?: string | undefined;
     GADApplicationIdentifier?: string | undefined;
     UIUserInterfaceStyle?: "Light" | "Dark" | "Automatic" | undefined;
     UIRequiresFullScreen?: boolean | undefined;
+    SKAdNetworkItems?: {
+        SKAdNetworkIdentifier: string;
+    }[] | undefined;
     branch_key?: {
         live?: string | undefined;
     } | undefined;
@@ -61,11 +65,15 @@ export declare function setFacebookAutoInitEnabled(config: ExpoConfigFacebook, {
     FacebookDisplayName?: string | undefined;
     FacebookAutoLogAppEventsEnabled?: boolean | undefined;
     FacebookAdvertiserIDCollectionEnabled?: boolean | undefined;
+    UIBackgroundModes?: string[] | undefined;
     UISupportedInterfaceOrientations?: import("@expo/config-plugins/build/ios/IosConfig.types").InterfaceOrientation[] | undefined;
     GMSApiKey?: string | undefined;
     GADApplicationIdentifier?: string | undefined;
     UIUserInterfaceStyle?: "Light" | "Dark" | "Automatic" | undefined;
     UIRequiresFullScreen?: boolean | undefined;
+    SKAdNetworkItems?: {
+        SKAdNetworkIdentifier: string;
+    }[] | undefined;
     branch_key?: {
         live?: string | undefined;
     } | undefined;
@@ -87,11 +95,15 @@ export declare function setFacebookAutoLogAppEventsEnabled(config: ExpoConfigFac
     FacebookDisplayName?: string | undefined;
     FacebookAutoInitEnabled?: boolean | undefined;
     FacebookAdvertiserIDCollectionEnabled?: boolean | undefined;
+    UIBackgroundModes?: string[] | undefined;
     UISupportedInterfaceOrientations?: import("@expo/config-plugins/build/ios/IosConfig.types").InterfaceOrientation[] | undefined;
     GMSApiKey?: string | undefined;
     GADApplicationIdentifier?: string | undefined;
     UIUserInterfaceStyle?: "Light" | "Dark" | "Automatic" | undefined;
     UIRequiresFullScreen?: boolean | undefined;
+    SKAdNetworkItems?: {
+        SKAdNetworkIdentifier: string;
+    }[] | undefined;
     branch_key?: {
         live?: string | undefined;
     } | undefined;
@@ -113,11 +125,15 @@ export declare function setFacebookAutoLogAppEventsEnabled(config: ExpoConfigFac
     FacebookDisplayName?: string | undefined;
     FacebookAutoInitEnabled?: boolean | undefined;
     FacebookAdvertiserIDCollectionEnabled?: boolean | undefined;
+    UIBackgroundModes?: string[] | undefined;
     UISupportedInterfaceOrientations?: import("@expo/config-plugins/build/ios/IosConfig.types").InterfaceOrientation[] | undefined;
     GMSApiKey?: string | undefined;
     GADApplicationIdentifier?: string | undefined;
     UIUserInterfaceStyle?: "Light" | "Dark" | "Automatic" | undefined;
     UIRequiresFullScreen?: boolean | undefined;
+    SKAdNetworkItems?: {
+        SKAdNetworkIdentifier: string;
+    }[] | undefined;
     branch_key?: {
         live?: string | undefined;
     } | undefined;
@@ -139,11 +155,15 @@ export declare function setFacebookAdvertiserIDCollectionEnabled(config: ExpoCon
     FacebookDisplayName?: string | undefined;
     FacebookAutoInitEnabled?: boolean | undefined;
     FacebookAutoLogAppEventsEnabled?: boolean | undefined;
+    UIBackgroundModes?: string[] | undefined;
     UISupportedInterfaceOrientations?: import("@expo/config-plugins/build/ios/IosConfig.types").InterfaceOrientation[] | undefined;
     GMSApiKey?: string | undefined;
     GADApplicationIdentifier?: string | undefined;
     UIUserInterfaceStyle?: "Light" | "Dark" | "Automatic" | undefined;
     UIRequiresFullScreen?: boolean | undefined;
+    SKAdNetworkItems?: {
+        SKAdNetworkIdentifier: string;
+    }[] | undefined;
     branch_key?: {
         live?: string | undefined;
     } | undefined;
@@ -165,11 +185,15 @@ export declare function setFacebookAdvertiserIDCollectionEnabled(config: ExpoCon
     FacebookDisplayName?: string | undefined;
     FacebookAutoInitEnabled?: boolean | undefined;
     FacebookAutoLogAppEventsEnabled?: boolean | undefined;
+    UIBackgroundModes?: string[] | undefined;
     UISupportedInterfaceOrientations?: import("@expo/config-plugins/build/ios/IosConfig.types").InterfaceOrientation[] | undefined;
     GMSApiKey?: string | undefined;
     GADApplicationIdentifier?: string | undefined;
     UIUserInterfaceStyle?: "Light" | "Dark" | "Automatic" | undefined;
     UIRequiresFullScreen?: boolean | undefined;
+    SKAdNetworkItems?: {
+        SKAdNetworkIdentifier: string;
+    }[] | undefined;
     branch_key?: {
         live?: string | undefined;
     } | undefined;
@@ -191,11 +215,15 @@ export declare function setFacebookAppId(config: Pick<ExpoConfigFacebook, 'faceb
     FacebookAutoInitEnabled?: boolean | undefined;
     FacebookAutoLogAppEventsEnabled?: boolean | undefined;
     FacebookAdvertiserIDCollectionEnabled?: boolean | undefined;
+    UIBackgroundModes?: string[] | undefined;
     UISupportedInterfaceOrientations?: import("@expo/config-plugins/build/ios/IosConfig.types").InterfaceOrientation[] | undefined;
     GMSApiKey?: string | undefined;
     GADApplicationIdentifier?: string | undefined;
     UIUserInterfaceStyle?: "Light" | "Dark" | "Automatic" | undefined;
     UIRequiresFullScreen?: boolean | undefined;
+    SKAdNetworkItems?: {
+        SKAdNetworkIdentifier: string;
+    }[] | undefined;
     branch_key?: {
         live?: string | undefined;
     } | undefined;
@@ -217,11 +245,15 @@ export declare function setFacebookAppId(config: Pick<ExpoConfigFacebook, 'faceb
     FacebookAutoInitEnabled?: boolean | undefined;
     FacebookAutoLogAppEventsEnabled?: boolean | undefined;
     FacebookAdvertiserIDCollectionEnabled?: boolean | undefined;
+    UIBackgroundModes?: string[] | undefined;
     UISupportedInterfaceOrientations?: import("@expo/config-plugins/build/ios/IosConfig.types").InterfaceOrientation[] | undefined;
     GMSApiKey?: string | undefined;
     GADApplicationIdentifier?: string | undefined;
     UIUserInterfaceStyle?: "Light" | "Dark" | "Automatic" | undefined;
     UIRequiresFullScreen?: boolean | undefined;
+    SKAdNetworkItems?: {
+        SKAdNetworkIdentifier: string;
+    }[] | undefined;
     branch_key?: {
         live?: string | undefined;
     } | undefined;
@@ -243,11 +275,15 @@ export declare function setFacebookDisplayName(config: ExpoConfigFacebook, { Fac
     FacebookAutoInitEnabled?: boolean | undefined;
     FacebookAutoLogAppEventsEnabled?: boolean | undefined;
     FacebookAdvertiserIDCollectionEnabled?: boolean | undefined;
+    UIBackgroundModes?: string[] | undefined;
     UISupportedInterfaceOrientations?: import("@expo/config-plugins/build/ios/IosConfig.types").InterfaceOrientation[] | undefined;
     GMSApiKey?: string | undefined;
     GADApplicationIdentifier?: string | undefined;
     UIUserInterfaceStyle?: "Light" | "Dark" | "Automatic" | undefined;
     UIRequiresFullScreen?: boolean | undefined;
+    SKAdNetworkItems?: {
+        SKAdNetworkIdentifier: string;
+    }[] | undefined;
     branch_key?: {
         live?: string | undefined;
     } | undefined;
@@ -269,11 +305,15 @@ export declare function setFacebookDisplayName(config: ExpoConfigFacebook, { Fac
     FacebookAutoInitEnabled?: boolean | undefined;
     FacebookAutoLogAppEventsEnabled?: boolean | undefined;
     FacebookAdvertiserIDCollectionEnabled?: boolean | undefined;
+    UIBackgroundModes?: string[] | undefined;
     UISupportedInterfaceOrientations?: import("@expo/config-plugins/build/ios/IosConfig.types").InterfaceOrientation[] | undefined;
     GMSApiKey?: string | undefined;
     GADApplicationIdentifier?: string | undefined;
     UIUserInterfaceStyle?: "Light" | "Dark" | "Automatic" | undefined;
     UIRequiresFullScreen?: boolean | undefined;
+    SKAdNetworkItems?: {
+        SKAdNetworkIdentifier: string;
+    }[] | undefined;
     branch_key?: {
         live?: string | undefined;
     } | undefined;

--- a/packages/expo-facebook/plugin/build/withNoopSwiftFile.d.ts
+++ b/packages/expo-facebook/plugin/build/withNoopSwiftFile.d.ts
@@ -1,0 +1,2 @@
+import { ConfigPlugin } from '@expo/config-plugins';
+export declare const withNoopSwiftFile: ConfigPlugin;

--- a/packages/expo-facebook/plugin/build/withNoopSwiftFile.js
+++ b/packages/expo-facebook/plugin/build/withNoopSwiftFile.js
@@ -1,0 +1,16 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.withNoopSwiftFile = void 0;
+const config_plugins_1 = require("@expo/config-plugins");
+exports.withNoopSwiftFile = config => {
+    return config_plugins_1.IOSConfig.XcodeProjectFile.withBuildSourceFile(config, {
+        filePath: 'noop-file.swift',
+        contents: [
+            '//',
+            '// @generated',
+            '// A blank Swift file must be created for native modules with Swift files to work correctly.',
+            '//',
+            '',
+        ].join('\n'),
+    });
+};

--- a/packages/expo-facebook/plugin/src/withFacebook.ts
+++ b/packages/expo-facebook/plugin/src/withFacebook.ts
@@ -2,8 +2,8 @@ import { ConfigPlugin, createRunOncePlugin } from '@expo/config-plugins';
 
 import { withFacebookAppIdString, withFacebookManifest } from './withFacebookAndroid';
 import { withFacebookIOS, withUserTrackingPermission } from './withFacebookIOS';
-import { withSKAdNetworkIdentifiers } from './withSKAdNetworkIdentifiers';
 import { withNoopSwiftFile } from './withNoopSwiftFile';
+import { withSKAdNetworkIdentifiers } from './withSKAdNetworkIdentifiers';
 
 const pkg = require('expo-facebook/package.json');
 

--- a/packages/expo-facebook/plugin/src/withFacebook.ts
+++ b/packages/expo-facebook/plugin/src/withFacebook.ts
@@ -3,6 +3,7 @@ import { ConfigPlugin, createRunOncePlugin } from '@expo/config-plugins';
 import { withFacebookAppIdString, withFacebookManifest } from './withFacebookAndroid';
 import { withFacebookIOS, withUserTrackingPermission } from './withFacebookIOS';
 import { withSKAdNetworkIdentifiers } from './withSKAdNetworkIdentifiers';
+import { withNoopSwiftFile } from './withNoopSwiftFile';
 
 const pkg = require('expo-facebook/package.json');
 
@@ -13,6 +14,7 @@ const withFacebook: ConfigPlugin = config => {
   config = withUserTrackingPermission(config);
   // https://developers.facebook.com/docs/SKAdNetwork
   config = withSKAdNetworkIdentifiers(config, ['v9wttpbfk9.skadnetwork', 'n38lu8286q.skadnetwork']);
+  config = withNoopSwiftFile(config);
 
   return config;
 };

--- a/packages/expo-facebook/plugin/src/withNoopSwiftFile.ts
+++ b/packages/expo-facebook/plugin/src/withNoopSwiftFile.ts
@@ -1,0 +1,14 @@
+import { ConfigPlugin, IOSConfig } from '@expo/config-plugins';
+
+export const withNoopSwiftFile: ConfigPlugin = config => {
+  return IOSConfig.XcodeProjectFile.withBuildSourceFile(config, {
+    filePath: 'noop-file.swift',
+    contents: [
+      '//',
+      '// @generated',
+      '// A blank Swift file must be created for native modules with Swift files to work correctly.',
+      '//',
+      '',
+    ].join('\n'),
+  });
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1338,6 +1338,26 @@
     xcode "^2.1.0"
     xml2js "^0.4.23"
 
+"@expo/config-plugins@^1.0.22":
+  version "1.0.22"
+  resolved "https://registry.yarnpkg.com/@expo/config-plugins/-/config-plugins-1.0.22.tgz#dc9cf458444d0aed100827d82a1c9e7df20c7991"
+  integrity sha512-kTZdJDO53riwsMHocQi/5RGwrkJ3LiUORqnCer4CQ2yWJHk+MQoEYlNUzojrzB0DaHjEsYSLt4NLqbVi5FuI8Q==
+  dependencies:
+    "@expo/config-types" "^40.0.0-beta.2"
+    "@expo/configure-splash-screen" "0.3.4"
+    "@expo/image-utils" "0.3.11"
+    "@expo/json-file" "8.2.28-alpha.0"
+    "@expo/plist" "0.0.11"
+    find-up "~5.0.0"
+    fs-extra "9.0.0"
+    getenv "^1.0.0"
+    glob "7.1.6"
+    resolve-from "^5.0.0"
+    slash "^3.0.0"
+    slugify "^1.3.4"
+    xcode "^2.1.0"
+    xml2js "^0.4.23"
+
 "@expo/config-types@^39.0.0":
   version "39.0.1"
   resolved "https://registry.yarnpkg.com/@expo/config-types/-/config-types-39.0.1.tgz#5ed09545a1418b46a237f215b9bdbca2ed051851"
@@ -1507,6 +1527,23 @@
     semver "7.3.2"
     tempy "0.3.0"
 
+"@expo/image-utils@0.3.11":
+  version "0.3.11"
+  resolved "https://registry.yarnpkg.com/@expo/image-utils/-/image-utils-0.3.11.tgz#2a2ddf48af14eb0faf5b1b296b16eb6518b22d79"
+  integrity sha512-JH5/FExvEsz9H9QsgoOEN3QYqH9V50dKjpkwTkytXLutD5Z587xSRka57pbX+d4nkHqiQBT0W8buUkbma78NYg==
+  dependencies:
+    "@expo/spawn-async" "1.5.0"
+    chalk "^4.0.0"
+    fs-extra "9.0.0"
+    getenv "^1.0.0"
+    jimp "0.12.1"
+    mime "^2.4.4"
+    node-fetch "^2.6.0"
+    parse-png "^2.1.0"
+    resolve-from "^5.0.0"
+    semver "7.3.2"
+    tempy "0.3.0"
+
 "@expo/image-utils@0.3.4":
   version "0.3.4"
   resolved "https://registry.yarnpkg.com/@expo/image-utils/-/image-utils-0.3.4.tgz#ff042ff33dfb107f4bfa3421c2e6c9ecdc46aa64"
@@ -1583,6 +1620,16 @@
     fs-extra "9.0.0"
     json5 "^1.0.1"
     lodash "^4.17.19"
+    write-file-atomic "^2.3.0"
+
+"@expo/json-file@8.2.28-alpha.0":
+  version "8.2.28-alpha.0"
+  resolved "https://registry.yarnpkg.com/@expo/json-file/-/json-file-8.2.28-alpha.0.tgz#0e5280c82a17165be12c6a95cd95ec108c6dfe7b"
+  integrity sha512-cCQdw/Nfw8doXjN3onvUnWkuJjtVxx2iUjSOLMydvgI87YpW3x05uUXOVs4P+77YFVoFS6xbki+fmKK2JSCf8w==
+  dependencies:
+    "@babel/code-frame" "~7.10.4"
+    fs-extra "9.0.0"
+    json5 "^1.0.1"
     write-file-atomic "^2.3.0"
 
 "@expo/metro-config@0.1.24":


### PR DESCRIPTION
# Why

- Fixes expo-facebook config plugin
<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How

- Created plugin to generate noop swift file which is required for ios FBSDK to work.
<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

- expo eject NCL and build it (latest expo-cli is required `4.3.1`)
  - noop swift file should be created

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).