### PR TITLE
[docs] Haptics snack example

### DIFF
--- a/docs/pages/versions/unversioned/sdk/haptics.md
+++ b/docs/pages/versions/unversioned/sdk/haptics.md
@@ -6,6 +6,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-haptics'
 import APISection from '~/components/plugins/APISection';
 import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
+import SnackInline from '~/components/plugins/SnackInline';
 
 **`expo-haptics`** provides haptic (touch) feedback for
 
@@ -30,6 +31,58 @@ On iOS, _the Taptic engine will do nothing if any of the following conditions ar
 ## Configuration
 
 On Android, this module requires permission to control vibration on the device. The `VIBRATE` permission is added automatically.
+
+## Usage
+
+<SnackInline label='Haptics usage' dependencies={['expo-haptics']}>
+
+```jsx
+import * as React from 'react';
+import { StyleSheet, View, Text, Button } from 'react-native';
+import * as Haptics from 'expo-haptics';
+
+export default function App() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>Haptics.selectionAsync</Text>
+      <View style={styles.buttonContainer}>
+        <Button title='Selection' onPress={() => /* @info */ Haptics.selectionAsync() /* @end */} />
+      </View>
+      <Text style={styles.text}>Haptics.notificationAsync</Text>
+      <View style={styles.buttonContainer}>
+        <Button title='Success' onPress={() => /* @info */ Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success) /* @end */} />
+        <Button title='Error' onPress={() => /* @info */ Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error) /* @end */} />
+        <Button title='Warning' onPress={() => /* @info */ Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning) /* @end */} />
+      </View>
+      <Text style={styles.text}>Haptics.impactAsync</Text>
+      <View style={styles.buttonContainer}>
+        <Button title='Light' onPress={() => /* @info */ Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light) /* @end */} />
+        <Button title='Medium' onPress={() => /* @info */ Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium) /* @end */} />
+        <Button title='Heavy' onPress={() => /* @info */ Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy) /* @end */} />
+      </View>
+    </View>
+  );
+}
+
+/* @hide const styles = StyleSheet.create({ ... }); */
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    paddingHorizontal: 16,
+  },
+  buttonContainer: {
+    flexDirection: 'row',
+    alignItems: 'stretch',
+    marginTop: 10,
+    marginBottom: 30,
+    justifyContent: 'space-between'
+  },
+});
+/* @end */
+```
+
+</SnackInline>
 
 ## API
 

--- a/docs/pages/versions/v41.0.0/sdk/haptics.md
+++ b/docs/pages/versions/v41.0.0/sdk/haptics.md
@@ -5,6 +5,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-41/packages/expo-haptics'
 
 import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
+import SnackInline from '~/components/plugins/SnackInline';
 
 **`expo-haptics`** provides haptic (touch) feedback for
 
@@ -29,6 +30,58 @@ On iOS, _the Taptic engine will do nothing if any of the following conditions ar
 ## Configuration
 
 On Android, this module requires permission to control vibration on the device. The `VIBRATE` permission is added automatically.
+
+## Usage
+
+<SnackInline label='Haptics usage' dependencies={['expo-haptics']}>
+
+```jsx
+import * as React from 'react';
+import { StyleSheet, View, Text, Button } from 'react-native';
+import * as Haptics from 'expo-haptics';
+
+export default function App() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>Haptics.selectionAsync</Text>
+      <View style={styles.buttonContainer}>
+        <Button title='Selection' onPress={() => /* @info */ Haptics.selectionAsync() /* @end */} />
+      </View>
+      <Text style={styles.text}>Haptics.notificationAsync</Text>
+      <View style={styles.buttonContainer}>
+        <Button title='Success' onPress={() => /* @info */ Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success) /* @end */} />
+        <Button title='Error' onPress={() => /* @info */ Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error) /* @end */} />
+        <Button title='Warning' onPress={() => /* @info */ Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning) /* @end */} />
+      </View>
+      <Text style={styles.text}>Haptics.impactAsync</Text>
+      <View style={styles.buttonContainer}>
+        <Button title='Light' onPress={() => /* @info */ Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light) /* @end */} />
+        <Button title='Medium' onPress={() => /* @info */ Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium) /* @end */} />
+        <Button title='Heavy' onPress={() => /* @info */ Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy) /* @end */} />
+      </View>
+    </View>
+  );
+}
+
+/* @hide const styles = StyleSheet.create({ ... }); */
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    paddingHorizontal: 16,
+  },
+  buttonContainer: {
+    flexDirection: 'row',
+    alignItems: 'stretch',
+    marginTop: 10,
+    marginBottom: 30,
+    justifyContent: 'space-between'
+  },
+});
+/* @end */
+```
+
+</SnackInline>
 
 ## API
 


### PR DESCRIPTION
# Why

Adds Snack example for expo-haptics demonstrating all APIs

![image](https://user-images.githubusercontent.com/6184593/122929221-faa45580-d36a-11eb-9a28-f49be1b92c84.png)

# How

- Add Snack example for unversioned and SDK 41

# Test Plan

- `yarn dev`
- Press blue `Try this on Snack` button
- Verified all buttons provide haptic feedback on Expo Go for iOS
- https://snack.expo.io/2hLQHgwJB