### PR TITLE
[docs] Add appstate to the react native api docs

### DIFF
--- a/docs/pages/versions/unversioned/react-native/appstate.md
+++ b/docs/pages/versions/unversioned/react-native/appstate.md
@@ -1,0 +1,126 @@
+---
+id: appstate
+title: AppState
+---
+
+`AppState` can tell you if the app is in the foreground or background, and notify you when the state changes.
+
+AppState is frequently used to determine the intent and proper behavior when handling push notifications.
+
+### App States
+
+- `active` - The app is running in the foreground
+- `background` - The app is running in the background. The user is either:
+  - in another app
+  - on the home screen
+  - [Android] on another `Activity` (even if it was launched by your app)
+- [iOS] `inactive` - This is a state that occurs when transitioning between foreground & background, and during periods of inactivity such as entering the Multitasking view or in the event of an incoming call
+
+For more information, see [Apple's documentation](https://developer.apple.com/documentation/uikit/app_and_scenes/managing_your_app_s_life_cycle)
+
+## Basic Usage
+
+To see the current state, you can check `AppState.currentState`, which will be kept up-to-date. However, `currentState` will be null at launch while `AppState` retrieves it over the bridge.
+
+```js
+import React, { useRef, useState, useEffect } from 'react';
+import { AppState, StyleSheet, Text, View } from 'react-native';
+
+const AppStateExample = () => {
+  const appState = useRef(AppState.currentState);
+  const [appStateVisible, setAppStateVisible] = useState(appState.current);
+
+  useEffect(() => {
+    AppState.addEventListener('change', _handleAppStateChange);
+
+    return () => {
+      AppState.removeEventListener('change', _handleAppStateChange);
+    };
+  }, []);
+
+  const _handleAppStateChange = (nextAppState) => {
+    if (
+      appState.current.match(/inactive|background/) &&
+      nextAppState === 'active'
+    ) {
+      console.log('App has come to the foreground!');
+    }
+
+    appState.current = nextAppState;
+    setAppStateVisible(appState.current);
+    console.log('AppState', appState.current);
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text>Current state is: {appStateVisible}</Text>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});
+
+export default AppStateExample;
+```
+
+If you don't want to see the AppState update from `active` to `inactive` on iOS you can remove the state variable and use the `appState.current` value.
+
+This example will only ever appear to say "Current state is: active" because the app is only visible to the user when in the `active` state, and the null state will happen only momentarily. If you want to experiment with the code we recommend to use your own device instead of embedded preview.
+
+---
+
+# Reference
+
+## Events
+
+### `change`
+
+This event is received when the app state has changed. The listener is called with one of [the current app state values](appstate.md#app-states).
+
+### `memoryWarning`
+
+This event is used in the need of throwing memory warning or releasing it.
+
+### `focus`
+
+[Android only] Received when the app gains focus (the user is interacting with the app).
+
+### `blur`
+
+[Android only] Received when the user is not actively interacting with the app. Useful in situations when the user pulls down the [notification drawer](https://developer.android.com/guide/topics/ui/notifiers/notifications#bar-and-drawer). `AppState` won't change but the `blur` event will get fired.
+
+## Methods
+
+### `addEventListener()`
+
+```js
+addEventListener(type, handler);
+```
+
+Add a handler to AppState changes by listening to the `change` event type and providing the handler
+
+TODO: now that AppState is a subclass of NativeEventEmitter, we could deprecate `addEventListener` and `removeEventListener` and use `addListener` and `listener.remove()` directly. That will be a breaking change though, as both the method and event names are different (addListener events are currently required to be globally unique).
+
+---
+
+### `removeEventListener()`
+
+```js
+removeEventListener(type, handler);
+```
+
+Remove a handler by passing the `change` event type and the handler
+
+## Properties
+
+### `currentState`
+
+```js
+AppState.currentState;
+```

--- a/docs/pages/versions/v38.0.0/react-native/appstate.md
+++ b/docs/pages/versions/v38.0.0/react-native/appstate.md
@@ -1,0 +1,117 @@
+---
+id: appstate
+title: AppState
+---
+
+`AppState` can tell you if the app is in the foreground or background, and notify you when the state changes.
+
+AppState is frequently used to determine the intent and proper behavior when handling push notifications.
+
+### App States
+
+- `active` - The app is running in the foreground
+- `background` - The app is running in the background. The user is either:
+  - in another app
+  - on the home screen
+  - [Android] on another `Activity` (even if it was launched by your app)
+- [iOS] `inactive` - This is a state that occurs when transitioning between foreground & background, and during periods of inactivity such as entering the Multitasking view or in the event of an incoming call
+
+For more information, see [Apple's documentation](https://developer.apple.com/documentation/uikit/app_and_scenes/managing_your_app_s_life_cycle)
+
+## Basic Usage
+
+To see the current state, you can check `AppState.currentState`, which will be kept up-to-date. However, `currentState` will be null at launch while `AppState` retrieves it over the bridge.
+
+```js
+import React, { useEffect, useState } from 'react';
+import { AppState, StyleSheet, Text, View } from 'react-native';
+
+const AppStateExample = () => {
+  const [appState, setAppState] = useState(AppState.currentState);
+
+  useEffect(() => {
+    AppState.addEventListener('change', _handleAppStateChange);
+
+    return () => {
+      AppState.removeEventListener('change', _handleAppStateChange);
+    };
+  }, []);
+
+  const _handleAppStateChange = nextAppState => {
+    if (appState.match(/inactive|background/) && nextAppState === 'active') {
+      console.log('App has come to the foreground!');
+    }
+    setAppState(nextAppState);
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text>Current state is: {appState}</Text>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});
+
+export default AppStateExample;
+```
+
+This example will only ever appear to say "Current state is: active" because the app is only visible to the user when in the `active` state, and the null state will happen only momentarily.
+
+---
+
+# Reference
+
+## Events
+
+### `change`
+
+This event is received when the app state has changed. The listener is called with one of [the current app state values](appstate.md#app-states).
+
+### `memoryWarning`
+
+This event is used in the need of throwing memory warning or releasing it.
+
+### `focus`
+
+[Android only] Received when the app gains focus (the user is interacting with the app).
+
+### `blur`
+
+[Android only] Received when the user is not actively interacting with the app. Useful in situations when the user pulls down the [notification drawer](https://developer.android.com/guide/topics/ui/notifiers/notifications#bar-and-drawer). `AppState` won't change but the `blur` event will get fired.
+
+## Methods
+
+### `addEventListener()`
+
+```js
+addEventListener(type, handler);
+```
+
+Add a handler to AppState changes by listening to the `change` event type and providing the handler
+
+TODO: now that AppState is a subclass of NativeEventEmitter, we could deprecate `addEventListener` and `removeEventListener` and use `addListener` and `listener.remove()` directly. That will be a breaking change though, as both the method and event names are different (addListener events are currently required to be globally unique).
+
+---
+
+### `removeEventListener()`
+
+```js
+removeEventListener(type, handler);
+```
+
+Remove a handler by passing the `change` event type and the handler
+
+## Properties
+
+### `currentState`
+
+```js
+AppState.currentState;
+```

--- a/docs/pages/versions/v39.0.0/react-native/appstate.md
+++ b/docs/pages/versions/v39.0.0/react-native/appstate.md
@@ -1,0 +1,126 @@
+---
+id: appstate
+title: AppState
+---
+
+`AppState` can tell you if the app is in the foreground or background, and notify you when the state changes.
+
+AppState is frequently used to determine the intent and proper behavior when handling push notifications.
+
+### App States
+
+- `active` - The app is running in the foreground
+- `background` - The app is running in the background. The user is either:
+  - in another app
+  - on the home screen
+  - [Android] on another `Activity` (even if it was launched by your app)
+- [iOS] `inactive` - This is a state that occurs when transitioning between foreground & background, and during periods of inactivity such as entering the Multitasking view or in the event of an incoming call
+
+For more information, see [Apple's documentation](https://developer.apple.com/documentation/uikit/app_and_scenes/managing_your_app_s_life_cycle)
+
+## Basic Usage
+
+To see the current state, you can check `AppState.currentState`, which will be kept up-to-date. However, `currentState` will be null at launch while `AppState` retrieves it over the bridge.
+
+```js
+import React, { useRef, useState, useEffect } from 'react';
+import { AppState, StyleSheet, Text, View } from 'react-native';
+
+const AppStateExample = () => {
+  const appState = useRef(AppState.currentState);
+  const [appStateVisible, setAppStateVisible] = useState(appState.current);
+
+  useEffect(() => {
+    AppState.addEventListener('change', _handleAppStateChange);
+
+    return () => {
+      AppState.removeEventListener('change', _handleAppStateChange);
+    };
+  }, []);
+
+  const _handleAppStateChange = (nextAppState) => {
+    if (
+      appState.current.match(/inactive|background/) &&
+      nextAppState === 'active'
+    ) {
+      console.log('App has come to the foreground!');
+    }
+
+    appState.current = nextAppState;
+    setAppStateVisible(appState.current);
+    console.log('AppState', appState.current);
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text>Current state is: {appStateVisible}</Text>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});
+
+export default AppStateExample;
+```
+
+If you don't want to see the AppState update from `active` to `inactive` on iOS you can remove the state variable and use the `appState.current` value.
+
+This example will only ever appear to say "Current state is: active" because the app is only visible to the user when in the `active` state, and the null state will happen only momentarily. If you want to experiment with the code we recommend to use your own device instead of embedded preview.
+
+---
+
+# Reference
+
+## Events
+
+### `change`
+
+This event is received when the app state has changed. The listener is called with one of [the current app state values](appstate.md#app-states).
+
+### `memoryWarning`
+
+This event is used in the need of throwing memory warning or releasing it.
+
+### `focus`
+
+[Android only] Received when the app gains focus (the user is interacting with the app).
+
+### `blur`
+
+[Android only] Received when the user is not actively interacting with the app. Useful in situations when the user pulls down the [notification drawer](https://developer.android.com/guide/topics/ui/notifiers/notifications#bar-and-drawer). `AppState` won't change but the `blur` event will get fired.
+
+## Methods
+
+### `addEventListener()`
+
+```js
+addEventListener(type, handler);
+```
+
+Add a handler to AppState changes by listening to the `change` event type and providing the handler
+
+TODO: now that AppState is a subclass of NativeEventEmitter, we could deprecate `addEventListener` and `removeEventListener` and use `addListener` and `listener.remove()` directly. That will be a breaking change though, as both the method and event names are different (addListener events are currently required to be globally unique).
+
+---
+
+### `removeEventListener()`
+
+```js
+removeEventListener(type, handler);
+```
+
+Remove a handler by passing the `change` event type and the handler
+
+## Properties
+
+### `currentState`
+
+```js
+AppState.currentState;
+```

--- a/docs/pages/versions/v40.0.0/react-native/appstate.md
+++ b/docs/pages/versions/v40.0.0/react-native/appstate.md
@@ -1,0 +1,126 @@
+---
+id: appstate
+title: AppState
+---
+
+`AppState` can tell you if the app is in the foreground or background, and notify you when the state changes.
+
+AppState is frequently used to determine the intent and proper behavior when handling push notifications.
+
+### App States
+
+- `active` - The app is running in the foreground
+- `background` - The app is running in the background. The user is either:
+  - in another app
+  - on the home screen
+  - [Android] on another `Activity` (even if it was launched by your app)
+- [iOS] `inactive` - This is a state that occurs when transitioning between foreground & background, and during periods of inactivity such as entering the Multitasking view or in the event of an incoming call
+
+For more information, see [Apple's documentation](https://developer.apple.com/documentation/uikit/app_and_scenes/managing_your_app_s_life_cycle)
+
+## Basic Usage
+
+To see the current state, you can check `AppState.currentState`, which will be kept up-to-date. However, `currentState` will be null at launch while `AppState` retrieves it over the bridge.
+
+```js
+import React, { useRef, useState, useEffect } from 'react';
+import { AppState, StyleSheet, Text, View } from 'react-native';
+
+const AppStateExample = () => {
+  const appState = useRef(AppState.currentState);
+  const [appStateVisible, setAppStateVisible] = useState(appState.current);
+
+  useEffect(() => {
+    AppState.addEventListener('change', _handleAppStateChange);
+
+    return () => {
+      AppState.removeEventListener('change', _handleAppStateChange);
+    };
+  }, []);
+
+  const _handleAppStateChange = (nextAppState) => {
+    if (
+      appState.current.match(/inactive|background/) &&
+      nextAppState === 'active'
+    ) {
+      console.log('App has come to the foreground!');
+    }
+
+    appState.current = nextAppState;
+    setAppStateVisible(appState.current);
+    console.log('AppState', appState.current);
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text>Current state is: {appStateVisible}</Text>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});
+
+export default AppStateExample;
+```
+
+If you don't want to see the AppState update from `active` to `inactive` on iOS you can remove the state variable and use the `appState.current` value.
+
+This example will only ever appear to say "Current state is: active" because the app is only visible to the user when in the `active` state, and the null state will happen only momentarily. If you want to experiment with the code we recommend to use your own device instead of embedded preview.
+
+---
+
+# Reference
+
+## Events
+
+### `change`
+
+This event is received when the app state has changed. The listener is called with one of [the current app state values](appstate.md#app-states).
+
+### `memoryWarning`
+
+This event is used in the need of throwing memory warning or releasing it.
+
+### `focus`
+
+[Android only] Received when the app gains focus (the user is interacting with the app).
+
+### `blur`
+
+[Android only] Received when the user is not actively interacting with the app. Useful in situations when the user pulls down the [notification drawer](https://developer.android.com/guide/topics/ui/notifiers/notifications#bar-and-drawer). `AppState` won't change but the `blur` event will get fired.
+
+## Methods
+
+### `addEventListener()`
+
+```js
+addEventListener(type, handler);
+```
+
+Add a handler to AppState changes by listening to the `change` event type and providing the handler
+
+TODO: now that AppState is a subclass of NativeEventEmitter, we could deprecate `addEventListener` and `removeEventListener` and use `addListener` and `listener.remove()` directly. That will be a breaking change though, as both the method and event names are different (addListener events are currently required to be globally unique).
+
+---
+
+### `removeEventListener()`
+
+```js
+removeEventListener(type, handler);
+```
+
+Remove a handler by passing the `change` event type and the handler
+
+## Properties
+
+### `currentState`
+
+```js
+AppState.currentState;
+```

--- a/docs/pages/versions/v41.0.0/react-native/appstate.md
+++ b/docs/pages/versions/v41.0.0/react-native/appstate.md
@@ -1,0 +1,126 @@
+---
+id: appstate
+title: AppState
+---
+
+`AppState` can tell you if the app is in the foreground or background, and notify you when the state changes.
+
+AppState is frequently used to determine the intent and proper behavior when handling push notifications.
+
+### App States
+
+- `active` - The app is running in the foreground
+- `background` - The app is running in the background. The user is either:
+  - in another app
+  - on the home screen
+  - [Android] on another `Activity` (even if it was launched by your app)
+- [iOS] `inactive` - This is a state that occurs when transitioning between foreground & background, and during periods of inactivity such as entering the Multitasking view or in the event of an incoming call
+
+For more information, see [Apple's documentation](https://developer.apple.com/documentation/uikit/app_and_scenes/managing_your_app_s_life_cycle)
+
+## Basic Usage
+
+To see the current state, you can check `AppState.currentState`, which will be kept up-to-date. However, `currentState` will be null at launch while `AppState` retrieves it over the bridge.
+
+```js
+import React, { useRef, useState, useEffect } from 'react';
+import { AppState, StyleSheet, Text, View } from 'react-native';
+
+const AppStateExample = () => {
+  const appState = useRef(AppState.currentState);
+  const [appStateVisible, setAppStateVisible] = useState(appState.current);
+
+  useEffect(() => {
+    AppState.addEventListener('change', _handleAppStateChange);
+
+    return () => {
+      AppState.removeEventListener('change', _handleAppStateChange);
+    };
+  }, []);
+
+  const _handleAppStateChange = (nextAppState) => {
+    if (
+      appState.current.match(/inactive|background/) &&
+      nextAppState === 'active'
+    ) {
+      console.log('App has come to the foreground!');
+    }
+
+    appState.current = nextAppState;
+    setAppStateVisible(appState.current);
+    console.log('AppState', appState.current);
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text>Current state is: {appStateVisible}</Text>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});
+
+export default AppStateExample;
+```
+
+If you don't want to see the AppState update from `active` to `inactive` on iOS you can remove the state variable and use the `appState.current` value.
+
+This example will only ever appear to say "Current state is: active" because the app is only visible to the user when in the `active` state, and the null state will happen only momentarily. If you want to experiment with the code we recommend to use your own device instead of embedded preview.
+
+---
+
+# Reference
+
+## Events
+
+### `change`
+
+This event is received when the app state has changed. The listener is called with one of [the current app state values](appstate.md#app-states).
+
+### `memoryWarning`
+
+This event is used in the need of throwing memory warning or releasing it.
+
+### `focus`
+
+[Android only] Received when the app gains focus (the user is interacting with the app).
+
+### `blur`
+
+[Android only] Received when the user is not actively interacting with the app. Useful in situations when the user pulls down the [notification drawer](https://developer.android.com/guide/topics/ui/notifiers/notifications#bar-and-drawer). `AppState` won't change but the `blur` event will get fired.
+
+## Methods
+
+### `addEventListener()`
+
+```js
+addEventListener(type, handler);
+```
+
+Add a handler to AppState changes by listening to the `change` event type and providing the handler
+
+TODO: now that AppState is a subclass of NativeEventEmitter, we could deprecate `addEventListener` and `removeEventListener` and use `addListener` and `listener.remove()` directly. That will be a breaking change though, as both the method and event names are different (addListener events are currently required to be globally unique).
+
+---
+
+### `removeEventListener()`
+
+```js
+removeEventListener(type, handler);
+```
+
+Remove a handler by passing the `change` event type and the handler
+
+## Properties
+
+### `currentState`
+
+```js
+AppState.currentState;
+```


### PR DESCRIPTION
# Why

Fixes #12370

In the future, this shouldn't be ignored anymore because we added it now. I remember that we used to ignore this doc in the past for some reason, but I don't think we should be doing that anymore.

# How

Added it manually by looking up the React Native versions used, and using the apostate doc from that version.

# Test Plan

Docs change only

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).