### PR TITLE
[expo-dev-menu][android] Reuse the react root view

### DIFF
--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/DevMenuActivity.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/DevMenuActivity.kt
@@ -3,9 +3,13 @@ package expo.modules.devmenu
 import android.content.Context
 import android.os.Bundle
 import android.view.KeyEvent
+import android.view.ViewGroup
 import com.facebook.react.ReactActivity
 import com.facebook.react.ReactActivityDelegate
+import com.facebook.react.ReactDelegate
 import com.facebook.react.ReactRootView
+import expo.modules.devmenu.helpers.getPrivateDeclaredFiledValue
+import expo.modules.devmenu.helpers.setPrivateDeclaredFiledValue
 import java.util.*
 
 /**
@@ -18,6 +22,35 @@ class DevMenuActivity : ReactActivity() {
 
   override fun createReactActivityDelegate(): ReactActivityDelegate {
     return object : ReactActivityDelegate(this, mainComponentName) {
+      // We don't want to destroy the root view, because we want to reuse it later.
+      override fun onDestroy() = Unit
+
+      override fun loadApp(appKey: String?) {
+        // On the first launch of this activity we need to call super.loadApp() to start the dev menu
+        if (!appWasLoaded) {
+          super.loadApp(appKey)
+          appWasLoaded = true
+          return
+        }
+
+        val reactDelegate: ReactDelegate = ReactActivityDelegate::class.java
+          .getPrivateDeclaredFiledValue("mReactDelegate", this)
+
+        ReactDelegate::class.java
+          .setPrivateDeclaredFiledValue("mReactRootView", reactDelegate, rootView)
+
+        // Removes the root view from the previous activity
+        (rootView.parent as? ViewGroup)?.removeView(rootView)
+
+        // Attaches the root view to the current activity
+        plainActivity.setContentView(reactDelegate.reactRootView)
+
+        // Sets up new app properties
+        runOnUiThread {
+          rootView.appProperties = launchOptions
+        }
+      }
+
       override fun getReactNativeHost() = DevMenuManager.getMenuHost()
 
       override fun getLaunchOptions() = Bundle().apply {
@@ -30,7 +63,7 @@ class DevMenuActivity : ReactActivity() {
         putString("openScreen", DevMenuManager.getSession()?.openScreen)
       }
 
-      override fun createRootView() = getVendoredClass<ReactRootView>("com.swmansion.gesturehandler.react.RNGestureHandlerEnabledRootView", arrayOf(Context::class.java), arrayOf(this@DevMenuActivity))
+      override fun createRootView() = createRootView(this@DevMenuActivity)
     }
   }
 
@@ -46,5 +79,23 @@ class DevMenuActivity : ReactActivity() {
   override fun onPause() {
     super.onPause()
     overridePendingTransition(0, 0)
+  }
+
+  companion object {
+    var appWasLoaded = false
+    private lateinit var rootView: ReactRootView
+
+    fun createRootView(activity: ReactActivity): ReactRootView {
+      if (::rootView.isInitialized) {
+        return rootView
+      }
+
+      rootView = getVendoredClass(
+        "com.swmansion.gesturehandler.react.RNGestureHandlerEnabledRootView",
+        arrayOf(Context::class.java),
+        arrayOf(activity)
+      )
+      return rootView
+    }
   }
 }

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/helpers/DevMenuReflectionExtensions.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/helpers/DevMenuReflectionExtensions.kt
@@ -1,0 +1,26 @@
+package expo.modules.devmenu.helpers
+
+import java.lang.reflect.Field
+import java.lang.reflect.Modifier
+
+@Suppress("UNCHECKED_CAST")
+fun <T, R> Class<out T>.getPrivateDeclaredFiledValue(filedName: String, obj: T) : R {
+  val field = getDeclaredField(filedName)
+  field.isAccessible = true
+  return field.get(obj) as R
+}
+
+fun <T> Class<out T>.setPrivateDeclaredFiledValue(filedName: String, obj: T, newValue: Any) {
+  val field = getDeclaredField(filedName)
+  val modifiersField = Field::class.java.getDeclaredField("accessFlags")
+
+  field.isAccessible = true
+  modifiersField.isAccessible = true
+
+  modifiersField.setInt(
+    field,
+    field.modifiers and Modifier.FINAL.inv()
+  )
+
+  field.set(obj, newValue)
+}


### PR DESCRIPTION
# Why

Closes ENG-344.

# How

- Saved the root view after creation.
- Restore the root view if any instance of the view was saved. 

# Test Plan

- bare-expo ✅