### PR TITLE
[docs] remove on-page API content ToCs

### DIFF
--- a/docs/pages/versions/unversioned/sdk/accelerometer.md
+++ b/docs/pages/versions/unversioned/sdk/accelerometer.md
@@ -173,5 +173,3 @@ Subscribe for updates to the accelerometer.
 
 - **intervalMs (_number_)** Desired interval in milliseconds between
   accelerometer updates.
-
-#

--- a/docs/pages/versions/unversioned/sdk/device.md
+++ b/docs/pages/versions/unversioned/sdk/device.md
@@ -20,44 +20,6 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 import * as Device from 'expo-device';
 ```
 
-### Constants
-
-- [`Device.isDevice`](#deviceisdevice)
-- [`Device.brand`](#devicebrand)
-- [`Device.manufacturer`](#devicemanufacturer)
-- [`Device.modelName`](#devicemodelname)
-- [`Device.modelId`](#devicemodelid) (iOS only)
-- [`Device.designName`](#devicedesignname) (Android only)
-- [`Device.productName`](#deviceproductname) (Android only)
-- [`Device.deviceYearClass`](#devicedeviceyearclass)
-- [`Device.totalMemory`](#devicetotalmemory)
-- [`Device.supportedCpuArchitectures`](#devicesupportedcpuarchitectures)
-- [`Device.osName`](#deviceosname)
-- [`Device.osVersion`](#deviceosversion)
-- [`Device.osBuildId`](#deviceosbuildid)
-- [`Device.osInternalBuildId`](#deviceosinternalbuildid)
-- [`Device.osBuildFingerprint`](#deviceosbuildfingerprint) (Android only)
-- [`Device.platformApiLevel`](#deviceplatformapilevel) (Android only)
-- [`Device.deviceName`](#devicedevicename)
-
-### Methods
-
-- [`Device.getDeviceTypeAsync()`](#devicegetdevicetypeasync)
-- [`Device.getUptimeAsync()`](#devicegetuptimeasync)
-- [`Device.getMaxMemoryAsync()`](#devicegetmaxmemoryasync) (Android only)
-- [`Device.isRootedExperimentalAsync()`](#deviceisrootedexperimentalasync)
-- [`Device.isSideLoadingEnabledAsync()`](#deviceissideloadingenabledasync) (Android only)
-- [`Device.getPlatformFeaturesAsync()`](#devicegetplatformfeaturesasync) (Android only)
-- [`Device.hasPlatformFeatureAsync(feature)`](#devicehasplatformfeatureasyncfeature) (Android only)
-
-### Enum Types
-
-- [`Device.DeviceType`](#devicedevicetype)
-
-### Errors
-
-- [Error Codes](#error-codes)
-
 ## Constants
 
 ### `Device.isDevice`

--- a/docs/pages/versions/unversioned/sdk/network.md
+++ b/docs/pages/versions/unversioned/sdk/network.md
@@ -24,21 +24,6 @@ On Android, this module requires permissions to access the network and Wi-Fi sta
 import * as Network from 'expo-network';
 ```
 
-### Methods
-
-- [`Network.getNetworkStateAsync()`](#networkgetnetworkstateasync)
-- [`Network.getIpAddressAsync()`](#networkgetipaddressasync)
-- [`Network.getMacAddressAsync(interfaceName?)`](#networkgetmacaddressasyncinterfacename)
-- [`Network.isAirplaneModeEnabledAsync()`](#networkisairplanemodeenabledasync) (Android only)
-
-### Enum Types
-
-- [`Network.NetworkStateType`](#networknetworkstatetype)
-
-### Errors
-
-- [Error Codes](#error-codes)
-
 ## Methods
 
 ### `Network.getNetworkStateAsync()`

--- a/docs/pages/versions/unversioned/sdk/screen-orientation.md
+++ b/docs/pages/versions/unversioned/sdk/screen-orientation.md
@@ -54,41 +54,6 @@ Tick the `Requires Full Screen` checkbox in Xcode. It should be located under `P
 import * as ScreenOrientation from 'expo-screen-orientation';
 ```
 
-### Methods
-
-- [`ScreenOrientation.lockAsync(orientationLock)`](#screenorientationlockasyncorientationlock)
-- [`ScreenOrientation.lockPlatformAsync(platformInfo)`](#screenorientationlockplatformasyncplatforminfo)
-- [`ScreenOrientation.unlockAsync()`](#screenorientationunlockasync)
-- [`ScreenOrientation.getOrientationAsync()`](#screenorientationgetorientationasync)
-- [`ScreenOrientation.getOrientationLockAsync()`](#screenorientationgetorientationlockasync)
-- [`ScreenOrientation.getPlatformOrientationLockAsync()`](#screenorientationgetplatformorientationlockasync)
-- [`ScreenOrientation.supportsOrientationLockAsync(orientationLock)`](#screenorientationsupportsorientationlockasyncorientationlock)
-- [`ScreenOrientation.addOrientationChangeListener(listener)`](#screenorientationaddorientationchangelistenerlistener)
-- [`ScreenOrientation.removeOrientationChangeListeners()`](#screenorientationremoveorientationchangelisteners)
-- [`ScreenOrientation.removeOrientationChangeListener(subscription)`](#screenorientationremoveorientationchangelistenersubscription)
-
-### Enum Types
-
-- [`ScreenOrientation.Orientation`](#screenorientationorientation)
-- [`ScreenOrientation.OrientationLock`](#screenorientationorientationlock)
-- [`ScreenOrientation.SizeClassIOS`](#screenorientationsizeclassios)
-- [`ScreenOrientation.WebOrientationLock`](#screenorientationweborientationlock)
-
-### Object Types
-
-- [`ScreenOrientation.PlatformOrientationInfo`](#screenorientationplatformorientationinfo)
-- [`ScreenOrientation.ScreenOrientationInfo`](#screenorientationscreenorientationinfo)
-- [`ScreenOrientation.OrientationChangeEvent`](#screenorientationorientationchangeevent)
-- [`Subscription`](#subscription)
-
-### Function Types
-
-- [`ScreenOrientation.OrientationChangeListener`](#screenorientationorientationchangelistener)
-
-### Errors
-
-- [Error Codes](#error-codes)
-
 ## Methods
 
 ### `ScreenOrientation.lockAsync(orientationLock)`


### PR DESCRIPTION
# Why

Since ToC component has been added on the right side of the page, the on-page API content ToCs are redundant.

# How

This PR removes on-page API ToCs and clears the redundant header at the end of `ScreenOrientation` page.

# Test Plan

Changes have been tested running docs website on `localhost`.