### PR TITLE
[home] Fix deep link uncaught error

### DIFF
--- a/dev-home-config.json
+++ b/dev-home-config.json
@@ -1,3 +1,3 @@
 {
-  "url": "exp://expo.io/@expo-home-dev/expo-home-dev-d64c4eb697098ded0ae9c6bb9c8931c40477756a"
+  "url": "exp://expo.io/@expo-home-dev/expo-home-dev-446289121df0dc8c2d00a69cbe3b4c1a90edce66"
 }


### PR DESCRIPTION
# Why

Closes ENG-877.
Better fix of https://github.com/expo/expo/issues/12541.
Reverts https://github.com/expo/expo/pull/12543.

# How

We can't use the `react-navigation` liking mechanism, because it causes crashes. So I've implemented a simple navigation dispatcher that decides which screen should be visible when a deep link is present. 

# Test Plan

- Expo Go ✅

https://user-images.githubusercontent.com/9578601/114872960-19322180-9dfb-11eb-9d33-fdaa0268cf8d.mp4



