### PR TITLE
[docs] Add next to cache key

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -56,10 +56,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: docs/.next/cache
-          key: docs-next-${{ hashFiles('docs/yarn.lock') }}
-          restore-keys: |
-            docs-next-${{ hashFiles('docs/yarn.lock') }}-
-            docs-next-
+          key: docs-next-${{ hashFiles('docs/yarn.lock')-next-${{ hashFiles('docs/next.config.js') }}
       - run: yarn export
         timeout-minutes: 20
         env:


### PR DESCRIPTION
# Why

I believe https://github.com/expo/expo/runs/2406564383 is failing because we are using a next cache for webpack 5, this should fix it and unblock me from deploying docs.

I don't think this is a great long term solution but I want to unblock publishing docs.