### PR TITLE
[expo-updates][ios] add EXUpdatesAppLoaderAssetBlock progress callback

### DIFF
--- a/ios/Exponent/Kernel/Services/EXUpdatesManager.m
+++ b/ios/Exponent/Kernel/Services/EXUpdatesManager.m
@@ -191,6 +191,8 @@ didRequestBundleWithCompletionQueue:(dispatch_queue_t)completionQueue
       startBlock();
     }
     return shouldLoad;
+  } asset:^(EXUpdatesAsset *asset, NSUInteger successfulAssetCount, NSUInteger failedAssetCount, NSUInteger totalAssetCount) {
+    // do nothing for now
   } success:^(EXUpdatesUpdate * _Nullable update) {
     if (update) {
       success(update.rawManifest);

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -10,9 +10,9 @@
 - Start converting untyped manifest JSON objects into well-specified classes. ([#12506](https://github.com/expo/expo/pull/12506) by [@wschurman](https://github.com/wschurman))
 - Finish conversion to an interface for raw manifests. ([#12509](https://github.com/expo/expo/pull/12509) by [@wschurman](https://github.com/wschurman))
 - Add support for loading new manifests in Expo Go. ([#12521](https://github.com/expo/expo/pull/12521) by [@wschurman](https://github.com/wschurman))
-- Split SelectionPolicy into 3 separate interfaces. (Android: [#12606](https://github.com/expo/expo/pull/12606) by [@esamelson](https://github.com/esamelson))
-- Add DatabaseIntegrityCheck and tests. (Android: [#12607](https://github.com/expo/expo/pull/12607) and iOS: [#12682](https://github.com/expo/expo/pull/12682) by [@esamelson](https://github.com/esamelson))
-- Add onAssetLoaded progress callback to remote loader. (Android: [#12608](https://github.com/expo/expo/pull/12608) by [@esamelson](https://github.com/esamelson))
+- Split SelectionPolicy into 3 separate interfaces. (Android: [#12606](https://github.com/expo/expo/pull/12606) and iOS: [#12682](https://github.com/expo/expo/pull/12682) by [@esamelson](https://github.com/esamelson))
+- Add DatabaseIntegrityCheck and tests. (Android: [#12607](https://github.com/expo/expo/pull/12607) by [@esamelson](https://github.com/esamelson))
+- Add onAssetLoaded progress callback to remote loader. (Android: [#12608](https://github.com/expo/expo/pull/12608) and iOS: [#12684](https://github.com/expo/expo/pull/12684) by [@esamelson](https://github.com/esamelson))
 - Add setter and resetter for SelectionPolicy. (Android: [#12609](https://github.com/expo/expo/pull/12609) by [@esamelson](https://github.com/esamelson))
 - Convert most remaining usages of JSON manifest to RawManifest. ([#12600](https://github.com/expo/expo/pull/12600) by [@wschurman](https://github.com/wschurman))
 

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoader+Private.h
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoader+Private.h
@@ -14,6 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong) NSURL *directory;
 @property (nonatomic, strong) EXUpdatesUpdate *updateManifest;
 @property (nonatomic, copy) EXUpdatesAppLoaderManifestBlock manifestBlock;
+@property (nonatomic, copy) EXUpdatesAppLoaderAssetBlock assetBlock;
 @property (nonatomic, copy) EXUpdatesAppLoaderSuccessBlock successBlock;
 @property (nonatomic, copy) EXUpdatesAppLoaderErrorBlock errorBlock;
 

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoader.h
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoader.h
@@ -1,5 +1,6 @@
 //  Copyright © 2019 650 Industries. All rights reserved.
 
+#import <EXUpdates/EXUpdatesAsset.h>
 #import <EXUpdates/EXUpdatesConfig.h>
 #import <EXUpdates/EXUpdatesDatabase.h>
 #import <EXUpdates/EXUpdatesUpdate.h>
@@ -7,6 +8,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 typedef BOOL (^EXUpdatesAppLoaderManifestBlock)(EXUpdatesUpdate *update);
+typedef void (^EXUpdatesAppLoaderAssetBlock) (EXUpdatesAsset *asset, NSUInteger successfulAssetCount, NSUInteger failedAssetCount, NSUInteger totalAssetCount);
 typedef void (^EXUpdatesAppLoaderSuccessBlock)(EXUpdatesUpdate * _Nullable update);
 typedef void (^EXUpdatesAppLoaderErrorBlock)(NSError *error);
 
@@ -24,9 +26,13 @@ typedef void (^EXUpdatesAppLoaderErrorBlock)(NSError *error);
  * The block should determine whether or not the update described by this manifest
  * should be downloaded, based on (for example) whether or not it already has the
  * update downloaded locally, and return the corresponding BOOL value.
+ *
+ * The `asset` block is called when an asset has either been successfully downloaded
+ * or failed to download.
  */
 - (void)loadUpdateFromUrl:(NSURL *)url
                onManifest:(EXUpdatesAppLoaderManifestBlock)manifestBlock
+                    asset:(EXUpdatesAppLoaderAssetBlock)assetBlock
                   success:(EXUpdatesAppLoaderSuccessBlock)success
                     error:(EXUpdatesAppLoaderErrorBlock)error;
 

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoaderTask.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoaderTask.m
@@ -209,6 +209,8 @@ static NSString * const EXUpdatesAppLoaderTaskErrorDomain = @"EXUpdatesAppLoader
           [self->_embeddedAppLoader loadUpdateFromEmbeddedManifestWithCallback:^BOOL(EXUpdatesUpdate * _Nonnull update) {
             // we already checked using selection policy, so we don't need to check again
             return YES;
+          } onAsset:^(EXUpdatesAsset *asset, NSUInteger successfulAssetCount, NSUInteger failedAssetCount, NSUInteger totalAssetCount) {
+            // do nothing for now
           } success:^(EXUpdatesUpdate * _Nullable update) {
             completion();
           } error:^(NSError * _Nonnull error) {
@@ -245,6 +247,8 @@ static NSString * const EXUpdatesAppLoaderTaskErrorDomain = @"EXUpdatesAppLoader
       self->_isUpToDate = YES;
       return NO;
     }
+  } asset:^(EXUpdatesAsset *asset, NSUInteger successfulAssetCount, NSUInteger failedAssetCount, NSUInteger totalAssetCount) {
+    // do nothing for now
   } success:^(EXUpdatesUpdate * _Nullable update) {
     completion(nil, update);
   } error:^(NSError *error) {

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesEmbeddedAppLoader.h
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesEmbeddedAppLoader.h
@@ -17,6 +17,7 @@ extern NSString * const EXUpdatesBareEmbeddedBundleFileType;
                                                 database:(nullable EXUpdatesDatabase *)database;
 
 - (void)loadUpdateFromEmbeddedManifestWithCallback:(EXUpdatesAppLoaderManifestBlock)manifestBlock
+                                           onAsset:(EXUpdatesAppLoaderAssetBlock)assetBlock
                                            success:(EXUpdatesAppLoaderSuccessBlock)success
                                              error:(EXUpdatesAppLoaderErrorBlock)error;
 

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesEmbeddedAppLoader.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesEmbeddedAppLoader.m
@@ -59,6 +59,7 @@ static NSString * const EXUpdatesEmbeddedAppLoaderErrorDomain = @"EXUpdatesEmbed
 }
 
 - (void)loadUpdateFromEmbeddedManifestWithCallback:(EXUpdatesAppLoaderManifestBlock)manifestBlock
+                                           onAsset:(EXUpdatesAppLoaderAssetBlock)assetBlock
                                            success:(EXUpdatesAppLoaderSuccessBlock)success
                                              error:(EXUpdatesAppLoaderErrorBlock)error
 {
@@ -66,6 +67,7 @@ static NSString * const EXUpdatesEmbeddedAppLoaderErrorDomain = @"EXUpdatesEmbed
                                                                       database:self.database];
   if (embeddedManifest) {
     self.manifestBlock = manifestBlock;
+    self.assetBlock = assetBlock;
     self.successBlock = success;
     self.errorBlock = error;
     [self startLoadingFromManifest:embeddedManifest];
@@ -113,6 +115,8 @@ static NSString * const EXUpdatesEmbeddedAppLoaderErrorDomain = @"EXUpdatesEmbed
 }
 
 - (void)loadUpdateFromUrl:(NSURL *)url
+               onManifest:(EXUpdatesAppLoaderManifestBlock)manifestBlock
+                    asset:(EXUpdatesAppLoaderAssetBlock)assetBlock
                   success:(EXUpdatesAppLoaderSuccessBlock)success
                     error:(EXUpdatesAppLoaderErrorBlock)error
 {

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesRemoteAppLoader.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesRemoteAppLoader.m
@@ -33,10 +33,12 @@ static NSString * const EXUpdatesRemoteAppLoaderErrorDomain = @"EXUpdatesRemoteA
 
 - (void)loadUpdateFromUrl:(NSURL *)url
                onManifest:(EXUpdatesAppLoaderManifestBlock)manifestBlock
+                    asset:(EXUpdatesAppLoaderAssetBlock)assetBlock
                   success:(EXUpdatesAppLoaderSuccessBlock)success
                     error:(EXUpdatesAppLoaderErrorBlock)error
 {
   self.manifestBlock = manifestBlock;
+  self.assetBlock = assetBlock;
   self.errorBlock = error;
 
   UM_WEAKIFY(self)

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesModule.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesModule.m
@@ -134,6 +134,8 @@ UM_EXPORT_METHOD_AS(fetchUpdateAsync,
   EXUpdatesRemoteAppLoader *remoteAppLoader = [[EXUpdatesRemoteAppLoader alloc] initWithConfig:_updatesService.config database:_updatesService.database directory:_updatesService.directory completionQueue:self.methodQueue];
   [remoteAppLoader loadUpdateFromUrl:_updatesService.config.updateUrl onManifest:^BOOL(EXUpdatesUpdate * _Nonnull update) {
     return [self->_updatesService.selectionPolicy shouldLoadNewUpdate:update withLaunchedUpdate:self->_updatesService.launchedUpdate filters:update.manifestFilters];
+  } asset:^(EXUpdatesAsset *asset, NSUInteger successfulAssetCount, NSUInteger failedAssetCount, NSUInteger totalAssetCount) {
+    // do nothing for now
   } success:^(EXUpdatesUpdate * _Nullable update) {
     if (update) {
       resolve(@{


### PR DESCRIPTION
# Why

iOS counterpart to #12608 -- everything below is basically just copy-pasted

PR 3/4 on iOS side of implementing functionality for https://www.notion.so/expo/expo-update-development-clients-spec-0f48db94049a4ea0b605c5dd03fdc295

The spec asks for a progress callback when downloading a new update, so this PR adds that functionality to `RemoteLoader`.

# How

- add an `asset` progress callback block to EXUpdatesAppLoader
- call this method each time a new asset is loaded

# Test Plan

Tested manually with breakpoints to ensure the callback is called for all assets

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).