### PR TITLE
[docs] move z-index post to ui-programming section

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -187,7 +187,11 @@ const sections = [
   },
   {
     name: 'UI Programming',
-    reference: ['Styling a React Native Button', "Setting a component's background image"],
+    reference: [
+      'Styling a React Native Button',
+      "Setting a component's background image",
+      'Stacking overlapping views with zIndex in Expo and React Native apps',
+    ],
   },
   {
     name: 'Assorted Guides',

--- a/docs/pages/ui-programming/z-index.md
+++ b/docs/pages/ui-programming/z-index.md
@@ -1,5 +1,6 @@
 ---
-title: 'Stacking overlapping views with zIndex in Expo and React Native apps'
+title: Stacking overlapping views with zIndex in Expo and React Native apps
+sidebar_title: Stacking views with zIndex
 ---
 
 import ImageSpotlight from '~/components/plugins/ImageSpotlight';


### PR DESCRIPTION
# Why

The new FAQ pages should now go under more specific guides sections.

# How

- moved MD file
- added a sidebar title
- added to constants file

# Test Plan

<img width="344" alt="Screen Shot 2021-04-08 at 20 05 31" src="https://user-images.githubusercontent.com/12488826/114110598-e2fa1c80-98a5-11eb-8f45-0fd599bcdc59.png">
