### PR TITLE
[dev-menu] Created versioned plugins

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 🎉 New features
 
+- [plugin] Prevent plugin from running multiple times in a single process. ([#12715](https://github.com/expo/expo/pull/12715) by [@EvanBacon](https://github.com/EvanBacon))
 - [plugin] Added AppDelegate tests. ([#12651](https://github.com/expo/expo/pull/12651) by [@EvanBacon](https://github.com/EvanBacon))
 - Added the ability to open managed apps inside the dev-launcher. ([#12698](https://github.com/expo/expo/pull/12698) by [@lukmccall](https://github.com/lukmccall))
 

--- a/packages/expo-dev-launcher/plugin/build/withDevLauncher.d.ts
+++ b/packages/expo-dev-launcher/plugin/build/withDevLauncher.d.ts
@@ -1,3 +1,3 @@
-import { ExpoConfig } from '@expo/config-types';
-declare const withDevLauncher: (config: ExpoConfig) => ExpoConfig;
-export default withDevLauncher;
+import { ConfigPlugin } from '@expo/config-plugins';
+declare const _default: ConfigPlugin<unknown>;
+export default _default;

--- a/packages/expo-dev-launcher/plugin/build/withDevLauncher.js
+++ b/packages/expo-dev-launcher/plugin/build/withDevLauncher.js
@@ -7,6 +7,7 @@ const config_plugins_1 = require("@expo/config-plugins");
 const fs_1 = __importDefault(require("fs"));
 const path_1 = __importDefault(require("path"));
 const withDevLauncherAppDelegate_1 = require("./withDevLauncherAppDelegate");
+const pkg = require('expo-dev-launcher/package.json');
 const DEV_LAUNCHER_ANDROID_IMPORT = 'expo.modules.devlauncher.DevLauncherController';
 const DEV_LAUNCHER_ON_NEW_INTENT = `
   @Override
@@ -132,4 +133,4 @@ const withDevLauncher = (config) => {
     config = withDevLauncherAppDelegate_1.withDevLauncherAppDelegate(config);
     return config;
 };
-exports.default = withDevLauncher;
+exports.default = config_plugins_1.createRunOncePlugin(withDevLauncher, pkg.name, pkg.version);

--- a/packages/expo-dev-launcher/plugin/src/withDevLauncher.ts
+++ b/packages/expo-dev-launcher/plugin/src/withDevLauncher.ts
@@ -1,15 +1,18 @@
 import {
   ConfigPlugin,
+  createRunOncePlugin,
+  ExportedConfigWithProps,
+  WarningAggregator,
   withDangerousMod,
   withMainActivity,
-  WarningAggregator,
-  ExportedConfigWithProps,
 } from '@expo/config-plugins';
 import { ExpoConfig } from '@expo/config-types';
 import fs from 'fs';
 import path from 'path';
 
 import { withDevLauncherAppDelegate } from './withDevLauncherAppDelegate';
+
+const pkg = require('expo-dev-launcher/package.json');
 
 const DEV_LAUNCHER_ANDROID_IMPORT = 'expo.modules.devlauncher.DevLauncherController';
 const DEV_LAUNCHER_ON_NEW_INTENT = `
@@ -183,4 +186,4 @@ const withDevLauncher = (config: ExpoConfig) => {
   return config;
 };
 
-export default withDevLauncher;
+export default createRunOncePlugin(withDevLauncher, pkg.name, pkg.version);

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 🎉 New features
 
+- [plugin] Prevent plugin from running multiple times in a single process. ([#12715](https://github.com/expo/expo/pull/12715) by [@EvanBacon](https://github.com/EvanBacon))
 - [plugin] Added AppDelegate tests. ([#12651](https://github.com/expo/expo/pull/12651) by [@EvanBacon](https://github.com/EvanBacon))
 - Float dev menu above RedBox on iOS. ([#12632](https://github.com/expo/expo/pull/12632) by [@EvanBacon](https://github.com/EvanBacon))
 

--- a/packages/expo-dev-menu/plugin/build/withDevMenu.d.ts
+++ b/packages/expo-dev-menu/plugin/build/withDevMenu.d.ts
@@ -1,3 +1,3 @@
-import { ExpoConfig } from '@expo/config-types';
-declare const withDevMenu: (config: ExpoConfig) => ExpoConfig;
-export default withDevMenu;
+import { ConfigPlugin } from '@expo/config-plugins';
+declare const _default: ConfigPlugin<unknown>;
+export default _default;

--- a/packages/expo-dev-menu/plugin/build/withDevMenu.js
+++ b/packages/expo-dev-menu/plugin/build/withDevMenu.js
@@ -7,6 +7,7 @@ const config_plugins_1 = require("@expo/config-plugins");
 const fs_1 = __importDefault(require("fs"));
 const path_1 = __importDefault(require("path"));
 const withDevMenuAppDelegate_1 = require("./withDevMenuAppDelegate");
+const pkg = require('expo-dev-menu/package.json');
 const DEV_MENU_ANDROID_IMPORT = 'expo.modules.devmenu.react.DevMenuAwareReactActivity';
 const DEV_MENU_ACTIVITY_CLASS = 'public class MainActivity extends DevMenuAwareReactActivity {';
 const DEV_MENU_POD_IMPORT = "pod 'expo-dev-menu', path: '../node_modules/expo-dev-menu', :configurations => :debug";
@@ -86,4 +87,4 @@ const withDevMenu = (config) => {
     config = withDevMenuAppDelegate_1.withDevMenuAppDelegate(config);
     return config;
 };
-exports.default = withDevMenu;
+exports.default = config_plugins_1.createRunOncePlugin(withDevMenu, pkg.name, pkg.version);

--- a/packages/expo-dev-menu/plugin/src/withDevMenu.ts
+++ b/packages/expo-dev-menu/plugin/src/withDevMenu.ts
@@ -1,5 +1,6 @@
 import {
   ConfigPlugin,
+  createRunOncePlugin,
   ExportedConfigWithProps,
   WarningAggregator,
   withDangerousMod,
@@ -10,6 +11,8 @@ import fs from 'fs';
 import path from 'path';
 
 import { withDevMenuAppDelegate } from './withDevMenuAppDelegate';
+
+const pkg = require('expo-dev-menu/package.json');
 
 const DEV_MENU_ANDROID_IMPORT = 'expo.modules.devmenu.react.DevMenuAwareReactActivity';
 const DEV_MENU_ACTIVITY_CLASS = 'public class MainActivity extends DevMenuAwareReactActivity {';
@@ -114,4 +117,4 @@ const withDevMenu = (config: ExpoConfig) => {
   return config;
 };
 
-export default withDevMenu;
+export default createRunOncePlugin(withDevMenu, pkg.name, pkg.version);


### PR DESCRIPTION
# Why

This will prevent the plugins from being run more than once per prebuild. When we add an auto plugin, this could become a problem, so doing this now to account for that.

