### PR TITLE
Update command from iOS to Android in Google Auth

### DIFF
--- a/docs/pages/guides/authentication.md
+++ b/docs/pages/guides/authentication.md
@@ -1110,7 +1110,7 @@ This can only be used in Standalone, and bare workflow apps. This method cannot 
   - Run `expo credentials:manager -p android` then select "Update upload Keystore" -> "Generate new keystore" -> "Go back to experience overview"
   - Copy your "Google Certificate Fingerprint", it will output a string that looks like `A1:B2:C3` but longer.
 - To test this you can:
-  1. Eject to bare: `expo eject` and run `yarn ios`
+  1. Eject to bare: `expo eject` and run `yarn android`
   2. Build a production IPA: `expo build:android`
 - Whenever you change the values in `app.json` you'll need to rebuild the native app.
 


### PR DESCRIPTION
The command should be `yarn android` and not `yarn ios`, because it's inside the Android's example.

# Why

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).