### PR TITLE
@tc/redirect moved pages

### DIFF
--- a/docs/pages/_error.tsx
+++ b/docs/pages/_error.tsx
@@ -333,5 +333,5 @@ const RENAMED_PAGES: Record<string, string> = {
   '/faq/clear-cache-windows/': '/troubleshooting/clear-cache-windows/',
   '/faq/clear-cache-macos-linux/': '/troubleshooting/clear-cache-macos-linux/',
   '/faq/application-has-not-been-registered/':
-   '/troubleshooting/application-has-not-been-registered/',
+    '/troubleshooting/application-has-not-been-registered/',
 };

--- a/docs/pages/_error.tsx
+++ b/docs/pages/_error.tsx
@@ -325,4 +325,12 @@ const RENAMED_PAGES: Record<string, string> = {
 
   // Archive unused pages
   '/guides/notification-channels/': '/archived/notification-channels/',
+  
+  // Migrated FAQ pages
+  '/faq/image-background/': '/ui-programming/image-background/',
+  '/faq/react-native-styling-buttons/': '/ui-programming/react-native-styling-buttons/',
+  '/faq/react-native-version-mismatch/': '/troubleshooting/react-native-version-mismatch/',
+  '/faq/clear-cache-windows/': '/troubleshooting/clear-cache-windows/',
+  '/faq/clear-cache-macos-linux/': '/troubleshooting/clear-cache-macos-linux/',
+  '/faq/application-has-not-been-registered/': '/troubleshooting/application-has-not-been-registered/',
 };

--- a/docs/pages/_error.tsx
+++ b/docs/pages/_error.tsx
@@ -325,12 +325,13 @@ const RENAMED_PAGES: Record<string, string> = {
 
   // Archive unused pages
   '/guides/notification-channels/': '/archived/notification-channels/',
-  
+
   // Migrated FAQ pages
   '/faq/image-background/': '/ui-programming/image-background/',
   '/faq/react-native-styling-buttons/': '/ui-programming/react-native-styling-buttons/',
   '/faq/react-native-version-mismatch/': '/troubleshooting/react-native-version-mismatch/',
   '/faq/clear-cache-windows/': '/troubleshooting/clear-cache-windows/',
   '/faq/clear-cache-macos-linux/': '/troubleshooting/clear-cache-macos-linux/',
-  '/faq/application-has-not-been-registered/': '/troubleshooting/application-has-not-been-registered/',
+  '/faq/application-has-not-been-registered/':
+   '/troubleshooting/application-has-not-been-registered/',
 };


### PR DESCRIPTION
# Why

We moved pages out of the faq section, but anyone who finds these pages from an internet search will not be redirected to the new location

# How

Set up redirects in pages/_error.tsx for all pages moved in https://github.com/expo/expo/commit/f9541aeeb0283b2ca4e7ccc1ebc293ccaa91da1c and
https://github.com/expo/expo/commit/a17539c96d066bd45a2613e0297ff617cae54303

This will ensure viewers are at least taken to a valid page, but will not return a 301

# Test Plan

Tested each page redirects to the intended location