### PR TITLE
[expo-updates][iOS] crash if EXUpdatesRequestHeaders is not a dictionary

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -5,7 +5,9 @@
 ### 🛠 Breaking changes
 
 - remove UPDATES_CONFIGURATION_USES_LEGACY_MANIFEST_KEY constant. ([#12181](https://github.com/expo/expo/pull/12181) by [@jkhales](https://github.com/jkhales))
-- Jonathan/e 499 remove EXUpdatesUsesLegacyManifest Plist constant (ios). ([#12249](https://github.com/expo/expo/pull/12249) by [@jkhales](https://github.com/jkhales))
+- remove EXUpdatesUsesLegacyManifest Plist constant (ios). ([#12249](https://github.com/expo/expo/pull/12249) by [@jkhales](https://github.com/jkhales))
+- crash if EXUpdatesRequestHeaders is not a dictionary (ios). ([#12457](https://github.com/expo/expo/pull/12457) by [@jkhales](https://github.com/jkhales))
+
 
 ### 🎉 New features
 

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.m
@@ -98,10 +98,18 @@ static NSString * const EXUpdatesConfigNeverString = @"NEVER";
   if (requestHeaders) {
     if(![requestHeaders isKindOfClass:[NSDictionary class]]){
       @throw [NSException exceptionWithName:NSInternalInconsistencyException
-                                     reason:[NSString stringWithFormat:@"PList key '%@' must be a Dictionary.",EXUpdatesConfigRequestHeadersKey]
+                                     reason:[NSString stringWithFormat:@"PList key '%@' must be a string valued Dictionary.", EXUpdatesConfigRequestHeadersKey]
                                    userInfo:@{}];
     }
     _requestHeaders = (NSDictionary *)requestHeaders;
+    
+    for (id key in _requestHeaders){
+      if (![_requestHeaders[key] isKindOfClass:[NSString class]]){
+        @throw [NSException exceptionWithName:NSInternalInconsistencyException
+                                       reason:[NSString stringWithFormat:@"PList key '%@' must be a string valued Dictionary.", EXUpdatesConfigRequestHeadersKey]
+                                     userInfo:@{}];
+      }
+    }
   }
 
   id releaseChannel = config[EXUpdatesConfigReleaseChannelKey];

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.m
@@ -95,7 +95,12 @@ static NSString * const EXUpdatesConfigNeverString = @"NEVER";
   }
 
   id requestHeaders = config[EXUpdatesConfigRequestHeadersKey];
-  if (requestHeaders && [requestHeaders isKindOfClass:[NSDictionary class]]) {
+  if (requestHeaders) {
+    if(![requestHeaders isKindOfClass:[NSDictionary class]]){
+      @throw [NSException exceptionWithName:NSInternalInconsistencyException
+                                     reason:[NSString stringWithFormat:@"PList key '%@' must be a Dictionary.",EXUpdatesConfigRequestHeadersKey]
+                                   userInfo:@{}];
+    }
     _requestHeaders = (NSDictionary *)requestHeaders;
   }
 


### PR DESCRIPTION
# Why

We want to match the behavior of the android client, which crashes if the. supplied string does not parse to a string valued dictionary.
https://github.com/expo/expo/pull/12229/files#diff-87624a95b81043171f46d6cf889b4429887ebe6eda9fa9a4be415a33de455915R47
# How

Throw a descriptive error.

# Test Plan
-  works with a correctly formatted dictionary
-  crashes if not given a dictionary
<img width="556" alt="Screen Shot 2021-04-08 at 7 01 48 AM" src="https://user-images.githubusercontent.com/1220444/114040890-e7d4b700-9838-11eb-926e-67e592d3f0e0.png">
-  crashes if given a dictionary, but not all values are strings
<img width="551" alt="Screen Shot 2021-04-08 at 7 19 52 AM" src="https://user-images.githubusercontent.com/1220444/114043426-20759000-983b-11eb-9634-5ca66a7f7c61.png">

