### PR TITLE
[docs] Update dev client EAS Build setup instructions

### DIFF
--- a/docs/pages/clients/eas-build.md
+++ b/docs/pages/clients/eas-build.md
@@ -7,74 +7,9 @@ import { Tab, Tabs } from '~/components/plugins/Tabs';
 
 ## Setting up EAS
 
-You can set up your project to use EAS by running `eas build:configure`.  If you have not installed EAS CLI yet, you can do so by running `npm install -g eas-cli` (or `yarn global add eas-cli`.)
+You can set up your project to use EAS Build by running `eas build:configure`. This command automatically adds a [build profile](build/eas-json/#build-profiles) named `development` that builds your client.
 
-## Modifying your EAS.json
-
-Now edit your eas.json to look like this:
-
-<Tabs tabs={["With config plugins", "If you are directly managing your native projects"]}>
-
-<Tab >
-
-```json
-{
-  "builds": {
-    "android": {
-      "release": {
-        "workflow": "managed"
-      },
-      "development": {
-        "workflow": "managed",
-        "distribution": "internal",
-        "buildType": "development-client"
-      }
-    },
-    "ios": {
-      "release": {
-        "workflow": "managed"
-      },
-      "development": {
-        "workflow": "managed",
-        "distribution": "internal",
-        "buildType": "development-client"
-      }
-    }
-  }
-}
-```
-</Tab>
-<Tab>
-
-```json
-{
-  "builds": {
-    "android": {
-      "release": {
-        "workflow": "generic",
-        "gradleCommand": ":app:bundleRelease"
-      },
-      "development": {
-        "workflow": "generic",
-        "distribution": "internal",
-        "gradleCommand": ":app:assembleDebug"
-      }
-    },
-    "ios": {
-      "release": {
-        "workflow": "generic"
-      },
-      "development": {
-        "workflow": "generic",
-        "distribution": "internal",
-        "schemeBuildConfiguration": "Debug"
-      }
-    }
-  }
-}
-```
-</Tab>
-</Tabs>
+> If you have not installed EAS CLI yet, you can do so by running `npm install -g eas-cli` (or `yarn global add eas-cli`.
 
 ## Generating your first build
 
@@ -92,7 +27,7 @@ Register any devices you would like to use your development client on to your ad
 Generate the build signed with your ad hoc provisioning profile.
 <InstallSection packageName="expo-dev-launcher" cmd={["eas build --profile development --platform ios"]} hideBareInstructions />
 
-You will need to generate a new build to install successfully on any new devices added to your provisioning profile.  [You can find more guidance on distributing your app to your team here.](https://docs.expo.io/build/internal-distribution/)
+You will need to generate a new build to install successfully on any new devices added to your provisioning profile. [You can find more guidance on distributing your app to your team here.](https://docs.expo.io/build/internal-distribution/)
 
 ### For Android:
 


### PR DESCRIPTION
# Why

`eas build:configure` adds `eas.json` profile for building dev clients, so the manual steps are no longer necessary.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).