### PR TITLE
[dev-launcher][ios] Connect to the WebSocket during development

### DIFF
--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -175,6 +175,11 @@ NSString *fakeLauncherBundleUrl = @"embedded://EXDevLauncher/dummy";
   rootViewController.view = rootView;
   _window.rootViewController = rootViewController;
 
+#if RCT_DEV && defined(DEV_LAUNCHER_URL)
+    // Connect to the websocket
+    [[RCTPackagerConnection sharedPackagerConnection] setSocketConnectionURL:[NSURL URLWithString:@DEV_LAUNCHER_URL]];
+#endif
+  
   [_window makeKeyAndVisible];
 }
 


### PR DESCRIPTION
# Why

Connect to the metro server via WebSocket in local development mode.

# Test Plan

- bare-expo✅