### PR TITLE
[expo-updates][ios] remove usage of deprecated reload method

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -13,7 +13,7 @@
 ### 🐛 Bug fixes
 
 - Improve behavior of dev client (with updates integration) when developer is logged out of expo-cli. ([#13310](https://github.com/expo/expo/pull/13310) by [@esamelson](https://github.com/esamelson))
-- Remove usage of deprecated `[RCTBridge reload]` method.
+- Remove usage of deprecated `[RCTBridge reload]` method. ([#13501](https://github.com/expo/expo/pull/13501) by [@esamelson](https://github.com/esamelson))
 
 ### 💡 Others
 

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 🐛 Bug fixes
 
 - Improve behavior of dev client (with updates integration) when developer is logged out of expo-cli. ([#13310](https://github.com/expo/expo/pull/13310) by [@esamelson](https://github.com/esamelson))
+- Remove usage of deprecated `[RCTBridge reload]` method.
 
 ### 💡 Others
 


### PR DESCRIPTION
# Why

Noticed that Xcode was displaying a warning in all expo-updates projects about `[RCTBridge reload]` being deprecated in favor of `RCTReloadCommand`.

# How

Replaced `[self->_bridge reload]` with the method from RCTReloadCommand.h, `RCTTriggerReloadCommandListeners`. This is exactly the current implementation of `[RCTCxxBridge reload]` only with a more specific `reason`. A bonus benefit is that EXUpdatesAppController no longer needs a reference to the bridge in order to reload (though it does still need it in order to send events).

The `RCTReloadCommandSetBundleURL` method appears to have no effect other than setting the new URL on the `userInfo` object of a notification; the bridge still actually uses the URL it gets through AppDelegate regardless of what's in the notification object. But there is no harm in calling this method here too -- it just means that the notification will have the correct URL value.

# Test Plan

Created a new bare project, made these changes in local node_modules, added a button in JS that calls `Updates.reloadAsync()` then made a release build. Confirmed that reloading still works, and the Xcode warning goes away 🎉 

Also tested the same thing in a project with the dev client installed, using a published project (with the `Updates.reloadAsync()` button) to confirm nothing goes awry in a project with multiple bridges.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).