### PR TITLE
[test-suite] Fix Recording.createAsync test

### DIFF
--- a/apps/test-suite/tests/Recording.js
+++ b/apps/test-suite/tests/Recording.js
@@ -459,9 +459,10 @@ export async function test(t) {
       });
 
       t.it('creates and starts recording', async () => {
-        recordingObject = await Audio.Recording.createAsync(
+        const { recording } = await Audio.Recording.createAsync(
           Audio.RECORDING_OPTIONS_PRESET_LOW_QUALITY
         );
+        recordingObject = recording;
         await retryForStatus(recordingObject, { isRecording: true });
       });
     });


### PR DESCRIPTION
# Why

`Recording.createAsync` returns `Promise<{ recording: Recording; status: RecordingStatus }>` and test doesn't unwrap it to get the recording object

https://github.com/expo/expo/blob/b6e49a07d173d75232675a96fa5e87df98753973/packages/expo-av/src/Audio/Recording.ts#L249-L253

# How

- Destructure the createAsync response

# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->

## Before

![before](https://user-images.githubusercontent.com/9887246/118358992-2c125000-b579-11eb-9015-286455ab8087.jpg)

## After

![after](https://user-images.githubusercontent.com/9887246/118358994-2f0d4080-b579-11eb-86f6-51d072936917.jpg)
