### PR TITLE
[docs] Replace deprecated CAMERA_ROLL

### DIFF
--- a/docs/pages/versions/unversioned/sdk/media-library.md
+++ b/docs/pages/versions/unversioned/sdk/media-library.md
@@ -18,7 +18,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 ## Configuration
 
-In managed apps, the permission to access images or videos ([`Permissions.CAMERA_ROLL`](permissions.md#permissionscamera_roll)) is added automatically.
+In managed apps, the permission to access images or videos ([`Permissions.MEDIA_LIBRARY`](permissions.md#permissionsmedia_library)) is added automatically.
 
 ## API
 

--- a/docs/pages/versions/v40.0.0/sdk/media-library.md
+++ b/docs/pages/versions/v40.0.0/sdk/media-library.md
@@ -16,7 +16,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 ## Configuration
 
-In managed apps, the permission to access images or videos ([`Permissions.CAMERA_ROLL`](permissions.md#permissionscamera_roll)) is added automatically.
+In managed apps, the permission to access images or videos ([`Permissions.MEDIA_LIBRARY`](permissions.md#permissionsmedia_library)) is added automatically.
 
 ## API
 

--- a/docs/pages/versions/v41.0.0/sdk/media-library.md
+++ b/docs/pages/versions/v41.0.0/sdk/media-library.md
@@ -18,7 +18,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 ## Configuration
 
-In managed apps, the permission to access images or videos ([`Permissions.CAMERA_ROLL`](permissions.md#permissionscamera_roll)) is added automatically.
+In managed apps, the permission to access images or videos ([`Permissions.MEDIA_LIBRARY`](permissions.md#permissionsmedia_library)) is added automatically.
 
 ## API
 


### PR DESCRIPTION

# Why

Permissions.CAMERA_ROLL is deprecated, replaced with Permissions.MEDIA_LIBRARY

# How

Read the docs

# Test Plan

[Docs review]

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).