### PR TITLE
[docs] remove font awesome

### DIFF
--- a/docs/pages/_document.tsx
+++ b/docs/pages/_document.tsx
@@ -50,13 +50,6 @@ export default class MyDocument extends Document<{ css?: string }> {
             ]}
           />
 
-          <link
-            rel="stylesheet"
-            href="https://use.fontawesome.com/releases/v5.7.2/css/all.css"
-            integrity="sha384-fnmOCqbTlWIlj8LyTjo7mOUStjsKC4pOpQbqyi7RrhN7udi9RwhKkMHpvLbHG9Sr"
-            crossOrigin="anonymous"
-          />
-
           {getInitGoogleScriptTag({ id: 'UA-107832480-3' })}
           {getGoogleScriptTag()}
         </Head>


### PR DESCRIPTION
# Why

We don't use Font Awesome but we are loading it on every pages:

<img width="748" alt="Screenshot 2021-04-09 at 10 34 08" src="https://user-images.githubusercontent.com/10477267/114153182-59873080-991f-11eb-908e-9873a0c6366c.png">
<img width="732" alt="Screenshot 2021-04-09 at 10 34 22" src="https://user-images.githubusercontent.com/10477267/114153188-5b50f400-991f-11eb-8e45-5dcb24a94c28.png">

# How

- Checked if we use any `fas` class
- Removed Font Awesome

# Test Plan

- Make sure that the docs are working correctly