### PR TITLE
[eyw] add package files to package.json

### DIFF
--- a/packages/expo-yarn-workspaces/CHANGELOG.md
+++ b/packages/expo-yarn-workspaces/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 ### 🐛 Bug fixes
+- add package files to package.json. ([#12622](https://github.com/expo/expo/pull/12622) by [@ajsmth](https://github.com/ajsmth))
 
 ## 1.5.0 — 2021-04-20
 

--- a/packages/expo-yarn-workspaces/package.json
+++ b/packages/expo-yarn-workspaces/package.json
@@ -10,7 +10,9 @@
   },
   "files": [
     "index.js",
-    "webpack.js"
+    "webpack.js",
+    "common/*",
+    "bin/*"
   ],
   "scripts": {
     "lint": "eslint .",


### PR DESCRIPTION
# Why


Since adding additional exports to the package, I did not include common and bin directories in the included files for this package

# Test Plan

run `yarn pack` and make sure `bin/` and `common/` files are included in the package
