### PR TITLE
[ci] increase timeout factors

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -192,7 +192,7 @@ jobs:
         working-directory: apps/bare-expo
         timeout-minutes: 35
         env:
-          GRADLE_OPTS: "-Dorg.gradle.internal.http.connectionTimeout=60000 -Dorg.gradle.internal.http.socketTimeout=60000 -Dorg.gradle.internal.network.retry.max.attempts=6 -Dorg.gradle.internal.network.retry.initial.backOff=2000"
+          GRADLE_OPTS: "-Dorg.gradle.internal.http.connectionTimeout=180000 -Dorg.gradle.internal.http.socketTimeout=180000 -Dorg.gradle.internal.network.retry.max.attempts=18 -Dorg.gradle.internal.network.retry.initial.backOff=2000"
       - name: Run tests
         uses: reactivecircus/android-emulator-runner@v2
         with:

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -188,6 +188,8 @@ jobs:
         run: yarn detox:clean
         working-directory: apps/bare-expo
       - name: Prebuild react-native AAR
+        # Workaround for next `yarn android:detox:build:release` occasionally failed at gradle fetching libraries on GitHub Actions
+        # Just to introduce another trail for gradle building.
         run: ./gradlew :ReactAndroid:installArchives | true
         working-directory: react-native-lab/react-native
         timeout-minutes: 35

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -188,7 +188,7 @@ jobs:
         run: yarn detox:clean
         working-directory: apps/bare-expo
       - name: Prebuild react-native AAR
-        run: ./gradlew :ReactAndroid:installArchives
+        run: ./gradlew :ReactAndroid:installArchives | true
         working-directory: react-native-lab/react-native
         timeout-minutes: 35
         env:

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -187,6 +187,12 @@ jobs:
       - name: Clean Detox
         run: yarn detox:clean
         working-directory: apps/bare-expo
+      - name: Prebuild react-native AAR
+        run: ./gradlew :ReactAndroid:installArchives
+        working-directory: react-native-lab/react-native
+        timeout-minutes: 35
+        env:
+          GRADLE_OPTS: "-Dorg.gradle.internal.http.connectionTimeout=180000 -Dorg.gradle.internal.http.socketTimeout=180000 -Dorg.gradle.internal.network.retry.max.attempts=18 -Dorg.gradle.internal.network.retry.initial.backOff=2000"
       - name: Build Android project for Detox
         run: yarn android:detox:build:release
         working-directory: apps/bare-expo


### PR DESCRIPTION
# Why

Android test suite CI still broken sometimes

# How

1. Increase timeout factors
2. Build twice to workaround the connection reset issue

# Test Plan

CI passing