### PR TITLE
[babel-preset-expo] Improve detection for NextJS 11 as a bundler

### DIFF
--- a/packages/babel-preset-expo/index.js
+++ b/packages/babel-preset-expo/index.js
@@ -118,7 +118,7 @@ function getBundler(caller) {
       // NextJS 11
       return 'webpack';
     } else if (name === 'babel-loader') {
-      // NextJS <10
+      // expo/webpack-config, gatsby, storybook, and next.js <10
       return 'webpack';
     }
   }

--- a/packages/babel-preset-expo/index.js
+++ b/packages/babel-preset-expo/index.js
@@ -114,8 +114,11 @@ function getBundler(caller) {
     if (name === 'metro') {
       // This is a hack to determine if metro is being used.
       return 'metro';
+    } else if (name === 'next-babel-turbo-loader') {
+      // NextJS 11
+      return 'webpack';
     } else if (name === 'babel-loader') {
-      // This won't work in all cases as tools like Next.js could change the name of their loader.
+      // NextJS <10
       return 'webpack';
     }
   }


### PR DESCRIPTION
# Why

NextJS 11 changed the name of their bundler

First in a series of PRs to add support for NextJS 11  https://github.com/expo/expo-cli/issues/3579

# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).