### PR TITLE
[expo-yarn-workspaces] Replace nullish operator with or for older node support

### DIFF
--- a/packages/expo-yarn-workspaces/webpack.js
+++ b/packages/expo-yarn-workspaces/webpack.js
@@ -28,7 +28,7 @@ exports.createWebpackConfigAsync = async function createWebpackConfigAsync(env, 
 
     // discover workspace package directories via glob - source yarn:
     // https://github.com/yarnpkg/yarn/blob/a4708b29ac74df97bac45365cba4f1d62537ceb7/src/config.js#L812-L826
-    const patterns = workspacePackage.workspaces ?? [];
+    const patterns = workspacePackage.workspaces || [];
     const registryFilenames = 'package.json';
     const trailingPattern = `/+(${registryFilenames})`;
 
@@ -51,7 +51,7 @@ exports.createWebpackConfigAsync = async function createWebpackConfigAsync(env, 
     debug(`Could not find Yarn workspace root`);
   }
 
-  env.babel = env.babel ?? {};
+  env.babel = env.babel || {};
 
   const config = await createExpoWebpackConfigAsync(
     {
@@ -59,7 +59,7 @@ exports.createWebpackConfigAsync = async function createWebpackConfigAsync(env, 
       babel: {
         dangerouslyAddModulePathsToTranspile: [
           ...workspacePackagesToTranspile,
-          ...(env.babel.dangerouslyAddModulePathsToTranspile ?? []),
+          ...(env.babel.dangerouslyAddModulePathsToTranspile || []),
         ],
       },
     },


### PR DESCRIPTION
# Why

Fixes #12674

# How

- Replaced the `??` operator with the old `||`. I don't think this causes issues, because we only use objects and arrays with this check.

# Test Plan

- Setup `expo-yarn-workspaces`
- Use Node v12
- Check if the webpack integration works

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).