### PR TITLE
[docs] Fix link to #plugin-module-resolution

### DIFF
--- a/docs/pages/guides/config-plugins.md
+++ b/docs/pages/guides/config-plugins.md
@@ -66,7 +66,7 @@ For instance, if you add a plugin that adds permission messages to your app, the
 
 And that's it! Now you're using Config plugins. No more having to interact with the native projects!
 
-> 💡 Check out all the different ways you can import `plugins`: [plugin module resolution](#Plugin-module-resolution)
+> 💡 Check out all the different ways you can import `plugins`: [plugin module resolution](#plugin-module-resolution)
 
 ## What are plugins
 


### PR DESCRIPTION
# Why

Fixed case in link to #plugin-module-resolution

# Test Plan

Checked that https://docs.expo.io/guides/config-plugins/#plugin-module-resolution navigates to the correct subsection