### PR TITLE
[ios] Backport react-native-maps updates to sdk-42

### DIFF
--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/Api/Components/GoogleMaps/ABI42_0_0AIRGoogleMap.h
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/Api/Components/GoogleMaps/ABI42_0_0AIRGoogleMap.h
@@ -54,6 +54,7 @@
 @property (nonatomic, assign) BOOL scrollEnabled;
 @property (nonatomic, assign) BOOL zoomEnabled;
 @property (nonatomic, assign) BOOL rotateEnabled;
+@property (nonatomic, assign) BOOL scrollDuringRotateOrZoomEnabled;
 @property (nonatomic, assign) BOOL pitchEnabled;
 @property (nonatomic, assign) BOOL zoomTapEnabled;
 @property (nonatomic, assign) BOOL showsUserLocation;
@@ -69,8 +70,8 @@
 - (void)didTapPolygon:(GMSPolygon *)polygon;
 - (void)didTapAtCoordinate:(CLLocationCoordinate2D)coordinate;
 - (void)didLongPressAtCoordinate:(CLLocationCoordinate2D)coordinate;
-- (void)didChangeCameraPosition:(GMSCameraPosition *)position;
-- (void)idleAtCameraPosition:(GMSCameraPosition *)position;
+- (void)didChangeCameraPosition:(GMSCameraPosition *)position isGesture:(BOOL)isGesture;
+- (void)idleAtCameraPosition:(GMSCameraPosition *)position isGesture:(BOOL)isGesture;
 - (void)didTapPOIWithPlaceID:(NSString *)placeID name:(NSString *) name location:(CLLocationCoordinate2D) location;
 - (NSArray *)getMapBoundaries;
 

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/Api/Components/GoogleMaps/ABI42_0_0AIRGoogleMap.m
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/Api/Components/GoogleMaps/ABI42_0_0AIRGoogleMap.m
@@ -49,7 +49,7 @@ id regionAsJSON(MKCoordinateRegion region) {
            };
 }
 
-@interface ABI42_0_0AIRGoogleMap ()
+@interface ABI42_0_0AIRGoogleMap () <GMSIndoorDisplayDelegate>
 
 - (id)eventFromCoordinate:(CLLocationCoordinate2D)coordinate;
 
@@ -93,8 +93,10 @@ id regionAsJSON(MKCoordinateRegion region) {
            forKeyPath:@"myLocation"
               options:NSKeyValueObservingOptionNew
               context:NULL];
-      
+
     self.origGestureRecognizersMeta = [[NSMutableDictionary alloc] init];
+
+    self.indoorDisplay.delegate = self;
   }
   return self;
 }
@@ -227,10 +229,10 @@ id regionAsJSON(MKCoordinateRegion region) {
 {
     GMSVisibleRegion visibleRegion = self.projection.visibleRegion;
     GMSCoordinateBounds *bounds = [[GMSCoordinateBounds alloc] initWithRegion:visibleRegion];
-    
+
     CLLocationCoordinate2D northEast = bounds.northEast;
     CLLocationCoordinate2D southWest = bounds.southWest;
-    
+
     return @[
         @[
             [NSNumber numberWithDouble:northEast.longitude],
@@ -290,7 +292,7 @@ id regionAsJSON(MKCoordinateRegion region) {
 - (void)didPrepareMap {
   UIView* mapView = [self valueForKey:@"mapView"]; //GMSVectorMapView
   [self overrideGestureRecognizersForView:mapView];
-    
+
   if (_didCallOnMapReady) return;
   _didCallOnMapReady = true;
   if (self.onMapReady) self.onMapReady(@{});
@@ -349,9 +351,10 @@ id regionAsJSON(MKCoordinateRegion region) {
   self.onLongPress([self eventFromCoordinate:coordinate]);
 }
 
-- (void)didChangeCameraPosition:(GMSCameraPosition *)position {
+- (void)didChangeCameraPosition:(GMSCameraPosition *)position isGesture:(BOOL)isGesture{
   id event = @{@"continuous": @YES,
                @"region": regionAsJSON([ABI42_0_0AIRGoogleMap makeGMSCameraPositionFromMap:self andGMSCameraPosition:position]),
+               @"isGesture": [NSNumber numberWithBool:isGesture],
                };
 
   if (self.onChange) self.onChange(event);
@@ -371,9 +374,10 @@ id regionAsJSON(MKCoordinateRegion region) {
   if (self.onPoiClick) self.onPoiClick(event);
 }
 
-- (void)idleAtCameraPosition:(GMSCameraPosition *)position {
+- (void)idleAtCameraPosition:(GMSCameraPosition *)position  isGesture:(BOOL)isGesture{
   id event = @{@"continuous": @NO,
                @"region": regionAsJSON([ABI42_0_0AIRGoogleMap makeGMSCameraPositionFromMap:self andGMSCameraPosition:position]),
+               @"isGesture": [NSNumber numberWithBool:isGesture],
                };
   if (self.onChange) self.onChange(event);  // complete
 }
@@ -412,7 +416,7 @@ id regionAsJSON(MKCoordinateRegion region) {
       return @"automatic";
     case kGMSMapViewPaddingAdjustmentBehaviorAlways:
       return @"always";
-      
+
     default:
       return @"unknown";
   }
@@ -432,6 +436,14 @@ id regionAsJSON(MKCoordinateRegion region) {
 
 - (BOOL)zoomEnabled {
   return self.settings.zoomGestures;
+}
+
+- (void)setScrollDuringRotateOrZoomEnabled:(BOOL)enableScrollGesturesDuringRotateOrZoom {
+  self.settings.allowScrollGesturesDuringRotateOrZoom = enableScrollGesturesDuringRotateOrZoom;
+}
+
+- (BOOL)scrollDuringRotateOrZoomEnabled {
+  return self.settings.allowScrollGesturesDuringRotateOrZoom;
 }
 
 - (void)setZoomTapEnabled:(BOOL)zoomTapEnabled {
@@ -646,7 +658,7 @@ id regionAsJSON(MKCoordinateRegion region) {
         NSNumber* grHash = [NSNumber numberWithUnsignedInteger:gestureRecognizer.hash];
         if([self.origGestureRecognizersMeta objectForKey:grHash] != nil)
             continue; //already patched
-        
+
         //get original handlers
         NSArray* origTargets = [gestureRecognizer valueForKey:@"targets"];
         NSMutableArray* origTargetsActions = [[NSMutableArray alloc] init];
@@ -664,7 +676,7 @@ id regionAsJSON(MKCoordinateRegion region) {
             [view removeGestureRecognizer:gestureRecognizer];
             continue;
         }
-        
+
         //replace with extendedMapGestureHandler
         for (NSDictionary* origTargetAction in origTargetsActions) {
             NSValue* targetValue = [origTargetAction objectForKey:@"target"];
@@ -674,7 +686,7 @@ id regionAsJSON(MKCoordinateRegion region) {
             [gestureRecognizer removeTarget:target action:action];
         }
         [gestureRecognizer addTarget:self action:@selector(extendedMapGestureHandler:)];
-        
+
         [self.origGestureRecognizersMeta setObject:@{@"targets": origTargetsActions}
                                             forKey:grHash];
     }
@@ -687,14 +699,14 @@ id regionAsJSON(MKCoordinateRegion region) {
     CGRect bubbleAbsoluteFrame = [bubbleProvider accessibilityFrame];
     CGRect bubbleFrame = [win convertRect:bubbleAbsoluteFrame toView:self];
     UIView* bubbleView = [bubbleProvider valueForKey:@"view"];
-    
+
     BOOL performOriginalActions = YES;
     BOOL isTap = [gestureRecognizer isKindOfClass:[UITapGestureRecognizer class]] || [gestureRecognizer isMemberOfClass:[UITapGestureRecognizer class]];
     if (isTap) {
         BOOL isTapInsideBubble = NO;
     CGPoint tapPoint = CGPointZero;
     CGPoint tapPointInBubble = CGPointZero;
-    
+
     NSArray* touches = [gestureRecognizer valueForKey:@"touches"];
     UITouch* oneTouch = [touches firstObject];
     NSArray* delayedTouches = [gestureRecognizer valueForKey:@"delayedTouches"];
@@ -718,7 +730,7 @@ id regionAsJSON(MKCoordinateRegion region) {
                     break;
                 }
             }
-            
+
             //find real tap target subview
             UIView* realSubview = [(ABI42_0_0RCTView*)bubbleView hitTest:tapPointInBubble withEvent:nil];
             ABI42_0_0AIRGoogleMapCalloutSubview* realPressableSubview = nil;
@@ -732,7 +744,7 @@ id regionAsJSON(MKCoordinateRegion region) {
                     tmp = tmp.superview;
                 }
             }
-            
+
             if (markerView) {
                 BOOL isInsideCallout = [markerView.calloutView isPointInside:tapPointInBubble];
                 if (isInsideCallout) {
@@ -747,12 +759,12 @@ id regionAsJSON(MKCoordinateRegion region) {
                         [self didTapAtCoordinate:coord];
                     }
                 }
-                
+
                 performOriginalActions = NO;
             }
         }
     }
-    
+
     if (performOriginalActions) {
         NSDictionary* origMeta = [self.origGestureRecognizersMeta objectForKey:grHash];
         NSDictionary* origTargets = [origMeta objectForKey:@"targets"];
@@ -767,7 +779,7 @@ id regionAsJSON(MKCoordinateRegion region) {
 #pragma clang diagnostic pop
         }
     }
-    
+
     return nil;
 }
 
@@ -877,6 +889,63 @@ id regionAsJSON(MKCoordinateRegion region) {
     REQUIRES_GOOGLE_MAPS_UTILS();
 #endif
 }
+
+
+- (void) didChangeActiveBuilding: (nullable GMSIndoorBuilding *) building {
+    if (!building) {
+        if (!self.onIndoorBuildingFocused) {
+            return;
+        }
+        self.onIndoorBuildingFocused(@{
+            @"IndoorBuilding": @{
+                    @"activeLevelIndex": @0,
+                    @"underground": @false,
+                    @"levels": [[NSMutableArray alloc]init]
+            }
+        });
+    }
+    NSInteger i = 0;
+    NSMutableArray *arrayLevels = [[NSMutableArray alloc]init];
+    for (GMSIndoorLevel *level in building.levels) {
+        [arrayLevels addObject: @{
+            @"index": @(i),
+            @"name" : level.name,
+            @"shortName" : level.shortName,
+        }];
+        i++;
+    }
+    if (!self.onIndoorBuildingFocused) {
+        return;
+    }
+    self.onIndoorBuildingFocused(@{
+        @"IndoorBuilding": @{
+                @"activeLevelIndex": @(building.defaultLevelIndex),
+                @"underground": @(building.underground),
+                @"levels": arrayLevels
+        }
+    });
+}
+
+- (void) didChangeActiveLevel: (nullable GMSIndoorLevel *)     level {
+    if (!self.onIndoorLevelActivated || !self.indoorDisplay  || !level) {
+        return;
+    }
+    NSInteger i = 0;
+    for (GMSIndoorLevel *buildingLevel in self.indoorDisplay.activeBuilding.levels) {
+        if (buildingLevel.name == level.name && buildingLevel.shortName == level.shortName) {
+            break;
+        }
+        i++;
+    }
+    self.onIndoorLevelActivated(@{
+        @"IndoorLevel": @{
+                @"activeLevelIndex": @(i),
+                @"name": level.name,
+                @"shortName": level.shortName
+        }
+    });
+}
+
 
 @end
 

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/Api/Components/GoogleMaps/ABI42_0_0AIRGoogleMapManager.h
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/Api/Components/GoogleMaps/ABI42_0_0AIRGoogleMapManager.h
@@ -8,10 +8,9 @@
 #ifdef ABI42_0_0HAVE_GOOGLE_MAPS
 
 #import <ABI42_0_0React/ABI42_0_0RCTViewManager.h>
-#import "ABI42_0_0AIRGoogleMap.h"
 
 @interface ABI42_0_0AIRGoogleMapManager : ABI42_0_0RCTViewManager
-@property (nonatomic, assign) ABI42_0_0AIRGoogleMap *map;
+@property (nonatomic) BOOL isGesture;
 
 @end
 

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/Api/Components/GoogleMaps/ABI42_0_0AIRGoogleMapMarker.m
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/Api/Components/GoogleMaps/ABI42_0_0AIRGoogleMapMarker.m
@@ -264,7 +264,7 @@ CGRect unionRect(CGRect a, CGRect b) {
   }
 
   if (!_iconImageView) {
-    // prevent glitch with marker (cf. https://github.com/ABI42_0_0React-native-community/ABI42_0_0React-native-maps/issues/738)
+    // prevent glitch with marker (cf. https://github.com/ABI42_0_0React-native-maps/ABI42_0_0React-native-maps/issues/738)
     UIImageView *empyImageView = [[UIImageView alloc] init];
     _iconImageView = empyImageView;
     [self iconViewInsertSubview:_iconImageView atIndex:0];
@@ -340,7 +340,7 @@ CGRect unionRect(CGRect a, CGRect b) {
                                    NSLog(@"%@", error);
                                  }
                                  dispatch_async(dispatch_get_main_queue(), ^{
-                                   _realMarker.icon = image;
+                                   self->_realMarker.icon = image;
                                  });
                                }];
 }

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/Api/Components/GoogleMaps/ABI42_0_0AIRGoogleMapOverlay.h
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/Api/Components/GoogleMaps/ABI42_0_0AIRGoogleMapOverlay.h
@@ -20,6 +20,7 @@
 @property (nonatomic, copy) NSArray *boundsRect;
 @property (nonatomic, assign) CGFloat opacity;
 @property (nonatomic, readonly) GMSCoordinateBounds *overlayBounds;
+@property (nonatomic, readonly) double bearing;
 
 @property (nonatomic, weak) ABI42_0_0RCTBridge *bridge;
 

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/Api/Components/GoogleMaps/ABI42_0_0AIRGoogleMapOverlay.m
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/Api/Components/GoogleMaps/ABI42_0_0AIRGoogleMapOverlay.m
@@ -15,6 +15,7 @@
 @interface ABI42_0_0AIRGoogleMapOverlay()
   @property (nonatomic, strong, readwrite) UIImage *overlayImage;
   @property (nonatomic, readwrite) GMSCoordinateBounds *overlayBounds;
+  @property (nonatomic) CLLocationDirection bearing;
 @end
 
 @implementation ABI42_0_0AIRGoogleMapOverlay {
@@ -73,6 +74,12 @@
                                                         coordinate:_northEast];
 
   _overlay.bounds = _overlayBounds;
+}
+
+- (void)setBearing:(double)bearing
+{
+    _bearing = (double)bearing;
+    _overlay.bearing = _bearing;
 }
 
 - (void)setOpacity:(CGFloat)opacity

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/Api/Components/GoogleMaps/ABI42_0_0AIRGoogleMapOverlayManager.m
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/Api/Components/GoogleMaps/ABI42_0_0AIRGoogleMapOverlayManager.m
@@ -17,6 +17,7 @@ ABI42_0_0RCT_EXPORT_MODULE()
 }
 
 ABI42_0_0RCT_REMAP_VIEW_PROPERTY(bounds, boundsRect, NSArray)
+ABI42_0_0RCT_REMAP_VIEW_PROPERTY(bearing, bearing, double)
 ABI42_0_0RCT_REMAP_VIEW_PROPERTY(image, imageSrc, NSString)
 ABI42_0_0RCT_REMAP_VIEW_PROPERTY(opacity, opacity, CGFloat)
 

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/Api/Components/Maps/ABI42_0_0AIRMap.h
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/Api/Components/Maps/ABI42_0_0AIRMap.h
@@ -30,6 +30,7 @@ extern const NSInteger ABI42_0_0AIRMapMaxZoomLevel;
 
 @property (nonatomic, copy) NSString *userLocationAnnotationTitle;
 @property (nonatomic, assign) BOOL followUserLocation;
+@property (nonatomic, assign) BOOL userLocationCalloutEnabled;
 @property (nonatomic, assign) BOOL hasStartedRendering;
 @property (nonatomic, assign) BOOL cacheEnabled;
 @property (nonatomic, assign) BOOL loadingEnabled;

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/Api/Components/Maps/ABI42_0_0AIRMap.m
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/Api/Components/Maps/ABI42_0_0AIRMap.m
@@ -158,6 +158,8 @@ const NSInteger ABI42_0_0AIRMapMaxZoomLevel = 20;
         [self removeOverlay:(id <MKOverlay>) subview];
     } else if ([subview isKindOfClass:[ABI42_0_0AIRMapUrlTile class]]) {
         [self removeOverlay:(id <MKOverlay>) subview];
+    } else if ([subview isKindOfClass:[ABI42_0_0AIRMapWMSTile class]]) {
+        [self removeOverlay:(id <MKOverlay>) subview];
     } else if ([subview isKindOfClass:[ABI42_0_0AIRMapLocalTile class]]) {
         [self removeOverlay:(id <MKOverlay>) subview];
     } else if ([subview isKindOfClass:[ABI42_0_0AIRMapOverlay class]]) {
@@ -358,6 +360,21 @@ const NSInteger ABI42_0_0AIRMapMaxZoomLevel = 20;
     }
 }
 
+- (void)setUserInterfaceStyle:(NSString*)userInterfaceStyle
+{
+    if (@available(iOS 13.0, *)) {
+        if([userInterfaceStyle isEqualToString:@"light"]) {
+            self.overrideUserInterfaceStyle = UIUserInterfaceStyleLight;
+        } else if([userInterfaceStyle isEqualToString:@"dark"]) {
+            self.overrideUserInterfaceStyle = UIUserInterfaceStyleDark;
+        } else {
+            self.overrideUserInterfaceStyle = UIUserInterfaceStyleUnspecified;
+        }
+    } else {
+        NSLog(@"UserInterfaceStyle not supported below iOS 13");
+    }
+}
+
 - (void)setTintColor:(UIColor *)tintColor
 {
     super.tintColor = tintColor;
@@ -366,6 +383,11 @@ const NSInteger ABI42_0_0AIRMapMaxZoomLevel = 20;
 - (void)setFollowsUserLocation:(BOOL)followsUserLocation
 {
     _followUserLocation = followsUserLocation;
+}
+
+- (void)setUserLocationCalloutEnabled:(BOOL)calloutEnabled
+{
+    _userLocationCalloutEnabled = calloutEnabled;
 }
 
 - (void)setHandlePanDrag:(BOOL)handleMapDrag {
@@ -531,7 +553,7 @@ const NSInteger ABI42_0_0AIRMapMaxZoomLevel = 20;
 }
 
 - (void)cacheViewIfNeeded {
-    // https://github.com/ABI42_0_0React-native-community/ABI42_0_0React-native-maps/issues/3100
+    // https://github.com/ABI42_0_0React-native-maps/ABI42_0_0React-native-maps/issues/3100
     // Do nothing if app is not active
     if ([[UIApplication sharedApplication] applicationState] != UIApplicationStateActive) {
         return;


### PR DESCRIPTION
# Why

Companion to #13362

# How

- reverted versioning commit on a branch
- ran versioning script for ios
- copied the versioned maps dirs to a tmp dir
- checked out a new branch from master
- copied in versioned maps dirs

# Test Plan

CI, NCL

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).