### PR TITLE
[android] pickFirst for only necessary libraries

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -77,7 +77,12 @@ android {
     abortOnError false
   }
   packagingOptions {
-    pickFirst "lib/**"
+    // libfbjni.so is prebuilt library shared between all ABIs
+    pickFirst "lib/**/libfbjni.so"
+
+    // TODO: Remove when we drop support for SDK 41
+    pickFirst "lib/**/libhermes-inspector.so"
+    pickFirst "lib/**/libfolly_futures.so"
   }
 }
 

--- a/tools/src/versioning/android/android-build-aar.sh
+++ b/tools/src/versioning/android/android-build-aar.sh
@@ -37,7 +37,7 @@ unzip expoview/libs/ReactAndroid-temp.aar -d expoview/libs/ReactAndroid-temp
 set +e
 UNRENAMED_LIBS=`unzip -l expoview/libs/ReactAndroid-temp.aar | grep 'lib.*\.so' | grep -v "$ABI_VERSION" | grep -v 'libc++_shared.so' | grep -v 'libfbjni.so'`
 if [ "x$UNRENAMED_LIBS" != "x" ]; then
-  echo -e "\n\n👀 These libraries are still not be renamed. Please make sure to update \`tools/src/versioning/android/libraries.ts\`."
+  echo -e "\n\n👀 The following libraries have not been renamed. Please make sure to update \`tools/src/versioning/android/libraries.ts\`."
   echo "$UNRENAMED_LIBS"
   exit 1
 fi

--- a/tools/src/versioning/android/android-build-aar.sh
+++ b/tools/src/versioning/android/android-build-aar.sh
@@ -32,6 +32,18 @@ cp versioned-react-native/ReactAndroid/build/outputs/aar/ReactAndroid-release.aa
 rm -rf expoview/libs/ReactAndroid-temp
 unzip expoview/libs/ReactAndroid-temp.aar -d expoview/libs/ReactAndroid-temp
 
+# Sanity check for renaming all the native libraries,
+# but excluding prebuilt libraries like libc++_shared.so and libfbjni.so.
+set +e
+UNRENAMED_LIBS=`unzip -l expoview/libs/ReactAndroid-temp.aar | grep 'lib.*\.so' | grep -v "$ABI_VERSION" | grep -v 'libc++_shared.so' | grep -v 'libfbjni.so'`
+if [ "x$UNRENAMED_LIBS" != "x" ]; then
+  echo -e "\n\n👀 These libraries are still not be renamed. Please make sure to update \`tools/src/versioning/android/libraries.ts\`."
+  echo "$UNRENAMED_LIBS"
+  exit 1
+fi
+unset UNRENAMED_LIBS
+set -e
+
 # Write jarjar rules file. Used in next step to rename package
 rm -f jarjar-rules.txt
 

--- a/tools/src/versioning/android/libraries.ts
+++ b/tools/src/versioning/android/libraries.ts
@@ -31,6 +31,9 @@ export const JniLibNames = [
   'hermes-executor-release',
   'hermes-executor-debug',
   'reanimated',
+  'hermes-inspector',
+  'fbjni',
+  'folly_futures',
 ];
 
 // this list is used in the shell scripts as well as directly by expotools


### PR DESCRIPTION
# Why

pickFirst is risky that we will never know which libraries will be picked if duplicated files are from different versions.
in this pr, we try to pick the libraries we really need:

- libfbjni.so
prebuilt library from gradle dependency `extractJNI("com.facebook.fbjni:fbjni:0.0.2")`
- libhermes-inspector.so
- libfolly_futures.so
libraries we didn't rename during sdk publishment before.

fortunately, sdk 39-41 are all based on react native 0.63, so it should not have problems in the meantime.

in the future, only libfbjni.so is needed for pickFirst.
that might still be a risk once we upgrade react native 0.65+ who use the fbjni version.
(somehow we might need to build fbjni ourselves from source or patch old react-native to unify fbjni version)

Closes [ENG-782](https://linear.app/expo/issue/ENG-782)

# How

1. pickFirst for only necessary libraries.
2. add libhermes-inspector.so and libfolly_futures.so to auto renaming list.
3. add sanity check if there are any libraries we didn't rename from versioning.
![Screen Shot 2021-06-03 at 12 21 30 PM](https://user-images.githubusercontent.com/46429/120597188-50c25f00-c477-11eb-8740-989a978caf13.png)

# Test Plan

1. client-android build pass
2. `et add-sdk -p android` will not show errors
