### PR TITLE
[docs] Add 301 redirects to trailing slash paths

### DIFF
--- a/docs/deploy.sh
+++ b/docs/deploy.sh
@@ -102,5 +102,16 @@ do
     --website-redirect "/${redirects[$i]}" \
     "$target/404.html" \
     "s3://${bucket}/${i}"
+
+  # Also add redirects for paths without `.html` or `/`
+  # S3 translates URLs with trailing slashes to `path/` -> `path/index.html`
+  if [[ $i != *".html" ]] && [[ $i != *"/" ]]; then
+    aws s3 cp \
+      --no-progress
+      --metadata-directive REPLACE \
+      --website-redirect "/${redirects[$i]}" \
+      "$target/404.html" \
+      "s3://${bucket}/${i}/index.html"
+  fi
 done
 echo "::endgroup::"


### PR DESCRIPTION
# Why

@tcdavis and I noticed that the 301 "server" redirects aren't properly redirected when using a trailing slash.

# How

- Added an additional redirect if the path doesn't end with `.html` or `/`

# Test Plan

- Deploy to S3
- Check if with and without the trailing slash is returning the 301 redirect.
