### PR TITLE
[templates] Added iOS background color support

### DIFF
--- a/templates/expo-template-bare-minimum/ios/HelloWorld/AppDelegate.m
+++ b/templates/expo-template-bare-minimum/ios/HelloWorld/AppDelegate.m
@@ -4,6 +4,7 @@
 #import <React/RCTBundleURLProvider.h>
 #import <React/RCTRootView.h>
 #import <React/RCTLinkingManager.h>
+#import <React/RCTConvert.h>
 
 #import <UMCore/UMModuleRegistry.h>
 #import <UMReactNativeAdapter/UMNativeModulesProxy.h>
@@ -65,7 +66,13 @@ static void InitializeFlipper(UIApplication *application) {
 {
   RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:self.launchOptions];
   RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge moduleName:@"main" initialProperties:nil];
-  rootView.backgroundColor = [[UIColor alloc] initWithRed:1.0f green:1.0f blue:1.0f alpha:1];
+  id rootViewBackgroundColor = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"RCTRootViewBackgroundColor"];
+  if (rootViewBackgroundColor != nil) {
+    rootView.backgroundColor = [RCTConvert UIColor:rootViewBackgroundColor];
+  } else {
+    rootView.backgroundColor = [UIColor whiteColor];
+  }
+
 
   UIViewController *rootViewController = [UIViewController new];
   rootViewController.view = rootView;


### PR DESCRIPTION
# Why

- Resolve ENG-1553

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How

- Added support for the iOS to read the static Info.plist value `RCTRootViewBackgroundColor` which we can safely apply from a config plugin.
