### PR TITLE
[expo-updates-interface][ios] add podspec and EXUpdatesInterface protocol

### DIFF
--- a/packages/expo-updates-interface/ios/EXUpdatesInterface.podspec
+++ b/packages/expo-updates-interface/ios/EXUpdatesInterface.podspec
@@ -1,0 +1,18 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, '..', 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name           = 'EXUpdatesInterface'
+  s.version        = package['version']
+  s.summary        = package['description']
+  s.description    = package['description']
+  s.license        = package['license']
+  s.author         = package['author']
+  s.homepage       = package['homepage']
+  s.platform       = :ios, '11.0'
+  s.source         = { git: 'https://github.com/expo/expo.git' }
+  s.source_files   = 'EXUpdatesInterface/**/*.{h,m}'
+  s.preserve_paths = 'EXUpdatesInterface/**/*.{h,m}'
+  s.requires_arc   = true
+end

--- a/packages/expo-updates-interface/ios/EXUpdatesInterface/EXUpdatesInterface.h
+++ b/packages/expo-updates-interface/ios/EXUpdatesInterface/EXUpdatesInterface.h
@@ -1,0 +1,26 @@
+//  Copyright © 2021 650 Industries. All rights reserved.
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef void (^EXUpdatesErrorBlock) (NSError *error);
+typedef void (^EXUpdatesSuccessBlock) (NSDictionary *manifest);
+typedef void (^EXUpdatesProgressBlock) (NSUInteger successfulAssetCount, NSUInteger failedAssetCount, NSUInteger totalAssetCount);
+typedef BOOL (^EXUpdatesManifestBlock) (NSDictionary *manifest);
+
+@protocol EXUpdatesInterface
+
+@property (nonatomic, weak) id bridge;
+
+- (NSURL *)launchAssetURL;
+
+- (void)fetchUpdateWithConfiguration:(NSDictionary *)configuration
+                          onManifest:(EXUpdatesManifestBlock)manifestBlock
+                            progress:(EXUpdatesProgressBlock)progressBlock
+                             success:(EXUpdatesSuccessBlock)successBlock
+                               error:(EXUpdatesErrorBlock)errorBlock;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesModule.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesModule.m
@@ -10,7 +10,7 @@
 
 @interface EXUpdatesModule ()
 
-@property (nonatomic, weak) id<EXUpdatesInterface> updatesService;
+@property (nonatomic, weak) id<EXUpdatesModuleInterface> updatesService;
 
 @end
 
@@ -20,7 +20,7 @@ UM_EXPORT_MODULE(ExpoUpdates);
 
 - (void)setModuleRegistry:(UMModuleRegistry *)moduleRegistry
 {
-  _updatesService = [moduleRegistry getModuleImplementingProtocol:@protocol(EXUpdatesInterface)];
+  _updatesService = [moduleRegistry getModuleImplementingProtocol:@protocol(EXUpdatesModuleInterface)];
 }
 
 - (NSDictionary *)constantsToExport

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesService.h
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesService.h
@@ -10,7 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 typedef void (^EXUpdatesAppRelaunchCompletionBlock)(BOOL success);
 
-@protocol EXUpdatesInterface
+@protocol EXUpdatesModuleInterface
 
 @property (nonatomic, readonly) EXUpdatesConfig *config;
 @property (nonatomic, readonly) EXUpdatesDatabase *database;
@@ -29,7 +29,7 @@ typedef void (^EXUpdatesAppRelaunchCompletionBlock)(BOOL success);
 
 @end
 
-@interface EXUpdatesService : NSObject <UMInternalModule, EXUpdatesInterface>
+@interface EXUpdatesService : NSObject <UMInternalModule, EXUpdatesModuleInterface>
 
 @end
 

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesService.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesService.m
@@ -12,7 +12,7 @@ UM_REGISTER_MODULE();
 
 + (const NSArray<Protocol *> *)exportedInterfaces
 {
-  return @[@protocol(EXUpdatesInterface)];
+  return @[@protocol(EXUpdatesModuleInterface)];
 }
 
 - (EXUpdatesConfig *)config


### PR DESCRIPTION
# Why

iOS counterpart to #13030. Will add Manifest types in a separate later PR, same as Android

# How

- add protocol and podspec
- rename expo-updates' internal EXUpdatesInterface to EXUpdatesModuleInterface to prevent class name collision

# Test Plan

manual tests in later PRs

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).