### PR TITLE
[docs] APISection - fix array types detection in union

### DIFF
--- a/docs/components/plugins/api/APIDataTypes.ts
+++ b/docs/components/plugins/api/APIDataTypes.ts
@@ -41,6 +41,9 @@ export type TypeDefinitionTypesData = {
   type: string;
   name?: string;
   value?: string | null;
+  elementType?: {
+    name: string;
+  };
 };
 
 export type MethodParamData = {

--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -88,7 +88,11 @@ export const resolveTypeName = ({
     }
     return elementType.name + type;
   } else if (type === 'union' && types?.length) {
-    return types.map((t: TypeDefinitionTypesData) => `${t.name || t.value}`).join(' | ');
+    return types
+      .map((t: TypeDefinitionTypesData) =>
+        t.type === 'array' ? `${t.elementType?.name}[]` : `${t.name || t.value}`
+      )
+      .join(' | ');
   }
   return 'undefined';
 };


### PR DESCRIPTION
# Why

Currently when array type is used in type `union`, the `resolveTypeName` util returns `undefined`.

Refs ENG-825

# How

This PR includes small fix which adds an array type detection in the `union` types and resolve the `undefined` type issue.

# Test Plan

The changes has been tested on `localhost`, they should not affect pages currently using the `APISection` components. I have discovered the issue while working on `expo-linear-gradient` modules conversion.

CC: @bbarthec 