### PR TITLE
[github] add notice about dev-client version to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/dev_client_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/dev_client_bug_report.yml
@@ -8,6 +8,9 @@ body:
   - type: markdown
     attributes:
       value: If you leave out sections there is a high likelihood your issue will be closed. If you have a question, not a bug report, please post it on our [forums](https://forums.expo.io/) instead.
+  - type: markdown
+    attributes:
+      value: 'IMPORTANT: Before filling out this template further, ensure you have the latest version of the `expo-dev-client` package. If not, try upgrading first and see if that fixes your issue.'
   - type: textarea
     attributes:
       label: Summary

--- a/.github/ISSUE_TEMPLATE/dev_client_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/dev_client_bug_report.yml
@@ -10,7 +10,7 @@ body:
       value: If you leave out sections there is a high likelihood your issue will be closed. If you have a question, not a bug report, please post it on our [forums](https://forums.expo.io/) instead.
   - type: markdown
     attributes:
-      value: 'IMPORTANT: Before filling out this template further, ensure you have the latest version of the `expo-dev-client` package. If not, try upgrading first and see if that fixes your issue.'
+      value: 'IMPORTANT: Before filling out this template further, ensure you have the latest version of the `expo-dev-client` package, `expo-cli`, and (if applicable) `eas-cli`. If not, try upgrading first and see if that fixes your issue.'
   - type: textarea
     attributes:
       label: Summary


### PR DESCRIPTION
# Why

We probably want people reporting dev client issues to check them against the latest version of `expo-dev-client` as much as possible, to head off confusion and wasted time in trying to reproduce issues.

# How

Add a notice to the top of the issue template.

# Test Plan

[Preview](https://github.com/expo/expo/blob/8b7353fd016b62f885889b418de453fbad09c3f4/.github/ISSUE_TEMPLATE/dev_client_bug_report.yml)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).