### PR TITLE
[android][ios][home] open Expo Go with expo.dev/expo-go universal link

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.java
+++ b/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.java
@@ -575,7 +575,7 @@ public class Kernel extends KernelInterface {
   private boolean shouldOpenUrl(@NonNull Uri uri) {
     String host = uri.getHost() != null ? uri.getHost() : "";
     String path = uri.getPath() != null ? uri.getPath() : "";
-    return !(host.equals("expo.io") && path.equals("/expo-go"));
+    return !((host.equals("expo.io") || host.equals("expo.dev")) && path.equals("/expo-go"));
   }
 
   private boolean openExperienceFromNotificationIntent(Intent intent) {

--- a/home/HomeApp.tsx
+++ b/home/HomeApp.tsx
@@ -120,7 +120,10 @@ export default function HomeApp() {
 // Certain links (i.e. 'expo.io/expo-go') should just open the HomeScreen
 function shouldOpenUrl(urlString: string) {
   const parsedUrl = url.parse(urlString);
-  return !(parsedUrl.hostname === 'expo.io' && parsedUrl.pathname === '/expo-go');
+  return !(
+    (parsedUrl.hostname === 'expo.io' || parsedUrl.hostname === 'expo.dev') &&
+    parsedUrl.pathname === '/expo-go'
+  );
 }
 
 const styles = StyleSheet.create({

--- a/home/HomeApp.tsx
+++ b/home/HomeApp.tsx
@@ -117,7 +117,7 @@ export default function HomeApp() {
   );
 }
 
-// Certain links (i.e. 'expo.io/expo-go') should just open the HomeScreen
+// Certain links (i.e. 'expo.dev/expo-go') should just open the HomeScreen
 function shouldOpenUrl(urlString: string) {
   const parsedUrl = url.parse(urlString);
   return !(

--- a/ios/Exponent/Kernel/Services/EXKernelLinkingManager.m
+++ b/ios/Exponent/Kernel/Services/EXKernelLinkingManager.m
@@ -271,7 +271,6 @@ NSString *kEXExpoLegacyDeepLinkSeparator = @"+";
   if (components.host) {
     return [components.host isEqualToString:@"exp.host"] ||
       [components.host isEqualToString:@"expo.io"] ||
-      [components.host isEqualToString:@"expo.dev"] ||
       [components.host isEqualToString:@"exp.direct"] ||
       [components.host isEqualToString:@"expo.test"] ||
       [components.host hasSuffix:@".exp.host"] ||

--- a/ios/Exponent/Kernel/Services/EXKernelLinkingManager.m
+++ b/ios/Exponent/Kernel/Services/EXKernelLinkingManager.m
@@ -271,6 +271,7 @@ NSString *kEXExpoLegacyDeepLinkSeparator = @"+";
   if (components.host) {
     return [components.host isEqualToString:@"exp.host"] ||
       [components.host isEqualToString:@"expo.io"] ||
+      [components.host isEqualToString:@"expo.dev"] ||
       [components.host isEqualToString:@"exp.direct"] ||
       [components.host isEqualToString:@"expo.test"] ||
       [components.host hasSuffix:@".exp.host"] ||

--- a/ios/Exponent/Supporting/Exponent.entitlements
+++ b/ios/Exponent/Supporting/Exponent.entitlements
@@ -13,6 +13,8 @@
 		<string>applinks:exp.host</string>
 		<string>applinks:expo.io</string>
 		<string>webcredentials:expo.io</string>
+		<string>applinks:expo.dev</string>
+		<string>webcredentials:expo.dev</string>
 	</array>
 	<key>com.apple.developer.icloud-container-identifiers</key>
 	<array>

--- a/template-files/android/AndroidManifest.xml
+++ b/template-files/android/AndroidManifest.xml
@@ -79,6 +79,15 @@
           android:host="expo.io"
           android:path="/expo-go"
           android:scheme="http"/>
+        
+        <data
+          android:host="expo.dev"
+          android:path="/expo-go"
+          android:scheme="https"/>
+        <data
+          android:host="expo.dev"
+          android:path="/expo-go"
+          android:scheme="http"/>
 
         <action android:name="android.intent.action.VIEW"/>
 

--- a/template-files/android/AndroidManifest.xml
+++ b/template-files/android/AndroidManifest.xml
@@ -84,10 +84,6 @@
           android:host="expo.dev"
           android:path="/expo-go"
           android:scheme="https"/>
-        <data
-          android:host="expo.dev"
-          android:path="/expo-go"
-          android:scheme="http"/>
 
         <action android:name="android.intent.action.VIEW"/>
 

--- a/template-files/android/AndroidManifest.xml
+++ b/template-files/android/AndroidManifest.xml
@@ -84,6 +84,10 @@
           android:host="expo.dev"
           android:path="/expo-go"
           android:scheme="https"/>
+        <data
+          android:host="expo.dev"
+          android:path="/expo-go"
+          android:scheme="http"/>
 
         <action android:name="android.intent.action.VIEW"/>
 


### PR DESCRIPTION
# Why

We want https://expo.dev/expo-go universal links to work with Expo Go. Intentionally, we don't want to add support for opening `https://expo.dev/@<username>/<slug>` links in Expo Go. Those links should always be opened by the website.

# How

We already have the `apple-app-site-association` file live on https://expo.dev, so all I needed to do was: 

- add new iOS entitlements for expo.dev `applinks` and `webcredentials`
- add expo.dev entries to Android manifest
- add expo.dev to `shouldOpenUrl` `host` checks

# Test Plan

Build Expo Go with your Expo Team Apple developer account and create + execute a shortcut that opens https://expo.dev/expo-go (or tap a link from a webpage). This link should open Expo Go, not the web browser like the current App Store release does.

## Android Demo

https://user-images.githubusercontent.com/12488826/121437223-efefc680-c94f-11eb-90aa-534744550db9.mp4

## iOS Demo

https://user-images.githubusercontent.com/12488826/121437283-09910e00-c950-11eb-9977-a687b51746c4.mp4

