### PR TITLE
[camera] fix camera video codec validation

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Update video codec validation to properly reject an invalid codec option. ([#13341](https://github.com/expo/expo/pull/13341) by [@ajsmth](https://github.com/ajsmth))
+
 ### 💡 Others
 
 ## 11.1.1 — 2021-06-16


### PR DESCRIPTION
# Why

The record session block was still being executed after the rejection callback had already fired - this PR prevents this from happening 

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

The check is done inside the async block to ensure the state of `movieFileOutput` is accurate. If it's nil then the session is invalid and we shouldn't continue with the record session

# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->

Test suite for Camera passes

