### PR TITLE
[expo-updates-interface] remove unnecessary gradle dependency on unimodules-core

### DIFF
--- a/packages/expo-updates-interface/android/build.gradle
+++ b/packages/expo-updates-interface/android/build.gradle
@@ -60,19 +60,10 @@ android {
   }
 }
 
-if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-  apply from: project(":unimodules-core").file("../unimodules-core.gradle")
-} else {
-  throw new GradleException(
-      '\'unimodules-core.gradle\' was not found in the usual React Native dependency location. ' +
-          'This package can only be used in such projects. Are you sure you\'ve installed the dependencies properly?')
-}
-
 repositories {
   mavenCentral()
 }
 
 dependencies {
-  unimodule 'unimodules-core'
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${safeExtGet("kotlinVersion", "1.3.50")}"
 }


### PR DESCRIPTION
# Why

Allows this library to compile in dev client projects without unimodules.

# How

Remove unimodules-core script and dependency from build.gradle; it isn't used or needed anywhere in this library.

# Test Plan

- [x] Android project in https://github.com/lukmccall/expo-dev-client-react-native compiles with this change made manually in node_modules
- [x] expo init (bare) project compiles in both debug and release mode with this change made manually in node_modules (doesn't mess anything up for projects _with_ unimodules)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).