### PR TITLE
[expo-updates] Updated @expo/metro-config dependency to 0.1.58.

### DIFF
--- a/packages/expo-updates/package.json
+++ b/packages/expo-updates/package.json
@@ -34,16 +34,16 @@
     "preset": "expo-module-scripts"
   },
   "dependencies": {
-    "@expo/metro-config": "^0.1.16",
     "@expo/config-plugins": "^1.0.18",
+    "@expo/metro-config": "^0.1.58",
     "expo-structured-headers": "~1.0.1",
     "fbemitter": "^2.1.1",
-    "uuid": "^3.4.0",
-    "resolve-from": "^5.0.0"
+    "resolve-from": "^5.0.0",
+    "uuid": "^3.4.0"
   },
   "devDependencies": {
     "expo-module-scripts": "^2.0.0",
-    "memfs": "^3.2.0",
-    "fs-extra": "^9.1.0"
+    "fs-extra": "^9.1.0",
+    "memfs": "^3.2.0"
   }
 }


### PR DESCRIPTION
# Why

Updated @expo/metro-config to 0.1.58. in `expo-updates` package.

The motivation behind this is to follow up this pr: https://github.com/expo/expo-cli/pull/3299

getenv dependency that @expo/metro-config was using did not have the MIT license attached to it, so it was updated to use the latest version that has it in the right place. 

# How

Run `yarn upgrade @expo/metro-config@^1.0.58`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [N/A] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [N/A] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [N/A] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).