### PR TITLE
[docs][clients] add note to installation page about iOS module name

### DIFF
--- a/docs/pages/clients/installation.md
+++ b/docs/pages/clients/installation.md
@@ -101,7 +101,7 @@ Make the following changes to allow the Development Client to control project in
 
 <Tab >
 
-Make sure to replace `MyApp` on line 75 in the following diff with your app's actual module name (found on the removed line 36).
+> ⚠️ Make sure to replace `MyApp` on line 75 in the following diff with your app's actual module name (found on the removed line 36).
 
 <ConfigurationDiff source="/static/diffs/client/app-delegate-no-unimodules.diff" />
 

--- a/docs/pages/clients/installation.md
+++ b/docs/pages/clients/installation.md
@@ -100,7 +100,11 @@ Make the following changes to allow the Development Client to control project in
 </Tab>
 
 <Tab >
+
+Make sure to replace `MyApp` on line 75 in the following diff with your app's actual module name (found on the removed line 36).
+
 <ConfigurationDiff source="/static/diffs/client/app-delegate-no-unimodules.diff" />
+
 </Tab>
 
 </Tabs>


### PR DESCRIPTION
# Why

[ENG-1511 (comment)](https://linear.app/expo/issue/ENG-1511#comment-708b7129)

# How

Add a note to the "Without unimodules" tab about replacing the correct module name.

# Test Plan

`cd docs && yarn run dev`, http://localhost:3002/clients/installation/, ensure tab in question renders correctly.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).