### PR TITLE
[expo-dev-launcher] Fix `DevelopmentClientController.getInstance() was called before the module was initialized`

### DIFF
--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/modules/DevLauncherDevMenuExtensions.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/modules/DevLauncherDevMenuExtensions.kt
@@ -23,7 +23,7 @@ class DevLauncherDevMenuExtensions(
 
   override fun devMenuItems(settings: DevMenuExtensionSettingsInterface): DevMenuItemsContainerInterface =
     DevMenuItemsContainer.export {
-      if (instance.mode == DevLauncherController.Mode.LAUNCHER) {
+      if (!DevLauncherController.wasInitialized() || instance.mode == DevLauncherController.Mode.LAUNCHER) {       
         return@export
       }
 

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/modules/DevLauncherDevMenuExtensions.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/modules/DevLauncherDevMenuExtensions.kt
@@ -23,7 +23,7 @@ class DevLauncherDevMenuExtensions(
 
   override fun devMenuItems(settings: DevMenuExtensionSettingsInterface): DevMenuItemsContainerInterface =
     DevMenuItemsContainer.export {
-      if (!DevLauncherController.wasInitialized() || instance.mode == DevLauncherController.Mode.LAUNCHER) {       
+      if (!DevLauncherController.wasInitialized() || instance.mode == DevLauncherController.Mode.LAUNCHER) {
         return@export
       }
 


### PR DESCRIPTION
# Why

Fixes `DevelopmentClientController.getInstance() was called before the module was initialized`
