### PR TITLE
[expo-dev-launcher] Use port 8090 for Metro during development

### DIFF
--- a/packages/expo-dev-launcher/package.json
+++ b/packages/expo-dev-launcher/package.json
@@ -13,7 +13,7 @@
     "prepare": "expo-module prepare",
     "prepublishOnly": "expo-module prepublishOnly",
     "expo-module": "expo-module",
-    "start": "npx react-native start",
+    "start": "react-native start --port 8090",
     "bundle": "./write_embedded_bundle.sh"
   },
   "repository": {


### PR DESCRIPTION
# Why

Found it useful to set the bundler for dev launcher to use a different port by default. When developing dev client it's common to have Metro for an app running on port 8081 already, so using a different port makes the ports not clash with each other.