### PR TITLE
Added dev menu to NCL for testing

### DIFF
--- a/apps/native-component-list/app.config.js
+++ b/apps/native-component-list/app.config.js
@@ -3,12 +3,17 @@ export default ({ config }) => {
   // app.json defines the sdkVersion as UNVERSIONED, we can override it here dynamically if we need to,
   // for example with an environment variable.
   // config.sdkVersion = '41.0.0';
-  config.plugins = [
+  if (!Array.isArray(config.plugins)) {
+    config.plugins = [];
+  }
+
+  config.plugins.push(
+    
     // iOS plugins
     // Add a plugin to modify the AppDelegate.
     './plugins/withNotFoundModule',
     // Add the React DevMenu back to the client.
-    './plugins/withDevMenu',
+    // './plugins/withDevMenu',
     // Add AsyncStorage
     './plugins/withExpoAsyncStorage',
     // Set the minimum version to 11 for Google Sign-In support -- TODO: Maybe this belongs in expo-google-sign-in?
@@ -34,7 +39,7 @@ export default ({ config }) => {
         packagePath: '../../../packages/unimodules-test-core/android',
       },
     ],
-  ];
+  );
 
   // NOTE(brentvatne):
   // This adds an ios.scheme property to manifest, which does not validate
@@ -46,13 +51,6 @@ export default ({ config }) => {
     {
       scheme: 'ncl-payments',
       merchantId: 'merchant.com.example.development',
-    },
-  ]);
-
-  config.plugins.push([
-    'expo-document-picker',
-    {
-      appleTeamId: 'XXXXXX',
     },
   ]);
 

--- a/apps/native-component-list/app.json
+++ b/apps/native-component-list/app.json
@@ -80,6 +80,10 @@
       "assets/**",
       "node_modules/react-navigation/src/**/*.png",
       "node_modules/@expo/vector-icons/fonts/*.ttf"
+    ],
+    "plugins": [
+      "expo-dev-menu",
+      "expo-dev-launcher"
     ]
   }
 }

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -19,6 +19,7 @@
   "expo-yarn-workspaces": {
     "symlinks": [
       "expo-constants",
+      "expo-dev-menu",
       "expo-camera",
       "expo-updates"
     ]
@@ -36,7 +37,8 @@
     },
     "ios": {
       "exclude": [
-        "expo-module-template"
+        "expo-module-template",
+        "expo-dev-menu"
       ],
       "modules_paths": [
         "../../../packages"
@@ -83,6 +85,8 @@
     "expo-constants": "~10.1.3",
     "expo-contacts": "~9.1.2",
     "expo-device": "~3.2.0",
+    "expo-dev-launcher": "~0.3.0",
+    "expo-dev-menu-interface": "~0.2.0",
     "expo-document-picker": "~9.1.2",
     "expo-face-detector": "~10.0.1",
     "expo-facebook": "~11.1.1",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -27,7 +27,8 @@
   "react-native-unimodules": {
     "android": {
       "exclude": [
-        "expo-module-template"
+        "expo-module-template",
+        "expo-dev-menu"
       ],
       "modulesPaths": [
         "../../../../packages"


### PR DESCRIPTION
# Why

- retry of this https://github.com/expo/expo/pull/11874/files
- resolve ENG-936

# Test Plan

- [x] `expo run:ios` in ncl
- [ ] `expo run:android` in ncl (plugin seems broken when interacting with other plugins in Expo)