### PR TITLE
[ios][android] Update react-native-svg to 12.1.1

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/svg/ClipPathView.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/svg/ClipPathView.java
@@ -22,7 +22,6 @@ class ClipPathView extends GroupView {
 
     public ClipPathView(ReactContext reactContext) {
         super(reactContext);
-        mClipRule = CLIP_RULE_NONZERO;
     }
 
     @Override

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/svg/VirtualView.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/svg/VirtualView.java
@@ -342,11 +342,11 @@ abstract public class VirtualView extends ReactViewGroup {
             ClipPathView mClipNode = (ClipPathView) getSvgView().getDefinedClipPath(mClipPath);
 
             if (mClipNode != null) {
-                Path clipPath = mClipNode.mClipRule == CLIP_RULE_EVENODD ? mClipNode.getPath(canvas, paint) :
+                Path clipPath = mClipRule == CLIP_RULE_EVENODD ? mClipNode.getPath(canvas, paint) :
                         mClipNode.getPath(canvas, paint, Region.Op.UNION);
                 clipPath.transform(mClipNode.mMatrix);
                 clipPath.transform(mClipNode.mTransform);
-                switch (mClipNode.mClipRule) {
+                switch (mClipRule) {
                     case CLIP_RULE_EVENODD:
                         clipPath.setFillType(Path.FillType.EVEN_ODD);
                         break;

--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -697,7 +697,7 @@ PODS:
     - React-Core
   - RNSharedElement (0.7.0):
     - React
-  - RNSVG (12.1.0):
+  - RNSVG (12.1.1):
     - React
   - SDWebImage (5.11.0):
     - SDWebImage/Core (= 5.11.0)
@@ -1343,7 +1343,7 @@ SPEC CHECKSUMS:
   RNReanimated: 70f662b5232dd5d19ccff581e919a54ea73df51c
   RNScreens: e8e8dd0588b5da0ab57dcca76ab9b2d8987757e0
   RNSharedElement: 00b1a1420d213a34459bb9a5aacabb38107d7948
-  RNSVG: ce9d996113475209013317e48b05c21ee988d42e
+  RNSVG: 551acb6562324b1d52a4e0758f7ca0ec234e278f
   SDWebImage: 7acbb57630ac7db4a495547fb73916ff3e432f6b
   UMAppLoader: fe2708bb0ac5cd70052bc207d06aa3b7e72b9e97
   UMCore: 912510bbff567298d738590f17788a8516f9d7f3

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -118,7 +118,7 @@
     "react-native-safe-area-context": "3.2.0",
     "react-native-screens": "~3.0.0",
     "react-native-shared-element": "0.7.0",
-    "react-native-svg": "12.1.0",
+    "react-native-svg": "12.1.1",
     "react-native-unimodules": "~0.14.0",
     "react-native-view-shot": "3.1.2",
     "react-native-webview": "11.2.3",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -145,7 +145,7 @@
     "react-native-shared-element": "0.7.0",
     "react-native-safe-area-context": "3.2.0",
     "react-native-safe-area-view": "^0.14.8",
-    "react-native-svg": "12.1.0",
+    "react-native-svg": "12.1.1",
     "react-native-webview": "11.2.3",
     "react-native-screens": "~3.0.0",
     "react-native-unimodules": "~0.14.0",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -145,7 +145,7 @@
     "react-native-shared-element": "0.7.0",
     "react-native-safe-area-context": "3.2.0",
     "react-native-safe-area-view": "^0.14.8",
-    "react-native-svg": "~12.1.0",
+    "react-native-svg": "12.1.0",
     "react-native-webview": "11.2.3",
     "react-native-screens": "~3.0.0",
     "react-native-unimodules": "~0.14.0",

--- a/ios/Exponent.xcodeproj/project.pbxproj
+++ b/ios/Exponent.xcodeproj/project.pbxproj
@@ -5,6 +5,7 @@
 	};
 	objectVersion = 46;
 	objects = {
+
 /* Begin PBXBuildFile section */
 		0726F0592007E438004992E7 /* EXKernelAppRecord.m in Sources */ = {isa = PBXBuildFile; fileRef = 0726F0582007E438004992E7 /* EXKernelAppRecord.m */; };
 		0726F05C2007E446004992E7 /* EXKernelAppRegistry.m in Sources */ = {isa = PBXBuildFile; fileRef = 0726F05B2007E446004992E7 /* EXKernelAppRegistry.m */; };
@@ -146,6 +147,7 @@
 		50620A8F1BBC4330AF4B4E26 /* AIRGoogleMapHeatmapManager.m in Sources */ = {isa = PBXBuildFile; fileRef = A5B705024D7B4371B0EB68EC /* AIRGoogleMapHeatmapManager.m */; settings = {COMPILER_FLAGS = "-w"; }; };
 		50659F05B6314F5192BC2215 /* RNSharedElementStyle.m in Sources */ = {isa = PBXBuildFile; fileRef = 391920741A374C4AB61BDB48 /* RNSharedElementStyle.m */; settings = {COMPILER_FLAGS = "-w"; }; };
 		65945A8A5EFCAD9BB688728F /* libPods-Tests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = EB9A99C3D4234AE6ED00CE1B /* libPods-Tests.a */; };
+		6782D340A0024AF58B3805D0 /* RNSVGTopAlignedLabel.ios.m in Sources */ = {isa = PBXBuildFile; fileRef = F4B751B511314328B86D13C6 /* RNSVGTopAlignedLabel.ios.m */; settings = {COMPILER_FLAGS = "-w"; }; };
 		7043DF762283303800272D74 /* RNSVGPainterBrush.m in Sources */ = {isa = PBXBuildFile; fileRef = 7043DEFF2283303800272D74 /* RNSVGPainterBrush.m */; settings = {COMPILER_FLAGS = "-w"; }; };
 		7043DF772283303800272D74 /* RNSVGBrush.m in Sources */ = {isa = PBXBuildFile; fileRef = 7043DF012283303800272D74 /* RNSVGBrush.m */; settings = {COMPILER_FLAGS = "-w"; }; };
 		7043DF782283303800272D74 /* RNSVGPainter.m in Sources */ = {isa = PBXBuildFile; fileRef = 7043DF022283303800272D74 /* RNSVGPainter.m */; settings = {COMPILER_FLAGS = "-w"; }; };
@@ -304,6 +306,7 @@
 		B5FB74F11FF6DADC001C764B /* EXScopedEventEmitter.m in Sources */ = {isa = PBXBuildFile; fileRef = B5FB74281FF6DADB001C764B /* EXScopedEventEmitter.m */; };
 		B75F881E8F9641B785F76CB0 /* RNSVGForeignObject.m in Sources */ = {isa = PBXBuildFile; fileRef = A0DCD2EBCF2B4FDC80E8EBE3 /* RNSVGForeignObject.m */; settings = {COMPILER_FLAGS = "-w"; }; };
 		B7FE7D4B1CE74F38AAA8941D /* RNSVGMarkerManager.m in Sources */ = {isa = PBXBuildFile; fileRef = D93FFB9A64504D3E92FE8931 /* RNSVGMarkerManager.m */; settings = {COMPILER_FLAGS = "-w"; }; };
+		BB55C7102669C97000EC1EDE /* RNSVGTopAlignedLabel.ios.m in Sources */ = {isa = PBXBuildFile; fileRef = F4B751B511314328B86D13C6 /* RNSVGTopAlignedLabel.ios.m */; };
 		BBB83C632479C3B50004FF8E /* RNCSafeAreaViewEdges.m in Sources */ = {isa = PBXBuildFile; fileRef = BBB83C552479C3B50004FF8E /* RNCSafeAreaViewEdges.m */; };
 		BBB83C642479C3B50004FF8E /* RNCSafeAreaProviderManager.m in Sources */ = {isa = PBXBuildFile; fileRef = BBB83C562479C3B50004FF8E /* RNCSafeAreaProviderManager.m */; };
 		BBB83C652479C3B50004FF8E /* RNCSafeAreaView.m in Sources */ = {isa = PBXBuildFile; fileRef = BBB83C572479C3B50004FF8E /* RNCSafeAreaView.m */; };
@@ -658,7 +661,6 @@
 		FCB4099525C6207C00326AC8 /* EXScopedNotificationsUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = B2F7C02D246B09AE0060EE06 /* EXScopedNotificationsUtils.m */; };
 		FCF6D37025B34BC200808BF5 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCF6D36F25B34BC200808BF5 /* NotificationService.swift */; };
 		FCF6D37425B34BC200808BF5 /* ExpoNotificationServiceExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = FCF6D36D25B34BC200808BF5 /* ExpoNotificationServiceExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		6782D340A0024AF58B3805D0 /* RNSVGTopAlignedLabel.ios.m in Sources */ = {isa = PBXBuildFile; fileRef = F4B751B511314328B86D13C6 /* RNSVGTopAlignedLabel.ios.m */; settings = {COMPILER_FLAGS = "-w"; }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -819,6 +821,7 @@
 		10B9AA823F57466698858869 /* RNDateTimePicker.h */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.c.h; path = RNDateTimePicker.h; sourceTree = "<group>"; };
 		12869A47946248B094FFB1C0 /* RNDateTimePickerManager.h */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.c.h; path = RNDateTimePickerManager.h; sourceTree = "<group>"; };
 		143A7129A6DA415F8B51B71E /* RNSharedElementTransitionManager.h */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.c.h; path = RNSharedElementTransitionManager.h; sourceTree = "<group>"; };
+		17D40143FCE844F89ABD4B05 /* RNSVGUIKit.h */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.c.h; path = RNSVGUIKit.h; sourceTree = "<group>"; };
 		19382BA71EC2EACC001ED4A1 /* EXScopedBranchManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EXScopedBranchManager.h; sourceTree = "<group>"; };
 		19382BA81EC2EACC001ED4A1 /* EXScopedBranchManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EXScopedBranchManager.m; sourceTree = "<group>"; };
 		19B2EF731FB25A1A003F2E1B /* EXCachedResourceManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EXCachedResourceManager.h; sourceTree = "<group>"; };
@@ -1322,6 +1325,7 @@
 		B5FB74271FF6DADB001C764B /* EXScopedEventEmitter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EXScopedEventEmitter.h; sourceTree = "<group>"; };
 		B5FB74281FF6DADB001C764B /* EXScopedEventEmitter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EXScopedEventEmitter.m; sourceTree = "<group>"; };
 		B683FEF12A9E4E4D9CFCC5A1 /* AIRGoogleMapHeatmap.h */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.c.h; path = AIRGoogleMapHeatmap.h; sourceTree = "<group>"; };
+		BBB57E7DED5040A38593385D /* RNSVGTopAlignedLabel.h */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.c.h; path = RNSVGTopAlignedLabel.h; sourceTree = "<group>"; };
 		BBB83C532479C3B50004FF8E /* RNCSafeAreaShadowView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNCSafeAreaShadowView.h; sourceTree = "<group>"; };
 		BBB83C542479C3B50004FF8E /* RNCSafeAreaViewLocalData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNCSafeAreaViewLocalData.h; sourceTree = "<group>"; };
 		BBB83C552479C3B50004FF8E /* RNCSafeAreaViewEdges.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNCSafeAreaViewEdges.m; sourceTree = "<group>"; };
@@ -1390,6 +1394,7 @@
 		F1E9894638084CB4956C637C /* RNCSlider.h */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.c.h; path = RNCSlider.h; sourceTree = "<group>"; };
 		F1F7433C24ABECD400EA5023 /* Exponent-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Exponent-Bridging-Header.h"; sourceTree = "<group>"; };
 		F1F7433D24ABECD500EA5023 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		F4B751B511314328B86D13C6 /* RNSVGTopAlignedLabel.ios.m */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.c.objc; path = RNSVGTopAlignedLabel.ios.m; sourceTree = "<group>"; };
 		F77DDB921E04AC1100624CA2 /* SafariServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SafariServices.framework; path = System/Library/Frameworks/SafariServices.framework; sourceTree = SDKROOT; };
 		F908C1B7DB88249B6ADE8937 /* libPods-Expo Go-Expo Go (unversioned).a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Expo Go-Expo Go (unversioned).a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		FC756CC824CB537400665AE6 /* EXScopedNotificationSerializer.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EXScopedNotificationSerializer.m; sourceTree = "<group>"; };
@@ -1402,9 +1407,6 @@
 		FCF6D36D25B34BC200808BF5 /* ExpoNotificationServiceExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = ExpoNotificationServiceExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		FCF6D36F25B34BC200808BF5 /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
 		FCF6D37125B34BC200808BF5 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		17D40143FCE844F89ABD4B05 /* RNSVGUIKit.h */ = {isa = PBXFileReference; name = "RNSVGUIKit.h"; path = "RNSVGUIKit.h"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; explicitFileType = undefined; includeInIndex = 0; };
-		BBB57E7DED5040A38593385D /* RNSVGTopAlignedLabel.h */ = {isa = PBXFileReference; name = "RNSVGTopAlignedLabel.h"; path = "RNSVGTopAlignedLabel.h"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; explicitFileType = undefined; includeInIndex = 0; };
-		F4B751B511314328B86D13C6 /* RNSVGTopAlignedLabel.ios.m */ = {isa = PBXFileReference; name = "RNSVGTopAlignedLabel.ios.m"; path = "RNSVGTopAlignedLabel.ios.m"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; explicitFileType = undefined; includeInIndex = 0; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -3724,6 +3726,7 @@
 				F142188F262CB68600BB97E6 /* EXScopedBridgeModule.m in Sources */,
 				F1421890262CB68600BB97E6 /* AIRDummyView.m in Sources */,
 				F1421891262CB68600BB97E6 /* AIRWeakMapReference.m in Sources */,
+				BB55C7102669C97000EC1EDE /* RNSVGTopAlignedLabel.ios.m in Sources */,
 				F1421892262CB68600BB97E6 /* EXPermissionsManager.m in Sources */,
 				F1421893262CB68600BB97E6 /* RNSVGRenderableManager.m in Sources */,
 				F1421894262CB68600BB97E6 /* AIRMapCircleManager.m in Sources */,

--- a/ios/Exponent.xcodeproj/project.pbxproj
+++ b/ios/Exponent.xcodeproj/project.pbxproj
@@ -5,7 +5,6 @@
 	};
 	objectVersion = 46;
 	objects = {
-
 /* Begin PBXBuildFile section */
 		0726F0592007E438004992E7 /* EXKernelAppRecord.m in Sources */ = {isa = PBXBuildFile; fileRef = 0726F0582007E438004992E7 /* EXKernelAppRecord.m */; };
 		0726F05C2007E446004992E7 /* EXKernelAppRegistry.m in Sources */ = {isa = PBXBuildFile; fileRef = 0726F05B2007E446004992E7 /* EXKernelAppRegistry.m */; };
@@ -659,6 +658,7 @@
 		FCB4099525C6207C00326AC8 /* EXScopedNotificationsUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = B2F7C02D246B09AE0060EE06 /* EXScopedNotificationsUtils.m */; };
 		FCF6D37025B34BC200808BF5 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCF6D36F25B34BC200808BF5 /* NotificationService.swift */; };
 		FCF6D37425B34BC200808BF5 /* ExpoNotificationServiceExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = FCF6D36D25B34BC200808BF5 /* ExpoNotificationServiceExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		6782D340A0024AF58B3805D0 /* RNSVGTopAlignedLabel.ios.m in Sources */ = {isa = PBXBuildFile; fileRef = F4B751B511314328B86D13C6 /* RNSVGTopAlignedLabel.ios.m */; settings = {COMPILER_FLAGS = "-w"; }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1402,6 +1402,9 @@
 		FCF6D36D25B34BC200808BF5 /* ExpoNotificationServiceExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = ExpoNotificationServiceExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		FCF6D36F25B34BC200808BF5 /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
 		FCF6D37125B34BC200808BF5 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		17D40143FCE844F89ABD4B05 /* RNSVGUIKit.h */ = {isa = PBXFileReference; name = "RNSVGUIKit.h"; path = "RNSVGUIKit.h"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; explicitFileType = undefined; includeInIndex = 0; };
+		BBB57E7DED5040A38593385D /* RNSVGTopAlignedLabel.h */ = {isa = PBXFileReference; name = "RNSVGTopAlignedLabel.h"; path = "RNSVGTopAlignedLabel.h"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; explicitFileType = undefined; includeInIndex = 0; };
+		F4B751B511314328B86D13C6 /* RNSVGTopAlignedLabel.ios.m */ = {isa = PBXFileReference; name = "RNSVGTopAlignedLabel.ios.m"; path = "RNSVGTopAlignedLabel.ios.m"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; explicitFileType = undefined; includeInIndex = 0; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1745,6 +1748,7 @@
 				7043DF652283303800272D74 /* Text */,
 				7043DF742283303800272D74 /* RNSVGNode.m */,
 				7043DF752283303800272D74 /* RNSVGContainer.h */,
+				17D40143FCE844F89ABD4B05 /* RNSVGUIKit.h */,
 			);
 			path = Svg;
 			sourceTree = "<group>";
@@ -1914,6 +1918,8 @@
 				7043DF712283303800272D74 /* RNSVGTSpan.m */,
 				7043DF722283303800272D74 /* RNSVGFontData.h */,
 				7043DF732283303800272D74 /* RNSVGGlyphContext.m */,
+				BBB57E7DED5040A38593385D /* RNSVGTopAlignedLabel.h */,
+				F4B751B511314328B86D13C6 /* RNSVGTopAlignedLabel.ios.m */,
 			);
 			path = Text;
 			sourceTree = "<group>";
@@ -3502,6 +3508,7 @@
 				BCB61D782B4944E89A1F0371 /* RNCSliderManager.m in Sources */,
 				07CB4E1A26045B620057443E /* RCTOnPageSelected.m in Sources */,
 				8B1448C54DEB4CFDB79D7E45 /* RNCSafeAreaViewMode.m in Sources */,
+				6782D340A0024AF58B3805D0 /* RNSVGTopAlignedLabel.ios.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/Exponent/Versioned/Core/Api/Components/Svg/Brushes/RNSVGPainter.m
+++ b/ios/Exponent/Versioned/Core/Api/Components/Svg/Brushes/RNSVGPainter.m
@@ -159,6 +159,11 @@ void PatternFunction(void* info, CGContextRef context)
     CGFloat h = [self getVal:[_points objectAtIndex:3] relative:height];
 
     CGAffineTransform viewbox = [self.pattern.svgView getViewBoxTransform];
+#if TARGET_OS_OSX
+    // This is needed because macOS and iOS have different conventions for where the origin is.
+    // For macOS, it's in the bottom-left corner. For iOS, it's in the top-left corner.
+    viewbox = CGAffineTransformScale(viewbox, 1, -1);
+#endif
     CGRect newBounds = CGRectMake(x, y, w, h);
     CGSize size = newBounds.size;
     self.useObjectBoundingBoxForContentUnits = _useContentObjectBoundingBox;

--- a/ios/Exponent/Versioned/Core/Api/Components/Svg/Elements/RNSVGClipPath.m
+++ b/ios/Exponent/Versioned/Core/Api/Components/Svg/Elements/RNSVGClipPath.m
@@ -19,9 +19,9 @@
 
 - (BOOL)isSimpleClipPath
 {
-    NSArray<UIView*> *children = self.subviews;
+    NSArray<RNSVGView*> *children = self.subviews;
     if (children.count == 1) {
-        UIView* child = children[0];
+        RNSVGView* child = children[0];
         if ([child class] != [RNSVGGroup class]) {
             return true;
         }

--- a/ios/Exponent/Versioned/Core/Api/Components/Svg/Elements/RNSVGDefs.h
+++ b/ios/Exponent/Versioned/Core/Api/Components/Svg/Elements/RNSVGDefs.h
@@ -9,7 +9,7 @@
 #import "RNSVGNode.h"
 
 /**
- * RNSVG defination are implemented as abstract UIViews for all elements inside Defs.
+ * RNSVG defination are implemented as abstract views for all elements inside Defs.
  */
 
 @interface RNSVGDefs : RNSVGNode

--- a/ios/Exponent/Versioned/Core/Api/Components/Svg/Elements/RNSVGDefs.m
+++ b/ios/Exponent/Versioned/Core/Api/Components/Svg/Elements/RNSVGDefs.m
@@ -27,7 +27,7 @@
     }];
 }
 
-- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
+- (RNSVGPlatformView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
 {
     return nil;
 }

--- a/ios/Exponent/Versioned/Core/Api/Components/Svg/Elements/RNSVGForeignObject.m
+++ b/ios/Exponent/Versioned/Core/Api/Components/Svg/Elements/RNSVGForeignObject.m
@@ -12,7 +12,7 @@
 
 @implementation RNSVGForeignObject
 
-- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
+- (RNSVGPlatformView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
 {
     return nil;
 }
@@ -42,7 +42,7 @@
 
     __block CGRect bounds = CGRectNull;
 
-    [self traverseSubviews:^(UIView *node) {
+    [self traverseSubviews:^(RNSVGView *node) {
         if ([node isKindOfClass:[RNSVGMask class]] || [node isKindOfClass:[RNSVGClipPath class]]) {
             // no-op
         } else if ([node isKindOfClass:[RNSVGNode class]]) {

--- a/ios/Exponent/Versioned/Core/Api/Components/Svg/Elements/RNSVGGroup.h
+++ b/ios/Exponent/Versioned/Core/Api/Components/Svg/Elements/RNSVGGroup.h
@@ -7,7 +7,9 @@
  */
 
 #import <Foundation/Foundation.h>
-#import <UIKit/UIKit.h>
+
+#import "RNSVGUIKit.h"
+
 #import "RNSVGContainer.h"
 #import "RNSVGCGFCRule.h"
 #import "RNSVGSvgView.h"

--- a/ios/Exponent/Versioned/Core/Api/Components/Svg/Elements/RNSVGGroup.m
+++ b/ios/Exponent/Versioned/Core/Api/Components/Svg/Elements/RNSVGGroup.m
@@ -38,7 +38,7 @@
 
     __block CGRect bounds = CGRectNull;
 
-    [self traverseSubviews:^(UIView *node) {
+    [self traverseSubviews:^(RNSVGView *node) {
         if ([node isKindOfClass:[RNSVGMask class]] || [node isKindOfClass:[RNSVGClipPath class]]) {
             // no-op
         } else if ([node isKindOfClass:[RNSVGNode class]]) {
@@ -160,7 +160,7 @@
     return cached;
 }
 
-- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
+- (RNSVGPlatformView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
 {
     CGPoint transformed = CGPointApplyAffineTransform(point, self.invmatrix);
     transformed = CGPointApplyAffineTransform(transformed, self.invTransform);
@@ -192,7 +192,7 @@
         }
     }
 
-    for (UIView *node in [self.subviews reverseObjectEnumerator]) {
+    for (RNSVGView *node in [self.subviews reverseObjectEnumerator]) {
         if ([node isKindOfClass:[RNSVGNode class]]) {
             if ([node isKindOfClass:[RNSVGMask class]]) {
                 continue;
@@ -201,21 +201,21 @@
             if (event) {
                 svgNode.active = NO;
             }
-            UIView *hitChild = [svgNode hitTest:transformed withEvent:event];
+            RNSVGPlatformView *hitChild = [svgNode hitTest:transformed withEvent:event];
             if (hitChild) {
                 svgNode.active = YES;
                 return (svgNode.responsible || (svgNode != hitChild)) ? hitChild : self;
             }
         } else if ([node isKindOfClass:[RNSVGSvgView class]]) {
             RNSVGSvgView* svgView = (RNSVGSvgView*)node;
-            UIView *hitChild = [svgView hitTest:transformed withEvent:event];
+            RNSVGPlatformView *hitChild = [svgView hitTest:transformed withEvent:event];
             if (hitChild) {
                 return hitChild;
             }
         }
     }
 
-    UIView *hitSelf = [super hitTest:transformed withEvent:event];
+    RNSVGPlatformView *hitSelf = [super hitTest:transformed withEvent:event];
     if (hitSelf) {
         return hitSelf;
     }

--- a/ios/Exponent/Versioned/Core/Api/Components/Svg/Elements/RNSVGLinearGradient.m
+++ b/ios/Exponent/Versioned/Core/Api/Components/Svg/Elements/RNSVGLinearGradient.m
@@ -85,7 +85,7 @@
     [self invalidate];
 }
 
-- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
+- (RNSVGPlatformView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
 {
     return nil;
 }

--- a/ios/Exponent/Versioned/Core/Api/Components/Svg/Elements/RNSVGMarker.m
+++ b/ios/Exponent/Versioned/Core/Api/Components/Svg/Elements/RNSVGMarker.m
@@ -13,7 +13,7 @@
 
 @implementation RNSVGMarker
 
-- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
+- (RNSVGPlatformView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
 {
     return nil;
 }

--- a/ios/Exponent/Versioned/Core/Api/Components/Svg/Elements/RNSVGMask.m
+++ b/ios/Exponent/Versioned/Core/Api/Components/Svg/Elements/RNSVGMask.m
@@ -12,7 +12,7 @@
 
 @implementation RNSVGMask
 
-- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
+- (RNSVGPlatformView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
 {
     return nil;
 }

--- a/ios/Exponent/Versioned/Core/Api/Components/Svg/Elements/RNSVGPattern.m
+++ b/ios/Exponent/Versioned/Core/Api/Components/Svg/Elements/RNSVGPattern.m
@@ -20,7 +20,7 @@
     return self;
 }
 
-- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
+- (RNSVGPlatformView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
 {
     return nil;
 }

--- a/ios/Exponent/Versioned/Core/Api/Components/Svg/Elements/RNSVGRadialGradient.m
+++ b/ios/Exponent/Versioned/Core/Api/Components/Svg/Elements/RNSVGRadialGradient.m
@@ -103,7 +103,7 @@
     [self invalidate];
 }
 
-- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
+- (RNSVGPlatformView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
 {
     return nil;
 }

--- a/ios/Exponent/Versioned/Core/Api/Components/Svg/Elements/RNSVGSvgView.h
+++ b/ios/Exponent/Versioned/Core/Api/Components/Svg/Elements/RNSVGSvgView.h
@@ -6,14 +6,15 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <UIKit/UIKit.h>
+#import "RNSVGUIKit.h"
+
 #import "RNSVGPainter.h"
 #import "RNSVGContainer.h"
 #import "RNSVGVBMOS.h"
 
 @class RNSVGNode;
 
-@interface RNSVGSvgView : UIView <RNSVGContainer>
+@interface RNSVGSvgView : RNSVGView <RNSVGContainer>
 
 @property (nonatomic, strong) RNSVGLength *bbWidth;
 @property (nonatomic, strong) RNSVGLength *bbHeight;
@@ -29,8 +30,6 @@
 @property (nonatomic, assign) CGAffineTransform initialCTM;
 @property (nonatomic, assign) CGAffineTransform invInitialCTM;
 @property (nonatomic, assign) CGAffineTransform viewBoxTransform;
-
-
 
 /**
  * define <ClipPath></ClipPath> content as clipPath template.

--- a/ios/Exponent/Versioned/Core/Api/Components/Svg/Elements/RNSVGSvgView.m
+++ b/ios/Exponent/Versioned/Core/Api/Components/Svg/Elements/RNSVGSvgView.m
@@ -25,22 +25,24 @@
 - (instancetype)initWithFrame:(CGRect)frame
 {
     if (self = [super initWithFrame:frame]) {
+#if !TARGET_OS_OSX // Not available on macOS
         // This is necessary to ensure that [self setNeedsDisplay] actually triggers
         // a redraw when our parent transitions between hidden and visible.
         self.contentMode = UIViewContentModeRedraw;
+#endif
         rendered = false;
     }
     return self;
 }
 
-- (void)insertReactSubview:(UIView *)subview atIndex:(NSInteger)atIndex
+- (void)insertReactSubview:(RNSVGView *)subview atIndex:(NSInteger)atIndex
 {
     [super insertReactSubview:subview atIndex:atIndex];
     [self insertSubview:subview atIndex:atIndex];
     [self invalidate];
 }
 
-- (void)removeReactSubview:(UIView *)subview
+- (void)removeReactSubview:(RNSVGView *)subview
 {
     [super removeReactSubview:subview];
     [self invalidate];
@@ -66,7 +68,7 @@
 
 - (void)invalidate
 {
-    UIView* parent = self.superview;
+    RNSVGPlatformView* parent = self.superview;
     if ([parent isKindOfClass:[RNSVGNode class]]) {
         if (!rendered) {
             return;
@@ -190,7 +192,7 @@
         _invviewBoxTransform = CGAffineTransformIdentity;
     }
 
-    for (UIView *node in self.subviews) {
+    for (RNSVGView *node in self.subviews) {
         if ([node isKindOfClass:[RNSVGNode class]]) {
             RNSVGNode *svg = (RNSVGNode *)node;
             [svg renderTo:context
@@ -203,7 +205,7 @@
 
 - (void)drawRect:(CGRect)rect
 {
-    UIView* parent = self.superview;
+    RNSVGPlatformView* parent = self.superview;
     if ([parent isKindOfClass:[RNSVGNode class]]) {
         return;
     }
@@ -214,7 +216,7 @@
     _boundingBox = rect;
     CGContextRef context = UIGraphicsGetCurrentContext();
 
-    for (UIView *node in self.subviews) {
+    for (RNSVGPlatformView *node in self.subviews) {
         if ([node isKindOfClass:[RNSVGNode class]]) {
             RNSVGNode *svg = (RNSVGNode *)node;
             if (svg.responsible && !self.responsible) {
@@ -228,7 +230,7 @@
     [self drawToContext:context withRect:rect];
 }
 
-- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
+- (RNSVGPlatformView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
 {
     CGPoint transformed = point;
     if (self.align) {
@@ -243,7 +245,7 @@
             node.active = NO;
         }
 
-        UIView *hitChild = [node hitTest:transformed withEvent:event];
+        RNSVGPlatformView *hitChild = [node hitTest:transformed withEvent:event];
 
         if (hitChild) {
             node.active = YES;
@@ -279,7 +281,7 @@
     return base64;
 }
 
-- (void)reactSetInheritedBackgroundColor:(UIColor *)inheritedBackgroundColor
+- (void)reactSetInheritedBackgroundColor:(RNSVGColor *)inheritedBackgroundColor
 {
     self.backgroundColor = inheritedBackgroundColor;
 }

--- a/ios/Exponent/Versioned/Core/Api/Components/Svg/Elements/RNSVGUse.m
+++ b/ios/Exponent/Versioned/Core/Api/Components/Svg/Elements/RNSVGUse.m
@@ -113,7 +113,7 @@
     self.frame = bounds;
 }
 
-- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event {
+- (RNSVGPlatformView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event {
     CGPoint transformed = CGPointApplyAffineTransform(point, self.invmatrix);
     transformed =  CGPointApplyAffineTransform(transformed, self.invTransform);
     RNSVGNode const* template = [self.svgView getDefinedTemplate:self.href];
@@ -122,7 +122,7 @@
     } else if (self.active) {
         return self;
     }
-    UIView const* hitChild = [template hitTest:transformed withEvent:event];
+    RNSVGPlatformView const* hitChild = [template hitTest:transformed withEvent:event];
     if (hitChild) {
         self.active = YES;
         return self;

--- a/ios/Exponent/Versioned/Core/Api/Components/Svg/RNSVGNode.h
+++ b/ios/Exponent/Versioned/Core/Api/Components/Svg/RNSVGNode.h
@@ -13,11 +13,11 @@
 @class RNSVGGroup;
 
 /**
- * RNSVG nodes are implemented as base UIViews. They should be implementation for all basic
+ * RNSVG nodes are implemented as base NSViews/UIViews. They should be implementation for all basic
  ＊interfaces for all non-definition nodes.
  */
 
-@interface RNSVGNode : UIView
+@interface RNSVGNode : RNSVGView
 
 /*
  N[1/Sqrt[2], 36]
@@ -132,7 +132,7 @@ extern CGFloat const RNSVG_DEFAULT_FONT_SIZE;
 
 - (void)endTransparencyLayer:(CGContextRef)context;
 
-- (void)traverseSubviews:(BOOL (^)(__kindof UIView *node))block;
+- (void)traverseSubviews:(BOOL (^)(__kindof RNSVGView *node))block;
 
 - (void)clearChildCache;
 

--- a/ios/Exponent/Versioned/Core/Api/Components/Svg/RNSVGRenderable.h
+++ b/ios/Exponent/Versioned/Core/Api/Components/Svg/RNSVGRenderable.h
@@ -8,6 +8,8 @@
 
 #import <Foundation/Foundation.h>
 
+#import "RNSVGUIKit.h"
+
 #import "RNSVGBrush.h"
 #import "RNSVGCGFCRule.h"
 #import "RNSVGNode.h"

--- a/ios/Exponent/Versioned/Core/Api/Components/Svg/RNSVGRenderable.m
+++ b/ios/Exponent/Versioned/Core/Api/Components/Svg/RNSVGRenderable.m
@@ -513,7 +513,7 @@ UInt32 saturate(CGFloat value) {
 }
 
 // hitTest delegate
-- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
+- (RNSVGPlatformView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
 {
     if (!_hitArea) {
         return nil;

--- a/ios/Exponent/Versioned/Core/Api/Components/Svg/RNSVGUIKit.h
+++ b/ios/Exponent/Versioned/Core/Api/Components/Svg/RNSVGUIKit.h
@@ -1,0 +1,42 @@
+// Most (if not all) of this file could probably go away once react-native-macos's version of RCTUIKit.h makes its way upstream.
+// https://github.com/microsoft/react-native-macos/issues/242
+
+#if !TARGET_OS_OSX
+
+#import <UIKit/UIKit.h>
+
+#define RNSVGColor UIColor
+#define RNSVGPlatformView UIView
+#define RNSVGTextView UILabel
+#define RNSVGView UIView
+
+#else // TARGET_OS_OSX [
+
+#import <React/RCTUIKit.h>
+
+#define RNSVGColor NSColor
+#define RNSVGPlatformView NSView
+#define RNSVGTextView NSTextView
+
+@interface RNSVGView : RCTUIView
+
+@property CGPoint center;
+@property (nonatomic, strong) RNSVGColor *tintColor;
+
+@end
+
+// TODO: These could probably be a part of react-native-macos
+// See https://github.com/microsoft/react-native-macos/issues/658 and https://github.com/microsoft/react-native-macos/issues/659
+@interface NSImage (RNSVGMacOSExtensions)
+@property (readonly) CGImageRef CGImage;
+@end
+
+@interface NSValue (RNSVGMacOSExtensions)
++ (NSValue *)valueWithCGAffineTransform:(CGAffineTransform)transform;
++ (NSValue *)valueWithCGPoint:(CGPoint)point;
+
+@property (readonly) CGAffineTransform CGAffineTransformValue;
+@property (readonly) CGPoint CGPointValue;
+@end
+
+#endif // ] TARGET_OS_OSX

--- a/ios/Exponent/Versioned/Core/Api/Components/Svg/Text/RNSVGFontData.h
+++ b/ios/Exponent/Versioned/Core/Api/Components/Svg/Text/RNSVGFontData.h
@@ -1,5 +1,6 @@
 #import <Foundation/Foundation.h>
-#import <UIKit/UIKit.h>
+
+#import "RNSVGUIKit.h"
 
 #import "RNSVGTextProperties.h"
 #import "RNSVGPropHelper.h"

--- a/ios/Exponent/Versioned/Core/Api/Components/Svg/Text/RNSVGTSpan.h
+++ b/ios/Exponent/Versioned/Core/Api/Components/Svg/Text/RNSVGTSpan.h
@@ -5,9 +5,12 @@
  * This source code is licensed under the MIT-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-#import <UIKit/UIKit.h>
+
 #import <Foundation/Foundation.h>
 #import <CoreText/CoreText.h>
+
+#import "RNSVGUIKit.h"
+
 #import "RNSVGText.h"
 
 @interface RNSVGTSpan : RNSVGText

--- a/ios/Exponent/Versioned/Core/Api/Components/Svg/Text/RNSVGText.m
+++ b/ios/Exponent/Versioned/Core/Api/Components/Svg/Text/RNSVGText.m
@@ -196,7 +196,7 @@
         return _alignmentBaseline;
     }
 
-    UIView* parent = self.superview;
+    RNSVGPlatformView* parent = self.superview;
     while (parent != nil) {
         if ([parent isKindOfClass:[RNSVGText class]]) {
             RNSVGText* node = (RNSVGText*)parent;
@@ -221,7 +221,7 @@
         return _baselineShift;
     }
 
-    UIView* parent = [self superview];
+    RNSVGPlatformView* parent = [self superview];
     while (parent != nil) {
         if ([parent isKindOfClass:[RNSVGText class]]) {
             RNSVGText* node = (RNSVGText*)parent;
@@ -271,7 +271,7 @@
     RNSVGGlyphContext* gc = [self.textRoot getGlyphContext];
     NSArray* font = [gc getFontContext];
     RNSVGText* node = self;
-    UIView* parent = [self superview];
+    RNSVGPlatformView* parent = [self superview];
     for (NSInteger i = [font count] - 1; i >= 0; i--) {
         RNSVGFontData* fontData = [font objectAtIndex:i];
         if (![parent isKindOfClass:[RNSVGText class]] ||
@@ -291,7 +291,7 @@
         return cachedAdvance;
     }
     CGFloat advance = 0;
-    for (UIView *node in self.subviews) {
+    for (RNSVGView *node in self.subviews) {
         if ([node isKindOfClass:[RNSVGText class]]) {
             RNSVGText *text = (RNSVGText*)node;
             advance += [text getSubtreeTextChunksTotalAdvance];

--- a/ios/Exponent/Versioned/Core/Api/Components/Svg/Text/RNSVGTopAlignedLabel.h
+++ b/ios/Exponent/Versioned/Core/Api/Components/Svg/Text/RNSVGTopAlignedLabel.h
@@ -1,0 +1,14 @@
+#import "RNSVGUIKit.h"
+#if TARGET_OS_OSX
+#import <React/RCTTextView.h>
+@interface RNSVGTopAlignedLabel : NSTextView
+
+@property NSAttributedString *attributedText;
+@property NSLineBreakMode lineBreakMode;
+@property NSInteger numberOfLines;
+@property NSString *text;
+@property NSTextAlignment textAlignment;
+#else
+@interface RNSVGTopAlignedLabel : UILabel
+#endif
+@end

--- a/ios/Exponent/Versioned/Core/Api/Components/Svg/Text/RNSVGTopAlignedLabel.ios.m
+++ b/ios/Exponent/Versioned/Core/Api/Components/Svg/Text/RNSVGTopAlignedLabel.ios.m
@@ -1,0 +1,17 @@
+#import "RNSVGTopAlignedLabel.h"
+
+@implementation RNSVGTopAlignedLabel
+
+- (void)drawTextInRect:(CGRect) rect
+{
+    NSAttributedString *attributedText = [[NSAttributedString alloc]     initWithString:self.text attributes:@{NSFontAttributeName:self.font}];
+    rect.size.height = [attributedText boundingRectWithSize:rect.size
+                                                    options:NSStringDrawingUsesLineFragmentOrigin
+                                                    context:nil].size.height;
+    if (self.numberOfLines != 0) {
+        rect.size.height = MIN(rect.size.height, self.numberOfLines * self.font.lineHeight);
+    }
+    [super drawTextInRect:rect];
+}
+
+@end

--- a/ios/Exponent/Versioned/Core/Api/Components/Svg/Utils/RNSVGBezierElement.h
+++ b/ios/Exponent/Versioned/Core/Api/Components/Svg/Utils/RNSVGBezierElement.h
@@ -4,8 +4,9 @@
  https://github.com/erica/iOS-Drawing/tree/master/C08/Quartz%20Book%20Pack/Bezier
  */
 
-#import <UIKit/UIKit.h>
 #import <Foundation/Foundation.h>
+
+#import "RNSVGUIKit.h"
 
 #define RNSVGNULLPOINT CGRectNull.origin
 

--- a/ios/Exponent/Versioned/Core/Api/Components/Svg/Utils/RNSVGLength.h
+++ b/ios/Exponent/Versioned/Core/Api/Components/Svg/Utils/RNSVGLength.h
@@ -1,4 +1,4 @@
-#import <UIKit/UIKit.h>
+#import "RNSVGUIKit.h"
 
 #ifndef RNSVGLength_h
 #define RNSVGLength_h

--- a/ios/Exponent/Versioned/Core/Api/Components/Svg/Utils/RNSVGMarkerPosition.h
+++ b/ios/Exponent/Versioned/Core/Api/Components/Svg/Utils/RNSVGMarkerPosition.h
@@ -1,6 +1,6 @@
-
-#import <UIKit/UIKit.h>
 #import <Foundation/Foundation.h>
+
+#import "RNSVGUIKit.h"
 
 typedef enum RNSVGMarkerType {
     kStartMarker,

--- a/ios/Exponent/Versioned/Core/Api/Components/Svg/Utils/RNSVGPathMeasure.h
+++ b/ios/Exponent/Versioned/Core/Api/Components/Svg/Utils/RNSVGPathMeasure.h
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <UIKit/UIKit.h>
+#import "RNSVGUIKit.h"
 
 @interface RNSVGPathMeasure : NSObject
 

--- a/ios/Exponent/Versioned/Core/Api/Components/Svg/Utils/RNSVGPathParser.h
+++ b/ios/Exponent/Versioned/Core/Api/Components/Svg/Utils/RNSVGPathParser.h
@@ -6,8 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-
-#import <UIKit/UIKit.h>
+#import "RNSVGUIKit.h"
 
 @interface RNSVGPathParser : NSObject
 

--- a/ios/Exponent/Versioned/Core/Api/Components/Svg/Utils/RNSVGViewBox.h
+++ b/ios/Exponent/Versioned/Core/Api/Components/Svg/Utils/RNSVGViewBox.h
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <UIKit/UIKit.h>
+#import "RNSVGUIKit.h"
+
 #import "RNSVGVBMOS.h"
 
 @interface RNSVGViewBox : NSObject

--- a/ios/Exponent/Versioned/Core/Api/Components/Svg/ViewManagers/RNSVGDefsManager.m
+++ b/ios/Exponent/Versioned/Core/Api/Components/Svg/ViewManagers/RNSVGDefsManager.m
@@ -18,7 +18,7 @@ RCT_EXPORT_MODULE()
   return [RNSVGDefs new];
 }
 
-- (UIView *)view
+- (RNSVGView *)view
 {
     return [self node];
 }

--- a/ios/Exponent/Versioned/Core/Api/Components/Svg/ViewManagers/RNSVGNodeManager.m
+++ b/ios/Exponent/Versioned/Core/Api/Components/Svg/ViewManagers/RNSVGNodeManager.m
@@ -146,7 +146,7 @@ RCT_EXPORT_MODULE()
     return [RNSVGNode new];
 }
 
-- (UIView *)view
+- (RNSVGView *)view
 {
     return [self node];
 }

--- a/ios/Exponent/Versioned/Core/Api/Components/Svg/ViewManagers/RNSVGRenderableManager.m
+++ b/ios/Exponent/Versioned/Core/Api/Components/Svg/ViewManagers/RNSVGRenderableManager.m
@@ -40,7 +40,7 @@ RCT_EXPORT_VIEW_PROPERTY(propList, NSArray<NSString *>)
 
 RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(isPointInFill:(nonnull NSNumber *)reactTag options:(NSDictionary *)options)
 {
-    __block UIView *view;
+    __block RNSVGPlatformView *view;
     dispatch_sync(dispatch_get_main_queue(), ^{
         view = [self.bridge.uiManager viewForReactTag:reactTag];
     });
@@ -63,14 +63,14 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(isPointInFill:(nonnull NSNumber *)reactTa
     CGFloat x = (CGFloat)[xo doubleValue];
     CGFloat y = (CGFloat)[yo doubleValue];
     CGPoint point = CGPointMake(x, y);
-    UIView *target = [svg hitTest:point withEvent:nil];
+    RNSVGPlatformView *target = [svg hitTest:point withEvent:nil];
     BOOL hit = target != nil;
     return [NSNumber numberWithBool:hit];
 }
 
 RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(isPointInStroke:(nonnull NSNumber *)reactTag options:(NSDictionary *)options)
 {
-    __block UIView *view;
+    __block RNSVGPlatformView *view;
     dispatch_sync(dispatch_get_main_queue(), ^{
         view = [self.bridge.uiManager viewForReactTag:reactTag];
     });
@@ -100,7 +100,7 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(isPointInStroke:(nonnull NSNumber *)react
 
 RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(getTotalLength:(nonnull NSNumber *)reactTag)
 {
-    __block UIView *view;
+    __block RNSVGPlatformView *view;
     dispatch_sync(dispatch_get_main_queue(), ^{
         view = [self.bridge.uiManager viewForReactTag:reactTag];
     });
@@ -119,7 +119,7 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(getTotalLength:(nonnull NSNumber *)reactT
 
 RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(getPointAtLength:(nonnull NSNumber *)reactTag options:(NSDictionary *)options)
 {
-    __block UIView *view;
+    __block RNSVGPlatformView *view;
     dispatch_sync(dispatch_get_main_queue(), ^{
         view = [self.bridge.uiManager viewForReactTag:reactTag];
     });
@@ -149,7 +149,7 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(getPointAtLength:(nonnull NSNumber *)reac
 
 RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(getBBox:(nonnull NSNumber *)reactTag options:(NSDictionary *)options)
 {
-    __block UIView *view;
+    __block RNSVGPlatformView *view;
     dispatch_sync(dispatch_get_main_queue(), ^{
         view = [self.bridge.uiManager viewForReactTag:reactTag];
     });
@@ -195,7 +195,7 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(getBBox:(nonnull NSNumber *)reactTag opti
 
 RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(getCTM:(nonnull NSNumber *)reactTag)
 {
-    __block UIView *view;
+    __block RNSVGPlatformView *view;
     dispatch_sync(dispatch_get_main_queue(), ^{
         view = [self.bridge.uiManager viewForReactTag:reactTag];
     });
@@ -218,7 +218,7 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(getCTM:(nonnull NSNumber *)reactTag)
 
 RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(getScreenCTM:(nonnull NSNumber *)reactTag)
 {
-    __block UIView *view;
+    __block RNSVGPlatformView *view;
     dispatch_sync(dispatch_get_main_queue(), ^{
         view = [self.bridge.uiManager viewForReactTag:reactTag];
     });

--- a/ios/Exponent/Versioned/Core/Api/Components/Svg/ViewManagers/RNSVGSvgViewManager.m
+++ b/ios/Exponent/Versioned/Core/Api/Components/Svg/ViewManagers/RNSVGSvgViewManager.m
@@ -16,7 +16,7 @@
 
 RCT_EXPORT_MODULE()
 
-- (UIView *)view
+- (RNSVGView *)view
 {
     return [RNSVGSvgView new];
 }
@@ -40,8 +40,8 @@ RCT_CUSTOM_VIEW_PROPERTY(color, id, RNSVGSvgView)
 
 
 - (void)toDataURL:(nonnull NSNumber *)reactTag options:(NSDictionary *)options callback:(RCTResponseSenderBlock)callback attempt:(int)attempt {
-    [self.bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *,UIView *> *viewRegistry) {
-        __kindof UIView *view = viewRegistry[reactTag];
+    [self.bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *,RNSVGView *> *viewRegistry) {
+        __kindof RNSVGView *view = viewRegistry[reactTag];
         NSString * b64;
         if ([view isKindOfClass:[RNSVGSvgView class]]) {
             RNSVGSvgView *svg = view;

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -97,7 +97,7 @@
   "react-native-safe-area-context": "3.2.0",
   "react-native-screens": "~3.0.0",
   "react-native-shared-element": "0.7.0",
-  "react-native-svg": "12.1.0",
+  "react-native-svg": "12.1.1",
   "react-native-unimodules": "~0.14.0",
   "react-native-view-shot": "3.1.2",
   "react-native-webview": "11.2.3",

--- a/tools/src/vendoring/legacy.ts
+++ b/tools/src/vendoring/legacy.ts
@@ -270,7 +270,7 @@ const vendoredModulesConfig: { [key: string]: VendoredModuleConfig } = {
     steps: [
       {
         recursive: true,
-        sourceIosPath: 'ios',
+        sourceIosPath: 'apple',
         targetIosPath: 'Api/Components/Svg',
         sourceAndroidPath: 'android/src/main/java/com/horcrux/svg',
         targetAndroidPath: 'modules/api/components/svg',

--- a/tools/src/vendoring/legacy.ts
+++ b/tools/src/vendoring/legacy.ts
@@ -40,6 +40,29 @@ interface VendoredModuleConfig {
 const IOS_DIR = Directories.getIosDir();
 const ANDROID_DIR = Directories.getAndroidDir();
 
+const SvgModifier: ModuleModifier = async function (
+  moduleConfig: VendoredModuleConfig,
+  clonedProjectPath: string
+): Promise<void> {
+  const removeMacFiles = async () => {
+    const macPattern = path.join(clonedProjectPath, 'apple', '**', '*.macos.@(h|m)');
+    const macFiles = await glob(macPattern);
+    for (const file of macFiles) {
+      await fs.remove(file);
+    }
+  };
+
+  const addHeaderImport = async () => {
+    const targetPath = path.join(clonedProjectPath, 'apple', 'Text', 'RNSVGTopAlignedLabel.h');
+    const content = await fs.readFile(targetPath, 'utf8');
+    const transformedContent = `#import "RNSVGUIKit.h"\n${content}`;
+    await fs.writeFile(targetPath, transformedContent, 'utf8');
+  };
+
+  await removeMacFiles();
+  await addHeaderImport();
+};
+
 const ReanimatedModifier: ModuleModifier = async function (
   moduleConfig: VendoredModuleConfig,
   clonedProjectPath: string
@@ -267,6 +290,7 @@ const vendoredModulesConfig: { [key: string]: VendoredModuleConfig } = {
   'react-native-svg': {
     repoUrl: 'https://github.com/react-native-community/react-native-svg.git',
     installableInManagedApps: true,
+    moduleModifier: SvgModifier,
     steps: [
       {
         recursive: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -17497,10 +17497,10 @@ react-native-shared-element@0.7.0:
   resolved "https://registry.yarnpkg.com/react-native-shared-element/-/react-native-shared-element-0.7.0.tgz#c5e02eb372f6e38e48eb1030fd59be8f3d8c7a1f"
   integrity sha512-TJTGwQceABYete+vH3ahNSgzVzXz7X2SPv3thT91gdcFCrm7ht7IKXBXJiYjOA+4TfdqnGEAWkspCy80oEnOgw==
 
-react-native-svg@12.1.0, react-native-svg@~12.1.0:
-  version "12.1.0"
-  resolved "https://registry.yarnpkg.com/react-native-svg/-/react-native-svg-12.1.0.tgz#acfe48c35cd5fca3d5fd767abae0560c36cfc03d"
-  integrity sha512-1g9qBRci7man8QsHoXn6tP3DhCDiypGgc6+AOWq+Sy+PmP6yiyf8VmvKuoqrPam/tf5x+ZaBT2KI0gl7bptZ7w==
+react-native-svg@12.1.1:
+  version "12.1.1"
+  resolved "https://registry.yarnpkg.com/react-native-svg/-/react-native-svg-12.1.1.tgz#5f292410b8bcc07bbc52b2da7ceb22caf5bcaaee"
+  integrity sha512-NIAJ8jCnXGCqGWXkkJ1GTzO4a3Md5at5sagYV8Vh4MXYnL4z5Rh428Wahjhh+LIjx40EE5xM5YtwyJBqOIba2Q==
   dependencies:
     css-select "^2.1.0"
     css-tree "^1.0.0-alpha.39"


### PR DESCRIPTION
# Why

SDK 42

# How

- The latest version of react-native-svg moves the ios source code to the apple directory within their repo, which is easy enough to adjust, but the reason for the change was to add macOS support. This required writing a `SvgModifier` in our vendoring script to delete macOS specific source files and add a missing header import.
- The [commit bumping the version to 12.1.1](https://github.com/react-native-svg/react-native-svg/commit/5ce2293f934f00ec9616c057854ea2135e22d31f) was not actually pushed to the react-native-svg repo, so I had to import from the parent commit and then manually increment the version number in our repo from 12.1.0 to 12.1.1.  

# Test Plan

Built iOS and Android Expo Go, ran NCL on unversioned.

# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).