### PR TITLE
[docs] Add projectId to example Firebase configuration

### DIFF
--- a/docs/pages/guides/setup-native-firebase.md
+++ b/docs/pages/guides/setup-native-firebase.md
@@ -65,6 +65,7 @@ which is otherwise unavailable in react-native using the Firebase JavaScript SDK
         "firebase": {
           "appId": "xxxxxxxxxxxxx:web:xxxxxxxxxxxxxxxx",
           "apiKey": "AIzaXXXXXXXX-xxxxxxxxxxxxxxxxxxx",
+          "projectId": "my-awesome-project-id",
           ...
           "measurementId": "G-XXXXXXXXXXXX"
         }


### PR DESCRIPTION
# Why

Omitting the `projectId` configuration results in an error:
<img width="1217" alt="Screen Shot 2021-03-23 at 16 53 53" src="https://user-images.githubusercontent.com/497214/112167324-090e9400-8bf9-11eb-9bd4-6c8b30407482.png">
