### PR TITLE
Added `enableIosContactNotes`

### DIFF
--- a/packages/expo-contacts/CHANGELOG.md
+++ b/packages/expo-contacts/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- [plugin] Added `enableIosContactNotes` property to add support for the contact notes entitlement. ([#12965](https://github.com/expo/expo/pull/12965) by [@EvanBacon](https://github.com/EvanBacon))
+
 ### 🐛 Bug fixes
 
 - Enable kotlin in all modules. ([#12716](https://github.com/expo/expo/pull/12716) by [@wschurman](https://github.com/wschurman))

--- a/packages/expo-contacts/plugin/build/withContacts.d.ts
+++ b/packages/expo-contacts/plugin/build/withContacts.d.ts
@@ -1,5 +1,17 @@
 import { ConfigPlugin } from '@expo/config-plugins';
 declare const _default: ConfigPlugin<void | {
+    /**
+     * The `NSContactsUsageDescription` contact permission message.
+     *
+     * @default 'Allow $(PRODUCT_NAME) to access your contacts'
+     */
     contactsPermission?: string | undefined;
+    /**
+     * If true, the `com.apple.developer.contacts.notes` entitlement will be added to your iOS project.
+     * This entitlement is _heavily_ restricted and requires prior permission from Apple via [this form](https://developer.apple.com/contact/request/contact-note-field).
+     *
+     * @default false
+     */
+    enableIosContactNotes?: boolean | undefined;
 }>;
 export default _default;

--- a/packages/expo-contacts/plugin/build/withContacts.js
+++ b/packages/expo-contacts/plugin/build/withContacts.js
@@ -4,6 +4,10 @@ const config_plugins_1 = require("@expo/config-plugins");
 const pkg = require('expo-contacts/package.json');
 const CONTACTS_USAGE = 'Allow $(PRODUCT_NAME) to access your contacts';
 const withContacts = (config, { contactsPermission, enableIosContactNotes } = {}) => {
+    var _a;
+    if (((_a = config.ios) === null || _a === void 0 ? void 0 : _a.accessesContactNotes) != null) {
+        config_plugins_1.WarningAggregator.addWarningIOS('expo-contacts', '`ios.accessesContactNotes` is deprecated in favor of the expo-contacts config plugin property `enableIosContactNotes`');
+    }
     // Append iOS contacts permission
     config = config_plugins_1.withInfoPlist(config, config => {
         // @ts-ignore: untyped

--- a/packages/expo-contacts/plugin/build/withContacts.js
+++ b/packages/expo-contacts/plugin/build/withContacts.js
@@ -3,16 +3,30 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const config_plugins_1 = require("@expo/config-plugins");
 const pkg = require('expo-contacts/package.json');
 const CONTACTS_USAGE = 'Allow $(PRODUCT_NAME) to access your contacts';
-const withContacts = (config, { contactsPermission } = {}) => {
-    if (!config.ios)
-        config.ios = {};
-    if (!config.ios.infoPlist)
-        config.ios.infoPlist = {};
-    config.ios.infoPlist.NSContactsUsageDescription =
-        contactsPermission || config.ios.infoPlist.NSContactsUsageDescription || CONTACTS_USAGE;
-    return config_plugins_1.AndroidConfig.Permissions.withPermissions(config, [
+const withContacts = (config, { contactsPermission, enableIosContactNotes } = {}) => {
+    // Append iOS contacts permission
+    config = config_plugins_1.withInfoPlist(config, config => {
+        // @ts-ignore: untyped
+        config.modResults.NSContactsUsageDescription =
+            // @ts-ignore: untyped
+            contactsPermission || config.modResults.NSContactsUsageDescription || CONTACTS_USAGE;
+        return config;
+    });
+    // Add contact notes entitlement
+    config = config_plugins_1.withEntitlementsPlist(config, config => {
+        if (enableIosContactNotes) {
+            config.modResults['com.apple.developer.contacts.notes'] = true;
+        }
+        else if (enableIosContactNotes === false) {
+            delete config.modResults['com.apple.developer.contacts.notes'];
+        }
+        return config;
+    });
+    // Add Android contacts permissions
+    config = config_plugins_1.AndroidConfig.Permissions.withPermissions(config, [
         'android.permission.READ_CONTACTS',
         'android.permission.WRITE_CONTACTS',
     ]);
+    return config;
 };
 exports.default = config_plugins_1.createRunOncePlugin(withContacts, pkg.name, pkg.version);

--- a/packages/expo-contacts/plugin/src/withContacts.ts
+++ b/packages/expo-contacts/plugin/src/withContacts.ts
@@ -4,6 +4,7 @@ import {
   createRunOncePlugin,
   withEntitlementsPlist,
   withInfoPlist,
+  WarningAggregator,
 } from '@expo/config-plugins';
 
 const pkg = require('expo-contacts/package.json');
@@ -25,6 +26,13 @@ const withContacts: ConfigPlugin<{
    */
   enableIosContactNotes?: boolean;
 } | void> = (config, { contactsPermission, enableIosContactNotes } = {}) => {
+  if (config.ios?.accessesContactNotes != null) {
+    WarningAggregator.addWarningIOS(
+      'expo-contacts',
+      '`ios.accessesContactNotes` is deprecated in favor of the expo-contacts config plugin property `enableIosContactNotes`'
+    );
+  }
+
   // Append iOS contacts permission
   config = withInfoPlist(config, config => {
     // @ts-ignore: untyped

--- a/packages/expo-contacts/plugin/src/withContacts.ts
+++ b/packages/expo-contacts/plugin/src/withContacts.ts
@@ -1,22 +1,56 @@
-import { AndroidConfig, ConfigPlugin, createRunOncePlugin } from '@expo/config-plugins';
+import {
+  AndroidConfig,
+  ConfigPlugin,
+  createRunOncePlugin,
+  withEntitlementsPlist,
+  withInfoPlist,
+} from '@expo/config-plugins';
 
 const pkg = require('expo-contacts/package.json');
 
 const CONTACTS_USAGE = 'Allow $(PRODUCT_NAME) to access your contacts';
 
-const withContacts: ConfigPlugin<{ contactsPermission?: string } | void> = (
-  config,
-  { contactsPermission } = {}
-) => {
-  if (!config.ios) config.ios = {};
-  if (!config.ios.infoPlist) config.ios.infoPlist = {};
-  config.ios.infoPlist.NSContactsUsageDescription =
-    contactsPermission || config.ios.infoPlist.NSContactsUsageDescription || CONTACTS_USAGE;
+const withContacts: ConfigPlugin<{
+  /**
+   * The `NSContactsUsageDescription` contact permission message.
+   *
+   * @default 'Allow $(PRODUCT_NAME) to access your contacts'
+   */
+  contactsPermission?: string;
+  /**
+   * If true, the `com.apple.developer.contacts.notes` entitlement will be added to your iOS project.
+   * This entitlement is _heavily_ restricted and requires prior permission from Apple via [this form](https://developer.apple.com/contact/request/contact-note-field).
+   *
+   * @default false
+   */
+  enableIosContactNotes?: boolean;
+} | void> = (config, { contactsPermission, enableIosContactNotes } = {}) => {
+  // Append iOS contacts permission
+  config = withInfoPlist(config, config => {
+    // @ts-ignore: untyped
+    config.modResults.NSContactsUsageDescription =
+      // @ts-ignore: untyped
+      contactsPermission || config.modResults.NSContactsUsageDescription || CONTACTS_USAGE;
+    return config;
+  });
 
-  return AndroidConfig.Permissions.withPermissions(config, [
+  // Add contact notes entitlement
+  config = withEntitlementsPlist(config, config => {
+    if (enableIosContactNotes) {
+      config.modResults['com.apple.developer.contacts.notes'] = true;
+    } else if (enableIosContactNotes === false) {
+      delete config.modResults['com.apple.developer.contacts.notes'];
+    }
+    return config;
+  });
+
+  // Add Android contacts permissions
+  config = AndroidConfig.Permissions.withPermissions(config, [
     'android.permission.READ_CONTACTS',
     'android.permission.WRITE_CONTACTS',
   ]);
+
+  return config;
 };
 
 export default createRunOncePlugin(withContacts, pkg.name, pkg.version);


### PR DESCRIPTION
# Why

- Added support for `enableIosContactNotes` property in config plugin to replace `ios.accessesContactNotes` in the Expo config schema. Pending https://github.com/expo/expo-cli/pull/3500

