### PR TITLE
[home] Add deep link into QR scanner

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/ExpoTurboPackage.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/ExpoTurboPackage.java
@@ -19,11 +19,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import javax.annotation.Nullable;
+
 import host.exp.exponent.ExponentManifest;
 import versioned.host.exp.exponent.modules.internal.ExponentAsyncStorageModule;
 import versioned.host.exp.exponent.modules.internal.ExponentIntentModule;
 import versioned.host.exp.exponent.modules.internal.ExponentUnsignedAsyncStorageModule;
 
+import static host.exp.exponent.kernel.KernelConstants.INTENT_URI_KEY;
 import static host.exp.exponent.kernel.KernelConstants.IS_HEADLESS_KEY;
 import static host.exp.exponent.kernel.KernelConstants.LINKING_URI_KEY;
 
@@ -45,10 +48,13 @@ public class ExpoTurboPackage extends TurboReactPackage {
     mManifest = manifest;
   }
 
-  public static ExpoTurboPackage kernelExpoTurboPackage(JSONObject manifest) {
+  public static ExpoTurboPackage kernelExpoTurboPackage(JSONObject manifest, @Nullable String initialURL) {
     Map<String, Object> kernelExperienceProperties = new HashMap<>();
     kernelExperienceProperties.put(LINKING_URI_KEY, "exp://");
     kernelExperienceProperties.put(IS_HEADLESS_KEY, false);
+    if (initialURL != null) {
+      kernelExperienceProperties.put(INTENT_URI_KEY, initialURL);
+    }
     return new ExpoTurboPackage(kernelExperienceProperties, manifest);
   }
 

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/ExponentPackage.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/ExponentPackage.java
@@ -25,6 +25,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import javax.annotation.Nullable;
+
 import host.exp.exponent.Constants;
 import host.exp.exponent.ExponentManifest;
 import host.exp.exponent.analytics.EXL;
@@ -69,6 +71,7 @@ import versioned.host.exp.exponent.modules.universal.ScopedModuleRegistryAdapter
 // This is an Expo module but not a unimodule
 import expo.modules.random.RandomModule;
 
+import static host.exp.exponent.kernel.KernelConstants.INTENT_URI_KEY;
 import static host.exp.exponent.kernel.KernelConstants.IS_HEADLESS_KEY;
 import static host.exp.exponent.kernel.KernelConstants.LINKING_URI_KEY;
 
@@ -115,11 +118,14 @@ public class ExponentPackage implements ReactPackage {
   }
 
 
-  public static ExponentPackage kernelExponentPackage(Context context, JSONObject manifest, List<Package> expoPackages) {
+  public static ExponentPackage kernelExponentPackage(Context context, JSONObject manifest, List<Package> expoPackages, @Nullable String initialURL) {
     Map<String, Object> kernelExperienceProperties = new HashMap<>();
     List<SingletonModule> singletonModules = ExponentPackage.getOrCreateSingletonModules(context, manifest, expoPackages);
     kernelExperienceProperties.put(LINKING_URI_KEY, "exp://");
     kernelExperienceProperties.put(IS_HEADLESS_KEY, false);
+    if (initialURL != null) {
+      kernelExperienceProperties.put(INTENT_URI_KEY, initialURL);
+    }
     return new ExponentPackage(true, kernelExperienceProperties, manifest, expoPackages, singletonModules);
   }
 

--- a/dev-home-config.json
+++ b/dev-home-config.json
@@ -1,3 +1,3 @@
 {
-  "url": "exp://expo.io/@expo-home-dev/expo-home-dev-96fc833e96d775fc772d328b4b117728eb096204"
+  "url": "exp://expo.io/@expo-home-dev/expo-home-dev-9dbfd48abe7ab7d183780081eb6a8f9460504e13"
 }

--- a/home/navigation/Navigation.tsx
+++ b/home/navigation/Navigation.tsx
@@ -222,34 +222,46 @@ function TabNavigator(props: { theme: string }) {
 
 const ModalStack = createStackNavigator();
 
-export default (props: { theme: string }) => (
-  <NavigationContainer theme={Themes[props.theme]}>
-    <ModalStack.Navigator
-      initialRouteName="RootStack"
-      screenOptions={({ route, navigation }) => ({
-        headerShown: false,
-        gestureEnabled: true,
-        cardOverlayEnabled: true,
-        cardStyle: { backgroundColor: 'transparent' },
-        headerStatusBarHeight:
-          navigation.dangerouslyGetState().routes.indexOf(route) > 0 ? 0 : undefined,
-        ...TransitionPresets.ModalPresentationIOS,
-      })}
-      mode="modal">
-      <ModalStack.Screen name="RootStack">
-        {() => (
-          <RootStack.Navigator initialRouteName="Tabs" mode="modal">
-            <RootStack.Screen name="Tabs" options={{ headerShown: false }}>
-              {() => <TabNavigator theme={props.theme} />}
-            </RootStack.Screen>
-          </RootStack.Navigator>
-        )}
-      </ModalStack.Screen>
-      <ModalStack.Screen name="QRCode" component={QRCodeScreen} />
-      <ModalStack.Screen name="Experience" component={ExperienceScreen} />
-    </ModalStack.Navigator>
-  </NavigationContainer>
-);
+export default (props: { theme: string }) => {
+  const linking = {
+    prefixes: ['expogo://'],
+    config: {
+      initialRouteName: 'RootStack',
+      screens: {
+        QRCode: 'qr-scanner',
+      },
+    },
+  };
+
+  return (
+    <NavigationContainer theme={Themes[props.theme]} linking={linking}>
+      <ModalStack.Navigator
+        initialRouteName="RootStack"
+        screenOptions={({ route, navigation }) => ({
+          headerShown: false,
+          gestureEnabled: true,
+          cardOverlayEnabled: true,
+          cardStyle: { backgroundColor: 'transparent' },
+          headerStatusBarHeight:
+            navigation.dangerouslyGetState().routes.indexOf(route) > 0 ? 0 : undefined,
+          ...TransitionPresets.ModalPresentationIOS,
+        })}
+        mode="modal">
+        <ModalStack.Screen name="RootStack">
+          {() => (
+            <RootStack.Navigator initialRouteName="Tabs" mode="modal">
+              <RootStack.Screen name="Tabs" options={{ headerShown: false }}>
+                {() => <TabNavigator theme={props.theme} />}
+              </RootStack.Screen>
+            </RootStack.Navigator>
+          )}
+        </ModalStack.Screen>
+        <ModalStack.Screen name="QRCode" component={QRCodeScreen} />
+        <ModalStack.Screen name="Experience" component={ExperienceScreen} />
+      </ModalStack.Navigator>
+    </NavigationContainer>
+  );
+};
 
 const styles = StyleSheet.create({
   icon: {

--- a/home/navigation/Navigation.tsx
+++ b/home/navigation/Navigation.tsx
@@ -224,7 +224,7 @@ const ModalStack = createStackNavigator();
 
 export default (props: { theme: string }) => {
   const linking = {
-    prefixes: ['expogo://'],
+    prefixes: ['expo-home://'],
     config: {
       initialRouteName: 'RootStack',
       screens: {

--- a/template-files/android/AndroidManifest.xml
+++ b/template-files/android/AndroidManifest.xml
@@ -142,6 +142,14 @@
         <category android:name="android.intent.category.DEFAULT"/>
         <category android:name="android.intent.category.BROWSABLE"/>
       </intent-filter>
+      <intent-filter>
+        <data android:scheme="expogo"/>
+
+        <action android:name="android.intent.action.VIEW"/>
+
+        <category android:name="android.intent.category.DEFAULT"/>
+        <category android:name="android.intent.category.BROWSABLE"/>
+      </intent-filter>
       <!-- END HOME INTENT FILTERS -->
     </activity>
 

--- a/template-files/android/AndroidManifest.xml
+++ b/template-files/android/AndroidManifest.xml
@@ -143,7 +143,7 @@
         <category android:name="android.intent.category.BROWSABLE"/>
       </intent-filter>
       <intent-filter>
-        <data android:scheme="expogo"/>
+        <data android:scheme="expo-home"/>
 
         <action android:name="android.intent.action.VIEW"/>
 


### PR DESCRIPTION
# Why

Closes ENG-695.

# How

- Fixed the initial URL not passed to the home app.
- Added a new deep link scheme.
- Configured react-navigation to work with deep links - according to https://reactnavigation.org/docs/configuring-links

# TODO

- [x] publish home

# Test Plan

- build Expo Go & run `adb shell am start -a android.intent.action.VIEW -d "expogo://qr-scanner"` ✅