### PR TITLE
[maps] Rerun upgrade react-native-maps to 0.28.0

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/AirMapManager.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/AirMapManager.java
@@ -152,7 +152,6 @@ public class AirMapManager extends ViewGroupManager<AirMapView> {
       }
     }
 
-    view.applyBaseMapPadding(left, top, right, bottom);
     view.map.setPadding(left, top, right, bottom);
   }
 
@@ -236,11 +235,6 @@ public class AirMapManager extends ViewGroupManager<AirMapView> {
   @ReactProp(name = "rotateEnabled", defaultBoolean = false)
   public void setRotateEnabled(AirMapView view, boolean rotateEnabled) {
     view.map.getUiSettings().setRotateGesturesEnabled(rotateEnabled);
-  }
-
-  @ReactProp(name = "scrollDuringRotateOrZoomEnabled", defaultBoolean = true)
-  public void setScrollDuringRotateOrZoomEnabled(AirMapView view, boolean scrollDuringRotateOrZoomEnabled) {
-    view.map.getUiSettings().setScrollGesturesEnabledDuringRotateOrZoom(scrollDuringRotateOrZoomEnabled);
   }
 
   @ReactProp(name = "cacheEnabled", defaultBoolean = false)
@@ -360,7 +354,7 @@ public class AirMapManager extends ViewGroupManager<AirMapView> {
         break;
 
       case FIT_TO_ELEMENTS:
-        view.fitToElements(args.getMap(0), args.getBoolean(1));
+        view.fitToElements(args.getBoolean(0));
         break;
 
       case FIT_TO_SUPPLIED_MARKERS:

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/AirMapModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/AirMapModule.java
@@ -3,8 +3,6 @@ package versioned.host.exp.exponent.modules.api.components.maps;
 import android.app.Activity;
 import android.graphics.Bitmap;
 import android.graphics.Point;
-import android.location.Address;
-import android.location.Geocoder;
 import android.net.Uri;
 import android.util.Base64;
 import android.util.DisplayMetrics;
@@ -30,7 +28,6 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 
-import java.util.List;
 import java.util.Map;
 import java.util.HashMap;
 
@@ -179,57 +176,6 @@ public class AirMapModule extends ReactContextBaseJavaModule {
         cameraJson.putDouble("pitch", (double)position.tilt);
 
         promise.resolve(cameraJson);
-      }
-    });
-  }
-
-  @ReactMethod
-  public void getAddressFromCoordinates(final int tag, final ReadableMap coordinate, final Promise promise) {
-    final ReactApplicationContext context = getReactApplicationContext();
-
-    UIManagerModule uiManager = context.getNativeModule(UIManagerModule.class);
-    uiManager.addUIBlock(new UIBlock()
-    {
-      @Override
-      public void execute(NativeViewHierarchyManager nvhm)
-      {
-        AirMapView view = (AirMapView) nvhm.resolveView(tag);
-        if (view == null) {
-          promise.reject("AirMapView not found");
-          return;
-        }
-        if (view.map == null) {
-          promise.reject("AirMapView.map is not valid");
-          return;
-        }
-        if (coordinate == null ||
-                !coordinate.hasKey("latitude") ||
-                !coordinate.hasKey("longitude")) {
-          promise.reject("Invalid coordinate format");
-          return;
-        }
-        Geocoder geocoder = new Geocoder(context);
-        try {
-          List<Address> list =
-                  geocoder.getFromLocation(coordinate.getDouble("latitude"),coordinate.getDouble("longitude"),1);
-          Address address = list.get(0);
-
-          WritableMap addressJson = new WritableNativeMap();
-          addressJson.putString("name", address.getFeatureName());
-          addressJson.putString("locality", address.getLocality());
-          addressJson.putString("thoroughfare", address.getThoroughfare());
-          addressJson.putString("subThoroughfare", address.getSubThoroughfare());
-          addressJson.putString("subLocality", address.getSubLocality());
-          addressJson.putString("administrativeArea", address.getAdminArea());
-          addressJson.putString("subAdministrativeArea", address.getSubAdminArea());
-          addressJson.putString("postalCode", address.getPostalCode());
-          addressJson.putString("countryCode", address.getCountryCode());
-          addressJson.putString("country", address.getCountryName());
-
-          promise.resolve(addressJson);
-        } catch (IOException e) {
-          promise.reject("Can not get address location");
-        }
       }
     });
   }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/AirMapOverlay.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/AirMapOverlay.java
@@ -20,7 +20,6 @@ public class AirMapOverlay extends AirMapFeature implements ImageReadable {
   private GroundOverlayOptions groundOverlayOptions;
   private GroundOverlay groundOverlay;
   private LatLngBounds bounds;
-  private float bearing;
   private BitmapDescriptor iconBitmapDescriptor;
   private Bitmap iconBitmap;
   private boolean tappable;
@@ -41,13 +40,6 @@ public class AirMapOverlay extends AirMapFeature implements ImageReadable {
     this.bounds = new LatLngBounds(sw, ne);
     if (this.groundOverlay != null) {
       this.groundOverlay.setPositionFromBounds(this.bounds);
-    }
-  }
-
-  public void setBearing(float bearing){
-    this.bearing = bearing;
-    if (this.groundOverlay != null) {
-      this.groundOverlay.setBearing(bearing);
     }
   }
 
@@ -100,7 +92,6 @@ public class AirMapOverlay extends AirMapFeature implements ImageReadable {
     }
     options.positionFromBounds(bounds);
     options.zIndex(zIndex);
-    options.bearing(bearing);
     return options;
   }
 

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/AirMapOverlayManager.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/AirMapOverlayManager.java
@@ -46,11 +46,6 @@ public class AirMapOverlayManager extends ViewGroupManager<AirMapOverlay> {
     view.setBounds(bounds);
   }
 
-  @ReactProp(name = "bearing")
-  public void setBearing(AirMapOverlay view, float bearing){
-    view.setBearing(bearing);
-  }
-
   @ReactProp(name = "zIndex", defaultFloat = 1.0f)
   public void setZIndex(AirMapOverlay view, float zIndex) {
     view.setZIndex(zIndex);

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/AirMapPolyline.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/AirMapPolyline.java
@@ -100,7 +100,6 @@ public class AirMapPolyline extends AirMapFeature {
 
   private void applyPattern() {
     if(patternValues == null) {
-      polyline.setPattern(null);
       return;
     }
     this.pattern = new ArrayList<>(patternValues.size());

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/AirMapView.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/AirMapView.java
@@ -508,7 +508,7 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
 
     builder.tilt((float)camera.getDouble("pitch"));
     builder.bearing((float)camera.getDouble("heading"));
-    builder.zoom((float)camera.getDouble("zoom"));
+    builder.zoom(camera.getInt("zoom"));
 
     CameraUpdate update = CameraUpdateFactory.newCameraPosition(builder.build());
 
@@ -827,7 +827,7 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
     map.animateCamera(CameraUpdateFactory.newLatLng(coordinate), duration, null);
   }
 
-  public void fitToElements(ReadableMap edgePadding, boolean animated) {
+  public void fitToElements(boolean animated) {
     if (map == null) return;
 
     LatLngBounds.Builder builder = new LatLngBounds.Builder();
@@ -845,12 +845,6 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
     if (addedPosition) {
       LatLngBounds bounds = builder.build();
       CameraUpdate cu = CameraUpdateFactory.newLatLngBounds(bounds, baseMapPadding);
-
-      if (edgePadding != null) {
-        map.setPadding(edgePadding.getInt("left"), edgePadding.getInt("top"),
-          edgePadding.getInt("right"), edgePadding.getInt("bottom"));
-      }
-
       if (animated) {
         map.animateCamera(cu);
       } else {
@@ -901,19 +895,6 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
     }
   }
 
-  int baseLeftMapPadding;
-  int baseRightMapPadding;
-  int baseTopMapPadding;
-  int baseBottomMapPadding;
-
-  public void applyBaseMapPadding(int left, int top, int right, int bottom){
-    this.map.setPadding(left, top, right, bottom);
-    baseLeftMapPadding = left;
-    baseRightMapPadding = right;
-    baseTopMapPadding = top;
-    baseBottomMapPadding = bottom;
-  }
-
   public void fitToCoordinates(ReadableArray coordinatesArray, ReadableMap edgePadding,
       boolean animated) {
     if (map == null) return;
@@ -931,7 +912,8 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
     CameraUpdate cu = CameraUpdateFactory.newLatLngBounds(bounds, baseMapPadding);
 
     if (edgePadding != null) {
-      appendMapPadding(edgePadding.getInt("left"), edgePadding.getInt("top"), edgePadding.getInt("right"), edgePadding.getInt("bottom"));
+      map.setPadding(edgePadding.getInt("left"), edgePadding.getInt("top"),
+          edgePadding.getInt("right"), edgePadding.getInt("bottom"));
     }
 
     if (animated) {
@@ -939,26 +921,8 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
     } else {
       map.moveCamera(cu);
     }
-    // Move the google logo to the default base padding value.
-    map.setPadding(baseLeftMapPadding, baseTopMapPadding, baseRightMapPadding, baseBottomMapPadding);
-  }
-
-  private void appendMapPadding(int iLeft,int iTop, int iRight, int iBottom) {
-    int left;
-    int top;
-    int right;
-    int bottom;
-    double density = getResources().getDisplayMetrics().density;
-
-    left = (int) (iLeft * density);
-    top = (int) (iTop * density);
-    right = (int) (iRight * density);
-    bottom = (int) (iBottom * density);
-
-    map.setPadding(left + baseLeftMapPadding,
-            top + baseTopMapPadding,
-            right + baseRightMapPadding,
-            bottom + baseBottomMapPadding);
+    map.setPadding(0, 0, 0,
+        0); // Without this, the Google logo is moved up by the value of edgePadding.bottom
   }
 
   public double[][] getMapBoundaries() {
@@ -1351,19 +1315,4 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
 
     return airMarker;
   }
-
-  @Override
-  public void requestLayout() {
-    super.requestLayout();
-    post(measureAndLayout);
-  }
-
-  private final Runnable measureAndLayout = new Runnable() {
-    @Override
-    public void run() {
-      measure(MeasureSpec.makeMeasureSpec(getWidth(), MeasureSpec.EXACTLY),
-              MeasureSpec.makeMeasureSpec(getHeight(), MeasureSpec.EXACTLY));
-      layout(getLeft(), getTop(), getRight(), getBottom());
-    }
-  };
 }

--- a/android/versioned-abis/expoview-abi42_0_0/src/main/java/abi42_0_0/host/exp/exponent/modules/api/components/maps/AirMapManager.java
+++ b/android/versioned-abis/expoview-abi42_0_0/src/main/java/abi42_0_0/host/exp/exponent/modules/api/components/maps/AirMapManager.java
@@ -151,7 +151,7 @@ public class AirMapManager extends ViewGroupManager<AirMapView> {
         bottom = (int) (padding.getDouble("bottom") * density);
       }
     }
-    view.applyBaseMapPadding(left, top, right, bottom);
+
     view.map.setPadding(left, top, right, bottom);
   }
 
@@ -235,11 +235,6 @@ public class AirMapManager extends ViewGroupManager<AirMapView> {
   @ReactProp(name = "rotateEnabled", defaultBoolean = false)
   public void setRotateEnabled(AirMapView view, boolean rotateEnabled) {
     view.map.getUiSettings().setRotateGesturesEnabled(rotateEnabled);
-  }
-
-  @ReactProp(name = "scrollDuringRotateOrZoomEnabled", defaultBoolean = true)
-   public void setScrollDuringRotateOrZoomEnabled(AirMapView view, boolean scrollDuringRotateOrZoomEnabled) {
-     view.map.getUiSettings().setScrollGesturesEnabledDuringRotateOrZoom(scrollDuringRotateOrZoomEnabled);
   }
 
   @ReactProp(name = "cacheEnabled", defaultBoolean = false)
@@ -359,7 +354,7 @@ public class AirMapManager extends ViewGroupManager<AirMapView> {
         break;
 
       case FIT_TO_ELEMENTS:
-        view.fitToElements(args.getMap(0), args.getBoolean(1));
+        view.fitToElements(args.getBoolean(0));
         break;
 
       case FIT_TO_SUPPLIED_MARKERS:

--- a/android/versioned-abis/expoview-abi42_0_0/src/main/java/abi42_0_0/host/exp/exponent/modules/api/components/maps/AirMapModule.java
+++ b/android/versioned-abis/expoview-abi42_0_0/src/main/java/abi42_0_0/host/exp/exponent/modules/api/components/maps/AirMapModule.java
@@ -3,8 +3,6 @@ package abi42_0_0.host.exp.exponent.modules.api.components.maps;
 import android.app.Activity;
 import android.graphics.Bitmap;
 import android.graphics.Point;
-import android.location.Address;
-import android.location.Geocoder;
 import android.net.Uri;
 import android.util.Base64;
 import android.util.DisplayMetrics;
@@ -30,7 +28,6 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 
-import java.util.List;
 import java.util.Map;
 import java.util.HashMap;
 
@@ -179,57 +176,6 @@ public class AirMapModule extends ReactContextBaseJavaModule {
         cameraJson.putDouble("pitch", (double)position.tilt);
 
         promise.resolve(cameraJson);
-      }
-    });
-  }
-
-  @ReactMethod
-  public void getAddressFromCoordinates(final int tag, final ReadableMap coordinate, final Promise promise) {
-    final ReactApplicationContext context = getReactApplicationContext();
-
-    UIManagerModule uiManager = context.getNativeModule(UIManagerModule.class);
-    uiManager.addUIBlock(new UIBlock()
-    {
-      @Override
-      public void execute(NativeViewHierarchyManager nvhm)
-      {
-        AirMapView view = (AirMapView) nvhm.resolveView(tag);
-        if (view == null) {
-          promise.reject("AirMapView not found");
-          return;
-        }
-        if (view.map == null) {
-          promise.reject("AirMapView.map is not valid");
-          return;
-        }
-        if (coordinate == null ||
-                !coordinate.hasKey("latitude") ||
-                !coordinate.hasKey("longitude")) {
-          promise.reject("Invalid coordinate format");
-          return;
-        }
-        Geocoder geocoder = new Geocoder(context);
-        try {
-          List<Address> list =
-                  geocoder.getFromLocation(coordinate.getDouble("latitude"),coordinate.getDouble("longitude"),1);
-          Address address = list.get(0);
-
-          WritableMap addressJson = new WritableNativeMap();
-          addressJson.putString("name", address.getFeatureName());
-          addressJson.putString("locality", address.getLocality());
-          addressJson.putString("thoroughfare", address.getThoroughfare());
-          addressJson.putString("subThoroughfare", address.getSubThoroughfare());
-          addressJson.putString("subLocality", address.getSubLocality());
-          addressJson.putString("administrativeArea", address.getAdminArea());
-          addressJson.putString("subAdministrativeArea", address.getSubAdminArea());
-          addressJson.putString("postalCode", address.getPostalCode());
-          addressJson.putString("countryCode", address.getCountryCode());
-          addressJson.putString("country", address.getCountryName());
-
-          promise.resolve(addressJson);
-        } catch (IOException e) {
-          promise.reject("Can not get address location");
-        }
       }
     });
   }

--- a/android/versioned-abis/expoview-abi42_0_0/src/main/java/abi42_0_0/host/exp/exponent/modules/api/components/maps/AirMapOverlay.java
+++ b/android/versioned-abis/expoview-abi42_0_0/src/main/java/abi42_0_0/host/exp/exponent/modules/api/components/maps/AirMapOverlay.java
@@ -20,7 +20,6 @@ public class AirMapOverlay extends AirMapFeature implements ImageReadable {
   private GroundOverlayOptions groundOverlayOptions;
   private GroundOverlay groundOverlay;
   private LatLngBounds bounds;
-  private float bearing;
   private BitmapDescriptor iconBitmapDescriptor;
   private Bitmap iconBitmap;
   private boolean tappable;
@@ -41,13 +40,6 @@ public class AirMapOverlay extends AirMapFeature implements ImageReadable {
     this.bounds = new LatLngBounds(sw, ne);
     if (this.groundOverlay != null) {
       this.groundOverlay.setPositionFromBounds(this.bounds);
-    }
-  }
-
-  public void setBearing(float bearing){
-    this.bearing = bearing;
-    if (this.groundOverlay != null) {
-      this.groundOverlay.setBearing(bearing);
     }
   }
 
@@ -100,7 +92,6 @@ public class AirMapOverlay extends AirMapFeature implements ImageReadable {
     }
     options.positionFromBounds(bounds);
     options.zIndex(zIndex);
-    options.bearing(bearing);
     return options;
   }
 

--- a/android/versioned-abis/expoview-abi42_0_0/src/main/java/abi42_0_0/host/exp/exponent/modules/api/components/maps/AirMapOverlayManager.java
+++ b/android/versioned-abis/expoview-abi42_0_0/src/main/java/abi42_0_0/host/exp/exponent/modules/api/components/maps/AirMapOverlayManager.java
@@ -46,11 +46,6 @@ public class AirMapOverlayManager extends ViewGroupManager<AirMapOverlay> {
     view.setBounds(bounds);
   }
 
-  @ReactProp(name = "bearing")
-  public void setBearing(AirMapOverlay view, float bearing){
-    view.setBearing(bearing);
-  }
-
   @ReactProp(name = "zIndex", defaultFloat = 1.0f)
   public void setZIndex(AirMapOverlay view, float zIndex) {
     view.setZIndex(zIndex);

--- a/android/versioned-abis/expoview-abi42_0_0/src/main/java/abi42_0_0/host/exp/exponent/modules/api/components/maps/AirMapPolyline.java
+++ b/android/versioned-abis/expoview-abi42_0_0/src/main/java/abi42_0_0/host/exp/exponent/modules/api/components/maps/AirMapPolyline.java
@@ -100,7 +100,6 @@ public class AirMapPolyline extends AirMapFeature {
 
   private void applyPattern() {
     if(patternValues == null) {
-      polyline.setPattern(null);
       return;
     }
     this.pattern = new ArrayList<>(patternValues.size());

--- a/android/versioned-abis/expoview-abi42_0_0/src/main/java/abi42_0_0/host/exp/exponent/modules/api/components/maps/AirMapView.java
+++ b/android/versioned-abis/expoview-abi42_0_0/src/main/java/abi42_0_0/host/exp/exponent/modules/api/components/maps/AirMapView.java
@@ -1,7 +1,6 @@
 package abi42_0_0.host.exp.exponent.modules.api.components.maps;
 
 import android.content.Context;
-import android.content.pm.PackageManager;
 import android.content.res.ColorStateList;
 import android.graphics.Bitmap;
 import android.graphics.Color;
@@ -351,8 +350,10 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
       @Override
       public void onCameraMove() {
         LatLngBounds bounds = map.getProjection().getVisibleRegion().latLngBounds;
+
         cameraLastIdleBounds = null;
         boolean isGesture = GoogleMap.OnCameraMoveStartedListener.REASON_GESTURE == cameraMoveReason;
+
         RegionChangeEvent event = new RegionChangeEvent(getId(), bounds, true, isGesture);
         eventDispatcher.dispatchEvent(event);
       }
@@ -430,7 +431,7 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
   }
 
   private boolean hasPermissions() {
-    return checkSelfPermission(getContext(), PERMISSIONS[0]) == PermissionChecker.PERMISSION_GRANTED || 
+    return checkSelfPermission(getContext(), PERMISSIONS[0]) == PermissionChecker.PERMISSION_GRANTED ||
         checkSelfPermission(getContext(), PERMISSIONS[1]) == PermissionChecker.PERMISSION_GRANTED;
   }
 
@@ -507,7 +508,7 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
 
     builder.tilt((float)camera.getDouble("pitch"));
     builder.bearing((float)camera.getDouble("heading"));
-    builder.zoom((float)camera.getDouble("zoom"));
+    builder.zoom(camera.getInt("zoom"));
 
     CameraUpdate update = CameraUpdateFactory.newCameraPosition(builder.build());
 
@@ -826,7 +827,7 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
     map.animateCamera(CameraUpdateFactory.newLatLng(coordinate), duration, null);
   }
 
-  public void fitToElements(ReadableMap edgePadding, boolean animated) {
+  public void fitToElements(boolean animated) {
     if (map == null) return;
 
     LatLngBounds.Builder builder = new LatLngBounds.Builder();
@@ -844,12 +845,6 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
     if (addedPosition) {
       LatLngBounds bounds = builder.build();
       CameraUpdate cu = CameraUpdateFactory.newLatLngBounds(bounds, baseMapPadding);
-
-      if (edgePadding != null) {
-        map.setPadding(edgePadding.getInt("left"), edgePadding.getInt("top"),
-          edgePadding.getInt("right"), edgePadding.getInt("bottom"));
-      }
-
       if (animated) {
         map.animateCamera(cu);
       } else {
@@ -886,31 +881,18 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
     if (addedPosition) {
       LatLngBounds bounds = builder.build();
       CameraUpdate cu = CameraUpdateFactory.newLatLngBounds(bounds, baseMapPadding);
-      
+
       if (edgePadding != null) {
         map.setPadding(edgePadding.getInt("left"), edgePadding.getInt("top"),
           edgePadding.getInt("right"), edgePadding.getInt("bottom"));
-      }   
-      
+      }
+
       if (animated) {
         map.animateCamera(cu);
       } else {
         map.moveCamera(cu);
       }
     }
-  }
-
-  int baseLeftMapPadding;
-  int baseRightMapPadding;
-  int baseTopMapPadding;
-  int baseBottomMapPadding;
-
-  public void applyBaseMapPadding(int left, int top, int right, int bottom){
-    this.map.setPadding(left, top, right, bottom);
-    baseLeftMapPadding = left;
-    baseRightMapPadding = right;
-    baseTopMapPadding = top;
-    baseBottomMapPadding = bottom;
   }
 
   public void fitToCoordinates(ReadableArray coordinatesArray, ReadableMap edgePadding,
@@ -930,7 +912,8 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
     CameraUpdate cu = CameraUpdateFactory.newLatLngBounds(bounds, baseMapPadding);
 
     if (edgePadding != null) {
-      appendMapPadding(edgePadding.getInt("left"), edgePadding.getInt("top"), edgePadding.getInt("right"), edgePadding.getInt("bottom"));
+      map.setPadding(edgePadding.getInt("left"), edgePadding.getInt("top"),
+          edgePadding.getInt("right"), edgePadding.getInt("bottom"));
     }
 
     if (animated) {
@@ -938,26 +921,8 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
     } else {
       map.moveCamera(cu);
     }
-        // Move the google logo to the default base padding value.
-     map.setPadding(baseLeftMapPadding, baseTopMapPadding, baseRightMapPadding, baseBottomMapPadding);
-  }
-
-  private void appendMapPadding(int iLeft,int iTop, int iRight, int iBottom) {
-    int left;
-    int top;
-    int right;
-    int bottom;
-    double density = getResources().getDisplayMetrics().density;
-
-    left = (int) (iLeft * density);
-    top = (int) (iTop * density);
-    right = (int) (iRight * density);
-    bottom = (int) (iBottom * density);
-
-    map.setPadding(left + baseLeftMapPadding,
-            top + baseTopMapPadding,
-            right + baseRightMapPadding,
-            bottom + baseBottomMapPadding);
+    map.setPadding(0, 0, 0,
+        0); // Without this, the Google logo is moved up by the value of edgePadding.bottom
   }
 
   public double[][] getMapBoundaries() {
@@ -1291,13 +1256,13 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
       indoorBuilding.putArray("levels", levelsArray);
       indoorBuilding.putInt("activeLevelIndex", 0);
       indoorBuilding.putBoolean("underground", false);
-      
+
       event.putMap("IndoorBuilding", indoorBuilding);
 
       manager.pushEvent(context, this, "onIndoorBuildingFocused", event);
     }
   }
-  
+
   @Override
   public void onIndoorLevelActivated(IndoorBuilding building) {
     if (building == null) {
@@ -1320,7 +1285,7 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
 
     manager.pushEvent(context, this, "onIndoorLevelActivated", event);
   }
-    
+
   public void setIndoorActiveLevelIndex(int activeLevelIndex) {
     IndoorBuilding building = this.map.getFocusedBuilding();
     if (building != null) {
@@ -1350,19 +1315,4 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
 
     return airMarker;
   }
-  
-  @Override
-  public void requestLayout() {
-    super.requestLayout();
-    post(measureAndLayout);
-  }
-
-  private final Runnable measureAndLayout = new Runnable() {
-    @Override
-    public void run() {
-      measure(MeasureSpec.makeMeasureSpec(getWidth(), MeasureSpec.EXACTLY),
-              MeasureSpec.makeMeasureSpec(getHeight(), MeasureSpec.EXACTLY));
-      layout(getLeft(), getTop(), getRight(), getBottom());
-    }
-  };
 }

--- a/android/versioned-abis/expoview-abi42_0_0/src/main/java/abi42_0_0/host/exp/exponent/modules/api/components/maps/RegionChangeEvent.java
+++ b/android/versioned-abis/expoview-abi42_0_0/src/main/java/abi42_0_0/host/exp/exponent/modules/api/components/maps/RegionChangeEvent.java
@@ -31,7 +31,6 @@ public class RegionChangeEvent extends Event<RegionChangeEvent> {
 
   @Override
   public void dispatch(RCTEventEmitter rctEventEmitter) {
-
     WritableMap event = new WritableNativeMap();
     event.putBoolean("continuous", continuous);
 
@@ -43,7 +42,7 @@ public class RegionChangeEvent extends Event<RegionChangeEvent> {
     region.putDouble("longitudeDelta", bounds.northeast.longitude - bounds.southwest.longitude);
     event.putMap("region", region);
     event.putBoolean("isGesture", isGesture);
-    
+
     rctEventEmitter.receiveEvent(getViewTag(), getEventName(), event);
   }
 }

--- a/ios/Exponent/Versioned/Core/Api/Components/GoogleMaps/AIRGoogleMap.h
+++ b/ios/Exponent/Versioned/Core/Api/Components/GoogleMaps/AIRGoogleMap.h
@@ -54,7 +54,6 @@
 @property (nonatomic, assign) BOOL scrollEnabled;
 @property (nonatomic, assign) BOOL zoomEnabled;
 @property (nonatomic, assign) BOOL rotateEnabled;
-@property (nonatomic, assign) BOOL scrollDuringRotateOrZoomEnabled;
 @property (nonatomic, assign) BOOL pitchEnabled;
 @property (nonatomic, assign) BOOL zoomTapEnabled;
 @property (nonatomic, assign) BOOL showsUserLocation;

--- a/ios/Exponent/Versioned/Core/Api/Components/GoogleMaps/AIRGoogleMap.m
+++ b/ios/Exponent/Versioned/Core/Api/Components/GoogleMaps/AIRGoogleMap.m
@@ -49,7 +49,7 @@ id regionAsJSON(MKCoordinateRegion region) {
            };
 }
 
-@interface AIRGoogleMap () <GMSIndoorDisplayDelegate>
+@interface AIRGoogleMap ()
 
 - (id)eventFromCoordinate:(CLLocationCoordinate2D)coordinate;
 
@@ -95,8 +95,6 @@ id regionAsJSON(MKCoordinateRegion region) {
               context:NULL];
 
     self.origGestureRecognizersMeta = [[NSMutableDictionary alloc] init];
-
-    self.indoorDisplay.delegate = self;
   }
   return self;
 }
@@ -436,14 +434,6 @@ id regionAsJSON(MKCoordinateRegion region) {
 
 - (BOOL)zoomEnabled {
   return self.settings.zoomGestures;
-}
-
-- (void)setScrollDuringRotateOrZoomEnabled:(BOOL)enableScrollGesturesDuringRotateOrZoom {
-  self.settings.allowScrollGesturesDuringRotateOrZoom = enableScrollGesturesDuringRotateOrZoom;
-}
-
-- (BOOL)scrollDuringRotateOrZoomEnabled {
-  return self.settings.allowScrollGesturesDuringRotateOrZoom;
 }
 
 - (void)setZoomTapEnabled:(BOOL)zoomTapEnabled {
@@ -889,63 +879,6 @@ id regionAsJSON(MKCoordinateRegion region) {
     REQUIRES_GOOGLE_MAPS_UTILS();
 #endif
 }
-
-
-- (void) didChangeActiveBuilding: (nullable GMSIndoorBuilding *) building {
-    if (!building) {
-        if (!self.onIndoorBuildingFocused) {
-            return;
-        }
-        self.onIndoorBuildingFocused(@{
-            @"IndoorBuilding": @{
-                    @"activeLevelIndex": @0,
-                    @"underground": @false,
-                    @"levels": [[NSMutableArray alloc]init]
-            }
-        });
-    }
-    NSInteger i = 0;
-    NSMutableArray *arrayLevels = [[NSMutableArray alloc]init];
-    for (GMSIndoorLevel *level in building.levels) {
-        [arrayLevels addObject: @{
-            @"index": @(i),
-            @"name" : level.name,
-            @"shortName" : level.shortName,
-        }];
-        i++;
-    }
-    if (!self.onIndoorBuildingFocused) {
-        return;
-    }
-    self.onIndoorBuildingFocused(@{
-        @"IndoorBuilding": @{
-                @"activeLevelIndex": @(building.defaultLevelIndex),
-                @"underground": @(building.underground),
-                @"levels": arrayLevels
-        }
-    });
-}
-
-- (void) didChangeActiveLevel: (nullable GMSIndoorLevel *)     level {
-    if (!self.onIndoorLevelActivated || !self.indoorDisplay  || !level) {
-        return;
-    }
-    NSInteger i = 0;
-    for (GMSIndoorLevel *buildingLevel in self.indoorDisplay.activeBuilding.levels) {
-        if (buildingLevel.name == level.name && buildingLevel.shortName == level.shortName) {
-            break;
-        }
-        i++;
-    }
-    self.onIndoorLevelActivated(@{
-        @"IndoorLevel": @{
-                @"activeLevelIndex": @(i),
-                @"name": level.name,
-                @"shortName": level.shortName
-        }
-    });
-}
-
 
 @end
 

--- a/ios/Exponent/Versioned/Core/Api/Components/GoogleMaps/AIRGoogleMapManager.h
+++ b/ios/Exponent/Versioned/Core/Api/Components/GoogleMaps/AIRGoogleMapManager.h
@@ -8,8 +8,10 @@
 #ifdef HAVE_GOOGLE_MAPS
 
 #import <React/RCTViewManager.h>
+#import "AIRGoogleMap.h"
 
 @interface AIRGoogleMapManager : RCTViewManager
+@property (nonatomic, assign) AIRGoogleMap *map;
 @property (nonatomic) BOOL isGesture;
 
 @end

--- a/ios/Exponent/Versioned/Core/Api/Components/GoogleMaps/AIRGoogleMapManager.m
+++ b/ios/Exponent/Versioned/Core/Api/Components/GoogleMaps/AIRGoogleMapManager.m
@@ -33,7 +33,7 @@
 static NSString *const RCTMapViewKey = @"MapView";
 
 
-@interface AIRGoogleMapManager() <GMSMapViewDelegate>
+@interface AIRGoogleMapManager() <GMSMapViewDelegate, GMSIndoorDisplayDelegate>
 {
   BOOL didCallOnMapReady;
 }
@@ -51,6 +51,8 @@ RCT_EXPORT_MODULE()
   map.isAccessibilityElement = NO;
   map.accessibilityElementsHidden = NO;
   map.settings.consumesGesturesInView = NO;
+  map.indoorDisplay.delegate = self;
+  self.map = map;
 
   UIPanGestureRecognizer *drag = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(handleMapDrag:)];
   [drag setMinimumNumberOfTouches:1];
@@ -76,7 +78,6 @@ RCT_EXPORT_VIEW_PROPERTY(showsTraffic, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(zoomEnabled, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(rotateEnabled, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(scrollEnabled, BOOL)
-RCT_EXPORT_VIEW_PROPERTY(scrollDuringRotateOrZoomEnabled, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(pitchEnabled, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(zoomTapEnabled, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(showsUserLocation, BOOL)
@@ -261,7 +262,6 @@ RCT_EXPORT_METHOD(animateToBearing:(nonnull NSNumber *)reactTag
 }
 
 RCT_EXPORT_METHOD(fitToElements:(nonnull NSNumber *)reactTag
-                  edgePadding:(nonnull NSDictionary *)edgePadding
                   animated:(BOOL)animated)
 {
   [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
@@ -276,20 +276,9 @@ RCT_EXPORT_METHOD(fitToElements:(nonnull NSNumber *)reactTag
 
       for (AIRGoogleMapMarker *marker in mapView.markers)
         bounds = [bounds includingCoordinate:marker.realMarker.position];
-        
-        GMSCameraUpdate* cameraUpdate;
-        
-        if ([edgePadding count] != 0) {
-            // Set Map viewport
-            CGFloat top = [RCTConvert CGFloat:edgePadding[@"top"]];
-            CGFloat right = [RCTConvert CGFloat:edgePadding[@"right"]];
-            CGFloat bottom = [RCTConvert CGFloat:edgePadding[@"bottom"]];
-            CGFloat left = [RCTConvert CGFloat:edgePadding[@"left"]];
-            
-            cameraUpdate = [GMSCameraUpdate fitBounds:bounds withEdgeInsets:UIEdgeInsetsMake(top, left, bottom, right)];
-        } else {
-            cameraUpdate = [GMSCameraUpdate fitBounds:bounds withPadding:55.0f];
-        }
+
+      GMSCameraUpdate *cameraUpdate = [GMSCameraUpdate fitBounds:bounds withPadding:55.0f];
+
       if (animated) {
         [mapView animateWithCameraUpdate: cameraUpdate];
       } else {
@@ -565,11 +554,11 @@ RCT_EXPORT_METHOD(setIndoorActiveLevelIndex:(nonnull NSNumber *)reactTag
       RCTLogError(@"Invalid view returned from registry, expecting AIRGoogleMap, got: %@", view);
     } else {
       AIRGoogleMap *mapView = (AIRGoogleMap *)view;
-      if (!mapView.indoorDisplay) {
+      if (!self.map.indoorDisplay) {
         return;
       }
-      if ( levelIndex < [mapView.indoorDisplay.activeBuilding.levels count]) {
-        mapView.indoorDisplay.activeLevel = mapView.indoorDisplay.activeBuilding.levels[levelIndex];
+      if ( levelIndex < [self.map.indoorDisplay.activeBuilding.levels count]) {
+        mapView.indoorDisplay.activeLevel = self.map.indoorDisplay.activeBuilding.levels[levelIndex];
       }
     }
   }];
@@ -654,6 +643,63 @@ RCT_EXPORT_METHOD(setIndoorActiveLevelIndex:(nonnull NSNumber *)reactTag
 - (void)mapView:(GMSMapView *)mapView didDragMarker:(GMSMarker *)marker {
   AIRGMSMarker *aMarker = (AIRGMSMarker *)marker;
   [aMarker.fakeMarker didDragMarker:aMarker];
+}
+
+- (void) didChangeActiveBuilding: (nullable GMSIndoorBuilding *) building {
+  if (!building) {
+    if (!self.map.onIndoorBuildingFocused) {
+      return;
+    }
+    self.map.onIndoorBuildingFocused(@{
+                                      @"IndoorBuilding": @{
+                                          @"activeLevelIndex": @0,
+                                          @"underground": @false,
+                                          @"levels": [[NSMutableArray alloc]init]
+                                      }
+    });
+  }
+  NSInteger i = 0;
+  NSMutableArray *arrayLevels = [[NSMutableArray alloc]init];
+  for (GMSIndoorLevel *level in building.levels) {
+    [arrayLevels addObject: @{
+                              @"index": @(i),
+                              @"name" : level.name,
+                              @"shortName" : level.shortName,
+                            }
+    ];
+    i++;
+  }
+  if (!self.map.onIndoorBuildingFocused) {
+    return;
+  }
+  self.map.onIndoorBuildingFocused(@{
+                                    @"IndoorBuilding": @{
+                                        @"activeLevelIndex": @(building.defaultLevelIndex),
+                                        @"underground": @(building.underground),
+                                        @"levels": arrayLevels
+                                    }
+                                  }
+  );
+}
+
+- (void) didChangeActiveLevel: (nullable GMSIndoorLevel *) 	level {
+  if (!self.map.onIndoorLevelActivated || !self.map.indoorDisplay  || !level) {
+    return;
+  }
+  NSInteger i = 0;
+  for (GMSIndoorLevel *buildingLevel in self.map.indoorDisplay.activeBuilding.levels) {
+    if (buildingLevel.name == level.name && buildingLevel.shortName == level.shortName) {
+      break;
+    }
+    i++;
+  }
+  self.map.onIndoorLevelActivated(@{
+                                  @"IndoorLevel": @{
+                                    @"activeLevelIndex": @(i),
+                                    @"name": level.name,
+                                    @"shortName": level.shortName
+                                  }
+  });
 }
 
 - (void)mapView:(GMSMapView *)mapView

--- a/ios/Exponent/Versioned/Core/Api/Components/GoogleMaps/AIRGoogleMapOverlay.h
+++ b/ios/Exponent/Versioned/Core/Api/Components/GoogleMaps/AIRGoogleMapOverlay.h
@@ -20,7 +20,6 @@
 @property (nonatomic, copy) NSArray *boundsRect;
 @property (nonatomic, assign) CGFloat opacity;
 @property (nonatomic, readonly) GMSCoordinateBounds *overlayBounds;
-@property (nonatomic, readonly) double bearing;
 
 @property (nonatomic, weak) RCTBridge *bridge;
 

--- a/ios/Exponent/Versioned/Core/Api/Components/GoogleMaps/AIRGoogleMapOverlay.m
+++ b/ios/Exponent/Versioned/Core/Api/Components/GoogleMaps/AIRGoogleMapOverlay.m
@@ -15,7 +15,6 @@
 @interface AIRGoogleMapOverlay()
   @property (nonatomic, strong, readwrite) UIImage *overlayImage;
   @property (nonatomic, readwrite) GMSCoordinateBounds *overlayBounds;
-  @property (nonatomic) CLLocationDirection bearing;
 @end
 
 @implementation AIRGoogleMapOverlay {
@@ -74,12 +73,6 @@
                                                         coordinate:_northEast];
 
   _overlay.bounds = _overlayBounds;
-}
-
-- (void)setBearing:(double)bearing
-{
-    _bearing = (double)bearing;
-    _overlay.bearing = _bearing;
 }
 
 - (void)setOpacity:(CGFloat)opacity

--- a/ios/Exponent/Versioned/Core/Api/Components/GoogleMaps/AIRGoogleMapOverlayManager.m
+++ b/ios/Exponent/Versioned/Core/Api/Components/GoogleMaps/AIRGoogleMapOverlayManager.m
@@ -17,7 +17,6 @@ RCT_EXPORT_MODULE()
 }
 
 RCT_REMAP_VIEW_PROPERTY(bounds, boundsRect, NSArray)
-RCT_REMAP_VIEW_PROPERTY(bearing, bearing, double)
 RCT_REMAP_VIEW_PROPERTY(image, imageSrc, NSString)
 RCT_REMAP_VIEW_PROPERTY(opacity, opacity, CGFloat)
 

--- a/ios/Exponent/Versioned/Core/Api/Components/Maps/AIRMap.h
+++ b/ios/Exponent/Versioned/Core/Api/Components/Maps/AIRMap.h
@@ -30,7 +30,6 @@ extern const NSInteger AIRMapMaxZoomLevel;
 
 @property (nonatomic, copy) NSString *userLocationAnnotationTitle;
 @property (nonatomic, assign) BOOL followUserLocation;
-@property (nonatomic, assign) BOOL userLocationCalloutEnabled;
 @property (nonatomic, assign) BOOL hasStartedRendering;
 @property (nonatomic, assign) BOOL cacheEnabled;
 @property (nonatomic, assign) BOOL loadingEnabled;

--- a/ios/Exponent/Versioned/Core/Api/Components/Maps/AIRMap.m
+++ b/ios/Exponent/Versioned/Core/Api/Components/Maps/AIRMap.m
@@ -158,8 +158,6 @@ const NSInteger AIRMapMaxZoomLevel = 20;
         [self removeOverlay:(id <MKOverlay>) subview];
     } else if ([subview isKindOfClass:[AIRMapUrlTile class]]) {
         [self removeOverlay:(id <MKOverlay>) subview];
-    } else if ([subview isKindOfClass:[AIRMapWMSTile class]]) {
-        [self removeOverlay:(id <MKOverlay>) subview];
     } else if ([subview isKindOfClass:[AIRMapLocalTile class]]) {
         [self removeOverlay:(id <MKOverlay>) subview];
     } else if ([subview isKindOfClass:[AIRMapOverlay class]]) {
@@ -360,21 +358,6 @@ const NSInteger AIRMapMaxZoomLevel = 20;
     }
 }
 
-- (void)setUserInterfaceStyle:(NSString*)userInterfaceStyle
-{
-    if (@available(iOS 13.0, *)) {
-        if([userInterfaceStyle isEqualToString:@"light"]) {
-            self.overrideUserInterfaceStyle = UIUserInterfaceStyleLight;
-        } else if([userInterfaceStyle isEqualToString:@"dark"]) {
-            self.overrideUserInterfaceStyle = UIUserInterfaceStyleDark;
-        } else {
-            self.overrideUserInterfaceStyle = UIUserInterfaceStyleUnspecified;
-        }
-    } else {
-        NSLog(@"UserInterfaceStyle not supported below iOS 13");
-    }
-}
-
 - (void)setTintColor:(UIColor *)tintColor
 {
     super.tintColor = tintColor;
@@ -383,11 +366,6 @@ const NSInteger AIRMapMaxZoomLevel = 20;
 - (void)setFollowsUserLocation:(BOOL)followsUserLocation
 {
     _followUserLocation = followsUserLocation;
-}
-
-- (void)setUserLocationCalloutEnabled:(BOOL)calloutEnabled
-{
-    _userLocationCalloutEnabled = calloutEnabled;
 }
 
 - (void)setHandlePanDrag:(BOOL)handleMapDrag {

--- a/ios/Exponent/Versioned/Core/Api/Components/Maps/AIRMapManager.m
+++ b/ios/Exponent/Versioned/Core/Api/Components/Maps/AIRMapManager.m
@@ -88,9 +88,7 @@ RCT_REMAP_VIEW_PROPERTY(testID, accessibilityIdentifier, NSString)
 RCT_EXPORT_VIEW_PROPERTY(showsUserLocation, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(tintColor, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(userLocationAnnotationTitle, NSString)
-RCT_EXPORT_VIEW_PROPERTY(userInterfaceStyle, NSString)
 RCT_EXPORT_VIEW_PROPERTY(followsUserLocation, BOOL)
-RCT_EXPORT_VIEW_PROPERTY(userLocationCalloutEnabled, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(showsPointsOfInterest, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(showsBuildings, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(showsCompass, BOOL)
@@ -382,7 +380,6 @@ RCT_EXPORT_METHOD(animateToBearing:(nonnull NSNumber *)reactTag
 }
 
 RCT_EXPORT_METHOD(fitToElements:(nonnull NSNumber *)reactTag
-        edgePadding:(nonnull NSDictionary *)edgePadding
         animated:(BOOL)animated)
 {
     [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
@@ -561,46 +558,6 @@ RCT_EXPORT_METHOD(coordinateForPoint:(nonnull NSNumber *)reactTag
                       @"latitude": @(coordinate.latitude),
                       @"longitude": @(coordinate.longitude),
                       });
-        }
-    }];
-}
-
-RCT_EXPORT_METHOD(getAddressFromCoordinates:(nonnull NSNumber *)reactTag
-                                 coordinate: (NSDictionary *)coordinate
-                                   resolver: (RCTPromiseResolveBlock)resolve
-                                   rejecter:(RCTPromiseRejectBlock)reject)
-{
-    [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
-        id view = viewRegistry[reactTag];
-        if (![view isKindOfClass:[AIRMap class]]) {
-            reject(@"Invalid argument", [NSString stringWithFormat:@"Invalid view returned from registry, expecting AIRMap, got: %@", view], NULL);
-        } else {
-            if (coordinate != nil ||
-                ![[coordinate allKeys] containsObject:@"latitude"] ||
-                ![[coordinate allKeys] containsObject:@"longitude"]) {
-                reject(@"Invalid argument", [NSString stringWithFormat:@"Invalid coordinate format"], NULL);
-            }
-            CLLocation *location = [[CLLocation alloc] initWithLatitude:[coordinate[@"latitude"] doubleValue]
-                                                              longitude:[coordinate[@"longitude"] doubleValue]];
-            CLGeocoder *geoCoder = [[CLGeocoder alloc] init];
-            [geoCoder reverseGeocodeLocation:location
-                           completionHandler:^(NSArray *placemarks, NSError *error) {
-                    if (error == nil && [placemarks count] > 0){
-                        CLPlacemark *placemark = placemarks[0];
-                        resolve(@{
-                            @"name" : [NSString stringWithFormat:@"%@", placemark.name],
-                            @"thoroughfare" : [NSString stringWithFormat:@"%@", placemark.thoroughfare],
-                            @"subThoroughfare" : [NSString stringWithFormat:@"%@", placemark.subThoroughfare],
-                            @"locality" : [NSString stringWithFormat:@"%@", placemark.locality],
-                            @"subLocality" : [NSString stringWithFormat:@"%@", placemark.subLocality],
-                            @"administrativeArea" : [NSString stringWithFormat:@"%@", placemark.administrativeArea],
-                            @"subAdministrativeArea" : [NSString stringWithFormat:@"%@", placemark.subAdministrativeArea],
-                            @"postalCode" : [NSString stringWithFormat:@"%@", placemark.postalCode],
-                            @"countryCode" : [NSString stringWithFormat:@"%@", placemark.ISOcountryCode],
-                            @"country" : [NSString stringWithFormat:@"%@", placemark.country],
-                        });
-                    }
-            }];
         }
     }];
 }
@@ -883,18 +840,6 @@ RCT_EXPORT_METHOD(getAddressFromCoordinates:(nonnull NSNumber *)reactTag
 
 #pragma mark Annotation Stuff
 
-- (void)mapView:(AIRMap *)mapView didAddAnnotationViews:(NSArray<MKAnnotationView *> *)views
-{
-    if(!mapView.userLocationCalloutEnabled){
-        for(MKAnnotationView* view in views){
-            if ([view.annotation isKindOfClass:[MKUserLocation class]]){
-                [view setEnabled:NO];
-                [view setCanShowCallout:NO];
-                break;
-            }
-        }
-    }
-}
 
 
 - (void)mapView:(AIRMap *)mapView didSelectAnnotationView:(MKAnnotationView *)view


### PR DESCRIPTION
# Why

Seems like there might be an issue with the vendored `react-native-maps` module. This is the result of the command below, which makes it possible that we currently aren't using `0.28.0`.

# How

```
$ et update-vendored-module --module react-native-maps --target expo-go --commit v0.28.0
```

# Test Plan

See #13584

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).