### PR TITLE
[expo-updates] add non-destructive migration to database v6

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Save asset with a key that does not include an extension. This introduces an implicit dependency on expo-asset@8.3.2 or above. ([#12734](https://github.com/expo/expo/pull/12734) by [@jkhales](https://github.com/jkhales))
 - Add last_accessed column to updates table schema, and rename metadata -> manifest. ([#12768](https://github.com/expo/expo/pull/12768) by [@esamelson](https://github.com/esamelson))
+- Add non-destructive database migration for the above change. ([#12820](https://github.com/expo/expo/pull/12820) by [@esamelson](https://github.com/esamelson))
 
 ### 🎉 New features
 

--- a/packages/expo-updates/android/build.gradle
+++ b/packages/expo-updates/android/build.gradle
@@ -54,6 +54,13 @@ android {
     versionCode 31
     versionName '0.6.0'
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    // uncomment below to export the database schema when making changes
+    /* javaCompileOptions {
+      annotationProcessorOptions {
+        arguments += ["room.schemaLocation":
+                      "$projectDir/src/androidTest/schemas".toString()]
+      }
+    } */
   }
   lintOptions {
     abortOnError false

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/db/UpdatesDatabaseMigrationTest.java
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/db/UpdatesDatabaseMigrationTest.java
@@ -86,18 +86,104 @@ public class UpdatesDatabaseMigrationTest {
     Cursor cursorUpdatesAssets4 = db.query("SELECT * FROM `updates_assets` WHERE `update_id` = X'594100ea066e4804b5c7c907c773f980' AND `asset_id` = 5");
     Assert.assertEquals(1, cursorUpdatesAssets4.getCount());
 
-    boolean fails;
-    try {
-      db.execSQL("INSERT INTO `updates_assets` (`update_id`, `asset_id`) VALUES (X'594100ea066e4804b5c7c907c773f980', 13)");
-      fails = false;
-    } catch (SQLiteConstraintException e) {
-      fails = true;
-    }
-    Assert.assertTrue(fails);
+    Assert.assertTrue(execSQLExpectingException(db, "INSERT INTO `updates_assets` (`update_id`, `asset_id`) VALUES (X'594100ea066e4804b5c7c907c773f980', 13)"));
 
     // test on delete cascade
     db.execSQL("DELETE FROM `assets` WHERE `id` = 5");
     Cursor cursorUpdatesAssets6 = db.query("SELECT * FROM `updates_assets` WHERE `update_id` = X'594100ea066e4804b5c7c907c773f980' AND `asset_id` = 5");
     Assert.assertEquals(0, cursorUpdatesAssets6.getCount());
+  }
+
+  @Test
+  public void testMigrate5To6() throws IOException {
+    SupportSQLiteDatabase db = helper.createDatabase(TEST_DB, 5);
+
+    // db has schema version 5. insert some data using SQL queries.
+    // cannot use DAO classes because they expect the latest schema.
+    db.execSQL("INSERT INTO \"assets\" (\"id\",\"url\",\"key\",\"headers\",\"type\",\"metadata\",\"download_time\",\"relative_path\",\"hash\",\"hash_type\",\"marked_for_deletion\") VALUES" +
+            " (2,'https://url.to/b56cf690e0afa93bd4dc7756d01edd3e','b56cf690e0afa93bd4dc7756d01edd3e.png',NULL,'image/png',NULL,1614137309295,'b56cf690e0afa93bd4dc7756d01edd3e.png',NULL,0,0),\n" +
+            " (3,'https://url.to/bundle-1614137308871','bundle-1614137308871',NULL,'application/javascript',NULL,1614137309513,'bundle-1614137308871',NULL,0,0),\n" +
+            " (4,NULL,NULL,NULL,'js',NULL,1614137406588,'bundle-1614137401950',NULL,0,0)");
+    db.execSQL("INSERT INTO \"updates\" (\"id\",\"scope_key\",\"commit_time\",\"runtime_version\",\"launch_asset_id\",\"metadata\",\"status\",\"keep\") VALUES" +
+            " (X'8C263F9DE3FF48888496E3244C788661','http://192.168.4.44:3000',1614137308871,'40.0.0',3,'{\\\"updateMetadata\\\":{\\\"updateGroup\\\":\\\"34993d39-57e6-46cf-8fa2-eba836f40828\\\",\\\"branchName\\\":\\\"rollout\\\"}}',1,1),\n" +
+            " (X'594100ea066e4804b5c7c907c773f980','http://192.168.4.44:3000',1614137401950,'40.0.0',4,NULL,1,1)");
+    db.execSQL("INSERT INTO \"updates_assets\" (\"update_id\",\"asset_id\") VALUES" +
+            " (X'8C263F9DE3FF48888496E3244C788661',2),\n" +
+            " (X'8C263F9DE3FF48888496E3244C788661',3),\n" +
+            " (X'594100ea066e4804b5c7c907c773f980',4)");
+
+    // Prepare for the next version.
+    db.close();
+
+    // Re-open the database with version 6 and provide
+    // MIGRATION_5_6 as the migration process.
+    db = helper.runMigrationsAndValidate(TEST_DB, 6, true, UpdatesDatabase.MIGRATION_5_6);
+
+    db.execSQL("PRAGMA foreign_keys=ON");
+
+    // schema changes automatically verified, we just need to verify data integrity
+    Cursor cursorUpdates1 = db.query("SELECT * FROM `updates` WHERE `id` = X'8C263F9DE3FF48888496E3244C788661' AND `scope_key` = 'http://192.168.4.44:3000' AND `commit_time` = 1614137308871 AND `runtime_version` = '40.0.0' AND `launch_asset_id` = 3 AND `manifest` IS NOT NULL AND `status` = 1 AND `keep` = 1");
+    Assert.assertEquals(1, cursorUpdates1.getCount());
+    Cursor cursorUpdates2 = db.query("SELECT * FROM `updates` WHERE `id` = X'594100ea066e4804b5c7c907c773f980' AND `scope_key` = 'http://192.168.4.44:3000' AND `commit_time` = 1614137401950 AND `runtime_version` = '40.0.0' AND `launch_asset_id` = 4 AND `manifest` IS NULL AND `status` = 1 AND `keep` = 1");
+    Assert.assertEquals(1, cursorUpdates2.getCount());
+
+    Cursor cursorAssets1 = db.query("SELECT * FROM `assets` WHERE `id` = 2 AND `url` = 'https://url.to/b56cf690e0afa93bd4dc7756d01edd3e' AND `key` = 'b56cf690e0afa93bd4dc7756d01edd3e.png' AND `headers` IS NULL AND `type` = 'image/png' AND `metadata` IS NULL AND `download_time` = 1614137309295 AND `relative_path` = 'b56cf690e0afa93bd4dc7756d01edd3e.png' AND `hash` IS NULL AND `hash_type` = 0 AND `marked_for_deletion` = 0");
+    Assert.assertEquals(1, cursorAssets1.getCount());
+    Cursor cursorAssets2 = db.query("SELECT * FROM `assets` WHERE `id` = 3 AND `url` = 'https://url.to/bundle-1614137308871' AND `key` = 'bundle-1614137308871' AND `headers` IS NULL AND `type` = 'application/javascript' AND `metadata` IS NULL AND `download_time` = 1614137309513 AND `relative_path` = 'bundle-1614137308871' AND `hash` IS NULL AND `hash_type` = 0 AND `marked_for_deletion` = 0");
+    Assert.assertEquals(1, cursorAssets2.getCount());
+    Cursor cursorAssets3 = db.query("SELECT * FROM `assets` WHERE `id` = 4 AND `url` IS NULL AND `key` IS NULL AND `headers` IS NULL AND `type` = 'js' AND `metadata` IS NULL AND `download_time` = 1614137406588 AND `relative_path` = 'bundle-1614137401950' AND `hash` IS NULL AND `hash_type` = 0 AND `marked_for_deletion` = 0");
+    Assert.assertEquals(1, cursorAssets3.getCount());
+
+    Cursor cursorUpdatesAssets1 = db.query("SELECT * FROM `updates_assets` WHERE `update_id` = X'8C263F9DE3FF48888496E3244C788661' AND `asset_id` = 2");
+    Assert.assertEquals(1, cursorUpdatesAssets1.getCount());
+    Cursor cursorUpdatesAssets2 = db.query("SELECT * FROM `updates_assets` WHERE `update_id` = X'8C263F9DE3FF48888496E3244C788661' AND `asset_id` = 3");
+    Assert.assertEquals(1, cursorUpdatesAssets2.getCount());
+    Cursor cursorUpdatesAssets3 = db.query("SELECT * FROM `updates_assets` WHERE `update_id` = X'594100ea066e4804b5c7c907c773f980' AND `asset_id` = 4");
+    Assert.assertEquals(1, cursorUpdatesAssets3.getCount());
+
+    // make sure metadata -> manifest column rename worked
+    Cursor cursorNonNullManifest = db.query("SELECT * FROM `updates` WHERE `id` = X'8C263F9DE3FF48888496E3244C788661' AND `manifest` = '{\\\"updateMetadata\\\":{\\\"updateGroup\\\":\\\"34993d39-57e6-46cf-8fa2-eba836f40828\\\",\\\"branchName\\\":\\\"rollout\\\"}}'");
+    Assert.assertEquals(1, cursorNonNullManifest.getCount());
+
+    // make sure last_accessed column was filled in appropriately (all existing updates have the same last_accessed time)
+    Cursor cursorLastAccessed = db.query("SELECT DISTINCT last_accessed FROM `updates`");
+    Assert.assertEquals(1, cursorLastAccessed.getCount());
+
+    // make sure we can add new updates with different last_accessed times
+    db.execSQL("INSERT INTO \"updates\" (\"id\",\"scope_key\",\"commit_time\",\"runtime_version\",\"launch_asset_id\",\"manifest\",\"status\",\"keep\", \"last_accessed\") VALUES" +
+            " (X'8F06A50E5A68499F986CCA31EE159F81','https://exp.host/@esamelson/sdk41updates',1619133262732,'41.0.0',NULL,NULL,1,1,1619647642456)");
+    Cursor cursorLastAccessed2 = db.query("SELECT DISTINCT last_accessed FROM `updates`");
+    Assert.assertEquals(2, cursorLastAccessed2.getCount());
+
+    // make sure foreign key constraints still work
+
+    // try to insert an update with a non-existent launch asset id (47)
+    Assert.assertTrue(execSQLExpectingException(db, "INSERT INTO \"updates\" (\"id\",\"scope_key\",\"commit_time\",\"runtime_version\",\"launch_asset_id\",\"manifest\",\"status\",\"keep\", \"last_accessed\") VALUES" +
+            " (X'E1AC9D5F55E041BBA5A9193DD1C1123A','https://exp.host/@esamelson/sdk41updates',1620168547318,'41.0.0',47,NULL,1,1,1619647642456)"));
+    // try to insert an entry in updates_assets that references a nonexistent update
+    Assert.assertTrue(execSQLExpectingException(db, "INSERT INTO `updates_assets` (`update_id`, `asset_id`) VALUES (X'3CF0A835CB3A4A5D9C14DFA3D55DE44D', 3)"));
+
+    // test updates on delete cascade
+    db.execSQL("DELETE FROM `assets` WHERE `id` = 3");
+    Cursor cursorUpdatesOnDelete = db.query("SELECT * FROM `updates` WHERE `id` = X'8C263F9DE3FF48888496E3244C788661'");
+    Assert.assertEquals(0, cursorUpdatesOnDelete.getCount());
+
+    // test updates_assets on delete cascade
+    // previous deletion should have deleted the update, which then should have deleted both entries in updates_assets
+    Cursor cursorUpdatesAssetsOnDelete1 = db.query("SELECT * FROM `updates_assets` WHERE `update_id` = X'8C263F9DE3FF48888496E3244C788661' AND `asset_id` = 2");
+    Assert.assertEquals(0, cursorUpdatesAssetsOnDelete1.getCount());
+    Cursor cursorUpdatesAssetsOnDelete2 = db.query("SELECT * FROM `updates_assets` WHERE `update_id` = X'8C263F9DE3FF48888496E3244C788661' AND `asset_id` = 3");
+    Assert.assertEquals(0, cursorUpdatesAssetsOnDelete2.getCount());
+  }
+
+  private boolean execSQLExpectingException(SupportSQLiteDatabase db, String sql) {
+    boolean fails;
+    try {
+      db.execSQL(sql);
+      fails = false;
+    } catch (SQLiteConstraintException e) {
+      fails = true;
+    }
+    return fails;
   }
 }

--- a/packages/expo-updates/android/src/androidTest/schemas/expo.modules.updates.db.UpdatesDatabase/6.json
+++ b/packages/expo-updates/android/src/androidTest/schemas/expo.modules.updates.db.UpdatesDatabase/6.json
@@ -1,0 +1,313 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 6,
+    "identityHash": "11427ffec6234dd35c2840f1b89d2efb",
+    "entities": [
+      {
+        "tableName": "updates",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `scope_key` TEXT NOT NULL, `commit_time` INTEGER NOT NULL, `runtime_version` TEXT NOT NULL, `launch_asset_id` INTEGER, `manifest` TEXT, `status` INTEGER NOT NULL, `keep` INTEGER NOT NULL, `last_accessed` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`launch_asset_id`) REFERENCES `assets`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scopeKey",
+            "columnName": "scope_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "commitTime",
+            "columnName": "commit_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "runtimeVersion",
+            "columnName": "runtime_version",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "launchAssetId",
+            "columnName": "launch_asset_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "metadata",
+            "columnName": "manifest",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "keep",
+            "columnName": "keep",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessed",
+            "columnName": "last_accessed",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_updates_launch_asset_id",
+            "unique": false,
+            "columnNames": [
+              "launch_asset_id"
+            ],
+            "createSql": "CREATE  INDEX `index_updates_launch_asset_id` ON `${TABLE_NAME}` (`launch_asset_id`)"
+          },
+          {
+            "name": "index_updates_scope_key_commit_time",
+            "unique": true,
+            "columnNames": [
+              "scope_key",
+              "commit_time"
+            ],
+            "createSql": "CREATE UNIQUE INDEX `index_updates_scope_key_commit_time` ON `${TABLE_NAME}` (`scope_key`, `commit_time`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "assets",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "launch_asset_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "updates_assets",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`update_id` BLOB NOT NULL, `asset_id` INTEGER NOT NULL, PRIMARY KEY(`update_id`, `asset_id`), FOREIGN KEY(`update_id`) REFERENCES `updates`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`asset_id`) REFERENCES `assets`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "updateId",
+            "columnName": "update_id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "assetId",
+            "columnName": "asset_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "update_id",
+            "asset_id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_updates_assets_asset_id",
+            "unique": false,
+            "columnNames": [
+              "asset_id"
+            ],
+            "createSql": "CREATE  INDEX `index_updates_assets_asset_id` ON `${TABLE_NAME}` (`asset_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "updates",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "update_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "assets",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "asset_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "assets",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `url` TEXT, `key` TEXT, `headers` TEXT, `type` TEXT NOT NULL, `metadata` TEXT, `download_time` INTEGER, `relative_path` TEXT, `hash` BLOB, `hash_type` INTEGER NOT NULL, `marked_for_deletion` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "headers",
+            "columnName": "headers",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadata",
+            "columnName": "metadata",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "downloadTime",
+            "columnName": "download_time",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "relativePath",
+            "columnName": "relative_path",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "hash",
+            "columnName": "hash",
+            "affinity": "BLOB",
+            "notNull": false
+          },
+          {
+            "fieldPath": "hashType",
+            "columnName": "hash_type",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "markedForDeletion",
+            "columnName": "marked_for_deletion",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_assets_key",
+            "unique": true,
+            "columnNames": [
+              "key"
+            ],
+            "createSql": "CREATE UNIQUE INDEX `index_assets_key` ON `${TABLE_NAME}` (`key`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "json_data",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `key` TEXT NOT NULL, `value` TEXT NOT NULL, `last_updated` INTEGER NOT NULL, `scope_key` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUpdated",
+            "columnName": "last_updated",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scopeKey",
+            "columnName": "scope_key",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_json_data_scope_key",
+            "unique": false,
+            "columnNames": [
+              "scope_key"
+            ],
+            "createSql": "CREATE  INDEX `index_json_data_scope_key` ON `${TABLE_NAME}` (`scope_key`)"
+          }
+        ],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '11427ffec6234dd35c2840f1b89d2efb')"
+    ]
+  }
+}

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/UpdatesDatabase.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/UpdatesDatabase.java
@@ -82,7 +82,7 @@ public abstract class UpdatesDatabase extends RoomDatabase {
           // insert current time as lastAccessed date for all existing updates
           long currentTime = new Date().getTime();
           database.execSQL("INSERT INTO `new_updates` (`id`, `scope_key`, `commit_time`, `runtime_version`, `launch_asset_id`, `manifest`, `status`, `keep`, `last_accessed`)" +
-                  " SELECT `id`, `scope_key`, `commit_time`, `runtime_version`, `launch_asset_id`, `metadata` AS `manifest`, `status`, `keep`, " + currentTime + " AS `last_accessed` FROM `updates`");
+                  " SELECT `id`, `scope_key`, `commit_time`, `runtime_version`, `launch_asset_id`, `metadata` AS `manifest`, `status`, `keep`, ?1 AS `last_accessed` FROM `updates`", new Object[]{currentTime});
           database.execSQL("DROP TABLE `updates`");
           database.execSQL("ALTER TABLE `new_updates` RENAME TO `updates`");
           database.execSQL("CREATE INDEX `index_updates_launch_asset_id` ON `updates` (`launch_asset_id`)");

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/UpdatesDatabase.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/UpdatesDatabase.java
@@ -20,6 +20,8 @@ import androidx.room.RoomDatabase;
 import androidx.room.TypeConverters;
 import androidx.sqlite.db.SupportSQLiteDatabase;
 
+import java.util.Date;
+
 @Database(entities = {UpdateEntity.class, UpdateAssetEntity.class, AssetEntity.class, JSONDataEntity.class}, exportSchema = false, version = 6)
 @TypeConverters({Converters.class})
 public abstract class UpdatesDatabase extends RoomDatabase {
@@ -58,6 +60,33 @@ public abstract class UpdatesDatabase extends RoomDatabase {
           database.execSQL("DROP TABLE `assets`");
           database.execSQL("ALTER TABLE `new_assets` RENAME TO `assets`");
           database.execSQL("CREATE UNIQUE INDEX `index_assets_key` ON `assets` (`key`)");
+          database.setTransactionSuccessful();
+        } finally {
+          database.endTransaction();
+        }
+      } finally {
+        database.execSQL("PRAGMA foreign_keys=ON");
+      }
+    }
+  };
+
+  static final Migration MIGRATION_5_6 = new Migration(5, 6) {
+    @Override
+    public void migrate(@NonNull SupportSQLiteDatabase database) {
+      // https://www.sqlite.org/lang_altertable.html#otheralter
+      database.execSQL("PRAGMA foreign_keys=OFF");
+      database.beginTransaction();
+      try {
+        try {
+          database.execSQL("CREATE TABLE `new_updates` (`id` BLOB NOT NULL, `scope_key` TEXT NOT NULL, `commit_time` INTEGER NOT NULL, `runtime_version` TEXT NOT NULL, `launch_asset_id` INTEGER, `manifest` TEXT, `status` INTEGER NOT NULL, `keep` INTEGER NOT NULL, `last_accessed` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`launch_asset_id`) REFERENCES `assets`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )");
+          // insert current time as lastAccessed date for all existing updates
+          long currentTime = new Date().getTime();
+          database.execSQL("INSERT INTO `new_updates` (`id`, `scope_key`, `commit_time`, `runtime_version`, `launch_asset_id`, `manifest`, `status`, `keep`, `last_accessed`)" +
+                  " SELECT `id`, `scope_key`, `commit_time`, `runtime_version`, `launch_asset_id`, `metadata` AS `manifest`, `status`, `keep`, " + currentTime + " AS `last_accessed` FROM `updates`");
+          database.execSQL("DROP TABLE `updates`");
+          database.execSQL("ALTER TABLE `new_updates` RENAME TO `updates`");
+          database.execSQL("CREATE INDEX `index_updates_launch_asset_id` ON `updates` (`launch_asset_id`)");
+          database.execSQL("CREATE UNIQUE INDEX `index_updates_scope_key_commit_time` ON `updates` (`scope_key`, `commit_time`)");
           database.setTransactionSuccessful();
         } finally {
           database.endTransaction();

--- a/packages/expo-updates/ios/EXUpdates/Database/Migrations/EXUpdatesDatabaseMigration5To6.m
+++ b/packages/expo-updates/ios/EXUpdates/Database/Migrations/EXUpdatesDatabaseMigration5To6.m
@@ -15,7 +15,44 @@ static NSString * const EXUpdatesDatabaseV5Filename = @"expo-v5.db";
 
 - (BOOL)runMigrationOnDatabase:(struct sqlite3 *)db error:(NSError ** _Nullable)error
 {
-  return NO;
+  // https://www.sqlite.org/lang_altertable.html#otheralter
+  if (sqlite3_exec(db, "PRAGMA foreign_keys=OFF;", NULL, NULL, NULL) != SQLITE_OK) return NO;
+  if (sqlite3_exec(db, "BEGIN;", NULL, NULL, NULL) != SQLITE_OK) return NO;
+
+  if (![self _safeExecOrRollback:db sql:@"CREATE TABLE \"new_updates\" (\
+        \"id\"  BLOB UNIQUE,\
+        \"scope_key\"  TEXT NOT NULL,\
+        \"commit_time\"  INTEGER NOT NULL,\
+        \"runtime_version\"  TEXT NOT NULL,\
+        \"launch_asset_id\" INTEGER,\
+        \"manifest\"  TEXT,\
+        \"status\"  INTEGER NOT NULL,\
+        \"keep\"  INTEGER NOT NULL,\
+        \"last_accessed\"  INTEGER NOT NULL,\
+        PRIMARY KEY(\"id\"),\
+        FOREIGN KEY(\"launch_asset_id\") REFERENCES \"assets\"(\"id\") ON DELETE CASCADE\
+        )"]) return NO;
+  // insert current time as lastAccessed date for all existing updates
+  long long currentTime = [NSDate date].timeIntervalSince1970 * 1000;
+  if (![self _safeExecOrRollback:db sql:[NSString stringWithFormat:@"INSERT INTO `new_updates` (`id`, `scope_key`, `commit_time`, `runtime_version`, `launch_asset_id`, `manifest`, `status`, `keep`, `last_accessed`)\
+                                         SELECT `id`, `scope_key`, `commit_time`, `runtime_version`, `launch_asset_id`, `metadata` AS `manifest`, `status`, `keep`, %lli AS `last_accessed` FROM `updates`", currentTime]]) return NO;
+  if (![self _safeExecOrRollback:db sql:@"DROP TABLE `updates`"]) return NO;
+  if (![self _safeExecOrRollback:db sql:@"ALTER TABLE `new_updates` RENAME TO `updates`"]) return NO;
+  if (![self _safeExecOrRollback:db sql:@"CREATE UNIQUE INDEX \"index_updates_scope_key_commit_time\" ON \"updates\" (\"scope_key\", \"commit_time\")"]) return NO;
+  if (![self _safeExecOrRollback:db sql:@"CREATE INDEX \"index_updates_launch_asset_id\" ON \"updates\" (\"launch_asset_id\")"]) return NO;
+
+  if (sqlite3_exec(db, "COMMIT;", NULL, NULL, NULL) != SQLITE_OK) return NO;
+  if (sqlite3_exec(db, "PRAGMA foreign_keys=ON;", NULL, NULL, NULL) != SQLITE_OK) return NO;
+  return YES;
+}
+
+- (BOOL)_safeExecOrRollback:(struct sqlite3 *)db sql:(NSString *)sql
+{
+  if (sqlite3_exec(db, sql.UTF8String, NULL, NULL, NULL) != SQLITE_OK) {
+    sqlite3_exec(db, "ROLLBACK;", NULL, NULL, NULL);
+    return NO;
+  }
+  return YES;
 }
 
 @end

--- a/packages/expo-updates/ios/Tests/EXUpdatesDatabaseInitializationTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesDatabaseInitializationTests.m
@@ -4,6 +4,7 @@
 
 #import <EXUpdates/EXUpdatesDatabaseInitialization+Tests.h>
 #import <EXUpdates/EXUpdatesDatabaseMigration4To5.h>
+#import <EXUpdates/EXUpdatesDatabaseMigration5To6.h>
 #import <EXUpdates/EXUpdatesDatabaseUtils.h>
 
 #import <sqlite3.h>
@@ -25,6 +26,50 @@ CREATE TABLE \"assets\" (\
 \"id\"  INTEGER PRIMARY KEY AUTOINCREMENT,\
 \"url\"  TEXT,\
 \"key\"  TEXT NOT NULL UNIQUE,\
+\"headers\"  TEXT,\
+\"type\"  TEXT NOT NULL,\
+\"metadata\"  TEXT,\
+\"download_time\"  INTEGER NOT NULL,\
+\"relative_path\"  TEXT NOT NULL,\
+\"hash\"  BLOB NOT NULL,\
+\"hash_type\"  INTEGER NOT NULL,\
+\"marked_for_deletion\"  INTEGER NOT NULL\
+);\
+CREATE TABLE \"updates_assets\" (\
+\"update_id\"  BLOB NOT NULL,\
+\"asset_id\" INTEGER NOT NULL,\
+FOREIGN KEY(\"update_id\") REFERENCES \"updates\"(\"id\") ON DELETE CASCADE,\
+FOREIGN KEY(\"asset_id\") REFERENCES \"assets\"(\"id\") ON DELETE CASCADE\
+);\
+CREATE TABLE \"json_data\" (\
+\"id\" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,\
+\"key\" TEXT NOT NULL,\
+\"value\" TEXT NOT NULL,\
+\"last_updated\" INTEGER NOT NULL,\
+\"scope_key\" TEXT NOT NULL\
+);\
+CREATE UNIQUE INDEX \"index_updates_scope_key_commit_time\" ON \"updates\" (\"scope_key\", \"commit_time\");\
+CREATE INDEX \"index_updates_launch_asset_id\" ON \"updates\" (\"launch_asset_id\");\
+CREATE INDEX \"index_json_data_scope_key\" ON \"json_data\" (\"scope_key\")\
+";
+
+static NSString * const EXUpdatesDatabaseV5Schema = @"\
+CREATE TABLE \"updates\" (\
+\"id\"  BLOB UNIQUE,\
+\"scope_key\"  TEXT NOT NULL,\
+\"commit_time\"  INTEGER NOT NULL,\
+\"runtime_version\"  TEXT NOT NULL,\
+\"launch_asset_id\" INTEGER,\
+\"metadata\"  TEXT,\
+\"status\"  INTEGER NOT NULL,\
+\"keep\"  INTEGER NOT NULL,\
+PRIMARY KEY(\"id\"),\
+FOREIGN KEY(\"launch_asset_id\") REFERENCES \"assets\"(\"id\") ON DELETE CASCADE\
+);\
+CREATE TABLE \"assets\" (\
+\"id\"  INTEGER PRIMARY KEY AUTOINCREMENT,\
+\"url\"  TEXT,\
+\"key\"  TEXT UNIQUE,\
 \"headers\"  TEXT,\
 \"type\"  TEXT NOT NULL,\
 \"metadata\"  TEXT,\
@@ -108,6 +153,77 @@ CREATE INDEX \"index_json_data_scope_key\" ON \"json_data\" (\"scope_key\")\
   NSArray<NSDictionary *> *rows = [EXUpdatesDatabaseUtils executeSql:selectSql withArgs:nil onDatabase:newDb error:nil];
   XCTAssertEqual(1, rows.count);
   XCTAssertEqualObjects(@1, rows[0][@"id"]);
+}
+
+- (void)testMigration4ToLatest
+{
+  // this test just does some simple data validation to make sure the database persists across all migrations
+  // individual migrations are tested in more detail individually
+  sqlite3 *db;
+  NSError *initializeError;
+  [EXUpdatesDatabaseInitialization initializeDatabaseWithSchema:EXUpdatesDatabaseV4Schema
+                                                       filename:@"expo-v4.db"
+                                                    inDirectory:_testDatabaseDir
+                                                  shouldMigrate:NO
+                                                     migrations:@[]
+                                                       database:&db
+                                                          error:&initializeError];
+  XCTAssertNil(initializeError);
+
+  // insert test data
+  NSString * const insertAssetsSql = @"INSERT INTO \"assets\" (\"id\",\"url\",\"key\",\"headers\",\"type\",\"metadata\",\"download_time\",\"relative_path\",\"hash\",\"hash_type\",\"marked_for_deletion\") VALUES\
+  (2,'https://url.to/b56cf690e0afa93bd4dc7756d01edd3e','b56cf690e0afa93bd4dc7756d01edd3e.png',NULL,'image/png',NULL,1614137309295,'b56cf690e0afa93bd4dc7756d01edd3e.png','c4fdfc2ec388025067a0f755bda7731a0a868a2be79c84509f4de4e40d23161b',0,0),\
+  (3,'https://url.to/bundle-1614137308871','bundle-1614137308871',NULL,'application/javascript',NULL,1614137309513,'bundle-1614137308871','e4d658861e85e301fb89bcfc49c42738ebcc0f9d5c979e037556435f44a27aa2',0,0),\
+  (4,NULL,'bundle-1614137401950',NULL,'js',NULL,1614137406588,'bundle-1614137401950','6ff4ee75b48a21c7a9ed98015ff6bfd0a47b94cd087c5e2258262e65af239952',0,0);";
+  NSString * const insertUpdatesSql = @"INSERT INTO \"updates\" (\"id\",\"scope_key\",\"commit_time\",\"runtime_version\",\"launch_asset_id\",\"metadata\",\"status\",\"keep\") VALUES\
+  (X'8C263F9DE3FF48888496E3244C788661','http://192.168.4.44:3000',1614137308871,'40.0.0',3,'{\"updateMetadata\":{\"updateGroup\":\"34993d39-57e6-46cf-8fa2-eba836f40828\",\"branchName\":\"rollout\"}}',1,1),\
+  (X'594100ea066e4804b5c7c907c773f980','http://192.168.4.44:3000',1614137401950,'40.0.0',4,NULL,1,1);";
+  NSString * const insertUpdatesAssetsSql = @"INSERT INTO \"updates_assets\" (\"update_id\",\"asset_id\") VALUES\
+  (X'8C263F9DE3FF48888496E3244C788661',2),\
+  (X'8C263F9DE3FF48888496E3244C788661',3),\
+  (X'594100ea066e4804b5c7c907c773f980',4);";
+  NSError *insertAssetsError;
+  [EXUpdatesDatabaseUtils executeSql:insertAssetsSql withArgs:nil onDatabase:db error:&insertAssetsError];
+  NSError *insertUpdatesError;
+  [EXUpdatesDatabaseUtils executeSql:insertUpdatesSql withArgs:nil onDatabase:db error:&insertUpdatesError];
+  NSError *insertUpdatesAssetsError;
+  [EXUpdatesDatabaseUtils executeSql:insertUpdatesAssetsSql withArgs:nil onDatabase:db error:&insertUpdatesAssetsError];
+  XCTAssert(!insertAssetsError && !insertUpdatesError && !insertUpdatesAssetsError);
+
+  sqlite3_close(db);
+
+  // initialize a new database object the normal way and run migrations
+  sqlite3 *migratedDb;
+  NSError *migrateError;
+  // initialize without specifying migrations in order to run them all
+  [EXUpdatesDatabaseInitialization initializeDatabaseWithLatestSchemaInDirectory:_testDatabaseDir
+                                                                        database:&migratedDb
+                                                                           error:&migrateError];
+  XCTAssertNil(migrateError);
+
+  // verify data integrity
+  NSString * const updatesSql1 = @"SELECT * FROM `updates` WHERE `id` = X'8C263F9DE3FF48888496E3244C788661'";
+  XCTAssertEqual(1, [EXUpdatesDatabaseUtils executeSql:updatesSql1 withArgs:nil onDatabase:migratedDb error:nil].count);
+  NSString * const updatesSql2 = @"SELECT * FROM `updates` WHERE `id` = X'594100ea066e4804b5c7c907c773f980'";
+  XCTAssertEqual(1, [EXUpdatesDatabaseUtils executeSql:updatesSql2 withArgs:nil onDatabase:migratedDb error:nil].count);
+
+  NSString * const assetsSql1 = @"SELECT * FROM `assets` WHERE `id` = 2";
+  XCTAssertEqual(1, [EXUpdatesDatabaseUtils executeSql:assetsSql1 withArgs:nil onDatabase:migratedDb error:nil].count);
+  NSString * const assetsSql2 = @"SELECT * FROM `assets` WHERE `id` = 3";
+  XCTAssertEqual(1, [EXUpdatesDatabaseUtils executeSql:assetsSql2 withArgs:nil onDatabase:migratedDb error:nil].count);
+  NSString * const assetsSql3 = @"SELECT * FROM `assets` WHERE `id` = 4";
+  XCTAssertEqual(1, [EXUpdatesDatabaseUtils executeSql:assetsSql3 withArgs:nil onDatabase:migratedDb error:nil].count);
+
+  NSString * const updatesAssetsSql1 = @"SELECT * FROM `updates_assets` WHERE `update_id` = X'8C263F9DE3FF48888496E3244C788661' AND `asset_id` = 2";
+  XCTAssertEqual(1, [EXUpdatesDatabaseUtils executeSql:updatesAssetsSql1 withArgs:nil onDatabase:migratedDb error:nil].count);
+  NSString * const updatesAssetsSql2 = @"SELECT * FROM `updates_assets` WHERE `update_id` = X'8C263F9DE3FF48888496E3244C788661' AND `asset_id` = 3";
+  XCTAssertEqual(1, [EXUpdatesDatabaseUtils executeSql:updatesAssetsSql2 withArgs:nil onDatabase:migratedDb error:nil].count);
+  NSString * const updatesAssetsSql3 = @"SELECT * FROM `updates_assets` WHERE `update_id` = X'594100ea066e4804b5c7c907c773f980' AND `asset_id` = 4";
+  XCTAssertEqual(1, [EXUpdatesDatabaseUtils executeSql:updatesAssetsSql3 withArgs:nil onDatabase:migratedDb error:nil].count);
+
+  // make sure multiple migrations are running
+  NSString * const lastAccessedSql1 = @"SELECT DISTINCT last_accessed FROM `updates`";
+  XCTAssertEqual(1, [EXUpdatesDatabaseUtils executeSql:lastAccessedSql1 withArgs:nil onDatabase:migratedDb error:nil].count);
 }
 
 - (void)testMigration4To5
@@ -199,6 +315,118 @@ CREATE INDEX \"index_json_data_scope_key\" ON \"json_data\" (\"scope_key\")\
   NSString * const selectDeletedSql = @"SELECT * FROM `updates_assets` WHERE `update_id` = X'594100ea066e4804b5c7c907c773f980' AND `asset_id` = 5";
   [EXUpdatesDatabaseUtils executeSql:deleteSql withArgs:nil onDatabase:migratedDb error:nil];
   XCTAssertEqual(0, [EXUpdatesDatabaseUtils executeSql:selectDeletedSql withArgs:nil onDatabase:migratedDb error:nil].count);
+}
+
+- (void)testMigration5To6
+{
+  sqlite3 *db;
+  NSError *initializeError;
+  [EXUpdatesDatabaseInitialization initializeDatabaseWithSchema:EXUpdatesDatabaseV5Schema
+                                                       filename:@"expo-v5.db"
+                                                    inDirectory:_testDatabaseDir
+                                                  shouldMigrate:NO
+                                                     migrations:@[]
+                                                       database:&db
+                                                          error:&initializeError];
+  XCTAssertNil(initializeError);
+
+  // insert test data
+  NSString * const insertAssetsSql = @"INSERT INTO \"assets\" (\"id\",\"url\",\"key\",\"headers\",\"type\",\"metadata\",\"download_time\",\"relative_path\",\"hash\",\"hash_type\",\"marked_for_deletion\") VALUES\
+  (2,'https://url.to/b56cf690e0afa93bd4dc7756d01edd3e','b56cf690e0afa93bd4dc7756d01edd3e.png',NULL,'image/png',NULL,1614137309295,'b56cf690e0afa93bd4dc7756d01edd3e.png','c4fdfc2ec388025067a0f755bda7731a0a868a2be79c84509f4de4e40d23161b',0,0),\
+  (3,'https://url.to/bundle-1614137308871','bundle-1614137308871',NULL,'application/javascript',NULL,1614137309513,'bundle-1614137308871','e4d658861e85e301fb89bcfc49c42738ebcc0f9d5c979e037556435f44a27aa2',0,0),\
+  (4,NULL,NULL,NULL,'js',NULL,1614137406588,'bundle-1614137401950','6ff4ee75b48a21c7a9ed98015ff6bfd0a47b94cd087c5e2258262e65af239952',0,0);";
+  NSString * const insertUpdatesSql = @"INSERT INTO \"updates\" (\"id\",\"scope_key\",\"commit_time\",\"runtime_version\",\"launch_asset_id\",\"metadata\",\"status\",\"keep\") VALUES\
+  (X'8C263F9DE3FF48888496E3244C788661','http://192.168.4.44:3000',1614137308871,'40.0.0',3,'{\\\"updateMetadata\\\":{\\\"updateGroup\\\":\\\"34993d39-57e6-46cf-8fa2-eba836f40828\\\",\\\"branchName\\\":\\\"rollout\\\"}}',1,1),\
+  (X'594100ea066e4804b5c7c907c773f980','http://192.168.4.44:3000',1614137401950,'40.0.0',4,NULL,1,1);";
+  NSString * const insertUpdatesAssetsSql = @"INSERT INTO \"updates_assets\" (\"update_id\",\"asset_id\") VALUES\
+  (X'8C263F9DE3FF48888496E3244C788661',2),\
+  (X'8C263F9DE3FF48888496E3244C788661',3),\
+  (X'594100ea066e4804b5c7c907c773f980',4);";
+  NSError *insertAssetsError;
+  [EXUpdatesDatabaseUtils executeSql:insertAssetsSql withArgs:nil onDatabase:db error:&insertAssetsError];
+  NSError *insertUpdatesError;
+  [EXUpdatesDatabaseUtils executeSql:insertUpdatesSql withArgs:nil onDatabase:db error:&insertUpdatesError];
+  NSError *insertUpdatesAssetsError;
+  [EXUpdatesDatabaseUtils executeSql:insertUpdatesAssetsSql withArgs:nil onDatabase:db error:&insertUpdatesAssetsError];
+  XCTAssert(!insertAssetsError && !insertUpdatesError && !insertUpdatesAssetsError);
+
+  sqlite3_close(db);
+
+  // initialize a new database object the normal way and run migrations
+  sqlite3 *migratedDb;
+  NSError *migrateError;
+  [EXUpdatesDatabaseInitialization initializeDatabaseWithLatestSchemaInDirectory:_testDatabaseDir
+                                                                        database:&migratedDb
+                                                                      migrations:@[[EXUpdatesDatabaseMigration5To6 new]]
+                                                                           error:&migrateError];
+  XCTAssertNil(migrateError);
+
+  // verify data integrity
+  NSString * const updatesSql1 = @"SELECT * FROM `updates` WHERE `id` = X'8C263F9DE3FF48888496E3244C788661' AND `scope_key` = 'http://192.168.4.44:3000' AND `commit_time` = 1614137308871 AND `runtime_version` = '40.0.0' AND `launch_asset_id` = 3 AND `manifest` IS NOT NULL AND `status` = 1 AND `keep` = 1";
+  XCTAssertEqual(1, [EXUpdatesDatabaseUtils executeSql:updatesSql1 withArgs:nil onDatabase:migratedDb error:nil].count);
+  NSString * const updatesSql2 = @"SELECT * FROM `updates` WHERE `id` = X'594100ea066e4804b5c7c907c773f980' AND `scope_key` = 'http://192.168.4.44:3000' AND `commit_time` = 1614137401950 AND `runtime_version` = '40.0.0' AND `launch_asset_id` = 4 AND `manifest` IS NULL AND `status` = 1 AND `keep` = 1";
+  XCTAssertEqual(1, [EXUpdatesDatabaseUtils executeSql:updatesSql2 withArgs:nil onDatabase:migratedDb error:nil].count);
+
+  NSString * const assetsSql1 = @"SELECT * FROM `assets` WHERE `id` = 2 AND `url` = 'https://url.to/b56cf690e0afa93bd4dc7756d01edd3e' AND `key` = 'b56cf690e0afa93bd4dc7756d01edd3e.png' AND `headers` IS NULL AND `type` = 'image/png' AND `metadata` IS NULL AND `download_time` = 1614137309295 AND `relative_path` = 'b56cf690e0afa93bd4dc7756d01edd3e.png' AND `hash` = 'c4fdfc2ec388025067a0f755bda7731a0a868a2be79c84509f4de4e40d23161b' AND `hash_type` = 0 AND `marked_for_deletion` = 0";
+  XCTAssertEqual(1, [EXUpdatesDatabaseUtils executeSql:assetsSql1 withArgs:nil onDatabase:migratedDb error:nil].count);
+  NSString * const assetsSql2 = @"SELECT * FROM `assets` WHERE `id` = 3 AND `url` = 'https://url.to/bundle-1614137308871' AND `key` = 'bundle-1614137308871' AND `headers` IS NULL AND `type` = 'application/javascript' AND `metadata` IS NULL AND `download_time` = 1614137309513 AND `relative_path` = 'bundle-1614137308871' AND `hash` = 'e4d658861e85e301fb89bcfc49c42738ebcc0f9d5c979e037556435f44a27aa2' AND `hash_type` = 0 AND `marked_for_deletion` = 0";
+  XCTAssertEqual(1, [EXUpdatesDatabaseUtils executeSql:assetsSql2 withArgs:nil onDatabase:migratedDb error:nil].count);
+  NSString * const assetsSql3 = @"SELECT * FROM `assets` WHERE `id` = 4 AND `url` IS NULL AND `key` IS NULL AND `headers` IS NULL AND `type` = 'js' AND `metadata` IS NULL AND `download_time` = 1614137406588 AND `relative_path` = 'bundle-1614137401950' AND `hash` = '6ff4ee75b48a21c7a9ed98015ff6bfd0a47b94cd087c5e2258262e65af239952' AND `hash_type` = 0 AND `marked_for_deletion` = 0";
+  XCTAssertEqual(1, [EXUpdatesDatabaseUtils executeSql:assetsSql3 withArgs:nil onDatabase:migratedDb error:nil].count);
+
+  NSString * const updatesAssetsSql1 = @"SELECT * FROM `updates_assets` WHERE `update_id` = X'8C263F9DE3FF48888496E3244C788661' AND `asset_id` = 2";
+  XCTAssertEqual(1, [EXUpdatesDatabaseUtils executeSql:updatesAssetsSql1 withArgs:nil onDatabase:migratedDb error:nil].count);
+  NSString * const updatesAssetsSql2 = @"SELECT * FROM `updates_assets` WHERE `update_id` = X'8C263F9DE3FF48888496E3244C788661' AND `asset_id` = 3";
+  XCTAssertEqual(1, [EXUpdatesDatabaseUtils executeSql:updatesAssetsSql2 withArgs:nil onDatabase:migratedDb error:nil].count);
+  NSString * const updatesAssetsSql3 = @"SELECT * FROM `updates_assets` WHERE `update_id` = X'594100ea066e4804b5c7c907c773f980' AND `asset_id` = 4";
+  XCTAssertEqual(1, [EXUpdatesDatabaseUtils executeSql:updatesAssetsSql3 withArgs:nil onDatabase:migratedDb error:nil].count);
+
+  // make sure metadata -> manifest column rename worked
+  NSString * const updatesNonNullManifestSql = @"SELECT * FROM `updates` WHERE `id` = X'8C263F9DE3FF48888496E3244C788661' AND `manifest` = '{\\\"updateMetadata\\\":{\\\"updateGroup\\\":\\\"34993d39-57e6-46cf-8fa2-eba836f40828\\\",\\\"branchName\\\":\\\"rollout\\\"}}'";
+  XCTAssertEqual(1, [EXUpdatesDatabaseUtils executeSql:updatesNonNullManifestSql withArgs:nil onDatabase:migratedDb error:nil].count);
+
+  // make sure last_accessed column was filled in appropriately (all existing updates have the same last_accessed time)
+  NSString * const lastAccessedSql1 = @"SELECT DISTINCT last_accessed FROM `updates`";
+  XCTAssertEqual(1, [EXUpdatesDatabaseUtils executeSql:lastAccessedSql1 withArgs:nil onDatabase:migratedDb error:nil].count);
+
+  // make sure we can add new updates with different last_accessed times
+  NSError *lastAccessedError;
+  NSString * const lastAccessedSql2 = @"INSERT INTO \"updates\" (\"id\",\"scope_key\",\"commit_time\",\"runtime_version\",\"launch_asset_id\",\"manifest\",\"status\",\"keep\", \"last_accessed\") VALUES\
+  (X'8F06A50E5A68499F986CCA31EE159F81','https://exp.host/@esamelson/sdk41updates',1619133262732,'41.0.0',NULL,NULL,1,1,1619647642456)";
+  [EXUpdatesDatabaseUtils executeSql:lastAccessedSql2 withArgs:nil onDatabase:migratedDb error:&lastAccessedError];
+  XCTAssertNil(lastAccessedError);
+  NSString * const lastAccessedSql3 = @"SELECT DISTINCT last_accessed FROM `updates`";
+  XCTAssertEqual(2, [EXUpdatesDatabaseUtils executeSql:lastAccessedSql3 withArgs:nil onDatabase:migratedDb error:nil].count);
+
+  // make sure foreign key constraints still work
+
+  // try to insert an update with a non-existent launch asset id (47)
+  NSString * const foreignKeyInsertBadSql1 = @"INSERT INTO \"updates\" (\"id\",\"scope_key\",\"commit_time\",\"runtime_version\",\"launch_asset_id\",\"manifest\",\"status\",\"keep\", \"last_accessed\") VALUES\
+  (X'E1AC9D5F55E041BBA5A9193DD1C1123A','https://exp.host/@esamelson/sdk41updates',1620168547318,'41.0.0',47,NULL,1,1,1619647642456)";
+  NSError *foreignKeyError1;
+  [EXUpdatesDatabaseUtils executeSql:foreignKeyInsertBadSql1 withArgs:nil onDatabase:migratedDb error:&foreignKeyError1];
+  XCTAssertNotNil(foreignKeyError1);
+  XCTAssertEqual(787, foreignKeyError1.code); // SQLITE_CONSTRAINT_FOREIGNKEY
+
+  // try to insert an entry in updates_assets that references a nonexistent update
+  NSString * const foreignKeyInsertBadSql2 = @"INSERT INTO `updates_assets` (`update_id`, `asset_id`) VALUES (X'3CF0A835CB3A4A5D9C14DFA3D55DE44D', 3)";
+  NSError *foreignKeyError2;
+  [EXUpdatesDatabaseUtils executeSql:foreignKeyInsertBadSql2 withArgs:nil onDatabase:migratedDb error:&foreignKeyError2];
+  XCTAssertNotNil(foreignKeyError2);
+  XCTAssertEqual(787, foreignKeyError2.code); // SQLITE_CONSTRAINT_FOREIGNKEY
+
+  // test updates on delete cascade
+  NSString * const deleteSql = @"DELETE FROM `assets` WHERE `id` = 3";
+  NSString * const selectDeletedSql1 = @"SELECT * FROM `updates` WHERE `id` = X'8C263F9DE3FF48888496E3244C788661'";
+  [EXUpdatesDatabaseUtils executeSql:deleteSql withArgs:nil onDatabase:migratedDb error:nil];
+  XCTAssertEqual(0, [EXUpdatesDatabaseUtils executeSql:selectDeletedSql1 withArgs:nil onDatabase:migratedDb error:nil].count);
+
+  // test updates_assets on delete cascade
+  // previous deletion should have deleted the update, which then should have deleted both entries in updates_assets
+  NSString * const selectDeletedSql2 = @"SELECT * FROM `updates_assets` WHERE `update_id` = X'8C263F9DE3FF48888496E3244C788661' AND `asset_id` = 2";
+  XCTAssertEqual(0, [EXUpdatesDatabaseUtils executeSql:selectDeletedSql2 withArgs:nil onDatabase:migratedDb error:nil].count);
+  NSString * const selectDeletedSql3 = @"SELECT * FROM `updates_assets` WHERE `update_id` = X'8C263F9DE3FF48888496E3244C788661' AND `asset_id` = 3";
+  XCTAssertEqual(0, [EXUpdatesDatabaseUtils executeSql:selectDeletedSql3 withArgs:nil onDatabase:migratedDb error:nil].count);
 }
 
 @end


### PR DESCRIPTION
# Why

Final follow-up to #12768, and step 4/4 of ENG-456. #12768 made a schema change to SQLite but did not add a nondestructive migration; this PR adds that.

# How

Added a migration from v5 to v6, following the pattern established previously.

# Test Plan

Added a comprehensive unit test of the 5->6 migration on each platform. Also added a smoke test of the 4->latest migration on iOS, to make sure the process of running multiple migrations runs smoothly. (I'm not worried about this on Android since Room takes care of the migrations.)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).