### PR TITLE
[home] check for camera permissions on QR scanner deep link

### DIFF
--- a/home/components/QRCodeButton.tsx
+++ b/home/components/QRCodeButton.tsx
@@ -1,7 +1,10 @@
 import { useNavigation } from '@react-navigation/native';
 import * as React from 'react';
 
-import requestCameraPermissionsAsync from '../utils/requestCameraPermissionsAsync';
+import {
+  alertWithCameraPermissionInstructions,
+  requestCameraPermissionsAsync,
+} from '../utils/PermissionUtils';
 import ListItem from './ListItem';
 
 type Props = React.ComponentProps<typeof ListItem>;
@@ -13,7 +16,7 @@ function QRCodeButton(props: Props) {
     if (await requestCameraPermissionsAsync()) {
       navigation.navigate('QRCode');
     } else {
-      alert('In order to use the QR Code scanner you need to provide camera permissions');
+      await alertWithCameraPermissionInstructions();
     }
   };
   return (

--- a/home/navigation/Navigation.tsx
+++ b/home/navigation/Navigation.tsx
@@ -31,6 +31,7 @@ import QRCodeScreen from '../screens/QRCodeScreen';
 import SnacksForAccountScreen from '../screens/SnacksForAccountScreen';
 import UserSettingsScreen from '../screens/UserSettingsScreen';
 import Environment from '../utils/Environment';
+import requestCameraPermissionsAsync from '../utils/requestCameraPermissionsAsync';
 import BottomTab, { getNavigatorProps } from './BottomTabNavigator';
 import {
   DiagnosticsStackRoutes,
@@ -219,7 +220,7 @@ export default (props: { theme: ColorTheme }) => {
   const initialURLWasConsumed = React.useRef(false);
 
   React.useEffect(() => {
-    const handleDeepLinks = ({ url }: { url: string | null }) => {
+    const handleDeepLinks = async ({ url }: { url: string | null }) => {
       if (Platform.OS === 'ios' || !url || !isNavigationReadyRef.current) {
         return;
       }
@@ -229,7 +230,11 @@ export default (props: { theme: ColorTheme }) => {
       }
 
       if (url.startsWith('expo-home://qr-scanner')) {
-        nav.navigate('QRCode');
+        if (await requestCameraPermissionsAsync()) {
+          nav.navigate('QRCode');
+        } else {
+          alert('In order to use the QR Code scanner you need to provide camera permissions');
+        }
       }
     };
     if (!initialURLWasConsumed.current) {

--- a/home/navigation/Navigation.tsx
+++ b/home/navigation/Navigation.tsx
@@ -31,7 +31,10 @@ import QRCodeScreen from '../screens/QRCodeScreen';
 import SnacksForAccountScreen from '../screens/SnacksForAccountScreen';
 import UserSettingsScreen from '../screens/UserSettingsScreen';
 import Environment from '../utils/Environment';
-import requestCameraPermissionsAsync from '../utils/requestCameraPermissionsAsync';
+import {
+  alertWithCameraPermissionInstructions,
+  requestCameraPermissionsAsync,
+} from '../utils/PermissionUtils';
 import BottomTab, { getNavigatorProps } from './BottomTabNavigator';
 import {
   DiagnosticsStackRoutes,
@@ -233,7 +236,7 @@ export default (props: { theme: ColorTheme }) => {
         if (await requestCameraPermissionsAsync()) {
           nav.navigate('QRCode');
         } else {
-          alert('In order to use the QR Code scanner you need to provide camera permissions');
+          await alertWithCameraPermissionInstructions();
         }
       }
     };

--- a/home/utils/PermissionUtils.ts
+++ b/home/utils/PermissionUtils.ts
@@ -1,0 +1,27 @@
+import * as Permissions from 'expo-permissions';
+import { Alert, Linking } from 'react-native';
+
+export async function requestCameraPermissionsAsync(): Promise<boolean> {
+  const { status } = await Permissions.askAsync(Permissions.CAMERA);
+  return status === 'granted';
+}
+
+export async function alertWithCameraPermissionInstructions(): Promise<void> {
+  return Alert.alert(
+    'Permission needed',
+    'In order to use the QR code scanner, you must give permission for Expo Go to access the camera. You can grant this permission in the Settings app.',
+    [
+      {
+        text: 'Cancel',
+        style: 'cancel',
+      },
+      {
+        text: 'Go to Settings',
+        onPress: () => Linking.openSettings(),
+      },
+    ],
+    {
+      cancelable: true,
+    }
+  );
+}

--- a/home/utils/requestCameraPermissionsAsync.ts
+++ b/home/utils/requestCameraPermissionsAsync.ts
@@ -1,7 +1,0 @@
-import * as Permissions from 'expo-permissions';
-
-// TODO(@skevy): weird formatting here...see https://github.com/jlongster/prettier/issues/700
-export default (async function requestCameraPermissionsAsync(): Promise<boolean> {
-  const { status } = await Permissions.askAsync(Permissions.CAMERA);
-  return status === 'granted';
-});


### PR DESCRIPTION
# Why

resolves ENG-1340

# How

Add a permission check (analogous to the one in QRCodeButton.tsx) to the deep link handler in Navigation.tsx.

# Test Plan

Tested the following scenarios on a local Android build from sdk-42 (clearing app data in between each test):

- [x] Open Expo Go, press QR code button, grant permission, see camera
- [x] Open Expo Go, press QR code button, deny permission, see alert
- [x] Open dev client, press QR code button (deep links to Expo Go), grant permission, see camera
- [x] Open dev client, press QR code button (deep links to Expo Go), deny permission, see alert

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).