### PR TITLE
fix: SQLResultSetRowList type definition incomplete

### DIFF
--- a/packages/expo-sqlite/src/SQLite.types.ts
+++ b/packages/expo-sqlite/src/SQLite.types.ts
@@ -73,6 +73,7 @@ export interface SQLResultSet {
 export interface SQLResultSetRowList {
   length: number;
   item(index: number): any;
+  _array: number[];
 }
 
 export declare class SQLError {


### PR DESCRIPTION
# Why

Property `_array` does not exist on type `SQLResultSetRowList`.

# How

Adding `_array: number[];` to `interface SQLResultSetRowList {…}`

# Test Plan

Check ESLint when accessing a [`ResultSet` object](https://docs.expo.io/versions/v41.0.0/sdk/sqlite/#resultset--objects).

# Checklist

- [✓] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [✓] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [✓] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).