### PR TITLE
fix: crash of file system when try to read cache dir file on android

### DIFF
--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 - Enable kotlin in all modules. ([#12716](https://github.com/expo/expo/pull/12716) by [@wschurman](https://github.com/wschurman))
 
+- crash of file system when try to read cache dir file on android. ([#12716](https://github.com/expo/expo/pull/13232) by [@nomi9995](https://github.com/nomi9995))
+
 ### 💡 Others
 
 - Migrated from `unimodules-file-system-interface` to `expo-modules-core`.

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -9,8 +9,7 @@
 ### 🐛 Bug fixes
 
 - Enable kotlin in all modules. ([#12716](https://github.com/expo/expo/pull/12716) by [@wschurman](https://github.com/wschurman))
-
-- crash of file system when try to read cache dir file on android. ([#12716](https://github.com/expo/expo/pull/13232) by [@nomi9995](https://github.com/nomi9995))
+- Fixed crash of file system when try to read cache dir file on android. ([#12716](https://github.com/expo/expo/pull/13232) by [@nomi9995](https://github.com/nomi9995))
 
 ### 💡 Others
 

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemModule.java
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemModule.java
@@ -234,10 +234,15 @@ public class FileSystemModule extends ExportedModule implements ActivityEventLis
   @ExpoMethod
   public void getInfoAsync(String uriStr, Map<String, Object> options, Promise promise) {
     try {
-      Uri uri = Uri.parse(uriStr);
-      ensurePermission(uri, Permission.READ);
+       Uri uri = Uri.parse(uriStr);
+       Uri absoluteUri = uri;
+       if ("file".equals(uri.getScheme())) {
+        uriStr = uriStr.substring(uriStr.indexOf(':') + 3);
+        absoluteUri = Uri.parse(uriStr);
+       }
+      ensurePermission(absoluteUri, Permission.READ);
       if ("file".equals(uri.getScheme())) {
-        File file = uriToFile(uri);
+        File file = uriToFile(absoluteUri);
         Bundle result = new Bundle();
         if (file.exists()) {
           result.putBoolean("exists", true);


### PR DESCRIPTION
fixed #5408
# Why
Should resolve to `{ exists: false }` instead of throwing
<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How
`getInfoAsync` throws an error `File <file path isn't readable>`
<!-- 
How did you build this feature or fix this bug and why? 
-->

# Steps to Reproduce
try to read file from `cacheDirectory` it will throw an exception which this PR has fixed
<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
### Reproducible Demo
https://snack.expo.io/@charliecruzan/getinfoasyncerror
