### PR TITLE
[expo-updates][ios][android] add ReaperSelectionPolicyDevelopmentClient, implement in Expo Go

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.java
+++ b/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.java
@@ -26,6 +26,9 @@ import expo.modules.updates.db.DatabaseHolder;
 import expo.modules.updates.db.entity.UpdateEntity;
 import expo.modules.updates.launcher.Launcher;
 import expo.modules.updates.launcher.NoDatabaseLauncher;
+import expo.modules.updates.selectionpolicy.LauncherSelectionPolicyFilterAware;
+import expo.modules.updates.selectionpolicy.LoaderSelectionPolicyFilterAware;
+import expo.modules.updates.selectionpolicy.ReaperSelectionPolicyDevelopmentClient;
 import expo.modules.updates.selectionpolicy.SelectionPolicy;
 import expo.modules.updates.loader.EmbeddedLoader;
 import expo.modules.updates.loader.FileDownloader;
@@ -33,7 +36,6 @@ import expo.modules.updates.loader.LoaderTask;
 import expo.modules.updates.manifest.Manifest;
 import expo.modules.updates.manifest.ManifestFactory;
 import expo.modules.updates.manifest.raw.RawManifest;
-import expo.modules.updates.selectionpolicy.SelectionPolicyFactory;
 import host.exp.exponent.di.NativeModuleDepsProvider;
 import host.exp.exponent.exceptions.ManifestException;
 import host.exp.exponent.kernel.ExpoViewKernel;
@@ -202,7 +204,11 @@ public class ExpoUpdatesAppLoader {
     for (String sdkVersion : Constants.SDK_VERSIONS_LIST) {
       sdkVersionsList.add("exposdk:" + sdkVersion);
     }
-    SelectionPolicy selectionPolicy = SelectionPolicyFactory.createFilterAwarePolicy(sdkVersionsList);
+    SelectionPolicy selectionPolicy = new SelectionPolicy(
+            new LauncherSelectionPolicyFilterAware(sdkVersionsList),
+            new LoaderSelectionPolicyFilterAware(),
+            new ReaperSelectionPolicyDevelopmentClient()
+    );
 
     File directory;
     try {

--- a/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
+++ b/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
@@ -18,8 +18,11 @@
 #import <EXUpdates/EXUpdatesConfig.h>
 #import <EXUpdates/EXUpdatesDatabase.h>
 #import <EXUpdates/EXUpdatesFileDownloader.h>
+#import <EXUpdates/EXUpdatesLauncherSelectionPolicyFilterAware.h>
+#import <EXUpdates/EXUpdatesLoaderSelectionPolicyFilterAware.h>
 #import <EXUpdates/EXUpdatesReaper.h>
-#import <EXUpdates/EXUpdatesSelectionPolicyFactory.h>
+#import <EXUpdates/EXUpdatesReaperSelectionPolicyDevelopmentClient.h>
+#import <EXUpdates/EXUpdatesSelectionPolicy.h>
 #import <EXUpdates/EXUpdatesUtils.h>
 #import <React/RCTUtils.h>
 #import <sys/utsname.h>
@@ -349,7 +352,10 @@ NS_ASSUME_NONNULL_BEGIN
   }
   [sdkVersions addObjectsFromArray:sdkVersionRuntimeVersions];
 
-  _selectionPolicy = [EXUpdatesSelectionPolicyFactory filterAwarePolicyWithRuntimeVersions:sdkVersions];
+  _selectionPolicy = [[EXUpdatesSelectionPolicy alloc]
+                      initWithLauncherSelectionPolicy:[[EXUpdatesLauncherSelectionPolicyFilterAware alloc] initWithRuntimeVersions:sdkVersions]
+                      loaderSelectionPolicy:[EXUpdatesLoaderSelectionPolicyFilterAware new]
+                      reaperSelectionPolicy:[EXUpdatesReaperSelectionPolicyDevelopmentClient new]];
 
   EXUpdatesAppLoaderTask *loaderTask = [[EXUpdatesAppLoaderTask alloc] initWithConfig:_config
                                                                              database:updatesDatabaseManager.database

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Factor out raw manifest into wrapper class. ([#12631](https://github.com/expo/expo/pull/12631) by [@wschurman](https://github.com/wschurman))
 - Remove code to handle nested root level manifest key. ([#12736](https://github.com/expo/expo/pull/12736) by [@wschurman](https://github.com/wschurman))
 - Move scope check from reaper to selection policy. ([#12769](https://github.com/expo/expo/pull/12769) by [@esamelson](https://github.com/esamelson))
+- Add ReaperSelectionPolicyDevelopmentClient, implement in Expo Go. ([#12770](https://github.com/expo/expo/pull/12770) by [@esamelson](https://github.com/esamelson))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/launcher/DatabaseLauncherTest.java
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/launcher/DatabaseLauncherTest.java
@@ -1,0 +1,69 @@
+package expo.modules.updates.launcher;
+
+import android.content.Context;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.Date;
+import java.util.UUID;
+
+import androidx.room.Room;
+import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner;
+import androidx.test.platform.app.InstrumentationRegistry;
+
+import expo.modules.updates.db.UpdatesDatabase;
+import expo.modules.updates.db.entity.AssetEntity;
+import expo.modules.updates.db.entity.UpdateEntity;
+
+@RunWith(AndroidJUnit4ClassRunner.class)
+public class DatabaseLauncherTest {
+  private Context context;
+  private UpdatesDatabase db;
+
+  @Before
+  public void createDb() {
+    context = InstrumentationRegistry.getInstrumentation().getTargetContext();
+    db = Room.inMemoryDatabaseBuilder(context, UpdatesDatabase.class).build();
+  }
+
+  @After
+  public void closeDb() {
+    db.close();
+  }
+
+  @Test
+  public void testLaunch_MarkUpdateAccessed() {
+    UpdateEntity testUpdate = new UpdateEntity(UUID.randomUUID(), new Date(), "1.0", "scopeKey");
+    testUpdate.lastAccessed = new Date(new Date().getTime() - 24 * 60 * 60 * 1000); // yesterday
+    db.updateDao().insertUpdate(testUpdate);
+
+    AssetEntity testAsset = new AssetEntity("bundle-1234", "js");
+    testAsset.relativePath = "bundle-1234";
+    testAsset.isLaunchAsset = true;
+    db.assetDao().insertAssets(Collections.singletonList(testAsset), testUpdate);
+
+    DatabaseLauncher launcher = new DatabaseLauncher(null, null, null, null);
+    DatabaseLauncher spyLauncher = Mockito.spy(launcher);
+    Mockito.doReturn(db.updateDao().loadUpdateWithId(testUpdate.id))
+            .when(spyLauncher).getLaunchableUpdate(ArgumentMatchers.any(), ArgumentMatchers.any());
+
+    File mockedFile = new File(context.getCacheDir(), "test");
+    Mockito.doReturn(mockedFile).when(spyLauncher).ensureAssetExists(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any());
+
+    Launcher.LauncherCallback mockedCallback = Mockito.mock(Launcher.LauncherCallback.class);
+    spyLauncher.launch(db, context, mockedCallback);
+    Mockito.verify(mockedCallback).onSuccess();
+
+    UpdateEntity sameUpdate = db.updateDao().loadUpdateWithId(testUpdate.id);
+    Assert.assertNotEquals(testUpdate.lastAccessed, sameUpdate.lastAccessed);
+    Assert.assertTrue("new lastAccessed date should be within 1000 ms of now", new Date().getTime() - sameUpdate.lastAccessed.getTime() < 1000);
+  }
+}

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/selectionpolicy/ReaperSelectionPolicyDevelopmentClientTest.java
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/selectionpolicy/ReaperSelectionPolicyDevelopmentClientTest.java
@@ -1,0 +1,108 @@
+package expo.modules.updates.selectionpolicy;
+
+import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+
+import expo.modules.updates.db.entity.UpdateEntity;
+
+@RunWith(AndroidJUnit4ClassRunner.class)
+public class ReaperSelectionPolicyDevelopmentClientTest {
+  String runtimeVersion = "1.0";
+
+  // test updates with different scopes to ensure this policy ignores scopes
+  UpdateEntity update1 = new UpdateEntity(UUID.randomUUID(), new Date(1608667857774L), runtimeVersion, "scope1");
+  UpdateEntity update2 = new UpdateEntity(UUID.randomUUID(), new Date(1608667857775L), runtimeVersion, "scope2");
+  UpdateEntity update3 = new UpdateEntity(UUID.randomUUID(), new Date(1608667857776L), runtimeVersion, "scope3");
+  UpdateEntity update4 = new UpdateEntity(UUID.randomUUID(), new Date(1608667857777L), runtimeVersion, "scope4");
+  UpdateEntity update5 = new UpdateEntity(UUID.randomUUID(), new Date(1608667857778L), runtimeVersion, "scope5");
+
+  // for readability/writability, test with a policy that keeps only 3 updates;
+  // the actual functionality is independent of the number
+  ReaperSelectionPolicy selectionPolicy = new ReaperSelectionPolicyDevelopmentClient(3);
+
+  @Test
+  public void testSelectUpdatesToDelete_BasicCase() {
+    update1.lastAccessed = new Date(1619569813251L);
+    update2.lastAccessed = new Date(1619569813252L);
+    update3.lastAccessed = new Date(1619569813253L);
+    update4.lastAccessed = new Date(1619569813254L);
+    update5.lastAccessed = new Date(1619569813255L);
+
+    List<UpdateEntity> updatesToDelete = selectionPolicy.selectUpdatesToDelete(
+            // the order of the list shouldn't matter
+            Arrays.asList(update2, update5, update4, update1, update3),
+            update5,
+            null);
+
+    Assert.assertEquals(2, updatesToDelete.size());
+    Assert.assertTrue(updatesToDelete.contains(update1));
+    Assert.assertTrue(updatesToDelete.contains(update2));
+  }
+
+  @Test
+  public void testSelectUpdatesToDelete_SameLastAccessedDate() {
+    // if multiple updates have the same lastAccessed date, should use commitTime to determine
+    // which updates to delete
+    update1.lastAccessed = new Date(1619569813250L);
+    update2.lastAccessed = new Date(1619569813250L);
+    update3.lastAccessed = new Date(1619569813250L);
+    update4.lastAccessed = new Date(1619569813250L);
+
+    List<UpdateEntity> updatesToDelete = selectionPolicy.selectUpdatesToDelete(
+            Arrays.asList(update3, update4, update1, update2),
+            update4,
+            null);
+
+    Assert.assertEquals(1, updatesToDelete.size());
+    Assert.assertTrue(updatesToDelete.contains(update1));
+  }
+
+  @Test
+  public void testSelectUpdatesToDelete_LaunchedUpdateIsOldest() {
+    // if the least recently accessed update happens to be launchedUpdate, delete instead the next
+    // least recently accessed update
+    update1.lastAccessed = new Date(1619569813251L);
+    update2.lastAccessed = new Date(1619569813252L);
+    update3.lastAccessed = new Date(1619569813253L);
+    update4.lastAccessed = new Date(1619569813254L);
+
+    List<UpdateEntity> updatesToDelete = selectionPolicy.selectUpdatesToDelete(
+            Arrays.asList(update1, update2, update3, update4),
+            update1,
+            null);
+
+    Assert.assertEquals(1, updatesToDelete.size());
+    Assert.assertTrue(updatesToDelete.contains(update2));
+  }
+
+  @Test
+  public void testSelectUpdatesToDelete_NoLaunchedUpdate() {
+    // if launchedUpdate is null, something has gone wrong, so don't delete anything
+    List<UpdateEntity> updatesToDelete = selectionPolicy.selectUpdatesToDelete(
+            Arrays.asList(update1, update2, update3, update4),
+            null,
+            null);
+    Assert.assertEquals(0, updatesToDelete.size());
+  }
+
+  @Test
+  public void testSelectUpdatesToDelete_BelowMaxNumber() {
+    // no need to delete any updates if we have <= the max number of updates
+    Assert.assertEquals(0, selectionPolicy.selectUpdatesToDelete(
+            Arrays.asList(update1, update2),
+            update2,
+            null).size());
+    Assert.assertEquals(0, selectionPolicy.selectUpdatesToDelete(
+            Arrays.asList(update1, update2, update3),
+            update3,
+            null).size());
+  }
+}

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/dao/UpdateDao.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/dao/UpdateDao.java
@@ -8,6 +8,7 @@ import expo.modules.updates.db.entity.UpdateEntity;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 
@@ -93,6 +94,11 @@ public abstract class UpdateDao {
 
   public void markUpdateFinished(UpdateEntity update) {
     markUpdateFinished(update, false);
+  }
+
+  public void markUpdateAccessed(UpdateEntity update) {
+    update.lastAccessed = new Date();
+    _updateUpdate(update);
   }
 
   public void markUpdatesWithMissingAssets(List<AssetEntity> missingAssets) {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/DatabaseLauncher.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/DatabaseLauncher.java
@@ -84,6 +84,8 @@ public class DatabaseLauncher implements Launcher {
       return;
     }
 
+    database.updateDao().markUpdateAccessed(mLaunchedUpdate);
+
     if (mLaunchedUpdate.status == UpdateStatus.EMBEDDED) {
       mBundleAssetName = EmbeddedLoader.BARE_BUNDLE_FILENAME;
       if (mLocalAssetFiles != null) {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/DatabaseLauncher.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/DatabaseLauncher.java
@@ -156,7 +156,7 @@ public class DatabaseLauncher implements Launcher {
     return mSelectionPolicy.selectUpdateToLaunch(filteredLaunchableUpdates, manifestFilters);
   }
 
-  private File ensureAssetExists(AssetEntity asset, UpdatesDatabase database, Context context) {
+  /* package */ File ensureAssetExists(AssetEntity asset, UpdatesDatabase database, Context context) {
     File assetFile = new File(mUpdatesDirectory, asset.relativePath);
     boolean assetFileExists = assetFile.exists();
     if (!assetFileExists) {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/selectionpolicy/ReaperSelectionPolicyDevelopmentClient.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/selectionpolicy/ReaperSelectionPolicyDevelopmentClient.java
@@ -46,11 +46,17 @@ public class ReaperSelectionPolicyDevelopmentClient implements ReaperSelectionPo
     });
 
     List<UpdateEntity> updatesToDelete = new ArrayList<>();
+    boolean hasFoundLaunchedUpdate = false;
     while (updatesMutable.size() > mMaxUpdatesToKeep) {
       UpdateEntity oldest = updatesMutable.remove(0);
       if (oldest.id.equals(launchedUpdate.id)) {
+        if (hasFoundLaunchedUpdate) {
+          // avoid infinite loop
+          throw new AssertionError("Multiple updates with the same ID were passed into ReaperSelectionPolicyDevelopmentClient");
+        }
         // we don't want to delete launchedUpdate, so put it back on the end of the stack
         updatesMutable.add(oldest);
+        hasFoundLaunchedUpdate = true;
       } else {
         updatesToDelete.add(oldest);
       }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/selectionpolicy/ReaperSelectionPolicyDevelopmentClient.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/selectionpolicy/ReaperSelectionPolicyDevelopmentClient.java
@@ -24,6 +24,9 @@ public class ReaperSelectionPolicyDevelopmentClient implements ReaperSelectionPo
   }
 
   public ReaperSelectionPolicyDevelopmentClient(int maxUpdatesToKeep) {
+    if (maxUpdatesToKeep <= 0) {
+      throw new AssertionError("Cannot initialize ReaperSelectionPolicyDevelopmentClient with maxUpdatesToKeep <= 0");
+    }
     mMaxUpdatesToKeep = maxUpdatesToKeep;
   }
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/selectionpolicy/ReaperSelectionPolicyDevelopmentClient.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/selectionpolicy/ReaperSelectionPolicyDevelopmentClient.java
@@ -1,0 +1,58 @@
+package expo.modules.updates.selectionpolicy;
+
+import org.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import expo.modules.updates.db.entity.UpdateEntity;
+
+/**
+ * ReaperSelectionPolicy which keeps a predefined maximum number of updates across all scopes, and,
+ * once that number is surpassed, selects the updates least recently accessed (and then least
+ * recently published) to delete. Ignores filters and scopes.
+ */
+public class ReaperSelectionPolicyDevelopmentClient implements ReaperSelectionPolicy {
+
+  private static final int DEFAULT_MAX_UPDATES_TO_KEEP = 10;
+
+  private int mMaxUpdatesToKeep;
+
+  public ReaperSelectionPolicyDevelopmentClient() {
+    this(DEFAULT_MAX_UPDATES_TO_KEEP);
+  }
+
+  public ReaperSelectionPolicyDevelopmentClient(int maxUpdatesToKeep) {
+    mMaxUpdatesToKeep = maxUpdatesToKeep;
+  }
+
+  @Override
+  public List<UpdateEntity> selectUpdatesToDelete(List<UpdateEntity> updates, UpdateEntity launchedUpdate, JSONObject filters) {
+    if (launchedUpdate == null || updates.size() <= mMaxUpdatesToKeep) {
+      return new ArrayList<>();
+    }
+
+    List<UpdateEntity> updatesMutable = new ArrayList<>(updates);
+    Collections.sort(updatesMutable, (u1, u2) -> {
+      int compare = u1.lastAccessed.compareTo(u2.lastAccessed);
+      if (compare == 0) {
+        compare = u1.commitTime.compareTo(u2.commitTime);
+      }
+      return compare;
+    });
+
+    List<UpdateEntity> updatesToDelete = new ArrayList<>();
+    while (updatesMutable.size() > mMaxUpdatesToKeep) {
+      UpdateEntity oldest = updatesMutable.remove(0);
+      if (oldest.id.equals(launchedUpdate.id)) {
+        // we don't want to delete launchedUpdate, so put it back on the end of the stack
+        updatesMutable.add(oldest);
+      } else {
+        updatesToDelete.add(oldest);
+      }
+    }
+
+    return updatesToDelete;
+  }
+}

--- a/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesAppLauncherWithDatabase+Tests.h
+++ b/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesAppLauncherWithDatabase+Tests.h
@@ -1,0 +1,16 @@
+// Copyright 2021-present 650 Industries. All rights reserved.
+
+#import <EXUpdates/EXUpdatesAppLauncherWithDatabase.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface EXUpdatesAppLauncherWithDatabase (Tests)
+
+@property (nonatomic, copy, readonly) EXUpdatesAppLauncherCompletionBlock completion;
+@property (nonatomic, strong, readonly) dispatch_queue_t completionQueue;
+
+- (void)_ensureAllAssetsExist;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesAppLauncherWithDatabase.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesAppLauncherWithDatabase.m
@@ -1,6 +1,6 @@
 //  Copyright © 2019 650 Industries. All rights reserved.
 
-#import <EXUpdates/EXUpdatesAppLauncherWithDatabase.h>
+#import <EXUpdates/EXUpdatesAppLauncherWithDatabase+Tests.h>
 #import <EXUpdates/EXUpdatesEmbeddedAppLoader.h>
 #import <EXUpdates/EXUpdatesDatabase.h>
 #import <EXUpdates/EXUpdatesFileDownloader.h>

--- a/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesAppLauncherWithDatabase.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesAppLauncherWithDatabase.m
@@ -109,19 +109,23 @@ static NSString * const EXUpdatesAppLauncherErrorDomain = @"AppLauncher";
         }
       } else {
         self->_launchedUpdate = launchableUpdate;
-        [self _markUpdateAccessed];
-        [self _ensureAllAssetsExist];
+        [self _finishLaunch];
       }
     } completionQueue:_launcherQueue];
   } else {
-    [self _markUpdateAccessed];
-    [self _ensureAllAssetsExist];
+    [self _finishLaunch];
   }
 }
 
 - (BOOL)isUsingEmbeddedAssets
 {
   return _assetFilesMap == nil;
+}
+
+- (void)_finishLaunch
+{
+  [self _markUpdateAccessed];
+  [self _ensureAllAssetsExist];
 }
 
 - (void)_markUpdateAccessed

--- a/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.h
+++ b/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.h
@@ -27,6 +27,7 @@ typedef NS_ENUM(NSInteger, EXUpdatesDatabaseHashType) {
 - (void)updateAsset:(EXUpdatesAsset *)asset error:(NSError ** _Nullable)error;
 - (void)mergeAsset:(EXUpdatesAsset *)asset withExistingEntry:(EXUpdatesAsset *)existingAsset error:(NSError ** _Nullable)error;
 - (void)markUpdateFinished:(EXUpdatesUpdate *)update error:(NSError ** _Nullable)error;
+- (void)markUpdateAccessed:(EXUpdatesUpdate *)update error:(NSError ** _Nullable)error;
 - (void)setScopeKey:(NSString *)scopeKey onUpdate:(EXUpdatesUpdate *)update error:(NSError ** _Nullable)error;
 - (void)markMissingAssets:(NSArray<EXUpdatesAsset *> *)assets error:(NSError ** _Nullable)error;
 

--- a/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.m
+++ b/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.m
@@ -203,6 +203,13 @@ static NSString * const EXUpdatesDatabaseServerDefinedHeadersKey = @"serverDefin
               error:error];
 }
 
+- (void)markUpdateAccessed:(EXUpdatesUpdate *)update error:(NSError ** _Nullable)error
+{
+  update.lastAccessed = [NSDate date];
+  NSString * const updateSql = @"UPDATE updates SET last_accessed = ?1 WHERE id = ?2;";
+  [self _executeSql:updateSql withArgs:@[update.lastAccessed, update.updateId] error:error];
+}
+
 - (void)setScopeKey:(NSString *)scopeKey onUpdate:(EXUpdatesUpdate *)update error:(NSError ** _Nullable)error
 {
   NSString * const updateSql = @"UPDATE updates SET scope_key = ?1 WHERE id = ?2;";

--- a/packages/expo-updates/ios/EXUpdates/SelectionPolicy/EXUpdatesReaperSelectionPolicyDevelopmentClient.h
+++ b/packages/expo-updates/ios/EXUpdates/SelectionPolicy/EXUpdatesReaperSelectionPolicyDevelopmentClient.h
@@ -1,0 +1,18 @@
+//  Copyright © 2021 650 Industries. All rights reserved.
+
+#import <EXUpdates/EXUpdatesReaperSelectionPolicy.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * An EXUpdatesReaperSelectionPolicy which keeps a predefined maximum number of updates across all scopes,
+ * and, once that number is surpassed, selects the updates least recently accessed (and then least
+ * recently published) to delete. Ignores filters and scopes.
+ */
+@interface EXUpdatesReaperSelectionPolicyDevelopmentClient : NSObject <EXUpdatesReaperSelectionPolicy>
+
+- (instancetype)initWithMaxUpdatesToKeep:(NSUInteger)maxUpdatesToKeep;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/ios/EXUpdates/SelectionPolicy/EXUpdatesReaperSelectionPolicyDevelopmentClient.m
+++ b/packages/expo-updates/ios/EXUpdates/SelectionPolicy/EXUpdatesReaperSelectionPolicyDevelopmentClient.m
@@ -49,12 +49,18 @@ static NSUInteger const EXUpdatesReaperSelectionPolicyDefaultMaxUpdates = 10;
   }].mutableCopy;
 
   NSMutableArray<EXUpdatesUpdate *> *updatesToDelete = [NSMutableArray new];
+  BOOL hasFoundLaunchedUpdate = NO;
   while (updatesMutable.count > _maxUpdatesToKeep) {
     EXUpdatesUpdate *oldest = updatesMutable[0];
     [updatesMutable removeObjectAtIndex:0];
     if ([launchedUpdate.updateId isEqual:oldest.updateId]) {
+      if (hasFoundLaunchedUpdate) {
+        // avoid infinite loop
+        @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:@"Multiple updates with the same ID were passed into EXUpdatesReaperSelectionPolicyDevelopmentClient" userInfo:nil];
+      }
       // we don't want to delete launchedUpdate, so put it back on the end of the stack
       [updatesMutable addObject:oldest];
+      hasFoundLaunchedUpdate = YES;
     } else {
       [updatesToDelete addObject:oldest];
     }

--- a/packages/expo-updates/ios/EXUpdates/SelectionPolicy/EXUpdatesReaperSelectionPolicyDevelopmentClient.m
+++ b/packages/expo-updates/ios/EXUpdates/SelectionPolicy/EXUpdatesReaperSelectionPolicyDevelopmentClient.m
@@ -22,6 +22,11 @@ static NSUInteger const EXUpdatesReaperSelectionPolicyDefaultMaxUpdates = 10;
 - (instancetype)initWithMaxUpdatesToKeep:(NSUInteger)maxUpdatesToKeep
 {
   if (self = [super init]) {
+    if (maxUpdatesToKeep <= 0) {
+      @throw [NSException exceptionWithName:NSInvalidArgumentException
+                                     reason:@"Cannot initiailize EXUpdatesReaperSelectionPolicy with maxUpdatesToKeep <= 0"
+                                   userInfo:nil];
+    }
     _maxUpdatesToKeep = maxUpdatesToKeep;
   }
   return self;

--- a/packages/expo-updates/ios/EXUpdates/SelectionPolicy/EXUpdatesReaperSelectionPolicyDevelopmentClient.m
+++ b/packages/expo-updates/ios/EXUpdates/SelectionPolicy/EXUpdatesReaperSelectionPolicyDevelopmentClient.m
@@ -1,0 +1,63 @@
+//  Copyright © 2021 650 Industries. All rights reserved.
+
+#import <EXUpdates/EXUpdatesReaperSelectionPolicyDevelopmentClient.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+static NSUInteger const EXUpdatesReaperSelectionPolicyDefaultMaxUpdates = 10;
+
+@interface EXUpdatesReaperSelectionPolicyDevelopmentClient ()
+
+@property (nonatomic, assign) NSUInteger maxUpdatesToKeep;
+
+@end
+
+@implementation EXUpdatesReaperSelectionPolicyDevelopmentClient
+
+- (instancetype)init
+{
+  return [self initWithMaxUpdatesToKeep:EXUpdatesReaperSelectionPolicyDefaultMaxUpdates];
+}
+
+- (instancetype)initWithMaxUpdatesToKeep:(NSUInteger)maxUpdatesToKeep
+{
+  if (self = [super init]) {
+    _maxUpdatesToKeep = maxUpdatesToKeep;
+  }
+  return self;
+}
+
+- (NSArray<EXUpdatesUpdate *> *)updatesToDeleteWithLaunchedUpdate:(EXUpdatesUpdate *)launchedUpdate updates:(NSArray<EXUpdatesUpdate *> *)updates filters:(nullable NSDictionary *)filters
+{
+  if (!launchedUpdate || updates.count <= _maxUpdatesToKeep) {
+    return @[];
+  }
+
+  NSMutableArray<EXUpdatesUpdate *> *updatesMutable = [updates sortedArrayUsingComparator:^NSComparisonResult(id obj1, id obj2) {
+    EXUpdatesUpdate *update1 = (EXUpdatesUpdate *)obj1;
+    EXUpdatesUpdate *update2 = (EXUpdatesUpdate *)obj2;
+    NSComparisonResult result = [update1.lastAccessed compare:update2.lastAccessed];
+    if (result == NSOrderedSame) {
+      result = [update1.commitTime compare:update2.commitTime];
+    }
+    return result;
+  }].mutableCopy;
+
+  NSMutableArray<EXUpdatesUpdate *> *updatesToDelete = [NSMutableArray new];
+  while (updatesMutable.count > _maxUpdatesToKeep) {
+    EXUpdatesUpdate *oldest = updatesMutable[0];
+    [updatesMutable removeObjectAtIndex:0];
+    if ([launchedUpdate.updateId isEqual:oldest.updateId]) {
+      // we don't want to delete launchedUpdate, so put it back on the end of the stack
+      [updatesMutable addObject:oldest];
+    } else {
+      [updatesToDelete addObject:oldest];
+    }
+  }
+
+  return updatesToDelete;
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/ios/Tests/EXUpdatesAppLauncherWithDatabaseTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesAppLauncherWithDatabaseTests.m
@@ -1,0 +1,134 @@
+//  Copyright (c) 2021 650 Industries, Inc. All rights reserved.
+
+#import <XCTest/XCTest.h>
+
+#import <EXUpdates/EXUpdatesAppLauncherWithDatabase+Tests.h>
+#import <EXUpdates/EXUpdatesConfig.h>
+#import <EXUpdates/EXUpdatesDatabase.h>
+#import <EXUpdates/EXUpdatesSelectionPolicy.h>
+
+@interface EXUpdatesAppLauncherWithDatabaseMock : EXUpdatesAppLauncherWithDatabase
+
++ (EXUpdatesUpdate *)testUpdate;
+
+@end
+
+@implementation EXUpdatesAppLauncherWithDatabaseMock
+
++ (EXUpdatesUpdate *)testUpdate
+{
+  static EXUpdatesUpdate *theUpdate;
+  static dispatch_once_t once;
+  dispatch_once(&once, ^{
+    if (!theUpdate) {
+      NSString *runtimeVersion = @"1.0";
+      NSString *scopeKey = @"dummyScope";
+      EXUpdatesConfig *config = [EXUpdatesConfig new];
+      EXUpdatesDatabase *database = [EXUpdatesDatabase new];
+      theUpdate = [EXUpdatesUpdate updateWithId:NSUUID.UUID scopeKey:scopeKey commitTime:[NSDate dateWithTimeIntervalSince1970:1608667851] runtimeVersion:runtimeVersion metadata:nil status:EXUpdatesUpdateStatusReady keep:YES config:config database:database];
+    }
+  });
+  return theUpdate;
+}
+
++ (void)launchableUpdateWithConfig:(EXUpdatesConfig *)config
+                          database:(EXUpdatesDatabase *)database
+                   selectionPolicy:(EXUpdatesSelectionPolicy *)selectionPolicy
+                        completion:(EXUpdatesAppLauncherUpdateCompletionBlock)completion
+                   completionQueue:(dispatch_queue_t)completionQueue
+{
+  completion(nil, [[self class] testUpdate]);
+}
+
+- (void)_ensureAllAssetsExist
+{
+  dispatch_async(self.completionQueue, ^{
+    self.completion(nil, YES);
+  });
+}
+
+@end
+
+@interface EXUpdatesAppLauncherWithDatabaseTests : XCTestCase
+
+@property (nonatomic, strong) EXUpdatesDatabase *db;
+@property (nonatomic, strong) NSURL *testDatabaseDir;
+
+@end
+
+@implementation EXUpdatesAppLauncherWithDatabaseTests
+
+- (void)setUp
+{
+  NSURL *applicationSupportDir = [NSFileManager.defaultManager URLsForDirectory:NSApplicationSupportDirectory inDomains:NSUserDomainMask].lastObject;
+  _testDatabaseDir = [applicationSupportDir URLByAppendingPathComponent:@"EXUpdatesDatabaseTests"];
+  if ([NSFileManager.defaultManager fileExistsAtPath:_testDatabaseDir.path]) {
+    NSError *error;
+    [NSFileManager.defaultManager removeItemAtPath:_testDatabaseDir.path error:&error];
+    XCTAssertNil(error);
+  }
+  NSError *error;
+  [NSFileManager.defaultManager createDirectoryAtPath:_testDatabaseDir.path withIntermediateDirectories:YES attributes:nil error:&error];
+  XCTAssertNil(error);
+
+  _db = [[EXUpdatesDatabase alloc] init];
+  dispatch_sync(_db.databaseQueue, ^{
+    NSError *dbOpenError;
+    [_db openDatabaseInDirectory:_testDatabaseDir withError:&dbOpenError];
+    XCTAssertNil(dbOpenError);
+  });
+}
+
+- (void)tearDown
+{
+  dispatch_sync(_db.databaseQueue, ^{
+    [_db closeDatabase];
+  });
+  NSError *error;
+  [NSFileManager.defaultManager removeItemAtPath:_testDatabaseDir.path error:&error];
+  XCTAssertNil(error);
+}
+
+- (void)testExample
+{
+  EXUpdatesUpdate *testUpdate = [EXUpdatesAppLauncherWithDatabaseMock testUpdate];
+  NSDate *yesterday = [NSDate dateWithTimeIntervalSinceNow:24 * 60 * 60 * -1];
+  testUpdate.lastAccessed = yesterday;
+  dispatch_sync(_db.databaseQueue, ^{
+    NSError *error1;
+    [_db addUpdate:testUpdate error:&error1];
+    XCTAssertNil(error1);
+  });
+
+  EXUpdatesAsset *testAsset = [[EXUpdatesAsset alloc] initWithKey:@"bundle-1234" type:@"js"];
+  testAsset.isLaunchAsset = YES;
+  testAsset.downloadTime = [NSDate date];
+  testAsset.contentHash = @"blah";
+  dispatch_sync(_db.databaseQueue, ^{
+    NSError *error2;
+    [_db addNewAssets:@[testAsset] toUpdateWithId:testUpdate.updateId error:&error2];
+    XCTAssertNil(error2);
+  });
+
+  __block NSNumber *successValue;
+  EXUpdatesAppLauncherWithDatabase *launcher = [[EXUpdatesAppLauncherWithDatabaseMock alloc] initWithConfig:[EXUpdatesConfig new] database:_db directory:_testDatabaseDir completionQueue:dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)];
+  [launcher launchUpdateWithSelectionPolicy:[EXUpdatesSelectionPolicy new] completion:^(NSError * _Nullable error, BOOL success) {
+    successValue = @(success);
+  }];
+
+  while (!successValue) {
+    sleep(0.1);
+  }
+
+  XCTAssertTrue(successValue.boolValue);
+
+  dispatch_sync(_db.databaseQueue, ^{
+    NSError *error3;
+    EXUpdatesUpdate *sameUpdate = [_db updateWithId:testUpdate.updateId config:[EXUpdatesConfig new] error:&error3];
+    XCTAssertNil(error3);
+    XCTAssertNotEqualObjects(yesterday, sameUpdate.lastAccessed);
+    XCTAssertTrue(fabs(sameUpdate.lastAccessed.timeIntervalSinceNow) < 1, @"new lastAccessed date should be within 1 second of now");
+  });
+}
+
+@end

--- a/packages/expo-updates/ios/Tests/EXUpdatesReaperSelectionPolicyDevelopmentClientTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesReaperSelectionPolicyDevelopmentClientTests.m
@@ -1,0 +1,112 @@
+//  Copyright (c) 2021 650 Industries, Inc. All rights reserved.
+
+#import <XCTest/XCTest.h>
+
+#import <EXUpdates/EXUpdatesConfig.h>
+#import <EXUpdates/EXUpdatesDatabase.h>
+#import <EXUpdates/EXUpdatesReaperSelectionPolicyDevelopmentClient.h>
+#import <EXUpdates/EXUpdatesUpdate.h>
+
+@interface EXUpdatesReaperSelectionPolicyDevelopmentClientTests : XCTestCase
+
+@property (nonatomic, strong) EXUpdatesUpdate *update1;
+@property (nonatomic, strong) EXUpdatesUpdate *update2;
+@property (nonatomic, strong) EXUpdatesUpdate *update3;
+@property (nonatomic, strong) EXUpdatesUpdate *update4;
+@property (nonatomic, strong) EXUpdatesUpdate *update5;
+@property (nonatomic, strong) id<EXUpdatesReaperSelectionPolicy> selectionPolicy;
+
+@end
+
+@implementation EXUpdatesReaperSelectionPolicyDevelopmentClientTests
+
+- (void)setUp
+{
+  [super setUp];
+  NSString *runtimeVersion = @"1.0";
+  EXUpdatesConfig *config = [EXUpdatesConfig new];
+  EXUpdatesDatabase *database = [EXUpdatesDatabase new];
+
+  // test updates with different scopes to ensure this policy ignores scopes
+  _update1 = [EXUpdatesUpdate updateWithId:NSUUID.UUID scopeKey:@"scope1" commitTime:[NSDate dateWithTimeIntervalSince1970:1608667851] runtimeVersion:runtimeVersion metadata:nil status:EXUpdatesUpdateStatusReady keep:YES config:config database:database];
+  _update2 = [EXUpdatesUpdate updateWithId:NSUUID.UUID scopeKey:@"scope2" commitTime:[NSDate dateWithTimeIntervalSince1970:1608667852] runtimeVersion:runtimeVersion metadata:nil status:EXUpdatesUpdateStatusReady keep:YES config:config database:database];
+  _update3 = [EXUpdatesUpdate updateWithId:NSUUID.UUID scopeKey:@"scope3" commitTime:[NSDate dateWithTimeIntervalSince1970:1608667853] runtimeVersion:runtimeVersion metadata:nil status:EXUpdatesUpdateStatusReady keep:YES config:config database:database];
+  _update4 = [EXUpdatesUpdate updateWithId:NSUUID.UUID scopeKey:@"scope4" commitTime:[NSDate dateWithTimeIntervalSince1970:1608667854] runtimeVersion:runtimeVersion metadata:nil status:EXUpdatesUpdateStatusReady keep:YES config:config database:database];
+  _update5 = [EXUpdatesUpdate updateWithId:NSUUID.UUID scopeKey:@"scope5" commitTime:[NSDate dateWithTimeIntervalSince1970:1608667855] runtimeVersion:runtimeVersion metadata:nil status:EXUpdatesUpdateStatusReady keep:YES config:config database:database];
+
+  // for readability/writability, test with a policy that keeps only 3 updates;
+  // the actual functionality is independent of the number
+  _selectionPolicy = [[EXUpdatesReaperSelectionPolicyDevelopmentClient alloc] initWithMaxUpdatesToKeep:3];
+}
+
+- (void)tearDown
+{
+  [super tearDown];
+}
+
+- (void)testUpdatesToDelete_BasicCase
+{
+  _update1.lastAccessed = [NSDate dateWithTimeIntervalSince1970:1619569811];
+  _update2.lastAccessed = [NSDate dateWithTimeIntervalSince1970:1619569812];
+  _update3.lastAccessed = [NSDate dateWithTimeIntervalSince1970:1619569813];
+  _update4.lastAccessed = [NSDate dateWithTimeIntervalSince1970:1619569814];
+  _update5.lastAccessed = [NSDate dateWithTimeIntervalSince1970:1619569815];
+
+  // the order of the array shouldn't matter
+  NSArray<EXUpdatesUpdate *> *updatesToDelete = [_selectionPolicy updatesToDeleteWithLaunchedUpdate:_update5 updates:@[_update2, _update5, _update4, _update1, _update3] filters:nil];
+
+  XCTAssertEqual(2, updatesToDelete.count);
+  XCTAssertTrue([updatesToDelete containsObject:_update1]);
+  XCTAssertTrue([updatesToDelete containsObject:_update2]);
+}
+
+- (void)testUpdatesToDelete_SameLastAccessedDate
+{
+  // if multiple updates have the same lastAccessed date, should use commitTime to determine
+  // which updates to delete
+  _update1.lastAccessed = [NSDate dateWithTimeIntervalSince1970:1619569810];
+  _update2.lastAccessed = [NSDate dateWithTimeIntervalSince1970:1619569810];
+  _update3.lastAccessed = [NSDate dateWithTimeIntervalSince1970:1619569810];
+  _update4.lastAccessed = [NSDate dateWithTimeIntervalSince1970:1619569810];
+
+  NSArray<EXUpdatesUpdate *> *updatesToDelete = [_selectionPolicy updatesToDeleteWithLaunchedUpdate:_update4 updates:@[_update3, _update4, _update1, _update2] filters:nil];
+
+  XCTAssertEqual(1, updatesToDelete.count);
+  XCTAssertTrue([updatesToDelete containsObject:_update1]);
+}
+
+- (void)testUpdatesToDelete_LaunchedUpdateIsOldest
+{
+  // if the least recently accessed update happens to be launchedUpdate, delete instead the next
+  // least recently accessed update
+  _update1.lastAccessed = [NSDate dateWithTimeIntervalSince1970:1619569811];
+  _update2.lastAccessed = [NSDate dateWithTimeIntervalSince1970:1619569812];
+  _update3.lastAccessed = [NSDate dateWithTimeIntervalSince1970:1619569813];
+  _update4.lastAccessed = [NSDate dateWithTimeIntervalSince1970:1619569814];
+
+  NSArray<EXUpdatesUpdate *> *updatesToDelete = [_selectionPolicy updatesToDeleteWithLaunchedUpdate:_update1 updates:@[_update1, _update2, _update3, _update4] filters:nil];
+
+  XCTAssertEqual(1, updatesToDelete.count);
+  XCTAssertTrue([updatesToDelete containsObject:_update2]);
+}
+
+- (void)testUpdatesToDelete_NoLaunchedUpdate
+{
+  // if launchedUpdate is null, something has gone wrong, so don't delete anything
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
+  NSArray<EXUpdatesUpdate *> *updatesToDelete = [_selectionPolicy updatesToDeleteWithLaunchedUpdate:nil updates:@[_update1, _update2, _update3, _update4] filters:nil];
+#pragma clang diagnostic pop
+  XCTAssertEqual(0, updatesToDelete.count);
+}
+
+- (void)testUpdatesToDelete_BelowMaxNumber
+{
+  // no need to delete any updates if we have <= the max number of updates
+  NSArray<EXUpdatesUpdate *> *updatesToDeleteWith2Total = [_selectionPolicy updatesToDeleteWithLaunchedUpdate:_update2 updates:@[_update1, _update2] filters:nil];
+  NSArray<EXUpdatesUpdate *> *updatesToDeleteWith3Total = [_selectionPolicy updatesToDeleteWithLaunchedUpdate:_update3 updates:@[_update1, _update2, _update3] filters:nil];
+  XCTAssertEqual(0, updatesToDeleteWith2Total.count);
+  XCTAssertEqual(0, updatesToDeleteWith3Total.count);
+}
+
+@end


### PR DESCRIPTION
# Why

Step 3/4 of ENG-456

For development clients including Expo Go, we'll use a different reaper selection policy that simply keeps the 10 most recently used updates across all scopes.

This PR uses the functionality added in #12768 and #12769 to implement this `ReaperSelectionPolicyDevelopmentClient` and adds it to the selection policy created in Expo Go. We'll want to use this policy in the dev client, as well, once it supports expo-updates.;

# How

- Update the `last_accessed` column on an update anytime we launch the update; this column therefore represents the last time an update was launched, or the time it was first downloaded if it has never been launched.
- Implement the new selection policy and add unit tests.
- Use the new policy in Expo Go.

# Test Plan

All existing and new unit tests pass. Also ran the following e2e test manually in Expo Go on each platform:
- Open 10 different published projects with different scope keys
- Verify all 10 are in SQLite db
- Re-open the first project you opened; verify the `last_accessed` column has been updated in SQLite
- Open an 11th project
- Verify the 2nd project and its assets have been deleted from SQLite and disk

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).