### PR TITLE
docs: fix setPurchaseListener example

### DIFF
--- a/docs/pages/versions/unversioned/sdk/in-app-purchases.md
+++ b/docs/pages/versions/unversioned/sdk/in-app-purchases.md
@@ -139,10 +139,7 @@ setPurchaseListener(({ responseCode, results, errorCode }) => {
         finishTransactionAsync(purchase, true);
       }
     });
-  }
-
-  // Else find out what went wrong
-  if (responseCode === IAPResponseCode.USER_CANCELED) {
+  } else if (responseCode === IAPResponseCode.USER_CANCELED) {
     console.log('User canceled the transaction');
   } else if (responseCode === IAPResponseCode.DEFERRED) {
     console.log('User does not have permissions to buy but requested parental approval (iOS only)');

--- a/docs/pages/versions/v41.0.0/sdk/in-app-purchases.md
+++ b/docs/pages/versions/v41.0.0/sdk/in-app-purchases.md
@@ -139,10 +139,7 @@ setPurchaseListener(({ responseCode, results, errorCode }) => {
         finishTransactionAsync(purchase, true);
       }
     });
-  }
-
-  // Else find out what went wrong
-  if (responseCode === IAPResponseCode.USER_CANCELED) {
+  } else if (responseCode === IAPResponseCode.USER_CANCELED) {
     console.log('User canceled the transaction');
   } else if (responseCode === IAPResponseCode.DEFERRED) {
     console.log('User does not have permissions to buy but requested parental approval (iOS only)');


### PR DESCRIPTION
# Why

I blindly copied the docs example not noticing it contains an error: when a purchase goes through successfully, it falls into the first if branch, goes through it and then continues down the body of the function into the final `else` branch and prints

```
console.warn(`Something went wrong with the purchase. Received errorCode ${errorCode}`);
```

# Test Plan

not necessary imo

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).