### PR TITLE
[CI] Run CI on all PRs including stacked PRs

### DIFF
--- a/.github/workflows/ad-hoc-client-shell-app-ios.yml
+++ b/.github/workflows/ad-hoc-client-shell-app-ios.yml
@@ -9,7 +9,6 @@ on:
   schedule:
     - cron: '20 5 * * 2,4,6'
   pull_request:
-    branches: [master]
     paths:
       - .github/workflows/ad-hoc-client-shell-app-ios.yml
       - .ruby-version

--- a/.github/workflows/android-instrumentation-tests.yml
+++ b/.github/workflows/android-instrumentation-tests.yml
@@ -11,7 +11,6 @@ on:
       - 'tools/**'
       - yarn.lock
   pull_request:
-    branches: [master]
     paths:
       - .github/workflows/android-instrumentation-tests.yml
       - 'fastlane/**'

--- a/.github/workflows/android-unit-tests.yml
+++ b/.github/workflows/android-unit-tests.yml
@@ -11,7 +11,6 @@ on:
       - 'tools/**'
       - yarn.lock
   pull_request:
-    branches: [master]
     paths:
       - .github/workflows/android-unit-tests.yml
       - 'android/**'

--- a/.github/workflows/client-android.yml
+++ b/.github/workflows/client-android.yml
@@ -10,7 +10,6 @@ on:
         description: 'type "release-google-play" to confirm release to Google Play'
         required: false
   pull_request:
-    branches: [master]
     paths:
       - .github/workflows/client-android.yml
       - secrets/**

--- a/.github/workflows/client-ios.yml
+++ b/.github/workflows/client-ios.yml
@@ -7,7 +7,6 @@ on:
         description: 'type "release-simulator" to confirm upload'
         required: false
   pull_request:
-    branches: [master]
     paths:
       - .github/workflows/client-ios.yml
       - ios/**

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -3,7 +3,6 @@ name: Danger
 on:
   workflow_dispatch: {}
   pull_request:
-    branches: [master]
     paths:
       - .github/workflows/danger.yml
       - packages/**

--- a/.github/workflows/development-client.yml
+++ b/.github/workflows/development-client.yml
@@ -3,7 +3,6 @@ name: Development Client
 on:
   workflow_dispatch: {}
   pull_request:
-    branches: [master]
     paths:
       - .github/workflows/development-client.yml
       - packages/expo-dev-*/**

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,6 @@ on:
       - 'docs/**'
       - '.github/workflows/docs.yml'
   pull_request:
-    branches: [master]
     paths:
       - 'docs/**'
       - '.github/workflows/docs.yml'

--- a/.github/workflows/expotools.yml
+++ b/.github/workflows/expotools.yml
@@ -8,7 +8,6 @@ on:
       - .github/workflows/expotools.yml
       - tools/**
   pull_request:
-    branches: [master]
     paths:
       - .github/workflows/expotools.yml
       - tools/**

--- a/.github/workflows/home.yml
+++ b/.github/workflows/home.yml
@@ -3,7 +3,6 @@ name: Home app
 on:
   workflow_dispatch: {}
   pull_request:
-    branches: [master]
     paths:
       - .github/workflows/home.yml
       - home/**

--- a/.github/workflows/ios-unit-tests.yml
+++ b/.github/workflows/ios-unit-tests.yml
@@ -3,7 +3,6 @@ name: iOS Unit Tests
 on:
   workflow_dispatch: {}
   pull_request:
-    branches: [master]
     paths:
       - .github/workflows/ios-unit-tests.yml
       - ios/**

--- a/.github/workflows/native-component-list.yml
+++ b/.github/workflows/native-component-list.yml
@@ -3,7 +3,6 @@ name: Native Component List app
 on:
   workflow_dispatch: {}
   pull_request:
-    branches: [master]
     paths:
       - .github/workflows/native-component-list.yml
       - apps/native-component-list/**

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -15,7 +15,6 @@ on:
       - packages/**
       - yarn.lock
   pull_request:
-    branches: [master]
     paths:
       - .github/workflows/sdk.yml
       - tools/**

--- a/.github/workflows/shell-app-ios.yml
+++ b/.github/workflows/shell-app-ios.yml
@@ -9,7 +9,6 @@ on:
   schedule:
     - cron: '20 5 * * 2,4,6'
   pull_request:
-    branches: [master]
     paths:
       - .github/workflows/shell-app-ios.yml
       - .ruby-version

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -11,7 +11,6 @@ on:
       - packages/**
       - yarn.lock
   pull_request:
-    branches: [master]
     paths:
       - .github/workflows/test-suite.yml
       - apps/bare-expo/**


### PR DESCRIPTION
# Why

Running CI on stacked PRs is critical to the stacked PR workflow for the following reasons:
- Truly lets stacked PRs be reviewed in isolation. Without the context of a green CI run, the reviewer and author must now do extra work to prove that basic sanity checks pass.
- Automatic bisection of issues in the stack. The same way that bisect can be used for finding an issue in git history, having CI run on all PRs easily identifies where a fix must be applied.
- Let's the author offload rebase sanity checking to CI, which for stacked PRs is a necessity. Otherwise at each step of a rebase the author must check sanity in order to figure out where something went wrong.

Unless I'm missing something, running GH Actions in public repos is free, so there shouldn't be a downside unless they have max parallelism and we run a lot of jobs. Even in this case though, I think the benefits outweigh the costs.

From https://docs.github.com/en/github/setting-up-and-managing-billing-and-payments-on-github/about-billing-for-github-actions#about-billing-for-github-actions

> GitHub Actions usage is free for public repositories.

# How

Change workflow configs to run on all PRs.

# Test Plan

Wait for CI.