### PR TITLE
[expo-updates][ios] implement EXUpdatesDevLauncherController

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -25,7 +25,7 @@
 - Remove code to handle nested root level manifest key. ([#12736](https://github.com/expo/expo/pull/12736) by [@wschurman](https://github.com/wschurman))
 - Move scope check from reaper to selection policy. ([#12769](https://github.com/expo/expo/pull/12769) by [@esamelson](https://github.com/esamelson))
 - Add ReaperSelectionPolicyDevelopmentClient, implement in Expo Go. ([#12770](https://github.com/expo/expo/pull/12770) by [@esamelson](https://github.com/esamelson))
-- Add UpdatesDevLauncherController for development client integration. ([#13032](https://github.com/expo/expo/pull/13032) by [@esamelson](https://github.com/esamelson))
+- Add UpdatesDevLauncherController for development client integration. (Android: [#13032](https://github.com/expo/expo/pull/13032) and iOS: ([#13112](https://github.com/expo/expo/pull/13112)) by [@esamelson](https://github.com/esamelson))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-updates/ios/EXUpdates.podspec
+++ b/packages/expo-updates/ios/EXUpdates.podspec
@@ -16,6 +16,7 @@ Pod::Spec.new do |s|
   s.dependency 'UMCore'
   s.dependency 'React-Core'
   s.dependency 'EXStructuredHeaders'
+  s.dependency 'EXUpdatesInterface'
 
   s.pod_target_xcconfig = {
     'GCC_TREAT_INCOMPATIBLE_POINTER_TYPE_WARNINGS_AS_ERRORS' => 'YES',

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesAppController+Internal.h
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesAppController+Internal.h
@@ -1,0 +1,26 @@
+//  Copyright © 2021 650 Industries. All rights reserved.
+
+#import <EXUpdates/EXUpdatesAppController.h>
+#import <EXUpdates/EXUpdatesAppLauncher.h>
+#import <EXUpdates/EXUpdatesConfig.h>
+#import <EXUpdates/EXUpdatesSelectionPolicy.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface EXUpdatesAppController (Internal)
+
+@property (nonatomic, readonly) dispatch_queue_t controllerQueue;
+
+- (BOOL)initializeUpdatesDirectoryWithError:(NSError ** _Nullable)error;
+- (BOOL)initializeUpdatesDatabaseWithError:(NSError ** _Nullable)error;
+
+- (void)setDefaultSelectionPolicy:(EXUpdatesSelectionPolicy *)selectionPolicy;
+- (void)setLauncher:(id<EXUpdatesAppLauncher>)launcher;
+- (void)setConfigurationInternal:(EXUpdatesConfig *)configuration;
+- (void)setIsStarted:(BOOL)isStarted;
+
+- (void)runReaper;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesAppController.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesAppController.m
@@ -89,7 +89,7 @@ static NSString * const EXUpdatesErrorEventName = @"error";
 
 - (void)resetSelectionPolicyToDefault
 {
-  _selectionPolicy = _defaultSelectionPolicy;
+  _selectionPolicy = nil;
 }
 
 - (void)start
@@ -254,21 +254,16 @@ static NSString * const EXUpdatesErrorEventName = @"error";
 
 - (BOOL)initializeUpdatesDirectoryWithError:(NSError ** _Nullable)error
 {
-  NSError *err;
-  _updatesDirectory = [EXUpdatesUtils initializeUpdatesDirectoryWithError:&err];
-  if (err && error) {
-    *error = err;
-  }
+  _updatesDirectory = [EXUpdatesUtils initializeUpdatesDirectoryWithError:error];
   return _updatesDirectory != nil;
 }
 
 - (BOOL)initializeUpdatesDatabaseWithError:(NSError ** _Nullable)error
 {
-  __block BOOL dbSuccess;
   __block NSError *dbError;
   dispatch_semaphore_t dbSemaphore = dispatch_semaphore_create(0);
   dispatch_async(_database.databaseQueue, ^{
-    dbSuccess = [self->_database openDatabaseInDirectory:self->_updatesDirectory withError:&dbError];
+    [self->_database openDatabaseInDirectory:self->_updatesDirectory withError:&dbError];
     dispatch_semaphore_signal(dbSemaphore);
   });
 
@@ -276,7 +271,7 @@ static NSString * const EXUpdatesErrorEventName = @"error";
   if (dbError && error) {
     *error = dbError;
   }
-  return dbSuccess;
+  return dbError == nil;
 }
 
 - (void)setDefaultSelectionPolicy:(EXUpdatesSelectionPolicy *)selectionPolicy

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.h
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.h
@@ -27,6 +27,7 @@ typedef NS_ENUM(NSInteger, EXUpdatesCheckAutomaticallyConfig) {
 
 @property (nonatomic, readonly) BOOL hasEmbeddedUpdate;
 
++ (instancetype)configWithExpoPlist;
 + (instancetype)configWithDictionary:(NSDictionary *)config;
 - (void)loadConfigFromDictionary:(NSDictionary *)config;
 

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.m
@@ -20,6 +20,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+static NSString * const EXUpdatesConfigPlistName = @"Expo";
+
 static NSString * const EXUpdatesDefaultReleaseChannelName = @"default";
 
 static NSString * const EXUpdatesConfigEnabledKey = @"EXUpdatesEnabled";
@@ -58,6 +60,17 @@ static NSString * const EXUpdatesConfigNeverString = @"NEVER";
   EXUpdatesConfig *updatesConfig = [[EXUpdatesConfig alloc] init];
   [updatesConfig loadConfigFromDictionary:config];
   return updatesConfig;
+}
+
++ (instancetype)configWithExpoPlist
+{
+  NSString *configPath = [[NSBundle mainBundle] pathForResource:EXUpdatesConfigPlistName ofType:@"plist"];
+  if (!configPath) {
+    @throw [NSException exceptionWithName:NSInternalInconsistencyException
+                                   reason:@"Cannot load configuration from Expo.plist. Please ensure you've followed the setup and installation instructions for expo-updates to create Expo.plist and add it to your Xcode project."
+                                 userInfo:@{}];
+  }
+  return [[self class] configWithDictionary:[NSDictionary dictionaryWithContentsOfFile:configPath]];
 }
 
 - (void)loadConfigFromDictionary:(NSDictionary *)config

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesDevLauncherController.h
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesDevLauncherController.h
@@ -1,0 +1,15 @@
+//  Copyright © 2021 650 Industries. All rights reserved.
+
+#import <EXUpdatesInterface/EXUpdatesInterface.h>
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface EXUpdatesDevLauncherController : NSObject <EXUpdatesInterface>
+
++ (instancetype)sharedInstance;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesDevLauncherController.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesDevLauncherController.m
@@ -15,6 +15,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 static NSString * const EXUpdatesDevLauncherControllerErrorDomain = @"EXUpdatesDevLauncherController";
 
+typedef NS_ENUM(NSInteger, EXUpdatesDevLauncherErrorCode) {
+  EXUpdatesDevLauncherErrorCodeInvalidUpdateURL = 1,
+  EXUpdatesDevLauncherErrorCodeDirectoryInitializationFailed,
+  EXUpdatesDevLauncherErrorCodeDatabaseInitializationFailed,
+  EXUpdatesDevLauncherErrorCodeUpdateLaunchFailed,
+};
+
 @implementation EXUpdatesDevLauncherController
 
 @synthesize bridge = _bridge;
@@ -54,17 +61,17 @@ static NSString * const EXUpdatesDevLauncherControllerErrorDomain = @"EXUpdatesD
   EXUpdatesConfig *updatesConfiguration = [EXUpdatesConfig configWithExpoPlist];
   [updatesConfiguration loadConfigFromDictionary:configuration];
   if (!updatesConfiguration.updateUrl) {
-    errorBlock([NSError errorWithDomain:EXUpdatesDevLauncherControllerErrorDomain code:1 userInfo:@{NSLocalizedDescriptionKey: @"Failed to load update: configuration object must include a valid update URL"}]);
+    errorBlock([NSError errorWithDomain:EXUpdatesDevLauncherControllerErrorDomain code:EXUpdatesDevLauncherErrorCodeInvalidUpdateURL userInfo:@{NSLocalizedDescriptionKey: @"Failed to load update: configuration object must include a valid update URL"}]);
     return;
   }
   NSError *fsError;
   if (![controller initializeUpdatesDirectoryWithError:&fsError]) {
-    errorBlock(fsError ?: [NSError errorWithDomain:EXUpdatesDevLauncherControllerErrorDomain code:2 userInfo:@{NSLocalizedDescriptionKey: @"Failed to initialize updates directory with an unknown error"}]);
+    errorBlock(fsError ?: [NSError errorWithDomain:EXUpdatesDevLauncherControllerErrorDomain code:EXUpdatesDevLauncherErrorCodeDirectoryInitializationFailed userInfo:@{NSLocalizedDescriptionKey: @"Failed to initialize updates directory with an unknown error"}]);
     return;
   }
   NSError *dbError;
   if (![controller initializeUpdatesDatabaseWithError:&dbError]) {
-    errorBlock(dbError ?: [NSError errorWithDomain:EXUpdatesDevLauncherControllerErrorDomain code:3 userInfo:@{NSLocalizedDescriptionKey: @"Failed to initialize updates database with an unknown error"}]);
+    errorBlock(dbError ?: [NSError errorWithDomain:EXUpdatesDevLauncherControllerErrorDomain code:EXUpdatesDevLauncherErrorCodeDatabaseInitializationFailed userInfo:@{NSLocalizedDescriptionKey: @"Failed to initialize updates database with an unknown error"}]);
     return;
   }
 
@@ -103,7 +110,7 @@ static NSString * const EXUpdatesDevLauncherControllerErrorDomain = @"EXUpdatesD
   EXUpdatesAppLauncherWithDatabase *launcher = [[EXUpdatesAppLauncherWithDatabase alloc] initWithConfig:configuration database:controller.database directory:controller.updatesDirectory completionQueue:controller.controllerQueue];
   [launcher launchUpdateWithSelectionPolicy:controller.selectionPolicy completion:^(NSError * _Nullable error, BOOL success) {
     if (!success) {
-      errorBlock(error ?: [NSError errorWithDomain:EXUpdatesDevLauncherControllerErrorDomain code:4 userInfo:@{NSLocalizedDescriptionKey: @"Failed to launch update with an unknown error"}]);
+      errorBlock(error ?: [NSError errorWithDomain:EXUpdatesDevLauncherControllerErrorDomain code:EXUpdatesDevLauncherErrorCodeUpdateLaunchFailed userInfo:@{NSLocalizedDescriptionKey: @"Failed to launch update with an unknown error"}]);
       return;
     }
 

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesDevLauncherController.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesDevLauncherController.m
@@ -1,0 +1,119 @@
+//  Copyright © 2021 650 Industries. All rights reserved.
+
+#import <EXUpdates/EXUpdatesAppController+Internal.h>
+#import <EXUpdates/EXUpdatesAppLauncherWithDatabase.h>
+#import <EXUpdates/EXUpdatesConfig.h>
+#import <EXUpdates/EXUpdatesDevLauncherController.h>
+#import <EXUpdates/EXUpdatesReaper.h>
+#import <EXUpdates/EXUpdatesReaperSelectionPolicyDevelopmentClient.h>
+#import <EXUpdates/EXUpdatesRemoteAppLoader.h>
+#import <EXUpdates/EXUpdatesSelectionPolicy.h>
+#import <EXUpdates/EXUpdatesUpdate.h>
+#import <React/RCTBridge.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+static NSString * const EXUpdatesDevLauncherControllerErrorDomain = @"EXUpdatesDevLauncherController";
+
+@implementation EXUpdatesDevLauncherController
+
+@synthesize bridge = _bridge;
+
++ (instancetype)sharedInstance
+{
+  static EXUpdatesDevLauncherController *theController;
+  static dispatch_once_t once;
+  dispatch_once(&once, ^{
+    if (!theController) {
+      theController = [EXUpdatesDevLauncherController new];
+    }
+  });
+  return theController;
+}
+
+- (void)setBridge:(nullable id)bridge
+{
+  _bridge = bridge;
+  if ([bridge isKindOfClass:[RCTBridge class]]) {
+    EXUpdatesAppController.sharedInstance.bridge = (RCTBridge *)bridge;
+  }
+}
+
+- (NSURL *)launchAssetURL
+{
+  return EXUpdatesAppController.sharedInstance.launchAssetUrl;
+}
+
+- (void)fetchUpdateWithConfiguration:(NSDictionary *)configuration
+                          onManifest:(EXUpdatesManifestBlock)manifestBlock
+                            progress:(EXUpdatesProgressBlock)progressBlock
+                             success:(EXUpdatesSuccessBlock)successBlock
+                               error:(EXUpdatesErrorBlock)errorBlock
+{
+  EXUpdatesAppController *controller = EXUpdatesAppController.sharedInstance;
+  EXUpdatesConfig *updatesConfiguration = [EXUpdatesConfig configWithExpoPlist];
+  [updatesConfiguration loadConfigFromDictionary:configuration];
+  if (!updatesConfiguration.updateUrl) {
+    errorBlock([NSError errorWithDomain:EXUpdatesDevLauncherControllerErrorDomain code:1 userInfo:@{NSLocalizedDescriptionKey: @"Failed to load update: configuration object must include a valid update URL"}]);
+    return;
+  }
+  NSError *fsError;
+  if (![controller initializeUpdatesDirectoryWithError:&fsError]) {
+    errorBlock(fsError ?: [NSError errorWithDomain:EXUpdatesDevLauncherControllerErrorDomain code:2 userInfo:@{NSLocalizedDescriptionKey: @"Failed to initialize updates directory with an unknown error"}]);
+    return;
+  }
+  NSError *dbError;
+  if (![controller initializeUpdatesDatabaseWithError:&dbError]) {
+    errorBlock(dbError ?: [NSError errorWithDomain:EXUpdatesDevLauncherControllerErrorDomain code:3 userInfo:@{NSLocalizedDescriptionKey: @"Failed to initialize updates database with an unknown error"}]);
+    return;
+  }
+
+  [controller setIsStarted:YES];
+  [self _setDevelopmentSelectionPolicy];
+
+  EXUpdatesRemoteAppLoader *loader = [[EXUpdatesRemoteAppLoader alloc] initWithConfig:updatesConfiguration database:controller.database directory:controller.updatesDirectory completionQueue:controller.controllerQueue];
+  [loader loadUpdateFromUrl:updatesConfiguration.updateUrl onManifest:^BOOL(EXUpdatesUpdate * _Nonnull update) {
+    return manifestBlock(update.rawManifest.rawManifestJSON);
+  } asset:^(EXUpdatesAsset * _Nonnull asset, NSUInteger successfulAssetCount, NSUInteger failedAssetCount, NSUInteger totalAssetCount) {
+    progressBlock(successfulAssetCount, failedAssetCount, totalAssetCount);
+  } success:^(EXUpdatesUpdate * _Nullable update) {
+    if (update) {
+      [self _launchUpdate:update withConfiguration:updatesConfiguration success:successBlock error:errorBlock];
+    }
+  } error:errorBlock];
+}
+
+- (void)_setDevelopmentSelectionPolicy
+{
+  EXUpdatesAppController *controller = EXUpdatesAppController.sharedInstance;
+  EXUpdatesSelectionPolicy *currentSelectionPolicy = controller.selectionPolicy;
+  [controller setDefaultSelectionPolicy:[[EXUpdatesSelectionPolicy alloc]
+                                         initWithLauncherSelectionPolicy:currentSelectionPolicy.launcherSelectionPolicy
+                                         loaderSelectionPolicy:currentSelectionPolicy.loaderSelectionPolicy
+                                         reaperSelectionPolicy:[EXUpdatesReaperSelectionPolicyDevelopmentClient new]]];
+  [controller resetSelectionPolicyToDefault];
+}
+
+- (void)_launchUpdate:(EXUpdatesUpdate *)update
+    withConfiguration:(EXUpdatesConfig *)configuration
+              success:(EXUpdatesSuccessBlock)successBlock
+                error:(EXUpdatesErrorBlock)errorBlock
+{
+  EXUpdatesAppController *controller = EXUpdatesAppController.sharedInstance;
+  EXUpdatesAppLauncherWithDatabase *launcher = [[EXUpdatesAppLauncherWithDatabase alloc] initWithConfig:configuration database:controller.database directory:controller.updatesDirectory completionQueue:controller.controllerQueue];
+  [launcher launchUpdateWithSelectionPolicy:controller.selectionPolicy completion:^(NSError * _Nullable error, BOOL success) {
+    if (!success) {
+      errorBlock(error ?: [NSError errorWithDomain:EXUpdatesDevLauncherControllerErrorDomain code:4 userInfo:@{NSLocalizedDescriptionKey: @"Failed to launch update with an unknown error"}]);
+      return;
+    }
+
+    [controller setConfigurationInternal:configuration];
+    [controller setLauncher:launcher];
+    successBlock(launcher.launchedUpdate.rawManifest.rawManifestJSON);
+    [controller runReaper];
+  }];
+}
+
+@end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
# Why

iOS counterpart to #13032; resolves ENG-957 and ENG-958

This PR adds EXUpdatesDevLauncherController, which implements EXUpdatesInterface and serves as the entry point to expo-updates from expo-dev-launcher.

# How

Followed the same pattern as in #13032 -- EXUpdatesDevLauncherController is a singleton which uses EXUpdatesAppController under the hood, and can set properties on EXUpdatesAppController which are otherwise only set internally. Added a new `EXUpdatesAppController+Internal` interface to limit access to such methods.

# Test Plan

Ran the following manual tests:
- opened published project in dev client
- opened locally served development project in dev client
- switched back and forth between the two without swiping closed the dev client; verified that the loading overlay only showed in locally served projects
- opened a published project, published an update, and used the module methods to fetch and reload the update programmatically

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).