### PR TITLE
[docs] Fix link to config-plugins from expo-dev-client's Getting Started guide

### DIFF
--- a/docs/pages/clients/getting-started.md
+++ b/docs/pages/clients/getting-started.md
@@ -13,7 +13,7 @@ Of course, there are always tradeoffs, and that flexibility means there's not ju
 
 ## Installing the Development Client module in your project
 
-If you have used Expo before, especially with the Managed workflow, [config plugins](guides/config-plugins.md) will let you customize your project from JavaScript without ever needing to directly modify Xcode or Android Studio projects.
+If you have used Expo before, especially with the Managed workflow, [config plugins](/guides/config-plugins.md) will let you customize your project from JavaScript without ever needing to directly modify Xcode or Android Studio projects.
 
 <Tabs tabs={["✨With config plugins✨", "👷If you are directly managing your native projects👷"]}>
 


### PR DESCRIPTION
Has a broken link here: https://docs.expo.io/clients/getting-started/#installing-the-development-client-module-in-your
