### PR TITLE
[ios] backport stable manifest ID code to 42 versioned code

### DIFF
--- a/ios/vendored/sdk42/react-native-webview/apple/ABI42_0_0RNCWKProcessPoolManager.h
+++ b/ios/vendored/sdk42/react-native-webview/apple/ABI42_0_0RNCWKProcessPoolManager.h
@@ -10,6 +10,6 @@
 @interface ABI42_0_0RNCWKProcessPoolManager : NSObject
 
 + (instancetype) sharedManager;
-- (WKProcessPool *)sharedProcessPoolForExperienceId:(NSString *)experienceId;
+- (WKProcessPool *)sharedProcessPoolForScopeKey:(NSString *)scopeKey;
 
 @end

--- a/ios/vendored/sdk42/react-native-webview/apple/ABI42_0_0RNCWKProcessPoolManager.m
+++ b/ios/vendored/sdk42/react-native-webview/apple/ABI42_0_0RNCWKProcessPoolManager.m
@@ -24,15 +24,15 @@
   return self;
 }
 
-- (WKProcessPool *)sharedProcessPoolForExperienceId:(NSString *)experienceId
+- (WKProcessPool *)sharedProcessPoolForScopeKey:(NSString *)scopeKey
 {
-  if (!experienceId) {
+  if (!scopeKey) {
     return [self sharedProcessPool];
   }
-  if (!_pools[experienceId]) {
-    _pools[experienceId] = [[WKProcessPool alloc] init];
+  if (!_pools[scopeKey]) {
+    _pools[scopeKey] = [[WKProcessPool alloc] init];
   }
-  return _pools[experienceId];
+  return _pools[scopeKey];
 }
 
 

--- a/ios/vendored/sdk42/react-native-webview/apple/ABI42_0_0RNCWebView.h
+++ b/ios/vendored/sdk42/react-native-webview/apple/ABI42_0_0RNCWebView.h
@@ -28,7 +28,7 @@
 @end
 
 @interface ABI42_0_0RNCWebView : ABI42_0_0RCTView
-@property (nonatomic, strong) NSString *experienceId;
+@property (nonatomic, strong) NSString *scopeKey;
 
 @property (nonatomic, weak) id<ABI42_0_0RNCWebViewDelegate> _Nullable delegate;
 @property (nonatomic, copy) NSDictionary * _Nullable source;

--- a/ios/vendored/sdk42/react-native-webview/apple/ABI42_0_0RNCWebView.m
+++ b/ios/vendored/sdk42/react-native-webview/apple/ABI42_0_0RNCWebView.m
@@ -233,7 +233,7 @@ static NSDictionary* customCertificatesForHost;
     wkWebViewConfig.websiteDataStore = [WKWebsiteDataStore defaultDataStore];
   }
   if(self.useSharedProcessPool) {
-    wkWebViewConfig.processPool = [[ABI42_0_0RNCWKProcessPoolManager sharedManager] sharedProcessPoolForExperienceId:self.experienceId];
+    wkWebViewConfig.processPool = [[ABI42_0_0RNCWKProcessPoolManager sharedManager] sharedProcessPoolForScopeKey:self.scopeKey];
   }
   wkWebViewConfig.userContentController = [WKUserContentController new];
 

--- a/ios/vendored/sdk42/react-native-webview/apple/ABI42_0_0RNCWebViewManager.m
+++ b/ios/vendored/sdk42/react-native-webview/apple/ABI42_0_0RNCWebViewManager.m
@@ -26,17 +26,18 @@ ABI42_0_0RCT_ENUM_CONVERTER(WKContentMode, (@{
 
 @implementation ABI42_0_0RNCWebViewManager
 {
-  NSString *_experienceId;
+  NSString *_scopeKey;
   NSConditionLock *_shouldStartLoadLock;
   BOOL _shouldStartLoad;
 }
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
-               kernelServiceDelegate:(id)kernelServiceInstance
-                              params:(NSDictionary *)params
+- (instancetype)initWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId
+                                        scopeKey:(NSString *)scopeKey
+                                     kernelServiceDelegate:(id)kernelServiceInstance
+                                              params:(NSDictionary *)params
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _scopeKey = _scopeKey;
   }
   return self;
 }
@@ -48,7 +49,7 @@ ABI42_0_0RCT_ENUM_CONVERTER(WKContentMode, (@{
 #endif // !TARGET_OS_OSX
 {
   ABI42_0_0RNCWebView *webView = [ABI42_0_0RNCWebView new];
-  webView.experienceId = _experienceId;
+  webView.scopeKey = _scopeKey;
   webView.delegate = self;
   return webView;
 }

--- a/ios/versioned-react-native/ABI42_0_0/Expo/EXTaskManager/ABI42_0_0EXTaskManager/ABI42_0_0EXTaskManager.h
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/EXTaskManager/ABI42_0_0EXTaskManager/ABI42_0_0EXTaskManager.h
@@ -9,6 +9,6 @@
 
 @interface ABI42_0_0EXTaskManager : ABI42_0_0UMExportedModule <ABI42_0_0UMInternalModule, ABI42_0_0UMEventEmitter, ABI42_0_0UMModuleRegistryConsumer, ABI42_0_0UMTaskManagerInterface>
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey NS_DESIGNATED_INITIALIZER;
 
 @end

--- a/ios/versioned-react-native/ABI42_0_0/Expo/EXTaskManager/ABI42_0_0EXTaskManager/ABI42_0_0EXTaskManager.m
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/EXTaskManager/ABI42_0_0EXTaskManager/ABI42_0_0EXTaskManager.m
@@ -33,14 +33,14 @@ ABI42_0_0UM_EXPORT_MODULE(ExpoTaskManager);
 
 - (instancetype)init
 {
-  return [self initWithExperienceId:@"mainApplication"];
+  return [self initWithScopeKey:@"mainApplication"];
 }
 
 // TODO: Remove when adding bare ABI42_0_0React Native support
-- (instancetype)initWithExperienceId:(NSString *)experienceId
+- (instancetype)initWithScopeKey:(NSString *)scopeKey
 {
   if (self = [super init]) {
-    _appId = experienceId;
+    _appId = scopeKey;
     _eventsQueue = [NSMutableArray new];
   }
   return self;

--- a/ios/versioned-react-native/ABI42_0_0/Expo/EXUpdates/ABI42_0_0EXUpdates/Update/ABI42_0_0EXUpdatesBareUpdate.m
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/EXUpdates/ABI42_0_0EXUpdates/Update/ABI42_0_0EXUpdatesBareUpdate.m
@@ -18,7 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
                                                                   config:config
                                                                 database:database];
 
-  NSString *updateId = manifest.rawID;
+  NSString *updateId = manifest.rawId;
   NSNumber *commitTime = manifest.commitTimeNumber;
   NSArray *assets = manifest.assets;
   

--- a/ios/versioned-react-native/ABI42_0_0/Expo/EXUpdates/ABI42_0_0EXUpdates/Update/ABI42_0_0EXUpdatesNewUpdate.m
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/EXUpdates/ABI42_0_0EXUpdates/Update/ABI42_0_0EXUpdatesNewUpdate.m
@@ -20,7 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
                                                                   config:config
                                                                 database:database];
   
-  NSString *updateId = manifest.rawID;
+  NSString *updateId = manifest.rawId;
   NSString *commitTime = manifest.createdAt;
   NSString *runtimeVersion = manifest.runtimeVersion;
   NSDictionary *launchAsset = manifest.launchAsset;

--- a/ios/versioned-react-native/ABI42_0_0/Expo/EXUpdates/ABI42_0_0EXUpdates/Update/RawManifest/ABI42_0_0EXUpdatesBareRawManifest.h
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/EXUpdates/ABI42_0_0EXUpdates/Update/RawManifest/ABI42_0_0EXUpdatesBareRawManifest.h
@@ -7,6 +7,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ABI42_0_0EXUpdatesBareRawManifest : ABI42_0_0EXUpdatesBaseLegacyRawManifest<ABI42_0_0EXUpdatesRawManifestBehavior>
 
+/**
+* A UUID for this manifest.
+*/
+- (NSString *)rawId;
 - (NSNumber *)commitTimeNumber;
 - (nullable NSDictionary *)metadata;
 - (nullable NSArray *)assets;

--- a/ios/versioned-react-native/ABI42_0_0/Expo/EXUpdates/ABI42_0_0EXUpdates/Update/RawManifest/ABI42_0_0EXUpdatesBareRawManifest.m
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/EXUpdates/ABI42_0_0EXUpdates/Update/RawManifest/ABI42_0_0EXUpdatesBareRawManifest.m
@@ -4,6 +4,10 @@
 
 @implementation ABI42_0_0EXUpdatesBareRawManifest
 
+- (NSString *)rawId {
+  return [self.rawManifestJSON stringForKey:@"id"];
+}
+
 - (NSNumber *)commitTimeNumber {
   return [self.rawManifestJSON numberForKey:@"commitTime"];
 }

--- a/ios/versioned-react-native/ABI42_0_0/Expo/EXUpdates/ABI42_0_0EXUpdates/Update/RawManifest/ABI42_0_0EXUpdatesBaseLegacyRawManifest.h
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/EXUpdates/ABI42_0_0EXUpdates/Update/RawManifest/ABI42_0_0EXUpdatesBaseLegacyRawManifest.h
@@ -6,6 +6,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ABI42_0_0EXUpdatesBaseLegacyRawManifest : ABI42_0_0EXUpdatesBaseRawManifest
 
+- (NSString *)stableLegacyId;
+- (NSString *)scopeKey;
+- (nullable NSString *)projectId;
+
 - (NSString *)bundleUrl;
 - (nullable NSString *)sdkVersion;
 - (nullable NSArray *)assets;

--- a/ios/versioned-react-native/ABI42_0_0/Expo/EXUpdates/ABI42_0_0EXUpdates/Update/RawManifest/ABI42_0_0EXUpdatesBaseLegacyRawManifest.m
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/EXUpdates/ABI42_0_0EXUpdates/Update/RawManifest/ABI42_0_0EXUpdatesBaseLegacyRawManifest.m
@@ -5,6 +5,28 @@
 
 @implementation ABI42_0_0EXUpdatesBaseLegacyRawManifest
 
+- (NSString *)stableLegacyId {
+  NSString *originalFullName = [self.rawManifestJSON nullableStringForKey:@"originalFullName"];
+  if (originalFullName) {
+    return originalFullName;
+  } else {
+    return [self legacyId];
+  }
+}
+
+- (NSString *)scopeKey {
+  NSString *scopeKey = [self.rawManifestJSON nullableStringForKey:@"scopeKey"];
+  if (scopeKey) {
+    return scopeKey;
+  } else {
+    return [self stableLegacyId];
+  }
+}
+
+- (nullable NSString *)projectId {
+  return [self.rawManifestJSON nullableStringForKey:@"projectId"];
+}
+
 - (NSString *)bundleUrl {
   return [self.rawManifestJSON stringForKey:@"bundleUrl"];
 }

--- a/ios/versioned-react-native/ABI42_0_0/Expo/EXUpdates/ABI42_0_0EXUpdates/Update/RawManifest/ABI42_0_0EXUpdatesBaseRawManifest.h
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/EXUpdates/ABI42_0_0EXUpdates/Update/RawManifest/ABI42_0_0EXUpdatesBaseRawManifest.h
@@ -13,7 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 # pragma mark - Common ABI42_0_0EXUpdatesRawManifestBehavior
 
-- (nullable NSString *)rawID;
+- (NSString *)legacyId;
 - (nullable NSString *)revisionId;
 - (nullable NSString *)slug;
 - (nullable NSString *)appKey;
@@ -23,6 +23,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSDictionary *)iosConfig;
 - (nullable NSString *)hostUri;
 - (nullable NSString *)orientation;
+- (nullable NSDictionary *)experiments;
+- (nullable NSDictionary *)developer;
 
 - (BOOL)isDevelopmentMode;
 - (BOOL)isDevelopmentSilentLaunch;

--- a/ios/versioned-react-native/ABI42_0_0/Expo/EXUpdates/ABI42_0_0EXUpdates/Update/RawManifest/ABI42_0_0EXUpdatesBaseRawManifest.m
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/EXUpdates/ABI42_0_0EXUpdates/Update/RawManifest/ABI42_0_0EXUpdatesBaseRawManifest.m
@@ -19,7 +19,7 @@
 
 # pragma mark - Field Getters
 
-- (nullable NSString *)rawID {
+- (NSString *)legacyId {
   return [self.rawManifestJSON nullableStringForKey:@"id"];
 }
 
@@ -59,11 +59,19 @@
   return [self.rawManifestJSON nullableStringForKey:@"orientation"];
 }
 
+- (nullable NSDictionary *)experiments {
+  return [self.rawManifestJSON nullableDictionaryForKey:@"experiments"];
+}
+
+- (nullable NSDictionary *)developer {
+  return [self.rawManifestJSON nullableDictionaryForKey:@"developer"];
+}
+
 # pragma mark - Derived Methods
 
 - (BOOL)isDevelopmentMode {
   NSDictionary *manifestPackagerOptsConfig = [self.rawManifestJSON nullableDictionaryForKey:@"packagerOpts"];
-  return ([self.rawManifestJSON nullableDictionaryForKey:@"developer"] != nil && manifestPackagerOptsConfig != nil && [@(YES) isEqualToNumber:manifestPackagerOptsConfig[@"dev"]]);
+  return (self.developer != nil && manifestPackagerOptsConfig != nil && [@(YES) isEqualToNumber:manifestPackagerOptsConfig[@"dev"]]);
 }
 
 - (BOOL)isDevelopmentSilentLaunch {
@@ -76,8 +84,7 @@
 }
 
 - (BOOL)isUsingDeveloperTool {
-  NSDictionary *manifestDeveloperConfig = self.rawManifestJSON[@"developer"];
-  BOOL isDeployedFromTool = (manifestDeveloperConfig && manifestDeveloperConfig[@"tool"] != nil);
+  BOOL isDeployedFromTool = (self.developer && self.developer[@"tool"] != nil);
   return (isDeployedFromTool);
 }
 

--- a/ios/versioned-react-native/ABI42_0_0/Expo/EXUpdates/ABI42_0_0EXUpdates/Update/RawManifest/ABI42_0_0EXUpdatesNewRawManifest.h
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/EXUpdates/ABI42_0_0EXUpdates/Update/RawManifest/ABI42_0_0EXUpdatesNewRawManifest.h
@@ -7,6 +7,26 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ABI42_0_0EXUpdatesNewRawManifest : ABI42_0_0EXUpdatesBaseRawManifest<ABI42_0_0EXUpdatesRawManifestBehavior>
 
+/**
+ * An ID representing this manifest, not the ID for the experience.
+ */
+- (NSString *)rawId;
+
+/**
+ * Incorrect for now until we figure out how to get this in the new manifest format.
+ */
+- (NSString *)stableLegacyId DEPRECATED_MSG_ATTRIBUTE("Modern manifests don't support stable legacy IDs");
+
+/**
+ * Incorrect for now until we figure out how to get this in the new manifest format.
+ */
+- (NSString *)scopeKey;
+
+/**
+ * Incorrect for now until we figure out how to get this in the new manifest format.
+ */
+- (nullable NSString *)projectId;
+
 - (NSString *)createdAt;
 - (NSString *)runtimeVersion;
 - (NSDictionary *)launchAsset;

--- a/ios/versioned-react-native/ABI42_0_0/Expo/EXUpdates/ABI42_0_0EXUpdates/Update/RawManifest/ABI42_0_0EXUpdatesNewRawManifest.m
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/EXUpdates/ABI42_0_0EXUpdates/Update/RawManifest/ABI42_0_0EXUpdatesNewRawManifest.m
@@ -4,6 +4,22 @@
 
 @implementation ABI42_0_0EXUpdatesNewRawManifest
 
+- (NSString *)rawId {
+  return [self.rawManifestJSON stringForKey:@"id"];
+}
+
+- (NSString *)stableLegacyId {
+  return self.rawId;
+}
+
+- (NSString *)scopeKey {
+  return self.rawId;
+}
+
+- (NSString *)projectId {
+  return self.rawId;
+}
+
 - (NSString *)createdAt {
   return [self.rawManifestJSON stringForKey:@"createdAt"];
 }

--- a/ios/versioned-react-native/ABI42_0_0/Expo/EXUpdates/ABI42_0_0EXUpdates/Update/RawManifest/ABI42_0_0EXUpdatesRawManifest.h
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/EXUpdates/ABI42_0_0EXUpdates/Update/RawManifest/ABI42_0_0EXUpdatesRawManifest.h
@@ -12,7 +12,36 @@ NS_ASSUME_NONNULL_BEGIN
 
 # pragma mark - Field getters
 
-- (nullable NSString *)rawID;
+/**
+ * A best-effort immutable legacy ID for this experience. Formatted the same as legacyId.
+ * Stable through project transfers.
+ */
+- (NSString *)stableLegacyId;
+
+/**
+ * A stable immutable scoping key for this experience. Should be used for scoping data that
+ * does not need to make calls externally with the legacy ID.
+ */
+- (NSString *)scopeKey;
+
+/**
+ * A stable UUID for this EAS project. Should be used to call EAS APIs where possible.
+ */
+- (nullable NSString *)projectId;
+
+/**
+ * The legacy ID of this experience.
+ * - For Bare manifests, formatted as a UUID.
+ * - For Legacy manifests, formatted as @owner/slug. Not stable through project transfers.
+ * - For New manifests, currently incorrect value is UUID.
+ *
+ * Use this in cases where an identifier of the current manifest is needed (experience loading for example).
+ * Use scopeKey for cases where a stable key is needed to scope data to this experience.
+ * Use projectId for cases where a stable UUID identifier of the experience is needed to identify over APIs.
+ * Use stableLegacyId for cases where a stable legacy format identifier of the experience is needed (experience scoping for example).
+ */
+- (NSString *)legacyId;
+
 - (nullable NSString *)sdkVersion;
 - (NSString *)bundleUrl;
 - (nullable NSString *)revisionId;
@@ -24,6 +53,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSDictionary *)iosConfig;
 - (nullable NSString *)hostUri;
 - (nullable NSString *)orientation;
+- (nullable NSDictionary *)experiments;
+- (nullable NSDictionary *)developer;
 
 # pragma mark - Derived Methods
 

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/ABI42_0_0EXVersionManager.h
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/ABI42_0_0EXVersionManager.h
@@ -2,15 +2,17 @@
 
 #import <Foundation/Foundation.h>
 #import <ABI42_0_0React/ABI42_0_0RCTLog.h>
+#import <ABI42_0_0EXUpdates/ABI42_0_0EXUpdatesRawManifest.h>
 
 @interface ABI42_0_0EXVersionManager : NSObject
 
 // Uses a params dict since the internal workings may change over time, but we want to keep the interface the same.
-- (instancetype)initWithParams: (NSDictionary *)params
-                  fatalHandler: (void (^)(NSError *))fatalHandler
-                   logFunction: (ABI42_0_0RCTLogFunction)logFunction
-                  logThreshold: (NSInteger)threshold;
-- (void)bridgeWillStartLoading: (id)bridge;
+- (instancetype)initWithParams:(NSDictionary *)params
+                      manifest:(ABI42_0_0EXUpdatesRawManifest *)manifest
+                  fatalHandler:(void (^)(NSError *))fatalHandler
+                   logFunction:(ABI42_0_0RCTLogFunction)logFunction
+                  logThreshold:(NSInteger)threshold;
+- (void)bridgeWillStartLoading:(id)bridge;
 - (void)bridgeFinishedLoading:(id)bridge;
 - (void)invalidate;
 

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/Api/ABI42_0_0EXNotifications.h
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/Api/ABI42_0_0EXNotifications.h
@@ -34,7 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol ABI42_0_0EXNotificationsIdentifiersManager
 
-- (NSString *)internalIdForIdentifier:(NSString *)identifier experienceId:(NSString *)experienceId;
+- (NSString *)internalIdForIdentifier:(NSString *)identifier scopeKey:(NSString *)scopeKey;
 - (NSString *)exportedIdForInternalIdentifier:(NSString *)identifier;
 
 @end

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/Api/ABI42_0_0EXNotifications.m
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/Api/ABI42_0_0EXNotifications.m
@@ -47,9 +47,12 @@ ABI42_0_0EX_EXPORT_SCOPED_MULTISERVICE_MODULE(ExponentNotifications, @"RemoteNot
   _bridge = bridge;
 }
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId kernelServiceDelegates:(NSDictionary *)kernelServiceInstances params:(NSDictionary *)params
+- (instancetype)initWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId
+                                        scopeKey:(NSString *)scopeKey
+                                    kernelServiceDelegates:(NSDictionary *)kernelServiceInstances
+                                                    params:(NSDictionary *)params
 {
-  if (self = [super initWithExperienceId:experienceId kernelServiceDelegates:kernelServiceInstances params:params]) {
+  if (self = [super initWithExperienceStableLegacyId:experienceStableLegacyId scopeKey:scopeKey kernelServiceDelegate:kernelServiceInstances params:params]) {
     _userNotificationCenter = kernelServiceInstances[@"UserNotificationCenter"];
     _remoteNotificationsDelegate = kernelServiceInstances[@"RemoteNotificationManager"];
     _notificationsIdentifiersManager = kernelServiceInstances[@"UserNotificationManager"];
@@ -80,7 +83,7 @@ ABI42_0_0RCT_REMAP_METHOD(getExponentPushTokenAsync,
                  getExponentPushTokenAsyncWithResolver:(ABI42_0_0RCTPromiseResolveBlock)resolve
                  rejecter:(ABI42_0_0RCTPromiseRejectBlock)reject)
 {
-  if (!self.experienceId) {
+  if (!self.experienceStableLegacyId) {
     reject(@"E_NOTIFICATIONS_INTERNAL_ERROR", @"The notifications module is missing the current project's ID", nil);
     return;
   }
@@ -212,7 +215,8 @@ ABI42_0_0RCT_EXPORT_METHOD(legacyScheduleLocalRepeatingNotification:(NSDictionar
   localNotification.applicationIconBadgeNumber = [ABI42_0_0RCTConvert NSInteger:payload[@"count"]] ?: 0;
   localNotification.userInfo = @{
                                  @"body": payload[@"data"],
-                                 @"experienceId": self.experienceId,
+                                 @"experienceId": self.scopeKey,
+                                 @"scopeKey": self.scopeKey,
                                  @"id": uniqueId
                                  };
   localNotification.fireDate = [ABI42_0_0RCTConvert NSDate:options[@"time"]] ?: [NSDate new];
@@ -256,7 +260,7 @@ ABI42_0_0RCT_REMAP_METHOD(cancelAllScheduledNotificationsAsync,
   [_userNotificationCenter getPendingNotificationRequestsWithCompletionHandler:^(NSArray<UNNotificationRequest *> * _Nonnull requests) {
     NSMutableArray<NSString *> *requestsToCancelIdentifiers = [NSMutableArray new];
     for (UNNotificationRequest *request in requests) {
-      if ([request.content.userInfo[@"experienceId"] isEqualToString:self.experienceId]) {
+      if ([request.content.userInfo[@"experienceId"] isEqualToString:self.scopeKey]) {
         [requestsToCancelIdentifiers addObject:request.identifier];
       }
     }
@@ -378,7 +382,8 @@ ABI42_0_0RCT_REMAP_METHOD(deleteCategoryAsync,
 
   content.userInfo = @{
                        @"body": payload[@"data"],
-                       @"experienceId": self.experienceId,
+                       @"experienceId": self.scopeKey,
+                       @"scopeKey": self.scopeKey,
                        @"id": uniqueId
                        };
 
@@ -386,7 +391,7 @@ ABI42_0_0RCT_REMAP_METHOD(deleteCategoryAsync,
 }
 
 - (NSString *)internalIdForIdentifier:(NSString *)identifier {
-  return [_notificationsIdentifiersManager internalIdForIdentifier:identifier experienceId:self.experienceId];
+  return [_notificationsIdentifiersManager internalIdForIdentifier:identifier scopeKey:self.scopeKey];
 }
 
 - (UNCalendarNotificationTrigger *)notificationTriggerFor:(NSNumber * _Nullable)unixTime

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/Api/ABI42_0_0EXUtil.m
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/Api/ABI42_0_0EXUtil.m
@@ -15,9 +15,12 @@ ABI42_0_0EX_DEFINE_SCOPED_MODULE_GETTER(ABI42_0_0EXUtil, util)
 
 ABI42_0_0EX_EXPORT_SCOPED_MODULE(ExponentUtil, UtilService);
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId kernelServiceDelegate:(id<ABI42_0_0EXUtilService>)kernelServiceInstance params:(NSDictionary *)params
+- (instancetype)initWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId scopeKey:(NSString *)scopeKey kernelServiceDelegate:(id<ABI42_0_0EXUtilService>)kernelServiceInstance params:(NSDictionary *)params
 {
-  if (self = [super initWithExperienceId:experienceId kernelServiceDelegate:kernelServiceInstance params:params]) {
+  if (self = [super initWithExperienceStableLegacyId:experienceStableLegacyId
+                                            scopeKey:scopeKey
+                               kernelServiceDelegate:kernelServiceInstance
+                                              params:params]) {
     _kernelUtilService = kernelServiceInstance;
   }
   return self;

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/Internal/ABI42_0_0EXLinkingManager.m
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/Internal/ABI42_0_0EXLinkingManager.m
@@ -22,9 +22,11 @@ NSString * const ABI42_0_0EXLinkingEventOpenUrl = @"url";
 
 ABI42_0_0EX_EXPORT_SCOPED_MODULE(ABI42_0_0RCTLinkingManager, KernelLinkingManager);
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId kernelServiceDelegate:(id)kernelServiceInstance params:(NSDictionary *)params
-{
-  if (self = [super initWithExperienceId:experienceId kernelServiceDelegate:kernelServiceInstance params:params]) {
+- (instancetype)initWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId
+                                        scopeKey:(NSString *)scopeKey
+                                     kernelServiceDelegate:(id)kernelServiceInstance params:(NSDictionary *)params
+                {
+                  if (self = [super initWithExperienceStableLegacyId:experienceStableLegacyId scopeKey:scopeKey kernelServiceDelegate:kernelServiceInstance params:params]) {
     _kernelLinkingDelegate = kernelServiceInstance;
     _initialUrl = params[@"initialUri"];
     if (_initialUrl == [NSNull null]) {

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/Internal/DevSupport/ABI42_0_0EXDevSettings.h
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/Internal/DevSupport/ABI42_0_0EXDevSettings.h
@@ -5,7 +5,7 @@
 @interface ABI42_0_0EXDevSettings : ABI42_0_0RCTDevSettings
 
 - (instancetype)init NS_UNAVAILABLE;
-- (instancetype)initWithExperienceId:(NSString *)experienceId
-                       isDevelopment:(BOOL)isDevelopment NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey
+                   isDevelopment:(BOOL)isDevelopment NS_DESIGNATED_INITIALIZER;
 
 @end

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/Internal/DevSupport/ABI42_0_0EXDevSettings.m
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/Internal/DevSupport/ABI42_0_0EXDevSettings.m
@@ -12,7 +12,7 @@ NSString *const kABI42_0_0RCTDevSettingHotLoadingEnabled = @"hotLoadingEnabled";
 
 + (NSString *)moduleName { return @"ABI42_0_0RCTDevSettings"; }
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId isDevelopment:(BOOL)isDevelopment
+- (instancetype)initWithScopeKey:(NSString *)scopeKey isDevelopment:(BOOL)isDevelopment
 {
   NSDictionary *defaultValues = @{
                                   kABI42_0_0RCTDevSettingShakeToShowDevMenu: @YES,
@@ -20,7 +20,7 @@ NSString *const kABI42_0_0RCTDevSettingHotLoadingEnabled = @"hotLoadingEnabled";
                                   kABI42_0_0RCTDevSettingLiveReloadEnabled: @NO,
                                   };
   ABI42_0_0EXDevSettingsDataSource *dataSource = [[ABI42_0_0EXDevSettingsDataSource alloc] initWithDefaultValues:defaultValues
-                                                                               forExperienceId:experienceId
+                                                                                                     forScopeKey:scopeKey
                                                                                  isDevelopment:isDevelopment];
   return [super initWithDataSource:dataSource];
 }

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/Internal/DevSupport/ABI42_0_0EXDevSettingsDataSource.h
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/Internal/DevSupport/ABI42_0_0EXDevSettingsDataSource.h
@@ -7,7 +7,7 @@
 
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithDefaultValues:(NSDictionary *)defaultValues
-                      forExperienceId:(NSString *)experienceId
+                          forScopeKey:(NSString *)scopeKey
                         isDevelopment:(BOOL)isDevelopment NS_DESIGNATED_INITIALIZER;
 
 @end

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/Internal/DevSupport/ABI42_0_0EXDevSettingsDataSource.m
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/Internal/DevSupport/ABI42_0_0EXDevSettingsDataSource.m
@@ -16,7 +16,7 @@ NSString *const ABI42_0_0EXDevSettingIsDebuggingRemotely = @"isDebuggingRemotely
 
 @interface ABI42_0_0EXDevSettingsDataSource ()
 
-@property (nonatomic, strong) NSString *experienceId;
+@property (nonatomic, strong) NSString *scopeKey;
 @property (nonatomic, readonly) NSSet *settingsDisabledInProduction;
 
 @end
@@ -27,10 +27,12 @@ NSString *const ABI42_0_0EXDevSettingIsDebuggingRemotely = @"isDebuggingRemotely
   BOOL _isDevelopment;
 }
 
-- (instancetype)initWithDefaultValues:(NSDictionary *)defaultValues forExperienceId:(NSString *)experienceId isDevelopment:(BOOL)isDevelopment
+- (instancetype)initWithDefaultValues:(NSDictionary *)defaultValues
+                          forScopeKey:(NSString *)scopeKey
+                                  isDevelopment:(BOOL)isDevelopment
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _scopeKey = scopeKey;
     _userDefaults = [NSUserDefaults standardUserDefaults];
     _isDevelopment = isDevelopment;
     _settingsDisabledInProduction = [NSSet setWithArray:@[
@@ -97,8 +99,8 @@ NSString *const ABI42_0_0EXDevSettingIsDebuggingRemotely = @"isDebuggingRemotely
 
 - (NSString *)_userDefaultsKey
 {
-  if (_experienceId) {
-    return [NSString stringWithFormat:@"%@/%@", _experienceId, ABI42_0_0EXDevSettingsUserDefaultsKey];
+  if (_scopeKey) {
+    return [NSString stringWithFormat:@"%@/%@", _scopeKey, ABI42_0_0EXDevSettingsUserDefaultsKey];
   } else {
     ABI42_0_0RCTLogWarn(@"Can't scope dev settings because bridge is not set");
     return ABI42_0_0EXDevSettingsUserDefaultsKey;

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/ScopedModule/ABI42_0_0EXScopedBridgeModule.h
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/ScopedModule/ABI42_0_0EXScopedBridgeModule.h
@@ -7,14 +7,17 @@
 
 - (instancetype)init NS_UNAVAILABLE;
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
-               kernelServiceDelegate:(id)kernelServiceInstance
-                              params:(NSDictionary *)params NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId
+                                        scopeKey:(NSString *)scopeKey
+                                     kernelServiceDelegate:(id)kernelServiceInstance
+                                                    params:(NSDictionary *)params NS_DESIGNATED_INITIALIZER;
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
-               kernelServiceDelegates:(NSDictionary *)kernelServiceInstances
-                              params:(NSDictionary *)params NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId
+                                        scopeKey:(NSString *)scopeKey
+                                    kernelServiceDelegates:(NSDictionary *)kernelServiceInstances
+                                                    params:(NSDictionary *)params NS_DESIGNATED_INITIALIZER;
 
-@property (nonatomic, readonly) NSString *experienceId;
+@property (nonatomic, readonly) NSString *scopeKey;
+@property (nonatomic, readonly) NSString *experienceStableLegacyId;
 
 @end

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/ScopedModule/ABI42_0_0EXScopedBridgeModule.m
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/ScopedModule/ABI42_0_0EXScopedBridgeModule.m
@@ -10,18 +10,26 @@
   return @"ExponentScopedBridgeModule";
 }
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId kernelServiceDelegate:(id)kernelServiceInstance params:(NSDictionary *)params
+- (instancetype)initWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId
+                                        scopeKey:(NSString *)scopeKey
+                           kernelServiceDelegate:(id)kernelServiceInstance
+                                          params:(NSDictionary *)params
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _experienceStableLegacyId = experienceStableLegacyId;
+    _scopeKey = scopeKey;
   }
   return self;
 }
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId kernelServiceDelegates:(NSDictionary *)kernelServiceInstances params:(NSDictionary *)params
+- (instancetype)initWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId
+                                        scopeKey:(NSString *)scopeKey
+                          kernelServiceDelegates:(NSDictionary *)kernelServiceInstances
+                                          params:(NSDictionary *)params
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _experienceStableLegacyId = experienceStableLegacyId;
+    _scopeKey = scopeKey;
   }
   return self;
 }

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/ScopedModule/ABI42_0_0EXScopedEventEmitter.h
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/ScopedModule/ABI42_0_0EXScopedEventEmitter.h
@@ -8,14 +8,16 @@
 
 - (instancetype)init NS_UNAVAILABLE;
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
-               kernelServiceDelegate:(id)kernelServiceInstance
-                              params:(NSDictionary *)params NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId
+                                        scopeKey:(NSString *)scopeKey
+                                     kernelServiceDelegate:(id)kernelServiceInstance
+                                                    params:(NSDictionary *)params NS_DESIGNATED_INITIALIZER;
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
-              kernelServiceDelegates:(NSDictionary *)kernelServiceInstances
-                              params:(NSDictionary *)params NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId
+                                        scopeKey:(NSString *)scopeKey
+                                    kernelServiceDelegates:(NSDictionary *)kernelServiceInstances
+                                                    params:(NSDictionary *)params NS_DESIGNATED_INITIALIZER;
 
-@property (nonatomic, readonly) NSString *experienceId;
+@property (nonatomic, readonly) NSString *scopeKey;
 
 @end

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/ScopedModule/ABI42_0_0EXScopedEventEmitter.m
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/ScopedModule/ABI42_0_0EXScopedEventEmitter.m
@@ -10,26 +10,26 @@
   return @"ExponentScopedEventEmitter";
 }
 
-+ (NSString *)getExperienceIdFromEventEmitter:(id)eventEmitter
++ (NSString *)getScopeKeyFromEventEmitter:(id)eventEmitter
 {
   if (eventEmitter) {
-    return ((ABI42_0_0EXScopedEventEmitter *)eventEmitter).experienceId;
+    return ((ABI42_0_0EXScopedEventEmitter *)eventEmitter).scopeKey;
   }
   return nil;
 }
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId kernelServiceDelegate:(id)kernelServiceInstance params:(NSDictionary *)params
+- (instancetype)initWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId scopeKey:(NSString *)scopeKey kernelServiceDelegate:(id)kernelServiceInstance params:(NSDictionary *)params
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _scopeKey = scopeKey;
   }
   return self;
 }
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId kernelServiceDelegates:(NSDictionary *)kernelServiceInstances params:(NSDictionary *)params
+- (instancetype)initWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId scopeKey:(NSString *)scopeKey kernelServiceDelegates:(NSDictionary *)kernelServiceInstances params:(NSDictionary *)params
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _scopeKey = scopeKey;
   }
   return self;
 }

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/ABI42_0_0EXConstantsBinding.h
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/ABI42_0_0EXConstantsBinding.h
@@ -11,7 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly) NSString *appOwnership;
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId andParams:(NSDictionary *)params;
+- (instancetype)initWithParams:(NSDictionary *)params;
 
 @end
 

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/ABI42_0_0EXConstantsBinding.m
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/ABI42_0_0EXConstantsBinding.m
@@ -6,17 +6,15 @@
 @interface ABI42_0_0EXConstantsBinding ()
 
 @property (nonatomic, strong) NSString *appOwnership;
-@property (nonatomic, strong) NSString *experienceId;
 @property (nonatomic, strong) NSDictionary *unversionedConstants;
 
 @end
 
 @implementation ABI42_0_0EXConstantsBinding : ABI42_0_0EXConstantsService
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId andParams:(NSDictionary *)params
+- (instancetype)initWithParams:(NSDictionary *)params
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
     _unversionedConstants = params[@"constants"];
     if (_unversionedConstants && _unversionedConstants[@"appOwnership"]) {
       _appOwnership = _unversionedConstants[@"appOwnership"];

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/ABI42_0_0EXScopedAmplitude.h
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/ABI42_0_0EXScopedAmplitude.h
@@ -7,7 +7,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ABI42_0_0EXScopedAmplitude : ABI42_0_0EXAmplitude
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId;
+- (instancetype)initWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId;
 
 @end
 

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/ABI42_0_0EXScopedAmplitude.m
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/ABI42_0_0EXScopedAmplitude.m
@@ -12,30 +12,30 @@
 
 @interface ABI42_0_0EXScopedAmplitude ()
 
-@property (strong, nonatomic) NSString *escapedExperienceId;
+@property (strong, nonatomic) NSString *escapedExperienceStableLegacyId;
 
 @end
 
 @implementation ABI42_0_0EXScopedAmplitude
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
+- (instancetype)initWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId
 {
   if (self = [super init]) {
-    _escapedExperienceId = [self escapedExperienceId:experienceId];
+    _escapedExperienceStableLegacyId = [self escapedExperienceStableLegacyId:experienceStableLegacyId];
   }
   return self;
 }
 
 - (Amplitude *)amplitudeInstance
 {
-  return [Amplitude instanceWithName:_escapedExperienceId];
+  return [Amplitude instanceWithName:_escapedExperienceStableLegacyId];
 }
 
-- (NSString *)escapedExperienceId:(NSString *)experienceId
+- (NSString *)escapedExperienceStableLegacyId:(NSString *)experienceStableLegacyId
 {
   NSString *charactersToEscape = @"!*'();:@&=+$,/?%#[]";
   NSCharacterSet *allowedCharacters = [[NSCharacterSet characterSetWithCharactersInString:charactersToEscape] invertedSet];
-  return [experienceId stringByAddingPercentEncodingWithAllowedCharacters:allowedCharacters];
+  return [experienceStableLegacyId stringByAddingPercentEncodingWithAllowedCharacters:allowedCharacters];
 }
 
 @end

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/ABI42_0_0EXScopedBranch.h
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/ABI42_0_0EXScopedBranch.h
@@ -15,9 +15,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ABI42_0_0EXScopedBranch : ABI42_0_0RNBranch <ABI42_0_0UMModuleRegistryConsumer, ABI42_0_0UMInternalModule>
 
-@property (nonatomic, strong) NSString *experienceId;
+@property (nonatomic, strong) NSString *scopeKey;
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey;
 
 @end
 

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/ABI42_0_0EXScopedBranch.m
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/ABI42_0_0EXScopedBranch.m
@@ -20,11 +20,11 @@
   return @[@protocol(ABI42_0_0EXDummyBranchProtocol)];
 }
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
+- (instancetype)initWithScopeKey:(NSString *)scopeKey
 {
   if (self = [super init]) {
     [[NSNotificationCenter defaultCenter] removeObserver:self name:ABI42_0_0RNBranchLinkOpenedNotification object:nil];
-    _experienceId = experienceId;
+    _scopeKey = scopeKey;
   }
   return self;
 }

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/ABI42_0_0EXScopedErrorRecoveryModule.h
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/ABI42_0_0EXScopedErrorRecoveryModule.h
@@ -5,7 +5,7 @@
 
 @interface ABI42_0_0EXScopedErrorRecoveryModule : ABI42_0_0EXErrorRecoveryModule
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey;
 
 @end
 

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/ABI42_0_0EXScopedErrorRecoveryModule.m
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/ABI42_0_0EXScopedErrorRecoveryModule.m
@@ -5,16 +5,16 @@
 
 @interface ABI42_0_0EXScopedErrorRecoveryModule ()
 
-@property (nonatomic, strong) NSString *experienceId;
+@property (nonatomic, strong) NSString *scopeKey;
 
 @end
 
 @implementation ABI42_0_0EXScopedErrorRecoveryModule
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
+- (instancetype)initWithScopeKey:(NSString *)scopeKey
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _scopeKey = scopeKey;
   }
   return self;
 }
@@ -24,7 +24,7 @@
   NSUserDefaults *preferences = [NSUserDefaults standardUserDefaults];
   NSDictionary *errorRecoveryStore = [preferences dictionaryForKey:[self userDefaultsKey]] ?: @{};
   NSMutableDictionary *newStore = [errorRecoveryStore mutableCopy];
-  newStore[_experienceId] = props;
+  newStore[_scopeKey] = props;
   [preferences setObject:newStore forKey:[self userDefaultsKey]];
   return [preferences synchronize];
 }
@@ -34,10 +34,10 @@
   NSUserDefaults *preferences = [NSUserDefaults standardUserDefaults];
   NSDictionary *errorRecoveryStore = [preferences dictionaryForKey:[self userDefaultsKey]];
   if (errorRecoveryStore) {
-    NSString *props = errorRecoveryStore[_experienceId];
+    NSString *props = errorRecoveryStore[_scopeKey];
     if (props) {
       NSMutableDictionary *storeWithRemovedProps = [errorRecoveryStore mutableCopy];
-      [storeWithRemovedProps removeObjectForKey:_experienceId];
+      [storeWithRemovedProps removeObjectForKey:_scopeKey];
       [preferences setObject:storeWithRemovedProps forKey:[self userDefaultsKey]];
       [preferences synchronize];
       return props;

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/ABI42_0_0EXScopedFirebaseCore.h
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/ABI42_0_0EXScopedFirebaseCore.h
@@ -9,7 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ABI42_0_0EXScopedFirebaseCore : ABI42_0_0EXFirebaseCore
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId andConstantsBinding:(ABI42_0_0EXConstantsBinding *)constantsBinding;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey andConstantsBinding:(ABI42_0_0EXConstantsBinding *)constantsBinding;
 
 @end
 

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/ABI42_0_0EXScopedFirebaseCore.m
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/ABI42_0_0EXScopedFirebaseCore.m
@@ -13,7 +13,7 @@
   NSDictionary* _protectedAppNames;
 }
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId andConstantsBinding:(ABI42_0_0EXConstantsBinding *)constantsBinding
+- (instancetype)initWithScopeKey:(NSString *)scopeKey andConstantsBinding:(ABI42_0_0EXConstantsBinding *)constantsBinding
 {
   if (![@"expo" isEqualToString:constantsBinding.appOwnership]) {
     return [super init];
@@ -34,8 +34,8 @@
   if ([FIRApp defaultApp]) [protectedAppNames setValue:@YES forKey:[FIRApp defaultApp].name];
   
   // Determine project app name & options
-  NSString *encodedExperienceId = [self.class encodedResourceName:experienceId];
-  NSString* appName = [NSString stringWithFormat:@"__sandbox_%@", encodedExperienceId];
+  NSString *encodedScopeKey = [self.class encodedResourceName:scopeKey];
+  NSString* appName = [NSString stringWithFormat:@"__sandbox_%@", encodedScopeKey];
   NSDictionary* googleServicesFile = [self.class googleServicesFileFromConstantsManifest:constantsBinding];
   FIROptions* options = [self.class optionsWithGoogleServicesFile:googleServicesFile];
   

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/ABI42_0_0EXScopedModuleRegistryAdapter.h
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/ABI42_0_0EXScopedModuleRegistryAdapter.h
@@ -4,6 +4,9 @@
 
 @interface ABI42_0_0EXScopedModuleRegistryAdapter : ABI42_0_0UMModuleRegistryAdapter
 
-- (ABI42_0_0UMModuleRegistry *)moduleRegistryForParams:(NSDictionary *)params forExperienceId:(NSString *)experienceId withKernelServices:(NSDictionary *)kernelServices;
+- (ABI42_0_0UMModuleRegistry *)moduleRegistryForParams:(NSDictionary *)params
+                           forExperienceStableLegacyId:(NSString *)experienceStableLegacyId
+                                    scopeKey:(NSString *)scopeKey
+                                    withKernelServices:(NSDictionary *)kernelServices;
 
 @end

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/ABI42_0_0EXScopedModuleRegistryAdapter.m
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/ABI42_0_0EXScopedModuleRegistryAdapter.m
@@ -37,24 +37,28 @@
 
 @implementation ABI42_0_0EXScopedModuleRegistryAdapter
 
-- (ABI42_0_0UMModuleRegistry *)moduleRegistryForParams:(NSDictionary *)params forExperienceId:(NSString *)experienceId withKernelServices:(NSDictionary *)kernelServices
+- (ABI42_0_0UMModuleRegistry *)moduleRegistryForParams:(NSDictionary *)params
+                           forExperienceStableLegacyId:(NSString *)experienceStableLegacyId
+                                    scopeKey:(NSString *)scopeKey
+                                    withKernelServices:(NSDictionary *)kernelServices
 {
   ABI42_0_0UMModuleRegistry *moduleRegistry = [self.moduleRegistryProvider moduleRegistry];
 
 #if __has_include(<ABI42_0_0EXUpdates/ABI42_0_0EXUpdatesService.h>)
-  ABI42_0_0EXUpdatesBinding *updatesBinding = [[ABI42_0_0EXUpdatesBinding alloc] initWithExperienceId:experienceId updatesKernelService:kernelServices[@"EXUpdatesManager"] databaseKernelService:kernelServices[@"EXUpdatesDatabaseManager"]];
+  ABI42_0_0EXUpdatesBinding *updatesBinding = [[ABI42_0_0EXUpdatesBinding alloc] initWithScopeKey:scopeKey
+                                                                             updatesKernelService:kernelServices[@"EXUpdatesManager"] databaseKernelService:kernelServices[@"EXUpdatesDatabaseManager"]];
   [moduleRegistry registerInternalModule:updatesBinding];
 #endif
 
 #if __has_include(<ABI42_0_0EXConstants/ABI42_0_0EXConstantsService.h>)
-  ABI42_0_0EXConstantsBinding *constantsBinding = [[ABI42_0_0EXConstantsBinding alloc] initWithExperienceId:experienceId andParams:params];
+  ABI42_0_0EXConstantsBinding *constantsBinding = [[ABI42_0_0EXConstantsBinding alloc] initWithParams:params];
   [moduleRegistry registerInternalModule:constantsBinding];
 #endif
 
 #if __has_include(<ABI42_0_0EXFacebook/ABI42_0_0EXFacebook.h>)
   // only override in Expo Go
   if ([params[@"constants"][@"appOwnership"] isEqualToString:@"expo"]) {
-    ABI42_0_0EXScopedFacebook *scopedFacebook = [[ABI42_0_0EXScopedFacebook alloc] initWithExperienceId:experienceId andParams:params];
+    ABI42_0_0EXScopedFacebook *scopedFacebook = [[ABI42_0_0EXScopedFacebook alloc] initWithScopeKey:scopeKey andParams:params];
     [moduleRegistry registerExportedModule:scopedFacebook];
   }
 #endif
@@ -80,7 +84,7 @@
 #endif
 
 #if __has_include(<ABI42_0_0EXSensors/ABI42_0_0EXSensorsManager.h>)
-  ABI42_0_0EXSensorsManagerBinding *sensorsManagerBinding = [[ABI42_0_0EXSensorsManagerBinding alloc] initWithExperienceId:experienceId andKernelService:kernelServices[@"EXSensorManager"]];
+  ABI42_0_0EXSensorsManagerBinding *sensorsManagerBinding = [[ABI42_0_0EXSensorsManagerBinding alloc] initWithScopeKey:scopeKey andKernelService:kernelServices[@"EXSensorManager"]];
   [moduleRegistry registerInternalModule:sensorsManagerBinding];
 #endif
 
@@ -96,17 +100,17 @@
 #endif
 
 #if __has_include(<ABI42_0_0EXSecureStore/ABI42_0_0EXSecureStore.h>)
-  ABI42_0_0EXScopedSecureStore *secureStoreModule = [[ABI42_0_0EXScopedSecureStore alloc] initWithExperienceId:experienceId andConstantsBinding:constantsBinding];
+  ABI42_0_0EXScopedSecureStore *secureStoreModule = [[ABI42_0_0EXScopedSecureStore alloc] initWithScopeKey:scopeKey andConstantsBinding:constantsBinding];
   [moduleRegistry registerExportedModule:secureStoreModule];
 #endif
 
 #if __has_include(<ABI42_0_0EXAmplitude/ABI42_0_0EXAmplitude.h>)
-  ABI42_0_0EXScopedAmplitude *amplitudeModule = [[ABI42_0_0EXScopedAmplitude alloc] initWithExperienceId:experienceId];
+  ABI42_0_0EXScopedAmplitude *amplitudeModule = [[ABI42_0_0EXScopedAmplitude alloc] initWithExperienceStableLegacyId:experienceStableLegacyId];
   [moduleRegistry registerExportedModule:amplitudeModule];
 #endif
 
 #if __has_include(<ABI42_0_0UMReactNativeAdapter/ABI42_0_0EXPermissionsService.h>)
-  ABI42_0_0EXScopedPermissions *permissionsModule = [[ABI42_0_0EXScopedPermissions alloc] initWithExperienceId:experienceId andConstantsBinding:constantsBinding];
+  ABI42_0_0EXScopedPermissions *permissionsModule = [[ABI42_0_0EXScopedPermissions alloc] initWithScopeKey:scopeKey andConstantsBinding:constantsBinding];
   [moduleRegistry registerExportedModule:permissionsModule];
   [moduleRegistry registerInternalModule:permissionsModule];
 #endif
@@ -117,7 +121,7 @@
 #endif
 
 #if __has_include(<ABI42_0_0EXBranch/ABI42_0_0RNBranch.h>)
-  ABI42_0_0EXScopedBranch *branchModule = [[ABI42_0_0EXScopedBranch alloc] initWithExperienceId:experienceId];
+  ABI42_0_0EXScopedBranch *branchModule = [[ABI42_0_0EXScopedBranch alloc] initWithScopeKey:scopeKey];
   [moduleRegistry registerInternalModule:branchModule];
 #endif
 
@@ -128,18 +132,18 @@
 
 #if __has_include(<ABI42_0_0EXTaskManager/ABI42_0_0EXTaskManager.h>)
   // TODO: Make scoped task manager when adding support for bare ABI42_0_0React Native
-  ABI42_0_0EXTaskManager *taskManagerModule = [[ABI42_0_0EXTaskManager alloc] initWithExperienceId:experienceId];
+  ABI42_0_0EXTaskManager *taskManagerModule = [[ABI42_0_0EXTaskManager alloc] initWithScopeKey:scopeKey];
   [moduleRegistry registerInternalModule:taskManagerModule];
   [moduleRegistry registerExportedModule:taskManagerModule];
 #endif
   
 #if __has_include(<ABI42_0_0EXErrorRecovery/ABI42_0_0EXErrorRecoveryModule.h>)
-  ABI42_0_0EXScopedErrorRecoveryModule *errorRecovery = [[ABI42_0_0EXScopedErrorRecoveryModule alloc] initWithExperienceId:experienceId];
+  ABI42_0_0EXScopedErrorRecoveryModule *errorRecovery = [[ABI42_0_0EXScopedErrorRecoveryModule alloc] initWithScopeKey:scopeKey];
   [moduleRegistry registerExportedModule:errorRecovery];
 #endif
   
 #if __has_include(<ABI42_0_0EXFirebaseCore/ABI42_0_0EXFirebaseCore.h>)
-  ABI42_0_0EXScopedFirebaseCore *firebaseCoreModule = [[ABI42_0_0EXScopedFirebaseCore alloc] initWithExperienceId:experienceId andConstantsBinding:constantsBinding];
+  ABI42_0_0EXScopedFirebaseCore *firebaseCoreModule = [[ABI42_0_0EXScopedFirebaseCore alloc] initWithScopeKey:scopeKey andConstantsBinding:constantsBinding];
   [moduleRegistry registerExportedModule:firebaseCoreModule];
   [moduleRegistry registerInternalModule:firebaseCoreModule];
 #endif
@@ -147,7 +151,7 @@
 #if __has_include(<ABI42_0_0EXNotifications/ABI42_0_0EXNotificationsEmitter.h>)
   // only override in Expo Go
   if ([params[@"constants"][@"appOwnership"] isEqualToString:@"expo"]) {
-    ABI42_0_0EXScopedNotificationsEmitter *notificationsEmmitter = [[ABI42_0_0EXScopedNotificationsEmitter alloc] initWithExperienceId:experienceId];
+    ABI42_0_0EXScopedNotificationsEmitter *notificationsEmmitter = [[ABI42_0_0EXScopedNotificationsEmitter alloc] initWithScopeKey:scopeKey];
     [moduleRegistry registerExportedModule:notificationsEmmitter];
   }
 #endif
@@ -155,20 +159,20 @@
 #if __has_include(<ABI42_0_0EXNotifications/ABI42_0_0EXNotificationsHandlerModule.h>)
   // only override in Expo Go
   if ([params[@"constants"][@"appOwnership"] isEqualToString:@"expo"]) {
-    ABI42_0_0EXScopedNotificationsHandlerModule *notificationsHandler = [[ABI42_0_0EXScopedNotificationsHandlerModule alloc] initWithExperienceId:experienceId];
+    ABI42_0_0EXScopedNotificationsHandlerModule *notificationsHandler = [[ABI42_0_0EXScopedNotificationsHandlerModule alloc] initWithScopeKey:scopeKey];
     [moduleRegistry registerExportedModule:notificationsHandler];
   }
 #endif
   
 #if __has_include(<ABI42_0_0EXNotifications/ABI42_0_0EXNotificationsHandlerModule.h>)
-  ABI42_0_0EXScopedNotificationBuilder *notificationsBuilder = [[ABI42_0_0EXScopedNotificationBuilder alloc] initWithExperienceId:experienceId andConstantsBinding:constantsBinding];
+  ABI42_0_0EXScopedNotificationBuilder *notificationsBuilder = [[ABI42_0_0EXScopedNotificationBuilder alloc] initWithScopeKey:scopeKey andConstantsBinding:constantsBinding];
   [moduleRegistry registerInternalModule:notificationsBuilder];
 #endif
   
 #if __has_include(<ABI42_0_0EXNotifications/ABI42_0_0EXNotificationSchedulerModule.h>)
   // only override in Expo Go
   if ([params[@"constants"][@"appOwnership"] isEqualToString:@"expo"]) {
-    ABI42_0_0EXScopedNotificationSchedulerModule *schedulerModule = [[ABI42_0_0EXScopedNotificationSchedulerModule alloc] initWithExperienceId:experienceId];
+    ABI42_0_0EXScopedNotificationSchedulerModule *schedulerModule = [[ABI42_0_0EXScopedNotificationSchedulerModule alloc] initWithScopeKey:scopeKey];
     [moduleRegistry registerExportedModule:schedulerModule];
   }
 #endif
@@ -176,7 +180,7 @@
 #if __has_include(<ABI42_0_0EXNotifications/ABI42_0_0EXNotificationPresentationModule.h>)
   // only override in Expo Go
   if ([params[@"constants"][@"appOwnership"] isEqualToString:@"expo"]) {
-    ABI42_0_0EXScopedNotificationPresentationModule *notificationPresentationModule = [[ABI42_0_0EXScopedNotificationPresentationModule alloc] initWithExperienceId:experienceId];
+    ABI42_0_0EXScopedNotificationPresentationModule *notificationPresentationModule = [[ABI42_0_0EXScopedNotificationPresentationModule alloc] initWithScopeKey:scopeKey];
     [moduleRegistry registerExportedModule:notificationPresentationModule];
   }
 #endif
@@ -184,15 +188,16 @@
 #if __has_include(<ABI42_0_0EXNotifications/ABI42_0_0EXNotificationCategoriesModule.h>)
   // only override in Expo Go
   if ([params[@"constants"][@"appOwnership"] isEqualToString:@"expo"]) {
-    ABI42_0_0EXScopedNotificationCategoriesModule *scopedCategoriesModule = [[ABI42_0_0EXScopedNotificationCategoriesModule alloc] initWithExperienceId:experienceId andConstantsBinding:constantsBinding];
+    ABI42_0_0EXScopedNotificationCategoriesModule *scopedCategoriesModule = [[ABI42_0_0EXScopedNotificationCategoriesModule alloc] initWithScopeKey:scopeKey andConstantsBinding:constantsBinding];
     [moduleRegistry registerExportedModule:scopedCategoriesModule];
   }
-  [ABI42_0_0EXScopedNotificationCategoriesModule maybeMigrateLegacyCategoryIdentifiersForProject:experienceId
+  [ABI42_0_0EXScopedNotificationCategoriesModule maybeMigrateLegacyCategoryIdentifiersForProjectWithExperienceStableLegacyId:experienceStableLegacyId
+                                                                                                                    scopeKey:scopeKey
                                                                              isInExpoGo:[params[@"constants"][@"appOwnership"] isEqualToString:@"expo"]];
 #endif
   
 #if __has_include(<ABI42_0_0EXNotifications/ABI42_0_0EXServerRegistrationModule.h>)
-  ABI42_0_0EXScopedServerRegistrationModule *serverRegistrationModule = [[ABI42_0_0EXScopedServerRegistrationModule alloc] initWithExperienceId:experienceId];
+  ABI42_0_0EXScopedServerRegistrationModule *serverRegistrationModule = [[ABI42_0_0EXScopedServerRegistrationModule alloc] initWithScopeKey:scopeKey];
   [moduleRegistry registerExportedModule:serverRegistrationModule];
 #endif
 

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/ABI42_0_0EXScopedSecureStore.h
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/ABI42_0_0EXScopedSecureStore.h
@@ -9,7 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ABI42_0_0EXScopedSecureStore : ABI42_0_0EXSecureStore
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
+- (instancetype)initWithScopeKey:(NSString *)scopeKey
                  andConstantsBinding:(ABI42_0_0EXConstantsBinding *)constantsBinding;
 
 @end

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/ABI42_0_0EXScopedSecureStore.m
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/ABI42_0_0EXScopedSecureStore.m
@@ -15,18 +15,18 @@
 
 @interface ABI42_0_0EXScopedSecureStore ()
 
-@property (strong, nonatomic) NSString *experienceId;
+@property (strong, nonatomic) NSString *scopeKey;
 @property (nonatomic) BOOL isStandaloneApp;
 
 @end
 
 @implementation ABI42_0_0EXScopedSecureStore
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
+- (instancetype)initWithScopeKey:(NSString *)scopeKey
                  andConstantsBinding:(ABI42_0_0EXConstantsBinding *)constantsBinding
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _scopeKey = scopeKey;
     _isStandaloneApp = ![@"expo" isEqualToString:constantsBinding.appOwnership];
   }
   return self;
@@ -37,11 +37,11 @@
     return nil;
   }
 
-  return _isStandaloneApp ? key : [NSString stringWithFormat:@"%@-%@", _experienceId, key];
+  return _isStandaloneApp ? key : [NSString stringWithFormat:@"%@-%@", _scopeKey, key];
 }
 
 // We must override this method so that items saved in standalone apps on SDK 40 and below,
-// which were scoped by prefixing the validated key with the experienceId, can still be
+// which were scoped by prefixing the validated key with the scopeKey, can still be
 // found in SDK 41 and up. This override can be removed in SDK 45.
 - (NSString *)_getValueWithKey:(NSString *)key withOptions:(NSDictionary *)options error:(NSError **)error
 {
@@ -54,7 +54,7 @@
                                             encoding:NSUTF8StringEncoding];
     return value;
   } else if (_isStandaloneApp) {
-    NSString *scopedKey = [NSString stringWithFormat:@"%@-%@", _experienceId, key];
+    NSString *scopedKey = [NSString stringWithFormat:@"%@-%@", _scopeKey, key];
     NSString *scopedValue = [self getValueWithScopedKey:scopedKey
                                              withOptions:options];
     if (scopedValue) {

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/ABI42_0_0EXSensorsManagerBinding.h
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/ABI42_0_0EXSensorsManagerBinding.h
@@ -11,30 +11,30 @@
 
 @protocol ABI42_0_0EXSensorsManagerBindingDelegate
 
-- (void)sensorModuleDidSubscribeForAccelerometerUpdatesOfExperience:(NSString *)experienceId withHandler:(void (^)(NSDictionary *event))handlerBlock;
-- (void)sensorModuleDidUnsubscribeForAccelerometerUpdatesOfExperience:(NSString *)experienceId;
+- (void)sensorModuleDidSubscribeForAccelerometerUpdatesOfExperience:(NSString *)scopeKey withHandler:(void (^)(NSDictionary *event))handlerBlock;
+- (void)sensorModuleDidUnsubscribeForAccelerometerUpdatesOfExperience:(NSString *)scopeKey;
 - (void)setAccelerometerUpdateInterval:(NSTimeInterval)intervalMs;
 
 - (float)getGravity;
-- (void)sensorModuleDidSubscribeForDeviceMotionUpdatesOfExperience:(NSString *)experienceId withHandler:(void (^)(NSDictionary *event))handlerBlock;
-- (void)sensorModuleDidUnsubscribeForDeviceMotionUpdatesOfExperience:(NSString *)experienceId;
+- (void)sensorModuleDidSubscribeForDeviceMotionUpdatesOfExperience:(NSString *)scopeKey withHandler:(void (^)(NSDictionary *event))handlerBlock;
+- (void)sensorModuleDidUnsubscribeForDeviceMotionUpdatesOfExperience:(NSString *)scopeKey;
 - (void)setDeviceMotionUpdateInterval:(NSTimeInterval)intervalMs;
 
-- (void)sensorModuleDidSubscribeForGyroscopeUpdatesOfExperience:(NSString *)experienceId withHandler:(void (^)(NSDictionary *event))handlerBlock;
-- (void)sensorModuleDidUnsubscribeForGyroscopeUpdatesOfExperience:(NSString *)experienceId;
+- (void)sensorModuleDidSubscribeForGyroscopeUpdatesOfExperience:(NSString *)scopeKey withHandler:(void (^)(NSDictionary *event))handlerBlock;
+- (void)sensorModuleDidUnsubscribeForGyroscopeUpdatesOfExperience:(NSString *)scopeKey;
 - (void)setGyroscopeUpdateInterval:(NSTimeInterval)intervalMs;
 
-- (void)sensorModuleDidSubscribeForMagnetometerUpdatesOfExperience:(NSString *)experienceId withHandler:(void (^)(NSDictionary *event))handlerBlock;
-- (void)sensorModuleDidUnsubscribeForMagnetometerUpdatesOfExperience:(NSString *)experienceId;
+- (void)sensorModuleDidSubscribeForMagnetometerUpdatesOfExperience:(NSString *)scopeKey withHandler:(void (^)(NSDictionary *event))handlerBlock;
+- (void)sensorModuleDidUnsubscribeForMagnetometerUpdatesOfExperience:(NSString *)scopeKey;
 - (void)setMagnetometerUpdateInterval:(NSTimeInterval)intervalMs;
 
-- (void)sensorModuleDidSubscribeForMagnetometerUncalibratedUpdatesOfExperience:(NSString *)experienceId
+- (void)sensorModuleDidSubscribeForMagnetometerUncalibratedUpdatesOfExperience:(NSString *)scopeKey
                                                        withHandler:(void (^)(NSDictionary *event))handlerBlock;
-- (void)sensorModuleDidUnsubscribeForMagnetometerUncalibratedUpdatesOfExperience:(NSString *)experienceId;
+- (void)sensorModuleDidUnsubscribeForMagnetometerUncalibratedUpdatesOfExperience:(NSString *)scopeKey;
 - (void)setMagnetometerUncalibratedUpdateInterval:(NSTimeInterval)intervalMs;
 
-- (void)sensorModuleDidSubscribeForBarometerUpdatesOfExperience:(NSString *)experienceId withHandler:(void (^)(NSDictionary *event))handlerBlock;
-- (void)sensorModuleDidUnsubscribeForBarometerUpdatesOfExperience:(NSString *)experienceId;
+- (void)sensorModuleDidSubscribeForBarometerUpdatesOfExperience:(NSString *)scopeKey withHandler:(void (^)(NSDictionary *event))handlerBlock;
+- (void)sensorModuleDidUnsubscribeForBarometerUpdatesOfExperience:(NSString *)scopeKey;
 - (void)setBarometerUpdateInterval:(NSTimeInterval)intervalMs;
 
 - (BOOL)isBarometerAvailable;
@@ -48,7 +48,7 @@
 
 @interface ABI42_0_0EXSensorsManagerBinding : NSObject <ABI42_0_0UMInternalModule, ABI42_0_0EXAccelerometerInterface, ABI42_0_0EXBarometerInterface, ABI42_0_0EXDeviceMotionInterface, ABI42_0_0EXGyroscopeInterface, ABI42_0_0EXMagnetometerInterface, ABI42_0_0EXMagnetometerUncalibratedInterface>
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId andKernelService:(id<ABI42_0_0EXSensorsManagerBindingDelegate>)kernelService;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey andKernelService:(id<ABI42_0_0EXSensorsManagerBindingDelegate>)kernelService;
 
 - (void)sensorModuleDidSubscribeForAccelerometerUpdates:(id)scopedSensorModule withHandler:(void (^)(NSDictionary *))handlerBlock;
 - (void)sensorModuleDidSubscribeForDeviceMotionUpdates:(id)scopedSensorModule withHandler:(void (^)(NSDictionary *))handlerBlock;

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/ABI42_0_0EXSensorsManagerBinding.m
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/ABI42_0_0EXSensorsManagerBinding.m
@@ -4,68 +4,68 @@
 
 @interface ABI42_0_0EXSensorsManagerBinding ()
 
-@property (nonatomic, strong) NSString *experienceId;
+@property (nonatomic, strong) NSString *scopeKey;
 @property (nonatomic, weak) id<ABI42_0_0EXSensorsManagerBindingDelegate> kernelService;
 
 @end
 
 @implementation ABI42_0_0EXSensorsManagerBinding
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId andKernelService:(id<ABI42_0_0EXSensorsManagerBindingDelegate>)kernelService
+- (instancetype)initWithScopeKey:(NSString *)scopeKey andKernelService:(id<ABI42_0_0EXSensorsManagerBindingDelegate>)kernelService
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _scopeKey = scopeKey;
     _kernelService = kernelService;
   }
   return self;
 }
 
 - (void)sensorModuleDidSubscribeForAccelerometerUpdates:(id)scopedSensorModule withHandler:(void (^)(NSDictionary *))handlerBlock {
-  [_kernelService sensorModuleDidSubscribeForAccelerometerUpdatesOfExperience:_experienceId withHandler:handlerBlock];
+  [_kernelService sensorModuleDidSubscribeForAccelerometerUpdatesOfExperience:_scopeKey withHandler:handlerBlock];
 }
 
 - (void)sensorModuleDidSubscribeForDeviceMotionUpdates:(id)scopedSensorModule withHandler:(void (^)(NSDictionary *))handlerBlock {
-  [_kernelService sensorModuleDidSubscribeForDeviceMotionUpdatesOfExperience:_experienceId withHandler:handlerBlock];
+  [_kernelService sensorModuleDidSubscribeForDeviceMotionUpdatesOfExperience:_scopeKey withHandler:handlerBlock];
 }
 
 - (void)sensorModuleDidSubscribeForGyroscopeUpdates:(id)scopedSensorModule withHandler:(void (^)(NSDictionary *))handlerBlock {
-  [_kernelService sensorModuleDidSubscribeForGyroscopeUpdatesOfExperience:_experienceId withHandler:handlerBlock];
+  [_kernelService sensorModuleDidSubscribeForGyroscopeUpdatesOfExperience:_scopeKey withHandler:handlerBlock];
 }
 
 - (void)sensorModuleDidSubscribeForMagnetometerUncalibratedUpdates:(id)scopedSensorModule withHandler:(void (^)(NSDictionary *))handlerBlock {
-  [_kernelService sensorModuleDidSubscribeForMagnetometerUncalibratedUpdatesOfExperience:_experienceId withHandler:handlerBlock];
+  [_kernelService sensorModuleDidSubscribeForMagnetometerUncalibratedUpdatesOfExperience:_scopeKey withHandler:handlerBlock];
 }
 
 - (void)sensorModuleDidSubscribeForMagnetometerUpdates:(id)scopedSensorModule withHandler:(void (^)(NSDictionary *))handlerBlock {
-  [_kernelService sensorModuleDidSubscribeForMagnetometerUpdatesOfExperience:_experienceId withHandler:handlerBlock];
+  [_kernelService sensorModuleDidSubscribeForMagnetometerUpdatesOfExperience:_scopeKey withHandler:handlerBlock];
 }
 
 - (void)sensorModuleDidSubscribeForBarometerUpdates:(id)scopedSensorModule withHandler:(void (^)(NSDictionary *))handlerBlock {
-  [_kernelService sensorModuleDidSubscribeForBarometerUpdatesOfExperience:_experienceId withHandler:handlerBlock];
+  [_kernelService sensorModuleDidSubscribeForBarometerUpdatesOfExperience:_scopeKey withHandler:handlerBlock];
 }
 
 - (void)sensorModuleDidUnsubscribeForAccelerometerUpdates:(id)scopedSensorModule {
-  [_kernelService sensorModuleDidUnsubscribeForAccelerometerUpdatesOfExperience:_experienceId];
+  [_kernelService sensorModuleDidUnsubscribeForAccelerometerUpdatesOfExperience:_scopeKey];
 }
 
 - (void)sensorModuleDidUnsubscribeForDeviceMotionUpdates:(id)scopedSensorModule {
-  [_kernelService sensorModuleDidUnsubscribeForDeviceMotionUpdatesOfExperience:_experienceId];
+  [_kernelService sensorModuleDidUnsubscribeForDeviceMotionUpdatesOfExperience:_scopeKey];
 }
 
 - (void)sensorModuleDidUnsubscribeForGyroscopeUpdates:(id)scopedSensorModule {
-  [_kernelService sensorModuleDidUnsubscribeForGyroscopeUpdatesOfExperience:_experienceId];
+  [_kernelService sensorModuleDidUnsubscribeForGyroscopeUpdatesOfExperience:_scopeKey];
 }
 
 - (void)sensorModuleDidUnsubscribeForMagnetometerUncalibratedUpdates:(id)scopedSensorModule {
-  [_kernelService sensorModuleDidUnsubscribeForMagnetometerUncalibratedUpdatesOfExperience:_experienceId];
+  [_kernelService sensorModuleDidUnsubscribeForMagnetometerUncalibratedUpdatesOfExperience:_scopeKey];
 }
 
 - (void)sensorModuleDidUnsubscribeForMagnetometerUpdates:(id)scopedSensorModule {
-  [_kernelService sensorModuleDidUnsubscribeForMagnetometerUpdatesOfExperience:_experienceId];
+  [_kernelService sensorModuleDidUnsubscribeForMagnetometerUpdatesOfExperience:_scopeKey];
 }
 
 - (void)sensorModuleDidUnsubscribeForBarometerUpdates:(id)scopedSensorModule {
-  [_kernelService sensorModuleDidUnsubscribeForBarometerUpdatesOfExperience:_experienceId];
+  [_kernelService sensorModuleDidUnsubscribeForBarometerUpdatesOfExperience:_scopeKey];
 }
 
 - (void)setAccelerometerUpdateInterval:(NSTimeInterval)intervalMs {

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/ABI42_0_0EXUpdatesBinding.h
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/ABI42_0_0EXUpdatesBinding.h
@@ -13,14 +13,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol ABI42_0_0EXUpdatesBindingDelegate
 
-- (ABI42_0_0EXUpdatesConfig *)configForExperienceId:(NSString *)experienceId;
-- (ABI42_0_0EXUpdatesSelectionPolicy *)selectionPolicyForExperienceId:(NSString *)experienceId;
-- (nullable ABI42_0_0EXUpdatesUpdate *)launchedUpdateForExperienceId:(NSString *)experienceId;
-- (nullable NSDictionary *)assetFilesMapForExperienceId:(NSString *)experienceId;
-- (BOOL)isUsingEmbeddedAssetsForExperienceId:(NSString *)experienceId;
-- (BOOL)isStartedForExperienceId:(NSString *)experienceId;
-- (BOOL)isEmergencyLaunchForExperienceId:(NSString *)experienceId;
-- (void)requestRelaunchForExperienceId:(NSString *)experienceId withCompletion:(ABI42_0_0EXUpdatesAppRelaunchCompletionBlock)completion;
+- (ABI42_0_0EXUpdatesConfig *)configForScopeKey:(NSString *)scopeKey;
+- (ABI42_0_0EXUpdatesSelectionPolicy *)selectionPolicyForScopeKey:(NSString *)scopeKey;
+- (nullable ABI42_0_0EXUpdatesUpdate *)launchedUpdateForScopeKey:(NSString *)scopeKey;
+- (nullable NSDictionary *)assetFilesMapForScopeKey:(NSString *)scopeKey;
+- (BOOL)isUsingEmbeddedAssetsForScopeKey:(NSString *)scopeKey;
+- (BOOL)isStartedForScopeKey:(NSString *)scopeKey;
+- (BOOL)isEmergencyLaunchForScopeKey:(NSString *)scopeKey;
+- (void)requestRelaunchForScopeKey:(NSString *)scopeKey withCompletion:(ABI42_0_0EXUpdatesAppRelaunchCompletionBlock)completion;
 
 @end
 
@@ -33,7 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ABI42_0_0EXUpdatesBinding : ABI42_0_0EXUpdatesService <ABI42_0_0UMInternalModule>
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId updatesKernelService:(id<ABI42_0_0EXUpdatesBindingDelegate>)updatesKernelService databaseKernelService:(id<ABI42_0_0EXUpdatesDatabaseBindingDelegate>)databaseKernelService;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey updatesKernelService:(id<ABI42_0_0EXUpdatesBindingDelegate>)updatesKernelService databaseKernelService:(id<ABI42_0_0EXUpdatesDatabaseBindingDelegate>)databaseKernelService;
 
 @end
 

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/ABI42_0_0EXUpdatesBinding.m
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/ABI42_0_0EXUpdatesBinding.m
@@ -8,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ABI42_0_0EXUpdatesBinding ()
 
-@property (nonatomic, strong) NSString *experienceId;
+@property (nonatomic, strong) NSString *scopeKey;
 @property (nonatomic, weak) id<ABI42_0_0EXUpdatesBindingDelegate> updatesKernelService;
 @property (nonatomic, weak) id<ABI42_0_0EXUpdatesDatabaseBindingDelegate> databaseKernelService;
 
@@ -16,10 +16,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation ABI42_0_0EXUpdatesBinding : ABI42_0_0EXUpdatesService
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId updatesKernelService:(id<ABI42_0_0EXUpdatesBindingDelegate>)updatesKernelService databaseKernelService:(id<ABI42_0_0EXUpdatesDatabaseBindingDelegate>)databaseKernelService
+- (instancetype)initWithScopeKey:(NSString *)scopeKey updatesKernelService:(id<ABI42_0_0EXUpdatesBindingDelegate>)updatesKernelService databaseKernelService:(id<ABI42_0_0EXUpdatesDatabaseBindingDelegate>)databaseKernelService
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _scopeKey = scopeKey;
     _updatesKernelService = updatesKernelService;
     _databaseKernelService = databaseKernelService;
   }
@@ -28,7 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (ABI42_0_0EXUpdatesConfig *)config
 {
-  return [_updatesKernelService configForExperienceId:_experienceId];
+  return [_updatesKernelService configForScopeKey:_scopeKey];
 }
 
 - (ABI42_0_0EXUpdatesDatabase *)database
@@ -38,7 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (ABI42_0_0EXUpdatesSelectionPolicy *)selectionPolicy
 {
-  return [_updatesKernelService selectionPolicyForExperienceId:_experienceId];
+  return [_updatesKernelService selectionPolicyForScopeKey:_scopeKey];
 }
 
 - (NSURL *)directory
@@ -48,27 +48,27 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (nullable ABI42_0_0EXUpdatesUpdate *)launchedUpdate
 {
-  return [_updatesKernelService launchedUpdateForExperienceId:_experienceId];
+  return [_updatesKernelService launchedUpdateForScopeKey:_scopeKey];
 }
 
 - (nullable NSDictionary *)assetFilesMap
 {
-  return [_updatesKernelService assetFilesMapForExperienceId:_experienceId];
+  return [_updatesKernelService assetFilesMapForScopeKey:_scopeKey];
 }
 
 - (BOOL)isUsingEmbeddedAssets
 {
-  return [_updatesKernelService isUsingEmbeddedAssetsForExperienceId:_experienceId];
+  return [_updatesKernelService isUsingEmbeddedAssetsForScopeKey:_scopeKey];
 }
 
 - (BOOL)isStarted
 {
-  return [_updatesKernelService isStartedForExperienceId:_experienceId];
+  return [_updatesKernelService isStartedForScopeKey:_scopeKey];
 }
 
 - (BOOL)isEmergencyLaunch
 {
-  return [_updatesKernelService isEmergencyLaunchForExperienceId:_experienceId];
+  return [_updatesKernelService isEmergencyLaunchForScopeKey:_scopeKey];
 }
 
 - (BOOL)canRelaunch
@@ -78,7 +78,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)requestRelaunchWithCompletion:(ABI42_0_0EXUpdatesAppRelaunchCompletionBlock)completion
 {
-  return [_updatesKernelService requestRelaunchForExperienceId:_experienceId withCompletion:completion];
+  return [_updatesKernelService requestRelaunchForScopeKey:_scopeKey withCompletion:completion];
 }
 
 - (void)resetSelectionPolicy

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/EXFacebook/ABI42_0_0EXScopedFacebook.h
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/EXFacebook/ABI42_0_0EXScopedFacebook.h
@@ -7,7 +7,7 @@
 
 @interface ABI42_0_0EXScopedFacebook : ABI42_0_0EXFacebook <ABI42_0_0UMAppLifecycleListener>
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId andParams:(NSDictionary *)params;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey andParams:(NSDictionary *)params;
 
 @end
 #endif

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/EXFacebook/ABI42_0_0EXScopedFacebook.m
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/EXFacebook/ABI42_0_0EXScopedFacebook.m
@@ -44,10 +44,10 @@ static NSString *AUTO_INIT_KEY = @"autoInitEnabled";
 
 @implementation ABI42_0_0EXScopedFacebook : ABI42_0_0EXFacebook
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId andParams:(NSDictionary *)params
+- (instancetype)initWithScopeKey:(NSString *)scopeKey andParams:(NSDictionary *)params
 {
   if (self = [super init]) {
-    NSString *suiteName = [NSString stringWithFormat:@"%@#%@", NSStringFromClass(self.class), experienceId];
+    NSString *suiteName = [NSString stringWithFormat:@"%@#%@", NSStringFromClass(self.class), scopeKey];
     _settings = [[NSUserDefaults alloc] initWithSuiteName:suiteName];
 
     BOOL hasPreviouslySetAutoInitEnabled = [_settings boolForKey:AUTO_INIT_KEY];

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI42_0_0EXScopedNotificationBuilder.h
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI42_0_0EXScopedNotificationBuilder.h
@@ -9,7 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ABI42_0_0EXScopedNotificationBuilder : ABI42_0_0EXNotificationBuilder
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
+- (instancetype)initWithScopeKey:(NSString *)scopeKey
                  andConstantsBinding:(ABI42_0_0EXConstantsBinding *)constantsBinding;
 
 @end

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI42_0_0EXScopedNotificationBuilder.m
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI42_0_0EXScopedNotificationBuilder.m
@@ -5,18 +5,18 @@
 
 @interface ABI42_0_0EXScopedNotificationBuilder ()
 
-@property (nonatomic, strong) NSString *experienceId;
+@property (nonatomic, strong) NSString *scopeKey;
 @property (nonatomic, assign) BOOL isInExpoGo;
 
 @end
 
 @implementation ABI42_0_0EXScopedNotificationBuilder
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
+- (instancetype)initWithScopeKey:(NSString *)scopeKey
                  andConstantsBinding:(ABI42_0_0EXConstantsBinding *)constantsBinding
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _scopeKey = scopeKey;
     _isInExpoGo = [@"expo" isEqualToString:constantsBinding.appOwnership];
   }
   
@@ -30,12 +30,13 @@
   if (!userInfo) {
     userInfo = [NSMutableDictionary dictionary];
   }
-  userInfo[@"experienceId"] = _experienceId;
+  userInfo[@"experienceId"] = _scopeKey;
+  userInfo[@"scopeKey"] = _scopeKey;
   [content setUserInfo:userInfo];
   
   if (content.categoryIdentifier && _isInExpoGo) {
     NSString *scopedCategoryIdentifier = [ABI42_0_0EXScopedNotificationsUtils scopedIdentifierFromId:content.categoryIdentifier
-                                                                              forExperience:_experienceId];
+                                                                              forExperience:_scopeKey];
     [content setCategoryIdentifier:scopedCategoryIdentifier];
   }
   

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI42_0_0EXScopedNotificationCategoriesModule.h
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI42_0_0EXScopedNotificationCategoriesModule.h
@@ -9,11 +9,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ABI42_0_0EXScopedNotificationCategoriesModule : ABI42_0_0EXNotificationCategoriesModule
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
+- (instancetype)initWithScopeKey:(NSString *)scopeKey
                  andConstantsBinding:(ABI42_0_0EXConstantsBinding *)constantsBinding;
 
-+ (void)maybeMigrateLegacyCategoryIdentifiersForProject:(NSString *)experienceId
-                                             isInExpoGo:(BOOL)isInExpoGo;
++ (void)maybeMigrateLegacyCategoryIdentifiersForProjectWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId
+                                                                           scopeKey:(NSString *)scopeKey
+                                                                                   isInExpoGo:(BOOL)isInExpoGo;
 
 @end
 

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI42_0_0EXScopedNotificationCategoriesModule.m
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI42_0_0EXScopedNotificationCategoriesModule.m
@@ -6,17 +6,17 @@
 
 @interface ABI42_0_0EXScopedNotificationCategoriesModule ()
 
-@property (nonatomic, strong) NSString *experienceId;
+@property (nonatomic, strong) NSString *scopeKey;
 
 @end
 
 @implementation ABI42_0_0EXScopedNotificationCategoriesModule
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
+- (instancetype)initWithScopeKey:(NSString *)scopeKey
                  andConstantsBinding:(ABI42_0_0EXConstantsBinding *)constantsBinding
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _scopeKey = scopeKey;
   }
   return self;
 }
@@ -26,7 +26,7 @@
   [[UNUserNotificationCenter currentNotificationCenter] getNotificationCategoriesWithCompletionHandler:^(NSSet<UNNotificationCategory *> *categories) {
     NSMutableArray* existingCategories = [NSMutableArray new];
     for (UNNotificationCategory *category in categories) {
-      if ([ABI42_0_0EXScopedNotificationsUtils isId:category.identifier scopedByExperience:self->_experienceId]) {
+      if ([ABI42_0_0EXScopedNotificationsUtils isId:category.identifier scopedByExperience:self->_scopeKey]) {
         [existingCategories addObject:[self serializeCategory:category]];
       }
     }
@@ -41,7 +41,7 @@
                                        reject:(ABI42_0_0UMPromiseRejectBlock)reject
 {
   NSString *scopedCategoryIdentifier = [ABI42_0_0EXScopedNotificationsUtils scopedIdentifierFromId:categoryId
-                                                                            forExperience:_experienceId];
+                                                                            forExperience:_scopeKey];
   [super setNotificationCategoryWithCategoryId:scopedCategoryIdentifier
                                        actions:actions
                                        options:options
@@ -54,7 +54,7 @@
                                           reject:(ABI42_0_0UMPromiseRejectBlock)reject
 {
   NSString *scopedCategoryIdentifier = [ABI42_0_0EXScopedNotificationsUtils scopedIdentifierFromId:categoryId
-                                                                            forExperience:_experienceId];
+                                                                            forExperience:_scopeKey];
   [super deleteNotificationCategoryWithCategoryId:scopedCategoryIdentifier
                                           resolve:resolve
                                            reject:reject];
@@ -70,14 +70,16 @@
 
 #pragma mark - static method for migrating categories in both Expo Go and standalones. Added in SDK 41. TODO(Cruzan): Remove in SDK 47
 
-+ (void)maybeMigrateLegacyCategoryIdentifiersForProject:(NSString *)experienceId isInExpoGo:(BOOL)isInExpoGo
++ (void)maybeMigrateLegacyCategoryIdentifiersForProjectWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId
+                                                                           scopeKey:(NSString *)scopeKey
+                                                                                   isInExpoGo:(BOOL)isInExpoGo
 {
   if (isInExpoGo) {
     // Changed scoping prefix in SDK 41 FROM "experienceId-" to ESCAPED "experienceId/"
-    [ABI42_0_0EXScopedNotificationCategoryMigrator migrateLegacyScopedCategoryIdentifiersForProject:experienceId];
+    [ABI42_0_0EXScopedNotificationCategoryMigrator migrateLegacyScopedCategoryIdentifiersForProjectWithScopeKey:scopeKey];
   } else {
     // Used to prefix with "experienceId-" even in standalone apps in SDKs <= 40, so we need to unscope those
-    [ABI42_0_0EXScopedNotificationCategoryMigrator unscopeLegacyCategoryIdentifiersForProject:experienceId];
+    [ABI42_0_0EXScopedNotificationCategoryMigrator unscopeLegacyCategoryIdentifiersForProjectWithScopeKey:scopeKey];
   }
 }
 

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI42_0_0EXScopedNotificationCategoryMigrator.h
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI42_0_0EXScopedNotificationCategoryMigrator.h
@@ -5,7 +5,7 @@
 
 @interface ABI42_0_0EXScopedNotificationCategoryMigrator : NSObject <ABI42_0_0EXNotificationsDelegate>
 
-+ (void)unscopeLegacyCategoryIdentifiersForProject:(NSString *)experienceId;
-+ (void)migrateLegacyScopedCategoryIdentifiersForProject:(NSString *)experienceId;
++ (void)unscopeLegacyCategoryIdentifiersForProjectWithScopeKey:(NSString *)scopeKey;
++ (void)migrateLegacyScopedCategoryIdentifiersForProjectWithScopeKey:(NSString *)scopeKey;
 
 @end

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI42_0_0EXScopedNotificationCategoryMigrator.m
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI42_0_0EXScopedNotificationCategoryMigrator.m
@@ -5,33 +5,33 @@
 
 @implementation ABI42_0_0EXScopedNotificationCategoryMigrator
 
-+ (void)migrateLegacyScopedCategoryIdentifiersForProject:(NSString *)experienceId
++ (void)migrateLegacyScopedCategoryIdentifiersForProjectWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId scopeKey:(NSString *)scopeKey
 {
-  [ABI42_0_0EXScopedNotificationCategoryMigrator renameLegacyCategoryIdentifiersForExperience:experienceId withBlock:^(UNNotificationCategory *oldCategory) {
-    NSString *unscopedLegacyCategoryId = [ABI42_0_0EXScopedNotificationsUtils unscopedLegacyCategoryIdentifierWithId:oldCategory.identifier forExperience:experienceId];
+  [ABI42_0_0EXScopedNotificationCategoryMigrator renameLegacyCategoryIdentifiersForExperienceWithScopeKey:scopeKey withBlock:^(UNNotificationCategory *oldCategory) {
+    NSString *unscopedLegacyCategoryId = [ABI42_0_0EXScopedNotificationsUtils unscopedLegacyCategoryIdentifierWithId:oldCategory.identifier forScopeKey:scopeKey];
     NSString *newCategoryId = [ABI42_0_0EXScopedNotificationsUtils scopedIdentifierFromId:unscopedLegacyCategoryId
-                                                                   forExperience:experienceId];
+                                                                   forExperience:scopeKey];
     UNNotificationCategory *newCategory = [ABI42_0_0EXScopedNotificationCategoryMigrator createNewCategoryFrom:oldCategory withNewIdentifier:newCategoryId];
     return newCategory;
   }];
 }
 
-+ (void)unscopeLegacyCategoryIdentifiersForProject:(NSString *)experienceId
++ (void)unscopeLegacyCategoryIdentifiersForProjectWithScopeKey:(NSString *)scopeKey
 {
-  [ABI42_0_0EXScopedNotificationCategoryMigrator renameLegacyCategoryIdentifiersForExperience:experienceId withBlock:^(UNNotificationCategory *oldCategory) {
-    NSString *unscopedCategoryId = [ABI42_0_0EXScopedNotificationsUtils unscopedLegacyCategoryIdentifierWithId:oldCategory.identifier forExperience:experienceId];
+  [ABI42_0_0EXScopedNotificationCategoryMigrator renameLegacyCategoryIdentifiersForExperienceWithScopeKey:scopeKey withBlock:^(UNNotificationCategory *oldCategory) {
+    NSString *unscopedCategoryId = [ABI42_0_0EXScopedNotificationsUtils unscopedLegacyCategoryIdentifierWithId:oldCategory.identifier forScopeKey:scopeKey];
     UNNotificationCategory *newCategory = [ABI42_0_0EXScopedNotificationCategoryMigrator createNewCategoryFrom:oldCategory withNewIdentifier:unscopedCategoryId];
     return newCategory;
   }];
 }
 
-+ (void)renameLegacyCategoryIdentifiersForExperience:(NSString *)experienceId withBlock:(UNNotificationCategory *(^)(UNNotificationCategory *category))renameCategoryBlock
++ (void)renameLegacyCategoryIdentifiersForExperienceWithScopeKey:(NSString *)scopeKey withBlock:(UNNotificationCategory *(^)(UNNotificationCategory *category))renameCategoryBlock
 {
   [[UNUserNotificationCenter currentNotificationCenter] getNotificationCategoriesWithCompletionHandler:^(NSSet<UNNotificationCategory *> *categories) {
     NSMutableSet<UNNotificationCategory *> *newCategories = [categories mutableCopy];
     BOOL didChangeCategories = NO;
     for (UNNotificationCategory *previousCategory in categories) {
-      if ([ABI42_0_0EXScopedNotificationsUtils isLegacyCategoryId:previousCategory.identifier scopedByExperience:experienceId]) {
+      if ([ABI42_0_0EXScopedNotificationsUtils isLegacyCategoryId:previousCategory.identifier scopedByScopeKey:scopeKey]) {
         UNNotificationCategory *newCategory = renameCategoryBlock(previousCategory);
         [newCategories removeObject:previousCategory];
         [newCategories addObject:newCategory];

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI42_0_0EXScopedNotificationPresentationModule.h
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI42_0_0EXScopedNotificationPresentationModule.h
@@ -8,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ABI42_0_0EXScopedNotificationPresentationModule : ABI42_0_0EXNotificationPresentationModule
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey;
 
 @end
 

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI42_0_0EXScopedNotificationPresentationModule.m
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI42_0_0EXScopedNotificationPresentationModule.m
@@ -7,16 +7,16 @@
 
 @interface ABI42_0_0EXScopedNotificationPresentationModule ()
 
-@property (nonatomic, strong) NSString *experienceId;
+@property (nonatomic, strong) NSString *scopeKey;
 
 @end
 
 @implementation ABI42_0_0EXScopedNotificationPresentationModule
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
+- (instancetype)initWithScopeKey:(NSString *)scopeKey
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _scopeKey = scopeKey;
   }
   
   return self;
@@ -26,7 +26,7 @@
 {
   NSMutableArray *serializedNotifications = [NSMutableArray new];
   for (UNNotification *notification in notifications) {
-    if ([ABI42_0_0EXScopedNotificationsUtils shouldNotification:notification beHandledByExperience:_experienceId]) {
+    if ([ABI42_0_0EXScopedNotificationsUtils shouldNotification:notification beHandledByExperience:_scopeKey]) {
       [serializedNotifications addObject:[ABI42_0_0EXScopedNotificationSerializer serializedNotification:notification]];
     }
   }
@@ -35,10 +35,10 @@
 
 - (void)dismissNotificationWithIdentifier:(NSString *)identifier resolve:(ABI42_0_0UMPromiseResolveBlock)resolve reject:(ABI42_0_0UMPromiseRejectBlock)reject
 {
-  __block NSString *experienceId = _experienceId;
+  __block NSString *scopeKey = _scopeKey;
   [[UNUserNotificationCenter currentNotificationCenter] getDeliveredNotificationsWithCompletionHandler:^(NSArray<UNNotification *> * _Nonnull notifications) {
     for (UNNotification *notification in notifications) {
-      if ([ABI42_0_0EXScopedNotificationsUtils shouldNotification:notification beHandledByExperience:experienceId]) {
+      if ([ABI42_0_0EXScopedNotificationsUtils shouldNotification:notification beHandledByExperience:scopeKey]) {
         // Usually we would scope the input ID and then check equality, but remote notifications do not
         // have the scoping prefix, so instead let's remove the scope if there is one, then check for
         // equality against the input
@@ -55,11 +55,11 @@
 
 - (void)dismissAllNotificationsWithResolver:(ABI42_0_0UMPromiseResolveBlock)resolve reject:(ABI42_0_0UMPromiseRejectBlock)reject
 {
-  __block NSString *experienceId = _experienceId;
+  __block NSString *scopeKey = _scopeKey;
   [[UNUserNotificationCenter currentNotificationCenter] getDeliveredNotificationsWithCompletionHandler:^(NSArray<UNNotification *> * _Nonnull notifications) {
     NSMutableArray<NSString *> *toDismiss = [NSMutableArray new];
     for (UNNotification *notification in notifications) {
-      if ([ABI42_0_0EXScopedNotificationsUtils shouldNotification:notification beHandledByExperience:experienceId]) {
+      if ([ABI42_0_0EXScopedNotificationsUtils shouldNotification:notification beHandledByExperience:scopeKey]) {
         [toDismiss addObject:notification.request.identifier];
       }
     }

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI42_0_0EXScopedNotificationSchedulerModule.h
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI42_0_0EXScopedNotificationSchedulerModule.h
@@ -8,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ABI42_0_0EXScopedNotificationSchedulerModule : ABI42_0_0EXNotificationSchedulerModule
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey;
 
 @end
 

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI42_0_0EXScopedNotificationSchedulerModule.m
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI42_0_0EXScopedNotificationSchedulerModule.m
@@ -7,16 +7,16 @@
 
 @interface ABI42_0_0EXScopedNotificationSchedulerModule ()
 
-@property (nonatomic, strong) NSString *experienceId;
+@property (nonatomic, strong) NSString *scopeKey;
 
 @end
 
 @implementation ABI42_0_0EXScopedNotificationSchedulerModule
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
+- (instancetype)initWithScopeKey:(NSString *)scopeKey
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _scopeKey = scopeKey;
   }
 
   return self;
@@ -27,7 +27,7 @@
                                                           trigger:(NSDictionary *)triggerInput
 {
   NSString *scopedIdentifier = [ABI42_0_0EXScopedNotificationsUtils scopedIdentifierFromId:identifier
-                                                                    forExperience:_experienceId];
+                                                                    forExperience:_scopeKey];
   return [super buildNotificationRequestWithIdentifier:scopedIdentifier content:contentInput trigger:triggerInput];
 }
 
@@ -35,7 +35,7 @@
 {
   NSMutableArray *serializedRequests = [NSMutableArray new];
   for (UNNotificationRequest *request in requests) {
-    if ([ABI42_0_0EXScopedNotificationsUtils isId:request.identifier scopedByExperience:_experienceId]) {
+    if ([ABI42_0_0EXScopedNotificationsUtils isId:request.identifier scopedByExperience:_scopeKey]) {
       [serializedRequests addObject:[ABI42_0_0EXScopedNotificationSerializer serializedNotificationRequest:request]];
     }
   }
@@ -46,17 +46,17 @@
 - (void)cancelNotification:(NSString *)identifier resolve:(ABI42_0_0UMPromiseResolveBlock)resolve rejecting:(ABI42_0_0UMPromiseRejectBlock)reject
 {
   NSString *scopedIdentifier = [ABI42_0_0EXScopedNotificationsUtils scopedIdentifierFromId:identifier
-                                                                    forExperience:_experienceId];
+                                                                    forExperience:_scopeKey];
   [super cancelNotification:scopedIdentifier resolve:resolve rejecting:reject];
 }
 
 - (void)cancelAllNotificationsWithResolver:(ABI42_0_0UMPromiseResolveBlock)resolve rejecting:(ABI42_0_0UMPromiseRejectBlock)reject
 {
-  __block NSString *experienceId = _experienceId;
+  __block NSString *scopeKey = _scopeKey;
   [[UNUserNotificationCenter currentNotificationCenter] getPendingNotificationRequestsWithCompletionHandler:^(NSArray<UNNotificationRequest *> * _Nonnull requests) {
     NSMutableArray<NSString *> *toRemove = [NSMutableArray new];
     for (UNNotificationRequest *request in requests) {
-      if ([ABI42_0_0EXScopedNotificationsUtils isId:request.identifier scopedByExperience:experienceId]) {
+      if ([ABI42_0_0EXScopedNotificationsUtils isId:request.identifier scopedByExperience:scopeKey]) {
         [toRemove addObject:request.identifier];
       }
     }

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI42_0_0EXScopedNotificationsEmitter.h
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI42_0_0EXScopedNotificationsEmitter.h
@@ -8,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ABI42_0_0EXScopedNotificationsEmitter : ABI42_0_0EXNotificationsEmitter
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey;
 
 @end
 

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI42_0_0EXScopedNotificationsEmitter.m
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI42_0_0EXScopedNotificationsEmitter.m
@@ -8,7 +8,7 @@
 
 @interface ABI42_0_0EXScopedNotificationsEmitter ()
 
-@property (nonatomic, strong) NSString *experienceId;
+@property (nonatomic, strong) NSString *scopeKey;
 
 @end
 
@@ -21,10 +21,10 @@
 
 @implementation ABI42_0_0EXScopedNotificationsEmitter
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
+- (instancetype)initWithScopeKey:(NSString *)scopeKey
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _scopeKey = scopeKey;
   }
   
   return self;
@@ -32,7 +32,7 @@
 
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center didReceiveNotificationResponse:(UNNotificationResponse *)response withCompletionHandler:(void (^)(void))completionHandler
 {
-  if ([ABI42_0_0EXScopedNotificationsUtils shouldNotification:response.notification beHandledByExperience:_experienceId]) {
+  if ([ABI42_0_0EXScopedNotificationsUtils shouldNotification:response.notification beHandledByExperience:_scopeKey]) {
     [super userNotificationCenter:center didReceiveNotificationResponse:response withCompletionHandler:completionHandler];
   } else {
     completionHandler();
@@ -41,7 +41,7 @@
 
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center willPresentNotification:(UNNotification *)notification withCompletionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler
 {
-  if ([ABI42_0_0EXScopedNotificationsUtils shouldNotification:notification beHandledByExperience:_experienceId]) {
+  if ([ABI42_0_0EXScopedNotificationsUtils shouldNotification:notification beHandledByExperience:_scopeKey]) {
     [super userNotificationCenter:center willPresentNotification:notification withCompletionHandler:completionHandler];
   } else {
     completionHandler(UNNotificationPresentationOptionNone);

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI42_0_0EXScopedNotificationsHandlerModule.h
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI42_0_0EXScopedNotificationsHandlerModule.h
@@ -8,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ABI42_0_0EXScopedNotificationsHandlerModule : ABI42_0_0EXNotificationsHandlerModule
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey;
 
 @end
 

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI42_0_0EXScopedNotificationsHandlerModule.m
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI42_0_0EXScopedNotificationsHandlerModule.m
@@ -5,16 +5,16 @@
 
 @interface ABI42_0_0EXScopedNotificationsHandlerModule ()
 
-@property (nonatomic, strong) NSString *experienceId;
+@property (nonatomic, strong) NSString *scopeKey;
 
 @end
 
 @implementation ABI42_0_0EXScopedNotificationsHandlerModule
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
+- (instancetype)initWithScopeKey:(NSString *)scopeKey
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _scopeKey = scopeKey;
   }
   
   return self;
@@ -22,7 +22,7 @@
 
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center willPresentNotification:(UNNotification *)notification withCompletionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler
 {
-  if ([ABI42_0_0EXScopedNotificationsUtils shouldNotification:notification beHandledByExperience:_experienceId]) {
+  if ([ABI42_0_0EXScopedNotificationsUtils shouldNotification:notification beHandledByExperience:_scopeKey]) {
     [super userNotificationCenter:center willPresentNotification:notification withCompletionHandler:completionHandler];
   }
 }

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI42_0_0EXScopedNotificationsUtils.h
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI42_0_0EXScopedNotificationsUtils.h
@@ -11,19 +11,20 @@ typedef struct {
 
 @interface ABI42_0_0EXScopedNotificationsUtils : NSObject
 
-+ (BOOL)shouldNotificationRequest:(UNNotificationRequest *)request beHandledByExperience:(NSString *)experienceId;
++ (BOOL)shouldNotificationRequest:(UNNotificationRequest *)request beHandledByExperience:(NSString *)scopeKey;
 
-+ (BOOL)shouldNotification:(UNNotification *)notification beHandledByExperience:(NSString *)experienceId;
++ (BOOL)shouldNotification:(UNNotification *)notification beHandledByExperience:(NSString *)scopeKey;
 
-+ (NSString *)scopedIdentifierFromId:(NSString *)unscopedId forExperience:(NSString *)experienceId;
++ (NSString *)scopedIdentifierFromId:(NSString *)unscopedId forExperience:(NSString *)scopeKey;
 
-+ (BOOL)isId:(NSString *)identifier scopedByExperience:(NSString *)experienceId;
++ (BOOL)isId:(NSString *)identifier scopedByExperience:(NSString *)scopeKey;
 
 + (ScopedIdentifierComponents)getScopeAndIdentifierFromScopedIdentifier:(NSString *)scopedIdentifier;
 
-+ (BOOL)isLegacyCategoryId:(NSString *) scopedCategoryId scopedByExperience:(NSString *) experienceId;
++ (BOOL)isLegacyCategoryId:(NSString *) scopedCategoryId scopedByScopeKey:(NSString *)scopeKey;
 
-+ (NSString *)unscopedLegacyCategoryIdentifierWithId:(NSString *) scopedCategoryId forExperience:(NSString *) experienceId;
++ (NSString *)unscopedLegacyCategoryIdentifierWithId:(NSString *)scopedCategoryId
+                                         forScopeKey:(NSString *)scopeKey;
 
 @end
 

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI42_0_0EXScopedNotificationsUtils.m
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI42_0_0EXScopedNotificationsUtils.m
@@ -4,31 +4,31 @@
 
 @implementation ABI42_0_0EXScopedNotificationsUtils
 
-+ (BOOL)shouldNotificationRequest:(UNNotificationRequest *)request beHandledByExperience:(NSString *)experienceId
++ (BOOL)shouldNotificationRequest:(UNNotificationRequest *)request beHandledByExperience:(NSString *)scopeKey
 {
-  NSString *notificationExperienceId = request.content.userInfo[@"experienceId"];
-  if (!notificationExperienceId) {
+  NSString *notificationScopeKey = request.content.userInfo[@"experienceId"];
+  if (!notificationScopeKey) {
     return true;
   }
-  return [notificationExperienceId isEqual:experienceId];
+  return [notificationScopeKey isEqual:scopeKey];
 }
 
-+ (BOOL)shouldNotification:(UNNotification *)notification beHandledByExperience:(NSString *)experienceId
++ (BOOL)shouldNotification:(UNNotification *)notification beHandledByExperience:(NSString *)scopeKey
 {
-  return [ABI42_0_0EXScopedNotificationsUtils shouldNotificationRequest:notification.request beHandledByExperience:experienceId];
+  return [ABI42_0_0EXScopedNotificationsUtils shouldNotificationRequest:notification.request beHandledByExperience:scopeKey];
 }
 
-+ (NSString *)scopedIdentifierFromId:(NSString *)unscopedId forExperience:(NSString *)experienceId
++ (NSString *)scopedIdentifierFromId:(NSString *)unscopedId forExperience:(NSString *)scopeKey
 {
-  NSString *scope = [ABI42_0_0EXScopedNotificationsUtils escapedString:experienceId];
+  NSString *scope = [ABI42_0_0EXScopedNotificationsUtils escapedString:scopeKey];
   NSString *escapedCategoryId = [ABI42_0_0EXScopedNotificationsUtils escapedString:unscopedId];
   return [NSString stringWithFormat:@"%@/%@", scope, escapedCategoryId];
 }
 
-+ (BOOL)isId:(NSString *)identifier scopedByExperience:(NSString *)experienceId
++ (BOOL)isId:(NSString *)identifier scopedByExperience:(NSString *)scopeKey
 {
   NSString *scopeFromCategoryId = [ABI42_0_0EXScopedNotificationsUtils getScopeAndIdentifierFromScopedIdentifier:identifier].scopeKey;
-  return [scopeFromCategoryId isEqualToString:experienceId];
+  return [scopeFromCategoryId isEqualToString:scopeKey];
 }
 
 + (ScopedIdentifierComponents)getScopeAndIdentifierFromScopedIdentifier:(NSString *)scopedIdentifier
@@ -73,17 +73,17 @@
 
 # pragma mark Legacy notification category scoping
 
-+ (BOOL)isLegacyCategoryId:(NSString *) scopedCategoryId scopedByExperience:(NSString *) experienceId
++ (BOOL)isLegacyCategoryId:(NSString *)scopedCategoryId scopedByScopeKey:(NSString *)scopeKey
 {
-  NSString* legacyScopingPrefix = [NSString stringWithFormat:@"%@-", experienceId];
+  NSString* legacyScopingPrefix = [NSString stringWithFormat:@"%@-", scopeKey];
   return [scopedCategoryId hasPrefix:legacyScopingPrefix];
 }
 
 // legacy categories were stored under an unescaped experienceId
-+ (NSString *)unscopedLegacyCategoryIdentifierWithId:(NSString *) scopedCategoryId
-                                       forExperience:(NSString *) experienceId
-{
-  NSString* legacyScopingPrefix = [NSString stringWithFormat:@"%@-", experienceId];
++ (NSString *)unscopedLegacyCategoryIdentifierWithId:(NSString *)scopedCategoryId
+                                         forScopeKey:(NSString *)scopeKey
+                {
+                  NSString* legacyScopingPrefix = [NSString stringWithFormat:@"%@-", scopeKey];
   return [scopedCategoryId stringByReplacingOccurrencesOfString:legacyScopingPrefix
                                                      withString:@""
                                                         options:NSAnchoredSearch

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI42_0_0EXScopedServerRegistrationModule.h
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI42_0_0EXScopedServerRegistrationModule.h
@@ -8,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ABI42_0_0EXScopedServerRegistrationModule : ABI42_0_0EXServerRegistrationModule
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey;
 
 @end
 

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI42_0_0EXScopedServerRegistrationModule.m
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI42_0_0EXScopedServerRegistrationModule.m
@@ -16,23 +16,23 @@ static NSString * const kEXRegistrationInfoKey = @"EXNotificationRegistrationInf
 
 @interface ABI42_0_0EXScopedServerRegistrationModule ()
 
-@property (nonatomic, strong) NSString *experienceId;
+@property (nonatomic, strong) NSString *scopeKey;
 
 @end
 
 @implementation ABI42_0_0EXScopedServerRegistrationModule
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId
+- (instancetype)initWithScopeKey:(NSString *)scopeKey
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _scopeKey = scopeKey;
   }
   return self;
 }
 
 - (NSDictionary *)registrationSearchQueryMerging:(NSDictionary *)dictionaryToMerge
 {
-  NSString *scopedKey = [kEXRegistrationInfoKey stringByAppendingFormat:@"-%@", _experienceId];
+  NSString *scopedKey = [kEXRegistrationInfoKey stringByAppendingFormat:@"-%@", _scopeKey];
   return [self keychainSearchQueryFor:scopedKey merging:dictionaryToMerge];
 }
 

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/Permissions/ABI42_0_0EXScopedPermissions.h
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/Permissions/ABI42_0_0EXScopedPermissions.h
@@ -9,14 +9,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol ABI42_0_0EXPermissionsScopedModuleDelegate
 
-- (ABI42_0_0EXPermissionStatus)getPermission:(NSString *)permissionType forExperience:(NSString *)experienceId;
-- (BOOL)savePermission:(NSDictionary *)permission ofType:(NSString *)type forExperience:(NSString *)experienceId;
+- (ABI42_0_0EXPermissionStatus)getPermission:(NSString *)permissionType forExperience:(NSString *)scopeKey;
+- (BOOL)savePermission:(NSDictionary *)permission ofType:(NSString *)type forExperience:(NSString *)scopeKey;
 
 @end
 
 @interface ABI42_0_0EXScopedPermissions : ABI42_0_0EXPermissionsService
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId andConstantsBinding:(ABI42_0_0EXConstantsBinding *)constantsBinding;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey andConstantsBinding:(ABI42_0_0EXConstantsBinding *)constantsBinding;
 
 @end
 

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/Permissions/ABI42_0_0EXScopedPermissions.m
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/Permissions/ABI42_0_0EXScopedPermissions.m
@@ -7,7 +7,7 @@
 
 @interface ABI42_0_0EXScopedPermissions ()
 
-@property (nonatomic, strong) NSString *experienceId;
+@property (nonatomic, strong) NSString *scopeKey;
 @property (nonatomic, weak) id<ABI42_0_0EXPermissionsScopedModuleDelegate> permissionsService;
 @property (nonatomic, weak) id<ABI42_0_0UMUtilitiesInterface> utils;
 @property (nonatomic, weak) ABI42_0_0EXConstantsBinding *constantsBinding;
@@ -16,10 +16,10 @@
 
 @implementation ABI42_0_0EXScopedPermissions
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId andConstantsBinding:(ABI42_0_0EXConstantsBinding *)constantsBinding
+- (instancetype)initWithScopeKey:(NSString *)scopeKey andConstantsBinding:(ABI42_0_0EXConstantsBinding *)constantsBinding
 {
   if (self = [super init]) {
-    _experienceId = experienceId;
+    _scopeKey = scopeKey;
     _constantsBinding = constantsBinding;
   }
   return self;
@@ -46,7 +46,7 @@
     return [[self class] permissionStringForStatus:ABI42_0_0EXPermissionStatusGranted];
   }
   
-  return [[self class] permissionStringForStatus:[_permissionsService getPermission:permissionType forExperience:_experienceId]];
+  return [[self class] permissionStringForStatus:[_permissionsService getPermission:permissionType forExperience:_scopeKey]];
 }
 
 - (BOOL)hasGrantedScopedPermission:(NSString *)permissionType
@@ -55,7 +55,7 @@
     return YES;
   }
   
-  return [_permissionsService getPermission:permissionType forExperience:_experienceId] == ABI42_0_0EXPermissionStatusGranted;
+  return [_permissionsService getPermission:permissionType forExperience:_scopeKey] == ABI42_0_0EXPermissionStatusGranted;
 }
 
 - (void)askForPermissionUsingRequesterClass:(Class)requesterClass
@@ -72,7 +72,7 @@
       ABI42_0_0UM_ENSURE_STRONGIFY(self)
       // if permission should be scoped save it
       if ([self shouldVerifyScopedPermission:permissionType]) {
-        [self.permissionsService savePermission:permission ofType:permissionType forExperience:self.experienceId];
+        [self.permissionsService savePermission:permission ofType:permissionType forExperience:self.scopeKey];
       }
       resolve(permission);
     };
@@ -86,7 +86,7 @@
       ABI42_0_0UM_ENSURE_STRONGIFY(self);
       NSMutableDictionary *permission = [globalPermissions mutableCopy];
       // try to save scoped permissions - if fails than permission is denied
-      if (![self.permissionsService savePermission:permission ofType:permissionType forExperience:self.experienceId]) {
+      if (![self.permissionsService savePermission:permission ofType:permissionType forExperience:self.scopeKey]) {
         permission[@"status"] = [[self class] permissionStringForStatus:ABI42_0_0EXPermissionStatusDenied];
         permission[@"granted"] = @(NO);
       }
@@ -129,7 +129,7 @@
                    withAllowAction:(UIAlertAction *)allow
                     withDenyAction:(UIAlertAction *)deny
 {
-  NSString *experienceName = self.experienceId; // TODO: we might want to use name from the manifest?
+  NSString *experienceName = self.scopeKey; // TODO: we might want to use name from the manifest?
   NSString *messageTemplate = @"%1$@ needs permissions for %2$@. You\'ve already granted permission to another Expo experience. Allow %1$@ to also use it?";
   NSString *permissionString = [[self class] textForPermissionType:permissionType];
 


### PR DESCRIPTION
# Why

https://github.com/expo/expo/pull/13280 didn't version 42 since it was created before 42 versioned code existed. Rather than add another round of review to that PR, a separate PR is used to version 42's code to simplify review.

# How

Apply all changes to 42 versioned code manually. This is done by going through the 41 versioned files modified in #13280 and manually copying the changes to the 42 equivalents.

# Test Plan

Build the app.