### PR TITLE
[docs] reliably fix multiple adb versions issue

### DIFF
--- a/docs/pages/workflow/android-studio-emulator.md
+++ b/docs/pages/workflow/android-studio-emulator.md
@@ -58,15 +58,16 @@ Having multiple `adb` versions on your system can result in the error `adb serve
 This is because the adb version on your system is different from the adb version on the android sdk platform-tools.
 
 - Open the terminal and check the `adb` version on the system:
-
-`$adb version`
+```sh
+adb version
+```
 
 - And from the Android SDK platform-tool directory:
+```sh
+$ANDROID_SDK/platform-tools/adb version
+```
 
-`$cd ~/Library/Android/sdk/platform-tools`
-
-`$./adb version`
-
-- Copy `adb` from Android SDK directory to `usr/bin` directory:
-
-`$sudo cp ~/Library/Android/sdk/platform-tools/adb /usr/bin`
+- Create a symbolic link for `adb` from the Android SDK directory to `usr/local/bin`:
+```sh
+sudo ln -s $ANDROID_SDK/platform-tools/adb /usr/local/bin/adb
+```


### PR DESCRIPTION
# Why

The current instructions rely on the user having installed the Android SDK to the default location, which isn't necessarily the case. Furthermore creating a symbolic link over a straight up copy is favorable since the link will reflect a possible update.

# How

The instructions in this pull request use the environment variable created in step 1, thus the commands will always function as expected regardless of the user's Android SDK location.