### PR TITLE
[docs] Readded babel plugins note to be listed last

### DIFF
--- a/docs/pages/versions/unversioned/sdk/reanimated.md
+++ b/docs/pages/versions/unversioned/sdk/reanimated.md
@@ -25,6 +25,7 @@ module.exports = function(api) {
   };
 };
 ```
+> Note: If you load other Babel plugins, the Reanimated plugin has to be the last item in the plugins array.
 
 > 🚨 **The new APIs in `react-native-reanimated@2` use React Native APIs that are incompatible with Remote JS Debugging**. Consequently, you can only debug apps using these APIs using Flipper, which is not yet available in the Expo managed workflow. **You will be unable to use Remote JS Debugging if you use the new APIs from Reanimated 2**. Remote JS Debugging will continue to work if you only use the APIs that were also available in Reanimated 1.
 

--- a/docs/pages/versions/v42.0.0/sdk/reanimated.md
+++ b/docs/pages/versions/v42.0.0/sdk/reanimated.md
@@ -25,6 +25,7 @@ module.exports = function(api) {
   };
 };
 ```
+> Note: If you load other Babel plugins, the Reanimated plugin has to be the last item in the plugins array.
 
 > 🚨 **The new APIs in `react-native-reanimated@2` use React Native APIs that are incompatible with Remote JS Debugging**. Consequently, you can only debug apps using these APIs using Flipper, which is not yet available in the Expo managed workflow. **You will be unable to use Remote JS Debugging if you use the new APIs from Reanimated 2**. Remote JS Debugging will continue to work if you only use the APIs that were also available in Reanimated 1.
 


### PR DESCRIPTION
# Why

Reanimated documentation still have a warning  `Reanimated plugin has to be listed last.`

[Reanimated babel plugin doc](https://docs.swmansion.com/react-native-reanimated/docs/installation#babel-plugin)

# How

Only docs

# Test Plan

Only docs

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).