### PR TITLE
[tools][ci] Suggesting changes in changelog entries

### DIFF
--- a/tools/src/Changelogs.ts
+++ b/tools/src/Changelogs.ts
@@ -84,6 +84,21 @@ export class Changelog {
   filePath: string;
   tokens: Markdown.Tokens | null = null;
 
+  static textToChangelogEntry(text: string): Required<ChangelogEntry> {
+    const pullRequests = execAll(
+      /\[#\d+\]\(https?:\/\/github\.com\/expo\/expo\/pull\/(\d+)\)/g,
+      text,
+      1
+    );
+    const authors = execAll(/\[@\w+\]\(https?:\/\/github\.com\/([^/)]+)\)/g, text, 1);
+
+    return {
+      message: text.trim(),
+      pullRequests: pullRequests.map((match) => parseInt(match, 10)),
+      authors,
+    };
+  }
+
   constructor(filePath: string) {
     this.filePath = filePath;
   }
@@ -182,7 +197,7 @@ export class Changelog {
           const text = item.tokens.find(Markdown.isTextToken)?.text ?? item.text;
 
           changes.totalCount++;
-          versions[currentVersion][currentSection].push(textToChangelogEntry(text));
+          versions[currentVersion][currentSection].push(Changelog.textToChangelogEntry(text));
         }
       }
     }
@@ -460,19 +475,4 @@ export function getChangeEntryLabel(entry: ChangelogEntry): string {
  */
 function getGroupLabel(groupName: string): string {
   return `**\`${groupName}\`**`;
-}
-
-function textToChangelogEntry(text: string): ChangelogEntry {
-  const pullRequests = execAll(
-    /\[#\d+\]\(https?:\/\/github\.com\/expo\/expo\/pull\/(\d+)\)/g,
-    text,
-    1
-  );
-  const authors = execAll(/\[@\w+\]\(https?:\/\/github\.com\/([^/)]+)\)/g, text, 1);
-
-  return {
-    message: text.trim(),
-    pullRequests: pullRequests.map((match) => parseInt(match, 10)),
-    authors,
-  };
 }

--- a/tools/src/GitHub.ts
+++ b/tools/src/GitHub.ts
@@ -110,9 +110,12 @@ export async function deleteAllPullRequestReviewCommentsAsync(
   review_id: number
 ) {
   const comments = await listPullRequestReviewCommentsAsync(pull_number, review_id);
-  for (const comment of comments) {
-    await deletePullRequestReviewCommentAsync(comment.id);
-  }
+
+  await Promise.all(
+    comments
+      .filter((comment) => comment.pull_request_review_id === review_id)
+      .map((comment) => deletePullRequestReviewCommentAsync(comment.id))
+  );
 }
 
 /**

--- a/tools/src/Markdown.ts
+++ b/tools/src/Markdown.ts
@@ -128,28 +128,28 @@ export function createListItemToken(text: string, depth: number = 0): ListItemTo
  * Type guard for tokens extending TextToken.
  */
 export function isTextToken(token: Token): token is TextToken {
-  return token.type === TokenType.TEXT;
+  return token?.type === TokenType.TEXT;
 }
 
 /**
  * Type guard for HeadingToken type.
  */
 export function isHeadingToken(token: Token): token is HeadingToken {
-  return token.type === TokenType.HEADING;
+  return token?.type === TokenType.HEADING;
 }
 
 /**
  * Type guard for ListToken type.
  */
 export function isListToken(token: Token): token is ListToken {
-  return token.type === TokenType.LIST;
+  return token?.type === TokenType.LIST;
 }
 
 /**
  * Type guard for ListItemToken type.
  */
 export function isListItemToken(token: Token): token is ListItemToken {
-  return token.type === TokenType.LIST_ITEM;
+  return token?.type === TokenType.LIST_ITEM;
 }
 
 /**

--- a/tools/src/code-review/index.ts
+++ b/tools/src/code-review/index.ts
@@ -5,12 +5,13 @@ import * as GitHub from '../GitHub';
 import logger from '../Logger';
 import { generateReviewBodyFromOutputs } from './reports';
 import checkMissingChangelogs from './reviewers/checkMissingChangelogs';
+import reviewChangelogEntries from './reviewers/reviewChangelogEntries';
 import { ReviewEvent, ReviewComment, ReviewInput, ReviewOutput, ReviewStatus } from './types';
 
 /**
  * An array with functions whose purpose is to check and review the diff.
  */
-const REVIEWERS = [checkMissingChangelogs];
+const REVIEWERS = [checkMissingChangelogs, reviewChangelogEntries];
 
 /**
  * Goes through the changes included in given pull request and checks if they meet basic requirements.

--- a/tools/src/code-review/reviewers/reviewChangelogEntries.ts
+++ b/tools/src/code-review/reviewers/reviewChangelogEntries.ts
@@ -1,0 +1,76 @@
+import parseDiff from 'parse-diff';
+import path from 'path';
+
+import { Changelog } from '../../Changelogs';
+import { PullRequest } from '../../GitHub';
+import * as Markdown from '../../Markdown';
+import { ReviewComment, ReviewInput, ReviewOutput, ReviewStatus } from '../types';
+
+export default async function ({ pullRequest, diff }: ReviewInput): Promise<ReviewOutput> {
+  const changelogs = diff.filter((fileDiff) => path.basename(fileDiff.to!) === 'CHANGELOG.md');
+  const comments: ReviewComment[] = [];
+
+  for (const changelogDiff of changelogs) {
+    for (const chunk of changelogDiff.chunks) {
+      chunk.changes.forEach((change, index) => {
+        // No need to care about unchanged or deleted lines
+        if (change.type !== 'add') {
+          return;
+        }
+
+        // Parse change content to markdown tokens
+        const [listToken] = Markdown.lexify(change.content.substr(1));
+
+        // Make sure that the line is a list item
+        if (!Markdown.isListToken(listToken) || !Markdown.isListItemToken(listToken.items[0])) {
+          return;
+        }
+
+        const { pullRequests } = Changelog.textToChangelogEntry(listToken.items[0].text);
+
+        // Skip if entry already has links to at least one PR
+        if (pullRequests.length > 0) {
+          return;
+        }
+
+        comments.push({
+          path: changelogDiff.to!,
+          position: index + 1,
+          body: generateSuggestion(pullRequest, change),
+        });
+      });
+    }
+  }
+  if (comments.length > 0) {
+    return {
+      status: ReviewStatus.WARN,
+      title: 'Missing links in changelog entries',
+      body: "I've added some suggestions below, you can just apply and commit them 😉",
+      comments,
+    };
+  } else {
+    return {
+      status: ReviewStatus.PASSIVE,
+    };
+  }
+}
+
+/**
+ * Returns a link in markdown format.
+ */
+function markdownLink(name: string, url: string): string {
+  return `[${name}](${url})`;
+}
+
+/**
+ * Generates GitHub's suggestion for given PR and change object.
+ */
+function generateSuggestion(pullRequest: PullRequest, change: parseDiff.Change) {
+  const prLink = markdownLink('#' + pullRequest.number, pullRequest.html_url);
+  const userLink = markdownLink('@' + pullRequest.user!.login, pullRequest.user!.html_url);
+
+  return `\`\`\`suggestion
+${change.content.substr(1).trim()} (${prLink} by ${userLink})
+\`\`\`
+`;
+}


### PR DESCRIPTION
# Why

Followup #12694 

# How

Added new code reviewer that checks if there is any new changelog entry without the link to the PR and leverages GitHub's code suggestions to make it easy to fix.

# Test Plan

I've run `et review -p 12571`, see https://github.com/expo/expo/pull/12571#pullrequestreview-648417217

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).