### PR TITLE
Bump compare-urls to 3.0.0 (security flaw)

### DIFF
--- a/packages/expo-web-browser/CHANGELOG.md
+++ b/packages/expo-web-browser/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Updated `compare-urls` from `^2.0.0` to `^3.0.0`. ([#13309](https://github.com/expo/expo/pull/13309) by [@BigZ](https://github.com/BigZ))
+
 ## 10.0.1 — 2021-10-01
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-web-browser/package.json
+++ b/packages/expo-web-browser/package.json
@@ -36,7 +36,7 @@
     "preset": "expo-module-scripts"
   },
   "dependencies": {
-    "compare-urls": "^2.0.0",
+    "compare-urls": "^3.0.0",
     "expo-modules-core": "~0.4.2"
   },
   "devDependencies": {


### PR DESCRIPTION
# Why

security flaw reported in npm audit

# How
simple bump

# Test Plan
up to you

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).