### PR TITLE
[bare-expo][android] Configure metro to download assets specified in the NCL

### DIFF
--- a/apps/bare-expo/metro.config.js
+++ b/apps/bare-expo/metro.config.js
@@ -25,6 +25,12 @@ module.exports = {
           req.url = req.url.replace(testSuiteAssets, '/assets/../test-suite/assets/');
         }
 
+        const nclAssets = '/native-component-list/';
+
+        if (req.url.startsWith(nclAssets)) {
+          req.url = req.url.replace(nclAssets, '/assets/../native-component-list/');
+        }
+
         return middleware(req, res, next);
       };
     },


### PR DESCRIPTION
# Why

Fixes:
```
[Glide] Can't load image from:
http://10.0.2.2:8081/assets/../native-component-list/assets/images/exponent-icon@3x.png?platform=android&hash=8f45a32605ae84a1e421ae600c9f43f7
```
When an asset is imported outside the project root, it has the wrong path on Android.  So to fix it we need to change the path via `metro.config.js`. 

# How

Configured metro to download assets specified in the NCL which is outside of the bare-expo folder.

# Test Plan

- bare-expo ✅

Icons are visible:
![image](https://user-images.githubusercontent.com/9578601/122221993-1f538580-ceb2-11eb-9987-32619f660741.png)

Local assets are also visible:
![image](https://user-images.githubusercontent.com/9578601/122222077-32665580-ceb2-11eb-9954-d8c2d77b68c8.png)

