### PR TITLE
[module-scripts] Inline source maps in the source code

### DIFF
--- a/packages/expo-module-scripts/tsconfig.base.json
+++ b/packages/expo-module-scripts/tsconfig.base.json
@@ -6,13 +6,9 @@
     "moduleResolution": "node",
     "esModuleInterop": true,
     "types": ["jest", "jest-require"],
-    "typeRoots": [
-      "./ts-declarations",
-      "node_modules/@types"
-    ],
-    "sourceMap": true,
+    "typeRoots": ["./ts-declarations", "node_modules/@types"],
+    "inlineSourceMap": true,
     "declaration": true,
-    "inlineSources": true,
     "strictNullChecks": true,
     "strictPropertyInitialization": true,
     "strictFunctionTypes": true,


### PR DESCRIPTION
# Why

Right now for each `*.ts` file we generate the final JS code, declaration file and the sourcemap. Due to `inlineSources: true` config, the sourcemaps also contain the source code which makes them unnecessarily thick and inefficient for Git because each delta needs to contain the entire file.

# How

Removed `inlineSources: true` from `tsconfig.base.json` in `expo-module-scripts` to make sourcemaps smaller

I went even further and replaced `sourceMap: true` with `inlineSourceMap: true` to inline sourcemaps within JS files. This reduces the number of files stored in `build` folders (no more `*.js.map` files) and therefore the number of files in pull requests.

# Test Plan

- Add `throw new Error` somewhere in the TS code of a package
- Rebuild JS files and notice the `.js.map` files are no longer in the build folder and the sourcemaps are inlined at the bottom of JS files
- Call the method throwing an error from the app (e.g. NCL) and notice that error's stacktrace is correct.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).