### PR TITLE
[docs] quick wins to improve accessibility of the doc

### DIFF
--- a/docs/components/DocumentationHeader.tsx
+++ b/docs/components/DocumentationHeader.tsx
@@ -12,6 +12,7 @@ import {
 import Link from 'next/link';
 import * as React from 'react';
 
+import { VisuallyHidden } from './VisuallyHidden';
 import { MoreHorizontal } from './icons/MoreHorizontal';
 import { SDK } from './icons/SDK';
 import { Search } from './icons/Search';
@@ -29,6 +30,8 @@ const STYLES_LOGO = css`
 const STYLES_UNSTYLED_ANCHOR = css`
   color: inherit;
   text-decoration: none;
+  display: flex;
+  align-items: center;
 `;
 
 const STYLES_TITLE_TEXT = css`
@@ -209,7 +212,6 @@ const SELECT_THEME = css`
   appearance: none;
   background-color: ${theme.background.default};
   cursor: pointer;
-  outline: none;
 `;
 
 const SELECT_THEME_ICON = css`
@@ -283,7 +285,12 @@ function SelectTheme() {
 
   return (
     <div css={SELECT_THEME_CONTAINER}>
+      <VisuallyHidden>
+        <label htmlFor="select-theme">Select your theme</label>
+      </VisuallyHidden>
+
       <select
+        id="select-theme"
         css={SELECT_THEME}
         value={themeName}
         onChange={e => {
@@ -318,14 +325,9 @@ export default class DocumentationHeader extends React.PureComponent<Props> {
             <div css={STYLES_LOGO_CONTAINER}>
               <Link href="/" passHref>
                 <a css={STYLES_UNSTYLED_ANCHOR}>
-                  <span css={STYLES_LOGO}>
+                  <span css={STYLES_LOGO} aria-hidden>
                     <SDK />
                   </span>
-                </a>
-              </Link>
-
-              <Link href="/" passHref>
-                <a css={STYLES_UNSTYLED_ANCHOR}>
                   <h1 css={STYLES_TITLE_TEXT}>Expo</h1>
                 </a>
               </Link>

--- a/docs/components/DocumentationPage.tsx
+++ b/docs/components/DocumentationPage.tsx
@@ -16,6 +16,7 @@ import DocumentationSidebarRight, {
   SidebarRightComponentType,
 } from '~/components/DocumentationSidebarRight';
 import Head from '~/components/Head';
+import { Main, SkipToContent } from '~/components/SkipToContent';
 import { H1 } from '~/components/base/headings';
 import navigation from '~/constants/navigation';
 import * as Constants from '~/constants/theme';
@@ -263,87 +264,93 @@ export default class DocumentationPage extends React.Component<Props, State> {
     const algoliaTag = this.getAlgoliaTag();
 
     return (
-      <DocumentationNestedScrollLayout
-        ref={this.layoutRef}
-        header={headerElement}
-        sidebar={sidebarElement}
-        sidebarRight={sidebarRight}
-        tocVisible={this.props.tocVisible}
-        isMenuActive={this.state.isMenuActive}
-        isMobileSearchActive={this.state.isMobileSearchActive}
-        onContentScroll={handleContentScroll}
-        sidebarScrollPosition={sidebarScrollPosition}>
-        <Head title={`${this.props.title} - Expo Documentation`}>
-          {algoliaTag !== null && <meta name="docsearch:version" content={algoliaTag} />}
-          <meta property="og:title" content={`${this.props.title} - Expo Documentation`} />
-          <meta property="og:type" content="website" />
-          <meta property="og:image" content="https://docs.expo.io/static/images/og.png" />
-          <meta property="og:image:url" content="https://docs.expo.io/static/images/og.png" />
-          <meta
-            property="og:image:secure_url"
-            content="https://docs.expo.io/static/images/og.png"
-          />
-          <meta property="og:locale" content="en_US" />
-          <meta property="og:site_name" content="Expo Documentation" />
-          <meta
-            property="og:description"
-            content="Expo is an open-source platform for making universal native apps for Android, iOS, and the web with JavaScript and React."
-          />
-
-          <meta name="twitter:site" content="@expo" />
-          <meta name="twitter:card" content="summary" />
-          <meta property="twitter:title" content={`${this.props.title} - Expo Documentation`} />
-          <meta
-            name="twitter:description"
-            content="Expo is an open-source platform for making universal native apps for Android, iOS, and the web with JavaScript and React."
-          />
-          <meta property="twitter:image" content="https://docs.expo.io/static/images/twitter.png" />
-
-          {(version === 'unversioned' || this.isPreviewPath()) && (
-            <meta name="robots" content="noindex" />
-          )}
-          {version !== 'unversioned' && <link rel="canonical" href={this.getCanonicalUrl()} />}
-        </Head>
-
-        {!this.state.isMenuActive ? (
-          <div css={STYLES_DOCUMENT}>
-            <H1>{this.props.title}</H1>
-            <DocumentationPageContext.Provider value={{ version }}>
-              {this.props.children}
-            </DocumentationPageContext.Provider>
-            <DocumentationFooter
-              title={this.props.title}
-              url={this.props.url}
-              asPath={this.props.asPath}
-              sourceCodeUrl={this.props.sourceCodeUrl}
+      <>
+        <SkipToContent>Skip to main content</SkipToContent>
+        <DocumentationNestedScrollLayout
+          ref={this.layoutRef}
+          header={headerElement}
+          sidebar={sidebarElement}
+          sidebarRight={sidebarRight}
+          tocVisible={this.props.tocVisible}
+          isMenuActive={this.state.isMenuActive}
+          isMobileSearchActive={this.state.isMobileSearchActive}
+          onContentScroll={handleContentScroll}
+          sidebarScrollPosition={sidebarScrollPosition}>
+          <Head title={`${this.props.title} - Expo Documentation`}>
+            {algoliaTag !== null && <meta name="docsearch:version" content={algoliaTag} />}
+            <meta property="og:title" content={`${this.props.title} - Expo Documentation`} />
+            <meta property="og:type" content="website" />
+            <meta property="og:image" content="https://docs.expo.io/static/images/og.png" />
+            <meta property="og:image:url" content="https://docs.expo.io/static/images/og.png" />
+            <meta
+              property="og:image:secure_url"
+              content="https://docs.expo.io/static/images/og.png"
             />
-          </div>
-        ) : (
-          <div>
-            <div css={[STYLES_DOCUMENT, HIDDEN_ON_MOBILE]}>
+            <meta property="og:locale" content="en_US" />
+            <meta property="og:site_name" content="Expo Documentation" />
+            <meta
+              property="og:description"
+              content="Expo is an open-source platform for making universal native apps for Android, iOS, and the web with JavaScript and React."
+            />
+
+            <meta name="twitter:site" content="@expo" />
+            <meta name="twitter:card" content="summary" />
+            <meta property="twitter:title" content={`${this.props.title} - Expo Documentation`} />
+            <meta
+              name="twitter:description"
+              content="Expo is an open-source platform for making universal native apps for Android, iOS, and the web with JavaScript and React."
+            />
+            <meta
+              property="twitter:image"
+              content="https://docs.expo.io/static/images/twitter.png"
+            />
+
+            {(version === 'unversioned' || this.isPreviewPath()) && (
+              <meta name="robots" content="noindex" />
+            )}
+            {version !== 'unversioned' && <link rel="canonical" href={this.getCanonicalUrl()} />}
+          </Head>
+
+          {!this.state.isMenuActive ? (
+            <Main css={STYLES_DOCUMENT}>
               <H1>{this.props.title}</H1>
               <DocumentationPageContext.Provider value={{ version }}>
                 {this.props.children}
               </DocumentationPageContext.Provider>
               <DocumentationFooter
                 title={this.props.title}
+                url={this.props.url}
                 asPath={this.props.asPath}
                 sourceCodeUrl={this.props.sourceCodeUrl}
               />
-            </div>
-            <div css={HIDDEN_ON_DESKTOP}>
-              <DocumentationSidebar
-                url={this.props.url}
-                asPath={this.props.asPath}
-                routes={routes}
-                version={version}
-                onSetVersion={this.handleSetVersion}
-                isVersionSelectorHidden={!isReferencePath}
-              />
-            </div>
-          </div>
-        )}
-      </DocumentationNestedScrollLayout>
+            </Main>
+          ) : (
+            <Main>
+              <div css={[STYLES_DOCUMENT, HIDDEN_ON_MOBILE]}>
+                <H1>{this.props.title}</H1>
+                <DocumentationPageContext.Provider value={{ version }}>
+                  {this.props.children}
+                </DocumentationPageContext.Provider>
+                <DocumentationFooter
+                  title={this.props.title}
+                  asPath={this.props.asPath}
+                  sourceCodeUrl={this.props.sourceCodeUrl}
+                />
+              </div>
+              <div css={HIDDEN_ON_DESKTOP}>
+                <DocumentationSidebar
+                  url={this.props.url}
+                  asPath={this.props.asPath}
+                  routes={routes}
+                  version={version}
+                  onSetVersion={this.handleSetVersion}
+                  isVersionSelectorHidden={!isReferencePath}
+                />
+              </div>
+            </Main>
+          )}
+        </DocumentationNestedScrollLayout>
+      </>
     );
   }
 }

--- a/docs/components/DocumentationSidebar.tsx
+++ b/docs/components/DocumentationSidebar.tsx
@@ -122,7 +122,7 @@ export default class DocumentationSidebar extends React.Component<Props> {
     };
 
     return (
-      <nav css={STYLES_SIDEBAR} {...customDataAttributes}>
+      <nav css={STYLES_SIDEBAR} {...customDataAttributes} aria-label="The basics">
         {!this.props.isVersionSelectorHidden && (
           <VersionSelector version={this.props.version} onSetVersion={this.props.onSetVersion} />
         )}

--- a/docs/components/DocumentationSidebar.tsx
+++ b/docs/components/DocumentationSidebar.tsx
@@ -122,7 +122,7 @@ export default class DocumentationSidebar extends React.Component<Props> {
     };
 
     return (
-      <nav css={STYLES_SIDEBAR} {...customDataAttributes} aria-label="The basics">
+      <nav css={STYLES_SIDEBAR} {...customDataAttributes} aria-label="Table of contents">
         {!this.props.isVersionSelectorHidden && (
           <VersionSelector version={this.props.version} onSetVersion={this.props.onSetVersion} />
         )}

--- a/docs/components/DocumentationSidebarGroup.tsx
+++ b/docs/components/DocumentationSidebarGroup.tsx
@@ -23,6 +23,8 @@ const STYLES_TITLE = css`
   padding: 8px 16px;
   border-radius: 4px;
   color: ${theme.text.default};
+  width: 100%;
+  border: none;
 
   :hover {
     cursor: pointer;
@@ -124,13 +126,23 @@ export default class DocumentationSidebarGroup extends React.Component<Props, { 
   };
 
   render() {
+    const accordionBtnId = `sidebar-${this.props.info.name.replace(/\s+/g, '-').toLowerCase()}`;
+
     return (
       <div>
-        <a css={STYLES_TITLE} onClick={this.toggleIsOpen}>
+        <button
+          aria-expanded={this.state.isOpen}
+          css={STYLES_TITLE}
+          onClick={this.toggleIsOpen}
+          id={accordionBtnId}>
           {this.props.info.name}
           <ChevronDown size={16} css={this.state.isOpen && STYLES_OPEN_CHEVRON_ICON} />
-        </a>
-        {this.state.isOpen && <div css={STYLES_SIDEBAR_INDENT}>{this.props.children}</div>}
+        </button>
+        {this.state.isOpen && (
+          <section css={STYLES_SIDEBAR_INDENT} aria-labelledby={accordionBtnId}>
+            {this.props.children}
+          </section>
+        )}
       </div>
     );
   }

--- a/docs/components/SkipToContent.tsx
+++ b/docs/components/SkipToContent.tsx
@@ -19,9 +19,9 @@ const SKIP_TO_CONTENT_STYLES = css`
   }
 `;
 
-export interface SkipToContentProps {
+export type SkipToContentProps = {
   children: React.ReactNode;
-}
+};
 
 export const SkipToContent = ({ children }: SkipToContentProps) => {
   return (
@@ -31,9 +31,9 @@ export const SkipToContent = ({ children }: SkipToContentProps) => {
   );
 };
 
-export interface MainProps {
+export type MainProps = {
   children: React.ReactNode;
-}
+};
 
 export const Main = ({ children, ...props }: MainProps) => {
   return (

--- a/docs/components/SkipToContent.tsx
+++ b/docs/components/SkipToContent.tsx
@@ -1,0 +1,44 @@
+import { css } from '@emotion/react';
+import { theme } from '@expo/styleguide';
+import React from 'react';
+
+const SKIP_TO_CONTENT_STYLES = css`
+  text-decoration: none;
+  position: absolute;
+  left: -100%;
+  top: -100%;
+  z-index: 9999;
+  border-radius: 4px;
+
+  background: ${theme.button.tertiary};
+  padding: 8px;
+
+  &:focus {
+    left: 16px;
+    top: 16px;
+  }
+`;
+
+export interface SkipToContentProps {
+  children: React.ReactNode;
+}
+
+export const SkipToContent = ({ children }: SkipToContentProps) => {
+  return (
+    <a href="#main-content" css={SKIP_TO_CONTENT_STYLES}>
+      {children}
+    </a>
+  );
+};
+
+export interface MainProps {
+  children: React.ReactNode;
+}
+
+export const Main = ({ children, ...props }: MainProps) => {
+  return (
+    <main id="main-content" {...props}>
+      {children}
+    </main>
+  );
+};

--- a/docs/components/VisuallyHidden.tsx
+++ b/docs/components/VisuallyHidden.tsx
@@ -1,0 +1,17 @@
+import { css } from '@emotion/react';
+import React from 'react';
+
+const VISUALLY_HIDDEN_STYLES = css`
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+`;
+
+export const VisuallyHidden = (props: React.HTMLAttributes<HTMLElement>) => (
+  <div css={VISUALLY_HIDDEN_STYLES} {...props} />
+);


### PR DESCRIPTION
# Why

Tiny improvements for people not using a mouse or not relying on the sight to navigate.

# How

- Adding tiny wins about semantics
- Labelling field
- "Skip to content"

# Test Plan

I've provided a recorded gif of all the modifications I did in order to provide insights to people that are not used to accessibility tricks

- Some stuff can be verified by tabbing through the website
- Using a screen reader will probably be necessary in order to test the modifications correctly

# Checklist

The following does not apply to my modifications, I think. Let me know if that's not the case 😊 

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).