### PR TITLE
[docs] remove top level sections from sidebar in /guides

### DIFF
--- a/docs/components/DocumentationSidebarGroup.tsx
+++ b/docs/components/DocumentationSidebarGroup.tsx
@@ -7,6 +7,7 @@ import { paragraph } from '~/components/base/typography';
 import ChevronDown from '~/components/icons/ChevronDown';
 import * as Constants from '~/constants/theme';
 import { NavigationRoute, Url } from '~/types/common';
+import { unexpandedSections } from '~/constants/navigation';
 
 const STYLES_TITLE = css`
   ${paragraph}
@@ -58,7 +59,7 @@ export default class DocumentationSidebarGroup extends React.Component<Props, { 
 
     // default to always open
     this.state = {
-      isOpen: props.info.name === 'Deprecated' ? isOpen : true,
+      isOpen: unexpandedSections.includes(props.info.name) ? isOpen : true,
     };
   }
 

--- a/docs/components/DocumentationSidebarGroup.tsx
+++ b/docs/components/DocumentationSidebarGroup.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import stripVersionFromPath from '~/common/stripVersionFromPath';
 import { paragraph } from '~/components/base/typography';
 import ChevronDown from '~/components/icons/ChevronDown';
-import { unexpandedSections } from '~/constants/navigation';
+import { collapsedSections } from '~/constants/navigation';
 import * as Constants from '~/constants/theme';
 import { NavigationRoute, Url } from '~/types/common';
 
@@ -59,7 +59,7 @@ export default class DocumentationSidebarGroup extends React.Component<Props, { 
 
     // default to always open
     this.state = {
-      isOpen: unexpandedSections.includes(props.info.name) ? isOpen : true,
+      isOpen: collapsedSections.includes(props.info.name) ? isOpen : true,
     };
   }
 

--- a/docs/components/DocumentationSidebarGroup.tsx
+++ b/docs/components/DocumentationSidebarGroup.tsx
@@ -5,9 +5,9 @@ import * as React from 'react';
 import stripVersionFromPath from '~/common/stripVersionFromPath';
 import { paragraph } from '~/components/base/typography';
 import ChevronDown from '~/components/icons/ChevronDown';
+import { unexpandedSections } from '~/constants/navigation';
 import * as Constants from '~/constants/theme';
 import { NavigationRoute, Url } from '~/types/common';
-import { unexpandedSections } from '~/constants/navigation';
 
 const STYLES_TITLE = css`
   ${paragraph}

--- a/docs/constants/navigation-data.js
+++ b/docs/constants/navigation-data.js
@@ -11,8 +11,7 @@ const { isEasReleased } = require('./FeatureFlags');
 const DIR_MAPPING = {
   introduction: 'Conceptual Overview',
   guides: 'Assorted Guides',
-  'managed-workflow': 'Managed Workflow',
-  bare: 'Essentials',
+  bare: 'Bare Workflow',
   tutorials: 'Tutorials',
   sdk: 'Expo SDK',
   config: 'Configuration Files',

--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -205,8 +205,10 @@ const sections = [
   {
     name: 'Assorted Guides',
     reference: [
+      'Assets',
       'Fonts',
       'Icons',
+      'Routing & Navigation',
       'Permissions',
       'App Icons',
       'Create a Splash Screen',

--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -414,8 +414,13 @@ const ROOT = [
 // These directories will not be placed in the sidebar, but will still be searchable
 const hiddenSections = ['FAQ', 'Troubleshooting'];
 
-//These sections will NOT be expanded by default in the sidebar
-const unexpandedSections = ['Deprecated', 'Regulatory Compliance', 'UI Programming'];
+// These sections will NOT be expanded by default in the sidebar
+const collapsedSections = [
+  'Deprecated',
+  'Regulatory Compliance',
+  'UI Programming',
+  'Technical Specs',
+];
 
 const sortAccordingToReference = (arr, reference) => {
   reference = Array.from(reference).reverse();
@@ -503,5 +508,5 @@ module.exports = {
   eas: sortedEas,
   reference: { ...sortedReference, latest: sortedReference['v' + packageVersion] },
   hiddenSections,
-  unexpandedSections,
+  collapsedSections,
 };

--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -6,17 +6,15 @@ const prevaledNavigationData = require('./navigation-data');
 // Groups -> Sections -> Pages
 const GROUPS = {
   'The Basics': ['Conceptual Overview', 'Get Started', 'Tutorial', 'Next Steps'],
-  'Managed Workflow': [
-    'Fundamentals',
-    'UI Programming',
-    'Assorted Guides',
-    'Push Notifications',
-    'Distributing Your App',
-    'Expo Accounts',
-    'Regulatory Compliance',
-  ],
+  Fundamentals: ['Fundamentals'],
+  'UI Programming': ['UI Programming'],
+  'Assorted Guides': ['Assorted Guides'],
+  'Push Notifications': ['Push Notifications'],
+  'Distributing Your App': ['Distributing Your App'],
+  'Expo Accounts': ['Expo Accounts'],
+  'Regulatory Compliance': ['Regulatory Compliance'],
   Deprecated: ['ExpoKit', 'Archived'],
-  'Bare Workflow': ['Essentials'],
+  'Bare Workflow': ['Bare Workflow'],
   'Expo SDK': ['Expo SDK'],
   'Configuration Files': ['Configuration Files'],
   'React Native': ['React Native'],
@@ -255,9 +253,9 @@ const sections = [
     ],
   },
   {
-    name: 'Essentials',
+    name: 'Bare Workflow',
     reference: [
-      'Bare Workflow Walkthrough',
+      'Walkthrough',
       'Up and Running',
       'Using Libraries',
       'Existing Apps',
@@ -399,13 +397,13 @@ const ROOT = [
   'Tutorial',
   'Conceptual Overview',
   'Fundamentals',
-  'UI Programming',
-  'Assorted Guides',
-  'Push Notifications',
   'Distributing Your App',
   'Expo Accounts',
+  'Bare Workflow',
+  'Push Notifications',
+  'UI Programming',
+  'Assorted Guides',
   'Regulatory Compliance',
-  'Essentials',
   'Configuration Files',
   'Expo SDK',
   'React Native',
@@ -415,6 +413,9 @@ const ROOT = [
 
 // These directories will not be placed in the sidebar, but will still be searchable
 const hiddenSections = ['FAQ', 'Troubleshooting'];
+
+//These sections will NOT be expanded by default in the sidebar
+const unexpandedSections = ['Deprecated', 'Regulatory Compliance', 'Assorted Guides'];
 
 const sortAccordingToReference = (arr, reference) => {
   reference = Array.from(reference).reverse();
@@ -502,4 +503,5 @@ module.exports = {
   eas: sortedEas,
   reference: { ...sortedReference, latest: sortedReference['v' + packageVersion] },
   hiddenSections,
+  unexpandedSections,
 };

--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -205,10 +205,8 @@ const sections = [
   {
     name: 'Assorted Guides',
     reference: [
-      'Assets',
       'Fonts',
       'Icons',
-      'Routing & Navigation',
       'Permissions',
       'App Icons',
       'Create a Splash Screen',
@@ -398,11 +396,11 @@ const ROOT = [
   'Conceptual Overview',
   'Fundamentals',
   'Distributing Your App',
+  'Assorted Guides',
   'Expo Accounts',
   'Bare Workflow',
   'Push Notifications',
   'UI Programming',
-  'Assorted Guides',
   'Regulatory Compliance',
   'Configuration Files',
   'Expo SDK',
@@ -415,7 +413,7 @@ const ROOT = [
 const hiddenSections = ['FAQ', 'Troubleshooting'];
 
 //These sections will NOT be expanded by default in the sidebar
-const unexpandedSections = ['Deprecated', 'Regulatory Compliance', 'Assorted Guides'];
+const unexpandedSections = ['Deprecated', 'Regulatory Compliance', 'UI Programming'];
 
 const sortAccordingToReference = (arr, reference) => {
   reference = Array.from(reference).reverse();

--- a/docs/pages/guides.md
+++ b/docs/pages/guides.md
@@ -5,11 +5,11 @@ hideTOC: true
 
 In the ['Get Started'](/) section we walk through how you can [install Expo tools](get-started/installation.md), [create your first app](get-started/create-a-new-app.md), [guide you through a tutorial](tutorial/planning.md), and give you a [conceptual overview](introduction/managed-vs-bare.md) of what working with Expo tools looks like, the limitations, and common questions folks have.
 
-The guides section of the documentation is oriented towards getting things done: we explain how to use certain tools and how to perform tasks that you may encounter while building your app. The guides are split up into two main sections: managed workflow and bare workflow.
+The guides section of the documentation is oriented towards getting things done: we explain how to use certain tools and how to perform tasks that you may encounter while building your app. The guides are split up into a few sections:
 
-## Managed workflow
+### Fundamentals
 
-In the managed workflow section we discuss topics as they apply specifically to building a managed workflow project ([what's that?](introduction/managed-vs-bare.md)). Some popular topics include:
+In this section we cover the fundamentals of developing with Expo's tools. Some popular topics are:
 
 - [Expo CLI](workflow/expo-cli.md)
 - [Debugging](workflow/debugging.md)
@@ -17,20 +17,62 @@ In the managed workflow section we discuss topics as they apply specifically to 
 - [Android Emulator](workflow/android-studio-emulator.md)
 - [App Icons](guides/app-icons.md)
 - [Splash Screens](guides/splash-screens.md)
+
+### Distributing Your App
+
+In this section we cover topics related to building, shipping, and updating your app with Expo's tools. Some popular topics are:
+
 - [Distributing your App on the App Store and Play Store](distribution/introduction.md)
-- [Configuring Over-the-Air Updates](guides/configuring-ota-updates.md)
+- [App Signing](distribution/app-signing.md)
 - [Release Channels](distribution/release-channels.md)
-- [Push Notifications](push-notifications/overview.md)
-- ....and more. Scroll through the sidebar or press `/` on your keyboard to search the documentation if a particular topic interests you.
 
-## Bare workflow
+### Expo Accounts
 
-The bare workflow section provides less guides than are available in the managed workflow currently, there is more to come here in the near future.
+This section is all about how to best use your Expo account. We cover topics like:
+
+- [Personal Accounts vs Organizations](accounts/account-types.md)
+- [Setting up programmatic access](accounts/programmatic-access.md)
+- [Adding members to your organization](accounts/working-together.md)
+
+### Bare Workflow
+
+In this section, we cover topics specific to the bare workflow:
 
 - [See a walkthrough of the bare workflow](bare/unimodules-full-list.md)
-- [Integrating Expo SDK into an existing React Native app](bare/existing-apps.md)
+- [Integrating the Expo SDK into an existing React Native app](bare/existing-apps.md)
 - [Learn which APIs from the Expo SDK are available in bare React Native apps](bare/unimodules-full-list.md)
 - [Using Expo for web](bare/using-web.md)
+
+### Push Notifications
+
+This section covers all things related to push notifications, including a full walkthrough on setting up your app to use Expo's push notification service, as well as:
+
+- [An FAQ and troubleshooting guide](push-notifications/faq.md)
+- [A guide to sending notifications directly through APNs and FCM](push-notifications/sending-notifications-custom.md)
+
+### UI Programming
+
+This section covers user interface topics such as:
+
+- [Setting a component's background image](ui-programming/image-background.md)
+- [Implementing a checkbox](ui-programming/implementing-a-checkbox.md)
+- [How to display a popup toast](ui-programming/react-native-toast.md)
+
+### Assorted Guides
+
+This section contains guides on various topics, like:
+
+- [Configuring Over-the-Air Updates](guides/configuring-ota-updates.md)
+- [Setting up Routing and Navigation](guides/routing-and-navigation.md)
+- [App Permissions](guides/permissions.md)
+
+### Regulatory Compliance
+
+This section contains information on things like [Data and Privacy protection](regulatory-compliance/data-and-privacy-protection.md), [GDPR](regulatory-compliance/gdpr.md), and [HIPPA](regulatory-compliance/hipaa.md).
+
+### Technical Specs
+
+This section contains technical specifications, such as the [spec for Expo Updates](technical-specs/expo-updates-0.md).
 
 ## Looking for something else?
 


### PR DESCRIPTION
# Why

pretty much all of these sections have content for bare and managed users, not one or the other. Plus in the current state it’s pretty hard to get a handle on the sidebar since it’s just so much content

# How

Removed top level "managed workflow" and "bare workflow" sections
this shows the new order of sections:

<img width="633" alt="Screen Shot 2021-05-21 at 2 06 52 PM" src="https://user-images.githubusercontent.com/35579283/119180075-ccff8000-ba3d-11eb-83d3-3580d33fdfc5.png">

The 'Deprecated', 'Regulatory Compliance', and 'Assorted Guides' sections will be unexpanded by default (first two are very niche docs, the last is basically just our catch-all section)

# Test Plan

`yarn dev`


