### PR TITLE
Bump min target to node 12

### DIFF
--- a/packages/expo-facebook/CHANGELOG.md
+++ b/packages/expo-facebook/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- [plugin] Bump min target to node 12. ([#12743](https://github.com/expo/expo/pull/12743) by [@EvanBacon](https://github.com/EvanBacon))
+
 ### 🐛 Bug fixes
 
 - Enable kotlin in all modules. ([#12716](https://github.com/expo/expo/pull/12716) by [@wschurman](https://github.com/wschurman))

--- a/packages/expo-facebook/plugin/build/withFacebookAndroid.js
+++ b/packages/expo-facebook/plugin/build/withFacebookAndroid.js
@@ -112,7 +112,7 @@ async function setFacebookAppIdString(config, projectRoot) {
     try {
         await XML_1.writeXMLAsync({ path: stringsPath, xml: stringsJSON });
     }
-    catch (_a) {
+    catch {
         throw new Error(`Error setting facebookAppId. Cannot write strings.xml to "${stringsPath}"`);
     }
     return true;

--- a/packages/expo-module-scripts/package.json
+++ b/packages/expo-module-scripts/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@babel/cli": "^7.1.2",
     "@expo/npm-proofread": "^1.0.1",
-    "@tsconfig/node10": "^1.0.7",
+    "@tsconfig/node12": "^1.0.7",
     "@testing-library/react-hooks": "^3.2.1",
     "@types/jest": "^24.0.11",
     "babel-preset-expo": "~8.3.0",

--- a/packages/expo-module-scripts/tsconfig.plugin.json
+++ b/packages/expo-module-scripts/tsconfig.plugin.json
@@ -1,5 +1,5 @@
 {
-    "extends": "@tsconfig/node10/tsconfig.json",
+    "extends": "@tsconfig/node12/tsconfig.json",
     "compilerOptions": {
         "declaration": true
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4602,10 +4602,10 @@
     "@babel/runtime" "^7.5.4"
     "@types/testing-library__react-hooks" "^3.3.0"
 
-"@tsconfig/node10@^1.0.7":
+"@tsconfig/node12@^1.0.7":
   version "1.0.7"
-  resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.7.tgz#1eb1de36c73478a2479cc661ef5af1c16d86d606"
-  integrity sha512-aBvUmXLQbayM4w3A8TrjwrXs4DZ8iduJnuJLLRGdkWlyakCf1q6uHZJBzXoRA/huAEknG5tcUyQxN3A+In5euQ==
+  resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.7.tgz#677bd9117e8164dc319987dd6ff5fc1ba6fbf18b"
+  integrity sha512-dgasobK/Y0wVMswcipr3k0HpevxFJLijN03A8mYfEPvWvOs14v0ZlYTR4kIgMx8g4+fTyTFv8/jLCIfRqLDJ4A==
 
 "@types/anymatch@*":
   version "1.3.1"


### PR DESCRIPTION
# Why

node 10 ded, expo cli only support LTS.