### PR TITLE
[expo-updates][android] add setter and resetter for SelectionPolicy

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/UpdatesBinding.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/UpdatesBinding.java
@@ -103,4 +103,9 @@ public class UpdatesBinding extends UpdatesService implements UpdatesInterface {
     KernelProvider.getInstance().reloadVisibleExperience(mManifestUrl, true);
     callback.onSuccess();
   }
+
+  @Override
+  public void resetSelectionPolicy() {
+    // no-op in managed
+  }
 }

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Add support for loading new manifests in Expo Go. ([#12521](https://github.com/expo/expo/pull/12521) by [@wschurman](https://github.com/wschurman))
 - Split SelectionPolicy into 3 separate interfaces. (Android: [#12606](https://github.com/expo/expo/pull/12606) by [@esamelson](https://github.com/esamelson))
 - Add DatabaseIntegrityCheck and tests. (Android: [#12607](https://github.com/expo/expo/pull/12607) by [@esamelson](https://github.com/esamelson))
+- Add setter and resetter for SelectionPolicy. (Android: [#12609](https://github.com/expo/expo/pull/12609) by [@esamelson](https://github.com/esamelson))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.java
@@ -226,7 +226,7 @@ public class UpdatesController {
 
   // internal setters
 
-  /* package */ void setSelectionPolicy(SelectionPolicy selectionPolicy) {
+  /* package */ void setNextSelectionPolicy(SelectionPolicy selectionPolicy) {
     mSelectionPolicy = selectionPolicy;
   }
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.java
@@ -61,7 +61,7 @@ public class UpdatesController {
   private UpdatesController(Context context, UpdatesConfiguration updatesConfiguration) {
     mUpdatesConfiguration = updatesConfiguration;
     mDatabaseHolder = new DatabaseHolder(UpdatesDatabase.getInstance(context));
-    mSelectionPolicy = SelectionPolicyFactory.createFilterAwarePolicy(UpdatesUtils.getRuntimeVersion(updatesConfiguration));
+    mSelectionPolicy = defaultSelectionPolicy();
     mFileDownloader = new FileDownloader(context);
     if (context instanceof ReactApplication) {
       mReactNativeHost = new WeakReference<>(((ReactApplication) context).getReactNativeHost());
@@ -73,6 +73,10 @@ public class UpdatesController {
       mUpdatesDirectoryException = e;
       mUpdatesDirectory = null;
     }
+  }
+
+  private SelectionPolicy defaultSelectionPolicy() {
+    return SelectionPolicyFactory.createFilterAwarePolicy(UpdatesUtils.getRuntimeVersion(mUpdatesConfiguration));
   }
 
   public static UpdatesController getInstance() {
@@ -218,6 +222,16 @@ public class UpdatesController {
 
   public boolean isEmergencyLaunch() {
     return mIsEmergencyLaunch;
+  }
+
+  // internal setters
+
+  /* package */ void setSelectionPolicy(SelectionPolicy selectionPolicy) {
+    mSelectionPolicy = selectionPolicy;
+  }
+
+  /* package */ void resetSelectionPolicyToDefault() {
+    mSelectionPolicy = defaultSelectionPolicy();
   }
 
   /**

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.java
@@ -226,6 +226,16 @@ public class UpdatesController {
 
   // internal setters
 
+  /**
+   * For external modules that want to modify the selection policy used at runtime.
+   *
+   * This method does not provide any guarantees about how long the provided selection policy will
+   * persist; sometimes expo-updates will reset the selection policy in situations where it makes
+   * sense to have explicit control (e.g. if the developer/user has programmatically fetched an
+   * update, expo-updates will reset the selection policy so the new update is launched on th
+   * next reload).
+   * @param selectionPolicy The SelectionPolicy to use next, until overridden by expo-updates
+   */
   /* package */ void setNextSelectionPolicy(SelectionPolicy selectionPolicy) {
     mSelectionPolicy = selectionPolicy;
   }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesInterface.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesInterface.java
@@ -28,4 +28,5 @@ public interface UpdatesInterface {
   Map<AssetEntity, String> getLocalAssetFiles();
 
   void relaunchReactApplication(Launcher.LauncherCallback callback);
+  void resetSelectionPolicy();
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.java
@@ -213,6 +213,7 @@ public class UpdatesModule extends ExportedModule {
                 if (update == null) {
                   updateInfo.putBoolean("isNew", false);
                 } else {
+                  updatesService.resetSelectionPolicy();
                   updateInfo.putBoolean("isNew", true);
                   updateInfo.putString("manifestString", update.metadata.toString());
                 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesService.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesService.java
@@ -90,4 +90,9 @@ public class UpdatesService implements InternalModule, UpdatesInterface {
   public void relaunchReactApplication(Launcher.LauncherCallback callback) {
     UpdatesController.getInstance().relaunchReactApplication(mContext, callback);
   }
+
+  @Override
+  public void resetSelectionPolicy() {
+    UpdatesController.getInstance().resetSelectionPolicyToDefault();
+  }
 }


### PR DESCRIPTION
# Why

PR 4/5 on Android side of implementing https://www.notion.so/expo/expo-update-development-clients-spec-0f48db94049a4ea0b605c5dd03fdc295

In order to implement `setCurrentUpdate` we need to be able to set the current SelectionPolicy at runtime.

# How

I've implemented a setter for this on `UpdatesController`, which is the only relevant place since the dev client interface will only be used in bare builds for now.

I also added a resetter, which sets the SelectionPolicy back to the default one after `fetchUpdateAsync` is called and a new update is downloaded successfully, meaning `reloadAsync` will have the expected effect in this case.

# Test Plan

Tested manually as part of the full implementation of the interface, which is added in a later PR.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).