### PR TITLE
bugfix: expo-yarn-workspaces: support nested packages under the workspace key

### DIFF
--- a/packages/expo-yarn-workspaces/webpack.js
+++ b/packages/expo-yarn-workspaces/webpack.js
@@ -28,7 +28,7 @@ exports.createWebpackConfigAsync = async function createWebpackConfigAsync(env, 
 
     // discover workspace package directories via glob - source yarn:
     // https://github.com/yarnpkg/yarn/blob/a4708b29ac74df97bac45365cba4f1d62537ceb7/src/config.js#L812-L826
-    const patterns = (workspacePackage.workspaces || workspacePackage.workspaces.packages) ?? [];
+    const patterns = (workspacePackage.workspaces?.packages || workspacePackage.workspaces) ?? [];
     const registryFilenames = 'package.json';
     const trailingPattern = `/+(${registryFilenames})`;
 

--- a/packages/expo-yarn-workspaces/webpack.js
+++ b/packages/expo-yarn-workspaces/webpack.js
@@ -28,7 +28,7 @@ exports.createWebpackConfigAsync = async function createWebpackConfigAsync(env, 
 
     // discover workspace package directories via glob - source yarn:
     // https://github.com/yarnpkg/yarn/blob/a4708b29ac74df97bac45365cba4f1d62537ceb7/src/config.js#L812-L826
-    const patterns = (workspacePackage.workspaces?.packages || workspacePackage.workspaces) ?? [];
+    const patterns = workspacePackage.workspaces?.packages ?? workspacePackage.workspaces ?? [];
     const registryFilenames = 'package.json';
     const trailingPattern = `/+(${registryFilenames})`;
 

--- a/packages/expo-yarn-workspaces/webpack.js
+++ b/packages/expo-yarn-workspaces/webpack.js
@@ -28,7 +28,7 @@ exports.createWebpackConfigAsync = async function createWebpackConfigAsync(env, 
 
     // discover workspace package directories via glob - source yarn:
     // https://github.com/yarnpkg/yarn/blob/a4708b29ac74df97bac45365cba4f1d62537ceb7/src/config.js#L812-L826
-    const patterns = workspacePackage.workspaces ?? [];
+    const patterns = (workspacePackage.workspaces || workspacePackage.workspaces.packages) ?? [];
     const registryFilenames = 'package.json';
     const trailingPattern = `/+(${registryFilenames})`;
 


### PR DESCRIPTION
# Why

In package.json, currently, only `workspaces: []` is supported. `workspaces.packages: []` is also possible. This supports both.

The solution feels a little ugly tbh, but it's late and I wanted to put this up before I forget :) 