### PR TITLE
[docs] refactor TaskManager example, fix links

### DIFF
--- a/docs/pages/versions/unversioned/sdk/task-manager.md
+++ b/docs/pages/versions/unversioned/sdk/task-manager.md
@@ -4,6 +4,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-task-mana
 ---
 
 import PlatformsSection from '~/components/plugins/PlatformsSection';
+import SnackInline from '~/components/plugins/SnackInline';
 
 **`expo-task-manager`** provides an API that allows you to manage long-running tasks, in particular those tasks that can run while your app is in the background.
 Some features of this module are used by other modules under the hood. Here is a list of Expo modules that use TaskManager:
@@ -159,6 +160,8 @@ Returns a promise that resolves as soon as all tasks are completely unregistered
 
 ## Example
 
+<SnackInline dependencies={["expo-task-manager", "expo-location"]}>
+
 ```javascript
 import React from 'react';
 import { Text, TouchableOpacity } from 'react-native';
@@ -195,3 +198,5 @@ TaskManager.defineTask(LOCATION_TASK_NAME, ({ data, error }) => {
 
 export default PermissionsButton;
 ```
+
+</SnackInline>

--- a/docs/pages/versions/unversioned/sdk/task-manager.md
+++ b/docs/pages/versions/unversioned/sdk/task-manager.md
@@ -8,20 +8,20 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 **`expo-task-manager`** provides an API that allows you to manage long-running tasks, in particular those tasks that can run while your app is in the background.
 Some features of this module are used by other modules under the hood. Here is a list of Expo modules that use TaskManager:
 
-- [Location](location.md)
-- [BackgroundFetch](background-fetch.md)
+- [Location](location)
+- [BackgroundFetch](background-fetch)
 
 <PlatformsSection android emulator ios simulator />
 
 ## Installation
 
-For [managed](../../../introduction/managed-vs-bare.md#managed-workflow) apps, you'll need to run `expo install expo-task-manager`. To use it in [bare](../../../introduction/managed-vs-bare.md#bare-workflow) React Native app, follow its [installation instructions](https://github.com/expo/expo/tree/master/packages/expo-task-manager);
+For [managed](/introduction/managed-vs-bare#managed-workflow) apps, you'll need to run `expo install expo-task-manager`. To use it in [bare](/introduction/managed-vs-bare#bare-workflow) React Native app, follow its [installation instructions](https://github.com/expo/expo/tree/master/packages/expo-task-manager);
 
 ## Configuration for standalone apps
 
 ### Background modes on iOS
 
-`TaskManager` works out of the box in the Expo Go app on Android, but on iOS you'll need to test using [a custom Expo Go build](../../../guides/adhoc-builds.md).
+`TaskManager` works out of the box in the Expo Go app on Android, but on iOS you'll need to test using [a custom Expo Go build](/guides/adhoc-builds).
 
 Standalone apps need some extra configuration: on iOS, each background feature requires a special key in `UIBackgroundModes` array in your `Info.plist` file. In standalone apps this array is empty by default, so in order to use background features you will need to add appropriate keys to your `app.json` configuration.
 Here is an example of an `app.json` configuration that enables background location and background fetch:
@@ -167,24 +167,20 @@ import * as Location from 'expo-location';
 
 const LOCATION_TASK_NAME = 'background-location-task';
 
-export default class Component extends React.Component {
-  onPress = async () => {
-    const { status } = await Location.requestPermissionsAsync();
-    if (status === 'granted') {
-      await Location.startLocationUpdatesAsync(LOCATION_TASK_NAME, {
-        accuracy: Location.Accuracy.Balanced,
-      });
-    }
-  };
-
-  render() {
-    return (
-      <TouchableOpacity onPress={this.onPress}>
-        <Text>Enable background location</Text>
-      </TouchableOpacity>
-    );
+const requestPermissions = async () => {
+  const { status } = await Location.requestPermissionsAsync();
+  if (status === 'granted') {
+    await Location.startLocationUpdatesAsync(LOCATION_TASK_NAME, {
+      accuracy: Location.Accuracy.Balanced,
+    });
   }
-}
+};
+
+const PermissionsButton = () => (
+  <TouchableOpacity onPress={requestPermissions}>
+    <Text>Enable background location</Text>
+  </TouchableOpacity>
+);
 
 TaskManager.defineTask(LOCATION_TASK_NAME, ({ data, error }) => {
   if (error) {
@@ -196,4 +192,6 @@ TaskManager.defineTask(LOCATION_TASK_NAME, ({ data, error }) => {
     // do something with the locations captured in the background
   }
 });
+
+export default PermissionsButton;
 ```

--- a/docs/pages/versions/unversioned/sdk/task-manager.md
+++ b/docs/pages/versions/unversioned/sdk/task-manager.md
@@ -9,20 +9,20 @@ import SnackInline from '~/components/plugins/SnackInline';
 **`expo-task-manager`** provides an API that allows you to manage long-running tasks, in particular those tasks that can run while your app is in the background.
 Some features of this module are used by other modules under the hood. Here is a list of Expo modules that use TaskManager:
 
-- [Location](location)
-- [BackgroundFetch](background-fetch)
+- [Location](location.md)
+- [BackgroundFetch](background-fetch.md)
 
 <PlatformsSection android emulator ios simulator />
 
 ## Installation
 
-For [managed](/introduction/managed-vs-bare#managed-workflow) apps, you'll need to run `expo install expo-task-manager`. To use it in [bare](/introduction/managed-vs-bare#bare-workflow) React Native app, follow its [installation instructions](https://github.com/expo/expo/tree/master/packages/expo-task-manager);
+For [managed](/introduction/managed-vs-bare.md#managed-workflow) apps, you'll need to run `expo install expo-task-manager`. To use it in [bare](/introduction/managed-vs-bare.md#bare-workflow) React Native app, follow its [installation instructions](https://github.com/expo/expo/tree/master/packages/expo-task-manager);
 
 ## Configuration for standalone apps
 
 ### Background modes on iOS
 
-`TaskManager` works out of the box in the Expo Go app on Android, but on iOS you'll need to test using [a custom Expo Go build](/guides/adhoc-builds).
+`TaskManager` works out of the box in the Expo Go app on Android, but on iOS you'll need to test using [a custom Expo Go build](/guides/adhoc-builds.md).
 
 Standalone apps need some extra configuration: on iOS, each background feature requires a special key in `UIBackgroundModes` array in your `Info.plist` file. In standalone apps this array is empty by default, so in order to use background features you will need to add appropriate keys to your `app.json` configuration.
 Here is an example of an `app.json` configuration that enables background location and background fetch:


### PR DESCRIPTION
# Why

Functional components are recommended over class components, also few links throws the warnings during `yarn lint-links`.

# How

This PR includes the refactor of `TaskManager` example to the functional component (with wrap with `InlineSnack` tag) and few fix for the internal links used on the pages (using `/` at the beginning of link is enough to start from the root, there is no need to travers the path manually).

# Test Plan

Docs changes has been tested on `localhost`, all links are working correctly.

The example refactor has been tested on Snack:
* https://snack.expo.io/@simek/tactless-raspberries