### PR TITLE
[dev-client][docs] Add compatibility section

### DIFF
--- a/docs/pages/clients/compatibility.md
+++ b/docs/pages/clients/compatibility.md
@@ -1,0 +1,21 @@
+---
+title: Compatibility
+---
+
+Expo Development Client contains three packages, which have to be compatible with each other. To check which versions are compatible, check the tables below.
+
+## expo-dev-menu
+
+| expo-dev-menu-interface | expo-dev-menu     |
+| ----------------------- | ----------------- |
+| `0.2.0`                 | `0.4.X`           |
+| `0.1.2`                 | `0.3.X`           |
+| `0.1.0` - `0.1.1`       | `0.1.X` - `0.2.X` |
+
+## expo-dev-launcher
+
+| expo-dev-menu-interface | expo-dev-launcher |
+| ----------------------- | ----------------- |
+| `0.2.0`                 | `0.3.X`           |
+| `0.1.2`                 | `0.2.X`           |
+| `0.1.0` - `0.1.1`       | `0.1.X`           |

--- a/docs/pages/clients/introduction.md
+++ b/docs/pages/clients/introduction.md
@@ -16,4 +16,5 @@ import ImageSpotlight from '~/components/plugins/ImageSpotlight'
 - [Distributing to Android Devices](distribution-for-android.md) - Get your Development Client running on an Android device
 - [Distributing to iOS Devices](distribution-for-ios.md) - Get your Development Client running on an iOS device
 - [Troubleshooting](troubleshooting.md) - Solutions for common issues you might encounter with the Development Client
-- [Extending the Dev Menu](extending-the-dev-menu.md) Make the Development Client your own by extending the menu with new functionality
+- [Extending the Dev Menu](extending-the-dev-menu.md) - Make the Development Client your own by extending the menu with new functionality
+- [Compatibility](compatibility.md) - Check compatibly versions


### PR DESCRIPTION
# Why

Adds the compatibility section.

# Test Plan

-  run `yarn dev` in `docs` 