### PR TITLE
Update deprecated Amplitude initialize

### DIFF
--- a/home/api/Analytics.ts
+++ b/home/api/Analytics.ts
@@ -46,9 +46,9 @@ export function track(event: string, options?: TrackingOptions): void {
   if (!canUseAmplitude) return;
 
   if (properties) {
-    Amplitude.logEventWithProperties(event, properties);
+    Amplitude.logEventWithPropertiesAsync(event, properties);
   } else {
-    Amplitude.logEvent(event);
+    Amplitude.logEventAsync(event);
   }
 }
 

--- a/home/api/Analytics.ts
+++ b/home/api/Analytics.ts
@@ -20,7 +20,7 @@ export function initialize(): void {
     return;
   }
 
-  Amplitude.initialize(apiKey);
+  Amplitude.initializeAsync(apiKey);
   isInitialized = true;
 }
 


### PR DESCRIPTION
# Why
<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->
I'm updating after seeing this function is outdated on SDK 42. When I was reading the docs and trying examples I saw that this is deprecated on typescript.

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->
Updating `Amplitude.initialize(apiKey)` with `Amplitude.initializeAsync(apiKey)` like on [docs](https://docs.expo.io/versions/latest/sdk/amplitude/#amplitudeinitializeasyncapikey).

# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->

I not tested it yet, if I see something different I will return here.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).