### PR TITLE
[expo-dev-launcher][expo-updates] reset updates module state on each load

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- Reset Updates module state on each dev client load. ([#13346](https://github.com/expo/expo/pull/13346) by [@esamelson](https://github.com/esamelson))
+
 ### 🎉 New features
 
 - Added expo-updates integration to config plugin. ([#13198](https://github.com/expo/expo/pull/13198) by [@esamelson](https://github.com/esamelson))

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
@@ -78,6 +78,8 @@ class DevLauncherController private constructor(
       val manifestParser = DevLauncherManifestParser(httpClient, url)
       val appIntent = createAppIntent()
 
+      updatesInterface?.reset()
+
       val appLoader = if (!manifestParser.isManifestUrl()) {
         // It's (maybe) a raw React Native bundle
         DevLauncherReactNativeAppLoader(url, appHost, context)

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -282,6 +282,10 @@ NSString *fakeLauncherBundleUrl = @"embedded://EXDevLauncher/dummy";
     }
   };
 
+  if (_updatesInterface) {
+    [_updatesInterface reset];
+  }
+
   EXDevLauncherManifestParser *manifestParser = [[EXDevLauncherManifestParser alloc] initWithURL:expoUrl session:[NSURLSession sharedSession]];
   [manifestParser isManifestURLWithCompletion:^(BOOL isManifestURL) {
     if (!isManifestURL) {

--- a/packages/expo-updates-interface/CHANGELOG.md
+++ b/packages/expo-updates-interface/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- Added method to reset Updates module state. ([#13346](https://github.com/expo/expo/pull/13346) by [@esamelson](https://github.com/esamelson))
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/packages/expo-updates-interface/android/src/main/java/expo/modules/updatesinterface/UpdatesInterface.java
+++ b/packages/expo-updates-interface/android/src/main/java/expo/modules/updatesinterface/UpdatesInterface.java
@@ -30,5 +30,6 @@ public interface UpdatesInterface {
     String getLaunchAssetPath();
   }
 
+  void reset();
   void fetchUpdateWithConfiguration(HashMap<String, Object> configuration, Context context, UpdateCallback callback);
 }

--- a/packages/expo-updates-interface/android/src/main/java/expo/modules/updatesinterface/UpdatesInterface.java
+++ b/packages/expo-updates-interface/android/src/main/java/expo/modules/updatesinterface/UpdatesInterface.java
@@ -31,5 +31,6 @@ public interface UpdatesInterface {
   }
 
   void reset();
+
   void fetchUpdateWithConfiguration(HashMap<String, Object> configuration, Context context, UpdateCallback callback);
 }

--- a/packages/expo-updates-interface/ios/EXUpdatesInterface/EXUpdatesExternalInterface.h
+++ b/packages/expo-updates-interface/ios/EXUpdatesInterface/EXUpdatesExternalInterface.h
@@ -24,6 +24,8 @@ typedef BOOL (^EXUpdatesManifestBlock) (NSDictionary *manifest);
 
 - (NSURL *)launchAssetURL;
 
+- (void)reset;
+
 - (void)fetchUpdateWithConfiguration:(NSDictionary *)configuration
                           onManifest:(EXUpdatesManifestBlock)manifestBlock
                             progress:(EXUpdatesProgressBlock)progressBlock

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- Added reset method to UpdatesDevLauncherController. ([#13346](https://github.com/expo/expo/pull/13346) by [@esamelson](https://github.com/esamelson))
+
 ### 🎉 New features
 
 - Use stable manifest ID where applicable. ([#12964](https://github.com/expo/expo/pull/12964) by [@wschurman](https://github.com/wschurman))

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.java
@@ -216,6 +216,9 @@ public class UpdatesController {
   }
 
   public UpdateEntity getLaunchedUpdate() {
+    if (mLauncher == null) {
+      return null;
+    }
     return mLauncher.getLaunchedUpdate();
   }
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.java
@@ -51,6 +51,12 @@ public class UpdatesDevLauncherController implements UpdatesInterface {
   }
 
   @Override
+  public void reset() {
+    UpdatesController controller = UpdatesController.getInstance();
+    controller.setLauncher(null);
+  }
+
+  @Override
   public void fetchUpdateWithConfiguration(HashMap<String, Object> configuration, Context context, UpdateCallback callback) {
     UpdatesController controller = UpdatesController.getInstance();
     UpdatesConfiguration updatesConfiguration = new UpdatesConfiguration()

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesService.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesService.java
@@ -73,7 +73,7 @@ public class UpdatesService implements InternalModule, UpdatesInterface {
 
   @Override
   public boolean canRelaunch() {
-    return getConfiguration().isEnabled();
+    return getConfiguration().isEnabled() && getLaunchedUpdate() != null;
   }
 
   @Override

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesAppController+Internal.h
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesAppController+Internal.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)initializeUpdatesDatabaseWithError:(NSError ** _Nullable)error;
 
 - (void)setDefaultSelectionPolicy:(EXUpdatesSelectionPolicy *)selectionPolicy;
-- (void)setLauncher:(id<EXUpdatesAppLauncher>)launcher;
+- (void)setLauncher:(nullable id<EXUpdatesAppLauncher>)launcher;
 - (void)setConfigurationInternal:(EXUpdatesConfig *)configuration;
 - (void)setIsStarted:(BOOL)isStarted;
 

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesAppController.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesAppController.m
@@ -19,7 +19,7 @@ static NSString * const EXUpdatesErrorEventName = @"error";
 @interface EXUpdatesAppController ()
 
 @property (nonatomic, readwrite, strong) EXUpdatesConfig *config;
-@property (nonatomic, readwrite, strong) id<EXUpdatesAppLauncher> launcher;
+@property (nonatomic, readwrite, strong, nullable) id<EXUpdatesAppLauncher> launcher;
 @property (nonatomic, readwrite, strong) EXUpdatesDatabase *database;
 @property (nonatomic, readwrite, strong) EXUpdatesSelectionPolicy *selectionPolicy;
 @property (nonatomic, readwrite, strong) EXUpdatesSelectionPolicy *defaultSelectionPolicy;
@@ -284,7 +284,7 @@ static NSString * const EXUpdatesErrorEventName = @"error";
   _defaultSelectionPolicy = selectionPolicy;
 }
 
-- (void)setLauncher:(id<EXUpdatesAppLauncher>)launcher
+- (void)setLauncher:(nullable id<EXUpdatesAppLauncher>)launcher
 {
   _launcher = launcher;
 }

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesDevLauncherController.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesDevLauncherController.m
@@ -46,6 +46,13 @@ typedef NS_ENUM(NSInteger, EXUpdatesDevLauncherErrorCode) {
   }
 }
 
+- (void)reset
+{
+  EXUpdatesAppController *controller = EXUpdatesAppController.sharedInstance;
+  [controller setLauncher:nil];
+  [controller setIsStarted:NO];
+}
+
 - (NSURL *)launchAssetURL
 {
   return EXUpdatesAppController.sharedInstance.launchAssetUrl;
@@ -75,7 +82,6 @@ typedef NS_ENUM(NSInteger, EXUpdatesDevLauncherErrorCode) {
     return;
   }
 
-  [controller setIsStarted:YES];
   [self _setDevelopmentSelectionPolicy];
 
   EXUpdatesRemoteAppLoader *loader = [[EXUpdatesRemoteAppLoader alloc] initWithConfig:updatesConfiguration database:controller.database directory:controller.updatesDirectory completionQueue:controller.controllerQueue];
@@ -116,6 +122,7 @@ typedef NS_ENUM(NSInteger, EXUpdatesDevLauncherErrorCode) {
       return;
     }
 
+    [controller setIsStarted:YES];
     [controller setConfigurationInternal:configuration];
     [controller setLauncher:launcher];
     successBlock(launcher.launchedUpdate.rawManifest.rawManifestJSON);


### PR DESCRIPTION
# Why

Discovered a bug in the dev-client/updates integration where if you load a production (published) bundle, and then a development (locally served) bundle, the Updates module state (e.g. `Updates.manifest`) from the production bundle isn't properly cleared between loads and persists into the development bundle's native module.

# How

Since the dev launcher controls when updates are loaded, we need a way for it to tell the UpdatesInterface (UpdatesDevLauncherController) when to reset the state, as well. I added a method for this to the interface, the implementation of which resets the state of the UpdatesController to what it would look like before an update is loaded.

# Test Plan

Start with a project with dev-client and updates installed from this branch, then create an app that displays a stringified version of the properties on the `Updates` native module. Publish this app, and run `expo start` to open a local development server. Use the dev client to switch back and forth between the published and development versions (using "Back to launcher" in the dev menu rather than closing and reopening the app) and make sure the correct field values are displayed.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).