### PR TITLE
[expo-updates][android] modify DatabaseIntegrityCheck to match iOS behavior

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Finish conversion to an interface for raw manifests. ([#12509](https://github.com/expo/expo/pull/12509) by [@wschurman](https://github.com/wschurman))
 - Add support for loading new manifests in Expo Go. ([#12521](https://github.com/expo/expo/pull/12521) by [@wschurman](https://github.com/wschurman))
 - Split SelectionPolicy into 3 separate interfaces. (Android: [#12606](https://github.com/expo/expo/pull/12606) and iOS: [#12682](https://github.com/expo/expo/pull/12682) by [@esamelson](https://github.com/esamelson))
-- Add DatabaseIntegrityCheck and tests. (Android: [#12607](https://github.com/expo/expo/pull/12607) and iOS: [#12683](https://github.com/expo/expo/pull/12683) by [@esamelson](https://github.com/esamelson))
+- Add DatabaseIntegrityCheck and tests. (Android: [#12607](https://github.com/expo/expo/pull/12607) and [#12754](https://github.com/expo/expo/pull/12754), and iOS: [#12683](https://github.com/expo/expo/pull/12683) by [@esamelson](https://github.com/esamelson))
 - Add onAssetLoaded progress callback to remote loader. (Android: [#12608](https://github.com/expo/expo/pull/12608) and iOS: [#12684](https://github.com/expo/expo/pull/12684) by [@esamelson](https://github.com/esamelson))
 - Add setter and resetter for SelectionPolicy. (Android: [#12609](https://github.com/expo/expo/pull/12609) and iOS: [#12685](https://github.com/expo/expo/pull/12685) by [@esamelson](https://github.com/esamelson))
 - Convert most remaining usages of JSON manifest to RawManifest. ([#12600](https://github.com/expo/expo/pull/12600) by [@wschurman](https://github.com/wschurman))

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/db/DatabaseIntegrityCheckTest.java
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/db/DatabaseIntegrityCheckTest.java
@@ -91,7 +91,6 @@ public class DatabaseIntegrityCheckTest {
     Assert.assertEquals(1, allUpdates.size());
     Assert.assertEquals(UpdateStatus.PENDING, allUpdates.get(0).status);
     Assert.assertEquals(1, allAssets.size());
-    Assert.assertNull(allAssets.get(0).relativePath);
 
     // cleanup
     db.updateDao().deleteUpdates(allUpdates);
@@ -121,7 +120,6 @@ public class DatabaseIntegrityCheckTest {
     Assert.assertEquals(1, allUpdates.size());
     Assert.assertEquals(UpdateStatus.READY, allUpdates.get(0).status);
     Assert.assertEquals(1, allAssets.size());
-    Assert.assertEquals(asset1.relativePath, allAssets.get(0).relativePath);
 
     // cleanup
     db.updateDao().deleteUpdates(allUpdates);

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/DatabaseIntegrityCheck.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/DatabaseIntegrityCheck.java
@@ -22,7 +22,7 @@ public class DatabaseIntegrityCheck {
     }
 
     if (missingAssets.size() > 0) {
-      database.assetDao().markMissingAssets(missingAssets);
+      database.updateDao().markUpdatesWithMissingAssets(missingAssets);
     }
 
     List<UpdateEntity> updatesToDelete = new ArrayList<>();

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/dao/AssetDao.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/dao/AssetDao.java
@@ -5,9 +5,7 @@ import androidx.room.Update;
 import expo.modules.updates.db.entity.AssetEntity;
 import expo.modules.updates.db.entity.UpdateAssetEntity;
 import expo.modules.updates.db.entity.UpdateEntity;
-import expo.modules.updates.db.enums.UpdateStatus;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
@@ -51,13 +49,6 @@ public abstract class AssetDao {
 
   @Query("SELECT * FROM assets WHERE `key` = :key LIMIT 1;")
   public abstract List<AssetEntity> _loadAssetWithKey(String key);
-
-  @Query("UPDATE assets SET relative_path = NULL WHERE id IN (:missingAssetIds)")
-  public abstract void _markMissingAssets(List<Long> missingAssetIds);
-
-  @Query("UPDATE updates SET status = :status WHERE id IN (" +
-          "SELECT DISTINCT update_id FROM updates_assets WHERE asset_id IN (:missingAssetIds));")
-  public abstract void _markUpdatesWithMissingAssets(List<Long> missingAssetIds, UpdateStatus status);
 
 
   /**
@@ -135,15 +126,5 @@ public abstract class AssetDao {
     _deleteAssetsMarkedForDeletion();
 
     return deletedAssets;
-  }
-
-  @Transaction
-  public void markMissingAssets(List<AssetEntity> missingAssets) {
-    ArrayList<Long> missingAssetIds = new ArrayList<>();
-    for (AssetEntity asset : missingAssets) {
-      missingAssetIds.add(asset.id);
-    }
-    _markMissingAssets(missingAssetIds);
-    _markUpdatesWithMissingAssets(missingAssetIds, UpdateStatus.PENDING);
   }
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/dao/UpdateDao.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/dao/UpdateDao.java
@@ -6,6 +6,7 @@ import expo.modules.updates.db.enums.UpdateStatus;
 import expo.modules.updates.db.entity.AssetEntity;
 import expo.modules.updates.db.entity.UpdateEntity;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
@@ -39,6 +40,10 @@ public abstract class UpdateDao {
 
   @Update
   public abstract void _updateUpdate(UpdateEntity update);
+
+  @Query("UPDATE updates SET status = :status WHERE id IN (" +
+          "SELECT DISTINCT update_id FROM updates_assets WHERE asset_id IN (:missingAssetIds));")
+  public abstract void _markUpdatesWithMissingAssets(List<Long> missingAssetIds, UpdateStatus status);
 
 
   /**
@@ -88,6 +93,14 @@ public abstract class UpdateDao {
 
   public void markUpdateFinished(UpdateEntity update) {
     markUpdateFinished(update, false);
+  }
+
+  public void markUpdatesWithMissingAssets(List<AssetEntity> missingAssets) {
+    List<Long> missingAssetIds = new ArrayList<>();
+    for (AssetEntity asset : missingAssets) {
+      missingAssetIds.add(asset.id);
+    }
+    _markUpdatesWithMissingAssets(missingAssetIds, UpdateStatus.PENDING);
   }
 
   @Delete


### PR DESCRIPTION
# Why

Follow-up to https://github.com/expo/expo/pull/12683#discussion_r619662954 .

Removes the unnecessary double meaning of the `relative_path` column in the assets table that was introduced in #12607. The presence of a value or NULL in `relative_path` no longer indicates whether or not we think the asset is currently present on disk; the meaning of the column is simply the path *if* the asset does indeed exist on disk.

The rest of the logic does not rely on the nullability of the field in this way, so there's no reason to introduce this added layer of meaning, and it will just lead to more confusion in the future (especially since it's Android-specific).

# How

Update the behavior of `DatabaseIntegrityCheck` and its tests to match iOS; we now update the status of any update with missing assets but don't modify the entries for the assets themselves.

# Test Plan

All unit tests pass.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).