### PR TITLE
[docs] Update `expo-battery` example code to use function component and have a visualization of a battery

### DIFF
--- a/docs/pages/versions/unversioned/sdk/battery.md
+++ b/docs/pages/versions/unversioned/sdk/battery.md
@@ -34,7 +34,7 @@ export default function App() {
     (async () => {
       setBatteryLevel(await Battery.getBatteryLevelAsync());
       function batteryLevelListener({ batteryLevel }) {
-        console.log(`Battery level changed to {batteryLevel}`);
+        console.log(`Battery level changed to ${batteryLevel}`);
         setBatteryLevel(batteryLevel);
       }
       listener = Battery.addBatteryLevelListener(batteryLevelListener);
@@ -74,12 +74,10 @@ function BatteryView(props, context) {
         borderWidth: 4,
         width: 100,
         height: 62,
-        alignContent: 'flexStart',
-        alignItems: 'flexStart',
       }}>
       <View
         style={{
-          width: 92 * props.level,
+          width: Math.floor(92 * props.level),
           backgroundColor: '#53d769',
           height: 54,
         }}

--- a/docs/pages/versions/unversioned/sdk/battery.md
+++ b/docs/pages/versions/unversioned/sdk/battery.md
@@ -21,44 +21,36 @@ import SnackInline from '~/components/plugins/SnackInline';
 <SnackInline label='Basic Battery Usage' dependencies={['expo-battery']}>
 
 ```jsx
-import * as React from 'react';
+import React, { useState, useEffect } from 'react';
 import * as Battery from 'expo-battery';
 import { StyleSheet, Text, View } from 'react-native';
 
-export default class App extends React.Component {
-  state = {
-    batteryLevel: null,
-  };
+export default function App() {
+  let [batteryLevel, setBatteryLevel] = useState(null);
 
-  componentDidMount() {
-    this._subscribe();
-  }
+  useEffect(() => {
+    let listener;
 
-  componentWillUnmount() {
-    this._unsubscribe();
-  }
+    (async () => {
+      setBatteryLevel(await Battery.getBatteryLevelAsync());
+      function batteryLevelListener({ batteryLevel }) {
+        console.log(`Battery level changed to {batteryLevel}`);
+        setBatteryLevel(batteryLevel);
+      }
+      listener = Battery.addBatteryLevelListener(batteryLevelListener);
+    })();
 
-  async _subscribe() {
-    const batteryLevel = await Battery.getBatteryLevelAsync();
-    this.setState({ batteryLevel });
-    this._subscription = Battery.addBatteryLevelListener(({ batteryLevel }) => {
-      this.setState({ batteryLevel });
-      console.log('batteryLevel changed!', batteryLevel);
-    });
-  }
+    return function cleanup() {
+      listener && listener.remove();
+    };
+  }, []);
 
-  _unsubscribe() {
-    this._subscription && this._subscription.remove();
-    this._subscription = null;
-  }
-
-  render() {
-    return (
-      <View style={styles.container}>
-        <Text>Current Battery Level: {this.state.batteryLevel}</Text>
-      </View>
-    );
-  }
+  return (
+    <View style={styles.container}>
+      <Text>Current Battery Level: {batteryLevel}</Text>
+      <BatteryView level={batteryLevel} />
+    </View>
+  );
 }
 
 /* @hide const styles = StyleSheet.create({ ... }); */
@@ -70,6 +62,31 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
 });
+
+function BatteryView(props, context) {
+  return (
+    <View
+      style={{
+        marginTop: 10,
+        borderRadius: 4,
+        borderStyle: 'solid',
+        borderColor: 'black',
+        borderWidth: 4,
+        width: 100,
+        height: 62,
+        alignContent: 'flexStart',
+        alignItems: 'flexStart',
+      }}>
+      <View
+        style={{
+          width: 92 * props.level,
+          backgroundColor: '#53d769',
+          height: 54,
+        }}
+      />
+    </View>
+  );
+}
 /* @end */
 ```
 

--- a/docs/pages/versions/unversioned/sdk/storereview.md
+++ b/docs/pages/versions/unversioned/sdk/storereview.md
@@ -47,6 +47,13 @@ It is important that you follow the [Human Interface Guidelines](https://develop
 - Don't request a review when the user is doing something time sensitive like navigating.
 - Don't ask the user any questions before or while presenting the rating button or card.
 
+### Rate Limits
+
+Both Apple and Google limit the amount that you can call the `requestReview` method, so you'll generally want to ask the user for permission to request a review before calling `StoreReview.requestReview()`
+
+- On iOS, you can prompt for ratings up to three times in a 365-day period.
+- On Android, the limits are not specified and may change at any time. But Google Play enforces a time-bound quota on how often a user can be shown the review dialog. And calling the `requestReview` method more than once during a short period of time (for example, less than a month) might not always display a dialog.
+
 ### Write Reviews
 
 #### iOS

--- a/packages/expo-store-review/src/StoreReview.ts
+++ b/packages/expo-store-review/src/StoreReview.ts
@@ -23,6 +23,13 @@ export async function isAvailableAsync(): Promise<boolean> {
  * that will then be applied to the App Store, without leaving the app. If the device is running
  * a version of iOS lower than 10.3, or a version of Android lower than 5.0, this will attempt
  * to get the store URL and link the user to it.
+ * 
+ * Google and Apple both rate limit the frequency of requests for reviews
+ * using this method, so you'll want to be thoughtful before calling this. See 
+ * [Rate Limits](#rate-limits) below for more. The most common way to avoid 
+ * hitting these rate limits is to ask the user if they'd like to review your 
+ * app with your own dialog before calling the `requestReview` method.
+ * 
  */
 export async function requestReview(): Promise<void> {
   if (StoreReview?.requestReview) {


### PR DESCRIPTION
# Why

Reviewing docs as part of docs jam. Thought it would be worthwhile to update the `expo-battery` example

# How

This updates the expo-battery docs to use a function
component instead of a class component. This is how most modern
React users will likely want to use this.
    
This change also adds a visualization of a battery to the example
Snack, just to make it more visual and fun. The code for this is
hidden from the docs so that it is not a distraction.

# Test Plan

Tested on iOS and Android devices manually

![image](https://user-images.githubusercontent.com/56719/119090994-38efd300-b9c1-11eb-80ae-8dc737ee1db3.png)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).