### PR TITLE
[gh-actions][docs] add 20 minutes timeout

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -61,7 +61,7 @@ jobs:
             docs-next-${{ hashFiles('docs/yarn.lock') }}-
             docs-next-
       - run: yarn export
-        timeout-minutes: 15
+        timeout-minutes: 20
         env:
           USE_ESBUILD: 1
       - name: lint links


### PR DESCRIPTION
# Why

Now that we use Webpack 5, `next export` can take quite some time to finish:

<img width="1761" alt="Screenshot 2021-04-21 at 08 50 58" src="https://user-images.githubusercontent.com/10477267/115509614-ed8dbc00-a27e-11eb-8173-cb9a48792577.png">

# How 

Added a 20 minutes timeout