### PR TITLE
Add _array in type definition

### DIFF
--- a/packages/expo-sqlite/src/SQLite.types.ts
+++ b/packages/expo-sqlite/src/SQLite.types.ts
@@ -73,6 +73,7 @@ export interface SQLResultSet {
 export interface SQLResultSetRowList {
   length: number;
   item(index: number): any;
+  _array: any[];
 }
 
 export declare class SQLError {


### PR DESCRIPTION
# Why

I was expo-sqlite in my project and found that _array type definition was missing. So I added it.

# How

Just added _array: any[] in SQLResultSetRowList in SQLite.types.ts

# Checklist

Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.

- [ x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).