### PR TITLE
[apple-auth] Updated plugin to be more automated

### DIFF
--- a/packages/expo-apple-authentication/CHANGELOG.md
+++ b/packages/expo-apple-authentication/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- [plugin] Apply entitlements regardless of `ios.usesAppleSignIn`, add support for locales ([#12927](https://github.com/expo/expo/pull/12927) by [@EvanBacon](https://github.com/EvanBacon))
+
 ### 🐛 Bug fixes
 
 ## 3.1.0 — 2021-03-10

--- a/packages/expo-apple-authentication/package.json
+++ b/packages/expo-apple-authentication/package.json
@@ -32,7 +32,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.io/versions/latest/sdk/apple-authentication/",
   "dependencies": {
-    "@expo/config-plugins": "^1.0.18"
+    "@expo/config-plugins": "^1.0.30"
   },
   "devDependencies": {
     "expo-module-scripts": "^2.0.0"

--- a/packages/expo-apple-authentication/plugin/build/withAppleAuthIOS.d.ts
+++ b/packages/expo-apple-authentication/plugin/build/withAppleAuthIOS.d.ts
@@ -1,4 +1,10 @@
 import { ConfigPlugin } from '@expo/config-plugins';
-import { ExpoConfig } from '@expo/config-types';
+/**
+ * Enable including `strings` files from external packages.
+ * Required for making the Apple Auth button support localizations.
+ *
+ * @param config
+ * @returns
+ */
+export declare const withIOSMixedLocales: ConfigPlugin;
 export declare const withAppleAuthIOS: ConfigPlugin;
-export declare function setAppleAuthEntitlements(config: Pick<ExpoConfig, 'ios'>, entitlements: Record<string, any>): Record<string, any>;

--- a/packages/expo-apple-authentication/plugin/build/withAppleAuthIOS.js
+++ b/packages/expo-apple-authentication/plugin/build/withAppleAuthIOS.js
@@ -1,18 +1,25 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.setAppleAuthEntitlements = exports.withAppleAuthIOS = void 0;
+exports.withAppleAuthIOS = exports.withIOSMixedLocales = void 0;
 const config_plugins_1 = require("@expo/config-plugins");
-exports.withAppleAuthIOS = config => {
-    return config_plugins_1.withEntitlementsPlist(config, config => {
-        config.modResults = setAppleAuthEntitlements(config, config.modResults);
+/**
+ * Enable including `strings` files from external packages.
+ * Required for making the Apple Auth button support localizations.
+ *
+ * @param config
+ * @returns
+ */
+exports.withIOSMixedLocales = config => {
+    return config_plugins_1.withInfoPlist(config, config => {
+        var _a;
+        config.modResults.CFBundleAllowMixedLocalizations = (_a = config.modResults.CFBundleAllowMixedLocalizations) !== null && _a !== void 0 ? _a : true;
         return config;
     });
 };
-function setAppleAuthEntitlements(config, entitlements) {
-    var _a;
-    if ((_a = config.ios) === null || _a === void 0 ? void 0 : _a.usesAppleSignIn) {
-        entitlements['com.apple.developer.applesignin'] = ['Default'];
-    }
-    return entitlements;
-}
-exports.setAppleAuthEntitlements = setAppleAuthEntitlements;
+exports.withAppleAuthIOS = config => {
+    config = exports.withIOSMixedLocales(config);
+    return config_plugins_1.withEntitlementsPlist(config, config => {
+        config.modResults['com.apple.developer.applesignin'] = ['Default'];
+        return config;
+    });
+};

--- a/packages/expo-apple-authentication/plugin/jest.config.js
+++ b/packages/expo-apple-authentication/plugin/jest.config.js
@@ -1,1 +1,0 @@
-module.exports = require('expo-module-scripts/jest-preset-plugin');

--- a/packages/expo-apple-authentication/plugin/src/__tests__/withAppleAuthIOS-test.ts
+++ b/packages/expo-apple-authentication/plugin/src/__tests__/withAppleAuthIOS-test.ts
@@ -1,9 +1,0 @@
-import { setAppleAuthEntitlements } from '../withAppleAuthIOS';
-
-describe(setAppleAuthEntitlements, () => {
-  it(`sets the apple auth entitlements`, () => {
-    expect(setAppleAuthEntitlements({ ios: { usesAppleSignIn: true } }, {})).toMatchObject({
-      'com.apple.developer.applesignin': ['Default'],
-    });
-  });
-});

--- a/packages/expo-apple-authentication/plugin/src/withAppleAuthIOS.ts
+++ b/packages/expo-apple-authentication/plugin/src/withAppleAuthIOS.ts
@@ -1,20 +1,25 @@
-import { ConfigPlugin, withEntitlementsPlist } from '@expo/config-plugins';
-import { ExpoConfig } from '@expo/config-types';
+import { ConfigPlugin, withEntitlementsPlist, withInfoPlist } from '@expo/config-plugins';
 
-export const withAppleAuthIOS: ConfigPlugin = config => {
-  return withEntitlementsPlist(config, config => {
-    config.modResults = setAppleAuthEntitlements(config, config.modResults);
+/**
+ * Enable including `strings` files from external packages.
+ * Required for making the Apple Auth button support localizations.
+ *
+ * @param config
+ * @returns
+ */
+export const withIOSMixedLocales: ConfigPlugin = config => {
+  return withInfoPlist(config, config => {
+    config.modResults.CFBundleAllowMixedLocalizations =
+      config.modResults.CFBundleAllowMixedLocalizations ?? true;
 
     return config;
   });
 };
 
-export function setAppleAuthEntitlements(
-  config: Pick<ExpoConfig, 'ios'>,
-  entitlements: Record<string, any>
-): Record<string, any> {
-  if (config.ios?.usesAppleSignIn) {
-    entitlements['com.apple.developer.applesignin'] = ['Default'];
-  }
-  return entitlements;
-}
+export const withAppleAuthIOS: ConfigPlugin = config => {
+  config = withIOSMixedLocales(config);
+  return withEntitlementsPlist(config, config => {
+    config.modResults['com.apple.developer.applesignin'] = ['Default'];
+    return config;
+  });
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2126,6 +2126,26 @@
     xcode "^3.0.1"
     xml2js "^0.4.23"
 
+"@expo/config-plugins@^1.0.30":
+  version "1.0.30"
+  resolved "https://registry.yarnpkg.com/@expo/config-plugins/-/config-plugins-1.0.30.tgz#5e7e7e06a6e2db1c83b809e3fea78f2d35ef8801"
+  integrity sha512-DS26sQj4uhN6AvtxyzHG9KzNr/J7NN8lHr1GBi417OSb6bJbf0E21jAvv033Abz0NpEDTVKOYpd3o7cxU1dMmw==
+  dependencies:
+    "@expo/config-types" "^40.0.0-beta.2"
+    "@expo/configure-splash-screen" "0.3.4"
+    "@expo/image-utils" "0.3.13"
+    "@expo/json-file" "8.2.29"
+    "@expo/plist" "0.0.12"
+    find-up "~5.0.0"
+    fs-extra "9.0.0"
+    getenv "^1.0.0"
+    glob "7.1.6"
+    resolve-from "^5.0.0"
+    slash "^3.0.0"
+    slugify "^1.3.4"
+    xcode "^3.0.1"
+    xml2js "^0.4.23"
+
 "@expo/config-types@^39.0.0":
   version "39.0.1"
   resolved "https://registry.yarnpkg.com/@expo/config-types/-/config-types-39.0.1.tgz#5ed09545a1418b46a237f215b9bdbca2ed051851"


### PR DESCRIPTION
# Why

- Use the existence of the package as a way to enable the apple auth feature.
- Auto enable `CFBundleAllowMixedLocalizations` if it's not already defined.

# Test Plan

- Removed tests as they're no longer used.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).