### PR TITLE
[notifications] Check if icon file exists before removing

### DIFF
--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - Fixed Android notifications not respecting the `shouldPlaySound` property in `setNotificationHandler`. ([#13411](https://github.com/expo/expo/pull/13411) by [@cruzach](https://github.com/cruzach))
 - Force device ID to lowercase before sending to Expo's servers. (Only applicable if you're using `ExpoPushToken`s). ([#13409](https://github.com/expo/expo/pull/13409) by [@cruzach](https://github.com/cruzach))
-- Fixed plugin to not throw if the notification icon isn't set, and there's no notification icon present in the Android project.
+- Fixed plugin to not throw if the notification icon isn't set, and there's no notification icon present in the Android project. ([#13539](https://github.com/expo/expo/pull/13539) by [@cruzach](https://github.com/cruzach))
 
 ### 💡 Others
 

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fixed Android notifications not respecting the `shouldPlaySound` property in `setNotificationHandler`. ([#13411](https://github.com/expo/expo/pull/13411) by [@cruzach](https://github.com/cruzach))
 - Force device ID to lowercase before sending to Expo's servers. (Only applicable if you're using `ExpoPushToken`s). ([#13409](https://github.com/expo/expo/pull/13409) by [@cruzach](https://github.com/cruzach))
+- Fixed plugin to not throw if the notification icon isn't set, and there's no notification icon present in the Android project.
 
 ### 💡 Others
 
@@ -125,9 +126,11 @@ _This version does not introduce any user-facing changes._
 - Changed class responsible for handling Firebase events from `FirebaseMessagingService` to `.service.NotificationsService` on Android. ([#10558](https://github.com/expo/expo/pull/10558) by [@sjchmiela](https://github.com/sjchmiela))
 
   > Note that this change most probably will not affect you — it only affects projects that override `FirebaseMessagingService` to implement some custom handling logic.
+
 - Changed how you can override ways in which a notification is reinterpreted from a [`StatusBarNotification`](https://developer.android.com/reference/android/service/notification/StatusBarNotification) and in which a [`Notification`](https://developer.android.com/reference/android/app/Notification.html?hl=en) is built from defining an `expo.modules.notifications#NotificationsScoper` meta-data value in `AndroidManifest.xml` to implementing a `BroadcastReceiver` subclassing `NotificationsService` delegating those responsibilities to your custom `PresentationDelegate` instance. ([#10558](https://github.com/expo/expo/pull/10558) by [@sjchmiela](https://github.com/sjchmiela))
 
   > Note that this change most probably will not affect you — it only affects projects that override those methods to implement some custom handling logic.
+
 - Removed `removeAllNotificationListeners` method. You can (and should) still remove listeners using `remove` method on `Subscription` objects returned by `addNotification…Listener`. ([#10883](https://github.com/expo/expo/pull/10883) by [@sjchmiela](https://github.com/sjchmiela))
 - Fixed device identifier being used to fetch Expo push token being backed up on Android which resulted in multiple devices having the same `deviceId` (and eventually, Expo push token). ([#11005](https://github.com/expo/expo/pull/11005) by [@sjchmiela](https://github.com/sjchmiela))
 - Fixed device identifier used when fetching Expo push token being different than `Constants.installationId` in managed workflow apps which resulted in different Expo push tokens returned for the same experience across old and new Expo API and the device push token not being automatically updated on Expo push servers which lead to Expo push tokens corresponding to outdated Firebase tokens. ([#11005](https://github.com/expo/expo/pull/11005) by [@sjchmiela](https://github.com/sjchmiela))

--- a/packages/expo-notifications/plugin/build/withNotificationsAndroid.js
+++ b/packages/expo-notifications/plugin/build/withNotificationsAndroid.js
@@ -132,7 +132,10 @@ function removeNotificationIconImageFiles(projectRoot) {
     Object.values(exports.dpiValues).forEach(async ({ folderName }) => {
         const drawableFolderName = folderName.replace('mipmap', 'drawable');
         const dpiFolderPath = path_1.resolve(projectRoot, exports.ANDROID_RES_PATH, drawableFolderName);
-        fs_1.unlinkSync(path_1.resolve(dpiFolderPath, exports.NOTIFICATION_ICON + '.png'));
+        const iconFile = path_1.resolve(dpiFolderPath, exports.NOTIFICATION_ICON + '.png');
+        if (fs_1.existsSync(iconFile)) {
+            fs_1.unlinkSync(iconFile);
+        }
     });
 }
 /**

--- a/packages/expo-notifications/plugin/src/withNotificationsAndroid.ts
+++ b/packages/expo-notifications/plugin/src/withNotificationsAndroid.ts
@@ -181,7 +181,10 @@ function removeNotificationIconImageFiles(projectRoot: string) {
   Object.values(dpiValues).forEach(async ({ folderName }) => {
     const drawableFolderName = folderName.replace('mipmap', 'drawable');
     const dpiFolderPath = resolve(projectRoot, ANDROID_RES_PATH, drawableFolderName);
-    unlinkSync(resolve(dpiFolderPath, NOTIFICATION_ICON + '.png'));
+    const iconFile = resolve(dpiFolderPath, NOTIFICATION_ICON + '.png');
+    if (existsSync(iconFile)) {
+      unlinkSync(iconFile);
+    }
   });
 }
 


### PR DESCRIPTION
# Why

We were removing the icon file even if it didn't exists, causing this error:

```
Config syncing(node:68723) UnhandledPromiseRejectionWarning: Error: ENOENT: no such file or directory, unlink '/Users/charliecruzan/expotests/easmanaged/android/app/src/main/res/drawable-mdpi/notification_icon.png'
    at Object.unlinkSync (fs.js:1210:3)
    at /Users/charliecruzan/expotests/easmanaged/node_modules/expo-notifications/plugin/build/withNotificationsAndroid.js:135:14
    at Array.forEach (<anonymous>)
    at removeNotificationIconImageFiles (/Users/charliecruzan/expotests/easmanaged/node_modules/expo-notifications/plugin/build/withNotificationsAndroid.js:132:38)
    at setNotificationIconAsync (/Users/charliecruzan/expotests/easmanaged/node_modules/expo-notifications/plugin/build/withNotificationsAndroid.js:88:9)
```

# How

checked for file

# Test Plan

added test

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).