### PR TITLE
[expo-updates] improve message when createManifest script errors on metro config

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Fixed local assets URIs on Android to be compliant with File URI specification. Now file URI takes the form of `file:///*` instead of `file:/*`. ([#12428](https://github.com/expo/expo/pull/12428) by [@tsapeta](https://github.com/tsapeta))
 - Fixed Updates module methods not rejecting properly in iOS managed workflow apps where updates are disabled.
 - Fixed uncaught exception in parseDateString on Android API 21-23. ([#12492](https://github.com/expo/expo/pull/12492) by [mrs2296](https://github.com/mrs2296))
+- Improved error message in createManifest script when there is an error getting the project's metro config.
 
 ## 0.5.3 — 2021-03-30
 

--- a/packages/expo-updates/scripts/createManifest.js
+++ b/packages/expo-updates/scripts/createManifest.js
@@ -78,7 +78,7 @@ const filterPlatformAssetScales = require('./filterPlatformAssetScales');
   fs.writeFileSync(path.join(destinationDir, 'app.manifest'), JSON.stringify(manifest));
 })().catch(e => {
   // Wrap in regex to make it easier for log parsers (like `@expo/xcpretty`) to find this error.
-  e.message = `@build-script-error-begin\n${e.message}\n@build-script-error-end\n`
+  e.message = `@build-script-error-begin\n${e.message}\n@build-script-error-end\n`;
   console.error(e);
   process.exit(1);
 });
@@ -91,7 +91,7 @@ function getAndroidResourceFolderName(asset) {
 
 // copied from react-native/Libraries/Image/assetPathUtils.js
 function getAndroidResourceIdentifier(asset) {
-  var folderPath = getBasePath(asset);
+  const folderPath = getBasePath(asset);
   return (folderPath + '/' + asset.name)
     .toLowerCase()
     .replace(/\//g, '_') // Encode folder structure in file name
@@ -107,7 +107,7 @@ function getIosDestinationDir(asset) {
 
 // copied from react-native/Libraries/Image/assetPathUtils.js
 function getBasePath(asset) {
-  var basePath = asset.httpServerLocation;
+  let basePath = asset.httpServerLocation;
   if (basePath[0] === '/') {
     basePath = basePath.substr(1);
   }

--- a/packages/expo-updates/scripts/createManifest.js
+++ b/packages/expo-updates/scripts/createManifest.js
@@ -27,7 +27,7 @@ const filterPlatformAssetScales = require('./filterPlatformAssetScales');
     let message = `Error loading Metro config and Expo app config: ${e.message}\n\nMake sure your project is configured properly and your app.json / app.config.js is valid.`;
     if (process.env.EAS_BUILD) {
       message +=
-        '\nIf you are using environment variables in app.config.js, verify that you have set them in your EAS Build profile configuration.';
+        '\nIf you are using environment variables in app.config.js, verify that you have set them in your EAS Build profile configuration or secrets.';
     }
     throw new Error(message);
   }


### PR DESCRIPTION
# Why

An EAS build user encountered an opaque error caused by missing environment variables that were used in their app.config.js. We can improve the error messaging around this.

# How

Isolate the call that loads the metro config (and, transitively, the app config) and throw a separate, helpful error there.

# Test Plan

Sanity checked a simple bare app locally to ensure it built and ran and the script didn't encounter any unexpected errors.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).