### PR TITLE
[dev-client][ios] Initialize only required modules

### DIFF
--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -12,6 +12,7 @@
 #import "EXDevLauncherRCTBridge.h"
 #import "EXDevLauncherManifestParser.h"
 #import "EXDevLauncherLoadingView.h"
+#import "EXDevLauncherInternal.h"
 #import "RCTPackagerConnection+EXDevLauncherPackagerConnectionInterceptor.h"
 
 #import <EXDevLauncher-Swift.h>
@@ -26,7 +27,7 @@
 #endif
 
 // Uncomment the below and set it to a React Native bundler URL to develop the launcher JS
-//#define DEV_LAUNCHER_URL "http://10.0.0.176:8090/index.bundle?platform=ios&dev=true&minify=false"
+//#define DEV_LAUNCHER_URL "http://localhost:8090/index.bundle?platform=ios&dev=true&minify=false"
 
 NSString *fakeLauncherBundleUrl = @"embedded://EXDevLauncher/dummy";
 
@@ -73,9 +74,10 @@ NSString *fakeLauncherBundleUrl = @"embedded://EXDevLauncher/dummy";
 - (NSArray<id<RCTBridgeModule>> *)extraModulesForBridge:(RCTBridge *)bridge
 {
   return @[
-    (id<RCTBridgeModule>)[[RCTDevMenu alloc] init],
-    [[RCTAsyncLocalStorage alloc] init],
-    [[EXDevLauncherLoadingView alloc] init]
+    (id<RCTBridgeModule>)[RCTDevMenu new],
+    [RCTAsyncLocalStorage new],
+    [EXDevLauncherLoadingView new],
+    [EXDevLauncherInternal new]
   ];
 }
 

--- a/packages/expo-dev-launcher/ios/EXDevLauncherInternal.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherInternal.m
@@ -9,7 +9,10 @@ NSString *ON_NEW_DEEP_LINK_EVENT = @"expo.modules.devlauncher.onnewdeeplink";
 
 @implementation EXDevLauncherInternal
 
-RCT_EXPORT_MODULE()
++ (NSString *)moduleName
+{
+  return @"EXDevLauncherInternal";
+}
 
 - (instancetype)init {
   if (self = [super init]) {

--- a/packages/expo-dev-launcher/ios/Headers/RCTCxxBridge+Private.h
+++ b/packages/expo-dev-launcher/ios/Headers/RCTCxxBridge+Private.h
@@ -1,0 +1,13 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+#import <React/RCTBridge+Private.h>
+
+@interface RCTCxxBridge (EXDevLauncherRCTCxxBridgePrivate)
+
+@property (nonatomic, weak, readonly) RCTBridge *parentBridge;
+
+- (NSArray<RCTModuleData *> *)_initializeModules:(NSArray<Class> *)modules
+                               withDispatchGroup:(dispatch_group_t)dispatchGroup
+                                lazilyDiscovered:(BOOL)lazilyDiscovered;
+
+@end

--- a/packages/expo-dev-launcher/ios/ReactNative/EXDevLauncherRCTBridge.m
+++ b/packages/expo-dev-launcher/ios/ReactNative/EXDevLauncherRCTBridge.m
@@ -1,9 +1,13 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
 #import "EXDevLauncherRCTBridge.h"
+#import "RCTCxxBridge+Private.h"
+
 #import <React/RCTPerformanceLogger.h>
 #import <React/RCTDevSettings.h>
 #import <React/RCTDevMenu.h>
+
+@import EXDevMenuInterface;
 
 @implementation EXDevLauncherRCTCxxBridge
 
@@ -20,6 +24,28 @@
 - (RCTDevMenu *)devMenu
 {
   return nil;
+}
+
+- (NSArray<RCTModuleData *> *)_initializeModules:(NSArray<Class> *)modules
+                               withDispatchGroup:(dispatch_group_t)dispatchGroup
+                                lazilyDiscovered:(BOOL)lazilyDiscovered
+{
+  NSArray<NSString *> *allowedModules = @[@"RCT", @"DevMenu"];
+  NSArray<Class> *filtredModuleList = [modules filteredArrayUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(id  _Nullable clazz, NSDictionary<NSString *,id> * _Nullable bindings) {
+    if ([clazz conformsToProtocol:@protocol(DevMenuExtensionProtocol)]) {
+      return true;
+    }
+    
+    NSString* clazzName = NSStringFromClass(clazz);
+    for (NSString *allowedModule in allowedModules) {
+      if ([clazzName hasPrefix:allowedModule]) {
+        return true;
+      }
+    }
+    return false;
+  }]];
+  
+  return [super _initializeModules:filtredModuleList withDispatchGroup:dispatchGroup lazilyDiscovered:lazilyDiscovered];
 }
 
 @end

--- a/packages/expo-dev-menu/ios/DevMenuRCTBridge.m
+++ b/packages/expo-dev-menu/ios/DevMenuRCTBridge.m
@@ -1,6 +1,8 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
 #import <EXDevMenu/DevMenuRCTBridge.h>
+#import <RCTCxxBridge+Private.h>
+
 #import <React/RCTPerformanceLogger.h>
 #import <React/RCTDevSettings.h>
 #import <React/RCTBridge+Private.h>
@@ -21,6 +23,24 @@
 - (RCTDevMenu *)devMenu
 {
   return nil;
+}
+
+- (NSArray<RCTModuleData *> *)_initializeModules:(NSArray<Class> *)modules
+                               withDispatchGroup:(dispatch_group_t)dispatchGroup
+                                lazilyDiscovered:(BOOL)lazilyDiscovered
+{
+  NSArray<NSString *> *allowedModules = @[@"RCT"];
+  NSArray<Class> *filtredModuleList = [modules filteredArrayUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(id  _Nullable clazz, NSDictionary<NSString *,id> * _Nullable bindings) {
+    NSString* clazzName = NSStringFromClass(clazz);
+    for (NSString *allowedModule in allowedModules) {
+      if ([clazzName hasPrefix:allowedModule]) {
+        return true;
+      }
+    }
+    return false;
+  }]];
+  
+  return [super _initializeModules:filtredModuleList withDispatchGroup:dispatchGroup lazilyDiscovered:lazilyDiscovered];
 }
 
 @end

--- a/packages/expo-dev-menu/ios/Headers/RCTCxxBridge+Private.h
+++ b/packages/expo-dev-menu/ios/Headers/RCTCxxBridge+Private.h
@@ -1,0 +1,13 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+#import <React/RCTBridge+Private.h>
+
+@interface RCTCxxBridge (DevMenuRCTCxxBridgePrivate)
+
+@property (nonatomic, weak, readonly) RCTBridge *parentBridge;
+
+- (NSArray<RCTModuleData *> *)_initializeModules:(NSArray<Class> *)modules
+                               withDispatchGroup:(dispatch_group_t)dispatchGroup
+                                lazilyDiscovered:(BOOL)lazilyDiscovered;
+
+@end


### PR DESCRIPTION
# Why

Initializes only those modules which are required by the `dev-launcher` or the `dev-menu`.

# How

Currently, we initilizes all modules on dev bridges (`dev-launcher` or `dev menu` bridge). Generally, it was working correctly and we didn't find a place where we can easily filtred modules list. However, some external modules may not work with this approach. For example, `Realm.js` freezes our UI. The code will be stuck in the while loop: https://github.com/realm/realm-js/blob/5b0eabf940d843b76835b6e889817f4052c0b5c3/react-native/ios/RealmReact/RealmReact.mm#L283-L285, cause we have two js threads which running at the same time (one for dev-launcher UI and the second for dev-menu). Realm starts on the dev-launcher thread, but then when we create the dev-menu, it tries to switch the js thread. However, this operation isn't possible, because we never invalidating the dev-launcher thread. So the code won't pass that loop.

- Made `EXDevLauncherInternal` truly internal - it shouldn't be exported.
- Filtered module list to initialized only required modules.

# Test Plan

- bare-expo ✅
- App with `realm.js`