### PR TITLE
[docs] Add ProGuard rule to updates install guide

### DIFF
--- a/docs/pages/bare/installing-updates.md
+++ b/docs/pages/bare/installing-updates.md
@@ -109,6 +109,20 @@ If you have `expo-splash-screen` installed in your bare workflow project, you'll
 
 <ConfigurationDiff source="/static/diffs/expo-updates-android.diff" />
 
+<details><summary><h4>💡 Are you using ProGuard?</h4></summary>
+<p>
+
+If you have ProGuard enabled, you'll need to add the following rule to `proguard-rules.pro`:
+
+```
+-keepclassmembers class com.facebook.react.ReactInstanceManager {
+    private final com.facebook.react.bridge.JSBundleLoader mBundleLoader;
+}
+```
+
+</p>
+</details>
+
 ## Usage
 
 See more information about usage in the [expo-updates README](https://github.com/expo/expo/blob/master/packages/expo-updates/README.md).


### PR DESCRIPTION
# Why
Reloading an updated bundle from JS fails on Android with ProGuard enabled. The exception thrown in a freshly initialized bare Expo project with ProGuard enabled follows. The UpdatesController accesses the mBundleLoader field using reflection, which ProGuard obfuscates.
```
Could not reset JSBundleLoader in ReactInstanceManager
java.lang.NoSuchFieldException: No field mBundleLoader in class Lcom/facebook/react/q;
	at java.lang.Class.getDeclaredField(Native Method)
	at e.a.m.f$b.a(Unknown Source:48)
	at e.a.m.m.b.a(Unknown Source:187)
	at e.a.m.f.a(Unknown Source:50)
	at e.a.m.k.a(Unknown Source:6)
	at e.a.m.h.reload(Unknown Source:23)
	at java.lang.reflect.Method.invoke(Native Method)
	at i.b.a.c.a(Unknown Source:67)
	at org.unimodules.adapters.react.NativeModulesProxy.callMethod(Unknown Source:75)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.facebook.react.bridge.JavaMethodWrapper.invoke(Unknown Source:149)
	at com.facebook.react.bridge.JavaModuleWrapper.invoke(Unknown Source:21)
	at com.facebook.react.bridge.queue.NativeRunnable.run(Native Method)
	at android.os.Handler.handleCallback(Handler.java:938)
	at android.os.Handler.dispatchMessage(Handler.java:99)
	at com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage(Unknown Source:0)
	at android.os.Looper.loop(Looper.java:223)
	at com.facebook.react.bridge.queue.MessageQueueThreadImpl$4.run(Unknown Source:37)
	at java.lang.Thread.run(Thread.java:923)
```

# How
Projects using ProGuard can use a rule to prevent the mBundleLoader field from being renamed. Document this requirement in the updates installation guide.

# Test Plan
All tests passed on localhost. In a fresh bare Expo project with ProGuard enabled, the above exception is thrown.  After adding the documented ProGuard rule, reloading an update from JS is successful.