### PR TITLE
[expo-updates] rename Update.metadata -> Update.manifest

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.java
+++ b/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.java
@@ -298,7 +298,7 @@ public class ExpoUpdatesAppLoader {
         mLauncher = launcher;
         mIsUpToDate = isUpToDate;
         try {
-          JSONObject manifestJson = processManifestJson(launcher.getLaunchedUpdate().metadata);
+          JSONObject manifestJson = processManifestJson(launcher.getLaunchedUpdate().manifest);
           RawManifest manifest = ManifestFactory.INSTANCE.getRawManifestFromJson(manifestJson);
           mCallback.onManifestCompleted(manifest);
 
@@ -329,7 +329,7 @@ public class ExpoUpdatesAppLoader {
               throw new AssertionError("Background update with error status must have a nonnull update object");
             }
             jsonParams.put("type", UPDATE_AVAILABLE_EVENT);
-            jsonParams.put("manifestString", update.metadata.toString());
+            jsonParams.put("manifestString", update.manifest.toString());
           } else if (status == LoaderTask.BackgroundUpdateStatus.NO_UPDATE_AVAILABLE) {
             jsonParams.put("type", UPDATE_NO_UPDATE_AVAILABLE_EVENT);
           }

--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/updates/UpdatesModule.java
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/updates/UpdatesModule.java
@@ -58,7 +58,7 @@ public class UpdatesModule extends ExportedModule {
         UpdateEntity launchedUpdate = updatesService.getLaunchedUpdate();
         if (launchedUpdate != null) {
           constants.put("updateId", launchedUpdate.id.toString());
-          constants.put("manifestString", launchedUpdate.metadata != null ? launchedUpdate.metadata.toString() : "{}");
+          constants.put("manifestString", launchedUpdate.manifest != null ? launchedUpdate.manifest.toString() : "{}");
         }
 
         Map<AssetEntity, String> localAssetFiles = updatesService.getLocalAssetFiles();
@@ -200,7 +200,7 @@ public class UpdatesModule extends ExportedModule {
                   updateInfo.putBoolean("isNew", false);
                 } else {
                   updateInfo.putBoolean("isNew", true);
-                  updateInfo.putString("manifestString", update.metadata.toString());
+                  updateInfo.putString("manifestString", update.manifest.toString());
                 }
                 promise.resolve(updateInfo);
               }

--- a/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/expo/modules/updates/UpdatesModule.java
+++ b/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/expo/modules/updates/UpdatesModule.java
@@ -58,7 +58,7 @@ public class UpdatesModule extends ExportedModule {
         UpdateEntity launchedUpdate = updatesService.getLaunchedUpdate();
         if (launchedUpdate != null) {
           constants.put("updateId", launchedUpdate.id.toString());
-          constants.put("manifestString", launchedUpdate.metadata != null ? launchedUpdate.metadata.toString() : "{}");
+          constants.put("manifestString", launchedUpdate.manifest != null ? launchedUpdate.manifest.toString() : "{}");
         }
 
         Map<AssetEntity, String> localAssetFiles = updatesService.getLocalAssetFiles();
@@ -200,7 +200,7 @@ public class UpdatesModule extends ExportedModule {
                   updateInfo.putBoolean("isNew", false);
                 } else {
                   updateInfo.putBoolean("isNew", true);
-                  updateInfo.putString("manifestString", update.metadata.toString());
+                  updateInfo.putString("manifestString", update.manifest.toString());
                 }
                 promise.resolve(updateInfo);
               }

--- a/android/versioned-abis/expoview-abi41_0_0/src/main/java/abi41_0_0/expo/modules/updates/UpdatesModule.java
+++ b/android/versioned-abis/expoview-abi41_0_0/src/main/java/abi41_0_0/expo/modules/updates/UpdatesModule.java
@@ -64,7 +64,7 @@ public class UpdatesModule extends ExportedModule {
         UpdateEntity launchedUpdate = updatesService.getLaunchedUpdate();
         if (launchedUpdate != null) {
           constants.put("updateId", launchedUpdate.id.toString());
-          constants.put("manifestString", launchedUpdate.metadata != null ? launchedUpdate.metadata.toString() : "{}");
+          constants.put("manifestString", launchedUpdate.manifest != null ? launchedUpdate.manifest.toString() : "{}");
         }
 
         Map<AssetEntity, String> localAssetFiles = updatesService.getLocalAssetFiles();
@@ -218,7 +218,7 @@ public class UpdatesModule extends ExportedModule {
                   updateInfo.putBoolean("isNew", false);
                 } else {
                   updateInfo.putBoolean("isNew", true);
-                  updateInfo.putString("manifestString", update.metadata.toString());
+                  updateInfo.putString("manifestString", update.manifest.toString());
                 }
                 promise.resolve(updateInfo);
               }

--- a/ios/versioned-react-native/ABI39_0_0/Expo/EXUpdates/ABI39_0_0EXUpdates/Database/ABI39_0_0EXUpdatesDatabase.m
+++ b/ios/versioned-react-native/ABI39_0_0/Expo/EXUpdates/ABI39_0_0EXUpdates/Database/ABI39_0_0EXUpdatesDatabase.m
@@ -152,7 +152,7 @@ static NSString * const ABI39_0_0EXUpdatesDatabaseFilename = @"expo-v3.db";
                       update.scopeKey,
                       @([update.commitTime timeIntervalSince1970] * 1000),
                       update.runtimeVersion,
-                      update.metadata ?: [NSNull null],
+                      update.manifest ?: [NSNull null],
                       @(ABI39_0_0EXUpdatesUpdateStatusPending)
                       ]
               error:error];

--- a/ios/versioned-react-native/ABI39_0_0/Expo/EXUpdates/ABI39_0_0EXUpdates/Update/ABI39_0_0EXUpdatesBareUpdate.m
+++ b/ios/versioned-react-native/ABI39_0_0/Expo/EXUpdates/ABI39_0_0EXUpdates/Update/ABI39_0_0EXUpdatesBareUpdate.m
@@ -63,7 +63,7 @@ NS_ASSUME_NONNULL_BEGIN
   update.commitTime = [NSDate dateWithTimeIntervalSince1970:[(NSNumber *)commitTime doubleValue] / 1000];
   update.runtimeVersion = [ABI39_0_0EXUpdatesUtils getRuntimeVersionWithConfig:config];
   if (metadata) {
-    update.metadata = (NSDictionary *)metadata;
+    update.manifest = (NSDictionary *)metadata;
   }
   update.status = ABI39_0_0EXUpdatesUpdateStatusEmbedded;
   update.keep = YES;

--- a/ios/versioned-react-native/ABI39_0_0/Expo/EXUpdates/ABI39_0_0EXUpdates/Update/ABI39_0_0EXUpdatesLegacyUpdate.m
+++ b/ios/versioned-react-native/ABI39_0_0/Expo/EXUpdates/ABI39_0_0EXUpdates/Update/ABI39_0_0EXUpdatesLegacyUpdate.m
@@ -108,7 +108,7 @@ static NSString * const ABI39_0_0EXUpdatesExpoTestDomain = @"expo.test";
     [processedAssets addObject:asset];
   }
 
-  update.metadata = manifest;
+  update.manifest = manifest;
   update.keep = YES;
   update.bundleUrl = bundleUrl;
   update.assets = processedAssets;

--- a/ios/versioned-react-native/ABI39_0_0/Expo/EXUpdates/ABI39_0_0EXUpdates/Update/ABI39_0_0EXUpdatesNewUpdate.m
+++ b/ios/versioned-react-native/ABI39_0_0/Expo/EXUpdates/ABI39_0_0EXUpdates/Update/ABI39_0_0EXUpdatesNewUpdate.m
@@ -78,7 +78,7 @@ NS_ASSUME_NONNULL_BEGIN
   update.commitTime = [NSDate dateWithTimeIntervalSince1970:[(NSNumber *)commitTime doubleValue] / 1000];
   update.runtimeVersion = (NSString *)runtimeVersion;
   if (metadata) {
-    update.metadata = (NSDictionary *)metadata;
+    update.manifest = (NSDictionary *)metadata;
   }
   update.status = ABI39_0_0EXUpdatesUpdateStatusPending;
   update.keep = YES;

--- a/ios/versioned-react-native/ABI39_0_0/Expo/EXUpdates/ABI39_0_0EXUpdates/Update/ABI39_0_0EXUpdatesUpdate+Private.h
+++ b/ios/versioned-react-native/ABI39_0_0/Expo/EXUpdates/ABI39_0_0EXUpdates/Update/ABI39_0_0EXUpdatesUpdate+Private.h
@@ -10,7 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readwrite) NSUUID *updateId;
 @property (nonatomic, strong, readwrite) NSDate *commitTime;
 @property (nonatomic, strong, readwrite) NSString *runtimeVersion;
-@property (nonatomic, strong, readwrite, nullable) NSDictionary *metadata;
+@property (nonatomic, strong, readwrite, nullable) NSDictionary *manifest;
 @property (nonatomic, assign, readwrite) BOOL keep;
 @property (nonatomic, strong, readwrite) NSURL *bundleUrl;
 @property (nonatomic, strong, readwrite) NSArray<ABI39_0_0EXUpdatesAsset *> *assets;

--- a/ios/versioned-react-native/ABI39_0_0/Expo/EXUpdates/ABI39_0_0EXUpdates/Update/ABI39_0_0EXUpdatesUpdate.h
+++ b/ios/versioned-react-native/ABI39_0_0/Expo/EXUpdates/ABI39_0_0EXUpdates/Update/ABI39_0_0EXUpdatesUpdate.h
@@ -23,7 +23,7 @@ typedef NS_ENUM(NSInteger, ABI39_0_0EXUpdatesUpdateStatus) {
 @property (nonatomic, strong, readonly) NSString *scopeKey;
 @property (nonatomic, strong, readonly) NSDate *commitTime;
 @property (nonatomic, strong, readonly) NSString *runtimeVersion;
-@property (nonatomic, strong, readonly, nullable) NSDictionary * metadata;
+@property (nonatomic, strong, readonly, nullable) NSDictionary *manifest;
 @property (nonatomic, assign, readonly) BOOL keep;
 @property (nonatomic, strong, readonly) NSArray<ABI39_0_0EXUpdatesAsset *> *assets;
 @property (nonatomic, assign, readonly) BOOL isDevelopmentMode;

--- a/ios/versioned-react-native/ABI39_0_0/Expo/EXUpdates/ABI39_0_0EXUpdates/Update/ABI39_0_0EXUpdatesUpdate.m
+++ b/ios/versioned-react-native/ABI39_0_0/Expo/EXUpdates/ABI39_0_0EXUpdates/Update/ABI39_0_0EXUpdatesUpdate.m
@@ -47,7 +47,7 @@ NS_ASSUME_NONNULL_BEGIN
   update.updateId = updateId;
   update.commitTime = commitTime;
   update.runtimeVersion = runtimeVersion;
-  update.metadata = metadata;
+  update.manifest = metadata;
   update.status = status;
   update.keep = keep;
   return update;

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Database/ABI40_0_0EXUpdatesDatabase.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Database/ABI40_0_0EXUpdatesDatabase.m
@@ -160,7 +160,7 @@ static NSString * const ABI40_0_0EXUpdatesDatabaseFilename = @"expo-v4.db";
                       update.scopeKey,
                       @([update.commitTime timeIntervalSince1970] * 1000),
                       update.runtimeVersion,
-                      update.metadata ?: [NSNull null],
+                      update.manifest ?: [NSNull null],
                       @(ABI40_0_0EXUpdatesUpdateStatusPending)
                       ]
               error:error];

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/ABI40_0_0EXUpdatesBareUpdate.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/ABI40_0_0EXUpdatesBareUpdate.m
@@ -63,7 +63,7 @@ NS_ASSUME_NONNULL_BEGIN
   update.commitTime = [NSDate dateWithTimeIntervalSince1970:[(NSNumber *)commitTime doubleValue] / 1000];
   update.runtimeVersion = [ABI40_0_0EXUpdatesUtils getRuntimeVersionWithConfig:config];
   if (metadata) {
-    update.metadata = (NSDictionary *)metadata;
+    update.manifest = (NSDictionary *)metadata;
   }
   update.status = ABI40_0_0EXUpdatesUpdateStatusEmbedded;
   update.keep = YES;

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/ABI40_0_0EXUpdatesLegacyUpdate.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/ABI40_0_0EXUpdatesLegacyUpdate.m
@@ -108,7 +108,7 @@ static NSString * const ABI40_0_0EXUpdatesExpoTestDomain = @"expo.test";
     [processedAssets addObject:asset];
   }
 
-  update.metadata = manifest;
+  update.manifest = manifest;
   update.keep = YES;
   update.bundleUrl = bundleUrl;
   update.assets = processedAssets;

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/ABI40_0_0EXUpdatesNewUpdate.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/ABI40_0_0EXUpdatesNewUpdate.m
@@ -78,7 +78,7 @@ NS_ASSUME_NONNULL_BEGIN
   update.commitTime = [NSDate dateWithTimeIntervalSince1970:[(NSNumber *)commitTime doubleValue] / 1000];
   update.runtimeVersion = (NSString *)runtimeVersion;
   if (metadata) {
-    update.metadata = (NSDictionary *)metadata;
+    update.manifest = (NSDictionary *)metadata;
   }
   update.status = ABI40_0_0EXUpdatesUpdateStatusPending;
   update.keep = YES;

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/ABI40_0_0EXUpdatesUpdate+Private.h
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/ABI40_0_0EXUpdatesUpdate+Private.h
@@ -11,7 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readwrite) NSString *scopeKey;
 @property (nonatomic, strong, readwrite) NSDate *commitTime;
 @property (nonatomic, strong, readwrite) NSString *runtimeVersion;
-@property (nonatomic, strong, readwrite, nullable) NSDictionary *metadata;
+@property (nonatomic, strong, readwrite, nullable) NSDictionary *manifest;
 @property (nonatomic, assign, readwrite) BOOL keep;
 @property (nonatomic, strong, readwrite) NSURL *bundleUrl;
 @property (nonatomic, strong, readwrite) NSArray<ABI40_0_0EXUpdatesAsset *> *assets;

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/ABI40_0_0EXUpdatesUpdate.h
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/ABI40_0_0EXUpdatesUpdate.h
@@ -23,7 +23,7 @@ typedef NS_ENUM(NSInteger, ABI40_0_0EXUpdatesUpdateStatus) {
 @property (nonatomic, strong, readonly) NSString *scopeKey;
 @property (nonatomic, strong, readonly) NSDate *commitTime;
 @property (nonatomic, strong, readonly) NSString *runtimeVersion;
-@property (nonatomic, strong, readonly, nullable) NSDictionary * metadata;
+@property (nonatomic, strong, readonly, nullable) NSDictionary *manifest;
 @property (nonatomic, assign, readonly) BOOL keep;
 @property (nonatomic, strong, readonly) NSArray<ABI40_0_0EXUpdatesAsset *> *assets;
 @property (nonatomic, assign, readonly) BOOL isDevelopmentMode;

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/ABI40_0_0EXUpdatesUpdate.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/ABI40_0_0EXUpdatesUpdate.m
@@ -49,7 +49,7 @@ NS_ASSUME_NONNULL_BEGIN
   update.scopeKey = scopeKey;
   update.commitTime = commitTime;
   update.runtimeVersion = runtimeVersion;
-  update.metadata = metadata;
+  update.manifest = metadata;
   update.status = status;
   update.keep = keep;
   return update;

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/AppLauncher/ABI41_0_0EXUpdatesSelectionPolicyFilterAware.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/AppLauncher/ABI41_0_0EXUpdatesSelectionPolicyFilterAware.m
@@ -99,11 +99,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (BOOL)doesUpdate:(ABI41_0_0EXUpdatesUpdate *)update matchFilters:(nullable NSDictionary *)filters
 {
-  if (!filters || !update.metadata) {
+  if (!filters || !update.manifest) {
     return YES;
   }
 
-  NSDictionary *updateMetadata = update.metadata[@"updateMetadata"];
+  NSDictionary *updateMetadata = update.manifest[@"updateMetadata"];
   if (!updateMetadata || ![updateMetadata isKindOfClass:[NSDictionary class]]) {
     return YES;
   }

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Database/ABI41_0_0EXUpdatesDatabase.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Database/ABI41_0_0EXUpdatesDatabase.m
@@ -65,7 +65,7 @@ static NSString * const ABI41_0_0EXUpdatesDatabaseServerDefinedHeadersKey = @"se
                       update.scopeKey,
                       @([update.commitTime timeIntervalSince1970] * 1000),
                       update.runtimeVersion,
-                      update.metadata ?: [NSNull null],
+                      update.manifest ?: [NSNull null],
                       @(ABI41_0_0EXUpdatesUpdateStatusPending)
                       ]
               error:error];

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/ABI41_0_0EXUpdatesBareUpdate.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/ABI41_0_0EXUpdatesBareUpdate.m
@@ -66,7 +66,7 @@ NS_ASSUME_NONNULL_BEGIN
   update.commitTime = [NSDate dateWithTimeIntervalSince1970:[(NSNumber *)commitTime doubleValue] / 1000];
   update.runtimeVersion = [ABI41_0_0EXUpdatesUtils getRuntimeVersionWithConfig:config];
   if (metadata) {
-    update.metadata = (NSDictionary *)metadata;
+    update.manifest = (NSDictionary *)metadata;
   }
   update.status = ABI41_0_0EXUpdatesUpdateStatusEmbedded;
   update.keep = YES;

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/ABI41_0_0EXUpdatesLegacyUpdate.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/ABI41_0_0EXUpdatesLegacyUpdate.m
@@ -108,7 +108,7 @@ static NSString * const ABI41_0_0EXUpdatesExpoTestDomain = @"expo.test";
     [processedAssets addObject:asset];
   }
 
-  update.metadata = manifest;
+  update.manifest = manifest;
   update.keep = YES;
   update.bundleUrl = bundleUrl;
   update.assets = processedAssets;

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/ABI41_0_0EXUpdatesNewUpdate.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/ABI41_0_0EXUpdatesNewUpdate.m
@@ -92,7 +92,7 @@ NS_ASSUME_NONNULL_BEGIN
   update.keep = YES;
   update.bundleUrl = bundleUrl;
   update.assets = processedAssets;
-  update.metadata = manifest;
+  update.manifest = manifest;
 
   if ([response isKindOfClass:[NSHTTPURLResponse class]]) {
     NSDictionary *headersDictionary = ((NSHTTPURLResponse *)response).allHeaderFields;

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/ABI41_0_0EXUpdatesUpdate+Private.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/ABI41_0_0EXUpdatesUpdate+Private.h
@@ -11,7 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readwrite) NSString *scopeKey;
 @property (nonatomic, strong, readwrite) NSDate *commitTime;
 @property (nonatomic, strong, readwrite) NSString *runtimeVersion;
-@property (nonatomic, strong, readwrite, nullable) NSDictionary *metadata;
+@property (nonatomic, strong, readwrite, nullable) NSDictionary *manifest;
 @property (nonatomic, assign, readwrite) BOOL keep;
 @property (nonatomic, strong, readwrite) NSURL *bundleUrl;
 @property (nonatomic, strong, readwrite) NSArray<ABI41_0_0EXUpdatesAsset *> *assets;

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/ABI41_0_0EXUpdatesUpdate.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/ABI41_0_0EXUpdatesUpdate.h
@@ -23,7 +23,7 @@ typedef NS_ENUM(NSInteger, ABI41_0_0EXUpdatesUpdateStatus) {
 @property (nonatomic, strong, readonly) NSString *scopeKey;
 @property (nonatomic, strong, readonly) NSDate *commitTime;
 @property (nonatomic, strong, readonly) NSString *runtimeVersion;
-@property (nonatomic, strong, readonly, nullable) NSDictionary * metadata;
+@property (nonatomic, strong, readonly, nullable) NSDictionary *manifest;
 @property (nonatomic, assign, readonly) BOOL keep;
 @property (nonatomic, strong, readonly) NSArray<ABI41_0_0EXUpdatesAsset *> *assets;
 @property (nonatomic, assign, readonly) BOOL isDevelopmentMode;

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/ABI41_0_0EXUpdatesUpdate.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/ABI41_0_0EXUpdatesUpdate.m
@@ -49,7 +49,7 @@ NS_ASSUME_NONNULL_BEGIN
   update.scopeKey = scopeKey;
   update.commitTime = commitTime;
   update.runtimeVersion = runtimeVersion;
-  update.metadata = metadata;
+  update.manifest = metadata;
   update.status = status;
   update.keep = keep;
   return update;

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -27,6 +27,7 @@
 ### 🐛 Bug fixes
 
 - Enable kotlin in all modules. ([#12716](https://github.com/expo/expo/pull/12716) by [@wschurman](https://github.com/wschurman))
+- Rename Update.metadata -> manifest in internal module classes. ([#12818](https://github.com/expo/expo/pull/12818) by [@esamelson](https://github.com/esamelson))
 
 ## 0.6.0 — 2021-04-13
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.java
@@ -295,7 +295,7 @@ public class UpdatesController {
             throw new AssertionError("Background update with error status must have a nonnull update object");
           }
           WritableMap params = Arguments.createMap();
-          params.putString("manifestString", update.metadata.toString());
+          params.putString("manifestString", update.manifest.toString());
           UpdatesUtils.sendEventToReactNative(mReactNativeHost, UPDATE_AVAILABLE_EVENT, params);
         } else if (status == LoaderTask.BackgroundUpdateStatus.NO_UPDATE_AVAILABLE) {
           UpdatesUtils.sendEventToReactNative(mReactNativeHost, UPDATE_NO_UPDATE_AVAILABLE_EVENT, null);

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.java
@@ -64,7 +64,7 @@ public class UpdatesModule extends ExportedModule {
         UpdateEntity launchedUpdate = updatesService.getLaunchedUpdate();
         if (launchedUpdate != null) {
           constants.put("updateId", launchedUpdate.id.toString());
-          constants.put("manifestString", launchedUpdate.metadata != null ? launchedUpdate.metadata.toString() : "{}");
+          constants.put("manifestString", launchedUpdate.manifest != null ? launchedUpdate.manifest.toString() : "{}");
         }
 
         Map<AssetEntity, String> localAssetFiles = updatesService.getLocalAssetFiles();
@@ -219,7 +219,7 @@ public class UpdatesModule extends ExportedModule {
                 } else {
                   updatesService.resetSelectionPolicy();
                   updateInfo.putBoolean("isNew", true);
-                  updateInfo.putString("manifestString", update.metadata.toString());
+                  updateInfo.putString("manifestString", update.manifest.toString());
                 }
                 promise.resolve(updateInfo);
               }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/entity/UpdateEntity.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/entity/UpdateEntity.java
@@ -47,7 +47,7 @@ public class UpdateEntity {
   public Long launchAssetId = null;
 
   @ColumnInfo(name = "manifest")
-  public JSONObject metadata = null;
+  public JSONObject manifest = null;
 
   @NonNull
   public UpdateStatus status = UpdateStatus.PENDING;
@@ -68,6 +68,6 @@ public class UpdateEntity {
   }
 
   public RawManifest getRawManifest() {
-    return ManifestFactory.INSTANCE.getRawManifestFromJson(this.metadata);
+    return ManifestFactory.INSTANCE.getRawManifestFromJson(this.manifest);
   }
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/BareManifest.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/BareManifest.kt
@@ -19,7 +19,6 @@ class BareManifest private constructor(
   private val mScopeKey: String,
   private val mCommitTime: Date,
   private val mRuntimeVersion: String,
-  private val mMetadata: JSONObject?,
   private val mAssets: JSONArray?
 ) : Manifest {
   override val serverDefinedHeaders: JSONObject? = null
@@ -28,9 +27,6 @@ class BareManifest private constructor(
 
   override val updateEntity: UpdateEntity by lazy {
     UpdateEntity(mId, mCommitTime, mRuntimeVersion, mScopeKey).apply {
-      if (mMetadata != null) {
-        metadata = mMetadata
-      }
       status = UpdateStatus.EMBEDDED
     }
   }
@@ -88,7 +84,6 @@ class BareManifest private constructor(
       val id = UUID.fromString(rawManifest.getID())
       val commitTime = Date(rawManifest.getCommitTimeLong())
       val runtimeVersion = UpdatesUtils.getRuntimeVersion(configuration)
-      val metadata = rawManifest.getMetadata()
       val assets = rawManifest.getAssets()
       if (runtimeVersion.contains(",")) {
         throw AssertionError("Should not be initializing a BareManifest in an environment with multiple runtime versions.")
@@ -99,7 +94,6 @@ class BareManifest private constructor(
         configuration.scopeKey,
         commitTime,
         runtimeVersion,
-        metadata,
         assets
       )
     }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/LegacyManifest.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/LegacyManifest.kt
@@ -32,7 +32,7 @@ class LegacyManifest private constructor(
 
   override val updateEntity: UpdateEntity by lazy {
     UpdateEntity(mId, mCommitTime, mRuntimeVersion, mScopeKey).apply {
-      metadata = this@LegacyManifest.rawManifest.getRawJson()
+      manifest = this@LegacyManifest.rawManifest.getRawJson()
       if (isDevelopmentMode) {
         status = UpdateStatus.DEVELOPMENT
       }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/NewManifest.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/NewManifest.kt
@@ -43,7 +43,7 @@ class NewManifest private constructor(
 
   override val updateEntity: UpdateEntity by lazy {
     UpdateEntity(mId, mCommitTime, mRuntimeVersion, mScopeKey).apply {
-      metadata = this@NewManifest.rawManifest.getRawJson()
+      manifest = this@NewManifest.rawManifest.getRawJson()
     }
   }
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/selectionpolicy/SelectionPolicies.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/selectionpolicy/SelectionPolicies.java
@@ -13,12 +13,12 @@ public class SelectionPolicies {
   public static final String TAG = SelectionPolicies.class.getSimpleName();
 
   public static boolean matchesFilters(UpdateEntity update, JSONObject manifestFilters) {
-    if (manifestFilters == null || update.metadata == null || !update.metadata.has("updateMetadata")) {
+    if (manifestFilters == null || update.manifest == null || !update.manifest.has("updateMetadata")) {
       // empty matches all
       return true;
     }
     try {
-      JSONObject updateMetadata = update.metadata.getJSONObject("updateMetadata");
+      JSONObject updateMetadata = update.manifest.getJSONObject("updateMetadata");
 
       // create lowercase copy for case-insensitive search
       JSONObject metadataLCKeys = new JSONObject();

--- a/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.m
+++ b/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.m
@@ -65,7 +65,7 @@ static NSString * const EXUpdatesDatabaseServerDefinedHeadersKey = @"serverDefin
                       update.scopeKey,
                       update.commitTime,
                       update.runtimeVersion,
-                      update.metadata ?: [NSNull null],
+                      update.manifest ?: [NSNull null],
                       @(update.status),
                       update.lastAccessed
                       ]
@@ -528,17 +528,17 @@ static NSString * const EXUpdatesDatabaseServerDefinedHeadersKey = @"serverDefin
 - (EXUpdatesUpdate *)_updateWithRow:(NSDictionary *)row config:(EXUpdatesConfig *)config
 {
   NSError *error;
-  id metadata = nil;
-  id rowMetadata = row[@"manifest"];
-  if ([rowMetadata isKindOfClass:[NSString class]]) {
-    metadata = [NSJSONSerialization JSONObjectWithData:[(NSString *)rowMetadata dataUsingEncoding:NSUTF8StringEncoding] options:kNilOptions error:&error];
-    NSAssert(!error && metadata && [metadata isKindOfClass:[NSDictionary class]], @"Update metadata should be a valid JSON object");
+  id manifest = nil;
+  id rowManifest = row[@"manifest"];
+  if ([rowManifest isKindOfClass:[NSString class]]) {
+    manifest = [NSJSONSerialization JSONObjectWithData:[(NSString *)rowManifest dataUsingEncoding:NSUTF8StringEncoding] options:kNilOptions error:&error];
+    NSAssert(!error && manifest && [manifest isKindOfClass:[NSDictionary class]], @"Update manifest should be a valid JSON object");
   }
   EXUpdatesUpdate *update = [EXUpdatesUpdate updateWithId:row[@"id"]
                                                  scopeKey:row[@"scope_key"]
                                                commitTime:[EXUpdatesDatabaseUtils dateFromUnixTimeMilliseconds:(NSNumber *)row[@"commit_time"]]
                                            runtimeVersion:row[@"runtime_version"]
-                                                 metadata:metadata
+                                                 manifest:manifest
                                                    status:(EXUpdatesUpdateStatus)[(NSNumber *)row[@"status"] integerValue]
                                                      keep:[(NSNumber *)row[@"keep"] boolValue]
                                                    config:config

--- a/packages/expo-updates/ios/EXUpdates/SelectionPolicy/EXUpdatesSelectionPolicies.m
+++ b/packages/expo-updates/ios/EXUpdates/SelectionPolicy/EXUpdatesSelectionPolicies.m
@@ -8,11 +8,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (BOOL)doesUpdate:(EXUpdatesUpdate *)update matchFilters:(nullable NSDictionary *)filters
 {
-  if (!filters || !update.metadata) {
+  if (!filters || !update.manifest) {
     return YES;
   }
   
-  NSDictionary *updateMetadata = update.metadata[@"updateMetadata"];
+  NSDictionary *updateMetadata = update.manifest[@"updateMetadata"];
   if (!updateMetadata || ![updateMetadata isKindOfClass:[NSDictionary class]]) {
     return YES;
   }

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesBareUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesBareUpdate.m
@@ -20,7 +20,6 @@ NS_ASSUME_NONNULL_BEGIN
 
   NSString *updateId = manifest.rawID;
   NSNumber *commitTime = manifest.commitTimeNumber;
-  NSDictionary *metadata = manifest.metadata;
   NSArray *assets = manifest.assets;
   
   NSAssert(updateId != nil, @"update ID should not be null");
@@ -63,9 +62,6 @@ NS_ASSUME_NONNULL_BEGIN
   update.updateId = uuid;
   update.commitTime = [NSDate dateWithTimeIntervalSince1970:[(NSNumber *)commitTime doubleValue] / 1000];
   update.runtimeVersion = [EXUpdatesUtils getRuntimeVersionWithConfig:config];
-  if (metadata) {
-    update.metadata = (NSDictionary *)metadata;
-  }
   update.status = EXUpdatesUpdateStatusEmbedded;
   update.keep = YES;
   update.assets = processedAssets;

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesLegacyUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesLegacyUpdate.m
@@ -103,7 +103,7 @@ static NSString * const EXUpdatesExpoTestDomain = @"expo.test";
     [processedAssets addObject:asset];
   }
 
-  update.metadata = manifest.rawManifestJSON;
+  update.manifest = manifest.rawManifestJSON;
   update.keep = YES;
   update.bundleUrl = bundleUrl;
   update.assets = processedAssets;

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesNewUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesNewUpdate.m
@@ -83,7 +83,7 @@ NS_ASSUME_NONNULL_BEGIN
   update.keep = YES;
   update.bundleUrl = bundleUrl;
   update.assets = processedAssets;
-  update.metadata = manifest.rawManifestJSON;
+  update.manifest = manifest.rawManifestJSON;
   
   if ([response isKindOfClass:[NSHTTPURLResponse class]]) {
     NSDictionary *headersDictionary = ((NSHTTPURLResponse *)response).allHeaderFields;

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate+Private.h
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate+Private.h
@@ -11,7 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readwrite) NSString *scopeKey;
 @property (nonatomic, strong, readwrite) NSDate *commitTime;
 @property (nonatomic, strong, readwrite) NSString *runtimeVersion;
-@property (nonatomic, strong, readwrite, nullable) NSDictionary *metadata;
+@property (nonatomic, strong, readwrite, nullable) NSDictionary *manifest;
 @property (nonatomic, assign, readwrite) BOOL keep;
 @property (nonatomic, strong, readwrite) NSURL *bundleUrl;
 @property (nonatomic, strong, readwrite) NSArray<EXUpdatesAsset *> *assets;

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate.h
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate.h
@@ -24,7 +24,7 @@ typedef NS_ENUM(NSInteger, EXUpdatesUpdateStatus) {
 @property (nonatomic, strong, readonly) NSString *scopeKey;
 @property (nonatomic, strong, readonly) NSDate *commitTime;
 @property (nonatomic, strong, readonly) NSString *runtimeVersion;
-@property (nonatomic, strong, readonly, nullable) NSDictionary * metadata;
+@property (nonatomic, strong, readonly, nullable) NSDictionary *manifest;
 @property (nonatomic, assign, readonly) BOOL keep;
 @property (nonatomic, strong, readonly) NSArray<EXUpdatesAsset *> *assets;
 @property (nonatomic, assign, readonly) BOOL isDevelopmentMode;
@@ -41,7 +41,7 @@ typedef NS_ENUM(NSInteger, EXUpdatesUpdateStatus) {
                     scopeKey:(NSString *)scopeKey
                   commitTime:(NSDate *)commitTime
               runtimeVersion:(NSString *)runtimeVersion
-                    metadata:(nullable NSDictionary *)metadata
+                    manifest:(nullable NSDictionary *)manifest
                       status:(EXUpdatesUpdateStatus)status
                         keep:(BOOL)keep
                       config:(EXUpdatesConfig *)config

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate.m
@@ -40,21 +40,20 @@ NSString * const EXUpdatesUpdateErrorDomain = @"EXUpdatesUpdate";
                     scopeKey:(NSString *)scopeKey
                   commitTime:(NSDate *)commitTime
               runtimeVersion:(NSString *)runtimeVersion
-                    metadata:(nullable NSDictionary *)metadata
+                    manifest:(nullable NSDictionary *)manifest
                       status:(EXUpdatesUpdateStatus)status
                         keep:(BOOL)keep
                       config:(EXUpdatesConfig *)config
                     database:(EXUpdatesDatabase *)database
-{  
-  // for now, we store the entire managed manifest in the metadata field
-  EXUpdatesUpdate *update = [[self alloc] initWithRawManifest:[self rawManifestForJSON:(metadata ?: @{})]
+{
+  EXUpdatesUpdate *update = [[self alloc] initWithRawManifest:[self rawManifestForJSON:(manifest ?: @{})]
                                                        config:config
                                                      database:database];
   update.updateId = updateId;
   update.scopeKey = scopeKey;
   update.commitTime = commitTime;
   update.runtimeVersion = runtimeVersion;
-  update.metadata = metadata;
+  update.manifest = manifest;
   update.status = status;
   update.keep = keep;
   return update;

--- a/packages/expo-updates/ios/Tests/EXUpdatesAppLauncherWithDatabaseTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesAppLauncherWithDatabaseTests.m
@@ -25,7 +25,7 @@
       NSString *scopeKey = @"dummyScope";
       EXUpdatesConfig *config = [EXUpdatesConfig new];
       EXUpdatesDatabase *database = [EXUpdatesDatabase new];
-      theUpdate = [EXUpdatesUpdate updateWithId:NSUUID.UUID scopeKey:scopeKey commitTime:[NSDate dateWithTimeIntervalSince1970:1608667851] runtimeVersion:runtimeVersion metadata:nil status:EXUpdatesUpdateStatusReady keep:YES config:config database:database];
+      theUpdate = [EXUpdatesUpdate updateWithId:NSUUID.UUID scopeKey:scopeKey commitTime:[NSDate dateWithTimeIntervalSince1970:1608667851] runtimeVersion:runtimeVersion manifest:nil status:EXUpdatesUpdateStatusReady keep:YES config:config database:database];
     }
   });
   return theUpdate;

--- a/packages/expo-updates/ios/Tests/EXUpdatesDatabaseIntegrityCheckTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesDatabaseIntegrityCheckTests.m
@@ -78,8 +78,8 @@
     @"EXUpdatesScopeKey": scopeKey,
     @"EXUpdatesRuntimeVersion": runtimeVersion
   }];
-  EXUpdatesUpdate *update1 = [EXUpdatesUpdate updateWithId:NSUUID.UUID scopeKey:scopeKey commitTime:[NSDate dateWithTimeIntervalSince1970:1608667851] runtimeVersion:runtimeVersion metadata:nil status:EXUpdatesUpdateStatusReady keep:YES config:config database:_db];
-  EXUpdatesUpdate *update2 = [EXUpdatesUpdate updateWithId:NSUUID.UUID scopeKey:scopeKey commitTime:[NSDate dateWithTimeIntervalSince1970:1608667852] runtimeVersion:runtimeVersion metadata:nil status:EXUpdatesUpdateStatusReady keep:YES config:config database:_db];
+  EXUpdatesUpdate *update1 = [EXUpdatesUpdate updateWithId:NSUUID.UUID scopeKey:scopeKey commitTime:[NSDate dateWithTimeIntervalSince1970:1608667851] runtimeVersion:runtimeVersion manifest:nil status:EXUpdatesUpdateStatusReady keep:YES config:config database:_db];
+  EXUpdatesUpdate *update2 = [EXUpdatesUpdate updateWithId:NSUUID.UUID scopeKey:scopeKey commitTime:[NSDate dateWithTimeIntervalSince1970:1608667852] runtimeVersion:runtimeVersion manifest:nil status:EXUpdatesUpdateStatusReady keep:YES config:config database:_db];
 
   update1.status = EXUpdatesUpdateStatusEmbedded;
   update2.status = EXUpdatesUpdateStatusEmbedded;
@@ -119,8 +119,8 @@
     @"EXUpdatesScopeKey": scopeKey,
     @"EXUpdatesRuntimeVersion": runtimeVersion
   }];
-  EXUpdatesUpdate *update1 = [EXUpdatesUpdate updateWithId:NSUUID.UUID scopeKey:scopeKey commitTime:[NSDate dateWithTimeIntervalSince1970:1608667851] runtimeVersion:runtimeVersion metadata:nil status:EXUpdatesUpdateStatusReady keep:YES config:config database:_db];
-  EXUpdatesUpdate *update2 = [EXUpdatesUpdate updateWithId:NSUUID.UUID scopeKey:scopeKey commitTime:[NSDate dateWithTimeIntervalSince1970:1608667852] runtimeVersion:runtimeVersion metadata:nil status:EXUpdatesUpdateStatusReady keep:YES config:config database:_db];
+  EXUpdatesUpdate *update1 = [EXUpdatesUpdate updateWithId:NSUUID.UUID scopeKey:scopeKey commitTime:[NSDate dateWithTimeIntervalSince1970:1608667851] runtimeVersion:runtimeVersion manifest:nil status:EXUpdatesUpdateStatusReady keep:YES config:config database:_db];
+  EXUpdatesUpdate *update2 = [EXUpdatesUpdate updateWithId:NSUUID.UUID scopeKey:scopeKey commitTime:[NSDate dateWithTimeIntervalSince1970:1608667852] runtimeVersion:runtimeVersion manifest:nil status:EXUpdatesUpdateStatusReady keep:YES config:config database:_db];
 
   update1.status = EXUpdatesUpdateStatusReady;
   update2.status = EXUpdatesUpdateStatusReady;

--- a/packages/expo-updates/ios/Tests/EXUpdatesReaperSelectionPolicyDevelopmentClientTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesReaperSelectionPolicyDevelopmentClientTests.m
@@ -28,11 +28,11 @@
   EXUpdatesDatabase *database = [EXUpdatesDatabase new];
 
   // test updates with different scopes to ensure this policy ignores scopes
-  _update1 = [EXUpdatesUpdate updateWithId:NSUUID.UUID scopeKey:@"scope1" commitTime:[NSDate dateWithTimeIntervalSince1970:1608667851] runtimeVersion:runtimeVersion metadata:nil status:EXUpdatesUpdateStatusReady keep:YES config:config database:database];
-  _update2 = [EXUpdatesUpdate updateWithId:NSUUID.UUID scopeKey:@"scope2" commitTime:[NSDate dateWithTimeIntervalSince1970:1608667852] runtimeVersion:runtimeVersion metadata:nil status:EXUpdatesUpdateStatusReady keep:YES config:config database:database];
-  _update3 = [EXUpdatesUpdate updateWithId:NSUUID.UUID scopeKey:@"scope3" commitTime:[NSDate dateWithTimeIntervalSince1970:1608667853] runtimeVersion:runtimeVersion metadata:nil status:EXUpdatesUpdateStatusReady keep:YES config:config database:database];
-  _update4 = [EXUpdatesUpdate updateWithId:NSUUID.UUID scopeKey:@"scope4" commitTime:[NSDate dateWithTimeIntervalSince1970:1608667854] runtimeVersion:runtimeVersion metadata:nil status:EXUpdatesUpdateStatusReady keep:YES config:config database:database];
-  _update5 = [EXUpdatesUpdate updateWithId:NSUUID.UUID scopeKey:@"scope5" commitTime:[NSDate dateWithTimeIntervalSince1970:1608667855] runtimeVersion:runtimeVersion metadata:nil status:EXUpdatesUpdateStatusReady keep:YES config:config database:database];
+  _update1 = [EXUpdatesUpdate updateWithId:NSUUID.UUID scopeKey:@"scope1" commitTime:[NSDate dateWithTimeIntervalSince1970:1608667851] runtimeVersion:runtimeVersion manifest:nil status:EXUpdatesUpdateStatusReady keep:YES config:config database:database];
+  _update2 = [EXUpdatesUpdate updateWithId:NSUUID.UUID scopeKey:@"scope2" commitTime:[NSDate dateWithTimeIntervalSince1970:1608667852] runtimeVersion:runtimeVersion manifest:nil status:EXUpdatesUpdateStatusReady keep:YES config:config database:database];
+  _update3 = [EXUpdatesUpdate updateWithId:NSUUID.UUID scopeKey:@"scope3" commitTime:[NSDate dateWithTimeIntervalSince1970:1608667853] runtimeVersion:runtimeVersion manifest:nil status:EXUpdatesUpdateStatusReady keep:YES config:config database:database];
+  _update4 = [EXUpdatesUpdate updateWithId:NSUUID.UUID scopeKey:@"scope4" commitTime:[NSDate dateWithTimeIntervalSince1970:1608667854] runtimeVersion:runtimeVersion manifest:nil status:EXUpdatesUpdateStatusReady keep:YES config:config database:database];
+  _update5 = [EXUpdatesUpdate updateWithId:NSUUID.UUID scopeKey:@"scope5" commitTime:[NSDate dateWithTimeIntervalSince1970:1608667855] runtimeVersion:runtimeVersion manifest:nil status:EXUpdatesUpdateStatusReady keep:YES config:config database:database];
 
   // for readability/writability, test with a policy that keeps only 3 updates;
   // the actual functionality is independent of the number

--- a/packages/expo-updates/ios/Tests/EXUpdatesReaperSelectionPolicyFilterAwareTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesReaperSelectionPolicyFilterAwareTests.m
@@ -29,11 +29,11 @@
   NSString *scopeKey = @"dummyScope";
   _config = [EXUpdatesConfig new];
   _database = [EXUpdatesDatabase new];
-  _update1 = [EXUpdatesUpdate updateWithId:NSUUID.UUID scopeKey:scopeKey commitTime:[NSDate dateWithTimeIntervalSince1970:1608667851] runtimeVersion:runtimeVersion metadata:nil status:EXUpdatesUpdateStatusReady keep:YES config:_config database:_database];
-  _update2 = [EXUpdatesUpdate updateWithId:NSUUID.UUID scopeKey:scopeKey commitTime:[NSDate dateWithTimeIntervalSince1970:1608667852] runtimeVersion:runtimeVersion metadata:nil status:EXUpdatesUpdateStatusReady keep:YES config:_config database:_database];
-  _update3 = [EXUpdatesUpdate updateWithId:NSUUID.UUID scopeKey:scopeKey commitTime:[NSDate dateWithTimeIntervalSince1970:1608667853] runtimeVersion:runtimeVersion metadata:nil status:EXUpdatesUpdateStatusReady keep:YES config:_config database:_database];
-  _update4 = [EXUpdatesUpdate updateWithId:NSUUID.UUID scopeKey:scopeKey commitTime:[NSDate dateWithTimeIntervalSince1970:1608667854] runtimeVersion:runtimeVersion metadata:nil status:EXUpdatesUpdateStatusReady keep:YES config:_config database:_database];
-  _update5 = [EXUpdatesUpdate updateWithId:NSUUID.UUID scopeKey:scopeKey commitTime:[NSDate dateWithTimeIntervalSince1970:1608667855] runtimeVersion:runtimeVersion metadata:nil status:EXUpdatesUpdateStatusReady keep:YES config:_config database:_database];
+  _update1 = [EXUpdatesUpdate updateWithId:NSUUID.UUID scopeKey:scopeKey commitTime:[NSDate dateWithTimeIntervalSince1970:1608667851] runtimeVersion:runtimeVersion manifest:nil status:EXUpdatesUpdateStatusReady keep:YES config:_config database:_database];
+  _update2 = [EXUpdatesUpdate updateWithId:NSUUID.UUID scopeKey:scopeKey commitTime:[NSDate dateWithTimeIntervalSince1970:1608667852] runtimeVersion:runtimeVersion manifest:nil status:EXUpdatesUpdateStatusReady keep:YES config:_config database:_database];
+  _update3 = [EXUpdatesUpdate updateWithId:NSUUID.UUID scopeKey:scopeKey commitTime:[NSDate dateWithTimeIntervalSince1970:1608667853] runtimeVersion:runtimeVersion manifest:nil status:EXUpdatesUpdateStatusReady keep:YES config:_config database:_database];
+  _update4 = [EXUpdatesUpdate updateWithId:NSUUID.UUID scopeKey:scopeKey commitTime:[NSDate dateWithTimeIntervalSince1970:1608667854] runtimeVersion:runtimeVersion manifest:nil status:EXUpdatesUpdateStatusReady keep:YES config:_config database:_database];
+  _update5 = [EXUpdatesUpdate updateWithId:NSUUID.UUID scopeKey:scopeKey commitTime:[NSDate dateWithTimeIntervalSince1970:1608667855] runtimeVersion:runtimeVersion manifest:nil status:EXUpdatesUpdateStatusReady keep:YES config:_config database:_database];
   _selectionPolicy = [[EXUpdatesReaperSelectionPolicyFilterAware alloc] init];
 }
 
@@ -76,7 +76,7 @@
 
 - (void)testUpdatesToDelete_differentScopeKey
 {
-  EXUpdatesUpdate *update4DifferentScope = [EXUpdatesUpdate updateWithId:_update4.updateId scopeKey:@"differentScopeKey" commitTime:_update4.commitTime runtimeVersion:_update4.runtimeVersion metadata:nil status:_update4.status keep:YES config:_config database:_database];
+  EXUpdatesUpdate *update4DifferentScope = [EXUpdatesUpdate updateWithId:_update4.updateId scopeKey:@"differentScopeKey" commitTime:_update4.commitTime runtimeVersion:_update4.runtimeVersion manifest:nil status:_update4.status keep:YES config:_config database:_database];
 
   NSArray<EXUpdatesUpdate *> *updatesToDelete = [_selectionPolicy updatesToDeleteWithLaunchedUpdate:update4DifferentScope updates:@[_update1, _update2, _update3, update4DifferentScope] filters:nil];
 


### PR DESCRIPTION
# Why

Follow-up to https://github.com/expo/expo/pull/12768#discussion_r623040507

# How

- Android: use Android Studio to rename the property on UpdateEntity
- iOS: search + replace all usages of `update.metadata` and `metadata:` with `update.manifest` and `manifest:`; manually modify a few more places in EXUpdatesUpdate.h/.m. Project-wide search of `metadata` to ensure no other relevant usages were missed.

I also changed the logic for embedded (bare) updates slightly; previously we looked for a field in the manifest called `metadata` and stored that in the db column, but we never actually had that field, so I've just removed that logic entirely.

To be clear, this doesn't change anything about current behavior; we store no manifest for embedded updates both before and after this PR. But it does open up the question -- should we be storing the embedded/bare manifest for embedded updates? My thinking is no, because it is so different from the format of both legacy and new updates, that manifest consumers (dev client, any developer using Constants.manifest/Updates.manifest, etc.) are better served handling a null/empty case than explicitly having to handle multiple possible formats. And the manifest for any embedded update is of no use unless it's the update that's embedded in the currently installed build -- in which case the manifest is available on disk. Open to other thoughts though!

# Test Plan

All unit tests pass; also ran Expo Go builds on each platform and verified that the versioned Updates module methods work. ✅ 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).