### PR TITLE
Mac/Linux examples for environment vars

### DIFF
--- a/docs/pages/guides/environment-variables.md
+++ b/docs/pages/guides/environment-variables.md
@@ -13,12 +13,12 @@ If you have installed the [`expo-constants`](../versions/latest/sdk/constants.md
 
 > While the `.env` property can be useful during development, this property is not available when running `expo publish` or `expo build`. It should not be used for feature flagging or other app-specific configuration because of this.
 
-For example, if you are developing on Mac/Linux, create and source a file that looks like this:
+For example, if you are developing on macOS or Linux, create and source a file that looks like this:
 
 ```
 export EXPO_HELLO=world
-export EXPO_MY_SECRET_VAR=secret
-export REACT_NATIVE_SECRET=anotherSecret
+export EXPO_MY_CONFIGURATION_OPTION=my-configuration-value
+export REACT_NATIVE_EXAMPLE_CONFIGURATION=another-configuration-value
 ```
 
 ### Using app manifest `.extra`

--- a/docs/pages/guides/environment-variables.md
+++ b/docs/pages/guides/environment-variables.md
@@ -13,6 +13,14 @@ If you have installed the [`expo-constants`](../versions/latest/sdk/constants.md
 
 > While the `.env` property can be useful during development, this property is not available when running `expo publish` or `expo build`. It should not be used for feature flagging or other app-specific configuration because of this.
 
+For example, if you are developing on Mac/Linux, create and source a file that looks like this:
+
+```
+export EXPO_HELLO=world
+export EXPO_MY_SECRET_VAR=secret
+export REACT_NATIVE_SECRET=anotherSecret
+```
+
 ### Using app manifest `.extra`
 
 In the app manifest, there is also a `.extra` property. Unlike `.env`, this property is included when you publish your project with `expo publish` or `expo build`. The contents of the `.extra` property are taken from your app manifest. By default, this does not add any environment variables, but we can make that happen with the [dynamic app manifest configuration](../workflow/configuration.md#app-config).


### PR DESCRIPTION
# Why

Adding examples for env vars

# How

I tested various ways of environment variables until it worked.  The current documentation is vague.

# Test Plan

No tests necessary.

# Checklist

- [x ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).