### PR TITLE
[expo-updates][android] implement UpdatesDevLauncherController

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Remove code to handle nested root level manifest key. ([#12736](https://github.com/expo/expo/pull/12736) by [@wschurman](https://github.com/wschurman))
 - Move scope check from reaper to selection policy. ([#12769](https://github.com/expo/expo/pull/12769) by [@esamelson](https://github.com/esamelson))
 - Add ReaperSelectionPolicyDevelopmentClient, implement in Expo Go. ([#12770](https://github.com/expo/expo/pull/12770) by [@esamelson](https://github.com/esamelson))
+- Add UpdatesDevLauncherController for development client integration. ([#13032](https://github.com/expo/expo/pull/13032) by [@esamelson](https://github.com/esamelson))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-updates/android/build.gradle
+++ b/packages/expo-updates/android/build.gradle
@@ -89,6 +89,7 @@ if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
 dependencies {
   unimodule 'unimodules-core'
   unimodule 'expo-structured-headers'
+  unimodule 'expo-updates-interface'
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.java
@@ -331,7 +331,7 @@ public class UpdatesController {
     notify();
   }
 
-  private void runReaper() {
+  /* package */ void runReaper() {
     AsyncTask.execute(() -> {
       UpdatesDatabase database = getDatabase();
       Reaper.reapUnusedUpdates(mUpdatesConfiguration, database, mUpdatesDirectory, getLaunchedUpdate(), getSelectionPolicy());

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.java
@@ -1,0 +1,116 @@
+package expo.modules.updates;
+
+import android.content.Context;
+
+import androidx.annotation.Nullable;
+
+import org.json.JSONObject;
+
+import java.util.HashMap;
+
+import expo.modules.updates.db.DatabaseHolder;
+import expo.modules.updates.db.entity.AssetEntity;
+import expo.modules.updates.db.entity.UpdateEntity;
+import expo.modules.updates.launcher.DatabaseLauncher;
+import expo.modules.updates.launcher.Launcher;
+import expo.modules.updates.loader.RemoteLoader;
+import expo.modules.updates.manifest.Manifest;
+import expo.modules.updates.selectionpolicy.ReaperSelectionPolicyDevelopmentClient;
+import expo.modules.updates.selectionpolicy.SelectionPolicy;
+import expo.modules.updatesinterface.UpdatesInterface;
+
+public class UpdatesDevLauncherController implements UpdatesInterface {
+
+  private JSONObject mRawManifest;
+
+  public UpdatesDevLauncherController(Context context) {
+    UpdatesController.initializeInternal(context);
+    setDevelopmentSelectionPolicy();
+  }
+
+  private void setDevelopmentSelectionPolicy() {
+    UpdatesController controller = UpdatesController.getInstance();
+    SelectionPolicy currentSelectionPolicy = controller.getSelectionPolicy();
+    controller.setDefaultSelectionPolicy(new SelectionPolicy(
+            currentSelectionPolicy.getLauncherSelectionPolicy(),
+            currentSelectionPolicy.getLoaderSelectionPolicy(),
+            new ReaperSelectionPolicyDevelopmentClient()
+    ));
+  }
+
+  private void reset() {
+    mRawManifest = null;
+  }
+
+  @Override
+  public void fetchUpdateWithConfiguration(HashMap<String, Object> configuration, Context context, UpdateCallback callback) {
+    reset();
+
+    UpdatesController controller = UpdatesController.getInstance();
+    UpdatesConfiguration updatesConfiguration = new UpdatesConfiguration()
+            .loadValuesFromMetadata(context)
+            .loadValuesFromMap(configuration);
+    if (updatesConfiguration.getUpdateUrl() == null) {
+      callback.onFailure(new Exception("Failed to load update: UpdatesConfiguration object must include a valid update URL"));
+      return;
+    }
+    if (controller.getUpdatesDirectory() == null) {
+      callback.onFailure(controller.getUpdatesDirectoryException());
+      return;
+    }
+
+    DatabaseHolder databaseHolder = controller.getDatabaseHolder();
+    RemoteLoader loader = new RemoteLoader(context, updatesConfiguration, databaseHolder.getDatabase(), controller.getFileDownloader(), controller.getUpdatesDirectory());
+    loader.start(new RemoteLoader.LoaderCallback() {
+      @Override
+      public void onFailure(Exception e) {
+        databaseHolder.releaseDatabase();
+        callback.onFailure(e);
+      }
+
+      @Override
+      public void onSuccess(@Nullable UpdateEntity update) {
+        databaseHolder.releaseDatabase();
+        if (update != null) {
+          DatabaseLauncher launcher = new DatabaseLauncher(updatesConfiguration, controller.getUpdatesDirectory(), controller.getFileDownloader(), controller.getSelectionPolicy());
+          launcher.launch(databaseHolder.getDatabase(), context, new Launcher.LauncherCallback() {
+            @Override
+            public void onFailure(Exception e) {
+              databaseHolder.releaseDatabase();
+              callback.onFailure(e);
+            }
+
+            @Override
+            public void onSuccess() {
+              databaseHolder.releaseDatabase();
+              controller.setLauncher(launcher);
+              controller.setUpdatesConfiguration(updatesConfiguration);
+              callback.onSuccess(new Update() {
+                @Override
+                public JSONObject getManifest() {
+                  return mRawManifest;
+                }
+
+                @Override
+                public String getLaunchAssetPath() {
+                  return launcher.getLaunchAssetFile();
+                }
+              });
+            }
+          });
+        }
+      }
+
+      @Override
+      public void onAssetLoaded(AssetEntity asset, int successfulAssetCount, int failedAssetCount, int totalAssetCount) {
+        callback.onProgress(successfulAssetCount, failedAssetCount, totalAssetCount);
+      }
+
+      @Override
+      public boolean onManifestLoaded(Manifest manifest) {
+        mRawManifest = manifest.getRawManifest().getRawJson();
+        return callback.onManifestLoaded(mRawManifest);
+      }
+    });
+  }
+}

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.java
@@ -38,8 +38,6 @@ public class UpdatesDevLauncherController implements UpdatesInterface {
 
   @Override
   public void fetchUpdateWithConfiguration(HashMap<String, Object> configuration, Context context, UpdateCallback callback) {
-    // TODO: call reaper
-
     UpdatesController controller = UpdatesController.getInstance();
     UpdatesConfiguration updatesConfiguration = new UpdatesConfiguration()
             .loadValuesFromMetadata(context)
@@ -110,6 +108,7 @@ public class UpdatesDevLauncherController implements UpdatesInterface {
             return launcher.getLaunchAssetFile();
           }
         });
+        controller.runReaper();
       }
     });
   }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.java
@@ -21,12 +21,25 @@ import expo.modules.updatesinterface.UpdatesInterface;
 
 public class UpdatesDevLauncherController implements UpdatesInterface {
 
-  public UpdatesDevLauncherController(Context context) {
-    UpdatesController.initializeWithoutStarting(context);
-    setDevelopmentSelectionPolicy();
+  private static UpdatesDevLauncherController sInstance;
+
+  public static UpdatesDevLauncherController getInstance() {
+    if (sInstance == null) {
+      throw new IllegalStateException("UpdatesDevLauncherController.getInstance() was called before the module was initialized");
+    }
+    return sInstance;
   }
 
-  private void setDevelopmentSelectionPolicy() {
+  public static UpdatesDevLauncherController initialize(Context context) {
+    if (sInstance == null) {
+      sInstance = new UpdatesDevLauncherController();
+    }
+    UpdatesController.initializeWithoutStarting(context);
+    setDevelopmentSelectionPolicy();
+    return getInstance();
+  }
+
+  private static void setDevelopmentSelectionPolicy() {
     UpdatesController controller = UpdatesController.getInstance();
     SelectionPolicy currentSelectionPolicy = controller.getSelectionPolicy();
     controller.setDefaultSelectionPolicy(new SelectionPolicy(

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.java
@@ -21,8 +21,6 @@ import expo.modules.updatesinterface.UpdatesInterface;
 
 public class UpdatesDevLauncherController implements UpdatesInterface {
 
-  private JSONObject mRawManifest;
-
   public UpdatesDevLauncherController(Context context) {
     UpdatesController.initializeInternal(context);
     setDevelopmentSelectionPolicy();
@@ -38,13 +36,9 @@ public class UpdatesDevLauncherController implements UpdatesInterface {
     ));
   }
 
-  private void reset() {
-    mRawManifest = null;
-  }
-
   @Override
   public void fetchUpdateWithConfiguration(HashMap<String, Object> configuration, Context context, UpdateCallback callback) {
-    reset();
+    // TODO: call reaper
 
     UpdatesController controller = UpdatesController.getInstance();
     UpdatesConfiguration updatesConfiguration = new UpdatesConfiguration()
@@ -88,7 +82,7 @@ public class UpdatesDevLauncherController implements UpdatesInterface {
               callback.onSuccess(new Update() {
                 @Override
                 public JSONObject getManifest() {
-                  return mRawManifest;
+                  return launcher.getLaunchedUpdate().getRawManifest().getRawJson();
                 }
 
                 @Override
@@ -108,8 +102,7 @@ public class UpdatesDevLauncherController implements UpdatesInterface {
 
       @Override
       public boolean onManifestLoaded(Manifest manifest) {
-        mRawManifest = manifest.getRawManifest().getRawJson();
-        return callback.onManifestLoaded(mRawManifest);
+        return callback.onManifestLoaded(manifest.getRawManifest().getRawJson());
       }
     });
   }

--- a/packages/expo-updates/package.json
+++ b/packages/expo-updates/package.json
@@ -37,7 +37,7 @@
     "@expo/metro-config": "^0.1.70",
     "@expo/config-plugins": "^2.0.0",
     "expo-structured-headers": "~1.0.1",
-    "expo-updates-interface": "~1.0.0",
+    "expo-updates-interface": "^0.0.1",
     "fbemitter": "^2.1.1",
     "uuid": "^3.4.0",
     "resolve-from": "^5.0.0"

--- a/packages/expo-updates/package.json
+++ b/packages/expo-updates/package.json
@@ -37,6 +37,7 @@
     "@expo/metro-config": "^0.1.70",
     "@expo/config-plugins": "^2.0.0",
     "expo-structured-headers": "~1.0.1",
+    "expo-updates-interface": "~1.0.0",
     "fbemitter": "^2.1.1",
     "uuid": "^3.4.0",
     "resolve-from": "^5.0.0"


### PR DESCRIPTION
# Why

step 3 of ENG-957 and ENG-958

This PR adds `UpdatesDevLauncherController`, which implements expo-updates-interface's `UpdatesInterface`, to expo-updates.

# How

This is essentially adding a secondary entry point to expo-updates. I decided to implement it internally on top of `UpdatesController` rather than adding a completely separate entry point, as that would require a lot of code duplication and some complicated logic to get the JS module to work correctly with the secondary entry point (since it currently calls into the `UpdatesController` singleton in all bare apps).

- Added an `initializeInternal` method to initialize `UpdatesController` without calling `start` -- this new class is essentially providing a new implementation of `start`.
- Added a few other setters to allow previously internal properties on `UpdatesController` to be set by the new class.
- Added `UpdatesDevLauncherController`, which sets the default selection policy to one with the correct reaper policy, and sets the launcher and configuration properties on `UpdatesController` once it has successfully loaded an update.

# Test Plan

Tested manually by opening both published and locally served projects in the same development client. Additionally, did manual tests to verify that local assets and all the Updates module methods work correctly.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).