### PR TITLE
[dev-launcher][ios] Show error screen on deep link failure

### DIFF
--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -187,7 +187,15 @@ NSString *fakeLauncherBundleUrl = @"embedded://EXDevLauncher/dummy";
   NSURL *appUrl = [EXDevLauncherURLHelper getAppURLFromDevLauncherURL:url];
   if (appUrl) {
     [self loadApp:appUrl onSuccess:nil onError:^(NSError *error) {
-      NSLog(@"%@", error.description);
+      __weak typeof(self) weakSelf = self;
+      dispatch_async(dispatch_get_main_queue(), ^{
+        typeof(self) self = weakSelf;
+        if (!self) {
+          return;
+        }
+        
+        [self.errorManager showErrorWithMessage:error.description stack:nil];
+      });
     }];
     return true;
   }


### PR DESCRIPTION
# Why

Show error screen when we can't load the app from the deep link. 

# Test Plan

- bare-expo ✅