### PR TITLE
use the same version of `react-test-renderer` across the workspace

### DIFF
--- a/packages/expo-gl/package.json
+++ b/packages/expo-gl/package.json
@@ -44,6 +44,6 @@
   "devDependencies": {
     "@types/invariant": "^2.2.33",
     "expo-module-scripts": "^2.0.0",
-    "react-test-renderer": "~16.11.0"
+    "react-test-renderer": "~16.13.1"
   }
 }

--- a/packages/jest-expo-enzyme/package.json
+++ b/packages/jest-expo-enzyme/package.json
@@ -45,7 +45,7 @@
     "jest-canvas-mock": "~2.2.0",
     "jest-enzyme": "~7.1.2",
     "jest-expo": "~42.0.0",
-    "react-test-renderer": "~16.11.0"
+    "react-test-renderer": "~16.13.1"
   },
   "devDependencies": {
     "@types/enzyme": "^3.10.3",

--- a/packages/jest-expo/package.json
+++ b/packages/jest-expo/package.json
@@ -38,8 +38,8 @@
     "jest-watch-select-projects": "^2.0.0",
     "jest-watch-typeahead": "^0.5.0",
     "json5": "^2.1.0",
-    "lodash": "^4.5.0",
-    "react-test-renderer": "~16.11.0"
+    "lodash": "^4.17.19",
+    "react-test-renderer": "~16.13.1"
   },
   "bugs": {
     "url": "https://github.com/expo/expo/issues"

--- a/yarn.lock
+++ b/yarn.lock
@@ -14332,7 +14332,7 @@ lodash@4.17.21, lodash@~4.17.0:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
-"lodash@>=3.5 <5", lodash@^4.15.0, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0, lodash@^4.5.0:
+"lodash@>=3.5 <5", lodash@^4.15.0, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
@@ -17702,16 +17702,6 @@ react-test-renderer@^16.0.0-0, react-test-renderer@~16.13.1:
     react-is "^16.8.6"
     scheduler "^0.19.1"
 
-react-test-renderer@~16.11.0:
-  version "16.11.0"
-  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.11.0.tgz#72574566496462c808ac449b0287a4c0a1a7d8f8"
-  integrity sha512-nh9gDl8R4ut+ZNNb2EeKO5VMvTKxwzurbSMuGBoKtjpjbg8JK/u3eVPVNi1h1Ue+eYK9oSzJjb+K3lzLxyA4ag==
-  dependencies:
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    react-is "^16.8.6"
-    scheduler "^0.17.0"
-
 react-timer-mixin@^0.13.3, react-timer-mixin@^0.13.4:
   version "0.13.4"
   resolved "https://registry.yarnpkg.com/react-timer-mixin/-/react-timer-mixin-0.13.4.tgz#75a00c3c94c13abe29b43d63b4c65a88fc8264d3"
@@ -18465,14 +18455,6 @@ scheduler@0.19.1, scheduler@^0.19.1:
   version "0.19.1"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.19.1.tgz#4f3e2ed2c1a7d65681f4c854fa8c5a1ccb40f196"
   integrity sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-
-scheduler@^0.17.0:
-  version "0.17.0"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.17.0.tgz#7c9c673e4ec781fac853927916d1c426b6f3ddfe"
-  integrity sha512-7rro8Io3tnCPuY4la/NuI5F2yfESpnfZyT6TtkXnSWVkcu0BCDJ+8gk5ozUaFaxpIyNuWAPXrH0yFcSi28fnDA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
# Why

Expo ships with React Native `0.63.3` (and React `16.13`) since SDK 40, but there are still packages in the workspace using `react-test-renderer` for React `16.11`. 

# How

This PR aims to remove the older version of `react-test-renderer` from the workspace and bumps the `react-test-renderer` dependency in the few packages. 

# Test Plan

`yarn` and `yarn test` (if available) commands were successfully executed in changed packages directory.