### PR TITLE
[expotools] add --packages option to native-unit-tests commands

### DIFF
--- a/tools/src/commands/NativeUnitTests.ts
+++ b/tools/src/commands/NativeUnitTests.ts
@@ -10,9 +10,11 @@ type TestType = 'local' | 'instrumented';
 async function thisAction({
   platform,
   type = 'local',
+  packages,
 }: {
   platform?: PlatformName;
   type: TestType;
+  packages?: string;
 }) {
   if (!platform) {
     console.log(chalk.yellow("You haven't specified platform to run unit tests for!"));
@@ -30,10 +32,10 @@ async function thisAction({
   const runAndroid = platform === 'android' || platform === 'both';
   const runIos = platform === 'ios' || platform === 'both';
   if (runIos) {
-    await iosNativeUnitTests();
+    await iosNativeUnitTests({ packages });
   }
   if (runAndroid) {
-    await androidNativeUnitTests({ type });
+    await androidNativeUnitTests({ type, packages });
   }
 }
 
@@ -47,6 +49,10 @@ export default (program: any) => {
     .option(
       '-t, --type <string>',
       'Type of unit test to run, if supported by this platform. local (default) or instrumented'
+    )
+    .option(
+      '--packages <string>',
+      '[optional] Comma-separated list of package names to run unit tests for. Defaults to all packages with unit tests.'
     )
     .description('Runs native unit tests for each unimodules that provides them.')
     .asyncAction(thisAction);


### PR DESCRIPTION
# Why

https://github.com/expo/expo/pull/11972#discussion_r604775469

# How

Added --packages option to all three native-unit-tests commands, which takes a comma-separated list of package names.
- if a valid list is provided, the command will run unit tests only for the packages in the list
- if the provided list includes a package which doesn't have native unit tests, the command throws an error
- if this option is not provided, we fall back to the default behavior of running tests for all supported packages

# Test Plan

Manually tested all 3 scenarios above for all 3 different unit test commands (including both `local` and `instrumented` type on Android).