### PR TITLE
[dev-menu][ios] Add websocket support

### DIFF
--- a/packages/expo-dev-menu/ios/DevMenuDevOptionsDelegate.swift
+++ b/packages/expo-dev-menu/ios/DevMenuDevOptionsDelegate.swift
@@ -1,0 +1,68 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import Foundation
+
+class DevMenuDevOptionsDelegate {
+  internal private(set) weak var bridge: RCTBridge?
+  internal private(set) weak var devSettings: RCTDevSettings?
+  
+  #if DEBUG
+  internal private(set) weak var perfMonitor: RCTPerfMonitor?
+  #endif
+  
+  internal init(forBridge bridge: RCTBridge) {
+    self.bridge = bridge
+    devSettings = bridge.module(forName: "DevSettings") as? RCTDevSettings
+    
+    #if DEBUG
+    perfMonitor = bridge.module(forName: "PerfMonitor") as? RCTPerfMonitor
+    #endif
+  }
+  
+  internal func reload() {
+    // Without this the `expo-splash-screen` will reject
+    // No native splash screen registered for given view controller. Call 'SplashScreen.show' for given view controller first.
+    DevMenuManager.shared.hideMenu();
+
+    bridge?.requestReload()
+  }
+  
+  internal func toggleElementInsector() {
+    devSettings?.toggleElementInspector()
+  }
+  
+  internal func toggleRemoteDebugging() {
+    guard let devSettings = devSettings else {
+      return
+    }
+    
+    DispatchQueue.main.async {
+      devSettings.isDebuggingRemotely = !devSettings.isDebuggingRemotely
+    }
+  }
+  
+  internal func togglePerformanceMonitor() {
+    #if DEBUG
+    guard let perfMonitor = perfMonitor else {
+      return
+    }
+    
+    guard let devSettings = devSettings else {
+      return
+    }
+    
+    DispatchQueue.main.async {
+      devSettings.isPerfMonitorShown ? perfMonitor.hide() : perfMonitor.show()
+      devSettings.isPerfMonitorShown = !devSettings.isPerfMonitorShown
+    }
+    #endif
+  }
+  
+  internal func toggleFastRefresh() {
+    guard let devSettings = devSettings else {
+      return
+    }
+    
+    devSettings.isHotLoadingEnabled = !devSettings.isHotLoadingEnabled
+  }
+}

--- a/packages/expo-dev-menu/ios/DevMenuManager.swift
+++ b/packages/expo-dev-menu/ios/DevMenuManager.swift
@@ -60,6 +60,7 @@ private let extensionToDevMenuDataSourcesMap = NSMapTable<DevMenuExtensionProtoc
  */
 @objc
 open class DevMenuManager: NSObject, DevMenuManagerProtocol {
+  var packagerConnectionHandler: DevMenuPackagerConnectionHandler?
   lazy var expoSessionDelegate: DevMenuExpoSessionDelegate = DevMenuExpoSessionDelegate(manager: self)
   lazy var extensionSettings: DevMenuExtensionSettingsProtocol = DevMenuExtensionDefaultSettings(manager: self)
   
@@ -126,7 +127,8 @@ open class DevMenuManager: NSObject, DevMenuManagerProtocol {
   override init() {
     super.init()
     self.window = DevMenuWindow(manager: self)
-    
+    self.packagerConnectionHandler = DevMenuPackagerConnectionHandler(manager: self)
+    self.packagerConnectionHandler?.setup()
     DevMenuSettings.setup()
     self.expoSessionDelegate.restoreSession()
   }

--- a/packages/expo-dev-menu/ios/DevMenuPackagerConnectionHandler.swift
+++ b/packages/expo-dev-menu/ios/DevMenuPackagerConnectionHandler.swift
@@ -1,0 +1,61 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import Foundation
+
+class DevMenuPackagerConnectionHandler {
+  weak var manager: DevMenuManager?
+  
+  init(manager: DevMenuManager) {
+    self.manager = manager
+  }
+  
+  func setup() {
+    RCTPackagerConnection
+      .shared()
+      .addNotificationHandler(
+        self.sendDevCommandNotificationHandler,
+        queue: DispatchQueue.main,
+        forMethod: "sendDevCommand"
+      )
+    
+    RCTPackagerConnection
+      .shared()
+      .addNotificationHandler(
+        self.devMenuNotificationHanlder,
+        queue: DispatchQueue.main,
+        forMethod: "devMenu"
+      )
+  }
+  
+  @objc
+  func sendDevCommandNotificationHandler(_ params: [String: Any]) {
+    guard let manager = manager,
+          let command = params["name"] as? String,
+          let bridge = manager.delegate?.appBridge?(forDevMenuManager: manager) as? RCTBridge
+    else {
+      return
+    }
+    
+    let devDelegate = DevMenuDevOptionsDelegate(forBridge: bridge)
+  
+    switch command {
+    case "reload":
+      devDelegate.reload()
+    case "toggleDevMenu":
+      self.manager?.toggleMenu()
+    case "toggleRemoteDebugging":
+      devDelegate.toggleRemoteDebugging()
+    case "toggleElementInspector":
+      devDelegate.toggleElementInsector()
+    case "togglePerformanceMonitor":
+      devDelegate.togglePerformanceMonitor()
+    default:
+      NSLog("Unknow command: %@", command);
+    }
+  }
+  
+  @objc
+  func devMenuNotificationHanlder(_ parames: [String: Any]) {
+    self.manager?.toggleMenu()
+  }
+}

--- a/packages/expo-dev-menu/ios/DevMenuPackagerConnectionHandler.swift
+++ b/packages/expo-dev-menu/ios/DevMenuPackagerConnectionHandler.swift
@@ -50,7 +50,7 @@ class DevMenuPackagerConnectionHandler {
     case "togglePerformanceMonitor":
       devDelegate.togglePerformanceMonitor()
     default:
-      NSLog("Unknow command: %@", command);
+      NSLog("Unknown command from packager: %@", command);
     }
   }
   

--- a/packages/expo-dev-menu/ios/Headers/EXDevMenu-Bridging-Header.h
+++ b/packages/expo-dev-menu/ios/Headers/EXDevMenu-Bridging-Header.h
@@ -16,6 +16,7 @@
 #import <React/RCTBridge+Private.h>
 #import <React/RCTLogBox.h>
 #import <React/RCTRedBox.h>
+#import <React/RCTPackagerConnection.h>
 
 #pragma clang diagnostic pop
 


### PR DESCRIPTION
# Why

Closes ENG-1144.

# How

Added web socket control support for dev-menu on iOS (very similar to the https://github.com/expo/expo/pull/12151).

# Test Plan

- bare-expo ✅