### PR TITLE
[AV][iOS] Allow video audio to continue to play in the background

### DIFF
--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Remove lodash and nullthrows. ([#12522](https://github.com/expo/expo/pull/12522) by [@EvanBacon](https://github.com/EvanBacon))
 - Add new `Recording.createAsync` API for faster recording on iOS. ([#12294](https://github.com/expo/expo/pull/12294) by [@IjzerenHein](https://github.com/IjzerenHein))
 - Add `keepAudioActiveHint` recording option to prevent deactivation of the Audio session when recording on iOS. ([#12294](https://github.com/expo/expo/pull/12294) by [@IjzerenHein](https://github.com/IjzerenHein))
+- Allow video audio to continue to play in the background on iOS. ([#12950](https://github.com/expo/expo/pull/12950) by [@matt-oakes](https://github.com/matt-oakes))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-av/ios/EXAV/EXAV.m
+++ b/packages/expo-av/ios/EXAV/EXAV.m
@@ -141,9 +141,13 @@ UM_EXPORT_MODULE(ExponentAV);
     [self _deactivateAudioSession]; // This will pause all players and stop all recordings
     
     [self _runBlockForAllAVObjects:^(NSObject<EXAVObject> *exAVObject) {
-      [exAVObject appDidBackground];
+      [exAVObject appDidBackgroundStayActive:NO];
     }];
     [_kernelAudioSessionManagerDelegate moduleDidBackground:self];
+  } else {
+    [self _runBlockForAllAVObjects:^(NSObject<EXAVObject> *exAVObject) {
+      [exAVObject appDidBackgroundStayActive:YES];
+    }];
   }
 }
 

--- a/packages/expo-av/ios/EXAV/EXAVObject.h
+++ b/packages/expo-av/ios/EXAV/EXAVObject.h
@@ -18,7 +18,7 @@ typedef NS_OPTIONS(NSUInteger, EXAVAudioSessionMode)
 
 - (void)appDidForeground;
 
-- (void)appDidBackground;
+- (void)appDidBackgroundStayActive:(BOOL)stayActive;
 
 - (void)handleAudioSessionInterruption:(NSNotification*)notification;
 

--- a/packages/expo-av/ios/EXAV/EXAVPlayerData.m
+++ b/packages/expo-av/ios/EXAV/EXAVPlayerData.m
@@ -826,7 +826,7 @@ NSString *const EXAVPlayerDataObserverPlaybackBufferEmptyKeyPath = @"playbackBuf
   [self _tryPlayPlayerWithRateAndMuteIfNecessary];
 }
 
-- (void)appDidBackground
+- (void)appDidBackgroundStayActive:(BOOL)stayActive
 {
   // EXAudio already forced pause.
 }

--- a/packages/expo-av/ios/EXAV/Video/EXVideoView.m
+++ b/packages/expo-av/ios/EXAV/Video/EXVideoView.m
@@ -686,13 +686,21 @@ willEndFullScreenPresentationWithAnimationCoordinator:(id<UIViewControllerTransi
 {
   if (_data) {
     [_data appDidForeground];
+
+    _playerViewController.player = _data.player;
+    _playerLayer.player = _data.player;
   }
 }
 
-- (void)appDidBackground
+- (void)appDidBackgroundStayActive:(BOOL)stayActive
 {
   if (_data) {
-    [_data appDidBackground];
+    [_data appDidBackgroundStayActive:stayActive];
+      
+    if (stayActive) {
+      _playerViewController.player = nil;
+      _playerLayer.player = nil;
+    }
   }
 }
 


### PR DESCRIPTION
# Why

Currently, the `expo-av` packaged appears to allow for background video audio, but it is currently not supported. This PR adds the required code to allow for background audio.

Fixes #12932.

# How

The player view controller or player layer needs to have the player set to `nil` when the app enters the background and set back to the correct player instance when it re-enters the foreground. this is documented by Apple here:

https://developer.apple.com/documentation/avfoundation/media_playback_and_selection/creating_a_basic_video_player_ios_and_tvos/playing_audio_from_a_video_asset_in_the_background

To accomplish this, I have modified the `appDidBackground` protocol to pass through information about if the video should stay active. Previously, this was only called if we needed to detach, so I have also added a call for both cases.

# Test Plan

This has been tested manually on on my physical iPhone XS.

# Checklist

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [X] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [X] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).