### PR TITLE
[ios] Pass manifest into EXScopedFirebaseCore

### DIFF
--- a/ios/Exponent/Versioned/Core/UniversalModules/EXScopedFirebaseCore.h
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXScopedFirebaseCore.h
@@ -3,13 +3,14 @@
 #if __has_include(<EXFirebaseCore/EXFirebaseCore.h>)
 #import <UIKit/UIKit.h>
 #import <EXFirebaseCore/EXFirebaseCore.h>
+#import <EXUpdates/EXUpdatesRawManifest.h>
 #import "EXConstantsBinding.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface EXScopedFirebaseCore : EXFirebaseCore
 
-- (instancetype)initWithScopeKey:(NSString *)scopeKey andConstantsBinding:(EXConstantsBinding *)constantsBinding;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey manifest:(EXUpdatesRawManifest *)manifest constantsBinding:(EXConstantsBinding *)constantsBinding;
 
 @end
 

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXScopedFirebaseCore.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXScopedFirebaseCore.m
@@ -13,7 +13,7 @@
   NSDictionary* _protectedAppNames;
 }
 
-- (instancetype)initWithScopeKey:(NSString *)scopeKey andConstantsBinding:(EXConstantsBinding *)constantsBinding
+- (instancetype)initWithScopeKey:(NSString *)scopeKey manifest:(EXUpdatesRawManifest *)manifest constantsBinding:(EXConstantsBinding *)constantsBinding
 {
   if (![@"expo" isEqualToString:constantsBinding.appOwnership]) {
     return [super init];
@@ -36,7 +36,7 @@
   // Determine project app name & options
   NSString *encodedScopeKey = [self.class encodedResourceName:scopeKey];
   NSString* appName = [NSString stringWithFormat:@"__sandbox_%@", encodedScopeKey];
-  NSDictionary* googleServicesFile = [self.class googleServicesFileFromConstantsManifest:constantsBinding];
+  NSDictionary* googleServicesFile = [self.class googleServicesFileFromManifest:manifest];
   FIROptions* options = [self.class optionsWithGoogleServicesFile:googleServicesFile];
   
   // Delete all previously created (project) apps, except for the currently
@@ -78,14 +78,11 @@
   return [base64 stringByTrimmingCharactersInSet:[NSCharacterSet characterSetWithCharactersInString:@"="]];
 }
 
-+ (nullable NSDictionary *)googleServicesFileFromConstantsManifest:(nullable id<EXConstantsInterface>)constants
++ (nullable NSDictionary *)googleServicesFileFromManifest:(EXUpdatesRawManifest *)manifest
 {
   // load GoogleService-Info.plist from manifest
   @try {
-    if (constants == nil) return nil;
-    NSDictionary* manifest = constants.constants[@"manifest"];
-    NSDictionary* ios = manifest ? manifest[@"ios"] : nil;
-    NSString* googleServicesFile = ios ? ios[@"googleServicesFile"] : nil;
+    NSString* googleServicesFile = manifest.iosGoogleServicesFile;
     if (!googleServicesFile) return nil;
     NSData *data = [[NSData alloc] initWithBase64EncodedString:googleServicesFile options:0];
     NSError* error;

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXScopedModuleRegistryAdapter.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXScopedModuleRegistryAdapter.m
@@ -145,7 +145,7 @@
 #endif
   
 #if __has_include(<EXFirebaseCore/EXFirebaseCore.h>)
-  EXScopedFirebaseCore *firebaseCoreModule = [[EXScopedFirebaseCore alloc] initWithScopeKey:scopeKey andConstantsBinding:constantsBinding];
+  EXScopedFirebaseCore *firebaseCoreModule = [[EXScopedFirebaseCore alloc] initWithScopeKey:scopeKey manifest:manifest constantsBinding:constantsBinding];
   [moduleRegistry registerExportedModule:firebaseCoreModule];
   [moduleRegistry registerInternalModule:firebaseCoreModule];
 #endif

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/RawManifest/ABI40_0_0EXUpdatesBaseRawManifest.h
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/RawManifest/ABI40_0_0EXUpdatesBaseRawManifest.h
@@ -37,6 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSString *)iosSplashBackgroundColor;
 - (nullable NSString *)iosSplashImageUrl;
 - (nullable NSString *)iosSplashImageResizeMode;
+- (nullable NSString *)iosGoogleServicesFile;
 
 @end
 

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/RawManifest/ABI40_0_0EXUpdatesBaseRawManifest.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/RawManifest/ABI40_0_0EXUpdatesBaseRawManifest.m
@@ -140,6 +140,13 @@
                                        ]];
 }
 
+- (nullable NSString *)iosGoogleServicesFile {
+  if (self.iosConfig) {
+    return [self.iosConfig nullableStringForKey:@"googleServicesFile"];
+  }
+  return nil;
+}
+
 + (NSString * _Nullable)getStringFromManifest:(NSDictionary *)manifest
                                         paths:(NSArray<NSArray<const NSString *> *> *)paths
 {

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/RawManifest/ABI40_0_0EXUpdatesRawManifest.h
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/RawManifest/ABI40_0_0EXUpdatesRawManifest.h
@@ -67,6 +67,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSString *)iosSplashBackgroundColor;
 - (nullable NSString *)iosSplashImageUrl;
 - (nullable NSString *)iosSplashImageResizeMode;
+- (nullable NSString *)iosGoogleServicesFile;
 
 @end
 

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/ABI40_0_0EXScopedFirebaseCore.h
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/ABI40_0_0EXScopedFirebaseCore.h
@@ -3,13 +3,14 @@
 #if __has_include(<ABI40_0_0EXFirebaseCore/ABI40_0_0EXFirebaseCore.h>)
 #import <UIKit/UIKit.h>
 #import <ABI40_0_0EXFirebaseCore/ABI40_0_0EXFirebaseCore.h>
+#import <ABI40_0_0EXUpdates/ABI40_0_0EXUpdatesRawManifest.h>
 #import "ABI40_0_0EXConstantsBinding.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface ABI40_0_0EXScopedFirebaseCore : ABI40_0_0EXFirebaseCore
 
-- (instancetype)initWithScopeKey:(NSString *)scopeKey andConstantsBinding:(ABI40_0_0EXConstantsBinding *)constantsBinding;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey manifest:(ABI40_0_0EXUpdatesRawManifest *)manifest constantsBinding:(ABI40_0_0EXConstantsBinding *)constantsBinding;
 
 @end
 

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/ABI40_0_0EXScopedFirebaseCore.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/ABI40_0_0EXScopedFirebaseCore.m
@@ -12,7 +12,7 @@
   NSDictionary* _protectedAppNames;
 }
 
-- (instancetype)initWithScopeKey:(NSString *)scopeKey andConstantsBinding:(ABI40_0_0EXConstantsBinding *)constantsBinding
+- (instancetype)initWithScopeKey:(NSString *)scopeKey manifest:(ABI40_0_0EXUpdatesRawManifest *)manifest constantsBinding:(ABI40_0_0EXConstantsBinding *)constantsBinding
 {
   if (![@"expo" isEqualToString:constantsBinding.appOwnership]) {
     return [super init];
@@ -35,7 +35,7 @@
   // Determine project app name & options
   NSString *encodedScopeKey = [self.class encodedResourceName:scopeKey];
   NSString* appName = [NSString stringWithFormat:@"__sandbox_%@", encodedScopeKey];
-  NSDictionary* googleServicesFile = [self.class googleServicesFileFromConstantsManifest:constantsBinding];
+  NSDictionary* googleServicesFile = [self.class googleServicesFileFromManifest:manifest];
   FIROptions* options = [self.class optionsWithGoogleServicesFile:googleServicesFile];
 
   // Delete all previously created (project) apps, except for the currently
@@ -77,14 +77,11 @@
   return [base64 stringByTrimmingCharactersInSet:[NSCharacterSet characterSetWithCharactersInString:@"="]];
 }
 
-+ (nullable NSDictionary *)googleServicesFileFromConstantsManifest:(nullable id<ABI40_0_0UMConstantsInterface>)constants
++ (nullable NSDictionary *)googleServicesFileFromManifest:(ABI40_0_0EXUpdatesRawManifest *)manifest
 {
   // load GoogleService-Info.plist from manifest
   @try {
-    if (constants == nil) return nil;
-    NSDictionary* manifest = constants.constants[@"manifest"];
-    NSDictionary* ios = manifest ? manifest[@"ios"] : nil;
-    NSString* googleServicesFile = ios ? ios[@"googleServicesFile"] : nil;
+    NSString* googleServicesFile = manifest.iosGoogleServicesFile;
     if (!googleServicesFile) return nil;
     NSData *data = [[NSData alloc] initWithBase64EncodedString:googleServicesFile options:0];
     NSError* error;

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/ABI40_0_0EXScopedModuleRegistryAdapter.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/UniversalModules/ABI40_0_0EXScopedModuleRegistryAdapter.m
@@ -144,7 +144,7 @@
 #endif
 
 #if __has_include(<ABI40_0_0EXFirebaseCore/ABI40_0_0EXFirebaseCore.h>)
-  ABI40_0_0EXScopedFirebaseCore *firebaseCoreModule = [[ABI40_0_0EXScopedFirebaseCore alloc] initWithScopeKey:scopeKey andConstantsBinding:constantsBinding];
+  ABI40_0_0EXScopedFirebaseCore *firebaseCoreModule = [[ABI40_0_0EXScopedFirebaseCore alloc] initWithScopeKey:scopeKey manifest:manifest constantsBinding:constantsBinding];
   [moduleRegistry registerExportedModule:firebaseCoreModule];
   [moduleRegistry registerInternalModule:firebaseCoreModule];
 #endif

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/RawManifest/ABI41_0_0EXUpdatesBaseRawManifest.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/RawManifest/ABI41_0_0EXUpdatesBaseRawManifest.h
@@ -37,6 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSString *)iosSplashBackgroundColor;
 - (nullable NSString *)iosSplashImageUrl;
 - (nullable NSString *)iosSplashImageResizeMode;
+- (nullable NSString *)iosGoogleServicesFile;
 
 @end
 

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/RawManifest/ABI41_0_0EXUpdatesBaseRawManifest.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/RawManifest/ABI41_0_0EXUpdatesBaseRawManifest.m
@@ -140,6 +140,13 @@
                                        ]];
 }
 
+- (nullable NSString *)iosGoogleServicesFile {
+  if (self.iosConfig) {
+    return [self.iosConfig nullableStringForKey:@"googleServicesFile"];
+  }
+  return nil;
+}
+
 + (NSString * _Nullable)getStringFromManifest:(NSDictionary *)manifest
                                         paths:(NSArray<NSArray<const NSString *> *> *)paths
 {

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/RawManifest/ABI41_0_0EXUpdatesRawManifest.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/RawManifest/ABI41_0_0EXUpdatesRawManifest.h
@@ -67,6 +67,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSString *)iosSplashBackgroundColor;
 - (nullable NSString *)iosSplashImageUrl;
 - (nullable NSString *)iosSplashImageResizeMode;
+- (nullable NSString *)iosGoogleServicesFile;
 
 @end
 

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/ABI41_0_0EXScopedFirebaseCore.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/ABI41_0_0EXScopedFirebaseCore.h
@@ -3,13 +3,14 @@
 #if __has_include(<ABI41_0_0EXFirebaseCore/ABI41_0_0EXFirebaseCore.h>)
 #import <UIKit/UIKit.h>
 #import <ABI41_0_0EXFirebaseCore/ABI41_0_0EXFirebaseCore.h>
+#import <ABI41_0_0EXUpdates/ABI41_0_0EXUpdatesRawManifest.h>
 #import "ABI41_0_0EXConstantsBinding.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface ABI41_0_0EXScopedFirebaseCore : ABI41_0_0EXFirebaseCore
 
-- (instancetype)initWithScopeKey:(NSString *)scopeKey andConstantsBinding:(ABI41_0_0EXConstantsBinding *)constantsBinding;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey manifest:(ABI41_0_0EXUpdatesRawManifest *)manifest constantsBinding:(ABI41_0_0EXConstantsBinding *)constantsBinding;
 
 @end
 

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/ABI41_0_0EXScopedFirebaseCore.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/ABI41_0_0EXScopedFirebaseCore.m
@@ -12,7 +12,7 @@
   NSDictionary* _protectedAppNames;
 }
 
-- (instancetype)initWithScopeKey:(NSString *)scopeKey andConstantsBinding:(ABI41_0_0EXConstantsBinding *)constantsBinding
+- (instancetype)initWithScopeKey:(NSString *)scopeKey manifest:(ABI41_0_0EXUpdatesRawManifest *)manifest constantsBinding:(ABI41_0_0EXConstantsBinding *)constantsBinding;
 {
   if (![@"expo" isEqualToString:constantsBinding.appOwnership]) {
     return [super init];
@@ -35,7 +35,7 @@
   // Determine project app name & options
   NSString *encodedScopeKey = [self.class encodedResourceName:scopeKey];
   NSString* appName = [NSString stringWithFormat:@"__sandbox_%@", encodedScopeKey];
-  NSDictionary* googleServicesFile = [self.class googleServicesFileFromConstantsManifest:constantsBinding];
+  NSDictionary* googleServicesFile = [self.class googleServicesFileFromManifest:manifest];
   FIROptions* options = [self.class optionsWithGoogleServicesFile:googleServicesFile];
 
   // Delete all previously created (project) apps, except for the currently
@@ -77,14 +77,11 @@
   return [base64 stringByTrimmingCharactersInSet:[NSCharacterSet characterSetWithCharactersInString:@"="]];
 }
 
-+ (nullable NSDictionary *)googleServicesFileFromConstantsManifest:(nullable id<ABI41_0_0UMConstantsInterface>)constants
++ (nullable NSDictionary *)googleServicesFileFromManifest:(ABI41_0_0EXUpdatesRawManifest *)manifest
 {
   // load GoogleService-Info.plist from manifest
   @try {
-    if (constants == nil) return nil;
-    NSDictionary* manifest = constants.constants[@"manifest"];
-    NSDictionary* ios = manifest ? manifest[@"ios"] : nil;
-    NSString* googleServicesFile = ios ? ios[@"googleServicesFile"] : nil;
+    NSString* googleServicesFile = manifest.iosGoogleServicesFile;
     if (!googleServicesFile) return nil;
     NSData *data = [[NSData alloc] initWithBase64EncodedString:googleServicesFile options:0];
     NSError* error;

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/ABI41_0_0EXScopedModuleRegistryAdapter.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/ABI41_0_0EXScopedModuleRegistryAdapter.m
@@ -144,7 +144,7 @@
 #endif
 
 #if __has_include(<ABI41_0_0EXFirebaseCore/ABI41_0_0EXFirebaseCore.h>)
-  ABI41_0_0EXScopedFirebaseCore *firebaseCoreModule = [[ABI41_0_0EXScopedFirebaseCore alloc] initWithScopeKey:scopeKey andConstantsBinding:constantsBinding];
+  ABI41_0_0EXScopedFirebaseCore *firebaseCoreModule = [[ABI41_0_0EXScopedFirebaseCore alloc] initWithScopeKey:scopeKey manifest:manifest constantsBinding:constantsBinding];
   [moduleRegistry registerExportedModule:firebaseCoreModule];
   [moduleRegistry registerInternalModule:firebaseCoreModule];
 #endif

--- a/ios/versioned-react-native/ABI42_0_0/Expo/EXUpdates/ABI42_0_0EXUpdates/Update/RawManifest/ABI42_0_0EXUpdatesBaseRawManifest.h
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/EXUpdates/ABI42_0_0EXUpdates/Update/RawManifest/ABI42_0_0EXUpdatesBaseRawManifest.h
@@ -37,6 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSString *)iosSplashBackgroundColor;
 - (nullable NSString *)iosSplashImageUrl;
 - (nullable NSString *)iosSplashImageResizeMode;
+- (nullable NSString *)iosGoogleServicesFile;
 
 @end
 

--- a/ios/versioned-react-native/ABI42_0_0/Expo/EXUpdates/ABI42_0_0EXUpdates/Update/RawManifest/ABI42_0_0EXUpdatesBaseRawManifest.m
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/EXUpdates/ABI42_0_0EXUpdates/Update/RawManifest/ABI42_0_0EXUpdatesBaseRawManifest.m
@@ -142,6 +142,13 @@
                                        ]];
 }
 
+- (nullable NSString *)iosGoogleServicesFile {
+  if (self.iosConfig) {
+    return [self.iosConfig nullableStringForKey:@"googleServicesFile"];
+  }
+  return nil;
+}
+
 + (NSString * _Nullable)getStringFromManifest:(NSDictionary *)manifest
                                         paths:(NSArray<NSArray<const NSString *> *> *)paths
 {

--- a/ios/versioned-react-native/ABI42_0_0/Expo/EXUpdates/ABI42_0_0EXUpdates/Update/RawManifest/ABI42_0_0EXUpdatesRawManifest.h
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/EXUpdates/ABI42_0_0EXUpdates/Update/RawManifest/ABI42_0_0EXUpdatesRawManifest.h
@@ -69,6 +69,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSString *)iosSplashBackgroundColor;
 - (nullable NSString *)iosSplashImageUrl;
 - (nullable NSString *)iosSplashImageResizeMode;
+- (nullable NSString *)iosGoogleServicesFile;
 
 @end
 

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/ABI42_0_0EXScopedFirebaseCore.h
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/ABI42_0_0EXScopedFirebaseCore.h
@@ -3,13 +3,14 @@
 #if __has_include(<ABI42_0_0EXFirebaseCore/ABI42_0_0EXFirebaseCore.h>)
 #import <UIKit/UIKit.h>
 #import <ABI42_0_0EXFirebaseCore/ABI42_0_0EXFirebaseCore.h>
+#import <ABI42_0_0EXUpdates/ABI42_0_0EXUpdatesRawManifest.h>
 #import "ABI42_0_0EXConstantsBinding.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface ABI42_0_0EXScopedFirebaseCore : ABI42_0_0EXFirebaseCore
 
-- (instancetype)initWithScopeKey:(NSString *)scopeKey andConstantsBinding:(ABI42_0_0EXConstantsBinding *)constantsBinding;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey manifest:(ABI42_0_0EXUpdatesRawManifest *)manifest constantsBinding:(ABI42_0_0EXConstantsBinding *)constantsBinding;
 
 @end
 

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/ABI42_0_0EXScopedFirebaseCore.m
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/ABI42_0_0EXScopedFirebaseCore.m
@@ -13,7 +13,7 @@
   NSDictionary* _protectedAppNames;
 }
 
-- (instancetype)initWithScopeKey:(NSString *)scopeKey andConstantsBinding:(ABI42_0_0EXConstantsBinding *)constantsBinding
+- (instancetype)initWithScopeKey:(NSString *)scopeKey manifest:(ABI42_0_0EXUpdatesRawManifest *)manifest constantsBinding:(ABI42_0_0EXConstantsBinding *)constantsBinding
 {
   if (![@"expo" isEqualToString:constantsBinding.appOwnership]) {
     return [super init];
@@ -36,7 +36,7 @@
   // Determine project app name & options
   NSString *encodedScopeKey = [self.class encodedResourceName:scopeKey];
   NSString* appName = [NSString stringWithFormat:@"__sandbox_%@", encodedScopeKey];
-  NSDictionary* googleServicesFile = [self.class googleServicesFileFromConstantsManifest:constantsBinding];
+  NSDictionary* googleServicesFile = [self.class googleServicesFileFromManifest:manifest];
   FIROptions* options = [self.class optionsWithGoogleServicesFile:googleServicesFile];
   
   // Delete all previously created (project) apps, except for the currently
@@ -78,14 +78,11 @@
   return [base64 stringByTrimmingCharactersInSet:[NSCharacterSet characterSetWithCharactersInString:@"="]];
 }
 
-+ (nullable NSDictionary *)googleServicesFileFromConstantsManifest:(nullable id<ABI42_0_0EXConstantsInterface>)constants
++ (nullable NSDictionary *)googleServicesFileFromManifest:(ABI42_0_0EXUpdatesRawManifest *)manifest
 {
   // load GoogleService-Info.plist from manifest
   @try {
-    if (constants == nil) return nil;
-    NSDictionary* manifest = constants.constants[@"manifest"];
-    NSDictionary* ios = manifest ? manifest[@"ios"] : nil;
-    NSString* googleServicesFile = ios ? ios[@"googleServicesFile"] : nil;
+    NSString* googleServicesFile = manifest.iosGoogleServicesFile;
     if (!googleServicesFile) return nil;
     NSData *data = [[NSData alloc] initWithBase64EncodedString:googleServicesFile options:0];
     NSError* error;

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/ABI42_0_0EXScopedModuleRegistryAdapter.m
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/ABI42_0_0EXScopedModuleRegistryAdapter.m
@@ -144,7 +144,7 @@
 #endif
   
 #if __has_include(<ABI42_0_0EXFirebaseCore/ABI42_0_0EXFirebaseCore.h>)
-  ABI42_0_0EXScopedFirebaseCore *firebaseCoreModule = [[ABI42_0_0EXScopedFirebaseCore alloc] initWithScopeKey:scopeKey andConstantsBinding:constantsBinding];
+  ABI42_0_0EXScopedFirebaseCore *firebaseCoreModule = [[ABI42_0_0EXScopedFirebaseCore alloc] initWithScopeKey:scopeKey manifest:manifest constantsBinding:constantsBinding];
   [moduleRegistry registerExportedModule:firebaseCoreModule];
   [moduleRegistry registerInternalModule:firebaseCoreModule];
 #endif

--- a/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesBaseRawManifest.h
+++ b/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesBaseRawManifest.h
@@ -37,6 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSString *)iosSplashBackgroundColor;
 - (nullable NSString *)iosSplashImageUrl;
 - (nullable NSString *)iosSplashImageResizeMode;
+- (nullable NSString *)iosGoogleServicesFile;
 
 @end
 

--- a/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesBaseRawManifest.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesBaseRawManifest.m
@@ -142,6 +142,13 @@
                                        ]];
 }
 
+- (nullable NSString *)iosGoogleServicesFile {
+  if (self.iosConfig) {
+    return [self.iosConfig nullableStringForKey:@"googleServicesFile"];
+  }
+  return nil;
+}
+
 + (NSString * _Nullable)getStringFromManifest:(NSDictionary *)manifest
                                         paths:(NSArray<NSArray<const NSString *> *> *)paths
 {

--- a/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesRawManifest.h
+++ b/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesRawManifest.h
@@ -69,6 +69,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSString *)iosSplashBackgroundColor;
 - (nullable NSString *)iosSplashImageUrl;
 - (nullable NSString *)iosSplashImageResizeMode;
+- (nullable NSString *)iosGoogleServicesFile;
 
 @end
 


### PR DESCRIPTION
# Why

Same as https://github.com/expo/expo/pull/13531 but for EXScopedFirebaseCore. This matches the [android implementation](https://github.com/expo/expo/blob/master/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ScopedFirebaseCoreService.java#L37).

# How

Pass manifest in instead of accessing via constants since that method of access won't work for new manifests.

# Test Plan

Build and run on simulator.