### PR TITLE
[android] Fix autolinking node command

### DIFF
--- a/packages/@unimodules/react-native-adapter/scripts/autolinking.gradle
+++ b/packages/@unimodules/react-native-adapter/scripts/autolinking.gradle
@@ -94,7 +94,7 @@ class ExpoAutolinkingManager {
     String[] args = [
       'node',
       '--eval',
-      'require(\'expo-modules-autolinking\')(process.argv.slice(1))',
+      '"require(\'expo-modules-autolinking\')(process.argv.slice(1))"',
       '--',
       command,
       '--platform',


### PR DESCRIPTION
# Why

Issue is explained here https://github.com/expo/expo/issues/13580

# How

Added double quotes in parameter when exec node command.

# Test Plan

https://github.com/expo/expo/issues/13580

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).