### PR TITLE
[docs] defer loading google analytics script

### DIFF
--- a/docs/common/analytics.tsx
+++ b/docs/common/analytics.tsx
@@ -1,17 +1,20 @@
-import * as React from 'react';
+import React from 'react';
 
-const getAnalyticsScript = (id: string) => {
+// Initialize the command queue in case analytics.js hasn't loaded yet
+const getInitGoogleAnalyticsScript = (id: string) => {
   return `
-(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
 ga('create', '${id}', {cookieDomain: 'auto', siteSpeedSampleRate: 100});
+ga('set', 'transport', 'beacon');
 ga('send', 'pageview');
 `.replace(/\n/g, '');
 };
 
-export const GoogleScript: React.FC<{ id: string }> = props => {
-  const markup = { __html: getAnalyticsScript(props.id) };
-  return <script dangerouslySetInnerHTML={markup} />;
-};
+export function getInitGoogleScriptTag({ id }: { id: string }) {
+  const initScript = { __html: getInitGoogleAnalyticsScript(id) };
+  return <script dangerouslySetInnerHTML={initScript} />;
+}
+
+export function getGoogleScriptTag() {
+  return <script defer src="https://www.google-analytics.com/analytics.js" />;
+}

--- a/docs/pages/_document.tsx
+++ b/docs/pages/_document.tsx
@@ -4,7 +4,7 @@ import { extractCritical } from 'emotion-server';
 import Document, { Html, Head, Main, NextScript, DocumentContext } from 'next/document';
 import * as React from 'react';
 
-import * as Analytics from '~/common/analytics';
+import { getInitGoogleScriptTag, getGoogleScriptTag } from '~/common/analytics';
 import { globalExtras } from '~/global-styles/extras';
 import { globalFonts } from '~/global-styles/fonts';
 import { globalNProgress } from '~/global-styles/nprogress';
@@ -35,7 +35,6 @@ export default class MyDocument extends Document<{ css?: string }> {
     return (
       <Html lang="en">
         <Head>
-          <Analytics.GoogleScript id="UA-107832480-3" />
           <script src="/static/libs/tippy/tippy.all.min.js" />
           <script src="/static/libs/nprogress/nprogress.js" />
 
@@ -59,6 +58,9 @@ export default class MyDocument extends Document<{ css?: string }> {
             integrity="sha384-fnmOCqbTlWIlj8LyTjo7mOUStjsKC4pOpQbqyi7RrhN7udi9RwhKkMHpvLbHG9Sr"
             crossOrigin="anonymous"
           />
+
+          {getInitGoogleScriptTag({ id: 'UA-107832480-3' })}
+          {getGoogleScriptTag()}
         </Head>
         <body>
           <BlockingSetInitialColorMode />


### PR DESCRIPTION
# Why

Loading Google Analytics shouldn't slow down the website.

# How

Use `defer` when loading the script and initialize the command queue in case analytics.js hasn't loaded yet.

Also added the use of beacon transport mechanism for Google Analytics.

"While the current tracking snippet is good, it can definitely be better. One problem with the async tracking snippet is, by default, it will still create two HTTP requests (one for the analytics.js script and one to send the initial pageview) that will push back the load event, which will affect other load-based metrics and potentially delay code scheduled to run after the window loads.

There are two ways to solve this problem, the first is to wait until after the load event fires to run the tracking code, but this is undesirable since it will potentially result in missed pageviews from users who bounce early.

The second option is to use the beacon transport mechanism to send all hits, which uses navigator.sendBeacon() under the hood. Since hits sent with sendBeacon() don’t affect loading (or unloading) of the current page, it has the best of both worlds."

https://philipwalton.com/articles/the-google-analytics-setup-i-use-on-every-site-i-build/

"By default, analytics.js picks the HTTP method and transport mechanism with which to optimally send hits. The three options are 'image' (using an Image object), 'xhr' (using an XMLHttpRequest object), or 'beacon' using the new navigator.sendBeacon method.

The former two methods share the problem described in the previous section (where hits are often not sent if the page is being unloaded). The navigator.sendBeacon method, by contrast, is a new HTML feature created to solve this problem."

https://developers.google.com/analytics/devguides/collection/analyticsjs/sending-hits#specifying_different_transport_mechanisms

# Test Plan

Look at the "Network" tab on Chrome DevTools and make sure that `analytics.js` is loading and check if GA events are firing:

<img width="515" alt="Screenshot 2021-04-06 at 10 13 13" src="https://user-images.githubusercontent.com/10477267/113680285-f730f480-96c0-11eb-84dd-482300238caf.png">

We are going to monitor the metrics after launch to make sure everything looks like it should. Note that we already tested this on the website. See https://github.com/expo/universe/pull/7160