### PR TITLE
Use triple slash in localUri of local assets

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 🐛 Bug fixes
 
 - Fixed Updates module methods in Android Expo Go by refactoring FileDownloader to have mostly instance methods rather than static methods.
+- Fixed local assets URIs on Android to be compliant with File URI specification. Now file URI takes the form of `file:///*` instead of `file:/*`. ([#12428](https://github.com/expo/expo/pull/12428) by [@tsapeta](https://github.com/tsapeta))
 
 ## 0.5.3 — 2021-03-30
 
@@ -84,8 +85,8 @@ _This version does not introduce any user-facing changes._
 ### 🛠 Breaking changes
 
 - This version adds an internal database migration, which means that when a user's device upgrades from an app with `expo-updates@0.3.x` to an app with `expo-updates@0.4.x`, any updates they had previously downloaded will no longer be accessible.
-  -   For **managed workflow apps**, this is inconsequential as this upgrade will be part of a major SDK version upgrade. You do not need to do anything if your app is made using the managed workflow.
-  -   For **bare workflow apps**, this means updates downloaded on clients running `expo-updates@0.3.x` will need to be redownloaded in order to run after those clients are upgraded to `expo-updates@0.4.x`. We recommend incrementing your runtime/SDK version after updating to `expo-updates@0.4.x`, and republishing any OTA updates that you do not intend to distribute embedded in your application binary.
+  - For **managed workflow apps**, this is inconsequential as this upgrade will be part of a major SDK version upgrade. You do not need to do anything if your app is made using the managed workflow.
+  - For **bare workflow apps**, this means updates downloaded on clients running `expo-updates@0.3.x` will need to be redownloaded in order to run after those clients are upgraded to `expo-updates@0.4.x`. We recommend incrementing your runtime/SDK version after updating to `expo-updates@0.4.x`, and republishing any OTA updates that you do not intend to distribute embedded in your application binary.
 
 ## 0.4.0 — 2020-11-17
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/DatabaseLauncher.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/DatabaseLauncher.java
@@ -1,6 +1,7 @@
 package expo.modules.updates.launcher;
 
 import android.content.Context;
+import android.net.Uri;
 import android.util.Log;
 
 import org.json.JSONObject;
@@ -116,7 +117,7 @@ public class DatabaseLauncher implements Launcher {
         if (assetFile != null) {
           mLocalAssetFiles.put(
               asset,
-              assetFile.toURI().toString()
+              Uri.fromFile(assetFile).toString()
           );
         }
       }


### PR DESCRIPTION
# Why

Fixes https://linear.app/expo/issue/ENG-724/textures-not-loading-in-expo-gl-in-published-android-apps
Fixes https://github.com/expo/expo/issues/10906
Related https://github.com/expo/expo/issues/12101

# How

Local assets returned by `expo-updates` have just one slash in their file URIs. `expo-gl` requires at least two, see below 👇
https://github.com/expo/expo/blob/9c26fbc09d2ec8c7b48d5e7d79bf99631b7b84cc/packages/expo-gl-cpp/cpp/EXGLImageUtils.cpp#L126

`expo-updates` used `file.toURI()` which returns `java.net.URI` object that stringifies to `file:/...` URI, which is actually not correct on many platforms. Instead, we need to use `Uri.fromFile(file)` from `android.net.Uri` that returns `file:///...` URI.

# Test Plan

Creating GL texture from the asset works and it renders correctly (tried some GL examples in **published** NCL). Also tested against some other examples using assets.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).