### PR TITLE
[template] Reset Android theme manually

### DIFF
--- a/templates/expo-template-bare-minimum/android/app/src/main/java/com/helloworld/MainActivity.java
+++ b/templates/expo-template-bare-minimum/android/app/src/main/java/com/helloworld/MainActivity.java
@@ -13,6 +13,10 @@ import expo.modules.splashscreen.SplashScreenImageResizeMode;
 public class MainActivity extends ReactActivity {
   @Override
   protected void onCreate(Bundle savedInstanceState) {
+    // Set the theme to AppTheme BEFORE onCreate to support 
+    // coloring the background, status bar, and navigation bar.
+    // This is required for expo-splash-screen.
+    setTheme(R.style.AppTheme);
     super.onCreate(null);
     // SplashScreen.show(...) has to be called after super.onCreate(...)
     // Below line is handled by '@expo/configure-splash-screen' command and it's discouraged to modify it manually


### PR DESCRIPTION
# Why

- Alternative to extending the style https://github.com/expo/expo/pull/13196
- resolve ENG-937
- resolve ENG-1234
- resolve ENG-1231
- resolve ENG-1209
- resolve ENG-1208
- resolve ENG-937
- Resetting the style before rendering the view seems to provide the functionality we want.

## Before

https://user-images.githubusercontent.com/9664363/121289832-3808dd80-c8ab-11eb-9120-68f01a337b00.mp4

## After

https://user-images.githubusercontent.com/9664363/121289817-2f180c00-c8ab-11eb-989a-a5d6ed6560b0.mp4

# Test Plan

- in template, run `npm pack`
- else where: `expo init`

- Render: some text, no background view, a text input
- Set some of these values to try the working features:

```json
    "androidStatusBar": {
      "barStyle": "light-content",
      "backgroundColor": "#ff0000"
    },
    "androidNavigationBar": {
      "barStyle": "light-content",
      "backgroundColor": "#ffff00"
    },
    "android": {
      "backgroundColor": "#00ff00"
    },
```
- in project: `expo prebuild --template /path/to/template.tgz`
- `expo run:android` -- everything should be working as expected
