### PR TITLE
[dev-launcher][ios] Fix compatibility with RN 0.64

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Fixed error message when trying to load a production app without expo-updates. ([#13458](https://github.com/expo/expo/pull/13458) by [@esamelson](https://github.com/esamelson))
 - Fixed Android release builds. ([#13544](https://github.com/expo/expo/pull/13544) by [@esamelson](https://github.com/esamelson))
 - Fixed web compatibility. ([#13535](https://github.com/expo/expo/pull/13535) by [@lukmccall](https://github.com/lukmccall))
+- Fixed compatibility with React Native 0.64.X. ([#13632](https://github.com/expo/expo/pull/13632) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/ios/Errors/EXDevLauncherRedBox.m
+++ b/packages/expo-dev-launcher/ios/Errors/EXDevLauncherRedBox.m
@@ -136,7 +136,11 @@
     return;
   }
   
-  [self.logBox hide];
+  // hide method was removed from the RCTLogBox interface in RN 0.64
+  if ([self.logBox respondsToSelector:@selector(hide)]) {
+    [self.logBox performSelector:@selector(hide)];
+  }
+
   dispatch_async(dispatch_get_main_queue(), ^{
     [[EXDevLauncherController sharedInstance].errorManager showErrorWithMessage:[self stripAnsi:message] stack:stack];
   });

--- a/packages/expo-dev-launcher/ios/Unsafe/RCTPackagerConnection+EXDevLauncherPackagerConnectionInterceptor.m
+++ b/packages/expo-dev-launcher/ios/Unsafe/RCTPackagerConnection+EXDevLauncherPackagerConnectionInterceptor.m
@@ -61,7 +61,10 @@ static RCTReconnectingWebSocket *createSocketForURL(NSURL * url)
   newSocket.delegate = (id<RCTReconnectingWebSocketDelegate>)self;
   [newSocket start];
   
-  [self setValue:url.absoluteString forKey:@"_serverHostForSocket"];
+  @try {
+    // _serverHostForSocket was removed in RN 0.64
+    [self setValue:url.absoluteString forKey:@"_serverHostForSocket"];
+  } @catch(id exception) {}
   [self setValue:newSocket forKey:@"_socket"];
 }
 


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/13529.
Closes ENG-1546.

# How

Addressed compatibility issues discovered here https://github.com/expo/expo/issues/13529#issuecomment-878864410.

# Test Plan

- Create a simple project with RN 0.64.2 and dev-client