### PR TITLE
[constants][updates] update bundle scripts to correctly find project

### DIFF
--- a/packages/expo-constants/CHANGELOG.md
+++ b/packages/expo-constants/CHANGELOG.md
@@ -11,6 +11,8 @@
 ### 🐛 Bug fixes
 
 - fix `__dir__` absolute path in script_phase making an inconsistent Podfile.lock. ([#13610](https://github.com/expo/expo/pull/13610) by [@kudo](https://github.com/kudo))
+- Fix `PROJECT_ROOT` path resolution in `get-app-config-ios.sh`. ([#13439](https://github.com/expo/expo/pull/13439) by [@ajsmth](https://github.com/ajsmth))
+
 
 ### 💡 Others
 

--- a/packages/expo-constants/scripts/get-app-config-ios.sh
+++ b/packages/expo-constants/scripts/get-app-config-ios.sh
@@ -5,8 +5,13 @@ set -eo pipefail
 DEST="$CONFIGURATION_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH"
 NODE_BINARY=${NODE_BINARY:-node}
 
-# Related to: https://github.com/facebook/react-native/blob/c9f869f9c7c8b035a669980382af4bbd4afecb89/scripts/react-native-xcode.sh#L59-L69
-PROJECT_ROOT=${PROJECT_ROOT:-$PWD}
+# ref: https://github.com/facebook/react-native/blob/c974cbff04a8d90ac0f856dbada3fc5a75c75b49/scripts/react-native-xcode.sh#L59-L65
+# Path to expo-constants folder inside node_modules
+EXPO_CONSTANTS_PACKAGE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# The project should be located next to where expo-constants is installed
+# in node_modules.
+PROJECT_ROOT=${PROJECT_ROOT:-"$EXPO_CONSTANTS_PACKAGE_DIR/../.."}
+
 cd "$PROJECT_ROOT" || exit
 
 if ! [ -x "$(command -v $NODE_BINARY)" ]; then
@@ -22,4 +27,4 @@ if [ "x$DIR_BASENAME" != "xPods" ]; then
   exit 0
 fi
 
-"$NODE_BINARY" "$(dirname "${BASH_SOURCE[0]}")/getAppConfig.js" "$PROJECT_ROOT/.." "$DEST/EXConstants.bundle"
+"$NODE_BINARY" "${EXPO_CONSTANTS_PACKAGE_DIR}/scripts/getAppConfig.js" "$PROJECT_ROOT" "$DEST"

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Improve behavior of dev client (with updates integration) when developer is logged out of expo-cli. ([#13310](https://github.com/expo/expo/pull/13310) by [@esamelson](https://github.com/esamelson))
 - Remove usage of deprecated `[RCTBridge reload]` method. ([#13501](https://github.com/expo/expo/pull/13501) by [@esamelson](https://github.com/esamelson))
 - Remove side effects from UpdatesDevLauncherController.initialize() method. ([#13555](https://github.com/expo/expo/pull/13555) by [@esamelson](https://github.com/esamelson))
+- Fix `PROJECT_ROOT` path resolution in `create-manifest-ios.sh` and in `createManifest.js` ([#13439](https://github.com/expo/expo/pull/13439) by [@ajsmth](https://github.com/ajsmth))
 
 ### 💡 Others
 

--- a/packages/expo-updates/scripts/create-manifest-ios.sh
+++ b/packages/expo-updates/scripts/create-manifest-ios.sh
@@ -7,8 +7,13 @@ ENTRY_FILE=${ENTRY_FILE:-index.js}
 RCT_METRO_PORT=${RCT_METRO_PORT:=8081}
 NODE_BINARY=${NODE_BINARY:-node}
 
-# Related to: https://github.com/facebook/react-native/blob/c9f869f9c7c8b035a669980382af4bbd4afecb89/scripts/react-native-xcode.sh#L59-L69
-PROJECT_ROOT=${PROJECT_ROOT:-$PWD}
+
+# ref: https://github.com/facebook/react-native/blob/c974cbff04a8d90ac0f856dbada3fc5a75c75b49/scripts/react-native-xcode.sh#L59-L65
+EXPO_UPDATES_PACKAGE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# The project should be located next to where expo-updates is installed
+# in node_modules.
+PROJECT_ROOT=${PROJECT_ROOT:-"$EXPO_UPDATES_PACKAGE_DIR/../.."}
+
 cd "$PROJECT_ROOT" || exit
 
 if ! [ -x "$(command -v $NODE_BINARY)" ]; then
@@ -18,4 +23,4 @@ if ! [ -x "$(command -v $NODE_BINARY)" ]; then
   exit 1
 fi
 
-"$NODE_BINARY" "$(dirname "${BASH_SOURCE[0]}")/createManifest.js" ios "$PROJECT_ROOT" "$DEST"
+"$NODE_BINARY" "${EXPO_UPDATES_PACKAGE_DIR}/scripts/createManifest.js" ios "$PROJECT_ROOT" "$DEST"

--- a/packages/expo-updates/scripts/createManifest.js
+++ b/packages/expo-updates/scripts/createManifest.js
@@ -15,7 +15,7 @@ const filterPlatformAssetScales = require('./filterPlatformAssetScales');
   // Remove projectRoot validation when we no longer support React Native <= 62
   let projectRoot;
   if (fs.existsSync(path.join(possibleProjectRoot, entryFile))) {
-    projectRoot = possibleProjectRoot;
+    projectRoot = path.resolve(possibleProjectRoot);
   } else if (fs.existsSync(path.join(possibleProjectRoot, '..', entryFile))) {
     projectRoot = path.resolve(possibleProjectRoot, '..');
   }


### PR DESCRIPTION
# Why

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

closes ENG-1421

The scripts that run during the `Bundle React Native code and images` build phase were executing in the wrong directory.
This would lead to issues where any `app.config.js` that read from `process.cwd()` (e.g `dotenv` stuff) returning undefined values

The `getConfig.js` node script in particular is problematic, because it searches and finds the project root but does not update the `process.cwd()` value , so this issue was failing silently.

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

I used the `react-native-xcode.sh` script as a reference to properly find the project root in these shell scripts

# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->

## Before:

- update `bare-expo`'s config to a JS file: `app.config.js` 
- console.log out `process.cwd()` and `_dirname` values
- build the project and view logs - note the `cwd` value - node is executed in the `ios` directory of the node_module

<img width="1015" alt="Screen Shot 2021-06-29 at 12 47 09 PM" src="https://user-images.githubusercontent.com/40680668/123859179-33977980-d8d9-11eb-87b2-f9008865b9cb.png">

## After:

- checkout this branch and rebuild
- note that the directory is correctly assigned: 

<img width="899" alt="Screen Shot 2021-06-29 at 12 45 06 PM" src="https://user-images.githubusercontent.com/40680668/123859263-4ca02a80-d8d9-11eb-868f-28b2e038c529.png">


In my experiments I also used `dotenv` in the `app.config.js` file to log out some custom values, ensuring that they were properly captured 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).