### PR TITLE
[unimodules][android] changed preBuild.dependsOn with quotes

### DIFF
--- a/packages/@unimodules/react-native-adapter/CHANGELOG.md
+++ b/packages/@unimodules/react-native-adapter/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Changed generateExpoModulesPackageList for preBuild.dependsOn with quotes in build.gradle. ([#13568](https://github.com/expo/expo/pull/13568) by [@wbroek](https://github.com/wbroek))
+
 ### 💡 Others
 
 ## 6.4.0 — 2021-07-05

--- a/packages/@unimodules/react-native-adapter/android/build.gradle
+++ b/packages/@unimodules/react-native-adapter/android/build.gradle
@@ -56,7 +56,7 @@ task generateExpoModulesPackageList {
 }
 
 // Run that task during prebuilding phase.
-preBuild.dependsOn generateExpoModulesPackageList
+preBuild.dependsOn "generateExpoModulesPackageList"
 
 android {
   compileSdkVersion safeExtGet("compileSdkVersion", 30)


### PR DESCRIPTION
# Why

This fixes https://github.com/expo/expo/issues/13168 where when combining clean and build in one command for Android the task/function `generateExpoModulesPackageList` was not called

# How

Because the value of preBuild.dependsOn had no quotes the function was invoked immediately and not handled as a task which Gradle could lookup and execute when needed.
Setting the value of preBuild.dependsOn in quotes fixes that and the task is invoked and mentioned in before the `:unimodules-react-native-adapter:preBuild` task as it should,
 
# Test Plan

Build the `bare-expo` with `./gradlew clean assembleRelease`
Without this change it will fail and the task `:unimodules-react-native-adapter:generateExpoModulesPackageList` will not be visible in the logs
```
expo/packages/@unimodules/react-native-adapter/android/src/main/java/org/unimodules/adapters/react/ModuleRegistryAdapter.java:26: error: cannot find symbol
    mModuleRegistryProvider = new ReactModuleRegistryProvider(new ExpoModulesPackageList().getPackageList(), null);
                                                                  ^
  symbol:   class ExpoModulesPackageList
  location: class ModuleRegistryAdapter
1 error
```

With the change build will be successful

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).