### PR TITLE
[expo-dev-launcher][android] fix switching from prod to dev mode

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed switching from published to local bundle loading on Android.
+- Fixed switching from published to local bundle loading on Android. ([#13363](https://github.com/expo/expo/pull/13363) by [@esamelson](https://github.com/esamelson))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed switching from published to local bundle loading on Android.
+
 ### 💡 Others
 
 ## 0.5.1 — 2021-06-16

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
@@ -79,6 +79,7 @@ class DevLauncherController private constructor(
       val appIntent = createAppIntent()
 
       updatesInterface?.reset()
+      useDeveloperSupport = true
 
       val appLoader = if (!manifestParser.isManifestUrl()) {
         // It's (maybe) a raw React Native bundle


### PR DESCRIPTION
# Why

fixes ENG-1388

Turns out the `useDeveloperSupport` value wasn't properly reset to `true` in the problematic case, meaning that `injectReactInterceptor` was passed an RN instance with `DisabledDevSupportManager` and it wasn't able to set all of the fields properly. This is what caused the hanging.

# How

Reset `useDeveloperSupport` to true in `loadApp` before loading the manifest. This is better than setting it in each case afterwards, as it will only be false in one case out of 4.

# Test Plan

Followed repro steps in ENG-1388. Switching back and forth multiple times works after this change.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).