### PR TITLE
[expo-constants] fix absolute path in script to inconsistent Podfile.lock

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -1143,7 +1143,7 @@ SPEC CHECKSUMS:
   EXCamera: 5a90a462cd0965bbf5e5ddb725115ac5109869e9
   EXCellular: 73ab436dd57f6b79ce5d6d542f930fc790dac19c
   EXClipboard: c66f7d22ba754496b0fc6b23a2cb9a3e10fa1581
-  EXConstants: 73a9aaa5e2af2889782520c081346dc2c956b38a
+  EXConstants: 0c200d22d140d3f1834dc51c4ebe0465ddaa82c5
   EXContacts: bc06f42aa1bc7fb5ed0f5b29287f772faa33ad55
   EXCrypto: 46e28f1eb7ec3e2ae5aab652fe1dc4d46bafb386
   EXDevice: 6f1eed02c099f5b382a12a40406c58868892aba6
@@ -1194,7 +1194,7 @@ SPEC CHECKSUMS:
   EXStoreReview: 40674cc897a6d7fd249969b86d1833f67b99170a
   EXStructuredHeaders: 384ccdf0c09ed0be8fc73d4b2d70e436cd195975
   EXTaskManager: 91fef764a2ec7690aa8070f862098df064facdc4
-  EXTrackingTransparency: 3632a570eef235f579c2e004f6515ba352bc735f
+  EXTrackingTransparency: dc21f285b53a1780e77d40fd888573f50615ccfc
   EXUpdatesInterface: 8e4f28434a2e6a75803c4ea0ab12cfb07ebb3438
   EXVideoThumbnails: f8a7d2330578131361c0a4f6e981a6e58baf1290
   EXWebBrowser: 76783ba5dcb8699237746ecf41a9643d428a4cc5

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -4034,7 +4034,7 @@ SPEC CHECKSUMS:
   EXCamera: 5a90a462cd0965bbf5e5ddb725115ac5109869e9
   EXCellular: c023099c6d53230d69c03a0ed0b515fbf2ffc5eb
   EXClipboard: c66f7d22ba754496b0fc6b23a2cb9a3e10fa1581
-  EXConstants: 4c1e78f8711b0991bf5bbd37a574e93e7a44a438
+  EXConstants: 0c200d22d140d3f1834dc51c4ebe0465ddaa82c5
   EXContacts: bc06f42aa1bc7fb5ed0f5b29287f772faa33ad55
   EXCrypto: 46e28f1eb7ec3e2ae5aab652fe1dc4d46bafb386
   EXDevice: 6f1eed02c099f5b382a12a40406c58868892aba6

--- a/packages/expo-constants/CHANGELOG.md
+++ b/packages/expo-constants/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- fix `__dir__` absolute path in script_phase making an inconsistent Podfile.lock. ([#13610](https://github.com/expo/expo/pull/13610) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ### ⚠️ Notices

--- a/packages/expo-constants/ios/EXConstants.podspec
+++ b/packages/expo-constants/ios/EXConstants.podspec
@@ -25,7 +25,7 @@ Pod::Spec.new do |s|
 
   s.script_phase = {
     :name => 'Generate app.config for prebuilt Constants.manifest',
-    :script => File.join(__dir__, '..', 'scripts', 'get-app-config-ios.sh'),
+    :script => '$PODS_TARGET_SRCROOT/../scripts/get-app-config-ios.sh',
     :execution_position => :before_compile
   }
 


### PR DESCRIPTION
# Why

Podfile.lock hashes are based on podspec content. the `__dir__` in script_phase is different between hosts and lead to different Podfile.lock.

# How

alternatively, use a static variable `$PODS_TARGET_SRCROOT` that will only translate in xcode build time.

# Test Plan

1. ci passes.
2. make sure app.config is generated.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).