### PR TITLE
[dev-launcher][ios] Show blue screen only if needed

### DIFF
--- a/packages/expo-dev-launcher/ios/Errors/EXDevLauncherRedBox.m
+++ b/packages/expo-dev-launcher/ios/Errors/EXDevLauncherRedBox.m
@@ -131,13 +131,15 @@
                 isUpdate:(BOOL)isUpdate
              errorCookie:(int)errorCookie
 {
-  // Other errors should be handled by the LogBox
-  if (isUpdate == NO && errorCookie == -1) {
-    [self.logBox hide];
-    dispatch_async(dispatch_get_main_queue(), ^{
-      [[EXDevLauncherController sharedInstance].errorManager showErrorWithMessage:[self stripAnsi:message] stack:stack];
-    });
+  if (isUpdate || errorCookie != -1) {
+    // These errors should be handled by LogBox
+    return;
   }
+  
+  [self.logBox hide];
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [[EXDevLauncherController sharedInstance].errorManager showErrorWithMessage:[self stripAnsi:message] stack:stack];
+  });
 }
 
 - (RCTRedBox *)unsafe_castToRCTRedBox {

--- a/packages/expo-dev-launcher/ios/Errors/EXDevLauncherRedBox.m
+++ b/packages/expo-dev-launcher/ios/Errors/EXDevLauncherRedBox.m
@@ -131,10 +131,13 @@
                 isUpdate:(BOOL)isUpdate
              errorCookie:(int)errorCookie
 {
-  [self.logBox hide];
-  dispatch_async(dispatch_get_main_queue(), ^{
-    [[EXDevLauncherController sharedInstance].errorManager showErrorWithMessage:[self stripAnsi:message] stack:stack];
-  });
+  // Other errors should be handled by the LogBox
+  if (isUpdate == NO && errorCookie == -1) {
+    [self.logBox hide];
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [[EXDevLauncherController sharedInstance].errorManager showErrorWithMessage:[self stripAnsi:message] stack:stack];
+    });
+  }
 }
 
 - (RCTRedBox *)unsafe_castToRCTRedBox {


### PR DESCRIPTION
# Why

Fixes ENG-1420

# How

For some reason, RN calls the `showErrorMessage` on RedBox even if the error is handled by the LogBox. I've added a check to not show the blue screen if that is the case. 

# Test Plan

https://linear.app/expo/issue/ENG-1420/blue-screen-rather-than-red-screen-shown-for-some-js-errors