### PR TITLE
expo-local-authentication: Avoid LAContext#biometryType bug on iOS 11.0.0

### DIFF
--- a/packages/expo-local-authentication/CHANGELOG.md
+++ b/packages/expo-local-authentication/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Avoid LAContext#biometryType bug on iOS 11.0.0. ([#12413](https://github.com/expo/expo/pull/12413) by [@mickamy](https://github.com/mickamy/))
+
 ## 11.0.0 — 2021-03-10
 
 ### 🛠 Breaking changes

--- a/packages/expo-local-authentication/ios/EXLocalAuthentication/EXLocalAuthentication.m
+++ b/packages/expo-local-authentication/ios/EXLocalAuthentication/EXLocalAuthentication.m
@@ -45,7 +45,7 @@ UM_EXPORT_METHOD_AS(hasHardwareAsync,
   BOOL isSupported = [context canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:&error];
   BOOL isAvailable;
 
-  if (@available(iOS 11.0, *)) {
+  if (@available(iOS 11.0.1, *)) {
     isAvailable = isSupported || error.code != LAErrorBiometryNotAvailable;
   } else {
     isAvailable = isSupported || error.code != LAErrorTouchIDNotAvailable;
@@ -187,7 +187,7 @@ UM_EXPORT_METHOD_AS(authenticateAsync,
 {
   static BOOL isFaceIDDevice = NO;
 
-  if (@available(iOS 11.0, *)) {
+  if (@available(iOS 11.0.1, *)) {
     static dispatch_once_t onceToken;
 
     dispatch_once(&onceToken, ^{
@@ -208,7 +208,7 @@ UM_EXPORT_METHOD_AS(authenticateAsync,
   dispatch_once(&onceToken, ^{
     LAContext *context = [LAContext new];
     [context canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:nil];
-    if (@available(iOS 11.0, *)) {
+    if (@available(iOS 11.0.1, *)) {
       isTouchIDDevice = context.biometryType == LABiometryTypeTouchID;
     } else {
       isTouchIDDevice = true;


### PR DESCRIPTION
ref. https://stackoverflow.com/questions/47588884/lacontext-biometrytype-unrecognized-selector-on-ios-11-0-0

# Why

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

There is a known bug in LAContext#biometryType on iOS 11.0.0.
So we should not use its API on iOS 11.0.0

ref.
- https://stackoverflow.com/questions/47588884/lacontext-biometrytype-unrecognized-selector-on-ios-11-0-0
- https://developer.apple.com/forums/thread/89043

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

Check version availability with succeeding version (namely, iOS 11.0.1).
[react-native-permissions](https://github.com/zoontek/react-native-permissions) is also [taking this option](https://github.com/zoontek/react-native-permissions/blame/2d645ff4f3dfc6db9686bc2fd2877bd049b8043e/ios/FaceID/RNPermissionHandlerFaceID.m#L56).

# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->

I think we don't need any tests for this is only a simple/small change.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).