### PR TITLE
[dev-client][android] Add auto-discovery for dev-menu extensions in dev-launcher

### DIFF
--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
@@ -8,6 +8,7 @@ import androidx.annotation.UiThread
 import com.facebook.react.ReactActivity
 import com.facebook.react.ReactActivityDelegate
 import com.facebook.react.ReactNativeHost
+import com.facebook.react.ReactPackage
 import com.facebook.react.bridge.ReactContext
 import expo.interfaces.devmenu.DevMenuManagerProviderInterface
 import expo.modules.devlauncher.helpers.changeUrlScheme
@@ -226,6 +227,7 @@ class DevLauncherController private constructor(
   companion object {
     private var sInstance: DevLauncherController? = null
     private var sLauncherClass: Class<*>? = null
+    internal var sAdditionalPackages: List<ReactPackage>? = null
 
     @JvmStatic
     fun wasInitialized() = sInstance != null
@@ -243,8 +245,9 @@ class DevLauncherController private constructor(
     }
 
     @JvmStatic
-    fun initialize(context: Context, appHost: ReactNativeHost, launcherClass: Class<*>) {
+    fun initialize(context: Context, appHost: ReactNativeHost, additionalPackages: List<ReactPackage>?, launcherClass: Class<*>? = null) {
       initialize(context, appHost)
+      sAdditionalPackages = additionalPackages
       sLauncherClass = launcherClass
     }
 

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/DevLauncherClientHost.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/DevLauncherClientHost.kt
@@ -2,15 +2,13 @@ package expo.modules.devlauncher.launcher
 
 import android.app.Application
 import com.facebook.react.ReactNativeHost
+import com.facebook.react.ReactPackage
 import com.facebook.react.shell.MainReactPackage
+import expo.modules.devlauncher.DevLauncherController
 import expo.modules.devlauncher.DevLauncherPackage
-import expo.modules.devlauncher.R
 import expo.modules.devlauncher.helpers.findDevMenuPackage
+import expo.modules.devlauncher.helpers.findPackagesWithDevMenuExtension
 import expo.modules.devlauncher.helpers.injectDebugServerHost
-import org.apache.commons.io.IOUtils
-import java.io.File
-import java.io.FileOutputStream
-import java.io.IOException
 
 class DevLauncherClientHost(
   application: Application,
@@ -25,11 +23,24 @@ class DevLauncherClientHost(
 
   override fun getUseDeveloperSupport() = launcherIp != null
 
-  override fun getPackages() = listOfNotNull(
-    MainReactPackage(null),
-    DevLauncherPackage(),
-    findDevMenuPackage()
-  )
+  override fun getPackages(): List<ReactPackage> {
+    val devMenuPackage = findDevMenuPackage()
+    val devMenuRelatedPackages: List<ReactPackage> =
+      if (devMenuPackage != null) {
+        findPackagesWithDevMenuExtension(this) + devMenuPackage
+      } else {
+        emptyList()
+      }
+
+    val additionalPackages = (DevLauncherController.sAdditionalPackages ?: emptyList())
+
+    return listOf(
+      MainReactPackage(null),
+      DevLauncherPackage()
+    ) +
+      devMenuRelatedPackages +
+      additionalPackages
+  }
 
   override fun getJSMainModuleName() = "index"
 

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/helpers/DevLauncherReactUtils.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/helpers/DevLauncherReactUtils.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.util.Log
 import com.facebook.react.ReactNativeHost
 import com.facebook.react.ReactPackage
+import expo.interfaces.devmenu.annotations.ContainsDevMenuExtension
 import expo.modules.devlauncher.react.DevLauncherInternalSettings
 
 fun injectDebugServerHost(
@@ -44,5 +45,24 @@ fun findDevMenuPackage(): ReactPackage? {
     clazz.newInstance() as? ReactPackage
   } catch (e: Exception) {
     null
+  }
+}
+
+fun findPackagesWithDevMenuExtension(reactNativeHost: ReactNativeHost): List<ReactPackage> {
+  return try {
+    val clazz = Class.forName("com.facebook.react.PackageList")
+    val ctor = clazz.getConstructor(ReactNativeHost::class.java)
+    val packageList = ctor.newInstance(reactNativeHost)
+
+    val getPackagesMethod = packageList.javaClass.getDeclaredMethod("getPackages")
+    val packages = getPackagesMethod.invoke(packageList) as List<*>
+    return packages
+      .filterIsInstance<ReactPackage>()
+      .filter {
+        it.javaClass.isAnnotationPresent(ContainsDevMenuExtension::class.java)
+      }
+  } catch (e: Exception) {
+    Log.e("DevLauncher", "Unable find packages with dev menu extension.`.", e)
+    emptyList()
   }
 }

--- a/packages/expo-dev-menu-interface/android/src/main/java/expo/interfaces/devmenu/annotations/ContainsDevMenuExtension.kt
+++ b/packages/expo-dev-menu-interface/android/src/main/java/expo/interfaces/devmenu/annotations/ContainsDevMenuExtension.kt
@@ -1,0 +1,5 @@
+package expo.interfaces.devmenu.annotations
+
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class ContainsDevMenuExtension


### PR DESCRIPTION
# Why

Closes ENG-1022

# How

Added a way to discover packages with dev-menu extensions in dev-launcher to include them in the launcher bridge. 

# Test Plan

- bare-expo ✅