### PR TITLE
[expo-updates] remove side effect from UpdatesDevLauncherController.initialize()

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 - Improve behavior of dev client (with updates integration) when developer is logged out of expo-cli. ([#13310](https://github.com/expo/expo/pull/13310) by [@esamelson](https://github.com/esamelson))
 - Remove usage of deprecated `[RCTBridge reload]` method. ([#13501](https://github.com/expo/expo/pull/13501) by [@esamelson](https://github.com/esamelson))
-- Remove side effects from UpdatesDevLauncherController.initialize() method.
+- Remove side effects from UpdatesDevLauncherController.initialize() method. ([#13555](https://github.com/expo/expo/pull/13555) by [@esamelson](https://github.com/esamelson))
 
 ### 💡 Others
 

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Improve behavior of dev client (with updates integration) when developer is logged out of expo-cli. ([#13310](https://github.com/expo/expo/pull/13310) by [@esamelson](https://github.com/esamelson))
 - Remove usage of deprecated `[RCTBridge reload]` method. ([#13501](https://github.com/expo/expo/pull/13501) by [@esamelson](https://github.com/esamelson))
+- Remove side effects from UpdatesDevLauncherController.initialize() method.
 
 ### 💡 Others
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.java
@@ -35,7 +35,6 @@ public class UpdatesDevLauncherController implements UpdatesInterface {
       sInstance = new UpdatesDevLauncherController();
     }
     UpdatesController.initializeWithoutStarting(context);
-    setDevelopmentSelectionPolicy();
     return getInstance();
   }
 
@@ -70,6 +69,8 @@ public class UpdatesDevLauncherController implements UpdatesInterface {
       callback.onFailure(controller.getUpdatesDirectoryException());
       return;
     }
+
+    setDevelopmentSelectionPolicy();
 
     DatabaseHolder databaseHolder = controller.getDatabaseHolder();
     RemoteLoader loader = new RemoteLoader(context, updatesConfiguration, databaseHolder.getDatabase(), controller.getFileDownloader(), controller.getUpdatesDirectory());


### PR DESCRIPTION
# Why

Realized that with the current dev client config plugin / integration steps, we currently initialize the UpdatesDevLauncherController in both debug and release builds. Since the `setDevelopmentSelectionPolicy` step was happening as a side effect in the `initialize` method, this is erroneously being set in release builds currently. (Not a huge deal in practice, it just means more old updates are cached on disk at a time, but good to fix anyhow.)

# How

Moved `setDevelopmentSelectionPolicy` to a different method, which is only called when the caller has actually indicated it wants to use UpdatesDevLauncherController to load an update. This matches the behavior/callsite of the analogous method on iOS.

# Test Plan

Added `Log.d("eric", selectionPolicy.getReaperSelectionPolicy().getClass().getSimpleName());` to the reaper. Built a project with the dev client integration installed in both debug (& used it to open a published project) and release mode, and ensured that `ReaperSelectionPolicyDevelopmentClient` was logged in the debug build and `ReaperSelectionPolicyFilterAware` in the release build.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).