### PR TITLE
[ios] Use stable manifest ID where applicable

### DIFF
--- a/home/storage/LocalStorage.ts
+++ b/home/storage/LocalStorage.ts
@@ -93,7 +93,7 @@ async function removeSessionAsync(): Promise<void> {
 // adds a hook for native code to query Home's history.
 // needed for routing push notifications in Home.
 addListenerWithNativeCallback('ExponentKernel.getHistoryUrlForExperienceId', async event => {
-  const { experienceId } = event;
+  const { experienceId } = event; // scopeKey
   let history = await getHistoryAsync();
   history = history.sort((item1, item2) => {
     // date descending -- we want to pick the most recent experience with this id,
@@ -103,7 +103,14 @@ addListenerWithNativeCallback('ExponentKernel.getHistoryUrlForExperienceId', asy
     const item1time = item1.time ? item1.time : 0;
     return item2time - item1time;
   });
-  const historyItem = history.find(item => item.manifest && item.manifest.id === experienceId);
+  // TODO(wschurman): only check for scope key in the future when most manifests contain it
+  // TODO(wschurman): update for new manifest2 format (Manifest)
+  const historyItem = history.find(
+    item =>
+      item.manifest &&
+      (item.manifest.id === experienceId ||
+        ('scopeKey' in item.manifest && item.manifest.scopeKey === experienceId))
+  );
   if (historyItem) {
     return { url: historyItem.url };
   }

--- a/ios/Client/EXHomeAppManager.h
+++ b/ios/Client/EXHomeAppManager.h
@@ -11,7 +11,7 @@ FOUNDATION_EXPORT NSString *kEXHomeManifestResourceName;
 #pragma mark - interfacing with home JS
 
 - (void)addHistoryItemWithUrl:(NSURL *)manifestUrl manifest:(EXUpdatesRawManifest *)manifest;
-- (void)getHistoryUrlForExperienceId:(NSString *)experienceId completion:(void (^)(NSString *))completion;
+- (void)getHistoryUrlForScopeKey:(NSString *)scopeKey completion:(void (^)(NSString *))completion;
 - (void)showQRReader;
 
 @end

--- a/ios/Client/EXHomeAppManager.m
+++ b/ios/Client/EXHomeAppManager.m
@@ -64,7 +64,7 @@ NSString *kEXHomeManifestResourceName = @"kernel-manifest";
 
 - (void)addHistoryItemWithUrl:(NSURL *)manifestUrl manifest:(EXUpdatesRawManifest *)manifest
 {
-  if (!manifest || !manifestUrl || [manifest.rawID isEqualToString:@"@exponent/home"]) {
+  if (!manifest || !manifestUrl || [manifest.legacyId isEqualToString:@"@exponent/home"]) {
     return;
   }
   NSDictionary *params = @{
@@ -74,10 +74,10 @@ NSString *kEXHomeManifestResourceName = @"kernel-manifest";
   [self _dispatchHomeJSEvent:@"addHistoryItem" body:params onSuccess:nil onFailure:nil];
 }
 
-- (void)getHistoryUrlForExperienceId:(NSString *)experienceId completion:(void (^)(NSString *))completion
+- (void)getHistoryUrlForScopeKey:(NSString *)scopeKey completion:(void (^)(NSString *))completion
 {
   [self _dispatchHomeJSEvent:@"getHistoryUrlForExperienceId"
-                        body:@{ @"experienceId": experienceId }
+                        body:@{ @"experienceId": scopeKey }
                    onSuccess:^(NSDictionary *result) {
                      NSString *url = result[@"url"];
                      completion(url);

--- a/ios/Client/EXRootViewController.m
+++ b/ios/Client/EXRootViewController.m
@@ -104,9 +104,9 @@ NS_ASSUME_NONNULL_BEGIN
   [[self _getHomeAppManager] addHistoryItemWithUrl:manifestUrl manifest:manifest];
 }
 
-- (void)getHistoryUrlForExperienceId:(NSString *)experienceId completion:(void (^)(NSString *))completion
+- (void)getHistoryUrlForScopeKey:(NSString *)scopeKey completion:(void (^)(NSString *))completion
 {
-  return [[self _getHomeAppManager] getHistoryUrlForExperienceId:experienceId completion:completion];
+  return [[self _getHomeAppManager] getHistoryUrlForScopeKey:scopeKey completion:completion];
 }
 
 - (void)setIsNuxFinished:(BOOL)isFinished

--- a/ios/Exponent/Kernel/AppLoader/AppFetcher/EXAppFetcher.h
+++ b/ios/Exponent/Kernel/AppLoader/AppFetcher/EXAppFetcher.h
@@ -59,7 +59,6 @@ NS_ASSUME_NONNULL_BEGIN
                           success:(void (^)(NSData *))successBlock
                             error:(void (^)(NSError *))errorBlock;
 
-+ (nullable NSString *)experienceIdWithManifest:(EXUpdatesRawManifest *)manifest;
 + (EXCachedResourceBehavior)cacheBehaviorForJSWithManifest:(EXUpdatesRawManifest *)manifest;
 
 @end

--- a/ios/Exponent/Kernel/AppLoader/AppFetcher/EXAppFetcher.m
+++ b/ios/Exponent/Kernel/AppLoader/AppFetcher/EXAppFetcher.m
@@ -55,14 +55,9 @@ NS_ASSUME_NONNULL_BEGIN
   [jsResource loadResourceWithBehavior:cacheBehavior progressBlock:progressBlock successBlock:successBlock errorBlock:errorBlock];
 }
 
-+ (nullable NSString *)experienceIdWithManifest:(EXUpdatesRawManifest * _Nonnull)manifest
-{
-  return manifest.rawID;
-}
-
 + (EXCachedResourceBehavior)cacheBehaviorForJSWithManifest:(EXUpdatesRawManifest * _Nonnull)manifest
 {
-  if ([[EXKernel sharedInstance].serviceRegistry.errorRecoveryManager experienceIdIsRecoveringFromError:[[self class] experienceIdWithManifest:manifest]]) {
+  if ([[EXKernel sharedInstance].serviceRegistry.errorRecoveryManager scopeKeyIsRecoveringFromError:manifest.scopeKey]) {
     // if this experience id encountered a loading error before, discard any cache we might have
     return EXCachedResourceWriteToCache;
   }

--- a/ios/Exponent/Kernel/AppLoader/EXAppLoader.m
+++ b/ios/Exponent/Kernel/AppLoader/EXAppLoader.m
@@ -248,7 +248,7 @@ NSTimeInterval const kEXJSBundleTimeout = 60 * 5;
 
   // if this experience id encountered a loading error before,
   // we should always check for an update, even if the manifest says not to
-  if ([[EXKernel sharedInstance].serviceRegistry.errorRecoveryManager experienceIdIsRecoveringFromError:[EXAppFetcher experienceIdWithManifest:manifest]]) {
+  if ([[EXKernel sharedInstance].serviceRegistry.errorRecoveryManager scopeKeyIsRecoveringFromError:manifest.scopeKey]) {
     shouldCheckForUpdate = YES;
   }
 

--- a/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
+++ b/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
@@ -184,7 +184,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
   [self _setShouldShowRemoteUpdateStatus:update.rawManifest];
   // if cached manifest was dev mode, or a previous run of this app failed due to a loading error, we want to make sure to check for remote updates
-  if (update.rawManifest.isUsingDeveloperTool || [[EXKernel sharedInstance].serviceRegistry.errorRecoveryManager experienceIdIsRecoveringFromError:[EXAppFetcher experienceIdWithManifest:update.rawManifest]]) {
+  if (update.rawManifest.isUsingDeveloperTool || [[EXKernel sharedInstance].serviceRegistry.errorRecoveryManager scopeKeyIsRecoveringFromError:update.rawManifest.scopeKey]) {
     return NO;
   }
   return YES;
@@ -481,17 +481,16 @@ NS_ASSUME_NONNULL_BEGIN
     mutableManifest[@"isVerified"] = @(NO);
   }
 
-  if (![mutableManifest[@"isVerified"] boolValue] && (EXEnvironment.sharedEnvironment.isManifestVerificationBypassed || [self _isAnonymousExperience:manifest])) {
+  if (![mutableManifest[@"isVerified"] boolValue] && (EXEnvironment.sharedEnvironment.isManifestVerificationBypassed || [EXAppLoaderExpoUpdates _isAnonymousExperience:manifest])) {
     mutableManifest[@"isVerified"] = @(YES);
   }
 
   return [EXUpdatesUpdate rawManifestForJSON:[mutableManifest copy]];
 }
 
-- (BOOL)_isAnonymousExperience:(EXUpdatesRawManifest *)manifest
++ (BOOL)_isAnonymousExperience:(EXUpdatesRawManifest *)manifest
 {
-  NSString *experienceId = manifest.rawID;
-  return experienceId != nil && [experienceId hasPrefix:@"@anonymous/"];
+  return manifest.legacyId != nil && [manifest.legacyId hasPrefix:@"@anonymous/"];
 }
 
 #pragma mark - headers

--- a/ios/Exponent/Kernel/Core/EXAppBrowserController.h
+++ b/ios/Exponent/Kernel/Core/EXAppBrowserController.h
@@ -10,7 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)reloadVisibleApp;
 - (void)showQRReader;
 - (void)addHistoryItemWithUrl:(NSURL *)manifestUrl manifest:(EXUpdatesRawManifest *)manifest;
-- (void)getHistoryUrlForExperienceId:(NSString *)experienceId completion:(void (^)(NSString * _Nullable))completion;
+- (void)getHistoryUrlForScopeKey:(NSString *)scopeKey completion:(void (^)(NSString * _Nullable))completion;
 - (BOOL)isNuxFinished;
 - (void)setIsNuxFinished:(BOOL)isFinished;
 - (void)appDidFinishLoadingSuccessfully:(EXKernelAppRecord *)appRecord;

--- a/ios/Exponent/Kernel/Core/EXKernel.h
+++ b/ios/Exponent/Kernel/Core/EXKernel.h
@@ -28,8 +28,8 @@ typedef NS_ENUM(NSInteger, EXKernelErrorCode) {
 
 - (EXKernelAppRecord *)createNewAppWithUrl:(NSURL *)url initialProps:(nullable NSDictionary *)initialProps;
 - (void)switchTasks;
-- (void)reloadAppWithExperienceId:(NSString *)experienceId; // called by Updates.reload
-- (void)reloadAppFromCacheWithExperienceId:(NSString *)experienceId; // called by Updates.reloadFromCache
+- (void)reloadAppWithScopeKey:(NSString *)scopeKey; // called by Updates.reload
+- (void)reloadAppFromCacheWithScopeKey:(NSString *)scopeKey; // called by Updates.reloadFromCache
 - (void)reloadVisibleApp; // called in development whenever the app is reloaded
 
 /**

--- a/ios/Exponent/Kernel/Core/EXKernel.m
+++ b/ios/Exponent/Kernel/Core/EXKernel.m
@@ -175,10 +175,10 @@ NSString * const kEXReloadActiveAppRequest = @"EXReloadActiveAppRequest";
 
 - (BOOL)sendNotification:(EXPendingNotification *)notification
 {
-  EXKernelAppRecord *destinationApp = [_appRegistry standaloneAppRecord] ?: [_appRegistry newestRecordWithExperienceId:notification.experienceId];
+  EXKernelAppRecord *destinationApp = [_appRegistry standaloneAppRecord] ?: [_appRegistry newestRecordWithScopeKey:notification.scopeKey];
 
   // This allows home app record to receive notification events as well.
-  if (!destinationApp && [_appRegistry.homeAppRecord.experienceId isEqualToString:notification.experienceId]) {
+  if (!destinationApp && [_appRegistry.homeAppRecord.scopeKey isEqualToString:notification.scopeKey]) {
     destinationApp = _appRegistry.homeAppRecord;
   }
 
@@ -192,7 +192,7 @@ NSString * const kEXReloadActiveAppRequest = @"EXReloadActiveAppRequest";
     // if we're Expo Go, we can query Home for a past experience in the user's history, and route the notification there.
     if (_browserController) {
       __weak typeof(self) weakSelf = self;
-      [_browserController getHistoryUrlForExperienceId:notification.experienceId completion:^(NSString *urlString) {
+      [_browserController getHistoryUrlForScopeKey:notification.scopeKey completion:^(NSString *urlString) {
         if (urlString) {
           NSURL *url = [NSURL URLWithString:urlString];
           if (url) {
@@ -285,9 +285,9 @@ NSString * const kEXReloadActiveAppRequest = @"EXReloadActiveAppRequest";
   }
 }
 
-- (void)reloadAppWithExperienceId:(NSString *)experienceId
+- (void)reloadAppWithScopeKey:(NSString *)scopeKey
 {
-  EXKernelAppRecord *appRecord = [_appRegistry newestRecordWithExperienceId:experienceId];
+  EXKernelAppRecord *appRecord = [_appRegistry newestRecordWithScopeKey:scopeKey];
   if (_browserController) {
     [self createNewAppWithUrl:appRecord.appLoader.manifestUrl initialProps:nil];
   } else if (_appRegistry.standaloneAppRecord && appRecord == _appRegistry.standaloneAppRecord) {
@@ -295,9 +295,9 @@ NSString * const kEXReloadActiveAppRequest = @"EXReloadActiveAppRequest";
   }
 }
 
-- (void)reloadAppFromCacheWithExperienceId:(NSString *)experienceId
+- (void)reloadAppFromCacheWithScopeKey:(NSString *)scopeKey
 {
-  EXKernelAppRecord *appRecord = [_appRegistry newestRecordWithExperienceId:experienceId];
+  EXKernelAppRecord *appRecord = [_appRegistry newestRecordWithScopeKey:scopeKey];
   [appRecord.viewController reloadFromCache];
 }
 

--- a/ios/Exponent/Kernel/Core/EXKernelAppRecord.h
+++ b/ios/Exponent/Kernel/Core/EXKernelAppRecord.h
@@ -27,7 +27,7 @@ typedef enum EXKernelAppRecordStatus {
 
 @property (nonatomic, readonly, assign) EXKernelAppRecordStatus status;
 @property (nonatomic, readonly, strong) NSDate *timeCreated;
-@property (nonatomic, readonly) NSString * _Nullable experienceId;
+@property (nonatomic, readonly) NSString * _Nullable scopeKey;
 @property (nonatomic, readonly) EXReactAppManager *appManager;
 @property (nonatomic, readonly, strong) EXAppLoader *appLoader;
 @property (nonatomic, readonly) EXAppViewController *viewController;

--- a/ios/Exponent/Kernel/Core/EXKernelAppRecord.m
+++ b/ios/Exponent/Kernel/Core/EXKernelAppRecord.m
@@ -55,20 +55,20 @@ NSString *kEXKernelBridgeDidBackgroundNotification = @"EXKernelBridgeDidBackgrou
   return kEXKernelAppRecordStatusNew;
 }
 
-- (NSString * _Nullable)experienceId
+- (NSString * _Nullable)scopeKey
 {
   if (self.appLoader && self.appLoader.manifest) {
-    return self.appLoader.manifest.rawID;
+    return self.appLoader.manifest.scopeKey;
   }
   return nil;
 }
 
 - (NSString *)description
 {
-  return [NSString stringWithFormat:@"EXKernelAppRecord %p:\n  url: %@\n  experience id: %@",
+  return [NSString stringWithFormat:@"EXKernelAppRecord %p:\n  url: %@\n  experience scope key: %@",
           self,
           self.appLoader.manifestUrl,
-          (self.experienceId) ? self.experienceId : @"(none)"];
+          self.scopeKey ?: @"(none)"];
 }
 
 @end

--- a/ios/Exponent/Kernel/Core/EXKernelAppRegistry.h
+++ b/ios/Exponent/Kernel/Core/EXKernelAppRegistry.h
@@ -37,9 +37,9 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly, nullable) EXKernelAppRecord *standaloneAppRecord;
 
 - (EXKernelAppRecord *)recordForId:(NSString *)recordId;
-- (EXKernelAppRecord * _Nullable)newestRecordWithExperienceId:(NSString *)experienceId;
+- (EXKernelAppRecord * _Nullable)newestRecordWithScopeKey:(NSString *)scopeKey;
 - (NSEnumerator<id> *)appEnumerator; // does not include home
-- (BOOL)isExperienceIdUnique:(NSString *)experienceId;
+- (BOOL)isScopeKeyUnique:(NSString *)scopeKey;
 
 @end
 

--- a/ios/Exponent/Kernel/Core/EXKernelAppRegistry.m
+++ b/ios/Exponent/Kernel/Core/EXKernelAppRegistry.m
@@ -28,7 +28,7 @@
 - (NSString *)registerAppWithManifestUrl:(NSURL *)manifestUrl initialProps:(NSDictionary *)initialProps
 {
   NSAssert(manifestUrl, @"Cannot register an app with no manifest URL");
-  // not enforcing uniqueness yet - we will do this once we download the manifest & have the experienceId
+  // not enforcing uniqueness yet - we will do this once we download the manifest & have the experience scope key
   EXKernelAppRecord *newRecord = [[EXKernelAppRecord alloc] initWithManifestUrl:manifestUrl initialProps:initialProps];
   NSString *recordId = [[NSUUID UUID] UUIDString];
   [_appRegistry setObject:newRecord forKey:recordId];
@@ -94,13 +94,13 @@
   return [_appRegistry objectForKey:recordId];
 }
 
-// when reloading, for a brief period of time there are two records with the same experienceId in the registry
-- (EXKernelAppRecord * _Nullable)newestRecordWithExperienceId:(NSString *)experienceId
+// when reloading, for a brief period of time there are two records with the same experience scopeKey in the registry
+- (EXKernelAppRecord * _Nullable)newestRecordWithScopeKey:(NSString *)scopeKey
 {
   EXKernelAppRecord *recordToReturn;
   for (NSString *recordId in self.appEnumerator) {
     EXKernelAppRecord *record = [self recordForId:recordId];
-    if (record && record.experienceId && [record.experienceId isEqualToString:experienceId]) {
+    if (record && record.scopeKey && [record.scopeKey isEqualToString:scopeKey]) {
       if (recordToReturn && [recordToReturn.timeCreated compare:record.timeCreated] == NSOrderedDescending) {
         continue;
       }
@@ -129,12 +129,12 @@
   return @"EXKernelAppRegistry (empty)";
 }
 
-- (BOOL)isExperienceIdUnique:(NSString *)experienceId
+- (BOOL)isScopeKeyUnique:(NSString *)scopeKey
 {
   int count = 0;
   for (NSString *recordId in self.appEnumerator) {
     EXKernelAppRecord *appRecord = [self recordForId:recordId];
-    if (appRecord.experienceId && [appRecord.experienceId isEqualToString:experienceId]) {
+    if (appRecord.scopeKey && [appRecord.scopeKey isEqualToString:scopeKey]) {
       count++;
       if (count > 1) {
         return NO;

--- a/ios/Exponent/Kernel/Core/EXPendingNotification.h
+++ b/ios/Exponent/Kernel/Core/EXPendingNotification.h
@@ -6,7 +6,7 @@
 
 @interface EXPendingNotification : NSObject
 
-@property (nonatomic, readonly) NSString *experienceId;
+@property (nonatomic, readonly) NSString *scopeKey;
 
 - (instancetype)initWithNotification:(UNNotification *)notification;
 - (instancetype)initWithNotificationResponse:(UNNotificationResponse *)notificationResponse identifiersManager:(id<EXNotificationsIdentifiersManager>)manager;

--- a/ios/Exponent/Kernel/Core/EXPendingNotification.m
+++ b/ios/Exponent/Kernel/Core/EXPendingNotification.m
@@ -5,7 +5,7 @@
 
 @interface EXPendingNotification ()
 
-@property (nonatomic, strong) NSString *experienceId;
+@property (nonatomic, strong) NSString *scopeKey;
 @property (nonatomic, strong) NSDictionary *body;
 @property (nonatomic, assign) BOOL isRemote;
 @property (nonatomic, assign) BOOL isFromBackground;
@@ -19,12 +19,12 @@
 - (instancetype)initWithNotification:(UNNotification *)notification
 {
   NSDictionary *payload = notification.request.content.userInfo ?: @{};
-  return [self initWithExperienceId:payload[@"experienceId"]
-                   notificationBody:payload[@"body"]
-                           isRemote:[notification.request.trigger isKindOfClass:[UNPushNotificationTrigger class]]
-                   isFromBackground:NO
-                           actionId:nil
-                           userText:nil];
+  return [self initWithScopeKey:payload[@"scopeKey"] ?: payload[@"experienceId"]
+                         notificationBody:payload[@"body"]
+                                 isRemote:[notification.request.trigger isKindOfClass:[UNPushNotificationTrigger class]]
+                         isFromBackground:NO
+                                 actionId:nil
+                                 userText:nil];
 }
 
 - (instancetype)initWithNotificationResponse:(UNNotificationResponse *)notificationResponse identifiersManager:(id<EXNotificationsIdentifiersManager>)manager
@@ -41,16 +41,16 @@
   return self;
 }
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
-                    notificationBody:(NSDictionary *)body
-                            isRemote:(BOOL)isRemote
-                    isFromBackground:(BOOL)isFromBackground
-                            actionId:(NSString *)actionId
-                            userText:(NSString *)userText {
+- (instancetype)initWithScopeKey:(NSString *)scopeKey
+                          notificationBody:(NSDictionary *)body
+                                  isRemote:(BOOL)isRemote
+                          isFromBackground:(BOOL)isFromBackground
+                                  actionId:(NSString *)actionId
+                                  userText:(NSString *)userText {
   if (self = [super init]) {
     _isRemote = isRemote;
     _isFromBackground = isFromBackground;
-    _experienceId = experienceId;
+    _scopeKey = scopeKey;
     _body = body ?: @{};
     _actionId = actionId;
     _userText = userText;

--- a/ios/Exponent/Kernel/DevSupport/EXHomeModule.m
+++ b/ios/Exponent/Kernel/DevSupport/EXHomeModule.m
@@ -27,9 +27,8 @@
 
 + (NSString *)moduleName { return @"ExponentKernel"; }
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId kernelServiceDelegate:(id)kernelServiceInstance params:(NSDictionary *)params
-{
-  if (self = [super initWithExperienceId:experienceId kernelServiceDelegate:kernelServiceInstance params:params]) {
+- (instancetype)initWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId scopeKey:(NSString *)scopeKey kernelServiceDelegate:(id)kernelServiceInstance params:(NSDictionary *)params {
+  if (self = [super initWithExperienceStableLegacyId:experienceStableLegacyId scopeKey:scopeKey kernelServiceDelegates:kernelServiceInstance params:params]) {
     _eventSuccessBlocks = [NSMutableDictionary dictionary];
     _eventFailureBlocks = [NSMutableDictionary dictionary];
     _sdkVersions = params[@"constants"][@"supportedExpoSdks"];

--- a/ios/Exponent/Kernel/ReactAppManager/EXReactAppExceptionHandler.m
+++ b/ios/Exponent/Kernel/ReactAppManager/EXReactAppExceptionHandler.m
@@ -65,7 +65,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
   NSDictionary *errorInfo = @{ NSLocalizedDescriptionKey: description, RCTJSStackTraceKey: stack };
   NSError *error = [NSError errorWithDomain:RCTErrorDomain code:0 userInfo:errorInfo];
 
-  [[EXKernel sharedInstance].serviceRegistry.errorRecoveryManager setError:error forExperienceId:_appRecord.experienceId];
+  [[EXKernel sharedInstance].serviceRegistry.errorRecoveryManager setError:error forScopeKey:_appRecord.scopeKey];
 
   if ([self _isProdHome]) {
     RCTFatal(error);

--- a/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager.mm
+++ b/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager.mm
@@ -115,18 +115,17 @@ typedef void (^SDK21RCTSourceLoadBlock)(NSError *error, NSData *source, int64_t 
   NSAssert((_delegate != nil), @"Cannot init react app without EXReactAppManagerDelegate");
   [self _invalidateAndClearDelegate:NO];
   [self computeVersionSymbolPrefix];
-  
+
   if ([self isReadyToLoad]) {
     Class versionManagerClass = [self versionedClassFromString:@"EXVersionManager"];
     Class bridgeClass = [self versionedClassFromString:@"RCTBridge"];
     Class rootViewClass = [self versionedClassFromString:@"RCTRootView"];
-    
-    _versionManager = [[versionManagerClass alloc]
-                       initWithParams:[self extraParams]
-                       fatalHandler:handleFatalReactError
-                       logFunction:[self logFunction]
-                       logThreshold:[self logLevel]
-                       ];
+
+    _versionManager = [[versionManagerClass alloc] initWithParams:[self extraParams]
+                                                         manifest:_appRecord.appLoader.manifest
+                                                     fatalHandler:handleFatalReactError
+                                                      logFunction:[self logFunction]
+                                                     logThreshold:[self logLevel]];
     _reactBridge = [[bridgeClass alloc] initWithDelegate:self launchOptions:[self launchOptionsForBridge]];
 
     if (!_isHeadless) {
@@ -139,7 +138,7 @@ typedef void (^SDK21RCTSourceLoadBlock)(NSError *error, NSData *source, int64_t 
 
     [self setupWebSocketControls];
     [_delegate reactAppManagerIsReadyForLoad:self];
-    
+
     NSAssert([_reactBridge isLoading], @"React bridge should be loading once initialized");
     [_versionManager bridgeWillStartLoading:_reactBridge];
   }
@@ -281,7 +280,7 @@ typedef void (^SDK21RCTSourceLoadBlock)(NSError *error, NSData *source, int64_t 
     NSLog(@"Standalone bundle remote url is %@", [EXEnvironment sharedEnvironment].standaloneManifestUrl);
     return kEXEmbeddedBundleResourceName;
   } else {
-    return manifest.rawID;
+    return manifest.legacyId;
   }
 }
 
@@ -300,21 +299,21 @@ typedef void (^SDK21RCTSourceLoadBlock)(NSError *error, NSData *source, int64_t 
 - (void)loadSourceForBridge:(RCTBridge *)bridge withBlock:(RCTSourceLoadBlock)loadCallback
 {
   // clear any potentially old loading state
-  if (_appRecord.experienceId) {
-    [[EXKernel sharedInstance].serviceRegistry.errorRecoveryManager setError:nil forExperienceId:_appRecord.experienceId];
+  if (_appRecord.scopeKey) {
+    [[EXKernel sharedInstance].serviceRegistry.errorRecoveryManager setError:nil forScopeKey:_appRecord.scopeKey];
   }
   [self _stopObservingBridgeNotifications];
   [self _startObservingBridgeNotificationsForBridge:bridge];
-  
+
   if ([self enablesDeveloperTools]) {
     if ([_appRecord.appLoader supportsBundleReload]) {
       [_appRecord.appLoader forceBundleReload];
     } else {
-      NSAssert(_appRecord.experienceId, @"EXKernelAppRecord.experienceId should be nonnull if we have a manifest with developer tools enabled");
-      [[EXKernel sharedInstance] reloadAppWithExperienceId:_appRecord.experienceId];
+      NSAssert(_appRecord.scopeKey, @"EXKernelAppRecord.scopeKey should be nonnull if we have a manifest with developer tools enabled");
+      [[EXKernel sharedInstance] reloadAppWithScopeKey:_appRecord.scopeKey];
     }
   }
-  
+
   _loadCallback = loadCallback;
   if (_appRecord.appLoader.status == kEXAppLoaderStatusHasManifestAndBundle) {
     // finish loading immediately (app loader won't call this since it's already done)
@@ -347,13 +346,13 @@ typedef void (^SDK21RCTSourceLoadBlock)(NSError *error, NSData *source, int64_t 
 {
   // RN is going to call RCTFatal() on this error, so keep a reference to it for later
   // so we can distinguish this non-fatal error from actual fatal cases.
-  if (_appRecord.experienceId) {
-    [[EXKernel sharedInstance].serviceRegistry.errorRecoveryManager setError:error forExperienceId:_appRecord.experienceId];
+  if (_appRecord.scopeKey) {
+    [[EXKernel sharedInstance].serviceRegistry.errorRecoveryManager setError:error forScopeKey:_appRecord.scopeKey];
   }
-  
+
   // react won't post this for us
   [[NSNotificationCenter defaultCenter] postNotificationName:[self versionedString:RCTJavaScriptDidFailToLoadNotification] object:error];
-  
+
   if (_loadCallback) {
     if ([self _compareVersionTo:22] == NSOrderedAscending) {
       SDK21RCTSourceLoadBlock legacyLoadCallback = (SDK21RCTSourceLoadBlock)_loadCallback;
@@ -370,7 +369,7 @@ typedef void (^SDK21RCTSourceLoadBlock)(NSError *error, NSData *source, int64_t 
 - (void)_startObservingBridgeNotificationsForBridge:(RCTBridge *)bridge
 {
   NSAssert(bridge, @"Must subscribe to loading notifs for a non-null bridge");
-  
+
   [[NSNotificationCenter defaultCenter] addObserver:self
                                            selector:@selector(_handleJavaScriptStartLoadingEvent:)
                                                name:[self versionedString:RCTJavaScriptWillStartLoadingNotification]
@@ -425,7 +424,7 @@ typedef void (^SDK21RCTSourceLoadBlock)(NSError *error, NSData *source, int64_t 
     if (_appRecord.viewController) {
       [_appRecord.viewController hideLoadingProgressWindow];
     }
-    
+
     // TODO: To be removed once SDK 38 is phased out
     // Above SDK 38 this code is invoked in different place
     if ([self _compareVersionTo:39] == NSOrderedAscending) {
@@ -433,8 +432,8 @@ typedef void (^SDK21RCTSourceLoadBlock)(NSError *error, NSData *source, int64_t 
     }
   } else if ([notification.name isEqualToString:[self versionedString:RCTJavaScriptDidFailToLoadNotification]]) {
     NSError *error = (notification.userInfo) ? notification.userInfo[@"error"] : nil;
-    if (_appRecord.experienceId) {
-      [[EXKernel sharedInstance].serviceRegistry.errorRecoveryManager setError:error forExperienceId:_appRecord.experienceId];
+    if (_appRecord.scopeKey) {
+      [[EXKernel sharedInstance].serviceRegistry.errorRecoveryManager setError:error forScopeKey:_appRecord.scopeKey];
     }
 
     UM_WEAKIFY(self);
@@ -455,7 +454,7 @@ typedef void (^SDK21RCTSourceLoadBlock)(NSError *error, NSData *source, int64_t 
     dispatch_async(dispatch_get_main_queue(), ^{
       UM_ENSURE_STRONGIFY(self);
       [self.delegate reactAppManagerAppContentDidAppear:self];
-      
+
       if ([self _compareVersionTo:38] == NSOrderedDescending) {
         // Post SDK 38 code
         // Up to SDK 38 this code is invoked in different place
@@ -485,7 +484,7 @@ typedef void (^SDK21RCTSourceLoadBlock)(NSError *error, NSData *source, int64_t 
     [_viewTestTimer invalidate];
     _viewTestTimer = nil;
   }
-  
+
   // SplashScreen.preventAutoHide is called despite actual JS method call.
   // Prior SDK 39, SplashScreen was basing on started & finished flags that are set via legacy Expo.SplashScreen JS methods calls.
   EXSplashScreenService *splashScreenService = (EXSplashScreenService *)[UMModuleRegistryProvider getSingletonModuleForClass:[EXSplashScreenService class]];
@@ -527,13 +526,13 @@ typedef void (^SDK21RCTSourceLoadBlock)(NSError *error, NSData *source, int64_t 
 
     // Remove once SDK 38 is phased out.
     id<PreSDK39EXSplashScreenManagerProtocol> splashManager = [self _preSDK39AppLoadingManagerInstance];
-    
+
     // SplashScreen: at this point SplashScreen is prevented from autohiding,
     // so we can safely hide it when the flags set.
     if (!splashManager || !splashManager.started || splashManager.finished) {
       [_viewTestTimer invalidate];
       _viewTestTimer = nil;
-      
+
       EXSplashScreenService *splashScreenService = (EXSplashScreenService *)[UMModuleRegistryProvider getSingletonModuleForClass:[EXSplashScreenService class]];
       [splashScreenService hideSplashScreenFor:(UIViewController *) _appRecord.viewController
                                successCallback:^(BOOL hasEffect) {}
@@ -548,8 +547,8 @@ typedef void (^SDK21RCTSourceLoadBlock)(NSError *error, NSData *source, int64_t 
   UM_WEAKIFY(self);
   dispatch_async(dispatch_get_main_queue(), ^{
     UM_ENSURE_STRONGIFY(self);
-    if (self.appRecord.experienceId) {
-      [[EXKernel sharedInstance].serviceRegistry.errorRecoveryManager experienceFinishedLoadingWithId:self.appRecord.experienceId];
+    if (self.appRecord.scopeKey) {
+      [[EXKernel sharedInstance].serviceRegistry.errorRecoveryManager experienceFinishedLoadingWithScopeKey:self.appRecord.scopeKey];
     }
     [self.delegate reactAppManagerFinishedLoadingJavaScript:self];
   });
@@ -707,7 +706,7 @@ typedef void (^SDK21RCTSourceLoadBlock)(NSError *error, NSData *source, int64_t 
   if (!_validatedVersion || _validatedVersion.length == 0 || [_validatedVersion isEqualToString:@"UNVERSIONED"]) {
     return NSOrderedDescending;
   }
-  
+
   NSUInteger projectVersionNumber = _validatedVersion.integerValue;
   if (projectVersionNumber == version) {
     return NSOrderedSame;
@@ -738,7 +737,7 @@ typedef void (^SDK21RCTSourceLoadBlock)(NSError *error, NSData *source, int64_t 
   if (manifest && manifest.appKey) {
     return manifest.appKey;
   }
-  
+
   NSURL *bundleUrl = [self bundleUrl];
   if (bundleUrl) {
     NSURLComponents *components = [NSURLComponents componentsWithURL:bundleUrl resolvingAgainstBaseURL:YES];
@@ -749,7 +748,7 @@ typedef void (^SDK21RCTSourceLoadBlock)(NSError *error, NSData *source, int64_t 
       }
     }
   }
-  
+
   return @"main";
 }
 
@@ -758,10 +757,10 @@ typedef void (^SDK21RCTSourceLoadBlock)(NSError *error, NSData *source, int64_t 
   NSMutableDictionary *props = [NSMutableDictionary dictionary];
   NSMutableDictionary *expProps = [NSMutableDictionary dictionary];
 
-  NSAssert(_appRecord.experienceId, @"Experience id should be nonnull when getting initial properties for root view");
+  NSAssert(_appRecord.scopeKey, @"Experience scope key should be nonnull when getting initial properties for root view");
 
-  NSDictionary *errorRecoveryProps = [[EXKernel sharedInstance].serviceRegistry.errorRecoveryManager developerInfoForExperienceId:_appRecord.experienceId];
-  if ([[EXKernel sharedInstance].serviceRegistry.errorRecoveryManager experienceIdIsRecoveringFromError:_appRecord.experienceId]) {
+  NSDictionary *errorRecoveryProps = [[EXKernel sharedInstance].serviceRegistry.errorRecoveryManager developerInfoForScopeKey:_appRecord.scopeKey];
+  if ([[EXKernel sharedInstance].serviceRegistry.errorRecoveryManager scopeKeyIsRecoveringFromError:_appRecord.scopeKey]) {
     [[EXKernel sharedInstance].serviceRegistry.errorRecoveryManager increaseAutoReloadBuffer];
     if (errorRecoveryProps) {
       expProps[@"errorRecovery"] = errorRecoveryProps;
@@ -773,7 +772,7 @@ typedef void (^SDK21RCTSourceLoadBlock)(NSError *error, NSData *source, int64_t 
   if (_initialProps) {
     [expProps addEntriesFromDictionary:_initialProps];
   }
-  EXPendingNotification *initialNotification = [[EXKernel sharedInstance].serviceRegistry.notificationsManager initialNotificationForExperience:_appRecord.experienceId];
+  EXPendingNotification *initialNotification = [[EXKernel sharedInstance].serviceRegistry.notificationsManager initialNotification];
   if (initialNotification) {
     expProps[@"notification"] = initialNotification.properties;
   }
@@ -817,18 +816,18 @@ typedef void (^SDK21RCTSourceLoadBlock)(NSError *error, NSData *source, int64_t 
 
 - (NSString *)scopedDocumentDirectory
 {
-  NSString *escapedExperienceId = [self escapedResourceName:_appRecord.experienceId];
+  NSString *escapedScopeKey = [self escapedResourceName:_appRecord.scopeKey];
   NSString *mainDocumentDirectory = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES).firstObject;
   NSString *exponentDocumentDirectory = [mainDocumentDirectory stringByAppendingPathComponent:@"ExponentExperienceData"];
-  return [[exponentDocumentDirectory stringByAppendingPathComponent:escapedExperienceId] stringByStandardizingPath];
+  return [[exponentDocumentDirectory stringByAppendingPathComponent:escapedScopeKey] stringByStandardizingPath];
 }
 
 - (NSString *)scopedCachesDirectory
 {
-  NSString *escapedExperienceId = [self escapedResourceName:_appRecord.experienceId];
+  NSString *escapedScopeKey = [self escapedResourceName:_appRecord.scopeKey];
   NSString *mainCachesDirectory = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES).firstObject;
   NSString *exponentCachesDirectory = [mainCachesDirectory stringByAppendingPathComponent:@"ExponentExperienceData"];
-  return [[exponentCachesDirectory stringByAppendingPathComponent:escapedExperienceId] stringByStandardizingPath];
+  return [[exponentCachesDirectory stringByAppendingPathComponent:escapedScopeKey] stringByStandardizingPath];
 }
 
 - (void *)jsExecutorFactoryForBridge:(id)bridge

--- a/ios/Exponent/Kernel/Services/EXErrorRecoveryManager.h
+++ b/ios/Exponent/Kernel/Services/EXErrorRecoveryManager.h
@@ -21,30 +21,30 @@
  *  Associate arbitrary developer info with this experience id. If the experience recovers from an
  *  error, we can pass this info to the new instance of the experience.
  */
-- (void)setDeveloperInfo: (NSDictionary *)developerInfo forExperienceid: (NSString *)experienceId;
-- (NSDictionary *)developerInfoForExperienceId: (NSString *)experienceId;
+- (void)setDeveloperInfo:(NSDictionary *)developerInfo forScopeKey:(NSString *)scopeKey;
+- (NSDictionary *)developerInfoForScopeKey: (NSString *)scopeKey;
 
 /**
  *  Associate an error with an experience id. This will never be cleared until the next
  *  call to `experienceFinishedLoadingWithId:`.
  */
-- (void)setError: (NSError *)error forExperienceId: (NSString *)experienceId;
+- (void)setError: (NSError *)error forScopeKey:(NSString *)scopeKey;
 
 /**
- *  Indicate that a JS bundle has successfully loaded for this experience id.
+ *  Indicate that a JS bundle has successfully loaded for this experience.
  */
-- (void)experienceFinishedLoadingWithId:(NSString *)experienceId;
+- (void)experienceFinishedLoadingWithScopeKey:(NSString *)scopeKey;
 
 /**
- *  True if any bridge for this experience id had an error, and has not successfully loaded
+ *  True if any bridge for this experience had an error, and has not successfully loaded
  *  since the error was reported.
  */
-- (BOOL)experienceIdIsRecoveringFromError:(NSString *)experienceId;
+- (BOOL)scopeKeyIsRecoveringFromError:(NSString *)scopeKey;
 
 /**
- *  True if this error object (by `isEqual:`) has been registered for any experience id.
+ *  True if this error object (by `isEqual:`) has been registered for any experience.
  */
-- (BOOL)errorBelongsToExperience: (NSError *)error;
+- (BOOL)errorBelongsToExperience:(NSError *)error;
 
 /**
  *  Returns any existing app record for this error. Since error state persists between reloads until cleared,
@@ -55,12 +55,12 @@
 /**
  *  Whether we want to auto-reload this experience if it encounters a fatal error.
  */
-- (BOOL)experienceIdShouldReloadOnError: (NSString *)experienceId;
+- (BOOL)experienceShouldReloadOnError:(NSString *)scopeKey;
 
 /**
  *  Back off to a less aggressive autoreload buffer time.
  *  The longer the time, the longer a experience must wait before a fatal JS error triggers auto reload
- *  via `experienceIdShouldReloadOnError:`.
+ *  via `experienceShouldReloadOnError:`.
  */
 - (void)increaseAutoReloadBuffer;
 

--- a/ios/Exponent/Kernel/Services/EXPermissionsManager.m
+++ b/ios/Exponent/Kernel/Services/EXPermissionsManager.m
@@ -25,12 +25,12 @@ NSString * const EXPermissionsKey = @"ExpoPermissions";
 
 UM_REGISTER_SINGLETON_MODULE(Permissions)
 
-- (EXPermissionStatus)getPermission:(NSString *)permissionType forExperience:(NSString *)experienceId
+- (EXPermissionStatus)getPermission:(NSString *)permissionType forExperience:(NSString *)scopeKey
 {
   permissionType = [EXPermissionsManager mapPermissionType:permissionType];
 
-  NSString *experienceIdKey = [EXPermissionsManager escapedResourceName:experienceId];
-  NSDictionary *experiencePermissions = _permissionsCache[experienceIdKey];
+  NSString *scopeKeyKey = [EXPermissionsManager escapedResourceName:scopeKey];
+  NSDictionary *experiencePermissions = _permissionsCache[scopeKeyKey];
   if (!experiencePermissions) {
     return EXPermissionStatusUndetermined;
   }
@@ -47,29 +47,29 @@ UM_REGISTER_SINGLETON_MODULE(Permissions)
   return EXPermissionStatusDenied;
 }
 
-- (BOOL)hasGrantedPermission:(NSString *)permission forExperience:(NSString *)experienceId
+- (BOOL)hasGrantedPermission:(NSString *)permission forExperience:(NSString *)scopeKey
 {
   if ([EXEnvironment sharedEnvironment].isDetached) {
     return YES;
   }
   
-  return [self getPermission:[EXPermissionsManager mapPermissionType:permission] forExperience:experienceId] == EXPermissionStatusGranted;
+  return [self getPermission:[EXPermissionsManager mapPermissionType:permission] forExperience:scopeKey] == EXPermissionStatusGranted;
 }
 
-- (BOOL)savePermission:(NSDictionary *)permission ofType:(NSString *)type forExperience:(NSString *)experienceId
+- (BOOL)savePermission:(NSDictionary *)permission ofType:(NSString *)type forExperience:(NSString *)scopeKey
 {
   type = [EXPermissionsManager mapPermissionType:type];
   
-  NSString *experienceIdKey = [EXPermissionsManager escapedResourceName:experienceId];
+  NSString *scopeKeyKey = [EXPermissionsManager escapedResourceName:scopeKey];
   NSMutableDictionary *experiencePermissions;
-  if ([_permissionsCache objectForKey:experienceIdKey] == nil) {
+  if ([_permissionsCache objectForKey:scopeKeyKey] == nil) {
     experiencePermissions = [[NSMutableDictionary alloc] init];
   } else {
-    experiencePermissions = [[NSMutableDictionary alloc] initWithDictionary:_permissionsCache[experienceIdKey]];
+    experiencePermissions = [[NSMutableDictionary alloc] initWithDictionary:_permissionsCache[scopeKeyKey]];
   }
 
   experiencePermissions[type] = permission;
-  _permissionsCache[experienceIdKey] = experiencePermissions;
+  _permissionsCache[scopeKeyKey] = experiencePermissions;
   [self synchronizeWithPermissions:_permissionsCache];
   return YES;
 }

--- a/ios/Exponent/Kernel/Services/EXScopedBranchManager.m
+++ b/ios/Exponent/Kernel/Services/EXScopedBranchManager.m
@@ -55,7 +55,7 @@ UM_REGISTER_SINGLETON_MODULE(BranchManager);
   }
 
   EXScopedBranch *branchModule = (EXScopedBranch *)versionedBranchModule;
-  EXKernelAppRecord *appForModule = [[EXKernel sharedInstance].appRegistry newestRecordWithExperienceId:branchModule.experienceId];
+  EXKernelAppRecord *appForModule = [[EXKernel sharedInstance].appRegistry newestRecordWithScopeKey:branchModule.scopeKey];
   if (appForModule && appForModule == [EXKernel sharedInstance].appRegistry.standaloneAppRecord) {
     _isInitialized = YES;
 

--- a/ios/Exponent/Kernel/Services/EXScreenOrientationManager.h
+++ b/ios/Exponent/Kernel/Services/EXScreenOrientationManager.h
@@ -8,9 +8,9 @@ didChangeSupportedInterfaceOrientations:(UIInterfaceOrientationMask)supportedInt
 
 - (UIInterfaceOrientationMask)supportedInterfaceOrientationsForVisibleApp;
 
-- (void)removeOrientationChangeListener:(nonnull NSString *)experienceId;
+- (void)removeOrientationChangeListenerForScopeKey:(nonnull NSString *)scopeKey;
 
-- (void)addOrientationChangeListener:(nonnull NSString *)experienceId subscriberModule:(nonnull id)subscriberModule;
+- (void)addOrientationChangeListenerForScopeKey:(nonnull NSString *)scopeKey subscriberModule:(nonnull id)subscriberModule;
 
 - (nullable UITraitCollection *)getTraitCollection;
 
@@ -28,7 +28,7 @@ didChangeSupportedInterfaceOrientations:(UIInterfaceOrientationMask)supportedInt
 
 @property (nonatomic, assign) UIInterfaceOrientationMask supportedInterfaceOrientationsForVisibleApp;
 
-- (void)setSupportInterfaceOrientations:(UIInterfaceOrientationMask)supportedInterfaceOrientations forExperienceId:(nullable NSString *)experienceId;
+- (void)setSupportInterfaceOrientations:(UIInterfaceOrientationMask)supportedInterfaceOrientations forScopeKey:(nullable NSString *)scopeKey;
 
 - (void)handleScreenOrientationChange:(nullable UITraitCollection *)traitCollection;
 

--- a/ios/Exponent/Kernel/Services/EXScreenOrientationManager.m
+++ b/ios/Exponent/Kernel/Services/EXScreenOrientationManager.m
@@ -17,10 +17,10 @@ NSNotificationName kEXChangeForegroundTaskSupportedOrientationsNotification = @"
   return self;
 }
 
-- (void)setSupportInterfaceOrientations:(UIInterfaceOrientationMask)supportedInterfaceOrientations forExperienceId:(NSString *)experienceId
+- (void)setSupportInterfaceOrientations:(UIInterfaceOrientationMask)supportedInterfaceOrientations forScopeKey:(nullable NSString *)scopeKey
 {
   EXKernelAppRegistry *appRegistry = [EXKernel sharedInstance].appRegistry;
-  EXKernelAppRecord *recordForId = [appRegistry newestRecordWithExperienceId:experienceId];
+  EXKernelAppRecord *recordForId = [appRegistry newestRecordWithScopeKey:scopeKey];
   if (recordForId) {
     [recordForId.viewController setSupportedInterfaceOrientations:supportedInterfaceOrientations];
   }
@@ -34,8 +34,8 @@ NSNotificationName kEXChangeForegroundTaskSupportedOrientationsNotification = @"
 
 - (void)handleScreenOrientationChange:(UITraitCollection *)traitCollection
 {
-  for(NSString *experienceId in _subscribedModules) {
-    id<EXScreenOrientationListener> subscribedModule = [_subscribedModules objectForKey:experienceId];
+  for(NSString *scopeKey in _subscribedModules) {
+    id<EXScreenOrientationListener> subscribedModule = [_subscribedModules objectForKey:scopeKey];
     [subscribedModule handleScreenOrientationChange:traitCollection];
   }
 }
@@ -51,18 +51,18 @@ NSNotificationName kEXChangeForegroundTaskSupportedOrientationsNotification = @"
 - (void)screenOrientationModule:(id)scopedOrientationModule
 didChangeSupportedInterfaceOrientations:(UIInterfaceOrientationMask)supportedInterfaceOrientations
 {
-  [self setSupportInterfaceOrientations:supportedInterfaceOrientations forExperienceId:((EXScopedBridgeModule *)scopedOrientationModule).experienceId];
+  [self setSupportInterfaceOrientations:supportedInterfaceOrientations forScopeKey:((EXScopedBridgeModule *)scopedOrientationModule).scopeKey];
 }
 
 
-- (void)removeOrientationChangeListener:(NSString *)experienceId
+- (void)removeOrientationChangeListenerForScopeKey:(NSString *)scopeKey
 {
-  [_subscribedModules removeObjectForKey:experienceId];
+  [_subscribedModules removeObjectForKey:scopeKey];
 }
 
-- (void)addOrientationChangeListener:(NSString *)experienceId subscriberModule:(id)subscriberModule
+- (void)addOrientationChangeListenerForScopeKey:(NSString *)scopeKey subscriberModule:(id)subscriberModule
 {
-  [_subscribedModules setObject:subscriberModule forKey:experienceId];
+  [_subscribedModules setObject:subscriberModule forKey:scopeKey];
 }
 
 @end

--- a/ios/Exponent/Kernel/Services/EXSensorManager.m
+++ b/ios/Exponent/Kernel/Services/EXSensorManager.m
@@ -58,11 +58,11 @@
   [self.altimeter stopRelativeAltitudeUpdates];
 }
 
-- (void)sensorModuleDidSubscribeForAccelerometerUpdatesOfExperience:experienceId
+- (void)sensorModuleDidSubscribeForAccelerometerUpdatesOfExperience:scopeKey
                                             withHandler:(void (^)(NSDictionary *event))handlerBlock
 {
   if ([self.manager isAccelerometerAvailable]) {
-    self.accelerometerHandlers[experienceId] = handlerBlock;
+    self.accelerometerHandlers[scopeKey] = handlerBlock;
   }
   if (![self.manager isAccelerometerActive]) {
     [self.manager setAccelerometerUpdateInterval:0.1f];
@@ -78,9 +78,9 @@
   }
 }
 
-- (void)sensorModuleDidUnsubscribeForAccelerometerUpdatesOfExperience:experienceId
+- (void)sensorModuleDidUnsubscribeForAccelerometerUpdatesOfExperience:scopeKey
 {
-  [self.accelerometerHandlers removeObjectForKey:experienceId];
+  [self.accelerometerHandlers removeObjectForKey:scopeKey];
   if (self.accelerometerHandlers.count == 0) {
     [self.manager stopAccelerometerUpdates];
   }
@@ -91,20 +91,20 @@
   [self.manager setAccelerometerUpdateInterval:intervalMs];
 }
 
-- (void)sensorModuleDidSubscribeForDeviceMotionUpdatesOfExperience:(NSString *)experienceId
+- (void)sensorModuleDidSubscribeForDeviceMotionUpdatesOfExperience:(NSString *)scopeKey
                                            withHandler:(void (^)(NSDictionary *event))handlerBlock
 {
   if ([self.manager isDeviceMotionAvailable]) {
-    self.deviceMotionHandlers[experienceId] = handlerBlock;
+    self.deviceMotionHandlers[scopeKey] = handlerBlock;
   }
   if (![self.manager isDeviceMotionActive]) {
     [self activateDeviceMotionUpdates];
   }
 }
 
-- (void)sensorModuleDidUnsubscribeForDeviceMotionUpdatesOfExperience:(NSString *)experienceId
+- (void)sensorModuleDidUnsubscribeForDeviceMotionUpdatesOfExperience:(NSString *)scopeKey
 {
-  [self.deviceMotionHandlers removeObjectForKey:experienceId];
+  [self.deviceMotionHandlers removeObjectForKey:scopeKey];
   if (self.deviceMotionHandlers.count == 0 && self.magnetometerHandlers.count == 0) {
     [self.manager stopDeviceMotionUpdates];
   }
@@ -115,11 +115,11 @@
   [self.manager setDeviceMotionUpdateInterval:intervalMs];
 }
 
-- (void)sensorModuleDidSubscribeForGyroscopeUpdatesOfExperience:(NSString *)experienceId
+- (void)sensorModuleDidSubscribeForGyroscopeUpdatesOfExperience:(NSString *)scopeKey
                                         withHandler:(void (^)(NSDictionary *event))handlerBlock
 {
   if ([self.manager isGyroAvailable]) {
-    self.gyroscopeHandlers[experienceId] = handlerBlock;
+    self.gyroscopeHandlers[scopeKey] = handlerBlock;
   }
   if (![self.manager isGyroActive]) {
     [self.manager setGyroUpdateInterval:0.1f];
@@ -135,9 +135,9 @@
   }
 }
 
-- (void)sensorModuleDidUnsubscribeForGyroscopeUpdatesOfExperience:(NSString *)experienceId
+- (void)sensorModuleDidUnsubscribeForGyroscopeUpdatesOfExperience:(NSString *)scopeKey
 {
-  [self.gyroscopeHandlers removeObjectForKey:experienceId];
+  [self.gyroscopeHandlers removeObjectForKey:scopeKey];
   if (self.gyroscopeHandlers.count == 0) {
     [self.manager stopGyroUpdates];
   }
@@ -148,20 +148,20 @@
   [self.manager setGyroUpdateInterval:intervalMs];
 }
 
-- (void)sensorModuleDidSubscribeForMagnetometerUpdatesOfExperience:(NSString *)experienceId
+- (void)sensorModuleDidSubscribeForMagnetometerUpdatesOfExperience:(NSString *)scopeKey
                                            withHandler:(void (^)(NSDictionary *event))handlerBlock
 {
   if ([self.manager isDeviceMotionAvailable]) {
-    self.magnetometerHandlers[experienceId] = handlerBlock;
+    self.magnetometerHandlers[scopeKey] = handlerBlock;
   }
   if (![self.manager isDeviceMotionActive]) {
     [self activateDeviceMotionUpdates];
   }
 }
 
-- (void)sensorModuleDidUnsubscribeForMagnetometerUpdatesOfExperience:(NSString *)experienceId
+- (void)sensorModuleDidUnsubscribeForMagnetometerUpdatesOfExperience:(NSString *)scopeKey
 {
-  [self.magnetometerHandlers removeObjectForKey:experienceId];
+  [self.magnetometerHandlers removeObjectForKey:scopeKey];
   if (self.deviceMotionHandlers.count == 0 && self.magnetometerHandlers.count == 0) {
     [self.manager stopDeviceMotionUpdates];
   }
@@ -172,11 +172,11 @@
   [self.manager setDeviceMotionUpdateInterval:intervalMs];
 }
 
-- (void)sensorModuleDidSubscribeForMagnetometerUncalibratedUpdatesOfExperience:(NSString *)experienceId
+- (void)sensorModuleDidSubscribeForMagnetometerUncalibratedUpdatesOfExperience:(NSString *)scopeKey
                                                        withHandler:(void (^)(NSDictionary *event))handlerBlock
 {
   if ([self.manager isMagnetometerAvailable]) {
-    self.magnetometerUncalibratedHandlers[experienceId] = handlerBlock;
+    self.magnetometerUncalibratedHandlers[scopeKey] = handlerBlock;
   }
   if (![self.manager isMagnetometerActive]) {
     [self.manager setMagnetometerUpdateInterval:0.1f];
@@ -192,9 +192,9 @@
   }
 }
 
-- (void)sensorModuleDidUnsubscribeForMagnetometerUncalibratedUpdatesOfExperience:(NSString *)experienceId
+- (void)sensorModuleDidUnsubscribeForMagnetometerUncalibratedUpdatesOfExperience:(NSString *)scopeKey
 {
-  [self.magnetometerUncalibratedHandlers removeObjectForKey:experienceId];
+  [self.magnetometerUncalibratedHandlers removeObjectForKey:scopeKey];
   if (self.magnetometerUncalibratedHandlers.count == 0) {
     [self.manager stopMagnetometerUpdates];
   }
@@ -276,10 +276,10 @@
    }];
 }
 
-- (void)sensorModuleDidSubscribeForBarometerUpdatesOfExperience:(NSString *)experienceId withHandler:(void (^)(NSDictionary *event))handlerBlock
+- (void)sensorModuleDidSubscribeForBarometerUpdatesOfExperience:(NSString *)scopeKey withHandler:(void (^)(NSDictionary *event))handlerBlock
 {
   if ([self isBarometerAvailable]) {
-    _barometerHandlers[experienceId] = handlerBlock;
+    _barometerHandlers[scopeKey] = handlerBlock;
   }
   
   __weak EXSensorManager *weakSelf = self;
@@ -296,9 +296,9 @@
   }];
 }
 
-- (void)sensorModuleDidUnsubscribeForBarometerUpdatesOfExperience:(NSString *)experienceId
+- (void)sensorModuleDidUnsubscribeForBarometerUpdatesOfExperience:(NSString *)scopeKey
 {
-  [_barometerHandlers removeObjectForKey:experienceId];
+  [_barometerHandlers removeObjectForKey:scopeKey];
   if (_barometerHandlers.count == 0) {
     [_altimeter stopRelativeAltitudeUpdates];
   }

--- a/ios/Exponent/Kernel/Services/EXUpdatesManager.m
+++ b/ios/Exponent/Kernel/Services/EXUpdatesManager.m
@@ -76,56 +76,56 @@ ofDownloadWithManifest:(EXUpdatesRawManifest * _Nullable)manifest
 
 - (EXAppLoader *)_appLoaderWithScopedModule:(id)scopedModule
 {
-  NSString *experienceId = ((EXScopedBridgeModule *)scopedModule).experienceId;
-  return [self _appLoaderWithExperienceId:experienceId];
+  NSString *scopeKey = ((EXScopedBridgeModule *)scopedModule).scopeKey;
+  return [self _appLoaderWithScopeKey:scopeKey];
 }
 
-- (EXAppLoader *)_appLoaderWithExperienceId:(NSString *)experienceId
+- (EXAppLoader *)_appLoaderWithScopeKey:(NSString *)scopeKey
 {
-  EXKernelAppRecord *appRecord = [[EXKernel sharedInstance].appRegistry newestRecordWithExperienceId:experienceId];
+  EXKernelAppRecord *appRecord = [[EXKernel sharedInstance].appRegistry newestRecordWithScopeKey:scopeKey];
   return appRecord.appLoader;
 }
 
 # pragma mark - EXUpdatesBindingDelegate
 
-- (EXUpdatesConfig *)configForExperienceId:(NSString *)experienceId
+- (EXUpdatesConfig *)configForScopeKey:(NSString *)scopeKey
 {
-  return [self _appLoaderWithExperienceId:experienceId].config;
+  return [self _appLoaderWithScopeKey:scopeKey].config;
 }
 
-- (EXUpdatesSelectionPolicy *)selectionPolicyForExperienceId:(NSString *)experienceId
+- (EXUpdatesSelectionPolicy *)selectionPolicyForScopeKey:(NSString *)scopeKey
 {
-  return [self _appLoaderWithExperienceId:experienceId].selectionPolicy;
+  return [self _appLoaderWithScopeKey:scopeKey].selectionPolicy;
 }
 
-- (nullable EXUpdatesUpdate *)launchedUpdateForExperienceId:(NSString *)experienceId
+- (nullable EXUpdatesUpdate *)launchedUpdateForScopeKey:(NSString *)scopeKey
 {
-  return [self _appLoaderWithExperienceId:experienceId].appLauncher.launchedUpdate;
+  return [self _appLoaderWithScopeKey:scopeKey].appLauncher.launchedUpdate;
 }
 
-- (nullable NSDictionary *)assetFilesMapForExperienceId:(NSString *)experienceId
+- (nullable NSDictionary *)assetFilesMapForScopeKey:(NSString *)scopeKey
 {
-  return [self _appLoaderWithExperienceId:experienceId].appLauncher.assetFilesMap;
+  return [self _appLoaderWithScopeKey:scopeKey].appLauncher.assetFilesMap;
 }
 
-- (BOOL)isUsingEmbeddedAssetsForExperienceId:(NSString *)experienceId
+- (BOOL)isUsingEmbeddedAssetsForScopeKey:(NSString *)scopeKey
 {
   return NO;
 }
 
-- (BOOL)isStartedForExperienceId:(NSString *)experienceId
+- (BOOL)isStartedForScopeKey:(NSString *)scopeKey
 {
-  return [self _appLoaderWithExperienceId:experienceId].appLauncher != nil;
+  return [self _appLoaderWithScopeKey:scopeKey].appLauncher != nil;
 }
 
-- (BOOL)isEmergencyLaunchForExperienceId:(NSString *)experienceId
+- (BOOL)isEmergencyLaunchForScopeKey:(NSString *)scopeKey
 {
-  return [self _appLoaderWithExperienceId:experienceId].isEmergencyLaunch;
+  return [self _appLoaderWithScopeKey:scopeKey].isEmergencyLaunch;
 }
 
-- (void)requestRelaunchForExperienceId:(NSString *)experienceId withCompletion:(EXUpdatesAppRelaunchCompletionBlock)completion
+- (void)requestRelaunchForScopeKey:(NSString *)scopeKey withCompletion:(EXUpdatesAppRelaunchCompletionBlock)completion
 {
-  [[EXKernel sharedInstance] reloadAppFromCacheWithExperienceId:experienceId];
+  [[EXKernel sharedInstance] reloadAppFromCacheWithScopeKey:scopeKey];
   completion(YES);
 }
 
@@ -133,14 +133,14 @@ ofDownloadWithManifest:(EXUpdatesRawManifest * _Nullable)manifest
 
 - (void)updatesModuleDidSelectReload:(id)scopedModule
 {
-  NSString *experienceId = ((EXScopedBridgeModule *)scopedModule).experienceId;
-  [[EXKernel sharedInstance] reloadAppWithExperienceId:experienceId];
+  NSString *scopeKey = ((EXScopedBridgeModule *)scopedModule).scopeKey;
+  [[EXKernel sharedInstance] reloadAppWithScopeKey:scopeKey];
 }
 
 - (void)updatesModuleDidSelectReloadFromCache:(id)scopedModule
 {
-  NSString *experienceId = ((EXScopedBridgeModule *)scopedModule).experienceId;
-  [[EXKernel sharedInstance] reloadAppFromCacheWithExperienceId:experienceId];
+  NSString *scopeKey = ((EXScopedBridgeModule *)scopedModule).scopeKey;
+  [[EXKernel sharedInstance] reloadAppFromCacheWithScopeKey:scopeKey];
 }
 
 - (void)updatesModule:(id)scopedModule

--- a/ios/Exponent/Kernel/Services/EXUserNotificationManager.h
+++ b/ios/Exponent/Kernel/Services/EXUserNotificationManager.h
@@ -10,6 +10,6 @@
 
 @interface EXUserNotificationManager : NSObject <UNUserNotificationCenterDelegate, EXNotificationsIdentifiersManager, EXNotificationsDelegate>
 
-- (EXPendingNotification *)initialNotificationForExperience:(NSString *)experienceId;
+- (EXPendingNotification *)initialNotification;
 
 @end

--- a/ios/Exponent/Kernel/Services/EXUserNotificationManager.m
+++ b/ios/Exponent/Kernel/Services/EXUserNotificationManager.m
@@ -16,7 +16,7 @@ static NSString * const scopedIdentifierSeparator = @":";
 
 @implementation EXUserNotificationManager
 
-- (EXPendingNotification *)initialNotificationForExperience:(NSString *)experienceId
+- (EXPendingNotification *)initialNotification
 {
   if ([EXEnvironment sharedEnvironment].isDetached) {
     return _pendingNotification;
@@ -27,12 +27,12 @@ static NSString * const scopedIdentifierSeparator = @":";
 
 # pragma mark - EXNotificationsIdentifiersManager
 
-- (NSString *)internalIdForIdentifier:(NSString *)identifier experienceId:(nonnull NSString *)experienceId
+- (NSString *)internalIdForIdentifier:(NSString *)identifier scopeKey:(nonnull NSString *)scopeKey
 {
   if ([EXEnvironment sharedEnvironment].isDetached) {
     return identifier;
   }
-  return [NSString stringWithFormat:@"%@%@%@", experienceId, scopedIdentifierSeparator, identifier];
+  return [NSString stringWithFormat:@"%@%@%@", scopeKey, scopedIdentifierSeparator, identifier];
 }
 
 - (NSString *)exportedIdForInternalIdentifier:(NSString *)identifier

--- a/ios/Exponent/Kernel/Services/Notifications/EXApiV2Client+EXRemoteNotifications.h
+++ b/ios/Exponent/Kernel/Services/Notifications/EXApiV2Client+EXRemoteNotifications.h
@@ -8,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSURLSessionTask *)updateDeviceToken:(NSData *)deviceToken
                       completionHandler:(void (^)(NSError * _Nullable postError))handler;
-- (NSURLSessionTask *)getExpoPushTokenForExperience:(NSString *)experienceId
+- (NSURLSessionTask *)getExpoPushTokenForExperience:(NSString *)experienceStableLegacyId
                                         deviceToken:(NSData *)deviceToken
                                   completionHandler:(void (^)(NSString * _Nullable expoPushToken, NSError * _Nullable error))handler;
 @end

--- a/ios/Exponent/Kernel/Services/Notifications/EXApiV2Client+EXRemoteNotifications.m
+++ b/ios/Exponent/Kernel/Services/Notifications/EXApiV2Client+EXRemoteNotifications.m
@@ -39,13 +39,13 @@
 }
 
 
-- (NSURLSessionTask *)getExpoPushTokenForExperience:(NSString *)experienceId
+- (NSURLSessionTask *)getExpoPushTokenForExperience:(NSString *)experienceStableLegacyId
                                         deviceToken:(NSData *)deviceToken
                                   completionHandler:(void (^)(NSString * _Nullable, NSError * _Nullable))handler
 {
   NSMutableDictionary *arguments = [NSMutableDictionary dictionaryWithDictionary:@{
     @"deviceId": [EXKernel deviceInstallationUUID],
-    @"experienceId": experienceId,
+    @"experienceId": experienceStableLegacyId,
     @"appId": NSBundle.mainBundle.bundleIdentifier,
     @"deviceToken": deviceToken.apnsTokenString,
     @"type": @"apns",

--- a/ios/Exponent/Kernel/Services/Notifications/EXRemoteNotificationManager.m
+++ b/ios/Exponent/Kernel/Services/Notifications/EXRemoteNotificationManager.m
@@ -146,8 +146,8 @@ typedef void(^EXRemoteNotificationAPNSTokenHandler)(NSData * _Nullable apnsToken
       }
 
       if (self->_currentAPNSToken) {
-        NSString *experienceId = ((EXScopedBridgeModule *)scopedModule).experienceId;
-        [[EXApiV2Client sharedClient] getExpoPushTokenForExperience:experienceId
+        NSString *experienceStableLegacyId = ((EXScopedBridgeModule *)scopedModule).experienceStableLegacyId;
+        [[EXApiV2Client sharedClient] getExpoPushTokenForExperience:experienceStableLegacyId
                                                         deviceToken:self->_currentAPNSToken
                                                   completionHandler:handler];
         return;
@@ -167,8 +167,8 @@ typedef void(^EXRemoteNotificationAPNSTokenHandler)(NSData * _Nullable apnsToken
         }
 
         if (apnsToken) {
-          NSString *experienceId = ((EXScopedBridgeModule *)scopedModule).experienceId;
-          [[EXApiV2Client sharedClient] getExpoPushTokenForExperience:experienceId
+          NSString *experienceStableLegacyId = ((EXScopedBridgeModule *)scopedModule).experienceStableLegacyId;
+          [[EXApiV2Client sharedClient] getExpoPushTokenForExperience:experienceStableLegacyId
                                                           deviceToken:apnsToken
                                                     completionHandler:handler];
         } else {

--- a/ios/Exponent/Kernel/Views/EXAppViewController.m
+++ b/ios/Exponent/Kernel/Views/EXAppViewController.m
@@ -788,7 +788,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)_willAutoRecoverFromError:(NSError *)error
 {
   if (![_appRecord.appManager enablesDeveloperTools]) {
-    BOOL shouldRecover = [[EXKernel sharedInstance].serviceRegistry.errorRecoveryManager experienceIdShouldReloadOnError:_appRecord.experienceId];
+    BOOL shouldRecover = [[EXKernel sharedInstance].serviceRegistry.errorRecoveryManager experienceShouldReloadOnError:_appRecord.scopeKey];
     if (shouldRecover) {
       [self _invalidateRecoveryTimer];
       _tmrAutoReloadDebounce = [NSTimer scheduledTimerWithTimeInterval:kEXAutoReloadDebounceSeconds

--- a/ios/Exponent/Versioned/Core/Api/EXNotifications.h
+++ b/ios/Exponent/Versioned/Core/Api/EXNotifications.h
@@ -34,7 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol EXNotificationsIdentifiersManager
 
-- (NSString *)internalIdForIdentifier:(NSString *)identifier experienceId:(NSString *)experienceId;
+- (NSString *)internalIdForIdentifier:(NSString *)identifier scopeKey:(NSString *)scopeKey;
 - (NSString *)exportedIdForInternalIdentifier:(NSString *)identifier;
 
 @end

--- a/ios/Exponent/Versioned/Core/Api/EXUtil.m
+++ b/ios/Exponent/Versioned/Core/Api/EXUtil.m
@@ -15,9 +15,15 @@ EX_DEFINE_SCOPED_MODULE_GETTER(EXUtil, util)
 
 EX_EXPORT_SCOPED_MODULE(ExponentUtil, UtilService);
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId kernelServiceDelegate:(id<EXUtilService>)kernelServiceInstance params:(NSDictionary *)params
+- (instancetype)initWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId
+                              scopeKey:(NSString *)scopeKey
+                           kernelServiceDelegate:(id<EXUtilService>)kernelServiceInstance
+                                          params:(NSDictionary *)params
 {
-  if (self = [super initWithExperienceId:experienceId kernelServiceDelegate:kernelServiceInstance params:params]) {
+  if (self = [super initWithExperienceStableLegacyId:experienceStableLegacyId
+                                  scopeKey:scopeKey
+                               kernelServiceDelegate:kernelServiceInstance
+                                              params:params]) {
     _kernelUtilService = kernelServiceInstance;
   }
   return self;

--- a/ios/Exponent/Versioned/Core/EXVersionManager.h
+++ b/ios/Exponent/Versioned/Core/EXVersionManager.h
@@ -2,15 +2,17 @@
 
 #import <Foundation/Foundation.h>
 #import <React/RCTLog.h>
+#import <EXUpdates/EXUpdatesRawManifest.h>
 
 @interface EXVersionManager : NSObject
 
 // Uses a params dict since the internal workings may change over time, but we want to keep the interface the same.
-- (instancetype)initWithParams: (NSDictionary *)params
-                  fatalHandler: (void (^)(NSError *))fatalHandler
-                   logFunction: (RCTLogFunction)logFunction
-                  logThreshold: (NSInteger)threshold;
-- (void)bridgeWillStartLoading: (id)bridge;
+- (instancetype)initWithParams:(NSDictionary *)params
+                      manifest:(EXUpdatesRawManifest *)manifest
+                  fatalHandler:(void (^)(NSError *))fatalHandler
+                   logFunction:(RCTLogFunction)logFunction
+                  logThreshold:(NSInteger)threshold;
+- (void)bridgeWillStartLoading:(id)bridge;
 - (void)bridgeFinishedLoading:(id)bridge;
 - (void)invalidate;
 

--- a/ios/Exponent/Versioned/Core/Internal/DevSupport/EXDevSettings.h
+++ b/ios/Exponent/Versioned/Core/Internal/DevSupport/EXDevSettings.h
@@ -5,7 +5,7 @@
 @interface EXDevSettings : RCTDevSettings
 
 - (instancetype)init NS_UNAVAILABLE;
-- (instancetype)initWithExperienceId:(NSString *)experienceId
-                       isDevelopment:(BOOL)isDevelopment NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey
+                             isDevelopment:(BOOL)isDevelopment NS_DESIGNATED_INITIALIZER;
 
 @end

--- a/ios/Exponent/Versioned/Core/Internal/DevSupport/EXDevSettings.m
+++ b/ios/Exponent/Versioned/Core/Internal/DevSupport/EXDevSettings.m
@@ -12,7 +12,7 @@ NSString *const kRCTDevSettingHotLoadingEnabled = @"hotLoadingEnabled";
 
 + (NSString *)moduleName { return @"RCTDevSettings"; }
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId isDevelopment:(BOOL)isDevelopment
+- (instancetype)initWithScopeKey:(NSString *)scopeKey isDevelopment:(BOOL)isDevelopment
 {
   NSDictionary *defaultValues = @{
                                   kRCTDevSettingShakeToShowDevMenu: @YES,
@@ -20,7 +20,7 @@ NSString *const kRCTDevSettingHotLoadingEnabled = @"hotLoadingEnabled";
                                   kRCTDevSettingLiveReloadEnabled: @NO,
                                   };
   EXDevSettingsDataSource *dataSource = [[EXDevSettingsDataSource alloc] initWithDefaultValues:defaultValues
-                                                                               forExperienceId:experienceId
+                                                                         forScopeKey:scopeKey
                                                                                  isDevelopment:isDevelopment];
   return [super initWithDataSource:dataSource];
 }

--- a/ios/Exponent/Versioned/Core/Internal/DevSupport/EXDevSettingsDataSource.h
+++ b/ios/Exponent/Versioned/Core/Internal/DevSupport/EXDevSettingsDataSource.h
@@ -7,7 +7,7 @@
 
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithDefaultValues:(NSDictionary *)defaultValues
-                      forExperienceId:(NSString *)experienceId
+                forScopeKey:(NSString *)scopeKey
                         isDevelopment:(BOOL)isDevelopment NS_DESIGNATED_INITIALIZER;
 
 @end

--- a/ios/Exponent/Versioned/Core/Internal/DevSupport/EXDevSettingsDataSource.m
+++ b/ios/Exponent/Versioned/Core/Internal/DevSupport/EXDevSettingsDataSource.m
@@ -16,7 +16,7 @@ NSString *const EXDevSettingIsDebuggingRemotely = @"isDebuggingRemotely";
 
 @interface EXDevSettingsDataSource ()
 
-@property (nonatomic, strong) NSString *experienceId;
+@property (nonatomic, strong) NSString *scopeKey;
 @property (nonatomic, readonly) NSSet *settingsDisabledInProduction;
 
 @end
@@ -27,10 +27,12 @@ NSString *const EXDevSettingIsDebuggingRemotely = @"isDebuggingRemotely";
   BOOL _isDevelopment;
 }
 
-- (instancetype)initWithDefaultValues:(NSDictionary *)defaultValues forExperienceId:(NSString *)experienceId isDevelopment:(BOOL)isDevelopment
+- (instancetype)initWithDefaultValues:(NSDictionary *)defaultValues
+                forScopeKey:(NSString *)scopeKey
+                        isDevelopment:(BOOL)isDevelopment
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _scopeKey = scopeKey;
     _userDefaults = [NSUserDefaults standardUserDefaults];
     _isDevelopment = isDevelopment;
     _settingsDisabledInProduction = [NSSet setWithArray:@[
@@ -97,8 +99,8 @@ NSString *const EXDevSettingIsDebuggingRemotely = @"isDebuggingRemotely";
 
 - (NSString *)_userDefaultsKey
 {
-  if (_experienceId) {
-    return [NSString stringWithFormat:@"%@/%@", _experienceId, EXDevSettingsUserDefaultsKey];
+  if (_scopeKey) {
+    return [NSString stringWithFormat:@"%@/%@", _scopeKey, EXDevSettingsUserDefaultsKey];
   } else {
     RCTLogWarn(@"Can't scope dev settings because bridge is not set");
     return EXDevSettingsUserDefaultsKey;

--- a/ios/Exponent/Versioned/Core/Internal/EXLinkingManager.m
+++ b/ios/Exponent/Versioned/Core/Internal/EXLinkingManager.m
@@ -22,9 +22,11 @@ NSString * const EXLinkingEventOpenUrl = @"url";
 
 EX_EXPORT_SCOPED_MODULE(RCTLinkingManager, KernelLinkingManager);
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId kernelServiceDelegate:(id)kernelServiceInstance params:(NSDictionary *)params
+- (instancetype)initWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId
+                        scopeKey:(NSString *)scopeKey
+                     kernelServiceDelegate:(id)kernelServiceInstance params:(NSDictionary *)params
 {
-  if (self = [super initWithExperienceId:experienceId kernelServiceDelegate:kernelServiceInstance params:params]) {
+  if (self = [super initWithExperienceStableLegacyId:experienceStableLegacyId scopeKey:scopeKey kernelServiceDelegate:kernelServiceInstance params:params]) {
     _kernelLinkingDelegate = kernelServiceInstance;
     _initialUrl = params[@"initialUri"];
     if (_initialUrl == [NSNull null]) {

--- a/ios/Exponent/Versioned/Core/ScopedModule/EXScopedBridgeModule.h
+++ b/ios/Exponent/Versioned/Core/ScopedModule/EXScopedBridgeModule.h
@@ -7,14 +7,17 @@
 
 - (instancetype)init NS_UNAVAILABLE;
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
-               kernelServiceDelegate:(id)kernelServiceInstance
-                              params:(NSDictionary *)params NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId
+                              scopeKey:(NSString *)scopeKey
+                           kernelServiceDelegate:(id)kernelServiceInstance
+                                          params:(NSDictionary *)params NS_DESIGNATED_INITIALIZER;
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
-               kernelServiceDelegates:(NSDictionary *)kernelServiceInstances
-                              params:(NSDictionary *)params NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId
+                              scopeKey:(NSString *)scopeKey
+                          kernelServiceDelegates:(NSDictionary *)kernelServiceInstances
+                                          params:(NSDictionary *)params NS_DESIGNATED_INITIALIZER;
 
-@property (nonatomic, readonly) NSString *experienceId;
+@property (nonatomic, readonly) NSString *scopeKey;
+@property (nonatomic, readonly) NSString *experienceStableLegacyId;
 
 @end

--- a/ios/Exponent/Versioned/Core/ScopedModule/EXScopedBridgeModule.m
+++ b/ios/Exponent/Versioned/Core/ScopedModule/EXScopedBridgeModule.m
@@ -10,18 +10,26 @@
   return @"ExponentScopedBridgeModule";
 }
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId kernelServiceDelegate:(id)kernelServiceInstance params:(NSDictionary *)params
+- (instancetype)initWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId
+                              scopeKey:(NSString *)scopeKey
+                           kernelServiceDelegate:(id)kernelServiceInstance
+                                          params:(NSDictionary *)params
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _experienceStableLegacyId = experienceStableLegacyId;
+    _scopeKey = scopeKey;
   }
   return self;
 }
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId kernelServiceDelegates:(NSDictionary *)kernelServiceInstances params:(NSDictionary *)params
+- (instancetype)initWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId
+                              scopeKey:(NSString *)scopeKey
+                          kernelServiceDelegates:(NSDictionary *)kernelServiceInstances
+                                          params:(NSDictionary *)params
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _experienceStableLegacyId = experienceStableLegacyId;
+    _scopeKey = scopeKey;
   }
   return self;
 }

--- a/ios/Exponent/Versioned/Core/ScopedModule/EXScopedEventEmitter.h
+++ b/ios/Exponent/Versioned/Core/ScopedModule/EXScopedEventEmitter.h
@@ -4,18 +4,20 @@
 
 @interface EXScopedEventEmitter : RCTEventEmitter
 
-+ (NSString *)getExperienceIdFromEventEmitter:(id)eventEmitter;
++ (NSString *)getScopeKeyFromEventEmitter:(id)eventEmitter;
 
 - (instancetype)init NS_UNAVAILABLE;
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
-               kernelServiceDelegate:(id)kernelServiceInstance
-                              params:(NSDictionary *)params NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId
+                        scopeKey:(NSString *)scopeKey
+                     kernelServiceDelegate:(id)kernelServiceInstance
+                                    params:(NSDictionary *)params NS_DESIGNATED_INITIALIZER;
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
-              kernelServiceDelegates:(NSDictionary *)kernelServiceInstances
-                              params:(NSDictionary *)params NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId
+                        scopeKey:(NSString *)scopeKey
+                    kernelServiceDelegates:(NSDictionary *)kernelServiceInstances
+                                    params:(NSDictionary *)params NS_DESIGNATED_INITIALIZER;
 
-@property (nonatomic, readonly) NSString *experienceId;
+@property (nonatomic, readonly) NSString *scopeKey;
 
 @end

--- a/ios/Exponent/Versioned/Core/ScopedModule/EXScopedEventEmitter.m
+++ b/ios/Exponent/Versioned/Core/ScopedModule/EXScopedEventEmitter.m
@@ -10,26 +10,26 @@
   return @"ExponentScopedEventEmitter";
 }
 
-+ (NSString *)getExperienceIdFromEventEmitter:(id)eventEmitter
++ (NSString *)getScopeKeyFromEventEmitter:(id)eventEmitter
 {
   if (eventEmitter) {
-    return ((EXScopedEventEmitter *)eventEmitter).experienceId;
+    return ((EXScopedEventEmitter *)eventEmitter).scopeKey;
   }
   return nil;
 }
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId kernelServiceDelegate:(id)kernelServiceInstance params:(NSDictionary *)params
+- (instancetype)initWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId scopeKey:(NSString *)scopeKey kernelServiceDelegate:(id)kernelServiceInstance params:(NSDictionary *)params
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _scopeKey = scopeKey;
   }
   return self;
 }
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId kernelServiceDelegates:(NSDictionary *)kernelServiceInstances params:(NSDictionary *)params
+- (instancetype)initWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId scopeKey:(NSString *)scopeKey kernelServiceDelegates:(NSDictionary *)kernelServiceInstances params:(NSDictionary *)params
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _scopeKey = scopeKey;
   }
   return self;
 }

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXConstantsBinding.h
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXConstantsBinding.h
@@ -11,7 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly) NSString *appOwnership;
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId andParams:(NSDictionary *)params;
+- (instancetype)initWithParams:(NSDictionary *)params;
 
 @end
 

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXConstantsBinding.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXConstantsBinding.m
@@ -6,17 +6,15 @@
 @interface EXConstantsBinding ()
 
 @property (nonatomic, strong) NSString *appOwnership;
-@property (nonatomic, strong) NSString *experienceId;
 @property (nonatomic, strong) NSDictionary *unversionedConstants;
 
 @end
 
 @implementation EXConstantsBinding : EXConstantsService
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId andParams:(NSDictionary *)params
+- (instancetype)initWithParams:(NSDictionary *)params
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
     _unversionedConstants = params[@"constants"];
     if (_unversionedConstants && _unversionedConstants[@"appOwnership"]) {
       _appOwnership = _unversionedConstants[@"appOwnership"];

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXFacebook/EXScopedFacebook.h
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXFacebook/EXScopedFacebook.h
@@ -7,7 +7,7 @@
 
 @interface EXScopedFacebook : EXFacebook <UMAppLifecycleListener>
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId andParams:(NSDictionary *)params;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey andParams:(NSDictionary *)params;
 
 @end
 #endif

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXFacebook/EXScopedFacebook.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXFacebook/EXScopedFacebook.m
@@ -44,10 +44,10 @@ static NSString *AUTO_INIT_KEY = @"autoInitEnabled";
 
 @implementation EXScopedFacebook : EXFacebook
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId andParams:(NSDictionary *)params
+- (instancetype)initWithScopeKey:(NSString *)scopeKey andParams:(NSDictionary *)params
 {
   if (self = [super init]) {
-    NSString *suiteName = [NSString stringWithFormat:@"%@#%@", NSStringFromClass(self.class), experienceId];
+    NSString *suiteName = [NSString stringWithFormat:@"%@#%@", NSStringFromClass(self.class), scopeKey];
     _settings = [[NSUserDefaults alloc] initWithSuiteName:suiteName];
 
     BOOL hasPreviouslySetAutoInitEnabled = [_settings boolForKey:AUTO_INIT_KEY];

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationBuilder.h
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationBuilder.h
@@ -9,8 +9,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface EXScopedNotificationBuilder : EXNotificationBuilder
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
-                 andConstantsBinding:(EXConstantsBinding *)constantsBinding;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey
+                       andConstantsBinding:(EXConstantsBinding *)constantsBinding;
 
 @end
 

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationBuilder.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationBuilder.m
@@ -5,18 +5,18 @@
 
 @interface EXScopedNotificationBuilder ()
 
-@property (nonatomic, strong) NSString *experienceId;
+@property (nonatomic, strong) NSString *scopeKey;
 @property (nonatomic, assign) BOOL isInExpoGo;
 
 @end
 
 @implementation EXScopedNotificationBuilder
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
-                 andConstantsBinding:(EXConstantsBinding *)constantsBinding
+- (instancetype)initWithScopeKey:(NSString *)scopeKey
+                       andConstantsBinding:(EXConstantsBinding *)constantsBinding
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _scopeKey = scopeKey;
     _isInExpoGo = [@"expo" isEqualToString:constantsBinding.appOwnership];
   }
   
@@ -30,12 +30,13 @@
   if (!userInfo) {
     userInfo = [NSMutableDictionary dictionary];
   }
-  userInfo[@"experienceId"] = _experienceId;
+  userInfo[@"experienceId"] = _scopeKey;
+  userInfo[@"scopeKey"] = _scopeKey;
   [content setUserInfo:userInfo];
   
   if (content.categoryIdentifier && _isInExpoGo) {
     NSString *scopedCategoryIdentifier = [EXScopedNotificationsUtils scopedIdentifierFromId:content.categoryIdentifier
-                                                                              forExperience:_experienceId];
+                                                                              forExperience:_scopeKey];
     [content setCategoryIdentifier:scopedCategoryIdentifier];
   }
   

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationCategoriesModule.h
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationCategoriesModule.h
@@ -9,11 +9,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface EXScopedNotificationCategoriesModule : EXNotificationCategoriesModule
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
-                 andConstantsBinding:(EXConstantsBinding *)constantsBinding;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey
+                       andConstantsBinding:(EXConstantsBinding *)constantsBinding;
 
-+ (void)maybeMigrateLegacyCategoryIdentifiersForProject:(NSString *)experienceId
-                                             isInExpoGo:(BOOL)isInExpoGo;
++ (void)maybeMigrateLegacyCategoryIdentifiersForProjectWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId
+                                                                 scopeKey:(NSString *)scopeKey
+                                                                         isInExpoGo:(BOOL)isInExpoGo;
 
 @end
 

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationCategoriesModule.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationCategoriesModule.m
@@ -6,17 +6,17 @@
 
 @interface EXScopedNotificationCategoriesModule ()
 
-@property (nonatomic, strong) NSString *experienceId;
+@property (nonatomic, strong) NSString *scopeKey;
 
 @end
 
 @implementation EXScopedNotificationCategoriesModule
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
-                 andConstantsBinding:(EXConstantsBinding *)constantsBinding
+- (instancetype)initWithScopeKey:(NSString *)scopeKey
+                       andConstantsBinding:(EXConstantsBinding *)constantsBinding
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _scopeKey = scopeKey;
   }
   return self;
 }
@@ -26,7 +26,7 @@
   [[UNUserNotificationCenter currentNotificationCenter] getNotificationCategoriesWithCompletionHandler:^(NSSet<UNNotificationCategory *> *categories) {
     NSMutableArray* existingCategories = [NSMutableArray new];
     for (UNNotificationCategory *category in categories) {
-      if ([EXScopedNotificationsUtils isId:category.identifier scopedByExperience:self->_experienceId]) {
+      if ([EXScopedNotificationsUtils isId:category.identifier scopedByExperience:self->_scopeKey]) {
         [existingCategories addObject:[self serializeCategory:category]];
       }
     }
@@ -41,7 +41,7 @@
                                        reject:(UMPromiseRejectBlock)reject
 {
   NSString *scopedCategoryIdentifier = [EXScopedNotificationsUtils scopedIdentifierFromId:categoryId
-                                                                            forExperience:_experienceId];
+                                                                            forExperience:_scopeKey];
   [super setNotificationCategoryWithCategoryId:scopedCategoryIdentifier
                                        actions:actions
                                        options:options
@@ -54,7 +54,7 @@
                                           reject:(UMPromiseRejectBlock)reject
 {
   NSString *scopedCategoryIdentifier = [EXScopedNotificationsUtils scopedIdentifierFromId:categoryId
-                                                                            forExperience:_experienceId];
+                                                                            forExperience:_scopeKey];
   [super deleteNotificationCategoryWithCategoryId:scopedCategoryIdentifier
                                           resolve:resolve
                                            reject:reject];
@@ -70,14 +70,16 @@
 
 #pragma mark - static method for migrating categories in both Expo Go and standalones. Added in SDK 41. TODO(Cruzan): Remove in SDK 47
 
-+ (void)maybeMigrateLegacyCategoryIdentifiersForProject:(NSString *)experienceId isInExpoGo:(BOOL)isInExpoGo
++ (void)maybeMigrateLegacyCategoryIdentifiersForProjectWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId
+                                                                 scopeKey:(NSString *)scopeKey
+                                                                         isInExpoGo:(BOOL)isInExpoGo
 {
   if (isInExpoGo) {
     // Changed scoping prefix in SDK 41 FROM "experienceId-" to ESCAPED "experienceId/"
-    [EXScopedNotificationCategoryMigrator migrateLegacyScopedCategoryIdentifiersForProject:experienceId];
+    [EXScopedNotificationCategoryMigrator migrateLegacyScopedCategoryIdentifiersForProjectWithScopeKey:scopeKey];
   } else {
     // Used to prefix with "experienceId-" even in standalone apps in SDKs <= 40, so we need to unscope those
-    [EXScopedNotificationCategoryMigrator unscopeLegacyCategoryIdentifiersForProject:experienceId];
+    [EXScopedNotificationCategoryMigrator unscopeLegacyCategoryIdentifiersForProjectWithScopeKey:scopeKey];
   }
 }
 

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationCategoryMigrator.h
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationCategoryMigrator.h
@@ -5,7 +5,7 @@
 
 @interface EXScopedNotificationCategoryMigrator : NSObject <EXNotificationsDelegate>
 
-+ (void)unscopeLegacyCategoryIdentifiersForProject:(NSString *)experienceId;
-+ (void)migrateLegacyScopedCategoryIdentifiersForProject:(NSString *)experienceId;
++ (void)unscopeLegacyCategoryIdentifiersForProjectWithScopeKey:(NSString *)scopeKey;
++ (void)migrateLegacyScopedCategoryIdentifiersForProjectWithScopeKey:(NSString *)scopeKey;
 
 @end

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationCategoryMigrator.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationCategoryMigrator.m
@@ -5,33 +5,33 @@
 
 @implementation EXScopedNotificationCategoryMigrator
 
-+ (void)migrateLegacyScopedCategoryIdentifiersForProject:(NSString *)experienceId
++ (void)migrateLegacyScopedCategoryIdentifiersForProjectWithScopeKey:(NSString *)scopeKey
 {
-  [EXScopedNotificationCategoryMigrator renameLegacyCategoryIdentifiersForExperience:experienceId withBlock:^(UNNotificationCategory *oldCategory) {
-    NSString *unscopedLegacyCategoryId = [EXScopedNotificationsUtils unscopedLegacyCategoryIdentifierWithId:oldCategory.identifier forExperience:experienceId];
+  [EXScopedNotificationCategoryMigrator renameLegacyCategoryIdentifiersForExperienceWithScopeKey:scopeKey withBlock:^(UNNotificationCategory *oldCategory) {
+    NSString *unscopedLegacyCategoryId = [EXScopedNotificationsUtils unscopedLegacyCategoryIdentifierWithId:oldCategory.identifier forScopeKey:scopeKey];
     NSString *newCategoryId = [EXScopedNotificationsUtils scopedIdentifierFromId:unscopedLegacyCategoryId
-                                                                   forExperience:experienceId];
+                                                                   forExperience:scopeKey];
     UNNotificationCategory *newCategory = [EXScopedNotificationCategoryMigrator createNewCategoryFrom:oldCategory withNewIdentifier:newCategoryId];
     return newCategory;
   }];
 }
 
-+ (void)unscopeLegacyCategoryIdentifiersForProject:(NSString *)experienceId
++ (void)unscopeLegacyCategoryIdentifiersForProjectWithScopeKey:(NSString *)scopeKey
 {
-  [EXScopedNotificationCategoryMigrator renameLegacyCategoryIdentifiersForExperience:experienceId withBlock:^(UNNotificationCategory *oldCategory) {
-    NSString *unscopedCategoryId = [EXScopedNotificationsUtils unscopedLegacyCategoryIdentifierWithId:oldCategory.identifier forExperience:experienceId];
+  [EXScopedNotificationCategoryMigrator renameLegacyCategoryIdentifiersForExperienceWithScopeKey:scopeKey withBlock:^(UNNotificationCategory *oldCategory) {
+    NSString *unscopedCategoryId = [EXScopedNotificationsUtils unscopedLegacyCategoryIdentifierWithId:oldCategory.identifier forScopeKey:scopeKey];
     UNNotificationCategory *newCategory = [EXScopedNotificationCategoryMigrator createNewCategoryFrom:oldCategory withNewIdentifier:unscopedCategoryId];
     return newCategory;
   }];
 }
 
-+ (void)renameLegacyCategoryIdentifiersForExperience:(NSString *)experienceId withBlock:(UNNotificationCategory *(^)(UNNotificationCategory *category))renameCategoryBlock
++ (void)renameLegacyCategoryIdentifiersForExperienceWithScopeKey:(NSString *)scopeKey withBlock:(UNNotificationCategory *(^)(UNNotificationCategory *category))renameCategoryBlock
 {
   [[UNUserNotificationCenter currentNotificationCenter] getNotificationCategoriesWithCompletionHandler:^(NSSet<UNNotificationCategory *> *categories) {
     NSMutableSet<UNNotificationCategory *> *newCategories = [categories mutableCopy];
     BOOL didChangeCategories = NO;
     for (UNNotificationCategory *previousCategory in categories) {
-      if ([EXScopedNotificationsUtils isLegacyCategoryId:previousCategory.identifier scopedByExperience:experienceId]) {
+      if ([EXScopedNotificationsUtils isLegacyCategoryId:previousCategory.identifier scopedByScopeKey:scopeKey]) {
         UNNotificationCategory *newCategory = renameCategoryBlock(previousCategory);
         [newCategories removeObject:previousCategory];
         [newCategories addObject:newCategory];

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationPresentationModule.h
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationPresentationModule.h
@@ -8,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface EXScopedNotificationPresentationModule : EXNotificationPresentationModule
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey;
 
 @end
 

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationPresentationModule.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationPresentationModule.m
@@ -7,16 +7,16 @@
 
 @interface EXScopedNotificationPresentationModule ()
 
-@property (nonatomic, strong) NSString *experienceId;
+@property (nonatomic, strong) NSString *scopeKey;
 
 @end
 
 @implementation EXScopedNotificationPresentationModule
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
+- (instancetype)initWithScopeKey:(NSString *)scopeKey
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _scopeKey = scopeKey;
   }
   
   return self;
@@ -26,7 +26,7 @@
 {
   NSMutableArray *serializedNotifications = [NSMutableArray new];
   for (UNNotification *notification in notifications) {
-    if ([EXScopedNotificationsUtils shouldNotification:notification beHandledByExperience:_experienceId]) {
+    if ([EXScopedNotificationsUtils shouldNotification:notification beHandledByExperience:_scopeKey]) {
       [serializedNotifications addObject:[EXScopedNotificationSerializer serializedNotification:notification]];
     }
   }
@@ -35,10 +35,10 @@
 
 - (void)dismissNotificationWithIdentifier:(NSString *)identifier resolve:(UMPromiseResolveBlock)resolve reject:(UMPromiseRejectBlock)reject
 {
-  __block NSString *experienceId = _experienceId;
+  __block NSString *scopeKey = _scopeKey;
   [[UNUserNotificationCenter currentNotificationCenter] getDeliveredNotificationsWithCompletionHandler:^(NSArray<UNNotification *> * _Nonnull notifications) {
     for (UNNotification *notification in notifications) {
-      if ([EXScopedNotificationsUtils shouldNotification:notification beHandledByExperience:experienceId]) {
+      if ([EXScopedNotificationsUtils shouldNotification:notification beHandledByExperience:scopeKey]) {
         // Usually we would scope the input ID and then check equality, but remote notifications do not
         // have the scoping prefix, so instead let's remove the scope if there is one, then check for
         // equality against the input
@@ -55,11 +55,11 @@
 
 - (void)dismissAllNotificationsWithResolver:(UMPromiseResolveBlock)resolve reject:(UMPromiseRejectBlock)reject
 {
-  __block NSString *experienceId = _experienceId;
+  __block NSString *scopeKey = _scopeKey;
   [[UNUserNotificationCenter currentNotificationCenter] getDeliveredNotificationsWithCompletionHandler:^(NSArray<UNNotification *> * _Nonnull notifications) {
     NSMutableArray<NSString *> *toDismiss = [NSMutableArray new];
     for (UNNotification *notification in notifications) {
-      if ([EXScopedNotificationsUtils shouldNotification:notification beHandledByExperience:experienceId]) {
+      if ([EXScopedNotificationsUtils shouldNotification:notification beHandledByExperience:scopeKey]) {
         [toDismiss addObject:notification.request.identifier];
       }
     }

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationSchedulerModule.h
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationSchedulerModule.h
@@ -8,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface EXScopedNotificationSchedulerModule : EXNotificationSchedulerModule
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey;
 
 @end
 

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationSchedulerModule.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationSchedulerModule.m
@@ -7,16 +7,16 @@
 
 @interface EXScopedNotificationSchedulerModule ()
 
-@property (nonatomic, strong) NSString *experienceId;
+@property (nonatomic, strong) NSString *scopeKey;
 
 @end
 
 @implementation EXScopedNotificationSchedulerModule
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
+- (instancetype)initWithScopeKey:(NSString *)scopeKey
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _scopeKey = scopeKey;
   }
 
   return self;
@@ -27,7 +27,7 @@
                                                           trigger:(NSDictionary *)triggerInput
 {
   NSString *scopedIdentifier = [EXScopedNotificationsUtils scopedIdentifierFromId:identifier
-                                                                    forExperience:_experienceId];
+                                                                    forExperience:_scopeKey];
   return [super buildNotificationRequestWithIdentifier:scopedIdentifier content:contentInput trigger:triggerInput];
 }
 
@@ -35,7 +35,7 @@
 {
   NSMutableArray *serializedRequests = [NSMutableArray new];
   for (UNNotificationRequest *request in requests) {
-    if ([EXScopedNotificationsUtils isId:request.identifier scopedByExperience:_experienceId]) {
+    if ([EXScopedNotificationsUtils isId:request.identifier scopedByExperience:_scopeKey]) {
       [serializedRequests addObject:[EXScopedNotificationSerializer serializedNotificationRequest:request]];
     }
   }
@@ -46,17 +46,17 @@
 - (void)cancelNotification:(NSString *)identifier resolve:(UMPromiseResolveBlock)resolve rejecting:(UMPromiseRejectBlock)reject
 {
   NSString *scopedIdentifier = [EXScopedNotificationsUtils scopedIdentifierFromId:identifier
-                                                                    forExperience:_experienceId];
+                                                                    forExperience:_scopeKey];
   [super cancelNotification:scopedIdentifier resolve:resolve rejecting:reject];
 }
 
 - (void)cancelAllNotificationsWithResolver:(UMPromiseResolveBlock)resolve rejecting:(UMPromiseRejectBlock)reject
 {
-  __block NSString *experienceId = _experienceId;
+  __block NSString *scopeKey = _scopeKey;
   [[UNUserNotificationCenter currentNotificationCenter] getPendingNotificationRequestsWithCompletionHandler:^(NSArray<UNNotificationRequest *> * _Nonnull requests) {
     NSMutableArray<NSString *> *toRemove = [NSMutableArray new];
     for (UNNotificationRequest *request in requests) {
-      if ([EXScopedNotificationsUtils isId:request.identifier scopedByExperience:experienceId]) {
+      if ([EXScopedNotificationsUtils isId:request.identifier scopedByExperience:scopeKey]) {
         [toRemove addObject:request.identifier];
       }
     }

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationsEmitter.h
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationsEmitter.h
@@ -8,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface EXScopedNotificationsEmitter : EXNotificationsEmitter
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey;
 
 @end
 

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationsEmitter.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationsEmitter.m
@@ -8,7 +8,7 @@
 
 @interface EXScopedNotificationsEmitter ()
 
-@property (nonatomic, strong) NSString *experienceId;
+@property (nonatomic, strong) NSString *scopeKey;
 
 @end
 
@@ -21,10 +21,10 @@
 
 @implementation EXScopedNotificationsEmitter
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
+- (instancetype)initWithScopeKey:(NSString *)scopeKey
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _scopeKey = scopeKey;
   }
   
   return self;
@@ -32,7 +32,7 @@
 
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center didReceiveNotificationResponse:(UNNotificationResponse *)response withCompletionHandler:(void (^)(void))completionHandler
 {
-  if ([EXScopedNotificationsUtils shouldNotification:response.notification beHandledByExperience:_experienceId]) {
+  if ([EXScopedNotificationsUtils shouldNotification:response.notification beHandledByExperience:_scopeKey]) {
     [super userNotificationCenter:center didReceiveNotificationResponse:response withCompletionHandler:completionHandler];
   } else {
     completionHandler();
@@ -41,7 +41,7 @@
 
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center willPresentNotification:(UNNotification *)notification withCompletionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler
 {
-  if ([EXScopedNotificationsUtils shouldNotification:notification beHandledByExperience:_experienceId]) {
+  if ([EXScopedNotificationsUtils shouldNotification:notification beHandledByExperience:_scopeKey]) {
     [super userNotificationCenter:center willPresentNotification:notification withCompletionHandler:completionHandler];
   } else {
     completionHandler(UNNotificationPresentationOptionNone);

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationsHandlerModule.h
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationsHandlerModule.h
@@ -8,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface EXScopedNotificationsHandlerModule : EXNotificationsHandlerModule
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey;
 
 @end
 

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationsHandlerModule.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationsHandlerModule.m
@@ -5,16 +5,16 @@
 
 @interface EXScopedNotificationsHandlerModule ()
 
-@property (nonatomic, strong) NSString *experienceId;
+@property (nonatomic, strong) NSString *scopeKey;
 
 @end
 
 @implementation EXScopedNotificationsHandlerModule
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
+- (instancetype)initWithScopeKey:(NSString *)scopeKey
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _scopeKey = scopeKey;
   }
   
   return self;
@@ -22,7 +22,7 @@
 
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center willPresentNotification:(UNNotification *)notification withCompletionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler
 {
-  if ([EXScopedNotificationsUtils shouldNotification:notification beHandledByExperience:_experienceId]) {
+  if ([EXScopedNotificationsUtils shouldNotification:notification beHandledByExperience:_scopeKey]) {
     [super userNotificationCenter:center willPresentNotification:notification withCompletionHandler:completionHandler];
   }
 }

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationsUtils.h
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationsUtils.h
@@ -11,19 +11,20 @@ typedef struct {
 
 @interface EXScopedNotificationsUtils : NSObject
 
-+ (BOOL)shouldNotificationRequest:(UNNotificationRequest *)request beHandledByExperience:(NSString *)experienceId;
++ (BOOL)shouldNotificationRequest:(UNNotificationRequest *)request beHandledByExperience:(NSString *)scopeKey;
 
-+ (BOOL)shouldNotification:(UNNotification *)notification beHandledByExperience:(NSString *)experienceId;
++ (BOOL)shouldNotification:(UNNotification *)notification beHandledByExperience:(NSString *)scopeKey;
 
-+ (NSString *)scopedIdentifierFromId:(NSString *)unscopedId forExperience:(NSString *)experienceId;
++ (NSString *)scopedIdentifierFromId:(NSString *)unscopedId forExperience:(NSString *)scopeKey;
 
-+ (BOOL)isId:(NSString *)identifier scopedByExperience:(NSString *)experienceId;
++ (BOOL)isId:(NSString *)identifier scopedByExperience:(NSString *)scopeKey;
 
 + (ScopedIdentifierComponents)getScopeAndIdentifierFromScopedIdentifier:(NSString *)scopedIdentifier;
 
-+ (BOOL)isLegacyCategoryId:(NSString *) scopedCategoryId scopedByExperience:(NSString *) experienceId;
++ (BOOL)isLegacyCategoryId:(NSString *)scopedCategoryId scopedByScopeKey:(NSString *)scopeKey;
 
-+ (NSString *)unscopedLegacyCategoryIdentifierWithId:(NSString *) scopedCategoryId forExperience:(NSString *) experienceId;
++ (NSString *)unscopedLegacyCategoryIdentifierWithId:(NSString *)scopedCategoryId
+                         forScopeKey:(NSString *)scopeKey;
 
 @end
 

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationsUtils.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationsUtils.m
@@ -4,31 +4,31 @@
 
 @implementation EXScopedNotificationsUtils
 
-+ (BOOL)shouldNotificationRequest:(UNNotificationRequest *)request beHandledByExperience:(NSString *)experienceId
++ (BOOL)shouldNotificationRequest:(UNNotificationRequest *)request beHandledByExperience:(NSString *)scopeKey
 {
-  NSString *notificationExperienceId = request.content.userInfo[@"experienceId"];
-  if (!notificationExperienceId) {
+  NSString *notificationScopeKey = request.content.userInfo[@"experienceId"];
+  if (!notificationScopeKey) {
     return true;
   }
-  return [notificationExperienceId isEqual:experienceId];
+  return [notificationScopeKey isEqual:scopeKey];
 }
 
-+ (BOOL)shouldNotification:(UNNotification *)notification beHandledByExperience:(NSString *)experienceId
++ (BOOL)shouldNotification:(UNNotification *)notification beHandledByExperience:(NSString *)scopeKey
 {
-  return [EXScopedNotificationsUtils shouldNotificationRequest:notification.request beHandledByExperience:experienceId];
+  return [EXScopedNotificationsUtils shouldNotificationRequest:notification.request beHandledByExperience:scopeKey];
 }
 
-+ (NSString *)scopedIdentifierFromId:(NSString *)unscopedId forExperience:(NSString *)experienceId
++ (NSString *)scopedIdentifierFromId:(NSString *)unscopedId forExperience:(NSString *)scopeKey
 {
-  NSString *scope = [EXScopedNotificationsUtils escapedString:experienceId];
+  NSString *scope = [EXScopedNotificationsUtils escapedString:scopeKey];
   NSString *escapedCategoryId = [EXScopedNotificationsUtils escapedString:unscopedId];
   return [NSString stringWithFormat:@"%@/%@", scope, escapedCategoryId];
 }
 
-+ (BOOL)isId:(NSString *)identifier scopedByExperience:(NSString *)experienceId
++ (BOOL)isId:(NSString *)identifier scopedByExperience:(NSString *)scopeKey
 {
   NSString *scopeFromCategoryId = [EXScopedNotificationsUtils getScopeAndIdentifierFromScopedIdentifier:identifier].scopeKey;
-  return [scopeFromCategoryId isEqualToString:experienceId];
+  return [scopeFromCategoryId isEqualToString:scopeKey];
 }
 
 + (ScopedIdentifierComponents)getScopeAndIdentifierFromScopedIdentifier:(NSString *)scopedIdentifier
@@ -73,17 +73,17 @@
 
 # pragma mark Legacy notification category scoping
 
-+ (BOOL)isLegacyCategoryId:(NSString *) scopedCategoryId scopedByExperience:(NSString *) experienceId
++ (BOOL)isLegacyCategoryId:(NSString *)scopedCategoryId scopedByScopeKey:(NSString *)scopeKey
 {
-  NSString* legacyScopingPrefix = [NSString stringWithFormat:@"%@-", experienceId];
+  NSString* legacyScopingPrefix = [NSString stringWithFormat:@"%@-", scopeKey];
   return [scopedCategoryId hasPrefix:legacyScopingPrefix];
 }
 
 // legacy categories were stored under an unescaped experienceId
-+ (NSString *)unscopedLegacyCategoryIdentifierWithId:(NSString *) scopedCategoryId
-                                       forExperience:(NSString *) experienceId
++ (NSString *)unscopedLegacyCategoryIdentifierWithId:(NSString *)scopedCategoryId
+                         forScopeKey:(NSString *)scopeKey
 {
-  NSString* legacyScopingPrefix = [NSString stringWithFormat:@"%@-", experienceId];
+  NSString* legacyScopingPrefix = [NSString stringWithFormat:@"%@-", scopeKey];
   return [scopedCategoryId stringByReplacingOccurrencesOfString:legacyScopingPrefix
                                                      withString:@""
                                                         options:NSAnchoredSearch

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedServerRegistrationModule.h
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedServerRegistrationModule.h
@@ -8,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface EXScopedServerRegistrationModule : EXServerRegistrationModule
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey;
 
 @end
 

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedServerRegistrationModule.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedServerRegistrationModule.m
@@ -16,23 +16,23 @@ static NSString * const kEXRegistrationInfoKey = EX_UNVERSIONED(@"EXNotification
 
 @interface EXScopedServerRegistrationModule ()
 
-@property (nonatomic, strong) NSString *experienceId;
+@property (nonatomic, strong) NSString *scopeKey;
 
 @end
 
 @implementation EXScopedServerRegistrationModule
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
+- (instancetype)initWithScopeKey:(NSString *)scopeKey
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _scopeKey = scopeKey;
   }
   return self;
 }
 
 - (NSDictionary *)registrationSearchQueryMerging:(NSDictionary *)dictionaryToMerge
 {
-  NSString *scopedKey = [kEXRegistrationInfoKey stringByAppendingFormat:@"-%@", _experienceId];
+  NSString *scopedKey = [kEXRegistrationInfoKey stringByAppendingFormat:@"-%@", _scopeKey];
   return [self keychainSearchQueryFor:scopedKey merging:dictionaryToMerge];
 }
 

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXScopedAmplitude.h
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXScopedAmplitude.h
@@ -7,7 +7,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface EXScopedAmplitude : EXAmplitude
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId;
+- (instancetype)initWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId;
 
 @end
 

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXScopedAmplitude.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXScopedAmplitude.m
@@ -12,30 +12,30 @@
 
 @interface EXScopedAmplitude ()
 
-@property (strong, nonatomic) NSString *escapedExperienceId;
+@property (strong, nonatomic) NSString *escapedExperienceStableLegacyId;
 
 @end
 
 @implementation EXScopedAmplitude
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
+- (instancetype)initWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId
 {
   if (self = [super init]) {
-    _escapedExperienceId = [self escapedExperienceId:experienceId];
+    _escapedExperienceStableLegacyId = [self escapedExperienceStableLegacyId:experienceStableLegacyId];
   }
   return self;
 }
 
 - (Amplitude *)amplitudeInstance
 {
-  return [Amplitude instanceWithName:_escapedExperienceId];
+  return [Amplitude instanceWithName:_escapedExperienceStableLegacyId];
 }
 
-- (NSString *)escapedExperienceId:(NSString *)experienceId
+- (NSString *)escapedExperienceStableLegacyId:(NSString *)experienceStableLegacyId
 {
   NSString *charactersToEscape = @"!*'();:@&=+$,/?%#[]";
   NSCharacterSet *allowedCharacters = [[NSCharacterSet characterSetWithCharactersInString:charactersToEscape] invertedSet];
-  return [experienceId stringByAddingPercentEncodingWithAllowedCharacters:allowedCharacters];
+  return [experienceStableLegacyId stringByAddingPercentEncodingWithAllowedCharacters:allowedCharacters];
 }
 
 @end

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXScopedBranch.h
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXScopedBranch.h
@@ -15,9 +15,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface EXScopedBranch : RNBranch <UMModuleRegistryConsumer, UMInternalModule>
 
-@property (nonatomic, strong) NSString *experienceId;
+@property (nonatomic, strong) NSString *scopeKey;
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey;
 
 @end
 

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXScopedBranch.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXScopedBranch.m
@@ -20,11 +20,11 @@
   return @[@protocol(EXDummyBranchProtocol)];
 }
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
+- (instancetype)initWithScopeKey:(NSString *)scopeKey
 {
   if (self = [super init]) {
     [[NSNotificationCenter defaultCenter] removeObserver:self name:RNBranchLinkOpenedNotification object:nil];
-    _experienceId = experienceId;
+    _scopeKey = scopeKey;
   }
   return self;
 }

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXScopedErrorRecoveryModule.h
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXScopedErrorRecoveryModule.h
@@ -5,7 +5,7 @@
 
 @interface EXScopedErrorRecoveryModule : EXErrorRecoveryModule
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey;
 
 @end
 

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXScopedErrorRecoveryModule.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXScopedErrorRecoveryModule.m
@@ -5,16 +5,16 @@
 
 @interface EXScopedErrorRecoveryModule ()
 
-@property (nonatomic, strong) NSString *experienceId;
+@property (nonatomic, strong) NSString *scopeKey;
 
 @end
 
 @implementation EXScopedErrorRecoveryModule
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
+- (instancetype)initWithScopeKey:(NSString *)scopeKey
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _scopeKey = scopeKey;
   }
   return self;
 }
@@ -24,7 +24,7 @@
   NSUserDefaults *preferences = [NSUserDefaults standardUserDefaults];
   NSDictionary *errorRecoveryStore = [preferences dictionaryForKey:[self userDefaultsKey]] ?: @{};
   NSMutableDictionary *newStore = [errorRecoveryStore mutableCopy];
-  newStore[_experienceId] = props;
+  newStore[_scopeKey] = props;
   [preferences setObject:newStore forKey:[self userDefaultsKey]];
   return [preferences synchronize];
 }
@@ -34,10 +34,10 @@
   NSUserDefaults *preferences = [NSUserDefaults standardUserDefaults];
   NSDictionary *errorRecoveryStore = [preferences dictionaryForKey:[self userDefaultsKey]];
   if (errorRecoveryStore) {
-    NSString *props = errorRecoveryStore[_experienceId];
+    NSString *props = errorRecoveryStore[_scopeKey];
     if (props) {
       NSMutableDictionary *storeWithRemovedProps = [errorRecoveryStore mutableCopy];
-      [storeWithRemovedProps removeObjectForKey:_experienceId];
+      [storeWithRemovedProps removeObjectForKey:_scopeKey];
       [preferences setObject:storeWithRemovedProps forKey:[self userDefaultsKey]];
       [preferences synchronize];
       return props;

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXScopedFirebaseCore.h
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXScopedFirebaseCore.h
@@ -9,7 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface EXScopedFirebaseCore : EXFirebaseCore
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId andConstantsBinding:(EXConstantsBinding *)constantsBinding;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey andConstantsBinding:(EXConstantsBinding *)constantsBinding;
 
 @end
 

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXScopedFirebaseCore.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXScopedFirebaseCore.m
@@ -13,7 +13,7 @@
   NSDictionary* _protectedAppNames;
 }
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId andConstantsBinding:(EXConstantsBinding *)constantsBinding
+- (instancetype)initWithScopeKey:(NSString *)scopeKey andConstantsBinding:(EXConstantsBinding *)constantsBinding
 {
   if (![@"expo" isEqualToString:constantsBinding.appOwnership]) {
     return [super init];
@@ -34,8 +34,8 @@
   if ([FIRApp defaultApp]) [protectedAppNames setValue:@YES forKey:[FIRApp defaultApp].name];
   
   // Determine project app name & options
-  NSString *encodedExperienceId = [self.class encodedResourceName:experienceId];
-  NSString* appName = [NSString stringWithFormat:@"__sandbox_%@", encodedExperienceId];
+  NSString *encodedScopeKey = [self.class encodedResourceName:scopeKey];
+  NSString* appName = [NSString stringWithFormat:@"__sandbox_%@", encodedScopeKey];
   NSDictionary* googleServicesFile = [self.class googleServicesFileFromConstantsManifest:constantsBinding];
   FIROptions* options = [self.class optionsWithGoogleServicesFile:googleServicesFile];
   

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXScopedModuleRegistryAdapter.h
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXScopedModuleRegistryAdapter.h
@@ -5,6 +5,9 @@
 
 @interface EXScopedModuleRegistryAdapter : UMModuleRegistryAdapter
 
-- (UMModuleRegistry *)moduleRegistryForParams:(NSDictionary *)params forExperienceId:(NSString *)experienceId withKernelServices:(NSDictionary *)kernelServices;
+- (UMModuleRegistry *)moduleRegistryForParams:(NSDictionary *)params
+                  forExperienceStableLegacyId:(NSString *)experienceStableLegacyId
+                           scopeKey:(NSString *)scopeKey
+                           withKernelServices:(NSDictionary *)kernelServices;
 
 @end

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXScopedModuleRegistryAdapter.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXScopedModuleRegistryAdapter.m
@@ -37,24 +37,29 @@
 
 @implementation EXScopedModuleRegistryAdapter
 
-- (UMModuleRegistry *)moduleRegistryForParams:(NSDictionary *)params forExperienceId:(NSString *)experienceId withKernelServices:(NSDictionary *)kernelServices
+- (UMModuleRegistry *)moduleRegistryForParams:(NSDictionary *)params
+                  forExperienceStableLegacyId:(NSString *)experienceStableLegacyId
+                           scopeKey:(NSString *)scopeKey
+                           withKernelServices:(NSDictionary *)kernelServices
 {
   UMModuleRegistry *moduleRegistry = [self.moduleRegistryProvider moduleRegistry];
 
 #if __has_include(<EXUpdates/EXUpdatesService.h>)
-  EXUpdatesBinding *updatesBinding = [[EXUpdatesBinding alloc] initWithExperienceId:experienceId updatesKernelService:kernelServices[EX_UNVERSIONED(@"EXUpdatesManager")] databaseKernelService:kernelServices[EX_UNVERSIONED(@"EXUpdatesDatabaseManager")]];
+  EXUpdatesBinding *updatesBinding = [[EXUpdatesBinding alloc] initWithScopeKey:scopeKey
+                                                                     updatesKernelService:kernelServices[EX_UNVERSIONED(@"EXUpdatesManager")]
+                                                                    databaseKernelService:kernelServices[EX_UNVERSIONED(@"EXUpdatesDatabaseManager")]];
   [moduleRegistry registerInternalModule:updatesBinding];
 #endif
 
 #if __has_include(<EXConstants/EXConstantsService.h>)
-  EXConstantsBinding *constantsBinding = [[EXConstantsBinding alloc] initWithExperienceId:experienceId andParams:params];
+  EXConstantsBinding *constantsBinding = [[EXConstantsBinding alloc] initWithParams:params];
   [moduleRegistry registerInternalModule:constantsBinding];
 #endif
 
 #if __has_include(<EXFacebook/EXFacebook.h>)
   // only override in Expo Go
   if ([params[@"constants"][@"appOwnership"] isEqualToString:@"expo"]) {
-    EXScopedFacebook *scopedFacebook = [[EXScopedFacebook alloc] initWithExperienceId:experienceId andParams:params];
+    EXScopedFacebook *scopedFacebook = [[EXScopedFacebook alloc] initWithScopeKey:scopeKey andParams:params];
     [moduleRegistry registerExportedModule:scopedFacebook];
   }
 #endif
@@ -80,7 +85,7 @@
 #endif
 
 #if __has_include(<EXSensors/EXSensorsManager.h>)
-  EXSensorsManagerBinding *sensorsManagerBinding = [[EXSensorsManagerBinding alloc] initWithExperienceId:experienceId andKernelService:kernelServices[EX_UNVERSIONED(@"EXSensorManager")]];
+  EXSensorsManagerBinding *sensorsManagerBinding = [[EXSensorsManagerBinding alloc] initWithScopeKey:scopeKey andKernelService:kernelServices[EX_UNVERSIONED(@"EXSensorManager")]];
   [moduleRegistry registerInternalModule:sensorsManagerBinding];
 #endif
 
@@ -96,17 +101,17 @@
 #endif
 
 #if __has_include(<EXSecureStore/EXSecureStore.h>)
-  EXScopedSecureStore *secureStoreModule = [[EXScopedSecureStore alloc] initWithExperienceId:experienceId andConstantsBinding:constantsBinding];
+  EXScopedSecureStore *secureStoreModule = [[EXScopedSecureStore alloc] initWithScopeKey:scopeKey andConstantsBinding:constantsBinding];
   [moduleRegistry registerExportedModule:secureStoreModule];
 #endif
 
 #if __has_include(<EXAmplitude/EXAmplitude.h>)
-  EXScopedAmplitude *amplitudeModule = [[EXScopedAmplitude alloc] initWithExperienceId:experienceId];
+  EXScopedAmplitude *amplitudeModule = [[EXScopedAmplitude alloc] initWithExperienceStableLegacyId:experienceStableLegacyId];
   [moduleRegistry registerExportedModule:amplitudeModule];
 #endif
 
 #if __has_include(<UMReactNativeAdapter/EXPermissionsService.h>)
-  EXScopedPermissions *permissionsModule = [[EXScopedPermissions alloc] initWithExperienceId:experienceId andConstantsBinding:constantsBinding];
+  EXScopedPermissions *permissionsModule = [[EXScopedPermissions alloc] initWithScopeKey:scopeKey andConstantsBinding:constantsBinding];
   [moduleRegistry registerExportedModule:permissionsModule];
   [moduleRegistry registerInternalModule:permissionsModule];
 #endif
@@ -117,7 +122,7 @@
 #endif
 
 #if __has_include(<EXBranch/RNBranch.h>)
-  EXScopedBranch *branchModule = [[EXScopedBranch alloc] initWithExperienceId:experienceId];
+  EXScopedBranch *branchModule = [[EXScopedBranch alloc] initWithScopeKey:scopeKey];
   [moduleRegistry registerInternalModule:branchModule];
 #endif
 
@@ -128,18 +133,18 @@
 
 #if __has_include(<EXTaskManager/EXTaskManager.h>)
   // TODO: Make scoped task manager when adding support for bare React Native
-  EXTaskManager *taskManagerModule = [[EXTaskManager alloc] initWithExperienceId:experienceId];
+  EXTaskManager *taskManagerModule = [[EXTaskManager alloc] initWithScopeKey:scopeKey];
   [moduleRegistry registerInternalModule:taskManagerModule];
   [moduleRegistry registerExportedModule:taskManagerModule];
 #endif
   
 #if __has_include(<EXErrorRecovery/EXErrorRecoveryModule.h>)
-  EXScopedErrorRecoveryModule *errorRecovery = [[EXScopedErrorRecoveryModule alloc] initWithExperienceId:experienceId];
+  EXScopedErrorRecoveryModule *errorRecovery = [[EXScopedErrorRecoveryModule alloc] initWithScopeKey:scopeKey];
   [moduleRegistry registerExportedModule:errorRecovery];
 #endif
   
 #if __has_include(<EXFirebaseCore/EXFirebaseCore.h>)
-  EXScopedFirebaseCore *firebaseCoreModule = [[EXScopedFirebaseCore alloc] initWithExperienceId:experienceId andConstantsBinding:constantsBinding];
+  EXScopedFirebaseCore *firebaseCoreModule = [[EXScopedFirebaseCore alloc] initWithScopeKey:scopeKey andConstantsBinding:constantsBinding];
   [moduleRegistry registerExportedModule:firebaseCoreModule];
   [moduleRegistry registerInternalModule:firebaseCoreModule];
 #endif
@@ -147,7 +152,7 @@
 #if __has_include(<EXNotifications/EXNotificationsEmitter.h>)
   // only override in Expo Go
   if ([params[@"constants"][@"appOwnership"] isEqualToString:@"expo"]) {
-    EXScopedNotificationsEmitter *notificationsEmmitter = [[EXScopedNotificationsEmitter alloc] initWithExperienceId:experienceId];
+    EXScopedNotificationsEmitter *notificationsEmmitter = [[EXScopedNotificationsEmitter alloc] initWithScopeKey:scopeKey];
     [moduleRegistry registerExportedModule:notificationsEmmitter];
   }
 #endif
@@ -155,20 +160,21 @@
 #if __has_include(<EXNotifications/EXNotificationsHandlerModule.h>)
   // only override in Expo Go
   if ([params[@"constants"][@"appOwnership"] isEqualToString:@"expo"]) {
-    EXScopedNotificationsHandlerModule *notificationsHandler = [[EXScopedNotificationsHandlerModule alloc] initWithExperienceId:experienceId];
+    EXScopedNotificationsHandlerModule *notificationsHandler = [[EXScopedNotificationsHandlerModule alloc] initWithScopeKey:scopeKey];
     [moduleRegistry registerExportedModule:notificationsHandler];
   }
 #endif
   
 #if __has_include(<EXNotifications/EXNotificationsHandlerModule.h>)
-  EXScopedNotificationBuilder *notificationsBuilder = [[EXScopedNotificationBuilder alloc] initWithExperienceId:experienceId andConstantsBinding:constantsBinding];
+  EXScopedNotificationBuilder *notificationsBuilder = [[EXScopedNotificationBuilder alloc] initWithScopeKey:scopeKey
+                                                                                                  andConstantsBinding:constantsBinding];
   [moduleRegistry registerInternalModule:notificationsBuilder];
 #endif
   
 #if __has_include(<EXNotifications/EXNotificationSchedulerModule.h>)
   // only override in Expo Go
   if ([params[@"constants"][@"appOwnership"] isEqualToString:@"expo"]) {
-    EXScopedNotificationSchedulerModule *schedulerModule = [[EXScopedNotificationSchedulerModule alloc] initWithExperienceId:experienceId];
+    EXScopedNotificationSchedulerModule *schedulerModule = [[EXScopedNotificationSchedulerModule alloc] initWithScopeKey:scopeKey];
     [moduleRegistry registerExportedModule:schedulerModule];
   }
 #endif
@@ -176,7 +182,7 @@
 #if __has_include(<EXNotifications/EXNotificationPresentationModule.h>)
   // only override in Expo Go
   if ([params[@"constants"][@"appOwnership"] isEqualToString:@"expo"]) {
-    EXScopedNotificationPresentationModule *notificationPresentationModule = [[EXScopedNotificationPresentationModule alloc] initWithExperienceId:experienceId];
+    EXScopedNotificationPresentationModule *notificationPresentationModule = [[EXScopedNotificationPresentationModule alloc] initWithScopeKey:scopeKey];
     [moduleRegistry registerExportedModule:notificationPresentationModule];
   }
 #endif
@@ -184,15 +190,17 @@
 #if __has_include(<EXNotifications/EXNotificationCategoriesModule.h>)
   // only override in Expo Go
   if ([params[@"constants"][@"appOwnership"] isEqualToString:@"expo"]) {
-    EXScopedNotificationCategoriesModule *scopedCategoriesModule = [[EXScopedNotificationCategoriesModule alloc] initWithExperienceId:experienceId andConstantsBinding:constantsBinding];
+    EXScopedNotificationCategoriesModule *scopedCategoriesModule = [[EXScopedNotificationCategoriesModule alloc] initWithScopeKey:scopeKey
+                                                                                                                        andConstantsBinding:constantsBinding];
     [moduleRegistry registerExportedModule:scopedCategoriesModule];
   }
-  [EXScopedNotificationCategoriesModule maybeMigrateLegacyCategoryIdentifiersForProject:experienceId
-                                                                             isInExpoGo:[params[@"constants"][@"appOwnership"] isEqualToString:@"expo"]];
+  [EXScopedNotificationCategoriesModule maybeMigrateLegacyCategoryIdentifiersForProjectWithExperienceStableLegacyId:experienceStableLegacyId
+                                                                                                 scopeKey:scopeKey
+                                                                                                         isInExpoGo:[params[@"constants"][@"appOwnership"] isEqualToString:@"expo"]];
 #endif
   
 #if __has_include(<EXNotifications/EXServerRegistrationModule.h>)
-  EXScopedServerRegistrationModule *serverRegistrationModule = [[EXScopedServerRegistrationModule alloc] initWithExperienceId:experienceId];
+  EXScopedServerRegistrationModule *serverRegistrationModule = [[EXScopedServerRegistrationModule alloc] initWithScopeKey:scopeKey];
   [moduleRegistry registerExportedModule:serverRegistrationModule];
 #endif
 

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXScopedSecureStore.h
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXScopedSecureStore.h
@@ -9,8 +9,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface EXScopedSecureStore : EXSecureStore
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
-                 andConstantsBinding:(EXConstantsBinding *)constantsBinding;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey
+                       andConstantsBinding:(EXConstantsBinding *)constantsBinding;
 
 @end
 

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXScopedSecureStore.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXScopedSecureStore.m
@@ -15,18 +15,18 @@
 
 @interface EXScopedSecureStore ()
 
-@property (strong, nonatomic) NSString *experienceId;
+@property (strong, nonatomic) NSString *scopeKey;
 @property (nonatomic) BOOL isStandaloneApp;
 
 @end
 
 @implementation EXScopedSecureStore
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
-                 andConstantsBinding:(EXConstantsBinding *)constantsBinding
+- (instancetype)initWithScopeKey:(NSString *)scopeKey
+                       andConstantsBinding:(EXConstantsBinding *)constantsBinding
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _scopeKey = scopeKey;
     _isStandaloneApp = ![@"expo" isEqualToString:constantsBinding.appOwnership];
   }
   return self;
@@ -37,11 +37,11 @@
     return nil;
   }
 
-  return _isStandaloneApp ? key : [NSString stringWithFormat:@"%@-%@", _experienceId, key];
+  return _isStandaloneApp ? key : [NSString stringWithFormat:@"%@-%@", _scopeKey, key];
 }
 
 // We must override this method so that items saved in standalone apps on SDK 40 and below,
-// which were scoped by prefixing the validated key with the experienceId, can still be
+// which were scoped by prefixing the validated key with the scopeKey, can still be
 // found in SDK 41 and up. This override can be removed in SDK 45.
 - (NSString *)_getValueWithKey:(NSString *)key withOptions:(NSDictionary *)options error:(NSError **)error
 {
@@ -54,7 +54,7 @@
                                             encoding:NSUTF8StringEncoding];
     return value;
   } else if (_isStandaloneApp) {
-    NSString *scopedKey = [NSString stringWithFormat:@"%@-%@", _experienceId, key];
+    NSString *scopedKey = [NSString stringWithFormat:@"%@-%@", _scopeKey, key];
     NSString *scopedValue = [self getValueWithScopedKey:scopedKey
                                              withOptions:options];
     if (scopedValue) {
@@ -67,7 +67,7 @@
     // If we don't find anything under the scopedKey, we want to return
     // the original error from searching for the unscoped key.
   }
-  
+
   *error = searchError;
   return nil;
 }

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXSensorsManagerBinding.h
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXSensorsManagerBinding.h
@@ -11,30 +11,30 @@
 
 @protocol EXSensorsManagerBindingDelegate
 
-- (void)sensorModuleDidSubscribeForAccelerometerUpdatesOfExperience:(NSString *)experienceId withHandler:(void (^)(NSDictionary *event))handlerBlock;
-- (void)sensorModuleDidUnsubscribeForAccelerometerUpdatesOfExperience:(NSString *)experienceId;
+- (void)sensorModuleDidSubscribeForAccelerometerUpdatesOfExperience:(NSString *)scopeKey withHandler:(void (^)(NSDictionary *event))handlerBlock;
+- (void)sensorModuleDidUnsubscribeForAccelerometerUpdatesOfExperience:(NSString *)scopeKey;
 - (void)setAccelerometerUpdateInterval:(NSTimeInterval)intervalMs;
 
 - (float)getGravity;
-- (void)sensorModuleDidSubscribeForDeviceMotionUpdatesOfExperience:(NSString *)experienceId withHandler:(void (^)(NSDictionary *event))handlerBlock;
-- (void)sensorModuleDidUnsubscribeForDeviceMotionUpdatesOfExperience:(NSString *)experienceId;
+- (void)sensorModuleDidSubscribeForDeviceMotionUpdatesOfExperience:(NSString *)scopeKey withHandler:(void (^)(NSDictionary *event))handlerBlock;
+- (void)sensorModuleDidUnsubscribeForDeviceMotionUpdatesOfExperience:(NSString *)scopeKey;
 - (void)setDeviceMotionUpdateInterval:(NSTimeInterval)intervalMs;
 
-- (void)sensorModuleDidSubscribeForGyroscopeUpdatesOfExperience:(NSString *)experienceId withHandler:(void (^)(NSDictionary *event))handlerBlock;
-- (void)sensorModuleDidUnsubscribeForGyroscopeUpdatesOfExperience:(NSString *)experienceId;
+- (void)sensorModuleDidSubscribeForGyroscopeUpdatesOfExperience:(NSString *)scopeKey withHandler:(void (^)(NSDictionary *event))handlerBlock;
+- (void)sensorModuleDidUnsubscribeForGyroscopeUpdatesOfExperience:(NSString *)scopeKey;
 - (void)setGyroscopeUpdateInterval:(NSTimeInterval)intervalMs;
 
-- (void)sensorModuleDidSubscribeForMagnetometerUpdatesOfExperience:(NSString *)experienceId withHandler:(void (^)(NSDictionary *event))handlerBlock;
-- (void)sensorModuleDidUnsubscribeForMagnetometerUpdatesOfExperience:(NSString *)experienceId;
+- (void)sensorModuleDidSubscribeForMagnetometerUpdatesOfExperience:(NSString *)scopeKey withHandler:(void (^)(NSDictionary *event))handlerBlock;
+- (void)sensorModuleDidUnsubscribeForMagnetometerUpdatesOfExperience:(NSString *)scopeKey;
 - (void)setMagnetometerUpdateInterval:(NSTimeInterval)intervalMs;
 
-- (void)sensorModuleDidSubscribeForMagnetometerUncalibratedUpdatesOfExperience:(NSString *)experienceId
+- (void)sensorModuleDidSubscribeForMagnetometerUncalibratedUpdatesOfExperience:(NSString *)scopeKey
                                                        withHandler:(void (^)(NSDictionary *event))handlerBlock;
-- (void)sensorModuleDidUnsubscribeForMagnetometerUncalibratedUpdatesOfExperience:(NSString *)experienceId;
+- (void)sensorModuleDidUnsubscribeForMagnetometerUncalibratedUpdatesOfExperience:(NSString *)scopeKey;
 - (void)setMagnetometerUncalibratedUpdateInterval:(NSTimeInterval)intervalMs;
 
-- (void)sensorModuleDidSubscribeForBarometerUpdatesOfExperience:(NSString *)experienceId withHandler:(void (^)(NSDictionary *event))handlerBlock;
-- (void)sensorModuleDidUnsubscribeForBarometerUpdatesOfExperience:(NSString *)experienceId;
+- (void)sensorModuleDidSubscribeForBarometerUpdatesOfExperience:(NSString *)scopeKey withHandler:(void (^)(NSDictionary *event))handlerBlock;
+- (void)sensorModuleDidUnsubscribeForBarometerUpdatesOfExperience:(NSString *)scopeKey;
 - (void)setBarometerUpdateInterval:(NSTimeInterval)intervalMs;
 
 - (BOOL)isBarometerAvailable;
@@ -48,7 +48,7 @@
 
 @interface EXSensorsManagerBinding : NSObject <UMInternalModule, EXAccelerometerInterface, EXBarometerInterface, EXDeviceMotionInterface, EXGyroscopeInterface, EXMagnetometerInterface, EXMagnetometerUncalibratedInterface>
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId andKernelService:(id<EXSensorsManagerBindingDelegate>)kernelService;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey andKernelService:(id<EXSensorsManagerBindingDelegate>)kernelService;
 
 - (void)sensorModuleDidSubscribeForAccelerometerUpdates:(id)scopedSensorModule withHandler:(void (^)(NSDictionary *))handlerBlock;
 - (void)sensorModuleDidSubscribeForDeviceMotionUpdates:(id)scopedSensorModule withHandler:(void (^)(NSDictionary *))handlerBlock;

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXSensorsManagerBinding.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXSensorsManagerBinding.m
@@ -4,68 +4,68 @@
 
 @interface EXSensorsManagerBinding ()
 
-@property (nonatomic, strong) NSString *experienceId;
+@property (nonatomic, strong) NSString *scopeKey;
 @property (nonatomic, weak) id<EXSensorsManagerBindingDelegate> kernelService;
 
 @end
 
 @implementation EXSensorsManagerBinding
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId andKernelService:(id<EXSensorsManagerBindingDelegate>)kernelService
+- (instancetype)initWithScopeKey:(NSString *)scopeKey andKernelService:(id<EXSensorsManagerBindingDelegate>)kernelService
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _scopeKey = scopeKey;
     _kernelService = kernelService;
   }
   return self;
 }
 
 - (void)sensorModuleDidSubscribeForAccelerometerUpdates:(id)scopedSensorModule withHandler:(void (^)(NSDictionary *))handlerBlock {
-  [_kernelService sensorModuleDidSubscribeForAccelerometerUpdatesOfExperience:_experienceId withHandler:handlerBlock];
+  [_kernelService sensorModuleDidSubscribeForAccelerometerUpdatesOfExperience:_scopeKey withHandler:handlerBlock];
 }
 
 - (void)sensorModuleDidSubscribeForDeviceMotionUpdates:(id)scopedSensorModule withHandler:(void (^)(NSDictionary *))handlerBlock {
-  [_kernelService sensorModuleDidSubscribeForDeviceMotionUpdatesOfExperience:_experienceId withHandler:handlerBlock];
+  [_kernelService sensorModuleDidSubscribeForDeviceMotionUpdatesOfExperience:_scopeKey withHandler:handlerBlock];
 }
 
 - (void)sensorModuleDidSubscribeForGyroscopeUpdates:(id)scopedSensorModule withHandler:(void (^)(NSDictionary *))handlerBlock {
-  [_kernelService sensorModuleDidSubscribeForGyroscopeUpdatesOfExperience:_experienceId withHandler:handlerBlock];
+  [_kernelService sensorModuleDidSubscribeForGyroscopeUpdatesOfExperience:_scopeKey withHandler:handlerBlock];
 }
 
 - (void)sensorModuleDidSubscribeForMagnetometerUncalibratedUpdates:(id)scopedSensorModule withHandler:(void (^)(NSDictionary *))handlerBlock {
-  [_kernelService sensorModuleDidSubscribeForMagnetometerUncalibratedUpdatesOfExperience:_experienceId withHandler:handlerBlock];
+  [_kernelService sensorModuleDidSubscribeForMagnetometerUncalibratedUpdatesOfExperience:_scopeKey withHandler:handlerBlock];
 }
 
 - (void)sensorModuleDidSubscribeForMagnetometerUpdates:(id)scopedSensorModule withHandler:(void (^)(NSDictionary *))handlerBlock {
-  [_kernelService sensorModuleDidSubscribeForMagnetometerUpdatesOfExperience:_experienceId withHandler:handlerBlock];
+  [_kernelService sensorModuleDidSubscribeForMagnetometerUpdatesOfExperience:_scopeKey withHandler:handlerBlock];
 }
 
 - (void)sensorModuleDidSubscribeForBarometerUpdates:(id)scopedSensorModule withHandler:(void (^)(NSDictionary *))handlerBlock {
-  [_kernelService sensorModuleDidSubscribeForBarometerUpdatesOfExperience:_experienceId withHandler:handlerBlock];
+  [_kernelService sensorModuleDidSubscribeForBarometerUpdatesOfExperience:_scopeKey withHandler:handlerBlock];
 }
 
 - (void)sensorModuleDidUnsubscribeForAccelerometerUpdates:(id)scopedSensorModule {
-  [_kernelService sensorModuleDidUnsubscribeForAccelerometerUpdatesOfExperience:_experienceId];
+  [_kernelService sensorModuleDidUnsubscribeForAccelerometerUpdatesOfExperience:_scopeKey];
 }
 
 - (void)sensorModuleDidUnsubscribeForDeviceMotionUpdates:(id)scopedSensorModule {
-  [_kernelService sensorModuleDidUnsubscribeForDeviceMotionUpdatesOfExperience:_experienceId];
+  [_kernelService sensorModuleDidUnsubscribeForDeviceMotionUpdatesOfExperience:_scopeKey];
 }
 
 - (void)sensorModuleDidUnsubscribeForGyroscopeUpdates:(id)scopedSensorModule {
-  [_kernelService sensorModuleDidUnsubscribeForGyroscopeUpdatesOfExperience:_experienceId];
+  [_kernelService sensorModuleDidUnsubscribeForGyroscopeUpdatesOfExperience:_scopeKey];
 }
 
 - (void)sensorModuleDidUnsubscribeForMagnetometerUncalibratedUpdates:(id)scopedSensorModule {
-  [_kernelService sensorModuleDidUnsubscribeForMagnetometerUncalibratedUpdatesOfExperience:_experienceId];
+  [_kernelService sensorModuleDidUnsubscribeForMagnetometerUncalibratedUpdatesOfExperience:_scopeKey];
 }
 
 - (void)sensorModuleDidUnsubscribeForMagnetometerUpdates:(id)scopedSensorModule {
-  [_kernelService sensorModuleDidUnsubscribeForMagnetometerUpdatesOfExperience:_experienceId];
+  [_kernelService sensorModuleDidUnsubscribeForMagnetometerUpdatesOfExperience:_scopeKey];
 }
 
 - (void)sensorModuleDidUnsubscribeForBarometerUpdates:(id)scopedSensorModule {
-  [_kernelService sensorModuleDidUnsubscribeForBarometerUpdatesOfExperience:_experienceId];
+  [_kernelService sensorModuleDidUnsubscribeForBarometerUpdatesOfExperience:_scopeKey];
 }
 
 - (void)setAccelerometerUpdateInterval:(NSTimeInterval)intervalMs {

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXUpdatesBinding.h
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXUpdatesBinding.h
@@ -13,14 +13,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol EXUpdatesBindingDelegate
 
-- (EXUpdatesConfig *)configForExperienceId:(NSString *)experienceId;
-- (EXUpdatesSelectionPolicy *)selectionPolicyForExperienceId:(NSString *)experienceId;
-- (nullable EXUpdatesUpdate *)launchedUpdateForExperienceId:(NSString *)experienceId;
-- (nullable NSDictionary *)assetFilesMapForExperienceId:(NSString *)experienceId;
-- (BOOL)isUsingEmbeddedAssetsForExperienceId:(NSString *)experienceId;
-- (BOOL)isStartedForExperienceId:(NSString *)experienceId;
-- (BOOL)isEmergencyLaunchForExperienceId:(NSString *)experienceId;
-- (void)requestRelaunchForExperienceId:(NSString *)experienceId withCompletion:(EXUpdatesAppRelaunchCompletionBlock)completion;
+- (EXUpdatesConfig *)configForScopeKey:(NSString *)scopeKey;
+- (EXUpdatesSelectionPolicy *)selectionPolicyForScopeKey:(NSString *)scopeKey;
+- (nullable EXUpdatesUpdate *)launchedUpdateForScopeKey:(NSString *)scopeKey;
+- (nullable NSDictionary *)assetFilesMapForScopeKey:(NSString *)scopeKey;
+- (BOOL)isUsingEmbeddedAssetsForScopeKey:(NSString *)scopeKey;
+- (BOOL)isStartedForScopeKey:(NSString *)scopeKey;
+- (BOOL)isEmergencyLaunchForScopeKey:(NSString *)scopeKey;
+- (void)requestRelaunchForScopeKey:(NSString *)scopeKey withCompletion:(EXUpdatesAppRelaunchCompletionBlock)completion;
 
 @end
 
@@ -33,7 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface EXUpdatesBinding : EXUpdatesService <UMInternalModule>
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId updatesKernelService:(id<EXUpdatesBindingDelegate>)updatesKernelService databaseKernelService:(id<EXUpdatesDatabaseBindingDelegate>)databaseKernelService;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey updatesKernelService:(id<EXUpdatesBindingDelegate>)updatesKernelService databaseKernelService:(id<EXUpdatesDatabaseBindingDelegate>)databaseKernelService;
 
 @end
 

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXUpdatesBinding.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXUpdatesBinding.m
@@ -8,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface EXUpdatesBinding ()
 
-@property (nonatomic, strong) NSString *experienceId;
+@property (nonatomic, strong) NSString *scopeKey;
 @property (nonatomic, weak) id<EXUpdatesBindingDelegate> updatesKernelService;
 @property (nonatomic, weak) id<EXUpdatesDatabaseBindingDelegate> databaseKernelService;
 
@@ -16,10 +16,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation EXUpdatesBinding : EXUpdatesService
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId updatesKernelService:(id<EXUpdatesBindingDelegate>)updatesKernelService databaseKernelService:(id<EXUpdatesDatabaseBindingDelegate>)databaseKernelService
+- (instancetype)initWithScopeKey:(NSString *)scopeKey updatesKernelService:(id<EXUpdatesBindingDelegate>)updatesKernelService databaseKernelService:(id<EXUpdatesDatabaseBindingDelegate>)databaseKernelService
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _scopeKey = scopeKey;
     _updatesKernelService = updatesKernelService;
     _databaseKernelService = databaseKernelService;
   }
@@ -28,7 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (EXUpdatesConfig *)config
 {
-  return [_updatesKernelService configForExperienceId:_experienceId];
+  return [_updatesKernelService configForScopeKey:_scopeKey];
 }
 
 - (EXUpdatesDatabase *)database
@@ -38,7 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (EXUpdatesSelectionPolicy *)selectionPolicy
 {
-  return [_updatesKernelService selectionPolicyForExperienceId:_experienceId];
+  return [_updatesKernelService selectionPolicyForScopeKey:_scopeKey];
 }
 
 - (NSURL *)directory
@@ -48,27 +48,27 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (nullable EXUpdatesUpdate *)launchedUpdate
 {
-  return [_updatesKernelService launchedUpdateForExperienceId:_experienceId];
+  return [_updatesKernelService launchedUpdateForScopeKey:_scopeKey];
 }
 
 - (nullable NSDictionary *)assetFilesMap
 {
-  return [_updatesKernelService assetFilesMapForExperienceId:_experienceId];
+  return [_updatesKernelService assetFilesMapForScopeKey:_scopeKey];
 }
 
 - (BOOL)isUsingEmbeddedAssets
 {
-  return [_updatesKernelService isUsingEmbeddedAssetsForExperienceId:_experienceId];
+  return [_updatesKernelService isUsingEmbeddedAssetsForScopeKey:_scopeKey];
 }
 
 - (BOOL)isStarted
 {
-  return [_updatesKernelService isStartedForExperienceId:_experienceId];
+  return [_updatesKernelService isStartedForScopeKey:_scopeKey];
 }
 
 - (BOOL)isEmergencyLaunch
 {
-  return [_updatesKernelService isEmergencyLaunchForExperienceId:_experienceId];
+  return [_updatesKernelService isEmergencyLaunchForScopeKey:_scopeKey];
 }
 
 - (BOOL)canRelaunch
@@ -78,7 +78,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)requestRelaunchWithCompletion:(EXUpdatesAppRelaunchCompletionBlock)completion
 {
-  return [_updatesKernelService requestRelaunchForExperienceId:_experienceId withCompletion:completion];
+  return [_updatesKernelService requestRelaunchForScopeKey:_scopeKey withCompletion:completion];
 }
 
 - (void)resetSelectionPolicy

--- a/ios/Exponent/Versioned/Core/UniversalModules/Permissions/EXScopedPermissions.h
+++ b/ios/Exponent/Versioned/Core/UniversalModules/Permissions/EXScopedPermissions.h
@@ -9,14 +9,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol EXPermissionsScopedModuleDelegate
 
-- (EXPermissionStatus)getPermission:(NSString *)permissionType forExperience:(NSString *)experienceId;
-- (BOOL)savePermission:(NSDictionary *)permission ofType:(NSString *)type forExperience:(NSString *)experienceId;
+- (EXPermissionStatus)getPermission:(NSString *)permissionType forExperience:(NSString *)scopeKey;
+- (BOOL)savePermission:(NSDictionary *)permission ofType:(NSString *)type forExperience:(NSString *)scopeKey;
 
 @end
 
 @interface EXScopedPermissions : EXPermissionsService
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId andConstantsBinding:(EXConstantsBinding *)constantsBinding;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey andConstantsBinding:(EXConstantsBinding *)constantsBinding;
 
 @end
 

--- a/ios/Exponent/Versioned/Core/UniversalModules/Permissions/EXScopedPermissions.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/Permissions/EXScopedPermissions.m
@@ -8,7 +8,7 @@
 
 @interface EXScopedPermissions ()
 
-@property (nonatomic, strong) NSString *experienceId;
+@property (nonatomic, strong) NSString *scopeKey;
 @property (nonatomic, weak) id<EXPermissionsScopedModuleDelegate> permissionsService;
 @property (nonatomic, weak) id<EXUtilitiesInterface> utils;
 @property (nonatomic, weak) EXConstantsBinding *constantsBinding;
@@ -17,10 +17,10 @@
 
 @implementation EXScopedPermissions
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId andConstantsBinding:(EXConstantsBinding *)constantsBinding
+- (instancetype)initWithScopeKey:(NSString *)scopeKey andConstantsBinding:(EXConstantsBinding *)constantsBinding
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _scopeKey = scopeKey;
     _constantsBinding = constantsBinding;
   }
   return self;
@@ -47,7 +47,7 @@
     return [[self class] permissionStringForStatus:EXPermissionStatusGranted];
   }
   
-  return [[self class] permissionStringForStatus:[_permissionsService getPermission:permissionType forExperience:_experienceId]];
+  return [[self class] permissionStringForStatus:[_permissionsService getPermission:permissionType forExperience:_scopeKey]];
 }
 
 - (BOOL)hasGrantedScopedPermission:(NSString *)permissionType
@@ -56,7 +56,7 @@
     return YES;
   }
   
-  return [_permissionsService getPermission:permissionType forExperience:_experienceId] == EXPermissionStatusGranted;
+  return [_permissionsService getPermission:permissionType forExperience:_scopeKey] == EXPermissionStatusGranted;
 }
 
 - (void)askForPermissionUsingRequesterClass:(Class)requesterClass
@@ -73,7 +73,7 @@
       EX_ENSURE_STRONGIFY(self)
       // if permission should be scoped save it
       if ([self shouldVerifyScopedPermission:permissionType]) {
-        [self.permissionsService savePermission:permission ofType:permissionType forExperience:self.experienceId];
+        [self.permissionsService savePermission:permission ofType:permissionType forExperience:self.scopeKey];
       }
       resolve(permission);
     };
@@ -87,7 +87,7 @@
       EX_ENSURE_STRONGIFY(self);
       NSMutableDictionary *permission = [globalPermissions mutableCopy];
       // try to save scoped permissions - if fails than permission is denied
-      if (![self.permissionsService savePermission:permission ofType:permissionType forExperience:self.experienceId]) {
+      if (![self.permissionsService savePermission:permission ofType:permissionType forExperience:self.scopeKey]) {
         permission[@"status"] = [[self class] permissionStringForStatus:EXPermissionStatusDenied];
         permission[@"granted"] = @(NO);
       }
@@ -130,7 +130,7 @@
                    withAllowAction:(UIAlertAction *)allow
                     withDenyAction:(UIAlertAction *)deny
 {
-  NSString *experienceName = self.experienceId; // TODO: we might want to use name from the manifest?
+  NSString *experienceName = self.scopeKey; // TODO: we might want to use name from the manifest?
   NSString *messageTemplate = @"%1$@ needs permissions for %2$@. You\'ve already granted permission to another Expo experience. Allow %1$@ to also use it?";
   NSString *permissionString = [[self class] textForPermissionType:permissionType];
 

--- a/ios/vendored/unversioned/react-native-webview/apple/RNCWKProcessPoolManager.h
+++ b/ios/vendored/unversioned/react-native-webview/apple/RNCWKProcessPoolManager.h
@@ -9,7 +9,7 @@
 
 @interface RNCWKProcessPoolManager : NSObject
 
-+ (instancetype) sharedManager;
-- (WKProcessPool *)sharedProcessPoolForExperienceId:(NSString *)experienceId;
++ (instancetype)sharedManager;
+- (WKProcessPool *)sharedProcessPoolForScopeKey:(NSString *)scopeKey;
 
 @end

--- a/ios/vendored/unversioned/react-native-webview/apple/RNCWKProcessPoolManager.m
+++ b/ios/vendored/unversioned/react-native-webview/apple/RNCWKProcessPoolManager.m
@@ -24,15 +24,15 @@
   return self;
 }
 
-- (WKProcessPool *)sharedProcessPoolForExperienceId:(NSString *)experienceId
+- (WKProcessPool *)sharedProcessPoolForScopeKey:(NSString *)scopeKey
 {
-  if (!experienceId) {
+  if (!scopeKey) {
     return [self sharedProcessPool];
   }
-  if (!_pools[experienceId]) {
-    _pools[experienceId] = [[WKProcessPool alloc] init];
+  if (!_pools[scopeKey]) {
+    _pools[scopeKey] = [[WKProcessPool alloc] init];
   }
-  return _pools[experienceId];
+  return _pools[scopeKey];
 }
 
 

--- a/ios/vendored/unversioned/react-native-webview/apple/RNCWebView.h
+++ b/ios/vendored/unversioned/react-native-webview/apple/RNCWebView.h
@@ -28,7 +28,7 @@
 @end
 
 @interface RNCWebView : RCTView
-@property (nonatomic, strong) NSString *experienceId;
+@property (nonatomic, strong) NSString *scopeKey;
 
 @property (nonatomic, weak) id<RNCWebViewDelegate> _Nullable delegate;
 @property (nonatomic, copy) NSDictionary * _Nullable source;

--- a/ios/vendored/unversioned/react-native-webview/apple/RNCWebView.m
+++ b/ios/vendored/unversioned/react-native-webview/apple/RNCWebView.m
@@ -233,7 +233,7 @@ static NSDictionary* customCertificatesForHost;
     wkWebViewConfig.websiteDataStore = [WKWebsiteDataStore defaultDataStore];
   }
   if(self.useSharedProcessPool) {
-    wkWebViewConfig.processPool = [[RNCWKProcessPoolManager sharedManager] sharedProcessPoolForExperienceId:self.experienceId];
+    wkWebViewConfig.processPool = [[RNCWKProcessPoolManager sharedManager] sharedProcessPoolForScopeKey:self.scopeKey];
   }
   wkWebViewConfig.userContentController = [WKUserContentController new];
 

--- a/ios/vendored/unversioned/react-native-webview/apple/RNCWebViewManager.m
+++ b/ios/vendored/unversioned/react-native-webview/apple/RNCWebViewManager.m
@@ -26,17 +26,18 @@ RCT_ENUM_CONVERTER(WKContentMode, (@{
 
 @implementation RNCWebViewManager
 {
-  NSString *_experienceId;
+  NSString *_scopeKey;
   NSConditionLock *_shouldStartLoadLock;
   BOOL _shouldStartLoad;
 }
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
-               kernelServiceDelegate:(id)kernelServiceInstance
-                              params:(NSDictionary *)params
+- (instancetype)initWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId
+                        scopeKey:(NSString *)scopeKey
+                     kernelServiceDelegate:(id)kernelServiceInstance
+                                    params:(NSDictionary *)params
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _scopeKey = scopeKey;
   }
   return self;
 }
@@ -48,7 +49,7 @@ RCT_ENUM_CONVERTER(WKContentMode, (@{
 #endif // !TARGET_OS_OSX
 {
   RNCWebView *webView = [RNCWebView new];
-  webView.experienceId = _experienceId;
+  webView.scopeKey = _scopeKey;
   webView.delegate = self;
   return webView;
 }

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXTaskManager/ABI40_0_0EXTaskManager/ABI40_0_0EXTaskManager.h
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXTaskManager/ABI40_0_0EXTaskManager/ABI40_0_0EXTaskManager.h
@@ -9,6 +9,6 @@
 
 @interface ABI40_0_0EXTaskManager : ABI40_0_0UMExportedModule <ABI40_0_0UMInternalModule, ABI40_0_0UMEventEmitter, ABI40_0_0UMModuleRegistryConsumer, ABI40_0_0UMTaskManagerInterface>
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey NS_DESIGNATED_INITIALIZER;
 
 @end

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXTaskManager/ABI40_0_0EXTaskManager/ABI40_0_0EXTaskManager.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXTaskManager/ABI40_0_0EXTaskManager/ABI40_0_0EXTaskManager.m
@@ -33,14 +33,14 @@ ABI40_0_0UM_EXPORT_MODULE(ExpoTaskManager);
 
 - (instancetype)init
 {
-  return [self initWithExperienceId:@"mainApplication"];
+  return [self initWithScopeKey:@"mainApplication"];
 }
 
 // TODO: Remove when adding bare ABI40_0_0React Native support
-- (instancetype)initWithExperienceId:(NSString *)experienceId
+- (instancetype)initWithScopeKey:(NSString *)scopeKey
 {
   if (self = [super init]) {
-    _appId = experienceId;
+    _appId = scopeKey;
     _eventsQueue = [NSMutableArray new];
   }
   return self;

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/ABI40_0_0EXUpdatesBareUpdate.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/ABI40_0_0EXUpdatesBareUpdate.m
@@ -18,10 +18,10 @@ NS_ASSUME_NONNULL_BEGIN
                                                                   config:config
                                                                 database:database];
 
-  NSString *updateId = manifest.rawID;
+  NSString *updateId = manifest.rawId;
   NSNumber *commitTime = manifest.commitTimeNumber;
   NSArray *assets = manifest.assets;
-  
+
   NSAssert(updateId != nil, @"update ID should not be null");
 
   NSUUID *uuid = [[NSUUID alloc] initWithUUIDString:(NSString *)updateId];

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/ABI40_0_0EXUpdatesNewUpdate.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/ABI40_0_0EXUpdatesNewUpdate.m
@@ -19,32 +19,32 @@ NS_ASSUME_NONNULL_BEGIN
   ABI40_0_0EXUpdatesUpdate *update = [[ABI40_0_0EXUpdatesUpdate alloc] initWithRawManifest:manifest
                                                                   config:config
                                                                 database:database];
-  
-  NSString *updateId = manifest.rawID;
+
+  NSString *updateId = manifest.rawId;
   NSString *commitTime = manifest.createdAt;
   NSString *runtimeVersion = manifest.runtimeVersion;
   NSDictionary *launchAsset = manifest.launchAsset;
   NSArray *assets = manifest.assets;
-  
+
   NSAssert(updateId != nil, @"update ID should not be null");
-  
+
   NSUUID *uuid = [[NSUUID alloc] initWithUUIDString:(NSString *)updateId];
   NSAssert(uuid, @"update ID should be a valid UUID");
-  
+
   id bundleUrlString = (NSDictionary *)launchAsset[@"url"];
   NSAssert([bundleUrlString isKindOfClass:[NSString class]], @"launchAsset.url should be a string");
   NSURL *bundleUrl = [NSURL URLWithString:bundleUrlString];
   NSAssert(bundleUrl, @"launchAsset.url should be a valid URL");
-  
+
   NSMutableArray<ABI40_0_0EXUpdatesAsset *> *processedAssets = [NSMutableArray new];
-  
+
   NSString *bundleKey = launchAsset[@"key"];
   ABI40_0_0EXUpdatesAsset *jsBundleAsset = [[ABI40_0_0EXUpdatesAsset alloc] initWithKey:bundleKey type:ABI40_0_0EXUpdatesEmbeddedBundleFileType];
   jsBundleAsset.url = bundleUrl;
   jsBundleAsset.isLaunchAsset = YES;
   jsBundleAsset.mainBundleFilename = ABI40_0_0EXUpdatesEmbeddedBundleFilename;
   [processedAssets addObject:jsBundleAsset];
-  
+
   if (assets) {
     for (NSDictionary *assetDict in (NSArray *)assets) {
       NSAssert([assetDict isKindOfClass:[NSDictionary class]], @"assets must be objects");
@@ -58,24 +58,24 @@ NS_ASSUME_NONNULL_BEGIN
       NSAssert(type && [type isKindOfClass:[NSString class]], @"asset contentType should be a nonnull string");
       NSURL *url = [NSURL URLWithString:(NSString *)urlString];
       NSAssert(url, @"asset url should be a valid URL");
-      
+
       ABI40_0_0EXUpdatesAsset *asset = [[ABI40_0_0EXUpdatesAsset alloc] initWithKey:key type:(NSString *)type];
       asset.url = url;
-      
+
       if (metadata) {
         NSAssert([metadata isKindOfClass:[NSDictionary class]], @"asset metadata should be an object");
         asset.metadata = (NSDictionary *)metadata;
       }
-      
+
       if (mainBundleFilename) {
         NSAssert([mainBundleFilename isKindOfClass:[NSString class]], @"asset localPath should be a string");
         asset.mainBundleFilename = (NSString *)mainBundleFilename;
       }
-      
+
       [processedAssets addObject:asset];
     }
   }
-  
+
   update.updateId = uuid;
   update.commitTime = [ABI40_0_0RCTConvert NSDate:(NSString *)commitTime];
   update.runtimeVersion = (NSString *)runtimeVersion;
@@ -84,13 +84,13 @@ NS_ASSUME_NONNULL_BEGIN
   update.bundleUrl = bundleUrl;
   update.assets = processedAssets;
   update.manifest = manifest.rawManifestJSON;
-  
+
   if ([response isKindOfClass:[NSHTTPURLResponse class]]) {
     NSDictionary *headersDictionary = ((NSHTTPURLResponse *)response).allHeaderFields;
     update.serverDefinedHeaders = [[self class] dictionaryWithStructuredHeader:headersDictionary[@"expo-server-defined-headers"]];
     update.manifestFilters = [[self class] dictionaryWithStructuredHeader:headersDictionary[@"expo-manifest-filters"]];
   }
-  
+
   return update;
 }
 
@@ -99,7 +99,7 @@ NS_ASSUME_NONNULL_BEGIN
   if (!headerString) {
     return nil;
   }
-  
+
   ABI40_0_0EXStructuredHeadersParser *parser = [[ABI40_0_0EXStructuredHeadersParser alloc] initWithRawInput:headerString fieldType:ABI40_0_0EXStructuredHeadersParserFieldTypeDictionary ignoringParameters:YES];
   NSError *error;
   NSDictionary *parserOutput = [parser parseStructuredFieldsWithError:&error];
@@ -107,7 +107,7 @@ NS_ASSUME_NONNULL_BEGIN
     NSLog(@"Error parsing header value: %@", error ? error.localizedDescription : @"Header was not a structured fields dictionary");
     return nil;
   }
-  
+
   NSMutableDictionary *mutableDict = [NSMutableDictionary dictionaryWithCapacity:parserOutput.count];
   [parserOutput enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
     // ignore any dictionary entries whose type is not string, number, or boolean

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/RawManifest/ABI40_0_0EXUpdatesBareRawManifest.h
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/RawManifest/ABI40_0_0EXUpdatesBareRawManifest.h
@@ -7,6 +7,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ABI40_0_0EXUpdatesBareRawManifest : ABI40_0_0EXUpdatesBaseLegacyRawManifest<ABI40_0_0EXUpdatesRawManifestBehavior>
 
+/**
+* A UUID for this manifest.
+*/
+- (NSString *)rawId;
 - (NSNumber *)commitTimeNumber;
 - (nullable NSDictionary *)metadata;
 - (nullable NSArray *)assets;

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/RawManifest/ABI40_0_0EXUpdatesBareRawManifest.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/RawManifest/ABI40_0_0EXUpdatesBareRawManifest.m
@@ -4,6 +4,10 @@
 
 @implementation ABI40_0_0EXUpdatesBareRawManifest
 
+- (NSString *)rawId {
+  return [self.rawManifestJSON stringForKey:@"id"];
+}
+
 - (NSNumber *)commitTimeNumber {
   return [self.rawManifestJSON numberForKey:@"commitTime"];
 }

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/RawManifest/ABI40_0_0EXUpdatesBaseLegacyRawManifest.h
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/RawManifest/ABI40_0_0EXUpdatesBaseLegacyRawManifest.h
@@ -6,6 +6,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ABI40_0_0EXUpdatesBaseLegacyRawManifest : ABI40_0_0EXUpdatesBaseRawManifest
 
+- (NSString *)stableLegacyId;
+- (NSString *)scopeKey;
+- (nullable NSString *)projectId;
+
 - (NSString *)bundleUrl;
 - (nullable NSString *)sdkVersion;
 - (nullable NSArray *)assets;

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/RawManifest/ABI40_0_0EXUpdatesBaseLegacyRawManifest.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/RawManifest/ABI40_0_0EXUpdatesBaseLegacyRawManifest.m
@@ -5,6 +5,28 @@
 
 @implementation ABI40_0_0EXUpdatesBaseLegacyRawManifest
 
+- (NSString *)stableLegacyId {
+  NSString *originalFullName = [self.rawManifestJSON nullableStringForKey:@"originalFullName"];
+  if (originalFullName) {
+    return originalFullName;
+  } else {
+    return [self legacyId];
+  }
+}
+
+- (NSString *)scopeKey {
+  NSString *scopeKey = [self.rawManifestJSON nullableStringForKey:@"scopeKey"];
+  if (scopeKey) {
+    return scopeKey;
+  } else {
+    return [self stableLegacyId];
+  }
+}
+
+- (nullable NSString *)projectId {
+  return [self.rawManifestJSON nullableStringForKey:@"projectId"];
+}
+
 - (NSString *)bundleUrl {
   return [self.rawManifestJSON stringForKey:@"bundleUrl"];
 }

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/RawManifest/ABI40_0_0EXUpdatesBaseRawManifest.h
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/RawManifest/ABI40_0_0EXUpdatesBaseRawManifest.h
@@ -13,7 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 # pragma mark - Common ABI40_0_0EXUpdatesRawManifestBehavior
 
-- (nullable NSString *)rawID;
+- (NSString *)legacyId;
 - (nullable NSString *)revisionId;
 - (nullable NSString *)slug;
 - (nullable NSString *)appKey;
@@ -23,6 +23,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSDictionary *)iosConfig;
 - (nullable NSString *)hostUri;
 - (nullable NSString *)orientation;
+- (nullable NSDictionary *)experiments;
+- (nullable NSDictionary *)developer;
 
 - (BOOL)isDevelopmentMode;
 - (BOOL)isDevelopmentSilentLaunch;

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/RawManifest/ABI40_0_0EXUpdatesBaseRawManifest.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/RawManifest/ABI40_0_0EXUpdatesBaseRawManifest.m
@@ -17,7 +17,7 @@
 
 # pragma mark - Field Getters
 
-- (nullable NSString *)rawID {
+- (NSString *)legacyId {
   return [self.rawManifestJSON nullableStringForKey:@"id"];
 }
 
@@ -57,11 +57,19 @@
   return [self.rawManifestJSON nullableStringForKey:@"orientation"];
 }
 
+- (nullable NSDictionary *)experiments {
+  return [self.rawManifestJSON nullableDictionaryForKey:@"experiments"];
+}
+
+- (nullable NSDictionary *)developer {
+  return [self.rawManifestJSON nullableDictionaryForKey:@"developer"];
+}
+
 # pragma mark - Derived Methods
 
 - (BOOL)isDevelopmentMode {
   NSDictionary *manifestPackagerOptsConfig = [self.rawManifestJSON nullableDictionaryForKey:@"packagerOpts"];
-  return ([self.rawManifestJSON nullableDictionaryForKey:@"developer"] != nil && manifestPackagerOptsConfig != nil && [@(YES) isEqualToNumber:manifestPackagerOptsConfig[@"dev"]]);
+  return (self.developer != nil && manifestPackagerOptsConfig != nil && [@(YES) isEqualToNumber:manifestPackagerOptsConfig[@"dev"]]);
 }
 
 - (BOOL)isDevelopmentSilentLaunch {
@@ -74,8 +82,7 @@
 }
 
 - (BOOL)isUsingDeveloperTool {
-  NSDictionary *manifestDeveloperConfig = self.rawManifestJSON[@"developer"];
-  BOOL isDeployedFromTool = (manifestDeveloperConfig && manifestDeveloperConfig[@"tool"] != nil);
+  BOOL isDeployedFromTool = (self.developer && self.developer[@"tool"] != nil);
   return (isDeployedFromTool);
 }
 

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/RawManifest/ABI40_0_0EXUpdatesNewRawManifest.h
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/RawManifest/ABI40_0_0EXUpdatesNewRawManifest.h
@@ -7,6 +7,26 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ABI40_0_0EXUpdatesNewRawManifest : ABI40_0_0EXUpdatesBaseRawManifest<ABI40_0_0EXUpdatesRawManifestBehavior>
 
+/**
+ * An ID representing this manifest, not the ID for the experience.
+ */
+- (NSString *)rawId;
+
+/**
+ * Incorrect for now until we figure out how to get this in the new manifest format.
+ */
+- (NSString *)stableLegacyId DEPRECATED_MSG_ATTRIBUTE("Modern manifests don't support stable legacy IDs");
+
+/**
+ * Incorrect for now until we figure out how to get this in the new manifest format.
+ */
+- (NSString *)scopeKey;
+
+/**
+ * Incorrect for now until we figure out how to get this in the new manifest format.
+ */
+- (nullable NSString *)projectId;
+
 - (NSString *)createdAt;
 - (NSString *)runtimeVersion;
 - (NSDictionary *)launchAsset;

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/RawManifest/ABI40_0_0EXUpdatesNewRawManifest.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/RawManifest/ABI40_0_0EXUpdatesNewRawManifest.m
@@ -4,6 +4,22 @@
 
 @implementation ABI40_0_0EXUpdatesNewRawManifest
 
+- (NSString *)rawId {
+  return [self.rawManifestJSON stringForKey:@"id"];
+}
+
+- (NSString *)stableLegacyId {
+  return self.rawId;
+}
+
+- (NSString *)scopeKey {
+  return self.rawId;
+}
+
+- (NSString *)projectId {
+  return self.rawId;
+}
+
 - (NSString *)createdAt {
   return [self.rawManifestJSON stringForKey:@"createdAt"];
 }
@@ -21,7 +37,7 @@
       return [runtimeVersion substringWithRange:matchRange];
     }
   }
-  
+
   return nil;
 }
 

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/RawManifest/ABI40_0_0EXUpdatesRawManifest.h
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/RawManifest/ABI40_0_0EXUpdatesRawManifest.h
@@ -10,7 +10,36 @@ NS_ASSUME_NONNULL_BEGIN
 
 # pragma mark - Field getters
 
-- (nullable NSString *)rawID;
+/**
+ * A best-effort immutable legacy ID for this experience. Formatted the same as legacyId.
+ * Stable through project transfers.
+ */
+- (NSString *)stableLegacyId;
+
+/**
+ * A stable immutable scoping key for this experience. Should be used for scoping data that
+ * does not need to make calls externally with the legacy ID.
+ */
+- (NSString *)scopeKey;
+
+/**
+ * A stable UUID for this EAS project. Should be used to call EAS APIs where possible.
+ */
+- (nullable NSString *)projectId;
+
+/**
+ * The legacy ID of this experience.
+ * - For Bare manifests, formatted as a UUID.
+ * - For Legacy manifests, formatted as @owner/slug. Not stable through project transfers.
+ * - For New manifests, currently incorrect value is UUID.
+ *
+ * Use this in cases where an identifier of the current manifest is needed (experience loading for example).
+ * Use scopeKey for cases where a stable key is needed to scope data to this experience.
+ * Use projectId for cases where a stable UUID identifier of the experience is needed to identify over APIs.
+ * Use stableLegacyId for cases where a stable legacy format identifier of the experience is needed (experience scoping for example).
+ */
+- (NSString *)legacyId;
+
 - (nullable NSString *)sdkVersion;
 - (NSString *)bundleUrl;
 - (nullable NSString *)revisionId;
@@ -22,6 +51,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSDictionary *)iosConfig;
 - (nullable NSString *)hostUri;
 - (nullable NSString *)orientation;
+- (nullable NSDictionary *)experiments;
+- (nullable NSDictionary *)developer;
 
 # pragma mark - Derived Methods
 

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/ABI40_0_0EXVersionManager.h
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/ABI40_0_0EXVersionManager.h
@@ -2,15 +2,17 @@
 
 #import <Foundation/Foundation.h>
 #import <ABI40_0_0React/ABI40_0_0RCTLog.h>
+#import <ABI40_0_0EXUpdates/ABI40_0_0EXUpdatesRawManifest.h>
 
 @interface ABI40_0_0EXVersionManager : NSObject
 
 // Uses a params dict since the internal workings may change over time, but we want to keep the interface the same.
-- (instancetype)initWithParams: (NSDictionary *)params
-                  fatalHandler: (void (^)(NSError *))fatalHandler
-                   logFunction: (ABI40_0_0RCTLogFunction)logFunction
-                  logThreshold: (NSInteger)threshold;
-- (void)bridgeWillStartLoading: (id)bridge;
+- (instancetype)initWithParams:(NSDictionary *)params
+                      manifest:(ABI40_0_0EXUpdatesRawManifest *)manifest
+                  fatalHandler:(void (^)(NSError *))fatalHandler
+                   logFunction:(ABI40_0_0RCTLogFunction)logFunction
+                  logThreshold:(NSInteger)threshold;
+- (void)bridgeWillStartLoading:(id)bridge;
 - (void)bridgeFinishedLoading:(id)bridge;
 - (void)invalidate;
 

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/ABI40_0_0EXVersionManager.mm
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/ABI40_0_0EXVersionManager.mm
@@ -83,6 +83,7 @@ ABI40_0_0RCT_EXTERN NSDictionary<NSString *, NSDictionary *> *ABI40_0_0EXGetScop
 // is this the first time this ABI has been touched at runtime?
 @property (nonatomic, assign) BOOL isFirstLoad;
 @property (nonatomic, strong) NSDictionary *params;
+@property (nonatomic, strong) ABI40_0_0EXUpdatesRawManifest *manifest;
 @property (nonatomic, strong) ABI40_0_0RCTTurboModuleManager *turboModuleManager;
 
 @end
@@ -91,7 +92,6 @@ ABI40_0_0RCT_EXTERN NSDictionary<NSString *, NSDictionary *> *ABI40_0_0EXGetScop
 
 /**
  *  Expected params:
- *    NSDictionary *manifest
  *    NSDictionary *constants
  *    NSURL *initialUri
  *    @BOOL isDeveloper
@@ -105,12 +105,14 @@ ABI40_0_0RCT_EXTERN NSDictionary<NSString *, NSDictionary *> *ABI40_0_0EXGetScop
  *    id exceptionsManagerDelegate
  */
 - (instancetype)initWithParams:(NSDictionary *)params
+                      manifest:(ABI40_0_0EXUpdatesRawManifest *)manifest
                   fatalHandler:(void (^)(NSError *))fatalHandler
                    logFunction:(ABI40_0_0RCTLogFunction)logFunction
                   logThreshold:(NSInteger)threshold
 {
   if (self = [super init]) {
     _params = params;
+    _manifest = manifest;
     [self configureABIWithFatalHandler:fatalHandler logFunction:logFunction logThreshold:threshold];
   }
   return self;
@@ -161,7 +163,7 @@ ABI40_0_0RCT_EXTERN NSDictionary<NSString *, NSDictionary *> *ABI40_0_0EXGetScop
       @"isEnabled": @NO
     };
   }
-  
+
   if (devSettings.isRemoteDebuggingAvailable && isDevModeEnabled) {
     items[@"dev-remote-debug"] = @{
       @"label": (devSettings.isDebuggingRemotely) ? @"Stop Remote Debugging" : @"Debug Remote JS",
@@ -274,7 +276,7 @@ ABI40_0_0RCT_EXTERN NSDictionary<NSString *, NSDictionary *> *ABI40_0_0EXGetScop
                          logFunction:(ABI40_0_0RCTLogFunction)logFunction
                         logThreshold:(NSInteger)threshold
 {
-  ABI40_0_0RCTEnableTurboModule([self.params[@"manifest"][@"experiments"][@"turboModules"] boolValue]);
+  ABI40_0_0RCTEnableTurboModule([self.manifest.experiments[@"turboModules"] boolValue]);
   ABI40_0_0RCTSetFatalHandler(fatalHandler);
   ABI40_0_0RCTSetLogThreshold((ABI40_0_0RCTLogLevel) threshold);
   ABI40_0_0RCTSetLogFunction(logFunction);
@@ -283,8 +285,6 @@ ABI40_0_0RCT_EXTERN NSDictionary<NSString *, NSDictionary *> *ABI40_0_0EXGetScop
 - (NSArray *)extraModulesForBridge:(id)bridge
 {
   NSDictionary *params = _params;
-  NSDictionary *manifest = params[@"manifest"];
-  NSString *experienceId = manifest[@"id"];
   NSDictionary *services = params[@"services"];
 
   NSMutableArray *extraModules = [NSMutableArray arrayWithArray:
@@ -293,10 +293,10 @@ ABI40_0_0RCT_EXTERN NSDictionary<NSString *, NSDictionary *> *ABI40_0_0EXGetScop
                                     [[ABI40_0_0EXDisabledDevLoadingView alloc] init],
                                     [[ABI40_0_0EXStatusBarManager alloc] init],
                                     ]];
-  
+
   // add scoped modules
-  [extraModules addObjectsFromArray:[self _newScopedModulesWithExperienceId:experienceId services:services params:params]];
-  
+  [extraModules addObjectsFromArray:[self _newScopedModulesForServices:services params:params]];
+
   if (params[@"testEnvironment"]) {
     ABI40_0_0EXTestEnvironment testEnvironment = (ABI40_0_0EXTestEnvironment)[params[@"testEnvironment"] unsignedIntegerValue];
     if (testEnvironment != ABI40_0_0EXTestEnvironmentNone) {
@@ -304,11 +304,12 @@ ABI40_0_0RCT_EXTERN NSDictionary<NSString *, NSDictionary *> *ABI40_0_0EXGetScop
       [extraModules addObject:testModule];
     }
   }
-  
+
   if (params[@"browserModuleClass"]) {
     Class browserModuleClass = params[@"browserModuleClass"];
-    id homeModule = [[browserModuleClass alloc] initWithExperienceId:experienceId
-                                                    kernelServiceDelegate:services[@"EXHomeModuleManager"]
+    id homeModule = [[browserModuleClass alloc] initWithExperienceStableLegacyId:self.manifest.stableLegacyId
+                                                              scopeKey:self.manifest.scopeKey
+                                                           kernelServiceDelegate:services[@"EXHomeModuleManager"]
                                                                    params:params];
     [extraModules addObject:homeModule];
   }
@@ -324,10 +325,13 @@ ABI40_0_0RCT_EXTERN NSDictionary<NSString *, NSDictionary *> *ABI40_0_0EXGetScop
   [moduleRegistryProvider setModuleRegistryDelegate:moduleRegistryDelegate];
 
   ABI40_0_0EXScopedModuleRegistryAdapter *moduleRegistryAdapter = [[ABI40_0_0EXScopedModuleRegistryAdapter alloc] initWithModuleRegistryProvider:moduleRegistryProvider];
-  ABI40_0_0UMModuleRegistry *moduleRegistry = [moduleRegistryAdapter moduleRegistryForParams:params forExperienceId:experienceId withKernelServices:services];
+  ABI40_0_0UMModuleRegistry *moduleRegistry = [moduleRegistryAdapter moduleRegistryForParams:params
+                                                        forExperienceStableLegacyId:self.manifest.stableLegacyId
+                                                                 scopeKey:self.manifest.scopeKey
+                                                                 withKernelServices:services];
   NSArray<id<ABI40_0_0RCTBridgeModule>> *expoModules = [moduleRegistryAdapter extraModulesForModuleRegistry:moduleRegistry];
   [extraModules addObjectsFromArray:expoModules];
-  
+
   if (!ABI40_0_0RCTTurboModuleEnabled()) {
     [extraModules addObject:[self getModuleInstanceFromClass:[self getModuleClassFromName:"DevSettings"]]];
     id exceptionsManager = [self getModuleInstanceFromClass:ABI40_0_0RCTExceptionsManagerCls()];
@@ -342,7 +346,7 @@ ABI40_0_0RCT_EXTERN NSDictionary<NSString *, NSDictionary *> *ABI40_0_0EXGetScop
   return extraModules;
 }
 
-- (NSArray *)_newScopedModulesWithExperienceId: (NSString *)experienceId services:(NSDictionary *)services params:(NSDictionary *)params
+- (NSArray *)_newScopedModulesForServices:(NSDictionary *)services params:(NSDictionary *)params
 {
   NSMutableArray *result = [NSMutableArray array];
   NSDictionary<NSString *, NSDictionary *> *ABI40_0_0EXScopedModuleClasses = ABI40_0_0EXGetScopedModuleClasses();
@@ -354,17 +358,26 @@ ABI40_0_0RCT_EXTERN NSDictionary<NSString *, NSDictionary *> *ABI40_0_0EXGetScop
         id service = ([kernelSerivceName isEqualToString:ABI40_0_0EX_KERNEL_SERVICE_NONE]) ? [NSNull null] : services[kernelSerivceName];
         moduleServices[kernelServiceClassName] = service;
       }
-      
+
       id scopedModule;
       Class scopedModuleClass = NSClassFromString(scopedModuleClassName);
       if (moduleServices.count > 1) {
-        scopedModule = [[scopedModuleClass alloc] initWithExperienceId:experienceId kernelServiceDelegates:moduleServices params:params];
+        scopedModule = [[scopedModuleClass alloc] initWithExperienceStableLegacyId:self.manifest.stableLegacyId
+                                                                scopeKey:self.manifest.scopeKey
+                                                            kernelServiceDelegates:moduleServices
+                                                                            params:params];
       } else if (moduleServices.count == 0) {
-        scopedModule = [[scopedModuleClass alloc] initWithExperienceId:experienceId kernelServiceDelegate:nil params:params];
+        scopedModule = [[scopedModuleClass alloc] initWithExperienceStableLegacyId:self.manifest.stableLegacyId
+                                                                scopeKey:self.manifest.scopeKey
+                                                             kernelServiceDelegate:nil
+                                                                            params:params];
       } else {
-        scopedModule = [[scopedModuleClass alloc] initWithExperienceId:experienceId kernelServiceDelegate:moduleServices[[moduleServices allKeys][0]] params:params];
+        scopedModule = [[scopedModuleClass alloc] initWithExperienceStableLegacyId:self.manifest.stableLegacyId
+                                                                scopeKey:self.manifest.scopeKey
+                                                             kernelServiceDelegate:moduleServices[[moduleServices allKeys][0]]
+                                                                            params:params];
       }
-      
+
       if (scopedModule) {
         [result addObject:scopedModule];
       }
@@ -425,7 +438,7 @@ ABI40_0_0RCT_EXTERN NSDictionary<NSString *, NSDictionary *> *ABI40_0_0EXGetScop
   // Expo-specific
   if (moduleClass == ABI40_0_0EXDevSettings.class) {
     BOOL isDevelopment = ![self _isOpeningHomeInProductionMode] && [_params[@"isDeveloper"] boolValue];
-    return [[moduleClass alloc] initWithExperienceId:[self _experienceId] isDevelopment:isDevelopment];
+    return [[moduleClass alloc] initWithScopeKey:self.manifest.scopeKey isDevelopment:isDevelopment];
   } else if (moduleClass == ABI40_0_0RCTExceptionsManagerCls()) {
     id exceptionsManagerDelegate = _params[@"exceptionsManagerDelegate"];
     if (exceptionsManagerDelegate) {
@@ -459,14 +472,10 @@ ABI40_0_0RCT_EXTERN NSDictionary<NSString *, NSDictionary *> *ABI40_0_0EXGetScop
 }
 
 
-- (NSString *)_experienceId
-{
-  return _params[@"manifest"][@"id"];
-}
 
 - (BOOL)_isOpeningHomeInProductionMode
 {
-  return _params[@"browserModuleClass"] && !_params[@"manifest"][@"developer"];
+  return _params[@"browserModuleClass"] && !self.manifest.developer;
 }
 
 - (void *)versionedJsExecutorFactoryForBridge:(ABI40_0_0RCTBridge *)bridge
@@ -487,7 +496,7 @@ ABI40_0_0RCT_EXTERN NSDictionary<NSString *, NSDictionary *> *ABI40_0_0EXGetScop
                                                                      delegate:self
                                                                     jsInvoker:bridge.jsCallInvoker];
     [self->_turboModuleManager installJSBindingWithRuntime:&runtime];
-    
+
     auto reanimatedModule = ABI40_0_0reanimated::createReanimatedModule(bridge.jsCallInvoker);
     runtime.global().setProperty(runtime,
                                  jsi::PropNameID::forAscii(runtime, "__reanimatedModuleProxy"),

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/Api/ABI40_0_0EXNotifications.h
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/Api/ABI40_0_0EXNotifications.h
@@ -34,7 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol ABI40_0_0EXNotificationsIdentifiersManager
 
-- (NSString *)internalIdForIdentifier:(NSString *)identifier experienceId:(NSString *)experienceId;
+- (NSString *)internalIdForIdentifier:(NSString *)identifier scopeKey:(NSString *)scopeKey;
 - (NSString *)exportedIdForInternalIdentifier:(NSString *)identifier;
 
 @end

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/Api/ABI40_0_0EXNotifications.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/Api/ABI40_0_0EXNotifications.m
@@ -47,9 +47,12 @@ ABI40_0_0EX_EXPORT_SCOPED_MULTISERVICE_MODULE(ExponentNotifications, @"RemoteNot
   _bridge = bridge;
 }
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId kernelServiceDelegates:(NSDictionary *)kernelServiceInstances params:(NSDictionary *)params
+- (instancetype)initWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId
+                              scopeKey:(NSString *)scopeKey
+                          kernelServiceDelegates:(NSDictionary *)kernelServiceInstances
+                                          params:(NSDictionary *)params
 {
-  if (self = [super initWithExperienceId:experienceId kernelServiceDelegates:kernelServiceInstances params:params]) {
+  if (self = [super initWithExperienceStableLegacyId:experienceStableLegacyId scopeKey:scopeKey kernelServiceDelegate:kernelServiceInstances params:params]) {
     _userNotificationCenter = kernelServiceInstances[@"UserNotificationCenter"];
     _remoteNotificationsDelegate = kernelServiceInstances[@"RemoteNotificationManager"];
     _notificationsIdentifiersManager = kernelServiceInstances[@"UserNotificationManager"];
@@ -80,7 +83,7 @@ ABI40_0_0RCT_REMAP_METHOD(getExponentPushTokenAsync,
                  getExponentPushTokenAsyncWithResolver:(ABI40_0_0RCTPromiseResolveBlock)resolve
                  rejecter:(ABI40_0_0RCTPromiseRejectBlock)reject)
 {
-  if (!self.experienceId) {
+  if (!self.experienceStableLegacyId) {
     reject(@"E_NOTIFICATIONS_INTERNAL_ERROR", @"The notifications module is missing the current project's ID", nil);
     return;
   }
@@ -212,7 +215,8 @@ ABI40_0_0RCT_EXPORT_METHOD(legacyScheduleLocalRepeatingNotification:(NSDictionar
   localNotification.applicationIconBadgeNumber = [ABI40_0_0RCTConvert NSInteger:payload[@"count"]] ?: 0;
   localNotification.userInfo = @{
                                  @"body": payload[@"data"],
-                                 @"experienceId": self.experienceId,
+                                 @"experienceId": self.scopeKey,
+                                 @"scopeKey": self.scopeKey,
                                  @"id": uniqueId
                                  };
   localNotification.fireDate = [ABI40_0_0RCTConvert NSDate:options[@"time"]] ?: [NSDate new];
@@ -256,7 +260,7 @@ ABI40_0_0RCT_REMAP_METHOD(cancelAllScheduledNotificationsAsync,
   [_userNotificationCenter getPendingNotificationRequestsWithCompletionHandler:^(NSArray<UNNotificationRequest *> * _Nonnull requests) {
     NSMutableArray<NSString *> *requestsToCancelIdentifiers = [NSMutableArray new];
     for (UNNotificationRequest *request in requests) {
-      if ([request.content.userInfo[@"experienceId"] isEqualToString:self.experienceId]) {
+      if ([request.content.userInfo[@"experienceId"] isEqualToString:self.scopeKey]) {
         [requestsToCancelIdentifiers addObject:request.identifier];
       }
     }
@@ -378,7 +382,8 @@ ABI40_0_0RCT_REMAP_METHOD(deleteCategoryAsync,
 
   content.userInfo = @{
                        @"body": payload[@"data"],
-                       @"experienceId": self.experienceId,
+                       @"experienceId": self.scopeKey,
+                       @"scopeKey": self.scopeKey,
                        @"id": uniqueId
                        };
 
@@ -386,7 +391,7 @@ ABI40_0_0RCT_REMAP_METHOD(deleteCategoryAsync,
 }
 
 - (NSString *)internalIdForIdentifier:(NSString *)identifier {
-  return [_notificationsIdentifiersManager internalIdForIdentifier:identifier experienceId:self.experienceId];
+  return [_notificationsIdentifiersManager internalIdForIdentifier:identifier scopeKey:self.scopeKey];
 }
 
 - (UNCalendarNotificationTrigger *)notificationTriggerFor:(NSNumber * _Nullable)unixTime

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/Api/ABI40_0_0EXUtil.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/Api/ABI40_0_0EXUtil.m
@@ -15,9 +15,12 @@ ABI40_0_0EX_DEFINE_SCOPED_MODULE_GETTER(ABI40_0_0EXUtil, util)
 
 ABI40_0_0EX_EXPORT_SCOPED_MODULE(ExponentUtil, UtilService);
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId kernelServiceDelegate:(id<ABI40_0_0EXUtilService>)kernelServiceInstance params:(NSDictionary *)params
+- (instancetype)initWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId scopeKey:(NSString *)scopeKey kernelServiceDelegate:(id<ABI40_0_0EXUtilService>)kernelServiceInstance params:(NSDictionary *)params
 {
-  if (self = [super initWithExperienceId:experienceId kernelServiceDelegate:kernelServiceInstance params:params]) {
+  if (self = [super initWithExperienceStableLegacyId:experienceStableLegacyId
+                                  scopeKey:scopeKey
+                               kernelServiceDelegate:kernelServiceInstance
+                                              params:params]) {
     _kernelUtilService = kernelServiceInstance;
   }
   return self;
@@ -44,7 +47,7 @@ ABI40_0_0EX_EXPORT_SCOPED_MODULE(ExponentUtil, UtilService);
 {
   const CGFloat *components = CGColorGetComponents(color);
   size_t count = CGColorGetNumberOfComponents(color);
-  
+
   if (count == 2) {
     return [NSString stringWithFormat:@"#%02lX%02lX%02lX",
             lroundf(components[0] * 255.0),
@@ -77,7 +80,7 @@ ABI40_0_0EX_EXPORT_SCOPED_MODULE(ExponentUtil, UtilService);
     int r = (hex >> 16) & 0xFF;
     int g = (hex >> 8) & 0xFF;
     int b = (hex) & 0xFF;
-    
+
     return [UIColor colorWithRed:r / 255.0f
                            green:g / 255.0f
                             blue:b / 255.0f

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/Api/Components/WebView/ABI40_0_0RNCWKProcessPoolManager.h
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/Api/Components/WebView/ABI40_0_0RNCWKProcessPoolManager.h
@@ -10,6 +10,6 @@
 @interface ABI40_0_0RNCWKProcessPoolManager : NSObject
 
 + (instancetype) sharedManager;
-- (WKProcessPool *)sharedProcessPoolForExperienceId:(NSString *)experienceId;
+- (WKProcessPool *)sharedProcessPoolForScopeKey:(NSString *)scopeKey;
 
 @end

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/Api/Components/WebView/ABI40_0_0RNCWKProcessPoolManager.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/Api/Components/WebView/ABI40_0_0RNCWKProcessPoolManager.m
@@ -42,17 +42,17 @@
     return _sharedProcessPool;
 }
 
-- (WKProcessPool *)sharedProcessPoolForExperienceId:(NSString *)experienceId
+- (WKProcessPool *)sharedProcessPoolForScopeKey:(NSString *)scopeKey
 {
-  if (!experienceId) {
+  if (!scopeKey) {
     return [self sharedProcessPool];
   }
 
-  if (!_pools[experienceId]) {
-    _pools[experienceId] = [[WKProcessPool alloc] init];
+  if (!_pools[scopeKey]) {
+    _pools[scopeKey] = [[WKProcessPool alloc] init];
   }
 
-  return _pools[experienceId];
+  return _pools[scopeKey];
 }
 
 @end

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/Api/Components/WebView/ABI40_0_0RNCWebView.h
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/Api/Components/WebView/ABI40_0_0RNCWebView.h
@@ -26,7 +26,7 @@
 
 @interface ABI40_0_0RNCWebView : ABI40_0_0RCTView
 
-@property (nonatomic, strong) NSString *experienceId;
+@property (nonatomic, strong) NSString *scopeKey;
 
 @property (nonatomic, weak) id<ABI40_0_0RNCWebViewDelegate> _Nullable delegate;
 @property (nonatomic, copy) NSDictionary * _Nullable source;

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/Api/Components/WebView/ABI40_0_0RNCWebView.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/Api/Components/WebView/ABI40_0_0RNCWebView.m
@@ -223,7 +223,7 @@ static NSDictionary* customCertificatesForHost;
     wkWebViewConfig.websiteDataStore = [WKWebsiteDataStore defaultDataStore];
   }
   if(self.useSharedProcessPool) {
-    wkWebViewConfig.processPool = [[ABI40_0_0RNCWKProcessPoolManager sharedManager] sharedProcessPoolForExperienceId:self.experienceId];
+    wkWebViewConfig.processPool = [[ABI40_0_0RNCWKProcessPoolManager sharedManager] sharedProcessPoolForScopeKey:self.scopeKey];
   }
 
   wkWebViewConfig.userContentController = [WKUserContentController new];
@@ -283,7 +283,7 @@ static NSDictionary* customCertificatesForHost;
     _webView.scrollView.scrollEnabled = _scrollEnabled;
     _webView.scrollView.pagingEnabled = _pagingEnabled;
       //For UIRefreshControl to work correctly, the bounces should always be true
-    _webView.scrollView.bounces = _pullToRefreshEnabled || _bounces; 
+    _webView.scrollView.bounces = _pullToRefreshEnabled || _bounces;
     _webView.scrollView.showsHorizontalScrollIndicator = _showsHorizontalScrollIndicator;
     _webView.scrollView.showsVerticalScrollIndicator = _showsVerticalScrollIndicator;
     _webView.scrollView.directionalLockEnabled = _directionalLockEnabled;
@@ -1156,7 +1156,7 @@ static NSDictionary* customCertificatesForHost;
 - (void)setPullToRefreshEnabled:(BOOL)pullToRefreshEnabled
 {
     _pullToRefreshEnabled = pullToRefreshEnabled;
-    
+
     if (pullToRefreshEnabled) {
         [self addPullToRefreshControl];
     } else {

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/Api/Components/WebView/ABI40_0_0RNCWebViewManager.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/Api/Components/WebView/ABI40_0_0RNCWebViewManager.m
@@ -30,17 +30,18 @@ ABI40_0_0RCT_ENUM_CONVERTER(WKContentMode, (@{
 {
   NSConditionLock *_shouldStartLoadLock;
   BOOL _shouldStartLoad;
-  NSString *_experienceId;
+  NSString *_scopeKey;
 }
 
 ABI40_0_0EX_EXPORT_SCOPED_MODULE(ABI40_0_0RNCWebViewManager, ABI40_0_0EXKernelServiceNone)
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
-               kernelServiceDelegate:(id)kernelServiceInstance
+- (instancetype)initWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId
+                        scopeKey:(NSString *)scopeKey
+                     kernelServiceDelegate:(id)kernelServiceInstance
                               params:(NSDictionary *)params
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _scopeKey = scopeKey;
   }
   return self;
 }
@@ -52,7 +53,7 @@ ABI40_0_0EX_EXPORT_SCOPED_MODULE(ABI40_0_0RNCWebViewManager, ABI40_0_0EXKernelSe
 #endif // !TARGET_OS_OSX
 {
   ABI40_0_0RNCWebView *webView = [ABI40_0_0RNCWebView new];
-  webView.experienceId = _experienceId;
+  webView.scopeKey = _scopeKey;
   webView.delegate = self;
   return webView;
 }

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/Internal/ABI40_0_0EXLinkingManager.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/Internal/ABI40_0_0EXLinkingManager.m
@@ -22,9 +22,11 @@ NSString * const ABI40_0_0EXLinkingEventOpenUrl = @"url";
 
 ABI40_0_0EX_EXPORT_SCOPED_MODULE(ABI40_0_0RCTLinkingManager, KernelLinkingManager);
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId kernelServiceDelegate:(id)kernelServiceInstance params:(NSDictionary *)params
+- (instancetype)initWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId
+                        scopeKey:(NSString *)scopeKey
+                     kernelServiceDelegate:(id)kernelServiceInstance params:(NSDictionary *)params
 {
-  if (self = [super initWithExperienceId:experienceId kernelServiceDelegate:kernelServiceInstance params:params]) {
+  if (self = [super initWithExperienceStableLegacyId:experienceStableLegacyId scopeKey:scopeKey kernelServiceDelegate:kernelServiceInstance params:params]) {
     _kernelLinkingDelegate = kernelServiceInstance;
     _initialUrl = params[@"initialUri"];
   }

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/Internal/DevSupport/ABI40_0_0EXDevSettings.h
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/Internal/DevSupport/ABI40_0_0EXDevSettings.h
@@ -5,7 +5,7 @@
 @interface ABI40_0_0EXDevSettings : ABI40_0_0RCTDevSettings
 
 - (instancetype)init NS_UNAVAILABLE;
-- (instancetype)initWithExperienceId:(NSString *)experienceId
-                       isDevelopment:(BOOL)isDevelopment NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey
+                             isDevelopment:(BOOL)isDevelopment NS_DESIGNATED_INITIALIZER;
 
 @end

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/Internal/DevSupport/ABI40_0_0EXDevSettings.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/Internal/DevSupport/ABI40_0_0EXDevSettings.m
@@ -12,7 +12,7 @@ NSString *const kABI40_0_0RCTDevSettingHotLoadingEnabled = @"hotLoadingEnabled";
 
 + (NSString *)moduleName { return @"ABI40_0_0RCTDevSettings"; }
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId isDevelopment:(BOOL)isDevelopment
+- (instancetype)initWithScopeKey:(NSString *)scopeKey isDevelopment:(BOOL)isDevelopment
 {
   NSDictionary *defaultValues = @{
                                   kABI40_0_0RCTDevSettingShakeToShowDevMenu: @YES,
@@ -20,7 +20,7 @@ NSString *const kABI40_0_0RCTDevSettingHotLoadingEnabled = @"hotLoadingEnabled";
                                   kABI40_0_0RCTDevSettingLiveReloadEnabled: @NO,
                                   };
   ABI40_0_0EXDevSettingsDataSource *dataSource = [[ABI40_0_0EXDevSettingsDataSource alloc] initWithDefaultValues:defaultValues
-                                                                               forExperienceId:experienceId
+                                                                         forScopeKey:scopeKey
                                                                                  isDevelopment:isDevelopment];
   return [super initWithDataSource:dataSource];
 }

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/Internal/DevSupport/ABI40_0_0EXDevSettingsDataSource.h
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/Internal/DevSupport/ABI40_0_0EXDevSettingsDataSource.h
@@ -7,7 +7,7 @@
 
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithDefaultValues:(NSDictionary *)defaultValues
-                      forExperienceId:(NSString *)experienceId
+                forScopeKey:(NSString *)scopeKey
                         isDevelopment:(BOOL)isDevelopment NS_DESIGNATED_INITIALIZER;
 
 @end

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/Internal/DevSupport/ABI40_0_0EXDevSettingsDataSource.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/Internal/DevSupport/ABI40_0_0EXDevSettingsDataSource.m
@@ -16,7 +16,7 @@ NSString *const ABI40_0_0EXDevSettingIsDebuggingRemotely = @"isDebuggingRemotely
 
 @interface ABI40_0_0EXDevSettingsDataSource ()
 
-@property (nonatomic, strong) NSString *experienceId;
+@property (nonatomic, strong) NSString *scopeKey;
 @property (nonatomic, readonly) NSSet *settingsDisabledInProduction;
 
 @end
@@ -27,10 +27,12 @@ NSString *const ABI40_0_0EXDevSettingIsDebuggingRemotely = @"isDebuggingRemotely
   BOOL _isDevelopment;
 }
 
-- (instancetype)initWithDefaultValues:(NSDictionary *)defaultValues forExperienceId:(NSString *)experienceId isDevelopment:(BOOL)isDevelopment
+- (instancetype)initWithDefaultValues:(NSDictionary *)defaultValues
+                forScopeKey:(NSString *)scopeKey
+                        isDevelopment:(BOOL)isDevelopment
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _scopeKey = scopeKey;
     _userDefaults = [NSUserDefaults standardUserDefaults];
     _isDevelopment = isDevelopment;
     _settingsDisabledInProduction = [NSSet setWithArray:@[
@@ -97,8 +99,8 @@ NSString *const ABI40_0_0EXDevSettingIsDebuggingRemotely = @"isDebuggingRemotely
 
 - (NSString *)_userDefaultsKey
 {
-  if (_experienceId) {
-    return [NSString stringWithFormat:@"%@/%@", _experienceId, ABI40_0_0EXDevSettingsUserDefaultsKey];
+  if (_scopeKey) {
+    return [NSString stringWithFormat:@"%@/%@", _scopeKey, ABI40_0_0EXDevSettingsUserDefaultsKey];
   } else {
     ABI40_0_0RCTLogWarn(@"Can't scope dev settings because bridge is not set");
     return ABI40_0_0EXDevSettingsUserDefaultsKey;

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/ScopedModule/ABI40_0_0EXScopedBridgeModule.h
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/ScopedModule/ABI40_0_0EXScopedBridgeModule.h
@@ -7,14 +7,17 @@
 
 - (instancetype)init NS_UNAVAILABLE;
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
-               kernelServiceDelegate:(id)kernelServiceInstance
-                              params:(NSDictionary *)params NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId
+                              scopeKey:(NSString *)scopeKey
+                           kernelServiceDelegate:(id)kernelServiceInstance
+                                          params:(NSDictionary *)params NS_DESIGNATED_INITIALIZER;
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
-               kernelServiceDelegates:(NSDictionary *)kernelServiceInstances
-                              params:(NSDictionary *)params NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId
+                              scopeKey:(NSString *)scopeKey
+                          kernelServiceDelegates:(NSDictionary *)kernelServiceInstances
+                                          params:(NSDictionary *)params NS_DESIGNATED_INITIALIZER;
 
-@property (nonatomic, readonly) NSString *experienceId;
+@property (nonatomic, readonly) NSString *scopeKey;
+@property (nonatomic, readonly) NSString *experienceStableLegacyId;
 
 @end

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/ScopedModule/ABI40_0_0EXScopedBridgeModule.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/ScopedModule/ABI40_0_0EXScopedBridgeModule.m
@@ -10,18 +10,26 @@
   return @"ExponentScopedBridgeModule";
 }
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId kernelServiceDelegate:(id)kernelServiceInstance params:(NSDictionary *)params
+- (instancetype)initWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId
+                              scopeKey:(NSString *)scopeKey
+                           kernelServiceDelegate:(id)kernelServiceInstance
+                                          params:(NSDictionary *)params
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _experienceStableLegacyId = experienceStableLegacyId;
+    _scopeKey = scopeKey;
   }
   return self;
 }
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId kernelServiceDelegates:(NSDictionary *)kernelServiceInstances params:(NSDictionary *)params
+- (instancetype)initWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId
+                              scopeKey:(NSString *)scopeKey
+                          kernelServiceDelegates:(NSDictionary *)kernelServiceInstances
+                                          params:(NSDictionary *)params
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _experienceStableLegacyId = experienceStableLegacyId;
+    _scopeKey = scopeKey;
   }
   return self;
 }

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/ScopedModule/ABI40_0_0EXScopedEventEmitter.h
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/ScopedModule/ABI40_0_0EXScopedEventEmitter.h
@@ -4,18 +4,20 @@
 
 @interface ABI40_0_0EXScopedEventEmitter : ABI40_0_0RCTEventEmitter
 
-+ (NSString *)getExperienceIdFromEventEmitter:(id)eventEmitter;
++ (NSString *)getScopeKeyFromEventEmitter:(id)eventEmitter;
 
 - (instancetype)init NS_UNAVAILABLE;
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
-               kernelServiceDelegate:(id)kernelServiceInstance
-                              params:(NSDictionary *)params NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId
+                        scopeKey:(NSString *)scopeKey
+                     kernelServiceDelegate:(id)kernelServiceInstance
+                                    params:(NSDictionary *)params NS_DESIGNATED_INITIALIZER;
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
-              kernelServiceDelegates:(NSDictionary *)kernelServiceInstances
-                              params:(NSDictionary *)params NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId
+                        scopeKey:(NSString *)scopeKey
+                    kernelServiceDelegates:(NSDictionary *)kernelServiceInstances
+                                    params:(NSDictionary *)params NS_DESIGNATED_INITIALIZER;
 
-@property (nonatomic, readonly) NSString *experienceId;
+@property (nonatomic, readonly) NSString *scopeKey;
 
 @end

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/ScopedModule/ABI40_0_0EXScopedEventEmitter.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/ScopedModule/ABI40_0_0EXScopedEventEmitter.m
@@ -10,26 +10,26 @@
   return @"ExponentScopedEventEmitter";
 }
 
-+ (NSString *)getExperienceIdFromEventEmitter:(id)eventEmitter
++ (NSString *)getScopeKeyFromEventEmitter:(id)eventEmitter
 {
   if (eventEmitter) {
-    return ((ABI40_0_0EXScopedEventEmitter *)eventEmitter).experienceId;
+    return ((ABI40_0_0EXScopedEventEmitter *)eventEmitter).scopeKey;
   }
   return nil;
 }
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId kernelServiceDelegate:(id)kernelServiceInstance params:(NSDictionary *)params
+- (instancetype)initWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId scopeKey:(NSString *)scopeKey kernelServiceDelegate:(id)kernelServiceInstance params:(NSDictionary *)params
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _scopeKey = scopeKey;
   }
   return self;
 }
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId kernelServiceDelegates:(NSDictionary *)kernelServiceInstances params:(NSDictionary *)params
+- (instancetype)initWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId scopeKey:(NSString *)scopeKey kernelServiceDelegates:(NSDictionary *)kernelServiceInstances params:(NSDictionary *)params
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _scopeKey = scopeKey;
   }
   return self;
 }

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/ABI40_0_0EXConstantsBinding.h
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/ABI40_0_0EXConstantsBinding.h
@@ -11,7 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly) NSString *appOwnership;
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId andParams:(NSDictionary *)params;
+- (instancetype)initWithParams:(NSDictionary *)params;
 
 @end
 

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/ABI40_0_0EXConstantsBinding.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/ABI40_0_0EXConstantsBinding.m
@@ -6,17 +6,15 @@
 @interface ABI40_0_0EXConstantsBinding ()
 
 @property (nonatomic, strong) NSString *appOwnership;
-@property (nonatomic, strong) NSString *experienceId;
 @property (nonatomic, strong) NSDictionary *unversionedConstants;
 
 @end
 
 @implementation ABI40_0_0EXConstantsBinding : ABI40_0_0EXConstantsService
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId andParams:(NSDictionary *)params
+- (instancetype)initWithParams:(NSDictionary *)params
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
     _unversionedConstants = params[@"constants"];
     if (_unversionedConstants && _unversionedConstants[@"appOwnership"]) {
       _appOwnership = _unversionedConstants[@"appOwnership"];
@@ -37,7 +35,7 @@
 #endif
 
   constants[@"isDetached"] = @(isDetached);
-  
+
   if (_unversionedConstants) {
     [constants addEntriesFromDictionary:_unversionedConstants];
   }

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/ABI40_0_0EXScopedAmplitude.h
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/ABI40_0_0EXScopedAmplitude.h
@@ -7,7 +7,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ABI40_0_0EXScopedAmplitude : ABI40_0_0EXAmplitude
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId;
+- (instancetype)initWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId;
 
 @end
 

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/ABI40_0_0EXScopedAmplitude.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/ABI40_0_0EXScopedAmplitude.m
@@ -12,30 +12,30 @@
 
 @interface ABI40_0_0EXScopedAmplitude ()
 
-@property (strong, nonatomic) NSString *escapedExperienceId;
+@property (strong, nonatomic) NSString *escapedExperienceStableLegacyId;
 
 @end
 
 @implementation ABI40_0_0EXScopedAmplitude
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
+- (instancetype)initWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId
 {
   if (self = [super init]) {
-    _escapedExperienceId = [self escapedExperienceId:experienceId];
+    _escapedExperienceStableLegacyId = [self escapedExperienceStableLegacyId:experienceStableLegacyId];
   }
   return self;
 }
 
 - (Amplitude *)amplitudeInstance
 {
-  return [Amplitude instanceWithName:_escapedExperienceId];
+  return [Amplitude instanceWithName:_escapedExperienceStableLegacyId];
 }
 
-- (NSString *)escapedExperienceId:(NSString *)experienceId
+- (NSString *)escapedExperienceStableLegacyId:(NSString *)experienceStableLegacyId
 {
   NSString *charactersToEscape = @"!*'();:@&=+$,/?%#[]";
   NSCharacterSet *allowedCharacters = [[NSCharacterSet characterSetWithCharactersInString:charactersToEscape] invertedSet];
-  return [experienceId stringByAddingPercentEncodingWithAllowedCharacters:allowedCharacters];
+  return [experienceStableLegacyId stringByAddingPercentEncodingWithAllowedCharacters:allowedCharacters];
 }
 
 @end

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/ABI40_0_0EXScopedBranch.h
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/ABI40_0_0EXScopedBranch.h
@@ -15,9 +15,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ABI40_0_0EXScopedBranch : ABI40_0_0RNBranch <ABI40_0_0UMModuleRegistryConsumer, ABI40_0_0UMInternalModule>
 
-@property (nonatomic, strong) NSString *experienceId;
+@property (nonatomic, strong) NSString *scopeKey;
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey;
 
 @end
 

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/ABI40_0_0EXScopedBranch.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/ABI40_0_0EXScopedBranch.m
@@ -20,11 +20,11 @@
   return @[@protocol(ABI40_0_0EXDummyBranchProtocol)];
 }
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
+- (instancetype)initWithScopeKey:(NSString *)scopeKey
 {
   if (self = [super init]) {
     [[NSNotificationCenter defaultCenter] removeObserver:self name:ABI40_0_0RNBranchLinkOpenedNotification object:nil];
-    _experienceId = experienceId;
+    _scopeKey = scopeKey;
   }
   return self;
 }

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/ABI40_0_0EXScopedErrorRecoveryModule.h
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/ABI40_0_0EXScopedErrorRecoveryModule.h
@@ -5,7 +5,7 @@
 
 @interface ABI40_0_0EXScopedErrorRecoveryModule : ABI40_0_0EXErrorRecoveryModule
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey;
 
 @end
 

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/ABI40_0_0EXScopedErrorRecoveryModule.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/ABI40_0_0EXScopedErrorRecoveryModule.m
@@ -5,16 +5,16 @@
 
 @interface ABI40_0_0EXScopedErrorRecoveryModule ()
 
-@property (nonatomic, strong) NSString *experienceId;
+@property (nonatomic, strong) NSString *scopeKey;
 
 @end
 
 @implementation ABI40_0_0EXScopedErrorRecoveryModule
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
+- (instancetype)initWithScopeKey:(NSString *)scopeKey
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _scopeKey = scopeKey;
   }
   return self;
 }
@@ -24,7 +24,7 @@
   NSUserDefaults *preferences = [NSUserDefaults standardUserDefaults];
   NSDictionary *errorRecoveryStore = [preferences dictionaryForKey:[self userDefaultsKey]] ?: @{};
   NSMutableDictionary *newStore = [errorRecoveryStore mutableCopy];
-  newStore[_experienceId] = props;
+  newStore[_scopeKey] = props;
   [preferences setObject:newStore forKey:[self userDefaultsKey]];
   return [preferences synchronize];
 }
@@ -34,10 +34,10 @@
   NSUserDefaults *preferences = [NSUserDefaults standardUserDefaults];
   NSDictionary *errorRecoveryStore = [preferences dictionaryForKey:[self userDefaultsKey]];
   if (errorRecoveryStore) {
-    NSString *props = errorRecoveryStore[_experienceId];
+    NSString *props = errorRecoveryStore[_scopeKey];
     if (props) {
       NSMutableDictionary *storeWithRemovedProps = [errorRecoveryStore mutableCopy];
-      [storeWithRemovedProps removeObjectForKey:_experienceId];
+      [storeWithRemovedProps removeObjectForKey:_scopeKey];
       [preferences setObject:storeWithRemovedProps forKey:[self userDefaultsKey]];
       [preferences synchronize];
       return props;

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/ABI40_0_0EXScopedFirebaseCore.h
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/ABI40_0_0EXScopedFirebaseCore.h
@@ -9,7 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ABI40_0_0EXScopedFirebaseCore : ABI40_0_0EXFirebaseCore
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId andConstantsBinding:(ABI40_0_0EXConstantsBinding *)constantsBinding;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey andConstantsBinding:(ABI40_0_0EXConstantsBinding *)constantsBinding;
 
 @end
 

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/ABI40_0_0EXScopedFirebaseCore.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/ABI40_0_0EXScopedFirebaseCore.m
@@ -12,7 +12,7 @@
   NSDictionary* _protectedAppNames;
 }
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId andConstantsBinding:(ABI40_0_0EXConstantsBinding *)constantsBinding
+- (instancetype)initWithScopeKey:(NSString *)scopeKey andConstantsBinding:(ABI40_0_0EXConstantsBinding *)constantsBinding
 {
   if (![@"expo" isEqualToString:constantsBinding.appOwnership]) {
     return [super init];
@@ -24,20 +24,20 @@
     @"[DEFAULT]": @YES
   }];
   _protectedAppNames = protectedAppNames;
-  
+
   // Make sure the [DEFAULT] app is initialized
   NSString *path = [[NSBundle mainBundle] pathForResource:@"GoogleService-Info" ofType:@"plist"];
   if (path && ![FIRApp defaultApp]) {
     [FIRApp configure];
   }
   if ([FIRApp defaultApp]) [protectedAppNames setValue:@YES forKey:[FIRApp defaultApp].name];
-  
+
   // Determine project app name & options
-  NSString *encodedExperienceId = [self.class encodedResourceName:experienceId];
-  NSString* appName = [NSString stringWithFormat:@"__sandbox_%@", encodedExperienceId];
+  NSString *encodedScopeKey = [self.class encodedResourceName:scopeKey];
+  NSString* appName = [NSString stringWithFormat:@"__sandbox_%@", encodedScopeKey];
   NSDictionary* googleServicesFile = [self.class googleServicesFileFromConstantsManifest:constantsBinding];
   FIROptions* options = [self.class optionsWithGoogleServicesFile:googleServicesFile];
-  
+
   // Delete all previously created (project) apps, except for the currently
   // loaded project and the "protected" ones
   NSDictionary<NSString *,FIRApp *>* apps = [FIRApp allApps];
@@ -101,9 +101,9 @@
 + (nullable FIROptions *)optionsWithGoogleServicesFile:(nullable NSDictionary *)plist
 {
   if (!plist) return nil;
-  
+
   FIROptions *firOptions = [[FIROptions alloc] initWithGoogleAppID:plist[@"GOOGLE_APP_ID"] GCMSenderID:plist[@"GCM_SENDER_ID"]];
-         
+
   firOptions.APIKey = plist[@"API_KEY"];
   firOptions.bundleID = plist[@"BUNDLE_ID"];
   firOptions.clientID = plist[@"CLIENT_ID"];
@@ -112,7 +112,7 @@
   firOptions.androidClientID = plist[@"ANDROID_CLIENT_ID"];
   firOptions.databaseURL = plist[@"DATABASE_URL"];
   firOptions.storageBucket = plist[@"STORAGE_BUCKET"];
-  
+
   return firOptions;
 }
 

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/ABI40_0_0EXScopedModuleRegistryAdapter.h
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/ABI40_0_0EXScopedModuleRegistryAdapter.h
@@ -4,6 +4,9 @@
 
 @interface ABI40_0_0EXScopedModuleRegistryAdapter : ABI40_0_0UMModuleRegistryAdapter
 
-- (ABI40_0_0UMModuleRegistry *)moduleRegistryForParams:(NSDictionary *)params forExperienceId:(NSString *)experienceId withKernelServices:(NSDictionary *)kernelServices;
+- (ABI40_0_0UMModuleRegistry *)moduleRegistryForParams:(NSDictionary *)params
+                  forExperienceStableLegacyId:(NSString *)experienceStableLegacyId
+                           scopeKey:(NSString *)scopeKey
+                           withKernelServices:(NSDictionary *)kernelServices;
 
 @end

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/ABI40_0_0EXScopedModuleRegistryAdapter.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/ABI40_0_0EXScopedModuleRegistryAdapter.m
@@ -37,24 +37,28 @@
 
 @implementation ABI40_0_0EXScopedModuleRegistryAdapter
 
-- (ABI40_0_0UMModuleRegistry *)moduleRegistryForParams:(NSDictionary *)params forExperienceId:(NSString *)experienceId withKernelServices:(NSDictionary *)kernelServices
+- (ABI40_0_0UMModuleRegistry *)moduleRegistryForParams:(NSDictionary *)params
+                  forExperienceStableLegacyId:(NSString *)experienceStableLegacyId
+                           scopeKey:(NSString *)scopeKey
+                           withKernelServices:(NSDictionary *)kernelServices
 {
   ABI40_0_0UMModuleRegistry *moduleRegistry = [self.moduleRegistryProvider moduleRegistry];
 
 #if __has_include(<ABI40_0_0EXUpdates/ABI40_0_0EXUpdatesService.h>)
-  ABI40_0_0EXUpdatesBinding *updatesBinding = [[ABI40_0_0EXUpdatesBinding alloc] initWithExperienceId:experienceId updatesKernelService:kernelServices[@"EXUpdatesManager"] databaseKernelService:kernelServices[@"EXUpdatesDatabaseManager"]];
+  ABI40_0_0EXUpdatesBinding *updatesBinding = [[ABI40_0_0EXUpdatesBinding alloc] initWithScopeKey:scopeKey
+                                                                     updatesKernelService:kernelServices[@"EXUpdatesManager"] databaseKernelService:kernelServices[@"EXUpdatesDatabaseManager"]];
   [moduleRegistry registerInternalModule:updatesBinding];
 #endif
 
 #if __has_include(<ABI40_0_0EXConstants/ABI40_0_0EXConstantsService.h>)
-  ABI40_0_0EXConstantsBinding *constantsBinding = [[ABI40_0_0EXConstantsBinding alloc] initWithExperienceId:experienceId andParams:params];
+  ABI40_0_0EXConstantsBinding *constantsBinding = [[ABI40_0_0EXConstantsBinding alloc] initWithParams:params];
   [moduleRegistry registerInternalModule:constantsBinding];
 #endif
 
 #if __has_include(<ABI40_0_0EXFacebook/ABI40_0_0EXFacebook.h>)
   // only override in Expo client
   if ([params[@"constants"][@"appOwnership"] isEqualToString:@"expo"]) {
-    ABI40_0_0EXScopedFacebook *scopedFacebook = [[ABI40_0_0EXScopedFacebook alloc] initWithExperienceId:experienceId andParams:params];
+    ABI40_0_0EXScopedFacebook *scopedFacebook = [[ABI40_0_0EXScopedFacebook alloc] initWithScopeKey:scopeKey andParams:params];
     [moduleRegistry registerExportedModule:scopedFacebook];
   }
 #endif
@@ -80,7 +84,7 @@
 #endif
 
 #if __has_include(<ABI40_0_0EXSensors/ABI40_0_0EXSensorsManager.h>)
-  ABI40_0_0EXSensorsManagerBinding *sensorsManagerBinding = [[ABI40_0_0EXSensorsManagerBinding alloc] initWithExperienceId:experienceId andKernelService:kernelServices[@"EXSensorManager"]];
+  ABI40_0_0EXSensorsManagerBinding *sensorsManagerBinding = [[ABI40_0_0EXSensorsManagerBinding alloc] initWithScopeKey:scopeKey andKernelService:kernelServices[@"EXSensorManager"]];
   [moduleRegistry registerInternalModule:sensorsManagerBinding];
 #endif
 
@@ -96,17 +100,17 @@
 #endif
 
 #if __has_include(<ABI40_0_0EXSecureStore/ABI40_0_0EXSecureStore.h>)
-  ABI40_0_0EXScopedSecureStore *secureStoreModule = [[ABI40_0_0EXScopedSecureStore alloc] initWithExperienceId:experienceId];
+  ABI40_0_0EXScopedSecureStore *secureStoreModule = [[ABI40_0_0EXScopedSecureStore alloc] initWithScopeKey:scopeKey];
   [moduleRegistry registerExportedModule:secureStoreModule];
 #endif
 
 #if __has_include(<ABI40_0_0EXAmplitude/ABI40_0_0EXAmplitude.h>)
-  ABI40_0_0EXScopedAmplitude *amplitudeModule = [[ABI40_0_0EXScopedAmplitude alloc] initWithExperienceId:experienceId];
+  ABI40_0_0EXScopedAmplitude *amplitudeModule = [[ABI40_0_0EXScopedAmplitude alloc] initWithExperienceStableLegacyId:experienceStableLegacyId];
   [moduleRegistry registerExportedModule:amplitudeModule];
 #endif
 
 #if __has_include(<ABI40_0_0EXPermissions/ABI40_0_0EXPermissions.h>)
-  ABI40_0_0EXScopedPermissions *permissionsModule = [[ABI40_0_0EXScopedPermissions alloc] initWithExperienceId:experienceId andConstantsBinding:constantsBinding];
+  ABI40_0_0EXScopedPermissions *permissionsModule = [[ABI40_0_0EXScopedPermissions alloc] initWithScopeKey:scopeKey andConstantsBinding:constantsBinding];
   [moduleRegistry registerExportedModule:permissionsModule];
   [moduleRegistry registerInternalModule:permissionsModule];
 #endif
@@ -117,7 +121,7 @@
 #endif
 
 #if __has_include(<ABI40_0_0EXBranch/ABI40_0_0RNBranch.h>)
-  ABI40_0_0EXScopedBranch *branchModule = [[ABI40_0_0EXScopedBranch alloc] initWithExperienceId:experienceId];
+  ABI40_0_0EXScopedBranch *branchModule = [[ABI40_0_0EXScopedBranch alloc] initWithScopeKey:scopeKey];
   [moduleRegistry registerInternalModule:branchModule];
 #endif
 
@@ -128,54 +132,54 @@
 
 #if __has_include(<ABI40_0_0EXTaskManager/ABI40_0_0EXTaskManager.h>)
   // TODO: Make scoped task manager when adding support for bare ABI40_0_0React Native
-  ABI40_0_0EXTaskManager *taskManagerModule = [[ABI40_0_0EXTaskManager alloc] initWithExperienceId:experienceId];
+  ABI40_0_0EXTaskManager *taskManagerModule = [[ABI40_0_0EXTaskManager alloc] initWithScopeKey:scopeKey];
   [moduleRegistry registerInternalModule:taskManagerModule];
   [moduleRegistry registerExportedModule:taskManagerModule];
 #endif
-  
+
 #if __has_include(<ABI40_0_0EXErrorRecovery/ABI40_0_0EXErrorRecoveryModule.h>)
-  ABI40_0_0EXScopedErrorRecoveryModule *errorRecovery = [[ABI40_0_0EXScopedErrorRecoveryModule alloc] initWithExperienceId:experienceId];
+  ABI40_0_0EXScopedErrorRecoveryModule *errorRecovery = [[ABI40_0_0EXScopedErrorRecoveryModule alloc] initWithScopeKey:scopeKey];
   [moduleRegistry registerExportedModule:errorRecovery];
 #endif
-  
+
 #if __has_include(<ABI40_0_0EXFirebaseCore/ABI40_0_0EXFirebaseCore.h>)
-  ABI40_0_0EXScopedFirebaseCore *firebaseCoreModule = [[ABI40_0_0EXScopedFirebaseCore alloc] initWithExperienceId:experienceId andConstantsBinding:constantsBinding];
+  ABI40_0_0EXScopedFirebaseCore *firebaseCoreModule = [[ABI40_0_0EXScopedFirebaseCore alloc] initWithScopeKey:scopeKey andConstantsBinding:constantsBinding];
   [moduleRegistry registerExportedModule:firebaseCoreModule];
   [moduleRegistry registerInternalModule:firebaseCoreModule];
 #endif
 
 #if __has_include(<ABI40_0_0EXNotifications/ABI40_0_0EXNotificationsEmitter.h>)
-  ABI40_0_0EXScopedNotificationsEmitter *notificationsEmmitter = [[ABI40_0_0EXScopedNotificationsEmitter alloc] initWithExperienceId:experienceId];
+  ABI40_0_0EXScopedNotificationsEmitter *notificationsEmmitter = [[ABI40_0_0EXScopedNotificationsEmitter alloc] initWithScopeKey:scopeKey];
   [moduleRegistry registerExportedModule:notificationsEmmitter];
 #endif
-  
+
 #if __has_include(<ABI40_0_0EXNotifications/ABI40_0_0EXNotificationsHandlerModule.h>)
-  ABI40_0_0EXScopedNotificationsHandlerModule *notificationsHandler = [[ABI40_0_0EXScopedNotificationsHandlerModule alloc] initWithExperienceId:experienceId];
+  ABI40_0_0EXScopedNotificationsHandlerModule *notificationsHandler = [[ABI40_0_0EXScopedNotificationsHandlerModule alloc] initWithScopeKey:scopeKey];
   [moduleRegistry registerExportedModule:notificationsHandler];
 #endif
-  
+
 #if __has_include(<ABI40_0_0EXNotifications/ABI40_0_0EXNotificationsHandlerModule.h>)
-  ABI40_0_0EXScopedNotificationBuilder *notificationsBuilder = [[ABI40_0_0EXScopedNotificationBuilder alloc] initWithExperienceId:experienceId];
+  ABI40_0_0EXScopedNotificationBuilder *notificationsBuilder = [[ABI40_0_0EXScopedNotificationBuilder alloc] initWithScopeKey:scopeKey];
   [moduleRegistry registerInternalModule:notificationsBuilder];
 #endif
-  
+
 #if __has_include(<ABI40_0_0EXNotifications/ABI40_0_0EXNotificationSchedulerModule.h>)
-  ABI40_0_0EXScopedNotificationSchedulerModule *schedulerModule = [[ABI40_0_0EXScopedNotificationSchedulerModule alloc] initWithExperienceId:experienceId];
+  ABI40_0_0EXScopedNotificationSchedulerModule *schedulerModule = [[ABI40_0_0EXScopedNotificationSchedulerModule alloc] initWithScopeKey:scopeKey];
   [moduleRegistry registerExportedModule:schedulerModule];
 #endif
-    
+
 #if __has_include(<ABI40_0_0EXNotifications/ABI40_0_0EXNotificationPresentationModule.h>)
-  ABI40_0_0EXScopedNotificationPresentationModule *notificationPresentationModule = [[ABI40_0_0EXScopedNotificationPresentationModule alloc] initWithExperienceId:experienceId];
+  ABI40_0_0EXScopedNotificationPresentationModule *notificationPresentationModule = [[ABI40_0_0EXScopedNotificationPresentationModule alloc] initWithScopeKey:scopeKey];
   [moduleRegistry registerExportedModule:notificationPresentationModule];
 #endif
-  
+
 #if __has_include(<ABI40_0_0EXNotifications/ABI40_0_0EXNotificationCategoriesModule.h>)
-  ABI40_0_0EXScopedNotificationCategoriesModule *categoriesModule = [[ABI40_0_0EXScopedNotificationCategoriesModule alloc] initWithExperienceId:experienceId];
+  ABI40_0_0EXScopedNotificationCategoriesModule *categoriesModule = [[ABI40_0_0EXScopedNotificationCategoriesModule alloc] initWithScopeKey:scopeKey];
   [moduleRegistry registerExportedModule:categoriesModule];
 #endif
-  
+
 #if __has_include(<ABI40_0_0EXNotifications/ABI40_0_0EXServerRegistrationModule.h>)
-  ABI40_0_0EXScopedServerRegistrationModule *serverRegistrationModule = [[ABI40_0_0EXScopedServerRegistrationModule alloc] initWithExperienceId:experienceId];
+  ABI40_0_0EXScopedServerRegistrationModule *serverRegistrationModule = [[ABI40_0_0EXScopedServerRegistrationModule alloc] initWithScopeKey:scopeKey];
   [moduleRegistry registerExportedModule:serverRegistrationModule];
 #endif
 

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/ABI40_0_0EXScopedSecureStore.h
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/ABI40_0_0EXScopedSecureStore.h
@@ -7,7 +7,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ABI40_0_0EXScopedSecureStore : ABI40_0_0EXSecureStore
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey;
 
 @end
 

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/ABI40_0_0EXScopedSecureStore.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/ABI40_0_0EXScopedSecureStore.m
@@ -11,16 +11,16 @@
 
 @interface ABI40_0_0EXScopedSecureStore ()
 
-@property (strong, nonatomic) NSString *experienceId;
+@property (strong, nonatomic) NSString *scopeKey;
 
 @end
 
 @implementation ABI40_0_0EXScopedSecureStore
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
+- (instancetype)initWithScopeKey:(NSString *)scopeKey
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _scopeKey = scopeKey;
   }
   return self;
 }
@@ -30,7 +30,7 @@
     return nil;
   }
 
-  return [NSString stringWithFormat:@"%@-%@", _experienceId, key];
+  return [NSString stringWithFormat:@"%@-%@", _scopeKey, key];
 }
 
 @end

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/ABI40_0_0EXSensorsManagerBinding.h
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/ABI40_0_0EXSensorsManagerBinding.h
@@ -11,30 +11,30 @@
 
 @protocol ABI40_0_0EXSensorsManagerBindingDelegate
 
-- (void)sensorModuleDidSubscribeForAccelerometerUpdatesOfExperience:(NSString *)experienceId withHandler:(void (^)(NSDictionary *event))handlerBlock;
-- (void)sensorModuleDidUnsubscribeForAccelerometerUpdatesOfExperience:(NSString *)experienceId;
+- (void)sensorModuleDidSubscribeForAccelerometerUpdatesOfExperience:(NSString *)scopeKey withHandler:(void (^)(NSDictionary *event))handlerBlock;
+- (void)sensorModuleDidUnsubscribeForAccelerometerUpdatesOfExperience:(NSString *)scopeKey;
 - (void)setAccelerometerUpdateInterval:(NSTimeInterval)intervalMs;
 
 - (float)getGravity;
-- (void)sensorModuleDidSubscribeForDeviceMotionUpdatesOfExperience:(NSString *)experienceId withHandler:(void (^)(NSDictionary *event))handlerBlock;
-- (void)sensorModuleDidUnsubscribeForDeviceMotionUpdatesOfExperience:(NSString *)experienceId;
+- (void)sensorModuleDidSubscribeForDeviceMotionUpdatesOfExperience:(NSString *)scopeKey withHandler:(void (^)(NSDictionary *event))handlerBlock;
+- (void)sensorModuleDidUnsubscribeForDeviceMotionUpdatesOfExperience:(NSString *)scopeKey;
 - (void)setDeviceMotionUpdateInterval:(NSTimeInterval)intervalMs;
 
-- (void)sensorModuleDidSubscribeForGyroscopeUpdatesOfExperience:(NSString *)experienceId withHandler:(void (^)(NSDictionary *event))handlerBlock;
-- (void)sensorModuleDidUnsubscribeForGyroscopeUpdatesOfExperience:(NSString *)experienceId;
+- (void)sensorModuleDidSubscribeForGyroscopeUpdatesOfExperience:(NSString *)scopeKey withHandler:(void (^)(NSDictionary *event))handlerBlock;
+- (void)sensorModuleDidUnsubscribeForGyroscopeUpdatesOfExperience:(NSString *)scopeKey;
 - (void)setGyroscopeUpdateInterval:(NSTimeInterval)intervalMs;
 
-- (void)sensorModuleDidSubscribeForMagnetometerUpdatesOfExperience:(NSString *)experienceId withHandler:(void (^)(NSDictionary *event))handlerBlock;
-- (void)sensorModuleDidUnsubscribeForMagnetometerUpdatesOfExperience:(NSString *)experienceId;
+- (void)sensorModuleDidSubscribeForMagnetometerUpdatesOfExperience:(NSString *)scopeKey withHandler:(void (^)(NSDictionary *event))handlerBlock;
+- (void)sensorModuleDidUnsubscribeForMagnetometerUpdatesOfExperience:(NSString *)scopeKey;
 - (void)setMagnetometerUpdateInterval:(NSTimeInterval)intervalMs;
 
-- (void)sensorModuleDidSubscribeForMagnetometerUncalibratedUpdatesOfExperience:(NSString *)experienceId
+- (void)sensorModuleDidSubscribeForMagnetometerUncalibratedUpdatesOfExperience:(NSString *)scopeKey
                                                        withHandler:(void (^)(NSDictionary *event))handlerBlock;
-- (void)sensorModuleDidUnsubscribeForMagnetometerUncalibratedUpdatesOfExperience:(NSString *)experienceId;
+- (void)sensorModuleDidUnsubscribeForMagnetometerUncalibratedUpdatesOfExperience:(NSString *)scopeKey;
 - (void)setMagnetometerUncalibratedUpdateInterval:(NSTimeInterval)intervalMs;
 
-- (void)sensorModuleDidSubscribeForBarometerUpdatesOfExperience:(NSString *)experienceId withHandler:(void (^)(NSDictionary *event))handlerBlock;
-- (void)sensorModuleDidUnsubscribeForBarometerUpdatesOfExperience:(NSString *)experienceId;
+- (void)sensorModuleDidSubscribeForBarometerUpdatesOfExperience:(NSString *)scopeKey withHandler:(void (^)(NSDictionary *event))handlerBlock;
+- (void)sensorModuleDidUnsubscribeForBarometerUpdatesOfExperience:(NSString *)scopeKey;
 - (void)setBarometerUpdateInterval:(NSTimeInterval)intervalMs;
 
 - (BOOL)isBarometerAvailable;
@@ -48,7 +48,7 @@
 
 @interface ABI40_0_0EXSensorsManagerBinding : NSObject <ABI40_0_0UMInternalModule, ABI40_0_0UMAccelerometerInterface, ABI40_0_0UMBarometerInterface, ABI40_0_0UMDeviceMotionInterface, ABI40_0_0UMGyroscopeInterface, ABI40_0_0UMMagnetometerInterface, ABI40_0_0UMMagnetometerUncalibratedInterface>
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId andKernelService:(id<ABI40_0_0EXSensorsManagerBindingDelegate>)kernelService;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey andKernelService:(id<ABI40_0_0EXSensorsManagerBindingDelegate>)kernelService;
 
 - (void)sensorModuleDidSubscribeForAccelerometerUpdates:(id)scopedSensorModule withHandler:(void (^)(NSDictionary *))handlerBlock;
 - (void)sensorModuleDidSubscribeForDeviceMotionUpdates:(id)scopedSensorModule withHandler:(void (^)(NSDictionary *))handlerBlock;

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/ABI40_0_0EXSensorsManagerBinding.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/ABI40_0_0EXSensorsManagerBinding.m
@@ -4,68 +4,68 @@
 
 @interface ABI40_0_0EXSensorsManagerBinding ()
 
-@property (nonatomic, strong) NSString *experienceId;
+@property (nonatomic, strong) NSString *scopeKey;
 @property (nonatomic, weak) id<ABI40_0_0EXSensorsManagerBindingDelegate> kernelService;
 
 @end
 
 @implementation ABI40_0_0EXSensorsManagerBinding
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId andKernelService:(id<ABI40_0_0EXSensorsManagerBindingDelegate>)kernelService
+- (instancetype)initWithScopeKey:(NSString *)scopeKey andKernelService:(id<ABI40_0_0EXSensorsManagerBindingDelegate>)kernelService
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _scopeKey = scopeKey;
     _kernelService = kernelService;
   }
   return self;
 }
 
 - (void)sensorModuleDidSubscribeForAccelerometerUpdates:(id)scopedSensorModule withHandler:(void (^)(NSDictionary *))handlerBlock {
-  [_kernelService sensorModuleDidSubscribeForAccelerometerUpdatesOfExperience:_experienceId withHandler:handlerBlock];
+  [_kernelService sensorModuleDidSubscribeForAccelerometerUpdatesOfExperience:_scopeKey withHandler:handlerBlock];
 }
 
 - (void)sensorModuleDidSubscribeForDeviceMotionUpdates:(id)scopedSensorModule withHandler:(void (^)(NSDictionary *))handlerBlock {
-  [_kernelService sensorModuleDidSubscribeForDeviceMotionUpdatesOfExperience:_experienceId withHandler:handlerBlock];
+  [_kernelService sensorModuleDidSubscribeForDeviceMotionUpdatesOfExperience:_scopeKey withHandler:handlerBlock];
 }
 
 - (void)sensorModuleDidSubscribeForGyroscopeUpdates:(id)scopedSensorModule withHandler:(void (^)(NSDictionary *))handlerBlock {
-  [_kernelService sensorModuleDidSubscribeForGyroscopeUpdatesOfExperience:_experienceId withHandler:handlerBlock];
+  [_kernelService sensorModuleDidSubscribeForGyroscopeUpdatesOfExperience:_scopeKey withHandler:handlerBlock];
 }
 
 - (void)sensorModuleDidSubscribeForMagnetometerUncalibratedUpdates:(id)scopedSensorModule withHandler:(void (^)(NSDictionary *))handlerBlock {
-  [_kernelService sensorModuleDidSubscribeForMagnetometerUncalibratedUpdatesOfExperience:_experienceId withHandler:handlerBlock];
+  [_kernelService sensorModuleDidSubscribeForMagnetometerUncalibratedUpdatesOfExperience:_scopeKey withHandler:handlerBlock];
 }
 
 - (void)sensorModuleDidSubscribeForMagnetometerUpdates:(id)scopedSensorModule withHandler:(void (^)(NSDictionary *))handlerBlock {
-  [_kernelService sensorModuleDidSubscribeForMagnetometerUpdatesOfExperience:_experienceId withHandler:handlerBlock];
+  [_kernelService sensorModuleDidSubscribeForMagnetometerUpdatesOfExperience:_scopeKey withHandler:handlerBlock];
 }
 
 - (void)sensorModuleDidSubscribeForBarometerUpdates:(id)scopedSensorModule withHandler:(void (^)(NSDictionary *))handlerBlock {
-  [_kernelService sensorModuleDidSubscribeForBarometerUpdatesOfExperience:_experienceId withHandler:handlerBlock];
+  [_kernelService sensorModuleDidSubscribeForBarometerUpdatesOfExperience:_scopeKey withHandler:handlerBlock];
 }
 
 - (void)sensorModuleDidUnsubscribeForAccelerometerUpdates:(id)scopedSensorModule {
-  [_kernelService sensorModuleDidUnsubscribeForAccelerometerUpdatesOfExperience:_experienceId];
+  [_kernelService sensorModuleDidUnsubscribeForAccelerometerUpdatesOfExperience:_scopeKey];
 }
 
 - (void)sensorModuleDidUnsubscribeForDeviceMotionUpdates:(id)scopedSensorModule {
-  [_kernelService sensorModuleDidUnsubscribeForDeviceMotionUpdatesOfExperience:_experienceId];
+  [_kernelService sensorModuleDidUnsubscribeForDeviceMotionUpdatesOfExperience:_scopeKey];
 }
 
 - (void)sensorModuleDidUnsubscribeForGyroscopeUpdates:(id)scopedSensorModule {
-  [_kernelService sensorModuleDidUnsubscribeForGyroscopeUpdatesOfExperience:_experienceId];
+  [_kernelService sensorModuleDidUnsubscribeForGyroscopeUpdatesOfExperience:_scopeKey];
 }
 
 - (void)sensorModuleDidUnsubscribeForMagnetometerUncalibratedUpdates:(id)scopedSensorModule {
-  [_kernelService sensorModuleDidUnsubscribeForMagnetometerUncalibratedUpdatesOfExperience:_experienceId];
+  [_kernelService sensorModuleDidUnsubscribeForMagnetometerUncalibratedUpdatesOfExperience:_scopeKey];
 }
 
 - (void)sensorModuleDidUnsubscribeForMagnetometerUpdates:(id)scopedSensorModule {
-  [_kernelService sensorModuleDidUnsubscribeForMagnetometerUpdatesOfExperience:_experienceId];
+  [_kernelService sensorModuleDidUnsubscribeForMagnetometerUpdatesOfExperience:_scopeKey];
 }
 
 - (void)sensorModuleDidUnsubscribeForBarometerUpdates:(id)scopedSensorModule {
-  [_kernelService sensorModuleDidUnsubscribeForBarometerUpdatesOfExperience:_experienceId];
+  [_kernelService sensorModuleDidUnsubscribeForBarometerUpdatesOfExperience:_scopeKey];
 }
 
 - (void)setAccelerometerUpdateInterval:(NSTimeInterval)intervalMs {

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/ABI40_0_0EXUpdatesBinding.h
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/ABI40_0_0EXUpdatesBinding.h
@@ -13,14 +13,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol ABI40_0_0EXUpdatesBindingDelegate
 
-- (ABI40_0_0EXUpdatesConfig *)configForExperienceId:(NSString *)experienceId;
-- (ABI40_0_0EXUpdatesSelectionPolicy *)selectionPolicyForExperienceId:(NSString *)experienceId;
-- (nullable ABI40_0_0EXUpdatesUpdate *)launchedUpdateForExperienceId:(NSString *)experienceId;
-- (nullable NSDictionary *)assetFilesMapForExperienceId:(NSString *)experienceId;
-- (BOOL)isUsingEmbeddedAssetsForExperienceId:(NSString *)experienceId;
-- (BOOL)isStartedForExperienceId:(NSString *)experienceId;
-- (BOOL)isEmergencyLaunchForExperienceId:(NSString *)experienceId;
-- (void)requestRelaunchForExperienceId:(NSString *)experienceId withCompletion:(ABI40_0_0EXUpdatesAppRelaunchCompletionBlock)completion;
+- (ABI40_0_0EXUpdatesConfig *)configForScopeKey:(NSString *)scopeKey;
+- (ABI40_0_0EXUpdatesSelectionPolicy *)selectionPolicyForScopeKey:(NSString *)scopeKey;
+- (nullable ABI40_0_0EXUpdatesUpdate *)launchedUpdateForScopeKey:(NSString *)scopeKey;
+- (nullable NSDictionary *)assetFilesMapForScopeKey:(NSString *)scopeKey;
+- (BOOL)isUsingEmbeddedAssetsForScopeKey:(NSString *)scopeKey;
+- (BOOL)isStartedForScopeKey:(NSString *)scopeKey;
+- (BOOL)isEmergencyLaunchForScopeKey:(NSString *)scopeKey;
+- (void)requestRelaunchForScopeKey:(NSString *)scopeKey withCompletion:(ABI40_0_0EXUpdatesAppRelaunchCompletionBlock)completion;
 
 @end
 
@@ -33,7 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ABI40_0_0EXUpdatesBinding : ABI40_0_0EXUpdatesService <ABI40_0_0UMInternalModule>
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId updatesKernelService:(id<ABI40_0_0EXUpdatesBindingDelegate>)updatesKernelService databaseKernelService:(id<ABI40_0_0EXUpdatesDatabaseBindingDelegate>)databaseKernelService;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey updatesKernelService:(id<ABI40_0_0EXUpdatesBindingDelegate>)updatesKernelService databaseKernelService:(id<ABI40_0_0EXUpdatesDatabaseBindingDelegate>)databaseKernelService;
 
 @end
 

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/ABI40_0_0EXUpdatesBinding.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/ABI40_0_0EXUpdatesBinding.m
@@ -8,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ABI40_0_0EXUpdatesBinding ()
 
-@property (nonatomic, strong) NSString *experienceId;
+@property (nonatomic, strong) NSString *scopeKey;
 @property (nonatomic, weak) id<ABI40_0_0EXUpdatesBindingDelegate> updatesKernelService;
 @property (nonatomic, weak) id<ABI40_0_0EXUpdatesDatabaseBindingDelegate> databaseKernelService;
 
@@ -16,10 +16,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation ABI40_0_0EXUpdatesBinding : ABI40_0_0EXUpdatesService
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId updatesKernelService:(id<ABI40_0_0EXUpdatesBindingDelegate>)updatesKernelService databaseKernelService:(id<ABI40_0_0EXUpdatesDatabaseBindingDelegate>)databaseKernelService
+- (instancetype)initWithScopeKey:(NSString *)scopeKey updatesKernelService:(id<ABI40_0_0EXUpdatesBindingDelegate>)updatesKernelService databaseKernelService:(id<ABI40_0_0EXUpdatesDatabaseBindingDelegate>)databaseKernelService
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _scopeKey = scopeKey;
     _updatesKernelService = updatesKernelService;
     _databaseKernelService = databaseKernelService;
   }
@@ -28,7 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (ABI40_0_0EXUpdatesConfig *)config
 {
-  return [_updatesKernelService configForExperienceId:_experienceId];
+  return [_updatesKernelService configForScopeKey:_scopeKey];
 }
 
 - (ABI40_0_0EXUpdatesDatabase *)database
@@ -38,7 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (ABI40_0_0EXUpdatesSelectionPolicy *)selectionPolicy
 {
-  return [_updatesKernelService selectionPolicyForExperienceId:_experienceId];
+  return [_updatesKernelService selectionPolicyForScopeKey:_scopeKey];
 }
 
 - (NSURL *)directory
@@ -48,27 +48,27 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (nullable ABI40_0_0EXUpdatesUpdate *)launchedUpdate
 {
-  return [_updatesKernelService launchedUpdateForExperienceId:_experienceId];
+  return [_updatesKernelService launchedUpdateForScopeKey:_scopeKey];
 }
 
 - (nullable NSDictionary *)assetFilesMap
 {
-  return [_updatesKernelService assetFilesMapForExperienceId:_experienceId];
+  return [_updatesKernelService assetFilesMapForScopeKey:_scopeKey];
 }
 
 - (BOOL)isUsingEmbeddedAssets
 {
-  return [_updatesKernelService isUsingEmbeddedAssetsForExperienceId:_experienceId];
+  return [_updatesKernelService isUsingEmbeddedAssetsForScopeKey:_scopeKey];
 }
 
 - (BOOL)isStarted
 {
-  return [_updatesKernelService isStartedForExperienceId:_experienceId];
+  return [_updatesKernelService isStartedForScopeKey:_scopeKey];
 }
 
 - (BOOL)isEmergencyLaunch
 {
-  return [_updatesKernelService isEmergencyLaunchForExperienceId:_experienceId];
+  return [_updatesKernelService isEmergencyLaunchForScopeKey:_scopeKey];
 }
 
 - (BOOL)canRelaunch
@@ -78,7 +78,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)requestRelaunchWithCompletion:(ABI40_0_0EXUpdatesAppRelaunchCompletionBlock)completion
 {
-  return [_updatesKernelService requestRelaunchForExperienceId:_experienceId withCompletion:completion];
+  return [_updatesKernelService requestRelaunchForScopeKey:_scopeKey withCompletion:completion];
 }
 
 - (void)resetSelectionPolicy

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/EXFacebook/ABI40_0_0EXScopedFacebook.h
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/EXFacebook/ABI40_0_0EXScopedFacebook.h
@@ -8,7 +8,7 @@
 
 @interface ABI40_0_0EXScopedFacebook : ABI40_0_0EXFacebook <ABI40_0_0UMAppLifecycleListener, ABI40_0_0UMModuleRegistryConsumer>
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId andParams:(NSDictionary *)params;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey andParams:(NSDictionary *)params;
 
 @end
 #endif

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/EXFacebook/ABI40_0_0EXScopedFacebook.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/EXFacebook/ABI40_0_0EXScopedFacebook.m
@@ -44,15 +44,15 @@ static NSString *AUTO_INIT_KEY = @"autoInitEnabled";
 
 @implementation ABI40_0_0EXScopedFacebook : ABI40_0_0EXFacebook
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId andParams:(NSDictionary *)params
+- (instancetype)initWithScopeKey:(NSString *)scopeKey andParams:(NSDictionary *)params
 {
   if (self = [super init]) {
-    NSString *suiteName = [NSString stringWithFormat:@"%@#%@", NSStringFromClass(self.class), experienceId];
+    NSString *suiteName = [NSString stringWithFormat:@"%@#%@", NSStringFromClass(self.class), scopeKey];
     _settings = [[NSUserDefaults alloc] initWithSuiteName:suiteName];
 
     BOOL hasPreviouslySetAutoInitEnabled = [_settings boolForKey:AUTO_INIT_KEY];
     BOOL manifestDefinesAutoInitEnabled = [params[@"manifest"][@"facebookAutoInitEnabled"] boolValue];
-    
+
     NSString *scopedFacebookAppId = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"FacebookAppID"];
     NSString *manifestFacebookAppId = params[@"manifest"][@"facebookAppId"];
 
@@ -84,11 +84,11 @@ static NSString *AUTO_INIT_KEY = @"autoInitEnabled";
   }
 
   NSString *scopedFacebookAppId = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"FacebookAppID"];
-  
+
   NSMutableDictionary *nativeOptions = [NSMutableDictionary dictionaryWithDictionary:options];
   // Overwrite the incoming app id with the Expo Facebook SDK app id.
   nativeOptions[@"appId"] = scopedFacebookAppId;
-  
+
   [super initializeAsync:nativeOptions resolver:resolve rejecter:reject];
 }
 

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI40_0_0EXScopedNotificationBuilder.h
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI40_0_0EXScopedNotificationBuilder.h
@@ -8,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ABI40_0_0EXScopedNotificationBuilder : ABI40_0_0EXNotificationBuilder
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey;
 
 @end
 

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI40_0_0EXScopedNotificationBuilder.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI40_0_0EXScopedNotificationBuilder.m
@@ -4,18 +4,18 @@
 
 @interface ABI40_0_0EXScopedNotificationBuilder ()
 
-@property (nonatomic, strong) NSString *experienceId;
+@property (nonatomic, strong) NSString *scopeKey;
 
 @end
 
 @implementation ABI40_0_0EXScopedNotificationBuilder
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
+- (instancetype)initWithScopeKey:(NSString *)scopeKey
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _scopeKey = scopeKey;
   }
-  
+
   return self;
 }
 
@@ -26,14 +26,15 @@
   if (!userInfo) {
     userInfo = [NSMutableDictionary dictionary];
   }
-  userInfo[@"experienceId"] = _experienceId;
+  userInfo[@"experienceId"] = _scopeKey;
+  userInfo[@"scopeKey"] = _scopeKey;
   [content setUserInfo:userInfo];
-  
+
   if (content.categoryIdentifier) {
-    NSString *categoryIdentifier = [NSString stringWithFormat:@"%@-%@", _experienceId, content.categoryIdentifier];
+    NSString *categoryIdentifier = [NSString stringWithFormat:@"%@-%@", _scopeKey, content.categoryIdentifier];
     [content setCategoryIdentifier:categoryIdentifier];
   }
-  
+
   return content;
 }
 

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI40_0_0EXScopedNotificationCategoriesModule.h
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI40_0_0EXScopedNotificationCategoriesModule.h
@@ -8,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ABI40_0_0EXScopedNotificationCategoriesModule : ABI40_0_0EXNotificationCategoriesModule
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey;
 
 @end
 

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI40_0_0EXScopedNotificationCategoriesModule.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI40_0_0EXScopedNotificationCategoriesModule.m
@@ -4,16 +4,16 @@
 
 @interface ABI40_0_0EXScopedNotificationCategoriesModule ()
 
-@property (nonatomic, strong) NSString *experienceId;
+@property (nonatomic, strong) NSString *scopeKey;
 
 @end
 
 @implementation ABI40_0_0EXScopedNotificationCategoriesModule
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
+- (instancetype)initWithScopeKey:(NSString *)scopeKey
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _scopeKey = scopeKey;
   }
   return self;
 }
@@ -23,7 +23,7 @@
   [[UNUserNotificationCenter currentNotificationCenter] getNotificationCategoriesWithCompletionHandler:^(NSSet<UNNotificationCategory *> *categories) {
     NSMutableArray* existingCategories = [NSMutableArray new];
     for (UNNotificationCategory *category in categories) {
-      if ([category.identifier hasPrefix:self->_experienceId]) {
+      if ([category.identifier hasPrefix:self->_scopeKey]) {
         [existingCategories addObject:[self serializeCategory:category]];
       }
     }
@@ -34,25 +34,25 @@
 - (void)setNotificationCategoryWithCategoryId:(NSString *)categoryId
                                       actions:(NSArray *)actions
                                       options:(NSDictionary *)options
-                                      resolve:(ABI40_0_0UMPromiseResolveBlock)resolve 
+                                      resolve:(ABI40_0_0UMPromiseResolveBlock)resolve
                                        reject:(ABI40_0_0UMPromiseRejectBlock)reject
 {
-  NSString *scopedCategoryIdentifier = [NSString stringWithFormat:@"%@-%@", _experienceId, categoryId];
+  NSString *scopedCategoryIdentifier = [NSString stringWithFormat:@"%@-%@", _scopeKey, categoryId];
   [super setNotificationCategoryWithCategoryId:scopedCategoryIdentifier actions:actions options:options resolve:resolve reject:reject];
 }
 
 - (void)deleteNotificationCategoryWithCategoryId:(NSString *)categoryId
-                                         resolve:(ABI40_0_0UMPromiseResolveBlock)resolve 
+                                         resolve:(ABI40_0_0UMPromiseResolveBlock)resolve
                                           reject:(ABI40_0_0UMPromiseRejectBlock)reject
 {
-  NSString *scopedCategoryIdentifier = [NSString stringWithFormat:@"%@-%@", _experienceId, categoryId];
+  NSString *scopedCategoryIdentifier = [NSString stringWithFormat:@"%@-%@", _scopeKey, categoryId];
   [super deleteNotificationCategoryWithCategoryId:scopedCategoryIdentifier resolve:resolve reject:reject];
 }
 
 - (NSMutableDictionary *)serializeCategory:(UNNotificationCategory *)category
 {
   NSMutableDictionary* serializedCategory = [NSMutableDictionary dictionary];
-  NSString* experienceIdPrefix = [NSString stringWithFormat:@"%@-", _experienceId];
+  NSString* experienceIdPrefix = [NSString stringWithFormat:@"%@-", _scopeKey];
   serializedCategory[@"identifier"] = [category.identifier stringByReplacingOccurrencesOfString:experienceIdPrefix withString:@""];
   serializedCategory[@"actions"] = [super serializeActions: category.actions];
   serializedCategory[@"options"] = [super serializeCategoryOptions: category];

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI40_0_0EXScopedNotificationPresentationModule.h
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI40_0_0EXScopedNotificationPresentationModule.h
@@ -8,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ABI40_0_0EXScopedNotificationPresentationModule : ABI40_0_0EXNotificationPresentationModule
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey;
 
 @end
 

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI40_0_0EXScopedNotificationPresentationModule.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI40_0_0EXScopedNotificationPresentationModule.m
@@ -6,18 +6,18 @@
 
 @interface ABI40_0_0EXScopedNotificationPresentationModule ()
 
-@property (nonatomic, strong) NSString *experienceId;
+@property (nonatomic, strong) NSString *scopeKey;
 
 @end
 
 @implementation ABI40_0_0EXScopedNotificationPresentationModule
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
+- (instancetype)initWithScopeKey:(NSString *)scopeKey
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _scopeKey = scopeKey;
   }
-  
+
   return self;
 }
 
@@ -25,7 +25,7 @@
 {
   NSMutableArray *serializedNotifications = [NSMutableArray new];
   for (UNNotification *notification in notifications) {
-    if ([ABI40_0_0EXScopedNotificationsUtils shouldNotification:notification beHandledByExperience:_experienceId]) {
+    if ([ABI40_0_0EXScopedNotificationsUtils shouldNotification:notification beHandledByExperience:_scopeKey]) {
       [serializedNotifications addObject:[ABI40_0_0EXScopedNotificationSerializer serializedNotification:notification]];
     }
   }
@@ -34,11 +34,11 @@
 
 - (void)dismissNotificationWithIdentifier:(NSString *)identifier resolve:(ABI40_0_0UMPromiseResolveBlock)resolve reject:(ABI40_0_0UMPromiseRejectBlock)reject
 {
-  __block NSString *experienceId = _experienceId;
+  __block NSString *scopeKey = _scopeKey;
   [[UNUserNotificationCenter currentNotificationCenter] getDeliveredNotificationsWithCompletionHandler:^(NSArray<UNNotification *> * _Nonnull notifications) {
     for (UNNotification *notification in notifications) {
       if ([notification.request.identifier isEqual:identifier]) {
-        if ([ABI40_0_0EXScopedNotificationsUtils shouldNotification:notification beHandledByExperience:experienceId]) {
+        if ([ABI40_0_0EXScopedNotificationsUtils shouldNotification:notification beHandledByExperience:scopeKey]) {
           [[UNUserNotificationCenter currentNotificationCenter] removeDeliveredNotificationsWithIdentifiers:@[identifier]];
         }
         break;
@@ -50,11 +50,11 @@
 
 - (void)dismissAllNotificationsWithResolver:(ABI40_0_0UMPromiseResolveBlock)resolve reject:(ABI40_0_0UMPromiseRejectBlock)reject
 {
-  __block NSString *experienceId = _experienceId;
+  __block NSString *scopeKey = _scopeKey;
   [[UNUserNotificationCenter currentNotificationCenter] getDeliveredNotificationsWithCompletionHandler:^(NSArray<UNNotification *> * _Nonnull notifications) {
     NSMutableArray<NSString *> *toDismiss = [NSMutableArray new];
     for (UNNotification *notification in notifications) {
-      if ([ABI40_0_0EXScopedNotificationsUtils shouldNotification:notification beHandledByExperience:experienceId]) {
+      if ([ABI40_0_0EXScopedNotificationsUtils shouldNotification:notification beHandledByExperience:scopeKey]) {
         [toDismiss addObject:notification.request.identifier];
       }
     }

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI40_0_0EXScopedNotificationSchedulerModule.h
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI40_0_0EXScopedNotificationSchedulerModule.h
@@ -8,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ABI40_0_0EXScopedNotificationSchedulerModule : ABI40_0_0EXNotificationSchedulerModule
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey;
 
 @end
 

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI40_0_0EXScopedNotificationSchedulerModule.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI40_0_0EXScopedNotificationSchedulerModule.m
@@ -6,7 +6,7 @@
 
 @interface ABI40_0_0EXScopedNotificationSchedulerModule ()
 
-@property (nonatomic, strong) NSString *experienceId;
+@property (nonatomic, strong) NSString *scopeKey;
 
 @end
 
@@ -14,10 +14,10 @@
 // See https://github.com/expo/expo/pull/8361#discussion_r429153429.
 @implementation ABI40_0_0EXScopedNotificationSchedulerModule
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
+- (instancetype)initWithScopeKey:(NSString *)scopeKey
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _scopeKey = scopeKey;
   }
 
   return self;
@@ -27,7 +27,7 @@
 {
   NSMutableArray *serializedRequests = [NSMutableArray new];
   for (UNNotificationRequest *request in requests) {
-    if ([ABI40_0_0EXScopedNotificationsUtils shouldNotificationRequest:request beHandledByExperience:_experienceId]) {
+    if ([ABI40_0_0EXScopedNotificationsUtils shouldNotificationRequest:request beHandledByExperience:_scopeKey]) {
       [serializedRequests addObject:[ABI40_0_0EXScopedNotificationSerializer serializedNotificationRequest:request]];
     }
   }
@@ -36,11 +36,11 @@
 
 - (void)cancelNotification:(NSString *)identifier resolve:(ABI40_0_0UMPromiseResolveBlock)resolve rejecting:(ABI40_0_0UMPromiseRejectBlock)reject
 {
-  __block NSString *experienceId = _experienceId;
+  __block NSString *scopeKey = _scopeKey;
   [[UNUserNotificationCenter currentNotificationCenter] getPendingNotificationRequestsWithCompletionHandler:^(NSArray<UNNotificationRequest *> * _Nonnull requests) {
     for (UNNotificationRequest *request in requests) {
       if ([request.identifier isEqual:identifier]) {
-        if ([ABI40_0_0EXScopedNotificationsUtils shouldNotificationRequest:request beHandledByExperience:experienceId]) {
+        if ([ABI40_0_0EXScopedNotificationsUtils shouldNotificationRequest:request beHandledByExperience:scopeKey]) {
           [[UNUserNotificationCenter currentNotificationCenter] removePendingNotificationRequestsWithIdentifiers:@[identifier]];
         }
         break;
@@ -52,11 +52,11 @@
 
 - (void)cancelAllNotificationsWithResolver:(ABI40_0_0UMPromiseResolveBlock)resolve rejecting:(ABI40_0_0UMPromiseRejectBlock)reject
 {
-  __block NSString *experienceId = _experienceId;
+  __block NSString *scopeKey = _scopeKey;
   [[UNUserNotificationCenter currentNotificationCenter] getPendingNotificationRequestsWithCompletionHandler:^(NSArray<UNNotificationRequest *> * _Nonnull requests) {
     NSMutableArray<NSString *> *toRemove = [NSMutableArray new];
     for (UNNotificationRequest *request in requests) {
-      if ([ABI40_0_0EXScopedNotificationsUtils shouldNotificationRequest:request beHandledByExperience:experienceId]) {
+      if ([ABI40_0_0EXScopedNotificationsUtils shouldNotificationRequest:request beHandledByExperience:scopeKey]) {
         [toRemove addObject:request.identifier];
       }
     }

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI40_0_0EXScopedNotificationsEmitter.h
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI40_0_0EXScopedNotificationsEmitter.h
@@ -8,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ABI40_0_0EXScopedNotificationsEmitter : ABI40_0_0EXNotificationsEmitter
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey;
 
 @end
 

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI40_0_0EXScopedNotificationsEmitter.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI40_0_0EXScopedNotificationsEmitter.m
@@ -8,7 +8,7 @@
 
 @interface ABI40_0_0EXScopedNotificationsEmitter ()
 
-@property (nonatomic, strong) NSString *experienceId;
+@property (nonatomic, strong) NSString *scopeKey;
 
 @end
 
@@ -21,18 +21,18 @@
 
 @implementation ABI40_0_0EXScopedNotificationsEmitter
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
+- (instancetype)initWithScopeKey:(NSString *)scopeKey
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _scopeKey = scopeKey;
   }
-  
+
   return self;
 }
 
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center didReceiveNotificationResponse:(UNNotificationResponse *)response withCompletionHandler:(void (^)(void))completionHandler
 {
-  if ([ABI40_0_0EXScopedNotificationsUtils shouldNotification:response.notification beHandledByExperience:_experienceId]) {
+  if ([ABI40_0_0EXScopedNotificationsUtils shouldNotification:response.notification beHandledByExperience:_scopeKey]) {
     [super userNotificationCenter:center didReceiveNotificationResponse:response withCompletionHandler:completionHandler];
   } else {
     completionHandler();
@@ -41,7 +41,7 @@
 
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center willPresentNotification:(UNNotification *)notification withCompletionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler
 {
-  if ([ABI40_0_0EXScopedNotificationsUtils shouldNotification:notification beHandledByExperience:_experienceId]) {
+  if ([ABI40_0_0EXScopedNotificationsUtils shouldNotification:notification beHandledByExperience:_scopeKey]) {
     [super userNotificationCenter:center willPresentNotification:notification withCompletionHandler:completionHandler];
   } else {
     completionHandler(UNNotificationPresentationOptionNone);

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI40_0_0EXScopedNotificationsHandlerModule.h
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI40_0_0EXScopedNotificationsHandlerModule.h
@@ -8,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ABI40_0_0EXScopedNotificationsHandlerModule : ABI40_0_0EXNotificationsHandlerModule
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey;
 
 @end
 

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI40_0_0EXScopedNotificationsHandlerModule.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI40_0_0EXScopedNotificationsHandlerModule.m
@@ -5,24 +5,24 @@
 
 @interface ABI40_0_0EXScopedNotificationsHandlerModule ()
 
-@property (nonatomic, strong) NSString *experienceId;
+@property (nonatomic, strong) NSString *scopeKey;
 
 @end
 
 @implementation ABI40_0_0EXScopedNotificationsHandlerModule
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
+- (instancetype)initWithScopeKey:(NSString *)scopeKey
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _scopeKey = scopeKey;
   }
-  
+
   return self;
 }
 
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center willPresentNotification:(UNNotification *)notification withCompletionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler
 {
-  if ([ABI40_0_0EXScopedNotificationsUtils shouldNotification:notification beHandledByExperience:_experienceId]) {
+  if ([ABI40_0_0EXScopedNotificationsUtils shouldNotification:notification beHandledByExperience:_scopeKey]) {
     [super userNotificationCenter:center willPresentNotification:notification withCompletionHandler:completionHandler];
   }
 }

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI40_0_0EXScopedNotificationsUtils.h
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI40_0_0EXScopedNotificationsUtils.h
@@ -6,9 +6,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ABI40_0_0EXScopedNotificationsUtils : NSObject
 
-+ (BOOL)shouldNotificationRequest:(UNNotificationRequest *)request beHandledByExperience:(NSString *)experienceId;
++ (BOOL)shouldNotificationRequest:(UNNotificationRequest *)request beHandledByExperience:(NSString *)scopeKey;
 
-+ (BOOL)shouldNotification:(UNNotification *)notification beHandledByExperience:(NSString *)experienceId;
++ (BOOL)shouldNotification:(UNNotification *)notification beHandledByExperience:(NSString *)scopeKey;
 
 @end
 

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI40_0_0EXScopedNotificationsUtils.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI40_0_0EXScopedNotificationsUtils.m
@@ -4,18 +4,18 @@
 
 @implementation ABI40_0_0EXScopedNotificationsUtils
 
-+ (BOOL)shouldNotificationRequest:(UNNotificationRequest *)request beHandledByExperience:(NSString *)experienceId
++ (BOOL)shouldNotificationRequest:(UNNotificationRequest *)request beHandledByExperience:(NSString *)scopeKey
 {
-  NSString *notificationExperienceId = request.content.userInfo[@"experienceId"];
-  if (!notificationExperienceId) {
+  NSString *notificationScopeKey = request.content.userInfo[@"experienceId"];
+  if (!notificationScopeKey) {
     return true;
   }
-  return [notificationExperienceId isEqual:experienceId];
+  return [notificationScopeKey isEqual:scopeKey];
 }
 
-+ (BOOL)shouldNotification:(UNNotification *)notification beHandledByExperience:(NSString *)experienceId
++ (BOOL)shouldNotification:(UNNotification *)notification beHandledByExperience:(NSString *)scopeKey
 {
-  return [ABI40_0_0EXScopedNotificationsUtils shouldNotificationRequest:notification.request beHandledByExperience:experienceId];
+  return [ABI40_0_0EXScopedNotificationsUtils shouldNotificationRequest:notification.request beHandledByExperience:scopeKey];
 }
 
 @end

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI40_0_0EXScopedServerRegistrationModule.h
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI40_0_0EXScopedServerRegistrationModule.h
@@ -8,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ABI40_0_0EXScopedServerRegistrationModule : ABI40_0_0EXServerRegistrationModule
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey;
 
 @end
 

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI40_0_0EXScopedServerRegistrationModule.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI40_0_0EXScopedServerRegistrationModule.m
@@ -16,23 +16,23 @@ static NSString * const kEXRegistrationInfoKey = @"EXNotificationRegistrationInf
 
 @interface ABI40_0_0EXScopedServerRegistrationModule ()
 
-@property (nonatomic, strong) NSString *experienceId;
+@property (nonatomic, strong) NSString *scopeKey;
 
 @end
 
 @implementation ABI40_0_0EXScopedServerRegistrationModule
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
+- (instancetype)initWithScopeKey:(NSString *)scopeKey
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _scopeKey = scopeKey;
   }
   return self;
 }
 
 - (NSDictionary *)registrationSearchQueryMerging:(NSDictionary *)dictionaryToMerge
 {
-  NSString *scopedKey = [kEXRegistrationInfoKey stringByAppendingFormat:@"-%@", _experienceId];
+  NSString *scopedKey = [kEXRegistrationInfoKey stringByAppendingFormat:@"-%@", _scopeKey];
   return [self keychainSearchQueryFor:scopedKey merging:dictionaryToMerge];
 }
 

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/Permissions/ABI40_0_0EXScopedPermissions.h
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/Permissions/ABI40_0_0EXScopedPermissions.h
@@ -9,14 +9,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol ABI40_0_0EXPermissionsScopedModuleDelegate
 
-- (ABI40_0_0UMPermissionStatus)getPermission:(NSString *)permissionType forExperience:(NSString *)experienceId;
-- (BOOL)savePermission:(NSDictionary *)permission ofType:(NSString *)type forExperience:(NSString *)experienceId;
+- (ABI40_0_0UMPermissionStatus)getPermission:(NSString *)permissionType forExperience:(NSString *)scopeKey;
+- (BOOL)savePermission:(NSDictionary *)permission ofType:(NSString *)type forExperience:(NSString *)scopeKey;
 
 @end
 
 @interface ABI40_0_0EXScopedPermissions : ABI40_0_0EXPermissions
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId andConstantsBinding:(ABI40_0_0EXConstantsBinding *)constantsBinding;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey andConstantsBinding:(ABI40_0_0EXConstantsBinding *)constantsBinding;
 
 @end
 

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/Permissions/ABI40_0_0EXScopedPermissions.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/Permissions/ABI40_0_0EXScopedPermissions.m
@@ -7,7 +7,7 @@
 
 @interface ABI40_0_0EXScopedPermissions ()
 
-@property (nonatomic, strong) NSString *experienceId;
+@property (nonatomic, strong) NSString *scopeKey;
 @property (nonatomic, weak) id<ABI40_0_0EXPermissionsScopedModuleDelegate> permissionsService;
 @property (nonatomic, weak) id<ABI40_0_0UMUtilitiesInterface> utils;
 @property (nonatomic, weak) ABI40_0_0EXConstantsBinding *constantsBinding;
@@ -16,10 +16,10 @@
 
 @implementation ABI40_0_0EXScopedPermissions
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId andConstantsBinding:(ABI40_0_0EXConstantsBinding *)constantsBinding
+- (instancetype)initWithScopeKey:(NSString *)scopeKey andConstantsBinding:(ABI40_0_0EXConstantsBinding *)constantsBinding
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _scopeKey = scopeKey;
     _constantsBinding = constantsBinding;
   }
   return self;
@@ -45,8 +45,8 @@
   if (!_permissionsService) {
     return [[self class] permissionStringForStatus:ABI40_0_0UMPermissionStatusGranted];
   }
-  
-  return [[self class] permissionStringForStatus:[_permissionsService getPermission:permissionType forExperience:_experienceId]];
+
+  return [[self class] permissionStringForStatus:[_permissionsService getPermission:permissionType forExperience:_scopeKey]];
 }
 
 - (BOOL)hasGrantedScopedPermission:(NSString *)permissionType
@@ -54,8 +54,8 @@
   if (!_permissionsService || ![self shouldVerifyScopedPermission:permissionType]) {
     return YES;
   }
-  
-  return [_permissionsService getPermission:permissionType forExperience:_experienceId] == ABI40_0_0UMPermissionStatusGranted;
+
+  return [_permissionsService getPermission:permissionType forExperience:_scopeKey] == ABI40_0_0UMPermissionStatusGranted;
 }
 
 - (void)askForPermissionUsingRequesterClass:(Class)requesterClass
@@ -72,11 +72,11 @@
       ABI40_0_0UM_ENSURE_STRONGIFY(self)
       // if permission should be scoped save it
       if ([self shouldVerifyScopedPermission:permissionType]) {
-        [self.permissionsService savePermission:permission ofType:permissionType forExperience:self.experienceId];
+        [self.permissionsService savePermission:permission ofType:permissionType forExperience:self.scopeKey];
       }
       resolve(permission);
     };
-    
+
     return [self askForGlobalPermissionUsingRequesterClass:requesterClass withResolver:customOnResults withRejecter:reject];
   } else if ([_constantsBinding.appOwnership isEqualToString:@"expo"] &&
              ![self hasGrantedScopedPermission:permissionType]) {
@@ -86,13 +86,13 @@
       ABI40_0_0UM_ENSURE_STRONGIFY(self);
       NSMutableDictionary *permission = [globalPermissions mutableCopy];
       // try to save scoped permissions - if fails than permission is denied
-      if (![self.permissionsService savePermission:permission ofType:permissionType forExperience:self.experienceId]) {
+      if (![self.permissionsService savePermission:permission ofType:permissionType forExperience:self.scopeKey]) {
         permission[@"status"] = [[self class] permissionStringForStatus:ABI40_0_0UMPermissionStatusDenied];
         permission[@"granted"] = @(NO);
       }
       resolve(permission);
     }];
-    
+
     UIAlertAction *denyAction = [UIAlertAction actionWithTitle:@"Deny" style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
       ABI40_0_0UM_ENSURE_STRONGIFY(self);
       NSMutableDictionary *permission = [globalPermissions mutableCopy];
@@ -100,10 +100,10 @@
       permission[@"granted"] = @(NO);
       resolve([NSDictionary dictionaryWithDictionary:permission]);
     }];
-    
+
     return [self showPermissionRequestAlert:permissionType withAllowAction:allowAction withDenyAction:denyAction];
   }
-  
+
   resolve(globalPermissions); // third group
 }
 
@@ -115,7 +115,7 @@
     return nil;
   }
   NSMutableDictionary *permission = [NSMutableDictionary dictionaryWithDictionary:globalPermission];
-  
+
   if ([_constantsBinding.appOwnership isEqualToString:@"expo"]
       && [self shouldVerifyScopedPermission:permissionType]
       && [ABI40_0_0EXPermissions statusForPermission:permission] == ABI40_0_0UMPermissionStatusGranted) {
@@ -129,7 +129,7 @@
                    withAllowAction:(UIAlertAction *)allow
                     withDenyAction:(UIAlertAction *)deny
 {
-  NSString *experienceName = self.experienceId; // TODO: we might want to use name from the manifest?
+  NSString *experienceName = self.scopeKey; // TODO: we might want to use name from the manifest?
   NSString *messageTemplate = @"%1$@ needs permissions for %2$@. You\'ve already granted permission to another Expo experience. Allow %1$@ to also use it?";
   NSString *permissionString = [[self class] textForPermissionType:permissionType];
 
@@ -155,7 +155,7 @@
   } else if ([type isEqualToString:@"cameraRoll"]) {
     return @"photos";
   }
-  
+
   return type;
 }
 

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXTaskManager/ABI41_0_0EXTaskManager/ABI41_0_0EXTaskManager.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXTaskManager/ABI41_0_0EXTaskManager/ABI41_0_0EXTaskManager.h
@@ -9,6 +9,6 @@
 
 @interface ABI41_0_0EXTaskManager : ABI41_0_0UMExportedModule <ABI41_0_0UMInternalModule, ABI41_0_0UMEventEmitter, ABI41_0_0UMModuleRegistryConsumer, ABI41_0_0UMTaskManagerInterface>
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey NS_DESIGNATED_INITIALIZER;
 
 @end

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXTaskManager/ABI41_0_0EXTaskManager/ABI41_0_0EXTaskManager.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXTaskManager/ABI41_0_0EXTaskManager/ABI41_0_0EXTaskManager.m
@@ -33,14 +33,14 @@ ABI41_0_0UM_EXPORT_MODULE(ExpoTaskManager);
 
 - (instancetype)init
 {
-  return [self initWithExperienceId:@"mainApplication"];
+  return [self initWithScopeKey:@"mainApplication"];
 }
 
 // TODO: Remove when adding bare ABI41_0_0React Native support
-- (instancetype)initWithExperienceId:(NSString *)experienceId
+- (instancetype)initWithScopeKey:(NSString *)scopeKey
 {
   if (self = [super init]) {
-    _appId = experienceId;
+    _appId = scopeKey;
     _eventsQueue = [NSMutableArray new];
   }
   return self;

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/ABI41_0_0EXUpdatesBareUpdate.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/ABI41_0_0EXUpdatesBareUpdate.m
@@ -18,10 +18,10 @@ NS_ASSUME_NONNULL_BEGIN
                                                                   config:config
                                                                 database:database];
 
-  NSString *updateId = manifest.rawID;
+  NSString *updateId = manifest.rawId;
   NSNumber *commitTime = manifest.commitTimeNumber;
   NSArray *assets = manifest.assets;
-  
+
   NSAssert(updateId != nil, @"update ID should not be null");
 
   NSUUID *uuid = [[NSUUID alloc] initWithUUIDString:(NSString *)updateId];

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/ABI41_0_0EXUpdatesNewUpdate.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/ABI41_0_0EXUpdatesNewUpdate.m
@@ -19,32 +19,32 @@ NS_ASSUME_NONNULL_BEGIN
   ABI41_0_0EXUpdatesUpdate *update = [[ABI41_0_0EXUpdatesUpdate alloc] initWithRawManifest:manifest
                                                                   config:config
                                                                 database:database];
-  
-  NSString *updateId = manifest.rawID;
+
+  NSString *updateId = manifest.rawId;
   NSString *commitTime = manifest.createdAt;
   NSString *runtimeVersion = manifest.runtimeVersion;
   NSDictionary *launchAsset = manifest.launchAsset;
   NSArray *assets = manifest.assets;
-  
+
   NSAssert(updateId != nil, @"update ID should not be null");
-  
+
   NSUUID *uuid = [[NSUUID alloc] initWithUUIDString:(NSString *)updateId];
   NSAssert(uuid, @"update ID should be a valid UUID");
-  
+
   id bundleUrlString = (NSDictionary *)launchAsset[@"url"];
   NSAssert([bundleUrlString isKindOfClass:[NSString class]], @"launchAsset.url should be a string");
   NSURL *bundleUrl = [NSURL URLWithString:bundleUrlString];
   NSAssert(bundleUrl, @"launchAsset.url should be a valid URL");
-  
+
   NSMutableArray<ABI41_0_0EXUpdatesAsset *> *processedAssets = [NSMutableArray new];
-  
+
   NSString *bundleKey = launchAsset[@"key"];
   ABI41_0_0EXUpdatesAsset *jsBundleAsset = [[ABI41_0_0EXUpdatesAsset alloc] initWithKey:bundleKey type:ABI41_0_0EXUpdatesEmbeddedBundleFileType];
   jsBundleAsset.url = bundleUrl;
   jsBundleAsset.isLaunchAsset = YES;
   jsBundleAsset.mainBundleFilename = ABI41_0_0EXUpdatesEmbeddedBundleFilename;
   [processedAssets addObject:jsBundleAsset];
-  
+
   if (assets) {
     for (NSDictionary *assetDict in (NSArray *)assets) {
       NSAssert([assetDict isKindOfClass:[NSDictionary class]], @"assets must be objects");
@@ -58,24 +58,24 @@ NS_ASSUME_NONNULL_BEGIN
       NSAssert(type && [type isKindOfClass:[NSString class]], @"asset contentType should be a nonnull string");
       NSURL *url = [NSURL URLWithString:(NSString *)urlString];
       NSAssert(url, @"asset url should be a valid URL");
-      
+
       ABI41_0_0EXUpdatesAsset *asset = [[ABI41_0_0EXUpdatesAsset alloc] initWithKey:key type:(NSString *)type];
       asset.url = url;
-      
+
       if (metadata) {
         NSAssert([metadata isKindOfClass:[NSDictionary class]], @"asset metadata should be an object");
         asset.metadata = (NSDictionary *)metadata;
       }
-      
+
       if (mainBundleFilename) {
         NSAssert([mainBundleFilename isKindOfClass:[NSString class]], @"asset localPath should be a string");
         asset.mainBundleFilename = (NSString *)mainBundleFilename;
       }
-      
+
       [processedAssets addObject:asset];
     }
   }
-  
+
   update.updateId = uuid;
   update.commitTime = [ABI41_0_0RCTConvert NSDate:(NSString *)commitTime];
   update.runtimeVersion = (NSString *)runtimeVersion;
@@ -84,13 +84,13 @@ NS_ASSUME_NONNULL_BEGIN
   update.bundleUrl = bundleUrl;
   update.assets = processedAssets;
   update.manifest = manifest.rawManifestJSON;
-  
+
   if ([response isKindOfClass:[NSHTTPURLResponse class]]) {
     NSDictionary *headersDictionary = ((NSHTTPURLResponse *)response).allHeaderFields;
     update.serverDefinedHeaders = [[self class] dictionaryWithStructuredHeader:headersDictionary[@"expo-server-defined-headers"]];
     update.manifestFilters = [[self class] dictionaryWithStructuredHeader:headersDictionary[@"expo-manifest-filters"]];
   }
-  
+
   return update;
 }
 
@@ -99,7 +99,7 @@ NS_ASSUME_NONNULL_BEGIN
   if (!headerString) {
     return nil;
   }
-  
+
   ABI41_0_0EXStructuredHeadersParser *parser = [[ABI41_0_0EXStructuredHeadersParser alloc] initWithRawInput:headerString fieldType:ABI41_0_0EXStructuredHeadersParserFieldTypeDictionary ignoringParameters:YES];
   NSError *error;
   NSDictionary *parserOutput = [parser parseStructuredFieldsWithError:&error];
@@ -107,7 +107,7 @@ NS_ASSUME_NONNULL_BEGIN
     NSLog(@"Error parsing header value: %@", error ? error.localizedDescription : @"Header was not a structured fields dictionary");
     return nil;
   }
-  
+
   NSMutableDictionary *mutableDict = [NSMutableDictionary dictionaryWithCapacity:parserOutput.count];
   [parserOutput enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
     // ignore any dictionary entries whose type is not string, number, or boolean

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/RawManifest/ABI41_0_0EXUpdatesBareRawManifest.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/RawManifest/ABI41_0_0EXUpdatesBareRawManifest.h
@@ -7,6 +7,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ABI41_0_0EXUpdatesBareRawManifest : ABI41_0_0EXUpdatesBaseLegacyRawManifest<ABI41_0_0EXUpdatesRawManifestBehavior>
 
+/**
+* A UUID for this manifest.
+*/
+- (NSString *)rawId;
 - (NSNumber *)commitTimeNumber;
 - (nullable NSDictionary *)metadata;
 - (nullable NSArray *)assets;

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/RawManifest/ABI41_0_0EXUpdatesBareRawManifest.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/RawManifest/ABI41_0_0EXUpdatesBareRawManifest.m
@@ -4,6 +4,10 @@
 
 @implementation ABI41_0_0EXUpdatesBareRawManifest
 
+- (NSString *)rawId {
+  return [self.rawManifestJSON stringForKey:@"id"];
+}
+
 - (NSNumber *)commitTimeNumber {
   return [self.rawManifestJSON numberForKey:@"commitTime"];
 }

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/RawManifest/ABI41_0_0EXUpdatesBaseLegacyRawManifest.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/RawManifest/ABI41_0_0EXUpdatesBaseLegacyRawManifest.h
@@ -6,6 +6,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ABI41_0_0EXUpdatesBaseLegacyRawManifest : ABI41_0_0EXUpdatesBaseRawManifest
 
+- (NSString *)stableLegacyId;
+- (NSString *)scopeKey;
+- (nullable NSString *)projectId;
+
 - (NSString *)bundleUrl;
 - (nullable NSString *)sdkVersion;
 - (nullable NSArray *)assets;

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/RawManifest/ABI41_0_0EXUpdatesBaseLegacyRawManifest.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/RawManifest/ABI41_0_0EXUpdatesBaseLegacyRawManifest.m
@@ -5,6 +5,28 @@
 
 @implementation ABI41_0_0EXUpdatesBaseLegacyRawManifest
 
+- (NSString *)stableLegacyId {
+  NSString *originalFullName = [self.rawManifestJSON nullableStringForKey:@"originalFullName"];
+  if (originalFullName) {
+    return originalFullName;
+  } else {
+    return [self legacyId];
+  }
+}
+
+- (NSString *)scopeKey {
+  NSString *scopeKey = [self.rawManifestJSON nullableStringForKey:@"scopeKey"];
+  if (scopeKey) {
+    return scopeKey;
+  } else {
+    return [self stableLegacyId];
+  }
+}
+
+- (nullable NSString *)projectId {
+  return [self.rawManifestJSON nullableStringForKey:@"projectId"];
+}
+
 - (NSString *)bundleUrl {
   return [self.rawManifestJSON stringForKey:@"bundleUrl"];
 }

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/RawManifest/ABI41_0_0EXUpdatesBaseRawManifest.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/RawManifest/ABI41_0_0EXUpdatesBaseRawManifest.h
@@ -13,7 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 # pragma mark - Common ABI41_0_0EXUpdatesRawManifestBehavior
 
-- (nullable NSString *)rawID;
+- (NSString *)legacyId;
 - (nullable NSString *)revisionId;
 - (nullable NSString *)slug;
 - (nullable NSString *)appKey;
@@ -23,6 +23,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSDictionary *)iosConfig;
 - (nullable NSString *)hostUri;
 - (nullable NSString *)orientation;
+- (nullable NSDictionary *)experiments;
+- (nullable NSDictionary *)developer;
 
 - (BOOL)isDevelopmentMode;
 - (BOOL)isDevelopmentSilentLaunch;

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/RawManifest/ABI41_0_0EXUpdatesBaseRawManifest.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/RawManifest/ABI41_0_0EXUpdatesBaseRawManifest.m
@@ -17,7 +17,7 @@
 
 # pragma mark - Field Getters
 
-- (nullable NSString *)rawID {
+- (NSString *)legacyId {
   return [self.rawManifestJSON nullableStringForKey:@"id"];
 }
 
@@ -57,11 +57,19 @@
   return [self.rawManifestJSON nullableStringForKey:@"orientation"];
 }
 
+- (nullable NSDictionary *)experiments {
+  return [self.rawManifestJSON nullableDictionaryForKey:@"experiments"];
+}
+
+- (nullable NSDictionary *)developer {
+  return [self.rawManifestJSON nullableDictionaryForKey:@"developer"];
+}
+
 # pragma mark - Derived Methods
 
 - (BOOL)isDevelopmentMode {
   NSDictionary *manifestPackagerOptsConfig = [self.rawManifestJSON nullableDictionaryForKey:@"packagerOpts"];
-  return ([self.rawManifestJSON nullableDictionaryForKey:@"developer"] != nil && manifestPackagerOptsConfig != nil && [@(YES) isEqualToNumber:manifestPackagerOptsConfig[@"dev"]]);
+  return (self.developer != nil && manifestPackagerOptsConfig != nil && [@(YES) isEqualToNumber:manifestPackagerOptsConfig[@"dev"]]);
 }
 
 - (BOOL)isDevelopmentSilentLaunch {
@@ -74,8 +82,7 @@
 }
 
 - (BOOL)isUsingDeveloperTool {
-  NSDictionary *manifestDeveloperConfig = self.rawManifestJSON[@"developer"];
-  BOOL isDeployedFromTool = (manifestDeveloperConfig && manifestDeveloperConfig[@"tool"] != nil);
+  BOOL isDeployedFromTool = (self.developer && self.developer[@"tool"] != nil);
   return (isDeployedFromTool);
 }
 

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/RawManifest/ABI41_0_0EXUpdatesNewRawManifest.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/RawManifest/ABI41_0_0EXUpdatesNewRawManifest.h
@@ -7,6 +7,26 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ABI41_0_0EXUpdatesNewRawManifest : ABI41_0_0EXUpdatesBaseRawManifest<ABI41_0_0EXUpdatesRawManifestBehavior>
 
+/**
+ * An ID representing this manifest, not the ID for the experience.
+ */
+- (NSString *)rawId;
+
+/**
+ * Incorrect for now until we figure out how to get this in the new manifest format.
+ */
+- (NSString *)stableLegacyId DEPRECATED_MSG_ATTRIBUTE("Modern manifests don't support stable legacy IDs");
+
+/**
+ * Incorrect for now until we figure out how to get this in the new manifest format.
+ */
+- (NSString *)scopeKey;
+
+/**
+ * Incorrect for now until we figure out how to get this in the new manifest format.
+ */
+- (nullable NSString *)projectId;
+
 - (NSString *)createdAt;
 - (NSString *)runtimeVersion;
 - (NSDictionary *)launchAsset;

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/RawManifest/ABI41_0_0EXUpdatesNewRawManifest.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/RawManifest/ABI41_0_0EXUpdatesNewRawManifest.m
@@ -4,6 +4,22 @@
 
 @implementation ABI41_0_0EXUpdatesNewRawManifest
 
+- (NSString *)rawId {
+  return [self.rawManifestJSON stringForKey:@"id"];
+}
+
+- (NSString *)stableLegacyId {
+  return self.rawId;
+}
+
+- (NSString *)scopeKey {
+  return self.rawId;
+}
+
+- (NSString *)projectId {
+  return self.rawId;
+}
+
 - (NSString *)createdAt {
   return [self.rawManifestJSON stringForKey:@"createdAt"];
 }
@@ -21,7 +37,7 @@
       return [runtimeVersion substringWithRange:matchRange];
     }
   }
-  
+
   return nil;
 }
 

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/RawManifest/ABI41_0_0EXUpdatesRawManifest.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/RawManifest/ABI41_0_0EXUpdatesRawManifest.h
@@ -10,7 +10,36 @@ NS_ASSUME_NONNULL_BEGIN
 
 # pragma mark - Field getters
 
-- (nullable NSString *)rawID;
+/**
+ * A best-effort immutable legacy ID for this experience. Formatted the same as legacyId.
+ * Stable through project transfers.
+ */
+- (NSString *)stableLegacyId;
+
+/**
+ * A stable immutable scoping key for this experience. Should be used for scoping data that
+ * does not need to make calls externally with the legacy ID.
+ */
+- (NSString *)scopeKey;
+
+/**
+ * A stable UUID for this EAS project. Should be used to call EAS APIs where possible.
+ */
+- (nullable NSString *)projectId;
+
+/**
+ * The legacy ID of this experience.
+ * - For Bare manifests, formatted as a UUID.
+ * - For Legacy manifests, formatted as @owner/slug. Not stable through project transfers.
+ * - For New manifests, currently incorrect value is UUID.
+ *
+ * Use this in cases where an identifier of the current manifest is needed (experience loading for example).
+ * Use scopeKey for cases where a stable key is needed to scope data to this experience.
+ * Use projectId for cases where a stable UUID identifier of the experience is needed to identify over APIs.
+ * Use stableLegacyId for cases where a stable legacy format identifier of the experience is needed (experience scoping for example).
+ */
+- (NSString *)legacyId;
+
 - (nullable NSString *)sdkVersion;
 - (NSString *)bundleUrl;
 - (nullable NSString *)revisionId;
@@ -22,6 +51,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSDictionary *)iosConfig;
 - (nullable NSString *)hostUri;
 - (nullable NSString *)orientation;
+- (nullable NSDictionary *)experiments;
+- (nullable NSDictionary *)developer;
 
 # pragma mark - Derived Methods
 

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/ABI41_0_0EXVersionManager.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/ABI41_0_0EXVersionManager.h
@@ -2,15 +2,17 @@
 
 #import <Foundation/Foundation.h>
 #import <ABI41_0_0React/ABI41_0_0RCTLog.h>
+#import <ABI41_0_0EXUpdates/ABI41_0_0EXUpdatesRawManifest.h>
 
 @interface ABI41_0_0EXVersionManager : NSObject
 
 // Uses a params dict since the internal workings may change over time, but we want to keep the interface the same.
-- (instancetype)initWithParams: (NSDictionary *)params
-                  fatalHandler: (void (^)(NSError *))fatalHandler
-                   logFunction: (ABI41_0_0RCTLogFunction)logFunction
-                  logThreshold: (NSInteger)threshold;
-- (void)bridgeWillStartLoading: (id)bridge;
+- (instancetype)initWithParams:(NSDictionary *)params
+                      manifest:(ABI41_0_0EXUpdatesRawManifest *)manifest
+                  fatalHandler:(void (^)(NSError *))fatalHandler
+                   logFunction:(ABI41_0_0RCTLogFunction)logFunction
+                  logThreshold:(NSInteger)threshold;
+- (void)bridgeWillStartLoading:(id)bridge;
 - (void)bridgeFinishedLoading:(id)bridge;
 - (void)invalidate;
 

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/ABI41_0_0EXVersionManager.mm
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/ABI41_0_0EXVersionManager.mm
@@ -87,6 +87,7 @@ ABI41_0_0RCT_EXTERN void ABI41_0_0EXRegisterScopedModule(Class, ...);
 // is this the first time this ABI has been touched at runtime?
 @property (nonatomic, assign) BOOL isFirstLoad;
 @property (nonatomic, strong) NSDictionary *params;
+@property (nonatomic, strong) ABI41_0_0EXUpdatesRawManifest *manifest;
 @property (nonatomic, strong) ABI41_0_0RCTTurboModuleManager *turboModuleManager;
 
 @end
@@ -95,7 +96,6 @@ ABI41_0_0RCT_EXTERN void ABI41_0_0EXRegisterScopedModule(Class, ...);
 
 /**
  *  Expected params:
- *    NSDictionary *manifest
  *    NSDictionary *constants
  *    NSURL *initialUri
  *    @BOOL isDeveloper
@@ -109,12 +109,14 @@ ABI41_0_0RCT_EXTERN void ABI41_0_0EXRegisterScopedModule(Class, ...);
  *    id exceptionsManagerDelegate
  */
 - (instancetype)initWithParams:(NSDictionary *)params
+                      manifest:(ABI41_0_0EXUpdatesRawManifest *)manifest
                   fatalHandler:(void (^)(NSError *))fatalHandler
                    logFunction:(ABI41_0_0RCTLogFunction)logFunction
                   logThreshold:(NSInteger)threshold
 {
   if (self = [super init]) {
     _params = params;
+    _manifest = manifest;
     [self configureABIWithFatalHandler:fatalHandler logFunction:logFunction logThreshold:threshold];
   }
   return self;
@@ -172,7 +174,7 @@ ABI41_0_0RCT_EXTERN void ABI41_0_0EXRegisterScopedModule(Class, ...);
       @"isEnabled": @NO
     };
   }
-  
+
   if (devSettings.isRemoteDebuggingAvailable && isDevModeEnabled) {
     items[@"dev-remote-debug"] = @{
       @"label": (devSettings.isDebuggingRemotely) ? @"Stop Remote Debugging" : @"Debug Remote JS",
@@ -314,7 +316,7 @@ ABI41_0_0RCT_EXTERN void ABI41_0_0EXRegisterScopedModule(Class, ...);
                          logFunction:(ABI41_0_0RCTLogFunction)logFunction
                         logThreshold:(NSInteger)threshold
 {
-  ABI41_0_0RCTEnableTurboModule([self.params[@"manifest"][@"experiments"][@"turboModules"] boolValue]);
+  ABI41_0_0RCTEnableTurboModule([self.manifest.experiments[@"turboModules"] boolValue]);
   ABI41_0_0RCTSetFatalHandler(fatalHandler);
   ABI41_0_0RCTSetLogThreshold((ABI41_0_0RCTLogLevel) threshold);
   ABI41_0_0RCTSetLogFunction(logFunction);
@@ -323,8 +325,6 @@ ABI41_0_0RCT_EXTERN void ABI41_0_0EXRegisterScopedModule(Class, ...);
 - (NSArray *)extraModulesForBridge:(id)bridge
 {
   NSDictionary *params = _params;
-  NSDictionary *manifest = params[@"manifest"];
-  NSString *experienceId = manifest[@"id"];
   NSDictionary *services = params[@"services"];
 
   NSMutableArray *extraModules = [NSMutableArray arrayWithArray:
@@ -333,10 +333,10 @@ ABI41_0_0RCT_EXTERN void ABI41_0_0EXRegisterScopedModule(Class, ...);
                                     [[ABI41_0_0EXDisabledDevLoadingView alloc] init],
                                     [[ABI41_0_0EXStatusBarManager alloc] init],
                                     ]];
-  
+
   // add scoped modules
-  [extraModules addObjectsFromArray:[self _newScopedModulesWithExperienceId:experienceId services:services params:params]];
-  
+  [extraModules addObjectsFromArray:[self _newScopedModulesForServices:services params:params]];
+
   if (params[@"testEnvironment"]) {
     ABI41_0_0EXTestEnvironment testEnvironment = (ABI41_0_0EXTestEnvironment)[params[@"testEnvironment"] unsignedIntegerValue];
     if (testEnvironment != ABI41_0_0EXTestEnvironmentNone) {
@@ -344,11 +344,12 @@ ABI41_0_0RCT_EXTERN void ABI41_0_0EXRegisterScopedModule(Class, ...);
       [extraModules addObject:testModule];
     }
   }
-  
+
   if (params[@"browserModuleClass"]) {
     Class browserModuleClass = params[@"browserModuleClass"];
-    id homeModule = [[browserModuleClass alloc] initWithExperienceId:experienceId
-                                                    kernelServiceDelegate:services[@"EXHomeModuleManager"]
+    id homeModule = [[browserModuleClass alloc] initWithExperienceStableLegacyId:self.manifest.stableLegacyId
+                                                              scopeKey:self.manifest.scopeKey
+                                                           kernelServiceDelegate:services[@"EXHomeModuleManager"]
                                                                    params:params];
     [extraModules addObject:homeModule];
   }
@@ -364,10 +365,13 @@ ABI41_0_0RCT_EXTERN void ABI41_0_0EXRegisterScopedModule(Class, ...);
   [moduleRegistryProvider setModuleRegistryDelegate:moduleRegistryDelegate];
 
   ABI41_0_0EXScopedModuleRegistryAdapter *moduleRegistryAdapter = [[ABI41_0_0EXScopedModuleRegistryAdapter alloc] initWithModuleRegistryProvider:moduleRegistryProvider];
-  ABI41_0_0UMModuleRegistry *moduleRegistry = [moduleRegistryAdapter moduleRegistryForParams:params forExperienceId:experienceId withKernelServices:services];
+  ABI41_0_0UMModuleRegistry *moduleRegistry = [moduleRegistryAdapter moduleRegistryForParams:params
+                                                        forExperienceStableLegacyId:self.manifest.stableLegacyId
+                                                                 scopeKey:self.manifest.scopeKey
+                                                                 withKernelServices:services];
   NSArray<id<ABI41_0_0RCTBridgeModule>> *expoModules = [moduleRegistryAdapter extraModulesForModuleRegistry:moduleRegistry];
   [extraModules addObjectsFromArray:expoModules];
-  
+
   if (!ABI41_0_0RCTTurboModuleEnabled()) {
     [extraModules addObject:[self getModuleInstanceFromClass:[self getModuleClassFromName:"DevSettings"]]];
     id exceptionsManager = [self getModuleInstanceFromClass:ABI41_0_0RCTExceptionsManagerCls()];
@@ -382,7 +386,7 @@ ABI41_0_0RCT_EXTERN void ABI41_0_0EXRegisterScopedModule(Class, ...);
   return extraModules;
 }
 
-- (NSArray *)_newScopedModulesWithExperienceId: (NSString *)experienceId services:(NSDictionary *)services params:(NSDictionary *)params
+- (NSArray *)_newScopedModulesForServices:(NSDictionary *)services params:(NSDictionary *)params
 {
   NSMutableArray *result = [NSMutableArray array];
   NSDictionary<NSString *, NSDictionary *> *ABI41_0_0EXScopedModuleClasses = ABI41_0_0EXGetScopedModuleClasses();
@@ -394,17 +398,26 @@ ABI41_0_0RCT_EXTERN void ABI41_0_0EXRegisterScopedModule(Class, ...);
         id service = ([kernelSerivceName isEqualToString:ABI41_0_0EX_KERNEL_SERVICE_NONE]) ? [NSNull null] : services[kernelSerivceName];
         moduleServices[kernelServiceClassName] = service;
       }
-      
+
       id scopedModule;
       Class scopedModuleClass = NSClassFromString(scopedModuleClassName);
       if (moduleServices.count > 1) {
-        scopedModule = [[scopedModuleClass alloc] initWithExperienceId:experienceId kernelServiceDelegates:moduleServices params:params];
+        scopedModule = [[scopedModuleClass alloc] initWithExperienceStableLegacyId:self.manifest.stableLegacyId
+                                                                scopeKey:self.manifest.scopeKey
+                                                            kernelServiceDelegates:moduleServices
+                                                                            params:params];
       } else if (moduleServices.count == 0) {
-        scopedModule = [[scopedModuleClass alloc] initWithExperienceId:experienceId kernelServiceDelegate:nil params:params];
+        scopedModule = [[scopedModuleClass alloc] initWithExperienceStableLegacyId:self.manifest.stableLegacyId
+                                                                scopeKey:self.manifest.scopeKey
+                                                             kernelServiceDelegate:nil
+                                                                            params:params];
       } else {
-        scopedModule = [[scopedModuleClass alloc] initWithExperienceId:experienceId kernelServiceDelegate:moduleServices[[moduleServices allKeys][0]] params:params];
+        scopedModule = [[scopedModuleClass alloc] initWithExperienceStableLegacyId:self.manifest.stableLegacyId
+                                                                scopeKey:self.manifest.scopeKey
+                                                             kernelServiceDelegate:moduleServices[[moduleServices allKeys][0]]
+                                                                            params:params];
       }
-      
+
       if (scopedModule) {
         [result addObject:scopedModule];
       }
@@ -465,7 +478,7 @@ ABI41_0_0RCT_EXTERN void ABI41_0_0EXRegisterScopedModule(Class, ...);
   // Expo-specific
   if (moduleClass == ABI41_0_0EXDevSettings.class) {
     BOOL isDevelopment = ![self _isOpeningHomeInProductionMode] && [_params[@"isDeveloper"] boolValue];
-    return [[moduleClass alloc] initWithExperienceId:[self _experienceId] isDevelopment:isDevelopment];
+    return [[moduleClass alloc] initWithScopeKey:self.manifest.scopeKey isDevelopment:isDevelopment];
   } else if (moduleClass == ABI41_0_0RCTExceptionsManagerCls()) {
     id exceptionsManagerDelegate = _params[@"exceptionsManagerDelegate"];
     if (exceptionsManagerDelegate) {
@@ -499,14 +512,10 @@ ABI41_0_0RCT_EXTERN void ABI41_0_0EXRegisterScopedModule(Class, ...);
 }
 
 
-- (NSString *)_experienceId
-{
-  return _params[@"manifest"][@"id"];
-}
 
 - (BOOL)_isOpeningHomeInProductionMode
 {
-  return _params[@"browserModuleClass"] && !_params[@"manifest"][@"developer"];
+  return _params[@"browserModuleClass"] && !self.manifest.developer;
 }
 
 - (void *)versionedJsExecutorFactoryForBridge:(ABI41_0_0RCTBridge *)bridge
@@ -527,7 +536,7 @@ ABI41_0_0RCT_EXTERN void ABI41_0_0EXRegisterScopedModule(Class, ...);
                                                                      delegate:self
                                                                     jsInvoker:bridge.jsCallInvoker];
     [self->_turboModuleManager installJSBindingWithRuntime:&runtime];
-    
+
     auto reanimatedModule = ABI41_0_0reanimated::createReanimatedModule(bridge.jsCallInvoker);
     runtime.global().setProperty(runtime,
                                  jsi::PropNameID::forAscii(runtime, "__reanimatedModuleProxy"),

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/Api/ABI41_0_0EXNotifications.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/Api/ABI41_0_0EXNotifications.h
@@ -34,7 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol ABI41_0_0EXNotificationsIdentifiersManager
 
-- (NSString *)internalIdForIdentifier:(NSString *)identifier experienceId:(NSString *)experienceId;
+- (NSString *)internalIdForIdentifier:(NSString *)identifier scopeKey:(NSString *)scopeKey;
 - (NSString *)exportedIdForInternalIdentifier:(NSString *)identifier;
 
 @end

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/Api/ABI41_0_0EXNotifications.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/Api/ABI41_0_0EXNotifications.m
@@ -47,9 +47,12 @@ ABI41_0_0EX_EXPORT_SCOPED_MULTISERVICE_MODULE(ExponentNotifications, @"RemoteNot
   _bridge = bridge;
 }
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId kernelServiceDelegates:(NSDictionary *)kernelServiceInstances params:(NSDictionary *)params
+- (instancetype)initWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId
+                              scopeKey:(NSString *)scopeKey
+                          kernelServiceDelegates:(NSDictionary *)kernelServiceInstances
+                                          params:(NSDictionary *)params
 {
-  if (self = [super initWithExperienceId:experienceId kernelServiceDelegates:kernelServiceInstances params:params]) {
+  if (self = [super initWithExperienceStableLegacyId:experienceStableLegacyId scopeKey:scopeKey kernelServiceDelegate:kernelServiceInstances params:params]) {
     _userNotificationCenter = kernelServiceInstances[@"UserNotificationCenter"];
     _remoteNotificationsDelegate = kernelServiceInstances[@"RemoteNotificationManager"];
     _notificationsIdentifiersManager = kernelServiceInstances[@"UserNotificationManager"];
@@ -80,7 +83,7 @@ ABI41_0_0RCT_REMAP_METHOD(getExponentPushTokenAsync,
                  getExponentPushTokenAsyncWithResolver:(ABI41_0_0RCTPromiseResolveBlock)resolve
                  rejecter:(ABI41_0_0RCTPromiseRejectBlock)reject)
 {
-  if (!self.experienceId) {
+  if (!self.experienceStableLegacyId) {
     reject(@"E_NOTIFICATIONS_INTERNAL_ERROR", @"The notifications module is missing the current project's ID", nil);
     return;
   }
@@ -212,7 +215,8 @@ ABI41_0_0RCT_EXPORT_METHOD(legacyScheduleLocalRepeatingNotification:(NSDictionar
   localNotification.applicationIconBadgeNumber = [ABI41_0_0RCTConvert NSInteger:payload[@"count"]] ?: 0;
   localNotification.userInfo = @{
                                  @"body": payload[@"data"],
-                                 @"experienceId": self.experienceId,
+                                 @"experienceId": self.scopeKey,
+                                 @"scopeKey": self.scopeKey,
                                  @"id": uniqueId
                                  };
   localNotification.fireDate = [ABI41_0_0RCTConvert NSDate:options[@"time"]] ?: [NSDate new];
@@ -256,7 +260,7 @@ ABI41_0_0RCT_REMAP_METHOD(cancelAllScheduledNotificationsAsync,
   [_userNotificationCenter getPendingNotificationRequestsWithCompletionHandler:^(NSArray<UNNotificationRequest *> * _Nonnull requests) {
     NSMutableArray<NSString *> *requestsToCancelIdentifiers = [NSMutableArray new];
     for (UNNotificationRequest *request in requests) {
-      if ([request.content.userInfo[@"experienceId"] isEqualToString:self.experienceId]) {
+      if ([request.content.userInfo[@"experienceId"] isEqualToString:self.scopeKey]) {
         [requestsToCancelIdentifiers addObject:request.identifier];
       }
     }
@@ -378,7 +382,8 @@ ABI41_0_0RCT_REMAP_METHOD(deleteCategoryAsync,
 
   content.userInfo = @{
                        @"body": payload[@"data"],
-                       @"experienceId": self.experienceId,
+                       @"experienceId": self.scopeKey,
+                       @"scopeKey": self.scopeKey,
                        @"id": uniqueId
                        };
 
@@ -386,7 +391,7 @@ ABI41_0_0RCT_REMAP_METHOD(deleteCategoryAsync,
 }
 
 - (NSString *)internalIdForIdentifier:(NSString *)identifier {
-  return [_notificationsIdentifiersManager internalIdForIdentifier:identifier experienceId:self.experienceId];
+  return [_notificationsIdentifiersManager internalIdForIdentifier:identifier scopeKey:self.scopeKey];
 }
 
 - (UNCalendarNotificationTrigger *)notificationTriggerFor:(NSNumber * _Nullable)unixTime

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/Api/ABI41_0_0EXUtil.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/Api/ABI41_0_0EXUtil.m
@@ -15,9 +15,12 @@ ABI41_0_0EX_DEFINE_SCOPED_MODULE_GETTER(ABI41_0_0EXUtil, util)
 
 ABI41_0_0EX_EXPORT_SCOPED_MODULE(ExponentUtil, UtilService);
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId kernelServiceDelegate:(id<ABI41_0_0EXUtilService>)kernelServiceInstance params:(NSDictionary *)params
+- (instancetype)initWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId scopeKey:(NSString *)scopeKey kernelServiceDelegate:(id<ABI41_0_0EXUtilService>)kernelServiceInstance params:(NSDictionary *)params
 {
-  if (self = [super initWithExperienceId:experienceId kernelServiceDelegate:kernelServiceInstance params:params]) {
+  if (self = [super initWithExperienceStableLegacyId:experienceStableLegacyId
+                                  scopeKey:scopeKey
+                               kernelServiceDelegate:kernelServiceInstance
+                                              params:params]) {
     _kernelUtilService = kernelServiceInstance;
   }
   return self;
@@ -44,7 +47,7 @@ ABI41_0_0EX_EXPORT_SCOPED_MODULE(ExponentUtil, UtilService);
 {
   const CGFloat *components = CGColorGetComponents(color);
   size_t count = CGColorGetNumberOfComponents(color);
-  
+
   if (count == 2) {
     return [NSString stringWithFormat:@"#%02lX%02lX%02lX",
             lroundf(components[0] * 255.0),
@@ -77,7 +80,7 @@ ABI41_0_0EX_EXPORT_SCOPED_MODULE(ExponentUtil, UtilService);
     int r = (hex >> 16) & 0xFF;
     int g = (hex >> 8) & 0xFF;
     int b = (hex) & 0xFF;
-    
+
     return [UIColor colorWithRed:r / 255.0f
                            green:g / 255.0f
                             blue:b / 255.0f

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/Api/Components/WebView/ABI41_0_0RNCWKProcessPoolManager.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/Api/Components/WebView/ABI41_0_0RNCWKProcessPoolManager.h
@@ -10,6 +10,6 @@
 @interface ABI41_0_0RNCWKProcessPoolManager : NSObject
 
 + (instancetype) sharedManager;
-- (WKProcessPool *)sharedProcessPoolForExperienceId:(NSString *)experienceId;
+- (WKProcessPool *)sharedProcessPoolForScopeKey:(NSString *)scopeKey;
 
 @end

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/Api/Components/WebView/ABI41_0_0RNCWKProcessPoolManager.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/Api/Components/WebView/ABI41_0_0RNCWKProcessPoolManager.m
@@ -24,15 +24,15 @@
   return self;
 }
 
-- (WKProcessPool *)sharedProcessPoolForExperienceId:(NSString *)experienceId
+- (WKProcessPool *)sharedProcessPoolForScopeKey:(NSString *)scopeKey
 {
-  if (!experienceId) {
+  if (!scopeKey) {
     return [self sharedProcessPool];
   }
-  if (!_pools[experienceId]) {
-    _pools[experienceId] = [[WKProcessPool alloc] init];
+  if (!_pools[scopeKey]) {
+    _pools[scopeKey] = [[WKProcessPool alloc] init];
   }
-  return _pools[experienceId];
+  return _pools[scopeKey];
 }
 
 

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/Api/Components/WebView/ABI41_0_0RNCWebView.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/Api/Components/WebView/ABI41_0_0RNCWebView.h
@@ -25,7 +25,7 @@
 @end
 
 @interface ABI41_0_0RNCWebView : ABI41_0_0RCTView
-@property (nonatomic, strong) NSString *experienceId;
+@property (nonatomic, strong) NSString *scopeKey;
 
 @property (nonatomic, weak) id<ABI41_0_0RNCWebViewDelegate> _Nullable delegate;
 @property (nonatomic, copy) NSDictionary * _Nullable source;

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/Api/Components/WebView/ABI41_0_0RNCWebView.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/Api/Components/WebView/ABI41_0_0RNCWebView.m
@@ -146,7 +146,7 @@ static NSDictionary* customCertificatesForHost;
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000 /* __IPHONE_13_0 */
     _savedAutomaticallyAdjustsScrollIndicatorInsets = NO;
 #endif
-      
+
   }
 
 #if !TARGET_OS_OSX
@@ -233,7 +233,7 @@ static NSDictionary* customCertificatesForHost;
     wkWebViewConfig.websiteDataStore = [WKWebsiteDataStore defaultDataStore];
   }
   if(self.useSharedProcessPool) {
-    wkWebViewConfig.processPool = [[ABI41_0_0RNCWKProcessPoolManager sharedManager] sharedProcessPoolForExperienceId:self.experienceId];
+    wkWebViewConfig.processPool = [[ABI41_0_0RNCWKProcessPoolManager sharedManager] sharedProcessPoolForScopeKey:self.scopeKey];
   }
   wkWebViewConfig.userContentController = [WKUserContentController new];
 

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/Api/Components/WebView/ABI41_0_0RNCWebViewManager.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/Api/Components/WebView/ABI41_0_0RNCWebViewManager.m
@@ -26,17 +26,18 @@ ABI41_0_0RCT_ENUM_CONVERTER(WKContentMode, (@{
 
 @implementation ABI41_0_0RNCWebViewManager
 {
-  NSString *_experienceId;
+  NSString *_scopeKey;
   NSConditionLock *_shouldStartLoadLock;
   BOOL _shouldStartLoad;
 }
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
-               kernelServiceDelegate:(id)kernelServiceInstance
+- (instancetype)initWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId
+                        scopeKey:(NSString *)scopeKey
+                     kernelServiceDelegate:(id)kernelServiceInstance
                               params:(NSDictionary *)params
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _scopeKey = scopeKey;
   }
   return self;
 }
@@ -48,7 +49,7 @@ ABI41_0_0RCT_ENUM_CONVERTER(WKContentMode, (@{
 #endif // !TARGET_OS_OSX
 {
   ABI41_0_0RNCWebView *webView = [ABI41_0_0RNCWebView new];
-  webView.experienceId = _experienceId;
+  webView.scopeKey = _scopeKey;
   webView.delegate = self;
   return webView;
 }

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/Internal/ABI41_0_0EXLinkingManager.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/Internal/ABI41_0_0EXLinkingManager.m
@@ -22,9 +22,11 @@ NSString * const ABI41_0_0EXLinkingEventOpenUrl = @"url";
 
 ABI41_0_0EX_EXPORT_SCOPED_MODULE(ABI41_0_0RCTLinkingManager, KernelLinkingManager);
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId kernelServiceDelegate:(id)kernelServiceInstance params:(NSDictionary *)params
+- (instancetype)initWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId
+                        scopeKey:(NSString *)scopeKey
+                     kernelServiceDelegate:(id)kernelServiceInstance params:(NSDictionary *)params
 {
-  if (self = [super initWithExperienceId:experienceId kernelServiceDelegate:kernelServiceInstance params:params]) {
+  if (self = [super initWithExperienceStableLegacyId:experienceStableLegacyId scopeKey:scopeKey kernelServiceDelegate:kernelServiceInstance params:params]) {
     _kernelLinkingDelegate = kernelServiceInstance;
     _initialUrl = params[@"initialUri"];
   }

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/Internal/DevSupport/ABI41_0_0EXDevSettings.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/Internal/DevSupport/ABI41_0_0EXDevSettings.h
@@ -5,7 +5,7 @@
 @interface ABI41_0_0EXDevSettings : ABI41_0_0RCTDevSettings
 
 - (instancetype)init NS_UNAVAILABLE;
-- (instancetype)initWithExperienceId:(NSString *)experienceId
-                       isDevelopment:(BOOL)isDevelopment NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey
+                             isDevelopment:(BOOL)isDevelopment NS_DESIGNATED_INITIALIZER;
 
 @end

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/Internal/DevSupport/ABI41_0_0EXDevSettings.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/Internal/DevSupport/ABI41_0_0EXDevSettings.m
@@ -12,7 +12,7 @@ NSString *const kABI41_0_0RCTDevSettingHotLoadingEnabled = @"hotLoadingEnabled";
 
 + (NSString *)moduleName { return @"ABI41_0_0RCTDevSettings"; }
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId isDevelopment:(BOOL)isDevelopment
+- (instancetype)initWithScopeKey:(NSString *)scopeKey isDevelopment:(BOOL)isDevelopment
 {
   NSDictionary *defaultValues = @{
                                   kABI41_0_0RCTDevSettingShakeToShowDevMenu: @YES,
@@ -20,7 +20,7 @@ NSString *const kABI41_0_0RCTDevSettingHotLoadingEnabled = @"hotLoadingEnabled";
                                   kABI41_0_0RCTDevSettingLiveReloadEnabled: @NO,
                                   };
   ABI41_0_0EXDevSettingsDataSource *dataSource = [[ABI41_0_0EXDevSettingsDataSource alloc] initWithDefaultValues:defaultValues
-                                                                               forExperienceId:experienceId
+                                                                         forScopeKey:scopeKey
                                                                                  isDevelopment:isDevelopment];
   return [super initWithDataSource:dataSource];
 }

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/Internal/DevSupport/ABI41_0_0EXDevSettingsDataSource.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/Internal/DevSupport/ABI41_0_0EXDevSettingsDataSource.h
@@ -7,7 +7,7 @@
 
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithDefaultValues:(NSDictionary *)defaultValues
-                      forExperienceId:(NSString *)experienceId
+                forScopeKey:(NSString *)scopeKey
                         isDevelopment:(BOOL)isDevelopment NS_DESIGNATED_INITIALIZER;
 
 @end

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/Internal/DevSupport/ABI41_0_0EXDevSettingsDataSource.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/Internal/DevSupport/ABI41_0_0EXDevSettingsDataSource.m
@@ -16,7 +16,7 @@ NSString *const ABI41_0_0EXDevSettingIsDebuggingRemotely = @"isDebuggingRemotely
 
 @interface ABI41_0_0EXDevSettingsDataSource ()
 
-@property (nonatomic, strong) NSString *experienceId;
+@property (nonatomic, strong) NSString *scopeKey;
 @property (nonatomic, readonly) NSSet *settingsDisabledInProduction;
 
 @end
@@ -27,10 +27,12 @@ NSString *const ABI41_0_0EXDevSettingIsDebuggingRemotely = @"isDebuggingRemotely
   BOOL _isDevelopment;
 }
 
-- (instancetype)initWithDefaultValues:(NSDictionary *)defaultValues forExperienceId:(NSString *)experienceId isDevelopment:(BOOL)isDevelopment
+- (instancetype)initWithDefaultValues:(NSDictionary *)defaultValues
+                forScopeKey:(NSString *)scopeKey
+                        isDevelopment:(BOOL)isDevelopment
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _scopeKey = scopeKey;
     _userDefaults = [NSUserDefaults standardUserDefaults];
     _isDevelopment = isDevelopment;
     _settingsDisabledInProduction = [NSSet setWithArray:@[
@@ -97,8 +99,8 @@ NSString *const ABI41_0_0EXDevSettingIsDebuggingRemotely = @"isDebuggingRemotely
 
 - (NSString *)_userDefaultsKey
 {
-  if (_experienceId) {
-    return [NSString stringWithFormat:@"%@/%@", _experienceId, ABI41_0_0EXDevSettingsUserDefaultsKey];
+  if (_scopeKey) {
+    return [NSString stringWithFormat:@"%@/%@", _scopeKey, ABI41_0_0EXDevSettingsUserDefaultsKey];
   } else {
     ABI41_0_0RCTLogWarn(@"Can't scope dev settings because bridge is not set");
     return ABI41_0_0EXDevSettingsUserDefaultsKey;

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/ScopedModule/ABI41_0_0EXScopedBridgeModule.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/ScopedModule/ABI41_0_0EXScopedBridgeModule.h
@@ -7,14 +7,17 @@
 
 - (instancetype)init NS_UNAVAILABLE;
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
-               kernelServiceDelegate:(id)kernelServiceInstance
-                              params:(NSDictionary *)params NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId
+                              scopeKey:(NSString *)scopeKey
+                           kernelServiceDelegate:(id)kernelServiceInstance
+                                          params:(NSDictionary *)params NS_DESIGNATED_INITIALIZER;
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
-               kernelServiceDelegates:(NSDictionary *)kernelServiceInstances
-                              params:(NSDictionary *)params NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId
+                              scopeKey:(NSString *)scopeKey
+                          kernelServiceDelegates:(NSDictionary *)kernelServiceInstances
+                                          params:(NSDictionary *)params NS_DESIGNATED_INITIALIZER;
 
-@property (nonatomic, readonly) NSString *experienceId;
+@property (nonatomic, readonly) NSString *scopeKey;
+@property (nonatomic, readonly) NSString *experienceStableLegacyId;
 
 @end

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/ScopedModule/ABI41_0_0EXScopedBridgeModule.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/ScopedModule/ABI41_0_0EXScopedBridgeModule.m
@@ -10,18 +10,26 @@
   return @"ExponentScopedBridgeModule";
 }
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId kernelServiceDelegate:(id)kernelServiceInstance params:(NSDictionary *)params
+- (instancetype)initWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId
+                              scopeKey:(NSString *)scopeKey
+                           kernelServiceDelegate:(id)kernelServiceInstance
+                                          params:(NSDictionary *)params
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _experienceStableLegacyId = experienceStableLegacyId;
+    _scopeKey = scopeKey;
   }
   return self;
 }
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId kernelServiceDelegates:(NSDictionary *)kernelServiceInstances params:(NSDictionary *)params
+- (instancetype)initWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId
+                              scopeKey:(NSString *)scopeKey
+                          kernelServiceDelegates:(NSDictionary *)kernelServiceInstances
+                                          params:(NSDictionary *)params
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _experienceStableLegacyId = experienceStableLegacyId;
+    _scopeKey = scopeKey;
   }
   return self;
 }

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/ScopedModule/ABI41_0_0EXScopedEventEmitter.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/ScopedModule/ABI41_0_0EXScopedEventEmitter.h
@@ -4,18 +4,20 @@
 
 @interface ABI41_0_0EXScopedEventEmitter : ABI41_0_0RCTEventEmitter
 
-+ (NSString *)getExperienceIdFromEventEmitter:(id)eventEmitter;
++ (NSString *)getScopeKeyFromEventEmitter:(id)eventEmitter;
 
 - (instancetype)init NS_UNAVAILABLE;
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
-               kernelServiceDelegate:(id)kernelServiceInstance
-                              params:(NSDictionary *)params NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId
+                        scopeKey:(NSString *)scopeKey
+                     kernelServiceDelegate:(id)kernelServiceInstance
+                                    params:(NSDictionary *)params NS_DESIGNATED_INITIALIZER;
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
-              kernelServiceDelegates:(NSDictionary *)kernelServiceInstances
-                              params:(NSDictionary *)params NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId
+                        scopeKey:(NSString *)scopeKey
+                    kernelServiceDelegates:(NSDictionary *)kernelServiceInstances
+                                    params:(NSDictionary *)params NS_DESIGNATED_INITIALIZER;
 
-@property (nonatomic, readonly) NSString *experienceId;
+@property (nonatomic, readonly) NSString *scopeKey;
 
 @end

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/ScopedModule/ABI41_0_0EXScopedEventEmitter.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/ScopedModule/ABI41_0_0EXScopedEventEmitter.m
@@ -10,26 +10,26 @@
   return @"ExponentScopedEventEmitter";
 }
 
-+ (NSString *)getExperienceIdFromEventEmitter:(id)eventEmitter
++ (NSString *)getScopeKeyFromEventEmitter:(id)eventEmitter
 {
   if (eventEmitter) {
-    return ((ABI41_0_0EXScopedEventEmitter *)eventEmitter).experienceId;
+    return ((ABI41_0_0EXScopedEventEmitter *)eventEmitter).scopeKey;
   }
   return nil;
 }
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId kernelServiceDelegate:(id)kernelServiceInstance params:(NSDictionary *)params
+- (instancetype)initWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId scopeKey:(NSString *)scopeKey kernelServiceDelegate:(id)kernelServiceInstance params:(NSDictionary *)params
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _scopeKey = scopeKey;
   }
   return self;
 }
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId kernelServiceDelegates:(NSDictionary *)kernelServiceInstances params:(NSDictionary *)params
+- (instancetype)initWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId scopeKey:(NSString *)scopeKey kernelServiceDelegates:(NSDictionary *)kernelServiceInstances params:(NSDictionary *)params
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _scopeKey = scopeKey;
   }
   return self;
 }

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/ABI41_0_0EXConstantsBinding.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/ABI41_0_0EXConstantsBinding.h
@@ -11,7 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly) NSString *appOwnership;
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId andParams:(NSDictionary *)params;
+- (instancetype)initWithParams:(NSDictionary *)params;
 
 @end
 

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/ABI41_0_0EXConstantsBinding.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/ABI41_0_0EXConstantsBinding.m
@@ -6,17 +6,15 @@
 @interface ABI41_0_0EXConstantsBinding ()
 
 @property (nonatomic, strong) NSString *appOwnership;
-@property (nonatomic, strong) NSString *experienceId;
 @property (nonatomic, strong) NSDictionary *unversionedConstants;
 
 @end
 
 @implementation ABI41_0_0EXConstantsBinding : ABI41_0_0EXConstantsService
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId andParams:(NSDictionary *)params
+- (instancetype)initWithParams:(NSDictionary *)params
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
     _unversionedConstants = params[@"constants"];
     if (_unversionedConstants && _unversionedConstants[@"appOwnership"]) {
       _appOwnership = _unversionedConstants[@"appOwnership"];
@@ -37,7 +35,7 @@
 #endif
 
   constants[@"isDetached"] = @(isDetached);
-  
+
   if (_unversionedConstants) {
     [constants addEntriesFromDictionary:_unversionedConstants];
   }

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/ABI41_0_0EXScopedAmplitude.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/ABI41_0_0EXScopedAmplitude.h
@@ -7,7 +7,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ABI41_0_0EXScopedAmplitude : ABI41_0_0EXAmplitude
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId;
+- (instancetype)initWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId;
 
 @end
 

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/ABI41_0_0EXScopedAmplitude.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/ABI41_0_0EXScopedAmplitude.m
@@ -12,30 +12,30 @@
 
 @interface ABI41_0_0EXScopedAmplitude ()
 
-@property (strong, nonatomic) NSString *escapedExperienceId;
+@property (strong, nonatomic) NSString *escapedExperienceStableLegacyId;
 
 @end
 
 @implementation ABI41_0_0EXScopedAmplitude
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
+- (instancetype)initWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId
 {
   if (self = [super init]) {
-    _escapedExperienceId = [self escapedExperienceId:experienceId];
+    _escapedExperienceStableLegacyId = [self escapedExperienceStableLegacyId:experienceStableLegacyId];
   }
   return self;
 }
 
 - (Amplitude *)amplitudeInstance
 {
-  return [Amplitude instanceWithName:_escapedExperienceId];
+  return [Amplitude instanceWithName:_escapedExperienceStableLegacyId];
 }
 
-- (NSString *)escapedExperienceId:(NSString *)experienceId
+- (NSString *)escapedExperienceStableLegacyId:(NSString *)experienceStableLegacyId
 {
   NSString *charactersToEscape = @"!*'();:@&=+$,/?%#[]";
   NSCharacterSet *allowedCharacters = [[NSCharacterSet characterSetWithCharactersInString:charactersToEscape] invertedSet];
-  return [experienceId stringByAddingPercentEncodingWithAllowedCharacters:allowedCharacters];
+  return [experienceStableLegacyId stringByAddingPercentEncodingWithAllowedCharacters:allowedCharacters];
 }
 
 @end

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/ABI41_0_0EXScopedBranch.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/ABI41_0_0EXScopedBranch.h
@@ -15,9 +15,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ABI41_0_0EXScopedBranch : ABI41_0_0RNBranch <ABI41_0_0UMModuleRegistryConsumer, ABI41_0_0UMInternalModule>
 
-@property (nonatomic, strong) NSString *experienceId;
+@property (nonatomic, strong) NSString *scopeKey;
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey;
 
 @end
 

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/ABI41_0_0EXScopedBranch.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/ABI41_0_0EXScopedBranch.m
@@ -20,11 +20,11 @@
   return @[@protocol(ABI41_0_0EXDummyBranchProtocol)];
 }
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
+- (instancetype)initWithScopeKey:(NSString *)scopeKey
 {
   if (self = [super init]) {
     [[NSNotificationCenter defaultCenter] removeObserver:self name:ABI41_0_0RNBranchLinkOpenedNotification object:nil];
-    _experienceId = experienceId;
+    _scopeKey = scopeKey;
   }
   return self;
 }

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/ABI41_0_0EXScopedErrorRecoveryModule.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/ABI41_0_0EXScopedErrorRecoveryModule.h
@@ -5,7 +5,7 @@
 
 @interface ABI41_0_0EXScopedErrorRecoveryModule : ABI41_0_0EXErrorRecoveryModule
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey;
 
 @end
 

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/ABI41_0_0EXScopedErrorRecoveryModule.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/ABI41_0_0EXScopedErrorRecoveryModule.m
@@ -5,16 +5,16 @@
 
 @interface ABI41_0_0EXScopedErrorRecoveryModule ()
 
-@property (nonatomic, strong) NSString *experienceId;
+@property (nonatomic, strong) NSString *scopeKey;
 
 @end
 
 @implementation ABI41_0_0EXScopedErrorRecoveryModule
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
+- (instancetype)initWithScopeKey:(NSString *)scopeKey
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _scopeKey = scopeKey;
   }
   return self;
 }
@@ -24,7 +24,7 @@
   NSUserDefaults *preferences = [NSUserDefaults standardUserDefaults];
   NSDictionary *errorRecoveryStore = [preferences dictionaryForKey:[self userDefaultsKey]] ?: @{};
   NSMutableDictionary *newStore = [errorRecoveryStore mutableCopy];
-  newStore[_experienceId] = props;
+  newStore[_scopeKey] = props;
   [preferences setObject:newStore forKey:[self userDefaultsKey]];
   return [preferences synchronize];
 }
@@ -34,10 +34,10 @@
   NSUserDefaults *preferences = [NSUserDefaults standardUserDefaults];
   NSDictionary *errorRecoveryStore = [preferences dictionaryForKey:[self userDefaultsKey]];
   if (errorRecoveryStore) {
-    NSString *props = errorRecoveryStore[_experienceId];
+    NSString *props = errorRecoveryStore[_scopeKey];
     if (props) {
       NSMutableDictionary *storeWithRemovedProps = [errorRecoveryStore mutableCopy];
-      [storeWithRemovedProps removeObjectForKey:_experienceId];
+      [storeWithRemovedProps removeObjectForKey:_scopeKey];
       [preferences setObject:storeWithRemovedProps forKey:[self userDefaultsKey]];
       [preferences synchronize];
       return props;

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/ABI41_0_0EXScopedFirebaseCore.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/ABI41_0_0EXScopedFirebaseCore.h
@@ -9,7 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ABI41_0_0EXScopedFirebaseCore : ABI41_0_0EXFirebaseCore
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId andConstantsBinding:(ABI41_0_0EXConstantsBinding *)constantsBinding;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey andConstantsBinding:(ABI41_0_0EXConstantsBinding *)constantsBinding;
 
 @end
 

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/ABI41_0_0EXScopedFirebaseCore.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/ABI41_0_0EXScopedFirebaseCore.m
@@ -12,7 +12,7 @@
   NSDictionary* _protectedAppNames;
 }
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId andConstantsBinding:(ABI41_0_0EXConstantsBinding *)constantsBinding
+- (instancetype)initWithScopeKey:(NSString *)scopeKey andConstantsBinding:(ABI41_0_0EXConstantsBinding *)constantsBinding
 {
   if (![@"expo" isEqualToString:constantsBinding.appOwnership]) {
     return [super init];
@@ -24,20 +24,20 @@
     @"[DEFAULT]": @YES
   }];
   _protectedAppNames = protectedAppNames;
-  
+
   // Make sure the [DEFAULT] app is initialized
   NSString *path = [[NSBundle mainBundle] pathForResource:@"GoogleService-Info" ofType:@"plist"];
   if (path && ![FIRApp defaultApp]) {
     [FIRApp configure];
   }
   if ([FIRApp defaultApp]) [protectedAppNames setValue:@YES forKey:[FIRApp defaultApp].name];
-  
+
   // Determine project app name & options
-  NSString *encodedExperienceId = [self.class encodedResourceName:experienceId];
-  NSString* appName = [NSString stringWithFormat:@"__sandbox_%@", encodedExperienceId];
+  NSString *encodedScopeKey = [self.class encodedResourceName:scopeKey];
+  NSString* appName = [NSString stringWithFormat:@"__sandbox_%@", encodedScopeKey];
   NSDictionary* googleServicesFile = [self.class googleServicesFileFromConstantsManifest:constantsBinding];
   FIROptions* options = [self.class optionsWithGoogleServicesFile:googleServicesFile];
-  
+
   // Delete all previously created (project) apps, except for the currently
   // loaded project and the "protected" ones
   NSDictionary<NSString *,FIRApp *>* apps = [FIRApp allApps];
@@ -101,9 +101,9 @@
 + (nullable FIROptions *)optionsWithGoogleServicesFile:(nullable NSDictionary *)plist
 {
   if (!plist) return nil;
-  
+
   FIROptions *firOptions = [[FIROptions alloc] initWithGoogleAppID:plist[@"GOOGLE_APP_ID"] GCMSenderID:plist[@"GCM_SENDER_ID"]];
-         
+
   firOptions.APIKey = plist[@"API_KEY"];
   firOptions.bundleID = plist[@"BUNDLE_ID"];
   firOptions.clientID = plist[@"CLIENT_ID"];
@@ -112,7 +112,7 @@
   firOptions.androidClientID = plist[@"ANDROID_CLIENT_ID"];
   firOptions.databaseURL = plist[@"DATABASE_URL"];
   firOptions.storageBucket = plist[@"STORAGE_BUCKET"];
-  
+
   return firOptions;
 }
 

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/ABI41_0_0EXScopedModuleRegistryAdapter.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/ABI41_0_0EXScopedModuleRegistryAdapter.h
@@ -4,6 +4,9 @@
 
 @interface ABI41_0_0EXScopedModuleRegistryAdapter : ABI41_0_0UMModuleRegistryAdapter
 
-- (ABI41_0_0UMModuleRegistry *)moduleRegistryForParams:(NSDictionary *)params forExperienceId:(NSString *)experienceId withKernelServices:(NSDictionary *)kernelServices;
+- (ABI41_0_0UMModuleRegistry *)moduleRegistryForParams:(NSDictionary *)params
+                  forExperienceStableLegacyId:(NSString *)experienceStableLegacyId
+                           scopeKey:(NSString *)scopeKey
+                           withKernelServices:(NSDictionary *)kernelServices;
 
 @end

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/ABI41_0_0EXScopedModuleRegistryAdapter.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/ABI41_0_0EXScopedModuleRegistryAdapter.m
@@ -37,24 +37,28 @@
 
 @implementation ABI41_0_0EXScopedModuleRegistryAdapter
 
-- (ABI41_0_0UMModuleRegistry *)moduleRegistryForParams:(NSDictionary *)params forExperienceId:(NSString *)experienceId withKernelServices:(NSDictionary *)kernelServices
+- (ABI41_0_0UMModuleRegistry *)moduleRegistryForParams:(NSDictionary *)params
+                  forExperienceStableLegacyId:(NSString *)experienceStableLegacyId
+                           scopeKey:(NSString *)scopeKey
+                           withKernelServices:(NSDictionary *)kernelServices
 {
   ABI41_0_0UMModuleRegistry *moduleRegistry = [self.moduleRegistryProvider moduleRegistry];
 
 #if __has_include(<ABI41_0_0EXUpdates/ABI41_0_0EXUpdatesService.h>)
-  ABI41_0_0EXUpdatesBinding *updatesBinding = [[ABI41_0_0EXUpdatesBinding alloc] initWithExperienceId:experienceId updatesKernelService:kernelServices[@"EXUpdatesManager"] databaseKernelService:kernelServices[@"EXUpdatesDatabaseManager"]];
+  ABI41_0_0EXUpdatesBinding *updatesBinding = [[ABI41_0_0EXUpdatesBinding alloc] initWithScopeKey:scopeKey
+                                                                     updatesKernelService:kernelServices[@"EXUpdatesManager"] databaseKernelService:kernelServices[@"EXUpdatesDatabaseManager"]];
   [moduleRegistry registerInternalModule:updatesBinding];
 #endif
 
 #if __has_include(<ABI41_0_0EXConstants/ABI41_0_0EXConstantsService.h>)
-  ABI41_0_0EXConstantsBinding *constantsBinding = [[ABI41_0_0EXConstantsBinding alloc] initWithExperienceId:experienceId andParams:params];
+  ABI41_0_0EXConstantsBinding *constantsBinding = [[ABI41_0_0EXConstantsBinding alloc] initWithParams:params];
   [moduleRegistry registerInternalModule:constantsBinding];
 #endif
 
 #if __has_include(<ABI41_0_0EXFacebook/ABI41_0_0EXFacebook.h>)
   // only override in Expo Go
   if ([params[@"constants"][@"appOwnership"] isEqualToString:@"expo"]) {
-    ABI41_0_0EXScopedFacebook *scopedFacebook = [[ABI41_0_0EXScopedFacebook alloc] initWithExperienceId:experienceId andParams:params];
+    ABI41_0_0EXScopedFacebook *scopedFacebook = [[ABI41_0_0EXScopedFacebook alloc] initWithScopeKey:scopeKey andParams:params];
     [moduleRegistry registerExportedModule:scopedFacebook];
   }
 #endif
@@ -80,7 +84,7 @@
 #endif
 
 #if __has_include(<ABI41_0_0EXSensors/ABI41_0_0EXSensorsManager.h>)
-  ABI41_0_0EXSensorsManagerBinding *sensorsManagerBinding = [[ABI41_0_0EXSensorsManagerBinding alloc] initWithExperienceId:experienceId andKernelService:kernelServices[@"EXSensorManager"]];
+  ABI41_0_0EXSensorsManagerBinding *sensorsManagerBinding = [[ABI41_0_0EXSensorsManagerBinding alloc] initWithScopeKey:scopeKey andKernelService:kernelServices[@"EXSensorManager"]];
   [moduleRegistry registerInternalModule:sensorsManagerBinding];
 #endif
 
@@ -96,17 +100,17 @@
 #endif
 
 #if __has_include(<ABI41_0_0EXSecureStore/ABI41_0_0EXSecureStore.h>)
-  ABI41_0_0EXScopedSecureStore *secureStoreModule = [[ABI41_0_0EXScopedSecureStore alloc] initWithExperienceId:experienceId andConstantsBinding:constantsBinding];
+  ABI41_0_0EXScopedSecureStore *secureStoreModule = [[ABI41_0_0EXScopedSecureStore alloc] initWithScopeKey:scopeKey andConstantsBinding:constantsBinding];
   [moduleRegistry registerExportedModule:secureStoreModule];
 #endif
 
 #if __has_include(<ABI41_0_0EXAmplitude/ABI41_0_0EXAmplitude.h>)
-  ABI41_0_0EXScopedAmplitude *amplitudeModule = [[ABI41_0_0EXScopedAmplitude alloc] initWithExperienceId:experienceId];
+  ABI41_0_0EXScopedAmplitude *amplitudeModule = [[ABI41_0_0EXScopedAmplitude alloc] initWithExperienceStableLegacyId:experienceStableLegacyId];
   [moduleRegistry registerExportedModule:amplitudeModule];
 #endif
 
 #if __has_include(<ABI41_0_0UMReactNativeAdapter/ABI41_0_0EXPermissionsService.h>)
-  ABI41_0_0EXScopedPermissions *permissionsModule = [[ABI41_0_0EXScopedPermissions alloc] initWithExperienceId:experienceId andConstantsBinding:constantsBinding];
+  ABI41_0_0EXScopedPermissions *permissionsModule = [[ABI41_0_0EXScopedPermissions alloc] initWithScopeKey:scopeKey andConstantsBinding:constantsBinding];
   [moduleRegistry registerExportedModule:permissionsModule];
   [moduleRegistry registerInternalModule:permissionsModule];
 #endif
@@ -117,7 +121,7 @@
 #endif
 
 #if __has_include(<ABI41_0_0EXBranch/ABI41_0_0RNBranch.h>)
-  ABI41_0_0EXScopedBranch *branchModule = [[ABI41_0_0EXScopedBranch alloc] initWithExperienceId:experienceId];
+  ABI41_0_0EXScopedBranch *branchModule = [[ABI41_0_0EXScopedBranch alloc] initWithScopeKey:scopeKey];
   [moduleRegistry registerInternalModule:branchModule];
 #endif
 
@@ -128,18 +132,18 @@
 
 #if __has_include(<ABI41_0_0EXTaskManager/ABI41_0_0EXTaskManager.h>)
   // TODO: Make scoped task manager when adding support for bare ABI41_0_0React Native
-  ABI41_0_0EXTaskManager *taskManagerModule = [[ABI41_0_0EXTaskManager alloc] initWithExperienceId:experienceId];
+  ABI41_0_0EXTaskManager *taskManagerModule = [[ABI41_0_0EXTaskManager alloc] initWithScopeKey:scopeKey];
   [moduleRegistry registerInternalModule:taskManagerModule];
   [moduleRegistry registerExportedModule:taskManagerModule];
 #endif
-  
+
 #if __has_include(<ABI41_0_0EXErrorRecovery/ABI41_0_0EXErrorRecoveryModule.h>)
-  ABI41_0_0EXScopedErrorRecoveryModule *errorRecovery = [[ABI41_0_0EXScopedErrorRecoveryModule alloc] initWithExperienceId:experienceId];
+  ABI41_0_0EXScopedErrorRecoveryModule *errorRecovery = [[ABI41_0_0EXScopedErrorRecoveryModule alloc] initWithScopeKey:scopeKey];
   [moduleRegistry registerExportedModule:errorRecovery];
 #endif
-  
+
 #if __has_include(<ABI41_0_0EXFirebaseCore/ABI41_0_0EXFirebaseCore.h>)
-  ABI41_0_0EXScopedFirebaseCore *firebaseCoreModule = [[ABI41_0_0EXScopedFirebaseCore alloc] initWithExperienceId:experienceId andConstantsBinding:constantsBinding];
+  ABI41_0_0EXScopedFirebaseCore *firebaseCoreModule = [[ABI41_0_0EXScopedFirebaseCore alloc] initWithScopeKey:scopeKey andConstantsBinding:constantsBinding];
   [moduleRegistry registerExportedModule:firebaseCoreModule];
   [moduleRegistry registerInternalModule:firebaseCoreModule];
 #endif
@@ -147,52 +151,53 @@
 #if __has_include(<ABI41_0_0EXNotifications/ABI41_0_0EXNotificationsEmitter.h>)
   // only override in Expo Go
   if ([params[@"constants"][@"appOwnership"] isEqualToString:@"expo"]) {
-    ABI41_0_0EXScopedNotificationsEmitter *notificationsEmmitter = [[ABI41_0_0EXScopedNotificationsEmitter alloc] initWithExperienceId:experienceId];
+    ABI41_0_0EXScopedNotificationsEmitter *notificationsEmmitter = [[ABI41_0_0EXScopedNotificationsEmitter alloc] initWithScopeKey:scopeKey];
     [moduleRegistry registerExportedModule:notificationsEmmitter];
   }
 #endif
-  
+
 #if __has_include(<ABI41_0_0EXNotifications/ABI41_0_0EXNotificationsHandlerModule.h>)
   // only override in Expo Go
   if ([params[@"constants"][@"appOwnership"] isEqualToString:@"expo"]) {
-    ABI41_0_0EXScopedNotificationsHandlerModule *notificationsHandler = [[ABI41_0_0EXScopedNotificationsHandlerModule alloc] initWithExperienceId:experienceId];
+    ABI41_0_0EXScopedNotificationsHandlerModule *notificationsHandler = [[ABI41_0_0EXScopedNotificationsHandlerModule alloc] initWithScopeKey:scopeKey];
     [moduleRegistry registerExportedModule:notificationsHandler];
   }
 #endif
-  
+
 #if __has_include(<ABI41_0_0EXNotifications/ABI41_0_0EXNotificationsHandlerModule.h>)
-  ABI41_0_0EXScopedNotificationBuilder *notificationsBuilder = [[ABI41_0_0EXScopedNotificationBuilder alloc] initWithExperienceId:experienceId andConstantsBinding:constantsBinding];
+  ABI41_0_0EXScopedNotificationBuilder *notificationsBuilder = [[ABI41_0_0EXScopedNotificationBuilder alloc] initWithScopeKey:scopeKey andConstantsBinding:constantsBinding];
   [moduleRegistry registerInternalModule:notificationsBuilder];
 #endif
-  
+
 #if __has_include(<ABI41_0_0EXNotifications/ABI41_0_0EXNotificationSchedulerModule.h>)
   // only override in Expo Go
   if ([params[@"constants"][@"appOwnership"] isEqualToString:@"expo"]) {
-    ABI41_0_0EXScopedNotificationSchedulerModule *schedulerModule = [[ABI41_0_0EXScopedNotificationSchedulerModule alloc] initWithExperienceId:experienceId];
+    ABI41_0_0EXScopedNotificationSchedulerModule *schedulerModule = [[ABI41_0_0EXScopedNotificationSchedulerModule alloc] initWithScopeKey:scopeKey];
     [moduleRegistry registerExportedModule:schedulerModule];
   }
 #endif
-    
+
 #if __has_include(<ABI41_0_0EXNotifications/ABI41_0_0EXNotificationPresentationModule.h>)
   // only override in Expo Go
   if ([params[@"constants"][@"appOwnership"] isEqualToString:@"expo"]) {
-    ABI41_0_0EXScopedNotificationPresentationModule *notificationPresentationModule = [[ABI41_0_0EXScopedNotificationPresentationModule alloc] initWithExperienceId:experienceId];
+    ABI41_0_0EXScopedNotificationPresentationModule *notificationPresentationModule = [[ABI41_0_0EXScopedNotificationPresentationModule alloc] initWithScopeKey:scopeKey];
     [moduleRegistry registerExportedModule:notificationPresentationModule];
   }
 #endif
-  
+
 #if __has_include(<ABI41_0_0EXNotifications/ABI41_0_0EXNotificationCategoriesModule.h>)
   // only override in Expo Go
   if ([params[@"constants"][@"appOwnership"] isEqualToString:@"expo"]) {
-    ABI41_0_0EXScopedNotificationCategoriesModule *scopedCategoriesModule = [[ABI41_0_0EXScopedNotificationCategoriesModule alloc] initWithExperienceId:experienceId andConstantsBinding:constantsBinding];
+    ABI41_0_0EXScopedNotificationCategoriesModule *scopedCategoriesModule = [[ABI41_0_0EXScopedNotificationCategoriesModule alloc] initWithScopeKey:scopeKey andConstantsBinding:constantsBinding];
     [moduleRegistry registerExportedModule:scopedCategoriesModule];
   }
-  [ABI41_0_0EXScopedNotificationCategoriesModule maybeMigrateLegacyCategoryIdentifiersForProject:experienceId
+  [ABI41_0_0EXScopedNotificationCategoriesModule maybeMigrateLegacyCategoryIdentifiersForProjectWithExperienceStableLegacyId:experienceStableLegacyId
+                                                                                                 scopeKey:scopeKey
                                                                              isInExpoGo:[params[@"constants"][@"appOwnership"] isEqualToString:@"expo"]];
 #endif
-  
+
 #if __has_include(<ABI41_0_0EXNotifications/ABI41_0_0EXServerRegistrationModule.h>)
-  ABI41_0_0EXScopedServerRegistrationModule *serverRegistrationModule = [[ABI41_0_0EXScopedServerRegistrationModule alloc] initWithExperienceId:experienceId];
+  ABI41_0_0EXScopedServerRegistrationModule *serverRegistrationModule = [[ABI41_0_0EXScopedServerRegistrationModule alloc] initWithScopeKey:scopeKey];
   [moduleRegistry registerExportedModule:serverRegistrationModule];
 #endif
 

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/ABI41_0_0EXScopedSecureStore.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/ABI41_0_0EXScopedSecureStore.h
@@ -9,7 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ABI41_0_0EXScopedSecureStore : ABI41_0_0EXSecureStore
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
+- (instancetype)initWithScopeKey:(NSString *)scopeKey
                  andConstantsBinding:(ABI41_0_0EXConstantsBinding *)constantsBinding;
 
 @end

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/ABI41_0_0EXScopedSecureStore.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/ABI41_0_0EXScopedSecureStore.m
@@ -15,18 +15,18 @@
 
 @interface ABI41_0_0EXScopedSecureStore ()
 
-@property (strong, nonatomic) NSString *experienceId;
+@property (strong, nonatomic) NSString *scopeKey;
 @property (nonatomic) BOOL isStandaloneApp;
 
 @end
 
 @implementation ABI41_0_0EXScopedSecureStore
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
+- (instancetype)initWithScopeKey:(NSString *)scopeKey
                  andConstantsBinding:(ABI41_0_0EXConstantsBinding *)constantsBinding
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _scopeKey = scopeKey;
     _isStandaloneApp = ![@"expo" isEqualToString:constantsBinding.appOwnership];
   }
   return self;
@@ -37,11 +37,11 @@
     return nil;
   }
 
-  return _isStandaloneApp ? key : [NSString stringWithFormat:@"%@-%@", _experienceId, key];
+  return _isStandaloneApp ? key : [NSString stringWithFormat:@"%@-%@", _scopeKey, key];
 }
 
 // We must override this method so that items saved in standalone apps on SDK 40 and below,
-// which were scoped by prefixing the validated key with the experienceId, can still be
+// which were scoped by prefixing the validated key with the scopeKey, can still be
 // found in SDK 41 and up. This override can be removed in SDK 45.
 - (NSString *)_getValueWithKey:(NSString *)key withOptions:(NSDictionary *)options error:(NSError **)error
 {
@@ -54,7 +54,7 @@
                                             encoding:NSUTF8StringEncoding];
     return value;
   } else if (_isStandaloneApp) {
-    NSString *scopedKey = [NSString stringWithFormat:@"%@-%@", _experienceId, key];
+    NSString *scopedKey = [NSString stringWithFormat:@"%@-%@", _scopeKey, key];
     NSString *scopedValue = [self getValueWithScopedKey:scopedKey
                                              withOptions:options];
     if (scopedValue) {
@@ -67,7 +67,7 @@
     // If we don't find anything under the scopedKey, we want to return
     // the original error from searching for the unscoped key.
   }
-  
+
   *error = searchError;
   return nil;
 }

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/ABI41_0_0EXSensorsManagerBinding.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/ABI41_0_0EXSensorsManagerBinding.h
@@ -11,30 +11,30 @@
 
 @protocol ABI41_0_0EXSensorsManagerBindingDelegate
 
-- (void)sensorModuleDidSubscribeForAccelerometerUpdatesOfExperience:(NSString *)experienceId withHandler:(void (^)(NSDictionary *event))handlerBlock;
-- (void)sensorModuleDidUnsubscribeForAccelerometerUpdatesOfExperience:(NSString *)experienceId;
+- (void)sensorModuleDidSubscribeForAccelerometerUpdatesOfExperience:(NSString *)scopeKey withHandler:(void (^)(NSDictionary *event))handlerBlock;
+- (void)sensorModuleDidUnsubscribeForAccelerometerUpdatesOfExperience:(NSString *)scopeKey;
 - (void)setAccelerometerUpdateInterval:(NSTimeInterval)intervalMs;
 
 - (float)getGravity;
-- (void)sensorModuleDidSubscribeForDeviceMotionUpdatesOfExperience:(NSString *)experienceId withHandler:(void (^)(NSDictionary *event))handlerBlock;
-- (void)sensorModuleDidUnsubscribeForDeviceMotionUpdatesOfExperience:(NSString *)experienceId;
+- (void)sensorModuleDidSubscribeForDeviceMotionUpdatesOfExperience:(NSString *)scopeKey withHandler:(void (^)(NSDictionary *event))handlerBlock;
+- (void)sensorModuleDidUnsubscribeForDeviceMotionUpdatesOfExperience:(NSString *)scopeKey;
 - (void)setDeviceMotionUpdateInterval:(NSTimeInterval)intervalMs;
 
-- (void)sensorModuleDidSubscribeForGyroscopeUpdatesOfExperience:(NSString *)experienceId withHandler:(void (^)(NSDictionary *event))handlerBlock;
-- (void)sensorModuleDidUnsubscribeForGyroscopeUpdatesOfExperience:(NSString *)experienceId;
+- (void)sensorModuleDidSubscribeForGyroscopeUpdatesOfExperience:(NSString *)scopeKey withHandler:(void (^)(NSDictionary *event))handlerBlock;
+- (void)sensorModuleDidUnsubscribeForGyroscopeUpdatesOfExperience:(NSString *)scopeKey;
 - (void)setGyroscopeUpdateInterval:(NSTimeInterval)intervalMs;
 
-- (void)sensorModuleDidSubscribeForMagnetometerUpdatesOfExperience:(NSString *)experienceId withHandler:(void (^)(NSDictionary *event))handlerBlock;
-- (void)sensorModuleDidUnsubscribeForMagnetometerUpdatesOfExperience:(NSString *)experienceId;
+- (void)sensorModuleDidSubscribeForMagnetometerUpdatesOfExperience:(NSString *)scopeKey withHandler:(void (^)(NSDictionary *event))handlerBlock;
+- (void)sensorModuleDidUnsubscribeForMagnetometerUpdatesOfExperience:(NSString *)scopeKey;
 - (void)setMagnetometerUpdateInterval:(NSTimeInterval)intervalMs;
 
-- (void)sensorModuleDidSubscribeForMagnetometerUncalibratedUpdatesOfExperience:(NSString *)experienceId
+- (void)sensorModuleDidSubscribeForMagnetometerUncalibratedUpdatesOfExperience:(NSString *)scopeKey
                                                        withHandler:(void (^)(NSDictionary *event))handlerBlock;
-- (void)sensorModuleDidUnsubscribeForMagnetometerUncalibratedUpdatesOfExperience:(NSString *)experienceId;
+- (void)sensorModuleDidUnsubscribeForMagnetometerUncalibratedUpdatesOfExperience:(NSString *)scopeKey;
 - (void)setMagnetometerUncalibratedUpdateInterval:(NSTimeInterval)intervalMs;
 
-- (void)sensorModuleDidSubscribeForBarometerUpdatesOfExperience:(NSString *)experienceId withHandler:(void (^)(NSDictionary *event))handlerBlock;
-- (void)sensorModuleDidUnsubscribeForBarometerUpdatesOfExperience:(NSString *)experienceId;
+- (void)sensorModuleDidSubscribeForBarometerUpdatesOfExperience:(NSString *)scopeKey withHandler:(void (^)(NSDictionary *event))handlerBlock;
+- (void)sensorModuleDidUnsubscribeForBarometerUpdatesOfExperience:(NSString *)scopeKey;
 - (void)setBarometerUpdateInterval:(NSTimeInterval)intervalMs;
 
 - (BOOL)isBarometerAvailable;
@@ -48,7 +48,7 @@
 
 @interface ABI41_0_0EXSensorsManagerBinding : NSObject <ABI41_0_0UMInternalModule, ABI41_0_0UMAccelerometerInterface, ABI41_0_0UMBarometerInterface, ABI41_0_0UMDeviceMotionInterface, ABI41_0_0UMGyroscopeInterface, ABI41_0_0UMMagnetometerInterface, ABI41_0_0UMMagnetometerUncalibratedInterface>
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId andKernelService:(id<ABI41_0_0EXSensorsManagerBindingDelegate>)kernelService;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey andKernelService:(id<ABI41_0_0EXSensorsManagerBindingDelegate>)kernelService;
 
 - (void)sensorModuleDidSubscribeForAccelerometerUpdates:(id)scopedSensorModule withHandler:(void (^)(NSDictionary *))handlerBlock;
 - (void)sensorModuleDidSubscribeForDeviceMotionUpdates:(id)scopedSensorModule withHandler:(void (^)(NSDictionary *))handlerBlock;

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/ABI41_0_0EXSensorsManagerBinding.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/ABI41_0_0EXSensorsManagerBinding.m
@@ -4,68 +4,68 @@
 
 @interface ABI41_0_0EXSensorsManagerBinding ()
 
-@property (nonatomic, strong) NSString *experienceId;
+@property (nonatomic, strong) NSString *scopeKey;
 @property (nonatomic, weak) id<ABI41_0_0EXSensorsManagerBindingDelegate> kernelService;
 
 @end
 
 @implementation ABI41_0_0EXSensorsManagerBinding
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId andKernelService:(id<ABI41_0_0EXSensorsManagerBindingDelegate>)kernelService
+- (instancetype)initWithScopeKey:(NSString *)scopeKey andKernelService:(id<ABI41_0_0EXSensorsManagerBindingDelegate>)kernelService
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _scopeKey = scopeKey;
     _kernelService = kernelService;
   }
   return self;
 }
 
 - (void)sensorModuleDidSubscribeForAccelerometerUpdates:(id)scopedSensorModule withHandler:(void (^)(NSDictionary *))handlerBlock {
-  [_kernelService sensorModuleDidSubscribeForAccelerometerUpdatesOfExperience:_experienceId withHandler:handlerBlock];
+  [_kernelService sensorModuleDidSubscribeForAccelerometerUpdatesOfExperience:_scopeKey withHandler:handlerBlock];
 }
 
 - (void)sensorModuleDidSubscribeForDeviceMotionUpdates:(id)scopedSensorModule withHandler:(void (^)(NSDictionary *))handlerBlock {
-  [_kernelService sensorModuleDidSubscribeForDeviceMotionUpdatesOfExperience:_experienceId withHandler:handlerBlock];
+  [_kernelService sensorModuleDidSubscribeForDeviceMotionUpdatesOfExperience:_scopeKey withHandler:handlerBlock];
 }
 
 - (void)sensorModuleDidSubscribeForGyroscopeUpdates:(id)scopedSensorModule withHandler:(void (^)(NSDictionary *))handlerBlock {
-  [_kernelService sensorModuleDidSubscribeForGyroscopeUpdatesOfExperience:_experienceId withHandler:handlerBlock];
+  [_kernelService sensorModuleDidSubscribeForGyroscopeUpdatesOfExperience:_scopeKey withHandler:handlerBlock];
 }
 
 - (void)sensorModuleDidSubscribeForMagnetometerUncalibratedUpdates:(id)scopedSensorModule withHandler:(void (^)(NSDictionary *))handlerBlock {
-  [_kernelService sensorModuleDidSubscribeForMagnetometerUncalibratedUpdatesOfExperience:_experienceId withHandler:handlerBlock];
+  [_kernelService sensorModuleDidSubscribeForMagnetometerUncalibratedUpdatesOfExperience:_scopeKey withHandler:handlerBlock];
 }
 
 - (void)sensorModuleDidSubscribeForMagnetometerUpdates:(id)scopedSensorModule withHandler:(void (^)(NSDictionary *))handlerBlock {
-  [_kernelService sensorModuleDidSubscribeForMagnetometerUpdatesOfExperience:_experienceId withHandler:handlerBlock];
+  [_kernelService sensorModuleDidSubscribeForMagnetometerUpdatesOfExperience:_scopeKey withHandler:handlerBlock];
 }
 
 - (void)sensorModuleDidSubscribeForBarometerUpdates:(id)scopedSensorModule withHandler:(void (^)(NSDictionary *))handlerBlock {
-  [_kernelService sensorModuleDidSubscribeForBarometerUpdatesOfExperience:_experienceId withHandler:handlerBlock];
+  [_kernelService sensorModuleDidSubscribeForBarometerUpdatesOfExperience:_scopeKey withHandler:handlerBlock];
 }
 
 - (void)sensorModuleDidUnsubscribeForAccelerometerUpdates:(id)scopedSensorModule {
-  [_kernelService sensorModuleDidUnsubscribeForAccelerometerUpdatesOfExperience:_experienceId];
+  [_kernelService sensorModuleDidUnsubscribeForAccelerometerUpdatesOfExperience:_scopeKey];
 }
 
 - (void)sensorModuleDidUnsubscribeForDeviceMotionUpdates:(id)scopedSensorModule {
-  [_kernelService sensorModuleDidUnsubscribeForDeviceMotionUpdatesOfExperience:_experienceId];
+  [_kernelService sensorModuleDidUnsubscribeForDeviceMotionUpdatesOfExperience:_scopeKey];
 }
 
 - (void)sensorModuleDidUnsubscribeForGyroscopeUpdates:(id)scopedSensorModule {
-  [_kernelService sensorModuleDidUnsubscribeForGyroscopeUpdatesOfExperience:_experienceId];
+  [_kernelService sensorModuleDidUnsubscribeForGyroscopeUpdatesOfExperience:_scopeKey];
 }
 
 - (void)sensorModuleDidUnsubscribeForMagnetometerUncalibratedUpdates:(id)scopedSensorModule {
-  [_kernelService sensorModuleDidUnsubscribeForMagnetometerUncalibratedUpdatesOfExperience:_experienceId];
+  [_kernelService sensorModuleDidUnsubscribeForMagnetometerUncalibratedUpdatesOfExperience:_scopeKey];
 }
 
 - (void)sensorModuleDidUnsubscribeForMagnetometerUpdates:(id)scopedSensorModule {
-  [_kernelService sensorModuleDidUnsubscribeForMagnetometerUpdatesOfExperience:_experienceId];
+  [_kernelService sensorModuleDidUnsubscribeForMagnetometerUpdatesOfExperience:_scopeKey];
 }
 
 - (void)sensorModuleDidUnsubscribeForBarometerUpdates:(id)scopedSensorModule {
-  [_kernelService sensorModuleDidUnsubscribeForBarometerUpdatesOfExperience:_experienceId];
+  [_kernelService sensorModuleDidUnsubscribeForBarometerUpdatesOfExperience:_scopeKey];
 }
 
 - (void)setAccelerometerUpdateInterval:(NSTimeInterval)intervalMs {

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/ABI41_0_0EXUpdatesBinding.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/ABI41_0_0EXUpdatesBinding.h
@@ -13,14 +13,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol ABI41_0_0EXUpdatesBindingDelegate
 
-- (ABI41_0_0EXUpdatesConfig *)configForExperienceId:(NSString *)experienceId;
-- (ABI41_0_0EXUpdatesSelectionPolicy *)selectionPolicyForExperienceId:(NSString *)experienceId;
-- (nullable ABI41_0_0EXUpdatesUpdate *)launchedUpdateForExperienceId:(NSString *)experienceId;
-- (nullable NSDictionary *)assetFilesMapForExperienceId:(NSString *)experienceId;
-- (BOOL)isUsingEmbeddedAssetsForExperienceId:(NSString *)experienceId;
-- (BOOL)isStartedForExperienceId:(NSString *)experienceId;
-- (BOOL)isEmergencyLaunchForExperienceId:(NSString *)experienceId;
-- (void)requestRelaunchForExperienceId:(NSString *)experienceId withCompletion:(ABI41_0_0EXUpdatesAppRelaunchCompletionBlock)completion;
+- (ABI41_0_0EXUpdatesConfig *)configForScopeKey:(NSString *)scopeKey;
+- (ABI41_0_0EXUpdatesSelectionPolicy *)selectionPolicyForScopeKey:(NSString *)scopeKey;
+- (nullable ABI41_0_0EXUpdatesUpdate *)launchedUpdateForScopeKey:(NSString *)scopeKey;
+- (nullable NSDictionary *)assetFilesMapForScopeKey:(NSString *)scopeKey;
+- (BOOL)isUsingEmbeddedAssetsForScopeKey:(NSString *)scopeKey;
+- (BOOL)isStartedForScopeKey:(NSString *)scopeKey;
+- (BOOL)isEmergencyLaunchForScopeKey:(NSString *)scopeKey;
+- (void)requestRelaunchForScopeKey:(NSString *)scopeKey withCompletion:(ABI41_0_0EXUpdatesAppRelaunchCompletionBlock)completion;
 
 @end
 
@@ -33,7 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ABI41_0_0EXUpdatesBinding : ABI41_0_0EXUpdatesService <ABI41_0_0UMInternalModule>
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId updatesKernelService:(id<ABI41_0_0EXUpdatesBindingDelegate>)updatesKernelService databaseKernelService:(id<ABI41_0_0EXUpdatesDatabaseBindingDelegate>)databaseKernelService;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey updatesKernelService:(id<ABI41_0_0EXUpdatesBindingDelegate>)updatesKernelService databaseKernelService:(id<ABI41_0_0EXUpdatesDatabaseBindingDelegate>)databaseKernelService;
 
 @end
 

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/ABI41_0_0EXUpdatesBinding.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/ABI41_0_0EXUpdatesBinding.m
@@ -8,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ABI41_0_0EXUpdatesBinding ()
 
-@property (nonatomic, strong) NSString *experienceId;
+@property (nonatomic, strong) NSString *scopeKey;
 @property (nonatomic, weak) id<ABI41_0_0EXUpdatesBindingDelegate> updatesKernelService;
 @property (nonatomic, weak) id<ABI41_0_0EXUpdatesDatabaseBindingDelegate> databaseKernelService;
 
@@ -16,10 +16,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation ABI41_0_0EXUpdatesBinding : ABI41_0_0EXUpdatesService
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId updatesKernelService:(id<ABI41_0_0EXUpdatesBindingDelegate>)updatesKernelService databaseKernelService:(id<ABI41_0_0EXUpdatesDatabaseBindingDelegate>)databaseKernelService
+- (instancetype)initWithScopeKey:(NSString *)scopeKey updatesKernelService:(id<ABI41_0_0EXUpdatesBindingDelegate>)updatesKernelService databaseKernelService:(id<ABI41_0_0EXUpdatesDatabaseBindingDelegate>)databaseKernelService
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _scopeKey = scopeKey;
     _updatesKernelService = updatesKernelService;
     _databaseKernelService = databaseKernelService;
   }
@@ -28,7 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (ABI41_0_0EXUpdatesConfig *)config
 {
-  return [_updatesKernelService configForExperienceId:_experienceId];
+  return [_updatesKernelService configForScopeKey:_scopeKey];
 }
 
 - (ABI41_0_0EXUpdatesDatabase *)database
@@ -38,7 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (ABI41_0_0EXUpdatesSelectionPolicy *)selectionPolicy
 {
-  return [_updatesKernelService selectionPolicyForExperienceId:_experienceId];
+  return [_updatesKernelService selectionPolicyForScopeKey:_scopeKey];
 }
 
 - (NSURL *)directory
@@ -48,27 +48,27 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (nullable ABI41_0_0EXUpdatesUpdate *)launchedUpdate
 {
-  return [_updatesKernelService launchedUpdateForExperienceId:_experienceId];
+  return [_updatesKernelService launchedUpdateForScopeKey:_scopeKey];
 }
 
 - (nullable NSDictionary *)assetFilesMap
 {
-  return [_updatesKernelService assetFilesMapForExperienceId:_experienceId];
+  return [_updatesKernelService assetFilesMapForScopeKey:_scopeKey];
 }
 
 - (BOOL)isUsingEmbeddedAssets
 {
-  return [_updatesKernelService isUsingEmbeddedAssetsForExperienceId:_experienceId];
+  return [_updatesKernelService isUsingEmbeddedAssetsForScopeKey:_scopeKey];
 }
 
 - (BOOL)isStarted
 {
-  return [_updatesKernelService isStartedForExperienceId:_experienceId];
+  return [_updatesKernelService isStartedForScopeKey:_scopeKey];
 }
 
 - (BOOL)isEmergencyLaunch
 {
-  return [_updatesKernelService isEmergencyLaunchForExperienceId:_experienceId];
+  return [_updatesKernelService isEmergencyLaunchForScopeKey:_scopeKey];
 }
 
 - (BOOL)canRelaunch
@@ -78,7 +78,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)requestRelaunchWithCompletion:(ABI41_0_0EXUpdatesAppRelaunchCompletionBlock)completion
 {
-  return [_updatesKernelService requestRelaunchForExperienceId:_experienceId withCompletion:completion];
+  return [_updatesKernelService requestRelaunchForScopeKey:_scopeKey withCompletion:completion];
 }
 
 - (void)resetSelectionPolicy

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/EXFacebook/ABI41_0_0EXScopedFacebook.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/EXFacebook/ABI41_0_0EXScopedFacebook.h
@@ -7,7 +7,7 @@
 
 @interface ABI41_0_0EXScopedFacebook : ABI41_0_0EXFacebook <ABI41_0_0UMAppLifecycleListener>
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId andParams:(NSDictionary *)params;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey andParams:(NSDictionary *)params;
 
 @end
 #endif

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/EXFacebook/ABI41_0_0EXScopedFacebook.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/EXFacebook/ABI41_0_0EXScopedFacebook.m
@@ -44,15 +44,15 @@ static NSString *AUTO_INIT_KEY = @"autoInitEnabled";
 
 @implementation ABI41_0_0EXScopedFacebook : ABI41_0_0EXFacebook
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId andParams:(NSDictionary *)params
+- (instancetype)initWithScopeKey:(NSString *)scopeKey andParams:(NSDictionary *)params
 {
   if (self = [super init]) {
-    NSString *suiteName = [NSString stringWithFormat:@"%@#%@", NSStringFromClass(self.class), experienceId];
+    NSString *suiteName = [NSString stringWithFormat:@"%@#%@", NSStringFromClass(self.class), scopeKey];
     _settings = [[NSUserDefaults alloc] initWithSuiteName:suiteName];
 
     BOOL hasPreviouslySetAutoInitEnabled = [_settings boolForKey:AUTO_INIT_KEY];
     BOOL manifestDefinesAutoInitEnabled = [params[@"manifest"][@"facebookAutoInitEnabled"] boolValue];
-    
+
     NSString *scopedFacebookAppId = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"FacebookAppID"];
     NSString *manifestFacebookAppId = params[@"manifest"][@"facebookAppId"];
 
@@ -84,11 +84,11 @@ static NSString *AUTO_INIT_KEY = @"autoInitEnabled";
   }
 
   NSString *scopedFacebookAppId = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"FacebookAppID"];
-  
+
   NSMutableDictionary *nativeOptions = [NSMutableDictionary dictionaryWithDictionary:options];
   // Overwrite the incoming app id with the Expo Facebook SDK app id.
   nativeOptions[@"appId"] = scopedFacebookAppId;
-  
+
   [super initializeAsync:nativeOptions resolver:resolve rejecter:reject];
 }
 
@@ -137,7 +137,7 @@ static NSString *AUTO_INIT_KEY = @"autoInitEnabled";
 - (void)setModuleRegistry:(ABI41_0_0UMModuleRegistry *)moduleRegistry
 {
   [super setModuleRegistry:moduleRegistry];
-  
+
   id<ABI41_0_0UMAppLifecycleService> appLifecycleService = [moduleRegistry getModuleImplementingProtocol:@protocol(ABI41_0_0UMAppLifecycleService)];
   [appLifecycleService registerAppLifecycleListener:self];
 }

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI41_0_0EXScopedNotificationBuilder.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI41_0_0EXScopedNotificationBuilder.h
@@ -9,7 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ABI41_0_0EXScopedNotificationBuilder : ABI41_0_0EXNotificationBuilder
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
+- (instancetype)initWithScopeKey:(NSString *)scopeKey
                  andConstantsBinding:(ABI41_0_0EXConstantsBinding *)constantsBinding;
 
 @end

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI41_0_0EXScopedNotificationBuilder.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI41_0_0EXScopedNotificationBuilder.m
@@ -5,21 +5,21 @@
 
 @interface ABI41_0_0EXScopedNotificationBuilder ()
 
-@property (nonatomic, strong) NSString *experienceId;
+@property (nonatomic, strong) NSString *scopeKey;
 @property (nonatomic, assign) BOOL isInExpoGo;
 
 @end
 
 @implementation ABI41_0_0EXScopedNotificationBuilder
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
+- (instancetype)initWithScopeKey:(NSString *)scopeKey
                  andConstantsBinding:(ABI41_0_0EXConstantsBinding *)constantsBinding
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _scopeKey = scopeKey;
     _isInExpoGo = [@"expo" isEqualToString:constantsBinding.appOwnership];
   }
-  
+
   return self;
 }
 
@@ -30,15 +30,16 @@
   if (!userInfo) {
     userInfo = [NSMutableDictionary dictionary];
   }
-  userInfo[@"experienceId"] = _experienceId;
+  userInfo[@"experienceId"] = _scopeKey;
+  userInfo[@"scopeKey"] = _scopeKey;
   [content setUserInfo:userInfo];
-  
+
   if (content.categoryIdentifier && _isInExpoGo) {
     NSString *scopedCategoryIdentifier = [ABI41_0_0EXScopedNotificationsUtils scopedIdentifierFromId:content.categoryIdentifier
-                                                                              forExperience:_experienceId];
+                                                                              forExperience:_scopeKey];
     [content setCategoryIdentifier:scopedCategoryIdentifier];
   }
-  
+
   return content;
 }
 

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI41_0_0EXScopedNotificationCategoriesModule.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI41_0_0EXScopedNotificationCategoriesModule.h
@@ -9,11 +9,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ABI41_0_0EXScopedNotificationCategoriesModule : ABI41_0_0EXNotificationCategoriesModule
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
+- (instancetype)initWithScopeKey:(NSString *)scopeKey
                  andConstantsBinding:(ABI41_0_0EXConstantsBinding *)constantsBinding;
 
-+ (void)maybeMigrateLegacyCategoryIdentifiersForProject:(NSString *)experienceId
-                                             isInExpoGo:(BOOL)isInExpoGo;
++ (void)maybeMigrateLegacyCategoryIdentifiersForProjectWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId
+                                                                 scopeKey:(NSString *)scopeKey
+                                                                         isInExpoGo:(BOOL)isInExpoGo;
 
 @end
 

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI41_0_0EXScopedNotificationCategoriesModule.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI41_0_0EXScopedNotificationCategoriesModule.m
@@ -6,17 +6,17 @@
 
 @interface ABI41_0_0EXScopedNotificationCategoriesModule ()
 
-@property (nonatomic, strong) NSString *experienceId;
+@property (nonatomic, strong) NSString *scopeKey;
 
 @end
 
 @implementation ABI41_0_0EXScopedNotificationCategoriesModule
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
+- (instancetype)initWithScopeKey:(NSString *)scopeKey
                  andConstantsBinding:(ABI41_0_0EXConstantsBinding *)constantsBinding
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _scopeKey = scopeKey;
   }
   return self;
 }
@@ -26,7 +26,7 @@
   [[UNUserNotificationCenter currentNotificationCenter] getNotificationCategoriesWithCompletionHandler:^(NSSet<UNNotificationCategory *> *categories) {
     NSMutableArray* existingCategories = [NSMutableArray new];
     for (UNNotificationCategory *category in categories) {
-      if ([ABI41_0_0EXScopedNotificationsUtils isId:category.identifier scopedByExperience:self->_experienceId]) {
+      if ([ABI41_0_0EXScopedNotificationsUtils isId:category.identifier scopedByExperience:self->_scopeKey]) {
         [existingCategories addObject:[self serializeCategory:category]];
       }
     }
@@ -41,7 +41,7 @@
                                        reject:(ABI41_0_0UMPromiseRejectBlock)reject
 {
   NSString *scopedCategoryIdentifier = [ABI41_0_0EXScopedNotificationsUtils scopedIdentifierFromId:categoryId
-                                                                            forExperience:_experienceId];
+                                                                            forExperience:_scopeKey];
   [super setNotificationCategoryWithCategoryId:scopedCategoryIdentifier
                                        actions:actions
                                        options:options
@@ -54,7 +54,7 @@
                                           reject:(ABI41_0_0UMPromiseRejectBlock)reject
 {
   NSString *scopedCategoryIdentifier = [ABI41_0_0EXScopedNotificationsUtils scopedIdentifierFromId:categoryId
-                                                                            forExperience:_experienceId];
+                                                                            forExperience:_scopeKey];
   [super deleteNotificationCategoryWithCategoryId:scopedCategoryIdentifier
                                           resolve:resolve
                                            reject:reject];
@@ -70,14 +70,16 @@
 
 #pragma mark - static method for migrating categories in both Expo Go and standalones. Added in SDK 41. TODO(Cruzan): Remove in SDK 47
 
-+ (void)maybeMigrateLegacyCategoryIdentifiersForProject:(NSString *)experienceId isInExpoGo:(BOOL)isInExpoGo
++ (void)maybeMigrateLegacyCategoryIdentifiersForProjectWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId
+                                                                 scopeKey:(NSString *)scopeKey
+                                                                         isInExpoGo:(BOOL)isInExpoGo
 {
   if (isInExpoGo) {
     // Changed scoping prefix in SDK 41 FROM "experienceId-" to ESCAPED "experienceId/"
-    [ABI41_0_0EXScopedNotificationCategoryMigrator migrateLegacyScopedCategoryIdentifiersForProject:experienceId];
+    [ABI41_0_0EXScopedNotificationCategoryMigrator migrateLegacyScopedCategoryIdentifiersForProjectWithScopeKey:scopeKey];
   } else {
     // Used to prefix with "experienceId-" even in standalone apps in SDKs <= 40, so we need to unscope those
-    [ABI41_0_0EXScopedNotificationCategoryMigrator unscopeLegacyCategoryIdentifiersForProject:experienceId];
+    [ABI41_0_0EXScopedNotificationCategoryMigrator unscopeLegacyCategoryIdentifiersForProjectWithScopeKey:scopeKey];
   }
 }
 

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI41_0_0EXScopedNotificationCategoryMigrator.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI41_0_0EXScopedNotificationCategoryMigrator.h
@@ -5,7 +5,7 @@
 
 @interface ABI41_0_0EXScopedNotificationCategoryMigrator : NSObject <ABI41_0_0EXNotificationsDelegate>
 
-+ (void)unscopeLegacyCategoryIdentifiersForProject:(NSString *)experienceId;
-+ (void)migrateLegacyScopedCategoryIdentifiersForProject:(NSString *)experienceId;
++ (void)unscopeLegacyCategoryIdentifiersForProjectWithScopeKey:(NSString *)scopeKey;
++ (void)migrateLegacyScopedCategoryIdentifiersForProjectWithScopeKey:(NSString *)scopeKey;
 
 @end

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI41_0_0EXScopedNotificationCategoryMigrator.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI41_0_0EXScopedNotificationCategoryMigrator.m
@@ -5,33 +5,33 @@
 
 @implementation ABI41_0_0EXScopedNotificationCategoryMigrator
 
-+ (void)migrateLegacyScopedCategoryIdentifiersForProject:(NSString *)experienceId
++ (void)migrateLegacyScopedCategoryIdentifiersForProjectWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId scopeKey:(NSString *)scopeKey
 {
-  [ABI41_0_0EXScopedNotificationCategoryMigrator renameLegacyCategoryIdentifiersForExperience:experienceId withBlock:^(UNNotificationCategory *oldCategory) {
-    NSString *unscopedLegacyCategoryId = [ABI41_0_0EXScopedNotificationsUtils unscopedLegacyCategoryIdentifierWithId:oldCategory.identifier forExperience:experienceId];
+  [ABI41_0_0EXScopedNotificationCategoryMigrator renameLegacyCategoryIdentifiersForExperienceWithScopeKey:scopeKey withBlock:^(UNNotificationCategory *oldCategory) {
+    NSString *unscopedLegacyCategoryId = [ABI41_0_0EXScopedNotificationsUtils unscopedLegacyCategoryIdentifierWithId:oldCategory.identifier forScopeKey:scopeKey];
     NSString *newCategoryId = [ABI41_0_0EXScopedNotificationsUtils scopedIdentifierFromId:unscopedLegacyCategoryId
-                                                                   forExperience:experienceId];
+                                                                   forExperience:scopeKey];
     UNNotificationCategory *newCategory = [ABI41_0_0EXScopedNotificationCategoryMigrator createNewCategoryFrom:oldCategory withNewIdentifier:newCategoryId];
     return newCategory;
   }];
 }
 
-+ (void)unscopeLegacyCategoryIdentifiersForProject:(NSString *)experienceId
++ (void)unscopeLegacyCategoryIdentifiersForProjectWithScopeKey:(NSString *)scopeKey
 {
-  [ABI41_0_0EXScopedNotificationCategoryMigrator renameLegacyCategoryIdentifiersForExperience:experienceId withBlock:^(UNNotificationCategory *oldCategory) {
-    NSString *unscopedCategoryId = [ABI41_0_0EXScopedNotificationsUtils unscopedLegacyCategoryIdentifierWithId:oldCategory.identifier forExperience:experienceId];
+  [ABI41_0_0EXScopedNotificationCategoryMigrator renameLegacyCategoryIdentifiersForExperienceWithScopeKey:scopeKey withBlock:^(UNNotificationCategory *oldCategory) {
+    NSString *unscopedCategoryId = [ABI41_0_0EXScopedNotificationsUtils unscopedLegacyCategoryIdentifierWithId:oldCategory.identifier forScopeKey:scopeKey];
     UNNotificationCategory *newCategory = [ABI41_0_0EXScopedNotificationCategoryMigrator createNewCategoryFrom:oldCategory withNewIdentifier:unscopedCategoryId];
     return newCategory;
   }];
 }
 
-+ (void)renameLegacyCategoryIdentifiersForExperience:(NSString *)experienceId withBlock:(UNNotificationCategory *(^)(UNNotificationCategory *category))renameCategoryBlock
++ (void)renameLegacyCategoryIdentifiersForExperienceWithScopeKey:(NSString *)scopeKey withBlock:(UNNotificationCategory *(^)(UNNotificationCategory *category))renameCategoryBlock
 {
   [[UNUserNotificationCenter currentNotificationCenter] getNotificationCategoriesWithCompletionHandler:^(NSSet<UNNotificationCategory *> *categories) {
     NSMutableSet<UNNotificationCategory *> *newCategories = [categories mutableCopy];
     BOOL didChangeCategories = NO;
     for (UNNotificationCategory *previousCategory in categories) {
-      if ([ABI41_0_0EXScopedNotificationsUtils isLegacyCategoryId:previousCategory.identifier scopedByExperience:experienceId]) {
+      if ([ABI41_0_0EXScopedNotificationsUtils isLegacyCategoryId:previousCategory.identifier scopedByScopeKey:scopeKey]) {
         UNNotificationCategory *newCategory = renameCategoryBlock(previousCategory);
         [newCategories removeObject:previousCategory];
         [newCategories addObject:newCategory];

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI41_0_0EXScopedNotificationPresentationModule.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI41_0_0EXScopedNotificationPresentationModule.h
@@ -8,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ABI41_0_0EXScopedNotificationPresentationModule : ABI41_0_0EXNotificationPresentationModule
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey;
 
 @end
 

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI41_0_0EXScopedNotificationPresentationModule.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI41_0_0EXScopedNotificationPresentationModule.m
@@ -7,18 +7,18 @@
 
 @interface ABI41_0_0EXScopedNotificationPresentationModule ()
 
-@property (nonatomic, strong) NSString *experienceId;
+@property (nonatomic, strong) NSString *scopeKey;
 
 @end
 
 @implementation ABI41_0_0EXScopedNotificationPresentationModule
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
+- (instancetype)initWithScopeKey:(NSString *)scopeKey
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _scopeKey = scopeKey;
   }
-  
+
   return self;
 }
 
@@ -26,7 +26,7 @@
 {
   NSMutableArray *serializedNotifications = [NSMutableArray new];
   for (UNNotification *notification in notifications) {
-    if ([ABI41_0_0EXScopedNotificationsUtils shouldNotification:notification beHandledByExperience:_experienceId]) {
+    if ([ABI41_0_0EXScopedNotificationsUtils shouldNotification:notification beHandledByExperience:_scopeKey]) {
       [serializedNotifications addObject:[ABI41_0_0EXScopedNotificationSerializer serializedNotification:notification]];
     }
   }
@@ -35,10 +35,10 @@
 
 - (void)dismissNotificationWithIdentifier:(NSString *)identifier resolve:(ABI41_0_0UMPromiseResolveBlock)resolve reject:(ABI41_0_0UMPromiseRejectBlock)reject
 {
-  __block NSString *experienceId = _experienceId;
+  __block NSString *scopeKey = _scopeKey;
   [[UNUserNotificationCenter currentNotificationCenter] getDeliveredNotificationsWithCompletionHandler:^(NSArray<UNNotification *> * _Nonnull notifications) {
     for (UNNotification *notification in notifications) {
-      if ([ABI41_0_0EXScopedNotificationsUtils shouldNotification:notification beHandledByExperience:experienceId]) {
+      if ([ABI41_0_0EXScopedNotificationsUtils shouldNotification:notification beHandledByExperience:scopeKey]) {
         // Usually we would scope the input ID and then check equality, but remote notifications do not
         // have the scoping prefix, so instead let's remove the scope if there is one, then check for
         // equality against the input
@@ -55,11 +55,11 @@
 
 - (void)dismissAllNotificationsWithResolver:(ABI41_0_0UMPromiseResolveBlock)resolve reject:(ABI41_0_0UMPromiseRejectBlock)reject
 {
-  __block NSString *experienceId = _experienceId;
+  __block NSString *scopeKey = _scopeKey;
   [[UNUserNotificationCenter currentNotificationCenter] getDeliveredNotificationsWithCompletionHandler:^(NSArray<UNNotification *> * _Nonnull notifications) {
     NSMutableArray<NSString *> *toDismiss = [NSMutableArray new];
     for (UNNotification *notification in notifications) {
-      if ([ABI41_0_0EXScopedNotificationsUtils shouldNotification:notification beHandledByExperience:experienceId]) {
+      if ([ABI41_0_0EXScopedNotificationsUtils shouldNotification:notification beHandledByExperience:scopeKey]) {
         [toDismiss addObject:notification.request.identifier];
       }
     }

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI41_0_0EXScopedNotificationSchedulerModule.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI41_0_0EXScopedNotificationSchedulerModule.h
@@ -8,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ABI41_0_0EXScopedNotificationSchedulerModule : ABI41_0_0EXNotificationSchedulerModule
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey;
 
 @end
 

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI41_0_0EXScopedNotificationSchedulerModule.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI41_0_0EXScopedNotificationSchedulerModule.m
@@ -7,16 +7,16 @@
 
 @interface ABI41_0_0EXScopedNotificationSchedulerModule ()
 
-@property (nonatomic, strong) NSString *experienceId;
+@property (nonatomic, strong) NSString *scopeKey;
 
 @end
 
 @implementation ABI41_0_0EXScopedNotificationSchedulerModule
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
+- (instancetype)initWithScopeKey:(NSString *)scopeKey
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _scopeKey = scopeKey;
   }
 
   return self;
@@ -27,7 +27,7 @@
                                                           trigger:(NSDictionary *)triggerInput
 {
   NSString *scopedIdentifier = [ABI41_0_0EXScopedNotificationsUtils scopedIdentifierFromId:identifier
-                                                                    forExperience:_experienceId];
+                                                                    forExperience:_scopeKey];
   return [super buildNotificationRequestWithIdentifier:scopedIdentifier content:contentInput trigger:triggerInput];
 }
 
@@ -35,7 +35,7 @@
 {
   NSMutableArray *serializedRequests = [NSMutableArray new];
   for (UNNotificationRequest *request in requests) {
-    if ([ABI41_0_0EXScopedNotificationsUtils isId:request.identifier scopedByExperience:_experienceId]) {
+    if ([ABI41_0_0EXScopedNotificationsUtils isId:request.identifier scopedByExperience:_scopeKey]) {
       [serializedRequests addObject:[ABI41_0_0EXScopedNotificationSerializer serializedNotificationRequest:request]];
     }
   }
@@ -46,17 +46,17 @@
 - (void)cancelNotification:(NSString *)identifier resolve:(ABI41_0_0UMPromiseResolveBlock)resolve rejecting:(ABI41_0_0UMPromiseRejectBlock)reject
 {
   NSString *scopedIdentifier = [ABI41_0_0EXScopedNotificationsUtils scopedIdentifierFromId:identifier
-                                                                    forExperience:_experienceId];
+                                                                    forExperience:_scopeKey];
   [super cancelNotification:scopedIdentifier resolve:resolve rejecting:reject];
 }
 
 - (void)cancelAllNotificationsWithResolver:(ABI41_0_0UMPromiseResolveBlock)resolve rejecting:(ABI41_0_0UMPromiseRejectBlock)reject
 {
-  __block NSString *experienceId = _experienceId;
+  __block NSString *scopeKey = _scopeKey;
   [[UNUserNotificationCenter currentNotificationCenter] getPendingNotificationRequestsWithCompletionHandler:^(NSArray<UNNotificationRequest *> * _Nonnull requests) {
     NSMutableArray<NSString *> *toRemove = [NSMutableArray new];
     for (UNNotificationRequest *request in requests) {
-      if ([ABI41_0_0EXScopedNotificationsUtils isId:request.identifier scopedByExperience:experienceId]) {
+      if ([ABI41_0_0EXScopedNotificationsUtils isId:request.identifier scopedByExperience:scopeKey]) {
         [toRemove addObject:request.identifier];
       }
     }

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI41_0_0EXScopedNotificationsEmitter.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI41_0_0EXScopedNotificationsEmitter.h
@@ -8,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ABI41_0_0EXScopedNotificationsEmitter : ABI41_0_0EXNotificationsEmitter
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey;
 
 @end
 

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI41_0_0EXScopedNotificationsEmitter.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI41_0_0EXScopedNotificationsEmitter.m
@@ -8,7 +8,7 @@
 
 @interface ABI41_0_0EXScopedNotificationsEmitter ()
 
-@property (nonatomic, strong) NSString *experienceId;
+@property (nonatomic, strong) NSString *scopeKey;
 
 @end
 
@@ -21,18 +21,18 @@
 
 @implementation ABI41_0_0EXScopedNotificationsEmitter
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
+- (instancetype)initWithScopeKey:(NSString *)scopeKey
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _scopeKey = scopeKey;
   }
-  
+
   return self;
 }
 
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center didReceiveNotificationResponse:(UNNotificationResponse *)response withCompletionHandler:(void (^)(void))completionHandler
 {
-  if ([ABI41_0_0EXScopedNotificationsUtils shouldNotification:response.notification beHandledByExperience:_experienceId]) {
+  if ([ABI41_0_0EXScopedNotificationsUtils shouldNotification:response.notification beHandledByExperience:_scopeKey]) {
     [super userNotificationCenter:center didReceiveNotificationResponse:response withCompletionHandler:completionHandler];
   } else {
     completionHandler();
@@ -41,7 +41,7 @@
 
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center willPresentNotification:(UNNotification *)notification withCompletionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler
 {
-  if ([ABI41_0_0EXScopedNotificationsUtils shouldNotification:notification beHandledByExperience:_experienceId]) {
+  if ([ABI41_0_0EXScopedNotificationsUtils shouldNotification:notification beHandledByExperience:_scopeKey]) {
     [super userNotificationCenter:center willPresentNotification:notification withCompletionHandler:completionHandler];
   } else {
     completionHandler(UNNotificationPresentationOptionNone);

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI41_0_0EXScopedNotificationsHandlerModule.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI41_0_0EXScopedNotificationsHandlerModule.h
@@ -8,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ABI41_0_0EXScopedNotificationsHandlerModule : ABI41_0_0EXNotificationsHandlerModule
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey;
 
 @end
 

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI41_0_0EXScopedNotificationsHandlerModule.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI41_0_0EXScopedNotificationsHandlerModule.m
@@ -5,24 +5,24 @@
 
 @interface ABI41_0_0EXScopedNotificationsHandlerModule ()
 
-@property (nonatomic, strong) NSString *experienceId;
+@property (nonatomic, strong) NSString *scopeKey;
 
 @end
 
 @implementation ABI41_0_0EXScopedNotificationsHandlerModule
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
+- (instancetype)initWithScopeKey:(NSString *)scopeKey
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _scopeKey = scopeKey;
   }
-  
+
   return self;
 }
 
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center willPresentNotification:(UNNotification *)notification withCompletionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler
 {
-  if ([ABI41_0_0EXScopedNotificationsUtils shouldNotification:notification beHandledByExperience:_experienceId]) {
+  if ([ABI41_0_0EXScopedNotificationsUtils shouldNotification:notification beHandledByExperience:_scopeKey]) {
     [super userNotificationCenter:center willPresentNotification:notification withCompletionHandler:completionHandler];
   }
 }

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI41_0_0EXScopedNotificationsUtils.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI41_0_0EXScopedNotificationsUtils.h
@@ -11,19 +11,20 @@ typedef struct {
 
 @interface ABI41_0_0EXScopedNotificationsUtils : NSObject
 
-+ (BOOL)shouldNotificationRequest:(UNNotificationRequest *)request beHandledByExperience:(NSString *)experienceId;
++ (BOOL)shouldNotificationRequest:(UNNotificationRequest *)request beHandledByExperience:(NSString *)scopeKey;
 
-+ (BOOL)shouldNotification:(UNNotification *)notification beHandledByExperience:(NSString *)experienceId;
++ (BOOL)shouldNotification:(UNNotification *)notification beHandledByExperience:(NSString *)scopeKey;
 
-+ (NSString *)scopedIdentifierFromId:(NSString *)unscopedId forExperience:(NSString *)experienceId;
++ (NSString *)scopedIdentifierFromId:(NSString *)unscopedId forExperience:(NSString *)scopeKey;
 
-+ (BOOL)isId:(NSString *)identifier scopedByExperience:(NSString *)experienceId;
++ (BOOL)isId:(NSString *)identifier scopedByExperience:(NSString *)scopeKey;
 
 + (ScopedIdentifierComponents)getScopeAndIdentifierFromScopedIdentifier:(NSString *)scopedIdentifier;
 
-+ (BOOL)isLegacyCategoryId:(NSString *) scopedCategoryId scopedByExperience:(NSString *) experienceId;
++ (BOOL)isLegacyCategoryId:(NSString *)scopedCategoryId scopedByScopeKey:(NSString *)scopeKey;
 
-+ (NSString *)unscopedLegacyCategoryIdentifierWithId:(NSString *) scopedCategoryId forExperience:(NSString *) experienceId;
++ (NSString *)unscopedLegacyCategoryIdentifierWithId:(NSString *)scopedCategoryId
+                         forScopeKey:(NSString *)scopeKey;
 
 @end
 

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI41_0_0EXScopedNotificationsUtils.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI41_0_0EXScopedNotificationsUtils.m
@@ -4,31 +4,31 @@
 
 @implementation ABI41_0_0EXScopedNotificationsUtils
 
-+ (BOOL)shouldNotificationRequest:(UNNotificationRequest *)request beHandledByExperience:(NSString *)experienceId
++ (BOOL)shouldNotificationRequest:(UNNotificationRequest *)request beHandledByExperience:(NSString *)scopeKey
 {
-  NSString *notificationExperienceId = request.content.userInfo[@"experienceId"];
-  if (!notificationExperienceId) {
+  NSString *notificationScopeKey = request.content.userInfo[@"experienceId"];
+  if (!notificationScopeKey) {
     return true;
   }
-  return [notificationExperienceId isEqual:experienceId];
+  return [notificationScopeKey isEqual:scopeKey];
 }
 
-+ (BOOL)shouldNotification:(UNNotification *)notification beHandledByExperience:(NSString *)experienceId
++ (BOOL)shouldNotification:(UNNotification *)notification beHandledByExperience:(NSString *)scopeKey
 {
-  return [ABI41_0_0EXScopedNotificationsUtils shouldNotificationRequest:notification.request beHandledByExperience:experienceId];
+  return [ABI41_0_0EXScopedNotificationsUtils shouldNotificationRequest:notification.request beHandledByExperience:scopeKey];
 }
 
-+ (NSString *)scopedIdentifierFromId:(NSString *)unscopedId forExperience:(NSString *)experienceId
++ (NSString *)scopedIdentifierFromId:(NSString *)unscopedId forExperience:(NSString *)scopeKey
 {
-  NSString *scope = [ABI41_0_0EXScopedNotificationsUtils escapedString:experienceId];
+  NSString *scope = [ABI41_0_0EXScopedNotificationsUtils escapedString:scopeKey];
   NSString *escapedCategoryId = [ABI41_0_0EXScopedNotificationsUtils escapedString:unscopedId];
   return [NSString stringWithFormat:@"%@/%@", scope, escapedCategoryId];
 }
 
-+ (BOOL)isId:(NSString *)identifier scopedByExperience:(NSString *)experienceId
++ (BOOL)isId:(NSString *)identifier scopedByExperience:(NSString *)scopeKey
 {
   NSString *scopeFromCategoryId = [ABI41_0_0EXScopedNotificationsUtils getScopeAndIdentifierFromScopedIdentifier:identifier].scopeKey;
-  return [scopeFromCategoryId isEqualToString:experienceId];
+  return [scopeFromCategoryId isEqualToString:scopeKey];
 }
 
 + (ScopedIdentifierComponents)getScopeAndIdentifierFromScopedIdentifier:(NSString *)scopedIdentifier
@@ -73,17 +73,17 @@
 
 # pragma mark Legacy notification category scoping
 
-+ (BOOL)isLegacyCategoryId:(NSString *) scopedCategoryId scopedByExperience:(NSString *) experienceId
++ (BOOL)isLegacyCategoryId:(NSString *)scopedCategoryId scopedByScopeKey:(NSString *)scopeKey
 {
-  NSString* legacyScopingPrefix = [NSString stringWithFormat:@"%@-", experienceId];
+  NSString* legacyScopingPrefix = [NSString stringWithFormat:@"%@-", scopeKey];
   return [scopedCategoryId hasPrefix:legacyScopingPrefix];
 }
 
 // legacy categories were stored under an unescaped experienceId
-+ (NSString *)unscopedLegacyCategoryIdentifierWithId:(NSString *) scopedCategoryId
-                                       forExperience:(NSString *) experienceId
++ (NSString *)unscopedLegacyCategoryIdentifierWithId:(NSString *)scopedCategoryId
+                         forScopeKey:(NSString *)scopeKey
 {
-  NSString* legacyScopingPrefix = [NSString stringWithFormat:@"%@-", experienceId];
+  NSString* legacyScopingPrefix = [NSString stringWithFormat:@"%@-", scopeKey];
   return [scopedCategoryId stringByReplacingOccurrencesOfString:legacyScopingPrefix
                                                      withString:@""
                                                         options:NSAnchoredSearch

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI41_0_0EXScopedServerRegistrationModule.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI41_0_0EXScopedServerRegistrationModule.h
@@ -8,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ABI41_0_0EXScopedServerRegistrationModule : ABI41_0_0EXServerRegistrationModule
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey;
 
 @end
 

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI41_0_0EXScopedServerRegistrationModule.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI41_0_0EXScopedServerRegistrationModule.m
@@ -16,23 +16,23 @@ static NSString * const kEXRegistrationInfoKey = @"EXNotificationRegistrationInf
 
 @interface ABI41_0_0EXScopedServerRegistrationModule ()
 
-@property (nonatomic, strong) NSString *experienceId;
+@property (nonatomic, strong) NSString *scopeKey;
 
 @end
 
 @implementation ABI41_0_0EXScopedServerRegistrationModule
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
+- (instancetype)initWithScopeKey:(NSString *)scopeKey
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _scopeKey = scopeKey;
   }
   return self;
 }
 
 - (NSDictionary *)registrationSearchQueryMerging:(NSDictionary *)dictionaryToMerge
 {
-  NSString *scopedKey = [kEXRegistrationInfoKey stringByAppendingFormat:@"-%@", _experienceId];
+  NSString *scopedKey = [kEXRegistrationInfoKey stringByAppendingFormat:@"-%@", _scopeKey];
   return [self keychainSearchQueryFor:scopedKey merging:dictionaryToMerge];
 }
 

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/Permissions/ABI41_0_0EXScopedPermissions.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/Permissions/ABI41_0_0EXScopedPermissions.h
@@ -9,14 +9,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol ABI41_0_0EXPermissionsScopedModuleDelegate
 
-- (ABI41_0_0UMPermissionStatus)getPermission:(NSString *)permissionType forExperience:(NSString *)experienceId;
-- (BOOL)savePermission:(NSDictionary *)permission ofType:(NSString *)type forExperience:(NSString *)experienceId;
+- (ABI41_0_0UMPermissionStatus)getPermission:(NSString *)permissionType forExperience:(NSString *)scopeKey;
+- (BOOL)savePermission:(NSDictionary *)permission ofType:(NSString *)type forExperience:(NSString *)scopeKey;
 
 @end
 
 @interface ABI41_0_0EXScopedPermissions : ABI41_0_0EXPermissionsService
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId andConstantsBinding:(ABI41_0_0EXConstantsBinding *)constantsBinding;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey andConstantsBinding:(ABI41_0_0EXConstantsBinding *)constantsBinding;
 
 @end
 

--- a/packages/expo-task-manager/ios/EXTaskManager/EXTaskManager.h
+++ b/packages/expo-task-manager/ios/EXTaskManager/EXTaskManager.h
@@ -9,6 +9,6 @@
 
 @interface EXTaskManager : UMExportedModule <UMInternalModule, UMEventEmitter, UMModuleRegistryConsumer, UMTaskManagerInterface>
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey NS_DESIGNATED_INITIALIZER;
 
 @end

--- a/packages/expo-task-manager/ios/EXTaskManager/EXTaskManager.m
+++ b/packages/expo-task-manager/ios/EXTaskManager/EXTaskManager.m
@@ -33,14 +33,14 @@ UM_EXPORT_MODULE(ExpoTaskManager);
 
 - (instancetype)init
 {
-  return [self initWithExperienceId:@"mainApplication"];
+  return [self initWithScopeKey:@"mainApplication"];
 }
 
 // TODO: Remove when adding bare React Native support
-- (instancetype)initWithExperienceId:(NSString *)experienceId
+- (instancetype)initWithScopeKey:(NSString *)scopeKey
 {
   if (self = [super init]) {
-    _appId = experienceId;
+    _appId = scopeKey;
     _eventsQueue = [NSMutableArray new];
   }
   return self;

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesBareUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesBareUpdate.m
@@ -18,7 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
                                                                   config:config
                                                                 database:database];
 
-  NSString *updateId = manifest.rawID;
+  NSString *updateId = manifest.rawId;
   NSNumber *commitTime = manifest.commitTimeNumber;
   NSArray *assets = manifest.assets;
   

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesNewUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesNewUpdate.m
@@ -20,7 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
                                                                   config:config
                                                                 database:database];
   
-  NSString *updateId = manifest.rawID;
+  NSString *updateId = manifest.rawId;
   NSString *commitTime = manifest.createdAt;
   NSString *runtimeVersion = manifest.runtimeVersion;
   NSDictionary *launchAsset = manifest.launchAsset;

--- a/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesBareRawManifest.h
+++ b/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesBareRawManifest.h
@@ -7,6 +7,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface EXUpdatesBareRawManifest : EXUpdatesBaseLegacyRawManifest<EXUpdatesRawManifestBehavior>
 
+/**
+* A UUID for this manifest.
+*/
+- (NSString *)rawId;
 - (NSNumber *)commitTimeNumber;
 - (nullable NSDictionary *)metadata;
 - (nullable NSArray *)assets;

--- a/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesBareRawManifest.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesBareRawManifest.m
@@ -4,6 +4,10 @@
 
 @implementation EXUpdatesBareRawManifest
 
+- (NSString *)rawId {
+  return [self.rawManifestJSON stringForKey:@"id"];
+}
+
 - (NSNumber *)commitTimeNumber {
   return [self.rawManifestJSON numberForKey:@"commitTime"];
 }

--- a/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesBaseLegacyRawManifest.h
+++ b/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesBaseLegacyRawManifest.h
@@ -6,6 +6,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface EXUpdatesBaseLegacyRawManifest : EXUpdatesBaseRawManifest
 
+- (NSString *)stableLegacyId;
+- (NSString *)scopeKey;
+- (nullable NSString *)projectId;
+
 - (NSString *)bundleUrl;
 - (nullable NSString *)sdkVersion;
 - (nullable NSArray *)assets;

--- a/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesBaseLegacyRawManifest.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesBaseLegacyRawManifest.m
@@ -5,12 +5,38 @@
 
 @implementation EXUpdatesBaseLegacyRawManifest
 
+- (NSString *)stableLegacyId {
+  NSString *originalFullName = [self.rawManifestJSON nullableStringForKey:@"originalFullName"];
+  if (originalFullName) {
+    return originalFullName;
+  } else {
+    return [self legacyId];
+  }
+}
+
+- (NSString *)scopeKey {
+  NSString *scopeKey = [self.rawManifestJSON nullableStringForKey:@"scopeKey"];
+  if (scopeKey) {
+    return scopeKey;
+  } else {
+    return [self stableLegacyId];
+  }
+}
+
+- (nullable NSString *)projectId {
+  return [self.rawManifestJSON nullableStringForKey:@"projectId"];
+}
+
 - (NSString *)bundleUrl {
   return [self.rawManifestJSON stringForKey:@"bundleUrl"];
 }
 
 - (nullable NSString *)sdkVersion {
   return [self.rawManifestJSON nullableStringForKey:@"sdkVersion"];
+}
+
+- (nullable NSArray *)assets {
+  return [self.rawManifestJSON nullableArrayForKey:@"assets"];
 }
 
 @end

--- a/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesBaseRawManifest.h
+++ b/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesBaseRawManifest.h
@@ -13,7 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 # pragma mark - Common EXUpdatesRawManifestBehavior
 
-- (nullable NSString *)rawID;
+- (NSString *)legacyId;
 - (nullable NSString *)revisionId;
 - (nullable NSString *)slug;
 - (nullable NSString *)appKey;
@@ -23,6 +23,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSDictionary *)iosConfig;
 - (nullable NSString *)hostUri;
 - (nullable NSString *)orientation;
+- (nullable NSDictionary *)experiments;
+- (nullable NSDictionary *)developer;
 
 - (BOOL)isDevelopmentMode;
 - (BOOL)isDevelopmentSilentLaunch;

--- a/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesBaseRawManifest.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesBaseRawManifest.m
@@ -19,7 +19,7 @@
 
 # pragma mark - Field Getters
 
-- (nullable NSString *)rawID {
+- (NSString *)legacyId {
   return [self.rawManifestJSON nullableStringForKey:@"id"];
 }
 
@@ -59,11 +59,19 @@
   return [self.rawManifestJSON nullableStringForKey:@"orientation"];
 }
 
+- (nullable NSDictionary *)experiments {
+  return [self.rawManifestJSON nullableDictionaryForKey:@"experiments"];
+}
+
+- (nullable NSDictionary *)developer {
+  return [self.rawManifestJSON nullableDictionaryForKey:@"developer"];
+}
+
 # pragma mark - Derived Methods
 
 - (BOOL)isDevelopmentMode {
   NSDictionary *manifestPackagerOptsConfig = [self.rawManifestJSON nullableDictionaryForKey:@"packagerOpts"];
-  return ([self.rawManifestJSON nullableDictionaryForKey:@"developer"] != nil && manifestPackagerOptsConfig != nil && [@(YES) isEqualToNumber:manifestPackagerOptsConfig[@"dev"]]);
+  return (self.developer != nil && manifestPackagerOptsConfig != nil && [@(YES) isEqualToNumber:manifestPackagerOptsConfig[@"dev"]]);
 }
 
 - (BOOL)isDevelopmentSilentLaunch {
@@ -76,8 +84,7 @@
 }
 
 - (BOOL)isUsingDeveloperTool {
-  NSDictionary *manifestDeveloperConfig = self.rawManifestJSON[@"developer"];
-  BOOL isDeployedFromTool = (manifestDeveloperConfig && manifestDeveloperConfig[@"tool"] != nil);
+  BOOL isDeployedFromTool = (self.developer && self.developer[@"tool"] != nil);
   return (isDeployedFromTool);
 }
 

--- a/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesNewRawManifest.h
+++ b/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesNewRawManifest.h
@@ -7,6 +7,26 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface EXUpdatesNewRawManifest : EXUpdatesBaseRawManifest<EXUpdatesRawManifestBehavior>
 
+/**
+ * An ID representing this manifest, not the ID for the experience.
+ */
+- (NSString *)rawId;
+
+/**
+ * Incorrect for now until we figure out how to get this in the new manifest format.
+ */
+- (NSString *)stableLegacyId DEPRECATED_MSG_ATTRIBUTE("Modern manifests don't support stable legacy IDs");
+
+/**
+ * Incorrect for now until we figure out how to get this in the new manifest format.
+ */
+- (NSString *)scopeKey;
+
+/**
+ * Incorrect for now until we figure out how to get this in the new manifest format.
+ */
+- (nullable NSString *)projectId;
+
 - (NSString *)createdAt;
 - (NSString *)runtimeVersion;
 - (NSDictionary *)launchAsset;

--- a/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesNewRawManifest.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesNewRawManifest.m
@@ -4,6 +4,22 @@
 
 @implementation EXUpdatesNewRawManifest
 
+- (NSString *)rawId {
+  return [self.rawManifestJSON stringForKey:@"id"];
+}
+
+- (NSString *)stableLegacyId {
+  return self.rawId;
+}
+
+- (NSString *)scopeKey {
+  return self.rawId;
+}
+
+- (NSString *)projectId {
+  return self.rawId;
+}
+
 - (NSString *)createdAt {
   return [self.rawManifestJSON stringForKey:@"createdAt"];
 }

--- a/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesRawManifest.h
+++ b/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesRawManifest.h
@@ -12,7 +12,36 @@ NS_ASSUME_NONNULL_BEGIN
 
 # pragma mark - Field getters
 
-- (nullable NSString *)rawID;
+/**
+ * A best-effort immutable legacy ID for this experience. Formatted the same as legacyId.
+ * Stable through project transfers.
+ */
+- (NSString *)stableLegacyId;
+
+/**
+ * A stable immutable scoping key for this experience. Should be used for scoping data that
+ * does not need to make calls externally with the legacy ID.
+ */
+- (NSString *)scopeKey;
+
+/**
+ * A stable UUID for this EAS project. Should be used to call EAS APIs where possible.
+ */
+- (nullable NSString *)projectId;
+
+/**
+ * The legacy ID of this experience.
+ * - For Bare manifests, formatted as a UUID.
+ * - For Legacy manifests, formatted as @owner/slug. Not stable through project transfers.
+ * - For New manifests, currently incorrect value is UUID.
+ *
+ * Use this in cases where an identifier of the current manifest is needed (experience loading for example).
+ * Use scopeKey for cases where a stable key is needed to scope data to this experience.
+ * Use projectId for cases where a stable UUID identifier of the experience is needed to identify over APIs.
+ * Use stableLegacyId for cases where a stable legacy format identifier of the experience is needed (experience scoping for example).
+ */
+- (NSString *)legacyId;
+
 - (nullable NSString *)sdkVersion;
 - (NSString *)bundleUrl;
 - (nullable NSString *)revisionId;
@@ -24,6 +53,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSDictionary *)iosConfig;
 - (nullable NSString *)hostUri;
 - (nullable NSString *)orientation;
+- (nullable NSDictionary *)experiments;
+- (nullable NSDictionary *)developer;
 
 # pragma mark - Derived Methods
 

--- a/tools/src/vendoring/config/expoGoConfig.ts
+++ b/tools/src/vendoring/config/expoGoConfig.ts
@@ -100,7 +100,7 @@ const config: VendoringTargetConfig = {
               paths: 'RNCWKProcessPoolManager.h',
               find: '- (WKProcessPool *)sharedProcessPool;',
               replaceWith:
-                '- (WKProcessPool *)sharedProcessPoolForExperienceId:(NSString *)experienceId;',
+                '- (WKProcessPool *)sharedProcessPoolForExperienceScopeKey:(NSString *)experienceScopeKey;',
             },
             {
               paths: 'RNCWKProcessPoolManager.m',
@@ -121,47 +121,48 @@ const config: VendoringTargetConfig = {
   return self;
 }
 
-- (WKProcessPool *)sharedProcessPoolForExperienceId:(NSString *)experienceId
+- (WKProcessPool *)sharedProcessPoolForExperienceScopeKey:(NSString *)experienceScopeKey
 {
-  if (!experienceId) {
+  if (!experienceScopeKey) {
     return [self sharedProcessPool];
   }
-  if (!_pools[experienceId]) {
-    _pools[experienceId] = [[WKProcessPool alloc] init];
+  if (!_pools[experienceScopeKey]) {
+    _pools[experienceScopeKey] = [[WKProcessPool alloc] init];
   }
-  return _pools[experienceId];
+  return _pools[experienceScopeKey];
 }
 `,
             },
             {
               paths: 'RNCWebView.h',
               find: /@interface RNCWebView : RCTView/,
-              replaceWith: '$&\n@property (nonatomic, strong) NSString *experienceId;',
+              replaceWith: '$&\n@property (nonatomic, strong) NSString *experienceScopeKey;',
             },
             {
               paths: 'RNCWebView.m',
               find: /(\[\[RNCWKProcessPoolManager sharedManager\] sharedProcessPool)]/,
-              replaceWith: '$1ForExperienceId:self.experienceId]',
+              replaceWith: '$1ForExperienceScopeKey:self.experienceScopeKey]',
             },
             {
               paths: 'RNCWebViewManager.m',
               find: /@implementation RNCWebViewManager\s*{/,
-              replaceWith: '$&\n  NSString *_experienceId;',
+              replaceWith: '$&\n  NSString *_experienceScopeKey;',
             },
             {
               paths: 'RNCWebViewManager.m',
               find: '*webView = [RNCWebView new];',
-              replaceWith: '*webView = [RNCWebView new];\n  webView.experienceId = _experienceId;',
+              replaceWith:
+                '*webView = [RNCWebView new];\n  webView.experienceScopeKey = _experienceScopeKey;',
             },
             {
               paths: 'RNCWebViewManager.m',
               find: /RCT_EXPORT_MODULE\(\)/,
-              replaceWith: `- (instancetype)initWithExperienceId:(NSString *)experienceId
+              replaceWith: `- (instancetype)initWithExperienceScopeKey:(NSString *)experienceScopeKey
                kernelServiceDelegate:(id)kernelServiceInstance
                               params:(NSDictionary *)params
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _experienceScopeKey = experienceScopeKey;
   }
   return self;
 }`,


### PR DESCRIPTION
# Why

iOS equivalent of https://github.com/expo/expo/pull/12964.

# How

- Add new manifest methods
- Compile, change calls to old methods to new methods (`scopeKey`, `stableLegacyId`, `legacyId`) changing variable and parameter names as move outwards from the manifest.

# Test Plan

Same as https://github.com/expo/expo/pull/12964 but on iOS.