### PR TITLE
[ci] Automatically cancel running workflows in the same concurrency group

### DIFF
--- a/.github/workflows/android-instrumentation-tests.yml
+++ b/.github/workflows/android-instrumentation-tests.yml
@@ -18,6 +18,10 @@ on:
       - 'tools/**'
       - yarn.lock
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: macos-latest

--- a/.github/workflows/android-unit-tests.yml
+++ b/.github/workflows/android-unit-tests.yml
@@ -20,6 +20,10 @@ on:
       - tools/**
       - yarn.lock
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-18.04

--- a/.github/workflows/client-android.yml
+++ b/.github/workflows/client-android.yml
@@ -29,6 +29,10 @@ on:
       - .ruby-version
       - yarn.lock
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-18.04

--- a/.github/workflows/client-ios.yml
+++ b/.github/workflows/client-ios.yml
@@ -26,6 +26,10 @@ on:
       - Gemfile.lock
       - .ruby-version
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: macos-10.15

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -11,6 +11,10 @@ on:
     paths:
       - packages/**
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   code_review:
     runs-on: ubuntu-18.04

--- a/.github/workflows/expotools.yml
+++ b/.github/workflows/expotools.yml
@@ -12,6 +12,10 @@ on:
       - .github/workflows/expotools.yml
       - tools/**
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-18.04

--- a/.github/workflows/ios-unit-tests.yml
+++ b/.github/workflows/ios-unit-tests.yml
@@ -24,6 +24,10 @@ on:
       - Gemfile.lock
       - .ruby-version
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: macos-10.15

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -23,6 +23,10 @@ on:
   schedule:
     - cron: 0 14 * * *
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-packages:
     runs-on: ubuntu-18.04

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -18,6 +18,10 @@ on:
       - packages/**
       - yarn.lock
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   web:
     runs-on: ubuntu-18.04


### PR DESCRIPTION
# Why

GitHub Actions has a new beta feature: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency

It allows us to automatically cancel running workflows that share the same concurrency group. For example, for workflows triggered on `pull_request` event, when we push a new commit before the previous workflow finishes, it will be automatically canceled.

# How

Added `concurrency` to some of the workflows (since this is beta feature, let's just test it in the subset of our workflows).
The group ID is made from the event name and the reference which is usually in the format `refs/heads/<branch_name>`.

# Test Plan

I've forced push to this PR when the workflows were running. As a result, these running workflows were canceled once the new ones were queued.

See annotations on this page: https://github.com/expo/expo/actions/runs/835389392
