### PR TITLE
[ios] Add dummy Swift file to native iOS tests

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -1267,7 +1267,7 @@ SPEC CHECKSUMS:
   EXSplashScreen: da00ad1d61c395c5c81b252c5987e8f83cba230a
   EXSQLite: faed80cf1f7ec5a116c44aae3ca9abff7315553b
   EXStoreReview: 40674cc897a6d7fd249969b86d1833f67b99170a
-  EXStructuredHeaders: 8b778f4e82ec7b5fb29dc69748f32bc674dbe644
+  EXStructuredHeaders: 384ccdf0c09ed0be8fc73d4b2d70e436cd195975
   EXTaskManager: 91fef764a2ec7690aa8070f862098df064facdc4
   EXTrackingTransparency: 2ac354968ed9167a8c48fef27d051624c66eed7a
   EXUpdatesInterface: 8e4f28434a2e6a75803c4ea0ab12cfb07ebb3438

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -4044,10 +4044,10 @@ SPEC CHECKSUMS:
   EXSplashScreen: da00ad1d61c395c5c81b252c5987e8f83cba230a
   EXSQLite: faed80cf1f7ec5a116c44aae3ca9abff7315553b
   EXStoreReview: 40674cc897a6d7fd249969b86d1833f67b99170a
-  EXStructuredHeaders: 8b778f4e82ec7b5fb29dc69748f32bc674dbe644
+  EXStructuredHeaders: 384ccdf0c09ed0be8fc73d4b2d70e436cd195975
   EXTaskManager: 91fef764a2ec7690aa8070f862098df064facdc4
   EXTrackingTransparency: 2ac354968ed9167a8c48fef27d051624c66eed7a
-  EXUpdates: 68e477fcbcff743d197df2c065cb7b0ee97eb3e7
+  EXUpdates: 555bae578b14cfd76cc9e46cbd0a010dc6edddd2
   EXUpdatesInterface: 8e4f28434a2e6a75803c4ea0ab12cfb07ebb3438
   EXVideoThumbnails: f8a7d2330578131361c0a4f6e981a6e58baf1290
   EXWebBrowser: 76783ba5dcb8699237746ecf41a9643d428a4cc5

--- a/packages/expo-structured-headers/ios/EXStructuredHeaders.podspec
+++ b/packages/expo-structured-headers/ios/EXStructuredHeaders.podspec
@@ -23,6 +23,6 @@ Pod::Spec.new do |s|
   end
 
   s.test_spec 'Tests' do |test_spec|
-    test_spec.source_files = 'Tests/*.{h,m}'
+    test_spec.source_files = 'Tests/*.{h,m,swift}'
   end
 end

--- a/packages/expo-structured-headers/ios/Tests/dummy.swift
+++ b/packages/expo-structured-headers/ios/Tests/dummy.swift
@@ -1,0 +1,3 @@
+// This dummy Swift file is to persuade Xcode to include Swift runtime,
+// which is required when one of the dependency has some Swift code.
+// Read more here: https://github.com/CocoaPods/CocoaPods/issues/7170#issuecomment-339815814

--- a/packages/expo-updates/ios/EXUpdates.podspec
+++ b/packages/expo-updates/ios/EXUpdates.podspec
@@ -31,6 +31,6 @@ Pod::Spec.new do |s|
   end
 
   s.test_spec 'Tests' do |test_spec|
-    test_spec.source_files = 'Tests/*.{h,m}'
+    test_spec.source_files = 'Tests/*.{h,m,swift}'
   end
 end

--- a/packages/expo-updates/ios/Tests/dummy.swift
+++ b/packages/expo-updates/ios/Tests/dummy.swift
@@ -1,0 +1,3 @@
+// This dummy Swift file is to persuade Xcode to include Swift runtime,
+// which is required when one of the dependency has some Swift code.
+// Read more here: https://github.com/CocoaPods/CocoaPods/issues/7170#issuecomment-339815814


### PR DESCRIPTION
# Why

Preliminary to #13272 
Because of test specs nature, they need to have at least one `*.swift` file to include Swift runtime and link the dependency that uses Swift 🤷‍♂️ See workaround here https://github.com/CocoaPods/CocoaPods/issues/7170#issuecomment-339815814

# How

Updated test specs in `expo-structured-headers` and `expo-updates` to include newly added `dummy.swift` and ran `et pod-install --force` to reinstall pods

# Test Plan

CI job passes (it's been failing in #13272 before I applied this change)
