### PR TITLE
[docs][CI/CD Guide] Missing EXPO_TOKEN usage explained

### DIFF
--- a/docs/pages/guides/setting-up-continuous-integration.md
+++ b/docs/pages/guides/setting-up-continuous-integration.md
@@ -246,7 +246,7 @@ If you don't want to expose the password in the login script, set the `EXPO_CLI_
 $ npx expo login --non-interactive -u <EXPO USERNAME>
 ```
 
-Alternatively you can generate an access token under your profile settings and set an environment variable named `EXPO_TOKEN` with it. After that you can skip whole login command.
+Alternatively, you can [generate an access token under your Expo account settings](https://docs.expo.io/accounts/programmatic-access/) and configure it as an environment variable named `EXPO_TOKEN`. 
 
 ### Publish new builds
 

--- a/docs/pages/guides/setting-up-continuous-integration.md
+++ b/docs/pages/guides/setting-up-continuous-integration.md
@@ -246,7 +246,7 @@ If you don't want to expose the password in the login script, set the `EXPO_CLI_
 $ npx expo login --non-interactive -u <EXPO USERNAME>
 ```
 
-Alternatively, you can [generate an access token under your Expo account settings](https://docs.expo.io/accounts/programmatic-access/) and configure it as an environment variable named `EXPO_TOKEN`. 
+Alternatively, you can [generate an access token under your Expo account settings](/accounts/programmatic-access.md) and configure it as an environment variable named `EXPO_TOKEN`. 
 
 ### Publish new builds
 

--- a/docs/pages/guides/setting-up-continuous-integration.md
+++ b/docs/pages/guides/setting-up-continuous-integration.md
@@ -246,6 +246,8 @@ If you don't want to expose the password in the login script, set the `EXPO_CLI_
 $ npx expo login --non-interactive -u <EXPO USERNAME>
 ```
 
+Alternatively you can generate an access token under your profile settings and set an environment variable named `EXPO_TOKEN` with it. After that you can skip whole login command.
+
 ### Publish new builds
 
 After having the CLI library and authentication in place, we can finally create the build step.


### PR DESCRIPTION
Some people might want to keep passwords themself. EXPO_TOKEN usage was missing before and it seems it cannot be found anywhere else in docs either. I've looked up explo-cli source and find out you can use EXPO_TOKEN as env. variable.