### PR TITLE
[expo-dev-launcher][ios] add ability to load published projects via expo-updates

### DIFF
--- a/packages/expo-dev-client/expo-dev-client.podspec
+++ b/packages/expo-dev-client/expo-dev-client.podspec
@@ -17,4 +17,5 @@ Pod::Spec.new do |s|
   s.dependency 'expo-dev-launcher', :configurations => :debug
   s.dependency 'expo-dev-menu', :configurations => :debug
   s.dependency 'expo-dev-menu-interface'
+  s.dependency 'EXUpdatesInterface'
 end

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Added ability to load published projects via expo-updates on Android. ([#13031](https://github.com/expo/expo/pull/13031) by [@esamelson](https://github.com/esamelson))
+- Added ability to load published projects via expo-updates. (Android: [#13031](https://github.com/expo/expo/pull/13031) and iOS: [#13087](https://github.com/expo/expo/pull/13087) by [@esamelson](https://github.com/esamelson))
 - Support remote JavaScript inspecting. ([#13041](https://github.com/expo/expo/pull/13041) by [@kudo](https://github.com/kudo))
 
 ### 🐛 Bug fixes

--- a/packages/expo-dev-launcher/expo-dev-launcher.podspec
+++ b/packages/expo-dev-launcher/expo-dev-launcher.podspec
@@ -37,6 +37,7 @@ Pod::Spec.new do |s|
   
   s.dependency "React"
   s.dependency "expo-dev-menu-interface"
+  s.dependency "EXUpdatesInterface"
   
   s.subspec 'Unsafe' do |unsafe|
     unsafe.source_files = 'ios/Unsafe/**/*.{h,m,mm,swift,cpp}'

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.h
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.h
@@ -3,6 +3,8 @@
 
 #import <UIKit/UIKit.h>
 
+#import <EXUpdatesInterface/EXUpdatesInterface.h>
+
 NS_ASSUME_NONNULL_BEGIN
 
 @class EXDevLauncherPendingDeepLinkRegistry;
@@ -22,6 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, weak) RCTBridge * _Nullable appBridge;
 @property (nonatomic, strong) RCTBridge *launcherBridge;
 @property (nonatomic, strong) EXDevLauncherPendingDeepLinkRegistry *pendingDeepLinkRegistry;
+@property (nonatomic, strong) id<EXUpdatesInterface> updatesInterface;
 
 + (instancetype)sharedInstance;
 

--- a/packages/expo-dev-launcher/ios/Manifest/EXDevLauncherManifest.swift
+++ b/packages/expo-dev-launcher/ios/Manifest/EXDevLauncherManifest.swift
@@ -34,6 +34,16 @@ public class CanHavePlatformSpecificValue<T> : Decodable where T : Decodable {
 public class iOSSection: NSObject, Decodable {}
 
 @objc
+public class DeveloperSection: NSObject, Decodable {
+  @objc
+  public var tool: String?
+
+  public enum CodingKeys: String, CodingKey {
+    case tool
+  }
+}
+
+@objc
 public class EXDevLauncherManifest: NSObject, Decodable {
   @objc
   var _rawData: String? = nil
@@ -80,13 +90,26 @@ public class EXDevLauncherManifest: NSObject, Decodable {
     return EXDevLauncherManifestHelper.exportManifestOrientation(_orientation)
   }
   
+  @objc
+  public var developer: DeveloperSection?
+
   var ios: iOSSection?
   
   public enum CodingKeys: String, CodingKey {
-    case name, slug, version, ios, bundleUrl
+    case name, slug, version, ios, bundleUrl, developer
     case _backgroundColor = "backgroundColor"
     case _orientation = "orientation"
     case _userInterfaceStyle = "userInterfaceStyle"
+  }
+
+  @objc
+  public static func fromJsonObject(_ jsonObject: NSDictionary) -> EXDevLauncherManifest? {
+    do {
+      let data = try JSONSerialization.data(withJSONObject: jsonObject, options: [])
+      return fromJsonData(data)
+    } catch {
+      return nil
+    }
   }
 
   @objc
@@ -100,6 +123,11 @@ public class EXDevLauncherManifest: NSObject, Decodable {
     } catch {
       return nil
     }
+  }
+
+  @objc
+  public func isUsingDeveloperTool() -> Bool {
+    return self.developer?.tool != nil;
   }
 }
 

--- a/packages/expo-dev-launcher/ios/Manifest/EXDevLauncherManifestParser.h
+++ b/packages/expo-dev-launcher/ios/Manifest/EXDevLauncherManifestParser.h
@@ -4,16 +4,18 @@ NS_ASSUME_NONNULL_BEGIN
 
 @class EXDevLauncherManifest;
 
+typedef void (^IsManifestURL)(BOOL isManifestURL);
 typedef void (^OnManifestParsed)(EXDevLauncherManifest *manifest);
-typedef void (^OnInvalidManifestURL)(void);
 typedef void (^OnManifestError)(NSError *error);
 
 @interface EXDevLauncherManifestParser : NSObject
 
 - (instancetype)initWithURL:(NSURL *)url session:(NSURLSession *)session;
 
+- (void)isManifestURLWithCompletion:(IsManifestURL)completion
+                            onError:(OnManifestError)onError;
+
 - (void)tryToParseManifest:(OnManifestParsed)onParsed
-      onInvalidManifestURL:(OnInvalidManifestURL)onInalidURL
                    onError:(OnManifestError)onError;
 
 @end


### PR DESCRIPTION
# Why

iOS counterpart to #13031

# How

Basically replicated the changes from #13031 in iOS code.

Had to add a few more things in order to get manual updates and `Updates.reloadAsync()` to work since we don't modify RCTBridge internals imperatively like on Android:
- dev launcher now passes the updates interface a weak reference to the bridge, so that updates can call `[bridge reload]` when `Updates.reloadAsync()` is called
- dev launcher also now reads `sourceUrl` from the updates interface, rather than its own instance variable, when updates is being used. This is so that when `Updates.reloadAsync()` is called, if a new update has been downloaded in the meantime, expo-updates can update the sourceUrl accordingly and launch the new update, as the user would expect. (The dev launcher could also pass expo-updates a block, but this seemed cleaner and more correct than requiring expo-updates to call an imperative block whenever its sourceUrl changes.)

# Test Plan

manual tests with the iOS counterpart to #13032 (not quite ready to PR right away)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).