### PR TITLE
[ci] Fix android test-suite ci connection reset error

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -191,6 +191,8 @@ jobs:
         run: yarn android:detox:build:release
         working-directory: apps/bare-expo
         timeout-minutes: 35
+        env:
+          GRADLE_OPTS: "-Dorg.gradle.internal.http.connectionTimeout=60000 -Dorg.gradle.internal.http.socketTimeout=60000 -Dorg.gradle.internal.network.retry.max.attempts=6 -Dorg.gradle.internal.network.retry.initial.backOff=2000"
       - name: Run tests
         uses: reactivecircus/android-emulator-runner@v2
         with:


### PR DESCRIPTION
# Why

Fix android test suite ci occasionally failed at "connection reset"

# How

Increase gradle timeout and retries
Referenced gradle code from:
https://github.com/gradle/gradle/blob/b7e82460c5373e194fb478a998c4fcfe7da53a7e/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/transport/NetworkOperationBackOffAndRetry.java#L25-L26
https://github.com/gradle/gradle/blob/b7e82460c5373e194fb478a998c4fcfe7da53a7e/subprojects/resources-http/src/main/java/org/gradle/internal/resource/transport/http/JavaSystemPropertiesHttpTimeoutSettings.java#L26-L27
Related GH issue: https://github.com/actions/virtual-environments/issues/2715



# Test Plan

android test suite ci build passed for three times.