### PR TITLE
Added info about manifest merging to config plugin docs

### DIFF
--- a/docs/components/base/code.tsx
+++ b/docs/components/base/code.tsx
@@ -109,7 +109,39 @@ export class Code extends React.Component<Props> {
     return text.replace(/"/g, '&quot;');
   }
 
-  private replaceCommentsWithAnnotations(value: string) {
+  private replaceXmlCommentsWithAnnotations(value: string) {
+    return value
+      .replace(
+        /<span class="token comment">&lt;!-- @info (.*?)--><\/span>\s*/g,
+        (match, content) => {
+          return `<span class="code-annotation" data-tippy-content="${this.escapeHtml(content)}">`;
+        }
+      )
+      .replace(
+        /<span class="token comment">&lt;!-- @hide (.*?)--><\/span>\s*/g,
+        (match, content) => {
+          return `<span><span class="code-hidden">%%placeholder-start%%</span><span class="code-placeholder">${this.escapeHtml(
+            content
+          )}</span><span class="code-hidden">%%placeholder-end%%</span><span class="code-hidden">`;
+        }
+      )
+      .replace(/<span class="token comment">&lt;!-- @end --><\/span>(\n *)?/g, '</span></span>');
+  }
+
+  private replaceHashCommentsWithAnnotations(value: string) {
+    return value
+      .replace(/<span class="token comment"># @info (.*?)#<\/span>\s*/g, (match, content) => {
+        return `<span class="code-annotation" data-tippy-content="${this.escapeHtml(content)}">`;
+      })
+      .replace(/<span class="token comment"># @hide (.*?)#<\/span>\s*/g, (match, content) => {
+        return `<span><span class="code-hidden">%%placeholder-start%%</span><span class="code-placeholder">${this.escapeHtml(
+          content
+        )}</span><span class="code-hidden">%%placeholder-end%%</span><span class="code-hidden">`;
+      })
+      .replace(/<span class="token comment"># @end #<\/span>(\n *)?/g, '</span></span>');
+  }
+
+  private replaceSlashCommentsWithAnnotations(value: string) {
     return value
       .replace(/<span class="token comment">\/\* @info (.*?)\*\/<\/span>\s*/g, (match, content) => {
         return `<span class="code-annotation" data-tippy-content="${this.escapeHtml(content)}">`;
@@ -141,7 +173,13 @@ export class Code extends React.Component<Props> {
       }
 
       html = Prism.highlight(html, grammar, lang as Language);
-      html = this.replaceCommentsWithAnnotations(html);
+      if (['properties', 'rb'].includes(lang)) {
+        html = this.replaceHashCommentsWithAnnotations(html);
+      } else if (['xml', 'html'].includes(lang)) {
+        html = this.replaceXmlCommentsWithAnnotations(html);
+      } else {
+        html = this.replaceSlashCommentsWithAnnotations(html);
+      }
     }
 
     // Remove leading newline if it exists (because inside <pre> all whitespace is dislayed as is by the browser, and

--- a/docs/components/base/languages/index.ts
+++ b/docs/components/base/languages/index.ts
@@ -4,12 +4,14 @@ import { installGroovy } from './groovy';
 import { installJson5 } from './json5';
 import { installKotlin } from './kotlin';
 import { installObjectiveC } from './objectivec';
+import { installProperties } from './properties';
 import { installRuby } from './ruby';
 import { installSwift } from './swift';
 
 export function installLanguages(prism: typeof Prism) {
   installGroovy(prism);
   installObjectiveC(prism);
+  installProperties(prism);
   installRuby(prism);
   installJson5(prism);
   installKotlin(prism);

--- a/docs/components/base/languages/properties.ts
+++ b/docs/components/base/languages/properties.ts
@@ -1,0 +1,13 @@
+export function installProperties(Prism: any) {
+  // https://github.com/PrismJS/prism/blob/e0ee93f138b7da294a28db50b97c22977fdfc8ed/components/prism-properties.js
+  Prism.languages.properties = {
+    comment: /^[ \t]*[#!].*$/m,
+    'attr-value': {
+      pattern:
+        /(^[ \t]*(?:\\(?:\r\n|[\s\S])|[^\\\s:=])+?(?: *[=:] *(?! )| ))(?:\\(?:\r\n|[\s\S])|[^\\\r\n])+/m,
+      lookbehind: true,
+    },
+    'attr-name': /^[ \t]*(?:\\(?:\r\n|[\s\S])|[^\\\s:=])+?(?= *[=:] *| )/m,
+    punctuation: /[=:]/,
+  };
+}

--- a/docs/pages/guides/config-plugins.md
+++ b/docs/pages/guides/config-plugins.md
@@ -502,6 +502,17 @@ If you aren't comfortable with setting up a monorepo, you can try manually runni
 
 Packages should attempt to use the built-in `AndroidManifest.xml` [merging system](https://android-doc.github.io/tools/building/manifest-merge.html) before using a config plugin. This can be used for static, non-optional features like permissions. This will ensure features are merged during build-time and not prebuild-time, which minimizes the possibility of users forgetting to prebuild. The drawback is that users cannot use [introspection](#introspection) to preview the changes and debug any potential issues.
 
+Here is an example of a package's AndroidManifest.xml, which injects a required permission:
+
+```xml
+    <!-- /* @info Include this line to use `android:*` properties like `android:name` in your manifest. */ -->
+<manifest package="expo.modules.filesystem"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- /* @end */ -->
+    <uses-permission android:name="android.permission.INTERNET"/>
+</manifest>
+```
+
 If you're building a plugin for your local project, or if your package needs more control, then you should implement a plugin.
 
 You can use built-in types and helpers to ease the process of working with complex objects.
@@ -709,7 +720,7 @@ The `gradle.properties` is a static key/value pair that groovy files can read fr
 
 `gradle.properties`
 
-```
+```properties
 /* @info Safely modified using the <code>withGradleProperties()</code> mod. */
 expo.react.jsEngine=hermes
 /* @end */
@@ -723,8 +734,7 @@ Then later in a Gradle file:
 project.ext.react = [
   /* @info This code would be added to the template ahead of time, but it could be regexed in using <code>withAppBuildGradle()</code> */
   enableHermes: findProperty('expo.react.jsEngine') ?: 'jsc'
-  /* @end */
-]
+/* @end */]
 ```
 
 - For keys in the `gradle.properties`, use camel case separated by `.`s, and usually starting with the `expo` prefix to denote that the property is managed by prebuild.

--- a/docs/pages/guides/config-plugins.md
+++ b/docs/pages/guides/config-plugins.md
@@ -505,10 +505,10 @@ Packages should attempt to use the built-in `AndroidManifest.xml` [merging syste
 Here is an example of a package's AndroidManifest.xml, which injects a required permission:
 
 ```xml
-    <!-- /* @info Include this line to use `android:*` properties like `android:name` in your manifest. */ -->
+<!-- @info Include <code>xmlns:android="..."</code> to use <code>android:*</code> properties like <code>android:name</code> in your manifest. -->
 <manifest package="expo.modules.filesystem"
     xmlns:android="http://schemas.android.com/apk/res/android">
-    <!-- /* @end */ -->
+    <!-- @end -->
     <uses-permission android:name="android.permission.INTERNET"/>
 </manifest>
 ```
@@ -721,9 +721,9 @@ The `gradle.properties` is a static key/value pair that groovy files can read fr
 `gradle.properties`
 
 ```properties
-/* @info Safely modified using the <code>withGradleProperties()</code> mod. */
+# @info Safely modified using the <code>withGradleProperties()</code> mod. #
 expo.react.jsEngine=hermes
-/* @end */
+# @end #
 ```
 
 Then later in a Gradle file:

--- a/docs/pages/guides/config-plugins.md
+++ b/docs/pages/guides/config-plugins.md
@@ -460,6 +460,8 @@ Because of this reasoning, the root of a Node module is searched instead of righ
 
 ## Developing a Plugin
 
+> Use [modifier previews](https://github.com/expo/vscode-expo#expo-preview-modifier) to debug the results of your plugin live.
+
 To make plugin development easier, we've added plugin support to [`expo-module-scripts`](https://www.npmjs.com/package/expo-module-scripts). Refer to the [config plugins guide](https://github.com/expo/expo/tree/master/packages/expo-module-scripts#-config-plugin) for more info on using TypeScript, and Jest to build plugins.
 
 Plugins will generally have `@expo/config-plugins` installed as a dependency, and `expo-module-scripts`, `@expo/config-types` installed as a devDependencies.
@@ -497,6 +499,10 @@ If you aren't comfortable with setting up a monorepo, you can try manually runni
 - If you need to update the package, change the `version` in the package's `package.json` and repeat the process.
 
 ### Modifying the AndroidManifest.xml
+
+Packages should attempt to use the built-in `AndroidManifest.xml` [merging system](https://android-doc.github.io/tools/building/manifest-merge.html) before using a config plugin. This can be used for static, non-optional features like permissions. This will ensure features are merged during build-time and not prebuild-time, which minimizes the possibility of users forgetting to prebuild. The drawback is that users cannot use [introspection](#introspection) to preview the changes and debug any potential issues.
+
+If you're building a plugin for your local project, or if your package needs more control, then you should implement a plugin.
 
 You can use built-in types and helpers to ease the process of working with complex objects.
 Here's an example of adding a `<meta-data android:name="..." android:value="..."/>` to the default `<application android:name=".MainApplication" />`.
@@ -634,7 +640,7 @@ Expo CLI commands can be profiled using `EXPO_PROFILE=1`.
 
 ## Introspection
 
-Introspection is an advanced technique used to read the evaluated results of modifiers without generating any code in the project. This can be used to quickly debug the results of [static modifications](#static-modification) without needing to run prebuild.
+Introspection is an advanced technique used to read the evaluated results of modifiers without generating any code in the project. This can be used to quickly debug the results of [static modifications](#static-modification) without needing to run prebuild. You can interact with introspection live, by using the [preview feature](https://github.com/expo/vscode-expo#expo-preview-modifier) of `vscode-expo`.
 
 You can try introspection by running `expo config --type introspect` in a project.
 


### PR DESCRIPTION
# Why

We've recently incorporated manifest merging more into our modules, added a note to it in the config-plugins doc. Also fixed the magic comments for hash and xml based comment languages.

- xml, html: `<!-- @info -->` & `<!-- @end -->`
- rb, ruby, properties: `# @info #` & `# @end #`