### PR TITLE
[tools] Fix issues with versioning on iOS

### DIFF
--- a/tools/src/versioning/ios/transforms/postTransforms.ts
+++ b/tools/src/versioning/ios/transforms/postTransforms.ts
@@ -84,9 +84,12 @@ export function postTransforms(versionName: string): TransformPipeline {
         with: `${versionName}NSData+EXFileSystem.h`,
       },
       {
-        paths: `${versionName}EXNotifications`,
-        replace: new RegExp(`NSDictionary\\+${versionName}EXNotificationsVerifyingClass\\.h`, 'g'),
-        with: `${versionName}NSDictionary+EXNotificationsVerifyingClass.h`,
+        paths: [`${versionName}EXNotifications`, `${versionName}EXUpdates`],
+        replace: new RegExp(
+          `NSDictionary\\+${versionName}(EXNotificationsVerifyingClass|EXUpdatesRawManifest)\\.h`,
+          'g'
+        ),
+        with: `${versionName}NSDictionary+$1.h`,
       },
 
       // react-native-maps


### PR DESCRIPTION
# Why

When testing upgrading `react-native-screens`, I tried to version the code for SDK42, but the script and compilation were failing in a few places. Mostly due to `expo-modules-core`, `expo-updates` and a new subproject in `expo-yarn-workspaces`

# How

Applied appropriate changes

# Test Plan

Ran `et add-sdk -p ios -s 42.0.0` and then built versioned Expo Go

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).