### PR TITLE
Add heroku to publishing options

### DIFF
--- a/docs/pages/distribution/publishing-websites.md
+++ b/docs/pages/distribution/publishing-websites.md
@@ -253,3 +253,43 @@ In case you want to change the header for hosting add the following config in `h
     }
   ]
 ```
+
+## [Heroku hosting](https://dashboard.heroku.com/apps/)
+
+### static.json
+
+- Add a `static.json` to select the web-build folder:
+
+```js
+{
+  "root": "web-build/",
+  "clean_urls": false
+}
+```
+
+- To enable client side routing add `"routes"`:
+
+```js
+{
+  "root": "web-build/",
+  "clean_urls": false,
+  "routes": {
+    "/**": "index.html"
+  }
+}
+```
+
+### Connect your app with Heroku
+
+- Create a new Heroku app
+
+- Connect your app via Heroku CLI or Github to deploy it
+
+
+### Heroku buildpack static
+
+- Add the `heroku-buildpack-static`. Go to Settings click on `Add buildpack` and paste [https://github.com/hone/heroku-buildpack-static](https://github.com/hone/heroku-buildpack-static) into the search bar and click `Save changes`.
+
+> Remove all other buildpacks if there are.
+
+- Deploy your app


### PR DESCRIPTION
Tested myself, a way to easily host static expo apps as a website on Heroku.

# Why

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).