### PR TITLE
[updates] Add exposdk special runtime versions to filter aware selection policy

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.java
+++ b/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.java
@@ -199,6 +199,9 @@ public class ExpoUpdatesAppLoader {
 
     List<String> sdkVersionsList = new ArrayList<>(Constants.SDK_VERSIONS_LIST);
     sdkVersionsList.add(RNObject.UNVERSIONED);
+    for (String sdkVersion : Constants.SDK_VERSIONS_LIST) {
+      sdkVersionsList.add("exposdk:" + sdkVersion);
+    }
     SelectionPolicy selectionPolicy = SelectionPolicyFactory.createFilterAwarePolicy(sdkVersionsList);
 
     File directory;

--- a/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
+++ b/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
@@ -342,6 +342,13 @@ NS_ASSUME_NONNULL_BEGIN
 
   NSMutableArray *sdkVersions = [[EXVersions sharedInstance].versions[@"sdkVersions"] ?: @[[EXVersions sharedInstance].temporarySdkVersion] mutableCopy];
   [sdkVersions addObject:@"UNVERSIONED"];
+
+  NSMutableArray *sdkVersionRuntimeVersions = [[NSMutableArray alloc] initWithCapacity:sdkVersions.count];
+  for (NSString *sdkVersion in sdkVersions) {
+    [sdkVersionRuntimeVersions addObject:[NSString stringWithFormat:@"exposdk:%@", sdkVersion]];
+  }
+  [sdkVersions addObjectsFromArray:sdkVersionRuntimeVersions];
+
   _selectionPolicy = [EXUpdatesSelectionPolicyFactory filterAwarePolicyWithRuntimeVersions:sdkVersions];
 
   EXUpdatesAppLoaderTask *loaderTask = [[EXUpdatesAppLoaderTask alloc] initWithConfig:_config


### PR DESCRIPTION
# Why

FilterAware selection policies use runtime version to check whether the update is launch-able in the current native build.
- For Legacy manifests, the runtime version is set to the SDK version, so the FilterAware selection policy is instantiated with the list of supported SDK versions by the Expo Go client. So legacy updates will match.
- For New EAS manifests in custom client builds, the runtime version is set by the user and hardcoded into the binary config, and then also included in the updates. So new updates match supported binaries built for them.
- For New EAS manifests that adhere to an Expo SDK runtime, the runtime version is set to `exposdk:<sdk version>`, which has special meaning in our system now (https://github.com/expo/eas-cli/pull/336). This PR makes this special version "match" SDK filters by adding those strings to the allowed runtime versions.

# How

Add SDK runtime versions to filter.

# Test Plan

1. Clean install and launch on android emulator, run `adb shell 'am start -d "exps://updates.expo.dev/37700852-0840-47b7-80cb-d57746395f57?runtime-version=exposdk%3A40.0.0&channel-name=main"'`, ensure bundle and assets are downloaded and app is opened.
2. Clean install and launch on ios simulator, run `xcrun simctl openurl booted "exps://updates.expo.dev/37700852-0840-47b7-80cb-d57746395f57?runtime-version=exposdk%3A40.0.0&channel-name=main"`, ensure bundle and assets are downloaded and app is opened.