### PR TITLE
[docs] Remove duplicated eslint modules

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -72,8 +72,6 @@
     "axios": "^0.19.2",
     "danger": "^9.2.10",
     "esbuild-loader": "^2.9.2",
-    "eslint": "^7.9.0",
-    "eslint-config-universe": "^4.0.0",
     "eslint": "^7.23.0",
     "eslint-config-universe": "^7.0.1",
     "eslint-plugin-lodash": "^7.2.0",

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -5826,7 +5826,7 @@ lodash.uniq@4.5.0, lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21:
+lodash@>=4, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
# Why

These were duplicated in PR #12569, also referencing different versions. 

# How

This removes the duplicated and outdated versions.

# Test Plan

Check if linting works and the docs can be built.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).