### PR TITLE
[local-authentication][android] Fix promise won't be resolved if the user used a PIN

### DIFF
--- a/packages/expo-local-authentication/CHANGELOG.md
+++ b/packages/expo-local-authentication/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Enable kotlin in all modules. ([#12716](https://github.com/expo/expo/pull/12716) by [@wschurman](https://github.com/wschurman))
+- Fixed `authenticateAsync` not resolving when the user used PIN on some Android devices. ([#13023](https://github.com/expo/expo/pull/13023) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-local-authentication/android/src/main/java/expo/modules/localauthentication/LocalAuthenticationModule.java
+++ b/packages/expo-local-authentication/android/src/main/java/expo/modules/localauthentication/LocalAuthenticationModule.java
@@ -5,12 +5,14 @@ package expo.modules.localauthentication;
 import android.app.Activity;
 import android.app.KeyguardManager;
 import android.content.Context;
+import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.os.Build;
 import android.os.Bundle;
 
 import androidx.biometric.BiometricManager;
 import androidx.biometric.BiometricPrompt;
+import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 
 import java.util.ArrayList;
@@ -22,11 +24,12 @@ import java.util.concurrent.Executors;
 import org.unimodules.core.ExportedModule;
 import org.unimodules.core.ModuleRegistry;
 import org.unimodules.core.Promise;
+import org.unimodules.core.interfaces.ActivityEventListener;
 import org.unimodules.core.interfaces.ActivityProvider;
 import org.unimodules.core.interfaces.ExpoMethod;
 import org.unimodules.core.interfaces.services.UIManager;
 
-public class LocalAuthenticationModule extends ExportedModule {
+public class LocalAuthenticationModule extends ExportedModule implements ActivityEventListener {
   private final BiometricManager mBiometricManager;
   private final PackageManager mPackageManager;
   private BiometricPrompt mBiometricPrompt;
@@ -82,6 +85,7 @@ public class LocalAuthenticationModule extends ExportedModule {
   public void onCreate(ModuleRegistry moduleRegistry) {
     mModuleRegistry = moduleRegistry;
     mUIManager = moduleRegistry.getModule(UIManager.class);
+    mUIManager.registerActivityEventListener(this);
   }
 
   @ExpoMethod
@@ -238,6 +242,25 @@ public class LocalAuthenticationModule extends ExportedModule {
         promise.resolve(null);
       }
     });
+  }
+
+  @Override
+  public void onActivityResult(Activity activity, int requestCode, int resultCode, Intent data) {
+    // If the user uses PIN as an authentication method, the result will be passed to the `onActivityResult`.
+    // Unfortunately, react-native doesn't pass this value to the underlying fragment - we won't resolve the promise.
+    // So we need to do it manually.
+    if (activity instanceof FragmentActivity) {
+      FragmentActivity fragmentActivity = (FragmentActivity) activity;
+      Fragment fragment = fragmentActivity.getSupportFragmentManager().findFragmentByTag("androidx.biometric.BiometricFragment");
+      if (fragment != null) {
+        fragment.onActivityResult(requestCode & 0xffff, resultCode, data);
+      }
+    }
+  }
+
+  @Override
+  public void onNewIntent(Intent intent) {
+    // noop
   }
 
   private boolean isDeviceSecure() {


### PR DESCRIPTION
# Why

Fixed promise won't be resolved if the user used a PIN as an auth method. 

# How

- Passes data from `onActivityResult` to the underlying auth fragment to trigger the `AuthenticationCallback`.

# Test Plan

- bare-expo ✅