### PR TITLE
[expo-dev-launcher] Fix incorrect dev menu and flash of launcher

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix flash of dev launcher screen during launch and incorrect dev menu shown on the 1st launch. ([#12765](https://github.com/expo/expo/pull/12765) by [@fson](https://github.com/fson))
+
 ### 💡 Others
 
 ## 0.3.2 — 2021-05-12

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -129,7 +129,9 @@ NSString *fakeLauncherBundleUrl = @"embedded://EXDevLauncher/dummy";
   _launchOptions = launchOptions;
   _window = window;
 
-  [self navigateToLauncher];
+  if (!launchOptions[UIApplicationLaunchOptionsURLKey]) {
+    [self navigateToLauncher];
+  }
 }
 
 - (void)navigateToLauncher


### PR DESCRIPTION
# Why

When running the app (using expo run:ios) there were two issues:
- on the 1st launch (app not installed yet), it showed the "Hello Friend" popup and then the dev menu for the launcher, not the dev menu for your app (the title said "Development Client" instead of the name of the app
- on subsequent launches, it navigated to the app, but there was a brief flash of dev launcher before showing the app

# How

Added a check for `UIApplicationLaunchOptionsURLKey` to prevent `navigateToLauncher` from being called when the app is opened with a deep link.

# Test Plan

Tested in an app created with `npx crna -t with-dev-client` and verified that the problem was no longer present after the fix.

# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).