### PR TITLE
[barcode-scanner] Add empty permission responses for web

### DIFF
--- a/packages/expo-barcode-scanner/src/ExpoBarCodeScannerModule.web.ts
+++ b/packages/expo-barcode-scanner/src/ExpoBarCodeScannerModule.web.ts
@@ -1,3 +1,12 @@
+import { PermissionResponse, PermissionStatus } from 'expo-modules-core';
+
+const noPermissionResponse: PermissionResponse = {
+  status: PermissionStatus.UNDETERMINED,
+  canAskAgain: true,
+  granted: false,
+  expires: 'never',
+};
+
 export default {
   get name(): string {
     return 'ExpoBarCodeScannerModule';
@@ -24,5 +33,11 @@ export default {
   },
   get Type() {
     return { front: 'front', back: 'back' };
+  },
+  async getPermissionsAsync(): Promise<PermissionResponse> {
+    return noPermissionResponse;
+  },
+  async requestPermissionsAsync(): Promise<PermissionResponse> {
+    return noPermissionResponse;
   },
 };


### PR DESCRIPTION
# Why

Related to #12279

We might need to overhaul the barcode scanner library to fully support web. Right now, we only have a sort-of web support using `expo-camera`, but that's QR only.


# How

Added empty responses, similar to [`expo-calendar`](https://github.com/expo/expo/blob/master/packages/expo-calendar/src/ExpoCalendar.web.ts)

# Test Plan

Check if running `requestPermissions` on web for barcode scanner doesn't crash.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).