### PR TITLE
Add note that universal link changes need rebuild

### DIFF
--- a/docs/pages/versions/unversioned/sdk/branch.md
+++ b/docs/pages/versions/unversioned/sdk/branch.md
@@ -27,7 +27,7 @@ Branch can track universal links from domains you associate with your app. **Not
 
 - Enable Universal Links in the [Link Settings](https://dashboard.branch.io/link-settings) section of the Branch Dashboard and fill in your Bundle Identifier and Apple App Prefix.
 
-- Add an associated domain to support universal links to your `app.json` in the `ios.associatedDomains` section. This should be in the form of `applinks:<link-domain>` where `link-domain` can be found in the Link Domain section of the [Link Settings](https://dashboard.branch.io/link-settings) page on the Branch Dashboard.
+- Add an associated domain to support universal links to your `app.json` in the `ios.associatedDomains` section. This should be in the form of `applinks:<link-domain>` where `link-domain` can be found in the Link Domain section of the [Link Settings](https://dashboard.branch.io/link-settings) page on the Branch Dashboard. You will [need to rebuild](https://docs.expo.io/workflow/publishing/#some-native-configuration-cant-be-updated-by) your app for the new associated domain to be picked up.
 
 ## Importing Branch
 

--- a/docs/pages/versions/unversioned/sdk/branch.md
+++ b/docs/pages/versions/unversioned/sdk/branch.md
@@ -28,7 +28,7 @@ Branch can track universal links from domains you associate with your app. **Not
 
 - Enable Universal Links in the [Link Settings](https://dashboard.branch.io/link-settings) section of the Branch Dashboard and fill in your Bundle Identifier and Apple App Prefix.
 
-- Add an associated domain to support universal links to your `app.json` in the `ios.associatedDomains` section. This should be in the form of `applinks:<link-domain>` where `link-domain` can be found in the Link Domain section of the [Link Settings](https://dashboard.branch.io/link-settings) page on the Branch Dashboard. You will [need to rebuild](https://docs.expo.io/workflow/publishing/#some-native-configuration-cant-be-updated-by) your app for the new associated domain to be picked up.
+- Add an associated domain to support universal links to your `app.json` in the `ios.associatedDomains` section. This should be in the form of `applinks:<link-domain>` where `link-domain` can be found in the Link Domain section of the [Link Settings](https://dashboard.branch.io/link-settings) page on the Branch Dashboard. You will [need to rebuild](/workflow/publishing/#some-native-configuration-cant-be-updated-by) your app for the new associated domain to be picked up.
 
 ## Importing Branch
 

--- a/docs/pages/versions/unversioned/sdk/branch.md
+++ b/docs/pages/versions/unversioned/sdk/branch.md
@@ -18,6 +18,7 @@ For [managed](../../../introduction/managed-vs-bare.md#managed-workflow) apps, y
 - Add the **Branch Key** to your `app.json` in the section `android.config.branch.apiKey` and `ios.config.branch.apiKey`. You can find your key on [this page](https://dashboard.branch.io/account-settings/app) of the Branch Dashboard.
 - Add a **linking scheme** to your `app.json` in the `scheme` section if you don't already have one.
 - On iOS, the `Branch` module will automatically be bundled with your `.ipa`. For Android, `expo-branch` must be present in your dependencies in `package.json` at the time `expo build:android` is run in order for the module to be bundled with your `.apk`.
+- For Android, add a new intent filter that registers the Branch `link-domain`, under `android.intentFilters` in `app.json`.
 
 ### Enable Branch support for Universal Links (iOS only)
 

--- a/docs/pages/versions/v41.0.0/sdk/branch.md
+++ b/docs/pages/versions/v41.0.0/sdk/branch.md
@@ -27,7 +27,7 @@ Branch can track universal links from domains you associate with your app. **Not
 
 - Enable Universal Links in the [Link Settings](https://dashboard.branch.io/link-settings) section of the Branch Dashboard and fill in your Bundle Identifier and Apple App Prefix.
 
-- Add an associated domain to support universal links to your `app.json` in the `ios.associatedDomains` section. This should be in the form of `applinks:<link-domain>` where `link-domain` can be found in the Link Domain section of the [Link Settings](https://dashboard.branch.io/link-settings) page on the Branch Dashboard.
+- Add an associated domain to support universal links to your `app.json` in the `ios.associatedDomains` section. This should be in the form of `applinks:<link-domain>` where `link-domain` can be found in the Link Domain section of the [Link Settings](https://dashboard.branch.io/link-settings) page on the Branch Dashboard. You will [need to rebuild](https://docs.expo.io/workflow/publishing/#some-native-configuration-cant-be-updated-by) your app for the new associated domain to be picked up.
 
 ## Importing Branch
 

--- a/docs/pages/versions/v41.0.0/sdk/branch.md
+++ b/docs/pages/versions/v41.0.0/sdk/branch.md
@@ -28,7 +28,7 @@ Branch can track universal links from domains you associate with your app. **Not
 
 - Enable Universal Links in the [Link Settings](https://dashboard.branch.io/link-settings) section of the Branch Dashboard and fill in your Bundle Identifier and Apple App Prefix.
 
-- Add an associated domain to support universal links to your `app.json` in the `ios.associatedDomains` section. This should be in the form of `applinks:<link-domain>` where `link-domain` can be found in the Link Domain section of the [Link Settings](https://dashboard.branch.io/link-settings) page on the Branch Dashboard. You will [need to rebuild](https://docs.expo.io/workflow/publishing/#some-native-configuration-cant-be-updated-by) your app for the new associated domain to be picked up.
+- Add an associated domain to support universal links to your `app.json` in the `ios.associatedDomains` section. This should be in the form of `applinks:<link-domain>` where `link-domain` can be found in the Link Domain section of the [Link Settings](https://dashboard.branch.io/link-settings) page on the Branch Dashboard. You will [need to rebuild](/workflow/publishing/#some-native-configuration-cant-be-updated-by) your app for the new associated domain to be picked up.
 
 ## Importing Branch
 

--- a/docs/pages/versions/v41.0.0/sdk/branch.md
+++ b/docs/pages/versions/v41.0.0/sdk/branch.md
@@ -18,6 +18,7 @@ For [managed](../../../introduction/managed-vs-bare.md#managed-workflow) apps, y
 - Add the **Branch Key** to your `app.json` in the section `android.config.branch.apiKey` and `ios.config.branch.apiKey`. You can find your key on [this page](https://dashboard.branch.io/account-settings/app) of the Branch Dashboard.
 - Add a **linking scheme** to your `app.json` in the `scheme` section if you don't already have one.
 - On iOS, the `Branch` module will automatically be bundled with your `.ipa`. For Android, `expo-branch` must be present in your dependencies in `package.json` at the time `expo build:android` is run in order for the module to be bundled with your `.apk`.
+- For Android, add a new intent filter that registers the Branch `link-domain`, under `android.intentFilters` in `app.json`.
 
 ### Enable Branch support for Universal Links (iOS only)
 


### PR DESCRIPTION
# Why

Update `expo-branch` docs to explain iOS binary needs to be rebuilt for universal links to work (i.e. for associated domain changes to be respected)

# How

By integrating `expo-branch` into our app
