### PR TITLE
[rfc][docs] Filter out errors from browser extensions

### DIFF
--- a/docs/common/sentry-utilities.ts
+++ b/docs/common/sentry-utilities.ts
@@ -7,6 +7,10 @@ import { Event } from '@sentry/types';
 
 // These exact error messages may be different depending on the browser!
 const ERRORS_TO_DISCARD = [
+  // Filter out errors from extensions
+  'chrome-extension://',
+  'moz-extension://',
+  'safari-extension://',
   // This error only appears in Safari
   "undefined is not an object (evaluating 'window.__pad.performLoop')",
 ];


### PR DESCRIPTION
Browser extensions are a common source of errors and can break pages. There is a tradeoff between learning about errors for which we're not responsible and learning about all errors that are seen in the wild.

This is an RFC PR that proposes filtering out errors known to be from extensions. In practice we have not seen these errors affect a large percentage of site visitors. However, over 20% of the total unique types of errors are from extensions: https://sentry.io/organizations/expoio/issues/?project=1526800&query=is%3Aunresolved+extension&statsPeriod=14d
