### PR TITLE
[docs] improve API props rendering, tweak to renderers types

### DIFF
--- a/docs/components/plugins/api/APISectionConstants.tsx
+++ b/docs/components/plugins/api/APISectionConstants.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { InlineCode } from '~/components/base/code';
 import { H2, H3Code } from '~/components/plugins/Headings';
 import { ConstantDefinitionData } from '~/components/plugins/api/APIDataTypes';
-import { CommentTextBlock, renderers } from '~/components/plugins/api/APISectionUtils';
+import { CommentTextBlock } from '~/components/plugins/api/APISectionUtils';
 
 export type APISectionConstantsProps = {
   data: ConstantDefinitionData[];
@@ -21,7 +21,7 @@ const renderConstant = (
         {name}
       </InlineCode>
     </H3Code>
-    <CommentTextBlock comment={comment} renderers={renderers} />
+    <CommentTextBlock comment={comment} />
   </div>
 );
 

--- a/docs/components/plugins/api/APISectionEnums.tsx
+++ b/docs/components/plugins/api/APISectionEnums.tsx
@@ -4,7 +4,7 @@ import { InlineCode } from '~/components/base/code';
 import { LI, UL } from '~/components/base/list';
 import { H2, H3Code } from '~/components/plugins/Headings';
 import { EnumDefinitionData, EnumValueData } from '~/components/plugins/api/APIDataTypes';
-import { CommentTextBlock, inlineRenderers } from '~/components/plugins/api/APISectionUtils';
+import { CommentTextBlock, mdInlineRenderers } from '~/components/plugins/api/APISectionUtils';
 
 export type APISectionEnumsProps = {
   data: EnumDefinitionData[];
@@ -21,7 +21,7 @@ const renderEnum = ({ name, children, comment }: EnumDefinitionData): JSX.Elemen
           <InlineCode>
             {name}.{enumValue.name}
           </InlineCode>
-          <CommentTextBlock comment={comment} renderers={inlineRenderers} withDash />
+          <CommentTextBlock comment={comment} renderers={mdInlineRenderers} withDash />
         </LI>
       ))}
     </UL>

--- a/docs/components/plugins/api/APISectionInterfaces.tsx
+++ b/docs/components/plugins/api/APISectionInterfaces.tsx
@@ -4,11 +4,7 @@ import { InlineCode } from '~/components/base/code';
 import { LI, UL } from '~/components/base/list';
 import { H2, H3Code } from '~/components/plugins/Headings';
 import { InterfaceDefinitionData, InterfaceValueData } from '~/components/plugins/api/APIDataTypes';
-import {
-  CommentTextBlock,
-  inlineRenderers,
-  renderers,
-} from '~/components/plugins/api/APISectionUtils';
+import { CommentTextBlock, mdInlineRenderers } from '~/components/plugins/api/APISectionUtils';
 
 export type APISectionInterfacesProps = {
   data: InterfaceDefinitionData[];
@@ -19,7 +15,7 @@ const renderInterface = ({ name, children, comment }: InterfaceDefinitionData): 
     <H3Code>
       <InlineCode>{name}</InlineCode>
     </H3Code>
-    <CommentTextBlock comment={comment} renderers={renderers} />
+    <CommentTextBlock comment={comment} />
     <UL>
       {children.map((interfaceValue: InterfaceValueData) => (
         <LI key={interfaceValue.name}>
@@ -27,7 +23,11 @@ const renderInterface = ({ name, children, comment }: InterfaceDefinitionData): 
             {name}.{interfaceValue.name}
             {interfaceValue.type.declaration?.signatures ? '()' : ''}
           </InlineCode>
-          <CommentTextBlock comment={interfaceValue.comment} renderers={inlineRenderers} withDash />
+          <CommentTextBlock
+            comment={interfaceValue.comment}
+            renderers={mdInlineRenderers}
+            withDash
+          />
         </LI>
       ))}
     </UL>

--- a/docs/components/plugins/api/APISectionMethods.tsx
+++ b/docs/components/plugins/api/APISectionMethods.tsx
@@ -7,7 +7,7 @@ import { H2, H3Code, H4 } from '~/components/plugins/Headings';
 import { MethodDefinitionData, MethodSignatureData } from '~/components/plugins/api/APIDataTypes';
 import {
   CommentTextBlock,
-  renderers,
+  mdRenderers,
   renderParam,
   resolveTypeName,
 } from '~/components/plugins/api/APISectionUtils';
@@ -33,7 +33,7 @@ const renderMethod = (
       </H3Code>
       {parameters ? <H4>Arguments</H4> : null}
       {parameters ? <UL>{parameters?.map(renderParam)}</UL> : null}
-      <CommentTextBlock comment={comment} renderers={renderers} />
+      <CommentTextBlock comment={comment} />
       {resolveTypeName(type) !== 'undefined' ? (
         <div>
           <H4>Returns</H4>
@@ -43,7 +43,7 @@ const renderMethod = (
             </LI>
           </UL>
           {comment?.returns ? (
-            <ReactMarkdown renderers={renderers}>{comment.returns}</ReactMarkdown>
+            <ReactMarkdown renderers={mdRenderers}>{comment.returns}</ReactMarkdown>
           ) : null}
         </div>
       ) : null}

--- a/docs/components/plugins/api/APISectionProps.tsx
+++ b/docs/components/plugins/api/APISectionProps.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { InlineCode } from '~/components/base/code';
 import { LI, UL } from '~/components/base/list';
-import { B } from '~/components/base/paragraph';
+import { P } from '~/components/base/paragraph';
 import { H2, H4 } from '~/components/plugins/Headings';
 import {
   CommentTagData,
@@ -12,11 +12,7 @@ import {
   TypeDeclarationData,
   TypePropertyData,
 } from '~/components/plugins/api/APIDataTypes';
-import {
-  CommentTextBlock,
-  inlineRenderers,
-  resolveTypeName,
-} from '~/components/plugins/api/APISectionUtils';
+import { CommentTextBlock, resolveTypeName } from '~/components/plugins/api/APISectionUtils';
 
 export type APISectionPropsProps = {
   data: PropsDefinitionData[];
@@ -64,11 +60,11 @@ const renderProps = (
   { name, type }: PropsDefinitionData,
   defaultValues: DefaultPropsDefinitionData
 ): JSX.Element => {
-  const props = type.types.filter((e: TypeDeclarationData) => e.declaration);
+  const propsDeclarations = type.types.filter((e: TypeDeclarationData) => e.declaration);
   return (
     <div key={`props-definition-${name}`}>
       <UL>
-        {props?.map((def: TypeDeclarationData) =>
+        {propsDeclarations?.map((def: TypeDeclarationData) =>
           def.declaration?.children.map((prop: PropData) =>
             renderProp(prop, extractDefaultPropValue(prop, defaultValues))
           )
@@ -81,16 +77,18 @@ const renderProps = (
 
 const renderProp = ({ comment, name, type }: PropData, defaultValue?: string) => (
   <LI key={`prop-entry-${name}`}>
-    <B>
-      {name} (<InlineCode>{resolveTypeName(type)}</InlineCode>)
-    </B>
-    <CommentTextBlock comment={comment} renderers={inlineRenderers} withDash />
-    {defaultValue && defaultValue !== UNKNOWN_VALUE ? (
-      <span>
-        {' Default: '}
-        <InlineCode>{defaultValue}</InlineCode>
-      </span>
-    ) : null}
+    <H4>{name}</H4>
+    <P>
+      Type: <InlineCode>{resolveTypeName(type)}</InlineCode>
+      {defaultValue && defaultValue !== UNKNOWN_VALUE ? (
+        <span>
+          &emsp;
+          {'Default: '}
+          <InlineCode>{defaultValue}</InlineCode>
+        </span>
+      ) : null}
+    </P>
+    <CommentTextBlock comment={comment} />
   </LI>
 );
 

--- a/docs/components/plugins/api/APISectionTypes.tsx
+++ b/docs/components/plugins/api/APISectionTypes.tsx
@@ -14,8 +14,8 @@ import {
   TypeValueData,
 } from '~/components/plugins/api/APIDataTypes';
 import {
-  inlineRenderers,
-  renderers,
+  mdInlineRenderers,
+  mdRenderers,
   resolveTypeName,
   renderParam,
   CommentTextBlock,
@@ -58,7 +58,7 @@ const renderTypePropertyRow = (typeProperty: TypePropertyData): JSX.Element => (
     </td>
     <td>
       {typeProperty?.comment?.shortText ? (
-        <ReactMarkdown renderers={inlineRenderers}>{typeProperty.comment.shortText}</ReactMarkdown>
+        <ReactMarkdown renderers={mdInlineRenderers}>{typeProperty.comment.shortText}</ReactMarkdown>
       ) : (
         '-'
       )}
@@ -77,7 +77,7 @@ const renderType = ({ name, comment, type }: TypeGeneralData): JSX.Element | und
             {type.declaration.signatures ? '()' : ''}
           </InlineCode>
         </H3Code>
-        <CommentTextBlock comment={comment} renderers={renderers} />
+        <CommentTextBlock comment={comment} />
         {type.declaration.children ? (
           <table>
             <thead>
@@ -109,7 +109,7 @@ const renderType = ({ name, comment, type }: TypeGeneralData): JSX.Element | und
           <H3Code>
             <InlineCode>{name}</InlineCode>
           </H3Code>
-          <ReactMarkdown renderers={renderers}>
+          <ReactMarkdown renderers={mdRenderers}>
             {defineLiteralType(validTypes) +
               `Acceptable values are: ${validTypes.map(decorateValue).join(', ')}.`}
           </ReactMarkdown>

--- a/docs/components/plugins/api/APISectionTypes.tsx
+++ b/docs/components/plugins/api/APISectionTypes.tsx
@@ -58,7 +58,9 @@ const renderTypePropertyRow = (typeProperty: TypePropertyData): JSX.Element => (
     </td>
     <td>
       {typeProperty?.comment?.shortText ? (
-        <ReactMarkdown renderers={mdInlineRenderers}>{typeProperty.comment.shortText}</ReactMarkdown>
+        <ReactMarkdown renderers={mdInlineRenderers}>
+          {typeProperty.comment.shortText}
+        </ReactMarkdown>
       ) : (
         '-'
       )}

--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -23,7 +23,9 @@ export enum TypeDocKind {
   TypeAlias = 4194304,
 }
 
-export const renderers: React.ComponentProps<typeof ReactMarkdown>['renderers'] = {
+export type MDRenderers = React.ComponentProps<typeof ReactMarkdown>['renderers'];
+
+export const mdRenderers: MDRenderers = {
   blockquote: ({ children }) => (
     <Quote>
       {React.Children.map(children, child =>
@@ -42,8 +44,8 @@ export const renderers: React.ComponentProps<typeof ReactMarkdown>['renderers'] 
   text: ({ value }) => (value ? <span>{value}</span> : null),
 };
 
-export const inlineRenderers: React.ComponentProps<typeof ReactMarkdown>['renderers'] = {
-  ...renderers,
+export const mdInlineRenderers: MDRenderers = {
+  ...mdRenderers,
   paragraph: ({ children }) => (children ? <span>{children}</span> : null),
 };
 
@@ -98,19 +100,19 @@ export const renderParam = ({ comment, name, type }: MethodParamData): JSX.Eleme
     <B>
       {name} (<InlineCode>{resolveTypeName(type)}</InlineCode>)
     </B>
-    <CommentTextBlock comment={comment} renderers={inlineRenderers} withDash />
+    <CommentTextBlock comment={comment} renderers={mdInlineRenderers} withDash />
   </LI>
 );
 
-type CommentTextBlockProps = {
+export type CommentTextBlockProps = {
   comment?: CommentData;
-  renderers?: React.ComponentProps<typeof ReactMarkdown>['renderers'];
+  renderers?: MDRenderers;
   withDash?: boolean;
 };
 
 export const CommentTextBlock: React.FC<CommentTextBlockProps> = ({
   comment,
-  renderers,
+  renderers = mdRenderers,
   withDash,
 }) => {
   const shortText = comment?.shortText?.trim().length ? (


### PR DESCRIPTION
# Why

Currently the readability of API Props section isn't the best. It was derived from original `BlurView` formatting, and doesn't looks that bad, but with more robust props definition, like in `LinearGradient`, the section doesn't look that good and content seems cramped.

Fixes: ENG-844

# How

This PR includes the formatting changes for the API Props section as well as the minor MD renderers types refactor and simplification.

# Test Plan

The changes has been tested on `localhost`.

# Preview

## Before
### `LinearGradient`
<img width="1130" alt="Screenshot 2021-04-09 at 18 14 48" src="https://user-images.githubusercontent.com/719641/114210872-46488500-9960-11eb-86c5-8f6df48c3f9c.png">

### `BlurView`
<img width="1130" alt="Screenshot 2021-04-09 at 18 28 03" src="https://user-images.githubusercontent.com/719641/114211781-590f8980-9961-11eb-8ed2-2b6dccd43857.png">

## After
### `LinearGradient`
<img width="1130" alt="Screenshot 2021-04-09 at 18 13 54" src="https://user-images.githubusercontent.com/719641/114210896-4cd6fc80-9960-11eb-9dba-386193a2f4aa.png">

### `BlurView`
<img width="1130" alt="Screenshot 2021-04-09 at 18 26 36" src="https://user-images.githubusercontent.com/719641/114211702-3f6e4200-9961-11eb-8d86-58a942a53974.png">

CC: @bbarthec @jonsamp 