### PR TITLE
Remove deep imports from plugins

### DIFF
--- a/packages/expo-ads-admob/CHANGELOG.md
+++ b/packages/expo-ads-admob/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- [plugin] Refactor imports ([#13029](https://github.com/expo/expo/pull/13029) by [@EvanBacon](https://github.com/EvanBacon))
+
 ### 🐛 Bug fixes
 
 - Updated `BannerView` on Android to not create a new ad request on every layout change. ([#12599](https://github.com/expo/expo/pull/12599) by [@cruzach](https://github.com/cruzach))

--- a/packages/expo-ads-admob/plugin/build/withAdMobIOS.d.ts
+++ b/packages/expo-ads-admob/plugin/build/withAdMobIOS.d.ts
@@ -1,5 +1,4 @@
-import { ConfigPlugin } from '@expo/config-plugins';
-import { InfoPlist } from '@expo/config-plugins/build/ios/IosConfig.types';
+import { ConfigPlugin, InfoPlist } from '@expo/config-plugins';
 import { ExpoConfig } from '@expo/config-types';
 export declare const withAdMobIOS: ConfigPlugin;
 export declare function getGoogleMobileAdsAppId(config: Pick<ExpoConfig, 'ios'>): string | null;

--- a/packages/expo-ads-admob/plugin/src/withAdMobIOS.ts
+++ b/packages/expo-ads-admob/plugin/src/withAdMobIOS.ts
@@ -1,6 +1,4 @@
-import { ConfigPlugin, withInfoPlist } from '@expo/config-plugins';
-// TODO: export from config-plugins proper
-import { InfoPlist } from '@expo/config-plugins/build/ios/IosConfig.types';
+import { ConfigPlugin, InfoPlist, withInfoPlist } from '@expo/config-plugins';
 import { ExpoConfig } from '@expo/config-types';
 
 export const withAdMobIOS: ConfigPlugin = config => {

--- a/packages/expo-branch/CHANGELOG.md
+++ b/packages/expo-branch/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- [plugin] Refactor imports ([#13029](https://github.com/expo/expo/pull/13029) by [@EvanBacon](https://github.com/EvanBacon))
+
 ### 🐛 Bug fixes
 
 - Enable kotlin in all modules. ([#12716](https://github.com/expo/expo/pull/12716) by [@wschurman](https://github.com/wschurman))

--- a/packages/expo-branch/plugin/build/withBranchAndroid.d.ts
+++ b/packages/expo-branch/plugin/build/withBranchAndroid.d.ts
@@ -1,5 +1,5 @@
-import { AndroidConfig } from '@expo/config-plugins';
+import { AndroidConfig, ConfigPlugin } from '@expo/config-plugins';
 import { ExpoConfig } from '@expo/config-types';
-export declare const withBranchAndroid: import("@expo/config-plugins").ConfigPlugin<void>;
+export declare const withBranchAndroid: ConfigPlugin;
 export declare function getBranchApiKey(config: ExpoConfig): string | null;
 export declare function setBranchApiKey(config: ExpoConfig, androidManifest: AndroidConfig.Manifest.AndroidManifest): AndroidConfig.Manifest.AndroidManifest;

--- a/packages/expo-branch/plugin/build/withBranchAndroid.js
+++ b/packages/expo-branch/plugin/build/withBranchAndroid.js
@@ -2,10 +2,14 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.setBranchApiKey = exports.getBranchApiKey = exports.withBranchAndroid = void 0;
 const config_plugins_1 = require("@expo/config-plugins");
-const android_plugins_1 = require("@expo/config-plugins/build/plugins/android-plugins");
 const { addMetaDataItemToMainApplication, getMainApplicationOrThrow, removeMetaDataItemFromMainApplication, } = config_plugins_1.AndroidConfig.Manifest;
 const META_BRANCH_KEY = 'io.branch.sdk.BranchKey';
-exports.withBranchAndroid = android_plugins_1.createAndroidManifestPlugin(setBranchApiKey, 'withBranchAndroid');
+exports.withBranchAndroid = config => {
+    return config_plugins_1.withAndroidManifest(config, config => {
+        config.modResults = setBranchApiKey(config, config.modResults);
+        return config;
+    });
+};
 function getBranchApiKey(config) {
     var _a, _b, _c, _d;
     return (_d = (_c = (_b = (_a = config.android) === null || _a === void 0 ? void 0 : _a.config) === null || _b === void 0 ? void 0 : _b.branch) === null || _c === void 0 ? void 0 : _c.apiKey) !== null && _d !== void 0 ? _d : null;

--- a/packages/expo-branch/plugin/build/withBranchIOS.d.ts
+++ b/packages/expo-branch/plugin/build/withBranchIOS.d.ts
@@ -1,5 +1,5 @@
-import { InfoPlist } from '@expo/config-plugins/build/ios/IosConfig.types';
+import { ConfigPlugin, InfoPlist } from '@expo/config-plugins';
 import { ExpoConfig } from '@expo/config-types';
-export declare const withBranchIOS: import("@expo/config-plugins").ConfigPlugin<void>;
+export declare const withBranchIOS: ConfigPlugin;
 export declare function getBranchApiKey(config: Pick<ExpoConfig, 'ios'>): string | null;
 export declare function setBranchApiKey(config: Pick<ExpoConfig, 'ios'>, infoPlist: InfoPlist): InfoPlist;

--- a/packages/expo-branch/plugin/build/withBranchIOS.js
+++ b/packages/expo-branch/plugin/build/withBranchIOS.js
@@ -1,8 +1,13 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.setBranchApiKey = exports.getBranchApiKey = exports.withBranchIOS = void 0;
-const ios_plugins_1 = require("@expo/config-plugins/build/plugins/ios-plugins");
-exports.withBranchIOS = ios_plugins_1.createInfoPlistPlugin(setBranchApiKey, 'withBranchIOS');
+const config_plugins_1 = require("@expo/config-plugins");
+exports.withBranchIOS = config => {
+    return config_plugins_1.withInfoPlist(config, config => {
+        config.modResults = setBranchApiKey(config, config.modResults);
+        return config;
+    });
+};
 function getBranchApiKey(config) {
     var _a, _b, _c, _d;
     return (_d = (_c = (_b = (_a = config.ios) === null || _a === void 0 ? void 0 : _a.config) === null || _b === void 0 ? void 0 : _b.branch) === null || _c === void 0 ? void 0 : _c.apiKey) !== null && _d !== void 0 ? _d : null;

--- a/packages/expo-branch/plugin/src/withBranchAndroid.ts
+++ b/packages/expo-branch/plugin/src/withBranchAndroid.ts
@@ -1,5 +1,4 @@
-import { AndroidConfig } from '@expo/config-plugins';
-import { createAndroidManifestPlugin } from '@expo/config-plugins/build/plugins/android-plugins';
+import { AndroidConfig, ConfigPlugin, withAndroidManifest } from '@expo/config-plugins';
 import { ExpoConfig } from '@expo/config-types';
 
 const {
@@ -10,7 +9,12 @@ const {
 
 const META_BRANCH_KEY = 'io.branch.sdk.BranchKey';
 
-export const withBranchAndroid = createAndroidManifestPlugin(setBranchApiKey, 'withBranchAndroid');
+export const withBranchAndroid: ConfigPlugin = config => {
+  return withAndroidManifest(config, config => {
+    config.modResults = setBranchApiKey(config, config.modResults);
+    return config;
+  });
+};
 
 export function getBranchApiKey(config: ExpoConfig) {
   return config.android?.config?.branch?.apiKey ?? null;

--- a/packages/expo-branch/plugin/src/withBranchIOS.ts
+++ b/packages/expo-branch/plugin/src/withBranchIOS.ts
@@ -1,8 +1,12 @@
-import { InfoPlist } from '@expo/config-plugins/build/ios/IosConfig.types';
-import { createInfoPlistPlugin } from '@expo/config-plugins/build/plugins/ios-plugins';
+import { ConfigPlugin, InfoPlist, withInfoPlist } from '@expo/config-plugins';
 import { ExpoConfig } from '@expo/config-types';
 
-export const withBranchIOS = createInfoPlistPlugin(setBranchApiKey, 'withBranchIOS');
+export const withBranchIOS: ConfigPlugin = config => {
+  return withInfoPlist(config, config => {
+    config.modResults = setBranchApiKey(config, config.modResults);
+    return config;
+  });
+};
 
 export function getBranchApiKey(config: Pick<ExpoConfig, 'ios'>) {
   return config.ios?.config?.branch?.apiKey ?? null;

--- a/packages/expo-facebook/CHANGELOG.md
+++ b/packages/expo-facebook/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 🎉 New features
 
+- [plugin] Refactor imports ([#13029](https://github.com/expo/expo/pull/13029) by [@EvanBacon](https://github.com/EvanBacon))
 - [plugin] Ability to disable `NSUserTrackingUsageDescription` by passing `userTrackingPermission: false`. ([#12767](https://github.com/expo/expo/pull/12767) by [@EvanBacon](https://github.com/EvanBacon))
 - [plugin] Bump min target to node 12. ([#12743](https://github.com/expo/expo/pull/12743) by [@EvanBacon](https://github.com/EvanBacon))
 

--- a/packages/expo-facebook/plugin/build/withFacebookAndroid.d.ts
+++ b/packages/expo-facebook/plugin/build/withFacebookAndroid.d.ts
@@ -1,7 +1,7 @@
-import { AndroidConfig } from '@expo/config-plugins';
+import { AndroidConfig, ConfigPlugin } from '@expo/config-plugins';
 import { ExpoConfig } from '@expo/config-types';
-export declare const withFacebookAppIdString: import("@expo/config-plugins").ConfigPlugin<void>;
-export declare const withFacebookManifest: import("@expo/config-plugins").ConfigPlugin<void>;
+export declare const withFacebookAppIdString: ConfigPlugin;
+export declare const withFacebookManifest: ConfigPlugin;
 declare type ExpoConfigFacebook = Pick<ExpoConfig, 'facebookScheme' | 'facebookAdvertiserIDCollectionEnabled' | 'facebookAppId' | 'facebookAutoInitEnabled' | 'facebookAutoLogAppEventsEnabled' | 'facebookDisplayName'>;
 export declare function getFacebookScheme(config: ExpoConfigFacebook): string | null;
 export declare function getFacebookAppId(config: ExpoConfigFacebook): string | null;

--- a/packages/expo-facebook/plugin/build/withFacebookAndroid.js
+++ b/packages/expo-facebook/plugin/build/withFacebookAndroid.js
@@ -5,11 +5,10 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.setFacebookConfig = exports.setFacebookAppIdString = exports.getFacebookAdvertiserIDCollection = exports.getFacebookAutoLogAppEvents = exports.getFacebookAutoInitEnabled = exports.getFacebookDisplayName = exports.getFacebookAppId = exports.getFacebookScheme = exports.withFacebookManifest = exports.withFacebookAppIdString = void 0;
 const config_plugins_1 = require("@expo/config-plugins");
-const Resources_1 = require("@expo/config-plugins/build/android/Resources");
-const Strings_1 = require("@expo/config-plugins/build/android/Strings");
-const android_plugins_1 = require("@expo/config-plugins/build/plugins/android-plugins");
-const XML_1 = require("@expo/config-plugins/build/utils/XML");
 const assert_1 = __importDefault(require("assert"));
+const { buildResourceItem, readResourcesXMLAsync } = config_plugins_1.AndroidConfig.Resources;
+const { getProjectStringsXMLPathAsync, removeStringItem, setStringItem } = config_plugins_1.AndroidConfig.Strings;
+const { writeXMLAsync } = config_plugins_1.XML;
 const { addMetaDataItemToMainApplication, getMainApplicationOrThrow, prefixAndroidKeys, removeMetaDataItemFromMainApplication, } = config_plugins_1.AndroidConfig.Manifest;
 const CUSTOM_TAB_ACTIVITY = 'com.facebook.CustomTabActivity';
 const STRING_FACEBOOK_APP_ID = 'facebook_app_id';
@@ -18,8 +17,18 @@ const META_APP_NAME = 'com.facebook.sdk.ApplicationName';
 const META_AUTO_INIT = 'com.facebook.sdk.AutoInitEnabled';
 const META_AUTO_LOG_APP_EVENTS = 'com.facebook.sdk.AutoLogAppEventsEnabled';
 const META_AD_ID_COLLECTION = 'com.facebook.sdk.AdvertiserIDCollectionEnabled';
-exports.withFacebookAppIdString = android_plugins_1.createStringsXmlPlugin(applyFacebookAppIdString, 'withFacebookAppIdString');
-exports.withFacebookManifest = android_plugins_1.createAndroidManifestPlugin(setFacebookConfig, 'withFacebookManifest');
+exports.withFacebookAppIdString = config => {
+    return config_plugins_1.withStringsXml(config, config => {
+        config.modResults = applyFacebookAppIdString(config, config.modResults);
+        return config;
+    });
+};
+exports.withFacebookManifest = config => {
+    return config_plugins_1.withAndroidManifest(config, config => {
+        config.modResults = setFacebookConfig(config, config.modResults);
+        return config;
+    });
+};
 function buildXMLItem({ head, children, }) {
     return { ...(children !== null && children !== void 0 ? children : {}), $: head };
 }
@@ -108,12 +117,12 @@ function ensureFacebookActivity({ mainApplication, scheme, }) {
     return mainApplication;
 }
 async function setFacebookAppIdString(config, projectRoot) {
-    const stringsPath = await Strings_1.getProjectStringsXMLPathAsync(projectRoot);
+    const stringsPath = await getProjectStringsXMLPathAsync(projectRoot);
     assert_1.default(stringsPath, `There was a problem setting your Facebook App ID in "${stringsPath}"`);
-    let stringsJSON = await Resources_1.readResourcesXMLAsync({ path: stringsPath });
+    let stringsJSON = await readResourcesXMLAsync({ path: stringsPath });
     stringsJSON = applyFacebookAppIdString(config, stringsJSON);
     try {
-        await XML_1.writeXMLAsync({ path: stringsPath, xml: stringsJSON });
+        await writeXMLAsync({ path: stringsPath, xml: stringsJSON });
     }
     catch {
         throw new Error(`Error setting facebookAppId. Cannot write strings.xml to "${stringsPath}"`);
@@ -124,9 +133,9 @@ exports.setFacebookAppIdString = setFacebookAppIdString;
 function applyFacebookAppIdString(config, stringsJSON) {
     const appId = getFacebookAppId(config);
     if (appId) {
-        return Strings_1.setStringItem([Resources_1.buildResourceItem({ name: STRING_FACEBOOK_APP_ID, value: appId })], stringsJSON);
+        return setStringItem([buildResourceItem({ name: STRING_FACEBOOK_APP_ID, value: appId })], stringsJSON);
     }
-    return Strings_1.removeStringItem(STRING_FACEBOOK_APP_ID, stringsJSON);
+    return removeStringItem(STRING_FACEBOOK_APP_ID, stringsJSON);
 }
 function setFacebookConfig(config, androidManifest) {
     const scheme = getFacebookScheme(config);

--- a/packages/expo-facebook/plugin/build/withFacebookIOS.d.ts
+++ b/packages/expo-facebook/plugin/build/withFacebookIOS.d.ts
@@ -1,8 +1,7 @@
-import { ConfigPlugin, IOSConfig } from '@expo/config-plugins';
-import { InfoPlist } from '@expo/config-plugins/build/ios/IosConfig.types';
+import { ConfigPlugin, InfoPlist } from '@expo/config-plugins';
 import { ExpoConfig } from '@expo/config-types';
 declare type ExpoConfigFacebook = Pick<ExpoConfig, 'facebookScheme' | 'facebookAdvertiserIDCollectionEnabled' | 'facebookAppId' | 'facebookAutoInitEnabled' | 'facebookAutoLogAppEventsEnabled' | 'facebookDisplayName'>;
-export declare const withFacebookIOS: ConfigPlugin<void>;
+export declare const withFacebookIOS: ConfigPlugin;
 /**
  * Getters
  * TODO: these getters are the same between ios/android, we could reuse them
@@ -16,8 +15,8 @@ export declare function getFacebookAdvertiserIDCollection(config: ExpoConfigFace
 /**
  * Setters
  */
-export declare function setFacebookConfig(config: ExpoConfigFacebook, infoPlist: InfoPlist): IOSConfig.InfoPlist;
-export declare function setFacebookScheme(config: ExpoConfigFacebook, infoPlist: InfoPlist): IOSConfig.InfoPlist;
+export declare function setFacebookConfig(config: ExpoConfigFacebook, infoPlist: InfoPlist): InfoPlist;
+export declare function setFacebookScheme(config: ExpoConfigFacebook, infoPlist: InfoPlist): InfoPlist;
 export declare function setFacebookAutoInitEnabled(config: ExpoConfigFacebook, { FacebookAutoInitEnabled, ...infoPlist }: InfoPlist): {
     [x: string]: string | number | boolean | import("@expo/json-file").JSONArray | import("@expo/json-file").JSONObject | null | undefined;
     UIStatusBarHidden?: boolean | undefined;

--- a/packages/expo-facebook/plugin/build/withFacebookIOS.js
+++ b/packages/expo-facebook/plugin/build/withFacebookIOS.js
@@ -2,12 +2,16 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.withUserTrackingPermission = exports.setFacebookApplicationQuerySchemes = exports.setFacebookDisplayName = exports.setFacebookAppId = exports.setFacebookAdvertiserIDCollectionEnabled = exports.setFacebookAutoLogAppEventsEnabled = exports.setFacebookAutoInitEnabled = exports.setFacebookScheme = exports.setFacebookConfig = exports.getFacebookAdvertiserIDCollection = exports.getFacebookAutoLogAppEvents = exports.getFacebookAutoInitEnabled = exports.getFacebookDisplayName = exports.getFacebookAppId = exports.getFacebookScheme = exports.withFacebookIOS = void 0;
 const config_plugins_1 = require("@expo/config-plugins");
-const ios_plugins_1 = require("@expo/config-plugins/build/plugins/ios-plugins");
 const { Scheme } = config_plugins_1.IOSConfig;
 const { appendScheme } = Scheme;
 const fbSchemes = ['fbapi', 'fb-messenger-api', 'fbauth2', 'fbshareextension'];
 const USER_TRACKING = 'This identifier will be used to deliver personalized ads to you.';
-exports.withFacebookIOS = ios_plugins_1.createInfoPlistPlugin(setFacebookConfig, 'withFacebookIOS');
+exports.withFacebookIOS = config => {
+    return config_plugins_1.withInfoPlist(config, config => {
+        config.modResults = setFacebookConfig(config, config.modResults);
+        return config;
+    });
+};
 /**
  * Getters
  * TODO: these getters are the same between ios/android, we could reuse them

--- a/packages/expo-facebook/plugin/src/withFacebookAndroid.ts
+++ b/packages/expo-facebook/plugin/src/withFacebookAndroid.ts
@@ -1,26 +1,19 @@
-import { AndroidConfig } from '@expo/config-plugins';
 import {
-  buildResourceItem,
-  readResourcesXMLAsync,
-  ResourceXML,
-} from '@expo/config-plugins/build/android/Resources';
-import {
-  getProjectStringsXMLPathAsync,
-  removeStringItem,
-  setStringItem,
-} from '@expo/config-plugins/build/android/Strings';
-import {
-  createAndroidManifestPlugin,
-  createStringsXmlPlugin,
-} from '@expo/config-plugins/build/plugins/android-plugins';
-import { writeXMLAsync } from '@expo/config-plugins/build/utils/XML';
+  AndroidConfig,
+  ConfigPlugin,
+  withAndroidManifest,
+  withStringsXml,
+  XML,
+} from '@expo/config-plugins';
 import { ExpoConfig } from '@expo/config-types';
 import assert from 'assert';
 
+const { buildResourceItem, readResourcesXMLAsync } = AndroidConfig.Resources;
+const { getProjectStringsXMLPathAsync, removeStringItem, setStringItem } = AndroidConfig.Strings;
+const { writeXMLAsync } = XML;
 const {
   addMetaDataItemToMainApplication,
   getMainApplicationOrThrow,
-
   prefixAndroidKeys,
   removeMetaDataItemFromMainApplication,
 } = AndroidConfig.Manifest;
@@ -33,14 +26,19 @@ const META_AUTO_INIT = 'com.facebook.sdk.AutoInitEnabled';
 const META_AUTO_LOG_APP_EVENTS = 'com.facebook.sdk.AutoLogAppEventsEnabled';
 const META_AD_ID_COLLECTION = 'com.facebook.sdk.AdvertiserIDCollectionEnabled';
 
-export const withFacebookAppIdString = createStringsXmlPlugin(
-  applyFacebookAppIdString,
-  'withFacebookAppIdString'
-);
-export const withFacebookManifest = createAndroidManifestPlugin(
-  setFacebookConfig,
-  'withFacebookManifest'
-);
+export const withFacebookAppIdString: ConfigPlugin = config => {
+  return withStringsXml(config, config => {
+    config.modResults = applyFacebookAppIdString(config, config.modResults);
+    return config;
+  });
+};
+
+export const withFacebookManifest: ConfigPlugin = config => {
+  return withAndroidManifest(config, config => {
+    config.modResults = setFacebookConfig(config, config.modResults);
+    return config;
+  });
+};
 
 function buildXMLItem({
   head,
@@ -162,7 +160,10 @@ export async function setFacebookAppIdString(config: ExpoConfigFacebook, project
   return true;
 }
 
-function applyFacebookAppIdString(config: ExpoConfigFacebook, stringsJSON: ResourceXML) {
+function applyFacebookAppIdString(
+  config: ExpoConfigFacebook,
+  stringsJSON: AndroidConfig.Resources.ResourceXML
+) {
   const appId = getFacebookAppId(config);
 
   if (appId) {

--- a/packages/expo-facebook/plugin/src/withFacebookIOS.ts
+++ b/packages/expo-facebook/plugin/src/withFacebookIOS.ts
@@ -1,6 +1,4 @@
-import { ConfigPlugin, IOSConfig } from '@expo/config-plugins';
-import { InfoPlist } from '@expo/config-plugins/build/ios/IosConfig.types';
-import { createInfoPlistPlugin } from '@expo/config-plugins/build/plugins/ios-plugins';
+import { ConfigPlugin, InfoPlist, IOSConfig, withInfoPlist } from '@expo/config-plugins';
 import { ExpoConfig } from '@expo/config-types';
 
 const { Scheme } = IOSConfig;
@@ -20,7 +18,12 @@ const fbSchemes = ['fbapi', 'fb-messenger-api', 'fbauth2', 'fbshareextension'];
 
 const USER_TRACKING = 'This identifier will be used to deliver personalized ads to you.';
 
-export const withFacebookIOS = createInfoPlistPlugin(setFacebookConfig, 'withFacebookIOS');
+export const withFacebookIOS: ConfigPlugin = config => {
+  return withInfoPlist(config, config => {
+    config.modResults = setFacebookConfig(config, config.modResults);
+    return config;
+  });
+};
 
 /**
  * Getters
@@ -38,6 +41,7 @@ export function getFacebookAppId(config: Pick<ExpoConfigFacebook, 'facebookAppId
 export function getFacebookDisplayName(config: ExpoConfigFacebook) {
   return config.facebookDisplayName ?? null;
 }
+
 export function getFacebookAutoInitEnabled(config: ExpoConfigFacebook) {
   return config.facebookAutoInitEnabled ?? null;
 }

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- [plugin] Refactor imports ([#13029](https://github.com/expo/expo/pull/13029) by [@EvanBacon](https://github.com/EvanBacon))
+
 ### 🐛 Bug fixes
 
 - Enable kotlin in all modules. ([#12716](https://github.com/expo/expo/pull/12716) by [@wschurman](https://github.com/wschurman))
@@ -109,9 +111,11 @@ _This version does not introduce any user-facing changes._
 - Changed class responsible for handling Firebase events from `FirebaseMessagingService` to `.service.NotificationsService` on Android. ([#10558](https://github.com/expo/expo/pull/10558) by [@sjchmiela](https://github.com/sjchmiela))
 
   > Note that this change most probably will not affect you — it only affects projects that override `FirebaseMessagingService` to implement some custom handling logic.
+
 - Changed how you can override ways in which a notification is reinterpreted from a [`StatusBarNotification`](https://developer.android.com/reference/android/service/notification/StatusBarNotification) and in which a [`Notification`](https://developer.android.com/reference/android/app/Notification.html?hl=en) is built from defining an `expo.modules.notifications#NotificationsScoper` meta-data value in `AndroidManifest.xml` to implementing a `BroadcastReceiver` subclassing `NotificationsService` delegating those responsibilities to your custom `PresentationDelegate` instance. ([#10558](https://github.com/expo/expo/pull/10558) by [@sjchmiela](https://github.com/sjchmiela))
 
   > Note that this change most probably will not affect you — it only affects projects that override those methods to implement some custom handling logic.
+
 - Removed `removeAllNotificationListeners` method. You can (and should) still remove listeners using `remove` method on `Subscription` objects returned by `addNotification…Listener`. ([#10883](https://github.com/expo/expo/pull/10883) by [@sjchmiela](https://github.com/sjchmiela))
 - Fixed device identifier being used to fetch Expo push token being backed up on Android which resulted in multiple devices having the same `deviceId` (and eventually, Expo push token). ([#11005](https://github.com/expo/expo/pull/11005) by [@sjchmiela](https://github.com/sjchmiela))
 - Fixed device identifier used when fetching Expo push token being different than `Constants.installationId` in managed workflow apps which resulted in different Expo push tokens returned for the same experience across old and new Expo API and the device push token not being automatically updated on Expo push servers which lead to Expo push tokens corresponding to outdated Firebase tokens. ([#11005](https://github.com/expo/expo/pull/11005) by [@sjchmiela](https://github.com/sjchmiela))

--- a/packages/expo-notifications/plugin/build/withNotificationsAndroid.d.ts
+++ b/packages/expo-notifications/plugin/build/withNotificationsAndroid.d.ts
@@ -8,7 +8,7 @@ export declare const NOTIFICATION_ICON_COLOR = "notification_icon_color";
 export declare const NOTIFICATION_ICON_COLOR_RESOURCE: string;
 export declare const withNotificationIcons: ConfigPlugin;
 export declare const withNotificationIconColor: ConfigPlugin;
-export declare const withNotificationManifest: ConfigPlugin<void>;
+export declare const withNotificationManifest: ConfigPlugin;
 export declare function getNotificationIcon(config: ExpoConfig): string | null;
 export declare function getNotificationColor(config: ExpoConfig): string | null;
 /**

--- a/packages/expo-notifications/plugin/build/withNotificationsAndroid.js
+++ b/packages/expo-notifications/plugin/build/withNotificationsAndroid.js
@@ -5,12 +5,11 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.withNotificationsAndroid = exports.setNotificationIconColorAsync = exports.setNotificationConfigAsync = exports.setNotificationIconAsync = exports.getNotificationColor = exports.getNotificationIcon = exports.withNotificationManifest = exports.withNotificationIconColor = exports.withNotificationIcons = exports.NOTIFICATION_ICON_COLOR_RESOURCE = exports.NOTIFICATION_ICON_COLOR = exports.NOTIFICATION_ICON_RESOURCE = exports.NOTIFICATION_ICON = exports.META_DATA_NOTIFICATION_ICON_COLOR = exports.META_DATA_NOTIFICATION_ICON = void 0;
 const config_plugins_1 = require("@expo/config-plugins");
-const Resources_1 = require("@expo/config-plugins/build/android/Resources");
-const android_plugins_1 = require("@expo/config-plugins/build/plugins/android-plugins");
-const XML_1 = require("@expo/config-plugins/build/utils/XML");
 const image_utils_1 = require("@expo/image-utils");
 const fs_extra_1 = __importDefault(require("fs-extra"));
 const path_1 = __importDefault(require("path"));
+const { buildResourceItem, readResourcesXMLAsync } = config_plugins_1.AndroidConfig.Resources;
+const { writeXMLAsync } = config_plugins_1.XML;
 const { Colors } = config_plugins_1.AndroidConfig;
 const { ANDROID_RES_PATH, dpiValues } = config_plugins_1.AndroidConfig.Icon;
 const { addMetaDataItemToMainApplication, getMainApplicationOrThrow, removeMetaDataItemFromMainApplication, } = config_plugins_1.AndroidConfig.Manifest;
@@ -39,7 +38,12 @@ exports.withNotificationIconColor = config => {
         },
     ]);
 };
-exports.withNotificationManifest = android_plugins_1.createAndroidManifestPlugin(setNotificationConfigAsync, 'withNotificationManifest');
+exports.withNotificationManifest = config => {
+    return config_plugins_1.withAndroidManifest(config, async (config) => {
+        config.modResults = await setNotificationConfigAsync(config, config.modResults);
+        return config;
+    });
+};
 function getNotificationIcon(config) {
     var _a;
     return ((_a = config.notification) === null || _a === void 0 ? void 0 : _a.icon) || null;
@@ -86,15 +90,15 @@ exports.setNotificationConfigAsync = setNotificationConfigAsync;
 async function setNotificationIconColorAsync(config, projectRoot) {
     const color = getNotificationColor(config);
     const colorsXmlPath = await Colors.getProjectColorsXMLPathAsync(projectRoot);
-    let colorsJson = await Resources_1.readResourcesXMLAsync({ path: colorsXmlPath });
+    let colorsJson = await readResourcesXMLAsync({ path: colorsXmlPath });
     if (color) {
-        const colorItemToAdd = Resources_1.buildResourceItem({ name: exports.NOTIFICATION_ICON_COLOR, value: color });
+        const colorItemToAdd = buildResourceItem({ name: exports.NOTIFICATION_ICON_COLOR, value: color });
         colorsJson = Colors.setColorItem(colorItemToAdd, colorsJson);
     }
     else {
         colorsJson = Colors.removeColorItem(exports.NOTIFICATION_ICON_COLOR, colorsJson);
     }
-    await XML_1.writeXMLAsync({ path: colorsXmlPath, xml: colorsJson });
+    await writeXMLAsync({ path: colorsXmlPath, xml: colorsJson });
 }
 exports.setNotificationIconColorAsync = setNotificationIconColorAsync;
 async function writeNotificationIconImageFilesAsync(icon, projectRoot) {

--- a/packages/expo-notifications/plugin/src/withNotificationsAndroid.ts
+++ b/packages/expo-notifications/plugin/src/withNotificationsAndroid.ts
@@ -1,15 +1,17 @@
-import { AndroidConfig, ConfigPlugin, withDangerousMod } from '@expo/config-plugins';
 import {
-  buildResourceItem,
-  readResourcesXMLAsync,
-} from '@expo/config-plugins/build/android/Resources';
-import { createAndroidManifestPlugin } from '@expo/config-plugins/build/plugins/android-plugins';
-import { writeXMLAsync } from '@expo/config-plugins/build/utils/XML';
+  AndroidConfig,
+  ConfigPlugin,
+  withAndroidManifest,
+  withDangerousMod,
+  XML,
+} from '@expo/config-plugins';
 import { ExpoConfig } from '@expo/config-types';
 import { generateImageAsync } from '@expo/image-utils';
 import fs from 'fs-extra';
 import path from 'path';
 
+const { buildResourceItem, readResourcesXMLAsync } = AndroidConfig.Resources;
+const { writeXMLAsync } = XML;
 const { Colors } = AndroidConfig;
 const { ANDROID_RES_PATH, dpiValues } = AndroidConfig.Icon;
 const {
@@ -46,10 +48,12 @@ export const withNotificationIconColor: ConfigPlugin = config => {
   ]);
 };
 
-export const withNotificationManifest = createAndroidManifestPlugin(
-  setNotificationConfigAsync,
-  'withNotificationManifest'
-);
+export const withNotificationManifest: ConfigPlugin = config => {
+  return withAndroidManifest(config, async config => {
+    config.modResults = await setNotificationConfigAsync(config, config.modResults);
+    return config;
+  });
+};
 
 export function getNotificationIcon(config: ExpoConfig) {
   return config.notification?.icon || null;


### PR DESCRIPTION
# Why

Makes it safer to update expo/config-plugins in the future.
- Resolves ENG-78