### PR TITLE
[expo-dev-client] Fix `react-native.config.js` not being added in `expo prebuild --platform android`

### DIFF
--- a/packages/expo-dev-client/CHANGELOG.md
+++ b/packages/expo-dev-client/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [plugin] Fix `react-native.config.js` not being added in `expo prebuild --platform android`.
+
 ### 💡 Others
 
 ## 0.1.3 — 2021-05-20

--- a/packages/expo-dev-client/CHANGELOG.md
+++ b/packages/expo-dev-client/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [plugin] Fix `react-native.config.js` not being added in `expo prebuild --platform android`.
+- [plugin] Fix `react-native.config.js` not being added in `expo prebuild --platform android`. ([#13204](https://github.com/expo/expo/pull/13204) by [@fson](https://github.com/fson))
 
 ### 💡 Others
 

--- a/packages/expo-dev-client/plugin/build/withDevClient.js
+++ b/packages/expo-dev-client/plugin/build/withDevClient.js
@@ -20,29 +20,29 @@ module.exports = {
 };
 `;
 function withReactNativeConfigJs(config) {
-    return config_plugins_1.withDangerousMod(config, [
-        'ios',
-        async (config) => {
-            const filename = path_1.default.join(config.modRequest.projectRoot, 'react-native.config.js');
-            try {
-                const config = fs_1.default.readFileSync(filename, 'utf8');
-                if (!config.includes('expo-dev-client/dependencies')) {
-                    throw new Error(`Could not add expo-dev-client dependencies to existing file ${filename}. See expo-dev-client installation instructions to add them manually.`);
-                }
-            }
-            catch (error) {
-                if (error.code === 'ENOENT') {
-                    // The file doesn't exist, so we create it.
-                    fs_1.default.writeFileSync(filename, REACT_NATIVE_CONFIG_JS);
-                }
-                else {
-                    throw error;
-                }
-            }
-            return config;
-        },
-    ]);
+    config = config_plugins_1.withDangerousMod(config, ['android', addReactNativeConfigAsync]);
+    config = config_plugins_1.withDangerousMod(config, ['ios', addReactNativeConfigAsync]);
+    return config;
 }
+const addReactNativeConfigAsync = async (config) => {
+    const filename = path_1.default.join(config.modRequest.projectRoot, 'react-native.config.js');
+    try {
+        const config = fs_1.default.readFileSync(filename, 'utf8');
+        if (!config.includes('expo-dev-client/dependencies')) {
+            throw new Error(`Could not add expo-dev-client dependencies to existing file ${filename}. See expo-dev-client installation instructions to add them manually.`);
+        }
+    }
+    catch (error) {
+        if (error.code === 'ENOENT') {
+            // The file doesn't exist, so we create it.
+            fs_1.default.writeFileSync(filename, REACT_NATIVE_CONFIG_JS);
+        }
+        else {
+            throw error;
+        }
+    }
+    return config;
+};
 function withDevClient(config) {
     config = app_plugin_2.default(config);
     config = app_plugin_1.default(config);

--- a/packages/expo-dev-client/plugin/src/withDevClient.ts
+++ b/packages/expo-dev-client/plugin/src/withDevClient.ts
@@ -1,4 +1,4 @@
-import { createRunOncePlugin, withDangerousMod } from '@expo/config-plugins';
+import { createRunOncePlugin, Mod, withDangerousMod } from '@expo/config-plugins';
 import { ExpoConfig } from '@expo/config-types';
 // @ts-expect-error missing types
 import withDevLauncher from 'expo-dev-launcher/app.plugin';
@@ -18,30 +18,31 @@ module.exports = {
 };
 `;
 
-function withReactNativeConfigJs(config: ExpoConfig) {
-  return withDangerousMod(config, [
-    'ios',
-    async config => {
-      const filename = path.join(config.modRequest.projectRoot, 'react-native.config.js');
-      try {
-        const config = fs.readFileSync(filename, 'utf8');
-        if (!config.includes('expo-dev-client/dependencies')) {
-          throw new Error(
-            `Could not add expo-dev-client dependencies to existing file ${filename}. See expo-dev-client installation instructions to add them manually.`
-          );
-        }
-      } catch (error) {
-        if (error.code === 'ENOENT') {
-          // The file doesn't exist, so we create it.
-          fs.writeFileSync(filename, REACT_NATIVE_CONFIG_JS);
-        } else {
-          throw error;
-        }
-      }
-      return config;
-    },
-  ]);
+function withReactNativeConfigJs(config: ExpoConfig): ExpoConfig {
+  config = withDangerousMod(config, ['android', addReactNativeConfigAsync]);
+  config = withDangerousMod(config, ['ios', addReactNativeConfigAsync]);
+  return config;
 }
+
+const addReactNativeConfigAsync: Mod = async config => {
+  const filename = path.join(config.modRequest.projectRoot, 'react-native.config.js');
+  try {
+    const config = fs.readFileSync(filename, 'utf8');
+    if (!config.includes('expo-dev-client/dependencies')) {
+      throw new Error(
+        `Could not add expo-dev-client dependencies to existing file ${filename}. See expo-dev-client installation instructions to add them manually.`
+      );
+    }
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      // The file doesn't exist, so we create it.
+      fs.writeFileSync(filename, REACT_NATIVE_CONFIG_JS);
+    } else {
+      throw error;
+    }
+  }
+  return config;
+};
 
 function withDevClient(config: ExpoConfig) {
   config = withDevMenu(config);


### PR DESCRIPTION
# Why

The dev client was not compiling when running `expo run:android` in a managed project because the `expo prebuild --platform android` command was not adding the `react-native.config.js` file that's needed for autolinking to work.

# How

There was a bug in the config plugin that made it only add React Native autolinking config when using `--platform ios` (or `--platform all`). Fixed the bug so that the modification runs both for Android and iOS.

# Test Plan

```
expo init --yes
yarn add expo-dev-client
yarn link expo-dev-client
expo prebuild --platform android --no-install
yarn unlink expo-dev-client
yarn install
expo run:android
```
Verified that the app started in the Android emulator successfully.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).