### PR TITLE
[docs] use fixed table layout in PlatformsSection

### DIFF
--- a/docs/components/plugins/PlatformsSection.tsx
+++ b/docs/components/plugins/PlatformsSection.tsx
@@ -21,6 +21,10 @@ const STYLES_LINK = css`
   color: ${theme.link.default};
 `;
 
+const STYLES_TABLE = css`
+  table-layout: fixed;
+`;
+
 const platforms = [
   { title: 'Android Device', propName: 'android' },
   { title: 'Android Emulator', propName: 'emulator' },
@@ -71,7 +75,7 @@ export default class PlatformsSection extends React.Component<Props> {
     return (
       <div>
         <H4 css={STYLES_TITLE}>{this.props.title || 'Platform Compatibility'}</H4>
-        <table>
+        <table css={STYLES_TABLE}>
           <thead>
             <tr>
               {platforms.map(({ title }) => (


### PR DESCRIPTION
# Why

Currently cells in `PlatformsSection` table are autosized, which produces uneven columns distribution. Some are squished, some have a lot of padding.

<img width="1122" alt="Screenshot 2021-06-07 at 21 37 14" src="https://user-images.githubusercontent.com/719641/121078173-e2640080-c7d8-11eb-94fb-4dc321289e75.png">

# How

This PR aims to improve the tables appearance by applying `table-layout: fixed` CSS rule to the  `PlatformsSection` table, which should enforce even width of the columns.

# Preview

<img width="1122" alt="Screenshot 2021-06-07 at 21 37 18" src="https://user-images.githubusercontent.com/719641/121078295-0cb5be00-c7d9-11eb-9ff3-53bb30204655.png">

# Test Plan

The change has been tested in few browsers by running the docs website on `localhost`.