### PR TITLE
[reanimated] Bump to 2.1.0 on JS side - should be runtime compatible with 2.0.1

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -18,14 +18,14 @@ PODS:
     - UMCore
   - EXApplication (3.1.0):
     - UMCore
-  - EXAV (9.1.0):
+  - EXAV (9.1.1):
     - UMCore
     - UMFileSystemInterface
     - UMPermissionsInterface
   - EXBackgroundFetch (9.1.0):
     - UMCore
     - UMTaskManagerInterface
-  - EXBarCodeScanner (10.1.0):
+  - EXBarCodeScanner (10.1.1):
     - UMBarCodeScannerInterface
     - UMCore
     - UMImageLoaderInterface
@@ -34,12 +34,12 @@ PODS:
     - ZXingObjC/PDF417
   - EXBattery (4.1.0):
     - UMCore
-  - EXBlur (9.0.2):
+  - EXBlur (9.0.3):
     - UMCore
-  - EXBrightness (9.1.0):
+  - EXBrightness (9.1.1):
     - UMCore
     - UMPermissionsInterface
-  - EXCalendar (9.1.0):
+  - EXCalendar (9.1.1):
     - UMCore
     - UMPermissionsInterface
   - EXCamera (11.0.0):
@@ -55,7 +55,7 @@ PODS:
   - EXConstants (10.1.1):
     - UMConstantsInterface
     - UMCore
-  - EXContacts (9.1.0):
+  - EXContacts (9.1.1):
     - UMCore
     - UMFileSystemInterface
     - UMPermissionsInterface
@@ -68,7 +68,7 @@ PODS:
     - UMFileSystemInterface
   - EXErrorRecovery (2.1.0):
     - UMCore
-  - EXFacebook (11.0.2):
+  - EXFacebook (11.0.4):
     - FacebookSDK/CoreKit (= 9.0.1)
     - FacebookSDK/LoginKit (= 9.0.1)
     - UMConstantsInterface
@@ -85,7 +85,7 @@ PODS:
   - EXFileSystem (11.0.0):
     - UMCore
     - UMFileSystemInterface
-  - EXFirebaseAnalytics (4.0.0):
+  - EXFirebaseAnalytics (4.0.1):
     - EXFirebaseCore
     - Firebase/Core (= 7.7.0)
     - UMCore
@@ -118,7 +118,7 @@ PODS:
     - UMCore
     - UMFileSystemInterface
     - UMImageLoaderInterface
-  - EXImagePicker (10.1.0):
+  - EXImagePicker (10.1.1):
     - UMCore
     - UMFileSystemInterface
     - UMPermissionsInterface
@@ -140,14 +140,14 @@ PODS:
   - EXMailComposer (10.1.0):
     - UMCore
     - UMFileSystemInterface
-  - EXMediaLibrary (12.0.0):
+  - EXMediaLibrary (12.0.1):
     - React-Core
     - UMCore
     - UMFileSystemInterface
     - UMPermissionsInterface
-  - EXNetwork (3.1.0):
+  - EXNetwork (3.1.1):
     - UMCore
-  - EXNotifications (0.11.1):
+  - EXNotifications (0.11.3):
     - UMCore
     - UMPermissionsInterface
   - EXPermissions (12.0.0):
@@ -176,7 +176,7 @@ PODS:
     - UMCore
   - EXSecureStore (10.1.0):
     - UMCore
-  - EXSegment (10.1.0):
+  - EXSegment (10.1.1):
     - Analytics (= 4.0.4)
     - UMConstantsInterface
     - UMCore
@@ -186,7 +186,7 @@ PODS:
   - EXSharing (9.1.0):
     - UMCore
     - UMFileSystemInterface
-  - EXSMS (9.1.0):
+  - EXSMS (9.1.1):
     - UMCore
     - UMPermissionsInterface
   - EXSpeech (9.1.0):
@@ -650,7 +650,7 @@ PODS:
     - React-Core
   - RNGestureHandler (1.10.2):
     - React-Core
-  - RNReanimated (2.0.0):
+  - RNReanimated (2.1.0):
     - DoubleConversion
     - FBLazyVector
     - FBReactNativeSpec
@@ -679,7 +679,7 @@ PODS:
     - React-RCTVibration
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNScreens (2.18.1):
+  - RNScreens (3.0.0):
     - React-Core
   - RNSharedElement (0.7.0):
     - React
@@ -702,7 +702,7 @@ PODS:
   - UMImageLoaderInterface (6.1.0)
   - UMPermissionsInterface (6.1.0):
     - UMCore
-  - UMReactNativeAdapter (6.2.0):
+  - UMReactNativeAdapter (6.2.1):
     - React-Core
     - UMCore
     - UMFontInterface
@@ -1228,25 +1228,25 @@ SPEC CHECKSUMS:
   EXAmplitude: 14bccb6919498a784536c9f22461a47167e9199d
   EXAppAuth: d49c6302716a5de459818ab2fcdd260058b88be0
   EXApplication: fe13d11e25ebaca30660ec51ec1112ba4a47fd31
-  EXAV: 15db3e384b75427bb5e14595594dc15c4fdb2493
+  EXAV: fb316da254793571f3de53f6602437e6d860f80d
   EXBackgroundFetch: 5348a5e4eaf3cc5d993425823d9d01de2866ec4e
-  EXBarCodeScanner: 250af16c5b9c1ef11bdc0c5b045b2ebe679808b0
+  EXBarCodeScanner: 94ab8bdb83ca9865e0c03e0cab0a3b68671fc080
   EXBattery: 03199bf4db5edb0978f658ab0f3ee931c8bc819a
-  EXBlur: 78fe13b091326e39e09a1f14357997cd7756be75
-  EXBrightness: c44e722e50ee0d9b4056e1e9eecf2c49ea5c2d05
-  EXCalendar: f94d2a4376eaba3bbdabbc4b06e145d0bfe0f4d9
+  EXBlur: 50d490040f3b14898ed8198d5125dc699189f4d9
+  EXBrightness: b322190c9d97916a6e4f5846e7d2084e07ef7bc8
+  EXCalendar: a1027004c41ea26280895c5cdc9a58ba8eafc50a
   EXCamera: dd244e6fb25301ae57cb9bc966bf8bc8cd355fe4
   EXCellular: 06e641f1c34e9d772da3c69cfe9ef4828791e3f8
   EXConstants: 7c75e5019483e84cc658c133f48607c951652465
-  EXContacts: fed2b61413f7ceed629bca63f7579cb720778e31
+  EXContacts: d9c238f65ab6e6187e66c36a5fad8cc8bb2c9ae6
   EXCrypto: 9cbeb90f6c60a8ae9f26242fd2db916b21c55700
   EXDevice: e69996534618927956e80a91135b5c0dd1d7d114
   EXDocumentPicker: 5b10e7ee57c0877738e89fdfc96ba91412834a58
   EXErrorRecovery: 720641265b8cf95e6cdeb1884ac38e794a352488
-  EXFacebook: 50208a5f802863af28d60e857e525fd0d3f96dc6
+  EXFacebook: 14796048a11d3dceb8f3aea7f8d3e28ddb5e4c77
   EXFaceDetector: c309852d636c773340a0a0e5dd25985ad4f39f6e
   EXFileSystem: b0f2bd62531acb3bc6541a5121f0b1338aaee34f
-  EXFirebaseAnalytics: 0c5a4572e4ec16d188770cdb58f75818b5e2c719
+  EXFirebaseAnalytics: cf36b67695d02c4bf587dbc123cba3e0efab61c6
   EXFirebaseCore: 7865e37021ddcff5c575a4598686a2939d6c4183
   EXFont: d6fb79f9863120f0d0b26b0c2d1453bc9511e9df
   EXGL: 65615aba0107b83c3f8bcd9639d9b7b613f79c10
@@ -1256,7 +1256,7 @@ SPEC CHECKSUMS:
   EXHaptics: 2de40c5f50a9e78da92c209db06db5134d8cac0b
   EXImageLoader: da941c9399e01ec28f2d5b270bdd21f2c8ca596c
   EXImageManipulator: a099e4694070c7cb86aa0b0b1afa3ea184153a7d
-  EXImagePicker: a8be9e6db14d692d04d723cac92d5c47f0b42ce3
+  EXImagePicker: 75f16de9f1113682352fa7bd5db4a8b28a57c898
   EXInAppPurchases: 781153434a138c7c5d20706f47c4003e3d76b5a1
   EXKeepAwake: f60c05abd0c3f3484ac73e9a8b04b3aaf0972d2e
   EXLinearGradient: 39b1cf1df5b885e8c35e8afedc9d8893b9fced4b
@@ -1264,9 +1264,9 @@ SPEC CHECKSUMS:
   EXLocalization: f139efe4a06be1041815879959346e3d437a6e93
   EXLocation: bf9799796c511ca6981b257e1964e10d3dec371a
   EXMailComposer: 3905ca3554cc1142f45bc54632e12e23b8a464a0
-  EXMediaLibrary: b7595816ee5261f7e1b9c48616d65b28e487f123
-  EXNetwork: 5358bd8f47f780e81b18971cef36fce0ebe0af67
-  EXNotifications: f199ea16d9e963759bf68f4d6952b3591638e612
+  EXMediaLibrary: 40fbfb2a813c18bd2cd896a718358ae601d69736
+  EXNetwork: 36144f5e572e6b6b218094c66a57c99e07ffbc0d
+  EXNotifications: 455f183bcb792067cf4937ab10e5a6d8cd6cd549
   EXPermissions: 67ff17d3c12ea06066492dde4242f8047658fd62
   expo-dev-launcher: d6ffbe10033d79c47991aaf768495610da43a39f
   expo-dev-menu: 9cab52a55688aef281dee77a101af83658c59b48
@@ -1277,10 +1277,10 @@ SPEC CHECKSUMS:
   EXScreenCapture: 2903dace06f2d06cc161017637cc4cbfcaa98986
   EXScreenOrientation: 4d9ec57c73055c8a4dbf9dd85def4db29b690a91
   EXSecureStore: da5a255445bb6ee8b8ac54f65412bc803272bd87
-  EXSegment: e4e2e6f0363961994934b3cd82cbf00f10386414
+  EXSegment: b63005c6acabf063a641fd0428c2f47b9822c432
   EXSensors: 8eade1eeb979e01f168f6d5f86597c1bd3fe0d69
   EXSharing: a882fc240b9f69fa9e1e6eeb2b475a356f838f10
-  EXSMS: ad21ae82309a09324f6eb466f973be98638611e2
+  EXSMS: 737cdadf97f24768e774ccddea1fab02f652b067
   EXSpeech: 010826dbfa8287358a05bbd59b44d620266806e3
   EXSplashScreen: 34d4681fe08c1a94a5ff0f80c8526e4b8222bcd3
   EXSQLite: f345a40a57f97ecf7a98e5d302d9b48b58757544
@@ -1357,8 +1357,8 @@ SPEC CHECKSUMS:
   RNCPicker: 6780c753e9e674065db90d9c965920516402579d
   RNDateTimePicker: 17593e41b6b1585aeb8ecbe1c1cbc30cba3d0b4b
   RNGestureHandler: e66feb0fda7da74ea6a3094656b3c1efe05f5c07
-  RNReanimated: 5231286440b796e09df3bfa5c1b12b02bfe07664
-  RNScreens: f7ad633b2e0190b77b6a7aab7f914fad6f198d8d
+  RNReanimated: 70f662b5232dd5d19ccff581e919a54ea73df51c
+  RNScreens: e8e8dd0588b5da0ab57dcca76ab9b2d8987757e0
   RNSharedElement: 00b1a1420d213a34459bb9a5aacabb38107d7948
   RNSVG: ce9d996113475209013317e48b05c21ee988d42e
   SDWebImage: c666b97e1fa9c64b4909816a903322018f0a9c84
@@ -1372,7 +1372,7 @@ SPEC CHECKSUMS:
   UMFontInterface: 5843cff7db85a42ba629aaac53d33091c35524d3
   UMImageLoaderInterface: 9ddffeb644b3f45d4eb0c2f51a2fd95fd5c8d1a4
   UMPermissionsInterface: 40b72935a7d12a3f60dc6b7bb99ce47908380cb1
-  UMReactNativeAdapter: bf25bdfe55639be8059ec4bc53c1814b94b23c49
+  UMReactNativeAdapter: 996daed63e56e4cf50d9260ba26c739812800d44
   UMSensorsInterface: a5e9db661e5d9ae214762033d725989880ae6993
   UMTaskManagerInterface: 203c11259d2699b5b3a4eda4adbc466f5cb5c561
   Yoga: 7740b94929bbacbddda59bf115b5317e9a161598

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -132,7 +132,7 @@
     "react-native": "0.63.2",
     "react-native-appearance": "~0.3.3",
     "react-native-gesture-handler": "~1.10.2",
-    "react-native-reanimated": "~2.0.0",
+    "react-native-reanimated": "~2.1.0",
     "react-native-safe-area-context": "3.2.0",
     "react-native-screens": "~3.0.0",
     "react-native-shared-element": "0.7.0",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -140,7 +140,7 @@
     "react-native-iphone-x-helper": "^1.3.0",
     "react-native-maps": "0.27.1",
     "react-native-paper": "^4.0.1",
-    "react-native-reanimated": "~2.0.0",
+    "react-native-reanimated": "~2.1.0",
     "react-native-redash": "^14.1.1",
     "react-native-shared-element": "0.7.0",
     "react-native-safe-area-context": "3.2.0",

--- a/home/package.json
+++ b/home/package.json
@@ -61,7 +61,7 @@
     "react-native-infinite-scroll-view": "^0.4.5",
     "react-native-maps": "0.27.1",
     "react-native-paper": "^4.0.1",
-    "react-native-reanimated": "~2.0.0",
+    "react-native-reanimated": "~2.1.0",
     "react-native-safe-area-context": "3.2.0",
     "react-native-screens": "~3.0.0",
     "react-redux": "^7.2.0",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -90,7 +90,7 @@
   "react-native-gesture-handler": "~1.10.2",
   "react-native-maps": "0.27.1",
   "react-native-pager-view": "5.0.12",
-  "react-native-reanimated": "~2.0.0",
+  "react-native-reanimated": "~2.1.0",
   "react-native-safe-area-context": "3.2.0",
   "react-native-screens": "~3.0.0",
   "react-native-shared-element": "0.7.0",

--- a/templates/expo-template-bare-minimum/android/app/src/main/java/com/helloworld/MainApplication.java
+++ b/templates/expo-template-bare-minimum/android/app/src/main/java/com/helloworld/MainApplication.java
@@ -23,6 +23,9 @@ import expo.modules.permissions.PermissionsPackage;
 import expo.modules.filesystem.FileSystemPackage;
 import expo.modules.updates.UpdatesController;
 
+import com.facebook.react.bridge.JSIModulePackage;
+import com.swmansion.reanimated.ReanimatedJSIModulePackage;
+
 import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 import java.util.List;
@@ -49,6 +52,11 @@ public class MainApplication extends Application implements ReactApplication {
     @Override
     protected String getJSMainModuleName() {
       return "index";
+    }
+
+    @Override
+    protected JSIModulePackage getJSIModulePackage() {
+      return new ReanimatedJSIModulePackage();
     }
 
     @Override

--- a/templates/expo-template-bare-minimum/package.json
+++ b/templates/expo-template-bare-minimum/package.json
@@ -19,7 +19,7 @@
     "react-dom": "16.13.1",
     "react-native": "~0.63.4",
     "react-native-gesture-handler": "~1.10.2",
-    "react-native-reanimated": "~2.0.0",
+    "react-native-reanimated": "~2.1.0",
     "react-native-screens": "~3.0.0",
     "react-native-unimodules": "~0.13.1",
     "react-native-web": "~0.13.12"

--- a/templates/expo-template-bare-typescript/android/app/src/main/java/com/helloworld/MainApplication.java
+++ b/templates/expo-template-bare-typescript/android/app/src/main/java/com/helloworld/MainApplication.java
@@ -23,6 +23,9 @@ import expo.modules.permissions.PermissionsPackage;
 import expo.modules.filesystem.FileSystemPackage;
 import expo.modules.updates.UpdatesController;
 
+import com.facebook.react.bridge.JSIModulePackage;
+import com.swmansion.reanimated.ReanimatedJSIModulePackage;
+
 import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 import java.util.List;
@@ -49,6 +52,11 @@ public class MainApplication extends Application implements ReactApplication {
     @Override
     protected String getJSMainModuleName() {
       return "index";
+    }
+
+    @Override
+    protected JSIModulePackage getJSIModulePackage() {
+      return new ReanimatedJSIModulePackage();
     }
 
     @Override

--- a/templates/expo-template-bare-typescript/package.json
+++ b/templates/expo-template-bare-typescript/package.json
@@ -18,7 +18,7 @@
     "react-dom": "16.13.1",
     "react-native": "~0.63.4",
     "react-native-gesture-handler": "~1.10.2",
-    "react-native-reanimated": "~2.0.0",
+    "react-native-reanimated": "~2.1.0",
     "react-native-screens": "~3.0.0",
     "react-native-unimodules": "~0.13.1",
     "react-native-web": "~0.13.12"

--- a/templates/expo-template-tabs/package.json
+++ b/templates/expo-template-tabs/package.json
@@ -31,7 +31,7 @@
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "react-native": "https://github.com/expo/react-native/archive/sdk-41.0.0.tar.gz",
-    "react-native-reanimated": "~2.0.0",
+    "react-native-reanimated": "~2.1.0",
     "react-native-gesture-handler": "~1.10.2",
     "react-native-safe-area-context": "3.2.0",
     "react-native-screens": "~3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16619,10 +16619,10 @@ react-native-paper@^4.0.1:
     color "^3.1.2"
     react-native-safe-area-view "^0.14.9"
 
-react-native-reanimated@~2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-2.0.0.tgz#0eb2f196e8fde23cf918530074134177aaee8702"
-  integrity sha512-kIrdBoXSky7DQ62SOgosgimKM+Lt+SzAaM+ovVpCLBcwUK2aYRfLxa9ffgvKjeH9/n7dONlwEMjbKssGkuyq2Q==
+react-native-reanimated@~2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-2.1.0.tgz#b9ad04aee490e1e030d0a6cdaa43a14895d9a54d"
+  integrity sha512-tlPvvcdf+X7HGQ7g/7npBFhwMznfdk7MHUc9gUB/kp2abSscXNe/kOVKlrNEOO4DS11rNOXc+llFxVFMuNk0zA==
   dependencies:
     "@babel/plugin-transform-object-assign" "^7.10.4"
     fbjs "^3.0.0"


### PR DESCRIPTION
# Why

https://github.com/software-mansion/react-native-reanimated/releases/tag/2.1.0 includes support for JSC on Android. This makes it possible to take a managed app that uses react-native-reanimated@2 and generate a native project for it with `prebuild`/`eject` that will work out of the box.

# How

- Updated package version where used in repo
- Updated NCL
- Updated template projects (including adding `ReanimatedJSIModulePackage` to `getJSIModulePackage` in `MainApplication` in bare templates)

# Test Plan

- [x] Manually tested NCL on iOS and Android
- [x] CI
- [x] Manually test prebuild

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).