### PR TITLE
[ios] Manually set the notification service extension's release profile

### DIFF
--- a/ios/Exponent.xcodeproj/project.pbxproj
+++ b/ios/Exponent.xcodeproj/project.pbxproj
@@ -3422,7 +3422,7 @@
 				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_IDENTITY = "Apple Distribution";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = C8D8QTF339;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
@@ -3433,6 +3433,7 @@
 				OTHER_LDFLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = host.exp.Exponent.ExpoNotificationServiceExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "ExpoNotificationServiceExtension (App Store)";
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "ExpoNotificationServiceExtension/ExpoNotificationServiceExtension-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";


### PR DESCRIPTION
Why
===
We need to configure the notification service extension's provisioning profile for App Store release.

How
===
I manually created an App ID and App Store provisioning profile for `host.exp.Exponent.ExpoNotificationServiceExtension` through the Apple Developer website and associated it with an existing App Store distribution certificate.

Through Xcode, I configured the ExpoNotificationServiceExtension target's Release provisioning profile to be managed manually, and set it to the provisioning profile I created online.

Test Plan
=========
I didn't test this for the release build since I don't have the certificate on my computer.

The warning notice about the wrong provisioning profile is now gone.