### PR TITLE
[expo-updates] backport rtv with dual update server assumption

### DIFF
--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/manifest/LegacyManifestTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/manifest/LegacyManifestTest.kt
@@ -214,54 +214,30 @@ class LegacyManifestTest {
     LegacyManifest.fromLegacyRawManifest(manifest, createConfig())
   }
 
-  private fun createConfig(): UpdatesConfiguration {
-    val configMap = HashMap<String, Any>()
-    configMap["updateUrl"] = Uri.parse("https://exp.host/@test/test")
-    return UpdatesConfiguration().loadValuesFromMap(configMap)
-  }
-
-  @Test
-  @Throws(JSONException::class)
-  fun testFromLegacyManifestJson_setsUpdateRuntimeAsSdkIfNoConfigRuntime() {
-    val legacyManifestJsonWithRuntimeVersion =
-      "{\"runtimeVersion\":\"hello\",\"sdkVersion\":\"39.0.0\",\"releaseId\":\"0eef8214-4833-4089-9dff-b4138a14f196\",\"commitTime\":\"2020-11-11T00:17:54.797Z\",\"bundleUrl\":\"https://url.to/bundle.js\"}"
-    val rawManifest = LegacyRawManifest(JSONObject(legacyManifestJsonWithRuntimeVersion))
-    val configWithoutRuntimeVersion = createConfig()
-
-    val newLegacyManifest = LegacyManifest.fromLegacyRawManifest(rawManifest, configWithoutRuntimeVersion)
-    Assert.assertEquals("39.0.0",newLegacyManifest.updateEntity.runtimeVersion)
-  }
-
   @Test
   @Throws(JSONException::class)
   fun testFromLegacyManifestJson_setsUpdateRuntimeAsSdkIfNoManifestRuntime() {
     val legacyManifestJsonWithoutRuntimeVersion =
       "{\"sdkVersion\":\"39.0.0\",\"releaseId\":\"0eef8214-4833-4089-9dff-b4138a14f196\",\"commitTime\":\"2020-11-11T00:17:54.797Z\",\"bundleUrl\":\"https://url.to/bundle.js\"}"
     val rawManifest = LegacyRawManifest(JSONObject(legacyManifestJsonWithoutRuntimeVersion))
-
-    val configMap = HashMap<String, Any>()
-    configMap["updateUrl"] = Uri.parse("https://exp.host/@test/test")
-    configMap["runtimeVersion"] = "nonEmpty"
-    val configWithRuntimeVersion = UpdatesConfiguration().loadValuesFromMap(configMap)
-
-    val newLegacyManifest = LegacyManifest.fromLegacyRawManifest(rawManifest, configWithRuntimeVersion)
+    val newLegacyManifest = LegacyManifest.fromLegacyRawManifest(rawManifest, createConfig())
     Assert.assertEquals("39.0.0",newLegacyManifest.updateEntity.runtimeVersion)
   }
 
   @Test
   @Throws(JSONException::class)
-  fun testFromLegacyManifestJson_setsUpdateRuntimeAsRuntimeIfBothManifestRuntimeAndConfigRuntime() {
+  fun testFromLegacyManifestJson_setsUpdateRuntimeAsRuntimeIfManifestRuntime() {
     val runtimeVersion = "hello";
     val legacyManifestJsonWithRuntimeVersion =
       String.format("{\"runtimeVersion\":\"%s\",\"sdkVersion\":\"39.0.0\",\"releaseId\":\"0eef8214-4833-4089-9dff-b4138a14f196\",\"commitTime\":\"2020-11-11T00:17:54.797Z\",\"bundleUrl\":\"https://url.to/bundle.js\"}",runtimeVersion)
     val rawManifest = LegacyRawManifest(JSONObject(legacyManifestJsonWithRuntimeVersion))
+    val newLegacyManifest = LegacyManifest.fromLegacyRawManifest(rawManifest, createConfig())
+    Assert.assertEquals(runtimeVersion,newLegacyManifest.updateEntity.runtimeVersion)
+  }
 
+  private fun createConfig(): UpdatesConfiguration {
     val configMap = HashMap<String, Any>()
     configMap["updateUrl"] = Uri.parse("https://exp.host/@test/test")
-    configMap["runtimeVersion"] = "nonEmpty"
-    val configWithRuntimeVersion = UpdatesConfiguration().loadValuesFromMap(configMap)
-
-    val newLegacyManifest = LegacyManifest.fromLegacyRawManifest(rawManifest, configWithRuntimeVersion)
-    Assert.assertEquals(runtimeVersion,newLegacyManifest.updateEntity.runtimeVersion)
+    return UpdatesConfiguration().loadValuesFromMap(configMap)
   }
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/LegacyManifest.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/LegacyManifest.kt
@@ -107,7 +107,7 @@ class LegacyManifest private constructor(
         }
       }
 
-      val runtimeVersion = if (rawManifest.getRuntimeVersion() != null){
+      val runtimeVersion = if (rawManifest.getRuntimeVersion() != null) {
         rawManifest.getRuntimeVersion()
       } else {
         rawManifest.getSDKVersion()

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/LegacyManifest.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/LegacyManifest.kt
@@ -107,12 +107,7 @@ class LegacyManifest private constructor(
         }
       }
 
-      val runtimeVersion = if (rawManifest.getRuntimeVersion() != null) {
-        rawManifest.getRuntimeVersion()
-      } else {
-        rawManifest.getSDKVersion()
-      }
-
+      val runtimeVersion = rawManifest.getRuntimeVersion() ?: rawManifest.getSDKVersion()
       val bundleUrl = Uri.parse(rawManifest.getBundleURL())
       val bundledAssets = rawManifest.getBundledAssets()
       return LegacyManifest(

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/LegacyManifest.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/LegacyManifest.kt
@@ -106,11 +106,11 @@ class LegacyManifest private constructor(
           Date()
         }
       }
-      var runtimeVersion = rawManifest.getSDKVersion()
-      // Use the manifest's runtimeVersion if it is not null AND the config's runtimeVersion is not null
-      val rawRuntimeVersion = rawManifest.getRuntimeVersion()
-      if (rawRuntimeVersion != null && configuration.runtimeVersion != null) {
-          runtimeVersion = rawRuntimeVersion
+
+      val runtimeVersion = if (rawManifest.getRuntimeVersion() != null){
+        rawManifest.getRuntimeVersion()
+      } else {
+        rawManifest.getSDKVersion()
       }
 
       val bundleUrl = Uri.parse(rawManifest.getBundleURL())

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesLegacyUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesLegacyUpdate.m
@@ -47,8 +47,7 @@ static NSString * const EXUpdatesExpoTestDomain = @"expo.test";
   NSString *bundleUrlString = manifest.bundleUrl;
   NSArray *assets = manifest.bundledAssets ?: @[];
   
-  // Use the manifest's runtimeVersion if it is not null AND the config's runtimeVersion is not null
-  if (manifest.runtimeVersion != nil && config.runtimeVersion != nil) {
+  if (manifest.runtimeVersion != nil) {
     update.runtimeVersion = manifest.runtimeVersion;
   } else {
     NSAssert(manifest.sdkVersion != nil, @"sdkVersion should not be null");

--- a/packages/expo-updates/ios/Tests/EXUpdatesLegacyUpdateTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesLegacyUpdateTests.m
@@ -175,27 +175,6 @@
   XCTAssertThrows([EXUpdatesLegacyUpdate updateWithLegacyManifest:manifest config:_config database:_database]);
 }
 
-- (void)testUpdateWithLegacyManifest_setsUpdateRuntimeAsSdkIfNoConfigRuntime
-{
-  NSString *sdkVersion = @"39.0.0";
-  EXUpdatesLegacyRawManifest *manifest = [[EXUpdatesLegacyRawManifest alloc] initWithRawManifestJSON:@{
-    @"runtimeVersion": @"hello",
-    @"sdkVersion": sdkVersion,
-    @"releaseId": @"0eef8214-4833-4089-9dff-b4138a14f196",
-    @"bundleUrl": @"https://url.to/bundle.js",
-    @"commitTime": @"2020-11-11T00:17:54.797Z"
-  }];
-  
-  EXUpdatesConfig *configWithNoRuntimeVersion = [EXUpdatesConfig configWithDictionary:@{
-    @"EXUpdatesURL": @"https://esamelson.github.io/self-hosting-test/ios-index.json",
-    @"EXUpdatesSDKVersion": sdkVersion
-  }];
-  
-  EXUpdatesUpdate *update = [EXUpdatesLegacyUpdate updateWithLegacyManifest:manifest config:configWithNoRuntimeVersion database:_database];
-  
-  XCTAssertEqualObjects(sdkVersion, update.runtimeVersion);
-}
-
 - (void)testUpdateWithLegacyManifest_setsUpdateRuntimeAsSdkIfNoManifestRuntime
 {
   NSString *sdkVersion = @"39.0.0";
@@ -205,19 +184,13 @@
     @"bundleUrl": @"https://url.to/bundle.js",
     @"commitTime": @"2020-11-11T00:17:54.797Z"
   }];
-  
-  EXUpdatesConfig *configWithRuntimeVersion = [EXUpdatesConfig configWithDictionary:@{
-    @"EXUpdatesURL": @"https://esamelson.github.io/self-hosting-test/ios-index.json",
-    @"EXUpdatesSDKVersion": sdkVersion,
-    @"EXUpdatesRuntimeVersion": @"notEmpty"
-  }];
-  
-  EXUpdatesUpdate *update = [EXUpdatesLegacyUpdate updateWithLegacyManifest:manifest config:configWithRuntimeVersion database:_database];
+   
+  EXUpdatesUpdate *update = [EXUpdatesLegacyUpdate updateWithLegacyManifest:manifest config:_config database:_database];
   
   XCTAssertEqualObjects(sdkVersion, update.runtimeVersion);
 }
 
-- (void)testUpdateWithLegacyManifest_setsUpdateRuntimeAsRuntimeIfBothManifestRuntimeAndConfigRuntime
+- (void)testUpdateWithLegacyManifest_setsUpdateRuntimeAsRuntimeIfBothManifestRuntime
 {
   NSString *sdkVersion = @"39.0.0";
   NSString *runtimeVersion = @"hello";
@@ -228,14 +201,8 @@
     @"bundleUrl": @"https://url.to/bundle.js",
     @"commitTime": @"2020-11-11T00:17:54.797Z"
   }];
-  
-  EXUpdatesConfig *configWithRuntimeVersion = [EXUpdatesConfig configWithDictionary:@{
-    @"EXUpdatesURL": @"https://esamelson.github.io/self-hosting-test/ios-index.json",
-    @"EXUpdatesSDKVersion": sdkVersion,
-    @"EXUpdatesRuntimeVersion": @"notEmpty"
-  }];
-  
-  EXUpdatesUpdate *update = [EXUpdatesLegacyUpdate updateWithLegacyManifest:manifest config:configWithRuntimeVersion database:_database];
+   
+  EXUpdatesUpdate *update = [EXUpdatesLegacyUpdate updateWithLegacyManifest:manifest config:_config database:_database];
   
   XCTAssertEqualObjects(runtimeVersion, update.runtimeVersion);
 }


### PR DESCRIPTION
# Why

@esamelson noticed a tricky edge case for when a developer is transitioning from an sdk to an rtv build and is publishing updates to both of them.

The crux of the issue is that the update ID is assumed to uniquely specify the db row created by the client to track an update.

After discussion with @ide we decide to go make the server create 2 revision groups each publish.
 1. standard sdk only revision
 2. sdk + rtv revision
 
 Under this set up, the client will always set the database 'version' column to rtv if it is present in the manifest, sdk otherwise.
 
 Note: the sdk is kept in the second manifest as it is also important for compatibility with other expo client libraries.
 
# How

Changed to always set the database 'version' column to rtv if it is present in the manifest, sdk otherwise/

# Test Plan

updated tests, and did the same manual testing outlined: https://github.com/expo/expo/pull/13283

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).