### PR TITLE
[CI] Schedule versioned Expo Go builds

### DIFF
--- a/.github/workflows/client-android.yml
+++ b/.github/workflows/client-android.yml
@@ -98,6 +98,17 @@ jobs:
         if: steps.cache-android-ndk.outputs.cache-hit != 'true'
         run: |
           sudo $ANDROID_SDK_ROOT/tools/bin/sdkmanager --install "ndk;19.2.5345600"
+      - name: 🔎 Check which flavor to build
+        id: flavor
+        uses: dorny/paths-filter@v2
+        with:
+          filters: |
+            versioned:
+              - android/versioned-abis/**
+              - android/versioned-react-native/**
+              - android/expoview/src/versioned/**
+              - android/expoview/src/main/java/versioned/**
+              - android/**/*.gradle
       - name: 🏭 Build APK
         env:
           ANDROID_KEYSTORE_B64: ${{ secrets.ANDROID_KEYSTORE_B64 }}

--- a/.github/workflows/client-android.yml
+++ b/.github/workflows/client-android.yml
@@ -9,6 +9,8 @@ on:
       releaseGooglePlay:
         description: 'type "release-google-play" to confirm release to Google Play'
         required: false
+  schedule:
+    - cron: '20 5 * * 1,3,5' # 5:20 AM UTC time on every Monday, Wednesday and Friday
   pull_request:
     paths:
       - .github/workflows/client-android.yml
@@ -104,6 +106,7 @@ jobs:
           ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
           ANDROID_NDK_HOME: /usr/local/lib/android/sdk/ndk/19.2.5345600/
           IS_RELEASE_BUILD: ${{ github.event.inputs.releaseAPK == 'release-apk' || github.event.inputs.releaseGooglePlay == 'release-google-play' }}
+          IS_VERSIONED_FLAVOR: ${{ github.event_name == 'schedule' || steps.flavor.outputs.versioned == 'true' }}
         run: |
           if [ "$IS_RELEASE_BUILD" == "false" ]; then
             export NDK_ABI_FILTERS="x86_64"
@@ -112,16 +115,15 @@ jobs:
           else
             BUILD_TYPE="Release"
           fi
+          [[ "$IS_VERSIONED_FLAVOR" == "true" ]] && FLAVOR="Versioned" || FLAVOR="Unversioned"
+          echo "Building with $FLAVOR flavor"
           if [ -z "$ANDROID_KEYSTORE_B64" ]; then
             echo "External build detected, APK will not be signed"
-            bin/fastlane android build build_type:$BUILD_TYPE \
-              flavor:${{ steps.flavor.outputs.versioned == 'true' && 'Versioned' || 'Unversioned' }} \
-              sign:false
+            bin/fastlane android build build_type:$BUILD_TYPE flavor:$FLAVOR sign:false
           else
             echo "Internal build detected, APK will be signed"
             echo $ANDROID_KEYSTORE_B64 | base64 -d > android/app/release-key.jks
-            bin/fastlane android build build_type:$BUILD_TYPE \
-              flavor:${{ steps.flavor.outputs.versioned == 'true' && 'Versioned' || 'Unversioned' }}
+            bin/fastlane android build build_type:$BUILD_TYPE flavor:$FLAVOR
           fi
       - name: 💾 Upload APK artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/client-ios.yml
+++ b/.github/workflows/client-ios.yml
@@ -6,6 +6,8 @@ on:
       releaseSimulator:
         description: 'type "release-simulator" to confirm upload'
         required: false
+  schedule:
+    - cron: '20 5 * * 1,3,5' # 5:20 AM UTC time on every Monday, Wednesday and Friday
   pull_request:
     paths:
       - .github/workflows/client-ios.yml
@@ -96,11 +98,15 @@ jobs:
               - ios/versioned-react-native/**
               - ios/Exponent/Versioned/**
       - name: 🏗 Build Expo Go for simulator
-        run: expotools client-build --platform ios --flavor ${{ steps.flavor.outputs.versioned == 'true' && 'versioned' || 'unversioned' }}
+        run: |
+          [[ "$IS_VERSIONED_FLAVOR" == "true" ]] && FLAVOR="versioned" || FLAVOR="unversioned"
+          echo "Building with $FLAVOR flavor"
+          expotools client-build --platform ios --flavor $FLAVOR
         timeout-minutes: 120
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          IS_VERSIONED_FLAVOR: ${{ github.event_name == 'schedule' || steps.flavor.outputs.versioned == 'true' }}
       - name: 💾 Save test results
         if: always()
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
# Why

resolves issue mentioned in https://github.com/expo/expo/pull/12917#discussion_r646830592 

We no longer build versioned Expo Go on PRs unless there are version-related changes (since #11999 and #12917 for iOS and Android, respectively). We want to build versioned Expo Go periodically the same way we do it for shell apps.

# How

- Added schedule trigger for both iOS and Android client CI jobs - it runs on 5:20 a.m. UTC on Mondays, Wednesdays and Fridays.
- I haven't touched Slack messaging because this should be working already.
- Added missing CI step for Android - I must have dropped it by accident when rebasing #12917 🙄 

# Test Plan

Tested on CI - cancelled jobs just to avoid unnecessary builds. 

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).