### PR TITLE
[expo-updates][ios] fix module methods not rejecting when updates are disabled

### DIFF
--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/ABI41_0_0EXUpdatesModule.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/ABI41_0_0EXUpdatesModule.m
@@ -56,6 +56,10 @@ ABI41_0_0UM_EXPORT_METHOD_AS(reload,
                     reloadAsync:(ABI41_0_0UMPromiseResolveBlock)resolve
                          reject:(ABI41_0_0UMPromiseRejectBlock)reject)
 {
+  if (!_updatesService.config.isEnabled) {
+    reject(@"ERR_UPDATES_DISABLED", @"You cannot reload when expo-updates is not enabled.", nil);
+    return;
+  }
   if (!_updatesService.canRelaunch) {
     reject(@"ERR_UPDATES_DISABLED", @"The updates module controller has not been properly initialized. If you're in development mode, you cannot use this method. Otherwise, make sure you have called [[ABI41_0_0EXUpdatesAppController sharedInstance] start].", nil);
     return;
@@ -74,6 +78,10 @@ ABI41_0_0UM_EXPORT_METHOD_AS(checkForUpdateAsync,
                     checkForUpdateAsync:(ABI41_0_0UMPromiseResolveBlock)resolve
                                  reject:(ABI41_0_0UMPromiseRejectBlock)reject)
 {
+  if (!_updatesService.config.isEnabled) {
+    reject(@"ERR_UPDATES_DISABLED", @"You cannot check for updates when expo-updates is not enabled.", nil);
+    return;
+  }
   if (!_updatesService.isStarted) {
     reject(@"ERR_UPDATES_DISABLED", @"The updates module controller has not been properly initialized. If you're in development mode, you cannot check for updates. Otherwise, make sure you have called [[ABI41_0_0EXUpdatesAppController sharedInstance] start].", nil);
     return;
@@ -114,6 +122,10 @@ ABI41_0_0UM_EXPORT_METHOD_AS(fetchUpdateAsync,
                     fetchUpdateAsync:(ABI41_0_0UMPromiseResolveBlock)resolve
                               reject:(ABI41_0_0UMPromiseRejectBlock)reject)
 {
+  if (!_updatesService.config.isEnabled) {
+    reject(@"ERR_UPDATES_DISABLED", @"You cannot fetch updates when expo-updates is not enabled.", nil);
+    return;
+  }
   if (!_updatesService.isStarted) {
     reject(@"ERR_UPDATES_DISABLED", @"The updates module controller has not been properly initialized. If you're in development mode, you cannot fetch updates. Otherwise, make sure you have called [[ABI41_0_0EXUpdatesAppController sharedInstance] start].", nil);
     return;

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Fixed Updates module methods in Android Expo Go by refactoring FileDownloader to have mostly instance methods rather than static methods.
 - Fixed local assets URIs on Android to be compliant with File URI specification. Now file URI takes the form of `file:///*` instead of `file:/*`. ([#12428](https://github.com/expo/expo/pull/12428) by [@tsapeta](https://github.com/tsapeta))
+- Fixed Updates module methods not rejecting properly in iOS managed workflow apps where updates are disabled.
 
 ## 0.5.3 — 2021-03-30
 

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesModule.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesModule.m
@@ -56,6 +56,10 @@ UM_EXPORT_METHOD_AS(reload,
                     reloadAsync:(UMPromiseResolveBlock)resolve
                          reject:(UMPromiseRejectBlock)reject)
 {
+  if (!_updatesService.config.isEnabled) {
+    reject(@"ERR_UPDATES_DISABLED", @"You cannot reload when expo-updates is not enabled.", nil);
+    return;
+  }
   if (!_updatesService.canRelaunch) {
     reject(@"ERR_UPDATES_DISABLED", @"The updates module controller has not been properly initialized. If you're in development mode, you cannot use this method. Otherwise, make sure you have called [[EXUpdatesAppController sharedInstance] start].", nil);
     return;
@@ -74,6 +78,10 @@ UM_EXPORT_METHOD_AS(checkForUpdateAsync,
                     checkForUpdateAsync:(UMPromiseResolveBlock)resolve
                                  reject:(UMPromiseRejectBlock)reject)
 {
+  if (!_updatesService.config.isEnabled) {
+    reject(@"ERR_UPDATES_DISABLED", @"You cannot check for updates when expo-updates is not enabled.", nil);
+    return;
+  }
   if (!_updatesService.isStarted) {
     reject(@"ERR_UPDATES_DISABLED", @"The updates module controller has not been properly initialized. If you're in development mode, you cannot check for updates. Otherwise, make sure you have called [[EXUpdatesAppController sharedInstance] start].", nil);
     return;
@@ -114,6 +122,10 @@ UM_EXPORT_METHOD_AS(fetchUpdateAsync,
                     fetchUpdateAsync:(UMPromiseResolveBlock)resolve
                               reject:(UMPromiseRejectBlock)reject)
 {
+  if (!_updatesService.config.isEnabled) {
+    reject(@"ERR_UPDATES_DISABLED", @"You cannot fetch updates when expo-updates is not enabled.", nil);
+    return;
+  }
   if (!_updatesService.isStarted) {
     reject(@"ERR_UPDATES_DISABLED", @"The updates module controller has not been properly initialized. If you're in development mode, you cannot fetch updates. Otherwise, make sure you have called [[EXUpdatesAppController sharedInstance] start].", nil);
     return;


### PR DESCRIPTION
# Why

Noticed during SDK 41 updates QA that iOS managed standalone apps with `updates.enabled: false` don't have their module methods properly rejecting. (This matches the behavior in iOS bare apps and all Android apps.)

# How

- added a check and error message that's analogous to what we already have on the Android side
- backported to ABI41 code for completion's sake, even though this logic shouldn't ever be needed in the ABI41 code (only used for Expo Go, which never has updates disabled)

# Test Plan

- [ ] iOS managed standalone app with enabled: false -- methods reject --> (hard to test, will test once this PR is deployed to turtle)
- [x] iOS managed standalone app with enabled: true -- methods work
- [x] iOS bare standalone app with enabled: false -- methods reject
- [x] iOS bare standalone app with enabled: true -- methods work

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).

# Todos

- [ ] cherry-pick to sdk-41