### PR TITLE
[dev-client] Fix the CI

### DIFF
--- a/.github/workflows/development-client.yml
+++ b/.github/workflows/development-client.yml
@@ -6,6 +6,11 @@ on:
     paths:
       - .github/workflows/development-client.yml
       - packages/expo-dev-*/**
+  push:
+    branches: [master]
+    paths:
+      - .github/workflows/development-client.yml
+      - packages/expo-dev-*/**
 
 jobs:
   android:
@@ -101,4 +106,4 @@ jobs:
         run: expo-cli eject
       - name: Build debug
         working-directory: ../development-client-ios-test
-        run: xcodebuild -workspace ios/developmentclientiostest.xcworkspace -scheme developmentclientiostest -configuration debug -sdk iphonesimulator -arch x86_64
+        run: xcodebuild -workspace ios/developmentclientiostest.xcworkspace -scheme developmentclientiostest -configuration debug -sdk iphonesimulator14.4 -arch x86_64


### PR DESCRIPTION
- Fix the development client `xcodebuild` failure in the CI by setting the SDK name to `iphonesimulator14.4` from the list of [installed SDKs in the macOS 10.15 image](https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md#installed-sdks).
- Make the `development-client.yml` workflow run also on `master` for applicable pushes to make it easier to track down when it started failing.