### PR TITLE
Clarify ability to import other files in app.config.js

### DIFF
--- a/docs/pages/workflow/configuration.md
+++ b/docs/pages/workflow/configuration.md
@@ -30,7 +30,7 @@ Most configuration from `app.json` is accessible at runtime from your JavaScript
 For more customization you can use the JavaScript and TypeScript `app.config.js`, or `app.config.ts`. These configs have the following properties:
 
 - Comments, variables, and single quotes!
-- Importing/requiring other js/json files (other files are not transpiled, and can only use syntax valid in your current node version). 
+- Importing/requiring other JavaScript files. Using import/export syntax in external files is not supported. All imported files must be transpiled to support your current version of Node.js. 
 - TypeScript support with nullish coalescing and optional chaining.
 - Updated whenever Metro bundler reloads.
 - Provide environment information to your app.

--- a/docs/pages/workflow/configuration.md
+++ b/docs/pages/workflow/configuration.md
@@ -30,7 +30,7 @@ Most configuration from `app.json` is accessible at runtime from your JavaScript
 For more customization you can use the JavaScript and TypeScript `app.config.js`, or `app.config.ts`. These configs have the following properties:
 
 - Comments, variables, and single quotes!
-- ES module support (import/export).
+- Importing/requiring other js/json files (other files are not transpiled, and can only use syntax valid in your current node version). 
 - TypeScript support with nullish coalescing and optional chaining.
 - Updated whenever Metro bundler reloads.
 - Provide environment information to your app.


### PR DESCRIPTION
Dynamic app configuration does not support importing/requiring files that use syntax unsupported by node.

# Why

https://github.com/expo/expo-cli/issues/3408

# How

Update docs

# Test Plan

Docs

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).