### PR TITLE
[expo-updates] add last_accessed column to updates table (destructive migration)

### DIFF
--- a/ios/versioned-react-native/ABI39_0_0/Expo/EXUpdates/ABI39_0_0EXUpdates/Update/ABI39_0_0EXUpdatesUpdate.h
+++ b/ios/versioned-react-native/ABI39_0_0/Expo/EXUpdates/ABI39_0_0EXUpdates/Update/ABI39_0_0EXUpdatesUpdate.h
@@ -31,6 +31,7 @@ typedef NS_ENUM(NSInteger, ABI39_0_0EXUpdatesUpdateStatus) {
 @property (nonatomic, strong, readonly) NSDictionary *rawManifest;
 
 @property (nonatomic, assign) ABI39_0_0EXUpdatesUpdateStatus status;
+@property (nonatomic, strong) NSDate *lastAccessed;
 
 + (instancetype)updateWithId:(NSUUID *)updateId
                   commitTime:(NSDate *)commitTime

--- a/ios/versioned-react-native/ABI39_0_0/Expo/EXUpdates/ABI39_0_0EXUpdates/Update/ABI39_0_0EXUpdatesUpdate.m
+++ b/ios/versioned-react-native/ABI39_0_0/Expo/EXUpdates/ABI39_0_0EXUpdates/Update/ABI39_0_0EXUpdatesUpdate.m
@@ -25,6 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
     _config = config;
     _database = database;
     _scopeKey = config.scopeKey;
+    _lastAccessed = [NSDate date];
     _isDevelopmentMode = NO;
   }
   return self;

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/ABI40_0_0EXUpdatesUpdate.h
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/ABI40_0_0EXUpdatesUpdate.h
@@ -31,6 +31,7 @@ typedef NS_ENUM(NSInteger, ABI40_0_0EXUpdatesUpdateStatus) {
 @property (nonatomic, strong, readonly) NSDictionary *rawManifest;
 
 @property (nonatomic, assign) ABI40_0_0EXUpdatesUpdateStatus status;
+@property (nonatomic, strong) NSDate *lastAccessed;
 
 + (instancetype)updateWithId:(NSUUID *)updateId
                     scopeKey:(NSString *)scopeKey

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/ABI40_0_0EXUpdatesUpdate.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/ABI40_0_0EXUpdatesUpdate.m
@@ -25,6 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
     _config = config;
     _database = database;
     _scopeKey = config.scopeKey;
+    _lastAccessed = [NSDate date];
     _isDevelopmentMode = NO;
   }
   return self;

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/ABI41_0_0EXUpdatesUpdate.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/ABI41_0_0EXUpdatesUpdate.h
@@ -34,6 +34,7 @@ typedef NS_ENUM(NSInteger, ABI41_0_0EXUpdatesUpdateStatus) {
 @property (nonatomic, strong, readonly) NSDictionary *rawManifest;
 
 @property (nonatomic, assign) ABI41_0_0EXUpdatesUpdateStatus status;
+@property (nonatomic, strong) NSDate *lastAccessed;
 
 + (instancetype)updateWithId:(NSUUID *)updateId
                     scopeKey:(NSString *)scopeKey

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/ABI41_0_0EXUpdatesUpdate.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/ABI41_0_0EXUpdatesUpdate.m
@@ -25,6 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
     _config = config;
     _database = database;
     _scopeKey = config.scopeKey;
+    _lastAccessed = [NSDate date];
     _isDevelopmentMode = NO;
   }
   return self;

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 🛠 Breaking changes
 
 - Save asset with a key that does not include an extension. This introduces an implicit dependency on expo-asset@8.3.2 or above. ([#12734](https://github.com/expo/expo/pull/12734) by [@jkhales](https://github.com/jkhales))
+- Add last_accessed column to updates table schema, and rename metadata -> manifest. ([#12768](https://github.com/expo/expo/pull/12768) by [@esamelson](https://github.com/esamelson))
 
 ### 🎉 New features
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/UpdatesDatabase.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/UpdatesDatabase.java
@@ -20,7 +20,7 @@ import androidx.room.RoomDatabase;
 import androidx.room.TypeConverters;
 import androidx.sqlite.db.SupportSQLiteDatabase;
 
-@Database(entities = {UpdateEntity.class, UpdateAssetEntity.class, AssetEntity.class, JSONDataEntity.class}, exportSchema = false, version = 5)
+@Database(entities = {UpdateEntity.class, UpdateAssetEntity.class, AssetEntity.class, JSONDataEntity.class}, exportSchema = false, version = 6)
 @TypeConverters({Converters.class})
 public abstract class UpdatesDatabase extends RoomDatabase {
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/dao/AssetDao.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/dao/AssetDao.java
@@ -57,7 +57,7 @@ public abstract class AssetDao {
   @Query("SELECT * FROM assets;")
   public abstract List<AssetEntity> loadAllAssets();
 
-  @Query("SELECT assets.id, url, `key`, headers, type, assets.metadata, download_time, relative_path, hash, hash_type, marked_for_deletion" +
+  @Query("SELECT assets.*" +
           " FROM assets" +
           " INNER JOIN updates_assets ON updates_assets.asset_id = assets.id" +
           " INNER JOIN updates ON updates_assets.update_id = updates.id" +

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/entity/UpdateEntity.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/entity/UpdateEntity.java
@@ -46,11 +46,8 @@ public class UpdateEntity {
   @ColumnInfo(name = "launch_asset_id")
   public Long launchAssetId = null;
 
+  @ColumnInfo(name = "manifest")
   public JSONObject metadata = null;
-
-  public RawManifest getRawManifest() {
-    return ManifestFactory.INSTANCE.getRawManifestFromJson(this.metadata);
-  }
 
   @NonNull
   public UpdateStatus status = UpdateStatus.PENDING;
@@ -58,10 +55,19 @@ public class UpdateEntity {
   @NonNull
   public boolean keep = false;
 
+  @ColumnInfo(name = "last_accessed")
+  @NonNull
+  public Date lastAccessed;
+
   public UpdateEntity(UUID id, Date commitTime, String runtimeVersion, String scopeKey) {
     this.id = id;
     this.commitTime = commitTime;
     this.runtimeVersion = runtimeVersion;
     this.scopeKey = scopeKey;
+    this.lastAccessed = new Date();
+  }
+
+  public RawManifest getRawManifest() {
+    return ManifestFactory.INSTANCE.getRawManifestFromJson(this.metadata);
   }
 }

--- a/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.m
+++ b/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.m
@@ -529,14 +529,14 @@ static NSString * const EXUpdatesDatabaseServerDefinedHeadersKey = @"serverDefin
   }
   EXUpdatesUpdate *update = [EXUpdatesUpdate updateWithId:row[@"id"]
                                                  scopeKey:row[@"scope_key"]
-                                               commitTime:[EXUpdatesDatabaseUtils dateFromNumber:(NSNumber *)row[@"commit_time"]]
+                                               commitTime:[EXUpdatesDatabaseUtils dateFromUnixTimeMilliseconds:(NSNumber *)row[@"commit_time"]]
                                            runtimeVersion:row[@"runtime_version"]
                                                  metadata:metadata
                                                    status:(EXUpdatesUpdateStatus)[(NSNumber *)row[@"status"] integerValue]
                                                      keep:[(NSNumber *)row[@"keep"] boolValue]
                                                    config:config
                                                  database:self];
-  update.lastAccessed = [EXUpdatesDatabaseUtils dateFromNumber:(NSNumber *)row[@"last_accessed"]];
+  update.lastAccessed = [EXUpdatesDatabaseUtils dateFromUnixTimeMilliseconds:(NSNumber *)row[@"last_accessed"]];
   return update;
 }
 
@@ -564,7 +564,7 @@ static NSString * const EXUpdatesDatabaseServerDefinedHeadersKey = @"serverDefin
   EXUpdatesAsset *asset = [[EXUpdatesAsset alloc] initWithKey:key type:row[@"type"]];
   asset.assetId = [(NSNumber *)row[@"id"] unsignedIntegerValue];
   asset.url = url;
-  asset.downloadTime = [EXUpdatesDatabaseUtils dateFromNumber:(NSNumber *)row[@"download_time"]];
+  asset.downloadTime = [EXUpdatesDatabaseUtils dateFromUnixTimeMilliseconds:(NSNumber *)row[@"download_time"]];
   asset.filename = row[@"relative_path"];
   asset.contentHash = row[@"hash"];
   asset.metadata = metadata;

--- a/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabaseInitialization+Tests.h
+++ b/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabaseInitialization+Tests.h
@@ -1,15 +1,22 @@
 // Copyright 2021-present 650 Industries. All rights reserved.
 
 #import <EXUpdates/EXUpdatesDatabaseInitialization.h>
+#import <EXUpdates/EXUpdatesDatabaseMigration.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface EXUpdatesDatabaseInitialization (Tests)
 
++ (BOOL)initializeDatabaseWithLatestSchemaInDirectory:(NSURL *)directory
+                                             database:(struct sqlite3 * _Nullable * _Nonnull)database
+                                           migrations:(NSArray<id<EXUpdatesDatabaseMigration>> *)migrations
+                                                error:(NSError ** _Nullable)error;
+
 + (BOOL)initializeDatabaseWithSchema:(NSString *)schema
                             filename:(NSString *)filename
                          inDirectory:(NSURL *)directory
                        shouldMigrate:(BOOL)shouldMigrate
+                          migrations:(NSArray<id<EXUpdatesDatabaseMigration>> *)migrations
                             database:(struct sqlite3 * _Nullable * _Nonnull)database
                                error:(NSError ** _Nullable)error;
 

--- a/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabaseInitialization.m
+++ b/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabaseInitialization.m
@@ -61,10 +61,22 @@ CREATE INDEX \"index_json_data_scope_key\" ON \"json_data\" (\"scope_key\")\
                                              database:(struct sqlite3 * _Nullable * _Nonnull)database
                                                 error:(NSError ** _Nullable)error
 {
+  return [[self class] initializeDatabaseWithLatestSchemaInDirectory:directory
+                                                            database:database
+                                                          migrations:[EXUpdatesDatabaseMigrationRegistry migrations]
+                                                               error:error];
+}
+
++ (BOOL)initializeDatabaseWithLatestSchemaInDirectory:(NSURL *)directory
+                                             database:(struct sqlite3 * _Nullable * _Nonnull)database
+                                           migrations:(NSArray<id<EXUpdatesDatabaseMigration>> *)migrations
+                                                error:(NSError ** _Nullable)error
+{
   return [[self class] initializeDatabaseWithSchema:EXUpdatesDatabaseInitializationLatestSchema
                                            filename:EXUpdatesDatabaseLatestFilename
                                         inDirectory:directory
                                       shouldMigrate:YES
+                                         migrations:migrations
                                            database:database
                                               error:error];
 }
@@ -73,6 +85,7 @@ CREATE INDEX \"index_json_data_scope_key\" ON \"json_data\" (\"scope_key\")\
                             filename:(NSString *)filename
                          inDirectory:(NSURL *)directory
                        shouldMigrate:(BOOL)shouldMigrate
+                          migrations:(NSArray<id<EXUpdatesDatabaseMigration>> *)migrations
                             database:(struct sqlite3 * _Nullable * _Nonnull)database
                                error:(NSError ** _Nullable)error
 {
@@ -80,7 +93,7 @@ CREATE INDEX \"index_json_data_scope_key\" ON \"json_data\" (\"scope_key\")\
   NSURL *dbUrl = [directory URLByAppendingPathComponent:filename];
   BOOL shouldInitializeDatabaseSchema = ![[NSFileManager defaultManager] fileExistsAtPath:[dbUrl path]];
 
-  BOOL success = [[self class] _migrateDatabaseInDirectory:directory];
+  BOOL success = [[self class] _migrateDatabaseInDirectory:directory withMigrations:migrations];
   if (!success) {
     NSError *removeFailedMigrationError;
     if ([NSFileManager.defaultManager fileExistsAtPath:dbUrl.path] &&
@@ -154,7 +167,7 @@ CREATE INDEX \"index_json_data_scope_key\" ON \"json_data\" (\"scope_key\")\
   return YES;
 }
 
-+ (BOOL)_migrateDatabaseInDirectory:(NSURL *)directory
++ (BOOL)_migrateDatabaseInDirectory:(NSURL *)directory withMigrations:(NSArray<id<EXUpdatesDatabaseMigration>> *)migrations
 {
   NSURL *latestURL = [directory URLByAppendingPathComponent:EXUpdatesDatabaseLatestFilename];
   if ([NSFileManager.defaultManager fileExistsAtPath:latestURL.path]) {
@@ -162,7 +175,6 @@ CREATE INDEX \"index_json_data_scope_key\" ON \"json_data\" (\"scope_key\")\
   }
 
   // find the newest database version that exists and try to migrate that file (ignore any older ones)
-  NSArray<id<EXUpdatesDatabaseMigration>> *migrations = [EXUpdatesDatabaseMigrationRegistry migrations];
   __block NSURL *existingURL;
   __block NSUInteger startingMigrationIndex;
   [migrations enumerateObjectsWithOptions:NSEnumerationReverse usingBlock:^(id<EXUpdatesDatabaseMigration> migration, NSUInteger idx, BOOL *stop) {

--- a/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabaseInitialization.m
+++ b/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabaseInitialization.m
@@ -8,7 +8,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 static NSString * const EXUpdatesDatabaseInitializationErrorDomain = @"EXUpdatesDatabaseInitialization";
-static NSString * const EXUpdatesDatabaseLatestFilename = @"expo-v5.db";
+static NSString * const EXUpdatesDatabaseLatestFilename = @"expo-v6.db";
 
 static NSString * const EXUpdatesDatabaseInitializationLatestSchema = @"\
 CREATE TABLE \"updates\" (\
@@ -17,9 +17,10 @@ CREATE TABLE \"updates\" (\
 \"commit_time\"  INTEGER NOT NULL,\
 \"runtime_version\"  TEXT NOT NULL,\
 \"launch_asset_id\" INTEGER,\
-\"metadata\"  TEXT,\
+\"manifest\"  TEXT,\
 \"status\"  INTEGER NOT NULL,\
 \"keep\"  INTEGER NOT NULL,\
+\"last_accessed\"  INTEGER NOT NULL,\
 PRIMARY KEY(\"id\"),\
 FOREIGN KEY(\"launch_asset_id\") REFERENCES \"assets\"(\"id\") ON DELETE CASCADE\
 );\

--- a/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabaseUtils.h
+++ b/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabaseUtils.h
@@ -14,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (NSError *)errorFromSqlite:(struct sqlite3 *)db;
 
-+ (NSDate *)dateFromNumber:(NSNumber *)number;
++ (NSDate *)dateFromUnixTimeMilliseconds:(NSNumber *)number;
 
 @end
 

--- a/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabaseUtils.h
+++ b/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabaseUtils.h
@@ -14,6 +14,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (NSError *)errorFromSqlite:(struct sqlite3 *)db;
 
++ (NSDate *)dateFromNumber:(NSNumber *)number;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabaseUtils.m
+++ b/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabaseUtils.m
@@ -112,6 +112,12 @@ static NSString * const EXUpdatesDatabaseUtilsErrorDomain = @"EXUpdatesDatabase"
         success = NO;
         *stop = YES;
       }
+    } else if ([obj isKindOfClass:[NSDate class]]) {
+      NSTimeInterval dateValue = [(NSDate *)obj timeIntervalSince1970] * 1000;
+      if (sqlite3_bind_int64(stmt, (int)idx + 1, (long long)dateValue) != SQLITE_OK) {
+        success = NO;
+        *stop = YES;
+      }
     } else if ([obj isKindOfClass:[NSDictionary class]]) {
       NSError *error;
       NSData *jsonData = [NSJSONSerialization dataWithJSONObject:(NSDictionary *)obj options:kNilOptions error:&error];
@@ -145,6 +151,11 @@ static NSString * const EXUpdatesDatabaseUtilsErrorDomain = @"EXUpdatesDatabase"
   return [NSError errorWithDomain:EXUpdatesDatabaseUtilsErrorDomain
                              code:extendedCode
                          userInfo:@{NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Error code %i: %@ (extended error code %i)", code, message, extendedCode]}];
+}
+
++ (NSDate *)dateFromNumber:(NSNumber *)number
+{
+  return [NSDate dateWithTimeIntervalSince1970:number.doubleValue / 1000];
 }
 
 @end

--- a/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabaseUtils.m
+++ b/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabaseUtils.m
@@ -153,7 +153,7 @@ static NSString * const EXUpdatesDatabaseUtilsErrorDomain = @"EXUpdatesDatabase"
                          userInfo:@{NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Error code %i: %@ (extended error code %i)", code, message, extendedCode]}];
 }
 
-+ (NSDate *)dateFromNumber:(NSNumber *)number
++ (NSDate *)dateFromUnixTimeMilliseconds:(NSNumber *)number
 {
   return [NSDate dateWithTimeIntervalSince1970:number.doubleValue / 1000];
 }

--- a/packages/expo-updates/ios/EXUpdates/Database/Migrations/EXUpdatesDatabaseMigration5To6.h
+++ b/packages/expo-updates/ios/EXUpdates/Database/Migrations/EXUpdatesDatabaseMigration5To6.h
@@ -1,0 +1,11 @@
+//  Copyright © 2021 650 Industries. All rights reserved.
+
+#import <EXUpdates/EXUpdatesDatabaseMigration.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface EXUpdatesDatabaseMigration5To6 : NSObject <EXUpdatesDatabaseMigration>
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/ios/EXUpdates/Database/Migrations/EXUpdatesDatabaseMigration5To6.m
+++ b/packages/expo-updates/ios/EXUpdates/Database/Migrations/EXUpdatesDatabaseMigration5To6.m
@@ -1,0 +1,23 @@
+//  Copyright © 2021 650 Industries. All rights reserved.
+
+#import <EXUpdates/EXUpdatesDatabaseMigration5To6.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+static NSString * const EXUpdatesDatabaseV5Filename = @"expo-v5.db";
+
+@implementation EXUpdatesDatabaseMigration5To6
+
+- (NSString *)filename
+{
+  return EXUpdatesDatabaseV5Filename;
+}
+
+- (BOOL)runMigrationOnDatabase:(struct sqlite3 *)db error:(NSError ** _Nullable)error
+{
+  return NO;
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/ios/EXUpdates/Database/Migrations/EXUpdatesDatabaseMigrationRegistry.m
+++ b/packages/expo-updates/ios/EXUpdates/Database/Migrations/EXUpdatesDatabaseMigrationRegistry.m
@@ -3,6 +3,7 @@
 #import <EXUpdates/EXUpdatesDatabaseMigrationRegistry.h>
 
 #import <EXUpdates/EXUpdatesDatabaseMigration4To5.h>
+#import <EXUpdates/EXUpdatesDatabaseMigration5To6.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -11,7 +12,10 @@ NS_ASSUME_NONNULL_BEGIN
 + (NSArray<id<EXUpdatesDatabaseMigration>> *)migrations
 {
   // migrations should be added here in the order they should be performed (e.g. oldest first)
-  return @[[EXUpdatesDatabaseMigration4To5 new]];
+  return @[
+    [EXUpdatesDatabaseMigration4To5 new],
+    [EXUpdatesDatabaseMigration5To6 new]
+  ];
 }
 
 @end

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate.h
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate.h
@@ -35,6 +35,7 @@ typedef NS_ENUM(NSInteger, EXUpdatesUpdateStatus) {
 @property (nonatomic, strong, readonly) EXUpdatesRawManifest *rawManifest;
 
 @property (nonatomic, assign) EXUpdatesUpdateStatus status;
+@property (nonatomic, strong) NSDate *lastAccessed;
 
 + (instancetype)updateWithId:(NSUUID *)updateId
                     scopeKey:(NSString *)scopeKey

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate.m
@@ -30,6 +30,7 @@ NSString * const EXUpdatesUpdateErrorDomain = @"EXUpdatesUpdate";
     _database = database;
     _scopeKey = config.scopeKey;
     _status = EXUpdatesUpdateStatusPending;
+    _lastAccessed = [NSDate date];
     _isDevelopmentMode = NO;
   }
   return self;

--- a/packages/expo-updates/ios/Tests/EXUpdatesDatabaseInitializationTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesDatabaseInitializationTests.m
@@ -3,6 +3,7 @@
 #import <XCTest/XCTest.h>
 
 #import <EXUpdates/EXUpdatesDatabaseInitialization+Tests.h>
+#import <EXUpdates/EXUpdatesDatabaseMigration4To5.h>
 #import <EXUpdates/EXUpdatesDatabaseUtils.h>
 
 #import <sqlite3.h>
@@ -117,6 +118,7 @@ CREATE INDEX \"index_json_data_scope_key\" ON \"json_data\" (\"scope_key\")\
                                                        filename:@"expo-v4.db"
                                                     inDirectory:_testDatabaseDir
                                                   shouldMigrate:NO
+                                                     migrations:@[]
                                                        database:&db
                                                           error:&initializeError];
   XCTAssertNil(initializeError);
@@ -148,6 +150,7 @@ CREATE INDEX \"index_json_data_scope_key\" ON \"json_data\" (\"scope_key\")\
   NSError *migrateError;
   [EXUpdatesDatabaseInitialization initializeDatabaseWithLatestSchemaInDirectory:_testDatabaseDir
                                                                         database:&migratedDb
+                                                                      migrations:@[[EXUpdatesDatabaseMigration4To5 new]]
                                                                            error:&migrateError];
   XCTAssertNil(migrateError);
 


### PR DESCRIPTION
# Why

Step 1/4 of ENG-456

For development clients including Expo Go, we'll use a different reaper selection policy that simply keeps the 10 most recently used updates across all scopes.

In order to implement this, we need to keep track of the date each update was last accessed. This first PR modifies the SQLite schema to add a `last_accessed` column to the `updates` table. The migration is currently destructive; once this and the next 2 PRs are approved and we're sure about the schema, I'll add the non-destructive migration as step 4/4.

Since we're modifying the `updates` table in this PR, I've taken the opportunity to also rename the `metadata` column to `manifest`, which more accurately reflects how it's being used now. (Currently this rename is restricted to the actual database schema; will rename the variable in the rest of the codebase in a later PR.)

# How

- Modify the database schema as above, as well as related SQL queries.
- Add a simple destructive migration on iOS; this is taken care of automatically by Room on Android.
- Added a way to run a subset of the existing migrations on iOS, in order to get the existing test to pass again (again, taken care of automatically by Room on Android).
- A few other quality of life changes on iOS (e.g. added db utils for `NSDate` objects).

# Test Plan

All existing tests pass; tested the new database functionality in later PRs.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).