### PR TITLE
[modules] Fix bare-expo doesn't compile

### DIFF
--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -54,8 +54,17 @@ android {
   lintOptions {
     abortOnError false
   }
+  compileOptions {
+    sourceCompatibility = '1.8'
+    targetCompatibility = '1.8'
+  }
+  kotlinOptions {
+    jvmTarget = '1.8'
+  }
 }
 
 dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${safeExtGet('kotlinVersion', '1.4.21')}"
+  implementation project(':unimodules-core')
+  implementation 'androidx.annotation:annotation:1.2.0'
 }


### PR DESCRIPTION
# Why

After https://github.com/expo/expo/pull/12718 was merged, the bare project stoped compiling. 

# How

Fixed all compilation errors. 

> I don't know if we want to add the `unimodules-core` in that way, but it works for now.
```
implementation project(':unimodules-core')
```

# Test Plan

- expo go ✅
- bare-expo ✅