### PR TITLE
[docs] Remove pending web support for Google

### DIFF
--- a/docs/pages/versions/unversioned/sdk/google-sign-in.md
+++ b/docs/pages/versions/unversioned/sdk/google-sign-in.md
@@ -7,7 +7,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`expo-google-sign-in`** provides native Google authentication for **standalone** Expo apps or bare React Native apps. It cannot be used in Expo Go as the native `GoogleSignIn` library expects your `REVERSED_CLIENT_ID` in the `info.plist` at build-time. To use Google authentication in the Expo Go, check out [`expo-google-app-auth`](google.md) or [expo-app-auth](app-auth.md).
 
-<PlatformsSection android emulator ios simulator web={{ pending: 'https://github.com/expo/expo/issues/6884' }} />
+<PlatformsSection android emulator ios simulator />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/google.md
+++ b/docs/pages/versions/unversioned/sdk/google.md
@@ -10,7 +10,7 @@ import { InlineCode } from '~/components/base/code';
 
 **`expo-google-app-auth`** provides Google authentication integration for Expo apps using a secure system web browser with native [**`expo-app-auth`**][expo-app-auth]. This is better than a WebView because you can reuse credentials saved on the device. This module uses [PKCE](https://tools.ietf.org/html/rfc7636) for secure native authentication. You won't need to define a provider config because this package utilizes Open ID Connect [auto discovery](https://openid.net/specs/openid-connect-discovery-1_0.html).
 
-<PlatformsSection android emulator ios simulator web={{ pending: 'https://github.com/expo/expo/issues/6884' }} />
+<PlatformsSection android emulator ios simulator />
 
 ### How it works
 

--- a/docs/pages/versions/v38.0.0/sdk/google-sign-in.md
+++ b/docs/pages/versions/v38.0.0/sdk/google-sign-in.md
@@ -7,7 +7,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`expo-google-sign-in`** provides native Google authentication for **standalone** Expo apps or bare React Native apps. It cannot be used in the Expo client as the native `GoogleSignIn` library expects your `REVERSE_CLIENT_ID` in the `info.plist` at build-time. To use Google authentication in the Expo client, check out [`expo-google-app-auth`](google.md) or [expo-app-auth](app-auth.md).
 
-<PlatformsSection android emulator ios simulator web={{ pending: 'https://github.com/expo/expo/issues/6884' }} />
+<PlatformsSection android emulator ios simulator />
 
 ## Installation
 

--- a/docs/pages/versions/v38.0.0/sdk/google.md
+++ b/docs/pages/versions/v38.0.0/sdk/google.md
@@ -8,7 +8,7 @@ import { InlineCode } from '~/components/base/code';
 
 **`expo-google-app-auth`** provides Google authentication integration for Expo apps using a secure system web browser with native [**`expo-app-auth`**][expo-app-auth]. This is better than a WebView because you can reuse credentials saved on the device. This module uses [PKCE](https://tools.ietf.org/html/rfc7636) for secure native authentication. You won't need to define a provider config because this package utilizes Open ID Connect [auto discovery](https://openid.net/specs/openid-connect-discovery-1_0.html).
 
-<PlatformsSection android emulator ios simulator web={{ pending: 'https://github.com/expo/expo/issues/6884' }} />
+<PlatformsSection android emulator ios simulator />
 
 ### How it works
 

--- a/docs/pages/versions/v39.0.0/sdk/google-sign-in.md
+++ b/docs/pages/versions/v39.0.0/sdk/google-sign-in.md
@@ -7,7 +7,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`expo-google-sign-in`** provides native Google authentication for **standalone** Expo apps or bare React Native apps. It cannot be used in the Expo client as the native `GoogleSignIn` library expects your `REVERSED_CLIENT_ID` in the `info.plist` at build-time. To use Google authentication in the Expo client, check out [`expo-google-app-auth`](google.md) or [expo-app-auth](app-auth.md).
 
-<PlatformsSection android emulator ios simulator web={{ pending: 'https://github.com/expo/expo/issues/6884' }} />
+<PlatformsSection android emulator ios simulator />
 
 ## Installation
 

--- a/docs/pages/versions/v39.0.0/sdk/google.md
+++ b/docs/pages/versions/v39.0.0/sdk/google.md
@@ -8,7 +8,7 @@ import { InlineCode } from '~/components/base/code';
 
 **`expo-google-app-auth`** provides Google authentication integration for Expo apps using a secure system web browser with native [**`expo-app-auth`**][expo-app-auth]. This is better than a WebView because you can reuse credentials saved on the device. This module uses [PKCE](https://tools.ietf.org/html/rfc7636) for secure native authentication. You won't need to define a provider config because this package utilizes Open ID Connect [auto discovery](https://openid.net/specs/openid-connect-discovery-1_0.html).
 
-<PlatformsSection android emulator ios simulator web={{ pending: 'https://github.com/expo/expo/issues/6884' }} />
+<PlatformsSection android emulator ios simulator />
 
 ### How it works
 

--- a/docs/pages/versions/v40.0.0/sdk/google-sign-in.md
+++ b/docs/pages/versions/v40.0.0/sdk/google-sign-in.md
@@ -7,7 +7,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`expo-google-sign-in`** provides native Google authentication for **standalone** Expo apps or bare React Native apps. It cannot be used in the Expo Go as the native `GoogleSignIn` library expects your `REVERSED_CLIENT_ID` in the `info.plist` at build-time. To use Google authentication in the Expo Go, check out [`expo-google-app-auth`](google.md) or [expo-app-auth](app-auth.md).
 
-<PlatformsSection android emulator ios simulator web={{ pending: 'https://github.com/expo/expo/issues/6884' }} />
+<PlatformsSection android emulator ios simulator />
 
 ## Installation
 

--- a/docs/pages/versions/v40.0.0/sdk/google.md
+++ b/docs/pages/versions/v40.0.0/sdk/google.md
@@ -10,7 +10,7 @@ import { InlineCode } from '~/components/base/code';
 
 **`expo-google-app-auth`** provides Google authentication integration for Expo apps using a secure system web browser with native [**`expo-app-auth`**][expo-app-auth]. This is better than a WebView because you can reuse credentials saved on the device. This module uses [PKCE](https://tools.ietf.org/html/rfc7636) for secure native authentication. You won't need to define a provider config because this package utilizes Open ID Connect [auto discovery](https://openid.net/specs/openid-connect-discovery-1_0.html).
 
-<PlatformsSection android emulator ios simulator web={{ pending: 'https://github.com/expo/expo/issues/6884' }} />
+<PlatformsSection android emulator ios simulator />
 
 ### How it works
 

--- a/docs/pages/versions/v41.0.0/sdk/google-sign-in.md
+++ b/docs/pages/versions/v41.0.0/sdk/google-sign-in.md
@@ -7,7 +7,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`expo-google-sign-in`** provides native Google authentication for **standalone** Expo apps or bare React Native apps. It cannot be used in Expo Go as the native `GoogleSignIn` library expects your `REVERSED_CLIENT_ID` in the `info.plist` at build-time. To use Google authentication in the Expo Go, check out [`expo-google-app-auth`](google.md) or [expo-app-auth](app-auth.md).
 
-<PlatformsSection android emulator ios simulator web={{ pending: 'https://github.com/expo/expo/issues/6884' }} />
+<PlatformsSection android emulator ios simulator />
 
 ## Installation
 

--- a/docs/pages/versions/v41.0.0/sdk/google.md
+++ b/docs/pages/versions/v41.0.0/sdk/google.md
@@ -10,7 +10,7 @@ import { InlineCode } from '~/components/base/code';
 
 **`expo-google-app-auth`** provides Google authentication integration for Expo apps using a secure system web browser with native [**`expo-app-auth`**][expo-app-auth]. This is better than a WebView because you can reuse credentials saved on the device. This module uses [PKCE](https://tools.ietf.org/html/rfc7636) for secure native authentication. You won't need to define a provider config because this package utilizes Open ID Connect [auto discovery](https://openid.net/specs/openid-connect-discovery-1_0.html).
 
-<PlatformsSection android emulator ios simulator web={{ pending: 'https://github.com/expo/expo/issues/6884' }} />
+<PlatformsSection android emulator ios simulator />
 
 ### How it works
 


### PR DESCRIPTION
# Why

The [pending PR](https://github.com/expo/expo/issues/6884) was closed in favor of `AuthSession`, people should use that instead.

# How

Removed Google and GoogleSignIn pending status for web support 

# Test Plan

Just a docs change

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).