### PR TITLE
[docs] added deprecation notice for app-auth and google

### DIFF
--- a/docs/pages/versions/unversioned/sdk/app-auth.md
+++ b/docs/pages/versions/unversioned/sdk/app-auth.md
@@ -10,7 +10,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { H3 } from '~/components/plugins/Headings';
 import { InlineCode } from '~/components/base/code';
 
-> ⚠️ For web support and more authentication methods, use the new [**AuthSession**](auth-session.md) API
+> ⚠️ This package is deprecated in favor of [**AuthSession**](auth-session.md). Check out the [authentication guides](../../../guides/authentication.md) to learn how to migrate your existing authentication today.
 
 **`expo-app-auth`** allows you to authenticate and authorize your users through the native OAuth library AppAuth by [OpenID](https://github.com/openid).
 
@@ -271,10 +271,10 @@ Use this method for signing-out. Returns a fetch request.
 
 #### Parameters
 
-| Name    | Type                 | Description                                             |
-| ------- | -------------------- | ------------------------------------------------------- |
+| Name    | Type                 | Description                                            |
+| ------- | -------------------- | ------------------------------------------------------ |
 | props   | `OAuthBaseProps`     | The same OAuth configuration used for the initial flow |
-| options | `OAuthRevokeOptions` | Refresh token or access token to revoke                 |
+| options | `OAuthRevokeOptions` | Refresh token or access token to revoke                |
 
 ### Example
 

--- a/docs/pages/versions/unversioned/sdk/google.md
+++ b/docs/pages/versions/unversioned/sdk/google.md
@@ -6,6 +6,8 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-google-ap
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { InlineCode } from '~/components/base/code';
 
+> ⚠️ This package is deprecated in favor of the Google [**AuthSession**](auth-session.md) provider. Check out the [Google authentication guides](../../../guides/authentication.md#google) to learn how to migrate your app today.
+
 **`expo-google-app-auth`** provides Google authentication integration for Expo apps using a secure system web browser with native [**`expo-app-auth`**][expo-app-auth]. This is better than a WebView because you can reuse credentials saved on the device. This module uses [PKCE](https://tools.ietf.org/html/rfc7636) for secure native authentication. You won't need to define a provider config because this package utilizes Open ID Connect [auto discovery](https://openid.net/specs/openid-connect-discovery-1_0.html).
 
 <PlatformsSection android emulator ios simulator web={{ pending: 'https://github.com/expo/expo/issues/6884' }} />
@@ -59,8 +61,8 @@ The difference between this method and native authentication are very sparce. Go
 
 | Name                                    | Type                                         | Description                                                                                                                                                         |
 | --------------------------------------- | -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [iosClientId][g-creds]                  | <InlineCode>string \| undefined</InlineCode> | The iOS client id registered with Google for use in the Expo Go app.                                                                                            |
-| [androidClientId][g-creds]              | <InlineCode>string \| undefined</InlineCode> | The Android client id registered with Google for use in the Expo Go app.                                                                                        |
+| [iosClientId][g-creds]                  | <InlineCode>string \| undefined</InlineCode> | The iOS client id registered with Google for use in the Expo Go app.                                                                                                |
+| [androidClientId][g-creds]              | <InlineCode>string \| undefined</InlineCode> | The Android client id registered with Google for use in the Expo Go app.                                                                                            |
 | [iosStandaloneAppClientId][g-creds]     | <InlineCode>string \| undefined</InlineCode> | The iOS client id registered with Google for use in a standalone app.                                                                                               |
 | [androidStandaloneAppClientId][g-creds] | <InlineCode>string \| undefined</InlineCode> | The Android client id registered with Google for use in a standalone app.                                                                                           |
 | [clientId][g-creds]                     | <InlineCode>string \| undefined</InlineCode> | If the platform-appropriate client ID is not provided, this will be used instead.                                                                                   |
@@ -136,8 +138,8 @@ Invalidates the provided `accessToken`, given the client ID used to sign-in is p
 | Name                                    | Type                                         | Description                                                                              |
 | --------------------------------------- | -------------------------------------------- | ---------------------------------------------------------------------------------------- |
 | accessToken                             | `string`                                     | Provided when the user authenticates with your Google application.                       |
-| [iosClientId][g-creds]                  | <InlineCode>string \| undefined</InlineCode> | The iOS client id registered with Google for use in the Expo Go app.                 |
-| [androidClientId][g-creds]              | <InlineCode>string \| undefined</InlineCode> | The Android client id registered with Google for use in the Expo Go app.             |
+| [iosClientId][g-creds]                  | <InlineCode>string \| undefined</InlineCode> | The iOS client id registered with Google for use in the Expo Go app.                     |
+| [androidClientId][g-creds]              | <InlineCode>string \| undefined</InlineCode> | The Android client id registered with Google for use in the Expo Go app.                 |
 | [iosStandaloneAppClientId][g-creds]     | <InlineCode>string \| undefined</InlineCode> | The iOS client id registered with Google for use in a standalone app.                    |
 | [androidStandaloneAppClientId][g-creds] | <InlineCode>string \| undefined</InlineCode> | The Android client id registered with Google for use in a standalone app.                |
 | scopes                                  | `string[] = ['profile', 'email']`            | The scopes to ask for from Google for this login ([more information here][g-using-apis]) |

--- a/docs/pages/versions/v40.0.0/sdk/app-auth.md
+++ b/docs/pages/versions/v40.0.0/sdk/app-auth.md
@@ -10,7 +10,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { H3 } from '~/components/plugins/Headings';
 import { InlineCode } from '~/components/base/code';
 
-> ⚠️ For web support and more authentication methods, use the new [**AuthSession**](auth-session.md) API
+> ⚠️ This package is deprecated in favor of [**AuthSession**](auth-session.md). Check out the [authentication guides](../../../guides/authentication.md) to learn how to migrate your existing authentication today.
 
 **`expo-app-auth`** allows you to authenticate and authorize your users through the native OAuth library AppAuth by [OpenID](https://github.com/openid).
 

--- a/docs/pages/versions/v40.0.0/sdk/google.md
+++ b/docs/pages/versions/v40.0.0/sdk/google.md
@@ -6,6 +6,8 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-40/packages/expo-google-ap
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { InlineCode } from '~/components/base/code';
 
+> ⚠️ This package is deprecated in favor of the Google [**AuthSession**](auth-session.md) provider. Check out the [Google authentication guides](../../../guides/authentication.md#google) to learn how to migrate your app today.
+
 **`expo-google-app-auth`** provides Google authentication integration for Expo apps using a secure system web browser with native [**`expo-app-auth`**][expo-app-auth]. This is better than a WebView because you can reuse credentials saved on the device. This module uses [PKCE](https://tools.ietf.org/html/rfc7636) for secure native authentication. You won't need to define a provider config because this package utilizes Open ID Connect [auto discovery](https://openid.net/specs/openid-connect-discovery-1_0.html).
 
 <PlatformsSection android emulator ios simulator web={{ pending: 'https://github.com/expo/expo/issues/6884' }} />
@@ -59,8 +61,8 @@ The difference between this method and native authentication are very sparce. Go
 
 | Name                                    | Type                                         | Description                                                                                                                                                         |
 | --------------------------------------- | -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [iosClientId][g-creds]                  | <InlineCode>string \| undefined</InlineCode> | The iOS client id registered with Google for use in the Expo Go app.                                                                                            |
-| [androidClientId][g-creds]              | <InlineCode>string \| undefined</InlineCode> | The Android client id registered with Google for use in the Expo Go app.                                                                                        |
+| [iosClientId][g-creds]                  | <InlineCode>string \| undefined</InlineCode> | The iOS client id registered with Google for use in the Expo Go app.                                                                                                |
+| [androidClientId][g-creds]              | <InlineCode>string \| undefined</InlineCode> | The Android client id registered with Google for use in the Expo Go app.                                                                                            |
 | [iosStandaloneAppClientId][g-creds]     | <InlineCode>string \| undefined</InlineCode> | The iOS client id registered with Google for use in a standalone app.                                                                                               |
 | [androidStandaloneAppClientId][g-creds] | <InlineCode>string \| undefined</InlineCode> | The Android client id registered with Google for use in a standalone app.                                                                                           |
 | [clientId][g-creds]                     | <InlineCode>string \| undefined</InlineCode> | If the platform-appropriate client ID is not provided, this will be used instead.                                                                                   |
@@ -136,8 +138,8 @@ Invalidates the provided `accessToken`, given the client ID used to sign-in is p
 | Name                                    | Type                                         | Description                                                                              |
 | --------------------------------------- | -------------------------------------------- | ---------------------------------------------------------------------------------------- |
 | accessToken                             | `string`                                     | Provided when the user authenticates with your Google application.                       |
-| [iosClientId][g-creds]                  | <InlineCode>string \| undefined</InlineCode> | The iOS client id registered with Google for use in the Expo Go app.                 |
-| [androidClientId][g-creds]              | <InlineCode>string \| undefined</InlineCode> | The Android client id registered with Google for use in the Expo Go app.             |
+| [iosClientId][g-creds]                  | <InlineCode>string \| undefined</InlineCode> | The iOS client id registered with Google for use in the Expo Go app.                     |
+| [androidClientId][g-creds]              | <InlineCode>string \| undefined</InlineCode> | The Android client id registered with Google for use in the Expo Go app.                 |
 | [iosStandaloneAppClientId][g-creds]     | <InlineCode>string \| undefined</InlineCode> | The iOS client id registered with Google for use in a standalone app.                    |
 | [androidStandaloneAppClientId][g-creds] | <InlineCode>string \| undefined</InlineCode> | The Android client id registered with Google for use in a standalone app.                |
 | scopes                                  | `string[] = ['profile', 'email']`            | The scopes to ask for from Google for this login ([more information here][g-using-apis]) |

--- a/docs/pages/versions/v41.0.0/sdk/app-auth.md
+++ b/docs/pages/versions/v41.0.0/sdk/app-auth.md
@@ -10,7 +10,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { H3 } from '~/components/plugins/Headings';
 import { InlineCode } from '~/components/base/code';
 
-> ⚠️ For web support and more authentication methods, use the new [**AuthSession**](auth-session.md) API
+> ⚠️ This package is deprecated in favor of [**AuthSession**](auth-session.md). Check out the [authentication guides](../../../guides/authentication.md) to learn how to migrate your existing authentication today.
 
 **`expo-app-auth`** allows you to authenticate and authorize your users through the native OAuth library AppAuth by [OpenID](https://github.com/openid).
 
@@ -271,10 +271,10 @@ Use this method for signing-out. Returns a fetch request.
 
 #### Parameters
 
-| Name    | Type                 | Description                                             |
-| ------- | -------------------- | ------------------------------------------------------- |
+| Name    | Type                 | Description                                            |
+| ------- | -------------------- | ------------------------------------------------------ |
 | props   | `OAuthBaseProps`     | The same OAuth configuration used for the initial flow |
-| options | `OAuthRevokeOptions` | Refresh token or access token to revoke                 |
+| options | `OAuthRevokeOptions` | Refresh token or access token to revoke                |
 
 ### Example
 

--- a/docs/pages/versions/v41.0.0/sdk/google.md
+++ b/docs/pages/versions/v41.0.0/sdk/google.md
@@ -6,6 +6,8 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-41/packages/expo-google-ap
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { InlineCode } from '~/components/base/code';
 
+> ⚠️ This package is deprecated in favor of the Google [**AuthSession**](auth-session.md) provider. Check out the [Google authentication guides](../../../guides/authentication.md#google) to learn how to migrate your app today.
+
 **`expo-google-app-auth`** provides Google authentication integration for Expo apps using a secure system web browser with native [**`expo-app-auth`**][expo-app-auth]. This is better than a WebView because you can reuse credentials saved on the device. This module uses [PKCE](https://tools.ietf.org/html/rfc7636) for secure native authentication. You won't need to define a provider config because this package utilizes Open ID Connect [auto discovery](https://openid.net/specs/openid-connect-discovery-1_0.html).
 
 <PlatformsSection android emulator ios simulator web={{ pending: 'https://github.com/expo/expo/issues/6884' }} />
@@ -59,8 +61,8 @@ The difference between this method and native authentication are very sparce. Go
 
 | Name                                    | Type                                         | Description                                                                                                                                                         |
 | --------------------------------------- | -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [iosClientId][g-creds]                  | <InlineCode>string \| undefined</InlineCode> | The iOS client id registered with Google for use in the Expo Go app.                                                                                            |
-| [androidClientId][g-creds]              | <InlineCode>string \| undefined</InlineCode> | The Android client id registered with Google for use in the Expo Go app.                                                                                        |
+| [iosClientId][g-creds]                  | <InlineCode>string \| undefined</InlineCode> | The iOS client id registered with Google for use in the Expo Go app.                                                                                                |
+| [androidClientId][g-creds]              | <InlineCode>string \| undefined</InlineCode> | The Android client id registered with Google for use in the Expo Go app.                                                                                            |
 | [iosStandaloneAppClientId][g-creds]     | <InlineCode>string \| undefined</InlineCode> | The iOS client id registered with Google for use in a standalone app.                                                                                               |
 | [androidStandaloneAppClientId][g-creds] | <InlineCode>string \| undefined</InlineCode> | The Android client id registered with Google for use in a standalone app.                                                                                           |
 | [clientId][g-creds]                     | <InlineCode>string \| undefined</InlineCode> | If the platform-appropriate client ID is not provided, this will be used instead.                                                                                   |
@@ -136,8 +138,8 @@ Invalidates the provided `accessToken`, given the client ID used to sign-in is p
 | Name                                    | Type                                         | Description                                                                              |
 | --------------------------------------- | -------------------------------------------- | ---------------------------------------------------------------------------------------- |
 | accessToken                             | `string`                                     | Provided when the user authenticates with your Google application.                       |
-| [iosClientId][g-creds]                  | <InlineCode>string \| undefined</InlineCode> | The iOS client id registered with Google for use in the Expo Go app.                 |
-| [androidClientId][g-creds]              | <InlineCode>string \| undefined</InlineCode> | The Android client id registered with Google for use in the Expo Go app.             |
+| [iosClientId][g-creds]                  | <InlineCode>string \| undefined</InlineCode> | The iOS client id registered with Google for use in the Expo Go app.                     |
+| [androidClientId][g-creds]              | <InlineCode>string \| undefined</InlineCode> | The Android client id registered with Google for use in the Expo Go app.                 |
 | [iosStandaloneAppClientId][g-creds]     | <InlineCode>string \| undefined</InlineCode> | The iOS client id registered with Google for use in a standalone app.                    |
 | [androidStandaloneAppClientId][g-creds] | <InlineCode>string \| undefined</InlineCode> | The Android client id registered with Google for use in a standalone app.                |
 | scopes                                  | `string[] = ['profile', 'email']`            | The scopes to ask for from Google for this login ([more information here][g-using-apis]) |


### PR DESCRIPTION
# Why

- app-auth is not dynamic enough to be useful in the custom workflow / bare workflow. 
- google-app-auth extends app-auth.
- auth-session is tested, supports web, and fully JS (no native component). 