### PR TITLE
docs: specify yarn edit script location

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,7 @@ All Expo SDK packages can be found in the `packages/` directory. These packages 
    - If you are only making JavaScript changes, you can run `test-suite` from the `apps/test-suite` project using `expo start`.
    - To run the full test suite with Puppeteer or Detox, you can run the tests `yarn test:<ios | web>`.
 5. You can edit a package's native code directly from its respective folder in the `packages/` directory or by opening `bare-expo` in a native editor:
-   - `cd apps/bare-expo`
+   - Navigate to the `bare-expo` app directory: `cd apps/bare-expo`
    - Android Studio: `yarn edit:android`
    - Xcode: `yarn edit:ios`
    - Remember to **rebuild** the native project whenever you make a native change

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,6 +65,7 @@ All Expo SDK packages can be found in the `packages/` directory. These packages 
    - If you are only making JavaScript changes, you can run `test-suite` from the `apps/test-suite` project using `expo start`.
    - To run the full test suite with Puppeteer or Detox, you can run the tests `yarn test:<ios | web>`.
 5. You can edit a package's native code directly from its respective folder in the `packages/` directory or by opening `bare-expo` in a native editor:
+   - `cd apps/bare-expo`
    - Android Studio: `yarn edit:android`
    - Xcode: `yarn edit:ios`
    - Remember to **rebuild** the native project whenever you make a native change


### PR DESCRIPTION
# Why

for newcomers, it's unclear where the `yarn edit:android` script should be executed from. The root? The folder of specific package (...)




# Test Plan

tried locally


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).