### PR TITLE
[home][cherry-pick] Add release channel label back to project page

### DIFF
--- a/home/components/ProjectView.tsx
+++ b/home/components/ProjectView.tsx
@@ -157,6 +157,11 @@ function LegacyLaunchSection({ app }: { app: ProjectDataProject }) {
     legacyUpdatesSDKMajorVersion !== null &&
     legacyUpdatesSDKMajorVersion < Environment.lowestSupportedSdkVersion;
 
+  const moreLegacyBranchesText =
+    Platform.OS === 'ios'
+      ? 'To launch from another classic release channel, follow the instructions on the project webpage.'
+      : 'To launch from another classic release channel, scan the QR code on the project webpage.';
+
   return (
     <View>
       <SectionHeader title="Classic release channels" />
@@ -173,11 +178,7 @@ function LegacyLaunchSection({ app }: { app: ProjectDataProject }) {
         }}
         last
       />
-      {Platform.OS === 'ios' ? null : (
-        <Text style={styles.moreLegacyBranchesText}>
-          To launch from another classic release channel, scan the QR code on the project webpage.
-        </Text>
-      )}
+      <Text style={styles.moreLegacyBranchesText}>{moreLegacyBranchesText}</Text>
     </View>
   );
 }


### PR DESCRIPTION
# Why

https://github.com/expo/expo/pull/12804 added a disambiguation page for users to choose between classic and EAS updates. One concern was the additional tap it introduced, but it was decided in that PR that the benefit of the consistent IA outweighed the cost of the additional tap. An additional concern was the inconsistency with being able to list "release channels" in the new EAS updates but not for classic updates, and to solve this a label was added to tell the user how to open other release channels for classic updates (following the instructions at https://docs.expo.io/distribution/release-channels/#publish-with-channels).

https://github.com/expo/expo/pull/13389 removed the label due to a concern with the language, but that introduced an unclear UX where users would question why their other classic release channels weren't listed. This started a discussion about skipping this screen entirely if possible, which is rehashing the discussion we had in the original PR.

While it's fine if we want to rehash the discussion and reverse course, it is a bit late in this release process to revert that decision. Instead, the more stability-conscious approach would be to reintroduce the label without language concerns in this release and then have the discussion again separately for the next release since any other change would be much larger in scope.

This PR reintroduces the label in iOS (hopefully without any controversial language).

# How

Instead of hiding the label entirely on iOS, show it but with different language.

# Test Plan

Android:
<img width="435" alt="Screen Shot 2021-06-30 at 11 13 47 AM" src="https://user-images.githubusercontent.com/189568/124012444-03fa7700-d996-11eb-87c6-caf4f991a5ef.png">

iOS:
<img width="474" alt="Screen Shot 2021-06-30 at 11 17 29 AM" src="https://user-images.githubusercontent.com/189568/124012455-065cd100-d996-11eb-829e-67828bfc87d6.png">
