### PR TITLE
[home] Use showInRecents on auth session to prevent prematurely closing the browser

### DIFF
--- a/home/components/ProfileUnauthenticated.tsx
+++ b/home/components/ProfileUnauthenticated.tsx
@@ -46,7 +46,15 @@ export default function ProfileUnauthenticated() {
       const authSessionURL = `${
         Config.website.origin
       }/${urlPath}?app_redirect_uri=${encodeURIComponent(redirectBase)}`;
-      const result = await WebBrowser.openAuthSessionAsync(authSessionURL, redirectBase);
+      const result = await WebBrowser.openAuthSessionAsync(authSessionURL, redirectBase, {
+        /** note(brentvatne): We should disable the showInRecents option when
+         * https://github.com/expo/expo/issues/8072 is resolved. This workaround
+         * prevents the Chrome Custom Tabs activity from closing when the user
+         * switches from the login / sign up form to a password manager or 2fa
+         * app. The downside of using this flag is that the browser window will
+         * remain open in the background after authentication completes. */
+        showInRecents: true,
+      });
 
       if (!mounted.current) {
         return;


### PR DESCRIPTION
# Why

In the below video, I am not manually dismissing the web browser window - it is being dismissed automatically by the operating system when I press the multi tasking button.

https://user-images.githubusercontent.com/90494/121970349-39af2700-cd2b-11eb-98b9-16be8772e173.mov

Related: https://github.com/expo/expo/issues/8072

# How

Use `showInRecents: true` option.

https://user-images.githubusercontent.com/90494/121970604-bfcb6d80-cd2b-11eb-8160-ba0645139707.mov

[This video shows it working properly when switching to a 2fa app](
https://user-images.githubusercontent.com/90494/121970582-b4784200-cd2b-11eb-8351-2196564c0448.mov).

## Tradeoff to enabling `showInRecents`

When using `showInRecents: true` the Chrome Custom Tabs window is not closed on redirect.

https://user-images.githubusercontent.com/90494/121970668-dffb2c80-cd2b-11eb-8522-cebb4b81dd5e.mov

# Test Plan

- Run Expo Go against local version of home
- Press sign in
- Press the multi tasker button
- Notice that with this patch, the browser window does not get dismissed
- Notice that without this patch, it is dismissed

# Follow up

Investigate a better fix to https://github.com/expo/expo/issues/8072