### PR TITLE
[docs] bump Expo styleguide

### DIFF
--- a/docs/global-styles/extras.ts
+++ b/docs/global-styles/extras.ts
@@ -78,7 +78,7 @@ export const globalExtras = css`
     margin: 0;
     margin-bottom: 0.5rem;
     text-decoration: none;
-    background: ${theme.button.primary};
+    background: ${theme.button.primary.background};
     color: ${palette.dark.white};
     font-family: ${Constants.fontFamilies.book};
     font-size: 1rem;

--- a/docs/package.json
+++ b/docs/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@emotion/core": "^10.0.35",
     "@expo/spawn-async": "^1.5.0",
-    "@expo/styleguide": "^2.1.4",
+    "@expo/styleguide": "^3.0.0",
     "@mdx-js/loader": "^1.6.16",
     "@mdx-js/mdx": "^1.6.16",
     "@mdx-js/react": "^1.6.16",

--- a/docs/pages/_app.tsx
+++ b/docs/pages/_app.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 
 import { preprocessSentryError } from '~/common/sentry-utilities';
 import 'react-diff-view/style/index.css';
-import '@expo/styleguide/dist/expo-colors.css';
+import '@expo/styleguide/dist/expo-theme.css';
 import 'tippy.js/dist/tippy.css';
 import '../public/static/libs/algolia/algolia.css';
 import '../public/static/libs/algolia/algolia-mobile.css';

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -549,10 +549,10 @@
   dependencies:
     cross-spawn "^6.0.5"
 
-"@expo/styleguide@^2.1.4":
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/@expo/styleguide/-/styleguide-2.1.4.tgz#6599008643ac8cdd9cb8cf6ce6055e0b7bfeb3da"
-  integrity sha512-6avY0jc9uwnaaHO2C6zITYnWsTZMx+EZuMW9EcdNpHkeibAgsHkGeH9ZEQDrxVGay+qu7HK8FI9lN2cY56ncZQ==
+"@expo/styleguide@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@expo/styleguide/-/styleguide-3.0.0.tgz#0bf6256a33c330ac808c8284d127b0e7260e4cf6"
+  integrity sha512-GzsgiMGIF3WOGTded5q12S62KhQqOtt1Ny2LQaXaiYjRTF8HRKJTgdD00Uy8bKyqi/Rn91V6Uzd/P3G74r5zBA==
 
 "@hapi/accept@5.0.1":
   version "5.0.1"


### PR DESCRIPTION
# Why

It's nice to stay up-to-date and probably we can utilize few new icons in docs too. 😉 

# How

Bump `@expo/styleguide` and rename CSS file, as described in the new release Breaking Changes section:
* https://github.com/expo/styleguide/releases/tag/v3.0.0

# Test Plan

The bump has been tested running docs website locally. I was not able to spot any visual regressions.

CC: @jonsamp 