### PR TITLE
[kernel] Fix `getInitialURL` returns `https://expo.io:443/<team>/<slug>` instead of null in standalone app

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
@@ -549,18 +549,6 @@ public class ExperienceActivity extends BaseExperienceActivity implements Expone
       notificationObject = options.notificationObject;
     }
 
-    // if we have an embedded initial url, we never need any part of this in the initial url
-    // passed to the JS, so we check for that and filter it out here.
-    // this can happen in dev mode on a detached app, for example, because the intent will have
-    // a url like customscheme://localhost:19000 but we don't care about the localhost:19000 part.
-    if (mIntentUri == null || mIntentUri.equals(Constants.INITIAL_URL)) {
-      if (Constants.SHELL_APP_SCHEME != null) {
-        mIntentUri = Constants.SHELL_APP_SCHEME + "://";
-      } else {
-        mIntentUri = mManifestUrl;
-      }
-    }
-
     final ExponentNotification finalNotificationObject = notificationObject;
 
     BranchManager.handleLink(this, mIntentUri, mDetachSdkVersion);

--- a/android/expoview/src/main/java/host/exp/exponent/headless/InternalHeadlessAppLoader.java
+++ b/android/expoview/src/main/java/host/exp/exponent/headless/InternalHeadlessAppLoader.java
@@ -165,18 +165,6 @@ public class InternalHeadlessAppLoader implements AppLoaderInterface, Exponent.S
 
     soloaderInit();
 
-    // if we have an embedded initial url, we never need any part of this in the initial url
-    // passed to the JS, so we check for that and filter it out here.
-    // this can happen in dev mode on a detached app, for example, because the intent will have
-    // a url like customscheme://localhost:19000 but we don't care about the localhost:19000 part.
-    if (mIntentUri == null || mIntentUri.equals(Constants.INITIAL_URL)) {
-      if (Constants.SHELL_APP_SCHEME != null) {
-        mIntentUri = Constants.SHELL_APP_SCHEME + "://";
-      } else {
-        mIntentUri = mManifestUrl;
-      }
-    }
-
     runOnUiThread(() -> {
       if (mReactInstanceManager.isNotNull()) {
         mReactInstanceManager.onHostDestroy();

--- a/ios/Exponent/Kernel/Services/EXKernelLinkingManager.m
+++ b/ios/Exponent/Kernel/Services/EXKernelLinkingManager.m
@@ -215,9 +215,10 @@ NSString *kEXExpoLegacyDeepLinkSeparator = @"+";
   if ([EXEnvironment sharedEnvironment].isDetached) {
     NSDictionary *launchOptions = [ExpoKit sharedInstance].launchOptions;
     NSURL *launchOptionsUrl = [[self class] initialUrlFromLaunchOptions:launchOptions];
-    if (launchOptionsUrl) {
-      urlToTransform = launchOptionsUrl;
+    if (!launchOptionsUrl) {
+      return nil;
     }
+    urlToTransform = launchOptionsUrl;
   }
 
   NSURLComponents *urlComponents = [NSURLComponents componentsWithURL:urlToTransform resolvingAgainstBaseURL:YES];

--- a/ios/Exponent/Versioned/Core/Internal/EXLinkingManager.m
+++ b/ios/Exponent/Versioned/Core/Internal/EXLinkingManager.m
@@ -27,6 +27,9 @@ EX_EXPORT_SCOPED_MODULE(RCTLinkingManager, KernelLinkingManager);
   if (self = [super initWithExperienceId:experienceId kernelServiceDelegate:kernelServiceInstance params:params]) {
     _kernelLinkingDelegate = kernelServiceInstance;
     _initialUrl = params[@"initialUri"];
+    if (_initialUrl == [NSNull null]) {
+      _initialUrl = nil;
+    }
   }
   return self;
 }


### PR DESCRIPTION
# Why

Closes ENG-1141.
Fixes https://github.com/expo/expo/issues/11920.

# How

On both platforms, we pass manifest URL to liking module if the initial URL is null. It's not the desired behavior right now. It looks like we used it in the past but not anymore. So I removed the code that was responsible for changing the initial URL. 

# Test Plan

- check if the linking module work in Expo Go on both platforms ✅
- build local shell apps using `et android-shell-app` and `et ios-shell-app` and confirm that `getInitialURL` returns null using a simple app:
```js
let singletonLock = false;

export default function App() {
  React.useEffect(() => {
    if (singletonLock === false) {
      singletonLock = true;

      ExpoLinking.getInitialURL().then((incomingLink) => {
        console.log("expo", { incomingLink });
        }
      });
      Linking.getInitialURL().then((incomingLink) => {
        console.log("rn", { incomingLink });
      });
    }
  }, []);
```

> Note: local shell apps are not the same as those produced by turtle because I needed to change a few things to compile them. However, the code which is responsible for starting the app should be the same.