### PR TITLE
[android][updates] Fix uncaught exception in parseDateString

### DIFF
--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesUtils.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesUtils.java
@@ -221,7 +221,7 @@ public class UpdatesUtils {
     try {
       DateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSX", Locale.US);
       return formatter.parse(dateString);
-    } catch (ParseException e) {
+    } catch (ParseException | IllegalArgumentException e) {
       Log.e(TAG, "Failed to parse date string on first try: " + dateString, e);
       // some old Android versions don't support the 'X' character in SimpleDateFormat, so try without this
       DateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US);


### PR DESCRIPTION
# Why
The SimpleDateFormat constructor throws an IllegalArgumentException when passed a pattern string with unrecognized pattern characters.  The UpdateUtils parseDateString method recognizes that SimpleDateFormat does not recognize the 'X' pattern on Android API levels < 24, yet does not catch IllegalArgumentExceptions.

# How
Add IllegalArgumentException to the exception types caught within the parseDateString method.

# Test Plan
The instrumented tests for parseDateString now pass for all Android API 21+.

# Checklist
- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).