### PR TITLE
[notifications][android] use proper notification ID when cancelling notifications

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/notifications/delegates/ScopedExpoPresentationDelegate.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/notifications/delegates/ScopedExpoPresentationDelegate.kt
@@ -50,8 +50,8 @@ class ScopedExpoPresentationDelegate(context: Context) : ExpoPresentationDelegat
    * The notification is either a remote notification sent through Expo's push
    * service, or a local notification.
    */
-  override fun getNotifyId(request: NotificationRequest): Int {
-    if (Constants.isStandaloneApp()) {
+  override fun getNotifyId(request: NotificationRequest?): Int {
+    if (Constants.isStandaloneApp() || request == null) {
       return super.getNotifyId(request)
     }
     val experienceId = if (request.trigger is FirebaseNotificationTrigger) {

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed an issue on Android where dismissing notifications by ID inside of Expo Go did nothing. ([#12306](https://github.com/expo/expo/pull/12306 by [@cruzach](https://github.com/cruzach))
+
 ## 0.11.1 — 2021-03-23
 
 ### 🎉 New features

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/delegates/ExpoPresentationDelegate.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/delegates/ExpoPresentationDelegate.kt
@@ -102,7 +102,7 @@ open class ExpoPresentationDelegate(
     )
   }
 
-  protected open fun getNotifyId(request: NotificationRequest): Int {
+  protected open fun getNotifyId(request: NotificationRequest?): Int {
     return ANDROID_NOTIFICATION_ID;
   }
 
@@ -130,8 +130,9 @@ open class ExpoPresentationDelegate(
         // Foreign notification identified by us
         NotificationManagerCompat.from(context).cancel(foreignNotification.first, foreignNotification.second)
       } else {
-        // Let's hope it's our notification, we have no reason to believe otherwise
-        NotificationManagerCompat.from(context).cancel(identifier, ANDROID_NOTIFICATION_ID)
+        // If the notification exists, let's assume it's ours, we have no reason to believe otherwise
+        val existingNotification = this.getAllPresentedNotifications().find { it.notificationRequest.identifier == identifier }
+        NotificationManagerCompat.from(context).cancel(identifier, getNotifyId(existingNotification?.notificationRequest))
       }
     }
   }


### PR DESCRIPTION
# Why

Test suite `resolves with an array that does not contain a canceled notification`- in Expo Go, cancelling notifications by specified ID was not working

# How

This was my fault, changes in https://github.com/expo/expo/commit/a91445962b39769687aaa4c51d188064eabe520d modified the notification `id` (different from our `notification.identifier`) in Expo Go to allow apps to overwrite their own notifications, and prevent projects in Expo Go from overwriting each other's notifications. But, I forgot to update the other callsite for `ANDROID_NOTIFICATION_ID`.

# Test Plan

test suite passes

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).