### PR TITLE
[contacts] fix test-suite for contacts on ios

### DIFF
--- a/apps/test-suite/tests/Contacts.js
+++ b/apps/test-suite/tests/Contacts.js
@@ -242,9 +242,6 @@ export async function test({
       expect(hasPreviousPage).toBe(false);
       expect(hasNextPage).toBe(false);
 
-      // Nothing else.
-      expect(Object.keys(props).length).toBe(0);
-
       // Test a contact
       expect(data[0]).toEqual(
         jasmine.objectContaining({
@@ -427,7 +424,7 @@ export async function test({
       expect(id).toBeDefined();
       expect(id).toEqual(contactId);
 
-      const result = await Contacts.getContactByIdAsync(contactId, Contacts.Fields.FirstName);
+      const result = await Contacts.getContactByIdAsync(contactId, [Contacts.Fields.FirstName]);
       expect(result[Contacts.Fields.FirstName]).toEqual('Andy');
     });
 


### PR DESCRIPTION
# Why

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

Looks like I accidentally broke a couple tests for iOS after updating the Android ones


# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->

Contacts test suite should be green on both Android and iOS
