### PR TITLE
[expo-dev-launcher] add script to remove ip.txt from xcode build

### DIFF
--- a/packages/expo-dev-launcher/package.json
+++ b/packages/expo-dev-launcher/package.json
@@ -28,7 +28,8 @@
   "license": "MIT",
   "homepage": "https://docs.expo.io",
   "dependencies": {
-    "@expo/config-plugins": "^1.0.28"
+    "@expo/config-plugins": "^1.0.28",
+    "resolve-from": "^5.0.0"
   },
   "devDependencies": {
     "babel-preset-expo": "~8.3.0",

--- a/packages/expo-dev-launcher/plugin/build/withDevLauncher.js
+++ b/packages/expo-dev-launcher/plugin/build/withDevLauncher.js
@@ -7,6 +7,7 @@ const config_plugins_1 = require("@expo/config-plugins");
 const fs_1 = __importDefault(require("fs"));
 const path_1 = __importDefault(require("path"));
 const withDevLauncherAppDelegate_1 = require("./withDevLauncherAppDelegate");
+const withDevLauncherXcodeProject_1 = require("./withDevLauncherXcodeProject");
 const pkg = require('expo-dev-launcher/package.json');
 const DEV_LAUNCHER_ANDROID_IMPORT = 'expo.modules.devlauncher.DevLauncherController';
 const DEV_LAUNCHER_ON_NEW_INTENT = `
@@ -131,6 +132,7 @@ const withDevLauncher = (config) => {
     config = withDevLauncherApplication(config);
     config = withDevLauncherPodfile(config);
     config = withDevLauncherAppDelegate_1.withDevLauncherAppDelegate(config);
+    config = withDevLauncherXcodeProject_1.withDevLauncherXcodeProject(config);
     return config;
 };
 exports.default = config_plugins_1.createRunOncePlugin(withDevLauncher, pkg.name, pkg.version);

--- a/packages/expo-dev-launcher/plugin/build/withDevLauncherXcodeProject.d.ts
+++ b/packages/expo-dev-launcher/plugin/build/withDevLauncherXcodeProject.d.ts
@@ -1,0 +1,5 @@
+import { ConfigPlugin } from '@expo/config-plugins';
+declare type XcodeProject = any;
+export declare function modifyReactNativeBuildPhase(projectRoot: string, project: XcodeProject): XcodeProject;
+export declare const withDevLauncherXcodeProject: ConfigPlugin;
+export {};

--- a/packages/expo-dev-launcher/plugin/build/withDevLauncherXcodeProject.js
+++ b/packages/expo-dev-launcher/plugin/build/withDevLauncherXcodeProject.js
@@ -1,0 +1,52 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.withDevLauncherXcodeProject = exports.modifyReactNativeBuildPhase = void 0;
+const config_plugins_1 = require("@expo/config-plugins");
+const path_1 = __importDefault(require("path"));
+const resolve_from_1 = __importDefault(require("resolve-from"));
+const DEV_LAUNCHER_SCRIPT_PATH = 'expo-dev-launcher/scripts/ios.sh';
+function getBundleReactNativePhase(project) {
+    const shellScriptBuildPhase = project.hash.project.objects.PBXShellScriptBuildPhase;
+    const bundleReactNative = Object.values(shellScriptBuildPhase).find(buildPhase => buildPhase.name === '"Bundle React Native code and images"');
+    if (!bundleReactNative) {
+        throw new Error(`Couldn't find a build phase "Bundle React Native code and images"`);
+    }
+    return bundleReactNative;
+}
+function formatConfigurationScriptPath(projectRoot) {
+    const buildScriptPath = resolve_from_1.default.silent(projectRoot, DEV_LAUNCHER_SCRIPT_PATH);
+    if (!buildScriptPath) {
+        throw new Error("Could not find the build script for iOS. This can happen in the case of outdated 'node_modules'. Run 'npm install' to make sure that it's up-to-date.");
+    }
+    return path_1.default.relative(path_1.default.join(projectRoot, 'ios'), buildScriptPath);
+}
+function isShellScriptBuildPhaseConfigured(projectRoot, project) {
+    const bundleReactNative = getBundleReactNativePhase(project);
+    const buildPhaseShellScriptPath = formatConfigurationScriptPath(projectRoot);
+    return bundleReactNative.shellScript.includes(buildPhaseShellScriptPath);
+}
+function modifyReactNativeBuildPhase(projectRoot, project) {
+    const bundleReactNative = getBundleReactNativePhase(project);
+    const buildPhaseShellScriptPath = formatConfigurationScriptPath(projectRoot);
+    if (!isShellScriptBuildPhaseConfigured(projectRoot, project)) {
+        // check if there's already another path to create-manifest-ios.sh
+        // this might be the case for monorepos
+        if (bundleReactNative.shellScript.includes(DEV_LAUNCHER_SCRIPT_PATH)) {
+            bundleReactNative.shellScript = bundleReactNative.shellScript.replace(new RegExp(`(\\\\n)(\\.\\.)+/node_modules/${DEV_LAUNCHER_SCRIPT_PATH}`), '');
+        }
+        bundleReactNative.shellScript = `${bundleReactNative.shellScript.replace(/"$/, '')}${buildPhaseShellScriptPath}\\n"`;
+    }
+    return project;
+}
+exports.modifyReactNativeBuildPhase = modifyReactNativeBuildPhase;
+exports.withDevLauncherXcodeProject = config => {
+    return config_plugins_1.withXcodeProject(config, async (config) => {
+        const projectRoot = config.modRequest.projectRoot;
+        const xcodeProject = config.modResults;
+        modifyReactNativeBuildPhase(projectRoot, xcodeProject);
+        return config;
+    });
+};

--- a/packages/expo-dev-launcher/plugin/src/withDevLauncher.ts
+++ b/packages/expo-dev-launcher/plugin/src/withDevLauncher.ts
@@ -11,6 +11,7 @@ import fs from 'fs';
 import path from 'path';
 
 import { withDevLauncherAppDelegate } from './withDevLauncherAppDelegate';
+import { withDevLauncherXcodeProject } from './withDevLauncherXcodeProject';
 
 const pkg = require('expo-dev-launcher/package.json');
 
@@ -183,6 +184,7 @@ const withDevLauncher = (config: ExpoConfig) => {
   config = withDevLauncherApplication(config);
   config = withDevLauncherPodfile(config);
   config = withDevLauncherAppDelegate(config);
+  config = withDevLauncherXcodeProject(config);
   return config;
 };
 

--- a/packages/expo-dev-launcher/plugin/src/withDevLauncherXcodeProject.ts
+++ b/packages/expo-dev-launcher/plugin/src/withDevLauncherXcodeProject.ts
@@ -1,0 +1,81 @@
+import { ConfigPlugin, withXcodeProject } from '@expo/config-plugins';
+import path from 'path';
+import resolveFrom from 'resolve-from';
+
+const DEV_LAUNCHER_SCRIPT_PATH = 'expo-dev-launcher/scripts/ios.sh';
+
+type XcodeProject = any;
+
+interface ShellScriptBuildPhase {
+  isa: 'PBXShellScriptBuildPhase';
+  name: string;
+  shellScript: string;
+  [key: string]: any;
+}
+
+function getBundleReactNativePhase(project: XcodeProject): ShellScriptBuildPhase {
+  const shellScriptBuildPhase = project.hash.project.objects.PBXShellScriptBuildPhase as Record<
+    string,
+    ShellScriptBuildPhase
+  >;
+  const bundleReactNative = Object.values(shellScriptBuildPhase).find(
+    buildPhase => buildPhase.name === '"Bundle React Native code and images"'
+  );
+
+  if (!bundleReactNative) {
+    throw new Error(`Couldn't find a build phase "Bundle React Native code and images"`);
+  }
+
+  return bundleReactNative;
+}
+
+function formatConfigurationScriptPath(projectRoot: string): string {
+  const buildScriptPath = resolveFrom.silent(projectRoot, DEV_LAUNCHER_SCRIPT_PATH);
+
+  if (!buildScriptPath) {
+    throw new Error(
+      "Could not find the build script for iOS. This can happen in the case of outdated 'node_modules'. Run 'npm install' to make sure that it's up-to-date."
+    );
+  }
+
+  return path.relative(path.join(projectRoot, 'ios'), buildScriptPath);
+}
+
+function isShellScriptBuildPhaseConfigured(projectRoot: string, project: XcodeProject): boolean {
+  const bundleReactNative = getBundleReactNativePhase(project);
+  const buildPhaseShellScriptPath = formatConfigurationScriptPath(projectRoot);
+  return bundleReactNative.shellScript.includes(buildPhaseShellScriptPath);
+}
+
+export function modifyReactNativeBuildPhase(
+  projectRoot: string,
+  project: XcodeProject
+): XcodeProject {
+  const bundleReactNative = getBundleReactNativePhase(project);
+  const buildPhaseShellScriptPath = formatConfigurationScriptPath(projectRoot);
+
+  if (!isShellScriptBuildPhaseConfigured(projectRoot, project)) {
+    // check if there's already another path to create-manifest-ios.sh
+    // this might be the case for monorepos
+    if (bundleReactNative.shellScript.includes(DEV_LAUNCHER_SCRIPT_PATH)) {
+      bundleReactNative.shellScript = bundleReactNative.shellScript.replace(
+        new RegExp(`(\\\\n)(\\.\\.)+/node_modules/${DEV_LAUNCHER_SCRIPT_PATH}`),
+        ''
+      );
+    }
+    bundleReactNative.shellScript = `${bundleReactNative.shellScript.replace(
+      /"$/,
+      ''
+    )}${buildPhaseShellScriptPath}\\n"`;
+  }
+  return project;
+}
+
+export const withDevLauncherXcodeProject: ConfigPlugin = config => {
+  return withXcodeProject(config, async config => {
+    const projectRoot = config.modRequest.projectRoot;
+    const xcodeProject = config.modResults;
+    modifyReactNativeBuildPhase(projectRoot, xcodeProject);
+    return config;
+  });
+};

--- a/packages/expo-dev-launcher/scripts/ios.sh
+++ b/packages/expo-dev-launcher/scripts/ios.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -x
+DEST=$CONFIGURATION_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH
+rm "$DEST/ip.txt"


### PR DESCRIPTION
# Why

resolves ENG-1133

@lukmccall discovered that RN's build script embeds an `ip.txt` file into the build with the local machine's IP address. RN seems to always ping this IP address first when opening an app in development mode. When the app is built on EAS build, the embedded local IP address is something like `10.254.24.132` which is not reachable by the client app, and the request takes a long time to resolve, which results in the hanging behavior.

Unfortunately there doesn't seem to be a way to configure or customize the contents of the ip.txt file, but we can modify or remove it after the fact. Looking at https://github.com/expo/react-native/blob/85f6d8f2b00f72ee18cedef2052471ae16c34e26/React/Base/RCTBundleURLProvider.m#L96-L112 it seems to handle the case where ip.txt doesn't exist, so removing the file entirely seems like a better solution than replacing it with a dummy value (since we don't need the file).

# How

I added a `scripts/ios.sh` shell script that removes the ip.txt file, and which can be added to the "Bundle React Native code and images" build phase in Xcode, just like similar scripts in expo-constants and expo-updates. **It must run after the `react-native-xcode.sh` script.** I also updated the config plugin to make this change automatically.

# Test Plan

By patching the ip.txt file using a similar build script, I was able to reproduce the EAS build issue locally, and can confirm that removing the file seems to fix the issue.

Tested the config plugin and shell script locally with `expo eject` to ensure they work as expected. (Tried to add jest tests but got stuck; can continue tomorrow if we think this is the right route.)

# Todo

- [ ] setup docs

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).