### PR TITLE
[templates] Disable Flipper by default for now

### DIFF
--- a/templates/expo-template-bare-minimum/ios/Podfile
+++ b/templates/expo-template-bare-minimum/ios/Podfile
@@ -10,10 +10,12 @@ target 'HelloWorld' do
 
   use_react_native!(:path => config["reactNativePath"])
 
-  if !ENV['CI']
-    use_flipper!({ 'Flipper' => '0.80.0' })
-    post_install do |installer|
-      flipper_post_install(installer)
-    end
-  end
+  # Uncomment to opt-in to using Flipper
+  #
+  # if !ENV['CI']
+  #   use_flipper!({ 'Flipper' => '0.80.0' })
+  #   post_install do |installer|
+  #     flipper_post_install(installer)
+  #   end
+  # end
 end

--- a/templates/expo-template-bare-typescript/ios/Podfile
+++ b/templates/expo-template-bare-typescript/ios/Podfile
@@ -10,10 +10,12 @@ target 'HelloWorld' do
 
   use_react_native!(:path => config["reactNativePath"])
 
-  if !ENV['CI']
-    use_flipper!({ 'Flipper' => '0.80.0' })
-    post_install do |installer|
-      flipper_post_install(installer)
-    end
-  end
+  # Uncomment to opt-in to using Flipper
+  #
+  # if !ENV['CI']
+  #   use_flipper!({ 'Flipper' => '0.80.0' })
+  #   post_install do |installer|
+  #     flipper_post_install(installer)
+  #   end
+  # end
 end


### PR DESCRIPTION
# Why

https://twitter.com/yagudaev/status/1387505599684890625

Too many unexpected occurrences of Flipper breaking ability to build and run template for now, we should add back when it's a bit more stable and versions are locked in React Native.