### PR TITLE
[expo-av] Fixed an issue with Audio Interruption Mode not correctly being set on Android

### DIFF
--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - Fixed the web Video Fullscreen APIs in Safari ([#12258](https://github.com/expo/expo/pull/12258) by [@elliotdickison](https://github.com/elliotdickison))
 - Enable kotlin in all modules. ([#12716](https://github.com/expo/expo/pull/12716) by [@wschurman](https://github.com/wschurman))
+- Fixed an issue with Audio Interruption Mode not correctly being set on Android. ([#13236](https://github.com/expo/expo/pull/13236) by [@matt-oakes](https://github.com/matt-oakes))
 
 ### 💡 Others
 

--- a/packages/expo-av/android/src/main/java/expo/modules/av/AVManager.java
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/AVManager.java
@@ -339,6 +339,7 @@ public class AVManager implements LifecycleEventListener, AudioManager.OnAudioFo
     switch (interruptionModeInt) {
       case 1:
         mAudioInterruptionMode = AudioInterruptionMode.DO_NOT_MIX;
+        break;
       case 2:
       default:
         mAudioInterruptionMode = AudioInterruptionMode.DUCK_OTHERS;


### PR DESCRIPTION
# Why

The audio interruption mode was not correctly set when using this code:

```
await Audio.setAudioModeAsync({
    interruptionModeAndroid: Audio.INTERRUPTION_MODE_ANDROID_DO_NOT_MIX,
});
```

If you started audio in another app and then played audio in my app, it would duck the other audio, rather than interrupting it.

# How

The issue was caused by the case statement incorrectly falling through due to a lack of `break` statement. This caused the `mAudioInterruptionMode` value to first be set to the correct `DO_NOT_MIX` value, before then being set to `DUCK_OTHERS` incorrectly.

Adding the break statement is all that is needed to fix the issue.

# Test Plan

Tested this manually in my project.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).