### PR TITLE
Update authentication.md - Dropbox PCKE Support Documentation

### DIFF
--- a/docs/pages/guides/authentication.md
+++ b/docs/pages/guides/authentication.md
@@ -311,7 +311,7 @@ export default function App() {
       clientId: 'CLIENT_ID',
       // There are no scopes so just pass an empty array
       scopes: [],
-      // Dropbox doesn't support PKCE
+      // Set to false for implicit authentication
       usePKCE: false,
       // For usage in managed apps using the proxy
       redirectUri: makeRedirectUri({
@@ -424,7 +424,7 @@ export default function App() {
 
 Auth code responses (`ResponseType.Code`) will only work in native with `useProxy: true` or `usePKCE: true`. The PCKE OAuth workflow returns an authentication code which can be exchanged for a short-lived access token and a long-lived refresh-token. This allows for long-session Dropbox connections.
 
-<SnackInline label='Dropbox Auth Code' dependencies={['expo-auth-session', 'expo-web-browser']}>
+<SnackInline label='Dropbox PKCE' dependencies={['expo-auth-session', 'expo-web-browser']}>
 
 <!-- prettier-ignore -->
 ```tsx
@@ -444,12 +444,15 @@ const discovery = {
 };
 
 export default function App() {
-  /* @info request will containt the <b>codeVerifier</b> which will need to be used with the Dropbox token endpoint to exchange the code for an access token and a refresh token*/
+  /* @info request will contain the <b>codeVerifier</b> which will need to be used with the Dropbox token endpoint to exchange the authorization code for an access token and a refresh token*/
   const [request, response, promptAsync] = useAuthRequest(
     {
+      //Set response type to code to obtain authorization code instead of an access token
+      responseType: ResponseType.Code,
       clientId: 'CLIENT_ID',
       // There are no scopes so just pass an empty array
       scopes: [],
+      // Set to true for PCKE flow
       usePKCE: true,
       redirectUri: makeRedirectUri({
         // For usage in bare and standalone
@@ -462,10 +465,11 @@ export default function App() {
     },
     discovery
   );
+  /* @end */
 
   React.useEffect(() => {
     if (response?.type === 'success') {
-      /* @info Exchange the code for an access token and refresh token via the Dropbox token enpoint using client_id and client_secret. Alternatively you can use the <b>Implicit</b> auth method. */
+      /* @info Exchange the authorization code for an access token and refresh token via the Dropbox token enpoint using client_id and client_secret. Alternatively you can use the <b>Implicit</b> auth method. */
       const { code } = response.params;
       /* @end */
     }


### PR DESCRIPTION
# Why
Dropbox supports PCKE - updated the documentation to reflect the same and added code sample for PCKE-based OAuth workflow.


# How 
Needed the PCKE workflow to obtain short-lived access tokens and long-lived refresh tokens from Dropbox API. Current implicit authentication only provided short-lived access tokens with no refresh tokens. For applications that want to maintain long sessions to Dropbox, this is not ideal.

# Test Plan
Running the auth-session authentication code with `usePCKE: true` and passing extraParams `token_access_type: "offline"` runs the Dropbox OAuth workflow in PCKE mode and returns an authentication code instead of access token which can then be exchanged for an access token and refresh token as per [Dropbox documentation](https://www.dropbox.com/developers/documentation/http/documentation#oauth2-token)

# Checklist

- [ X] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).