### PR TITLE
[rnu] Remove expo-permissions (again)

### DIFF
--- a/packages/react-native-unimodules/CHANGELOG.md
+++ b/packages/react-native-unimodules/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Remove expo-permissions (again). ([#12900](https://github.com/expo/expo/pull/12900) by [@brentvatne](https://github.com/brentvatne))
+
 ### 💡 Others
 
 - Migrated camera and constants interfaces from their own packages to `expo-modules-core`. ([#12876](https://github.com/expo/expo/pull/12876) by [@tsapeta](https://github.com/tsapeta))

--- a/packages/react-native-unimodules/package.json
+++ b/packages/react-native-unimodules/package.json
@@ -44,7 +44,6 @@
     "expo-file-system": "~11.0.2",
     "expo-image-loader": "~2.1.1",
     "expo-modules-core": "~0.0.1",
-    "expo-permissions": "~12.0.1",
     "find-up": "~5.0.0",
     "unimodules-app-loader": "~2.1.0",
     "unimodules-barcode-scanner-interface": "~6.1.0",


### PR DESCRIPTION
# Why

- We removed expo-permissions in https://github.com/expo/expo/pull/12405 but then didn't cherry-pick to sdk-41.
- When doing the final release for sdk-41 we had to publish packages from the sdk-41 branch, and I wanted to cherry-pick that back into master so we wouldn't have to deal with a beta version in the expo package for the entire cycle, and so our package versions would be up to date on master in general.
- This resulted in expo-permissions getting added back to react-native-unimodules on master.

# How

Remove it, run yarn

# Test Plan

CI

# Checklist


- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).