### PR TITLE
[home] Fix tsc error after manifest2 landed

### DIFF
--- a/home/utils/Environment.ts
+++ b/home/utils/Environment.ts
@@ -5,7 +5,7 @@ import semver from 'semver';
 import * as Kernel from '../kernel/Kernel';
 
 const isProduction = !!(
-  Constants.manifest.id === '@exponent/home' && Constants.manifest.publishedTime
+  Constants.manifest?.id === '@exponent/home' && Constants.manifest?.publishedTime
 );
 
 const IOSClientReleaseType = Kernel.iosClientReleaseType;


### PR DESCRIPTION
# Why

Side effect from #12817 that Constants.manifest may be null now.
This PR does not cover manifest2 yet, not sure how Expo Go works for manifest2.

# Test Plan

Errors free for `yarn tsc` in home/ 
