### PR TITLE
[docs] eas travis ci stagename from deploy => build 

### DIFF
--- a/docs/pages/build/building-on-ci.md
+++ b/docs/pages/build/building-on-ci.md
@@ -69,7 +69,7 @@ before_script:
 
 jobs:
   include:
-    - stage: deploy
+    - stage: build
       node_js: lts/*
       script:
         - npm ci


### PR DESCRIPTION
# Why

EAS build docs for CI integration has a Travis CI example with an inaccurate stage name

# How

updated the EAS build docs' Travis Ci example stage name from deploy => build

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).