### PR TITLE
[expo-dev-client] Autogenerate a common URI scheme for iOS/Android if none exist

### DIFF
--- a/packages/expo-dev-client/CHANGELOG.md
+++ b/packages/expo-dev-client/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- [plugin] Autogenerate a common URI scheme for iOS/Android if one doesn't exist. ([#13147](https://github.com/expo/expo/pull/13147) by [@fson](https://github.com/fson))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-dev-client/plugin/build/generateScheme.d.ts
+++ b/packages/expo-dev-client/plugin/build/generateScheme.d.ts
@@ -1,0 +1,2 @@
+import { ExpoConfig } from '@expo/config-types';
+export default function generateScheme(config: Pick<ExpoConfig, 'slug'>): string;

--- a/packages/expo-dev-client/plugin/build/generateScheme.js
+++ b/packages/expo-dev-client/plugin/build/generateScheme.js
@@ -1,0 +1,20 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+/*
+ * Converts the slug from app configuration to a string that's a valid URI scheme.
+ * From RFC3986 Section 3.1.
+ * scheme      = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
+ */
+function generateScheme(config) {
+    // Remove unallowed characters. Also remove `-` to keep this shorter.
+    let scheme = config.slug.replace(/[^A-Za-z0-9+\-.]/g, '');
+    // Edge case: if the slug didn't include any allowed characters we may end up with an empty string.
+    if (scheme.length === 0) {
+        throw new Error('Could not autogenerate a scheme. Please set the "scheme" property in app config.');
+    }
+    // Lowercasing might not be strictly necessary, but let's do it for stylistic purposes.
+    scheme = scheme.toLowerCase();
+    // Add a prefix to avoid leading digits and to distinguish from user-defined schemes.
+    return `exp+${scheme}`;
+}
+exports.default = generateScheme;

--- a/packages/expo-dev-client/plugin/build/withDevClient.js
+++ b/packages/expo-dev-client/plugin/build/withDevClient.js
@@ -10,6 +10,8 @@ const app_plugin_1 = __importDefault(require("expo-dev-launcher/app.plugin"));
 const app_plugin_2 = __importDefault(require("expo-dev-menu/app.plugin"));
 const fs_1 = __importDefault(require("fs"));
 const path_1 = __importDefault(require("path"));
+const withGeneratedAndroidScheme_1 = __importDefault(require("./withGeneratedAndroidScheme"));
+const withGeneratedIosScheme_1 = __importDefault(require("./withGeneratedIosScheme"));
 const pkg = require('expo-dev-client/package.json');
 const REACT_NATIVE_CONFIG_JS = `// File created by expo-dev-client/app.plugin.js
 
@@ -47,6 +49,8 @@ function withDevClient(config) {
     config = app_plugin_2.default(config);
     config = app_plugin_1.default(config);
     config = withReactNativeConfigJs(config);
+    config = withGeneratedAndroidScheme_1.default(config);
+    config = withGeneratedIosScheme_1.default(config);
     return config;
 }
 exports.default = config_plugins_1.createRunOncePlugin(withDevClient, pkg.name, pkg.version);

--- a/packages/expo-dev-client/plugin/build/withGeneratedAndroidScheme.d.ts
+++ b/packages/expo-dev-client/plugin/build/withGeneratedAndroidScheme.d.ts
@@ -1,0 +1,5 @@
+import { AndroidManifest } from '@expo/config-plugins';
+import { ExpoConfig } from '@expo/config-types';
+declare const _default: import("@expo/config-plugins").ConfigPlugin<void>;
+export default _default;
+export declare function setGeneratedAndroidScheme(config: Pick<ExpoConfig, 'scheme' | 'slug'>, androidManifest: AndroidManifest): AndroidManifest;

--- a/packages/expo-dev-client/plugin/build/withGeneratedAndroidScheme.js
+++ b/packages/expo-dev-client/plugin/build/withGeneratedAndroidScheme.js
@@ -1,0 +1,20 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.setGeneratedAndroidScheme = void 0;
+const config_plugins_1 = require("@expo/config-plugins");
+const android_plugins_1 = require("@expo/config-plugins/build/plugins/android-plugins");
+const generateScheme_1 = __importDefault(require("./generateScheme"));
+exports.default = android_plugins_1.createAndroidManifestPlugin(setGeneratedAndroidScheme, 'withGeneratedAndroidScheme');
+function setGeneratedAndroidScheme(config, androidManifest) {
+    if (!config.scheme) {
+        // No cross-platform scheme specified in configuration,
+        // generate one to be used for launching the dev client.
+        const scheme = generateScheme_1.default(config);
+        return config_plugins_1.AndroidConfig.Scheme.appendScheme(scheme, androidManifest);
+    }
+    return androidManifest;
+}
+exports.setGeneratedAndroidScheme = setGeneratedAndroidScheme;

--- a/packages/expo-dev-client/plugin/build/withGeneratedAndroidScheme.js
+++ b/packages/expo-dev-client/plugin/build/withGeneratedAndroidScheme.js
@@ -9,12 +9,8 @@ const android_plugins_1 = require("@expo/config-plugins/build/plugins/android-pl
 const generateScheme_1 = __importDefault(require("./generateScheme"));
 exports.default = android_plugins_1.createAndroidManifestPlugin(setGeneratedAndroidScheme, 'withGeneratedAndroidScheme');
 function setGeneratedAndroidScheme(config, androidManifest) {
-    if (!config.scheme) {
-        // No cross-platform scheme specified in configuration,
-        // generate one to be used for launching the dev client.
-        const scheme = generateScheme_1.default(config);
-        return config_plugins_1.AndroidConfig.Scheme.appendScheme(scheme, androidManifest);
-    }
-    return androidManifest;
+    // Generate a cross-platform scheme used to launch the dev client.
+    const scheme = generateScheme_1.default(config);
+    return config_plugins_1.AndroidConfig.Scheme.appendScheme(scheme, androidManifest);
 }
 exports.setGeneratedAndroidScheme = setGeneratedAndroidScheme;

--- a/packages/expo-dev-client/plugin/build/withGeneratedIosScheme.d.ts
+++ b/packages/expo-dev-client/plugin/build/withGeneratedIosScheme.d.ts
@@ -1,0 +1,5 @@
+import { IOSConfig, InfoPlist } from '@expo/config-plugins';
+import { ExpoConfig } from '@expo/config-types';
+declare const _default: import("@expo/config-plugins").ConfigPlugin<void>;
+export default _default;
+export declare function setGeneratedIosScheme(config: Pick<ExpoConfig, 'scheme' | 'slug'>, infoPlist: InfoPlist): IOSConfig.InfoPlist;

--- a/packages/expo-dev-client/plugin/build/withGeneratedIosScheme.js
+++ b/packages/expo-dev-client/plugin/build/withGeneratedIosScheme.js
@@ -1,0 +1,21 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.setGeneratedIosScheme = void 0;
+const config_plugins_1 = require("@expo/config-plugins");
+const ios_plugins_1 = require("@expo/config-plugins/build/plugins/ios-plugins");
+const generateScheme_1 = __importDefault(require("./generateScheme"));
+exports.default = ios_plugins_1.createInfoPlistPlugin(setGeneratedIosScheme, 'withGeneratedIosScheme');
+function setGeneratedIosScheme(config, infoPlist) {
+    if (!config.scheme) {
+        // No cross-platform scheme specified in configuration,
+        // generate one to be used for launching the dev client.
+        const scheme = generateScheme_1.default(config);
+        const result = config_plugins_1.IOSConfig.Scheme.appendScheme(scheme, infoPlist);
+        return result;
+    }
+    return infoPlist;
+}
+exports.setGeneratedIosScheme = setGeneratedIosScheme;

--- a/packages/expo-dev-client/plugin/build/withGeneratedIosScheme.js
+++ b/packages/expo-dev-client/plugin/build/withGeneratedIosScheme.js
@@ -9,13 +9,9 @@ const ios_plugins_1 = require("@expo/config-plugins/build/plugins/ios-plugins");
 const generateScheme_1 = __importDefault(require("./generateScheme"));
 exports.default = ios_plugins_1.createInfoPlistPlugin(setGeneratedIosScheme, 'withGeneratedIosScheme');
 function setGeneratedIosScheme(config, infoPlist) {
-    if (!config.scheme) {
-        // No cross-platform scheme specified in configuration,
-        // generate one to be used for launching the dev client.
-        const scheme = generateScheme_1.default(config);
-        const result = config_plugins_1.IOSConfig.Scheme.appendScheme(scheme, infoPlist);
-        return result;
-    }
-    return infoPlist;
+    // Generate a cross-platform scheme used to launch the dev client.
+    const scheme = generateScheme_1.default(config);
+    const result = config_plugins_1.IOSConfig.Scheme.appendScheme(scheme, infoPlist);
+    return result;
 }
 exports.setGeneratedIosScheme = setGeneratedIosScheme;

--- a/packages/expo-dev-client/plugin/src/__tests__/fixtures/test-AndroidManifest.xml
+++ b/packages/expo-dev-client/plugin/src/__tests__/fixtures/test-AndroidManifest.xml
@@ -1,0 +1,26 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.helloworld">
+  <uses-permission android:name="android.permission.INTERNET"/>
+  <application
+    android:name=".MainApplication"
+    android:label="@string/app_name"
+    android:icon="@mipmap/ic_launcher"
+    android:roundIcon="@mipmap/ic_launcher_round"
+    android:allowBackup="false"
+    android:theme="@style/AppTheme"
+  >
+    <activity
+      android:name=".MainActivity"
+      android:label="@string/app_name"
+      android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
+      android:launchMode="singleTask"
+      android:windowSoftInputMode="adjustResize"
+      android:theme="@style/Theme.App.SplashScreen"
+    >
+      <intent-filter>
+        <action android:name="android.intent.action.MAIN"/>
+        <category android:name="android.intent.category.LAUNCHER"/>
+      </intent-filter>
+    </activity>
+    <activity android:name="com.facebook.react.devsupport.DevSettingsActivity"/>
+  </application>
+</manifest>

--- a/packages/expo-dev-client/plugin/src/__tests__/generateScheme-test.ts
+++ b/packages/expo-dev-client/plugin/src/__tests__/generateScheme-test.ts
@@ -1,0 +1,23 @@
+import generateScheme from '../generateScheme';
+
+it(`generates a valid URI scheme from slug`, () => {
+  expect(generateScheme({ slug: 'hello-world' })).toMatchInlineSnapshot(`"exp+hello-world"`);
+  expect(generateScheme({ slug: 'my app 2000' })).toMatchInlineSnapshot(`"exp+myapp2000"`);
+  expect(generateScheme({ slug: 'Yolo ¯\\_(ツ)_/¯' })).toMatchInlineSnapshot(`"exp+yolo"`);
+});
+
+it(`removes unallowed characters`, () => {
+  // scheme      = ALPHA *( ALPHA /` DIGIT / "+" / "-" / "." )
+  expect(generateScheme({ slug: 'miun äppi!1!!!!!@' })).toMatch(/^[A-Za-z][A-Za-z0-9+\-.]*/);
+});
+
+it(`doesn't start with a number or special character`, () => {
+  // scheme      = ALPHA *( ALPHA /` DIGIT / "+" / "-" / "." )
+  expect(generateScheme({ slug: '650-industries' })).toMatch(/^[A-Za-z][A-Za-z0-9+\-.]*/);
+});
+
+it(`bails out if there aren't any ASCII characters in the slug to work with`, () => {
+  expect(() => generateScheme({ slug: '👋' })).toThrowErrorMatchingInlineSnapshot(
+    `"Could not autogenerate a scheme. Please set the \\"scheme\\" property in app config."`
+  );
+});

--- a/packages/expo-dev-client/plugin/src/__tests__/withGeneratedIosScheme-test.ts
+++ b/packages/expo-dev-client/plugin/src/__tests__/withGeneratedIosScheme-test.ts
@@ -1,0 +1,23 @@
+import { setGeneratedIosScheme } from '../withGeneratedIosScheme';
+
+it(`adds a scheme, if not specified in the config`, () => {
+  const config = { slug: 'cello' };
+  const infoPlist = {};
+  expect(setGeneratedIosScheme(config, infoPlist)).toMatchInlineSnapshot(`
+    Object {
+      "CFBundleURLTypes": Array [
+        Object {
+          "CFBundleURLSchemes": Array [
+            "exp+cello",
+          ],
+        },
+      ],
+    }
+  `);
+});
+
+it(`doesn't add anything, if scheme is defined in config`, () => {
+  const config = { scheme: 'play', slug: 'cello' };
+  const infoPlist = {};
+  expect(setGeneratedIosScheme(config, infoPlist)).toEqual(infoPlist);
+});

--- a/packages/expo-dev-client/plugin/src/__tests__/withGeneratedIosScheme-test.ts
+++ b/packages/expo-dev-client/plugin/src/__tests__/withGeneratedIosScheme-test.ts
@@ -1,6 +1,6 @@
 import { setGeneratedIosScheme } from '../withGeneratedIosScheme';
 
-it(`adds a scheme, if not specified in the config`, () => {
+it(`adds a scheme generated from slug`, () => {
   const config = { slug: 'cello' };
   const infoPlist = {};
   expect(setGeneratedIosScheme(config, infoPlist)).toMatchInlineSnapshot(`
@@ -14,10 +14,4 @@ it(`adds a scheme, if not specified in the config`, () => {
       ],
     }
   `);
-});
-
-it(`doesn't add anything, if scheme is defined in config`, () => {
-  const config = { scheme: 'play', slug: 'cello' };
-  const infoPlist = {};
-  expect(setGeneratedIosScheme(config, infoPlist)).toEqual(infoPlist);
 });

--- a/packages/expo-dev-client/plugin/src/generateScheme.ts
+++ b/packages/expo-dev-client/plugin/src/generateScheme.ts
@@ -1,0 +1,23 @@
+import { ExpoConfig } from '@expo/config-types';
+
+/*
+ * Converts the slug from app configuration to a string that's a valid URI scheme.
+ * From RFC3986 Section 3.1.
+ * scheme      = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
+ */
+export default function generateScheme(config: Pick<ExpoConfig, 'slug'>): string {
+  // Remove unallowed characters. Also remove `-` to keep this shorter.
+  let scheme = config.slug.replace(/[^A-Za-z0-9+\-.]/g, '');
+  // Edge case: if the slug didn't include any allowed characters we may end up with an empty string.
+  if (scheme.length === 0) {
+    throw new Error(
+      'Could not autogenerate a scheme. Please set the "scheme" property in app config.'
+    );
+  }
+
+  // Lowercasing might not be strictly necessary, but let's do it for stylistic purposes.
+  scheme = scheme.toLowerCase();
+
+  // Add a prefix to avoid leading digits and to distinguish from user-defined schemes.
+  return `exp+${scheme}`;
+}

--- a/packages/expo-dev-client/plugin/src/withDevClient.ts
+++ b/packages/expo-dev-client/plugin/src/withDevClient.ts
@@ -6,6 +6,8 @@ import withDevLauncher from 'expo-dev-launcher/app.plugin';
 import withDevMenu from 'expo-dev-menu/app.plugin';
 import fs from 'fs';
 import path from 'path';
+import withGeneratedAndroidScheme from './withGeneratedAndroidScheme';
+import withGeneratedIosScheme from './withGeneratedIosScheme';
 
 const pkg = require('expo-dev-client/package.json');
 
@@ -47,6 +49,8 @@ function withDevClient(config: ExpoConfig) {
   config = withDevMenu(config);
   config = withDevLauncher(config);
   config = withReactNativeConfigJs(config);
+  config = withGeneratedAndroidScheme(config);
+  config = withGeneratedIosScheme(config);
   return config;
 }
 

--- a/packages/expo-dev-client/plugin/src/withDevClient.ts
+++ b/packages/expo-dev-client/plugin/src/withDevClient.ts
@@ -6,6 +6,7 @@ import withDevLauncher from 'expo-dev-launcher/app.plugin';
 import withDevMenu from 'expo-dev-menu/app.plugin';
 import fs from 'fs';
 import path from 'path';
+
 import withGeneratedAndroidScheme from './withGeneratedAndroidScheme';
 import withGeneratedIosScheme from './withGeneratedIosScheme';
 

--- a/packages/expo-dev-client/plugin/src/withGeneratedAndroidScheme.ts
+++ b/packages/expo-dev-client/plugin/src/withGeneratedAndroidScheme.ts
@@ -1,0 +1,20 @@
+import { AndroidConfig, AndroidManifest } from '@expo/config-plugins';
+import { createAndroidManifestPlugin } from '@expo/config-plugins/build/plugins/android-plugins';
+import { ExpoConfig } from '@expo/config-types';
+
+import generateScheme from './generateScheme';
+
+export default createAndroidManifestPlugin(setGeneratedAndroidScheme, 'withGeneratedAndroidScheme');
+
+export function setGeneratedAndroidScheme(
+  config: Pick<ExpoConfig, 'scheme' | 'slug'>,
+  androidManifest: AndroidManifest
+): AndroidManifest {
+  if (!config.scheme) {
+    // No cross-platform scheme specified in configuration,
+    // generate one to be used for launching the dev client.
+    const scheme = generateScheme(config);
+    return AndroidConfig.Scheme.appendScheme(scheme, androidManifest);
+  }
+  return androidManifest;
+}

--- a/packages/expo-dev-client/plugin/src/withGeneratedAndroidScheme.ts
+++ b/packages/expo-dev-client/plugin/src/withGeneratedAndroidScheme.ts
@@ -10,11 +10,7 @@ export function setGeneratedAndroidScheme(
   config: Pick<ExpoConfig, 'scheme' | 'slug'>,
   androidManifest: AndroidManifest
 ): AndroidManifest {
-  if (!config.scheme) {
-    // No cross-platform scheme specified in configuration,
-    // generate one to be used for launching the dev client.
-    const scheme = generateScheme(config);
-    return AndroidConfig.Scheme.appendScheme(scheme, androidManifest);
-  }
-  return androidManifest;
+  // Generate a cross-platform scheme used to launch the dev client.
+  const scheme = generateScheme(config);
+  return AndroidConfig.Scheme.appendScheme(scheme, androidManifest);
 }

--- a/packages/expo-dev-client/plugin/src/withGeneratedIosScheme.ts
+++ b/packages/expo-dev-client/plugin/src/withGeneratedIosScheme.ts
@@ -1,4 +1,4 @@
-import { IOSConfig, InfoPlist, withInfoPlist } from '@expo/config-plugins';
+import { IOSConfig, InfoPlist } from '@expo/config-plugins';
 import { createInfoPlistPlugin } from '@expo/config-plugins/build/plugins/ios-plugins';
 import { ExpoConfig } from '@expo/config-types';
 

--- a/packages/expo-dev-client/plugin/src/withGeneratedIosScheme.ts
+++ b/packages/expo-dev-client/plugin/src/withGeneratedIosScheme.ts
@@ -1,0 +1,21 @@
+import { IOSConfig, InfoPlist, withInfoPlist } from '@expo/config-plugins';
+import { createInfoPlistPlugin } from '@expo/config-plugins/build/plugins/ios-plugins';
+import { ExpoConfig } from '@expo/config-types';
+
+import generateScheme from './generateScheme';
+
+export default createInfoPlistPlugin(setGeneratedIosScheme, 'withGeneratedIosScheme');
+
+export function setGeneratedIosScheme(
+  config: Pick<ExpoConfig, 'scheme' | 'slug'>,
+  infoPlist: InfoPlist
+): IOSConfig.InfoPlist {
+  if (!config.scheme) {
+    // No cross-platform scheme specified in configuration,
+    // generate one to be used for launching the dev client.
+    const scheme = generateScheme(config);
+    const result = IOSConfig.Scheme.appendScheme(scheme, infoPlist);
+    return result;
+  }
+  return infoPlist;
+}

--- a/packages/expo-dev-client/plugin/src/withGeneratedIosScheme.ts
+++ b/packages/expo-dev-client/plugin/src/withGeneratedIosScheme.ts
@@ -10,12 +10,8 @@ export function setGeneratedIosScheme(
   config: Pick<ExpoConfig, 'scheme' | 'slug'>,
   infoPlist: InfoPlist
 ): IOSConfig.InfoPlist {
-  if (!config.scheme) {
-    // No cross-platform scheme specified in configuration,
-    // generate one to be used for launching the dev client.
-    const scheme = generateScheme(config);
-    const result = IOSConfig.Scheme.appendScheme(scheme, infoPlist);
-    return result;
-  }
-  return infoPlist;
+  // Generate a cross-platform scheme used to launch the dev client.
+  const scheme = generateScheme(config);
+  const result = IOSConfig.Scheme.appendScheme(scheme, infoPlist);
+  return result;
 }


### PR DESCRIPTION
# Why

At the moment `expo start --dev-client` requires a common URI scheme for Android and iOS to exist in the app to be able to make a URI (and QR code) for the app and to be able to launch it.

If `scheme` property is defined in `app.json`, that scheme can be used by the CLI. If not, we will need to add autogenerate a scheme in the config plugin for `expo-dev-client` so that this autogenerated scheme can be used instead.

# How

One field that's always defined in the configuration is the `slug`. If not defined explicitly, it generated from `name`. And if `name` is not defined, it will be generated from the name of the directory as the last resort. It will always be defined.

So we'll generate the scheme from the slug.

A scheme MUST start with alphabetic character (A-Z, a-z) which can be followed by alphanumeric characters, hyphens (-), plus (+) and period (.). We strip all other characters away from the slug. We could also try some fancy transliteration similar to the `slugify` npm package, so that "ääkköset" would be turned into "aakkoset" etc., but we're not doing this because:
- it's important for the algorithm to be simple and stable, we don't want changes to the npm package to change the scheme because then the app won't open
- there's no need to generate a fancy scheme, since this is just a fallback for when no scheme is defined
- it's expected for the slug to already be in the slugified form (but we're stripping out unallowed characters anyway because this is not guaranteed)

We also prefix the scheme with `exp+`. This serves two purposes:
- avoids starting the scheme with a number because now it always starts with `exp+`.
- distinguishes the scheme from user defined schemes or schemes set by other plugins

I chose `exp+` because the scheme for Expo Go (default client) is `exp` so `exp+myapp` kind of makes sense as a scheme for a custom client :)

# Test Plan

In a managed app:
- Removed `scheme` from `app.json`
- Ran:
```
yarn link expo-dev-client
expo prebuild
```
Checked that schemes were added to `AndroidManifest.xml` and `Info.plist`. Tried starting `expo start` to verify that the new scheme was used.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).