### PR TITLE
[android] Escape Android autolinking script for windows

### DIFF
--- a/packages/@unimodules/react-native-adapter/CHANGELOG.md
+++ b/packages/@unimodules/react-native-adapter/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Escape Android autolinking script for Windows. ([#13494](https://github.com/expo/expo/pull/13494) by [@byCedric](https://github.com/byCedric))
+
 ### 💡 Others
 
 ## 6.3.0 — 2021-05-25

--- a/packages/@unimodules/react-native-adapter/scripts/autolinking.gradle
+++ b/packages/@unimodules/react-native-adapter/scripts/autolinking.gradle
@@ -94,7 +94,7 @@ class ExpoAutolinkingManager {
     String[] args = [
       'node',
       '--eval',
-      'require("expo-modules-autolinking")(process.argv.slice(1))',
+      'require(\'expo-modules-autolinking\')(process.argv.slice(1))',
       '--',
       command,
       '--platform',


### PR DESCRIPTION
# Why

This fixes #13475

# How

It looks like the Gradle script removes the unescaped `"` symbol when executing the command on Windows. On MacOS, `"` and this fix works as expected.

# Test Plan

- On Windows
- Create a new bare project for SDK 42
- Run `yarn android`
- At the later stages, it should crash with the error described in #13475
- After the fix, it should pass that stage without issues.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).