### PR TITLE
Added missing android intents

### DIFF
--- a/packages/expo-contacts/CHANGELOG.md
+++ b/packages/expo-contacts/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- Added `AndroidManifest.xml` queries for intent handling. ([#13388](https://github.com/expo/expo/pull/13388) by [@EvanBacon](https://github.com/EvanBacon))
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/packages/expo-contacts/android/src/main/AndroidManifest.xml
+++ b/packages/expo-contacts/android/src/main/AndroidManifest.xml
@@ -1,5 +1,17 @@
-
 <manifest package="expo.modules.contacts">
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.SEND" />
+            <category android:name="android.intent.category.DEFAULT" />
 
+            <data android:mimeType="application/octet-stream" />
+            <data android:mimeType="text/vcard" />
+            <data android:mimeType="text/x-vcard" />
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.EDIT" />
+            <action android:name="android.intent.action.INSERT" />
+        </intent>
+    </queries>
 </manifest>
   

--- a/packages/expo-document-picker/CHANGELOG.md
+++ b/packages/expo-document-picker/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Added `AndroidManifest.xml` queries for intent handling. ([#13388](https://github.com/expo/expo/pull/13388) by [@EvanBacon](https://github.com/EvanBacon))
+
 ### 💡 Others
 
 ## 9.2.0 — 2021-06-16

--- a/packages/expo-document-picker/android/src/main/AndroidManifest.xml
+++ b/packages/expo-document-picker/android/src/main/AndroidManifest.xml
@@ -1,2 +1,13 @@
 <manifest package="expo.modules.documentpicker">
+
+    <queries>
+        <!-- Query open documents -->
+        <intent>
+            <action android:name="android.intent.action.OPEN_DOCUMENT" />
+            <category android:name="android.intent.category.DEFAULT" />
+            <category android:name="android.intent.category.OPENABLE" />
+            <data android:mimeType="*/*" />
+        </intent>
+    </queries>
 </manifest>
+

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- Added `AndroidManifest.xml` queries for intent handling. ([#13388](https://github.com/expo/expo/pull/13388) by [@EvanBacon](https://github.com/EvanBacon))
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/packages/expo-file-system/android/src/main/AndroidManifest.xml
+++ b/packages/expo-file-system/android/src/main/AndroidManifest.xml
@@ -1,4 +1,3 @@
-
 <manifest package="expo.modules.filesystem"
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
@@ -6,17 +5,15 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <application>
-        <provider
-            tools:replace="android:authorities"
-            android:name=".FileSystemFileProvider"
-            android:authorities="${applicationId}.FileSystemFileProvider"
-            android:exported="false"
-            android:grantUriPermissions="true"
-            >
-            <meta-data
-                android:name="android.support.FILE_PROVIDER_PATHS"
-                android:resource="@xml/file_system_provider_paths"
-                />
+        <provider tools:replace="android:authorities" android:name=".FileSystemFileProvider" android:authorities="${applicationId}.FileSystemFileProvider" android:exported="false" android:grantUriPermissions="true">
+            <meta-data android:name="android.support.FILE_PROVIDER_PATHS" android:resource="@xml/file_system_provider_paths" />
         </provider>
     </application>
+
+    <queries>
+        <!-- Query open documents -->
+        <intent>
+            <action android:name="android.intent.action.OPEN_DOCUMENT_TREE" />
+        </intent>
+    </queries>
 </manifest>

--- a/packages/expo-mail-composer/CHANGELOG.md
+++ b/packages/expo-mail-composer/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- Added `AndroidManifest.xml` queries for intent handling. ([#13388](https://github.com/expo/expo/pull/13388) by [@EvanBacon](https://github.com/EvanBacon))
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/packages/expo-mail-composer/android/src/main/AndroidManifest.xml
+++ b/packages/expo-mail-composer/android/src/main/AndroidManifest.xml
@@ -1,24 +1,23 @@
 <manifest package="expo.modules.mailcomposer"
-          xmlns:android="http://schemas.android.com/apk/res/android">
+    xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application>
         <!-- https://developer.android.com/guide/topics/manifest/provider-element.html -->
-        <provider
-            android:name=".MailComposerFileProvider"
-            android:authorities="${applicationId}.MailComposerFileProvider"
-            android:exported="false"
-            android:grantUriPermissions="true">
-            <meta-data
-                android:name="android.support.FILE_PROVIDER_PATHS"
-                android:resource="@xml/mail_composer_provider_paths"/>
+        <provider android:name=".MailComposerFileProvider" android:authorities="${applicationId}.MailComposerFileProvider" android:exported="false" android:grantUriPermissions="true">
+            <meta-data android:name="android.support.FILE_PROVIDER_PATHS" android:resource="@xml/mail_composer_provider_paths"/>
         </provider>
     </application>
 
     <queries>
         <intent>
-          <!-- Required for sending mails if targeting API 30 -->
-          <action android:name="android.intent.action.SENDTO" />
-          <data android:scheme="mailto" />
+            <!-- Required for sending mails if targeting API 30 -->
+            <action android:name="android.intent.action.SENDTO" />
+            <data android:scheme="mailto" />
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.SEND_MULTIPLE" />
+            <category android:name="android.intent.category.DEFAULT" />
+            <data android:mimeType="*/*" />
         </intent>
     </queries>
 </manifest>

--- a/packages/expo-sms/CHANGELOG.md
+++ b/packages/expo-sms/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- Added `AndroidManifest.xml` queries for intent handling. ([#13388](https://github.com/expo/expo/pull/13388) by [@EvanBacon](https://github.com/EvanBacon))
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/packages/expo-sms/android/src/main/AndroidManifest.xml
+++ b/packages/expo-sms/android/src/main/AndroidManifest.xml
@@ -1,5 +1,19 @@
-
 <manifest package="expo.modules.sms">
 
+
+    <queries>
+        <intent>
+            <!-- Required for file sharing if targeting API 30 -->
+            <action android:name="android.intent.action.SEND" />
+            <data android:mimeType="*/*" />
+        </intent>
+        <!-- Fallback SENDTO -->
+        <intent>
+            <action android:name="android.intent.action.SENDTO" />
+            <category android:name="android.intent.category.DEFAULT" />
+            <category android:name="android.intent.category.BROWSABLE" />
+            <data android:scheme="sms" />
+            <data android:scheme="smsto" />
+        </intent>
+    </queries>
 </manifest>
-  


### PR DESCRIPTION
# Why

- resolve ENG-1386
- related https://github.com/expo/expo/pull/11829

# How

- <kbd>⌘f</kbd> for `Intent(Intent.` and check each package's `AndroidManifest.xml` to see if they included the correct queries
- If not, googled to attempt to find out when the correct queries were for each Intent (opting to be a bit looser with things like mime types)

# Test Plan

- TBD