### PR TITLE
[dev-launcher][android] Fix can't reload app from the blue screen

### DIFF
--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
@@ -139,6 +139,12 @@ class DevLauncherController private constructor(
     }
   }
 
+  fun onAppLoadedWithError() {
+    synchronized(this) {
+      appIsLoading = false
+    }
+  }
+  
   fun getRecentlyOpenedApps(): Map<String, String?> = recentlyOpedAppsRegistry.getRecentlyOpenedApps()
 
   fun navigateToLauncher() {

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/react/DevLauncherDevSupportManager.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/react/DevLauncherDevSupportManager.kt
@@ -42,6 +42,8 @@ class DevLauncherDevSupportManager(
     if (activity == null || activity.isFinishing || activity.isDestroyed) {
       return
     }
+
+    DevLauncherController.instance.onAppLoadedWithError()
     DevLauncherErrorActivity.showError(activity, DevLauncherAppError(message, e))
   }
 }

--- a/packages/expo-dev-launcher/android/src/release/java/expo/modules/devlauncher/DevLauncherController.kt
+++ b/packages/expo-dev-launcher/android/src/release/java/expo/modules/devlauncher/DevLauncherController.kt
@@ -47,6 +47,10 @@ class DevLauncherController private constructor() {
     throw IllegalStateException(DEV_LAUNCHER_IS_NOT_AVAILABLE) 
   }
 
+  fun onAppLoadedWithError() {
+    throw IllegalStateException(DEV_LAUNCHER_IS_NOT_AVAILABLE) 
+  }
+
   companion object {
     private var sInstance: DevLauncherController? = null
 


### PR DESCRIPTION
# Why

Fixes can't reload the app from the blue screen.

# How

The reload button on the blue screen doesn't work, because we didn't reset the `appIsLoading` variable when the app loaded with an error. 

# Test Plan

- bare-expo ✅