### PR TITLE
[expo-camera] add unimodules-permissions-interface to expo-camera

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Enable kotlin in all modules. ([#12716](https://github.com/expo/expo/pull/12716) by [@wschurman](https://github.com/wschurman))
+- Add unimodules-permissions-interface to expo-camera. ([#12739](https://github.com/expo/expo/pull/12739) by [@ajsmth](https://github.com/ajsmth))
 
 ## 11.0.2 — 2021-04-13
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🐛 Bug fixes
 
 - Enable kotlin in all modules. ([#12716](https://github.com/expo/expo/pull/12716) by [@wschurman](https://github.com/wschurman))
-- Add unimodules-permissions-interface to expo-camera. ([#12739](https://github.com/expo/expo/pull/12739) by [@ajsmth](https://github.com/ajsmth))
+- Add `unimodules-permissions-interface` dependency. ([#12739](https://github.com/expo/expo/pull/12739) by [@ajsmth](https://github.com/ajsmth))
 
 ## 11.0.2 — 2021-04-13
 

--- a/packages/expo-camera/package.json
+++ b/packages/expo-camera/package.json
@@ -36,7 +36,8 @@
   "dependencies": {
     "@expo/config-plugins": "^1.0.18",
     "@koale/useworker": "^3.2.1",
-    "invariant": "2.2.4"
+    "invariant": "2.2.4",
+    "unimodules-permissions-interface": "^6.1.0"
   },
   "devDependencies": {
     "expo-module-scripts": "^2.0.0"


### PR DESCRIPTION
# Why

Upgrading to SDK41 lead to this error when trying to use `expo-camera`:
<img width="702" alt="115785278-193e9e00-a374-11eb-9ec7-fe727c083bf4" src="https://user-images.githubusercontent.com/40680668/116140633-76946100-a68c-11eb-8d28-31321ae21298.png">



# How

Adding it as a dependency fixes the bundler 

