### PR TITLE
[docs] fix cumulative layout shift

### DIFF
--- a/docs/components/DocumentationHeader.tsx
+++ b/docs/components/DocumentationHeader.tsx
@@ -279,7 +279,7 @@ function SelectTheme() {
     setLoaded(true);
   }, []);
 
-  if (!loaded) return <div />;
+  if (!loaded) return <div css={SELECT_THEME_CONTAINER} />;
 
   return (
     <div css={SELECT_THEME_CONTAINER}>

--- a/docs/components/plugins/Redirect.tsx
+++ b/docs/components/plugins/Redirect.tsx
@@ -1,11 +1,4 @@
-import { css } from '@emotion/core';
-import * as React from 'react';
-
-const CONTAINER_STYLE = css`
-  background-color: rgba(225, 228, 23, 0.1);
-  padding: 20px;
-  margin-bottom: 20px;
-`;
+import React from 'react';
 
 const Redirect: React.FC<{ path: string }> = ({ path }) => {
   React.useEffect(() => {
@@ -14,11 +7,7 @@ const Redirect: React.FC<{ path: string }> = ({ path }) => {
     }, 0);
   });
 
-  return (
-    <div css={CONTAINER_STYLE}>
-      Redirecting to <a href={path}>{path}</a>
-    </div>
-  );
+  return null;
 };
 
 export default Redirect;


### PR DESCRIPTION
# Why

We have a pretty high cumulative layout shift on desktop for returning users

<img width="1221" alt="Screenshot 2021-04-13 at 13 58 52" src="https://user-images.githubusercontent.com/10477267/114878689-cb201c80-9e00-11eb-9b9b-8d5d87ec3119.png">
<img width="1256" alt="Screenshot 2021-04-13 at 16 54 47" src="https://user-images.githubusercontent.com/10477267/114878693-cce9e000-9e00-11eb-9e0d-aedc4eafe250.png">

# How

Fixed small layout shifts

# Test Plan

- The theme selector should not move the search bar if loading
- Redirecting to a new page should not move the screen too much