### PR TITLE
[home] Add list of accounts and organizations to Profile

### DIFF
--- a/home/components/AccountView.tsx
+++ b/home/components/AccountView.tsx
@@ -1,4 +1,6 @@
 import { StackScreenProps } from '@react-navigation/stack';
+import { Project } from 'components/ProjectList';
+import { Snack } from 'components/SnackList';
 import { AccountData } from 'containers/Account';
 import dedent from 'dedent';
 import { take, takeRight } from 'lodash';
@@ -112,7 +114,7 @@ export default function AccountView({
   return (
     <ScrollView
       refreshControl={<RefreshControl refreshing={isRefreshing} onRefresh={_handleRefreshAsync} />}
-      contentContainerStyle={{ paddingBottom: 20 }}
+      contentContainerStyle={{ paddingBottom: 20, paddingTop: 12 }}
       style={styles.container}>
       {data?.account.byName && (
         <>
@@ -173,7 +175,9 @@ function AccountProjectsSection({
     });
   };
 
-  const renderApp = (app: any, i: number) => {
+  const apps = data.account.byName.apps;
+
+  const renderApp = (app: Project, i: number) => {
     return (
       <ProjectListItem
         key={i}
@@ -184,12 +188,12 @@ function AccountProjectsSection({
         sdkVersion={app.sdkVersion}
         subtitle={app.packageName || app.fullName}
         experienceInfo={{ username: app.username, slug: app.packageName }}
+        last={i === apps.length - 1}
       />
     );
   };
 
   const renderContents = () => {
-    const apps = data.account.byName.apps;
     if (!apps.length) {
       return <EmptyAccountProjectsNotice />;
     }
@@ -227,7 +231,9 @@ function AccountSnacksSection({
     });
   };
 
-  const renderSnack = (snack: any, i: number) => {
+  const snacks = data.account.byName.snacks;
+
+  const renderSnack = (snack: Snack, i: number) => {
     return (
       <SnackListItem
         key={i}
@@ -235,12 +241,12 @@ function AccountSnacksSection({
         title={snack.name}
         subtitle={snack.description}
         isDraft={snack.isDraft}
+        last={i === snacks.length - 1}
       />
     );
   };
 
   const renderContents = () => {
-    const snacks = data.account.byName.snacks;
     if (!snacks?.length) {
       return <EmptyAccountSnacksNotice />;
     }

--- a/home/components/EmptyAccountSnacksNotice.tsx
+++ b/home/components/EmptyAccountSnacksNotice.tsx
@@ -9,7 +9,7 @@ import { StyledText } from './Text';
 import { StyledView } from './Views';
 
 function handleLearnMorePress() {
-  WebBrowser.openBrowserAsync('https://snack.expo.io');
+  WebBrowser.openBrowserAsync('https://docs.expo.io/workflow/snack');
 }
 
 export default function EmptyAccountSnacksNotice() {

--- a/home/components/EmptyAccountSnacksNotice.tsx
+++ b/home/components/EmptyAccountSnacksNotice.tsx
@@ -12,33 +12,20 @@ function handleLearnMorePress() {
   WebBrowser.openBrowserAsync('https://snack.expo.io');
 }
 
-export default function EmptyAccountSnacksNotice({
-  isCurrentUsersPersonalAccount,
-}: {
-  isCurrentUsersPersonalAccount: boolean;
-}) {
-  if (isCurrentUsersPersonalAccount) {
-    return (
-      <StyledView style={styles.container} lightBackgroundColor={Colors.light.greyBackground}>
-        <StyledText style={[SharedStyles.noticeDescriptionText, styles.descriptionText]}>
-          Snacks that you save to your profile will appear here!
-        </StyledText>
-
-        <PrimaryButton
-          plain
-          onPress={handleLearnMorePress}
-          fallback={TouchableOpacity}
-          style={{ marginBottom: 5 }}>
-          Learn more about Snack
-        </PrimaryButton>
-      </StyledView>
-    );
-  }
+export default function EmptyAccountSnacksNotice() {
   return (
     <StyledView style={styles.container} lightBackgroundColor={Colors.light.greyBackground}>
       <StyledText style={[SharedStyles.noticeDescriptionText, styles.descriptionText]}>
         No saved Snacks
       </StyledText>
+
+      <PrimaryButton
+        plain
+        onPress={handleLearnMorePress}
+        fallback={TouchableOpacity}
+        style={{ marginBottom: 5 }}>
+        Learn more about Snack
+      </PrimaryButton>
     </StyledView>
   );
 }

--- a/home/components/ProfileView.tsx
+++ b/home/components/ProfileView.tsx
@@ -187,6 +187,9 @@ function ProfileAccountsSection({
   };
 
   const accounts = data.me.accounts;
+  if (accounts.length === 1) {
+    return null;
+  }
 
   const renderAccount = (account: { id: string; name: string }, index: number) => {
     return (
@@ -268,6 +271,8 @@ function ProfileSnacksSection({
     navigation.navigate('ProfileAllSnacks', {});
   };
 
+  const snacks = data.me.snacks;
+
   const renderSnack = (snack: any, i: number) => {
     return (
       <SnackListItem
@@ -276,12 +281,12 @@ function ProfileSnacksSection({
         title={snack.name}
         subtitle={snack.description}
         isDraft={snack.isDraft}
+        last={i === snacks.length - 1}
       />
     );
   };
 
   const renderContents = () => {
-    const snacks = data.me.snacks;
     if (!snacks?.length) {
       return <EmptyAccountSnacksNotice />;
     }

--- a/home/containers/Account.tsx
+++ b/home/containers/Account.tsx
@@ -7,8 +7,6 @@ import * as React from 'react';
 import AccountView from '../components/AccountView';
 import { Project } from '../components/ProjectList';
 import { Snack } from '../components/SnackList';
-import { useDispatch } from '../redux/Hooks';
-import SessionActions from '../redux/SessionActions';
 
 const APP_LIMIT = 7;
 const SNACK_LIMIT = 4;
@@ -18,13 +16,6 @@ export interface AccountData {
     byName: {
       id: string;
       name: string;
-      owner: {
-        id: string;
-        username: string;
-        firstName: string | null;
-        lastName: string | null;
-        profilePhoto: string;
-      } | null;
       appCount: number;
       apps: Project[];
       snacks: Snack[];
@@ -42,13 +33,6 @@ const AccountDataQuery = gql`
       byName(accountName: $accountName) {
         id
         name
-        owner {
-          id
-          username
-          firstName
-          lastName
-          profilePhoto
-        }
         appCount
         apps(limit: ${APP_LIMIT}, offset: 0) {
           id
@@ -76,26 +60,13 @@ const AccountDataQuery = gql`
 export default function Account(
   props: {
     accountName: string;
-    isAuthenticated: boolean;
-    isCurrentUsersPersonalAccount: boolean;
   } & StackScreenProps<AllStackRoutes, 'Account'>
 ) {
-  const dispatch = useDispatch();
   const query = useQuery<AccountData, AccountVars>(AccountDataQuery, {
     fetchPolicy: 'cache-and-network',
     variables: {
-      accountName: props.accountName.replace('@', ''),
+      accountName: props.accountName,
     },
   });
-  const { loading, error, data } = query;
-
-  // We verify that the viewer is logged in when we receive data from the server; if the viewer
-  // isn't logged in, we clear our locally stored credentials
-  React.useEffect(() => {
-    if (!loading && !error && props.isCurrentUsersPersonalAccount && !data?.account.byName) {
-      dispatch(SessionActions.signOut());
-    }
-  }, [loading, error, data?.account.byName]);
-
   return <AccountView {...props} {...query} />;
 }

--- a/home/containers/Profile.tsx
+++ b/home/containers/Profile.tsx
@@ -1,5 +1,7 @@
 import { useQuery } from '@apollo/client';
 import { StackScreenProps } from '@react-navigation/stack';
+import { Project } from 'components/ProjectList';
+import { Snack } from 'components/SnackList';
 import gql from 'graphql-tag';
 import { AllStackRoutes } from 'navigation/Navigation.types';
 import * as React from 'react';
@@ -7,6 +9,9 @@ import * as React from 'react';
 import ProfileView from '../components/ProfileView';
 import { useDispatch } from '../redux/Hooks';
 import SessionActions from '../redux/SessionActions';
+
+const APP_LIMIT = 3;
+const SNACK_LIMIT = 3;
 
 export interface ProfileData {
   me: {
@@ -19,6 +24,9 @@ export interface ProfileData {
       id: string;
       name: string;
     }[];
+    appCount: number;
+    apps: Project[];
+    snacks: Snack[];
   };
 }
 
@@ -35,6 +43,26 @@ const ProfileDataQuery = gql`
       accounts {
         id
         name
+      }
+      appCount
+      apps(limit: ${APP_LIMIT}, offset: 0) {
+        id
+        description
+        fullName
+        iconUrl
+        lastPublishedTime
+        name
+        packageName
+        username
+        sdkVersion
+        privacy
+      }
+      snacks(limit: ${SNACK_LIMIT}, offset: 0) {
+        name
+        description
+        fullName
+        slug
+        isDraft
       }
     }
   }

--- a/home/containers/Profile.tsx
+++ b/home/containers/Profile.tsx
@@ -1,0 +1,59 @@
+import { useQuery } from '@apollo/client';
+import { StackScreenProps } from '@react-navigation/stack';
+import gql from 'graphql-tag';
+import { AllStackRoutes } from 'navigation/Navigation.types';
+import * as React from 'react';
+
+import ProfileView from '../components/ProfileView';
+import { useDispatch } from '../redux/Hooks';
+import SessionActions from '../redux/SessionActions';
+
+export interface ProfileData {
+  me: {
+    id: string;
+    username: string;
+    firstName: string | null;
+    lastName: string | null;
+    profilePhoto: string;
+    accounts: {
+      id: string;
+      name: string;
+    }[];
+  };
+}
+
+interface ProfileVars {}
+
+const ProfileDataQuery = gql`
+  query Home_ProfileData2 {
+    me {
+      id
+      username
+      firstName
+      lastName
+      profilePhoto
+      accounts {
+        id
+        name
+      }
+    }
+  }
+`;
+
+export default function Profile(props: StackScreenProps<AllStackRoutes, 'Profile'>) {
+  const dispatch = useDispatch();
+  const query = useQuery<ProfileData, ProfileVars>(ProfileDataQuery, {
+    fetchPolicy: 'cache-and-network',
+  });
+  const { loading, error, data } = query;
+
+  // We verify that the viewer is logged in when we receive data from the server; if the viewer
+  // isn't logged in, we clear our locally stored credentials
+  React.useEffect(() => {
+    if (!loading && !error && !data?.me) {
+      dispatch(SessionActions.signOut());
+    }
+  }, [loading, error, data?.me]);
+
+  return <ProfileView {...props} {...query} />;
+}

--- a/home/containers/ProfileProjectsList.tsx
+++ b/home/containers/ProfileProjectsList.tsx
@@ -1,0 +1,99 @@
+import { useQuery } from '@apollo/client';
+import gql from 'graphql-tag';
+import * as React from 'react';
+
+import ProjectList, { Project } from '../components/ProjectList';
+
+interface ProfileProjectsData {
+  me: {
+    id: string;
+    appCount: number;
+    apps: Project[];
+  };
+}
+
+interface ProfileProjectsVars {
+  limit: number;
+  offset: number;
+}
+
+const ProfileProjectsQuery = gql`
+  query Home_MyApps($limit: Int!, $offset: Int!) {
+    me {
+      id
+      appCount
+      apps(limit: $limit, offset: $offset) {
+        id
+        description
+        fullName
+        iconUrl
+        lastPublishedTime
+        name
+        username
+        packageName
+        privacy
+        sdkVersion
+      }
+    }
+  }
+`;
+
+function useProfileProjectsQuery() {
+  const { data, fetchMore, loading, error, refetch } = useQuery<
+    ProfileProjectsData,
+    ProfileProjectsVars
+  >(ProfileProjectsQuery, {
+    variables: {
+      limit: 15,
+      offset: 0,
+    },
+    fetchPolicy: 'cache-and-network',
+  });
+
+  const apps = data?.me?.apps;
+  const appCount = data?.me?.appCount;
+
+  const loadMoreAsync = React.useCallback(() => {
+    return fetchMore({
+      variables: {
+        offset: apps?.length || 0,
+      },
+      updateQuery(previousData, { fetchMoreResult }) {
+        if (!fetchMoreResult?.me) {
+          return previousData;
+        }
+
+        const combinedData = {
+          me: {
+            ...previousData.me,
+            ...fetchMoreResult.me,
+            apps: [...previousData.me.apps, ...fetchMoreResult.me.apps],
+          },
+        };
+
+        return {
+          ...combinedData,
+          appCount: combinedData.me.appCount,
+          apps: combinedData.me.apps,
+        };
+      },
+    });
+  }, [fetchMore, apps]);
+
+  return {
+    loading,
+    error,
+    refetch,
+    data: {
+      ...data,
+      apps,
+      appCount,
+    },
+    loadMoreAsync,
+  };
+}
+
+export function ProfileProjectsList() {
+  const query = useProfileProjectsQuery();
+  return <ProjectList {...query} />;
+}

--- a/home/containers/ProfileSnacksList.tsx
+++ b/home/containers/ProfileSnacksList.tsx
@@ -1,0 +1,82 @@
+import { useQuery } from '@apollo/client';
+import gql from 'graphql-tag';
+import * as React from 'react';
+
+import SnackList, { Snack } from '../components/SnackList';
+
+interface ProfileSnacksData {
+  me: {
+    id: string;
+    snacks: Snack[];
+  };
+}
+
+interface ProfileSnacksVars {
+  limit: number;
+  offset: number;
+}
+
+const ProfileSnacksQuery = gql`
+  query Home_ProfileSnacks($limit: Int!, $offset: Int!) {
+    me {
+      id
+      snacks(limit: $limit, offset: $offset) {
+        name
+        description
+        fullName
+        slug
+        isDraft
+      }
+    }
+  }
+`;
+
+function useProfileSnacksQuery() {
+  const { data, fetchMore } = useQuery<ProfileSnacksData, ProfileSnacksVars>(ProfileSnacksQuery, {
+    variables: {
+      limit: 15,
+      offset: 0,
+    },
+    fetchPolicy: 'cache-and-network',
+  });
+
+  const snacks = data?.me?.snacks;
+
+  const loadMoreAsync = React.useCallback(() => {
+    return fetchMore({
+      variables: {
+        offset: snacks?.length || 0,
+      },
+      updateQuery(previousData, { fetchMoreResult }) {
+        if (!fetchMoreResult?.me) {
+          return previousData;
+        }
+        const combinedData = {
+          me: {
+            ...previousData.me,
+            ...fetchMoreResult.me,
+            snacks: [...previousData.me.snacks, ...fetchMoreResult.me.snacks],
+          },
+        };
+
+        return {
+          ...combinedData,
+          snacks: combinedData.me.snacks,
+        };
+      },
+    });
+  }, [fetchMore, snacks]);
+
+  return {
+    data: {
+      ...data,
+      snacks,
+    },
+    loadMoreAsync,
+  };
+}
+
+export function ProfileSnacksList() {
+  const { data, loadMoreAsync } = useProfileSnacksQuery();
+  return <SnackList data={data.snacks ?? []} loadMoreAsync={loadMoreAsync} />;
+}

--- a/home/navigation/Navigation.tsx
+++ b/home/navigation/Navigation.tsx
@@ -16,6 +16,7 @@ import DiagnosticsScreen from '../screens/DiagnosticsScreen';
 import ExperienceScreen from '../screens/ExperienceScreen';
 import GeofencingScreen from '../screens/GeofencingScreen';
 import LocationDiagnosticsScreen from '../screens/LocationDiagnosticsScreen';
+import ProfileScreen from '../screens/ProfileScreen';
 import ProjectsForAccountScreen from '../screens/ProjectsForAccountScreen';
 import ProjectsScreen from '../screens/ProjectsScreen';
 import QRCodeScreen from '../screens/QRCodeScreen';
@@ -36,8 +37,15 @@ function useThemeName() {
 const accountNavigationOptions = ({ route }) => {
   const accountName = route.params?.accountName;
   return {
-    title: accountName ?? 'Profile',
-    headerRight: () => (accountName ? <OptionsButton /> : <UserSettingsButton />),
+    title: `@${accountName}`,
+    headerRight: () => <OptionsButton />,
+  };
+};
+
+const profileNavigationOptions = ({ route }) => {
+  return {
+    title: 'Profile',
+    headerRight: () => <UserSettingsButton />,
   };
 };
 
@@ -71,6 +79,11 @@ function ProfileStackScreen() {
     <ProfileStack.Navigator
       initialRouteName="Profile"
       screenOptions={defaultNavigationOptions(theme)}>
+      <ProfileStack.Screen
+        name="Profile"
+        component={ProfileScreen}
+        options={profileNavigationOptions}
+      />
       <ProfileStack.Screen
         name="Account"
         component={AccountScreen}

--- a/home/navigation/Navigation.tsx
+++ b/home/navigation/Navigation.tsx
@@ -16,6 +16,8 @@ import DiagnosticsScreen from '../screens/DiagnosticsScreen';
 import ExperienceScreen from '../screens/ExperienceScreen';
 import GeofencingScreen from '../screens/GeofencingScreen';
 import LocationDiagnosticsScreen from '../screens/LocationDiagnosticsScreen';
+import ProfileAllProjectsScreen from '../screens/ProfileAllProjectsScreen';
+import ProfileAllSnacksScreen from '../screens/ProfileAllSnacksScreen';
 import ProfileScreen from '../screens/ProfileScreen';
 import ProjectsForAccountScreen from '../screens/ProjectsForAccountScreen';
 import ProjectsScreen from '../screens/ProjectsScreen';
@@ -83,6 +85,16 @@ function ProfileStackScreen() {
         name="Profile"
         component={ProfileScreen}
         options={profileNavigationOptions}
+      />
+      <ProfileStack.Screen
+        name="ProfileAllProjects"
+        component={ProfileAllProjectsScreen}
+        options={{ title: 'Projects' }}
+      />
+      <ProfileStack.Screen
+        name="ProfileAllSnacks"
+        component={ProfileAllSnacksScreen}
+        options={{ title: 'Snacks' }}
       />
       <ProfileStack.Screen
         name="Account"

--- a/home/navigation/Navigation.types.ts
+++ b/home/navigation/Navigation.types.ts
@@ -5,6 +5,8 @@ type ModalStackRoutes = {
 export type AllStackRoutes = {
   Projects: object;
   Profile: object;
+  ProfileAllProjects: object;
+  ProfileAllSnacks: object;
   Account: { accountName: string };
   UserSettings: object;
   ProjectsForAccount: { accountName: string };

--- a/home/navigation/Navigation.types.ts
+++ b/home/navigation/Navigation.types.ts
@@ -4,7 +4,8 @@ type ModalStackRoutes = {
 
 export type AllStackRoutes = {
   Projects: object;
-  Account: { accountName?: string };
+  Profile: object;
+  Account: { accountName: string };
   UserSettings: object;
   ProjectsForAccount: { accountName: string };
   SnacksForAccount: { accountName: string };

--- a/home/screens/AccountScreen.tsx
+++ b/home/screens/AccountScreen.tsx
@@ -1,95 +1,14 @@
 import { StackScreenProps } from '@react-navigation/stack';
 import { AllStackRoutes } from 'navigation/Navigation.types';
 import * as React from 'react';
-import { StyleSheet, View } from 'react-native';
-import { useSelector } from 'react-redux';
 
-import ProfileUnauthenticated from '../components/ProfileUnauthenticated';
 import Account from '../containers/Account';
-import getViewerUsernameAsync from '../utils/getViewerUsernameAsync';
-import isUserAuthenticated from '../utils/isUserAuthenticated';
 
 export default function AccountScreen({
   navigation,
   ...props
 }: StackScreenProps<AllStackRoutes, 'Account'>) {
-  const {
-    isAuthenticated,
-    accountName,
-  }: { isAuthenticated: boolean; accountName?: string } = useSelector(
-    React.useCallback(
-      data => {
-        const isAuthenticated = isUserAuthenticated(data.session);
-        return {
-          isAuthenticated,
-          accountName: props.route.params?.accountName,
-        };
-      },
-      [props.route]
-    )
-  );
-
   return (
-    <AccountView
-      {...props}
-      isAuthenticated={isAuthenticated}
-      accountName={accountName}
-      navigation={navigation}
-    />
+    <Account {...props} accountName={props.route.params.accountName} navigation={navigation} />
   );
 }
-
-function AccountView(
-  props: {
-    accountName?: string;
-    isAuthenticated: boolean;
-  } & StackScreenProps<AllStackRoutes, 'Account'>
-) {
-  // undefined means not yet computed, show loading screen
-  const [viewerUsername, setViewerUsername] = React.useState<string | null | undefined>(null);
-
-  React.useEffect(() => {
-    if (!props.isAuthenticated) {
-      setViewerUsername(null);
-    } else {
-      getViewerUsernameAsync().then(
-        viewerUsername => {
-          setViewerUsername(viewerUsername);
-        },
-        error => {
-          setViewerUsername(null);
-          console.warn(`There was an error fetching the viewer's username`, error);
-        }
-      );
-    }
-  }, [props.isAuthenticated]);
-
-  if (viewerUsername === undefined) {
-    return <View style={styles.loadingContainer} />;
-  }
-
-  if (!props.isAuthenticated || !viewerUsername) {
-    return <ProfileUnauthenticated />;
-  }
-
-  return (
-    <Account
-      {...props}
-      accountName={props.accountName ?? viewerUsername}
-      isCurrentUsersPersonalAccount={viewerUsername === props.accountName}
-    />
-  );
-}
-
-const styles = StyleSheet.create({
-  loadingContainer: {
-    flex: 1,
-  },
-  buttonContainer: {
-    flex: 1,
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    paddingRight: 15,
-  },
-});

--- a/home/screens/ProfileAllProjectsScreen.tsx
+++ b/home/screens/ProfileAllProjectsScreen.tsx
@@ -1,0 +1,7 @@
+import * as React from 'react';
+
+import { ProfileProjectsList } from '../containers/ProfileProjectsList';
+
+export default function ProjectsForUserScreen() {
+  return <ProfileProjectsList />;
+}

--- a/home/screens/ProfileAllSnacksScreen.tsx
+++ b/home/screens/ProfileAllSnacksScreen.tsx
@@ -1,0 +1,7 @@
+import * as React from 'react';
+
+import { ProfileSnacksList } from '../containers/ProfileSnacksList';
+
+export default function SnacksForUserScreen() {
+  return <ProfileSnacksList />;
+}

--- a/home/screens/ProfileScreen.tsx
+++ b/home/screens/ProfileScreen.tsx
@@ -1,0 +1,70 @@
+import { StackScreenProps } from '@react-navigation/stack';
+import { AllStackRoutes } from 'navigation/Navigation.types';
+import * as React from 'react';
+import { StyleSheet, View } from 'react-native';
+import { useSelector } from 'react-redux';
+
+import ProfileUnauthenticated from '../components/ProfileUnauthenticated';
+import Profile from '../containers/Profile';
+import getViewerUsernameAsync from '../utils/getViewerUsernameAsync';
+import isUserAuthenticated from '../utils/isUserAuthenticated';
+
+export default function ProfileScreen({
+  navigation,
+  ...props
+}: StackScreenProps<AllStackRoutes, 'Profile'>) {
+  const { isAuthenticated }: { isAuthenticated: boolean } = useSelector(
+    React.useCallback(
+      data => {
+        const isAuthenticated = isUserAuthenticated(data.session);
+        return {
+          isAuthenticated,
+        };
+      },
+      [props.route]
+    )
+  );
+
+  return <ProfileView {...props} isAuthenticated={isAuthenticated} navigation={navigation} />;
+}
+
+function ProfileView(
+  props: {
+    isAuthenticated: boolean;
+  } & StackScreenProps<AllStackRoutes, 'Profile'>
+) {
+  // undefined means not yet computed, show loading screen
+  const [viewerUsername, setViewerUsername] = React.useState<string | null | undefined>(null);
+
+  React.useEffect(() => {
+    if (!props.isAuthenticated) {
+      setViewerUsername(null);
+    } else {
+      getViewerUsernameAsync().then(
+        viewerUsername => {
+          setViewerUsername(viewerUsername);
+        },
+        error => {
+          setViewerUsername(null);
+          console.warn(`There was an error fetching the viewer's username`, error);
+        }
+      );
+    }
+  }, [props.isAuthenticated]);
+
+  if (viewerUsername === undefined) {
+    return <View style={styles.loadingContainer} />;
+  }
+
+  if (!props.isAuthenticated || !viewerUsername) {
+    return <ProfileUnauthenticated />;
+  }
+
+  return <Profile {...props} />;
+}
+
+const styles = StyleSheet.create({
+  loadingContainer: {
+    flex: 1,
+  },
+});

--- a/home/screens/ProfileScreen.tsx
+++ b/home/screens/ProfileScreen.tsx
@@ -34,7 +34,7 @@ function ProfileView(
   } & StackScreenProps<AllStackRoutes, 'Profile'>
 ) {
   // undefined means not yet computed, show loading screen
-  const [viewerUsername, setViewerUsername] = React.useState<string | null | undefined>(null);
+  const [viewerUsername, setViewerUsername] = React.useState<string | null | undefined>(undefined);
 
   React.useEffect(() => {
     if (!props.isAuthenticated) {

--- a/home/screens/ProjectsForAccountScreen.tsx
+++ b/home/screens/ProjectsForAccountScreen.tsx
@@ -7,7 +7,5 @@ import ProjectsList from '../containers/ProjectsList';
 export default function ProjectsForAccountScreen({
   route,
 }: StackScreenProps<AllStackRoutes, 'ProjectsForAccount'>) {
-  const { accountName } = route.params ?? {};
-
-  return <ProjectsList accountName={accountName} />;
+  return <ProjectsList accountName={route.params.accountName} />;
 }


### PR DESCRIPTION
# Why

A follow-up to https://github.com/expo/expo/pull/12342 that moves the Profile page back to a user query, but just displays the user's accounts and organizations in a standard list view and detail view like UI. This brings the home app up to date with our changes to UX on the website and in www.

# How

1. Add profile screen that queries information about the user and their accounts/organizations and displays it in a list view. Tapping an account list view item will push an account screen. This screen is now responsible for displaying the logged-out UX and showing networking issues.
2. Remove user-specific information from the account screens since they're only shown as detail views (no longer a top-level tab screen). Now they are just containers for projects and snacks.

# Test Plan

Same as https://github.com/expo/expo/pull/12342.

<img width="412" alt="Screen Shot 2021-04-01 at 10 24 45 AM" src="https://user-images.githubusercontent.com/189568/113331704-1d2b5300-92d5-11eb-97bf-ebf28e578759.png">

<img width="414" alt="Screen Shot 2021-03-29 at 1 09 52 PM" src="https://user-images.githubusercontent.com/189568/112896557-67bd8d00-9093-11eb-9012-ef29453da8e0.png">
