### PR TITLE
[expo-dev-launcher] Fix config plugin not including expo-dev-launcher in Podfile

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Account for rubocop formatting in plugin. ([#12480](https://github.com/expo/expo/pull/12480) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix bundled images. ([#12668](https://github.com/expo/expo/pull/12668) by [@fson](https://github.com/fson))
 - Enable kotlin in all modules. ([#12716](https://github.com/expo/expo/pull/12716) by [@wschurman](https://github.com/wschurman))
+- Fix config plugin not including `expo-dev-launcher` in `Podfile`. ([#12828](https://github.com/expo/expo/pull/12828) by [@fson](https://github.com/fson))
 
 ## 0.3.1 — 2021-04-09
 

--- a/packages/expo-dev-launcher/plugin/src/withDevLauncher.ts
+++ b/packages/expo-dev-launcher/plugin/src/withDevLauncher.ts
@@ -28,7 +28,7 @@ const DEV_LAUNCHER_WRAPPED_ACTIVITY_DELEGATE = `DevLauncherController.wrapReactA
 const DEV_LAUNCHER_ANDROID_INIT = 'DevLauncherController.initialize(this, getReactNativeHost());';
 
 const DEV_LAUNCHER_POD_IMPORT =
-  "pod 'expo-dev-menu', path: '../node_modules/expo-dev-menu', :configurations => :debug";
+  "pod 'expo-dev-launcher', path: '../node_modules/expo-dev-launcher', :configurations => :debug";
 
 async function readFileAsync(path: string): Promise<string> {
   return fs.promises.readFile(path, 'utf8');
@@ -162,11 +162,11 @@ const withDevLauncherPodfile: ConfigPlugin = config => {
       await editPodfile(config, podfile => {
         podfile = podfile.replace("platform :ios, '10.0'", "platform :ios, '11.0'");
         // Match both variations of Ruby config:
-        // unknown: pod 'expo-dev-menu', path: '../node_modules/expo-dev-menu', :configurations => :debug
-        // Rubocop: pod 'expo-dev-menu', path: '../node_modules/expo-dev-menu', configurations: :debug
+        // unknown: pod 'expo-dev-launcher', path: '../node_modules/expo-dev-launcher', :configurations => :debug
+        // Rubocop: pod 'expo-dev-launcher', path: '../node_modules/expo-dev-launcher', configurations: :debug
         if (
           !podfile.match(
-            /pod ['"]expo-dev-menu['"],\s?path: ['"]\.\.\/node_modules\/expo-dev-menu['"],\s?:?configurations:?\s(?:=>\s)?:debug/
+            /pod ['"]expo-dev-launcher['"],\s?path: ['"]\.\.\/node_modules\/expo-dev-launcher['"],\s?:?configurations:?\s(?:=>\s)?:debug/
           )
         ) {
           podfile = addLines(podfile, 'use_react_native', 0, [`  ${DEV_LAUNCHER_POD_IMPORT}`]);


### PR DESCRIPTION
# Why

Running the eject command with `expo-dev-launcher` config plugin only added `expo-dev-menu` to `ios/Podfile`.

# How

Fixed parts of the config plugin that applied to `expo-dev-menu` rather than `expo-dev-launcer`. `expo-dev-menu` has its own config plugin.

# Test Plan

1. Published `expo-dev-client` and `expo-dev-launcher` packages to a local npm proxy ([Verdaccio](https://verdaccio.org))
1. Created a managed app with `expo init`.
1. `yarn add expo-dev-client`
1. `expod eject` (using Expo CLI from https://github.com/expo/expo-cli/pull/3436)
1. observed that `ios/Podfile` had correct contents and `pod install` succeeded

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).