### PR TITLE
[docs] set max-old-space-size to 4gb

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "rimraf .next/preval && next dev -p 3002",
-    "build": "cross-env NODE_OPTIONS=--max-old-space-size=5120 next build",
+    "build": "cross-env NODE_OPTIONS=--max-old-space-size=4096 next build",
     "export": "yarn run build && next export && yarn run export-issue-404",
     "export-issue-404": "echo \"🛠  Patching https://github.com/vercel/next.js/issues/16528\"; cp out/404/index.html out/404.html",
     "export-server": "http-server out -p 8000",


### PR DESCRIPTION
# Why

GitHub Actions runners only have 7gb of RAM

# How

Set `--max-old-space-size=4096`

# Test Plan

GitHub Actions docs shouldn't fail