### PR TITLE
[docs] dynamic import load analytics

### DIFF
--- a/docs/common/analytics.tsx
+++ b/docs/common/analytics.tsx
@@ -1,3 +1,4 @@
+import Head from 'next/head';
 import React from 'react';
 
 // Initialize the command queue in case analytics.js hasn't loaded yet
@@ -17,4 +18,8 @@ export function getInitGoogleScriptTag({ id }: { id: string }) {
 
 export function getGoogleScriptTag() {
   return <script defer src="https://www.google-analytics.com/analytics.js" />;
+}
+
+export function LoadAnalytics() {
+  return <Head>{getGoogleScriptTag()}</Head>;
 }

--- a/docs/next-env.d.ts
+++ b/docs/next-env.d.ts
@@ -1,2 +1,3 @@
 /// <reference types="next" />
 /// <reference types="next/types/global" />
+/// <reference types="google.analytics" />

--- a/docs/pages/_app.tsx
+++ b/docs/pages/_app.tsx
@@ -1,8 +1,6 @@
-/// <reference types="google.analytics" />
-
 import { ThemeProvider } from '@expo/styleguide';
 import * as Sentry from '@sentry/browser';
-import App from 'next/app';
+import App, { NextWebVitalsMetric } from 'next/app';
 import React from 'react';
 
 import { preprocessSentryError } from '~/common/sentry-utilities';
@@ -17,17 +15,7 @@ Sentry.init({
   beforeSend: preprocessSentryError,
 });
 
-export function reportWebVitals({
-  id,
-  name,
-  label,
-  value,
-}: {
-  id: string;
-  name: string;
-  label: string;
-  value: number;
-}) {
+export function reportWebVitals({ id, name, label, value }: NextWebVitalsMetric) {
   window?.ga?.('send', 'event', {
     eventCategory: label === 'web-vital' ? 'Web Vitals' : 'Next.js custom metric',
     eventAction: name,

--- a/docs/pages/_app.tsx
+++ b/docs/pages/_app.tsx
@@ -28,7 +28,7 @@ export function reportWebVitals({
   label: string;
   value: number;
 }) {
-  window?.ga('send', 'event', {
+  window?.ga?.('send', 'event', {
     eventCategory: label === 'web-vital' ? 'Web Vitals' : 'Next.js custom metric',
     eventAction: name,
     // The `id` value will be unique to the current page load. When sending

--- a/docs/pages/_document.tsx
+++ b/docs/pages/_document.tsx
@@ -2,9 +2,10 @@ import { Global } from '@emotion/core';
 import { BlockingSetInitialColorMode } from '@expo/styleguide';
 import { extractCritical } from 'emotion-server';
 import Document, { Html, Head, Main, NextScript, DocumentContext } from 'next/document';
-import * as React from 'react';
+import dynamic from 'next/dynamic';
+import React from 'react';
 
-import { getInitGoogleScriptTag, getGoogleScriptTag } from '~/common/analytics';
+import { getInitGoogleScriptTag } from '~/common/analytics';
 import { globalExtras } from '~/global-styles/extras';
 import { globalFonts } from '~/global-styles/fonts';
 import { globalNProgress } from '~/global-styles/nprogress';
@@ -12,6 +13,10 @@ import { globalPrism } from '~/global-styles/prism';
 import { globalReset } from '~/global-styles/reset';
 import { globalTables } from '~/global-styles/tables';
 import { globalTippy } from '~/global-styles/tippy';
+
+const DynamicLoadAnalytics = dynamic<any>(() =>
+  import('~/common/analytics').then(mod => mod.LoadAnalytics)
+);
 
 export default class MyDocument extends Document<{ css?: string }> {
   static async getInitialProps(ctx: DocumentContext) {
@@ -56,9 +61,9 @@ export default class MyDocument extends Document<{ css?: string }> {
           />
 
           {getInitGoogleScriptTag({ id: 'UA-107832480-3' })}
-          {getGoogleScriptTag()}
         </Head>
         <body>
+          <DynamicLoadAnalytics />
           <BlockingSetInitialColorMode />
           <Main />
           <NextScript />


### PR DESCRIPTION
# Why

Loading analytics script should not block the main thread and it should be loading only after the browser painted the website.

This is essentially the same goal as https://github.com/expo/expo/pull/12352

# How

Used `next/dynamic` to dynamically import a function that load the Google Analytics script

# Test Plan

Look at the "Network" tab on Chrome DevTools and make sure that `analytics.js` is loading and check if GA events are firing:

<img width="515" alt="Screenshot 2021-04-06 at 10 13 13" src="https://user-images.githubusercontent.com/10477267/113680285-f730f480-96c0-11eb-84dd-482300238caf.png">

We are going to monitor the metrics after launch to make sure everything looks like it should.