### PR TITLE
[no ci] Remove template meta-data for expo-updates

### DIFF
--- a/templates/expo-template-bare-minimum/android/app/src/main/AndroidManifest.xml
+++ b/templates/expo-template-bare-minimum/android/app/src/main/AndroidManifest.xml
@@ -18,8 +18,6 @@
     android:allowBackup="false"
     android:theme="@style/AppTheme"
   >
-    <meta-data android:name="expo.modules.updates.EXPO_UPDATE_URL" android:value="YOUR-APP-URL-HERE"/>
-    <meta-data android:name="expo.modules.updates.EXPO_SDK_VERSION" android:value="YOUR-APP-SDK-VERSION-HERE"/>
     <activity
       android:name=".MainActivity"
       android:label="@string/app_name"

--- a/templates/expo-template-bare-typescript/android/app/src/main/AndroidManifest.xml
+++ b/templates/expo-template-bare-typescript/android/app/src/main/AndroidManifest.xml
@@ -17,8 +17,6 @@
     android:allowBackup="false"
     android:theme="@style/AppTheme"
   >
-    <meta-data android:name="expo.modules.updates.EXPO_UPDATE_URL" android:value="YOUR-APP-URL-HERE"/>
-    <meta-data android:name="expo.modules.updates.EXPO_SDK_VERSION" android:value="YOUR-APP-SDK-VERSION-HERE"/>
     <activity
       android:name=".MainActivity"
       android:label="@string/app_name"


### PR DESCRIPTION
# Why

These aren't needed and make the template tied to `expo-updates`, ideally `expo-updates` would be contained inside of its config plugin.