### PR TITLE
[bare-expo] Add detox testing for android

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -149,7 +149,7 @@ jobs:
           author_name: Test Suite (iOS)
 
   android:
-    runs-on: ubuntu-18.04
+    runs-on: macos-latest
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -149,7 +149,7 @@ jobs:
           author_name: Test Suite (iOS)
 
   android:
-    runs-on: macos-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -190,7 +190,7 @@ jobs:
       - name: Build Android project for Detox
         run: yarn android:detox:build:release
         working-directory: apps/bare-expo
-        timeout-minutes: 30
+        timeout-minutes: 35
       - name: Run tests
         uses: reactivecircus/android-emulator-runner@v2
         with:

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -147,3 +147,71 @@ jobs:
           status: ${{ job.status }}
           fields: job,commit,ref,eventName,author,took
           author_name: Test Suite (iOS)
+
+  android:
+    runs-on: macos-latest
+    steps:
+      - name: 👀 Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: 🍺 Install required tools
+        run: |
+          brew install watchman
+          echo "$(pwd)/bin" >> $GITHUB_PATH
+      - name: ♻️ Restore workspace node modules
+        uses: actions/cache@v2
+        id: node-modules-cache
+        with:
+          path: |
+            # See "workspaces" → "packages" in the root package.json for the source of truth of
+            # which node_modules are affected by the root yarn.lock
+            node_modules
+            apps/*/node_modules
+            home/node_modules
+            packages/*/node_modules
+            packages/@unimodules/*/node_modules
+            react-native-lab/react-native/node_modules
+          key: ${{ runner.os }}-modules-${{ hashFiles('yarn.lock') }}
+      - name: 🧶 Install node modules in root dir
+        run: yarn install --frozen-lockfile
+      - uses: actions/cache@v2
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('android/*.gradle*') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+      - name: ⚛️ Display React Native config
+        run: yarn react-native config
+        working-directory: apps/bare-expo
+      - name: Clean Detox
+        run: yarn detox:clean
+        working-directory: apps/bare-expo
+      - name: Build Android project for Detox
+        run: yarn android:detox:build:release
+        working-directory: apps/bare-expo
+        timeout-minutes: 30
+      - name: Run tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 29
+          avd-name: bare-expo
+          script: yarn android:detox:test:release
+          working-directory: ./apps/bare-expo
+      - name: Store images of build failures
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: bare-expo-artifacts
+          path: apps/bare-expo/artifacts
+      - name: 🔔 Notify on Slack
+        uses: 8398a7/action-slack@v3
+        if: failure() && (github.event.ref == 'refs/heads/master' || startsWith(github.event.ref, 'refs/heads/sdk-'))
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_android }}
+        with:
+          channel: '#platform-android'
+          status: ${{ job.status }}
+          fields: job,commit,ref,eventName,author,took
+          author_name: Test Suite (Android)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Expo for Web code is easy to test and contribute to compared to the native code,
 
 We recommend that folks interested in contributing to the SDK use the `apps/bare-expo` project in their SDK development workflow instead of the Expo client. The Expo client itself (in the `ios/` and `android/` directories) are difficult to setup and require API tokens.
 
-The `bare-expo` project includes most of the Expo SDK and runs the JavaScript code from `apps/test-suite` to allow you to easily write and run E2E tests for iOS, Android, and web for any given SDK package. Unit tests can be written within the SDK package itself. When pushed to the remote, CI will run this project with Device Farm for Android, Detox for iOS, and Puppeteer for web and report the results on your pull request.
+The `bare-expo` project includes most of the Expo SDK and runs the JavaScript code from `apps/test-suite` to allow you to easily write and run E2E tests for iOS, Android, and web for any given SDK package. Unit tests can be written within the SDK package itself. When pushed to the remote, CI will run this project with Detox for Android/iOS and Puppeteer for web and report the results on your pull request.
 
 Manual smoke tests are included in `apps/native-component-list`, this is a good fit for demos or tests that require physical interactions. This is particularly useful if you are testing interactions with UI components, or there is something that is very difficult to test in an automated way but would be easy to verify through manual interaction.
 
@@ -63,7 +63,7 @@ All Expo SDK packages can be found in the `packages/` directory. These packages 
    - Add or modify a file named after the API you're working on. Ex: `apps/test-suite/tests/Constants.js`
    - To see native changes, you will need to run the `test-suite` with the `apps/bare-expo` project using `yarn <android | ios | web>`.
    - If you are only making JavaScript changes, you can run `test-suite` from the `apps/test-suite` project using `expo start`.
-   - To run the full test suite with Puppeteer or Detox, you can run the tests `yarn test:<ios | web>`.
+   - To run the full test suite with Puppeteer or Detox, you can run the tests `yarn test:<android | ios | web>`.
 5. You can edit a package's native code directly from its respective folder in the `packages/` directory or by opening `bare-expo` in a native editor:
    - Android Studio: `yarn edit:android`
    - Xcode: `yarn edit:ios`
@@ -101,9 +101,7 @@ The best way to get your changes merged is to build good tests for them! We have
 1. Write your tests in `apps/test-suite/tests`
    - These tests are written with a non-feature-complete version of Jasmine that runs on the Android and iOS clients, so no special features like snapshot testing will be available.
    - If you created a new test file, be sure to add it in `apps/test-suite/TestUtils.js`. This is where you can do platform exclusion. Use `global.DETOX` to test for iOS tests, and `ExponentTest.isInCI` to test for Android Device Farm.
-2. Run your tests locally from the `bare-expo` directory with `yarn test:ios`, or `yarn test:web`.
-    <!-- TODO(Bacon): Remove once Android Detox is setup -->
-   - For the moment Android Detox is not set up, but you can still run the project in an emulator or on a device to test it.
+2. Run your tests locally from the `bare-expo` directory with `yarn test:android`, `yarn test:ios`, or `yarn test:web`.
    - It's important you test locally because native CI tests can be fragile, take a while to finish, and be frustrating when they fail.
    - When testing for web, you can set `headless: false` in the `apps/bare-expo/jest-puppeteer.config.js` to watch the tests live. You can also execute `await jestPuppeteer.debug();` in `apps/bare-expo/e2e/TestSuite-test.web.js` to pause the tests and debug them!
 3. Remember to try and get your feature running on as many platforms as possible.

--- a/apps/bare-expo/android/app/build.gradle
+++ b/apps/bare-expo/android/app/build.gradle
@@ -259,3 +259,17 @@ applyNativeModulesAppBuildGradle(project)
 // [Custom]: Add Google Services file
 apply plugin: GenerateDynamicMacrosPlugin
 apply plugin: 'com.google.gms.google-services'
+
+// Make sure JS bundle to be merged for gradle android plugin 4.1.0+
+// react native 0.64 should fix this already
+// See https://github.com/facebook/react-native/pull/30177
+afterEvaluate {
+    android.applicationVariants.all { def variant ->
+        def targetName = variant.name.capitalize()
+        def mergeResourcesTask = tasks.findByName("merge${targetName}Resources")
+        def copyBundledJsTask = tasks.findByName("copy${targetName}BundledJs")
+        if (mergeResourcesTask && copyBundledJsTask) {
+            mergeResourcesTask.dependsOn(copyBundledJsTask)
+        }
+    }
+}

--- a/apps/bare-expo/android/app/build.gradle
+++ b/apps/bare-expo/android/app/build.gradle
@@ -136,6 +136,9 @@ android {
             // [Custom]: Required for expo-app-auth
             appAuthRedirectScheme: "dev.expo.payments"
         ]
+
+        testBuildType System.getProperty('testBuildType', 'debug')
+        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
     splits {
         abi {
@@ -185,10 +188,6 @@ android {
     }
 }
 
-repositories {
-    jcenter()
-}
-
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "com.android.support:appcompat-v7:${rootProject.ext.supportLibVersion}"
@@ -210,6 +209,8 @@ dependencies {
     implementation('com.facebook.flipper:flipper-network-plugin:0.62.0') {
         exclude group:'com.facebook.flipper'
     }
+
+    androidTestImplementation('com.wix:detox:+')
 }
 
 // Run this once to be able to run the application with BUCK

--- a/apps/bare-expo/android/app/src/androidTest/java/dev/expo/payments/DetoxTest.java
+++ b/apps/bare-expo/android/app/src/androidTest/java/dev/expo/payments/DetoxTest.java
@@ -1,6 +1,7 @@
 package dev.expo.payments;
 
 import com.wix.detox.Detox;
+import com.wix.detox.config.DetoxConfig;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -13,12 +14,16 @@ import androidx.test.rule.ActivityTestRule;
 @RunWith(AndroidJUnit4.class)
 @LargeTest
 public class DetoxTest {
+  @Rule
+  public ActivityTestRule<MainActivity> mActivityRule = new ActivityTestRule<>(MainActivity.class, false, false);
 
-    @Rule
-    public ActivityTestRule<MainActivity> mActivityRule = new ActivityTestRule<>(MainActivity.class, false, false);
+  @Test
+  public void runDetoxTests() {
+    DetoxConfig detoxConfig = new DetoxConfig();
+    detoxConfig.idlePolicyConfig.masterTimeoutSec = 90;
+    detoxConfig.idlePolicyConfig.idleResourceTimeoutSec = 60;
+    detoxConfig.rnContextLoadTimeoutSec = (BuildConfig.DEBUG ? 180 : 60);
 
-    @Test
-    public void runDetoxTests() {
-        Detox.runTests(mActivityRule);
-    }
+    Detox.runTests(mActivityRule, detoxConfig);
+  }
 }

--- a/apps/bare-expo/android/app/src/main/java/dev/expo/payments/MainActivity.java
+++ b/apps/bare-expo/android/app/src/main/java/dev/expo/payments/MainActivity.java
@@ -1,8 +1,9 @@
 package dev.expo.payments;
 
-import android.content.Intent;
-
 import android.app.Activity;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.net.Uri;
 import android.os.Bundle;
 
 import com.facebook.react.ReactActivityDelegate;
@@ -11,9 +12,8 @@ import com.swmansion.gesturehandler.react.RNGestureHandlerEnabledRootView;
 
 import expo.modules.devlauncher.DevLauncherController;
 import expo.modules.devmenu.react.DevMenuAwareReactActivity;
-
-import expo.modules.splashscreen.singletons.SplashScreen;
 import expo.modules.splashscreen.SplashScreenImageResizeMode;
+import expo.modules.splashscreen.singletons.SplashScreen;
 
 public class MainActivity extends DevMenuAwareReactActivity {
 
@@ -41,6 +41,19 @@ public class MainActivity extends DevMenuAwareReactActivity {
         // SplashScreen.show(...) has to be called after super.onCreate(...)
         // Below line is handled by '@expo/configure-splash-screen' command and it's discouraged to modify it manually
         SplashScreen.show(activity, SplashScreenImageResizeMode.COVER, ReactRootView.class, false);
+
+        // Hacky way to prevent onboarding DevMenuActivity breaks detox testing,
+        // which to setup the dev-menu internal setting.
+        final Intent intent = getIntent();
+        final String action = intent.getAction();
+        final Uri initialUri = intent.getData();
+        if (action.equals(Intent.ACTION_VIEW) &&
+          initialUri != null &&
+          initialUri.getHost().equals("test-suite")) {
+          final String devMenuPrefKey = "expo.modules.devmenu.sharedpreferences";
+          final SharedPreferences pref = getApplicationContext().getSharedPreferences(devMenuPrefKey, MODE_PRIVATE);
+          pref.edit().putBoolean("isOnboardingFinished", true).apply();
+        }
       }
     };
 

--- a/apps/bare-expo/android/app/src/main/java/dev/expo/payments/MainActivity.java
+++ b/apps/bare-expo/android/app/src/main/java/dev/expo/payments/MainActivity.java
@@ -43,7 +43,7 @@ public class MainActivity extends DevMenuAwareReactActivity {
         SplashScreen.show(activity, SplashScreenImageResizeMode.COVER, ReactRootView.class, false);
 
         // Hacky way to prevent onboarding DevMenuActivity breaks detox testing,
-        // which to setup the dev-menu internal setting.
+        // we do this by setting the dev-menu internal setting.
         final Intent intent = getIntent();
         final String action = intent.getAction();
         final Uri initialUri = intent.getData();

--- a/apps/bare-expo/android/build.gradle
+++ b/apps/bare-expo/android/build.gradle
@@ -15,6 +15,7 @@ buildscript {
     }
     repositories {
         google()
+        mavenCentral()
         jcenter()
     }
     dependencies {
@@ -61,7 +62,13 @@ allprojects {
             url "$rootDir/../node_modules/expo-camera/android/maven"
         }
 
+       maven {
+           // Detox is installed from workspace root npm
+           url "$rootDir/../../../node_modules/detox/Detox-android"
+       }
+
         google()
+        mavenCentral()
         jcenter()
         maven { url 'https://jitpack.io' }
     }

--- a/apps/bare-expo/android/build.gradle
+++ b/apps/bare-expo/android/build.gradle
@@ -63,8 +63,8 @@ allprojects {
         }
 
        maven {
-           // Detox is installed from workspace root npm
-           url "$rootDir/../../../node_modules/detox/Detox-android"
+           // Detox is installed from npm
+           url "$rootDir/../node_modules/detox/Detox-android"
        }
 
         google()

--- a/apps/bare-expo/e2e/TestSuite-test.native.js
+++ b/apps/bare-expo/e2e/TestSuite-test.native.js
@@ -36,11 +36,15 @@ describe('test-suite', () => {
     it(
       `passes ${testName}`,
       async () => {
+        const platform = device.getPlatform();
         await device.launchApp({
           newInstance: true,
           url: `bareexpo://test-suite/run?tests=${testName}`,
         });
-        await sleepAsync(100);
+
+        const launchWaitingTime = platform === 'ios' ? 100 : 3000;
+        await sleepAsync(launchWaitingTime);
+
         await detoxExpect(element(by.id('test_suite_container'))).toExist();
         try {
           await waitFor(element(by.id('test_suite_text_results')))
@@ -50,14 +54,18 @@ describe('test-suite', () => {
           // test hasn't completed within the timeout
           // continue and log the intermediate results
         }
-        const attributes = await element(by.id('test_suite_final_results')).getAttributes();
 
-        const input = attributes.text;
-
-        expectResults({
-          testName,
-          input,
-        });
+        if (platform === 'ios') {
+          const attributes = await element(by.id('test_suite_final_results')).getAttributes();
+          const input = attributes.text;
+          expectResults({
+            testName,
+            input,
+          });
+        } else {
+          // Platforms do no support `getAttributes()`, using text matching instead
+          await detoxExpect(element(by.id('test_suite_text_results'))).toHaveText('Complete: 0 tests failed.');
+        }
       },
       MIN_TIME * 1.5
     );

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -130,7 +130,7 @@
     "@types/react-native": "~0.63.2",
     "babel-plugin-module-resolver": "^4.0.0",
     "babel-preset-expo": "~8.3.0",
-    "detox": "^18.6.2",
+    "detox": "^18.13.0",
     "expo-module-scripts": "^2.0.0",
     "expo-yarn-workspaces": "^1.5.1",
     "jest-expo": "~41.0.0",

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -67,13 +67,13 @@
       },
       "android.emu.debug": {
         "binaryPath": "android/app/build/outputs/apk/debug/app-debug.apk",
-        "build": "cd android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug && cd ..",
+        "build": "cd android && ./gradlew :app:assembleDebug :app:assembleAndroidTest -DtestBuildType=debug && cd ..",
         "type": "android.emulator",
         "name": "bare-expo"
       },
       "android.emu.release": {
         "binaryPath": "android/app/build/outputs/apk/release/app-release.apk",
-        "build": "cd android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release && cd ..",
+        "build": "cd android && ./gradlew :app:assembleRelease :app:assembleAndroidTest -DtestBuildType=release && cd ..",
         "type": "android.emulator",
         "name": "bare-expo"
       }

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -85,7 +85,8 @@
     "symlinks": [
       "expo-constants",
       "expo-camera",
-      "expo-updates"
+      "expo-updates",
+      "detox"
     ]
   },
   "dependencies": {

--- a/apps/test-suite/tests/FirebaseCore.js
+++ b/apps/test-suite/tests/FirebaseCore.js
@@ -59,22 +59,34 @@ export async function test({ describe, it, xit, expect, beforeAll }) {
           expect(DEFAULT_APP_OPTIONS).toBeDefined();
           expect(DEFAULT_APP_OPTIONS.appId).not.toBeNull();
           expect(DEFAULT_APP_OPTIONS.appId.indexOf(`:${Platform.OS}:`)).toBeGreaterThan(0);
-          expect(DEFAULT_APP_OPTIONS.messagingSenderId).not.toBeNull();
-          expect(DEFAULT_APP_OPTIONS.messagingSenderId.length).toBeGreaterThan(10);
-          expect(DEFAULT_APP_OPTIONS.apiKey).not.toBeNull();
-          expect(DEFAULT_APP_OPTIONS.apiKey.length).toBeGreaterThan(30);
-          expect(DEFAULT_APP_OPTIONS.projectId).not.toBeNull();
-          expect(DEFAULT_APP_OPTIONS.projectId.length).toBeGreaterThan(2);
+
+          if (Platform.OS === 'android') {
+            // These are empty values for default app in Firebase Android SDK.
+            // Just to check the keys are existed.
+            expect(DEFAULT_APP_OPTIONS.messagingSenderId).toBeDefined();
+            expect(DEFAULT_APP_OPTIONS.apiKey).toBeDefined();
+            expect(DEFAULT_APP_OPTIONS.projectId).toBeDefined();
+            expect(DEFAULT_APP_OPTIONS.storageBucket).toBeDefined();
+            expect(DEFAULT_APP_OPTIONS.databaseURL).toBeDefined();
+          } else {
+            expect(DEFAULT_APP_OPTIONS.messagingSenderId).not.toBeNull();
+            expect(DEFAULT_APP_OPTIONS.messagingSenderId.length).toBeGreaterThan(10);
+            expect(DEFAULT_APP_OPTIONS.apiKey).not.toBeNull();
+            expect(DEFAULT_APP_OPTIONS.apiKey.length).toBeGreaterThan(30);
+            expect(DEFAULT_APP_OPTIONS.projectId).not.toBeNull();
+            expect(DEFAULT_APP_OPTIONS.projectId.length).toBeGreaterThan(2);
+            expect(DEFAULT_APP_OPTIONS.storageBucket).not.toBeNull();
+            expect(DEFAULT_APP_OPTIONS.storageBucket.indexOf('appspot.com')).toBeGreaterThan(0);
+            expect(DEFAULT_APP_OPTIONS.databaseURL).not.toBeNull();
+            expect(DEFAULT_APP_OPTIONS.databaseURL.indexOf('firebaseio.com')).toBeGreaterThan(0);
+          }
+
           if (Platform.OS === 'ios') {
             expect(DEFAULT_APP_OPTIONS.clientId).not.toBeNull();
             expect(DEFAULT_APP_OPTIONS.clientId.indexOf('googleusercontent.com')).toBeGreaterThan(
               0
             );
           }
-          expect(DEFAULT_APP_OPTIONS.storageBucket).not.toBeNull();
-          expect(DEFAULT_APP_OPTIONS.storageBucket.indexOf('appspot.com')).toBeGreaterThan(0);
-          expect(DEFAULT_APP_OPTIONS.databaseURL).not.toBeNull();
-          expect(DEFAULT_APP_OPTIONS.databaseURL.indexOf('firebaseio.com')).toBeGreaterThan(0);
         } catch (e) {
           error = e;
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8386,10 +8386,10 @@ detect-port-alt@1.1.6:
     address "^1.0.1"
     debug "^2.6.0"
 
-detox@^18.6.2:
-  version "18.6.2"
-  resolved "https://registry.yarnpkg.com/detox/-/detox-18.6.2.tgz#9e8808a1f570c67d954e76d4793dc8270c22fd49"
-  integrity sha512-p+qh6XBKapp1aPAUA/oa1wqjIi+bBthCE/WylfCnHOhmB3ZjaeloskS+8qpxCLtu6efcO6CoxLiD2aStjhn9/w==
+detox@^18.13.0:
+  version "18.13.0"
+  resolved "https://registry.yarnpkg.com/detox/-/detox-18.13.0.tgz#c6108bfcc0a5579ea5f1f975222ca62773511b3c"
+  integrity sha512-YQPhi+uUGhVXYQm4W76EyKXdDKXnxq3dO+9ua22gGhNGwiJDbV8TUOavZNMbjBKWLb+OueGKOEBp4uNGOrVANw==
   dependencies:
     bunyan "^1.8.12"
     bunyan-debug-stream "^1.1.0"
@@ -8405,13 +8405,15 @@ detox@^18.6.2:
     proper-lockfile "^3.0.2"
     resolve-from "^5.0.0"
     sanitize-filename "^1.6.1"
+    semver "^7.0.0"
+    serialize-error "^8.0.1"
     shell-quote "^1.7.2"
     signal-exit "^3.0.3"
     tail "^2.0.0"
     telnet-client "1.2.8"
     tempfile "^2.0.0"
     which "^1.3.1"
-    ws "^3.3.1"
+    ws "^7.0.0"
     yargs "^16.0.3"
     yargs-unparser "^2.0.0"
 
@@ -17753,6 +17755,13 @@ semver@^6.0.0, semver@^6.1.1, semver@^6.2.0, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
+semver@^7.0.0:
+  version "7.3.5"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
+  integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
+  dependencies:
+    lru-cache "^6.0.0"
+
 semver@~7.3.2:
   version "7.3.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.4.tgz#27aaa7d2e4ca76452f98d3add093a72c943edc97"
@@ -17809,6 +17818,13 @@ serialize-error@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/serialize-error/-/serialize-error-2.1.0.tgz#50b679d5635cdf84667bdc8e59af4e5b81d5f60a"
   integrity sha1-ULZ51WNc34Rme9yOWa9OW4HV9go=
+
+serialize-error@^8.0.1:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/serialize-error/-/serialize-error-8.1.0.tgz#3a069970c712f78634942ddd50fbbc0eaebe2f67"
+  integrity sha512-3NnuWfM6vBYoy5gZFvHiYsVbafvI9vZv/+jlIigFn4oP4zjNPK3LhcY0xSCgeb1a5L8jO71Mit9LlNoi2UfDDQ==
+  dependencies:
+    type-fest "^0.20.2"
 
 serialize-javascript@^4.0.0:
   version "4.0.0"
@@ -19191,6 +19207,11 @@ type-fest@^0.12.0:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.12.0.tgz#f57a27ab81c68d136a51fd71467eff94157fa1ee"
   integrity sha512-53RyidyjvkGpnWPMF9bQgFtWp+Sl8O2Rp13VavmJgfAP9WWG6q6TkrKU8iyJdnwnfgHI6k2hTlgqH4aSdjoTbg==
 
+type-fest@^0.20.2:
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
+  integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
+
 type-fest@^0.3.0, type-fest@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.3.1.tgz#63d00d204e059474fe5e1b7c011112bbd1dc29e1"
@@ -19273,11 +19294,6 @@ ultron@1.0.x:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.0.2.tgz#ace116ab557cd197386a4e88f4685378c8b2e4fa"
   integrity sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po=
-
-ultron@~1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.1.1.tgz#9fe1536a10a664a65266a1e3ccf85fd36302bc9c"
-  integrity sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==
 
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"
@@ -20578,15 +20594,6 @@ ws@^1.1.0, ws@^1.1.5:
   dependencies:
     options ">=0.0.5"
     ultron "1.0.x"
-
-ws@^3.3.1:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-3.3.3.tgz#f1cf84fe2d5e901ebce94efaece785f187a228f2"
-  integrity sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==
-  dependencies:
-    async-limiter "~1.0.0"
-    safe-buffer "~5.1.0"
-    ultron "~1.1.0"
 
 ws@^5.2.0:
   version "5.2.2"


### PR DESCRIPTION
# Why

Originally, detox testing is not enabled on Android.
Though we had `expotools android-native-unit-tests --type instrumented`, unfortunately,  the test cases right now only test on modules themselves but not bare-expo.
With this PR, we could be more confident from bare-expo or test-suites regressions. 

# How

Fix debox build on Andriod.

# Test Plan

Make these works
`yarn android:detox:test:debug`
`yarn android:detox:test:release`

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] Add Android detox to CI.
- [x] Fix broken test-suites.
- [x] Fix test broken for UI blocked by dev-client onboarding activity.  