### PR TITLE
Update uuid dependency to v8.3.2

### DIFF
--- a/packages/expo-constants/CHANGELOG.md
+++ b/packages/expo-constants/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 - Migrated module interface from `unimodules-constants-interface` to `expo-modules-core`. ([#12876](https://github.com/expo/expo/pull/12876) by [@tsapeta](https://github.com/tsapeta))
 - Build Android code using Java 8 to fix Android instrumented test build error. ([#12939](https://github.com/expo/expo/pull/12939) by [@kudo](https://github.com/kudo))
+- Updated `uuid` dependency to `^8.3.2`.
 
 ## 10.1.3 — 2021-04-13
 

--- a/packages/expo-constants/CHANGELOG.md
+++ b/packages/expo-constants/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 - Migrated module interface from `unimodules-constants-interface` to `expo-modules-core`. ([#12876](https://github.com/expo/expo/pull/12876) by [@tsapeta](https://github.com/tsapeta))
 - Build Android code using Java 8 to fix Android instrumented test build error. ([#12939](https://github.com/expo/expo/pull/12939) by [@kudo](https://github.com/kudo))
-- Updated `uuid` dependency to `^8.3.2`.
+- Updated `uuid` dependency to `^8.3.2`. ([#13043](https://github.com/expo/expo/pull/13043) by [@tsapeta](https://github.com/tsapeta))
 
 ## 10.1.3 — 2021-04-13
 

--- a/packages/expo-constants/package.json
+++ b/packages/expo-constants/package.json
@@ -39,9 +39,10 @@
   "dependencies": {
     "@expo/config": "^3.3.42",
     "expo-modules-core": "~0.0.1",
-    "uuid": "^3.3.2"
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
+    "@types/uuid": "^8.3.0",
     "expo-module-scripts": "^2.0.0"
   }
 }

--- a/packages/expo-contacts/CHANGELOG.md
+++ b/packages/expo-contacts/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Migrated from `unimodules-file-system-interface` and `unimodules-permissions-interface` to `expo-modules-core`. ([#12961](https://github.com/expo/expo/pull/12961) by [@tsapeta](https://github.com/tsapeta))
 - Build Android code using Java 8 to fix Android instrumented test build error. ([#12939](https://github.com/expo/expo/pull/12939) by [@kudo](https://github.com/kudo))
 - Refactored uuid imports to v7 style. ([#13037](https://github.com/expo/expo/pull/13037) by [@giautm](https://github.com/giautm))
+- Updated `uuid` dependency to `^8.3.2`.
 
 ## 9.1.2 — 2021-04-13
 

--- a/packages/expo-contacts/CHANGELOG.md
+++ b/packages/expo-contacts/CHANGELOG.md
@@ -15,7 +15,7 @@
 - Migrated from `unimodules-file-system-interface` and `unimodules-permissions-interface` to `expo-modules-core`. ([#12961](https://github.com/expo/expo/pull/12961) by [@tsapeta](https://github.com/tsapeta))
 - Build Android code using Java 8 to fix Android instrumented test build error. ([#12939](https://github.com/expo/expo/pull/12939) by [@kudo](https://github.com/kudo))
 - Refactored uuid imports to v7 style. ([#13037](https://github.com/expo/expo/pull/13037) by [@giautm](https://github.com/giautm))
-- Updated `uuid` dependency to `^8.3.2`.
+- Updated `uuid` dependency to `^8.3.2`. ([#13043](https://github.com/expo/expo/pull/13043) by [@tsapeta](https://github.com/tsapeta))
 
 ## 9.1.2 — 2021-04-13
 

--- a/packages/expo-contacts/package.json
+++ b/packages/expo-contacts/package.json
@@ -36,10 +36,10 @@
   "dependencies": {
     "@expo/config-plugins": "^1.0.32",
     "expo-modules-core": "~0.0.1",
-    "uuid": "^3.4.0"
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@types/uuid": "^3.4.7",
+    "@types/uuid": "^8.3.0",
     "expo-module-scripts": "^2.0.0"
   }
 }

--- a/packages/expo-document-picker/CHANGELOG.md
+++ b/packages/expo-document-picker/CHANGELOG.md
@@ -15,7 +15,7 @@
 - Migrated from `unimodules-file-system-interface` to `expo-modules-core`.
 - Build Android code using Java 8 to fix Android instrumented test build error. ([#12939](https://github.com/expo/expo/pull/12939) by [@kudo](https://github.com/kudo))
 - Refactored uuid imports to v7 style. ([#13037](https://github.com/expo/expo/pull/13037) by [@giautm](https://github.com/giautm))
-- Updated `uuid` dependency to `^8.3.2`.
+- Updated `uuid` dependency to `^8.3.2`. ([#13043](https://github.com/expo/expo/pull/13043) by [@tsapeta](https://github.com/tsapeta))
 
 ## 9.1.2 — 2021-04-13
 

--- a/packages/expo-document-picker/CHANGELOG.md
+++ b/packages/expo-document-picker/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Migrated from `unimodules-file-system-interface` to `expo-modules-core`.
 - Build Android code using Java 8 to fix Android instrumented test build error. ([#12939](https://github.com/expo/expo/pull/12939) by [@kudo](https://github.com/kudo))
 - Refactored uuid imports to v7 style. ([#13037](https://github.com/expo/expo/pull/13037) by [@giautm](https://github.com/giautm))
+- Updated `uuid` dependency to `^8.3.2`.
 
 ## 9.1.2 — 2021-04-13
 

--- a/packages/expo-document-picker/package.json
+++ b/packages/expo-document-picker/package.json
@@ -37,12 +37,13 @@
   "dependencies": {
     "@expo/config-plugins": "^1.0.32",
     "expo-modules-core": "~0.0.1",
-    "uuid": "^3.3.2"
+    "uuid": "^8.3.2"
   },
   "unimodulePeerDependencies": {
     "@unimodules/core": "*"
   },
   "devDependencies": {
+    "@types/uuid": "^8.3.0",
     "expo-module-scripts": "^2.0.0"
   }
 }

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Migrated from `unimodules-file-system-interface` to `expo-modules-core`.
 - Build Android code using Java 8 to fix Android instrumented test build error. ([#12939](https://github.com/expo/expo/pull/12939) by [@kudo](https://github.com/kudo))
 - Refactored uuid imports to v7 style. ([#13037](https://github.com/expo/expo/pull/13037) by [@giautm](https://github.com/giautm))
+- Updated `uuid` dependency to `^8.3.2`.
 
 ## 11.0.2 — 2021-04-13
 

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -15,7 +15,7 @@
 - Migrated from `unimodules-file-system-interface` to `expo-modules-core`.
 - Build Android code using Java 8 to fix Android instrumented test build error. ([#12939](https://github.com/expo/expo/pull/12939) by [@kudo](https://github.com/kudo))
 - Refactored uuid imports to v7 style. ([#13037](https://github.com/expo/expo/pull/13037) by [@giautm](https://github.com/giautm))
-- Updated `uuid` dependency to `^8.3.2`.
+- Updated `uuid` dependency to `^8.3.2`. ([#13043](https://github.com/expo/expo/pull/13043) by [@tsapeta](https://github.com/tsapeta))
 
 ## 11.0.2 — 2021-04-13
 

--- a/packages/expo-file-system/package.json
+++ b/packages/expo-file-system/package.json
@@ -37,9 +37,10 @@
   "dependencies": {
     "@expo/config-plugins": "^1.0.32",
     "expo-modules-core": "~0.0.1",
-    "uuid": "^3.4.0"
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
+    "@types/uuid": "^8.3.0",
     "expo-module-scripts": "^2.0.0",
     "jest-expo": "~41.0.0"
   }

--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -15,7 +15,7 @@
 ### 💡 Others
 
 - Migrated from `unimodules-file-system-interface` and `unimodules-permissions-interface` to `expo-modules-core`. ([#12961](https://github.com/expo/expo/pull/12961) by [@tsapeta](https://github.com/tsapeta))
-- Updated `uuid` dependency to `^8.3.2`.
+- Updated `uuid` dependency to `^8.3.2`. ([#13043](https://github.com/expo/expo/pull/13043) by [@tsapeta](https://github.com/tsapeta))
 
 ## 10.1.3 — 2021-04-13
 

--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### 💡 Others
 
 - Migrated from `unimodules-file-system-interface` and `unimodules-permissions-interface` to `expo-modules-core`. ([#12961](https://github.com/expo/expo/pull/12961) by [@tsapeta](https://github.com/tsapeta))
+- Updated `uuid` dependency to `^8.3.2`.
 
 ## 10.1.3 — 2021-04-13
 

--- a/packages/expo-image-picker/package.json
+++ b/packages/expo-image-picker/package.json
@@ -42,9 +42,10 @@
     "@expo/config-plugins": "^1.0.32",
     "expo-modules-core": "~0.0.1",
     "expo-permissions": "~12.0.1",
-    "uuid": "7.0.2"
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
+    "@types/uuid": "^8.3.0",
     "expo-module-scripts": "^2.0.0"
   }
 }

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 - Migrated from `unimodules-permissions-interface` to `expo-modules-core`. ([#12961](https://github.com/expo/expo/pull/12961) by [@tsapeta](https://github.com/tsapeta))
 - Refactored uuid imports to v7 style. ([#13037](https://github.com/expo/expo/pull/13037) by [@giautm](https://github.com/giautm))
-- Updated `uuid` dependency to `^8.3.2`.
+- Updated `uuid` dependency to `^8.3.2`. ([#13043](https://github.com/expo/expo/pull/13043) by [@tsapeta](https://github.com/tsapeta))
 
 ## 0.11.5 — 2021-04-13
 

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - Migrated from `unimodules-permissions-interface` to `expo-modules-core`. ([#12961](https://github.com/expo/expo/pull/12961) by [@tsapeta](https://github.com/tsapeta))
 - Refactored uuid imports to v7 style. ([#13037](https://github.com/expo/expo/pull/13037) by [@giautm](https://github.com/giautm))
+- Updated `uuid` dependency to `^8.3.2`.
 
 ## 0.11.5 — 2021-04-13
 

--- a/packages/expo-notifications/package.json
+++ b/packages/expo-notifications/package.json
@@ -52,12 +52,12 @@
     "expo-constants": "10.1.3",
     "expo-modules-core": "~0.0.1",
     "fs-extra": "^9.0.1",
-    "uuid": "^3.4.0"
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@types/fs-extra": "^9.0.6",
     "@types/node-fetch": "^2.5.7",
-    "@types/uuid": "^3.4.7",
+    "@types/uuid": "^8.3.0",
     "expo-module-scripts": "^2.0.0",
     "memfs": "^2.15.5",
     "node-fetch": "^2.6.1"

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -34,7 +34,7 @@
 ### 💡 Others
 
 - Refactored uuid imports to v7 style. ([#13037](https://github.com/expo/expo/pull/13037) by [@giautm](https://github.com/giautm))
-- Updated `uuid` dependency to `^8.3.2`.
+- Updated `uuid` dependency to `^8.3.2`. ([#13043](https://github.com/expo/expo/pull/13043) by [@tsapeta](https://github.com/tsapeta))
 
 ## 0.6.0 — 2021-04-13
 

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -34,6 +34,7 @@
 ### 💡 Others
 
 - Refactored uuid imports to v7 style. ([#13037](https://github.com/expo/expo/pull/13037) by [@giautm](https://github.com/giautm))
+- Updated `uuid` dependency to `^8.3.2`.
 
 ## 0.6.0 — 2021-04-13
 

--- a/packages/expo-updates/package.json
+++ b/packages/expo-updates/package.json
@@ -34,16 +34,17 @@
     "preset": "expo-module-scripts"
   },
   "dependencies": {
-    "@expo/metro-config": "^0.1.68",
     "@expo/config-plugins": "^1.0.32",
+    "@expo/metro-config": "^0.1.68",
     "expo-structured-headers": "~1.0.1",
     "fbemitter": "^2.1.1",
-    "uuid": "^3.4.0",
-    "resolve-from": "^5.0.0"
+    "resolve-from": "^5.0.0",
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
+    "@types/uuid": "^8.3.0",
     "expo-module-scripts": "^2.0.0",
-    "memfs": "^3.2.0",
-    "fs-extra": "^9.1.0"
+    "fs-extra": "^9.1.0",
+    "memfs": "^3.2.0"
   }
 }

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -69,7 +69,7 @@
     "pretty-format": "^26.4.0",
     "react-native-safe-area-context": "3.2.0",
     "serialize-error": "^2.1.0",
-    "uuid": "^3.4.0"
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@types/fbemitter": "^2.0.32",
@@ -77,9 +77,9 @@
     "@types/react": "^16.9.0",
     "@types/react-native": "~0.63.2",
     "@types/react-test-renderer": "16.9.0",
-    "@types/uuid": "^3.4.7",
-    "expo-module-scripts": "^2.0.0",
+    "@types/uuid": "^8.3.0",
     "expo-location": "^12.0.4",
+    "expo-module-scripts": "^2.0.0",
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "react-native": "0.63.2"

--- a/tools/package.json
+++ b/tools/package.json
@@ -40,7 +40,7 @@
     "@types/node": "^10.12.9",
     "@types/server-destroy": "^1.0.0",
     "@types/source-map-support": "^0.4.1",
-    "@types/uuid": "^3.4.4",
+    "@types/uuid": "^8.3.0",
     "@types/ws": "^6.0.1",
     "aws-sdk": "^2.357.0",
     "base-64": "^0.1.0",
@@ -90,7 +90,7 @@
     "terminal-link": "^2.1.1",
     "transformer-proxy": "^0.3.4",
     "typedoc": "^0.20.35",
-    "uuid": "^3.1.0",
+    "uuid": "^8.3.2",
     "ws": "^6.1.0",
     "xcode": "^2.0.0"
   },

--- a/tools/yarn.lock
+++ b/tools/yarn.lock
@@ -3842,12 +3842,10 @@
   dependencies:
     source-map "^0.6.1"
 
-"@types/uuid@^3.4.4":
-  version "3.4.5"
-  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-3.4.5.tgz#d4dc10785b497a1474eae0ba7f0cb09c0ddfd6eb"
-  integrity sha512-MNL15wC3EKyw1VLF+RoVO4hJJdk9t/Hlv3rt1OL65Qvuadm4BYo6g9ZJQqoq7X8NBFSsQXgAujWciovh2lpVjA==
-  dependencies:
-    "@types/node" "*"
+"@types/uuid@^8.3.0":
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.0.tgz#215c231dff736d5ba92410e6d602050cce7e273f"
+  integrity sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==
 
 "@types/webpack-sources@*":
   version "1.4.0"
@@ -16288,7 +16286,7 @@ uuid@3.0.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.0.tgz#6728fc0459c450d796a99c31837569bdf672d728"
   integrity sha1-Zyj8BFnEUNeWqZwxg3VpvfZy1yg=
 
-uuid@3.3.2, uuid@^3.1.0, uuid@^3.2.1, uuid@^3.3.2:
+uuid@3.3.2, uuid@^3.2.1, uuid@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
@@ -16312,6 +16310,11 @@ uuid@^8.0.0:
   version "8.3.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.1.tgz#2ba2e6ca000da60fce5a196954ab241131e05a31"
   integrity sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg==
+
+uuid@^8.3.2:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
 valid-url@~1.0.9:
   version "1.0.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5223,10 +5223,10 @@
   resolved "https://registry.yarnpkg.com/@types/url-parse/-/url-parse-1.4.3.tgz#fba49d90f834951cb000a674efee3d6f20968329"
   integrity sha512-4kHAkbV/OfW2kb5BLVUuUMoumB3CP8rHqlw48aHvFy5tf9ER0AfOonBlX29l/DD68G70DmyhRlSYfQPSYpC5Vw==
 
-"@types/uuid@^3.4.7":
-  version "3.4.9"
-  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-3.4.9.tgz#fcf01997bbc9f7c09ae5f91383af076d466594e1"
-  integrity sha512-XDwyIlt/47l2kWLTzw/mtrpLdB+GPSskR2n/PIcPn+VYhVO77rGhRncIR5GPU0KRzXuqkDO+J5qqrG0Y8P6jzQ==
+"@types/uuid@^8.3.0":
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.0.tgz#215c231dff736d5ba92410e6d602050cce7e273f"
+  integrity sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==
 
 "@types/victory@^31.0.14":
   version "31.0.22"
@@ -20858,11 +20858,6 @@ uuid@3.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
-uuid@7.0.2:
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.2.tgz#7ff5c203467e91f5e0d85cfcbaaf7d2ebbca9be6"
-  integrity sha512-vy9V/+pKG+5ZTYKf+VcphF5Oc6EFiu3W8Nv3P3zIh0EqVI80ZxOzuPfe9EHjkFNvf8+xuTHVeei4Drydlx4zjw==
-
 uuid@^2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.3.tgz#67e2e863797215530dff318e5bf9dcebfd47b21a"
@@ -20878,7 +20873,7 @@ uuid@^7.0.3:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"
   integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==
 
-uuid@^8.0.0:
+uuid@^8.0.0, uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==


### PR DESCRIPTION
# Why

Followup #13037 

# How

Ran `yarn add uuid` and `yarn add --dev @types/uuid` in all packages and tools using this dependency

# Test Plan

SDK and expotools CI jobs should pass (https://github.com/expo/expo/actions?query=branch%3A%40tsapeta%2Fupdate-uuid-dep)

# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).