### PR TITLE
[expo-updates][android] refactor FileDownloader to have instance methods

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.java
+++ b/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.java
@@ -29,6 +29,7 @@ import expo.modules.updates.launcher.NoDatabaseLauncher;
 import expo.modules.updates.launcher.SelectionPolicy;
 import expo.modules.updates.launcher.SelectionPolicyFilterAware;
 import expo.modules.updates.loader.EmbeddedLoader;
+import expo.modules.updates.loader.FileDownloader;
 import expo.modules.updates.loader.LoaderTask;
 import expo.modules.updates.manifest.Manifest;
 import host.exp.exponent.di.NativeModuleDepsProvider;
@@ -69,6 +70,7 @@ public class ExpoUpdatesAppLoader {
 
   private UpdatesConfiguration mUpdatesConfiguration;
   private File mUpdatesDirectory;
+  private FileDownloader mFileDownloader;
   private SelectionPolicy mSelectionPolicy;
   private Launcher mLauncher;
   private boolean mIsEmergencyLaunch = false;
@@ -120,6 +122,13 @@ public class ExpoUpdatesAppLoader {
     return mSelectionPolicy;
   }
 
+  public FileDownloader getFileDownloader() {
+    if (mFileDownloader == null) {
+      throw new IllegalStateException("Tried to access FileDownloader before it was set");
+    }
+    return mFileDownloader;
+  }
+
   public Launcher getLauncher() {
     if (mLauncher == null) {
       throw new IllegalStateException("Tried to access Launcher before it was set");
@@ -155,6 +164,7 @@ public class ExpoUpdatesAppLoader {
     isStarted = true;
     mStatus = AppLoaderStatus.CHECKING_FOR_UPDATE;
 
+    mFileDownloader = new FileDownloader(context);
     mKernel.addAppLoaderForManifestUrl(mManifestUrl, this);
 
     Uri httpManifestUrl = mExponentManifest.httpManifestUrl(mManifestUrl);
@@ -210,7 +220,7 @@ public class ExpoUpdatesAppLoader {
       return;
     }
 
-    new LoaderTask(configuration, mDatabaseHolder, directory, selectionPolicy, new LoaderTask.LoaderTaskCallback() {
+    new LoaderTask(configuration, mDatabaseHolder, directory, mFileDownloader, selectionPolicy, new LoaderTask.LoaderTaskCallback() {
       private boolean didAbort = false;
 
       @Override

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/UpdatesBinding.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/UpdatesBinding.java
@@ -19,6 +19,7 @@ import expo.modules.updates.db.entity.AssetEntity;
 import expo.modules.updates.db.entity.UpdateEntity;
 import expo.modules.updates.launcher.Launcher;
 import expo.modules.updates.launcher.SelectionPolicy;
+import expo.modules.updates.loader.FileDownloader;
 import host.exp.exponent.ExpoUpdatesAppLoader;
 import host.exp.exponent.di.NativeModuleDepsProvider;
 import host.exp.exponent.kernel.KernelConstants;
@@ -60,6 +61,11 @@ public class UpdatesBinding extends UpdatesService implements UpdatesInterface {
   @Override
   public File getDirectory() {
     return mAppLoader.getUpdatesDirectory();
+  }
+
+  @Override
+  public FileDownloader getFileDownloader() {
+    return mAppLoader.getFileDownloader();
   }
 
   @Override

--- a/android/versioned-abis/expoview-abi38_0_0/src/main/java/abi38_0_0/host/exp/exponent/modules/api/UpdatesModule.java
+++ b/android/versioned-abis/expoview-abi38_0_0/src/main/java/abi38_0_0/host/exp/exponent/modules/api/UpdatesModule.java
@@ -80,7 +80,7 @@ public class UpdatesModule extends ReactContextBaseJavaModule {
     try {
       String manifestUrl = (String) mExperienceProperties.get(KernelConstants.MANIFEST_URL_KEY);
       ExpoUpdatesAppLoader appLoader = KernelProvider.getInstance().getAppLoaderForManifestUrl(manifestUrl);
-      FileDownloader.downloadManifest(appLoader.getUpdatesConfiguration(), null, getReactApplicationContext(), new FileDownloader.ManifestDownloadCallback() {
+      appLoader.getFileDownloader().downloadManifest(appLoader.getUpdatesConfiguration(), null, getReactApplicationContext(), new FileDownloader.ManifestDownloadCallback() {
         @Override
         public void onFailure(String message, Exception e) {
           promise.reject("E_FETCH_MANIFEST_FAILED", e);
@@ -121,9 +121,8 @@ public class UpdatesModule extends ReactContextBaseJavaModule {
     String manifestUrl = (String) mExperienceProperties.get(KernelConstants.MANIFEST_URL_KEY);
     ExpoUpdatesAppLoader appLoader = KernelProvider.getInstance().getAppLoaderForManifestUrl(manifestUrl);
     AsyncTask.execute(() -> {
-      new RemoteLoader(getReactApplicationContext(), appLoader.getUpdatesConfiguration(), mDatabaseHolder.getDatabase(), appLoader.getUpdatesDirectory())
+      new RemoteLoader(getReactApplicationContext(), appLoader.getUpdatesConfiguration(), mDatabaseHolder.getDatabase(), appLoader.getFileDownloader(), appLoader.getUpdatesDirectory())
         .start(
-          appLoader.getUpdatesConfiguration().getUpdateUrl(),
           new RemoteLoader.LoaderCallback() {
             @Override
             public void onFailure(Exception e) {

--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/updates/UpdatesInterface.java
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/updates/UpdatesInterface.java
@@ -11,6 +11,7 @@ import expo.modules.updates.db.entity.AssetEntity;
 import expo.modules.updates.db.entity.UpdateEntity;
 import expo.modules.updates.launcher.Launcher;
 import expo.modules.updates.launcher.SelectionPolicy;
+import expo.modules.updates.loader.FileDownloader;
 
 public interface UpdatesInterface {
 
@@ -18,6 +19,7 @@ public interface UpdatesInterface {
   SelectionPolicy getSelectionPolicy();
   File getDirectory();
   DatabaseHolder getDatabaseHolder();
+  FileDownloader getFileDownloader();
 
   boolean isEmergencyLaunch();
   boolean isUsingEmbeddedAssets();

--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/updates/UpdatesModule.java
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/updates/UpdatesModule.java
@@ -122,7 +122,7 @@ public class UpdatesModule extends ExportedModule {
         return;
       }
 
-      FileDownloader.downloadManifest(updatesService.getConfiguration(), null, getContext(), new FileDownloader.ManifestDownloadCallback() {
+      updatesService.getFileDownloader().downloadManifest(updatesService.getConfiguration(), null, getContext(), new FileDownloader.ManifestDownloadCallback() {
         @Override
         public void onFailure(String message, Exception e) {
           promise.reject("ERR_UPDATES_CHECK", message, e);
@@ -171,9 +171,8 @@ public class UpdatesModule extends ExportedModule {
 
       AsyncTask.execute(() -> {
         final DatabaseHolder databaseHolder = updatesService.getDatabaseHolder();
-        new RemoteLoader(getContext(), updatesService.getConfiguration(), databaseHolder.getDatabase(), updatesService.getDirectory())
+        new RemoteLoader(getContext(), updatesService.getConfiguration(), databaseHolder.getDatabase(), updatesService.getFileDownloader(), updatesService.getDirectory())
           .start(
-            updatesService.getConfiguration().getUpdateUrl(),
             new RemoteLoader.LoaderCallback() {
               @Override
               public void onFailure(Exception e) {

--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/updates/UpdatesService.java
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/updates/UpdatesService.java
@@ -18,6 +18,7 @@ import expo.modules.updates.db.entity.AssetEntity;
 import expo.modules.updates.db.entity.UpdateEntity;
 import expo.modules.updates.launcher.Launcher;
 import expo.modules.updates.launcher.SelectionPolicy;
+import expo.modules.updates.loader.FileDownloader;
 
 public class UpdatesService implements InternalModule, UpdatesInterface {
 
@@ -48,6 +49,11 @@ public class UpdatesService implements InternalModule, UpdatesInterface {
   @Override
   public File getDirectory() {
     return UpdatesController.getInstance().getUpdatesDirectory();
+  }
+
+  @Override
+  public FileDownloader getFileDownloader() {
+    return UpdatesController.getInstance().getFileDownloader();
   }
 
   @Override

--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/host/exp/exponent/modules/universal/UpdatesBinding.java
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/host/exp/exponent/modules/universal/UpdatesBinding.java
@@ -19,6 +19,7 @@ import expo.modules.updates.db.entity.AssetEntity;
 import expo.modules.updates.db.entity.UpdateEntity;
 import expo.modules.updates.launcher.Launcher;
 import expo.modules.updates.launcher.SelectionPolicy;
+import expo.modules.updates.loader.FileDownloader;
 import host.exp.exponent.ExpoUpdatesAppLoader;
 import host.exp.exponent.di.NativeModuleDepsProvider;
 import host.exp.exponent.kernel.KernelConstants;
@@ -60,6 +61,11 @@ public class UpdatesBinding extends UpdatesService implements UpdatesInterface {
   @Override
   public File getDirectory() {
     return mAppLoader.getUpdatesDirectory();
+  }
+
+  @Override
+  public FileDownloader getFileDownloader() {
+    return mAppLoader.getFileDownloader();
   }
 
   @Override

--- a/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/expo/modules/updates/UpdatesInterface.java
+++ b/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/expo/modules/updates/UpdatesInterface.java
@@ -11,6 +11,7 @@ import expo.modules.updates.db.entity.AssetEntity;
 import expo.modules.updates.db.entity.UpdateEntity;
 import expo.modules.updates.launcher.Launcher;
 import expo.modules.updates.launcher.SelectionPolicy;
+import expo.modules.updates.loader.FileDownloader;
 
 public interface UpdatesInterface {
 
@@ -18,6 +19,7 @@ public interface UpdatesInterface {
   SelectionPolicy getSelectionPolicy();
   File getDirectory();
   DatabaseHolder getDatabaseHolder();
+  FileDownloader getFileDownloader();
 
   boolean isEmergencyLaunch();
   boolean isUsingEmbeddedAssets();

--- a/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/expo/modules/updates/UpdatesModule.java
+++ b/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/expo/modules/updates/UpdatesModule.java
@@ -122,7 +122,7 @@ public class UpdatesModule extends ExportedModule {
         return;
       }
 
-      FileDownloader.downloadManifest(updatesService.getConfiguration(), null, getContext(), new FileDownloader.ManifestDownloadCallback() {
+      updatesService.getFileDownloader().downloadManifest(updatesService.getConfiguration(), null, getContext(), new FileDownloader.ManifestDownloadCallback() {
         @Override
         public void onFailure(String message, Exception e) {
           promise.reject("ERR_UPDATES_CHECK", message, e);
@@ -171,9 +171,8 @@ public class UpdatesModule extends ExportedModule {
 
       AsyncTask.execute(() -> {
         final DatabaseHolder databaseHolder = updatesService.getDatabaseHolder();
-        new RemoteLoader(getContext(), updatesService.getConfiguration(), databaseHolder.getDatabase(), updatesService.getDirectory())
+        new RemoteLoader(getContext(), updatesService.getConfiguration(), databaseHolder.getDatabase(), updatesService.getFileDownloader(), updatesService.getDirectory())
           .start(
-            updatesService.getConfiguration().getUpdateUrl(),
             new RemoteLoader.LoaderCallback() {
               @Override
               public void onFailure(Exception e) {

--- a/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/expo/modules/updates/UpdatesService.java
+++ b/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/expo/modules/updates/UpdatesService.java
@@ -18,6 +18,7 @@ import expo.modules.updates.db.entity.AssetEntity;
 import expo.modules.updates.db.entity.UpdateEntity;
 import expo.modules.updates.launcher.Launcher;
 import expo.modules.updates.launcher.SelectionPolicy;
+import expo.modules.updates.loader.FileDownloader;
 
 public class UpdatesService implements InternalModule, UpdatesInterface {
 
@@ -48,6 +49,11 @@ public class UpdatesService implements InternalModule, UpdatesInterface {
   @Override
   public File getDirectory() {
     return UpdatesController.getInstance().getUpdatesDirectory();
+  }
+
+  @Override
+  public FileDownloader getFileDownloader() {
+    return UpdatesController.getInstance().getFileDownloader();
   }
 
   @Override

--- a/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/host/exp/exponent/modules/universal/UpdatesBinding.java
+++ b/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/host/exp/exponent/modules/universal/UpdatesBinding.java
@@ -19,6 +19,7 @@ import expo.modules.updates.db.entity.AssetEntity;
 import expo.modules.updates.db.entity.UpdateEntity;
 import expo.modules.updates.launcher.Launcher;
 import expo.modules.updates.launcher.SelectionPolicy;
+import expo.modules.updates.loader.FileDownloader;
 import host.exp.exponent.ExpoUpdatesAppLoader;
 import host.exp.exponent.di.NativeModuleDepsProvider;
 import host.exp.exponent.kernel.KernelConstants;
@@ -60,6 +61,11 @@ public class UpdatesBinding extends UpdatesService implements UpdatesInterface {
   @Override
   public File getDirectory() {
     return mAppLoader.getUpdatesDirectory();
+  }
+
+  @Override
+  public FileDownloader getFileDownloader() {
+    return mAppLoader.getFileDownloader();
   }
 
   @Override

--- a/android/versioned-abis/expoview-abi41_0_0/src/main/java/abi41_0_0/expo/modules/updates/UpdatesInterface.java
+++ b/android/versioned-abis/expoview-abi41_0_0/src/main/java/abi41_0_0/expo/modules/updates/UpdatesInterface.java
@@ -11,6 +11,7 @@ import expo.modules.updates.db.entity.AssetEntity;
 import expo.modules.updates.db.entity.UpdateEntity;
 import expo.modules.updates.launcher.Launcher;
 import expo.modules.updates.launcher.SelectionPolicy;
+import expo.modules.updates.loader.FileDownloader;
 
 public interface UpdatesInterface {
 
@@ -18,6 +19,7 @@ public interface UpdatesInterface {
   SelectionPolicy getSelectionPolicy();
   File getDirectory();
   DatabaseHolder getDatabaseHolder();
+  FileDownloader getFileDownloader();
 
   boolean isEmergencyLaunch();
   boolean isUsingEmbeddedAssets();

--- a/android/versioned-abis/expoview-abi41_0_0/src/main/java/abi41_0_0/expo/modules/updates/UpdatesModule.java
+++ b/android/versioned-abis/expoview-abi41_0_0/src/main/java/abi41_0_0/expo/modules/updates/UpdatesModule.java
@@ -140,7 +140,7 @@ public class UpdatesModule extends ExportedModule {
       JSONObject extraHeaders = ManifestMetadata.getServerDefinedHeaders(databaseHolder.getDatabase(), updatesService.getConfiguration());
       databaseHolder.releaseDatabase();
 
-      FileDownloader.downloadManifest(updatesService.getConfiguration(), extraHeaders, getContext(), new FileDownloader.ManifestDownloadCallback() {
+      updatesService.getFileDownloader().downloadManifest(updatesService.getConfiguration(), extraHeaders, getContext(), new FileDownloader.ManifestDownloadCallback() {
         @Override
         public void onFailure(String message, Exception e) {
           promise.reject("ERR_UPDATES_CHECK", message, e);
@@ -189,9 +189,8 @@ public class UpdatesModule extends ExportedModule {
 
       AsyncTask.execute(() -> {
         final DatabaseHolder databaseHolder = updatesService.getDatabaseHolder();
-        new RemoteLoader(getContext(), updatesService.getConfiguration(), databaseHolder.getDatabase(), updatesService.getDirectory())
+        new RemoteLoader(getContext(), updatesService.getConfiguration(), databaseHolder.getDatabase(), updatesService.getFileDownloader(), updatesService.getDirectory())
           .start(
-            updatesService.getConfiguration().getUpdateUrl(),
             new RemoteLoader.LoaderCallback() {
               @Override
               public void onFailure(Exception e) {

--- a/android/versioned-abis/expoview-abi41_0_0/src/main/java/abi41_0_0/expo/modules/updates/UpdatesService.java
+++ b/android/versioned-abis/expoview-abi41_0_0/src/main/java/abi41_0_0/expo/modules/updates/UpdatesService.java
@@ -18,6 +18,7 @@ import expo.modules.updates.db.entity.AssetEntity;
 import expo.modules.updates.db.entity.UpdateEntity;
 import expo.modules.updates.launcher.Launcher;
 import expo.modules.updates.launcher.SelectionPolicy;
+import expo.modules.updates.loader.FileDownloader;
 
 public class UpdatesService implements InternalModule, UpdatesInterface {
 
@@ -48,6 +49,11 @@ public class UpdatesService implements InternalModule, UpdatesInterface {
   @Override
   public File getDirectory() {
     return UpdatesController.getInstance().getUpdatesDirectory();
+  }
+
+  @Override
+  public FileDownloader getFileDownloader() {
+    return UpdatesController.getInstance().getFileDownloader();
   }
 
   @Override

--- a/android/versioned-abis/expoview-abi41_0_0/src/main/java/abi41_0_0/host/exp/exponent/modules/universal/UpdatesBinding.java
+++ b/android/versioned-abis/expoview-abi41_0_0/src/main/java/abi41_0_0/host/exp/exponent/modules/universal/UpdatesBinding.java
@@ -19,6 +19,7 @@ import expo.modules.updates.db.entity.AssetEntity;
 import expo.modules.updates.db.entity.UpdateEntity;
 import expo.modules.updates.launcher.Launcher;
 import expo.modules.updates.launcher.SelectionPolicy;
+import expo.modules.updates.loader.FileDownloader;
 import host.exp.exponent.ExpoUpdatesAppLoader;
 import host.exp.exponent.di.NativeModuleDepsProvider;
 import host.exp.exponent.kernel.KernelConstants;
@@ -60,6 +61,11 @@ public class UpdatesBinding extends UpdatesService implements UpdatesInterface {
   @Override
   public File getDirectory() {
     return mAppLoader.getUpdatesDirectory();
+  }
+
+  @Override
+  public FileDownloader getFileDownloader() {
+    return mAppLoader.getFileDownloader();
   }
 
   @Override

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed Updates module methods in Android Expo Go by refactoring FileDownloader to have mostly instance methods rather than static methods.
+
 ## 0.5.3 — 2021-03-30
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesInterface.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesInterface.java
@@ -11,6 +11,7 @@ import expo.modules.updates.db.entity.AssetEntity;
 import expo.modules.updates.db.entity.UpdateEntity;
 import expo.modules.updates.launcher.Launcher;
 import expo.modules.updates.launcher.SelectionPolicy;
+import expo.modules.updates.loader.FileDownloader;
 
 public interface UpdatesInterface {
 
@@ -18,6 +19,7 @@ public interface UpdatesInterface {
   SelectionPolicy getSelectionPolicy();
   File getDirectory();
   DatabaseHolder getDatabaseHolder();
+  FileDownloader getFileDownloader();
 
   boolean isEmergencyLaunch();
   boolean isUsingEmbeddedAssets();

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.java
@@ -25,7 +25,7 @@ import expo.modules.updates.loader.RemoteLoader;
 import expo.modules.updates.manifest.ManifestMetadata;
 
 // this unused import must stay because of versioning
-
+import expo.modules.updates.UpdatesConfiguration;
 
 public class UpdatesModule extends ExportedModule {
   private static final String NAME = "ExpoUpdates";

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.java
@@ -25,7 +25,7 @@ import expo.modules.updates.loader.RemoteLoader;
 import expo.modules.updates.manifest.ManifestMetadata;
 
 // this unused import must stay because of versioning
-import expo.modules.updates.UpdatesConfiguration;
+
 
 public class UpdatesModule extends ExportedModule {
   private static final String NAME = "ExpoUpdates";
@@ -140,7 +140,7 @@ public class UpdatesModule extends ExportedModule {
       JSONObject extraHeaders = ManifestMetadata.getServerDefinedHeaders(databaseHolder.getDatabase(), updatesService.getConfiguration());
       databaseHolder.releaseDatabase();
 
-      FileDownloader.downloadManifest(updatesService.getConfiguration(), extraHeaders, getContext(), new FileDownloader.ManifestDownloadCallback() {
+      updatesService.getFileDownloader().downloadManifest(updatesService.getConfiguration(), extraHeaders, getContext(), new FileDownloader.ManifestDownloadCallback() {
         @Override
         public void onFailure(String message, Exception e) {
           promise.reject("ERR_UPDATES_CHECK", message, e);
@@ -189,9 +189,8 @@ public class UpdatesModule extends ExportedModule {
 
       AsyncTask.execute(() -> {
         final DatabaseHolder databaseHolder = updatesService.getDatabaseHolder();
-        new RemoteLoader(getContext(), updatesService.getConfiguration(), databaseHolder.getDatabase(), updatesService.getDirectory())
+        new RemoteLoader(getContext(), updatesService.getConfiguration(), databaseHolder.getDatabase(), updatesService.getFileDownloader(), updatesService.getDirectory())
           .start(
-            updatesService.getConfiguration().getUpdateUrl(),
             new RemoteLoader.LoaderCallback() {
               @Override
               public void onFailure(Exception e) {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesService.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesService.java
@@ -18,6 +18,7 @@ import expo.modules.updates.db.entity.AssetEntity;
 import expo.modules.updates.db.entity.UpdateEntity;
 import expo.modules.updates.launcher.Launcher;
 import expo.modules.updates.launcher.SelectionPolicy;
+import expo.modules.updates.loader.FileDownloader;
 
 public class UpdatesService implements InternalModule, UpdatesInterface {
 
@@ -48,6 +49,11 @@ public class UpdatesService implements InternalModule, UpdatesInterface {
   @Override
   public File getDirectory() {
     return UpdatesController.getInstance().getUpdatesDirectory();
+  }
+
+  @Override
+  public FileDownloader getFileDownloader() {
+    return UpdatesController.getInstance().getFileDownloader();
   }
 
   @Override

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/DatabaseLauncher.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/DatabaseLauncher.java
@@ -29,6 +29,7 @@ public class DatabaseLauncher implements Launcher {
 
   private UpdatesConfiguration mConfiguration;
   private File mUpdatesDirectory;
+  private FileDownloader mFileDownloader;
   private SelectionPolicy mSelectionPolicy;
 
   private UpdateEntity mLaunchedUpdate = null;
@@ -42,9 +43,10 @@ public class DatabaseLauncher implements Launcher {
 
   private LauncherCallback mCallback = null;
 
-  public DatabaseLauncher(UpdatesConfiguration configuration, File updatesDirectory, SelectionPolicy selectionPolicy) {
+  public DatabaseLauncher(UpdatesConfiguration configuration, File updatesDirectory, FileDownloader fileDownloader, SelectionPolicy selectionPolicy) {
     mConfiguration = configuration;
     mUpdatesDirectory = updatesDirectory;
+    mFileDownloader = fileDownloader;
     mSelectionPolicy = selectionPolicy;
   }
 
@@ -184,7 +186,7 @@ public class DatabaseLauncher implements Launcher {
     if (!assetFileExists) {
       // we still don't have the asset locally, so try downloading it remotely
       mAssetsToDownload++;
-      FileDownloader.downloadAsset(asset, mUpdatesDirectory, mConfiguration, context, new FileDownloader.AssetDownloadCallback() {
+      mFileDownloader.downloadAsset(asset, mUpdatesDirectory, mConfiguration, new FileDownloader.AssetDownloadCallback() {
         @Override
         public void onFailure(Exception e, AssetEntity assetEntity) {
           Log.e(TAG, "Failed to load asset from disk or network", e);

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/Crypto.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/Crypto.java
@@ -1,7 +1,6 @@
 package expo.modules.updates.loader;
 
 import android.annotation.SuppressLint;
-import android.content.Context;
 import android.security.keystore.KeyProperties;
 import android.util.Base64;
 
@@ -30,14 +29,25 @@ public class Crypto {
 
   private static String PUBLIC_KEY_URL = "https://exp.host/--/manifest-public-key";
 
-  public static void verifyPublicRSASignature(final String plainText, final String cipherText, final Context context, final RSASignatureListener listener) {
-    fetchPublicKeyAndVerifyPublicRSASignature(true, plainText, cipherText, context, listener);
+  public static void verifyPublicRSASignature(
+    final String plainText,
+    final String cipherText,
+    final FileDownloader fileDownloader,
+    final RSASignatureListener listener
+  ) {
+    fetchPublicKeyAndVerifyPublicRSASignature(true, plainText, cipherText, fileDownloader, listener);
   }
 
   // On first attempt use cache. If verification fails try a second attempt without
   // cache in case the keys were actually rotated.
   // On second attempt reject promise if it fails.
-  private static void fetchPublicKeyAndVerifyPublicRSASignature(final boolean isFirstAttempt, final String plainText, final String cipherText, final Context context, final RSASignatureListener listener) {
+  private static void fetchPublicKeyAndVerifyPublicRSASignature(
+    final boolean isFirstAttempt,
+    final String plainText,
+    final String cipherText,
+    final FileDownloader fileDownloader,
+    final RSASignatureListener listener
+  ) {
     final CacheControl cacheControl = isFirstAttempt ? CacheControl.FORCE_CACHE : CacheControl.FORCE_NETWORK;
 
     final Request request = new Request.Builder()
@@ -45,7 +55,7 @@ public class Crypto {
             .cacheControl(cacheControl)
             .build();
 
-    FileDownloader.downloadData(request, context, new Callback() {
+    fileDownloader.downloadData(request, new Callback() {
       @Override
       public void onFailure(Call call, IOException e) {
         listener.onError(e, true);
@@ -64,7 +74,7 @@ public class Crypto {
         }
 
         if (isFirstAttempt) {
-          fetchPublicKeyAndVerifyPublicRSASignature(false, plainText, cipherText, context, listener);
+          fetchPublicKeyAndVerifyPublicRSASignature(false, plainText, cipherText, fileDownloader, listener);
         } else {
           listener.onError(exception, false);
         }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.java
@@ -38,7 +38,7 @@ public class FileDownloader {
 
   private static final String TAG = FileDownloader.class.getSimpleName();
 
-  private static OkHttpClient sClient;
+  private OkHttpClient mClient;
 
   public interface FileDownloadCallback {
     void onFailure(Exception e);
@@ -55,28 +55,21 @@ public class FileDownloader {
     void onSuccess(AssetEntity assetEntity, boolean isNew);
   }
 
-  private static OkHttpClient getClient(Context context) {
-    if (sClient == null) {
-      sClient = new OkHttpClient.Builder().cache(getCache(context)).build();
-    } else {
-      if (sClient.cache() == null || !getCacheDirectory(context).getAbsolutePath().equals(sClient.cache().directory().getAbsolutePath())) {
-        throw new AssertionError("Error: trying to access static OkHttpClient that was created with a different context.");
-      }
-    }
-    return sClient;
+  public FileDownloader(Context context) {
+    mClient = new OkHttpClient.Builder().cache(getCache(context)).build();
   }
 
-  private static Cache getCache(Context context) {
+  private Cache getCache(Context context) {
     int cacheSize = 50 * 1024 * 1024; // 50 MiB
     return new Cache(getCacheDirectory(context), cacheSize);
   }
 
-  private static File getCacheDirectory(Context context) {
-    return new File(context.getCacheDir(), "okhttp");
+  private File getCacheDirectory(Context context) {
+    return new File(context.getApplicationContext().getCacheDir(), "okhttp");
   }
 
-  public static void downloadFileToPath(Request request, final File destination, final Context context, final FileDownloadCallback callback) {
-    downloadData(request, context, new Callback() {
+  public void downloadFileToPath(Request request, final File destination, final FileDownloadCallback callback) {
+    downloadData(request, new Callback() {
       @Override
       public void onFailure(Call call, IOException e) {
         callback.onFailure(e);
@@ -102,9 +95,9 @@ public class FileDownloader {
     });
   }
 
-  public static void downloadManifest(final UpdatesConfiguration configuration, JSONObject extraHeaders, final Context context, final ManifestDownloadCallback callback) {
+  public void downloadManifest(final UpdatesConfiguration configuration, JSONObject extraHeaders, final Context context, final ManifestDownloadCallback callback) {
     try {
-      downloadData(setHeadersForManifestUrl(configuration, extraHeaders, context), context, new Callback() {
+      downloadData(setHeadersForManifestUrl(configuration, extraHeaders, context), new Callback() {
         @Override
         public void onFailure(Call call, IOException e) {
           callback.onFailure("Failed to download manifest from URL: " + configuration.getUpdateUrl(), e);
@@ -141,10 +134,10 @@ public class FileDownloader {
 
             if (signature != null && !isUnsignedFromXDL) {
               Crypto.verifyPublicRSASignature(
-                  manifestString,
-                  signature,
-                  context,
-                  new Crypto.RSASignatureListener() {
+                manifestString,
+                signature,
+                FileDownloader.this,
+                new Crypto.RSASignatureListener() {
                     @Override
                     public void onError(Exception e, boolean isNetworkError) {
                       callback.onFailure("Could not validate signed manifest", e);
@@ -196,7 +189,7 @@ public class FileDownloader {
     }
   }
 
-  public static void downloadAsset(final AssetEntity asset, File destinationDirectory, UpdatesConfiguration configuration, Context context, final AssetDownloadCallback callback) {
+  public void downloadAsset(final AssetEntity asset, File destinationDirectory, UpdatesConfiguration configuration, final AssetDownloadCallback callback) {
     if (asset.url == null) {
       callback.onFailure(new Exception("Could not download asset " + asset.key + " with no URL"), asset);
       return;
@@ -210,7 +203,7 @@ public class FileDownloader {
       callback.onSuccess(asset, false);
     } else {
       try {
-        downloadFileToPath(setHeadersForUrl(asset.url, configuration), path, context, new FileDownloadCallback() {
+        downloadFileToPath(setHeadersForUrl(asset.url, configuration), path, new FileDownloadCallback() {
           @Override
           public void onFailure(Exception e) {
             callback.onFailure(e, asset);
@@ -230,18 +223,18 @@ public class FileDownloader {
     }
   }
 
-  public static void downloadData(Request request, Context context, Callback callback) {
-    downloadData(request, callback, context, false);
+  public void downloadData(Request request, Callback callback) {
+    downloadData(request, callback, false);
   }
 
-  private static void downloadData(final Request request, final Callback callback, Context context, final boolean isRetry) {
-    getClient(context).newCall(request).enqueue(new Callback() {
+  private void downloadData(final Request request, final Callback callback, final boolean isRetry) {
+    mClient.newCall(request).enqueue(new Callback() {
       @Override
       public void onFailure(Call call, IOException e) {
         if (isRetry) {
           callback.onFailure(call, e);
         } else {
-          downloadData(request, callback, context, true);
+          downloadData(request, callback, true);
         }
       }
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.java
@@ -65,7 +65,7 @@ public class FileDownloader {
   }
 
   private File getCacheDirectory(Context context) {
-    return new File(context.getApplicationContext().getCacheDir(), "okhttp");
+    return new File(context.getCacheDir(), "okhttp");
   }
 
   public void downloadFileToPath(Request request, final File destination, final FileDownloadCallback callback) {


### PR DESCRIPTION
# Why

Currently, using `Updates.checkForUpdateAsync` or `Updates.fetchUpdateAsync` in Android Expo Go will cause the error added in https://github.com/expo/expo/pull/11976 to be thrown.

The error was added because of https://github.com/expo/expo/pull/11875, which added a cache the OkHttpClient instance used in `FileDownloader`. This requires a `Context` object; the current implementation keeps the static OkHttpClient and assumes that `FileDownloader` will only ever be provided `Context`s that have equal return values of `getCacheDir`.

Unfortunately, I did not account for the `ScopedContext` provided to experiences in Expo Go, which has a different `cacheDir` than the application's root context. In this case, we do want to share the OkHttp cache with the root application (the `ScopedContext`'s cache directory is a subdirectory of the root context cache directory); however, this is not something expo-updates should assume or determine on its own.

I decided the correct approach here is to keep track of an instance of FileDownloader (with a member OkHttpClient) and reduce the amount of static methods in this class. This way, the classes that call into FileDownloader can decide whether or not an instance should be shared.

# How

- Make `FileDownloader`'s `OkHttpClient` a member field rather than a static one, and make all methods that use the client non-static.
- Instantiate a copy of `FileDownloader` in `UpdatesController` (for bare apps) and `ExpoUpdatesAppLoader` (for Expo Go / managed apps) and thread it through the stack.

# Test Plan

Tested manually as part of SDK 41 Updates QA

- [x] Expo Go apps update automatically
- [x] all module methods work in Expo Go

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).

# Todo

- [ ] cherry pick to master after landing. (I PR'd this directly to sdk-41 because there are almost certainly some merge conflicts with master right now.)