### PR TITLE
[updates] Remove code to handle nested root level manifest key

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Add setter and resetter for SelectionPolicy. (Android: [#12609](https://github.com/expo/expo/pull/12609) and iOS: [#12685](https://github.com/expo/expo/pull/12685) by [@esamelson](https://github.com/esamelson))
 - Convert most remaining usages of JSON manifest to RawManifest. ([#12600](https://github.com/expo/expo/pull/12600) by [@wschurman](https://github.com/wschurman))
 - Factor out raw manifest into wrapper class. ([#12631](https://github.com/expo/expo/pull/12631) by [@wschurman](https://github.com/wschurman))
+- Remove code to handle nested root level manifest key. ([#12736](https://github.com/expo/expo/pull/12736) by [@wschurman](https://github.com/wschurman))
 
 
 ### 🐛 Bug fixes

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/manifest/NewManifestTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/manifest/NewManifestTest.kt
@@ -59,26 +59,6 @@ class NewManifestTest {
     NewManifest.fromRawManifest(manifest, null, createConfig())
   }
 
-  @Test
-  @Throws(JSONException::class)
-  fun testFromManifestJson_StripsOptionalRootLevelKeys() {
-    val manifestJsonWithRootLevelKeys =
-      "{\"manifest\":{\"runtimeVersion\":\"1\",\"id\":\"0eef8214-4833-4089-9dff-b4138a14f196\",\"createdAt\":\"2020-11-11T00:17:54.797Z\",\"launchAsset\":{\"url\":\"https://url.to/bundle.js\",\"contentType\":\"application/javascript\"}}}"
-    val manifest1: Manifest = NewManifest.fromRawManifest(
-      NewRawManifest(NewRawManifest.normalizeNestedManifestJSON(JSONObject(manifestJsonWithRootLevelKeys))),
-      null,
-      createConfig()
-    )
-    val manifestJsonNoRootLevelKeys =
-      "{\"runtimeVersion\":\"1\",\"id\":\"0eef8214-4833-4089-9dff-b4138a14f196\",\"createdAt\":\"2020-11-11T00:17:54.797Z\",\"launchAsset\":{\"url\":\"https://url.to/bundle.js\",\"contentType\":\"application/javascript\"}}"
-    val manifest2: Manifest = NewManifest.fromRawManifest(
-      NewRawManifest(NewRawManifest.normalizeNestedManifestJSON(JSONObject(manifestJsonNoRootLevelKeys))),
-      null,
-      createConfig()
-    )
-    Assert.assertEquals(manifest1.rawManifestJson.getID(), manifest2.rawManifestJson.getID())
-  }
-
   private fun createConfig(): UpdatesConfiguration {
     val configMap = HashMap<String, Any>()
     configMap["updateUrl"] = Uri.parse("https://exp.host/@test/test")

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ManifestFactory.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ManifestFactory.kt
@@ -19,7 +19,7 @@ object ManifestFactory {
                 LegacyManifest.fromLegacyRawManifest(LegacyRawManifest(manifestJson), configuration!!)
             }
             Integer.valueOf(expoProtocolVersion) == 0 -> {
-                NewManifest.fromRawManifest(NewRawManifest(NewRawManifest.normalizeNestedManifestJSON(manifestJson)), httpResponse, configuration!!)
+                NewManifest.fromRawManifest(NewRawManifest(manifestJson), httpResponse, configuration!!)
             }
             else -> {
                 throw Exception("Unsupported expo-protocol-version: $expoProtocolVersion")

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/raw/NewRawManifest.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/raw/NewRawManifest.kt
@@ -36,13 +36,4 @@ class NewRawManifest(json: JSONObject) : RawManifest(json) {
 
   @Throws(JSONException::class)
   fun getCreatedAt(): String = json.getString("createdAt")
-
-  companion object {
-    fun normalizeNestedManifestJSON(json: JSONObject): JSONObject {
-      if (json.has("manifest")) {
-        return json.getJSONObject("manifest")
-      }
-      return json
-    }
-  }
 }

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesNewUpdate.h
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesNewUpdate.h
@@ -7,7 +7,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface EXUpdatesNewUpdate : NSObject
 
-+ (EXUpdatesUpdate *)updateWithNewManifest:(EXUpdatesNewRawManifest *)rootManifest
++ (EXUpdatesUpdate *)updateWithNewManifest:(EXUpdatesNewRawManifest *)manifest
                                   response:(nullable NSURLResponse *)response
                                     config:(EXUpdatesConfig *)config
                                   database:(EXUpdatesDatabase *)database;

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesNewUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesNewUpdate.m
@@ -11,18 +11,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation EXUpdatesNewUpdate
 
-+ (EXUpdatesUpdate *)updateWithNewManifest:(EXUpdatesNewRawManifest *)rootManifest
++ (EXUpdatesUpdate *)updateWithNewManifest:(EXUpdatesNewRawManifest *)manifest
                                   response:(nullable NSURLResponse *)response
                                     config:(EXUpdatesConfig *)config
                                   database:(EXUpdatesDatabase *)database
 {
-  NSDictionary *tempManifest = rootManifest.rawManifestJSON;
-  if (tempManifest[@"manifest"]) {
-    tempManifest = tempManifest[@"manifest"];
-  }
-  
-  EXUpdatesNewRawManifest *manifest = [[EXUpdatesNewRawManifest alloc] initWithRawManifestJSON:tempManifest];
-  
   EXUpdatesUpdate *update = [[EXUpdatesUpdate alloc] initWithRawManifest:manifest
                                                                   config:config
                                                                 database:database];

--- a/packages/expo-updates/ios/Tests/EXUpdatesNewUpdateTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesNewUpdateTests.m
@@ -83,26 +83,6 @@
   XCTAssertThrows([EXUpdatesNewUpdate updateWithNewManifest:manifest response:nil config:_config database:_database]);
 }
 
-- (void)testUpdateWithNewManifest_StripsOptionalRootLevelKeys
-{
-  NSDictionary *rawManifestJSON = @{
-    @"runtimeVersion": @"1",
-    @"id": @"0eef8214-4833-4089-9dff-b4138a14f196",
-    @"createdAt": @"2020-11-11T00:17:54.797Z",
-    @"launchAsset": @{@"url": @"https://url.to/bundle.js", @"contentType": @"application/javascript"}
-  };
-  
-  EXUpdatesNewRawManifest *manifestNoRootLevelKeys = [[EXUpdatesNewRawManifest alloc] initWithRawManifestJSON:rawManifestJSON];
-  EXUpdatesNewRawManifest *manifestWithRootLevelKeys = [[EXUpdatesNewRawManifest alloc] initWithRawManifestJSON:@{
-    @"manifest": rawManifestJSON
-  }];
-
-  EXUpdatesUpdate *update1 = [EXUpdatesNewUpdate updateWithNewManifest:manifestNoRootLevelKeys response:nil config:_config database:_database];
-  EXUpdatesUpdate *update2 = [EXUpdatesNewUpdate updateWithNewManifest:manifestWithRootLevelKeys response:nil config:_config database:_database];
-
-  XCTAssert([update1.updateId isEqual:update2.updateId]);
-}
-
 - (void)testDictionaryWithStructuredHeader_SupportedTypes
 {
   NSString *header = @"string=\"string-0000\", true=?1, false=?0, integer=47, decimal=47.5";

--- a/packages/expo-updates/ios/Tests/EXUpdatesUpdateTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesUpdateTests.m
@@ -32,12 +32,10 @@
   };
 
   _easNewManifest = @{
-    @"manifest": @{
-      @"runtimeVersion": @"1",
-      @"id": @"0eef8214-4833-4089-9dff-b4138a14f196",
-      @"createdAt": @"2020-11-11T00:17:54.797Z",
-      @"launchAsset": @{@"url": @"https://url.to/bundle.js", @"contentType": @"application/javascript"}
-    }
+    @"runtimeVersion": @"1",
+    @"id": @"0eef8214-4833-4089-9dff-b4138a14f196",
+    @"createdAt": @"2020-11-11T00:17:54.797Z",
+    @"launchAsset": @{@"url": @"https://url.to/bundle.js", @"contentType": @"application/javascript"}
   };
 
   _bareManifest = @{


### PR DESCRIPTION
# Why

https://github.com/expo/expo/pull/12631#discussion_r619008364

# How

Remove code that handles the nested `manifest` key in new manifests on both ios and android.

# Test Plan

Inspect. See that the current www endpoint doesn't serve this nested field.