### PR TITLE
[dev-client][ios] POC of EXDevLauncherAppDelegate as decoupled module

### DIFF
--- a/apps/bare-expo/ios/BareExpo/AppDelegate.swift
+++ b/apps/bare-expo/ios/BareExpo/AppDelegate.swift
@@ -19,54 +19,31 @@ import FlipperKit
 @UIApplicationMain
 class AppDelegate: UMAppDelegateWrapper {
   var moduleRegistryAdapter: UMModuleRegistryAdapter!
-  var bridge: RCTBridge?
-  var launchOptions: [UIApplication.LaunchOptionsKey: Any]?
-
-  let useDevClient: Bool = false
   
+  // FIXME(kudo): should use package.json to exclude dev-client module
+  // let useDevClient: Bool = true
+
   override func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
     initializeFlipper(with: application)
     moduleRegistryAdapter = UMModuleRegistryAdapter(moduleRegistryProvider: UMModuleRegistryProvider())
-    window = UIWindow(frame: UIScreen.main.bounds)
-    self.launchOptions = launchOptions;
-
-    if (useDevClient) {
-      let controller = EXDevLauncherController.sharedInstance()
-      controller.start(with: window!, delegate: self, launchOptions: launchOptions);
-    } else {
-      initializeReactNativeBridge(launchOptions);
+    
+    if let bridge = RCTBridge(delegate: self, launchOptions: launchOptions) {
+      let rootView = RCTRootView(bridge: bridge, moduleName: "main", initialProperties: nil)
+      rootView.backgroundColor = UIColor.white
+      window = UIWindow(frame: UIScreen.main.bounds)
+      let rootViewController = UIViewController()
+      rootViewController.view = rootView
+      window?.rootViewController = rootViewController
+      window?.makeKeyAndVisible()
     }
 
     super.application(application, didFinishLaunchingWithOptions: launchOptions)
-    
     return true
   }
-
-  @discardableResult
-  func initializeReactNativeBridge(_ launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> RCTBridge? {
-    if let bridge = RCTBridge(delegate: self, launchOptions: launchOptions) {
-      let rootView = RCTRootView(bridge: bridge, moduleName: "main", initialProperties: nil)
-      let rootViewController = UIViewController()
-      rootView.backgroundColor = UIColor.white
-      rootViewController.view = rootView
-
-      window?.rootViewController = rootViewController
-      window?.makeKeyAndVisible()
-      self.bridge = bridge
-      return bridge;
-    }
-    return nil;
-  }
-  
-  #if RCT_DEV
-  func bridge(_ bridge: RCTBridge!, didNotFindModule moduleName: String!) -> Bool {
-    return true
-  }
-  #endif
   
   override func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
-    if (useDevClient && EXDevLauncherController.sharedInstance().onDeepLink(url, options: options)) {
-      return true;
+    if (super.application(app, open: url, options: options)) {
+      return true
     }
     
     return RCTLinkingManager.application(app, open: url, options: options)
@@ -91,11 +68,7 @@ extension AppDelegate: RCTBridgeDelegate {
   func sourceURL(for bridge: RCTBridge!) -> URL! {
     // DEBUG must be setup in Swift projects: https://stackoverflow.com/a/24112024/4047926
     #if DEBUG
-    if (useDevClient) {
-      return EXDevLauncherController.sharedInstance().sourceUrl()
-    } else {
-      return RCTBundleURLProvider.sharedSettings()?.jsBundleURL(forBundleRoot: "index", fallbackResource: nil)
-    }
+    return RCTBundleURLProvider.sharedSettings()?.jsBundleURL(forBundleRoot: "index", fallbackResource: nil)
     #else
     return Bundle.main.url(forResource: "main", withExtension: "jsbundle")
     #endif
@@ -117,13 +90,5 @@ extension AppDelegate: RCTBridgeDelegate {
     let storageDirectory = documentDirectory.appendingPathComponent("RCTAsyncLocalStorage_V1")
     extraModules?.append(RCTAsyncLocalStorage(storageDirectory: storageDirectory))
     return extraModules
-  }
-}
-
-// MARK: - EXDevelopmentClientControllerDelegate
-
-extension AppDelegate:  EXDevLauncherControllerDelegate {
-  func devLauncherController(_ developmentClientController: EXDevLauncherController, didStartWithSuccess success: Bool) {
-    developmentClientController.appBridge = initializeReactNativeBridge(developmentClientController.getLaunchOptions())
   }
 }

--- a/packages/expo-dev-launcher/ios/EXDevLauncherAppDelegate.h
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherAppDelegate.h
@@ -1,0 +1,17 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+#import <UIKit/UIKit.h>
+
+#import <UMCore/UMSingletonModule.h>
+
+#import "EXDevLauncherController.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface EXDevLauncherAppDelegate : UMSingletonModule<UIApplicationDelegate, EXDevLauncherControllerDelegate>
+
+- (const NSInteger)priority;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-dev-launcher/ios/EXDevLauncherAppDelegate.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherAppDelegate.m
@@ -1,0 +1,135 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+#import "EXDevLauncherAppDelegate.h"
+
+#import <React/RCTBridge.h>
+#import <React/RCTBridgeDelegate.h>
+#import <React/RCTRootView.h>
+#import <UMCore/UMDefines.h>
+
+#import "EXDevLauncherController.h"
+
+@interface EXDevLauncherBridgeDelegateInterceptor : NSObject<RCTBridgeDelegate>
+
+@property (nonatomic, weak) id<RCTBridgeDelegate> bridgeDelegate;
+
+- (nonnull instancetype)initWithBridgeDelegate:(id<RCTBridgeDelegate>)bridgeDelegate;
+
+@end
+
+@interface EXDevLauncherAppDelegate()
+
+@property (nonatomic, strong) NSDictionary *launchOptions;
+
+@end
+
+@implementation EXDevLauncherAppDelegate
+
+#if DEBUG
+
+UM_REGISTER_SINGLETON_MODULE(EXDevLauncherAppDelegate)
+
+#endif
+
+- (const NSInteger)priority
+{
+  return 1;
+}
+
+#pragma mark - UIApplicationDelegate
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+{
+  self.launchOptions = launchOptions;
+  UIWindow *window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+  id<UIApplicationDelegate> appDelegate = UIApplication.sharedApplication.delegate;
+  appDelegate.window = window;
+  EXDevLauncherController *controller = [EXDevLauncherController sharedInstance];
+  [controller startWithWindow:appDelegate.window delegate:self launchOptions:launchOptions];
+
+  return YES;
+}
+
+- (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options
+{
+  if ([[EXDevLauncherController sharedInstance] onDeepLink:url options:options]) {
+    return YES;
+  }
+  return NO;
+}
+
+#pragma mark - EXDevLauncherAppDelegate
+
+- (void)devLauncherController:(EXDevLauncherController *)developmentClientController
+          didStartWithSuccess:(BOOL)success
+{
+  developmentClientController.appBridge = [self initializeReactNativeApp];
+}
+
+- (RCTBridge *)initializeReactNativeApp
+{
+  if (![UIApplication.sharedApplication.delegate conformsToProtocol:@protocol(RCTBridgeDelegate)]) {
+    [NSException raise:NSInvalidArgumentException format:@"AppDelegate does not conforms to RCTBridgeDelegate"];
+  }
+  EXDevLauncherBridgeDelegateInterceptor* bridgeDelegate = [[EXDevLauncherBridgeDelegateInterceptor alloc]
+                                                            initWithBridgeDelegate:(id<RCTBridgeDelegate>)UIApplication.sharedApplication.delegate];
+
+  RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:bridgeDelegate launchOptions:self.launchOptions];
+  RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge moduleName:@"main" initialProperties:nil];
+  rootView.backgroundColor = [[UIColor alloc] initWithRed:1.0f green:1.0f blue:1.0f alpha:1];
+
+  UIViewController *rootViewController = [UIViewController new];
+  rootViewController.view = rootView;
+
+  id<UIApplicationDelegate> appDelegate = UIApplication.sharedApplication.delegate;
+  appDelegate.window.rootViewController = rootViewController;
+  [appDelegate.window makeKeyAndVisible];
+
+  return bridge;
+}
+
+@end
+
+# pragma mark - EXDevLauncherBridgeDelegateInterceptor
+
+@implementation EXDevLauncherBridgeDelegateInterceptor
+
+- (nonnull instancetype)initWithBridgeDelegate:(id<RCTBridgeDelegate>)bridgeDelegate
+{
+  if (self = [super init]) {
+    self.bridgeDelegate = bridgeDelegate;
+  }
+  return self;
+}
+
+- (id)forwardingTargetForSelector:(SEL)selector {
+  if ([self isInterceptedSelector:selector]) {
+    return self;
+  }
+  return self.bridgeDelegate;
+}
+
+- (BOOL)respondsToSelector:(SEL)selector {
+  if ([self isInterceptedSelector:selector]) {
+    return YES;
+  }
+  return [self.bridgeDelegate respondsToSelector:selector];
+}
+
+- (BOOL)isInterceptedSelector:(SEL)selector {
+  if (selector == @selector(sourceURLForBridge:) || selector == @selector(bridge:didNotFindModule:)) {
+    return YES;
+  }
+  return NO;
+}
+
+- (NSURL *)sourceURLForBridge:(RCTBridge *)bridge
+{
+  return EXDevLauncherController.sharedInstance.sourceUrl;
+}
+
+- (BOOL)bridge:(RCTBridge *)bridge didNotFindModule:(NSString *)moduleName {
+  return YES;
+}
+
+@end


### PR DESCRIPTION
# Why

Traditionally, to adopt dev-client or expo-updates, we use config-plugin to modify AppDelegate by regular expression.
Replacing user customizable AppDelegate by regular expression may not be a reliable way.
 
# How

Use Expo Modules (Unimodules) provided AppDelegate wrapper to do the registration.
A drawback of this approach is that the app will try to load original bundle first and DevLauncher will replace the window later.

# Test Plan

Try to launch bare-expo with dev-client and load local bundle.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] EXDevLauncherAppDelegate should take care backward compatibility if AppDelegate already have the registration