### PR TITLE
To include missing UMPermissionsInterface dependency inside UMReactNativeAdapter.podspec

### DIFF
--- a/packages/@unimodules/react-native-adapter/CHANGELOG.md
+++ b/packages/@unimodules/react-native-adapter/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### 🐛 Bug fixes
 
+## 6.2.3 - 2021-05-08
+
+- To include missing UMPermissionsInterface dependency inside UMReactNativeAdapter.podspec
+
 ## 6.2.2 — 2021-04-13
 
 ### 🎉 New features

--- a/packages/@unimodules/react-native-adapter/CHANGELOG.md
+++ b/packages/@unimodules/react-native-adapter/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unpublished
+- Include missing `UMPermissionsInterface` dependency in the podspec. ([#12862](https://github.com/expo/expo/pull/12862) by [@budiTjendra](https://github.com/budiTjendra))
 
 ### 🛠 Breaking changes
 
@@ -9,10 +10,6 @@
 - Added CocoaPods & Gradle scripts to use new autolinking implementation (opt-in feature). ([#11593](https://github.com/expo/expo/pull/11593) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
-
-## 6.2.3 - 2021-05-08
-
-- To include missing UMPermissionsInterface dependency inside UMReactNativeAdapter.podspec
 
 ## 6.2.2 — 2021-04-13
 

--- a/packages/@unimodules/react-native-adapter/ios/UMReactNativeAdapter.podspec
+++ b/packages/@unimodules/react-native-adapter/ios/UMReactNativeAdapter.podspec
@@ -16,7 +16,8 @@ Pod::Spec.new do |s|
   s.dependency 'React-Core'
   s.dependency 'UMCore'
   s.dependency 'UMFontInterface'
-
+  s.dependency 'UMPermissionsInterface' 
+  
   if !$ExpoUseSources&.include?(package['name']) && ENV['EXPO_USE_SOURCE'].to_i == 0 && File.exist?("#{s.name}.xcframework") && Gem::Version.new(Pod::VERSION) >= Gem::Version.new('1.10.0')
     s.source_files = "#{s.name}/**/*.h"
     s.vendored_frameworks = "#{s.name}.xcframework"

--- a/packages/@unimodules/react-native-adapter/package.json
+++ b/packages/@unimodules/react-native-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unimodules/react-native-adapter",
-  "version": "6.2.3",
+  "version": "6.2.2",
   "description": "The adapter to use universal modules with the React Native bridge",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/packages/@unimodules/react-native-adapter/package.json
+++ b/packages/@unimodules/react-native-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unimodules/react-native-adapter",
-  "version": "6.2.2",
+  "version": "6.2.3",
   "description": "The adapter to use universal modules with the React Native bridge",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
# Why

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

Fixes: 

```
In file included from .../node_modules/@unimodules/react-native-adapter/ios/UMReactNativeAdapter/Services/Permissions/EXReactNativeUserNotificationCenterProxy.m:5:
.../node_modules/@unimodules/react-native-adapter/ios/UMReactNativeAdapter/Services/Permissions/EXReactNativeUserNotificationCenterProxy.h:7:9: fatal error: 'UMPermissionsInterface/UMUserNotificationCenterProxyInterface.h' file not found
#import <UMPermissionsInterface/UMUserNotificationCenterProxyInterface.h>
^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

Dependency UMPermissionsInterface is missing declaration inside UMReactNativeAdapter.podspec. And this will throw a compilation error when using with  use_framework! Refer to  issue https://github.com/expo/expo/issues/12840 for more details


# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->

Tested locally. 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).