### PR TITLE
Use expo install instead of yarn

### DIFF
--- a/docs/pages/versions/v41.0.0/sdk/firebase-analytics.md
+++ b/docs/pages/versions/v41.0.0/sdk/firebase-analytics.md
@@ -74,7 +74,7 @@ To enable the AdSupport framework:
 import * as Analytics from 'expo-firebase-analytics';
 ```
 
-To use web analytics, you'll also need to install the peer dependency **firebase** with `yarn add firebase`.
+To use web analytics, you'll also need to install the peer dependency **firebase** with `expo install firebase`.
 
 ## Methods
 


### PR DESCRIPTION
Changed documentation also in V41 to mirror https://github.com/expo/expo/pull/12744#pullrequestreview-655943580 per request from @cruzach.

# Why

yarn add will give a version of firebase not compatible with expo 

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).