### PR TITLE
Getting started improvements

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -95,7 +95,7 @@ const sections = [
       'Introduction',
       'Getting Started',
       'Installation in React Native and Bare workflow projects',
-      'Building With EAS',
+      'Building with EAS',
       'Extending the Development Menu',
     ],
   },

--- a/docs/pages/clients/eas-build.md
+++ b/docs/pages/clients/eas-build.md
@@ -1,5 +1,5 @@
 ---
-title: Building With EAS
+title: Building with EAS
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/clients/getting-started.md
+++ b/docs/pages/clients/getting-started.md
@@ -7,12 +7,12 @@ import InstallSection from '~/components/plugins/InstallSection'
 import SnackInline from '~/components/plugins/SnackInline';
 import { Tab, Tabs } from '~/components/plugins/Tabs';
 
-## Install the Development Client module in your project
+## Installing the Development Client module in your project
 
 <Tabs tabs={["With config plugins", "If you are directly managing your native projects"]}>
 
 <Tab >
-<InstallSection packageName="expo-dev-client" cmd={["expo init # if you don't already have a Managed Workflow project", "yarn add expo-dev-client@next"]} hideBareInstructions />
+<InstallSection packageName="expo-dev-client" cmd={["expo init # if you don't already have a Managed Workflow project", "yarn add expo-dev-client"]} hideBareInstructions />
 
 </Tab>
 
@@ -32,28 +32,78 @@ The Development Client uses deep links to open projects from the QR code. If you
 
 </Tabs>
 
-## Building your Development Client
+## Building and installing your first custom client
 
-You can now build your project and launch it in your iOS simulator
+### In the cloud
+
+However you choose to manage your native projects, we recommend using [EAS Build](eas-build.md) for the smoothest experience, especially if you do not have experience with Xcode and gradle builds.
+
+After you configure your project as covered by [the Building with EAS guide](eas-build.md), you can build your custom client with one command:
+
+<Tabs tabs={["For iOS Devices (Apple Developer membership required)", "For Android Devices"]}>
+
+<Tab >
+
+<InstallSection packageName="expo-dev-client" cmd={["eas build --profile development --platform ios"]} hideBareInstructions />
+
+</Tab>
+
+<Tab >
+
+<InstallSection packageName="expo-dev-client" cmd={["eas build --profile development --platform android"]} hideBareInstructions />
+
+</Tab>
+
+</Tabs>
+
+and installing the resulting build on your device.
+
+### Locally
+
+If you are comfortable setting up Xcode, Android Studio, and related dependencies, you can build and distribute your app the same as any other iOS or Android application (after running `expo prebuild` to generate the native projects if you are using config plugins).
+
+The `expo run` commands will run a new build, install it in your emulated device, and launch you into your application.
+
+<Tabs tabs={["For iOS Simulator (MacOS Only)", "For Android Emulator"]}>
+
+<Tab >
 
 <InstallSection packageName="expo-dev-client" cmd={["expo run:ios"]} hideBareInstructions />
 
-or your Android emulator
+</Tab>
+
+<Tab >
 
 <InstallSection packageName="expo-dev-client" cmd={["expo run:android"]} hideBareInstructions />
 
-If you are eager to install your project on a physical device, we recommend using [EAS Build](eas-build.md) for the smoothest experience, but you can build and distribute the same as any other React Native application. Once it's installed, you're ready to start developing by running:
+</Tab>
+
+</Tabs>
+
+
+## Developing your application
+
+As you can see, creating a new native build from scratch takes long enough that you'll be tempted to switch tasks and lose your focus.
+
+Now that you have a custom client for you project installed on your device, though, you won't have to wait for the native build process again until you change the native runtime!
+
+Instead, you can start developing in a fraction of the time by running:
 
 <InstallSection packageName="expo-dev-client" cmd={["expo start --dev-client"]} hideBareInstructions />
 
-## Loading your application
+and scanning the resulting QR code with your system camera or QR code reader (if you want to develop against a physical device)
 
-When you first launch your application, you will see a screen that looks like this:
+or pressing the A or I keys (to open the app in your Android or iPhone emulator respectively).
+
+Now make some changes to your application code and see them reflected on your device!
+
+### The launcher screen
+
+If you launch your custom development client from your device's Home Screen, you will see your launcher screen, which looks like this:
 
 <ImageSpotlight alt="The launcher screen of the Development Client" src="/static/images/dev-client-launcher.png" style={{ maxWidth: 225}} />
 
-If a bundler is available on your local network, or you've signed in to your Expo account, you can connect to it directly from this screen.
-Otherwise, you can connect by scanning the QR code displayed by Expo CLI.
+If a bundler is detected on your local network, or you've signed in to an Expo account in `expo-cli` and your client, you can connect to it directly from this screen.
 
 ## Customizing your runtime
 

--- a/docs/pages/clients/getting-started.md
+++ b/docs/pages/clients/getting-started.md
@@ -3,7 +3,7 @@ title: Getting Started
 ---
 
 import ImageSpotlight from '~/components/plugins/ImageSpotlight'
-import InstallSection from '~/components/plugins/InstallSection'
+import TerminalBlock from '~/components/plugins/TerminalBlock';
 import SnackInline from '~/components/plugins/SnackInline';
 import { Tab, Tabs } from '~/components/plugins/Tabs';
 
@@ -12,7 +12,7 @@ import { Tab, Tabs } from '~/components/plugins/Tabs';
 <Tabs tabs={["With config plugins", "If you are directly managing your native projects"]}>
 
 <Tab >
-<InstallSection packageName="expo-dev-client" cmd={["expo init # if you don't already have a Managed Workflow project", "yarn add expo-dev-client"]} hideBareInstructions />
+<TerminalBlock cmd={["expo init # if you don't already have a Managed Workflow project", "yarn add expo-dev-client"]}  />
 
 </Tab>
 
@@ -20,13 +20,13 @@ import { Tab, Tabs } from '~/components/plugins/Tabs';
 
 If you're just starting your project, you can create a new project from our template with:
 
-<InstallSection packageName="expo-dev-client" cmd={["npx crna -t with-dev-client"]} hideBareInstructions />
+<TerminalBlock cmd={["npx crna -t with-dev-client"]}  />
 
 If you have an existing project, you'll need to [install the package and make a few changes](installation.md) to your `AppDelegate.m`, `MainActivity.java` and `MainApplication.java`.
 
 The Development Client uses deep links to open projects from the QR code. If you had added a custom deep link schema to your project, the Development Client will use it. However, if this isn't the case, you need to configure the deep link support for your application. The `uri-scheme` package will do this for you once you have chosen a scheme.
 
-<InstallSection packageName="expo-dev-client" cmd={["npx uri-scheme add <your scheme>"]} hideBareInstructions />
+<TerminalBlock cmd={["npx uri-scheme add <your scheme>"]}  />
 
 </Tab>
 
@@ -44,13 +44,13 @@ After you configure your project as covered by [the Building with EAS guide](eas
 
 <Tab >
 
-<InstallSection packageName="expo-dev-client" cmd={["eas build --profile development --platform ios"]} hideBareInstructions />
+<TerminalBlock cmd={["eas build --profile development --platform ios"]}  />
 
 </Tab>
 
 <Tab >
 
-<InstallSection packageName="expo-dev-client" cmd={["eas build --profile development --platform android"]} hideBareInstructions />
+<TerminalBlock cmd={["eas build --profile development --platform android"]}  />
 
 </Tab>
 
@@ -68,13 +68,13 @@ The `expo run` commands will run a new build, install it in your emulated device
 
 <Tab >
 
-<InstallSection packageName="expo-dev-client" cmd={["expo run:ios"]} hideBareInstructions />
+<TerminalBlock cmd={["expo run:ios"]}  />
 
 </Tab>
 
 <Tab >
 
-<InstallSection packageName="expo-dev-client" cmd={["expo run:android"]} hideBareInstructions />
+<TerminalBlock cmd={["expo run:android"]}  />
 
 </Tab>
 
@@ -89,7 +89,7 @@ Now that you have a custom client for you project installed on your device, thou
 
 Instead, you can start developing in a fraction of the time by running:
 
-<InstallSection packageName="expo-dev-client" cmd={["expo start --dev-client"]} hideBareInstructions />
+<TerminalBlock packageName="expo-dev-client" cmd={["expo start --dev-client"]}  />
 
 and scanning the resulting QR code with your system camera or QR code reader (if you want to develop against a physical device)
 
@@ -111,7 +111,7 @@ In the Expo Go client, you can already convert text to audio with [expo-speech](
 
 First, install the library as you normally would:
 
-<InstallSection packageName="expo-dev-client" cmd={["yarn add @react-native-voice/voice"]} hideBareInstructions />
+<TerminalBlock cmd={["yarn add @react-native-voice/voice"]}  />
 
 then register the plugin in your app.json.  Using this module will require new permissions, and the plugin can optionally customize the message displayed to users in the permission prompt.
 <!-- prettier-ignore -->

--- a/docs/pages/clients/getting-started.md
+++ b/docs/pages/clients/getting-started.md
@@ -36,7 +36,7 @@ The Development Client uses deep links to open projects from the QR code. If you
 
 ### In the cloud
 
-However you choose to manage your native projects, we recommend using [EAS Build](eas-build.md) for the smoothest experience, especially if you do not have experience with Xcode and gradle builds.
+However you choose to manage your native projects, we recommend using [EAS Build](eas-build.md) for the smoothest experience, especially if you do not have experience with Xcode and Android Studio builds.
 
 After you configure your project as covered by [the Building with EAS guide](eas-build.md), you can build your custom client with one command:
 
@@ -60,9 +60,9 @@ and installing the resulting build on your device.
 
 ### Locally
 
-If you are comfortable setting up Xcode, Android Studio, and related dependencies, you can build and distribute your app the same as any other iOS or Android application (after running `expo prebuild` to generate the native projects if you are using config plugins).
+If you are comfortable setting up Xcode, Android Studio, and related dependencies, you can build and distribute your app the same as any other iOS or Android application.
 
-The `expo run` commands will run a new build, install it in your emulated device, and launch you into your application.
+The `expo run` commands will run a new build, install it on to your emulated device, and launch you into your application.
 
 <Tabs tabs={["For iOS Simulator (MacOS Only)", "For Android Emulator"]}>
 
@@ -85,15 +85,15 @@ The `expo run` commands will run a new build, install it in your emulated device
 
 As you can see, creating a new native build from scratch takes long enough that you'll be tempted to switch tasks and lose your focus.
 
-Now that you have a custom client for you project installed on your device, though, you won't have to wait for the native build process again until you change the native runtime!
+But now that you have a custom client for your project installed on your device, you won't have to wait for the native build process again until you change the underlying native code that powers your application!
 
-Instead, you can start developing in a fraction of the time by running:
+Instead, all you need to do to start developing is to run:
 
 <TerminalBlock packageName="expo-dev-client" cmd={["expo start --dev-client"]}  />
 
 and scanning the resulting QR code with your system camera or QR code reader (if you want to develop against a physical device)
 
-or pressing the A or I keys (to open the app in your Android or iPhone emulator respectively).
+or pressing the "a" or "i" keys (to open the app in your Android or iPhone emulator respectively).
 
 Now make some changes to your application code and see them reflected on your device!
 
@@ -103,7 +103,7 @@ If you launch your custom development client from your device's Home Screen, you
 
 <ImageSpotlight alt="The launcher screen of the Development Client" src="/static/images/dev-client-launcher.png" style={{ maxWidth: 225}} />
 
-If a bundler is detected on your local network, or you've signed in to an Expo account in `expo-cli` and your client, you can connect to it directly from this screen.
+If a bundler is detected on your local network, or if you've signed in to an Expo account in both `expo-cli` and your client, you can connect to it directly from this screen. Otherwise you can connect by scanning the QR code displayed by Expo CLI.
 
 ## Customizing your runtime
 


### PR DESCRIPTION
# Why

Closes ENG-1375

In user testing we discovered:
- some devs run into challenges with the run commands from missing or misconfigured dependencies while EAS works for everyone
- when you need to create a new build and when you can run expo start is not coming through consistently

# How

Reworked the getting started guide to steer users towards EAS if it would be a better fit for them
and to emphasize the native runtime vs JS application code distinction and associated commands

also cleaned up some page casing while I was in there
![image](https://user-images.githubusercontent.com/4551666/122660828-5e473c80-d139-11eb-830c-9c8a36bc07a7.png)
![image](https://user-images.githubusercontent.com/4551666/122660837-6901d180-d139-11eb-9388-a02d45c3c0d7.png)



# Test Plan

Ran `yarn dev`, clicked around and followed links