### PR TITLE
[docs] fix undefined name bug

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -414,7 +414,7 @@ const sortNav = nav => {
 
   sections.forEach(({ name, reference }) => {
     const section = nav.find(o => {
-      return o.name.toLowerCase() === name.toLowerCase();
+      return (o.name || '').toLowerCase() === name.toLowerCase();
     });
 
     if (section) {


### PR DESCRIPTION
# Why

`yarn dev` failing with:

<img width="1143" alt="Screen Shot 2021-04-05 at 12 19 30 PM" src="https://user-images.githubusercontent.com/1220444/113616114-8f6ba280-9609-11eb-9af0-fea40e22096f.png">


# How

Since this is a matching operation, we can substitute with an empty string `''`

# Test Plan
site works 