### PR TITLE
[docs] add updates integration to dev client setup docs

### DIFF
--- a/docs/pages/clients/installation.md
+++ b/docs/pages/clients/installation.md
@@ -81,6 +81,18 @@ import App from "./App";
 
 > Note: This will only affect the application in which you make this change. If you are using your custom client to load multiple applications, you'll need to add this import statement to each of them.
 
+### Loading published updates
+
+The Development Client can also be used to open and preview published updates to your app. To add this feature, you need to add `expo-updates` to your app if it isn't already installed, and add a small additional integration in your `AppDelegate.m` and `MainApplication.java` files.
+
+1. [Install and set up `react-native-unimodules` in your project](../bare/installing-unimodules.md), if you have not already done so.
+2. [Install and set up `expo-updates` in your project](../bare/installing-updates.md), if you have not already done so.
+3. Make the following changes to complete the integration with `expo-updates`:
+
+<ConfigurationDiff source="/static/diffs/client/app-delegate-updates.diff" />
+
+<ConfigurationDiff source="/static/diffs/client/main-application-updates.diff" />
+
 ## 4. Build and Install
 
 You're now ready to [build your first custom client](/clients/getting-started.md#building-and-installing-your-first-custom-client) and to start developing.

--- a/docs/pages/clients/installation.md
+++ b/docs/pages/clients/installation.md
@@ -83,7 +83,7 @@ import App from "./App";
 
 ### Loading published updates
 
-The Development Client can also be used to open and preview published updates to your app. To add this feature, you need to add `expo-updates` to your app if it isn't already installed, and add a small additional integration in your `AppDelegate.m` and `MainApplication.java` files.
+The Development Client can also be used to open and preview published updates to your app. To add this feature, you need to add `expo-updates@0.8.0` or newer to your app if it isn't already installed, and add a small additional integration in your `AppDelegate.m` and `MainApplication.java` files.
 
 1. [Install and set up `react-native-unimodules` in your project](../bare/installing-unimodules.md), if you have not already done so.
 2. [Install and set up `expo-updates` in your project](../bare/installing-updates.md), if you have not already done so.

--- a/docs/public/static/diffs/client/app-delegate-updates.diff
+++ b/docs/public/static/diffs/client/app-delegate-updates.diff
@@ -1,0 +1,20 @@
+diff --git a/ios/DevClientTest/AppDelegate.m b/ios/DevClientTest/AppDelegate.m
+index 3a55de0..efb70e1 100644
+--- a/ios/DevClientTest/AppDelegate.m
++++ b/ios/DevClientTest/AppDelegate.m
+@@ -17,6 +17,7 @@
+
+ #if defined(EX_DEV_LAUNCHER_ENABLED)
+ #include <EXDevLauncher/EXDevLauncherController.h>
++#import <EXUpdatesDevLauncherController.h>
+ #endif
+
+ #ifdef FB_SONARKIT_ENABLED
+@@ -60,6 +61,7 @@ static void InitializeFlipper(UIApplication *application) {
+   #ifdef DEBUG
+     #if defined(EX_DEV_LAUNCHER_ENABLED)
+       EXDevLauncherController *controller = [EXDevLauncherController sharedInstance];
++      controller.updatesInterface = [EXUpdatesDevLauncherController sharedInstance];
+       [controller startWithWindow:self.window delegate:self launchOptions:launchOptions];
+     #else
+       [self initializeReactNativeApp];

--- a/docs/public/static/diffs/client/main-activity-and-application.diff
+++ b/docs/public/static/diffs/client/main-activity-and-application.diff
@@ -69,6 +69,6 @@ index 78736bf..bce13b9 100644
 @@ -85,6 +87,7 @@ public class MainApplication extends Application implements ReactApplication {
     
 
-     initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
 +    DevLauncherController.initialize(this, getReactNativeHost());
+     initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
    }

--- a/docs/public/static/diffs/client/main-application-updates.diff
+++ b/docs/public/static/diffs/client/main-application-updates.diff
@@ -1,0 +1,28 @@
+diff --git a/android/app/src/main/java/com/expodevexample/MainApplication.java b/android/app/src/main/java/com/expodevexample/MainApplication.java
+index 15b21ef..f6f50f7 100644
+--- a/android/app/src/main/java/com/expodevexample/MainApplication.java
++++ b/android/app/src/main/java/com/expodevexample/MainApplication.java
+@@ -23,6 +23,7 @@ import expo.modules.devlauncher.DevLauncherController;
+ import expo.modules.permissions.PermissionsPackage;
+ import expo.modules.filesystem.FileSystemPackage;
+ import expo.modules.updates.UpdatesController;
++import expo.modules.updates.UpdatesDevLauncherController;
+
+ import java.lang.reflect.InvocationTargetException;
+ import java.util.Arrays;
+@@ -37,7 +38,7 @@ public class MainApplication extends Application implements ReactApplication {
+   private final ReactNativeHost mReactNativeHost = new ReactNativeHost(this) {
+     @Override
+     public boolean getUseDeveloperSupport() {
+-      return BuildConfig.DEBUG;
++      return DevLauncherController.getInstance().getUseDeveloperSupport();
+     }
+
+     @Override
+@@ -88,6 +89,7 @@ public class MainApplication extends Application implements ReactApplication {
+     }
+
+     DevLauncherController.initialize(this, getReactNativeHost());
++    DevLauncherController.getInstance().setUpdatesInterface(UpdatesDevLauncherController.initialize(this));
+     initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
+   }


### PR DESCRIPTION
[DRAFT] - Wait until releasing new versions of expo-dev-launcher/expo-updates before merging this.

# Why

Follow up to the dev-launcher/updates integration -- we want to let people know how to set this up in existing apps.

# How

After talking to @tcdavis , we decided to add an optional setup step at the end of the installation instructions that links to the complete expo-updates installation doc and has the diffs for the integration.

# Test Plan

Ran the docs site locally to ensure the diffs render correctly and the links work.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).