### PR TITLE
[ios][updates] Add better runtime type checking to manifest fields

### DIFF
--- a/ios/Exponent/Kernel/AppLoader/AppFetcher/EXAppFetcher.h
+++ b/ios/Exponent/Kernel/AppLoader/AppFetcher/EXAppFetcher.h
@@ -59,7 +59,7 @@ NS_ASSUME_NONNULL_BEGIN
                           success:(void (^)(NSData *))successBlock
                             error:(void (^)(NSError *))errorBlock;
 
-+ (NSString *)experienceIdWithManifest:(EXUpdatesRawManifest *)manifest;
++ (nullable NSString *)experienceIdWithManifest:(EXUpdatesRawManifest *)manifest;
 + (EXCachedResourceBehavior)cacheBehaviorForJSWithManifest:(EXUpdatesRawManifest *)manifest;
 
 @end

--- a/ios/Exponent/Kernel/AppLoader/AppFetcher/EXAppFetcher.m
+++ b/ios/Exponent/Kernel/AppLoader/AppFetcher/EXAppFetcher.m
@@ -55,7 +55,7 @@ NS_ASSUME_NONNULL_BEGIN
   [jsResource loadResourceWithBehavior:cacheBehavior progressBlock:progressBlock successBlock:successBlock errorBlock:errorBlock];
 }
 
-+ (NSString *)experienceIdWithManifest:(EXUpdatesRawManifest * _Nonnull)manifest
++ (nullable NSString *)experienceIdWithManifest:(EXUpdatesRawManifest * _Nonnull)manifest
 {
   return manifest.rawID;
 }

--- a/ios/Exponent/Kernel/AppLoader/AppFetcher/EXAppFetcher.m
+++ b/ios/Exponent/Kernel/AppLoader/AppFetcher/EXAppFetcher.m
@@ -57,12 +57,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (NSString *)experienceIdWithManifest:(EXUpdatesRawManifest * _Nonnull)manifest
 {
-  id experienceIdJsonValue = manifest.rawID;
-  if (experienceIdJsonValue) {
-    RCTAssert([experienceIdJsonValue isKindOfClass:[NSString class]], @"Manifest contains an id which is not a string: %@", experienceIdJsonValue);
-    return experienceIdJsonValue;
-  }
-  return nil;
+  return manifest.rawID;
 }
 
 + (EXCachedResourceBehavior)cacheBehaviorForJSWithManifest:(EXUpdatesRawManifest * _Nonnull)manifest

--- a/ios/Exponent/Kernel/AppLoader/EXApiUtil.m
+++ b/ios/Exponent/Kernel/AppLoader/EXApiUtil.m
@@ -15,9 +15,7 @@ static NSString* kPublicKeyTag = @"exp.host.publickey";
 
 + (NSURL *)bundleUrlFromManifest:(EXUpdatesRawManifest *)manifest
 {
-  NSString *urlString = manifest.bundleUrl;
-  RCTAssert([urlString isKindOfClass:[NSString class]], @"Manifest contains a bundleUrl which is not a string: %@", urlString);
-  return [[self class] encodedUrlFromString:urlString];
+  return [[self class] encodedUrlFromString:manifest.bundleUrl];
 }
 
 + (NSURL *)encodedUrlFromString:(NSString *)urlString

--- a/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
+++ b/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
@@ -417,7 +417,6 @@ NS_ASSUME_NONNULL_BEGIN
     if (![@"UNVERSIONED" isEqual:sdkVersion] &&
         sdkVersion.integerValue < 39 &&
         [@"snack" isEqual:manifest.slug] &&
-        bundleUrl && [bundleUrl isKindOfClass:[NSString class]] &&
         [bundleUrl hasPrefix:@"https://d1wp6m56sqw74a.cloudfront.net/%40exponent%2Fsnack"]) {
       _shouldShowRemoteUpdateStatus = NO;
       return;

--- a/ios/Exponent/Kernel/Core/EXKernelAppRecord.m
+++ b/ios/Exponent/Kernel/Core/EXKernelAppRecord.m
@@ -58,11 +58,7 @@ NSString *kEXKernelBridgeDidBackgroundNotification = @"EXKernelBridgeDidBackgrou
 - (NSString * _Nullable)experienceId
 {
   if (self.appLoader && self.appLoader.manifest) {
-    id experienceIdJsonValue = self.appLoader.manifest.rawID;
-    if (experienceIdJsonValue) {
-      RCTAssert([experienceIdJsonValue isKindOfClass:[NSString class]], @"Manifest contains an id which is not a string: %@", experienceIdJsonValue);
-      return experienceIdJsonValue;
-    }
+    return self.appLoader.manifest.rawID;
   }
   return nil;
 }

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesBareUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesBareUpdate.m
@@ -18,15 +18,12 @@ NS_ASSUME_NONNULL_BEGIN
                                                                   config:config
                                                                 database:database];
 
-  id updateId = manifest.rawID;
-  id commitTime = manifest.commitTimeNumber;
-  id metadata = manifest.metadata;
-  id assets = manifest.assets;
-
-  NSAssert([updateId isKindOfClass:[NSString class]], @"update ID should be a string");
-  NSAssert([commitTime isKindOfClass:[NSNumber class]], @"commitTime should be a number");
-  NSAssert(!metadata || [metadata isKindOfClass:[NSDictionary class]], @"metadata should be null or an object");
-  NSAssert(!assets || [assets isKindOfClass:[NSArray class]], @"assets should be null or an array");
+  NSString *updateId = manifest.rawID;
+  NSNumber *commitTime = manifest.commitTimeNumber;
+  NSDictionary *metadata = manifest.metadata;
+  NSArray *assets = manifest.assets;
+  
+  NSAssert(updateId != nil, @"update ID should not be null");
 
   NSUUID *uuid = [[NSUUID alloc] initWithUUIDString:(NSString *)updateId];
   NSAssert(uuid, @"update ID should be a valid UUID");

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesLegacyUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesLegacyUpdate.m
@@ -29,13 +29,11 @@ static NSString * const EXUpdatesExpoTestDomain = @"expo.test";
     update.updateId = [NSUUID UUID];
     update.commitTime = [NSDate date];
   } else {
-    id updateId = manifest.releaseID;
-    NSAssert([updateId isKindOfClass:[NSString class]], @"update ID should be a string");
+    NSString *updateId = manifest.releaseID;
     update.updateId = [[NSUUID alloc] initWithUUIDString:(NSString *)updateId];
     NSAssert(update.updateId, @"update ID should be a valid UUID");
 
-    id commitTimeString = manifest.commitTime;
-    NSAssert([commitTimeString isKindOfClass:[NSString class]], @"commitTime should be a string");
+    NSString *commitTimeString = manifest.commitTime;
     update.commitTime = [RCTConvert NSDate:commitTimeString];
   }
 
@@ -46,10 +44,9 @@ static NSString * const EXUpdatesExpoTestDomain = @"expo.test";
     update.status = EXUpdatesUpdateStatusPending;
   }
 
-  id bundleUrlString = manifest.bundleUrl;
-  id assets = manifest.bundledAssets ?: @[];
+  NSString *bundleUrlString = manifest.bundleUrl;
+  NSArray *assets = manifest.bundledAssets ?: @[];
 
-  id sdkVersion = manifest.sdkVersion;
   id runtimeVersion = manifest.runtimeVersion;
   if (runtimeVersion && [runtimeVersion isKindOfClass:[NSDictionary class]]) {
     id runtimeVersionIos = ((NSDictionary *)runtimeVersion)[@"ios"];
@@ -58,12 +55,10 @@ static NSString * const EXUpdatesExpoTestDomain = @"expo.test";
   } else if (runtimeVersion && [runtimeVersion isKindOfClass:[NSString class]]) {
     update.runtimeVersion = (NSString *)runtimeVersion;
   } else {
-    NSAssert([sdkVersion isKindOfClass:[NSString class]], @"sdkVersion should be a string");
-    update.runtimeVersion = (NSString *)sdkVersion;
+    NSString *sdkVersion = manifest.sdkVersion;
+    NSAssert(sdkVersion != nil, @"sdkVersion should not be null");
+    update.runtimeVersion = sdkVersion;
   }
-
-  NSAssert([bundleUrlString isKindOfClass:[NSString class]], @"bundleUrl should be a string");
-  NSAssert([assets isKindOfClass:[NSArray class]], @"assets should be a nonnull array");
 
   NSURL *bundleUrl = [NSURL URLWithString:bundleUrlString];
   NSAssert(bundleUrl, @"bundleUrl should be a valid URL");
@@ -79,7 +74,7 @@ static NSString * const EXUpdatesExpoTestDomain = @"expo.test";
   
   NSURL *bundledAssetBaseUrl = [[self class] bundledAssetBaseUrlWithManifest:manifest config:config];
 
-  for (NSString *bundledAsset in (NSArray *)assets) {
+  for (NSString *bundledAsset in assets) {
     NSAssert([bundledAsset isKindOfClass:[NSString class]], @"bundledAssets must be an array of strings");
 
     NSRange extensionStartRange = [bundledAsset rangeOfString:@"." options:NSBackwardsSearch];

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesNewUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesNewUpdate.m
@@ -20,17 +20,13 @@ NS_ASSUME_NONNULL_BEGIN
                                                                   config:config
                                                                 database:database];
   
-  id updateId = manifest.rawID;
-  id commitTime = manifest.createdAt;
-  id runtimeVersion = manifest.runtimeVersion;
-  id launchAsset = manifest.launchAsset;
-  id assets = manifest.assets;
+  NSString *updateId = manifest.rawID;
+  NSString *commitTime = manifest.createdAt;
+  NSString *runtimeVersion = manifest.runtimeVersion;
+  NSDictionary *launchAsset = manifest.launchAsset;
+  NSArray *assets = manifest.assets;
   
-  NSAssert([updateId isKindOfClass:[NSString class]], @"update ID should be a string");
-  NSAssert([commitTime isKindOfClass:[NSString class]], @"createdAt should be a string");
-  NSAssert([runtimeVersion isKindOfClass:[NSString class]], @"runtimeVersion should be a string");
-  NSAssert([launchAsset isKindOfClass:[NSDictionary class]], @"launchAsset should be a dictionary");
-  NSAssert(!assets || [assets isKindOfClass:[NSArray class]], @"assets should be null or an array");
+  NSAssert(updateId != nil, @"update ID should not be null");
   
   NSUUID *uuid = [[NSUUID alloc] initWithUUIDString:(NSString *)updateId];
   NSAssert(uuid, @"update ID should be a valid UUID");

--- a/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesBareRawManifest.h
+++ b/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesBareRawManifest.h
@@ -9,6 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSNumber *)commitTimeNumber;
 - (nullable NSDictionary *)metadata;
+- (nullable NSArray *)assets;
 
 @end
 

--- a/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesBareRawManifest.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesBareRawManifest.m
@@ -4,12 +4,16 @@
 
 @implementation EXUpdatesBareRawManifest
 
-- (nonnull NSNumber *)commitTimeNumber {
-  return self.rawManifestJSON[@"commitTime"];
+- (NSNumber *)commitTimeNumber {
+  return [self.rawManifestJSON numberForKey:@"commitTime"];
 }
 
 - (NSDictionary *)metadata {
-  return self.rawManifestJSON[@"metadata"];
+  return [self.rawManifestJSON nullableDictionaryForKey:@"metadata"];
+}
+
+- (nullable NSArray *)assets {
+  return [self.rawManifestJSON nullableArrayForKey:@"assets"];
 }
 
 @end

--- a/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesBaseLegacyRawManifest.h
+++ b/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesBaseLegacyRawManifest.h
@@ -7,7 +7,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface EXUpdatesBaseLegacyRawManifest : EXUpdatesBaseRawManifest
 
 - (NSString *)bundleUrl;
-- (NSString *)sdkVersion;
+- (nullable NSString *)sdkVersion;
 - (nullable NSArray *)assets;
 
 @end

--- a/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesBaseLegacyRawManifest.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesBaseLegacyRawManifest.m
@@ -1,19 +1,16 @@
 //  Copyright © 2021 650 Industries. All rights reserved.
 
 #import <EXUpdates/EXUpdatesBaseLegacyRawManifest.h>
+#import <EXUpdates/NSDictionary+EXUpdatesRawManifest.h>
 
 @implementation EXUpdatesBaseLegacyRawManifest
 
 - (NSString *)bundleUrl {
-  return self.rawManifestJSON[@"bundleUrl"];
+  return [self.rawManifestJSON stringForKey:@"bundleUrl"];
 }
 
-- (NSString *)sdkVersion {
-  return self.rawManifestJSON[@"sdkVersion"];
-}
-
-- (nullable NSArray *)assets {
-  return self.rawManifestJSON[@"assets"];
+- (nullable NSString *)sdkVersion {
+  return [self.rawManifestJSON nullableStringForKey:@"sdkVersion"];
 }
 
 @end

--- a/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesBaseRawManifest.h
+++ b/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesBaseRawManifest.h
@@ -1,5 +1,7 @@
 //  Copyright © 2021 650 Industries. All rights reserved.
 
+#import <EXUpdates/NSDictionary+EXUpdatesRawManifest.h>
+
 NS_ASSUME_NONNULL_BEGIN
 
 @interface EXUpdatesBaseRawManifest : NSObject
@@ -11,8 +13,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 # pragma mark - Common EXUpdatesRawManifestBehavior
 
-- (NSString *)rawID;
-- (NSString *)revisionId;
+- (nullable NSString *)rawID;
+- (nullable NSString *)revisionId;
 - (nullable NSString *)slug;
 - (nullable NSString *)appKey;
 - (nullable NSString *)name;

--- a/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesBaseRawManifest.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesBaseRawManifest.m
@@ -17,51 +17,51 @@
 
 # pragma mark - Field Getters
 
-- (NSString *)rawID {
-  return self.rawManifestJSON[@"id"];
+- (nullable NSString *)rawID {
+  return [self.rawManifestJSON nullableStringForKey:@"id"];
 }
 
-- (NSString *)revisionId {
-  return self.rawManifestJSON[@"revisionId"];
+- (nullable NSString *)revisionId {
+  return [self.rawManifestJSON nullableStringForKey:@"revisionId"];
 }
 
 - (nullable NSString *)slug {
-  return self.rawManifestJSON[@"slug"];
+  return [self.rawManifestJSON nullableStringForKey:@"slug"];
 }
 
 - (nullable NSString *)appKey {
-  return self.rawManifestJSON[@"appKey"];
+  return [self.rawManifestJSON nullableStringForKey:@"appKey"];
 }
 
 - (nullable NSString *)name {
-  return self.rawManifestJSON[@"name"];
+  return [self.rawManifestJSON nullableStringForKey:@"name"];
 }
 
 - (nullable NSDictionary *)notificationPreferences {
-  return self.rawManifestJSON[@"notification"];
+  return [self.rawManifestJSON nullableDictionaryForKey:@"notification"];
 }
 
 - (nullable NSDictionary *)updatesInfo {
-  return self.rawManifestJSON[@"updates"];
+  return [self.rawManifestJSON nullableDictionaryForKey:@"updates"];
 }
 
 - (nullable NSDictionary *)iosConfig {
-  return self.rawManifestJSON[@"ios"];
+  return [self.rawManifestJSON nullableDictionaryForKey:@"ios"];
 }
 
 - (nullable NSString *)hostUri {
-  return self.rawManifestJSON[@"hostUri"];
+  return [self.rawManifestJSON nullableStringForKey:@"hostUri"];
 }
 
 - (nullable NSString *)orientation {
-  return self.rawManifestJSON[@"orientation"];
+  return [self.rawManifestJSON nullableStringForKey:@"orientation"];
 }
 
 # pragma mark - Derived Methods
 
 - (BOOL)isDevelopmentMode {
-  NSDictionary *manifestPackagerOptsConfig = self.rawManifestJSON[@"packagerOpts"];
-  return (self.rawManifestJSON[@"developer"] != nil && manifestPackagerOptsConfig != nil && [@(YES) isEqualToNumber:manifestPackagerOptsConfig[@"dev"]]);
+  NSDictionary *manifestPackagerOptsConfig = [self.rawManifestJSON nullableDictionaryForKey:@"packagerOpts"];
+  return ([self.rawManifestJSON nullableDictionaryForKey:@"developer"] != nil && manifestPackagerOptsConfig != nil && [@(YES) isEqualToNumber:manifestPackagerOptsConfig[@"dev"]]);
 }
 
 - (BOOL)isDevelopmentSilentLaunch {
@@ -80,17 +80,17 @@
 }
 
 - (nullable NSString *)userInterfaceStyle {
-  if (self.iosConfig && self.iosConfig[@"userInterfaceStyle"]) {
-    return self.iosConfig[@"userInterfaceStyle"];
+  if (self.iosConfig && [self.iosConfig nullableStringForKey:@"userInterfaceStyle"]) {
+    return [self.iosConfig nullableStringForKey:@"userInterfaceStyle"];
   }
-  return self.rawManifestJSON[@"userInterfaceStyle"];
+  return [self.rawManifestJSON nullableStringForKey:@"userInterfaceStyle"];
 }
 
 - (nullable NSString *)androidOrRootBackroundColor {
-  if (self.iosConfig && self.iosConfig[@"backgroundColor"]) {
-    return self.iosConfig[@"backgroundColor"];
+  if (self.iosConfig && [self.iosConfig nullableStringForKey:@"backgroundColor"]) {
+    return [self.iosConfig nullableStringForKey:@"backgroundColor"];
   }
-  return self.rawManifestJSON[@"backgroundColor"];
+  return [self.rawManifestJSON nullableStringForKey:@"backgroundColor"];
 }
 
 - (nullable NSString *)iosSplashBackgroundColor {

--- a/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesLegacyRawManifest.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesLegacyRawManifest.m
@@ -7,15 +7,15 @@
 # pragma mark - Field Methods
 
 - (NSString *)releaseID {
-  return self.rawManifestJSON[@"releaseId"];
+  return [self.rawManifestJSON stringForKey:@"releaseId"];
 }
 
 - (NSString *)commitTime {
-  return self.rawManifestJSON[@"commitTime"];
+  return [self.rawManifestJSON stringForKey:@"commitTime"];
 }
 
 - (nullable NSArray *)bundledAssets {
-  return self.rawManifestJSON[@"bundledAssets"];
+  return [self.rawManifestJSON nullableArrayForKey:@"bundledAssets"];
 }
 
 - (nullable id)runtimeVersion {
@@ -23,11 +23,11 @@
 }
 
 - (nullable NSString *)bundleKey {
-  return self.rawManifestJSON[@"bundleKey"];
+  return [self.rawManifestJSON nullableStringForKey:@"bundleKey"];
 }
 
 - (nullable NSString *)assetUrlOverride {
-  return self.rawManifestJSON[@"assetUrlOverride"];
+  return [self.rawManifestJSON nullableStringForKey:@"assetUrlOverride"];
 }
 
 @end

--- a/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesNewRawManifest.h
+++ b/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesNewRawManifest.h
@@ -10,6 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSString *)createdAt;
 - (NSString *)runtimeVersion;
 - (NSDictionary *)launchAsset;
+- (nullable NSArray *)assets;
 
 @end
 

--- a/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesNewRawManifest.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesNewRawManifest.m
@@ -5,10 +5,10 @@
 @implementation EXUpdatesNewRawManifest
 
 - (NSString *)createdAt {
-  return self.rawManifestJSON[@"createdAt"];
+  return [self.rawManifestJSON stringForKey:@"createdAt"];
 }
 
-- (NSString *)sdkVersion {
+- (nullable NSString *)sdkVersion {
   NSString *runtimeVersion = self.runtimeVersion;
   NSRegularExpression *regex =
       [NSRegularExpression regularExpressionWithPattern:@"^exposdk:(\\d+\\.\\d+\\.\\d+)$"
@@ -26,19 +26,19 @@
 }
 
 - (NSString *)runtimeVersion {
-  return self.rawManifestJSON[@"runtimeVersion"];
+  return [self.rawManifestJSON stringForKey:@"runtimeVersion"];
 }
 
 - (NSDictionary *)launchAsset {
-  return self.rawManifestJSON[@"launchAsset"];
+  return [self.rawManifestJSON dictionaryForKey:@"launchAsset"];
 }
 
-- (NSArray *)assets {
-  return self.rawManifestJSON[@"assets"];
+- (nullable NSArray *)assets {
+  return [self.rawManifestJSON nullableArrayForKey:@"assets"];
 }
 
 - (NSString *)bundleUrl {
-  return self.launchAsset[@"url"];
+  return [self.launchAsset stringForKey:@"url"];
 }
 
 @end

--- a/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesRawManifest.h
+++ b/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesRawManifest.h
@@ -10,11 +10,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 # pragma mark - Field getters
 
-- (NSString *)rawID;
-- (NSString *)sdkVersion;
+- (nullable NSString *)rawID;
+- (nullable NSString *)sdkVersion;
 - (NSString *)bundleUrl;
-- (NSString *)revisionId;
-- (nullable NSArray *)assets;
+- (nullable NSString *)revisionId;
 - (nullable NSString *)slug;
 - (nullable NSString *)appKey;
 - (nullable NSString *)name;

--- a/packages/expo-updates/ios/EXUpdates/Update/RawManifest/NSDictionary+EXUpdatesRawManifest.h
+++ b/packages/expo-updates/ios/EXUpdates/Update/RawManifest/NSDictionary+EXUpdatesRawManifest.h
@@ -1,0 +1,18 @@
+// Copyright © 2021 650 Industries. All rights reserved.
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface NSDictionary (EXUpdatesRawManifest)
+
+- (NSString *)stringForKey:(NSString *)key;
+- (nullable NSString *)nullableStringForKey:(NSString *)key;
+- (NSNumber *)numberForKey:(NSString *)key;
+- (nullable NSNumber *)nullableNumberForKey:(NSString *)key;
+- (NSArray *)arrayForKey:(NSString *)key;
+- (nullable NSArray *)nullableArrayForKey:(NSString *)key;
+- (NSDictionary *)dictionaryForKey:(NSString *)key;
+- (nullable NSDictionary *)nullableDictionaryForKey:(NSString *)key;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/ios/EXUpdates/Update/RawManifest/NSDictionary+EXUpdatesRawManifest.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/RawManifest/NSDictionary+EXUpdatesRawManifest.m
@@ -1,0 +1,54 @@
+// Copyright © 2021 650 Industries. All rights reserved.
+
+#import <EXUpdates/NSDictionary+EXUpdatesRawManifest.h>
+
+#define EXGetNonNullManifestValue(Type, key) \
+({ \
+  id value = [self objectForKey:key]; \
+  NSAssert(value != nil, @"Value for (key = %@) should not be null", key); \
+  NSAssert([value isKindOfClass:[Type class]], @"Value for (key = %@) should be a %@", key, NSStringFromClass([Type class])); \
+  value; \
+})
+
+#define EXGetNullableManifestValue(Type, key) \
+({ \
+  id value = [self objectForKey:key]; \
+  NSAssert(!value || [value isKindOfClass:[Type class]], @"Value for (key = %@) should be a %@ or null", key, NSStringFromClass([Type class])); \
+  value; \
+})
+
+@implementation NSDictionary (EXUpdatesRawManifest)
+
+- (NSString *)stringForKey:(NSString *)key {
+  return EXGetNonNullManifestValue(NSString, key);
+}
+
+- (nullable NSString *)nullableStringForKey:(NSString *)key {
+  return EXGetNullableManifestValue(NSString, key);
+}
+
+- (NSNumber *)numberForKey:(NSString *)key {
+  return EXGetNonNullManifestValue(NSNumber, key);
+}
+
+- (nullable NSNumber *)nullableNumberForKey:(NSString *)key {
+  return EXGetNullableManifestValue(NSNumber, key);
+}
+
+- (NSArray *)arrayForKey:(NSString *)key {
+  return EXGetNonNullManifestValue(NSArray, key);
+}
+
+- (nullable NSArray *)nullableArrayForKey:(NSString *)key {
+  return EXGetNullableManifestValue(NSArray, key);
+}
+
+- (NSDictionary *)dictionaryForKey:(NSString *)key {
+  return EXGetNonNullManifestValue(NSDictionary, key);
+}
+
+- (nullable NSDictionary *)nullableDictionaryForKey:(NSString *)key {
+  return EXGetNullableManifestValue(NSDictionary, key);
+}
+
+@end

--- a/packages/expo-updates/ios/NSDictionary+EXUpdatesRawManifestTest.m
+++ b/packages/expo-updates/ios/NSDictionary+EXUpdatesRawManifestTest.m
@@ -1,0 +1,72 @@
+//  Copyright (c) 2020 650 Industries, Inc. All rights reserved.
+
+#import <XCTest/XCTest.h>
+
+#import <EXUpdates/NSDictionary+EXUpdatesRawManifest.h>
+
+@interface NSDictionaryEXUpdatesRawManifestTest : XCTestCase
+
+@property (nonatomic, strong) NSDictionary *testData;
+
+@end
+
+@implementation NSDictionaryEXUpdatesRawManifestTest
+
+- (void)setUp {
+  _testData = @{
+    @"string": @"hello",
+    @"number": @2,
+    @"dictionary": @{},
+    @"array": @[],
+  };
+}
+
+- (void)test_stringForKey {
+  XCTAssertEqual([self.testData stringForKey:@"string"], @"hello");
+  XCTAssertThrows([self.testData stringForKey:@"number"]);
+  XCTAssertThrows([self.testData stringForKey:@"nonexistent"]);
+}
+
+- (void)test_nullableStringForKey {
+  XCTAssertEqual([self.testData nullableStringForKey:@"string"], @"hello");
+  XCTAssertNil([self.testData nullableStringForKey:@"nonexistent"]);
+  XCTAssertThrows([self.testData nullableStringForKey:@"number"]);
+}
+
+- (void)test_numberForKey {
+  XCTAssertEqual([self.testData numberForKey:@"number"], @2);
+  XCTAssertThrows([self.testData numberForKey:@"string"]);
+  XCTAssertThrows([self.testData numberForKey:@"nonexistent"]);
+}
+
+- (void)test_nullableNumberForKey {
+  XCTAssertEqual([self.testData nullableNumberForKey:@"number"], @2);
+  XCTAssertNil([self.testData nullableNumberForKey:@"nonexistent"]);
+  XCTAssertThrows([self.testData nullableNumberForKey:@"string"]);
+}
+
+- (void)test_dictionaryForKey {
+  XCTAssertEqual([self.testData dictionaryForKey:@"dictionary"], @{});
+  XCTAssertThrows([self.testData dictionaryForKey:@"string"]);
+  XCTAssertThrows([self.testData dictionaryForKey:@"nonexistent"]);
+}
+
+- (void)test_nullableDictionaryForKey {
+  XCTAssertEqual([self.testData nullableDictionaryForKey:@"dictionary"], @{});
+  XCTAssertNil([self.testData nullableDictionaryForKey:@"nonexistent"]);
+  XCTAssertThrows([self.testData nullableDictionaryForKey:@"string"]);
+}
+
+- (void)arrayForKey {
+  XCTAssertEqual([self.testData arrayForKey:@"array"], @[]);
+  XCTAssertThrows([self.testData arrayForKey:@"string"]);
+  XCTAssertThrows([self.testData arrayForKey:@"nonexistent"]);
+}
+
+- (void)test_nullableArrayForKey {
+  XCTAssertEqual([self.testData nullableArrayForKey:@"array"], @[]);
+  XCTAssertNil([self.testData nullableArrayForKey:@"nonexistent"]);
+  XCTAssertThrows([self.testData nullableArrayForKey:@"string"]);
+}
+
+@end


### PR DESCRIPTION
# Why

https://github.com/expo/expo/pull/12631#discussion_r619017048

The idea is to move the nullability and type checks out from the callsites and into the manifests themselves now that we have the ability to do it in one place.

# How

- Inspect the usage of each field, ensure that ones that are expected to be nullable allow null, and that the few that always expected non-null use the appropriate methods.
- Add tests for NSDictionary category for helper methods related to the manifest getters.

# Test Plan

- Run new test
- Run app, load some manifests, ensure nothing immediately breaks.