### PR TITLE
[dev-menu] Integrate javascript inspector

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - Added ability to load published projects via expo-updates on Android. ([#13031](https://github.com/expo/expo/pull/13031) by [@esamelson](https://github.com/esamelson))
+- Support remote JavaScript inspecting. ([#13041](https://github.com/expo/expo/pull/13041) by [@kudo](https://github.com/kudo))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/helpers/DevLauncherReactUtils.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/helpers/DevLauncherReactUtils.kt
@@ -29,12 +29,19 @@ fun injectReactInterceptor(
 
   injectDevSupportManager(reactNativeHost)
 
-  return injectDebugServerHost(
+  val result = injectDebugServerHost(
     context,
     reactNativeHost,
     debugServerHost,
     appBundleName
   )
+
+  // inspector connection will create right after ReactInstanceManager construction,
+  // we should reconnect here to use intercepted inspector server host.
+  reactNativeHost.reactInstanceManager.devSupportManager.stopInspector()
+  reactNativeHost.reactInstanceManager.devSupportManager.startInspector()
+
+  return result
 }
 
 fun injectDevSupportManager(

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/react/DevLauncherPackagerConnectionSettings.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/react/DevLauncherPackagerConnectionSettings.kt
@@ -10,4 +10,6 @@ class DevLauncherPackagerConnectionSettings(
   override fun getDebugServerHost() = serverIp
 
   override fun setDebugServerHost(host: String) = Unit
+
+  override fun getInspectorServerHost() = serverIp
 }

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 ### 🎉 New features
 
-- Add JavaScript runtime information. ([#13041](https://github.com/expo/expo/pull/13041) by [@kudo](https://github.com/kudo))
+- Add JavaScript runtime information. ([#13042](https://github.com/expo/expo/pull/13042) by [@kudo](https://github.com/kudo))
+- Add JavaScript inspector menu item. ([#13041](https://github.com/expo/expo/pull/13041) by [@kudo](https://github.com/kudo))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuManager.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuManager.kt
@@ -34,6 +34,7 @@ import expo.interfaces.devmenu.items.DevMenuScreenItem
 import expo.interfaces.devmenu.items.KeyCommand
 import expo.interfaces.devmenu.items.getItemsOfType
 import expo.modules.devmenu.api.DevMenuExpoApiClient
+import expo.modules.devmenu.api.DevMenuMetroClient
 import expo.modules.devmenu.detectors.ShakeDetector
 import expo.modules.devmenu.detectors.ThreeFingerLongPressDetector
 import expo.modules.devmenu.modules.DevMenuSettings
@@ -42,6 +43,8 @@ import expo.modules.devmenu.websockets.DevMenuCommandHandlersProvider
 import java.lang.ref.WeakReference
 
 object DevMenuManager : DevMenuManagerInterface, LifecycleEventListener {
+  val metroClient: DevMenuMetroClient by lazy { DevMenuMetroClient() }
+
   private var shakeDetector: ShakeDetector? = null
   private var threeFingerLongPressDetector: ThreeFingerLongPressDetector? = null
   private var session: DevMenuSession? = null

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuManager.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuManager.kt
@@ -159,6 +159,12 @@ object DevMenuManager : DevMenuManagerInterface, LifecycleEventListener {
       devMenuHost = DevMenuHost(application)
       UiThreadUtil.runOnUiThread {
         devMenuHost.reactInstanceManager.createReactContextInBackground()
+
+        // Hermes inspector will use latest executed script for Chrome DevTools Protocol.
+        // It will be EXDevMenuApp.android.js in our case.
+        // To let Hermes aware target bundle, we try to reload here as a workaround solution.
+        // @see <a href="https://github.com/facebook/react-native/blob/0.63-stable/ReactCommon/hermes/inspector/Inspector.cpp#L231>code here</a>
+        currentReactInstanceManager.get()?.devSupportManager?.handleReloadJS()
       }
     }
   }

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/api/DevMenuMetroClient.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/api/DevMenuMetroClient.kt
@@ -1,0 +1,37 @@
+package expo.modules.devmenu.api
+
+import android.net.Uri
+import expo.modules.devmenu.helpers.await
+import expo.modules.devmenu.helpers.fetch
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody
+
+
+class DevMenuMetroClient {
+  private val httpClient = OkHttpClient()
+
+  suspend fun queryJSInspectorAvailability(metroHost: String, applicationId: String): Boolean {
+    val url = Uri.parse("$metroHost/inspector")
+      .buildUpon()
+      .appendQueryParameter("applicationId", applicationId)
+      .build()
+    val request = Request.Builder()
+      .get()
+      .url(url.toString())
+      .build()
+    return request.await(httpClient).isSuccessful
+  }
+
+  suspend fun openJSInspector(metroHost: String, applicationId: String) {
+    val url = Uri.parse("$metroHost/inspector")
+      .buildUpon()
+      .appendQueryParameter("applicationId", applicationId)
+      .build()
+    val request = Request.Builder()
+      .put(RequestBody.create(null, ""))
+      .url(url.toString())
+      .build()
+    request.await(httpClient)
+  }
+}

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/extensions/DevMenuExtension.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/extensions/DevMenuExtension.kt
@@ -13,7 +13,9 @@ import expo.interfaces.devmenu.items.DevMenuItemsContainer
 import expo.interfaces.devmenu.items.DevMenuScreen
 import expo.interfaces.devmenu.items.KeyCommand
 import expo.modules.devmenu.DEV_MENU_TAG
+import expo.modules.devmenu.DevMenuManager
 import expo.modules.devmenu.devtools.DevMenuDevToolsDelegate
+import kotlinx.coroutines.runBlocking
 
 class DevMenuExtension(reactContext: ReactApplicationContext)
   : ReactContextBaseJavaModule(reactContext), DevMenuExtensionInterface {
@@ -79,6 +81,21 @@ class DevMenuExtension(reactContext: ReactApplicationContext)
     }
 
     if (devSettings is DevInternalSettings) {
+      action("js-inspector", devDelegate::openJsInspector) {
+        isAvailable = {
+          val metroHost = "http://${devSettings.packagerConnectionSettings.debugServerHost}"
+          var result: Boolean
+          runBlocking {
+            result = DevMenuManager.metroClient
+              .queryJSInspectorAvailability(metroHost, reactApplicationContext.packageName)
+          }
+          result
+        }
+        label = { "Open JavaScript Inspector" }
+        glyphName = { "language-javascript" }
+        importance = DevMenuItemImportance.LOW.value
+      }
+
       val fastRefreshAction = {
         devSettings.isHotModuleReplacementEnabled = !devSettings.isHotModuleReplacementEnabled
       }

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/react/DevMenuPackagerConnectionSettings.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/react/DevMenuPackagerConnectionSettings.kt
@@ -14,4 +14,6 @@ class DevMenuPackagerConnectionSettings(
   override fun getDebugServerHost(): String = serverIp
 
   override fun setDebugServerHost(host: String) = Unit
+
+  override fun getInspectorServerHost() = serverIp
 }

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/websockets/DevMenuCommandHandlersProvider.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/websockets/DevMenuCommandHandlersProvider.kt
@@ -53,6 +53,7 @@ class DevMenuCommandHandlersProvider(
             val activity = instanceManager.currentReactContext?.currentActivity ?: return
             devDelegate.togglePerformanceMonitor(activity)
           }
+          "openJsInspector" -> devDelegate.openJsInspector()
           else -> Log.w("DevMenu", "Unknown command: $command")
         }
       }

--- a/packages/expo-dev-menu/android/src/release/java/expo/modules/devmenu/DevMenuManager.kt
+++ b/packages/expo-dev-menu/android/src/release/java/expo/modules/devmenu/DevMenuManager.kt
@@ -12,11 +12,15 @@ import expo.interfaces.devmenu.DevMenuSessionInterface
 import expo.interfaces.devmenu.DevMenuSettingsInterface
 import expo.interfaces.devmenu.expoapi.DevMenuExpoApiClientInterface
 import expo.interfaces.devmenu.items.DevMenuDataSourceItem
+import expo.modules.devmenu.api.DevMenuMetroClient
 
 private const val DEV_MENU_IS_NOT_AVAILABLE = "DevMenu isn't available in release builds"
 
 object DevMenuManager : DevMenuManagerInterface {
   internal var delegate: DevMenuDelegateInterface? = null
+  val metroClient: DevMenuMetroClient by lazy {
+    throw IllegalStateException(DEV_MENU_IS_NOT_AVAILABLE)
+  }
 
   override fun openMenu(activity: Activity, screen: String?) {
     throw IllegalStateException(DEV_MENU_IS_NOT_AVAILABLE)


### PR DESCRIPTION
# Why

To support hermes inspector in dev-menu

# How

## Add a menu item
in expo/expo-cli#3495, we added `/inspector` endpoint to dev-server which supports querying or opening inspector.
and in this pr, we added a menu item to integrate the function.

js runtime w/ inspector support, the item is enabled. e.g. Hermes.
<img width="50%" src="https://user-images.githubusercontent.com/46429/120075967-0b4c0d80-c0d6-11eb-8f2b-3305c750f397.png">


js runtime w/o inspector support, the item is disabled. e.g. JSC.
<img width="50%" src="https://user-images.githubusercontent.com/46429/120075989-24ed5500-c0d6-11eb-932b-513071d837f6.png">

## dev-menu and dev-launcher fixes

- dev-menu adds an extra EXDevMenuApp bundle which will make sources in inspector missing the target source code.
there is a workaround and see code comment for details.
- the debugging app will create a different connection to metro other than packager. to make dev-launcher works with a remote packager, we should also intercept the inspector connection.



# Test Plan

### BareExpo + JSC
1. use latest expo-cli to run `/path/to/expo-cli/packages/expo-cli/bin/expo.js start --dev-client`
2. expect to show the menu item in disabled state.

### BareExpo + Hermes
1. use latest expo-cli to run `/path/to/expo-cli/packages/expo-cli/bin/expo.js start --dev-client`
2. yarn add 'react-native-reanimated@2.2.0' # Fix inspecting crash issue
3. expect to show the menu item, clicking the item will open an inspector in chrome or edge.
4. expect in the inspector sources tab, there is BareExpo's javascript source code.

### BareSandbox + Hermes
1. use latest expo-cli to run `/path/to/expo-cli/packages/expo-cli/bin/expo.js start --dev-client`
2. yarn add 'react-native-reanimated@2.2.0' # Fix inspecting crash issue
3.  Update `apps/bare-sandbox/android/app/build.gradle` to make `enableHermes: true`
4. adb reverse tcp:8081 --remove # make sure there is no localhost:8081 tunnel for inspector connection
5. expect to show the menu item, clicking the item will open an inspector in chrome or edge.
6. expect in the inspector sources tab, there is BareSandbox's javascript source code.
