### PR TITLE
Added android style reset

### DIFF
--- a/templates/expo-template-bare-minimum/android/app/src/main/AndroidManifest.xml
+++ b/templates/expo-template-bare-minimum/android/app/src/main/AndroidManifest.xml
@@ -26,6 +26,7 @@
       android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
       android:launchMode="singleTask"
       android:windowSoftInputMode="adjustResize"
+      android:theme="@style/Theme.App.SplashScreen"
     >
       <intent-filter>
         <action android:name="android.intent.action.MAIN"/>

--- a/templates/expo-template-bare-minimum/android/app/src/main/AndroidManifest.xml
+++ b/templates/expo-template-bare-minimum/android/app/src/main/AndroidManifest.xml
@@ -26,7 +26,6 @@
       android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
       android:launchMode="singleTask"
       android:windowSoftInputMode="adjustResize"
-      android:theme="@style/Theme.App.SplashScreen"
     >
       <intent-filter>
         <action android:name="android.intent.action.MAIN"/>

--- a/templates/expo-template-bare-minimum/android/app/src/main/res/values/styles.xml
+++ b/templates/expo-template-bare-minimum/android/app/src/main/res/values/styles.xml
@@ -10,7 +10,7 @@
     <item name="android:textColorHint">#c8c8c8</item>
     <item name="android:textColor">@android:color/black</item>
   </style>
-  <style name="Theme.App.SplashScreen" parent="AppTheme">
+  <style name="Theme.App.SplashScreen" parent="Theme.AppCompat.Light.NoActionBar">
     <!-- Below line is handled by '@expo/configure-splash-screen' command and it's discouraged to modify it manually -->
     <item name="android:windowBackground">@drawable/splashscreen</item>
     <!-- Customize your splash screen theme here -->

--- a/templates/expo-template-bare-minimum/android/app/src/main/res/values/styles.xml
+++ b/templates/expo-template-bare-minimum/android/app/src/main/res/values/styles.xml
@@ -1,7 +1,6 @@
 <resources>
   <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
     <item name="android:textColor">@android:color/black</item>
-    <item name="android:windowTranslucentStatus">true</item>
     <item name="android:editTextStyle">@style/ResetEditText</item>
   </style>
   <style name="ResetEditText" parent="@android:style/Widget.EditText">

--- a/templates/expo-template-bare-minimum/android/app/src/main/res/values/styles.xml
+++ b/templates/expo-template-bare-minimum/android/app/src/main/res/values/styles.xml
@@ -1,9 +1,8 @@
 <resources>
   <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
-    <item name="colorPrimary">@color/colorPrimary</item>
+    <item name="android:textColor">@android:color/black</item>
     <item name="android:windowTranslucentStatus">true</item>
     <item name="android:editTextStyle">@style/ResetEditText</item>
-    <item name="android:textColor">@android:color/black</item>
   </style>
   <style name="ResetEditText" parent="@android:style/Widget.EditText">
     <item name="android:padding">0dp</item>

--- a/templates/expo-template-bare-minimum/android/app/src/main/res/values/styles.xml
+++ b/templates/expo-template-bare-minimum/android/app/src/main/res/values/styles.xml
@@ -3,13 +3,16 @@
     <item name="colorPrimary">@color/colorPrimary</item>
     <item name="android:windowTranslucentStatus">true</item>
     <item name="android:editTextStyle">@style/ResetEditText</item>
-    <item name="android:windowBackground">@drawable/splashscreen</item>
     <item name="android:textColor">@android:color/black</item>
   </style>
-  
   <style name="ResetEditText" parent="@android:style/Widget.EditText">
     <item name="android:padding">0dp</item>
     <item name="android:textColorHint">#c8c8c8</item>
     <item name="android:textColor">@android:color/black</item>
+  </style>
+  <style name="Theme.App.SplashScreen" parent="AppTheme">
+    <!-- Below line is handled by '@expo/configure-splash-screen' command and it's discouraged to modify it manually -->
+    <item name="android:windowBackground">@drawable/splashscreen</item>
+    <!-- Customize your splash screen theme here -->
   </style>
 </resources>

--- a/templates/expo-template-bare-minimum/android/app/src/main/res/values/styles.xml
+++ b/templates/expo-template-bare-minimum/android/app/src/main/res/values/styles.xml
@@ -1,12 +1,15 @@
 <resources>
-  <!-- Base application theme. -->
   <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
-    <!-- Customize your theme here. -->
-    <item name="android:textColor">#000000</item>
-  </style>
-  <style name="Theme.App.SplashScreen" parent="Theme.AppCompat.Light.NoActionBar">
-    <!-- Below line is handled by '@expo/configure-splash-screen' command and it's discouraged to modify it manually -->
+    <item name="colorPrimary">@color/colorPrimary</item>
+    <item name="android:windowTranslucentStatus">true</item>
+    <item name="android:editTextStyle">@style/ResetEditText</item>
     <item name="android:windowBackground">@drawable/splashscreen</item>
-    <!-- Customize your splash screen theme here -->
+    <item name="android:textColor">@android:color/black</item>
+  </style>
+  
+  <style name="ResetEditText" parent="@android:style/Widget.EditText">
+    <item name="android:padding">0dp</item>
+    <item name="android:textColorHint">#c8c8c8</item>
+    <item name="android:textColor">@android:color/black</item>
   </style>
 </resources>


### PR DESCRIPTION
# Why

- ENG-1234
- ENG-1231
- https://github.com/expo/expo/issues/13118
- https://github.com/expo/expo/issues/12791
- https://github.com/expo/expo/issues/13062

Partially fix style issues on Android by extending the theme applied by configure-splash-screen and adding the default theme from the Android shell app for TextInput. I've opted to put these changes in the template so that they can be versioned, but it might make sense in the future to move them to plugins.

The issues won't be resolved until we update splash screen plugin in Expo CLI and in the versioned plugin to not overwrite the default styles with an empty splash style.
