### PR TITLE
[ci] Fix scheduled client build

### DIFF
--- a/.github/workflows/client-android.yml
+++ b/.github/workflows/client-android.yml
@@ -102,6 +102,8 @@ jobs:
         id: flavor
         uses: dorny/paths-filter@v2
         with:
+          # this action fails when base is not set on schedule event
+          base: ${{ github.event_name == 'schedule' && 'master' || null }}
           filters: |
             versioned:
               - android/versioned-abis/**

--- a/.github/workflows/client-android.yml
+++ b/.github/workflows/client-android.yml
@@ -103,7 +103,7 @@ jobs:
         uses: dorny/paths-filter@v2
         with:
           # this action fails when base is not set on schedule event
-          base: ${{ github.event_name == 'schedule' && 'master' || null }}
+          base: ${{ github.ref }}
           filters: |
             versioned:
               - android/versioned-abis/**

--- a/.github/workflows/client-ios.yml
+++ b/.github/workflows/client-ios.yml
@@ -93,6 +93,8 @@ jobs:
         id: flavor
         uses: dorny/paths-filter@v2
         with:
+          # this action fails when base is not set on schedule event
+          base: ${{ github.event_name == 'schedule' && 'master' || null }}
           filters: |
             versioned:
               - ios/versioned-react-native/**

--- a/.github/workflows/client-ios.yml
+++ b/.github/workflows/client-ios.yml
@@ -94,7 +94,7 @@ jobs:
         uses: dorny/paths-filter@v2
         with:
           # this action fails when base is not set on schedule event
-          base: ${{ github.event_name == 'schedule' && 'master' || null }}
+          base: ${{ github.ref }}
           filters: |
             versioned:
               - ios/versioned-react-native/**


### PR DESCRIPTION
# Why

GH action [`dorny/paths-filter@v2`](https://github.com/dorny/paths-filter) fails when `base` is not set on different events than `pull_request`.

See this workflow https://github.com/expo/expo/actions/runs/970366184

# How

Added the conditional `base` parameter. I set it to `${{ github.ref }}` according to docs: [Change detection workflow -> Long lived branch](https://github.com/dorny/paths-filter). Expected behavior:

> Workflow triggered by push event when base input parameter is the same as the branch that triggered the workflow:
> * Changes are detected against the most recent commit on the same branch before the push

> Workflow triggered by any other event when base input parameter is the same as the branch that triggered the workflow:
> * Changes are detected from the last commit

On scheduled events, it doesn't matter, because the `versioned` flavor is always chosen.

On `pull_request` event, the `base` param is ignored. 

# Test Plan

CI (will see if schedule runs properly next time)

_Edit: It ran properly_