### PR TITLE
Updated user tracking permission message

### DIFF
--- a/packages/expo-ads-admob/CHANGELOG.md
+++ b/packages/expo-ads-admob/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Updated user tracking permission message. ([#12322](https://github.com/expo/expo/pull/12322) by [@EvanBacon](https://github.com/EvanBacon))
+
 ### 🐛 Bug fixes
 
 ## 10.0.1 — 2021-03-23

--- a/packages/expo-ads-admob/README.md
+++ b/packages/expo-ads-admob/README.md
@@ -36,7 +36,7 @@ Add `NSUserTrackingUsageDescription` key to your `Info.plist`:
 
 ```xml
 <key>NSUserTrackingUsageDescription</key>
-<string>Allow $(PRODUCT_NAME) to use data for tracking the user or the device</string>
+<string>This identifier will be used to deliver personalized ads to you.</string>
 ```
 
 Add the required `SKAdNetworkIdentifier` items to your `Info.plist`: [Google SKAdNetwork](https://developers.google.com/admob/ios/ios14#skadnetwork).

--- a/packages/expo-ads-admob/plugin/build/withAdMobIOS.js
+++ b/packages/expo-ads-admob/plugin/build/withAdMobIOS.js
@@ -35,7 +35,7 @@ function setAdMobConfig(config, infoPlist) {
     infoPlist = setGoogleMobileAdsAppId(config, infoPlist);
     return infoPlist;
 }
-const USER_TRACKING = 'Allow $(PRODUCT_NAME) to use data for tracking the user or the device';
+const USER_TRACKING = 'This identifier will be used to deliver personalized ads to you.';
 exports.withUserTrackingPermission = (config, { userTrackingPermission } = {}) => {
     if (!config.ios)
         config.ios = {};

--- a/packages/expo-ads-admob/plugin/src/withAdMobIOS.ts
+++ b/packages/expo-ads-admob/plugin/src/withAdMobIOS.ts
@@ -42,7 +42,7 @@ function setAdMobConfig(config: Pick<ExpoConfig, 'ios'>, infoPlist: InfoPlist): 
   return infoPlist;
 }
 
-const USER_TRACKING = 'Allow $(PRODUCT_NAME) to use data for tracking the user or the device';
+const USER_TRACKING = 'This identifier will be used to deliver personalized ads to you.';
 
 export const withUserTrackingPermission: ConfigPlugin<{
   userTrackingPermission?: string;

--- a/packages/expo-ads-facebook/CHANGELOG.md
+++ b/packages/expo-ads-facebook/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Updated user tracking permission message. ([#12322](https://github.com/expo/expo/pull/12322) by [@EvanBacon](https://github.com/EvanBacon))
+
 ### 🐛 Bug fixes
 
 ## 10.0.1 — 2021-03-23

--- a/packages/expo-ads-facebook/README.md
+++ b/packages/expo-ads-facebook/README.md
@@ -29,7 +29,7 @@ Add `NSUserTrackingUsageDescription` key to your `Info.plist`:
 
 ```xml
 <key>NSUserTrackingUsageDescription</key>
-<string>Allow $(PRODUCT_NAME) to use data for tracking the user or the device</string>
+<string>This identifier will be used to deliver personalized ads to you.</string>
 ```
 
 Add the required `SKAdNetworkIdentifier` items to your `Info.plist`: [Facebook SKAdNetwork](https://developers.facebook.com/docs/SKAdNetwork).

--- a/packages/expo-ads-facebook/plugin/build/withFacebookAdsIOS.js
+++ b/packages/expo-ads-facebook/plugin/build/withFacebookAdsIOS.js
@@ -1,7 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.withUserTrackingPermission = void 0;
-const USER_TRACKING = 'Allow $(PRODUCT_NAME) to use data for tracking the user or the device';
+const USER_TRACKING = 'This identifier will be used to deliver personalized ads to you.';
 exports.withUserTrackingPermission = (config, { userTrackingPermission } = {}) => {
     if (!config.ios)
         config.ios = {};

--- a/packages/expo-ads-facebook/plugin/src/withFacebookAdsIOS.ts
+++ b/packages/expo-ads-facebook/plugin/src/withFacebookAdsIOS.ts
@@ -1,6 +1,6 @@
 import { ConfigPlugin } from '@expo/config-plugins';
 
-const USER_TRACKING = 'Allow $(PRODUCT_NAME) to use data for tracking the user or the device';
+const USER_TRACKING = 'This identifier will be used to deliver personalized ads to you.';
 
 export const withUserTrackingPermission: ConfigPlugin<{
   userTrackingPermission?: string;

--- a/packages/expo-facebook/CHANGELOG.md
+++ b/packages/expo-facebook/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Updated user tracking permission message. ([#12322](https://github.com/expo/expo/pull/12322) by [@EvanBacon](https://github.com/EvanBacon))
+
 ### 🐛 Bug fixes
 
 ## 11.0.2 — 2021-03-23

--- a/packages/expo-facebook/README.md
+++ b/packages/expo-facebook/README.md
@@ -29,7 +29,7 @@ Add `NSUserTrackingUsageDescription` key to your `Info.plist`:
 
 ```xml
 <key>NSUserTrackingUsageDescription</key>
-<string>Allow $(PRODUCT_NAME) to use data for tracking the user or the device</string>
+<string>This identifier will be used to deliver personalized ads to you.</string>
 ```
 
 Add the required `SKAdNetworkIdentifier` items to your `Info.plist`: [Facebook SKAdNetwork](https://developers.facebook.com/docs/SKAdNetwork).

--- a/packages/expo-facebook/plugin/build/withFacebookIOS.js
+++ b/packages/expo-facebook/plugin/build/withFacebookIOS.js
@@ -6,7 +6,7 @@ const ios_plugins_1 = require("@expo/config-plugins/build/plugins/ios-plugins");
 const { Scheme } = config_plugins_1.IOSConfig;
 const { appendScheme } = Scheme;
 const fbSchemes = ['fbapi', 'fb-messenger-api', 'fbauth2', 'fbshareextension'];
-const USER_TRACKING = 'Allow $(PRODUCT_NAME) to use data for tracking the user or the device';
+const USER_TRACKING = 'This identifier will be used to deliver personalized ads to you.';
 exports.withFacebookIOS = ios_plugins_1.createInfoPlistPlugin(setFacebookConfig, 'withFacebookIOS');
 /**
  * Getters

--- a/packages/expo-facebook/plugin/src/withFacebookIOS.ts
+++ b/packages/expo-facebook/plugin/src/withFacebookIOS.ts
@@ -18,7 +18,7 @@ type ExpoConfigFacebook = Pick<
 
 const fbSchemes = ['fbapi', 'fb-messenger-api', 'fbauth2', 'fbshareextension'];
 
-const USER_TRACKING = 'Allow $(PRODUCT_NAME) to use data for tracking the user or the device';
+const USER_TRACKING = 'This identifier will be used to deliver personalized ads to you.';
 
 export const withFacebookIOS = createInfoPlistPlugin(setFacebookConfig, 'withFacebookIOS');
 


### PR DESCRIPTION
# Why

Use `This identifier will be used to deliver personalized ads to you.` which is a more recommended permission message.
