### PR TITLE
[home] Temporarily disable navigation linking handler

### DIFF
--- a/home/navigation/Navigation.tsx
+++ b/home/navigation/Navigation.tsx
@@ -198,18 +198,21 @@ function TabNavigator(props: { theme: string }) {
 const ModalStack = createStackNavigator();
 
 export default (props: { theme: string }) => {
-  const linking = {
-    prefixes: ['expo-home://'],
-    config: {
-      initialRouteName: 'RootStack',
-      screens: {
-        QRCode: 'qr-scanner',
-      },
-    },
-  };
+  // Temporarily disable QR code deep linking due to Android Expo Go issue:
+  // https://linear.app/expo/issue/ENG-877/expo-home-on-android-reloads-when-resumed
+  //
+  // const linking = {
+  //   prefixes: ['expo-home://'],
+  //   config: {
+  //     initialRouteName: 'RootStack',
+  //     screens: {
+  //       QRCode: 'qr-scanner',
+  //     },
+  //   },
+  // };
 
   return (
-    <NavigationContainer theme={Themes[props.theme]} linking={linking}>
+    <NavigationContainer theme={Themes[props.theme]} /* linking={linking} */>
       <ModalStack.Navigator
         initialRouteName="RootStack"
         screenOptions={({ route, navigation }) => ({


### PR DESCRIPTION
# Why

Fix #12541

# How

Temporarily disable linking on navigation container until we resolve underlying bug described in ENG-877.

# Test Plan

- Run Expo Go locally
- From home, open some project
- Close it from the Android multitasker once it's loaded
- Go back to home
- Notice that home reloads, but it doesn't error