### PR TITLE
Move permission from template into expo-av

### DIFF
--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 🎉 New features
 
+- [plugin] Added Android `android.permission.MODIFY_AUDIO_SETTINGS` permission. ([#13163](https://github.com/expo/expo/pull/13163) by [@EvanBacon](https://github.com/EvanBacon))
 - Remove lodash and nullthrows. ([#12522](https://github.com/expo/expo/pull/12522) by [@EvanBacon](https://github.com/EvanBacon))
 - Add new `Recording.createAsync` API for faster recording on iOS. ([#12294](https://github.com/expo/expo/pull/12294) by [@IjzerenHein](https://github.com/IjzerenHein))
 - Add `keepAudioActiveHint` recording option to prevent deactivation of the Audio session when recording on iOS. ([#12294](https://github.com/expo/expo/pull/12294) by [@IjzerenHein](https://github.com/IjzerenHein))

--- a/packages/expo-av/plugin/build/withAV.js
+++ b/packages/expo-av/plugin/build/withAV.js
@@ -4,12 +4,14 @@ const config_plugins_1 = require("@expo/config-plugins");
 const pkg = require('expo-av/package.json');
 const MICROPHONE_USAGE = 'Allow $(PRODUCT_NAME) to access your microphone';
 const withAV = (config, { microphonePermission } = {}) => {
-    if (!config.ios)
-        config.ios = {};
-    if (!config.ios.infoPlist)
-        config.ios.infoPlist = {};
-    config.ios.infoPlist.NSMicrophoneUsageDescription =
-        microphonePermission || config.ios.infoPlist.NSMicrophoneUsageDescription || MICROPHONE_USAGE;
-    return config_plugins_1.AndroidConfig.Permissions.withPermissions(config, ['android.permission.RECORD_AUDIO']);
+    config = config_plugins_1.withInfoPlist(config, config => {
+        config.modResults.NSMicrophoneUsageDescription =
+            microphonePermission || config.modResults.NSMicrophoneUsageDescription || MICROPHONE_USAGE;
+        return config;
+    });
+    return config_plugins_1.AndroidConfig.Permissions.withPermissions(config, [
+        'android.permission.RECORD_AUDIO',
+        'android.permission.MODIFY_AUDIO_SETTINGS',
+    ]);
 };
 exports.default = config_plugins_1.createRunOncePlugin(withAV, pkg.name, pkg.version);

--- a/packages/expo-av/plugin/src/withAV.ts
+++ b/packages/expo-av/plugin/src/withAV.ts
@@ -1,4 +1,9 @@
-import { AndroidConfig, ConfigPlugin, createRunOncePlugin } from '@expo/config-plugins';
+import {
+  AndroidConfig,
+  ConfigPlugin,
+  createRunOncePlugin,
+  withInfoPlist,
+} from '@expo/config-plugins';
 
 const pkg = require('expo-av/package.json');
 
@@ -8,12 +13,16 @@ const withAV: ConfigPlugin<{ microphonePermission?: string } | void> = (
   config,
   { microphonePermission } = {}
 ) => {
-  if (!config.ios) config.ios = {};
-  if (!config.ios.infoPlist) config.ios.infoPlist = {};
-  config.ios.infoPlist.NSMicrophoneUsageDescription =
-    microphonePermission || config.ios.infoPlist.NSMicrophoneUsageDescription || MICROPHONE_USAGE;
+  config = withInfoPlist(config, config => {
+    config.modResults.NSMicrophoneUsageDescription =
+      microphonePermission || config.modResults.NSMicrophoneUsageDescription || MICROPHONE_USAGE;
+    return config;
+  });
 
-  return AndroidConfig.Permissions.withPermissions(config, ['android.permission.RECORD_AUDIO']);
+  return AndroidConfig.Permissions.withPermissions(config, [
+    'android.permission.RECORD_AUDIO',
+    'android.permission.MODIFY_AUDIO_SETTINGS',
+  ]);
 };
 
 export default createRunOncePlugin(withAV, pkg.name, pkg.version);

--- a/templates/expo-template-bare-minimum/android/app/src/main/AndroidManifest.xml
+++ b/templates/expo-template-bare-minimum/android/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
   <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
   <uses-permission android:name="android.permission.READ_PHONE_STATE"/>
   <uses-permission android:name="android.permission.VIBRATE"/>
+  <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
   <!-- These require runtime permissions on M -->
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>

--- a/templates/expo-template-bare-minimum/android/app/src/main/AndroidManifest.xml
+++ b/templates/expo-template-bare-minimum/android/app/src/main/AndroidManifest.xml
@@ -5,7 +5,6 @@
   <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
   <uses-permission android:name="android.permission.READ_PHONE_STATE"/>
   <uses-permission android:name="android.permission.VIBRATE"/>
-  <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
   <!-- These require runtime permissions on M -->
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>


### PR DESCRIPTION
# Why

split up sensitive permissions, expo-av appears to be the only modules using native modules that can modify the audio.