### PR TITLE
[docs] EAS Build - unified workflow

### DIFF
--- a/docs/components/plugins/EasJsonPropertiesTable.tsx
+++ b/docs/components/plugins/EasJsonPropertiesTable.tsx
@@ -44,7 +44,7 @@ export function formatSchema(rawSchema: Property[]) {
   return formattedSchema;
 }
 
-//appends a property and recursivley appends sub-properties
+//appends a property and recursively appends sub-properties
 function appendProperty(
   formattedSchema: FormattedProperty[],
   property: Property,

--- a/docs/components/plugins/EasJsonPropertiesTable.tsx
+++ b/docs/components/plugins/EasJsonPropertiesTable.tsx
@@ -1,0 +1,130 @@
+import { css } from '@emotion/react';
+import { theme } from '@expo/styleguide';
+import MDX from '@mdx-js/runtime';
+import * as React from 'react';
+
+import * as components from '~/common/translate-markdown';
+
+const STYLES_TABLE = css`
+  font-size: 1rem;
+  margin-top: 24px;
+`;
+
+const STYLES_HEAD = css`
+  background-color: ${theme.background.tertiary};
+`;
+
+const STYLES_DESCRIPTION_CELL = css`
+  word-break: break-word;
+  white-space: break-spaces;
+  padding-bottom: 0.2rem;
+`;
+
+export type Property = {
+  description?: string[];
+  name: string;
+  type?: string | string[];
+  enum?: string[];
+  properties?: Property[];
+};
+
+type FormattedProperty = {
+  name: string;
+  description: string;
+  nestingLevel: number;
+};
+
+export function formatSchema(rawSchema: Property[]) {
+  const formattedSchema: FormattedProperty[] = [];
+
+  rawSchema.map(property => {
+    appendProperty(formattedSchema, property, 0);
+  });
+
+  return formattedSchema;
+}
+
+//appends a property and recursivley appends sub-properties
+function appendProperty(
+  formattedSchema: FormattedProperty[],
+  property: Property,
+  _nestingLevel: number
+) {
+  let nestingLevel = _nestingLevel;
+
+  formattedSchema.push({
+    name: nestingLevel
+      ? `<subpropertyAnchor level={${nestingLevel}}><inlineCode>${property.name}</inlineCode></subpropertyAnchor>`
+      : `<propertyAnchor level={0}><inlineCode>${property.name}</inlineCode></propertyAnchor>`,
+    description: createDescription(property),
+    nestingLevel,
+  });
+
+  nestingLevel++;
+
+  if (property.properties) {
+    (property.properties ?? []).forEach(subproperty => {
+      appendProperty(formattedSchema, subproperty, nestingLevel);
+    });
+  }
+}
+
+export function _getType(property: Property) {
+  if (property.enum) {
+    return 'enum';
+  } else {
+    return property.type?.toString().replace(/,/g, ' || ');
+  }
+}
+
+export function createDescription(property: Property) {
+  let propertyDescription = `**(${_getType(property)})**`;
+  if (property.description) {
+    propertyDescription += ` - ` + property.description.join('\n');
+  }
+
+  return propertyDescription;
+}
+
+export default class EasJsonPropertiesTable extends React.Component<{
+  schema: Property[];
+}> {
+  render() {
+    const formattedSchema = formatSchema(this.props.schema);
+
+    return (
+      <table css={STYLES_TABLE}>
+        <thead css={STYLES_HEAD}>
+          <tr>
+            <td>Property</td>
+            <td>Description</td>
+          </tr>
+        </thead>
+        <tbody>
+          {formattedSchema.map((property, index) => {
+            return (
+              <tr key={index}>
+                <td>
+                  <div
+                    data-testid={property.name}
+                    style={{
+                      marginLeft: `${property.nestingLevel * 32}px`,
+                      display: property.nestingLevel ? 'list-item' : 'block',
+                      listStyleType: property.nestingLevel % 2 ? 'default' : 'circle',
+                      width: 'fit-content',
+                      overflowX: 'visible',
+                    }}>
+                    <MDX components={components}>{property.name}</MDX>
+                  </div>
+                </td>
+                <td css={STYLES_DESCRIPTION_CELL}>
+                  <MDX components={components}>{property.description}</MDX>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    );
+  }
+}

--- a/docs/pages/build/eas-json.md
+++ b/docs/pages/build/eas-json.md
@@ -2,6 +2,13 @@
 title: Configuration with eas.json
 ---
 
+import EasJsonPropertiesTable from '~/components/plugins/EasJsonPropertiesTable';
+
+import androidSchema from '~/scripts/schemas/unversioned/eas-json-android-schema.js';
+import iosSchema from '~/scripts/schemas/unversioned/eas-json-ios-schema.js';
+
+
+
 `eas.json` is your go-to place for configuring EAS Build. It is located at the root of your project next to your `package.json`. It looks something like this:
 
 ```json
@@ -9,12 +16,20 @@ title: Configuration with eas.json
   "builds": {
     "android": {
       "release": {
-        "workflow": "generic"
+        "buildType": "app-bundle"
+      },
+      "development": {
+        "buildType": "development-client",
+        "distribution": "internal",
       }
     },
     "ios": {
       "release": {
-        "workflow": "generic"
+        "buildType": "release"
+      },
+      "development": {
+        "buildType": "development-client",
+        "distribution": "internal"
       }
     }
   }
@@ -43,291 +58,92 @@ Generally, the schema of this file looks like this:
 
 where `PLATFORM_NAME` is one of `android` or `ios`.
 
-## Build Profiles
+## Examples
 
-There are two types of build profiles: generic and managed.
-
-**Generic projects** make almost no assumptions about your project's structure. The only requirement is that your project follows the general structure of React Native projects. This means there are `android` and `ios` directories in the root directory with the Gradle and Xcode projects, respectively. Whether you've initialized your project with `expo init --template bare-minimum` or with `npx react-native init`, you can build it with EAS Build.
-
-**Managed projects** are much simpler in terms of the project's structure and the knowledge needed to start developing your application. Those projects don't have the native code in the repository and they are tightly coupled with Expo. Basically, by managed projects, we mean projects initialized with `expo init` using a managed workflow template (like `blank`, `blank-typescript`, or `tabs`).
-
-## Android
-
-### Generic project
-
-The schema of a build profile for a generic Android project looks like this:
-
-```json
-{
-  "workflow": "generic",
-  "extends": string,
-  "credentialsSource": "local" | "remote", // default: "remote"
-  "withoutCredentials": boolean, // default: false
-  "gradleCommand": string, // default: ":app:bundleRelease"
-  "artifactPath": string, // default: "android/app/build/outputs/**/*.{apk,aab}"
-  "releaseChannel": string, // default: "default"
-  "distribution": "store" | "internal", // default: "store"
-  "image": string, // default: "default"
-  "node": string,
-  "yarn": string,
-  "ndk": string,
-  "env": Record<string, string>,
-  "cache": {
-    "disabled": boolean, // default: false
-    "key": string,
-    "customPaths": string[] // default: []
-  }
-}
-```
-
-- `"workflow": "generic"` indicates that your project is a generic one.
-- `extends` allows extending values from another build profile.
-- `credentialsSource` defines the source of credentials for this build profile. If you want to provide your own `credentials.json` file, set this to `local` ([learn more on this here](/app-signing/local-credentials.md)). If you want to use the credentials managed by EAS, choose `remote` (this is the default option).
-- `withoutCredentials`: when set to `true`, EAS CLI won't require you to configure credentials when building the app using this profile. This comes in handy when you want to build debug binaries and the debug keystore is checked in to the repository. The default is `false`.
-- `gradleCommand` defines the Gradle task to be run on EAS servers to build your project. You can set it to any valid Gradle task, e.g. `:app:assembleDebug` to build a debug binary. The default Gradle command is `:app:bundleRelease`.
-- `artifactPath` is the path (or pattern) where EAS Build is going to look for the build artifacts. EAS Build uses the `fast-glob` npm package for pattern matching ([see their README to learn more about the syntax you can use](https://github.com/mrmlnc/fast-glob#pattern-syntax)). The default value is `android/app/build/outputs/**/*.{apk,aab}`.
-- `releaseChannel` is the release channel for the `expo-updates` package ([Learn more about this](../distribution/release-channels.md)). If you do not specify a channel, your binary will pull releases from the `default` channel. If you do not use `expo-updates` in your project then this property will have no effect.
-- `distribution` is the flow of distributing your app. If you choose `internal` you'll be able to share your build URLs with anyone, and they will be able to install the builds to their devices straight from the Expo website. When using `internal`, make sure the `gradleCommand` produces an APK file (e.g. `:app:assembleRelease`). Otherwise, the sharable URL will be useless. The default is `store` which means your build URLs won't be sharable. [Learn more about internal distribution](internal-distribution.md).
-- `image` - image with build environment. [Learn more about it here](../build-reference/infrastructure).
-- `node` - version of Node.js
-- `yarn` - version of Yarn
-- `ndk` - version of Android NDK
-- `env` - environment variables that should be set during the build process (should only be used for values that you would commit to your git repository, i.e. not passwords or secrets).
-- `cache` configures paths that will be saved and restored in the next build. The cache can be explicitly invalidated by updating the value of the `key` field. Values in `customPaths` support both absolute and relative paths, where relative paths are resolved from the directory with `eas.json`. This feature is intended for caching values that require a lot of computation, e.g. compilation results (both final binaries and any intermediate files), but it wouldn't work well for `node_modules` because the cache is not local to the machine, so a download speed is similar to downloading from the npm registry. Set `"disabled": true` to disable caching.
-
-#### Examples
-
-This is the minimal working example. EAS CLI will ask you for the app's credentials, the project will be built with the `./gradlew :app:bundleRelease` command, and you'll be provided with the URL to the `android/app/build/outputs/bundle/release/app-release.aab` file.
-
-```json
-{
-  "workflow": "generic"
-}
-```
-
-If you'd like to build a release APK, use this example:
-
-```json
-{
-  "workflow": "generic",
-  "gradleCommand": ":app:assembleRelease",
-  "artifactPath": "android/app/build/outputs/apk/release/app-release.apk"
-}
-```
-
-If you'd like to build a debug APK use the following example. Also, make sure the debug keystore is checked in to the repository.
-
-```json
-{
-  "workflow": "generic",
-  "withoutCredentials": true,
-  "gradleCommand": ":app:assembleDebug",
-  "artifactPath": "android/app/build/outputs/apk/debug/app-debug.apk"
-}
-```
-
-### Managed Project
-
-The schema of a build profile for a managed Android project looks like this:
-
-```json
-{
-  "workflow": "managed",
-  "extends": string,
-  "credentialsSource": "local" | "remote", // default: "remote"
-  "buildType": "app-bundle" | "apk" | "development-client", // default: "app-bundle"
-  "releaseChannel": string, // default: "default"
-  "distribution": "store" | "internal", // default: "store"
-  "image": string, // default: "default"
-  "node": string,
-  "yarn": string,
-  "expoCli": string,
-  "ndk": string,
-  "env": Record<string, string>,
-  "cache": {
-    "disabled" : boolean, // default: false
-    "key": string,
-    "customPaths": string[] // default: []
-  }
-}
-```
-
-- `"workflow": "managed"` indicates that your project is a managed one.
-- `extends` allows extending values from another build profile.
-- `credentialsSource` defines the source of credentials for this build profile. If you want to provide your own `credentials.json` file, set this to `local` ([learn more on this here](/app-signing/local-credentials.md)). If you want to use the credentials managed by EAS, choose `remote` (this is the default option).
-- `buildType` when set to `app-bundle` or `apk` it produces a release AAB or APK archive respectively, but when set to `development-client` it produces a debug APK.
-- `releaseChannel` is the release channel for the `expo-updates` package ([Learn more about this](../distribution/release-channels.md)). If you do not specify a channel, your binary will pull releases from the `default` channel. If you do not use `expo-updates` in your project then this property will have no effect.
-- `distribution` is the flow of distributing your app. If you choose `internal` you'll be able to share your build URLs with anyone, and they will be able to install the builds to their devices straight from the Expo website. When `distribution` is `internal`, `buildType` needs to be set to `apk`. The default is `store` which means your build URLs won't be sharable. [Learn more about internal distribution](internal-distribution.md).
-- `image` - image with build environment. [Learn more about it here](../build-reference/infrastructure).
-- `node` - version of Node.js
-- `yarn` - version of Yarn
-- `expoCli` - version of [expo-cli](https://www.npmjs.com/package/expo-cli) used to [prebuild](../workflow/expo-cli/#expo-prebuild) your app
-- `ndk` - version of Android NDK
-- `env` - environment variables that should be set during the build process (should only be used for values that you would commit to your git repository, i.e. not passwords or secrets).
-- `cache` configures paths that will be saved and restored in the next build. The cache can be explicitly invalidated by updating the value of the `key` field. Values in `customPaths` support both absolute and relative paths, where relative paths are resolved from the directory with `eas.json`. This feature is intended for caching values that require a lot of computation, e.g. compilation results (both final binaries and any intermediate files), but it wouldn't work well for `node_modules` because the cache is not local to the machine, so a download speed is similar to downloading from the npm registry. Set `"disabled": true` to disable caching.
-
-#### Examples
-
-This is the minimal working example. EAS CLI will ask you for the app's credentials, an AAB file will be produced.
-
-```json
-{
-  "workflow": "managed"
-}
-```
-
-If you'd like to build a release APK instead, use the following example:
-
-```json
-{
-  "workflow": "managed",
-  "buildType": "apk"
-}
-```
-
-## iOS
-
-### Generic Project
-
-The schema of a build profile for a generic iOS project looks like this:
-
-```json
-{
-  "workflow": "generic",
-  "extends": string,
-  "credentialsSource": "local" | "remote", // default: "remote"
-  "scheme": string,
-  "schemeBuildConfiguration": string,
-  "artifactPath": string, // default: "ios/build/App.ipa"
-  "releaseChannel": string, // default: "default"
-  "distribution": "store" | "internal" | "simulator", // default: "store"
-  "enterpriseProvisioning": "adhoc" | "universal",
-  "autoIncrement": boolean | "version" | "buildNumber", // default: false
-  "image": string, // default: "default"
-  "node": string,
-  "yarn": string,
-  "bundler": string,
-  "fastlane": string,
-  "cocoapods": string,
-  "env": Record<string, string>,
-  "cache": {
-    "disabled" : boolean, // default: false
-    "key": string,
-    "cacheDefaultPaths": boolean, // default: true
-    "customPaths": string[] // default: []
-  }
-}
-```
-
-- `"workflow": "generic"` indicates that your project is a generic one.
-- `extends` allows extending values from another build profile.
-- `credentialsSource` defines the source of credentials for this build profile. If you want to provide your own `credentials.json` file, set this to `local` ([learn more on this here](/app-signing/local-credentials.md)). If you want to use the credentials managed by EAS, choose `remote` (this is the default option).
-- `scheme` defines the Xcode project's scheme to build. You should set it if your project has multiple schemes. Please note that if the project has only one scheme, it will automatically be detected. However, if multiple schemes exist and this value is **not** set, EAS CLI will prompt you to select one of them.
-- `schemeBuildConfiguration` is the configuration to use when building the app. When set, the native project configuration is overridden with the corresponding value. If left unset, the value set in the scheme is used. For example, `"Debug"` or `"Release"` are common values.
-- `artifactPath` is the path (or pattern) where EAS Build is going to look for the build artifacts. EAS Build uses the `fast-glob` npm package for pattern matching, ([see their README to learn more about the syntax you can use](https://github.com/mrmlnc/fast-glob#pattern-syntax)). You should modify that path only if you are using a custom `Gymfile`. The default is `ios/build/App.ipa`.
-- `releaseChannel` is the release channel for the `expo-updates` package ([Learn more about this](../distribution/release-channels.md)). If you do not specify a channel, your binary will pull releases from the `default` channel. If you do not use `expo-updates` in your project then this property will have no effect.
-- `distribution` is the flow of distributing your app. If you choose `internal` you'll be able to share your build URLs with anyone, and they will be able to install the builds to their devices straight from the Expo website. Choose `simulator` to run the app on an iOS simulator on your computer. The default is `store` which means your build URLs won't be sharable. [Learn more about internal distribution](internal-distribution.md).
-- `enterpriseProvisioning` should only be used with `"distribution": "internal"` when you have an Apple account with Apple Developer Enterprise Program membership. You can choose if you want to use `adhoc` or `universal` provisioning. The latter is recommended as it does not require you to register each individual device. If you don't provide this option and you still authenticate with an enterprise team, you'll be prompted which provisioning to use.
-- `autoIncrement` controls how EAS CLI bumps your application build version. The App Store uses two values from `Info.plist` to identify the app build: `CFBundleShortVersionString` and `CFBundleVersion`. `CFBundleShortVersionString` is the version visible to users, whereas `CFBundleVersion` defines the build number. The combination of those needs to be unique, so you can bump either of them. When set to `version`, the patch of `CFBundleShortVersionString` is bumped (e.g. `1.2.3` -> `1.2.4`). When set to `buildNumber`, the last component of `CFBundleVersion` is bumped (e.g. `1.2.3.39` -> `1.2.3.40`). Versions will also be updated in app.json. `expo.version` corresponds to `CFBundleShortVersionString` and `expo.ios.buildNumber` to `CFBundleVersion`. Defaults to `false` - versions won't be bumped automatically.
-- `image` - image with build environment. [Learn more about it here](../build-reference/infrastructure).
-- `node` - version of Node.js
-- `yarn` - version of Yarn
-- `bundler` - version of [bundler](https://bundler.io/)
-- `fastlane` - version of fastlane
-- `cocoapods` - version of CocoaPods
-- `env` - environment variables that should be set during the build process (should only be used for values that you would commit to your git repository, i.e. not passwords or secrets).
-- `cache` configures paths that will be saved and restored in the next build. The cache can be explicitly invalidated by updating the value of the `key` field. Values in `customPaths` support both absolute and relative paths, where relative paths are resolved from the directory with `eas.json`. If you set `cacheDefaultPaths` to true, or leave the `cache` config unspecified, `Podfile.lock` will be cached by default. This feature is intended for caching values that require a lot of computation, e.g. compilation results (both final binaries and any intermediate files), but it wouldn't work well for `node_modules` because the cache is not local to the machine, so a download speed is similar to downloading from the npm registry. Set `"disabled": true` to disable caching.
-
-#### Examples
-
-This is the minimal working example. EAS CLI will ask you for the app's credentials and you'll be provided with the URL to the `ios/build/App.ipa` file.
-
-```json
-{
-  "workflow": "generic"
-}
-```
-
-If you'd like to build your iOS project with a custom `Gymfile` ([learn more on this here](/build-reference/ios-builds.md#building-ios-projects-with-fastlane)) where you've defined a different output directory than `ios/build`, use the following example:
-
-<!-- prettier-ignore -->
-```json
-{
-  "workflow": "generic",
-  "artifactPath": /* @info determined by output_directory and output_name in Gymfile */ "ios/my/build/directory/RNApp.ipa" /* @end */
-
-}
-```
-
-### Managed Project
-
-The schema of a build profile for a managed iOS project looks like this:
-
-```json
-{
-  "workflow": "managed",
-  "extends": string,
-  "credentialsSource": "local" | "remote", // default: "remote"
-  "buildType": "release" | "development-client", // default: "release"
-  "releaseChannel": string, // default: "default"
-  "distribution": "store" | "internal" | "simulator", // default: "store"
-  "enterpriseProvisioning": "adhoc" | "universal",
-  "autoIncrement": boolean | "version" | "buildNumber", // default: false
-  "image": string, // default: "default"
-  "node": string,
-  "yarn": string,
-  "expoCli": string,
-  "bundler": string,
-  "fastlane": string,
-  "cocoapods": string,
-  "env": Record<string, string>,
-  "cache": {
-    "disabled": boolean, // default: false
-    "key": string,
-    "cacheDefaultPaths": boolean, // default: true
-    "customPaths": string[] // default: []
-  }
-}
-```
-
-- `"workflow": "managed"` indicates that your project is a managed one.
-- `extends` allows extending values from another build profile.
-- `credentialsSource` defines the source of credentials for this build profile. If you want to provide your own `credentials.json` file, set this to `local` ([learn more on this here](/app-signing/local-credentials.md)). If you want to use the credentials managed by EAS, choose `remote` (this is the default option).
-- `buildType` when set to `release` it produces a release archive, but when set to `development-client` it produces a debug archive.
-- `releaseChannel` is the release channel for the `expo-updates` package ([Learn more about this](../distribution/release-channels.md)). If you do not specify a channel, your binary will pull releases from the `default` channel. If you do not use `expo-updates` in your project then this property will have no effect.
-- `distribution` is the flow of distributing your app. If you choose `internal` you'll be able to share your build URLs with anyone, and they will be able to install the builds to their devices straight from the Expo website. Choose `simulator` to run the app on an iOS simulator on your computer. The default is `store` which means your build URLs won't be sharable. [Learn more Internal Distribution](internal-distribution.md).
-- `enterpriseProvisioning` should only be used with `"distribution": "internal"` when you have an Apple account with Apple Developer Enterprise Program membership. You can choose if you want to use `adhoc` or `universal` provisioning. The latter is recommended as it does not require you to register each individual device. If you don't provide this option and you still authenticate with an enterprise team, you'll be prompted which provisioning to use.
-- `autoIncrement` controls how EAS CLI bumps your application build version. When set to `version`, the patch component of `expo.version` is bumped (e.g. `1.2.3` -> `1.2.4`). When set to `buildNumber`, the last component of `expo.ios.buildNumber` is bumped (e.g. `1.2.3.39` -> `1.2.3.40`). Defaults to `false` - versions won't be bumped automatically.
-- `image` - image with build environment. [Learn more about it here](../build-reference/infrastructure).
-- `node` - version of Node.js
-- `yarn` - version of Yarn
-- `expoCli` - version of [expo-cli](https://www.npmjs.com/package/expo-cli) used to [prebuild](../workflow/expo-cli/#expo-prebuild) your app
-- `bundler` - version of [bundler](https://bundler.io/)
-- `fastlane` - version of fastlane
-- `cocoapods` - version of CocoaPods
-- `env` - environment variables that should be set during the build process (should only be used for values that you would commit to your git repository, i.e. not passwords or secrets).
-- `cache` configures paths that will be saved and restored in the next build. The cache can be explicitly invalidated by updating the value of the `key` field. Values in `customPaths` support both absolute and relative paths, where relative paths are resolved from the directory with `eas.json`. If you set `cacheDefaultPaths` to true, or leave the `cache` config unspecified, `Podfile.lock` will be cached by default. This feature is intended for caching values that require a lot of computation, e.g. compilation results (both final binaries and any intermediate files), but it wouldn't work well for `node_modules` because the cache is not local to the machine, so a download speed is similar to downloading from the npm registry. Set `"disabled": true` to disable caching.
-
-#### Examples
-
-This is the minimal working example. EAS CLI will ask you for the app's credentials and you'll be provided with the URL to the `ios/build/App.ipa` file.
-
-```json
-{
-  "workflow": "managed"
-}
-```
-
-## Overall Example
-
-The following example of `eas.json` configures both Android and iOS builds:
+<details>
+  <summary>A managed project with several common profiles</summary>
 
 ```json
 {
   "builds": {
     "android": {
       "base": {
-        "workflow": "generic",
+        "image": "default",
+        "env": {
+          "EXAMPLE_ENV": "example value"
+        }
+      },
+      "release": {
+        "extends": "base",
+        "env": {
+          "ENVIRONMENT": "production"
+        },
+        "buildType": "app-bundle"
+      },
+      "staging": {
+        "extends": "base",
+        "env": {
+          "ENVIRONMENT": "staging"
+        }
+        "distribution": "internal",
+        "buildType": "apk"
+      },
+      "debug": {
+        "extends": "base",
+        "withoutCredentials": true,
+        "env": {
+          "ENVIRONMENT": "staging"
+        },
+        "distribution": "internal",
+        "buildType": "development-client"
+      }
+    },
+    "ios": {
+      "base": {
+        "image": "latest",
+        "node": "12.13.0",
+        "yarn": "1.22.5",
+      },
+      "release": {
+        "extends": "base",
+        "buildType": "release"
+        "env": {
+          "ENVIRONMENT": "production"
+        },
+      },
+      "inhouse": {
+        "extends": "base",
+        "distribution": "internal",
+        "enterpriseProvisioning": "universal",
+        "env": {
+          "ENVIRONMENT": "staging"
+        },
+      }
+      "adhoc": {
+        "extends": "base",
+        "distribution": "internal"
+        "env": {
+          "ENVIRONMENT": "staging"
+        },
+      },
+      "client": {
+        "extends": "adhoc",
+        "buildType": "development-client"
+      }
+    }
+  }
+}
+```
+</details>
+
+<details>
+  <summary>A bare project with several common profiles</summary>
+
+```json
+{
+  "builds": {
+    "android": {
+      "base": {
         "image": "ubuntu-18.04-android-30-ndk-r19c",
         "ndk": "21.4.7075529",
         "env": {
@@ -338,32 +154,71 @@ The following example of `eas.json` configures both Android and iOS builds:
         "extends": "base",
         "env": {
           "ENVIRONMENT": "production"
+        },
+        "gradleCommand": ":app:bundleRelease"
+      },
+      "staging": {
+        "extends": "base",
+        "env": {
+          "ENVIRONMENT": "staging"
         }
+        "distribution": "internal",
+        "gradleCommand": ":app:assembleRelease"
       },
       "debug": {
         "extends": "base",
         "withoutCredentials": true,
-        "gradleCommand": ":app:assembleDebug",
-        "artifactPath": "android/app/build/outputs/apk/debug/app-debug.apk",
         "env": {
           "ENVIRONMENT": "staging"
-        }
+        },
+        "distribution": "internal",
+        "gradleCommand": ":app:assembleDebug",
       }
     },
     "ios": {
-      "release": {
-        "workflow": "generic",
-        "image": "macos-catalina-11.15-xcode-12.1",
+      "base": {
+        "image": "latest",
         "node": "12.13.0",
         "yarn": "1.22.5",
-        "artifactPath": "ios/my/build/directory/RNApp.ipa"
       },
+      "release": {
+        "extends": "base",
+        "schemeBuildConfiguration": "Release",
+        "scheme": "testapp"
+        "env": {
+          "ENVIRONMENT": "production"
+        },
+      },
+      "inhouse": {
+        "extends": "base",
+        "distribution": "internal",
+        "enterpriseProvisioning": "universal",
+        "scheme": "testapp-enterprise"
+        "env": {
+          "ENVIRONMENT": "staging"
+        },
+      }
       "adhoc": {
-        "workflow": "generic",
-        "image": "latest",
+        "extends": "base",
         "distribution": "internal"
+        "scheme": "testapp"
+        "env": {
+          "ENVIRONMENT": "staging"
+        },
       }
     }
   }
 }
 ```
+
+</details>
+
+
+
+## Android
+
+<EasJsonPropertiesTable schema={androidSchema}/>
+
+## iOS
+
+<EasJsonPropertiesTable schema={iosSchema}/>

--- a/docs/pages/build/eas-json.md
+++ b/docs/pages/build/eas-json.md
@@ -84,7 +84,7 @@ where `PLATFORM_NAME` is one of `android` or `ios`.
         "extends": "base",
         "env": {
           "ENVIRONMENT": "staging"
-        }
+        },
         "distribution": "internal",
         "buildType": "apk"
       },
@@ -102,11 +102,11 @@ where `PLATFORM_NAME` is one of `android` or `ios`.
       "base": {
         "image": "latest",
         "node": "12.13.0",
-        "yarn": "1.22.5",
+        "yarn": "1.22.5"
       },
       "release": {
         "extends": "base",
-        "buildType": "release"
+        "buildType": "release",
         "env": {
           "ENVIRONMENT": "production"
         },
@@ -117,14 +117,14 @@ where `PLATFORM_NAME` is one of `android` or `ios`.
         "enterpriseProvisioning": "universal",
         "env": {
           "ENVIRONMENT": "staging"
-        },
-      }
+        }
+      },
       "adhoc": {
         "extends": "base",
-        "distribution": "internal"
+        "distribution": "internal",
         "env": {
           "ENVIRONMENT": "staging"
-        },
+        }
       },
       "client": {
         "extends": "adhoc",
@@ -161,7 +161,7 @@ where `PLATFORM_NAME` is one of `android` or `ios`.
         "extends": "base",
         "env": {
           "ENVIRONMENT": "staging"
-        }
+        },
         "distribution": "internal",
         "gradleCommand": ":app:assembleRelease"
       },
@@ -172,7 +172,7 @@ where `PLATFORM_NAME` is one of `android` or `ios`.
           "ENVIRONMENT": "staging"
         },
         "distribution": "internal",
-        "gradleCommand": ":app:assembleDebug",
+        "gradleCommand": ":app:assembleDebug"
       }
     },
     "ios": {
@@ -184,27 +184,27 @@ where `PLATFORM_NAME` is one of `android` or `ios`.
       "release": {
         "extends": "base",
         "schemeBuildConfiguration": "Release",
-        "scheme": "testapp"
+        "scheme": "testapp",
         "env": {
           "ENVIRONMENT": "production"
-        },
+        }
       },
       "inhouse": {
         "extends": "base",
         "distribution": "internal",
         "enterpriseProvisioning": "universal",
-        "scheme": "testapp-enterprise"
+        "scheme": "testapp-enterprise",
         "env": {
           "ENVIRONMENT": "staging"
-        },
-      }
+        }
+      },
       "adhoc": {
         "extends": "base",
-        "distribution": "internal"
-        "scheme": "testapp"
+        "distribution": "internal",
+        "scheme": "testapp",
         "env": {
           "ENVIRONMENT": "staging"
-        },
+        }
       }
     }
   }

--- a/docs/scripts/schemas/unversioned/eas-json-android-schema.js
+++ b/docs/scripts/schemas/unversioned/eas-json-android-schema.js
@@ -1,0 +1,130 @@
+export default [
+  {
+    name: 'extends',
+    type: 'string',
+    description: [
+      'The name of the build profile that the current one should inherit values from.'
+    ],
+  },
+  {
+    name: 'credentialsSource',
+    enum: ['local', 'remote'],
+    description: [
+      'The source of credentials used to sign build artifacts.',
+      ' - `local` - if you want to provide your own `credentials.json` file. ([learn more on this here](/app-signing/local-credentials)).',
+      ' - `remote` - if you want to use the credentials managed by EAS (this is the default option).'
+    ],
+  },
+  {
+    name: 'releaseChannel',
+    type: 'string',
+    description: [
+      'Name of the release channel for the `expo-updates` package ([Learn more about this](../../distribution/release-channels)). If you do not specify a channel, your binary will pull releases from the `default` channel. If you do not use `expo-updates` in your project then this property will have no effect.',
+    ]
+  },
+  {
+    name: 'distribution',
+    enum: [ 'store', 'internal' ],
+    description: [ 'The method of distributing your app.',
+      '- `internal` - with this option you\'ll be able to share your build URLs with anyone, and they will be able to install the builds to their devices straight from the Expo website. When using `internal`, make sure the build produces an APK file (e.g. `gradleCommand: ":app:assembleRelease"` or `buildType: "apk"` or `"buildType": "development-client"` ). Otherwise, the sharable URL will be useless. [Learn more about internal distribution](../internal-distribution).',
+      ' - `store` - creates builds intended for store upload, your build URLs won\'t be sharable.'
+    ]
+  },
+  {
+    name: 'withoutCredentials',
+    type: 'boolean',
+    description: [
+      "When set to `true`, EAS CLI won't require you to configure credentials when building the app. This comes in handy when you want to build debug binaries and the debug keystore is checked in to the repository. The default is `false`.",
+    ],
+  },
+
+  {
+    name: 'image',
+    type: 'string',
+    description: [
+      'Image with build environment. [Learn more about it here](../../build-reference/infrastructure).',
+    ],
+  },
+  {
+    name: 'node',
+    type: 'string',
+    description: [ 'Version of Node.js.' ],
+  },
+  {
+    name: 'yarn',
+    type: 'string',
+    description: [ 'Version of Yarn.' ],
+  },
+  {
+    name: 'ndk',
+    type: 'string',
+    description: [ 'Version of Android NDK.' ],
+  },
+  {
+    name: 'expoCli',
+    type: 'string',
+    description: [
+      'Version of [expo-cli](https://www.npmjs.com/package/expo-cli) used to [prebuild](../../workflow/expo-cli/#expo-prebuild) your app. It does not affect bare projects.',
+    ],
+  },
+  {
+    name: 'env',
+    type: 'object',
+    description: [
+      'Environment variables that should be set during the build process (should only be used for values that you would commit to your git repository, i.e. not passwords or secrets).',
+    ],
+  },
+  {
+    name: 'cache',
+    type: 'object',
+    description: [
+      'Configuration for caching machanism. This feature is intended for caching values that require a lot of computation, e.g. compilation results (both final binaries and any intermediate files), but it wouldn\'t work well for `node_modules` because the cache is not local to the machine, so a download speed is similar to downloading from the npm registry. '
+    ],
+    properties: [
+      {
+        name: 'disabled',
+        type: 'boolean',
+        description: [ 'Disables caching. Dafults to false.' ],
+      },
+      {
+        name: 'key',
+        type: 'string',
+        description: [ 'Identifies where cache is saved and restored from. The cache can be invalidated by changing this value.' ],
+      },
+      {
+        name: 'customPaths',
+        type: 'array',
+        description: [
+          'List of the paths that will be saved after sucesfull build and restored at the beging of the next one. Both absolute and relative paths are supported, where relative paths are resolved from the directory with `eas.json`.',
+        ]
+      }
+    ]
+  },
+  {
+    name: 'buildType',
+    enum: ['app-bundle', 'apk', 'development-client'],
+    description: [
+      'Type of the artifact you want to build. It controls what Gradle task will be used, can be overridden by `gradleCommand` option.',
+      ' - `app-bundle` - `:app:bundleRelease`',
+      ' - `apk` - `:app:assembleRelease`',
+      ' - `development-client` - `:app:assembleDebug`',
+      '   - for managed project it will build development client',
+      '   - for bare project it will build development client if it\'s configured, otherwise it will be regular debug build',
+    ],
+  },
+  {
+    name: 'gradleCommand',
+    type: 'string',
+    description: [
+      'Gradle task that will be used to build your project, e.g. `:app:assembleDebug` to build a debug binary.',
+      "It's not recommended unless you need to run a task that `buildType` does not support, it will overide `buildType` behaviour if both are specified.",
+    ],
+  },
+  {
+    name: 'artifactPath',
+    type: 'string',
+    description: [
+      'Path (or pattern) where EAS Build is going to look for the build artifacts. EAS Build uses the `fast-glob` npm package for pattern matching ([see their README to learn more about the syntax you can use](https://github.com/mrmlnc/fast-glob#pattern-syntax)). The default value is `android/app/build/outputs/**/*.{apk,aab}`.'
+    ],
+  },
+]

--- a/docs/scripts/schemas/unversioned/eas-json-android-schema.js
+++ b/docs/scripts/schemas/unversioned/eas-json-android-schema.js
@@ -27,7 +27,7 @@ export default [
     enum: [ 'store', 'internal' ],
     description: [ 'The method of distributing your app.',
       '- `internal` - with this option you\'ll be able to share your build URLs with anyone, and they will be able to install the builds to their devices straight from the Expo website. When using `internal`, make sure the build produces an APK file (e.g. `gradleCommand: ":app:assembleRelease"` or `buildType: "apk"` or `"buildType": "development-client"` ). Otherwise, the sharable URL will be useless. [Learn more about internal distribution](../internal-distribution).',
-      ' - `store` - creates builds intended for store upload, your build URLs won\'t be sharable.'
+      ' - `store` - produces builds for store uploads, your build URLs won\'t be sharable.'
     ]
   },
   {
@@ -64,7 +64,7 @@ export default [
     name: 'expoCli',
     type: 'string',
     description: [
-      'Version of [expo-cli](https://www.npmjs.com/package/expo-cli) used to [prebuild](../../workflow/expo-cli/#expo-prebuild) your app. It does not affect bare projects.',
+      'Version of [expo-cli](https://www.npmjs.com/package/expo-cli) used to [prebuild](../../workflow/expo-cli/#expo-prebuild) your app. It does not have any effect for bare projects.',
     ],
   },
   {
@@ -78,24 +78,24 @@ export default [
     name: 'cache',
     type: 'object',
     description: [
-      'Configuration for caching machanism. This feature is intended for caching values that require a lot of computation, e.g. compilation results (both final binaries and any intermediate files), but it wouldn\'t work well for `node_modules` because the cache is not local to the machine, so a download speed is similar to downloading from the npm registry. '
+      'Cache configuration. This feature is intended for caching values that require a lot of computation, e.g. compilation results (both final binaries and any intermediate files), but it wouldn\'t work well for `node_modules` because the cache is not local to the machine, so the download speed is similar to downloading from the npm registry. '
     ],
     properties: [
       {
         name: 'disabled',
         type: 'boolean',
-        description: [ 'Disables caching. Dafults to false.' ],
+        description: [ 'Disables caching. Defaults to false.' ],
       },
       {
         name: 'key',
         type: 'string',
-        description: [ 'Identifies where cache is saved and restored from. The cache can be invalidated by changing this value.' ],
+        description: [ 'Cache key. You can invalidate the cache by changing this value.' ],
       },
       {
         name: 'customPaths',
         type: 'array',
         description: [
-          'List of the paths that will be saved after sucesfull build and restored at the beging of the next one. Both absolute and relative paths are supported, where relative paths are resolved from the directory with `eas.json`.',
+          'List of the paths that will be saved after a successful build and restored at the beginning of the next one. Both absolute and relative paths are supported, where relative paths are resolved from the directory with `eas.json`.',
         ]
       }
     ]
@@ -108,8 +108,8 @@ export default [
       ' - `app-bundle` - `:app:bundleRelease`',
       ' - `apk` - `:app:assembleRelease`',
       ' - `development-client` - `:app:assembleDebug`',
-      '   - for managed project it will build development client',
-      '   - for bare project it will build development client if it\'s configured, otherwise it will be regular debug build',
+      '   - managed project: builds a development client',
+      '   - bare project: builds a development client (if configured)',
     ],
   },
   {
@@ -117,7 +117,7 @@ export default [
     type: 'string',
     description: [
       'Gradle task that will be used to build your project, e.g. `:app:assembleDebug` to build a debug binary.',
-      "It's not recommended unless you need to run a task that `buildType` does not support, it will overide `buildType` behaviour if both are specified.",
+      "It's not recommended unless you need to run a task that `buildType` does not support, it takes priority over `buildType`.",
     ],
   },
   {

--- a/docs/scripts/schemas/unversioned/eas-json-android-schema.js
+++ b/docs/scripts/schemas/unversioned/eas-json-android-schema.js
@@ -64,7 +64,7 @@ export default [
     name: 'expoCli',
     type: 'string',
     description: [
-      'Version of [expo-cli](https://www.npmjs.com/package/expo-cli) used to [prebuild](../../workflow/expo-cli/#expo-prebuild) your app. It does not have any effect for bare projects.',
+      'Version of [expo-cli](https://www.npmjs.com/package/expo-cli) used to [prebuild](../../workflow/expo-cli/#expo-prebuild) your app. It does not have any effect on bare projects.',
     ],
   },
   {

--- a/docs/scripts/schemas/unversioned/eas-json-ios-schema.js
+++ b/docs/scripts/schemas/unversioned/eas-json-ios-schema.js
@@ -1,0 +1,173 @@
+export default [
+  {
+    name: 'extends',
+    type: 'string',
+    description: [
+      'The name of the build profile that the current one should inherit values from.'
+    ],
+  },
+  {
+    name: 'credentialsSource',
+    enum: ['local', 'remote'],
+    description: [
+      'The source of credentials used to sign build artifacts.',
+      ' - `local` - if you want to provide your own `credentials.json` file. ([learn more on this here](/app-signing/local-credentials)).',
+      ' - `remote` - if you want to use the credentials managed by EAS (this is the default option).'
+    ],
+  },
+  {
+    name: 'releaseChannel',
+    type: 'string',
+    description: [
+      'Name of the release channel for the `expo-updates` package ([Learn more about this](../../distribution/release-channels)). If you do not specify a channel, your binary will pull releases from the `default` channel. If you do not use `expo-updates` in your project then this property will have no effect.',
+    ]
+  },
+  {
+    name: 'distribution',
+    enum: [ 'store', 'internal', 'simulator' ],
+    description: [ 'The method of distributing your app.',
+      '- `internal` - with this option you\'ll be able to share your build URLs with anyone, and they will be able to install the builds to their devices straight from the Expo website. [Learn more about internal distribution](../internal-distribution).',
+      ' - `simulator` - creates build for simulator',
+      ' - `store` - creates builds intended for store upload, your build URLs won\'t be sharable.'
+    ]
+  },
+  {
+    name: 'enterpriseProvisioning',
+    enum: [ 'universal', 'adhoc' ],
+    description: [ 'Provisioning method used for `"distribution": "internal"` when you have an Apple account with Apple Developer Enterprise Program membership. You can choose if you want to use `adhoc` or `universal` provisioning. The latter is recommended as it does not require you to register each individual device. If you don\'t provide this option and you still authenticate with an enterprise team, you\'ll be prompted which provisioning method to use.',
+    ]
+  },
+  {
+    name: 'autoIncrement',
+    type: 'boolean | \"version\" | \"buildNumber\"',
+    description: [
+      'Controls how EAS CLI bumps your application build version. Defaults to `false`',
+      ' - `"version"` - the patch of `expo.version` is bumped (e.g. `1.2.3` -> `1.2.4`).',
+      ' - `"buildNumber"` (or `true`) - the last component of `expo.ios.buildNumber` is bumped (e.g. `1.2.3.39` -> `1.2.3.40`).',
+      ' - `false` - versions won\'t be bumped automatically',
+      '',
+      'Versions will also be updated in native code if it\'s a bare project. `expo.version` corresponds to `CFBundleShortVersionString` and `expo.ios.buildNumber` to `CFBundleVersion` in the `Info.plist`. The App Store is using those values to identify the app build, `CFBundleShortVersionString` is the version visible to users, whereas `CFBundleVersion` defines the build number. The combination of those needs to be unique, so you can bump either of them.',
+    ],
+  },
+  {
+    name: 'image',
+    type: 'string',
+    description: [
+      'Image with build environment. [Learn more about it here](../../build-reference/infrastructure).',
+    ],
+  },
+  {
+    name: 'node',
+    type: 'string',
+    description: [ 'Version of Node.js.' ],
+  },
+  {
+    name: 'yarn',
+    type: 'string',
+    description: [ 'Version of Yarn.' ],
+  },
+  {
+    name: 'bundler',
+    type: 'string',
+    description: [ 'Version of [bundler](https://bundler.io/).' ],
+  },
+  {
+    name: 'fastlane',
+    type: 'string',
+    description: [ 'Version of fastlane.' ],
+  },
+  {
+    name: 'cocoapods',
+    type: 'string',
+    description: [ 'Version of CocoaPods.' ],
+  },
+  {
+    name: 'expoCli',
+    type: 'string',
+    description: [
+      'Version of [expo-cli](https://www.npmjs.com/package/expo-cli) used to [prebuild](../../workflow/expo-cli/#expo-prebuild) your app. It does not affect bare projects.',
+    ],
+  },
+  {
+    name: 'env',
+    type: 'object',
+    description: [
+      'Environment variables that should be set during the build process (should only be used for values that you would commit to your git repository, i.e. not passwords or secrets).',
+    ],
+  },
+  {
+    name: 'cache',
+    type: 'object',
+    description: [
+      'Configuration for caching machanism. This feature is intended for caching values that require a lot of computation, e.g. compilation results (both final binaries and any intermediate files), but it wouldn\'t work well for `node_modules` because the cache is not local to the machine, so a download speed is similar to downloading from the npm registry.'
+    ],
+    properties: [
+      {
+        name: 'disabled',
+        type: 'boolean',
+        description: [ 'Disables caching. Dafults to false.' ],
+      },
+      {
+        name: 'key',
+        type: 'string',
+        description: [ 'Identifies where cache is saved and restored from. The cache can be invalidated by changing this value.' ],
+      },
+      {
+        name: 'customPaths',
+        type: 'array',
+        description: [
+          'List of the paths that will be saved after sucesfull build and restored at the beging of the next one. Both absolute and relative paths are supported, where relative paths are resolved from the directory with `eas.json`.',
+        ]
+      },
+      {
+        name: 'cacheDefaultPaths',
+        type: 'boolean',
+        description: [
+          'Specifies whether recommended set of files should be cached, currently only Podfile.lock is included in that list. Defaults to true.',
+        ],
+      }
+    ]
+  },
+  {
+    name: 'buildType',
+    enum: ['release', 'development-client'],
+    description: [
+      'Type of the artifact you want to build. It controls which Xcode Build Configuration will be used, can be overridden by `schemeBuildConfiguration` option.',
+      ' - `release` - `Release`',
+      ' - `development-client` - `Debug`',
+      '   - for managed project it will build development client',
+      '   - for bare project it will build development client if it\'s configured, otherwise it will be a regular debug build',
+    ],
+  },
+  {
+    name: 'scheme',
+    type: 'string',
+    description: [
+      'Xcode project\'s scheme.',
+      ' - managed project have only one scheme and this value should not be defined.',
+      ' - bare project',
+      '   - If your project has multiple schemes, you should set this value.',
+      '   - If the project has only one scheme, it will automatically be detected.',
+      '   - If multiple schemes exist and this value is **not** set, EAS CLI will prompt you to select one of them.',
+
+    ]
+  },
+  {
+    name: 'schemeBuildConfiguration',
+    type: 'string',
+    description: [
+      'Xcode project\'s Build Configuration.',
+      ' - managed projects have only 2 configurations "Debug" and "Release", defaults to "Release"',
+      ' - bare projects defaults to value specified in scheme',
+      '',
+      'it will overide `buildType` behaviour if both are specified.',
+    ],
+  },
+  {
+    name: 'artifactPath',
+    type: 'string',
+    description: [
+      'Path (or pattern) where EAS Build is going to look for the build artifacts. EAS Build uses the `fast-glob` npm package for pattern matching, ([see their README to learn more about the syntax you can use](https://github.com/mrmlnc/fast-glob#pattern-syntax)). You should modify that path only if you are using a custom `Gymfile`. The default is `ios/build/Build/Products/*-iphonesimulator/*.app` when building for simulator and `ios/build/*.ipa` in other cases.'
+    ],
+  },
+]

--- a/docs/scripts/schemas/unversioned/eas-json-ios-schema.js
+++ b/docs/scripts/schemas/unversioned/eas-json-ios-schema.js
@@ -28,7 +28,7 @@ export default [
     description: [ 'The method of distributing your app.',
       '- `internal` - with this option you\'ll be able to share your build URLs with anyone, and they will be able to install the builds to their devices straight from the Expo website. [Learn more about internal distribution](../internal-distribution).',
       ' - `simulator` - creates build for simulator',
-      ' - `store` - creates builds intended for store upload, your build URLs won\'t be sharable.'
+      ' - `store` - produces builds for store uploads, your build URLs won\'t be sharable.'
     ]
   },
   {
@@ -46,7 +46,7 @@ export default [
       ' - `"buildNumber"` (or `true`) - the last component of `expo.ios.buildNumber` is bumped (e.g. `1.2.3.39` -> `1.2.3.40`).',
       ' - `false` - versions won\'t be bumped automatically',
       '',
-      'Versions will also be updated in native code if it\'s a bare project. `expo.version` corresponds to `CFBundleShortVersionString` and `expo.ios.buildNumber` to `CFBundleVersion` in the `Info.plist`. The App Store is using those values to identify the app build, `CFBundleShortVersionString` is the version visible to users, whereas `CFBundleVersion` defines the build number. The combination of those needs to be unique, so you can bump either of them.',
+      'In the case of a bare project, it also updates versions in native code. `expo.version` corresponds to `CFBundleShortVersionString` and `expo.ios.buildNumber` to `CFBundleVersion` in the `Info.plist`. The App Store is using those values to identify the app build, `CFBundleShortVersionString` is the version visible to users, whereas `CFBundleVersion` defines the build number. The combination of those needs to be unique, so you can bump either of them.',
     ],
   },
   {
@@ -85,7 +85,7 @@ export default [
     name: 'expoCli',
     type: 'string',
     description: [
-      'Version of [expo-cli](https://www.npmjs.com/package/expo-cli) used to [prebuild](../../workflow/expo-cli/#expo-prebuild) your app. It does not affect bare projects.',
+      'Version of [expo-cli](https://www.npmjs.com/package/expo-cli) used to [prebuild](../../workflow/expo-cli/#expo-prebuild) your app. It does not have any effect for bare projects.',
     ],
   },
   {
@@ -99,7 +99,7 @@ export default [
     name: 'cache',
     type: 'object',
     description: [
-      'Configuration for caching machanism. This feature is intended for caching values that require a lot of computation, e.g. compilation results (both final binaries and any intermediate files), but it wouldn\'t work well for `node_modules` because the cache is not local to the machine, so a download speed is similar to downloading from the npm registry.'
+      'Cache configuration. This feature is intended for caching values that require a lot of computation, e.g. compilation results (both final binaries and any intermediate files), but it wouldn\'t work well for `node_modules` because the cache is not local to the machine, so the download speed is similar to downloading from the npm registry.'
     ],
     properties: [
       {
@@ -110,20 +110,20 @@ export default [
       {
         name: 'key',
         type: 'string',
-        description: [ 'Identifies where cache is saved and restored from. The cache can be invalidated by changing this value.' ],
+        description: [ 'Cache key. You can invalidate the cache by changing this value.' ],
       },
       {
         name: 'customPaths',
         type: 'array',
         description: [
-          'List of the paths that will be saved after sucesfull build and restored at the beging of the next one. Both absolute and relative paths are supported, where relative paths are resolved from the directory with `eas.json`.',
+          'List of the paths that will be saved after a successful build and restored at the beginning of the next one. Both absolute and relative paths are supported, where relative paths are resolved from the directory with `eas.json`.',
         ]
       },
       {
         name: 'cacheDefaultPaths',
         type: 'boolean',
         description: [
-          'Specifies whether recommended set of files should be cached, currently only Podfile.lock is included in that list. Defaults to true.',
+          'Specifies whether to cache the recommended set of files, currently only Podfile.lock is included in the list. Defaults to true.',
         ],
       }
     ]
@@ -135,8 +135,8 @@ export default [
       'Type of the artifact you want to build. It controls which Xcode Build Configuration will be used, can be overridden by `schemeBuildConfiguration` option.',
       ' - `release` - `Release`',
       ' - `development-client` - `Debug`',
-      '   - for managed project it will build development client',
-      '   - for bare project it will build development client if it\'s configured, otherwise it will be a regular debug build',
+      '   - managed project: builds a development client',
+      '   - bare project: builds a development client (if configured)',
     ],
   },
   {
@@ -144,10 +144,10 @@ export default [
     type: 'string',
     description: [
       'Xcode project\'s scheme.',
-      ' - managed project have only one scheme and this value should not be defined.',
+      ' - managed project: does not have any effect',
       ' - bare project',
       '   - If your project has multiple schemes, you should set this value.',
-      '   - If the project has only one scheme, it will automatically be detected.',
+      '   - If the project has only one scheme, it will be detected automatically.',
       '   - If multiple schemes exist and this value is **not** set, EAS CLI will prompt you to select one of them.',
 
     ]
@@ -157,10 +157,10 @@ export default [
     type: 'string',
     description: [
       'Xcode project\'s Build Configuration.',
-      ' - managed projects have only 2 configurations "Debug" and "Release", defaults to "Release"',
-      ' - bare projects defaults to value specified in scheme',
+      ' - managed project: "Release" or "Debug", defaults to "Release"',
+      ' - bare project: defaults to the value specified in the scheme',
       '',
-      'it will overide `buildType` behaviour if both are specified.',
+      'It takes priority over `buildType`.',
     ],
   },
   {

--- a/docs/scripts/schemas/unversioned/eas-json-ios-schema.js
+++ b/docs/scripts/schemas/unversioned/eas-json-ios-schema.js
@@ -85,7 +85,7 @@ export default [
     name: 'expoCli',
     type: 'string',
     description: [
-      'Version of [expo-cli](https://www.npmjs.com/package/expo-cli) used to [prebuild](../../workflow/expo-cli/#expo-prebuild) your app. It does not have any effect for bare projects.',
+      'Version of [expo-cli](https://www.npmjs.com/package/expo-cli) used to [prebuild](../../workflow/expo-cli/#expo-prebuild) your app. It does not have any effect on bare projects.',
     ],
   },
   {


### PR DESCRIPTION
# Why

docs for unified generic and managed workflow

# How

- only eas.json page (other parts also need to be updated, but I prefer to do that in a separate PR)
- `EasJsonPropertiesTable.tsx` is copy of the class that renders app config (with small changes)

![screencapture-localhost-3002-build-eas-json-2021-07-06-17_16_27](https://user-images.githubusercontent.com/9753141/124625971-8eebdd80-de7e-11eb-8901-5fa2a35eccaf.png)
