### PR TITLE
[image-picker] Use android.net.Uri API to get a correct file URI

### DIFF
--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerUtils.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerUtils.kt
@@ -63,11 +63,3 @@ fun deduceExtension(type: String): String = when {
   }
   else -> ".jpg"
 }
-
-fun slashifyFilePath(path: String): String {
-  return if (!path.startsWith("file:///")) {
-    path.replace("file:/", "file:///")
-  } else {
-    path
-  }
-}

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/tasks/ImageResultTask.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/tasks/ImageResultTask.kt
@@ -11,7 +11,6 @@ import expo.modules.imagepicker.ImagePickerConstants.exifTags
 import expo.modules.imagepicker.exporters.ImageExporter
 import expo.modules.imagepicker.exporters.ImageExporter.Listener
 import expo.modules.imagepicker.fileproviders.FileProvider
-import expo.modules.imagepicker.slashifyFilePath
 import org.unimodules.core.Promise
 import java.io.ByteArrayOutputStream
 import java.io.IOException
@@ -32,7 +31,7 @@ open class ImageResultTask(private val promise: Promise,
       val imageExporterHandler = object : Listener {
         override fun onResult(out: ByteArrayOutputStream?, width: Int, height: Int) {
           val response = Bundle().apply {
-            putString("uri", slashifyFilePath(outputFile.toURI().toString()))
+            putString("uri", Uri.fromFile(outputFile).toString())
             putInt("width", width)
             putInt("height", height)
             putBoolean("cancelled", false)

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/tasks/VideoResultTask.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/tasks/VideoResultTask.kt
@@ -7,7 +7,6 @@ import android.os.AsyncTask
 import android.os.Bundle
 import expo.modules.imagepicker.ImagePickerConstants
 import expo.modules.imagepicker.fileproviders.FileProvider
-import expo.modules.imagepicker.slashifyFilePath
 import org.unimodules.core.Promise
 import java.io.File
 import java.io.FileOutputStream
@@ -26,7 +25,7 @@ class VideoResultTask(private val promise: Promise,
       val outputFile = fileProvider.generateFile()
       saveVideo(outputFile)
       val response = Bundle().apply {
-        putString("uri", slashifyFilePath(outputFile.toURI().toString()))
+        putString("uri", Uri.fromFile(outputFile).toString())
         putBoolean("cancelled", false)
         putString("type", "video")
         putInt("width", mediaMetadataRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_WIDTH)!!.toInt())


### PR DESCRIPTION
# Why

Fixes #12101 
Followup #12428 

# How

Used `android.net.Uri.fromFile` function instead of `java.net.URI` and custom `slashifyFilePath`.

# Test Plan

Confirmed the `uri` property in returned image and videos is correct and starts with `file:///`.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).