### PR TITLE
[docs] Wrap `window.localStorage` access in try-catch

### DIFF
--- a/docs/common/sentry-utilities.ts
+++ b/docs/common/sentry-utilities.ts
@@ -45,16 +45,16 @@ export function preprocessSentryError(event: Event) {
 }
 
 // https://gist.github.com/paulirish/5558557
-function isLocalStorageAvailable() {
-  if (!window.localStorage) {
-    return false;
-  }
-
+function isLocalStorageAvailable(): boolean {
   try {
+    if (!window.localStorage) {
+      return false;
+    }
+
     localStorage.setItem('localStorage:test', 'value');
     localStorage.removeItem('localStorage:test');
     return true;
-  } catch (e) {
+  } catch {
     return false;
   }
 }


### PR DESCRIPTION
Why: The error "Failed to read the 'localStorage' property from 'Window': Access is denied for this document" is thrown sometimes. This can be due to accessing localStorage when a user agent is configured to disallow storing data.

From the error we can't see whether this is due to a third-party script or our own code, but let's wrap the localStorage access in our own code with try-catch to be extra sure.

Test Plan:

Ran the function in a browser:
```
function isLocalStorageAvailable() {
  try {
    if (!window.localStorage) {
      return false;
    }

    localStorage.setItem('localStorage:test', 'value');
    localStorage.removeItem('localStorage:test');
    return true;
  } catch {
    return false;
  }
}

isLocalStorageAvailable()
```

Got back `true`.
