### PR TITLE
Adjust Linking docs to describe `/--/` prefix

### DIFF
--- a/docs/pages/guides/linking.md
+++ b/docs/pages/guides/linking.md
@@ -177,7 +177,12 @@ To save you the trouble of inserting a bunch of conditionals based on the enviro
 - _Published app in standalone_: `myapp://`
 - _Development_: `exp://localhost:19000`
 
-You can also change the returned url by passing optional parameters into `Linking.makeUrl()`. These will be used by your app to receive data, which we will talk about in the next section.
+You can also change the returned url by passing optional parameters into `Linking.makeUrl()`. For example, the current default for the starter application is `Linking.makeUrl('/')`, which resolves to the following: (Expo-hosted applications add a `/--/` prefix)
+
+- _Published app in Expo Go_: `exp://exp.host/@community/with-webbrowser-redirect/--/`
+- _Published app in standalone_: `myapp://`
+- _Development_: `exp://localhost:19000/--/`
+
 
 ### Handling links into your app
 


### PR DESCRIPTION
# Why

The Linking docs could use an adjustment for newbies like me. This is in response to https://github.com/expo/expo/issues/12830#

# How

In reference to the following code comment and actual code that does the prefixing: https://github.com/expo/expo/blob/master/packages/expo-linking/src/Linking.ts#L100-L105

# Test Plan

🤷 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).