### PR TITLE
[android] Fix persistent error jsonization

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/experience/BaseExperienceActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/BaseExperienceActivity.java
@@ -239,9 +239,6 @@ public abstract class BaseExperienceActivity extends MultipleVersionReactNativeA
       while (!sErrorQueue.isEmpty()) {
         ExponentError error = sErrorQueue.remove();
         ErrorActivity.addError(error);
-        if (sVisibleActivity != null) {
-          sVisibleActivity.onError(error);
-        }
 
         // Just use the last error message for now, is there a better way to do this?
         errorMessage = error.errorMessage;
@@ -262,10 +259,5 @@ public abstract class BaseExperienceActivity extends MultipleVersionReactNativeA
   // Override
   protected void onError(final Intent intent) {
     // Modify intent used to start ErrorActivity
-  }
-
-  // Override
-  protected void onError(final ExponentError error) {
-    // Called for each JS error
   }
 }

--- a/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
@@ -829,40 +829,7 @@ public class ExperienceActivity extends BaseExperienceActivity implements Expone
 
   @Override
   protected void onError(final ExponentError error) {
-    if (mManifest == null) {
-      return;
-    }
 
-    JSONObject errorJson = error.toJSONObject();
-    if (errorJson == null) {
-      return;
-    }
-
-    String experienceId;
-    try {
-      experienceId = mManifest.getID();
-    } catch (JSONException e) {
-      return;
-    }
-
-    JSONObject metadata = mExponentSharedPreferences.getExperienceMetadata(experienceId);
-    if (metadata == null) {
-      metadata = new JSONObject();
-    }
-
-    JSONArray errors = metadata.optJSONArray(ExponentSharedPreferences.EXPERIENCE_METADATA_LAST_ERRORS);
-    if (errors == null) {
-      errors = new JSONArray();
-    }
-
-    errors.put(errorJson);
-
-    try {
-      metadata.put(ExponentSharedPreferences.EXPERIENCE_METADATA_LAST_ERRORS, errors);
-      mExponentSharedPreferences.updateExperienceMetadata(experienceId, metadata);
-    } catch (JSONException e) {
-      e.printStackTrace();
-    }
   }
 
   public String getExperienceId() {

--- a/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
@@ -827,11 +827,6 @@ public class ExperienceActivity extends BaseExperienceActivity implements Expone
     }
   }
 
-  @Override
-  protected void onError(final ExponentError error) {
-
-  }
-
   public String getExperienceId() {
     return mExperienceIdString;
   }

--- a/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.java
@@ -478,17 +478,6 @@ public abstract class ReactNativeActivity extends AppCompatActivity implements c
 
     JSONObject metadata = mExponentSharedPreferences.getExperienceMetadata(mExperienceIdString);
     if (metadata != null) {
-      if (metadata.has(ExponentSharedPreferences.EXPERIENCE_METADATA_LAST_ERRORS)) {
-        try {
-          exponentProps.put(ExponentSharedPreferences.EXPERIENCE_METADATA_LAST_ERRORS,
-            metadata.getJSONArray(ExponentSharedPreferences.EXPERIENCE_METADATA_LAST_ERRORS).toString());
-        } catch (JSONException e) {
-          e.printStackTrace();
-        }
-
-        metadata.remove(ExponentSharedPreferences.EXPERIENCE_METADATA_LAST_ERRORS);
-      }
-
       // TODO: fix this. this is the only place that EXPERIENCE_METADATA_UNREAD_REMOTE_NOTIFICATIONS is sent to the experience,
       // we need to sent them with the standard notification events so that you can get all the unread notification through an event
       // Copy unreadNotifications into exponentProps

--- a/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.java
@@ -481,7 +481,7 @@ public abstract class ReactNativeActivity extends AppCompatActivity implements c
       if (metadata.has(ExponentSharedPreferences.EXPERIENCE_METADATA_LAST_ERRORS)) {
         try {
           exponentProps.put(ExponentSharedPreferences.EXPERIENCE_METADATA_LAST_ERRORS,
-            metadata.getJSONArray(ExponentSharedPreferences.EXPERIENCE_METADATA_LAST_ERRORS));
+            metadata.getJSONArray(ExponentSharedPreferences.EXPERIENCE_METADATA_LAST_ERRORS).toString());
         } catch (JSONException e) {
           e.printStackTrace();
         }
@@ -495,7 +495,7 @@ public abstract class ReactNativeActivity extends AppCompatActivity implements c
       if (metadata.has(ExponentSharedPreferences.EXPERIENCE_METADATA_UNREAD_REMOTE_NOTIFICATIONS)) {
         try {
           JSONArray unreadNotifications = metadata.getJSONArray(ExponentSharedPreferences.EXPERIENCE_METADATA_UNREAD_REMOTE_NOTIFICATIONS);
-          exponentProps.put(ExponentSharedPreferences.EXPERIENCE_METADATA_UNREAD_REMOTE_NOTIFICATIONS, unreadNotifications);
+          exponentProps.put(ExponentSharedPreferences.EXPERIENCE_METADATA_UNREAD_REMOTE_NOTIFICATIONS, unreadNotifications.toString());
 
           delegate.handleUnreadNotifications(unreadNotifications);
         } catch (JSONException e) {

--- a/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.java
@@ -484,8 +484,6 @@ public abstract class ReactNativeActivity extends AppCompatActivity implements c
       if (metadata.has(ExponentSharedPreferences.EXPERIENCE_METADATA_UNREAD_REMOTE_NOTIFICATIONS)) {
         try {
           JSONArray unreadNotifications = metadata.getJSONArray(ExponentSharedPreferences.EXPERIENCE_METADATA_UNREAD_REMOTE_NOTIFICATIONS);
-          exponentProps.put(ExponentSharedPreferences.EXPERIENCE_METADATA_UNREAD_REMOTE_NOTIFICATIONS, unreadNotifications.toString());
-
           delegate.handleUnreadNotifications(unreadNotifications);
         } catch (JSONException e) {
           e.printStackTrace();

--- a/android/expoview/src/main/java/host/exp/exponent/storage/ExponentSharedPreferences.java
+++ b/android/expoview/src/main/java/host/exp/exponent/storage/ExponentSharedPreferences.java
@@ -62,7 +62,6 @@ public class ExponentSharedPreferences {
 
   // Metadata
   public static final String EXPERIENCE_METADATA_PREFIX = "experience_metadata_";
-  public static final String EXPERIENCE_METADATA_LAST_ERRORS = "lastErrors";
   public static final String EXPERIENCE_METADATA_UNREAD_REMOTE_NOTIFICATIONS = "unreadNotifications";
   public static final String EXPERIENCE_METADATA_ALL_NOTIFICATION_IDS = "allNotificationIds";
   public static final String EXPERIENCE_METADATA_ALL_SCHEDULED_NOTIFICATION_IDS = "allScheduledNotificationIds";


### PR DESCRIPTION
# Why

Resolves ENG-720

# How

On Android I've searched for any occurrence of `JSONArray` that is then converted into `Bundle` (that is later used as initial props).
There're two keys `ExponentSharedPreferences.EXPERIENCE_METADATA_LAST_ERRORS` and `ExponentSharedPreferences.EXPERIENCE_METADATA_UNREAD_REMOTE_NOTIFICATIONS` that might cause array-based problems.
~Strangely these two keys are not used by any other part of the current codebase 🤔~ `LAST_ERRORS` is no longer used and `UNREAD_REMOTE_NOTIFICATIONS` is used for managing notifications internally. 

There's a suggestion to get rid of them altogether, ~but as I'm not sure why these were proposed in the first place I'm refraining from deleting them 🤷~

`ExponentSharedPreferences.EXPERIENCE_METADATA_LAST_ERRORS` is removed completely and `ExponentSharedPreferences.EXPERIENCE_METADATA_UNREAD_REMOTE_NOTIFICATIONS` is no longer send as a part of `initialProps` to React Root View 💪 

# Test Plan

Tried to obtain any persistent error for the project, but failed to 😞 
I can only assure that these keys are not read by anything on JS or native side or at least I couldn't find anything 🧐 
