### PR TITLE
Remove jest from bare template

### DIFF
--- a/templates/expo-template-bare-minimum/package.json
+++ b/templates/expo-template-bare-minimum/package.json
@@ -7,8 +7,7 @@
     "android": "react-native run-android",
     "ios": "react-native run-ios",
     "web": "expo start --web",
-    "start": "react-native start",
-    "test": "jest"
+    "start": "react-native start"
   },
   "dependencies": {
     "expo": "~41.0.0-beta.3",
@@ -26,11 +25,5 @@
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",
-    "babel-jest": "~25.2.6",
-    "jest": "~25.2.6",
-    "react-test-renderer": "~16.13.1"
-  },
-  "jest": {
-    "preset": "react-native"
   }
 }

--- a/templates/expo-template-bare-typescript/package.json
+++ b/templates/expo-template-bare-typescript/package.json
@@ -7,8 +7,7 @@
     "android": "react-native run-android",
     "ios": "react-native run-ios",
     "web": "expo start --web",
-    "start": "react-native start",
-    "test": "jest"
+    "start": "react-native start"
   },
   "dependencies": {
     "expo": "~41.0.0-beta.3",
@@ -28,10 +27,6 @@
     "@types/react": "~16.9.35",
     "@types/react-native": "~0.63.2",
     "babel-preset-expo": "~8.3.0",
-    "jest-expo": "~41.0.0-beta.0",
     "typescript": "~4.0.0"
-  },
-  "jest": {
-    "preset": "react-native"
   }
 }


### PR DESCRIPTION
# Why

Simplify the base requirements for a project and minimize the changes applied on eject / prebuild.
It doesn't make a lot of sense to have our code generation step add random jest libraries. Also we recommend universal testing with jest-expo, so I think we should add testing back at a later time when we have a better story around how users should test their apps.