### PR TITLE
[ios] fix versioned updates on master

### DIFF
--- a/ios/versioned-react-native/ABI39_0_0/Expo/EXUpdates/ABI39_0_0EXUpdates/Update/ABI39_0_0EXUpdatesUpdate.m
+++ b/ios/versioned-react-native/ABI39_0_0/Expo/EXUpdates/ABI39_0_0EXUpdates/Update/ABI39_0_0EXUpdatesUpdate.m
@@ -56,15 +56,9 @@ NS_ASSUME_NONNULL_BEGIN
                             config:(ABI39_0_0EXUpdatesConfig *)config
                           database:(ABI39_0_0EXUpdatesDatabase *)database
 {
-  if (config.usesLegacyManifest) {
-    return [ABI39_0_0EXUpdatesLegacyUpdate updateWithLegacyManifest:manifest
-                                                    config:config
-                                                  database:database];
-  } else {
-    return [ABI39_0_0EXUpdatesNewUpdate updateWithNewManifest:manifest
-                                              config:config
-                                            database:database];
-  }
+  return [ABI39_0_0EXUpdatesLegacyUpdate updateWithLegacyManifest:manifest
+                                                  config:config
+                                                database:database];
 }
 
 + (instancetype)updateWithEmbeddedManifest:(NSDictionary *)manifest

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/ABI40_0_0EXUpdatesUpdate.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/ABI40_0_0EXUpdatesUpdate.m
@@ -58,15 +58,9 @@ NS_ASSUME_NONNULL_BEGIN
                             config:(ABI40_0_0EXUpdatesConfig *)config
                           database:(ABI40_0_0EXUpdatesDatabase *)database
 {
-  if (config.usesLegacyManifest) {
-    return [ABI40_0_0EXUpdatesLegacyUpdate updateWithLegacyManifest:manifest
-                                                    config:config
-                                                  database:database];
-  } else {
-    return [ABI40_0_0EXUpdatesNewUpdate updateWithNewManifest:manifest
-                                              config:config
-                                            database:database];
-  }
+  return [ABI40_0_0EXUpdatesLegacyUpdate updateWithLegacyManifest:manifest
+                                                  config:config
+                                                database:database];
 }
 
 + (instancetype)updateWithEmbeddedManifest:(NSDictionary *)manifest

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/AppLoader/ABI41_0_0EXUpdatesFileDownloader.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/AppLoader/ABI41_0_0EXUpdatesFileDownloader.m
@@ -78,10 +78,6 @@ NSTimeInterval const ABI41_0_0EXUpdatesDefaultTimeoutInterval = 60;
 - (NSURLRequest *)createManifestRequestWithURL:(NSURL *)url extraHeaders:(nullable NSDictionary *)extraHeaders
 {
   NSURLRequestCachePolicy cachePolicy = _sessionConfiguration ? _sessionConfiguration.requestCachePolicy : NSURLRequestUseProtocolCachePolicy;
-  if (_config.usesLegacyManifest) {
-    // legacy manifest loads should ignore cache-control headers from the server and always load remotely
-    cachePolicy = NSURLRequestReloadIgnoringLocalCacheData;
-  }
 
   NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url cachePolicy:cachePolicy timeoutInterval:ABI41_0_0EXUpdatesDefaultTimeoutInterval];
   [self _setManifestHTTPHeaderFields:request withExtraHeaders:extraHeaders];

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/ABI41_0_0EXUpdatesUpdate.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/ABI41_0_0EXUpdatesUpdate.m
@@ -59,16 +59,9 @@ NS_ASSUME_NONNULL_BEGIN
                             config:(ABI41_0_0EXUpdatesConfig *)config
                           database:(ABI41_0_0EXUpdatesDatabase *)database
 {
-  if (config.usesLegacyManifest) {
-    return [ABI41_0_0EXUpdatesLegacyUpdate updateWithLegacyManifest:manifest
-                                                    config:config
-                                                  database:database];
-  } else {
-    return [ABI41_0_0EXUpdatesNewUpdate updateWithNewManifest:manifest
-                                            response:response
-                                              config:config
-                                            database:database];
-  }
+  return [ABI41_0_0EXUpdatesLegacyUpdate updateWithLegacyManifest:manifest
+                                                  config:config
+                                                database:database];
 }
 
 + (instancetype)updateWithEmbeddedManifest:(NSDictionary *)manifest


### PR DESCRIPTION
# Why

Noticed while testing #12682 that versioned updates are broken on master, since #12249.

Confusingly, the versioned copies of expo-updates _sometimes_ actually use unversioned copies of _certain_ EXUpdates objects at runtime -- taking advantage of obj-c's weak typing -- so this can happen even when the iOS build seems to compile.

In this case, the versioned modules were receiving unversioned `EXUpdatesConfig` objects, which no longer have the `usesLegacyManifest` selector, resulting in the familiar `unrecognized selector sent to instance` error.

# How

Removed the problematic usages of `usesLegacyManifest` in the versioned module files; I assume that all SDK 39-41 updates that will be loaded in Expo Go will be legacy updates, so there's no need to handle the case where `usesLegacyManifest` is false.

# Test Plan

Tested opening updates, calling `checkForUpdateAsync`, `fetchUpdateAsync` (both with and without a new update available) and `reloadAsync` in each of SDK 39, 40, 41 in Expo Go. Before this change, `check` errored and `fetch` caused a crash; after this change, all work as expected.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).