### PR TITLE
[expo go] add universal & app link support

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.java
+++ b/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.java
@@ -574,9 +574,11 @@ public class Kernel extends KernelInterface {
     openDefaultUrl();
   }
 
-  // Certain links should just open the HomeScreen
+  // Certain links (i.e. 'expo.io/expo-go') should just open the HomeScreen
   private boolean shouldOpenUrl(@NonNull Uri uri) {
-    return !uri.toString().contains("expo.io/expo-go");
+    String host = uri.getHost() != null ? uri.getHost() : "";
+    String path = uri.getPath() != null ? uri.getPath() : "";
+    return !(host.equals("expo.io") && path.equals("/expo-go"));
   }
 
   private boolean openExperienceFromNotificationIntent(Intent intent) {

--- a/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.java
+++ b/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.java
@@ -554,7 +554,7 @@ public class Kernel extends KernelInterface {
 
     if (uri != null && shouldOpenUrl(uri)) {
       if (Constants.INITIAL_URL == null) {
-        // We got an Expo Go app link (could be exp://, http://, or https://)
+        // We got an Expo Go app link (could be exp://, exps://, http://, or https://)
         if (!uri.getScheme().equals("exp")) {
           intentUri = uri.buildUpon().scheme("exp").toString();
         }

--- a/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.java
+++ b/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.java
@@ -17,6 +17,8 @@ import android.os.Handler;
 import android.util.Log;
 import android.widget.Toast;
 
+import androidx.annotation.NonNull;
+
 import com.facebook.internal.BundleJSONConverter;
 import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.ReactInstanceManager;
@@ -550,7 +552,7 @@ public class Kernel extends KernelInterface {
       }
     }
 
-    if (uri != null && !uri.toString().contains("expo.io/expo-go")) {
+    if (uri != null && shouldOpenUrl(uri)) {
       if (Constants.INITIAL_URL == null) {
         // We got an Expo Go app link (could be exp://, http://, or https://)
         if (!uri.getScheme().equals("exp")) {
@@ -570,6 +572,11 @@ public class Kernel extends KernelInterface {
     }
 
     openDefaultUrl();
+  }
+
+  private boolean shouldOpenUrl(@NonNull Uri uri) {
+    // Certain links should just open the HomeScreen
+    return !uri.toString().contains("expo.io/expo-go");
   }
 
   private boolean openExperienceFromNotificationIntent(Intent intent) {

--- a/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.java
+++ b/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.java
@@ -550,9 +550,12 @@ public class Kernel extends KernelInterface {
       }
     }
 
-    if (uri != null) {
+    if (uri != null && !uri.toString().contains("expo.io/expo-go")) {
       if (Constants.INITIAL_URL == null) {
-        // We got an "exp://" link
+        // We got an Expo Go app link (could be exp://, http://, or https://)
+        if (!uri.getScheme().equals("exp")) {
+          intentUri = uri.buildUpon().scheme("exp").toString();
+        }
         openExperience(new KernelConstants.ExperienceOptions(intentUri, intentUri, null));
         return;
       } else {

--- a/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.java
+++ b/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.java
@@ -574,8 +574,8 @@ public class Kernel extends KernelInterface {
     openDefaultUrl();
   }
 
+  // Certain links should just open the HomeScreen
   private boolean shouldOpenUrl(@NonNull Uri uri) {
-    // Certain links should just open the HomeScreen
     return !uri.toString().contains("expo.io/expo-go");
   }
 

--- a/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.java
+++ b/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.java
@@ -554,10 +554,7 @@ public class Kernel extends KernelInterface {
 
     if (uri != null && shouldOpenUrl(uri)) {
       if (Constants.INITIAL_URL == null) {
-        // We got an Expo Go app link (could be exp://, exps://, http://, or https://)
-        if (!uri.getScheme().equals("exp")) {
-          intentUri = uri.buildUpon().scheme("exp").toString();
-        }
+        // We got an "exp://", "exps://", "http://", or "https://" app link
         openExperience(new KernelConstants.ExperienceOptions(intentUri, intentUri, null));
         return;
       } else {

--- a/home/HomeApp.tsx
+++ b/home/HomeApp.tsx
@@ -57,7 +57,7 @@ export default function HomeApp() {
     if (!isShowingSplashScreen && Platform.OS === 'ios') {
       // If Expo Go is opened via deep linking, we'll get the URL here
       Linking.getInitialURL().then(initialUrl => {
-        if (initialUrl && !initialUrl.includes('expo.io/expo-go')) {
+        if (initialUrl && shouldOpenUrl(initialUrl)) {
           Linking.openURL(UrlUtils.toExp(initialUrl));
         }
       });
@@ -113,6 +113,11 @@ export default function HomeApp() {
       </ActionSheetProvider>
     </View>
   );
+}
+
+// Certain links should just open the HomeScreen
+function shouldOpenUrl(url: string) {
+  return !url.includes('expo.io/expo-go');
 }
 
 const styles = StyleSheet.create({

--- a/home/HomeApp.tsx
+++ b/home/HomeApp.tsx
@@ -115,9 +115,10 @@ export default function HomeApp() {
   );
 }
 
-// Certain links should just open the HomeScreen
-function shouldOpenUrl(url: string) {
-  return !url.includes('expo.io/expo-go');
+// Certain links (i.e. 'expo.io/expo-go') should just open the HomeScreen
+function shouldOpenUrl(urlString: string) {
+  const url = new URL(urlString);
+  return !(url.hostname === 'expo.io' && url.pathname === '/expo-go');
 }
 
 const styles = StyleSheet.create({

--- a/home/HomeApp.tsx
+++ b/home/HomeApp.tsx
@@ -14,8 +14,8 @@ import { useDispatch, useSelector } from './redux/Hooks';
 import SessionActions from './redux/SessionActions';
 import SettingsActions from './redux/SettingsActions';
 import LocalStorage from './storage/LocalStorage';
-import addListenerWithNativeCallback from './utils/addListenerWithNativeCallback';
 import * as UrlUtils from './utils/UrlUtils';
+import addListenerWithNativeCallback from './utils/addListenerWithNativeCallback';
 
 // Download and cache stack assets, don't block loading on this though
 Asset.loadAsync(StackAssets);

--- a/home/HomeApp.tsx
+++ b/home/HomeApp.tsx
@@ -7,6 +7,7 @@ import * as SplashScreen from 'expo-splash-screen';
 import * as React from 'react';
 import { Linking, Platform, StyleSheet, View } from 'react-native';
 import { useColorScheme } from 'react-native-appearance';
+import url from 'url';
 
 import Navigation from './navigation/Navigation';
 import HistoryActions from './redux/HistoryActions';
@@ -117,8 +118,8 @@ export default function HomeApp() {
 
 // Certain links (i.e. 'expo.io/expo-go') should just open the HomeScreen
 function shouldOpenUrl(urlString: string) {
-  const url = new URL(urlString);
-  return !(url.hostname === 'expo.io' && url.pathname === '/expo-go');
+  const parsedUrl = url.parse(urlString);
+  return !(parsedUrl.hostname === 'expo.io' && parsedUrl.pathname === '/expo-go');
 }
 
 const styles = StyleSheet.create({

--- a/home/HomeApp.tsx
+++ b/home/HomeApp.tsx
@@ -15,6 +15,7 @@ import SessionActions from './redux/SessionActions';
 import SettingsActions from './redux/SettingsActions';
 import LocalStorage from './storage/LocalStorage';
 import addListenerWithNativeCallback from './utils/addListenerWithNativeCallback';
+import * as UrlUtils from './utils/UrlUtils';
 
 // Download and cache stack assets, don't block loading on this though
 Asset.loadAsync(StackAssets);
@@ -56,8 +57,8 @@ export default function HomeApp() {
     if (!isShowingSplashScreen && Platform.OS === 'ios') {
       // If Expo Go is opened via deep linking, we'll get the URL here
       Linking.getInitialURL().then(initialUrl => {
-        if (initialUrl) {
-          Linking.openURL(initialUrl);
+        if (initialUrl && !initialUrl.match('expo.io/expo-go')) {
+          Linking.openURL(UrlUtils.toExp(initialUrl));
         }
       });
     }

--- a/home/HomeApp.tsx
+++ b/home/HomeApp.tsx
@@ -57,7 +57,7 @@ export default function HomeApp() {
     if (!isShowingSplashScreen && Platform.OS === 'ios') {
       // If Expo Go is opened via deep linking, we'll get the URL here
       Linking.getInitialURL().then(initialUrl => {
-        if (initialUrl && !initialUrl.match('expo.io/expo-go')) {
+        if (initialUrl && !initialUrl.includes('expo.io/expo-go')) {
           Linking.openURL(UrlUtils.toExp(initialUrl));
         }
       });

--- a/ios/Exponent/ExpoKit/ExpoKit.m
+++ b/ios/Exponent/ExpoKit/ExpoKit.m
@@ -182,8 +182,10 @@ fetchCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandl
         [EXKernelLinkingManager application:application continueUserActivity:userActivity restorationHandler:restorationHandler];
         return YES;
       } else {
-        [application openURL:webpageURL options:@{} completionHandler:nil];
-        return YES;
+        if (![path isEqualToString:@"/expo-go"]) {
+          [application openURL:webpageURL options:@{} completionHandler:nil];
+          return YES;
+        }
       }
     }
   }

--- a/template-files/android/AndroidManifest.xml
+++ b/template-files/android/AndroidManifest.xml
@@ -89,14 +89,6 @@
       <!-- This has to be separate from the exp[s]:// scheme filter. No idea why -->
       <intent-filter>
         <data
-          android:host="expo.io"
-          android:pathPattern="/@.*/.*"
-          android:scheme="https"/>
-        <data
-          android:host="expo.io"
-          android:pathPattern="/@.*/.*"
-          android:scheme="http"/>
-        <data
           android:host="exp.host"
           android:pathPrefix="/@"
           android:scheme="http"/>

--- a/template-files/android/AndroidManifest.xml
+++ b/template-files/android/AndroidManifest.xml
@@ -70,8 +70,32 @@
         <category android:name="android.intent.category.BROWSABLE"/>
       </intent-filter>
 
+      <intent-filter android:autoVerify="true">
+        <data
+          android:host="expo.io"
+          android:path="/expo-go"
+          android:scheme="https"/>
+        <data
+          android:host="expo.io"
+          android:path="/expo-go"
+          android:scheme="http"/>
+
+        <action android:name="android.intent.action.VIEW"/>
+
+        <category android:name="android.intent.category.DEFAULT"/>
+        <category android:name="android.intent.category.BROWSABLE"/>
+      </intent-filter>
+      
       <!-- This has to be separate from the exp[s]:// scheme filter. No idea why -->
       <intent-filter>
+        <data
+          android:host="expo.io"
+          android:pathPattern="/@.*/.*"
+          android:scheme="https"/>
+        <data
+          android:host="expo.io"
+          android:pathPattern="/@.*/.*"
+          android:scheme="http"/>
         <data
           android:host="exp.host"
           android:pathPrefix="/@"


### PR DESCRIPTION
# Why

Support universal links (coined "app links" on android, but they're the same), to allow us to distribute a regular `https://` url that will either:
- open expo go if installed, or
- navigate to a web page that redirects to the app store listing to download expo go

# How

Work was already done on iOS in terms of adding the `associatedDomains`. On Android, followed [this guide](https://developer.android.com/training/app-links#add-app-links) (tldr: add some intent filters, configure `assetlinks.json` on the serverside).

# Test Plan

Server-side changes are deployed so can test this branch as it is by building locally, and:

- opening `https://expo.io/expo-go` opens homepage of the app on ios and android, both from a killed state and a backgrounded state.
- `exp` and `exps` scheme urls (i.e. `exp://expo.io/@cruzantest/smart-chips+BGbWXggSXv` still work as expected)
- `exp.host` deep links still work as expected (i.e. `https://exp.host/@cruzantest/smart-chips+BGbWXggSXv` opens the project on ios and android)

> on android, use `adb shell am start -a android.intent.action.VIEW -c android.intent.category.BROWSABLE -d 'your link here'` to test app links

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md). **N/A**
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`). **N/A**
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin). **N/A**