### PR TITLE
[ios] backport misc changes to versioned EXUpdates and EXUpdatesInterface

### DIFF
--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/ABI40_0_0EXUpdatesAppController+Internal.h
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/ABI40_0_0EXUpdatesAppController+Internal.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)initializeUpdatesDatabaseWithError:(NSError ** _Nullable)error;
 
 - (void)setDefaultSelectionPolicy:(ABI40_0_0EXUpdatesSelectionPolicy *)selectionPolicy;
-- (void)setLauncher:(id<ABI40_0_0EXUpdatesAppLauncher>)launcher;
+- (void)setLauncher:(nullable id<ABI40_0_0EXUpdatesAppLauncher>)launcher;
 - (void)setConfigurationInternal:(ABI40_0_0EXUpdatesConfig *)configuration;
 - (void)setIsStarted:(BOOL)isStarted;
 

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/ABI40_0_0EXUpdatesAppController.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/ABI40_0_0EXUpdatesAppController.m
@@ -7,6 +7,7 @@
 #import <ABI40_0_0EXUpdates/ABI40_0_0EXUpdatesReaper.h>
 #import <ABI40_0_0EXUpdates/ABI40_0_0EXUpdatesSelectionPolicyFactory.h>
 #import <ABI40_0_0EXUpdates/ABI40_0_0EXUpdatesUtils.h>
+#import <ABI40_0_0React/ABI40_0_0RCTReloadCommand.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -19,7 +20,7 @@ static NSString * const ABI40_0_0EXUpdatesErrorEventName = @"error";
 @interface ABI40_0_0EXUpdatesAppController ()
 
 @property (nonatomic, readwrite, strong) ABI40_0_0EXUpdatesConfig *config;
-@property (nonatomic, readwrite, strong) id<ABI40_0_0EXUpdatesAppLauncher> launcher;
+@property (nonatomic, readwrite, strong, nullable) id<ABI40_0_0EXUpdatesAppLauncher> launcher;
 @property (nonatomic, readwrite, strong) ABI40_0_0EXUpdatesDatabase *database;
 @property (nonatomic, readwrite, strong) ABI40_0_0EXUpdatesSelectionPolicy *selectionPolicy;
 @property (nonatomic, readwrite, strong) ABI40_0_0EXUpdatesSelectionPolicy *defaultSelectionPolicy;
@@ -113,6 +114,11 @@ static NSString * const ABI40_0_0EXUpdatesErrorEventName = @"error";
                                    reason:@"expo-updates is enabled, but no valid URL is configured under ABI40_0_0EXUpdatesURL. If you are making a release build for the first time, make sure you have run `expo publish` at least once."
                                  userInfo:@{}];
   }
+  if (!_config.scopeKey) {
+    @throw [NSException exceptionWithName:NSInternalInconsistencyException
+                                   reason:@"expo-updates was configured with no scope key. Make sure a valid URL is configured under ABI40_0_0EXUpdatesURL."
+                                 userInfo:@{}];
+  }
 
   _isStarted = YES;
 
@@ -167,24 +173,20 @@ static NSString * const ABI40_0_0EXUpdatesErrorEventName = @"error";
 
 - (void)requestRelaunchWithCompletion:(ABI40_0_0EXUpdatesAppRelaunchCompletionBlock)completion
 {
-  if (_bridge) {
-    ABI40_0_0EXUpdatesAppLauncherWithDatabase *launcher = [[ABI40_0_0EXUpdatesAppLauncherWithDatabase alloc] initWithConfig:_config database:_database directory:_updatesDirectory completionQueue:_controllerQueue];
-    _candidateLauncher = launcher;
-    [launcher launchUpdateWithSelectionPolicy:self.selectionPolicy completion:^(NSError * _Nullable error, BOOL success) {
-      if (success) {
-        self->_launcher = self->_candidateLauncher;
-        completion(YES);
-        [self->_bridge reload];
-        [self runReaper];
-      } else {
-        NSLog(@"Failed to relaunch: %@", error.localizedDescription);
-        completion(NO);
-      }
-    }];
-  } else {
-    NSLog(@"ABI40_0_0EXUpdatesAppController: Failed to reload because bridge was nil. Did you set the bridge property on the controller singleton?");
-    completion(NO);
-  }
+  ABI40_0_0EXUpdatesAppLauncherWithDatabase *launcher = [[ABI40_0_0EXUpdatesAppLauncherWithDatabase alloc] initWithConfig:_config database:_database directory:_updatesDirectory completionQueue:_controllerQueue];
+  _candidateLauncher = launcher;
+  [launcher launchUpdateWithSelectionPolicy:self.selectionPolicy completion:^(NSError * _Nullable error, BOOL success) {
+    if (success) {
+      self->_launcher = self->_candidateLauncher;
+      completion(YES);
+      ABI40_0_0RCTReloadCommandSetBundleURL(launcher.launchAssetUrl);
+      ABI40_0_0RCTTriggerReloadCommandListeners(@"Requested by JavaScript - Updates.reloadAsync()");
+      [self runReaper];
+    } else {
+      NSLog(@"Failed to relaunch: %@", error.localizedDescription);
+      completion(NO);
+    }
+  }];
 }
 
 - (nullable ABI40_0_0EXUpdatesUpdate *)launchedUpdate
@@ -279,7 +281,7 @@ static NSString * const ABI40_0_0EXUpdatesErrorEventName = @"error";
   _defaultSelectionPolicy = selectionPolicy;
 }
 
-- (void)setLauncher:(id<ABI40_0_0EXUpdatesAppLauncher>)launcher
+- (void)setLauncher:(nullable id<ABI40_0_0EXUpdatesAppLauncher>)launcher
 {
   _launcher = launcher;
 }

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/ABI40_0_0EXUpdatesConfig.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/ABI40_0_0EXUpdatesConfig.m
@@ -100,10 +100,6 @@ static NSString * const ABI40_0_0EXUpdatesConfigNeverString = @"NEVER";
   if (!_scopeKey) {
     if (_updateUrl) {
       _scopeKey = [[self class] normalizedURLOrigin:_updateUrl];
-    } else {
-      @throw [NSException exceptionWithName:NSInternalInconsistencyException
-                                     reason:@"expo-updates must be configured with a valid update URL or scope key."
-                                   userInfo:@{}];
     }
   }
 

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/ABI40_0_0EXUpdatesDevLauncherController.h
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/ABI40_0_0EXUpdatesDevLauncherController.h
@@ -1,12 +1,12 @@
 //  Copyright © 2021 650 Industries. All rights reserved.
 
-#import <ABI40_0_0EXUpdatesInterface/ABI40_0_0EXUpdatesInterface.h>
+#import <ABI40_0_0EXUpdatesInterface/ABI40_0_0EXUpdatesExternalInterface.h>
 
 #import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface ABI40_0_0EXUpdatesDevLauncherController : NSObject <ABI40_0_0EXUpdatesInterface>
+@interface ABI40_0_0EXUpdatesDevLauncherController : NSObject <ABI40_0_0EXUpdatesExternalInterface>
 
 + (instancetype)sharedInstance;
 

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/ABI40_0_0EXUpdatesDevLauncherController.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/ABI40_0_0EXUpdatesDevLauncherController.m
@@ -46,6 +46,13 @@ typedef NS_ENUM(NSInteger, ABI40_0_0EXUpdatesDevLauncherErrorCode) {
   }
 }
 
+- (void)reset
+{
+  ABI40_0_0EXUpdatesAppController *controller = ABI40_0_0EXUpdatesAppController.sharedInstance;
+  [controller setLauncher:nil];
+  [controller setIsStarted:NO];
+}
+
 - (NSURL *)launchAssetURL
 {
   return ABI40_0_0EXUpdatesAppController.sharedInstance.launchAssetUrl;
@@ -60,7 +67,7 @@ typedef NS_ENUM(NSInteger, ABI40_0_0EXUpdatesDevLauncherErrorCode) {
   ABI40_0_0EXUpdatesAppController *controller = ABI40_0_0EXUpdatesAppController.sharedInstance;
   ABI40_0_0EXUpdatesConfig *updatesConfiguration = [ABI40_0_0EXUpdatesConfig configWithExpoPlist];
   [updatesConfiguration loadConfigFromDictionary:configuration];
-  if (!updatesConfiguration.updateUrl) {
+  if (!updatesConfiguration.updateUrl || !updatesConfiguration.scopeKey) {
     errorBlock([NSError errorWithDomain:ABI40_0_0EXUpdatesDevLauncherControllerErrorDomain code:ABI40_0_0EXUpdatesDevLauncherErrorCodeInvalidUpdateURL userInfo:@{NSLocalizedDescriptionKey: @"Failed to load update: configuration object must include a valid update URL"}]);
     return;
   }
@@ -75,7 +82,6 @@ typedef NS_ENUM(NSInteger, ABI40_0_0EXUpdatesDevLauncherErrorCode) {
     return;
   }
 
-  [controller setIsStarted:YES];
   [self _setDevelopmentSelectionPolicy];
 
   ABI40_0_0EXUpdatesRemoteAppLoader *loader = [[ABI40_0_0EXUpdatesRemoteAppLoader alloc] initWithConfig:updatesConfiguration database:controller.database directory:controller.updatesDirectory completionQueue:controller.controllerQueue];
@@ -116,6 +122,7 @@ typedef NS_ENUM(NSInteger, ABI40_0_0EXUpdatesDevLauncherErrorCode) {
       return;
     }
 
+    [controller setIsStarted:YES];
     [controller setConfigurationInternal:configuration];
     [controller setLauncher:launcher];
     successBlock(launcher.launchedUpdate.rawManifest.rawManifestJSON);

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/ABI40_0_0EXUpdatesBareUpdate.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/ABI40_0_0EXUpdatesBareUpdate.m
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
   NSString *updateId = manifest.rawId;
   NSNumber *commitTime = manifest.commitTimeNumber;
   NSArray *assets = manifest.assets;
-
+  
   NSAssert(updateId != nil, @"update ID should not be null");
 
   NSUUID *uuid = [[NSUUID alloc] initWithUUIDString:(NSString *)updateId];

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/ABI40_0_0EXUpdatesLegacyUpdate.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/ABI40_0_0EXUpdatesLegacyUpdate.m
@@ -46,18 +46,12 @@ static NSString * const ABI40_0_0EXUpdatesExpoTestDomain = @"expo.test";
 
   NSString *bundleUrlString = manifest.bundleUrl;
   NSArray *assets = manifest.bundledAssets ?: @[];
-
-  id runtimeVersion = manifest.runtimeVersion;
-  if (runtimeVersion && [runtimeVersion isKindOfClass:[NSDictionary class]]) {
-    id runtimeVersionIos = ((NSDictionary *)runtimeVersion)[@"ios"];
-    NSAssert([runtimeVersionIos isKindOfClass:[NSString class]], @"runtimeVersion['ios'] should be a string");
-    update.runtimeVersion = (NSString *)runtimeVersionIos;
-  } else if (runtimeVersion && [runtimeVersion isKindOfClass:[NSString class]]) {
-    update.runtimeVersion = (NSString *)runtimeVersion;
+  
+  if (manifest.runtimeVersion != nil) {
+    update.runtimeVersion = manifest.runtimeVersion;
   } else {
-    NSString *sdkVersion = manifest.sdkVersion;
-    NSAssert(sdkVersion != nil, @"sdkVersion should not be null");
-    update.runtimeVersion = sdkVersion;
+    NSAssert(manifest.sdkVersion != nil, @"sdkVersion should not be null");
+    update.runtimeVersion = manifest.sdkVersion;
   }
 
   NSURL *bundleUrl = [NSURL URLWithString:bundleUrlString];

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/ABI40_0_0EXUpdatesNewUpdate.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/ABI40_0_0EXUpdatesNewUpdate.m
@@ -19,32 +19,32 @@ NS_ASSUME_NONNULL_BEGIN
   ABI40_0_0EXUpdatesUpdate *update = [[ABI40_0_0EXUpdatesUpdate alloc] initWithRawManifest:manifest
                                                                   config:config
                                                                 database:database];
-
+  
   NSString *updateId = manifest.rawId;
   NSString *commitTime = manifest.createdAt;
   NSString *runtimeVersion = manifest.runtimeVersion;
   NSDictionary *launchAsset = manifest.launchAsset;
   NSArray *assets = manifest.assets;
-
+  
   NSAssert(updateId != nil, @"update ID should not be null");
-
+  
   NSUUID *uuid = [[NSUUID alloc] initWithUUIDString:(NSString *)updateId];
   NSAssert(uuid, @"update ID should be a valid UUID");
-
+  
   id bundleUrlString = (NSDictionary *)launchAsset[@"url"];
   NSAssert([bundleUrlString isKindOfClass:[NSString class]], @"launchAsset.url should be a string");
   NSURL *bundleUrl = [NSURL URLWithString:bundleUrlString];
   NSAssert(bundleUrl, @"launchAsset.url should be a valid URL");
-
+  
   NSMutableArray<ABI40_0_0EXUpdatesAsset *> *processedAssets = [NSMutableArray new];
-
+  
   NSString *bundleKey = launchAsset[@"key"];
   ABI40_0_0EXUpdatesAsset *jsBundleAsset = [[ABI40_0_0EXUpdatesAsset alloc] initWithKey:bundleKey type:ABI40_0_0EXUpdatesEmbeddedBundleFileType];
   jsBundleAsset.url = bundleUrl;
   jsBundleAsset.isLaunchAsset = YES;
   jsBundleAsset.mainBundleFilename = ABI40_0_0EXUpdatesEmbeddedBundleFilename;
   [processedAssets addObject:jsBundleAsset];
-
+  
   if (assets) {
     for (NSDictionary *assetDict in (NSArray *)assets) {
       NSAssert([assetDict isKindOfClass:[NSDictionary class]], @"assets must be objects");
@@ -58,24 +58,24 @@ NS_ASSUME_NONNULL_BEGIN
       NSAssert(type && [type isKindOfClass:[NSString class]], @"asset contentType should be a nonnull string");
       NSURL *url = [NSURL URLWithString:(NSString *)urlString];
       NSAssert(url, @"asset url should be a valid URL");
-
+      
       ABI40_0_0EXUpdatesAsset *asset = [[ABI40_0_0EXUpdatesAsset alloc] initWithKey:key type:(NSString *)type];
       asset.url = url;
-
+      
       if (metadata) {
         NSAssert([metadata isKindOfClass:[NSDictionary class]], @"asset metadata should be an object");
         asset.metadata = (NSDictionary *)metadata;
       }
-
+      
       if (mainBundleFilename) {
         NSAssert([mainBundleFilename isKindOfClass:[NSString class]], @"asset localPath should be a string");
         asset.mainBundleFilename = (NSString *)mainBundleFilename;
       }
-
+      
       [processedAssets addObject:asset];
     }
   }
-
+  
   update.updateId = uuid;
   update.commitTime = [ABI40_0_0RCTConvert NSDate:(NSString *)commitTime];
   update.runtimeVersion = (NSString *)runtimeVersion;
@@ -84,13 +84,13 @@ NS_ASSUME_NONNULL_BEGIN
   update.bundleUrl = bundleUrl;
   update.assets = processedAssets;
   update.manifest = manifest.rawManifestJSON;
-
+  
   if ([response isKindOfClass:[NSHTTPURLResponse class]]) {
     NSDictionary *headersDictionary = ((NSHTTPURLResponse *)response).allHeaderFields;
     update.serverDefinedHeaders = [[self class] dictionaryWithStructuredHeader:headersDictionary[@"expo-server-defined-headers"]];
     update.manifestFilters = [[self class] dictionaryWithStructuredHeader:headersDictionary[@"expo-manifest-filters"]];
   }
-
+  
   return update;
 }
 
@@ -99,7 +99,7 @@ NS_ASSUME_NONNULL_BEGIN
   if (!headerString) {
     return nil;
   }
-
+  
   ABI40_0_0EXStructuredHeadersParser *parser = [[ABI40_0_0EXStructuredHeadersParser alloc] initWithRawInput:headerString fieldType:ABI40_0_0EXStructuredHeadersParserFieldTypeDictionary ignoringParameters:YES];
   NSError *error;
   NSDictionary *parserOutput = [parser parseStructuredFieldsWithError:&error];
@@ -107,7 +107,7 @@ NS_ASSUME_NONNULL_BEGIN
     NSLog(@"Error parsing header value: %@", error ? error.localizedDescription : @"Header was not a structured fields dictionary");
     return nil;
   }
-
+  
   NSMutableDictionary *mutableDict = [NSMutableDictionary dictionaryWithCapacity:parserOutput.count];
   [parserOutput enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
     // ignore any dictionary entries whose type is not string, number, or boolean

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/RawManifest/ABI40_0_0EXUpdatesBaseLegacyRawManifest.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/RawManifest/ABI40_0_0EXUpdatesBaseLegacyRawManifest.m
@@ -43,4 +43,8 @@
   return [self.rawManifestJSON nullableStringForKey:@"sdkVersion"];
 }
 
+- (nullable NSArray *)assets {
+  return [self.rawManifestJSON nullableArrayForKey:@"assets"];
+}
+
 @end

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/RawManifest/ABI40_0_0EXUpdatesBaseRawManifest.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/RawManifest/ABI40_0_0EXUpdatesBaseRawManifest.m
@@ -2,6 +2,8 @@
 
 #import <ABI40_0_0EXUpdates/ABI40_0_0EXUpdatesBaseRawManifest.h>
 
+#import <UIKit/UIKit.h>
+
 @implementation ABI40_0_0EXUpdatesBaseRawManifest
 
 - (instancetype)initWithRawManifestJSON:(NSDictionary *)rawManifestJSON {

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/RawManifest/ABI40_0_0EXUpdatesNewRawManifest.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/RawManifest/ABI40_0_0EXUpdatesNewRawManifest.m
@@ -37,7 +37,7 @@
       return [runtimeVersion substringWithRange:matchRange];
     }
   }
-
+  
   return nil;
 }
 

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/RawManifest/ABI40_0_0EXUpdatesRawManifest.h
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/RawManifest/ABI40_0_0EXUpdatesRawManifest.h
@@ -1,5 +1,7 @@
 //  Copyright © 2021 650 Industries. All rights reserved.
 
+#import <Foundation/Foundation.h>
+
 NS_ASSUME_NONNULL_BEGIN
 
 @protocol ABI40_0_0EXUpdatesRawManifestBehavior <NSObject>

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/RawManifest/NSDictionary+ABI40_0_0EXUpdatesRawManifest.h
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdates/ABI40_0_0EXUpdates/Update/RawManifest/NSDictionary+ABI40_0_0EXUpdatesRawManifest.h
@@ -1,5 +1,7 @@
 // Copyright © 2021 650 Industries. All rights reserved.
 
+#import <Foundation/Foundation.h>
+
 NS_ASSUME_NONNULL_BEGIN
 
 @interface NSDictionary (ABI40_0_0EXUpdatesRawManifest)

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdatesInterface/ABI40_0_0EXUpdatesInterface/ABI40_0_0EXUpdatesExternalInterface.h
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXUpdatesInterface/ABI40_0_0EXUpdatesInterface/ABI40_0_0EXUpdatesExternalInterface.h
@@ -18,11 +18,13 @@ typedef BOOL (^ABI40_0_0EXUpdatesManifestBlock) (NSDictionary *manifest);
  * Protocol for modules that depend on expo-updates for loading production updates but do not want
  * to depend on expo-updates or delegate control to the singleton ABI40_0_0EXUpdatesAppController.
  */
-@protocol ABI40_0_0EXUpdatesInterface
+@protocol ABI40_0_0EXUpdatesExternalInterface
 
 @property (nonatomic, weak) id bridge;
 
 - (NSURL *)launchAssetURL;
+
+- (void)reset;
 
 - (void)fetchUpdateWithConfiguration:(NSDictionary *)configuration
                           onManifest:(ABI40_0_0EXUpdatesManifestBlock)manifestBlock

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/ABI41_0_0EXUpdatesAppController+Internal.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/ABI41_0_0EXUpdatesAppController+Internal.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)initializeUpdatesDatabaseWithError:(NSError ** _Nullable)error;
 
 - (void)setDefaultSelectionPolicy:(ABI41_0_0EXUpdatesSelectionPolicy *)selectionPolicy;
-- (void)setLauncher:(id<ABI41_0_0EXUpdatesAppLauncher>)launcher;
+- (void)setLauncher:(nullable id<ABI41_0_0EXUpdatesAppLauncher>)launcher;
 - (void)setConfigurationInternal:(ABI41_0_0EXUpdatesConfig *)configuration;
 - (void)setIsStarted:(BOOL)isStarted;
 

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/ABI41_0_0EXUpdatesAppController.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/ABI41_0_0EXUpdatesAppController.m
@@ -7,6 +7,7 @@
 #import <ABI41_0_0EXUpdates/ABI41_0_0EXUpdatesReaper.h>
 #import <ABI41_0_0EXUpdates/ABI41_0_0EXUpdatesSelectionPolicyFactory.h>
 #import <ABI41_0_0EXUpdates/ABI41_0_0EXUpdatesUtils.h>
+#import <ABI41_0_0React/ABI41_0_0RCTReloadCommand.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -19,7 +20,7 @@ static NSString * const ABI41_0_0EXUpdatesErrorEventName = @"error";
 @interface ABI41_0_0EXUpdatesAppController ()
 
 @property (nonatomic, readwrite, strong) ABI41_0_0EXUpdatesConfig *config;
-@property (nonatomic, readwrite, strong) id<ABI41_0_0EXUpdatesAppLauncher> launcher;
+@property (nonatomic, readwrite, strong, nullable) id<ABI41_0_0EXUpdatesAppLauncher> launcher;
 @property (nonatomic, readwrite, strong) ABI41_0_0EXUpdatesDatabase *database;
 @property (nonatomic, readwrite, strong) ABI41_0_0EXUpdatesSelectionPolicy *selectionPolicy;
 @property (nonatomic, readwrite, strong) ABI41_0_0EXUpdatesSelectionPolicy *defaultSelectionPolicy;
@@ -113,6 +114,11 @@ static NSString * const ABI41_0_0EXUpdatesErrorEventName = @"error";
                                    reason:@"expo-updates is enabled, but no valid URL is configured under ABI41_0_0EXUpdatesURL. If you are making a release build for the first time, make sure you have run `expo publish` at least once."
                                  userInfo:@{}];
   }
+  if (!_config.scopeKey) {
+    @throw [NSException exceptionWithName:NSInternalInconsistencyException
+                                   reason:@"expo-updates was configured with no scope key. Make sure a valid URL is configured under ABI41_0_0EXUpdatesURL."
+                                 userInfo:@{}];
+  }
 
   _isStarted = YES;
 
@@ -167,24 +173,20 @@ static NSString * const ABI41_0_0EXUpdatesErrorEventName = @"error";
 
 - (void)requestRelaunchWithCompletion:(ABI41_0_0EXUpdatesAppRelaunchCompletionBlock)completion
 {
-  if (_bridge) {
-    ABI41_0_0EXUpdatesAppLauncherWithDatabase *launcher = [[ABI41_0_0EXUpdatesAppLauncherWithDatabase alloc] initWithConfig:_config database:_database directory:_updatesDirectory completionQueue:_controllerQueue];
-    _candidateLauncher = launcher;
-    [launcher launchUpdateWithSelectionPolicy:self.selectionPolicy completion:^(NSError * _Nullable error, BOOL success) {
-      if (success) {
-        self->_launcher = self->_candidateLauncher;
-        completion(YES);
-        [self->_bridge reload];
-        [self runReaper];
-      } else {
-        NSLog(@"Failed to relaunch: %@", error.localizedDescription);
-        completion(NO);
-      }
-    }];
-  } else {
-    NSLog(@"ABI41_0_0EXUpdatesAppController: Failed to reload because bridge was nil. Did you set the bridge property on the controller singleton?");
-    completion(NO);
-  }
+  ABI41_0_0EXUpdatesAppLauncherWithDatabase *launcher = [[ABI41_0_0EXUpdatesAppLauncherWithDatabase alloc] initWithConfig:_config database:_database directory:_updatesDirectory completionQueue:_controllerQueue];
+  _candidateLauncher = launcher;
+  [launcher launchUpdateWithSelectionPolicy:self.selectionPolicy completion:^(NSError * _Nullable error, BOOL success) {
+    if (success) {
+      self->_launcher = self->_candidateLauncher;
+      completion(YES);
+      ABI41_0_0RCTReloadCommandSetBundleURL(launcher.launchAssetUrl);
+      ABI41_0_0RCTTriggerReloadCommandListeners(@"Requested by JavaScript - Updates.reloadAsync()");
+      [self runReaper];
+    } else {
+      NSLog(@"Failed to relaunch: %@", error.localizedDescription);
+      completion(NO);
+    }
+  }];
 }
 
 - (nullable ABI41_0_0EXUpdatesUpdate *)launchedUpdate
@@ -279,7 +281,7 @@ static NSString * const ABI41_0_0EXUpdatesErrorEventName = @"error";
   _defaultSelectionPolicy = selectionPolicy;
 }
 
-- (void)setLauncher:(id<ABI41_0_0EXUpdatesAppLauncher>)launcher
+- (void)setLauncher:(nullable id<ABI41_0_0EXUpdatesAppLauncher>)launcher
 {
   _launcher = launcher;
 }

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/ABI41_0_0EXUpdatesConfig.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/ABI41_0_0EXUpdatesConfig.m
@@ -100,10 +100,6 @@ static NSString * const ABI41_0_0EXUpdatesConfigNeverString = @"NEVER";
   if (!_scopeKey) {
     if (_updateUrl) {
       _scopeKey = [[self class] normalizedURLOrigin:_updateUrl];
-    } else {
-      @throw [NSException exceptionWithName:NSInternalInconsistencyException
-                                     reason:@"expo-updates must be configured with a valid update URL or scope key."
-                                   userInfo:@{}];
     }
   }
 

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/ABI41_0_0EXUpdatesDevLauncherController.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/ABI41_0_0EXUpdatesDevLauncherController.h
@@ -1,12 +1,12 @@
 //  Copyright © 2021 650 Industries. All rights reserved.
 
-#import <ABI41_0_0EXUpdatesInterface/ABI41_0_0EXUpdatesInterface.h>
+#import <ABI41_0_0EXUpdatesInterface/ABI41_0_0EXUpdatesExternalInterface.h>
 
 #import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface ABI41_0_0EXUpdatesDevLauncherController : NSObject <ABI41_0_0EXUpdatesInterface>
+@interface ABI41_0_0EXUpdatesDevLauncherController : NSObject <ABI41_0_0EXUpdatesExternalInterface>
 
 + (instancetype)sharedInstance;
 

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/ABI41_0_0EXUpdatesDevLauncherController.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/ABI41_0_0EXUpdatesDevLauncherController.m
@@ -46,6 +46,13 @@ typedef NS_ENUM(NSInteger, ABI41_0_0EXUpdatesDevLauncherErrorCode) {
   }
 }
 
+- (void)reset
+{
+  ABI41_0_0EXUpdatesAppController *controller = ABI41_0_0EXUpdatesAppController.sharedInstance;
+  [controller setLauncher:nil];
+  [controller setIsStarted:NO];
+}
+
 - (NSURL *)launchAssetURL
 {
   return ABI41_0_0EXUpdatesAppController.sharedInstance.launchAssetUrl;
@@ -60,7 +67,7 @@ typedef NS_ENUM(NSInteger, ABI41_0_0EXUpdatesDevLauncherErrorCode) {
   ABI41_0_0EXUpdatesAppController *controller = ABI41_0_0EXUpdatesAppController.sharedInstance;
   ABI41_0_0EXUpdatesConfig *updatesConfiguration = [ABI41_0_0EXUpdatesConfig configWithExpoPlist];
   [updatesConfiguration loadConfigFromDictionary:configuration];
-  if (!updatesConfiguration.updateUrl) {
+  if (!updatesConfiguration.updateUrl || !updatesConfiguration.scopeKey) {
     errorBlock([NSError errorWithDomain:ABI41_0_0EXUpdatesDevLauncherControllerErrorDomain code:ABI41_0_0EXUpdatesDevLauncherErrorCodeInvalidUpdateURL userInfo:@{NSLocalizedDescriptionKey: @"Failed to load update: configuration object must include a valid update URL"}]);
     return;
   }
@@ -75,7 +82,6 @@ typedef NS_ENUM(NSInteger, ABI41_0_0EXUpdatesDevLauncherErrorCode) {
     return;
   }
 
-  [controller setIsStarted:YES];
   [self _setDevelopmentSelectionPolicy];
 
   ABI41_0_0EXUpdatesRemoteAppLoader *loader = [[ABI41_0_0EXUpdatesRemoteAppLoader alloc] initWithConfig:updatesConfiguration database:controller.database directory:controller.updatesDirectory completionQueue:controller.controllerQueue];
@@ -116,6 +122,7 @@ typedef NS_ENUM(NSInteger, ABI41_0_0EXUpdatesDevLauncherErrorCode) {
       return;
     }
 
+    [controller setIsStarted:YES];
     [controller setConfigurationInternal:configuration];
     [controller setLauncher:launcher];
     successBlock(launcher.launchedUpdate.rawManifest.rawManifestJSON);

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/ABI41_0_0EXUpdatesBareUpdate.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/ABI41_0_0EXUpdatesBareUpdate.m
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
   NSString *updateId = manifest.rawId;
   NSNumber *commitTime = manifest.commitTimeNumber;
   NSArray *assets = manifest.assets;
-
+  
   NSAssert(updateId != nil, @"update ID should not be null");
 
   NSUUID *uuid = [[NSUUID alloc] initWithUUIDString:(NSString *)updateId];

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/ABI41_0_0EXUpdatesLegacyUpdate.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/ABI41_0_0EXUpdatesLegacyUpdate.m
@@ -46,18 +46,12 @@ static NSString * const ABI41_0_0EXUpdatesExpoTestDomain = @"expo.test";
 
   NSString *bundleUrlString = manifest.bundleUrl;
   NSArray *assets = manifest.bundledAssets ?: @[];
-
-  id runtimeVersion = manifest.runtimeVersion;
-  if (runtimeVersion && [runtimeVersion isKindOfClass:[NSDictionary class]]) {
-    id runtimeVersionIos = ((NSDictionary *)runtimeVersion)[@"ios"];
-    NSAssert([runtimeVersionIos isKindOfClass:[NSString class]], @"runtimeVersion['ios'] should be a string");
-    update.runtimeVersion = (NSString *)runtimeVersionIos;
-  } else if (runtimeVersion && [runtimeVersion isKindOfClass:[NSString class]]) {
-    update.runtimeVersion = (NSString *)runtimeVersion;
+  
+  if (manifest.runtimeVersion != nil) {
+    update.runtimeVersion = manifest.runtimeVersion;
   } else {
-    NSString *sdkVersion = manifest.sdkVersion;
-    NSAssert(sdkVersion != nil, @"sdkVersion should not be null");
-    update.runtimeVersion = sdkVersion;
+    NSAssert(manifest.sdkVersion != nil, @"sdkVersion should not be null");
+    update.runtimeVersion = manifest.sdkVersion;
   }
 
   NSURL *bundleUrl = [NSURL URLWithString:bundleUrlString];

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/ABI41_0_0EXUpdatesNewUpdate.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/ABI41_0_0EXUpdatesNewUpdate.m
@@ -19,32 +19,32 @@ NS_ASSUME_NONNULL_BEGIN
   ABI41_0_0EXUpdatesUpdate *update = [[ABI41_0_0EXUpdatesUpdate alloc] initWithRawManifest:manifest
                                                                   config:config
                                                                 database:database];
-
+  
   NSString *updateId = manifest.rawId;
   NSString *commitTime = manifest.createdAt;
   NSString *runtimeVersion = manifest.runtimeVersion;
   NSDictionary *launchAsset = manifest.launchAsset;
   NSArray *assets = manifest.assets;
-
+  
   NSAssert(updateId != nil, @"update ID should not be null");
-
+  
   NSUUID *uuid = [[NSUUID alloc] initWithUUIDString:(NSString *)updateId];
   NSAssert(uuid, @"update ID should be a valid UUID");
-
+  
   id bundleUrlString = (NSDictionary *)launchAsset[@"url"];
   NSAssert([bundleUrlString isKindOfClass:[NSString class]], @"launchAsset.url should be a string");
   NSURL *bundleUrl = [NSURL URLWithString:bundleUrlString];
   NSAssert(bundleUrl, @"launchAsset.url should be a valid URL");
-
+  
   NSMutableArray<ABI41_0_0EXUpdatesAsset *> *processedAssets = [NSMutableArray new];
-
+  
   NSString *bundleKey = launchAsset[@"key"];
   ABI41_0_0EXUpdatesAsset *jsBundleAsset = [[ABI41_0_0EXUpdatesAsset alloc] initWithKey:bundleKey type:ABI41_0_0EXUpdatesEmbeddedBundleFileType];
   jsBundleAsset.url = bundleUrl;
   jsBundleAsset.isLaunchAsset = YES;
   jsBundleAsset.mainBundleFilename = ABI41_0_0EXUpdatesEmbeddedBundleFilename;
   [processedAssets addObject:jsBundleAsset];
-
+  
   if (assets) {
     for (NSDictionary *assetDict in (NSArray *)assets) {
       NSAssert([assetDict isKindOfClass:[NSDictionary class]], @"assets must be objects");
@@ -58,24 +58,24 @@ NS_ASSUME_NONNULL_BEGIN
       NSAssert(type && [type isKindOfClass:[NSString class]], @"asset contentType should be a nonnull string");
       NSURL *url = [NSURL URLWithString:(NSString *)urlString];
       NSAssert(url, @"asset url should be a valid URL");
-
+      
       ABI41_0_0EXUpdatesAsset *asset = [[ABI41_0_0EXUpdatesAsset alloc] initWithKey:key type:(NSString *)type];
       asset.url = url;
-
+      
       if (metadata) {
         NSAssert([metadata isKindOfClass:[NSDictionary class]], @"asset metadata should be an object");
         asset.metadata = (NSDictionary *)metadata;
       }
-
+      
       if (mainBundleFilename) {
         NSAssert([mainBundleFilename isKindOfClass:[NSString class]], @"asset localPath should be a string");
         asset.mainBundleFilename = (NSString *)mainBundleFilename;
       }
-
+      
       [processedAssets addObject:asset];
     }
   }
-
+  
   update.updateId = uuid;
   update.commitTime = [ABI41_0_0RCTConvert NSDate:(NSString *)commitTime];
   update.runtimeVersion = (NSString *)runtimeVersion;
@@ -84,13 +84,13 @@ NS_ASSUME_NONNULL_BEGIN
   update.bundleUrl = bundleUrl;
   update.assets = processedAssets;
   update.manifest = manifest.rawManifestJSON;
-
+  
   if ([response isKindOfClass:[NSHTTPURLResponse class]]) {
     NSDictionary *headersDictionary = ((NSHTTPURLResponse *)response).allHeaderFields;
     update.serverDefinedHeaders = [[self class] dictionaryWithStructuredHeader:headersDictionary[@"expo-server-defined-headers"]];
     update.manifestFilters = [[self class] dictionaryWithStructuredHeader:headersDictionary[@"expo-manifest-filters"]];
   }
-
+  
   return update;
 }
 
@@ -99,7 +99,7 @@ NS_ASSUME_NONNULL_BEGIN
   if (!headerString) {
     return nil;
   }
-
+  
   ABI41_0_0EXStructuredHeadersParser *parser = [[ABI41_0_0EXStructuredHeadersParser alloc] initWithRawInput:headerString fieldType:ABI41_0_0EXStructuredHeadersParserFieldTypeDictionary ignoringParameters:YES];
   NSError *error;
   NSDictionary *parserOutput = [parser parseStructuredFieldsWithError:&error];
@@ -107,7 +107,7 @@ NS_ASSUME_NONNULL_BEGIN
     NSLog(@"Error parsing header value: %@", error ? error.localizedDescription : @"Header was not a structured fields dictionary");
     return nil;
   }
-
+  
   NSMutableDictionary *mutableDict = [NSMutableDictionary dictionaryWithCapacity:parserOutput.count];
   [parserOutput enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
     // ignore any dictionary entries whose type is not string, number, or boolean

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/RawManifest/ABI41_0_0EXUpdatesBaseLegacyRawManifest.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/RawManifest/ABI41_0_0EXUpdatesBaseLegacyRawManifest.m
@@ -43,4 +43,8 @@
   return [self.rawManifestJSON nullableStringForKey:@"sdkVersion"];
 }
 
+- (nullable NSArray *)assets {
+  return [self.rawManifestJSON nullableArrayForKey:@"assets"];
+}
+
 @end

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/RawManifest/ABI41_0_0EXUpdatesBaseRawManifest.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/RawManifest/ABI41_0_0EXUpdatesBaseRawManifest.m
@@ -2,6 +2,8 @@
 
 #import <ABI41_0_0EXUpdates/ABI41_0_0EXUpdatesBaseRawManifest.h>
 
+#import <UIKit/UIKit.h>
+
 @implementation ABI41_0_0EXUpdatesBaseRawManifest
 
 - (instancetype)initWithRawManifestJSON:(NSDictionary *)rawManifestJSON {

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/RawManifest/ABI41_0_0EXUpdatesNewRawManifest.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/RawManifest/ABI41_0_0EXUpdatesNewRawManifest.m
@@ -37,7 +37,7 @@
       return [runtimeVersion substringWithRange:matchRange];
     }
   }
-
+  
   return nil;
 }
 

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/RawManifest/ABI41_0_0EXUpdatesRawManifest.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/RawManifest/ABI41_0_0EXUpdatesRawManifest.h
@@ -1,5 +1,7 @@
 //  Copyright © 2021 650 Industries. All rights reserved.
 
+#import <Foundation/Foundation.h>
+
 NS_ASSUME_NONNULL_BEGIN
 
 @protocol ABI41_0_0EXUpdatesRawManifestBehavior <NSObject>

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/RawManifest/NSDictionary+ABI41_0_0EXUpdatesRawManifest.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdates/ABI41_0_0EXUpdates/Update/RawManifest/NSDictionary+ABI41_0_0EXUpdatesRawManifest.h
@@ -1,5 +1,7 @@
 // Copyright © 2021 650 Industries. All rights reserved.
 
+#import <Foundation/Foundation.h>
+
 NS_ASSUME_NONNULL_BEGIN
 
 @interface NSDictionary (ABI41_0_0EXUpdatesRawManifest)

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdatesInterface/ABI41_0_0EXUpdatesInterface/ABI41_0_0EXUpdatesExternalInterface.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXUpdatesInterface/ABI41_0_0EXUpdatesInterface/ABI41_0_0EXUpdatesExternalInterface.h
@@ -18,11 +18,13 @@ typedef BOOL (^ABI41_0_0EXUpdatesManifestBlock) (NSDictionary *manifest);
  * Protocol for modules that depend on expo-updates for loading production updates but do not want
  * to depend on expo-updates or delegate control to the singleton ABI41_0_0EXUpdatesAppController.
  */
-@protocol ABI41_0_0EXUpdatesInterface
+@protocol ABI41_0_0EXUpdatesExternalInterface
 
 @property (nonatomic, weak) id bridge;
 
 - (NSURL *)launchAssetURL;
+
+- (void)reset;
 
 - (void)fetchUpdateWithConfiguration:(NSDictionary *)configuration
                           onManifest:(ABI41_0_0EXUpdatesManifestBlock)manifestBlock

--- a/ios/versioned-react-native/ABI42_0_0/Expo/EXUpdates/ABI42_0_0EXUpdates/ABI42_0_0EXUpdatesAppController+Internal.h
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/EXUpdates/ABI42_0_0EXUpdates/ABI42_0_0EXUpdatesAppController+Internal.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)initializeUpdatesDatabaseWithError:(NSError ** _Nullable)error;
 
 - (void)setDefaultSelectionPolicy:(ABI42_0_0EXUpdatesSelectionPolicy *)selectionPolicy;
-- (void)setLauncher:(id<ABI42_0_0EXUpdatesAppLauncher>)launcher;
+- (void)setLauncher:(nullable id<ABI42_0_0EXUpdatesAppLauncher>)launcher;
 - (void)setConfigurationInternal:(ABI42_0_0EXUpdatesConfig *)configuration;
 - (void)setIsStarted:(BOOL)isStarted;
 

--- a/ios/versioned-react-native/ABI42_0_0/Expo/EXUpdates/ABI42_0_0EXUpdates/ABI42_0_0EXUpdatesAppController.m
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/EXUpdates/ABI42_0_0EXUpdates/ABI42_0_0EXUpdatesAppController.m
@@ -7,6 +7,7 @@
 #import <ABI42_0_0EXUpdates/ABI42_0_0EXUpdatesReaper.h>
 #import <ABI42_0_0EXUpdates/ABI42_0_0EXUpdatesSelectionPolicyFactory.h>
 #import <ABI42_0_0EXUpdates/ABI42_0_0EXUpdatesUtils.h>
+#import <ABI42_0_0React/ABI42_0_0RCTReloadCommand.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -19,7 +20,7 @@ static NSString * const ABI42_0_0EXUpdatesErrorEventName = @"error";
 @interface ABI42_0_0EXUpdatesAppController ()
 
 @property (nonatomic, readwrite, strong) ABI42_0_0EXUpdatesConfig *config;
-@property (nonatomic, readwrite, strong) id<ABI42_0_0EXUpdatesAppLauncher> launcher;
+@property (nonatomic, readwrite, strong, nullable) id<ABI42_0_0EXUpdatesAppLauncher> launcher;
 @property (nonatomic, readwrite, strong) ABI42_0_0EXUpdatesDatabase *database;
 @property (nonatomic, readwrite, strong) ABI42_0_0EXUpdatesSelectionPolicy *selectionPolicy;
 @property (nonatomic, readwrite, strong) ABI42_0_0EXUpdatesSelectionPolicy *defaultSelectionPolicy;
@@ -113,6 +114,11 @@ static NSString * const ABI42_0_0EXUpdatesErrorEventName = @"error";
                                    reason:@"expo-updates is enabled, but no valid URL is configured under ABI42_0_0EXUpdatesURL. If you are making a release build for the first time, make sure you have run `expo publish` at least once."
                                  userInfo:@{}];
   }
+  if (!_config.scopeKey) {
+    @throw [NSException exceptionWithName:NSInternalInconsistencyException
+                                   reason:@"expo-updates was configured with no scope key. Make sure a valid URL is configured under ABI42_0_0EXUpdatesURL."
+                                 userInfo:@{}];
+  }
 
   _isStarted = YES;
 
@@ -167,24 +173,20 @@ static NSString * const ABI42_0_0EXUpdatesErrorEventName = @"error";
 
 - (void)requestRelaunchWithCompletion:(ABI42_0_0EXUpdatesAppRelaunchCompletionBlock)completion
 {
-  if (_bridge) {
-    ABI42_0_0EXUpdatesAppLauncherWithDatabase *launcher = [[ABI42_0_0EXUpdatesAppLauncherWithDatabase alloc] initWithConfig:_config database:_database directory:_updatesDirectory completionQueue:_controllerQueue];
-    _candidateLauncher = launcher;
-    [launcher launchUpdateWithSelectionPolicy:self.selectionPolicy completion:^(NSError * _Nullable error, BOOL success) {
-      if (success) {
-        self->_launcher = self->_candidateLauncher;
-        completion(YES);
-        [self->_bridge reload];
-        [self runReaper];
-      } else {
-        NSLog(@"Failed to relaunch: %@", error.localizedDescription);
-        completion(NO);
-      }
-    }];
-  } else {
-    NSLog(@"ABI42_0_0EXUpdatesAppController: Failed to reload because bridge was nil. Did you set the bridge property on the controller singleton?");
-    completion(NO);
-  }
+  ABI42_0_0EXUpdatesAppLauncherWithDatabase *launcher = [[ABI42_0_0EXUpdatesAppLauncherWithDatabase alloc] initWithConfig:_config database:_database directory:_updatesDirectory completionQueue:_controllerQueue];
+  _candidateLauncher = launcher;
+  [launcher launchUpdateWithSelectionPolicy:self.selectionPolicy completion:^(NSError * _Nullable error, BOOL success) {
+    if (success) {
+      self->_launcher = self->_candidateLauncher;
+      completion(YES);
+      ABI42_0_0RCTReloadCommandSetBundleURL(launcher.launchAssetUrl);
+      ABI42_0_0RCTTriggerReloadCommandListeners(@"Requested by JavaScript - Updates.reloadAsync()");
+      [self runReaper];
+    } else {
+      NSLog(@"Failed to relaunch: %@", error.localizedDescription);
+      completion(NO);
+    }
+  }];
 }
 
 - (nullable ABI42_0_0EXUpdatesUpdate *)launchedUpdate
@@ -279,7 +281,7 @@ static NSString * const ABI42_0_0EXUpdatesErrorEventName = @"error";
   _defaultSelectionPolicy = selectionPolicy;
 }
 
-- (void)setLauncher:(id<ABI42_0_0EXUpdatesAppLauncher>)launcher
+- (void)setLauncher:(nullable id<ABI42_0_0EXUpdatesAppLauncher>)launcher
 {
   _launcher = launcher;
 }

--- a/ios/versioned-react-native/ABI42_0_0/Expo/EXUpdates/ABI42_0_0EXUpdates/ABI42_0_0EXUpdatesConfig.m
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/EXUpdates/ABI42_0_0EXUpdates/ABI42_0_0EXUpdatesConfig.m
@@ -100,10 +100,6 @@ static NSString * const ABI42_0_0EXUpdatesConfigNeverString = @"NEVER";
   if (!_scopeKey) {
     if (_updateUrl) {
       _scopeKey = [[self class] normalizedURLOrigin:_updateUrl];
-    } else {
-      @throw [NSException exceptionWithName:NSInternalInconsistencyException
-                                     reason:@"expo-updates must be configured with a valid update URL or scope key."
-                                   userInfo:@{}];
     }
   }
 

--- a/ios/versioned-react-native/ABI42_0_0/Expo/EXUpdates/ABI42_0_0EXUpdates/ABI42_0_0EXUpdatesDevLauncherController.m
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/EXUpdates/ABI42_0_0EXUpdates/ABI42_0_0EXUpdatesDevLauncherController.m
@@ -46,6 +46,13 @@ typedef NS_ENUM(NSInteger, ABI42_0_0EXUpdatesDevLauncherErrorCode) {
   }
 }
 
+- (void)reset
+{
+  ABI42_0_0EXUpdatesAppController *controller = ABI42_0_0EXUpdatesAppController.sharedInstance;
+  [controller setLauncher:nil];
+  [controller setIsStarted:NO];
+}
+
 - (NSURL *)launchAssetURL
 {
   return ABI42_0_0EXUpdatesAppController.sharedInstance.launchAssetUrl;
@@ -60,7 +67,7 @@ typedef NS_ENUM(NSInteger, ABI42_0_0EXUpdatesDevLauncherErrorCode) {
   ABI42_0_0EXUpdatesAppController *controller = ABI42_0_0EXUpdatesAppController.sharedInstance;
   ABI42_0_0EXUpdatesConfig *updatesConfiguration = [ABI42_0_0EXUpdatesConfig configWithExpoPlist];
   [updatesConfiguration loadConfigFromDictionary:configuration];
-  if (!updatesConfiguration.updateUrl) {
+  if (!updatesConfiguration.updateUrl || !updatesConfiguration.scopeKey) {
     errorBlock([NSError errorWithDomain:ABI42_0_0EXUpdatesDevLauncherControllerErrorDomain code:ABI42_0_0EXUpdatesDevLauncherErrorCodeInvalidUpdateURL userInfo:@{NSLocalizedDescriptionKey: @"Failed to load update: configuration object must include a valid update URL"}]);
     return;
   }
@@ -75,7 +82,6 @@ typedef NS_ENUM(NSInteger, ABI42_0_0EXUpdatesDevLauncherErrorCode) {
     return;
   }
 
-  [controller setIsStarted:YES];
   [self _setDevelopmentSelectionPolicy];
 
   ABI42_0_0EXUpdatesRemoteAppLoader *loader = [[ABI42_0_0EXUpdatesRemoteAppLoader alloc] initWithConfig:updatesConfiguration database:controller.database directory:controller.updatesDirectory completionQueue:controller.controllerQueue];
@@ -116,6 +122,7 @@ typedef NS_ENUM(NSInteger, ABI42_0_0EXUpdatesDevLauncherErrorCode) {
       return;
     }
 
+    [controller setIsStarted:YES];
     [controller setConfigurationInternal:configuration];
     [controller setLauncher:launcher];
     successBlock(launcher.launchedUpdate.rawManifest.rawManifestJSON);

--- a/ios/versioned-react-native/ABI42_0_0/Expo/EXUpdates/ABI42_0_0EXUpdates/Update/RawManifest/ABI42_0_0EXUpdatesBaseLegacyRawManifest.m
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/EXUpdates/ABI42_0_0EXUpdates/Update/RawManifest/ABI42_0_0EXUpdatesBaseLegacyRawManifest.m
@@ -43,4 +43,8 @@
   return [self.rawManifestJSON nullableStringForKey:@"sdkVersion"];
 }
 
+- (nullable NSArray *)assets {
+  return [self.rawManifestJSON nullableArrayForKey:@"assets"];
+}
+
 @end

--- a/ios/versioned-react-native/ABI42_0_0/Expo/EXUpdates/ABI42_0_0EXUpdates/Update/RawManifest/ABI42_0_0EXUpdatesNewRawManifest.m
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/EXUpdates/ABI42_0_0EXUpdates/Update/RawManifest/ABI42_0_0EXUpdatesNewRawManifest.m
@@ -37,7 +37,7 @@
       return [runtimeVersion substringWithRange:matchRange];
     }
   }
-
+  
   return nil;
 }
 

--- a/ios/versioned-react-native/ABI42_0_0/Expo/EXUpdatesInterface/ABI42_0_0EXUpdatesInterface/ABI42_0_0EXUpdatesExternalInterface.h
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/EXUpdatesInterface/ABI42_0_0EXUpdatesInterface/ABI42_0_0EXUpdatesExternalInterface.h
@@ -24,6 +24,8 @@ typedef BOOL (^ABI42_0_0EXUpdatesManifestBlock) (NSDictionary *manifest);
 
 - (NSURL *)launchAssetURL;
 
+- (void)reset;
+
 - (void)fetchUpdateWithConfiguration:(NSDictionary *)configuration
                           onManifest:(ABI42_0_0EXUpdatesManifestBlock)manifestBlock
                             progress:(ABI42_0_0EXUpdatesProgressBlock)progressBlock


### PR DESCRIPTION
# Why

Backport the current master branch expo-updates to ABI40, ABI41, and ABI42 on iOS. This is possible (as in #13150 and similar) because none of these changes touch the JS API for updates.

Multiple commits have landed since the module was last backported; thus, this PR backports the following commits:

- 7e08b5a68d1e211eff190995e2fc9470acb01929 to 40 and 41 (@esamelson)
- 918c53a46b4f17dfa1f28c7872909af8921f6961 (@esamelson)
- b032029e5c20834ce367e1f22c0ae984a47a1bc7 (@jkhales)
- 937e962b56bf7fc913d0e26c58b9599ce6c22013 (@jkhales)
- b3a1db07a1ab4ccdd4ae4cc81e532a5e38d861f2 (@esamelson)
- ab09c40f8f98e2d68aad553969e193e0a0fc7236 (@esamelson)
- numerous other small changes to `Manifest`/`Update` files that seem to be the result of manual backporting in other commits

# How

Followed the process from #13150, replacing 39 with 42.

Modified the process for expo-updates-interface to look like this:

```
rm -rf ios/versioned-react-native/ABI40_0_0/Expo/EXUpdatesInterface
et add-sdk-version -p ios -s 40.0.0 --package expo-updates-interface --prevent-reinstall
rm -rf ios/versioned-react-native/ABI41_0_0/Expo/EXUpdatesInterface
et add-sdk-version -p ios -s 41.0.0 --package expo-updates-interface --prevent-reinstall
rm -rf ios/versioned-react-native/ABI42_0_0/Expo/EXUpdatesInterface
et add-sdk-version -p ios -s 42.0.0 --package expo-updates-interface --prevent-reinstall
git checkout -- ios/versioned-react-native/ABI40_0_0/Expo/EXUpdatesInterface/package.json
git checkout -- ios/versioned-react-native/ABI41_0_0/Expo/EXUpdatesInterface/package.json
git add .
git commit -m "update versioned expo-updates-interface"
```

# Test Plan

Build iOS Expo Go (versioned target) locally. For each of SDK {40,41,42}, open a published project, publish an update, use module methods to check, fetch, and reload with new update.

Had to revert [this commit](https://github.com/expo/expo/commit/3f213569385d1833c7dd5df2d079a4069c2dc527) by @tsapeta in order to get the project to build locally; not sure if this is just a local issue or not. Also needed to run home locally in order to get [this change](https://github.com/expo/expo/pull/13293).

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).