### PR TITLE
[docs] improve API interfaces section render, fix literal type extraction issue

### DIFF
--- a/docs/components/plugins/api/APIDataTypes.ts
+++ b/docs/components/plugins/api/APIDataTypes.ts
@@ -53,6 +53,10 @@ export type MethodParamData = {
   comment?: CommentData;
 };
 
+export type TypePropertyDataFlags = {
+  isOptional: boolean;
+};
+
 // Constants section
 
 export type ConstantDefinitionData = {
@@ -89,7 +93,8 @@ export type InterfaceDefinitionData = {
 
 export type InterfaceValueData = {
   name: string;
-  type: TypeDeclarationData;
+  type: TypeDefinitionData;
+  flags?: TypePropertyDataFlags;
   kind: TypeDocKind;
   comment?: CommentData;
 };
@@ -158,9 +163,7 @@ export type TypeSignaturesData = {
 
 export type TypePropertyData = {
   name: string;
-  flags: {
-    isOptional: boolean;
-  };
+  flags?: TypePropertyDataFlags;
   comment: CommentData;
   type: TypeDefinitionData;
   defaultValue: string;
@@ -168,5 +171,6 @@ export type TypePropertyData = {
 
 export type TypeValueData = {
   type: string;
-  value: string | boolean | null;
+  value?: string | boolean | null;
+  name?: string;
 };

--- a/docs/components/plugins/api/APISectionInterfaces.tsx
+++ b/docs/components/plugins/api/APISectionInterfaces.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactMarkdown from 'react-markdown';
 
 import { InlineCode } from '~/components/base/code';
-import { LI, UL } from '~/components/base/list';
 import { B } from '~/components/base/paragraph';
 import { H2, H3Code } from '~/components/plugins/Headings';
 import { InterfaceDefinitionData, InterfaceValueData } from '~/components/plugins/api/APIDataTypes';

--- a/docs/components/plugins/api/APISectionInterfaces.tsx
+++ b/docs/components/plugins/api/APISectionInterfaces.tsx
@@ -1,14 +1,50 @@
 import React from 'react';
+import ReactMarkdown from 'react-markdown';
 
 import { InlineCode } from '~/components/base/code';
 import { LI, UL } from '~/components/base/list';
+import { B } from '~/components/base/paragraph';
 import { H2, H3Code } from '~/components/plugins/Headings';
 import { InterfaceDefinitionData, InterfaceValueData } from '~/components/plugins/api/APIDataTypes';
-import { CommentTextBlock, mdInlineRenderers } from '~/components/plugins/api/APISectionUtils';
+import {
+  CommentTextBlock,
+  mdInlineRenderers,
+  resolveTypeName,
+  STYLES_OPTIONAL,
+} from '~/components/plugins/api/APISectionUtils';
 
 export type APISectionInterfacesProps = {
   data: InterfaceDefinitionData[];
 };
+
+const renderInterfacePropertyRow = ({
+  name,
+  flags,
+  type,
+  comment,
+}: InterfaceValueData): JSX.Element => (
+  <tr key={name}>
+    <td>
+      <B>{name}</B>
+      {flags?.isOptional ? (
+        <>
+          <br />
+          <span css={STYLES_OPTIONAL}>(optional)</span>
+        </>
+      ) : null}
+    </td>
+    <td>
+      <InlineCode>{resolveTypeName(type)}</InlineCode>
+    </td>
+    <td>
+      {comment?.shortText ? (
+        <ReactMarkdown renderers={mdInlineRenderers}>{comment.shortText}</ReactMarkdown>
+      ) : (
+        '-'
+      )}
+    </td>
+  </tr>
+);
 
 const renderInterface = ({ name, children, comment }: InterfaceDefinitionData): JSX.Element => (
   <div key={`interface-definition-${name}`}>
@@ -16,21 +52,16 @@ const renderInterface = ({ name, children, comment }: InterfaceDefinitionData): 
       <InlineCode>{name}</InlineCode>
     </H3Code>
     <CommentTextBlock comment={comment} />
-    <UL>
-      {children.map((interfaceValue: InterfaceValueData) => (
-        <LI key={interfaceValue.name}>
-          <InlineCode>
-            {name}.{interfaceValue.name}
-            {interfaceValue.type.declaration?.signatures ? '()' : ''}
-          </InlineCode>
-          <CommentTextBlock
-            comment={interfaceValue.comment}
-            renderers={mdInlineRenderers}
-            withDash
-          />
-        </LI>
-      ))}
-    </UL>
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>{children.map(renderInterfacePropertyRow)}</tbody>
+    </table>
   </div>
 );
 

--- a/docs/components/plugins/api/APISectionTypes.tsx
+++ b/docs/components/plugins/api/APISectionTypes.tsx
@@ -1,5 +1,3 @@
-import { css } from '@emotion/core';
-import { theme } from '@expo/styleguide';
 import React from 'react';
 import ReactMarkdown from 'react-markdown';
 
@@ -19,34 +17,31 @@ import {
   resolveTypeName,
   renderParam,
   CommentTextBlock,
+  STYLES_OPTIONAL,
 } from '~/components/plugins/api/APISectionUtils';
 
 export type APISectionTypesProps = {
   data: TypeGeneralData[];
 };
 
-const STYLES_OPTIONAL = css`
-  color: ${theme.text.secondary};
-  font-size: 90%;
-  padding-top: 22px;
-`;
-
-const defineLiteralType = (types: TypeValueData[]): string | undefined => {
+const defineLiteralType = (types: TypeValueData[]): string => {
   const uniqueTypes = Array.from(new Set(types.map((t: TypeValueData) => typeof t.value)));
   if (uniqueTypes.length === 1) {
     return '`' + uniqueTypes[0] + '` - ';
   }
-  return undefined;
+  return '';
 };
 
 const decorateValue = (type: TypeValueData): string =>
-  typeof type.value === 'string' ? "`'" + type.value + "'`" : `'` + type.value + '`';
+  typeof type?.value === 'string'
+    ? "`'" + type.value + "'`"
+    : '`' + (type.value || type.name) + '`';
 
-const renderTypePropertyRow = (typeProperty: TypePropertyData): JSX.Element => (
-  <tr key={typeProperty.name}>
+const renderTypePropertyRow = ({ name, flags, type, comment }: TypePropertyData): JSX.Element => (
+  <tr key={name}>
     <td>
-      <B>{typeProperty.name}</B>
-      {typeProperty.flags?.isOptional ? (
+      <B>{name}</B>
+      {flags?.isOptional ? (
         <>
           <br />
           <span css={STYLES_OPTIONAL}>(optional)</span>
@@ -54,13 +49,11 @@ const renderTypePropertyRow = (typeProperty: TypePropertyData): JSX.Element => (
       ) : null}
     </td>
     <td>
-      <InlineCode>{resolveTypeName(typeProperty.type)}</InlineCode>
+      <InlineCode>{resolveTypeName(type)}</InlineCode>
     </td>
     <td>
-      {typeProperty?.comment?.shortText ? (
-        <ReactMarkdown renderers={mdInlineRenderers}>
-          {typeProperty.comment.shortText}
-        </ReactMarkdown>
+      {comment?.shortText ? (
+        <ReactMarkdown renderers={mdInlineRenderers}>{comment.shortText}</ReactMarkdown>
       ) : (
         '-'
       )}
@@ -104,7 +97,9 @@ const renderType = ({ name, comment, type }: TypeGeneralData): JSX.Element | und
     );
   } else if (type.types && type.type === 'union') {
     // Literal Types
-    const validTypes = type.types.filter((t: TypeValueData) => t.type === 'literal');
+    const validTypes = type.types.filter(
+      (t: TypeValueData) => t.type === 'literal' || t.type === 'intrinsic'
+    );
     if (validTypes.length) {
       return (
         <div key={`type-definition-${name}`}>

--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -1,3 +1,5 @@
+import { css } from '@emotion/core';
+import { theme } from '@expo/styleguide';
 import React from 'react';
 import ReactMarkdown from 'react-markdown';
 
@@ -138,3 +140,9 @@ export const CommentTextBlock: React.FC<CommentTextBlockProps> = ({
     </>
   );
 };
+
+export const STYLES_OPTIONAL = css`
+  color: ${theme.text.secondary};
+  font-size: 90%;
+  padding-top: 22px;
+`;


### PR DESCRIPTION
# Why

Currently the `interface` API section rendering was based on the Enums one and do not offer too much useful information to the users. So far the only interface was listed in `Pedometer` docs, so the change should not affect other modules docs.

# How

This PR changes the base deign to the similar one which objects `type`s uses, which should be more accurate and offer a bit more information.

# Test Plan

The changes have been tested by running `docs` on `localhost`.

# Preview

### Before
<img width="1137" alt="Screenshot 2021-04-14 at 15 11 05" src="https://user-images.githubusercontent.com/719641/114715715-aad65c00-9d33-11eb-9ea8-c8fd8065cae8.png">

### After
<img width="1137" alt="Screenshot 2021-04-14 at 15 08 30" src="https://user-images.githubusercontent.com/719641/114715379-4e733c80-9d33-11eb-8038-06feee0dfb0d.png">

CC: @bbarthec @brentvatne 