### PR TITLE
Bump config plugins, config, metro-config, xdl, webpack-config

### DIFF
--- a/packages/expo-ads-admob/package.json
+++ b/packages/expo-ads-admob/package.json
@@ -35,7 +35,7 @@
     "preset": "expo-module-scripts/ios"
   },
   "dependencies": {
-    "@expo/config-plugins": "^1.0.32",
+    "@expo/config-plugins": "^2.0.0",
     "expo-modules-core": "~0.0.2"
   },
   "devDependencies": {

--- a/packages/expo-ads-facebook/package.json
+++ b/packages/expo-ads-facebook/package.json
@@ -31,7 +31,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.io/versions/latest/sdk/facebook-ads/",
   "dependencies": {
-    "@expo/config-plugins": "^1.0.32",
+    "@expo/config-plugins": "^2.0.0",
     "expo-modules-core": "~0.0.2",
     "fbemitter": "^2.1.1",
     "nullthrows": "^1.1.0"

--- a/packages/expo-app-auth/package.json
+++ b/packages/expo-app-auth/package.json
@@ -44,7 +44,7 @@
     "preset": "expo-module-scripts"
   },
   "dependencies": {
-    "@expo/config-plugins": "^1.0.32",
+    "@expo/config-plugins": "^2.0.0",
     "expo-modules-core": "~0.0.2",
     "invariant": "^2.2.4"
   },

--- a/packages/expo-apple-authentication/package.json
+++ b/packages/expo-apple-authentication/package.json
@@ -32,7 +32,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.io/versions/latest/sdk/apple-authentication/",
   "dependencies": {
-    "@expo/config-plugins": "^1.0.32"
+    "@expo/config-plugins": "^2.0.0"
   },
   "devDependencies": {
     "expo-module-scripts": "^2.0.0"

--- a/packages/expo-av/package.json
+++ b/packages/expo-av/package.json
@@ -32,7 +32,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.io/versions/latest/sdk/av/",
   "dependencies": {
-    "@expo/config-plugins": "^1.0.32",
+    "@expo/config-plugins": "^2.0.0",
     "expo-modules-core": "~0.0.2"
   },
   "devDependencies": {

--- a/packages/expo-background-fetch/package.json
+++ b/packages/expo-background-fetch/package.json
@@ -37,7 +37,7 @@
     "unimodules-task-manager-interface": "*"
   },
   "dependencies": {
-    "@expo/config-plugins": "^1.0.32",
+    "@expo/config-plugins": "^2.0.0",
     "expo-task-manager": "~9.1.0"
   },
   "devDependencies": {

--- a/packages/expo-barcode-scanner/package.json
+++ b/packages/expo-barcode-scanner/package.json
@@ -35,7 +35,7 @@
     "preset": "expo-module-scripts/ios"
   },
   "dependencies": {
-    "@expo/config-plugins": "^1.0.32",
+    "@expo/config-plugins": "^2.0.0",
     "expo-modules-core": "~0.0.2"
   },
   "devDependencies": {

--- a/packages/expo-branch/package.json
+++ b/packages/expo-branch/package.json
@@ -32,7 +32,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.io/versions/latest/sdk/branch/",
   "dependencies": {
-    "@expo/config-plugins": "^1.0.32",
+    "@expo/config-plugins": "^2.0.0",
     "react-native-branch": "5.0.0"
   },
   "devDependencies": {

--- a/packages/expo-brightness/package.json
+++ b/packages/expo-brightness/package.json
@@ -35,7 +35,7 @@
     "preset": "expo-module-scripts"
   },
   "dependencies": {
-    "@expo/config-plugins": "^1.0.32",
+    "@expo/config-plugins": "^2.0.0",
     "expo-modules-core": "~0.0.2"
   },
   "devDependencies": {

--- a/packages/expo-calendar/package.json
+++ b/packages/expo-calendar/package.json
@@ -35,7 +35,7 @@
     "preset": "expo-module-scripts/ios"
   },
   "dependencies": {
-    "@expo/config-plugins": "^1.0.32",
+    "@expo/config-plugins": "^2.0.0",
     "expo-modules-core": "~0.0.2"
   },
   "devDependencies": {

--- a/packages/expo-camera/package.json
+++ b/packages/expo-camera/package.json
@@ -34,7 +34,7 @@
     "preset": "expo-module-scripts"
   },
   "dependencies": {
-    "@expo/config-plugins": "^1.0.32",
+    "@expo/config-plugins": "^2.0.0",
     "@koale/useworker": "^3.2.1",
     "expo-modules-core": "~0.0.2",
     "invariant": "2.2.4"

--- a/packages/expo-constants/package.json
+++ b/packages/expo-constants/package.json
@@ -37,7 +37,7 @@
     "@unimodules/core": "*"
   },
   "dependencies": {
-    "@expo/config": "^3.3.42",
+    "@expo/config": "^4.0.0",
     "expo-modules-core": "~0.0.2",
     "uuid": "^3.3.2"
   },

--- a/packages/expo-contacts/package.json
+++ b/packages/expo-contacts/package.json
@@ -34,7 +34,7 @@
     "preset": "expo-module-scripts"
   },
   "dependencies": {
-    "@expo/config-plugins": "^1.0.32",
+    "@expo/config-plugins": "^2.0.0",
     "expo-modules-core": "~0.0.2",
     "uuid": "^3.4.0"
   },

--- a/packages/expo-dev-client/package.json
+++ b/packages/expo-dev-client/package.json
@@ -30,7 +30,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.io/versions/latest/sdk/module-template",
   "dependencies": {
-    "@expo/config-plugins": "^1.0.32",
+    "@expo/config-plugins": "^2.0.0",
     "expo-dev-launcher": "~0.3.4",
     "expo-dev-menu": "~0.5.2",
     "expo-dev-menu-interface": "~0.3.1"

--- a/packages/expo-dev-launcher/package.json
+++ b/packages/expo-dev-launcher/package.json
@@ -28,7 +28,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.io",
   "dependencies": {
-    "@expo/config-plugins": "^1.0.32"
+    "@expo/config-plugins": "^2.0.0"
   },
   "devDependencies": {
     "babel-preset-expo": "~8.3.0",

--- a/packages/expo-dev-menu/package.json
+++ b/packages/expo-dev-menu/package.json
@@ -41,7 +41,7 @@
     "preset": "expo-module-scripts"
   },
   "dependencies": {
-    "@expo/config-plugins": "^1.0.32",
+    "@expo/config-plugins": "^2.0.0",
     "expo-dev-menu-interface": "0.3.1"
   },
   "devDependencies": {

--- a/packages/expo-document-picker/package.json
+++ b/packages/expo-document-picker/package.json
@@ -35,7 +35,7 @@
     "preset": "expo-module-scripts/ios"
   },
   "dependencies": {
-    "@expo/config-plugins": "^1.0.32",
+    "@expo/config-plugins": "^2.0.0",
     "expo-modules-core": "~0.0.2",
     "uuid": "^3.3.2"
   },

--- a/packages/expo-facebook/package.json
+++ b/packages/expo-facebook/package.json
@@ -40,7 +40,7 @@
     "expo-module-scripts": "^2.0.0"
   },
   "dependencies": {
-    "@expo/config-plugins": "^1.0.32",
+    "@expo/config-plugins": "^2.0.0",
     "expo-modules-core": "~0.0.2"
   }
 }

--- a/packages/expo-file-system/package.json
+++ b/packages/expo-file-system/package.json
@@ -35,7 +35,7 @@
     "preset": "expo-module-scripts"
   },
   "dependencies": {
-    "@expo/config-plugins": "^1.0.32",
+    "@expo/config-plugins": "^2.0.0",
     "expo-modules-core": "~0.0.2",
     "uuid": "^3.4.0"
   },

--- a/packages/expo-image-picker/package.json
+++ b/packages/expo-image-picker/package.json
@@ -39,7 +39,7 @@
     "@unimodules/core": "*"
   },
   "dependencies": {
-    "@expo/config-plugins": "^1.0.32",
+    "@expo/config-plugins": "^2.0.0",
     "expo-modules-core": "~0.0.2",
     "expo-permissions": "~12.0.1",
     "uuid": "7.0.2"

--- a/packages/expo-local-authentication/package.json
+++ b/packages/expo-local-authentication/package.json
@@ -38,7 +38,7 @@
     "preset": "expo-module-scripts"
   },
   "dependencies": {
-    "@expo/config-plugins": "^1.0.32",
+    "@expo/config-plugins": "^2.0.0",
     "invariant": "^2.2.4"
   },
   "devDependencies": {

--- a/packages/expo-location/package.json
+++ b/packages/expo-location/package.json
@@ -42,7 +42,7 @@
     "expo-module-scripts": "^2.0.0"
   },
   "dependencies": {
-    "@expo/config-plugins": "^1.0.32",
+    "@expo/config-plugins": "^2.0.0",
     "expo-modules-core": "~0.0.2"
   }
 }

--- a/packages/expo-media-library/package.json
+++ b/packages/expo-media-library/package.json
@@ -38,7 +38,7 @@
     "preset": "expo-module-scripts/ios"
   },
   "dependencies": {
-    "@expo/config-plugins": "^1.0.32",
+    "@expo/config-plugins": "^2.0.0",
     "expo-modules-core": "~0.0.2"
   },
   "devDependencies": {

--- a/packages/expo-notifications/package.json
+++ b/packages/expo-notifications/package.json
@@ -42,7 +42,7 @@
     "expo-constants": ">=9.3.3 <11.0.0"
   },
   "dependencies": {
-    "@expo/config-plugins": "^1.0.32",
+    "@expo/config-plugins": "^2.0.0",
     "@expo/image-utils": "^0.3.10",
     "@ide/backoff": "^1.0.0",
     "abort-controller": "^3.0.0",

--- a/packages/expo-notifications/plugin/build/withNotificationsAndroid.d.ts
+++ b/packages/expo-notifications/plugin/build/withNotificationsAndroid.d.ts
@@ -1,5 +1,12 @@
 import { AndroidConfig, ConfigPlugin } from '@expo/config-plugins';
 import { ExpoConfig } from '@expo/config-types';
+declare type DPIString = 'mdpi' | 'hdpi' | 'xhdpi' | 'xxhdpi' | 'xxxhdpi';
+declare type dpiMap = Record<DPIString, {
+    folderName: string;
+    scale: number;
+}>;
+export declare const ANDROID_RES_PATH = "android/app/src/main/res/";
+export declare const dpiValues: dpiMap;
 export declare const META_DATA_NOTIFICATION_ICON = "expo.modules.notifications.default_notification_icon";
 export declare const META_DATA_NOTIFICATION_ICON_COLOR = "expo.modules.notifications.default_notification_color";
 export declare const NOTIFICATION_ICON = "notification_icon";
@@ -19,3 +26,4 @@ export declare function setNotificationIconAsync(config: ExpoConfig, projectRoot
 export declare function setNotificationConfigAsync(config: ExpoConfig, manifest: AndroidConfig.Manifest.AndroidManifest): Promise<AndroidConfig.Manifest.AndroidManifest>;
 export declare function setNotificationIconColorAsync(config: ExpoConfig, projectRoot: string): Promise<void>;
 export declare const withNotificationsAndroid: ConfigPlugin;
+export {};

--- a/packages/expo-notifications/plugin/build/withNotificationsAndroid.js
+++ b/packages/expo-notifications/plugin/build/withNotificationsAndroid.js
@@ -3,7 +3,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.withNotificationsAndroid = exports.setNotificationIconColorAsync = exports.setNotificationConfigAsync = exports.setNotificationIconAsync = exports.getNotificationColor = exports.getNotificationIcon = exports.withNotificationManifest = exports.withNotificationIconColor = exports.withNotificationIcons = exports.NOTIFICATION_ICON_COLOR_RESOURCE = exports.NOTIFICATION_ICON_COLOR = exports.NOTIFICATION_ICON_RESOURCE = exports.NOTIFICATION_ICON = exports.META_DATA_NOTIFICATION_ICON_COLOR = exports.META_DATA_NOTIFICATION_ICON = void 0;
+exports.withNotificationsAndroid = exports.setNotificationIconColorAsync = exports.setNotificationConfigAsync = exports.setNotificationIconAsync = exports.getNotificationColor = exports.getNotificationIcon = exports.withNotificationManifest = exports.withNotificationIconColor = exports.withNotificationIcons = exports.NOTIFICATION_ICON_COLOR_RESOURCE = exports.NOTIFICATION_ICON_COLOR = exports.NOTIFICATION_ICON_RESOURCE = exports.NOTIFICATION_ICON = exports.META_DATA_NOTIFICATION_ICON_COLOR = exports.META_DATA_NOTIFICATION_ICON = exports.dpiValues = exports.ANDROID_RES_PATH = void 0;
 const config_plugins_1 = require("@expo/config-plugins");
 const image_utils_1 = require("@expo/image-utils");
 const fs_extra_1 = __importDefault(require("fs-extra"));
@@ -11,7 +11,14 @@ const path_1 = __importDefault(require("path"));
 const { buildResourceItem, readResourcesXMLAsync } = config_plugins_1.AndroidConfig.Resources;
 const { writeXMLAsync } = config_plugins_1.XML;
 const { Colors } = config_plugins_1.AndroidConfig;
-const { ANDROID_RES_PATH, dpiValues } = config_plugins_1.AndroidConfig.Icon;
+exports.ANDROID_RES_PATH = 'android/app/src/main/res/';
+exports.dpiValues = {
+    mdpi: { folderName: 'mipmap-mdpi', scale: 1 },
+    hdpi: { folderName: 'mipmap-hdpi', scale: 1.5 },
+    xhdpi: { folderName: 'mipmap-xhdpi', scale: 2 },
+    xxhdpi: { folderName: 'mipmap-xxhdpi', scale: 3 },
+    xxxhdpi: { folderName: 'mipmap-xxxhdpi', scale: 4 },
+};
 const { addMetaDataItemToMainApplication, getMainApplicationOrThrow, removeMetaDataItemFromMainApplication, } = config_plugins_1.AndroidConfig.Manifest;
 const BASELINE_PIXEL_SIZE = 24;
 exports.META_DATA_NOTIFICATION_ICON = 'expo.modules.notifications.default_notification_icon';
@@ -102,9 +109,9 @@ async function setNotificationIconColorAsync(config, projectRoot) {
 }
 exports.setNotificationIconColorAsync = setNotificationIconColorAsync;
 async function writeNotificationIconImageFilesAsync(icon, projectRoot) {
-    await Promise.all(Object.values(dpiValues).map(async ({ folderName, scale }) => {
+    await Promise.all(Object.values(exports.dpiValues).map(async ({ folderName, scale }) => {
         const drawableFolderName = folderName.replace('mipmap', 'drawable');
-        const dpiFolderPath = path_1.default.resolve(projectRoot, ANDROID_RES_PATH, drawableFolderName);
+        const dpiFolderPath = path_1.default.resolve(projectRoot, exports.ANDROID_RES_PATH, drawableFolderName);
         await fs_extra_1.default.ensureDir(dpiFolderPath);
         const iconSizePx = BASELINE_PIXEL_SIZE * scale;
         try {
@@ -123,9 +130,9 @@ async function writeNotificationIconImageFilesAsync(icon, projectRoot) {
     }));
 }
 async function removeNotificationIconImageFilesAsync(projectRoot) {
-    await Promise.all(Object.values(dpiValues).map(async ({ folderName }) => {
+    await Promise.all(Object.values(exports.dpiValues).map(async ({ folderName }) => {
         const drawableFolderName = folderName.replace('mipmap', 'drawable');
-        const dpiFolderPath = path_1.default.resolve(projectRoot, ANDROID_RES_PATH, drawableFolderName);
+        const dpiFolderPath = path_1.default.resolve(projectRoot, exports.ANDROID_RES_PATH, drawableFolderName);
         await fs_extra_1.default.remove(path_1.default.resolve(dpiFolderPath, exports.NOTIFICATION_ICON + '.png'));
     }));
 }

--- a/packages/expo-notifications/plugin/src/withNotificationsAndroid.ts
+++ b/packages/expo-notifications/plugin/src/withNotificationsAndroid.ts
@@ -10,10 +10,20 @@ import { generateImageAsync } from '@expo/image-utils';
 import fs from 'fs-extra';
 import path from 'path';
 
+type DPIString = 'mdpi' | 'hdpi' | 'xhdpi' | 'xxhdpi' | 'xxxhdpi';
+type dpiMap = Record<DPIString, { folderName: string; scale: number }>;
+
 const { buildResourceItem, readResourcesXMLAsync } = AndroidConfig.Resources;
 const { writeXMLAsync } = XML;
 const { Colors } = AndroidConfig;
-const { ANDROID_RES_PATH, dpiValues } = AndroidConfig.Icon;
+export const ANDROID_RES_PATH = 'android/app/src/main/res/';
+export const dpiValues: dpiMap = {
+  mdpi: { folderName: 'mipmap-mdpi', scale: 1 },
+  hdpi: { folderName: 'mipmap-hdpi', scale: 1.5 },
+  xhdpi: { folderName: 'mipmap-xhdpi', scale: 2 },
+  xxhdpi: { folderName: 'mipmap-xxhdpi', scale: 3 },
+  xxxhdpi: { folderName: 'mipmap-xxxhdpi', scale: 4 },
+};
 const {
   addMetaDataItemToMainApplication,
   getMainApplicationOrThrow,

--- a/packages/expo-payments-stripe/package.json
+++ b/packages/expo-payments-stripe/package.json
@@ -33,7 +33,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.io/versions/latest/sdk/payments/",
   "dependencies": {
-    "@expo/config-plugins": "^1.0.32",
+    "@expo/config-plugins": "^2.0.0",
     "prop-types": "^15.6.0"
   },
   "devDependencies": {

--- a/packages/expo-screen-orientation/package.json
+++ b/packages/expo-screen-orientation/package.json
@@ -42,6 +42,6 @@
     "expo-module-scripts": "^2.0.0"
   },
   "dependencies": {
-    "@expo/config-plugins": "^1.0.32"
+    "@expo/config-plugins": "^2.0.0"
   }
 }

--- a/packages/expo-sensors/package.json
+++ b/packages/expo-sensors/package.json
@@ -43,7 +43,7 @@
     "@unimodules/core": "*"
   },
   "dependencies": {
-    "@expo/config-plugins": "^1.0.32",
+    "@expo/config-plugins": "^2.0.0",
     "expo-modules-core": "~0.0.2",
     "invariant": "^2.2.4"
   },

--- a/packages/expo-task-manager/package.json
+++ b/packages/expo-task-manager/package.json
@@ -33,7 +33,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.io/versions/latest/sdk/task-manager/",
   "dependencies": {
-    "@expo/config-plugins": "^1.0.32",
+    "@expo/config-plugins": "^2.0.0",
     "expo-modules-core": "~0.0.2",
     "unimodules-app-loader": "~2.1.0"
   },

--- a/packages/expo-tracking-transparency/package.json
+++ b/packages/expo-tracking-transparency/package.json
@@ -30,7 +30,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.io/versions/latest/sdk/module-template",
   "dependencies": {
-    "@expo/config-plugins": "^1.0.32",
+    "@expo/config-plugins": "^2.0.0",
     "expo-modules-core": "~0.0.2"
   },
   "devDependencies": {

--- a/packages/expo-updates/package.json
+++ b/packages/expo-updates/package.json
@@ -34,8 +34,8 @@
     "preset": "expo-module-scripts"
   },
   "dependencies": {
-    "@expo/metro-config": "^0.1.68",
-    "@expo/config-plugins": "^1.0.32",
+    "@expo/metro-config": "^0.1.70",
+    "@expo/config-plugins": "^2.0.0",
     "expo-structured-headers": "~1.0.1",
     "fbemitter": "^2.1.1",
     "uuid": "^3.4.0",

--- a/packages/expo-yarn-workspaces/package.json
+++ b/packages/expo-yarn-workspaces/package.json
@@ -20,8 +20,8 @@
     "test": "jest ."
   },
   "dependencies": {
-    "@expo/metro-config": "^0.1.68",
-    "@expo/webpack-config": "^0.12.72",
+    "@expo/metro-config": "^0.1.70",
+    "@expo/webpack-config": "^0.12.74",
     "debug": "^4.1.1",
     "find-yarn-workspace-root": "^2.0.0",
     "glob": "^7.1.6",

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -50,7 +50,7 @@
   "homepage": "https://github.com/expo/expo/tree/master/packages/expo",
   "dependencies": {
     "@babel/runtime": "^7.1.2",
-    "@expo/metro-config": "^0.1.68",
+    "@expo/metro-config": "^0.1.70",
     "@expo/vector-icons": "^12.0.4",
     "@unimodules/core": "~7.1.1",
     "@unimodules/react-native-adapter": "~6.3.0",

--- a/packages/jest-expo-puppeteer/package.json
+++ b/packages/jest-expo-puppeteer/package.json
@@ -25,8 +25,8 @@
     "Evan Bacon <bacon@expo.io> (https://github.com/evanbacon)"
   ],
   "dependencies": {
-    "@expo/config": "^3.3.42",
-    "xdl": "^59.0.38",
+    "@expo/config": "^4.0.0",
+    "xdl": "^59.0.40",
     "getenv": "^1.0.0",
     "jest": "^25.2.0",
     "jest-puppeteer": "^4.4.0",

--- a/packages/jest-expo/package.json
+++ b/packages/jest-expo/package.json
@@ -31,7 +31,7 @@
     "preset": "jest-expo/universal"
   },
   "dependencies": {
-    "@expo/config": "^3.3.42",
+    "@expo/config": "^4.0.0",
     "babel-jest": "^25.2.0",
     "jest": "^25.2.0",
     "jest-watch-select-projects": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2100,14 +2100,12 @@
     mv "~2"
     safe-json-stringify "~1"
 
-"@expo/config-plugins@1.0.32", "@expo/config-plugins@^1.0.32":
-  version "1.0.32"
-  resolved "https://registry.yarnpkg.com/@expo/config-plugins/-/config-plugins-1.0.32.tgz#abf4ab24a1cfd53e824fefdf15f727687491a856"
-  integrity sha512-goQoBvWYq1fk/jdDYYioN5gYlEhmPVRP6Y9jxmCLTHoHhZHSI+Pl5BXidUqVNdE2XFhoiz9yLbjQrGgYFPXuwQ==
+"@expo/config-plugins@2.0.0", "@expo/config-plugins@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@expo/config-plugins/-/config-plugins-2.0.0.tgz#a76053612a8b3598d8017dcdeaa7ab42de14df84"
+  integrity sha512-MyD9cdoVuXEw/xzpHiFNzRvMFi1DWTU2oShTTviA8xt1U1gyuBTa9aBwFSyvZmpMoCEscOsC8ED0sZl7LM5wNw==
   dependencies:
     "@expo/config-types" "^40.0.0-beta.2"
-    "@expo/configure-splash-screen" "0.4.0"
-    "@expo/image-utils" "0.3.14"
     "@expo/json-file" "8.2.30"
     "@expo/plist" "0.0.13"
     find-up "~5.0.0"
@@ -2116,7 +2114,6 @@
     glob "7.1.6"
     resolve-from "^5.0.0"
     slash "^3.0.0"
-    slugify "^1.3.4"
     xcode "^3.0.1"
     xml2js "^0.4.23"
 
@@ -2152,16 +2149,16 @@
     xcode "^2.1.0"
     xml2js "^0.4.23"
 
-"@expo/config@3.3.42", "@expo/config@^3.3.42":
-  version "3.3.42"
-  resolved "https://registry.yarnpkg.com/@expo/config/-/config-3.3.42.tgz#668d3d47112e562ad9265ebafa3db0063369cff8"
-  integrity sha512-BLFp9JvMHkBFutwKM+o9RhvmdllSyQpswvY9974Y8gjYsO5/BXfvT5J0GyUt1bdtqGyA8dlfo5jew/mtkeStRA==
+"@expo/config@4.0.0", "@expo/config@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@expo/config/-/config-4.0.0.tgz#92b76c4ead19b38bdd927b1eeded12b5707c16c7"
+  integrity sha512-Hy2/49BMMzziDhJFf+N0gG5znLuhoorS9/+OFO7wqDbRV4LRraNx4UuGdyY06yLI7F0BgEJBGy109pZ4LZoKrA==
   dependencies:
     "@babel/core" "7.9.0"
     "@babel/plugin-proposal-class-properties" "~7.12.13"
     "@babel/preset-env" "~7.12.13"
     "@babel/preset-typescript" "~7.12.13"
-    "@expo/config-plugins" "1.0.32"
+    "@expo/config-plugins" "2.0.0"
     "@expo/config-types" "^40.0.0-beta.2"
     "@expo/json-file" "8.2.30"
     fs-extra "9.0.0"
@@ -2203,13 +2200,13 @@
     xcode "^3.0.0"
     xml-js "^1.6.11"
 
-"@expo/dev-server@0.1.68":
-  version "0.1.68"
-  resolved "https://registry.yarnpkg.com/@expo/dev-server/-/dev-server-0.1.68.tgz#f652bb29537114328544a890350bfe5c14b993fb"
-  integrity sha512-mk1owhrNK6UAPn3WkHi1A0cktmPGD0UrSO8Ebleizx2QmZ3oqASwd04bjcxd47QkvGf9jsYpiw+sld029P9VVQ==
+"@expo/dev-server@0.1.70":
+  version "0.1.70"
+  resolved "https://registry.yarnpkg.com/@expo/dev-server/-/dev-server-0.1.70.tgz#290d101ee8eece3ec2089969c28014033878314e"
+  integrity sha512-6OytCPP8krQwjhJeluzDZd1dBb9oIptpkskSsrZHQTHyCGK9m3CLILu/hSiUffN73vINscnUXwCusfbKU+g3yQ==
   dependencies:
     "@expo/bunyan" "4.0.0"
-    "@expo/metro-config" "0.1.68"
+    "@expo/metro-config" "0.1.70"
     "@react-native-community/cli-server-api" "4.9.0"
     body-parser "1.19.0"
     resolve-from "^5.0.0"
@@ -2306,12 +2303,12 @@
     json5 "^1.0.1"
     write-file-atomic "^2.3.0"
 
-"@expo/metro-config@0.1.68", "@expo/metro-config@^0.1.68":
-  version "0.1.68"
-  resolved "https://registry.yarnpkg.com/@expo/metro-config/-/metro-config-0.1.68.tgz#f48e27603b531d109f72d9a49c30db49e585817d"
-  integrity sha512-jxcGOCPUK9SiHqX9LB0c7N9LbasDIUYghqC6xc0VUS+8ZmbDZZ/QFjeKUJbHjjXsZG+jSGcft37PdUf4Mrcbzg==
+"@expo/metro-config@0.1.70", "@expo/metro-config@^0.1.70":
+  version "0.1.70"
+  resolved "https://registry.yarnpkg.com/@expo/metro-config/-/metro-config-0.1.70.tgz#8f6c21c359e5f09c8e45bf97818ceca50c3aeeca"
+  integrity sha512-zegpHSI0EedKSXkBg0wtU99YYA6OY8qCgm0urdKszDJ9c8Oea26b2+x2j0PBqspUiTC4kY+t/pzZkKWDEFAquQ==
   dependencies:
-    "@expo/config" "3.3.42"
+    "@expo/config" "4.0.0"
     chalk "^4.1.0"
     getenv "^1.0.0"
     metro-react-native-babel-transformer "^0.59.0"
@@ -2430,21 +2427,21 @@
     lodash.pick "^4.4.0"
     lodash.template "^4.5.0"
 
-"@expo/webpack-config@0.12.72", "@expo/webpack-config@^0.12.72":
-  version "0.12.72"
-  resolved "https://registry.yarnpkg.com/@expo/webpack-config/-/webpack-config-0.12.72.tgz#92b337e769863ffa03da0907d79ca57812cdf530"
-  integrity sha512-kyKB8MxNPVP5Dm/L1Dxi53ek+LZpPwpxuVyQCwvF0wQoap10UA1/2CY4xIWn+uRI6uSWmbocABQUCjJLz9Jy2A==
+"@expo/webpack-config@0.12.74", "@expo/webpack-config@^0.12.74":
+  version "0.12.74"
+  resolved "https://registry.yarnpkg.com/@expo/webpack-config/-/webpack-config-0.12.74.tgz#e1922250c4b8bb2ab284da5a70ce8b354d7a6fe7"
+  integrity sha512-xYyiin5uvRwRC3ehqRxb+MSzv9ArJSb3spOgl4yNZPkojXUbNjgyC3xfliVAH7ZuRMlEgL1Is7miixVe69ftYw==
   dependencies:
     "@babel/core" "7.9.0"
     "@babel/runtime" "7.9.0"
-    "@expo/config" "3.3.42"
+    "@expo/config" "4.0.0"
     "@pmmmwh/react-refresh-webpack-plugin" "^0.3.3"
     babel-loader "8.1.0"
     chalk "^4.0.0"
     clean-webpack-plugin "^3.0.0"
     copy-webpack-plugin "~6.0.3"
     css-loader "~3.6.0"
-    expo-pwa "0.0.78"
+    expo-pwa "0.0.80"
     file-loader "~6.0.0"
     find-yarn-workspace-root "~2.0.0"
     getenv "^1.0.0"
@@ -10005,12 +10002,12 @@ expo-progress@^0.0.2:
   resolved "https://registry.yarnpkg.com/expo-progress/-/expo-progress-0.0.2.tgz#0d42470f8f1f019d3ae0f1da377c9bca891f3dd8"
   integrity sha512-RFd6aUxuZSH+ZhFeQB7Z6llnm8MZo7PmmgjoHeN5Hfvq1zc1gjQw0H4pCFcf3h6f08SXg32VMoaoi5A+D7Cs1A==
 
-expo-pwa@0.0.78:
-  version "0.0.78"
-  resolved "https://registry.yarnpkg.com/expo-pwa/-/expo-pwa-0.0.78.tgz#8706b2dbaa9d13b2f7adaaea939c0e217fc70e31"
-  integrity sha512-uy7TF/Son1y9Xx/ONtCYh/SYqAVFX9a3E58IRjAyzpncrB11asjHe6BvR10enB7L6pH4Gm9ZvygU4vAxbUigJQ==
+expo-pwa@0.0.80:
+  version "0.0.80"
+  resolved "https://registry.yarnpkg.com/expo-pwa/-/expo-pwa-0.0.80.tgz#f0c9be530df0ebe07c022f22c1635b542a955bd1"
+  integrity sha512-AZefVqcB3OFS7yOhfOtkHANhFRTG34fAMrlDx69ERbxh0sEPI/Gv+wwYycUdmq/aYh7u8zuaoOlY9BUgMd6U6w==
   dependencies:
-    "@expo/config" "3.3.42"
+    "@expo/config" "4.0.0"
     "@expo/image-utils" "0.3.14"
     chalk "^4.0.0"
     commander "2.20.0"
@@ -21928,15 +21925,15 @@ xcode@^3.0.0, xcode@^3.0.1:
     simple-plist "^1.1.0"
     uuid "^7.0.3"
 
-xdl@^59.0.38:
-  version "59.0.38"
-  resolved "https://registry.yarnpkg.com/xdl/-/xdl-59.0.38.tgz#e464355a9385f1ce90cdfeefcc2ef5f4ebc649ec"
-  integrity sha512-wNL3zmfQjGU1Iz38Mx88eLJmobUBy3xPWDJ61t1EE7fS3v/X1DuV50MrYn0do5mFhMenLUCj/DoPUgoirEnJfg==
+xdl@^59.0.40:
+  version "59.0.40"
+  resolved "https://registry.yarnpkg.com/xdl/-/xdl-59.0.40.tgz#23d1f057c16857cfed0807b4ee3e73567df3bd24"
+  integrity sha512-TRSCBA2bRGiMATsf0dpyKtTo80WHYRWL+Rbo6OOLh1ODR032dvdrh0v1eaUcmnEnjUxF2uXgUQaoi5qiVhxB3A==
   dependencies:
     "@expo/bunyan" "4.0.0"
-    "@expo/config" "3.3.42"
-    "@expo/config-plugins" "1.0.32"
-    "@expo/dev-server" "0.1.68"
+    "@expo/config" "4.0.0"
+    "@expo/config-plugins" "2.0.0"
+    "@expo/dev-server" "0.1.70"
     "@expo/devcert" "^1.0.0"
     "@expo/json-file" "8.2.30"
     "@expo/osascript" "2.0.28"
@@ -21944,7 +21941,7 @@ xdl@^59.0.38:
     "@expo/plist" "0.0.13"
     "@expo/schemer" "1.3.29"
     "@expo/spawn-async" "1.5.0"
-    "@expo/webpack-config" "0.12.72"
+    "@expo/webpack-config" "0.12.74"
     "@hapi/joi" "^17.1.1"
     analytics-node "3.5.0"
     axios "0.21.1"


### PR DESCRIPTION
# Why

Large refactor to config-plugins reduces its size 7x, other packages are reduces ~2x in size.

