### PR TITLE
[expo][docs] add sentry-expo to bundledNativeModules

### DIFF
--- a/docs/pages/guides/using-sentry.md
+++ b/docs/pages/guides/using-sentry.md
@@ -39,7 +39,8 @@ Once you have each of these: organization name, project name, DSN, and auth toke
 
 ### Install and configure Sentry
 
-- In your project, install the Expo integration: `yarn add sentry-expo` or `npm i sentry-expo`
+- In your project, install the Expo integration: `expo install sentry-expo`
+  > If you're using SDK 39 or below, run `yarn add sentry-expo@~3.0.0` or `npm i sentry-expo@~3.0.0`
 - Add the following in your app's main file (usually `App.js`):
 
 ```javascript

--- a/docs/pages/guides/using-sentry.md
+++ b/docs/pages/guides/using-sentry.md
@@ -40,7 +40,7 @@ Once you have each of these: organization name, project name, DSN, and auth toke
 ### Install and configure Sentry
 
 - In your project, install the Expo integration: `expo install sentry-expo`
-  > If you're using SDK 39 or below, run `yarn add sentry-expo@~3.0.0` or `npm i sentry-expo@~3.0.0`
+  > If you're using SDK 39 or lower, run `npm install sentry-expo@~3.0.0`
 - Add the following in your app's main file (usually `App.js`):
 
 ```javascript

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -108,5 +108,6 @@
   "expo-status-bar": "~1.0.4",
   "@react-native-picker/picker": "1.9.11",
   "@react-native-segmented-control/segmented-control": "2.3.0",
-  "react-native-unimodules": "~0.13.0"
+  "react-native-unimodules": "~0.13.0",
+  "sentry-expo": "^3.1.0"
 }


### PR DESCRIPTION
# Why


This will make it so that future updates to sentry-expo don't always have to be compatible with all SDK versions (although hopefully they always are anyways 😅 )