### PR TITLE
[expoview][android] Fix crash in standalone app while using Reanimated 2

### DIFF
--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/host/exp/exponent/VersionedUtils.java
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/host/exp/exponent/VersionedUtils.java
@@ -3,12 +3,16 @@
 package abi39_0_0.host.exp.exponent;
 
 import android.app.Activity;
+import android.util.Log;
 
 import abi39_0_0.com.facebook.react.ReactInstanceManager;
 import abi39_0_0.com.facebook.react.ReactInstanceManagerBuilder;
+import abi39_0_0.com.facebook.react.bridge.NativeModule;
+import abi39_0_0.com.facebook.react.bridge.ReactApplicationContext;
 import abi39_0_0.com.facebook.react.common.LifecycleState;
 import abi39_0_0.com.facebook.react.shell.MainReactPackage;
 
+import java.lang.reflect.Field;
 import java.util.Collections;
 
 import host.exp.exponent.RNObject;
@@ -22,15 +26,18 @@ public class VersionedUtils {
     ReactInstanceManagerBuilder builder = ReactInstanceManager.builder()
         .setApplication(instanceManagerBuilderProperties.application)
         .setJSIModulesPackage((reactApplicationContext, jsContext) -> {
-          Activity currentActivity = Exponent.getInstance().getCurrentActivity();
-          if (currentActivity instanceof ReactNativeActivity) {
-            ReactNativeActivity reactNativeActivity = (ReactNativeActivity) currentActivity;
-            RNObject devSettings = reactNativeActivity.getDevSupportManager().callRecursive("getDevSettings");
-            boolean isRemoteJSDebugEnabled = devSettings != null && (boolean) devSettings.call("isRemoteJSDebugEnabled");
-            if (!isRemoteJSDebugEnabled) {
-              return new ReanimatedJSIModulePackage().getJSIModules(reactApplicationContext, jsContext);
-            }
+          RNObject devSupportManager = getDevSupportManager(reactApplicationContext);
+          if (devSupportManager == null) {
+            Log.e("Exponent", "Couldn't get the `DevSupportManager`. JSI modules won't be initialized.");
+            return Collections.emptyList();
           }
+
+          RNObject devSettings = devSupportManager.callRecursive("getDevSettings");
+          boolean isRemoteJSDebugEnabled = devSettings != null && (boolean) devSettings.call("isRemoteJSDebugEnabled");
+          if (!isRemoteJSDebugEnabled) {
+            return new ReanimatedJSIModulePackage().getJSIModules(reactApplicationContext, jsContext);
+          }
+
           return Collections.emptyList();
         })
         .addPackage(new MainReactPackage())
@@ -51,4 +58,25 @@ public class VersionedUtils {
     return builder;
   }
 
+  private static RNObject getDevSupportManager(ReactApplicationContext reactApplicationContext) {
+    Activity currentActivity = Exponent.getInstance().getCurrentActivity();
+    if (currentActivity != null) {
+      if (currentActivity instanceof ReactNativeActivity) {
+        ReactNativeActivity reactNativeActivity = (ReactNativeActivity) currentActivity;
+        return reactNativeActivity.getDevSupportManager();
+      } else {
+        return null;
+      }
+    }
+
+    try {
+      NativeModule devSettingsModule = reactApplicationContext.getCatalystInstance().getNativeModule("DevSettings");
+      Field devSupportManagerField = devSettingsModule.getClass().getDeclaredField("mDevSupportManager");
+      devSupportManagerField.setAccessible(true);
+      return RNObject.wrap(devSupportManagerField.get(devSettingsModule));
+    } catch (Throwable e) {
+      e.printStackTrace();
+      return null;
+    }
+  }
 }

--- a/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/host/exp/exponent/VersionedUtils.java
+++ b/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/host/exp/exponent/VersionedUtils.java
@@ -3,12 +3,16 @@
 package abi40_0_0.host.exp.exponent;
 
 import android.app.Activity;
+import android.util.Log;
 
 import abi40_0_0.com.facebook.react.ReactInstanceManager;
 import abi40_0_0.com.facebook.react.ReactInstanceManagerBuilder;
+import abi40_0_0.com.facebook.react.bridge.NativeModule;
+import abi40_0_0.com.facebook.react.bridge.ReactApplicationContext;
 import abi40_0_0.com.facebook.react.common.LifecycleState;
 import abi40_0_0.com.facebook.react.shell.MainReactPackage;
 
+import java.lang.reflect.Field;
 import java.util.Collections;
 
 import host.exp.exponent.RNObject;
@@ -22,15 +26,18 @@ public class VersionedUtils {
     ReactInstanceManagerBuilder builder = ReactInstanceManager.builder()
         .setApplication(instanceManagerBuilderProperties.application)
         .setJSIModulesPackage((reactApplicationContext, jsContext) -> {
-          Activity currentActivity = Exponent.getInstance().getCurrentActivity();
-          if (currentActivity instanceof ReactNativeActivity) {
-            ReactNativeActivity reactNativeActivity = (ReactNativeActivity) currentActivity;
-            RNObject devSettings = reactNativeActivity.getDevSupportManager().callRecursive("getDevSettings");
-            boolean isRemoteJSDebugEnabled = devSettings != null && (boolean) devSettings.call("isRemoteJSDebugEnabled");
-            if (!isRemoteJSDebugEnabled) {
-              return new ReanimatedJSIModulePackage().getJSIModules(reactApplicationContext, jsContext);
-            }
+          RNObject devSupportManager = getDevSupportManager(reactApplicationContext);
+          if (devSupportManager == null) {
+            Log.e("Exponent", "Couldn't get the `DevSupportManager`. JSI modules won't be initialized.");
+            return Collections.emptyList();
           }
+
+          RNObject devSettings = devSupportManager.callRecursive("getDevSettings");
+          boolean isRemoteJSDebugEnabled = devSettings != null && (boolean) devSettings.call("isRemoteJSDebugEnabled");
+          if (!isRemoteJSDebugEnabled) {
+            return new ReanimatedJSIModulePackage().getJSIModules(reactApplicationContext, jsContext);
+          }
+
           return Collections.emptyList();
         })
         .addPackage(new MainReactPackage())
@@ -51,4 +58,25 @@ public class VersionedUtils {
     return builder;
   }
 
+  private static RNObject getDevSupportManager(ReactApplicationContext reactApplicationContext) {
+    Activity currentActivity = Exponent.getInstance().getCurrentActivity();
+    if (currentActivity != null) {
+      if (currentActivity instanceof ReactNativeActivity) {
+        ReactNativeActivity reactNativeActivity = (ReactNativeActivity) currentActivity;
+        return reactNativeActivity.getDevSupportManager();
+      } else {
+        return null;
+      }
+    }
+
+    try {
+      NativeModule devSettingsModule = reactApplicationContext.getCatalystInstance().getNativeModule("DevSettings");
+      Field devSupportManagerField = devSettingsModule.getClass().getDeclaredField("mDevSupportManager");
+      devSupportManagerField.setAccessible(true);
+      return RNObject.wrap(devSupportManagerField.get(devSettingsModule));
+    } catch (Throwable e) {
+      e.printStackTrace();
+      return null;
+    }
+  }
 }


### PR DESCRIPTION
# Why

Closes https://github.com/expo/expo/issues/11672
 
# How

The current activity is null sometimes here:
https://github.com/expo/expo/blob/6bb454d7ce708b85b053fc92a2770d0d0cca85ae/android[…]w/src/main/java/versioned/host/exp/exponent/VersionedUtils.java
That's why we don't init jsi modules - for example, the Reanimated 2.

We can get the `DevSupportManager` from the `DevSettingsModule` if the current activity is null. This should be safe, cause I left the old method of getting the `DevSupportManager`. 

# Test Plan

- run using local shell app ✅
- expo go ✅ (run unversioned and versioned code)
