### PR TITLE
[android] Fix duplicated libraries build break on linux

### DIFF
--- a/android/expoview/build.gradle
+++ b/android/expoview/build.gradle
@@ -156,7 +156,18 @@ android {
   packagingOptions {
     println "Native libs debug enabled: ${debugNativeLibraries}"
     doNotStrip debugNativeLibraries ? "**/**/*.so" : ''
-    excludes = ["**/libc++_shared.so"]
+
+    // Gradle will add cmake target dependencies into packaging.
+    // Theses files are intermediated linking files to build reanimated and should not be in final package.
+    excludes = [
+      "**/libc++_shared.so",
+      "**/libreactnativejni.so",
+      "**/libglog.so",
+      "**/libjscexecutor.so",
+      "**/libfbjni.so",
+      "**/libfolly_json.so",
+      "**/libhermes.so",
+    ]
   }
 
   configurations {


### PR DESCRIPTION
# Why

reanimated tries to link some react native shared libraries during cmake building.
the interesting thing especially on linux, for gradle cmake integration, the dependency libraries will be packed as well.
and this will cause the duplicated libraries problem.
this should be somehow an issue from mixing ndk-build and cmake.

# How

further exclude reanimated dependencies. 

# Test Plan

CI green