### PR TITLE
[location] Add support for user-initiated background tracking without background permission

### DIFF
--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Add support for user-initiated background tracking without background permission ([#12456](https://github.com/expo/expo/pull/12456) by [@bycedric](https://github.com/bycedric))
+
 ## 12.0.2 — 2021-03-29
 
 ### 🐛 Bug fixes

--- a/packages/expo-location/android/src/main/AndroidManifest.xml
+++ b/packages/expo-location/android/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
   <application>
     <service
       android:name=".services.LocationTaskService"
-      android:exported="false" />
+      android:exported="false"
+      android:foregroundServiceType="location" />
   </application>
 </manifest>

--- a/packages/expo-location/android/src/main/java/expo/modules/location/LocationModule.java
+++ b/packages/expo-location/android/src/main/java/expo/modules/location/LocationModule.java
@@ -463,12 +463,12 @@ public class LocationModule extends ExportedModule implements LifecycleEventList
 
   @ExpoMethod
   public void startLocationUpdatesAsync(String taskName, Map<String, Object> options, final Promise promise) {
-    boolean useForegroundService = LocationTaskConsumer.useForegroundService(options);
+    boolean shouldUseForegroundService = LocationTaskConsumer.shouldUseForegroundService(options);
 
     // There are two ways of starting this service.
     // 1. As a background location service, this requires the background location permission.
     // 2. As a user-initiated foreground service with notification, this does NOT require the background location permission.
-    if (!useForegroundService && isMissingBackgroundPermissions()) {
+    if (!shouldUseForegroundService && isMissingBackgroundPermissions()) {
       promise.reject(new LocationBackgroundUnauthorizedException());
       return;
     }

--- a/packages/expo-location/android/src/main/java/expo/modules/location/LocationModule.java
+++ b/packages/expo-location/android/src/main/java/expo/modules/location/LocationModule.java
@@ -483,11 +483,6 @@ public class LocationModule extends ExportedModule implements LifecycleEventList
 
   @ExpoMethod
   public void stopLocationUpdatesAsync(String taskName, final Promise promise) {
-    if (isMissingBackgroundPermissions()) {
-      promise.reject(new LocationBackgroundUnauthorizedException());
-      return;
-    }
-
     try {
       mTaskManager.unregisterTask(taskName, LocationTaskConsumer.class);
       promise.resolve(null);
@@ -498,11 +493,6 @@ public class LocationModule extends ExportedModule implements LifecycleEventList
 
   @ExpoMethod
   public void hasStartedLocationUpdatesAsync(String taskName, final Promise promise) {
-    if (isMissingBackgroundPermissions()) {
-      promise.reject(new LocationBackgroundUnauthorizedException());
-      return;
-    }
-
     promise.resolve(mTaskManager.taskHasConsumerOfClass(taskName, LocationTaskConsumer.class));
   }
 

--- a/packages/expo-location/android/src/main/java/expo/modules/location/LocationModule.java
+++ b/packages/expo-location/android/src/main/java/expo/modules/location/LocationModule.java
@@ -463,7 +463,12 @@ public class LocationModule extends ExportedModule implements LifecycleEventList
 
   @ExpoMethod
   public void startLocationUpdatesAsync(String taskName, Map<String, Object> options, final Promise promise) {
-    if (isMissingBackgroundPermissions()) {
+    boolean useForegroundService = LocationTaskConsumer.useForegroundService(options);
+
+    // There are two ways of starting this service.
+    // 1. As a background location service, this requires the background location permission.
+    // 2. As a user-initiated foreground service with notification, this does NOT require the background location permission.
+    if (!useForegroundService && isMissingBackgroundPermissions()) {
       promise.reject(new LocationBackgroundUnauthorizedException());
       return;
     }

--- a/packages/expo-location/android/src/main/java/expo/modules/location/taskConsumers/LocationTaskConsumer.java
+++ b/packages/expo-location/android/src/main/java/expo/modules/location/taskConsumers/LocationTaskConsumer.java
@@ -159,6 +159,10 @@ public class LocationTaskConsumer extends TaskConsumer implements TaskConsumerIn
     return true;
   }
 
+  public static boolean useForegroundService(Map<String, Object> options) {
+    return options.containsKey(FOREGROUND_SERVICE_KEY);
+  }
+
   //region private
 
   private void startLocationUpdates() {
@@ -199,7 +203,7 @@ public class LocationTaskConsumer extends TaskConsumer implements TaskConsumerIn
 
     ReadableArguments options = new MapArguments(mTask.getOptions());
     final Context context = getContext();
-    boolean useForegroundService = options.containsKey(FOREGROUND_SERVICE_KEY);
+    boolean useForegroundService = useForegroundService(mTask.getOptions());
 
     if (context == null) {
       Log.w(TAG, "Context not found when trying to start foreground service.");

--- a/packages/expo-location/android/src/main/java/expo/modules/location/taskConsumers/LocationTaskConsumer.java
+++ b/packages/expo-location/android/src/main/java/expo/modules/location/taskConsumers/LocationTaskConsumer.java
@@ -159,7 +159,7 @@ public class LocationTaskConsumer extends TaskConsumer implements TaskConsumerIn
     return true;
   }
 
-  public static boolean useForegroundService(Map<String, Object> options) {
+  public static boolean shouldUseForegroundService(Map<String, Object> options) {
     return options.containsKey(FOREGROUND_SERVICE_KEY);
   }
 
@@ -203,7 +203,7 @@ public class LocationTaskConsumer extends TaskConsumer implements TaskConsumerIn
 
     ReadableArguments options = new MapArguments(mTask.getOptions());
     final Context context = getContext();
-    boolean useForegroundService = useForegroundService(mTask.getOptions());
+    boolean useForegroundService = shouldUseForegroundService(mTask.getOptions());
 
     if (context == null) {
       Log.w(TAG, "Context not found when trying to start foreground service.");


### PR DESCRIPTION
# Why

Google has restricted the `ACCESS_BACKGROUND_LOCATION` permission and added an extra review when using this permission. We already made it an opt-in, but Google has split the location usage into [two main use cases](https://developer.android.com/training/location/permissions#types-of-access), as described below.

Right now, we only support the "background" and not the "foreground" use case. We already have the `foregroundService` option, so we should support it without any user-facing API changes. See [this issue thread for community-provided scenarios with the foreground use case](https://github.com/expo/expo/issues/11854).

1. **The ["foreground" use case](https://developer.android.com/training/location/permissions#foreground)**
> If your app contains a feature that shares or receives location information only once or for a defined amount of time, then that feature requires foreground location access. Some examples include the following:
>
> - Within a navigation app, a feature allows users to get turn-by-turn directions.
> - Within a messaging app, a feature allows users to share their current location with another user.
>
>The system considers your app to be using foreground location if a feature of your app accesses the device's current location in one of the following situations:
>
> - An activity that belongs to your app is visible.
> - Your app is running a foreground service. When a foreground service is running, the system raises user awareness by showing a persistent notification. Your app retains access when placed in the background, such as when the user presses the Home button on their device or turns their device's display off.

2. **The ["background" use case](https://developer.android.com/training/location/permissions#background)**
> An app requires background location access if a feature within the app constantly shares location with other users or uses the Geofencing API. Several examples include the following:
> 
> - Within a family location sharing app, a feature allows users to continuously share location with family members.
> - Within an IoT app, a feature allows users to configure their home devices such that they turn off when the user leaves their home and turn back on when the user returns home.
>
> The system considers your app to be using background location if it accesses the device's current location in any situation other than the ones described in the foreground location section.

# How

- **Added a public static `useForegroundService` method in `LocationTaskConsumer`**
This checks if `foregroundService` is defined in the options. By adding it here, we can reuse the constant from this class in the module.
- **Added a check in the `startLocationUpdatesAsync` to determine if we should validate the background permission**
This helps us not-blocking the "foreground" use case. It only blocks when `foregroundService` option and the background permission are NOT defined.
- **Removed additional background permission checks in the `stopLocationUpdatesAsync` and `hasStartedLocationUpdatesAsync`**
Because the validation is now dependent on the provided options, we can't validate this here. I think it still makes sense to allow developers to check/stop, even if they misconfigured it. It still won't start the background location without an error when misconfigured.


# Test Plan

- Clone my [example app "Office Marathon"](https://github.com/bycedric/office-marathon)
- Run `$ expo eject`
- Remove the `ACCESS_BACKGROUND_LOCATION` permission from manifest + `app.json`
- Add this PR manually to the local `expo-location`.

I tested this app with this change for the following scenarios:

Scenario | Android 30 | Android 29 | Android 28
--- | --- | --- | ---
App foregrounded | ✅ | ✅ | ✅
App foregrounded with locked screen | ✅ | ✅ | ✅
App backgrounded with locked screen | ✅ | ✅ | ✅

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).