### PR TITLE
[tools] add clarifying message to checkbox prompt

### DIFF
--- a/tools/src/commands/AndroidBuildPackages.ts
+++ b/tools/src/commands/AndroidBuildPackages.ts
@@ -222,11 +222,11 @@ async function _updateExpoViewAsync(packages: Package[], sdkVersion: string): Pr
 
   // hacky workaround for weird issue where some packages need to be built twice after cleaning
   // in order to have .so libs included in the aar
-  const reactAndroidIndex = packages.findIndex(pkg => pkg.name === REACT_ANDROID_PKG.name);
+  const reactAndroidIndex = packages.findIndex((pkg) => pkg.name === REACT_ANDROID_PKG.name);
   if (reactAndroidIndex > -1) {
     packages.splice(reactAndroidIndex, 0, REACT_ANDROID_PKG);
   }
-  const expoviewIndex = packages.findIndex(pkg => pkg.name === EXPOVIEW_PKG.name);
+  const expoviewIndex = packages.findIndex((pkg) => pkg.name === EXPOVIEW_PKG.name);
   if (expoviewIndex > -1) {
     packages.splice(expoviewIndex, 0, EXPOVIEW_PKG);
   }
@@ -364,7 +364,7 @@ async function action(options: ActionOptions) {
         {
           type: 'checkbox',
           name: 'packagesToBuild',
-          message: 'Choose which packages to build',
+          message: 'Choose which packages to build\n  ● selected ○ unselected\n',
           choices: packages.map((pkg) => pkg.name),
           default: packagesToBuild,
           pageSize: Math.min(packages.length, (process.stdout.rows || 100) - 2),

--- a/tools/src/commands/Vendor.ts
+++ b/tools/src/commands/Vendor.ts
@@ -177,7 +177,7 @@ async function askForConfigurations(): Promise<string[]> {
     {
       type: 'checkbox',
       name: 'configurationNames',
-      message: 'Which configuration would you like to run?',
+      message: 'Which configuration would you like to run?\n  ● selected ○ unselected\n',
       choices: Object.keys(CONFIGURATIONS),
       default: Object.keys(CONFIGURATIONS),
     },

--- a/tools/src/promote-packages/tasks/selectPackagesToPromote.ts
+++ b/tools/src/promote-packages/tasks/selectPackagesToPromote.ts
@@ -55,7 +55,7 @@ async function promptForPackagesToPromoteAsync(parcels: Parcel[]): Promise<strin
     {
       type: 'checkbox',
       name: 'selectedPackageNames',
-      message: 'Which packages do you want to promote?\n',
+      message: 'Which packages do you want to promote?\n  ● selected ○ unselected\n',
       choices: [
         // Choices unchecked by default (these being demoted) should be on top.
         // We could sort them, but JS sorting algorithm is unstable :/


### PR DESCRIPTION
# Why

Can be a bit confusing what is selected and what is not.

<img width="790" alt="Screen Shot 2021-04-22 at 2 00 31 PM" src="https://user-images.githubusercontent.com/1220444/115784543-1d1df080-a373-11eb-951b-7f48d3166237.png">

# How

Added a clarifying message.
