### PR TITLE
[ios] move RCTOverrideAppearancePreference into versioned block

### DIFF
--- a/ios/Exponent/Kernel/Views/EXAppViewController.m
+++ b/ios/Exponent/Kernel/Views/EXAppViewController.m
@@ -647,10 +647,11 @@ NS_ASSUME_NONNULL_BEGIN
     appearancePreference = nil;
   }
   RCTOverrideAppearancePreference(appearancePreference);
+
+#ifdef INCLUDES_VERSIONED_CODE
 #if __has_include(<ABI42_0_0React/ABI42_0_0RCTAppearance.h>)
   ABI42_0_0RCTOverrideAppearancePreference(appearancePreference);
 #endif
-#ifdef INCLUDES_VERSIONED_CODE
 #if __has_include(<ABI41_0_0React/ABI41_0_0RCTAppearance.h>)
   ABI41_0_0RCTOverrideAppearancePreference(appearancePreference);
 #endif


### PR DESCRIPTION
# Why

Looks like this fixes the failing builds, although I'm not sure its right!