### PR TITLE
[dev-menu][ios] Temporarily disable the reload action if LogBox is opened

### DIFF
--- a/packages/expo-dev-menu/ios/Headers/EXDevMenu-Bridging-Header.h
+++ b/packages/expo-dev-menu/ios/Headers/EXDevMenu-Bridging-Header.h
@@ -11,6 +11,8 @@
 #import <React/RCTRootView.h>
 #import <React/RCTBundleURLProvider.h>
 #import <React/RCTBridge+Private.h>
+#import <React/RCTLogBox.h>
+#import <React/RCTRedBox.h>
 
 // Private
 #import "RCTPerfMonitor+Private.h"

--- a/packages/expo-dev-menu/ios/Modules/DevMenuExtensions.swift
+++ b/packages/expo-dev-menu/ios/Modules/DevMenuExtensions.swift
@@ -39,6 +39,7 @@ open class DevMenuExtensions: NSObject, RCTBridgeModule, DevMenuExtensionProtoco
       DevMenuManager.shared.hideMenu();
       self.bridge?.requestReload()
     }
+    reload.isAvailable = { !DevMenuExtensions.checkIfLogBoxIsOpened() }
 
     let inspector = DevMenuExtensions.elementInspectorAction {
       devSettings.toggleElementInspector()
@@ -146,7 +147,7 @@ open class DevMenuExtensions: NSObject, RCTBridgeModule, DevMenuExtensionProtoco
 
   // MARK: static helpers
 
-  public static func reloadAction(action: @escaping () -> ()) -> DevMenuAction {
+  private static func reloadAction(action: @escaping () -> ()) -> DevMenuAction {
     let reload = DevMenuAction(withId: "reload", action: action)
     reload.label = { "Reload" }
     reload.glyphName = { "reload" }
@@ -155,7 +156,7 @@ open class DevMenuExtensions: NSObject, RCTBridgeModule, DevMenuExtensionProtoco
     return reload
   }
 
-  public static func elementInspectorAction(_ action: @escaping () -> ()) -> DevMenuAction {
+  private static func elementInspectorAction(_ action: @escaping () -> ()) -> DevMenuAction {
     let inspector = DevMenuAction(withId: "inspector", action: action)
     inspector.label = { inspector.isEnabled() ? "Hide Element Inspector" : "Show Element Inspector" }
     inspector.glyphName = { "border-style" }
@@ -164,7 +165,7 @@ open class DevMenuExtensions: NSObject, RCTBridgeModule, DevMenuExtensionProtoco
     return inspector
   }
 
-  public static func remoteDebugAction(_ action: @escaping () -> ()) -> DevMenuAction {
+  private static func remoteDebugAction(_ action: @escaping () -> ()) -> DevMenuAction {
     let remoteDebug = DevMenuAction(withId: "remote-debug", action: action)
     remoteDebug.label = { remoteDebug.isAvailable() ? remoteDebug.isEnabled() ? "Stop Remote Debugging" : "Debug Remote JS" : "Remote Debugger Unavailable" }
     remoteDebug.glyphName = { "remote-desktop" }
@@ -172,7 +173,7 @@ open class DevMenuExtensions: NSObject, RCTBridgeModule, DevMenuExtensionProtoco
     return remoteDebug
   }
 
-  public static func fastRefreshAction(_ action: @escaping () -> ()) -> DevMenuAction {
+  private static func fastRefreshAction(_ action: @escaping () -> ()) -> DevMenuAction {
     let fastRefresh = DevMenuAction(withId: "fast-refresh", action: action)
     fastRefresh.label = { fastRefresh.isAvailable() ? fastRefresh.isEnabled() ? "Disable Fast Refresh" : "Enable Fast Refresh" : "Fast Refresh Unavailable" }
     fastRefresh.glyphName = { "run-fast" }
@@ -180,12 +181,23 @@ open class DevMenuExtensions: NSObject, RCTBridgeModule, DevMenuExtensionProtoco
     return fastRefresh
   }
 
-  public static func performanceMonitorAction(_ action: @escaping () -> ()) -> DevMenuAction {
+  private static func performanceMonitorAction(_ action: @escaping () -> ()) -> DevMenuAction {
     let perfMonitor = DevMenuAction(withId: "performance-monitor", action: action)
     perfMonitor.label = { perfMonitor.isAvailable() ? perfMonitor.isEnabled() ? "Hide Performance Monitor" : "Show Performance Monitor" : "Performance Monitor Unavailable" }
     perfMonitor.glyphName = { "speedometer" }
     perfMonitor.importance = DevMenuScreenItem.ImportanceHigh
     perfMonitor.registerKeyCommand(input: "p", modifiers: .command)
     return perfMonitor
+  }
+  
+  private static func checkIfLogBoxIsOpened() -> Bool {
+    return UIApplication.shared.windows.contains {
+      let className = String(describing: type(of: $0))
+      if className == "RCTLogBoxView" || className == "RCTRedBoxView" {
+        return true
+      }
+  
+      return false
+    }
   }
 }


### PR DESCRIPTION
# Why

Temporarily disable the reload action if LogBox is opened. Otherwise, reloading, in that case, will causes crashes. 
Connected with https://exponent-internal.slack.com/archives/C011V63429H/p1619107418099200.

# Test Plan

- bare-expo ✅