### PR TITLE
[dev-launcher][android] Reduce crashes when user is spamming deep links

### DIFF
--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
@@ -62,52 +62,78 @@ class DevLauncherController private constructor(
 
   internal var mode = Mode.LAUNCHER
 
+  private var appIsLoading = false
+
   suspend fun loadApp(url: Uri, mainActivity: ReactActivity? = null) {
-    ensureHostWasCleared(appHost, activityToBeInvalidated = mainActivity)
-
-    val manifestParser = DevLauncherManifestParser(httpClient, url)
-    val appIntent = createAppIntent()
-
-    val appLoader = if (!manifestParser.isManifestUrl()) {
-      // It's (maybe) a raw React Native bundle
-      DevLauncherReactNativeAppLoader(url, appHost, context)
-    } else {
-      if (updatesInterface == null) {
-        manifest = manifestParser.parseManifest()
-        if (!manifest!!.isUsingDeveloperTool()) {
-          throw Exception("expo-updates is not properly installed or integrated. In order to load published projects with this development client, follow all installation and setup instructions for both the expo-dev-client and expo-updates packages.")
-        }
-        DevLauncherLocalAppLoader(manifest!!, appHost, context)
-      } else {
-        val configuration = createUpdatesConfigurationWithUrl(url)
-        val update = updatesInterface!!.loadUpdate(configuration, context) {
-          manifest = DevLauncherManifest.fromJson(it.toString().reader())
-          return@loadUpdate !manifest!!.isUsingDeveloperTool()
-        }
-        if (manifest!!.isUsingDeveloperTool()) {
-          DevLauncherLocalAppLoader(manifest!!, appHost, context)
-        } else {
-          useDeveloperSupport = false
-          val localBundlePath = update.launchAssetPath
-          DevLauncherPublishedAppLoader(manifest!!, localBundlePath, appHost, context)
-        }
+    synchronized(this) {
+      if (appIsLoading) {
+        return
       }
+      appIsLoading = true
     }
 
-    val appLoaderListener = appLoader.createOnDelegateWillBeCreatedListener()
-    lifecycle.addListener(appLoaderListener)
-    mode = Mode.APP
+    try {
+      ensureHostWasCleared(appHost, activityToBeInvalidated = mainActivity)
 
-    // Note that `launch` method is a suspend one. So the execution will be stopped here until the method doesn't finish.
-    if (appLoader.launch(appIntent)) {
-      recentlyOpedAppsRegistry.appWasOpened(url, appLoader.getAppName())
-      latestLoadedApp = url
-      // Here the app will be loaded - we can remove listener here.
-      lifecycle.removeListener(appLoaderListener)
-    } else {
-      // The app couldn't be loaded. For now, we just return to the launcher.
-      mode = Mode.LAUNCHER
-      manifest = null
+      val manifestParser = DevLauncherManifestParser(httpClient, url)
+      val appIntent = createAppIntent()
+
+      val appLoader = if (!manifestParser.isManifestUrl()) {
+        // It's (maybe) a raw React Native bundle
+        DevLauncherReactNativeAppLoader(url, appHost, context)
+      } else {
+        if (updatesInterface == null) {
+          manifest = manifestParser.parseManifest()
+          if (!manifest!!.isUsingDeveloperTool()) {
+            throw Exception("expo-updates is not properly installed or integrated. In order to load published projects with this development client, follow all installation and setup instructions for both the expo-dev-client and expo-updates packages.")
+          }
+          DevLauncherLocalAppLoader(manifest!!, appHost, context)
+        } else {
+          val configuration = createUpdatesConfigurationWithUrl(url)
+          val update = updatesInterface!!.loadUpdate(configuration, context) {
+            manifest = DevLauncherManifest.fromJson(it.toString().reader())
+            return@loadUpdate !manifest!!.isUsingDeveloperTool()
+          }
+          if (manifest!!.isUsingDeveloperTool()) {
+            DevLauncherLocalAppLoader(manifest!!, appHost, context)
+          } else {
+            useDeveloperSupport = false
+            val localBundlePath = update.launchAssetPath
+            DevLauncherPublishedAppLoader(manifest!!, localBundlePath, appHost, context)
+          }
+        }
+      }
+
+      val appLoaderListener = appLoader.createOnDelegateWillBeCreatedListener()
+      lifecycle.addListener(appLoaderListener)
+      mode = Mode.APP
+
+      // Note that `launch` method is a suspend one. So the execution will be stopped here until the method doesn't finish.
+      if (appLoader.launch(appIntent)) {
+        recentlyOpedAppsRegistry.appWasOpened(url, appLoader.getAppName())
+        latestLoadedApp = url
+        // Here the app will be loaded - we can remove listener here.
+        lifecycle.removeListener(appLoaderListener)
+      } else {
+        // The app couldn't be loaded. For now, we just return to the launcher.
+        mode = Mode.LAUNCHER
+        manifest = null
+      }
+
+    } catch (e: Exception) {
+      synchronized(this) {
+        appIsLoading = false
+      }
+      throw e
+    }
+  }
+
+  fun onAppLoaded(context: ReactContext) {
+    // App can be started from deep link.
+    // That's why, we maybe need to initialized dev menu here.
+    maybeInitDevMenuDelegate(context)
+    synchronized(this) {
+      appIsLoading = false
     }
   }
 
@@ -115,6 +141,9 @@ class DevLauncherController private constructor(
 
   fun navigateToLauncher() {
     ensureHostWasCleared(appHost)
+    synchronized(this) {
+      appIsLoading = false
+    }
 
     mode = Mode.LAUNCHER
     manifest = null

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
@@ -119,7 +119,6 @@ class DevLauncherController private constructor(
         mode = Mode.LAUNCHER
         manifest = null
       }
-
     } catch (e: Exception) {
       synchronized(this) {
         appIsLoading = false

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/loaders/DevLauncherAppLoader.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/loaders/DevLauncherAppLoader.kt
@@ -51,9 +51,7 @@ abstract class DevLauncherAppLoader(
             return
           }
 
-          // App can be started from deep link.
-          // That's why, we maybe need to initialized dev menu here.
-          DevLauncherController.instance.maybeInitDevMenuDelegate(context)
+          DevLauncherController.instance.onAppLoaded(context)
           onReactContext(context)
           appHost.reactInstanceManager.removeReactInstanceEventListener(this)
           reactContextWasInitialized = true

--- a/packages/expo-dev-launcher/android/src/release/java/expo/modules/devlauncher/DevLauncherController.kt
+++ b/packages/expo-dev-launcher/android/src/release/java/expo/modules/devlauncher/DevLauncherController.kt
@@ -43,6 +43,10 @@ class DevLauncherController private constructor() {
     throw IllegalStateException(DEV_LAUNCHER_IS_NOT_AVAILABLE)
   }
 
+  fun onAppLoaded(context: ReactContext) {
+    throw IllegalStateException(DEV_LAUNCHER_IS_NOT_AVAILABLE) 
+  }
+
   companion object {
     private var sInstance: DevLauncherController? = null
 


### PR DESCRIPTION
# Why

Closes ENG-942.

Reduces app crashes when the user is spamming deep links on Android. Unfortunately, we can't completely remove crashes (because of the RN internal implementation), but now it should happen very rarely.

# How

Added a boolean which holds information whether the app is loading or no. The next app can be loaded only if the previous one was loaded. 

# Test Plan

- open bare-expo and spam `adb shell am start -a android.intent.action.VIEW -d "bareexpo://expo-development-client/?url=exp%3A%2F%2F192.168.0.136%3A19000` in the terminal ✅