### PR TITLE
[expo-updates] move scope check from Reaper to SelectionPolicyFilterAware

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Convert most remaining usages of JSON manifest to RawManifest. ([#12600](https://github.com/expo/expo/pull/12600) by [@wschurman](https://github.com/wschurman))
 - Factor out raw manifest into wrapper class. ([#12631](https://github.com/expo/expo/pull/12631) by [@wschurman](https://github.com/wschurman))
 - Remove code to handle nested root level manifest key. ([#12736](https://github.com/expo/expo/pull/12736) by [@wschurman](https://github.com/wschurman))
+- Move scope check from reaper to selection policy. ([#12769](https://github.com/expo/expo/pull/12769) by [@esamelson](https://github.com/esamelson))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/db/DatabaseIntegrityCheckTest.java
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/db/DatabaseIntegrityCheckTest.java
@@ -55,11 +55,11 @@ public class DatabaseIntegrityCheckTest {
     db.updateDao().insertUpdate(embeddedUpdate1);
     db.updateDao().insertUpdate(embeddedUpdate2);
 
-    Assert.assertEquals(2, db.updateDao().loadAllUpdatesForScope(scopeKey).size());
+    Assert.assertEquals(2, db.updateDao().loadAllUpdates().size());
 
     new DatabaseIntegrityCheck().run(db, null, embeddedUpdate2);
 
-    List<UpdateEntity> allUpdates = db.updateDao().loadAllUpdatesForScope(scopeKey);
+    List<UpdateEntity> allUpdates = db.updateDao().loadAllUpdates();
     Assert.assertEquals(1, allUpdates.size());
     Assert.assertEquals(embeddedUpdate2.id, allUpdates.get(0).id);
 
@@ -79,14 +79,14 @@ public class DatabaseIntegrityCheckTest {
     db.updateDao().insertUpdate(update1);
     db.assetDao().insertAssets(Collections.singletonList(asset1), update1);
 
-    Assert.assertEquals(1, db.updateDao().loadAllUpdatesForScope(scopeKey).size());
+    Assert.assertEquals(1, db.updateDao().loadAllUpdates().size());
     Assert.assertEquals(1, db.assetDao().loadAllAssets().size());
 
     DatabaseIntegrityCheck integrityCheck = Mockito.spy(DatabaseIntegrityCheck.class);
     Mockito.doReturn(false).when(integrityCheck).assetExists(ArgumentMatchers.any(), ArgumentMatchers.any());
     integrityCheck.run(db, context.getCacheDir(), update1);
 
-    List<UpdateEntity> allUpdates = db.updateDao().loadAllUpdatesForScope(scopeKey);
+    List<UpdateEntity> allUpdates = db.updateDao().loadAllUpdates();
     List<AssetEntity> allAssets = db.assetDao().loadAllAssets();
     Assert.assertEquals(1, allUpdates.size());
     Assert.assertEquals(UpdateStatus.PENDING, allUpdates.get(0).status);
@@ -108,14 +108,14 @@ public class DatabaseIntegrityCheckTest {
     db.updateDao().insertUpdate(update1);
     db.assetDao().insertAssets(Collections.singletonList(asset1), update1);
 
-    Assert.assertEquals(1, db.updateDao().loadAllUpdatesForScope(scopeKey).size());
+    Assert.assertEquals(1, db.updateDao().loadAllUpdates().size());
     Assert.assertEquals(1, db.assetDao().loadAllAssets().size());
 
     DatabaseIntegrityCheck integrityCheck = Mockito.spy(DatabaseIntegrityCheck.class);
     Mockito.doReturn(true).when(integrityCheck).assetExists(ArgumentMatchers.any(), ArgumentMatchers.any());
     integrityCheck.run(db, context.getCacheDir(), update1);
 
-    List<UpdateEntity> allUpdates = db.updateDao().loadAllUpdatesForScope(scopeKey);
+    List<UpdateEntity> allUpdates = db.updateDao().loadAllUpdates();
     List<AssetEntity> allAssets = db.assetDao().loadAllAssets();
     Assert.assertEquals(1, allUpdates.size());
     Assert.assertEquals(UpdateStatus.READY, allUpdates.get(0).status);

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/db/UpdatesDatabaseTest.java
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/db/UpdatesDatabaseTest.java
@@ -62,7 +62,7 @@ public class UpdatesDatabaseTest {
     Assert.assertEquals(projectId, byId.scopeKey);
 
     updateDao.deleteUpdates(Arrays.asList(testUpdate));
-    Assert.assertEquals(0, updateDao.loadAllUpdatesForScope(projectId).size());
+    Assert.assertEquals(0, updateDao.loadAllUpdates().size());
   }
 
   @Test(expected = SQLiteConstraintException.class)
@@ -97,7 +97,7 @@ public class UpdatesDatabaseTest {
     Assert.assertEquals(1, updateDao.loadLaunchableUpdatesForScope(projectId).size());
 
     updateDao.deleteUpdates(Arrays.asList(testUpdate));
-    Assert.assertEquals(0, updateDao.loadAllUpdatesForScope(projectId).size());
+    Assert.assertEquals(0, updateDao.loadAllUpdates().size());
   }
 
   @Test
@@ -130,7 +130,7 @@ public class UpdatesDatabaseTest {
     updateDao.markUpdateFinished(update3);
 
     // check that test has been properly set up
-    List<UpdateEntity> allUpdates = updateDao.loadAllUpdatesForScope(projectId);
+    List<UpdateEntity> allUpdates = updateDao.loadAllUpdates();
     Assert.assertEquals(2, allUpdates.size());
     for (UpdateEntity update : allUpdates) {
       if (update.id.equals(update2.id)) {

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/selectionpolicy/ReaperSelectionPolicyFilterAwareTest.java
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/selectionpolicy/ReaperSelectionPolicyFilterAwareTest.java
@@ -69,4 +69,16 @@ public class ReaperSelectionPolicyFilterAwareTest {
     Assert.assertFalse(updatesToDelete.contains(update4));
     Assert.assertFalse(updatesToDelete.contains(update5));
   }
+
+  @Test
+  public void testSelectUpdatesToDelete_differentScopeKey() {
+    UpdateEntity update4DifferentScope = new UpdateEntity(update4.id, update4.commitTime, update4.runtimeVersion, "differentScopeKey");
+    List<UpdateEntity> updatesToDelete = selectionPolicy.selectUpdatesToDelete(
+            Arrays.asList(update1, update2, update3, update4DifferentScope),
+            update4DifferentScope,
+            null);
+
+    // shouldn't delete any updates whose scope key doesn't match that of `launchedUpdate`
+    Assert.assertEquals(0, updatesToDelete.size());
+  }
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/Reaper.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/Reaper.java
@@ -24,7 +24,7 @@ public class Reaper {
       return;
     }
 
-    List<UpdateEntity> allUpdates = database.updateDao().loadAllUpdatesForScope(configuration.getScopeKey());
+    List<UpdateEntity> allUpdates = database.updateDao().loadAllUpdates();
 
     JSONObject manifestFilters = ManifestMetadata.getManifestFilters(database, configuration);
     List<UpdateEntity> updatesToDelete = selectionPolicy.selectUpdatesToDelete(allUpdates, launchedUpdate, manifestFilters);

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/dao/UpdateDao.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/dao/UpdateDao.java
@@ -50,8 +50,8 @@ public abstract class UpdateDao {
    * for public use
    */
 
-  @Query("SELECT * FROM updates WHERE scope_key = :scopeKey;")
-  public abstract List<UpdateEntity> loadAllUpdatesForScope(String scopeKey);
+  @Query("SELECT * FROM updates;")
+  public abstract List<UpdateEntity> loadAllUpdates();
 
   public List<UpdateEntity> loadLaunchableUpdatesForScope(String scopeKey) {
     return _loadUpdatesForProjectWithStatuses(scopeKey, Arrays.asList(UpdateStatus.READY, UpdateStatus.EMBEDDED, UpdateStatus.DEVELOPMENT));

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/selectionpolicy/ReaperSelectionPolicyFilterAware.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/selectionpolicy/ReaperSelectionPolicyFilterAware.java
@@ -12,6 +12,8 @@ import expo.modules.updates.db.entity.UpdateEntity;
  * originating from the server. If an older update is available, it will choose to keep one older
  * update in addition to the one currently running, preferring updates that match the same filters
  * if available.
+ *
+ * Chooses only to delete updates whose scope matches that of `launchedUpdate`.
  */
 public class ReaperSelectionPolicyFilterAware implements ReaperSelectionPolicy {
 
@@ -28,6 +30,10 @@ public class ReaperSelectionPolicyFilterAware implements ReaperSelectionPolicy {
     UpdateEntity nextNewestUpdate = null;
     UpdateEntity nextNewestUpdateMatchingFilters = null;
     for (UpdateEntity update : updates) {
+      // ignore any updates whose scopeKey doesn't match that of the launched update
+      if (!update.scopeKey.equals(launchedUpdate.scopeKey)) {
+        continue;
+      }
       if (update.commitTime.before(launchedUpdate.commitTime)) {
         updatesToDelete.add(update);
         if (nextNewestUpdate == null || nextNewestUpdate.commitTime.before(update.commitTime)) {

--- a/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.h
+++ b/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.h
@@ -37,8 +37,7 @@ typedef NS_ENUM(NSInteger, EXUpdatesDatabaseHashType) {
  * This method ignores the scopeKey field in the config object and returns ALL updates in the database.
  * The config object is passed along to each update object, even if its scopeKey doesn't match.
  *
- * This method should only be used to introspect the state of the database, and the update objects
- * returned should not be used for any other purpose.
+ * Updates returned from this method should not be used to launch.
  */
 - (nullable NSArray<EXUpdatesUpdate *> *)allUpdatesWithConfig:(EXUpdatesConfig *)config error:(NSError ** _Nullable)error;
 - (nullable NSArray<EXUpdatesUpdate *> *)allUpdatesWithStatus:(EXUpdatesUpdateStatus)status config:(EXUpdatesConfig *)config error:(NSError ** _Nullable)error;

--- a/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.h
+++ b/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.h
@@ -33,6 +33,13 @@ typedef NS_ENUM(NSInteger, EXUpdatesDatabaseHashType) {
 - (void)deleteUpdates:(NSArray<EXUpdatesUpdate *> *)updates error:(NSError ** _Nullable)error;
 - (nullable NSArray<EXUpdatesAsset *> *)deleteUnusedAssetsWithError:(NSError ** _Nullable)error;
 
+/**
+ * This method ignores the scopeKey field in the config object and returns ALL updates in the database.
+ * The config object is passed along to each update object, even if its scopeKey doesn't match.
+ *
+ * This method should only be used to introspect the state of the database, and the update objects
+ * returned should not be used for any other purpose.
+ */
 - (nullable NSArray<EXUpdatesUpdate *> *)allUpdatesWithConfig:(EXUpdatesConfig *)config error:(NSError ** _Nullable)error;
 - (nullable NSArray<EXUpdatesUpdate *> *)allUpdatesWithStatus:(EXUpdatesUpdateStatus)status config:(EXUpdatesConfig *)config error:(NSError ** _Nullable)error;
 - (nullable NSArray<EXUpdatesUpdate *> *)launchableUpdatesWithConfig:(EXUpdatesConfig *)config error:(NSError ** _Nullable)error;

--- a/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.m
+++ b/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.m
@@ -295,8 +295,8 @@ static NSString * const EXUpdatesDatabaseServerDefinedHeadersKey = @"serverDefin
 
 - (nullable NSArray<EXUpdatesUpdate *> *)allUpdatesWithConfig:(EXUpdatesConfig *)config error:(NSError ** _Nullable)error
 {
-  NSString * const sql = @"SELECT * FROM updates WHERE scope_key = ?1;";
-  NSArray<NSDictionary *> *rows = [self _executeSql:sql withArgs:@[config.scopeKey] error:error];
+  NSString * const sql = @"SELECT * FROM updates;";
+  NSArray<NSDictionary *> *rows = [self _executeSql:sql withArgs:nil error:error];
   if (!rows) {
     return nil;
   }

--- a/packages/expo-updates/ios/EXUpdates/SelectionPolicy/EXUpdatesReaperSelectionPolicyFilterAware.h
+++ b/packages/expo-updates/ios/EXUpdates/SelectionPolicy/EXUpdatesReaperSelectionPolicyFilterAware.h
@@ -9,6 +9,8 @@ NS_ASSUME_NONNULL_BEGIN
  * originating from the server. If an older update is available, it will choose to keep one older
  * update in addition to the one currently running, preferring updates that match the same filters
  * if available.
+ *
+ * Chooses only to delete updates who scope matches that of `launchedUpdate`.
  */
 @interface EXUpdatesReaperSelectionPolicyFilterAware : NSObject <EXUpdatesReaperSelectionPolicy>
 

--- a/packages/expo-updates/ios/EXUpdates/SelectionPolicy/EXUpdatesReaperSelectionPolicyFilterAware.m
+++ b/packages/expo-updates/ios/EXUpdates/SelectionPolicy/EXUpdatesReaperSelectionPolicyFilterAware.m
@@ -20,6 +20,10 @@ NS_ASSUME_NONNULL_BEGIN
   EXUpdatesUpdate *nextNewestUpdate;
   EXUpdatesUpdate *nextNewestUpdateMatchingFilters;
   for (EXUpdatesUpdate *update in updates) {
+    // ignore any updates whose scopeKey doesn't match that of the launched update
+    if (![launchedUpdate.scopeKey isEqualToString:update.scopeKey]) {
+      continue;
+    }
     if ([launchedUpdate.commitTime compare:update.commitTime] == NSOrderedDescending) {
       [updatesToDelete addObject:update];
       if (!nextNewestUpdate || [update.commitTime compare:nextNewestUpdate.commitTime] == NSOrderedDescending) {

--- a/packages/expo-updates/ios/Tests/EXUpdatesReaperSelectionPolicyFilterAwareTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesReaperSelectionPolicyFilterAwareTests.m
@@ -7,8 +7,10 @@
 #import <EXUpdates/EXUpdatesReaperSelectionPolicyFilterAware.h>
 #import <EXUpdates/EXUpdatesUpdate.h>
 
-@interface EXUpdatesReaperSelectionPolicyTests : XCTestCase
+@interface EXUpdatesReaperSelectionPolicyFilterAwareTests : XCTestCase
 
+@property (nonatomic, strong) EXUpdatesConfig *config;
+@property (nonatomic, strong) EXUpdatesDatabase *database;
 @property (nonatomic, strong) EXUpdatesUpdate *update1;
 @property (nonatomic, strong) EXUpdatesUpdate *update2;
 @property (nonatomic, strong) EXUpdatesUpdate *update3;
@@ -18,20 +20,20 @@
 
 @end
 
-@implementation EXUpdatesReaperSelectionPolicyTests
+@implementation EXUpdatesReaperSelectionPolicyFilterAwareTests
 
 - (void)setUp
 {
   [super setUp];
   NSString *runtimeVersion = @"1.0";
   NSString *scopeKey = @"dummyScope";
-  EXUpdatesConfig *config = [EXUpdatesConfig new];
-  EXUpdatesDatabase *database = [EXUpdatesDatabase new];
-  _update1 = [EXUpdatesUpdate updateWithId:NSUUID.UUID scopeKey:scopeKey commitTime:[NSDate dateWithTimeIntervalSince1970:1608667851] runtimeVersion:runtimeVersion metadata:nil status:EXUpdatesUpdateStatusReady keep:YES config:config database:database];
-  _update2 = [EXUpdatesUpdate updateWithId:NSUUID.UUID scopeKey:scopeKey commitTime:[NSDate dateWithTimeIntervalSince1970:1608667852] runtimeVersion:runtimeVersion metadata:nil status:EXUpdatesUpdateStatusReady keep:YES config:config database:database];
-  _update3 = [EXUpdatesUpdate updateWithId:NSUUID.UUID scopeKey:scopeKey commitTime:[NSDate dateWithTimeIntervalSince1970:1608667853] runtimeVersion:runtimeVersion metadata:nil status:EXUpdatesUpdateStatusReady keep:YES config:config database:database];
-  _update4 = [EXUpdatesUpdate updateWithId:NSUUID.UUID scopeKey:scopeKey commitTime:[NSDate dateWithTimeIntervalSince1970:1608667854] runtimeVersion:runtimeVersion metadata:nil status:EXUpdatesUpdateStatusReady keep:YES config:config database:database];
-  _update5 = [EXUpdatesUpdate updateWithId:NSUUID.UUID scopeKey:scopeKey commitTime:[NSDate dateWithTimeIntervalSince1970:1608667855] runtimeVersion:runtimeVersion metadata:nil status:EXUpdatesUpdateStatusReady keep:YES config:config database:database];
+  _config = [EXUpdatesConfig new];
+  _database = [EXUpdatesDatabase new];
+  _update1 = [EXUpdatesUpdate updateWithId:NSUUID.UUID scopeKey:scopeKey commitTime:[NSDate dateWithTimeIntervalSince1970:1608667851] runtimeVersion:runtimeVersion metadata:nil status:EXUpdatesUpdateStatusReady keep:YES config:_config database:_database];
+  _update2 = [EXUpdatesUpdate updateWithId:NSUUID.UUID scopeKey:scopeKey commitTime:[NSDate dateWithTimeIntervalSince1970:1608667852] runtimeVersion:runtimeVersion metadata:nil status:EXUpdatesUpdateStatusReady keep:YES config:_config database:_database];
+  _update3 = [EXUpdatesUpdate updateWithId:NSUUID.UUID scopeKey:scopeKey commitTime:[NSDate dateWithTimeIntervalSince1970:1608667853] runtimeVersion:runtimeVersion metadata:nil status:EXUpdatesUpdateStatusReady keep:YES config:_config database:_database];
+  _update4 = [EXUpdatesUpdate updateWithId:NSUUID.UUID scopeKey:scopeKey commitTime:[NSDate dateWithTimeIntervalSince1970:1608667854] runtimeVersion:runtimeVersion metadata:nil status:EXUpdatesUpdateStatusReady keep:YES config:_config database:_database];
+  _update5 = [EXUpdatesUpdate updateWithId:NSUUID.UUID scopeKey:scopeKey commitTime:[NSDate dateWithTimeIntervalSince1970:1608667855] runtimeVersion:runtimeVersion metadata:nil status:EXUpdatesUpdateStatusReady keep:YES config:_config database:_database];
   _selectionPolicy = [[EXUpdatesReaperSelectionPolicyFilterAware alloc] init];
 }
 
@@ -70,6 +72,15 @@
   XCTAssert(![updatesToDelete containsObject:_update3]);
   XCTAssert(![updatesToDelete containsObject:_update4]);
   XCTAssert(![updatesToDelete containsObject:_update5]);
+}
+
+- (void)testUpdatesToDelete_differentScopeKey
+{
+  EXUpdatesUpdate *update4DifferentScope = [EXUpdatesUpdate updateWithId:_update4.updateId scopeKey:@"differentScopeKey" commitTime:_update4.commitTime runtimeVersion:_update4.runtimeVersion metadata:nil status:_update4.status keep:YES config:_config database:_database];
+
+  NSArray<EXUpdatesUpdate *> *updatesToDelete = [_selectionPolicy updatesToDeleteWithLaunchedUpdate:update4DifferentScope updates:@[_update1, _update2, _update3, update4DifferentScope] filters:nil];
+
+  XCTAssertEqual(0, updatesToDelete.count);
 }
 
 @end

--- a/packages/expo-updates/ios/Tests/EXUpdatesSelectionPolicyFilterAwareTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesSelectionPolicyFilterAwareTests.m
@@ -43,7 +43,10 @@
 
   NSString *runtimeVersion = @"1.0";
   NSString *scopeKey = @"dummyScope";
-  EXUpdatesConfig *config = [EXUpdatesConfig new];
+  EXUpdatesConfig *config = [EXUpdatesConfig configWithDictionary:@{
+    @"EXUpdatesRuntimeVersion": runtimeVersion,
+    @"EXUpdatesScopeKey": scopeKey
+  }];
   EXUpdatesDatabase *database = [EXUpdatesDatabase new];
 
   _updateRollout0 = [EXUpdatesNewUpdate updateWithNewManifest:[[EXUpdatesNewRawManifest alloc] initWithRawManifestJSON:@{


### PR DESCRIPTION
# Why

Step 2/4 of ENG-456

For development clients including Expo Go, we'll use a different reaper selection policy that simply keeps the 10 most recently used updates across all scopes.

In order to do this, the Reaper needs to be aware of all updates, rather than just the ones matching the current scope. This PR moves the scope filtering from Reaper to the current ReaperSelectionPolicyFilterAware; this way, individual selection policies can decide whether or not to filter based on the current scope.

# How

- Remove scopeKey filtering from the `allUpdates` function that Reaper uses to load all updates before choosing which ones to delete.
- In ReaperSelectionPolicyFilterAware, never choose to delete any updates whose scopeKey doesn't match the currently launched update.

# Test Plan

All existing tests pass; added one more unit test to ensure ReaperSelectionPolicyFilterAware ignores updates whose scopeKey doesn't match the currently launched update (fails before this diff, passes after).

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).