### PR TITLE
Fix the tsconfig documentation

### DIFF
--- a/docs/pages/guides/typescript.md
+++ b/docs/pages/guides/typescript.md
@@ -32,7 +32,7 @@ An Expo app's `tsconfig.json` should extend the `expo/tsconfig.base` by default.
   - Improve Babel ecosystem compatibility. This also sets `allowSyntheticDefaultImports` to `true`, allowing default imports from modules with no default export.
 - [`"jsx"`][tsc-jsx]: `"react-native"`
   - Preserve JSX, and converts the `jsx` extension to `js`. This is optimized for bundlers that transform the JSX internally (like Metro).
-- `"lib"`: `["ESNext"]`
+- `"lib"`: `["DOM", "ESNext"]`
   - Allow using the latest [ECMAScript proposed features and libraries](https://github.com/tc39/proposals).
 - [`"moduleResolution"`][tsc-moduleresolution]: `"node"`
   - Emulate how Metro and Webpack resolve modules.

--- a/docs/pages/guides/typescript.md
+++ b/docs/pages/guides/typescript.md
@@ -32,7 +32,7 @@ An Expo app's `tsconfig.json` should extend the `expo/tsconfig.base` by default.
   - Improve Babel ecosystem compatibility. This also sets `allowSyntheticDefaultImports` to `true`, allowing default imports from modules with no default export.
 - [`"jsx"`][tsc-jsx]: `"react-native"`
   - Preserve JSX, and converts the `jsx` extension to `js`. This is optimized for bundlers that transform the JSX internally (like Metro).
-- `"lib"`: -- `["ESNext"]`
+- `"lib"`: `["ESNext"]`
   - Allow using the latest [ECMAScript proposed features and libraries](https://github.com/tc39/proposals).
 - [`"moduleResolution"`][tsc-moduleresolution]: `"node"`
   - Emulate how Metro and Webpack resolve modules.


### PR DESCRIPTION
# Why

Update the documentation for `tsconfig.json` so that it is in sync with the actual `tsconfig.json` used. This is a follow up to https://github.com/expo/expo/pull/12738, because I found a small error.

One question though: Why are we including the `"DOM"` library? The code doesn't run in a browser, so objects like `window` and `document` are not available. It turns out that is needed because `alert()` is available. Could we create a small subset of `"DOM"`, so that only the actually available objects and methods would be listed? I think the documentation line below should explain why `"DOM"` is included, but I couldn't figure out what to write.

# How & Test Plan

The changes in here only affect the documentation, so they haven't been tested.

# Checklist

- [*] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).