### PR TITLE
Android performance fix by upgrading MaskedView to v0.2.4

### DIFF
--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -50,7 +50,7 @@
     "@expo/react-native-action-sheet": "^3.8.0",
     "@react-native-async-storage/async-storage": "~1.15.0",
     "@react-native-community/slider": "3.0.3",
-    "@react-native-community/masked-view": "0.1.10",
+    "@react-native-masked-view/masked-view": "0.2.4",
     "@react-native-community/datetimepicker": "3.2.0",
     "@react-native-community/netinfo": "6.0.0",
     "@react-native-community/viewpager": "5.0.11",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -2,7 +2,7 @@
   "@expo/vector-icons": "^12.0.0",
   "@react-native-async-storage/async-storage": "~1.15.0",
   "@react-native-community/datetimepicker": "3.2.0",
-  "@react-native-community/masked-view": "0.1.10",
+  "@react-native-masked-view/masked-view": "0.2.4",
   "@react-native-community/netinfo": "6.0.0",
   "@react-native-community/slider": "3.0.3",
   "@react-native-community/viewpager": "5.0.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4352,10 +4352,10 @@
   dependencies:
     invariant "^2.2.4"
 
-"@react-native-community/masked-view@0.1.10", "@react-native-community/masked-view@^0.1.10":
-  version "0.1.10"
-  resolved "https://registry.yarnpkg.com/@react-native-community/masked-view/-/masked-view-0.1.10.tgz#5dda643e19e587793bc2034dd9bf7398ad43d401"
-  integrity sha512-rk4sWFsmtOw8oyx8SD3KSvawwaK7gRBSEIy2TAwURyGt+3TizssXP1r8nx3zY+R7v2vYYHXZ+k2/GULAT/bcaQ==
+"@react-native-masked-view/masked-view@^0.2.4":
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/@react-native-masked-view/masked-view/-/masked-view-0.2.4.tgz#305a548abd47dee494a38f90016432d3a6e4164c"
+  integrity sha512-2Y9OXWHRutYmdyW+bNMaFTW8uTBpaaK20xdIFoVtqahEOO9++B+ut3CAWKPZcdRtb9ikG0LUKChGqMeocg0PGA==
 
 "@react-native-community/netinfo@6.0.0":
   version "6.0.0"


### PR DESCRIPTION
# Why

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->
Android has been having terrible performance issues with animated MaskedViews. This was caused by hardware acceleration that seemed to be disabled. Enabling this solves the problem.
[Without HW Acceleration](https://www.dropbox.com/s/tp92z4mhwgje2t6/software.webm?dl=0) _sorry performance is so bad it impacted screen recording._
[With HW Acceleration](https://www.dropbox.com/s/7hc0enqmitf0ijh/hardware.webm?dl=0)

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->
Enabled hardware acceleration on Android canvas gives better performance on animated and interactive maskedview's.

# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->
Create a scene with an animated maskedview and see performance on Android pre and post update.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).