### PR TITLE
let current shell env read config

### DIFF
--- a/docs/pages/workflow/android-studio-emulator.md
+++ b/docs/pages/workflow/android-studio-emulator.md
@@ -33,7 +33,11 @@ echo "export ANDROID_SDK=$ANDROID_SDK" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zs
 echo "export PATH=$HOME/Library/Android/sdk/platform-tools:\$PATH" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zshenv' || echo '.bash_profile'`
 ```
 
-- Make sure that you can run `adb` from your terminal.
+- Make sure that you can run `adb` from your terminal. If you fail to run it, try this command:
+
+```bash
+source ~/`[[ $SHELL == *"zsh" ]] && echo '.zshenv' || echo '.bash_profile'`
+```
 
 ## Step 2: Set up a virtual device
 


### PR DESCRIPTION
# Why

The new env variable won't take effect without using the `source` command.

# How

Use the `source` command after appending new variable  config to shell profile

# Test Plan

It works on my macOS 10.15