### PR TITLE
[native-component-list] fix Pedometer type

### DIFF
--- a/apps/native-component-list/src/screens/PedometerScreen.tsx
+++ b/apps/native-component-list/src/screens/PedometerScreen.tsx
@@ -8,7 +8,7 @@ import { useResolvedValue } from '../utilities/useResolvedValue';
 
 function usePedometer({ isActive }: { isActive: boolean }): Pedometer.PedometerResult | null {
   const [data, setData] = React.useState<Pedometer.PedometerResult | null>(null);
-  const listener = React.useRef<Pedometer.PedometerListener | null>(null);
+  const listener = React.useRef<Pedometer.Subscription | null>(null);
 
   React.useEffect(() => {
     return () => {


### PR DESCRIPTION
# Why

It looks like after changing the returned type of `Pedometer.watchStepCount`, `native-component-list` app fail to compile.

CI: https://github.com/expo/expo/runs/2335279276

Refs: #12497

> Sorry about that! I'm still learning the project structure and what depends on what internally :wink:

# How

This PR updates the `watchStepCount` return type to `Subscription`, which should fix the CI.

# Test Plan

`yarn tsc` executed in `native-component-list` directory do not fail locally.

CC @wschurman @bbarthec 
