### PR TITLE
[expo-payments-stripe][android] Fix activity listener which causing unexpected app reloads

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/reactnativestripesdk/StripeSdkModule.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/reactnativestripesdk/StripeSdkModule.kt
@@ -41,7 +41,11 @@ class StripeSdkModule(reactContext: ReactApplicationContext, cardFieldManager: S
   private var confirmPaymentClientSecret: String? = null
 
   private val mActivityEventListener = object : BaseActivityEventListener() {
-    override fun onActivityResult(activity: Activity, requestCode: Int, resultCode: Int, data: Intent) {
+    override fun onActivityResult(activity: Activity, requestCode: Int, resultCode: Int, data: Intent?) {
+      if (!this@StripeSdkModule::stripe.isInitialized) {
+        return
+      }
+
       stripe.onSetupResult(requestCode, data, object : ApiResultCallback<SetupIntentResult> {
         override fun onSuccess(result: SetupIntentResult) {
           val setupIntent = result.intent

--- a/android/versioned-abis/expoview-abi41_0_0/src/main/java/abi41_0_0/host/exp/exponent/modules/api/components/reactnativestripesdk/StripeSdkModule.kt
+++ b/android/versioned-abis/expoview-abi41_0_0/src/main/java/abi41_0_0/host/exp/exponent/modules/api/components/reactnativestripesdk/StripeSdkModule.kt
@@ -41,7 +41,11 @@ class StripeSdkModule(reactContext: ReactApplicationContext, cardFieldManager: S
   private var confirmPaymentClientSecret: String? = null
 
   private val mActivityEventListener = object : BaseActivityEventListener() {
-    override fun onActivityResult(activity: Activity, requestCode: Int, resultCode: Int, data: Intent) {
+    override fun onActivityResult(activity: Activity, requestCode: Int, resultCode: Int, data: Intent?) {
+      if (!this@StripeSdkModule::stripe.isInitialized) {
+        return
+      }
+
       stripe.onSetupResult(requestCode, data, object : ApiResultCallback<SetupIntentResult> {
         override fun onSuccess(result: SetupIntentResult) {
           val setupIntent = result.intent


### PR DESCRIPTION
# Why

The app will reload itself every time if `onActivityResults` is triggered by the system. It's not a behavior we want. This PR fixes it.

# How

- Fixed listener signature. `OnActivityResult` gets a data parameter that can be null.  The kotlin runtime will check that. If someone will pass null to the listener, runtime will throw an exception. 
![image](https://user-images.githubusercontent.com/9578601/119553385-ea18b380-bd9b-11eb-86cd-260e165f1c5b.png)
- In the listener, check if the stripe was initialized.

# Test Plan

- Expo Go ✅