### PR TITLE
[updates] Add support for loading new manifests in Expo Go

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/ExponentManifest.java
+++ b/android/expoview/src/main/java/host/exp/exponent/ExponentManifest.java
@@ -139,6 +139,8 @@ public class ExponentManifest {
   public static final String DEEP_LINK_SEPARATOR = "--";
   public static final String DEEP_LINK_SEPARATOR_WITH_SLASH = "--/";
   public static final String QUERY_PARAM_KEY_RELEASE_CHANNEL = "release-channel";
+  public static final String QUERY_PARAM_KEY_EXPO_UPDATES_RUNTIME_VERSION = "runtime-version";
+  public static final String QUERY_PARAM_KEY_EXPO_UPDATES_CHANNEL_NAME = "channel-name";
 
   private static final int MAX_BITMAP_SIZE = 192;
   private static final String REDIRECT_SNIPPET = "exp.host/--/to-exp/";

--- a/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.java
+++ b/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.java
@@ -35,6 +35,7 @@ import org.json.JSONObject;
 
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -614,8 +615,8 @@ public class Kernel extends KernelInterface {
         }
       }
 
-      // ignore any query param other than the release-channel
-      // as these will cause the client to treat this as a different experience
+      // transfer the release-channel param to the built URL as this will cause the client to treat
+      // this as a different experience
       String releaseChannel = uri.getQueryParameter(ExponentManifest.QUERY_PARAM_KEY_RELEASE_CHANNEL);
       builder.query(null);
       if (releaseChannel != null) {
@@ -628,6 +629,17 @@ public class Kernel extends KernelInterface {
           releaseChannel = releaseChannel.substring(0, releaseChannelDeepLinkPosition);
         }
         builder.appendQueryParameter(ExponentManifest.QUERY_PARAM_KEY_RELEASE_CHANNEL, releaseChannel);
+      }
+
+      // transfer the expo-updates query params: runtime-version, channel-name
+      List<String> expoUpdatesQueryParameters = Arrays.asList(
+              ExponentManifest.QUERY_PARAM_KEY_EXPO_UPDATES_RUNTIME_VERSION,
+              ExponentManifest.QUERY_PARAM_KEY_EXPO_UPDATES_CHANNEL_NAME);
+      for (String queryParameter : expoUpdatesQueryParameters) {
+        String queryParameterValue = uri.getQueryParameter(queryParameter);
+        if (queryParameterValue != null) {
+          builder.appendQueryParameter(queryParameter, queryParameterValue);
+        }
       }
 
       // ignore fragments as well (e.g. those added by auth-session)

--- a/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.java
+++ b/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.java
@@ -615,8 +615,8 @@ public class Kernel extends KernelInterface {
         }
       }
 
-      // transfer the release-channel param to the built URL as this will cause the client to treat
-      // this as a different experience
+      // transfer the release-channel param to the built URL as this will cause Expo Go to treat
+      // this as a different project
       String releaseChannel = uri.getQueryParameter(ExponentManifest.QUERY_PARAM_KEY_RELEASE_CHANNEL);
       builder.query(null);
       if (releaseChannel != null) {

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Convert manifest definitions and tests to kotlin. ([#12479](https://github.com/expo/expo/pull/12479) by [@wschurman](https://github.com/wschurman))
 - Start converting untyped manifest JSON objects into well-specified classes. ([#12506](https://github.com/expo/expo/pull/12506) by [@wschurman](https://github.com/wschurman))
 - Finish conversion to an interface for raw manifests. ([#12509](https://github.com/expo/expo/pull/12509) by [@wschurman](https://github.com/wschurman))
+- Add support for loading new manifests in Expo Go. ([#12521](https://github.com/expo/expo/pull/12521) by [@wschurman](https://github.com/wschurman))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/manifest/raw/NewRawManifestTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/manifest/raw/NewRawManifestTest.kt
@@ -1,0 +1,40 @@
+package expo.modules.updates.manifest.raw
+
+import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
+import org.json.JSONObject
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4ClassRunner::class)
+class NewRawManifestTest {
+  @Test
+  @Throws(Exception::class)
+  fun testGetSDKVersionNullable_ValidCases() {
+    val runtimeVersion = "exposdk:39.0.0"
+    val manifestJson =
+      "{\"runtimeVersion\":\"$runtimeVersion\"}"
+    val manifest = NewRawManifest(JSONObject(manifestJson))
+    Assert.assertEquals(manifest.getSDKVersionNullable(), "39.0.0")
+  }
+
+  @Test
+  @Throws(Exception::class)
+  fun testGetSDKVersionNullable_NotSDKRuntimeVersionCases() {
+    val runtimeVersions = listOf(
+      "exposdk:123",
+      "exposdkd:39.0.0",
+      "exposdk:hello",
+      "bexposdk:39.0.0",
+      "exposdk:39.0.0-beta.0",
+      "exposdk:39.0.0-alpha.256"
+    )
+    runtimeVersions.forEach { runtimeVersion ->
+      val manifestJson =
+        "{\"runtimeVersion\":\"$runtimeVersion\"}"
+      val manifest = NewRawManifest(JSONObject(manifestJson))
+      Assert.assertNull(manifest.getSDKVersionNullable())
+    }
+
+  }
+}

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/raw/BaseLegacyRawManifest.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/raw/BaseLegacyRawManifest.kt
@@ -1,9 +1,22 @@
 package expo.modules.updates.manifest.raw
 
 import org.json.JSONArray
+import org.json.JSONException
 import org.json.JSONObject
 
 abstract class BaseLegacyRawManifest(json: JSONObject) : RawManifest(json) {
   fun getMetadata(): JSONObject? = json.optJSONObject("metadata")
   override fun getAssets(): JSONArray? = json.optJSONArray("assets")
+
+  @Throws(JSONException::class)
+  override fun getBundleURL(): String = json.getString("bundleUrl")
+
+  override fun getSDKVersionNullable(): String? = if (json.has("sdkVersion")) {
+    json.optString("sdkVersion")
+  } else {
+    null
+  }
+
+  @Throws(JSONException::class)
+  override fun getSDKVersion(): String = json.getString("sdkVersion")
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/raw/NewRawManifest.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/raw/NewRawManifest.kt
@@ -3,10 +3,31 @@ package expo.modules.updates.manifest.raw
 import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
+import java.util.regex.Matcher
+import java.util.regex.Pattern
 
 class NewRawManifest(json: JSONObject) : RawManifest(json) {
   @Throws(JSONException::class)
   fun getRuntimeVersion(): String = json.getString("runtimeVersion")
+
+  @Throws(JSONException::class)
+  override fun getBundleURL(): String = getLaunchAsset().getString("url")
+
+  override fun getSDKVersionNullable(): String? {
+    val runtimeVersion = getRuntimeVersion()
+    val expoSDKRuntimeVersionRegex: Pattern = Pattern.compile("^exposdk:(\\d+\\.\\d+\\.\\d+)$")
+    val expoSDKRuntimeVersionMatch: Matcher = expoSDKRuntimeVersionRegex.matcher(runtimeVersion)
+    if (expoSDKRuntimeVersionMatch.find()) {
+      return expoSDKRuntimeVersionMatch.group(1)!!
+    }
+    return null
+  }
+
+  @Throws(JSONException::class)
+  override fun getSDKVersion(): String {
+    return getSDKVersionNullable()
+      ?: throw JSONException("SDKVersion not found for runtimeVersion ${getRuntimeVersion()}")
+  }
 
   @Throws(JSONException::class)
   fun getLaunchAsset(): JSONObject = json.getJSONObject("launchAsset")

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/raw/RawManifest.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/raw/RawManifest.kt
@@ -11,22 +11,16 @@ abstract class RawManifest(protected val json: JSONObject) {
   @Throws(JSONException::class)
   fun getID(): String = json.getString("id")
 
-  // this will need to be updated for new manifests
   @Throws(JSONException::class)
-  fun getBundleURL(): String = json.getString("bundleUrl")
+  abstract fun getBundleURL(): String
 
   @Throws(JSONException::class)
   fun getRevisionId(): String = json.getString("revisionId")
 
-  // this will need to be overridden in NewManifest once sdkVersion can be parsed from sdkVersion
-  fun getSDKVersionNullable(): String? = if (json.has("sdkVersion")) {
-    json.optString("sdkVersion")
-  } else {
-    null
-  }
+  abstract fun getSDKVersionNullable(): String?
 
   @Throws(JSONException::class)
-  fun getSDKVersion(): String = json.getString("sdkVersion")
+  abstract fun getSDKVersion(): String
 
   abstract fun getAssets(): JSONArray?
 


### PR DESCRIPTION
# Why

This PR is the 4th step of https://github.com/expo/expo/pull/12479, and adds support for loading NewManifests in Expo Go. Note that this only supports bundle and asset loading in a certain SDK version. There are still a lot more features to transfer over from the old manifest format to the new one to reach parity.

# How

- Fork the behavior of SDK version parsing in new manifests to match that of https://www.npmjs.com/package/@expo/sdk-runtime-versions
- Keep new manifest URL parameters in manifest URL.

# Test Plan

`adb shell 'am start -d "exps://updates.expo.dev/37700852-0840-47b7-80cb-d57746395f57?runtime-version=exposdk%3A40.0.0&channel-name=main"'`