### PR TITLE
[ci][android] Build only one architecture in client-android

### DIFF
--- a/.github/workflows/client-android.yml
+++ b/.github/workflows/client-android.yml
@@ -103,14 +103,22 @@ jobs:
           ANDROID_KEY_ALIAS: ExponentKey
           ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
           ANDROID_NDK_HOME: /usr/local/lib/android/sdk/ndk/19.2.5345600/
+          IS_RELEASE_BUILD: ${{ github.event.inputs.releaseAPK == 'release-apk' || github.event.inputs.releaseGooglePlay == 'release-google-play' }}
         run: |
+          if [ "$IS_RELEASE_BUILD" == "false" ]; then
+            export NDK_ABI_FILTERS="x86_64"
+            BUILD_TYPE="Debug"
+            echo "Using ABI filters: $NDK_ABI_FILTERS"
+          else
+            BUILD_TYPE="Release"
+          fi
           if [ -z "$ANDROID_KEYSTORE_B64" ]; then
             echo "External build detected, APK will not be signed"
-            bin/fastlane android build build_type:Release sign:false
+            bin/fastlane android build build_type:$BUILD_TYPE sign:false
           else
             echo "Internal build detected, APK will be signed"
             echo $ANDROID_KEYSTORE_B64 | base64 -d > android/app/release-key.jks
-            bin/fastlane android build build_type:Release
+            bin/fastlane android build build_type:$BUILD_TYPE
           fi
       - name: 💾 Upload APK artifact
         uses: actions/upload-artifact@v2
@@ -130,7 +138,7 @@ jobs:
           AWS_ACCESS_KEY_ID: AKIAJ3SWUQ4QLNQC7FXA
           AWS_SECRET_ACCESS_KEY: ${{ secrets.android_client_build_aws_secret_key }}
           EXPO_VERSIONS_SECRET: ${{ secrets.expo_versions_secret }}
-      - name: Upload APK to Google Play and release to production
+      - name: 📤 Upload APK to Google Play and release to production
         if: ${{ github.event.inputs.releaseGooglePlay == 'release-google-play' }}
         run: bin/fastlane android prod_release
         env:

--- a/android/ReactAndroid/src/main/jni/Application.mk
+++ b/android/ReactAndroid/src/main/jni/Application.mk
@@ -5,7 +5,7 @@
 
 APP_BUILD_SCRIPT := Android.mk
 
-APP_ABI := armeabi-v7a x86 arm64-v8a x86_64
+APP_ABI := $(if $(NDK_ABI_FILTERS),$(NDK_ABI_FILTERS),$(armeabi-v7a x86 arm64-v8a x86_64))
 APP_PLATFORM := android-16
 
 APP_MK_DIR := $(dir $(lastword $(MAKEFILE_LIST)))

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -41,6 +41,9 @@ android {
     manifestPlaceholders = [
         'appAuthRedirectScheme': 'host.exp.exponent'
     ]
+    ndk {
+      abiFilters(*(System.getenv('NDK_ABI_FILTERS') ?: 'armeabi-v7a x86 arm64-v8a x86_64').split(' '))
+    }
   }
   dexOptions {
     javaMaxHeapSize System.getenv("DISABLE_DEX_MAX_HEAP") ? null : "8g"

--- a/android/expoview/src/main/JNI/Application.mk
+++ b/android/expoview/src/main/JNI/Application.mk
@@ -1,6 +1,5 @@
-# [expo] We don't want the CI to build only for x86
-# because we build release versions of expoview on CI.
-APP_ABI := armeabi-v7a x86 arm64-v8a x86_64
+
+APP_ABI := $(if $(NDK_ABI_FILTERS),$(NDK_ABI_FILTERS),$(armeabi-v7a x86 arm64-v8a x86_64))
 
 APP_BUILD_SCRIPT := Android.mk
 APP_PLATFORM := android-18

--- a/tools/src/commands/UpdateReactNative.ts
+++ b/tools/src/commands/UpdateReactNative.ts
@@ -1,12 +1,14 @@
-import path from 'path';
-import fs from 'fs-extra';
-import chalk from 'chalk';
 import { Command } from '@expo/commander';
 import spawnAsync from '@expo/spawn-async';
+import chalk from 'chalk';
+import fs from 'fs-extra';
+import path from 'path';
 
 import { EXPO_DIR, ANDROID_DIR } from '../Constants';
-import { getNextSDKVersionAsync } from '../ProjectVersions';
 import { getReactNativeSubmoduleDir } from '../Directories';
+import logger from '../Logger';
+import { getNextSDKVersionAsync } from '../ProjectVersions';
+import { transformFileAsync } from '../Transforms';
 
 type ActionOptions = {
   checkout?: string;
@@ -16,6 +18,7 @@ type ActionOptions = {
 const REACT_NATIVE_SUBMODULE_PATH = getReactNativeSubmoduleDir();
 const REACT_ANDROID_PATH = path.join(ANDROID_DIR, 'ReactAndroid');
 const REACT_COMMON_PATH = path.join(ANDROID_DIR, 'ReactCommon');
+const REACT_APPLICATION_MK_PATH = path.join(REACT_ANDROID_PATH, 'src/main/jni/Application.mk');
 
 async function checkoutReactNativeSubmoduleAsync(checkoutRef: string): Promise<void> {
   await spawnAsync('git', ['fetch'], {
@@ -42,6 +45,19 @@ async function updateReactAndroidAsync(sdkVersion: string): Promise<void> {
     cwd: ANDROID_DIR,
     stdio: 'inherit',
   });
+
+  logger.info(
+    '📇 Transforming',
+    chalk.magenta('Application.mk'),
+    'to make use of',
+    chalk.yellow('NDK_ABI_FILTERS')
+  );
+  await transformFileAsync(REACT_APPLICATION_MK_PATH, [
+    {
+      find: /^APP_ABI := (.*)$/m,
+      replaceWith: 'APP_ABI := $(if $(NDK_ABI_FILTERS),$(NDK_ABI_FILTERS),$($1))',
+    },
+  ]);
 }
 
 async function action(options: ActionOptions) {


### PR DESCRIPTION
# Why

Making CI jobs faster

# How

- Introduced `NDK_ABI_FILTERS` environment variable to control the ABIs used in `Application.mk` files
- Updated `APP_ABI` in `Application.mk` of ReactAndroid and expoview (includes Reanimated)
- If the workflow run is not going to release the APK nor to Google Play store, we use only `x86_64` abi filter
- Changed the default `build_type` to `Debug`
- Added `ndk.abiFilters` to app's `build.gradle`, depending on the `NDK_ABI_FILTERS` env
- Applied appropriate file transformation on ReactAndroid's `Application.mk` in `expotools update-react-native` command

# Test Plan

- CI jobs are passing
- Run `expotools update-react-native` and check that `android/ReactAndroid/src/main/jni/Application.mk` still makes use of `NDK_ABI_FILTERS`
