### PR TITLE
Remove expo-status-bar from blank template

### DIFF
--- a/templates/expo-template-bare-minimum/App.js
+++ b/templates/expo-template-bare-minimum/App.js
@@ -1,4 +1,3 @@
-import { StatusBar } from 'expo-status-bar';
 import React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 
@@ -6,7 +5,6 @@ export default function App() {
   return (
     <View style={styles.container}>
       <Text>Open up App.js to start working on your app!</Text>
-      <StatusBar style="auto" />
     </View>
   );
 }

--- a/templates/expo-template-bare-minimum/package.json
+++ b/templates/expo-template-bare-minimum/package.json
@@ -12,7 +12,6 @@
   "dependencies": {
     "expo": "~41.0.0-beta.3",
     "expo-splash-screen": "~0.10.1",
-    "expo-status-bar": "~1.0.4",
     "expo-updates": "~0.5.3",
     "react": "16.13.1",
     "react-dom": "16.13.1",


### PR DESCRIPTION
# Why

This gets added to all projects on prebuild, we may want to just create a new template with actual bare requirements for prebuild instead though.
