### PR TITLE
[ios] Fix bug where we attempt to validate manifest instance rather than JSON as a JSON object

### DIFF
--- a/ios/Client/Menu/EXDevMenuViewController.m
+++ b/ios/Client/Menu/EXDevMenuViewController.m
@@ -95,9 +95,10 @@
 {
   EXKernelAppRecord *visibleApp = [EXKernel sharedInstance].visibleApp;
   NSString *manifestString = nil;
-  if (visibleApp.appLoader.manifest && [NSJSONSerialization isValidJSONObject:visibleApp.appLoader.manifest]) {
+  EXUpdatesRawManifest *manifest = visibleApp.appLoader.manifest;
+  if (manifest && [NSJSONSerialization isValidJSONObject:manifest.rawManifestJSON]) {
     NSError *error;
-    NSData *jsonData = [NSJSONSerialization dataWithJSONObject:visibleApp.appLoader.manifest.rawManifestJSON options:0 error:&error];
+    NSData *jsonData = [NSJSONSerialization dataWithJSONObject:manifest.rawManifestJSON options:0 error:&error];
     if (jsonData) {
       manifestString = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
     } else {


### PR DESCRIPTION
# Why

## Before
![IMG_0337](https://user-images.githubusercontent.com/90494/123876438-3487d580-d8f0-11eb-9c2b-0c2b9914391a.jpeg)

## After
![Simulator Screen Shot - iPhone 8 - 2021-06-29 at 15 39 25](https://user-images.githubusercontent.com/90494/123876447-3b164d00-d8f0-11eb-8694-1be0c0de78cd.png)

# How

`[NSJSONSerialization isValidJSONObject:manifest]` -> `[NSJSONSerialization isValidJSONObject:manifest.rawManifestJSON]`

# Test Plan

Run Expo Go, open an existing project with a name and an icon, verify that it appears in dev menu.