### PR TITLE
[expo-updates][ios] add setter and resetter for SelectionPolicy

### DIFF
--- a/ios/Exponent/Versioned/Core/UniversalModules/EXUpdatesBinding.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXUpdatesBinding.m
@@ -81,6 +81,11 @@ NS_ASSUME_NONNULL_BEGIN
   return [_updatesKernelService requestRelaunchForExperienceId:_experienceId withCompletion:completion];
 }
 
+- (void)resetSelectionPolicy
+{
+  // no-op in managed
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Split SelectionPolicy into 3 separate interfaces. (Android: [#12606](https://github.com/expo/expo/pull/12606) and iOS: [#12682](https://github.com/expo/expo/pull/12682) by [@esamelson](https://github.com/esamelson))
 - Add DatabaseIntegrityCheck and tests. (Android: [#12607](https://github.com/expo/expo/pull/12607) by [@esamelson](https://github.com/esamelson))
 - Add onAssetLoaded progress callback to remote loader. (Android: [#12608](https://github.com/expo/expo/pull/12608) and iOS: [#12684](https://github.com/expo/expo/pull/12684) by [@esamelson](https://github.com/esamelson))
-- Add setter and resetter for SelectionPolicy. (Android: [#12609](https://github.com/expo/expo/pull/12609) by [@esamelson](https://github.com/esamelson))
+- Add setter and resetter for SelectionPolicy. (Android: [#12609](https://github.com/expo/expo/pull/12609) and iOS: [#12685](https://github.com/expo/expo/pull/12685) by [@esamelson](https://github.com/esamelson))
 - Convert most remaining usages of JSON manifest to RawManifest. ([#12600](https://github.com/expo/expo/pull/12600) by [@wschurman](https://github.com/wschurman))
 
 

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesAppController.h
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesAppController.h
@@ -71,6 +71,23 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setConfiguration:(NSDictionary *)configuration;
 
 /**
+ * For external modules that want to modify the selection policy used at runtime.
+ *
+ * This method does not provide any guarantees about how long the provided selection policy will
+ * persist; sometimes expo-updates will reset the selection policy in situations where it makes
+ * sense to have explicit control (e.g. if the developer/user has programmatically fetched an
+ * update, expo-updates will reset the selection policy so the new update is launched on the
+ * next reload).
+ */
+- (void)setNextSelectionPolicy:(EXUpdatesSelectionPolicy *)nextSelectionPolicy;
+
+/**
+ * Similar to the above method, but sets the next selection policy to whatever
+ * EXUpdatesAppController's default selection policy is.
+ */
+- (void)resetSelectionPolicyToDefault;
+
+/**
  Starts the update process to launch a previously-loaded update and (if configured to do so)
  check for a new update from the server. This method should be called as early as possible in
  the application's lifecycle.

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesAppController.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesAppController.m
@@ -56,7 +56,7 @@ static NSString * const EXUpdatesErrorEventName = @"error";
   if (self = [super init]) {
     _config = [self _loadConfigFromExpoPlist];
     _database = [[EXUpdatesDatabase alloc] init];
-    _selectionPolicy = [EXUpdatesSelectionPolicyFactory filterAwarePolicyWithRuntimeVersion:[EXUpdatesUtils getRuntimeVersionWithConfig:_config]];
+    _selectionPolicy = [self _defaultSelectionPolicy];
     _assetFilesQueue = dispatch_queue_create("expo.controller.AssetFilesQueue", DISPATCH_QUEUE_SERIAL);
     _controllerQueue = dispatch_queue_create("expo.controller.ControllerQueue", DISPATCH_QUEUE_SERIAL);
     _isStarted = NO;
@@ -72,7 +72,17 @@ static NSString * const EXUpdatesErrorEventName = @"error";
                                  userInfo:@{}];
   }
   [_config loadConfigFromDictionary:configuration];
-  _selectionPolicy = [EXUpdatesSelectionPolicyFactory filterAwarePolicyWithRuntimeVersion:[EXUpdatesUtils getRuntimeVersionWithConfig:_config]];
+  [self resetSelectionPolicyToDefault];
+}
+
+- (void)setNextSelectionPolicy:(EXUpdatesSelectionPolicy *)nextSelectionPolicy
+{
+  _selectionPolicy = nextSelectionPolicy;
+}
+
+- (void)resetSelectionPolicyToDefault
+{
+  _selectionPolicy = [self _defaultSelectionPolicy];
 }
 
 - (void)start
@@ -253,6 +263,11 @@ static NSString * const EXUpdatesErrorEventName = @"error";
   }
 
   return [EXUpdatesConfig configWithDictionary:[NSDictionary dictionaryWithContentsOfFile:configPath]];
+}
+
+- (EXUpdatesSelectionPolicy *)_defaultSelectionPolicy
+{
+  return [EXUpdatesSelectionPolicyFactory filterAwarePolicyWithRuntimeVersion:[EXUpdatesUtils getRuntimeVersionWithConfig:_config]];
 }
 
 - (void)_runReaper

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesModule.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesModule.m
@@ -138,6 +138,7 @@ UM_EXPORT_METHOD_AS(fetchUpdateAsync,
     // do nothing for now
   } success:^(EXUpdatesUpdate * _Nullable update) {
     if (update) {
+      [self->_updatesService resetSelectionPolicy];
       resolve(@{
         @"isNew": @(YES),
         @"manifest": update.rawManifest

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesService.h
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesService.h
@@ -25,6 +25,7 @@ typedef void (^EXUpdatesAppRelaunchCompletionBlock)(BOOL success);
 @property (nonatomic, readonly, assign) BOOL canRelaunch;
 
 - (void)requestRelaunchWithCompletion:(EXUpdatesAppRelaunchCompletionBlock)completion;
+- (void)resetSelectionPolicy;
 
 @end
 

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesService.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesService.m
@@ -70,6 +70,11 @@ UM_REGISTER_MODULE();
   return [EXUpdatesAppController.sharedInstance requestRelaunchWithCompletion:completion];
 }
 
+- (void)resetSelectionPolicy
+{
+  return [EXUpdatesAppController.sharedInstance resetSelectionPolicyToDefault];
+}
+
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
# Why

iOS counterpart to #12609 -- everything below is basically just copy-pasted

PR 4/4 on iOS side of implementing functionality for https://www.notion.so/expo/expo-update-development-clients-spec-0f48db94049a4ea0b605c5dd03fdc295

In order to implement `setCurrentUpdate` we need to be able to set the current SelectionPolicy at runtime.

# How

I've implemented a setter for this on `UpdatesController`, which is the only relevant place since the dev client interface will only be used in bare builds for now.

I also added a resetter, which sets the SelectionPolicy back to the default one after `fetchUpdateAsync` is called and a new update is downloaded successfully, meaning `reloadAsync` will have the expected effect in this case.

Used the same names and docblocks from the Android PR, as discussed in comments.

# Test Plan

Tested manually as part of the full implementation of the interface, which is added in a later PR.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).