### PR TITLE
[expo-updates][android] add DatabaseIntegrityCheck and tests

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Finish conversion to an interface for raw manifests. ([#12509](https://github.com/expo/expo/pull/12509) by [@wschurman](https://github.com/wschurman))
 - Add support for loading new manifests in Expo Go. ([#12521](https://github.com/expo/expo/pull/12521) by [@wschurman](https://github.com/wschurman))
 - Split SelectionPolicy into 3 separate interfaces. (Android: [#12606](https://github.com/expo/expo/pull/12606) by [@esamelson](https://github.com/esamelson))
+- Add DatabaseIntegrityCheck and tests. (Android: [#12607](https://github.com/expo/expo/pull/12607) by [@esamelson](https://github.com/esamelson))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/db/DatabaseIntegrityCheckTest.java
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/db/DatabaseIntegrityCheckTest.java
@@ -1,0 +1,129 @@
+package expo.modules.updates.db;
+
+import android.content.Context;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
+
+import androidx.room.Room;
+import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner;
+import androidx.test.platform.app.InstrumentationRegistry;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+
+import expo.modules.updates.db.entity.AssetEntity;
+import expo.modules.updates.db.entity.UpdateEntity;
+import expo.modules.updates.db.enums.UpdateStatus;
+
+@RunWith(AndroidJUnit4ClassRunner.class)
+public class DatabaseIntegrityCheckTest {
+
+  private Context context;
+  private UpdatesDatabase db;
+
+  @Before
+  public void createDb() {
+    context = InstrumentationRegistry.getInstrumentation().getTargetContext();
+    db = Room.inMemoryDatabaseBuilder(context, UpdatesDatabase.class).build();
+  }
+
+  @After
+  public void closeDb() {
+    db.close();
+  }
+
+  @Test
+  public void testFilterEmbeddedUpdates() {
+    // We can't run any updates with the status EMBEDDED if they aren't the update that's
+    // currently embedded in the installed app; the integrity check should remove any such updates
+    // from the database entirely.
+
+    String scopeKey = "testScopeKey";
+    UpdateEntity embeddedUpdate1 = new UpdateEntity(UUID.randomUUID(), new Date(1608667857774L), "1.0", scopeKey);
+    embeddedUpdate1.status = UpdateStatus.EMBEDDED;
+    UpdateEntity embeddedUpdate2 = new UpdateEntity(UUID.randomUUID(), new Date(1608667857775L), "1.0", scopeKey);
+    embeddedUpdate2.status = UpdateStatus.EMBEDDED;
+
+    db.updateDao().insertUpdate(embeddedUpdate1);
+    db.updateDao().insertUpdate(embeddedUpdate2);
+
+    Assert.assertEquals(2, db.updateDao().loadAllUpdatesForScope(scopeKey).size());
+
+    new DatabaseIntegrityCheck().run(db, null, embeddedUpdate2);
+
+    List<UpdateEntity> allUpdates = db.updateDao().loadAllUpdatesForScope(scopeKey);
+    Assert.assertEquals(1, allUpdates.size());
+    Assert.assertEquals(embeddedUpdate2.id, allUpdates.get(0).id);
+
+    // cleanup
+    db.updateDao().deleteUpdates(allUpdates);
+  }
+
+  @Test
+  public void testMissingAssets() {
+    AssetEntity asset1 = new AssetEntity("asset1", "png");
+    asset1.relativePath = "asset1.png";
+
+    String scopeKey = "testScopeKey";
+    UpdateEntity update1 = new UpdateEntity(UUID.randomUUID(), new Date(), "1.0", scopeKey);
+    update1.status = UpdateStatus.READY;
+
+    db.updateDao().insertUpdate(update1);
+    db.assetDao().insertAssets(Collections.singletonList(asset1), update1);
+
+    Assert.assertEquals(1, db.updateDao().loadAllUpdatesForScope(scopeKey).size());
+    Assert.assertEquals(1, db.assetDao().loadAllAssets().size());
+
+    DatabaseIntegrityCheck integrityCheck = Mockito.spy(DatabaseIntegrityCheck.class);
+    Mockito.doReturn(false).when(integrityCheck).assetExists(ArgumentMatchers.any(), ArgumentMatchers.any());
+    integrityCheck.run(db, context.getCacheDir(), update1);
+
+    List<UpdateEntity> allUpdates = db.updateDao().loadAllUpdatesForScope(scopeKey);
+    List<AssetEntity> allAssets = db.assetDao().loadAllAssets();
+    Assert.assertEquals(1, allUpdates.size());
+    Assert.assertEquals(UpdateStatus.PENDING, allUpdates.get(0).status);
+    Assert.assertEquals(1, allAssets.size());
+    Assert.assertNull(allAssets.get(0).relativePath);
+
+    // cleanup
+    db.updateDao().deleteUpdates(allUpdates);
+  }
+
+  @Test
+  public void testNoMissingAssets() {
+    AssetEntity asset1 = new AssetEntity("asset1", "png");
+    asset1.relativePath = "asset1.png";
+
+    String scopeKey = "testScopeKey";
+    UpdateEntity update1 = new UpdateEntity(UUID.randomUUID(), new Date(), "1.0", scopeKey);
+    update1.status = UpdateStatus.READY;
+
+    db.updateDao().insertUpdate(update1);
+    db.assetDao().insertAssets(Collections.singletonList(asset1), update1);
+
+    Assert.assertEquals(1, db.updateDao().loadAllUpdatesForScope(scopeKey).size());
+    Assert.assertEquals(1, db.assetDao().loadAllAssets().size());
+
+    DatabaseIntegrityCheck integrityCheck = Mockito.spy(DatabaseIntegrityCheck.class);
+    Mockito.doReturn(true).when(integrityCheck).assetExists(ArgumentMatchers.any(), ArgumentMatchers.any());
+    integrityCheck.run(db, context.getCacheDir(), update1);
+
+    List<UpdateEntity> allUpdates = db.updateDao().loadAllUpdatesForScope(scopeKey);
+    List<AssetEntity> allAssets = db.assetDao().loadAllAssets();
+    Assert.assertEquals(1, allUpdates.size());
+    Assert.assertEquals(UpdateStatus.READY, allUpdates.get(0).status);
+    Assert.assertEquals(1, allAssets.size());
+    Assert.assertEquals(asset1.relativePath, allAssets.get(0).relativePath);
+
+    // cleanup
+    db.updateDao().deleteUpdates(allUpdates);
+  }
+}

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/DatabaseIntegrityCheck.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/DatabaseIntegrityCheck.java
@@ -1,5 +1,7 @@
 package expo.modules.updates.db;
 
+import androidx.annotation.Nullable;
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
@@ -8,7 +10,7 @@ import expo.modules.updates.db.entity.AssetEntity;
 import expo.modules.updates.db.entity.UpdateEntity;
 
 public class DatabaseIntegrityCheck {
-  public void run(UpdatesDatabase database, File updatesDirectory, UpdateEntity embeddedUpdate) {
+  public void run(UpdatesDatabase database, File updatesDirectory, @Nullable UpdateEntity embeddedUpdate) {
     List<AssetEntity> assets = database.assetDao().loadAllAssets();
 
     ArrayList<AssetEntity> missingAssets = new ArrayList<>();
@@ -30,7 +32,7 @@ public class DatabaseIntegrityCheck {
     // we can't run any updates with the status EMBEDDED unless they match the current embedded update
     List<UpdateEntity> updatesWithEmbeddedStatus = database.updateDao().loadEmbeddedUpdates();
     for (UpdateEntity update : updatesWithEmbeddedStatus) {
-      if (!update.id.equals(embeddedUpdate.id)) {
+      if (embeddedUpdate == null || !update.id.equals(embeddedUpdate.id)) {
         updatesToDelete.add(update);
       }
     }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/DatabaseIntegrityCheck.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/DatabaseIntegrityCheck.java
@@ -1,0 +1,47 @@
+package expo.modules.updates.db;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import expo.modules.updates.db.entity.AssetEntity;
+import expo.modules.updates.db.entity.UpdateEntity;
+
+public class DatabaseIntegrityCheck {
+  public void run(UpdatesDatabase database, File updatesDirectory, UpdateEntity embeddedUpdate) {
+    List<AssetEntity> assets = database.assetDao().loadAllAssets();
+
+    ArrayList<AssetEntity> missingAssets = new ArrayList<>();
+    for (AssetEntity asset : assets) {
+      if (asset.relativePath == null) {
+        missingAssets.add(asset);
+      } else {
+        if (!assetExists(asset, updatesDirectory)) {
+          missingAssets.add(asset);
+        }
+      }
+    }
+
+    if (missingAssets.size() > 0) {
+      database.assetDao().markMissingAssets(missingAssets);
+    }
+
+    ArrayList<UpdateEntity> updatesToDelete = new ArrayList<>();
+    // we can't run any updates with the status EMBEDDED unless they match the current embedded update
+    List<UpdateEntity> updatesWithEmbeddedStatus = database.updateDao().loadEmbeddedUpdates();
+    for (UpdateEntity update : updatesWithEmbeddedStatus) {
+      if (!update.id.equals(embeddedUpdate.id)) {
+        updatesToDelete.add(update);
+      }
+    }
+
+    if (updatesToDelete.size() > 0) {
+      database.updateDao().deleteUpdates(updatesToDelete);
+    }
+  }
+
+  /* package */ boolean assetExists(AssetEntity asset, File updatesDirectory) {
+    File path = new File(updatesDirectory, asset.relativePath);
+    return path.exists();
+  }
+}

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/dao/AssetDao.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/dao/AssetDao.java
@@ -5,7 +5,9 @@ import androidx.room.Update;
 import expo.modules.updates.db.entity.AssetEntity;
 import expo.modules.updates.db.entity.UpdateAssetEntity;
 import expo.modules.updates.db.entity.UpdateEntity;
+import expo.modules.updates.db.enums.UpdateStatus;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
@@ -50,10 +52,20 @@ public abstract class AssetDao {
   @Query("SELECT * FROM assets WHERE `key` = :key LIMIT 1;")
   public abstract List<AssetEntity> _loadAssetWithKey(String key);
 
+  @Query("UPDATE assets SET relative_path = NULL WHERE id IN (:missingAssetIds)")
+  public abstract void _markMissingAssets(List<Long> missingAssetIds);
+
+  @Query("UPDATE updates SET status = :status WHERE id IN (" +
+          "SELECT DISTINCT update_id FROM updates_assets WHERE asset_id IN (:missingAssetIds));")
+  public abstract void _markUpdatesWithMissingAssets(List<Long> missingAssetIds, UpdateStatus status);
+
 
   /**
    * for public use
    */
+  @Query("SELECT * FROM assets;")
+  public abstract List<AssetEntity> loadAllAssets();
+
   @Query("SELECT assets.id, url, `key`, headers, type, assets.metadata, download_time, relative_path, hash, hash_type, marked_for_deletion" +
           " FROM assets" +
           " INNER JOIN updates_assets ON updates_assets.asset_id = assets.id" +
@@ -123,5 +135,15 @@ public abstract class AssetDao {
     _deleteAssetsMarkedForDeletion();
 
     return deletedAssets;
+  }
+
+  @Transaction
+  public void markMissingAssets(List<AssetEntity> missingAssets) {
+    ArrayList<Long> missingAssetIds = new ArrayList<>();
+    for (AssetEntity asset : missingAssets) {
+      missingAssetIds.add(asset.id);
+    }
+    _markMissingAssets(missingAssetIds);
+    _markUpdatesWithMissingAssets(missingAssetIds, UpdateStatus.PENDING);
   }
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/dao/UpdateDao.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/dao/UpdateDao.java
@@ -25,9 +25,6 @@ public abstract class UpdateDao {
   @Query("SELECT * FROM updates WHERE scope_key = :scopeKey AND status IN (:statuses);")
   public abstract List<UpdateEntity> _loadUpdatesForProjectWithStatuses(String scopeKey, List<UpdateStatus> statuses);
 
-  @Query("SELECT * FROM updates WHERE status = :status;")
-  public abstract List<UpdateEntity> _loadUpdatesWithStatus(UpdateStatus status);
-
   @Query("SELECT * FROM updates WHERE id = :id;")
   public abstract List<UpdateEntity> _loadUpdatesWithId(UUID id);
 
@@ -55,9 +52,8 @@ public abstract class UpdateDao {
     return _loadUpdatesForProjectWithStatuses(scopeKey, Arrays.asList(UpdateStatus.READY, UpdateStatus.EMBEDDED, UpdateStatus.DEVELOPMENT));
   }
 
-  public List<UpdateEntity> loadEmbeddedUpdates() {
-    return _loadUpdatesWithStatus(UpdateStatus.EMBEDDED);
-  }
+  @Query("SELECT * FROM updates WHERE status = :status;")
+  public abstract List<UpdateEntity> loadAllUpdatesWithStatus(UpdateStatus status);
 
   public UpdateEntity loadUpdateWithId(UUID id) {
     List<UpdateEntity> updateEntities = _loadUpdatesWithId(id);

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/dao/UpdateDao.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/dao/UpdateDao.java
@@ -25,6 +25,9 @@ public abstract class UpdateDao {
   @Query("SELECT * FROM updates WHERE scope_key = :scopeKey AND status IN (:statuses);")
   public abstract List<UpdateEntity> _loadUpdatesForProjectWithStatuses(String scopeKey, List<UpdateStatus> statuses);
 
+  @Query("SELECT * FROM updates WHERE status = :status;")
+  public abstract List<UpdateEntity> _loadUpdatesWithStatus(UpdateStatus status);
+
   @Query("SELECT * FROM updates WHERE id = :id;")
   public abstract List<UpdateEntity> _loadUpdatesWithId(UUID id);
 
@@ -50,6 +53,10 @@ public abstract class UpdateDao {
 
   public List<UpdateEntity> loadLaunchableUpdatesForScope(String scopeKey) {
     return _loadUpdatesForProjectWithStatuses(scopeKey, Arrays.asList(UpdateStatus.READY, UpdateStatus.EMBEDDED, UpdateStatus.DEVELOPMENT));
+  }
+
+  public List<UpdateEntity> loadEmbeddedUpdates() {
+    return _loadUpdatesWithStatus(UpdateStatus.EMBEDDED);
   }
 
   public UpdateEntity loadUpdateWithId(UUID id) {


### PR DESCRIPTION
# Why

PR 2/5 on Android side of implementing https://www.notion.so/expo/expo-update-development-clients-spec-0f48db94049a4ea0b605c5dd03fdc295

In the `getDownloadedUpdates()` method the spec describes, we'll need to check that all the updates we return are actually runnable -- meaning we actually have all the assets on disk that we think we have. This PR adds a `DatabaseIntegrityCheck` class that does just that, and which the `getDownloadedUpdates()` method can use.

# How

- check all assets in the database to see if they're on disk in the expected location; for any that aren't, we mark the `relativePath` as NULL in sqlite, and mark the update as `PENDING` rather than `READY`.
- also check to make sure we don't have multiple updates marked with the `EMBEDDED` status, and if we do, remove any that aren't the currently embedded update. (This can happen since we're on Android and we don't always have access to all the assets stored in `res` -- this special `EMBEDDED` status exists to mark that case.)

# Test Plan

Added some unit tests for this class and they all pass ✅ 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).