### PR TITLE
[docs] Add dev client to top level docs

### DIFF
--- a/docs/components/DocumentationHeader.tsx
+++ b/docs/components/DocumentationHeader.tsx
@@ -19,7 +19,7 @@ import { X } from './icons/X';
 
 import { paragraph } from '~/components/base/typography';
 import AlgoliaSearch from '~/components/plugins/AlgoliaSearch';
-import { isEasReleased } from '~/constants/FeatureFlags';
+import { shouldShowFeaturePreviewLink } from '~/constants/FeatureFlags';
 import * as Constants from '~/constants/theme';
 
 const STYLES_LOGO = css`
@@ -388,9 +388,13 @@ export default class DocumentationHeader extends React.PureComponent<Props> {
               <span css={SECTION_LINK_TEXT}>Guides</span>
             </a>
           </Link>
-          {isEasReleased ? (
-            <Link href="/eas" passHref>
-              <a css={[SECTION_LINK, this.props.activeSection === 'eas' && SECTION_LINK_ACTIVE]}>
+          {shouldShowFeaturePreviewLink() ? (
+            <Link href="/feature-preview" passHref>
+              <a
+                css={[
+                  SECTION_LINK,
+                  this.props.activeSection === 'featurePreview' && SECTION_LINK_ACTIVE,
+                ]}>
                 <span css={SECTION_LINK_TEXT}>Feature Preview</span>
               </a>
             </Link>

--- a/docs/components/DocumentationPage.tsx
+++ b/docs/components/DocumentationPage.tsx
@@ -156,8 +156,10 @@ export default class DocumentationPage extends React.Component<Props, State> {
     );
   };
 
-  private isEasPath = () => {
-    return some(navigation.easDirectories, name => this.props.url.pathname.startsWith(`/${name}`));
+  private isFeaturePreviewPath = () => {
+    return some(navigation.featurePreviewDirectories, name =>
+      this.props.url.pathname.startsWith(`/${name}`)
+    );
   };
 
   private isPreviewPath = () => {
@@ -209,8 +211,8 @@ export default class DocumentationPage extends React.Component<Props, State> {
       return 'general';
     } else if (this.isGettingStartedPath()) {
       return 'starting';
-    } else if (this.isEasPath()) {
-      return 'eas';
+    } else if (this.isFeaturePreviewPath()) {
+      return 'featurePreview';
     } else if (this.isPreviewPath()) {
       return 'preview';
     }

--- a/docs/constants/FeatureFlags.js
+++ b/docs/constants/FeatureFlags.js
@@ -1,3 +1,14 @@
+// If you change the flag value, you need to restart the dev server.
+const flags = {
+  isEasInFeaturePreview: true,
+  isDevClientInFeaturePreview: false,
+};
+
+const shouldShowFeaturePreviewLink = () => {
+  return Object.values(flags).some(isInPreview => isInPreview);
+};
+
 module.exports = {
-  isEasReleased: true,
+  ...flags,
+  shouldShowFeaturePreviewLink,
 };

--- a/docs/constants/FeatureFlags.js
+++ b/docs/constants/FeatureFlags.js
@@ -1,7 +1,7 @@
 // If you change the flag value, you need to restart the dev server.
 const flags = {
   isEasInFeaturePreview: true,
-  isDevClientInFeaturePreview: false,
+  isDevClientInFeaturePreview: true,
 };
 
 const shouldShowFeaturePreviewLink = () => {

--- a/docs/constants/navigation-data.js
+++ b/docs/constants/navigation-data.js
@@ -4,7 +4,7 @@ const fm = require('front-matter');
 const fs = require('fs-extra');
 const path = require('path');
 
-const { isEasReleased } = require('./FeatureFlags');
+const { isEasInFeaturePreview, isDevClientInFeaturePreview } = require('./FeatureFlags');
 
 // TODO(brentvatne): move this to navigation.js so it's all in one place!
 // Map directories in a version directory to a section name
@@ -29,6 +29,7 @@ const DIR_MAPPING = {
   preview: 'Preview',
   build: 'Start Building',
   eas: 'Feature Preview',
+  'feature-preview': 'Feature Preview',
   'app-signing': 'App Signing',
   'build-reference': 'Reference',
   submit: 'EAS Submit',
@@ -132,21 +133,20 @@ const referenceDirectories = fs
 // A manual list of directories to pull in to the getting started tutorial
 const startingDirectories = ['introduction', 'get-started', 'tutorial', 'next-steps'];
 
-let previewDirectories, easDirectories;
-if (isEasReleased) {
-  easDirectories = ['eas', 'build', 'app-signing', 'build-reference', 'submit'];
-  previewDirectories = ['preview', 'clients'];
+const easDirectories = ['eas', 'build', 'app-signing', 'build-reference', 'submit'];
+let previewDirectories = ['preview']; // a private preview section which isn't linked in the documentation
+let featurePreviewDirectories = ['feature-preview']; // a public preview section which is linked under `Feature Preview`
+
+if (isEasInFeaturePreview) {
+  featurePreviewDirectories = [...featurePreviewDirectories, ...easDirectories];
 } else {
-  easDirectories = [];
-  previewDirectories = [
-    'eas',
-    'preview',
-    'build',
-    'app-signing',
-    'build-reference',
-    'submit',
-    'clients',
-  ];
+  previewDirectories = [...previewDirectories, ...easDirectories];
+}
+
+if (isDevClientInFeaturePreview) {
+  featurePreviewDirectories = [...featurePreviewDirectories, 'clients'];
+} else {
+  previewDirectories = [...previewDirectories, 'clients'];
 }
 
 // Find any directories that aren't reference or starting directories. Also exclude the api
@@ -160,14 +160,14 @@ const generalDirectories = fs
     name =>
       name !== 'api' &&
       name !== 'versions' &&
-      ![...startingDirectories, ...previewDirectories, ...easDirectories].includes(name)
+      ![...startingDirectories, ...previewDirectories, ...featurePreviewDirectories].includes(name)
   );
 
 module.exports = {
   startingDirectories,
   generalDirectories,
   previewDirectories,
-  easDirectories,
+  featurePreviewDirectories,
   starting: startingDirectories.map(directory =>
     generateGeneralNavLinks(`${ROOT_PATH_PREFIX}/${directory}`)
   ),
@@ -177,7 +177,9 @@ module.exports = {
   preview: previewDirectories.map(directory =>
     generateGeneralNavLinks(`${ROOT_PATH_PREFIX}/${directory}`)
   ),
-  eas: easDirectories.map(directory => generateGeneralNavLinks(`${ROOT_PATH_PREFIX}/${directory}`)),
+  featurePreview: featurePreviewDirectories.map(directory =>
+    generateGeneralNavLinks(`${ROOT_PATH_PREFIX}/${directory}`)
+  ),
   reference: referenceDirectories.reduce(
     (obj, version) => ({
       ...obj,

--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -489,17 +489,17 @@ const sortedReference = Object.assign(
 const sortedGeneral = groupNav(sortNav(prevaledNavigationData.general));
 const sortedStarting = groupNav(sortNav(prevaledNavigationData.starting));
 const sortedPreview = groupNav(sortNav(prevaledNavigationData.preview));
-const sortedEas = groupNav(sortNav(prevaledNavigationData.eas));
+const sortedFeaturePreview = groupNav(sortNav(prevaledNavigationData.featurePreview));
 
 module.exports = {
   generalDirectories: prevaledNavigationData.generalDirectories,
   startingDirectories: prevaledNavigationData.startingDirectories,
   previewDirectories: prevaledNavigationData.previewDirectories,
-  easDirectories: prevaledNavigationData.easDirectories,
+  featurePreviewDirectories: prevaledNavigationData.featurePreviewDirectories,
   starting: sortedStarting,
   general: sortedGeneral,
   preview: sortedPreview,
-  eas: sortedEas,
+  featurePreview: sortedFeaturePreview,
   reference: { ...sortedReference, latest: sortedReference['v' + packageVersion] },
   hiddenSections,
 };

--- a/docs/pages/eas/index.md
+++ b/docs/pages/eas/index.md
@@ -1,5 +1,5 @@
 ---
-title: Feature Preview
+title: Expo Application Services
 ---
 
 Expo Application Services (EAS) is the next-generation of services that unlock new opportunities for improving your apps and development processes.

--- a/docs/pages/feature-preview/index.md
+++ b/docs/pages/feature-preview/index.md
@@ -2,9 +2,16 @@
 title: Feature Preview
 ---
 
-The feature preview of the documentation is oriented towards new things which were added to the Expo ecosystem.
+### What does Feature Preview mean?
 
-Features available as a preview:
+We decided to publish some of our new features as a preview to get feedback from you. It doesn't mean that those functionalities are in the "beta". As developers, we are skeptical of relying on anything labeled a "beta", knowing it is sometimes applied to projects that are early in development, incomplete, or may not receive long-term support. Expo offers you tested and adapted by many teams solutions to help you with day-to-day work. The main reason why those features were published as a preview is to hear your feedback to make them better. We treat that period as a time to decided what developers expected from our services. Preview also means that we expect to need to make breaking changes in those packages.
 
-- Expo Application Services. [Learn more](/eas)
-- Development Client. [Learn more](/clients/introduction)
+### Features in preview
+
+- **Expo Application Services (EAS)**. [Learn more](/eas):
+
+  - **EAS Build**: Compile and sign Android/iOS apps with custom native code in the cloud. Easily distribute your apps to testers without waiting for TestFlight or Google Play. [Learn more](/build/introduction.md).
+
+  - **EAS Submit**: Upload your app to the Apple App Store or Google Play Store from the cloud with one CLI command. [Learn more](/submit/introduction.md).
+
+- **Development Client**: When you need to customize your project beyond the standard runtime provided in Expo Go, you can create a custom development client for your application, install it on your phone, and continue developing. [Learn more](clients/introduction).

--- a/docs/pages/feature-preview/index.md
+++ b/docs/pages/feature-preview/index.md
@@ -1,0 +1,10 @@
+---
+title: Feature Preview
+---
+
+The feature preview of the documentation is oriented towards new things which were added to the Expo ecosystem.
+
+Features available as a preview:
+
+- Expo Application Services. [Learn more](/eas)
+- Development Client. [Learn more](/clients/introduction)

--- a/docs/pages/feature-preview/index.md
+++ b/docs/pages/feature-preview/index.md
@@ -4,7 +4,7 @@ title: Feature Preview
 
 ### What does Feature Preview mean?
 
-We decided to publish some of our new features as a preview to get feedback from you. It doesn't mean that those functionalities are in the "beta". As developers, we are skeptical of relying on anything labeled a "beta", knowing it is sometimes applied to projects that are early in development, incomplete, or may not receive long-term support. Expo offers you tested and adapted by many teams solutions to help you with day-to-day work. The main reason why those features were published as a preview is to hear your feedback to make them better. We treat that period as a time to decided what developers expected from our services. Preview also means that we expect to need to make breaking changes in those packages.
+We decided to publish some of our new features as a preview to get feedback from you. It doesn't mean that those functionalities are in the "beta". As developers, we are skeptical of relying on anything labeled a "beta", knowing it is sometimes applied to projects that are early in development, incomplete, or may not receive long-term support. Expo offers you solutions that have been tested and adopted by many teams to help you with day-to-day work. The reason those features are published as a preview is to hear your feedback to make them better. We treat that period as a time to better understand what developers expect from our services and shape them to fit your needs. While we make those improvements, we expect we will need to make breaking changes in those packages more frequently than we do in the Expo SDK.
 
 ### Features in preview
 
@@ -14,4 +14,4 @@ We decided to publish some of our new features as a preview to get feedback from
 
   - **EAS Submit**: Upload your app to the Apple App Store or Google Play Store from the cloud with one CLI command. [Learn more](/submit/introduction.md).
 
-- **Development Client**: When you need to customize your project beyond the standard runtime provided in Expo Go, you can create a custom development client for your application, install it on your phone, and continue developing. [Learn more](clients/introduction).
+- **expo-dev-client**: When you need to customize your project beyond the standard runtime provided in Expo Go, you can create a custom development client for your application, install it on your phone, and continue developing. [Learn more](clients/introduction.md).


### PR DESCRIPTION
# Why

Closes ENG-1326.

# How

Redirected to a new page when the user selects the `Feature Preview` section.
Moved dev client documentation into the `Feature Preview` section.

# Test Plan

![Screenshot 2021-06-18 at 14 47 19](https://user-images.githubusercontent.com/9578601/122563651-bd775500-d044-11eb-8ef9-52e1e7c95ae7.png)

![Screenshot 2021-06-18 at 14 47 27](https://user-images.githubusercontent.com/9578601/122563659-bfd9af00-d044-11eb-84cc-4402eb413907.png)
