### PR TITLE
[docs] Update installation docs to use expo-dev-client

### DIFF
--- a/docs/pages/clients/installation.md
+++ b/docs/pages/clients/installation.md
@@ -21,7 +21,7 @@ The easiest way to get started is to initialize a new project by executing the f
 
 Add the Expo Development Client packages to your package.json.
 
-<InstallSection packageName="expo-development-client" cmd={["npm install expo-dev-menu expo-dev-menu-interface expo-dev-launcher"]} hideBareInstructions />
+<InstallSection packageName="expo-development-client" cmd={["npm install expo-dev-client"]} hideBareInstructions />
 
 <!-- note: `/client/submodules` doesn't exists, commenting this out for now -->
 <!-- [Want to learn more about how these modules work?](/client/submodules/) -->
@@ -31,6 +31,10 @@ Add the Expo Development Client packages to your package.json.
 Change your `Podfile` to make sure that the Development Client will be removed in the release builds:
 
 <ConfigurationDiff source="/static/diffs/client/podfile.diff" />
+
+Add configuration in `react-native.config.js` to allow React Native autolinking to find the dependencies of `expo-dev-client`:
+
+<ConfigurationDiff source="/static/diffs/client/react-native.config.js.diff" />
 
 Then you can run the following command to install native code for the Dev Launcher via Cocoapods.
 

--- a/docs/public/static/diffs/client/react-native.config.js.diff
+++ b/docs/public/static/diffs/client/react-native.config.js.diff
@@ -1,0 +1,11 @@
+diff --git a/react-native.config.js b/react-native.config.js
+new file mode 100644
+index 0000000..651d3b9
+--- /dev/null
++++ b/react-native.config.js
+@@ -0,0 +1,5 @@
++module.exports = {
++  dependencies: {
++    ...require('expo-dev-client/dependencies'),
++  },
++};


### PR DESCRIPTION
# Why

Builds on https://github.com/expo/expo/pull/12765, which added the new `expo-dev-client` package. This PR updates installation instructions in the docs to use the new package instead of the separate `expo-dev-menu` and `expo-dev-launcher` packages.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).