### PR TITLE
[ios][splash] remove autoHideAsync warning

### DIFF
--- a/packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenController.m
+++ b/packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenController.m
@@ -56,10 +56,6 @@
     return successCallback(NO);
   }
 
-  if (!_splashScreenShown) {
-    return failureCallback(@"Native splash screen is already hidden. Call this method before rendering any view.");
-  }
-
   _autoHideEnabled = NO;
   successCallback(YES);
 }


### PR DESCRIPTION
# Why

Fast Refresh is causing a failure callback to fire in the `preventAutoHideAsync()` method even though it shouldn't

# How

From what I can tell, this method is setting some local state on the screen controller which influences the splash screen behaviour when content appears -- calling it multiple times shouldn't have any impact on it's behaviour

If I've missed something please let me know!!

# Test Plan

A good example is provided in the linear issue - this can be pasted into the Sandbox app. Make an update in the app code and ensure the warning does not come up.

About fast refresh (TIL): 

```
Hooks with dependencies—such as useEffect, useMemo, and useCallback—will always update during Fast Refresh. Their list of dependencies will be ignored while Fast Refresh is happening.
```

This means that in the provided sample, the `prepare()` function is called on every save!

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->
- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
