### PR TITLE
[docs] Explicitly mention timeouts in expo-updates docs

### DIFF
--- a/docs/pages/versions/unversioned/sdk/updates.md
+++ b/docs/pages/versions/unversioned/sdk/updates.md
@@ -73,7 +73,7 @@ A `Promise` that resolves to an object with the following keys:
 - **isAvailable (_boolean_)** -- `true` if an update is available, `false` if you're already running the most up-to-date JS bundle.
 - **manifest (_object_)** -- If `isAvailable` is true, the manifest of the available update. Undefined otherwise.
 
-The `Promise` rejects if the app is in development mode, or if there is an unexpected error communicating with the server.
+The `Promise` rejects if the app is in development mode, or if there is an unexpected error or timeout communicating with the server.
 
 ### `Updates.fetchUpdateAsync()`
 
@@ -88,7 +88,7 @@ A `Promise` that resolves to an object with the following keys:
 - **isNew (_boolean_)** -- `true` if the fetched bundle is new (i.e. a different version than what's currently running), `false` otherwise.
 - **manifest (_object_)** -- If `isNew` is true, the manifest of the newly downloaded update. Undefined otherwise.
 
-The `Promise` rejects if the app is in development mode, or if there is an unexpected error communicating with the server.
+The `Promise` rejects if the app is in development mode, or if there is an unexpected error or timeout communicating with the server.
 
 ### `Updates.addListener(eventListener)`
 

--- a/docs/pages/versions/v40.0.0/sdk/updates.md
+++ b/docs/pages/versions/v40.0.0/sdk/updates.md
@@ -73,7 +73,7 @@ A `Promise` that resolves to an object with the following keys:
 - **isAvailable (_boolean_)** -- `true` if an update is available, `false` if you're already running the most up-to-date JS bundle.
 - **manifest (_object_)** -- If `isAvailable` is true, the manifest of the available update. Undefined otherwise.
 
-The `Promise` rejects if the app is in development mode, or if there is an unexpected error communicating with the server.
+The `Promise` rejects if the app is in development mode, or if there is an unexpected error or timeout communicating with the server.
 
 ### `Updates.fetchUpdateAsync()`
 
@@ -88,7 +88,7 @@ A `Promise` that resolves to an object with the following keys:
 - **isNew (_boolean_)** -- `true` if the fetched bundle is new (i.e. a different version than what's currently running), `false` otherwise.
 - **manifest (_object_)** -- If `isNew` is true, the manifest of the newly downloaded update. Undefined otherwise.
 
-The `Promise` rejects if the app is in development mode, or if there is an unexpected error communicating with the server.
+The `Promise` rejects if the app is in development mode, or if there is an unexpected error or timeout communicating with the server.
 
 ### `Updates.addListener(eventListener)`
 

--- a/docs/pages/versions/v41.0.0/sdk/updates.md
+++ b/docs/pages/versions/v41.0.0/sdk/updates.md
@@ -73,7 +73,7 @@ A `Promise` that resolves to an object with the following keys:
 - **isAvailable (_boolean_)** -- `true` if an update is available, `false` if you're already running the most up-to-date JS bundle.
 - **manifest (_object_)** -- If `isAvailable` is true, the manifest of the available update. Undefined otherwise.
 
-The `Promise` rejects if the app is in development mode, or if there is an unexpected error communicating with the server.
+The `Promise` rejects if the app is in development mode, or if there is an unexpected error or timeout communicating with the server.
 
 ### `Updates.fetchUpdateAsync()`
 
@@ -88,7 +88,7 @@ A `Promise` that resolves to an object with the following keys:
 - **isNew (_boolean_)** -- `true` if the fetched bundle is new (i.e. a different version than what's currently running), `false` otherwise.
 - **manifest (_object_)** -- If `isNew` is true, the manifest of the newly downloaded update. Undefined otherwise.
 
-The `Promise` rejects if the app is in development mode, or if there is an unexpected error communicating with the server.
+The `Promise` rejects if the app is in development mode, or if there is an unexpected error or timeout communicating with the server.
 
 ### `Updates.addListener(eventListener)`
 


### PR DESCRIPTION
Why: make it clear that server timeouts are a possible cause of errors.

How: explicitly mentioned timeouts in the sections that talk about server errors.

Test Plan: view docs, http://localhost:3002/versions/v41.0.0/sdk/updates/#updatescheckforupdateasync
<img width="729" alt="Screen Shot 2021-06-02 at 1 03 35 PM" src="https://user-images.githubusercontent.com/379606/120545147-21422280-c3a3-11eb-815a-291b1a4b8ef3.png">
