### PR TITLE
[home] Clean up some typedefs and legacy components

### DIFF
--- a/home/components/AccountView.tsx
+++ b/home/components/AccountView.tsx
@@ -1,14 +1,14 @@
 import { StackScreenProps } from '@react-navigation/stack';
-import { Project } from 'components/ProjectList';
-import { Snack } from 'components/SnackList';
-import { AccountData } from 'containers/Account';
 import dedent from 'dedent';
 import { take, takeRight } from 'lodash';
 import React from 'react';
-import { ActivityIndicator, StyleSheet, TouchableOpacity, View } from 'react-native';
+import { ActivityIndicator, StyleSheet, View } from 'react-native';
 
+import { Project } from '../components/ProjectList';
+import { Snack } from '../components/SnackList';
 import Colors from '../constants/Colors';
 import SharedStyles from '../constants/SharedStyles';
+import { AccountData } from '../containers/Account';
 import { AllStackRoutes } from '../navigation/Navigation.types';
 import EmptyAccountProjectsNotice from './EmptyAccountProjectsNotice';
 import EmptyAccountSnacksNotice from './EmptyAccountSnacksNotice';
@@ -149,7 +149,7 @@ function AccountErrorView({
         {isConnectionError ? NETWORK_ERROR_TEXT : SERVER_ERROR_TEXT}
       </StyledText>
 
-      <PrimaryButton plain onPress={onRefresh} fallback={TouchableOpacity}>
+      <PrimaryButton plain onPress={onRefresh}>
         Try again
       </PrimaryButton>
 

--- a/home/components/AdditionalTwoFactorOptionsButton.tsx
+++ b/home/components/AdditionalTwoFactorOptionsButton.tsx
@@ -1,6 +1,6 @@
 import { connectActionSheet } from '@expo/react-native-action-sheet';
 import React from 'react';
-import { TouchableOpacity, ActionSheetIOSOptions } from 'react-native';
+import { ActionSheetIOSOptions } from 'react-native';
 
 import PrimaryButton from '../components/PrimaryButton';
 
@@ -66,7 +66,7 @@ function AdditionalTwoFactorOptionsButton({
   };
 
   return (
-    <PrimaryButton plain onPress={handlePress} fallback={TouchableOpacity}>
+    <PrimaryButton plain onPress={handlePress}>
       More one-time password options
     </PrimaryButton>
   );

--- a/home/components/EmptyAccountProjectsNotice.tsx
+++ b/home/components/EmptyAccountProjectsNotice.tsx
@@ -1,6 +1,6 @@
 import * as WebBrowser from 'expo-web-browser';
 import * as React from 'react';
-import { StyleSheet, TouchableOpacity } from 'react-native';
+import { StyleSheet } from 'react-native';
 
 import Colors from '../constants/Colors';
 import SharedStyles from '../constants/SharedStyles';
@@ -20,11 +20,7 @@ export default function EmptyAccountProjectsNotice() {
         screen.
       </StyledText>
 
-      <PrimaryButton
-        plain
-        onPress={handleLearnMorePress}
-        fallback={TouchableOpacity}
-        style={{ marginBottom: 5 }}>
+      <PrimaryButton plain onPress={handleLearnMorePress} style={{ marginBottom: 5 }}>
         Learn more about publishing
       </PrimaryButton>
     </StyledView>

--- a/home/components/EmptyAccountSnacksNotice.tsx
+++ b/home/components/EmptyAccountSnacksNotice.tsx
@@ -1,6 +1,6 @@
 import * as WebBrowser from 'expo-web-browser';
 import * as React from 'react';
-import { StyleSheet, TouchableOpacity } from 'react-native';
+import { StyleSheet } from 'react-native';
 
 import Colors from '../constants/Colors';
 import SharedStyles from '../constants/SharedStyles';
@@ -19,11 +19,7 @@ export default function EmptyAccountSnacksNotice() {
         No saved Snacks
       </StyledText>
 
-      <PrimaryButton
-        plain
-        onPress={handleLearnMorePress}
-        fallback={TouchableOpacity}
-        style={{ marginBottom: 5 }}>
+      <PrimaryButton plain onPress={handleLearnMorePress} style={{ marginBottom: 5 }}>
         Learn more about Snack
       </PrimaryButton>
     </StyledView>

--- a/home/components/ListItem.tsx
+++ b/home/components/ListItem.tsx
@@ -1,13 +1,5 @@
 import * as React from 'react';
-import {
-  View,
-  StyleSheet,
-  TouchableHighlight,
-  Platform,
-  Text,
-  ViewStyle,
-  Image,
-} from 'react-native';
+import { View, StyleSheet, Platform, Text, ViewStyle, Image } from 'react-native';
 import FadeIn from 'react-native-fade-in-image';
 
 import Colors from '../constants/Colors';
@@ -57,8 +49,6 @@ export default class ListItem extends React.PureComponent<Props> {
         <StyledButton
           onPress={onPress}
           onLongPress={onLongPress}
-          fallback={TouchableHighlight}
-          underlayColor="#b7b7b7"
           style={[styles.container, last && styles.containerLast, style]}>
           {this.renderImage()}
           <StyledView style={[styles.contentContainer, !last && styles.contentContainerNotLast]}>

--- a/home/components/OptionsButton.android.tsx
+++ b/home/components/OptionsButton.android.tsx
@@ -18,7 +18,7 @@ export default function OptionsButton() {
       handle,
       ['Report this user'],
       () => {},
-      (action, selectedIndex) => {
+      (_action, selectedIndex) => {
         if (selectedIndex === 0) {
           // TODO(Bacon): Anything...
           Alert.alert(

--- a/home/components/PrimaryButton.tsx
+++ b/home/components/PrimaryButton.tsx
@@ -1,18 +1,16 @@
-import TouchableNativeFeedback from '@expo/react-native-touchable-native-feedback-safe';
 import * as React from 'react';
 import {
   ActivityIndicator,
   Platform,
   StyleSheet,
   Text,
-  TouchableOpacity,
+  TouchableNativeFeedback,
   View,
 } from 'react-native';
 
 import Colors from '../constants/Colors';
 
-type TouchableNativeFeedbackProps = React.ComponentProps<typeof TouchableNativeFeedback>['style'];
-// eslint-disable-next-line no-unused-vars
+type TouchableNativeFeedbackProps = React.ComponentProps<typeof TouchableNativeFeedback>;
 export default function PrimaryButton({
   children,
   isLoading,
@@ -25,13 +23,8 @@ export default function PrimaryButton({
   plain?: boolean;
 }) {
   return (
-    <TouchableNativeFeedback
-      fallback={TouchableOpacity}
-      {...props}
-      activeOpacity={isLoading ? 1 : 0.5}
-      style={[plain ? styles.plainButton : styles.button, style]}>
+    <TouchableNativeFeedback {...props} style={[plain ? styles.plainButton : styles.button, style]}>
       <Text style={plain ? styles.plainButtonText : styles.buttonText}>{children}</Text>
-
       {isLoading && (
         <View style={styles.activityIndicatorContainer}>
           <ActivityIndicator color="#fff" />

--- a/home/components/ProfileUnauthenticated.tsx
+++ b/home/components/ProfileUnauthenticated.tsx
@@ -1,6 +1,6 @@
 import * as WebBrowser from 'expo-web-browser';
 import * as React from 'react';
-import { Platform, StyleSheet, TouchableOpacity, View } from 'react-native';
+import { Platform, StyleSheet, View } from 'react-native';
 import url from 'url';
 
 import Analytics from '../api/Analytics';
@@ -99,13 +99,11 @@ export default function ProfileUnauthenticated() {
         {description}
       </StyledText>
 
-      <PrimaryButton onPress={_handleSignInPress} fallback={TouchableOpacity}>
-        Sign in to your account
-      </PrimaryButton>
+      <PrimaryButton onPress={_handleSignInPress}>Sign in to your account</PrimaryButton>
 
       <View style={{ marginBottom: 20 }} />
 
-      <PrimaryButton plain onPress={_handleSignUpPress} fallback={TouchableOpacity}>
+      <PrimaryButton plain onPress={_handleSignUpPress}>
         Sign up for Expo
       </PrimaryButton>
 

--- a/home/components/ProfileView.tsx
+++ b/home/components/ProfileView.tsx
@@ -3,7 +3,7 @@ import { Project } from 'components/ProjectList';
 import dedent from 'dedent';
 import { take, takeRight } from 'lodash';
 import React from 'react';
-import { ActivityIndicator, Image, StyleSheet, TouchableOpacity, View } from 'react-native';
+import { ActivityIndicator, Image, StyleSheet, View } from 'react-native';
 import FadeIn from 'react-native-fade-in-image';
 
 import Colors from '../constants/Colors';
@@ -143,7 +143,7 @@ function ProfileErrorView({
         {isConnectionError ? NETWORK_ERROR_TEXT : SERVER_ERROR_TEXT}
       </StyledText>
 
-      <PrimaryButton plain onPress={onRefresh} fallback={TouchableOpacity}>
+      <PrimaryButton plain onPress={onRefresh}>
         Try again
       </PrimaryButton>
 

--- a/home/components/ProjectList.tsx
+++ b/home/components/ProjectList.tsx
@@ -1,7 +1,7 @@
 import { useTheme } from '@react-navigation/native';
 import dedent from 'dedent';
 import * as React from 'react';
-import { ActivityIndicator, FlatList, ScrollView, TouchableOpacity, View } from 'react-native';
+import { ActivityIndicator, FlatList, ScrollView, View } from 'react-native';
 import InfiniteScrollView from 'react-native-infinite-scroll-view';
 
 import Colors from '../constants/Colors';
@@ -94,7 +94,7 @@ export default function LoadingProjectList(props: Props) {
             {isConnectionError ? NETWORK_ERROR_TEXT : SERVER_ERROR_TEXT}
           </StyledText>
 
-          <PrimaryButton plain onPress={refetchDataAsync} fallback={TouchableOpacity}>
+          <PrimaryButton plain onPress={refetchDataAsync}>
             Try again
           </PrimaryButton>
         </View>

--- a/home/components/ProjectTools.tsx
+++ b/home/components/ProjectTools.tsx
@@ -51,7 +51,7 @@ function EnabledProjectTools({ pollForUpdates }: Props) {
     (props: State, state: Partial<State>): State => ({ ...props, ...state }),
     initialState
   );
-  const clipboardUpdateInterval = React.useRef<null | any>(null);
+  const clipboardUpdateInterval = React.useRef<null | ReturnType<typeof setInterval>>(null);
 
   const appState = useAppState();
 

--- a/home/components/ProjectView.tsx
+++ b/home/components/ProjectView.tsx
@@ -75,8 +75,7 @@ function truthy<TValue>(value: TValue | null | undefined): value is TValue {
 }
 
 function getSDKMajorVersionsForLegacyUpdates(app: ProjectDataProject): number | null {
-  const majorVersionString = app.sdkVersion ? semver.major(app.sdkVersion) : null;
-  return majorVersionString ? parseInt(majorVersionString, 10) : null;
+  return app.sdkVersion ? semver.major(app.sdkVersion) : null;
 }
 
 function getSDKMajorVersionForEASUpdateBranch(branch: ProjectUpdateBranch): number | null {
@@ -89,8 +88,7 @@ function getSDKMajorVersionForEASUpdateBranch(branch: ProjectUpdateBranch): numb
     updates
       .map(update => {
         const potentialSDKVersion = getSDKVersionFromRuntimeVersion(update.runtimeVersion);
-        const majorVersion = potentialSDKVersion ? semver.major(potentialSDKVersion) : null;
-        return majorVersion ? parseInt(majorVersion, 10) : undefined;
+        return potentialSDKVersion ? semver.major(potentialSDKVersion) : null;
       })
       .filter(truthy)
       .sort((a, b) => b - a)[0] ?? null

--- a/home/components/Views.tsx
+++ b/home/components/Views.tsx
@@ -1,8 +1,7 @@
-import TouchableNativeFeedbackSafe from '@expo/react-native-touchable-native-feedback-safe';
 import { useTheme } from '@react-navigation/native';
 import { BlurView } from 'expo-blur';
 import * as React from 'react';
-import { Platform, ScrollView, StyleSheet, View } from 'react-native';
+import { Platform, ScrollView, StyleSheet, TouchableNativeFeedback, View } from 'react-native';
 
 import Colors from '../constants/Colors';
 
@@ -159,7 +158,7 @@ function ThemedBlurView(props: React.ComponentProps<typeof View> & { children?: 
   return <BlurView intensity={100} tint={theme.dark ? 'dark' : 'light'} {...props} />;
 }
 
-type ButtonProps = Props & TouchableNativeFeedbackSafe['props'];
+type ButtonProps = Props & React.ComponentProps<typeof TouchableNativeFeedback>;
 
 // Extend this if you ever need to customize ripple color
 function useRippleColor(_props: any) {
@@ -174,6 +173,7 @@ export const StyledButton = (props: ButtonProps) => {
     darkBackgroundColor: _darkBackgroundColor,
     lightBorderColor: _lightBorderColor,
     darkBorderColor: _darkBorderColor,
+    children,
     ...otherProps
   } = props;
 
@@ -182,17 +182,20 @@ export const StyledButton = (props: ButtonProps) => {
   const rippleColor = useRippleColor(props);
 
   return (
-    <TouchableNativeFeedbackSafe
-      background={TouchableNativeFeedbackSafe.Ripple(rippleColor, false)}
-      style={[
-        {
-          backgroundColor,
-          borderColor,
-        },
-        style,
-      ]}
-      {...otherProps}
-    />
+    <TouchableNativeFeedback
+      background={TouchableNativeFeedback.Ripple(rippleColor, false)}
+      {...otherProps}>
+      <View
+        style={[
+          {
+            backgroundColor,
+            borderColor,
+          },
+          style,
+        ]}>
+        {children}
+      </View>
+    </TouchableNativeFeedback>
   );
 };
 

--- a/home/kernel/MockKernel.ts
+++ b/home/kernel/MockKernel.ts
@@ -16,7 +16,7 @@ export default {
     return null;
   },
 
-  async setDevMenuSettingAsync(key: string, value: any): Promise<void> {},
+  async setDevMenuSettingAsync(_key: string, _value: any): Promise<void> {},
 
   async doesCurrentTaskEnableDevtoolsAsync(): Promise<boolean> {
     return false;

--- a/home/navigation/BottomTabNavigator.ts
+++ b/home/navigation/BottomTabNavigator.ts
@@ -4,7 +4,7 @@ import { ComponentProps } from 'react';
 const BottomTabNavigator = createBottomTabNavigator();
 export default BottomTabNavigator;
 
-export const getNavigatorProps = (props: {
+export const getNavigatorProps = (_props: {
   theme: string;
 }): Partial<ComponentProps<typeof BottomTabNavigator.Navigator>> => ({
   tabBarOptions: { labelStyle: { fontWeight: '600' }, keyboardHidesTabBar: false },

--- a/home/navigation/Navigation.tsx
+++ b/home/navigation/Navigation.tsx
@@ -44,7 +44,7 @@ const accountNavigationOptions = ({ route }) => {
   };
 };
 
-const profileNavigationOptions = ({ route }) => {
+const profileNavigationOptions = () => {
   return {
     title: 'Profile',
     headerRight: () => <UserSettingsButton />,

--- a/home/package.json
+++ b/home/package.json
@@ -19,7 +19,6 @@
   "dependencies": {
     "@apollo/client": "^3.2.0",
     "@expo/react-native-action-sheet": "^2.1.0",
-    "@expo/react-native-touchable-native-feedback-safe": "^1.1.2",
     "@expo/sdk-runtime-versions": "^1.0.0",
     "@expo/vector-icons": "^12.0.4",
     "@react-native-async-storage/async-storage": "~1.15.0",
@@ -68,7 +67,7 @@
     "reanimated-bottom-sheet": "^1.0.0-alpha.18",
     "redux": "^4.0.5",
     "redux-thunk": "^2.3.0",
-    "semver": "^6.1.1",
+    "semver": "^7.3.5",
     "sha1": "^1.1.1",
     "url": "^0.11.0"
   },
@@ -78,7 +77,10 @@
     "@graphql-codegen/typescript": "1.22.0",
     "@graphql-codegen/typescript-operations": "1.17.16",
     "@graphql-codegen/typescript-react-apollo": "2.2.4",
+    "@types/dedent": "^0.7.0",
     "@types/jest": "^26.0.20",
+    "@types/semver": "^7.3.6",
+    "@types/sha1": "^1.1.2",
     "jest-expo": "~41.0.0",
     "react-native-bundle-visualizer": "^2.2.1",
     "uuid": "^3.3.2"

--- a/home/screens/AccountScreen.tsx
+++ b/home/screens/AccountScreen.tsx
@@ -1,8 +1,8 @@
 import { StackScreenProps } from '@react-navigation/stack';
-import { AllStackRoutes } from 'navigation/Navigation.types';
 import * as React from 'react';
 
 import Account from '../containers/Account';
+import { AllStackRoutes } from '../navigation/Navigation.types';
 
 export default function AccountScreen({
   navigation,

--- a/home/screens/ProjectsScreen.tsx
+++ b/home/screens/ProjectsScreen.tsx
@@ -83,7 +83,7 @@ export default function ProjectsScreen(props: NavigationProps) {
 }
 
 class ProjectsView extends React.Component<Props, State> {
-  private _projectPolling?: any;
+  private _projectPolling?: ReturnType<typeof setInterval>;
 
   state: State = {
     projects: [],
@@ -202,7 +202,9 @@ class ProjectsView extends React.Component<Props, State> {
   };
 
   private _stopPollingForProjects = async () => {
-    clearInterval(this._projectPolling);
+    if (this._projectPolling) {
+      clearInterval(this._projectPolling);
+    }
     this._projectPolling = undefined;
   };
 

--- a/home/screens/ProjectsScreen.tsx
+++ b/home/screens/ProjectsScreen.tsx
@@ -1,6 +1,5 @@
 import { StackScreenProps } from '@react-navigation/stack';
 import Constants from 'expo-constants';
-import { AllStackRoutes } from 'navigation/Navigation.types';
 import * as React from 'react';
 import { Alert, AppState, Clipboard, Linking, Platform, StyleSheet, View } from 'react-native';
 
@@ -17,6 +16,7 @@ import RefreshControl from '../components/RefreshControl';
 import SectionHeader from '../components/SectionHeader';
 import { StyledText } from '../components/Text';
 import ThemedStatusBar from '../components/ThemedStatusBar';
+import { AllStackRoutes } from '../navigation/Navigation.types';
 import HistoryActions from '../redux/HistoryActions';
 import { useDispatch, useSelector } from '../redux/Hooks';
 import { DevSession, HistoryList } from '../types';
@@ -104,7 +104,7 @@ class ProjectsView extends React.Component<Props, State> {
     // find a way to move this listener up to the root of the app in order to ensure
     // that it has been registered regardless of whether we have been on the project
     // screen in the home app
-    addListenerWithNativeCallback('ExponentKernel.showQRReader', async event => {
+    addListenerWithNativeCallback('ExponentKernel.showQRReader', async () => {
       // @ts-ignore
       this.props.navigation.navigate('QRCode');
       return { success: true };

--- a/home/tsconfig.json
+++ b/home/tsconfig.json
@@ -4,8 +4,8 @@
     "resolveJsonModule": true,
     "baseUrl": ".",
     "noEmit": true,
-    "paths": {
-      "@expo/vector-icons": ["react-native-vector-icons"]
-    }
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2640,11 +2640,6 @@
     "@types/hoist-non-react-statics" "^3.3.1"
     hoist-non-react-statics "^3.3.0"
 
-"@expo/react-native-touchable-native-feedback-safe@^1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@expo/react-native-touchable-native-feedback-safe/-/react-native-touchable-native-feedback-safe-1.1.2.tgz#7ef501d5d32140eed657f75f0de145d4a96244d8"
-  integrity sha1-fvUB1dMhQO7WV/dfDeFF1KliRNg=
-
 "@expo/schemer@1.3.27-alpha.0":
   version "1.3.27-alpha.0"
   resolved "https://registry.yarnpkg.com/@expo/schemer/-/schemer-1.3.27-alpha.0.tgz#04171095b7f0145becec7f97592600719d554b79"
@@ -5162,6 +5157,11 @@
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
+"@types/dedent@^0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@types/dedent/-/dedent-0.7.0.tgz#155f339ca404e6dd90b9ce46a3f78fd69ca9b050"
+  integrity sha512-EGlKlgMhnLt/cM4DbUSafFdrkeJoC9Mvnj0PUCU7tFmTjMjNRT957kXCx0wYm3JuEq4o4ZsS5vG+NlkM2DMd2A==
+
 "@types/enzyme-adapter-react-16@~1.0.6":
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/@types/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.0.6.tgz#8aca7ae2fd6c7137d869b6616e696d21bb8b0cec"
@@ -5446,6 +5446,18 @@
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.0.tgz#2b35eccfcee7d38cd72ad99232fbd58bffb3c84d"
   integrity sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==
+
+"@types/semver@^7.3.6":
+  version "7.3.6"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.6.tgz#e9831776f4512a7ba6da53e71c26e5fb67882d63"
+  integrity sha512-0caWDWmpCp0uifxFh+FaqK3CuZ2SkRR/ZRxAV5+zNdC3QVUi6wyOJnefhPvtNt8NQWXB5OA93BUvZsXpWat2Xw==
+
+"@types/sha1@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@types/sha1/-/sha1-1.1.2.tgz#e4a101952a6a1ea341431b5107894c8b0e0fcaa7"
+  integrity sha512-qL23ImGRNLvDvLXL6EmE41QTAaBfwGgSOfxmytyOwfFSF0xj7BnhhHff8lcv6DpLWt2I5q+LLQ6iIKL+zev9mw==
+  dependencies:
+    "@types/node" "*"
 
 "@types/source-list-map@*":
   version "0.1.2"
@@ -19154,7 +19166,7 @@ semver@^6.0.0, semver@^6.1.1, semver@^6.2.0, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-semver@^7.0.0:
+semver@^7.0.0, semver@^7.3.5:
   version "7.3.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
   integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==


### PR DESCRIPTION
# Why

The goal of this series of PRs is to make the home app more maintainable and PRs within it easier and faster to review.

This PR does a few interrelated things:
- Remove [`@expo/react-native-touchable-native-feedback-safe`](https://www.npmjs.com/package/@expo/react-native-touchable-native-feedback-safe) since it's only necessary for "<= API 20 (below 5.0)" and our minSdkVersion is 21.
- Add various `@types` typedef packages.
- Add a few more typescript config rules to clean code.

# Test Plan

`yarn tsc`, launch app and ensure everything looks correct (for `react-native-touchable-native-feedback-safe` change since it had slightly different style semantics)