### PR TITLE
@tc/dev client docs 0713

### DIFF
--- a/docs/pages/clients/getting-started.md
+++ b/docs/pages/clients/getting-started.md
@@ -9,13 +9,17 @@ import { Tab, Tabs } from '~/components/plugins/Tabs';
 
 `expo-dev-client` has been designed to support any workflow, release process, or set of dependencies in the Expo / React Native ecosystem. Whatever the needs of your project, either now or in the future, you'll be able to create custom development clients for it and get the productivity and quality of life improvements of JavaScript-driven development.
 
-Of course, there are always tradeoffs, and that flexibility means there's not just one way to get started!  If you're ever not sure how to proceed, we've used ✨sparkles✨ to indicate our most magical experience, and 👷builders👷 for alternate options that may require more configuration or set up to get working.   
+Of course, there are always tradeoffs, and that flexibility means there's not just one way to get started! To help you choose the options that are right for you, these icons indicate: 
+
+> ✨ The quickest way to get up and running
+
+> 👷 Advanced options that may require additional configuration
 
 ## Installing the Development Client module in your project
 
 If you have used Expo before, especially with the Managed workflow, [config plugins](/guides/config-plugins.md) will let you customize your project from JavaScript without ever needing to directly modify Xcode or Android Studio projects.
 
-<Tabs tabs={["✨With config plugins✨", "👷If you are directly managing your native projects👷"]}>
+<Tabs tabs={["✨ With config plugins ✨", "👷 If you are directly managing your native projects 👷"]}>
 
 <Tab >
 <TerminalBlock cmd={["expo init # if you don't already have a Managed Workflow project", "yarn add expo-dev-client"]}  />
@@ -42,7 +46,7 @@ Custom clients use deep links to open projects from the QR code. If you have add
 
 ## Building and installing your first custom client
 
-### ✨In the cloud✨
+### ✨ In the cloud ✨
 
 However you choose to manage your native projects, we recommend using [EAS Build](eas-build.md) for the smoothest experience, especially if you do not have experience with Xcode and Android Studio builds.
 
@@ -70,7 +74,7 @@ Once you have all of the iOS devices you would like to install a custom client o
 
 and installing the resulting build on your device.
 
-### 👷Locally👷
+### 👷 Locally 👷
 
 If you are comfortable setting up Xcode, Android Studio, and related dependencies, you can build and distribute your app the same as any other iOS or Android application.
 

--- a/docs/pages/clients/installation.md
+++ b/docs/pages/clients/installation.md
@@ -129,7 +129,7 @@ There are a few more changes you can make to get the best experience, but you [c
 
 ### Enable development with Expo CLI
 
-Expo CLI requires you to have the `expo` package installed so it can maintain consistent behavior in your project when new versions of the Expo SDK are released.  The package will not be used directly by you project unless you import it in your application code, which is not recommended.
+Expo CLI requires you to have the `expo` package installed so it can maintain consistent behavior in your project when new versions of the Expo SDK are released.  The package will not be used directly by your project unless you import it in your application code, which is not recommended.
 
 <InstallSection packageName="expo" cmd={["npm install expo --save-dev"]} hideBareInstructions />
 

--- a/docs/pages/clients/installation.md
+++ b/docs/pages/clients/installation.md
@@ -127,6 +127,12 @@ Make the following changes to allow the Development Client to control project in
 
 There are a few more changes you can make to get the best experience, but you [can skip ahead to building](/clients/getting-started/#building-and-installing-your-first-custom-client) if you prefer.
 
+### Enable development with Expo CLI
+
+Expo CLI requires you to have the `expo` package installed so it can maintain consistent behavior in your project when new versions of the Expo SDK are released.  The package will not be used directly by you project unless you import it in your application code, which is not recommended.
+
+<InstallSection packageName="expo" cmd={["npm install expo --save-dev"]} hideBareInstructions />
+
 ### Disable packager autostart when building for iOS
 
 When you start your project on iOS, the metro bundler will be started automatically. This behavior might not be ideal when you want to use `expo start`. Our recommended solution is to remove the `Start Packager` action from building scripts. To do that you need to open the Xcode, go to `Project settings` > `Build Phases` and remove the `Start Packager` action.

--- a/docs/pages/clients/introduction.md
+++ b/docs/pages/clients/introduction.md
@@ -18,11 +18,10 @@ Depending on your project, you may find that you need to customize the standard 
 
 ## How it works
 
-
 <object width="100%" height="400">
-  <param name="movie" value="https://youtube.com/embed/5c60VHxUBo8" />
+  <param name="movie" value="https://youtube.com/embed/_SWalkrP0CA" />
   <param name="wmode" value="transparent" />
-  <embed src="https://youtube.com/embed/5c60VHxUBo8" type="application/x-shockwave-flash" wmode="transparent" width="100%" height="400" />
+  <embed src="https://youtube.com/embed/_SWalkrP0CA" type="application/x-shockwave-flash" wmode="transparent" width="100%" height="400" />
 </object>
 
 `expo-dev-client` is an npm package installable in any Expo or React Native project. Once installed, any Debug builds of your application will gain an extensible debug menu and the ability to load projects from Expo CLI. Release builds of your application will not change other than the addition of a few header files.

--- a/docs/pages/clients/introduction.md
+++ b/docs/pages/clients/introduction.md
@@ -4,7 +4,7 @@ title: Introduction
 
 import ImageSpotlight from '~/components/plugins/ImageSpotlight'
 
-> ⏩ Want to create a custom client for your project?  Follow the [getting started guide](getting-started.md).
+> ⏩ Want to create a custom client for your project?  Follow the [Getting Started guide](getting-started.md).
 
 > 👀 Want to get notified of new releases with a changelog and upgrade instructions?  Sign up for the [mailing list](https://expo.dev/mailing-list/dev-client).
 

--- a/docs/pages/clients/introduction.md
+++ b/docs/pages/clients/introduction.md
@@ -6,6 +6,8 @@ import ImageSpotlight from '~/components/plugins/ImageSpotlight'
 
 > ⏩ Want to create a custom client for your project?  Follow the [getting started guide](getting-started.md).
 
+> 👀 Want to get notified of new releases with a changelog and upgrade instructions?  Sign up for the [mailing list](https://expo.dev/mailing-list/dev-client).
+
 **Expo Clients** provide a precompiled runtime that can load and run applications built with Expo. With a compatible client for each platform an application targets, you can focus your time and energy building your application fully in JavaScript and gain the developer experience that Expo is known for:
 
 - Easy for new developers without native experience to join the team

--- a/docs/pages/clients/introduction.md
+++ b/docs/pages/clients/introduction.md
@@ -4,7 +4,7 @@ title: Introduction
 
 import ImageSpotlight from '~/components/plugins/ImageSpotlight'
 
-> ⏩ Want to create a custom client for your project?  Follow the [getting started guide](/getting-started.md).
+> ⏩ Want to create a custom client for your project?  Follow the [getting started guide](getting-started.md).
 
 **Expo Clients** provide a precompiled runtime that can load and run applications built with Expo. With a compatible client for each platform an application targets, you can focus your time and energy building your application fully in JavaScript and gain the developer experience that Expo is known for:
 
@@ -35,7 +35,7 @@ Your debug builds can be shared with anyone on your team who needs to work on or
 - Develop in the same environment as your released application
 - Access to the full power of Xcode and Android Studio when you need them
 
-> ⏩ [Create a custom client for your project](/getting-started.md).
+> ⏩ [Create a custom client for your project](getting-started.md).
 
 ### If you are using React Native CLI
 
@@ -46,4 +46,4 @@ Your debug builds can be shared with anyone on your team who needs to work on or
 - Improved developer experience of Expo CLI
 
 
-> ⏩ [Create a custom client for your project](/installation.md).
+> ⏩ [Create a custom client for your project](installation.md).

--- a/docs/pages/clients/introduction.md
+++ b/docs/pages/clients/introduction.md
@@ -4,6 +4,8 @@ title: Introduction
 
 import ImageSpotlight from '~/components/plugins/ImageSpotlight'
 
+> ⏩ Want to create a custom client for your project?  Follow the [getting started guide](/getting-started.md).
+
 **Expo Clients** provide a precompiled runtime that can load and run applications built with Expo. With a compatible client for each platform an application targets, you can focus your time and energy building your application fully in JavaScript and gain the developer experience that Expo is known for:
 
 - Easy for new developers without native experience to join the team
@@ -33,6 +35,8 @@ Your debug builds can be shared with anyone on your team who needs to work on or
 - Develop in the same environment as your released application
 - Access to the full power of Xcode and Android Studio when you need them
 
+> ⏩ [Create a custom client for your project](/getting-started.md).
+
 ### If you are using React Native CLI
 
 - Develop iOS applications without a machine running MacOS
@@ -40,3 +44,6 @@ Your debug builds can be shared with anyone on your team who needs to work on or
 - Develop using any available port
 - Quickly connect to your device via QR code
 - Improved developer experience of Expo CLI
+
+
+> ⏩ [Create a custom client for your project](/installation.md).

--- a/docs/pages/feature-preview/index.md
+++ b/docs/pages/feature-preview/index.md
@@ -14,4 +14,4 @@ We decided to publish some of our new features as a preview to get feedback from
 
   - **EAS Submit**: Upload your app to the Apple App Store or Google Play Store from the cloud with one CLI command. [Learn more](/submit/introduction.md).
 
-- **expo-dev-client**: When you need to customize your project beyond the standard runtime provided in Expo Go, you can create a custom development client for your application, install it on your phone, and continue developing. [Learn more](clients/introduction.md).
+- **expo-dev-client**: When you need to customize your project beyond the standard runtime provided in Expo Go, you can create a custom development client for your application, install it on your phone, and continue developing. [Learn more](/clients/introduction.md).


### PR DESCRIPTION
# Why

Closes a bunch of issues in the docs:
- ENG-1523
- ENG-1517
- ENG-1329
- ENG-1320

and fixes a couple of other assorted issues:
- broken link on preview overview page
- poor formatting on getting started page

# Test Plan

`yarn dev`, follow links and play new video
