### PR TITLE
[client] Update NewManifest field paths for new extra field format

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/ExponentManifest.java
+++ b/android/expoview/src/main/java/host/exp/exponent/ExponentManifest.java
@@ -388,17 +388,8 @@ public class ExponentManifest {
   }
 
   private RawManifest newerManifest(RawManifest manifest1, RawManifest manifest2) throws JSONException, ParseException {
-    // use commitTime instead of publishedTime as it is more accurate;
-    // however, fall back to publishedTime in case older cached manifests do not contain
-    // the commitTime key (we have not always served it)
-    @Nullable String manifest1Timestamp = manifest1.getCommitTime();
-    if (manifest1Timestamp == null) {
-      manifest1Timestamp = manifest1.getPublishedTime();
-    }
-    @Nullable String manifest2Timestamp = manifest2.getCommitTime();
-    if (manifest2Timestamp == null) {
-      manifest2Timestamp = manifest2.getPublishedTime();
-    }
+    String manifest1Timestamp = manifest1.getSortTime();
+    String manifest2Timestamp = manifest2.getSortTime();
 
     // SimpleDateFormat on Android does not support the ISO-8601 representation of the timezone,
     // namely, using 'Z' to represent GMT. Since all our dates here are in the same timezone,

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🎉 New features
 
 - Use stable manifest ID where applicable. ([#12964](https://github.com/expo/expo/pull/12964) by [@wschurman](https://github.com/wschurman))
+- Update NewManifest field paths for new extra field format. ([#13398](https://github.com/expo/expo/pull/13398) by [@wschurman](https://github.com/wschurman))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/raw/BaseLegacyRawManifest.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/raw/BaseLegacyRawManifest.kt
@@ -37,4 +37,40 @@ abstract class BaseLegacyRawManifest(json: JSONObject) : RawManifest(json) {
 
   @Throws(JSONException::class)
   override fun getSDKVersion(): String = json.getString("sdkVersion")
+
+  override fun getExpoGoConfigRootObject(): JSONObject? {
+    return json
+  }
+
+  override fun getExpoClientConfigRootObject(): JSONObject? {
+    return json
+  }
+
+  override fun getSlug(): String? = if (json.has("slug")) {
+    json.optString("slug")
+  } else {
+    null
+  }
+
+  override fun getAppKey(): String? = if (json.has("appKey")) {
+    json.optString("appKey")
+  } else {
+    null
+  }
+
+  fun getCommitTime(): String? = if (json.has("commitTime")) {
+    json.optString("commitTime")
+  } else {
+    null
+  }
+
+  @Throws(JSONException::class)
+  private fun getPublishedTime(): String = json.getString("publishedTime")
+
+  override fun getSortTime(): String? {
+    // use commitTime instead of publishedTime as it is more accurate;
+    // however, fall back to publishedTime in case older cached manifests do not contain
+    // the commitTime key (we have not always served it)
+    return getCommitTime() ?: getPublishedTime()
+  }
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/raw/NewRawManifest.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/raw/NewRawManifest.kt
@@ -1,5 +1,9 @@
 package expo.modules.updates.manifest.raw
 
+import android.net.Uri
+import android.util.Log
+import expo.modules.updates.db.entity.AssetEntity
+import expo.modules.updates.manifest.NewManifest
 import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
@@ -61,4 +65,23 @@ class NewRawManifest(json: JSONObject) : RawManifest(json) {
 
   @Throws(JSONException::class)
   fun getCreatedAt(): String = json.getString("createdAt")
+
+  override fun getExpoGoConfigRootObject(): JSONObject? {
+    return getExtra()?.optJSONObject("expoGo")
+  }
+
+  override fun getExpoClientConfigRootObject(): JSONObject? {
+    return getExtra()?.optJSONObject("expoClient")
+  }
+
+  override fun getSlug(): String? = null
+  override fun getAppKey(): String? = null
+
+  override fun getSortTime(): String {
+    return getCreatedAt()
+  }
+
+  private fun getExtra(): JSONObject? {
+    return json.optJSONObject("extra")
+  }
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/raw/RawManifest.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/raw/RawManifest.kt
@@ -72,104 +72,101 @@ abstract class RawManifest(protected val json: JSONObject) {
 
   abstract fun getAssets(): JSONArray?
 
+  abstract fun getExpoGoConfigRootObject(): JSONObject?
+  abstract fun getExpoClientConfigRootObject(): JSONObject?
+
   fun isDevelopmentMode(): Boolean {
+    val expoGoRootObject = getExpoGoConfigRootObject() ?: return false
     return try {
-      json.has("developer") &&
-          json.has("packagerOpts") &&
-          json.getJSONObject("packagerOpts").optBoolean("dev", false)
+      expoGoRootObject.has("developer") &&
+              expoGoRootObject.has("packagerOpts") &&
+              expoGoRootObject.getJSONObject("packagerOpts").optBoolean("dev", false)
     } catch (e: JSONException) {
       false
     }
   }
 
   fun isDevelopmentSilentLaunch(): Boolean {
+    val expoGoRootObject = getExpoGoConfigRootObject() ?: return false
     return try {
-      json.has("developmentClient") &&
-          json.getJSONObject("developmentClient")
-            .optBoolean("silentLaunch", false)
+      expoGoRootObject.has("developmentClient") &&
+              expoGoRootObject.getJSONObject("developmentClient").optBoolean("silentLaunch", false)
     } catch (e: JSONException) {
       false
     }
   }
 
   fun isUsingDeveloperTool(): Boolean {
+    val expoGoRootObject = getExpoGoConfigRootObject() ?: return false
     return try {
-      json.has("developer") && json.getJSONObject("developer").has("tool")
+      expoGoRootObject.has("developer") && expoGoRootObject.getJSONObject(
+        "developer"
+      ).has("tool")
     } catch (e: JSONException) {
       false
     }
   }
 
-  fun getSlug(): String? = if (json.has("slug")) {
-    json.optString("slug")
-  } else {
-    null
-  }
+  abstract fun getSlug(): String?
 
-  fun getDebuggerHost(): String = json.optString("debuggerHost")
-  fun getMainModuleName(): String = json.optString("mainModuleName")
+  fun getDebuggerHost(): String = getExpoGoConfigRootObject()!!.getString("debuggerHost")
+  fun getMainModuleName(): String = getExpoGoConfigRootObject()!!.getString("mainModuleName")
 
   fun isVerified(): Boolean = json.optBoolean("isVerified")
 
-  fun getAppKey(): String? = if (json.has("appKey")) {
-    json.optString("appKey")
-  } else {
-    null
+  abstract fun getAppKey(): String?
+
+  fun getName(): String? {
+    val expoClientConfig = getExpoClientConfigRootObject() ?: return null
+    return expoClientConfig.optString("name")
   }
 
-  fun getName(): String? = if (json.has("name")) {
-    json.optString("name")
-  } else {
-    null
+  fun getUpdatesInfo(): JSONObject? {
+    val expoClientConfig = getExpoClientConfigRootObject() ?: return null
+    return expoClientConfig.optJSONObject("updates")
   }
 
-  fun getUpdatesInfo(): JSONObject? = json.optJSONObject("updates")
+  abstract fun getSortTime(): String?
 
-  fun getCommitTime(): String? = if (json.has("commitTime")) {
-    json.optString("commitTime")
-  } else {
-    null
+  fun getPrimaryColor(): String? {
+    val expoClientConfig = getExpoClientConfigRootObject() ?: return null
+    return expoClientConfig.optString("primaryColor")
   }
 
-  @Throws(JSONException::class)
-  fun getPublishedTime(): String = json.getString("publishedTime")
-
-  fun getPrimaryColor(): String? = if (json.has("primaryColor")) {
-    json.optString("primaryColor")
-  } else {
-    null
-  }
-
-  fun getOrientation(): String? = if (json.has("orientation")) {
-    json.optString("orientation")
-  } else {
-    null
+  fun getOrientation(): String? {
+    val expoClientConfig = getExpoClientConfigRootObject() ?: return null
+    return expoClientConfig.optString("orientation")
   }
 
   fun getAndroidKeyboardLayoutMode(): String? {
-    val android = json.optJSONObject("android") ?: return null
-    return android.optString("softwareKeyboardLayoutMode") ?: return null
+    val expoClientConfig = getExpoClientConfigRootObject() ?: return null
+    val android = expoClientConfig.optJSONObject("android") ?: return null
+    return android.optString("softwareKeyboardLayoutMode")
   }
 
   fun getAndroidUserInterfaceStyle(): String? {
-    val android = json.optJSONObject("android") ?: return null
-    return android.optString("userInterfaceStyle") ?: return null
+    val expoClientConfig = getExpoClientConfigRootObject() ?: return null
+    val android = expoClientConfig.optJSONObject("android") ?: return null
+    return android.optString("userInterfaceStyle")
   }
 
   fun getAndroidStatusBarOptions(): JSONObject? {
-    return json.optJSONObject("androidStatusBar")
+    val expoClientConfig = getExpoClientConfigRootObject() ?: return null
+    return expoClientConfig.optJSONObject("androidStatusBar")
   }
 
   fun getAndroidBackgroundColor(): String? {
+    val expoClientConfig = getExpoClientConfigRootObject() ?: return null
     return try {
-      json.getJSONObject("android").getString("backgroundColor")
+      expoClientConfig.getJSONObject("android").getString("backgroundColor")
     } catch (e: JSONException) {
-      json.optString("backgroundColor")
+      expoClientConfig.optString("backgroundColor")
     }
   }
 
   fun getAndroidNavigationBarOptions(): JSONObject? {
-    return json.optJSONObject("androidNavigationBar")
+    val expoClientConfig = getExpoClientConfigRootObject() ?: return null
+    return expoClientConfig.optJSONObject("androidNavigationBar")
   }
 
   fun getAndroidJsEngine(): String? {
@@ -178,45 +175,43 @@ abstract class RawManifest(protected val json: JSONObject) {
   }
 
   fun getIconUrl(): String? {
-    return json.optString("iconUrl")
+    val expoClientConfig = getExpoClientConfigRootObject() ?: return null
+    return expoClientConfig.optString("iconUrl")
   }
 
   fun getNotificationPreferences(): JSONObject? {
-    return json.optJSONObject("notification")
+    val expoClientConfig = getExpoClientConfigRootObject() ?: return null
+    return expoClientConfig.optJSONObject("notification")
   }
 
   fun getAndroidSplashInfo(): JSONObject? {
-    return json.optJSONObject("android")?.optJSONObject("splash")
+    val expoClientConfig = getExpoClientConfigRootObject() ?: return null
+    return expoClientConfig.optJSONObject("android")?.optJSONObject("splash")
   }
 
   fun getRootSplashInfo(): JSONObject? {
-    return json.optJSONObject("splash")
+    val expoClientConfig = getExpoClientConfigRootObject() ?: return null
+    return expoClientConfig.optJSONObject("splash")
   }
 
   fun getAndroidGoogleServicesFile(): String? {
-    val android = json.optJSONObject("android")
-    return if (android != null && android.has("googleServicesFile")) {
-      android.optString("googleServicesFile")
-    } else {
-      null
-    }
+    val expoClientConfig = getExpoClientConfigRootObject() ?: return null
+    val android = expoClientConfig.optJSONObject("android") ?: return null
+    return android.optString("googleServicesFile")
   }
 
   fun getAndroidPackageName(): String? {
-    val android = json.optJSONObject("android")
-    return if (android != null && android.has("packageName")) {
-      android.optString("packageName")
-    } else {
-      null
-    }
+    val expoClientConfig = getExpoClientConfigRootObject() ?: return null
+    val android = expoClientConfig.optJSONObject("android") ?: return null
+    return android.optString("packageName")
   }
 
   @Throws(JSONException::class)
-  fun getFacebookAppId(): String = json.getString("facebookAppId")
+  fun getFacebookAppId(): String = getExpoClientConfigRootObject()!!.getString("facebookAppId")
 
   @Throws(JSONException::class)
-  fun getFacebookApplicationName(): String = json.getString("facebookDisplayName")
+  fun getFacebookApplicationName(): String = getExpoClientConfigRootObject()!!.getString("facebookDisplayName")
 
   @Throws(JSONException::class)
-  fun getFacebookAutoInitEnabled(): Boolean = json.getBoolean("facebookAutoInitEnabled")
+  fun getFacebookAutoInitEnabled(): Boolean = getExpoClientConfigRootObject()!!.getBoolean("facebookAutoInitEnabled")
 }


### PR DESCRIPTION
# Why

https://github.com/expo/expo-cli/pull/3606 defines the new format for the `extra` field. `expoClientConfig` contains the fields necessary for the client to function (with the exception of scopeKey). `expoGoConfig` contains the fields necessary for development using Expo Go.

This PR updates the RawManifest and NewManifest to look in the new location for the fields it needs. Previously none of these fields were defined on the new manifest format.

# How

Point field getters to new location in NewManifests.

# Test Plan

In combination with https://github.com/expo/expo-cli/pull/3606:
- Run `EXPO_DEBUG=true ~/expo/expo-cli/node_modules/.bin/expo start` in a project.
- Load http://192.168.86.113:19000/update-manifest-experimental?platform=ios in the simulator with this PR, ensure all assets and fields resolve correctly.