### PR TITLE
[dev-menu] Fix compatibility with RN 0.64

### DIFF
--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/loaders/DevLauncherAppLoader.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/loaders/DevLauncherAppLoader.kt
@@ -98,10 +98,14 @@ abstract class DevLauncherAppLoader(
     val debugServerHost = url.host + ":" + url.port
     // We need to remove "/" which is added to begin of the path by the Uri
     // and the bundle type
-    val bundleName = url.path
-      ?.substring(1)
-      ?.replace(".bundle", "")
-      ?: "index"
+    val bundleName = if (url.path.isNullOrEmpty()) {
+      "index"
+    } else {
+      url.path
+        ?.substring(1)
+        ?.replace(".bundle", "")
+        ?: "index"
+    }
 
     return injectReactInterceptor(
       context,

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -28,7 +28,7 @@
 - Fixed XCode warnings. ([#12798](https://github.com/expo/expo/pull/12798) by [@lukmccall](https://github.com/lukmccall))
 - Fixed the `SafeAreaView` color wasn't applied correctly while using the dark mode. ([#12851](https://github.com/expo/expo/pull/12851) by [@lukmccall](https://github.com/lukmccall))
 - [plugin] Removed unused menu initialization if expo-dev-launcher is installed on iOS. ([#12875](https://github.com/expo/expo/pull/12875) by [@lukmccall](https://github.com/lukmccall))
-- Fixed compatibility with React Native 0.64.X on iOS.
+- Fixed compatibility with React Native 0.64.X on iOS. ([#12909](https://github.com/expo/expo/pull/12909) by [@lukmccall](https://github.com/lukmccall))
 
 ## 0.4.1 — 2021-03-30
 

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed compatibility with React Native 0.64.X on iOS. ([#12909](https://github.com/expo/expo/pull/12909) by [@lukmccall](https://github.com/lukmccall))
+- Fixed compatibility with React Native 0.64.X. ([#12909](https://github.com/expo/expo/pull/12909) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed compatibility with React Native 0.64.X on iOS. ([#12909](https://github.com/expo/expo/pull/12909) by [@lukmccall](https://github.com/lukmccall))
+
 ### 💡 Others
 
 ## 0.5.0 — 2021-05-11
@@ -28,7 +30,6 @@
 - Fixed XCode warnings. ([#12798](https://github.com/expo/expo/pull/12798) by [@lukmccall](https://github.com/lukmccall))
 - Fixed the `SafeAreaView` color wasn't applied correctly while using the dark mode. ([#12851](https://github.com/expo/expo/pull/12851) by [@lukmccall](https://github.com/lukmccall))
 - [plugin] Removed unused menu initialization if expo-dev-launcher is installed on iOS. ([#12875](https://github.com/expo/expo/pull/12875) by [@lukmccall](https://github.com/lukmccall))
-- Fixed compatibility with React Native 0.64.X on iOS. ([#12909](https://github.com/expo/expo/pull/12909) by [@lukmccall](https://github.com/lukmccall))
 
 ## 0.4.1 — 2021-03-30
 

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Fixed XCode warnings. ([#12798](https://github.com/expo/expo/pull/12798) by [@lukmccall](https://github.com/lukmccall))
 - Fixed the `SafeAreaView` color wasn't applied correctly while using the dark mode. ([#12851](https://github.com/expo/expo/pull/12851) by [@lukmccall](https://github.com/lukmccall))
 - [plugin] Removed unused menu initialization if expo-dev-launcher is installed on iOS. ([#12875](https://github.com/expo/expo/pull/12875) by [@lukmccall](https://github.com/lukmccall))
+- Fixed compatibility with React Native 0.64.X on iOS.
 
 ## 0.4.1 — 2021-03-30
 

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuManager.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuManager.kt
@@ -187,7 +187,7 @@ object DevMenuManager : DevMenuManagerInterface, LifecycleEventListener {
     maybeStartDetectors(devMenuHost.getContext())
 
     settings = if (reactContext.hasNativeModule(DevMenuSettings::class.java)) {
-      reactContext.getNativeModule(DevMenuSettings::class.java)
+      reactContext.getNativeModule(DevMenuSettings::class.java)!!
     } else {
       DevMenuDefaultSettings()
     }.also {

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/modules/DevMenuModule.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/modules/DevMenuModule.kt
@@ -13,7 +13,7 @@ class DevMenuModule(reactContext: ReactApplicationContext)
 
   private val devMenuManager by lazy {
     reactContext
-      .getNativeModule(DevMenuManagerProvider::class.java)
+      .getNativeModule(DevMenuManagerProvider::class.java)!!
       .getDevMenuManager()
   }
 

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/modules/internals/DevMenuInternalMenuControllerModule.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/modules/internals/DevMenuInternalMenuControllerModule.kt
@@ -13,7 +13,7 @@ class DevMenuInternalMenuControllerModule(private val reactContext: ReactContext
   : DevMenuInternalMenuControllerModuleInterface {
   private val devMenuManger by lazy {
     reactContext
-      .getNativeModule(DevMenuManagerProvider::class.java)
+      .getNativeModule(DevMenuManagerProvider::class.java)!!
       .getDevMenuManager()
   }
 

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/modules/internals/DevMenuInternalSessionManagerModule.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/modules/internals/DevMenuInternalSessionManagerModule.kt
@@ -23,7 +23,7 @@ class DevMenuInternalSessionManagerModule(
 ) : DevMenuInternalSessionManagerModuleInterface {
   private val devMenuManger by lazy {
     reactContext
-      .getNativeModule(DevMenuManagerProvider::class.java)
+      .getNativeModule(DevMenuManagerProvider::class.java)!!
       .getDevMenuManager()
   }
 

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/react/DevMenuReactInternalSettings.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/react/DevMenuReactInternalSettings.kt
@@ -38,8 +38,6 @@ class DevMenuReactInternalSettings(
 
   override fun isHotModuleReplacementEnabled() = true
 
-  override fun isNuclideJSDebugEnabled() = false
-
   override fun setHotModuleReplacementEnabled(enabled: Boolean) = Unit
 
   override fun addMenuItem(title: String?) = Unit

--- a/packages/expo-dev-menu/ios/DevMenuAppInstance.swift
+++ b/packages/expo-dev-menu/ios/DevMenuAppInstance.swift
@@ -27,10 +27,7 @@ class DevMenuAppInstance: NSObject, RCTBridgeDelegate {
   func sourceURL(for bridge: RCTBridge!) -> URL! {
     #if DEBUG
     if let packagerHost = jsPackagerHost() {
-      if RCTBundleURLProvider.sharedSettings()?.isPackagerRunning(packagerHost) == true {
-        return RCTBundleURLProvider.jsBundleURL(forBundleRoot: "index", packagerHost: packagerHost, enableDev: true, enableMinification: false)
-      }
-      print("Expo DevMenu packager host \(packagerHost) not found, falling back to bundled source file...");
+      return RCTBundleURLProvider.jsBundleURL(forBundleRoot: "index", packagerHost: packagerHost, enableDev: true, enableMinification: false)
     }
     #endif
     return jsSourceUrl()

--- a/packages/expo-dev-menu/vendored/react-native-gesture-handler/ios/DevMenuRNGestureHandlerManager.h
+++ b/packages/expo-dev-menu/vendored/react-native-gesture-handler/ios/DevMenuRNGestureHandlerManager.h
@@ -2,6 +2,7 @@
 
 #import <React/RCTBridgeModule.h>
 #import <React/RCTUIManager.h>
+#import <React/RCTEventDispatcher.h>
 
 @interface DevMenuRNGestureHandlerManager : NSObject
 


### PR DESCRIPTION
# Why

Dev-menu project doesn't compile with the newest react-native version.

# Test Plan

- test-app ✅
- bare-expo ✅