### PR TITLE
[bare-apps][templates] Update gradle.properties for jsEngine replacement

### DIFF
--- a/apps/bare-expo/android/app/build.gradle
+++ b/apps/bare-expo/android/app/build.gradle
@@ -75,7 +75,7 @@ import com.android.build.OutputFile
  */
 
 project.ext.react = [
-    enableHermes: (findProperty('JS_RUNTIME') ?: "hermes") == "hermes",  // clean and rebuild if changing
+    enableHermes: (findProperty('expo.jsEngine') ?: "jsc") == "hermes",  // clean and rebuild if changing
 ]
 
 apply from: "../../node_modules/react-native/react.gradle"

--- a/apps/bare-expo/android/gradle.properties
+++ b/apps/bare-expo/android/gradle.properties
@@ -21,6 +21,6 @@ org.gradle.jvmargs=-Xmx10240M -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryErr
 android.useAndroidX=true
 android.enableJetifier=true
 
-# The hosted JavaScript runtime
-# Supported values: JS_RUNTIME = "hermes" | "jsc"
-JS_RUNTIME=hermes
+# The hosted JavaScript engine
+# Supported values: expo.jsEngine = "hermes" | "jsc"
+expo.jsEngine=hermes

--- a/apps/bare-sandbox/android/app/build.gradle
+++ b/apps/bare-sandbox/android/app/build.gradle
@@ -78,7 +78,7 @@ import com.android.build.OutputFile
  */
 
 project.ext.react = [
-    enableHermes: false
+    enableHermes: (findProperty('expo.jsEngine') ?: "jsc") == "hermes",
 ]
 
 apply from: "../../node_modules/react-native/react.gradle"

--- a/apps/bare-sandbox/android/gradle.properties
+++ b/apps/bare-sandbox/android/gradle.properties
@@ -27,3 +27,7 @@ android.enableJetifier=true
 
 # Version of flipper SDK to use with React Native
 FLIPPER_VERSION=0.54.0
+
+# The hosted JavaScript engine
+# Supported values: expo.jsEngine = "hermes" | "jsc"
+expo.jsEngine=hermes

--- a/templates/expo-template-bare-minimum/android/app/build.gradle
+++ b/templates/expo-template-bare-minimum/android/app/build.gradle
@@ -78,7 +78,7 @@ import com.android.build.OutputFile
  */
 
 project.ext.react = [
-    enableHermes: false
+    enableHermes: (findProperty('expo.jsEngine') ?: "jsc") == "hermes",
 ]
 
 apply from: '../../node_modules/react-native-unimodules/gradle.groovy'

--- a/templates/expo-template-bare-minimum/android/gradle.properties
+++ b/templates/expo-template-bare-minimum/android/gradle.properties
@@ -27,3 +27,7 @@ android.enableJetifier=true
 
 # Version of flipper SDK to use with React Native
 FLIPPER_VERSION=0.54.0
+
+# The hosted JavaScript engine
+# Supported values: expo.jsEngine = "hermes" | "jsc"
+expo.jsEngine=jsc

--- a/templates/expo-template-bare-typescript/android/app/build.gradle
+++ b/templates/expo-template-bare-typescript/android/app/build.gradle
@@ -78,7 +78,7 @@ import com.android.build.OutputFile
  */
 
 project.ext.react = [
-    enableHermes: false
+    enableHermes: (findProperty('expo.jsEngine') ?: "jsc") == "hermes",
 ]
 
 apply from: '../../node_modules/react-native-unimodules/gradle.groovy'

--- a/templates/expo-template-bare-typescript/android/gradle.properties
+++ b/templates/expo-template-bare-typescript/android/gradle.properties
@@ -27,3 +27,7 @@ android.enableJetifier=true
 
 # Version of flipper SDK to use with React Native
 FLIPPER_VERSION=0.54.0
+
+# The hosted JavaScript engine
+# Supported values: expo.jsEngine = "hermes" | "jsc"
+expo.jsEngine=jsc


### PR DESCRIPTION
# Why

update the template layouts to support javascript engine replacement.

# How

specify `enableHermes` setting by gradle.properties which is easier for config-plugins to parse or update.

### Default engine
bare-expo: hermes
bare-sandbox: hermes
expo-template-bare-minimum: jsc
expo-template-bare-typescript: jsc

even to have changes in templates, that changes should be backward-compatible (still stick on jsc).

# Test Plan

bare-apps: build passes and run.
