### PR TITLE
[expo-updates-interface] rename iOS protocol to EXUpdatesExternalInterface

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- Renamed the iOS protocol in expo-updates-interface to EXUpdatesExternalInterface. ([#13214](https://github.com/expo/expo/pull/13214) by [@esamelson](https://github.com/esamelson))
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.h
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.h
@@ -3,7 +3,7 @@
 
 #import <UIKit/UIKit.h>
 
-#import <EXUpdatesInterface/EXUpdatesInterface.h>
+#import <EXUpdatesInterface/EXUpdatesExternalInterface.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, weak) RCTBridge * _Nullable appBridge;
 @property (nonatomic, strong) RCTBridge *launcherBridge;
 @property (nonatomic, strong) EXDevLauncherPendingDeepLinkRegistry *pendingDeepLinkRegistry;
-@property (nonatomic, strong) id<EXUpdatesInterface> updatesInterface;
+@property (nonatomic, strong) id<EXUpdatesExternalInterface> updatesInterface;
 
 + (instancetype)sharedInstance;
 

--- a/packages/expo-updates-interface/CHANGELOG.md
+++ b/packages/expo-updates-interface/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- Renamed the iOS protocol to EXUpdatesExternalInterface. ([#13214](https://github.com/expo/expo/pull/13214) by [@esamelson](https://github.com/esamelson))
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/packages/expo-updates-interface/ios/EXUpdatesInterface/EXUpdatesExternalInterface.h
+++ b/packages/expo-updates-interface/ios/EXUpdatesInterface/EXUpdatesExternalInterface.h
@@ -18,7 +18,7 @@ typedef BOOL (^EXUpdatesManifestBlock) (NSDictionary *manifest);
  * Protocol for modules that depend on expo-updates for loading production updates but do not want
  * to depend on expo-updates or delegate control to the singleton EXUpdatesAppController.
  */
-@protocol EXUpdatesInterface
+@protocol EXUpdatesExternalInterface
 
 @property (nonatomic, weak) id bridge;
 

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- Renamed the iOS protocol in expo-updates-interface to EXUpdatesExternalInterface. ([#13214](https://github.com/expo/expo/pull/13214) by [@esamelson](https://github.com/esamelson))
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesDevLauncherController.h
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesDevLauncherController.h
@@ -1,12 +1,12 @@
 //  Copyright © 2021 650 Industries. All rights reserved.
 
-#import <EXUpdatesInterface/EXUpdatesInterface.h>
+#import <EXUpdatesInterface/EXUpdatesExternalInterface.h>
 
 #import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface EXUpdatesDevLauncherController : NSObject <EXUpdatesInterface>
+@interface EXUpdatesDevLauncherController : NSObject <EXUpdatesExternalInterface>
 
 + (instancetype)sharedInstance;
 


### PR DESCRIPTION
# Why

#13088 added EXUpdatesInterface to the expo-updates-interface package and renamed the existing EXUpdatesInterface class in expo-updates to EXUpdatesModuleInterface.

However, it's possible that projects may include a newer version of dev-client & updates-interface, but an older version of expo-updates that still has the old EXUpdatesInterface class. This causes the iOS project to fail to compile.

# How

Rename the new class to EXUpdatesExternalInterface. Now no more packages include any class called `EXUpdatesInterface`, making version compatibility simpler.

# Test Plan

```
npx crna -t with-dev-client
yarn add expo-dev-client@next expo-updates@next
cd node_modules/expo-dev-launcher && rm -rf ios && cp -R ~/expo/expo/packages/expo-dev-launcher/ios ./ios
cd ../expo-updates && rm -rf ios && cp -R ~/expo/expo/packages/expo-updates/ios ./ios
cd ../expo-updates-interface && rm -rf ios && cp -R ~/expo/expo/packages/expo-updates-interface/ios ./ios
cd ../../ios && pod install
```
project builds and runs successfully ✅ 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).