### PR TITLE
Bump config-plugins to v3.0.0

### DIFF
--- a/packages/expo-ads-admob/package.json
+++ b/packages/expo-ads-admob/package.json
@@ -35,7 +35,7 @@
     "preset": "expo-module-scripts/ios"
   },
   "dependencies": {
-    "@expo/config-plugins": "^2.0.0",
+    "@expo/config-plugins": "^3.0.0",
     "expo-modules-core": "~0.1.1"
   },
   "devDependencies": {

--- a/packages/expo-ads-facebook/package.json
+++ b/packages/expo-ads-facebook/package.json
@@ -31,7 +31,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.io/versions/latest/sdk/facebook-ads/",
   "dependencies": {
-    "@expo/config-plugins": "^2.0.0",
+    "@expo/config-plugins": "^3.0.0",
     "expo-modules-core": "~0.1.1",
     "fbemitter": "^2.1.1",
     "nullthrows": "^1.1.0"

--- a/packages/expo-app-auth/package.json
+++ b/packages/expo-app-auth/package.json
@@ -44,7 +44,7 @@
     "preset": "expo-module-scripts"
   },
   "dependencies": {
-    "@expo/config-plugins": "^2.0.0",
+    "@expo/config-plugins": "^3.0.0",
     "expo-modules-core": "~0.1.1",
     "invariant": "^2.2.4"
   },

--- a/packages/expo-apple-authentication/package.json
+++ b/packages/expo-apple-authentication/package.json
@@ -32,7 +32,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.io/versions/latest/sdk/apple-authentication/",
   "dependencies": {
-    "@expo/config-plugins": "^2.0.0"
+    "@expo/config-plugins": "^3.0.0"
   },
   "devDependencies": {
     "expo-module-scripts": "^2.0.0"

--- a/packages/expo-av/package.json
+++ b/packages/expo-av/package.json
@@ -32,7 +32,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.io/versions/latest/sdk/av/",
   "dependencies": {
-    "@expo/config-plugins": "^2.0.0",
+    "@expo/config-plugins": "^3.0.0",
     "expo-modules-core": "~0.1.1"
   },
   "devDependencies": {

--- a/packages/expo-background-fetch/package.json
+++ b/packages/expo-background-fetch/package.json
@@ -37,7 +37,7 @@
     "unimodules-task-manager-interface": "*"
   },
   "dependencies": {
-    "@expo/config-plugins": "^2.0.0",
+    "@expo/config-plugins": "^3.0.0",
     "expo-task-manager": "~9.2.0"
   },
   "devDependencies": {

--- a/packages/expo-barcode-scanner/package.json
+++ b/packages/expo-barcode-scanner/package.json
@@ -35,7 +35,7 @@
     "preset": "expo-module-scripts/ios"
   },
   "dependencies": {
-    "@expo/config-plugins": "^2.0.0",
+    "@expo/config-plugins": "^3.0.0",
     "expo-modules-core": "~0.1.1"
   },
   "devDependencies": {

--- a/packages/expo-branch/package.json
+++ b/packages/expo-branch/package.json
@@ -32,7 +32,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.io/versions/latest/sdk/branch/",
   "dependencies": {
-    "@expo/config-plugins": "^2.0.0",
+    "@expo/config-plugins": "^3.0.0",
     "react-native-branch": "5.0.0"
   },
   "devDependencies": {

--- a/packages/expo-brightness/package.json
+++ b/packages/expo-brightness/package.json
@@ -35,7 +35,7 @@
     "preset": "expo-module-scripts"
   },
   "dependencies": {
-    "@expo/config-plugins": "^2.0.0",
+    "@expo/config-plugins": "^3.0.0",
     "expo-modules-core": "~0.1.1"
   },
   "devDependencies": {

--- a/packages/expo-calendar/package.json
+++ b/packages/expo-calendar/package.json
@@ -35,7 +35,7 @@
     "preset": "expo-module-scripts/ios"
   },
   "dependencies": {
-    "@expo/config-plugins": "^2.0.0",
+    "@expo/config-plugins": "^3.0.0",
     "expo-modules-core": "~0.1.1"
   },
   "devDependencies": {

--- a/packages/expo-camera/package.json
+++ b/packages/expo-camera/package.json
@@ -34,7 +34,7 @@
     "preset": "expo-module-scripts"
   },
   "dependencies": {
-    "@expo/config-plugins": "^2.0.0",
+    "@expo/config-plugins": "^3.0.0",
     "@koale/useworker": "^3.2.1",
     "expo-modules-core": "~0.1.1",
     "invariant": "2.2.4"

--- a/packages/expo-contacts/package.json
+++ b/packages/expo-contacts/package.json
@@ -34,7 +34,7 @@
     "preset": "expo-module-scripts"
   },
   "dependencies": {
-    "@expo/config-plugins": "^2.0.0",
+    "@expo/config-plugins": "^3.0.0",
     "expo-modules-core": "~0.1.1",
     "uuid": "^3.4.0"
   },

--- a/packages/expo-dev-client/package.json
+++ b/packages/expo-dev-client/package.json
@@ -30,7 +30,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.io/versions/latest/sdk/module-template",
   "dependencies": {
-    "@expo/config-plugins": "^2.0.0",
+    "@expo/config-plugins": "^3.0.0",
     "expo-dev-launcher": "~0.5.1",
     "expo-dev-menu": "~0.7.0",
     "expo-dev-menu-interface": "~0.3.1",

--- a/packages/expo-dev-launcher/package.json
+++ b/packages/expo-dev-launcher/package.json
@@ -28,7 +28,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.io",
   "dependencies": {
-    "@expo/config-plugins": "^2.0.0",
+    "@expo/config-plugins": "^3.0.0",
     "resolve-from": "^5.0.0",
     "semver": "^7.3.5"
   },

--- a/packages/expo-dev-menu/package.json
+++ b/packages/expo-dev-menu/package.json
@@ -41,7 +41,7 @@
     "preset": "expo-module-scripts"
   },
   "dependencies": {
-    "@expo/config-plugins": "^2.0.0",
+    "@expo/config-plugins": "^3.0.0",
     "expo-dev-menu-interface": "0.3.1"
   },
   "devDependencies": {

--- a/packages/expo-document-picker/package.json
+++ b/packages/expo-document-picker/package.json
@@ -35,7 +35,7 @@
     "preset": "expo-module-scripts/ios"
   },
   "dependencies": {
-    "@expo/config-plugins": "^2.0.0",
+    "@expo/config-plugins": "^3.0.0",
     "expo-modules-core": "~0.1.1",
     "uuid": "^3.3.2"
   },

--- a/packages/expo-facebook/package.json
+++ b/packages/expo-facebook/package.json
@@ -40,7 +40,7 @@
     "expo-module-scripts": "^2.0.0"
   },
   "dependencies": {
-    "@expo/config-plugins": "^2.0.0",
+    "@expo/config-plugins": "^3.0.0",
     "expo-modules-core": "~0.1.1"
   }
 }

--- a/packages/expo-facebook/plugin/build/withFacebookAndroid.d.ts
+++ b/packages/expo-facebook/plugin/build/withFacebookAndroid.d.ts
@@ -9,6 +9,5 @@ export declare function getFacebookDisplayName(config: ExpoConfigFacebook): stri
 export declare function getFacebookAutoInitEnabled(config: ExpoConfigFacebook): boolean | null;
 export declare function getFacebookAutoLogAppEvents(config: ExpoConfigFacebook): boolean | null;
 export declare function getFacebookAdvertiserIDCollection(config: ExpoConfigFacebook): boolean | null;
-export declare function setFacebookAppIdString(config: ExpoConfigFacebook, projectRoot: string): Promise<boolean>;
 export declare function setFacebookConfig(config: ExpoConfigFacebook, androidManifest: AndroidConfig.Manifest.AndroidManifest): AndroidConfig.Manifest.AndroidManifest;
 export {};

--- a/packages/expo-facebook/plugin/build/withFacebookAndroid.js
+++ b/packages/expo-facebook/plugin/build/withFacebookAndroid.js
@@ -1,14 +1,9 @@
 "use strict";
-var __importDefault = (this && this.__importDefault) || function (mod) {
-    return (mod && mod.__esModule) ? mod : { "default": mod };
-};
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.setFacebookConfig = exports.setFacebookAppIdString = exports.getFacebookAdvertiserIDCollection = exports.getFacebookAutoLogAppEvents = exports.getFacebookAutoInitEnabled = exports.getFacebookDisplayName = exports.getFacebookAppId = exports.getFacebookScheme = exports.withFacebookManifest = exports.withFacebookAppIdString = void 0;
+exports.setFacebookConfig = exports.getFacebookAdvertiserIDCollection = exports.getFacebookAutoLogAppEvents = exports.getFacebookAutoInitEnabled = exports.getFacebookDisplayName = exports.getFacebookAppId = exports.getFacebookScheme = exports.withFacebookManifest = exports.withFacebookAppIdString = void 0;
 const config_plugins_1 = require("@expo/config-plugins");
-const assert_1 = __importDefault(require("assert"));
-const { buildResourceItem, readResourcesXMLAsync } = config_plugins_1.AndroidConfig.Resources;
-const { getProjectStringsXMLPathAsync, removeStringItem, setStringItem } = config_plugins_1.AndroidConfig.Strings;
-const { writeXMLAsync } = config_plugins_1.XML;
+const { buildResourceItem } = config_plugins_1.AndroidConfig.Resources;
+const { removeStringItem, setStringItem } = config_plugins_1.AndroidConfig.Strings;
 const { addMetaDataItemToMainApplication, getMainApplicationOrThrow, prefixAndroidKeys, removeMetaDataItemFromMainApplication, } = config_plugins_1.AndroidConfig.Manifest;
 const CUSTOM_TAB_ACTIVITY = 'com.facebook.CustomTabActivity';
 const STRING_FACEBOOK_APP_ID = 'facebook_app_id';
@@ -116,20 +111,6 @@ function ensureFacebookActivity({ mainApplication, scheme, }) {
     }
     return mainApplication;
 }
-async function setFacebookAppIdString(config, projectRoot) {
-    const stringsPath = await getProjectStringsXMLPathAsync(projectRoot);
-    assert_1.default(stringsPath, `There was a problem setting your Facebook App ID in "${stringsPath}"`);
-    let stringsJSON = await readResourcesXMLAsync({ path: stringsPath });
-    stringsJSON = applyFacebookAppIdString(config, stringsJSON);
-    try {
-        await writeXMLAsync({ path: stringsPath, xml: stringsJSON });
-    }
-    catch {
-        throw new Error(`Error setting facebookAppId. Cannot write strings.xml to "${stringsPath}"`);
-    }
-    return true;
-}
-exports.setFacebookAppIdString = setFacebookAppIdString;
 function applyFacebookAppIdString(config, stringsJSON) {
     const appId = getFacebookAppId(config);
     if (appId) {
@@ -148,9 +129,7 @@ function setFacebookConfig(config, androidManifest) {
     let mainApplication = getMainApplicationOrThrow(androidManifest);
     mainApplication = ensureFacebookActivity({ scheme, mainApplication });
     if (appId) {
-        mainApplication = addMetaDataItemToMainApplication(mainApplication, META_APP_ID, 
-        // The corresponding string is set in setFacebookAppIdString
-        `@string/${STRING_FACEBOOK_APP_ID}`);
+        mainApplication = addMetaDataItemToMainApplication(mainApplication, META_APP_ID, `@string/${STRING_FACEBOOK_APP_ID}`);
     }
     else {
         mainApplication = removeMetaDataItemFromMainApplication(mainApplication, META_APP_ID);

--- a/packages/expo-facebook/plugin/src/withFacebookAndroid.ts
+++ b/packages/expo-facebook/plugin/src/withFacebookAndroid.ts
@@ -3,14 +3,11 @@ import {
   ConfigPlugin,
   withAndroidManifest,
   withStringsXml,
-  XML,
 } from '@expo/config-plugins';
 import { ExpoConfig } from '@expo/config-types';
-import assert from 'assert';
 
-const { buildResourceItem, readResourcesXMLAsync } = AndroidConfig.Resources;
-const { getProjectStringsXMLPathAsync, removeStringItem, setStringItem } = AndroidConfig.Strings;
-const { writeXMLAsync } = XML;
+const { buildResourceItem } = AndroidConfig.Resources;
+const { removeStringItem, setStringItem } = AndroidConfig.Strings;
 const {
   addMetaDataItemToMainApplication,
   getMainApplicationOrThrow,
@@ -145,21 +142,6 @@ function ensureFacebookActivity({
   return mainApplication;
 }
 
-export async function setFacebookAppIdString(config: ExpoConfigFacebook, projectRoot: string) {
-  const stringsPath = await getProjectStringsXMLPathAsync(projectRoot);
-  assert(stringsPath, `There was a problem setting your Facebook App ID in "${stringsPath}"`);
-
-  let stringsJSON = await readResourcesXMLAsync({ path: stringsPath });
-  stringsJSON = applyFacebookAppIdString(config, stringsJSON);
-
-  try {
-    await writeXMLAsync({ path: stringsPath, xml: stringsJSON });
-  } catch {
-    throw new Error(`Error setting facebookAppId. Cannot write strings.xml to "${stringsPath}"`);
-  }
-  return true;
-}
-
 function applyFacebookAppIdString(
   config: ExpoConfigFacebook,
   stringsJSON: AndroidConfig.Resources.ResourceXML
@@ -196,7 +178,6 @@ export function setFacebookConfig(
     mainApplication = addMetaDataItemToMainApplication(
       mainApplication,
       META_APP_ID,
-      // The corresponding string is set in setFacebookAppIdString
       `@string/${STRING_FACEBOOK_APP_ID}`
     );
   } else {

--- a/packages/expo-file-system/package.json
+++ b/packages/expo-file-system/package.json
@@ -35,7 +35,7 @@
     "preset": "expo-module-scripts"
   },
   "dependencies": {
-    "@expo/config-plugins": "^2.0.0",
+    "@expo/config-plugins": "^3.0.0",
     "expo-modules-core": "~0.1.1",
     "uuid": "^3.4.0"
   },

--- a/packages/expo-image-picker/package.json
+++ b/packages/expo-image-picker/package.json
@@ -39,7 +39,7 @@
     "@unimodules/core": "*"
   },
   "dependencies": {
-    "@expo/config-plugins": "^2.0.0",
+    "@expo/config-plugins": "^3.0.0",
     "expo-modules-core": "~0.1.1",
     "expo-permissions": "~12.1.0",
     "uuid": "7.0.2"

--- a/packages/expo-local-authentication/package.json
+++ b/packages/expo-local-authentication/package.json
@@ -38,7 +38,7 @@
     "preset": "expo-module-scripts"
   },
   "dependencies": {
-    "@expo/config-plugins": "^2.0.0",
+    "@expo/config-plugins": "^3.0.0",
     "invariant": "^2.2.4"
   },
   "devDependencies": {

--- a/packages/expo-location/package.json
+++ b/packages/expo-location/package.json
@@ -42,7 +42,7 @@
     "expo-module-scripts": "^2.0.0"
   },
   "dependencies": {
-    "@expo/config-plugins": "^2.0.0",
+    "@expo/config-plugins": "^3.0.0",
     "expo-modules-core": "~0.1.1"
   }
 }

--- a/packages/expo-media-library/package.json
+++ b/packages/expo-media-library/package.json
@@ -38,7 +38,7 @@
     "preset": "expo-module-scripts/ios"
   },
   "dependencies": {
-    "@expo/config-plugins": "^2.0.0",
+    "@expo/config-plugins": "^3.0.0",
     "expo-modules-core": "~0.1.1"
   },
   "devDependencies": {

--- a/packages/expo-notifications/package.json
+++ b/packages/expo-notifications/package.json
@@ -43,7 +43,7 @@
     "expo-constants": ">=9.3.3 <11.0.0"
   },
   "dependencies": {
-    "@expo/config-plugins": "^2.0.0",
+    "@expo/config-plugins": "^3.0.0",
     "@expo/image-utils": "^0.3.10",
     "@ide/backoff": "^1.0.0",
     "abort-controller": "^3.0.0",

--- a/packages/expo-notifications/plugin/build/withNotificationsAndroid.d.ts
+++ b/packages/expo-notifications/plugin/build/withNotificationsAndroid.d.ts
@@ -1,4 +1,4 @@
-import { ConfigPlugin } from '@expo/config-plugins';
+import { AndroidConfig, ConfigPlugin } from '@expo/config-plugins';
 import { ExpoConfig } from '@expo/config-types';
 import { NotificationsPluginProps } from './withNotifications';
 declare type DPIString = 'mdpi' | 'hdpi' | 'xhdpi' | 'xxhdpi' | 'xxxhdpi';
@@ -29,11 +29,11 @@ export declare const withNotificationSounds: ConfigPlugin<{
 }>;
 export declare function getNotificationIcon(config: ExpoConfig): string | null;
 export declare function getNotificationColor(config: ExpoConfig): string | null;
+export declare function setNotificationIconColor(color: string | null, colors: AndroidConfig.Resources.ResourceXML): AndroidConfig.Resources.ResourceXML;
 /**
  * Applies notification icon configuration for expo-notifications
  */
 export declare function setNotificationIconAsync(projectRoot: string, icon: string | null): Promise<void>;
-export declare function setNotificationIconColorAsync(projectRoot: string, color: string | null): Promise<void>;
 /**
  * Save sound files to `<project-root>/android/app/src/main/res/raw`
  */

--- a/packages/expo-notifications/plugin/build/withNotificationsAndroid.js
+++ b/packages/expo-notifications/plugin/build/withNotificationsAndroid.js
@@ -1,12 +1,10 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.withNotificationsAndroid = exports.setNotificationSounds = exports.setNotificationIconColorAsync = exports.setNotificationIconAsync = exports.getNotificationColor = exports.getNotificationIcon = exports.withNotificationSounds = exports.withNotificationManifest = exports.withNotificationIconColor = exports.withNotificationIcons = exports.NOTIFICATION_ICON_COLOR_RESOURCE = exports.NOTIFICATION_ICON_COLOR = exports.NOTIFICATION_ICON_RESOURCE = exports.NOTIFICATION_ICON = exports.META_DATA_NOTIFICATION_ICON_COLOR = exports.META_DATA_NOTIFICATION_ICON = exports.dpiValues = exports.ANDROID_RES_PATH = void 0;
+exports.withNotificationsAndroid = exports.setNotificationSounds = exports.setNotificationIconAsync = exports.setNotificationIconColor = exports.getNotificationColor = exports.getNotificationIcon = exports.withNotificationSounds = exports.withNotificationManifest = exports.withNotificationIconColor = exports.withNotificationIcons = exports.NOTIFICATION_ICON_COLOR_RESOURCE = exports.NOTIFICATION_ICON_COLOR = exports.NOTIFICATION_ICON_RESOURCE = exports.NOTIFICATION_ICON = exports.META_DATA_NOTIFICATION_ICON_COLOR = exports.META_DATA_NOTIFICATION_ICON = exports.dpiValues = exports.ANDROID_RES_PATH = void 0;
 const config_plugins_1 = require("@expo/config-plugins");
 const image_utils_1 = require("@expo/image-utils");
 const fs_1 = require("fs");
 const path_1 = require("path");
-const { buildResourceItem, readResourcesXMLAsync } = config_plugins_1.AndroidConfig.Resources;
-const { writeXMLAsync } = config_plugins_1.XML;
 const { Colors } = config_plugins_1.AndroidConfig;
 exports.ANDROID_RES_PATH = 'android/app/src/main/res/';
 exports.dpiValues = {
@@ -38,14 +36,11 @@ exports.withNotificationIcons = (config, { icon }) => {
 };
 exports.withNotificationIconColor = (config, { color }) => {
     // If no color provided in the config plugin props, fallback to value from app.json
-    color = color || getNotificationColor(config);
-    return config_plugins_1.withDangerousMod(config, [
-        'android',
-        async (config) => {
-            await setNotificationIconColorAsync(config.modRequest.projectRoot, color);
-            return config;
-        },
-    ]);
+    return config_plugins_1.withAndroidColors(config, config => {
+        color = color || getNotificationColor(config);
+        config.modResults = setNotificationIconColor(color, config.modResults);
+        return config;
+    });
 };
 exports.withNotificationManifest = (config, { icon, color }) => {
     // If no icon or color provided in the config plugin props, fallback to value from app.json
@@ -75,6 +70,13 @@ function getNotificationColor(config) {
     return ((_a = config.notification) === null || _a === void 0 ? void 0 : _a.color) || null;
 }
 exports.getNotificationColor = getNotificationColor;
+function setNotificationIconColor(color, colors) {
+    return Colors.assignColorValue(colors, {
+        name: exports.NOTIFICATION_ICON_COLOR,
+        value: color,
+    });
+}
+exports.setNotificationIconColor = setNotificationIconColor;
 /**
  * Applies notification icon configuration for expo-notifications
  */
@@ -103,19 +105,6 @@ function setNotificationConfig(props, manifest) {
     }
     return manifest;
 }
-async function setNotificationIconColorAsync(projectRoot, color) {
-    const colorsXmlPath = await Colors.getProjectColorsXMLPathAsync(projectRoot);
-    let colorsJson = await readResourcesXMLAsync({ path: colorsXmlPath });
-    if (color) {
-        const colorItemToAdd = buildResourceItem({ name: exports.NOTIFICATION_ICON_COLOR, value: color });
-        colorsJson = Colors.setColorItem(colorItemToAdd, colorsJson);
-    }
-    else {
-        colorsJson = Colors.removeColorItem(exports.NOTIFICATION_ICON_COLOR, colorsJson);
-    }
-    await writeXMLAsync({ path: colorsXmlPath, xml: colorsJson });
-}
-exports.setNotificationIconColorAsync = setNotificationIconColorAsync;
 async function writeNotificationIconImageFilesAsync(icon, projectRoot) {
     await Promise.all(Object.values(exports.dpiValues).map(async ({ folderName, scale }) => {
         const drawableFolderName = folderName.replace('mipmap', 'drawable');

--- a/packages/expo-notifications/plugin/src/__tests__/withNotificationsAndroid-test.ts
+++ b/packages/expo-notifications/plugin/src/__tests__/withNotificationsAndroid-test.ts
@@ -5,9 +5,7 @@ import * as path from 'path';
 import {
   getNotificationColor,
   getNotificationIcon,
-  NOTIFICATION_ICON_COLOR,
   setNotificationIconAsync,
-  setNotificationIconColorAsync,
   setNotificationSounds,
 } from '../withNotificationsAndroid';
 
@@ -86,14 +84,7 @@ describe('Android notifications configuration', () => {
       '#123456'
     );
   });
-  it('writes to colors.xml correctly', async () => {
-    await setNotificationIconColorAsync(projectRoot, '#00ff00');
 
-    const after = getDirFromFS(vol.toJSON(), projectRoot);
-    expect(after['android/app/src/main/res/values/colors.xml']).toContain(
-      `<color name="${NOTIFICATION_ICON_COLOR}">#00ff00</color>`
-    );
-  });
   it('writes all the asset files (sounds and images) as expected', async () => {
     await setNotificationIconAsync(projectRoot, '/app/assets/notificationIcon.png');
     setNotificationSounds(projectRoot, ['/app/assets/notificationSound.wav']);

--- a/packages/expo-notifications/plugin/src/__tests__/withNotificationsiOS-test.ts
+++ b/packages/expo-notifications/plugin/src/__tests__/withNotificationsiOS-test.ts
@@ -22,6 +22,7 @@ const projectRoot = '/app';
 
 describe('iOS notifications configuration', () => {
   beforeAll(async () => {
+    jest.mock('fs');
     const sound = fsReal.readFileSync(soundPath);
     vol.fromJSON({ 'ios/testproject/AppDelegate.m': '' }, projectRoot);
     vol.mkdirpSync('/app/assets');

--- a/packages/expo-payments-stripe/package.json
+++ b/packages/expo-payments-stripe/package.json
@@ -33,7 +33,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.io/versions/latest/sdk/payments/",
   "dependencies": {
-    "@expo/config-plugins": "^2.0.0",
+    "@expo/config-plugins": "^3.0.0",
     "prop-types": "^15.6.0"
   },
   "devDependencies": {

--- a/packages/expo-screen-orientation/package.json
+++ b/packages/expo-screen-orientation/package.json
@@ -42,6 +42,6 @@
     "expo-module-scripts": "^2.0.0"
   },
   "dependencies": {
-    "@expo/config-plugins": "^2.0.0"
+    "@expo/config-plugins": "^3.0.0"
   }
 }

--- a/packages/expo-sensors/package.json
+++ b/packages/expo-sensors/package.json
@@ -43,7 +43,7 @@
     "@unimodules/core": "*"
   },
   "dependencies": {
-    "@expo/config-plugins": "^2.0.0",
+    "@expo/config-plugins": "^3.0.0",
     "expo-modules-core": "~0.1.1",
     "invariant": "^2.2.4"
   },

--- a/packages/expo-task-manager/package.json
+++ b/packages/expo-task-manager/package.json
@@ -33,7 +33,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.io/versions/latest/sdk/task-manager/",
   "dependencies": {
-    "@expo/config-plugins": "^2.0.0",
+    "@expo/config-plugins": "^3.0.0",
     "expo-modules-core": "~0.1.1",
     "unimodules-app-loader": "~2.2.0"
   },

--- a/packages/expo-tracking-transparency/package.json
+++ b/packages/expo-tracking-transparency/package.json
@@ -30,7 +30,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.io/versions/latest/sdk/module-template",
   "dependencies": {
-    "@expo/config-plugins": "^2.0.0",
+    "@expo/config-plugins": "^3.0.0",
     "expo-modules-core": "~0.1.1"
   },
   "devDependencies": {

--- a/packages/expo-updates/package.json
+++ b/packages/expo-updates/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@expo/metro-config": "^0.1.70",
-    "@expo/config-plugins": "^2.0.0",
+    "@expo/config-plugins": "^3.0.0",
     "expo-structured-headers": "~1.1.0",
     "expo-updates-interface": "^0.1.0",
     "fbemitter": "^2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2092,7 +2092,7 @@
     mv "~2"
     safe-json-stringify "~1"
 
-"@expo/config-plugins@2.0.0", "@expo/config-plugins@^2.0.0":
+"@expo/config-plugins@2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@expo/config-plugins/-/config-plugins-2.0.0.tgz#a76053612a8b3598d8017dcdeaa7ab42de14df84"
   integrity sha512-MyD9cdoVuXEw/xzpHiFNzRvMFi1DWTU2oShTTviA8xt1U1gyuBTa9aBwFSyvZmpMoCEscOsC8ED0sZl7LM5wNw==
@@ -2109,7 +2109,7 @@
     xcode "^3.0.1"
     xml2js "^0.4.23"
 
-"@expo/config-plugins@3.0.0":
+"@expo/config-plugins@3.0.0", "@expo/config-plugins@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@expo/config-plugins/-/config-plugins-3.0.0.tgz#29ed1cb1c5ecf3d12f5811bd39b13ac8f3a3c2aa"
   integrity sha512-kRPSFgnZvce/X1c+Zfq0k0H7oAirAhe4dWrT2ZZwOoBI8xQtRaRgqG5OpIEYXyYznvWYugbsOGJ72/ykBpu7Hg==


### PR DESCRIPTION
# Why

- Keep updated
- Use new mods for expo-notifications
- Remove dead code in expo-facebook