### PR TITLE
[dev-launcher][plugin] Ensure that `withErrorHandling` is triggered on every platform

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -16,10 +16,10 @@
 - Fixed switching from published to local bundle loading on Android. ([#13363](https://github.com/expo/expo/pull/13363) by [@esamelson](https://github.com/esamelson))
 - [plugin] Use Node module resolution to find package paths for Podfile ([#13382](https://github.com/expo/expo/pull/13382) by [@fson](https://github.com/fson))
 - Send expo-updates-environment: DEVELOPMENT header in manifest requests. ([#13375](https://github.com/expo/expo/pull/13375) by [@esamelson](https://github.com/esamelson))
-
 - Fixed can't reload app from the blue screen. ([#13422](https://github.com/expo/expo/pull/13422) by [@lukmccall](https://github.com/lukmccall))
 - Fixed `JSPackagerClient` wasn't close on React Native 0.63.4 what may lead to various bugs on Android. ([#13423](https://github.com/expo/expo/pull/13423) by [@lukmccall](https://github.com/lukmccall))
 - Fixed the blue screen was shown instead of the LogBox on iOS. ([#13421](https://github.com/expo/expo/pull/13421) by [@lukmccall](https://github.com/lukmccall))
+- [plugin] Fixed error handlers weren't initialize after running `expo run:ios`. ([#13438](https://github.com/expo/expo/pull/13438) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/plugin/build/withDevLauncher.js
+++ b/packages/expo-dev-launcher/plugin/build/withDevLauncher.js
@@ -168,19 +168,21 @@ const withDevLauncherPodfile = config => {
     ]);
 };
 const withErrorHandling = config => {
-    return config_plugins_1.withDangerousMod(config, [
-        // We want to edit js file, but for the `DangerousMod` we need to select a platform.
-        'android',
-        async (config) => {
-            await editIndex(config, index => {
-                if (!index.includes(DEV_LAUNCHER_JS_REGISTER_ERROR_HANDLERS)) {
-                    index = DEV_LAUNCHER_JS_REGISTER_ERROR_HANDLERS + '\n\n' + index;
-                }
-                return index;
-            });
-            return config;
-        },
-    ]);
+    const injectErrorHandlers = async (config) => {
+        await editIndex(config, index => {
+            if (!index.includes(DEV_LAUNCHER_JS_REGISTER_ERROR_HANDLERS)) {
+                index = DEV_LAUNCHER_JS_REGISTER_ERROR_HANDLERS + '\n\n' + index;
+            }
+            return index;
+        });
+        return config;
+    };
+    // We need to run the same task twice to ensure it will work on both platforms,
+    // because if someone runs `expo run:ios`, it will trigger only dangerous mode for that specific platform.
+    // Note: after the first execution, the second one won't change anything.
+    config = config_plugins_1.withDangerousMod(config, ['android', injectErrorHandlers]);
+    config = config_plugins_1.withDangerousMod(config, ['ios', injectErrorHandlers]);
+    return config;
 };
 const withDevLauncher = (config) => {
     config = withDevLauncherActivity(config);


### PR DESCRIPTION
# Why

Closes ENG-1442.

# How

If someone runs `expo run:ios`, the config plugin won't modify `index.js`, because `withDangerousMod` is tied to the platform. 

# Test Plan

- run `expo run:ios` and check if the `index.js` was modified ✅
- run `expo eject` and check if the `index.js` was modified ✅