### PR TITLE
[docs] ImagePicker remove unused imports

### DIFF
--- a/docs/pages/versions/unversioned/sdk/imagepicker.md
+++ b/docs/pages/versions/unversioned/sdk/imagepicker.md
@@ -24,13 +24,12 @@ In managed apps, the permissions to pick images, from camera ([`Permissions.CAME
 
 ## Usage
 
-<SnackInline label='Image Picker' dependencies={['expo-constants', 'expo-permissions', 'expo-image-picker']}>
+<SnackInline label='Image Picker' dependencies={['expo-image-picker']}>
 
 ```js
 import React, { useState, useEffect } from 'react';
 import { Button, Image, View, Platform } from 'react-native';
 import * as ImagePicker from 'expo-image-picker';
-import Constants from 'expo-constants';
 
 export default function ImagePickerExample() {
   const [image, setImage] = useState(null);

--- a/docs/pages/versions/v38.0.0/sdk/imagepicker.md
+++ b/docs/pages/versions/v38.0.0/sdk/imagepicker.md
@@ -20,13 +20,12 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 ## Usage
 
-<SnackInline label='Image Picker' dependencies={['expo-constants', 'expo-permissions', 'expo-image-picker']}>
+<SnackInline label='Image Picker' dependencies={['expo-permissions', 'expo-image-picker']}>
 
 ```js
 import * as React from 'react';
 import { Button, Image, View, Platform } from 'react-native';
 import * as ImagePicker from 'expo-image-picker';
-import Constants from 'expo-constants';
 import * as Permissions from 'expo-permissions';
 
 export default class ImagePickerExample extends React.Component {

--- a/docs/pages/versions/v39.0.0/sdk/imagepicker.md
+++ b/docs/pages/versions/v39.0.0/sdk/imagepicker.md
@@ -24,13 +24,12 @@ In managed apps, the permissions to pick images, from camera ([`Permissions.CAME
 
 ## Usage
 
-<SnackInline label='Image Picker' dependencies={['expo-constants', 'expo-permissions', 'expo-image-picker']}>
+<SnackInline label='Image Picker' dependencies={['expo-image-picker']}>
 
 ```js
 import React, { useState, useEffect } from 'react';
 import { Button, Image, View, Platform } from 'react-native';
 import * as ImagePicker from 'expo-image-picker';
-import Constants from 'expo-constants';
 
 export default function ImagePickerExample() {
   const [image, setImage] = useState(null);

--- a/docs/pages/versions/v40.0.0/sdk/imagepicker.md
+++ b/docs/pages/versions/v40.0.0/sdk/imagepicker.md
@@ -24,13 +24,12 @@ In managed apps, the permissions to pick images, from camera ([`Permissions.CAME
 
 ## Usage
 
-<SnackInline label='Image Picker' dependencies={['expo-constants', 'expo-permissions', 'expo-image-picker']}>
+<SnackInline label='Image Picker' dependencies={['expo-image-picker']}>
 
 ```js
 import React, { useState, useEffect } from 'react';
 import { Button, Image, View, Platform } from 'react-native';
 import * as ImagePicker from 'expo-image-picker';
-import Constants from 'expo-constants';
 
 export default function ImagePickerExample() {
   const [image, setImage] = useState(null);

--- a/docs/pages/versions/v41.0.0/sdk/imagepicker.md
+++ b/docs/pages/versions/v41.0.0/sdk/imagepicker.md
@@ -24,13 +24,12 @@ In managed apps, the permissions to pick images, from camera ([`Permissions.CAME
 
 ## Usage
 
-<SnackInline label='Image Picker' dependencies={['expo-constants', 'expo-permissions', 'expo-image-picker']}>
+<SnackInline label='Image Picker' dependencies={['expo-image-picker']}>
 
 ```js
 import React, { useState, useEffect } from 'react';
 import { Button, Image, View, Platform } from 'react-native';
 import * as ImagePicker from 'expo-image-picker';
-import Constants from 'expo-constants';
 
 export default function ImagePickerExample() {
   const [image, setImage] = useState(null);


### PR DESCRIPTION
# Why

Currently `ImagePicker` docs example includes no longer used import, same applies to the `InlineSnack` dependencies list.

# How

This PR removes the unused imports and Snack dependencies from `ImagePicker` docs starting from `unversioned` to SDK v38 version.

# Test Plan

The changes has been tested on `localhost`.
