### PR TITLE
[unimodules-core][ios] Fix `getModuleImplementingProtocol` cannot find protocols which starts with "UM"

### DIFF
--- a/packages/@unimodules/core/ios/UMCore/Protocols/UMAppLifecycleListener.h
+++ b/packages/@unimodules/core/ios/UMCore/Protocols/UMAppLifecycleListener.h
@@ -2,6 +2,4 @@
 
 #import <ExpoModulesCore/EXAppLifecycleListener.h>
 
-@protocol UMAppLifecycleListener <EXAppLifecycleListener>
-
-@end
+#define UMAppLifecycleListener EXAppLifecycleListener

--- a/packages/@unimodules/core/ios/UMCore/Protocols/UMAppLifecycleService.h
+++ b/packages/@unimodules/core/ios/UMCore/Protocols/UMAppLifecycleService.h
@@ -3,6 +3,4 @@
 #import <ExpoModulesCore/EXAppLifecycleService.h>
 #import <UMCore/UMAppLifecycleListener.h>
 
-@protocol UMAppLifecycleService <EXAppLifecycleService>
-
-@end
+#define UMAppLifecycleService EXAppLifecycleService

--- a/packages/@unimodules/core/ios/UMCore/Protocols/UMEventEmitter.h
+++ b/packages/@unimodules/core/ios/UMCore/Protocols/UMEventEmitter.h
@@ -2,6 +2,4 @@
 
 #import <ExpoModulesCore/EXEventEmitter.h>
 
-@protocol UMEventEmitter <EXEventEmitter>
-
-@end
+#define UMEventEmitter EXEventEmitter

--- a/packages/@unimodules/core/ios/UMCore/Protocols/UMEventEmitterService.h
+++ b/packages/@unimodules/core/ios/UMCore/Protocols/UMEventEmitterService.h
@@ -2,6 +2,4 @@
 
 #import <ExpoModulesCore/EXEventEmitterService.h>
 
-@protocol UMEventEmitterService <EXEventEmitterService>
-
-@end
+#define UMEventEmitterService EXEventEmitterService

--- a/packages/@unimodules/core/ios/UMCore/Protocols/UMInternalModule.h
+++ b/packages/@unimodules/core/ios/UMCore/Protocols/UMInternalModule.h
@@ -3,6 +3,5 @@
 #import <ExpoModulesCore/EXInternalModule.h>
 #import <UMCore/UMDefines.h>
 
-@protocol UMInternalModule <EXInternalModule>
+#define UMInternalModule EXInternalModule
 
-@end

--- a/packages/@unimodules/core/ios/UMCore/Protocols/UMJavaScriptContextProvider.h
+++ b/packages/@unimodules/core/ios/UMCore/Protocols/UMJavaScriptContextProvider.h
@@ -2,6 +2,4 @@
 
 #import <ExpoModulesCore/EXJavaScriptContextProvider.h>
 
-@protocol UMJavaScriptContextProvider <EXJavaScriptContextProvider>
-
-@end
+#define UMJavaScriptContextProvider EXJavaScriptContextProvider

--- a/packages/@unimodules/core/ios/UMCore/Protocols/UMKernelService.h
+++ b/packages/@unimodules/core/ios/UMCore/Protocols/UMKernelService.h
@@ -2,6 +2,4 @@
 
 #import <ExpoModulesCore/EXKernelService.h>
 
-@protocol UMKernelService <EXKernelService>
-
-@end
+#define UMKernelService EXKernelService

--- a/packages/@unimodules/core/ios/UMCore/Protocols/UMLogHandler.h
+++ b/packages/@unimodules/core/ios/UMCore/Protocols/UMLogHandler.h
@@ -2,6 +2,4 @@
 
 #import <ExpoModulesCore/EXLogHandler.h>
 
-@protocol UMLogHandler <EXLogHandler>
-
-@end
+#define UMLogHandler EXLogHandler

--- a/packages/@unimodules/core/ios/UMCore/Protocols/UMModuleRegistryConsumer.h
+++ b/packages/@unimodules/core/ios/UMCore/Protocols/UMModuleRegistryConsumer.h
@@ -4,6 +4,4 @@
 #import <UMCore/UMModuleRegistry.h>
 #import <UMCore/UMDefines.h>
 
-@protocol UMModuleRegistryConsumer <EXModuleRegistryConsumer>
-
-@end
+#define UMModuleRegistryConsumer EXModuleRegistryConsumer

--- a/packages/@unimodules/core/ios/UMCore/Protocols/UMUIManager.h
+++ b/packages/@unimodules/core/ios/UMCore/Protocols/UMUIManager.h
@@ -2,6 +2,4 @@
 
 #import <ExpoModulesCore/EXUIManager.h>
 
-@protocol UMUIManager <EXUIManager>
-
-@end
+#define UMUIManager EXUIManager

--- a/packages/@unimodules/core/ios/UMCore/Protocols/UMUtilitiesInterface.h
+++ b/packages/@unimodules/core/ios/UMCore/Protocols/UMUtilitiesInterface.h
@@ -2,6 +2,4 @@
 
 #import <ExpoModulesCore/EXUtilitiesInterface.h>
 
-@protocol UMUtilitiesInterface <EXUtilitiesInterface>
-
-@end
+#define UMUtilitiesInterface EXUtilitiesInterface


### PR DESCRIPTION
# Why

Fixes `getModuleImplementingProtocol` always returns `nil` when protocols name starts with "UM". 

# How

`getModuleImplementingProtocol` gets protocols from module registry by protocol class. React Native adapter provides services that start with "EX". Services from "UMCore" were deprecated but still should work. To ensure backward compatibility, I've changed how we declared "UM" services.  

# Test Plan

- bare-expo ✅
- expo go ✅