### PR TITLE
[updates][ios] Factor out raw manifest into wrapper class

### DIFF
--- a/ios/Client/EXHomeAppManager.h
+++ b/ios/Client/EXHomeAppManager.h
@@ -1,15 +1,16 @@
 #import "EXReactAppManager.h"
+#import <EXUpdates/EXUpdatesRawManifest.h>
 
 FOUNDATION_EXPORT NSString *kEXHomeBundleResourceName;
 FOUNDATION_EXPORT NSString *kEXHomeManifestResourceName;
 
 @interface EXHomeAppManager : EXReactAppManager
 
-+ (NSDictionary *)bundledHomeManifest;
++ (EXUpdatesRawManifest *)bundledHomeManifest;
 
 #pragma mark - interfacing with home JS
 
-- (void)addHistoryItemWithUrl:(NSURL *)manifestUrl manifest:(NSDictionary *)manifest;
+- (void)addHistoryItemWithUrl:(NSURL *)manifestUrl manifest:(EXUpdatesRawManifest *)manifest;
 - (void)getHistoryUrlForExperienceId:(NSString *)experienceId completion:(void (^)(NSString *))completion;
 - (void)showQRReader;
 

--- a/ios/Client/EXHomeAppManager.m
+++ b/ios/Client/EXHomeAppManager.m
@@ -15,6 +15,7 @@
 #import "EXVersions.h"
 
 #import <EXConstants/EXConstantsService.h>
+#import <EXUpdates/EXUpdatesUpdate.h>
 
 #import <React/RCTUtils.h>
 #import <React/RCTBridge.h>
@@ -34,8 +35,8 @@ NSString *kEXHomeManifestResourceName = @"kernel-manifest";
     @"constants": @{
         @"expoRuntimeVersion": [EXBuildConstants sharedInstance].expoRuntimeVersion,
         @"linkingUri": @"exp://",
-        @"experienceUrl": [@"exp://" stringByAppendingString:self.appRecord.appLoader.manifest[@"hostUri"]],
-        @"manifest": self.appRecord.appLoader.manifest,
+        @"experienceUrl": [@"exp://" stringByAppendingString:self.appRecord.appLoader.manifest.hostUri],
+        @"manifest": self.appRecord.appLoader.manifest.rawManifestJSON,
         @"executionEnvironment": EXConstantsExecutionEnvironmentStoreClient,
         @"appOwnership": @"expo",
         @"supportedExpoSdks": [EXVersions sharedInstance].versions[@"sdkVersions"],
@@ -43,7 +44,7 @@ NSString *kEXHomeManifestResourceName = @"kernel-manifest";
     @"exceptionsManagerDelegate": self.exceptionHandler,
     @"isDeveloper": @([EXBuildConstants sharedInstance].isDevKernel),
     @"isStandardDevMenuAllowed": @(YES), // kernel enables traditional RN dev menu
-    @"manifest": self.appRecord.appLoader.manifest,
+    @"manifest": self.appRecord.appLoader.manifest.rawManifestJSON,
     @"services": [EXKernel sharedInstance].serviceRegistry.allServices,
     @"singletonModules": [UMModuleRegistryProvider singletonModules],
     @"fileSystemDirectories": @{
@@ -61,9 +62,9 @@ NSString *kEXHomeManifestResourceName = @"kernel-manifest";
 
 #pragma mark - interfacing with home JS
 
-- (void)addHistoryItemWithUrl:(NSURL *)manifestUrl manifest:(NSDictionary *)manifest
+- (void)addHistoryItemWithUrl:(NSURL *)manifestUrl manifest:(EXUpdatesRawManifest *)manifest
 {
-  if (!manifest || !manifestUrl || [manifest[@"id"] isEqualToString:@"@exponent/home"]) {
+  if (!manifest || !manifestUrl || [manifest.rawID isEqualToString:@"@exponent/home"]) {
     return;
   }
   NSDictionary *params = @{
@@ -127,7 +128,7 @@ NSString *kEXHomeManifestResourceName = @"kernel-manifest";
   }
 }
 
-- (NSString *)bundleResourceNameForAppFetcher:(__unused EXAppFetcher *)appFetcher withManifest:(nonnull __unused NSDictionary *)manifest
+- (NSString *)bundleResourceNameForAppFetcher:(__unused EXAppFetcher *)appFetcher withManifest:(nonnull __unused EXUpdatesRawManifest *)manifest
 {
   return kEXHomeBundleResourceName;
 }
@@ -161,7 +162,7 @@ NSString *kEXHomeManifestResourceName = @"kernel-manifest";
   return initialHomeUrl;
 }
 
-+ (NSDictionary * _Nullable)bundledHomeManifest
++ (EXUpdatesRawManifest * _Nullable)bundledHomeManifest
 {
   NSString *manifestJson = nil;
   BOOL usesNSBundleManifest = NO;
@@ -190,7 +191,7 @@ NSString *kEXHomeManifestResourceName = @"kernel-manifest";
       if (usesNSBundleManifest && ![manifest[@"id"] isEqualToString:@"@exponent/home"]) {
         DDLogError(@"Bundled kernel manifest was published with an id other than @exponent/home");
       }
-      return manifest;
+      return [EXUpdatesUpdate rawManifestForJSON:manifest];
     }
   }
   return nil;

--- a/ios/Client/EXRootViewController.m
+++ b/ios/Client/EXRootViewController.m
@@ -99,7 +99,7 @@ NS_ASSUME_NONNULL_BEGIN
   [[EXKernel sharedInstance] createNewAppWithUrl:urlToRefresh initialProps:nil];
 }
 
-- (void)addHistoryItemWithUrl:(NSURL *)manifestUrl manifest:(NSDictionary *)manifest
+- (void)addHistoryItemWithUrl:(NSURL *)manifestUrl manifest:(EXUpdatesRawManifest *)manifest
 {
   [[self _getHomeAppManager] addHistoryItemWithUrl:manifestUrl manifest:manifest];
 }

--- a/ios/Exponent/Kernel/AppLoader/AppFetcher/EXAppFetcher+Private.h
+++ b/ios/Exponent/Kernel/AppLoader/AppFetcher/EXAppFetcher+Private.h
@@ -2,6 +2,7 @@
 
 #import <Foundation/Foundation.h>
 #import "EXAppFetcher.h"
+#import <EXUpdates/EXUpdatesRawManifest.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -9,7 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, weak) EXAppLoader *appLoader;
 
-@property (nonatomic, strong) NSDictionary * _Nullable manifest;
+@property (nonatomic, strong) EXUpdatesRawManifest * _Nullable manifest;
 @property (nonatomic, strong) NSData * _Nullable bundle;
 @property (nonatomic, strong) NSError * _Nullable error;
 

--- a/ios/Exponent/Kernel/AppLoader/AppFetcher/EXAppFetcher.h
+++ b/ios/Exponent/Kernel/AppLoader/AppFetcher/EXAppFetcher.h
@@ -2,6 +2,7 @@
 
 #import <Foundation/Foundation.h>
 #import "EXResourceLoader.h"
+#import <EXUpdates/EXUpdatesRawManifest.h>
 
 @class EXAppLoader;
 @class EXAppFetcher;
@@ -19,15 +20,15 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)appFetcher:(EXAppFetcher *)appFetcher didSwitchToAppFetcher:(EXAppFetcher *)newAppFetcher retainingCurrent:(BOOL)shouldRetain;
 
-- (void)appFetcher:(EXAppFetcher *)appFetcher didLoadOptimisticManifest:(NSDictionary *)manifest;
-- (void)appFetcher:(EXAppFetcher *)appFetcher didFinishLoadingManifest:(NSDictionary *)manifest bundle:(NSData *)bundle;
+- (void)appFetcher:(EXAppFetcher *)appFetcher didLoadOptimisticManifest:(EXUpdatesRawManifest *)manifest;
+- (void)appFetcher:(EXAppFetcher *)appFetcher didFinishLoadingManifest:(EXUpdatesRawManifest *)manifest bundle:(NSData *)bundle;
 - (void)appFetcher:(EXAppFetcher *)appFetcher didFailWithError:(NSError *)error;
 
 @end
 
 @protocol EXAppFetcherDataSource <NSObject>
 
-- (NSString *)bundleResourceNameForAppFetcher:(EXAppFetcher *)appFetcher withManifest:(NSDictionary *)manifest;
+- (NSString *)bundleResourceNameForAppFetcher:(EXAppFetcher *)appFetcher withManifest:(EXUpdatesRawManifest *)manifest;
 - (BOOL)appFetcherShouldInvalidateBundleCache:(EXAppFetcher *)appFetcher;
 
 @end
@@ -40,7 +41,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface EXAppFetcher : NSObject
 
-@property (nonatomic, readonly) NSDictionary * _Nullable manifest;
+@property (nonatomic, readonly) EXUpdatesRawManifest * _Nullable manifest;
 @property (nonatomic, readonly) NSData * _Nullable bundle;
 @property (nonatomic, readonly) NSError * _Nullable error;
 
@@ -51,16 +52,15 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithAppLoader:(EXAppLoader *)appLoader;
 - (void)start;
 
-- (void)fetchJSBundleWithManifest:(NSDictionary *)manifest
+- (void)fetchJSBundleWithManifest:(EXUpdatesRawManifest *)manifest
                     cacheBehavior:(EXCachedResourceBehavior)cacheBehavior
                   timeoutInterval:(NSTimeInterval)timeoutInterval
                          progress:(void (^ _Nullable )(EXLoadingProgress *))progressBlock
                           success:(void (^)(NSData *))successBlock
                             error:(void (^)(NSError *))errorBlock;
 
-+ (NSString *)experienceIdWithManifest:(NSDictionary *)manifest;
-+ (BOOL)areDevToolsEnabledWithManifest:(NSDictionary *)manifest;
-+ (EXCachedResourceBehavior)cacheBehaviorForJSWithManifest:(NSDictionary *)manifest;
++ (NSString *)experienceIdWithManifest:(EXUpdatesRawManifest *)manifest;
++ (EXCachedResourceBehavior)cacheBehaviorForJSWithManifest:(EXUpdatesRawManifest *)manifest;
 
 @end
 

--- a/ios/Exponent/Kernel/AppLoader/AppFetcher/EXAppFetcher.m
+++ b/ios/Exponent/Kernel/AppLoader/AppFetcher/EXAppFetcher.m
@@ -29,7 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
   @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:@"Should not call EXAppFetcher#start -- use a subclass instead" userInfo:nil];
 }
 
-- (void)fetchJSBundleWithManifest:(NSDictionary *)manifest
+- (void)fetchJSBundleWithManifest:(EXUpdatesRawManifest *)manifest
                     cacheBehavior:(EXCachedResourceBehavior)cacheBehavior
                   timeoutInterval:(NSTimeInterval)timeoutInterval
                          progress:(void (^ _Nullable )(EXLoadingProgress *))progressBlock
@@ -38,7 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
   EXJavaScriptResource *jsResource = [[EXJavaScriptResource alloc] initWithBundleName:[self.dataSource bundleResourceNameForAppFetcher:self withManifest:manifest]
                                                                             remoteUrl:[EXApiUtil bundleUrlFromManifest:manifest]
-                                                                      devToolsEnabled:[[self class] areDevToolsEnabledWithManifest:manifest]];
+                                                                      devToolsEnabled:manifest.isDevelopmentMode];
   jsResource.abiVersion = [[EXVersions sharedInstance] availableSdkVersionForManifest:manifest];
   jsResource.requestTimeoutInterval = timeoutInterval;
 
@@ -55,9 +55,9 @@ NS_ASSUME_NONNULL_BEGIN
   [jsResource loadResourceWithBehavior:cacheBehavior progressBlock:progressBlock successBlock:successBlock errorBlock:errorBlock];
 }
 
-+ (NSString *)experienceIdWithManifest:(NSDictionary * _Nonnull)manifest
++ (NSString *)experienceIdWithManifest:(EXUpdatesRawManifest * _Nonnull)manifest
 {
-  id experienceIdJsonValue = manifest[@"id"];
+  id experienceIdJsonValue = manifest.rawID;
   if (experienceIdJsonValue) {
     RCTAssert([experienceIdJsonValue isKindOfClass:[NSString class]], @"Manifest contains an id which is not a string: %@", experienceIdJsonValue);
     return experienceIdJsonValue;
@@ -65,20 +65,13 @@ NS_ASSUME_NONNULL_BEGIN
   return nil;
 }
 
-+ (BOOL)areDevToolsEnabledWithManifest:(NSDictionary * _Nonnull)manifest
-{
-  NSDictionary *manifestDeveloperConfig = manifest[@"developer"];
-  BOOL isDeployedFromTool = (manifestDeveloperConfig && manifestDeveloperConfig[@"tool"] != nil);
-  return (isDeployedFromTool);
-}
-
-+ (EXCachedResourceBehavior)cacheBehaviorForJSWithManifest:(NSDictionary * _Nonnull)manifest
++ (EXCachedResourceBehavior)cacheBehaviorForJSWithManifest:(EXUpdatesRawManifest * _Nonnull)manifest
 {
   if ([[EXKernel sharedInstance].serviceRegistry.errorRecoveryManager experienceIdIsRecoveringFromError:[[self class] experienceIdWithManifest:manifest]]) {
     // if this experience id encountered a loading error before, discard any cache we might have
     return EXCachedResourceWriteToCache;
   }
-  if ([[self class] areDevToolsEnabledWithManifest:manifest]) {
+  if (manifest.isDevelopmentMode) {
     return EXCachedResourceNoCache;
   }
   return EXCachedResourceWriteToCache;

--- a/ios/Exponent/Kernel/AppLoader/AppFetcher/EXAppFetcherCacheOnly.h
+++ b/ios/Exponent/Kernel/AppLoader/AppFetcher/EXAppFetcherCacheOnly.h
@@ -1,12 +1,13 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
 #import "EXAppFetcher+Private.h"
+#import <EXUpdates/EXUpdatesRawManifest.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface EXAppFetcherCacheOnly : EXAppFetcher
 
-- (instancetype)initWithAppLoader:(EXAppLoader *)appLoader manifest:(NSDictionary *)manifest;
+- (instancetype)initWithAppLoader:(EXAppLoader *)appLoader manifest:(EXUpdatesRawManifest *)manifest;
 
 @end
 

--- a/ios/Exponent/Kernel/AppLoader/AppFetcher/EXAppFetcherCacheOnly.m
+++ b/ios/Exponent/Kernel/AppLoader/AppFetcher/EXAppFetcherCacheOnly.m
@@ -8,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation EXAppFetcherCacheOnly
 
-- (instancetype)initWithAppLoader:(EXAppLoader *)appLoader manifest:(NSDictionary *)manifest;
+- (instancetype)initWithAppLoader:(EXAppLoader *)appLoader manifest:(EXUpdatesRawManifest *)manifest;
 {
   if (self = [super initWithAppLoader:appLoader]) {
     self.manifest = manifest;
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
   if (self.manifest) {
     [self startWithManifest];
   } else {
-    [self.appLoader fetchManifestWithCacheBehavior:EXManifestOnlyCache success:^(NSDictionary * _Nonnull manifest) {
+    [self.appLoader fetchManifestWithCacheBehavior:EXManifestOnlyCache success:^(EXUpdatesRawManifest * _Nonnull manifest) {
       self.manifest = manifest;
       [self startWithManifest];
     } failure:^(NSError * _Nonnull error) {

--- a/ios/Exponent/Kernel/AppLoader/AppFetcher/EXAppFetcherDevelopmentMode.h
+++ b/ios/Exponent/Kernel/AppLoader/AppFetcher/EXAppFetcherDevelopmentMode.h
@@ -1,6 +1,7 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
 #import "EXAppFetcher+Private.h"
+#import <EXUpdates/EXUpdatesRawManifest.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -14,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, weak) id<EXAppFetcherDevelopmentModeDelegate> developmentModeDelegate;
 
-- (instancetype)initWithAppLoader:(EXAppLoader *)appLoader manifest:(NSDictionary *)manifest;
+- (instancetype)initWithAppLoader:(EXAppLoader *)appLoader manifest:(EXUpdatesRawManifest *)manifest;
 
 - (void)forceBundleReload;
 

--- a/ios/Exponent/Kernel/AppLoader/AppFetcher/EXAppFetcherDevelopmentMode.m
+++ b/ios/Exponent/Kernel/AppLoader/AppFetcher/EXAppFetcherDevelopmentMode.m
@@ -7,7 +7,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation EXAppFetcherDevelopmentMode
 
-- (instancetype)initWithAppLoader:(EXAppLoader *)appLoader manifest:(NSDictionary *)manifest;
+- (instancetype)initWithAppLoader:(EXAppLoader *)appLoader manifest:(EXUpdatesRawManifest *)manifest;
 {
   if (self = [super initWithAppLoader:appLoader]) {
     self.manifest = manifest;
@@ -20,7 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
   if (self.manifest) {
     [self startWithManifest];
   } else {
-    [self.appLoader fetchManifestWithCacheBehavior:EXManifestNoCache success:^(NSDictionary * _Nonnull manifest) {
+    [self.appLoader fetchManifestWithCacheBehavior:EXManifestNoCache success:^(EXUpdatesRawManifest * _Nonnull manifest) {
       self.manifest = manifest;
       [self startWithManifest];
     } failure:^(NSError * _Nonnull error) {

--- a/ios/Exponent/Kernel/AppLoader/AppFetcher/EXAppFetcherWithTimeout.h
+++ b/ios/Exponent/Kernel/AppLoader/AppFetcher/EXAppFetcherWithTimeout.h
@@ -1,12 +1,13 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
 #import "EXAppFetcher+Private.h"
+#import <EXUpdates/EXUpdatesRawManifest.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 @protocol EXAppFetcherWithTimeoutDelegate <NSObject>
 
-- (void)appFetcher:(EXAppFetcher *)appFetcher didResolveUpdatedBundleWithManifest:(NSDictionary * _Nullable)manifest isFromCache:(BOOL)isFromCache error:(NSError * _Nullable)error;
+- (void)appFetcher:(EXAppFetcher *)appFetcher didResolveUpdatedBundleWithManifest:(EXUpdatesRawManifest * _Nullable)manifest isFromCache:(BOOL)isFromCache error:(NSError * _Nullable)error;
 
 @end
 

--- a/ios/Exponent/Kernel/AppLoader/AppFetcher/EXAppFetcherWithTimeout.m
+++ b/ios/Exponent/Kernel/AppLoader/AppFetcher/EXAppFetcherWithTimeout.m
@@ -42,9 +42,9 @@ NS_ASSUME_NONNULL_BEGIN
     [self _finishWithError:nil];
   }
 
-  [self.appLoader fetchManifestWithCacheBehavior:EXManifestPrepareToCache success:^(NSDictionary * _Nonnull manifest) {
+  [self.appLoader fetchManifestWithCacheBehavior:EXManifestPrepareToCache success:^(EXUpdatesRawManifest * _Nonnull manifest) {
     self.manifest = manifest;
-    if ([[self class] areDevToolsEnabledWithManifest:manifest] && self.timer) {
+    if (manifest.isDevelopmentMode && self.timer) {
       // make sure we never time out in dev mode
       // this can happen because there is no cached manifest & therefore we fall back to default behavior w/ timer
       [self _stopTimer];

--- a/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.h
+++ b/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.h
@@ -1,6 +1,7 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
 #import "EXCachedResource.h"
+#import <EXUpdates/EXUpdatesRawManifest.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -24,7 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)writeToCache;
 
-- (NSError *)verifyManifestSdkVersion:(NSDictionary *)maybeManifest;
+- (NSError *)verifyManifestSdkVersion:(EXUpdatesRawManifest *)maybeManifest;
 - (NSError *)formatError:(NSError *)error;
 
 @end

--- a/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.m
+++ b/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.m
@@ -10,6 +10,7 @@
 #import "EXVersions.h"
 
 #import <React/RCTConvert.h>
+#import <EXUpdates/EXUpdatesUpdate.h>
 
 NSString * const kEXPublicKeyUrl = @"https://exp.host/--/manifest-public-key";
 
@@ -48,13 +49,14 @@ NSString * const kEXPublicKeyUrl = @"https://exp.host/--/manifest-public-key";
   return self;
 }
 
-- (NSMutableDictionary * _Nullable) _chooseManifest:(NSArray *)manifestArray error:(NSError **)error {
+- (NSMutableDictionary * _Nullable) _chooseJSONManifest:(NSArray *)jsonManifestObjArray error:(NSError **)error {
   // Find supported sdk versions
-  if (manifestArray) {
-    for (id providedManifest in manifestArray) {
-      if ([providedManifest isKindOfClass:[NSDictionary class]] && providedManifest[@"sdkVersion"]){
-        NSString *sdkVersion = providedManifest[@"sdkVersion"];
-        if ([[EXVersions sharedInstance] supportsVersion:sdkVersion]){
+  if (jsonManifestObjArray) {
+    for (id providedManifest in jsonManifestObjArray) {
+      if ([providedManifest isKindOfClass:[NSDictionary class]]) {
+        EXUpdatesRawManifest *providedRawManifest = [EXUpdatesUpdate rawManifestForJSON:providedManifest];
+        NSString *sdkVersion = providedRawManifest.sdkVersion;
+        if (sdkVersion && [[EXVersions sharedInstance] supportsVersion:sdkVersion]) {
           return providedManifest;
         }
       }
@@ -82,7 +84,7 @@ NSString * const kEXPublicKeyUrl = @"https://exp.host/--/manifest-public-key";
     }
 
     __block NSError *jsonError;
-    id manifestObjOrArray = [NSJSONSerialization JSONObjectWithData:data options:0 error:&jsonError];
+    id manifestJSONObjOrJSONObjArray = [NSJSONSerialization JSONObjectWithData:data options:0 error:&jsonError];
     if (jsonError) {
       errorBlock(jsonError);
       return;
@@ -90,17 +92,18 @@ NSString * const kEXPublicKeyUrl = @"https://exp.host/--/manifest-public-key";
     
     id manifestObj;
     // Check if server sent an array of manifests (multi-manifests)
-    if ([manifestObjOrArray isKindOfClass:[NSArray class]]) {
-      NSArray *manifestArray = (NSArray *)manifestObjOrArray;
+    if ([manifestJSONObjOrJSONObjArray isKindOfClass:[NSArray class]]) {
+      NSArray *manifestArray = (NSArray *)manifestJSONObjOrJSONObjArray;
       __block NSError *manifestError;
-      manifestObj = [self _chooseManifest:(NSArray *)manifestArray error:&manifestError];
+      manifestObj = [self _chooseJSONManifest:(NSArray *)manifestArray error:&manifestError];
       if (!manifestObj) {
         errorBlock(manifestError);
         return;
       }
     } else {
-      manifestObj = manifestObjOrArray;
+      manifestObj = manifestJSONObjOrJSONObjArray;
     }
+    
     NSString *innerManifestString = (NSString *)manifestObj[@"manifestString"];
     NSString *manifestSignature = (NSString *)manifestObj[@"signature"];
     
@@ -122,7 +125,9 @@ NSString * const kEXPublicKeyUrl = @"https://exp.host/--/manifest-public-key";
       }
     }
     
-    NSError *sdkVersionError = [self verifyManifestSdkVersion:innerManifestObj];
+    EXUpdatesRawManifest *manifest = [EXUpdatesUpdate rawManifestForJSON:innerManifestObj];
+    
+    NSError *sdkVersionError = [self verifyManifestSdkVersion:manifest];
     if (sdkVersionError) {
       errorBlock(sdkVersionError);
       return;
@@ -323,13 +328,13 @@ NSString * const kEXPublicKeyUrl = @"https://exp.host/--/manifest-public-key";
   return nil;
 }
 
-- (NSError *)verifyManifestSdkVersion:(NSDictionary *)maybeManifest
+- (NSError *)verifyManifestSdkVersion:(EXUpdatesRawManifest *)maybeManifest
 {
   NSString *errorCode;
   NSDictionary *metadata;
-  if (maybeManifest && maybeManifest[@"sdkVersion"]) {
-    if (![maybeManifest[@"sdkVersion"] isEqualToString:@"UNVERSIONED"]) {
-      NSInteger manifestSdkVersion = [maybeManifest[@"sdkVersion"] integerValue];
+  if (maybeManifest && maybeManifest.sdkVersion) {
+    if (![maybeManifest.sdkVersion isEqualToString:@"UNVERSIONED"]) {
+      NSInteger manifestSdkVersion = [maybeManifest.sdkVersion integerValue];
       if (manifestSdkVersion) {
         NSInteger oldestSdkVersion = [[self _earliestSdkVersionSupported] integerValue];
         NSInteger newestSdkVersion = [[self _latestSdkVersionSupported] integerValue];
@@ -337,7 +342,7 @@ NSString * const kEXPublicKeyUrl = @"https://exp.host/--/manifest-public-key";
           errorCode = @"EXPERIENCE_SDK_VERSION_OUTDATED";
           // since we are spoofing this error, we put the SDK version of the project as the
           // "available" SDK version -- it's the only one available from the server
-          metadata = @{@"availableSDKVersions": @[maybeManifest[@"sdkVersion"]]};
+          metadata = @{@"availableSDKVersions": @[maybeManifest.sdkVersion]};
         }
         if (manifestSdkVersion > newestSdkVersion) {
           errorCode = @"EXPERIENCE_SDK_VERSION_TOO_NEW";

--- a/ios/Exponent/Kernel/AppLoader/EXApiUtil.h
+++ b/ios/Exponent/Kernel/AppLoader/EXApiUtil.h
@@ -1,6 +1,7 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
 #import <Foundation/Foundation.h>
+#import <EXUpdates/EXUpdatesRawManifest.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -25,7 +26,7 @@ typedef void (^EXVerifySignatureErrorBlock)(NSError *error);
                            successBlock:(EXVerifySignatureSuccessBlock)successBlock
                              errorBlock:(EXVerifySignatureErrorBlock)errorBlock;
 
-+ (NSURL *)bundleUrlFromManifest:(NSDictionary *)manifest;
++ (NSURL *)bundleUrlFromManifest:(EXUpdatesRawManifest *)manifest;
 + (NSURL *)encodedUrlFromString:(NSString *)urlString;
 
 @end

--- a/ios/Exponent/Kernel/AppLoader/EXApiUtil.m
+++ b/ios/Exponent/Kernel/AppLoader/EXApiUtil.m
@@ -13,9 +13,9 @@ static NSString* kPublicKeyTag = @"exp.host.publickey";
 
 @implementation EXApiUtil
 
-+ (NSURL *)bundleUrlFromManifest:(NSDictionary *)manifest
++ (NSURL *)bundleUrlFromManifest:(EXUpdatesRawManifest *)manifest
 {
-  NSString *urlString = [manifest objectForKey:@"bundleUrl"];
+  NSString *urlString = manifest.bundleUrl;
   RCTAssert([urlString isKindOfClass:[NSString class]], @"Manifest contains a bundleUrl which is not a string: %@", urlString);
   return [[self class] encodedUrlFromString:urlString];
 }

--- a/ios/Exponent/Kernel/AppLoader/EXAppLoader.h
+++ b/ios/Exponent/Kernel/AppLoader/EXAppLoader.h
@@ -5,6 +5,7 @@
 #import "EXAppFetcherDevelopmentMode.h"
 #import "EXAppFetcherWithTimeout.h"
 #import "EXCachedResource.h"
+#import <EXUpdates/EXUpdatesRawManifest.h>
 
 @class EXKernelAppRecord;
 @class EXAppLoader;
@@ -28,19 +29,19 @@ typedef enum EXAppLoaderRemoteUpdateStatus {
 
 @protocol EXAppLoaderDelegate <NSObject>
 
-- (void)appLoader:(EXAppLoader *)appLoader didLoadOptimisticManifest:(NSDictionary *)manifest;
+- (void)appLoader:(EXAppLoader *)appLoader didLoadOptimisticManifest:(EXUpdatesRawManifest *)manifest;
 - (void)appLoader:(EXAppLoader *)appLoader didLoadBundleWithProgress:(EXLoadingProgress *)progress;
-- (void)appLoader:(EXAppLoader *)appLoader didFinishLoadingManifest:(NSDictionary *)manifest bundle:(NSData *)data;
+- (void)appLoader:(EXAppLoader *)appLoader didFinishLoadingManifest:(EXUpdatesRawManifest *)manifest bundle:(NSData *)data;
 - (void)appLoader:(EXAppLoader *)appLoader didFailWithError:(NSError *)error;
-- (void)appLoader:(EXAppLoader *)appLoader didResolveUpdatedBundleWithManifest:(NSDictionary * _Nullable)manifest isFromCache:(BOOL)isFromCache error:(NSError * _Nullable)error;
+- (void)appLoader:(EXAppLoader *)appLoader didResolveUpdatedBundleWithManifest:(EXUpdatesRawManifest * _Nullable)manifest isFromCache:(BOOL)isFromCache error:(NSError * _Nullable)error;
 
 @end
 
 @interface EXAppLoader : NSObject <EXAppFetcherDelegate, EXAppFetcherDevelopmentModeDelegate, EXAppFetcherWithTimeoutDelegate, EXAppFetcherCacheDataSource>
 
 @property (nonatomic, readonly) NSURL *manifestUrl;
-@property (nonatomic, readonly) NSDictionary * _Nullable manifest; // possibly optimistic
-@property (nonatomic, readonly) NSDictionary * _Nullable cachedManifest; // we definitely have this manifest and its bundle on the device
+@property (nonatomic, readonly) EXUpdatesRawManifest * _Nullable manifest; // possibly optimistic
+@property (nonatomic, readonly) EXUpdatesRawManifest * _Nullable cachedManifest; // we definitely have this manifest and its bundle on the device
 @property (nonatomic, readonly) NSData * _Nullable bundle;
 @property (nonatomic, readonly) EXAppLoaderStatus status;
 @property (nonatomic, readonly) EXAppLoaderRemoteUpdateStatus remoteUpdateStatus;
@@ -51,7 +52,7 @@ typedef enum EXAppLoaderRemoteUpdateStatus {
 @property (nonatomic, weak) id<EXAppFetcherDataSource> dataSource;
 
 - (instancetype)initWithManifestUrl:(NSURL *)url;
-- (instancetype)initWithLocalManifest:(NSDictionary * _Nonnull)manifest;
+- (instancetype)initWithLocalManifest:(EXUpdatesRawManifest * _Nonnull)manifest;
 
 /**
  *  Begin a new request.
@@ -90,7 +91,7 @@ typedef enum EXAppLoaderRemoteUpdateStatus {
 /**
  * Fetch manifest without any side effects or interaction with the timer.
  */
-- (void)fetchManifestWithCacheBehavior:(EXManifestCacheBehavior)cacheBehavior success:(void (^)(NSDictionary *))success failure:(void (^)(NSError *))failure;
+- (void)fetchManifestWithCacheBehavior:(EXManifestCacheBehavior)cacheBehavior success:(void (^)(EXUpdatesRawManifest *))success failure:(void (^)(NSError *))failure;
 
 @end
 

--- a/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
+++ b/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
@@ -31,8 +31,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, nullable) NSURL *manifestUrl;
 @property (nonatomic, strong, nullable) NSURL *httpManifestUrl;
 
-@property (nonatomic, strong, nullable) NSDictionary *confirmedManifest;
-@property (nonatomic, strong, nullable) NSDictionary *optimisticManifest;
+@property (nonatomic, strong, nullable) EXUpdatesRawManifest *confirmedManifest;
+@property (nonatomic, strong, nullable) EXUpdatesRawManifest *optimisticManifest;
 @property (nonatomic, strong, nullable) NSData *bundle;
 @property (nonatomic, assign) EXAppLoaderRemoteUpdateStatus remoteUpdateStatus;
 @property (nonatomic, assign) BOOL shouldShowRemoteUpdateStatus;
@@ -111,7 +111,7 @@ NS_ASSUME_NONNULL_BEGIN
   return kEXAppLoaderStatusNew;
 }
 
-- (nullable NSDictionary *)manifest
+- (nullable EXUpdatesRawManifest *)manifest
 {
   if (_confirmedManifest) {
     return _confirmedManifest;
@@ -151,7 +151,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)supportsBundleReload
 {
   if (_optimisticManifest) {
-    return [[self class] areDevToolsEnabledWithManifest:_optimisticManifest];
+    return _optimisticManifest.isDevelopmentMode;
   }
   return NO;
 }
@@ -181,7 +181,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
   [self _setShouldShowRemoteUpdateStatus:update.rawManifest];
   // if cached manifest was dev mode, or a previous run of this app failed due to a loading error, we want to make sure to check for remote updates
-  if ([[self class] areDevToolsEnabledWithManifest:update.rawManifest] || [[EXKernel sharedInstance].serviceRegistry.errorRecoveryManager experienceIdIsRecoveringFromError:[EXAppFetcher experienceIdWithManifest:update.rawManifest]]) {
+  if (update.rawManifest.isUsingDeveloperTool || [[EXKernel sharedInstance].serviceRegistry.errorRecoveryManager experienceIdIsRecoveringFromError:[EXAppFetcher experienceIdWithManifest:update.rawManifest]]) {
     return NO;
   }
   return YES;
@@ -216,7 +216,7 @@ NS_ASSUME_NONNULL_BEGIN
     [self _setOptimisticManifest:[self _processManifest:launcher.launchedUpdate.rawManifest]];
   }
   _isUpToDate = isUpToDate;
-  if ([[self class] areDevToolsEnabledWithManifest:launcher.launchedUpdate.rawManifest]) {
+  if (launcher.launchedUpdate.rawManifest.isUsingDeveloperTool) {
     // in dev mode, we need to set an optimistic manifest but nothing else
     return;
   }
@@ -380,7 +380,7 @@ NS_ASSUME_NONNULL_BEGIN
   }
 }
 
-- (void)_setOptimisticManifest:(NSDictionary *)manifest
+- (void)_setOptimisticManifest:(EXUpdatesRawManifest *)manifest
 {
   _optimisticManifest = manifest;
   if (self.delegate) {
@@ -388,7 +388,7 @@ NS_ASSUME_NONNULL_BEGIN
   }
 }
 
-- (void)_setShouldShowRemoteUpdateStatus:(NSDictionary *)manifest
+- (void)_setShouldShowRemoteUpdateStatus:(EXUpdatesRawManifest *)manifest
 {
   // we don't want to show the cached experience alert when Updates.reloadAsync() is called
   if (_shouldUseCacheOnly) {
@@ -397,23 +397,19 @@ NS_ASSUME_NONNULL_BEGIN
   }
 
   if (manifest) {
-    NSDictionary *developmentClientSettings = manifest[@"developmentClient"];
-    if (developmentClientSettings && [developmentClientSettings isKindOfClass:[NSDictionary class]]) {
-      id silentLaunch = developmentClientSettings[@"silentLaunch"];
-      if (silentLaunch && [@(YES) isEqual:silentLaunch]) {
-        _shouldShowRemoteUpdateStatus = NO;
-        return;
-      }
+    if (manifest.isDevelopmentSilentLaunch) {
+      _shouldShowRemoteUpdateStatus = NO;
+      return;
     }
 
     // we want to avoid showing the status for older snack SDK versions, too
     // we make our best guess based on the manifest fields
     // TODO: remove this after SDK 38 is phased out
-    NSString *sdkVersion = manifest[@"sdkVersion"];
-    NSString *bundleUrl = manifest[@"bundleUrl"];
+    NSString *sdkVersion = manifest.sdkVersion;
+    NSString *bundleUrl = manifest.bundleUrl;
     if (![@"UNVERSIONED" isEqual:sdkVersion] &&
         sdkVersion.integerValue < 39 &&
-        [@"snack" isEqual:manifest[@"slug"]] &&
+        [@"snack" isEqual:manifest.slug] &&
         bundleUrl && [bundleUrl isKindOfClass:[NSString class]] &&
         [bundleUrl hasPrefix:@"https://d1wp6m56sqw74a.cloudfront.net/%40exponent%2Fsnack"]) {
       _shouldShowRemoteUpdateStatus = NO;
@@ -449,16 +445,16 @@ NS_ASSUME_NONNULL_BEGIN
 
 # pragma mark - manifest processing
 
-- (NSDictionary *)_processManifest:(NSDictionary *)manifest
+- (EXUpdatesRawManifest *)_processManifest:(EXUpdatesRawManifest *)manifest
 {
-  NSMutableDictionary *mutableManifest = [manifest mutableCopy];
+  NSMutableDictionary *mutableManifest = [manifest.rawManifestJSON mutableCopy];
   if (!mutableManifest[@"isVerified"] && ![EXKernelLinkingManager isExpoHostedUrl:_httpManifestUrl] && !EXEnvironment.sharedEnvironment.isDetached){
     // the manifest id determines the namespace/experience id an app is sandboxed with
     // if manifest is hosted by third parties, we sandbox it with the hostname to avoid clobbering exp.host namespaces
     // for https urls, sandboxed id is of form quinlanj.github.io/myProj-myApp
     // for http urls, sandboxed id is of form UNVERIFIED-quinlanj.github.io/myProj-myApp
     NSString *securityPrefix = [_httpManifestUrl.scheme isEqualToString:@"https"] ? @"" : @"UNVERIFIED-";
-    NSString *slugSuffix = manifest[@"slug"] ? [@"-" stringByAppendingString:manifest[@"slug"]]: @"";
+    NSString *slugSuffix = manifest.slug ? [@"-" stringByAppendingString:manifest.slug]: @"";
     mutableManifest[@"id"] = [NSString stringWithFormat:@"%@%@%@%@", securityPrefix, _httpManifestUrl.host, _httpManifestUrl.path ?: @"", slugSuffix];
     mutableManifest[@"isVerified"] = @(YES);
   }
@@ -470,20 +466,13 @@ NS_ASSUME_NONNULL_BEGIN
     mutableManifest[@"isVerified"] = @(YES);
   }
 
-  return [mutableManifest copy];
+  return [EXUpdatesUpdate rawManifestForJSON:[mutableManifest copy]];
 }
 
-- (BOOL)_isAnonymousExperience:(NSDictionary *)manifest
+- (BOOL)_isAnonymousExperience:(EXUpdatesRawManifest *)manifest
 {
-  NSString *experienceId = manifest[@"id"];
+  NSString *experienceId = manifest.rawID;
   return experienceId != nil && [experienceId hasPrefix:@"@anonymous/"];
-}
-
-+ (BOOL)areDevToolsEnabledWithManifest:(NSDictionary *)manifest
-{
-  NSDictionary *manifestDeveloperConfig = manifest[@"developer"];
-  BOOL isDeployedFromTool = (manifestDeveloperConfig && manifestDeveloperConfig[@"tool"] != nil);
-  return (isDeployedFromTool);
 }
 
 #pragma mark - headers

--- a/ios/Exponent/Kernel/Core/EXAppBrowserController.h
+++ b/ios/Exponent/Kernel/Core/EXAppBrowserController.h
@@ -1,4 +1,5 @@
 #import "EXKernelAppRegistry.h"
+#import <EXUpdates/EXUpdatesRawManifest.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -8,7 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)moveHomeToVisible;
 - (void)reloadVisibleApp;
 - (void)showQRReader;
-- (void)addHistoryItemWithUrl:(NSURL *)manifestUrl manifest:(NSDictionary *)manifest;
+- (void)addHistoryItemWithUrl:(NSURL *)manifestUrl manifest:(EXUpdatesRawManifest *)manifest;
 - (void)getHistoryUrlForExperienceId:(NSString *)experienceId completion:(void (^)(NSString * _Nullable))completion;
 - (BOOL)isNuxFinished;
 - (void)setIsNuxFinished:(BOOL)isFinished;

--- a/ios/Exponent/Kernel/Core/EXKernelAppRecord.m
+++ b/ios/Exponent/Kernel/Core/EXKernelAppRecord.m
@@ -58,7 +58,7 @@ NSString *kEXKernelBridgeDidBackgroundNotification = @"EXKernelBridgeDidBackgrou
 - (NSString * _Nullable)experienceId
 {
   if (self.appLoader && self.appLoader.manifest) {
-    id experienceIdJsonValue = self.appLoader.manifest[@"id"];
+    id experienceIdJsonValue = self.appLoader.manifest.rawID;
     if (experienceIdJsonValue) {
       RCTAssert([experienceIdJsonValue isKindOfClass:[NSString class]], @"Manifest contains an id which is not a string: %@", experienceIdJsonValue);
       return experienceIdJsonValue;

--- a/ios/Exponent/Kernel/Environment/EXVersions.h
+++ b/ios/Exponent/Kernel/Environment/EXVersions.h
@@ -1,6 +1,7 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
 #import <Foundation/Foundation.h>
+#import <EXUpdates/EXUpdatesRawManifest.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -12,7 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly, nonnull) NSString *temporarySdkVersion;
 
 - (NSString *)symbolPrefixForSdkVersion: (NSString * _Nullable)version isKernel:(BOOL)isKernel;
-- (NSString *)availableSdkVersionForManifest: (NSDictionary * _Nullable)manifest;
+- (NSString *)availableSdkVersionForManifest: (EXUpdatesRawManifest * _Nullable)manifest;
 - (BOOL)supportsVersion:(NSString *)sdkVersion;
 + (NSString * _Nullable)versionedString: (NSString * _Nullable)string withPrefix: (NSString * _Nullable)symbolPrefix;
 

--- a/ios/Exponent/Kernel/Environment/EXVersions.m
+++ b/ios/Exponent/Kernel/Environment/EXVersions.m
@@ -78,17 +78,17 @@
   return @"";
 }
 
-- (NSString *)availableSdkVersionForManifest: (NSDictionary * _Nullable)manifest
+- (NSString *)availableSdkVersionForManifest: (EXUpdatesRawManifest * _Nullable)manifest
 {
   return [self _versionForManifest:manifest];
 }
 
 #pragma mark - Internal
 
-- (NSString *)_versionForManifest:(NSDictionary * _Nullable)manifest
+- (NSString *)_versionForManifest:(EXUpdatesRawManifest * _Nullable)manifest
 {
-  if (manifest && manifest[@"sdkVersion"]) {
-    NSString *sdkVersion = manifest[@"sdkVersion"];
+  if (manifest && manifest.sdkVersion) {
+    NSString *sdkVersion = manifest.sdkVersion;
     NSArray *sdkVersions = _versions[@"sdkVersions"];
     if (sdkVersion && sdkVersions) {
       for (NSString *availableVersion in sdkVersions) {

--- a/ios/Exponent/Kernel/Services/EXUpdatesManager.h
+++ b/ios/Exponent/Kernel/Services/EXUpdatesManager.h
@@ -2,13 +2,14 @@
 
 #import "EXKernelAppRecord.h"
 #import "EXUpdatesBinding.h"
+#import <EXUpdates/EXUpdatesRawManifest.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface EXUpdatesManager : NSObject <EXUpdatesBindingDelegate>
 
 - (void)notifyApp:(EXKernelAppRecord *)appRecord
-ofDownloadWithManifest:(NSDictionary * _Nullable)manifest
+ofDownloadWithManifest:(EXUpdatesRawManifest * _Nullable)manifest
             isNew:(BOOL)isBundleNew
             error:(NSError * _Nullable)error;
 

--- a/ios/Exponent/Kernel/Services/EXUpdatesManager.m
+++ b/ios/Exponent/Kernel/Services/EXUpdatesManager.m
@@ -36,7 +36,7 @@ NSString * const EXUpdatesDownloadFinishedEventType = @"downloadFinished";
 @implementation EXUpdatesManager
 
 - (void)notifyApp:(EXKernelAppRecord *)appRecord
-ofDownloadWithManifest:(NSDictionary * _Nullable)manifest
+ofDownloadWithManifest:(EXUpdatesRawManifest * _Nullable)manifest
             isNew:(BOOL)isBundleNew
             error:(NSError * _Nullable)error;
 {
@@ -48,17 +48,15 @@ ofDownloadWithManifest:(NSDictionary * _Nullable)manifest
              @"message": error.localizedDescription
              };
   } else if (isBundleNew) {
-    if (!manifest) {
-      // prevent a crash, but this shouldn't ever happen
-      manifest = @{};
-    }
+    // prevent a crash, but this shouldn't ever happen
+    NSDictionary *rawManifestJSON = manifest ? manifest.rawManifestJSON : @{};
     bodyLegacy = @{
                    @"type": EXUpdatesDownloadFinishedEventType,
-                   @"manifest": manifest
+                   @"manifest": rawManifestJSON
                    };
     body = @{
              @"type": EXUpdatesUpdateAvailableEventType,
-             @"manifest": manifest
+             @"manifest": rawManifestJSON
              };
   } else {
     body = @{
@@ -147,7 +145,7 @@ ofDownloadWithManifest:(NSDictionary * _Nullable)manifest
 
 - (void)updatesModule:(id)scopedModule
 didRequestManifestWithCacheBehavior:(EXManifestCacheBehavior)cacheBehavior
-              success:(void (^)(NSDictionary * _Nonnull))success
+              success:(void (^)(EXUpdatesRawManifest * _Nonnull))success
               failure:(void (^)(NSError * _Nonnull))failure
 {
   if ([EXEnvironment sharedEnvironment].isDetached && ![EXEnvironment sharedEnvironment].areRemoteUpdatesEnabled) {
@@ -173,7 +171,7 @@ didRequestManifestWithCacheBehavior:(EXManifestCacheBehavior)cacheBehavior
 - (void)updatesModule:(id)scopedModule
 didRequestBundleWithCompletionQueue:(dispatch_queue_t)completionQueue
                 start:(void (^)(void))startBlock
-              success:(void (^)(NSDictionary * _Nullable))success
+              success:(void (^)(EXUpdatesRawManifest * _Nullable))success
               failure:(void (^)(NSError * _Nonnull))failure
 {
   if ([EXEnvironment sharedEnvironment].isDetached && ![EXEnvironment sharedEnvironment].areRemoteUpdatesEnabled) {

--- a/ios/Exponent/Kernel/Services/EXUserNotificationManager.m
+++ b/ios/Exponent/Kernel/Services/EXUserNotificationManager.m
@@ -61,10 +61,10 @@ static NSString * const scopedIdentifierSeparator = @":";
 
   EXKernelAppRecord *visibleApp = [EXKernel sharedInstance].visibleApp;
   if (visibleApp) {
-    NSDictionary *visibleAppManifest = visibleApp.appLoader.manifest;
-    if (visibleAppManifest && visibleAppManifest[@"notification"] && visibleAppManifest[@"notification"][@"iosDisplayInForeground"]) {
+    EXUpdatesRawManifest *visibleAppManifest = visibleApp.appLoader.manifest;
+    if (visibleAppManifest && visibleAppManifest.notificationPreferences && visibleAppManifest.notificationPreferences[@"iosDisplayInForeground"]) {
       // If user specifically set `notification.iosDisplayInForeground` in `app.json`.
-      shouldDisplayInForeground = [visibleAppManifest[@"notification"][@"iosDisplayInForeground"] boolValue];
+      shouldDisplayInForeground = [visibleAppManifest.notificationPreferences[@"iosDisplayInForeground"] boolValue];
     }
   }
 

--- a/ios/Exponent/Kernel/Views/EXAppViewController.m
+++ b/ios/Exponent/Kernel/Views/EXAppViewController.m
@@ -328,7 +328,7 @@ NS_ASSUME_NONNULL_BEGIN
  * therefore for any consecutive SplashScreen.show call we just reconfigure what's already visible.
  * In HomeApp or standalone apps this function is no-op as SplashScreen is managed differently.
  */
-- (void)_showOrReconfigureManagedAppSplashScreen:(NSDictionary *)manifest
+- (void)_showOrReconfigureManagedAppSplashScreen:(EXUpdatesRawManifest *)manifest
 {
   if (_isStandalone || _isHomeApp) {
     return;
@@ -412,7 +412,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - EXAppLoaderDelegate
 
-- (void)appLoader:(EXAppLoader *)appLoader didLoadOptimisticManifest:(NSDictionary *)manifest
+- (void)appLoader:(EXAppLoader *)appLoader didLoadOptimisticManifest:(EXUpdatesRawManifest *)manifest
 {
   if (_appLoadingCancelView) {
     UM_WEAKIFY(self);
@@ -437,7 +437,7 @@ NS_ASSUME_NONNULL_BEGIN
   }
 }
 
-- (void)appLoader:(EXAppLoader *)appLoader didFinishLoadingManifest:(NSDictionary *)manifest bundle:(NSData *)data
+- (void)appLoader:(EXAppLoader *)appLoader didFinishLoadingManifest:(EXUpdatesRawManifest *)manifest bundle:(NSData *)data
 {
   [self _showOrReconfigureManagedAppSplashScreen:manifest];
   [self _rebuildBridge];
@@ -458,7 +458,7 @@ NS_ASSUME_NONNULL_BEGIN
   [self maybeShowError:error];
 }
 
-- (void)appLoader:(EXAppLoader *)appLoader didResolveUpdatedBundleWithManifest:(NSDictionary * _Nullable)manifest isFromCache:(BOOL)isFromCache error:(NSError * _Nullable)error
+- (void)appLoader:(EXAppLoader *)appLoader didResolveUpdatedBundleWithManifest:(EXUpdatesRawManifest * _Nullable)manifest isFromCache:(BOOL)isFromCache error:(NSError * _Nullable)error
 {
   [[EXKernel sharedInstance].serviceRegistry.updatesManager notifyApp:_appRecord ofDownloadWithManifest:manifest isNew:!isFromCache error:error];
 }
@@ -544,7 +544,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (UIInterfaceOrientationMask)orientationMaskFromManifestOrDefault {
   if (_appRecord.appLoader.manifest) {
-    NSString *orientationConfig = _appRecord.appLoader.manifest[@"orientation"];
+    NSString *orientationConfig = _appRecord.appLoader.manifest.orientation;
     if ([orientationConfig isEqualToString:@"portrait"]) {
       // lock to portrait
       return UIInterfaceOrientationMaskPortrait;
@@ -663,12 +663,9 @@ NS_ASSUME_NONNULL_BEGIN
   }
 }
 
-- (NSString * _Nullable)_readUserInterfaceStyleFromManifest:(NSDictionary *)manifest
+- (NSString * _Nullable)_readUserInterfaceStyleFromManifest:(EXUpdatesRawManifest *)manifest
 {
-  if (manifest[@"ios"] && manifest[@"ios"][@"userInterfaceStyle"]) {
-    return manifest[@"ios"][@"userInterfaceStyle"];
-  }
-  return manifest[@"userInterfaceStyle"];
+  return manifest.userInterfaceStyle;
 }
 
 - (UIUserInterfaceStyle)_userInterfaceStyleForString:(NSString *)userInterfaceStyleString API_AVAILABLE(ios(12.0)) {
@@ -712,12 +709,9 @@ NS_ASSUME_NONNULL_BEGIN
     }
 }
 
-- (NSString * _Nullable)_readBackgroundColorFromManifest:(NSDictionary *)manifest
+- (NSString * _Nullable)_readBackgroundColorFromManifest:(EXUpdatesRawManifest *)manifest
 {
-  if (manifest[@"ios"] && manifest[@"ios"][@"backgroundColor"]) {
-    return manifest[@"ios"][@"backgroundColor"];
-  }
-  return manifest[@"backgroundColor"];
+  return manifest.androidOrRootBackroundColor;
 }
 
 

--- a/ios/Exponent/Kernel/Views/EXErrorView.m
+++ b/ios/Exponent/Kernel/Views/EXErrorView.m
@@ -81,8 +81,8 @@
   if (_appRecord) {
     if (_appRecord == [EXKernel sharedInstance].appRegistry.homeAppRecord) {
       appOwnerName = @"Expo";
-    } else if (_appRecord.appLoader.manifest && _appRecord.appLoader.manifest[@"name"]) {
-      appOwnerName = [NSString stringWithFormat:@"\"%@\"", _appRecord.appLoader.manifest[@"name"]];
+    } else if (_appRecord.appLoader.manifest && _appRecord.appLoader.manifest.name) {
+      appOwnerName = [NSString stringWithFormat:@"\"%@\"", _appRecord.appLoader.manifest.name];
     }
   }
 

--- a/ios/Exponent/Kernel/Views/Loading/EXManagedAppSplashScreenConfigurationBuilder.h
+++ b/ios/Exponent/Kernel/Views/Loading/EXManagedAppSplashScreenConfigurationBuilder.h
@@ -1,5 +1,6 @@
 #import <Foundation/Foundation.h>
 #import "EXManagedAppSplashScreenConfiguration.h"
+#import <EXUpdates/EXUpdatesRawManifest.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -8,7 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface EXManagedAppSplashScreenConfigurationBuilder : NSObject
 
-+ (EXManagedAppSplashScreenConfiguration *)parseManifest:(NSDictionary *)manifest;
++ (EXManagedAppSplashScreenConfiguration *)parseManifest:(EXUpdatesRawManifest *)manifest;
 
 @end
 

--- a/ios/Exponent/Kernel/Views/Loading/EXManagedAppSplashScreenConfigurationBuilder.m
+++ b/ios/Exponent/Kernel/Views/Loading/EXManagedAppSplashScreenConfigurationBuilder.m
@@ -16,7 +16,7 @@ static const NSString *kImageResizeModeCover = @"cover";
 
 @implementation EXManagedAppSplashScreenConfigurationBuilder
 
-+ (EXManagedAppSplashScreenConfiguration *)parseManifest:(NSDictionary *)manifest
++ (EXManagedAppSplashScreenConfiguration *)parseManifest:(EXUpdatesRawManifest *)manifest
 {
   UIColor *backgroundColor = [[self class] parseBackgroundColor:manifest];
   NSString *imageUrl = [[self class] parseImageUrl:manifest];
@@ -26,14 +26,10 @@ static const NSString *kImageResizeModeCover = @"cover";
                                                                 imageResizeMode:imageResizeMode];
 }
 
-+ (UIColor * _Nonnull)parseBackgroundColor:(NSDictionary *)manifest
++ (UIColor * _Nonnull)parseBackgroundColor:(EXUpdatesRawManifest *)manifest
 {
   // TODO: (@bbarthec) backgroundColor is recommended to be in HEX format for now, but it should be any css-valid format
-  NSString *hexString = [[self class] getStringFromManifest:manifest
-                                                      paths:@[
-                                                        @[kManifestIosKey, kManifestSplashKey, kManifestBackgroundColorKey],
-                                                        @[kManifestSplashKey, kManifestBackgroundColorKey],
-                                                      ]];
+  NSString *hexString = manifest.iosSplashBackgroundColor;
   UIColor *color = [EXUtil colorWithHexString:hexString];
   if (color) {
     return color;
@@ -42,57 +38,18 @@ static const NSString *kImageResizeModeCover = @"cover";
   return [UIColor whiteColor];
 }
 
-+ (NSString * _Nullable)parseImageUrl:(NSDictionary *)manifest
++ (NSString * _Nullable)parseImageUrl:(EXUpdatesRawManifest *)manifest
 {
-  return [[self class] getStringFromManifest:manifest
-                                       paths:@[
-                                         [UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPad
-                                           ? @[kManifestIosKey, kManifestSplashKey, kManifestTabletImageUrlKey]
-                                           : @[],
-                                         @[kManifestIosKey, kManifestSplashKey, kManifestImageUrlKey],
-                                         @[kManifestSplashKey, kManifestImageUrlKey],
-                                       ]];
+  return manifest.iosSplashImageUrl;
 }
 
-+ (EXSplashScreenImageResizeMode)parseImageResizeMode:(NSDictionary *)manifest
++ (EXSplashScreenImageResizeMode)parseImageResizeMode:(EXUpdatesRawManifest *)manifest
 {
-  NSString *resizeMode = [[self class] getStringFromManifest:manifest
-                                                       paths:@[
-                                                         @[kManifestIosKey, kManifestSplashKey, kManifestResizeModeKey],
-                                                         @[kManifestSplashKey, kManifestResizeModeKey],
-                                                       ]];
+  NSString *resizeMode = manifest.iosSplashImageResizeMode;
   if ([kImageResizeModeCover isEqualToString:resizeMode]) {
     return EXSplashScreenImageResizeModeCover;
   }
   return EXSplashScreenImageResizeModeContain;
-}
-
-+ (NSString * _Nullable)getStringFromManifest:(NSDictionary *)manifest
-                                        paths:(NSArray<NSArray<const NSString *> *> *)paths
-{
-  for (NSArray<const NSString *> *path in paths) {
-    NSString *result = [[self class] getStringFromManifest:manifest path:path];
-    if (result) {
-      return result;
-    }
-  }
-  return nil;
-}
-
-+ (NSString * _Nullable)getStringFromManifest:(NSDictionary *)manifest
-                                         path:(NSArray<const NSString *> *)path
-{
-  NSDictionary *json = manifest;
-  for (int i = 0; i < path.count; i++) {
-    BOOL isLastKey = i == path.count - 1;
-    const NSString *key = path[i];
-    id value = json[key];
-    if (isLastKey && [value isKindOfClass:[NSString class]]) {
-      return value;
-    }
-    json = value;
-  }
-  return nil;
 }
 
 @end

--- a/ios/Exponent/Kernel/Views/Loading/EXManagedAppSplashScreenViewProvider.h
+++ b/ios/Exponent/Kernel/Views/Loading/EXManagedAppSplashScreenViewProvider.h
@@ -11,12 +11,12 @@ NS_ASSUME_NONNULL_BEGIN
 @interface EXManagedAppSplashScreenViewProvider : NSObject<EXSplashScreenViewProvider>
 
 - (instancetype)init NS_UNAVAILABLE;
-- (instancetype)initWithManifest:(NSDictionary *)manifest;
+- (instancetype)initWithManifest:(EXUpdatesRawManifest *)manifest;
 
 /**
  * Triggers the view reconfiguration.
  */
-- (void)updateSplashScreenViewWithManifest:(NSDictionary *)manifest;
+- (void)updateSplashScreenViewWithManifest:(EXUpdatesRawManifest *)manifest;
 
 @end
 

--- a/ios/Exponent/Kernel/Views/Loading/EXManagedAppSplashScreenViewProvider.m
+++ b/ios/Exponent/Kernel/Views/Loading/EXManagedAppSplashScreenViewProvider.m
@@ -18,7 +18,7 @@
 
 @implementation EXManagedAppSplashScreenViewProvider
 
-- (instancetype)initWithManifest:(NSDictionary *)manifest
+- (instancetype)initWithManifest:(EXUpdatesRawManifest *)manifest
 {
   if (self = [super init]) {
     _configuration = [EXManagedAppSplashScreenConfigurationBuilder parseManifest:manifest];
@@ -26,7 +26,7 @@
   return self;
 }
 
-- (void)updateSplashScreenViewWithManifest:(NSDictionary *)manifest
+- (void)updateSplashScreenViewWithManifest:(EXUpdatesRawManifest *)manifest
 {
   EXManagedAppSplashScreenConfiguration *previousConfiguration = _configuration;
   _configuration = [EXManagedAppSplashScreenConfigurationBuilder parseManifest:manifest];

--- a/ios/Tests/AppLoader/EXAppLoader+Tests.h
+++ b/ios/Tests/AppLoader/EXAppLoader+Tests.h
@@ -1,4 +1,5 @@
 #import "EXAppLoader.h"
+#import <EXUpdates/EXUpdatesRawManifest.h>
 
 #pragma mark - private/internal methods in App Loader & App Fetchers
 
@@ -6,6 +7,6 @@
 
 @property (nonatomic, readonly) EXAppFetcher * _Nullable appFetcher;
 
-- (BOOL)_fetchBundleWithManifest:(NSDictionary *)manifest;
+- (BOOL)_fetchBundleWithManifest:(EXUpdatesRawManifest *)manifest;
 
 @end

--- a/ios/Tests/Linking/EXLinkingTests.m
+++ b/ios/Tests/Linking/EXLinkingTests.m
@@ -130,6 +130,12 @@
   }
 }
 
+#pragma mark - EAS manifests
+
+- (void)testEASManifestUrls {
+  [self _assertDeepLink:@"exps://updates.expo.dev/37700852-0840-47b7-80cb-d57746395f57?runtime-version=exposdk%3A40.0.0&channel-name=main" routesToManifest:@"exps://updates.expo.dev/37700852-0840-47b7-80cb-d57746395f57?runtime-version=exposdk%3A40.0.0&channel-name=main"];
+}
+
 #pragma mark - internal
 
 - (void)_assertDeepLink:(NSString *)deepLinkUrlString routesToManifest:(NSString *)manifestUrlString

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Add onAssetLoaded progress callback to remote loader. (Android: [#12608](https://github.com/expo/expo/pull/12608) and iOS: [#12684](https://github.com/expo/expo/pull/12684) by [@esamelson](https://github.com/esamelson))
 - Add setter and resetter for SelectionPolicy. (Android: [#12609](https://github.com/expo/expo/pull/12609) and iOS: [#12685](https://github.com/expo/expo/pull/12685) by [@esamelson](https://github.com/esamelson))
 - Convert most remaining usages of JSON manifest to RawManifest. ([#12600](https://github.com/expo/expo/pull/12600) by [@wschurman](https://github.com/wschurman))
+- Factor out raw manifest into wrapper class. ([#12631](https://github.com/expo/expo/pull/12631) by [@wschurman](https://github.com/wschurman))
 
 
 ### 🐛 Bug fixes

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesAppController.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesAppController.m
@@ -245,7 +245,7 @@ static NSString * const EXUpdatesErrorEventName = @"error";
     [EXUpdatesUtils sendEventToBridge:_bridge withType:EXUpdatesErrorEventName body:@{@"message": error.localizedDescription}];
   } else if (status == EXUpdatesBackgroundUpdateStatusUpdateAvailable) {
     NSAssert(update != nil, @"Background update with error status must have a nonnull update object");
-    [EXUpdatesUtils sendEventToBridge:_bridge withType:EXUpdatesUpdateAvailableEventName body:@{@"manifest": update.rawManifest}];
+    [EXUpdatesUtils sendEventToBridge:_bridge withType:EXUpdatesUpdateAvailableEventName body:@{@"manifest": update.rawManifest.rawManifestJSON}];
   } else if (status == EXUpdatesBackgroundUpdateStatusNoUpdateAvailable) {
     [EXUpdatesUtils sendEventToBridge:_bridge withType:EXUpdatesNoUpdateAvailableEventName body:@{}];
   }

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesModule.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesModule.m
@@ -42,7 +42,7 @@ UM_EXPORT_MODULE(ExpoUpdates);
       @"isEnabled": @(YES),
       @"isUsingEmbeddedAssets": @(_updatesService.isUsingEmbeddedAssets),
       @"updateId": launchedUpdate.updateId.UUIDString ?: @"",
-      @"manifest": launchedUpdate.rawManifest ?: @{},
+      @"manifest": launchedUpdate.rawManifest.rawManifestJSON ?: @{},
       @"releaseChannel": _updatesService.config.releaseChannel,
       @"localAssets": _updatesService.assetFilesMap ?: @{},
       @"isEmergencyLaunch": @(_updatesService.isEmergencyLaunch),
@@ -106,7 +106,7 @@ UM_EXPORT_METHOD_AS(checkForUpdateAsync,
     if ([selectionPolicy shouldLoadNewUpdate:update withLaunchedUpdate:launchedUpdate filters:update.manifestFilters]) {
       resolve(@{
         @"isAvailable": @(YES),
-        @"manifest": update.rawManifest
+        @"manifest": update.rawManifest.rawManifestJSON
       });
     } else {
       resolve(@{
@@ -141,7 +141,7 @@ UM_EXPORT_METHOD_AS(fetchUpdateAsync,
       [self->_updatesService resetSelectionPolicy];
       resolve(@{
         @"isNew": @(YES),
-        @"manifest": update.rawManifest
+        @"manifest": update.rawManifest.rawManifestJSON
       });
     } else {
       resolve(@{

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesBareUpdate.h
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesBareUpdate.h
@@ -1,14 +1,15 @@
 //  Copyright © 2019 650 Industries. All rights reserved.
 
 #import <EXUpdates/EXUpdatesUpdate.h>
+#import <EXUpdates/EXUpdatesBareRawManifest.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface EXUpdatesBareUpdate : NSObject
 
-+ (EXUpdatesUpdate *)updateWithBareManifest:(NSDictionary *)manifest
-                                     config:(EXUpdatesConfig *)config
-                                   database:(EXUpdatesDatabase *)database;
++ (EXUpdatesUpdate *)updateWithBareRawManifest:(EXUpdatesBareRawManifest *)manifest
+                                        config:(EXUpdatesConfig *)config
+                                      database:(EXUpdatesDatabase *)database;
 
 @end
 

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesBareUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesBareUpdate.m
@@ -4,23 +4,24 @@
 #import <EXUpdates/EXUpdatesEmbeddedAppLoader.h>
 #import <EXUpdates/EXUpdatesUpdate+Private.h>
 #import <EXUpdates/EXUpdatesUtils.h>
+#import <EXUpdates/EXUpdatesBareRawManifest.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 @implementation EXUpdatesBareUpdate
 
-+ (EXUpdatesUpdate *)updateWithBareManifest:(NSDictionary *)manifest
-                                     config:(EXUpdatesConfig *)config
-                                   database:(EXUpdatesDatabase *)database
++ (EXUpdatesUpdate *)updateWithBareRawManifest:(EXUpdatesBareRawManifest *)manifest
+                                        config:(EXUpdatesConfig *)config
+                                      database:(EXUpdatesDatabase *)database
 {
   EXUpdatesUpdate *update = [[EXUpdatesUpdate alloc] initWithRawManifest:manifest
                                                                   config:config
                                                                 database:database];
 
-  id updateId = manifest[@"id"];
-  id commitTime = manifest[@"commitTime"];
-  id metadata = manifest[@"metadata"];
-  id assets = manifest[@"assets"];
+  id updateId = manifest.rawID;
+  id commitTime = manifest.commitTimeNumber;
+  id metadata = manifest.metadata;
+  id assets = manifest.assets;
 
   NSAssert([updateId isKindOfClass:[NSString class]], @"update ID should be a string");
   NSAssert([commitTime isKindOfClass:[NSNumber class]], @"commitTime should be a number");

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesLegacyUpdate.h
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesLegacyUpdate.h
@@ -1,16 +1,17 @@
 //  Copyright © 2019 650 Industries. All rights reserved.
 
 #import <EXUpdates/EXUpdatesUpdate.h>
+#import <EXUpdates/EXUpdatesLegacyRawManifest.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface EXUpdatesLegacyUpdate : NSObject
 
-+ (EXUpdatesUpdate *)updateWithLegacyManifest:(NSDictionary *)manifest
++ (EXUpdatesUpdate *)updateWithLegacyManifest:(EXUpdatesLegacyRawManifest *)manifest
                                        config:(EXUpdatesConfig *)config
                                      database:(EXUpdatesDatabase *)database;
 
-+ (NSURL *)bundledAssetBaseUrlWithManifest:(NSDictionary *)manifest config:(EXUpdatesConfig *)config;
++ (NSURL *)bundledAssetBaseUrlWithManifest:(EXUpdatesLegacyRawManifest *)manifest config:(EXUpdatesConfig *)config;
 
 @end
 

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesNewUpdate.h
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesNewUpdate.h
@@ -1,12 +1,13 @@
 //  Copyright © 2019 650 Industries. All rights reserved.
 
 #import <EXUpdates/EXUpdatesUpdate.h>
+#import <EXUpdates/EXUpdatesNewRawManifest.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface EXUpdatesNewUpdate : NSObject
 
-+ (EXUpdatesUpdate *)updateWithNewManifest:(NSDictionary *)rootManifest
++ (EXUpdatesUpdate *)updateWithNewManifest:(EXUpdatesNewRawManifest *)rootManifest
                                   response:(nullable NSURLResponse *)response
                                     config:(EXUpdatesConfig *)config
                                   database:(EXUpdatesDatabase *)database;

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate+Private.h
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate+Private.h
@@ -23,7 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong) EXUpdatesConfig *config;
 @property (nonatomic, strong, nullable) EXUpdatesDatabase *database;
 
-- (instancetype)initWithRawManifest:(NSDictionary *)manifest
+- (instancetype)initWithRawManifest:(EXUpdatesRawManifest *)manifest
                              config:(EXUpdatesConfig *)config
                            database:(nullable EXUpdatesDatabase *)database;
 

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate.h
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate.h
@@ -2,6 +2,7 @@
 
 #import <EXUpdates/EXUpdatesAsset.h>
 #import <EXUpdates/EXUpdatesConfig.h>
+#import <EXUpdates/EXUpdatesRawManifest.h>
 
 @class EXUpdatesDatabase;
 
@@ -31,7 +32,7 @@ typedef NS_ENUM(NSInteger, EXUpdatesUpdateStatus) {
 @property (nonatomic, strong, readonly, nullable) NSDictionary *serverDefinedHeaders;
 @property (nonatomic, strong, readonly, nullable) NSDictionary *manifestFilters;
 
-@property (nonatomic, strong, readonly) NSDictionary *rawManifest;
+@property (nonatomic, strong, readonly) EXUpdatesRawManifest *rawManifest;
 
 @property (nonatomic, assign) EXUpdatesUpdateStatus status;
 
@@ -54,6 +55,8 @@ typedef NS_ENUM(NSInteger, EXUpdatesUpdateStatus) {
 + (instancetype)updateWithEmbeddedManifest:(NSDictionary *)manifest
                                     config:(EXUpdatesConfig *)config
                                   database:(nullable EXUpdatesDatabase *)database;
+
++ (EXUpdatesRawManifest *)rawManifestForJSON:(NSDictionary *)manifestJSON;
 
 @end
 

--- a/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesBareRawManifest.h
+++ b/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesBareRawManifest.h
@@ -1,0 +1,15 @@
+//  Copyright © 2021 650 Industries. All rights reserved.
+
+#import <EXUpdates/EXUpdatesRawManifest.h>
+#import <EXUpdates/EXUpdatesBaseLegacyRawManifest.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface EXUpdatesBareRawManifest : EXUpdatesBaseLegacyRawManifest<EXUpdatesRawManifestBehavior>
+
+- (NSNumber *)commitTimeNumber;
+- (nullable NSDictionary *)metadata;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesBareRawManifest.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesBareRawManifest.m
@@ -1,0 +1,15 @@
+//  Copyright © 2021 650 Industries. All rights reserved.
+
+#import <EXUpdates/EXUpdatesBareRawManifest.h>
+
+@implementation EXUpdatesBareRawManifest
+
+- (nonnull NSNumber *)commitTimeNumber {
+  return self.rawManifestJSON[@"commitTime"];
+}
+
+- (NSDictionary *)metadata {
+  return self.rawManifestJSON[@"metadata"];
+}
+
+@end

--- a/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesBaseLegacyRawManifest.h
+++ b/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesBaseLegacyRawManifest.h
@@ -1,0 +1,15 @@
+//  Copyright © 2021 650 Industries. All rights reserved.
+
+#import <EXUpdates/EXUpdatesBaseRawManifest.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface EXUpdatesBaseLegacyRawManifest : EXUpdatesBaseRawManifest
+
+- (NSString *)bundleUrl;
+- (NSString *)sdkVersion;
+- (nullable NSArray *)assets;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesBaseLegacyRawManifest.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesBaseLegacyRawManifest.m
@@ -1,0 +1,19 @@
+//  Copyright © 2021 650 Industries. All rights reserved.
+
+#import <EXUpdates/EXUpdatesBaseLegacyRawManifest.h>
+
+@implementation EXUpdatesBaseLegacyRawManifest
+
+- (NSString *)bundleUrl {
+  return self.rawManifestJSON[@"bundleUrl"];
+}
+
+- (NSString *)sdkVersion {
+  return self.rawManifestJSON[@"sdkVersion"];
+}
+
+- (nullable NSArray *)assets {
+  return self.rawManifestJSON[@"assets"];
+}
+
+@end

--- a/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesBaseRawManifest.h
+++ b/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesBaseRawManifest.h
@@ -1,0 +1,36 @@
+//  Copyright © 2021 650 Industries. All rights reserved.
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface EXUpdatesBaseRawManifest : NSObject
+
+@property (nonatomic, readonly, strong) NSDictionary* rawManifestJSON;
+
+- (instancetype)init NS_UNAVAILABLE;
+- (instancetype)initWithRawManifestJSON:(NSDictionary *)rawManifestJSON NS_DESIGNATED_INITIALIZER;
+
+# pragma mark - Common EXUpdatesRawManifestBehavior
+
+- (NSString *)rawID;
+- (NSString *)revisionId;
+- (nullable NSString *)slug;
+- (nullable NSString *)appKey;
+- (nullable NSString *)name;
+- (nullable NSDictionary *)notificationPreferences;
+- (nullable NSDictionary *)updatesInfo;
+- (nullable NSDictionary *)iosConfig;
+- (nullable NSString *)hostUri;
+- (nullable NSString *)orientation;
+
+- (BOOL)isDevelopmentMode;
+- (BOOL)isDevelopmentSilentLaunch;
+- (BOOL)isUsingDeveloperTool;
+- (nullable NSString *)userInterfaceStyle;
+- (nullable NSString *)androidOrRootBackroundColor;
+- (nullable NSString *)iosSplashBackgroundColor;
+- (nullable NSString *)iosSplashImageUrl;
+- (nullable NSString *)iosSplashImageResizeMode;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesBaseRawManifest.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesBaseRawManifest.m
@@ -1,0 +1,151 @@
+//  Copyright © 2021 650 Industries. All rights reserved.
+
+#import <EXUpdates/EXUpdatesBaseRawManifest.h>
+
+@implementation EXUpdatesBaseRawManifest
+
+- (instancetype)initWithRawManifestJSON:(NSDictionary *)rawManifestJSON {
+  if (self = [super init]) {
+    _rawManifestJSON = rawManifestJSON;
+  }
+  return self;
+}
+
+- (NSString *)description {
+   return self.rawManifestJSON.description;
+}
+
+# pragma mark - Field Getters
+
+- (NSString *)rawID {
+  return self.rawManifestJSON[@"id"];
+}
+
+- (NSString *)revisionId {
+  return self.rawManifestJSON[@"revisionId"];
+}
+
+- (nullable NSString *)slug {
+  return self.rawManifestJSON[@"slug"];
+}
+
+- (nullable NSString *)appKey {
+  return self.rawManifestJSON[@"appKey"];
+}
+
+- (nullable NSString *)name {
+  return self.rawManifestJSON[@"name"];
+}
+
+- (nullable NSDictionary *)notificationPreferences {
+  return self.rawManifestJSON[@"notification"];
+}
+
+- (nullable NSDictionary *)updatesInfo {
+  return self.rawManifestJSON[@"updates"];
+}
+
+- (nullable NSDictionary *)iosConfig {
+  return self.rawManifestJSON[@"ios"];
+}
+
+- (nullable NSString *)hostUri {
+  return self.rawManifestJSON[@"hostUri"];
+}
+
+- (nullable NSString *)orientation {
+  return self.rawManifestJSON[@"orientation"];
+}
+
+# pragma mark - Derived Methods
+
+- (BOOL)isDevelopmentMode {
+  NSDictionary *manifestPackagerOptsConfig = self.rawManifestJSON[@"packagerOpts"];
+  return (self.rawManifestJSON[@"developer"] != nil && manifestPackagerOptsConfig != nil && [@(YES) isEqualToNumber:manifestPackagerOptsConfig[@"dev"]]);
+}
+
+- (BOOL)isDevelopmentSilentLaunch {
+  NSDictionary *developmentClientSettings = self.rawManifestJSON[@"developmentClient"];
+  if (developmentClientSettings && [developmentClientSettings isKindOfClass:[NSDictionary class]]) {
+    id silentLaunch = developmentClientSettings[@"silentLaunch"];
+    return silentLaunch && [@(YES) isEqual:silentLaunch];
+  }
+  return false;
+}
+
+- (BOOL)isUsingDeveloperTool {
+  NSDictionary *manifestDeveloperConfig = self.rawManifestJSON[@"developer"];
+  BOOL isDeployedFromTool = (manifestDeveloperConfig && manifestDeveloperConfig[@"tool"] != nil);
+  return (isDeployedFromTool);
+}
+
+- (nullable NSString *)userInterfaceStyle {
+  if (self.iosConfig && self.iosConfig[@"userInterfaceStyle"]) {
+    return self.iosConfig[@"userInterfaceStyle"];
+  }
+  return self.rawManifestJSON[@"userInterfaceStyle"];
+}
+
+- (nullable NSString *)androidOrRootBackroundColor {
+  if (self.iosConfig && self.iosConfig[@"backgroundColor"]) {
+    return self.iosConfig[@"backgroundColor"];
+  }
+  return self.rawManifestJSON[@"backgroundColor"];
+}
+
+- (nullable NSString *)iosSplashBackgroundColor {
+  return [[self class] getStringFromManifest:self.rawManifestJSON
+                                       paths:@[
+                                         @[@"ios", @"splash", @"backgroundColor"],
+                                         @[@"splash", @"backgroundColor"],
+                                       ]];
+}
+
+- (nullable NSString *)iosSplashImageUrl {
+  return [[self class] getStringFromManifest:self.rawManifestJSON
+                                       paths:@[
+                                         [UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPad
+                                         ? @[@"ios", @"splash", @"tabletImageUrl"]
+                                         : @[],
+                                         @[@"ios", @"splash", @"imageUrl"],
+                                         @[@"splash", @"imageUrl"],
+                                       ]];
+}
+
+- (nullable NSString *)iosSplashImageResizeMode {
+  return [[self class] getStringFromManifest:self.rawManifestJSON
+                                       paths:@[
+                                         @[@"ios", @"splash", @"resizeMode"],
+                                         @[@"splash", @"resizeMode"],
+                                       ]];
+}
+
++ (NSString * _Nullable)getStringFromManifest:(NSDictionary *)manifest
+                                        paths:(NSArray<NSArray<const NSString *> *> *)paths
+{
+  for (NSArray<const NSString *> *path in paths) {
+    NSString *result = [[self class] getStringFromManifest:manifest path:path];
+    if (result) {
+      return result;
+    }
+  }
+  return nil;
+}
+
++ (NSString * _Nullable)getStringFromManifest:(NSDictionary *)manifest
+                                         path:(NSArray<const NSString *> *)path
+{
+  NSDictionary *json = manifest;
+  for (int i = 0; i < path.count; i++) {
+    BOOL isLastKey = i == path.count - 1;
+    const NSString *key = path[i];
+    id value = json[key];
+    if (isLastKey && [value isKindOfClass:[NSString class]]) {
+      return value;
+    }
+    json = value;
+  }
+  return nil;
+}
+
+@end

--- a/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesLegacyRawManifest.h
+++ b/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesLegacyRawManifest.h
@@ -1,0 +1,19 @@
+//  Copyright © 2021 650 Industries. All rights reserved.
+
+#import <EXUpdates/EXUpdatesRawManifest.h>
+#import <EXUpdates/EXUpdatesBaseLegacyRawManifest.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface EXUpdatesLegacyRawManifest : EXUpdatesBaseLegacyRawManifest<EXUpdatesRawManifestBehavior>
+
+- (NSString *)releaseID;
+- (NSString *)commitTime;
+- (nullable NSArray *)bundledAssets;
+- (nullable id)runtimeVersion;
+- (nullable NSString *)bundleKey;
+- (nullable NSString *)assetUrlOverride;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesLegacyRawManifest.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesLegacyRawManifest.m
@@ -1,0 +1,33 @@
+//  Copyright © 2021 650 Industries. All rights reserved.
+
+#import <EXUpdates/EXUpdatesLegacyRawManifest.h>
+
+@implementation EXUpdatesLegacyRawManifest
+
+# pragma mark - Field Methods
+
+- (NSString *)releaseID {
+  return self.rawManifestJSON[@"releaseId"];
+}
+
+- (NSString *)commitTime {
+  return self.rawManifestJSON[@"commitTime"];
+}
+
+- (nullable NSArray *)bundledAssets {
+  return self.rawManifestJSON[@"bundledAssets"];
+}
+
+- (nullable id)runtimeVersion {
+  return self.rawManifestJSON[@"runtimeVersion"];
+}
+
+- (nullable NSString *)bundleKey {
+  return self.rawManifestJSON[@"bundleKey"];
+}
+
+- (nullable NSString *)assetUrlOverride {
+  return self.rawManifestJSON[@"assetUrlOverride"];
+}
+
+@end

--- a/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesNewRawManifest.h
+++ b/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesNewRawManifest.h
@@ -1,0 +1,16 @@
+//  Copyright © 2021 650 Industries. All rights reserved.
+
+#import <EXUpdates/EXUpdatesRawManifest.h>
+#import <EXUpdates/EXUpdatesBaseRawManifest.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface EXUpdatesNewRawManifest : EXUpdatesBaseRawManifest<EXUpdatesRawManifestBehavior>
+
+- (NSString *)createdAt;
+- (NSString *)runtimeVersion;
+- (NSDictionary *)launchAsset;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesNewRawManifest.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesNewRawManifest.m
@@ -1,0 +1,44 @@
+//  Copyright © 2021 650 Industries. All rights reserved.
+
+#import <EXUpdates/EXUpdatesNewRawManifest.h>
+
+@implementation EXUpdatesNewRawManifest
+
+- (NSString *)createdAt {
+  return self.rawManifestJSON[@"createdAt"];
+}
+
+- (NSString *)sdkVersion {
+  NSString *runtimeVersion = self.runtimeVersion;
+  NSRegularExpression *regex =
+      [NSRegularExpression regularExpressionWithPattern:@"^exposdk:(\\d+\\.\\d+\\.\\d+)$"
+                                                options:0
+                                                  error:nil];
+  NSTextCheckingResult *match = [regex firstMatchInString:runtimeVersion options:0 range:NSMakeRange(0, [runtimeVersion length])];
+  if (match) {
+    NSRange matchRange = [match rangeAtIndex:1];
+    if (!NSEqualRanges(matchRange, NSMakeRange(NSNotFound, 0))) {
+      return [runtimeVersion substringWithRange:matchRange];
+    }
+  }
+  
+  return nil;
+}
+
+- (NSString *)runtimeVersion {
+  return self.rawManifestJSON[@"runtimeVersion"];
+}
+
+- (NSDictionary *)launchAsset {
+  return self.rawManifestJSON[@"launchAsset"];
+}
+
+- (NSArray *)assets {
+  return self.rawManifestJSON[@"assets"];
+}
+
+- (NSString *)bundleUrl {
+  return self.launchAsset[@"url"];
+}
+
+@end

--- a/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesRawManifest.h
+++ b/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesRawManifest.h
@@ -1,0 +1,42 @@
+//  Copyright © 2021 650 Industries. All rights reserved.
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol EXUpdatesRawManifestBehavior <NSObject>
+
+# pragma mark - Raw JSON
+
+- (NSDictionary *)rawManifestJSON;
+
+# pragma mark - Field getters
+
+- (NSString *)rawID;
+- (NSString *)sdkVersion;
+- (NSString *)bundleUrl;
+- (NSString *)revisionId;
+- (nullable NSArray *)assets;
+- (nullable NSString *)slug;
+- (nullable NSString *)appKey;
+- (nullable NSString *)name;
+- (nullable NSDictionary *)notificationPreferences;
+- (nullable NSDictionary *)updatesInfo;
+- (nullable NSDictionary *)iosConfig;
+- (nullable NSString *)hostUri;
+- (nullable NSString *)orientation;
+
+# pragma mark - Derived Methods
+
+- (BOOL)isDevelopmentMode;
+- (BOOL)isDevelopmentSilentLaunch;
+- (BOOL)isUsingDeveloperTool;
+- (nullable NSString *)userInterfaceStyle;
+- (nullable NSString *)androidOrRootBackroundColor;
+- (nullable NSString *)iosSplashBackgroundColor;
+- (nullable NSString *)iosSplashImageUrl;
+- (nullable NSString *)iosSplashImageResizeMode;
+
+@end
+
+typedef NSObject<EXUpdatesRawManifestBehavior> EXUpdatesRawManifest;
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/ios/Tests/EXUpdatesDatabaseTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesDatabaseTests.m
@@ -10,7 +10,7 @@
 
 @property (nonatomic, strong) EXUpdatesDatabase *db;
 @property (nonatomic, strong) NSURL *testDatabaseDir;
-@property (nonatomic, strong) NSDictionary *manifest;
+@property (nonatomic, strong) EXUpdatesNewRawManifest *manifest;
 @property (nonatomic, strong) EXUpdatesConfig *config;
 
 @end
@@ -34,12 +34,12 @@
     XCTAssertNil(dbOpenError);
   });
 
-  _manifest = @{
+  _manifest = [[EXUpdatesNewRawManifest alloc] initWithRawManifestJSON:@{
     @"runtimeVersion": @"1",
     @"id": @"0eef8214-4833-4089-9dff-b4138a14f196",
     @"createdAt": @"2020-11-11T00:17:54.797Z",
     @"launchAsset": @{@"url": @"https://url.to/bundle.js", @"contentType": @"application/javascript"}
-  };
+  }];
   _config = [EXUpdatesConfig configWithDictionary:@{
     @"EXUpdatesURL": @"https://exp.host/@test/test",
     @"EXUpdatesUsesLegacyManifest": @(NO)

--- a/packages/expo-updates/ios/Tests/EXUpdatesLegacyUpdateTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesLegacyUpdateTests.m
@@ -39,137 +39,139 @@
 
 - (void)testBundledAssetBaseUrl_ExpoDomain
 {
+  EXUpdatesLegacyRawManifest *manifest = [[EXUpdatesLegacyRawManifest alloc] initWithRawManifestJSON:@{}];
   NSURL *expected = [NSURL URLWithString:@"https://d1wp6m56sqw74a.cloudfront.net/~assets/"];
-  XCTAssert([expected isEqual:[EXUpdatesLegacyUpdate bundledAssetBaseUrlWithManifest:@{} config:[EXUpdatesConfig configWithDictionary:@{@"EXUpdatesURL": @"https://exp.host/@test/test"}]]]);
-  XCTAssert([expected isEqual:[EXUpdatesLegacyUpdate bundledAssetBaseUrlWithManifest:@{} config:[EXUpdatesConfig configWithDictionary:@{@"EXUpdatesURL": @"https://expo.io/@test/test"}]]]);
-  XCTAssert([expected isEqual:[EXUpdatesLegacyUpdate bundledAssetBaseUrlWithManifest:@{} config:[EXUpdatesConfig configWithDictionary:@{@"EXUpdatesURL": @"https://expo.test/@test/test"}]]]);
+  XCTAssert([expected isEqual:[EXUpdatesLegacyUpdate bundledAssetBaseUrlWithManifest:manifest config:[EXUpdatesConfig configWithDictionary:@{@"EXUpdatesURL": @"https://exp.host/@test/test"}]]]);
+  XCTAssert([expected isEqual:[EXUpdatesLegacyUpdate bundledAssetBaseUrlWithManifest:manifest config:[EXUpdatesConfig configWithDictionary:@{@"EXUpdatesURL": @"https://expo.io/@test/test"}]]]);
+  XCTAssert([expected isEqual:[EXUpdatesLegacyUpdate bundledAssetBaseUrlWithManifest:manifest config:[EXUpdatesConfig configWithDictionary:@{@"EXUpdatesURL": @"https://expo.test/@test/test"}]]]);
 }
 
 - (void)testBundledAssetBaseUrl_ExpoSubdomain
 {
+  EXUpdatesLegacyRawManifest *manifest = [[EXUpdatesLegacyRawManifest alloc] initWithRawManifestJSON:@{}];
   NSURL *expected = [NSURL URLWithString:@"https://d1wp6m56sqw74a.cloudfront.net/~assets/"];
-  XCTAssert([expected isEqual:[EXUpdatesLegacyUpdate bundledAssetBaseUrlWithManifest:@{} config:[EXUpdatesConfig configWithDictionary:@{@"EXUpdatesURL": @"https://staging.exp.host/@test/test"}]]]);
-  XCTAssert([expected isEqual:[EXUpdatesLegacyUpdate bundledAssetBaseUrlWithManifest:@{} config:[EXUpdatesConfig configWithDictionary:@{@"EXUpdatesURL": @"https://staging.expo.io/@test/test"}]]]);
-  XCTAssert([expected isEqual:[EXUpdatesLegacyUpdate bundledAssetBaseUrlWithManifest:@{} config:[EXUpdatesConfig configWithDictionary:@{@"EXUpdatesURL": @"https://staging.expo.test/@test/test"}]]]);
+  XCTAssert([expected isEqual:[EXUpdatesLegacyUpdate bundledAssetBaseUrlWithManifest:manifest config:[EXUpdatesConfig configWithDictionary:@{@"EXUpdatesURL": @"https://staging.exp.host/@test/test"}]]]);
+  XCTAssert([expected isEqual:[EXUpdatesLegacyUpdate bundledAssetBaseUrlWithManifest:manifest config:[EXUpdatesConfig configWithDictionary:@{@"EXUpdatesURL": @"https://staging.expo.io/@test/test"}]]]);
+  XCTAssert([expected isEqual:[EXUpdatesLegacyUpdate bundledAssetBaseUrlWithManifest:manifest config:[EXUpdatesConfig configWithDictionary:@{@"EXUpdatesURL": @"https://staging.expo.test/@test/test"}]]]);
 }
 
 - (void)testBundledAssetBaseUrl_AssetUrlOverride_AbsoluteUrl
 {
   NSString *absoluteUrlString = @"https://xxx.dev/~assets";
   NSURL *absoluteExpected = [NSURL URLWithString:absoluteUrlString];
-  NSURL *absoluteActual = [EXUpdatesLegacyUpdate bundledAssetBaseUrlWithManifest:@{ @"assetUrlOverride": absoluteUrlString } config:_selfHostedConfig];
+  NSURL *absoluteActual = [EXUpdatesLegacyUpdate bundledAssetBaseUrlWithManifest:[[EXUpdatesLegacyRawManifest alloc] initWithRawManifestJSON:@{ @"assetUrlOverride": absoluteUrlString }] config:_selfHostedConfig];
   XCTAssert([absoluteActual isEqual:absoluteExpected], @"should return the value of assetUrlOverride if it's an absolute URL");
 }
 
 - (void)testBundledAssetBaseUrl_AssetUrlOverride_RelativeUrl
 {
   NSURL *relativeExpected = [NSURL URLWithString:@"https://esamelson.github.io/self-hosting-test/my_assets"];
-  NSURL *relativeActual = [EXUpdatesLegacyUpdate bundledAssetBaseUrlWithManifest:@{ @"assetUrlOverride": @"my_assets" } config:_selfHostedConfig];
+  NSURL *relativeActual = [EXUpdatesLegacyUpdate bundledAssetBaseUrlWithManifest:[[EXUpdatesLegacyRawManifest alloc] initWithRawManifestJSON:@{ @"assetUrlOverride": @"my_assets" }] config:_selfHostedConfig];
   XCTAssert([relativeActual isEqual:relativeExpected], @"should return a URL relative to manifest URL base if it's a relative URL");
 }
 
 - (void)testBundledAssetBaseUrl_AssetUrlOverride_OriginRelativeUrl
 {
   NSURL *originRelativeExpected = [NSURL URLWithString:@"https://esamelson.github.io/my_assets"];
-  NSURL *originRelativeActual = [EXUpdatesLegacyUpdate bundledAssetBaseUrlWithManifest:@{ @"assetUrlOverride": @"/my_assets" } config:_selfHostedConfig];
+  NSURL *originRelativeActual = [EXUpdatesLegacyUpdate bundledAssetBaseUrlWithManifest:[[EXUpdatesLegacyRawManifest alloc] initWithRawManifestJSON:@{ @"assetUrlOverride": @"/my_assets" }] config:_selfHostedConfig];
   XCTAssert([originRelativeActual isEqual:originRelativeExpected], @"should return a URL relative to manifest URL base if it's an origin-relative URL");
 }
 
 - (void)testBundledAssetBaseUrl_AssetUrlOverride_RelativeUrlDotSlash
 {
   NSURL *relativeDotSlashExpected = [NSURL URLWithString:@"https://esamelson.github.io/self-hosting-test/my_assets"];
-  NSURL *relativeDotSlashActual = [EXUpdatesLegacyUpdate bundledAssetBaseUrlWithManifest:@{ @"assetUrlOverride": @"./my_assets" } config:_selfHostedConfig];
+  NSURL *relativeDotSlashActual = [EXUpdatesLegacyUpdate bundledAssetBaseUrlWithManifest:[[EXUpdatesLegacyRawManifest alloc] initWithRawManifestJSON:@{ @"assetUrlOverride": @"./my_assets" }] config:_selfHostedConfig];
   XCTAssert([relativeDotSlashActual isEqual:relativeDotSlashExpected], @"should return a URL relative to manifest URL base with `./` resolved correctly if it's a relative URL");
 }
 
 - (void)testBundledAssetBaseUrl_AssetUrlOverride_Normalize
 {
   NSURL *expected = [NSURL URLWithString:@"https://esamelson.github.io/self-hosting-test/b"];
-  NSURL *actual = [EXUpdatesLegacyUpdate bundledAssetBaseUrlWithManifest:@{ @"assetUrlOverride": @"./a/../b" } config:_selfHostedConfig];
+  NSURL *actual = [EXUpdatesLegacyUpdate bundledAssetBaseUrlWithManifest:[[EXUpdatesLegacyRawManifest alloc] initWithRawManifestJSON:@{ @"assetUrlOverride": @"./a/../b" }] config:_selfHostedConfig];
   XCTAssert([actual isEqual:expected], @"should return a correctly normalized URL relative to manifest URL base");
 }
 
 - (void)testBundledAssetBaseUrl_AssetUrlOverride_NormalizeToHostname
 {
   NSURL *expected = [NSURL URLWithString:@"https://esamelson.github.io/b"];
-  NSURL *actual = [EXUpdatesLegacyUpdate bundledAssetBaseUrlWithManifest:@{ @"assetUrlOverride": @"../b" } config:_selfHostedConfig];
+  NSURL *actual = [EXUpdatesLegacyUpdate bundledAssetBaseUrlWithManifest:[[EXUpdatesLegacyRawManifest alloc] initWithRawManifestJSON:@{ @"assetUrlOverride": @"../b" }] config:_selfHostedConfig];
   XCTAssert([actual isEqual:expected], @"should return a correctly normalized URL relative to manifest URL base if the relative path goes back to the hostname");
 }
 
 - (void)testBundledAssetBaseUrl_AssetUrlOverride_NormalizePastHostname
 {
   NSURL *expected = [NSURL URLWithString:@"https://esamelson.github.io/b"];
-  NSURL *actual = [EXUpdatesLegacyUpdate bundledAssetBaseUrlWithManifest:@{ @"assetUrlOverride": @"../../b" } config:_selfHostedConfig];
+  NSURL *actual = [EXUpdatesLegacyUpdate bundledAssetBaseUrlWithManifest:[[EXUpdatesLegacyRawManifest alloc] initWithRawManifestJSON:@{ @"assetUrlOverride": @"../../b" }] config:_selfHostedConfig];
   XCTAssert([actual isEqual:expected], @"should return a correctly normalized URL relative to manifest URL base if the relative path goes back past the hostname");
 }
 
 - (void)testBundledAssetBaseUrl_AssetUrlOverride_Default
 {
   NSURL *defaultExpected = [NSURL URLWithString:@"https://esamelson.github.io/self-hosting-test/assets"];
-  NSURL *defaultActual = [EXUpdatesLegacyUpdate bundledAssetBaseUrlWithManifest:@{} config:_selfHostedConfig];
+  NSURL *defaultActual = [EXUpdatesLegacyUpdate bundledAssetBaseUrlWithManifest:[[EXUpdatesLegacyRawManifest alloc] initWithRawManifestJSON:@{}] config:_selfHostedConfig];
   XCTAssert([defaultActual isEqual:defaultExpected], @"should return a URL with `assets` relative to manifest URL base if unspecified");
 }
 
 - (void)testUpdateWithLegacyManifest_Development
 {
   // manifests served from a developer tool should not need the releaseId and commitTime fields
-  NSDictionary *manifest = @{
+  EXUpdatesLegacyRawManifest *manifest = [[EXUpdatesLegacyRawManifest alloc] initWithRawManifestJSON:@{
     @"sdkVersion": @"39.0.0",
     @"bundleUrl": @"https://url.to/bundle.js",
     @"developer": @{@"tool": @"expo-cli"}
-  };
+  }];
   XCTAssert([EXUpdatesLegacyUpdate updateWithLegacyManifest:manifest config:_config database:_database] != nil);
 }
 
 - (void)testUpdateWithLegacyManifest_Production_AllFields
 {
   // production manifests should require the releaseId, commitTime, sdkVersion, and bundleUrl fields
-  NSDictionary *manifest = @{
+  EXUpdatesLegacyRawManifest *manifest = [[EXUpdatesLegacyRawManifest alloc] initWithRawManifestJSON:@{
     @"sdkVersion": @"39.0.0",
     @"releaseId": @"0eef8214-4833-4089-9dff-b4138a14f196",
     @"commitTime": @"2020-11-11T00:17:54.797Z",
     @"bundleUrl": @"https://url.to/bundle.js"
-  };
+  }];
   XCTAssert([EXUpdatesLegacyUpdate updateWithLegacyManifest:manifest config:_config database:_database] != nil);
 }
 
 - (void)testUpdateWithLegacyManifest_Production_NoSdkVersion
 {
-  NSDictionary *manifest = @{
+  EXUpdatesLegacyRawManifest *manifest = [[EXUpdatesLegacyRawManifest alloc] initWithRawManifestJSON:@{
     @"releaseId": @"0eef8214-4833-4089-9dff-b4138a14f196",
     @"commitTime": @"2020-11-11T00:17:54.797Z",
     @"bundleUrl": @"https://url.to/bundle.js"
-  };
+  }];
   XCTAssertThrows([EXUpdatesLegacyUpdate updateWithLegacyManifest:manifest config:_config database:_database]);
 }
 
 - (void)testUpdateWithLegacyManifest_Production_NoReleaseId
 {
-  NSDictionary *manifest = @{
+  EXUpdatesLegacyRawManifest *manifest = [[EXUpdatesLegacyRawManifest alloc] initWithRawManifestJSON:@{
     @"sdkVersion": @"39.0.0",
     @"commitTime": @"2020-11-11T00:17:54.797Z",
     @"bundleUrl": @"https://url.to/bundle.js"
-  };
+  }];
   XCTAssertThrows([EXUpdatesLegacyUpdate updateWithLegacyManifest:manifest config:_config database:_database]);
 }
 
 - (void)testUpdateWithLegacyManifest_Production_NoCommitTime
 {
-  NSDictionary *manifest = @{
+  EXUpdatesLegacyRawManifest *manifest = [[EXUpdatesLegacyRawManifest alloc] initWithRawManifestJSON:@{
     @"sdkVersion": @"39.0.0",
     @"releaseId": @"0eef8214-4833-4089-9dff-b4138a14f196",
     @"bundleUrl": @"https://url.to/bundle.js"
-  };
+  }];
   XCTAssertThrows([EXUpdatesLegacyUpdate updateWithLegacyManifest:manifest config:_config database:_database]);
 }
 
 - (void)testUpdateWithLegacyManifest_Production_NoBundleUrl
 {
-  NSDictionary *manifest = @{
+  EXUpdatesLegacyRawManifest *manifest = [[EXUpdatesLegacyRawManifest alloc] initWithRawManifestJSON:@{
     @"sdkVersion": @"39.0.0",
     @"releaseId": @"0eef8214-4833-4089-9dff-b4138a14f196",
     @"commitTime": @"2020-11-11T00:17:54.797Z"
-  };
+  }];
   XCTAssertThrows([EXUpdatesLegacyUpdate updateWithLegacyManifest:manifest config:_config database:_database]);
 }
 

--- a/packages/expo-updates/ios/Tests/EXUpdatesNewRawManifestTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesNewRawManifestTests.m
@@ -1,0 +1,41 @@
+//  Copyright (c) 2020 650 Industries, Inc. All rights reserved.
+
+#import <XCTest/XCTest.h>
+
+#import <EXUpdates/EXUpdatesNewRawManifest.h>
+
+@interface EXUpdatesNewRawManifestTests : XCTestCase
+
+@end
+
+@implementation EXUpdatesNewRawManifestTests
+
+- (void)testSDKVersion_ValidCases {
+  NSString *runtimeVersion = @"exposdk:39.0.0";
+  NSDictionary *manifestJson = @{
+    @"runtimeVersion": runtimeVersion
+  };
+  EXUpdatesNewRawManifest *manifest = [[EXUpdatesNewRawManifest alloc] initWithRawManifestJSON:manifestJson];
+  XCTAssert([manifest.sdkVersion isEqualToString:@"39.0.0"], @"%@", manifest.sdkVersion);
+}
+
+- (void)testSDKVersion_NotSDKRuntimeVersionCases {  
+  NSArray *runtimeVersions = @[
+    @"exposdk:123",
+    @"exposdkd:39.0.0",
+    @"exposdk:hello",
+    @"bexposdk:39.0.0",
+    @"exposdk:39.0.0-beta.0",
+    @"exposdk:39.0.0-alpha.256"
+  ];
+  
+  [runtimeVersions enumerateObjectsUsingBlock:^(NSString *  _Nonnull runtimeVersion, NSUInteger idx, BOOL * _Nonnull stop) {
+    NSDictionary *manifestJson = @{
+      @"runtimeVersion": runtimeVersion
+    };
+    EXUpdatesNewRawManifest *manifest = [[EXUpdatesNewRawManifest alloc] initWithRawManifestJSON:manifestJson];
+    XCTAssert(manifest.sdkVersion == nil, @"%@", manifest.sdkVersion);
+  }];
+}
+
+@end

--- a/packages/expo-updates/ios/Tests/EXUpdatesNewUpdateTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesNewUpdateTests.m
@@ -34,66 +34,68 @@
 - (void)testUpdateWithNewManifest_AllFields
 {
   // production manifests should require the id, createdAt, runtimeVersion, and launchAsset fields
-  NSDictionary *manifest = @{
+  EXUpdatesNewRawManifest *manifest = [[EXUpdatesNewRawManifest alloc] initWithRawManifestJSON:@{
     @"runtimeVersion": @"1",
     @"id": @"0eef8214-4833-4089-9dff-b4138a14f196",
     @"createdAt": @"2020-11-11T00:17:54.797Z",
     @"launchAsset": @{@"url": @"https://url.to/bundle.js", @"contentType": @"application/javascript"}
-  };
+  }];
   XCTAssert([EXUpdatesNewUpdate updateWithNewManifest:manifest response:nil config:_config database:_database] != nil);
 }
 
 - (void)testUpdateWithNewManifest_NoRuntimeVersion
 {
-  NSDictionary *manifest = @{
+  EXUpdatesNewRawManifest *manifest = [[EXUpdatesNewRawManifest alloc] initWithRawManifestJSON:@{
     @"id": @"0eef8214-4833-4089-9dff-b4138a14f196",
     @"createdAt": @"2020-11-11T00:17:54.797Z",
     @"launchAsset": @{@"url": @"https://url.to/bundle.js", @"contentType": @"application/javascript"}
-  };
+  }];
   XCTAssertThrows([EXUpdatesNewUpdate updateWithNewManifest:manifest response:nil config:_config database:_database]);
 }
 
 - (void)testUpdateWithNewManifest_NoId
 {
-  NSDictionary *manifest = @{
+  EXUpdatesNewRawManifest *manifest = [[EXUpdatesNewRawManifest alloc] initWithRawManifestJSON:@{
     @"runtimeVersion": @"1",
     @"createdAt": @"2020-11-11T00:17:54.797Z",
     @"launchAsset": @{@"url": @"https://url.to/bundle.js", @"contentType": @"application/javascript"}
-  };
+  }];
   XCTAssertThrows([EXUpdatesNewUpdate updateWithNewManifest:manifest response:nil config:_config database:_database]);
 }
 
 - (void)testUpdateWithNewManifest_NoCreatedAt
 {
-  NSDictionary *manifest = @{
+  EXUpdatesNewRawManifest *manifest = [[EXUpdatesNewRawManifest alloc] initWithRawManifestJSON:@{
     @"runtimeVersion": @"1",
     @"id": @"0eef8214-4833-4089-9dff-b4138a14f196",
     @"launchAsset": @{@"url": @"https://url.to/bundle.js", @"contentType": @"application/javascript"}
-  };
+  }];
   XCTAssertThrows([EXUpdatesNewUpdate updateWithNewManifest:manifest response:nil config:_config database:_database]);
 }
 
 - (void)testUpdateWithNewManifest_NoLaunchAsset
 {
-  NSDictionary *manifest = @{
+  EXUpdatesNewRawManifest *manifest = [[EXUpdatesNewRawManifest alloc] initWithRawManifestJSON:@{
     @"runtimeVersion": @"1",
     @"id": @"0eef8214-4833-4089-9dff-b4138a14f196",
     @"createdAt": @"2020-11-11T00:17:54.797Z"
-  };
+  }];
   XCTAssertThrows([EXUpdatesNewUpdate updateWithNewManifest:manifest response:nil config:_config database:_database]);
 }
 
 - (void)testUpdateWithNewManifest_StripsOptionalRootLevelKeys
 {
-  NSDictionary *manifestNoRootLevelKeys = @{
+  NSDictionary *rawManifestJSON = @{
     @"runtimeVersion": @"1",
     @"id": @"0eef8214-4833-4089-9dff-b4138a14f196",
     @"createdAt": @"2020-11-11T00:17:54.797Z",
     @"launchAsset": @{@"url": @"https://url.to/bundle.js", @"contentType": @"application/javascript"}
   };
-  NSDictionary *manifestWithRootLevelKeys = @{
-    @"manifest": manifestNoRootLevelKeys
-  };
+  
+  EXUpdatesNewRawManifest *manifestNoRootLevelKeys = [[EXUpdatesNewRawManifest alloc] initWithRawManifestJSON:rawManifestJSON];
+  EXUpdatesNewRawManifest *manifestWithRootLevelKeys = [[EXUpdatesNewRawManifest alloc] initWithRawManifestJSON:@{
+    @"manifest": rawManifestJSON
+  }];
 
   EXUpdatesUpdate *update1 = [EXUpdatesNewUpdate updateWithNewManifest:manifestNoRootLevelKeys response:nil config:_config database:_database];
   EXUpdatesUpdate *update2 = [EXUpdatesNewUpdate updateWithNewManifest:manifestWithRootLevelKeys response:nil config:_config database:_database];

--- a/packages/expo-updates/ios/Tests/EXUpdatesSelectionPolicyFilterAwareTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesSelectionPolicyFilterAwareTests.m
@@ -45,68 +45,68 @@
   NSString *scopeKey = @"dummyScope";
   EXUpdatesConfig *config = [EXUpdatesConfig new];
   EXUpdatesDatabase *database = [EXUpdatesDatabase new];
-  
-  _updateRollout0 = [EXUpdatesNewUpdate updateWithNewManifest:@{
+
+  _updateRollout0 = [EXUpdatesNewUpdate updateWithNewManifest:[[EXUpdatesNewRawManifest alloc] initWithRawManifestJSON:@{
     @"id": @"079cde35-8433-4c17-81c8-7117c1513e71",
     @"createdAt": @"2021-01-10T19:39:22.480Z",
     @"runtimeVersion": @"1.0",
     @"launchAsset": launchAsset,
     @"assets": @[imageAsset],
     @"updateMetadata": @{@"branchName": @"rollout"}
-  } response:nil config:config database:database];
+  }] response:nil config:config database:database];
 
-  _updateDefault1 = [EXUpdatesNewUpdate updateWithNewManifest:@{
+  _updateDefault1 = [EXUpdatesNewUpdate updateWithNewManifest:[[EXUpdatesNewRawManifest alloc] initWithRawManifestJSON:@{
     @"id": @"079cde35-8433-4c17-81c8-7117c1513e72",
     @"createdAt": @"2021-01-11T19:39:22.480Z",
     @"runtimeVersion": @"1.0",
     @"launchAsset": launchAsset,
     @"assets": @[imageAsset],
     @"updateMetadata": @{@"branchName": @"default"}
-  } response:nil config:config database:database];
-  
-  _updateRollout1 = [EXUpdatesNewUpdate updateWithNewManifest:@{
+  }] response:nil config:config database:database];
+
+  _updateRollout1 = [EXUpdatesNewUpdate updateWithNewManifest:[[EXUpdatesNewRawManifest alloc] initWithRawManifestJSON:@{
     @"id": @"079cde35-8433-4c17-81c8-7117c1513e73",
     @"createdAt": @"2021-01-12T19:39:22.480Z",
     @"runtimeVersion": @"1.0",
     @"launchAsset": launchAsset,
     @"assets": @[imageAsset],
     @"updateMetadata": @{@"branchName": @"rollout"}
-  } response:nil config:config database:database];
-  
-  _updateDefault2 = [EXUpdatesNewUpdate updateWithNewManifest:@{
+  }] response:nil config:config database:database];
+
+  _updateDefault2 = [EXUpdatesNewUpdate updateWithNewManifest:[[EXUpdatesNewRawManifest alloc] initWithRawManifestJSON:@{
     @"id": @"079cde35-8433-4c17-81c8-7117c1513e74",
     @"createdAt": @"2021-01-13T19:39:22.480Z",
     @"runtimeVersion": @"1.0",
     @"launchAsset": launchAsset,
     @"assets": @[imageAsset],
     @"updateMetadata": @{@"branchName": @"default"}
-  } response:nil config:config database:database];
-  
-  _updateRollout2 = [EXUpdatesNewUpdate updateWithNewManifest:@{
+  }] response:nil config:config database:database];
+
+  _updateRollout2 = [EXUpdatesNewUpdate updateWithNewManifest:[[EXUpdatesNewRawManifest alloc] initWithRawManifestJSON:@{
     @"id": @"079cde35-8433-4c17-81c8-7117c1513e75",
     @"createdAt": @"2021-01-14T19:39:22.480Z",
     @"runtimeVersion": @"1.0",
     @"launchAsset": launchAsset,
     @"assets": @[imageAsset],
     @"updateMetadata": @{@"branchName": @"rollout"}
-  } response:nil config:config database:database];
+  }] response:nil config:config database:database];
 
-  _updateMultipleFilters = [EXUpdatesNewUpdate updateWithNewManifest:@{
+  _updateMultipleFilters = [EXUpdatesNewUpdate updateWithNewManifest:[[EXUpdatesNewRawManifest alloc] initWithRawManifestJSON:@{
     @"id": @"079cde35-8433-4c17-81c8-7117c1513e72",
     @"createdAt": @"2021-01-11T19:39:22.480Z",
     @"runtimeVersion": @"1.0",
     @"launchAsset": launchAsset,
     @"assets": @[imageAsset],
     @"updateMetadata": @{@"firstKey": @"value1", @"secondKey": @"value2"}
-  } response:nil config:config database:database];
+  }] response:nil config:config database:database];
 
-  _updateNoMetadata = [EXUpdatesNewUpdate updateWithNewManifest:@{
+  _updateNoMetadata = [EXUpdatesNewUpdate updateWithNewManifest:[[EXUpdatesNewRawManifest alloc] initWithRawManifestJSON:@{
     @"id": @"079cde35-8433-4c17-81c8-7117c1513e72",
     @"createdAt": @"2021-01-11T19:39:22.480Z",
     @"runtimeVersion": @"1.0",
     @"launchAsset": launchAsset,
     @"assets": @[imageAsset]
-  } response:nil config:config database:database];
+  }] response:nil config:config database:database];
 
   _selectionPolicy = [EXUpdatesSelectionPolicyFactory filterAwarePolicyWithRuntimeVersion:runtimeVersion];
   _manifestFilters = @{@"branchname": @"rollout"};


### PR DESCRIPTION
# Why

This brings the iOS implementation of Expo Go EAS update manifest loading to the same state as Android, which as I recently found out is still not working (one more tweak needed for runtime version stuff).

This is the iOS equivalent of https://github.com/expo/expo/pull/12506, https://github.com/expo/expo/pull/12509, and https://github.com/expo/expo/pull/12521.

# How

1. Factor out raw manifests into classes that wrap the JSON and expose methods for different features and fields individually. This is so we can tell what things we'll need to add to the new manifest format to bring it up to feature parity with the old manifest format, especially in the context of Expo Go.
2. Use the compiler change from https://github.com/expo/expo/pull/12605 to tell me what needed changing.
3. Temporarily rename `EXUpdatesUpdate.rawManifest` to `rawManifestTemp` and go through callsites one-by-one to ensure all callsites that serialized it now call into `EXUpdatesUpdate.rawManifest.rawManifestJSON` instead.

# Test Plan

- Wait for CI tests (some coverage of expo-updates changes).
- Sanity check by running Expo go and opening an experience.