### PR TITLE
[ios][Expo Go] fix web socket versioning

### DIFF
--- a/ios/Exponent/Kernel/DevSupport/EXKernelDevKeyCommands.m
+++ b/ios/Exponent/Kernel/DevSupport/EXKernelDevKeyCommands.m
@@ -8,7 +8,6 @@
 
 #import <React/RCTDefines.h>
 #import <React/RCTUtils.h>
-#import <React/RCTPackagerConnection.h>
 
 #import <UIKit/UIKit.h>
 

--- a/ios/Exponent/Kernel/DevSupport/EXKernelDevKeyCommands.m
+++ b/ios/Exponent/Kernel/DevSupport/EXKernelDevKeyCommands.m
@@ -163,51 +163,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
                              action:^(__unused UIKeyCommand *_) {
                                [weakSelf _handleKernelMenuCommand];
                              }];
-  
-  // Attach listeners to the bundler's dev server web socket connection.
-  // This enables tools to automatically reload the client remotely (i.e. in expo-cli).
-  
-  // Enable a lot of tools under the same command namespace
-  [[RCTPackagerConnection sharedPackagerConnection]
-      addNotificationHandler:^(id params) {
-        if (params != [NSNull null] && (NSDictionary *)params) {
-          NSDictionary *_params = (NSDictionary *)params;
-          if (_params[@"name"] != nil && (NSString *)_params[@"name"]) {
-            NSString *name = _params[@"name"];
-            if ([name isEqualToString:@"reload"]) {
-              [weakSelf _handleRefreshCommand];
-            } else if ([name isEqualToString:@"toggleDevMenu"]) {
-              [weakSelf _handleMenuCommand];
-            } else if ([name isEqualToString:@"toggleRemoteDebugging"]) {
-              [weakSelf _handleToggleRemoteDebuggingCommand];
-            } else if ([name isEqualToString:@"toggleElementInspector"]) {
-              [weakSelf _handleToggleInspectorCommand];
-            } else if ([name isEqualToString:@"togglePerformanceMonitor"]) {
-              [weakSelf _handleTogglePerformanceMonitorCommand];
-            }
-          }
-        }
-      }
-                       queue:dispatch_get_main_queue()
-                   forMethod:@"sendDevCommand"];
-  
-  // These (reload and devMenu) are here to match RN dev tooling.
-  
-  // Reload the app on "reload"
-  [[RCTPackagerConnection sharedPackagerConnection]
-      addNotificationHandler:^(id params) {
-        [weakSelf _handleRefreshCommand];
-      }
-                       queue:dispatch_get_main_queue()
-                   forMethod:@"reload"];
-  
-  // Open the dev menu on "devMenu"
-  [[RCTPackagerConnection sharedPackagerConnection]
-      addNotificationHandler:^(id params) {
-        [weakSelf _handleMenuCommand];
-      }
-                       queue:dispatch_get_main_queue()
-                   forMethod:@"devMenu"];
+
 }
 
 - (void)_handleMenuCommand

--- a/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager.mm
+++ b/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager.mm
@@ -137,6 +137,7 @@ typedef void (^SDK21RCTSourceLoadBlock)(NSError *error, NSData *source, int64_t 
                                            initialProperties:[self initialPropertiesForRootView]];
     }
 
+    [self setupWebSocketControls];
     [_delegate reactAppManagerIsReadyForLoad:self];
     
     NSAssert([_reactBridge isLoading], @"React bridge should be loading once initialized");
@@ -623,6 +624,66 @@ typedef void (^SDK21RCTSourceLoadBlock)(NSError *error, NSData *source, int64_t 
 {
   if ([self enablesDeveloperTools]) {
     [self.versionManager toggleElementInspectorForBridge:self.reactBridge];
+  }
+}
+
+- (void)toggleDevMenu
+{
+  if ([EXEnvironment sharedEnvironment].isDetached) {
+    [[EXKernel sharedInstance].visibleApp.appManager showDevMenu];
+  } else {
+    [[EXKernel sharedInstance] switchTasks];
+  }
+}
+
+- (void)setupWebSocketControls
+{
+  if ([self enablesDeveloperTools]) {
+    if ([_versionManager respondsToSelector:@selector(addWebSocketNotificationHandler:queue:forMethod:)]) {
+      __weak typeof(self) weakSelf = self;
+
+      // Attach listeners to the bundler's dev server web socket connection.
+      // This enables tools to automatically reload the client remotely (i.e. in expo-cli).
+
+      // Enable a lot of tools under the same command namespace
+      [_versionManager addWebSocketNotificationHandler:^(id params) {
+        if (params != [NSNull null] && (NSDictionary *)params) {
+          NSDictionary *_params = (NSDictionary *)params;
+          if (_params[@"name"] != nil && (NSString *)_params[@"name"]) {
+            NSString *name = _params[@"name"];
+            if ([name isEqualToString:@"reload"]) {
+              [[EXKernel sharedInstance] reloadVisibleApp];
+            } else if ([name isEqualToString:@"toggleDevMenu"]) {
+              [weakSelf toggleDevMenu];
+            } else if ([name isEqualToString:@"toggleRemoteDebugging"]) {
+              [weakSelf toggleRemoteDebugging];
+            } else if ([name isEqualToString:@"toggleElementInspector"]) {
+              [weakSelf toggleElementInspector];
+            } else if ([name isEqualToString:@"togglePerformanceMonitor"]) {
+              [weakSelf togglePerformanceMonitor];
+            }
+          }
+        }
+      }
+                                                 queue:dispatch_get_main_queue()
+                                             forMethod:@"sendDevCommand"];
+
+      // These (reload and devMenu) are here to match RN dev tooling.
+
+      // Reload the app on "reload"
+      [_versionManager addWebSocketNotificationHandler:^(id params) {
+        [[EXKernel sharedInstance] reloadVisibleApp];
+      }
+                                                 queue:dispatch_get_main_queue()
+                                             forMethod:@"reload"];
+
+      // Open the dev menu on "devMenu"
+      [_versionManager addWebSocketNotificationHandler:^(id params) {
+        [weakSelf toggleDevMenu];
+      }
+                                                 queue:dispatch_get_main_queue()
+                                             forMethod:@"devMenu"];
+    }
   }
 }
 

--- a/ios/Exponent/Versioned/Core/EXVersionManager.h
+++ b/ios/Exponent/Versioned/Core/EXVersionManager.h
@@ -22,6 +22,9 @@
 - (void)toggleRemoteDebuggingForBridge:(id)bridge;
 - (void)togglePerformanceMonitorForBridge:(id)bridge;
 - (void)toggleElementInspectorForBridge:(id)bridge;
+- (uint32_t)addWebSocketNotificationHandler:(void (^)(NSDictionary<NSString *, id> *))handler
+                         queue:(dispatch_queue_t)queue
+                     forMethod:(NSString *)method;
 
 - (NSDictionary<NSString *, NSString *> *)devMenuItemsForBridge:(id)bridge;
 - (void)selectDevMenuItemWithKey:(NSString *)key onBridge:(id)bridge;

--- a/ios/Exponent/Versioned/Core/EXVersionManager.mm
+++ b/ios/Exponent/Versioned/Core/EXVersionManager.mm
@@ -289,6 +289,12 @@ RCT_EXTERN void EXRegisterScopedModule(Class, ...);
   [devSettings toggleElementInspector];
 }
 
+- (uint32_t)addWebSocketNotificationHandler:(void (^)(NSDictionary<NSString *, id> *))handler
+                                    queue:(dispatch_queue_t)queue
+                                forMethod:(NSString *)method
+{
+  return [[RCTPackagerConnection sharedPackagerConnection] addNotificationHandler:handler queue:queue forMethod:method];
+}
 
 #pragma mark - internal
 

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/ABI41_0_0EXVersionManager.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/ABI41_0_0EXVersionManager.h
@@ -22,7 +22,10 @@
 - (void)toggleRemoteDebuggingForBridge:(id)bridge;
 - (void)togglePerformanceMonitorForBridge:(id)bridge;
 - (void)toggleElementInspectorForBridge:(id)bridge;
-
+- (uint32_t)addWebSocketNotificationHandler:(void (^)(NSDictionary<NSString *, id> *))handler
+                         queue:(dispatch_queue_t)queue
+                     forMethod:(NSString *)method;
+                     
 - (NSDictionary<NSString *, NSString *> *)devMenuItemsForBridge:(id)bridge;
 - (void)selectDevMenuItemWithKey:(NSString *)key onBridge:(id)bridge;
 

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/ABI41_0_0EXVersionManager.mm
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/ABI41_0_0EXVersionManager.mm
@@ -289,6 +289,12 @@ ABI41_0_0RCT_EXTERN void ABI41_0_0EXRegisterScopedModule(Class, ...);
   [devSettings toggleElementInspector];
 }
 
+- (uint32_t)addWebSocketNotificationHandler:(void (^)(NSDictionary<NSString *, id> *))handler
+                                    queue:(dispatch_queue_t)queue
+                                forMethod:(NSString *)method
+{
+  return [[ABI41_0_0RCTPackagerConnection sharedPackagerConnection] addNotificationHandler:handler queue:queue forMethod:method];
+}
 
 #pragma mark - internal
 


### PR DESCRIPTION
# Why

The current implementation doesn't work with versioning, this implementation moves the logic behind a versioned interface.
<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# Test Plan

- Built Expo Go from source and tested against unversioned.
<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).