### PR TITLE
[android] Apply `pickFirst` only to `lib/**` and Revert #12336

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -67,7 +67,7 @@ android {
     abortOnError false
   }
   packagingOptions {
-    pickFirst "**"
+    pickFirst "lib/**"
   }
 }
 

--- a/android/versioned-abis/expoview-abi38_0_0/src/main/java/abi38_0_0/expo/modules/payments/stripe/GoogleApiPayFlowImpl.java
+++ b/android/versioned-abis/expoview-abi38_0_0/src/main/java/abi38_0_0/expo/modules/payments/stripe/GoogleApiPayFlowImpl.java
@@ -1,5 +1,6 @@
 package abi38_0_0.expo.modules.payments.stripe;
 import android.app.Activity;
+import android.util.Log;
 import android.content.Intent;
 import androidx.annotation.NonNull;
 
@@ -22,12 +23,14 @@ import com.google.android.gms.wallet.ShippingAddressRequirements;
 import com.google.android.gms.wallet.TransactionInfo;
 import com.google.android.gms.wallet.Wallet;
 import com.google.android.gms.wallet.WalletConstants;
-import com.stripe.android.BuildConfig;
 import com.stripe.android.model.Token;
+import com.stripe.android.Stripe;
 
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
+import org.json.JSONObject;
+import org.json.JSONException;
 
 import static abi38_0_0.expo.modules.payments.stripe.Errors.toErrorCode;
 import static abi38_0_0.expo.modules.payments.stripe.util.Converters.convertTokenToWritableMap;
@@ -93,7 +96,7 @@ public final class GoogleApiPayFlowImpl extends PayFlow {
       .setPaymentMethodTokenizationType(WalletConstants.PAYMENT_METHOD_TOKENIZATION_TYPE_PAYMENT_GATEWAY)
       .addParameter("gateway", "stripe")
       .addParameter("stripe:publishableKey", getPublishableKey())
-      .addParameter("stripe:version", BuildConfig.VERSION_NAME)
+      .addParameter("stripe:version", Stripe.VERSION_NAME)
       .build();
   }
 
@@ -225,7 +228,12 @@ public final class GoogleApiPayFlowImpl extends PayFlow {
             PaymentData paymentData = PaymentData.getFromIntent(data);
             ArgCheck.nonNull(paymentData);
             String tokenJson = paymentData.getPaymentMethodToken().getToken();
-            Token token = Token.fromString(tokenJson);
+            Token token = null;
+            try {
+              token = Token.fromJson(new JSONObject(tokenJson));
+            } catch (JSONException e) {
+              Log.e(TAG, "Unable to create token from JSON string '" + tokenJson + "'.\n" + e);
+            }
             if (token == null) {
               payPromise.reject(
                 getErrorCode("parseResponse"),

--- a/android/versioned-abis/expoview-abi38_0_0/src/main/java/abi38_0_0/expo/modules/payments/stripe/StripeModule.java
+++ b/android/versioned-abis/expoview-abi38_0_0/src/main/java/abi38_0_0/expo/modules/payments/stripe/StripeModule.java
@@ -24,10 +24,12 @@ import abi38_0_0.expo.modules.payments.stripe.util.ArgCheck;
 import abi38_0_0.expo.modules.payments.stripe.util.Converters;
 import abi38_0_0.expo.modules.payments.stripe.util.Fun0;
 import com.google.android.gms.wallet.WalletConstants;
-import com.stripe.android.SourceCallback;
+import com.stripe.android.ApiResultCallback;
 import com.stripe.android.Stripe;
-import com.stripe.android.TokenCallback;
+import com.stripe.android.model.CardParams;
 import com.stripe.android.model.Source;
+import com.stripe.android.model.Source.Flow;
+import com.stripe.android.model.Source.Status;
 import com.stripe.android.model.SourceParams;
 import com.stripe.android.model.Token;
 
@@ -43,8 +45,7 @@ import static abi38_0_0.expo.modules.payments.stripe.Errors.getErrorCode;
 import static abi38_0_0.expo.modules.payments.stripe.Errors.toErrorCode;
 import static abi38_0_0.expo.modules.payments.stripe.util.Converters.convertSourceToWritableMap;
 import static abi38_0_0.expo.modules.payments.stripe.util.Converters.convertTokenToWritableMap;
-import static abi38_0_0.expo.modules.payments.stripe.util.Converters.createBankAccount;
-import static abi38_0_0.expo.modules.payments.stripe.util.Converters.createCard;
+import static abi38_0_0.expo.modules.payments.stripe.util.Converters.createBankAccountTokenParams;
 import static abi38_0_0.expo.modules.payments.stripe.util.Converters.getStringOrNull;
 import static abi38_0_0.expo.modules.payments.stripe.util.InitializationOptions.ANDROID_PAY_MODE_KEY;
 import static abi38_0_0.expo.modules.payments.stripe.util.InitializationOptions.ANDROID_PAY_MODE_PRODUCTION;
@@ -181,13 +182,16 @@ public class StripeModule extends ExportedModule {
       ArgCheck.nonNull(mStripe);
       ArgCheck.notEmptyString(mPublicKey);
 
-      mStripe.createToken(
-        createCard(cardData),
-        mPublicKey,
-        new TokenCallback() {
-          public void onSuccess(Token token) {
+      mStripe.createCardToken(
+        Converters.createCardParams(cardData),
+        null,
+        null,
+        new ApiResultCallback<Token>() {
+          @Override
+          public void onSuccess(@NonNull Token token) {
             promise.resolve(convertTokenToWritableMap(token));
           }
+          @Override
           public void onError(Exception error) {
             error.printStackTrace();
             promise.reject(toErrorCode(error), error.getMessage());
@@ -205,13 +209,15 @@ public class StripeModule extends ExportedModule {
       ArgCheck.notEmptyString(mPublicKey);
 
       mStripe.createBankAccountToken(
-        createBankAccount(accountData),
+        createBankAccountTokenParams(accountData),
         mPublicKey,
         null,
-        new TokenCallback() {
-          public void onSuccess(Token token) {
+        new ApiResultCallback<Token>() {
+          @Override
+          public void onSuccess(@NonNull Token token) {
             promise.resolve(convertTokenToWritableMap(token));
           }
+          @Override
           public void onError(Exception error) {
             error.printStackTrace();
             promise.reject(toErrorCode(error), error.getMessage());
@@ -333,15 +339,13 @@ public class StripeModule extends ExportedModule {
 
     ArgCheck.nonNull(sourceParams);
 
-    mStripe.createSource(sourceParams, new SourceCallback() {
-      @Override
+    mStripe.createSource(sourceParams, new ApiResultCallback<Source>() {
       public void onError(Exception error) {
         promise.reject(toErrorCode(error), error);
       }
 
-      @Override
-      public void onSuccess(Source source) {
-        if (Source.REDIRECT.equals(source.getFlow())) {
+      public void onSuccess(@NonNull Source source) {
+        if (Flow.Redirect.equals(source.getFlow())) {
           Activity currentActivity = getCurrentActivity();
           if (currentActivity == null) {
             promise.reject(
@@ -433,19 +437,18 @@ public class StripeModule extends ExportedModule {
         }
 
         switch (source.getStatus()) {
-          case Source.CHARGEABLE:
-          case Source.CONSUMED:
+          case Chargeable:
+          case Consumed:
             promise.resolve(convertSourceToWritableMap(source));
             break;
-          case Source.CANCELED:
+          case Canceled:
             promise.reject(
               getErrorCode(mErrorCodes, "redirectCancelled"),
               getDescription(mErrorCodes, "redirectCancelled")
             );
             break;
-          case Source.PENDING:
-          case Source.FAILED:
-          case Source.UNKNOWN:
+          case Pending:
+          case Failed:
             promise.reject(
               getErrorCode(mErrorCodes, "redirectFailed"),
               getDescription(mErrorCodes, "redirectFailed")

--- a/android/versioned-abis/expoview-abi38_0_0/src/main/java/abi38_0_0/expo/modules/payments/stripe/dialog/AddCardDialogFragment.java
+++ b/android/versioned-abis/expoview-abi38_0_0/src/main/java/abi38_0_0/expo/modules/payments/stripe/dialog/AddCardDialogFragment.java
@@ -1,5 +1,6 @@
 package abi38_0_0.expo.modules.payments.stripe.dialog;
 
+import androidx.annotation.NonNull;
 import android.app.AlertDialog;
 import android.app.Dialog;
 import android.app.DialogFragment;
@@ -27,8 +28,7 @@ import abi38_0_0.expo.modules.payments.stripe.util.CardFlipAnimator;
 import abi38_0_0.expo.modules.payments.stripe.util.Converters;
 import abi38_0_0.expo.modules.payments.stripe.util.Utils;
 
-import com.stripe.android.SourceCallback;
-import com.stripe.android.TokenCallback;
+import com.stripe.android.ApiResultCallback;
 import com.stripe.android.model.Card;
 import com.stripe.android.model.Source;
 import com.stripe.android.model.SourceParams;
@@ -193,11 +193,12 @@ public class AddCardDialogFragment extends DialogFragment {
     doneButton.setEnabled(false);
     progressBar.setVisibility(View.VISIBLE);
     final CreditCard fromCard = from.getCreditCard();
-    final Card card = new Card(
+    final Card card = Card.create(
       fromCard.getCardNumber(),
       fromCard.getExpMonth(),
       fromCard.getExpYear(),
-      fromCard.getSecurityCode());
+      fromCard.getSecurityCode()
+    );
 
     String errorMessage = Utils.validateCard(card);
     if (errorMessage == null) {
@@ -205,9 +206,9 @@ public class AddCardDialogFragment extends DialogFragment {
         SourceParams cardSourceParams = SourceParams.createCardParams(card);
         StripeModule.getInstance(tag).getStripe().createSource(
           cardSourceParams,
-          new SourceCallback() {
+          new ApiResultCallback<Source>() {
             @Override
-            public void onSuccess(Source source) {
+            public void onSuccess(@NonNull Source source) {
               // Normalize data with iOS SDK
               final Bundle sourceMap = Converters.convertSourceToWritableMap(source);
               sourceMap.putBundle("card", Converters.mapToWritableMap(source.getSourceTypeData()));
@@ -230,11 +231,13 @@ public class AddCardDialogFragment extends DialogFragment {
           }
         );
       } else {
-        StripeModule.getInstance(tag).getStripe().createToken(
-            card,
-            PUBLISHABLE_KEY,
-            new TokenCallback() {
-              public void onSuccess(Token token) {
+        StripeModule.getInstance(tag).getStripe().createCardToken(
+          card,
+          null,
+          null,
+          new ApiResultCallback<Token>() {
+            @Override
+            public void onSuccess(@NonNull Token token) {
                 if (promise != null) {
                   promise.resolve(Converters.convertTokenToWritableMap(token));
                   promise = null;
@@ -243,6 +246,7 @@ public class AddCardDialogFragment extends DialogFragment {
                 dismiss();
               }
 
+              @Override
               public void onError(Exception error) {
                 doneButton.setEnabled(true);
                 progressBar.setVisibility(View.GONE);

--- a/android/versioned-abis/expoview-abi38_0_0/src/main/java/abi38_0_0/expo/modules/payments/stripe/util/Converters.java
+++ b/android/versioned-abis/expoview-abi38_0_0/src/main/java/abi38_0_0/expo/modules/payments/stripe/util/Converters.java
@@ -10,16 +10,19 @@ import com.google.android.gms.identity.intents.model.UserAddress;
 import com.google.android.gms.wallet.PaymentData;
 import com.stripe.android.model.Address;
 import com.stripe.android.model.BankAccount;
+import com.stripe.android.model.BankAccountTokenParams;
 import com.stripe.android.model.Card;
+import com.stripe.android.model.CardParams;
 import com.stripe.android.model.Source;
-import com.stripe.android.model.SourceCodeVerification;
-import com.stripe.android.model.SourceOwner;
-import com.stripe.android.model.SourceReceiver;
-import com.stripe.android.model.SourceRedirect;
+import com.stripe.android.model.Source.CodeVerification;
+import com.stripe.android.model.Source.Owner;
+import com.stripe.android.model.Source.Receiver;
+import com.stripe.android.model.Source.Redirect;
 import com.stripe.android.model.Token;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -68,7 +71,7 @@ public class Converters {
 
     result.putString("cardId", card.getId());
     result.putString("number", card.getNumber());
-    result.putString("cvc", card.getCVC() );
+    result.putString("cvc", card.getCvc() );
     result.putInt("expMonth", card.getExpMonth() );
     result.putInt("expYear", card.getExpYear() );
     result.putString("name", card.getName() );
@@ -79,8 +82,8 @@ public class Converters {
     result.putString("addressZip", card.getAddressZip() );
     result.putString("addressCountry", card.getAddressCountry() );
     result.putString("last4", card.getLast4() );
-    result.putString("brand", card.getBrand() );
-    result.putString("funding", card.getFunding() );
+    result.putString("brand", card.getBrand().getDisplayName() );
+    result.putString("funding", card.getFunding().name() );
     result.putString("fingerprint", card.getFingerprint() );
     result.putString("country", card.getCountry() );
     result.putString("currency", card.getCurrency() );
@@ -94,11 +97,10 @@ public class Converters {
     if (account == null) return result;
 
     result.putString("routingNumber", account.getRoutingNumber());
-    result.putString("accountNumber", account.getAccountNumber());
     result.putString("countryCode", account.getCountryCode());
     result.putString("currency", account.getCurrency());
     result.putString("accountHolderName", account.getAccountHolderName());
-    result.putString("accountHolderType", account.getAccountHolderType());
+    result.putString("accountHolderType", account.getAccountHolderType().name());
     result.putString("fingerprint", account.getFingerprint());
     result.putString("bankName", account.getBankName());
     result.putString("last4", account.getLast4());
@@ -165,32 +167,33 @@ public class Converters {
     return allowedCountriesForShipping;
   }
 
-  public static Card createCard(final Map<String, Object> cardData) {
-    return new Card(
-      // required fields
+  public static CardParams createCardParams(final Map<String, Object> cardData) {
+    Address address = new Address(
+      getValue(cardData, "addressCity"),
+      getValue(cardData, "country"),
+      getValue(cardData, "addressLine1"),
+      getValue(cardData, "addressLine2"),
+      getValue(cardData, "addressZip"),
+      getValue(cardData, "addressState")
+    );
+    Map <String, String> metaData = new HashMap<String, String>();
+    metaData.put("brand", getValue(cardData, "brand"));
+    metaData.put("last4", getValue(cardData, "last4"));
+    metaData.put("fingerprint", getValue(cardData, "fingerprint"));
+    metaData.put("funding", getValue(cardData, "funding"));
+    metaData.put("id", getValue(cardData, "id"));
+    return 
+      new CardParams(
         (String)cardData.get("number"),
         new Integer((int)Math.round((Double)cardData.get("expMonth"))),
         new Integer((int)Math.round((Double)cardData.get("expYear"))),
-      // additional fields
-      getValue(cardData, "cvc"),
-      getValue(cardData, "name"),
-      getValue(cardData, "addressLine1"),
-      getValue(cardData, "addressLine2"),
-      getValue(cardData, "addressCity"),
-      getValue(cardData, "addressState"),
-      getValue(cardData, "addressZip"),
-      getValue(cardData, "addressCountry"),
-      getValue(cardData, "brand"),
-      getValue(cardData, "last4"),
-      getValue(cardData, "fingerprint"),
-      getValue(cardData, "funding"),
-      getValue(cardData, "country"),
-      getValue(cardData, "currency"),
-      getValue(cardData, "id")
-    );
+        getValue(cardData, "cvc"),
+        getValue(cardData, "name"),
+        address,
+        getValue(cardData, "currency"),
+        metaData
+      );
   }
-
-
 
   @NonNull
   public static Bundle convertSourceToWritableMap(@Nullable Source source) {
@@ -205,17 +208,16 @@ public class Converters {
     newSource.putInt("created", source.getCreated().intValue());
     newSource.putBundle("codeVerification", convertCodeVerificationToWritableMap(source.getCodeVerification()));
     newSource.putString("currency", source.getCurrency());
-    newSource.putString("flow", source.getFlow());
+    newSource.putString("flow", source.getFlow().name());
     newSource.putBoolean("livemode", source.isLiveMode());
-    newSource.putBundle("metadata", stringMapToWritableMap(source.getMetaData()));
     newSource.putBundle("owner", convertOwnerToWritableMap(source.getOwner()));
     newSource.putBundle("receiver", convertReceiverToWritableMap(source.getReceiver()));
     newSource.putBundle("redirect", convertRedirectToWritableMap(source.getRedirect()));
     newSource.putBundle("sourceTypeData", mapToWritableMap(source.getSourceTypeData()));
-    newSource.putString("status", source.getStatus());
+    newSource.putString("status", source.getStatus().name());
     newSource.putString("type", source.getType());
     newSource.putString("typeRaw", source.getTypeRaw());
-    newSource.putString("usage", source.getUsage());
+    newSource.putString("usage", source.getUsage().name());
 
     return newSource;
   }
@@ -236,7 +238,7 @@ public class Converters {
   }
 
   @NonNull
-  public static Bundle convertOwnerToWritableMap(@Nullable final SourceOwner owner) {
+  public static Bundle convertOwnerToWritableMap(@Nullable final Owner owner) {
     Bundle map = new Bundle();
 
     if (owner == null) {
@@ -274,7 +276,7 @@ public class Converters {
   }
 
   @NonNull
-  public static Bundle convertReceiverToWritableMap(@Nullable final SourceReceiver receiver) {
+  public static Bundle convertReceiverToWritableMap(@Nullable final Receiver receiver) {
     Bundle map = new Bundle();
 
     if (receiver == null) {
@@ -290,7 +292,7 @@ public class Converters {
   }
 
   @NonNull
-  public static Bundle convertRedirectToWritableMap(@Nullable SourceRedirect redirect) {
+  public static Bundle convertRedirectToWritableMap(@Nullable Redirect redirect) {
     Bundle map = new Bundle();
 
     if (redirect == null) {
@@ -298,14 +300,14 @@ public class Converters {
     }
 
     map.putString("returnUrl", redirect.getReturnUrl());
-    map.putString("status", redirect.getStatus());
+    map.putString("status", redirect.getStatus().name());
     map.putString("url", redirect.getUrl());
 
     return map;
   }
 
   @NonNull
-  public static Bundle convertCodeVerificationToWritableMap(@Nullable SourceCodeVerification codeVerification) {
+  public static Bundle convertCodeVerificationToWritableMap(@Nullable CodeVerification codeVerification) {
     Bundle map = new Bundle();
 
     if (codeVerification == null) {
@@ -313,7 +315,7 @@ public class Converters {
     }
 
     map.putInt("attemptsRemaining", codeVerification.getAttemptsRemaining());
-    map.putString("status", codeVerification.getStatus());
+    map.putString("status", codeVerification.getStatus().name());
 
     return map;
   }
@@ -376,18 +378,18 @@ public class Converters {
     return result;
   }
 
-  public static BankAccount createBankAccount(Map<String, Object> accountData) {
-    BankAccount account = new BankAccount(
-      // required fields only
-        (String)accountData.get("accountNumber"),
+  public static BankAccountTokenParams createBankAccountTokenParams(Map<String, Object> accountData) {
+    BankAccountTokenParams accountTokenParams = new BankAccountTokenParams(
+        // required fields
         (String)accountData.get("countryCode"),
         (String)accountData.get("currency"),
-      getValue(accountData, "routingNumber", "")
+        (String)accountData.get("accountNumber"),
+      null,
+      getValue(accountData, "accountHolderName"),
+      getValue(accountData, "routingNumber")
     );
-    account.setAccountHolderName(getValue(accountData, "accountHolderName"));
-    account.setAccountHolderType(getValue(accountData, "accountHolderType"));
 
-    return account;
+    return accountTokenParams;
   }
 
   public static String getStringOrNull(@NonNull Map<String, Object> map, @NonNull String key) {

--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/payments/stripe/GoogleApiPayFlowImpl.java
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/payments/stripe/GoogleApiPayFlowImpl.java
@@ -1,5 +1,6 @@
 package abi39_0_0.expo.modules.payments.stripe;
 import android.app.Activity;
+import android.util.Log;
 import android.content.Intent;
 import androidx.annotation.NonNull;
 
@@ -22,12 +23,14 @@ import com.google.android.gms.wallet.ShippingAddressRequirements;
 import com.google.android.gms.wallet.TransactionInfo;
 import com.google.android.gms.wallet.Wallet;
 import com.google.android.gms.wallet.WalletConstants;
-import com.stripe.android.BuildConfig;
 import com.stripe.android.model.Token;
+import com.stripe.android.Stripe;
 
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
+import org.json.JSONObject;
+import org.json.JSONException;
 
 import static abi39_0_0.expo.modules.payments.stripe.Errors.toErrorCode;
 import static abi39_0_0.expo.modules.payments.stripe.util.Converters.convertTokenToWritableMap;
@@ -93,7 +96,7 @@ public final class GoogleApiPayFlowImpl extends PayFlow {
       .setPaymentMethodTokenizationType(WalletConstants.PAYMENT_METHOD_TOKENIZATION_TYPE_PAYMENT_GATEWAY)
       .addParameter("gateway", "stripe")
       .addParameter("stripe:publishableKey", getPublishableKey())
-      .addParameter("stripe:version", BuildConfig.VERSION_NAME)
+      .addParameter("stripe:version", Stripe.VERSION_NAME)
       .build();
   }
 
@@ -225,7 +228,12 @@ public final class GoogleApiPayFlowImpl extends PayFlow {
             PaymentData paymentData = PaymentData.getFromIntent(data);
             ArgCheck.nonNull(paymentData);
             String tokenJson = paymentData.getPaymentMethodToken().getToken();
-            Token token = Token.fromString(tokenJson);
+            Token token = null;
+            try {
+              token = Token.fromJson(new JSONObject(tokenJson));
+            } catch (JSONException e) {
+              Log.e(TAG, "Unable to create token from JSON string '" + tokenJson + "'.\n" + e);
+            }
             if (token == null) {
               payPromise.reject(
                 getErrorCode("parseResponse"),

--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/payments/stripe/StripeModule.java
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/payments/stripe/StripeModule.java
@@ -24,10 +24,12 @@ import abi39_0_0.expo.modules.payments.stripe.util.ArgCheck;
 import abi39_0_0.expo.modules.payments.stripe.util.Converters;
 import abi39_0_0.expo.modules.payments.stripe.util.Fun0;
 import com.google.android.gms.wallet.WalletConstants;
-import com.stripe.android.SourceCallback;
+import com.stripe.android.ApiResultCallback;
 import com.stripe.android.Stripe;
-import com.stripe.android.TokenCallback;
+import com.stripe.android.model.CardParams;
 import com.stripe.android.model.Source;
+import com.stripe.android.model.Source.Flow;
+import com.stripe.android.model.Source.Status;
 import com.stripe.android.model.SourceParams;
 import com.stripe.android.model.Token;
 
@@ -43,8 +45,7 @@ import static abi39_0_0.expo.modules.payments.stripe.Errors.getErrorCode;
 import static abi39_0_0.expo.modules.payments.stripe.Errors.toErrorCode;
 import static abi39_0_0.expo.modules.payments.stripe.util.Converters.convertSourceToWritableMap;
 import static abi39_0_0.expo.modules.payments.stripe.util.Converters.convertTokenToWritableMap;
-import static abi39_0_0.expo.modules.payments.stripe.util.Converters.createBankAccount;
-import static abi39_0_0.expo.modules.payments.stripe.util.Converters.createCard;
+import static abi39_0_0.expo.modules.payments.stripe.util.Converters.createBankAccountTokenParams;
 import static abi39_0_0.expo.modules.payments.stripe.util.Converters.getStringOrNull;
 import static abi39_0_0.expo.modules.payments.stripe.util.InitializationOptions.ANDROID_PAY_MODE_KEY;
 import static abi39_0_0.expo.modules.payments.stripe.util.InitializationOptions.ANDROID_PAY_MODE_PRODUCTION;
@@ -181,13 +182,16 @@ public class StripeModule extends ExportedModule {
       ArgCheck.nonNull(mStripe);
       ArgCheck.notEmptyString(mPublicKey);
 
-      mStripe.createToken(
-        createCard(cardData),
-        mPublicKey,
-        new TokenCallback() {
-          public void onSuccess(Token token) {
+      mStripe.createCardToken(
+        Converters.createCardParams(cardData),
+        null,
+        null,
+        new ApiResultCallback<Token>() {
+          @Override
+          public void onSuccess(@NonNull Token token) {
             promise.resolve(convertTokenToWritableMap(token));
           }
+          @Override
           public void onError(Exception error) {
             error.printStackTrace();
             promise.reject(toErrorCode(error), error.getMessage());
@@ -205,13 +209,15 @@ public class StripeModule extends ExportedModule {
       ArgCheck.notEmptyString(mPublicKey);
 
       mStripe.createBankAccountToken(
-        createBankAccount(accountData),
+        createBankAccountTokenParams(accountData),
         mPublicKey,
         null,
-        new TokenCallback() {
-          public void onSuccess(Token token) {
+        new ApiResultCallback<Token>() {
+          @Override
+          public void onSuccess(@NonNull Token token) {
             promise.resolve(convertTokenToWritableMap(token));
           }
+          @Override
           public void onError(Exception error) {
             error.printStackTrace();
             promise.reject(toErrorCode(error), error.getMessage());
@@ -333,15 +339,13 @@ public class StripeModule extends ExportedModule {
 
     ArgCheck.nonNull(sourceParams);
 
-    mStripe.createSource(sourceParams, new SourceCallback() {
-      @Override
+    mStripe.createSource(sourceParams, new ApiResultCallback<Source>() {
       public void onError(Exception error) {
         promise.reject(toErrorCode(error), error);
       }
 
-      @Override
-      public void onSuccess(Source source) {
-        if (Source.REDIRECT.equals(source.getFlow())) {
+      public void onSuccess(@NonNull Source source) {
+        if (Flow.Redirect.equals(source.getFlow())) {
           Activity currentActivity = getCurrentActivity();
           if (currentActivity == null) {
             promise.reject(
@@ -433,19 +437,18 @@ public class StripeModule extends ExportedModule {
         }
 
         switch (source.getStatus()) {
-          case Source.CHARGEABLE:
-          case Source.CONSUMED:
+          case Chargeable:
+          case Consumed:
             promise.resolve(convertSourceToWritableMap(source));
             break;
-          case Source.CANCELED:
+          case Canceled:
             promise.reject(
               getErrorCode(mErrorCodes, "redirectCancelled"),
               getDescription(mErrorCodes, "redirectCancelled")
             );
             break;
-          case Source.PENDING:
-          case Source.FAILED:
-          case Source.UNKNOWN:
+          case Pending:
+          case Failed:
             promise.reject(
               getErrorCode(mErrorCodes, "redirectFailed"),
               getDescription(mErrorCodes, "redirectFailed")

--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/payments/stripe/dialog/AddCardDialogFragment.java
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/payments/stripe/dialog/AddCardDialogFragment.java
@@ -1,5 +1,6 @@
 package abi39_0_0.expo.modules.payments.stripe.dialog;
 
+import androidx.annotation.NonNull;
 import android.app.AlertDialog;
 import android.app.Dialog;
 import android.app.DialogFragment;
@@ -27,8 +28,7 @@ import abi39_0_0.expo.modules.payments.stripe.util.CardFlipAnimator;
 import abi39_0_0.expo.modules.payments.stripe.util.Converters;
 import abi39_0_0.expo.modules.payments.stripe.util.Utils;
 
-import com.stripe.android.SourceCallback;
-import com.stripe.android.TokenCallback;
+import com.stripe.android.ApiResultCallback;
 import com.stripe.android.model.Card;
 import com.stripe.android.model.Source;
 import com.stripe.android.model.SourceParams;
@@ -193,11 +193,12 @@ public class AddCardDialogFragment extends DialogFragment {
     doneButton.setEnabled(false);
     progressBar.setVisibility(View.VISIBLE);
     final CreditCard fromCard = from.getCreditCard();
-    final Card card = new Card(
+    final Card card = Card.create(
       fromCard.getCardNumber(),
       fromCard.getExpMonth(),
       fromCard.getExpYear(),
-      fromCard.getSecurityCode());
+      fromCard.getSecurityCode()
+    );
 
     String errorMessage = Utils.validateCard(card);
     if (errorMessage == null) {
@@ -205,9 +206,9 @@ public class AddCardDialogFragment extends DialogFragment {
         SourceParams cardSourceParams = SourceParams.createCardParams(card);
         StripeModule.getInstance(tag).getStripe().createSource(
           cardSourceParams,
-          new SourceCallback() {
+          new ApiResultCallback<Source>() {
             @Override
-            public void onSuccess(Source source) {
+            public void onSuccess(@NonNull Source source) {
               // Normalize data with iOS SDK
               final Bundle sourceMap = Converters.convertSourceToWritableMap(source);
               sourceMap.putBundle("card", Converters.mapToWritableMap(source.getSourceTypeData()));
@@ -230,11 +231,13 @@ public class AddCardDialogFragment extends DialogFragment {
           }
         );
       } else {
-        StripeModule.getInstance(tag).getStripe().createToken(
-            card,
-            PUBLISHABLE_KEY,
-            new TokenCallback() {
-              public void onSuccess(Token token) {
+        StripeModule.getInstance(tag).getStripe().createCardToken(
+          card,
+          null,
+          null,
+          new ApiResultCallback<Token>() {
+            @Override
+            public void onSuccess(@NonNull Token token) {
                 if (promise != null) {
                   promise.resolve(Converters.convertTokenToWritableMap(token));
                   promise = null;
@@ -243,6 +246,7 @@ public class AddCardDialogFragment extends DialogFragment {
                 dismiss();
               }
 
+              @Override
               public void onError(Exception error) {
                 doneButton.setEnabled(true);
                 progressBar.setVisibility(View.GONE);

--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/payments/stripe/util/Converters.java
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/payments/stripe/util/Converters.java
@@ -10,16 +10,19 @@ import com.google.android.gms.identity.intents.model.UserAddress;
 import com.google.android.gms.wallet.PaymentData;
 import com.stripe.android.model.Address;
 import com.stripe.android.model.BankAccount;
+import com.stripe.android.model.BankAccountTokenParams;
 import com.stripe.android.model.Card;
+import com.stripe.android.model.CardParams;
 import com.stripe.android.model.Source;
-import com.stripe.android.model.SourceCodeVerification;
-import com.stripe.android.model.SourceOwner;
-import com.stripe.android.model.SourceReceiver;
-import com.stripe.android.model.SourceRedirect;
+import com.stripe.android.model.Source.CodeVerification;
+import com.stripe.android.model.Source.Owner;
+import com.stripe.android.model.Source.Receiver;
+import com.stripe.android.model.Source.Redirect;
 import com.stripe.android.model.Token;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -68,7 +71,7 @@ public class Converters {
 
     result.putString("cardId", card.getId());
     result.putString("number", card.getNumber());
-    result.putString("cvc", card.getCVC() );
+    result.putString("cvc", card.getCvc());
     result.putInt("expMonth", card.getExpMonth() );
     result.putInt("expYear", card.getExpYear() );
     result.putString("name", card.getName() );
@@ -79,8 +82,8 @@ public class Converters {
     result.putString("addressZip", card.getAddressZip() );
     result.putString("addressCountry", card.getAddressCountry() );
     result.putString("last4", card.getLast4() );
-    result.putString("brand", card.getBrand() );
-    result.putString("funding", card.getFunding() );
+    result.putString("brand", card.getBrand().getDisplayName() );
+    result.putString("funding", card.getFunding().name() );
     result.putString("fingerprint", card.getFingerprint() );
     result.putString("country", card.getCountry() );
     result.putString("currency", card.getCurrency() );
@@ -94,11 +97,10 @@ public class Converters {
     if (account == null) return result;
 
     result.putString("routingNumber", account.getRoutingNumber());
-    result.putString("accountNumber", account.getAccountNumber());
     result.putString("countryCode", account.getCountryCode());
     result.putString("currency", account.getCurrency());
     result.putString("accountHolderName", account.getAccountHolderName());
-    result.putString("accountHolderType", account.getAccountHolderType());
+    result.putString("accountHolderType", account.getAccountHolderType().name());
     result.putString("fingerprint", account.getFingerprint());
     result.putString("bankName", account.getBankName());
     result.putString("last4", account.getLast4());
@@ -164,33 +166,34 @@ public class Converters {
 
     return allowedCountriesForShipping;
   }
-
-  public static Card createCard(final Map<String, Object> cardData) {
-    return new Card(
-      // required fields
+  
+  public static CardParams createCardParams(final Map<String, Object> cardData) {
+    Address address = new Address(
+      getValue(cardData, "addressCity"),
+      getValue(cardData, "country"),
+      getValue(cardData, "addressLine1"),
+      getValue(cardData, "addressLine2"),
+      getValue(cardData, "addressZip"),
+      getValue(cardData, "addressState")
+    );
+    Map <String, String> metaData = new HashMap<String, String>();
+    metaData.put("brand", getValue(cardData, "brand"));
+    metaData.put("last4", getValue(cardData, "last4"));
+    metaData.put("fingerprint", getValue(cardData, "fingerprint"));
+    metaData.put("funding", getValue(cardData, "funding"));
+    metaData.put("id", getValue(cardData, "id"));
+    return 
+      new CardParams(
         (String)cardData.get("number"),
         new Integer((int)Math.round((Double)cardData.get("expMonth"))),
         new Integer((int)Math.round((Double)cardData.get("expYear"))),
-      // additional fields
-      getValue(cardData, "cvc"),
-      getValue(cardData, "name"),
-      getValue(cardData, "addressLine1"),
-      getValue(cardData, "addressLine2"),
-      getValue(cardData, "addressCity"),
-      getValue(cardData, "addressState"),
-      getValue(cardData, "addressZip"),
-      getValue(cardData, "addressCountry"),
-      getValue(cardData, "brand"),
-      getValue(cardData, "last4"),
-      getValue(cardData, "fingerprint"),
-      getValue(cardData, "funding"),
-      getValue(cardData, "country"),
-      getValue(cardData, "currency"),
-      getValue(cardData, "id")
-    );
+        getValue(cardData, "cvc"),
+        getValue(cardData, "name"),
+        address,
+        getValue(cardData, "currency"),
+        metaData
+      );
   }
-
-
 
   @NonNull
   public static Bundle convertSourceToWritableMap(@Nullable Source source) {
@@ -205,17 +208,16 @@ public class Converters {
     newSource.putInt("created", source.getCreated().intValue());
     newSource.putBundle("codeVerification", convertCodeVerificationToWritableMap(source.getCodeVerification()));
     newSource.putString("currency", source.getCurrency());
-    newSource.putString("flow", source.getFlow());
+    newSource.putString("flow", source.getFlow().name());
     newSource.putBoolean("livemode", source.isLiveMode());
-    newSource.putBundle("metadata", stringMapToWritableMap(source.getMetaData()));
     newSource.putBundle("owner", convertOwnerToWritableMap(source.getOwner()));
     newSource.putBundle("receiver", convertReceiverToWritableMap(source.getReceiver()));
     newSource.putBundle("redirect", convertRedirectToWritableMap(source.getRedirect()));
     newSource.putBundle("sourceTypeData", mapToWritableMap(source.getSourceTypeData()));
-    newSource.putString("status", source.getStatus());
+    newSource.putString("status", source.getStatus().name());
     newSource.putString("type", source.getType());
     newSource.putString("typeRaw", source.getTypeRaw());
-    newSource.putString("usage", source.getUsage());
+    newSource.putString("usage", source.getUsage().name());
 
     return newSource;
   }
@@ -236,7 +238,7 @@ public class Converters {
   }
 
   @NonNull
-  public static Bundle convertOwnerToWritableMap(@Nullable final SourceOwner owner) {
+  public static Bundle convertOwnerToWritableMap(@Nullable final Owner owner) {
     Bundle map = new Bundle();
 
     if (owner == null) {
@@ -274,7 +276,7 @@ public class Converters {
   }
 
   @NonNull
-  public static Bundle convertReceiverToWritableMap(@Nullable final SourceReceiver receiver) {
+  public static Bundle convertReceiverToWritableMap(@Nullable final Receiver receiver) {
     Bundle map = new Bundle();
 
     if (receiver == null) {
@@ -290,7 +292,7 @@ public class Converters {
   }
 
   @NonNull
-  public static Bundle convertRedirectToWritableMap(@Nullable SourceRedirect redirect) {
+  public static Bundle convertRedirectToWritableMap(@Nullable Redirect redirect) {
     Bundle map = new Bundle();
 
     if (redirect == null) {
@@ -298,14 +300,14 @@ public class Converters {
     }
 
     map.putString("returnUrl", redirect.getReturnUrl());
-    map.putString("status", redirect.getStatus());
+    map.putString("status", redirect.getStatus().name());
     map.putString("url", redirect.getUrl());
 
     return map;
   }
 
   @NonNull
-  public static Bundle convertCodeVerificationToWritableMap(@Nullable SourceCodeVerification codeVerification) {
+  public static Bundle convertCodeVerificationToWritableMap(@Nullable CodeVerification codeVerification) {
     Bundle map = new Bundle();
 
     if (codeVerification == null) {
@@ -313,7 +315,7 @@ public class Converters {
     }
 
     map.putInt("attemptsRemaining", codeVerification.getAttemptsRemaining());
-    map.putString("status", codeVerification.getStatus());
+    map.putString("status", codeVerification.getStatus().name());
 
     return map;
   }
@@ -376,18 +378,18 @@ public class Converters {
     return result;
   }
 
-  public static BankAccount createBankAccount(Map<String, Object> accountData) {
-    BankAccount account = new BankAccount(
-      // required fields only
-        (String)accountData.get("accountNumber"),
+  public static BankAccountTokenParams createBankAccountTokenParams(Map<String, Object> accountData) {
+    BankAccountTokenParams accountTokenParams = new BankAccountTokenParams(
+        // required fields
         (String)accountData.get("countryCode"),
         (String)accountData.get("currency"),
-      getValue(accountData, "routingNumber", "")
+        (String)accountData.get("accountNumber"),
+      null,
+      getValue(accountData, "accountHolderName"),
+      getValue(accountData, "routingNumber")
     );
-    account.setAccountHolderName(getValue(accountData, "accountHolderName"));
-    account.setAccountHolderType(getValue(accountData, "accountHolderType"));
 
-    return account;
+    return accountTokenParams;
   }
 
   public static String getStringOrNull(@NonNull Map<String, Object> map, @NonNull String key) {

--- a/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/expo/modules/payments/stripe/GoogleApiPayFlowImpl.java
+++ b/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/expo/modules/payments/stripe/GoogleApiPayFlowImpl.java
@@ -1,5 +1,6 @@
 package abi40_0_0.expo.modules.payments.stripe;
 import android.app.Activity;
+import android.util.Log;
 import android.content.Intent;
 import androidx.annotation.NonNull;
 
@@ -22,12 +23,14 @@ import com.google.android.gms.wallet.ShippingAddressRequirements;
 import com.google.android.gms.wallet.TransactionInfo;
 import com.google.android.gms.wallet.Wallet;
 import com.google.android.gms.wallet.WalletConstants;
-import com.stripe.android.BuildConfig;
 import com.stripe.android.model.Token;
+import com.stripe.android.Stripe;
 
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
+import org.json.JSONObject;
+import org.json.JSONException;
 
 import static abi40_0_0.expo.modules.payments.stripe.Errors.toErrorCode;
 import static abi40_0_0.expo.modules.payments.stripe.util.Converters.convertTokenToWritableMap;
@@ -93,7 +96,7 @@ public final class GoogleApiPayFlowImpl extends PayFlow {
       .setPaymentMethodTokenizationType(WalletConstants.PAYMENT_METHOD_TOKENIZATION_TYPE_PAYMENT_GATEWAY)
       .addParameter("gateway", "stripe")
       .addParameter("stripe:publishableKey", getPublishableKey())
-      .addParameter("stripe:version", BuildConfig.VERSION_NAME)
+      .addParameter("stripe:version", Stripe.VERSION_NAME)
       .build();
   }
 
@@ -225,7 +228,12 @@ public final class GoogleApiPayFlowImpl extends PayFlow {
             PaymentData paymentData = PaymentData.getFromIntent(data);
             ArgCheck.nonNull(paymentData);
             String tokenJson = paymentData.getPaymentMethodToken().getToken();
-            Token token = Token.fromString(tokenJson);
+            Token token = null;
+            try {
+              token = Token.fromJson(new JSONObject(tokenJson));
+            } catch (JSONException e) {
+              Log.e(TAG, "Unable to create token from JSON string '" + tokenJson + "'.\n" + e);
+            }
             if (token == null) {
               payPromise.reject(
                 getErrorCode("parseResponse"),

--- a/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/expo/modules/payments/stripe/util/Converters.java
+++ b/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/expo/modules/payments/stripe/util/Converters.java
@@ -10,16 +10,19 @@ import com.google.android.gms.identity.intents.model.UserAddress;
 import com.google.android.gms.wallet.PaymentData;
 import com.stripe.android.model.Address;
 import com.stripe.android.model.BankAccount;
+import com.stripe.android.model.BankAccountTokenParams;
 import com.stripe.android.model.Card;
+import com.stripe.android.model.CardParams;
 import com.stripe.android.model.Source;
-import com.stripe.android.model.SourceCodeVerification;
-import com.stripe.android.model.SourceOwner;
-import com.stripe.android.model.SourceReceiver;
-import com.stripe.android.model.SourceRedirect;
+import com.stripe.android.model.Source.CodeVerification;
+import com.stripe.android.model.Source.Owner;
+import com.stripe.android.model.Source.Receiver;
+import com.stripe.android.model.Source.Redirect;
 import com.stripe.android.model.Token;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -68,7 +71,7 @@ public class Converters {
 
     result.putString("cardId", card.getId());
     result.putString("number", card.getNumber());
-    result.putString("cvc", card.getCVC() );
+    result.putString("cvc", card.getCvc() );
     result.putInt("expMonth", card.getExpMonth() );
     result.putInt("expYear", card.getExpYear() );
     result.putString("name", card.getName() );
@@ -79,8 +82,8 @@ public class Converters {
     result.putString("addressZip", card.getAddressZip() );
     result.putString("addressCountry", card.getAddressCountry() );
     result.putString("last4", card.getLast4() );
-    result.putString("brand", card.getBrand() );
-    result.putString("funding", card.getFunding() );
+    result.putString("brand", card.getBrand().getDisplayName() );
+    result.putString("funding", card.getFunding().name() );
     result.putString("fingerprint", card.getFingerprint() );
     result.putString("country", card.getCountry() );
     result.putString("currency", card.getCurrency() );
@@ -94,11 +97,10 @@ public class Converters {
     if (account == null) return result;
 
     result.putString("routingNumber", account.getRoutingNumber());
-    result.putString("accountNumber", account.getAccountNumber());
     result.putString("countryCode", account.getCountryCode());
     result.putString("currency", account.getCurrency());
     result.putString("accountHolderName", account.getAccountHolderName());
-    result.putString("accountHolderType", account.getAccountHolderType());
+    result.putString("accountHolderType", account.getAccountHolderType().name());
     result.putString("fingerprint", account.getFingerprint());
     result.putString("bankName", account.getBankName());
     result.putString("last4", account.getLast4());
@@ -165,32 +167,33 @@ public class Converters {
     return allowedCountriesForShipping;
   }
 
-  public static Card createCard(final Map<String, Object> cardData) {
-    return new Card(
-      // required fields
+  public static CardParams createCardParams(final Map<String, Object> cardData) {
+    Address address = new Address(
+      getValue(cardData, "addressCity"),
+      getValue(cardData, "country"),
+      getValue(cardData, "addressLine1"),
+      getValue(cardData, "addressLine2"),
+      getValue(cardData, "addressZip"),
+      getValue(cardData, "addressState")
+    );
+    Map <String, String> metaData = new HashMap<String, String>();
+    metaData.put("brand", getValue(cardData, "brand"));
+    metaData.put("last4", getValue(cardData, "last4"));
+    metaData.put("fingerprint", getValue(cardData, "fingerprint"));
+    metaData.put("funding", getValue(cardData, "funding"));
+    metaData.put("id", getValue(cardData, "id"));
+    return 
+      new CardParams(
         (String)cardData.get("number"),
         new Integer((int)Math.round((Double)cardData.get("expMonth"))),
         new Integer((int)Math.round((Double)cardData.get("expYear"))),
-      // additional fields
-      getValue(cardData, "cvc"),
-      getValue(cardData, "name"),
-      getValue(cardData, "addressLine1"),
-      getValue(cardData, "addressLine2"),
-      getValue(cardData, "addressCity"),
-      getValue(cardData, "addressState"),
-      getValue(cardData, "addressZip"),
-      getValue(cardData, "addressCountry"),
-      getValue(cardData, "brand"),
-      getValue(cardData, "last4"),
-      getValue(cardData, "fingerprint"),
-      getValue(cardData, "funding"),
-      getValue(cardData, "country"),
-      getValue(cardData, "currency"),
-      getValue(cardData, "id")
-    );
+        getValue(cardData, "cvc"),
+        getValue(cardData, "name"),
+        address,
+        getValue(cardData, "currency"),
+        metaData
+      );
   }
-
-
 
   @NonNull
   public static Bundle convertSourceToWritableMap(@Nullable Source source) {
@@ -205,17 +208,16 @@ public class Converters {
     newSource.putInt("created", source.getCreated().intValue());
     newSource.putBundle("codeVerification", convertCodeVerificationToWritableMap(source.getCodeVerification()));
     newSource.putString("currency", source.getCurrency());
-    newSource.putString("flow", source.getFlow());
+    newSource.putString("flow", source.getFlow().name());
     newSource.putBoolean("livemode", source.isLiveMode());
-    newSource.putBundle("metadata", stringMapToWritableMap(source.getMetaData()));
     newSource.putBundle("owner", convertOwnerToWritableMap(source.getOwner()));
     newSource.putBundle("receiver", convertReceiverToWritableMap(source.getReceiver()));
     newSource.putBundle("redirect", convertRedirectToWritableMap(source.getRedirect()));
     newSource.putBundle("sourceTypeData", mapToWritableMap(source.getSourceTypeData()));
-    newSource.putString("status", source.getStatus());
+    newSource.putString("status", source.getStatus().name());
     newSource.putString("type", source.getType());
     newSource.putString("typeRaw", source.getTypeRaw());
-    newSource.putString("usage", source.getUsage());
+    newSource.putString("usage", source.getUsage().name());
 
     return newSource;
   }
@@ -236,7 +238,7 @@ public class Converters {
   }
 
   @NonNull
-  public static Bundle convertOwnerToWritableMap(@Nullable final SourceOwner owner) {
+  public static Bundle convertOwnerToWritableMap(@Nullable final Owner owner) {
     Bundle map = new Bundle();
 
     if (owner == null) {
@@ -274,7 +276,7 @@ public class Converters {
   }
 
   @NonNull
-  public static Bundle convertReceiverToWritableMap(@Nullable final SourceReceiver receiver) {
+  public static Bundle convertReceiverToWritableMap(@Nullable final Receiver receiver) {
     Bundle map = new Bundle();
 
     if (receiver == null) {
@@ -290,7 +292,7 @@ public class Converters {
   }
 
   @NonNull
-  public static Bundle convertRedirectToWritableMap(@Nullable SourceRedirect redirect) {
+  public static Bundle convertRedirectToWritableMap(@Nullable Redirect redirect) {
     Bundle map = new Bundle();
 
     if (redirect == null) {
@@ -298,14 +300,14 @@ public class Converters {
     }
 
     map.putString("returnUrl", redirect.getReturnUrl());
-    map.putString("status", redirect.getStatus());
+    map.putString("status", redirect.getStatus().name());
     map.putString("url", redirect.getUrl());
 
     return map;
   }
 
   @NonNull
-  public static Bundle convertCodeVerificationToWritableMap(@Nullable SourceCodeVerification codeVerification) {
+  public static Bundle convertCodeVerificationToWritableMap(@Nullable CodeVerification codeVerification) {
     Bundle map = new Bundle();
 
     if (codeVerification == null) {
@@ -313,7 +315,7 @@ public class Converters {
     }
 
     map.putInt("attemptsRemaining", codeVerification.getAttemptsRemaining());
-    map.putString("status", codeVerification.getStatus());
+    map.putString("status", codeVerification.getStatus().name());
 
     return map;
   }
@@ -376,18 +378,18 @@ public class Converters {
     return result;
   }
 
-  public static BankAccount createBankAccount(Map<String, Object> accountData) {
-    BankAccount account = new BankAccount(
-      // required fields only
-        (String)accountData.get("accountNumber"),
+  public static BankAccountTokenParams createBankAccountTokenParams(Map<String, Object> accountData) {
+    BankAccountTokenParams accountTokenParams = new BankAccountTokenParams(
+        // required fields
         (String)accountData.get("countryCode"),
         (String)accountData.get("currency"),
-      getValue(accountData, "routingNumber", "")
+        (String)accountData.get("accountNumber"),
+      null,
+      getValue(accountData, "accountHolderName"),
+      getValue(accountData, "routingNumber")
     );
-    account.setAccountHolderName(getValue(accountData, "accountHolderName"));
-    account.setAccountHolderType(getValue(accountData, "accountHolderType"));
 
-    return account;
+    return accountTokenParams;
   }
 
   public static String getStringOrNull(@NonNull Map<String, Object> map, @NonNull String key) {

--- a/android/versioned-abis/expoview-abi41_0_0/src/main/java/abi41_0_0/expo/modules/payments/stripe/GoogleApiPayFlowImpl.java
+++ b/android/versioned-abis/expoview-abi41_0_0/src/main/java/abi41_0_0/expo/modules/payments/stripe/GoogleApiPayFlowImpl.java
@@ -2,12 +2,7 @@ package abi41_0_0.expo.modules.payments.stripe;
 
 import android.app.Activity;
 import android.content.Intent;
-import androidx.annotation.NonNull;
-
-import abi41_0_0.org.unimodules.core.Promise;
-import abi41_0_0.expo.modules.payments.stripe.util.ArgCheck;
-import abi41_0_0.expo.modules.payments.stripe.util.Converters;
-import abi41_0_0.expo.modules.payments.stripe.util.Fun0;
+import android.util.Log;
 
 import com.google.android.gms.common.api.ApiException;
 import com.google.android.gms.common.api.Status;
@@ -24,12 +19,21 @@ import com.google.android.gms.wallet.ShippingAddressRequirements;
 import com.google.android.gms.wallet.TransactionInfo;
 import com.google.android.gms.wallet.Wallet;
 import com.google.android.gms.wallet.WalletConstants;
-import com.stripe.android.BuildConfig;
+import com.stripe.android.Stripe;
 import com.stripe.android.model.Token;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import abi41_0_0.org.unimodules.core.Promise;
 
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
+
+import androidx.annotation.NonNull;
+import abi41_0_0.expo.modules.payments.stripe.util.ArgCheck;
+import abi41_0_0.expo.modules.payments.stripe.util.Converters;
+import abi41_0_0.expo.modules.payments.stripe.util.Fun0;
 
 import static abi41_0_0.expo.modules.payments.stripe.Errors.toErrorCode;
 import static abi41_0_0.expo.modules.payments.stripe.util.Converters.convertTokenToWritableMap;
@@ -95,7 +99,7 @@ public final class GoogleApiPayFlowImpl extends PayFlow {
       .setPaymentMethodTokenizationType(WalletConstants.PAYMENT_METHOD_TOKENIZATION_TYPE_PAYMENT_GATEWAY)
       .addParameter("gateway", "stripe")
       .addParameter("stripe:publishableKey", getPublishableKey())
-      .addParameter("stripe:version", BuildConfig.VERSION_NAME)
+      .addParameter("stripe:version", Stripe.VERSION_NAME)
       .build();
   }
 
@@ -227,7 +231,12 @@ public final class GoogleApiPayFlowImpl extends PayFlow {
             PaymentData paymentData = PaymentData.getFromIntent(data);
             ArgCheck.nonNull(paymentData);
             String tokenJson = paymentData.getPaymentMethodToken().getToken();
-            Token token = Token.fromString(tokenJson);
+            Token token = null;
+            try {
+              token = Token.fromJson(new JSONObject(tokenJson));
+            } catch (JSONException e) {
+              Log.e(TAG, "Unable to create token from JSON string '" + tokenJson + "'.\n" + e);
+            }
             if (token == null) {
               payPromise.reject(
                 getErrorCode("parseResponse"),

--- a/android/versioned-abis/expoview-abi41_0_0/src/main/java/abi41_0_0/expo/modules/payments/stripe/dialog/AddCardDialogFragment.java
+++ b/android/versioned-abis/expoview-abi41_0_0/src/main/java/abi41_0_0/expo/modules/payments/stripe/dialog/AddCardDialogFragment.java
@@ -6,7 +6,6 @@ import android.app.DialogFragment;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.os.Bundle;
-import androidx.core.content.ContextCompat;
 import android.text.Editable;
 import android.text.TextUtils;
 import android.text.TextWatcher;
@@ -19,21 +18,21 @@ import android.widget.Toast;
 import com.devmarvel.creditcardentry.fields.SecurityCodeText;
 import com.devmarvel.creditcardentry.library.CreditCard;
 import com.devmarvel.creditcardentry.library.CreditCardForm;
+import com.stripe.android.ApiResultCallback;
+import com.stripe.android.model.Card;
+import com.stripe.android.model.Source;
+import com.stripe.android.model.SourceParams;
+import com.stripe.android.model.Token;
 
 import abi41_0_0.org.unimodules.core.Promise;
 
+import androidx.annotation.NonNull;
+import androidx.core.content.ContextCompat;
 import abi41_0_0.host.exp.expoview.R;
 import abi41_0_0.expo.modules.payments.stripe.StripeModule;
 import abi41_0_0.expo.modules.payments.stripe.util.CardFlipAnimator;
 import abi41_0_0.expo.modules.payments.stripe.util.Converters;
 import abi41_0_0.expo.modules.payments.stripe.util.Utils;
-
-import com.stripe.android.SourceCallback;
-import com.stripe.android.TokenCallback;
-import com.stripe.android.model.Card;
-import com.stripe.android.model.Source;
-import com.stripe.android.model.SourceParams;
-import com.stripe.android.model.Token;
 
 
 /**
@@ -194,11 +193,12 @@ public class AddCardDialogFragment extends DialogFragment {
     doneButton.setEnabled(false);
     progressBar.setVisibility(View.VISIBLE);
     final CreditCard fromCard = from.getCreditCard();
-    final Card card = new Card(
+    final Card card = Card.create(
       fromCard.getCardNumber(),
       fromCard.getExpMonth(),
       fromCard.getExpYear(),
-      fromCard.getSecurityCode());
+      fromCard.getSecurityCode()
+    );
 
     String errorMessage = Utils.validateCard(card);
     if (errorMessage == null) {
@@ -206,9 +206,9 @@ public class AddCardDialogFragment extends DialogFragment {
         SourceParams cardSourceParams = SourceParams.createCardParams(card);
         StripeModule.getInstance(tag).getStripe().createSource(
           cardSourceParams,
-          new SourceCallback() {
+          new ApiResultCallback<Source>() {
             @Override
-            public void onSuccess(Source source) {
+            public void onSuccess(@NonNull Source source) {
               // Normalize data with iOS SDK
               final Bundle sourceMap = Converters.convertSourceToWritableMap(source);
               sourceMap.putBundle("card", Converters.mapToWritableMap(source.getSourceTypeData()));
@@ -231,11 +231,13 @@ public class AddCardDialogFragment extends DialogFragment {
           }
         );
       } else {
-        StripeModule.getInstance(tag).getStripe().createToken(
+        StripeModule.getInstance(tag).getStripe().createCardToken(
             card,
-          PUBLISHABLE_KEY,
-          new TokenCallback() {
-            public void onSuccess(Token token) {
+            null,
+            null,
+            new ApiResultCallback<Token>() {
+              @Override
+              public void onSuccess(@NonNull Token token) {
                 if (promise != null) {
                   promise.resolve(Converters.convertTokenToWritableMap(token));
                   promise = null;
@@ -244,6 +246,7 @@ public class AddCardDialogFragment extends DialogFragment {
                 dismiss();
               }
 
+              @Override
               public void onError(Exception error) {
                 doneButton.setEnabled(true);
                 progressBar.setVisibility(View.GONE);

--- a/android/versioned-abis/expoview-abi41_0_0/src/main/java/abi41_0_0/expo/modules/payments/stripe/util/Converters.java
+++ b/android/versioned-abis/expoview-abi41_0_0/src/main/java/abi41_0_0/expo/modules/payments/stripe/util/Converters.java
@@ -1,8 +1,6 @@
 package abi41_0_0.expo.modules.payments.stripe.util;
 
 import android.os.Bundle;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import android.text.TextUtils;
 
 import com.google.android.gms.identity.intents.model.CountrySpecification;
@@ -10,18 +8,24 @@ import com.google.android.gms.identity.intents.model.UserAddress;
 import com.google.android.gms.wallet.PaymentData;
 import com.stripe.android.model.Address;
 import com.stripe.android.model.BankAccount;
+import com.stripe.android.model.BankAccountTokenParams;
 import com.stripe.android.model.Card;
+import com.stripe.android.model.CardParams;
 import com.stripe.android.model.Source;
-import com.stripe.android.model.SourceCodeVerification;
-import com.stripe.android.model.SourceOwner;
-import com.stripe.android.model.SourceReceiver;
-import com.stripe.android.model.SourceRedirect;
+import com.stripe.android.model.Source.CodeVerification;
+import com.stripe.android.model.Source.Owner;
+import com.stripe.android.model.Source.Receiver;
+import com.stripe.android.model.Source.Redirect;
 import com.stripe.android.model.Token;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 /**
  * Created by ngoriachev on 13/03/2018.
@@ -68,7 +72,7 @@ public class Converters {
 
     result.putString("cardId", card.getId());
     result.putString("number", card.getNumber());
-    result.putString("cvc", card.getCVC() );
+    result.putString("cvc", card.getCvc() );
     result.putInt("expMonth", card.getExpMonth() );
     result.putInt("expYear", card.getExpYear() );
     result.putString("name", card.getName() );
@@ -79,8 +83,8 @@ public class Converters {
     result.putString("addressZip", card.getAddressZip() );
     result.putString("addressCountry", card.getAddressCountry() );
     result.putString("last4", card.getLast4() );
-    result.putString("brand", card.getBrand() );
-    result.putString("funding", card.getFunding() );
+    result.putString("brand", card.getBrand().getDisplayName() );
+    result.putString("funding", card.getFunding().name() );
     result.putString("fingerprint", card.getFingerprint() );
     result.putString("country", card.getCountry() );
     result.putString("currency", card.getCurrency() );
@@ -94,11 +98,10 @@ public class Converters {
     if (account == null) return result;
 
     result.putString("routingNumber", account.getRoutingNumber());
-    result.putString("accountNumber", account.getAccountNumber());
     result.putString("countryCode", account.getCountryCode());
     result.putString("currency", account.getCurrency());
     result.putString("accountHolderName", account.getAccountHolderName());
-    result.putString("accountHolderType", account.getAccountHolderType());
+    result.putString("accountHolderType", account.getAccountHolderType().name());
     result.putString("fingerprint", account.getFingerprint());
     result.putString("bankName", account.getBankName());
     result.putString("last4", account.getLast4());
@@ -165,32 +168,33 @@ public class Converters {
     return allowedCountriesForShipping;
   }
 
-  public static Card createCard(final Map<String, Object> cardData) {
-    return new Card(
-      // required fields
+  public static CardParams createCardParams(final Map<String, Object> cardData) {
+    Address address = new Address(
+      getValue(cardData, "addressCity"),
+      getValue(cardData, "country"),
+      getValue(cardData, "addressLine1"),
+      getValue(cardData, "addressLine2"),
+      getValue(cardData, "addressZip"),
+      getValue(cardData, "addressState")
+    );
+    Map <String, String> metaData = new HashMap<String, String>();
+    metaData.put("brand", getValue(cardData, "brand"));
+    metaData.put("last4", getValue(cardData, "last4"));
+    metaData.put("fingerprint", getValue(cardData, "fingerprint"));
+    metaData.put("funding", getValue(cardData, "funding"));
+    metaData.put("id", getValue(cardData, "id"));
+    return 
+      new CardParams(
         (String)cardData.get("number"),
         new Integer((int)Math.round((Double)cardData.get("expMonth"))),
         new Integer((int)Math.round((Double)cardData.get("expYear"))),
-      // additional fields
         getValue(cardData, "cvc"),
         getValue(cardData, "name"),
-      getValue(cardData, "addressLine1"),
-      getValue(cardData, "addressLine2"),
-      getValue(cardData, "addressCity"),
-      getValue(cardData, "addressState"),
-      getValue(cardData, "addressZip"),
-      getValue(cardData, "addressCountry"),
-      getValue(cardData, "brand"),
-      getValue(cardData, "last4"),
-      getValue(cardData, "fingerprint"),
-      getValue(cardData, "funding"),
-      getValue(cardData, "country"),
+        address,
         getValue(cardData, "currency"),
-      getValue(cardData, "id")
+        metaData
       );
   }
-
-
 
   @NonNull
   public static Bundle convertSourceToWritableMap(@Nullable Source source) {
@@ -205,17 +209,16 @@ public class Converters {
     newSource.putInt("created", source.getCreated().intValue());
     newSource.putBundle("codeVerification", convertCodeVerificationToWritableMap(source.getCodeVerification()));
     newSource.putString("currency", source.getCurrency());
-    newSource.putString("flow", source.getFlow());
+    newSource.putString("flow", source.getFlow().name());
     newSource.putBoolean("livemode", source.isLiveMode());
-    newSource.putBundle("metadata", stringMapToWritableMap(source.getMetaData()));
     newSource.putBundle("owner", convertOwnerToWritableMap(source.getOwner()));
     newSource.putBundle("receiver", convertReceiverToWritableMap(source.getReceiver()));
     newSource.putBundle("redirect", convertRedirectToWritableMap(source.getRedirect()));
     newSource.putBundle("sourceTypeData", mapToWritableMap(source.getSourceTypeData()));
-    newSource.putString("status", source.getStatus());
+    newSource.putString("status", source.getStatus().name());
     newSource.putString("type", source.getType());
     newSource.putString("typeRaw", source.getTypeRaw());
-    newSource.putString("usage", source.getUsage());
+    newSource.putString("usage", source.getUsage().name());
 
     return newSource;
   }
@@ -236,7 +239,7 @@ public class Converters {
   }
 
   @NonNull
-  public static Bundle convertOwnerToWritableMap(@Nullable final SourceOwner owner) {
+  public static Bundle convertOwnerToWritableMap(@Nullable final Owner owner) {
     Bundle map = new Bundle();
 
     if (owner == null) {
@@ -274,7 +277,7 @@ public class Converters {
   }
 
   @NonNull
-  public static Bundle convertReceiverToWritableMap(@Nullable final SourceReceiver receiver) {
+  public static Bundle convertReceiverToWritableMap(@Nullable final Receiver receiver) {
     Bundle map = new Bundle();
 
     if (receiver == null) {
@@ -290,7 +293,7 @@ public class Converters {
   }
 
   @NonNull
-  public static Bundle convertRedirectToWritableMap(@Nullable SourceRedirect redirect) {
+  public static Bundle convertRedirectToWritableMap(@Nullable Redirect redirect) {
     Bundle map = new Bundle();
 
     if (redirect == null) {
@@ -298,14 +301,14 @@ public class Converters {
     }
 
     map.putString("returnUrl", redirect.getReturnUrl());
-    map.putString("status", redirect.getStatus());
+    map.putString("status", redirect.getStatus().name());
     map.putString("url", redirect.getUrl());
 
     return map;
   }
 
   @NonNull
-  public static Bundle convertCodeVerificationToWritableMap(@Nullable SourceCodeVerification codeVerification) {
+  public static Bundle convertCodeVerificationToWritableMap(@Nullable CodeVerification codeVerification) {
     Bundle map = new Bundle();
 
     if (codeVerification == null) {
@@ -313,7 +316,7 @@ public class Converters {
     }
 
     map.putInt("attemptsRemaining", codeVerification.getAttemptsRemaining());
-    map.putString("status", codeVerification.getStatus());
+    map.putString("status", codeVerification.getStatus().name());
 
     return map;
   }
@@ -376,18 +379,18 @@ public class Converters {
     return result;
   }
 
-  public static BankAccount createBankAccount(Map<String, Object> accountData) {
-    BankAccount account = new BankAccount(
-      // required fields only
-      (String)accountData.get("accountNumber"),
+  public static BankAccountTokenParams createBankAccountTokenParams(Map<String, Object> accountData) {
+    BankAccountTokenParams accountTokenParams = new BankAccountTokenParams(
+        // required fields
         (String)accountData.get("countryCode"),
         (String)accountData.get("currency"),
-      getValue(accountData, "routingNumber", "")
+        (String)accountData.get("accountNumber"),
+      null,
+      getValue(accountData, "accountHolderName"),
+      getValue(accountData, "routingNumber")
     );
-    account.setAccountHolderName(getValue(accountData, "accountHolderName"));
-    account.setAccountHolderType(getValue(accountData, "accountHolderType"));
 
-    return account;
+    return accountTokenParams;
   }
 
   public static String getStringOrNull(@NonNull Map<String, Object> map, @NonNull String key) {

--- a/apps/native-component-list/src/screens/PaymentsScreen.tsx
+++ b/apps/native-component-list/src/screens/PaymentsScreen.tsx
@@ -111,6 +111,60 @@ export default function PaymentsScreen() {
 
   return (
     <View style={styles.container}>
+      <Text style={styles.header}>Miscellaneous methods</Text>
+      <Text style={styles.instruction}>
+        Click button to show create a token based on example card params.
+      </Text>
+      <Button
+        title="Create token"
+        onPress={async () => {
+          const params = {
+            // mandatory
+            number: '4242424242424242',
+            expMonth: 11,
+            expYear: 22,
+            cvc: '223',
+            // optional
+            name: 'Test User',
+            currency: 'usd',
+            addressLine1: '123 Test Street',
+            addressLine2: 'Apt. 5',
+            addressCity: 'Test City',
+            addressState: 'Test State',
+            addressCountry: 'Test Country',
+            addressZip: '55555',
+          };
+
+          const token = await Payments.createTokenWithCardAsync(params);
+          console.log({ token });
+        }}
+      />
+      <Text style={styles.instruction}>
+        Click button to launch Add Card view to accept payment.
+      </Text>
+      <Button
+        title="Add card"
+        onPress={async () => {
+          const token = await Payments.paymentRequestWithCardFormAsync({
+            requiredBillingAddressFields: 'full',
+            prefilledInformation: {
+              billingAddress: {
+                name: 'Gunilla Haugeh',
+                line1: 'Canary Place',
+                line2: '3',
+                city: 'Macon',
+                state: 'Georgia',
+                country: 'US',
+                postalCode: '31217',
+                phone: '123-4567',
+                email: 'myemail@email.com',
+              },
+            },
+          });
+          console.log({ token });
+        }}
+      />
+
       <Text style={styles.header}>Apple Pay Example with Expo</Text>
       <Text style={styles.instruction}>Click button to show Apple Pay dialog.</Text>
       <Button

--- a/packages/expo-payments-stripe/android/build.gradle
+++ b/packages/expo-payments-stripe/android/build.gradle
@@ -61,7 +61,7 @@ dependencies {
 
   api 'com.google.android.gms:play-services-wallet:15.0.1'
   api 'com.google.firebase:firebase-core:16.0.1'
-  api 'com.stripe:stripe-android:8.1.0'
+  api "com.stripe:stripe-android:${safeExtGet('stripeVersion', '16.1.1')}"
   api 'com.github.tipsi:CreditCardEntry:1.5.0'
-  api "com.google.android.material:material:1.0.0"
+  api "com.google.android.material:material:1.1.0"
 }

--- a/packages/expo-payments-stripe/android/src/main/java/expo/modules/payments/stripe/GoogleApiPayFlowImpl.java
+++ b/packages/expo-payments-stripe/android/src/main/java/expo/modules/payments/stripe/GoogleApiPayFlowImpl.java
@@ -1,12 +1,9 @@
 package expo.modules.payments.stripe;
+
 import android.app.Activity;
 import android.content.Intent;
-import androidx.annotation.NonNull;
+import android.util.Log;
 
-import org.unimodules.core.Promise;
-import expo.modules.payments.stripe.util.ArgCheck;
-import expo.modules.payments.stripe.util.Converters;
-import expo.modules.payments.stripe.util.Fun0;
 import com.google.android.gms.common.api.ApiException;
 import com.google.android.gms.common.api.Status;
 import com.google.android.gms.tasks.OnCompleteListener;
@@ -22,12 +19,21 @@ import com.google.android.gms.wallet.ShippingAddressRequirements;
 import com.google.android.gms.wallet.TransactionInfo;
 import com.google.android.gms.wallet.Wallet;
 import com.google.android.gms.wallet.WalletConstants;
-import com.stripe.android.BuildConfig;
+import com.stripe.android.Stripe;
 import com.stripe.android.model.Token;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.unimodules.core.Promise;
 
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
+
+import androidx.annotation.NonNull;
+import expo.modules.payments.stripe.util.ArgCheck;
+import expo.modules.payments.stripe.util.Converters;
+import expo.modules.payments.stripe.util.Fun0;
 
 import static expo.modules.payments.stripe.Errors.toErrorCode;
 import static expo.modules.payments.stripe.util.Converters.convertTokenToWritableMap;
@@ -93,7 +99,7 @@ public final class GoogleApiPayFlowImpl extends PayFlow {
       .setPaymentMethodTokenizationType(WalletConstants.PAYMENT_METHOD_TOKENIZATION_TYPE_PAYMENT_GATEWAY)
       .addParameter("gateway", "stripe")
       .addParameter("stripe:publishableKey", getPublishableKey())
-      .addParameter("stripe:version", BuildConfig.VERSION_NAME)
+      .addParameter("stripe:version", Stripe.VERSION_NAME)
       .build();
   }
 
@@ -225,7 +231,12 @@ public final class GoogleApiPayFlowImpl extends PayFlow {
             PaymentData paymentData = PaymentData.getFromIntent(data);
             ArgCheck.nonNull(paymentData);
             String tokenJson = paymentData.getPaymentMethodToken().getToken();
-            Token token = Token.fromString(tokenJson);
+            Token token = null;
+            try {
+              token = Token.fromJson(new JSONObject(tokenJson));
+            } catch (JSONException e) {
+              Log.e(TAG, "Unable to create token from JSON string '" + tokenJson + "'.\n" + e);
+            }
             if (token == null) {
               payPromise.reject(
                 getErrorCode("parseResponse"),

--- a/packages/expo-payments-stripe/android/src/main/java/expo/modules/payments/stripe/StripeModule.java
+++ b/packages/expo-payments-stripe/android/src/main/java/expo/modules/payments/stripe/StripeModule.java
@@ -9,47 +9,47 @@ import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import android.text.TextUtils;
 
+import com.google.android.gms.wallet.WalletConstants;
+import com.stripe.android.ApiResultCallback;
+import com.stripe.android.Stripe;
+import com.stripe.android.model.Source;
+import com.stripe.android.model.Source.Flow;
+import com.stripe.android.model.SourceParams;
+import com.stripe.android.model.Token;
+
+import org.unimodules.core.ExportedModule;
 import org.unimodules.core.ModuleRegistry;
 import org.unimodules.core.Promise;
 import org.unimodules.core.interfaces.ActivityEventListener;
 import org.unimodules.core.interfaces.ActivityProvider;
 import org.unimodules.core.interfaces.ExpoMethod;
 import org.unimodules.core.interfaces.services.UIManager;
-import expo.modules.payments.stripe.dialog.AddCardDialogFragment;
-import expo.modules.payments.stripe.util.ArgCheck;
-import expo.modules.payments.stripe.util.Converters;
-import expo.modules.payments.stripe.util.Fun0;
-import com.google.android.gms.wallet.WalletConstants;
-import com.stripe.android.SourceCallback;
-import com.stripe.android.Stripe;
-import com.stripe.android.TokenCallback;
-import com.stripe.android.model.Source;
-import com.stripe.android.model.SourceParams;
-import com.stripe.android.model.Token;
 
 import java.lang.ref.WeakReference;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.unimodules.core.ExportedModule;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import expo.modules.payments.stripe.dialog.AddCardDialogFragment;
+import expo.modules.payments.stripe.util.ArgCheck;
+import expo.modules.payments.stripe.util.Converters;
+import expo.modules.payments.stripe.util.Fun0;
 
 import static expo.modules.payments.stripe.Errors.getDescription;
 import static expo.modules.payments.stripe.Errors.getErrorCode;
 import static expo.modules.payments.stripe.Errors.toErrorCode;
 import static expo.modules.payments.stripe.util.Converters.convertSourceToWritableMap;
 import static expo.modules.payments.stripe.util.Converters.convertTokenToWritableMap;
-import static expo.modules.payments.stripe.util.Converters.createBankAccount;
-import static expo.modules.payments.stripe.util.Converters.createCard;
+import static expo.modules.payments.stripe.util.Converters.createBankAccountTokenParams;
 import static expo.modules.payments.stripe.util.Converters.getStringOrNull;
 import static expo.modules.payments.stripe.util.InitializationOptions.ANDROID_PAY_MODE_KEY;
 import static expo.modules.payments.stripe.util.InitializationOptions.ANDROID_PAY_MODE_PRODUCTION;
-import static expo.modules.payments.stripe.util.InitializationOptions.PUBLISHABLE_KEY;
 import static expo.modules.payments.stripe.util.InitializationOptions.ANDROID_PAY_MODE_TEST;
+import static expo.modules.payments.stripe.util.InitializationOptions.PUBLISHABLE_KEY;
 
 public class StripeModule extends ExportedModule {
   private static final String META_DATA_SCHEME_KEY = "standaloneStripeScheme";
@@ -181,13 +181,16 @@ public class StripeModule extends ExportedModule {
       ArgCheck.nonNull(mStripe);
       ArgCheck.notEmptyString(mPublicKey);
 
-      mStripe.createToken(
-        createCard(cardData),
-        mPublicKey,
-        new TokenCallback() {
-          public void onSuccess(Token token) {
+      mStripe.createCardToken(
+        Converters.createCardParams(cardData),
+        null,
+        null,
+        new ApiResultCallback<Token>() {
+          @Override
+          public void onSuccess(@NonNull Token token) {
             promise.resolve(convertTokenToWritableMap(token));
           }
+          @Override
           public void onError(Exception error) {
             error.printStackTrace();
             promise.reject(toErrorCode(error), error.getMessage());
@@ -205,13 +208,15 @@ public class StripeModule extends ExportedModule {
       ArgCheck.notEmptyString(mPublicKey);
 
       mStripe.createBankAccountToken(
-        createBankAccount(accountData),
+        createBankAccountTokenParams(accountData),
         mPublicKey,
         null,
-        new TokenCallback() {
-          public void onSuccess(Token token) {
+        new ApiResultCallback<Token>() {
+          @Override
+          public void onSuccess(@NonNull Token token) {
             promise.resolve(convertTokenToWritableMap(token));
           }
+          @Override
           public void onError(Exception error) {
             error.printStackTrace();
             promise.reject(toErrorCode(error), error.getMessage());
@@ -333,15 +338,15 @@ public class StripeModule extends ExportedModule {
 
     ArgCheck.nonNull(sourceParams);
 
-    mStripe.createSource(sourceParams, new SourceCallback() {
+    mStripe.createSource(sourceParams, new ApiResultCallback<Source>() {
       @Override
       public void onError(Exception error) {
         promise.reject(toErrorCode(error), error);
       }
 
       @Override
-      public void onSuccess(Source source) {
-        if (Source.REDIRECT.equals(source.getFlow())) {
+      public void onSuccess(@NonNull Source source) {
+        if (Flow.Redirect.equals(source.getFlow())) {
           Activity currentActivity = getCurrentActivity();
           if (currentActivity == null) {
             promise.reject(
@@ -433,19 +438,18 @@ public class StripeModule extends ExportedModule {
         }
 
         switch (source.getStatus()) {
-          case Source.CHARGEABLE:
-          case Source.CONSUMED:
+          case Chargeable:
+          case Consumed:
             promise.resolve(convertSourceToWritableMap(source));
             break;
-          case Source.CANCELED:
+          case Canceled:
             promise.reject(
               getErrorCode(mErrorCodes, "redirectCancelled"),
               getDescription(mErrorCodes, "redirectCancelled")
             );
             break;
-          case Source.PENDING:
-          case Source.FAILED:
-          case Source.UNKNOWN:
+          case Pending:
+          case Failed:
             promise.reject(
               getErrorCode(mErrorCodes, "redirectFailed"),
               getDescription(mErrorCodes, "redirectFailed")

--- a/packages/expo-payments-stripe/android/src/main/java/expo/modules/payments/stripe/dialog/AddCardDialogFragment.java
+++ b/packages/expo-payments-stripe/android/src/main/java/expo/modules/payments/stripe/dialog/AddCardDialogFragment.java
@@ -3,36 +3,36 @@ package expo.modules.payments.stripe.dialog;
 import android.app.AlertDialog;
 import android.app.Dialog;
 import android.app.DialogFragment;
+import android.content.Context;
 import android.content.DialogInterface;
 import android.os.Bundle;
-import androidx.core.content.ContextCompat;
 import android.text.Editable;
+import android.text.TextUtils;
 import android.text.TextWatcher;
 import android.view.View;
 import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.ProgressBar;
 import android.widget.Toast;
-import android.content.Context;
-import android.text.TextUtils;
 
 import com.devmarvel.creditcardentry.fields.SecurityCodeText;
 import com.devmarvel.creditcardentry.library.CreditCard;
 import com.devmarvel.creditcardentry.library.CreditCardForm;
+import com.stripe.android.ApiResultCallback;
+import com.stripe.android.model.Card;
+import com.stripe.android.model.Source;
+import com.stripe.android.model.SourceParams;
+import com.stripe.android.model.Token;
 
 import org.unimodules.core.Promise;
+
+import androidx.annotation.NonNull;
+import androidx.core.content.ContextCompat;
 import expo.modules.payments.stripe.R;
 import expo.modules.payments.stripe.StripeModule;
 import expo.modules.payments.stripe.util.CardFlipAnimator;
 import expo.modules.payments.stripe.util.Converters;
 import expo.modules.payments.stripe.util.Utils;
-
-import com.stripe.android.SourceCallback;
-import com.stripe.android.TokenCallback;
-import com.stripe.android.model.Card;
-import com.stripe.android.model.Source;
-import com.stripe.android.model.SourceParams;
-import com.stripe.android.model.Token;
 
 
 /**
@@ -193,11 +193,12 @@ public class AddCardDialogFragment extends DialogFragment {
     doneButton.setEnabled(false);
     progressBar.setVisibility(View.VISIBLE);
     final CreditCard fromCard = from.getCreditCard();
-    final Card card = new Card(
+    final Card card = Card.create(
       fromCard.getCardNumber(),
       fromCard.getExpMonth(),
       fromCard.getExpYear(),
-      fromCard.getSecurityCode());
+      fromCard.getSecurityCode()
+    );
 
     String errorMessage = Utils.validateCard(card);
     if (errorMessage == null) {
@@ -205,9 +206,9 @@ public class AddCardDialogFragment extends DialogFragment {
         SourceParams cardSourceParams = SourceParams.createCardParams(card);
         StripeModule.getInstance(tag).getStripe().createSource(
           cardSourceParams,
-          new SourceCallback() {
+          new ApiResultCallback<Source>() {
             @Override
-            public void onSuccess(Source source) {
+            public void onSuccess(@NonNull Source source) {
               // Normalize data with iOS SDK
               final Bundle sourceMap = Converters.convertSourceToWritableMap(source);
               sourceMap.putBundle("card", Converters.mapToWritableMap(source.getSourceTypeData()));
@@ -230,11 +231,13 @@ public class AddCardDialogFragment extends DialogFragment {
           }
         );
       } else {
-        StripeModule.getInstance(tag).getStripe().createToken(
+        StripeModule.getInstance(tag).getStripe().createCardToken(
             card,
-            PUBLISHABLE_KEY,
-            new TokenCallback() {
-              public void onSuccess(Token token) {
+            null,
+            null,
+            new ApiResultCallback<Token>() {
+              @Override
+              public void onSuccess(@NonNull Token token) {
                 if (promise != null) {
                   promise.resolve(Converters.convertTokenToWritableMap(token));
                   promise = null;
@@ -243,6 +246,7 @@ public class AddCardDialogFragment extends DialogFragment {
                 dismiss();
               }
 
+              @Override
               public void onError(Exception error) {
                 doneButton.setEnabled(true);
                 progressBar.setVisibility(View.GONE);

--- a/packages/expo-payments-stripe/android/src/main/java/expo/modules/payments/stripe/util/Converters.java
+++ b/packages/expo-payments-stripe/android/src/main/java/expo/modules/payments/stripe/util/Converters.java
@@ -1,8 +1,6 @@
 package expo.modules.payments.stripe.util;
 
 import android.os.Bundle;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import android.text.TextUtils;
 
 import com.google.android.gms.identity.intents.model.CountrySpecification;
@@ -10,18 +8,24 @@ import com.google.android.gms.identity.intents.model.UserAddress;
 import com.google.android.gms.wallet.PaymentData;
 import com.stripe.android.model.Address;
 import com.stripe.android.model.BankAccount;
+import com.stripe.android.model.BankAccountTokenParams;
 import com.stripe.android.model.Card;
+import com.stripe.android.model.CardParams;
 import com.stripe.android.model.Source;
-import com.stripe.android.model.SourceCodeVerification;
-import com.stripe.android.model.SourceOwner;
-import com.stripe.android.model.SourceReceiver;
-import com.stripe.android.model.SourceRedirect;
+import com.stripe.android.model.Source.CodeVerification;
+import com.stripe.android.model.Source.Owner;
+import com.stripe.android.model.Source.Receiver;
+import com.stripe.android.model.Source.Redirect;
 import com.stripe.android.model.Token;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 /**
  * Created by ngoriachev on 13/03/2018.
@@ -68,7 +72,7 @@ public class Converters {
 
     result.putString("cardId", card.getId());
     result.putString("number", card.getNumber());
-    result.putString("cvc", card.getCVC() );
+    result.putString("cvc", card.getCvc() );
     result.putInt("expMonth", card.getExpMonth() );
     result.putInt("expYear", card.getExpYear() );
     result.putString("name", card.getName() );
@@ -79,8 +83,8 @@ public class Converters {
     result.putString("addressZip", card.getAddressZip() );
     result.putString("addressCountry", card.getAddressCountry() );
     result.putString("last4", card.getLast4() );
-    result.putString("brand", card.getBrand() );
-    result.putString("funding", card.getFunding() );
+    result.putString("brand", card.getBrand().getDisplayName() );
+    result.putString("funding", card.getFunding().name() );
     result.putString("fingerprint", card.getFingerprint() );
     result.putString("country", card.getCountry() );
     result.putString("currency", card.getCurrency() );
@@ -94,11 +98,10 @@ public class Converters {
     if (account == null) return result;
 
     result.putString("routingNumber", account.getRoutingNumber());
-    result.putString("accountNumber", account.getAccountNumber());
     result.putString("countryCode", account.getCountryCode());
     result.putString("currency", account.getCurrency());
     result.putString("accountHolderName", account.getAccountHolderName());
-    result.putString("accountHolderType", account.getAccountHolderType());
+    result.putString("accountHolderType", account.getAccountHolderType().name());
     result.putString("fingerprint", account.getFingerprint());
     result.putString("bankName", account.getBankName());
     result.putString("last4", account.getLast4());
@@ -165,32 +168,33 @@ public class Converters {
     return allowedCountriesForShipping;
   }
 
-  public static Card createCard(final Map<String, Object> cardData) {
-    return new Card(
-      // required fields
+  public static CardParams createCardParams(final Map<String, Object> cardData) {
+    Address address = new Address(
+      getValue(cardData, "addressCity"),
+      getValue(cardData, "country"),
+      getValue(cardData, "addressLine1"),
+      getValue(cardData, "addressLine2"),
+      getValue(cardData, "addressZip"),
+      getValue(cardData, "addressState")
+    );
+    Map <String, String> metaData = new HashMap<String, String>();
+    metaData.put("brand", getValue(cardData, "brand"));
+    metaData.put("last4", getValue(cardData, "last4"));
+    metaData.put("fingerprint", getValue(cardData, "fingerprint"));
+    metaData.put("funding", getValue(cardData, "funding"));
+    metaData.put("id", getValue(cardData, "id"));
+    return 
+      new CardParams(
         (String)cardData.get("number"),
         new Integer((int)Math.round((Double)cardData.get("expMonth"))),
         new Integer((int)Math.round((Double)cardData.get("expYear"))),
-      // additional fields
-      getValue(cardData, "cvc"),
-      getValue(cardData, "name"),
-      getValue(cardData, "addressLine1"),
-      getValue(cardData, "addressLine2"),
-      getValue(cardData, "addressCity"),
-      getValue(cardData, "addressState"),
-      getValue(cardData, "addressZip"),
-      getValue(cardData, "addressCountry"),
-      getValue(cardData, "brand"),
-      getValue(cardData, "last4"),
-      getValue(cardData, "fingerprint"),
-      getValue(cardData, "funding"),
-      getValue(cardData, "country"),
-      getValue(cardData, "currency"),
-      getValue(cardData, "id")
-    );
+        getValue(cardData, "cvc"),
+        getValue(cardData, "name"),
+        address,
+        getValue(cardData, "currency"),
+        metaData
+      );
   }
-
-
 
   @NonNull
   public static Bundle convertSourceToWritableMap(@Nullable Source source) {
@@ -205,17 +209,16 @@ public class Converters {
     newSource.putInt("created", source.getCreated().intValue());
     newSource.putBundle("codeVerification", convertCodeVerificationToWritableMap(source.getCodeVerification()));
     newSource.putString("currency", source.getCurrency());
-    newSource.putString("flow", source.getFlow());
+    newSource.putString("flow", source.getFlow().name());
     newSource.putBoolean("livemode", source.isLiveMode());
-    newSource.putBundle("metadata", stringMapToWritableMap(source.getMetaData()));
     newSource.putBundle("owner", convertOwnerToWritableMap(source.getOwner()));
     newSource.putBundle("receiver", convertReceiverToWritableMap(source.getReceiver()));
     newSource.putBundle("redirect", convertRedirectToWritableMap(source.getRedirect()));
     newSource.putBundle("sourceTypeData", mapToWritableMap(source.getSourceTypeData()));
-    newSource.putString("status", source.getStatus());
+    newSource.putString("status", source.getStatus().name());
     newSource.putString("type", source.getType());
     newSource.putString("typeRaw", source.getTypeRaw());
-    newSource.putString("usage", source.getUsage());
+    newSource.putString("usage", source.getUsage().name());
 
     return newSource;
   }
@@ -236,7 +239,7 @@ public class Converters {
   }
 
   @NonNull
-  public static Bundle convertOwnerToWritableMap(@Nullable final SourceOwner owner) {
+  public static Bundle convertOwnerToWritableMap(@Nullable final Owner owner) {
     Bundle map = new Bundle();
 
     if (owner == null) {
@@ -274,7 +277,7 @@ public class Converters {
   }
 
   @NonNull
-  public static Bundle convertReceiverToWritableMap(@Nullable final SourceReceiver receiver) {
+  public static Bundle convertReceiverToWritableMap(@Nullable final Receiver receiver) {
     Bundle map = new Bundle();
 
     if (receiver == null) {
@@ -290,7 +293,7 @@ public class Converters {
   }
 
   @NonNull
-  public static Bundle convertRedirectToWritableMap(@Nullable SourceRedirect redirect) {
+  public static Bundle convertRedirectToWritableMap(@Nullable Redirect redirect) {
     Bundle map = new Bundle();
 
     if (redirect == null) {
@@ -298,14 +301,14 @@ public class Converters {
     }
 
     map.putString("returnUrl", redirect.getReturnUrl());
-    map.putString("status", redirect.getStatus());
+    map.putString("status", redirect.getStatus().name());
     map.putString("url", redirect.getUrl());
 
     return map;
   }
 
   @NonNull
-  public static Bundle convertCodeVerificationToWritableMap(@Nullable SourceCodeVerification codeVerification) {
+  public static Bundle convertCodeVerificationToWritableMap(@Nullable CodeVerification codeVerification) {
     Bundle map = new Bundle();
 
     if (codeVerification == null) {
@@ -313,7 +316,7 @@ public class Converters {
     }
 
     map.putInt("attemptsRemaining", codeVerification.getAttemptsRemaining());
-    map.putString("status", codeVerification.getStatus());
+    map.putString("status", codeVerification.getStatus().name());
 
     return map;
   }
@@ -376,18 +379,18 @@ public class Converters {
     return result;
   }
 
-  public static BankAccount createBankAccount(Map<String, Object> accountData) {
-    BankAccount account = new BankAccount(
-      // required fields only
-        (String)accountData.get("accountNumber"),
+  public static BankAccountTokenParams createBankAccountTokenParams(Map<String, Object> accountData) {
+    BankAccountTokenParams accountTokenParams = new BankAccountTokenParams(
+        // required fields
         (String)accountData.get("countryCode"),
         (String)accountData.get("currency"),
-      getValue(accountData, "routingNumber", "")
+        (String)accountData.get("accountNumber"),
+      null,
+      getValue(accountData, "accountHolderName"),
+      getValue(accountData, "routingNumber")
     );
-    account.setAccountHolderName(getValue(accountData, "accountHolderName"));
-    account.setAccountHolderType(getValue(accountData, "accountHolderType"));
 
-    return account;
+    return accountTokenParams;
   }
 
   public static String getStringOrNull(@NonNull Map<String, Object> map, @NonNull String key) {


### PR DESCRIPTION
# Why

Add back in the Stripe native upgrade

# How

Narrowed it down to v 9.1.1 of the android stripe module that was causing the issue mentioned in https://github.com/expo/expo/pull/12336 (which aligns well with https://github.com/stripe/stripe-android/issues/2460), but from the changelog in Stripe's Android repo I'm still not sure _exactly_ what about that version triggered this error. My guess is that the upgrade of their 3DS2 dependency involved another dependency which triggered this error:
```
Invalid signature file digest for Manifest main attributes
```
due to incorrect `META-INF/` content in our APKs. 

Anyways, [gradle's default settings for packagingOptions](https://google.github.io/android-gradle-dsl/3.2/com.android.build.gradle.internal.dsl.PackagingOptions.html) should be merging some of those files, and excluding others, but since we had `pickFirst "**"`, I think that was being applied to those `META-INF/` files as well, and including them, since the very first check done by gradle is:
```
If any of the first-pick patterns match the path and that path has not been included in the FULL_APK, add it to the FULL_APK.
```

So even adding `exclude (<pattern matching these meta-inf file>)` would do nothing.

I'm not really sure why we had `pickFirst "**"`, but it seems like quite a dangerous setting to have anyways. I pulled it back to just `lib/**`, and builds are succeeding, and the FaceDetector crash mentioned in https://github.com/expo/expo/pull/12336 doesn't happen anymore

# Test Plan

NCL face-detector screen works without crashing
