### PR TITLE
[docs] Fix iOS simulator build link.

### DIFF
--- a/docs/pages/build/setup.md
+++ b/docs/pages/build/setup.md
@@ -76,7 +76,7 @@ Additional configuration may be required for some scenarios:
 
 ### Build for Android device/emulator or iOS simulator
 
-The easiest way to try out EAS Build is to create a build that you can run on your Android device/emulator or iOS simulator. It's quicker than uploading it to a store, and you don't need any store developer membership accounts. If you'd like to try this, read about [creating an installable APK for Android](/build-reference/apk.md) and [creating a simulator build for iOS](/build/simulators.md).
+The easiest way to try out EAS Build is to create a build that you can run on your Android device/emulator or iOS simulator. It's quicker than uploading it to a store, and you don't need any store developer membership accounts. If you'd like to try this, read about [creating an installable APK for Android](/build-reference/apk.md) and [creating a simulator build for iOS](/build-reference/simulators.md).
 
 ### Build for app stores
 


### PR DESCRIPTION
# Why

The current link 404s

# How

Updated the link to point to `/build-reference/simulators.md`.

# Test Plan

Checked the link locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).