### PR TITLE
[gl-cpp] Add kotlin gradle plugin, fixes #12707

### DIFF
--- a/packages/expo-gl-cpp/android/build.gradle
+++ b/packages/expo-gl-cpp/android/build.gradle
@@ -17,6 +17,7 @@ buildscript {
 
   dependencies {
     classpath("de.undercouch:gradle-download-task:${safeExtGet("gradleDownloadTaskVersion", "3.4.3")}")
+    classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${safeExtGet('kotlinVersion', '1.4.21')}")
   }
 }
 


### PR DESCRIPTION
# Why

Make `expo-gl-cpp` (and therefore `expo-gl`) work out of the box with prebuild, without users needing to modify their `android/build.gradle` to add the kotlin-gradle-plugin. We do the same thing on other expo-* packages. 

# How

Add kotlin-gradle-plugin to buildscript in build.gradle, in the same way as in expo-gl.

# Test Plan

- Create a new managed project, run `expo install expo-gl`, run it on EAS Build. Notice it fails: https://expo.io/accounts/notbrent/projects/gee-el/builds/f2f44ea1-ff34-4870-a665-8b504adf55de
- Patch the module according to this diff with `patch-package`, run it again on EAS Build. Notice it succeeds: https://expo.io/accounts/notbrent/projects/gee-el/builds/7fb56709-fcfe-419c-9781-2b6898bfc2e3