### PR TITLE
[dev-menu] Fix actions doesn't dismiss menu

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed actions doesn't dismiss menu. ([#13021](https://github.com/expo/expo/pull/13021) by [@lukmccall](https://github.com/lukmccall))
+
 ### 💡 Others
 
 ## 0.5.2 — 2021-05-20

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed actions doesn't dismiss menu. ([#13021](https://github.com/expo/expo/pull/13021) by [@lukmccall](https://github.com/lukmccall))
+- Fixed actions don't dismiss the dev-menu. ([#13021](https://github.com/expo/expo/pull/13021) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuManager.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuManager.kt
@@ -321,6 +321,7 @@ object DevMenuManager : DevMenuManagerInterface, LifecycleEventListener {
       ?.run {
         if (isAvailable()) {
           action()
+          closeMenu()
         }
         true
       } ?: false

--- a/packages/expo-dev-menu/ios/Interceptors/DevMenuKeyCommandsInterceptor.swift
+++ b/packages/expo-dev-menu/ios/Interceptors/DevMenuKeyCommandsInterceptor.swift
@@ -58,6 +58,7 @@ extension UIResponder: DevMenuUIResponderExtensionProtocol {
       
       if action.isAvailable() {
         action.call()
+        DevMenuManager.shared.closeMenu()
       }
     }
   }


### PR DESCRIPTION
# Why

Closes ENG-1107.

# How

Closed the menu if the user used a shortcut to run an action. 

# Test Plan

- bare-expo ✅