### PR TITLE
[no ci] Remove READ_PHONE_STATE permission from default template

### DIFF
--- a/templates/expo-template-bare-minimum/android/app/src/main/AndroidManifest.xml
+++ b/templates/expo-template-bare-minimum/android/app/src/main/AndroidManifest.xml
@@ -3,7 +3,6 @@
   <uses-permission android:name="android.permission.INTERNET"/>
   <!-- OPTIONAL PERMISSIONS, REMOVE WHATEVER YOU DO NOT NEED -->
   <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
-  <uses-permission android:name="android.permission.READ_PHONE_STATE"/>
   <uses-permission android:name="android.permission.VIBRATE"/>
   <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
   <!-- These require runtime permissions on M -->


### PR DESCRIPTION
- We split this out in https://github.com/expo/expo/pull/13175
- Merge after SDK 42 has landed.
- Resolve ENG-1196