### PR TITLE
Revert "[android][payments-stripe] Upgrade underlying native library from v8 to v16 (#12250)

### DIFF
--- a/android/versioned-abis/expoview-abi38_0_0/src/main/java/abi38_0_0/expo/modules/payments/stripe/GoogleApiPayFlowImpl.java
+++ b/android/versioned-abis/expoview-abi38_0_0/src/main/java/abi38_0_0/expo/modules/payments/stripe/GoogleApiPayFlowImpl.java
@@ -1,6 +1,5 @@
 package abi38_0_0.expo.modules.payments.stripe;
 import android.app.Activity;
-import android.util.Log;
 import android.content.Intent;
 import androidx.annotation.NonNull;
 
@@ -23,14 +22,12 @@ import com.google.android.gms.wallet.ShippingAddressRequirements;
 import com.google.android.gms.wallet.TransactionInfo;
 import com.google.android.gms.wallet.Wallet;
 import com.google.android.gms.wallet.WalletConstants;
+import com.stripe.android.BuildConfig;
 import com.stripe.android.model.Token;
-import com.stripe.android.Stripe;
 
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
-import org.json.JSONObject;
-import org.json.JSONException;
 
 import static abi38_0_0.expo.modules.payments.stripe.Errors.toErrorCode;
 import static abi38_0_0.expo.modules.payments.stripe.util.Converters.convertTokenToWritableMap;
@@ -96,7 +93,7 @@ public final class GoogleApiPayFlowImpl extends PayFlow {
       .setPaymentMethodTokenizationType(WalletConstants.PAYMENT_METHOD_TOKENIZATION_TYPE_PAYMENT_GATEWAY)
       .addParameter("gateway", "stripe")
       .addParameter("stripe:publishableKey", getPublishableKey())
-      .addParameter("stripe:version", Stripe.VERSION_NAME)
+      .addParameter("stripe:version", BuildConfig.VERSION_NAME)
       .build();
   }
 
@@ -228,12 +225,7 @@ public final class GoogleApiPayFlowImpl extends PayFlow {
             PaymentData paymentData = PaymentData.getFromIntent(data);
             ArgCheck.nonNull(paymentData);
             String tokenJson = paymentData.getPaymentMethodToken().getToken();
-            Token token = null;
-            try {
-              token = Token.fromJson(new JSONObject(tokenJson));
-            } catch (JSONException e) {
-              Log.e(TAG, "Unable to create token from JSON string '" + tokenJson + "'.\n" + e);
-            }
+            Token token = Token.fromString(tokenJson);
             if (token == null) {
               payPromise.reject(
                 getErrorCode("parseResponse"),

--- a/android/versioned-abis/expoview-abi38_0_0/src/main/java/abi38_0_0/expo/modules/payments/stripe/StripeModule.java
+++ b/android/versioned-abis/expoview-abi38_0_0/src/main/java/abi38_0_0/expo/modules/payments/stripe/StripeModule.java
@@ -24,12 +24,10 @@ import abi38_0_0.expo.modules.payments.stripe.util.ArgCheck;
 import abi38_0_0.expo.modules.payments.stripe.util.Converters;
 import abi38_0_0.expo.modules.payments.stripe.util.Fun0;
 import com.google.android.gms.wallet.WalletConstants;
-import com.stripe.android.ApiResultCallback;
+import com.stripe.android.SourceCallback;
 import com.stripe.android.Stripe;
-import com.stripe.android.model.CardParams;
+import com.stripe.android.TokenCallback;
 import com.stripe.android.model.Source;
-import com.stripe.android.model.Source.Flow;
-import com.stripe.android.model.Source.Status;
 import com.stripe.android.model.SourceParams;
 import com.stripe.android.model.Token;
 
@@ -45,7 +43,8 @@ import static abi38_0_0.expo.modules.payments.stripe.Errors.getErrorCode;
 import static abi38_0_0.expo.modules.payments.stripe.Errors.toErrorCode;
 import static abi38_0_0.expo.modules.payments.stripe.util.Converters.convertSourceToWritableMap;
 import static abi38_0_0.expo.modules.payments.stripe.util.Converters.convertTokenToWritableMap;
-import static abi38_0_0.expo.modules.payments.stripe.util.Converters.createBankAccountTokenParams;
+import static abi38_0_0.expo.modules.payments.stripe.util.Converters.createBankAccount;
+import static abi38_0_0.expo.modules.payments.stripe.util.Converters.createCard;
 import static abi38_0_0.expo.modules.payments.stripe.util.Converters.getStringOrNull;
 import static abi38_0_0.expo.modules.payments.stripe.util.InitializationOptions.ANDROID_PAY_MODE_KEY;
 import static abi38_0_0.expo.modules.payments.stripe.util.InitializationOptions.ANDROID_PAY_MODE_PRODUCTION;
@@ -182,16 +181,13 @@ public class StripeModule extends ExportedModule {
       ArgCheck.nonNull(mStripe);
       ArgCheck.notEmptyString(mPublicKey);
 
-      mStripe.createCardToken(
-        Converters.createCardParams(cardData),
-        null,
-        null,
-        new ApiResultCallback<Token>() {
-          @Override
-          public void onSuccess(@NonNull Token token) {
+      mStripe.createToken(
+        createCard(cardData),
+        mPublicKey,
+        new TokenCallback() {
+          public void onSuccess(Token token) {
             promise.resolve(convertTokenToWritableMap(token));
           }
-          @Override
           public void onError(Exception error) {
             error.printStackTrace();
             promise.reject(toErrorCode(error), error.getMessage());
@@ -209,15 +205,13 @@ public class StripeModule extends ExportedModule {
       ArgCheck.notEmptyString(mPublicKey);
 
       mStripe.createBankAccountToken(
-        createBankAccountTokenParams(accountData),
+        createBankAccount(accountData),
         mPublicKey,
         null,
-        new ApiResultCallback<Token>() {
-          @Override
-          public void onSuccess(@NonNull Token token) {
+        new TokenCallback() {
+          public void onSuccess(Token token) {
             promise.resolve(convertTokenToWritableMap(token));
           }
-          @Override
           public void onError(Exception error) {
             error.printStackTrace();
             promise.reject(toErrorCode(error), error.getMessage());
@@ -339,13 +333,15 @@ public class StripeModule extends ExportedModule {
 
     ArgCheck.nonNull(sourceParams);
 
-    mStripe.createSource(sourceParams, new ApiResultCallback<Source>() {
+    mStripe.createSource(sourceParams, new SourceCallback() {
+      @Override
       public void onError(Exception error) {
         promise.reject(toErrorCode(error), error);
       }
 
-      public void onSuccess(@NonNull Source source) {
-        if (Flow.Redirect.equals(source.getFlow())) {
+      @Override
+      public void onSuccess(Source source) {
+        if (Source.REDIRECT.equals(source.getFlow())) {
           Activity currentActivity = getCurrentActivity();
           if (currentActivity == null) {
             promise.reject(
@@ -437,18 +433,19 @@ public class StripeModule extends ExportedModule {
         }
 
         switch (source.getStatus()) {
-          case Chargeable:
-          case Consumed:
+          case Source.CHARGEABLE:
+          case Source.CONSUMED:
             promise.resolve(convertSourceToWritableMap(source));
             break;
-          case Canceled:
+          case Source.CANCELED:
             promise.reject(
               getErrorCode(mErrorCodes, "redirectCancelled"),
               getDescription(mErrorCodes, "redirectCancelled")
             );
             break;
-          case Pending:
-          case Failed:
+          case Source.PENDING:
+          case Source.FAILED:
+          case Source.UNKNOWN:
             promise.reject(
               getErrorCode(mErrorCodes, "redirectFailed"),
               getDescription(mErrorCodes, "redirectFailed")

--- a/android/versioned-abis/expoview-abi38_0_0/src/main/java/abi38_0_0/expo/modules/payments/stripe/dialog/AddCardDialogFragment.java
+++ b/android/versioned-abis/expoview-abi38_0_0/src/main/java/abi38_0_0/expo/modules/payments/stripe/dialog/AddCardDialogFragment.java
@@ -1,6 +1,5 @@
 package abi38_0_0.expo.modules.payments.stripe.dialog;
 
-import androidx.annotation.NonNull;
 import android.app.AlertDialog;
 import android.app.Dialog;
 import android.app.DialogFragment;
@@ -28,7 +27,8 @@ import abi38_0_0.expo.modules.payments.stripe.util.CardFlipAnimator;
 import abi38_0_0.expo.modules.payments.stripe.util.Converters;
 import abi38_0_0.expo.modules.payments.stripe.util.Utils;
 
-import com.stripe.android.ApiResultCallback;
+import com.stripe.android.SourceCallback;
+import com.stripe.android.TokenCallback;
 import com.stripe.android.model.Card;
 import com.stripe.android.model.Source;
 import com.stripe.android.model.SourceParams;
@@ -193,12 +193,11 @@ public class AddCardDialogFragment extends DialogFragment {
     doneButton.setEnabled(false);
     progressBar.setVisibility(View.VISIBLE);
     final CreditCard fromCard = from.getCreditCard();
-    final Card card = Card.create(
+    final Card card = new Card(
       fromCard.getCardNumber(),
       fromCard.getExpMonth(),
       fromCard.getExpYear(),
-      fromCard.getSecurityCode()
-    );
+      fromCard.getSecurityCode());
 
     String errorMessage = Utils.validateCard(card);
     if (errorMessage == null) {
@@ -206,9 +205,9 @@ public class AddCardDialogFragment extends DialogFragment {
         SourceParams cardSourceParams = SourceParams.createCardParams(card);
         StripeModule.getInstance(tag).getStripe().createSource(
           cardSourceParams,
-          new ApiResultCallback<Source>() {
+          new SourceCallback() {
             @Override
-            public void onSuccess(@NonNull Source source) {
+            public void onSuccess(Source source) {
               // Normalize data with iOS SDK
               final Bundle sourceMap = Converters.convertSourceToWritableMap(source);
               sourceMap.putBundle("card", Converters.mapToWritableMap(source.getSourceTypeData()));
@@ -231,13 +230,11 @@ public class AddCardDialogFragment extends DialogFragment {
           }
         );
       } else {
-        StripeModule.getInstance(tag).getStripe().createCardToken(
-          card,
-          null,
-          null,
-          new ApiResultCallback<Token>() {
-            @Override
-            public void onSuccess(@NonNull Token token) {
+        StripeModule.getInstance(tag).getStripe().createToken(
+            card,
+            PUBLISHABLE_KEY,
+            new TokenCallback() {
+              public void onSuccess(Token token) {
                 if (promise != null) {
                   promise.resolve(Converters.convertTokenToWritableMap(token));
                   promise = null;
@@ -246,7 +243,6 @@ public class AddCardDialogFragment extends DialogFragment {
                 dismiss();
               }
 
-              @Override
               public void onError(Exception error) {
                 doneButton.setEnabled(true);
                 progressBar.setVisibility(View.GONE);

--- a/android/versioned-abis/expoview-abi38_0_0/src/main/java/abi38_0_0/expo/modules/payments/stripe/util/Converters.java
+++ b/android/versioned-abis/expoview-abi38_0_0/src/main/java/abi38_0_0/expo/modules/payments/stripe/util/Converters.java
@@ -10,19 +10,16 @@ import com.google.android.gms.identity.intents.model.UserAddress;
 import com.google.android.gms.wallet.PaymentData;
 import com.stripe.android.model.Address;
 import com.stripe.android.model.BankAccount;
-import com.stripe.android.model.BankAccountTokenParams;
 import com.stripe.android.model.Card;
-import com.stripe.android.model.CardParams;
 import com.stripe.android.model.Source;
-import com.stripe.android.model.Source.CodeVerification;
-import com.stripe.android.model.Source.Owner;
-import com.stripe.android.model.Source.Receiver;
-import com.stripe.android.model.Source.Redirect;
+import com.stripe.android.model.SourceCodeVerification;
+import com.stripe.android.model.SourceOwner;
+import com.stripe.android.model.SourceReceiver;
+import com.stripe.android.model.SourceRedirect;
 import com.stripe.android.model.Token;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -71,7 +68,7 @@ public class Converters {
 
     result.putString("cardId", card.getId());
     result.putString("number", card.getNumber());
-    result.putString("cvc", card.getCvc() );
+    result.putString("cvc", card.getCVC() );
     result.putInt("expMonth", card.getExpMonth() );
     result.putInt("expYear", card.getExpYear() );
     result.putString("name", card.getName() );
@@ -82,8 +79,8 @@ public class Converters {
     result.putString("addressZip", card.getAddressZip() );
     result.putString("addressCountry", card.getAddressCountry() );
     result.putString("last4", card.getLast4() );
-    result.putString("brand", card.getBrand().getDisplayName() );
-    result.putString("funding", card.getFunding().name() );
+    result.putString("brand", card.getBrand() );
+    result.putString("funding", card.getFunding() );
     result.putString("fingerprint", card.getFingerprint() );
     result.putString("country", card.getCountry() );
     result.putString("currency", card.getCurrency() );
@@ -97,10 +94,11 @@ public class Converters {
     if (account == null) return result;
 
     result.putString("routingNumber", account.getRoutingNumber());
+    result.putString("accountNumber", account.getAccountNumber());
     result.putString("countryCode", account.getCountryCode());
     result.putString("currency", account.getCurrency());
     result.putString("accountHolderName", account.getAccountHolderName());
-    result.putString("accountHolderType", account.getAccountHolderType().name());
+    result.putString("accountHolderType", account.getAccountHolderType());
     result.putString("fingerprint", account.getFingerprint());
     result.putString("bankName", account.getBankName());
     result.putString("last4", account.getLast4());
@@ -167,33 +165,32 @@ public class Converters {
     return allowedCountriesForShipping;
   }
 
-  public static CardParams createCardParams(final Map<String, Object> cardData) {
-    Address address = new Address(
-      getValue(cardData, "addressCity"),
-      getValue(cardData, "country"),
-      getValue(cardData, "addressLine1"),
-      getValue(cardData, "addressLine2"),
-      getValue(cardData, "addressZip"),
-      getValue(cardData, "addressState")
-    );
-    Map <String, String> metaData = new HashMap<String, String>();
-    metaData.put("brand", getValue(cardData, "brand"));
-    metaData.put("last4", getValue(cardData, "last4"));
-    metaData.put("fingerprint", getValue(cardData, "fingerprint"));
-    metaData.put("funding", getValue(cardData, "funding"));
-    metaData.put("id", getValue(cardData, "id"));
-    return 
-      new CardParams(
+  public static Card createCard(final Map<String, Object> cardData) {
+    return new Card(
+      // required fields
         (String)cardData.get("number"),
         new Integer((int)Math.round((Double)cardData.get("expMonth"))),
         new Integer((int)Math.round((Double)cardData.get("expYear"))),
-        getValue(cardData, "cvc"),
-        getValue(cardData, "name"),
-        address,
-        getValue(cardData, "currency"),
-        metaData
-      );
+      // additional fields
+      getValue(cardData, "cvc"),
+      getValue(cardData, "name"),
+      getValue(cardData, "addressLine1"),
+      getValue(cardData, "addressLine2"),
+      getValue(cardData, "addressCity"),
+      getValue(cardData, "addressState"),
+      getValue(cardData, "addressZip"),
+      getValue(cardData, "addressCountry"),
+      getValue(cardData, "brand"),
+      getValue(cardData, "last4"),
+      getValue(cardData, "fingerprint"),
+      getValue(cardData, "funding"),
+      getValue(cardData, "country"),
+      getValue(cardData, "currency"),
+      getValue(cardData, "id")
+    );
   }
+
+
 
   @NonNull
   public static Bundle convertSourceToWritableMap(@Nullable Source source) {
@@ -208,16 +205,17 @@ public class Converters {
     newSource.putInt("created", source.getCreated().intValue());
     newSource.putBundle("codeVerification", convertCodeVerificationToWritableMap(source.getCodeVerification()));
     newSource.putString("currency", source.getCurrency());
-    newSource.putString("flow", source.getFlow().name());
+    newSource.putString("flow", source.getFlow());
     newSource.putBoolean("livemode", source.isLiveMode());
+    newSource.putBundle("metadata", stringMapToWritableMap(source.getMetaData()));
     newSource.putBundle("owner", convertOwnerToWritableMap(source.getOwner()));
     newSource.putBundle("receiver", convertReceiverToWritableMap(source.getReceiver()));
     newSource.putBundle("redirect", convertRedirectToWritableMap(source.getRedirect()));
     newSource.putBundle("sourceTypeData", mapToWritableMap(source.getSourceTypeData()));
-    newSource.putString("status", source.getStatus().name());
+    newSource.putString("status", source.getStatus());
     newSource.putString("type", source.getType());
     newSource.putString("typeRaw", source.getTypeRaw());
-    newSource.putString("usage", source.getUsage().name());
+    newSource.putString("usage", source.getUsage());
 
     return newSource;
   }
@@ -238,7 +236,7 @@ public class Converters {
   }
 
   @NonNull
-  public static Bundle convertOwnerToWritableMap(@Nullable final Owner owner) {
+  public static Bundle convertOwnerToWritableMap(@Nullable final SourceOwner owner) {
     Bundle map = new Bundle();
 
     if (owner == null) {
@@ -276,7 +274,7 @@ public class Converters {
   }
 
   @NonNull
-  public static Bundle convertReceiverToWritableMap(@Nullable final Receiver receiver) {
+  public static Bundle convertReceiverToWritableMap(@Nullable final SourceReceiver receiver) {
     Bundle map = new Bundle();
 
     if (receiver == null) {
@@ -292,7 +290,7 @@ public class Converters {
   }
 
   @NonNull
-  public static Bundle convertRedirectToWritableMap(@Nullable Redirect redirect) {
+  public static Bundle convertRedirectToWritableMap(@Nullable SourceRedirect redirect) {
     Bundle map = new Bundle();
 
     if (redirect == null) {
@@ -300,14 +298,14 @@ public class Converters {
     }
 
     map.putString("returnUrl", redirect.getReturnUrl());
-    map.putString("status", redirect.getStatus().name());
+    map.putString("status", redirect.getStatus());
     map.putString("url", redirect.getUrl());
 
     return map;
   }
 
   @NonNull
-  public static Bundle convertCodeVerificationToWritableMap(@Nullable CodeVerification codeVerification) {
+  public static Bundle convertCodeVerificationToWritableMap(@Nullable SourceCodeVerification codeVerification) {
     Bundle map = new Bundle();
 
     if (codeVerification == null) {
@@ -315,7 +313,7 @@ public class Converters {
     }
 
     map.putInt("attemptsRemaining", codeVerification.getAttemptsRemaining());
-    map.putString("status", codeVerification.getStatus().name());
+    map.putString("status", codeVerification.getStatus());
 
     return map;
   }
@@ -378,18 +376,18 @@ public class Converters {
     return result;
   }
 
-  public static BankAccountTokenParams createBankAccountTokenParams(Map<String, Object> accountData) {
-    BankAccountTokenParams accountTokenParams = new BankAccountTokenParams(
-        // required fields
+  public static BankAccount createBankAccount(Map<String, Object> accountData) {
+    BankAccount account = new BankAccount(
+      // required fields only
+        (String)accountData.get("accountNumber"),
         (String)accountData.get("countryCode"),
         (String)accountData.get("currency"),
-        (String)accountData.get("accountNumber"),
-      null,
-      getValue(accountData, "accountHolderName"),
-      getValue(accountData, "routingNumber")
+      getValue(accountData, "routingNumber", "")
     );
+    account.setAccountHolderName(getValue(accountData, "accountHolderName"));
+    account.setAccountHolderType(getValue(accountData, "accountHolderType"));
 
-    return accountTokenParams;
+    return account;
   }
 
   public static String getStringOrNull(@NonNull Map<String, Object> map, @NonNull String key) {

--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/payments/stripe/GoogleApiPayFlowImpl.java
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/payments/stripe/GoogleApiPayFlowImpl.java
@@ -1,6 +1,5 @@
 package abi39_0_0.expo.modules.payments.stripe;
 import android.app.Activity;
-import android.util.Log;
 import android.content.Intent;
 import androidx.annotation.NonNull;
 
@@ -23,14 +22,12 @@ import com.google.android.gms.wallet.ShippingAddressRequirements;
 import com.google.android.gms.wallet.TransactionInfo;
 import com.google.android.gms.wallet.Wallet;
 import com.google.android.gms.wallet.WalletConstants;
+import com.stripe.android.BuildConfig;
 import com.stripe.android.model.Token;
-import com.stripe.android.Stripe;
 
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
-import org.json.JSONObject;
-import org.json.JSONException;
 
 import static abi39_0_0.expo.modules.payments.stripe.Errors.toErrorCode;
 import static abi39_0_0.expo.modules.payments.stripe.util.Converters.convertTokenToWritableMap;
@@ -96,7 +93,7 @@ public final class GoogleApiPayFlowImpl extends PayFlow {
       .setPaymentMethodTokenizationType(WalletConstants.PAYMENT_METHOD_TOKENIZATION_TYPE_PAYMENT_GATEWAY)
       .addParameter("gateway", "stripe")
       .addParameter("stripe:publishableKey", getPublishableKey())
-      .addParameter("stripe:version", Stripe.VERSION_NAME)
+      .addParameter("stripe:version", BuildConfig.VERSION_NAME)
       .build();
   }
 
@@ -228,12 +225,7 @@ public final class GoogleApiPayFlowImpl extends PayFlow {
             PaymentData paymentData = PaymentData.getFromIntent(data);
             ArgCheck.nonNull(paymentData);
             String tokenJson = paymentData.getPaymentMethodToken().getToken();
-            Token token = null;
-            try {
-              token = Token.fromJson(new JSONObject(tokenJson));
-            } catch (JSONException e) {
-              Log.e(TAG, "Unable to create token from JSON string '" + tokenJson + "'.\n" + e);
-            }
+            Token token = Token.fromString(tokenJson);
             if (token == null) {
               payPromise.reject(
                 getErrorCode("parseResponse"),

--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/payments/stripe/StripeModule.java
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/payments/stripe/StripeModule.java
@@ -24,12 +24,10 @@ import abi39_0_0.expo.modules.payments.stripe.util.ArgCheck;
 import abi39_0_0.expo.modules.payments.stripe.util.Converters;
 import abi39_0_0.expo.modules.payments.stripe.util.Fun0;
 import com.google.android.gms.wallet.WalletConstants;
-import com.stripe.android.ApiResultCallback;
+import com.stripe.android.SourceCallback;
 import com.stripe.android.Stripe;
-import com.stripe.android.model.CardParams;
+import com.stripe.android.TokenCallback;
 import com.stripe.android.model.Source;
-import com.stripe.android.model.Source.Flow;
-import com.stripe.android.model.Source.Status;
 import com.stripe.android.model.SourceParams;
 import com.stripe.android.model.Token;
 
@@ -45,7 +43,8 @@ import static abi39_0_0.expo.modules.payments.stripe.Errors.getErrorCode;
 import static abi39_0_0.expo.modules.payments.stripe.Errors.toErrorCode;
 import static abi39_0_0.expo.modules.payments.stripe.util.Converters.convertSourceToWritableMap;
 import static abi39_0_0.expo.modules.payments.stripe.util.Converters.convertTokenToWritableMap;
-import static abi39_0_0.expo.modules.payments.stripe.util.Converters.createBankAccountTokenParams;
+import static abi39_0_0.expo.modules.payments.stripe.util.Converters.createBankAccount;
+import static abi39_0_0.expo.modules.payments.stripe.util.Converters.createCard;
 import static abi39_0_0.expo.modules.payments.stripe.util.Converters.getStringOrNull;
 import static abi39_0_0.expo.modules.payments.stripe.util.InitializationOptions.ANDROID_PAY_MODE_KEY;
 import static abi39_0_0.expo.modules.payments.stripe.util.InitializationOptions.ANDROID_PAY_MODE_PRODUCTION;
@@ -182,16 +181,13 @@ public class StripeModule extends ExportedModule {
       ArgCheck.nonNull(mStripe);
       ArgCheck.notEmptyString(mPublicKey);
 
-      mStripe.createCardToken(
-        Converters.createCardParams(cardData),
-        null,
-        null,
-        new ApiResultCallback<Token>() {
-          @Override
-          public void onSuccess(@NonNull Token token) {
+      mStripe.createToken(
+        createCard(cardData),
+        mPublicKey,
+        new TokenCallback() {
+          public void onSuccess(Token token) {
             promise.resolve(convertTokenToWritableMap(token));
           }
-          @Override
           public void onError(Exception error) {
             error.printStackTrace();
             promise.reject(toErrorCode(error), error.getMessage());
@@ -209,15 +205,13 @@ public class StripeModule extends ExportedModule {
       ArgCheck.notEmptyString(mPublicKey);
 
       mStripe.createBankAccountToken(
-        createBankAccountTokenParams(accountData),
+        createBankAccount(accountData),
         mPublicKey,
         null,
-        new ApiResultCallback<Token>() {
-          @Override
-          public void onSuccess(@NonNull Token token) {
+        new TokenCallback() {
+          public void onSuccess(Token token) {
             promise.resolve(convertTokenToWritableMap(token));
           }
-          @Override
           public void onError(Exception error) {
             error.printStackTrace();
             promise.reject(toErrorCode(error), error.getMessage());
@@ -339,13 +333,15 @@ public class StripeModule extends ExportedModule {
 
     ArgCheck.nonNull(sourceParams);
 
-    mStripe.createSource(sourceParams, new ApiResultCallback<Source>() {
+    mStripe.createSource(sourceParams, new SourceCallback() {
+      @Override
       public void onError(Exception error) {
         promise.reject(toErrorCode(error), error);
       }
 
-      public void onSuccess(@NonNull Source source) {
-        if (Flow.Redirect.equals(source.getFlow())) {
+      @Override
+      public void onSuccess(Source source) {
+        if (Source.REDIRECT.equals(source.getFlow())) {
           Activity currentActivity = getCurrentActivity();
           if (currentActivity == null) {
             promise.reject(
@@ -437,18 +433,19 @@ public class StripeModule extends ExportedModule {
         }
 
         switch (source.getStatus()) {
-          case Chargeable:
-          case Consumed:
+          case Source.CHARGEABLE:
+          case Source.CONSUMED:
             promise.resolve(convertSourceToWritableMap(source));
             break;
-          case Canceled:
+          case Source.CANCELED:
             promise.reject(
               getErrorCode(mErrorCodes, "redirectCancelled"),
               getDescription(mErrorCodes, "redirectCancelled")
             );
             break;
-          case Pending:
-          case Failed:
+          case Source.PENDING:
+          case Source.FAILED:
+          case Source.UNKNOWN:
             promise.reject(
               getErrorCode(mErrorCodes, "redirectFailed"),
               getDescription(mErrorCodes, "redirectFailed")

--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/payments/stripe/dialog/AddCardDialogFragment.java
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/payments/stripe/dialog/AddCardDialogFragment.java
@@ -1,6 +1,5 @@
 package abi39_0_0.expo.modules.payments.stripe.dialog;
 
-import androidx.annotation.NonNull;
 import android.app.AlertDialog;
 import android.app.Dialog;
 import android.app.DialogFragment;
@@ -28,7 +27,8 @@ import abi39_0_0.expo.modules.payments.stripe.util.CardFlipAnimator;
 import abi39_0_0.expo.modules.payments.stripe.util.Converters;
 import abi39_0_0.expo.modules.payments.stripe.util.Utils;
 
-import com.stripe.android.ApiResultCallback;
+import com.stripe.android.SourceCallback;
+import com.stripe.android.TokenCallback;
 import com.stripe.android.model.Card;
 import com.stripe.android.model.Source;
 import com.stripe.android.model.SourceParams;
@@ -193,12 +193,11 @@ public class AddCardDialogFragment extends DialogFragment {
     doneButton.setEnabled(false);
     progressBar.setVisibility(View.VISIBLE);
     final CreditCard fromCard = from.getCreditCard();
-    final Card card = Card.create(
+    final Card card = new Card(
       fromCard.getCardNumber(),
       fromCard.getExpMonth(),
       fromCard.getExpYear(),
-      fromCard.getSecurityCode()
-    );
+      fromCard.getSecurityCode());
 
     String errorMessage = Utils.validateCard(card);
     if (errorMessage == null) {
@@ -206,9 +205,9 @@ public class AddCardDialogFragment extends DialogFragment {
         SourceParams cardSourceParams = SourceParams.createCardParams(card);
         StripeModule.getInstance(tag).getStripe().createSource(
           cardSourceParams,
-          new ApiResultCallback<Source>() {
+          new SourceCallback() {
             @Override
-            public void onSuccess(@NonNull Source source) {
+            public void onSuccess(Source source) {
               // Normalize data with iOS SDK
               final Bundle sourceMap = Converters.convertSourceToWritableMap(source);
               sourceMap.putBundle("card", Converters.mapToWritableMap(source.getSourceTypeData()));
@@ -231,13 +230,11 @@ public class AddCardDialogFragment extends DialogFragment {
           }
         );
       } else {
-        StripeModule.getInstance(tag).getStripe().createCardToken(
-          card,
-          null,
-          null,
-          new ApiResultCallback<Token>() {
-            @Override
-            public void onSuccess(@NonNull Token token) {
+        StripeModule.getInstance(tag).getStripe().createToken(
+            card,
+            PUBLISHABLE_KEY,
+            new TokenCallback() {
+              public void onSuccess(Token token) {
                 if (promise != null) {
                   promise.resolve(Converters.convertTokenToWritableMap(token));
                   promise = null;
@@ -246,7 +243,6 @@ public class AddCardDialogFragment extends DialogFragment {
                 dismiss();
               }
 
-              @Override
               public void onError(Exception error) {
                 doneButton.setEnabled(true);
                 progressBar.setVisibility(View.GONE);

--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/payments/stripe/util/Converters.java
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/payments/stripe/util/Converters.java
@@ -10,19 +10,16 @@ import com.google.android.gms.identity.intents.model.UserAddress;
 import com.google.android.gms.wallet.PaymentData;
 import com.stripe.android.model.Address;
 import com.stripe.android.model.BankAccount;
-import com.stripe.android.model.BankAccountTokenParams;
 import com.stripe.android.model.Card;
-import com.stripe.android.model.CardParams;
 import com.stripe.android.model.Source;
-import com.stripe.android.model.Source.CodeVerification;
-import com.stripe.android.model.Source.Owner;
-import com.stripe.android.model.Source.Receiver;
-import com.stripe.android.model.Source.Redirect;
+import com.stripe.android.model.SourceCodeVerification;
+import com.stripe.android.model.SourceOwner;
+import com.stripe.android.model.SourceReceiver;
+import com.stripe.android.model.SourceRedirect;
 import com.stripe.android.model.Token;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -71,7 +68,7 @@ public class Converters {
 
     result.putString("cardId", card.getId());
     result.putString("number", card.getNumber());
-    result.putString("cvc", card.getCvc());
+    result.putString("cvc", card.getCVC() );
     result.putInt("expMonth", card.getExpMonth() );
     result.putInt("expYear", card.getExpYear() );
     result.putString("name", card.getName() );
@@ -82,8 +79,8 @@ public class Converters {
     result.putString("addressZip", card.getAddressZip() );
     result.putString("addressCountry", card.getAddressCountry() );
     result.putString("last4", card.getLast4() );
-    result.putString("brand", card.getBrand().getDisplayName() );
-    result.putString("funding", card.getFunding().name() );
+    result.putString("brand", card.getBrand() );
+    result.putString("funding", card.getFunding() );
     result.putString("fingerprint", card.getFingerprint() );
     result.putString("country", card.getCountry() );
     result.putString("currency", card.getCurrency() );
@@ -97,10 +94,11 @@ public class Converters {
     if (account == null) return result;
 
     result.putString("routingNumber", account.getRoutingNumber());
+    result.putString("accountNumber", account.getAccountNumber());
     result.putString("countryCode", account.getCountryCode());
     result.putString("currency", account.getCurrency());
     result.putString("accountHolderName", account.getAccountHolderName());
-    result.putString("accountHolderType", account.getAccountHolderType().name());
+    result.putString("accountHolderType", account.getAccountHolderType());
     result.putString("fingerprint", account.getFingerprint());
     result.putString("bankName", account.getBankName());
     result.putString("last4", account.getLast4());
@@ -166,34 +164,33 @@ public class Converters {
 
     return allowedCountriesForShipping;
   }
-  
-  public static CardParams createCardParams(final Map<String, Object> cardData) {
-    Address address = new Address(
-      getValue(cardData, "addressCity"),
-      getValue(cardData, "country"),
-      getValue(cardData, "addressLine1"),
-      getValue(cardData, "addressLine2"),
-      getValue(cardData, "addressZip"),
-      getValue(cardData, "addressState")
-    );
-    Map <String, String> metaData = new HashMap<String, String>();
-    metaData.put("brand", getValue(cardData, "brand"));
-    metaData.put("last4", getValue(cardData, "last4"));
-    metaData.put("fingerprint", getValue(cardData, "fingerprint"));
-    metaData.put("funding", getValue(cardData, "funding"));
-    metaData.put("id", getValue(cardData, "id"));
-    return 
-      new CardParams(
+
+  public static Card createCard(final Map<String, Object> cardData) {
+    return new Card(
+      // required fields
         (String)cardData.get("number"),
         new Integer((int)Math.round((Double)cardData.get("expMonth"))),
         new Integer((int)Math.round((Double)cardData.get("expYear"))),
-        getValue(cardData, "cvc"),
-        getValue(cardData, "name"),
-        address,
-        getValue(cardData, "currency"),
-        metaData
-      );
+      // additional fields
+      getValue(cardData, "cvc"),
+      getValue(cardData, "name"),
+      getValue(cardData, "addressLine1"),
+      getValue(cardData, "addressLine2"),
+      getValue(cardData, "addressCity"),
+      getValue(cardData, "addressState"),
+      getValue(cardData, "addressZip"),
+      getValue(cardData, "addressCountry"),
+      getValue(cardData, "brand"),
+      getValue(cardData, "last4"),
+      getValue(cardData, "fingerprint"),
+      getValue(cardData, "funding"),
+      getValue(cardData, "country"),
+      getValue(cardData, "currency"),
+      getValue(cardData, "id")
+    );
   }
+
+
 
   @NonNull
   public static Bundle convertSourceToWritableMap(@Nullable Source source) {
@@ -208,16 +205,17 @@ public class Converters {
     newSource.putInt("created", source.getCreated().intValue());
     newSource.putBundle("codeVerification", convertCodeVerificationToWritableMap(source.getCodeVerification()));
     newSource.putString("currency", source.getCurrency());
-    newSource.putString("flow", source.getFlow().name());
+    newSource.putString("flow", source.getFlow());
     newSource.putBoolean("livemode", source.isLiveMode());
+    newSource.putBundle("metadata", stringMapToWritableMap(source.getMetaData()));
     newSource.putBundle("owner", convertOwnerToWritableMap(source.getOwner()));
     newSource.putBundle("receiver", convertReceiverToWritableMap(source.getReceiver()));
     newSource.putBundle("redirect", convertRedirectToWritableMap(source.getRedirect()));
     newSource.putBundle("sourceTypeData", mapToWritableMap(source.getSourceTypeData()));
-    newSource.putString("status", source.getStatus().name());
+    newSource.putString("status", source.getStatus());
     newSource.putString("type", source.getType());
     newSource.putString("typeRaw", source.getTypeRaw());
-    newSource.putString("usage", source.getUsage().name());
+    newSource.putString("usage", source.getUsage());
 
     return newSource;
   }
@@ -238,7 +236,7 @@ public class Converters {
   }
 
   @NonNull
-  public static Bundle convertOwnerToWritableMap(@Nullable final Owner owner) {
+  public static Bundle convertOwnerToWritableMap(@Nullable final SourceOwner owner) {
     Bundle map = new Bundle();
 
     if (owner == null) {
@@ -276,7 +274,7 @@ public class Converters {
   }
 
   @NonNull
-  public static Bundle convertReceiverToWritableMap(@Nullable final Receiver receiver) {
+  public static Bundle convertReceiverToWritableMap(@Nullable final SourceReceiver receiver) {
     Bundle map = new Bundle();
 
     if (receiver == null) {
@@ -292,7 +290,7 @@ public class Converters {
   }
 
   @NonNull
-  public static Bundle convertRedirectToWritableMap(@Nullable Redirect redirect) {
+  public static Bundle convertRedirectToWritableMap(@Nullable SourceRedirect redirect) {
     Bundle map = new Bundle();
 
     if (redirect == null) {
@@ -300,14 +298,14 @@ public class Converters {
     }
 
     map.putString("returnUrl", redirect.getReturnUrl());
-    map.putString("status", redirect.getStatus().name());
+    map.putString("status", redirect.getStatus());
     map.putString("url", redirect.getUrl());
 
     return map;
   }
 
   @NonNull
-  public static Bundle convertCodeVerificationToWritableMap(@Nullable CodeVerification codeVerification) {
+  public static Bundle convertCodeVerificationToWritableMap(@Nullable SourceCodeVerification codeVerification) {
     Bundle map = new Bundle();
 
     if (codeVerification == null) {
@@ -315,7 +313,7 @@ public class Converters {
     }
 
     map.putInt("attemptsRemaining", codeVerification.getAttemptsRemaining());
-    map.putString("status", codeVerification.getStatus().name());
+    map.putString("status", codeVerification.getStatus());
 
     return map;
   }
@@ -378,18 +376,18 @@ public class Converters {
     return result;
   }
 
-  public static BankAccountTokenParams createBankAccountTokenParams(Map<String, Object> accountData) {
-    BankAccountTokenParams accountTokenParams = new BankAccountTokenParams(
-        // required fields
+  public static BankAccount createBankAccount(Map<String, Object> accountData) {
+    BankAccount account = new BankAccount(
+      // required fields only
+        (String)accountData.get("accountNumber"),
         (String)accountData.get("countryCode"),
         (String)accountData.get("currency"),
-        (String)accountData.get("accountNumber"),
-      null,
-      getValue(accountData, "accountHolderName"),
-      getValue(accountData, "routingNumber")
+      getValue(accountData, "routingNumber", "")
     );
+    account.setAccountHolderName(getValue(accountData, "accountHolderName"));
+    account.setAccountHolderType(getValue(accountData, "accountHolderType"));
 
-    return accountTokenParams;
+    return account;
   }
 
   public static String getStringOrNull(@NonNull Map<String, Object> map, @NonNull String key) {

--- a/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/expo/modules/payments/stripe/GoogleApiPayFlowImpl.java
+++ b/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/expo/modules/payments/stripe/GoogleApiPayFlowImpl.java
@@ -1,6 +1,5 @@
 package abi40_0_0.expo.modules.payments.stripe;
 import android.app.Activity;
-import android.util.Log;
 import android.content.Intent;
 import androidx.annotation.NonNull;
 
@@ -23,14 +22,12 @@ import com.google.android.gms.wallet.ShippingAddressRequirements;
 import com.google.android.gms.wallet.TransactionInfo;
 import com.google.android.gms.wallet.Wallet;
 import com.google.android.gms.wallet.WalletConstants;
+import com.stripe.android.BuildConfig;
 import com.stripe.android.model.Token;
-import com.stripe.android.Stripe;
 
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
-import org.json.JSONObject;
-import org.json.JSONException;
 
 import static abi40_0_0.expo.modules.payments.stripe.Errors.toErrorCode;
 import static abi40_0_0.expo.modules.payments.stripe.util.Converters.convertTokenToWritableMap;
@@ -96,7 +93,7 @@ public final class GoogleApiPayFlowImpl extends PayFlow {
       .setPaymentMethodTokenizationType(WalletConstants.PAYMENT_METHOD_TOKENIZATION_TYPE_PAYMENT_GATEWAY)
       .addParameter("gateway", "stripe")
       .addParameter("stripe:publishableKey", getPublishableKey())
-      .addParameter("stripe:version", Stripe.VERSION_NAME)
+      .addParameter("stripe:version", BuildConfig.VERSION_NAME)
       .build();
   }
 
@@ -228,12 +225,7 @@ public final class GoogleApiPayFlowImpl extends PayFlow {
             PaymentData paymentData = PaymentData.getFromIntent(data);
             ArgCheck.nonNull(paymentData);
             String tokenJson = paymentData.getPaymentMethodToken().getToken();
-            Token token = null;
-            try {
-              token = Token.fromJson(new JSONObject(tokenJson));
-            } catch (JSONException e) {
-              Log.e(TAG, "Unable to create token from JSON string '" + tokenJson + "'.\n" + e);
-            }
+            Token token = Token.fromString(tokenJson);
             if (token == null) {
               payPromise.reject(
                 getErrorCode("parseResponse"),

--- a/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/expo/modules/payments/stripe/StripeModule.java
+++ b/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/expo/modules/payments/stripe/StripeModule.java
@@ -24,12 +24,10 @@ import abi40_0_0.expo.modules.payments.stripe.util.ArgCheck;
 import abi40_0_0.expo.modules.payments.stripe.util.Converters;
 import abi40_0_0.expo.modules.payments.stripe.util.Fun0;
 import com.google.android.gms.wallet.WalletConstants;
-import com.stripe.android.ApiResultCallback;
+import com.stripe.android.SourceCallback;
 import com.stripe.android.Stripe;
-import com.stripe.android.model.CardParams;
+import com.stripe.android.TokenCallback;
 import com.stripe.android.model.Source;
-import com.stripe.android.model.Source.Flow;
-import com.stripe.android.model.Source.Status;
 import com.stripe.android.model.SourceParams;
 import com.stripe.android.model.Token;
 
@@ -45,7 +43,8 @@ import static abi40_0_0.expo.modules.payments.stripe.Errors.getErrorCode;
 import static abi40_0_0.expo.modules.payments.stripe.Errors.toErrorCode;
 import static abi40_0_0.expo.modules.payments.stripe.util.Converters.convertSourceToWritableMap;
 import static abi40_0_0.expo.modules.payments.stripe.util.Converters.convertTokenToWritableMap;
-import static abi40_0_0.expo.modules.payments.stripe.util.Converters.createBankAccountTokenParams;
+import static abi40_0_0.expo.modules.payments.stripe.util.Converters.createBankAccount;
+import static abi40_0_0.expo.modules.payments.stripe.util.Converters.createCard;
 import static abi40_0_0.expo.modules.payments.stripe.util.Converters.getStringOrNull;
 import static abi40_0_0.expo.modules.payments.stripe.util.InitializationOptions.ANDROID_PAY_MODE_KEY;
 import static abi40_0_0.expo.modules.payments.stripe.util.InitializationOptions.ANDROID_PAY_MODE_PRODUCTION;
@@ -182,16 +181,13 @@ public class StripeModule extends ExportedModule {
       ArgCheck.nonNull(mStripe);
       ArgCheck.notEmptyString(mPublicKey);
 
-      mStripe.createCardToken(
-        Converters.createCardParams(cardData),
-        null,
-        null,
-        new ApiResultCallback<Token>() {
-          @Override
-          public void onSuccess(@NonNull Token token) {
+      mStripe.createToken(
+        createCard(cardData),
+        mPublicKey,
+        new TokenCallback() {
+          public void onSuccess(Token token) {
             promise.resolve(convertTokenToWritableMap(token));
           }
-          @Override
           public void onError(Exception error) {
             error.printStackTrace();
             promise.reject(toErrorCode(error), error.getMessage());
@@ -209,15 +205,13 @@ public class StripeModule extends ExportedModule {
       ArgCheck.notEmptyString(mPublicKey);
 
       mStripe.createBankAccountToken(
-        createBankAccountTokenParams(accountData),
+        createBankAccount(accountData),
         mPublicKey,
         null,
-        new ApiResultCallback<Token>() {
-          @Override
-          public void onSuccess(@NonNull Token token) {
+        new TokenCallback() {
+          public void onSuccess(Token token) {
             promise.resolve(convertTokenToWritableMap(token));
           }
-          @Override
           public void onError(Exception error) {
             error.printStackTrace();
             promise.reject(toErrorCode(error), error.getMessage());
@@ -339,13 +333,15 @@ public class StripeModule extends ExportedModule {
 
     ArgCheck.nonNull(sourceParams);
 
-    mStripe.createSource(sourceParams, new ApiResultCallback<Source>() {
+    mStripe.createSource(sourceParams, new SourceCallback() {
+      @Override
       public void onError(Exception error) {
         promise.reject(toErrorCode(error), error);
       }
 
-      public void onSuccess(@NonNull Source source) {
-        if (Flow.Redirect.equals(source.getFlow())) {
+      @Override
+      public void onSuccess(Source source) {
+        if (Source.REDIRECT.equals(source.getFlow())) {
           Activity currentActivity = getCurrentActivity();
           if (currentActivity == null) {
             promise.reject(
@@ -437,18 +433,19 @@ public class StripeModule extends ExportedModule {
         }
 
         switch (source.getStatus()) {
-          case Chargeable:
-          case Consumed:
+          case Source.CHARGEABLE:
+          case Source.CONSUMED:
             promise.resolve(convertSourceToWritableMap(source));
             break;
-          case Canceled:
+          case Source.CANCELED:
             promise.reject(
               getErrorCode(mErrorCodes, "redirectCancelled"),
               getDescription(mErrorCodes, "redirectCancelled")
             );
             break;
-          case Pending:
-          case Failed:
+          case Source.PENDING:
+          case Source.FAILED:
+          case Source.UNKNOWN:
             promise.reject(
               getErrorCode(mErrorCodes, "redirectFailed"),
               getDescription(mErrorCodes, "redirectFailed")

--- a/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/expo/modules/payments/stripe/dialog/AddCardDialogFragment.java
+++ b/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/expo/modules/payments/stripe/dialog/AddCardDialogFragment.java
@@ -1,6 +1,5 @@
 package abi40_0_0.expo.modules.payments.stripe.dialog;
 
-import androidx.annotation.NonNull;
 import android.app.AlertDialog;
 import android.app.Dialog;
 import android.app.DialogFragment;
@@ -28,7 +27,8 @@ import abi40_0_0.expo.modules.payments.stripe.util.CardFlipAnimator;
 import abi40_0_0.expo.modules.payments.stripe.util.Converters;
 import abi40_0_0.expo.modules.payments.stripe.util.Utils;
 
-import com.stripe.android.ApiResultCallback;
+import com.stripe.android.SourceCallback;
+import com.stripe.android.TokenCallback;
 import com.stripe.android.model.Card;
 import com.stripe.android.model.Source;
 import com.stripe.android.model.SourceParams;
@@ -193,12 +193,11 @@ public class AddCardDialogFragment extends DialogFragment {
     doneButton.setEnabled(false);
     progressBar.setVisibility(View.VISIBLE);
     final CreditCard fromCard = from.getCreditCard();
-    final Card card = Card.create(
+    final Card card = new Card(
       fromCard.getCardNumber(),
       fromCard.getExpMonth(),
       fromCard.getExpYear(),
-      fromCard.getSecurityCode()
-    );
+      fromCard.getSecurityCode());
 
     String errorMessage = Utils.validateCard(card);
     if (errorMessage == null) {
@@ -206,9 +205,9 @@ public class AddCardDialogFragment extends DialogFragment {
         SourceParams cardSourceParams = SourceParams.createCardParams(card);
         StripeModule.getInstance(tag).getStripe().createSource(
           cardSourceParams,
-          new ApiResultCallback<Source>() {
+          new SourceCallback() {
             @Override
-            public void onSuccess(@NonNull Source source) {
+            public void onSuccess(Source source) {
               // Normalize data with iOS SDK
               final Bundle sourceMap = Converters.convertSourceToWritableMap(source);
               sourceMap.putBundle("card", Converters.mapToWritableMap(source.getSourceTypeData()));
@@ -231,13 +230,11 @@ public class AddCardDialogFragment extends DialogFragment {
           }
         );
       } else {
-        StripeModule.getInstance(tag).getStripe().createCardToken(
-          card,
-          null,
-          null,
-          new ApiResultCallback<Token>() {
-            @Override
-            public void onSuccess(@NonNull Token token) {
+        StripeModule.getInstance(tag).getStripe().createToken(
+            card,
+            PUBLISHABLE_KEY,
+            new TokenCallback() {
+              public void onSuccess(Token token) {
                 if (promise != null) {
                   promise.resolve(Converters.convertTokenToWritableMap(token));
                   promise = null;
@@ -246,7 +243,6 @@ public class AddCardDialogFragment extends DialogFragment {
                 dismiss();
               }
 
-              @Override
               public void onError(Exception error) {
                 doneButton.setEnabled(true);
                 progressBar.setVisibility(View.GONE);

--- a/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/expo/modules/payments/stripe/util/Converters.java
+++ b/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/expo/modules/payments/stripe/util/Converters.java
@@ -10,19 +10,16 @@ import com.google.android.gms.identity.intents.model.UserAddress;
 import com.google.android.gms.wallet.PaymentData;
 import com.stripe.android.model.Address;
 import com.stripe.android.model.BankAccount;
-import com.stripe.android.model.BankAccountTokenParams;
 import com.stripe.android.model.Card;
-import com.stripe.android.model.CardParams;
 import com.stripe.android.model.Source;
-import com.stripe.android.model.Source.CodeVerification;
-import com.stripe.android.model.Source.Owner;
-import com.stripe.android.model.Source.Receiver;
-import com.stripe.android.model.Source.Redirect;
+import com.stripe.android.model.SourceCodeVerification;
+import com.stripe.android.model.SourceOwner;
+import com.stripe.android.model.SourceReceiver;
+import com.stripe.android.model.SourceRedirect;
 import com.stripe.android.model.Token;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -71,7 +68,7 @@ public class Converters {
 
     result.putString("cardId", card.getId());
     result.putString("number", card.getNumber());
-    result.putString("cvc", card.getCvc() );
+    result.putString("cvc", card.getCVC() );
     result.putInt("expMonth", card.getExpMonth() );
     result.putInt("expYear", card.getExpYear() );
     result.putString("name", card.getName() );
@@ -82,8 +79,8 @@ public class Converters {
     result.putString("addressZip", card.getAddressZip() );
     result.putString("addressCountry", card.getAddressCountry() );
     result.putString("last4", card.getLast4() );
-    result.putString("brand", card.getBrand().getDisplayName() );
-    result.putString("funding", card.getFunding().name() );
+    result.putString("brand", card.getBrand() );
+    result.putString("funding", card.getFunding() );
     result.putString("fingerprint", card.getFingerprint() );
     result.putString("country", card.getCountry() );
     result.putString("currency", card.getCurrency() );
@@ -97,10 +94,11 @@ public class Converters {
     if (account == null) return result;
 
     result.putString("routingNumber", account.getRoutingNumber());
+    result.putString("accountNumber", account.getAccountNumber());
     result.putString("countryCode", account.getCountryCode());
     result.putString("currency", account.getCurrency());
     result.putString("accountHolderName", account.getAccountHolderName());
-    result.putString("accountHolderType", account.getAccountHolderType().name());
+    result.putString("accountHolderType", account.getAccountHolderType());
     result.putString("fingerprint", account.getFingerprint());
     result.putString("bankName", account.getBankName());
     result.putString("last4", account.getLast4());
@@ -167,33 +165,32 @@ public class Converters {
     return allowedCountriesForShipping;
   }
 
-  public static CardParams createCardParams(final Map<String, Object> cardData) {
-    Address address = new Address(
-      getValue(cardData, "addressCity"),
-      getValue(cardData, "country"),
-      getValue(cardData, "addressLine1"),
-      getValue(cardData, "addressLine2"),
-      getValue(cardData, "addressZip"),
-      getValue(cardData, "addressState")
-    );
-    Map <String, String> metaData = new HashMap<String, String>();
-    metaData.put("brand", getValue(cardData, "brand"));
-    metaData.put("last4", getValue(cardData, "last4"));
-    metaData.put("fingerprint", getValue(cardData, "fingerprint"));
-    metaData.put("funding", getValue(cardData, "funding"));
-    metaData.put("id", getValue(cardData, "id"));
-    return 
-      new CardParams(
+  public static Card createCard(final Map<String, Object> cardData) {
+    return new Card(
+      // required fields
         (String)cardData.get("number"),
         new Integer((int)Math.round((Double)cardData.get("expMonth"))),
         new Integer((int)Math.round((Double)cardData.get("expYear"))),
-        getValue(cardData, "cvc"),
-        getValue(cardData, "name"),
-        address,
-        getValue(cardData, "currency"),
-        metaData
-      );
+      // additional fields
+      getValue(cardData, "cvc"),
+      getValue(cardData, "name"),
+      getValue(cardData, "addressLine1"),
+      getValue(cardData, "addressLine2"),
+      getValue(cardData, "addressCity"),
+      getValue(cardData, "addressState"),
+      getValue(cardData, "addressZip"),
+      getValue(cardData, "addressCountry"),
+      getValue(cardData, "brand"),
+      getValue(cardData, "last4"),
+      getValue(cardData, "fingerprint"),
+      getValue(cardData, "funding"),
+      getValue(cardData, "country"),
+      getValue(cardData, "currency"),
+      getValue(cardData, "id")
+    );
   }
+
+
 
   @NonNull
   public static Bundle convertSourceToWritableMap(@Nullable Source source) {
@@ -208,16 +205,17 @@ public class Converters {
     newSource.putInt("created", source.getCreated().intValue());
     newSource.putBundle("codeVerification", convertCodeVerificationToWritableMap(source.getCodeVerification()));
     newSource.putString("currency", source.getCurrency());
-    newSource.putString("flow", source.getFlow().name());
+    newSource.putString("flow", source.getFlow());
     newSource.putBoolean("livemode", source.isLiveMode());
+    newSource.putBundle("metadata", stringMapToWritableMap(source.getMetaData()));
     newSource.putBundle("owner", convertOwnerToWritableMap(source.getOwner()));
     newSource.putBundle("receiver", convertReceiverToWritableMap(source.getReceiver()));
     newSource.putBundle("redirect", convertRedirectToWritableMap(source.getRedirect()));
     newSource.putBundle("sourceTypeData", mapToWritableMap(source.getSourceTypeData()));
-    newSource.putString("status", source.getStatus().name());
+    newSource.putString("status", source.getStatus());
     newSource.putString("type", source.getType());
     newSource.putString("typeRaw", source.getTypeRaw());
-    newSource.putString("usage", source.getUsage().name());
+    newSource.putString("usage", source.getUsage());
 
     return newSource;
   }
@@ -238,7 +236,7 @@ public class Converters {
   }
 
   @NonNull
-  public static Bundle convertOwnerToWritableMap(@Nullable final Owner owner) {
+  public static Bundle convertOwnerToWritableMap(@Nullable final SourceOwner owner) {
     Bundle map = new Bundle();
 
     if (owner == null) {
@@ -276,7 +274,7 @@ public class Converters {
   }
 
   @NonNull
-  public static Bundle convertReceiverToWritableMap(@Nullable final Receiver receiver) {
+  public static Bundle convertReceiverToWritableMap(@Nullable final SourceReceiver receiver) {
     Bundle map = new Bundle();
 
     if (receiver == null) {
@@ -292,7 +290,7 @@ public class Converters {
   }
 
   @NonNull
-  public static Bundle convertRedirectToWritableMap(@Nullable Redirect redirect) {
+  public static Bundle convertRedirectToWritableMap(@Nullable SourceRedirect redirect) {
     Bundle map = new Bundle();
 
     if (redirect == null) {
@@ -300,14 +298,14 @@ public class Converters {
     }
 
     map.putString("returnUrl", redirect.getReturnUrl());
-    map.putString("status", redirect.getStatus().name());
+    map.putString("status", redirect.getStatus());
     map.putString("url", redirect.getUrl());
 
     return map;
   }
 
   @NonNull
-  public static Bundle convertCodeVerificationToWritableMap(@Nullable CodeVerification codeVerification) {
+  public static Bundle convertCodeVerificationToWritableMap(@Nullable SourceCodeVerification codeVerification) {
     Bundle map = new Bundle();
 
     if (codeVerification == null) {
@@ -315,7 +313,7 @@ public class Converters {
     }
 
     map.putInt("attemptsRemaining", codeVerification.getAttemptsRemaining());
-    map.putString("status", codeVerification.getStatus().name());
+    map.putString("status", codeVerification.getStatus());
 
     return map;
   }
@@ -378,18 +376,18 @@ public class Converters {
     return result;
   }
 
-  public static BankAccountTokenParams createBankAccountTokenParams(Map<String, Object> accountData) {
-    BankAccountTokenParams accountTokenParams = new BankAccountTokenParams(
-        // required fields
+  public static BankAccount createBankAccount(Map<String, Object> accountData) {
+    BankAccount account = new BankAccount(
+      // required fields only
+        (String)accountData.get("accountNumber"),
         (String)accountData.get("countryCode"),
         (String)accountData.get("currency"),
-        (String)accountData.get("accountNumber"),
-      null,
-      getValue(accountData, "accountHolderName"),
-      getValue(accountData, "routingNumber")
+      getValue(accountData, "routingNumber", "")
     );
+    account.setAccountHolderName(getValue(accountData, "accountHolderName"));
+    account.setAccountHolderType(getValue(accountData, "accountHolderType"));
 
-    return accountTokenParams;
+    return account;
   }
 
   public static String getStringOrNull(@NonNull Map<String, Object> map, @NonNull String key) {

--- a/android/versioned-abis/expoview-abi41_0_0/src/main/java/abi41_0_0/expo/modules/payments/stripe/GoogleApiPayFlowImpl.java
+++ b/android/versioned-abis/expoview-abi41_0_0/src/main/java/abi41_0_0/expo/modules/payments/stripe/GoogleApiPayFlowImpl.java
@@ -2,7 +2,12 @@ package abi41_0_0.expo.modules.payments.stripe;
 
 import android.app.Activity;
 import android.content.Intent;
-import android.util.Log;
+import androidx.annotation.NonNull;
+
+import abi41_0_0.org.unimodules.core.Promise;
+import abi41_0_0.expo.modules.payments.stripe.util.ArgCheck;
+import abi41_0_0.expo.modules.payments.stripe.util.Converters;
+import abi41_0_0.expo.modules.payments.stripe.util.Fun0;
 
 import com.google.android.gms.common.api.ApiException;
 import com.google.android.gms.common.api.Status;
@@ -19,21 +24,12 @@ import com.google.android.gms.wallet.ShippingAddressRequirements;
 import com.google.android.gms.wallet.TransactionInfo;
 import com.google.android.gms.wallet.Wallet;
 import com.google.android.gms.wallet.WalletConstants;
-import com.stripe.android.Stripe;
+import com.stripe.android.BuildConfig;
 import com.stripe.android.model.Token;
-
-import org.json.JSONException;
-import org.json.JSONObject;
-import abi41_0_0.org.unimodules.core.Promise;
 
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
-
-import androidx.annotation.NonNull;
-import abi41_0_0.expo.modules.payments.stripe.util.ArgCheck;
-import abi41_0_0.expo.modules.payments.stripe.util.Converters;
-import abi41_0_0.expo.modules.payments.stripe.util.Fun0;
 
 import static abi41_0_0.expo.modules.payments.stripe.Errors.toErrorCode;
 import static abi41_0_0.expo.modules.payments.stripe.util.Converters.convertTokenToWritableMap;
@@ -99,7 +95,7 @@ public final class GoogleApiPayFlowImpl extends PayFlow {
       .setPaymentMethodTokenizationType(WalletConstants.PAYMENT_METHOD_TOKENIZATION_TYPE_PAYMENT_GATEWAY)
       .addParameter("gateway", "stripe")
       .addParameter("stripe:publishableKey", getPublishableKey())
-      .addParameter("stripe:version", Stripe.VERSION_NAME)
+      .addParameter("stripe:version", BuildConfig.VERSION_NAME)
       .build();
   }
 
@@ -231,12 +227,7 @@ public final class GoogleApiPayFlowImpl extends PayFlow {
             PaymentData paymentData = PaymentData.getFromIntent(data);
             ArgCheck.nonNull(paymentData);
             String tokenJson = paymentData.getPaymentMethodToken().getToken();
-            Token token = null;
-            try {
-              token = Token.fromJson(new JSONObject(tokenJson));
-            } catch (JSONException e) {
-              Log.e(TAG, "Unable to create token from JSON string '" + tokenJson + "'.\n" + e);
-            }
+            Token token = Token.fromString(tokenJson);
             if (token == null) {
               payPromise.reject(
                 getErrorCode("parseResponse"),

--- a/android/versioned-abis/expoview-abi41_0_0/src/main/java/abi41_0_0/expo/modules/payments/stripe/StripeModule.java
+++ b/android/versioned-abis/expoview-abi41_0_0/src/main/java/abi41_0_0/expo/modules/payments/stripe/StripeModule.java
@@ -9,13 +9,15 @@ import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import android.text.TextUtils;
 
 import com.google.android.gms.wallet.WalletConstants;
-import com.stripe.android.ApiResultCallback;
+import com.stripe.android.SourceCallback;
 import com.stripe.android.Stripe;
+import com.stripe.android.TokenCallback;
 import com.stripe.android.model.Source;
-import com.stripe.android.model.Source.Flow;
 import com.stripe.android.model.SourceParams;
 import com.stripe.android.model.Token;
 
@@ -32,8 +34,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import abi41_0_0.expo.modules.payments.stripe.dialog.AddCardDialogFragment;
 import abi41_0_0.expo.modules.payments.stripe.util.ArgCheck;
 import abi41_0_0.expo.modules.payments.stripe.util.Converters;
@@ -44,7 +44,8 @@ import static abi41_0_0.expo.modules.payments.stripe.Errors.getErrorCode;
 import static abi41_0_0.expo.modules.payments.stripe.Errors.toErrorCode;
 import static abi41_0_0.expo.modules.payments.stripe.util.Converters.convertSourceToWritableMap;
 import static abi41_0_0.expo.modules.payments.stripe.util.Converters.convertTokenToWritableMap;
-import static abi41_0_0.expo.modules.payments.stripe.util.Converters.createBankAccountTokenParams;
+import static abi41_0_0.expo.modules.payments.stripe.util.Converters.createBankAccount;
+import static abi41_0_0.expo.modules.payments.stripe.util.Converters.createCard;
 import static abi41_0_0.expo.modules.payments.stripe.util.Converters.getStringOrNull;
 import static abi41_0_0.expo.modules.payments.stripe.util.InitializationOptions.ANDROID_PAY_MODE_KEY;
 import static abi41_0_0.expo.modules.payments.stripe.util.InitializationOptions.ANDROID_PAY_MODE_PRODUCTION;
@@ -181,16 +182,13 @@ public class StripeModule extends ExportedModule {
       ArgCheck.nonNull(mStripe);
       ArgCheck.notEmptyString(mPublicKey);
 
-      mStripe.createCardToken(
-        Converters.createCardParams(cardData),
-        null,
-        null,
-        new ApiResultCallback<Token>() {
-          @Override
-          public void onSuccess(@NonNull Token token) {
+      mStripe.createToken(
+        createCard(cardData),
+        mPublicKey,
+        new TokenCallback() {
+          public void onSuccess(Token token) {
             promise.resolve(convertTokenToWritableMap(token));
           }
-          @Override
           public void onError(Exception error) {
             error.printStackTrace();
             promise.reject(toErrorCode(error), error.getMessage());
@@ -208,15 +206,13 @@ public class StripeModule extends ExportedModule {
       ArgCheck.notEmptyString(mPublicKey);
 
       mStripe.createBankAccountToken(
-        createBankAccountTokenParams(accountData),
+        createBankAccount(accountData),
         mPublicKey,
         null,
-        new ApiResultCallback<Token>() {
-          @Override
-          public void onSuccess(@NonNull Token token) {
+        new TokenCallback() {
+          public void onSuccess(Token token) {
             promise.resolve(convertTokenToWritableMap(token));
           }
-          @Override
           public void onError(Exception error) {
             error.printStackTrace();
             promise.reject(toErrorCode(error), error.getMessage());
@@ -237,11 +233,11 @@ public class StripeModule extends ExportedModule {
       boolean createCardSource = params.get("createCardSource") instanceof Boolean ? (Boolean) params.get("createCardSource") : false;
 
       final AddCardDialogFragment cardDialog = AddCardDialogFragment.newInstance(
-          mPublicKey,
-          getErrorCode(mErrorCodes, "cancelled"),
-          getDescription(mErrorCodes, "cancelled"),
-          createCardSource,
-          mTag
+        mPublicKey,
+        getErrorCode(mErrorCodes, "cancelled"),
+        getDescription(mErrorCodes, "cancelled"),
+        createCardSource,
+        mTag
       );
       cardDialog.setPromise(promise);
       cardDialog.show(currentActivity.getFragmentManager(), "AddNewCard");
@@ -282,71 +278,71 @@ public class StripeModule extends ExportedModule {
     switch (sourceType) {
       case "alipay":
         sourceParams = SourceParams.createAlipaySingleUseParams(
-            Math.round((Double)options.get("amount")),
-            (String)options.get("currency"),
-            getStringOrNull(options, "name"),
-            getStringOrNull(options, "email"),
-            (String)options.get("returnURL"));
+          Math.round((Double)options.get("amount")),
+          (String)options.get("currency"),
+          getStringOrNull(options, "name"),
+          getStringOrNull(options, "email"),
+          (String)options.get("returnURL"));
         break;
       case "bancontact":
         sourceParams = SourceParams.createBancontactParams(
-            Math.round((Double)options.get("amount")),
-            (String)options.get("name"),
-            (String)options.get("returnURL"),
-            getStringOrNull(options, "statementDescriptor"),
-            (String)options.get("preferredLanguage"));
+          Math.round((Double)options.get("amount")),
+          (String)options.get("name"),
+          (String)options.get("returnURL"),
+          getStringOrNull(options, "statementDescriptor"),
+          (String)options.get("preferredLanguage"));
         break;
       case "giropay":
         sourceParams = SourceParams.createGiropayParams(
-            Math.round((Double)options.get("amount")),
-            (String)options.get("name"),
-            (String)options.get("returnURL"),
-            getStringOrNull(options, "statementDescriptor"));
+          Math.round((Double)options.get("amount")),
+          (String)options.get("name"),
+          (String)options.get("returnURL"),
+          getStringOrNull(options, "statementDescriptor"));
         break;
       case "ideal":
         sourceParams = SourceParams.createIdealParams(
-            Math.round((Double)options.get("amount")),
-            (String)options.get("name"),
-            (String)options.get("returnURL"),
-            getStringOrNull(options, "statementDescriptor"),
-            getStringOrNull(options, "bank"));
+          Math.round((Double)options.get("amount")),
+          (String)options.get("name"),
+          (String)options.get("returnURL"),
+          getStringOrNull(options, "statementDescriptor"),
+          getStringOrNull(options, "bank"));
         break;
       case "sepaDebit":
         sourceParams = SourceParams.createSepaDebitParams(
-            (String)options.get("name"),
-            (String)options.get("iban"),
-            getStringOrNull(options, "addressLine1"),
-            (String)options.get("city"),
-            (String)options.get("postalCode"),
-            (String)options.get("country"));
+          (String)options.get("name"),
+          (String)options.get("iban"),
+          getStringOrNull(options, "addressLine1"),
+          (String)options.get("city"),
+          (String)options.get("postalCode"),
+          (String)options.get("country"));
         break;
       case "sofort":
         sourceParams = SourceParams.createSofortParams(
-            Math.round((Double)options.get("amount")),
-            (String)options.get("returnURL"),
-            (String)options.get("country"),
-            getStringOrNull(options, "statementDescriptor"));
+          Math.round((Double)options.get("amount")),
+          (String)options.get("returnURL"),
+          (String)options.get("country"),
+          getStringOrNull(options, "statementDescriptor"));
         break;
       case "threeDSecure":
         sourceParams = SourceParams.createThreeDSecureParams(
-            Math.round(((Double)options.get("amount"))),
-            (String)options.get("currency"),
-            (String)options.get("returnURL"),
-            (String)options.get("card"));
+          Math.round(((Double)options.get("amount"))),
+          (String)options.get("currency"),
+          (String)options.get("returnURL"),
+          (String)options.get("card"));
         break;
     }
 
     ArgCheck.nonNull(sourceParams);
 
-    mStripe.createSource(sourceParams, new ApiResultCallback<Source>() {
+    mStripe.createSource(sourceParams, new SourceCallback() {
       @Override
       public void onError(Exception error) {
         promise.reject(toErrorCode(error), error);
       }
 
       @Override
-      public void onSuccess(@NonNull Source source) {
-        if (Flow.Redirect.equals(source.getFlow())) {
+      public void onSuccess(Source source) {
+        if (Source.REDIRECT.equals(source.getFlow())) {
           Activity currentActivity = getCurrentActivity();
           if (currentActivity == null) {
             promise.reject(
@@ -358,9 +354,9 @@ public class StripeModule extends ExportedModule {
             mCreatedSource = source;
             String redirectUrl = source.getRedirect().getUrl();
             Intent browserIntent = new Intent(currentActivity, OpenBrowserActivity.class)
-                .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP)
-                .putExtra(OpenBrowserActivity.EXTRA_URL, redirectUrl)
-                .putExtra("tag", mTag);
+              .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP)
+              .putExtra(OpenBrowserActivity.EXTRA_URL, redirectUrl)
+              .putExtra("tag", mTag);
             currentActivity.startActivity(browserIntent);
           }
         } else {
@@ -438,18 +434,19 @@ public class StripeModule extends ExportedModule {
         }
 
         switch (source.getStatus()) {
-          case Chargeable:
-          case Consumed:
+          case Source.CHARGEABLE:
+          case Source.CONSUMED:
             promise.resolve(convertSourceToWritableMap(source));
             break;
-          case Canceled:
+          case Source.CANCELED:
             promise.reject(
               getErrorCode(mErrorCodes, "redirectCancelled"),
               getDescription(mErrorCodes, "redirectCancelled")
             );
             break;
-          case Pending:
-          case Failed:
+          case Source.PENDING:
+          case Source.FAILED:
+          case Source.UNKNOWN:
             promise.reject(
               getErrorCode(mErrorCodes, "redirectFailed"),
               getDescription(mErrorCodes, "redirectFailed")

--- a/android/versioned-abis/expoview-abi41_0_0/src/main/java/abi41_0_0/expo/modules/payments/stripe/dialog/AddCardDialogFragment.java
+++ b/android/versioned-abis/expoview-abi41_0_0/src/main/java/abi41_0_0/expo/modules/payments/stripe/dialog/AddCardDialogFragment.java
@@ -6,6 +6,7 @@ import android.app.DialogFragment;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.os.Bundle;
+import androidx.core.content.ContextCompat;
 import android.text.Editable;
 import android.text.TextUtils;
 import android.text.TextWatcher;
@@ -18,21 +19,21 @@ import android.widget.Toast;
 import com.devmarvel.creditcardentry.fields.SecurityCodeText;
 import com.devmarvel.creditcardentry.library.CreditCard;
 import com.devmarvel.creditcardentry.library.CreditCardForm;
-import com.stripe.android.ApiResultCallback;
-import com.stripe.android.model.Card;
-import com.stripe.android.model.Source;
-import com.stripe.android.model.SourceParams;
-import com.stripe.android.model.Token;
 
 import abi41_0_0.org.unimodules.core.Promise;
 
-import androidx.annotation.NonNull;
-import androidx.core.content.ContextCompat;
 import abi41_0_0.host.exp.expoview.R;
 import abi41_0_0.expo.modules.payments.stripe.StripeModule;
 import abi41_0_0.expo.modules.payments.stripe.util.CardFlipAnimator;
 import abi41_0_0.expo.modules.payments.stripe.util.Converters;
 import abi41_0_0.expo.modules.payments.stripe.util.Utils;
+
+import com.stripe.android.SourceCallback;
+import com.stripe.android.TokenCallback;
+import com.stripe.android.model.Card;
+import com.stripe.android.model.Source;
+import com.stripe.android.model.SourceParams;
+import com.stripe.android.model.Token;
 
 
 /**
@@ -193,12 +194,11 @@ public class AddCardDialogFragment extends DialogFragment {
     doneButton.setEnabled(false);
     progressBar.setVisibility(View.VISIBLE);
     final CreditCard fromCard = from.getCreditCard();
-    final Card card = Card.create(
+    final Card card = new Card(
       fromCard.getCardNumber(),
       fromCard.getExpMonth(),
       fromCard.getExpYear(),
-      fromCard.getSecurityCode()
-    );
+      fromCard.getSecurityCode());
 
     String errorMessage = Utils.validateCard(card);
     if (errorMessage == null) {
@@ -206,9 +206,9 @@ public class AddCardDialogFragment extends DialogFragment {
         SourceParams cardSourceParams = SourceParams.createCardParams(card);
         StripeModule.getInstance(tag).getStripe().createSource(
           cardSourceParams,
-          new ApiResultCallback<Source>() {
+          new SourceCallback() {
             @Override
-            public void onSuccess(@NonNull Source source) {
+            public void onSuccess(Source source) {
               // Normalize data with iOS SDK
               final Bundle sourceMap = Converters.convertSourceToWritableMap(source);
               sourceMap.putBundle("card", Converters.mapToWritableMap(source.getSourceTypeData()));
@@ -231,13 +231,11 @@ public class AddCardDialogFragment extends DialogFragment {
           }
         );
       } else {
-        StripeModule.getInstance(tag).getStripe().createCardToken(
+        StripeModule.getInstance(tag).getStripe().createToken(
             card,
-            null,
-            null,
-            new ApiResultCallback<Token>() {
-              @Override
-              public void onSuccess(@NonNull Token token) {
+          PUBLISHABLE_KEY,
+          new TokenCallback() {
+            public void onSuccess(Token token) {
                 if (promise != null) {
                   promise.resolve(Converters.convertTokenToWritableMap(token));
                   promise = null;
@@ -246,7 +244,6 @@ public class AddCardDialogFragment extends DialogFragment {
                 dismiss();
               }
 
-              @Override
               public void onError(Exception error) {
                 doneButton.setEnabled(true);
                 progressBar.setVisibility(View.GONE);

--- a/android/versioned-abis/expoview-abi41_0_0/src/main/java/abi41_0_0/expo/modules/payments/stripe/util/Converters.java
+++ b/android/versioned-abis/expoview-abi41_0_0/src/main/java/abi41_0_0/expo/modules/payments/stripe/util/Converters.java
@@ -1,6 +1,8 @@
 package abi41_0_0.expo.modules.payments.stripe.util;
 
 import android.os.Bundle;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import android.text.TextUtils;
 
 import com.google.android.gms.identity.intents.model.CountrySpecification;
@@ -8,24 +10,18 @@ import com.google.android.gms.identity.intents.model.UserAddress;
 import com.google.android.gms.wallet.PaymentData;
 import com.stripe.android.model.Address;
 import com.stripe.android.model.BankAccount;
-import com.stripe.android.model.BankAccountTokenParams;
 import com.stripe.android.model.Card;
-import com.stripe.android.model.CardParams;
 import com.stripe.android.model.Source;
-import com.stripe.android.model.Source.CodeVerification;
-import com.stripe.android.model.Source.Owner;
-import com.stripe.android.model.Source.Receiver;
-import com.stripe.android.model.Source.Redirect;
+import com.stripe.android.model.SourceCodeVerification;
+import com.stripe.android.model.SourceOwner;
+import com.stripe.android.model.SourceReceiver;
+import com.stripe.android.model.SourceRedirect;
 import com.stripe.android.model.Token;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 /**
  * Created by ngoriachev on 13/03/2018.
@@ -72,7 +68,7 @@ public class Converters {
 
     result.putString("cardId", card.getId());
     result.putString("number", card.getNumber());
-    result.putString("cvc", card.getCvc() );
+    result.putString("cvc", card.getCVC() );
     result.putInt("expMonth", card.getExpMonth() );
     result.putInt("expYear", card.getExpYear() );
     result.putString("name", card.getName() );
@@ -83,8 +79,8 @@ public class Converters {
     result.putString("addressZip", card.getAddressZip() );
     result.putString("addressCountry", card.getAddressCountry() );
     result.putString("last4", card.getLast4() );
-    result.putString("brand", card.getBrand().getDisplayName() );
-    result.putString("funding", card.getFunding().name() );
+    result.putString("brand", card.getBrand() );
+    result.putString("funding", card.getFunding() );
     result.putString("fingerprint", card.getFingerprint() );
     result.putString("country", card.getCountry() );
     result.putString("currency", card.getCurrency() );
@@ -98,10 +94,11 @@ public class Converters {
     if (account == null) return result;
 
     result.putString("routingNumber", account.getRoutingNumber());
+    result.putString("accountNumber", account.getAccountNumber());
     result.putString("countryCode", account.getCountryCode());
     result.putString("currency", account.getCurrency());
     result.putString("accountHolderName", account.getAccountHolderName());
-    result.putString("accountHolderType", account.getAccountHolderType().name());
+    result.putString("accountHolderType", account.getAccountHolderType());
     result.putString("fingerprint", account.getFingerprint());
     result.putString("bankName", account.getBankName());
     result.putString("last4", account.getLast4());
@@ -168,33 +165,32 @@ public class Converters {
     return allowedCountriesForShipping;
   }
 
-  public static CardParams createCardParams(final Map<String, Object> cardData) {
-    Address address = new Address(
-      getValue(cardData, "addressCity"),
-      getValue(cardData, "country"),
-      getValue(cardData, "addressLine1"),
-      getValue(cardData, "addressLine2"),
-      getValue(cardData, "addressZip"),
-      getValue(cardData, "addressState")
-    );
-    Map <String, String> metaData = new HashMap<String, String>();
-    metaData.put("brand", getValue(cardData, "brand"));
-    metaData.put("last4", getValue(cardData, "last4"));
-    metaData.put("fingerprint", getValue(cardData, "fingerprint"));
-    metaData.put("funding", getValue(cardData, "funding"));
-    metaData.put("id", getValue(cardData, "id"));
-    return 
-      new CardParams(
+  public static Card createCard(final Map<String, Object> cardData) {
+    return new Card(
+      // required fields
         (String)cardData.get("number"),
         new Integer((int)Math.round((Double)cardData.get("expMonth"))),
         new Integer((int)Math.round((Double)cardData.get("expYear"))),
+      // additional fields
         getValue(cardData, "cvc"),
         getValue(cardData, "name"),
-        address,
+      getValue(cardData, "addressLine1"),
+      getValue(cardData, "addressLine2"),
+      getValue(cardData, "addressCity"),
+      getValue(cardData, "addressState"),
+      getValue(cardData, "addressZip"),
+      getValue(cardData, "addressCountry"),
+      getValue(cardData, "brand"),
+      getValue(cardData, "last4"),
+      getValue(cardData, "fingerprint"),
+      getValue(cardData, "funding"),
+      getValue(cardData, "country"),
         getValue(cardData, "currency"),
-        metaData
+      getValue(cardData, "id")
       );
   }
+
+
 
   @NonNull
   public static Bundle convertSourceToWritableMap(@Nullable Source source) {
@@ -209,16 +205,17 @@ public class Converters {
     newSource.putInt("created", source.getCreated().intValue());
     newSource.putBundle("codeVerification", convertCodeVerificationToWritableMap(source.getCodeVerification()));
     newSource.putString("currency", source.getCurrency());
-    newSource.putString("flow", source.getFlow().name());
+    newSource.putString("flow", source.getFlow());
     newSource.putBoolean("livemode", source.isLiveMode());
+    newSource.putBundle("metadata", stringMapToWritableMap(source.getMetaData()));
     newSource.putBundle("owner", convertOwnerToWritableMap(source.getOwner()));
     newSource.putBundle("receiver", convertReceiverToWritableMap(source.getReceiver()));
     newSource.putBundle("redirect", convertRedirectToWritableMap(source.getRedirect()));
     newSource.putBundle("sourceTypeData", mapToWritableMap(source.getSourceTypeData()));
-    newSource.putString("status", source.getStatus().name());
+    newSource.putString("status", source.getStatus());
     newSource.putString("type", source.getType());
     newSource.putString("typeRaw", source.getTypeRaw());
-    newSource.putString("usage", source.getUsage().name());
+    newSource.putString("usage", source.getUsage());
 
     return newSource;
   }
@@ -239,7 +236,7 @@ public class Converters {
   }
 
   @NonNull
-  public static Bundle convertOwnerToWritableMap(@Nullable final Owner owner) {
+  public static Bundle convertOwnerToWritableMap(@Nullable final SourceOwner owner) {
     Bundle map = new Bundle();
 
     if (owner == null) {
@@ -277,7 +274,7 @@ public class Converters {
   }
 
   @NonNull
-  public static Bundle convertReceiverToWritableMap(@Nullable final Receiver receiver) {
+  public static Bundle convertReceiverToWritableMap(@Nullable final SourceReceiver receiver) {
     Bundle map = new Bundle();
 
     if (receiver == null) {
@@ -293,7 +290,7 @@ public class Converters {
   }
 
   @NonNull
-  public static Bundle convertRedirectToWritableMap(@Nullable Redirect redirect) {
+  public static Bundle convertRedirectToWritableMap(@Nullable SourceRedirect redirect) {
     Bundle map = new Bundle();
 
     if (redirect == null) {
@@ -301,14 +298,14 @@ public class Converters {
     }
 
     map.putString("returnUrl", redirect.getReturnUrl());
-    map.putString("status", redirect.getStatus().name());
+    map.putString("status", redirect.getStatus());
     map.putString("url", redirect.getUrl());
 
     return map;
   }
 
   @NonNull
-  public static Bundle convertCodeVerificationToWritableMap(@Nullable CodeVerification codeVerification) {
+  public static Bundle convertCodeVerificationToWritableMap(@Nullable SourceCodeVerification codeVerification) {
     Bundle map = new Bundle();
 
     if (codeVerification == null) {
@@ -316,7 +313,7 @@ public class Converters {
     }
 
     map.putInt("attemptsRemaining", codeVerification.getAttemptsRemaining());
-    map.putString("status", codeVerification.getStatus().name());
+    map.putString("status", codeVerification.getStatus());
 
     return map;
   }
@@ -379,18 +376,18 @@ public class Converters {
     return result;
   }
 
-  public static BankAccountTokenParams createBankAccountTokenParams(Map<String, Object> accountData) {
-    BankAccountTokenParams accountTokenParams = new BankAccountTokenParams(
-        // required fields
+  public static BankAccount createBankAccount(Map<String, Object> accountData) {
+    BankAccount account = new BankAccount(
+      // required fields only
+      (String)accountData.get("accountNumber"),
         (String)accountData.get("countryCode"),
         (String)accountData.get("currency"),
-        (String)accountData.get("accountNumber"),
-      null,
-      getValue(accountData, "accountHolderName"),
-      getValue(accountData, "routingNumber")
+      getValue(accountData, "routingNumber", "")
     );
+    account.setAccountHolderName(getValue(accountData, "accountHolderName"));
+    account.setAccountHolderType(getValue(accountData, "accountHolderType"));
 
-    return accountTokenParams;
+    return account;
   }
 
   public static String getStringOrNull(@NonNull Map<String, Object> map, @NonNull String key) {

--- a/apps/native-component-list/src/screens/PaymentsScreen.tsx
+++ b/apps/native-component-list/src/screens/PaymentsScreen.tsx
@@ -111,60 +111,6 @@ export default function PaymentsScreen() {
 
   return (
     <View style={styles.container}>
-      <Text style={styles.header}>Miscellaneous methods</Text>
-      <Text style={styles.instruction}>
-        Click button to show create a token based on example card params.
-      </Text>
-      <Button
-        title="Create token"
-        onPress={async () => {
-          const params = {
-            // mandatory
-            number: '4242424242424242',
-            expMonth: 11,
-            expYear: 22,
-            cvc: '223',
-            // optional
-            name: 'Test User',
-            currency: 'usd',
-            addressLine1: '123 Test Street',
-            addressLine2: 'Apt. 5',
-            addressCity: 'Test City',
-            addressState: 'Test State',
-            addressCountry: 'Test Country',
-            addressZip: '55555',
-          };
-
-          const token = await Payments.createTokenWithCardAsync(params);
-          console.log({ token });
-        }}
-      />
-      <Text style={styles.instruction}>
-        Click button to launch Add Card view to accept payment.
-      </Text>
-      <Button
-        title="Add card"
-        onPress={async () => {
-          const token = await Payments.paymentRequestWithCardFormAsync({
-            requiredBillingAddressFields: 'full',
-            prefilledInformation: {
-              billingAddress: {
-                name: 'Gunilla Haugeh',
-                line1: 'Canary Place',
-                line2: '3',
-                city: 'Macon',
-                state: 'Georgia',
-                country: 'US',
-                postalCode: '31217',
-                phone: '123-4567',
-                email: 'myemail@email.com',
-              },
-            },
-          });
-          console.log({ token });
-        }}
-      />
-
       <Text style={styles.header}>Apple Pay Example with Expo</Text>
       <Text style={styles.instruction}>Click button to show Apple Pay dialog.</Text>
       <Button

--- a/packages/expo-payments-stripe/CHANGELOG.md
+++ b/packages/expo-payments-stripe/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- Downgraded underlying native library on Android from v16 to v8.
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/packages/expo-payments-stripe/android/build.gradle
+++ b/packages/expo-payments-stripe/android/build.gradle
@@ -61,7 +61,7 @@ dependencies {
 
   api 'com.google.android.gms:play-services-wallet:15.0.1'
   api 'com.google.firebase:firebase-core:16.0.1'
-  api "com.stripe:stripe-android:${safeExtGet('stripeVersion', '16.1.1')}"
+  api 'com.stripe:stripe-android:8.1.0'
   api 'com.github.tipsi:CreditCardEntry:1.5.0'
-  api "com.google.android.material:material:1.1.0"
+  api "com.google.android.material:material:1.0.0"
 }

--- a/packages/expo-payments-stripe/android/src/main/java/expo/modules/payments/stripe/GoogleApiPayFlowImpl.java
+++ b/packages/expo-payments-stripe/android/src/main/java/expo/modules/payments/stripe/GoogleApiPayFlowImpl.java
@@ -1,9 +1,12 @@
 package expo.modules.payments.stripe;
-
 import android.app.Activity;
 import android.content.Intent;
-import android.util.Log;
+import androidx.annotation.NonNull;
 
+import org.unimodules.core.Promise;
+import expo.modules.payments.stripe.util.ArgCheck;
+import expo.modules.payments.stripe.util.Converters;
+import expo.modules.payments.stripe.util.Fun0;
 import com.google.android.gms.common.api.ApiException;
 import com.google.android.gms.common.api.Status;
 import com.google.android.gms.tasks.OnCompleteListener;
@@ -19,21 +22,12 @@ import com.google.android.gms.wallet.ShippingAddressRequirements;
 import com.google.android.gms.wallet.TransactionInfo;
 import com.google.android.gms.wallet.Wallet;
 import com.google.android.gms.wallet.WalletConstants;
-import com.stripe.android.Stripe;
+import com.stripe.android.BuildConfig;
 import com.stripe.android.model.Token;
-
-import org.json.JSONException;
-import org.json.JSONObject;
-import org.unimodules.core.Promise;
 
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
-
-import androidx.annotation.NonNull;
-import expo.modules.payments.stripe.util.ArgCheck;
-import expo.modules.payments.stripe.util.Converters;
-import expo.modules.payments.stripe.util.Fun0;
 
 import static expo.modules.payments.stripe.Errors.toErrorCode;
 import static expo.modules.payments.stripe.util.Converters.convertTokenToWritableMap;
@@ -99,7 +93,7 @@ public final class GoogleApiPayFlowImpl extends PayFlow {
       .setPaymentMethodTokenizationType(WalletConstants.PAYMENT_METHOD_TOKENIZATION_TYPE_PAYMENT_GATEWAY)
       .addParameter("gateway", "stripe")
       .addParameter("stripe:publishableKey", getPublishableKey())
-      .addParameter("stripe:version", Stripe.VERSION_NAME)
+      .addParameter("stripe:version", BuildConfig.VERSION_NAME)
       .build();
   }
 
@@ -231,12 +225,7 @@ public final class GoogleApiPayFlowImpl extends PayFlow {
             PaymentData paymentData = PaymentData.getFromIntent(data);
             ArgCheck.nonNull(paymentData);
             String tokenJson = paymentData.getPaymentMethodToken().getToken();
-            Token token = null;
-            try {
-              token = Token.fromJson(new JSONObject(tokenJson));
-            } catch (JSONException e) {
-              Log.e(TAG, "Unable to create token from JSON string '" + tokenJson + "'.\n" + e);
-            }
+            Token token = Token.fromString(tokenJson);
             if (token == null) {
               payPromise.reject(
                 getErrorCode("parseResponse"),

--- a/packages/expo-payments-stripe/android/src/main/java/expo/modules/payments/stripe/dialog/AddCardDialogFragment.java
+++ b/packages/expo-payments-stripe/android/src/main/java/expo/modules/payments/stripe/dialog/AddCardDialogFragment.java
@@ -3,36 +3,36 @@ package expo.modules.payments.stripe.dialog;
 import android.app.AlertDialog;
 import android.app.Dialog;
 import android.app.DialogFragment;
-import android.content.Context;
 import android.content.DialogInterface;
 import android.os.Bundle;
+import androidx.core.content.ContextCompat;
 import android.text.Editable;
-import android.text.TextUtils;
 import android.text.TextWatcher;
 import android.view.View;
 import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.ProgressBar;
 import android.widget.Toast;
+import android.content.Context;
+import android.text.TextUtils;
 
 import com.devmarvel.creditcardentry.fields.SecurityCodeText;
 import com.devmarvel.creditcardentry.library.CreditCard;
 import com.devmarvel.creditcardentry.library.CreditCardForm;
-import com.stripe.android.ApiResultCallback;
-import com.stripe.android.model.Card;
-import com.stripe.android.model.Source;
-import com.stripe.android.model.SourceParams;
-import com.stripe.android.model.Token;
 
 import org.unimodules.core.Promise;
-
-import androidx.annotation.NonNull;
-import androidx.core.content.ContextCompat;
 import expo.modules.payments.stripe.R;
 import expo.modules.payments.stripe.StripeModule;
 import expo.modules.payments.stripe.util.CardFlipAnimator;
 import expo.modules.payments.stripe.util.Converters;
 import expo.modules.payments.stripe.util.Utils;
+
+import com.stripe.android.SourceCallback;
+import com.stripe.android.TokenCallback;
+import com.stripe.android.model.Card;
+import com.stripe.android.model.Source;
+import com.stripe.android.model.SourceParams;
+import com.stripe.android.model.Token;
 
 
 /**
@@ -193,12 +193,11 @@ public class AddCardDialogFragment extends DialogFragment {
     doneButton.setEnabled(false);
     progressBar.setVisibility(View.VISIBLE);
     final CreditCard fromCard = from.getCreditCard();
-    final Card card = Card.create(
+    final Card card = new Card(
       fromCard.getCardNumber(),
       fromCard.getExpMonth(),
       fromCard.getExpYear(),
-      fromCard.getSecurityCode()
-    );
+      fromCard.getSecurityCode());
 
     String errorMessage = Utils.validateCard(card);
     if (errorMessage == null) {
@@ -206,9 +205,9 @@ public class AddCardDialogFragment extends DialogFragment {
         SourceParams cardSourceParams = SourceParams.createCardParams(card);
         StripeModule.getInstance(tag).getStripe().createSource(
           cardSourceParams,
-          new ApiResultCallback<Source>() {
+          new SourceCallback() {
             @Override
-            public void onSuccess(@NonNull Source source) {
+            public void onSuccess(Source source) {
               // Normalize data with iOS SDK
               final Bundle sourceMap = Converters.convertSourceToWritableMap(source);
               sourceMap.putBundle("card", Converters.mapToWritableMap(source.getSourceTypeData()));
@@ -231,13 +230,11 @@ public class AddCardDialogFragment extends DialogFragment {
           }
         );
       } else {
-        StripeModule.getInstance(tag).getStripe().createCardToken(
+        StripeModule.getInstance(tag).getStripe().createToken(
             card,
-            null,
-            null,
-            new ApiResultCallback<Token>() {
-              @Override
-              public void onSuccess(@NonNull Token token) {
+            PUBLISHABLE_KEY,
+            new TokenCallback() {
+              public void onSuccess(Token token) {
                 if (promise != null) {
                   promise.resolve(Converters.convertTokenToWritableMap(token));
                   promise = null;
@@ -246,7 +243,6 @@ public class AddCardDialogFragment extends DialogFragment {
                 dismiss();
               }
 
-              @Override
               public void onError(Exception error) {
                 doneButton.setEnabled(true);
                 progressBar.setVisibility(View.GONE);


### PR DESCRIPTION
This reverts commit 679ebac87f524c0e5ea3bc69de4f2664441e7db5.

# Why

Apparently reverted commit causes some issues with `Invalid signature file digest for Manifest main attributes` when Firebase messaging is involved. 

**This is temporary solution for now**

# How

I've bisected commits and narrowed the problem to the `payments-stripe` upgrade commit.
I suspect some transient dependencies are the real cause here, but it has to be investigated further 🤔 

# Test Plan

- [x] `SDK-40` `face-detector` works
- [x] `SDK-41` `face-detector` works
- [x] `UNVERSIONED` `face-detector` works