### PR TITLE
[CI][Android] Fix `The following variables are used in this project, but they are set to NOTFOUND`

### DIFF
--- a/android/expoview/build.gradle
+++ b/android/expoview/build.gradle
@@ -738,6 +738,8 @@ tasks.whenTaskAdded { task ->
     task.dependsOn(extractAARHeaders)
     task.dependsOn(extractSOFiles)
     task.dependsOn(":ReactAndroid:packageReactNdkLibs")
+  } else if (task.name.startsWith('generateJsonModel')) {
+    task.dependsOn(":ReactAndroid:packageReactNdkLibs")
   }
 }
 


### PR DESCRIPTION
# Why

Fixes:
```
* What went wrong:
Execution failed for task ':expoview:generateJsonModelDebug'.
> /home/runner/work/expo/expo/android/expoview/CMakeLists.txt : C/C++ debug|x86_64 : CMake Error: The following variables are used in this project, but they are set to NOTFOUND.
  Please set them or make sure they are set and tested correctly in the CMake files:
  FBJNI_LIB
      linked by target "reanimated" in directory /home/runner/work/expo/expo/android/expoview
  FOLLY_JSON_LIB
      linked by target "reanimated" in directory /home/runner/work/expo/expo/android/expoview
  GLOG_LIB
      linked by target "reanimated" in directory /home/runner/work/expo/expo/android/expoview
  JSEXECUTOR_LIB
      linked by target "reanimated" in directory /home/runner/work/expo/expo/android/expoview
  REACT_NATIVE_JNI_LIB
      linked by target "reanimated" in directory /home/runner/work/expo/expo/android/expoview
```

# How

`generateJsonModel` is triggering the CMake that is trying to parse the native project. However, to build reanimated we need to have access to the react NDKs libs. So I've rearranged the task order to make sure that the `generateJsonModel` will be triggered later than `packageReactNdkLibs`.

# Test Plan

- local test ✅