### PR TITLE
[docs] load algolia css with Next.js

### DIFF
--- a/docs/pages/_app.tsx
+++ b/docs/pages/_app.tsx
@@ -8,6 +8,8 @@ import React from 'react';
 import { preprocessSentryError } from '~/common/sentry-utilities';
 import 'react-diff-view/style/index.css';
 import '@expo/styleguide/dist/expo-colors.css';
+import '../public/static/libs/algolia/algolia.css';
+import '../public/static/libs/algolia/algolia-mobile.css';
 
 Sentry.init({
   dsn: 'https://67e35a01698649d5aa33aaab61777851@sentry.io/1526800',

--- a/docs/pages/_document.tsx
+++ b/docs/pages/_document.tsx
@@ -50,8 +50,6 @@ export default class MyDocument extends Document<{ css?: string }> {
             ]}
           />
 
-          <link rel="stylesheet" href="/static/libs/algolia/algolia.css" />
-          <link rel="stylesheet" href="/static/libs/algolia/algolia-mobile.css" />
           <link
             rel="stylesheet"
             href="https://use.fontawesome.com/releases/v5.7.2/css/all.css"


### PR DESCRIPTION
# Why

Algolia CSS is not minified and is blocking the first page of the page:

<img width="743" alt="Screenshot 2021-04-08 at 13 27 39" src="https://user-images.githubusercontent.com/10477267/114019037-38b2d280-986e-11eb-901a-b60e862c8029.png">

"In production, all CSS files will be automatically concatenated into a single minified .css file." From https://nextjs.org/docs/basic-features/built-in-css-support

# How

Import Algolia CSS files from `_app`

# Test Plan

Algolia search bar should be the same