### PR TITLE
[image-picker] fix: view being transparent on iOS 14.5

### DIFF
--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXImagePicker/ABI41_0_0EXImagePicker/ABI41_0_0EXImagePicker.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXImagePicker/ABI41_0_0EXImagePicker/ABI41_0_0EXImagePicker.m
@@ -209,7 +209,7 @@ ABI41_0_0UM_EXPORT_METHOD_AS(launchImageLibraryAsync, launchImageLibraryAsync:(N
     
     self.picker.videoMaximumDuration = videoMaxDuration;
     
-    self.picker.modalPresentationStyle = UIModalPresentationOverCurrentContext;
+    self.picker.modalPresentationStyle = UIModalPresentationPageSheet;
     self.picker.delegate = self;
 
     [self maybePreserveVisibilityAndHideStatusBar:[[self.options objectForKey:@"allowsEditing"] boolValue]];

--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fixed `base64` return on web. ([#12529](https://github.com/expo/expo/pull/12529) by [@simonezuccala](https://github.com/simonezuccala) and [@misterdev](https://github.com/misterdev))
 - Enable kotlin in all modules. ([#12716](https://github.com/expo/expo/pull/12716) by [@wschurman](https://github.com/wschurman))
+- Fixed cases where Picker & Camera would be transparent on iOS 14.5. ([#12897](https://github.com/expo/expo/pull/12897) by [@cruzach](https://github.com/cruzach))
 
 ## 10.1.3 — 2021-04-13
 

--- a/packages/expo-image-picker/ios/EXImagePicker/EXImagePicker.m
+++ b/packages/expo-image-picker/ios/EXImagePicker/EXImagePicker.m
@@ -209,7 +209,7 @@ UM_EXPORT_METHOD_AS(launchImageLibraryAsync, launchImageLibraryAsync:(NSDictiona
     
     self.picker.videoMaximumDuration = videoMaxDuration;
     
-    self.picker.modalPresentationStyle = UIModalPresentationOverCurrentContext;
+    self.picker.modalPresentationStyle = UIModalPresentationPageSheet;
     self.picker.delegate = self;
 
     [self maybePreserveVisibilityAndHideStatusBar:[[self.options objectForKey:@"allowsEditing"] boolValue]];


### PR DESCRIPTION
# Why

closes https://github.com/expo/expo/issues/12771
closes https://github.com/expo/expo/issues/12009

# How

reading through https://developer.apple.com/library/archive/featuredarticles/ViewControllerPGforiPhoneOS/PresentingaViewController.html#//apple_ref/doc/uid/TP40007457-CH14-SW1, and after testing a couple of the different UIModalPresentationStyles, it seems like `UIModalPresentationPageSheet` is what we're after. it actually looks like UIModalPresentationOverCurrentContext is the only one of that enum to cause that problem, bc part of its purpose is to allow for a transparent view.

worth mentioning that `UIModalPresentationPageSheet` is [_usually_ the default used by iOS ](https://developer.apple.com/documentation/uikit/uimodalpresentationstyle/uimodalpresentationautomatic?language=objc)

# Test Plan

Tested using the repro in the issue linked, and the modal is no longer visible underneath. see screenshots for behavior:
Without the fix, you can see that the modal containing the `Camera` button is visible when the picker is open. The major change that this PR introduces is that on iPads, the imagepicker is no longer presented as full screen (this should match the behavior of `expo-docement-picker` since it has the same `UIModalPresentationPageSheet` setting.

## ios 14.5 without fix:
<img width="400" alt="Screen Shot 2021-05-11 at 3 48 51 PM" src="https://user-images.githubusercontent.com/35579283/117878358-ad18d100-b273-11eb-9031-a0b7bb0b15aa.png">
<img width="200" alt="Screen Shot 2021-05-11 at 3 48 44 PM" src="https://user-images.githubusercontent.com/35579283/117878364-adb16780-b273-11eb-996d-21be399507c0.png">

## ipad without fix:
<img width="600" alt="Screen Shot 2021-05-11 at 3 46 07 PM" src="https://user-images.githubusercontent.com/35579283/117878368-ae49fe00-b273-11eb-8304-b7a8ee33ce5a.png">
<img width="300" alt="Screen Shot 2021-05-11 at 3 45 59 PM" src="https://user-images.githubusercontent.com/35579283/117878370-aee29480-b273-11eb-97f6-fd799bbda61c.png">

## ios 14.5 with fix:
<img width="400" alt="Screen Shot 2021-05-11 at 3 50 52 PM" src="https://user-images.githubusercontent.com/35579283/117878343-aab67700-b273-11eb-8a08-c7f753d3a710.png">
<img width="200" alt="Screen Shot 2021-05-11 at 3 50 47 PM" src="https://user-images.githubusercontent.com/35579283/117878353-abe7a400-b273-11eb-8573-e1427339e68b.png">

## ipad with fix:
<img width="600" alt="Screen Shot 2021-05-11 at 3 43 06 PM" src="https://user-images.githubusercontent.com/35579283/117878371-af7b2b00-b273-11eb-9b1f-ad5c0f3983f8.png">
<img width="300" alt="Screen Shot 2021-05-11 at 3 43 00 PM" src="https://user-images.githubusercontent.com/35579283/117878372-b013c180-b273-11eb-9ccb-a08bdfee3cc5.png">

## ios 12 with fix:
(included to check to make sure no issues on older versions of iOS)
<img width="400" alt="Screen Shot 2021-05-11 at 4 03 57 PM" src="https://user-images.githubusercontent.com/35579283/117878334-a8541d00-b273-11eb-823e-364886c37a9d.png">
<img width="200" alt="Screen Shot 2021-05-11 at 4 03 42 PM" src="https://user-images.githubusercontent.com/35579283/117878341-aa1de080-b273-11eb-87ea-22458f8fd1fc.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).