### PR TITLE
[bare-expo] Use hermes runtime

### DIFF
--- a/apps/bare-expo/android/app/build.gradle
+++ b/apps/bare-expo/android/app/build.gradle
@@ -75,7 +75,7 @@ import com.android.build.OutputFile
  */
 
 project.ext.react = [
-    enableHermes: false,  // clean and rebuild if changing
+    enableHermes: JS_RUNTIME == "hermes",  // clean and rebuild if changing
 ]
 
 apply from: "../../node_modules/react-native/react.gradle"

--- a/apps/bare-expo/android/app/build.gradle
+++ b/apps/bare-expo/android/app/build.gradle
@@ -75,7 +75,7 @@ import com.android.build.OutputFile
  */
 
 project.ext.react = [
-    enableHermes: JS_RUNTIME == "hermes",  // clean and rebuild if changing
+    enableHermes: (findProperty('JS_RUNTIME') ?: "hermes") == "hermes",  // clean and rebuild if changing
 ]
 
 apply from: "../../node_modules/react-native/react.gradle"

--- a/apps/bare-expo/android/gradle.properties
+++ b/apps/bare-expo/android/gradle.properties
@@ -20,3 +20,7 @@
 org.gradle.jvmargs=-Xmx10240M -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 android.useAndroidX=true
 android.enableJetifier=true
+
+# The hosted JavaScript runtime
+# Supported values: JS_RUNTIME = "hermes" | "jsc"
+JS_RUNTIME=hermes

--- a/apps/test-suite/TestModules.js
+++ b/apps/test-suite/TestModules.js
@@ -76,6 +76,7 @@ export function getTestModules() {
 
   if (Platform.OS === 'android') {
     modules.push(require('./tests/JSC'));
+    modules.push(require('./tests/Hermes'));
   }
 
   if (global.DETOX) {

--- a/apps/test-suite/tests/Hermes.js
+++ b/apps/test-suite/tests/Hermes.js
@@ -1,0 +1,9 @@
+export const name = 'Hermes';
+
+export function test(t) {
+  t.describe('Hermes', () => {
+    t.it('defines HermesInternal', () => {
+      t.expect(global.HermesInternal).toBeDefined();
+    });
+  });
+}


### PR DESCRIPTION
# Why

Use hermes as default engine for Expo apps

# How

Set JS runtime configuration in `gradle.properties` as @EvanBacon recommended
Will further rely on this configuration to determine if we need to compile hbc during expo export/publish

# Test Plan

Added `apps/test-suite/tests/Hermes.js` and make sure the test passing.

