### PR TITLE
[expo-splash-screen][ios] search for viewController with a RCTRootView

### DIFF
--- a/packages/expo-splash-screen/CHANGELOG.md
+++ b/packages/expo-splash-screen/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- On iOS, search for a view controller with a RCTRootView rather than always using the keyWindow's rootViewController. ([#13429](https://github.com/expo/expo/pull/13429) by [@esamelson](https://github.com/esamelson))
+
 ### 💡 Others
 
 ## 0.11.0 — 2021-06-16

--- a/packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenModule.m
+++ b/packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenModule.m
@@ -2,8 +2,15 @@
 
 #import <EXSplashScreen/EXSplashScreenModule.h>
 #import <EXSplashScreen/EXSplashScreenService.h>
+#import <React/RCTRootView.h>
 #import <UMCore/UMAppLifecycleService.h>
 #import <UMCore/UMUtilities.h>
+
+@protocol EXSplashScreenUtilService
+
+- (UIViewController *)currentViewController;
+
+@end
 
 @interface EXSplashScreenModule ()
 
@@ -30,7 +37,7 @@ UM_EXPORT_METHOD_AS(hideAsync,
   UM_WEAKIFY(self);
   dispatch_async(dispatch_get_main_queue(), ^{
     UM_ENSURE_STRONGIFY(self);
-    UIViewController *currentViewController = self.utilities.currentViewController;
+    UIViewController *currentViewController = [self reactViewController];
     [[self splashScreenService] hideSplashScreenFor:currentViewController
                                     successCallback:^(BOOL hasEffect){ resolve(@(hasEffect)); }
                                     failureCallback:^(NSString *message){ reject(@"ERR_SPLASH_SCREEN_CANNOT_HIDE", message, nil); }];
@@ -44,7 +51,7 @@ UM_EXPORT_METHOD_AS(preventAutoHideAsync,
   UM_WEAKIFY(self);
   dispatch_async(dispatch_get_main_queue(), ^{
     UM_ENSURE_STRONGIFY(self);
-    UIViewController *currentViewController = self.utilities.currentViewController;
+    UIViewController *currentViewController = [self reactViewController];
     [[self splashScreenService] preventSplashScreenAutoHideFor:currentViewController
                                                successCallback:^(BOOL hasEffect){ resolve(@(hasEffect)); }
                                                failureCallback:^(NSString *message){ reject(@"ERR_SPLASH_SCREEN_CANNOT_PREVENT_AUTOHIDE", message, nil); }];
@@ -62,7 +69,7 @@ UM_EXPORT_METHOD_AS(preventAutoHideAsync,
   UM_WEAKIFY(self);
   dispatch_async(dispatch_get_main_queue(), ^{
     UM_ENSURE_STRONGIFY(self);
-    UIViewController* currentViewController = self.utilities.currentViewController;
+    UIViewController* currentViewController = [self reactViewController];
     [[self splashScreenService] onAppContentDidAppear:currentViewController];
   });
 }
@@ -72,7 +79,7 @@ UM_EXPORT_METHOD_AS(preventAutoHideAsync,
   UM_WEAKIFY(self);
   dispatch_async(dispatch_get_main_queue(), ^{
     UM_ENSURE_STRONGIFY(self);
-    UIViewController* currentViewController = self.utilities.currentViewController;
+    UIViewController* currentViewController = [self reactViewController];
     [[self splashScreenService] onAppContentWillReload:currentViewController];
   });
 }
@@ -86,6 +93,55 @@ UM_EXPORT_METHOD_AS(preventAutoHideAsync,
 - (id<EXSplashScreenService>)splashScreenService
 {
   return [self.moduleRegistry getSingletonModuleForName:@"SplashScreen"];
+}
+
+/**
+ * Tries to obtain a reference to the UIViewController for the main RCTRootView
+ * by iterating through all of the application's windows and their viewControllers
+ * until it finds one with a RCTRootView.
+ */
+- (UIViewController *)reactViewController
+{
+  dispatch_assert_queue(dispatch_get_main_queue());
+
+  // first check to see if the host application has a module that provides the reference we want
+  // (this is the case in Expo Go and in the ExpoKit pod used in `expo build` apps)
+  id<EXSplashScreenUtilService> utilService = [_moduleRegistry getSingletonModuleForName:@"Util"];
+  if (utilService != nil) {
+    return [utilService currentViewController];
+  }
+
+  NSArray<UIWindow *> *allWindows;
+  if (@available(iOS 13, *)) {
+    NSSet<UIScene *> *allWindowScenes = UIApplication.sharedApplication.connectedScenes;
+    NSMutableArray<UIWindow *> *allForegroundWindows = [NSMutableArray new];
+    for (UIScene *scene in allWindowScenes.allObjects) {
+      if ([scene isKindOfClass:[UIWindowScene class]] && scene.activationState == UISceneActivationStateForegroundActive) {
+        [allForegroundWindows addObjectsFromArray:((UIWindowScene *)scene).windows];
+      }
+    }
+    allWindows = allForegroundWindows;
+  } else {
+    allWindows = UIApplication.sharedApplication.windows;
+  }
+
+  for (UIWindow *window in allWindows) {
+    UIViewController *controller = window.rootViewController;
+    if ([controller.view isKindOfClass:[RCTRootView class]]) {
+      return controller;
+    }
+    UIViewController *presentedController = controller.presentedViewController;
+    while (presentedController && ![presentedController isBeingDismissed]) {
+      if ([presentedController.view isKindOfClass:[RCTRootView class]]) {
+        return presentedController;
+      }
+      controller = presentedController;
+      presentedController = controller.presentedViewController;
+    }
+  }
+
+  // if all else fails, fall back to the key window
+  return self.utilities.currentViewController;
 }
 
 @end

--- a/packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenModule.m
+++ b/packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenModule.m
@@ -111,6 +111,22 @@ UM_EXPORT_METHOD_AS(preventAutoHideAsync,
     return [utilService currentViewController];
   }
 
+  UIViewController *controller = [self viewControllerContainingRCTRootView];
+  if (!controller) {
+    // no RCTRootView was found, so just fall back to the key window's root view controller
+    return self.utilities.currentViewController;
+  }
+
+  UIViewController *presentedController = controller.presentedViewController;
+  while (presentedController && ![presentedController isBeingDismissed]) {
+    controller = presentedController;
+    presentedController = controller.presentedViewController;
+  }
+  return controller;
+}
+
+- (nullable UIViewController *)viewControllerContainingRCTRootView
+{
   NSArray<UIWindow *> *allWindows;
   if (@available(iOS 13, *)) {
     NSSet<UIScene *> *allWindowScenes = UIApplication.sharedApplication.connectedScenes;
@@ -140,8 +156,8 @@ UM_EXPORT_METHOD_AS(preventAutoHideAsync,
     }
   }
 
-  // if all else fails, fall back to the key window
-  return self.utilities.currentViewController;
+  // no RCTRootView was found
+  return nil;
 }
 
 @end


### PR DESCRIPTION
# Why

resolves ENG-1373 -- slightly better version of #13426

Rather than making assumptions about who owns the UIWindow we need, let's just cycle through all of the application's windows until we find a RCTRootView, and return its view controller.

# How

Add a `reactViewController` method to EXSplashScreenModule, which reads from the managed workflow internal module if it exists (stealing this code from `UMUtilities`) and then iterates through the application's windows to find a view controller with a RCTRootView, before falling back to the original `UMUtilities` code if it can't find one.

# Test Plan

```
expo init (tabs)
yarn add expo-dev-client
expo prebuild
```
- Make this change in local node_modules
- Build and run project from Xcode, then stop it without interacting at all with the dev menu
- `expo start --dev-client` then press `i`

Project should open and splash screen should hide while dev menu also appears automatically.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).