### PR TITLE
[dev-client][ios] Fix XCode warnings 

### DIFF
--- a/apps/bare-expo/ios/BareExpo/AppDelegate.swift
+++ b/apps/bare-expo/ios/BareExpo/AppDelegate.swift
@@ -32,7 +32,7 @@ class AppDelegate: UMAppDelegateWrapper {
 
     if (useDevClient) {
       let controller = EXDevLauncherController.sharedInstance()
-      controller?.start(with: window, delegate: self, launchOptions: launchOptions);
+      controller.start(with: window!, delegate: self, launchOptions: launchOptions);
     } else {
       initializeReactNativeBridge(launchOptions);
     }
@@ -65,7 +65,7 @@ class AppDelegate: UMAppDelegateWrapper {
   #endif
   
   override func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
-    if (useDevClient && EXDevLauncherController.sharedInstance()!.onDeepLink(url, options: options)) {
+    if (useDevClient && EXDevLauncherController.sharedInstance().onDeepLink(url, options: options)) {
       return true;
     }
     
@@ -92,7 +92,7 @@ extension AppDelegate: RCTBridgeDelegate {
     // DEBUG must be setup in Swift projects: https://stackoverflow.com/a/24112024/4047926
     #if DEBUG
     if (useDevClient) {
-      return EXDevLauncherController.sharedInstance()?.sourceUrl()
+      return EXDevLauncherController.sharedInstance().sourceUrl()
     } else {
       return RCTBundleURLProvider.sharedSettings()?.jsBundleURL(forBundleRoot: "index", fallbackResource: nil)
     }
@@ -123,7 +123,7 @@ extension AppDelegate: RCTBridgeDelegate {
 // MARK: - EXDevelopmentClientControllerDelegate
 
 extension AppDelegate:  EXDevLauncherControllerDelegate {
-  func devLauncherController(_ developmentClientController: EXDevLauncherController!, didStartWithSuccess success: Bool) {
+  func devLauncherController(_ developmentClientController: EXDevLauncherController, didStartWithSuccess success: Bool) {
     developmentClientController.appBridge = initializeReactNativeBridge(developmentClientController.getLaunchOptions())
   }
 }

--- a/packages/expo-dev-launcher/ios/EXDevLauncher.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncher.m
@@ -16,8 +16,8 @@ RCT_EXPORT_MODULE()
 
 - (NSDictionary *)constantsToExport
 {
-  NSString *manifestString = [EXDevLauncherController.sharedInstance appManifest].rawData ?: [NSNull null];
-  return @{ @"manifestString": manifestString };
+  NSString *manifestString = [EXDevLauncherController.sharedInstance appManifest].rawData;
+  return @{ @"manifestString": manifestString ?: [NSNull null] };
 }
 
 @end

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.h
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.h
@@ -3,6 +3,8 @@
 
 #import <UIKit/UIKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class EXDevLauncherPendingDeepLinkRegistry;
 @class EXDevLauncherController;
 @class EXDevLauncherManifest;
@@ -16,12 +18,12 @@
 
 @interface EXDevLauncherController : NSObject <RCTBridgeDelegate>
 
-@property (nonatomic, weak) RCTBridge *appBridge;
+@property (nonatomic, weak) RCTBridge * _Nullable appBridge;
 @property (nonatomic, strong) EXDevLauncherPendingDeepLinkRegistry *pendingDeepLinkRegistry;
 
 + (instancetype)sharedInstance;
 
-- (void)startWithWindow:(UIWindow *)window delegate:(id<EXDevLauncherControllerDelegate>)delegate launchOptions:(NSDictionary *)launchOptions;
+- (void)startWithWindow:(UIWindow *)window delegate:(id<EXDevLauncherControllerDelegate>)delegate launchOptions:(NSDictionary * _Nullable)launchOptions;
 
 - (NSURL *)sourceUrl;
 
@@ -29,16 +31,18 @@
 
 - (BOOL)onDeepLink:(NSURL *)url options:(NSDictionary *)options;
 
-- (void)loadApp:(NSURL *)url onSuccess:(void (^)())onSuccess onError:(void (^)(NSError *error))onError;
+- (void)loadApp:(NSURL *)url onSuccess:(void (^ _Nullable)(void))onSuccess onError:(void (^ _Nullable)(NSError *error))onError;
 
 - (NSDictionary *)recentlyOpenedApps;
 
 - (NSDictionary<UIApplicationLaunchOptionsKey, NSObject*> *)getLaunchOptions;
 
-- (EXDevLauncherManifest *)appManifest;
+- (EXDevLauncherManifest * _Nullable)appManifest;
 
 - (BOOL)isAppRunning;
 
 + (NSString * _Nullable)version;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -198,12 +198,12 @@ NSString *fakeLauncherBundleUrl = @"embedded://EXDevLauncher/dummy";
   }
     
 EXDevLauncherManifestParser *manifestParser = [[EXDevLauncherManifestParser alloc] initWithURL:url session:[NSURLSession sharedSession]];
-  __weak __typeof(self) weekSelf = self;
+  __weak __typeof(self) weakSelf = self;
   [manifestParser tryToParseManifest:^(EXDevLauncherManifest * _Nullable manifest) {
-    if (!weekSelf) {
+    if (!weakSelf) {
       return;
     }
-    __typeof(self) self = weekSelf;
+    __typeof(self) self = weakSelf;
     
     NSURL *bundleUrl = [NSURL URLWithString:manifest.bundleUrl];
     
@@ -232,12 +232,12 @@ EXDevLauncherManifestParser *manifestParser = [[EXDevLauncherManifestParser allo
   __block UIInterfaceOrientation orientation = manifest.orientation;
   __block UIColor *backgroundColor = manifest.backgroundColor;
   
-  __weak __typeof(self) weekSelf = self;
+  __weak __typeof(self) weakSelf = self;
   dispatch_async(dispatch_get_main_queue(), ^{
-    if (!weekSelf) {
+    if (!weakSelf) {
       return;
     }
-    __typeof(self) self = weekSelf;
+    __typeof(self) self = weakSelf;
     
     self.sourceUrl = bundleUrl;
     

--- a/packages/expo-dev-launcher/ios/EXDevLauncherInternal.h
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherInternal.h
@@ -1,7 +1,13 @@
 #import <React/RCTBridgeModule.h>
 #import <React/RCTBridgeDelegate.h>
 #import <React/RCTInvalidating.h>
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Weverything"
+
 #import <React/RCTEventEmitter.h>
+
+#pragma clang diagnostic pop
 
 #import "EXDevLauncherPendingDeepLinkListener.h"
 

--- a/packages/expo-dev-launcher/ios/EXDevLauncherInternal.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherInternal.m
@@ -5,7 +5,7 @@
 
 #import <EXDevLauncher-Swift.h>
 
-const NSString *ON_NEW_DEEP_LINK_EVENT = @"expo.modules.devlauncher.onnewdeeplink";
+NSString *ON_NEW_DEEP_LINK_EVENT = @"expo.modules.devlauncher.onnewdeeplink";
 
 @implementation EXDevLauncherInternal
 

--- a/packages/expo-dev-launcher/ios/EXDevLauncherMenuDelegate.swift
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherMenuDelegate.swift
@@ -32,7 +32,7 @@ private class AppDelegate : DevMenuDelegateProtocol {
     self.controller = controller
   }
   
-  func appBridge(forDevMenuManager manager: DevMenuManagerProtocol) -> AnyObject?{
+  func appBridge(forDevMenuManager manager: DevMenuManagerProtocol) -> AnyObject? {
     return controller.appBridge
   }
   
@@ -42,7 +42,8 @@ private class AppDelegate : DevMenuDelegateProtocol {
         "appName": "Development Client - App",
         "appVersion": NSNull(),
         "appIcon": NSNull(),
-        "hostUrl": controller.appBridge.bundleURL?.absoluteString,
+        // AppBridge should be present here, but for safety, we use null checks
+        "hostUrl": controller.appBridge?.bundleURL?.absoluteString ?? NSNull(),
       ]
     }
     

--- a/packages/expo-dev-launcher/ios/EXDevLauncherRecentlyOpenedAppsRegistry.swift
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherRecentlyOpenedAppsRegistry.swift
@@ -31,7 +31,7 @@ public class EXDevLauncherRecentlyOpenedAppsRegistry : NSObject {
   @objc
   public func recentlyOpenedApps() -> [String: Any] {
     var result = [String: Any]()
-    guard var registry = appRegistry as? [String: [String: Any]] else {
+    guard let registry = appRegistry as? [String: [String: Any]] else {
       return [:]
     }
     

--- a/packages/expo-dev-launcher/ios/Manifest/EXDevLauncherManifestParser.h
+++ b/packages/expo-dev-launcher/ios/Manifest/EXDevLauncherManifestParser.h
@@ -1,18 +1,20 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
-
 NS_ASSUME_NONNULL_BEGIN
+
 @class EXDevLauncherManifest;
 
 typedef void (^OnManifestParsed)(EXDevLauncherManifest *manifest);
-typedef void (^OnInvalidManifestURL)();
+typedef void (^OnInvalidManifestURL)(void);
 typedef void (^OnManifestError)(NSError *error);
 
 @interface EXDevLauncherManifestParser : NSObject
 
 - (instancetype)initWithURL:(NSURL *)url session:(NSURLSession *)session;
 
-- (void)tryToParseManifest:(OnManifestParsed)onParsed onInvalidManifestURL:(OnInvalidManifestURL)onInalidURL onError:(OnManifestError)onError;
+- (void)tryToParseManifest:(OnManifestParsed)onParsed
+      onInvalidManifestURL:(OnInvalidManifestURL)onInalidURL
+                   onError:(OnManifestError)onError;
 
 @end
 

--- a/packages/expo-dev-launcher/ios/Manifest/EXDevLauncherManifestParser.m
+++ b/packages/expo-dev-launcher/ios/Manifest/EXDevLauncherManifestParser.m
@@ -25,7 +25,9 @@ typedef void (^CompletionHandler)(NSData *data, NSURLResponse *response);
 }
 
 
-- (void)tryToParseManifest:(OnManifestParsed)onParsed onInvalidManifestURL:(OnInvalidManifestURL)onInalidURL onError:(OnManifestError)onError
+- (void)tryToParseManifest:(OnManifestParsed)onParsed
+      onInvalidManifestURL:(OnInvalidManifestURL)onInalidURL
+                   onError:(OnManifestError)onError
 {
   [self _fetch:@"HEAD" onError:onError completionHandler:^(NSData *data, NSURLResponse *response) {
     NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
@@ -39,7 +41,9 @@ typedef void (^CompletionHandler)(NSData *data, NSURLResponse *response);
     [self _fetch:@"GET" onError:onError completionHandler:^(NSData *data, NSURLResponse *response) {
       EXDevLauncherManifest *manifest = [EXDevLauncherManifest fromJsonData:data];
       if (!manifest) {
-        onError([[NSError alloc] initWithDomain:@"DevelopemntClient" code:@1 userInfo:@"Couldn't parse the manifest."]);
+        NSMutableDictionary* details = [NSMutableDictionary dictionary];
+        [details setValue:@"Couldn't parse the manifest." forKey:NSLocalizedDescriptionKey];
+        onError([[NSError alloc] initWithDomain:@"DevelopemntClient" code:1 userInfo:details]);
         return;
       }
       onParsed(manifest);

--- a/packages/expo-dev-launcher/ios/ReactNative/EXDevLauncherRCTBridge.m
+++ b/packages/expo-dev-launcher/ios/ReactNative/EXDevLauncherRCTBridge.m
@@ -29,8 +29,10 @@
   return [EXDevLauncherRCTCxxBridge class];
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
+// This method is still used so we need to override it even if it's deprecated
 - (void)reloadWithReason:(NSString *)reason {}
+#pragma clang diagnostic pop
 
 @end
-
-

--- a/packages/expo-dev-launcher/plugin/src/__tests__/__snapshots__/withDevLauncherAppDelegate-test.ts.snap
+++ b/packages/expo-dev-launcher/plugin/src/__tests__/__snapshots__/withDevLauncherAppDelegate-test.ts.snap
@@ -58,8 +58,8 @@ static void InitializeFlipper(UIApplication *application) {
   self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
   #ifdef DEBUG
     #if defined(EX_DEV_LAUNCHER_ENABLED)
-        EXDevLauncherController *contoller = [EXDevLauncherController sharedInstance];
-        [contoller startWithWindow:self.window delegate:self launchOptions:launchOptions];
+        EXDevLauncherController *controller = [EXDevLauncherController sharedInstance];
+        [controller startWithWindow:self.window delegate:(id<EXDevLauncherControllerDelegate>)self launchOptions:launchOptions];
       #else
         [self initializeReactNativeApp];
       #endif

--- a/packages/expo-dev-launcher/plugin/src/withDevLauncherAppDelegate.ts
+++ b/packages/expo-dev-launcher/plugin/src/withDevLauncherAppDelegate.ts
@@ -31,8 +31,8 @@ const DEV_LAUNCHER_APP_DELEGATE_CONTROLLER_DELEGATE = `
 #endif
 `;
 const DEV_LAUNCHER_APP_DELEGATE_INIT = `#if defined(EX_DEV_LAUNCHER_ENABLED)
-        EXDevLauncherController *contoller = [EXDevLauncherController sharedInstance];
-        [contoller startWithWindow:self.window delegate:self launchOptions:launchOptions];
+        EXDevLauncherController *controller = [EXDevLauncherController sharedInstance];
+        [controller startWithWindow:self.window delegate:(id<EXDevLauncherControllerDelegate>)self launchOptions:launchOptions];
       #else
         [self initializeReactNativeApp];
       #endif`;

--- a/packages/expo-dev-menu-interface/ios/DevMenuExtensionProtocol.swift
+++ b/packages/expo-dev-menu-interface/ios/DevMenuExtensionProtocol.swift
@@ -11,10 +11,16 @@ public protocol DevMenuExtensionSettingsProtocol {
 @objc
 public protocol DevMenuExtensionProtocol {
   /**
-   Returns a name of the module and the extension. Also required by `RCTBridgeModule`.
+   Returns a name of the module and the extension. Required by `RCTBridgeModule`.
+   This function is optional because otherwise we end up with linker warning:
+   `method '+moduleName' in category from /.../expo-dev-menu/libexpo-dev-menu.a(DevMenuExtensions-....o)
+   overrides method from class in /.../expo-dev-menu/libexpo-dev-menu.a(DevMenuExtensions-....o`
+   
+   So we assume that this method will be implemented by `RCTBridgeModule`.
+   In theory we can remove it. However, we leave it  to get easy access to the module name.
    */
   @objc
-  static func moduleName() -> String!
+  optional static func moduleName() -> String!
 
   /**
    Returns an array of the dev menu items to show.

--- a/packages/expo-dev-menu-interface/ios/ExpoApiClient/DevMenuExpoApiClientProtocol.swift
+++ b/packages/expo-dev-menu-interface/ios/ExpoApiClient/DevMenuExpoApiClientProtocol.swift
@@ -49,14 +49,14 @@ public protocol DevMenuExpoApiClientProtocol {
 }
 
 public extension DevMenuExpoApiClientProtocol {
-  public func queryUpdateChannels(
+  func queryUpdateChannels(
     appId: String,
     completionHandler: @escaping ([DevMenuEASUpdates.Channel]?, URLResponse?, Error?) -> Void
   ) {
     queryUpdateChannels(appId: appId, completionHandler: completionHandler, options: DevMenuGraphQLOptions())
   }
   
-  public func queryUpdateBranches(
+  func queryUpdateBranches(
     appId: String,
     completionHandler: @escaping ([DevMenuEASUpdates.Branch]?, URLResponse?, Error?) -> Void
   ) {

--- a/packages/expo-dev-menu-interface/ios/MenuItems/DevMenuAction.swift
+++ b/packages/expo-dev-menu-interface/ios/MenuItems/DevMenuAction.swift
@@ -59,7 +59,7 @@ open class DevMenuAction: DevMenuScreenItem, DevMenuCallableProvider {
     var dict = super.serialize()
     dict["actionId"] = self.callable.id
     dict["keyCommand"] = self.callable.keyCommand == nil ? nil : [
-      "input": self.callable.keyCommand!.input,
+      "input": self.callable.keyCommand!.input!,
       "modifiers": exportKeyCommandModifiers()
     ]
     

--- a/packages/expo-dev-menu-interface/ios/MenuItems/DevMenuSelectionList.swift
+++ b/packages/expo-dev-menu-interface/ios/MenuItems/DevMenuSelectionList.swift
@@ -15,7 +15,7 @@ public class DevMenuSelectionList: DevMenuScreenItem, DevMenuCallableProvider {
       fileprivate func serialize() -> [String : Any] {
         return [
           "text": text(),
-          "glyphName": glyphName(),
+          "glyphName": glyphName() ?? NSNull(),
         ]
       }
     }
@@ -38,10 +38,10 @@ public class DevMenuSelectionList: DevMenuScreenItem, DevMenuCallableProvider {
     public func serialize() -> [String : Any] {
       return [
         "title": title(),
-        "warning": warning(),
+        "warning": warning() ?? NSNull(),
         "isChecked": isChecked(),
         "tags": tags().map { $0.serialize() },
-        "onClickData": onClickData()
+        "onClickData": onClickData() ?? NSNull()
       ]
     }
   }

--- a/packages/expo-dev-menu/expo-dev-menu.podspec
+++ b/packages/expo-dev-menu/expo-dev-menu.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.platform       = :ios, '11.0'
   s.swift_version  = '5.2'
   s.source         = { git: 'https://github.com/expo/expo.git' }
-  s.source_files   = 'ios/**/*.{h,m,swift}', 'vendored/**/*.{h,m}'
+  s.source_files   = 'ios/**/*.{h,m,swift}'
   s.preserve_paths = 'ios/**/*.{h,m,swift}'
   s.requires_arc   = true
   s.header_dir     = 'EXDevMenu'
@@ -25,17 +25,22 @@ Pod::Spec.new do |s|
   ]}
 
   s.xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => 'EX_DEV_MENU_ENABLED=1', 'OTHER_SWIFT_FLAGS' => '-DEX_DEV_MENU_ENABLED=1' }
-  
-  # EXDevMenu
+
   # Swift/Objective-C compatibility
   s.pod_target_xcconfig = { "DEFINES_MODULE" => "YES" }
-  # s.script_phase = {
-  #   :name => 'Copy Swift Header',
-  #   :script => 'ditto "${BUILT_PRODUCTS_DIR}/Swift Compatibility Header/${PRODUCT_MODULE_NAME}-Swift.h" "${PODS_ROOT}/Headers/Public/${PRODUCT_MODULE_NAME}/${PRODUCT_MODULE_NAME}-Swift.h"',
-  #   :execution_position => :after_compile,
-  #   :input_files => ['${BUILT_PRODUCTS_DIR}/Swift Compatibility Header/${PRODUCT_MODULE_NAME}-Swift.h']
-  # }
 
   s.dependency 'React'
   s.dependency 'expo-dev-menu-interface'
+  
+  s.subspec 'Vendored' do |vendored|
+    vendored.source_files = 'vendored/**/*.{h,m}'
+    vendored.private_header_files = 'vendored/**/*.h'
+    vendored.compiler_flags = '-w -Xanalyzer -analyzer-disable-all-checks'
+  end
+  
+  s.subspec 'Main' do |main|
+    main.dependency "expo-dev-menu/Vendored"
+  end
+  
+  s.default_subspec = 'Main'
 end

--- a/packages/expo-dev-menu/ios/DevMenuManager.swift
+++ b/packages/expo-dev-menu/ios/DevMenuManager.swift
@@ -197,7 +197,8 @@ open class DevMenuManager: NSObject, DevMenuManagerProtocol {
       return;
     }
     
-    bridge.enqueueJSCall("RCTDeviceEventEmitter.emit", args: [eventName, data])
+    let args = data == nil ? [eventName] : [eventName, data!];
+    bridge.enqueueJSCall("RCTDeviceEventEmitter.emit", args: args)
   }
 
   // MARK: internals
@@ -230,7 +231,7 @@ open class DevMenuManager: NSObject, DevMenuManagerProtocol {
       return nil
     }
     let allExtensions = bridge.modulesConforming(to: DevMenuExtensionProtocol.self) as! [DevMenuExtensionProtocol]
-    let uniqueExtensionNames: [String] = Array(Set(allExtensions.map({ type(of: $0).moduleName() })))
+    let uniqueExtensionNames: [String] = Array(Set(allExtensions.map({ type(of: $0).moduleName!() })))
 
     return uniqueExtensionNames
       .map({ bridge.module(forName: DevMenuUtils.stripRCT($0)) })
@@ -273,8 +274,8 @@ open class DevMenuManager: NSObject, DevMenuManagerProtocol {
       devMenuItems.filter { $0 is DevMenuCallableProvider } :
       (devMenuScreens.first { $0.screenName == currentScreen }?.getAllItems() ?? []).filter { $0 is DevMenuCallableProvider }
     
-    // We use flatMap here to remove nils
-    return (providers as! [DevMenuCallableProvider]).flatMap { $0.registerCallable?() }
+    // We use compactMap here to remove nils
+    return (providers as! [DevMenuCallableProvider]).compactMap { $0.registerCallable?() }
   }
 
   /**

--- a/packages/expo-dev-menu/ios/DevMenuRCTBridge.m
+++ b/packages/expo-dev-menu/ios/DevMenuRCTBridge.m
@@ -30,6 +30,10 @@
   return [DevMenuRCTCxxBridge class];
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
+// This method is still used so we need to override it even if it's deprecated
 - (void)reloadWithReason:(NSString *)reason {}
+#pragma clang diagnostic pop
 
 @end

--- a/packages/expo-dev-menu/ios/DevMenuRootView.m
+++ b/packages/expo-dev-menu/ios/DevMenuRootView.m
@@ -15,7 +15,7 @@
   // Use the (batched) bridge that's sent in the notification payload, so the
   // RCTRootContentView is scoped to the right bridge
   RCTBridge *bridge = notification.userInfo[@"bridge"];
-  RCTRootContentView *rootView = self.contentView;
+  RCTRootContentView *rootView = (RCTRootContentView *)self.contentView;
   if (bridge != rootView.bridge) {
     if (self.reactTag == rootView.reactTag) {
       // Clear the reactTag so it can be re-assigned

--- a/packages/expo-dev-menu/ios/DevMenuSession.swift
+++ b/packages/expo-dev-menu/ios/DevMenuSession.swift
@@ -32,9 +32,9 @@ fileprivate func guessAppInfo(forBridge bridge: RCTBridge) -> [String : Any] {
     return [:]
   }
   return [
-    "appName": infoDictionary["CFBundleDisplayName"] ?? infoDictionary["CFBundleExecutable"],
-    "appVersion": infoDictionary["CFBundleVersion"],
-    "appIcon": findAppIconPath(),
+    "appName": infoDictionary["CFBundleDisplayName"] ?? infoDictionary["CFBundleExecutable"] ?? NSNull(),
+    "appVersion": infoDictionary["CFBundleVersion"] ?? NSNull(),
+    "appIcon": findAppIconPath() ?? NSNull(),
     "hostUrl": bridge.bundleURL?.absoluteString ?? NSNull(),
   ]
 }

--- a/packages/expo-dev-menu/ios/DevMenuVendoredModulesUtils.m
+++ b/packages/expo-dev-menu/ios/DevMenuVendoredModulesUtils.m
@@ -2,6 +2,9 @@
 
 #import "DevMenuVendoredModulesUtils.h"
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Weverything"
+
 #if __has_include("DevMenuREAModule.h")
 #import "DevMenuREAModule.h"
 #endif
@@ -9,6 +12,8 @@
 #if __has_include("DevMenuRNGestureHandlerModule.h")
 #import "DevMenuRNGestureHandlerModule.h"
 #endif
+
+#pragma clang diagnostic pop
 
 @implementation DevMenuVendoredModulesUtils
 

--- a/packages/expo-dev-menu/ios/DevMenuViewController.swift
+++ b/packages/expo-dev-menu/ios/DevMenuViewController.swift
@@ -80,7 +80,7 @@ class DevMenuViewController: UIViewController {
       "devMenuScreens": manager.serializedDevMenuScreens(),
       "appInfo": manager.session?.appInfo ?? [:],
       "uuid": UUID.init().uuidString,
-      "openScreen": manager.session?.openScreen
+      "openScreen": manager.session?.openScreen ?? NSNull()
     ]
   }
 

--- a/packages/expo-dev-menu/ios/Headers/EXDevMenu-Bridging-Header.h
+++ b/packages/expo-dev-menu/ios/Headers/EXDevMenu-Bridging-Header.h
@@ -2,6 +2,9 @@
 //  Use this file to import your target's public headers that you would like to expose to Swift.
 //
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Weverything"
+
 // React Native
 #import <React/RCTDevSettings.h>
 #import <React/RCTDevMenu.h>
@@ -13,6 +16,8 @@
 #import <React/RCTBridge+Private.h>
 #import <React/RCTLogBox.h>
 #import <React/RCTRedBox.h>
+
+#pragma clang diagnostic pop
 
 // Private
 #import "RCTPerfMonitor+Private.h"

--- a/packages/expo-dev-menu/ios/Modules/DeMenuManagerProvider.swift
+++ b/packages/expo-dev-menu/ios/Modules/DeMenuManagerProvider.swift
@@ -3,16 +3,7 @@
 import EXDevMenuInterface
 
 @objc(DevMenuManagerProvider)
-class DevMenuManagerProvider : NSObject, RCTBridgeModule, DevMenuManagerProviderProtocol {
-  @objc
-  static func moduleName() -> String! {
-    return "ExpoDevMenuManagerProvider"
-  }
-  
-  @objc
-  public static func requiresMainQueueSetup() -> Bool {
-    return true
-  }
+class DevMenuManagerProvider : NSObject, DevMenuManagerProviderProtocol {
   
   @objc
   open func getDevMenuManager() -> DevMenuManagerProtocol {

--- a/packages/expo-dev-menu/ios/Modules/DevMenuExtensions.m
+++ b/packages/expo-dev-menu/ios/Modules/DevMenuExtensions.m
@@ -4,4 +4,9 @@
 
 @interface RCT_EXTERN_REMAP_MODULE(ExpoDevMenuExtensions, DevMenuExtensions, NSObject)
 
++ (BOOL)requiresMainQueueSetup
+{
+  return true;
+}
+
 @end

--- a/packages/expo-dev-menu/ios/Modules/DevMenuExtensions.swift
+++ b/packages/expo-dev-menu/ios/Modules/DevMenuExtensions.swift
@@ -3,18 +3,7 @@
 import EXDevMenuInterface
 
 @objc(DevMenuExtensions)
-open class DevMenuExtensions: NSObject, RCTBridgeModule, DevMenuExtensionProtocol {
-  // MARK: RCTBridgeModule
-
-  @objc
-  public static func moduleName() -> String! {
-    return "ExpoDevMenuExtensions"
-  }
-
-  @objc
-  public static func requiresMainQueueSetup() -> Bool {
-    return true
-  }
+open class DevMenuExtensions: NSObject, DevMenuExtensionProtocol {
 
   @objc
   open var bridge: RCTBridge?
@@ -103,7 +92,7 @@ open class DevMenuExtensions: NSObject, RCTBridgeModule, DevMenuExtensionProtoco
 
     let selectionList = DevMenuSelectionList(dataSourceId: "updatesList")
     selectionList.addOnClick { data in
-      print(data?["id"])
+      print(data!["id"]!)
     }
     
     testScreen.addItem(selectionList)

--- a/packages/expo-dev-menu/ios/Modules/DevMenuInternalModule.swift
+++ b/packages/expo-dev-menu/ios/Modules/DevMenuInternalModule.swift
@@ -34,7 +34,7 @@ public class DevMenuInternalModule: NSObject, RCTBridgeModule {
   // MARK: JavaScript API
 
   @objc
-  func constantsToExport() -> [String : Any] {
+  public func constantsToExport() -> [AnyHashable : Any] {
 #if targetEnvironment(simulator)
     let doesDeviceSupportKeyCommands = true
 #else
@@ -82,8 +82,8 @@ public class DevMenuInternalModule: NSObject, RCTBridgeModule {
   }
 
   @objc
-  func fetchDataSourceAsync(_ dataSourceId: String, resolve: @escaping RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
-    if dataSourceId == nil {
+  func fetchDataSourceAsync(_ dataSourceId: String?, resolve: @escaping RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
+    guard let dataSourceId = dataSourceId else {
       return reject("ERR_DEVMENU_DATA_SOURCE_FAILED", "DataSource ID not provided.", nil)
     }
     
@@ -100,8 +100,8 @@ public class DevMenuInternalModule: NSObject, RCTBridgeModule {
   }
   
   @objc
-  func dispatchCallableAsync(_ callableId: String, args: [String : Any]?, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
-    if callableId == nil {
+  func dispatchCallableAsync(_ callableId: String?, args: [String : Any]?, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
+    guard let callableId = callableId else {
       return reject("ERR_DEVMENU_ACTION_FAILED", "Callable ID not provided.", nil)
     }
     manager.dispatchCallable(withId: callableId, args: args)

--- a/packages/expo-dev-menu/ios/Modules/DevMenuManagerProvider.m
+++ b/packages/expo-dev-menu/ios/Modules/DevMenuManagerProvider.m
@@ -4,4 +4,9 @@
 
 @interface RCT_EXTERN_REMAP_MODULE(ExpoDevMenuManagerProvider, DevMenuManagerProvider, NSObject)
 
++ (BOOL)requiresMainQueueSetup
+{
+  return true;
+}
+
 @end

--- a/packages/expo-dev-menu/ios/Modules/DevMenuModule.m
+++ b/packages/expo-dev-menu/ios/Modules/DevMenuModule.m
@@ -4,6 +4,11 @@
 
 @interface RCT_EXTERN_REMAP_MODULE(ExpoDevMenu, DevMenuModule, NSObject)
 
++ (BOOL)requiresMainQueueSetup
+{
+  return true;
+}
+
 RCT_EXTERN_METHOD(openMenu)
 RCT_EXTERN_METHOD(openProfile)
 RCT_EXTERN_METHOD(openSettings)

--- a/packages/expo-dev-menu/ios/Modules/DevMenuModule.swift
+++ b/packages/expo-dev-menu/ios/Modules/DevMenuModule.swift
@@ -1,15 +1,8 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
 @objc(DevMenuModule)
-open class DevMenuModule: NSObject, RCTBridgeModule {
-  public static func moduleName() -> String! {
-    return "ExpoDevMenu"
-  }
-
-  public static func requiresMainQueueSetup() -> Bool {
-    return true
-  }
-
+open class DevMenuModule: NSObject {
+  
   // MARK: JavaScript API
 
   @objc

--- a/packages/expo-dev-menu/vendored/react-native-gesture-handler/ios/DevMenuRNGestureHandler.m
+++ b/packages/expo-dev-menu/vendored/react-native-gesture-handler/ios/DevMenuRNGestureHandler.m
@@ -6,14 +6,14 @@
 
 #import <React/UIView+React.h>
 
-@interface UIGestureRecognizer (GestureHandler)
-@property (nonatomic, readonly) DevMenuRNGestureHandler *gestureHandler;
+@interface UIGestureRecognizer (DevMenuGestureHandler)
+@property (nonatomic, readonly) DevMenuRNGestureHandler *devMenugestureHandler;
 @end
 
 
-@implementation UIGestureRecognizer (GestureHandler)
+@implementation UIGestureRecognizer (DevMenuGestureHandler)
 
-- (DevMenuRNGestureHandler *)gestureHandler
+- (DevMenuRNGestureHandler *)devMenugestureHandler
 {
     id delegate = self.delegate;
     if ([delegate isKindOfClass:[DevMenuRNGestureHandler class]]) {
@@ -224,7 +224,7 @@ static NSHashTable<DevMenuRNGestureHandler *> *allGestureHandlers;
 
 + (DevMenuRNGestureHandler *)findGestureHandlerByRecognizer:(UIGestureRecognizer *)recognizer
 {
-    DevMenuRNGestureHandler *handler = recognizer.gestureHandler;
+    DevMenuRNGestureHandler *handler = recognizer.devMenugestureHandler;
     if (handler != nil) {
         return handler;
     }
@@ -238,7 +238,7 @@ static NSHashTable<DevMenuRNGestureHandler *> *allGestureHandlers;
 
     for (UIGestureRecognizer *recognizer in reactView.gestureRecognizers) {
         if ([recognizer isKindOfClass:[DevMenuRNDummyGestureRecognizer class]]) {
-            return recognizer.gestureHandler;
+            return recognizer.devMenugestureHandler;
         }
     }
 


### PR DESCRIPTION
# Why

Closes GRO-112.
Removes other warnings reported by XCode.

# How

- Fixed or suppressed warnings 
- Added vendored modules as a subspec to suppress all warnings coming from them

> Note
The remaining warnings come from RN code - we can't do anything about them.

# Test Plan

- bare-expo ✅
- new project created using `npx crna`

# Befor

<img width="335" alt="Screenshot 2021-05-01 at 13 15 57" src="https://user-images.githubusercontent.com/9578601/116895329-60aa1180-ac33-11eb-9f14-1615ff70861e.png">

# Now

<img width="464" alt="Screenshot 2021-05-01 at 16 23 08" src="https://user-images.githubusercontent.com/9578601/116895332-61db3e80-ac33-11eb-9224-21ae4c6d4683.png">

