### PR TITLE
[expo-updates][android] add onAssetLoaded progress callback to RemoteLoader

### DIFF
--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/updates/UpdatesModule.java
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/updates/UpdatesModule.java
@@ -181,6 +181,10 @@ public class UpdatesModule extends ExportedModule {
               }
 
               @Override
+              public void onAssetLoaded(AssetEntity asset, int assetsLoaded, int totalAssets) {
+              }
+
+              @Override
               public boolean onManifestLoaded(Manifest manifest) {
                 return updatesService.getSelectionPolicy().shouldLoadNewUpdate(
                   manifest.getUpdateEntity(),

--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/updates/UpdatesModule.java
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/updates/UpdatesModule.java
@@ -181,7 +181,7 @@ public class UpdatesModule extends ExportedModule {
               }
 
               @Override
-              public void onAssetLoaded(AssetEntity asset, boolean success, int assetsLoaded, int totalAssets) {
+              public void onAssetLoaded(AssetEntity asset, int successfulAssetCount, int failedAssetCount, int totalAssetCount) {
               }
 
               @Override

--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/updates/UpdatesModule.java
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/updates/UpdatesModule.java
@@ -181,7 +181,7 @@ public class UpdatesModule extends ExportedModule {
               }
 
               @Override
-              public void onAssetLoaded(AssetEntity asset, int assetsLoaded, int totalAssets) {
+              public void onAssetLoaded(AssetEntity asset, boolean success, int assetsLoaded, int totalAssets) {
               }
 
               @Override

--- a/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/expo/modules/updates/UpdatesModule.java
+++ b/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/expo/modules/updates/UpdatesModule.java
@@ -181,6 +181,10 @@ public class UpdatesModule extends ExportedModule {
               }
 
               @Override
+              public void onAssetLoaded(AssetEntity asset, int assetsLoaded, int totalAssets) {
+              }
+
+              @Override
               public boolean onManifestLoaded(Manifest manifest) {
                 return updatesService.getSelectionPolicy().shouldLoadNewUpdate(
                   manifest.getUpdateEntity(),

--- a/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/expo/modules/updates/UpdatesModule.java
+++ b/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/expo/modules/updates/UpdatesModule.java
@@ -181,7 +181,7 @@ public class UpdatesModule extends ExportedModule {
               }
 
               @Override
-              public void onAssetLoaded(AssetEntity asset, boolean success, int assetsLoaded, int totalAssets) {
+              public void onAssetLoaded(AssetEntity asset, int successfulAssetCount, int failedAssetCount, int totalAssetCount) {
               }
 
               @Override

--- a/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/expo/modules/updates/UpdatesModule.java
+++ b/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/expo/modules/updates/UpdatesModule.java
@@ -181,7 +181,7 @@ public class UpdatesModule extends ExportedModule {
               }
 
               @Override
-              public void onAssetLoaded(AssetEntity asset, int assetsLoaded, int totalAssets) {
+              public void onAssetLoaded(AssetEntity asset, boolean success, int assetsLoaded, int totalAssets) {
               }
 
               @Override

--- a/android/versioned-abis/expoview-abi41_0_0/src/main/java/abi41_0_0/expo/modules/updates/UpdatesModule.java
+++ b/android/versioned-abis/expoview-abi41_0_0/src/main/java/abi41_0_0/expo/modules/updates/UpdatesModule.java
@@ -199,6 +199,10 @@ public class UpdatesModule extends ExportedModule {
               }
 
               @Override
+              public void onAssetLoaded(AssetEntity asset, int assetsLoaded, int totalAssets) {
+              }
+
+              @Override
               public boolean onManifestLoaded(Manifest manifest) {
                 return updatesService.getSelectionPolicy().shouldLoadNewUpdate(
                   manifest.getUpdateEntity(),

--- a/android/versioned-abis/expoview-abi41_0_0/src/main/java/abi41_0_0/expo/modules/updates/UpdatesModule.java
+++ b/android/versioned-abis/expoview-abi41_0_0/src/main/java/abi41_0_0/expo/modules/updates/UpdatesModule.java
@@ -199,7 +199,7 @@ public class UpdatesModule extends ExportedModule {
               }
 
               @Override
-              public void onAssetLoaded(AssetEntity asset, int assetsLoaded, int totalAssets) {
+              public void onAssetLoaded(AssetEntity asset, boolean success, int assetsLoaded, int totalAssets) {
               }
 
               @Override

--- a/android/versioned-abis/expoview-abi41_0_0/src/main/java/abi41_0_0/expo/modules/updates/UpdatesModule.java
+++ b/android/versioned-abis/expoview-abi41_0_0/src/main/java/abi41_0_0/expo/modules/updates/UpdatesModule.java
@@ -199,7 +199,7 @@ public class UpdatesModule extends ExportedModule {
               }
 
               @Override
-              public void onAssetLoaded(AssetEntity asset, boolean success, int assetsLoaded, int totalAssets) {
+              public void onAssetLoaded(AssetEntity asset, int successfulAssetCount, int failedAssetCount, int totalAssetCount) {
               }
 
               @Override

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Add support for loading new manifests in Expo Go. ([#12521](https://github.com/expo/expo/pull/12521) by [@wschurman](https://github.com/wschurman))
 - Split SelectionPolicy into 3 separate interfaces. (Android: [#12606](https://github.com/expo/expo/pull/12606) by [@esamelson](https://github.com/esamelson))
 - Add DatabaseIntegrityCheck and tests. (Android: [#12607](https://github.com/expo/expo/pull/12607) by [@esamelson](https://github.com/esamelson))
+- Add onAssetLoaded progress callback to remote loader. (Android: [#12608](https://github.com/expo/expo/pull/12608) by [@esamelson](https://github.com/esamelson))
 - Add setter and resetter for SelectionPolicy. (Android: [#12609](https://github.com/expo/expo/pull/12609) by [@esamelson](https://github.com/esamelson))
 
 ### 🐛 Bug fixes

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.java
@@ -199,6 +199,10 @@ public class UpdatesModule extends ExportedModule {
               }
 
               @Override
+              public void onAssetLoaded(AssetEntity asset, int assetsLoaded, int totalAssets) {
+              }
+
+              @Override
               public boolean onManifestLoaded(Manifest manifest) {
                 return updatesService.getSelectionPolicy().shouldLoadNewUpdate(
                   manifest.getUpdateEntity(),

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.java
@@ -199,7 +199,7 @@ public class UpdatesModule extends ExportedModule {
               }
 
               @Override
-              public void onAssetLoaded(AssetEntity asset, int assetsLoaded, int totalAssets) {
+              public void onAssetLoaded(AssetEntity asset, boolean success, int assetsLoaded, int totalAssets) {
               }
 
               @Override

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.java
@@ -199,7 +199,7 @@ public class UpdatesModule extends ExportedModule {
               }
 
               @Override
-              public void onAssetLoaded(AssetEntity asset, boolean success, int assetsLoaded, int totalAssets) {
+              public void onAssetLoaded(AssetEntity asset, int successfulAssetCount, int failedAssetCount, int totalAssetCount) {
               }
 
               @Override

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/LoaderTask.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/LoaderTask.java
@@ -16,6 +16,7 @@ import expo.modules.updates.UpdatesUtils;
 import expo.modules.updates.db.DatabaseHolder;
 import expo.modules.updates.db.Reaper;
 import expo.modules.updates.db.UpdatesDatabase;
+import expo.modules.updates.db.entity.AssetEntity;
 import expo.modules.updates.db.entity.UpdateEntity;
 import expo.modules.updates.launcher.DatabaseLauncher;
 import expo.modules.updates.launcher.Launcher;
@@ -262,6 +263,10 @@ public class LoaderTask {
             remoteUpdateCallback.onFailure(e);
             mCallback.onBackgroundUpdateFinished(BackgroundUpdateStatus.ERROR, null, e);
             Log.e(TAG, "Failed to download remote update", e);
+          }
+
+          @Override
+          public void onAssetLoaded(AssetEntity asset, int assetsLoaded, int totalAssets) {
           }
 
           @Override

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/LoaderTask.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/LoaderTask.java
@@ -266,7 +266,7 @@ public class LoaderTask {
           }
 
           @Override
-          public void onAssetLoaded(AssetEntity asset, int assetsLoaded, int totalAssets) {
+          public void onAssetLoaded(AssetEntity asset, boolean success, int assetsLoaded, int totalAssets) {
           }
 
           @Override

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/LoaderTask.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/LoaderTask.java
@@ -266,7 +266,7 @@ public class LoaderTask {
           }
 
           @Override
-          public void onAssetLoaded(AssetEntity asset, boolean success, int assetsLoaded, int totalAssets) {
+          public void onAssetLoaded(AssetEntity asset, int successfulAssetCount, int failedAssetCount, int totalAssetCount) {
           }
 
           @Override

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/RemoteLoader.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/RemoteLoader.java
@@ -211,11 +211,10 @@ public class RemoteLoader {
       } else {
         mExistingAssetList.add(assetEntity);
       }
+      mCallback.onAssetLoaded(assetEntity, mFinishedAssetList.size() + mExistingAssetList.size(), mAssetTotal);
     } else {
       mErroredAssetList.add(assetEntity);
     }
-
-    mCallback.onAssetLoaded(assetEntity, mFinishedAssetList.size() + mExistingAssetList.size() + mErroredAssetList.size(), mAssetTotal);
 
     if (mFinishedAssetList.size() + mErroredAssetList.size() + mExistingAssetList.size() == mAssetTotal) {
       try {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/RemoteLoader.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/RemoteLoader.java
@@ -41,7 +41,17 @@ public class RemoteLoader {
   public interface LoaderCallback {
     void onFailure(Exception e);
     void onSuccess(@Nullable UpdateEntity update);
-    void onAssetLoaded(AssetEntity asset, int assetsLoaded, int totalAssets);
+
+    /**
+     * Called when an asset has either been successfully downloaded or failed to download.
+     *
+     * @param asset Entity representing the asset that was either just downloaded or failed
+     * @param success Whether the asset succeeded or failed in downloading
+     * @param assetsLoaded The number of assets whose loading process has finished so far
+     *                     (either failed or successful)
+     * @param totalAssets The total number of assets that comprise the update
+     */
+    void onAssetLoaded(AssetEntity asset, boolean success, int assetsLoaded, int totalAssets);
 
     /**
      * Called when a manifest has been downloaded. The calling class should determine whether or not
@@ -215,7 +225,7 @@ public class RemoteLoader {
       mErroredAssetList.add(assetEntity);
     }
 
-    mCallback.onAssetLoaded(assetEntity, mFinishedAssetList.size() + mExistingAssetList.size() + mErroredAssetList.size(), mAssetTotal);
+    mCallback.onAssetLoaded(assetEntity, success, mFinishedAssetList.size() + mExistingAssetList.size() + mErroredAssetList.size(), mAssetTotal);
 
     if (mFinishedAssetList.size() + mErroredAssetList.size() + mExistingAssetList.size() == mAssetTotal) {
       try {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/RemoteLoader.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/RemoteLoader.java
@@ -46,12 +46,12 @@ public class RemoteLoader {
      * Called when an asset has either been successfully downloaded or failed to download.
      *
      * @param asset Entity representing the asset that was either just downloaded or failed
-     * @param success Whether the asset succeeded or failed in downloading
-     * @param assetsLoaded The number of assets whose loading process has finished so far
-     *                     (either failed or successful)
-     * @param totalAssets The total number of assets that comprise the update
+     * @param successfulAssetCount The number of assets that have so far been loaded successfully
+     *                             (including any that were found to already exist on disk)
+     * @param failedAssetCount The number of assets that have so far failed to load
+     * @param totalAssetCount The total number of assets that comprise the update
      */
-    void onAssetLoaded(AssetEntity asset, boolean success, int assetsLoaded, int totalAssets);
+    void onAssetLoaded(AssetEntity asset, int successfulAssetCount, int failedAssetCount, int totalAssetCount);
 
     /**
      * Called when a manifest has been downloaded. The calling class should determine whether or not
@@ -225,7 +225,7 @@ public class RemoteLoader {
       mErroredAssetList.add(assetEntity);
     }
 
-    mCallback.onAssetLoaded(assetEntity, success, mFinishedAssetList.size() + mExistingAssetList.size() + mErroredAssetList.size(), mAssetTotal);
+    mCallback.onAssetLoaded(assetEntity, mFinishedAssetList.size() + mExistingAssetList.size(), mErroredAssetList.size(), mAssetTotal);
 
     if (mFinishedAssetList.size() + mErroredAssetList.size() + mExistingAssetList.size() == mAssetTotal) {
       try {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/RemoteLoader.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/RemoteLoader.java
@@ -41,6 +41,7 @@ public class RemoteLoader {
   public interface LoaderCallback {
     void onFailure(Exception e);
     void onSuccess(@Nullable UpdateEntity update);
+    void onAssetLoaded(AssetEntity asset, int assetsLoaded, int totalAssets);
 
     /**
      * Called when a manifest has been downloaded. The calling class should determine whether or not
@@ -213,6 +214,8 @@ public class RemoteLoader {
     } else {
       mErroredAssetList.add(assetEntity);
     }
+
+    mCallback.onAssetLoaded(assetEntity, mFinishedAssetList.size() + mExistingAssetList.size() + mErroredAssetList.size(), mAssetTotal);
 
     if (mFinishedAssetList.size() + mErroredAssetList.size() + mExistingAssetList.size() == mAssetTotal) {
       try {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/RemoteLoader.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/RemoteLoader.java
@@ -211,10 +211,11 @@ public class RemoteLoader {
       } else {
         mExistingAssetList.add(assetEntity);
       }
-      mCallback.onAssetLoaded(assetEntity, mFinishedAssetList.size() + mExistingAssetList.size(), mAssetTotal);
     } else {
       mErroredAssetList.add(assetEntity);
     }
+
+    mCallback.onAssetLoaded(assetEntity, mFinishedAssetList.size() + mExistingAssetList.size() + mErroredAssetList.size(), mAssetTotal);
 
     if (mFinishedAssetList.size() + mErroredAssetList.size() + mExistingAssetList.size() == mAssetTotal) {
       try {


### PR DESCRIPTION
# Why

PR 3/5 on Android side of implementing https://www.notion.so/expo/expo-update-development-clients-spec-0f48db94049a4ea0b605c5dd03fdc295

The spec asks for a progress callback when downloading a new update, so this PR adds that functionality to `RemoteLoader`.

# How

- add an `onAssetLoaded` method to RemoteLoader's Callback interface, and stubs
- call this method each time a new asset is loaded

# Test Plan

Tested manually via logging as part of the full implementation of the interface, which is added in a later PR.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).