### PR TITLE
[docs] eas build: document EAS_BUILD_USERNAME env var

### DIFF
--- a/docs/pages/build-reference/variables.md
+++ b/docs/pages/build-reference/variables.md
@@ -159,3 +159,4 @@ The following environment variables are exposed to each build job:
 - `EAS_BUILD_PROFILE` - the name of the build profile from `eas.json`, e.g. `release`
 - `EAS_BUILD_GIT_COMMIT_HASH` - the hash of the Git commit, e.g. `88f28ab5ea39108ade978de2d0d1adeedf0ece76`
 - `EAS_BUILD_NPM_CACHE_URL` - the URL of the npm cache ([learn more](how-tos.md#using-npm-cache-with-yarn-v1))
+- `EAS_BUILD_USERNAME` - the username of the user initiating the build (it's undefined for bot users)


### PR DESCRIPTION
A new env var has been exposed to EAS Build builds https://linear.app/expo/issue/ENG-912/expose-eas-build-username-as-built-in-environment-variable