### PR TITLE
[android] Update google-services to 4.3.5

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,7 +21,7 @@ buildscript {
   }
   dependencies {
     classpath "com.android.tools.build:gradle:${gradlePluginVersion}"
-    classpath 'com.google.gms:google-services:3.2.1'
+    classpath 'com.google.gms:google-services:4.3.5'
     classpath "de.undercouch:gradle-download-task:$gradleDownloadTaskVersion"
 
     // https://github.com/awslabs/aws-device-farm-gradle-plugin/releases

--- a/apps/bare-expo/android/build.gradle
+++ b/apps/bare-expo/android/build.gradle
@@ -24,7 +24,7 @@ buildscript {
         // Newer versions suffer either from "play-services-basement was supposed to be 15.0.1,
         // but has been resolved to 17.0.0"
         // or https://github.com/segment-integrations/analytics-android-integration-firebase/issues/23
-        classpath 'com.google.gms:google-services:3.2.1'  // Google Services plugin
+        classpath 'com.google.gms:google-services:4.3.5'  // Google Services plugin
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/docs/pages/guides/setup-native-firebase.md
+++ b/docs/pages/guides/setup-native-firebase.md
@@ -92,7 +92,7 @@ You are free to use any native Firebase packages such as [react-native-firebase]
   ```groovy
   buildscript {
       dependencies {
-          classpath 'com.google.gms:google-services:4.2.0'
+          classpath 'com.google.gms:google-services:4.3.5'
       }
   }
   ```


### PR DESCRIPTION
# Why

Gets rid of this cryptic warnings:
```
Could not find google-services.json while looking in [src/nullnull/debug, src/debug/nullnull, src/nullnull, src/debug, src/nullnullDebug]
```
Fixes ENG-898

# How

Updated `google-services` dependency to `4.3.5` (issue causing this warning was fixed in `4.0.2`)

# Test Plan

Expo Go compiles, Firebase captcha example works fine, sending push notifications works

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).