### PR TITLE
[docs][dev-client] Make enabling `improved error messages` an additional installation step in managed

### DIFF
--- a/docs/pages/clients/getting-started.md
+++ b/docs/pages/clients/getting-started.md
@@ -20,6 +20,8 @@ If you have used Expo before, especially with the Managed workflow, [config plug
 <Tab >
 <TerminalBlock cmd={["expo init # if you don't already have a Managed Workflow project", "yarn add expo-dev-client"]}  />
 
+> You can also improve error messages what will be helpful during the development process. To do it, you need to add `import 'expo-dev-client';` on top of your `App.{js|tsx}` file. [Learn more](installation.md#add-better-error-handlers).
+
 </Tab>
 
 <Tab >

--- a/docs/pages/clients/installation.md
+++ b/docs/pages/clients/installation.md
@@ -76,10 +76,12 @@ When you start your project on iOS, the metro bundler will be started automatica
 
 ### Add better error handlers
 
-Sometimes, for certain types of errors, we can provide more helpful error messages than the ones that ship by default with React Native. To turn this feature on you need to import `expo-dev-client` in your `index` file. Make sure that the import statement is above of `import App from './App'`.
+Sometimes, for certain types of errors, we can provide more helpful error messages than the ones that ship by default with React Native. To turn this feature on you need to import `expo-dev-client` in your `index` file (in the managed workflow, you need to add this import on top of the `App.{js|tsx}`). Make sure that the import statement is above of `import App from './App'`.
 
 ```js
 import 'expo-dev-client';
 ...
 import App from "./App";
 ```
+
+> Note: This will only affect application which uses modified index file. If you are loading multiple applications, you need to add this import statement to each of them.


### PR DESCRIPTION
# Why

To enable extended messages, you need to import `expo-dev-client` into your project - we inject this via config plugin, but if you run expo `run:ios`, it will create a copy of your project and then run expo eject in the temp folder. However, the launcher is started from the main project directory (not the temp one). So your app won’t contain the import statement.

To fix that users need to enable `improved error messages` in managed by themselves. I've changed the documentation to reflect this.