### PR TITLE
[ios] update versioned EXUpdatesSelectionPolicy interface in ABI39 and 40

### DIFF
--- a/guides/releasing/Updates QA.md
+++ b/guides/releasing/Updates QA.md
@@ -13,7 +13,7 @@
 - Try loading an older project with an unsupported SDK version; should see a helpful error message about SDK versions.
 - Add some buttons to your UI that test the `Updates` module methods and publish a new update.
 - Test `checkForUpdateAsync`, `fetchUpdateAsync`, and `reloadAsync`; publish another new update and use these methods to download the update and reload with it.
-- If any changes were made to the ABIXX `expo-updates` files, test the module methods in all supported SDK versions.
+- Publish a similar project for each supported SDK version in Expo Go; test the production module methods in all supported SDK versions.
 - Try launching a self-hosted update like https://esamelson.github.io/self-hosting-test/ios-index.json / android-index.json.
 - Finally, try opening a saved snack and an unsaved snack.
 

--- a/ios/versioned-react-native/ABI39_0_0/Expo/EXUpdates/ABI39_0_0EXUpdates/ABI39_0_0EXUpdatesModule.m
+++ b/ios/versioned-react-native/ABI39_0_0/Expo/EXUpdates/ABI39_0_0EXUpdates/ABI39_0_0EXUpdatesModule.m
@@ -83,7 +83,7 @@ ABI39_0_0UM_EXPORT_METHOD_AS(checkForUpdateAsync,
                              successBlock:^(ABI39_0_0EXUpdatesUpdate *update) {
     ABI39_0_0EXUpdatesUpdate *launchedUpdate = self->_updatesService.launchedUpdate;
     id<ABI39_0_0EXUpdatesSelectionPolicy> selectionPolicy = self->_updatesService.selectionPolicy;
-    if ([selectionPolicy shouldLoadNewUpdate:update withLaunchedUpdate:launchedUpdate]) {
+    if ([selectionPolicy shouldLoadNewUpdate:update withLaunchedUpdate:launchedUpdate filters:nil]) {
       resolve(@{
         @"isAvailable": @(YES),
         @"manifest": update.rawManifest
@@ -109,7 +109,7 @@ ABI39_0_0UM_EXPORT_METHOD_AS(fetchUpdateAsync,
 
   ABI39_0_0EXUpdatesRemoteAppLoader *remoteAppLoader = [[ABI39_0_0EXUpdatesRemoteAppLoader alloc] initWithConfig:_updatesService.config database:_updatesService.database directory:_updatesService.directory completionQueue:self.methodQueue];
   [remoteAppLoader loadUpdateFromUrl:_updatesService.config.updateUrl onManifest:^BOOL(ABI39_0_0EXUpdatesUpdate * _Nonnull update) {
-    return [self->_updatesService.selectionPolicy shouldLoadNewUpdate:update withLaunchedUpdate:self->_updatesService.launchedUpdate];
+    return [self->_updatesService.selectionPolicy shouldLoadNewUpdate:update withLaunchedUpdate:self->_updatesService.launchedUpdate filters:nil];
   } success:^(ABI39_0_0EXUpdatesUpdate * _Nullable update) {
     if (update) {
       resolve(@{

--- a/ios/versioned-react-native/ABI39_0_0/Expo/EXUpdates/ABI39_0_0EXUpdates/AppLauncher/ABI39_0_0EXUpdatesSelectionPolicy.h
+++ b/ios/versioned-react-native/ABI39_0_0/Expo/EXUpdates/ABI39_0_0EXUpdates/AppLauncher/ABI39_0_0EXUpdatesSelectionPolicy.h
@@ -8,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (nullable ABI39_0_0EXUpdatesUpdate *)launchableUpdateWithUpdates:(NSArray<ABI39_0_0EXUpdatesUpdate *> *)updates;
 - (NSArray<ABI39_0_0EXUpdatesUpdate *> *)updatesToDeleteWithLaunchedUpdate:(ABI39_0_0EXUpdatesUpdate *)launchedUpdate updates:(NSArray<ABI39_0_0EXUpdatesUpdate *> *)updates;
-- (BOOL)shouldLoadNewUpdate:(nullable ABI39_0_0EXUpdatesUpdate *)newUpdate withLaunchedUpdate:(nullable ABI39_0_0EXUpdatesUpdate *)launchedUpdate;
+- (BOOL)shouldLoadNewUpdate:(nullable ABI39_0_0EXUpdatesUpdate *)newUpdate withLaunchedUpdate:(nullable ABI39_0_0EXUpdatesUpdate *)launchedUpdate filters:(nullable NSDictionary *)filters;
 
 @end
 

--- a/ios/versioned-react-native/ABI39_0_0/Expo/EXUpdates/ABI39_0_0EXUpdates/AppLauncher/ABI39_0_0EXUpdatesSelectionPolicyNewest.m
+++ b/ios/versioned-react-native/ABI39_0_0/Expo/EXUpdates/ABI39_0_0EXUpdates/AppLauncher/ABI39_0_0EXUpdatesSelectionPolicyNewest.m
@@ -58,7 +58,7 @@ NS_ASSUME_NONNULL_BEGIN
   return updatesToDelete;
 }
 
-- (BOOL)shouldLoadNewUpdate:(nullable ABI39_0_0EXUpdatesUpdate *)newUpdate withLaunchedUpdate:(nullable ABI39_0_0EXUpdatesUpdate *)launchedUpdate
+- (BOOL)shouldLoadNewUpdate:(nullable ABI39_0_0EXUpdatesUpdate *)newUpdate withLaunchedUpdate:(nullable ABI39_0_0EXUpdatesUpdate *)launchedUpdate filters:(nullable NSDictionary *)filters
 {
   if (!newUpdate) {
     return false;

--- a/ios/versioned-react-native/ABI39_0_0/Expo/EXUpdates/ABI39_0_0EXUpdates/AppLoader/ABI39_0_0EXUpdatesAppLoaderTask.m
+++ b/ios/versioned-react-native/ABI39_0_0/Expo/EXUpdates/ABI39_0_0EXUpdates/AppLoader/ABI39_0_0EXUpdatesAppLoaderTask.m
@@ -194,7 +194,8 @@ static NSString * const ABI39_0_0EXUpdatesAppLoaderTaskErrorDomain = @"ABI39_0_0
   [ABI39_0_0EXUpdatesAppLauncherWithDatabase launchableUpdateWithConfig:_config database:_database selectionPolicy:_selectionPolicy completion:^(NSError * _Nullable error, ABI39_0_0EXUpdatesUpdate * _Nullable launchableUpdate) {
     if (self->_config.hasEmbeddedUpdate &&
         [self->_selectionPolicy shouldLoadNewUpdate:[ABI39_0_0EXUpdatesEmbeddedAppLoader embeddedManifestWithConfig:self->_config database:self->_database]
-                                 withLaunchedUpdate:launchableUpdate]) {
+                                 withLaunchedUpdate:launchableUpdate
+                                            filters:nil]) {
       self->_embeddedAppLoader = [[ABI39_0_0EXUpdatesEmbeddedAppLoader alloc] initWithConfig:self->_config database:self->_database directory:self->_directory completionQueue:self->_loaderTaskQueue];
       [self->_embeddedAppLoader loadUpdateFromEmbeddedManifestWithCallback:^BOOL(ABI39_0_0EXUpdatesUpdate * _Nonnull update) {
         // we already checked using selection policy, so we don't need to check again
@@ -221,7 +222,7 @@ static NSString * const ABI39_0_0EXUpdatesAppLoaderTaskErrorDomain = @"ABI39_0_0
 {
   _remoteAppLoader = [[ABI39_0_0EXUpdatesRemoteAppLoader alloc] initWithConfig:_config database:_database directory:_directory completionQueue:_loaderTaskQueue];
   [_remoteAppLoader loadUpdateFromUrl:_config.updateUrl onManifest:^BOOL(ABI39_0_0EXUpdatesUpdate * _Nonnull update) {
-    if ([self->_selectionPolicy shouldLoadNewUpdate:update withLaunchedUpdate:self->_launcher.launchedUpdate]) {
+    if ([self->_selectionPolicy shouldLoadNewUpdate:update withLaunchedUpdate:self->_launcher.launchedUpdate filters:nil]) {
       self->_isUpToDate = NO;
       if (self->_delegate) {
         dispatch_async(self->_delegateQueue, ^{

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/ABI40_0_0EXUpdatesModule.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/ABI40_0_0EXUpdatesModule.m
@@ -83,7 +83,7 @@ ABI40_0_0UM_EXPORT_METHOD_AS(checkForUpdateAsync,
                              successBlock:^(ABI40_0_0EXUpdatesUpdate *update) {
     ABI40_0_0EXUpdatesUpdate *launchedUpdate = self->_updatesService.launchedUpdate;
     id<ABI40_0_0EXUpdatesSelectionPolicy> selectionPolicy = self->_updatesService.selectionPolicy;
-    if ([selectionPolicy shouldLoadNewUpdate:update withLaunchedUpdate:launchedUpdate]) {
+    if ([selectionPolicy shouldLoadNewUpdate:update withLaunchedUpdate:launchedUpdate filters:nil]) {
       resolve(@{
         @"isAvailable": @(YES),
         @"manifest": update.rawManifest
@@ -109,7 +109,7 @@ ABI40_0_0UM_EXPORT_METHOD_AS(fetchUpdateAsync,
 
   ABI40_0_0EXUpdatesRemoteAppLoader *remoteAppLoader = [[ABI40_0_0EXUpdatesRemoteAppLoader alloc] initWithConfig:_updatesService.config database:_updatesService.database directory:_updatesService.directory completionQueue:self.methodQueue];
   [remoteAppLoader loadUpdateFromUrl:_updatesService.config.updateUrl onManifest:^BOOL(ABI40_0_0EXUpdatesUpdate * _Nonnull update) {
-    return [self->_updatesService.selectionPolicy shouldLoadNewUpdate:update withLaunchedUpdate:self->_updatesService.launchedUpdate];
+    return [self->_updatesService.selectionPolicy shouldLoadNewUpdate:update withLaunchedUpdate:self->_updatesService.launchedUpdate filters:nil];
   } success:^(ABI40_0_0EXUpdatesUpdate * _Nullable update) {
     if (update) {
       resolve(@{

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/AppLauncher/ABI40_0_0EXUpdatesSelectionPolicy.h
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/AppLauncher/ABI40_0_0EXUpdatesSelectionPolicy.h
@@ -8,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (nullable ABI40_0_0EXUpdatesUpdate *)launchableUpdateWithUpdates:(NSArray<ABI40_0_0EXUpdatesUpdate *> *)updates;
 - (NSArray<ABI40_0_0EXUpdatesUpdate *> *)updatesToDeleteWithLaunchedUpdate:(ABI40_0_0EXUpdatesUpdate *)launchedUpdate updates:(NSArray<ABI40_0_0EXUpdatesUpdate *> *)updates;
-- (BOOL)shouldLoadNewUpdate:(nullable ABI40_0_0EXUpdatesUpdate *)newUpdate withLaunchedUpdate:(nullable ABI40_0_0EXUpdatesUpdate *)launchedUpdate;
+- (BOOL)shouldLoadNewUpdate:(nullable ABI40_0_0EXUpdatesUpdate *)newUpdate withLaunchedUpdate:(nullable ABI40_0_0EXUpdatesUpdate *)launchedUpdate filters:(nullable NSDictionary *)filters;
 
 @end
 

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/AppLauncher/ABI40_0_0EXUpdatesSelectionPolicyNewest.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/AppLauncher/ABI40_0_0EXUpdatesSelectionPolicyNewest.m
@@ -58,7 +58,7 @@ NS_ASSUME_NONNULL_BEGIN
   return updatesToDelete;
 }
 
-- (BOOL)shouldLoadNewUpdate:(nullable ABI40_0_0EXUpdatesUpdate *)newUpdate withLaunchedUpdate:(nullable ABI40_0_0EXUpdatesUpdate *)launchedUpdate
+- (BOOL)shouldLoadNewUpdate:(nullable ABI40_0_0EXUpdatesUpdate *)newUpdate withLaunchedUpdate:(nullable ABI40_0_0EXUpdatesUpdate *)launchedUpdate filters:(nullable NSDictionary *)filters
 {
   if (!newUpdate) {
     return false;

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/AppLoader/ABI40_0_0EXUpdatesAppLoaderTask.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/AppLoader/ABI40_0_0EXUpdatesAppLoaderTask.m
@@ -194,7 +194,8 @@ static NSString * const ABI40_0_0EXUpdatesAppLoaderTaskErrorDomain = @"ABI40_0_0
   [ABI40_0_0EXUpdatesAppLauncherWithDatabase launchableUpdateWithConfig:_config database:_database selectionPolicy:_selectionPolicy completion:^(NSError * _Nullable error, ABI40_0_0EXUpdatesUpdate * _Nullable launchableUpdate) {
     if (self->_config.hasEmbeddedUpdate &&
         [self->_selectionPolicy shouldLoadNewUpdate:[ABI40_0_0EXUpdatesEmbeddedAppLoader embeddedManifestWithConfig:self->_config database:self->_database]
-                                 withLaunchedUpdate:launchableUpdate]) {
+                                 withLaunchedUpdate:launchableUpdate
+                                            filters:nil]) {
       self->_embeddedAppLoader = [[ABI40_0_0EXUpdatesEmbeddedAppLoader alloc] initWithConfig:self->_config database:self->_database directory:self->_directory completionQueue:self->_loaderTaskQueue];
       [self->_embeddedAppLoader loadUpdateFromEmbeddedManifestWithCallback:^BOOL(ABI40_0_0EXUpdatesUpdate * _Nonnull update) {
         // we already checked using selection policy, so we don't need to check again
@@ -221,7 +222,7 @@ static NSString * const ABI40_0_0EXUpdatesAppLoaderTaskErrorDomain = @"ABI40_0_0
 {
   _remoteAppLoader = [[ABI40_0_0EXUpdatesRemoteAppLoader alloc] initWithConfig:_config database:_database directory:_directory completionQueue:_loaderTaskQueue];
   [_remoteAppLoader loadUpdateFromUrl:_config.updateUrl onManifest:^BOOL(ABI40_0_0EXUpdatesUpdate * _Nonnull update) {
-    if ([self->_selectionPolicy shouldLoadNewUpdate:update withLaunchedUpdate:self->_launcher.launchedUpdate]) {
+    if ([self->_selectionPolicy shouldLoadNewUpdate:update withLaunchedUpdate:self->_launcher.launchedUpdate filters:nil]) {
       self->_isUpToDate = NO;
       if (self->_delegate) {
         dispatch_async(self->_delegateQueue, ^{


### PR DESCRIPTION
# Why

addresses #12604

The crash is due to

```
*** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[EXUpdatesSelectionPolicyFilterAware shouldLoadNewUpdate:withLaunchedUpdate:]: unrecognized selector sent to instance 0x6000037686c0'
```

Versioning works on iOS by relying on the fact that versioned modules have the same interfaces as their unversioned counterparts. In this case, the interface of the unversioned EXUpdatesSelectionPolicy class changed, but the versioned modules did not account for this change.

# How

Changed the interface of the versioned EXUpdatesSelectionPolicy classes to match the unversioned one; updated all call sites so the app builds. (No changes were needed to the ABI38 files on the sdk-41 branch since they had a completely different version of the updates module.)

Also updated the Updates QA guide to note that we should test the module methods in all supported SDK versions, even if no changes have been made to the versioned files.

# Test Plan

I tested this change manually on the sdk-41 branch. For each SDK {38, 39, 40, 41} I published an app that tested all the updates module methods, opened it in Expo Go, and verified the methods worked as expected and did not cause the app to crash.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).