### PR TITLE
[docs] update docs for SDK 41 patch release

### DIFF
--- a/docs/pages/versions/unversioned/sdk/payments.md
+++ b/docs/pages/versions/unversioned/sdk/payments.md
@@ -6,6 +6,8 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-payments-
 import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
+> **This library is deprecated in favor of [`@stripe/stripe-react-native`](./stripe.md).** [Here's a guide to help make the transition as easy as possible](https://github.com/expo/fyi/blob/master/payments-migration-guide.md#how-to-migrate-from-expo-payments-stripe-to-the-new-stripestripe-react-native-library).
+
 > 🚨 On iOS, the Payments module is currently only supported the [bare workflow](https://docs.expo.io/bare/customizing/).
 
 Payments uses [Stripe](https://stripe.com/) and [Apple Pay](https://www.apple.com/apple-pay/) on iOS, but the module is only available in bare workflow apps.

--- a/docs/pages/versions/unversioned/sdk/stripe.md
+++ b/docs/pages/versions/unversioned/sdk/stripe.md
@@ -1,0 +1,66 @@
+---
+title: Stripe
+sourceCodeUrl: 'https://github.com/stripe/stripe-react-native'
+---
+
+import InstallSection from '~/components/plugins/InstallSection';
+import PlatformsSection from '~/components/plugins/PlatformsSection';
+import SnackInline from '~/components/plugins/SnackInline';
+
+Expo includes support for [`@stripe/stripe-react-native`](https://github.com/stripe/stripe-react-native), which allows you to build delightful payment experiences in your native Android and iOS apps using React Native & Expo. This library provides powerful and customizable UI screens and elements that can be used out-of-the-box to collect your users' payment details.
+
+> Migrating from Expo's `expo-payments-stripe` module? [Here's a guide to help make the transition as easy as possible](https://github.com/expo/fyi/blob/master/payments-migration-guide.md#how-to-migrate-from-expo-payments-stripe-to-the-new-stripestripe-react-native-library).
+
+<PlatformsSection android emulator ios simulator />
+
+## Installation
+
+<InstallSection packageName="@stripe/stripe-react-native" href="https://github.com/stripe/stripe-react-native" />
+
+### Config plugin setup (optional)
+
+If you're using EAS Build or the bare workflow, you can do most of your Stripe setup using the `@stripe/stripe-react-native` config plugin ([what's a config plugin?](/guides/config-plugins.md)). To setup, just add the config plugin to the `plugins` array of your `app.json` or `app.config.js`:
+
+```json
+{
+  "expo": {
+    ...
+    "plugins": [
+      [
+        "@stripe/stripe-react-native",
+        {
+          "merchantIdentifier": string | string [],
+          "enableGooglePay": boolean
+        }
+      ]
+    ],
+  }
+}
+```
+
+- **merchantIdentifier**: iOS only. This is the Apple merchant ID obtained [here](https://stripe.com/docs/apple-pay?platform=react-native). Otherwise, Apple Pay will not work as expected. If you have multiple merchantIdentifiers, you can set them in an array.
+- **enableGooglePay**: Android only. Boolean indicating whether or not Google Pay is enabled. Defaults to `false`.
+
+Then rebuild the app. If you're using the bare workflow, make sure to run `expo prebuild` first (this will apply the config plugin using [prebuilding](https://expo.fyi/prebuilding)).
+
+## Usage
+
+For usage information and detailed documentation, please refer to:
+
+- [Stripe's React Native SDK reference](https://stripe.dev/stripe-react-native/api-reference/index.html)
+- [Stripe's React Native GitHub repo](https://github.com/stripe/stripe-react-native)
+- [Stripe's example React Native app](https://github.com/stripe/stripe-react-native/tree/master/example)
+
+## Limitations
+
+### Standalone apps
+
+`@stripe/stripe-react-native` is supported in Expo Go on Android and iOS out of the box, **however**, for iOS, it is only available for standalone apps built with [EAS Build](/build/introduction.md), and not for apps built on the legacy build system- `expo build:ios`. Android apps built with `expo build:android` _will_ have access to the `@stripe/stripe-react-native` library.
+
+### Apple Pay
+
+Apple Pay **is not** supported in Expo Go. To use Apple Pay, you must use either [EAS Build](/build/introduction.md), or run `expo run:ios` in your project directory.
+
+### Google Pay
+
+Google Pay **is not** supported in Expo Go. To use Google Pay, you must use either a standalone app built with `expo build:android` or [EAS Build](/build/introduction.md), or run `expo run:android` in your project directory.

--- a/docs/pages/versions/v41.0.0/sdk/payments.md
+++ b/docs/pages/versions/v41.0.0/sdk/payments.md
@@ -6,6 +6,8 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-41/packages/expo-payments-
 import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
+> **This library is deprecated in favor of [`@stripe/stripe-react-native`](./stripe.md).** [Here's a guide to help make the transition as easy as possible](https://github.com/expo/fyi/blob/master/payments-migration-guide.md#how-to-migrate-from-expo-payments-stripe-to-the-new-stripestripe-react-native-library).
+
 > 🚨 On iOS, the Payments module is currently only supported the [bare workflow](https://docs.expo.io/bare/customizing/).
 
 Payments uses [Stripe](https://stripe.com/) and [Apple Pay](https://www.apple.com/apple-pay/) on iOS, but the module is only available in bare workflow apps.

--- a/docs/pages/versions/v41.0.0/sdk/stripe.md
+++ b/docs/pages/versions/v41.0.0/sdk/stripe.md
@@ -1,0 +1,66 @@
+---
+title: Stripe
+sourceCodeUrl: 'https://github.com/stripe/stripe-react-native'
+---
+
+import InstallSection from '~/components/plugins/InstallSection';
+import PlatformsSection from '~/components/plugins/PlatformsSection';
+import SnackInline from '~/components/plugins/SnackInline';
+
+Expo includes support for [`@stripe/stripe-react-native`](https://github.com/stripe/stripe-react-native), which allows you to build delightful payment experiences in your native Android and iOS apps using React Native & Expo. This library provides powerful and customizable UI screens and elements that can be used out-of-the-box to collect your users' payment details.
+
+> Migrating from Expo's `expo-payments-stripe` module? [Here's a guide to help make the transition as easy as possible](https://github.com/expo/fyi/blob/master/payments-migration-guide.md#how-to-migrate-from-expo-payments-stripe-to-the-new-stripestripe-react-native-library).
+
+<PlatformsSection android emulator ios simulator />
+
+## Installation
+
+<InstallSection packageName="@stripe/stripe-react-native" href="https://github.com/stripe/stripe-react-native" />
+
+### Config plugin setup (optional)
+
+If you're using EAS Build or the bare workflow, you can do most of your Stripe setup using the `@stripe/stripe-react-native` config plugin ([what's a config plugin?](/guides/config-plugins.md)). To setup, just add the config plugin to the `plugins` array of your `app.json` or `app.config.js`:
+
+```json
+{
+  "expo": {
+    ...
+    "plugins": [
+      [
+        "@stripe/stripe-react-native",
+        {
+          "merchantIdentifier": string | string [],
+          "enableGooglePay": boolean
+        }
+      ]
+    ],
+  }
+}
+```
+
+- **merchantIdentifier**: iOS only. This is the Apple merchant ID obtained [here](https://stripe.com/docs/apple-pay?platform=react-native). Otherwise, Apple Pay will not work as expected. If you have multiple merchantIdentifiers, you can set them in an array.
+- **enableGooglePay**: Android only. Boolean indicating whether or not Google Pay is enabled. Defaults to `false`.
+
+Then rebuild the app. If you're using the bare workflow, make sure to run `expo prebuild` first (this will apply the config plugin using [prebuilding](https://expo.fyi/prebuilding)).
+
+## Usage
+
+For usage information and detailed documentation, please refer to:
+
+- [Stripe's React Native SDK reference](https://stripe.dev/stripe-react-native/api-reference/index.html)
+- [Stripe's React Native GitHub repo](https://github.com/stripe/stripe-react-native)
+- [Stripe's example React Native app](https://github.com/stripe/stripe-react-native/tree/master/example)
+
+## Limitations
+
+### Standalone apps
+
+`@stripe/stripe-react-native` is supported in Expo Go on Android and iOS out of the box, **however**, for iOS, it is only available for standalone apps built with [EAS Build](/build/introduction.md), and not for apps built on the legacy build system- `expo build:ios`. Android apps built with `expo build:android` _will_ have access to the `@stripe/stripe-react-native` library.
+
+### Apple Pay
+
+Apple Pay **is not** supported in Expo Go. To use Apple Pay, you must use either [EAS Build](/build/introduction.md), or run `expo run:ios` in your project directory.
+
+### Google Pay
+
+Google Pay **is not** supported in Expo Go. To use Google Pay, you must use either a standalone app built with `expo build:android` or [EAS Build](/build/introduction.md), or run `expo run:android` in your project directory.

--- a/docs/pages/versions/v41.0.0/sdk/tracking-transparency.md
+++ b/docs/pages/versions/v41.0.0/sdk/tracking-transparency.md
@@ -1,6 +1,6 @@
 ---
 title: TrackingTransparency
-sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-tracking-transparency'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-41/packages/expo-tracking-transparency'
 ---
 
 import APISection from '~/components/plugins/APISection';


### PR DESCRIPTION
# Why

patch release brings some goodies. This PR should be merged once production turtle builders have been upgdated

# How

- versioned tracking transparency docs
- create stripe docs
- add deprecation note to `expo-payments-stripe`
