### PR TITLE
[dev-menu][ios] Fix items rearranging

### DIFF
--- a/packages/expo-dev-menu/ios/DevMenuManager.swift
+++ b/packages/expo-dev-menu/ios/DevMenuManager.swift
@@ -231,11 +231,16 @@ open class DevMenuManager: NSObject, DevMenuManagerProtocol {
       return nil
     }
     let allExtensions = bridge.modulesConforming(to: DevMenuExtensionProtocol.self) as! [DevMenuExtensionProtocol]
-    let uniqueExtensionNames: [String] = Array(Set(allExtensions.map({ type(of: $0).moduleName!() })))
 
+    let uniqueExtensionNames = Set(
+      allExtensions
+        .map { type(of: $0).moduleName!() }
+        .compactMap { $0 } // removes nils
+    ).sorted()
+    
     return uniqueExtensionNames
       .map({ bridge.module(forName: DevMenuUtils.stripRCT($0)) })
-      .filter({ $0 is DevMenuExtensionProtocol }) as! [DevMenuExtensionProtocol]
+      .filter({ $0 is DevMenuExtensionProtocol }) as? [DevMenuExtensionProtocol]
   }
 
   /**


### PR DESCRIPTION
# Why

Fixed items rearranging.

# How

Dev-menu Items now are always in the same order between the dev-menu opening. 

# Test Plan

- bare-expo ✅