### PR TITLE
[ci][ios] fix shell app build break

### DIFF
--- a/.github/workflows/shell-app-ios.yml
+++ b/.github/workflows/shell-app-ios.yml
@@ -35,6 +35,22 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
+      - name: ♻️ Restore workspace node modules
+        uses: actions/cache@v2
+        id: node-modules-cache
+        with:
+          path: |
+            # See "workspaces" → "packages" in the root package.json for the source of truth of
+            # which node_modules are affected by the root yarn.lock
+            node_modules
+            apps/*/node_modules
+            home/node_modules
+            packages/*/node_modules
+            packages/@unimodules/*/node_modules
+            react-native-lab/react-native/node_modules
+          key: ${{ runner.os }}-modules-${{ hashFiles('yarn.lock') }}
+      - name: 🧶 Yarn install
+        run: yarn install --frozen-lockfile
       - name: ♻️ Restore tools/node_modules from cache
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
# Why

iOS shell app build error from https://github.com/expo/expo/commit/79ca9839c299a81a1cbdd8cf3cca4c4461f885be
during `get-app-config-ios.sh` execution, nodejs cannot find the @expo/config module:
expo-constants is in `/Users/runner/work/expo/expo/packages/expo-constants`
shell app workspace is in `/Users/runner/work/expo/expo/shellAppWorkspaces/default`
we did yarn install in shell app workspace but not root workspace (/Users/runner/work/expo/expo).

error log
```
2021-07-07T16:26:53.7889610Z     /bin/sh -c /Users/runner/work/expo/expo/shellAppBase-archive/Build/Intermediates.noindex/ArchiveIntermediates/ExpoKitApp/IntermediateBuildFilesPath/Pods.build/Release-iphoneos/EXConstants.build/Script-271CA36460607FC5EA5776628625C6D2.sh
2021-07-07T16:26:53.7891690Z XXX Debug PROJECT_ROOT: /Users/runner/work/expo/expo/shellAppWorkspaces/default/ios/Pods
2021-07-07T16:26:53.7892410Z XXX Debug DIR_BASENAME: Pods
2021-07-07T16:26:53.7894170Z XXX Debug DEST: /Users/runner/work/expo/expo/shellAppBase-archive/Build/Intermediates.noindex/ArchiveIntermediates/ExpoKitApp/BuildProductsPath/Release-iphoneos/EXConstants/
2021-07-07T16:26:53.7895410Z XXX ls PROJECT_ROOT/..
2021-07-07T16:26:53.7896150Z Build-Phases
2021-07-07T16:26:53.7896550Z ExpoKitApp
2021-07-07T16:26:53.7897010Z ExpoKitApp.xcodeproj
2021-07-07T16:26:53.7897560Z ExpoKitApp.xcworkspace
2021-07-07T16:26:53.7898020Z Podfile
2021-07-07T16:26:53.7898370Z Podfile.lock
2021-07-07T16:26:53.7898730Z Pods
2021-07-07T16:26:53.7899090Z XXX ls PROJECT_ROOT/../..
2021-07-07T16:26:53.7899450Z ios
2021-07-07T16:26:53.7899780Z node_modules
2021-07-07T16:26:53.7900160Z package.json
2021-07-07T16:26:53.7900520Z yarn.lock
2021-07-07T16:26:53.7900890Z XXX ls PROJECT_ROOT/../../..
2021-07-07T16:26:53.7901270Z default
2021-07-07T16:26:53.7902820Z MODULE 12940: looking for "/Users/runner/work/expo/expo/packages/expo-constants/scripts/getAppConfig.js" in ["/Users/runner/.node_modules","/Users/runner/.node_libraries","/usr/local/Cellar/node@14/14.17.1/lib/node"]
2021-07-07T16:26:53.7904620Z MODULE 12940: load "/Users/runner/work/expo/expo/packages/expo-constants/scripts/getAppConfig.js" for module "."
2021-07-07T16:26:53.7905500Z MODULE 12940: Module._load REQUEST @expo/config parent: .
2021-07-07T16:26:53.7908300Z MODULE 12940: looking for "@expo/config" in ["/Users/runner/work/expo/expo/packages/expo-constants/scripts/node_modules","/Users/runner/work/expo/expo/packages/expo-constants/node_modules","/Users/runner/work/expo/expo/packages/node_modules","/Users/runner/work/expo/expo/node_modules","/Users/runner/work/expo/node_modules","/Users/runner/work/node_modules","/Users/runner/node_modules","/Users/node_modules","/node_modules","/Users/runner/.node_modules","/Users/runner/.node_libraries","/usr/local/Cellar/node@14/14.17.1/lib/node"]
2021-07-07T16:26:53.7910340Z internal/modules/cjs/loader.js:905
2021-07-07T16:26:53.7910780Z   throw err;
2021-07-07T16:26:53.7911110Z   ^
2021-07-07T16:26:53.7911310Z 
2021-07-07T16:26:53.7912090Z Error: Cannot find module '@expo/config'
2021-07-07T16:26:53.7912540Z Require stack:
2021-07-07T16:26:53.7913580Z - /Users/runner/work/expo/expo/packages/expo-constants/scripts/getAppConfig.js
2021-07-07T16:26:53.7914510Z     at Function.Module._resolveFilename (internal/modules/cjs/loader.js:902:15)
2021-07-07T16:26:53.7915340Z     at Function.Module._load (internal/modules/cjs/loader.js:746:27)
2021-07-07T16:26:53.7916070Z     at Module.require (internal/modules/cjs/loader.js:974:19)
2021-07-07T16:26:53.7916720Z     at require (internal/modules/cjs/helpers.js:92:18)
2021-07-07T16:26:53.7918010Z     at Object.<anonymous> (/Users/runner/work/expo/expo/packages/expo-constants/scripts/getAppConfig.js:1:23)
2021-07-07T16:26:53.7918900Z     at Module._compile (internal/modules/cjs/loader.js:1085:14)
2021-07-07T16:26:53.7919650Z     at Object.Module._extensions..js (internal/modules/cjs/loader.js:1114:10)
2021-07-07T16:26:53.7920370Z     at Module.load (internal/modules/cjs/loader.js:950:32)
2021-07-07T16:26:53.7921060Z     at Function.Module._load (internal/modules/cjs/loader.js:790:14)
2021-07-07T16:26:53.7921990Z     at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:76:12) {
2021-07-07T16:26:53.7923090Z   code: 'MODULE_NOT_FOUND',
2021-07-07T16:26:53.7923520Z   requireStack: [
2021-07-07T16:26:53.7924570Z     '/Users/runner/work/expo/expo/packages/expo-constants/scripts/getAppConfig.js'
2021-07-07T16:26:53.7925190Z   ]
2021-07-07T16:26:53.7925470Z }
2021-07-07T16:26:53.7926020Z Command PhaseScriptExecution failed with a nonzero exit code
```
# How

Install packages in root workspace, so that expo-constants can find @expo/config module.

# Test Plan

iOS shell build success