### PR TITLE
[actions][ios] Always run pod install in iOS test workflow

### DIFF
--- a/.github/workflows/ad-hoc-client-shell-app-ios.yml
+++ b/.github/workflows/ad-hoc-client-shell-app-ios.yml
@@ -45,9 +45,6 @@ jobs:
           key: ${{ runner.os }}-pods-${{ hashFiles('ios/Podfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-pods-
-      - name: 🥥 Install CocoaPods in `ios`
-        run: pod install
-        working-directory: ios
       - name: Build iOS Expo client shell app
         timeout-minutes: 120
         run: fastlane ios create_expo_client_build

--- a/.github/workflows/ad-hoc-client-shell-app-ios.yml
+++ b/.github/workflows/ad-hoc-client-shell-app-ios.yml
@@ -45,6 +45,9 @@ jobs:
           key: ${{ runner.os }}-pods-${{ hashFiles('ios/Podfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-pods-
+      - name: 🥥 Install CocoaPods in `ios`
+        run: pod install
+        working-directory: ios
       - name: Build iOS Expo client shell app
         timeout-minutes: 120
         run: fastlane ios create_expo_client_build

--- a/.github/workflows/client-ios.yml
+++ b/.github/workflows/client-ios.yml
@@ -72,6 +72,9 @@ jobs:
           key: ${{ runner.os }}-pods-${{ hashFiles('ios/Podfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-pods-
+      - name: 🥥 Install CocoaPods in `ios`
+        run: pod install
+        working-directory: ios
       - run: expotools client-build --platform ios
         timeout-minutes: 120
         env:

--- a/.github/workflows/ios-unit-tests.yml
+++ b/.github/workflows/ios-unit-tests.yml
@@ -73,7 +73,6 @@ jobs:
             ${{ runner.os }}-pods-
       - name: 🥥 Install CocoaPods in `ios`
         run: pod install
-        if: steps.pods-cache.outputs.cache-hit != 'true' || hashFiles('ios/Podfile.lock') != hashFiles('ios/Pods/Manifest.lock')
         working-directory: ios
       - name: Run native iOS unit tests
         run: expotools native-unit-tests --platform ios


### PR DESCRIPTION
# Why

The cocoapods GH actions cache does the following: Cache `ios/Pods` directory with the cache key: `${{ runner.os }}-pods-${{ hashFiles('ios/Podfile.lock') }}`

The problem is that the `Podfile.lock` just contains versions of dependencies, so if the underlying code of the dependency changes without changing the version it won't be restored from cache. Normally this would be fine since code isn't supposed to change without a version change, but for our modules workflow it doesn't work since we have a lot of pods that are local, and we don't want to have to bump the version in each commit (I think).

# How

Always run `pod install` so that the resulting Pods project is guaranteed to match the current state of the filesystem.

# Test Plan

Wait for CI, see that it adds an additional ~40 seconds on average, which means that it does use the cache in a smart way it seems even if it is inconsistent.