### PR TITLE
[expo-updates-interface] make Update nullable in onSuccess callback

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### 🐛 Bug fixes
 
+- Updates integration: make Update nullable in onSuccess callback ([#13136](https://github.com/expo/expo/pull/13136) by [@esamelson](https://github.com/esamelson))
+
 ### 💡 Others
 
 ## 0.3.4 — 2021-05-20

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/helpers/DevLauncherUpdatesHelper.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/helpers/DevLauncherUpdatesHelper.kt
@@ -16,7 +16,10 @@ suspend fun UpdatesInterface.loadUpdate(
 ): UpdatesInterface.Update =
   suspendCoroutine { cont ->
     this.fetchUpdateWithConfiguration(configuration, context, object : UpdatesInterface.UpdateCallback {
-      override fun onSuccess(update: UpdatesInterface.Update) = cont.resume(update)
+      override fun onSuccess(update: UpdatesInterface.Update?) {
+        // if the update is null, we previously aborted the fetch, so we've already resumed
+        update?.let { cont.resume(update) }
+      }
       override fun onFailure(e: Exception?) {
         cont.resumeWithException(e ?: Exception("There was an unexpected error loading the update."))
       }

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -309,8 +309,10 @@ NSString *fakeLauncherBundleUrl = @"embedded://EXDevLauncher/dummy";
       return YES;
     } progress:^(NSUInteger successfulAssetCount, NSUInteger failedAssetCount, NSUInteger totalAssetCount) {
       // do nothing for now
-    } success:^(NSDictionary *manifest) {
-      launchExpoApp(self->_updatesInterface.launchAssetURL, [EXDevLauncherManifest fromJsonObject:manifest]);
+    } success:^(NSDictionary * _Nullable manifest) {
+      if (manifest) {
+        launchExpoApp(self->_updatesInterface.launchAssetURL, [EXDevLauncherManifest fromJsonObject:manifest]);
+      }
     } error:onError];
   } onError:onError];
 }

--- a/packages/expo-updates-interface/CHANGELOG.md
+++ b/packages/expo-updates-interface/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Make Update nullable in onSuccess callback ([#13136](https://github.com/expo/expo/pull/13136) by [@esamelson](https://github.com/esamelson))
+
 ### 💡 Others
 
 ## 0.0.1 — 2021-05-28

--- a/packages/expo-updates-interface/android/src/main/java/expo/modules/updatesinterface/UpdatesInterface.java
+++ b/packages/expo-updates-interface/android/src/main/java/expo/modules/updatesinterface/UpdatesInterface.java
@@ -20,7 +20,7 @@ public interface UpdatesInterface {
     /**
      * Called when a manifest has been downloaded. The return value indicates whether or not to
      * continue downloading the update described by this manifest. Returning `false` will abort the
-     * load and no other callback methods will be called.
+     * load, and the `onSuccess` callback will be immediately called with a null `update`.
      */
     boolean onManifestLoaded(JSONObject manifest);
   }

--- a/packages/expo-updates-interface/ios/EXUpdatesInterface/EXUpdatesInterface.h
+++ b/packages/expo-updates-interface/ios/EXUpdatesInterface/EXUpdatesInterface.h
@@ -5,7 +5,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 typedef void (^EXUpdatesErrorBlock) (NSError *error);
-typedef void (^EXUpdatesSuccessBlock) (NSDictionary *manifest);
+typedef void (^EXUpdatesSuccessBlock) (NSDictionary * _Nullable manifest);
 typedef void (^EXUpdatesProgressBlock) (NSUInteger successfulAssetCount, NSUInteger failedAssetCount, NSUInteger totalAssetCount);
 typedef BOOL (^EXUpdatesManifestBlock) (NSDictionary *manifest);
 

--- a/packages/expo-updates-interface/ios/EXUpdatesInterface/EXUpdatesInterface.h
+++ b/packages/expo-updates-interface/ios/EXUpdatesInterface/EXUpdatesInterface.h
@@ -7,8 +7,17 @@ NS_ASSUME_NONNULL_BEGIN
 typedef void (^EXUpdatesErrorBlock) (NSError *error);
 typedef void (^EXUpdatesSuccessBlock) (NSDictionary * _Nullable manifest);
 typedef void (^EXUpdatesProgressBlock) (NSUInteger successfulAssetCount, NSUInteger failedAssetCount, NSUInteger totalAssetCount);
+/**
+ * Called when a manifest has been downloaded. The return value indicates whether or not to
+ * continue downloading the update described by this manifest. Returning `NO` will abort the
+ * load, and the success block will be immediately called with a nil `manifest`.
+ */
 typedef BOOL (^EXUpdatesManifestBlock) (NSDictionary *manifest);
 
+/**
+ * Protocol for modules that depend on expo-updates for loading production updates but do not want
+ * to depend on expo-updates or delegate control to the singleton EXUpdatesAppController.
+ */
 @protocol EXUpdatesInterface
 
 @property (nonatomic, weak) id bridge;

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Enable kotlin in all modules. ([#12716](https://github.com/expo/expo/pull/12716) by [@wschurman](https://github.com/wschurman))
 - Rename Update.metadata -> manifest in internal module classes. ([#12818](https://github.com/expo/expo/pull/12818) by [@esamelson](https://github.com/esamelson))
 - Reset selection policy in UpdatesDevLauncherController ([#13113](https://github.com/expo/expo/pull/13113) by [@esamelson](https://github.com/esamelson))
+- UpdatesDevLauncherController: make Update nullable in onSuccess callback ([#13136](https://github.com/expo/expo/pull/13136) by [@esamelson](https://github.com/esamelson))
 
 ### 💡 Others
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.java
@@ -78,6 +78,7 @@ public class UpdatesDevLauncherController implements UpdatesInterface {
       public void onSuccess(@Nullable UpdateEntity update) {
         databaseHolder.releaseDatabase();
         if (update == null) {
+          callback.onSuccess(null);
           return;
         }
         launchNewestUpdate(updatesConfiguration, context, callback);

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesDevLauncherController.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesDevLauncherController.m
@@ -84,9 +84,11 @@ typedef NS_ENUM(NSInteger, EXUpdatesDevLauncherErrorCode) {
   } asset:^(EXUpdatesAsset * _Nonnull asset, NSUInteger successfulAssetCount, NSUInteger failedAssetCount, NSUInteger totalAssetCount) {
     progressBlock(successfulAssetCount, failedAssetCount, totalAssetCount);
   } success:^(EXUpdatesUpdate * _Nullable update) {
-    if (update) {
-      [self _launchUpdate:update withConfiguration:updatesConfiguration success:successBlock error:errorBlock];
+    if (!update) {
+      successBlock(nil);
+      return;
     }
+    [self _launchUpdate:update withConfiguration:updatesConfiguration success:successBlock error:errorBlock];
   } error:errorBlock];
 }
 


### PR DESCRIPTION
# Why

https://github.com/expo/expo/pull/13112#discussion_r643628875

Initially I imagined that if the caller aborts fetching an update by returning `false` to the `onManifest` callback, we shouldn't call any other callbacks; but based on @ide's comment I'm thinking it's better to let the calling class decide.

# How

Make success callback's update/manifest parameter nullable, and pass through the null value in the case where the caller has aborted fetching an update.

# Test Plan

Tested on both platforms by opening a locally served project in the dev client (which is an example of the case in question) and making sure the project loaded without any issues.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).