### PR TITLE
[docs] fix some links reported by `lint-links` (batch no. 1)

### DIFF
--- a/docs/pages/versions/unversioned/index.md
+++ b/docs/pages/versions/unversioned/index.md
@@ -22,7 +22,7 @@ import * as Contacts from 'expo-contacts';
 import { Gyroscope } from 'expo-sensors';
 ```
 
-This allows you to write [`Contacts.getContactsAsync()`](sdk/contacts.md#getcontactsasync) and read the contacts from the device, read the gyroscope sensor to detect device movement, or render a Camera view and take photos.
+This allows you to write [`Contacts.getContactsAsync()`](sdk/contacts.md#contactsgetcontactsasynccontactquery) and read the contacts from the device, read the gyroscope sensor to detect device movement, or render a Camera view and take photos.
 
 ## These packages work in bare React Native apps too
 

--- a/docs/pages/versions/unversioned/sdk/amplitude.md
+++ b/docs/pages/versions/unversioned/sdk/amplitude.md
@@ -22,16 +22,6 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 import * as Amplitude from 'expo-analytics-amplitude';
 ```
 
-**[Methods](#methods)**
-
-- [`Amplitude.initializeAsync(apiKey)`](#amplitudeinitializeasyncapikey)
-- [`Amplitude.setUserIdAsync(userId)`](#amplitudesetuseridasyncuserid)
-- [`Amplitude.setUserPropertiesAsync(userProperties)`](#amplitudesetuserpropertiesasyncuserproperties)
-- [`Amplitude.clearUserPropertiesAsync()`](#amplitudeclearuserpropertiesasync)
-- [`Amplitude.logEventAsync(eventName)`](#amplitudelogeventasynceventname)
-- [`Amplitude.logEventWithPropertiesAsync(eventName, properties)`](#amplitudelogeventwithpropertiesasynceventname-properties)
-- [`Amplitude.setGroupAsync(groupType, groupNames)`](#amplitudesetgroupasyncgrouptype-groupnames)
-
 ## Methods
 
 ### `Amplitude.initializeAsync(apiKey)`
@@ -60,7 +50,7 @@ Set properties for the current user. See [here for details](https://amplitude.ze
 
 ### `Amplitude.clearUserPropertiesAsync()`
 
-Clear properties set by [`Amplitude.setUserProperties()`](#expoamplitudesetuserproperties 'Amplitude.setUserProperties').
+Clear properties set by [`Amplitude.setUserPropertiesAsync()`](#amplitudesetuserpropertiesasyncuserproperties).
 
 ### `Amplitude.logEventAsync(eventName)`
 

--- a/docs/pages/versions/unversioned/sdk/auth-session.md
+++ b/docs/pages/versions/unversioned/sdk/auth-session.md
@@ -116,7 +116,7 @@ const [request, response, promptAsync] = useAuthRequest({ ... }, { ... });
 Load an authorization request for a code. Returns a loaded request, a response, and a prompt method.
 When the prompt method completes then the response will be fulfilled.
 
-> 🚨 In order to close the popup window on web, you need to invoke `WebBrowser.maybeCompleteAuthSession()`. See the [Identity example](../../../guides/authentication.md#identity-4) for more info.
+> 🚨 In order to close the popup window on web, you need to invoke `WebBrowser.maybeCompleteAuthSession()`. See the [Identity example](../../../guides/authentication.md#identityserver-4) for more info.
 
 If an Implicit grant flow was used, you can pass the `response.params` to `TokenResponse.fromQueryParams()` to get a `TokenResponse` instance which you can use to easily refresh the token.
 

--- a/docs/pages/versions/unversioned/sdk/bar-code-scanner.md
+++ b/docs/pages/versions/unversioned/sdk/bar-code-scanner.md
@@ -159,7 +159,7 @@ Object of type `BarCodeSize` contains following keys:
 - **height (_number_)** -- The height value.
 - **width (_number_)** -- The width value.
 
-### `BarCodeBounds`
+### `BarCodeScanner.BarCodeBounds`
 
 Object of type `BarCodeBounds` contains following keys:
 

--- a/docs/pages/versions/unversioned/sdk/brightness.md
+++ b/docs/pages/versions/unversioned/sdk/brightness.md
@@ -113,7 +113,7 @@ A `Promise` that is resolved when the brightness has been successfully set.
 
 #### Error Codes
 
-- [`ERR_BRIGHTNESS`](#errbrightness)
+- [`ERR_BRIGHTNESS`](#err_brightness)
 
 ---
 
@@ -137,7 +137,7 @@ A `Promise` that resolves with `true` when the current activity is using the sys
 
 #### Error Codes
 
-- [`ERR_BRIGHTNESS`](#errbrightness)
+- [`ERR_BRIGHTNESS`](#err_brightness)
 
 ---
 
@@ -151,7 +151,7 @@ A `Promise` that is resolved with a number between 0 and 1, inclusive, represent
 
 #### Error Codes
 
-- [`ERR_BRIGHTNESS_SYSTEM`](#errbrightnesssystem)
+- [`ERR_BRIGHTNESS_SYSTEM`](#err_brightness_system)
 
 ---
 
@@ -171,8 +171,8 @@ A `Promise` that is resolved when the brightness has been successfully set.
 
 #### Error Codes
 
-- [`ERR_BRIGHTNESS_MODE`](#errbrightnessmode)
-- [`ERR_BRIGHTNESS_PERMISSIONS_DENIED`](#errbrightnesspermissionsdenied)
+- [`ERR_BRIGHTNESS_MODE`](#err_brightness_mode)
+- [`ERR_BRIGHTNESS_PERMISSIONS_DENIED`](#err_brightness_permissions_denied)
 
 ### `Brightness.getSystemBrightnessModeAsync()`
 
@@ -184,7 +184,7 @@ A `Promise` that is resolved with a [`BrightnessMode`](#brightnessbrightnessmode
 
 #### Error Codes
 
-- [`ERR_BRIGHTNESS_MODE`](#errbrightnessmode)
+- [`ERR_BRIGHTNESS_MODE`](#err_brightness_mode)
 
 ---
 
@@ -202,9 +202,9 @@ A `Promise` that is resolved when the brightness mode has been successfully set.
 
 #### Error Codes
 
-- [`ERR_INVALID_ARGUMENT`](#errinvalidargument)
-- [`ERR_BRIGHTNESS_MODE`](#errbrightnessmode)
-- [`ERR_BRIGHTNESS_PERMISSIONS_DENIED`](#errbrightnesspermissionsdenied)
+- [`ERR_INVALID_ARGUMENT`](#err_invalid_argument)
+- [`ERR_BRIGHTNESS_MODE`](#err_brightness_mode)
+- [`ERR_BRIGHTNESS_PERMISSIONS_DENIED`](#err_brightness_permissions_denied)
 
 ## Enum Types
 

--- a/docs/pages/versions/unversioned/sdk/camera.md
+++ b/docs/pages/versions/unversioned/sdk/camera.md
@@ -243,7 +243,7 @@ snap = async () => {
 
 Takes a picture and saves it to app's cache directory. Photos are rotated to match device's orientation (if **options.skipProcessing** flag is not enabled) and scaled to match the preview. Anyway on Android it is essential to set `ratio` prop to get a picture with correct dimensions.
 
-> **Note**: Make sure to wait for the [`onCameraReady`](./#oncameraready) callback before calling this method.
+> **Note**: Make sure to wait for the [`onCameraReady`](#oncameraready) callback before calling this method.
 
 #### Arguments
 
@@ -262,7 +262,7 @@ Takes a picture and saves it to app's cache directory. Photos are rotated to mat
 
 Returns a Promise that resolves to an object: `{ uri, width, height, exif, base64 }` where `uri` is a URI to the local image file on iOS, Android, and a base64 string on web (usable as the source for an `Image` element). The `width, height` properties specify the dimensions of the image. `base64` is included if the `base64` option was truthy, and is a string containing the JPEG data of the image in Base64--prepend that with `'data:image/jpg;base64,'` to get a data URI, which you can use as the source for an `Image` element for example. `exif` is included if the `exif` option was truthy, and is an object containing EXIF data for the image--the names of its properties are EXIF tags and their values are the values for those tags.
 
-On native platforms, the local image URI is temporary. Use [`FileSystem.copyAsync`](filesystem.md#expofilesystemcopyasyncoptions) to make a permanent copy of the image.
+On native platforms, the local image URI is temporary. Use [`FileSystem.copyAsync`](filesystem.md#filesystemcopyasyncoptions) to make a permanent copy of the image.
 
 On web, the `uri` is a base64 representation of the image because file system URLs are not supported in the browser. The `exif` data returned on web is a partial representation of the [`MediaTrackSettings`](https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackSettings), if available.
 

--- a/docs/pages/versions/unversioned/sdk/captureRef.md
+++ b/docs/pages/versions/unversioned/sdk/captureRef.md
@@ -8,7 +8,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 Given a view, `captureRef` will essentially screenshot that view and return an image for you. This is very useful for things like signature pads, where the user draws something and then you want to save an image from it.
 
-If you're interested in taking snapshots from the GLView, we recommend you use [GLView's takeSnapshotAsync](gl-view.md#takesnapshotasync) instead.
+If you're interested in taking snapshots from the GLView, we recommend you use [GLView's takeSnapshotAsync](gl-view.md#takesnapshotasyncoptions) instead.
 
 <PlatformsSection android emulator ios simulator  />
 

--- a/docs/pages/versions/unversioned/sdk/document-picker.md
+++ b/docs/pages/versions/unversioned/sdk/document-picker.md
@@ -45,7 +45,7 @@ import * as DocumentPicker from 'expo-document-picker';
 
 ### `DocumentPicker.getDocumentAsync(options)`
 
-Display the system UI for choosing a document. By default, the chosen file is copied to [the app's internal cache directory](filesystem.md#expofilesystemcachedirectory).
+Display the system UI for choosing a document. By default, the chosen file is copied to [the app's internal cache directory](filesystem.md#filesystemcachedirectory).
 
 > **Notes for Web:** The system UI can only be shown after user activation (e.g. a `Button` press). Therefore, calling `getDocumentAsync` in `componentDidMount`, for example, will **not** work as intended. The `cancel` event will not be returned in the browser due to platform restrictions and inconsistencies across browsers.
 
@@ -56,7 +56,7 @@ Display the system UI for choosing a document. By default, the chosen file is co
   A map of options:
 
   - **type (_string_)** -- The [MIME type](https://en.wikipedia.org/wiki/Media_type) of the documents that are available to be picked. Is also supports wildcards like `image/*` to choose any image. To allow any type of document you can use `*/*`. Defaults to `*/*`.
-  - **copyToCacheDirectory (_boolean_)** -- If `true`, the picked file is copied to [`FileSystem.CacheDirectory`](filesystem.md#expofilesystemcachedirectory), which allows other Expo APIs to read the file immediately. Defaults to `true`. This may impact performance for large files, so you should consider setting this to `false` if you expect users to pick particularly large files and your app does not need immediate read access.
+  - **copyToCacheDirectory (_boolean_)** -- If `true`, the picked file is copied to [`FileSystem.CacheDirectory`](filesystem.md#filesystemcachedirectory), which allows other Expo APIs to read the file immediately. Defaults to `true`. This may impact performance for large files, so you should consider setting this to `false` if you expect users to pick particularly large files and your app does not need immediate read access.
   - **multiple (_boolean_)** -- (Web Only) Allows multiple files to be selected from the system UI. Defaults to `false`.
 
 #### Returns

--- a/docs/pages/versions/v41.0.0/index.md
+++ b/docs/pages/versions/v41.0.0/index.md
@@ -22,7 +22,7 @@ import * as Contacts from 'expo-contacts';
 import { Gyroscope } from 'expo-sensors';
 ```
 
-This allows you to write [`Contacts.getContactsAsync()`](sdk/contacts.md#getcontactsasync) and read the contacts from the device, read the gyroscope sensor to detect device movement, or render a Camera view and take photos.
+This allows you to write [`Contacts.getContactsAsync()`](sdk/contacts.md#contactsgetcontactsasynccontactquery) and read the contacts from the device, read the gyroscope sensor to detect device movement, or render a Camera view and take photos.
 
 ## These packages work in bare React Native apps too
 

--- a/docs/pages/versions/v41.0.0/sdk/amplitude.md
+++ b/docs/pages/versions/v41.0.0/sdk/amplitude.md
@@ -22,16 +22,6 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 import * as Amplitude from 'expo-analytics-amplitude';
 ```
 
-**[Methods](#methods)**
-
-- [`Amplitude.initializeAsync(apiKey)`](#amplitudeinitializeasyncapikey)
-- [`Amplitude.setUserIdAsync(userId)`](#amplitudesetuseridasyncuserid)
-- [`Amplitude.setUserPropertiesAsync(userProperties)`](#amplitudesetuserpropertiesasyncuserproperties)
-- [`Amplitude.clearUserPropertiesAsync()`](#amplitudeclearuserpropertiesasync)
-- [`Amplitude.logEventAsync(eventName)`](#amplitudelogeventasynceventname)
-- [`Amplitude.logEventWithPropertiesAsync(eventName, properties)`](#amplitudelogeventwithpropertiesasynceventname-properties)
-- [`Amplitude.setGroupAsync(groupType, groupNames)`](#amplitudesetgroupasyncgrouptype-groupnames)
-
 ## Methods
 
 ### `Amplitude.initializeAsync(apiKey)`
@@ -60,7 +50,7 @@ Set properties for the current user. See [here for details](https://amplitude.ze
 
 ### `Amplitude.clearUserPropertiesAsync()`
 
-Clear properties set by [`Amplitude.setUserProperties()`](#expoamplitudesetuserproperties 'Amplitude.setUserProperties').
+Clear properties set by [`Amplitude.setUserPropertiesAsync()`](#amplitudesetuserpropertiesasyncuserproperties).
 
 ### `Amplitude.logEventAsync(eventName)`
 

--- a/docs/pages/versions/v41.0.0/sdk/auth-session.md
+++ b/docs/pages/versions/v41.0.0/sdk/auth-session.md
@@ -116,7 +116,7 @@ const [request, response, promptAsync] = useAuthRequest({ ... }, { ... });
 Load an authorization request for a code. Returns a loaded request, a response, and a prompt method.
 When the prompt method completes then the response will be fulfilled.
 
-> 🚨 In order to close the popup window on web, you need to invoke `WebBrowser.maybeCompleteAuthSession()`. See the [Identity example](../../../guides/authentication.md#identity-4) for more info.
+> 🚨 In order to close the popup window on web, you need to invoke `WebBrowser.maybeCompleteAuthSession()`. See the [Identity example](../../../guides/authentication.md#identityserver-4) for more info.
 
 If an Implicit grant flow was used, you can pass the `response.params` to `TokenResponse.fromQueryParams()` to get a `TokenResponse` instance which you can use to easily refresh the token.
 

--- a/docs/pages/versions/v41.0.0/sdk/bar-code-scanner.md
+++ b/docs/pages/versions/v41.0.0/sdk/bar-code-scanner.md
@@ -159,7 +159,7 @@ Object of type `BarCodeSize` contains following keys:
 - **height (_number_)** -- The height value.
 - **width (_number_)** -- The width value.
 
-### `BarCodeBounds`
+### `BarCodeScanner.BarCodeBounds`
 
 Object of type `BarCodeBounds` contains following keys:
 

--- a/docs/pages/versions/v41.0.0/sdk/brightness.md
+++ b/docs/pages/versions/v41.0.0/sdk/brightness.md
@@ -113,7 +113,7 @@ A `Promise` that is resolved when the brightness has been successfully set.
 
 #### Error Codes
 
-- [`ERR_BRIGHTNESS`](#errbrightness)
+- [`ERR_BRIGHTNESS`](#err_brightness)
 
 ---
 
@@ -137,7 +137,7 @@ A `Promise` that resolves with `true` when the current activity is using the sys
 
 #### Error Codes
 
-- [`ERR_BRIGHTNESS`](#errbrightness)
+- [`ERR_BRIGHTNESS`](#err_brightness)
 
 ---
 
@@ -151,7 +151,7 @@ A `Promise` that is resolved with a number between 0 and 1, inclusive, represent
 
 #### Error Codes
 
-- [`ERR_BRIGHTNESS_SYSTEM`](#errbrightnesssystem)
+- [`ERR_BRIGHTNESS_SYSTEM`](#err_brightness_system)
 
 ---
 
@@ -171,8 +171,8 @@ A `Promise` that is resolved when the brightness has been successfully set.
 
 #### Error Codes
 
-- [`ERR_BRIGHTNESS_MODE`](#errbrightnessmode)
-- [`ERR_BRIGHTNESS_PERMISSIONS_DENIED`](#errbrightnesspermissionsdenied)
+- [`ERR_BRIGHTNESS_MODE`](#err_brightness_mode)
+- [`ERR_BRIGHTNESS_PERMISSIONS_DENIED`](#err_brightness_permissions_denied)
 
 ### `Brightness.getSystemBrightnessModeAsync()`
 
@@ -184,7 +184,7 @@ A `Promise` that is resolved with a [`BrightnessMode`](#brightnessbrightnessmode
 
 #### Error Codes
 
-- [`ERR_BRIGHTNESS_MODE`](#errbrightnessmode)
+- [`ERR_BRIGHTNESS_MODE`](#err_brightness_mode)
 
 ---
 
@@ -202,9 +202,9 @@ A `Promise` that is resolved when the brightness mode has been successfully set.
 
 #### Error Codes
 
-- [`ERR_INVALID_ARGUMENT`](#errinvalidargument)
-- [`ERR_BRIGHTNESS_MODE`](#errbrightnessmode)
-- [`ERR_BRIGHTNESS_PERMISSIONS_DENIED`](#errbrightnesspermissionsdenied)
+- [`ERR_INVALID_ARGUMENT`](#err_invalid_argument)
+- [`ERR_BRIGHTNESS_MODE`](#err_brightness_mode)
+- [`ERR_BRIGHTNESS_PERMISSIONS_DENIED`](#err_brightness_permissions_denied)
 
 ## Enum Types
 

--- a/docs/pages/versions/v41.0.0/sdk/camera.md
+++ b/docs/pages/versions/v41.0.0/sdk/camera.md
@@ -243,7 +243,7 @@ snap = async () => {
 
 Takes a picture and saves it to app's cache directory. Photos are rotated to match device's orientation (if **options.skipProcessing** flag is not enabled) and scaled to match the preview. Anyway on Android it is essential to set `ratio` prop to get a picture with correct dimensions.
 
-> **Note**: Make sure to wait for the [`onCameraReady`](./#oncameraready) callback before calling this method.
+> **Note**: Make sure to wait for the [`onCameraReady`](#oncameraready) callback before calling this method.
 
 #### Arguments
 
@@ -262,7 +262,7 @@ Takes a picture and saves it to app's cache directory. Photos are rotated to mat
 
 Returns a Promise that resolves to an object: `{ uri, width, height, exif, base64 }` where `uri` is a URI to the local image file on iOS, Android, and a base64 string on web (usable as the source for an `Image` element). The `width, height` properties specify the dimensions of the image. `base64` is included if the `base64` option was truthy, and is a string containing the JPEG data of the image in Base64--prepend that with `'data:image/jpg;base64,'` to get a data URI, which you can use as the source for an `Image` element for example. `exif` is included if the `exif` option was truthy, and is an object containing EXIF data for the image--the names of its properties are EXIF tags and their values are the values for those tags.
 
-On native platforms, the local image URI is temporary. Use [`FileSystem.copyAsync`](filesystem.md#expofilesystemcopyasyncoptions) to make a permanent copy of the image.
+On native platforms, the local image URI is temporary. Use [`FileSystem.copyAsync`](filesystem.md#filesystemcopyasyncoptions) to make a permanent copy of the image.
 
 On web, the `uri` is a base64 representation of the image because file system URLs are not supported in the browser. The `exif` data returned on web is a partial representation of the [`MediaTrackSettings`](https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackSettings), if available.
 

--- a/docs/pages/versions/v41.0.0/sdk/captureRef.md
+++ b/docs/pages/versions/v41.0.0/sdk/captureRef.md
@@ -8,7 +8,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 Given a view, `captureRef` will essentially screenshot that view and return an image for you. This is very useful for things like signature pads, where the user draws something and then you want to save an image from it.
 
-If you're interested in taking snapshots from the GLView, we recommend you use [GLView's takeSnapshotAsync](gl-view.md#takesnapshotasync) instead.
+If you're interested in taking snapshots from the GLView, we recommend you use [GLView's takeSnapshotAsync](gl-view.md#takesnapshotasyncoptions) instead.
 
 <PlatformsSection android emulator ios simulator  />
 

--- a/docs/pages/versions/v41.0.0/sdk/document-picker.md
+++ b/docs/pages/versions/v41.0.0/sdk/document-picker.md
@@ -45,7 +45,7 @@ import * as DocumentPicker from 'expo-document-picker';
 
 ### `DocumentPicker.getDocumentAsync(options)`
 
-Display the system UI for choosing a document. By default, the chosen file is copied to [the app's internal cache directory](filesystem.md#expofilesystemcachedirectory).
+Display the system UI for choosing a document. By default, the chosen file is copied to [the app's internal cache directory](filesystem.md#filesystemcachedirectory).
 
 > **Notes for Web:** The system UI can only be shown after user activation (e.g. a `Button` press). Therefore, calling `getDocumentAsync` in `componentDidMount`, for example, will **not** work as intended. The `cancel` event will not be returned in the browser due to platform restrictions and inconsistencies across browsers.
 
@@ -56,7 +56,7 @@ Display the system UI for choosing a document. By default, the chosen file is co
   A map of options:
 
   - **type (_string_)** -- The [MIME type](https://en.wikipedia.org/wiki/Media_type) of the documents that are available to be picked. Is also supports wildcards like `image/*` to choose any image. To allow any type of document you can use `*/*`. Defaults to `*/*`.
-  - **copyToCacheDirectory (_boolean_)** -- If `true`, the picked file is copied to [`FileSystem.CacheDirectory`](filesystem.md#expofilesystemcachedirectory), which allows other Expo APIs to read the file immediately. Defaults to `true`. This may impact performance for large files, so you should consider setting this to `false` if you expect users to pick particularly large files and your app does not need immediate read access.
+  - **copyToCacheDirectory (_boolean_)** -- If `true`, the picked file is copied to [`FileSystem.CacheDirectory`](filesystem.md#filesystemcachedirectory), which allows other Expo APIs to read the file immediately. Defaults to `true`. This may impact performance for large files, so you should consider setting this to `false` if you expect users to pick particularly large files and your app does not need immediate read access.
   - **multiple (_boolean_)** -- (Web Only) Allows multiple files to be selected from the system UI. Defaults to `false`.
 
 #### Returns


### PR DESCRIPTION
# Why

Currently `lint-links` reports a bunch invalid links. Not all reports are correct, but still there are a bunch of not properly working links in the docs.

# How

This PR corrects the some of the links reported by `lint-links` and removes methods ToC in page content from `Amplitude` docs (it's no longer needed, since the right sidebar exist).

The changes are applied to `unversioned` and SDK v41 docs.

# Test Plan

Links and changes have been tested on `localhost`.
