### PR TITLE
@tc/eng 961

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -231,7 +231,7 @@ Sometimes it's useful to show multiple ways of doing something, for instance may
 import { Tab, Tabs } from '~/components/plugins/Tabs';
 
 <Tabs>
-    <Tab label="Add 1 One Way">
+<Tab label="Add 1 One Way">
 
     addOne = async x => {
     /* @info This text will be shown onHover */
@@ -240,8 +240,8 @@ import { Tab, Tabs } from '~/components/plugins/Tabs';
     };
 
 
-    </Tab>
-    <Tab label="Add 1 Another Way">
+</Tab>
+<Tab label="Add 1 Another Way">
 
 
     addOne = async x => {
@@ -250,9 +250,10 @@ import { Tab, Tabs } from '~/components/plugins/Tabs';
     /* @end */
     };
 
-    </Tab>
+</Tab>
 </Tabs>
 ```
+n.b. The components should not be indented or they will not be parsed correctly.
 
 ### Excluding pages from Docsearch
 

--- a/docs/components/plugins/Tabs.js
+++ b/docs/components/plugins/Tabs.js
@@ -19,10 +19,6 @@ const STYLES_TAB_BUTTON = css`
   }
 `;
 
-const STYLES_TAB_PANELS = css`
-  padding-top: 6;
-`;
-
 function TabButton({ selected, ...props }) {
   return (
     <ReachTab
@@ -52,7 +48,7 @@ export function Tabs({ children, tabs }) {
           </TabButton>
         ))}
       </TabList>
-      <TabPanels className={STYLES_TAB_PANELS}>{children}</TabPanels>
+      <TabPanels style={{ paddingTop: 6 }}>{children}</TabPanels>
     </ReachTabs>
   );
 }

--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -94,7 +94,7 @@ const sections = [
     reference: [
       'Introduction',
       'Getting Started',
-      'Installation',
+      'Installation in React Native and Bare workflow projects',
       'Building With EAS',
       'Extending the Development Menu',
     ],

--- a/docs/pages/clients/eas-build.md
+++ b/docs/pages/clients/eas-build.md
@@ -3,6 +3,7 @@ title: Building With EAS
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';
+import { Tab, Tabs } from '~/components/plugins/Tabs';
 
 ## Setting up EAS
 
@@ -11,6 +12,40 @@ You can set up your project to use EAS by running `eas build:configure`.  If you
 ## Modifying your EAS.json
 
 Now edit your eas.json to look like this.
+
+<Tabs tabs={["With config plugins", "If you are directly managing your native projects"]}>
+
+<Tab >
+
+```json
+{
+  "builds": {
+    "android": {
+      "release": {
+        "workflow": "managed",
+        "gradleCommand": ":app:bundleRelease"
+      },
+      "development": {
+        "workflow": "managed",
+        "distribution": "internal",
+        "gradleCommand": ":app:assembleDebug"
+      }
+    },
+    "ios": {
+      "release": {
+        "workflow": "managed"
+      },
+      "development": {
+        "workflow": "managed",
+        "distribution": "internal",
+        "schemeBuildConfiguration": "Debug"
+      }
+    }
+  }
+}
+```
+</Tab>
+<Tab>
 
 ```json
 {
@@ -39,6 +74,8 @@ Now edit your eas.json to look like this.
   }
 }
 ```
+</Tab>
+</Tabs>
 
 ## Generating your first build
 

--- a/docs/pages/clients/eas-build.md
+++ b/docs/pages/clients/eas-build.md
@@ -11,7 +11,7 @@ You can set up your project to use EAS by running `eas build:configure`.  If you
 
 ## Modifying your EAS.json
 
-Now edit your eas.json to look like this.
+Now edit your eas.json to look like this:
 
 <Tabs tabs={["With config plugins", "If you are directly managing your native projects"]}>
 
@@ -23,12 +23,11 @@ Now edit your eas.json to look like this.
     "android": {
       "release": {
         "workflow": "managed",
-        "gradleCommand": ":app:bundleRelease"
       },
       "development": {
         "workflow": "managed",
         "distribution": "internal",
-        "gradleCommand": ":app:assembleDebug"
+        "buildType": "development-client",
       }
     },
     "ios": {
@@ -38,7 +37,7 @@ Now edit your eas.json to look like this.
       "development": {
         "workflow": "managed",
         "distribution": "internal",
-        "schemeBuildConfiguration": "Debug"
+        "buildType": "development-client",
       }
     }
   }

--- a/docs/pages/clients/eas-build.md
+++ b/docs/pages/clients/eas-build.md
@@ -22,12 +22,12 @@ Now edit your eas.json to look like this:
   "builds": {
     "android": {
       "release": {
-        "workflow": "managed",
+        "workflow": "managed"
       },
       "development": {
         "workflow": "managed",
         "distribution": "internal",
-        "buildType": "development-client",
+        "buildType": "development-client"
       }
     },
     "ios": {
@@ -37,7 +37,7 @@ Now edit your eas.json to look like this:
       "development": {
         "workflow": "managed",
         "distribution": "internal",
-        "buildType": "development-client",
+        "buildType": "development-client"
       }
     }
   }

--- a/docs/pages/clients/getting-started.md
+++ b/docs/pages/clients/getting-started.md
@@ -4,19 +4,32 @@ title: Getting Started
 
 import ImageSpotlight from '~/components/plugins/ImageSpotlight'
 import InstallSection from '~/components/plugins/InstallSection'
+import { Tab, Tabs } from '~/components/plugins/Tabs';
 
 ## Install the Development Client module in your project
 
+<Tabs tabs={["With config plugins", "If you are directly managing your native projects"]}>
+
+<Tab >
+<InstallSection packageName="expo-dev-client" cmd={["expo init # if you don't already have a Managed Workflow project", "yarn add expo-dev-client"]} hideBareInstructions />
+
+</Tab>
+
+<Tab >
+
 If you're just starting your project, you can create a new project from our template with:
+
 <InstallSection packageName="expo-dev-client" cmd={["npx crna -t with-dev-client"]} hideBareInstructions />
 
 If you have an existing project, you'll need to [install the package and make a few changes](installation.md) to your `AppDelegate.m`, `MainActivity.java` and `MainApplication.java`.
 
-## Deep linking scheme
-
 The Development Client uses deep links to open projects from the QR code. If you had added a custom deep link schema to your project, the Development Client will use it. However, if this isn't the case, you need to configure the deep link support for your application. The `uri-scheme` package will do this for you once you have chosen a scheme.
 
 <InstallSection packageName="expo-dev-client" cmd={["npx uri-scheme add <your scheme>"]} hideBareInstructions />
+
+</Tab>
+
+</Tabs>
 
 ## Building your Development Client
 
@@ -43,4 +56,4 @@ Otherwise, you can connect by scanning the QR code displayed by Expo CLI.
 
 ## Debugging your application
 
-When you need to, you can access the menu by pressing Cmd-d in Expo CLI. Here you'll be able to access all of the functions of your Development Client, access any debugging functionality you need, switch to a different version of your application, or [any capabilities you have added yourself](extending-the-dev-menu.md).
+When you need to, you can access the menu by pressing Cmd-d in Expo CLI or by shaking your phone or tablet. Here you'll be able to access all of the functions of your Development Client, access any debugging functionality you need, switch to a different version of your application, or [any capabilities you have added yourself](extending-the-dev-menu.md).

--- a/docs/pages/clients/installation.md
+++ b/docs/pages/clients/installation.md
@@ -1,19 +1,14 @@
 ---
-title: Installation
+title: Installation in React Native and Bare workflow projects
+sidebar_title: Manual Installation
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';
 import ConfigurationDiff from '~/components/plugins/ConfigurationDiff';
 
-**Expo Development Client** is an open source project to improve your development experience while working on your Expo and React Native projects. It allows your team to focus on the JavaScript portion of your project, only needing to interact with Xcode or Android Studio when you need to make changes to the native code used in your project.
+The installation steps on this page are only required to add a development client to an **existing** React Native or Bare project.
 
-> ⚠️ **Managed Expo projects are not yet supported**, but we are working on bringing the Development Client to the Managed Workflow! If you want to build a managed Expo project with the Development Client, you'll have to eject it first. See the [Ejecting to Bare Workflow](../workflow/customizing.md) page to learn how.
-
-## Create a new project with the Development Client
-
-The easiest way to get started is to initialize a new project by executing the following command:
-
-<InstallSection packageName="expo-development-client" cmd={["npx crna -t with-dev-client"]} hideBareInstructions />
+To initialize a new Bare project or to add a development client to an existing managed project, see our [Getting Started guide](/getting-started.md).
 
 ## Add the Development Client to the existing project
 
@@ -41,7 +36,7 @@ Then you can run the following command to install native code for the Dev Launch
 <InstallSection packageName="expo-development-client" cmd={["npx pod-install"]} hideBareInstructions />
 
 Also, make sure that your project is configured to deploy on iOS **above 10**.
-To do that you need open the Xcode, go to `Project settings` > `General` > `Deployment info` and select iOS version is at least 11.
+To do that, you need to open Xcode, go to `Project settings` > `General` > `Deployment info` and select iOS version is at least 11.
 
 <img src="/static/images/client/check_ios_version.png" style={{maxWidth: "100%" }}/>
 

--- a/docs/pages/clients/introduction.md
+++ b/docs/pages/clients/introduction.md
@@ -35,5 +35,3 @@ Depending on your project, you may find that you need to customize the standard 
 `expo-dev-client` is an npm package installable in any Expo or React Native project. Once installed, any Debug builds of your application will gain an extensible debug menu and the ability to load projects from Expo CLI. Release builds of your application will not change other than the addition of a few header files.
 
 Your debug builds can be shared with anyone on the team who needs to work on or review your application. Your team can develop the JavaScript portion of your application with `expo-cli` and your custom client without waiting for your native code to build until the next time you need to upgrade, install a new module, or otherwise change the native code in your project.
-
-> ⚠️ **Managed Expo projects are not yet supported**, but we are working on bringing the Development Client to the Managed Workflow! If you want to build a Managed Expo project with the Development Client, you'll have to eject it first. See the [Ejecting to Bare Workflow](../workflow/customizing.md) page to learn how.

--- a/docs/pages/clients/introduction.md
+++ b/docs/pages/clients/introduction.md
@@ -34,4 +34,4 @@ Depending on your project, you may find that you need to customize the standard 
 
 `expo-dev-client` is an npm package installable in any Expo or React Native project. Once installed, any Debug builds of your application will gain an extensible debug menu and the ability to load projects from Expo CLI. Release builds of your application will not change other than the addition of a few header files.
 
-Your debug builds can be shared with anyone on the team who needs to work on or review your application. Your team can develop the JavaScript portion of your application with `expo-cli` and your custom client without waiting for your native code to build until the next time you need to upgrade, install a new module, or otherwise change the native code in your project.
+Your debug builds can be shared with anyone on your team who needs to work on or review your application. Your team can develop the JavaScript portion of your application with `expo-cli` and your custom client without waiting for your native code to build until the next time you need to upgrade, install a new module, or otherwise change the native code in your project.


### PR DESCRIPTION
# Why

Closes ENG-961, updating our docs to account for support of the managed workflow
Also cleans up a couple issues with the Tabs plugins:
README guide would not work in an actual page.
The tabs component clearly intended to pad the top of the tab content container, but the styles were not being passed correctly.

# Test Plan

Reviewed all pages locally
