### PR TITLE
[fastlane] Sync ExpoNotificationServiceExtension versions

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -11,20 +11,36 @@ STAGING_API_URL = 'https://staging.exp.host/'
 # path relative to Fastfile
 output_directory = File.expand_path('./Deployment')
 
-def set_bundle_version_from_commit_count
-  bundle_version = Actions.lane_context[SharedValues::VERSION_NUMBER] + ".10" + number_of_commits.to_s
-  puts "Setting build number (CFBundleVersion) to '" + bundle_version + "'..."
+def update_bundle_versions
+  bundle_short_version = Actions.lane_context[SharedValues::VERSION_NUMBER]
+  bundle_version = bundle_short_version + ".10" + number_of_commits.to_s
+
+  puts "Setting CFBundleVersion for Exponent to #{bundle_version}..."
   set_info_plist_value(
     path: "./ios/Exponent/Supporting/Info.plist",
     key: "CFBundleVersion",
     value: bundle_version
   )
+
+  puts "Setting CFBundleVersion to #{bundle_version} and CFBundleShortVersionString #{bundle_short_version} for ExpoNotificationServiceExtension..."
+  set_info_plist_value(
+    path: "./ios/ExpoNotificationServiceExtension/Info.plist",
+    key: "CFBundleVersion",
+    value: bundle_version
+  )
+
+  set_info_plist_value(
+    path: "./ios/ExpoNotificationServiceExtension/Info.plist",
+    key: "CFBundleShortVersionString",
+    value: bundle_short_version
+  )
 end
 
 # This will keep a copy of the original Info.plist
 @original_info_plist = nil
+@original_notification_extension_info_plist = nil
 
-def save_original_info_plist
+def save_original_info_plists
   update_info_plist(
     xcodeproj: "ios/Exponent.xcodeproj",
     plist_path: "Exponent/Supporting/Info.plist",
@@ -32,15 +48,32 @@ def save_original_info_plist
       @original_info_plist = Marshal.load(Marshal.dump(plist))
     end
   )
+
+  update_info_plist(
+    xcodeproj: "ios/Exponent.xcodeproj",
+    plist_path: "ExpoNotificationServiceExtension/Info.plist",
+    block: proc do |plist|
+      @original_notification_extension_info_plist = Marshal.load(Marshal.dump(plist))
+    end
+  )
 end
 
-def restore_original_info_plist
+def restore_original_info_plists
   update_info_plist(
     xcodeproj: "ios/Exponent.xcodeproj",
     plist_path: "Exponent/Supporting/Info.plist",
     block: proc do |plist|
-      puts "Restoring original Info.plist..."
+      puts "Restoring original Exponent/Info.plist..."
       plist.replace(@original_info_plist)
+    end
+  )
+
+  update_info_plist(
+    xcodeproj: "ios/Exponent.xcodeproj",
+    plist_path: "ExpoNotificationServiceExtension/Info.plist",
+    block: proc do |plist|
+      puts "Restoring original ExpoNotificationServiceExtension/Info.plist..."
+      plist.replace(@original_notification_extension_info_plist)
     end
   )
 end
@@ -89,8 +122,8 @@ platform :ios do
       xcodeproj: "./ios/Exponent.xcodeproj",
       target: "Exponent"
     )
-    save_original_info_plist
-    set_bundle_version_from_commit_count
+    save_original_info_plists
+    update_bundle_versions
     setup_circle_ci
   end
 
@@ -173,7 +206,7 @@ platform :ios do
 
   after_all do |lane|
     # FileUtils.rm_rf(output_directory)
-    restore_original_info_plist
+    restore_original_info_plists
   end
 
   error do |lane, exception|


### PR DESCRIPTION
# Why

https://exponent-internal.slack.com/archives/CNHBN8LNS/p1616719294121400

# How

Sync the CFBundleVersion and CFBundleShortVersionString from Exponent/Supporting/Info.plist to ExpoNotificationServiceExtension/Info.plist. 

# Test Plan

I created a test lane that did nothing but run the beforeAll block and commented out the afterAll cleanup, then verified that only exactly what we expected to change was changed:

```diff
diff --git a/ios/ExpoNotificationServiceExtension/Info.plist b/ios/ExpoNotificationServiceExtension/Info.plist
index fe0e927c6b..29e7abe454 100644
--- a/ios/ExpoNotificationServiceExtension/Info.plist
+++ b/ios/ExpoNotificationServiceExtension/Info.plist
@@ -17,9 +17,9 @@
        <key>CFBundlePackageType</key>
        <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
        <key>CFBundleShortVersionString</key>
-       <string>1.0</string>
+       <string>2.18.5</string>
        <key>CFBundleVersion</key>
-       <string>1</string>
+       <string>2.18.5.1011302</string>
        <key>NSExtension</key>
        <dict>
                <key>NSExtensionPointIdentifier</key>
diff --git a/ios/Exponent/Supporting/Info.plist b/ios/Exponent/Supporting/Info.plist
index 0efa5f234b..1ca40731a8 100644
--- a/ios/Exponent/Supporting/Info.plist
+++ b/ios/Exponent/Supporting/Info.plist
@@ -55,7 +55,7 @@
                </dict>
        </array>
        <key>CFBundleVersion</key>
-       <string>2.18.5</string>
+       <string>2.18.5.1011302</string>
        <key>FacebookAdvertiserIDCollectionEnabled</key>
        <false/>
        <key>FacebookAppID</key>
```

(CFBundleShortVersionString was already 2.18.5 in Exponent/Supporting/Info.plist)