### PR TITLE
[android] fix verifying self-hosted apps

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.java
+++ b/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.java
@@ -339,7 +339,7 @@ public class ExpoUpdatesAppLoader {
 
   private JSONObject processManifest(JSONObject manifest) throws JSONException {
     Uri parsedManifestUrl = Uri.parse(mManifestUrl);
-    if (!manifest.has(ExponentManifest.MANIFEST_IS_VERIFIED_KEY) &&
+    if (!manifest.optBoolean(ExponentManifest.MANIFEST_IS_VERIFIED_KEY, false) &&
         isThirdPartyHosted(parsedManifestUrl) &&
         !Constants.isStandaloneApp()) {
       // Sandbox third party apps and consider them verified


### PR DESCRIPTION
# Why

Self-hosted apps do not load correctly in Android Expo Go.

# How

Since we now add `isVerified: false` to all manifests in expo-updates, Expo Go's special logic for self-hosted apps is getting skipped 😱 it previously assumed this value would be undefined. I changed this to check if the value is undefined or false.

# Test Plan

Self-hosted apps open and load properly with this change.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
#12396 

# Todos

- [x] cherry-pick to sdk-41 after landing