### PR TITLE
[docs] Add Google fonts Snack example

### DIFF
--- a/docs/pages/guides/using-custom-fonts.md
+++ b/docs/pages/guides/using-custom-fonts.md
@@ -19,9 +19,13 @@ $ expo install expo-font @expo-google-fonts/inter
 
 After that, you can integrate this in your project by using the `useFonts` hook in the root of your app.
 
+<SnackInline
+label="Google Fonts"
+dependencies={['expo-app-loading', '@expo-google-fonts/inter']}>
+
 ```jsx
 import React from 'react';
-import { Text } from 'react-native';
+import { View, Text } from 'react-native';
 import AppLoading from 'expo-app-loading';
 import { useFonts, Inter_900Black } from '@expo-google-fonts/inter';
 
@@ -32,11 +36,17 @@ export default function App() {
 
   if (!fontsLoaded) {
     return <AppLoading />;
+  } else {
+    return (
+      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+        <Text style={{ fontFamily: 'Inter_900Black', fontSize: 40 }}>Inter Black</Text>
+      </View>
+    );
   }
-
-  return <Text style={{ fontFamily: 'Inter_900Black' }}>Inter Black</Text>;
 }
 ```
+
+</SnackInline>
 
 ## A minimal but complete working example
 


### PR DESCRIPTION
# Why

Add Google fonts Snack example. This PR was added in succesion to fixing Google fonts on web-player.
https://github.com/expo/snack/pull/170
https://github.com/expo/snack/pull/179

**before**

![image](https://user-images.githubusercontent.com/6184593/124942127-a4dad900-e00b-11eb-9cd1-63c1d25d40bd.png)

**after**

![image](https://user-images.githubusercontent.com/6184593/124942289-c63bc500-e00b-11eb-8a87-8962162ca714.png)

# How

- See #why

# Test Plan

- Verified that the Snack works: https://staging.snack.expo.dev/bJqBFqaQ7

