### PR TITLE
[docs] Fix links for multi-package install sections

### DIFF
--- a/docs/components/plugins/InstallSection.tsx
+++ b/docs/components/plugins/InstallSection.tsx
@@ -37,11 +37,14 @@ type Props = {
   href?: string;
 };
 
+const getPackageLink = (packageNames: string) =>
+  `https://github.com/expo/expo/tree/master/packages/${packageNames.split(' ')[0]}`;
+
 const InstallSection: React.FC<Props> = ({
   packageName,
   hideBareInstructions = false,
   cmd = [`expo install ${packageName}`],
-  href = `https://github.com/expo/expo/tree/master/packages/${packageName}`,
+  href = getPackageLink(packageName),
 }) => (
   <div>
     <TerminalBlock cmd={cmd} />


### PR DESCRIPTION
# Why

Fixes #12887

# How

This splits the package name(s) by space and uses the first package for the link. This is overwritable by providing the `href` property.

# Test Plan

- Open StoreReview
- Click "React Native instructions" link

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).