### PR TITLE
[dev-menu][android] Add websocket support

### DIFF
--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuManager.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuManager.kt
@@ -37,6 +37,8 @@ import expo.modules.devmenu.api.DevMenuExpoApiClient
 import expo.modules.devmenu.detectors.ShakeDetector
 import expo.modules.devmenu.detectors.ThreeFingerLongPressDetector
 import expo.modules.devmenu.modules.DevMenuSettings
+import expo.modules.devmenu.react.DevMenuPackagerCommandHandlersSwapper
+import expo.modules.devmenu.websockets.DevMenuCommandHandlersProvider
 import java.lang.ref.WeakReference
 
 object DevMenuManager : DevMenuManagerInterface, LifecycleEventListener {
@@ -160,6 +162,16 @@ object DevMenuManager : DevMenuManagerInterface, LifecycleEventListener {
 
   private fun setUpReactInstanceManager(reactInstanceManager: ReactInstanceManager) {
     currentReactInstanceManager = WeakReference(reactInstanceManager)
+
+    val handlers = DevMenuCommandHandlersProvider(this, reactInstanceManager)
+      .createCommandHandlers()
+
+    DevMenuPackagerCommandHandlersSwapper()
+      .swapPackagerCommandHandlers(
+        reactInstanceManager,
+        handlers
+      )
+
     if (reactInstanceManager.currentReactContext == null) {
       reactInstanceManager.addReactInstanceEventListener(object : ReactInstanceManager.ReactInstanceEventListener {
         override fun onReactContextInitialized(context: ReactContext) {

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/DevMenuActivity.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/DevMenuActivity.kt
@@ -7,7 +7,9 @@ import android.view.ViewGroup
 import com.facebook.react.ReactActivity
 import com.facebook.react.ReactActivityDelegate
 import com.facebook.react.ReactDelegate
+import com.facebook.react.ReactInstanceManager
 import com.facebook.react.ReactRootView
+import com.facebook.react.devsupport.interfaces.DevSupportManager
 import expo.modules.devmenu.helpers.getPrivateDeclaredFiledValue
 import expo.modules.devmenu.helpers.setPrivateDeclaredFiledValue
 import java.util.*
@@ -79,6 +81,21 @@ class DevMenuActivity : ReactActivity() {
   override fun onPause() {
     super.onPause()
     overridePendingTransition(0, 0)
+  }
+
+  override fun onStart() {
+    super.onStart()
+    val instanceManager = DevMenuManager.delegate?.reactInstanceManager() ?: return
+    val supportsDevelopment = DevMenuManager.delegate?.supportsDevelopment() ?: false
+
+    if (supportsDevelopment) {
+      val devSupportManager: DevSupportManager =
+        ReactInstanceManager::class.java.getPrivateDeclaredFiledValue(
+          "mDevSupportManager", instanceManager
+        )
+
+      devSupportManager.devSupportEnabled = true
+    }
   }
 
   companion object {

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/devtools/DevMenuDevToolsDelegate.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/devtools/DevMenuDevToolsDelegate.kt
@@ -1,0 +1,87 @@
+package expo.modules.devmenu.devtools
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.provider.Settings
+import com.facebook.react.ReactInstanceManager
+import com.facebook.react.bridge.UiThreadUtil
+import expo.interfaces.devmenu.DevMenuManagerInterface
+import java.lang.ref.WeakReference
+
+class DevMenuDevToolsDelegate(
+  private val manager: DevMenuManagerInterface,
+  reactInstanceManager: ReactInstanceManager
+) {
+  private val _reactDevManager = WeakReference(
+    reactInstanceManager.devSupportManager
+  )
+  val reactDevManager
+    get() = _reactDevManager.get()
+
+  val devSettings
+    get() = reactDevManager?.devSettings
+
+  fun reload() {
+    val reactDevManager = reactDevManager ?: return
+    manager.closeMenu()
+    UiThreadUtil.runOnUiThread {
+      reactDevManager.handleReloadJS()
+    }
+  }
+
+  fun toggleElementInspector() = runWithDevSupportEnabled {
+    reactDevManager?.toggleElementInspector()
+  }
+
+  fun toggleRemoteDebugging() = runWithDevSupportEnabled {
+    val reactDevManager = reactDevManager ?: return
+    val devSettings = devSettings ?: return
+    manager.closeMenu()
+    UiThreadUtil.runOnUiThread {
+      devSettings.isRemoteJSDebugEnabled = !devSettings.isRemoteJSDebugEnabled
+      reactDevManager.handleReloadJS()
+    }
+  }
+
+  fun togglePerformanceMonitor(context: Context)  {
+    val reactDevManager = reactDevManager ?: return
+    val devSettings = devSettings ?: return
+
+    requestOverlaysPermission(context)
+    runWithDevSupportEnabled {
+      reactDevManager.setFpsDebugEnabled(!devSettings.isFpsDebugEnabled)
+    }
+  }
+
+  /**
+   * RN will temporary disable `devSupport` if the current activity isn't active.
+   * Because of that we can't call some functions like `toggleElementInspector`.
+   * However, we can temporary set the `devSupport` flag to true and run needed methods.
+   */
+  private inline fun runWithDevSupportEnabled(action: () -> Unit) {
+    val reactDevManager = reactDevManager ?: return
+    val currentSetting = reactDevManager.devSupportEnabled
+    reactDevManager.devSupportEnabled = true
+    action()
+    reactDevManager.devSupportEnabled = currentSetting
+  }
+
+  /**
+   * Requests for the permission that allows the app to draw overlays on other apps.
+   * Such permission is required to enable performance monitor.
+   */
+  private fun requestOverlaysPermission(context: Context) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M
+      && !Settings.canDrawOverlays(context)) {
+      val uri = Uri.parse("package:" + context.applicationContext.packageName)
+      val intent = Intent(Settings.ACTION_MANAGE_OVERLAY_PERMISSION, uri).apply {
+        flags = Intent.FLAG_ACTIVITY_NEW_TASK
+      }
+      if (intent.resolveActivity(context.packageManager) != null) {
+        context.startActivity(intent)
+      }
+    }
+  }
+}

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/extensions/DevMenuExtension.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/extensions/DevMenuExtension.kt
@@ -1,14 +1,9 @@
 package expo.modules.devmenu.extensions
 
-import android.content.Intent
-import android.net.Uri
-import android.os.Build
-import android.provider.Settings
 import android.util.Log
 import android.view.KeyEvent
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
-import com.facebook.react.bridge.UiThreadUtil
 import com.facebook.react.devsupport.DevInternalSettings
 import expo.interfaces.devmenu.DevMenuExtensionInterface
 import expo.interfaces.devmenu.DevMenuExtensionSettingsInterface
@@ -18,6 +13,7 @@ import expo.interfaces.devmenu.items.DevMenuItemsContainer
 import expo.interfaces.devmenu.items.DevMenuScreen
 import expo.interfaces.devmenu.items.KeyCommand
 import expo.modules.devmenu.DEV_MENU_TAG
+import expo.modules.devmenu.devtools.DevMenuDevToolsDelegate
 
 class DevMenuExtension(reactContext: ReactApplicationContext)
   : ReactContextBaseJavaModule(reactContext), DevMenuExtensionInterface {
@@ -28,62 +24,29 @@ class DevMenuExtension(reactContext: ReactApplicationContext)
       return@export
     }
 
-    val reactDevManager = settings
-      .manager
-      .getSession()
-      ?.reactInstanceManager
-      ?.devSupportManager
-    val devSettings = reactDevManager?.devSettings
+    val reactInstanceManager = settings.manager.getSession()?.reactInstanceManager
+    if (reactInstanceManager == null) {
+      Log.w(DEV_MENU_TAG, "Couldn't export dev-menu items, because the react instance manager isn't present.")
+      return@export
+    }
+
+    val devDelegate = DevMenuDevToolsDelegate(settings.manager, reactInstanceManager)
+    val reactDevManager = devDelegate.reactDevManager
+    val devSettings = devDelegate.devSettings
 
     if (reactDevManager == null || devSettings == null) {
       Log.w(DEV_MENU_TAG, "Couldn't export dev-menu items, because react-native bridge doesn't contain the dev support manager.")
       return@export
     }
 
-    // RN will temporary disable `devSupport` if the current activity isn't active.
-    // Because of that we can't call some functions like `toggleElementInspector`.
-    // However, we can temporary set the `devSupport` flag to true and run needed methods.
-    val runWithDevSupportEnabled = { action: () -> Unit ->
-      val currentSetting = reactDevManager.devSupportEnabled
-      reactDevManager.devSupportEnabled = true
-      action()
-      reactDevManager.devSupportEnabled = currentSetting
-    }
-
-    val reloadAction = {
-      UiThreadUtil.runOnUiThread {
-        reactDevManager.handleReloadJS()
-      }
-    }
-
-    val elementInspectorAction = {
-      runWithDevSupportEnabled {
-        reactDevManager.toggleElementInspector()
-      }
-    }
-
-    val performanceMonitorAction = {
-      requestOverlaysPermission()
-      runWithDevSupportEnabled {
-        reactDevManager.setFpsDebugEnabled(!devSettings.isFpsDebugEnabled)
-      }
-    }
-
-    val remoteDebugAction = {
-      UiThreadUtil.runOnUiThread {
-        devSettings.isRemoteJSDebugEnabled = !devSettings.isRemoteJSDebugEnabled
-        reactDevManager.handleReloadJS()
-      }
-    }
-
-    action("reload", reloadAction) {
+    action("reload", devDelegate::reload) {
       label = { "Reload" }
       glyphName = { "reload" }
       keyCommand = KeyCommand(KeyEvent.KEYCODE_R)
       importance = DevMenuItemImportance.HIGHEST.value
     }
 
-    action("inspector", elementInspectorAction) {
+    action("inspector", devDelegate::toggleElementInspector) {
       isEnabled = { devSettings.isElementInspectorEnabled }
       label = { if (isEnabled()) "Hide Element Inspector" else "Show Element Inspector" }
       glyphName = { "border-style" }
@@ -91,7 +54,14 @@ class DevMenuExtension(reactContext: ReactApplicationContext)
       importance = DevMenuItemImportance.HIGH.value
     }
 
-    action("performance-monitor", performanceMonitorAction) {
+    action(
+      "performance-monitor",
+      {
+        currentActivity?.let {
+          devDelegate.togglePerformanceMonitor(it)
+        }
+      }
+    ) {
       isEnabled = { devSettings.isFpsDebugEnabled }
       label = { if (isEnabled()) "Hide Performance Monitor" else "Show Performance Monitor" }
       glyphName = { "speedometer" }
@@ -99,7 +69,7 @@ class DevMenuExtension(reactContext: ReactApplicationContext)
       importance = DevMenuItemImportance.HIGH.value
     }
 
-    action("remote-debug", remoteDebugAction) {
+    action("remote-debug", devDelegate::toggleRemoteDebugging) {
       isEnabled = {
         devSettings.isRemoteJSDebugEnabled
       }
@@ -122,30 +92,7 @@ class DevMenuExtension(reactContext: ReactApplicationContext)
     }
   }
 
-  override fun devMenuScreens(settings: DevMenuExtensionSettingsInterface): List<DevMenuScreen>? {
-    return null
-  }
+  override fun devMenuScreens(settings: DevMenuExtensionSettingsInterface): List<DevMenuScreen>? = null
 
-  override fun devMenuDataSources(settings: DevMenuExtensionSettingsInterface): List<DevMenuDataSourceInterface>? {
-    return null
-  }
-
-  /**
-   * Requests for the permission that allows the app to draw overlays on other apps.
-   * Such permission is required to enable performance monitor.
-   */
-  private fun requestOverlaysPermission() {
-    val context = currentActivity ?: return
-
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M
-      && !Settings.canDrawOverlays(context)) {
-      val uri = Uri.parse("package:" + context.applicationContext.packageName)
-      val intent = Intent(Settings.ACTION_MANAGE_OVERLAY_PERMISSION, uri).apply {
-        flags = Intent.FLAG_ACTIVITY_NEW_TASK
-      }
-      if (intent.resolveActivity(context.packageManager) != null) {
-        context.startActivity(intent)
-      }
-    }
-  }
+  override fun devMenuDataSources(settings: DevMenuExtensionSettingsInterface): List<DevMenuDataSourceInterface>? = null
 }

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/react/DevMenuPackagerCommandHandlersSwapper.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/react/DevMenuPackagerCommandHandlersSwapper.kt
@@ -1,0 +1,110 @@
+package expo.modules.devmenu.react
+
+import android.util.Log
+import com.facebook.react.ReactInstanceManager
+import com.facebook.react.devsupport.DevServerHelper
+import com.facebook.react.devsupport.DevSupportManagerBase
+import com.facebook.react.packagerconnection.JSPackagerClient
+import com.facebook.react.packagerconnection.RequestHandler
+import expo.modules.devmenu.helpers.getPrivateDeclaredFiledValue
+import expo.modules.devmenu.helpers.setPrivateDeclaredFiledValue
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+class DevMenuPackagerCommandHandlersSwapper {
+  fun swapPackagerCommandHandlers(
+    reactInstanceManager: ReactInstanceManager,
+    handlers: Map<String, RequestHandler>
+  ) {
+    try {
+      val devSupportManager: DevSupportManagerBase =
+        ReactInstanceManager::class.java.getPrivateDeclaredFiledValue(
+          "mDevSupportManager",
+          reactInstanceManager
+        )
+
+      val currentCommandHandlers: Map<String, RequestHandler>? =
+        DevSupportManagerBase::class.java.getPrivateDeclaredFiledValue(
+          "mCustomPackagerCommandHandlers",
+          devSupportManager
+        )
+
+      val newCommandHandlers = currentCommandHandlers?.toMutableMap() ?: mutableMapOf()
+      newCommandHandlers.putAll(handlers)
+
+      DevSupportManagerBase::class.java.setPrivateDeclaredFiledValue(
+        "mCustomPackagerCommandHandlers",
+        devSupportManager,
+        newCommandHandlers
+      )
+
+      swapCurrentCommandHandlers(reactInstanceManager, handlers)
+    } catch (e: Exception) {
+      Log.w("DevMenu", "Couldn't add packager command handlers to current client: ${e.message}", e)
+    }
+  }
+
+  /**
+   * No matter where we swap the command handlers there always will be an instance of [JSPackagerClient]
+   * that was created before swapping. The only place where you can add custom handlers,
+   * is in the [com.facebook.react.ReactInstanceManagerBuilder.setCustomPackagerCommandHandlers].
+   * Unfortunately, we don't have access to this function. What's worst, we can't even add a new installation step.
+   * The builder is hidden from the user.
+   *
+   * So we need to swap command handlers in the current [JSPackagerClient] instance.
+   * However, we can't just use the reflection API to access handlers variable inside that object,
+   * cause we don't know if it is available. [JSPackagerClient] is created on background thread (see [DevServerHelper.openPackagerConnection]).
+   * The final solution is to spin a background task that monitors if the client is present.
+   */
+  private fun swapCurrentCommandHandlers(
+    reactInstanceManager: ReactInstanceManager,
+    handlers: Map<String, RequestHandler>
+  ) {
+    GlobalScope.launch {
+      try {
+        while (true) {
+          val devSupportManager: DevSupportManagerBase =
+            ReactInstanceManager::class.java.getPrivateDeclaredFiledValue(
+              "mDevSupportManager",
+              reactInstanceManager
+            )
+
+          val devServerHelper: DevServerHelper =
+            DevSupportManagerBase::class.java.getPrivateDeclaredFiledValue(
+              "mDevServerHelper",
+              devSupportManager
+            )
+
+          val jsPackagerClient: JSPackagerClient? =
+            DevServerHelper::class.java.getPrivateDeclaredFiledValue(
+              "mPackagerClient",
+              devServerHelper
+            )
+
+          if (jsPackagerClient != null) {
+            val currentCommandHandlers: Map<String, RequestHandler>? =
+              JSPackagerClient::class.java.getPrivateDeclaredFiledValue(
+                "mRequestHandlers",
+                jsPackagerClient
+              )
+
+            val newCommandHandlers = currentCommandHandlers?.toMutableMap() ?: mutableMapOf()
+            newCommandHandlers.putAll(handlers)
+            JSPackagerClient::class.java.setPrivateDeclaredFiledValue(
+              "mRequestHandlers",
+              jsPackagerClient,
+              newCommandHandlers
+            )
+
+            return@launch
+          }
+
+          delay(50)
+        }
+      } catch (e: Exception) {
+        Log.w("DevMenu", "Couldn't add packager command handlers to current client: ${e.message}", e)
+      }
+    }
+  }
+}

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/websockets/DevMenuCommandHandlersProvider.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/websockets/DevMenuCommandHandlersProvider.kt
@@ -1,0 +1,69 @@
+package expo.modules.devmenu.websockets
+
+import android.util.Log
+import com.facebook.react.ReactInstanceManager
+import com.facebook.react.bridge.UiThreadUtil
+import com.facebook.react.packagerconnection.NotificationOnlyHandler
+import expo.interfaces.devmenu.DevMenuManagerInterface
+import expo.modules.devmenu.devtools.DevMenuDevToolsDelegate
+import org.json.JSONObject
+import java.lang.ref.WeakReference
+
+class DevMenuCommandHandlersProvider(
+  private val manager: DevMenuManagerInterface,
+  reactInstanceManager: ReactInstanceManager
+) {
+  private val _instanceManager = WeakReference(reactInstanceManager)
+  private val instanceManager
+    get() = _instanceManager.get()
+
+  private val onReload = object : NotificationOnlyHandler() {
+    override fun onNotification(params: Any?) {
+      manager.closeMenu()
+      UiThreadUtil.runOnUiThread {
+        instanceManager?.devSupportManager?.handleReloadJS()
+      }
+    }
+  }
+
+  private val onDevMenu = object : NotificationOnlyHandler() {
+    override fun onNotification(params: Any?) {
+      val activity = instanceManager?.currentReactContext?.currentActivity ?: return
+      manager.toggleMenu(activity)
+    }
+  }
+
+  private val onDevCommand = object : NotificationOnlyHandler() {
+    override fun onNotification(params: Any?) {
+      val instanceManager = instanceManager ?: return
+      val devDelegate = DevMenuDevToolsDelegate(manager, instanceManager)
+
+      if (params is JSONObject) {
+        val command = params.optString("name") ?: return
+
+        when (command) {
+          "reload" -> devDelegate.reload()
+          "toggleDevMenu" -> {
+            val activity = instanceManager.currentReactContext?.currentActivity ?: return
+            manager.toggleMenu(activity)
+          }
+          "toggleRemoteDebugging" -> devDelegate.toggleRemoteDebugging()
+          "toggleElementInspector" -> devDelegate.toggleElementInspector()
+          "togglePerformanceMonitor" -> {
+            val activity = instanceManager.currentReactContext?.currentActivity ?: return
+            devDelegate.togglePerformanceMonitor(activity)
+          }
+          else -> Log.w("DevMenu", "Unknown command: $command")
+        }
+      }
+    }
+  }
+
+  fun createCommandHandlers(): Map<String, NotificationOnlyHandler> {
+    return mapOf(
+      "reload" to onReload,
+      "devMenu" to onDevMenu,
+      "sendDevCommand" to onDevCommand
+    )
+  }
+}

--- a/packages/expo-dev-menu/android/src/release/java/expo/modules/devmenu/DevMenuManager.kt
+++ b/packages/expo-dev-menu/android/src/release/java/expo/modules/devmenu/DevMenuManager.kt
@@ -16,6 +16,8 @@ import expo.interfaces.devmenu.items.DevMenuDataSourceItem
 private const val DEV_MENU_IS_NOT_AVAILABLE = "DevMenu isn't available in release builds"
 
 object DevMenuManager : DevMenuManagerInterface {
+  internal var delegate: DevMenuDelegateInterface? = null
+
   override fun openMenu(activity: Activity, screen: String?) {
     throw IllegalStateException(DEV_MENU_IS_NOT_AVAILABLE)
   }


### PR DESCRIPTION
# Why

Closes ENG-1145.

# How

Added web socket control support for dev-menu on iOS (very similar to the https://github.com/expo/expo/pull/12172).

No matter where we swap the command handlers there always will be an instance of `JSPackagerClient` that was created before swapping. The only place where you can add custom handlers is in the `ReactInstanceManagerBuilder.setCustomPackagerCommandHandlers`. Unfortunately, we don't have access to this function. What's worst, we can't even add a new installation step. The builder is hidden from the user. 

So we need to swap command handlers in the current `JSPackagerClient` instance too. However, we can't just use the reflection API to access handlers variable inside that object, cause we don't know if it is available. `JSPackagerClient` is created on background thread (see `DevServerHelper.openPackagerConnection`). The final solution is to spin a background task that monitors if the client is present.
   
# Test Plan

- bare-expo ✅