### PR TITLE
Add monorepo support to `expo-dev-menu`

### DIFF
--- a/packages/expo-dev-menu/plugin/src/withDevMenu.ts
+++ b/packages/expo-dev-menu/plugin/src/withDevMenu.ts
@@ -92,7 +92,7 @@ const withDevMenuActivity: ConfigPlugin = config => {
   });
 };
 
-const withDevMenuPodfile: ConfigPlugin<DevMenuPodOptions | undefined> = (config, options) => {
+const withDevMenuPodfile: ConfigPlugin<DevMenuPodOptions> = (config, options) => {
   return withDangerousMod(config, [
     'ios',
     async config => {
@@ -115,7 +115,7 @@ const withDevMenuPodfile: ConfigPlugin<DevMenuPodOptions | undefined> = (config,
   ]);
 };
 
-const withDevMenu = (config: ExpoConfig, devMenuPodfileOptions?: DevMenuPodOptions) => {
+const withDevMenu = (config: ExpoConfig, devMenuPodfileOptions: DevMenuPodOptions = {}) => {
   config = withDevMenuActivity(config);
   config = withDevMenuPodfile(config, devMenuPodfileOptions);
   config = withDevMenuAppDelegate(config);

--- a/packages/expo-dev-menu/plugin/src/withDevMenu.ts
+++ b/packages/expo-dev-menu/plugin/src/withDevMenu.ts
@@ -17,8 +17,13 @@ const pkg = require('expo-dev-menu/package.json');
 const DEV_MENU_ANDROID_IMPORT = 'expo.modules.devmenu.react.DevMenuAwareReactActivity';
 const DEV_MENU_ACTIVITY_CLASS = 'public class MainActivity extends DevMenuAwareReactActivity {';
 
-const DEV_MENU_POD_IMPORT =
-  "pod 'expo-dev-menu', path: '../node_modules/expo-dev-menu', :configurations => :debug";
+type DevMenuPodOptions = {
+  nodeModulesPath?: string
+}
+
+const getDevMenuPodImport = ({ nodeModulesPath = '../node_modules '}: DevMenuPodOptions) => {
+  return `pod 'expo-dev-menu', path: '${nodeModulesPath}/expo-dev-menu', :configurations => :debug`;
+}
 
 async function readFileAsync(path: string): Promise<string> {
   return fs.promises.readFile(path, 'utf8');
@@ -87,7 +92,7 @@ const withDevMenuActivity: ConfigPlugin = config => {
   });
 };
 
-const withDevMenuPodfile: ConfigPlugin = config => {
+const withDevMenuPodfile: ConfigPlugin<DevMenuPodOptions | undefined> = (config, options) => {
   return withDangerousMod(config, [
     'ios',
     async config => {
@@ -101,7 +106,7 @@ const withDevMenuPodfile: ConfigPlugin = config => {
             /pod ['"]expo-dev-menu['"],\s?path: ['"]\.\.\/node_modules\/expo-dev-menu['"],\s?:?configurations:?\s(?:=>\s)?:debug/
           )
         ) {
-          podfile = addLines(podfile, 'use_react_native', 0, [`  ${DEV_MENU_POD_IMPORT}`]);
+          podfile = addLines(podfile, 'use_react_native', 0, [`  ${getDevMenuPodImport(options)}`]);
         }
         return podfile;
       });
@@ -110,9 +115,9 @@ const withDevMenuPodfile: ConfigPlugin = config => {
   ]);
 };
 
-const withDevMenu = (config: ExpoConfig) => {
+const withDevMenu = (config: ExpoConfig, devMenuPodfileOptions?: DevMenuPodOptions) => {
   config = withDevMenuActivity(config);
-  config = withDevMenuPodfile(config);
+  config = withDevMenuPodfile(config, devMenuPodfileOptions);
   config = withDevMenuAppDelegate(config);
   return config;
 };

--- a/packages/expo-dev-menu/plugin/src/withDevMenu.ts
+++ b/packages/expo-dev-menu/plugin/src/withDevMenu.ts
@@ -21,7 +21,7 @@ type DevMenuPodOptions = {
   nodeModulesPath?: string
 }
 
-const getDevMenuPodImport = ({ nodeModulesPath = '../node_modules '}: DevMenuPodOptions = {}) => {
+const getDevMenuPodImport = ({ nodeModulesPath = '../node_modules' }: DevMenuPodOptions = {}) => {
   return `pod 'expo-dev-menu', path: '${nodeModulesPath}/expo-dev-menu', :configurations => :debug`;
 }
 

--- a/packages/expo-dev-menu/plugin/src/withDevMenu.ts
+++ b/packages/expo-dev-menu/plugin/src/withDevMenu.ts
@@ -21,7 +21,7 @@ type DevMenuPodOptions = {
   nodeModulesPath?: string
 }
 
-const getDevMenuPodImport = ({ nodeModulesPath = '../node_modules '}: DevMenuPodOptions) => {
+const getDevMenuPodImport = ({ nodeModulesPath = '../node_modules '}: DevMenuPodOptions = {}) => {
   return `pod 'expo-dev-menu', path: '${nodeModulesPath}/expo-dev-menu', :configurations => :debug`;
 }
 


### PR DESCRIPTION
# Why

Currently `expo-dev-menu`'s config plugin resolves node modules to your current folder. This breaks in a monorepo, which should resolve to the level. 

# How

By adding the `nodeModulesPath`, users can set `nodeModulesPath: '../../../node_modules'`.

# Test Plan

Using this in my app.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).