### PR TITLE
update / fix usage of react-native-fade-in-image

### DIFF
--- a/home/components/ListItem.tsx
+++ b/home/components/ListItem.tsx
@@ -85,7 +85,7 @@ export default class ListItem extends React.PureComponent<Props> {
         const source = typeof image === 'number' ? image : { uri: image };
         return (
           <View style={[styles.imageContainer, imageSizeStyle, imageStyle]}>
-            <FadeIn placeholderColor="#eee">
+            <FadeIn>
               <Image source={source} style={[styles.image, imageSizeStyle]} />
             </FadeIn>
           </View>

--- a/home/components/SeeAllProjectsButton.tsx
+++ b/home/components/SeeAllProjectsButton.tsx
@@ -40,7 +40,7 @@ export default class SeeAllProjectsButton extends React.Component<Props> {
                 ? { uri: app.iconUrl }
                 : require('../assets/placeholder-app-icon.png');
               return (
-                <FadeIn key={i} placeholderColor="#eee">
+                <FadeIn key={i}>
                   <Image source={image} style={styles.appIcon} />
                 </FadeIn>
               );

--- a/home/package.json
+++ b/home/package.json
@@ -54,7 +54,7 @@
     "react": "16.13.1",
     "react-native": "0.63.2",
     "react-native-appearance": "~0.3.3",
-    "react-native-fade-in-image": "^1.6.0",
+    "react-native-fade-in-image": "^1.6.1",
     "react-native-gesture-handler": "~1.10.2",
     "react-native-infinite-scroll-view": "^0.4.5",
     "react-native-maps": "0.27.1",

--- a/home/package.json
+++ b/home/package.json
@@ -54,7 +54,7 @@
     "react": "16.13.1",
     "react-native": "0.63.2",
     "react-native-appearance": "~0.3.3",
-    "react-native-fade-in-image": "^1.5.0",
+    "react-native-fade-in-image": "^1.6.0",
     "react-native-gesture-handler": "~1.10.2",
     "react-native-infinite-scroll-view": "^0.4.5",
     "react-native-maps": "0.27.1",

--- a/home/types/react-native-fade-in-image.d.ts
+++ b/home/types/react-native-fade-in-image.d.ts
@@ -1,1 +1,0 @@
-declare module 'react-native-fade-in-image';

--- a/yarn.lock
+++ b/yarn.lock
@@ -17396,10 +17396,10 @@ react-native-bundle-visualizer@^2.2.1:
     rimraf "^3.0.2"
     source-map-explorer "^2.4.2"
 
-react-native-fade-in-image@^1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/react-native-fade-in-image/-/react-native-fade-in-image-1.5.0.tgz#efface43f9846b1d1ffd6c6894576cede710617d"
-  integrity sha512-I03XZzr9flUnGO9XqMsv1rWAcpvHR6bhPamKsM6S8kjgYeYFUAVT7qNmyB3bN+qfRFPMFEkSlXE1TqUG2pZ8vw==
+react-native-fade-in-image@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/react-native-fade-in-image/-/react-native-fade-in-image-1.6.1.tgz#4645a57a505558a1d22da5c304a903aaa8ed2772"
+  integrity sha512-tGERKpO01Iu6D1eLFu9HC7NcPJRWQGeUofXrOC3sznSnbLDNZM6jKURWuAZmxKaE5YZIHi/zecu0TqEyjgMOTA==
   dependencies:
     react-clone-referenced-element "^1.0.1"
     react-mixin "^3.0.5"


### PR DESCRIPTION
# Why

Update version of `react-native-fade-in-image` to use provided type declarations. Also, fix misuse of props in two files.

# How

Remove `declare module react-native-fade-in-image` type declaration and bump minor version in `package.json`. 
Removed use of nonexistent prop `placeholderColor` in two places. Didn't need to replace with `placeholderStyle: { backgroundColor: ... }` as the color `#eee` is the default value in the module.

# Test Plan

Compile Expo Go locally to ensure no bugs or errors are caused by minor types update.

# Checklist

Non applicable

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).