### PR TITLE
[ci] Use the same caching keys in android-instrumentation-tests

### DIFF
--- a/.github/workflows/android-instrumentation-tests.yml
+++ b/.github/workflows/android-instrumentation-tests.yml
@@ -24,30 +24,42 @@ concurrency:
 
 jobs:
   test:
-    runs-on: macos-latest
+    runs-on: macos-10.15
     steps:
-      - name: Check out repository
+      - name: 👀 Check out repository
         uses: actions/checkout@v2
         with:
           submodules: true
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v2
+      - name: ♻️ Restore workspace node modules
+        uses: actions/cache@v2
+        id: node-modules-cache
         with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-      - run: yarn install --frozen-lockfile
-      - uses: actions/cache@v2
+          path: |
+            # See "workspaces" → "packages" in the root package.json for the source of truth of
+            # which node_modules are affected by the root yarn.lock
+            node_modules
+            apps/*/node_modules
+            home/node_modules
+            packages/*/node_modules
+            packages/@unimodules/*/node_modules
+            react-native-lab/react-native/node_modules
+          key: ${{ runner.os }}-modules-${{ hashFiles('yarn.lock') }}
+      - name: 🧶 Install node modules in root dir
+        run: yarn install --frozen-lockfile
+      - name: ♻️ Restore node modules in tools
+        uses: actions/cache@v2
+        with:
+          path: tools/node_modules
+          key: ${{ runner.os }}-tools-modules-${{ hashFiles('tools/yarn.lock') }}
+      - name: ♻️ Restore Gradle caches
+        uses: actions/cache@v2
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('android/*.gradle*') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
-      - name: Run instrumented unit tests
+      - name: 🎸 Run instrumented unit tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 29
-          script: ./bin/expotools android-native-unit-tests --type instrumented
+          script: bin/expotools android-native-unit-tests --type instrumented


### PR DESCRIPTION
# Why

`android-instrumentation-tests` workflow is using the old way of caching node_modules. It also uses `macos-latest` runner, which seems kinda unsafe if the `latest` tag changes. I'd prefer being stick with the versions, so we don't hit unexpected behavior.

# How

Updated `android-instrumentation-tests.yml`

# Test Plan

CI does it for me