### PR TITLE
[docs] Show 'Technical Specs' before 'Deprecated'

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -409,6 +409,7 @@ const ROOT = [
   'Configuration Files',
   'Expo SDK',
   'React Native',
+  'Technical Specs',
   'ExpoKit',
 ];
 


### PR DESCRIPTION
# Why

 Show 'Technical Specs' before 'Deprecated'

# How

The sorting is a bit opaque in this area of the code, but essentially we need the 'Technical Specs' ahead of any section that has been deprecated, namely ahead of 'ExpoKit'.

# Test Plan

Observer it works locally.

<img width="616" alt="Screen Shot 2021-05-18 at 8 13 21 AM" src="https://user-images.githubusercontent.com/1220444/118677220-f061cb00-b7b0-11eb-889e-03a7c5948256.png">


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).