### PR TITLE
[expo-dev-client] pin versions of dev-client-specific dependencies

### DIFF
--- a/packages/expo-dev-client/package.json
+++ b/packages/expo-dev-client/package.json
@@ -31,9 +31,9 @@
   "homepage": "https://docs.expo.io/versions/latest/sdk/module-template",
   "dependencies": {
     "@expo/config-plugins": "^3.0.0",
-    "expo-dev-launcher": "~0.5.1",
-    "expo-dev-menu": "~0.7.0",
-    "expo-dev-menu-interface": "~0.3.1",
+    "expo-dev-launcher": "0.5.1",
+    "expo-dev-menu": "0.7.0",
+    "expo-dev-menu-interface": "0.3.1",
     "expo-updates-interface": "~0.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
# Why

I think it will be easier to both diagnose/reproduce issues and release fixes if we pin the expo-dev-client package to exact versions of the dev-launcher/dev-menu/dev-menu-interface packages.

- If we release new patch versions of dev-launcher/dev-menu, AFAIK there isn't a great way for people using the expo-dev-client package to get the patches without upgrading all the transitive dependencies in their entire project. Whereas if we release a new expo-dev-client patch at the same time, users can be deliberate about when/if they want to upgrade.
- It's easier to understand what's going on in bug reports; if users tell us they have `expo-dev-client@0.4.2` installed we can be sure about what dev-launcher/dev-menu code they have, whereas if the versions are unpinned there's an extra step on their end or ours to figure this out.
- It's also easier to conceptualize expo-dev-client as a single package this way; with the unpinned versions any given "version" of expo-dev-client might have many possibilities for the actual code it adds to the project.

I don't think we should pin shared dependencies like `expo-updates-interface`; it's too easy to get mismatched versions (and therefore duplicate copies) this way, but after discussing with @tcdavis today I do think the benefits outweigh the costs for these 3 packages, since no one else should be depending on them directly.

# How

Remove `~` from package.json version matchers.

# Test Plan

Land this and cherry-pick to sdk-42 branch, `et publish expo-dev-client` and make sure it publishes a new version even when there are only patch version bumps.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).