### PR TITLE
[stripe][docs] Explain from where to import constants for linking

### DIFF
--- a/docs/pages/versions/unversioned/sdk/stripe.md
+++ b/docs/pages/versions/unversioned/sdk/stripe.md
@@ -68,9 +68,6 @@ If you're relying on redirects, you'll need to pass in a `urlScheme` to `initStr
 ```js
 import * as Linking from 'expo-linking';
 import Constants, { ExecutionEnvironment } from 'expo-constants';
-
-...
-
 urlScheme:
   Constants.executionEnvironment === ExecutionEnvironment.StoreClient
     ? Linking.createURL('/--/')

--- a/docs/pages/versions/unversioned/sdk/stripe.md
+++ b/docs/pages/versions/unversioned/sdk/stripe.md
@@ -68,6 +68,7 @@ If you're relying on redirects, you'll need to pass in a `urlScheme` to `initStr
 ```js
 import * as Linking from 'expo-linking';
 import Constants from 'expo-constants';
+
 urlScheme:
   Constants.executionEnvironment === ExecutionEnvironment.StoreClient
     ? Linking.createURL('/--/')

--- a/docs/pages/versions/unversioned/sdk/stripe.md
+++ b/docs/pages/versions/unversioned/sdk/stripe.md
@@ -66,6 +66,7 @@ For usage information and detailed documentation, please refer to:
 If you're relying on redirects, you'll need to pass in a `urlScheme` to `initStripe`. To make sure you always use the proper `urlScheme`, pass in:
 
 ```js
+import * as Linking from 'expo-linking';
 import Constants, { ExecutionEnvironment } from 'expo-constants';
 
 ...

--- a/docs/pages/versions/unversioned/sdk/stripe.md
+++ b/docs/pages/versions/unversioned/sdk/stripe.md
@@ -66,6 +66,10 @@ For usage information and detailed documentation, please refer to:
 If you're relying on redirects, you'll need to pass in a `urlScheme` to `initStripe`. To make sure you always use the proper `urlScheme`, pass in:
 
 ```js
+import Constants, { ExecutionEnvironment } from 'expo-constants';
+
+...
+
 urlScheme:
   Constants.executionEnvironment === ExecutionEnvironment.StoreClient
     ? Linking.createURL('/--/')

--- a/docs/pages/versions/unversioned/sdk/stripe.md
+++ b/docs/pages/versions/unversioned/sdk/stripe.md
@@ -67,7 +67,7 @@ If you're relying on redirects, you'll need to pass in a `urlScheme` to `initStr
 
 ```js
 import * as Linking from 'expo-linking';
-import Constants, { ExecutionEnvironment } from 'expo-constants';
+import Constants from 'expo-constants';
 urlScheme:
   Constants.executionEnvironment === ExecutionEnvironment.StoreClient
     ? Linking.createURL('/--/')

--- a/docs/pages/versions/v42.0.0/sdk/stripe.md
+++ b/docs/pages/versions/v42.0.0/sdk/stripe.md
@@ -66,6 +66,9 @@ For usage information and detailed documentation, please refer to:
 If you're relying on redirects, you'll need to pass in a `urlScheme` to `initStripe`. To make sure you always use the proper `urlScheme`, pass in:
 
 ```js
+import * as Linking from 'expo-linking';
+import Constants from 'expo-constants';
+
 urlScheme:
   Constants.executionEnvironment === ExecutionEnvironment.StoreClient
     ? Linking.createURL('/--/')


### PR DESCRIPTION
# Why

In Stripe integration docs I found it difficult to understand from where to import contacts for setting the correct urlSchema. 

# How

I've added an import statement in the code snippet.

# Test Plan

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).