### PR TITLE
[home] Fix project list item long press of organization project

### DIFF
--- a/home/components/ExploreTab.tsx
+++ b/home/components/ExploreTab.tsx
@@ -108,9 +108,9 @@ export default function ExploreTab(props: QueryProps) {
         iconUrl={app.iconUrl}
         name={app.name}
         projectUrl={app.fullName}
-        username={app.packageUsername}
+        username={app.username}
         description={app.description}
-        experienceInfo={{ username: app.packageUsername, slug: app.packageName }}
+        experienceInfo={{ username: app.username, slug: app.packageName }}
         sdkVersion={app.sdkVersion}
         onPressUsername={onPressUsername}
         style={{ marginBottom: 10 }}

--- a/home/components/Profile.tsx
+++ b/home/components/Profile.tsx
@@ -237,7 +237,7 @@ function ProfileHeader({ data }: Pick<Props, 'data'>) {
 
 function ProfileProjectsSection({
   data: {
-    user: { apps, appCount, ...user },
+    user: { apps, appCount },
   },
   isOwnProfile,
   navigation,
@@ -250,8 +250,6 @@ function ProfileProjectsSection({
     });
   };
 
-  const currentUsername = username || user.username;
-
   const renderApp = (app: any, i: number) => {
     return (
       <ProjectListItem
@@ -262,7 +260,7 @@ function ProfileProjectsSection({
         title={app.name}
         sdkVersion={app.sdkVersion}
         subtitle={app.packageName || app.fullName}
-        experienceInfo={{ username: app.username || currentUsername, slug: app.packageName }}
+        experienceInfo={{ username: app.username, slug: app.packageName }}
       />
     );
   };

--- a/home/components/ProjectList.tsx
+++ b/home/components/ProjectList.tsx
@@ -39,7 +39,7 @@ export type Project = {
   packageName: string;
   privacy: string;
   sdkVersion: string;
-  packageUsername: string;
+  username: string;
 };
 
 type Props = {
@@ -144,7 +144,7 @@ function ProjectList({ data, loadMoreAsync, belongsToCurrentUser, listTitle }: P
   };
 
   const renderItem = ({ item: app, index }) => {
-    const experienceInfo = { username: app.username || app.packageUsername, slug: app.packageName };
+    const experienceInfo = { username: app.username, slug: app.packageName };
     if (belongsToCurrentUser) {
       return (
         <ProjectListItem
@@ -167,7 +167,7 @@ function ProjectList({ data, loadMoreAsync, belongsToCurrentUser, listTitle }: P
           iconUrl={app.iconUrl}
           name={app.name}
           projectUrl={app.fullName}
-          username={app.packageUsername}
+          username={app.username}
           description={app.description}
           onPressUsername={handlePressUsername}
           experienceInfo={experienceInfo}

--- a/home/containers/Explore.tsx
+++ b/home/containers/Explore.tsx
@@ -24,7 +24,7 @@ const PublicAppsQuery = gql`
         name
         iconUrl
         packageName
-        packageUsername
+        username
         description
         lastPublishedTime
         sdkVersion

--- a/home/containers/Profile.tsx
+++ b/home/containers/Profile.tsx
@@ -34,6 +34,7 @@ const MyProfileQuery = gql`
         lastPublishedTime
         name
         packageName
+        username
         sdkVersion
         privacy
       }
@@ -104,7 +105,7 @@ const OtherProfileQuery = gql`
           name
           iconUrl
           packageName
-          packageUsername
+          username
           description
           sdkVersion
           lastPublishedTime

--- a/home/containers/ProjectsList.tsx
+++ b/home/containers/ProjectsList.tsx
@@ -42,7 +42,7 @@ const MyProjectsQuery = gql`
         iconUrl
         lastPublishedTime
         name
-        packageUsername
+        username
         packageName
         privacy
         sdkVersion
@@ -139,7 +139,7 @@ const OtherProjectsQuery = gql`
           name
           iconUrl
           packageName
-          packageUsername
+          username
           description
           lastPublishedTime
           sdkVersion


### PR DESCRIPTION
# Why

The "My Profile" screen displays all apps that a user has access to, including those via organizations. Long pressing an item in the project list though would misattribute the app to the current user instead of the organization.

This also uses `Project.username` everywhere instead of `Project.packageUsername` since `Project.packageUsername` is deprecated.

# How

Load the app username for "My Profile" and use that to generate the experience data necessary to load the experience permalink successfully.

Grep for `packageUsername` and replace it with `username` which has the same value in all cases but is not deprecated.

# Test Plan

Load home app locally, log in with a user that has access to an organization with a project, long press on that project, no longer see an error.