### PR TITLE
[docs] API generation: add event subscriptions section, fix function type in arguments table

### DIFF
--- a/docs/components/plugins/APISection.tsx
+++ b/docs/components/plugins/APISection.tsx
@@ -35,7 +35,14 @@ const renderAPI = (
   try {
     const data = require(`~/public/static/data/${version}/${packageName}.json`).children;
 
-    const methods = filterDataByKind(data, TypeDocKind.Function);
+    const methods = filterDataByKind(
+      data,
+      TypeDocKind.Function,
+      entry => !entry.name.includes('Listener')
+    );
+    const eventSubscriptions = filterDataByKind(data, TypeDocKind.Function, entry =>
+      entry.name.includes('Listener')
+    );
     const types = filterDataByKind(
       data,
       TypeDocKind.TypeAlias,
@@ -60,6 +67,11 @@ const renderAPI = (
       <>
         <APISectionConstants data={constants} apiName={apiName} />
         <APISectionMethods data={methods} apiName={apiName} />
+        <APISectionMethods
+          data={eventSubscriptions}
+          apiName={apiName}
+          header="Event Subscriptions"
+        />
         <APISectionProps data={props} defaultProps={defaultProps} />
         <APISectionTypes data={types} />
         <APISectionInterfaces data={interfaces} />

--- a/docs/components/plugins/APISection.tsx
+++ b/docs/components/plugins/APISection.tsx
@@ -40,8 +40,10 @@ const renderAPI = (
       TypeDocKind.Function,
       entry => !entry.name.includes('Listener')
     );
-    const eventSubscriptions = filterDataByKind(data, TypeDocKind.Function, entry =>
-      entry.name.includes('Listener')
+    const eventSubscriptions = filterDataByKind(
+      data,
+      TypeDocKind.Function,
+      entry => entry.name.includes('Listener')
     );
     const types = filterDataByKind(
       data,

--- a/docs/components/plugins/APISection.tsx
+++ b/docs/components/plugins/APISection.tsx
@@ -40,10 +40,8 @@ const renderAPI = (
       TypeDocKind.Function,
       entry => !entry.name.includes('Listener')
     );
-    const eventSubscriptions = filterDataByKind(
-      data,
-      TypeDocKind.Function,
-      entry => entry.name.includes('Listener')
+    const eventSubscriptions = filterDataByKind(data, TypeDocKind.Function, entry =>
+      entry.name.includes('Listener')
     );
     const types = filterDataByKind(
       data,

--- a/docs/components/plugins/api/APIDataTypes.ts
+++ b/docs/components/plugins/api/APIDataTypes.ts
@@ -35,6 +35,7 @@ export type TypeDefinitionData = {
     name: string;
   };
   typeArguments?: TypeDefinitionData[];
+  declaration?: TypeDeclarationContentData;
 };
 
 export type TypeDefinitionTypesData = {
@@ -138,11 +139,13 @@ export type TypeGeneralData = {
   kind: TypeDocKind;
 };
 
+export type TypeDeclarationContentData = {
+  signatures: TypeSignaturesData[];
+  children: TypePropertyData[];
+};
+
 export type TypeDeclarationData = {
-  declaration?: {
-    signatures: TypeSignaturesData[];
-    children: TypePropertyData[];
-  };
+  declaration?: TypeDeclarationContentData;
   type: string;
   types: TypeValueData[];
   typeArguments?: TypeDefinitionData[];
@@ -150,6 +153,7 @@ export type TypeDeclarationData = {
 
 export type TypeSignaturesData = {
   parameters: MethodParamData[];
+  type: TypeDefinitionData;
 };
 
 export type TypePropertyData = {

--- a/docs/components/plugins/api/APISectionMethods.tsx
+++ b/docs/components/plugins/api/APISectionMethods.tsx
@@ -15,6 +15,7 @@ import {
 export type APISectionMethodsProps = {
   data: MethodDefinitionData[];
   apiName?: string;
+  header?: string;
 };
 
 const renderMethod = (
@@ -51,10 +52,14 @@ const renderMethod = (
     </div>
   ));
 
-const APISectionMethods: React.FC<APISectionMethodsProps> = ({ data, apiName }) =>
+const APISectionMethods: React.FC<APISectionMethodsProps> = ({
+  data,
+  apiName,
+  header = 'Methods',
+}) =>
   data?.length ? (
     <>
-      <H2 key="methods-header">Methods</H2>
+      <H2 key="methods-header">{header}</H2>
       {data.map((method, index) => renderMethod(method, index, data.length, apiName))}
     </>
   ) : null;

--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -96,7 +96,7 @@ export const resolveTypeName = ({
         t.type === 'array' ? `${t.elementType?.name}[]` : `${t.name || t.value}`
       )
       .join(' | ');
-  } else if (declaration && declaration.signatures) {
+  } else if (declaration?.signatures) {
     return `() => ${resolveTypeName(declaration.signatures[0].type)}`;
   }
   return 'undefined';

--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -55,6 +55,7 @@ export const resolveTypeName = ({
   type,
   types,
   typeArguments,
+  declaration,
 }: TypeDefinitionData): string | JSX.Element => {
   if (name) {
     if (type === 'reference') {
@@ -95,6 +96,8 @@ export const resolveTypeName = ({
         t.type === 'array' ? `${t.elementType?.name}[]` : `${t.name || t.value}`
       )
       .join(' | ');
+  } else if (declaration && declaration.signatures) {
+    return `() => ${resolveTypeName(declaration.signatures[0].type)}`;
   }
   return 'undefined';
 };


### PR DESCRIPTION
# Why

During work on `Battery` module API generation I have stumble upon two issues:
* functions in typed record are not correctly recognized and appears as `undefined` in the type table
* "Event Subscription" section is missing - methods are not split into usual methods and listeners

Refs: ENG-857

# How

This PR includes the fixes for the both cases described above. 

The changes should not affect other modules generated so far, but it looks like `PedometerListener` interface type probably should be converted to unimodules `Subscription`.

# Test Plan

Changes have been tested on `localhost` using `expo-battery` extracted data and modules already using auto-generated `APISection` component.

CC @bbarthec