### PR TITLE
[admob][android] fix: bannerview creating new ad request every layout change

### DIFF
--- a/apps/native-component-list/src/navigation/ExpoComponentsStackNavigator.tsx
+++ b/apps/native-component-list/src/navigation/ExpoComponentsStackNavigator.tsx
@@ -13,6 +13,12 @@ const Stack = createStackNavigator();
 export const Screens = [
   {
     getComponent() {
+      return optionalRequire(() => require('../screens/AdMobScreen'));
+    },
+    name: 'Admob',
+  },
+  {
+    getComponent() {
       return optionalRequire(() => require('../screens/BarCodeScannerScreen'));
     },
     name: 'BarCodeScanner',

--- a/apps/native-component-list/src/screens/AdMobScreen.tsx
+++ b/apps/native-component-list/src/screens/AdMobScreen.tsx
@@ -6,9 +6,10 @@ import {
   AdMobRewarded,
   isAvailableAsync,
   setTestDeviceIDAsync,
+  PublisherBanner,
 } from 'expo-ads-admob';
 import * as React from 'react';
-import { StyleSheet, Platform, Switch, Text, View } from 'react-native';
+import { StyleSheet, Platform, Switch, Text, View, ScrollView } from 'react-native';
 
 import Button from '../components/Button';
 import SimpleActionDemo from '../components/SimpleActionDemo';
@@ -131,7 +132,7 @@ function AdMobView() {
   };
 
   return (
-    <View style={styles.container}>
+    <ScrollView style={styles.container} contentContainerStyle={styles.scrollViewContainer}>
       <View style={{ flex: 1 }}>
         <SimpleActionDemo
           title="get tracking permissions"
@@ -153,7 +154,14 @@ function AdMobView() {
           onPress={onInterstitialPress}
           disabled={!isInterstitialReady}
         />
-        <AdMobBanner bannerSize="banner" adUnitID={AdMobBannerTestUnitID} />
+        <AdMobBanner
+          onAdViewDidReceiveAd={() => {
+            console.log('This should not spam the console.');
+          }}
+          bannerSize="largeBanner"
+          adUnitID={AdMobBannerTestUnitID}
+        />
+        <PublisherBanner bannerSize="largeBanner" adUnitID={AdMobBannerTestUnitID} />
         <View
           style={{
             flexDirection: 'row',
@@ -165,7 +173,7 @@ function AdMobView() {
           <Switch value={servePersonalizedAds} onValueChange={setPersonalizedAds} />
         </View>
       </View>
-    </View>
+    </ScrollView>
   );
 }
 
@@ -177,7 +185,11 @@ const styles = StyleSheet.create({
   container: {
     marginTop: 30,
     flex: 1,
+  },
+  scrollViewContainer: {
+    justifyContent: 'flex-start',
     alignItems: 'center',
+    paddingBottom: 15,
   },
   button: {
     marginVertical: 10,

--- a/packages/expo-ads-admob/CHANGELOG.md
+++ b/packages/expo-ads-admob/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Updated `BannerView` on Android to not create a new ad request on every layout change. ([#12599](https://github.com/expo/expo/pull/12599) by [@cruzach](https://github.com/cruzach))
+
 ## 10.0.4 — 2021-04-13
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-ads-admob/android/src/main/java/expo/modules/ads/admob/AdMobBannerView.java
+++ b/packages/expo-ads-admob/android/src/main/java/expo/modules/ads/admob/AdMobBannerView.java
@@ -23,19 +23,7 @@ public class AdMobBannerView extends FrameLayout {
   public AdMobBannerView(@NonNull Context context, EventEmitter eventEmitter) {
     super(context);
     this.mEventEmitter = eventEmitter;
-    init();
-  }
-
-  private void init() {
     attachNewAdView();
-
-    addOnLayoutChangeListener(new OnLayoutChangeListener() {
-      public void onLayoutChange(View view, int left, int top, int right, int bottom, int oldLeft, int oldTop, int oldRight, int oldBottom) {
-        if (left != oldLeft || right != oldRight || top != oldTop || bottom != oldBottom) {
-          setBannerSize(mSizeString);
-        }
-      }
-    });
   }
 
   protected void attachNewAdView() {
@@ -63,7 +51,9 @@ public class AdMobBannerView extends FrameLayout {
         int top = adView.getTop();
         adView.measure(width, height);
         adView.layout(left, top, left + width, top + height);
-
+        sendEvent(
+          AdMobBannerViewManager.Events.EVENT_SIZE_CHANGE,
+          AdMobUtils.createEventForSizeChange(getContext(), adView.getAdSize()));
         sendEvent(AdMobBannerViewManager.Events.EVENT_RECEIVE_AD);
       }
 

--- a/packages/expo-ads-admob/android/src/main/java/expo/modules/ads/admob/PublisherBannerView.java
+++ b/packages/expo-ads-admob/android/src/main/java/expo/modules/ads/admob/PublisherBannerView.java
@@ -59,7 +59,9 @@ public class PublisherBannerView extends FrameLayout implements AppEventListener
         int top = adView.getTop();
         adView.measure(width, height);
         adView.layout(left, top, left + width, top + height);
-
+        sendEvent(
+          AdMobBannerViewManager.Events.EVENT_SIZE_CHANGE,
+          AdMobUtils.createEventForSizeChange(getContext(), adView.getAdSize()));
         sendEvent(PublisherBannerViewManager.Events.EVENT_RECEIVE_AD);
       }
 

--- a/packages/expo-ads-admob/android/src/main/java/expo/modules/ads/admob/PublisherBannerView.java
+++ b/packages/expo-ads-admob/android/src/main/java/expo/modules/ads/admob/PublisherBannerView.java
@@ -60,7 +60,7 @@ public class PublisherBannerView extends FrameLayout implements AppEventListener
         adView.measure(width, height);
         adView.layout(left, top, left + width, top + height);
         sendEvent(
-          AdMobBannerViewManager.Events.EVENT_SIZE_CHANGE,
+          PublisherBannerViewManager.Events.EVENT_SIZE_CHANGE,
           AdMobUtils.createEventForSizeChange(getContext(), adView.getAdSize()));
         sendEvent(PublisherBannerViewManager.Events.EVENT_RECEIVE_AD);
       }


### PR DESCRIPTION
# Why

fixes https://github.com/expo/expo/issues/12114
fixes https://github.com/expo/expo/issues/11046

# How

The `onLayoutChange` listener was triggering a new call to `loadAd` each time, but wasn't doing anything else (it isn't used in the `PublisherBannerView` at all)

# Test Plan

NCL banners are working correctly and not spamming `onAdViewDidReceiveAd` events

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).