### PR TITLE
[docs] Instruct user to check Firebase API Key restrictions

### DIFF
--- a/docs/pages/push-notifications/using-fcm.md
+++ b/docs/pages/push-notifications/using-fcm.md
@@ -43,7 +43,7 @@ Note that FCM is not currently available for Expo iOS apps.
     ]
   }
   ```
-  **Note:** Firebase will create an API key in the Google Cloud Platform console with a name like `Android key (auto created by Firebase)`. **This is not always the same key as the one found in `google-services.json`. Always confirm your key and associated restrictions in the Google Cloud Platform console.**
+>  **Note:** Firebase will create an API key in the Google Cloud Platform console with a name like `Android key (auto created by Firebase)`. **This is not always the same key as the one found in `google-services.json`. Always confirm your key and associated restrictions in the Google Cloud Platform console.**
 
 6. Finally, make a new build of your app by running `expo build:android`.
 

--- a/docs/pages/push-notifications/using-fcm.md
+++ b/docs/pages/push-notifications/using-fcm.md
@@ -17,17 +17,35 @@ Note that FCM is not currently available for Expo iOS apps.
 
 4. In your app.json, add an `android.googleServicesFile` field with the relative path to the `google-services.json` file you just downloaded. If you placed it in the root directory, this will probably look like
 
-```javascript
-{
-  ...
-  "android": {
-    "googleServicesFile": "./google-services.json",
+  ```javascript
+  {
     ...
+    "android": {
+      "googleServicesFile": "./google-services.json",
+      ...
+    }
   }
-}
-```
+  ```
 
-Finally, make a new build of your app by running `expo build:android`.
+5.  Confirm that the API key in the `google-services.json` file has the correct restrictions in the [Google Cloud Platform API Credentials console](https://console.cloud.google.com/apis/credentials). Firebase requires the API key to have access to both `Firebase Cloud Messaging API` and `Firebase Installations API` for push notifications to work correctly. The API key in the `google-services.json` file can be found under the `client.api_key.current_key` field, e.g.
+
+  ```javascript
+  {
+    ...
+    "client": [
+      {
+        "api_key": [
+          {
+            "current_key" "<your Google Cloud Platform API key>",
+          }
+        ],
+      }
+    ]
+  }
+  ```
+  **Note:** Firebase will create an API key in the Google Cloud Platform console with a name like `Android key (auto created by Firebase)`. **This is not always the same key as the one found in `google-services.json`. Always confirm your key and associated restrictions in the Google Cloud Platform console.**
+
+6. Finally, make a new build of your app by running `expo build:android`.
 
 ### Bare projects
 

--- a/docs/pages/push-notifications/using-fcm.md
+++ b/docs/pages/push-notifications/using-fcm.md
@@ -27,7 +27,7 @@ Note that FCM is not currently available for Expo iOS apps.
   }
   ```
 
-5.  Confirm that the API key in the `google-services.json` file has the correct restrictions in the [Google Cloud Platform API Credentials console](https://console.cloud.google.com/apis/credentials). Firebase requires the API key to have access to both `Firebase Cloud Messaging API` and `Firebase Installations API` for push notifications to work correctly. The API key in the `google-services.json` file can be found under the `client.api_key.current_key` field, e.g.
+5.  Confirm that your API key in `google-services.json` has the correct "API restrictions" in the [Google Cloud Platform API Credentials console](https://console.cloud.google.com/apis/credentials). For push notifications to work correctly, Firebase requires the API key to either be unrestricted (the key can call any API), or have access to both `Firebase Cloud Messaging API` and `Firebase Installations API`. The API key can be found under the `client.api_key.current_key` field in `google-services.json`.
 
   ```javascript
   {


### PR DESCRIPTION
Added in an extra step in the 'Client Setup' step of the 'Using FCM for
Push Notifications' doc.

Firebase will sometimes reuse an existing API Key, instead of using the
key that it autogenerates. If this key has existing restrictions it will
prevent Firebase from working correctly. Users should double check the
key restrictions to prevent Firebase from failing.

See: https://github.com/expo/expo/issues/9061#issuecomment-662423138

# Why

See above

# How

N/A

# Test Plan

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).