### PR TITLE
[ios] backport #13112 to versioned code

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -281,6 +281,7 @@ PODS:
   - ABI39_0_0EXUpdates (0.3.1):
     - ABI39_0_0React
     - ABI39_0_0UMCore
+  - ABI39_0_0EXUpdatesInterface (0.0.1)
   - ABI39_0_0EXVideoThumbnails (4.3.0):
     - ABI39_0_0UMCore
     - ABI39_0_0UMFileSystemInterface
@@ -819,6 +820,7 @@ PODS:
   - ABI40_0_0EXUpdates (0.4.1):
     - ABI40_0_0React-Core
     - ABI40_0_0UMCore
+  - ABI40_0_0EXUpdatesInterface (0.0.1)
   - ABI40_0_0EXVideoThumbnails (4.4.0):
     - ABI40_0_0UMCore
     - ABI40_0_0UMFileSystemInterface
@@ -1389,6 +1391,7 @@ PODS:
     - ABI41_0_0EXStructuredHeaders
     - ABI41_0_0React-Core
     - ABI41_0_0UMCore
+  - ABI41_0_0EXUpdatesInterface (0.0.1)
   - ABI41_0_0EXVideoThumbnails (5.1.0):
     - ABI41_0_0UMCore
     - ABI41_0_0UMFileSystemInterface
@@ -1913,12 +1916,15 @@ PODS:
     - UMCore
   - EXUpdates (0.6.0):
     - EXStructuredHeaders
+    - EXUpdatesInterface
     - React-Core
     - UMCore
   - EXUpdates/Tests (0.6.0):
     - EXStructuredHeaders
+    - EXUpdatesInterface
     - React-Core
     - UMCore
+  - EXUpdatesInterface (0.0.1)
   - EXVideoThumbnails (5.1.0):
     - ExpoModulesCore
     - UMCore
@@ -2434,6 +2440,7 @@ DEPENDENCIES:
   - ABI39_0_0EXStructuredHeaders (from `./versioned-react-native/ABI39_0_0/Expo/EXStructuredHeaders`)
   - ABI39_0_0EXTaskManager (from `./versioned-react-native/ABI39_0_0/Expo/EXTaskManager`)
   - ABI39_0_0EXUpdates (from `./versioned-react-native/ABI39_0_0/Expo/EXUpdates`)
+  - ABI39_0_0EXUpdatesInterface (from `./versioned-react-native/ABI39_0_0/Expo/EXUpdatesInterface`)
   - ABI39_0_0EXVideoThumbnails (from `./versioned-react-native/ABI39_0_0/Expo/EXVideoThumbnails`)
   - ABI39_0_0EXWebBrowser (from `./versioned-react-native/ABI39_0_0/Expo/EXWebBrowser`)
   - ABI39_0_0FBLazyVector (from `./versioned-react-native/ABI39_0_0/ReactNative/Libraries/FBLazyVector`)
@@ -2537,6 +2544,7 @@ DEPENDENCIES:
   - ABI40_0_0EXStructuredHeaders (from `./versioned-react-native/ABI40_0_0/Expo/EXStructuredHeaders`)
   - ABI40_0_0EXTaskManager (from `./versioned-react-native/ABI40_0_0/Expo/EXTaskManager`)
   - ABI40_0_0EXUpdates (from `./versioned-react-native/ABI40_0_0/Expo/EXUpdates`)
+  - ABI40_0_0EXUpdatesInterface (from `./versioned-react-native/ABI40_0_0/Expo/EXUpdatesInterface`)
   - ABI40_0_0EXVideoThumbnails (from `./versioned-react-native/ABI40_0_0/Expo/EXVideoThumbnails`)
   - ABI40_0_0EXWebBrowser (from `./versioned-react-native/ABI40_0_0/Expo/EXWebBrowser`)
   - ABI40_0_0FBLazyVector (from `./versioned-react-native/ABI40_0_0/ReactNative/Libraries/FBLazyVector`)
@@ -2640,6 +2648,7 @@ DEPENDENCIES:
   - ABI41_0_0EXTaskManager (from `./versioned-react-native/ABI41_0_0/Expo/EXTaskManager`)
   - ABI41_0_0EXTrackingTransparency (from `./versioned-react-native/ABI41_0_0/Expo/EXTrackingTransparency`)
   - ABI41_0_0EXUpdates (from `./versioned-react-native/ABI41_0_0/Expo/EXUpdates`)
+  - ABI41_0_0EXUpdatesInterface (from `./versioned-react-native/ABI41_0_0/Expo/EXUpdatesInterface`)
   - ABI41_0_0EXVideoThumbnails (from `./versioned-react-native/ABI41_0_0/Expo/EXVideoThumbnails`)
   - ABI41_0_0EXWebBrowser (from `./versioned-react-native/ABI41_0_0/Expo/EXWebBrowser`)
   - ABI41_0_0FBLazyVector (from `./versioned-react-native/ABI41_0_0/ReactNative/Libraries/FBLazyVector`)
@@ -2752,6 +2761,7 @@ DEPENDENCIES:
   - EXTrackingTransparency (from `../packages/expo-tracking-transparency/ios`)
   - EXUpdates (from `../packages/expo-updates/ios`)
   - EXUpdates/Tests (from `../packages/expo-updates/ios`)
+  - EXUpdatesInterface (from `../packages/expo-updates-interface/ios`)
   - EXVideoThumbnails (from `../packages/expo-video-thumbnails/ios`)
   - EXWebBrowser (from `../packages/expo-web-browser/ios`)
   - FBLazyVector (from `../react-native-lab/react-native/Libraries/FBLazyVector`)
@@ -2959,6 +2969,8 @@ EXTERNAL SOURCES:
     :path: "./versioned-react-native/ABI39_0_0/Expo/EXTaskManager"
   ABI39_0_0EXUpdates:
     :path: "./versioned-react-native/ABI39_0_0/Expo/EXUpdates"
+  ABI39_0_0EXUpdatesInterface:
+    :path: "./versioned-react-native/ABI39_0_0/Expo/EXUpdatesInterface"
   ABI39_0_0EXVideoThumbnails:
     :path: "./versioned-react-native/ABI39_0_0/Expo/EXVideoThumbnails"
   ABI39_0_0EXWebBrowser:
@@ -3159,6 +3171,8 @@ EXTERNAL SOURCES:
     :path: "./versioned-react-native/ABI40_0_0/Expo/EXTaskManager"
   ABI40_0_0EXUpdates:
     :path: "./versioned-react-native/ABI40_0_0/Expo/EXUpdates"
+  ABI40_0_0EXUpdatesInterface:
+    :path: "./versioned-react-native/ABI40_0_0/Expo/EXUpdatesInterface"
   ABI40_0_0EXVideoThumbnails:
     :path: "./versioned-react-native/ABI40_0_0/Expo/EXVideoThumbnails"
   ABI40_0_0EXWebBrowser:
@@ -3359,6 +3373,8 @@ EXTERNAL SOURCES:
     :path: "./versioned-react-native/ABI41_0_0/Expo/EXTrackingTransparency"
   ABI41_0_0EXUpdates:
     :path: "./versioned-react-native/ABI41_0_0/Expo/EXUpdates"
+  ABI41_0_0EXUpdatesInterface:
+    :path: "./versioned-react-native/ABI41_0_0/Expo/EXUpdatesInterface"
   ABI41_0_0EXVideoThumbnails:
     :path: "./versioned-react-native/ABI41_0_0/Expo/EXVideoThumbnails"
   ABI41_0_0EXWebBrowser:
@@ -3571,6 +3587,8 @@ EXTERNAL SOURCES:
     :path: "../packages/expo-tracking-transparency/ios"
   EXUpdates:
     :path: "../packages/expo-updates/ios"
+  EXUpdatesInterface:
+    :path: "../packages/expo-updates-interface/ios"
   EXVideoThumbnails:
     :path: "../packages/expo-video-thumbnails/ios"
   EXWebBrowser:
@@ -3704,6 +3722,7 @@ SPEC CHECKSUMS:
   ABI39_0_0EXStructuredHeaders: a8ee82ecd320db16e160a07b7cc13e7ebcfd695b
   ABI39_0_0EXTaskManager: 10b5e6d9311d29dd4fa739c717f13704a4217d74
   ABI39_0_0EXUpdates: f5b053b484a3c70e6e515112511faabf9d2079d4
+  ABI39_0_0EXUpdatesInterface: 32a87fc28cd3aea2857a37ae9113dba1e60c1e76
   ABI39_0_0EXVideoThumbnails: 352a80fc860b96b1d03e4b80e9880372c2b56674
   ABI39_0_0EXWebBrowser: 46208491d2133e4de89a4bcb62c0a5493b2c9c78
   ABI39_0_0FBLazyVector: 08aa5c8e5e118af21306f8515b97f2f0b1dd0b69
@@ -3804,6 +3823,7 @@ SPEC CHECKSUMS:
   ABI40_0_0EXStructuredHeaders: f4d8b1bd97cd76c206df7a1cb3ade9cea2c65759
   ABI40_0_0EXTaskManager: c30a8b453caa8bf3c712afdd346ae23a83e575f2
   ABI40_0_0EXUpdates: 24684f33c3a8797c040a97bedca35a8b7d0279a0
+  ABI40_0_0EXUpdatesInterface: fb7b6c4e56f9b587e7a55fcba8c7f9a5284333a4
   ABI40_0_0EXVideoThumbnails: 6ebadb682fe996744d2fe531fd92e2d6b4e56132
   ABI40_0_0EXWebBrowser: c70ff6aae05c64a0ba25aab9571a1c0e51ab49e5
   ABI40_0_0FBLazyVector: aacc9a03c2b7415a9a19e11a6fcf8758f42f5320
@@ -3904,6 +3924,7 @@ SPEC CHECKSUMS:
   ABI41_0_0EXTaskManager: 6be1098cb568807194a7d425fbc33092c9fe158f
   ABI41_0_0EXTrackingTransparency: 82452df66df448b5eaeca97f639019f109d6165f
   ABI41_0_0EXUpdates: cac3153bd44716866280bf0e645eed060f3e2533
+  ABI41_0_0EXUpdatesInterface: b7df6394ea5690a62e87539cba2b5bf3713c10ee
   ABI41_0_0EXVideoThumbnails: f3b4634744998652e114c0cae3a202b8a935c3e8
   ABI41_0_0EXWebBrowser: 5125cd0d9eba1f87301b784d1fbfb602a16d7fa1
   ABI41_0_0FBLazyVector: 6d79f50b57819134875729057a6709a7bdc2e2bb
@@ -4015,7 +4036,8 @@ SPEC CHECKSUMS:
   EXStructuredHeaders: 7e7eec19a326bc58cca2fb3edbac0afaecb89c16
   EXTaskManager: d30b4a5723a5969443da644d786853923efa5f17
   EXTrackingTransparency: ea1f4c054b2e0908d2a781faca6f4a5402278220
-  EXUpdates: 7c181d03d802ef71bd06c6229ac87de023bb1f2f
+  EXUpdates: dec9d211e99630e109c20b1dc626fd17e6ec3cf9
+  EXUpdatesInterface: 8649cedc0dd767fa3c1807129b92b1cd6045ebf7
   EXVideoThumbnails: 6d5a5d7c2c5f631b1950b1e8b2a0305ab741b9b4
   EXWebBrowser: 0b466c50e5ff61c9758095d49d5081e3229d77ac
   FacebookSDK: 4b9bb8e2824898b47f18c666dc145c09b40609e6

--- a/ios/versioned-react-native/ABI39_0_0/Expo/EXUpdates/ABI39_0_0EXUpdates/ABI39_0_0EXUpdatesAppController+Internal.h
+++ b/ios/versioned-react-native/ABI39_0_0/Expo/EXUpdates/ABI39_0_0EXUpdates/ABI39_0_0EXUpdatesAppController+Internal.h
@@ -1,0 +1,26 @@
+//  Copyright © 2021 650 Industries. All rights reserved.
+
+#import <ABI39_0_0EXUpdates/ABI39_0_0EXUpdatesAppController.h>
+#import <ABI39_0_0EXUpdates/ABI39_0_0EXUpdatesAppLauncher.h>
+#import <ABI39_0_0EXUpdates/ABI39_0_0EXUpdatesConfig.h>
+#import <ABI39_0_0EXUpdates/ABI39_0_0EXUpdatesSelectionPolicy.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ABI39_0_0EXUpdatesAppController (Internal)
+
+@property (nonatomic, readonly) dispatch_queue_t controllerQueue;
+
+- (BOOL)initializeUpdatesDirectoryWithError:(NSError ** _Nullable)error;
+- (BOOL)initializeUpdatesDatabaseWithError:(NSError ** _Nullable)error;
+
+- (void)setDefaultSelectionPolicy:(ABI39_0_0EXUpdatesSelectionPolicy *)selectionPolicy;
+- (void)setLauncher:(id<ABI39_0_0EXUpdatesAppLauncher>)launcher;
+- (void)setConfigurationInternal:(ABI39_0_0EXUpdatesConfig *)configuration;
+- (void)setIsStarted:(BOOL)isStarted;
+
+- (void)runReaper;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/versioned-react-native/ABI39_0_0/Expo/EXUpdates/ABI39_0_0EXUpdates/ABI39_0_0EXUpdatesAppController.m
+++ b/ios/versioned-react-native/ABI39_0_0/Expo/EXUpdates/ABI39_0_0EXUpdates/ABI39_0_0EXUpdatesAppController.m
@@ -1,6 +1,6 @@
 //  Copyright © 2019 650 Industries. All rights reserved.
 
-#import <ABI39_0_0EXUpdates/ABI39_0_0EXUpdatesAppController.h>
+#import <ABI39_0_0EXUpdates/ABI39_0_0EXUpdatesAppController+Internal.h>
 #import <ABI39_0_0EXUpdates/ABI39_0_0EXUpdatesAppLauncher.h>
 #import <ABI39_0_0EXUpdates/ABI39_0_0EXUpdatesAppLauncherNoDatabase.h>
 #import <ABI39_0_0EXUpdates/ABI39_0_0EXUpdatesAppLauncherWithDatabase.h>
@@ -12,8 +12,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 static NSString * const ABI39_0_0EXUpdatesAppControllerErrorDomain = @"ABI39_0_0EXUpdatesAppController";
 
-static NSString * const ABI39_0_0EXUpdatesConfigPlistName = @"Expo";
-
 static NSString * const ABI39_0_0EXUpdatesUpdateAvailableEventName = @"updateAvailable";
 static NSString * const ABI39_0_0EXUpdatesNoUpdateAvailableEventName = @"noUpdateAvailable";
 static NSString * const ABI39_0_0EXUpdatesErrorEventName = @"error";
@@ -24,13 +22,14 @@ static NSString * const ABI39_0_0EXUpdatesErrorEventName = @"error";
 @property (nonatomic, readwrite, strong) id<ABI39_0_0EXUpdatesAppLauncher> launcher;
 @property (nonatomic, readwrite, strong) ABI39_0_0EXUpdatesDatabase *database;
 @property (nonatomic, readwrite, strong) ABI39_0_0EXUpdatesSelectionPolicy *selectionPolicy;
+@property (nonatomic, readwrite, strong) ABI39_0_0EXUpdatesSelectionPolicy *defaultSelectionPolicy;
+@property (nonatomic, readwrite, strong) dispatch_queue_t controllerQueue;
 @property (nonatomic, readwrite, strong) dispatch_queue_t assetFilesQueue;
 
 @property (nonatomic, readwrite, strong) NSURL *updatesDirectory;
 
 @property (nonatomic, strong) id<ABI39_0_0EXUpdatesAppLauncher> candidateLauncher;
 @property (nonatomic, assign) BOOL hasLaunched;
-@property (nonatomic, strong) dispatch_queue_t controllerQueue;
 
 @property (nonatomic, assign) BOOL isStarted;
 @property (nonatomic, assign) BOOL isEmergencyLaunch;
@@ -54,9 +53,9 @@ static NSString * const ABI39_0_0EXUpdatesErrorEventName = @"error";
 - (instancetype)init
 {
   if (self = [super init]) {
-    _config = [self _loadConfigFromExpoPlist];
+    _config = [ABI39_0_0EXUpdatesConfig configWithExpoPlist];
     _database = [[ABI39_0_0EXUpdatesDatabase alloc] init];
-    _selectionPolicy = [self _defaultSelectionPolicy];
+    _defaultSelectionPolicy = [ABI39_0_0EXUpdatesSelectionPolicyFactory filterAwarePolicyWithRuntimeVersion:[ABI39_0_0EXUpdatesUtils getRuntimeVersionWithConfig:_config]];
     _assetFilesQueue = dispatch_queue_create("expo.controller.AssetFilesQueue", DISPATCH_QUEUE_SERIAL);
     _controllerQueue = dispatch_queue_create("expo.controller.ControllerQueue", DISPATCH_QUEUE_SERIAL);
     _isStarted = NO;
@@ -66,13 +65,21 @@ static NSString * const ABI39_0_0EXUpdatesErrorEventName = @"error";
 
 - (void)setConfiguration:(NSDictionary *)configuration
 {
-  if (_updatesDirectory) {
+  if (_isStarted) {
     @throw [NSException exceptionWithName:NSInternalInconsistencyException
                                    reason:@"ABI39_0_0EXUpdatesAppController:setConfiguration should not be called after start"
                                  userInfo:@{}];
   }
   [_config loadConfigFromDictionary:configuration];
   [self resetSelectionPolicyToDefault];
+}
+
+- (ABI39_0_0EXUpdatesSelectionPolicy *)selectionPolicy
+{
+  if (!_selectionPolicy) {
+    _selectionPolicy = _defaultSelectionPolicy;
+  }
+  return _selectionPolicy;
 }
 
 - (void)setNextSelectionPolicy:(ABI39_0_0EXUpdatesSelectionPolicy *)nextSelectionPolicy
@@ -82,12 +89,12 @@ static NSString * const ABI39_0_0EXUpdatesErrorEventName = @"error";
 
 - (void)resetSelectionPolicyToDefault
 {
-  _selectionPolicy = [self _defaultSelectionPolicy];
+  _selectionPolicy = nil;
 }
 
 - (void)start
 {
-  NSAssert(!_updatesDirectory, @"ABI39_0_0EXUpdatesAppController:start should only be called once per instance");
+  NSAssert(!_isStarted, @"ABI39_0_0EXUpdatesAppController:start should only be called once per instance");
 
   if (!_config.isEnabled) {
     ABI39_0_0EXUpdatesAppLauncherNoDatabase *launcher = [[ABI39_0_0EXUpdatesAppLauncherNoDatabase alloc] init];
@@ -110,22 +117,14 @@ static NSString * const ABI39_0_0EXUpdatesErrorEventName = @"error";
   _isStarted = YES;
 
   NSError *fsError;
-  _updatesDirectory = [ABI39_0_0EXUpdatesUtils initializeUpdatesDirectoryWithError:&fsError];
+  [self initializeUpdatesDirectoryWithError:&fsError];
   if (fsError) {
     [self _emergencyLaunchWithFatalError:fsError];
     return;
   }
 
-  __block BOOL dbSuccess;
-  __block NSError *dbError;
-  dispatch_semaphore_t dbSemaphore = dispatch_semaphore_create(0);
-  dispatch_async(_database.databaseQueue, ^{
-    dbSuccess = [self->_database openDatabaseInDirectory:self->_updatesDirectory withError:&dbError];
-    dispatch_semaphore_signal(dbSemaphore);
-  });
-
-  dispatch_semaphore_wait(dbSemaphore, DISPATCH_TIME_FOREVER);
-  if (!dbSuccess) {
+  NSError *dbError;
+  if (![self initializeUpdatesDatabaseWithError:&dbError]) {
     [self _emergencyLaunchWithFatalError:dbError];
     return;
   }
@@ -133,7 +132,7 @@ static NSString * const ABI39_0_0EXUpdatesErrorEventName = @"error";
   ABI39_0_0EXUpdatesAppLoaderTask *loaderTask = [[ABI39_0_0EXUpdatesAppLoaderTask alloc] initWithConfig:_config
                                                                              database:_database
                                                                             directory:_updatesDirectory
-                                                                      selectionPolicy:_selectionPolicy
+                                                                      selectionPolicy:self.selectionPolicy
                                                                         delegateQueue:_controllerQueue];
   loaderTask.delegate = self;
   [loaderTask start];
@@ -171,12 +170,12 @@ static NSString * const ABI39_0_0EXUpdatesErrorEventName = @"error";
   if (_bridge) {
     ABI39_0_0EXUpdatesAppLauncherWithDatabase *launcher = [[ABI39_0_0EXUpdatesAppLauncherWithDatabase alloc] initWithConfig:_config database:_database directory:_updatesDirectory completionQueue:_controllerQueue];
     _candidateLauncher = launcher;
-    [launcher launchUpdateWithSelectionPolicy:self->_selectionPolicy completion:^(NSError * _Nullable error, BOOL success) {
+    [launcher launchUpdateWithSelectionPolicy:self.selectionPolicy completion:^(NSError * _Nullable error, BOOL success) {
       if (success) {
         self->_launcher = self->_candidateLauncher;
         completion(YES);
         [self->_bridge reload];
-        [self _runReaper];
+        [self runReaper];
       } else {
         NSLog(@"Failed to relaunch: %@", error.localizedDescription);
         completion(NO);
@@ -251,35 +250,62 @@ static NSString * const ABI39_0_0EXUpdatesErrorEventName = @"error";
   }
 }
 
-# pragma mark - internal
+# pragma mark - ABI39_0_0EXUpdatesAppController+Internal
 
-- (ABI39_0_0EXUpdatesConfig *)_loadConfigFromExpoPlist
+- (BOOL)initializeUpdatesDirectoryWithError:(NSError ** _Nullable)error
 {
-  NSString *configPath = [[NSBundle mainBundle] pathForResource:ABI39_0_0EXUpdatesConfigPlistName ofType:@"plist"];
-  if (!configPath) {
-    @throw [NSException exceptionWithName:NSInternalInconsistencyException
-                                   reason:@"Cannot load configuration from Expo.plist. Please ensure you've followed the setup and installation instructions for expo-updates to create Expo.plist and add it to your Xcode project."
-                                 userInfo:@{}];
+  _updatesDirectory = [ABI39_0_0EXUpdatesUtils initializeUpdatesDirectoryWithError:error];
+  return _updatesDirectory != nil;
+}
+
+- (BOOL)initializeUpdatesDatabaseWithError:(NSError ** _Nullable)error
+{
+  __block NSError *dbError;
+  dispatch_semaphore_t dbSemaphore = dispatch_semaphore_create(0);
+  dispatch_async(_database.databaseQueue, ^{
+    [self->_database openDatabaseInDirectory:self->_updatesDirectory withError:&dbError];
+    dispatch_semaphore_signal(dbSemaphore);
+  });
+
+  dispatch_semaphore_wait(dbSemaphore, DISPATCH_TIME_FOREVER);
+  if (dbError && error) {
+    *error = dbError;
   }
-
-  return [ABI39_0_0EXUpdatesConfig configWithDictionary:[NSDictionary dictionaryWithContentsOfFile:configPath]];
+  return dbError == nil;
 }
 
-- (ABI39_0_0EXUpdatesSelectionPolicy *)_defaultSelectionPolicy
+- (void)setDefaultSelectionPolicy:(ABI39_0_0EXUpdatesSelectionPolicy *)selectionPolicy
 {
-  return [ABI39_0_0EXUpdatesSelectionPolicyFactory filterAwarePolicyWithRuntimeVersion:[ABI39_0_0EXUpdatesUtils getRuntimeVersionWithConfig:_config]];
+  _defaultSelectionPolicy = selectionPolicy;
 }
 
-- (void)_runReaper
+- (void)setLauncher:(id<ABI39_0_0EXUpdatesAppLauncher>)launcher
+{
+  _launcher = launcher;
+}
+
+- (void)setConfigurationInternal:(ABI39_0_0EXUpdatesConfig *)configuration
+{
+  _config = configuration;
+}
+
+- (void)setIsStarted:(BOOL)isStarted
+{
+  _isStarted = isStarted;
+}
+
+- (void)runReaper
 {
   if (_launcher.launchedUpdate) {
     [ABI39_0_0EXUpdatesReaper reapUnusedUpdatesWithConfig:_config
                                         database:_database
                                        directory:_updatesDirectory
-                                 selectionPolicy:_selectionPolicy
+                                 selectionPolicy:self.selectionPolicy
                                   launchedUpdate:_launcher.launchedUpdate];
   }
 }
+
+# pragma mark - internal
 
 - (void)_emergencyLaunchWithFatalError:(NSError *)error
 {

--- a/ios/versioned-react-native/ABI39_0_0/Expo/EXUpdates/ABI39_0_0EXUpdates/ABI39_0_0EXUpdatesConfig.h
+++ b/ios/versioned-react-native/ABI39_0_0/Expo/EXUpdates/ABI39_0_0EXUpdates/ABI39_0_0EXUpdatesConfig.h
@@ -27,6 +27,7 @@ typedef NS_ENUM(NSInteger, ABI39_0_0EXUpdatesCheckAutomaticallyConfig) {
 
 @property (nonatomic, readonly) BOOL hasEmbeddedUpdate;
 
++ (instancetype)configWithExpoPlist;
 + (instancetype)configWithDictionary:(NSDictionary *)config;
 - (void)loadConfigFromDictionary:(NSDictionary *)config;
 

--- a/ios/versioned-react-native/ABI39_0_0/Expo/EXUpdates/ABI39_0_0EXUpdates/ABI39_0_0EXUpdatesConfig.m
+++ b/ios/versioned-react-native/ABI39_0_0/Expo/EXUpdates/ABI39_0_0EXUpdates/ABI39_0_0EXUpdatesConfig.m
@@ -20,6 +20,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+static NSString * const ABI39_0_0EXUpdatesConfigPlistName = @"Expo";
+
 static NSString * const ABI39_0_0EXUpdatesDefaultReleaseChannelName = @"default";
 
 static NSString * const ABI39_0_0EXUpdatesConfigEnabledKey = @"ABI39_0_0EXUpdatesEnabled";
@@ -58,6 +60,17 @@ static NSString * const ABI39_0_0EXUpdatesConfigNeverString = @"NEVER";
   ABI39_0_0EXUpdatesConfig *updatesConfig = [[ABI39_0_0EXUpdatesConfig alloc] init];
   [updatesConfig loadConfigFromDictionary:config];
   return updatesConfig;
+}
+
++ (instancetype)configWithExpoPlist
+{
+  NSString *configPath = [[NSBundle mainBundle] pathForResource:ABI39_0_0EXUpdatesConfigPlistName ofType:@"plist"];
+  if (!configPath) {
+    @throw [NSException exceptionWithName:NSInternalInconsistencyException
+                                   reason:@"Cannot load configuration from Expo.plist. Please ensure you've followed the setup and installation instructions for expo-updates to create Expo.plist and add it to your Xcode project."
+                                 userInfo:@{}];
+  }
+  return [[self class] configWithDictionary:[NSDictionary dictionaryWithContentsOfFile:configPath]];
 }
 
 - (void)loadConfigFromDictionary:(NSDictionary *)config

--- a/ios/versioned-react-native/ABI39_0_0/Expo/EXUpdates/ABI39_0_0EXUpdates/ABI39_0_0EXUpdatesDevLauncherController.h
+++ b/ios/versioned-react-native/ABI39_0_0/Expo/EXUpdates/ABI39_0_0EXUpdates/ABI39_0_0EXUpdatesDevLauncherController.h
@@ -1,0 +1,15 @@
+//  Copyright © 2021 650 Industries. All rights reserved.
+
+#import <ABI39_0_0EXUpdatesInterface/ABI39_0_0EXUpdatesInterface.h>
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ABI39_0_0EXUpdatesDevLauncherController : NSObject <ABI39_0_0EXUpdatesInterface>
+
++ (instancetype)sharedInstance;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/versioned-react-native/ABI39_0_0/Expo/EXUpdates/ABI39_0_0EXUpdates/ABI39_0_0EXUpdatesDevLauncherController.m
+++ b/ios/versioned-react-native/ABI39_0_0/Expo/EXUpdates/ABI39_0_0EXUpdates/ABI39_0_0EXUpdatesDevLauncherController.m
@@ -1,0 +1,128 @@
+//  Copyright © 2021 650 Industries. All rights reserved.
+
+#import <ABI39_0_0EXUpdates/ABI39_0_0EXUpdatesAppController+Internal.h>
+#import <ABI39_0_0EXUpdates/ABI39_0_0EXUpdatesAppLauncherWithDatabase.h>
+#import <ABI39_0_0EXUpdates/ABI39_0_0EXUpdatesConfig.h>
+#import <ABI39_0_0EXUpdates/ABI39_0_0EXUpdatesDevLauncherController.h>
+#import <ABI39_0_0EXUpdates/ABI39_0_0EXUpdatesReaper.h>
+#import <ABI39_0_0EXUpdates/ABI39_0_0EXUpdatesReaperSelectionPolicyDevelopmentClient.h>
+#import <ABI39_0_0EXUpdates/ABI39_0_0EXUpdatesRemoteAppLoader.h>
+#import <ABI39_0_0EXUpdates/ABI39_0_0EXUpdatesSelectionPolicy.h>
+#import <ABI39_0_0EXUpdates/ABI39_0_0EXUpdatesUpdate.h>
+#import <ABI39_0_0React/ABI39_0_0RCTBridge.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+static NSString * const ABI39_0_0EXUpdatesDevLauncherControllerErrorDomain = @"ABI39_0_0EXUpdatesDevLauncherController";
+
+typedef NS_ENUM(NSInteger, ABI39_0_0EXUpdatesDevLauncherErrorCode) {
+  ABI39_0_0EXUpdatesDevLauncherErrorCodeInvalidUpdateURL = 1,
+  ABI39_0_0EXUpdatesDevLauncherErrorCodeDirectoryInitializationFailed,
+  ABI39_0_0EXUpdatesDevLauncherErrorCodeDatabaseInitializationFailed,
+  ABI39_0_0EXUpdatesDevLauncherErrorCodeUpdateLaunchFailed,
+};
+
+@implementation ABI39_0_0EXUpdatesDevLauncherController
+
+@synthesize bridge = _bridge;
+
++ (instancetype)sharedInstance
+{
+  static ABI39_0_0EXUpdatesDevLauncherController *theController;
+  static dispatch_once_t once;
+  dispatch_once(&once, ^{
+    if (!theController) {
+      theController = [ABI39_0_0EXUpdatesDevLauncherController new];
+    }
+  });
+  return theController;
+}
+
+- (void)setBridge:(nullable id)bridge
+{
+  _bridge = bridge;
+  if ([bridge isKindOfClass:[ABI39_0_0RCTBridge class]]) {
+    ABI39_0_0EXUpdatesAppController.sharedInstance.bridge = (ABI39_0_0RCTBridge *)bridge;
+  }
+}
+
+- (NSURL *)launchAssetURL
+{
+  return ABI39_0_0EXUpdatesAppController.sharedInstance.launchAssetUrl;
+}
+
+- (void)fetchUpdateWithConfiguration:(NSDictionary *)configuration
+                          onManifest:(ABI39_0_0EXUpdatesManifestBlock)manifestBlock
+                            progress:(ABI39_0_0EXUpdatesProgressBlock)progressBlock
+                             success:(ABI39_0_0EXUpdatesSuccessBlock)successBlock
+                               error:(ABI39_0_0EXUpdatesErrorBlock)errorBlock
+{
+  ABI39_0_0EXUpdatesAppController *controller = ABI39_0_0EXUpdatesAppController.sharedInstance;
+  ABI39_0_0EXUpdatesConfig *updatesConfiguration = [ABI39_0_0EXUpdatesConfig configWithExpoPlist];
+  [updatesConfiguration loadConfigFromDictionary:configuration];
+  if (!updatesConfiguration.updateUrl) {
+    errorBlock([NSError errorWithDomain:ABI39_0_0EXUpdatesDevLauncherControllerErrorDomain code:ABI39_0_0EXUpdatesDevLauncherErrorCodeInvalidUpdateURL userInfo:@{NSLocalizedDescriptionKey: @"Failed to load update: configuration object must include a valid update URL"}]);
+    return;
+  }
+  NSError *fsError;
+  if (![controller initializeUpdatesDirectoryWithError:&fsError]) {
+    errorBlock(fsError ?: [NSError errorWithDomain:ABI39_0_0EXUpdatesDevLauncherControllerErrorDomain code:ABI39_0_0EXUpdatesDevLauncherErrorCodeDirectoryInitializationFailed userInfo:@{NSLocalizedDescriptionKey: @"Failed to initialize updates directory with an unknown error"}]);
+    return;
+  }
+  NSError *dbError;
+  if (![controller initializeUpdatesDatabaseWithError:&dbError]) {
+    errorBlock(dbError ?: [NSError errorWithDomain:ABI39_0_0EXUpdatesDevLauncherControllerErrorDomain code:ABI39_0_0EXUpdatesDevLauncherErrorCodeDatabaseInitializationFailed userInfo:@{NSLocalizedDescriptionKey: @"Failed to initialize updates database with an unknown error"}]);
+    return;
+  }
+
+  [controller setIsStarted:YES];
+  [self _setDevelopmentSelectionPolicy];
+
+  ABI39_0_0EXUpdatesRemoteAppLoader *loader = [[ABI39_0_0EXUpdatesRemoteAppLoader alloc] initWithConfig:updatesConfiguration database:controller.database directory:controller.updatesDirectory completionQueue:controller.controllerQueue];
+  [loader loadUpdateFromUrl:updatesConfiguration.updateUrl onManifest:^BOOL(ABI39_0_0EXUpdatesUpdate * _Nonnull update) {
+    return manifestBlock(update.rawManifest.rawManifestJSON);
+  } asset:^(ABI39_0_0EXUpdatesAsset * _Nonnull asset, NSUInteger successfulAssetCount, NSUInteger failedAssetCount, NSUInteger totalAssetCount) {
+    progressBlock(successfulAssetCount, failedAssetCount, totalAssetCount);
+  } success:^(ABI39_0_0EXUpdatesUpdate * _Nullable update) {
+    if (!update) {
+      successBlock(nil);
+      return;
+    }
+    [self _launchUpdate:update withConfiguration:updatesConfiguration success:successBlock error:errorBlock];
+  } error:errorBlock];
+}
+
+- (void)_setDevelopmentSelectionPolicy
+{
+  ABI39_0_0EXUpdatesAppController *controller = ABI39_0_0EXUpdatesAppController.sharedInstance;
+  ABI39_0_0EXUpdatesSelectionPolicy *currentSelectionPolicy = controller.selectionPolicy;
+  [controller setDefaultSelectionPolicy:[[ABI39_0_0EXUpdatesSelectionPolicy alloc]
+                                         initWithLauncherSelectionPolicy:currentSelectionPolicy.launcherSelectionPolicy
+                                         loaderSelectionPolicy:currentSelectionPolicy.loaderSelectionPolicy
+                                         reaperSelectionPolicy:[ABI39_0_0EXUpdatesReaperSelectionPolicyDevelopmentClient new]]];
+  [controller resetSelectionPolicyToDefault];
+}
+
+- (void)_launchUpdate:(ABI39_0_0EXUpdatesUpdate *)update
+    withConfiguration:(ABI39_0_0EXUpdatesConfig *)configuration
+              success:(ABI39_0_0EXUpdatesSuccessBlock)successBlock
+                error:(ABI39_0_0EXUpdatesErrorBlock)errorBlock
+{
+  ABI39_0_0EXUpdatesAppController *controller = ABI39_0_0EXUpdatesAppController.sharedInstance;
+  ABI39_0_0EXUpdatesAppLauncherWithDatabase *launcher = [[ABI39_0_0EXUpdatesAppLauncherWithDatabase alloc] initWithConfig:configuration database:controller.database directory:controller.updatesDirectory completionQueue:controller.controllerQueue];
+  [launcher launchUpdateWithSelectionPolicy:controller.selectionPolicy completion:^(NSError * _Nullable error, BOOL success) {
+    if (!success) {
+      errorBlock(error ?: [NSError errorWithDomain:ABI39_0_0EXUpdatesDevLauncherControllerErrorDomain code:ABI39_0_0EXUpdatesDevLauncherErrorCodeUpdateLaunchFailed userInfo:@{NSLocalizedDescriptionKey: @"Failed to launch update with an unknown error"}]);
+      return;
+    }
+
+    [controller setConfigurationInternal:configuration];
+    [controller setLauncher:launcher];
+    successBlock(launcher.launchedUpdate.rawManifest.rawManifestJSON);
+    [controller runReaper];
+  }];
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/versioned-react-native/ABI39_0_0/Expo/EXUpdates/ABI39_0_0EXUpdates/ABI39_0_0EXUpdatesModule.m
+++ b/ios/versioned-react-native/ABI39_0_0/Expo/EXUpdates/ABI39_0_0EXUpdates/ABI39_0_0EXUpdatesModule.m
@@ -10,7 +10,7 @@
 
 @interface ABI39_0_0EXUpdatesModule ()
 
-@property (nonatomic, weak) id<ABI39_0_0EXUpdatesInterface> updatesService;
+@property (nonatomic, weak) id<ABI39_0_0EXUpdatesModuleInterface> updatesService;
 
 @end
 
@@ -20,7 +20,7 @@ ABI39_0_0UM_EXPORT_MODULE(ExpoUpdates);
 
 - (void)setModuleRegistry:(ABI39_0_0UMModuleRegistry *)moduleRegistry
 {
-  _updatesService = [moduleRegistry getModuleImplementingProtocol:@protocol(ABI39_0_0EXUpdatesInterface)];
+  _updatesService = [moduleRegistry getModuleImplementingProtocol:@protocol(ABI39_0_0EXUpdatesModuleInterface)];
 }
 
 - (NSDictionary *)constantsToExport

--- a/ios/versioned-react-native/ABI39_0_0/Expo/EXUpdates/ABI39_0_0EXUpdates/ABI39_0_0EXUpdatesService.h
+++ b/ios/versioned-react-native/ABI39_0_0/Expo/EXUpdates/ABI39_0_0EXUpdates/ABI39_0_0EXUpdatesService.h
@@ -10,7 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 typedef void (^ABI39_0_0EXUpdatesAppRelaunchCompletionBlock)(BOOL success);
 
-@protocol ABI39_0_0EXUpdatesInterface
+@protocol ABI39_0_0EXUpdatesModuleInterface
 
 @property (nonatomic, readonly) ABI39_0_0EXUpdatesConfig *config;
 @property (nonatomic, readonly) ABI39_0_0EXUpdatesDatabase *database;
@@ -29,7 +29,7 @@ typedef void (^ABI39_0_0EXUpdatesAppRelaunchCompletionBlock)(BOOL success);
 
 @end
 
-@interface ABI39_0_0EXUpdatesService : NSObject <ABI39_0_0UMInternalModule, ABI39_0_0EXUpdatesInterface>
+@interface ABI39_0_0EXUpdatesService : NSObject <ABI39_0_0UMInternalModule, ABI39_0_0EXUpdatesModuleInterface>
 
 @end
 

--- a/ios/versioned-react-native/ABI39_0_0/Expo/EXUpdates/ABI39_0_0EXUpdates/ABI39_0_0EXUpdatesService.m
+++ b/ios/versioned-react-native/ABI39_0_0/Expo/EXUpdates/ABI39_0_0EXUpdates/ABI39_0_0EXUpdatesService.m
@@ -12,7 +12,7 @@ ABI39_0_0UM_REGISTER_MODULE();
 
 + (const NSArray<Protocol *> *)exportedInterfaces
 {
-  return @[@protocol(ABI39_0_0EXUpdatesInterface)];
+  return @[@protocol(ABI39_0_0EXUpdatesModuleInterface)];
 }
 
 - (ABI39_0_0EXUpdatesConfig *)config

--- a/ios/versioned-react-native/ABI39_0_0/Expo/EXUpdatesInterface/ABI39_0_0EXUpdatesInterface.podspec
+++ b/ios/versioned-react-native/ABI39_0_0/Expo/EXUpdatesInterface/ABI39_0_0EXUpdatesInterface.podspec
@@ -1,0 +1,18 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name           = 'ABI39_0_0EXUpdatesInterface'
+  s.version        = package['version']
+  s.summary        = package['description']
+  s.description    = package['description']
+  s.license        = package['license']
+  s.author         = package['author']
+  s.homepage       = package['homepage']
+  s.platform       = :ios, '11.0'
+  s.source         = { git: 'https://github.com/expo/expo.git' }
+  s.source_files   = 'ABI39_0_0EXUpdatesInterface/**/*.{h,m}'
+  s.preserve_paths = 'ABI39_0_0EXUpdatesInterface/**/*.{h,m}'
+  s.requires_arc   = true
+end

--- a/ios/versioned-react-native/ABI39_0_0/Expo/EXUpdatesInterface/ABI39_0_0EXUpdatesInterface/ABI39_0_0EXUpdatesInterface.h
+++ b/ios/versioned-react-native/ABI39_0_0/Expo/EXUpdatesInterface/ABI39_0_0EXUpdatesInterface/ABI39_0_0EXUpdatesInterface.h
@@ -1,0 +1,35 @@
+//  Copyright © 2021 650 Industries. All rights reserved.
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef void (^ABI39_0_0EXUpdatesErrorBlock) (NSError *error);
+typedef void (^ABI39_0_0EXUpdatesSuccessBlock) (NSDictionary * _Nullable manifest);
+typedef void (^ABI39_0_0EXUpdatesProgressBlock) (NSUInteger successfulAssetCount, NSUInteger failedAssetCount, NSUInteger totalAssetCount);
+/**
+ * Called when a manifest has been downloaded. The return value indicates whether or not to
+ * continue downloading the update described by this manifest. Returning `NO` will abort the
+ * load, and the success block will be immediately called with a nil `manifest`.
+ */
+typedef BOOL (^ABI39_0_0EXUpdatesManifestBlock) (NSDictionary *manifest);
+
+/**
+ * Protocol for modules that depend on expo-updates for loading production updates but do not want
+ * to depend on expo-updates or delegate control to the singleton ABI39_0_0EXUpdatesAppController.
+ */
+@protocol ABI39_0_0EXUpdatesInterface
+
+@property (nonatomic, weak) id bridge;
+
+- (NSURL *)launchAssetURL;
+
+- (void)fetchUpdateWithConfiguration:(NSDictionary *)configuration
+                          onManifest:(ABI39_0_0EXUpdatesManifestBlock)manifestBlock
+                            progress:(ABI39_0_0EXUpdatesProgressBlock)progressBlock
+                             success:(ABI39_0_0EXUpdatesSuccessBlock)successBlock
+                               error:(ABI39_0_0EXUpdatesErrorBlock)errorBlock;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/versioned-react-native/ABI39_0_0/Expo/EXUpdatesInterface/package.json
+++ b/ios/versioned-react-native/ABI39_0_0/Expo/EXUpdatesInterface/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "expo-updates-interface",
+  "version": "0.0.1",
+  "description": "Native interface for modules that optionally depend on expo-updates, e.g. expo-dev-launcher.",
+  "main": "index.js",
+  "keywords": [
+    "react-native",
+    "expo",
+    "expo-updates-interface"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/expo/expo.git",
+    "directory": "packages/expo-updates-interface"
+  },
+  "bugs": {
+    "url": "https://github.com/expo/expo/issues"
+  },
+  "author": "650 Industries, Inc.",
+  "license": "MIT",
+  "homepage": "https://docs.expo.io/versions/latest/sdk/module-template"
+}

--- a/ios/versioned-react-native/ABI39_0_0/dependencies.rb
+++ b/ios/versioned-react-native/ABI39_0_0/dependencies.rb
@@ -200,6 +200,9 @@ pod 'ABI39_0_0EXStructuredHeaders',
 pod 'ABI39_0_0EXUpdates',
   :path => './versioned-react-native/ABI39_0_0/Expo/EXUpdates',
   :project_name => 'ABI39_0_0'
+pod 'ABI39_0_0EXUpdatesInterface',
+  :path => './versioned-react-native/ABI39_0_0/Expo/EXUpdatesInterface',
+  :project_name => 'ABI39_0_0'
 pod 'ABI39_0_0EXVideoThumbnails',
   :path => './versioned-react-native/ABI39_0_0/Expo/EXVideoThumbnails',
   :project_name => 'ABI39_0_0'

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/ABI40_0_0EXUpdatesAppController+Internal.h
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/ABI40_0_0EXUpdatesAppController+Internal.h
@@ -1,0 +1,26 @@
+//  Copyright © 2021 650 Industries. All rights reserved.
+
+#import <ABI40_0_0EXUpdates/ABI40_0_0EXUpdatesAppController.h>
+#import <ABI40_0_0EXUpdates/ABI40_0_0EXUpdatesAppLauncher.h>
+#import <ABI40_0_0EXUpdates/ABI40_0_0EXUpdatesConfig.h>
+#import <ABI40_0_0EXUpdates/ABI40_0_0EXUpdatesSelectionPolicy.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ABI40_0_0EXUpdatesAppController (Internal)
+
+@property (nonatomic, readonly) dispatch_queue_t controllerQueue;
+
+- (BOOL)initializeUpdatesDirectoryWithError:(NSError ** _Nullable)error;
+- (BOOL)initializeUpdatesDatabaseWithError:(NSError ** _Nullable)error;
+
+- (void)setDefaultSelectionPolicy:(ABI40_0_0EXUpdatesSelectionPolicy *)selectionPolicy;
+- (void)setLauncher:(id<ABI40_0_0EXUpdatesAppLauncher>)launcher;
+- (void)setConfigurationInternal:(ABI40_0_0EXUpdatesConfig *)configuration;
+- (void)setIsStarted:(BOOL)isStarted;
+
+- (void)runReaper;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/ABI40_0_0EXUpdatesConfig.h
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/ABI40_0_0EXUpdatesConfig.h
@@ -27,6 +27,7 @@ typedef NS_ENUM(NSInteger, ABI40_0_0EXUpdatesCheckAutomaticallyConfig) {
 
 @property (nonatomic, readonly) BOOL hasEmbeddedUpdate;
 
++ (instancetype)configWithExpoPlist;
 + (instancetype)configWithDictionary:(NSDictionary *)config;
 - (void)loadConfigFromDictionary:(NSDictionary *)config;
 

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/ABI40_0_0EXUpdatesConfig.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/ABI40_0_0EXUpdatesConfig.m
@@ -20,6 +20,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+static NSString * const ABI40_0_0EXUpdatesConfigPlistName = @"Expo";
+
 static NSString * const ABI40_0_0EXUpdatesDefaultReleaseChannelName = @"default";
 
 static NSString * const ABI40_0_0EXUpdatesConfigEnabledKey = @"ABI40_0_0EXUpdatesEnabled";
@@ -58,6 +60,17 @@ static NSString * const ABI40_0_0EXUpdatesConfigNeverString = @"NEVER";
   ABI40_0_0EXUpdatesConfig *updatesConfig = [[ABI40_0_0EXUpdatesConfig alloc] init];
   [updatesConfig loadConfigFromDictionary:config];
   return updatesConfig;
+}
+
++ (instancetype)configWithExpoPlist
+{
+  NSString *configPath = [[NSBundle mainBundle] pathForResource:ABI40_0_0EXUpdatesConfigPlistName ofType:@"plist"];
+  if (!configPath) {
+    @throw [NSException exceptionWithName:NSInternalInconsistencyException
+                                   reason:@"Cannot load configuration from Expo.plist. Please ensure you've followed the setup and installation instructions for expo-updates to create Expo.plist and add it to your Xcode project."
+                                 userInfo:@{}];
+  }
+  return [[self class] configWithDictionary:[NSDictionary dictionaryWithContentsOfFile:configPath]];
 }
 
 - (void)loadConfigFromDictionary:(NSDictionary *)config

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/ABI40_0_0EXUpdatesDevLauncherController.h
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/ABI40_0_0EXUpdatesDevLauncherController.h
@@ -1,0 +1,15 @@
+//  Copyright © 2021 650 Industries. All rights reserved.
+
+#import <ABI40_0_0EXUpdatesInterface/ABI40_0_0EXUpdatesInterface.h>
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ABI40_0_0EXUpdatesDevLauncherController : NSObject <ABI40_0_0EXUpdatesInterface>
+
++ (instancetype)sharedInstance;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/ABI40_0_0EXUpdatesDevLauncherController.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/ABI40_0_0EXUpdatesDevLauncherController.m
@@ -1,0 +1,128 @@
+//  Copyright © 2021 650 Industries. All rights reserved.
+
+#import <ABI40_0_0EXUpdates/ABI40_0_0EXUpdatesAppController+Internal.h>
+#import <ABI40_0_0EXUpdates/ABI40_0_0EXUpdatesAppLauncherWithDatabase.h>
+#import <ABI40_0_0EXUpdates/ABI40_0_0EXUpdatesConfig.h>
+#import <ABI40_0_0EXUpdates/ABI40_0_0EXUpdatesDevLauncherController.h>
+#import <ABI40_0_0EXUpdates/ABI40_0_0EXUpdatesReaper.h>
+#import <ABI40_0_0EXUpdates/ABI40_0_0EXUpdatesReaperSelectionPolicyDevelopmentClient.h>
+#import <ABI40_0_0EXUpdates/ABI40_0_0EXUpdatesRemoteAppLoader.h>
+#import <ABI40_0_0EXUpdates/ABI40_0_0EXUpdatesSelectionPolicy.h>
+#import <ABI40_0_0EXUpdates/ABI40_0_0EXUpdatesUpdate.h>
+#import <ABI40_0_0React/ABI40_0_0RCTBridge.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+static NSString * const ABI40_0_0EXUpdatesDevLauncherControllerErrorDomain = @"ABI40_0_0EXUpdatesDevLauncherController";
+
+typedef NS_ENUM(NSInteger, ABI40_0_0EXUpdatesDevLauncherErrorCode) {
+  ABI40_0_0EXUpdatesDevLauncherErrorCodeInvalidUpdateURL = 1,
+  ABI40_0_0EXUpdatesDevLauncherErrorCodeDirectoryInitializationFailed,
+  ABI40_0_0EXUpdatesDevLauncherErrorCodeDatabaseInitializationFailed,
+  ABI40_0_0EXUpdatesDevLauncherErrorCodeUpdateLaunchFailed,
+};
+
+@implementation ABI40_0_0EXUpdatesDevLauncherController
+
+@synthesize bridge = _bridge;
+
++ (instancetype)sharedInstance
+{
+  static ABI40_0_0EXUpdatesDevLauncherController *theController;
+  static dispatch_once_t once;
+  dispatch_once(&once, ^{
+    if (!theController) {
+      theController = [ABI40_0_0EXUpdatesDevLauncherController new];
+    }
+  });
+  return theController;
+}
+
+- (void)setBridge:(nullable id)bridge
+{
+  _bridge = bridge;
+  if ([bridge isKindOfClass:[ABI40_0_0RCTBridge class]]) {
+    ABI40_0_0EXUpdatesAppController.sharedInstance.bridge = (ABI40_0_0RCTBridge *)bridge;
+  }
+}
+
+- (NSURL *)launchAssetURL
+{
+  return ABI40_0_0EXUpdatesAppController.sharedInstance.launchAssetUrl;
+}
+
+- (void)fetchUpdateWithConfiguration:(NSDictionary *)configuration
+                          onManifest:(ABI40_0_0EXUpdatesManifestBlock)manifestBlock
+                            progress:(ABI40_0_0EXUpdatesProgressBlock)progressBlock
+                             success:(ABI40_0_0EXUpdatesSuccessBlock)successBlock
+                               error:(ABI40_0_0EXUpdatesErrorBlock)errorBlock
+{
+  ABI40_0_0EXUpdatesAppController *controller = ABI40_0_0EXUpdatesAppController.sharedInstance;
+  ABI40_0_0EXUpdatesConfig *updatesConfiguration = [ABI40_0_0EXUpdatesConfig configWithExpoPlist];
+  [updatesConfiguration loadConfigFromDictionary:configuration];
+  if (!updatesConfiguration.updateUrl) {
+    errorBlock([NSError errorWithDomain:ABI40_0_0EXUpdatesDevLauncherControllerErrorDomain code:ABI40_0_0EXUpdatesDevLauncherErrorCodeInvalidUpdateURL userInfo:@{NSLocalizedDescriptionKey: @"Failed to load update: configuration object must include a valid update URL"}]);
+    return;
+  }
+  NSError *fsError;
+  if (![controller initializeUpdatesDirectoryWithError:&fsError]) {
+    errorBlock(fsError ?: [NSError errorWithDomain:ABI40_0_0EXUpdatesDevLauncherControllerErrorDomain code:ABI40_0_0EXUpdatesDevLauncherErrorCodeDirectoryInitializationFailed userInfo:@{NSLocalizedDescriptionKey: @"Failed to initialize updates directory with an unknown error"}]);
+    return;
+  }
+  NSError *dbError;
+  if (![controller initializeUpdatesDatabaseWithError:&dbError]) {
+    errorBlock(dbError ?: [NSError errorWithDomain:ABI40_0_0EXUpdatesDevLauncherControllerErrorDomain code:ABI40_0_0EXUpdatesDevLauncherErrorCodeDatabaseInitializationFailed userInfo:@{NSLocalizedDescriptionKey: @"Failed to initialize updates database with an unknown error"}]);
+    return;
+  }
+
+  [controller setIsStarted:YES];
+  [self _setDevelopmentSelectionPolicy];
+
+  ABI40_0_0EXUpdatesRemoteAppLoader *loader = [[ABI40_0_0EXUpdatesRemoteAppLoader alloc] initWithConfig:updatesConfiguration database:controller.database directory:controller.updatesDirectory completionQueue:controller.controllerQueue];
+  [loader loadUpdateFromUrl:updatesConfiguration.updateUrl onManifest:^BOOL(ABI40_0_0EXUpdatesUpdate * _Nonnull update) {
+    return manifestBlock(update.rawManifest.rawManifestJSON);
+  } asset:^(ABI40_0_0EXUpdatesAsset * _Nonnull asset, NSUInteger successfulAssetCount, NSUInteger failedAssetCount, NSUInteger totalAssetCount) {
+    progressBlock(successfulAssetCount, failedAssetCount, totalAssetCount);
+  } success:^(ABI40_0_0EXUpdatesUpdate * _Nullable update) {
+    if (!update) {
+      successBlock(nil);
+      return;
+    }
+    [self _launchUpdate:update withConfiguration:updatesConfiguration success:successBlock error:errorBlock];
+  } error:errorBlock];
+}
+
+- (void)_setDevelopmentSelectionPolicy
+{
+  ABI40_0_0EXUpdatesAppController *controller = ABI40_0_0EXUpdatesAppController.sharedInstance;
+  ABI40_0_0EXUpdatesSelectionPolicy *currentSelectionPolicy = controller.selectionPolicy;
+  [controller setDefaultSelectionPolicy:[[ABI40_0_0EXUpdatesSelectionPolicy alloc]
+                                         initWithLauncherSelectionPolicy:currentSelectionPolicy.launcherSelectionPolicy
+                                         loaderSelectionPolicy:currentSelectionPolicy.loaderSelectionPolicy
+                                         reaperSelectionPolicy:[ABI40_0_0EXUpdatesReaperSelectionPolicyDevelopmentClient new]]];
+  [controller resetSelectionPolicyToDefault];
+}
+
+- (void)_launchUpdate:(ABI40_0_0EXUpdatesUpdate *)update
+    withConfiguration:(ABI40_0_0EXUpdatesConfig *)configuration
+              success:(ABI40_0_0EXUpdatesSuccessBlock)successBlock
+                error:(ABI40_0_0EXUpdatesErrorBlock)errorBlock
+{
+  ABI40_0_0EXUpdatesAppController *controller = ABI40_0_0EXUpdatesAppController.sharedInstance;
+  ABI40_0_0EXUpdatesAppLauncherWithDatabase *launcher = [[ABI40_0_0EXUpdatesAppLauncherWithDatabase alloc] initWithConfig:configuration database:controller.database directory:controller.updatesDirectory completionQueue:controller.controllerQueue];
+  [launcher launchUpdateWithSelectionPolicy:controller.selectionPolicy completion:^(NSError * _Nullable error, BOOL success) {
+    if (!success) {
+      errorBlock(error ?: [NSError errorWithDomain:ABI40_0_0EXUpdatesDevLauncherControllerErrorDomain code:ABI40_0_0EXUpdatesDevLauncherErrorCodeUpdateLaunchFailed userInfo:@{NSLocalizedDescriptionKey: @"Failed to launch update with an unknown error"}]);
+      return;
+    }
+
+    [controller setConfigurationInternal:configuration];
+    [controller setLauncher:launcher];
+    successBlock(launcher.launchedUpdate.rawManifest.rawManifestJSON);
+    [controller runReaper];
+  }];
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/ABI40_0_0EXUpdatesModule.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/ABI40_0_0EXUpdatesModule.m
@@ -10,7 +10,7 @@
 
 @interface ABI40_0_0EXUpdatesModule ()
 
-@property (nonatomic, weak) id<ABI40_0_0EXUpdatesInterface> updatesService;
+@property (nonatomic, weak) id<ABI40_0_0EXUpdatesModuleInterface> updatesService;
 
 @end
 
@@ -20,7 +20,7 @@ ABI40_0_0UM_EXPORT_MODULE(ExpoUpdates);
 
 - (void)setModuleRegistry:(ABI40_0_0UMModuleRegistry *)moduleRegistry
 {
-  _updatesService = [moduleRegistry getModuleImplementingProtocol:@protocol(ABI40_0_0EXUpdatesInterface)];
+  _updatesService = [moduleRegistry getModuleImplementingProtocol:@protocol(ABI40_0_0EXUpdatesModuleInterface)];
 }
 
 - (NSDictionary *)constantsToExport

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/ABI40_0_0EXUpdatesService.h
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/ABI40_0_0EXUpdatesService.h
@@ -10,7 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 typedef void (^ABI40_0_0EXUpdatesAppRelaunchCompletionBlock)(BOOL success);
 
-@protocol ABI40_0_0EXUpdatesInterface
+@protocol ABI40_0_0EXUpdatesModuleInterface
 
 @property (nonatomic, readonly) ABI40_0_0EXUpdatesConfig *config;
 @property (nonatomic, readonly) ABI40_0_0EXUpdatesDatabase *database;
@@ -29,7 +29,7 @@ typedef void (^ABI40_0_0EXUpdatesAppRelaunchCompletionBlock)(BOOL success);
 
 @end
 
-@interface ABI40_0_0EXUpdatesService : NSObject <ABI40_0_0UMInternalModule, ABI40_0_0EXUpdatesInterface>
+@interface ABI40_0_0EXUpdatesService : NSObject <ABI40_0_0UMInternalModule, ABI40_0_0EXUpdatesModuleInterface>
 
 @end
 

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/ABI40_0_0EXUpdatesService.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/ABI40_0_0EXUpdatesService.m
@@ -12,7 +12,7 @@ ABI40_0_0UM_REGISTER_MODULE();
 
 + (const NSArray<Protocol *> *)exportedInterfaces
 {
-  return @[@protocol(ABI40_0_0EXUpdatesInterface)];
+  return @[@protocol(ABI40_0_0EXUpdatesModuleInterface)];
 }
 
 - (ABI40_0_0EXUpdatesConfig *)config

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdatesInterface/ABI40_0_0EXUpdatesInterface.podspec
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdatesInterface/ABI40_0_0EXUpdatesInterface.podspec
@@ -1,0 +1,18 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name           = 'ABI40_0_0EXUpdatesInterface'
+  s.version        = package['version']
+  s.summary        = package['description']
+  s.description    = package['description']
+  s.license        = package['license']
+  s.author         = package['author']
+  s.homepage       = package['homepage']
+  s.platform       = :ios, '11.0'
+  s.source         = { git: 'https://github.com/expo/expo.git' }
+  s.source_files   = 'ABI40_0_0EXUpdatesInterface/**/*.{h,m}'
+  s.preserve_paths = 'ABI40_0_0EXUpdatesInterface/**/*.{h,m}'
+  s.requires_arc   = true
+end

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdatesInterface/ABI40_0_0EXUpdatesInterface/ABI40_0_0EXUpdatesInterface.h
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdatesInterface/ABI40_0_0EXUpdatesInterface/ABI40_0_0EXUpdatesInterface.h
@@ -1,0 +1,35 @@
+//  Copyright © 2021 650 Industries. All rights reserved.
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef void (^ABI40_0_0EXUpdatesErrorBlock) (NSError *error);
+typedef void (^ABI40_0_0EXUpdatesSuccessBlock) (NSDictionary * _Nullable manifest);
+typedef void (^ABI40_0_0EXUpdatesProgressBlock) (NSUInteger successfulAssetCount, NSUInteger failedAssetCount, NSUInteger totalAssetCount);
+/**
+ * Called when a manifest has been downloaded. The return value indicates whether or not to
+ * continue downloading the update described by this manifest. Returning `NO` will abort the
+ * load, and the success block will be immediately called with a nil `manifest`.
+ */
+typedef BOOL (^ABI40_0_0EXUpdatesManifestBlock) (NSDictionary *manifest);
+
+/**
+ * Protocol for modules that depend on expo-updates for loading production updates but do not want
+ * to depend on expo-updates or delegate control to the singleton ABI40_0_0EXUpdatesAppController.
+ */
+@protocol ABI40_0_0EXUpdatesInterface
+
+@property (nonatomic, weak) id bridge;
+
+- (NSURL *)launchAssetURL;
+
+- (void)fetchUpdateWithConfiguration:(NSDictionary *)configuration
+                          onManifest:(ABI40_0_0EXUpdatesManifestBlock)manifestBlock
+                            progress:(ABI40_0_0EXUpdatesProgressBlock)progressBlock
+                             success:(ABI40_0_0EXUpdatesSuccessBlock)successBlock
+                               error:(ABI40_0_0EXUpdatesErrorBlock)errorBlock;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdatesInterface/package.json
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdatesInterface/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "expo-updates-interface",
+  "version": "0.0.1",
+  "description": "Native interface for modules that optionally depend on expo-updates, e.g. expo-dev-launcher.",
+  "main": "index.js",
+  "keywords": [
+    "react-native",
+    "expo",
+    "expo-updates-interface"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/expo/expo.git",
+    "directory": "packages/expo-updates-interface"
+  },
+  "bugs": {
+    "url": "https://github.com/expo/expo/issues"
+  },
+  "author": "650 Industries, Inc.",
+  "license": "MIT",
+  "homepage": "https://docs.expo.io/versions/latest/sdk/module-template"
+}

--- a/ios/versioned-react-native/ABI40_0_0/dependencies.rb
+++ b/ios/versioned-react-native/ABI40_0_0/dependencies.rb
@@ -197,6 +197,9 @@ pod 'ABI40_0_0EXStructuredHeaders',
 pod 'ABI40_0_0EXUpdates',
   :path => './versioned-react-native/ABI40_0_0/Expo/EXUpdates',
   :project_name => 'ABI40_0_0'
+pod 'ABI40_0_0EXUpdatesInterface',
+  :path => './versioned-react-native/ABI40_0_0/Expo/EXUpdatesInterface',
+  :project_name => 'ABI40_0_0'
 pod 'ABI40_0_0EXVideoThumbnails',
   :path => './versioned-react-native/ABI40_0_0/Expo/EXVideoThumbnails',
   :project_name => 'ABI40_0_0'

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/ABI41_0_0EXUpdatesAppController+Internal.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/ABI41_0_0EXUpdatesAppController+Internal.h
@@ -1,0 +1,26 @@
+//  Copyright © 2021 650 Industries. All rights reserved.
+
+#import <ABI41_0_0EXUpdates/ABI41_0_0EXUpdatesAppController.h>
+#import <ABI41_0_0EXUpdates/ABI41_0_0EXUpdatesAppLauncher.h>
+#import <ABI41_0_0EXUpdates/ABI41_0_0EXUpdatesConfig.h>
+#import <ABI41_0_0EXUpdates/ABI41_0_0EXUpdatesSelectionPolicy.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ABI41_0_0EXUpdatesAppController (Internal)
+
+@property (nonatomic, readonly) dispatch_queue_t controllerQueue;
+
+- (BOOL)initializeUpdatesDirectoryWithError:(NSError ** _Nullable)error;
+- (BOOL)initializeUpdatesDatabaseWithError:(NSError ** _Nullable)error;
+
+- (void)setDefaultSelectionPolicy:(ABI41_0_0EXUpdatesSelectionPolicy *)selectionPolicy;
+- (void)setLauncher:(id<ABI41_0_0EXUpdatesAppLauncher>)launcher;
+- (void)setConfigurationInternal:(ABI41_0_0EXUpdatesConfig *)configuration;
+- (void)setIsStarted:(BOOL)isStarted;
+
+- (void)runReaper;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/ABI41_0_0EXUpdatesAppController.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/ABI41_0_0EXUpdatesAppController.m
@@ -1,6 +1,6 @@
 //  Copyright © 2019 650 Industries. All rights reserved.
 
-#import <ABI41_0_0EXUpdates/ABI41_0_0EXUpdatesAppController.h>
+#import <ABI41_0_0EXUpdates/ABI41_0_0EXUpdatesAppController+Internal.h>
 #import <ABI41_0_0EXUpdates/ABI41_0_0EXUpdatesAppLauncher.h>
 #import <ABI41_0_0EXUpdates/ABI41_0_0EXUpdatesAppLauncherNoDatabase.h>
 #import <ABI41_0_0EXUpdates/ABI41_0_0EXUpdatesAppLauncherWithDatabase.h>
@@ -12,8 +12,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 static NSString * const ABI41_0_0EXUpdatesAppControllerErrorDomain = @"ABI41_0_0EXUpdatesAppController";
 
-static NSString * const ABI41_0_0EXUpdatesConfigPlistName = @"Expo";
-
 static NSString * const ABI41_0_0EXUpdatesUpdateAvailableEventName = @"updateAvailable";
 static NSString * const ABI41_0_0EXUpdatesNoUpdateAvailableEventName = @"noUpdateAvailable";
 static NSString * const ABI41_0_0EXUpdatesErrorEventName = @"error";
@@ -24,13 +22,14 @@ static NSString * const ABI41_0_0EXUpdatesErrorEventName = @"error";
 @property (nonatomic, readwrite, strong) id<ABI41_0_0EXUpdatesAppLauncher> launcher;
 @property (nonatomic, readwrite, strong) ABI41_0_0EXUpdatesDatabase *database;
 @property (nonatomic, readwrite, strong) ABI41_0_0EXUpdatesSelectionPolicy *selectionPolicy;
+@property (nonatomic, readwrite, strong) ABI41_0_0EXUpdatesSelectionPolicy *defaultSelectionPolicy;
+@property (nonatomic, readwrite, strong) dispatch_queue_t controllerQueue;
 @property (nonatomic, readwrite, strong) dispatch_queue_t assetFilesQueue;
 
 @property (nonatomic, readwrite, strong) NSURL *updatesDirectory;
 
 @property (nonatomic, strong) id<ABI41_0_0EXUpdatesAppLauncher> candidateLauncher;
 @property (nonatomic, assign) BOOL hasLaunched;
-@property (nonatomic, strong) dispatch_queue_t controllerQueue;
 
 @property (nonatomic, assign) BOOL isStarted;
 @property (nonatomic, assign) BOOL isEmergencyLaunch;
@@ -54,9 +53,9 @@ static NSString * const ABI41_0_0EXUpdatesErrorEventName = @"error";
 - (instancetype)init
 {
   if (self = [super init]) {
-    _config = [self _loadConfigFromExpoPlist];
+    _config = [ABI41_0_0EXUpdatesConfig configWithExpoPlist];
     _database = [[ABI41_0_0EXUpdatesDatabase alloc] init];
-    _selectionPolicy = [self _defaultSelectionPolicy];
+    _defaultSelectionPolicy = [ABI41_0_0EXUpdatesSelectionPolicyFactory filterAwarePolicyWithRuntimeVersion:[ABI41_0_0EXUpdatesUtils getRuntimeVersionWithConfig:_config]];
     _assetFilesQueue = dispatch_queue_create("expo.controller.AssetFilesQueue", DISPATCH_QUEUE_SERIAL);
     _controllerQueue = dispatch_queue_create("expo.controller.ControllerQueue", DISPATCH_QUEUE_SERIAL);
     _isStarted = NO;
@@ -66,13 +65,21 @@ static NSString * const ABI41_0_0EXUpdatesErrorEventName = @"error";
 
 - (void)setConfiguration:(NSDictionary *)configuration
 {
-  if (_updatesDirectory) {
+  if (_isStarted) {
     @throw [NSException exceptionWithName:NSInternalInconsistencyException
                                    reason:@"ABI41_0_0EXUpdatesAppController:setConfiguration should not be called after start"
                                  userInfo:@{}];
   }
   [_config loadConfigFromDictionary:configuration];
   [self resetSelectionPolicyToDefault];
+}
+
+- (ABI41_0_0EXUpdatesSelectionPolicy *)selectionPolicy
+{
+  if (!_selectionPolicy) {
+    _selectionPolicy = _defaultSelectionPolicy;
+  }
+  return _selectionPolicy;
 }
 
 - (void)setNextSelectionPolicy:(ABI41_0_0EXUpdatesSelectionPolicy *)nextSelectionPolicy
@@ -82,12 +89,12 @@ static NSString * const ABI41_0_0EXUpdatesErrorEventName = @"error";
 
 - (void)resetSelectionPolicyToDefault
 {
-  _selectionPolicy = [self _defaultSelectionPolicy];
+  _selectionPolicy = nil;
 }
 
 - (void)start
 {
-  NSAssert(!_updatesDirectory, @"ABI41_0_0EXUpdatesAppController:start should only be called once per instance");
+  NSAssert(!_isStarted, @"ABI41_0_0EXUpdatesAppController:start should only be called once per instance");
 
   if (!_config.isEnabled) {
     ABI41_0_0EXUpdatesAppLauncherNoDatabase *launcher = [[ABI41_0_0EXUpdatesAppLauncherNoDatabase alloc] init];
@@ -110,22 +117,14 @@ static NSString * const ABI41_0_0EXUpdatesErrorEventName = @"error";
   _isStarted = YES;
 
   NSError *fsError;
-  _updatesDirectory = [ABI41_0_0EXUpdatesUtils initializeUpdatesDirectoryWithError:&fsError];
+  [self initializeUpdatesDirectoryWithError:&fsError];
   if (fsError) {
     [self _emergencyLaunchWithFatalError:fsError];
     return;
   }
 
-  __block BOOL dbSuccess;
-  __block NSError *dbError;
-  dispatch_semaphore_t dbSemaphore = dispatch_semaphore_create(0);
-  dispatch_async(_database.databaseQueue, ^{
-    dbSuccess = [self->_database openDatabaseInDirectory:self->_updatesDirectory withError:&dbError];
-    dispatch_semaphore_signal(dbSemaphore);
-  });
-
-  dispatch_semaphore_wait(dbSemaphore, DISPATCH_TIME_FOREVER);
-  if (!dbSuccess) {
+  NSError *dbError;
+  if (![self initializeUpdatesDatabaseWithError:&dbError]) {
     [self _emergencyLaunchWithFatalError:dbError];
     return;
   }
@@ -133,7 +132,7 @@ static NSString * const ABI41_0_0EXUpdatesErrorEventName = @"error";
   ABI41_0_0EXUpdatesAppLoaderTask *loaderTask = [[ABI41_0_0EXUpdatesAppLoaderTask alloc] initWithConfig:_config
                                                                              database:_database
                                                                             directory:_updatesDirectory
-                                                                      selectionPolicy:_selectionPolicy
+                                                                      selectionPolicy:self.selectionPolicy
                                                                         delegateQueue:_controllerQueue];
   loaderTask.delegate = self;
   [loaderTask start];
@@ -171,12 +170,12 @@ static NSString * const ABI41_0_0EXUpdatesErrorEventName = @"error";
   if (_bridge) {
     ABI41_0_0EXUpdatesAppLauncherWithDatabase *launcher = [[ABI41_0_0EXUpdatesAppLauncherWithDatabase alloc] initWithConfig:_config database:_database directory:_updatesDirectory completionQueue:_controllerQueue];
     _candidateLauncher = launcher;
-    [launcher launchUpdateWithSelectionPolicy:self->_selectionPolicy completion:^(NSError * _Nullable error, BOOL success) {
+    [launcher launchUpdateWithSelectionPolicy:self.selectionPolicy completion:^(NSError * _Nullable error, BOOL success) {
       if (success) {
         self->_launcher = self->_candidateLauncher;
         completion(YES);
         [self->_bridge reload];
-        [self _runReaper];
+        [self runReaper];
       } else {
         NSLog(@"Failed to relaunch: %@", error.localizedDescription);
         completion(NO);
@@ -251,35 +250,62 @@ static NSString * const ABI41_0_0EXUpdatesErrorEventName = @"error";
   }
 }
 
-# pragma mark - internal
+# pragma mark - ABI41_0_0EXUpdatesAppController+Internal
 
-- (ABI41_0_0EXUpdatesConfig *)_loadConfigFromExpoPlist
+- (BOOL)initializeUpdatesDirectoryWithError:(NSError ** _Nullable)error
 {
-  NSString *configPath = [[NSBundle mainBundle] pathForResource:ABI41_0_0EXUpdatesConfigPlistName ofType:@"plist"];
-  if (!configPath) {
-    @throw [NSException exceptionWithName:NSInternalInconsistencyException
-                                   reason:@"Cannot load configuration from Expo.plist. Please ensure you've followed the setup and installation instructions for expo-updates to create Expo.plist and add it to your Xcode project."
-                                 userInfo:@{}];
+  _updatesDirectory = [ABI41_0_0EXUpdatesUtils initializeUpdatesDirectoryWithError:error];
+  return _updatesDirectory != nil;
+}
+
+- (BOOL)initializeUpdatesDatabaseWithError:(NSError ** _Nullable)error
+{
+  __block NSError *dbError;
+  dispatch_semaphore_t dbSemaphore = dispatch_semaphore_create(0);
+  dispatch_async(_database.databaseQueue, ^{
+    [self->_database openDatabaseInDirectory:self->_updatesDirectory withError:&dbError];
+    dispatch_semaphore_signal(dbSemaphore);
+  });
+
+  dispatch_semaphore_wait(dbSemaphore, DISPATCH_TIME_FOREVER);
+  if (dbError && error) {
+    *error = dbError;
   }
-
-  return [ABI41_0_0EXUpdatesConfig configWithDictionary:[NSDictionary dictionaryWithContentsOfFile:configPath]];
+  return dbError == nil;
 }
 
-- (ABI41_0_0EXUpdatesSelectionPolicy *)_defaultSelectionPolicy
+- (void)setDefaultSelectionPolicy:(ABI41_0_0EXUpdatesSelectionPolicy *)selectionPolicy
 {
-  return [ABI41_0_0EXUpdatesSelectionPolicyFactory filterAwarePolicyWithRuntimeVersion:[ABI41_0_0EXUpdatesUtils getRuntimeVersionWithConfig:_config]];
+  _defaultSelectionPolicy = selectionPolicy;
 }
 
-- (void)_runReaper
+- (void)setLauncher:(id<ABI41_0_0EXUpdatesAppLauncher>)launcher
+{
+  _launcher = launcher;
+}
+
+- (void)setConfigurationInternal:(ABI41_0_0EXUpdatesConfig *)configuration
+{
+  _config = configuration;
+}
+
+- (void)setIsStarted:(BOOL)isStarted
+{
+  _isStarted = isStarted;
+}
+
+- (void)runReaper
 {
   if (_launcher.launchedUpdate) {
     [ABI41_0_0EXUpdatesReaper reapUnusedUpdatesWithConfig:_config
                                         database:_database
                                        directory:_updatesDirectory
-                                 selectionPolicy:_selectionPolicy
+                                 selectionPolicy:self.selectionPolicy
                                   launchedUpdate:_launcher.launchedUpdate];
   }
 }
+
+# pragma mark - internal
 
 - (void)_emergencyLaunchWithFatalError:(NSError *)error
 {

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/ABI41_0_0EXUpdatesConfig.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/ABI41_0_0EXUpdatesConfig.h
@@ -27,6 +27,7 @@ typedef NS_ENUM(NSInteger, ABI41_0_0EXUpdatesCheckAutomaticallyConfig) {
 
 @property (nonatomic, readonly) BOOL hasEmbeddedUpdate;
 
++ (instancetype)configWithExpoPlist;
 + (instancetype)configWithDictionary:(NSDictionary *)config;
 - (void)loadConfigFromDictionary:(NSDictionary *)config;
 

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/ABI41_0_0EXUpdatesConfig.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/ABI41_0_0EXUpdatesConfig.m
@@ -20,6 +20,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+static NSString * const ABI41_0_0EXUpdatesConfigPlistName = @"Expo";
+
 static NSString * const ABI41_0_0EXUpdatesDefaultReleaseChannelName = @"default";
 
 static NSString * const ABI41_0_0EXUpdatesConfigEnabledKey = @"ABI41_0_0EXUpdatesEnabled";
@@ -58,6 +60,17 @@ static NSString * const ABI41_0_0EXUpdatesConfigNeverString = @"NEVER";
   ABI41_0_0EXUpdatesConfig *updatesConfig = [[ABI41_0_0EXUpdatesConfig alloc] init];
   [updatesConfig loadConfigFromDictionary:config];
   return updatesConfig;
+}
+
++ (instancetype)configWithExpoPlist
+{
+  NSString *configPath = [[NSBundle mainBundle] pathForResource:ABI41_0_0EXUpdatesConfigPlistName ofType:@"plist"];
+  if (!configPath) {
+    @throw [NSException exceptionWithName:NSInternalInconsistencyException
+                                   reason:@"Cannot load configuration from Expo.plist. Please ensure you've followed the setup and installation instructions for expo-updates to create Expo.plist and add it to your Xcode project."
+                                 userInfo:@{}];
+  }
+  return [[self class] configWithDictionary:[NSDictionary dictionaryWithContentsOfFile:configPath]];
 }
 
 - (void)loadConfigFromDictionary:(NSDictionary *)config

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/ABI41_0_0EXUpdatesDevLauncherController.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/ABI41_0_0EXUpdatesDevLauncherController.h
@@ -1,0 +1,15 @@
+//  Copyright © 2021 650 Industries. All rights reserved.
+
+#import <ABI41_0_0EXUpdatesInterface/ABI41_0_0EXUpdatesInterface.h>
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ABI41_0_0EXUpdatesDevLauncherController : NSObject <ABI41_0_0EXUpdatesInterface>
+
++ (instancetype)sharedInstance;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/ABI41_0_0EXUpdatesDevLauncherController.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/ABI41_0_0EXUpdatesDevLauncherController.m
@@ -1,0 +1,128 @@
+//  Copyright © 2021 650 Industries. All rights reserved.
+
+#import <ABI41_0_0EXUpdates/ABI41_0_0EXUpdatesAppController+Internal.h>
+#import <ABI41_0_0EXUpdates/ABI41_0_0EXUpdatesAppLauncherWithDatabase.h>
+#import <ABI41_0_0EXUpdates/ABI41_0_0EXUpdatesConfig.h>
+#import <ABI41_0_0EXUpdates/ABI41_0_0EXUpdatesDevLauncherController.h>
+#import <ABI41_0_0EXUpdates/ABI41_0_0EXUpdatesReaper.h>
+#import <ABI41_0_0EXUpdates/ABI41_0_0EXUpdatesReaperSelectionPolicyDevelopmentClient.h>
+#import <ABI41_0_0EXUpdates/ABI41_0_0EXUpdatesRemoteAppLoader.h>
+#import <ABI41_0_0EXUpdates/ABI41_0_0EXUpdatesSelectionPolicy.h>
+#import <ABI41_0_0EXUpdates/ABI41_0_0EXUpdatesUpdate.h>
+#import <ABI41_0_0React/ABI41_0_0RCTBridge.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+static NSString * const ABI41_0_0EXUpdatesDevLauncherControllerErrorDomain = @"ABI41_0_0EXUpdatesDevLauncherController";
+
+typedef NS_ENUM(NSInteger, ABI41_0_0EXUpdatesDevLauncherErrorCode) {
+  ABI41_0_0EXUpdatesDevLauncherErrorCodeInvalidUpdateURL = 1,
+  ABI41_0_0EXUpdatesDevLauncherErrorCodeDirectoryInitializationFailed,
+  ABI41_0_0EXUpdatesDevLauncherErrorCodeDatabaseInitializationFailed,
+  ABI41_0_0EXUpdatesDevLauncherErrorCodeUpdateLaunchFailed,
+};
+
+@implementation ABI41_0_0EXUpdatesDevLauncherController
+
+@synthesize bridge = _bridge;
+
++ (instancetype)sharedInstance
+{
+  static ABI41_0_0EXUpdatesDevLauncherController *theController;
+  static dispatch_once_t once;
+  dispatch_once(&once, ^{
+    if (!theController) {
+      theController = [ABI41_0_0EXUpdatesDevLauncherController new];
+    }
+  });
+  return theController;
+}
+
+- (void)setBridge:(nullable id)bridge
+{
+  _bridge = bridge;
+  if ([bridge isKindOfClass:[ABI41_0_0RCTBridge class]]) {
+    ABI41_0_0EXUpdatesAppController.sharedInstance.bridge = (ABI41_0_0RCTBridge *)bridge;
+  }
+}
+
+- (NSURL *)launchAssetURL
+{
+  return ABI41_0_0EXUpdatesAppController.sharedInstance.launchAssetUrl;
+}
+
+- (void)fetchUpdateWithConfiguration:(NSDictionary *)configuration
+                          onManifest:(ABI41_0_0EXUpdatesManifestBlock)manifestBlock
+                            progress:(ABI41_0_0EXUpdatesProgressBlock)progressBlock
+                             success:(ABI41_0_0EXUpdatesSuccessBlock)successBlock
+                               error:(ABI41_0_0EXUpdatesErrorBlock)errorBlock
+{
+  ABI41_0_0EXUpdatesAppController *controller = ABI41_0_0EXUpdatesAppController.sharedInstance;
+  ABI41_0_0EXUpdatesConfig *updatesConfiguration = [ABI41_0_0EXUpdatesConfig configWithExpoPlist];
+  [updatesConfiguration loadConfigFromDictionary:configuration];
+  if (!updatesConfiguration.updateUrl) {
+    errorBlock([NSError errorWithDomain:ABI41_0_0EXUpdatesDevLauncherControllerErrorDomain code:ABI41_0_0EXUpdatesDevLauncherErrorCodeInvalidUpdateURL userInfo:@{NSLocalizedDescriptionKey: @"Failed to load update: configuration object must include a valid update URL"}]);
+    return;
+  }
+  NSError *fsError;
+  if (![controller initializeUpdatesDirectoryWithError:&fsError]) {
+    errorBlock(fsError ?: [NSError errorWithDomain:ABI41_0_0EXUpdatesDevLauncherControllerErrorDomain code:ABI41_0_0EXUpdatesDevLauncherErrorCodeDirectoryInitializationFailed userInfo:@{NSLocalizedDescriptionKey: @"Failed to initialize updates directory with an unknown error"}]);
+    return;
+  }
+  NSError *dbError;
+  if (![controller initializeUpdatesDatabaseWithError:&dbError]) {
+    errorBlock(dbError ?: [NSError errorWithDomain:ABI41_0_0EXUpdatesDevLauncherControllerErrorDomain code:ABI41_0_0EXUpdatesDevLauncherErrorCodeDatabaseInitializationFailed userInfo:@{NSLocalizedDescriptionKey: @"Failed to initialize updates database with an unknown error"}]);
+    return;
+  }
+
+  [controller setIsStarted:YES];
+  [self _setDevelopmentSelectionPolicy];
+
+  ABI41_0_0EXUpdatesRemoteAppLoader *loader = [[ABI41_0_0EXUpdatesRemoteAppLoader alloc] initWithConfig:updatesConfiguration database:controller.database directory:controller.updatesDirectory completionQueue:controller.controllerQueue];
+  [loader loadUpdateFromUrl:updatesConfiguration.updateUrl onManifest:^BOOL(ABI41_0_0EXUpdatesUpdate * _Nonnull update) {
+    return manifestBlock(update.rawManifest.rawManifestJSON);
+  } asset:^(ABI41_0_0EXUpdatesAsset * _Nonnull asset, NSUInteger successfulAssetCount, NSUInteger failedAssetCount, NSUInteger totalAssetCount) {
+    progressBlock(successfulAssetCount, failedAssetCount, totalAssetCount);
+  } success:^(ABI41_0_0EXUpdatesUpdate * _Nullable update) {
+    if (!update) {
+      successBlock(nil);
+      return;
+    }
+    [self _launchUpdate:update withConfiguration:updatesConfiguration success:successBlock error:errorBlock];
+  } error:errorBlock];
+}
+
+- (void)_setDevelopmentSelectionPolicy
+{
+  ABI41_0_0EXUpdatesAppController *controller = ABI41_0_0EXUpdatesAppController.sharedInstance;
+  ABI41_0_0EXUpdatesSelectionPolicy *currentSelectionPolicy = controller.selectionPolicy;
+  [controller setDefaultSelectionPolicy:[[ABI41_0_0EXUpdatesSelectionPolicy alloc]
+                                         initWithLauncherSelectionPolicy:currentSelectionPolicy.launcherSelectionPolicy
+                                         loaderSelectionPolicy:currentSelectionPolicy.loaderSelectionPolicy
+                                         reaperSelectionPolicy:[ABI41_0_0EXUpdatesReaperSelectionPolicyDevelopmentClient new]]];
+  [controller resetSelectionPolicyToDefault];
+}
+
+- (void)_launchUpdate:(ABI41_0_0EXUpdatesUpdate *)update
+    withConfiguration:(ABI41_0_0EXUpdatesConfig *)configuration
+              success:(ABI41_0_0EXUpdatesSuccessBlock)successBlock
+                error:(ABI41_0_0EXUpdatesErrorBlock)errorBlock
+{
+  ABI41_0_0EXUpdatesAppController *controller = ABI41_0_0EXUpdatesAppController.sharedInstance;
+  ABI41_0_0EXUpdatesAppLauncherWithDatabase *launcher = [[ABI41_0_0EXUpdatesAppLauncherWithDatabase alloc] initWithConfig:configuration database:controller.database directory:controller.updatesDirectory completionQueue:controller.controllerQueue];
+  [launcher launchUpdateWithSelectionPolicy:controller.selectionPolicy completion:^(NSError * _Nullable error, BOOL success) {
+    if (!success) {
+      errorBlock(error ?: [NSError errorWithDomain:ABI41_0_0EXUpdatesDevLauncherControllerErrorDomain code:ABI41_0_0EXUpdatesDevLauncherErrorCodeUpdateLaunchFailed userInfo:@{NSLocalizedDescriptionKey: @"Failed to launch update with an unknown error"}]);
+      return;
+    }
+
+    [controller setConfigurationInternal:configuration];
+    [controller setLauncher:launcher];
+    successBlock(launcher.launchedUpdate.rawManifest.rawManifestJSON);
+    [controller runReaper];
+  }];
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/ABI41_0_0EXUpdatesModule.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/ABI41_0_0EXUpdatesModule.m
@@ -10,7 +10,7 @@
 
 @interface ABI41_0_0EXUpdatesModule ()
 
-@property (nonatomic, weak) id<ABI41_0_0EXUpdatesInterface> updatesService;
+@property (nonatomic, weak) id<ABI41_0_0EXUpdatesModuleInterface> updatesService;
 
 @end
 
@@ -20,7 +20,7 @@ ABI41_0_0UM_EXPORT_MODULE(ExpoUpdates);
 
 - (void)setModuleRegistry:(ABI41_0_0UMModuleRegistry *)moduleRegistry
 {
-  _updatesService = [moduleRegistry getModuleImplementingProtocol:@protocol(ABI41_0_0EXUpdatesInterface)];
+  _updatesService = [moduleRegistry getModuleImplementingProtocol:@protocol(ABI41_0_0EXUpdatesModuleInterface)];
 }
 
 - (NSDictionary *)constantsToExport

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/ABI41_0_0EXUpdatesService.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/ABI41_0_0EXUpdatesService.h
@@ -10,7 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 typedef void (^ABI41_0_0EXUpdatesAppRelaunchCompletionBlock)(BOOL success);
 
-@protocol ABI41_0_0EXUpdatesInterface
+@protocol ABI41_0_0EXUpdatesModuleInterface
 
 @property (nonatomic, readonly) ABI41_0_0EXUpdatesConfig *config;
 @property (nonatomic, readonly) ABI41_0_0EXUpdatesDatabase *database;
@@ -29,7 +29,7 @@ typedef void (^ABI41_0_0EXUpdatesAppRelaunchCompletionBlock)(BOOL success);
 
 @end
 
-@interface ABI41_0_0EXUpdatesService : NSObject <ABI41_0_0UMInternalModule, ABI41_0_0EXUpdatesInterface>
+@interface ABI41_0_0EXUpdatesService : NSObject <ABI41_0_0UMInternalModule, ABI41_0_0EXUpdatesModuleInterface>
 
 @end
 

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/ABI41_0_0EXUpdatesService.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/ABI41_0_0EXUpdatesService.m
@@ -12,7 +12,7 @@ ABI41_0_0UM_REGISTER_MODULE();
 
 + (const NSArray<Protocol *> *)exportedInterfaces
 {
-  return @[@protocol(ABI41_0_0EXUpdatesInterface)];
+  return @[@protocol(ABI41_0_0EXUpdatesModuleInterface)];
 }
 
 - (ABI41_0_0EXUpdatesConfig *)config

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdatesInterface/ABI41_0_0EXUpdatesInterface.podspec
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdatesInterface/ABI41_0_0EXUpdatesInterface.podspec
@@ -1,0 +1,18 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name           = 'ABI41_0_0EXUpdatesInterface'
+  s.version        = package['version']
+  s.summary        = package['description']
+  s.description    = package['description']
+  s.license        = package['license']
+  s.author         = package['author']
+  s.homepage       = package['homepage']
+  s.platform       = :ios, '11.0'
+  s.source         = { git: 'https://github.com/expo/expo.git' }
+  s.source_files   = 'ABI41_0_0EXUpdatesInterface/**/*.{h,m}'
+  s.preserve_paths = 'ABI41_0_0EXUpdatesInterface/**/*.{h,m}'
+  s.requires_arc   = true
+end

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdatesInterface/ABI41_0_0EXUpdatesInterface/ABI41_0_0EXUpdatesInterface.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdatesInterface/ABI41_0_0EXUpdatesInterface/ABI41_0_0EXUpdatesInterface.h
@@ -1,0 +1,35 @@
+//  Copyright © 2021 650 Industries. All rights reserved.
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef void (^ABI41_0_0EXUpdatesErrorBlock) (NSError *error);
+typedef void (^ABI41_0_0EXUpdatesSuccessBlock) (NSDictionary * _Nullable manifest);
+typedef void (^ABI41_0_0EXUpdatesProgressBlock) (NSUInteger successfulAssetCount, NSUInteger failedAssetCount, NSUInteger totalAssetCount);
+/**
+ * Called when a manifest has been downloaded. The return value indicates whether or not to
+ * continue downloading the update described by this manifest. Returning `NO` will abort the
+ * load, and the success block will be immediately called with a nil `manifest`.
+ */
+typedef BOOL (^ABI41_0_0EXUpdatesManifestBlock) (NSDictionary *manifest);
+
+/**
+ * Protocol for modules that depend on expo-updates for loading production updates but do not want
+ * to depend on expo-updates or delegate control to the singleton ABI41_0_0EXUpdatesAppController.
+ */
+@protocol ABI41_0_0EXUpdatesInterface
+
+@property (nonatomic, weak) id bridge;
+
+- (NSURL *)launchAssetURL;
+
+- (void)fetchUpdateWithConfiguration:(NSDictionary *)configuration
+                          onManifest:(ABI41_0_0EXUpdatesManifestBlock)manifestBlock
+                            progress:(ABI41_0_0EXUpdatesProgressBlock)progressBlock
+                             success:(ABI41_0_0EXUpdatesSuccessBlock)successBlock
+                               error:(ABI41_0_0EXUpdatesErrorBlock)errorBlock;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdatesInterface/package.json
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdatesInterface/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "expo-updates-interface",
+  "version": "0.0.1",
+  "description": "Native interface for modules that optionally depend on expo-updates, e.g. expo-dev-launcher.",
+  "main": "index.js",
+  "keywords": [
+    "react-native",
+    "expo",
+    "expo-updates-interface"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/expo/expo.git",
+    "directory": "packages/expo-updates-interface"
+  },
+  "bugs": {
+    "url": "https://github.com/expo/expo/issues"
+  },
+  "author": "650 Industries, Inc.",
+  "license": "MIT",
+  "homepage": "https://docs.expo.io/versions/latest/sdk/module-template"
+}

--- a/ios/versioned-react-native/ABI41_0_0/dependencies.rb
+++ b/ios/versioned-react-native/ABI41_0_0/dependencies.rb
@@ -200,6 +200,9 @@ pod 'ABI41_0_0EXTrackingTransparency',
 pod 'ABI41_0_0EXUpdates',
   :path => './versioned-react-native/ABI41_0_0/Expo/EXUpdates',
   :project_name => 'ABI41_0_0'
+pod 'ABI41_0_0EXUpdatesInterface',
+  :path => './versioned-react-native/ABI41_0_0/Expo/EXUpdatesInterface',
+  :project_name => 'ABI41_0_0'
 pod 'ABI41_0_0EXVideoThumbnails',
   :path => './versioned-react-native/ABI41_0_0/Expo/EXVideoThumbnails',
   :project_name => 'ABI41_0_0'


### PR DESCRIPTION
# Why

https://github.com/expo/expo/pull/13112#pullrequestreview-673437337

# How

Basically followed @wschurman 's helpfully documented process from #12826:

```
rm -rf ios/versioned-react-native/ABI39_0_0/Expo/EXUpdates/ABI39_0_0EXUpdates
et add-sdk-version -p ios -s 39.0.0 -f "packages/expo-updates/ios/EXUpdates/**/*.{m,h}" --prevent-reinstall
find packages/expo-updates/ios/EXUpdates -name 'ABI39_0_0*' -exec bash -c 'mkdir -p `dirname ${0/packages\/expo-updates\/ios\/EXUpdates/ios\/versioned-react-native\/ABI39_0_0\/Expo\/EXUpdates\/ABI39_0_0EXUpdates}`; mv $0 ${0/packages\/expo-updates\/ios\/EXUpdates/ios\/versioned-react-native\/ABI39_0_0\/Expo\/EXUpdates\/ABI39_0_0EXUpdates}' {} \;
mv ios/versioned-react-native/ABI39_0_0/Expo/EXUpdates/ABI39_0_0EXUpdates/Update/RawManifest/ABI39_0_0NSDictionary+EXUpdatesRawManifest.h ios/versioned-react-native/ABI39_0_0/Expo/EXUpdates/ABI39_0_0EXUpdates/Update/RawManifest/NSDictionary+ABI39_0_0EXUpdatesRawManifest.h
mv ios/versioned-react-native/ABI39_0_0/Expo/EXUpdates/ABI39_0_0EXUpdates/Update/RawManifest/ABI39_0_0NSDictionary+EXUpdatesRawManifest.m ios/versioned-react-native/ABI39_0_0/Expo/EXUpdates/ABI39_0_0EXUpdates/Update/RawManifest/NSDictionary+ABI39_0_0EXUpdatesRawManifest.m
git checkout -- packages/expo-updates
git clean -f -d packages/expo-updates
git add .
git commit -m "sdk 39"


rm -rf ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates
et add-sdk-version -p ios -s 40.0.0 -f "packages/expo-updates/ios/EXUpdates/**/*.{m,h}" --prevent-reinstall
find packages/expo-updates/ios/EXUpdates -name 'ABI40_0_0*' -exec bash -c 'mkdir -p `dirname ${0/packages\/expo-updates\/ios\/EXUpdates/ios\/versioned-react-native\/ABI40_0_0\/Expo\/EXUpdates\/ABI40_0_0EXUpdates}`; mv $0 ${0/packages\/expo-updates\/ios\/EXUpdates/ios\/versioned-react-native\/ABI40_0_0\/Expo\/EXUpdates\/ABI40_0_0EXUpdates}' {} \;
mv ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/RawManifest/ABI40_0_0NSDictionary+EXUpdatesRawManifest.h ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/RawManifest/NSDictionary+ABI40_0_0EXUpdatesRawManifest.h
mv ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/RawManifest/ABI40_0_0NSDictionary+EXUpdatesRawManifest.m ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/RawManifest/NSDictionary+ABI40_0_0EXUpdatesRawManifest.m
git checkout -- packages/expo-updates
git clean -f -d packages/expo-updates
git add .
git commit -m "sdk 40"

rm -rf ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates
et add-sdk-version -p ios -s 41.0.0 -f "packages/expo-updates/ios/EXUpdates/**/*.{m,h}" --prevent-reinstall
find packages/expo-updates/ios/EXUpdates -name 'ABI41_0_0*' -exec bash -c 'mkdir -p `dirname ${0/packages\/expo-updates\/ios\/EXUpdates/ios\/versioned-react-native\/ABI41_0_0\/Expo\/EXUpdates\/ABI41_0_0EXUpdates}`; mv $0 ${0/packages\/expo-updates\/ios\/EXUpdates/ios\/versioned-react-native\/ABI41_0_0\/Expo\/EXUpdates\/ABI41_0_0EXUpdates}' {} \;
mv ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/RawManifest/ABI41_0_0NSDictionary+EXUpdatesRawManifest.h ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/RawManifest/NSDictionary+ABI41_0_0EXUpdatesRawManifest.h
mv ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/RawManifest/ABI41_0_0NSDictionary+EXUpdatesRawManifest.m ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/RawManifest/NSDictionary+ABI41_0_0EXUpdatesRawManifest.m
git checkout -- packages/expo-updates
git clean -f -d packages/expo-updates
git add .
git commit -m "sdk 41"

et add-sdk-version -p ios -s 39.0.0 --package expo-updates-interface --prevent-reinstall
et add-sdk-version -p ios -s 40.0.0 --package expo-updates-interface --prevent-reinstall
et add-sdk-version -p ios -s 41.0.0 --package expo-updates-interface --prevent-reinstall
git add .
git commit -m "backport expo-updates-interface"
```
+ manually adding to versioned dependencies.rb

# Test Plan

Built versioned Expo Go, opened updates in all 3 SDK versions and manually tested module methods.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).