### PR TITLE
[docs][clients] shorten and fix getting started example

### DIFF
--- a/docs/pages/clients/getting-started.md
+++ b/docs/pages/clients/getting-started.md
@@ -124,11 +124,13 @@ then register the plugin in your app.json.  Using this module will require new p
 ```js
 "expo": {
   "plugins": [
-    "@react-native-voice/voice",
-    {
-      "microphonePermission": "Allow $(PRODUCT_NAME) to access your microphone",
-      "speechRecogntionPermission": "Allow $(PRODUCT_NAME) to securely recognize user speech"
-    }
+    [
+      "@react-native-voice/voice",
+      {
+        "microphonePermission": "Allow $(PRODUCT_NAME) to access your microphone",
+        "speechRecogntionPermission": "Allow $(PRODUCT_NAME) to securely recognize user speech"
+      }
+    ]
   ]
 }
 ```
@@ -141,195 +143,69 @@ Add the following code to your App.tsx, run `expo start --dev-client`, and load 
 
 <!-- prettier-ignore -->
 ```js
-
-import React, { Component } from 'react';
-import {
-  StyleSheet,
-  Text,
-  View,
-  Image,
-  TouchableHighlight,
-} from 'react-native';
-
+import React, { useState, useEffect } from "react";
+import { Button, StyleSheet, Text, View } from "react-native";
 import Voice, {
-  SpeechRecognizedEvent,
   SpeechResultsEvent,
   SpeechErrorEvent,
-} from '@react-native-voice/voice';
+} from "@react-native-voice/voice";
 
-type Props = {};
-type State = {
-  recognized: string;
-  pitch: string;
-  error: string;
-  end: string;
-  started: string;
-  results: string[];
-  partialResults: string[];
-};
+export default function App() {
+  const [results, setResults] = useState([] as string[]);
+  const [isListening, setIsListening] = useState(false);
 
-class VoiceTest extends Component<Props, State> {
-  state = {
-    recognized: '',
-    pitch: '',
-    error: '',
-    end: '',
-    started: '',
-    results: [],
-    partialResults: [],
-  };
+  useEffect(() => {
+    function onSpeechResults(e: SpeechResultsEvent) {
+      setResults(e.value ?? []);
+    }
+    function onSpeechError(e: SpeechErrorEvent) {
+      console.error(e);
+    }
+    Voice.onSpeechError = onSpeechError;
+    Voice.onSpeechResults = onSpeechResults;
+    return function cleanup() {
+      Voice.destroy().then(Voice.removeAllListeners);
+    };
+  }, []);
 
-  constructor(props: Props) {
-    super(props);
-    Voice.onSpeechStart = this.onSpeechStart;
-    Voice.onSpeechRecognized = this.onSpeechRecognized;
-    Voice.onSpeechEnd = this.onSpeechEnd;
-    Voice.onSpeechError = this.onSpeechError;
-    Voice.onSpeechResults = this.onSpeechResults;
-    Voice.onSpeechPartialResults = this.onSpeechPartialResults;
-  }
-
-  componentWillUnmount() {
-    Voice.destroy().then(Voice.removeAllListeners);
-  }
-
-  onSpeechStart = (e: any) => {
-    console.log('onSpeechStart: ', e);
-    this.setState({
-      started: '√',
-    });
-  };
-
-  onSpeechRecognized = (e: SpeechRecognizedEvent) => {
-    console.log('onSpeechRecognized: ', e);
-    this.setState({
-      recognized: '√',
-    });
-  };
-
-  onSpeechEnd = (e: any) => {
-    console.log('onSpeechEnd: ', e);
-    this.setState({
-      end: '√',
-    });
-  };
-
-  onSpeechError = (e: SpeechErrorEvent) => {
-    console.log('onSpeechError: ', e);
-    this.setState({
-      error: JSON.stringify(e.error),
-    });
-  };
-
-  onSpeechResults = (e: SpeechResultsEvent) => {
-    console.log('onSpeechResults: ', e);
-    this.setState({
-      results: e.value,
-    });
-  };
-
-  onSpeechPartialResults = (e: SpeechResultsEvent) => {
-    console.log('onSpeechPartialResults: ', e);
-    this.setState({
-      partialResults: e.value,
-    });
-  };
-
-  _startRecognizing = async () => {
-    this.setState({
-      recognized: '',
-      pitch: '',
-      error: '',
-      started: '',
-      results: [],
-      partialResults: [],
-      end: '',
-    });
-
+  async function toggleListening() {
     try {
-      await Voice.start('en-US');
+      if (isListening) {
+        await Voice.stop();
+        setIsListening(false);
+      } else {
+        setResults([]);
+        await Voice.start("en-US");
+        setIsListening(true);
+      }
     } catch (e) {
       console.error(e);
     }
-  };
-
-  _stopRecognizing = async () => {
-    try {
-      await Voice.stop();
-    } catch (e) {
-      console.error(e);
-    }
-  };
-
-  render() {
-    return (
-      <View style={styles.container}>
-        <Text style={styles.instructions}>
-          Press the button and start speaking.
-        </Text>
-        <Text style={styles.stat}>{`Started: ${this.state.started}`}</Text>
-        <Text style={styles.stat}>{`Recognized: ${
-          this.state.recognized
-        }`}</Text>
-        <Text style={styles.stat}>{`Error: ${this.state.error}`}</Text>
-        <Text style={styles.stat}>Results</Text>
-        {this.state.results.map((result, index) => {
-          return (
-            <Text key={`result-${index}`} style={styles.stat}>
-              {result}
-            </Text>
-          );
-        })}
-        <Text style={styles.stat}>Partial Results</Text>
-        {this.state.partialResults.map((result, index) => {
-          return (
-            <Text key={`partial-result-${index}`} style={styles.stat}>
-              {result}
-            </Text>
-          );
-        })}
-        <Text style={styles.stat}>{`End: ${this.state.end}`}</Text>
-        <TouchableHighlight onPress={this._startRecognizing}>
-          <Text style={styles.action}>Start Recognizing</Text>
-        </TouchableHighlight>
-        <TouchableHighlight onPress={this._stopRecognizing}>
-          <Text style={styles.action}>Stop Recognizing</Text>
-        </TouchableHighlight>
-      </View>
-    );
   }
+
+  return (
+    <View style={styles.container}>
+      <Text>Press the button and start speaking.</Text>
+      <Button
+        title={isListening ? "Stop Recognizing" : "Start Recognizing"}
+        onPress={toggleListening}
+      />
+      <Text>Results:</Text>
+      {results.map((result, index) => {
+        return <Text key={`result-${index}`}>{result}</Text>;
+      })}
+    </View>
+  );
 }
 
 const styles = StyleSheet.create({
-  button: {
-    width: 50,
-    height: 50,
-  },
   container: {
     flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    backgroundColor: '#F5FCFF',
-  },
- action: {
-    textAlign: 'center',
-    color: '#0000FF',
-    marginVertical: 5,
-    fontWeight: 'bold',
-  },
-  instructions: {
-    textAlign: 'center',
-    color: '#333333',
-    marginBottom: 5,
-  },
-  stat: {
-    textAlign: 'center',
-    color: '#B0171F',
-    marginBottom: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    backgroundColor: "#F5FCFF",
   },
 });
-
-export default VoiceTest;
 ```
 
 ## Debugging your application


### PR DESCRIPTION
# Why

fixes ENG-1423

# How

- Fix the app.json plugin snippet so it actually works (as written, it gives an error about the plugin being an object)
- Strip the example down to more bare bones, and use hooks instead of lifecycle methods; went from 189 to 64 lines

# Test Plan

Followed the guide and ran the app in a local repo; confirmed it works in the current iteration. Also tested docs locally, now the code example only takes two full pages on my tiny 13" screen (with all the docs headers & stuff) as opposed to 7-ish before

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).