### PR TITLE
[docs] Update eas secret command to singular

### DIFF
--- a/docs/pages/build-reference/variables.md
+++ b/docs/pages/build-reference/variables.md
@@ -103,19 +103,19 @@ A secret needs a name and a value. The name can only contain alphanumeric charac
 
 ### Adding secrets with EAS CLI
 
-To create a new secret, run `eas secrets:create`
+To create a new secret, run `eas secret:create`
 
 ```
-> eas secrets:create project SECRET_NAME secretvalue
+> eas secret:create project SECRET_NAME secretvalue
 ✔ Linked to project @fiberjw/goodweebs
 ✔ You're inside the project directory. Would you like to use fiberjw account? … yes
 ✔ ️Created a new secret SECRET_NAME on project @fiberjw/goodweebs.
 ```
 
-To view any existing secrets for this project, run `eas secrets:list`:
+To view any existing secrets for this project, run `eas secret:list`:
 
 ```
-> eas secrets:list
+> eas secret:list
 ✔ Linked to project @fiberjw/goodweebs
 Secrets for this account and project:
 ┌─────────────────┬─────────┬─────────────────┬──────────────────────────────────────┐


### PR DESCRIPTION
# Why

`eas secret` is now singular - updating docs for that change.

# How

Used edit page link on docs page

# Test

Just removed s - not sure how to verify when using the "edit page" link on docs page

