### PR TITLE
[docs] Tweak the designs for page notifications

### DIFF
--- a/docs/components/plugins/PossibleRedirectNotification.tsx
+++ b/docs/components/plugins/PossibleRedirectNotification.tsx
@@ -1,11 +1,7 @@
-import { css } from '@emotion/react';
 import * as React from 'react';
 
-const CONTAINER_STYLE = css`
-  background-color: rgba(225, 228, 23, 0.1);
-  padding: 20px;
-  margin-bottom: 20px;
-`;
+import { P } from '~/components/base/paragraph';
+import { CONTAINER_STYLE } from '~/components/plugins/VersionedRedirectNotification';
 
 const PossibleRedirectNotification: React.FC<{ newUrl: string }> = ({ newUrl }) => {
   const [targetId, setTargetId] = React.useState<string | null>(null);
@@ -23,8 +19,10 @@ const PossibleRedirectNotification: React.FC<{ newUrl: string }> = ({ newUrl }) 
   if (targetId) {
     return (
       <div css={CONTAINER_STYLE}>
-        ⚠️ The information you are looking for (addressed by <em>"{targetId}"</em>) has moved.{' '}
-        <a href={`${newUrl}#${targetId}`}>Continue to the new location.</a>
+        <P>
+          ⚠️ The information you are looking for (addressed by <em>"{targetId}"</em>) has moved.{' '}
+          <a href={`${newUrl}#${targetId}`}>Continue to the new location.</a>
+        </P>
       </div>
     );
   } else {

--- a/docs/components/plugins/VersionedRedirectNotification.tsx
+++ b/docs/components/plugins/VersionedRedirectNotification.tsx
@@ -5,14 +5,15 @@ import * as React from 'react';
 
 import { P } from '~/components/base/paragraph';
 
-const CONTAINER_STYLE = css`
+export const CONTAINER_STYLE = css`
   background-color: ${theme.background.warning};
-  border: 1px solid ${theme.border.error};
+  border: 1px solid ${theme.border.warning};
   padding: 16px;
   margin-bottom: 1rem;
   border-radius: 4px;
 
-  div {
+  div,
+  p {
     margin-bottom: 0;
   }
 `;

--- a/docs/components/plugins/VersionedRedirectNotification.tsx
+++ b/docs/components/plugins/VersionedRedirectNotification.tsx
@@ -26,7 +26,7 @@ export default function VersionedRedirectNotification({ showForQuery = 'redirect
     if (router.query) {
       setVisible(router.query.hasOwnProperty(showForQuery));
     }
-  }, []);
+  }, [router.query]);
 
   if (visible) {
     return (


### PR DESCRIPTION
# Why

@tcdavis mentioned the notifications that sporadically pop up aren't styled right with the docs.

# How

- Fixed the appearance of `VersionedRedirectNotification`, it wasn't appearing because `router.query` isn't set on initial render
- Reused the `CONTAINER_STYLE` from the versioned redirect in possible redirect.
  - `docs/components/plugins/VersionedRedirectNotification.tsx`
  - `docs/components/plugins/PossibleRedirectNotification.tsx`
- Fixed the border color for both notifications
- Added `P` within possible redirect notification

notification | before | after
--- | --- | ---
Versioned... | ![Screenshot 2021-05-21 at 18 11 04](https://user-images.githubusercontent.com/1203991/119168124-de0db880-ba60-11eb-8c88-77c15775cbab.png) | ![Screenshot 2021-05-21 at 18 10 31](https://user-images.githubusercontent.com/1203991/119168190-f087f200-ba60-11eb-8ae8-30b009acaec4.png)
Possible... | ![Screenshot 2021-05-21 at 18 13 29](https://user-images.githubusercontent.com/1203991/119168166-e82fb700-ba60-11eb-9a9c-d1e1239e05e9.png) | ![Screenshot 2021-05-21 at 18 10 41](https://user-images.githubusercontent.com/1203991/119168247-01386800-ba61-11eb-8ff7-a534e530c754.png)

# Test Plan

- Try out the [`PossibleRedirectNotification`](https://docs.expo.io/workflow/configuration/#ios)
- Try out the [`VersionedRedirectNotification`](https://docs.expo.io/versions/unversioned/?redirected=asd) (_note: this currently doesn't work on our docs, you can still try it locally_)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).