### PR TITLE
[ci][tools] Forbid adding large files and gifs to the repo

### DIFF
--- a/tools/package.json
+++ b/tools/package.json
@@ -78,6 +78,7 @@
     "pacote": "^11.2.7",
     "parse-diff": "^0.8.1",
     "plist": "^3.0.1",
+    "pretty-bytes": "^5.6.0",
     "qrcode-terminal": "^0.12.0",
     "recursive-omit-by": "^2.0.0",
     "semver": "^5.4.1",

--- a/tools/src/code-review/index.ts
+++ b/tools/src/code-review/index.ts
@@ -6,6 +6,7 @@ import logger from '../Logger';
 import { generateReviewBodyFromOutputs } from './reports';
 import checkMissingChangelogs from './reviewers/checkMissingChangelogs';
 import reviewChangelogEntries from './reviewers/reviewChangelogEntries';
+import reviewForbiddenFiles from './reviewers/reviewForbiddenFiles';
 import {
   ReviewEvent,
   ReviewComment,
@@ -18,7 +19,7 @@ import {
 /**
  * An array with functions whose purpose is to check and review the diff.
  */
-const REVIEWERS = [checkMissingChangelogs, reviewChangelogEntries];
+const REVIEWERS = [checkMissingChangelogs, reviewChangelogEntries, reviewForbiddenFiles];
 
 enum Label {
   APPROVED = '🤖 approved',

--- a/tools/src/code-review/reports.ts
+++ b/tools/src/code-review/reports.ts
@@ -25,7 +25,7 @@ function reportForOutput(output: ReviewOutput): string {
   return `<details>
   <summary><strong>${prefixForStatus(output.status)}</strong>: ${output.title}</summary>
 
-\\
+&NewLine;
 ${output.body}
 </details>
 

--- a/tools/src/code-review/reviewers/reviewForbiddenFiles.ts
+++ b/tools/src/code-review/reviewers/reviewForbiddenFiles.ts
@@ -24,13 +24,17 @@ export default async function ({ pullRequest, diff }: ReviewInput): Promise<Revi
       if (IGNORED_PATHS.some((pattern) => minimatch(file.path, pattern))) {
         return null;
       }
-      if (path.extname(file.path).substr(1) === 'gif') {
-        logs.push(`**GIF** format is forbidden, please consider using **MP4** format`);
+
+      const extname = path.extname(file.path).substr(1).toLowerCase();
+      if (extname === 'gif') {
+        logs.push(`**GIF** files are forbidden, please consider using **MP4** instead`);
       }
+
       if (file.size > FILE_SIZE_LIMIT) {
         const prettySize = prettyBytes(file.size);
         logs.push(`File size **${prettySize}** exceeds the limit of **${PRETTY_FILE_SIZE_LIMIT}**`);
       }
+
       if (logs.length === 0) {
         return null;
       }

--- a/tools/src/code-review/reviewers/reviewForbiddenFiles.ts
+++ b/tools/src/code-review/reviewers/reviewForbiddenFiles.ts
@@ -1,0 +1,54 @@
+import minimatch from 'minimatch';
+import path from 'path';
+import prettyBytes from 'pretty-bytes';
+
+import Git from '../../Git';
+import { ReviewInput, ReviewOutput, ReviewStatus } from '../types';
+
+const FILE_SIZE_LIMIT = 5 * 1000 * 1000; // 5MB
+const PRETTY_FILE_SIZE_LIMIT = prettyBytes(FILE_SIZE_LIMIT);
+
+const IGNORED_PATHS = ['android/versioned-abis/**/*.aar'];
+
+export default async function ({ pullRequest, diff }: ReviewInput): Promise<ReviewOutput | null> {
+  const listTree = await Git.listTreeAsync(
+    pullRequest.head.sha,
+    diff.filter((file) => !file.deleted).map((file) => file.path)
+  );
+
+  const fileReports = listTree
+    .map((file) => {
+      const logs: string[] = [];
+
+      // We may ignore some paths where the files are allowed to be bigger (e.g. versioned .aar files).
+      if (IGNORED_PATHS.some((pattern) => minimatch(file.path, pattern))) {
+        return null;
+      }
+      if (path.extname(file.path).substr(1) === 'gif') {
+        logs.push(`**GIF** format is forbidden, please consider using **MP4** format`);
+      }
+      if (file.size > FILE_SIZE_LIMIT) {
+        const prettySize = prettyBytes(file.size);
+        logs.push(`File size **${prettySize}** exceeds the limit of **${PRETTY_FILE_SIZE_LIMIT}**`);
+      }
+      if (logs.length === 0) {
+        return null;
+      }
+      return `- ${linkToFile(pullRequest, file.path)}\n  - ${logs.join('\n  - ')}`;
+    })
+    .filter(Boolean);
+
+  if (fileReports.length === 0) {
+    return null;
+  }
+
+  return {
+    status: ReviewStatus.ERROR,
+    title: 'Forbidden file size or format',
+    body: fileReports.join('\n'),
+  };
+}
+
+function linkToFile(pr: ReviewInput['pullRequest'], path: string): string {
+  return `[${path}](${pr.head.repo.html_url}/blob/${pr.head.ref}/${encodeURIComponent(path)})`;
+}

--- a/tools/yarn.lock
+++ b/tools/yarn.lock
@@ -13185,6 +13185,11 @@ pretty-bytes@^5.3.0:
   resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-5.4.1.tgz#cd89f79bbcef21e3d21eb0da68ffe93f803e884b"
   integrity sha512-s1Iam6Gwz3JI5Hweaz4GoCD1WUNUIyzePFy5+Js2hjwGVt2Z79wNN+ZKOZ2vB6C+Xs6njyB84Z1IthQg8d9LxA==
 
+pretty-bytes@^5.6.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-5.6.0.tgz#356256f643804773c82f64723fe78c92c62beaeb"
+  integrity sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==
+
 pretty-error@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/pretty-error/-/pretty-error-2.1.1.tgz#5f4f87c8f91e5ae3f3ba87ab4cf5e03b1a17f1a3"


### PR DESCRIPTION
# Why

We don't want to put large files and gifs (pretty unoptimized) to the repository, so we need a way to detect that beforehand.

# How

Added new reviewer to `expotools code-review` command. It will be rejecting pull request if it has a file with size bigger than 5MB or is adding a GIF.

# Test Plan

I temporarily duplicated a 6MB gif and ran `expotools code-review --pr 13063` locally against this PR — you can see it in action below. Of course I'll remove that file before merging.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).