### PR TITLE
Update MaskedView and add @react-native-masked-view/masked-view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Package-specific changes not released in any SDK will be added here just before 
 - Updated `react-native-reanimated` from `2.1.0` to `2.2.0`. ([#13161](https://github.com/expo/expo/pull/13161) by [@lukmccall](https://github.com/lukmccall))
 - Updated `react-native-svg` from `12.1.0` to `12.1.1`. ([#13154](https://github.com/expo/expo/pull/13154) by [@brentvatne](https://github.com/brentvatne))
 - Updated `react-native-webview` from `11.2.3` to `11.6.2`. ([#13188](https://github.com/expo/expo/pull/13188) by [@kudo](https://github.com/kudo))
-- Updated `@react-native-community/masked-view` to `@react-native-masked-view/masked-view` `0.2.4` (note: old package is compatible with underlying native code still)
+- Updated `@react-native-community/masked-view` to `@react-native-masked-view/masked-view` `0.2.4` (note: old package is compatible with underlying native code still) ([#13212](https://github.com/expo/expo/pull/13212) by [@brentvatne](https://github.com/brentvatne))
 
 ### 🛠 Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Package-specific changes not released in any SDK will be added here just before 
 - Updated `react-native-reanimated` from `2.1.0` to `2.2.0`. ([#13161](https://github.com/expo/expo/pull/13161) by [@lukmccall](https://github.com/lukmccall))
 - Updated `react-native-svg` from `12.1.0` to `12.1.1`. ([#13154](https://github.com/expo/expo/pull/13154) by [@brentvatne](https://github.com/brentvatne))
 - Updated `react-native-webview` from `11.2.3` to `11.6.2`. ([#13188](https://github.com/expo/expo/pull/13188) by [@kudo](https://github.com/kudo))
+- Updated `@react-native-community/masked-view` to `@react-native-masked-view/masked-view` `0.2.4` (note: old package is compatible with underlying native code still)
 
 ### 🛠 Breaking changes
 

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -93,7 +93,7 @@
     "@babel/runtime": "^7.5.5",
     "@react-native-community/async-storage": "~1.12.0",
     "@react-native-community/datetimepicker": "3.5.2",
-    "@react-native-community/masked-view": "^0.1.10",
+    "@react-native-masked-view/masked-view": "0.2.4",
     "@react-native-community/netinfo": "6.0.0",
     "@react-native-community/slider": "3.0.3",
     "@react-native-community/viewpager": "5.0.11",

--- a/docs/pages/versions/unversioned/sdk/masked-view.md
+++ b/docs/pages/versions/unversioned/sdk/masked-view.md
@@ -1,21 +1,23 @@
 ---
 title: MaskedView
-sourceCodeUrl: 'https://github.com/react-native-community/react-native-masked-view'
+sourceCodeUrl: 'https://github.com/react-native-masked-view/masked-view'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-**`@react-native-community/masked-view`** provides a masked view which only displays the pixels that overlap with the view rendered in its mask element.
+**`@react-native-masked-view/masked-view`** provides a masked view which only displays the pixels that overlap with the view rendered in its mask element.
 
-> ⚠️ Android support for this library is currently experimental and you may encounter inconsistencies in behavior across platforms. Please report issues you encounter to [react-native-community/react-native-masked-view/issues](https://github.com/react-native-community/react-native-masked-view).
+> ⚠️ You can only have one of either `@react-native-community/masked-view` or `@react-native-masked-view/masked-view` installed in your project at any given time. React Navigation v5.x requires `@react-native-community/masked-view`, so you should use that package instead if you are using React Navigation v5.x.
+
+> ⚠️ Android support for this library is experimental and you may encounter inconsistencies in behavior across platforms. Please report issues you encounter to [react-native-masked-view/masked-view/issues](https://github.com/react-native-masked-view/masked-view).
 
 <PlatformsSection android emulator ios simulator />
 
 ## Installation
 
-<InstallSection packageName="@react-native-community/masked-view" href="https://github.com/react-native-community/react-native-masked-view#getting-started" />
+<InstallSection packageName="@react-native-masked-view/masked-view" href="https://github.com/react-native-masked-view/masked-view#getting-started" />
 
 ## Usage
 
-See full documentation at [react-native-community/react-native-masked-view](https://github.com/react-native-community/react-native-masked-view).
+See full documentation at [react-native-masked-view/masked-view](https://github.com/react-native-masked-view/masked-view).

--- a/ios/Exponent.xcodeproj/project.pbxproj
+++ b/ios/Exponent.xcodeproj/project.pbxproj
@@ -5,7 +5,6 @@
 	};
 	objectVersion = 46;
 	objects = {
-
 /* Begin PBXBuildFile section */
 		0726F0592007E438004992E7 /* EXKernelAppRecord.m in Sources */ = {isa = PBXBuildFile; fileRef = 0726F0582007E438004992E7 /* EXKernelAppRecord.m */; };
 		0726F05C2007E446004992E7 /* EXKernelAppRegistry.m in Sources */ = {isa = PBXBuildFile; fileRef = 0726F05B2007E446004992E7 /* EXKernelAppRegistry.m */; };

--- a/tools/src/vendoring/config/expoGoConfig.ts
+++ b/tools/src/vendoring/config/expoGoConfig.ts
@@ -206,7 +206,7 @@ const config: VendoringTargetConfig = {
     // NOTE(brentvatne): masked-view has been renamed to
     // @react-native-masked-view/masked-view but we should synchronize moving
     // over to the new package name along with React Navigation
-    '@react-native-community/masked-view': {
+    '@react-native-masked-view/masked-view': {
       source: 'https://github.com/react-native-masked-view/masked-view',
     },
     '@react-native-community/viewpager': {

--- a/tools/src/vendoring/legacy.ts
+++ b/tools/src/vendoring/legacy.ts
@@ -391,8 +391,8 @@ const vendoredModulesConfig: { [key: string]: VendoredModuleConfig } = {
       )}s used for grabbing style of dialogs are being resolved properly.`,
     ],
   },
-  '@react-native-community/masked-view': {
-    repoUrl: 'https://github.com/react-native-community/react-native-masked-view',
+  '@react-native-masked-view/masked-view': {
+    repoUrl: 'https://github.com/react-native-masked-view/masked-view',
     installableInManagedApps: true,
     steps: [
       {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4476,7 +4476,7 @@
   dependencies:
     invariant "^2.2.4"
 
-"@react-native-community/masked-view@0.1.10", "@react-native-community/masked-view@^0.1.10":
+"@react-native-community/masked-view@0.1.10":
   version "0.1.10"
   resolved "https://registry.yarnpkg.com/@react-native-community/masked-view/-/masked-view-0.1.10.tgz#5dda643e19e587793bc2034dd9bf7398ad43d401"
   integrity sha512-rk4sWFsmtOw8oyx8SD3KSvawwaK7gRBSEIy2TAwURyGt+3TizssXP1r8nx3zY+R7v2vYYHXZ+k2/GULAT/bcaQ==
@@ -4495,6 +4495,11 @@
   version "5.0.11"
   resolved "https://registry.yarnpkg.com/@react-native-community/viewpager/-/viewpager-5.0.11.tgz#dbeb2d1b2452607926407c99e4de59c7db9e3019"
   integrity sha512-eboJwbDQjP1qJP3LFzVspgh88IGNF07S2qpU296j+4kL0inVuL+HXs81SuczMGtJmDZ4u19RNEBVq79of/h+jQ==
+
+"@react-native-masked-view/masked-view@0.2.4":
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/@react-native-masked-view/masked-view/-/masked-view-0.2.4.tgz#305a548abd47dee494a38f90016432d3a6e4164c"
+  integrity sha512-2Y9OXWHRutYmdyW+bNMaFTW8uTBpaaK20xdIFoVtqahEOO9++B+ut3CAWKPZcdRtb9ikG0LUKChGqMeocg0PGA==
 
 "@react-native-picker/picker@1.16.1":
   version "1.16.1"


### PR DESCRIPTION
# Why

Let people use the new version of this library.

# How

- `et update-vendored-module -m @react-native-masked-view/masked-view`.
- The native code is compatible with `@react-native-community/masked-view`, but React Navigation 5 requires `@react-native-community/masked-view` be installed. So I didn't switch over our usages in any of our `apps/` projects.
- I also made note of this quirk in our documentation.

# Test Plan

Run NCL and Home.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).