### PR TITLE
[maps] Upgrade react-native-maps to 0.28.0

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/AirMapManager.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/AirMapManager.java
@@ -152,6 +152,7 @@ public class AirMapManager extends ViewGroupManager<AirMapView> {
       }
     }
 
+    view.applyBaseMapPadding(left, top, right, bottom);
     view.map.setPadding(left, top, right, bottom);
   }
 
@@ -235,6 +236,11 @@ public class AirMapManager extends ViewGroupManager<AirMapView> {
   @ReactProp(name = "rotateEnabled", defaultBoolean = false)
   public void setRotateEnabled(AirMapView view, boolean rotateEnabled) {
     view.map.getUiSettings().setRotateGesturesEnabled(rotateEnabled);
+  }
+
+  @ReactProp(name = "scrollDuringRotateOrZoomEnabled", defaultBoolean = true)
+  public void setScrollDuringRotateOrZoomEnabled(AirMapView view, boolean scrollDuringRotateOrZoomEnabled) {
+    view.map.getUiSettings().setScrollGesturesEnabledDuringRotateOrZoom(scrollDuringRotateOrZoomEnabled);
   }
 
   @ReactProp(name = "cacheEnabled", defaultBoolean = false)
@@ -354,7 +360,7 @@ public class AirMapManager extends ViewGroupManager<AirMapView> {
         break;
 
       case FIT_TO_ELEMENTS:
-        view.fitToElements(args.getBoolean(0));
+        view.fitToElements(args.getMap(0), args.getBoolean(1));
         break;
 
       case FIT_TO_SUPPLIED_MARKERS:

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/AirMapModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/AirMapModule.java
@@ -3,6 +3,8 @@ package versioned.host.exp.exponent.modules.api.components.maps;
 import android.app.Activity;
 import android.graphics.Bitmap;
 import android.graphics.Point;
+import android.location.Address;
+import android.location.Geocoder;
 import android.net.Uri;
 import android.util.Base64;
 import android.util.DisplayMetrics;
@@ -28,6 +30,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 
+import java.util.List;
 import java.util.Map;
 import java.util.HashMap;
 
@@ -176,6 +179,57 @@ public class AirMapModule extends ReactContextBaseJavaModule {
         cameraJson.putDouble("pitch", (double)position.tilt);
 
         promise.resolve(cameraJson);
+      }
+    });
+  }
+
+  @ReactMethod
+  public void getAddressFromCoordinates(final int tag, final ReadableMap coordinate, final Promise promise) {
+    final ReactApplicationContext context = getReactApplicationContext();
+
+    UIManagerModule uiManager = context.getNativeModule(UIManagerModule.class);
+    uiManager.addUIBlock(new UIBlock()
+    {
+      @Override
+      public void execute(NativeViewHierarchyManager nvhm)
+      {
+        AirMapView view = (AirMapView) nvhm.resolveView(tag);
+        if (view == null) {
+          promise.reject("AirMapView not found");
+          return;
+        }
+        if (view.map == null) {
+          promise.reject("AirMapView.map is not valid");
+          return;
+        }
+        if (coordinate == null ||
+                !coordinate.hasKey("latitude") ||
+                !coordinate.hasKey("longitude")) {
+          promise.reject("Invalid coordinate format");
+          return;
+        }
+        Geocoder geocoder = new Geocoder(context);
+        try {
+          List<Address> list =
+                  geocoder.getFromLocation(coordinate.getDouble("latitude"),coordinate.getDouble("longitude"),1);
+          Address address = list.get(0);
+
+          WritableMap addressJson = new WritableNativeMap();
+          addressJson.putString("name", address.getFeatureName());
+          addressJson.putString("locality", address.getLocality());
+          addressJson.putString("thoroughfare", address.getThoroughfare());
+          addressJson.putString("subThoroughfare", address.getSubThoroughfare());
+          addressJson.putString("subLocality", address.getSubLocality());
+          addressJson.putString("administrativeArea", address.getAdminArea());
+          addressJson.putString("subAdministrativeArea", address.getSubAdminArea());
+          addressJson.putString("postalCode", address.getPostalCode());
+          addressJson.putString("countryCode", address.getCountryCode());
+          addressJson.putString("country", address.getCountryName());
+
+          promise.resolve(addressJson);
+        } catch (IOException e) {
+          promise.reject("Can not get address location");
+        }
       }
     });
   }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/AirMapOverlay.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/AirMapOverlay.java
@@ -20,6 +20,7 @@ public class AirMapOverlay extends AirMapFeature implements ImageReadable {
   private GroundOverlayOptions groundOverlayOptions;
   private GroundOverlay groundOverlay;
   private LatLngBounds bounds;
+  private float bearing;
   private BitmapDescriptor iconBitmapDescriptor;
   private Bitmap iconBitmap;
   private boolean tappable;
@@ -35,11 +36,18 @@ public class AirMapOverlay extends AirMapFeature implements ImageReadable {
   }
 
   public void setBounds(ReadableArray bounds) {
-    LatLng sw = new LatLng(bounds.getArray(1).getDouble(0), bounds.getArray(0).getDouble(1));
-    LatLng ne = new LatLng(bounds.getArray(0).getDouble(0), bounds.getArray(1).getDouble(1));
+    LatLng sw = new LatLng(bounds.getArray(0).getDouble(0), bounds.getArray(0).getDouble(1));
+    LatLng ne = new LatLng(bounds.getArray(1).getDouble(0), bounds.getArray(1).getDouble(1));
     this.bounds = new LatLngBounds(sw, ne);
     if (this.groundOverlay != null) {
       this.groundOverlay.setPositionFromBounds(this.bounds);
+    }
+  }
+
+  public void setBearing(float bearing){
+    this.bearing = bearing;
+    if (this.groundOverlay != null) {
+      this.groundOverlay.setBearing(bearing);
     }
   }
 
@@ -92,6 +100,7 @@ public class AirMapOverlay extends AirMapFeature implements ImageReadable {
     }
     options.positionFromBounds(bounds);
     options.zIndex(zIndex);
+    options.bearing(bearing);
     return options;
   }
 

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/AirMapOverlayManager.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/AirMapOverlayManager.java
@@ -46,6 +46,11 @@ public class AirMapOverlayManager extends ViewGroupManager<AirMapOverlay> {
     view.setBounds(bounds);
   }
 
+  @ReactProp(name = "bearing")
+  public void setBearing(AirMapOverlay view, float bearing){
+    view.setBearing(bearing);
+  }
+
   @ReactProp(name = "zIndex", defaultFloat = 1.0f)
   public void setZIndex(AirMapOverlay view, float zIndex) {
     view.setZIndex(zIndex);

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/AirMapPolyline.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/AirMapPolyline.java
@@ -100,6 +100,7 @@ public class AirMapPolyline extends AirMapFeature {
 
   private void applyPattern() {
     if(patternValues == null) {
+      polyline.setPattern(null);
       return;
     }
     this.pattern = new ArrayList<>(patternValues.size());

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/AirMapView.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/AirMapView.java
@@ -1,7 +1,6 @@
 package versioned.host.exp.exponent.modules.api.components.maps;
 
 import android.content.Context;
-import android.content.pm.PackageManager;
 import android.content.res.ColorStateList;
 import android.graphics.Bitmap;
 import android.graphics.Color;
@@ -9,6 +8,8 @@ import android.graphics.Point;
 import android.graphics.PorterDuff;
 import android.graphics.Rect;
 import android.os.Build;
+
+import androidx.core.content.PermissionChecker;
 import androidx.core.view.GestureDetectorCompat;
 import androidx.core.view.MotionEventCompat;
 import android.view.GestureDetector;
@@ -123,10 +124,10 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
   }
 
   // We do this to fix this bug:
-  // https://github.com/react-native-community/react-native-maps/issues/271
+  // https://github.com/react-native-maps/react-native-maps/issues/271
   //
   // which conflicts with another bug regarding the passed in context:
-  // https://github.com/react-native-community/react-native-maps/issues/1147
+  // https://github.com/react-native-maps/react-native-maps/issues/1147
   //
   // Doing this allows us to avoid both bugs.
   private static Context getNonBuggyContext(ThemedReactContext reactContext,
@@ -349,8 +350,12 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
       @Override
       public void onCameraMove() {
         LatLngBounds bounds = map.getProjection().getVisibleRegion().latLngBounds;
+
         cameraLastIdleBounds = null;
-        eventDispatcher.dispatchEvent(new RegionChangeEvent(getId(), bounds, true));
+        boolean isGesture = GoogleMap.OnCameraMoveStartedListener.REASON_GESTURE == cameraMoveReason;
+
+        RegionChangeEvent event = new RegionChangeEvent(getId(), bounds, true, isGesture);
+        eventDispatcher.dispatchEvent(event);
       }
     });
 
@@ -361,8 +366,12 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
         if ((cameraMoveReason != 0) &&
           ((cameraLastIdleBounds == null) ||
             LatLngBoundsUtils.BoundsAreDifferent(bounds, cameraLastIdleBounds))) {
+
           cameraLastIdleBounds = bounds;
-          eventDispatcher.dispatchEvent(new RegionChangeEvent(getId(), bounds, false));
+          boolean isGesture = GoogleMap.OnCameraMoveStartedListener.REASON_GESTURE == cameraMoveReason;
+
+          RegionChangeEvent event = new RegionChangeEvent(getId(), bounds, false, isGesture);
+          eventDispatcher.dispatchEvent(event);
         }
       }
     });
@@ -422,8 +431,8 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
   }
 
   private boolean hasPermissions() {
-    return checkSelfPermission(getContext(), PERMISSIONS[0]) == PackageManager.PERMISSION_GRANTED ||
-        checkSelfPermission(getContext(), PERMISSIONS[1]) == PackageManager.PERMISSION_GRANTED;
+    return checkSelfPermission(getContext(), PERMISSIONS[0]) == PermissionChecker.PERMISSION_GRANTED ||
+        checkSelfPermission(getContext(), PERMISSIONS[1]) == PermissionChecker.PERMISSION_GRANTED;
   }
 
 
@@ -499,7 +508,7 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
 
     builder.tilt((float)camera.getDouble("pitch"));
     builder.bearing((float)camera.getDouble("heading"));
-    builder.zoom(camera.getInt("zoom"));
+    builder.zoom((float)camera.getDouble("zoom"));
 
     CameraUpdate update = CameraUpdateFactory.newCameraPosition(builder.build());
 
@@ -737,7 +746,7 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
       int width = data.get("width") == null ? 0 : data.get("width").intValue();
       int height = data.get("height") == null ? 0 : data.get("height").intValue();
 
-      //fix for https://github.com/react-native-community/react-native-maps/issues/245,
+      //fix for https://github.com/react-native-maps/react-native-maps/issues/245,
       //it's not guaranteed the passed-in height and width would be greater than 0.
       if (width <= 0 || height <= 0) {
         map.moveCamera(CameraUpdateFactory.newLatLngBounds(boundsToMove, 0));
@@ -818,7 +827,7 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
     map.animateCamera(CameraUpdateFactory.newLatLng(coordinate), duration, null);
   }
 
-  public void fitToElements(boolean animated) {
+  public void fitToElements(ReadableMap edgePadding, boolean animated) {
     if (map == null) return;
 
     LatLngBounds.Builder builder = new LatLngBounds.Builder();
@@ -836,6 +845,12 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
     if (addedPosition) {
       LatLngBounds bounds = builder.build();
       CameraUpdate cu = CameraUpdateFactory.newLatLngBounds(bounds, baseMapPadding);
+
+      if (edgePadding != null) {
+        map.setPadding(edgePadding.getInt("left"), edgePadding.getInt("top"),
+          edgePadding.getInt("right"), edgePadding.getInt("bottom"));
+      }
+
       if (animated) {
         map.animateCamera(cu);
       } else {
@@ -872,18 +887,31 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
     if (addedPosition) {
       LatLngBounds bounds = builder.build();
       CameraUpdate cu = CameraUpdateFactory.newLatLngBounds(bounds, baseMapPadding);
-      
+
       if (edgePadding != null) {
         map.setPadding(edgePadding.getInt("left"), edgePadding.getInt("top"),
           edgePadding.getInt("right"), edgePadding.getInt("bottom"));
-      }   
-      
+      }
+
       if (animated) {
         map.animateCamera(cu);
       } else {
         map.moveCamera(cu);
       }
     }
+  }
+
+  int baseLeftMapPadding;
+  int baseRightMapPadding;
+  int baseTopMapPadding;
+  int baseBottomMapPadding;
+
+  public void applyBaseMapPadding(int left, int top, int right, int bottom){
+    this.map.setPadding(left, top, right, bottom);
+    baseLeftMapPadding = left;
+    baseRightMapPadding = right;
+    baseTopMapPadding = top;
+    baseBottomMapPadding = bottom;
   }
 
   public void fitToCoordinates(ReadableArray coordinatesArray, ReadableMap edgePadding,
@@ -903,8 +931,7 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
     CameraUpdate cu = CameraUpdateFactory.newLatLngBounds(bounds, baseMapPadding);
 
     if (edgePadding != null) {
-      map.setPadding(edgePadding.getInt("left"), edgePadding.getInt("top"),
-          edgePadding.getInt("right"), edgePadding.getInt("bottom"));
+      appendMapPadding(edgePadding.getInt("left"), edgePadding.getInt("top"), edgePadding.getInt("right"), edgePadding.getInt("bottom"));
     }
 
     if (animated) {
@@ -912,8 +939,26 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
     } else {
       map.moveCamera(cu);
     }
-    map.setPadding(0, 0, 0,
-        0); // Without this, the Google logo is moved up by the value of edgePadding.bottom
+    // Move the google logo to the default base padding value.
+    map.setPadding(baseLeftMapPadding, baseTopMapPadding, baseRightMapPadding, baseBottomMapPadding);
+  }
+
+  private void appendMapPadding(int iLeft,int iTop, int iRight, int iBottom) {
+    int left;
+    int top;
+    int right;
+    int bottom;
+    double density = getResources().getDisplayMetrics().density;
+
+    left = (int) (iLeft * density);
+    top = (int) (iTop * density);
+    right = (int) (iRight * density);
+    bottom = (int) (iBottom * density);
+
+    map.setPadding(left + baseLeftMapPadding,
+            top + baseTopMapPadding,
+            right + baseRightMapPadding,
+            bottom + baseBottomMapPadding);
   }
 
   public double[][] getMapBoundaries() {
@@ -1113,6 +1158,7 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
   }
 
   public void onDoublePress(MotionEvent ev) {
+    if (this.map == null) return;
     Point point = new Point((int) ev.getX(), (int) ev.getY());
     LatLng coords = this.map.getProjection().fromScreenLocation(point);
     WritableMap event = makeClickEventData(coords);
@@ -1246,13 +1292,13 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
       indoorBuilding.putArray("levels", levelsArray);
       indoorBuilding.putInt("activeLevelIndex", 0);
       indoorBuilding.putBoolean("underground", false);
-      
+
       event.putMap("IndoorBuilding", indoorBuilding);
 
       manager.pushEvent(context, this, "onIndoorBuildingFocused", event);
     }
   }
-  
+
   @Override
   public void onIndoorLevelActivated(IndoorBuilding building) {
     if (building == null) {
@@ -1275,7 +1321,7 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
 
     manager.pushEvent(context, this, "onIndoorLevelActivated", event);
   }
-    
+
   public void setIndoorActiveLevelIndex(int activeLevelIndex) {
     IndoorBuilding building = this.map.getFocusedBuilding();
     if (building != null) {
@@ -1305,4 +1351,19 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
 
     return airMarker;
   }
+
+  @Override
+  public void requestLayout() {
+    super.requestLayout();
+    post(measureAndLayout);
+  }
+
+  private final Runnable measureAndLayout = new Runnable() {
+    @Override
+    public void run() {
+      measure(MeasureSpec.makeMeasureSpec(getWidth(), MeasureSpec.EXACTLY),
+              MeasureSpec.makeMeasureSpec(getHeight(), MeasureSpec.EXACTLY));
+      layout(getLeft(), getTop(), getRight(), getBottom());
+    }
+  };
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/FusedLocationSource.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/FusedLocationSource.java
@@ -12,6 +12,8 @@ import com.google.android.gms.location.LocationServices;
 import com.google.android.gms.maps.LocationSource;
 import com.google.android.gms.tasks.OnSuccessListener;
 
+import java.lang.SecurityException;
+
 public class FusedLocationSource implements LocationSource {
 
     private final FusedLocationProviderClient fusedLocationClientProviderClient;
@@ -40,23 +42,27 @@ public class FusedLocationSource implements LocationSource {
 
     @Override
     public void activate(final OnLocationChangedListener onLocationChangedListener) {
-        fusedLocationClientProviderClient.getLastLocation().addOnSuccessListener(new OnSuccessListener<Location>() {
-            @Override
-            public void onSuccess(Location location) {
-                if (location != null) {
-                    onLocationChangedListener.onLocationChanged(location);
+        try {
+            fusedLocationClientProviderClient.getLastLocation().addOnSuccessListener(new OnSuccessListener<Location>() {
+                @Override
+                public void onSuccess(Location location) {
+                    if (location != null) {
+                        onLocationChangedListener.onLocationChanged(location);
+                    }
                 }
-            }
-        });
-        locationCallback = new LocationCallback() {
-            @Override
-            public void onLocationResult(LocationResult locationResult) {
-                for (Location location : locationResult.getLocations()) {
-                    onLocationChangedListener.onLocationChanged(location);
+            });
+            locationCallback = new LocationCallback() {
+                @Override
+                public void onLocationResult(LocationResult locationResult) {
+                    for (Location location : locationResult.getLocations()) {
+                        onLocationChangedListener.onLocationChanged(location);
+                    }
                 }
-            }
-        };
-        fusedLocationClientProviderClient.requestLocationUpdates(locationRequest, locationCallback, Looper.myLooper());
+            };
+            fusedLocationClientProviderClient.requestLocationUpdates(locationRequest, locationCallback, Looper.myLooper());
+        } catch (SecurityException e) {
+            e.printStackTrace();
+        }
     }
 
     @Override

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/ImageReader.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/ImageReader.java
@@ -89,7 +89,7 @@ public class ImageReader {
       imp.setIconBitmapDescriptor(null);
       imp.update();
     } else if (uri.startsWith("http://") || uri.startsWith("https://") ||
-        uri.startsWith("file://") || uri.startsWith("asset://")) {
+        uri.startsWith("file://") || uri.startsWith("asset://") || uri.startsWith("data:")) {
       ImageRequest imageRequest = ImageRequestBuilder
           .newBuilderWithSource(Uri.parse(uri))
           .build();

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/RegionChangeEvent.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/RegionChangeEvent.java
@@ -10,11 +10,13 @@ import com.google.android.gms.maps.model.LatLngBounds;
 public class RegionChangeEvent extends Event<RegionChangeEvent> {
   private final LatLngBounds bounds;
   private final boolean continuous;
+  private final boolean isGesture;
 
-  public RegionChangeEvent(int id, LatLngBounds bounds, boolean continuous) {
+  public RegionChangeEvent(int id, LatLngBounds bounds, boolean continuous, boolean isGesture) {
     super(id);
     this.bounds = bounds;
     this.continuous = continuous;
+    this.isGesture = isGesture;
   }
 
   @Override
@@ -29,7 +31,6 @@ public class RegionChangeEvent extends Event<RegionChangeEvent> {
 
   @Override
   public void dispatch(RCTEventEmitter rctEventEmitter) {
-
     WritableMap event = new WritableNativeMap();
     event.putBoolean("continuous", continuous);
 
@@ -40,6 +41,7 @@ public class RegionChangeEvent extends Event<RegionChangeEvent> {
     region.putDouble("latitudeDelta", bounds.northeast.latitude - bounds.southwest.latitude);
     region.putDouble("longitudeDelta", bounds.northeast.longitude - bounds.southwest.longitude);
     event.putMap("region", region);
+    event.putBoolean("isGesture", isGesture);
 
     rctEventEmitter.receiveEvent(getViewTag(), getEventName(), event);
   }

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -138,7 +138,7 @@
     "react-native-appearance": "~0.3.4",
     "react-native-gesture-handler": "~1.10.2",
     "react-native-iphone-x-helper": "^1.3.0",
-    "react-native-maps": "0.27.1",
+    "react-native-maps": "0.28.0",
     "react-native-paper": "^4.0.1",
     "react-native-reanimated": "~2.1.0",
     "react-native-redash": "^14.1.1",

--- a/home/package.json
+++ b/home/package.json
@@ -57,7 +57,7 @@
     "react-native-fade-in-image": "^1.5.0",
     "react-native-gesture-handler": "~1.10.2",
     "react-native-infinite-scroll-view": "^0.4.5",
-    "react-native-maps": "0.27.1",
+    "react-native-maps": "0.28.0",
     "react-native-paper": "^4.0.1",
     "react-native-reanimated": "~2.1.0",
     "react-native-safe-area-context": "3.2.0",

--- a/ios/Exponent.xcodeproj/project.pbxproj
+++ b/ios/Exponent.xcodeproj/project.pbxproj
@@ -5,7 +5,6 @@
 	};
 	objectVersion = 46;
 	objects = {
-
 /* Begin PBXBuildFile section */
 		0726F0592007E438004992E7 /* EXKernelAppRecord.m in Sources */ = {isa = PBXBuildFile; fileRef = 0726F0582007E438004992E7 /* EXKernelAppRecord.m */; };
 		0726F05C2007E446004992E7 /* EXKernelAppRegistry.m in Sources */ = {isa = PBXBuildFile; fileRef = 0726F05B2007E446004992E7 /* EXKernelAppRegistry.m */; };

--- a/ios/Exponent/Versioned/Core/Api/Components/GoogleMaps/AIRGoogleMap.h
+++ b/ios/Exponent/Versioned/Core/Api/Components/GoogleMaps/AIRGoogleMap.h
@@ -54,6 +54,7 @@
 @property (nonatomic, assign) BOOL scrollEnabled;
 @property (nonatomic, assign) BOOL zoomEnabled;
 @property (nonatomic, assign) BOOL rotateEnabled;
+@property (nonatomic, assign) BOOL scrollDuringRotateOrZoomEnabled;
 @property (nonatomic, assign) BOOL pitchEnabled;
 @property (nonatomic, assign) BOOL zoomTapEnabled;
 @property (nonatomic, assign) BOOL showsUserLocation;
@@ -69,8 +70,8 @@
 - (void)didTapPolygon:(GMSPolygon *)polygon;
 - (void)didTapAtCoordinate:(CLLocationCoordinate2D)coordinate;
 - (void)didLongPressAtCoordinate:(CLLocationCoordinate2D)coordinate;
-- (void)didChangeCameraPosition:(GMSCameraPosition *)position;
-- (void)idleAtCameraPosition:(GMSCameraPosition *)position;
+- (void)didChangeCameraPosition:(GMSCameraPosition *)position isGesture:(BOOL)isGesture;
+- (void)idleAtCameraPosition:(GMSCameraPosition *)position isGesture:(BOOL)isGesture;
 - (void)didTapPOIWithPlaceID:(NSString *)placeID name:(NSString *) name location:(CLLocationCoordinate2D) location;
 - (NSArray *)getMapBoundaries;
 

--- a/ios/Exponent/Versioned/Core/Api/Components/GoogleMaps/AIRGoogleMapManager.h
+++ b/ios/Exponent/Versioned/Core/Api/Components/GoogleMaps/AIRGoogleMapManager.h
@@ -8,10 +8,9 @@
 #ifdef HAVE_GOOGLE_MAPS
 
 #import <React/RCTViewManager.h>
-#import "AIRGoogleMap.h"
 
 @interface AIRGoogleMapManager : RCTViewManager
-@property (nonatomic, assign) AIRGoogleMap *map;
+@property (nonatomic) BOOL isGesture;
 
 @end
 

--- a/ios/Exponent/Versioned/Core/Api/Components/GoogleMaps/AIRGoogleMapManager.m
+++ b/ios/Exponent/Versioned/Core/Api/Components/GoogleMaps/AIRGoogleMapManager.m
@@ -33,7 +33,7 @@
 static NSString *const RCTMapViewKey = @"MapView";
 
 
-@interface AIRGoogleMapManager() <GMSMapViewDelegate, GMSIndoorDisplayDelegate>
+@interface AIRGoogleMapManager() <GMSMapViewDelegate>
 {
   BOOL didCallOnMapReady;
 }
@@ -51,8 +51,6 @@ RCT_EXPORT_MODULE()
   map.isAccessibilityElement = NO;
   map.accessibilityElementsHidden = NO;
   map.settings.consumesGesturesInView = NO;
-  map.indoorDisplay.delegate = self;
-  self.map = map;
 
   UIPanGestureRecognizer *drag = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(handleMapDrag:)];
   [drag setMinimumNumberOfTouches:1];
@@ -78,6 +76,7 @@ RCT_EXPORT_VIEW_PROPERTY(showsTraffic, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(zoomEnabled, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(rotateEnabled, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(scrollEnabled, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(scrollDuringRotateOrZoomEnabled, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(pitchEnabled, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(zoomTapEnabled, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(showsUserLocation, BOOL)
@@ -262,6 +261,7 @@ RCT_EXPORT_METHOD(animateToBearing:(nonnull NSNumber *)reactTag
 }
 
 RCT_EXPORT_METHOD(fitToElements:(nonnull NSNumber *)reactTag
+                  edgePadding:(nonnull NSDictionary *)edgePadding
                   animated:(BOOL)animated)
 {
   [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
@@ -276,9 +276,20 @@ RCT_EXPORT_METHOD(fitToElements:(nonnull NSNumber *)reactTag
 
       for (AIRGoogleMapMarker *marker in mapView.markers)
         bounds = [bounds includingCoordinate:marker.realMarker.position];
-
-      GMSCameraUpdate *cameraUpdate = [GMSCameraUpdate fitBounds:bounds withPadding:55.0f];
-
+        
+        GMSCameraUpdate* cameraUpdate;
+        
+        if ([edgePadding count] != 0) {
+            // Set Map viewport
+            CGFloat top = [RCTConvert CGFloat:edgePadding[@"top"]];
+            CGFloat right = [RCTConvert CGFloat:edgePadding[@"right"]];
+            CGFloat bottom = [RCTConvert CGFloat:edgePadding[@"bottom"]];
+            CGFloat left = [RCTConvert CGFloat:edgePadding[@"left"]];
+            
+            cameraUpdate = [GMSCameraUpdate fitBounds:bounds withEdgeInsets:UIEdgeInsetsMake(top, left, bottom, right)];
+        } else {
+            cameraUpdate = [GMSCameraUpdate fitBounds:bounds withPadding:55.0f];
+        }
       if (animated) {
         [mapView animateWithCameraUpdate: cameraUpdate];
       } else {
@@ -554,11 +565,11 @@ RCT_EXPORT_METHOD(setIndoorActiveLevelIndex:(nonnull NSNumber *)reactTag
       RCTLogError(@"Invalid view returned from registry, expecting AIRGoogleMap, got: %@", view);
     } else {
       AIRGoogleMap *mapView = (AIRGoogleMap *)view;
-      if (!self.map.indoorDisplay) {
+      if (!mapView.indoorDisplay) {
         return;
       }
-      if ( levelIndex < [self.map.indoorDisplay.activeBuilding.levels count]) {
-        mapView.indoorDisplay.activeLevel = self.map.indoorDisplay.activeBuilding.levels[levelIndex];
+      if ( levelIndex < [mapView.indoorDisplay.activeBuilding.levels count]) {
+        mapView.indoorDisplay.activeLevel = mapView.indoorDisplay.activeBuilding.levels[levelIndex];
       }
     }
   }];
@@ -570,6 +581,10 @@ RCT_EXPORT_METHOD(setIndoorActiveLevelIndex:(nonnull NSNumber *)reactTag
 
 - (NSDictionary *)constantsToExport {
   return @{ @"legalNotice": [GMSServices openSourceLicenseInfo] };
+}
+
+- (void)mapView:(GMSMapView *)mapView willMove:(BOOL)gesture{
+    self.isGesture = gesture;
 }
 
 - (void)mapViewDidStartTileRendering:(GMSMapView *)mapView {
@@ -604,12 +619,12 @@ RCT_EXPORT_METHOD(setIndoorActiveLevelIndex:(nonnull NSNumber *)reactTag
 
 - (void)mapView:(GMSMapView *)mapView didChangeCameraPosition:(GMSCameraPosition *)position {
   AIRGoogleMap *googleMapView = (AIRGoogleMap *)mapView;
-  [googleMapView didChangeCameraPosition:position];
+  [googleMapView didChangeCameraPosition:position isGesture:self.isGesture];
 }
 
 - (void)mapView:(GMSMapView *)mapView idleAtCameraPosition:(GMSCameraPosition *)position {
   AIRGoogleMap *googleMapView = (AIRGoogleMap *)mapView;
-  [googleMapView idleAtCameraPosition:position];
+  [googleMapView idleAtCameraPosition:position isGesture:self.isGesture];
 }
 
 - (UIView *)mapView:(GMSMapView *)mapView markerInfoWindow:(GMSMarker *)marker {
@@ -639,63 +654,6 @@ RCT_EXPORT_METHOD(setIndoorActiveLevelIndex:(nonnull NSNumber *)reactTag
 - (void)mapView:(GMSMapView *)mapView didDragMarker:(GMSMarker *)marker {
   AIRGMSMarker *aMarker = (AIRGMSMarker *)marker;
   [aMarker.fakeMarker didDragMarker:aMarker];
-}
-
-- (void) didChangeActiveBuilding: (nullable GMSIndoorBuilding *) building {
-  if (!building) {
-    if (!self.map.onIndoorBuildingFocused) {
-      return;
-    }
-    self.map.onIndoorBuildingFocused(@{
-                                      @"IndoorBuilding": @{
-                                          @"activeLevelIndex": @0,
-                                          @"underground": @false,
-                                          @"levels": [[NSMutableArray alloc]init]
-                                      }
-    });
-  }
-  NSInteger i = 0;
-  NSMutableArray *arrayLevels = [[NSMutableArray alloc]init];
-  for (GMSIndoorLevel *level in building.levels) {
-    [arrayLevels addObject: @{
-                              @"index": @(i),
-                              @"name" : level.name,
-                              @"shortName" : level.shortName,
-                            }
-    ];
-    i++;
-  }
-  if (!self.map.onIndoorBuildingFocused) {
-    return;
-  }
-  self.map.onIndoorBuildingFocused(@{
-                                    @"IndoorBuilding": @{
-                                        @"activeLevelIndex": @(building.defaultLevelIndex),
-                                        @"underground": @(building.underground),
-                                        @"levels": arrayLevels
-                                    }
-                                  }
-  );
-}
-
-- (void) didChangeActiveLevel: (nullable GMSIndoorLevel *) 	level {
-  if (!self.map.onIndoorLevelActivated || !self.map.indoorDisplay  || !level) {
-    return;
-  }
-  NSInteger i = 0;
-  for (GMSIndoorLevel *buildingLevel in self.map.indoorDisplay.activeBuilding.levels) {
-    if (buildingLevel.name == level.name && buildingLevel.shortName == level.shortName) {
-      break;
-    }
-    i++;
-  }
-  self.map.onIndoorLevelActivated(@{
-                                  @"IndoorLevel": @{
-                                    @"activeLevelIndex": @(i),
-                                    @"name": level.name,
-                                    @"shortName": level.shortName
-                                  }
-  });
 }
 
 - (void)mapView:(GMSMapView *)mapView

--- a/ios/Exponent/Versioned/Core/Api/Components/GoogleMaps/AIRGoogleMapMarker.m
+++ b/ios/Exponent/Versioned/Core/Api/Components/GoogleMaps/AIRGoogleMapMarker.m
@@ -264,7 +264,7 @@ CGRect unionRect(CGRect a, CGRect b) {
   }
 
   if (!_iconImageView) {
-    // prevent glitch with marker (cf. https://github.com/react-native-community/react-native-maps/issues/738)
+    // prevent glitch with marker (cf. https://github.com/react-native-maps/react-native-maps/issues/738)
     UIImageView *empyImageView = [[UIImageView alloc] init];
     _iconImageView = empyImageView;
     [self iconViewInsertSubview:_iconImageView atIndex:0];
@@ -340,7 +340,7 @@ CGRect unionRect(CGRect a, CGRect b) {
                                    NSLog(@"%@", error);
                                  }
                                  dispatch_async(dispatch_get_main_queue(), ^{
-                                   _realMarker.icon = image;
+                                   self->_realMarker.icon = image;
                                  });
                                }];
 }

--- a/ios/Exponent/Versioned/Core/Api/Components/GoogleMaps/AIRGoogleMapOverlay.h
+++ b/ios/Exponent/Versioned/Core/Api/Components/GoogleMaps/AIRGoogleMapOverlay.h
@@ -20,6 +20,7 @@
 @property (nonatomic, copy) NSArray *boundsRect;
 @property (nonatomic, assign) CGFloat opacity;
 @property (nonatomic, readonly) GMSCoordinateBounds *overlayBounds;
+@property (nonatomic, readonly) double bearing;
 
 @property (nonatomic, weak) RCTBridge *bridge;
 

--- a/ios/Exponent/Versioned/Core/Api/Components/GoogleMaps/AIRGoogleMapOverlay.m
+++ b/ios/Exponent/Versioned/Core/Api/Components/GoogleMaps/AIRGoogleMapOverlay.m
@@ -15,6 +15,7 @@
 @interface AIRGoogleMapOverlay()
   @property (nonatomic, strong, readwrite) UIImage *overlayImage;
   @property (nonatomic, readwrite) GMSCoordinateBounds *overlayBounds;
+  @property (nonatomic) CLLocationDirection bearing;
 @end
 
 @implementation AIRGoogleMapOverlay {
@@ -73,6 +74,12 @@
                                                         coordinate:_northEast];
 
   _overlay.bounds = _overlayBounds;
+}
+
+- (void)setBearing:(double)bearing
+{
+    _bearing = (double)bearing;
+    _overlay.bearing = _bearing;
 }
 
 - (void)setOpacity:(CGFloat)opacity

--- a/ios/Exponent/Versioned/Core/Api/Components/GoogleMaps/AIRGoogleMapOverlayManager.m
+++ b/ios/Exponent/Versioned/Core/Api/Components/GoogleMaps/AIRGoogleMapOverlayManager.m
@@ -17,6 +17,7 @@ RCT_EXPORT_MODULE()
 }
 
 RCT_REMAP_VIEW_PROPERTY(bounds, boundsRect, NSArray)
+RCT_REMAP_VIEW_PROPERTY(bearing, bearing, double)
 RCT_REMAP_VIEW_PROPERTY(image, imageSrc, NSString)
 RCT_REMAP_VIEW_PROPERTY(opacity, opacity, CGFloat)
 

--- a/ios/Exponent/Versioned/Core/Api/Components/Maps/AIRMap.h
+++ b/ios/Exponent/Versioned/Core/Api/Components/Maps/AIRMap.h
@@ -30,6 +30,7 @@ extern const NSInteger AIRMapMaxZoomLevel;
 
 @property (nonatomic, copy) NSString *userLocationAnnotationTitle;
 @property (nonatomic, assign) BOOL followUserLocation;
+@property (nonatomic, assign) BOOL userLocationCalloutEnabled;
 @property (nonatomic, assign) BOOL hasStartedRendering;
 @property (nonatomic, assign) BOOL cacheEnabled;
 @property (nonatomic, assign) BOOL loadingEnabled;

--- a/ios/Exponent/Versioned/Core/Api/Components/Maps/AIRMap.m
+++ b/ios/Exponent/Versioned/Core/Api/Components/Maps/AIRMap.m
@@ -158,6 +158,8 @@ const NSInteger AIRMapMaxZoomLevel = 20;
         [self removeOverlay:(id <MKOverlay>) subview];
     } else if ([subview isKindOfClass:[AIRMapUrlTile class]]) {
         [self removeOverlay:(id <MKOverlay>) subview];
+    } else if ([subview isKindOfClass:[AIRMapWMSTile class]]) {
+        [self removeOverlay:(id <MKOverlay>) subview];
     } else if ([subview isKindOfClass:[AIRMapLocalTile class]]) {
         [self removeOverlay:(id <MKOverlay>) subview];
     } else if ([subview isKindOfClass:[AIRMapOverlay class]]) {
@@ -358,6 +360,21 @@ const NSInteger AIRMapMaxZoomLevel = 20;
     }
 }
 
+- (void)setUserInterfaceStyle:(NSString*)userInterfaceStyle
+{
+    if (@available(iOS 13.0, *)) {
+        if([userInterfaceStyle isEqualToString:@"light"]) {
+            self.overrideUserInterfaceStyle = UIUserInterfaceStyleLight;
+        } else if([userInterfaceStyle isEqualToString:@"dark"]) {
+            self.overrideUserInterfaceStyle = UIUserInterfaceStyleDark;
+        } else {
+            self.overrideUserInterfaceStyle = UIUserInterfaceStyleUnspecified;
+        }
+    } else {
+        NSLog(@"UserInterfaceStyle not supported below iOS 13");
+    }
+}
+
 - (void)setTintColor:(UIColor *)tintColor
 {
     super.tintColor = tintColor;
@@ -366,6 +383,11 @@ const NSInteger AIRMapMaxZoomLevel = 20;
 - (void)setFollowsUserLocation:(BOOL)followsUserLocation
 {
     _followUserLocation = followsUserLocation;
+}
+
+- (void)setUserLocationCalloutEnabled:(BOOL)calloutEnabled
+{
+    _userLocationCalloutEnabled = calloutEnabled;
 }
 
 - (void)setHandlePanDrag:(BOOL)handleMapDrag {
@@ -531,7 +553,7 @@ const NSInteger AIRMapMaxZoomLevel = 20;
 }
 
 - (void)cacheViewIfNeeded {
-    // https://github.com/react-native-community/react-native-maps/issues/3100
+    // https://github.com/react-native-maps/react-native-maps/issues/3100
     // Do nothing if app is not active
     if ([[UIApplication sharedApplication] applicationState] != UIApplicationStateActive) {
         return;

--- a/ios/Exponent/Versioned/Core/Api/Components/Maps/AIRMapManager.m
+++ b/ios/Exponent/Versioned/Core/Api/Components/Maps/AIRMapManager.m
@@ -88,7 +88,9 @@ RCT_REMAP_VIEW_PROPERTY(testID, accessibilityIdentifier, NSString)
 RCT_EXPORT_VIEW_PROPERTY(showsUserLocation, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(tintColor, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(userLocationAnnotationTitle, NSString)
+RCT_EXPORT_VIEW_PROPERTY(userInterfaceStyle, NSString)
 RCT_EXPORT_VIEW_PROPERTY(followsUserLocation, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(userLocationCalloutEnabled, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(showsPointsOfInterest, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(showsBuildings, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(showsCompass, BOOL)
@@ -380,6 +382,7 @@ RCT_EXPORT_METHOD(animateToBearing:(nonnull NSNumber *)reactTag
 }
 
 RCT_EXPORT_METHOD(fitToElements:(nonnull NSNumber *)reactTag
+        edgePadding:(nonnull NSDictionary *)edgePadding
         animated:(BOOL)animated)
 {
     [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
@@ -558,6 +561,46 @@ RCT_EXPORT_METHOD(coordinateForPoint:(nonnull NSNumber *)reactTag
                       @"latitude": @(coordinate.latitude),
                       @"longitude": @(coordinate.longitude),
                       });
+        }
+    }];
+}
+
+RCT_EXPORT_METHOD(getAddressFromCoordinates:(nonnull NSNumber *)reactTag
+                                 coordinate: (NSDictionary *)coordinate
+                                   resolver: (RCTPromiseResolveBlock)resolve
+                                   rejecter:(RCTPromiseRejectBlock)reject)
+{
+    [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
+        id view = viewRegistry[reactTag];
+        if (![view isKindOfClass:[AIRMap class]]) {
+            reject(@"Invalid argument", [NSString stringWithFormat:@"Invalid view returned from registry, expecting AIRMap, got: %@", view], NULL);
+        } else {
+            if (coordinate != nil ||
+                ![[coordinate allKeys] containsObject:@"latitude"] ||
+                ![[coordinate allKeys] containsObject:@"longitude"]) {
+                reject(@"Invalid argument", [NSString stringWithFormat:@"Invalid coordinate format"], NULL);
+            }
+            CLLocation *location = [[CLLocation alloc] initWithLatitude:[coordinate[@"latitude"] doubleValue]
+                                                              longitude:[coordinate[@"longitude"] doubleValue]];
+            CLGeocoder *geoCoder = [[CLGeocoder alloc] init];
+            [geoCoder reverseGeocodeLocation:location
+                           completionHandler:^(NSArray *placemarks, NSError *error) {
+                    if (error == nil && [placemarks count] > 0){
+                        CLPlacemark *placemark = placemarks[0];
+                        resolve(@{
+                            @"name" : [NSString stringWithFormat:@"%@", placemark.name],
+                            @"thoroughfare" : [NSString stringWithFormat:@"%@", placemark.thoroughfare],
+                            @"subThoroughfare" : [NSString stringWithFormat:@"%@", placemark.subThoroughfare],
+                            @"locality" : [NSString stringWithFormat:@"%@", placemark.locality],
+                            @"subLocality" : [NSString stringWithFormat:@"%@", placemark.subLocality],
+                            @"administrativeArea" : [NSString stringWithFormat:@"%@", placemark.administrativeArea],
+                            @"subAdministrativeArea" : [NSString stringWithFormat:@"%@", placemark.subAdministrativeArea],
+                            @"postalCode" : [NSString stringWithFormat:@"%@", placemark.postalCode],
+                            @"countryCode" : [NSString stringWithFormat:@"%@", placemark.ISOcountryCode],
+                            @"country" : [NSString stringWithFormat:@"%@", placemark.country],
+                        });
+                    }
+            }];
         }
     }];
 }
@@ -840,6 +883,18 @@ RCT_EXPORT_METHOD(coordinateForPoint:(nonnull NSNumber *)reactTag
 
 #pragma mark Annotation Stuff
 
+- (void)mapView:(AIRMap *)mapView didAddAnnotationViews:(NSArray<MKAnnotationView *> *)views
+{
+    if(!mapView.userLocationCalloutEnabled){
+        for(MKAnnotationView* view in views){
+            if ([view.annotation isKindOfClass:[MKUserLocation class]]){
+                [view setEnabled:NO];
+                [view setCanShowCallout:NO];
+                break;
+            }
+        }
+    }
+}
 
 
 - (void)mapView:(AIRMap *)mapView didSelectAnnotationView:(MKAnnotationView *)view

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -91,7 +91,7 @@
   "react-native-branch": "5.0.0",
   "react-native-gesture-handler": "~1.10.2",
   "react-native-get-random-values": "~1.7.0",
-  "react-native-maps": "0.27.1",
+  "react-native-maps": "0.28.0",
   "react-native-pager-view": "5.0.12",
   "react-native-reanimated": "~2.1.0",
   "react-native-safe-area-context": "3.2.0",


### PR DESCRIPTION
# Why

Reattempt of #13158

# How

`et update-module -m react-native-maps`

# Test Plan

There aren't a lot of new features, this is the changelog:

---

## 0.28.0

* Common: [#3705](https://github.com/react-native-maps/react-native-maps/pull/3705) Update example project
* Common: [#3424](https://github.com/react-native-maps/react-native-maps/pull/3424) Bugfix for the "require cycles" warning
* Common: [#3452](https://github.com/react-native-maps/react-native-maps/pull/3452) Ability to pass a Marker image as Geojson prop
* Common: [#3516](https://github.com/react-native-maps/react-native-maps/pull/3516) Polyline props to obtain dashed/dotted lines in Geojson component
* Common: [#3358](https://github.com/react-native-maps/react-native-maps/pull/3358) onRegionChange sends a boolean indicating if the move was from the user (true) or an animation (false)
* Common: [#3658](https://github.com/react-native-maps/react-native-maps/pull/#3658) Geojson stroke color, stroke width, fill color, and marker color properties preserved
* Common: [#3695](https://github.com/react-native-maps/react-native-maps/pull/3695) AnimateCamera duration bugfixed
* iOS: [#3383](https://github.com/react-native-maps/react-native-maps/pull/3383) Added tintColor prop for setting the color of the map
* Android: [#3414](https://github.com/react-native-maps/react-native-maps/pull/3414) Play services version updated

---

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).