### PR TITLE
[expo-dev-launcher] fix error message when loading a production app without expo-updates

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Fixed the blue screen was shown instead of the LogBox on iOS. ([#13421](https://github.com/expo/expo/pull/13421) by [@lukmccall](https://github.com/lukmccall))
 - [plugin] Fixed error handlers weren't initialize after running `expo run:ios`. ([#13438](https://github.com/expo/expo/pull/13438) by [@lukmccall](https://github.com/lukmccall))
 - Order dev menu items consistently across platforms. ([#13449](https://github.com/expo/expo/pull/13449) by [@lukmccall](https://github.com/lukmccall))
+- Fixed error message when trying to load a production app without expo-updates. ([#13458](https://github.com/expo/expo/pull/13458) by [@esamelson](https://github.com/esamelson))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/manifest/DevLauncherManifestParser.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/manifest/DevLauncherManifestParser.kt
@@ -19,7 +19,7 @@ class DevLauncherManifestParser(
   private suspend fun downloadManifest(): Reader {
     val response = fetch(url, "GET").await(httpClient)
     if (!response.isSuccessful) {
-      throw Exception("Failed to open app.\n\nIf you are trying to load the app from a development server, please check your network connectivity and make sure you can access the server from your device.\n\nIf you are trying to open a published project, please install a compatible version of expo-updates and follow all setup and integration steps.")
+      throw Exception("Failed to open app.\n\nIf you are trying to load the app from a development server, check your network connectivity and make sure you can access the server from your device.\n\nIf you are trying to open a published project, install a compatible version of expo-updates and follow all setup and integration steps.")
     }
     return response.body()!!.charStream()
   }

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/manifest/DevLauncherManifestParser.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/manifest/DevLauncherManifestParser.kt
@@ -19,12 +19,7 @@ class DevLauncherManifestParser(
   private suspend fun downloadManifest(): Reader {
     val response = fetch(url, "GET").await(httpClient)
     if (!response.isSuccessful) {
-      val extraMessage = if (url.scheme.equals("https")) {
-        "If you are trying to open a published project, you need to install a compatible version of expo-updates and follow all setup and integration steps."
-      } else {
-        "Please check your network connectivity and make sure you can access the local packager server."
-      }
-      throw Exception("Failed to open app. $extraMessage")
+      throw Exception("Failed to open app.\n\nIf you are trying to load the app from a development server, please check your network connectivity and make sure you can access the server from your device.\n\nIf you are trying to open a published project, please install a compatible version of expo-updates and follow all setup and integration steps.")
     }
     return response.body()!!.charStream()
   }

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/manifest/DevLauncherManifestParser.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/manifest/DevLauncherManifestParser.kt
@@ -18,7 +18,14 @@ class DevLauncherManifestParser(
 
   private suspend fun downloadManifest(): Reader {
     val response = fetch(url, "GET").await(httpClient)
-    require(response.isSuccessful)
+    if (!response.isSuccessful) {
+      val extraMessage = if (url.scheme.equals("https")) {
+        "If you are trying to open a published project, you need to install a compatible version of expo-updates and follow all setup and integration steps."
+      } else {
+        "Please check your network connectivity and make sure you can access the local packager server."
+      }
+      throw Exception("Failed to open app. $extraMessage")
+    }
     return response.body()!!.charStream()
   }
 

--- a/packages/expo-dev-launcher/android/src/test/java/expo/modules/devlauncher/launcher/manifest/DevLauncherManifestParserTest.kt
+++ b/packages/expo-dev-launcher/android/src/test/java/expo/modules/devlauncher/launcher/manifest/DevLauncherManifestParserTest.kt
@@ -80,7 +80,7 @@ internal class DevLauncherManifestParserTest {
       MockResponse()
         .setResponseCode(501)
     )
-    val failure = Assert.assertThrows(IllegalArgumentException::class.java) {
+    val failure = Assert.assertThrows(Exception::class.java) {
       runBlocking { manifestParser.parseManifest() }
     }
 

--- a/packages/expo-dev-launcher/ios/Manifest/EXDevLauncherManifestParser.m
+++ b/packages/expo-dev-launcher/ios/Manifest/EXDevLauncherManifestParser.m
@@ -53,10 +53,7 @@ typedef void (^CompletionHandler)(NSData *data, NSURLResponse *response);
     if ([response isKindOfClass:[NSHTTPURLResponse class]]) {
       NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
       if (httpResponse.statusCode < 200 || httpResponse.statusCode >= 300) {
-        NSString *extraMessage = [@"https" isEqualToString:self.url.scheme]
-          ? @"If you are trying to open a published project, you need to install a compatible version of expo-updates and follow all setup and integration steps."
-          : @"Please check your network connectivity and make sure you can access the local packager server.";
-        NSString *message = [NSString stringWithFormat:@"Failed to open app. %@", extraMessage];
+        NSString *message = @"Failed to open app.\n\nIf you are trying to load the app from a development server, please check your network connectivity and make sure you can access the server from your device.\n\nIf you are trying to open a published project, please install a compatible version of expo-updates and follow all setup and integration steps.";
         onError([NSError errorWithDomain:@"DevelopmentClient" code:1 userInfo:@{NSLocalizedDescriptionKey: message}]);
         return;
       }

--- a/packages/expo-dev-launcher/ios/Manifest/EXDevLauncherManifestParser.m
+++ b/packages/expo-dev-launcher/ios/Manifest/EXDevLauncherManifestParser.m
@@ -53,7 +53,7 @@ typedef void (^CompletionHandler)(NSData *data, NSURLResponse *response);
     if ([response isKindOfClass:[NSHTTPURLResponse class]]) {
       NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
       if (httpResponse.statusCode < 200 || httpResponse.statusCode >= 300) {
-        NSString *message = @"Failed to open app.\n\nIf you are trying to load the app from a development server, please check your network connectivity and make sure you can access the server from your device.\n\nIf you are trying to open a published project, please install a compatible version of expo-updates and follow all setup and integration steps.";
+        NSString *message = @"Failed to open app.\n\nIf you are trying to load the app from a development server, check your network connectivity and make sure you can access the server from your device.\n\nIf you are trying to open a published project, install a compatible version of expo-updates and follow all setup and integration steps.";
         onError([NSError errorWithDomain:@"DevelopmentClient" code:1 userInfo:@{NSLocalizedDescriptionKey: message}]);
         return;
       }


### PR DESCRIPTION
# Why

resolves ENG-1453

The existing error message wasn't being reached; since no headers were sent with the initial manifest request, www was returning an error ("The request was malformed. Please include a list of SDK versions in your request.").

# How

Added a more helpful error message if the initial manifest request fails. If the URL scheme is https, it's a pretty good guess that the user was trying to request a published app, so show a message about expo-updates.

# Test Plan

Tested manually on both platforms by trying to open a published app in a dev client without the expo-updates integration installed. Also ensured all android unit tests passed.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).