### PR TITLE
[eyw] use index.js as entry point

### DIFF
--- a/packages/expo-yarn-workspaces/CHANGELOG.md
+++ b/packages/expo-yarn-workspaces/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Use `index.js` as entry point. ([#13203](https://github.com/expo/expo/pull/13203) by [@axeldelafosse](https://github.com/axeldelafosse))
+
 ## 1.5.1 — 2021-04-20
 
 ### 🐛 Bug fixes

--- a/packages/expo-yarn-workspaces/README.md
+++ b/packages/expo-yarn-workspaces/README.md
@@ -22,9 +22,7 @@ Each Expo app in the repository that is intended to work with Yarn workspaces (a
 
 ### Define the entry module in the `"main"` field of each app's package.json
 
-The postinstall script determines the location of the generated entry module by looking at the `"main"` field in package.json. In a conventional Expo app, the value of the `"main"` field is `node_modules/expo/AppEntry.js`. In a workspace in the Expo repo, **specify `"__generated__/AppEntry.js"` as the value of the `"main"` field in package.json.**
-
-You can specify other paths too. The `.expo` directory is convenient since it already contains auto-generated files and is .gitignore'd.
+The postinstall script determines the location of the generated entry module by looking at the `"main"` field in package.json. In a conventional Expo app, the value of the `"main"` field is `node_modules/expo/AppEntry.js`. In a workspace in the Expo repo, **specify `"index.js"` as the value of the `"main"` field in package.json.** The file will be generated automatically by `expo-yarn-workspaces`.
 
 ### Create a file named `metro.config.js`
 


### PR DESCRIPTION
# Why

Recently found a bug with `expo-yarn-workspaces` and `expo-updates` when running `expo prebuild`. We need to replace the entry point to use `index.js` because `expo-updates` can't resolve the monorepo root automatically.

More context here: https://docs.google.com/presentation/d/10ChHPq5dhaFAGd-ZTRMzh17zqZWQcrUS7kwAeJLhOBg/edit#slide=id.gd49eb1375f_0_4 and here: https://exponent-internal.slack.com/archives/C020VQQ8WAE/p1622119621134100

# How

- Updated instructions to specify `index.js` instead of `__generated__/AppEntry.js`
- Also planning to update the example https://github.com/expo/examples/tree/master/with-yarn-workspaces