### PR TITLE
[tools] Add changelog section for changes not suitable for other sections

### DIFF
--- a/tools/src/Changelogs.ts
+++ b/tools/src/Changelogs.ts
@@ -47,11 +47,35 @@ export type InsertOptions = Partial<{
  * Enum with changelog sections that are commonly used by us.
  */
 export enum ChangeType {
+  /**
+   * Upgrading vendored libs.
+   */
   LIBRARY_UPGRADES = '📚 3rd party library updates',
+
+  /**
+   * Changes in the API that may require users to change their code.
+   */
   BREAKING_CHANGES = '🛠 Breaking changes',
+
+  /**
+   * New features and non-breaking changes in the API.
+   */
   NEW_FEATURES = '🎉 New features',
+
+  /**
+   * Bug fixes and inconsistencies with the documentation.
+   */
   BUG_FIXES = '🐛 Bug fixes',
+
+  /**
+   * Changes that users should be aware of as they cause behavior changes in corner cases.
+   */
   NOTICES = '⚠️ Notices',
+
+  /**
+   * Anything that doesn't apply to other types.
+   */
+  OTHERS = '💡 Others',
 }
 
 /**
@@ -313,7 +337,12 @@ export class Changelog {
    */
   async cutOffAsync(
     version: string,
-    types: string[] = [ChangeType.BREAKING_CHANGES, ChangeType.NEW_FEATURES, ChangeType.BUG_FIXES]
+    types: string[] = [
+      ChangeType.BREAKING_CHANGES,
+      ChangeType.NEW_FEATURES,
+      ChangeType.BUG_FIXES,
+      ChangeType.OTHERS,
+    ]
   ): Promise<void> {
     const tokens = await this.getTokensAsync();
     const firstVersionHeadingIndex = tokens.findIndex((token) => isVersionToken(token));


### PR DESCRIPTION
# Why

So far we used to be adding changelog entries only for user-facing changes. Maybe that was good enough, but since we want to encourage developers to contribute to our packages it seems useful to also include developer-facing changes, such as enabling Kotlin in the codebase.

# How

Added new enum option and some comments to clarify the meaning of change types.

# Test Plan

Tried to cut off a changelog and confirmed it contains this new section under "unpublished" version
