### PR TITLE
[docs] Remove pending web support for AppAuth

### DIFF
--- a/docs/pages/versions/unversioned/sdk/app-auth.md
+++ b/docs/pages/versions/unversioned/sdk/app-auth.md
@@ -18,7 +18,7 @@ Many services that let you authenticate with them or login with them, like GitHu
 
 If you are trying to implement sign in with [Google](google-sign-in.md) or [Facebook](facebook.md), there are special modules in the Expo SDK for those (though this module will work).
 
-<PlatformsSection android emulator ios simulator web={{ pending: 'https://github.com/expo/expo/issues/6883' }} />
+<PlatformsSection android emulator ios simulator />
 
 ## Installation
 

--- a/docs/pages/versions/v38.0.0/sdk/app-auth.md
+++ b/docs/pages/versions/v38.0.0/sdk/app-auth.md
@@ -18,7 +18,7 @@ Many services that let you authenticate with them or login with them, like GitHu
 
 If you are trying to implement sign in with [Google](google-sign-in.md) or [Facebook](facebook.md), there are special modules in the Expo SDK for those (though this module will work).
 
-<PlatformsSection android emulator ios simulator web={{ pending: 'https://github.com/expo/expo/issues/6883' }} />
+<PlatformsSection android emulator ios simulator />
 
 ## Installation
 

--- a/docs/pages/versions/v39.0.0/sdk/app-auth.md
+++ b/docs/pages/versions/v39.0.0/sdk/app-auth.md
@@ -18,7 +18,7 @@ Many services that let you authenticate with them or login with them, like GitHu
 
 If you are trying to implement sign in with [Google](google-sign-in.md) or [Facebook](facebook.md), there are special modules in the Expo SDK for those (though this module will work).
 
-<PlatformsSection android emulator ios simulator web={{ pending: 'https://github.com/expo/expo/issues/6883' }} />
+<PlatformsSection android emulator ios simulator />
 
 ## Installation
 

--- a/docs/pages/versions/v40.0.0/sdk/app-auth.md
+++ b/docs/pages/versions/v40.0.0/sdk/app-auth.md
@@ -18,7 +18,7 @@ Many services that let you authenticate with them or login with them, like GitHu
 
 If you are trying to implement sign in with [Google](google-sign-in.md) or [Facebook](facebook.md), there are special modules in the Expo SDK for those (though this module will work).
 
-<PlatformsSection android emulator ios simulator web={{ pending: 'https://github.com/expo/expo/issues/6883' }} />
+<PlatformsSection android emulator ios simulator />
 
 ## Installation
 

--- a/docs/pages/versions/v41.0.0/sdk/app-auth.md
+++ b/docs/pages/versions/v41.0.0/sdk/app-auth.md
@@ -18,7 +18,7 @@ Many services that let you authenticate with them or login with them, like GitHu
 
 If you are trying to implement sign in with [Google](google-sign-in.md) or [Facebook](facebook.md), there are special modules in the Expo SDK for those (though this module will work).
 
-<PlatformsSection android emulator ios simulator web={{ pending: 'https://github.com/expo/expo/issues/6883' }} />
+<PlatformsSection android emulator ios simulator />
 
 ## Installation
 


### PR DESCRIPTION
# Why

The [pending PR](https://github.com/expo/expo/issues/6883) was closed in favor of `AuthSession`, people should use that instead.

# How

Removed AppAuth pending status for web support 

# Test Plan

Just a docs change

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).