### PR TITLE
[docs] fix View Pager doc warning

### DIFF
--- a/docs/pages/versions/unversioned/sdk/view-pager.md
+++ b/docs/pages/versions/unversioned/sdk/view-pager.md
@@ -9,7 +9,7 @@ import Video from '~/components/plugins/Video'
 
 **`@react-native-community/viewpager`** exposes a component that provides the layout and gestures to scroll between pages of content, like a carousel.
 
-<Video file={"sdk/viewpager.mp4"} loop={"false"}/>
+<Video file={"sdk/viewpager.mp4"} loop={false}/>
 
 <PlatformsSection android emulator ios simulator />
 

--- a/docs/pages/versions/v36.0.0/sdk/view-pager.md
+++ b/docs/pages/versions/v36.0.0/sdk/view-pager.md
@@ -9,7 +9,7 @@ import Video from '~/components/plugins/Video'
 
 **`@react-native-community/viewpager`** exposes a component that provides the layout and gestures to scroll between pages of content, like a carousel.
 
-<Video file={"sdk/viewpager.mp4"} loop={"false"}/>
+<Video file={"sdk/viewpager.mp4"} loop={false}/>
 
 <PlatformsSection android emulator ios simulator />
 

--- a/docs/pages/versions/v37.0.0/sdk/view-pager.md
+++ b/docs/pages/versions/v37.0.0/sdk/view-pager.md
@@ -9,7 +9,7 @@ import Video from '~/components/plugins/Video'
 
 **`@react-native-community/viewpager`** exposes a component that provides the layout and gestures to scroll between pages of content, like a carousel.
 
-<Video file={"sdk/viewpager.mp4"} loop={"false"}/>
+<Video file={"sdk/viewpager.mp4"} loop={false}/>
 
 <PlatformsSection android emulator ios simulator />
 

--- a/docs/pages/versions/v38.0.0/sdk/view-pager.md
+++ b/docs/pages/versions/v38.0.0/sdk/view-pager.md
@@ -9,7 +9,7 @@ import Video from '~/components/plugins/Video'
 
 **`@react-native-community/viewpager`** exposes a component that provides the layout and gestures to scroll between pages of content, like a carousel.
 
-<Video file={"sdk/viewpager.mp4"} loop={"false"}/>
+<Video file={"sdk/viewpager.mp4"} loop={false}/>
 
 <PlatformsSection android emulator ios simulator />
 

--- a/docs/pages/versions/v39.0.0/sdk/view-pager.md
+++ b/docs/pages/versions/v39.0.0/sdk/view-pager.md
@@ -9,7 +9,7 @@ import Video from '~/components/plugins/Video'
 
 **`@react-native-community/viewpager`** exposes a component that provides the layout and gestures to scroll between pages of content, like a carousel.
 
-<Video file={"sdk/viewpager.mp4"} loop={"false"}/>
+<Video file={"sdk/viewpager.mp4"} loop={false}/>
 
 <PlatformsSection android emulator ios simulator />
 

--- a/docs/pages/versions/v40.0.0/sdk/view-pager.md
+++ b/docs/pages/versions/v40.0.0/sdk/view-pager.md
@@ -10,7 +10,7 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 **`@react-native-community/viewpager`** exposes a component that provides the layout and gestures to scroll between pages of content, like a carousel.
 
-<Video file={"sdk/viewpager.mp4"} loop={"false"}/>
+<Video file={"sdk/viewpager.mp4"} loop={false}/>
 
 <PlatformsSection android emulator ios simulator />
 

--- a/docs/pages/versions/v41.0.0/sdk/view-pager.md
+++ b/docs/pages/versions/v41.0.0/sdk/view-pager.md
@@ -9,7 +9,7 @@ import Video from '~/components/plugins/Video'
 
 **`@react-native-community/viewpager`** exposes a component that provides the layout and gestures to scroll between pages of content, like a carousel.
 
-<Video file={"sdk/viewpager.mp4"} loop={"false"}/>
+<Video file={"sdk/viewpager.mp4"} loop={false}/>
 
 <PlatformsSection android emulator ios simulator />
 


### PR DESCRIPTION
# Why

Currently on the View Pager page the `Video` component have an invalid prop type.

<img width="585" alt="Screenshot 2021-04-01 at 12 25 06" src="https://user-images.githubusercontent.com/719641/113281057-65eb0800-92e5-11eb-9467-73a85ba915c0.png">

# How

`"false"` string has been replaced with `boolean`.

# Test Plan

Change has been tested on `localhost`.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).