### PR TITLE
[android] use hermes engine if specifing jsEngine in manifest

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/VersionedUtils.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/VersionedUtils.java
@@ -268,18 +268,18 @@ public class VersionedUtils {
     }
 
     final Pair<Boolean, Integer> hermesBundlePair = parseHermesBundleHeader(instanceManagerBuilderProperties.jsBundlePath);
-    if (hermesBundlePair.first) {
-      if (hermesBundlePair.second != HERMES_BYTECODE_VERSION) {
-        final String message = String.format(Locale.US,
-                "Unable to load unsupported Hermes bundle.\n\tsupportedBytecodeVersion: %d\n\ttargetBytecodeVersion: %d",
-                HERMES_BYTECODE_VERSION, hermesBundlePair.second);
-        KernelProvider.getInstance().handleError(new RuntimeException(message));
-        return null;
-      }
-      return new HermesExecutorFactory();
+    if (hermesBundlePair.first && hermesBundlePair.second != HERMES_BYTECODE_VERSION) {
+      final String message = String.format(Locale.US,
+              "Unable to load unsupported Hermes bundle.\n\tsupportedBytecodeVersion: %d\n\ttargetBytecodeVersion: %d",
+              HERMES_BYTECODE_VERSION, hermesBundlePair.second);
+      KernelProvider.getInstance().handleError(new RuntimeException(message));
+      return null;
     }
 
-    return new JSCExecutorFactory(appName, deviceName);
+    final String jsEngineFromManifest = instanceManagerBuilderProperties.manifest.getAndroidJsEngine();
+    return (jsEngineFromManifest != null && jsEngineFromManifest.equals("hermes"))
+            ? new HermesExecutorFactory()
+            : new JSCExecutorFactory(appName, deviceName);
   }
 
   @NonNull

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/raw/RawManifest.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/raw/RawManifest.kt
@@ -172,6 +172,11 @@ abstract class RawManifest(protected val json: JSONObject) {
     return json.optJSONObject("androidNavigationBar")
   }
 
+  fun getAndroidJsEngine(): String? {
+    val android = json.optJSONObject("android") ?: return null
+    return android.optString("jsEngine") ?: return null
+  }
+
   fun getIconUrl(): String? {
     return json.optString("iconUrl")
   }


### PR DESCRIPTION
# Why

Since we store `jsEngine` in manifest already, it is good to reference this value even in development.

# How

Reference the `jsEngine` manifest value to create JavaScriptExecutorFactory even the loading bundle is a plaintext javascript bundle.

# Test Plan

Verify with Brent's test project which has hermes jsEngine in manifest but a plaintext javascript bundle.
