### PR TITLE
[app-auth] Added info plist plugin

### DIFF
--- a/packages/expo-app-auth/CHANGELOG.md
+++ b/packages/expo-app-auth/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Added info plist plugin. ([#12379](https://github.com/expo/expo/pull/12379) by [@EvanBacon](https://github.com/EvanBacon))
+
 ## 10.1.0 — 2021-03-10
 
 ### 🎉 New features

--- a/packages/expo-app-auth/plugin/build/withAppAuth.js
+++ b/packages/expo-app-auth/plugin/build/withAppAuth.js
@@ -17,7 +17,7 @@ function setGradlePlaceholders(buildGradle, placeholder) {
         manifestPlaceholders = [${replacement}]`);
 }
 exports.setGradlePlaceholders = setGradlePlaceholders;
-const withAppAuth = (config, { placeholder = config_plugins_1.AndroidConfig.Scheme.getScheme(config)[0] || 'dev.expo.app' } = {}) => {
+const withAppAuthGradleManifestPlaceholder = (config, { placeholder = config_plugins_1.AndroidConfig.Scheme.getScheme(config)[0] || 'dev.expo.app' } = {}) => {
     return config_plugins_1.withAppBuildGradle(config, config => {
         if (config.modResults.language === 'groovy') {
             config.modResults.contents = setGradlePlaceholders(config.modResults.contents, placeholder);
@@ -27,5 +27,29 @@ const withAppAuth = (config, { placeholder = config_plugins_1.AndroidConfig.Sche
         }
         return config;
     });
+};
+const withAppAuthInfoPlist = (config, OAuthRedirect) => {
+    return config_plugins_1.withInfoPlist(config, config => {
+        var _a;
+        if (!Array.isArray(config.modResults.CFBundleURLTypes)) {
+            config.modResults.CFBundleURLTypes = [];
+        }
+        if (!((_a = config.ios) === null || _a === void 0 ? void 0 : _a.bundleIdentifier)) {
+            config_plugins_1.WarningAggregator.addWarningIOS('expo-app-auth', 'The ios.bundleIdentifier must be defined in the app.json!');
+            return config;
+        }
+        config.modResults.CFBundleURLTypes.push({
+            // @ts-ignore: not on type
+            CFBundleTypeRole: 'Editor',
+            CFBundleURLName: 'OAuthRedirect',
+            CFBundleURLSchemes: [OAuthRedirect ? OAuthRedirect : config.ios.bundleIdentifier],
+        });
+        return config;
+    });
+};
+const withAppAuth = (config, props) => {
+    config = withAppAuthGradleManifestPlaceholder(config, props);
+    config = withAppAuthInfoPlist(config);
+    return config;
 };
 exports.default = config_plugins_1.createRunOncePlugin(withAppAuth, pkg.name, pkg.version);

--- a/packages/expo-app-auth/plugin/build/withAppAuth.js
+++ b/packages/expo-app-auth/plugin/build/withAppAuth.js
@@ -35,7 +35,7 @@ const withAppAuthInfoPlist = (config, OAuthRedirect) => {
             config.modResults.CFBundleURLTypes = [];
         }
         if (!((_a = config.ios) === null || _a === void 0 ? void 0 : _a.bundleIdentifier)) {
-            config_plugins_1.WarningAggregator.addWarningIOS('expo-app-auth', 'The ios.bundleIdentifier must be defined in the app.json!');
+            config_plugins_1.WarningAggregator.addWarningIOS('expo-app-auth', 'ios.bundleIdentifier must be defined in app.json or app.config.js');
             return config;
         }
         config.modResults.CFBundleURLTypes.push({

--- a/packages/expo-app-auth/plugin/src/withAppAuth.ts
+++ b/packages/expo-app-auth/plugin/src/withAppAuth.ts
@@ -51,7 +51,7 @@ const withAppAuthInfoPlist: ConfigPlugin<string | void> = (config, OAuthRedirect
     if (!config.ios?.bundleIdentifier) {
       WarningAggregator.addWarningIOS(
         'expo-app-auth',
-        'The ios.bundleIdentifier must be defined in the app.json!'
+        'ios.bundleIdentifier must be defined in app.json or app.config.js'
       );
       return config;
     }

--- a/packages/expo-app-auth/plugin/src/withAppAuth.ts
+++ b/packages/expo-app-auth/plugin/src/withAppAuth.ts
@@ -2,7 +2,9 @@ import {
   AndroidConfig,
   ConfigPlugin,
   createRunOncePlugin,
+  WarningAggregator,
   withAppBuildGradle,
+  withInfoPlist,
 } from '@expo/config-plugins';
 
 const pkg = require('expo-app-auth/package.json');
@@ -25,7 +27,7 @@ export function setGradlePlaceholders(buildGradle: string, placeholder: string):
   );
 }
 
-const withAppAuth: ConfigPlugin<{ placeholder?: string } | void> = (
+const withAppAuthGradleManifestPlaceholder: ConfigPlugin<{ placeholder?: string } | void> = (
   config,
   { placeholder = AndroidConfig.Scheme.getScheme(config)[0] || 'dev.expo.app' } = {}
 ) => {
@@ -39,6 +41,36 @@ const withAppAuth: ConfigPlugin<{ placeholder?: string } | void> = (
     }
     return config;
   });
+};
+
+const withAppAuthInfoPlist: ConfigPlugin<string | void> = (config, OAuthRedirect) => {
+  return withInfoPlist(config, config => {
+    if (!Array.isArray(config.modResults.CFBundleURLTypes)) {
+      config.modResults.CFBundleURLTypes = [];
+    }
+    if (!config.ios?.bundleIdentifier) {
+      WarningAggregator.addWarningIOS(
+        'expo-app-auth',
+        'The ios.bundleIdentifier must be defined in the app.json!'
+      );
+      return config;
+    }
+
+    config.modResults.CFBundleURLTypes.push({
+      // @ts-ignore: not on type
+      CFBundleTypeRole: 'Editor',
+      CFBundleURLName: 'OAuthRedirect',
+      CFBundleURLSchemes: [OAuthRedirect ? OAuthRedirect : config.ios!.bundleIdentifier!],
+    });
+    return config;
+  });
+};
+
+const withAppAuth: ConfigPlugin<{ placeholder?: string } | void> = (config, props) => {
+  config = withAppAuthGradleManifestPlaceholder(config, props);
+  config = withAppAuthInfoPlist(config);
+
+  return config;
 };
 
 export default createRunOncePlugin(withAppAuth, pkg.name, pkg.version);


### PR DESCRIPTION
# Why

- Set `OAuthRedirect` to the `ios.bundleIdentifier` upon ejecting.
