### PR TITLE
[dev-launcher] Use "bundler" instead of "server"

### DIFF
--- a/packages/expo-dev-launcher/bundle/screens/LauncherMainScreen.tsx
+++ b/packages/expo-dev-launcher/bundle/screens/LauncherMainScreen.tsx
@@ -270,9 +270,9 @@ class LauncherMainScreen extends React.Component<Props, State> {
           <MainView>
             <MainText style={styles.header}>DEVELOPMENT CLIENT</MainText>
           </MainView>
-          <SectionHeader title="Connected to a development server" />
+          <SectionHeader title="Connected to a development bundler" />
           <MainView style={styles.sectionContainer}>
-            <MainText style={styles.textMarginBottom}>Start a local server with:</MainText>
+            <MainText style={styles.textMarginBottom}>Start a local bundler with:</MainText>
             <SecondaryView style={[styles.codeBox, styles.marginBottom]}>
               <SecondaryText style={styles.codeText}>expo start --dev-client</SecondaryText>
             </SecondaryView>


### PR DESCRIPTION
# Why

Closes ENG-927.

However, this ticket was really solved by `expo-dev-launcher@0.3.0`, but I want to make the UI consistent and use "bundler" instead of "server".

# TODO

- [ ] build js 