### PR TITLE
[CI] improve the workflows running rules

### DIFF
--- a/.github/workflows/android-unit-tests.yml
+++ b/.github/workflows/android-unit-tests.yml
@@ -6,16 +6,18 @@ on:
     branches: [master]
     paths:
       - .github/workflows/android-unit-tests.yml
-      - 'android/**'
-      - 'fastlane/**'
-      - 'tools/**'
+      - android/**
+      - fastlane/**
+      - packages/**/android/**
+      - tools/**
       - yarn.lock
   pull_request:
     paths:
       - .github/workflows/android-unit-tests.yml
-      - 'android/**'
-      - 'fastlane/**'
-      - 'tools/**'
+      - android/**
+      - fastlane/**
+      - packages/**/android/**
+      - tools/**
       - yarn.lock
 
 jobs:

--- a/.github/workflows/native-component-list.yml
+++ b/.github/workflows/native-component-list.yml
@@ -6,12 +6,14 @@ on:
     paths:
       - .github/workflows/native-component-list.yml
       - apps/native-component-list/**
+      - packages/**
       - yarn.lock
   push:
     branches: [master]
     paths:
       - .github/workflows/native-component-list.yml
       - apps/native-component-list/**
+      - packages/**
       - yarn.lock
 
 jobs:


### PR DESCRIPTION
# Why

Refs: #12518
After changing the package types CI was green, but push on `master` failed due to error in `native-component-list` app.

Also Android unit tests were not run on changes in `packages`, so I have added the `packages/**/android/**` pattern, similar to the iOS unit test workflow:
* https://github.com/expo/expo/blob/master/.github/workflows/ios-unit-tests.yml#L9

# How

This PR updates the path which are used to detect if workflow should be run and includes the following changes:
* run `native-component-list` on packages changes
* run Android unit tests on `packages/**/android/` changes

# Test Plan

Test the changes on the CI 😉 