### PR TITLE
[expo-calendar][android] Fixed calendar crashes with java.lang.NumberFormatException

### DIFF
--- a/packages/expo-calendar/CHANGELOG.md
+++ b/packages/expo-calendar/CHANGELOG.md
@@ -7,7 +7,8 @@
 ### 🎉 New features
 
 ### 🐛 Bug fixes
-- Fix `ExpoCalendar.getCalendarsAsync()` crash on Android when device has unsupported calendars. ([#12724](https://github.com/expo/expo/pull/12724) by [@ibraude](https://github.com/ibraude))
+
+- Fixed `ExpoCalendar.getCalendarsAsync()` crashing on Android when device has unsupported calendars. ([#12724](https://github.com/expo/expo/pull/12724) by [@ibraude](https://github.com/ibraude))
 
 ## 9.1.2 — 2021-04-13
 

--- a/packages/expo-calendar/CHANGELOG.md
+++ b/packages/expo-calendar/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 ### 🐛 Bug fixes
+- Fix `ExpoCalendar.getCalendarsAsync()` crash on Android when device has unsupported calendars. ([#12724](https://github.com/expo/expo/pull/12724) by [@ibraude](https://github.com/ibraude))
 
 ## 9.1.2 — 2021-04-13
 

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/CalendarModule.java
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/CalendarModule.java
@@ -929,7 +929,9 @@ public class CalendarModule extends ExportedModule implements RegistryLifecycleL
   private ArrayList<String> calendarAllowedRemindersFromDBString(String dbString) {
     ArrayList<String> array = new ArrayList<>();
     for (String constant : dbString.split(",")) {
+      if(!constant.isEmpty() && constant.matches("-?\\d+")){
       array.add(reminderStringMatchingConstant(Integer.parseInt(constant)));
+      }
     }
     return array;
   }
@@ -1118,7 +1120,9 @@ public class CalendarModule extends ExportedModule implements RegistryLifecycleL
   private ArrayList<String> calendarAllowedAttendeeTypesFromDBString(String dbString) {
     ArrayList<String> array = new ArrayList<>();
     for (String constant : dbString.split(",")) {
+      if(!constant.isEmpty() && constant.matches("-?\\d+")){
       array.add(attendeeTypeStringMatchingConstant(Integer.parseInt(constant)));
+      }
     }
     return array;
   }

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/CalendarModule.java
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/CalendarModule.java
@@ -1125,7 +1125,7 @@ public class CalendarModule extends ExportedModule implements RegistryLifecycleL
       try{
         array.add(attendeeTypeStringMatchingConstant(Integer.parseInt(constant)));
       } catch (NumberFormatException e) {
-          Log.e(TAG, "error", e);
+          Log.e(TAG, "Couldn't convert attendee constant into an int.", e);
       }
     }
     return array;

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/CalendarModule.java
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/CalendarModule.java
@@ -932,7 +932,7 @@ public class CalendarModule extends ExportedModule implements RegistryLifecycleL
       try{
       	array.add(reminderStringMatchingConstant(Integer.parseInt(constant)));
       } catch (NumberFormatException e) {
-          Log.e(TAG, "error", e);
+          Log.e(TAG, "Couldn't convert reminder constant into an int.", e);
       }
     }
     return array;

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/CalendarModule.java
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/CalendarModule.java
@@ -930,7 +930,7 @@ public class CalendarModule extends ExportedModule implements RegistryLifecycleL
     ArrayList<String> array = new ArrayList<>();
     for (String constant : dbString.split(",")) {
       try{
-      array.add(reminderStringMatchingConstant(Integer.parseInt(constant)));
+      	array.add(reminderStringMatchingConstant(Integer.parseInt(constant)));
       } catch (NumberFormatException e) {
           Log.e(TAG, "error", e);
       }

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/CalendarModule.java
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/CalendarModule.java
@@ -1123,7 +1123,7 @@ public class CalendarModule extends ExportedModule implements RegistryLifecycleL
     ArrayList<String> array = new ArrayList<>();
     for (String constant : dbString.split(",")) {
       try{
-      array.add(attendeeTypeStringMatchingConstant(Integer.parseInt(constant)));
+        array.add(attendeeTypeStringMatchingConstant(Integer.parseInt(constant)));
       } catch (NumberFormatException e) {
           Log.e(TAG, "error", e);
       }

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/CalendarModule.java
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/CalendarModule.java
@@ -929,8 +929,10 @@ public class CalendarModule extends ExportedModule implements RegistryLifecycleL
   private ArrayList<String> calendarAllowedRemindersFromDBString(String dbString) {
     ArrayList<String> array = new ArrayList<>();
     for (String constant : dbString.split(",")) {
-      if(!constant.isEmpty() && constant.matches("-?\\d+")){
+      try{
       array.add(reminderStringMatchingConstant(Integer.parseInt(constant)));
+      } catch (NumberFormatException e) {
+          Log.e(TAG, "error", e);
       }
     }
     return array;
@@ -1120,8 +1122,10 @@ public class CalendarModule extends ExportedModule implements RegistryLifecycleL
   private ArrayList<String> calendarAllowedAttendeeTypesFromDBString(String dbString) {
     ArrayList<String> array = new ArrayList<>();
     for (String constant : dbString.split(",")) {
-      if(!constant.isEmpty() && constant.matches("-?\\d+")){
+      try{
       array.add(attendeeTypeStringMatchingConstant(Integer.parseInt(constant)));
+      } catch (NumberFormatException e) {
+          Log.e(TAG, "error", e);
       }
     }
     return array;


### PR DESCRIPTION
# Why

On android, Expo Calendar throws a fatal error if the device used has another app installed for calendar management such as the one mentioned in issue #1853, or in my case "Nine - Email & Calendar" if it is used to sync certain calendars (e.g outlook). 
The error thrown is: `Fatal Exception: java.lang.NumberFormatException: For input string: ""`

Steps to reproduce error: 
1. Install an app that uses Expo Calendar and retrieves the calendars on the device, for example by calling `ExpoCalendar.getCalendarsAsync()`
2. Verify calendars are fetched an app does not crash
3. Create an Outlook account
4. Install "Nine - Email & Calendar" App and sync the calendar with the new Outlook account
5. Open the app that uses Expo Calendar

Result: App will crash


# How

To avoid this fatal error  I added a check to make sure the string is a parsable integer.

# Test Plan

1. Install an app that uses Expo Calendar and retrieves the calendars on the device, for example by calling `ExpoCalendar.getCalendarsAsync()`
2. Verify calendars are fetched an app does not crash
3. Create an Outlook account
4. Install "Nine - Email & Calendar" App and sync the calendar with the new Outlook account
5. Open the app that uses Expo Calendar

Result: App will not crash this time

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).