### PR TITLE
[ios] Remove unnecessary constants binding argument from EXScopedNotificationCategoriesModule

### DIFF
--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationCategoriesModule.h
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationCategoriesModule.h
@@ -9,8 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface EXScopedNotificationCategoriesModule : EXNotificationCategoriesModule
 
-- (instancetype)initWithScopeKey:(NSString *)scopeKey
-                       andConstantsBinding:(EXConstantsBinding *)constantsBinding;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey;
 
 + (void)maybeMigrateLegacyCategoryIdentifiersForProjectWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId
                                                                  scopeKey:(NSString *)scopeKey

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationCategoriesModule.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationCategoriesModule.m
@@ -13,7 +13,6 @@
 @implementation EXScopedNotificationCategoriesModule
 
 - (instancetype)initWithScopeKey:(NSString *)scopeKey
-                       andConstantsBinding:(EXConstantsBinding *)constantsBinding
 {
   if (self = [super init]) {
     _scopeKey = scopeKey;

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXScopedModuleRegistryAdapter.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXScopedModuleRegistryAdapter.m
@@ -191,8 +191,7 @@
 #if __has_include(<EXNotifications/EXNotificationCategoriesModule.h>)
   // only override in Expo Go
   if ([params[@"constants"][@"appOwnership"] isEqualToString:@"expo"]) {
-    EXScopedNotificationCategoriesModule *scopedCategoriesModule = [[EXScopedNotificationCategoriesModule alloc] initWithScopeKey:scopeKey
-                                                                                                                        andConstantsBinding:constantsBinding];
+    EXScopedNotificationCategoriesModule *scopedCategoriesModule = [[EXScopedNotificationCategoriesModule alloc] initWithScopeKey:scopeKey];
     [moduleRegistry registerExportedModule:scopedCategoriesModule];
   }
   [EXScopedNotificationCategoriesModule maybeMigrateLegacyCategoryIdentifiersForProjectWithExperienceStableLegacyId:experienceStableLegacyId

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/ABI41_0_0EXScopedModuleRegistryAdapter.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/ABI41_0_0EXScopedModuleRegistryAdapter.m
@@ -189,7 +189,7 @@
 #if __has_include(<ABI41_0_0EXNotifications/ABI41_0_0EXNotificationCategoriesModule.h>)
   // only override in Expo Go
   if ([params[@"constants"][@"appOwnership"] isEqualToString:@"expo"]) {
-    ABI41_0_0EXScopedNotificationCategoriesModule *scopedCategoriesModule = [[ABI41_0_0EXScopedNotificationCategoriesModule alloc] initWithScopeKey:scopeKey andConstantsBinding:constantsBinding];
+    ABI41_0_0EXScopedNotificationCategoriesModule *scopedCategoriesModule = [[ABI41_0_0EXScopedNotificationCategoriesModule alloc] initWithScopeKey:scopeKey];
     [moduleRegistry registerExportedModule:scopedCategoriesModule];
   }
   [ABI41_0_0EXScopedNotificationCategoriesModule maybeMigrateLegacyCategoryIdentifiersForProjectWithExperienceStableLegacyId:experienceStableLegacyId

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI41_0_0EXScopedNotificationCategoriesModule.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI41_0_0EXScopedNotificationCategoriesModule.h
@@ -9,8 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ABI41_0_0EXScopedNotificationCategoriesModule : ABI41_0_0EXNotificationCategoriesModule
 
-- (instancetype)initWithScopeKey:(NSString *)scopeKey
-                 andConstantsBinding:(ABI41_0_0EXConstantsBinding *)constantsBinding;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey;
 
 + (void)maybeMigrateLegacyCategoryIdentifiersForProjectWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId
                                                                  scopeKey:(NSString *)scopeKey

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI41_0_0EXScopedNotificationCategoriesModule.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI41_0_0EXScopedNotificationCategoriesModule.m
@@ -13,7 +13,6 @@
 @implementation ABI41_0_0EXScopedNotificationCategoriesModule
 
 - (instancetype)initWithScopeKey:(NSString *)scopeKey
-                 andConstantsBinding:(ABI41_0_0EXConstantsBinding *)constantsBinding
 {
   if (self = [super init]) {
     _scopeKey = scopeKey;

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/ABI42_0_0EXScopedModuleRegistryAdapter.m
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/ABI42_0_0EXScopedModuleRegistryAdapter.m
@@ -189,7 +189,7 @@
 #if __has_include(<ABI42_0_0EXNotifications/ABI42_0_0EXNotificationCategoriesModule.h>)
   // only override in Expo Go
   if ([params[@"constants"][@"appOwnership"] isEqualToString:@"expo"]) {
-    ABI42_0_0EXScopedNotificationCategoriesModule *scopedCategoriesModule = [[ABI42_0_0EXScopedNotificationCategoriesModule alloc] initWithScopeKey:scopeKey andConstantsBinding:constantsBinding];
+    ABI42_0_0EXScopedNotificationCategoriesModule *scopedCategoriesModule = [[ABI42_0_0EXScopedNotificationCategoriesModule alloc] initWithScopeKey:scopeKey];
     [moduleRegistry registerExportedModule:scopedCategoriesModule];
   }
   [ABI42_0_0EXScopedNotificationCategoriesModule maybeMigrateLegacyCategoryIdentifiersForProjectWithExperienceStableLegacyId:experienceStableLegacyId

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI42_0_0EXScopedNotificationCategoriesModule.h
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI42_0_0EXScopedNotificationCategoriesModule.h
@@ -9,8 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ABI42_0_0EXScopedNotificationCategoriesModule : ABI42_0_0EXNotificationCategoriesModule
 
-- (instancetype)initWithScopeKey:(NSString *)scopeKey
-                 andConstantsBinding:(ABI42_0_0EXConstantsBinding *)constantsBinding;
+- (instancetype)initWithScopeKey:(NSString *)scopeKey;
 
 + (void)maybeMigrateLegacyCategoryIdentifiersForProjectWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId
                                                                            scopeKey:(NSString *)scopeKey

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI42_0_0EXScopedNotificationCategoriesModule.m
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI42_0_0EXScopedNotificationCategoriesModule.m
@@ -13,7 +13,6 @@
 @implementation ABI42_0_0EXScopedNotificationCategoriesModule
 
 - (instancetype)initWithScopeKey:(NSString *)scopeKey
-                 andConstantsBinding:(ABI42_0_0EXConstantsBinding *)constantsBinding
 {
   if (self = [super init]) {
     _scopeKey = scopeKey;


### PR DESCRIPTION
# Why

Noticed that this was unused while doing https://github.com/expo/expo/pull/13543. It should also be removed so that there's less temptation to access the raw JSON manifest directly rather than through the manifest objects.

# How

Remove unused argument.

# Test Plan

Compile.