### PR TITLE
[dev-launcher][android] Fix `VerifyError` causing crashes

### DIFF
--- a/packages/expo-dev-launcher/android/build.gradle
+++ b/packages/expo-dev-launcher/android/build.gradle
@@ -84,8 +84,8 @@ dependencies {
   api "androidx.lifecycle:lifecycle-extensions:2.2.0"
 
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${safeExtGet('kotlinVersion', '1.4.21')}"
-  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.7")
-  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.5")
+  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.3")
+  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.1")
   implementation "org.jetbrains.kotlin:kotlin-reflect:${safeExtGet('kotlinVersion', '1.4.21')}"
 
   testImplementation "com.google.truth:truth:1.1.2"

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/helpers/DevLauncherCoroutinesExtensions.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/helpers/DevLauncherCoroutinesExtensions.kt
@@ -10,5 +10,11 @@ fun <T> runBlockingOnMainThread(block: () -> T): T {
     return block()
   }
 
-  return runBlocking(Dispatchers.Main) { block() }
+  // I know it looks stupid, but actually, this was made with purpose.
+  // In some kotlin compiler versions, you can find a bug which causes crashes.
+  // You can read more here: https://github.com/Kotlin/kotlinx.coroutines/issues/2041.
+  // We store additional ref to the block to prevent `java.lang.VerifyError` from being thrown.
+  @Suppress("UnnecessaryVariable")
+  val blockRef = block
+  return runBlocking(Dispatchers.Main) { blockRef() }
 }


### PR DESCRIPTION
# Why

Fixes:
```
2021-05-07 17:53:30.805 11096-11096/host.exp.nclexp E/AndroidRuntime: FATAL EXCEPTION: main
    Process: host.exp.nclexp, PID: 11096
    java.lang.VerifyError: Verifier rejected class expo.modules.devlauncher.helpers.DevLauncherCoroutinesExtensionsKt: java.lang.Object expo.modules.devlauncher.helpers.DevLauncherCoroutinesExtensionsKt.runBlockingOnMainThread(kotlin.jvm.functions.Function0) failed to verify: java.lang.Object expo.modules.devlauncher.helpers.DevLauncherCoroutinesExtensionsKt.runBlockingOnMainThread(kotlin.jvm.functions.Function0): [0x1C] cannot access instance field java.lang.Object kotlin.jvm.internal.Ref$ObjectRef.element from object of type Reference: kotlin.jvm.functions.Function0 (declaration of 'expo.modules.devlauncher.helpers.DevLauncherCoroutinesExtensionsKt' appears in /data/app/~~Pctup_2b0rAIMhpgLMjdzQ==/host.exp.nclexp-Jvfz4oK2KizpZpVNYK5cJQ==/base.apk!classes81.dex)
        at expo.modules.devlauncher.helpers.DevLauncherCoroutinesExtensionsKt.runBlockingOnMainThread(Unknown Source:0)
        at expo.modules.devlauncher.DevLauncherController.ensureHostWasCleared(DevLauncherController.kt:139)
        at expo.modules.devlauncher.DevLauncherController.ensureHostWasCleared$default(DevLauncherController.kt:137)
        at expo.modules.devlauncher.DevLauncherController.navigateToLauncher(DevLauncherController.kt:99)
        at expo.modules.devlauncher.DevLauncherController.redirectFromStartActivity(DevLauncherController.kt:180)
        at expo.modules.devlauncher.DevLauncherController.access$redirectFromStartActivity(DevLauncherController.kt:46)
        at expo.modules.devlauncher.DevLauncherController$getCurrentReactActivityDelegate$1.invoke(DevLauncherController.kt:172)
        at expo.modules.devlauncher.DevLauncherController$getCurrentReactActivityDelegate$1.invoke(DevLauncherController.kt:46)
        at expo.modules.devlauncher.react.activitydelegates.DevLauncherReactActivityRedirectDelegate.onCreate(DevLauncherReactActivityRedirectDelegate.kt:13)
        at com.facebook.react.ReactActivity.onCreate(ReactActivity.java:45)
        at host.exp.nclexp.MainActivity.onCreate(MainActivity.java:40)
        at android.app.Activity.performCreate(Activity.java:8000)
        at android.app.Activity.performCreate(Activity.java:7984)
        at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1309)
        at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:3422)
        at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3601)
        at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:85)
        at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:135)
        at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:95)
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2066)
        at android.os.Handler.dispatchMessage(Handler.java:106)
        at android.os.Looper.loop(Looper.java:223)
        at android.app.ActivityThread.main(ActivityThread.java:7656)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:592)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:947)
2021-05-07 17:53:30.883 11096-11096/host.exp.nclexp I/Process: Sending signal. PID: 11096 SIG: 9
```

# How

- Updated coroutines package to the newest version.
- Added a workaround for something that looks like a bug in the compiler (see https://github.com/Kotlin/kotlinx.coroutines/issues/2041).  

# Test Plan

- newly created app with older kotlin version ✅