### PR TITLE
Added config plugin for expo cellular

### DIFF
--- a/packages/expo-cellular/CHANGELOG.md
+++ b/packages/expo-cellular/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- [plugin] Created config plugin for applying permissions on Android ([#13175](https://github.com/expo/expo/pull/13175) by [@EvanBacon](https://github.com/EvanBacon))
+
 ### 🐛 Bug fixes
 
 - Fix null cellular information on iOS. ([#12710](https://github.com/expo/expo/pull/12710) by [@randomhajile](https://github.com/randomhajile))

--- a/packages/expo-cellular/README.md
+++ b/packages/expo-cellular/README.md
@@ -21,6 +21,15 @@ For bare React Native projects, you must ensure that you have [installed and con
 expo install expo-cellular
 ```
 
+### Configure for Android
+
+This package requires the `android.permission.READ_PHONE_STATE` be added to your `AndroidManifest.xml`, this is used for `TelephonyManager` on Android. We **do not** require the more risky `READ_PRIVILEGED_PHONE_STATE` permission.
+
+```xml
+<!-- Added permissions -->
+<uses-permission android:name="android.permission.READ_PHONE_STATE" />
+```
+
 # Contributing
 
 Contributions are very welcome! Please refer to guidelines described in the [contributing guide](https://github.com/expo/expo#contributing).

--- a/packages/expo-cellular/app.plugin.js
+++ b/packages/expo-cellular/app.plugin.js
@@ -1,0 +1,1 @@
+module.exports = require('./plugin/build/withCellular');

--- a/packages/expo-cellular/plugin/build/withCellular.d.ts
+++ b/packages/expo-cellular/plugin/build/withCellular.d.ts
@@ -1,0 +1,3 @@
+import { ConfigPlugin } from '@expo/config-plugins';
+declare const _default: ConfigPlugin<void>;
+export default _default;

--- a/packages/expo-cellular/plugin/build/withCellular.js
+++ b/packages/expo-cellular/plugin/build/withCellular.js
@@ -1,0 +1,12 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const config_plugins_1 = require("@expo/config-plugins");
+const pkg = require('expo-cellular/package.json');
+const withCellular = config => {
+    config = config_plugins_1.AndroidConfig.Permissions.withPermissions(config, [
+        // Required for TelephonyManager and `getNetworkType`
+        'android.permission.READ_PHONE_STATE',
+    ]);
+    return config;
+};
+exports.default = config_plugins_1.createRunOncePlugin(withCellular, pkg.name, pkg.version);

--- a/packages/expo-cellular/plugin/src/withCellular.ts
+++ b/packages/expo-cellular/plugin/src/withCellular.ts
@@ -1,0 +1,13 @@
+import { AndroidConfig, ConfigPlugin, createRunOncePlugin } from '@expo/config-plugins';
+
+const pkg = require('expo-cellular/package.json');
+
+const withCellular: ConfigPlugin = config => {
+  config = AndroidConfig.Permissions.withPermissions(config, [
+    // Required for TelephonyManager and `getNetworkType`
+    'android.permission.READ_PHONE_STATE',
+  ]);
+  return config;
+};
+
+export default createRunOncePlugin(withCellular, pkg.name, pkg.version);

--- a/packages/expo-cellular/plugin/tsconfig.json
+++ b/packages/expo-cellular/plugin/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "expo-module-scripts/tsconfig.plugin",
+  "compilerOptions": {
+    "outDir": "build",
+    "rootDir": "src"
+  },
+  "include": ["./src"],
+  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+}


### PR DESCRIPTION
# Why

The permission wasn't documented so we missed this in the initial pass. https://exponent-internal.slack.com/archives/C1QNF5L3C/p1622937598025200
In the future we can remove this from the template and inform ppl to add the permission manually if they want to access it with PermissionsAndroid from RN.