### PR TITLE
[expo-dev-launcher][android] update plugin and docs to only initialize UpdatesDevLauncherController in debug builds

### DIFF
--- a/docs/public/static/diffs/client/main-application-updates.diff
+++ b/docs/public/static/diffs/client/main-application-updates.diff
@@ -19,10 +19,12 @@ index 15b21ef..f6f50f7 100644
      }
 
      @Override
-@@ -88,6 +89,7 @@ public class MainApplication extends Application implements ReactApplication {
+@@ -88,6 +89,9 @@ public class MainApplication extends Application implements ReactApplication {
      }
 
      DevLauncherController.initialize(this, getReactNativeHost());
-+    DevLauncherController.getInstance().setUpdatesInterface(UpdatesDevLauncherController.initialize(this));
++    if (BuildConfig.DEBUG) {
++      DevLauncherController.getInstance().setUpdatesInterface(UpdatesDevLauncherController.initialize(this));
++    }
      initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
    }

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fixed compatibility with React Native 0.64.X. ([#13632](https://github.com/expo/expo/pull/13632) by [@lukmccall](https://github.com/lukmccall))
+- Updated plugin to only initialize UpdatesDevLauncherController in debug builds.
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fixed compatibility with React Native 0.64.X. ([#13632](https://github.com/expo/expo/pull/13632) by [@lukmccall](https://github.com/lukmccall))
-- Updated plugin to only initialize UpdatesDevLauncherController in debug builds.
+- Updated plugin to only initialize UpdatesDevLauncherController in debug builds. ([#13597](https://github.com/expo/expo/pull/13597) by [@esamelson](https://github.com/esamelson))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/plugin/build/withDevLauncher.js
+++ b/packages/expo-dev-launcher/plugin/build/withDevLauncher.js
@@ -23,7 +23,9 @@ const DEV_LAUNCHER_ON_NEW_INTENT = `
 `;
 const DEV_LAUNCHER_WRAPPED_ACTIVITY_DELEGATE = `DevLauncherController.wrapReactActivityDelegate(this, () -> $1);`;
 const DEV_LAUNCHER_ANDROID_INIT = 'DevLauncherController.initialize(this, getReactNativeHost());';
-const DEV_LAUNCHER_UPDATES_ANDROID_INIT = 'DevLauncherController.getInstance().setUpdatesInterface(UpdatesDevLauncherController.initialize(this));';
+const DEV_LAUNCHER_UPDATES_ANDROID_INIT = `if (BuildConfig.DEBUG) {
+      DevLauncherController.getInstance().setUpdatesInterface(UpdatesDevLauncherController.initialize(this));
+    }`;
 const DEV_LAUNCHER_UPDATES_DEVELOPER_SUPPORT = 'return DevLauncherController.getInstance().getUseDeveloperSupport();';
 const DEV_LAUNCHER_JS_REGISTER_ERROR_HANDLERS = `import 'expo-dev-client';`;
 async function readFileAsync(path) {

--- a/packages/expo-dev-launcher/plugin/src/withDevLauncher.ts
+++ b/packages/expo-dev-launcher/plugin/src/withDevLauncher.ts
@@ -29,8 +29,9 @@ const DEV_LAUNCHER_ON_NEW_INTENT = `
 `;
 const DEV_LAUNCHER_WRAPPED_ACTIVITY_DELEGATE = `DevLauncherController.wrapReactActivityDelegate(this, () -> $1);`;
 const DEV_LAUNCHER_ANDROID_INIT = 'DevLauncherController.initialize(this, getReactNativeHost());';
-const DEV_LAUNCHER_UPDATES_ANDROID_INIT =
-  'DevLauncherController.getInstance().setUpdatesInterface(UpdatesDevLauncherController.initialize(this));';
+const DEV_LAUNCHER_UPDATES_ANDROID_INIT = `if (BuildConfig.DEBUG) {
+      DevLauncherController.getInstance().setUpdatesInterface(UpdatesDevLauncherController.initialize(this));
+    }`;
 const DEV_LAUNCHER_UPDATES_DEVELOPER_SUPPORT =
   'return DevLauncherController.getInstance().getUseDeveloperSupport();';
 


### PR DESCRIPTION
# Why

https://github.com/expo/expo/pull/13555#issuecomment-876847654

There is no need to initialize this singleton in release builds; doing so just uses up memory and can potentially have side effects we don't want (like the one removed in #13555). On iOS, this already only happens in debug builds, so this PR just modifies Android to have the same behavior.

# How

Update both the config plugin and the installation instructions for the dev-client/updates integration to wrap the `DevLauncherController.initialize()` call in `if (BuildConfig.DEBUG)`.

# Test Plan

Tested the config plugin in a bare project with dev client to ensure it has the correct output; tested debug and release Android builds to ensure they build and run with this change.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).