### PR TITLE
[swift] Accessing internal modules from legacy module registry

### DIFF
--- a/packages/expo-modules-core/ios/ModuleRegistry/EXModuleRegistry.h
+++ b/packages/expo-modules-core/ios/ModuleRegistry/EXModuleRegistry.h
@@ -9,7 +9,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-NS_SWIFT_NAME(ModuleRegistry)
 @interface EXModuleRegistry : NSObject
 
 - (instancetype)initWithInternalModules:(NSSet<id<EXInternalModule>> *)internalModules

--- a/packages/expo-modules-core/ios/NativeModulesProxy/EXNativeModulesProxy.m
+++ b/packages/expo-modules-core/ios/NativeModulesProxy/EXNativeModulesProxy.m
@@ -45,7 +45,7 @@ static const NSString *methodInfoArgumentsCountKey = @"argumentsCount";
 {
   if (self = [self initWithModuleRegistry:moduleRegistry]) {
     if ([swiftModulesProviderClass conformsToProtocol:@protocol(ModulesProviderObjCProtocol)]) {
-      _swiftInteropBridge = [[SwiftInteropBridge alloc] initWithModulesProvider:[swiftModulesProviderClass new]];
+      _swiftInteropBridge = [[SwiftInteropBridge alloc] initWithModulesProvider:[swiftModulesProviderClass new] legacyModuleRegistry:_exModuleRegistry];
     }
   }
   return self;

--- a/packages/expo-modules-core/ios/Swift/AppContext.swift
+++ b/packages/expo-modules-core/ios/Swift/AppContext.swift
@@ -1,0 +1,64 @@
+/**
+ The app context is an interface to a single Expo app.
+ */
+public class AppContext {
+  /**
+   The module registry for the app context.
+   */
+  public private(set) lazy var moduleRegistry: ModuleRegistry = ModuleRegistry(appContext: self)
+
+  /**
+   The legacy module registry with modules written in the old-fashioned way.
+   */
+  public let legacyModuleRegistry: EXModuleRegistry?
+
+  /**
+   Initializes the app context and registers provided modules in the module registry.
+   */
+  public init(withModulesProvider provider: ModulesProviderProtocol, legacyModuleRegistry: EXModuleRegistry?) {
+    self.legacyModuleRegistry = legacyModuleRegistry
+    moduleRegistry.register(fromProvider: provider)
+  }
+
+  /**
+   Returns a legacy module implementing given protocol/interface.
+   */
+  public func legacyModule<ModuleProtocol>(implementing moduleProtocol: Protocol) -> ModuleProtocol? {
+    return legacyModuleRegistry?.getModuleImplementingProtocol(moduleProtocol) as? ModuleProtocol
+  }
+
+  /**
+   Provides access to app's constants from legacy module registry.
+   */
+  public var constants: EXConstantsInterface? {
+    return legacyModule(implementing: EXConstantsInterface.self)
+  }
+
+  /**
+   Provides access to the file system manager from legacy module registry.
+   */
+  public var fileSystem: EXFileSystemInterface? {
+    return legacyModule(implementing: EXFileSystemInterface.self)
+  }
+
+  /**
+   Provides access to the permissions manager from legacy module registry.
+   */
+  public var permissions: EXPermissionsInterface? {
+    return legacyModule(implementing: EXPermissionsInterface.self)
+  }
+
+  /**
+   Provides access to the image loader from legacy module registry.
+   */
+  public var imageLoader: EXImageLoaderInterface? {
+    return legacyModule(implementing: EXImageLoaderInterface.self)
+  }
+
+  /**
+   Provides access to the utilities from legacy module registry.
+   */
+  public var utilities: EXUtilitiesInterface? {
+    return legacyModule(implementing: EXUtilitiesInterface.self)
+  }
+}

--- a/packages/expo-modules-core/ios/Swift/ModuleRegistry.swift
+++ b/packages/expo-modules-core/ios/Swift/ModuleRegistry.swift
@@ -1,16 +1,34 @@
 
 public class ModuleRegistry: Sequence {
+  public typealias Element = ModuleHolder
+
+  private weak var appContext: AppContext?
+
   private var registry: [String: ModuleHolder] = [:]
 
-  init(withProvider provider: ModulesProviderProtocol) {
-    provider.exportedModules().forEach { moduleType in
-      register(module: moduleType.init())
-    }
+  init(appContext: AppContext) {
+    self.appContext = appContext
   }
 
+  /**
+   Registers a single module in the registry.
+   */
   public func register(module: AnyModule) {
     let holder = ModuleHolder(module: module)
     registry[holder.name] = holder
+  }
+
+  /**
+   Registers modules exported by given modules provider.
+   */
+  public func register(fromProvider provider: ModulesProviderProtocol) {
+    guard let appContext = appContext else {
+      // TODO: (@tsapeta) App context is deallocated, throw an error?
+      return
+    }
+    provider.exportedModules().forEach { moduleType in
+      register(module: moduleType.init(appContext: appContext))
+    }
   }
 
   public func has(moduleWithName moduleName: String) -> Bool {

--- a/packages/expo-modules-core/ios/Swift/Modules/AnyModule.swift
+++ b/packages/expo-modules-core/ios/Swift/Modules/AnyModule.swift
@@ -7,7 +7,7 @@ public protocol AnyModule: AnyObject {
    The default initializer. Must be public, but the module class does *not* need to
    define it as it is implemented in protocol composition, see `BaseModule` class.
    */
-  init()
+  init(appContext: AppContext)
 
   /**
    A DSL-like function that returns a `ModuleDefinition` which can be built up from module's name, constants or methods.

--- a/packages/expo-modules-core/ios/Swift/Modules/Module.swift
+++ b/packages/expo-modules-core/ios/Swift/Modules/Module.swift
@@ -5,7 +5,11 @@
  other modules to use `override` keyword in the function returning the definition.
  */
 open class BaseModule {
-  required public init() {}
+  public private(set) weak var appContext: AppContext?
+
+  required public init(appContext: AppContext) {
+    self.appContext = appContext
+  }
 }
 
 /**

--- a/packages/expo-modules-core/ios/Swift/SwiftInteropBridge.swift
+++ b/packages/expo-modules-core/ios/Swift/SwiftInteropBridge.swift
@@ -3,11 +3,15 @@ import Foundation
 
 @objc
 public class SwiftInteropBridge: NSObject {
-  let registry: ModuleRegistry
+  let appContext: AppContext
+
+  var registry: ModuleRegistry {
+    appContext.moduleRegistry
+  }
 
   @objc
-  public init(modulesProvider: ModulesProviderObjCProtocol) {
-    self.registry = ModuleRegistry(withProvider: modulesProvider as! ModulesProviderProtocol)
+  public init(modulesProvider: ModulesProviderObjCProtocol, legacyModuleRegistry: EXModuleRegistry) {
+    self.appContext = AppContext(withModulesProvider: modulesProvider as! ModulesProviderProtocol, legacyModuleRegistry: legacyModuleRegistry)
     super.init()
   }
 


### PR DESCRIPTION
# Why

Most of the native modules depend on some internal modules like file system or permissions. To rewrite such modules to Swift, we must be able to access these internal modules.

# How

- Created `AppContext` that will be the entry point for all informations corresponding to the app within which the module is instantiated
- Added `legacyModule(implementing:)` method to access any internal module registered in the legacy registry
- **Expo**sed convenient getters for the most common internal modules

# Test Plan

Expo Go compiles, the internal modules seem to be accessible from swifty modules.
