### PR TITLE
[home] Styling fixes, fix crashes on iOS due to TouchableNativeFeedback

### DIFF
--- a/home/components/PrimaryButton.tsx
+++ b/home/components/PrimaryButton.tsx
@@ -5,6 +5,7 @@ import {
   StyleSheet,
   Text,
   TouchableNativeFeedback,
+  TouchableOpacity,
   View,
 } from 'react-native';
 
@@ -22,7 +23,7 @@ export default function PrimaryButton({
   isLoading?: boolean;
   plain?: boolean;
 }) {
-  return (
+  return Platform.OS === 'android' ? (
     <TouchableNativeFeedback {...props} style={[plain ? styles.plainButton : styles.button, style]}>
       <Text style={plain ? styles.plainButtonText : styles.buttonText}>{children}</Text>
       {isLoading && (
@@ -31,6 +32,15 @@ export default function PrimaryButton({
         </View>
       )}
     </TouchableNativeFeedback>
+  ) : (
+    <TouchableOpacity {...props} style={[plain ? styles.plainButton : styles.button, style]}>
+      <Text style={plain ? styles.plainButtonText : styles.buttonText}>{children}</Text>
+      {isLoading && (
+        <View style={styles.activityIndicatorContainer}>
+          <ActivityIndicator color="#fff" />
+        </View>
+      )}
+    </TouchableOpacity>
   );
 }
 

--- a/home/components/Views.tsx
+++ b/home/components/Views.tsx
@@ -1,7 +1,14 @@
 import { useTheme } from '@react-navigation/native';
 import { BlurView } from 'expo-blur';
 import * as React from 'react';
-import { Platform, ScrollView, StyleSheet, TouchableNativeFeedback, View } from 'react-native';
+import {
+  Platform,
+  ScrollView,
+  StyleSheet,
+  TouchableNativeFeedback,
+  TouchableOpacity,
+  View,
+} from 'react-native';
 
 import Colors, { ColorTheme } from '../constants/Colors';
 
@@ -182,7 +189,7 @@ export const StyledButton = (props: ButtonProps) => {
   const borderColor = useThemeBorderColor(props, 'cardSeparator');
   const rippleColor = useRippleColor(props);
 
-  return (
+  return Platform.OS === 'android' ? (
     <TouchableNativeFeedback
       background={TouchableNativeFeedback.Ripple(rippleColor, false)}
       {...otherProps}>
@@ -197,6 +204,19 @@ export const StyledButton = (props: ButtonProps) => {
         {children}
       </View>
     </TouchableNativeFeedback>
+  ) : (
+    <TouchableOpacity background={rippleColor} {...otherProps}>
+      <View
+        style={[
+          {
+            backgroundColor,
+            borderColor,
+          },
+          style,
+        ]}>
+        {children}
+      </View>
+    </TouchableOpacity>
   );
 };
 

--- a/home/screens/UserSettingsScreen.tsx
+++ b/home/screens/UserSettingsScreen.tsx
@@ -126,6 +126,7 @@ function TrackingItem() {
       <SectionHeader title="Tracking" />
       <ListItem
         last
+        margins={false}
         title="Allow access to app-related data for tracking"
         onPress={async () => {
           const { status } = await Tracking.requestTrackingPermissionsAsync();

--- a/ios/Exponent/Supporting/Info.plist
+++ b/ios/Exponent/Supporting/Info.plist
@@ -110,7 +110,7 @@
 	<key>NSRemindersUsageDescription</key>
 	<string>Allow Expo projects to access your reminders</string>
 	<key>NSUserTrackingUsageDescription</key>
-	<string>Allow Expo projects to use data for tracking the user or the device</string>
+	<string>This identifier will be used to deliver personalized ads to you</string>
 	<key>SKAdNetworkItems</key>
 	<array>
 		<dict>


### PR DESCRIPTION
# Why

Fix some styling, use the proper Tracking description, and fix some breakages introduced in https://github.com/expo/expo/pull/12974

# How

Since `TouchableNativeFeedback` is only supported on Android, we fallback to `TouchableOpacity` (same fallback as before) on iOS now. Tested- no more crashes on iOS when navigating to the user settings screen 🎉 

# Test Plan

ran home locally
