### PR TITLE
[dev-launcher][android] Fix deep linking on first open doesn't redirect to the app

### DIFF
--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
@@ -23,8 +23,8 @@ import expo.modules.devlauncher.launcher.DevLauncherReactActivityDelegateSupplie
 import expo.modules.devlauncher.launcher.DevLauncherRecentlyOpenedAppsRegistry
 import expo.modules.devlauncher.launcher.loaders.DevLauncherExpoAppLoader
 import expo.modules.devlauncher.launcher.loaders.DevLauncherReactNativeAppLoader
-import expo.modules.devlauncher.launcher.manifest.DevLauncherManifestParser
 import expo.modules.devlauncher.launcher.manifest.DevLauncherManifest
+import expo.modules.devlauncher.launcher.manifest.DevLauncherManifestParser
 import expo.modules.devlauncher.launcher.menu.DevLauncherMenuDelegate
 import expo.modules.devlauncher.react.activitydelegates.DevLauncherReactActivityNOPDelegate
 import expo.modules.devlauncher.react.activitydelegates.DevLauncherReactActivityRedirectDelegate
@@ -36,8 +36,9 @@ import okhttp3.OkHttpClient
 //  private final String DEV_LAUNCHER_HOST = "10.0.0.175:8090";
 private val DEV_LAUNCHER_HOST: String? = null
 
-private const val NEW_ACTIVITY_FLAGS =
-  Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NO_ANIMATION
+private const val NEW_ACTIVITY_FLAGS = Intent.FLAG_ACTIVITY_NEW_TASK or
+  Intent.FLAG_ACTIVITY_CLEAR_TASK or
+  Intent.FLAG_ACTIVITY_NO_ANIMATION
 
 private var MenuDelegateWasInitialized = false
 
@@ -53,7 +54,7 @@ class DevLauncherController private constructor(
     private set
   val pendingIntentRegistry = DevLauncherIntentRegistry()
 
-  internal  enum class Mode {
+  internal enum class Mode {
     LAUNCHER, APP
   }
 

--- a/packages/expo-dev-launcher/android/src/main/AndroidManifest.xml
+++ b/packages/expo-dev-launcher/android/src/main/AndroidManifest.xml
@@ -5,7 +5,8 @@
     <activity
       android:name="expo.modules.devlauncher.launcher.DevLauncherActivity"
       android:screenOrientation="portrait"
-      android:theme="@style/Theme.DevelopmentClient" />
+      android:theme="@style/Theme.DevelopmentClient"
+      android:launchMode="singleTask" />
   </application>
 
   <queries>

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/DevLauncherActivity.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/DevLauncherActivity.kt
@@ -2,18 +2,30 @@ package expo.modules.devlauncher.launcher
 
 import android.os.Build
 import android.os.Bundle
+import android.os.Handler
 import android.view.KeyEvent
 import android.view.MotionEvent
+import android.view.View
+import android.view.ViewGroup
 import com.facebook.react.ReactActivity
 import com.facebook.react.ReactActivityDelegate
 import com.facebook.react.ReactInstanceManager
+import com.facebook.react.ReactRootView
 import com.facebook.react.bridge.ReactContext
 import expo.interfaces.devmenu.DevMenuManagerInterface
 import expo.interfaces.devmenu.DevMenuManagerProviderInterface
 import expo.modules.devlauncher.DevLauncherController
+import expo.modules.devlauncher.splashscreen.DevLauncherSplashScreen
+import expo.modules.devlauncher.splashscreen.DevLauncherSplashScreenProvider
+
+const val SEARCH_FOR_ROOT_VIEW_INTERVAL = 20L
 
 class DevLauncherActivity : ReactActivity(), ReactInstanceManager.ReactInstanceEventListener {
   private var devMenuManager: DevMenuManagerInterface? = null
+  private var splashScreen: DevLauncherSplashScreen? = null
+  private var rootView: ViewGroup? = null
+  private lateinit var contentView: ViewGroup
+  private val handler = Handler()
 
   override fun getMainComponentName() = "main"
 
@@ -31,6 +43,15 @@ class DevLauncherActivity : ReactActivity(), ReactInstanceManager.ReactInstanceE
   override fun onStart() {
     overridePendingTransition(0, 0)
     super.onStart()
+  }
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+
+    contentView = findViewById(android.R.id.content) ?: return
+    splashScreen = DevLauncherSplashScreenProvider()
+      .attachSplashScreenViewAsync(this)
+    searchForRootView()
   }
 
   override fun onPostCreate(savedInstanceState: Bundle?) {
@@ -78,4 +99,51 @@ class DevLauncherActivity : ReactActivity(), ReactInstanceManager.ReactInstanceE
 
   private val isSimulator
     get() = Build.FINGERPRINT.contains("vbox") || Build.FINGERPRINT.contains("generic")
+
+  private fun searchForRootView() {
+    if (rootView != null) {
+      return
+    }
+    // RootView is successfully found in first check (nearly impossible for first call)
+    findRootView(contentView)?.let { return@searchForRootView handleRootView(it) }
+    handler.postDelayed({ searchForRootView() }, SEARCH_FOR_ROOT_VIEW_INTERVAL)
+  }
+
+  private fun findRootView(view: View): ViewGroup? {
+    if (view is ReactRootView) {
+      return view
+    }
+    if (view != splashScreen && view is ViewGroup) {
+      for (idx in 0 until view.childCount) {
+        findRootView(view.getChildAt(idx))?.let { return@findRootView it }
+      }
+    }
+    return null
+  }
+
+  private fun handleRootView(view: ViewGroup) {
+    rootView = view
+    if ((rootView?.childCount ?: 0) > 0) {
+      hideSplashScreen()
+    }
+
+    view.setOnHierarchyChangeListener(object : ViewGroup.OnHierarchyChangeListener {
+      override fun onChildViewRemoved(parent: View, child: View) = Unit
+      override fun onChildViewAdded(parent: View, child: View) {
+        // react only to first child
+        if (rootView?.childCount == 1) {
+          hideSplashScreen()
+        }
+      }
+    })
+  }
+
+  private fun hideSplashScreen() {
+    splashScreen?.let {
+      runOnUiThread {
+        contentView.removeView(it)
+        splashScreen = null
+      }
+    }
+  }
 }

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/react/activitydelegates/DevLauncherReactActivityRedirectDelegate.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/react/activitydelegates/DevLauncherReactActivityRedirectDelegate.kt
@@ -3,6 +3,7 @@ package expo.modules.devlauncher.react.activitydelegates
 import android.content.Intent
 import android.os.Bundle
 import com.facebook.react.ReactActivity
+import expo.modules.devlauncher.splashscreen.DevLauncherSplashScreenProvider
 
 class DevLauncherReactActivityRedirectDelegate(
   activity: ReactActivity,
@@ -10,7 +11,8 @@ class DevLauncherReactActivityRedirectDelegate(
 ) : DevLauncherReactActivityNOPDelegate(activity) {
 
   override fun onCreate(savedInstanceState: Bundle?) {
+    DevLauncherSplashScreenProvider()
+      .attachSplashScreenViewAsync(plainActivity)
     redirect(plainActivity.intent)
-    plainActivity.finish()
   }
 }

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/splashscreen/DevLauncherSplashScreen.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/splashscreen/DevLauncherSplashScreen.kt
@@ -1,0 +1,28 @@
+package expo.modules.devlauncher.splashscreen
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.view.Gravity
+import android.widget.LinearLayout
+import android.widget.RelativeLayout
+import android.widget.TextView
+import expo.modules.devlauncher.R
+
+@SuppressLint("ViewConstructor")
+class DevLauncherSplashScreen(
+  context: Context,
+  textColor: Int
+) : RelativeLayout(context) {
+  init {
+    val textView = TextView(context)
+    textView.text = context.getString(R.string.splash_screen_text)
+    textView.gravity = Gravity.CENTER
+    textView.textSize = 24F
+    textView.layoutParams = LayoutParams(
+      LinearLayout.LayoutParams.MATCH_PARENT,
+      LinearLayout.LayoutParams.MATCH_PARENT
+    )
+    textView.setTextColor(textColor)
+    addView(textView)
+  }
+}

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/splashscreen/DevLauncherSplashScreenProvider.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/splashscreen/DevLauncherSplashScreenProvider.kt
@@ -1,0 +1,51 @@
+package expo.modules.devlauncher.splashscreen
+
+import android.app.Activity
+import android.content.Context
+import android.graphics.Color
+import android.view.ViewGroup
+import androidx.core.graphics.ColorUtils
+
+class DevLauncherSplashScreenProvider {
+  fun attachSplashScreenViewAsync(activity: Activity): DevLauncherSplashScreen? {
+      val contentView = activity.findViewById<ViewGroup>(android.R.id.content)
+        ?: return null
+      val backgroundColor = getBackgroundColor(activity)
+      val splashScreenView = DevLauncherSplashScreen(
+        activity,
+        getTextColorForBackgroundColor(backgroundColor)
+      )
+      splashScreenView.setBackgroundColor(backgroundColor)
+      contentView.addView(splashScreenView)
+
+      return splashScreenView
+  }
+
+  private fun getBackgroundColor(context: Context): Int {
+    val expoSplashScreenColor = context
+      .resources
+      .getIdentifier(
+        "splashscreen_background",
+        "drawable",
+        context.packageName
+      )
+
+    return if (expoSplashScreenColor == 0) {
+      // splashscreen_background doesn't exist
+      Color.parseColor("#000020")
+    } else {
+      expoSplashScreenColor
+    }
+  }
+
+  private fun getTextColorForBackgroundColor(backgroundColor: Int): Int {
+    val luminance = ColorUtils.calculateLuminance(backgroundColor)
+    return if (luminance > 0.5) {
+      Color.BLACK
+    } else {
+      Color.WHITE
+    }
+  }
+
+
+}

--- a/packages/expo-dev-launcher/android/src/main/res/values/strings.xml
+++ b/packages/expo-dev-launcher/android/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="splash_screen_text">DEVELOPMENT CLIENT</string>
+</resources>


### PR DESCRIPTION
# Why

Part of ENG-921.
Closes ENG-985.

# How

- Fixed the init deep link was sometimes ignored.
- Added splash screen on Android to hide where screen.

# Test Plan

- bare-expo ✅
