### PR TITLE
[docs] add 'next steps' and 'see also' sections to notifications guide

### DIFF
--- a/docs/components/DocumentationSidebarRight.tsx
+++ b/docs/components/DocumentationSidebarRight.tsx
@@ -86,7 +86,9 @@ class DocumentationSidebarRight extends React.Component<PropsWithHM, State> {
 
     //filter out headings nested too much
     const displayedHeadings = headings.filter(
-      head => head.level <= BASE_HEADING_LEVEL + this.props.maxNestingDepth!
+      head =>
+        head.level <= BASE_HEADING_LEVEL + this.props.maxNestingDepth! &&
+        head.title.toLowerCase() !== 'see also'
     );
 
     return (

--- a/docs/pages/push-notifications/overview.md
+++ b/docs/pages/push-notifications/overview.md
@@ -150,4 +150,4 @@ Read through the [notification setup guide](./push-notifications-setup.md) to ge
 
 ## See also
 
-- Having trouble? Visit [Expo's notification FAQ page](./faq.md)
+Having trouble? Visit [Expo's notifications FAQ page](./faq.md)

--- a/docs/pages/push-notifications/overview.md
+++ b/docs/pages/push-notifications/overview.md
@@ -143,3 +143,11 @@ async function registerForPushNotificationsAsync() {
 We recommend testing push notifications on a physical device. iOS simulators **cannot** receive push notifications, and neither can Android emulators unless you are running an image with Google Play Services installed and configured. Additionally, when calling `Notifications.requestPermissionsAsync()` on the simulator, it will resolve immediately with `undetermined` as the status, regardless of whether you choose to allow or not.
 
 The [Expo push notification tool](https://expo.io/notifications) is also useful for testing push notifications during development. It lets you easily send test notifications to your device, without having to use your CLI or write out a test server.
+
+## Next steps
+
+Read through the [notification setup guide](./push-notifications-setup.md) to get your credentials setup, and start collecting push tokens!
+
+## See also
+
+- Having trouble? Visit [Expo's notification FAQ page](./faq.md)

--- a/docs/pages/push-notifications/overview.md
+++ b/docs/pages/push-notifications/overview.md
@@ -150,4 +150,4 @@ Read through the [notification setup guide](./push-notifications-setup.md) to ge
 
 ## See also
 
-Having trouble? Visit [Expo's notifications FAQ page](./faq.md)
+- Having trouble? Visit [Expo's notification FAQ page](./faq.md)

--- a/docs/pages/push-notifications/push-notifications-setup.md
+++ b/docs/pages/push-notifications/push-notifications-setup.md
@@ -115,3 +115,11 @@ For iOS, the managed workflow takes care of push notification credentials automa
 4. Select `Add new Push Notifications Key` (or `Use existing Push Notifications Key in current project` if you already have one)
 
 > Note: A paid Apple Developer Account is **required** to generate credentials.
+
+## Next steps
+
+Try out [sending a notification with Expo](./sending-notifications.md)!
+
+## See also
+
+- Having trouble? Visit [Expo's notification FAQ page](./faq.md)

--- a/docs/pages/push-notifications/push-notifications-setup.md
+++ b/docs/pages/push-notifications/push-notifications-setup.md
@@ -122,4 +122,4 @@ Try out [sending a notification with Expo](./sending-notifications.md)!
 
 ## See also
 
-- Having trouble? Visit [Expo's notification FAQ page](./faq.md)
+Having trouble? Visit [Expo's notifications FAQ page](./faq.md)

--- a/docs/pages/push-notifications/push-notifications-setup.md
+++ b/docs/pages/push-notifications/push-notifications-setup.md
@@ -122,4 +122,4 @@ Try out [sending a notification with Expo](./sending-notifications.md)!
 
 ## See also
 
-Having trouble? Visit [Expo's notifications FAQ page](./faq.md)
+- Having trouble? Visit [Expo's notification FAQ page](./faq.md)

--- a/docs/pages/push-notifications/receiving-notifications.md
+++ b/docs/pages/push-notifications/receiving-notifications.md
@@ -86,3 +86,11 @@ On Android, users can set certain OS-level settings (**usually** revolving aroun
 Event listeners added using `addNotificationReceivedListener` and `addNotificationResponseReceivedListener` will receive an object when a notification is received or interacted with, respectively. See the [documentation](../versions/latest/sdk/notifications.md#notification) for information on these objects.
 
 There are two different subscriptions for this so that you can easily address cases where a notification comes in while your app is open and foregrounded, **and** cases where a notification comes in while your app is backgrounded or closed, and the user taps on the notification.
+
+## Next steps
+
+Now that you're able to send & receive notifications, read through all of [`expo-notifications`'s feature set](../versions/latest/sdk/notifications.md) to get a sense of the possibilities!
+
+## See also
+
+- Having trouble? Visit [Expo's notification FAQ page](./faq.md)

--- a/docs/pages/push-notifications/receiving-notifications.md
+++ b/docs/pages/push-notifications/receiving-notifications.md
@@ -93,4 +93,4 @@ Now that you're able to send & receive notifications, read through all of [`expo
 
 ## See also
 
-- Having trouble? Visit [Expo's notification FAQ page](./faq.md)
+Having trouble? Visit [Expo's notifications FAQ page](./faq.md)

--- a/docs/pages/push-notifications/receiving-notifications.md
+++ b/docs/pages/push-notifications/receiving-notifications.md
@@ -93,4 +93,4 @@ Now that you're able to send & receive notifications, read through all of [`expo
 
 ## See also
 
-Having trouble? Visit [Expo's notifications FAQ page](./faq.md)
+- Having trouble? Visit [Expo's notification FAQ page](./faq.md)

--- a/docs/pages/push-notifications/sending-notifications-custom.md
+++ b/docs/pages/push-notifications/sending-notifications-custom.md
@@ -235,3 +235,7 @@ admin.messaging().sendToDevice(
   options
 );
 ```
+
+## Next steps
+
+Now that you can send notifications to your app, set your app up for [receiving notifications and taking action based on those events](./receiving-notifications.md)!

--- a/docs/pages/push-notifications/sending-notifications.md
+++ b/docs/pages/push-notifications/sending-notifications.md
@@ -293,3 +293,11 @@ Expo makes a best effort to deliver notifications to the push notification servi
 After a notification has been handed off to an underlying push notification service, Expo creates a "push receipt" that records whether the handoff was successful; a push receipt denotes whether the underlying push notification service received the notification.
 
 Finally, the push notification services from Apple, Google, etc... make a best effort to deliver the notification to the device according to their own policies.
+
+## Next steps
+
+Now that you can send notifications to your app, set your app up for [receiving notifications and taking action based on those events](./receiving-notifications.md)!
+
+## See also
+
+- Having trouble? Visit [Expo's notification FAQ page](./faq.md)

--- a/docs/pages/push-notifications/sending-notifications.md
+++ b/docs/pages/push-notifications/sending-notifications.md
@@ -300,4 +300,4 @@ Now that you can send notifications to your app, set your app up for [receiving 
 
 ## See also
 
-Having trouble? Visit [Expo's notifications FAQ page](./faq.md)
+- Having trouble? Visit [Expo's notification FAQ page](./faq.md)

--- a/docs/pages/push-notifications/sending-notifications.md
+++ b/docs/pages/push-notifications/sending-notifications.md
@@ -300,4 +300,4 @@ Now that you can send notifications to your app, set your app up for [receiving 
 
 ## See also
 
-- Having trouble? Visit [Expo's notification FAQ page](./faq.md)
+Having trouble? Visit [Expo's notifications FAQ page](./faq.md)

--- a/docs/pages/push-notifications/using-fcm.md
+++ b/docs/pages/push-notifications/using-fcm.md
@@ -71,4 +71,4 @@ That's it -- users who run this new version of the app will now receive notifica
 
 ## See also
 
-Having trouble? Visit [Expo's notifications FAQ page](./faq.md)
+- Having trouble? Visit [Expo's notification FAQ page](./faq.md)

--- a/docs/pages/push-notifications/using-fcm.md
+++ b/docs/pages/push-notifications/using-fcm.md
@@ -71,4 +71,4 @@ That's it -- users who run this new version of the app will now receive notifica
 
 ## See also
 
-- Having trouble? Visit [Expo's notification FAQ page](./faq.md)
+Having trouble? Visit [Expo's notifications FAQ page](./faq.md)

--- a/docs/pages/push-notifications/using-fcm.md
+++ b/docs/pages/push-notifications/using-fcm.md
@@ -17,33 +17,34 @@ Note that FCM is not currently available for Expo iOS apps.
 
 4. In your app.json, add an `android.googleServicesFile` field with the relative path to the `google-services.json` file you just downloaded. If you placed it in the root directory, this will probably look like
 
-  ```javascript
-  {
+```javascript
+{
+  ...
+  "android": {
+    "googleServicesFile": "./google-services.json",
     ...
-    "android": {
-      "googleServicesFile": "./google-services.json",
-      ...
-    }
   }
-  ```
+}
+```
 
 5.  Confirm that your API key in `google-services.json` has the correct "API restrictions" in the [Google Cloud Platform API Credentials console](https://console.cloud.google.com/apis/credentials). For push notifications to work correctly, Firebase requires the API key to either be unrestricted (the key can call any API), or have access to both `Firebase Cloud Messaging API` and `Firebase Installations API`. The API key can be found under the `client.api_key.current_key` field in `google-services.json`.
 
-  ```javascript
-  {
-    ...
-    "client": [
-      {
-        "api_key": [
-          {
-            "current_key" "<your Google Cloud Platform API key>",
-          }
-        ],
-      }
-    ]
-  }
-  ```
->  **Note:** Firebase will create an API key in the Google Cloud Platform console with a name like `Android key (auto created by Firebase)`. **This is not always the same key as the one found in `google-services.json`. Always confirm your key and associated restrictions in the Google Cloud Platform console.**
+```javascript
+{
+  ...
+  "client": [
+    {
+      "api_key": [
+        {
+          "current_key" "<your Google Cloud Platform API key>",
+        }
+      ],
+    }
+  ]
+}
+```
+
+> **Note:** Firebase will create an API key in the Google Cloud Platform console with a name like `Android key (auto created by Firebase)`. **This is not always the same key as the one found in `google-services.json`. Always confirm your key and associated restrictions in the Google Cloud Platform console.**
 
 6. Finally, make a new build of your app by running `expo build:android`.
 
@@ -67,3 +68,7 @@ In order for Expo to send notifications from our servers using your credentials,
 4. Run `expo push:android:upload --api-key <your-token-here>`, replacing `<your-token-here>` with the string you just copied. We'll store your token securely on our servers, where it will only be accessed when you send a push notification.
 
 That's it -- users who run this new version of the app will now receive notifications through FCM using your project's credentials. You just send the push notifications as you normally would (see [guide](sending-notifications.md)). We'll take care of choosing the correct service to send the notification.
+
+## See also
+
+- Having trouble? Visit [Expo's notification FAQ page](./faq.md)


### PR DESCRIPTION
# Why

these pages are all related and should flow like a story
