### PR TITLE
[iOS] cherry-pick expo-camera codec validation

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Update video codec validation to properly reject an invalid codec option. ([#13341](https://github.com/expo/expo/pull/13341) by [@ajsmth](https://github.com/ajsmth))
+
 ### 💡 Others
 
 ## 11.1.1 — 2021-06-16


### PR DESCRIPTION
# Why

Fixes a bug in the expo-camera for iOS where the video codec option would improperly reject 

