### PR TITLE
[docs] EAS Build - update default image + update cache docs

### DIFF
--- a/docs/pages/build-reference/android-builds.md
+++ b/docs/pages/build-reference/android-builds.md
@@ -113,7 +113,7 @@ tasks.whenTaskAdded {
     def credentialsJson = rootProject.file("../credentials.json");
 
     if (credentialsJson.exists()) {
-      if (storeFile && ! System.getenv("EAS_BUILD")) {
+      if (storeFile && !System.getenv("EAS_BUILD")) {
         println("Path to release keystore file is already set, ignoring 'credentials.json'")
       } else {
         try {

--- a/docs/pages/build-reference/android-builds.md
+++ b/docs/pages/build-reference/android-builds.md
@@ -113,7 +113,7 @@ tasks.whenTaskAdded {
     def credentialsJson = rootProject.file("../credentials.json");
 
     if (credentialsJson.exists()) {
-      if (storeFile && System.getenv("EAS_BUILD") != "true") {
+      if (storeFile && ! System.getenv("EAS_BUILD")) {
         println("Path to release keystore file is already set, ignoring 'credentials.json'")
       } else {
         try {

--- a/docs/pages/build-reference/caching.md
+++ b/docs/pages/build-reference/caching.md
@@ -25,7 +25,6 @@ EAS Build runs a Maven cache server that can speed up downloading Android depend
 Currently we are caching:
 - `maven-central` - [https://repo1.maven.org/maven2/](https://repo1.maven.org/maven2/)
 - `google` - [https://maven.google.com/](https://maven.google.com/)
-- `android-tools` - [https://dl.bintray.com/android/android-tools/](https://dl.bintray.com/android/android-tools/)
 - `jcenter` - [https://jcenter.bintray.com/](https://jcenter.bintray.com/)
 - `plugins` - [https://plugins.gradle.org/m2/](https://plugins.gradle.org/m2/)
 

--- a/docs/pages/build-reference/infrastructure.md
+++ b/docs/pages/build-reference/infrastructure.md
@@ -75,7 +75,7 @@ When selecting an image for the build you can use the full name provided below o
   npmRegistryServer: "registry=http://10.254.24.8:4873"
   ```
 
-#### Image `macos-big-sur-11.4-xcode-12.5` (alias `latest`)
+#### Image `macos-big-sur-11.4-xcode-12.5` (alias `default`, `latest`)
 
 - macOS Big Sur 11.4
 - Xcode 12.5 (12E5244e)
@@ -85,7 +85,7 @@ When selecting an image for the build you can use the full name provided below o
 - CocoaPods 1.10.1
 - Ruby 2.7.0p0 (2019-12-25 revision 647ee6f091) [x86_64-darwin19]
 
-#### Image `macos-catalina-10.15-xcode-12.4` (alias `default`)
+#### Image `macos-catalina-10.15-xcode-12.4`
 
 - macOS Catalina 10.15.7
 - Xcode 12.4 (12D4e)

--- a/docs/pages/build-reference/variables.md
+++ b/docs/pages/build-reference/variables.md
@@ -154,7 +154,7 @@ After creating a secret, you can access the value via EAS Build hooks in Node.js
 The following environment variables are exposed to each build job:
 
 - `CI=1` - indicates this is a CI environment
-- `EAS_BUILD=1` - indicates this is an EAS Build environment
+- `EAS_BUILD=true` - indicates this is an EAS Build environment
 - `EAS_BUILD_PROFILE` - the name of the build profile from `eas.json`, e.g. `release`
 - `EAS_BUILD_GIT_COMMIT_HASH` - the hash of the Git commit, e.g. `88f28ab5ea39108ade978de2d0d1adeedf0ece76`
 - `EAS_BUILD_NPM_CACHE_URL` - the URL of the npm cache ([learn more](how-tos.md#using-npm-cache-with-yarn-v1))


### PR DESCRIPTION
# Why

update docs for EAS BUild

# How

- switch default image to code 12.5
- remove bintray registry (the registry is no longer available)
- update docs for EAS_BUILD env


# Test Plan

