### PR TITLE
[docs] Add barcode-scanner permission APIs for current SDKs

### DIFF
--- a/docs/pages/versions/unversioned/sdk/bar-code-scanner.md
+++ b/docs/pages/versions/unversioned/sdk/bar-code-scanner.md
@@ -129,7 +129,7 @@ import { BarCodeScanner } from 'expo-barcode-scanner';
 
 ### `BarCodeScanner.requestPermissionsAsync()`
 
-Asks the user to grant permissions for accessing camera.
+Asks the user to grant permissions for accessing the camera.
 
 On iOS this will require apps to specify the `NSCameraUsageDescription` entry in the `Info.plist`
 
@@ -139,7 +139,7 @@ A promise that resolves to an object of type [PermissionResponse](permissions.md
 
 ### `BarCodeScanner.getPermissionsAsync()`
 
-Checks user's permissions for accessing camera.
+Checks user's permissions for accessing the camera.
 
 #### Returns
 

--- a/docs/pages/versions/v39.0.0/sdk/bar-code-scanner.md
+++ b/docs/pages/versions/v39.0.0/sdk/bar-code-scanner.md
@@ -123,6 +123,24 @@ import { BarCodeScanner } from 'expo-barcode-scanner';
 
 ## Methods
 
+### `BarCodeScanner.requestPermissionsAsync()`
+
+Asks the user to grant permissions for accessing the camera.
+
+On iOS this will require apps to specify the `NSCameraUsageDescription` entry in the `Info.plist`
+
+#### Returns
+
+A promise that resolves to an object of type [PermissionResponse](permissions.md#permissionresponse).
+
+### `BarCodeScanner.getPermissionsAsync()`
+
+Checks user's permissions for accessing the camera.
+
+#### Returns
+
+A promise that resolves to an object of type [PermissionResponse](permissions.md#permissionresponse).
+
 ### `BarCodeScanner.scanFromURLAsync(url, barCodeTypes)`
 
 Scan bar codes from the image given by the URL.

--- a/docs/pages/versions/v40.0.0/sdk/bar-code-scanner.md
+++ b/docs/pages/versions/v40.0.0/sdk/bar-code-scanner.md
@@ -127,6 +127,24 @@ import { BarCodeScanner } from 'expo-barcode-scanner';
 
 ## Methods
 
+### `BarCodeScanner.requestPermissionsAsync()`
+
+Asks the user to grant permissions for accessing the camera.
+
+On iOS this will require apps to specify the `NSCameraUsageDescription` entry in the `Info.plist`
+
+#### Returns
+
+A promise that resolves to an object of type [PermissionResponse](permissions.md#permissionresponse).
+
+### `BarCodeScanner.getPermissionsAsync()`
+
+Checks user's permissions for accessing the camera.
+
+#### Returns
+
+A promise that resolves to an object of type [PermissionResponse](permissions.md#permissionresponse).
+
 ### `BarCodeScanner.scanFromURLAsync(url, barCodeTypes)`
 
 Scan bar codes from the image given by the URL.

--- a/docs/pages/versions/v41.0.0/sdk/bar-code-scanner.md
+++ b/docs/pages/versions/v41.0.0/sdk/bar-code-scanner.md
@@ -127,6 +127,24 @@ import { BarCodeScanner } from 'expo-barcode-scanner';
 
 ## Methods
 
+### `BarCodeScanner.requestPermissionsAsync()`
+
+Asks the user to grant permissions for accessing the camera.
+
+On iOS this will require apps to specify the `NSCameraUsageDescription` entry in the `Info.plist`
+
+#### Returns
+
+A promise that resolves to an object of type [PermissionResponse](permissions.md#permissionresponse).
+
+### `BarCodeScanner.getPermissionsAsync()`
+
+Checks user's permissions for accessing the camera.
+
+#### Returns
+
+A promise that resolves to an object of type [PermissionResponse](permissions.md#permissionresponse).
+
 ### `BarCodeScanner.scanFromURLAsync(url, barCodeTypes)`
 
 Scan bar codes from the image given by the URL.


### PR DESCRIPTION
# Why

Current docs (SDK 41) does not list the `requestPermissionsAsync` and `getPermissionsAsync` methods for `expo-barcode-scanner`, which is what you need to use in SDK 41 because `expo-permissions` is deprecated. They were added to the `unversioned` docs, but not to the current SDK docs. Checked and found that these methods have been part of `expo-barcode-scanner` for a long time and updated the SDK docs accordingly. 

# How

- Add `requestPermissionsAsync` and `getPermissionsAsync` for SDK 41, 40 & 39
- Replace `for accessing camera` with `for accessing the camera`

# Test Plan

- `yarn dev`
- Verified barcode-scanner API docs for SDK 41, 40 and 39
