### PR TITLE
[ios][av] Fix container default type to work cross-platform

### DIFF
--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- Default audio recording settings on ios are now `extension: '.mp4'` and `outputFormat: RECORDING_OPTION_IOS_OUTPUT_FORMAT_MPEG4AAC` so as to ensure cross-platform compatibility. ([[#13492](https://github.com/expo/expo/pull/13492)]) by [@actuallymentor](https://github.com/actuallymentor)
+
 ### 🎉 New features
 
 - Add web support for recording. ([#8721](https://github.com/expo/expo/pull/8721) by [@WazzaJB](https://github.com/WazzaJB) and [@mnightingale](https://github.com/mnightingale))

--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🛠 Breaking changes
 
-- Default audio recording settings on ios are now `extension: '.mp4'` and `outputFormat: RECORDING_OPTION_IOS_OUTPUT_FORMAT_MPEG4AAC` so as to ensure cross-platform compatibility. ([#13492](https://github.com/expo/expo/pull/13492) by [@actuallymentor](https://github.com/actuallymentor))
+- Default audio recording settings on ios are now `extension: '.m4a'` and `outputFormat: RECORDING_OPTION_IOS_OUTPUT_FORMAT_MPEG4AAC` so as to ensure cross-platform compatibility. ([#13492](https://github.com/expo/expo/pull/13492) by [@actuallymentor](https://github.com/actuallymentor))
 
 ### 🎉 New features
 

--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🛠 Breaking changes
 
-- Default audio recording settings on ios are now `extension: '.mp4'` and `outputFormat: RECORDING_OPTION_IOS_OUTPUT_FORMAT_MPEG4AAC` so as to ensure cross-platform compatibility. ([[#13492](https://github.com/expo/expo/pull/13492)]) by [@actuallymentor](https://github.com/actuallymentor)
+- Default audio recording settings on ios are now `extension: '.mp4'` and `outputFormat: RECORDING_OPTION_IOS_OUTPUT_FORMAT_MPEG4AAC` so as to ensure cross-platform compatibility. ([#13492](https://github.com/expo/expo/pull/13492) by [@actuallymentor](https://github.com/actuallymentor))
 
 ### 🎉 New features
 

--- a/packages/expo-av/src/Audio/Recording.ts
+++ b/packages/expo-av/src/Audio/Recording.ts
@@ -119,7 +119,7 @@ export const RECORDING_OPTIONS_PRESET_HIGH_QUALITY: RecordingOptions = {
     bitRate: 128000,
   },
   ios: {
-    extension: '.mp4',
+    extension: '.m4a',
     outputFormat: RECORDING_OPTION_IOS_OUTPUT_FORMAT_MPEG4AAC,
     audioQuality: RECORDING_OPTION_IOS_AUDIO_QUALITY_MAX,
     sampleRate: 44100,

--- a/packages/expo-av/src/Audio/Recording.ts
+++ b/packages/expo-av/src/Audio/Recording.ts
@@ -119,7 +119,8 @@ export const RECORDING_OPTIONS_PRESET_HIGH_QUALITY: RecordingOptions = {
     bitRate: 128000,
   },
   ios: {
-    extension: '.caf',
+    extension: '.mp4',
+    outputFormat: RECORDING_OPTION_IOS_OUTPUT_FORMAT_MPEG4AAC,
     audioQuality: RECORDING_OPTION_IOS_AUDIO_QUALITY_MAX,
     sampleRate: 44100,
     numberOfChannels: 2,


### PR DESCRIPTION
With these defaults, ios audio can't be played on android. This codec change results in the files of ios and android being cross-playable.

Resolves #11952
Tagging @jonsamp for a second pair of eyes.

# Why

iOS `caf` files with their default codec cannot be played on Android. This goes against the cross-platform ethos of Expo.

# How

By changing the defaults to use a codec that both platforms support.

# Test Plan

New defaults have been tested to work by multiple users, see the [corresponding issue](https://github.com/expo/expo/issues/11952).

For context, copy-paste from issue:

```js
// Below code runs in a function

const { ios, android } = Audio.RECORDING_OPTIONS_PRESET_HIGH_QUALITY
await recorder.prepareToRecordAsync( {
	android: android,
	ios: {
		...ios,
		extension: '.mp4',
		outputFormat: Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_MPEG4AAC
	}

} )
```

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).