### PR TITLE
[android] Fix null pointer when working with null manifest

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
@@ -671,7 +671,7 @@ public class ExperienceActivity extends BaseExperienceActivity implements Expone
 
   @Override
   public boolean isDebugModeEnabled() {
-    return mManifest.isDevelopmentMode();
+    return mManifest != null && mManifest.isDevelopmentMode();
   }
 
   @Override

--- a/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.java
@@ -370,7 +370,7 @@ public abstract class ReactNativeActivity extends AppCompatActivity implements c
   }
 
   public boolean isDebugModeEnabled() {
-    return mManifest.isDevelopmentMode();
+    return mManifest != null && mManifest.isDevelopmentMode();
   }
 
   protected void destroyReactInstanceManager() {

--- a/android/expoview/src/main/java/host/exp/exponent/headless/InternalHeadlessAppLoader.java
+++ b/android/expoview/src/main/java/host/exp/exponent/headless/InternalHeadlessAppLoader.java
@@ -200,7 +200,7 @@ public class InternalHeadlessAppLoader implements AppLoaderInterface, Exponent.S
   }
 
   public boolean isDebugModeEnabled() {
-    return mManifest.isDevelopmentMode();
+    return mManifest != null && mManifest.isDevelopmentMode();
   }
 
   private void soloaderInit() {


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/13489.

Blame: 944c88f55b64cd7b0ba1a645ba2d39dbe1034b75

# How

Audit all callsites to `RawManifest.isDevelopmentMode` that were replacements of `ExponentManifest.isDebugModeEnabled` (which did the null check internally) and ensure they either cannot have null target object. If they can, add a null check before `isDevelopmentMode` is called.

# Test Plan

1. Create app: `expo init testproject`
2. `expo start`, load app

Before:

```
2021-07-05 10:24:37.848 520-520/host.exp.exponent E/AndroidRuntime: FATAL EXCEPTION: main
    Process: host.exp.exponent, PID: 520
    java.lang.NullPointerException: Attempt to invoke virtual method 'boolean expo.modules.updates.manifest.raw.RawManifest.isDevelopmentMode()' on a null object reference
        at host.exp.exponent.experience.ExperienceActivity.isDebugModeEnabled(ExperienceActivity.java:674)
        at host.exp.exponent.experience.BaseExperienceActivity.lambda$consumeErrorQueue$0$BaseExperienceActivity(BaseExperienceActivity.java:213)
        at host.exp.exponent.experience.-$$Lambda$BaseExperienceActivity$KACrV8PgD2oygGCw48QyqHbt-ok.run(Unknown Source:2)
        at android.app.Activity.runOnUiThread(Activity.java:6282)
        at host.exp.exponent.experience.BaseExperienceActivity.consumeErrorQueue(BaseExperienceActivity.java:190)
        at host.exp.exponent.experience.BaseExperienceActivity.addError(BaseExperienceActivity.java:70)
        at host.exp.exponent.kernel.Kernel.handleReactNativeError(Kernel.java:1151)
        at host.exp.exponent.kernel.Kernel.handleError(Kernel.java:1160)
        at host.exp.exponent.kernel.Kernel$4.lambda$onError$3$Kernel$4(Kernel.java:776)
        at host.exp.exponent.kernel.-$$Lambda$Kernel$4$DEQUCGFAzQX__Ih5Fb93c0rLhDg.run(Unknown Source:4)
        at android.os.Handler.handleCallback(Handler.java:873)
        at android.os.Handler.dispatchMessage(Handler.java:99)
        at android.os.Looper.loop(Looper.java:193)
        at android.app.ActivityThread.main(ActivityThread.java:6669)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:493)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:858)
```

After:
Launches successfully