### PR TITLE
[docs] add account member_limit to working together doc

### DIFF
--- a/docs/pages/accounts/working-together.md
+++ b/docs/pages/accounts/working-together.md
@@ -6,7 +6,7 @@ You can grant other users access to the projects belonging to your Personal Acco
 
 ## Adding Members
 
-You can invite new members to your Personal Account, or any account you administrate, from the [Members page](https://expo.io/settings/members) in your dashboard. You can only add users with Expo accounts as members; you can direct them to [https://expo.io/signup](https://expo.io/signup) if they don't have an account yet. By default, you have up to 100 members and pending invitations for an account.
+You can invite new members to your Personal Account, or any account you administrate, from the [Members page](https://expo.io/settings/members) in your dashboard. You can only add users with Expo accounts as members; you can direct them to [https://expo.io/signup](https://expo.io/signup) if they don't have an account yet. You may have up to 100 members and pending invitations combined for a single account.
 
 > When adding new developers to your projects, who are publishing updates or create new builds, make sure to add the [`owner`](../versions/latest/config/app.md#owner) property to your project app manifest.
 

--- a/docs/pages/accounts/working-together.md
+++ b/docs/pages/accounts/working-together.md
@@ -6,7 +6,7 @@ You can grant other users access to the projects belonging to your Personal Acco
 
 ## Adding Members
 
-You can invite new members to your Personal Account, or any account you administrate, from the [Members page](https://expo.io/settings/members) in your dashboard. You can only add users with Expo accounts as members; you can direct them to [https://expo.io/signup](https://expo.io/signup) if they don't have an account yet.
+You can invite new members to your Personal Account, or any account you administrate, from the [Members page](https://expo.io/settings/members) in your dashboard. You can only add users with Expo accounts as members; you can direct them to [https://expo.io/signup](https://expo.io/signup) if they don't have an account yet. By default, you have up to 100 members and pending invitations for an account.
 
 > When adding new developers to your projects, who are publishing updates or create new builds, make sure to add the [`owner`](../versions/latest/config/app.md#owner) property to your project app manifest.
 


### PR DESCRIPTION
# Why

A prior PR (#7695) limited the amount of members / open pending invitations on an account to be 100 excluding bots. This PR reflects editing our docs to reflect this behavior. A subsequent PR will update the invitation GUI to reflect this limit.

# How

Added a sentence describing new behavior to `working-together.md`.

# Test Plan

N/A

# Checklist

N/A

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).