### PR TITLE
[contacts] Switch to androidx.annotation.Nullable

### DIFF
--- a/packages/expo-contacts/CHANGELOG.md
+++ b/packages/expo-contacts/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🐛 Bug fixes
 
 - Enable kotlin in all modules. ([#12716](https://github.com/expo/expo/pull/12716) by [@wschurman](https://github.com/wschurman))
-- Switch to androidx.annotation.Nullable.
+- Switch to androidx.annotation.Nullable. ([#13133](https://github.com/expo/expo/pull/13133) by [@brentvatne](https://github.com/brentvatne))
 
 ### 💡 Others
 

--- a/packages/expo-contacts/CHANGELOG.md
+++ b/packages/expo-contacts/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Enable kotlin in all modules. ([#12716](https://github.com/expo/expo/pull/12716) by [@wschurman](https://github.com/wschurman))
+- Switch to androidx.annotation.Nullable.
 
 ### 💡 Others
 

--- a/packages/expo-contacts/android/build.gradle
+++ b/packages/expo-contacts/android/build.gradle
@@ -76,5 +76,6 @@ dependencies {
   unimodule "unimodules-core"
   unimodule 'expo-modules-core'
 
+  implementation 'androidx.annotation:annotation:1.2.0'
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${safeExtGet('kotlinVersion', '1.4.21')}"
 }

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/Contact.java
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/Contact.java
@@ -11,7 +11,7 @@ import android.provider.ContactsContract;
 import android.text.TextUtils;
 import android.util.Log;
 
-import org.jetbrains.annotations.Nullable;
+import androidx.annotation.Nullable;
 
 import java.io.ByteArrayOutputStream;
 import java.text.ParseException;


### PR DESCRIPTION
# Why

Fixes #13100

# How

It's not immediately clear to me why adding `expo-camera` as described in #13100 breaks the `org.jetbrains.annotations.Nullable` import, but to be consistent with other packages in the SDK we should be using the androidx annotation anyhow.

# Test Plan

Follow steps in #13100. Patch `node_modules` with this diff.

# Checklist
- [n/a] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).