### PR TITLE
[docs] Use expo-cli tools

### DIFF
--- a/docs/pages/bare/hello-world.md
+++ b/docs/pages/bare/hello-world.md
@@ -16,7 +16,7 @@ npm i -g expo-cli
 expo init --template bare-minimum
 ```
 
-Next, let's get the project running. Go into your project directory and run `react-native run-ios` or `react-native run-android` &mdash; hurray! Your project is working.
+Next, let's get the project running. Go into your project directory and run `expo run:ios` or `expo run:android` &mdash; hurray! Your project is working.
 
 ## Using react-native-unimodules
 
@@ -64,11 +64,11 @@ This will not yet work because we haven't linked the native code that powers it.
 Bare projects are initialized using [CocoaPods](https://cocoapods.org/), a dependency manager for iOS projects.
 
 - Run `npx pod-install` to link the native iOS packages using CocoaPods.
-- Run `npx react-native run-ios` to rebuild your project with the native code linked.
+- Run `expo run:ios` to rebuild your project with the native code linked.
 
 ### Android configuration
 
-You don't have to do anything, just run the project with `npx react-native run-android`. Once the app is built, press the "Open a web browser" button and watch the browser open. Success! Happy times.
+You don't have to do anything, just run the project with `expo run:android`. Once the app is built, press the "Open a web browser" button and watch the browser open. Success! Happy times.
 
 ## What now?
 

--- a/docs/pages/build-reference/how-tos.md
+++ b/docs/pages/build-reference/how-tos.md
@@ -28,7 +28,7 @@ This is an example of how your package.json might look like:
     "android": "expo run:android",
     "ios": "expo run:ios",
     "web": "expo start --web",
-    "start": "expo start --dev-client",
+    "start": "react-native start",
     "test": "jest"
   },
   "dependencies": {

--- a/docs/pages/build-reference/how-tos.md
+++ b/docs/pages/build-reference/how-tos.md
@@ -25,10 +25,10 @@ This is an example of how your package.json might look like:
     "eas-build-pre-install": "echo 123",
     "eas-build-post-install": "echo 456",
     "eas-build-pre-upload-artifacts": "echo 789",
-    "android": "react-native run-android",
-    "ios": "react-native run-ios",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
     "web": "expo start --web",
-    "start": "react-native start",
+    "start": "expo start --dev-client",
     "test": "jest"
   },
   "dependencies": {

--- a/docs/pages/build-reference/variables.md
+++ b/docs/pages/build-reference/variables.md
@@ -141,10 +141,9 @@ After creating a secret, you can access the value via EAS Build hooks in Node.js
     "android": "expo run:android",
     "ios": "expo run:ios",
     "web": "expo start --web",
-    "start": "expo start --dev-client",
+    "start": "react-native start",
     "test": "jest"
-  },
- ...
+  }
 }
 ```
 

--- a/docs/pages/build-reference/variables.md
+++ b/docs/pages/build-reference/variables.md
@@ -138,10 +138,10 @@ After creating a secret, you can access the value via EAS Build hooks in Node.js
 {
   "scripts": {
     "eas-build-pre-install": "echo $VARIABLE_NAME",
-    "android": "react-native run-android",
-    "ios": "react-native run-ios",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
     "web": "expo start --web",
-    "start": "react-native start",
+    "start": "expo start --dev-client",
     "test": "jest"
   },
  ...

--- a/docs/pages/build/eas-json.md
+++ b/docs/pages/build/eas-json.md
@@ -47,7 +47,7 @@ where `PLATFORM_NAME` is one of `android` or `ios`.
 
 There are two types of build profiles: generic and managed.
 
-**Generic projects** make almost no assumptions about your project's structure. The only requirement is that your project follows the general structure of React Native projects. This means there are `android` and `ios` directories in the root directory with the Gradle and Xcode projects, respectively. Whether you've intialized your project with `expo init --template bare-minimum` or with `npx create-react-native-app`, you can build it with EAS Build.
+**Generic projects** make almost no assumptions about your project's structure. The only requirement is that your project follows the general structure of React Native projects. This means there are `android` and `ios` directories in the root directory with the Gradle and Xcode projects, respectively. Whether you've initialized your project with `expo init --template bare-minimum` or with `npx react-native init`, you can build it with EAS Build.
 
 **Managed projects** are much simpler in terms of the project's structure and the knowledge needed to start developing your application. Those projects don't have the native code in the repository and they are tightly coupled with Expo. Basically, by managed projects, we mean projects initialized with `expo init` using a managed workflow template (like `blank`, `blank-typescript`, or `tabs`).
 

--- a/docs/pages/build/eas-json.md
+++ b/docs/pages/build/eas-json.md
@@ -47,7 +47,7 @@ where `PLATFORM_NAME` is one of `android` or `ios`.
 
 There are two types of build profiles: generic and managed.
 
-**Generic projects** make almost no assumptions about your project's structure. The only requirement is that your project follows the general structure of React Native projects. This means there are `android` and `ios` directories in the root directory with the Gradle and Xcode projects, respectively. Whether you've intialized your project with `expo init --template bare-minimum` or with `npx react-native init`, you can build it with EAS Build.
+**Generic projects** make almost no assumptions about your project's structure. The only requirement is that your project follows the general structure of React Native projects. This means there are `android` and `ios` directories in the root directory with the Gradle and Xcode projects, respectively. Whether you've intialized your project with `expo init --template bare-minimum` or with `npx create-react-native-app`, you can build it with EAS Build.
 
 **Managed projects** are much simpler in terms of the project's structure and the knowledge needed to start developing your application. Those projects don't have the native code in the repository and they are tightly coupled with Expo. Basically, by managed projects, we mean projects initialized with `expo init` using a managed workflow template (like `blank`, `blank-typescript`, or `tabs`).
 

--- a/docs/pages/build/setup.md
+++ b/docs/pages/build/setup.md
@@ -23,7 +23,7 @@ Don't have a project yet? No problem: it's quick and easy to create a "Hello wor
 
 - Install Expo CLI by running `npm install -g expo-cli`.
 - Run `expo init PROJECT_NAME`. Choose the project template that best suits you.
-- EAS Build also works well with projects created by `npx react-native`, `create-react-native-app`, `ignite-cli`, and other project bootstrapping tools.
+- EAS Build also works well with projects created by `npx create-react-native-app`, `npx react-native`, `ignite-cli`, and other project bootstrapping tools.
 
 <ImageSpotlight alt="Terminal running expo init, with minimal (TypeScript) selected" src="/static/images/eas-build/walkthrough/01-init.png" />
 
@@ -99,8 +99,6 @@ The easiest way to try out EAS Build is to create a build that you can run on yo
 
 </p>
 </details>
-
-
 
 - Run `eas build --platform android` to build for Android.
 

--- a/docs/pages/guides/setup-native-firebase.md
+++ b/docs/pages/guides/setup-native-firebase.md
@@ -100,7 +100,7 @@ You are free to use any native Firebase packages such as [react-native-firebase]
   ```groovy
   apply plugin: 'com.google.gms.google-services'
   ```
-- Finally rebuild your native Android app: `yarn react-native run-android`
+- Finally rebuild your native Android app: `expo run:android`
 
 ### iOS
 
@@ -121,7 +121,7 @@ You are free to use any native Firebase packages such as [react-native-firebase]
   - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
       [FIRApp configure];
   ```
-- Rebuild your iOS project to see the changes: `yarn react-native run-ios`
+- Rebuild your iOS project to see the changes: `expo run:ios`
 
 ### Usage with react-native-firebase
 


### PR DESCRIPTION
# Why

- Document using the new expo run commands and `expo start --dev-client`
- Use CRNA.