### PR TITLE
remove trailing comma that causes parse error

### DIFF
--- a/templates/expo-template-bare-minimum/package.json
+++ b/templates/expo-template-bare-minimum/package.json
@@ -24,6 +24,6 @@
     "react-native-web": "~0.13.12"
   },
   "devDependencies": {
-    "@babel/core": "^7.9.0",
+    "@babel/core": "^7.9.0"
   }
 }


### PR DESCRIPTION
Following CONTRIBUTING.md steps failed to run metro server because of parse error. Removing trailing comma from templates/expo-template-bare-minimum/package.json fixed the issue for me