### PR TITLE
[NCL][test-suite] Rely on the same FB appId on Android and iOS

### DIFF
--- a/apps/native-component-list/app.json
+++ b/apps/native-component-list/app.json
@@ -23,8 +23,8 @@
       "silentLaunch": true
     },
     "platforms": ["android", "ios", "web"],
-    "facebookScheme": "fb629712900716487",
-    "facebookAppId": "629712900716487",
+    "facebookScheme": "fb1696089354000816",
+    "facebookAppId": "1696089354000816",
     "facebookDisplayName": "Expo APIs",
     "facebookAutoLogAppEventsEnabled": true,
     "facebookAdvertiserIDCollectionEnabled": true,

--- a/apps/native-component-list/src/screens/FacebookAppEventsScreen.tsx
+++ b/apps/native-component-list/src/screens/FacebookAppEventsScreen.tsx
@@ -6,11 +6,9 @@ import HeadingText from '../components/HeadingText';
 import ListButton from '../components/ListButton';
 import SimpleActionDemo from '../components/SimpleActionDemo';
 
-const appId = '629712900716487';
-const appEventsDashboardUrlExpoGoIos =
+const appId = '1696089354000816';
+const appEventsDashboardUrl =
   'https://www.facebook.com/events_manager2/list/app/1696089354000816/test_events?act=453712715268302';
-const appEventsDashboardUrlAndroid =
-  'https://www.facebook.com/events_manager2/list/app/629712900716487/';
 
 export default class FacebookAppEventsScreen extends React.Component {
   static navigationOptions = {
@@ -86,18 +84,10 @@ export default class FacebookAppEventsScreen extends React.Component {
 
         <View style={{ paddingBottom: 30 }}>
           <HeadingText style={{ textAlign: 'center' }}>
-            To view app events in Expo Go on iOS, go to this dashboard:
+            To view app events from Expo Go, go to this dashboard:
           </HeadingText>
           <Text selectable style={{ textAlign: 'center' }}>
-            {appEventsDashboardUrlExpoGoIos}
-          </Text>
-
-          <HeadingText style={{ textAlign: 'center' }}>
-            To view app events in Expo Go on Android, and in standalones on iOS & Android, go to
-            this dashboard and navigate to 'Test Events':
-          </HeadingText>
-          <Text selectable style={{ textAlign: 'center' }}>
-            {appEventsDashboardUrlAndroid}
+            {appEventsDashboardUrl}
           </Text>
         </View>
       </ScrollView>

--- a/apps/native-component-list/src/screens/FacebookLoginScreen.tsx
+++ b/apps/native-component-list/src/screens/FacebookLoginScreen.tsx
@@ -6,7 +6,7 @@ import ListButton from '../components/ListButton';
 import MonoText from '../components/MonoText';
 import SimpleActionDemo from '../components/SimpleActionDemo';
 
-const appId = '629712900716487';
+const appId = '1696089354000816';
 
 export default class FacebookLoginScreen extends React.Component {
   static navigationOptions = {

--- a/apps/test-suite/tests/FBBannerAd.js
+++ b/apps/test-suite/tests/FBBannerAd.js
@@ -18,7 +18,7 @@ export const name = 'BannerAd';
 // Probably test won't pass if you are not logged into account connected
 // with placement id.
 
-const placementId = '629712900716487_662949307392846';
+const placementId = 'IMG_16_9_APP_INSTALL#YOUR_PLACEMENT_ID';
 
 export function test(t, { setPortalChild, cleanupPortal }) {
   t.describe('FacebookAds.BannerView', () => {

--- a/apps/test-suite/tests/Facebook.js
+++ b/apps/test-suite/tests/Facebook.js
@@ -27,7 +27,7 @@ export async function test(
   describe(name, () => {
     beforeAll(async () => {
       await Facebook.initializeAsync({
-        appId: '629712900716487',
+        appId: '1696089354000816',
         version: Platform.select({
           web: 'v5.0',
         }),
@@ -47,13 +47,13 @@ export async function test(
       });
     } else {
       it(`calls setAdvertiserTrackingEnabled`, async () => {
-      const result = await Facebook.setAdvertiserTrackingEnabledAsync(true);
+        const result = await Facebook.setAdvertiserTrackingEnabledAsync(true);
         if (Platform.OS === 'ios') {
           if (parseInt(Device.osVersion, 10) >= 14) {
             expect(result).toBe(true);
           } else {
             expect(result).toBe(false);
-          } 
+          }
         } else {
           expect(result).toBe(false);
         }


### PR DESCRIPTION
# Why

We use 2 diff app IDs, and the one we were using for android didn't have the necessary permissions in the facebook developer console. To reduce the amount of work from us in the future and the likelihood of things breaking, let's just use one single App ID for both

# How

switched app id

# Test Plan

test suite and NCL both work on all facebook-related screens
