### PR TITLE
[ios][android] upgrade fb audience network

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -118,9 +118,6 @@ dependencies {
   // Our dependencies from ExpoView
   // DON'T ADD ANYTHING HERE THAT ISN'T IN EXPOVIEW. ONLY COPY THINGS FROM EXPOVIEW TO HERE.
   implementation 'androidx.appcompat:appcompat:1.2.0'
-  implementation('com.facebook.android:audience-network-sdk:5.1.1') {
-    exclude module: 'play-services-ads'
-  }
   compileOnly 'org.glassfish:javax.annotation:3.1.1'
   implementation 'com.jakewharton:butterknife:10.2.1'
   implementation 'de.greenrobot:eventbus:2.4.0'

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -7,7 +7,7 @@ PODS:
     - Google-Mobile-Ads-SDK (= 7.69.0)
   - ABI39_0_0EXAdsFacebook (8.4.0):
     - ABI39_0_0UMCore
-    - FBAudienceNetwork (= 6.3.0)
+    - FBAudienceNetwork (= 6.5.0)
   - ABI39_0_0EXAmplitude (8.3.1):
     - ABI39_0_0UMConstantsInterface
     - ABI39_0_0UMCore
@@ -547,7 +547,7 @@ PODS:
     - Google-Mobile-Ads-SDK (= 7.69.0)
   - ABI40_0_0EXAdsFacebook (8.4.1):
     - ABI40_0_0UMCore
-    - FBAudienceNetwork (= 6.3.0)
+    - FBAudienceNetwork (= 6.5.0)
   - ABI40_0_0EXAmplitude (9.0.0):
     - ABI40_0_0UMConstantsInterface
     - ABI40_0_0UMCore
@@ -1106,7 +1106,7 @@ PODS:
   - ABI41_0_0EXAdsFacebook (10.0.0):
     - ABI41_0_0UMCore
     - ABI41_0_0UMPermissionsInterface
-    - FBAudienceNetwork (= 6.3.0)
+    - FBAudienceNetwork (= 6.5.0)
   - ABI41_0_0EXAmplitude (10.1.0):
     - ABI41_0_0UMConstantsInterface
     - ABI41_0_0UMCore
@@ -1729,7 +1729,7 @@ PODS:
     - UMCore
   - EXAdsFacebook (10.0.4):
     - ExpoModulesCore
-    - FBAudienceNetwork (= 6.3.0)
+    - FBAudienceNetwork (= 6.5.0)
     - UMCore
   - EXAmplitude (10.1.0):
     - Amplitude (~> 6.0.0)
@@ -1934,7 +1934,7 @@ PODS:
     - FBSDKCoreKit (~> 9.2.0)
   - FacebookSDK/LoginKit (9.2.0):
     - FacebookSDK/CoreKit
-  - FBAudienceNetwork (6.3.0):
+  - FBAudienceNetwork (6.5.0):
     - FBSDKCoreKit/Basics (>= 7.0.1)
   - FBLazyVector (0.63.2)
   - FBReactNativeSpec (0.63.2):
@@ -3672,7 +3672,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   ABI39_0_0-lottie-react-native: f67bc5229cd919107137b81045e1a72e18afc597
   ABI39_0_0EXAdsAdMob: 409abe0403cc5b02e6240c5a0aa4d79112e4ced1
-  ABI39_0_0EXAdsFacebook: ba961283c441792855ddc67ff13715fbac9be4d3
+  ABI39_0_0EXAdsFacebook: 45b09dadc3c7f63d84b92be7705c7bcefa09b18b
   ABI39_0_0EXAmplitude: 75a77f8459efe03dd46fd79e1ebf5525599dcda6
   ABI39_0_0EXAppAuth: da5325b3b2fece50f55a8562ff3a15df5df318c1
   ABI39_0_0EXAppleAuthentication: 2f97cbd679c6ada55f480c559b89ff9d8151d66d
@@ -3774,7 +3774,7 @@ SPEC CHECKSUMS:
   ABI39_0_0Yoga: 341913ed0ab0e924b93cd1bd4200267d74013d8b
   ABI40_0_0-lottie-react-native: 26e0e92bec37b7d428d850d6d33c0327df520bf7
   ABI40_0_0EXAdsAdMob: 8778f0ee1aac15a7f590c26609d9812142366935
-  ABI40_0_0EXAdsFacebook: ff83a8c50cd306885da97b4b4c71f14f7ef927b2
+  ABI40_0_0EXAdsFacebook: 2806ff4ba9bec16e3b3586af16a18db59802ee44
   ABI40_0_0EXAmplitude: fb7793f57385650c460819f1b83ab58ca99ac376
   ABI40_0_0EXAppAuth: 0bc2ff698131a99c3fa6fef0ec97ecfabb45a8ae
   ABI40_0_0EXAppleAuthentication: 10cb5a2248faa299df924b386569b2003456b2a8
@@ -3874,7 +3874,7 @@ SPEC CHECKSUMS:
   ABI40_0_0UMTaskManagerInterface: 917e9f9d1b08c15036451761a053689a798101bb
   ABI40_0_0Yoga: dc519b656d9f26f0e4b824dc71349a8e2ce7d183
   ABI41_0_0EXAdsAdMob: ec981aa80fb068429204ba72b8841c34e8883649
-  ABI41_0_0EXAdsFacebook: 65e044024c4708662391398c7a331f000237ccf4
+  ABI41_0_0EXAdsFacebook: dd45611db9fd3c1f8f73554daf39685c97c647b6
   ABI41_0_0EXAmplitude: ef0e7cc62eb3cdab3bb438cb04ce1b9ea9732cd6
   ABI41_0_0EXAppAuth: de2f21f6133535a77039a21235dc0525ddafb16d
   ABI41_0_0EXAppleAuthentication: 5ced2cc582ba5f0f26d8e4c5247bd2b021f7a1ca
@@ -3985,7 +3985,7 @@ SPEC CHECKSUMS:
   CocoaLumberjack: 2f44e60eb91c176d471fdba43b9e3eae6a721947
   DoubleConversion: cde416483dac037923206447da6e1454df403714
   EXAdsAdMob: ce6bd5c87317b12cbf9743e95c9e82dd21b7994c
-  EXAdsFacebook: 66287787c175c7d3eb5f7af9b8705163b4b44ee6
+  EXAdsFacebook: f1bede7a3e30b397e518a9cf60538795f41ca8d0
   EXAmplitude: bb4870721d97deeee4afa42bba2deb179d180f2e
   EXAppAuth: aadce7faa2cf26e33e8123eeaacd73fd9655138c
   EXAppleAuthentication: e6bb6f9ffe84e52b04a36f00220456da07694c3d
@@ -4052,7 +4052,7 @@ SPEC CHECKSUMS:
   EXVideoThumbnails: 6d5a5d7c2c5f631b1950b1e8b2a0305ab741b9b4
   EXWebBrowser: 0b466c50e5ff61c9758095d49d5081e3229d77ac
   FacebookSDK: 4b9bb8e2824898b47f18c666dc145c09b40609e6
-  FBAudienceNetwork: 58b4d0f2359783e5bc9ee59f138b4fda43173ac4
+  FBAudienceNetwork: cfe55330dcc4e9a1df083c34a346ca7f8e32951e
   FBLazyVector: 3ef4a7f62e7db01092f9d517d2ebc0d0677c4a37
   FBReactNativeSpec: dc7fa9088f0f2a998503a352b0554d69a4391c5a
   FBSDKCoreKit: dace5abafc2fd9272733e6d027bcf18102712117

--- a/ios/versioned-react-native/ABI39_0_0/Expo/EXAdsFacebook/ABI39_0_0EXAdsFacebook.podspec
+++ b/ios/versioned-react-native/ABI39_0_0/Expo/EXAdsFacebook/ABI39_0_0EXAdsFacebook.podspec
@@ -17,5 +17,5 @@ Pod::Spec.new do |s|
   s.requires_arc   = true
 
   s.dependency 'ABI39_0_0UMCore'
-  s.dependency 'FBAudienceNetwork', $FBAudienceNetworkVersion || '6.3.0'
+  s.dependency 'FBAudienceNetwork', $FBAudienceNetworkVersion || '6.5.0'
 end

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXAdsFacebook/ABI40_0_0EXAdsFacebook.podspec
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXAdsFacebook/ABI40_0_0EXAdsFacebook.podspec
@@ -17,5 +17,5 @@ Pod::Spec.new do |s|
   s.requires_arc   = true
 
   s.dependency 'ABI40_0_0UMCore'
-  s.dependency 'FBAudienceNetwork', $FBAudienceNetworkVersion || '6.3.0'
+  s.dependency 'FBAudienceNetwork', $FBAudienceNetworkVersion || '6.5.0'
 end

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXAdsFacebook/ABI41_0_0EXAdsFacebook.podspec
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXAdsFacebook/ABI41_0_0EXAdsFacebook.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
 
   s.dependency 'ABI41_0_0UMCore'
   s.dependency 'ABI41_0_0UMPermissionsInterface'
-  s.dependency 'FBAudienceNetwork', $FBAudienceNetworkVersion || '6.3.0'
+  s.dependency 'FBAudienceNetwork', $FBAudienceNetworkVersion || '6.5.0'
 
   if !$ExpoUseSources&.include?(package['name']) && ENV['EXPO_USE_SOURCE'].to_i == 0 && File.exist?("#{s.name}.xcframework") && Gem::Version.new(Pod::VERSION) >= Gem::Version.new('1.10.0')
     s.source_files = "#{s.name}/**/*.h"

--- a/packages/expo-ads-facebook/CHANGELOG.md
+++ b/packages/expo-ads-facebook/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Enable kotlin in all modules. ([#12716](https://github.com/expo/expo/pull/12716) by [@wschurman](https://github.com/wschurman))
+- Upgraded underlying native libraries to v6.5.0.
 
 ### 💡 Others
 

--- a/packages/expo-ads-facebook/CHANGELOG.md
+++ b/packages/expo-ads-facebook/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🐛 Bug fixes
 
 - Enable kotlin in all modules. ([#12716](https://github.com/expo/expo/pull/12716) by [@wschurman](https://github.com/wschurman))
-- Upgraded underlying native libraries to v6.5.0.
+- Upgraded underlying native libraries to v6.5.0. ([#13258](https://github.com/expo/expo/pull/13258) by [@cruzach](https://github.com/cruzach))
 
 ### 💡 Others
 

--- a/packages/expo-ads-facebook/android/build.gradle
+++ b/packages/expo-ads-facebook/android/build.gradle
@@ -79,7 +79,7 @@ repositories {
 
 dependencies {
   unimodule 'unimodules-core'
-  api "com.facebook.android:audience-network-sdk:${safeExtGet('fbAudienceNetworkVersion', '6.3.0')}"
+  api "com.facebook.android:audience-network-sdk:${safeExtGet('fbAudienceNetworkVersion', '6.5.0')}"
 
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${safeExtGet('kotlinVersion', '1.4.21')}"
 }

--- a/packages/expo-ads-facebook/ios/EXAdsFacebook.podspec
+++ b/packages/expo-ads-facebook/ios/EXAdsFacebook.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
 
   s.dependency 'UMCore'
   s.dependency 'ExpoModulesCore'
-  s.dependency 'FBAudienceNetwork', $FBAudienceNetworkVersion || '6.3.0'
+  s.dependency 'FBAudienceNetwork', $FBAudienceNetworkVersion || '6.5.0'
 
   if !$ExpoUseSources&.include?(package['name']) && ENV['EXPO_USE_SOURCE'].to_i == 0 && File.exist?("#{s.name}.xcframework") && Gem::Version.new(Pod::VERSION) >= Gem::Version.new('1.10.0')
     s.source_files = "#{s.name}/**/*.h"


### PR DESCRIPTION
# Why

closes https://github.com/expo/expo/issues/13185

# How

upgraded to most recent version on ios and android

also removed an old version from `android/app/build.gradle`. It says in that file not to add anything that isn't in expoview, and that dependency is **not** in `android/expoview/build.gradle`

# Test Plan

NCL Expo Go on android and ios
