### PR TITLE
Float dev menu above logbox on iOS

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Float dev menu above RedBox on iOS. ([#12632](https://github.com/expo/expo/pull/12632) by [@EvanBacon](https://github.com/EvanBacon))
+
 ### 🐛 Bug fixes
 
 - Account for rubocop formatting in plugin. ([#12480](https://github.com/expo/expo/pull/12480) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/expo-dev-menu/ios/DevMenuWindow.swift
+++ b/packages/expo-dev-menu/ios/DevMenuWindow.swift
@@ -12,6 +12,7 @@ class DevMenuWindow: UIWindow {
     self.rootViewController = DevMenuViewController(manager: manager)
     self.backgroundColor = UIColor.clear
     self.bounds = UIScreen.main.bounds
+    self.windowLevel = .statusBar
     self.isHidden = true
   }
 


### PR DESCRIPTION
# Why

- Emulate Expo Go

![Simulator Screen Shot - iPhone 11 - 2021-04-21 at 00 15 55](https://user-images.githubusercontent.com/9664363/115505796-dc1cc380-a22e-11eb-8d06-725638dd617b.png)

