### PR TITLE
doc: async function returns a Promise

### DIFF
--- a/docs/pages/versions/unversioned/sdk/sqlite.md
+++ b/docs/pages/versions/unversioned/sdk/sqlite.md
@@ -115,7 +115,7 @@ module.exports = {
 - Use the following function (or similar) to open your database:
 
 ```ts
-async function openDatabase(pathToDatabaseFile: string): SQLite.WebSQLDatabase {
+async function openDatabase(pathToDatabaseFile: string): Promise<SQLite.WebSQLDatabase> {
   if (!(await FileSystem.getInfoAsync(FileSystem.documentDirectory + 'SQLite')).exists) {
     await FileSystem.makeDirectoryAsync(FileSystem.documentDirectory + 'SQLite');
   }

--- a/docs/pages/versions/v38.0.0/sdk/sqlite.md
+++ b/docs/pages/versions/v38.0.0/sdk/sqlite.md
@@ -115,7 +115,7 @@ module.exports = {
 - Use the following function (or similar) to open your database:
 
 ```ts
-async function openDatabase(pathToDatabaseFile: string): SQLite.WebSQLDatabase {
+async function openDatabase(pathToDatabaseFile: string): Promise<SQLite.WebSQLDatabase> {
   if (!(await FileSystem.getInfoAsync(FileSystem.documentDirectory + 'SQLite')).exists) {
     await FileSystem.makeDirectoryAsync(FileSystem.documentDirectory + 'SQLite');
   }

--- a/docs/pages/versions/v39.0.0/sdk/sqlite.md
+++ b/docs/pages/versions/v39.0.0/sdk/sqlite.md
@@ -115,7 +115,7 @@ module.exports = {
 - Use the following function (or similar) to open your database:
 
 ```ts
-async function openDatabase(pathToDatabaseFile: string): SQLite.WebSQLDatabase {
+async function openDatabase(pathToDatabaseFile: string): Promise<SQLite.WebSQLDatabase> {
   if (!(await FileSystem.getInfoAsync(FileSystem.documentDirectory + 'SQLite')).exists) {
     await FileSystem.makeDirectoryAsync(FileSystem.documentDirectory + 'SQLite');
   }

--- a/docs/pages/versions/v40.0.0/sdk/sqlite.md
+++ b/docs/pages/versions/v40.0.0/sdk/sqlite.md
@@ -115,7 +115,7 @@ module.exports = {
 - Use the following function (or similar) to open your database:
 
 ```ts
-async function openDatabase(pathToDatabaseFile: string): SQLite.WebSQLDatabase {
+async function openDatabase(pathToDatabaseFile: string): Promise<SQLite.WebSQLDatabase> {
   if (!(await FileSystem.getInfoAsync(FileSystem.documentDirectory + 'SQLite')).exists) {
     await FileSystem.makeDirectoryAsync(FileSystem.documentDirectory + 'SQLite');
   }

--- a/docs/pages/versions/v41.0.0/sdk/sqlite.md
+++ b/docs/pages/versions/v41.0.0/sdk/sqlite.md
@@ -115,7 +115,7 @@ module.exports = {
 - Use the following function (or similar) to open your database:
 
 ```ts
-async function openDatabase(pathToDatabaseFile: string): SQLite.WebSQLDatabase {
+async function openDatabase(pathToDatabaseFile: string): Promise<SQLite.WebSQLDatabase> {
   if (!(await FileSystem.getInfoAsync(FileSystem.documentDirectory + 'SQLite')).exists) {
     await FileSystem.makeDirectoryAsync(FileSystem.documentDirectory + 'SQLite');
   }

--- a/docs/pages/versions/v42.0.0/sdk/sqlite.md
+++ b/docs/pages/versions/v42.0.0/sdk/sqlite.md
@@ -115,7 +115,7 @@ module.exports = {
 - Use the following function (or similar) to open your database:
 
 ```ts
-async function openDatabase(pathToDatabaseFile: string): SQLite.WebSQLDatabase {
+async function openDatabase(pathToDatabaseFile: string): Promise<SQLite.WebSQLDatabase> {
   if (!(await FileSystem.getInfoAsync(FileSystem.documentDirectory + 'SQLite')).exists) {
     await FileSystem.makeDirectoryAsync(FileSystem.documentDirectory + 'SQLite');
   }


### PR DESCRIPTION
# Why

When using the provided source code, typescript tell us that async functions should return a promise

```
The return type of an async function or method must be the global Promise<T> type. Did you mean to write 'Promise<WebSQLDatabase>'?
```

# How

Edited the documentation

# Test Plan

Copy the code example and paste in your code editor

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).