### PR TITLE
[android][ios] grab release channel from URL query parameter in Expo Go

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.java
+++ b/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.java
@@ -173,11 +173,20 @@ public class ExpoUpdatesAppLoader {
 
     Uri httpManifestUrl = mExponentManifest.httpManifestUrl(mManifestUrl);
 
+    String releaseChannel = Constants.RELEASE_CHANNEL;
+    if (!Constants.isStandaloneApp()) {
+      // in Expo Go, the release channel can change at runtime depending on the URL we load
+      String releaseChannelQueryParam = httpManifestUrl.getQueryParameter(ExponentManifest.QUERY_PARAM_KEY_RELEASE_CHANNEL);
+      if (releaseChannelQueryParam != null) {
+        releaseChannel = releaseChannelQueryParam;
+      }
+    }
+
     HashMap<String, Object> configMap = new HashMap<>();
     configMap.put(UpdatesConfiguration.UPDATES_CONFIGURATION_UPDATE_URL_KEY, httpManifestUrl);
     configMap.put(UpdatesConfiguration.UPDATES_CONFIGURATION_SCOPE_KEY_KEY, httpManifestUrl.toString());
     configMap.put(UpdatesConfiguration.UPDATES_CONFIGURATION_SDK_VERSION_KEY, Constants.SDK_VERSIONS);
-    configMap.put(UpdatesConfiguration.UPDATES_CONFIGURATION_RELEASE_CHANNEL_KEY, Constants.RELEASE_CHANNEL);
+    configMap.put(UpdatesConfiguration.UPDATES_CONFIGURATION_RELEASE_CHANNEL_KEY, releaseChannel);
     configMap.put(UpdatesConfiguration.UPDATES_CONFIGURATION_HAS_EMBEDDED_UPDATE_KEY, Constants.isStandaloneApp());
     configMap.put(UpdatesConfiguration.UPDATES_CONFIGURATION_ENABLED_KEY, Constants.ARE_REMOTE_UPDATES_ENABLED);
     if (mUseCacheOnly) {

--- a/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
+++ b/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
@@ -323,11 +323,18 @@ NS_ASSUME_NONNULL_BEGIN
 
   NSURL *httpManifestUrl = [[self class] _httpUrlFromManifestUrl:_manifestUrl];
 
+  NSString *releaseChannel = [EXEnvironment sharedEnvironment].releaseChannel;
+  if (![EXEnvironment sharedEnvironment].isDetached) {
+    // in Expo Go, the release channel can change at runtime depending on the URL we load
+    NSURLComponents *manifestUrlComponents = [NSURLComponents componentsWithURL:httpManifestUrl resolvingAgainstBaseURL:YES];
+    releaseChannel = [EXKernelLinkingManager releaseChannelWithUrlComponents:manifestUrlComponents];
+  }
+
   _config = [EXUpdatesConfig configWithDictionary:@{
     @"EXUpdatesURL": httpManifestUrl.absoluteString,
     @"EXUpdatesSDKVersion": [self _sdkVersions],
     @"EXUpdatesScopeKey": httpManifestUrl.absoluteString,
-    @"EXUpdatesReleaseChannel": [EXEnvironment sharedEnvironment].releaseChannel,
+    @"EXUpdatesReleaseChannel": releaseChannel,
     @"EXUpdatesHasEmbeddedUpdate": @([EXEnvironment sharedEnvironment].isDetached),
     @"EXUpdatesEnabled": @([EXEnvironment sharedEnvironment].areRemoteUpdatesEnabled),
     @"EXUpdatesLaunchWaitMs": launchWaitMs,

--- a/ios/Exponent/Kernel/Services/EXKernelLinkingManager.h
+++ b/ios/Exponent/Kernel/Services/EXKernelLinkingManager.h
@@ -38,6 +38,11 @@
  */
 + (BOOL)isExpoHostedUrl: (NSURL *)url;
 
+/**
+ *  Grab the release channel from the query parameters of a uri
+ */
++ (NSString *)releaseChannelWithUrlComponents:(NSURLComponents *)urlComponents;
+
 # pragma mark - app-wide linking handlers
 
 + (BOOL)application:(UIApplication *)application

--- a/ios/Exponent/Kernel/Services/EXKernelLinkingManager.m
+++ b/ios/Exponent/Kernel/Services/EXKernelLinkingManager.m
@@ -291,8 +291,8 @@ NSString *kEXExpoLegacyDeepLinkSeparator = @"+";
 
       if ([urlToRouteBasePath isEqualToString:manifestUrlBasePath]) {
         // release-channel is a special query parameter that we treat as a separate app, so we need to check that here
-        NSString *manifestUrlReleaseChannel = [[self class] _releaseChannelWithUrlComponents:manifestUrlComponents];
-        NSString *urlToRouteReleaseChannel = [[self class] _releaseChannelWithUrlComponents:urlToRouteComponents];
+        NSString *manifestUrlReleaseChannel = [[self class] releaseChannelWithUrlComponents:manifestUrlComponents];
+        NSString *urlToRouteReleaseChannel = [[self class] releaseChannelWithUrlComponents:urlToRouteComponents];
         if ([manifestUrlReleaseChannel isEqualToString:urlToRouteReleaseChannel]) {
           return YES;
         }
@@ -315,7 +315,7 @@ NSString *kEXExpoLegacyDeepLinkSeparator = @"+";
   return mutablePath;
 }
 
-+ (NSString *)_releaseChannelWithUrlComponents:(NSURLComponents *)urlComponents
++ (NSString *)releaseChannelWithUrlComponents:(NSURLComponents *)urlComponents
 {
   NSString *releaseChannel = @"default";
   NSArray<NSURLQueryItem *> *queryItems = urlComponents.queryItems;


### PR DESCRIPTION
# Why

Fix `Updates.releaseChannel` always having the value `default` in Expo Go (https://forums.expo.io/t/release-channel-and-eas-build/52133/2); native fix for #12895.

In Expo Go, we were providing expo-updates with a configuration object that always had the value of `default` for the release channel. However, it is possible to load projects with other release channels in Expo Go by adding a query parameter to the URL. This PR corrects the configuration object provided to expo-updates in that case, which has the effect of correcting the exported value for `Updates.releaseChannel`.

# How

If we're in Expo Go, when creating the expo-updates configuration object, get the release channel query parameter from the manifest URL and, if it's nonnull, set its value as the release channel on the configuration object. 

Another possible solution (which I think can safely coexist with this one) is to grab the `releaseChannel` value from the manifest after we have it and changing `Updates.releaseChannel` to point to that instead -- i.e. a native version of #12895's fix. That would change the meaning of `Updates.releaseChannel` slightly from "the release channel that we have configured locally, send to the server, and expect to run" from "the release channel of the currently running update, according to the server", which is maybe more useful, but also adds a dependency on a legacy manifest field that we (again) don't currently have an analogue for in the new manifest format. Bringing this up in case we think we want to add this to the new manifest format somehow.

# Test Plan

Opened a published SDK 41 project in Expo Go on iOS and Android, once with `default` release channel and once with `demo` release channel, and verified `Updates.releaseChannel` matched each time.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).