### PR TITLE
[ios][android] Update lottie-react-native to v4.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Package-specific changes not released in any SDK will be added here just before 
 
 ### 📚 3rd party library updates
 
-- Updated `lottie-react-native` from `3.5.0` to `4.0.2`.
+- Updated `lottie-react-native` from `3.5.0` to `4.0.2`. ([#13151](https://github.com/expo/expo/pull/13151) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🛠 Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Package-specific changes not released in any SDK will be added here just before 
 
 ### 📚 3rd party library updates
 
+- Updated `lottie-react-native` from `3.5.0` to `4.0.2`.
+
 ### 🛠 Breaking changes
 
 ### 🎉 New features

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/lottie/LottieAnimationViewManager.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/lottie/LottieAnimationViewManager.java
@@ -118,11 +118,16 @@ class LottieAnimationViewManager extends SimpleViewManager<LottieAnimationView> 
             int startFrame = args.getInt(0);
             int endFrame = args.getInt(1);
             if (startFrame != -1 && endFrame != -1) {
-               if(startFrame > endFrame){
+               if (startFrame > endFrame) {
                 view.setMinAndMaxFrame(endFrame, startFrame);
-                view.reverseAnimationSpeed();
+                if (view.getSpeed() > 0) {
+                  view.reverseAnimationSpeed();
+                }
               } else {
                 view.setMinAndMaxFrame(startFrame, endFrame);
+                if (view.getSpeed() < 0) {
+                  view.reverseAnimationSpeed();
+                }
               }
             }
             if (ViewCompat.isAttachedToWindow(view)) {
@@ -200,6 +205,11 @@ class LottieAnimationViewManager extends SimpleViewManager<LottieAnimationView> 
   @ReactProp(name = "sourceJson")
   public void setSourceJson(LottieAnimationView view, String json) {
     getOrCreatePropertyManager(view).setAnimationJson(json);
+  }
+
+  @ReactProp(name = "cacheComposition")
+  public void setCacheComposition(LottieAnimationView view, boolean cacheComposition) {
+    view.setCacheComposition(cacheComposition);
   }
 
   @ReactProp(name = "resizeMode")

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -127,7 +127,7 @@
     "gl-mat4": "^1.1.4",
     "hsv2rgb": "^1.1.0",
     "i18n-js": "^3.1.0",
-    "lottie-react-native": "3.5.0",
+    "lottie-react-native": "4.0.2",
     "moment": "^2.10.6",
     "path": "^0.12.7",
     "pixi.js": "^4.6.1",

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2068,9 +2068,9 @@ PODS:
   - GTMSessionFetcher/Core (1.5.0)
   - JKBigInteger2 (0.0.5)
   - lottie-ios (3.1.9)
-  - lottie-react-native (3.4.0):
+  - lottie-react-native (4.0.2):
     - lottie-ios (~> 3.1.8)
-    - React
+    - React-Core
   - MLKitCommon (2.1.0):
     - GoogleDataTransport (~> 8.0)
     - GoogleToolboxForMac/Logger (~> 2.1)
@@ -4052,7 +4052,7 @@ SPEC CHECKSUMS:
   GTMSessionFetcher: b3503b20a988c4e20cc189aa798fd18220133f52
   JKBigInteger2: e91672035c42328c48b7dd015b66812ddf40ca9b
   lottie-ios: 3a3758ef5a008e762faec9c9d50a39842f26d124
-  lottie-react-native: 55abec29d1a068cd43fdd2e7353e409fdaee8389
+  lottie-react-native: 4dff8fe8d10ddef9e7880e770080f4a56121397e
   MLKitCommon: 9ed187a042139d51c0d8bf6a8301bb20b375c576
   MLKitFaceDetection: 5b92261dd6e4205e3dab0df62537ac3f4e90e5db
   MLKitVision: 51385878c9100024478971856510f9271ff555b5
@@ -4063,7 +4063,7 @@ SPEC CHECKSUMS:
   RCTTypeSafety: 44982c5c8e43ff4141eb519a8ddc88059acd1f3a
   React: e1c65dd41cb9db13b99f24608e47dd595f28ca9a
   React-callinvoker: 552a6a6bc8b3bb794cf108ad59e5a9e2e3b4fc98
-  React-Core: 9d341e725dc9cd2f49e4c49ad1fc4e8776aa2639
+  React-Core: a42b4deaadbde5a2d8e2dab7a2b874303f733cf4
   React-CoreModules: 5335e168165da7f7083ce7147768d36d3e292318
   React-cxxreact: d3261ec5f7d11743fbf21e263a34ea51d1f13ebc
   React-jsi: 54245e1d5f4b690dec614a73a3795964eeef13a8

--- a/ios/vendored/unversioned/lottie-react-native/lottie-react-native.podspec.json
+++ b/ios/vendored/unversioned/lottie-react-native/lottie-react-native.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "lottie-react-native",
-  "version": "3.4.0",
+  "version": "4.0.2",
   "summary": "Lottie component for React Native (iOS and Android)",
   "authors": {
     "intelligibabble": "leland.m.richardson@gmail.com"
@@ -8,19 +8,22 @@
   "homepage": "https://github.com/airbnb/lottie-react-native#readme",
   "license": "Apache-2.0",
   "platforms": {
-    "ios": "9.0"
+    "ios": "9.0",
+    "osx": "10.10"
   },
   "source": {
     "git": "https://github.com/react-community/lottie-react-native.git",
-    "tag": "v3.4.0"
+    "tag": "v4.0.2"
   },
   "source_files": "src/ios/**/*.{h,m,swift}",
-  "swift_versions": "5.0",
+  "requires_arc": true,
+  "pod_target_xcconfig": {
+    "DEFINES_MODULE": "YES"
+  },
   "dependencies": {
-    "React": [],
+    "React-Core": [],
     "lottie-ios": [
       "~> 3.1.8"
     ]
-  },
-  "swift_version": "5.0"
+  }
 }

--- a/ios/vendored/unversioned/lottie-react-native/src/ios/LottieReactNative/AnimationViewManagerModule.swift
+++ b/ios/vendored/unversioned/lottie-react-native/src/ios/LottieReactNative/AnimationViewManagerModule.swift
@@ -1,26 +1,33 @@
-#if canImport(React)
-import React
-#endif
-
 import Lottie
+
+#if os(OSX)
+import AppKit
+
+typealias View = NSView
+
+#else
+import UIKit
+
+typealias View = UIView
+
+#endif
 
 @objc(LottieAnimationView)
 class AnimationViewManagerModule: RCTViewManager {
-    override func view() -> UIView! {
+    override func view() -> View! {
         return ContainerView()
     }
-    
+
     @objc override func constantsToExport() -> [AnyHashable : Any]! {
         return ["VERSION": 1]
     }
-    
-    
+
+
     @objc(play:fromFrame:toFrame:)
     public func play(_ reactTag: NSNumber, startFrame: NSNumber, endFrame: NSNumber) {
-        
         self.bridge.uiManager.addUIBlock { (uiManager, viewRegistry) in
             guard let view = viewRegistry?[reactTag] as? ContainerView else {
-                if (RCT_DEV == 1) {
+                if (RCT_DEBUG == 1) {
                     print("Invalid view returned from registry, expecting ContainerView")
                 }
                 return
@@ -37,14 +44,14 @@ class AnimationViewManagerModule: RCTViewManager {
             } else {
                 view.play(completion: callback)
             }
-        }      
+        }
     }
-    
+
     @objc(reset:)
     public func reset(_ reactTag: NSNumber) {
         self.bridge.uiManager.addUIBlock { uiManager, viewRegistry in
             guard let view = viewRegistry?[reactTag] as? ContainerView else {
-                if (RCT_DEV == 1) {
+                if (RCT_DEBUG == 1) {
                     print("Invalid view returned from registry, expecting ContainerView")
                 }
                 return
@@ -53,12 +60,12 @@ class AnimationViewManagerModule: RCTViewManager {
             view.reset()
         }
     }
-    
+
     @objc(pause:)
     public func pause(_ reactTag: NSNumber) {
         self.bridge.uiManager.addUIBlock { uiManager, viewRegistry in
             guard let view = viewRegistry?[reactTag] as? ContainerView else {
-                if (RCT_DEV == 1) {
+                if (RCT_DEBUG == 1) {
                     print("Invalid view returned from registry, expecting ContainerView")
                 }
                 return
@@ -72,7 +79,7 @@ class AnimationViewManagerModule: RCTViewManager {
     public func resume(_ reactTag: NSNumber) {
         self.bridge.uiManager.addUIBlock { uiManager, viewRegistry in
             guard let view = viewRegistry?[reactTag] as? ContainerView else {
-                if (RCT_DEV == 1) {
+                if (RCT_DEBUG == 1) {
                     print("Invalid view returned from registry, expecting ContainerView")
                 }
                 return
@@ -81,9 +88,8 @@ class AnimationViewManagerModule: RCTViewManager {
             view.resume()
         }
     }
-    
+
     override static func requiresMainQueueSetup() -> Bool {
         return true
     }
-    
 }

--- a/ios/vendored/unversioned/lottie-react-native/src/ios/LottieReactNative/ContainerView.swift
+++ b/ios/vendored/unversioned/lottie-react-native/src/ios/LottieReactNative/ContainerView.swift
@@ -1,7 +1,3 @@
-#if canImport(React)
-import React
-#endif
-
 import Lottie
 
 class ContainerView: RCTView {
@@ -17,7 +13,7 @@ class ContainerView: RCTView {
 
     @objc func setSpeed(_ newSpeed: CGFloat) {
         speed = newSpeed
-        
+
         if (newSpeed != 0.0) {
             animationView?.animationSpeed = newSpeed
             if (!(animationView?.isAnimationPlaying ?? true)) {
@@ -48,7 +44,7 @@ class ContainerView: RCTView {
 
         guard let data = sourceJson.data(using: String.Encoding.utf8),
         let animation = try? JSONDecoder().decode(Animation.self, from: data) else {
-            if (RCT_DEV == 1) {
+            if (RCT_DEBUG == 1) {
                 print("Unable to create the lottie animation object from the JSON source")
             }
             return
@@ -86,32 +82,6 @@ class ContainerView: RCTView {
         applyProperties()
     }
 
-    func hexStringToUIColor(hex: String) -> UIColor {
-        var cString:String = hex.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
-
-        if (cString.hasPrefix("#")) {
-            cString.remove(at: cString.startIndex)
-        }
-
-        if ((cString.count) == 0) {
-            return UIColor.red
-        }
-
-        if ((cString.count) != 6) {
-            return UIColor.green
-        }
-
-        var rgbValue:UInt32 = 0
-        Scanner(string: cString).scanHexInt32(&rgbValue)
-
-        return UIColor(
-            red: CGFloat((rgbValue & 0xFF0000) >> 16) / 255.0,
-            green: CGFloat((rgbValue & 0x00FF00) >> 8) / 255.0,
-            blue: CGFloat(rgbValue & 0x0000FF) / 255.0,
-            alpha: CGFloat(1.0)
-        )
-    }
-
     func play(fromFrame: AnimationFrameTime? = nil, toFrame: AnimationFrameTime, completion: LottieCompletionBlock? = nil) {
         animationView?.backgroundBehavior = .pauseAndRestore
         animationView?.play(fromFrame: fromFrame, toFrame: toFrame, loopMode: self.loop, completion: completion);
@@ -126,7 +96,7 @@ class ContainerView: RCTView {
         animationView?.currentProgress = 0;
         animationView?.pause()
     }
-    
+
     func pause() {
         animationView?.pause()
     }
@@ -156,7 +126,7 @@ class ContainerView: RCTView {
             for filter in colorFilters {
                 let keypath: String = "\(filter.value(forKey: "keypath") as! String).**.Color"
                 let fillKeypath = AnimationKeypath(keypath: keypath)
-                let colorFilterValueProvider = ColorValueProvider(hexStringToUIColor(hex: filter.value(forKey: "color") as! String).lottieColorValue)
+                let colorFilterValueProvider = ColorValueProvider(hexStringToColor(hex: filter.value(forKey: "color") as! String))
                 animationView?.setValueProvider(colorFilterValueProvider, keypath: fillKeypath)
             }
         }

--- a/ios/vendored/unversioned/lottie-react-native/src/ios/LottieReactNative/hexStringToColor.swift
+++ b/ios/vendored/unversioned/lottie-react-native/src/ios/LottieReactNative/hexStringToColor.swift
@@ -1,0 +1,58 @@
+//
+//  hexStringToColor.swift
+//  LottieReactNative
+//
+//  Created by Igor Mandrigin on 2020-08-28.
+//  Copyright © 2020 Airbnb. All rights reserved.
+//
+import Lottie
+
+#if os(OSX)
+
+import AppKit
+
+typealias PlatformColor = NSColor
+
+// NSColor doesn't have this extension (UIColor receives it from Lottie), so we add it here
+public extension NSColor {
+    var lottieColorValue: Color {
+        var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
+        getRed(&r, green: &g, blue: &b, alpha: &a)
+        return Color(r: Double(r), g: Double(g), b: Double(b), a: Double(a))
+    }
+}
+
+#else
+
+import UIKit
+
+typealias PlatformColor = UIColor
+
+#endif
+
+func hexStringToColor(hex: String) -> Color {
+    var cString:String = hex.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
+
+    if (cString.hasPrefix("#")) {
+        cString.remove(at: cString.startIndex)
+    }
+
+    if ((cString.count) == 0) {
+        return PlatformColor.red.lottieColorValue
+    }
+
+    if ((cString.count) != 6) {
+        return PlatformColor.green.lottieColorValue
+    }
+
+    var rgbValue:UInt32 = 0
+    Scanner(string: cString).scanHexInt32(&rgbValue)
+
+    return PlatformColor(red: CGFloat((rgbValue & 0xFF0000) >> 16) / 255.0,
+                         green: CGFloat((rgbValue & 0x00FF00) >> 8) / 255.0,
+                         blue: CGFloat(rgbValue & 0x0000FF) / 255.0,
+                         alpha:CGFloat(1.0)).lottieColorValue;
+}
+
+
+

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -86,7 +86,7 @@
   "expo-video-thumbnails": "~5.1.0",
   "expo-web-browser": "~9.1.0",
   "firebase": "8.2.3",
-  "lottie-react-native": "3.5.0",
+  "lottie-react-native": "4.0.2",
   "react-native-appearance": "~0.3.3",
   "react-native-branch": "5.0.0",
   "react-native-gesture-handler": "~1.10.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14301,20 +14301,14 @@ loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1, loose-envify@^1.4
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
 
-lottie-ios@^3.1.8:
-  version "3.1.9"
-  resolved "https://registry.yarnpkg.com/lottie-ios/-/lottie-ios-3.1.9.tgz#592a8978cd679945c66a2b5fc087146c33e9d475"
-  integrity sha512-iB/jtMQiZnhNvPiQOkyRU3h8y+SKsIL8bqo8aAC9wTv2YStXSInmCPLw3JbIFy0HqW6YPwEFbqgFjtgo9vAHUg==
-
-lottie-react-native@3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/lottie-react-native/-/lottie-react-native-3.5.0.tgz#749fed964bdc9fabfae24ef81696f90f4d758f59"
-  integrity sha512-yKYj58xynDAG/BqJUhg9LTATBqwD4ATGXJKL2Ho6g4BTmPexOjDBNnPSeRBwjlpBxQ1nP4Qw//0zbuFsTFD1TA==
+lottie-react-native@4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/lottie-react-native/-/lottie-react-native-4.0.2.tgz#d0b7a479995b4bfdf5402671e096f15b7ef2a7d8"
+  integrity sha512-8X5SV8X+es5dJwUGYcSyRIbHIPeWIcUH6PiRaReUEy+6s1d+NLBp3rj4+9I75F1ZN0nbFGNkrgypnGsXOAXBTw==
   dependencies:
     invariant "^2.2.2"
-    lottie-ios "^3.1.8"
     prop-types "^15.5.10"
-    react-native-safe-modules "^1.0.0"
+    react-native-safe-modules "^1.0.3"
 
 lower-case-first@^2.0.2:
   version "2.0.2"
@@ -17475,10 +17469,10 @@ react-native-safe-area-view@^0.14.8, react-native-safe-area-view@^0.14.9:
   dependencies:
     hoist-non-react-statics "^2.3.1"
 
-react-native-safe-modules@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/react-native-safe-modules/-/react-native-safe-modules-1.0.0.tgz#10a918adf97da920adb1e33e0c852b1e80123b65"
-  integrity sha512-ShT8duWBT30W4OFcltZl+UvpPDikZFURvLDQqAsrvbyy6HzWPGJDCpdqM+6GqzPPs4DPEW31YfMNmdJcZ6zI2w==
+react-native-safe-modules@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/react-native-safe-modules/-/react-native-safe-modules-1.0.3.tgz#f5f29bb9d09d17581193843d4173ad3054f74890"
+  integrity sha512-DUxti4Z+AgJ/ZsO5U7p3uSCUBko8JT8GvFlCeOXk9bMd+4qjpoDvMYpfbixXKgL88M+HwmU/KI1YFN6gsQZyBA==
   dependencies:
     dedent "^0.6.0"
 


### PR DESCRIPTION
# Why

Updating 3rd-party libs for SDK42

# How

- Ran `et uvm -m lottie-react-native -c v4.0.2`
- Noticed an issue during `pod install` that `lottie-react-native` now requires `React-Core` dependency to define modules
- Added `"DEFINES_MODULE" => "YES"` to `React-Core.podspec` in our RN fork (see https://github.com/expo/react-native/commit/cb242431b8ab1738fce47da45dcd68a3b9224269)

# Test Plan

NCL examples seem to work as expected

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).