### PR TITLE
[docs] improve `resolveTypeName` function, simplify union types, add tests

### DIFF
--- a/docs/components/plugins/api/APIDataTypes.ts
+++ b/docs/components/plugins/api/APIDataTypes.ts
@@ -28,6 +28,7 @@ export type TypeDefinitionData = {
   name?: string;
   type: string;
   types?: TypeDefinitionData[];
+  elements?: TypeDefinitionData[];
   elementType?: {
     name: string;
     type: string;

--- a/docs/components/plugins/api/APISectionTypes.tsx
+++ b/docs/components/plugins/api/APISectionTypes.tsx
@@ -26,8 +26,10 @@ export type APISectionTypesProps = {
 };
 
 const defineLiteralType = (types: TypeDefinitionData[]): JSX.Element | null => {
-  const uniqueTypes = Array.from(new Set(types.map((t: TypeDefinitionData) => typeof t.value)));
-  if (uniqueTypes.length === 1) {
+  const uniqueTypes = Array.from(
+    new Set(types.map((t: TypeDefinitionData) => t.value && typeof t.value))
+  );
+  if (uniqueTypes.length === 1 && uniqueTypes.filter(Boolean).length === 1) {
     return (
       <>
         <InlineCode>{uniqueTypes[0]}</InlineCode>
@@ -117,9 +119,7 @@ const renderType = ({ name, comment, type }: TypeGeneralData): JSX.Element | und
   } else if (type.types && (type.type === 'union' || 'intersection')) {
     const literalTypes = type.types.filter(
       (t: TypeDefinitionData) =>
-        t.type === 'literal' ||
-        t.type === 'intrinsic' ||
-        (t.type === 'reference' && t.name === 'Record')
+        t.type === 'literal' || t.type === 'intrinsic' || t.type === 'reference'
     );
     const propTypes = type.types.filter((t: TypeDefinitionData) => t.type === 'reflection');
     if (literalTypes.length) {
@@ -131,10 +131,10 @@ const renderType = ({ name, comment, type }: TypeGeneralData): JSX.Element | und
           <P>
             {defineLiteralType(literalTypes)}
             Acceptable values are:{' '}
-            {literalTypes.map((type, index) => (
+            {literalTypes.map((lt, index) => (
               <span key={`${name}-literal-type-${index}`}>
-                <InlineCode>{resolveTypeName(type)}</InlineCode>
-                {index !== literalTypes.length - 1 ? ', ' : '.'}
+                <InlineCode>{resolveTypeName(lt)}</InlineCode>
+                {index + 1 !== literalTypes.length ? ', ' : '.'}
               </span>
             ))}
           </P>

--- a/docs/components/plugins/api/APISectionTypes.tsx
+++ b/docs/components/plugins/api/APISectionTypes.tsx
@@ -119,7 +119,7 @@ const renderType = ({ name, comment, type }: TypeGeneralData): JSX.Element | und
   } else if (type.types && (type.type === 'union' || 'intersection')) {
     const literalTypes = type.types.filter(
       (t: TypeDefinitionData) =>
-        t.type === 'literal' || t.type === 'intrinsic' || t.type === 'reference'
+		['literal', 'intrinsic', 'reference'].includes(t.type)
     );
     const propTypes = type.types.filter((t: TypeDefinitionData) => t.type === 'reflection');
     if (literalTypes.length) {

--- a/docs/components/plugins/api/APISectionTypes.tsx
+++ b/docs/components/plugins/api/APISectionTypes.tsx
@@ -116,7 +116,7 @@ const renderType = ({ name, comment, type }: TypeGeneralData): JSX.Element | und
           : null}
       </div>
     );
-  } else if (type.types && (type.type === 'union' || 'intersection')) {
+  } else if (type.types && ['union', 'intersection'].includes(type.type)) {
     const literalTypes = type.types.filter(
       (t: TypeDefinitionData) =>
 		['literal', 'intrinsic', 'reference'].includes(t.type)

--- a/docs/components/plugins/api/APISectionTypes.tsx
+++ b/docs/components/plugins/api/APISectionTypes.tsx
@@ -117,9 +117,8 @@ const renderType = ({ name, comment, type }: TypeGeneralData): JSX.Element | und
       </div>
     );
   } else if (type.types && ['union', 'intersection'].includes(type.type)) {
-    const literalTypes = type.types.filter(
-      (t: TypeDefinitionData) =>
-		['literal', 'intrinsic', 'reference'].includes(t.type)
+    const literalTypes = type.types.filter((t: TypeDefinitionData) =>
+      ['literal', 'intrinsic', 'reference'].includes(t.type)
     );
     const propTypes = type.types.filter((t: TypeDefinitionData) => t.type === 'reflection');
     if (literalTypes.length) {

--- a/docs/components/plugins/api/APISectionTypes.tsx
+++ b/docs/components/plugins/api/APISectionTypes.tsx
@@ -118,28 +118,10 @@ const renderType = ({ name, comment, type }: TypeGeneralData): JSX.Element | und
     );
   } else if (type.types && ['union', 'intersection'].includes(type.type)) {
     const literalTypes = type.types.filter((t: TypeDefinitionData) =>
-      ['literal', 'intrinsic', 'reference'].includes(t.type)
+      ['literal', 'intrinsic', 'reference', 'tuple'].includes(t.type)
     );
     const propTypes = type.types.filter((t: TypeDefinitionData) => t.type === 'reflection');
-    if (literalTypes.length) {
-      return (
-        <div key={`type-definition-${name}`}>
-          <H3Code>
-            <InlineCode>{name}</InlineCode>
-          </H3Code>
-          <P>
-            {defineLiteralType(literalTypes)}
-            Acceptable values are:{' '}
-            {literalTypes.map((lt, index) => (
-              <span key={`${name}-literal-type-${index}`}>
-                <InlineCode>{resolveTypeName(lt)}</InlineCode>
-                {index + 1 !== literalTypes.length ? ', ' : '.'}
-              </span>
-            ))}
-          </P>
-        </div>
-      );
-    } else if (propTypes.length) {
+    if (propTypes.length) {
       return (
         <div key={`prop-type-definition-${name}`}>
           <H3Code>
@@ -158,6 +140,24 @@ const renderType = ({ name, comment, type }: TypeGeneralData): JSX.Element | und
             propType =>
               propType?.declaration?.children && renderTypeDeclarationTable(propType.declaration)
           )}
+        </div>
+      );
+    } else if (literalTypes.length) {
+      return (
+        <div key={`type-definition-${name}`}>
+          <H3Code>
+            <InlineCode>{name}</InlineCode>
+          </H3Code>
+          <P>
+            {defineLiteralType(literalTypes)}
+            Acceptable values are:{' '}
+            {literalTypes.map((lt, index) => (
+              <span key={`${name}-literal-type-${index}`}>
+                <InlineCode>{resolveTypeName(lt)}</InlineCode>
+                {index + 1 !== literalTypes.length ? ', ' : '.'}
+              </span>
+            ))}
+          </P>
         </div>
       );
     }

--- a/docs/components/plugins/api/APISectionUtils.test.tsx
+++ b/docs/components/plugins/api/APISectionUtils.test.tsx
@@ -33,6 +33,18 @@ describe('APISectionUtils.resolveTypeName', () => {
     expect(container).toMatchSnapshot();
   });
 
+  test('custom type non-linkable array', () => {
+    const { container } = render(
+      <>
+        {resolveTypeName({
+          type: 'array',
+          elementType: { type: 'reference', name: 'T' },
+        })}
+      </>
+    );
+    expect(container).toMatchSnapshot();
+  });
+
   test('query type', () => {
     const { container } = render(
       <>
@@ -135,6 +147,53 @@ describe('APISectionUtils.resolveTypeName', () => {
             { type: 'array', elementType: { type: 'intrinsic', name: 'number' } },
             { type: 'literal', value: null },
           ],
+        })}
+      </>
+    );
+    expect(container).toMatchSnapshot();
+  });
+
+  test('union with custom type and array', () => {
+    const { container } = render(
+      <>
+        {resolveTypeName({
+          type: 'union',
+          types: [
+            { type: 'array', elementType: { type: 'reference', name: 'AssetRef' } },
+            { type: 'reference', name: 'AssetRef' },
+          ],
+        })}
+      </>
+    );
+    expect(container).toMatchSnapshot();
+  });
+
+  test('generic type', () => {
+    const { container } = render(
+      <>
+        {resolveTypeName({
+          type: 'reference',
+          typeArguments: [{ type: 'reference', name: 'Asset' }],
+          name: 'PagedInfo',
+        })}
+      </>
+    );
+    expect(container).toMatchSnapshot();
+  });
+
+  test('generic type in Promise', () => {
+    const { container } = render(
+      <>
+        {resolveTypeName({
+          type: 'reference',
+          typeArguments: [
+            {
+              type: 'reference',
+              typeArguments: [{ type: 'reference', name: 'Asset' }],
+              name: 'PagedInfo',
+            },
+          ],
+          name: 'Promise',
         })}
       </>
     );

--- a/docs/components/plugins/api/APISectionUtils.test.tsx
+++ b/docs/components/plugins/api/APISectionUtils.test.tsx
@@ -181,6 +181,21 @@ describe('APISectionUtils.resolveTypeName', () => {
     expect(container).toMatchSnapshot();
   });
 
+  test('tuple type', () => {
+    const { container } = render(
+      <>
+        {resolveTypeName({
+          type: 'tuple',
+          elements: [
+            { type: 'reference', name: 'SortByKey' },
+            { type: 'intrinsic', name: 'boolean' },
+          ],
+        })}
+      </>
+    );
+    expect(container).toMatchSnapshot();
+  });
+
   test('generic type in Promise', () => {
     const { container } = render(
       <>

--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -53,6 +53,7 @@ export const mdInlineRenderers: MDRenderers = {
 const nonLinkableTypes = ['Date', 'Error', 'Promise', 'T', 'TaskOptions', 'Uint8Array'];
 
 export const resolveTypeName = ({
+  elements,
   elementType,
   name,
   type,
@@ -155,6 +156,19 @@ export const resolveTypeName = ({
         </>
       );
     }
+  } else if (type === 'tuple' && elements) {
+    return (
+      <>
+        [
+        {elements.map((elem, i) => (
+          <span key={`tuple-${name}-${i}`}>
+            {resolveTypeName(elem)}
+            {i + 1 !== elements.length ? ', ' : ''}
+          </span>
+        ))}
+        ]
+      </>
+    );
   } else if (type === 'query' && queryType) {
     return queryType.name;
   } else if (type === 'literal' && value) {

--- a/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
+++ b/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
@@ -223,6 +223,26 @@ exports[`APISectionUtils.resolveTypeName query type 1`] = `
 </div>
 `;
 
+exports[`APISectionUtils.resolveTypeName tuple type 1`] = `
+<div>
+  [
+  <span>
+    <a
+      class="css-12zqqiz-STYLES_EXTERNAL_LINK"
+      href="/#sortbykey"
+    >
+      SortByKey
+    </a>
+    , 
+  </span>
+  <span>
+    boolean
+    
+  </span>
+  ]
+</div>
+`;
+
 exports[`APISectionUtils.resolveTypeName union 1`] = `
 <div>
   <span>

--- a/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
+++ b/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
@@ -2,74 +2,70 @@
 
 exports[`APISectionUtils.resolveTypeName Promise 1`] = `
 <div>
+  Promise
+  &lt;
   <span>
-    Promise
-    &lt;
     void
-    &gt;
   </span>
+  &gt;
 </div>
 `;
 
 exports[`APISectionUtils.resolveTypeName Promise with custom type 1`] = `
 <div>
+  Promise
+  &lt;
   <span>
-    Promise
-    &lt;
     <a
       class="css-12zqqiz-STYLES_EXTERNAL_LINK"
       href="/#appleauthenticationcredential"
     >
       AppleAuthenticationCredential
     </a>
-    &gt;
   </span>
+  &gt;
 </div>
 `;
 
 exports[`APISectionUtils.resolveTypeName Record 1`] = `
 <div>
+  Record
+  &lt;
   <span>
-    Record
-    &lt;
-    <span>
-      string
-      , 
-    </span>
-    <span>
-      any
-      
-    </span>
-    &gt;
+    string
+    , 
   </span>
+  <span>
+    any
+    
+  </span>
+  &gt;
 </div>
 `;
 
 exports[`APISectionUtils.resolveTypeName Record with union 1`] = `
 <div>
+  Record
+  &lt;
   <span>
-    Record
-    &lt;
+    string
+    , 
+  </span>
+  <span>
+    <span>
+      number
+       | 
+    </span>
+    <span>
+      boolean
+       | 
+    </span>
     <span>
       string
-      , 
     </span>
-    <span>
-      <span>
-        number
-         | 
-      </span>
-      <span>
-        boolean
-         | 
-      </span>
-      <span>
-        string
-      </span>
-      
-    </span>
-    &gt;
+    
   </span>
+  &gt;
 </div>
 `;
 
@@ -93,6 +89,12 @@ exports[`APISectionUtils.resolveTypeName custom type array 1`] = `
     AppleAuthenticationScope
     []
   </a>
+</div>
+`;
+
+exports[`APISectionUtils.resolveTypeName custom type non-linkable array 1`] = `
+<div>
+  T[]
 </div>
 `;
 
@@ -162,17 +164,62 @@ exports[`APISectionUtils.resolveTypeName generic type 1`] = `
 </div>
 `;
 
-exports[`APISectionUtils.resolveTypeName query type 1`] = `
+exports[`APISectionUtils.resolveTypeName generic type 2`] = `
 <div>
+  <a
+    class="css-12zqqiz-STYLES_EXTERNAL_LINK"
+    href="/#pagedinfo"
+  >
+    PagedInfo
+  </a>
+  &lt;
   <span>
-    React.ComponentProps
+    <a
+      class="css-12zqqiz-STYLES_EXTERNAL_LINK"
+      href="/#asset"
+    >
+      Asset
+    </a>
+  </span>
+  &gt;
+</div>
+`;
+
+exports[`APISectionUtils.resolveTypeName generic type in Promise 1`] = `
+<div>
+  Promise
+  &lt;
+  <span>
+    <a
+      class="css-12zqqiz-STYLES_EXTERNAL_LINK"
+      href="/#pagedinfo"
+    >
+      PagedInfo
+    </a>
     &lt;
     <span>
-      View
-      
+      <a
+        class="css-12zqqiz-STYLES_EXTERNAL_LINK"
+        href="/#asset"
+      >
+        Asset
+      </a>
     </span>
     &gt;
   </span>
+  &gt;
+</div>
+`;
+
+exports[`APISectionUtils.resolveTypeName query type 1`] = `
+<div>
+  React.ComponentProps
+  &lt;
+  <span>
+    View
+    
+  </span>
+  &gt;
 </div>
 `;
 
@@ -201,6 +248,29 @@ exports[`APISectionUtils.resolveTypeName union with array 1`] = `
   </span>
   <span>
     null
+  </span>
+</div>
+`;
+
+exports[`APISectionUtils.resolveTypeName union with custom type and array 1`] = `
+<div>
+  <span>
+    <a
+      class="css-12zqqiz-STYLES_EXTERNAL_LINK"
+      href="/#assetref"
+    >
+      AssetRef
+      []
+    </a>
+     | 
+  </span>
+  <span>
+    <a
+      class="css-12zqqiz-STYLES_EXTERNAL_LINK"
+      href="/#assetref"
+    >
+      AssetRef
+    </a>
   </span>
 </div>
 `;


### PR DESCRIPTION
# Why

Refs ENG-1458

API data documentation generation feature is still in development and in this PR I'm aiming to improve and simplify types resolution helper util method `resolveTypeName`. Also the changeset includes few new test cases which I have stumble upon working on the `MediaLibrary` package conversion.

# How

Short summary of most important changes:
* types in Unions are now resolved by `resolveTypeName` util
* initial generics and tuple types support
* markup simplification (`span` wrapper removed where possible)
* few fixes for linkable/non-linkable custom types, especially in arrays and unions
* fixes for the few missing `key` warnings for React nodes

# Test Plan

Docs website has been run and tested on `localhost`, all the docs tests and lint checks are successful.