### PR TITLE
[gha] remove `install awscli` from android shell app workflow

### DIFF
--- a/.github/workflows/shell-app-android.yml
+++ b/.github/workflows/shell-app-android.yml
@@ -66,7 +66,6 @@ jobs:
         with:
           name: android-shell-app
           path: artifacts/android-shell-builder.tar.gz
-      - run: sudo apt-get install awscli
       - name: Upload shell app tarball to S3
         if: ${{ github.event_name == 'workflow_dispatch' }}
         env:


### PR DESCRIPTION
# Why

awscli comes preinstalled in this env: https://github.com/actions/virtual-environments/blob/releases/ubuntu18/20200726/images/linux/Ubuntu1804-README.md

# How

found https://github.com/expo/expo/pull/9448

# Test Plan

hopefully after this, the workflow won't fail, see https://github.com/expo/expo/actions/runs/871534157
