### PR TITLE
[expo-updates] add runtimeVersion support to classic updates

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Backport runtimeVersion to classic Updates ([#13283](https://github.com/expo/expo/pull/13283) by [@jkhales](https://github.com/jkhales))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/manifest/LegacyManifestTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/manifest/LegacyManifestTest.kt
@@ -219,4 +219,49 @@ class LegacyManifestTest {
     configMap["updateUrl"] = Uri.parse("https://exp.host/@test/test")
     return UpdatesConfiguration().loadValuesFromMap(configMap)
   }
+
+  @Test
+  @Throws(JSONException::class)
+  fun testFromLegacyManifestJson_setsUpdateRuntimeAsSdkIfNoConfigRuntime() {
+    val legacyManifestJsonWithRuntimeVersion =
+      "{\"runtimeVersion\":\"hello\",\"sdkVersion\":\"39.0.0\",\"releaseId\":\"0eef8214-4833-4089-9dff-b4138a14f196\",\"commitTime\":\"2020-11-11T00:17:54.797Z\",\"bundleUrl\":\"https://url.to/bundle.js\"}"
+    val rawManifest = LegacyRawManifest(JSONObject(legacyManifestJsonWithRuntimeVersion))
+    val configWithoutRuntimeVersion = createConfig()
+
+    val newLegacyManifest = LegacyManifest.fromLegacyRawManifest(rawManifest, configWithoutRuntimeVersion)
+    Assert.assertEquals("39.0.0",newLegacyManifest.updateEntity.runtimeVersion)
+  }
+
+  @Test
+  @Throws(JSONException::class)
+  fun testFromLegacyManifestJson_setsUpdateRuntimeAsSdkIfNoManifestRuntime() {
+    val legacyManifestJsonWithoutRuntimeVersion =
+      "{\"sdkVersion\":\"39.0.0\",\"releaseId\":\"0eef8214-4833-4089-9dff-b4138a14f196\",\"commitTime\":\"2020-11-11T00:17:54.797Z\",\"bundleUrl\":\"https://url.to/bundle.js\"}"
+    val rawManifest = LegacyRawManifest(JSONObject(legacyManifestJsonWithoutRuntimeVersion))
+
+    val configMap = HashMap<String, Any>()
+    configMap["updateUrl"] = Uri.parse("https://exp.host/@test/test")
+    configMap["runtimeVersion"] = "nonEmpty"
+    val configWithRuntimeVersion = UpdatesConfiguration().loadValuesFromMap(configMap)
+
+    val newLegacyManifest = LegacyManifest.fromLegacyRawManifest(rawManifest, configWithRuntimeVersion)
+    Assert.assertEquals("39.0.0",newLegacyManifest.updateEntity.runtimeVersion)
+  }
+
+  @Test
+  @Throws(JSONException::class)
+  fun testFromLegacyManifestJson_setsUpdateRuntimeAsRuntimeIfBothManifestRuntimeAndConfigRuntime() {
+    val runtimeVersion = "hello";
+    val legacyManifestJsonWithRuntimeVersion =
+      String.format("{\"runtimeVersion\":\"%s\",\"sdkVersion\":\"39.0.0\",\"releaseId\":\"0eef8214-4833-4089-9dff-b4138a14f196\",\"commitTime\":\"2020-11-11T00:17:54.797Z\",\"bundleUrl\":\"https://url.to/bundle.js\"}",runtimeVersion)
+    val rawManifest = LegacyRawManifest(JSONObject(legacyManifestJsonWithRuntimeVersion))
+
+    val configMap = HashMap<String, Any>()
+    configMap["updateUrl"] = Uri.parse("https://exp.host/@test/test")
+    configMap["runtimeVersion"] = "nonEmpty"
+    val configWithRuntimeVersion = UpdatesConfiguration().loadValuesFromMap(configMap)
+
+    val newLegacyManifest = LegacyManifest.fromLegacyRawManifest(rawManifest, configWithRuntimeVersion)
+    Assert.assertEquals(runtimeVersion,newLegacyManifest.updateEntity.runtimeVersion)
+  }
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/LegacyManifest.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/LegacyManifest.kt
@@ -107,14 +107,12 @@ class LegacyManifest private constructor(
         }
       }
       var runtimeVersion = rawManifest.getSDKVersion()
-      val runtimeVersionObject = rawManifest.getRuntimeVersion()
-      if (runtimeVersionObject != null) {
-        if (runtimeVersionObject is String) {
-          runtimeVersion = runtimeVersionObject
-        } else if (runtimeVersionObject is JSONObject) {
-          runtimeVersion = runtimeVersionObject.optString("android", runtimeVersion)
-        }
+      // Use the manifest's runtimeVersion if it is not null AND the config's runtimeVersion is not null
+      val rawRuntimeVersion = rawManifest.getRuntimeVersion()
+      if (rawRuntimeVersion != null && configuration.runtimeVersion != null) {
+          runtimeVersion = rawRuntimeVersion
       }
+
       val bundleUrl = Uri.parse(rawManifest.getBundleURL())
       val bundledAssets = rawManifest.getBundledAssets()
       return LegacyManifest(

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/raw/LegacyRawManifest.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/raw/LegacyRawManifest.kt
@@ -15,7 +15,11 @@ class LegacyRawManifest(json: JSONObject) : BaseLegacyRawManifest(json) {
   @Throws(JSONException::class)
   fun getReleaseId(): String = json.getString("releaseId")
 
-  fun getRuntimeVersion(): Any? = json.opt("runtimeVersion")
+  fun getRuntimeVersion(): String? = if (json.has("runtimeVersion")) {
+    json.getString("runtimeVersion")
+  } else {
+    null
+  }
 
   @Throws(JSONException::class)
   fun getBundledAssets(): JSONArray? = json.optJSONArray("bundledAssets")

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesLegacyUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesLegacyUpdate.m
@@ -46,18 +46,13 @@ static NSString * const EXUpdatesExpoTestDomain = @"expo.test";
 
   NSString *bundleUrlString = manifest.bundleUrl;
   NSArray *assets = manifest.bundledAssets ?: @[];
-
-  id runtimeVersion = manifest.runtimeVersion;
-  if (runtimeVersion && [runtimeVersion isKindOfClass:[NSDictionary class]]) {
-    id runtimeVersionIos = ((NSDictionary *)runtimeVersion)[@"ios"];
-    NSAssert([runtimeVersionIos isKindOfClass:[NSString class]], @"runtimeVersion['ios'] should be a string");
-    update.runtimeVersion = (NSString *)runtimeVersionIos;
-  } else if (runtimeVersion && [runtimeVersion isKindOfClass:[NSString class]]) {
-    update.runtimeVersion = (NSString *)runtimeVersion;
+  
+  // Use the manifest's runtimeVersion if it is not null AND the config's runtimeVersion is not null
+  if (manifest.runtimeVersion != nil && config.runtimeVersion != nil) {
+    update.runtimeVersion = manifest.runtimeVersion;
   } else {
-    NSString *sdkVersion = manifest.sdkVersion;
-    NSAssert(sdkVersion != nil, @"sdkVersion should not be null");
-    update.runtimeVersion = sdkVersion;
+    NSAssert(manifest.sdkVersion != nil, @"sdkVersion should not be null");
+    update.runtimeVersion = manifest.sdkVersion;
   }
 
   NSURL *bundleUrl = [NSURL URLWithString:bundleUrlString];

--- a/packages/expo-updates/ios/Tests/EXUpdatesLegacyUpdateTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesLegacyUpdateTests.m
@@ -175,4 +175,69 @@
   XCTAssertThrows([EXUpdatesLegacyUpdate updateWithLegacyManifest:manifest config:_config database:_database]);
 }
 
+- (void)testUpdateWithLegacyManifest_setsUpdateRuntimeAsSdkIfNoConfigRuntime
+{
+  NSString *sdkVersion = @"39.0.0";
+  EXUpdatesLegacyRawManifest *manifest = [[EXUpdatesLegacyRawManifest alloc] initWithRawManifestJSON:@{
+    @"runtimeVersion": @"hello",
+    @"sdkVersion": sdkVersion,
+    @"releaseId": @"0eef8214-4833-4089-9dff-b4138a14f196",
+    @"bundleUrl": @"https://url.to/bundle.js",
+    @"commitTime": @"2020-11-11T00:17:54.797Z"
+  }];
+  
+  EXUpdatesConfig *configWithNoRuntimeVersion = [EXUpdatesConfig configWithDictionary:@{
+    @"EXUpdatesURL": @"https://esamelson.github.io/self-hosting-test/ios-index.json",
+    @"EXUpdatesSDKVersion": sdkVersion
+  }];
+  
+  EXUpdatesUpdate *update = [EXUpdatesLegacyUpdate updateWithLegacyManifest:manifest config:configWithNoRuntimeVersion database:_database];
+  
+  XCTAssertEqualObjects(sdkVersion, update.runtimeVersion);
+}
+
+- (void)testUpdateWithLegacyManifest_setsUpdateRuntimeAsSdkIfNoManifestRuntime
+{
+  NSString *sdkVersion = @"39.0.0";
+  EXUpdatesLegacyRawManifest *manifest = [[EXUpdatesLegacyRawManifest alloc] initWithRawManifestJSON:@{
+    @"sdkVersion": sdkVersion,
+    @"releaseId": @"0eef8214-4833-4089-9dff-b4138a14f196",
+    @"bundleUrl": @"https://url.to/bundle.js",
+    @"commitTime": @"2020-11-11T00:17:54.797Z"
+  }];
+  
+  EXUpdatesConfig *configWithRuntimeVersion = [EXUpdatesConfig configWithDictionary:@{
+    @"EXUpdatesURL": @"https://esamelson.github.io/self-hosting-test/ios-index.json",
+    @"EXUpdatesSDKVersion": sdkVersion,
+    @"EXUpdatesRuntimeVersion": @"notEmpty"
+  }];
+  
+  EXUpdatesUpdate *update = [EXUpdatesLegacyUpdate updateWithLegacyManifest:manifest config:configWithRuntimeVersion database:_database];
+  
+  XCTAssertEqualObjects(sdkVersion, update.runtimeVersion);
+}
+
+- (void)testUpdateWithLegacyManifest_setsUpdateRuntimeAsRuntimeIfBothManifestRuntimeAndConfigRuntime
+{
+  NSString *sdkVersion = @"39.0.0";
+  NSString *runtimeVersion = @"hello";
+  EXUpdatesLegacyRawManifest *manifest = [[EXUpdatesLegacyRawManifest alloc] initWithRawManifestJSON:@{
+    @"runtimeVersion": runtimeVersion,
+    @"sdkVersion": sdkVersion,
+    @"releaseId": @"0eef8214-4833-4089-9dff-b4138a14f196",
+    @"bundleUrl": @"https://url.to/bundle.js",
+    @"commitTime": @"2020-11-11T00:17:54.797Z"
+  }];
+  
+  EXUpdatesConfig *configWithRuntimeVersion = [EXUpdatesConfig configWithDictionary:@{
+    @"EXUpdatesURL": @"https://esamelson.github.io/self-hosting-test/ios-index.json",
+    @"EXUpdatesSDKVersion": sdkVersion,
+    @"EXUpdatesRuntimeVersion": @"notEmpty"
+  }];
+  
+  EXUpdatesUpdate *update = [EXUpdatesLegacyUpdate updateWithLegacyManifest:manifest config:configWithRuntimeVersion database:_database];
+  
+  XCTAssertEqualObjects(runtimeVersion, update.runtimeVersion);
+}
+
 @end


### PR DESCRIPTION
# Why

We want expo-updates to optionally use runtime version instead of sdk version. This will allow it to work with EAS build.

# How

This PR makes it so that an app sets a newly downloaded updates runtimeVersion to be the  manifests runtimeVersion if both the manifest has a runtimeVersion field and the config has a runtimeVersion (indicating a request for an rtv was made). Otherwise the update's runtimeVersion is set to the manifest's sdkVersion, as before.

It's important to require the config be configured correctly in addition to the manifest as a user may start bumping the rtv without touching the sdk version and we don't want old "sdk-clients" to get bricked by incompatible rtv updates.

# Test Plan

Tested iOS and Android clients against https://github.com/expo/universe/pull/7663 running on a local docker db 

- EXPO_SDK_VERSION - confirmed both of the following cases set the associated update entity's runtime version to the sdk version and the app updated:
  - published with out rtv
  - published with rtv
  
- EXPO_RUNTIME_VERSION
  - published with out rtv - no change to app, as the app is looking for updates published with an rtv
  - published with rtv - app updated successfully and the associated entity's runtime version was the runtime version.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).