### PR TITLE
@tc/preview changes existing docs

### DIFF
--- a/docs/pages/guides/using-hermes.md
+++ b/docs/pages/guides/using-hermes.md
@@ -43,7 +43,7 @@ To use Hermes inspector for JavaScript debugging, we recommend following [the in
 - _This is only supported on a debug build app._
 - _Execute `expo start` and make sure Expo development server is running._
 
-> 💡 The upcoming [Expo Development Client](https://expo.fyi/dev-client) will simplify this process by integrating directly with Hermes inspector.
+> 💡 [Custom development clients](/clients/introduction.md) built with `expo-dev-client` simplify this process by integrating directly with Hermes inspector.
 
 ## Limitations
 

--- a/docs/pages/workflow/customizing.md
+++ b/docs/pages/workflow/customizing.md
@@ -37,12 +37,12 @@ If you want to make static changes to your native project files like the iOS `In
 
 If you've decided that you want to roll your app back to being fully managed (no iOS and Android projects in your project directory), you can checkout your most recent commit before executing `expo run:[ios|android]`, then run `npm install` again to restore the state of your `node_modules` directory.
 
+## Developing apps with custom native code
+
+Once you have customized the native code in their project, you can use the [`expo-dev-client`](/clients/introduction.md) package to create a custom development client and retain the convenience of working with just JavaScript and/or TypeScript in Expo Go. You can create a custom client for your managed or bare workflow by following [our guide](/clients/getting-started.md).
+
 ## Releasing apps with custom native code to production
 
 The classic `expo build` command does not support custom native code. When you're ready to ship your app, you can [build it with EAS Build](/build/introduction.md) or archive and sign it locally.
 
 <TerminalBlock cmd={['# Install the CLI', 'npm i -g eas-cli', '', '# Build your app!', 'eas build -p all']} />
-
-## Coming soon: "Expo Development Client"
-
-We are working on a way for developers to be able to customize the native code in their projects and retain the convenience of working with just JavaScript and/or TypeScript. You can learn more about this in ["Expo managed workflow in 2021, Part 2: Customizing the runtime"](https://blog.expo.io/expo-managed-workflow-in-2021-d1c9b68aa10).

--- a/docs/pages/workflow/customizing.md
+++ b/docs/pages/workflow/customizing.md
@@ -39,7 +39,7 @@ If you've decided that you want to roll your app back to being fully managed (no
 
 ## Developing apps with custom native code
 
-Once you have customized the native code in their project, you can use the [`expo-dev-client`](/clients/introduction.md) package to create a custom development client and retain the convenience of working with just JavaScript and/or TypeScript in Expo Go. You can create a custom client for your managed or bare workflow by following [our guide](/clients/getting-started.md).
+Once you have customized the native code in your project, you can use the [`expo-dev-client`](/clients/introduction.md) package to create a custom development client and retain the convenience of working with just JavaScript and/or TypeScript in Expo Go. You can create a custom client for your managed or bare workflow by following [our guide](/clients/getting-started.md).
 
 ## Releasing apps with custom native code to production
 


### PR DESCRIPTION
# Why

Updates existing docs pages referencing development clients to point to our new pages

# How

`ag Development Client` 
Update pages

# Test Plan

Ran locally and followed all links