### PR TITLE
[expo-updates][android] Allow optional 'string:' prefix to runtime

### DIFF
--- a/packages/expo-updates/android/build.gradle
+++ b/packages/expo-updates/android/build.gradle
@@ -110,6 +110,7 @@ dependencies {
   testImplementation 'io.mockk:mockk:1.10.6'
 
   androidTestImplementation 'androidx.test:runner:1.1.0'
+  androidTestImplementation 'androidx.test:core:1.0.0'
   androidTestImplementation 'androidx.test:rules:1.1.0'
   androidTestImplementation 'org.mockito:mockito-android:3.7.7'
   androidTestImplementation 'io.mockk:mockk-android:1.10.6'

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/UpdatesConfigurationInstrumentationTest.java
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/UpdatesConfigurationInstrumentationTest.java
@@ -1,0 +1,68 @@
+package expo.modules.updates;
+
+import android.content.Context;
+import org.junit.Assert;
+import org.junit.Test;
+import android.content.Context;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
+import android.net.Uri;
+import android.os.Bundle;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class UpdatesConfigurationInstrumentationTest {
+    String packageName = "test";
+    String runtimeVersion = "3.14";
+
+    @Test
+    public void testLoadValuesFromMetadata_stripsPrefix() throws PackageManager.NameNotFoundException {
+        Bundle metaData = new Bundle();
+        metaData.putString("expo.modules.updates.EXPO_RUNTIME_VERSION",String.format("string:%s",runtimeVersion) );
+
+        ApplicationInfo mockAi = mock(ApplicationInfo.class);
+        mockAi.metaData = metaData;
+
+        PackageManager packageManager = mock(PackageManager.class);
+        when(packageManager.getApplicationInfo(packageName, PackageManager.GET_META_DATA)).thenReturn(mockAi);
+
+        Context context = mock(Context.class);
+        when(context.getPackageName()).thenReturn(packageName);
+        when(context.getPackageManager()).thenReturn(packageManager);
+
+        UpdatesConfiguration config = new UpdatesConfiguration();
+        config = config.loadValuesFromMetadata(context);
+
+        Assert.assertEquals(runtimeVersion, config.getRuntimeVersion());
+    }
+
+    @Test
+    public void testLoadValuesFromMetadata_worksWithoutPrefix() throws PackageManager.NameNotFoundException {
+        Bundle metaData = new Bundle();
+        metaData.putString("expo.modules.updates.EXPO_RUNTIME_VERSION",runtimeVersion);
+
+        ApplicationInfo mockAi = mock(ApplicationInfo.class);
+        mockAi.metaData = metaData;
+
+        PackageManager packageManager = mock(PackageManager.class);
+        when(packageManager.getApplicationInfo(packageName, PackageManager.GET_META_DATA)).thenReturn(mockAi);
+
+
+        Context context = mock(Context.class);
+        when(context.getPackageName()).thenReturn(packageName);
+        when(context.getPackageManager()).thenReturn(packageManager);
+
+        UpdatesConfiguration config = new UpdatesConfiguration();
+        config = config.loadValuesFromMetadata(context);
+
+        Assert.assertEquals(runtimeVersion, config.getRuntimeVersion());
+    }
+}

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesConfiguration.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesConfiguration.java
@@ -115,7 +115,7 @@ public class UpdatesConfiguration {
       mLaunchWaitMs = ai.metaData.getInt("expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS", 0);
 
       Object runtimeVersion = ai.metaData.get("expo.modules.updates.EXPO_RUNTIME_VERSION");
-      mRuntimeVersion = runtimeVersion == null ? null : String.valueOf(runtimeVersion);
+      mRuntimeVersion = runtimeVersion == null ? null : String.valueOf(runtimeVersion).replaceFirst("^string:","");
 
       String checkOnLaunchString = ai.metaData.getString("expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH", "ALWAYS");
       try {


### PR DESCRIPTION
# Why
Provide a way to fix: https://github.com/expo/expo/issues/13349 by prefixing an rtv with `string:` in the AndroidManifest. The `string:` prefix is not required (although skipping it will allow bugs like the motivating issue to occur) so this is backwards compatible.

We will need to add documentation as well as make config-plugins add the prefix to the value found in app.json before transcribing it to the native code.

Note: we are intentionally not making use of "resources" in order to keep all of the config in a single file and following this idea: https://stackoverflow.com/a/29779967/3219704 We think this reduces cognitive load.

# How

do a string replace on rtv.

# Test Plan

Added tests and tested different variants (`rtv`, `string:rtv`, `1.10` (should fail), `string:1.10`) on demo app.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).