### PR TITLE
[expo-updates] move update URL checks to later in update lifecycle

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- Improve behavior of dev client (with updates integration) when developer is logged out of expo-cli.
+- Improve behavior of dev client (with updates integration) when developer is logged out of expo-cli. ([#13310](https://github.com/expo/expo/pull/13310) by [@esamelson](https://github.com/esamelson))
 
 ### 💡 Others
 

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Improve behavior of dev client (with updates integration) when developer is logged out of expo-cli.
+
 ### 💡 Others
 
 ## 0.7.0 — 2021-06-16

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesConfiguration.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesConfiguration.java
@@ -220,8 +220,6 @@ public class UpdatesConfiguration {
     if (mScopeKey == null) {
       if (mUpdateUrl != null) {
         mScopeKey = getNormalizedUrlOrigin(mUpdateUrl);
-      } else {
-        throw new AssertionError("expo-updates must be configured with a valid update URL or scope key.");
       }
     }
   }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.java
@@ -276,6 +276,9 @@ public class UpdatesController {
     if (!mUpdatesConfiguration.isEnabled()) {
       mLauncher = new NoDatabaseLauncher(context, mUpdatesConfiguration);
     }
+    if (mUpdatesConfiguration.getUpdateUrl() == null || mUpdatesConfiguration.getScopeKey() == null) {
+      throw new AssertionError("expo-updates is enabled, but no valid URL is configured in AndroidManifest.xml. If you are making a release build for the first time, make sure you have run `expo publish` at least once.");
+    }
     if (mUpdatesDirectory == null) {
       mLauncher = new NoDatabaseLauncher(context, mUpdatesConfiguration, mUpdatesDirectoryException);
       mIsEmergencyLaunch = true;

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.java
@@ -56,7 +56,7 @@ public class UpdatesDevLauncherController implements UpdatesInterface {
     UpdatesConfiguration updatesConfiguration = new UpdatesConfiguration()
             .loadValuesFromMetadata(context)
             .loadValuesFromMap(configuration);
-    if (updatesConfiguration.getUpdateUrl() == null) {
+    if (updatesConfiguration.getUpdateUrl() == null || updatesConfiguration.getScopeKey() == null) {
       callback.onFailure(new Exception("Failed to load update: UpdatesConfiguration object must include a valid update URL"));
       return;
     }

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesAppController.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesAppController.m
@@ -113,6 +113,11 @@ static NSString * const EXUpdatesErrorEventName = @"error";
                                    reason:@"expo-updates is enabled, but no valid URL is configured under EXUpdatesURL. If you are making a release build for the first time, make sure you have run `expo publish` at least once."
                                  userInfo:@{}];
   }
+  if (!_config.scopeKey) {
+    @throw [NSException exceptionWithName:NSInternalInconsistencyException
+                                   reason:@"expo-updates was configured with no scope key. Make sure a valid URL is configured under EXUpdatesURL."
+                                 userInfo:@{}];
+  }
 
   _isStarted = YES;
 

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.m
@@ -100,10 +100,6 @@ static NSString * const EXUpdatesConfigNeverString = @"NEVER";
   if (!_scopeKey) {
     if (_updateUrl) {
       _scopeKey = [[self class] normalizedURLOrigin:_updateUrl];
-    } else {
-      @throw [NSException exceptionWithName:NSInternalInconsistencyException
-                                     reason:@"expo-updates must be configured with a valid update URL or scope key."
-                                   userInfo:@{}];
     }
   }
 

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesDevLauncherController.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesDevLauncherController.m
@@ -60,7 +60,7 @@ typedef NS_ENUM(NSInteger, EXUpdatesDevLauncherErrorCode) {
   EXUpdatesAppController *controller = EXUpdatesAppController.sharedInstance;
   EXUpdatesConfig *updatesConfiguration = [EXUpdatesConfig configWithExpoPlist];
   [updatesConfiguration loadConfigFromDictionary:configuration];
-  if (!updatesConfiguration.updateUrl) {
+  if (!updatesConfiguration.updateUrl || !updatesConfiguration.scopeKey) {
     errorBlock([NSError errorWithDomain:EXUpdatesDevLauncherControllerErrorDomain code:EXUpdatesDevLauncherErrorCodeInvalidUpdateURL userInfo:@{NSLocalizedDescriptionKey: @"Failed to load update: configuration object must include a valid update URL"}]);
     return;
   }


### PR DESCRIPTION
# Why

fixes ENG-1371

The crash described there is coming from the fact that no update URL is automatically configured by `expo prebuild` if the developer is signed out of expo-cli. But in the dev client case, we currently don't need an update URL to be configured in the native configuration files, since it's provided at runtime.

# How

Move the check for a valid update URL out of the creation of the initial configuration object, and into the `start` method where it's actually used. This allows us to provide our own update URL at runtime in the dev client, without first triggering the exception.

# Test Plan

Ran the following:
```
expo logout
expo init (blank)
yarn add expo-dev-client@next expo-updates@next
expo prebuild
```
Ensured no update URL was configured in Expo.plist/AndroidManifest.xml, then ran the following manual tests on both platforms, ensuring they failed before these changes and succeeded after:
- [x] Open a project in development, it doesn't crash
- [x] Complete the dev-client/updates integration by following [these instructions](https://github.com/expo/expo/pull/13197/files) then rebuild, open a project in development, it doesn't crash
- [x] Open a project in production, it doesn't crash

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).