### PR TITLE
[docs] enable webpack 5

### DIFF
--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -25,9 +25,9 @@ const enableEsbuild = !!process.env.USE_ESBUILD;
 console.log(enableEsbuild ? 'Using esbuild for MDX files' : 'Using babel for MDX files');
 
 module.exports = {
-  // future: {
-  //   webpack5: true,
-  // },
+  future: {
+    webpack5: true,
+  },
   trailingSlash: true,
   // Rather than use `@zeit/next-mdx`, we replicate it
   pageExtensions: ['js', 'jsx', 'ts', 'tsx', 'md', 'mdx'],
@@ -74,10 +74,7 @@ module.exports = {
     });
 
     // Fix inline or browser MDX usage: https://mdxjs.com/getting-started/webpack#running-mdx-in-the-browser
-    // Webpack 4
-    config.node = { fs: 'empty' };
-    // Webpack 5
-    // config.resolve.fallback = { fs: false, path: require.resolve('path-browserify') };
+    config.resolve.fallback = { fs: false, path: require.resolve('path-browserify') };
 
     // Add the esbuild plugin only when using esbuild
     if (enableEsbuild) {


### PR DESCRIPTION
# Why

Next.js now support Webpack 5. Adopting webpack 5 has many benefits, notably:

- Improved Disk Caching: next build is significantly faster on subsequent builds
- Improved Fast Refresh: Fast Refresh work is prioritized
- Improved Long Term Caching of Assets: Deterministic code output that is less likely to change between builds
- Improved Tree Shaking
- Support for assets using new URL("file.png", import.meta.url)
- Support for web workers using new Worker(new URL("worker.js", import.meta.url))
- Support for exports/imports field in package.json

https://nextjs.org/docs/messages/webpack5

# How

- Use future.webpack5 flag in next.config.js
- Update webpack config

# Test Plan

- Docs should build and export correctly with Webpack 5 using babel for MDX files
- Docs should build and export correctly with Webpack 5 using esbuild for MDX files
- Docs should build and export correctly on GitHub Actions