### PR TITLE
[ios] Update NewManifest field paths for new extra field format

### DIFF
--- a/ios/Exponent/Kernel/Views/EXAppViewController.m
+++ b/ios/Exponent/Kernel/Views/EXAppViewController.m
@@ -734,7 +734,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSString * _Nullable)_readBackgroundColorFromManifest:(EXUpdatesRawManifest *)manifest
 {
-  return manifest.androidOrRootBackroundColor;
+  return manifest.iosOrRootBackroundColor;
 }
 
 

--- a/ios/Exponent/Kernel/Views/EXAppViewController.m
+++ b/ios/Exponent/Kernel/Views/EXAppViewController.m
@@ -734,7 +734,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSString * _Nullable)_readBackgroundColorFromManifest:(EXUpdatesRawManifest *)manifest
 {
-  return manifest.iosOrRootBackroundColor;
+  return manifest.iosOrRootBackgroundColor;
 }
 
 

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/RawManifest/ABI40_0_0EXUpdatesBaseLegacyRawManifest.h
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/RawManifest/ABI40_0_0EXUpdatesBaseLegacyRawManifest.h
@@ -6,6 +6,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ABI40_0_0EXUpdatesBaseLegacyRawManifest : ABI40_0_0EXUpdatesBaseRawManifest
 
+- (nullable NSDictionary *)expoGoConfigRootObject;
+- (nullable NSDictionary *)expoClientConfigRootObject;
+
 - (NSString *)stableLegacyId;
 - (NSString *)scopeKey;
 - (nullable NSString *)projectId;

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/RawManifest/ABI40_0_0EXUpdatesBaseLegacyRawManifest.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/RawManifest/ABI40_0_0EXUpdatesBaseLegacyRawManifest.m
@@ -5,6 +5,14 @@
 
 @implementation ABI40_0_0EXUpdatesBaseLegacyRawManifest
 
+- (nullable NSDictionary *)expoClientConfigRootObject {
+  return self.rawManifestJSON;
+}
+
+- (nullable NSDictionary *)expoGoConfigRootObject {
+  return self.rawManifestJSON;
+}
+
 - (NSString *)stableLegacyId {
   NSString *originalFullName = [self.rawManifestJSON nullableStringForKey:@"originalFullName"];
   if (originalFullName) {

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/RawManifest/ABI40_0_0EXUpdatesBaseRawManifest.h
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/RawManifest/ABI40_0_0EXUpdatesBaseRawManifest.h
@@ -33,11 +33,14 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)isDevelopmentSilentLaunch;
 - (BOOL)isUsingDeveloperTool;
 - (nullable NSString *)userInterfaceStyle;
-- (nullable NSString *)androidOrRootBackroundColor;
+- (nullable NSString *)iosOrRootBackroundColor;
 - (nullable NSString *)iosSplashBackgroundColor;
 - (nullable NSString *)iosSplashImageUrl;
 - (nullable NSString *)iosSplashImageResizeMode;
 - (nullable NSString *)iosGoogleServicesFile;
+
+- (nullable NSDictionary *)expoGoConfigRootObject;
+- (nullable NSDictionary *)expoClientConfigRootObject;
 
 @end
 

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/RawManifest/ABI40_0_0EXUpdatesBaseRawManifest.h
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/RawManifest/ABI40_0_0EXUpdatesBaseRawManifest.h
@@ -33,7 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)isDevelopmentSilentLaunch;
 - (BOOL)isUsingDeveloperTool;
 - (nullable NSString *)userInterfaceStyle;
-- (nullable NSString *)iosOrRootBackroundColor;
+- (nullable NSString *)iosOrRootBackgroundColor;
 - (nullable NSString *)iosSplashBackgroundColor;
 - (nullable NSString *)iosSplashImageUrl;
 - (nullable NSString *)iosSplashImageResizeMode;

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/RawManifest/ABI40_0_0EXUpdatesBaseRawManifest.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/RawManifest/ABI40_0_0EXUpdatesBaseRawManifest.m
@@ -22,71 +22,135 @@
 }
 
 - (nullable NSString *)revisionId {
-  return [self.rawManifestJSON nullableStringForKey:@"revisionId"];
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [expoClientConfig nullableStringForKey:@"revisionId"];
 }
 
 - (nullable NSString *)slug {
-  return [self.rawManifestJSON nullableStringForKey:@"slug"];
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [expoClientConfig nullableStringForKey:@"slug"];
 }
 
 - (nullable NSString *)appKey {
-  return [self.rawManifestJSON nullableStringForKey:@"appKey"];
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [expoClientConfig nullableStringForKey:@"appKey"];
 }
 
 - (nullable NSString *)name {
-  return [self.rawManifestJSON nullableStringForKey:@"name"];
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [expoClientConfig nullableStringForKey:@"name"];
 }
 
 - (nullable NSDictionary *)notificationPreferences {
-  return [self.rawManifestJSON nullableDictionaryForKey:@"notification"];
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [expoClientConfig nullableDictionaryForKey:@"notification"];
 }
 
 - (nullable NSDictionary *)updatesInfo {
-  return [self.rawManifestJSON nullableDictionaryForKey:@"updates"];
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [expoClientConfig nullableDictionaryForKey:@"updates"];
 }
 
 - (nullable NSDictionary *)iosConfig {
-  return [self.rawManifestJSON nullableDictionaryForKey:@"ios"];
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [expoClientConfig nullableDictionaryForKey:@"ios"];
 }
 
 - (nullable NSString *)hostUri {
-  return [self.rawManifestJSON nullableStringForKey:@"hostUri"];
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [expoClientConfig nullableStringForKey:@"hostUri"];
 }
 
 - (nullable NSString *)orientation {
-  return [self.rawManifestJSON nullableStringForKey:@"orientation"];
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [expoClientConfig nullableStringForKey:@"orientation"];
 }
 
 - (nullable NSDictionary *)experiments {
-  return [self.rawManifestJSON nullableDictionaryForKey:@"experiments"];
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [expoClientConfig nullableDictionaryForKey:@"experiments"];
 }
 
 - (nullable NSDictionary *)developer {
-  return [self.rawManifestJSON nullableDictionaryForKey:@"developer"];
+  NSDictionary *expoGoConfig = self.expoGoConfigRootObject;
+  if (!expoGoConfig) {
+    return nil;
+  }
+  return [expoGoConfig nullableDictionaryForKey:@"developer"];
 }
 
 - (nullable NSString *)facebookAppId {
-  return [self.rawManifestJSON nullableStringForKey:@"facebookAppId"];
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [expoClientConfig nullableStringForKey:@"facebookAppId"];
 }
 
 - (nullable NSString *)facebookApplicationName {
-  return [self.rawManifestJSON nullableStringForKey:@"facebookDisplayName"];
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [expoClientConfig nullableStringForKey:@"facebookDisplayName"];
 }
 
 - (BOOL)facebookAutoInitEnabled {
-  NSNumber *enabledNumber = [self.rawManifestJSON nullableNumberForKey:@"facebookAutoInitEnabled"];
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  NSNumber *enabledNumber = [expoClientConfig nullableNumberForKey:@"facebookAutoInitEnabled"];
   return enabledNumber != nil && [enabledNumber boolValue];
 }
 
 # pragma mark - Derived Methods
 
 - (BOOL)isDevelopmentMode {
-  NSDictionary *manifestPackagerOptsConfig = [self.rawManifestJSON nullableDictionaryForKey:@"packagerOpts"];
+  NSDictionary *expoGoConfig = self.expoGoConfigRootObject;
+  if (!expoGoConfig) {
+    return nil;
+  }
+  NSDictionary *manifestPackagerOptsConfig = [expoGoConfig nullableDictionaryForKey:@"packagerOpts"];
   return (self.developer != nil && manifestPackagerOptsConfig != nil && [@(YES) isEqualToNumber:manifestPackagerOptsConfig[@"dev"]]);
 }
 
 - (BOOL)isDevelopmentSilentLaunch {
-  NSDictionary *developmentClientSettings = self.rawManifestJSON[@"developmentClient"];
+  NSDictionary *expoGoConfig = self.expoGoConfigRootObject;
+  if (!expoGoConfig) {
+    return nil;
+  }
+  NSDictionary *developmentClientSettings = expoGoConfig[@"developmentClient"];
   if (developmentClientSettings && [developmentClientSettings isKindOfClass:[NSDictionary class]]) {
     id silentLaunch = developmentClientSettings[@"silentLaunch"];
     return silentLaunch && [@(YES) isEqual:silentLaunch];
@@ -103,18 +167,30 @@
   if (self.iosConfig && [self.iosConfig nullableStringForKey:@"userInterfaceStyle"]) {
     return [self.iosConfig nullableStringForKey:@"userInterfaceStyle"];
   }
-  return [self.rawManifestJSON nullableStringForKey:@"userInterfaceStyle"];
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [expoClientConfig nullableStringForKey:@"userInterfaceStyle"];
 }
 
-- (nullable NSString *)androidOrRootBackroundColor {
+- (nullable NSString *)iosOrRootBackroundColor {
   if (self.iosConfig && [self.iosConfig nullableStringForKey:@"backgroundColor"]) {
     return [self.iosConfig nullableStringForKey:@"backgroundColor"];
   }
-  return [self.rawManifestJSON nullableStringForKey:@"backgroundColor"];
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [expoClientConfig nullableStringForKey:@"backgroundColor"];
 }
 
 - (nullable NSString *)iosSplashBackgroundColor {
-  return [[self class] getStringFromManifest:self.rawManifestJSON
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [[self class] getStringFromManifest:expoClientConfig
                                        paths:@[
                                          @[@"ios", @"splash", @"backgroundColor"],
                                          @[@"splash", @"backgroundColor"],
@@ -122,7 +198,11 @@
 }
 
 - (nullable NSString *)iosSplashImageUrl {
-  return [[self class] getStringFromManifest:self.rawManifestJSON
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [[self class] getStringFromManifest:expoClientConfig
                                        paths:@[
                                          [UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPad
                                          ? @[@"ios", @"splash", @"tabletImageUrl"]
@@ -133,7 +213,11 @@
 }
 
 - (nullable NSString *)iosSplashImageResizeMode {
-  return [[self class] getStringFromManifest:self.rawManifestJSON
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [[self class] getStringFromManifest:expoClientConfig
                                        paths:@[
                                          @[@"ios", @"splash", @"resizeMode"],
                                          @[@"splash", @"resizeMode"],
@@ -145,6 +229,18 @@
     return [self.iosConfig nullableStringForKey:@"googleServicesFile"];
   }
   return nil;
+}
+
+- (nullable NSDictionary *)expoClientConfigRootObject {
+  @throw [NSException exceptionWithName:NSInternalInconsistencyException
+                                 reason:[NSString stringWithFormat:@"You must override %@ in a subclass", NSStringFromSelector(_cmd)]
+                               userInfo:nil];
+}
+
+- (nullable NSDictionary *)expoGoConfigRootObject {
+  @throw [NSException exceptionWithName:NSInternalInconsistencyException
+                                 reason:[NSString stringWithFormat:@"You must override %@ in a subclass", NSStringFromSelector(_cmd)]
+                               userInfo:nil];
 }
 
 + (NSString * _Nullable)getStringFromManifest:(NSDictionary *)manifest

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/RawManifest/ABI40_0_0EXUpdatesBaseRawManifest.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/RawManifest/ABI40_0_0EXUpdatesBaseRawManifest.m
@@ -174,7 +174,7 @@
   return [expoClientConfig nullableStringForKey:@"userInterfaceStyle"];
 }
 
-- (nullable NSString *)iosOrRootBackroundColor {
+- (nullable NSString *)iosOrRootBackgroundColor {
   if (self.iosConfig && [self.iosConfig nullableStringForKey:@"backgroundColor"]) {
     return [self.iosConfig nullableStringForKey:@"backgroundColor"];
   }

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/RawManifest/ABI40_0_0EXUpdatesNewRawManifest.h
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/RawManifest/ABI40_0_0EXUpdatesNewRawManifest.h
@@ -32,6 +32,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSDictionary *)launchAsset;
 - (nullable NSArray *)assets;
 
+- (nullable NSDictionary *)expoGoConfigRootObject;
+- (nullable NSDictionary *)expoClientConfigRootObject;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/RawManifest/ABI40_0_0EXUpdatesNewRawManifest.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/RawManifest/ABI40_0_0EXUpdatesNewRawManifest.m
@@ -57,4 +57,22 @@
   return [self.launchAsset stringForKey:@"url"];
 }
 
+- (nullable NSDictionary *)extra {
+  return [self.rawManifestJSON nullableDictionaryForKey:@"extra"];
+}
+
+- (nullable NSDictionary *)expoClientConfigRootObject {
+  if (!self.extra) {
+    return nil;
+  }
+  return [self.extra nullableDictionaryForKey:@"expoClient"];
+}
+
+- (nullable NSDictionary *)expoGoConfigRootObject {
+  if (!self.extra) {
+    return nil;
+  }
+  return [self.extra nullableDictionaryForKey:@"expoGo"];
+}
+
 @end

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/RawManifest/ABI40_0_0EXUpdatesRawManifest.h
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/RawManifest/ABI40_0_0EXUpdatesRawManifest.h
@@ -63,7 +63,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)isDevelopmentSilentLaunch;
 - (BOOL)isUsingDeveloperTool;
 - (nullable NSString *)userInterfaceStyle;
-- (nullable NSString *)iosOrRootBackroundColor;
+- (nullable NSString *)iosOrRootBackgroundColor;
 - (nullable NSString *)iosSplashBackgroundColor;
 - (nullable NSString *)iosSplashImageUrl;
 - (nullable NSString *)iosSplashImageResizeMode;

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/RawManifest/ABI40_0_0EXUpdatesRawManifest.h
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/RawManifest/ABI40_0_0EXUpdatesRawManifest.h
@@ -63,11 +63,16 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)isDevelopmentSilentLaunch;
 - (BOOL)isUsingDeveloperTool;
 - (nullable NSString *)userInterfaceStyle;
-- (nullable NSString *)androidOrRootBackroundColor;
+- (nullable NSString *)iosOrRootBackroundColor;
 - (nullable NSString *)iosSplashBackgroundColor;
 - (nullable NSString *)iosSplashImageUrl;
 - (nullable NSString *)iosSplashImageResizeMode;
 - (nullable NSString *)iosGoogleServicesFile;
+
+# pragma mark - helper methods
+
+- (nullable NSDictionary *)expoGoConfigRootObject;
+- (nullable NSDictionary *)expoClientConfigRootObject;
 
 @end
 

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/RawManifest/ABI41_0_0EXUpdatesBaseLegacyRawManifest.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/RawManifest/ABI41_0_0EXUpdatesBaseLegacyRawManifest.h
@@ -6,6 +6,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ABI41_0_0EXUpdatesBaseLegacyRawManifest : ABI41_0_0EXUpdatesBaseRawManifest
 
+- (nullable NSDictionary *)expoGoConfigRootObject;
+- (nullable NSDictionary *)expoClientConfigRootObject;
+
 - (NSString *)stableLegacyId;
 - (NSString *)scopeKey;
 - (nullable NSString *)projectId;

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/RawManifest/ABI41_0_0EXUpdatesBaseLegacyRawManifest.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/RawManifest/ABI41_0_0EXUpdatesBaseLegacyRawManifest.m
@@ -5,6 +5,14 @@
 
 @implementation ABI41_0_0EXUpdatesBaseLegacyRawManifest
 
+- (nullable NSDictionary *)expoClientConfigRootObject {
+  return self.rawManifestJSON;
+}
+
+- (nullable NSDictionary *)expoGoConfigRootObject {
+  return self.rawManifestJSON;
+}
+
 - (NSString *)stableLegacyId {
   NSString *originalFullName = [self.rawManifestJSON nullableStringForKey:@"originalFullName"];
   if (originalFullName) {

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/RawManifest/ABI41_0_0EXUpdatesBaseRawManifest.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/RawManifest/ABI41_0_0EXUpdatesBaseRawManifest.h
@@ -33,11 +33,14 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)isDevelopmentSilentLaunch;
 - (BOOL)isUsingDeveloperTool;
 - (nullable NSString *)userInterfaceStyle;
-- (nullable NSString *)androidOrRootBackroundColor;
+- (nullable NSString *)iosOrRootBackroundColor;
 - (nullable NSString *)iosSplashBackgroundColor;
 - (nullable NSString *)iosSplashImageUrl;
 - (nullable NSString *)iosSplashImageResizeMode;
 - (nullable NSString *)iosGoogleServicesFile;
+
+- (nullable NSDictionary *)expoGoConfigRootObject;
+- (nullable NSDictionary *)expoClientConfigRootObject;
 
 @end
 

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/RawManifest/ABI41_0_0EXUpdatesBaseRawManifest.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/RawManifest/ABI41_0_0EXUpdatesBaseRawManifest.h
@@ -33,7 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)isDevelopmentSilentLaunch;
 - (BOOL)isUsingDeveloperTool;
 - (nullable NSString *)userInterfaceStyle;
-- (nullable NSString *)iosOrRootBackroundColor;
+- (nullable NSString *)iosOrRootBackgroundColor;
 - (nullable NSString *)iosSplashBackgroundColor;
 - (nullable NSString *)iosSplashImageUrl;
 - (nullable NSString *)iosSplashImageResizeMode;

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/RawManifest/ABI41_0_0EXUpdatesBaseRawManifest.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/RawManifest/ABI41_0_0EXUpdatesBaseRawManifest.m
@@ -22,71 +22,135 @@
 }
 
 - (nullable NSString *)revisionId {
-  return [self.rawManifestJSON nullableStringForKey:@"revisionId"];
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [expoClientConfig nullableStringForKey:@"revisionId"];
 }
 
 - (nullable NSString *)slug {
-  return [self.rawManifestJSON nullableStringForKey:@"slug"];
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [expoClientConfig nullableStringForKey:@"slug"];
 }
 
 - (nullable NSString *)appKey {
-  return [self.rawManifestJSON nullableStringForKey:@"appKey"];
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [expoClientConfig nullableStringForKey:@"appKey"];
 }
 
 - (nullable NSString *)name {
-  return [self.rawManifestJSON nullableStringForKey:@"name"];
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [expoClientConfig nullableStringForKey:@"name"];
 }
 
 - (nullable NSDictionary *)notificationPreferences {
-  return [self.rawManifestJSON nullableDictionaryForKey:@"notification"];
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [expoClientConfig nullableDictionaryForKey:@"notification"];
 }
 
 - (nullable NSDictionary *)updatesInfo {
-  return [self.rawManifestJSON nullableDictionaryForKey:@"updates"];
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [expoClientConfig nullableDictionaryForKey:@"updates"];
 }
 
 - (nullable NSDictionary *)iosConfig {
-  return [self.rawManifestJSON nullableDictionaryForKey:@"ios"];
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [expoClientConfig nullableDictionaryForKey:@"ios"];
 }
 
 - (nullable NSString *)hostUri {
-  return [self.rawManifestJSON nullableStringForKey:@"hostUri"];
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [expoClientConfig nullableStringForKey:@"hostUri"];
 }
 
 - (nullable NSString *)orientation {
-  return [self.rawManifestJSON nullableStringForKey:@"orientation"];
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [expoClientConfig nullableStringForKey:@"orientation"];
 }
 
 - (nullable NSDictionary *)experiments {
-  return [self.rawManifestJSON nullableDictionaryForKey:@"experiments"];
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [expoClientConfig nullableDictionaryForKey:@"experiments"];
 }
 
 - (nullable NSDictionary *)developer {
-  return [self.rawManifestJSON nullableDictionaryForKey:@"developer"];
+  NSDictionary *expoGoConfig = self.expoGoConfigRootObject;
+  if (!expoGoConfig) {
+    return nil;
+  }
+  return [expoGoConfig nullableDictionaryForKey:@"developer"];
 }
 
 - (nullable NSString *)facebookAppId {
-  return [self.rawManifestJSON nullableStringForKey:@"facebookAppId"];
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [expoClientConfig nullableStringForKey:@"facebookAppId"];
 }
 
 - (nullable NSString *)facebookApplicationName {
-  return [self.rawManifestJSON nullableStringForKey:@"facebookDisplayName"];
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [expoClientConfig nullableStringForKey:@"facebookDisplayName"];
 }
 
 - (BOOL)facebookAutoInitEnabled {
-  NSNumber *enabledNumber = [self.rawManifestJSON nullableNumberForKey:@"facebookAutoInitEnabled"];
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  NSNumber *enabledNumber = [expoClientConfig nullableNumberForKey:@"facebookAutoInitEnabled"];
   return enabledNumber != nil && [enabledNumber boolValue];
 }
 
 # pragma mark - Derived Methods
 
 - (BOOL)isDevelopmentMode {
-  NSDictionary *manifestPackagerOptsConfig = [self.rawManifestJSON nullableDictionaryForKey:@"packagerOpts"];
+  NSDictionary *expoGoConfig = self.expoGoConfigRootObject;
+  if (!expoGoConfig) {
+    return nil;
+  }
+  NSDictionary *manifestPackagerOptsConfig = [expoGoConfig nullableDictionaryForKey:@"packagerOpts"];
   return (self.developer != nil && manifestPackagerOptsConfig != nil && [@(YES) isEqualToNumber:manifestPackagerOptsConfig[@"dev"]]);
 }
 
 - (BOOL)isDevelopmentSilentLaunch {
-  NSDictionary *developmentClientSettings = self.rawManifestJSON[@"developmentClient"];
+  NSDictionary *expoGoConfig = self.expoGoConfigRootObject;
+  if (!expoGoConfig) {
+    return nil;
+  }
+  NSDictionary *developmentClientSettings = expoGoConfig[@"developmentClient"];
   if (developmentClientSettings && [developmentClientSettings isKindOfClass:[NSDictionary class]]) {
     id silentLaunch = developmentClientSettings[@"silentLaunch"];
     return silentLaunch && [@(YES) isEqual:silentLaunch];
@@ -103,18 +167,30 @@
   if (self.iosConfig && [self.iosConfig nullableStringForKey:@"userInterfaceStyle"]) {
     return [self.iosConfig nullableStringForKey:@"userInterfaceStyle"];
   }
-  return [self.rawManifestJSON nullableStringForKey:@"userInterfaceStyle"];
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [expoClientConfig nullableStringForKey:@"userInterfaceStyle"];
 }
 
-- (nullable NSString *)androidOrRootBackroundColor {
+- (nullable NSString *)iosOrRootBackroundColor {
   if (self.iosConfig && [self.iosConfig nullableStringForKey:@"backgroundColor"]) {
     return [self.iosConfig nullableStringForKey:@"backgroundColor"];
   }
-  return [self.rawManifestJSON nullableStringForKey:@"backgroundColor"];
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [expoClientConfig nullableStringForKey:@"backgroundColor"];
 }
 
 - (nullable NSString *)iosSplashBackgroundColor {
-  return [[self class] getStringFromManifest:self.rawManifestJSON
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [[self class] getStringFromManifest:expoClientConfig
                                        paths:@[
                                          @[@"ios", @"splash", @"backgroundColor"],
                                          @[@"splash", @"backgroundColor"],
@@ -122,7 +198,11 @@
 }
 
 - (nullable NSString *)iosSplashImageUrl {
-  return [[self class] getStringFromManifest:self.rawManifestJSON
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [[self class] getStringFromManifest:expoClientConfig
                                        paths:@[
                                          [UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPad
                                          ? @[@"ios", @"splash", @"tabletImageUrl"]
@@ -133,7 +213,11 @@
 }
 
 - (nullable NSString *)iosSplashImageResizeMode {
-  return [[self class] getStringFromManifest:self.rawManifestJSON
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [[self class] getStringFromManifest:expoClientConfig
                                        paths:@[
                                          @[@"ios", @"splash", @"resizeMode"],
                                          @[@"splash", @"resizeMode"],
@@ -145,6 +229,18 @@
     return [self.iosConfig nullableStringForKey:@"googleServicesFile"];
   }
   return nil;
+}
+
+- (nullable NSDictionary *)expoClientConfigRootObject {
+  @throw [NSException exceptionWithName:NSInternalInconsistencyException
+                                 reason:[NSString stringWithFormat:@"You must override %@ in a subclass", NSStringFromSelector(_cmd)]
+                               userInfo:nil];
+}
+
+- (nullable NSDictionary *)expoGoConfigRootObject {
+  @throw [NSException exceptionWithName:NSInternalInconsistencyException
+                                 reason:[NSString stringWithFormat:@"You must override %@ in a subclass", NSStringFromSelector(_cmd)]
+                               userInfo:nil];
 }
 
 + (NSString * _Nullable)getStringFromManifest:(NSDictionary *)manifest

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/RawManifest/ABI41_0_0EXUpdatesBaseRawManifest.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/RawManifest/ABI41_0_0EXUpdatesBaseRawManifest.m
@@ -174,7 +174,7 @@
   return [expoClientConfig nullableStringForKey:@"userInterfaceStyle"];
 }
 
-- (nullable NSString *)iosOrRootBackroundColor {
+- (nullable NSString *)iosOrRootBackgroundColor {
   if (self.iosConfig && [self.iosConfig nullableStringForKey:@"backgroundColor"]) {
     return [self.iosConfig nullableStringForKey:@"backgroundColor"];
   }

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/RawManifest/ABI41_0_0EXUpdatesNewRawManifest.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/RawManifest/ABI41_0_0EXUpdatesNewRawManifest.h
@@ -32,6 +32,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSDictionary *)launchAsset;
 - (nullable NSArray *)assets;
 
+- (nullable NSDictionary *)expoGoConfigRootObject;
+- (nullable NSDictionary *)expoClientConfigRootObject;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/RawManifest/ABI41_0_0EXUpdatesNewRawManifest.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/RawManifest/ABI41_0_0EXUpdatesNewRawManifest.m
@@ -57,4 +57,22 @@
   return [self.launchAsset stringForKey:@"url"];
 }
 
+- (nullable NSDictionary *)extra {
+  return [self.rawManifestJSON nullableDictionaryForKey:@"extra"];
+}
+
+- (nullable NSDictionary *)expoClientConfigRootObject {
+  if (!self.extra) {
+    return nil;
+  }
+  return [self.extra nullableDictionaryForKey:@"expoClient"];
+}
+
+- (nullable NSDictionary *)expoGoConfigRootObject {
+  if (!self.extra) {
+    return nil;
+  }
+  return [self.extra nullableDictionaryForKey:@"expoGo"];
+}
+
 @end

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/RawManifest/ABI41_0_0EXUpdatesRawManifest.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/RawManifest/ABI41_0_0EXUpdatesRawManifest.h
@@ -63,7 +63,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)isDevelopmentSilentLaunch;
 - (BOOL)isUsingDeveloperTool;
 - (nullable NSString *)userInterfaceStyle;
-- (nullable NSString *)iosOrRootBackroundColor;
+- (nullable NSString *)iosOrRootBackgroundColor;
 - (nullable NSString *)iosSplashBackgroundColor;
 - (nullable NSString *)iosSplashImageUrl;
 - (nullable NSString *)iosSplashImageResizeMode;

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/RawManifest/ABI41_0_0EXUpdatesRawManifest.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/RawManifest/ABI41_0_0EXUpdatesRawManifest.h
@@ -63,11 +63,16 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)isDevelopmentSilentLaunch;
 - (BOOL)isUsingDeveloperTool;
 - (nullable NSString *)userInterfaceStyle;
-- (nullable NSString *)androidOrRootBackroundColor;
+- (nullable NSString *)iosOrRootBackroundColor;
 - (nullable NSString *)iosSplashBackgroundColor;
 - (nullable NSString *)iosSplashImageUrl;
 - (nullable NSString *)iosSplashImageResizeMode;
 - (nullable NSString *)iosGoogleServicesFile;
+
+# pragma mark - helper methods
+
+- (nullable NSDictionary *)expoGoConfigRootObject;
+- (nullable NSDictionary *)expoClientConfigRootObject;
 
 @end
 

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI41_0_0EXScopedNotificationCategoryMigrator.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI41_0_0EXScopedNotificationCategoryMigrator.m
@@ -5,7 +5,7 @@
 
 @implementation ABI41_0_0EXScopedNotificationCategoryMigrator
 
-+ (void)migrateLegacyScopedCategoryIdentifiersForProjectWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId scopeKey:(NSString *)scopeKey
++ (void)migrateLegacyScopedCategoryIdentifiersForProjectWithScopeKey:(NSString *)scopeKey
 {
   [ABI41_0_0EXScopedNotificationCategoryMigrator renameLegacyCategoryIdentifiersForExperienceWithScopeKey:scopeKey withBlock:^(UNNotificationCategory *oldCategory) {
     NSString *unscopedLegacyCategoryId = [ABI41_0_0EXScopedNotificationsUtils unscopedLegacyCategoryIdentifierWithId:oldCategory.identifier forScopeKey:scopeKey];

--- a/ios/versioned-react-native/ABI42_0_0/Expo/EXUpdates/ABI42_0_0EXUpdates/Update/RawManifest/ABI42_0_0EXUpdatesBaseLegacyRawManifest.h
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/EXUpdates/ABI42_0_0EXUpdates/Update/RawManifest/ABI42_0_0EXUpdatesBaseLegacyRawManifest.h
@@ -6,6 +6,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ABI42_0_0EXUpdatesBaseLegacyRawManifest : ABI42_0_0EXUpdatesBaseRawManifest
 
+- (nullable NSDictionary *)expoGoConfigRootObject;
+- (nullable NSDictionary *)expoClientConfigRootObject;
+
 - (NSString *)stableLegacyId;
 - (NSString *)scopeKey;
 - (nullable NSString *)projectId;

--- a/ios/versioned-react-native/ABI42_0_0/Expo/EXUpdates/ABI42_0_0EXUpdates/Update/RawManifest/ABI42_0_0EXUpdatesBaseLegacyRawManifest.m
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/EXUpdates/ABI42_0_0EXUpdates/Update/RawManifest/ABI42_0_0EXUpdatesBaseLegacyRawManifest.m
@@ -5,6 +5,14 @@
 
 @implementation ABI42_0_0EXUpdatesBaseLegacyRawManifest
 
+- (nullable NSDictionary *)expoClientConfigRootObject {
+  return self.rawManifestJSON;
+}
+
+- (nullable NSDictionary *)expoGoConfigRootObject {
+  return self.rawManifestJSON;
+}
+
 - (NSString *)stableLegacyId {
   NSString *originalFullName = [self.rawManifestJSON nullableStringForKey:@"originalFullName"];
   if (originalFullName) {

--- a/ios/versioned-react-native/ABI42_0_0/Expo/EXUpdates/ABI42_0_0EXUpdates/Update/RawManifest/ABI42_0_0EXUpdatesBaseRawManifest.h
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/EXUpdates/ABI42_0_0EXUpdates/Update/RawManifest/ABI42_0_0EXUpdatesBaseRawManifest.h
@@ -33,11 +33,14 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)isDevelopmentSilentLaunch;
 - (BOOL)isUsingDeveloperTool;
 - (nullable NSString *)userInterfaceStyle;
-- (nullable NSString *)androidOrRootBackroundColor;
+- (nullable NSString *)iosOrRootBackroundColor;
 - (nullable NSString *)iosSplashBackgroundColor;
 - (nullable NSString *)iosSplashImageUrl;
 - (nullable NSString *)iosSplashImageResizeMode;
 - (nullable NSString *)iosGoogleServicesFile;
+
+- (nullable NSDictionary *)expoGoConfigRootObject;
+- (nullable NSDictionary *)expoClientConfigRootObject;
 
 @end
 

--- a/ios/versioned-react-native/ABI42_0_0/Expo/EXUpdates/ABI42_0_0EXUpdates/Update/RawManifest/ABI42_0_0EXUpdatesBaseRawManifest.h
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/EXUpdates/ABI42_0_0EXUpdates/Update/RawManifest/ABI42_0_0EXUpdatesBaseRawManifest.h
@@ -33,7 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)isDevelopmentSilentLaunch;
 - (BOOL)isUsingDeveloperTool;
 - (nullable NSString *)userInterfaceStyle;
-- (nullable NSString *)iosOrRootBackroundColor;
+- (nullable NSString *)iosOrRootBackgroundColor;
 - (nullable NSString *)iosSplashBackgroundColor;
 - (nullable NSString *)iosSplashImageUrl;
 - (nullable NSString *)iosSplashImageResizeMode;

--- a/ios/versioned-react-native/ABI42_0_0/Expo/EXUpdates/ABI42_0_0EXUpdates/Update/RawManifest/ABI42_0_0EXUpdatesBaseRawManifest.m
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/EXUpdates/ABI42_0_0EXUpdates/Update/RawManifest/ABI42_0_0EXUpdatesBaseRawManifest.m
@@ -176,7 +176,7 @@
   return [expoClientConfig nullableStringForKey:@"userInterfaceStyle"];
 }
 
-- (nullable NSString *)iosOrRootBackroundColor {
+- (nullable NSString *)iosOrRootBackgroundColor {
   if (self.iosConfig && [self.iosConfig nullableStringForKey:@"backgroundColor"]) {
     return [self.iosConfig nullableStringForKey:@"backgroundColor"];
   }

--- a/ios/versioned-react-native/ABI42_0_0/Expo/EXUpdates/ABI42_0_0EXUpdates/Update/RawManifest/ABI42_0_0EXUpdatesBaseRawManifest.m
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/EXUpdates/ABI42_0_0EXUpdates/Update/RawManifest/ABI42_0_0EXUpdatesBaseRawManifest.m
@@ -24,71 +24,135 @@
 }
 
 - (nullable NSString *)revisionId {
-  return [self.rawManifestJSON nullableStringForKey:@"revisionId"];
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [expoClientConfig nullableStringForKey:@"revisionId"];
 }
 
 - (nullable NSString *)slug {
-  return [self.rawManifestJSON nullableStringForKey:@"slug"];
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [expoClientConfig nullableStringForKey:@"slug"];
 }
 
 - (nullable NSString *)appKey {
-  return [self.rawManifestJSON nullableStringForKey:@"appKey"];
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [expoClientConfig nullableStringForKey:@"appKey"];
 }
 
 - (nullable NSString *)name {
-  return [self.rawManifestJSON nullableStringForKey:@"name"];
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [expoClientConfig nullableStringForKey:@"name"];
 }
 
 - (nullable NSDictionary *)notificationPreferences {
-  return [self.rawManifestJSON nullableDictionaryForKey:@"notification"];
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [expoClientConfig nullableDictionaryForKey:@"notification"];
 }
 
 - (nullable NSDictionary *)updatesInfo {
-  return [self.rawManifestJSON nullableDictionaryForKey:@"updates"];
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [expoClientConfig nullableDictionaryForKey:@"updates"];
 }
 
 - (nullable NSDictionary *)iosConfig {
-  return [self.rawManifestJSON nullableDictionaryForKey:@"ios"];
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [expoClientConfig nullableDictionaryForKey:@"ios"];
 }
 
 - (nullable NSString *)hostUri {
-  return [self.rawManifestJSON nullableStringForKey:@"hostUri"];
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [expoClientConfig nullableStringForKey:@"hostUri"];
 }
 
 - (nullable NSString *)orientation {
-  return [self.rawManifestJSON nullableStringForKey:@"orientation"];
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [expoClientConfig nullableStringForKey:@"orientation"];
 }
 
 - (nullable NSDictionary *)experiments {
-  return [self.rawManifestJSON nullableDictionaryForKey:@"experiments"];
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [expoClientConfig nullableDictionaryForKey:@"experiments"];
 }
 
 - (nullable NSDictionary *)developer {
-  return [self.rawManifestJSON nullableDictionaryForKey:@"developer"];
+  NSDictionary *expoGoConfig = self.expoGoConfigRootObject;
+  if (!expoGoConfig) {
+    return nil;
+  }
+  return [expoGoConfig nullableDictionaryForKey:@"developer"];
 }
 
 - (nullable NSString *)facebookAppId {
-  return [self.rawManifestJSON nullableStringForKey:@"facebookAppId"];
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [expoClientConfig nullableStringForKey:@"facebookAppId"];
 }
 
 - (nullable NSString *)facebookApplicationName {
-  return [self.rawManifestJSON nullableStringForKey:@"facebookDisplayName"];
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [expoClientConfig nullableStringForKey:@"facebookDisplayName"];
 }
 
 - (BOOL)facebookAutoInitEnabled {
-  NSNumber *enabledNumber = [self.rawManifestJSON nullableNumberForKey:@"facebookAutoInitEnabled"];
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  NSNumber *enabledNumber = [expoClientConfig nullableNumberForKey:@"facebookAutoInitEnabled"];
   return enabledNumber != nil && [enabledNumber boolValue];
 }
 
 # pragma mark - Derived Methods
 
 - (BOOL)isDevelopmentMode {
-  NSDictionary *manifestPackagerOptsConfig = [self.rawManifestJSON nullableDictionaryForKey:@"packagerOpts"];
+  NSDictionary *expoGoConfig = self.expoGoConfigRootObject;
+  if (!expoGoConfig) {
+    return nil;
+  }
+  NSDictionary *manifestPackagerOptsConfig = [expoGoConfig nullableDictionaryForKey:@"packagerOpts"];
   return (self.developer != nil && manifestPackagerOptsConfig != nil && [@(YES) isEqualToNumber:manifestPackagerOptsConfig[@"dev"]]);
 }
 
 - (BOOL)isDevelopmentSilentLaunch {
-  NSDictionary *developmentClientSettings = self.rawManifestJSON[@"developmentClient"];
+  NSDictionary *expoGoConfig = self.expoGoConfigRootObject;
+  if (!expoGoConfig) {
+    return nil;
+  }
+  NSDictionary *developmentClientSettings = expoGoConfig[@"developmentClient"];
   if (developmentClientSettings && [developmentClientSettings isKindOfClass:[NSDictionary class]]) {
     id silentLaunch = developmentClientSettings[@"silentLaunch"];
     return silentLaunch && [@(YES) isEqual:silentLaunch];
@@ -105,18 +169,30 @@
   if (self.iosConfig && [self.iosConfig nullableStringForKey:@"userInterfaceStyle"]) {
     return [self.iosConfig nullableStringForKey:@"userInterfaceStyle"];
   }
-  return [self.rawManifestJSON nullableStringForKey:@"userInterfaceStyle"];
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [expoClientConfig nullableStringForKey:@"userInterfaceStyle"];
 }
 
-- (nullable NSString *)androidOrRootBackroundColor {
+- (nullable NSString *)iosOrRootBackroundColor {
   if (self.iosConfig && [self.iosConfig nullableStringForKey:@"backgroundColor"]) {
     return [self.iosConfig nullableStringForKey:@"backgroundColor"];
   }
-  return [self.rawManifestJSON nullableStringForKey:@"backgroundColor"];
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [expoClientConfig nullableStringForKey:@"backgroundColor"];
 }
 
 - (nullable NSString *)iosSplashBackgroundColor {
-  return [[self class] getStringFromManifest:self.rawManifestJSON
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [[self class] getStringFromManifest:expoClientConfig
                                        paths:@[
                                          @[@"ios", @"splash", @"backgroundColor"],
                                          @[@"splash", @"backgroundColor"],
@@ -124,7 +200,11 @@
 }
 
 - (nullable NSString *)iosSplashImageUrl {
-  return [[self class] getStringFromManifest:self.rawManifestJSON
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [[self class] getStringFromManifest:expoClientConfig
                                        paths:@[
                                          [UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPad
                                          ? @[@"ios", @"splash", @"tabletImageUrl"]
@@ -135,7 +215,11 @@
 }
 
 - (nullable NSString *)iosSplashImageResizeMode {
-  return [[self class] getStringFromManifest:self.rawManifestJSON
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [[self class] getStringFromManifest:expoClientConfig
                                        paths:@[
                                          @[@"ios", @"splash", @"resizeMode"],
                                          @[@"splash", @"resizeMode"],
@@ -147,6 +231,18 @@
     return [self.iosConfig nullableStringForKey:@"googleServicesFile"];
   }
   return nil;
+}
+
+- (nullable NSDictionary *)expoClientConfigRootObject {
+  @throw [NSException exceptionWithName:NSInternalInconsistencyException
+                                 reason:[NSString stringWithFormat:@"You must override %@ in a subclass", NSStringFromSelector(_cmd)]
+                               userInfo:nil];
+}
+
+- (nullable NSDictionary *)expoGoConfigRootObject {
+  @throw [NSException exceptionWithName:NSInternalInconsistencyException
+                                 reason:[NSString stringWithFormat:@"You must override %@ in a subclass", NSStringFromSelector(_cmd)]
+                               userInfo:nil];
 }
 
 + (NSString * _Nullable)getStringFromManifest:(NSDictionary *)manifest

--- a/ios/versioned-react-native/ABI42_0_0/Expo/EXUpdates/ABI42_0_0EXUpdates/Update/RawManifest/ABI42_0_0EXUpdatesNewRawManifest.h
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/EXUpdates/ABI42_0_0EXUpdates/Update/RawManifest/ABI42_0_0EXUpdatesNewRawManifest.h
@@ -32,6 +32,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSDictionary *)launchAsset;
 - (nullable NSArray *)assets;
 
+- (nullable NSDictionary *)expoGoConfigRootObject;
+- (nullable NSDictionary *)expoClientConfigRootObject;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/versioned-react-native/ABI42_0_0/Expo/EXUpdates/ABI42_0_0EXUpdates/Update/RawManifest/ABI42_0_0EXUpdatesNewRawManifest.m
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/EXUpdates/ABI42_0_0EXUpdates/Update/RawManifest/ABI42_0_0EXUpdatesNewRawManifest.m
@@ -37,7 +37,7 @@
       return [runtimeVersion substringWithRange:matchRange];
     }
   }
-  
+
   return nil;
 }
 
@@ -55,6 +55,24 @@
 
 - (NSString *)bundleUrl {
   return [self.launchAsset stringForKey:@"url"];
+}
+
+- (nullable NSDictionary *)extra {
+  return [self.rawManifestJSON nullableDictionaryForKey:@"extra"];
+}
+
+- (nullable NSDictionary *)expoClientConfigRootObject {
+  if (!self.extra) {
+    return nil;
+  }
+  return [self.extra nullableDictionaryForKey:@"expoClient"];
+}
+
+- (nullable NSDictionary *)expoGoConfigRootObject {
+  if (!self.extra) {
+    return nil;
+  }
+  return [self.extra nullableDictionaryForKey:@"expoGo"];
 }
 
 @end

--- a/ios/versioned-react-native/ABI42_0_0/Expo/EXUpdates/ABI42_0_0EXUpdates/Update/RawManifest/ABI42_0_0EXUpdatesRawManifest.h
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/EXUpdates/ABI42_0_0EXUpdates/Update/RawManifest/ABI42_0_0EXUpdatesRawManifest.h
@@ -65,7 +65,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)isDevelopmentSilentLaunch;
 - (BOOL)isUsingDeveloperTool;
 - (nullable NSString *)userInterfaceStyle;
-- (nullable NSString *)iosOrRootBackroundColor;
+- (nullable NSString *)iosOrRootBackgroundColor;
 - (nullable NSString *)iosSplashBackgroundColor;
 - (nullable NSString *)iosSplashImageUrl;
 - (nullable NSString *)iosSplashImageResizeMode;

--- a/ios/versioned-react-native/ABI42_0_0/Expo/EXUpdates/ABI42_0_0EXUpdates/Update/RawManifest/ABI42_0_0EXUpdatesRawManifest.h
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/EXUpdates/ABI42_0_0EXUpdates/Update/RawManifest/ABI42_0_0EXUpdatesRawManifest.h
@@ -65,11 +65,16 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)isDevelopmentSilentLaunch;
 - (BOOL)isUsingDeveloperTool;
 - (nullable NSString *)userInterfaceStyle;
-- (nullable NSString *)androidOrRootBackroundColor;
+- (nullable NSString *)iosOrRootBackroundColor;
 - (nullable NSString *)iosSplashBackgroundColor;
 - (nullable NSString *)iosSplashImageUrl;
 - (nullable NSString *)iosSplashImageResizeMode;
 - (nullable NSString *)iosGoogleServicesFile;
+
+# pragma mark - helper methods
+
+- (nullable NSDictionary *)expoGoConfigRootObject;
+- (nullable NSDictionary *)expoClientConfigRootObject;
 
 @end
 

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI42_0_0EXScopedNotificationCategoryMigrator.m
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/UniversalModules/EXNotifications/ABI42_0_0EXScopedNotificationCategoryMigrator.m
@@ -5,7 +5,7 @@
 
 @implementation ABI42_0_0EXScopedNotificationCategoryMigrator
 
-+ (void)migrateLegacyScopedCategoryIdentifiersForProjectWithExperienceStableLegacyId:(NSString *)experienceStableLegacyId scopeKey:(NSString *)scopeKey
++ (void)migrateLegacyScopedCategoryIdentifiersForProjectWithScopeKey:(NSString *)scopeKey
 {
   [ABI42_0_0EXScopedNotificationCategoryMigrator renameLegacyCategoryIdentifiersForExperienceWithScopeKey:scopeKey withBlock:^(UNNotificationCategory *oldCategory) {
     NSString *unscopedLegacyCategoryId = [ABI42_0_0EXScopedNotificationsUtils unscopedLegacyCategoryIdentifierWithId:oldCategory.identifier forScopeKey:scopeKey];

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/raw/RawManifest.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/raw/RawManifest.kt
@@ -63,7 +63,7 @@ abstract class RawManifest(protected val json: JSONObject) {
   abstract fun getBundleURL(): String
 
   @Throws(JSONException::class)
-  fun getRevisionId(): String = json.getString("revisionId")
+  fun getRevisionId(): String = getExpoClientConfigRootObject()!!.getString("revisionId")
 
   abstract fun getSDKVersionNullable(): String?
 
@@ -170,7 +170,8 @@ abstract class RawManifest(protected val json: JSONObject) {
   }
 
   fun getAndroidJsEngine(): String? {
-    val android = json.optJSONObject("android") ?: return null
+    val expoClientConfig = getExpoClientConfigRootObject() ?: return null
+    val android = expoClientConfig.optJSONObject("android") ?: return null
     return android.optString("jsEngine") ?: return null
   }
 

--- a/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesBaseLegacyRawManifest.h
+++ b/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesBaseLegacyRawManifest.h
@@ -6,6 +6,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface EXUpdatesBaseLegacyRawManifest : EXUpdatesBaseRawManifest
 
+- (nullable NSDictionary *)expoGoConfigRootObject;
+- (nullable NSDictionary *)expoClientConfigRootObject;
+
 - (NSString *)stableLegacyId;
 - (NSString *)scopeKey;
 - (nullable NSString *)projectId;

--- a/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesBaseLegacyRawManifest.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesBaseLegacyRawManifest.m
@@ -5,6 +5,14 @@
 
 @implementation EXUpdatesBaseLegacyRawManifest
 
+- (nullable NSDictionary *)expoClientConfigRootObject {
+  return self.rawManifestJSON;
+}
+
+- (nullable NSDictionary *)expoGoConfigRootObject {
+  return self.rawManifestJSON;
+}
+
 - (NSString *)stableLegacyId {
   NSString *originalFullName = [self.rawManifestJSON nullableStringForKey:@"originalFullName"];
   if (originalFullName) {

--- a/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesBaseRawManifest.h
+++ b/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesBaseRawManifest.h
@@ -33,11 +33,14 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)isDevelopmentSilentLaunch;
 - (BOOL)isUsingDeveloperTool;
 - (nullable NSString *)userInterfaceStyle;
-- (nullable NSString *)androidOrRootBackroundColor;
+- (nullable NSString *)iosOrRootBackroundColor;
 - (nullable NSString *)iosSplashBackgroundColor;
 - (nullable NSString *)iosSplashImageUrl;
 - (nullable NSString *)iosSplashImageResizeMode;
 - (nullable NSString *)iosGoogleServicesFile;
+
+- (nullable NSDictionary *)expoGoConfigRootObject;
+- (nullable NSDictionary *)expoClientConfigRootObject;
 
 @end
 

--- a/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesBaseRawManifest.h
+++ b/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesBaseRawManifest.h
@@ -33,7 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)isDevelopmentSilentLaunch;
 - (BOOL)isUsingDeveloperTool;
 - (nullable NSString *)userInterfaceStyle;
-- (nullable NSString *)iosOrRootBackroundColor;
+- (nullable NSString *)iosOrRootBackgroundColor;
 - (nullable NSString *)iosSplashBackgroundColor;
 - (nullable NSString *)iosSplashImageUrl;
 - (nullable NSString *)iosSplashImageResizeMode;

--- a/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesBaseRawManifest.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesBaseRawManifest.m
@@ -176,7 +176,7 @@
   return [expoClientConfig nullableStringForKey:@"userInterfaceStyle"];
 }
 
-- (nullable NSString *)iosOrRootBackroundColor {
+- (nullable NSString *)iosOrRootBackgroundColor {
   if (self.iosConfig && [self.iosConfig nullableStringForKey:@"backgroundColor"]) {
     return [self.iosConfig nullableStringForKey:@"backgroundColor"];
   }

--- a/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesBaseRawManifest.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesBaseRawManifest.m
@@ -24,71 +24,135 @@
 }
 
 - (nullable NSString *)revisionId {
-  return [self.rawManifestJSON nullableStringForKey:@"revisionId"];
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [expoClientConfig nullableStringForKey:@"revisionId"];
 }
 
 - (nullable NSString *)slug {
-  return [self.rawManifestJSON nullableStringForKey:@"slug"];
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [expoClientConfig nullableStringForKey:@"slug"];
 }
 
 - (nullable NSString *)appKey {
-  return [self.rawManifestJSON nullableStringForKey:@"appKey"];
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [expoClientConfig nullableStringForKey:@"appKey"];
 }
 
 - (nullable NSString *)name {
-  return [self.rawManifestJSON nullableStringForKey:@"name"];
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [expoClientConfig nullableStringForKey:@"name"];
 }
 
 - (nullable NSDictionary *)notificationPreferences {
-  return [self.rawManifestJSON nullableDictionaryForKey:@"notification"];
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [expoClientConfig nullableDictionaryForKey:@"notification"];
 }
 
 - (nullable NSDictionary *)updatesInfo {
-  return [self.rawManifestJSON nullableDictionaryForKey:@"updates"];
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [expoClientConfig nullableDictionaryForKey:@"updates"];
 }
 
 - (nullable NSDictionary *)iosConfig {
-  return [self.rawManifestJSON nullableDictionaryForKey:@"ios"];
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [expoClientConfig nullableDictionaryForKey:@"ios"];
 }
 
 - (nullable NSString *)hostUri {
-  return [self.rawManifestJSON nullableStringForKey:@"hostUri"];
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [expoClientConfig nullableStringForKey:@"hostUri"];
 }
 
 - (nullable NSString *)orientation {
-  return [self.rawManifestJSON nullableStringForKey:@"orientation"];
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [expoClientConfig nullableStringForKey:@"orientation"];
 }
 
 - (nullable NSDictionary *)experiments {
-  return [self.rawManifestJSON nullableDictionaryForKey:@"experiments"];
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [expoClientConfig nullableDictionaryForKey:@"experiments"];
 }
 
 - (nullable NSDictionary *)developer {
-  return [self.rawManifestJSON nullableDictionaryForKey:@"developer"];
+  NSDictionary *expoGoConfig = self.expoGoConfigRootObject;
+  if (!expoGoConfig) {
+    return nil;
+  }
+  return [expoGoConfig nullableDictionaryForKey:@"developer"];
 }
 
 - (nullable NSString *)facebookAppId {
-  return [self.rawManifestJSON nullableStringForKey:@"facebookAppId"];
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [expoClientConfig nullableStringForKey:@"facebookAppId"];
 }
 
 - (nullable NSString *)facebookApplicationName {
-  return [self.rawManifestJSON nullableStringForKey:@"facebookDisplayName"];
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [expoClientConfig nullableStringForKey:@"facebookDisplayName"];
 }
 
 - (BOOL)facebookAutoInitEnabled {
-  NSNumber *enabledNumber = [self.rawManifestJSON nullableNumberForKey:@"facebookAutoInitEnabled"];
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  NSNumber *enabledNumber = [expoClientConfig nullableNumberForKey:@"facebookAutoInitEnabled"];
   return enabledNumber != nil && [enabledNumber boolValue];
 }
 
 # pragma mark - Derived Methods
 
 - (BOOL)isDevelopmentMode {
-  NSDictionary *manifestPackagerOptsConfig = [self.rawManifestJSON nullableDictionaryForKey:@"packagerOpts"];
+  NSDictionary *expoGoConfig = self.expoGoConfigRootObject;
+  if (!expoGoConfig) {
+    return nil;
+  }
+  NSDictionary *manifestPackagerOptsConfig = [expoGoConfig nullableDictionaryForKey:@"packagerOpts"];
   return (self.developer != nil && manifestPackagerOptsConfig != nil && [@(YES) isEqualToNumber:manifestPackagerOptsConfig[@"dev"]]);
 }
 
 - (BOOL)isDevelopmentSilentLaunch {
-  NSDictionary *developmentClientSettings = self.rawManifestJSON[@"developmentClient"];
+  NSDictionary *expoGoConfig = self.expoGoConfigRootObject;
+  if (!expoGoConfig) {
+    return nil;
+  }
+  NSDictionary *developmentClientSettings = expoGoConfig[@"developmentClient"];
   if (developmentClientSettings && [developmentClientSettings isKindOfClass:[NSDictionary class]]) {
     id silentLaunch = developmentClientSettings[@"silentLaunch"];
     return silentLaunch && [@(YES) isEqual:silentLaunch];
@@ -105,18 +169,30 @@
   if (self.iosConfig && [self.iosConfig nullableStringForKey:@"userInterfaceStyle"]) {
     return [self.iosConfig nullableStringForKey:@"userInterfaceStyle"];
   }
-  return [self.rawManifestJSON nullableStringForKey:@"userInterfaceStyle"];
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [expoClientConfig nullableStringForKey:@"userInterfaceStyle"];
 }
 
-- (nullable NSString *)androidOrRootBackroundColor {
+- (nullable NSString *)iosOrRootBackroundColor {
   if (self.iosConfig && [self.iosConfig nullableStringForKey:@"backgroundColor"]) {
     return [self.iosConfig nullableStringForKey:@"backgroundColor"];
   }
-  return [self.rawManifestJSON nullableStringForKey:@"backgroundColor"];
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [expoClientConfig nullableStringForKey:@"backgroundColor"];
 }
 
 - (nullable NSString *)iosSplashBackgroundColor {
-  return [[self class] getStringFromManifest:self.rawManifestJSON
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [[self class] getStringFromManifest:expoClientConfig
                                        paths:@[
                                          @[@"ios", @"splash", @"backgroundColor"],
                                          @[@"splash", @"backgroundColor"],
@@ -124,7 +200,11 @@
 }
 
 - (nullable NSString *)iosSplashImageUrl {
-  return [[self class] getStringFromManifest:self.rawManifestJSON
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [[self class] getStringFromManifest:expoClientConfig
                                        paths:@[
                                          [UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPad
                                          ? @[@"ios", @"splash", @"tabletImageUrl"]
@@ -135,7 +215,11 @@
 }
 
 - (nullable NSString *)iosSplashImageResizeMode {
-  return [[self class] getStringFromManifest:self.rawManifestJSON
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [[self class] getStringFromManifest:expoClientConfig
                                        paths:@[
                                          @[@"ios", @"splash", @"resizeMode"],
                                          @[@"splash", @"resizeMode"],
@@ -147,6 +231,18 @@
     return [self.iosConfig nullableStringForKey:@"googleServicesFile"];
   }
   return nil;
+}
+
+- (nullable NSDictionary *)expoClientConfigRootObject {
+  @throw [NSException exceptionWithName:NSInternalInconsistencyException
+                                 reason:[NSString stringWithFormat:@"You must override %@ in a subclass", NSStringFromSelector(_cmd)]
+                               userInfo:nil];
+}
+
+- (nullable NSDictionary *)expoGoConfigRootObject {
+  @throw [NSException exceptionWithName:NSInternalInconsistencyException
+                                 reason:[NSString stringWithFormat:@"You must override %@ in a subclass", NSStringFromSelector(_cmd)]
+                               userInfo:nil];
 }
 
 + (NSString * _Nullable)getStringFromManifest:(NSDictionary *)manifest

--- a/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesNewRawManifest.h
+++ b/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesNewRawManifest.h
@@ -32,6 +32,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSDictionary *)launchAsset;
 - (nullable NSArray *)assets;
 
+- (nullable NSDictionary *)expoGoConfigRootObject;
+- (nullable NSDictionary *)expoClientConfigRootObject;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesNewRawManifest.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesNewRawManifest.m
@@ -57,4 +57,22 @@
   return [self.launchAsset stringForKey:@"url"];
 }
 
+- (nullable NSDictionary *)extra {
+  return [self.rawManifestJSON nullableDictionaryForKey:@"extra"];
+}
+
+- (nullable NSDictionary *)expoClientConfigRootObject {
+  if (!self.extra) {
+    return nil;
+  }
+  return [self.extra nullableDictionaryForKey:@"expoClient"];
+}
+
+- (nullable NSDictionary *)expoGoConfigRootObject {
+  if (!self.extra) {
+    return nil;
+  }
+  return [self.extra nullableDictionaryForKey:@"expoGo"];
+}
+
 @end

--- a/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesRawManifest.h
+++ b/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesRawManifest.h
@@ -65,7 +65,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)isDevelopmentSilentLaunch;
 - (BOOL)isUsingDeveloperTool;
 - (nullable NSString *)userInterfaceStyle;
-- (nullable NSString *)iosOrRootBackroundColor;
+- (nullable NSString *)iosOrRootBackgroundColor;
 - (nullable NSString *)iosSplashBackgroundColor;
 - (nullable NSString *)iosSplashImageUrl;
 - (nullable NSString *)iosSplashImageResizeMode;

--- a/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesRawManifest.h
+++ b/packages/expo-updates/ios/EXUpdates/Update/RawManifest/EXUpdatesRawManifest.h
@@ -65,11 +65,16 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)isDevelopmentSilentLaunch;
 - (BOOL)isUsingDeveloperTool;
 - (nullable NSString *)userInterfaceStyle;
-- (nullable NSString *)androidOrRootBackroundColor;
+- (nullable NSString *)iosOrRootBackroundColor;
 - (nullable NSString *)iosSplashBackgroundColor;
 - (nullable NSString *)iosSplashImageUrl;
 - (nullable NSString *)iosSplashImageResizeMode;
 - (nullable NSString *)iosGoogleServicesFile;
+
+# pragma mark - helper methods
+
+- (nullable NSDictionary *)expoGoConfigRootObject;
+- (nullable NSDictionary *)expoClientConfigRootObject;
 
 @end
 


### PR DESCRIPTION
# Why

iOS equivalent of https://github.com/expo/expo/pull/13398.

# How

3 commits:
- Make same changes as https://github.com/expo/expo/pull/13398 but in iOS code.
- Manually backport versions
- Fix other crash

# Test Plan

Load new manifest in iOS simulator, see it launches. Still crashes in JS though since an equivalent change to this will need to be made in the JS.