### PR TITLE
[segment][android] upgrade segment version v4.9.4

### DIFF
--- a/packages/expo-analytics-segment/CHANGELOG.md
+++ b/packages/expo-analytics-segment/CHANGELOG.md
@@ -9,6 +9,8 @@
 ### 🐛 Bug fixes
 
 - Enable kotlin in all modules. ([#12716](https://github.com/expo/expo/pull/12716) by [@wschurman](https://github.com/wschurman))
+- Update Android segment package from `v4.8.2` to `v4.9.2` . ([#13263](https://github.com/expo/expo/pull/13263) by [@ajsmth](https://github.com/ajsmth))
+
 
 ### 💡 Others
 

--- a/packages/expo-analytics-segment/android/build.gradle
+++ b/packages/expo-analytics-segment/android/build.gradle
@@ -76,7 +76,7 @@ dependencies {
   unimodule "unimodules-core"
   unimodule "expo-modules-core"
 
-  api 'com.segment.analytics.android:analytics:4.8.2'
+  api 'com.segment.analytics.android:analytics:4.9.4'
   api 'com.segment.analytics.android.integrations:firebase:1.2.0'
 
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${safeExtGet('kotlinVersion', '1.4.21')}"

--- a/packages/expo-analytics-segment/android/src/main/java/expo/modules/analytics/segment/SegmentModule.java
+++ b/packages/expo-analytics-segment/android/src/main/java/expo/modules/analytics/segment/SegmentModule.java
@@ -135,6 +135,7 @@ public class SegmentModule extends ExportedModule {
   @ExpoMethod
   public void initialize(final String writeKey, Promise promise) {
     Analytics.Builder builder = new Analytics.Builder(mContext, writeKey);
+    builder.experimentalUseNewLifecycleMethods(false);
     builder.tag(Integer.toString(sCurrentTag++));
     builder.use(FirebaseIntegration.FACTORY);
     mClient = builder.build();


### PR DESCRIPTION
# Why

Closes #13128 and fixes Segment test-suite 

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

Looks like the package authors have recently added a flag that can turn off the `addObserver()` call that was resulting in this uncaught error: 

https://github.com/segmentio/analytics-android/pull/734

Note that segment provides its own SDK for react-native which also turns this flag off, as they've noted its not needed in RN

# Test Plan

- test-suite for Segment should be fixed (`Segment.alias` tests were failing) 
# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).