### PR TITLE
[expo-dev-launcher] Build plugin JS

### DIFF
--- a/packages/expo-dev-launcher/plugin/build/withDevLauncherAppDelegate.js
+++ b/packages/expo-dev-launcher/plugin/build/withDevLauncherAppDelegate.js
@@ -45,6 +45,11 @@ const DEV_LAUNCHER_APP_DELEGATE_BRIDGE = `#if defined(EX_DEV_LAUNCHER_ENABLED)
   #endif
   
     RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:launchOptions];`;
+const DEV_MENU_IMPORT = `@import EXDevMenu;`;
+const DEV_MENU_IOS_INIT = `
+#if defined(EX_DEV_MENU_ENABLED)
+  [DevMenuManager configureWithBridge:bridge];
+#endif`;
 function modifyAppDelegate(appDelegate) {
     if (!appDelegate.includes(DEV_LAUNCHER_APP_DELEGATE_IOS_IMPORT)) {
         const lines = appDelegate.split('\n');
@@ -65,6 +70,11 @@ function modifyAppDelegate(appDelegate) {
     }
     if (!appDelegate.includes(DEV_LAUNCHER_APP_DELEGATE_CONTROLLER_DELEGATE)) {
         appDelegate += DEV_LAUNCHER_APP_DELEGATE_CONTROLLER_DELEGATE;
+    }
+    if (!appDelegate.includes(DEV_MENU_IMPORT)) {
+        // expo-dev-launcher is responsible for initializing the expo-dev-menu.
+        // We need to remove init block from AppDelegate.
+        appDelegate = appDelegate.replace(DEV_MENU_IOS_INIT, '');
     }
     return appDelegate;
 }


### PR DESCRIPTION
# Why

The built JS output was not up to date.

# How

`yarn prepare`

# Test Plan

Run `expo prebuild` once this is published to `next` tag.