### PR TITLE
[docs] add Cache-Control header for Next.js static assets

### DIFF
--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -130,4 +130,8 @@ module.exports = {
     });
     return pathMap;
   },
+  async headers() {
+    const cacheHeaders = [{ key: 'Cache-Control', value: 'public, max-age=31536000, immutable' }];
+    return [{ source: '/_next/static/:static*', headers: cacheHeaders }];
+  },
 };


### PR DESCRIPTION
# Why

We don't set the `Cache-Control` header for Next.js static assets, i.e. `_next/static/*`. These URLs will change after each build so it's safe to cache them with `public, max-age=31536000, immutable`.

Lighthouse:
<img width="735" alt="Screenshot 2021-04-08 at 20 22 38" src="https://user-images.githubusercontent.com/10477267/114077512-2eadc580-98a8-11eb-8d9f-90d4dce729eb.png">

# How

Added headers via Next.js

# Test Plan

Run Lighthouse or WebPageTest and see if they complain about the caching of Next.js static assets