### PR TITLE
[updates][android] Convert most remaining usages of JSON manifest to RawManifest

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/ExponentManifest.java
+++ b/android/expoview/src/main/java/host/exp/exponent/ExponentManifest.java
@@ -593,7 +593,7 @@ public class ExponentManifest {
     listener.onCompleted(manifest);
   }
 
-  public void normalizeManifestInPlace(final String manifestUrl, final RawManifest rawManifest) throws JSONException {
+  public static void normalizeRawManifestInPlace(final RawManifest rawManifest, final String manifestUrl) throws JSONException {
     rawManifest.mutateInternalJSONInPlace(json -> {
       if (!json.has(MANIFEST_ID_KEY)) {
         json.put(MANIFEST_ID_KEY, manifestUrl);

--- a/android/expoview/src/main/java/host/exp/exponent/experience/DetachedModuleRegistryAdapter.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/DetachedModuleRegistryAdapter.java
@@ -15,6 +15,7 @@ import java.util.Map;
 import expo.modules.notifications.notifications.categories.ExpoNotificationCategoriesModule;
 import expo.modules.notifications.notifications.handling.NotificationsHandler;
 import expo.modules.notifications.notifications.scheduling.NotificationScheduler;
+import expo.modules.updates.manifest.raw.RawManifest;
 import host.exp.exponent.kernel.ExperienceId;
 import host.exp.exponent.utils.ScopedContext;
 import versioned.host.exp.exponent.modules.universal.ConstantsBinding;
@@ -31,7 +32,7 @@ public class DetachedModuleRegistryAdapter extends ExpoModuleRegistryAdapter {
   }
 
   @Override
-  public List<NativeModule> createNativeModules(final ScopedContext scopedContext, ExperienceId experienceId, Map<String, Object> experienceProperties, JSONObject manifest, List<NativeModule> otherModules) {
+  public List<NativeModule> createNativeModules(final ScopedContext scopedContext, ExperienceId experienceId, Map<String, Object> experienceProperties, RawManifest manifest, List<NativeModule> otherModules) {
     ReactApplicationContext reactApplicationContext = (ReactApplicationContext) scopedContext.getContext();
 
     // We only use React application context, because we're detached -- no scopes

--- a/android/expoview/src/main/java/host/exp/exponent/experience/splashscreen/ManagedAppSplashScreenConfiguration.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/splashscreen/ManagedAppSplashScreenConfiguration.kt
@@ -38,34 +38,30 @@ class ManagedAppSplashScreenConfiguration private constructor() {
     }
 
     private fun parseResizeMode(manifest: RawManifest): SplashScreenImageResizeMode? {
-      val resizeMode = getStringFromJSONObject(
-        manifest.getRawJson(),
-        arrayOf(
-          ExponentManifest.MANIFEST_ANDROID_INFO_KEY,
-          ExponentManifest.MANIFEST_SPLASH_INFO_KEY,
-          ExponentManifest.MANIFEST_SPLASH_RESIZE_MODE_KEY
-        ),
-        arrayOf(
-          ExponentManifest.MANIFEST_SPLASH_INFO_KEY,
-          ExponentManifest.MANIFEST_SPLASH_RESIZE_MODE_KEY
-        )
-      )
+      val androidSplashInfo = manifest.getAndroidSplashInfo()
+      val rootSplashInfo = manifest.getRootSplashInfo()
+      val resizeMode = if (androidSplashInfo != null && androidSplashInfo.has(ExponentManifest.MANIFEST_SPLASH_RESIZE_MODE_KEY)) {
+        androidSplashInfo.getString(ExponentManifest.MANIFEST_SPLASH_RESIZE_MODE_KEY)
+      } else if (rootSplashInfo != null && rootSplashInfo.has(ExponentManifest.MANIFEST_SPLASH_RESIZE_MODE_KEY)) {
+        rootSplashInfo.getString(ExponentManifest.MANIFEST_SPLASH_RESIZE_MODE_KEY)
+      } else {
+        null
+      }
+
       return SplashScreenImageResizeMode.fromString(resizeMode)
     }
 
     private fun parseBackgroundColor(manifest: RawManifest): Int? {
-      val backgroundColor = getStringFromJSONObject(
-        manifest.getRawJson(),
-        arrayOf(
-          ExponentManifest.MANIFEST_ANDROID_INFO_KEY,
-          ExponentManifest.MANIFEST_SPLASH_INFO_KEY,
-          ExponentManifest.MANIFEST_SPLASH_BACKGROUND_COLOR_KEY
-        ),
-        arrayOf(
-          ExponentManifest.MANIFEST_SPLASH_INFO_KEY,
-          ExponentManifest.MANIFEST_SPLASH_BACKGROUND_COLOR_KEY
-        )
-      )
+      val androidSplashInfo = manifest.getAndroidSplashInfo()
+      val rootSplashInfo = manifest.getRootSplashInfo()
+      val backgroundColor = if (androidSplashInfo != null && androidSplashInfo.has(ExponentManifest.MANIFEST_SPLASH_BACKGROUND_COLOR_KEY)) {
+        androidSplashInfo.getString(ExponentManifest.MANIFEST_SPLASH_BACKGROUND_COLOR_KEY)
+      } else if (rootSplashInfo != null && rootSplashInfo.has(ExponentManifest.MANIFEST_SPLASH_BACKGROUND_COLOR_KEY)) {
+        rootSplashInfo.getString(ExponentManifest.MANIFEST_SPLASH_BACKGROUND_COLOR_KEY)
+      } else {
+        null
+      }
+
       return if (ColorParser.isValid(backgroundColor)) {
         Color.parseColor(backgroundColor)
       } else null
@@ -78,9 +74,7 @@ class ManagedAppSplashScreenConfiguration private constructor() {
      * - generic splash imageUrl
      */
     private fun parseImageUrl(manifest: RawManifest): String? {
-      val androidSplash = manifest.getRawJson()
-        .optJSONObject(ExponentManifest.MANIFEST_ANDROID_INFO_KEY)
-        ?.optJSONObject(ExponentManifest.MANIFEST_SPLASH_INFO_KEY)
+      val androidSplash = manifest.getAndroidSplashInfo()
       if (androidSplash != null) {
         val dpiRelatedImageUrl = getStringFromJSONObject(
           androidSplash,
@@ -94,18 +88,15 @@ class ManagedAppSplashScreenConfiguration private constructor() {
         }
       }
 
-      return getStringFromJSONObject(
-        manifest.getRawJson(),
-        arrayOf(
-          ExponentManifest.MANIFEST_ANDROID_INFO_KEY,
-          ExponentManifest.MANIFEST_SPLASH_INFO_KEY,
-          ExponentManifest.MANIFEST_SPLASH_IMAGE_URL_KEY
-        ),
-        arrayOf(
-          ExponentManifest.MANIFEST_SPLASH_INFO_KEY,
-          ExponentManifest.MANIFEST_SPLASH_IMAGE_URL_KEY
-        )
-      )
+      val androidSplashInfo = manifest.getAndroidSplashInfo()
+      val rootSplashInfo = manifest.getRootSplashInfo()
+      return if (androidSplashInfo != null && androidSplashInfo.has(ExponentManifest.MANIFEST_SPLASH_IMAGE_URL_KEY)) {
+        androidSplashInfo.getString(ExponentManifest.MANIFEST_SPLASH_IMAGE_URL_KEY)
+      } else if (rootSplashInfo != null && rootSplashInfo.has(ExponentManifest.MANIFEST_SPLASH_IMAGE_URL_KEY)) {
+        rootSplashInfo.getString(ExponentManifest.MANIFEST_SPLASH_IMAGE_URL_KEY)
+      } else {
+        null
+      }
     }
 
     private fun getStringFromJSONObject(jsonObject: JSONObject, vararg paths: Array<String>): String? {

--- a/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.java
+++ b/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.java
@@ -48,7 +48,6 @@ import de.greenrobot.event.EventBus;
 import expo.modules.notifications.notifications.model.NotificationResponse;
 import expo.modules.notifications.service.NotificationsService;
 import expo.modules.notifications.service.delegates.ExpoHandlingDelegate;
-import expo.modules.updates.manifest.Manifest;
 import expo.modules.updates.manifest.ManifestFactory;
 import expo.modules.updates.manifest.raw.RawManifest;
 import host.exp.exponent.ExpoUpdatesAppLoader;
@@ -777,8 +776,7 @@ public class Kernel extends KernelInterface {
     Kernel.ExperienceActivityTask task = getExperienceActivityTask(manifestUrl);
     task.bundleUrl = bundleUrl;
 
-    JSONObject manifestJSON = mExponentManifest.normalizeManifest(manifestUrl, manifest.getRawJson());
-    manifest = ManifestFactory.INSTANCE.getRawManifestFromJson(manifestJSON);
+    mExponentManifest.normalizeManifestInPlace(manifestUrl, manifest);
 
     JSONObject opts = new JSONObject();
 

--- a/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.java
+++ b/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.java
@@ -776,7 +776,7 @@ public class Kernel extends KernelInterface {
     Kernel.ExperienceActivityTask task = getExperienceActivityTask(manifestUrl);
     task.bundleUrl = bundleUrl;
 
-    mExponentManifest.normalizeManifestInPlace(manifestUrl, manifest);
+    ExponentManifest.normalizeRawManifestInPlace(manifest, manifestUrl);
 
     JSONObject opts = new JSONObject();
 

--- a/android/expoview/src/main/java/host/exp/exponent/notifications/NotificationHelper.java
+++ b/android/expoview/src/main/java/host/exp/exponent/notifications/NotificationHelper.java
@@ -558,7 +558,7 @@ public class NotificationHelper {
     final int id,
     final HashMap<String, Object> data,
     final HashMap options,
-    final JSONObject manifest,
+    final RawManifest manifest,
     final Listener listener) {
 
     HashMap<String, java.io.Serializable> details = new HashMap<>();
@@ -568,7 +568,7 @@ public class NotificationHelper {
     String experienceId;
 
     try {
-      experienceId = manifest.getString(ExponentManifest.MANIFEST_ID_KEY);
+      experienceId = manifest.getID();
       details.put("experienceId", experienceId);
     } catch (Exception e) {
       listener.onFailure(new Exception("Requires Experience Id"));

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/ExponentPackage.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/ExponentPackage.java
@@ -183,7 +183,7 @@ public class ExponentPackage implements ReactPackage {
     }
     if (!mIsKernel && !Constants.isStandaloneApp()) {
       // We need DevMenuModule only in non-home and non-standalone apps.
-      nativeModules.add(new DevMenuModule(reactContext, mExperienceProperties, mManifest.getRawJson()));
+      nativeModules.add(new DevMenuModule(reactContext, mExperienceProperties, mManifest));
     }
 
     if (isVerified) {
@@ -191,7 +191,7 @@ public class ExponentPackage implements ReactPackage {
         ExperienceId experienceId = ExperienceId.create(mManifest.getID());
         ScopedContext scopedContext = new ScopedContext(reactContext, experienceId.getUrlEncoded());
 
-        nativeModules.add(new NotificationsModule(reactContext, mManifest.getRawJson(), mExperienceProperties));
+        nativeModules.add(new NotificationsModule(reactContext, mManifest, mExperienceProperties));
         nativeModules.add(new RNViewShotModule(reactContext, scopedContext));
         nativeModules.add(new RandomModule(reactContext));
         nativeModules.add(new ExponentTestNativeModule(reactContext));
@@ -225,7 +225,7 @@ public class ExponentPackage implements ReactPackage {
         // Call to create native modules has to be at the bottom --
         // -- ExpoModuleRegistryAdapter uses the list of native modules
         // to create Bindings for internal modules.
-        nativeModules.addAll(mModuleRegistryAdapter.createNativeModules(scopedContext, experienceId, mExperienceProperties, mManifest.getRawJson(), nativeModules));
+        nativeModules.addAll(mModuleRegistryAdapter.createNativeModules(scopedContext, experienceId, mExperienceProperties, mManifest, nativeModules));
       } catch (JSONException | UnsupportedEncodingException e) {
         EXL.e(TAG, e.toString());
       }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/internal/DevMenuModule.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/internal/DevMenuModule.kt
@@ -12,6 +12,7 @@ import com.facebook.react.bridge.UiThreadUtil
 import com.facebook.react.devsupport.DevInternalSettings
 import com.facebook.react.devsupport.DevSupportManagerImpl
 import com.facebook.react.devsupport.HMRClient
+import expo.modules.updates.manifest.raw.RawManifest
 import host.exp.exponent.di.NativeModuleDepsProvider
 import host.exp.exponent.experience.ExperienceActivity
 import host.exp.exponent.experience.ReactNativeActivity
@@ -19,12 +20,10 @@ import host.exp.exponent.kernel.DevMenuManager
 import host.exp.exponent.kernel.DevMenuModuleInterface
 import host.exp.exponent.kernel.KernelConstants
 import host.exp.expoview.R
-import org.json.JSONException
-import org.json.JSONObject
 import java.util.*
 import javax.inject.Inject
 
-class DevMenuModule(reactContext: ReactApplicationContext, val experienceProperties: Map<String, Any>, val manifest: JSONObject?) : ReactContextBaseJavaModule(reactContext), LifecycleEventListener, DevMenuModuleInterface {
+class DevMenuModule(reactContext: ReactApplicationContext, val experienceProperties: Map<String, Any>, val manifest: RawManifest?) : ReactContextBaseJavaModule(reactContext), LifecycleEventListener, DevMenuModuleInterface {
 
   @Inject
   internal var devMenuManager: DevMenuManager? = null
@@ -57,7 +56,7 @@ class DevMenuModule(reactContext: ReactApplicationContext, val experiencePropert
     val taskBundle = Bundle()
 
     taskBundle.putString("manifestUrl", getManifestUrl())
-    taskBundle.putString("manifestString", manifest.toString())
+    taskBundle.putString("manifestString", manifest?.getRawJson().toString())
 
     bundle.putBundle("task", taskBundle)
     bundle.putString("uuid", UUID.randomUUID().toString())
@@ -165,11 +164,7 @@ class DevMenuModule(reactContext: ReactApplicationContext, val experiencePropert
    * Returns boolean value determining whether this app supports developer tools.
    */
   override fun isDevSupportEnabled(): Boolean {
-    return try {
-      manifest?.getJSONObject("developer")?.get("tool") != null
-    } catch (e: JSONException) {
-      false
-    }
+    return manifest != null && manifest.isUsingDeveloperTool()
   }
 
   //endregion DevMenuModuleInterface

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ConstantsBinding.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ConstantsBinding.java
@@ -17,6 +17,7 @@ import javax.inject.Inject;
 
 import androidx.annotation.Nullable;
 import expo.modules.constants.ConstantsService;
+import expo.modules.updates.manifest.raw.RawManifest;
 import host.exp.exponent.Constants;
 import host.exp.exponent.di.NativeModuleDepsProvider;
 import host.exp.exponent.kernel.ExpoViewKernel;
@@ -29,7 +30,7 @@ public class ConstantsBinding extends ConstantsService implements ConstantsInter
   ExponentSharedPreferences mExponentSharedPreferences;
 
   private final Map<String, Object> mExperienceProperties;
-  private JSONObject mManifest;
+  private RawManifest mManifest;
 
   private static int convertPixelsToDp(float px, Context context) {
     Resources resources = context.getResources();
@@ -38,7 +39,7 @@ public class ConstantsBinding extends ConstantsService implements ConstantsInter
     return (int) dp;
   }
 
-  public ConstantsBinding(Context context, Map<String, Object> experienceProperties, JSONObject manifest) {
+  public ConstantsBinding(Context context, Map<String, Object> experienceProperties, RawManifest manifest) {
     super(context);
     NativeModuleDepsProvider.getInstance().inject(ConstantsBinding.class, this);
 
@@ -55,7 +56,7 @@ public class ConstantsBinding extends ConstantsService implements ConstantsInter
     Map<String, Object> constants = super.getConstants();
 
     constants.put("expoVersion", ExpoViewKernel.getInstance().getVersionName());
-    constants.put("manifest", mManifest.toString());
+    constants.put("manifest", mManifest.getRawJson().toString());
     constants.put("nativeAppVersion", ExpoViewKernel.getInstance().getVersionName());
     constants.put("nativeBuildVersion", Constants.ANDROID_VERSION_CODE);
     constants.put("supportedExpoSdks", Constants.SDK_VERSIONS_LIST);
@@ -81,7 +82,7 @@ public class ConstantsBinding extends ConstantsService implements ConstantsInter
 
   public String getAppId() {
     try {
-      return mManifest.getString("id");
+      return mManifest.getID();
     } catch (JSONException e) {
       return null;
     }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ExpoModuleRegistryAdapter.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ExpoModuleRegistryAdapter.java
@@ -13,6 +13,7 @@ import org.unimodules.core.interfaces.RegistryLifecycleListener;
 import java.util.List;
 import java.util.Map;
 
+import expo.modules.updates.manifest.raw.RawManifest;
 import host.exp.exponent.kernel.ExperienceId;
 import versioned.host.exp.exponent.modules.api.notifications.channels.ScopedNotificationsChannelsProvider;
 import host.exp.exponent.utils.ScopedContext;
@@ -37,7 +38,7 @@ public class ExpoModuleRegistryAdapter extends ModuleRegistryAdapter implements 
     super(moduleRegistryProvider);
   }
 
-  public List<NativeModule> createNativeModules(ScopedContext scopedContext, ExperienceId experienceId, Map<String, Object> experienceProperties, JSONObject manifest, List<NativeModule> otherModules) {
+  public List<NativeModule> createNativeModules(ScopedContext scopedContext, ExperienceId experienceId, Map<String, Object> experienceProperties, RawManifest manifest, List<NativeModule> otherModules) {
     ModuleRegistry moduleRegistry = mModuleRegistryProvider.get(scopedContext);
 
     // Overriding sensor services from expo-sensors for scoped implementations using kernel services

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ScopedErrorRecoveryModule.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ScopedErrorRecoveryModule.kt
@@ -4,17 +4,18 @@ import android.content.Context
 import android.content.SharedPreferences
 import expo.modules.errorrecovery.ErrorRecoveryModule
 import expo.modules.errorrecovery.RECOVERY_STORE
+import expo.modules.updates.manifest.raw.RawManifest
 import host.exp.exponent.ExponentManifest
 import host.exp.exponent.kernel.ExperienceId
 import org.json.JSONObject
 
 class ScopedErrorRecoveryModule(
   context: Context,
-  manifest: JSONObject,
+  manifest: RawManifest,
   val experienceId: ExperienceId
 ) : ErrorRecoveryModule(context) {
   override val mSharedPreferences: SharedPreferences = run {
-    val currentSDKVersion = manifest.optString(ExponentManifest.MANIFEST_SDK_VERSION_KEY)
+    val currentSDKVersion = manifest.getSDKVersionNullable()
     context.applicationContext.getSharedPreferences(
         "$RECOVERY_STORE.$currentSDKVersion",
         Context.MODE_PRIVATE

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ScopedFirebaseCoreService.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ScopedFirebaseCoreService.java
@@ -6,6 +6,7 @@ import android.util.Base64;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
+import expo.modules.updates.manifest.raw.RawManifest;
 import host.exp.exponent.kernel.ExperienceId;
 
 import com.google.firebase.FirebaseApp;
@@ -33,7 +34,7 @@ public class ScopedFirebaseCoreService extends FirebaseCoreService implements Re
   private String mAppName;
   private FirebaseOptions mAppOptions;
 
-  public ScopedFirebaseCoreService(Context context, JSONObject manifest, ExperienceId experienceId) {
+  public ScopedFirebaseCoreService(Context context, RawManifest manifest, ExperienceId experienceId) {
     super(context);
 
     // Get the default firebase app name
@@ -171,13 +172,12 @@ public class ScopedFirebaseCoreService extends FirebaseCoreService implements Re
     return client;
   }
 
-  private static FirebaseOptions getOptionsFromManifest(JSONObject manifest) {
+  private static FirebaseOptions getOptionsFromManifest(RawManifest manifest) {
     try {
-      JSONObject android = manifest.optJSONObject("android");
-      String googleServicesFileString = (android != null) ? android.optString("googleServicesFile", null) : null;
+      String googleServicesFileString = manifest.getAndroidGoogleServicesFile();
       JSONObject googleServicesFile = (googleServicesFileString != null) ? new JSONObject(googleServicesFileString)
         : null;
-      String packageName = (android != null) ? android.optString("package") : "";
+      String packageName = manifest.getAndroidPackageName() != null ? manifest.getAndroidPackageName() : "";
 
       // Read project-info settings
       // https://developers.google.com/android/guides/google-services-plugin

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ScopedModuleRegistryAdapter.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ScopedModuleRegistryAdapter.java
@@ -9,10 +9,11 @@ import org.json.JSONObject;
 import java.util.List;
 import java.util.Map;
 
+import expo.modules.updates.manifest.raw.RawManifest;
 import host.exp.exponent.kernel.ExperienceId;
 import host.exp.exponent.utils.ScopedContext;
 
 public interface ScopedModuleRegistryAdapter {
   List<ViewManager> createViewManagers(ReactApplicationContext reactContext);
-  List<NativeModule> createNativeModules(ScopedContext scopedContext, ExperienceId experienceId, Map<String, Object> experienceProperties, JSONObject manifest, List<NativeModule> otherModules);
+  List<NativeModule> createNativeModules(ScopedContext scopedContext, ExperienceId experienceId, Map<String, Object> experienceProperties, RawManifest manifest, List<NativeModule> otherModules);
 }

--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/host/exp/exponent/ExponentPackage.java
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/host/exp/exponent/ExponentPackage.java
@@ -177,7 +177,7 @@ public class ExponentPackage implements ReactPackage {
     }
     if (!mIsKernel && !Constants.isStandaloneApp()) {
       // We need DevMenuModule only in non-home and non-standalone apps.
-      nativeModules.add(new DevMenuModule(reactContext, mExperienceProperties, mManifest.getRawJson()));
+      nativeModules.add(new DevMenuModule(reactContext, mExperienceProperties, mManifest));
     }
 
     if (isVerified) {
@@ -185,7 +185,7 @@ public class ExponentPackage implements ReactPackage {
         ExperienceId experienceId = ExperienceId.create(mManifest.getID());
         ScopedContext scopedContext = new ScopedContext(reactContext, experienceId.getUrlEncoded());
 
-        nativeModules.add(new NotificationsModule(reactContext, mManifest.getRawJson(), mExperienceProperties));
+        nativeModules.add(new NotificationsModule(reactContext, mManifest, mExperienceProperties));
         nativeModules.add(new RNViewShotModule(reactContext, scopedContext));
         nativeModules.add(new RandomModule(reactContext));
         nativeModules.add(new ExponentTestNativeModule(reactContext));
@@ -219,7 +219,7 @@ public class ExponentPackage implements ReactPackage {
         // Call to create native modules has to be at the bottom --
         // -- ExpoModuleRegistryAdapter uses the list of native modules
         // to create Bindings for internal modules.
-        nativeModules.addAll(mModuleRegistryAdapter.createNativeModules(scopedContext, experienceId, mExperienceProperties, mManifest.getRawJson(), nativeModules));
+        nativeModules.addAll(mModuleRegistryAdapter.createNativeModules(scopedContext, experienceId, mExperienceProperties, mManifest, nativeModules));
       } catch (JSONException | UnsupportedEncodingException e) {
         EXL.e(TAG, e.toString());
       }

--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/host/exp/exponent/modules/internal/DevMenuModule.kt
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/host/exp/exponent/modules/internal/DevMenuModule.kt
@@ -12,6 +12,7 @@ import abi39_0_0.com.facebook.react.bridge.UiThreadUtil
 import abi39_0_0.com.facebook.react.devsupport.DevInternalSettings
 import abi39_0_0.com.facebook.react.devsupport.DevSupportManagerImpl
 import abi39_0_0.com.facebook.react.devsupport.HMRClient
+import expo.modules.updates.manifest.raw.RawManifest
 import host.exp.exponent.di.NativeModuleDepsProvider
 import host.exp.exponent.experience.ExperienceActivity
 import host.exp.exponent.experience.ReactNativeActivity
@@ -19,12 +20,10 @@ import host.exp.exponent.kernel.DevMenuManager
 import host.exp.exponent.kernel.DevMenuModuleInterface
 import host.exp.exponent.kernel.KernelConstants
 import host.exp.expoview.R
-import org.json.JSONException
-import org.json.JSONObject
 import java.util.*
 import javax.inject.Inject
 
-class DevMenuModule(reactContext: ReactApplicationContext, val experienceProperties: Map<String, Any>, val manifest: JSONObject?) : ReactContextBaseJavaModule(reactContext), LifecycleEventListener, DevMenuModuleInterface {
+class DevMenuModule(reactContext: ReactApplicationContext, val experienceProperties: Map<String, Any>, val manifest: RawManifest?) : ReactContextBaseJavaModule(reactContext), LifecycleEventListener, DevMenuModuleInterface {
 
   @Inject
   internal var devMenuManager: DevMenuManager? = null
@@ -57,7 +56,7 @@ class DevMenuModule(reactContext: ReactApplicationContext, val experiencePropert
     val taskBundle = Bundle()
 
     taskBundle.putString("manifestUrl", getManifestUrl())
-    taskBundle.putString("manifestString", manifest.toString())
+    taskBundle.putString("manifestString", manifest?.getRawJson().toString())
 
     bundle.putBundle("task", taskBundle)
     bundle.putString("uuid", UUID.randomUUID().toString())
@@ -165,11 +164,7 @@ class DevMenuModule(reactContext: ReactApplicationContext, val experiencePropert
    * Returns boolean value determining whether this app supports developer tools.
    */
   override fun isDevSupportEnabled(): Boolean {
-    return try {
-      manifest?.getJSONObject("developer")?.get("tool") != null
-    } catch (e: JSONException) {
-      false
-    }
+    return manifest != null && manifest.isUsingDeveloperTool()
   }
 
   //endregion DevMenuModuleInterface

--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/host/exp/exponent/modules/universal/ConstantsBinding.java
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/host/exp/exponent/modules/universal/ConstantsBinding.java
@@ -17,6 +17,7 @@ import javax.inject.Inject;
 
 import androidx.annotation.Nullable;
 import abi39_0_0.expo.modules.constants.ConstantsService;
+import expo.modules.updates.manifest.raw.RawManifest;
 import host.exp.exponent.Constants;
 import host.exp.exponent.di.NativeModuleDepsProvider;
 import host.exp.exponent.kernel.ExpoViewKernel;
@@ -29,7 +30,7 @@ public class ConstantsBinding extends ConstantsService implements ConstantsInter
   ExponentSharedPreferences mExponentSharedPreferences;
 
   private final Map<String, Object> mExperienceProperties;
-  private JSONObject mManifest;
+  private RawManifest mManifest;
 
   private static int convertPixelsToDp(float px, Context context) {
     Resources resources = context.getResources();
@@ -38,7 +39,7 @@ public class ConstantsBinding extends ConstantsService implements ConstantsInter
     return (int) dp;
   }
 
-  public ConstantsBinding(Context context, Map<String, Object> experienceProperties, JSONObject manifest) {
+  public ConstantsBinding(Context context, Map<String, Object> experienceProperties, RawManifest manifest) {
     super(context);
     NativeModuleDepsProvider.getInstance().inject(ConstantsBinding.class, this);
 
@@ -55,7 +56,7 @@ public class ConstantsBinding extends ConstantsService implements ConstantsInter
     Map<String, Object> constants = super.getConstants();
 
     constants.put("expoVersion", ExpoViewKernel.getInstance().getVersionName());
-    constants.put("manifest", mManifest.toString());
+    constants.put("manifest", mManifest.getRawJson().toString());
     constants.put("nativeAppVersion", ExpoViewKernel.getInstance().getVersionName());
     constants.put("nativeBuildVersion", Constants.ANDROID_VERSION_CODE);
     constants.put("supportedExpoSdks", Constants.SDK_VERSIONS_LIST);
@@ -80,7 +81,7 @@ public class ConstantsBinding extends ConstantsService implements ConstantsInter
 
   public String getAppId() {
     try {
-      return mManifest.getString("id");
+      return mManifest.getID();
     } catch (JSONException e) {
       return null;
     }

--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/host/exp/exponent/modules/universal/ExpoModuleRegistryAdapter.java
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/host/exp/exponent/modules/universal/ExpoModuleRegistryAdapter.java
@@ -13,6 +13,7 @@ import abi39_0_0.org.unimodules.core.interfaces.RegistryLifecycleListener;
 import java.util.List;
 import java.util.Map;
 
+import expo.modules.updates.manifest.raw.RawManifest;
 import host.exp.exponent.kernel.ExperienceId;
 import abi39_0_0.host.exp.exponent.modules.api.notifications.channels.ScopedNotificationsChannelsProvider;
 import host.exp.exponent.utils.ScopedContext;
@@ -36,7 +37,7 @@ public class ExpoModuleRegistryAdapter extends ModuleRegistryAdapter implements 
     super(moduleRegistryProvider);
   }
 
-  public List<NativeModule> createNativeModules(ScopedContext scopedContext, ExperienceId experienceId, Map<String, Object> experienceProperties, JSONObject manifest, List<NativeModule> otherModules) {
+  public List<NativeModule> createNativeModules(ScopedContext scopedContext, ExperienceId experienceId, Map<String, Object> experienceProperties, RawManifest manifest, List<NativeModule> otherModules) {
     ModuleRegistry moduleRegistry = mModuleRegistryProvider.get(scopedContext);
 
     // Overriding sensor services from expo-sensors for scoped implementations using kernel services

--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/host/exp/exponent/modules/universal/ScopedErrorRecoveryModule.kt
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/host/exp/exponent/modules/universal/ScopedErrorRecoveryModule.kt
@@ -4,17 +4,16 @@ import android.content.Context
 import android.content.SharedPreferences
 import abi39_0_0.expo.modules.errorrecovery.ErrorRecoveryModule
 import abi39_0_0.expo.modules.errorrecovery.RECOVERY_STORE
-import host.exp.exponent.ExponentManifest
+import expo.modules.updates.manifest.raw.RawManifest
 import host.exp.exponent.kernel.ExperienceId
-import org.json.JSONObject
 
 class ScopedErrorRecoveryModule(
   context: Context,
-  manifest: JSONObject,
+  manifest: RawManifest,
   val experienceId: ExperienceId
 ) : ErrorRecoveryModule(context) {
   override val mSharedPreferences: SharedPreferences = run {
-    val currentSDKVersion = manifest.optString(ExponentManifest.MANIFEST_SDK_VERSION_KEY)
+    val currentSDKVersion = manifest.getSDKVersionNullable()
     context.applicationContext.getSharedPreferences(
         "$RECOVERY_STORE.$currentSDKVersion",
         Context.MODE_PRIVATE

--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/host/exp/exponent/modules/universal/ScopedFacebookModule.java
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/host/exp/exponent/modules/universal/ScopedFacebookModule.java
@@ -13,6 +13,7 @@ import abi39_0_0.org.unimodules.core.arguments.ReadableArguments;
 import abi39_0_0.org.unimodules.core.interfaces.LifecycleEventListener;
 
 import abi39_0_0.expo.modules.facebook.FacebookModule;
+import expo.modules.updates.manifest.raw.RawManifest;
 import host.exp.exponent.kernel.ExperienceId;
 
 public class ScopedFacebookModule extends FacebookModule implements LifecycleEventListener {
@@ -22,7 +23,7 @@ public class ScopedFacebookModule extends FacebookModule implements LifecycleEve
   private boolean mIsInitialized = false;
   private SharedPreferences mSharedPreferences;
 
-  public ScopedFacebookModule(Context context, JSONObject manifest) {
+  public ScopedFacebookModule(Context context, RawManifest manifest) {
     super(context);
 
     mSharedPreferences = context.getSharedPreferences(getClass().getCanonicalName(), Context.MODE_PRIVATE);
@@ -31,9 +32,9 @@ public class ScopedFacebookModule extends FacebookModule implements LifecycleEve
     String facebookAppId = null;
     String facebookApplicationName = null;
     try {
-      facebookAppId = manifest.getString("facebookAppId");
-      facebookApplicationName = manifest.getString("facebookDisplayName");
-      manifestDefinesAutoInitEnabled = manifest.getBoolean("facebookAutoInitEnabled");
+      facebookAppId = manifest.getFacebookAppId();
+      facebookApplicationName = manifest.getFacebookApplicationName();
+      manifestDefinesAutoInitEnabled = manifest.getFacebookAutoInitEnabled();
     } catch (JSONException e) {
       // do nothing
     }

--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/host/exp/exponent/modules/universal/ScopedFirebaseCoreService.java
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/host/exp/exponent/modules/universal/ScopedFirebaseCoreService.java
@@ -6,6 +6,7 @@ import android.util.Base64;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
+import expo.modules.updates.manifest.raw.RawManifest;
 import host.exp.exponent.kernel.ExperienceId;
 
 import com.google.firebase.FirebaseApp;
@@ -33,7 +34,7 @@ public class ScopedFirebaseCoreService extends FirebaseCoreService implements Re
   private String mAppName;
   private FirebaseOptions mAppOptions;
 
-  public ScopedFirebaseCoreService(Context context, JSONObject manifest, ExperienceId experienceId) {
+  public ScopedFirebaseCoreService(Context context, RawManifest manifest, ExperienceId experienceId) {
     super(context);
 
     // Get the default firebase app name
@@ -171,13 +172,12 @@ public class ScopedFirebaseCoreService extends FirebaseCoreService implements Re
     return client;
   }
 
-  private static FirebaseOptions getOptionsFromManifest(JSONObject manifest) {
+  private static FirebaseOptions getOptionsFromManifest(RawManifest manifest) {
     try {
-      JSONObject android = manifest.optJSONObject("android");
-      String googleServicesFileString = (android != null) ? android.optString("googleServicesFile", null) : null;
+      String googleServicesFileString = manifest.getAndroidGoogleServicesFile();
       JSONObject googleServicesFile = (googleServicesFileString != null) ? new JSONObject(googleServicesFileString)
         : null;
-      String packageName = (android != null) ? android.optString("package") : "";
+      String packageName = manifest.getAndroidPackageName() != null ? manifest.getAndroidPackageName() : "";
 
       // Read project-info settings
       // https://developers.google.com/android/guides/google-services-plugin

--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/host/exp/exponent/modules/universal/ScopedModuleRegistryAdapter.java
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/host/exp/exponent/modules/universal/ScopedModuleRegistryAdapter.java
@@ -9,10 +9,11 @@ import org.json.JSONObject;
 import java.util.List;
 import java.util.Map;
 
+import expo.modules.updates.manifest.raw.RawManifest;
 import host.exp.exponent.kernel.ExperienceId;
 import host.exp.exponent.utils.ScopedContext;
 
 public interface ScopedModuleRegistryAdapter {
   List<ViewManager> createViewManagers(ReactApplicationContext reactContext);
-  List<NativeModule> createNativeModules(ScopedContext scopedContext, ExperienceId experienceId, Map<String, Object> experienceProperties, JSONObject manifest, List<NativeModule> otherModules);
+  List<NativeModule> createNativeModules(ScopedContext scopedContext, ExperienceId experienceId, Map<String, Object> experienceProperties, RawManifest manifest, List<NativeModule> otherModules);
 }

--- a/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/host/exp/exponent/ExponentPackage.java
+++ b/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/host/exp/exponent/ExponentPackage.java
@@ -177,7 +177,7 @@ public class ExponentPackage implements ReactPackage {
     }
     if (!mIsKernel && !Constants.isStandaloneApp()) {
       // We need DevMenuModule only in non-home and non-standalone apps.
-      nativeModules.add(new DevMenuModule(reactContext, mExperienceProperties, mManifest.getRawJson()));
+      nativeModules.add(new DevMenuModule(reactContext, mExperienceProperties, mManifest));
     }
 
     if (isVerified) {
@@ -185,7 +185,7 @@ public class ExponentPackage implements ReactPackage {
         ExperienceId experienceId = ExperienceId.create(mManifest.getID());
         ScopedContext scopedContext = new ScopedContext(reactContext, experienceId.getUrlEncoded());
 
-        nativeModules.add(new NotificationsModule(reactContext, mManifest.getRawJson(), mExperienceProperties));
+        nativeModules.add(new NotificationsModule(reactContext, mManifest, mExperienceProperties));
         nativeModules.add(new RNViewShotModule(reactContext, scopedContext));
         nativeModules.add(new RandomModule(reactContext));
         nativeModules.add(new ExponentTestNativeModule(reactContext));
@@ -219,7 +219,7 @@ public class ExponentPackage implements ReactPackage {
         // Call to create native modules has to be at the bottom --
         // -- ExpoModuleRegistryAdapter uses the list of native modules
         // to create Bindings for internal modules.
-        nativeModules.addAll(mModuleRegistryAdapter.createNativeModules(scopedContext, experienceId, mExperienceProperties, mManifest.getRawJson(), nativeModules));
+        nativeModules.addAll(mModuleRegistryAdapter.createNativeModules(scopedContext, experienceId, mExperienceProperties, mManifest, nativeModules));
       } catch (JSONException | UnsupportedEncodingException e) {
         EXL.e(TAG, e.toString());
       }

--- a/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/host/exp/exponent/modules/internal/DevMenuModule.kt
+++ b/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/host/exp/exponent/modules/internal/DevMenuModule.kt
@@ -12,6 +12,7 @@ import abi40_0_0.com.facebook.react.bridge.UiThreadUtil
 import abi40_0_0.com.facebook.react.devsupport.DevInternalSettings
 import abi40_0_0.com.facebook.react.devsupport.DevSupportManagerImpl
 import abi40_0_0.com.facebook.react.devsupport.HMRClient
+import expo.modules.updates.manifest.raw.RawManifest
 import host.exp.exponent.di.NativeModuleDepsProvider
 import host.exp.exponent.experience.ExperienceActivity
 import host.exp.exponent.experience.ReactNativeActivity
@@ -19,12 +20,10 @@ import host.exp.exponent.kernel.DevMenuManager
 import host.exp.exponent.kernel.DevMenuModuleInterface
 import host.exp.exponent.kernel.KernelConstants
 import host.exp.expoview.R
-import org.json.JSONException
-import org.json.JSONObject
 import java.util.*
 import javax.inject.Inject
 
-class DevMenuModule(reactContext: ReactApplicationContext, val experienceProperties: Map<String, Any>, val manifest: JSONObject?) : ReactContextBaseJavaModule(reactContext), LifecycleEventListener, DevMenuModuleInterface {
+class DevMenuModule(reactContext: ReactApplicationContext, val experienceProperties: Map<String, Any>, val manifest: RawManifest?) : ReactContextBaseJavaModule(reactContext), LifecycleEventListener, DevMenuModuleInterface {
 
   @Inject
   internal var devMenuManager: DevMenuManager? = null
@@ -57,7 +56,7 @@ class DevMenuModule(reactContext: ReactApplicationContext, val experiencePropert
     val taskBundle = Bundle()
 
     taskBundle.putString("manifestUrl", getManifestUrl())
-    taskBundle.putString("manifestString", manifest.toString())
+    taskBundle.putString("manifestString", manifest?.getRawJson().toString())
 
     bundle.putBundle("task", taskBundle)
     bundle.putString("uuid", UUID.randomUUID().toString())
@@ -165,11 +164,7 @@ class DevMenuModule(reactContext: ReactApplicationContext, val experiencePropert
    * Returns boolean value determining whether this app supports developer tools.
    */
   override fun isDevSupportEnabled(): Boolean {
-    return try {
-      manifest?.getJSONObject("developer")?.get("tool") != null
-    } catch (e: JSONException) {
-      false
-    }
+    return manifest != null && manifest.isUsingDeveloperTool()
   }
 
   //endregion DevMenuModuleInterface

--- a/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/host/exp/exponent/modules/universal/ConstantsBinding.java
+++ b/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/host/exp/exponent/modules/universal/ConstantsBinding.java
@@ -17,6 +17,7 @@ import javax.inject.Inject;
 
 import androidx.annotation.Nullable;
 import abi40_0_0.expo.modules.constants.ConstantsService;
+import expo.modules.updates.manifest.raw.RawManifest;
 import host.exp.exponent.Constants;
 import host.exp.exponent.di.NativeModuleDepsProvider;
 import host.exp.exponent.kernel.ExpoViewKernel;
@@ -29,7 +30,7 @@ public class ConstantsBinding extends ConstantsService implements ConstantsInter
   ExponentSharedPreferences mExponentSharedPreferences;
 
   private final Map<String, Object> mExperienceProperties;
-  private JSONObject mManifest;
+  private RawManifest mManifest;
 
   private static int convertPixelsToDp(float px, Context context) {
     Resources resources = context.getResources();
@@ -38,7 +39,7 @@ public class ConstantsBinding extends ConstantsService implements ConstantsInter
     return (int) dp;
   }
 
-  public ConstantsBinding(Context context, Map<String, Object> experienceProperties, JSONObject manifest) {
+  public ConstantsBinding(Context context, Map<String, Object> experienceProperties, RawManifest manifest) {
     super(context);
     NativeModuleDepsProvider.getInstance().inject(ConstantsBinding.class, this);
 
@@ -55,7 +56,7 @@ public class ConstantsBinding extends ConstantsService implements ConstantsInter
     Map<String, Object> constants = super.getConstants();
 
     constants.put("expoVersion", ExpoViewKernel.getInstance().getVersionName());
-    constants.put("manifest", mManifest.toString());
+    constants.put("manifest", mManifest.getRawJson().toString());
     constants.put("nativeAppVersion", ExpoViewKernel.getInstance().getVersionName());
     constants.put("nativeBuildVersion", Constants.ANDROID_VERSION_CODE);
     constants.put("supportedExpoSdks", Constants.SDK_VERSIONS_LIST);
@@ -81,7 +82,7 @@ public class ConstantsBinding extends ConstantsService implements ConstantsInter
 
   public String getAppId() {
     try {
-      return mManifest.getString("id");
+      return mManifest.getID();
     } catch (JSONException e) {
       return null;
     }

--- a/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/host/exp/exponent/modules/universal/ExpoModuleRegistryAdapter.java
+++ b/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/host/exp/exponent/modules/universal/ExpoModuleRegistryAdapter.java
@@ -13,6 +13,7 @@ import abi40_0_0.org.unimodules.core.interfaces.RegistryLifecycleListener;
 import java.util.List;
 import java.util.Map;
 
+import expo.modules.updates.manifest.raw.RawManifest;
 import host.exp.exponent.kernel.ExperienceId;
 import abi40_0_0.host.exp.exponent.modules.api.notifications.channels.ScopedNotificationsChannelsProvider;
 import host.exp.exponent.utils.ScopedContext;
@@ -37,7 +38,7 @@ public class ExpoModuleRegistryAdapter extends ModuleRegistryAdapter implements 
     super(moduleRegistryProvider);
   }
 
-  public List<NativeModule> createNativeModules(ScopedContext scopedContext, ExperienceId experienceId, Map<String, Object> experienceProperties, JSONObject manifest, List<NativeModule> otherModules) {
+  public List<NativeModule> createNativeModules(ScopedContext scopedContext, ExperienceId experienceId, Map<String, Object> experienceProperties, RawManifest manifest, List<NativeModule> otherModules) {
     ModuleRegistry moduleRegistry = mModuleRegistryProvider.get(scopedContext);
 
     // Overriding sensor services from expo-sensors for scoped implementations using kernel services

--- a/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/host/exp/exponent/modules/universal/ScopedErrorRecoveryModule.kt
+++ b/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/host/exp/exponent/modules/universal/ScopedErrorRecoveryModule.kt
@@ -4,17 +4,18 @@ import android.content.Context
 import android.content.SharedPreferences
 import abi40_0_0.expo.modules.errorrecovery.ErrorRecoveryModule
 import abi40_0_0.expo.modules.errorrecovery.RECOVERY_STORE
+import expo.modules.updates.manifest.raw.RawManifest
 import host.exp.exponent.ExponentManifest
 import host.exp.exponent.kernel.ExperienceId
 import org.json.JSONObject
 
 class ScopedErrorRecoveryModule(
   context: Context,
-  manifest: JSONObject,
+  manifest: RawManifest,
   val experienceId: ExperienceId
 ) : ErrorRecoveryModule(context) {
   override val mSharedPreferences: SharedPreferences = run {
-    val currentSDKVersion = manifest.optString(ExponentManifest.MANIFEST_SDK_VERSION_KEY)
+    val currentSDKVersion = manifest.getSDKVersionNullable()
     context.applicationContext.getSharedPreferences(
         "$RECOVERY_STORE.$currentSDKVersion",
         Context.MODE_PRIVATE

--- a/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/host/exp/exponent/modules/universal/ScopedFacebookModule.java
+++ b/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/host/exp/exponent/modules/universal/ScopedFacebookModule.java
@@ -13,6 +13,7 @@ import abi40_0_0.org.unimodules.core.arguments.ReadableArguments;
 import abi40_0_0.org.unimodules.core.interfaces.LifecycleEventListener;
 
 import abi40_0_0.expo.modules.facebook.FacebookModule;
+import expo.modules.updates.manifest.raw.RawManifest;
 import host.exp.exponent.kernel.ExperienceId;
 
 public class ScopedFacebookModule extends FacebookModule implements LifecycleEventListener {
@@ -22,7 +23,7 @@ public class ScopedFacebookModule extends FacebookModule implements LifecycleEve
   private boolean mIsInitialized = false;
   private SharedPreferences mSharedPreferences;
 
-  public ScopedFacebookModule(Context context, JSONObject manifest) {
+  public ScopedFacebookModule(Context context, RawManifest manifest) {
     super(context);
 
     mSharedPreferences = context.getSharedPreferences(getClass().getCanonicalName(), Context.MODE_PRIVATE);
@@ -31,9 +32,9 @@ public class ScopedFacebookModule extends FacebookModule implements LifecycleEve
     String facebookAppId = null;
     String facebookApplicationName = null;
     try {
-      facebookAppId = manifest.getString("facebookAppId");
-      facebookApplicationName = manifest.getString("facebookDisplayName");
-      manifestDefinesAutoInitEnabled = manifest.getBoolean("facebookAutoInitEnabled");
+      facebookAppId = manifest.getFacebookAppId();
+      facebookApplicationName = manifest.getFacebookApplicationName();
+      manifestDefinesAutoInitEnabled = manifest.getFacebookAutoInitEnabled();
     } catch (JSONException e) {
       // do nothing
     }

--- a/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/host/exp/exponent/modules/universal/ScopedFirebaseCoreService.java
+++ b/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/host/exp/exponent/modules/universal/ScopedFirebaseCoreService.java
@@ -6,6 +6,7 @@ import android.util.Base64;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
+import expo.modules.updates.manifest.raw.RawManifest;
 import host.exp.exponent.kernel.ExperienceId;
 
 import com.google.firebase.FirebaseApp;
@@ -33,7 +34,7 @@ public class ScopedFirebaseCoreService extends FirebaseCoreService implements Re
   private String mAppName;
   private FirebaseOptions mAppOptions;
 
-  public ScopedFirebaseCoreService(Context context, JSONObject manifest, ExperienceId experienceId) {
+  public ScopedFirebaseCoreService(Context context, RawManifest manifest, ExperienceId experienceId) {
     super(context);
 
     // Get the default firebase app name
@@ -171,13 +172,12 @@ public class ScopedFirebaseCoreService extends FirebaseCoreService implements Re
     return client;
   }
 
-  private static FirebaseOptions getOptionsFromManifest(JSONObject manifest) {
+  private static FirebaseOptions getOptionsFromManifest(RawManifest manifest) {
     try {
-      JSONObject android = manifest.optJSONObject("android");
-      String googleServicesFileString = (android != null) ? android.optString("googleServicesFile", null) : null;
+      String googleServicesFileString = manifest.getAndroidGoogleServicesFile();
       JSONObject googleServicesFile = (googleServicesFileString != null) ? new JSONObject(googleServicesFileString)
         : null;
-      String packageName = (android != null) ? android.optString("package") : "";
+      String packageName = manifest.getAndroidPackageName() != null ? manifest.getAndroidPackageName() : "";
 
       // Read project-info settings
       // https://developers.google.com/android/guides/google-services-plugin

--- a/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/host/exp/exponent/modules/universal/ScopedModuleRegistryAdapter.java
+++ b/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/host/exp/exponent/modules/universal/ScopedModuleRegistryAdapter.java
@@ -9,10 +9,11 @@ import org.json.JSONObject;
 import java.util.List;
 import java.util.Map;
 
+import expo.modules.updates.manifest.raw.RawManifest;
 import host.exp.exponent.kernel.ExperienceId;
 import host.exp.exponent.utils.ScopedContext;
 
 public interface ScopedModuleRegistryAdapter {
   List<ViewManager> createViewManagers(ReactApplicationContext reactContext);
-  List<NativeModule> createNativeModules(ScopedContext scopedContext, ExperienceId experienceId, Map<String, Object> experienceProperties, JSONObject manifest, List<NativeModule> otherModules);
+  List<NativeModule> createNativeModules(ScopedContext scopedContext, ExperienceId experienceId, Map<String, Object> experienceProperties, RawManifest manifest, List<NativeModule> otherModules);
 }

--- a/android/versioned-abis/expoview-abi41_0_0/src/main/java/abi41_0_0/host/exp/exponent/ExponentPackage.java
+++ b/android/versioned-abis/expoview-abi41_0_0/src/main/java/abi41_0_0/host/exp/exponent/ExponentPackage.java
@@ -183,7 +183,7 @@ public class ExponentPackage implements ReactPackage {
     }
     if (!mIsKernel && !Constants.isStandaloneApp()) {
       // We need DevMenuModule only in non-home and non-standalone apps.
-      nativeModules.add(new DevMenuModule(reactContext, mExperienceProperties, mManifest.getRawJson()));
+      nativeModules.add(new DevMenuModule(reactContext, mExperienceProperties, mManifest));
     }
 
     if (isVerified) {
@@ -191,7 +191,7 @@ public class ExponentPackage implements ReactPackage {
         ExperienceId experienceId = ExperienceId.create(mManifest.getID());
         ScopedContext scopedContext = new ScopedContext(reactContext, experienceId.getUrlEncoded());
 
-        nativeModules.add(new NotificationsModule(reactContext, mManifest.getRawJson(), mExperienceProperties));
+        nativeModules.add(new NotificationsModule(reactContext, mManifest, mExperienceProperties));
         nativeModules.add(new RNViewShotModule(reactContext, scopedContext));
         nativeModules.add(new RandomModule(reactContext));
         nativeModules.add(new ExponentTestNativeModule(reactContext));
@@ -225,7 +225,7 @@ public class ExponentPackage implements ReactPackage {
         // Call to create native modules has to be at the bottom --
         // -- ExpoModuleRegistryAdapter uses the list of native modules
         // to create Bindings for internal modules.
-        nativeModules.addAll(mModuleRegistryAdapter.createNativeModules(scopedContext, experienceId, mExperienceProperties, mManifest.getRawJson(), nativeModules));
+        nativeModules.addAll(mModuleRegistryAdapter.createNativeModules(scopedContext, experienceId, mExperienceProperties, mManifest, nativeModules));
       } catch (JSONException | UnsupportedEncodingException e) {
         EXL.e(TAG, e.toString());
       }

--- a/android/versioned-abis/expoview-abi41_0_0/src/main/java/abi41_0_0/host/exp/exponent/modules/internal/DevMenuModule.kt
+++ b/android/versioned-abis/expoview-abi41_0_0/src/main/java/abi41_0_0/host/exp/exponent/modules/internal/DevMenuModule.kt
@@ -12,6 +12,7 @@ import abi41_0_0.com.facebook.react.bridge.UiThreadUtil
 import abi41_0_0.com.facebook.react.devsupport.DevInternalSettings
 import abi41_0_0.com.facebook.react.devsupport.DevSupportManagerImpl
 import abi41_0_0.com.facebook.react.devsupport.HMRClient
+import expo.modules.updates.manifest.raw.RawManifest
 import host.exp.exponent.di.NativeModuleDepsProvider
 import host.exp.exponent.experience.ExperienceActivity
 import host.exp.exponent.experience.ReactNativeActivity
@@ -19,12 +20,10 @@ import host.exp.exponent.kernel.DevMenuManager
 import host.exp.exponent.kernel.DevMenuModuleInterface
 import host.exp.exponent.kernel.KernelConstants
 import host.exp.expoview.R
-import org.json.JSONException
-import org.json.JSONObject
 import java.util.*
 import javax.inject.Inject
 
-class DevMenuModule(reactContext: ReactApplicationContext, val experienceProperties: Map<String, Any>, val manifest: JSONObject?) : ReactContextBaseJavaModule(reactContext), LifecycleEventListener, DevMenuModuleInterface {
+class DevMenuModule(reactContext: ReactApplicationContext, val experienceProperties: Map<String, Any>, val manifest: RawManifest?) : ReactContextBaseJavaModule(reactContext), LifecycleEventListener, DevMenuModuleInterface {
 
   @Inject
   internal var devMenuManager: DevMenuManager? = null
@@ -57,7 +56,7 @@ class DevMenuModule(reactContext: ReactApplicationContext, val experiencePropert
     val taskBundle = Bundle()
 
     taskBundle.putString("manifestUrl", getManifestUrl())
-    taskBundle.putString("manifestString", manifest.toString())
+    taskBundle.putString("manifestString", manifest?.getRawJson().toString())
 
     bundle.putBundle("task", taskBundle)
     bundle.putString("uuid", UUID.randomUUID().toString())
@@ -165,11 +164,7 @@ class DevMenuModule(reactContext: ReactApplicationContext, val experiencePropert
    * Returns boolean value determining whether this app supports developer tools.
    */
   override fun isDevSupportEnabled(): Boolean {
-    return try {
-      manifest?.getJSONObject("developer")?.get("tool") != null
-    } catch (e: JSONException) {
-      false
-    }
+    return manifest != null && manifest.isUsingDeveloperTool()
   }
 
   //endregion DevMenuModuleInterface

--- a/android/versioned-abis/expoview-abi41_0_0/src/main/java/abi41_0_0/host/exp/exponent/modules/universal/ConstantsBinding.java
+++ b/android/versioned-abis/expoview-abi41_0_0/src/main/java/abi41_0_0/host/exp/exponent/modules/universal/ConstantsBinding.java
@@ -17,6 +17,7 @@ import javax.inject.Inject;
 
 import androidx.annotation.Nullable;
 import abi41_0_0.expo.modules.constants.ConstantsService;
+import expo.modules.updates.manifest.raw.RawManifest;
 import host.exp.exponent.Constants;
 import host.exp.exponent.di.NativeModuleDepsProvider;
 import host.exp.exponent.kernel.ExpoViewKernel;
@@ -29,7 +30,7 @@ public class ConstantsBinding extends ConstantsService implements ConstantsInter
   ExponentSharedPreferences mExponentSharedPreferences;
 
   private final Map<String, Object> mExperienceProperties;
-  private JSONObject mManifest;
+  private RawManifest mManifest;
 
   private static int convertPixelsToDp(float px, Context context) {
     Resources resources = context.getResources();
@@ -38,7 +39,7 @@ public class ConstantsBinding extends ConstantsService implements ConstantsInter
     return (int) dp;
   }
 
-  public ConstantsBinding(Context context, Map<String, Object> experienceProperties, JSONObject manifest) {
+  public ConstantsBinding(Context context, Map<String, Object> experienceProperties, RawManifest manifest) {
     super(context);
     NativeModuleDepsProvider.getInstance().inject(ConstantsBinding.class, this);
 
@@ -55,7 +56,7 @@ public class ConstantsBinding extends ConstantsService implements ConstantsInter
     Map<String, Object> constants = super.getConstants();
 
     constants.put("expoVersion", ExpoViewKernel.getInstance().getVersionName());
-    constants.put("manifest", mManifest.toString());
+    constants.put("manifest", mManifest.getRawJson().toString());
     constants.put("nativeAppVersion", ExpoViewKernel.getInstance().getVersionName());
     constants.put("nativeBuildVersion", Constants.ANDROID_VERSION_CODE);
     constants.put("supportedExpoSdks", Constants.SDK_VERSIONS_LIST);
@@ -81,7 +82,7 @@ public class ConstantsBinding extends ConstantsService implements ConstantsInter
 
   public String getAppId() {
     try {
-      return mManifest.getString("id");
+      return mManifest.getID();
     } catch (JSONException e) {
       return null;
     }

--- a/android/versioned-abis/expoview-abi41_0_0/src/main/java/abi41_0_0/host/exp/exponent/modules/universal/ExpoModuleRegistryAdapter.java
+++ b/android/versioned-abis/expoview-abi41_0_0/src/main/java/abi41_0_0/host/exp/exponent/modules/universal/ExpoModuleRegistryAdapter.java
@@ -13,6 +13,7 @@ import abi41_0_0.org.unimodules.core.interfaces.RegistryLifecycleListener;
 import java.util.List;
 import java.util.Map;
 
+import expo.modules.updates.manifest.raw.RawManifest;
 import host.exp.exponent.kernel.ExperienceId;
 import abi41_0_0.host.exp.exponent.modules.api.notifications.channels.ScopedNotificationsChannelsProvider;
 import host.exp.exponent.utils.ScopedContext;
@@ -37,7 +38,7 @@ public class ExpoModuleRegistryAdapter extends ModuleRegistryAdapter implements 
     super(moduleRegistryProvider);
   }
 
-  public List<NativeModule> createNativeModules(ScopedContext scopedContext, ExperienceId experienceId, Map<String, Object> experienceProperties, JSONObject manifest, List<NativeModule> otherModules) {
+  public List<NativeModule> createNativeModules(ScopedContext scopedContext, ExperienceId experienceId, Map<String, Object> experienceProperties, RawManifest manifest, List<NativeModule> otherModules) {
     ModuleRegistry moduleRegistry = mModuleRegistryProvider.get(scopedContext);
 
     // Overriding sensor services from expo-sensors for scoped implementations using kernel services

--- a/android/versioned-abis/expoview-abi41_0_0/src/main/java/abi41_0_0/host/exp/exponent/modules/universal/ScopedErrorRecoveryModule.kt
+++ b/android/versioned-abis/expoview-abi41_0_0/src/main/java/abi41_0_0/host/exp/exponent/modules/universal/ScopedErrorRecoveryModule.kt
@@ -4,17 +4,16 @@ import android.content.Context
 import android.content.SharedPreferences
 import abi41_0_0.expo.modules.errorrecovery.ErrorRecoveryModule
 import abi41_0_0.expo.modules.errorrecovery.RECOVERY_STORE
-import host.exp.exponent.ExponentManifest
+import expo.modules.updates.manifest.raw.RawManifest
 import host.exp.exponent.kernel.ExperienceId
-import org.json.JSONObject
 
 class ScopedErrorRecoveryModule(
   context: Context,
-  manifest: JSONObject,
+  manifest: RawManifest,
   val experienceId: ExperienceId
 ) : ErrorRecoveryModule(context) {
   override val mSharedPreferences: SharedPreferences = run {
-    val currentSDKVersion = manifest.optString(ExponentManifest.MANIFEST_SDK_VERSION_KEY)
+    val currentSDKVersion = manifest.getSDKVersionNullable()
     context.applicationContext.getSharedPreferences(
         "$RECOVERY_STORE.$currentSDKVersion",
         Context.MODE_PRIVATE

--- a/android/versioned-abis/expoview-abi41_0_0/src/main/java/abi41_0_0/host/exp/exponent/modules/universal/ScopedFirebaseCoreService.java
+++ b/android/versioned-abis/expoview-abi41_0_0/src/main/java/abi41_0_0/host/exp/exponent/modules/universal/ScopedFirebaseCoreService.java
@@ -6,6 +6,7 @@ import android.util.Base64;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
+import expo.modules.updates.manifest.raw.RawManifest;
 import host.exp.exponent.kernel.ExperienceId;
 
 import com.google.firebase.FirebaseApp;
@@ -33,7 +34,7 @@ public class ScopedFirebaseCoreService extends FirebaseCoreService implements Re
   private String mAppName;
   private FirebaseOptions mAppOptions;
 
-  public ScopedFirebaseCoreService(Context context, JSONObject manifest, ExperienceId experienceId) {
+  public ScopedFirebaseCoreService(Context context, RawManifest manifest, ExperienceId experienceId) {
     super(context);
 
     // Get the default firebase app name
@@ -171,13 +172,12 @@ public class ScopedFirebaseCoreService extends FirebaseCoreService implements Re
     return client;
   }
 
-  private static FirebaseOptions getOptionsFromManifest(JSONObject manifest) {
+  private static FirebaseOptions getOptionsFromManifest(RawManifest manifest) {
     try {
-      JSONObject android = manifest.optJSONObject("android");
-      String googleServicesFileString = (android != null) ? android.optString("googleServicesFile", null) : null;
+      String googleServicesFileString = manifest.getAndroidGoogleServicesFile();
       JSONObject googleServicesFile = (googleServicesFileString != null) ? new JSONObject(googleServicesFileString)
         : null;
-      String packageName = (android != null) ? android.optString("package") : "";
+      String packageName = manifest.getAndroidPackageName() != null ? manifest.getAndroidPackageName() : "";
 
       // Read project-info settings
       // https://developers.google.com/android/guides/google-services-plugin

--- a/android/versioned-abis/expoview-abi41_0_0/src/main/java/abi41_0_0/host/exp/exponent/modules/universal/ScopedModuleRegistryAdapter.java
+++ b/android/versioned-abis/expoview-abi41_0_0/src/main/java/abi41_0_0/host/exp/exponent/modules/universal/ScopedModuleRegistryAdapter.java
@@ -9,10 +9,11 @@ import org.json.JSONObject;
 import java.util.List;
 import java.util.Map;
 
+import expo.modules.updates.manifest.raw.RawManifest;
 import host.exp.exponent.kernel.ExperienceId;
 import host.exp.exponent.utils.ScopedContext;
 
 public interface ScopedModuleRegistryAdapter {
   List<ViewManager> createViewManagers(ReactApplicationContext reactContext);
-  List<NativeModule> createNativeModules(ScopedContext scopedContext, ExperienceId experienceId, Map<String, Object> experienceProperties, JSONObject manifest, List<NativeModule> otherModules);
+  List<NativeModule> createNativeModules(ScopedContext scopedContext, ExperienceId experienceId, Map<String, Object> experienceProperties, RawManifest manifest, List<NativeModule> otherModules);
 }

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -13,6 +13,8 @@
 - Split SelectionPolicy into 3 separate interfaces. (Android: [#12606](https://github.com/expo/expo/pull/12606) by [@esamelson](https://github.com/esamelson))
 - Add DatabaseIntegrityCheck and tests. (Android: [#12607](https://github.com/expo/expo/pull/12607) by [@esamelson](https://github.com/esamelson))
 - Add setter and resetter for SelectionPolicy. (Android: [#12609](https://github.com/expo/expo/pull/12609) by [@esamelson](https://github.com/esamelson))
+- Convert most remaining usages of JSON manifest to RawManifest. ([#12600](https://github.com/expo/expo/pull/12600) by [@wschurman](https://github.com/wschurman))
+
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/manifest/NewManifestTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/manifest/NewManifestTest.kt
@@ -65,14 +65,14 @@ class NewManifestTest {
     val manifestJsonWithRootLevelKeys =
       "{\"manifest\":{\"runtimeVersion\":\"1\",\"id\":\"0eef8214-4833-4089-9dff-b4138a14f196\",\"createdAt\":\"2020-11-11T00:17:54.797Z\",\"launchAsset\":{\"url\":\"https://url.to/bundle.js\",\"contentType\":\"application/javascript\"}}}"
     val manifest1: Manifest = NewManifest.fromRawManifest(
-      NewRawManifest(JSONObject(manifestJsonWithRootLevelKeys)),
+      NewRawManifest(NewRawManifest.normalizeNestedManifestJSON(JSONObject(manifestJsonWithRootLevelKeys))),
       null,
       createConfig()
     )
     val manifestJsonNoRootLevelKeys =
       "{\"runtimeVersion\":\"1\",\"id\":\"0eef8214-4833-4089-9dff-b4138a14f196\",\"createdAt\":\"2020-11-11T00:17:54.797Z\",\"launchAsset\":{\"url\":\"https://url.to/bundle.js\",\"contentType\":\"application/javascript\"}}"
     val manifest2: Manifest = NewManifest.fromRawManifest(
-      NewRawManifest(JSONObject(manifestJsonNoRootLevelKeys)),
+      NewRawManifest(NewRawManifest.normalizeNestedManifestJSON(JSONObject(manifestJsonNoRootLevelKeys))),
       null,
       createConfig()
     )

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ManifestFactory.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ManifestFactory.kt
@@ -19,7 +19,7 @@ object ManifestFactory {
                 LegacyManifest.fromLegacyRawManifest(LegacyRawManifest(manifestJson), configuration!!)
             }
             Integer.valueOf(expoProtocolVersion) == 0 -> {
-                NewManifest.fromRawManifest(NewRawManifest(manifestJson), httpResponse, configuration!!)
+                NewManifest.fromRawManifest(NewRawManifest(NewRawManifest.normalizeNestedManifestJSON(manifestJson)), httpResponse, configuration!!)
             }
             else -> {
                 throw Exception("Unsupported expo-protocol-version: $expoProtocolVersion")

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/NewManifest.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/NewManifest.kt
@@ -92,16 +92,12 @@ class NewManifest private constructor(
       httpResponse: ManifestResponse?,
       configuration: UpdatesConfiguration
     ): NewManifest {
-      var actualRawManifest = rawManifest
-      if (actualRawManifest.getRawJson().has("manifest")) {
-        actualRawManifest = NewRawManifest(actualRawManifest.getRawJson().getJSONObject("manifest"))
-      }
-      val id = UUID.fromString(actualRawManifest.getID())
-      val runtimeVersion = actualRawManifest.getRuntimeVersion()
-      val launchAsset = actualRawManifest.getLaunchAsset()
-      val assets = actualRawManifest.getAssets()
+      val id = UUID.fromString(rawManifest.getID())
+      val runtimeVersion = rawManifest.getRuntimeVersion()
+      val launchAsset = rawManifest.getLaunchAsset()
+      val assets = rawManifest.getAssets()
       val commitTime: Date = try {
-        UpdatesUtils.parseDateString(actualRawManifest.getCreatedAt())
+        UpdatesUtils.parseDateString(rawManifest.getCreatedAt())
       } catch (e: ParseException) {
         Log.e(TAG, "Could not parse manifest createdAt string; falling back to current time", e)
         Date()
@@ -109,7 +105,7 @@ class NewManifest private constructor(
       val serverDefinedHeaders = httpResponse?.header("expo-server-defined-headers")
       val manifestFilters = httpResponse?.header("expo-manifest-filters")
       return NewManifest(
-        actualRawManifest,
+        rawManifest,
         id,
         configuration.scopeKey,
         commitTime,

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/raw/NewRawManifest.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/raw/NewRawManifest.kt
@@ -36,4 +36,13 @@ class NewRawManifest(json: JSONObject) : RawManifest(json) {
 
   @Throws(JSONException::class)
   fun getCreatedAt(): String = json.getString("createdAt")
+
+  companion object {
+    fun normalizeNestedManifestJSON(json: JSONObject): JSONObject {
+      if (json.has("manifest")) {
+        return json.getJSONObject("manifest")
+      }
+      return json
+    }
+  }
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/raw/RawManifest.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/raw/RawManifest.kt
@@ -4,7 +4,20 @@ import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
 
+interface InternalJSONMutator {
+  @Throws(JSONException::class)
+  fun updateJSON(json: JSONObject)
+}
+
 abstract class RawManifest(protected val json: JSONObject) {
+  @Deprecated(message = "Strive for manifests to be immutable")
+  @Throws(JSONException::class)
+  fun mutateInternalJSONInPlace(internalJSONMutator: InternalJSONMutator) {
+    json.apply {
+      internalJSONMutator.updateJSON(this)
+    }
+  }
+
   @Deprecated(message = "Prefer to use specific field getters")
   fun getRawJson(): JSONObject = json
 
@@ -131,4 +144,39 @@ abstract class RawManifest(protected val json: JSONObject) {
   fun getNotificationPreferences(): JSONObject? {
     return json.optJSONObject("notification")
   }
+
+  fun getAndroidSplashInfo(): JSONObject? {
+    return json.optJSONObject("android")?.optJSONObject("splash")
+  }
+
+  fun getRootSplashInfo(): JSONObject? {
+    return json.optJSONObject("splash")
+  }
+
+  fun getAndroidGoogleServicesFile(): String? {
+    val android = json.optJSONObject("android")
+    return if (android != null && android.has("googleServicesFile")) {
+      android.optString("googleServicesFile")
+    } else {
+      null
+    }
+  }
+
+  fun getAndroidPackageName(): String? {
+    val android = json.optJSONObject("android")
+    return if (android != null && android.has("packageName")) {
+      android.optString("packageName")
+    } else {
+      null
+    }
+  }
+
+  @Throws(JSONException::class)
+  fun getFacebookAppId(): String = json.getString("facebookAppId")
+
+  @Throws(JSONException::class)
+  fun getFacebookApplicationName(): String = json.getString("facebookDisplayName")
+
+  @Throws(JSONException::class)
+  fun getFacebookAutoInitEnabled(): Boolean = json.getBoolean("facebookAutoInitEnabled")
 }


### PR DESCRIPTION
# Why

This is part 2 of https://github.com/expo/expo/pull/12509.

This converts the remaining cases of direct JSON access to be through methods on the `RawManifest`.

The places that are exceptions to this are:
- ExponentManifest construction and mutation
- Serialization. To not break existing serialization all serialization of manifests for purposes like sending over the bridge need to still be via raw JSON.

# How

- Use intelli-j's Find Usages of getRawJson, replace with new getter or the `mutateInternalJSONInPlace` for mutations.
- Inspect all usages of manifest serialization and change to call `.getRawJSON`

# Test Plan

Wait for CI, build and run Expo Go and experience within it.