### PR TITLE
[expo-permissions] Fix multiple permissions request crash on Android

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.java
@@ -632,8 +632,9 @@ public abstract class ReactNativeActivity extends AppCompatActivity implements c
   public void onRequestPermissionsResult(final int requestCode, final String[] permissions, @NonNull final int[] grantResults) {
     if (requestCode == EXPONENT_PERMISSIONS_REQUEST) {
       if (permissions.length > 0 && grantResults.length == permissions.length && mScopedPermissionsRequester != null) {
-        mScopedPermissionsRequester.onRequestPermissionsResult(permissions, grantResults);
-        mScopedPermissionsRequester = null;
+        if (mScopedPermissionsRequester.onRequestPermissionsResult(permissions, grantResults)) {
+          mScopedPermissionsRequester = null;
+        }
       }
     } else {
       super.onRequestPermissionsResult(requestCode, permissions, grantResults);

--- a/android/expoview/src/main/java/host/exp/exponent/utils/ScopedPermissionsRequester.java
+++ b/android/expoview/src/main/java/host/exp/exponent/utils/ScopedPermissionsRequester.java
@@ -80,11 +80,11 @@ public class ScopedPermissionsRequester {
     }
   }
 
-  public void onRequestPermissionsResult(final String[] permissions, final int[] grantResults) {
+  public Boolean onRequestPermissionsResult(final String[] permissions, final int[] grantResults) {
     if (mPermissionListener == null) {
       // sometimes onRequestPermissionsResult is called multiple times if the first permission
       // is rejected...
-      return;
+      return true;
     }
 
     if (grantResults.length > 0) {
@@ -96,16 +96,16 @@ public class ScopedPermissionsRequester {
       }
     }
 
-    callPermissionsListener();
+    return callPermissionsListener();
   }
 
-  private void callPermissionsListener() {
+  private boolean callPermissionsListener() {
     String[] permissions = mPermissionsResult.keySet().toArray(new String[0]);
     int[] result = new int[permissions.length];
     for (int i = 0; i < permissions.length; i++) {
       result[i] = mPermissionsResult.get(permissions[i]);
     }
-    mPermissionListener.onRequestPermissionsResult(EXPONENT_PERMISSIONS_REQUEST, permissions, result);
+    return mPermissionListener.onRequestPermissionsResult(EXPONENT_PERMISSIONS_REQUEST, permissions, result);
   }
 
   private void requestExperienceAndGlobalPermissions(String permission) {

--- a/packages/@unimodules/react-native-adapter/android/src/main/java/org/unimodules/adapters/react/permissions/PermissionsService.kt
+++ b/packages/@unimodules/react-native-adapter/android/src/main/java/org/unimodules/adapters/react/permissions/PermissionsService.kt
@@ -241,7 +241,7 @@ open class PermissionsService(val context: Context) : InternalModule, Permission
           mPendingPermissionCalls.add(permissions to listener)
         } else {
           mCurrentPermissionListener = listener
-          currentActivity.requestPermissions(permissions, PERMISSIONS_REQUEST, createPermissionRequester())
+          currentActivity.requestPermissions(permissions, PERMISSIONS_REQUEST, createListenerWithPendingPermissionsRequest())
         }
       }
     } else {
@@ -249,7 +249,7 @@ open class PermissionsService(val context: Context) : InternalModule, Permission
     }
   }
 
-  private fun createPermissionRequester(): PermissionListener {
+  private fun createListenerWithPendingPermissionsRequest(): PermissionListener {
     return PermissionListener { requestCode, receivePermissions, grantResults ->
       if (requestCode == PERMISSIONS_REQUEST) {
         synchronized(this@PermissionsService) {
@@ -270,7 +270,7 @@ open class PermissionsService(val context: Context) : InternalModule, Permission
             }
 
             mCurrentPermissionListener = pendingCall.second
-            activity.requestPermissions(pendingCall.first, PERMISSIONS_REQUEST, createPermissionRequester())
+            activity.requestPermissions(pendingCall.first, PERMISSIONS_REQUEST, createListenerWithPendingPermissionsRequest())
             return@PermissionListener false
           }
 


### PR DESCRIPTION
# Why

Closes ENG-650.
Fixes https://github.com/expo/expo/issues/12248

# How

React Native doesn't allow asking for multiple permissions in separate calls before receiving responses. So we need to queue permission calls.

# Test Plan

- Expo Go and bare-expo
  - https://snack.expo.io/@brents/carefree-candy
  -  NCL 
 
# Changelog 

- Fixed multiple permissions request crash on Android