### PR TITLE
[updates] Start converting untyped manifest JSON objects into well-specified classes

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - Convert manifest definitions and tests to kotlin. ([#12479](https://github.com/expo/expo/pull/12479) by [@wschurman](https://github.com/wschurman))
+- Start converting untyped manifest JSON objects into well-specified classes. ([#12506](https://github.com/expo/expo/pull/12506) by [@wschurman](https://github.com/wschurman))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/Manifest.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/Manifest.kt
@@ -2,13 +2,14 @@ package expo.modules.updates.manifest
 
 import expo.modules.updates.db.entity.AssetEntity
 import expo.modules.updates.db.entity.UpdateEntity
+import expo.modules.updates.manifest.raw.RawManifest
 import org.json.JSONObject
 import java.util.*
 
 interface Manifest {
   val updateEntity: UpdateEntity?
   val assetEntityList: List<AssetEntity?>?
-  val rawManifestJson: JSONObject?
+  val rawManifestJson: RawManifest
   val serverDefinedHeaders: JSONObject?
   val manifestFilters: JSONObject?
   val isDevelopmentMode: Boolean

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ManifestFactory.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ManifestFactory.kt
@@ -1,6 +1,9 @@
 package expo.modules.updates.manifest
 
 import expo.modules.updates.UpdatesConfiguration
+import expo.modules.updates.manifest.raw.BareRawManifest
+import expo.modules.updates.manifest.raw.LegacyRawManifest
+import expo.modules.updates.manifest.raw.NewRawManifest
 import org.json.JSONException
 import org.json.JSONObject
 
@@ -8,14 +11,14 @@ object ManifestFactory {
     private val TAG = ManifestFactory::class.java.simpleName
 
     @Throws(Exception::class)
-    fun getManifest(manifestJson: JSONObject?, httpResponse: ManifestResponse, configuration: UpdatesConfiguration?): Manifest {
+    fun getManifest(manifestJson: JSONObject, httpResponse: ManifestResponse, configuration: UpdatesConfiguration?): Manifest {
         val expoProtocolVersion = httpResponse.header("expo-protocol-version", null)
         return when {
             expoProtocolVersion == null -> {
-                LegacyManifest.fromLegacyManifestJson(manifestJson!!, configuration!!)
+                LegacyManifest.fromLegacyRawManifest(manifestJson as LegacyRawManifest, configuration!!)
             }
             Integer.valueOf(expoProtocolVersion) == 0 -> {
-                NewManifest.fromManifestJson(manifestJson!!, httpResponse, configuration!!)
+                NewManifest.fromRawManifest(manifestJson as NewRawManifest, httpResponse, configuration!!)
             }
             else -> {
                 throw Exception("Unsupported expo-protocol-version: $expoProtocolVersion")
@@ -26,9 +29,9 @@ object ManifestFactory {
     @Throws(JSONException::class)
     fun getEmbeddedManifest(manifestJson: JSONObject, configuration: UpdatesConfiguration?): Manifest {
         return if (manifestJson.has("releaseId")) {
-            LegacyManifest.fromLegacyManifestJson(manifestJson, configuration!!)
+            LegacyManifest.fromLegacyRawManifest(manifestJson as LegacyRawManifest, configuration!!)
         } else {
-            BareManifest.fromManifestJson(manifestJson, configuration!!)
+            BareManifest.fromManifestJson(manifestJson as BareRawManifest, configuration!!)
         }
     }
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/raw/BareRawManifest.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/raw/BareRawManifest.kt
@@ -1,0 +1,8 @@
+package expo.modules.updates.manifest.raw
+
+import org.json.JSONException
+
+class BareRawManifest(json: String) : BaseLegacyRawManifest(json) {
+  @Throws(JSONException::class)
+  fun getCommitTime(): Long = getLong("commitTime")
+}

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/raw/BaseLegacyRawManifest.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/raw/BaseLegacyRawManifest.kt
@@ -1,0 +1,9 @@
+package expo.modules.updates.manifest.raw
+
+import org.json.JSONArray
+import org.json.JSONObject
+
+abstract class BaseLegacyRawManifest(json: String) : RawManifest(json) {
+  fun getMetadata(): JSONObject? = optJSONObject("metadata")
+  override fun getAssets(): JSONArray? = optJSONArray("assets")
+}

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/raw/LegacyRawManifest.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/raw/LegacyRawManifest.kt
@@ -1,0 +1,48 @@
+package expo.modules.updates.manifest.raw
+
+import org.json.JSONArray
+import org.json.JSONException
+
+class LegacyRawManifest(json: String) : BaseLegacyRawManifest(json) {
+  @Throws(JSONException::class)
+  fun getBundleKey(): String? = if (has("bundleKey")) {
+    getString("bundleKey")
+  } else {
+    null
+  }
+
+  @Throws(JSONException::class)
+  fun getReleaseId(): String = getString("releaseId")
+
+  @Throws(JSONException::class)
+  fun getCommitTime(): String = getString("commitTime")
+
+  fun getRuntimeVersion(): Any? = opt("runtimeVersion")
+
+  @Throws(JSONException::class)
+  fun getSDKVersion(): String = getString("sdkVersion")
+
+  @Throws(JSONException::class)
+  fun getBundleURL(): String = getString("bundleUrl")
+
+  @Throws(JSONException::class)
+  fun getBundledAssets(): JSONArray? = optJSONArray("bundledAssets")
+
+  fun isDevelopmentMode(): Boolean {
+    return try {
+      has("developer") &&
+          has("packagerOpts") &&
+          getJSONObject("packagerOpts").optBoolean("dev", false)
+    } catch (e: JSONException) {
+      false
+    }
+  }
+
+  fun isUsingDeveloperTool(): Boolean {
+    return try {
+      has("developer") && getJSONObject("developer").has("tool")
+    } catch (e: JSONException) {
+      false
+    }
+  }
+}

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/raw/NewRawManifest.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/raw/NewRawManifest.kt
@@ -1,0 +1,18 @@
+package expo.modules.updates.manifest.raw
+
+import org.json.JSONArray
+import org.json.JSONException
+import org.json.JSONObject
+
+class NewRawManifest(json: String) : RawManifest(json) {
+  @Throws(JSONException::class)
+  fun getRuntimeVersion(): String = getString("runtimeVersion")
+
+  @Throws(JSONException::class)
+  fun getLaunchAsset(): JSONObject = getJSONObject("launchAsset")
+
+  override fun getAssets(): JSONArray? = optJSONArray("assets")
+
+  @Throws(JSONException::class)
+  fun getCreatedAt(): String = getString("createdAt")
+}

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/raw/RawManifest.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/raw/RawManifest.kt
@@ -1,0 +1,12 @@
+package expo.modules.updates.manifest.raw
+
+import org.json.JSONArray
+import org.json.JSONException
+import org.json.JSONObject
+
+abstract class RawManifest(json: String) : JSONObject(json) {
+  @Throws(JSONException::class)
+  fun getID(): String = getString("id")
+
+  abstract fun getAssets(): JSONArray?
+}


### PR DESCRIPTION
# Why

Part 2 of https://github.com/expo/expo/pull/12479.

This PR adds new `Raw*Manifest` classes which for now extend JSONObject so that we can migrate the JSON field getter calls gradually. The idea is to eventually have these not extend JSONObject and instead compose it.

# How

This PR starts the process by converting some internal-ish calls to use getters on the classes instead of raw JSON accessors. If all went to plan, it is a no-op in terms of functionality and is equivalent to the prior implementation.

The `Raw*Manifest` hierarchy is as follows:
- `RawManifest` common base class of all raw manifests. This is where all the methods used outside of the manifests will need to be specified (possibly abstract for diverging implementations).
- `LegacyRawManifest` raw legacy manifest, extends `RawManifest`
- `NewRawManifest` raw new manifest, extends `RawManifest`
- `BareRawManifest` raw bare manifest, extends `RawManifest`

# Test Plan

Wait for CI tests.