### PR TITLE
 [expo-updates][ios] add DatabaseIntegrityCheck and tests

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Finish conversion to an interface for raw manifests. ([#12509](https://github.com/expo/expo/pull/12509) by [@wschurman](https://github.com/wschurman))
 - Add support for loading new manifests in Expo Go. ([#12521](https://github.com/expo/expo/pull/12521) by [@wschurman](https://github.com/wschurman))
 - Split SelectionPolicy into 3 separate interfaces. (Android: [#12606](https://github.com/expo/expo/pull/12606) and iOS: [#12682](https://github.com/expo/expo/pull/12682) by [@esamelson](https://github.com/esamelson))
-- Add DatabaseIntegrityCheck and tests. (Android: [#12607](https://github.com/expo/expo/pull/12607) by [@esamelson](https://github.com/esamelson))
+- Add DatabaseIntegrityCheck and tests. (Android: [#12607](https://github.com/expo/expo/pull/12607) and iOS: [#12683](https://github.com/expo/expo/pull/12683) by [@esamelson](https://github.com/esamelson))
 - Add onAssetLoaded progress callback to remote loader. (Android: [#12608](https://github.com/expo/expo/pull/12608) and iOS: [#12684](https://github.com/expo/expo/pull/12684) by [@esamelson](https://github.com/esamelson))
 - Add setter and resetter for SelectionPolicy. (Android: [#12609](https://github.com/expo/expo/pull/12609) and iOS: [#12685](https://github.com/expo/expo/pull/12685) by [@esamelson](https://github.com/esamelson))
 - Convert most remaining usages of JSON manifest to RawManifest. ([#12600](https://github.com/expo/expo/pull/12600) by [@wschurman](https://github.com/wschurman))

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAsset.h
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAsset.h
@@ -25,6 +25,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nullable, nonatomic, strong) NSString *contentHash;
 @property (nullable, nonatomic, strong) NSDictionary *headers;
 
+/**
+ * properties determined by updates database
+ */
+@property (nonatomic, assign) NSUInteger assetId;
+
 - (instancetype)initWithKey:(nullable NSString *)key type:(NSString *)type;
 
 @end

--- a/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.h
+++ b/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.h
@@ -28,13 +28,16 @@ typedef NS_ENUM(NSInteger, EXUpdatesDatabaseHashType) {
 - (void)mergeAsset:(EXUpdatesAsset *)asset withExistingEntry:(EXUpdatesAsset *)existingAsset error:(NSError ** _Nullable)error;
 - (void)markUpdateFinished:(EXUpdatesUpdate *)update error:(NSError ** _Nullable)error;
 - (void)setScopeKey:(NSString *)scopeKey onUpdate:(EXUpdatesUpdate *)update error:(NSError ** _Nullable)error;
+- (void)markMissingAssets:(NSArray<EXUpdatesAsset *> *)assets error:(NSError ** _Nullable)error;
 
 - (void)deleteUpdates:(NSArray<EXUpdatesUpdate *> *)updates error:(NSError ** _Nullable)error;
 - (nullable NSArray<EXUpdatesAsset *> *)deleteUnusedAssetsWithError:(NSError ** _Nullable)error;
 
 - (nullable NSArray<EXUpdatesUpdate *> *)allUpdatesWithConfig:(EXUpdatesConfig *)config error:(NSError ** _Nullable)error;
+- (nullable NSArray<EXUpdatesUpdate *> *)allUpdatesWithStatus:(EXUpdatesUpdateStatus)status config:(EXUpdatesConfig *)config error:(NSError ** _Nullable)error;
 - (nullable NSArray<EXUpdatesUpdate *> *)launchableUpdatesWithConfig:(EXUpdatesConfig *)config error:(NSError ** _Nullable)error;
 - (nullable EXUpdatesUpdate *)updateWithId:(NSUUID *)updateId config:(EXUpdatesConfig *)config error:(NSError ** _Nullable)error;
+- (nullable NSArray<EXUpdatesAsset *> *)allAssetsWithError:(NSError ** _Nullable)error;
 - (nullable NSArray<EXUpdatesAsset *> *)assetsWithUpdateId:(NSUUID *)updateId error:(NSError ** _Nullable)error;
 - (nullable EXUpdatesAsset *)assetWithKey:(nullable NSString *)key error:(NSError ** _Nullable)error;
 

--- a/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabaseIntegrityCheck.h
+++ b/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabaseIntegrityCheck.h
@@ -1,0 +1,19 @@
+// Copyright 2021-present 650 Industries. All rights reserved.
+
+#import <EXUpdates/EXUpdatesConfig.h>
+#import <EXUpdates/EXUpdatesDatabase.h>
+#import <EXUpdates/EXUpdatesUpdate.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface EXUpdatesDatabaseIntegrityCheck : NSObject
+
++ (BOOL)runWithDatabase:(EXUpdatesDatabase *)database
+              directory:(NSURL *)directory
+                 config:(EXUpdatesConfig *)config
+         embeddedUpdate:(nullable EXUpdatesUpdate *)embeddedUpdate
+                  error:(NSError ** _Nullable)error;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabaseIntegrityCheck.h
+++ b/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabaseIntegrityCheck.h
@@ -14,6 +14,8 @@ NS_ASSUME_NONNULL_BEGIN
          embeddedUpdate:(nullable EXUpdatesUpdate *)embeddedUpdate
                   error:(NSError ** _Nullable)error;
 
++ (BOOL)asset:(EXUpdatesAsset *)asset existsInDirectory:(NSURL *)directory;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabaseIntegrityCheck.m
+++ b/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabaseIntegrityCheck.m
@@ -1,0 +1,78 @@
+// Copyright 2021-present 650 Industries. All rights reserved.
+
+#import <EXUpdates/EXUpdatesAsset.h>
+#import <EXUpdates/EXUpdatesDatabaseIntegrityCheck.h>
+#import <EXUpdates/EXUpdatesFileDownloader.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@implementation EXUpdatesDatabaseIntegrityCheck
+
++ (BOOL)runWithDatabase:(EXUpdatesDatabase *)database
+              directory:(NSURL *)directory
+                 config:(EXUpdatesConfig *)config
+         embeddedUpdate:(nullable EXUpdatesUpdate *)embeddedUpdate
+                  error:(NSError ** _Nullable)error
+{
+  __block NSError *errorToReturn;
+  dispatch_sync(database.databaseQueue, ^{
+    NSError *err;
+    NSArray<EXUpdatesAsset *> *assets = [database allAssetsWithError:&err];
+    if (err) {
+      errorToReturn = err;
+      return;
+    }
+
+    NSMutableArray<EXUpdatesAsset *> *missingAssets = [NSMutableArray new];
+    dispatch_sync([EXUpdatesFileDownloader assetFilesQueue], ^{
+      for (EXUpdatesAsset *asset in assets) {
+        if (!asset.filename || ![[self class] asset:asset existsInDirectory:directory]) {
+          [missingAssets addObject:asset];
+        }
+      }
+    });
+
+    if (missingAssets.count > 0) {
+      [database markMissingAssets:missingAssets error:&err];
+      if (err) {
+        errorToReturn = err;
+        return;
+      }
+    }
+
+    NSArray<EXUpdatesUpdate *> *updatesWithEmbeddedStatus = [database allUpdatesWithStatus:EXUpdatesUpdateStatusEmbedded config:config error:&err];
+    if (err) {
+      errorToReturn = err;
+      return;
+    }
+
+    NSMutableArray<EXUpdatesUpdate *> *updatesToDelete = [NSMutableArray new];
+    for (EXUpdatesUpdate *update in updatesWithEmbeddedStatus) {
+      if (!embeddedUpdate || ![update.updateId isEqual:embeddedUpdate.updateId]) {
+        [updatesToDelete addObject:update];
+      }
+    }
+
+    if (updatesToDelete.count > 0) {
+      [database deleteUpdates:updatesToDelete error:&err];
+      if (err) {
+        errorToReturn = err;
+        return;
+      }
+    }
+  });
+  if (error && errorToReturn) {
+    *error = errorToReturn;
+    return NO;
+  }
+  return YES;
+}
+
++ (BOOL)asset:(EXUpdatesAsset *)asset existsInDirectory:(NSURL *)directory
+{
+  return NO;
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabaseIntegrityCheck.m
+++ b/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabaseIntegrityCheck.m
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
   NSMutableArray<EXUpdatesAsset *> *missingAssets = [NSMutableArray new];
   dispatch_sync([EXUpdatesFileDownloader assetFilesQueue], ^{
     for (EXUpdatesAsset *asset in assets) {
-      if (!asset.filename || ![[self class] asset:asset existsInDirectory:directory]) {
+      if (![[self class] asset:asset existsInDirectory:directory]) {
         [missingAssets addObject:asset];
       }
     }

--- a/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabaseIntegrityCheck.m
+++ b/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabaseIntegrityCheck.m
@@ -63,7 +63,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (BOOL)asset:(EXUpdatesAsset *)asset existsInDirectory:(NSURL *)directory
 {
-  return NO;
+  NSURL *fileURL = [directory URLByAppendingPathComponent:asset.filename];
+  return [NSFileManager.defaultManager fileExistsAtPath:fileURL.path];
 }
 
 @end

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate.m
@@ -28,6 +28,7 @@ NSString * const EXUpdatesUpdateErrorDomain = @"EXUpdatesUpdate";
     _config = config;
     _database = database;
     _scopeKey = config.scopeKey;
+    _status = EXUpdatesUpdateStatusPending;
     _isDevelopmentMode = NO;
   }
   return self;

--- a/packages/expo-updates/ios/Tests/EXUpdatesDatabaseIntegrityCheckTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesDatabaseIntegrityCheckTests.m
@@ -1,0 +1,160 @@
+//  Copyright (c) 2021 650 Industries, Inc. All rights reserved.
+
+#import <XCTest/XCTest.h>
+
+#import <EXUpdates/EXUpdatesAsset.h>
+#import <EXUpdates/EXUpdatesConfig.h>
+#import <EXUpdates/EXUpdatesDatabase.h>
+#import <EXUpdates/EXUpdatesDatabaseIntegrityCheck.h>
+#import <EXUpdates/EXUpdatesUpdate.h>
+#import <EXUpdates/EXUpdatesUtils.h>
+
+/**
+ * special test implementation of this class that will mock the situation
+ * where asset1 exists on disk but asset2 does not
+ */
+@interface EXUpdatesDatabaseIntegrityCheckMockingAssetExists : EXUpdatesDatabaseIntegrityCheck
+
+@end
+
+@implementation EXUpdatesDatabaseIntegrityCheckMockingAssetExists
+
++ (BOOL)asset:(EXUpdatesAsset *)asset existsInDirectory:(NSURL *)directory
+{
+  return [@"asset1" isEqualToString:asset.key];
+}
+
+@end
+
+@interface EXUpdatesDatabaseIntegrityCheckTests : XCTestCase
+
+@property (nonatomic, strong) EXUpdatesDatabase *db;
+@property (nonatomic, strong) NSURL *testDatabaseDir;
+
+@end
+
+@implementation EXUpdatesDatabaseIntegrityCheckTests
+
+- (void)setUp
+{
+  NSURL *applicationSupportDir = [NSFileManager.defaultManager URLsForDirectory:NSApplicationSupportDirectory inDomains:NSUserDomainMask].lastObject;
+  _testDatabaseDir = [applicationSupportDir URLByAppendingPathComponent:@"EXUpdatesDatabaseTests"];
+  if ([NSFileManager.defaultManager fileExistsAtPath:_testDatabaseDir.path]) {
+    NSError *error;
+    [NSFileManager.defaultManager removeItemAtPath:_testDatabaseDir.path error:&error];
+    XCTAssertNil(error);
+  }
+  NSError *error;
+  [NSFileManager.defaultManager createDirectoryAtPath:_testDatabaseDir.path withIntermediateDirectories:YES attributes:nil error:&error];
+  XCTAssertNil(error);
+
+  _db = [[EXUpdatesDatabase alloc] init];
+  dispatch_sync(_db.databaseQueue, ^{
+    NSError *dbOpenError;
+    [_db openDatabaseInDirectory:_testDatabaseDir withError:&dbOpenError];
+    XCTAssertNil(dbOpenError);
+  });
+}
+
+- (void)tearDown
+{
+  dispatch_sync(_db.databaseQueue, ^{
+    [_db closeDatabase];
+  });
+  NSError *error;
+  [NSFileManager.defaultManager removeItemAtPath:_testDatabaseDir.path error:&error];
+  XCTAssertNil(error);
+}
+
+- (void)testFilterEmbeddedUpdates
+{
+  // We can't run any updates with the status EMBEDDED if they aren't the update that's
+  // currently embedded in the installed app; the integrity check should remove any such updates
+  // from the database entirely.
+
+  NSString *scopeKey = @"testScopeKey";
+  NSString *runtimeVersion = @"1.0";
+  EXUpdatesConfig *config = [EXUpdatesConfig configWithDictionary:@{
+    @"EXUpdatesScopeKey": scopeKey,
+    @"EXUpdatesRuntimeVersion": runtimeVersion
+  }];
+  EXUpdatesUpdate *update1 = [EXUpdatesUpdate updateWithId:NSUUID.UUID scopeKey:scopeKey commitTime:[NSDate dateWithTimeIntervalSince1970:1608667851] runtimeVersion:runtimeVersion metadata:nil status:EXUpdatesUpdateStatusReady keep:YES config:config database:_db];
+  EXUpdatesUpdate *update2 = [EXUpdatesUpdate updateWithId:NSUUID.UUID scopeKey:scopeKey commitTime:[NSDate dateWithTimeIntervalSince1970:1608667852] runtimeVersion:runtimeVersion metadata:nil status:EXUpdatesUpdateStatusReady keep:YES config:config database:_db];
+
+  update1.status = EXUpdatesUpdateStatusEmbedded;
+  update2.status = EXUpdatesUpdateStatusEmbedded;
+
+  dispatch_sync(_db.databaseQueue, ^{
+    NSError *error1;
+    [_db addUpdate:update1 error:&error1];
+    XCTAssertNil(error1);
+    NSError *error2;
+    [_db addUpdate:update2 error:&error2];
+    XCTAssertNil(error2);
+
+    XCTAssertEqual(2, [_db allUpdatesWithConfig:config error:nil].count);
+
+    NSError *error3;
+    [EXUpdatesDatabaseIntegrityCheck runWithDatabase:_db directory:_testDatabaseDir config:config embeddedUpdate:update2 error:&error3];
+    XCTAssertNil(error3);
+
+    NSArray<EXUpdatesUpdate *> *allUpdates = [_db allUpdatesWithConfig:config error:nil];
+    XCTAssertEqual(1, allUpdates.count);
+    XCTAssertEqualObjects(update2.updateId, allUpdates[0].updateId);
+  });
+}
+
+- (void)testMissingAssets
+{
+  EXUpdatesAsset *asset1 = [[EXUpdatesAsset alloc] initWithKey:@"asset1" type:@"png"];
+  asset1.downloadTime = [NSDate date];
+  asset1.contentHash = @"hash1";
+  EXUpdatesAsset *asset2 = [[EXUpdatesAsset alloc] initWithKey:@"asset2" type:@"png"];
+  asset2.downloadTime = [NSDate date];
+  asset2.contentHash = @"hash2";
+
+  NSString *scopeKey = @"testScopeKey";
+  NSString *runtimeVersion = @"1.0";
+  EXUpdatesConfig *config = [EXUpdatesConfig configWithDictionary:@{
+    @"EXUpdatesScopeKey": scopeKey,
+    @"EXUpdatesRuntimeVersion": runtimeVersion
+  }];
+  EXUpdatesUpdate *update1 = [EXUpdatesUpdate updateWithId:NSUUID.UUID scopeKey:scopeKey commitTime:[NSDate dateWithTimeIntervalSince1970:1608667851] runtimeVersion:runtimeVersion metadata:nil status:EXUpdatesUpdateStatusReady keep:YES config:config database:_db];
+  EXUpdatesUpdate *update2 = [EXUpdatesUpdate updateWithId:NSUUID.UUID scopeKey:scopeKey commitTime:[NSDate dateWithTimeIntervalSince1970:1608667852] runtimeVersion:runtimeVersion metadata:nil status:EXUpdatesUpdateStatusReady keep:YES config:config database:_db];
+
+  update1.status = EXUpdatesUpdateStatusReady;
+  update2.status = EXUpdatesUpdateStatusReady;
+
+  dispatch_sync(_db.databaseQueue, ^{
+    NSError *error1;
+    [_db addUpdate:update1 error:&error1];
+    XCTAssertNil(error1);
+    NSError *error2;
+    [_db addUpdate:update2 error:&error2];
+    XCTAssertNil(error2);
+    NSError *error3;
+    [_db addNewAssets:@[asset1] toUpdateWithId:update1.updateId error:&error3];
+    XCTAssertNil(error3);
+    NSError *error4;
+    [_db addNewAssets:@[asset2] toUpdateWithId:update2.updateId error:&error4];
+    XCTAssertNil(error4);
+
+    XCTAssertEqual(2, [_db allUpdatesWithConfig:config error:nil].count);
+    XCTAssertEqual(2, [_db allAssetsWithError:nil].count);
+
+    NSError *error5;
+    [EXUpdatesDatabaseIntegrityCheckMockingAssetExists runWithDatabase:_db directory:_testDatabaseDir config:config embeddedUpdate:nil error:&error5];
+    XCTAssertNil(error5);
+
+    NSArray<EXUpdatesUpdate *> *allUpdates = [_db allUpdatesWithConfig:config error:nil];
+    NSArray<EXUpdatesAsset *> *allAssets = [_db allAssetsWithError:nil];
+    XCTAssertEqual(2, allUpdates.count);
+    XCTAssertEqual(2, allAssets.count);
+
+    NSArray<EXUpdatesUpdate *> *sortedUpdates = [allUpdates sortedArrayUsingDescriptors:@[[NSSortDescriptor sortDescriptorWithKey:@"commitTime" ascending:YES]]];
+    XCTAssertEqual(EXUpdatesUpdateStatusReady, sortedUpdates[0].status);
+    XCTAssertEqual(EXUpdatesUpdateStatusPending, sortedUpdates[1].status);
+  });
+}
+
+@end


### PR DESCRIPTION
# Why

iOS counterpart to #12607 (though this one does have some differences, marked in bold)

PR 2/4 on iOS side of implementing functionality for https://www.notion.so/expo/expo-update-development-clients-spec-0f48db94049a4ea0b605c5dd03fdc295

In the `getDownloadedUpdates()` method the spec describes, we'll need to check that all the updates we return are actually runnable -- meaning we actually have all the assets on disk that we think we have. This PR adds a `DatabaseIntegrityCheck` class that does just that, and which the `getDownloadedUpdates()` method can use.

# How

- check all assets in the database to see if they're on disk in the expected location; for any that aren't, we mark the update as `PENDING` rather than `READY`.
- **unlike on Android, I discovered that we can't easily set the asset's relativePath to NULL in sqlite; the column is marked as NOT NULL, but even if we do a migration, the iOS code around filename is different and assumes the property is never null.** Rather than make some bigger structural changes to make the iOS module behave more like Android, I decided to just ignore this entirely; this is safe to do because every time we check the database to see if an asset already exists, we **also** check to make sure it's on disk (so there isn't anything to be gained by setting the asset's relativePath to NULL).
- also check to make sure we don't have multiple updates marked with the `Embedded` status, and if we do, remove any that aren't the currently embedded update. (The `Embedded` status can happen if any of the assets from an embedded update fail to be copied to the expo-updates cache for some reason, but we still want to be able to run the update.)
- **Also fixed a tiny bug in the Database code (all updates were being inserted with the Pending status, no matter what the value on the object was), and exposed the asset ID on the EXUpdatesAsset object**

# Test Plan

Added some unit tests for this class and they all pass ✅ 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).