### PR TITLE
[ios] Pass manifest into EXScopedFacebook

### DIFF
--- a/ios/Exponent/Versioned/Core/EXVersionManager.mm
+++ b/ios/Exponent/Versioned/Core/EXVersionManager.mm
@@ -366,7 +366,8 @@ RCT_EXTERN void EXRegisterScopedModule(Class, ...);
   EXScopedModuleRegistryAdapter *moduleRegistryAdapter = [[EXScopedModuleRegistryAdapter alloc] initWithModuleRegistryProvider:moduleRegistryProvider];
   EXModuleRegistry *moduleRegistry = [moduleRegistryAdapter moduleRegistryForParams:params
                                                         forExperienceStableLegacyId:self.manifest.stableLegacyId
-                                                                 scopeKey:self.manifest.scopeKey
+                                                                           scopeKey:self.manifest.scopeKey
+                                                                           manifest:self.manifest
                                                                  withKernelServices:services];
   NSArray<id<RCTBridgeModule>> *expoModules = [moduleRegistryAdapter extraModulesForModuleRegistry:moduleRegistry];
   [extraModules addObjectsFromArray:expoModules];

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXFacebook/EXScopedFacebook.h
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXFacebook/EXScopedFacebook.h
@@ -4,10 +4,11 @@
 #import <Foundation/Foundation.h>
 #import <EXFacebook/EXFacebook.h>
 #import <UMCore/UMAppLifecycleListener.h>
+#import <EXUpdates/EXUpdatesRawManifest.h>
 
 @interface EXScopedFacebook : EXFacebook <UMAppLifecycleListener>
 
-- (instancetype)initWithScopeKey:(NSString *)scopeKey andParams:(NSDictionary *)params;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey manifest:(EXUpdatesRawManifest *)manifest;
 
 @end
 #endif

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXFacebook/EXScopedFacebook.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXFacebook/EXScopedFacebook.m
@@ -44,17 +44,17 @@ static NSString *AUTO_INIT_KEY = @"autoInitEnabled";
 
 @implementation EXScopedFacebook : EXFacebook
 
-- (instancetype)initWithScopeKey:(NSString *)scopeKey andParams:(NSDictionary *)params
+- (instancetype)initWithScopeKey:(NSString *)scopeKey manifest:(EXUpdatesRawManifest *)manifest
 {
   if (self = [super init]) {
     NSString *suiteName = [NSString stringWithFormat:@"%@#%@", NSStringFromClass(self.class), scopeKey];
     _settings = [[NSUserDefaults alloc] initWithSuiteName:suiteName];
 
     BOOL hasPreviouslySetAutoInitEnabled = [_settings boolForKey:AUTO_INIT_KEY];
-    BOOL manifestDefinesAutoInitEnabled = [params[@"manifest"][@"facebookAutoInitEnabled"] boolValue];
+    BOOL manifestDefinesAutoInitEnabled = manifest.facebookAutoInitEnabled;
     
     NSString *scopedFacebookAppId = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"FacebookAppID"];
-    NSString *manifestFacebookAppId = params[@"manifest"][@"facebookAppId"];
+    NSString *manifestFacebookAppId = manifest.facebookAppId;
 
     if (hasPreviouslySetAutoInitEnabled || manifestDefinesAutoInitEnabled) {
       // This happens even before the app foregrounds, which mimics

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXScopedModuleRegistryAdapter.h
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXScopedModuleRegistryAdapter.h
@@ -2,12 +2,14 @@
 
 #import <UMReactNativeAdapter/UMModuleRegistryAdapter.h>
 #import <UMCore/UMModuleRegistry.h>
+#import <EXUpdates/EXUpdatesRawManifest.h>
 
 @interface EXScopedModuleRegistryAdapter : UMModuleRegistryAdapter
 
 - (UMModuleRegistry *)moduleRegistryForParams:(NSDictionary *)params
                   forExperienceStableLegacyId:(NSString *)experienceStableLegacyId
-                           scopeKey:(NSString *)scopeKey
+                                     scopeKey:(NSString *)scopeKey
+                                     manifest:(EXUpdatesRawManifest *)manifest
                            withKernelServices:(NSDictionary *)kernelServices;
 
 @end

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXScopedModuleRegistryAdapter.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXScopedModuleRegistryAdapter.m
@@ -39,7 +39,8 @@
 
 - (UMModuleRegistry *)moduleRegistryForParams:(NSDictionary *)params
                   forExperienceStableLegacyId:(NSString *)experienceStableLegacyId
-                           scopeKey:(NSString *)scopeKey
+                                     scopeKey:(NSString *)scopeKey
+                                     manifest:(EXUpdatesRawManifest *)manifest
                            withKernelServices:(NSDictionary *)kernelServices
 {
   UMModuleRegistry *moduleRegistry = [self.moduleRegistryProvider moduleRegistry];
@@ -59,7 +60,7 @@
 #if __has_include(<EXFacebook/EXFacebook.h>)
   // only override in Expo Go
   if ([params[@"constants"][@"appOwnership"] isEqualToString:@"expo"]) {
-    EXScopedFacebook *scopedFacebook = [[EXScopedFacebook alloc] initWithScopeKey:scopeKey andParams:params];
+    EXScopedFacebook *scopedFacebook = [[EXScopedFacebook alloc] initWithScopeKey:scopeKey manifest:manifest];
     [moduleRegistry registerExportedModule:scopedFacebook];
   }
 #endif

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -4034,7 +4034,7 @@ SPEC CHECKSUMS:
   EXCamera: 5a90a462cd0965bbf5e5ddb725115ac5109869e9
   EXCellular: 82f7267f13f296f37434d0031e9a214bbd4b8919
   EXClipboard: c66f7d22ba754496b0fc6b23a2cb9a3e10fa1581
-  EXConstants: abbb7d6af1bab55debdb7ac1b9def07033ca35ee
+  EXConstants: 4c1e78f8711b0991bf5bbd37a574e93e7a44a438
   EXContacts: bc06f42aa1bc7fb5ed0f5b29287f772faa33ad55
   EXCrypto: 46e28f1eb7ec3e2ae5aab652fe1dc4d46bafb386
   EXDevice: 6f1eed02c099f5b382a12a40406c58868892aba6

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/RawManifest/ABI40_0_0EXUpdatesBaseRawManifest.h
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/RawManifest/ABI40_0_0EXUpdatesBaseRawManifest.h
@@ -25,6 +25,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSString *)orientation;
 - (nullable NSDictionary *)experiments;
 - (nullable NSDictionary *)developer;
+- (nullable NSString *)facebookAppId;
+- (nullable NSString *)facebookApplicationName;
+- (BOOL)facebookAutoInitEnabled;
 
 - (BOOL)isDevelopmentMode;
 - (BOOL)isDevelopmentSilentLaunch;

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/RawManifest/ABI40_0_0EXUpdatesBaseRawManifest.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/RawManifest/ABI40_0_0EXUpdatesBaseRawManifest.m
@@ -65,6 +65,19 @@
   return [self.rawManifestJSON nullableDictionaryForKey:@"developer"];
 }
 
+- (nullable NSString *)facebookAppId {
+  return [self.rawManifestJSON nullableStringForKey:@"facebookAppId"];
+}
+
+- (nullable NSString *)facebookApplicationName {
+  return [self.rawManifestJSON nullableStringForKey:@"facebookDisplayName"];
+}
+
+- (BOOL)facebookAutoInitEnabled {
+  NSNumber *enabledNumber = [self.rawManifestJSON nullableNumberForKey:@"facebookAutoInitEnabled"];
+  return enabledNumber != nil && [enabledNumber boolValue];
+}
+
 # pragma mark - Derived Methods
 
 - (BOOL)isDevelopmentMode {

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/RawManifest/ABI40_0_0EXUpdatesRawManifest.h
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/RawManifest/ABI40_0_0EXUpdatesRawManifest.h
@@ -53,6 +53,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSString *)orientation;
 - (nullable NSDictionary *)experiments;
 - (nullable NSDictionary *)developer;
+- (nullable NSString *)facebookAppId;
+- (nullable NSString *)facebookApplicationName;
+- (BOOL)facebookAutoInitEnabled;
 
 # pragma mark - Derived Methods
 

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/ABI40_0_0EXVersionManager.mm
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/ABI40_0_0EXVersionManager.mm
@@ -326,9 +326,10 @@ ABI40_0_0RCT_EXTERN NSDictionary<NSString *, NSDictionary *> *ABI40_0_0EXGetScop
 
   ABI40_0_0EXScopedModuleRegistryAdapter *moduleRegistryAdapter = [[ABI40_0_0EXScopedModuleRegistryAdapter alloc] initWithModuleRegistryProvider:moduleRegistryProvider];
   ABI40_0_0UMModuleRegistry *moduleRegistry = [moduleRegistryAdapter moduleRegistryForParams:params
-                                                        forExperienceStableLegacyId:self.manifest.stableLegacyId
-                                                                 scopeKey:self.manifest.scopeKey
-                                                                 withKernelServices:services];
+                                                                 forExperienceStableLegacyId:self.manifest.stableLegacyId
+                                                                                    scopeKey:self.manifest.scopeKey
+                                                                                    manifest:self.manifest
+                                                                          withKernelServices:services];
   NSArray<id<ABI40_0_0RCTBridgeModule>> *expoModules = [moduleRegistryAdapter extraModulesForModuleRegistry:moduleRegistry];
   [extraModules addObjectsFromArray:expoModules];
 

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/ABI40_0_0EXScopedModuleRegistryAdapter.h
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/ABI40_0_0EXScopedModuleRegistryAdapter.h
@@ -1,12 +1,14 @@
 // Copyright © 2018 650 Industries. All rights reserved.
 
 #import <ABI40_0_0UMReactNativeAdapter/ABI40_0_0UMModuleRegistryAdapter.h>
+#import <ABI40_0_0EXUpdates/ABI40_0_0EXUpdatesRawManifest.h>
 
 @interface ABI40_0_0EXScopedModuleRegistryAdapter : ABI40_0_0UMModuleRegistryAdapter
 
 - (ABI40_0_0UMModuleRegistry *)moduleRegistryForParams:(NSDictionary *)params
-                  forExperienceStableLegacyId:(NSString *)experienceStableLegacyId
-                           scopeKey:(NSString *)scopeKey
-                           withKernelServices:(NSDictionary *)kernelServices;
+                           forExperienceStableLegacyId:(NSString *)experienceStableLegacyId
+                                              scopeKey:(NSString *)scopeKey
+                                              manifest:(ABI40_0_0EXUpdatesRawManifest *)manifest
+                                    withKernelServices:(NSDictionary *)kernelServices;
 
 @end

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/ABI40_0_0EXScopedModuleRegistryAdapter.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/ABI40_0_0EXScopedModuleRegistryAdapter.m
@@ -38,9 +38,10 @@
 @implementation ABI40_0_0EXScopedModuleRegistryAdapter
 
 - (ABI40_0_0UMModuleRegistry *)moduleRegistryForParams:(NSDictionary *)params
-                  forExperienceStableLegacyId:(NSString *)experienceStableLegacyId
-                           scopeKey:(NSString *)scopeKey
-                           withKernelServices:(NSDictionary *)kernelServices
+                           forExperienceStableLegacyId:(NSString *)experienceStableLegacyId
+                                              scopeKey:(NSString *)scopeKey
+                                              manifest:(ABI40_0_0EXUpdatesRawManifest *)manifest
+                                    withKernelServices:(NSDictionary *)kernelServices
 {
   ABI40_0_0UMModuleRegistry *moduleRegistry = [self.moduleRegistryProvider moduleRegistry];
 
@@ -58,7 +59,7 @@
 #if __has_include(<ABI40_0_0EXFacebook/ABI40_0_0EXFacebook.h>)
   // only override in Expo client
   if ([params[@"constants"][@"appOwnership"] isEqualToString:@"expo"]) {
-    ABI40_0_0EXScopedFacebook *scopedFacebook = [[ABI40_0_0EXScopedFacebook alloc] initWithScopeKey:scopeKey andParams:params];
+    ABI40_0_0EXScopedFacebook *scopedFacebook = [[ABI40_0_0EXScopedFacebook alloc] initWithScopeKey:scopeKey manifest:manifest];
     [moduleRegistry registerExportedModule:scopedFacebook];
   }
 #endif

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/EXFacebook/ABI40_0_0EXScopedFacebook.h
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/EXFacebook/ABI40_0_0EXScopedFacebook.h
@@ -5,10 +5,11 @@
 #import <ABI40_0_0EXFacebook/ABI40_0_0EXFacebook.h>
 #import <ABI40_0_0UMCore/ABI40_0_0UMAppLifecycleListener.h>
 #import <ABI40_0_0UMCore/ABI40_0_0UMModuleRegistryConsumer.h>
+#import <ABI40_0_0EXUpdates/ABI40_0_0EXUpdatesRawManifest.h>
 
 @interface ABI40_0_0EXScopedFacebook : ABI40_0_0EXFacebook <ABI40_0_0UMAppLifecycleListener, ABI40_0_0UMModuleRegistryConsumer>
 
-- (instancetype)initWithScopeKey:(NSString *)scopeKey andParams:(NSDictionary *)params;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey manifest:(ABI40_0_0EXUpdatesRawManifest *)manifest;
 
 @end
 #endif

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/EXFacebook/ABI40_0_0EXScopedFacebook.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/EXFacebook/ABI40_0_0EXScopedFacebook.m
@@ -44,17 +44,17 @@ static NSString *AUTO_INIT_KEY = @"autoInitEnabled";
 
 @implementation ABI40_0_0EXScopedFacebook : ABI40_0_0EXFacebook
 
-- (instancetype)initWithScopeKey:(NSString *)scopeKey andParams:(NSDictionary *)params
+- (instancetype)initWithScopeKey:(NSString *)scopeKey manifest:(ABI40_0_0EXUpdatesRawManifest *)manifest
 {
   if (self = [super init]) {
     NSString *suiteName = [NSString stringWithFormat:@"%@#%@", NSStringFromClass(self.class), scopeKey];
     _settings = [[NSUserDefaults alloc] initWithSuiteName:suiteName];
 
     BOOL hasPreviouslySetAutoInitEnabled = [_settings boolForKey:AUTO_INIT_KEY];
-    BOOL manifestDefinesAutoInitEnabled = [params[@"manifest"][@"facebookAutoInitEnabled"] boolValue];
+    BOOL manifestDefinesAutoInitEnabled = manifest.facebookAutoInitEnabled;
 
     NSString *scopedFacebookAppId = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"FacebookAppID"];
-    NSString *manifestFacebookAppId = params[@"manifest"][@"facebookAppId"];
+    NSString *manifestFacebookAppId = manifest.facebookAppId;
 
     if (hasPreviouslySetAutoInitEnabled || manifestDefinesAutoInitEnabled) {
       // This happens even before the app foregrounds, which mimics

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/RawManifest/ABI41_0_0EXUpdatesBaseRawManifest.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/RawManifest/ABI41_0_0EXUpdatesBaseRawManifest.h
@@ -25,6 +25,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSString *)orientation;
 - (nullable NSDictionary *)experiments;
 - (nullable NSDictionary *)developer;
+- (nullable NSString *)facebookAppId;
+- (nullable NSString *)facebookApplicationName;
+- (BOOL)facebookAutoInitEnabled;
 
 - (BOOL)isDevelopmentMode;
 - (BOOL)isDevelopmentSilentLaunch;

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/RawManifest/ABI41_0_0EXUpdatesBaseRawManifest.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/RawManifest/ABI41_0_0EXUpdatesBaseRawManifest.m
@@ -65,6 +65,19 @@
   return [self.rawManifestJSON nullableDictionaryForKey:@"developer"];
 }
 
+- (nullable NSString *)facebookAppId {
+  return [self.rawManifestJSON nullableStringForKey:@"facebookAppId"];
+}
+
+- (nullable NSString *)facebookApplicationName {
+  return [self.rawManifestJSON nullableStringForKey:@"facebookDisplayName"];
+}
+
+- (BOOL)facebookAutoInitEnabled {
+  NSNumber *enabledNumber = [self.rawManifestJSON nullableNumberForKey:@"facebookAutoInitEnabled"];
+  return enabledNumber != nil && [enabledNumber boolValue];
+}
+
 # pragma mark - Derived Methods
 
 - (BOOL)isDevelopmentMode {

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/RawManifest/ABI41_0_0EXUpdatesRawManifest.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/RawManifest/ABI41_0_0EXUpdatesRawManifest.h
@@ -53,6 +53,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSString *)orientation;
 - (nullable NSDictionary *)experiments;
 - (nullable NSDictionary *)developer;
+- (nullable NSString *)facebookAppId;
+- (nullable NSString *)facebookApplicationName;
+- (BOOL)facebookAutoInitEnabled;
 
 # pragma mark - Derived Methods
 

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/ABI41_0_0EXVersionManager.mm
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/ABI41_0_0EXVersionManager.mm
@@ -366,9 +366,10 @@ ABI41_0_0RCT_EXTERN void ABI41_0_0EXRegisterScopedModule(Class, ...);
 
   ABI41_0_0EXScopedModuleRegistryAdapter *moduleRegistryAdapter = [[ABI41_0_0EXScopedModuleRegistryAdapter alloc] initWithModuleRegistryProvider:moduleRegistryProvider];
   ABI41_0_0UMModuleRegistry *moduleRegistry = [moduleRegistryAdapter moduleRegistryForParams:params
-                                                        forExperienceStableLegacyId:self.manifest.stableLegacyId
-                                                                 scopeKey:self.manifest.scopeKey
-                                                                 withKernelServices:services];
+                                                                 forExperienceStableLegacyId:self.manifest.stableLegacyId
+                                                                                    scopeKey:self.manifest.scopeKey
+                                                                                    manifest:self.manifest
+                                                                          withKernelServices:services];
   NSArray<id<ABI41_0_0RCTBridgeModule>> *expoModules = [moduleRegistryAdapter extraModulesForModuleRegistry:moduleRegistry];
   [extraModules addObjectsFromArray:expoModules];
 

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/ABI41_0_0EXScopedModuleRegistryAdapter.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/ABI41_0_0EXScopedModuleRegistryAdapter.h
@@ -1,12 +1,14 @@
 // Copyright © 2018 650 Industries. All rights reserved.
 
 #import <ABI41_0_0UMReactNativeAdapter/ABI41_0_0UMModuleRegistryAdapter.h>
+#import <ABI41_0_0EXUpdates/ABI41_0_0EXUpdatesRawManifest.h>
 
 @interface ABI41_0_0EXScopedModuleRegistryAdapter : ABI41_0_0UMModuleRegistryAdapter
 
 - (ABI41_0_0UMModuleRegistry *)moduleRegistryForParams:(NSDictionary *)params
-                  forExperienceStableLegacyId:(NSString *)experienceStableLegacyId
-                           scopeKey:(NSString *)scopeKey
-                           withKernelServices:(NSDictionary *)kernelServices;
+                           forExperienceStableLegacyId:(NSString *)experienceStableLegacyId
+                                              scopeKey:(NSString *)scopeKey
+                                              manifest:(ABI41_0_0EXUpdatesRawManifest *)manifest
+                                    withKernelServices:(NSDictionary *)kernelServices;
 
 @end

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/ABI41_0_0EXScopedModuleRegistryAdapter.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/ABI41_0_0EXScopedModuleRegistryAdapter.m
@@ -38,9 +38,10 @@
 @implementation ABI41_0_0EXScopedModuleRegistryAdapter
 
 - (ABI41_0_0UMModuleRegistry *)moduleRegistryForParams:(NSDictionary *)params
-                  forExperienceStableLegacyId:(NSString *)experienceStableLegacyId
-                           scopeKey:(NSString *)scopeKey
-                           withKernelServices:(NSDictionary *)kernelServices
+                           forExperienceStableLegacyId:(NSString *)experienceStableLegacyId
+                                              scopeKey:(NSString *)scopeKey
+                                              manifest:(ABI41_0_0EXUpdatesRawManifest *)manifest
+                                    withKernelServices:(NSDictionary *)kernelServices
 {
   ABI41_0_0UMModuleRegistry *moduleRegistry = [self.moduleRegistryProvider moduleRegistry];
 
@@ -58,7 +59,7 @@
 #if __has_include(<ABI41_0_0EXFacebook/ABI41_0_0EXFacebook.h>)
   // only override in Expo Go
   if ([params[@"constants"][@"appOwnership"] isEqualToString:@"expo"]) {
-    ABI41_0_0EXScopedFacebook *scopedFacebook = [[ABI41_0_0EXScopedFacebook alloc] initWithScopeKey:scopeKey andParams:params];
+    ABI41_0_0EXScopedFacebook *scopedFacebook = [[ABI41_0_0EXScopedFacebook alloc] initWithScopeKey:scopeKey manifest:manifest];
     [moduleRegistry registerExportedModule:scopedFacebook];
   }
 #endif

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/EXFacebook/ABI41_0_0EXScopedFacebook.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/EXFacebook/ABI41_0_0EXScopedFacebook.h
@@ -4,10 +4,11 @@
 #import <Foundation/Foundation.h>
 #import <ABI41_0_0EXFacebook/ABI41_0_0EXFacebook.h>
 #import <ABI41_0_0UMCore/ABI41_0_0UMAppLifecycleListener.h>
+#import <ABI41_0_0EXUpdates/ABI41_0_0EXUpdatesRawManifest.h>
 
 @interface ABI41_0_0EXScopedFacebook : ABI41_0_0EXFacebook <ABI41_0_0UMAppLifecycleListener>
 
-- (instancetype)initWithScopeKey:(NSString *)scopeKey andParams:(NSDictionary *)params;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey manifest:(ABI41_0_0EXUpdatesRawManifest *)manifest;
 
 @end
 #endif

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/EXFacebook/ABI41_0_0EXScopedFacebook.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/EXFacebook/ABI41_0_0EXScopedFacebook.m
@@ -44,17 +44,17 @@ static NSString *AUTO_INIT_KEY = @"autoInitEnabled";
 
 @implementation ABI41_0_0EXScopedFacebook : ABI41_0_0EXFacebook
 
-- (instancetype)initWithScopeKey:(NSString *)scopeKey andParams:(NSDictionary *)params
+- (instancetype)initWithScopeKey:(NSString *)scopeKey manifest:(ABI41_0_0EXUpdatesRawManifest *)manifest;
 {
   if (self = [super init]) {
     NSString *suiteName = [NSString stringWithFormat:@"%@#%@", NSStringFromClass(self.class), scopeKey];
     _settings = [[NSUserDefaults alloc] initWithSuiteName:suiteName];
 
     BOOL hasPreviouslySetAutoInitEnabled = [_settings boolForKey:AUTO_INIT_KEY];
-    BOOL manifestDefinesAutoInitEnabled = [params[@"manifest"][@"facebookAutoInitEnabled"] boolValue];
+    BOOL manifestDefinesAutoInitEnabled = manifest.facebookAutoInitEnabled;
 
     NSString *scopedFacebookAppId = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"FacebookAppID"];
-    NSString *manifestFacebookAppId = params[@"manifest"][@"facebookAppId"];
+    NSString *manifestFacebookAppId = manifest.facebookAppId;
 
     if (hasPreviouslySetAutoInitEnabled || manifestDefinesAutoInitEnabled) {
       // This happens even before the app foregrounds, which mimics

--- a/ios/versioned-react-native/ABI42_0_0/Expo/EXUpdates/ABI42_0_0EXUpdates/Update/RawManifest/ABI42_0_0EXUpdatesBaseRawManifest.h
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/EXUpdates/ABI42_0_0EXUpdates/Update/RawManifest/ABI42_0_0EXUpdatesBaseRawManifest.h
@@ -25,6 +25,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSString *)orientation;
 - (nullable NSDictionary *)experiments;
 - (nullable NSDictionary *)developer;
+- (nullable NSString *)facebookAppId;
+- (nullable NSString *)facebookApplicationName;
+- (BOOL)facebookAutoInitEnabled;
 
 - (BOOL)isDevelopmentMode;
 - (BOOL)isDevelopmentSilentLaunch;

--- a/ios/versioned-react-native/ABI42_0_0/Expo/EXUpdates/ABI42_0_0EXUpdates/Update/RawManifest/ABI42_0_0EXUpdatesBaseRawManifest.m
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/EXUpdates/ABI42_0_0EXUpdates/Update/RawManifest/ABI42_0_0EXUpdatesBaseRawManifest.m
@@ -67,6 +67,19 @@
   return [self.rawManifestJSON nullableDictionaryForKey:@"developer"];
 }
 
+- (nullable NSString *)facebookAppId {
+  return [self.rawManifestJSON nullableStringForKey:@"facebookAppId"];
+}
+
+- (nullable NSString *)facebookApplicationName {
+  return [self.rawManifestJSON nullableStringForKey:@"facebookDisplayName"];
+}
+
+- (BOOL)facebookAutoInitEnabled {
+  NSNumber *enabledNumber = [self.rawManifestJSON nullableNumberForKey:@"facebookAutoInitEnabled"];
+  return enabledNumber != nil && [enabledNumber boolValue];
+}
+
 # pragma mark - Derived Methods
 
 - (BOOL)isDevelopmentMode {

--- a/ios/versioned-react-native/ABI42_0_0/Expo/EXUpdates/ABI42_0_0EXUpdates/Update/RawManifest/ABI42_0_0EXUpdatesRawManifest.h
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/EXUpdates/ABI42_0_0EXUpdates/Update/RawManifest/ABI42_0_0EXUpdatesRawManifest.h
@@ -55,6 +55,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSString *)orientation;
 - (nullable NSDictionary *)experiments;
 - (nullable NSDictionary *)developer;
+- (nullable NSString *)facebookAppId;
+- (nullable NSString *)facebookApplicationName;
+- (BOOL)facebookAutoInitEnabled;
 
 # pragma mark - Derived Methods
 

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/ABI42_0_0EXVersionManager.mm
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/ABI42_0_0EXVersionManager.mm
@@ -368,6 +368,7 @@ ABI42_0_0RCT_EXTERN void ABI42_0_0EXRegisterScopedModule(Class, ...);
   ABI42_0_0UMModuleRegistry *moduleRegistry = [moduleRegistryAdapter moduleRegistryForParams:params
                                                                  forExperienceStableLegacyId:self.manifest.stableLegacyId
                                                                                     scopeKey:self.manifest.scopeKey
+                                                                                    manifest:self.manifest
                                                                           withKernelServices:services];
   NSArray<id<ABI42_0_0RCTBridgeModule>> *expoModules = [moduleRegistryAdapter extraModulesForModuleRegistry:moduleRegistry];
   [extraModules addObjectsFromArray:expoModules];

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/ABI42_0_0EXScopedModuleRegistryAdapter.h
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/ABI42_0_0EXScopedModuleRegistryAdapter.h
@@ -1,12 +1,14 @@
 // Copyright © 2018 650 Industries. All rights reserved.
 
 #import <ABI42_0_0UMReactNativeAdapter/ABI42_0_0UMModuleRegistryAdapter.h>
+#import <ABI42_0_0EXUpdates/ABI42_0_0EXUpdatesRawManifest.h>
 
 @interface ABI42_0_0EXScopedModuleRegistryAdapter : ABI42_0_0UMModuleRegistryAdapter
 
 - (ABI42_0_0UMModuleRegistry *)moduleRegistryForParams:(NSDictionary *)params
                            forExperienceStableLegacyId:(NSString *)experienceStableLegacyId
-                                    scopeKey:(NSString *)scopeKey
+                                              scopeKey:(NSString *)scopeKey
+                                              manifest:(ABI42_0_0EXUpdatesRawManifest *)manifest
                                     withKernelServices:(NSDictionary *)kernelServices;
 
 @end

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/ABI42_0_0EXScopedModuleRegistryAdapter.m
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/ABI42_0_0EXScopedModuleRegistryAdapter.m
@@ -39,7 +39,8 @@
 
 - (ABI42_0_0UMModuleRegistry *)moduleRegistryForParams:(NSDictionary *)params
                            forExperienceStableLegacyId:(NSString *)experienceStableLegacyId
-                                    scopeKey:(NSString *)scopeKey
+                                              scopeKey:(NSString *)scopeKey
+                                              manifest:(ABI42_0_0EXUpdatesRawManifest *)manifest
                                     withKernelServices:(NSDictionary *)kernelServices
 {
   ABI42_0_0UMModuleRegistry *moduleRegistry = [self.moduleRegistryProvider moduleRegistry];
@@ -58,7 +59,7 @@
 #if __has_include(<ABI42_0_0EXFacebook/ABI42_0_0EXFacebook.h>)
   // only override in Expo Go
   if ([params[@"constants"][@"appOwnership"] isEqualToString:@"expo"]) {
-    ABI42_0_0EXScopedFacebook *scopedFacebook = [[ABI42_0_0EXScopedFacebook alloc] initWithScopeKey:scopeKey andParams:params];
+    ABI42_0_0EXScopedFacebook *scopedFacebook = [[ABI42_0_0EXScopedFacebook alloc] initWithScopeKey:scopeKey manifest:manifest];
     [moduleRegistry registerExportedModule:scopedFacebook];
   }
 #endif

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/EXFacebook/ABI42_0_0EXScopedFacebook.h
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/EXFacebook/ABI42_0_0EXScopedFacebook.h
@@ -4,10 +4,11 @@
 #import <Foundation/Foundation.h>
 #import <ABI42_0_0EXFacebook/ABI42_0_0EXFacebook.h>
 #import <ABI42_0_0UMCore/ABI42_0_0UMAppLifecycleListener.h>
+#import <ABI42_0_0EXUpdates/ABI42_0_0EXUpdatesRawManifest.h>
 
 @interface ABI42_0_0EXScopedFacebook : ABI42_0_0EXFacebook <ABI42_0_0UMAppLifecycleListener>
 
-- (instancetype)initWithScopeKey:(NSString *)scopeKey andParams:(NSDictionary *)params;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey manifest:(ABI42_0_0EXUpdatesRawManifest *)manifest;
 
 @end
 #endif

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/EXFacebook/ABI42_0_0EXScopedFacebook.m
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/EXFacebook/ABI42_0_0EXScopedFacebook.m
@@ -44,17 +44,17 @@ static NSString *AUTO_INIT_KEY = @"autoInitEnabled";
 
 @implementation ABI42_0_0EXScopedFacebook : ABI42_0_0EXFacebook
 
-- (instancetype)initWithScopeKey:(NSString *)scopeKey andParams:(NSDictionary *)params
+- (instancetype)initWithScopeKey:(NSString *)scopeKey manifest:(ABI42_0_0EXUpdatesRawManifest *)manifest;
 {
   if (self = [super init]) {
     NSString *suiteName = [NSString stringWithFormat:@"%@#%@", NSStringFromClass(self.class), scopeKey];
     _settings = [[NSUserDefaults alloc] initWithSuiteName:suiteName];
 
     BOOL hasPreviouslySetAutoInitEnabled = [_settings boolForKey:AUTO_INIT_KEY];
-    BOOL manifestDefinesAutoInitEnabled = [params[@"manifest"][@"facebookAutoInitEnabled"] boolValue];
+    BOOL manifestDefinesAutoInitEnabled = manifest.facebookAutoInitEnabled;
     
     NSString *scopedFacebookAppId = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"FacebookAppID"];
-    NSString *manifestFacebookAppId = params[@"manifest"][@"facebookAppId"];
+    NSString *manifestFacebookAppId = manifest.facebookAppId;
 
     if (hasPreviouslySetAutoInitEnabled || manifestDefinesAutoInitEnabled) {
       // This happens even before the app foregrounds, which mimics

--- a/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesBaseRawManifest.h
+++ b/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesBaseRawManifest.h
@@ -25,6 +25,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSString *)orientation;
 - (nullable NSDictionary *)experiments;
 - (nullable NSDictionary *)developer;
+- (nullable NSString *)facebookAppId;
+- (nullable NSString *)facebookApplicationName;
+- (BOOL)facebookAutoInitEnabled;
 
 - (BOOL)isDevelopmentMode;
 - (BOOL)isDevelopmentSilentLaunch;

--- a/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesBaseRawManifest.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesBaseRawManifest.m
@@ -67,6 +67,19 @@
   return [self.rawManifestJSON nullableDictionaryForKey:@"developer"];
 }
 
+- (nullable NSString *)facebookAppId {
+  return [self.rawManifestJSON nullableStringForKey:@"facebookAppId"];
+}
+
+- (nullable NSString *)facebookApplicationName {
+  return [self.rawManifestJSON nullableStringForKey:@"facebookDisplayName"];
+}
+
+- (BOOL)facebookAutoInitEnabled {
+  NSNumber *enabledNumber = [self.rawManifestJSON nullableNumberForKey:@"facebookAutoInitEnabled"];
+  return enabledNumber != nil && [enabledNumber boolValue];
+}
+
 # pragma mark - Derived Methods
 
 - (BOOL)isDevelopmentMode {

--- a/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesRawManifest.h
+++ b/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesRawManifest.h
@@ -55,6 +55,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSString *)orientation;
 - (nullable NSDictionary *)experiments;
 - (nullable NSDictionary *)developer;
+- (nullable NSString *)facebookAppId;
+- (nullable NSString *)facebookApplicationName;
+- (BOOL)facebookAutoInitEnabled;
 
 # pragma mark - Derived Methods
 


### PR DESCRIPTION
# Why

This is a follow-up to https://github.com/expo/expo/pull/12631. No code should be accessing the raw manifest since the new manifest formats may have the fields in different paths. This PR fixes one instance of a raw manifest access by the facebook module.

# How

Pass the manifest into the module like we do on android ([link](https://github.com/expo/expo/blob/master/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/host/exp/exponent/modules/universal/ScopedFacebookModule.java#L26)), extract the values directly.

# Test Plan

Build app for simulator.