### PR TITLE
[client] Fix ExponentKernel.sdkVersions type inference in home

### DIFF
--- a/home/kernel/Kernel.ts
+++ b/home/kernel/Kernel.ts
@@ -13,7 +13,9 @@ export enum ExpoClientReleaseType {
   APPLE_APP_STORE = 'APPLE_APP_STORE',
 }
 
-export const sdkVersions: string = NativeKernel.sdkVersions;
+export const sdkVersions: string = Array.isArray(NativeKernel.sdkVersions)
+  ? NativeKernel.sdkVersions.join(',')
+  : NativeKernel.sdkVersions;
 
 export const iosClientReleaseType: ExpoClientReleaseType =
   NativeKernel.IOSClientReleaseType || ExpoClientReleaseType.UNKNOWN;

--- a/home/kernel/MockKernel.ts
+++ b/home/kernel/MockKernel.ts
@@ -10,7 +10,7 @@ const STORAGE_PREFIX = '@@expo@@';
  * kernel module and use this implementation only on web.
  */
 export default {
-  sdkVersions: [] as string[],
+  sdkVersions: '',
 
   async getDevMenuSettingsAsync(): Promise<null> {
     return null;


### PR DESCRIPTION
# Why

https://github.com/expo/expo/commit/c3f10bd532fcd0e09815ba9feb70ccf94b3bf314 erroneously changed this to be a string in typescript since that's what android exports:
- https://github.com/expo/expo/blame/master/android/expoview/src/main/java/host/exp/exponent/modules/ExponentKernelModule.java#L68
- https://github.com/expo/expo/blob/master/android/expoview/src/main/java/host/exp/exponent/Constants.java#L48

The issue is that on iOS this constant is an array: https://github.com/expo/expo/blob/master/ios/Exponent/Kernel/DevSupport/EXHomeModule.m#L51

So, the actual type of the exported constant is `string | string[]`. We can't change/correct the type since there could be apps in the wild only using a single platform and expecting the type not to change.

# How

Change code to check if it is an array and if so normalize it to a comma-separated string.

# Test Plan

Run home on iOS, navigate to experience page in profile, no longer see crash.