### PR TITLE
Update obsolete @react-native-community/viewpager reference 

### DIFF
--- a/docs/pages/versions/unversioned/sdk/view-pager.md
+++ b/docs/pages/versions/unversioned/sdk/view-pager.md
@@ -1,13 +1,13 @@
 ---
 title: ViewPager
-sourceCodeUrl: 'https://github.com/react-native-community/react-native-viewpager'
+sourceCodeUrl: 'https://github.com/callstack/react-native-pager-view'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import Video from '~/components/plugins/Video'
 
-**`@react-native-community/viewpager`** exposes a component that provides the layout and gestures to scroll between pages of content, like a carousel.
+**`react-native-pager-view`** exposes a component that provides the layout and gestures to scroll between pages of content, like a carousel.
 
 <Video file={"sdk/viewpager.mp4"} loop={false}/>
 
@@ -15,23 +15,23 @@ import Video from '~/components/plugins/Video'
 
 ## Installation
 
-<InstallSection packageName="@react-native-community/viewpager" href="https://github.com/react-native-community/react-native-viewpager#linking" />
+<InstallSection packageName="react-native-pager-view" href="https://github.com/callstack/react-native-pager-view#linking" />
 
 ## Usage
 
-See full documentation at [react-native-community/react-native-viewpager](https://github.com/react-native-community/react-native-viewpager).
+See full documentation at [callstack/react-native-pager-view](https://github.com/callstack/react-native-pager-view).
 
 ## Basic Example
 
 ```js
 import React from 'react';
 import { StyleSheet, View, Text } from 'react-native';
-import ViewPager from '@react-native-community/viewpager';
+import PagerView from 'react-native-pager-view';
 
 const MyPager = () => {
   return (
     <View style={{ flex: 1 }}>
-      <ViewPager style={styles.viewPager} initialPage={0}>
+      <PagerView style={styles.viewPager} initialPage={0}>
         <View style={styles.page} key="1">
           <Text>First page</Text>
           <Text>Swipe ➡️</Text>
@@ -42,7 +42,7 @@ const MyPager = () => {
         <View style={styles.page} key="3">
           <Text>Third page</Text>
         </View>
-      </ViewPager>
+      </PagerView>
     </View>
   );
 };


### PR DESCRIPTION
# Why
ViewPager docs are currently linked to an outdated (unsupported) version of @react-native-community/viewpager. It also behaves really buggy on Android, follow for info https://github.com/callstack/react-native-pager-view/issues/164 
On the other hand, as per react-native-pager-view docs, it's not that obvious that it's compatible with Expo starting 5.0.x but it is. Which could be confusing.
<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).