### PR TITLE
docs: describe OSTYPE env var

### DIFF
--- a/docs/pages/build-reference/variables.md
+++ b/docs/pages/build-reference/variables.md
@@ -159,3 +159,4 @@ The following environment variables are exposed to each build job:
 - `EAS_BUILD_PROFILE` - the name of the build profile from `eas.json`, e.g. `release`
 - `EAS_BUILD_GIT_COMMIT_HASH` - the hash of the Git commit, e.g. `88f28ab5ea39108ade978de2d0d1adeedf0ece76`
 - `EAS_BUILD_NPM_CACHE_URL` - the URL of the npm cache ([learn more](how-tos.md#using-npm-cache-with-yarn-v1))
+- `OSTYPE` - will be either `ios` or `android`


### PR DESCRIPTION
# Why

Didn't realise there was an `OSTYPE` env var exposed in EAS builds.

# How

N/A

# Test Plan

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [✅] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [✅] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [✅] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).