### PR TITLE
[dev-menu][android] Fix module doesn't compile in older projects

### DIFF
--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/DevMenuActivity.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/DevMenuActivity.kt
@@ -90,7 +90,9 @@ class DevMenuActivity : ReactActivity() {
         return rootView
       }
 
-      rootView = getVendoredClass(
+      // This type hint is needed for the older kotlin version.
+      @Suppress("RemoveExplicitTypeArguments")
+      rootView = getVendoredClass<ReactRootView>(
         "com.swmansion.gesturehandler.react.RNGestureHandlerEnabledRootView",
         arrayOf(Context::class.java),
         arrayOf(activity)

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/modules/DevMenuInternalModule.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/modules/DevMenuInternalModule.kt
@@ -58,7 +58,7 @@ interface DevMenuInternalWebBrowserModuleInterface {
 }
 
 class DevMenuInternalModule(
-  reactContext: ReactApplicationContext,
+  reactContext: ReactApplicationContext
 ) : ReactContextBaseJavaModule(reactContext),
   DevMenuInternalFontManagerModuleInterface by DevMenuInternalFontManagerModule(reactContext),
   DevMenuInternalWebBrowserModuleInterface by DevMenuInternalWebBrowserModule(reactContext),


### PR DESCRIPTION
# Why

Fixes:
```
> Task :expo-dev-menu:compileDebugKotlin
e: /Users/lukasz/work/expo/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/DevMenuActivity.kt: (93, 18): Type inference failed: fun <T> getVendoredClass(className: String, argsType: Array<Class<*>>, args: Array<Any>): T
cannot be applied to
(String,Array<Class<*>>,Array<Any>)

e: /Users/lukasz/work/expo/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/modules/DevMenuInternalModule.kt: (61, 41): Expecting a parameter declaration

> Task :expo-dev-menu:compileDebugKotlin FAILED
```

# How

Some projects don't use the newest kotlin version. To make sure the dev-menu works out of the box for most kotlin versions, I changed problematic places.

# Test Plan

- bare-expo & NCL app ✅