### PR TITLE
[docs] Ignore the operation is insecure error on firefox

### DIFF
--- a/docs/common/sentry-utilities.ts
+++ b/docs/common/sentry-utilities.ts
@@ -9,6 +9,8 @@ import { Event } from '@sentry/types';
 const ERRORS_TO_DISCARD = [
   // This error only appears in Safari
   "undefined is not an object (evaluating 'window.__pad.performLoop')",
+  // This error appears in Firefox related to local storage and flooded our Sentry bandwidth
+  'SecurityError: The operation is insecure.',
 ];
 
 const REPORTED_ERRORS_KEY = 'sentry:reportedErrors';


### PR DESCRIPTION
# Why

It flooded our Sentry bandwidth, without a direct cause. Could be related to an [older bug in the local storage](https://bugzilla.mozilla.org/show_bug.cgi?id=1381307) within Firefox. Other than that, I wasn't able to find anything more specific about this issue.

# How

Added message to Sentry process error method to filter it out

# Test Plan

Docs change only.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).