### PR TITLE
Fix Tracking Transparency Warning

### DIFF
--- a/docs/pages/versions/unversioned/sdk/tracking-transparency.md
+++ b/docs/pages/versions/unversioned/sdk/tracking-transparency.md
@@ -23,7 +23,7 @@ For more information on Apple's new App Tracking Transparency framework, please 
 <SnackInline label='Basic tracking transparency usage' dependencies={['expo-tracking-transparency']}>
 
 ```jsx
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Text, StyleSheet, View } from 'react-native';
 import { requestTrackingPermissionsAsync } from 'expo-tracking-transparency';
 

--- a/docs/pages/versions/v41.0.0/sdk/tracking-transparency.md
+++ b/docs/pages/versions/v41.0.0/sdk/tracking-transparency.md
@@ -25,7 +25,7 @@ For more information on Apple's new App Tracking Transparency framework, please 
 <SnackInline label='Basic tracking transparency usage' dependencies={['expo-tracking-transparency']}>
 
 ```jsx
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Text, StyleSheet, View } from 'react-native';
 import { requestTrackingPermissionsAsync } from 'expo-tracking-transparency';
 


### PR DESCRIPTION
Import `useEffect` to fix `'useEffect' is not defined` warning

# Why

I tried to run the Snack Example & found this warning, so this PR fixes the warning caused by a missed import.

# How

I fixed the bug in the Snack example.

# Test Plan

The fix was tested in the same Snack example

# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).