### PR TITLE
[ios] use isUsingDeveloperTool where necessary

### DIFF
--- a/ios/Exponent/Kernel/AppLoader/AppFetcher/EXAppFetcher.m
+++ b/ios/Exponent/Kernel/AppLoader/AppFetcher/EXAppFetcher.m
@@ -38,7 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
   EXJavaScriptResource *jsResource = [[EXJavaScriptResource alloc] initWithBundleName:[self.dataSource bundleResourceNameForAppFetcher:self withManifest:manifest]
                                                                             remoteUrl:[EXApiUtil bundleUrlFromManifest:manifest]
-                                                                      devToolsEnabled:manifest.isDevelopmentMode];
+                                                                      devToolsEnabled:manifest.isUsingDeveloperTool];
   jsResource.abiVersion = [[EXVersions sharedInstance] availableSdkVersionForManifest:manifest];
   jsResource.requestTimeoutInterval = timeoutInterval;
 
@@ -66,7 +66,7 @@ NS_ASSUME_NONNULL_BEGIN
     // if this experience id encountered a loading error before, discard any cache we might have
     return EXCachedResourceWriteToCache;
   }
-  if (manifest.isDevelopmentMode) {
+  if (manifest.isUsingDeveloperTool) {
     return EXCachedResourceNoCache;
   }
   return EXCachedResourceWriteToCache;

--- a/ios/Exponent/Kernel/AppLoader/AppFetcher/EXAppFetcherWithTimeout.m
+++ b/ios/Exponent/Kernel/AppLoader/AppFetcher/EXAppFetcherWithTimeout.m
@@ -44,7 +44,7 @@ NS_ASSUME_NONNULL_BEGIN
 
   [self.appLoader fetchManifestWithCacheBehavior:EXManifestPrepareToCache success:^(EXUpdatesRawManifest * _Nonnull manifest) {
     self.manifest = manifest;
-    if (manifest.isDevelopmentMode && self.timer) {
+    if (manifest.isUsingDeveloperTool && self.timer) {
       // make sure we never time out in dev mode
       // this can happen because there is no cached manifest & therefore we fall back to default behavior w/ timer
       [self _stopTimer];

--- a/ios/Exponent/Kernel/AppLoader/EXAppLoader.m
+++ b/ios/Exponent/Kernel/AppLoader/EXAppLoader.m
@@ -213,7 +213,7 @@ NSTimeInterval const kEXJSBundleTimeout = 60 * 5;
   NSTimeInterval fallbackToCacheTimeout = kEXAppLoaderDefaultTimeout;
 
   // in case check for dev mode failed before, check again
-  if (manifest.isDevelopmentMode) {
+  if (manifest.isUsingDeveloperTool) {
     [self _startAppFetcher:[[EXAppFetcherDevelopmentMode alloc] initWithAppLoader:self]];
     return;
   }

--- a/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
+++ b/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
@@ -154,7 +154,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)supportsBundleReload
 {
   if (_optimisticManifest) {
-    return _optimisticManifest.isDevelopmentMode;
+    return _optimisticManifest.isUsingDeveloperTool;
   }
   return NO;
 }


### PR DESCRIPTION
# Why

if you build Expo Go on iOS on `master` and run a project in production mode (`expo r --no-dev --minify`), the project will enter an endless reload cycle

# How

bisected it down to https://github.com/expo/expo/pull/12631/files, and noticed that a couple call sites to 
```
areDevToolsEnabledWithManifest:manifest
```
were replaced with
```
manifest.isDevelopmentMode
```

where they should actually be replaced with 
```
manifest.isUsingDeveloperTool
```

# Test Plan

run a project in production mode, bundle should load properly
