### PR TITLE
[docs] add Cache-Control header for fonts

### DIFF
--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -132,9 +132,6 @@ module.exports = {
   },
   async headers() {
     const cacheHeaders = [{ key: 'Cache-Control', value: 'public, max-age=15552000, immutable' }];
-    return [
-      { source: '/static/fonts/:font*', headers: cacheHeaders },
-      { source: '/static/libs/:lib*', headers: cacheHeaders },
-    ];
+    return [{ source: '/static/fonts/:font*', headers: cacheHeaders }];
   },
 };

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -130,4 +130,11 @@ module.exports = {
     });
     return pathMap;
   },
+  async headers() {
+    const cacheHeaders = [{ key: 'Cache-Control', value: 'public, max-age=15552000, immutable' }];
+    return [
+      { source: '/static/fonts/:font*', headers: cacheHeaders },
+      { source: '/static/libs/:lib*', headers: cacheHeaders },
+    ];
+  },
 };


### PR DESCRIPTION
# Why

We don't have an efficient `Cache-Control` header for fonts

<img width="734" alt="Screenshot 2021-04-08 at 12 48 08" src="https://user-images.githubusercontent.com/10477267/114014344-ce4b6380-9868-11eb-9d8f-c6a34d87de43.png">

# How

Added headers via Next.js

# Test Plan

Run Lighthouse or WebPageTest and see if they complain about the caching of fonts