### PR TITLE
[expo-updates][android] reset selection policy in UpdatesDevLauncherController

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -31,6 +31,7 @@
 
 - Enable kotlin in all modules. ([#12716](https://github.com/expo/expo/pull/12716) by [@wschurman](https://github.com/wschurman))
 - Rename Update.metadata -> manifest in internal module classes. ([#12818](https://github.com/expo/expo/pull/12818) by [@esamelson](https://github.com/esamelson))
+- Reset selection policy in UpdatesDevLauncherController ([#13113](https://github.com/expo/expo/pull/13113) by [@esamelson](https://github.com/esamelson))
 
 ### 💡 Others
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.java
@@ -251,7 +251,7 @@ public class UpdatesController {
   }
 
   /* package */ void resetSelectionPolicyToDefault() {
-    mSelectionPolicy = mDefaultSelectionPolicy;
+    mSelectionPolicy = null;
   }
 
   /* package */ void setDefaultSelectionPolicy(SelectionPolicy selectionPolicy) {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.java
@@ -47,6 +47,7 @@ public class UpdatesDevLauncherController implements UpdatesInterface {
             currentSelectionPolicy.getLoaderSelectionPolicy(),
             new ReaperSelectionPolicyDevelopmentClient()
     ));
+    controller.resetSelectionPolicyToDefault();
   }
 
   @Override


### PR DESCRIPTION
# Why

Follow up from the conversation in https://github.com/expo/expo/pull/13032#discussion_r638794930 . I noticed when I was implementing #13112 that I hadn't added this call.

While not necessary (in theory this should always be called before anything accesses the selection policy in UpdatesController), it's safest to do this to ensure the new default selection policy is used right away. Otherwise, if some other method accesses the selection policy before UpdatesDevLauncherController has a chance to set the new default, the new default might never be used.

# How

Reset selection policy to default immediately after setting a new default.

# Test Plan

- [x] project builds

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).