### PR TITLE
[dev-launcher] Fix the application hanging on the splash screen on iOS.

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed the application hanging on the splash screen on iOS.
+
 ### 💡 Others
 
 ## 0.3.3 — 2021-05-13

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed the application hanging on the splash screen on iOS.
+- Fixed the application hanging on the splash screen on iOS. ([#12952](https://github.com/expo/expo/pull/12952) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 


### PR DESCRIPTION
# Why

Closes ENG-1133. 

# How

It seems that `[[NSProcessInfo processInfo] hostName]` sometimes takes a lot of time. Unfortunately, there's no official API that shows up the local network permissions dialog. Other known solutions require an `NSLOCAlNetworkUsageDescription` in `Info.plist`  which isn't ideal. 
For now, we decided to remove our hacky way to display the local network permission dialog.

# Test Plan

- bare-expo ✅