### PR TITLE
[ci] Update workflows to macOS 11

### DIFF
--- a/.github/workflows/ad-hoc-client-shell-app-ios.yml
+++ b/.github/workflows/ad-hoc-client-shell-app-ios.yml
@@ -19,13 +19,13 @@ concurrency:
 
 jobs:
   build:
-    runs-on: macos-10.15
+    runs-on: macos-11
     steps:
       - uses: actions/checkout@v2
         with:
           submodules: true
-      - name: Switch to Xcode 12.1
-        run: sudo xcode-select --switch /Applications/Xcode_12.1.app
+      - name: Switch to Xcode 12.5.1
+        run: sudo xcode-select --switch /Applications/Xcode_12.5.1.app
       - name: Get cache key of git lfs files
         id: git-lfs
         run: echo "::set-output name=sha256::$(git lfs ls-files | openssl dgst -sha256)"

--- a/.github/workflows/client-ios.yml
+++ b/.github/workflows/client-ios.yml
@@ -34,12 +34,14 @@ concurrency:
 
 jobs:
   build:
-    runs-on: macos-10.15
+    runs-on: macos-11
     steps:
       - name: 👀 Checkout a ref for the event
         uses: actions/checkout@v2
         with:
           submodules: true
+      - name: 🔨 Switch to Xcode 12.5.1
+        run: sudo xcode-select --switch /Applications/Xcode_12.5.1.app
       - name: 🍺 Setup Homebrew
         run: brew install git-crypt
       - name: 🔓 decrypt secrets if possible

--- a/.github/workflows/development-client.yml
+++ b/.github/workflows/development-client.yml
@@ -92,7 +92,7 @@ jobs:
         run: ./gradlew assembleDebug
 
   ios:
-    runs-on: macos-latest
+    runs-on: macos-11
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
@@ -138,4 +138,4 @@ jobs:
         run: expo-cli eject
       - name: Build debug
         working-directory: ../development-client-ios-test
-        run: xcodebuild -workspace ios/developmentclientiostest.xcworkspace -scheme developmentclientiostest -configuration debug -sdk iphonesimulator14.4 -arch x86_64
+        run: xcodebuild -workspace ios/developmentclientiostest.xcworkspace -scheme developmentclientiostest -configuration debug -sdk iphonesimulator -arch x86_64

--- a/.github/workflows/ios-unit-tests.yml
+++ b/.github/workflows/ios-unit-tests.yml
@@ -30,7 +30,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: macos-10.15
+    runs-on: macos-11
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/shell-app-ios.yml
+++ b/.github/workflows/shell-app-ios.yml
@@ -20,13 +20,13 @@ concurrency:
 
 jobs:
   build:
-    runs-on: macos-10.15
+    runs-on: macos-11
     steps:
       - uses: actions/checkout@v2
         with:
           submodules: true
-      - name: 🔨 Switch to Xcode 12.1
-        run: sudo xcode-select --switch /Applications/Xcode_12.1.app
+      - name: 🔨 Switch to Xcode 12.5.1
+        run: sudo xcode-select --switch /Applications/Xcode_12.5.1.app
       - name: 🍺 Setup
         run: |
           echo "$(pwd)/bin" >> $GITHUB_PATH

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -66,7 +66,7 @@ jobs:
           author_name: Test Suite (Web)
 
   ios:
-    runs-on: macos-10.15
+    runs-on: macos-11
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v2
@@ -194,13 +194,13 @@ jobs:
         working-directory: react-native-lab/react-native
         timeout-minutes: 35
         env:
-          GRADLE_OPTS: "-Dorg.gradle.internal.http.connectionTimeout=180000 -Dorg.gradle.internal.http.socketTimeout=180000 -Dorg.gradle.internal.network.retry.max.attempts=18 -Dorg.gradle.internal.network.retry.initial.backOff=2000"
+          GRADLE_OPTS: '-Dorg.gradle.internal.http.connectionTimeout=180000 -Dorg.gradle.internal.http.socketTimeout=180000 -Dorg.gradle.internal.network.retry.max.attempts=18 -Dorg.gradle.internal.network.retry.initial.backOff=2000'
       - name: Build Android project for Detox
         run: yarn android:detox:build:release
         working-directory: apps/bare-expo
         timeout-minutes: 35
         env:
-          GRADLE_OPTS: "-Dorg.gradle.internal.http.connectionTimeout=180000 -Dorg.gradle.internal.http.socketTimeout=180000 -Dorg.gradle.internal.network.retry.max.attempts=18 -Dorg.gradle.internal.network.retry.initial.backOff=2000"
+          GRADLE_OPTS: '-Dorg.gradle.internal.http.connectionTimeout=180000 -Dorg.gradle.internal.http.socketTimeout=180000 -Dorg.gradle.internal.network.retry.max.attempts=18 -Dorg.gradle.internal.network.retry.initial.backOff=2000'
       - name: Run tests
         uses: reactivecircus/android-emulator-runner@v2
         with:

--- a/apps/bare-expo/ios/Build-Phases/generate-dynamic-macros.sh
+++ b/apps/bare-expo/ios/Build-Phases/generate-dynamic-macros.sh
@@ -6,7 +6,11 @@ if [ -z "$EXPO_TOOLS_DIR" ]; then
   EXPO_TOOLS_DIR="${SRCROOT}/../../../tools"
 fi
 
-source ${EXPO_TOOLS_DIR}/source-login-scripts.sh
+# Sourcing login scripts on macOS-11 runners is broken but can be omitted.
+if [ -z "$CI" ]; then
+  source ${EXPO_TOOLS_DIR}/source-login-scripts.sh
+fi
+
 export PATH="${SRCROOT}/../../../bin:$PATH"
 
 et ios-generate-dynamic-macros --configuration ${CONFIGURATION}

--- a/ios/Build-Phases/generate-dynamic-macros.sh
+++ b/ios/Build-Phases/generate-dynamic-macros.sh
@@ -6,7 +6,11 @@ if [ -z "$EXPO_TOOLS_DIR" ]; then
   EXPO_TOOLS_DIR="${SRCROOT}/../tools"
 fi
 
-source ${EXPO_TOOLS_DIR}/source-login-scripts.sh
+# Sourcing login scripts on macOS-11 runners is broken but can be omitted.
+if [ -z "$CI" ]; then
+  source ${EXPO_TOOLS_DIR}/source-login-scripts.sh
+fi
+
 export PATH="${SRCROOT}/../bin:$PATH"
 
 if [ "${APP_OWNER}" == "Expo" ]; then
@@ -14,4 +18,3 @@ if [ "${APP_OWNER}" == "Expo" ]; then
 else
   et ios-generate-dynamic-macros --configuration ${CONFIGURATION} --skip-template=GoogleService-Info.plist
 fi
-


### PR DESCRIPTION
# Why

As we've recently gotten access to macOS 11 runners on GitHub Actions and the fact that iOS 15 is in public beta phase, we can start preparing for Xcode 13 upgrade.

# How

- Updated all macOS workflows to run on `macos-11`
- Explicitly selected Xcode v12.5.1 so we won't be surprised when GitHub changes the default version
- `xcodebuild` has been failing on sourcing `source-login-scripts.sh`, but looks like we don't really need it on the CI so I skipped it there

# Test Plan

CI is the source of truth (iOS Shell App is failing but this is caused by https://github.com/expo/expo/commit/79ca9839c299a81a1cbdd8cf3cca4c4461f885be)