### PR TITLE
[docs] add typescript formatting to spec

### DIFF
--- a/docs/pages/technical-specs/expo-updates-0.md
+++ b/docs/pages/technical-specs/expo-updates-0.md
@@ -90,7 +90,7 @@ cache-control: max-age=0, private
 ### Manifest Response Body
 
 The body of the response MUST be a manifest, which is defined as JSON conforming to both the following `Manifest` definition expressed in [TypeScript](https://www.typescriptlang.org/) and the detailed descriptions for each field:
-```
+```typescript
 export type Manifest = {
   id: string;
   createdAt: string;


### PR DESCRIPTION
# Why

turn: 


<img width="1160" alt="Screen Shot 2021-05-14 at 5 51 45 AM" src="https://user-images.githubusercontent.com/1220444/118273162-79f35f00-b478-11eb-87a8-5a0a32a164ae.png">

into:

<img width="1137" alt="Screen Shot 2021-05-14 at 5 52 02 AM" src="https://user-images.githubusercontent.com/1220444/118273186-84155d80-b478-11eb-9da0-3bbe7f716c5a.png">

Couldn't find BNF/ABNF in our current markdown renderer for the other code blocks 😞 :
https://github.com/FormidableLabs/prism-react-renderer/blob/master/src/vendor/prism/includeLangs.js

