### PR TITLE
[dev-launcher] Use dependency injection & make package more testable

### DIFF
--- a/packages/expo-dev-launcher/android/build.gradle
+++ b/packages/expo-dev-launcher/android/build.gradle
@@ -25,12 +25,18 @@ android {
     versionCode 9
     versionName "0.5.1"
   }
+
   lintOptions {
     abortOnError false
   }
+
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_1_8
     targetCompatibility JavaVersion.VERSION_1_8
+  }
+
+  kotlinOptions {
+    jvmTarget = "1.8"
   }
 
   buildTypes {
@@ -92,6 +98,9 @@ dependencies {
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.3")
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.1")
   implementation "org.jetbrains.kotlin:kotlin-reflect:${safeExtGet('kotlinVersion', '1.4.21')}"
+
+  implementation "io.insert-koin:koin-core:3.1.2"
+  implementation "io.insert-koin:koin-android:3.1.2"
 
   testImplementation "com.google.truth:truth:1.1.2"
   testImplementation "org.robolectric:robolectric:4.3.1"

--- a/packages/expo-dev-launcher/android/build.gradle
+++ b/packages/expo-dev-launcher/android/build.gradle
@@ -99,8 +99,8 @@ dependencies {
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.1")
   implementation "org.jetbrains.kotlin:kotlin-reflect:${safeExtGet('kotlinVersion', '1.4.21')}"
 
-  implementation "io.insert-koin:koin-core:3.1.2"
-  implementation "io.insert-koin:koin-android:3.1.2"
+  api "io.insert-koin:koin-core:3.1.2"
+  api "io.insert-koin:koin-android:3.1.2"
 
   testImplementation "com.google.truth:truth:1.1.2"
   testImplementation "org.robolectric:robolectric:4.3.1"

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
@@ -63,7 +63,7 @@ class DevLauncherController private constructor()
   private val pendingIntentRegistry: DevLauncherIntentRegistryInterface by inject()
   val internalUpdatesInterface: UpdatesInterface? by optInject()
   private var devMenuManager: DevMenuManagerInterface? = null
-  var updatesInterface: UpdatesInterface?
+  override var updatesInterface: UpdatesInterface?
     get() = internalUpdatesInterface
     set(value) = DevLauncherKoinContext.app.koin.loadModules(listOf(module {
       single { value }
@@ -75,7 +75,7 @@ class DevLauncherController private constructor()
   override var manifest: DevLauncherManifest? = null
     private set
   override var latestLoadedApp: Uri? = null
-  var useDeveloperSupport = true
+  override var useDeveloperSupport = true
 
   enum class Mode {
     LAUNCHER, APP

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
@@ -10,26 +10,37 @@ import com.facebook.react.ReactActivityDelegate
 import com.facebook.react.ReactNativeHost
 import com.facebook.react.ReactPackage
 import com.facebook.react.bridge.ReactContext
+import expo.interfaces.devmenu.DevMenuManagerInterface
 import expo.interfaces.devmenu.DevMenuManagerProviderInterface
-import expo.modules.devlauncher.helpers.*
+import expo.modules.devlauncher.helpers.getAppUrlFromDevLauncherUrl
+import expo.modules.devlauncher.helpers.getFieldInClassHierarchy
+import expo.modules.devlauncher.helpers.isDevLauncherUrl
+import expo.modules.devlauncher.helpers.runBlockingOnMainThread
+import expo.modules.devlauncher.koin.DevLauncherKoinComponent
+import expo.modules.devlauncher.koin.DevLauncherKoinContext
+import expo.modules.devlauncher.koin.devLauncherKoin
+import expo.modules.devlauncher.koin.optInject
 import expo.modules.devlauncher.launcher.DevLauncherActivity
 import expo.modules.devlauncher.launcher.DevLauncherClientHost
-import expo.modules.devlauncher.launcher.DevLauncherIntentRegistry
+import expo.modules.devlauncher.launcher.DevLauncherControllerInterface
+import expo.modules.devlauncher.launcher.DevLauncherIntentRegistryInterface
 import expo.modules.devlauncher.launcher.DevLauncherLifecycle
 import expo.modules.devlauncher.launcher.DevLauncherReactActivityDelegateSupplier
 import expo.modules.devlauncher.launcher.DevLauncherRecentlyOpenedAppsRegistry
-import expo.modules.devlauncher.launcher.loaders.DevLauncherLocalAppLoader
-import expo.modules.devlauncher.launcher.loaders.DevLauncherPublishedAppLoader
-import expo.modules.devlauncher.launcher.loaders.DevLauncherReactNativeAppLoader
+import expo.modules.devlauncher.launcher.loaders.DevLauncherAppLoaderFactoryInterface
 import expo.modules.devlauncher.launcher.manifest.DevLauncherManifest
 import expo.modules.devlauncher.launcher.manifest.DevLauncherManifestParser
 import expo.modules.devlauncher.launcher.menu.DevLauncherMenuDelegate
 import expo.modules.devlauncher.react.activitydelegates.DevLauncherReactActivityNOPDelegate
 import expo.modules.devlauncher.react.activitydelegates.DevLauncherReactActivityRedirectDelegate
+import expo.modules.devlauncher.tests.DevLauncherTestInterceptor
 import expo.modules.updatesinterface.UpdatesInterface
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import okhttp3.OkHttpClient
+import org.koin.core.component.get
+import org.koin.core.component.inject
+import org.koin.dsl.module
 
 // Use this to load from a development server for the development client launcher UI
 //  private final String DEV_LAUNCHER_HOST = "10.0.0.175:8090";
@@ -41,30 +52,40 @@ private const val NEW_ACTIVITY_FLAGS = Intent.FLAG_ACTIVITY_NEW_TASK or
 
 private var MenuDelegateWasInitialized = false
 
-class DevLauncherController private constructor(
-  private val context: Context,
-  internal val appHost: ReactNativeHost
-) {
-  val devClientHost = DevLauncherClientHost((context as Application), DEV_LAUNCHER_HOST)
-  private val httpClient = OkHttpClient()
-  private val lifecycle = DevLauncherLifecycle()
+class DevLauncherController private constructor()
+  : DevLauncherKoinComponent, DevLauncherControllerInterface {
+  private val context: Context by lazy {
+    DevLauncherKoinContext.app.koin.get()
+  }
+  override val appHost: ReactNativeHost by inject()
+  private val httpClient: OkHttpClient by inject()
+  private val lifecycle: DevLauncherLifecycle by inject()
+  private val pendingIntentRegistry: DevLauncherIntentRegistryInterface by inject()
+  val internalUpdatesInterface: UpdatesInterface? by optInject()
+  private var devMenuManager: DevMenuManagerInterface? = null
+  var updatesInterface: UpdatesInterface?
+    get() = internalUpdatesInterface
+    set(value) = DevLauncherKoinContext.app.koin.loadModules(listOf(module {
+      single { value }
+    }))
+
+  override val devClientHost = DevLauncherClientHost((context as Application), DEV_LAUNCHER_HOST)
+
   private val recentlyOpedAppsRegistry = DevLauncherRecentlyOpenedAppsRegistry(context)
-  var manifest: DevLauncherManifest? = null
+  override var manifest: DevLauncherManifest? = null
     private set
-  var updatesInterface: UpdatesInterface? = null
-  val pendingIntentRegistry = DevLauncherIntentRegistry()
-  var latestLoadedApp: Uri? = null
+  override var latestLoadedApp: Uri? = null
   var useDeveloperSupport = true
 
-  internal enum class Mode {
+  enum class Mode {
     LAUNCHER, APP
   }
 
-  internal var mode = Mode.LAUNCHER
+  override var mode = Mode.LAUNCHER
 
   private var appIsLoading = false
 
-  suspend fun loadApp(url: Uri, mainActivity: ReactActivity? = null) {
+  override suspend fun loadApp(url: Uri, mainActivity: ReactActivity?) {
     synchronized(this) {
       if (appIsLoading) {
         return
@@ -78,34 +99,12 @@ class DevLauncherController private constructor(
       val manifestParser = DevLauncherManifestParser(httpClient, url)
       val appIntent = createAppIntent()
 
-      updatesInterface?.reset()
-      useDeveloperSupport = true
+      internalUpdatesInterface?.reset()
 
-      val appLoader = if (!manifestParser.isManifestUrl()) {
-        // It's (maybe) a raw React Native bundle
-        DevLauncherReactNativeAppLoader(url, appHost, context)
-      } else {
-        if (updatesInterface == null) {
-          manifest = manifestParser.parseManifest()
-          if (!manifest!!.isUsingDeveloperTool()) {
-            throw Exception("expo-updates is not properly installed or integrated. In order to load published projects with this development client, follow all installation and setup instructions for both the expo-dev-client and expo-updates packages.")
-          }
-          DevLauncherLocalAppLoader(manifest!!, appHost, context)
-        } else {
-          val configuration = createUpdatesConfigurationWithUrl(url)
-          val update = updatesInterface!!.loadUpdate(configuration, context) {
-            manifest = DevLauncherManifest.fromJson(it.toString().reader())
-            return@loadUpdate !manifest!!.isUsingDeveloperTool()
-          }
-          if (manifest!!.isUsingDeveloperTool()) {
-            DevLauncherLocalAppLoader(manifest!!, appHost, context)
-          } else {
-            useDeveloperSupport = false
-            val localBundlePath = update.launchAssetPath
-            DevLauncherPublishedAppLoader(manifest!!, localBundlePath, appHost, context)
-          }
-        }
-      }
+      val appLoaderFactory = get<DevLauncherAppLoaderFactoryInterface>()
+      val appLoader = appLoaderFactory.createAppLoader(url, manifestParser)
+      useDeveloperSupport = appLoaderFactory.shouldUseDeveloperSupport()
+      manifest = appLoaderFactory.getManifest()
 
       val appLoaderListener = appLoader.createOnDelegateWillBeCreatedListener()
       lifecycle.addListener(appLoaderListener)
@@ -130,7 +129,7 @@ class DevLauncherController private constructor(
     }
   }
 
-  fun onAppLoaded(context: ReactContext) {
+  override fun onAppLoaded(context: ReactContext) {
     // App can be started from deep link.
     // That's why, we maybe need to initialized dev menu here.
     maybeInitDevMenuDelegate(context)
@@ -139,15 +138,15 @@ class DevLauncherController private constructor(
     }
   }
 
-  fun onAppLoadedWithError() {
+  override fun onAppLoadedWithError() {
     synchronized(this) {
       appIsLoading = false
     }
   }
 
-  fun getRecentlyOpenedApps(): Map<String, String?> = recentlyOpedAppsRegistry.getRecentlyOpenedApps()
+  override fun getRecentlyOpenedApps(): Map<String, String?> = recentlyOpedAppsRegistry.getRecentlyOpenedApps()
 
-  fun navigateToLauncher() {
+  override fun navigateToLauncher() {
     ensureHostWasCleared(appHost)
     synchronized(this) {
       appIsLoading = false
@@ -158,7 +157,7 @@ class DevLauncherController private constructor(
     context.applicationContext.startActivity(createLauncherIntent())
   }
 
-  private fun handleIntent(intent: Intent?, activityToBeInvalidated: ReactActivity?): Boolean {
+  override fun handleIntent(intent: Intent?, activityToBeInvalidated: ReactActivity?): Boolean {
     intent
       ?.data
       ?.let { uri ->
@@ -197,7 +196,14 @@ class DevLauncherController private constructor(
     }
   }
 
-  fun maybeInitDevMenuDelegate(context: ReactContext) {
+  override fun maybeSynchronizeDevMenuDelegate() {
+    val devMenuManager = this.devMenuManager
+    if (MenuDelegateWasInitialized && devMenuManager != null) {
+      devMenuManager.synchronizeDelegate()
+    }
+  }
+
+  override fun maybeInitDevMenuDelegate(context: ReactContext) {
     if (MenuDelegateWasInitialized) {
       return
     }
@@ -212,6 +218,7 @@ class DevLauncherController private constructor(
 
     val devMenuManager = devMenuManagerProvider?.getDevMenuManager() ?: return
     devMenuManager.setDelegate(DevLauncherMenuDelegate(instance))
+    this.devMenuManager = devMenuManager
   }
 
   @UiThread
@@ -222,7 +229,7 @@ class DevLauncherController private constructor(
     }
   }
 
-  private fun getCurrentReactActivityDelegate(activity: ReactActivity, delegateSupplierDevLauncher: DevLauncherReactActivityDelegateSupplier): ReactActivityDelegate {
+  override fun getCurrentReactActivityDelegate(activity: ReactActivity, delegateSupplierDevLauncher: DevLauncherReactActivityDelegateSupplier): ReactActivityDelegate {
     return if (mode == Mode.LAUNCHER) {
       DevLauncherReactActivityRedirectDelegate(activity, this::redirectFromStartActivity)
     } else {
@@ -281,27 +288,40 @@ class DevLauncherController private constructor(
     }.apply { addFlags(NEW_ACTIVITY_FLAGS) }
 
   companion object {
-    private var sInstance: DevLauncherController? = null
     private var sLauncherClass: Class<*>? = null
     internal var sAdditionalPackages: List<ReactPackage>? = null
 
     @JvmStatic
-    fun wasInitialized() = sInstance != null
+    fun wasInitialized() =
+      DevLauncherKoinContext.app.koin.getOrNull<DevLauncherControllerInterface>() != null
 
     @JvmStatic
-    val instance: DevLauncherController
-      get() = checkNotNull(sInstance) {
+    val instance: DevLauncherControllerInterface
+      get() = checkNotNull(
+        DevLauncherKoinContext.app.koin.getOrNull()
+      ) {
         "DevelopmentClientController.getInstance() was called before the module was initialized"
       }
 
     @JvmStatic
     fun initialize(context: Context, appHost: ReactNativeHost) {
-      check(sInstance == null) { "DevelopmentClientController was initialized." }
-      sInstance = DevLauncherController(context, appHost)
+      val testInterceptor = DevLauncherKoinContext.app.koin.get<DevLauncherTestInterceptor>()
+      if (!testInterceptor.allowReinitialization()) {
+        check(wasInitialized()) { "DevelopmentClientController was initialized." }
+      }
+
+      MenuDelegateWasInitialized = false
+      DevLauncherKoinContext.app.koin.loadModules(listOf(
+        module {
+          single { context }
+          single { appHost }
+        }
+      ), allowOverride = true)
+      DevLauncherKoinContext.app.koin.declare<DevLauncherControllerInterface>(DevLauncherController())
     }
 
     @JvmStatic
-    fun initialize(context: Context, appHost: ReactNativeHost, additionalPackages: List<ReactPackage>?, launcherClass: Class<*>? = null) {
+    fun initialize(context: Context, appHost: ReactNativeHost, additionalPackages: List<ReactPackage>? = null, launcherClass: Class<*>? = null) {
       initialize(context, appHost)
       sAdditionalPackages = additionalPackages
       sLauncherClass = launcherClass
@@ -309,13 +329,20 @@ class DevLauncherController private constructor(
 
     @JvmStatic
     fun wrapReactActivityDelegate(activity: ReactActivity, devLauncherReactActivityDelegateSupplier: DevLauncherReactActivityDelegateSupplier): ReactActivityDelegate {
-      instance.lifecycle.delegateWillBeCreated(activity)
-      return instance.getCurrentReactActivityDelegate(activity, devLauncherReactActivityDelegateSupplier)
+      devLauncherKoin()
+        .get<DevLauncherLifecycle>()
+        .delegateWillBeCreated(activity)
+
+      return devLauncherKoin()
+        .get<DevLauncherControllerInterface>()
+        .getCurrentReactActivityDelegate(activity, devLauncherReactActivityDelegateSupplier)
     }
 
     @JvmStatic
     fun tryToHandleIntent(activity: ReactActivity, intent: Intent): Boolean {
-      return instance.handleIntent(intent, activityToBeInvalidated = activity)
+      return devLauncherKoin()
+        .get<DevLauncherControllerInterface>()
+        .handleIntent(intent, activityToBeInvalidated = activity)
     }
   }
 }

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/loaders/DevLauncherAppLoader.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/loaders/DevLauncherAppLoader.kt
@@ -9,7 +9,7 @@ import com.facebook.react.ReactActivity
 import com.facebook.react.ReactInstanceManager
 import com.facebook.react.ReactNativeHost
 import com.facebook.react.bridge.ReactContext
-import expo.modules.devlauncher.DevLauncherController
+import expo.modules.devlauncher.launcher.DevLauncherControllerInterface
 import kotlin.coroutines.Continuation
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
@@ -35,7 +35,8 @@ import kotlin.coroutines.suspendCoroutine
  */
 abstract class DevLauncherAppLoader(
   private val appHost: ReactNativeHost,
-  private val context: Context
+  private val context: Context,
+  private val controller: DevLauncherControllerInterface
 ) {
   private var continuation: Continuation<Boolean>? = null
   private var reactContextWasInitialized = false
@@ -51,7 +52,7 @@ abstract class DevLauncherAppLoader(
             return
           }
 
-          DevLauncherController.instance.onAppLoaded(context)
+          controller.onAppLoaded(context)
           onReactContext(context)
           appHost.reactInstanceManager.removeReactInstanceEventListener(this)
           reactContextWasInitialized = true

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/loaders/DevLauncherAppLoaderFactory.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/loaders/DevLauncherAppLoaderFactory.kt
@@ -1,0 +1,74 @@
+package expo.modules.devlauncher.launcher.loaders
+
+import android.content.Context
+import android.net.Uri
+import com.facebook.react.ReactNativeHost
+import expo.modules.devlauncher.helpers.createUpdatesConfigurationWithUrl
+import expo.modules.devlauncher.helpers.loadUpdate
+import expo.modules.devlauncher.koin.DevLauncherKoinComponent
+import expo.modules.devlauncher.koin.optInject
+import expo.modules.devlauncher.launcher.DevLauncherControllerInterface
+import expo.modules.devlauncher.launcher.manifest.DevLauncherManifest
+import expo.modules.devlauncher.launcher.manifest.DevLauncherManifestParser
+import expo.modules.updatesinterface.UpdatesInterface
+import org.koin.core.component.inject
+import java.lang.IllegalStateException
+
+interface DevLauncherAppLoaderFactoryInterface {
+  suspend fun createAppLoader(url: Uri, manifestParser: DevLauncherManifestParser): DevLauncherAppLoader
+  fun getManifest(): DevLauncherManifest?
+  fun shouldUseDeveloperSupport(): Boolean
+}
+
+class DevLauncherAppLoaderFactory : DevLauncherKoinComponent, DevLauncherAppLoaderFactoryInterface {
+  private val context: Context by inject()
+  private val appHost: ReactNativeHost by inject()
+  private val updatesInterface: UpdatesInterface? by optInject()
+  private val controller: DevLauncherControllerInterface by inject()
+
+  private var instanceWasCreated = false
+  private var manifest: DevLauncherManifest? = null
+  private var useDeveloperSupport = true
+
+  override suspend fun createAppLoader(url: Uri, manifestParser: DevLauncherManifestParser): DevLauncherAppLoader {
+    instanceWasCreated = true
+    return if (!manifestParser.isManifestUrl()) {
+      // It's (maybe) a raw React Native bundle
+      DevLauncherReactNativeAppLoader(url, appHost, context, controller)
+    } else {
+      if (updatesInterface == null) {
+        manifest = manifestParser.parseManifest()
+        if (!manifest!!.isUsingDeveloperTool()) {
+          throw Exception("expo-updates is not properly installed or integrated. In order to load published projects with this development client, follow all installation and setup instructions for both the expo-dev-client and expo-updates packages.")
+        }
+        DevLauncherLocalAppLoader(manifest!!, appHost, context, controller)
+      } else {
+        val configuration = createUpdatesConfigurationWithUrl(url)
+        val update = updatesInterface!!.loadUpdate(configuration, context) {
+          manifest = DevLauncherManifest.fromJson(it.toString().reader())
+          return@loadUpdate !manifest!!.isUsingDeveloperTool()
+        }
+        if (manifest!!.isUsingDeveloperTool()) {
+          DevLauncherLocalAppLoader(manifest!!, appHost, context, controller)
+        } else {
+          useDeveloperSupport = false
+          val localBundlePath = update.launchAssetPath
+          DevLauncherPublishedAppLoader(manifest!!, localBundlePath, appHost, context, controller)
+        }
+      }
+    }
+  }
+
+  override fun getManifest(): DevLauncherManifest? = checkIfInstanceWasCreated { manifest }
+
+  override fun shouldUseDeveloperSupport(): Boolean = checkIfInstanceWasCreated { useDeveloperSupport }
+
+  private inline fun <T> checkIfInstanceWasCreated(block: () -> T): T {
+    if (!instanceWasCreated) {
+      throw IllegalStateException("You need to create the AppLoader first.")
+    }
+
+    return block()
+  }
+}
+

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/loaders/DevLauncherExpoAppLoader.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/loaders/DevLauncherExpoAppLoader.kt
@@ -10,17 +10,19 @@ import com.facebook.react.bridge.ReactContext
 import com.facebook.react.modules.appearance.AppearanceModule
 import expo.modules.devlauncher.helpers.isValidColor
 import expo.modules.devlauncher.helpers.setProtectedDeclaredField
+import expo.modules.devlauncher.launcher.DevLauncherControllerInterface
 import expo.modules.devlauncher.launcher.configurators.DevLauncherExpoActivityConfigurator
-import expo.modules.devlauncher.launcher.manifest.DevLauncherUserInterface
 import expo.modules.devlauncher.launcher.manifest.DevLauncherManifest
+import expo.modules.devlauncher.launcher.manifest.DevLauncherUserInterface
 
 abstract class DevLauncherExpoAppLoader(
   private val manifest: DevLauncherManifest,
   appHost: ReactNativeHost,
   context: Context,
+  controller: DevLauncherControllerInterface,
   private val activityConfigurator: DevLauncherExpoActivityConfigurator =
     DevLauncherExpoActivityConfigurator(manifest, context)
-) : DevLauncherAppLoader(appHost, context) {
+) : DevLauncherAppLoader(appHost, context, controller) {
   override fun onCreate(activity: ReactActivity) = with(activityConfigurator) {
     applyOrientation(activity)
     applyStatusBarConfiguration(activity)

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/loaders/DevLauncherLocalAppLoader.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/loaders/DevLauncherLocalAppLoader.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.net.Uri
 import com.facebook.react.ReactNativeHost
 import expo.modules.devlauncher.helpers.injectReactInterceptor
+import expo.modules.devlauncher.launcher.DevLauncherControllerInterface
 import expo.modules.devlauncher.launcher.manifest.DevLauncherManifest
 
 /**
@@ -13,8 +14,9 @@ import expo.modules.devlauncher.launcher.manifest.DevLauncherManifest
 class DevLauncherLocalAppLoader(
   private val manifest: DevLauncherManifest,
   private val appHost: ReactNativeHost,
-  private val context: Context
-) : DevLauncherExpoAppLoader(manifest, appHost, context) {
+  private val context: Context,
+  controller: DevLauncherControllerInterface
+) : DevLauncherExpoAppLoader(manifest, appHost, context, controller) {
   override fun injectBundleLoader(): Boolean {
     return injectReactInterceptor(context, appHost, Uri.parse(manifest.bundleUrl))
   }

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/loaders/DevLauncherPublishedAppLoader.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/loaders/DevLauncherPublishedAppLoader.kt
@@ -3,6 +3,11 @@ package expo.modules.devlauncher.launcher.loaders
 import android.content.Context
 import com.facebook.react.ReactNativeHost
 import expo.modules.devlauncher.helpers.injectLocalBundleLoader
+import expo.modules.devlauncher.helpers.isValidColor
+import expo.modules.devlauncher.helpers.setProtectedDeclaredField
+import expo.modules.devlauncher.launcher.DevLauncherControllerInterface
+import expo.modules.devlauncher.launcher.configurators.DevLauncherExpoActivityConfigurator
+import expo.modules.devlauncher.launcher.manifest.DevLauncherUserInterface
 import expo.modules.devlauncher.launcher.manifest.DevLauncherManifest
 
 /**
@@ -13,8 +18,9 @@ class DevLauncherPublishedAppLoader(
   manifest: DevLauncherManifest,
   private val localBundlePath: String,
   private val appHost: ReactNativeHost,
-  context: Context
-) : DevLauncherExpoAppLoader(manifest, appHost, context) {
+  context: Context,
+  controller: DevLauncherControllerInterface
+) : DevLauncherExpoAppLoader(manifest, appHost, context, controller) {
   override fun injectBundleLoader(): Boolean {
     return injectLocalBundleLoader(appHost, localBundlePath)
   }

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/loaders/DevLauncherReactNativeAppLoader.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/loaders/DevLauncherReactNativeAppLoader.kt
@@ -4,12 +4,14 @@ import android.content.Context
 import android.net.Uri
 import com.facebook.react.ReactNativeHost
 import expo.modules.devlauncher.helpers.injectReactInterceptor
+import expo.modules.devlauncher.launcher.DevLauncherControllerInterface
 
 class DevLauncherReactNativeAppLoader(
   private val url: Uri,
   private val appHost: ReactNativeHost,
-  private val context: Context
-) : DevLauncherAppLoader(appHost, context) {
+  private val context: Context,
+  controller: DevLauncherControllerInterface
+) : DevLauncherAppLoader(appHost, context, controller) {
   override fun injectBundleLoader(): Boolean {
     return injectReactInterceptor(context, appHost, url)
   }

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/modules/DevLauncherDevMenuExtensions.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/modules/DevLauncherDevMenuExtensions.kt
@@ -10,24 +10,28 @@ import expo.interfaces.devmenu.items.DevMenuItemsContainer
 import expo.interfaces.devmenu.items.DevMenuItemsContainerInterface
 import expo.interfaces.devmenu.items.KeyCommand
 import expo.modules.devlauncher.DevLauncherController
-import expo.modules.devlauncher.DevLauncherController.Companion.instance
+import expo.modules.devlauncher.koin.devLauncherKoin
+import expo.modules.devlauncher.launcher.DevLauncherControllerInterface
 
 class DevLauncherDevMenuExtensions(
   reactContext: ReactApplicationContext?
 ) : ReactContextBaseJavaModule(reactContext),
   DevMenuExtensionInterface {
+
   override fun getName(): String {
     return "ExpoDevLauncherDevMenuExtensions"
   }
 
   override fun devMenuItems(settings: DevMenuExtensionSettingsInterface): DevMenuItemsContainerInterface =
     DevMenuItemsContainer.export {
-      if (!DevLauncherController.wasInitialized() || instance.mode == DevLauncherController.Mode.LAUNCHER) {
+      val controller = devLauncherKoin().getOrNull<DevLauncherControllerInterface>()
+
+      if (controller?.mode == DevLauncherController.Mode.LAUNCHER) {
         return@export
       }
 
       action("dev-launcher-back-to-launcher", {
-        instance.navigateToLauncher()
+        controller?.navigateToLauncher()
       }) {
         isEnabled = { true }
         label = { "Back to Launcher" }

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/modules/DevLauncherInternalModule.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/modules/DevLauncherInternalModule.kt
@@ -9,29 +9,36 @@ import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.modules.core.DeviceEventManagerModule.RCTDeviceEventEmitter
-import expo.modules.devlauncher.DevLauncherController.Companion.instance
 import expo.modules.devlauncher.DevLauncherController.Companion.wasInitialized
 import expo.modules.devlauncher.helpers.getAppUrlFromDevLauncherUrl
 import expo.modules.devlauncher.helpers.isDevLauncherUrl
+import expo.modules.devlauncher.koin.DevLauncherKoinComponent
+import expo.modules.devlauncher.launcher.DevLauncherControllerInterface
+import expo.modules.devlauncher.launcher.DevLauncherIntentRegistryInterface
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
+import org.koin.core.component.inject
 
 private const val ON_NEW_DEEP_LINK_EVENT = "expo.modules.devlauncher.onnewdeeplink"
 private const val CLIENT_PACKAGE_NAME = "host.exp.exponent"
 private val CLIENT_HOME_QR_SCANNER_DEEP_LINK = Uri.parse("expo-home://qr-scanner")
 
-class DevLauncherInternalModule(reactContext: ReactApplicationContext?) : ReactContextBaseJavaModule(reactContext) {
+class DevLauncherInternalModule(reactContext: ReactApplicationContext?)
+  : ReactContextBaseJavaModule(reactContext), DevLauncherKoinComponent {
+  private val controller: DevLauncherControllerInterface by inject()
+  private val intentRegistry: DevLauncherIntentRegistryInterface by inject()
+
   override fun initialize() {
     super.initialize()
     if (wasInitialized()) {
-      instance.pendingIntentRegistry.subscribe(this::onNewPendingIntent)
+      intentRegistry.subscribe(this::onNewPendingIntent)
     }
   }
 
   override fun invalidate() {
     super.invalidate()
     if (wasInitialized()) {
-      instance.pendingIntentRegistry.unsubscribe(this::onNewPendingIntent)
+      intentRegistry.unsubscribe(this::onNewPendingIntent)
     }
   }
 
@@ -47,7 +54,7 @@ class DevLauncherInternalModule(reactContext: ReactApplicationContext?) : ReactC
         } else {
           parsedUrl
         }
-        instance.loadApp(appUrl)
+        controller.loadApp(appUrl)
       } catch (e: Exception) {
         promise.reject("ERR_DEV_LAUNCHER_CANNOT_LOAD_APP", e.message, e)
         return@launch
@@ -61,7 +68,7 @@ class DevLauncherInternalModule(reactContext: ReactApplicationContext?) : ReactC
     promise.resolve(Arguments
       .createMap()
       .apply {
-        instance.getRecentlyOpenedApps().forEach { (key, value) ->
+        controller.getRecentlyOpenedApps().forEach { (key, value) ->
           putString(key, value)
         }
       })
@@ -93,7 +100,7 @@ class DevLauncherInternalModule(reactContext: ReactApplicationContext?) : ReactC
 
   @ReactMethod
   fun getPendingDeepLink(promise: Promise) {
-    promise.resolve(instance.pendingIntentRegistry.intent?.data?.toString())
+    promise.resolve(intentRegistry.intent?.data?.toString())
   }
 
   private fun onNewPendingIntent(intent: Intent) {

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/modules/DevLauncherModule.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/modules/DevLauncherModule.kt
@@ -3,15 +3,20 @@ package expo.modules.devlauncher.modules
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
 import expo.modules.devlauncher.DevLauncherController
+import expo.modules.devlauncher.koin.DevLauncherKoinComponent
+import expo.modules.devlauncher.launcher.DevLauncherControllerInterface
+import org.koin.core.component.inject
 
-class DevLauncherModule(reactContext: ReactApplicationContext?) : ReactContextBaseJavaModule(reactContext) {
+class DevLauncherModule(reactContext: ReactApplicationContext?) : ReactContextBaseJavaModule(reactContext), DevLauncherKoinComponent {
+  private val controller: DevLauncherControllerInterface by inject()
+
   override fun getName() = "EXDevLauncher"
 
   override fun hasConstants() = true
 
   override fun getConstants(): Map<String, Any?> {
     val manifestString = try {
-      DevLauncherController.instance.manifest?.rawData
+      controller.manifest?.rawData
     } catch (_: IllegalStateException) {
       null
     }

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/koin/DevLauncherKoinApp.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/koin/DevLauncherKoinApp.kt
@@ -1,0 +1,44 @@
+package expo.modules.devlauncher.koin
+
+import expo.modules.devlauncher.launcher.DevLauncherIntentRegistry
+import expo.modules.devlauncher.launcher.DevLauncherIntentRegistryInterface
+import expo.modules.devlauncher.launcher.DevLauncherLifecycle
+import expo.modules.devlauncher.launcher.loaders.DevLauncherAppLoaderFactory
+import expo.modules.devlauncher.launcher.loaders.DevLauncherAppLoaderFactoryInterface
+import expo.modules.devlauncher.tests.DevLauncherDisabledTestInterceptor
+import expo.modules.devlauncher.tests.DevLauncherTestInterceptor
+import okhttp3.OkHttpClient
+import org.koin.core.KoinApplication
+import org.koin.dsl.koinApplication
+import org.koin.dsl.module
+
+val DevLauncherTestModule = module {
+  single<DevLauncherTestInterceptor> { DevLauncherDisabledTestInterceptor() }
+}
+
+val DevLauncherBaseModule = module {
+  single<DevLauncherIntentRegistryInterface> { DevLauncherIntentRegistry() }
+  single { OkHttpClient() }
+  single { DevLauncherLifecycle() }
+  factory<DevLauncherAppLoaderFactoryInterface> { DevLauncherAppLoaderFactory() }
+}
+
+private val koinAppFactory = {
+  koinApplication {
+    modules(DevLauncherBaseModule, DevLauncherTestModule)
+  }
+}
+
+object DevLauncherKoinContext {
+  private var internalApp: KoinApplication = koinAppFactory()
+
+  fun reinitialize() {
+    internalApp.close()
+    internalApp = koinAppFactory()
+  }
+
+  val app: KoinApplication
+    get() = internalApp
+}
+
+fun devLauncherKoin() = DevLauncherKoinContext.app.koin

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/koin/DevLauncherKoinComponent.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/koin/DevLauncherKoinComponent.kt
@@ -1,0 +1,25 @@
+package expo.modules.devlauncher.koin
+
+import org.koin.core.Koin
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.get
+import org.koin.core.parameter.ParametersDefinition
+import org.koin.core.qualifier.Qualifier
+import org.koin.mp.KoinPlatformTools
+
+interface DevLauncherKoinComponent : KoinComponent {
+  override fun getKoin(): Koin = devLauncherKoin()
+}
+
+inline fun <reified T : Any> DevLauncherKoinComponent.optInject(
+  qualifier: Qualifier? = null,
+  mode: LazyThreadSafetyMode = KoinPlatformTools.defaultLazyMode(),
+  noinline parameters: ParametersDefinition? = null
+): Lazy<T?> =
+  lazy(mode) {
+    try {
+      get(qualifier, parameters)
+    } catch (e: Exception) {
+      return@lazy null
+    }
+  }

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/DevLauncherActivity.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/DevLauncherActivity.kt
@@ -15,12 +15,15 @@ import com.facebook.react.bridge.ReactContext
 import expo.interfaces.devmenu.DevMenuManagerInterface
 import expo.interfaces.devmenu.DevMenuManagerProviderInterface
 import expo.modules.devlauncher.DevLauncherController
+import expo.modules.devlauncher.koin.DevLauncherKoinComponent
 import expo.modules.devlauncher.splashscreen.DevLauncherSplashScreen
 import expo.modules.devlauncher.splashscreen.DevLauncherSplashScreenProvider
+import org.koin.core.component.inject
 
 const val SEARCH_FOR_ROOT_VIEW_INTERVAL = 20L
 
-class DevLauncherActivity : ReactActivity(), ReactInstanceManager.ReactInstanceEventListener {
+class DevLauncherActivity : ReactActivity(), ReactInstanceManager.ReactInstanceEventListener, DevLauncherKoinComponent {
+  private val controller: DevLauncherControllerInterface by inject()
   private var devMenuManager: DevMenuManagerInterface? = null
   private var splashScreen: DevLauncherSplashScreen? = null
   private var rootView: ViewGroup? = null
@@ -32,7 +35,7 @@ class DevLauncherActivity : ReactActivity(), ReactInstanceManager.ReactInstanceE
   override fun createReactActivityDelegate(): ReactActivityDelegate {
     return object : ReactActivityDelegate(this, mainComponentName) {
 
-      override fun getReactNativeHost() = DevLauncherController.instance.devClientHost
+      override fun getReactNativeHost() = controller.devClientHost
 
       override fun getLaunchOptions() = Bundle().apply {
         putBoolean("isSimulator", isSimulator)
@@ -56,7 +59,7 @@ class DevLauncherActivity : ReactActivity(), ReactInstanceManager.ReactInstanceE
 
   override fun onPostCreate(savedInstanceState: Bundle?) {
     super.onPostCreate(savedInstanceState)
-
+    controller.maybeSynchronizeDevMenuDelegate()
     reactInstanceManager.currentReactContext?.let {
       onReactContextInitialized(it)
       return
@@ -85,7 +88,7 @@ class DevLauncherActivity : ReactActivity(), ReactInstanceManager.ReactInstanceE
   }
 
   private fun setUpDevMenuDelegateIfPresent(context: ReactContext) {
-    DevLauncherController.instance.maybeInitDevMenuDelegate(context)
+    controller.maybeInitDevMenuDelegate(context)
 
     val devMenuManagerProvider = context
       .catalystInstance

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/DevLauncherControllerInterface.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/DevLauncherControllerInterface.kt
@@ -1,0 +1,28 @@
+package expo.modules.devlauncher.launcher
+
+import android.content.Intent
+import android.net.Uri
+import com.facebook.react.ReactActivity
+import com.facebook.react.ReactActivityDelegate
+import com.facebook.react.ReactNativeHost
+import com.facebook.react.bridge.ReactContext
+import expo.modules.devlauncher.DevLauncherController
+import expo.modules.devlauncher.launcher.manifest.DevLauncherManifest
+
+interface DevLauncherControllerInterface {
+  suspend fun loadApp(url: Uri, mainActivity: ReactActivity? = null)
+  fun onAppLoaded(context: ReactContext)
+  fun onAppLoadedWithError()
+  fun getRecentlyOpenedApps(): Map<String, String?>
+  fun navigateToLauncher()
+  fun maybeSynchronizeDevMenuDelegate()
+  fun maybeInitDevMenuDelegate(context: ReactContext)
+  fun getCurrentReactActivityDelegate(activity: ReactActivity, delegateSupplierDevLauncher: DevLauncherReactActivityDelegateSupplier): ReactActivityDelegate
+  fun handleIntent(intent: Intent?, activityToBeInvalidated: ReactActivity?): Boolean
+
+  val manifest: DevLauncherManifest?
+  val devClientHost: DevLauncherClientHost
+  val mode: DevLauncherController.Mode
+  val appHost: ReactNativeHost
+  val latestLoadedApp: Uri?
+}

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/DevLauncherControllerInterface.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/DevLauncherControllerInterface.kt
@@ -8,6 +8,7 @@ import com.facebook.react.ReactNativeHost
 import com.facebook.react.bridge.ReactContext
 import expo.modules.devlauncher.DevLauncherController
 import expo.modules.devlauncher.launcher.manifest.DevLauncherManifest
+import expo.modules.updatesinterface.UpdatesInterface
 
 interface DevLauncherControllerInterface {
   suspend fun loadApp(url: Uri, mainActivity: ReactActivity? = null)
@@ -25,4 +26,6 @@ interface DevLauncherControllerInterface {
   val mode: DevLauncherController.Mode
   val appHost: ReactNativeHost
   val latestLoadedApp: Uri?
+  val useDeveloperSupport: Boolean
+  var updatesInterface: UpdatesInterface?
 }

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/DevLauncherIntentRegistry.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/DevLauncherIntentRegistry.kt
@@ -5,9 +5,19 @@ import kotlin.properties.Delegates
 
 typealias DevLauncherPendingIntentListener = (Intent) -> Unit
 
-class DevLauncherIntentRegistry {
+interface DevLauncherIntentRegistryInterface {
+  var intent: Intent?
+
+  fun subscribe(listener: DevLauncherPendingIntentListener)
+
+  fun unsubscribe(listener: DevLauncherPendingIntentListener)
+
+  fun consumePendingIntent(): Intent?
+}
+
+class DevLauncherIntentRegistry : DevLauncherIntentRegistryInterface {
   private val pendingIntentListeners = mutableListOf<DevLauncherPendingIntentListener>()
-  var intent by Delegates.observable<Intent?>(null) { _, _, newValue ->
+  override var intent by Delegates.observable<Intent?>(null) { _, _, newValue ->
     newValue?.let { intent ->
       pendingIntentListeners.forEach {
         it.invoke(intent)
@@ -15,15 +25,15 @@ class DevLauncherIntentRegistry {
     }
   }
 
-  fun subscribe(listener: DevLauncherPendingIntentListener) {
+  override fun subscribe(listener: DevLauncherPendingIntentListener) {
     pendingIntentListeners.add(listener)
   }
 
-  fun unsubscribe(listener: DevLauncherPendingIntentListener) {
+  override fun unsubscribe(listener: DevLauncherPendingIntentListener) {
     pendingIntentListeners.remove(listener)
   }
 
-  fun consumePendingIntent(): Intent? {
+  override fun consumePendingIntent(): Intent? {
     val pendingIntent = intent
     intent = null
     return pendingIntent

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/errors/DevLauncherErrorActivity.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/errors/DevLauncherErrorActivity.kt
@@ -11,10 +11,13 @@ import androidx.fragment.app.FragmentPagerAdapter
 import com.facebook.react.ReactActivity
 import expo.modules.devlauncher.DevLauncherController
 import expo.modules.devlauncher.databinding.ErrorActivityContentViewBinding
+import expo.modules.devlauncher.koin.DevLauncherKoinComponent
+import expo.modules.devlauncher.launcher.DevLauncherControllerInterface
 import expo.modules.devlauncher.launcher.errors.fragments.DevLauncherErrorConsoleFragment
 import expo.modules.devlauncher.launcher.errors.fragments.DevLauncherErrorFragment
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
+import org.koin.core.component.inject
 import java.lang.ref.WeakReference
 import java.util.*
 
@@ -28,7 +31,12 @@ interface DevLauncherErrorActivityInterface {
   fun reload()
 }
 
-class DevLauncherErrorActivity : FragmentActivity(), DevLauncherErrorActivityInterface {
+class DevLauncherErrorActivity
+  : FragmentActivity(),
+  DevLauncherErrorActivityInterface,
+  DevLauncherKoinComponent {
+  val controller: DevLauncherControllerInterface by inject()
+
   private class ViewPagerAdapter(fm: FragmentManager) : FragmentPagerAdapter(fm, BEHAVIOR_RESUME_ONLY_CURRENT_FRAGMENT) {
     override fun getCount() = 2
 
@@ -66,7 +74,7 @@ class DevLauncherErrorActivity : FragmentActivity(), DevLauncherErrorActivityInt
       errorQueue.clear()
     }
 
-    DevLauncherController.instance.navigateToLauncher()
+    controller.navigateToLauncher()
   }
 
   override fun reload() {
@@ -74,19 +82,18 @@ class DevLauncherErrorActivity : FragmentActivity(), DevLauncherErrorActivityInt
       errorQueue.clear()
     }
 
-    val appUrl = DevLauncherController.instance.latestLoadedApp
+    val appUrl = controller.latestLoadedApp
 
     if (appUrl == null) {
-      DevLauncherController.instance.navigateToLauncher()
+      controller.navigateToLauncher()
       return
     }
 
     GlobalScope.launch {
-      DevLauncherController
-        .instance
+      controller
         .loadApp(
           appUrl,
-          DevLauncherController.instance.appHost.reactInstanceManager.currentReactContext?.currentActivity as? ReactActivity?
+          controller.appHost.reactInstanceManager.currentReactContext?.currentActivity as? ReactActivity?
         )
     }
   }

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/menu/DevLauncherMenuDelegate.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/menu/DevLauncherMenuDelegate.kt
@@ -5,8 +5,9 @@ import com.facebook.react.ReactInstanceManager
 import expo.interfaces.devmenu.DevMenuDelegateInterface
 import expo.modules.devlauncher.BuildConfig
 import expo.modules.devlauncher.DevLauncherController
+import expo.modules.devlauncher.launcher.DevLauncherControllerInterface
 
-private class LauncherDelegate(private val controller: DevLauncherController) : DevMenuDelegateInterface {
+private class LauncherDelegate(private val controller: DevLauncherControllerInterface) : DevMenuDelegateInterface {
   override fun appInfo(): Bundle = Bundle().apply {
     putString("appName", "Development Client")
     putString("appVersion", BuildConfig.VERSION)
@@ -23,7 +24,7 @@ private class LauncherDelegate(private val controller: DevLauncherController) : 
   }
 }
 
-private class AppDelegate(private val controller: DevLauncherController) : DevMenuDelegateInterface {
+private class AppDelegate(private val controller: DevLauncherControllerInterface) : DevMenuDelegateInterface {
   override fun appInfo(): Bundle = Bundle().apply {
     putString("appName", controller.manifest?.name ?: "Development Client - App")
     putString("appVersion", controller.manifest?.version)
@@ -41,7 +42,7 @@ private class AppDelegate(private val controller: DevLauncherController) : DevMe
   }
 }
 
-class DevLauncherMenuDelegate(private val controller: DevLauncherController) : DevMenuDelegateInterface {
+class DevLauncherMenuDelegate(private val controller: DevLauncherControllerInterface) : DevMenuDelegateInterface {
   private val launcherDelegate = LauncherDelegate(controller)
   private val appDelegate = AppDelegate(controller)
 

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/react/DevLauncherDevSupportManager.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/react/DevLauncherDevSupportManager.kt
@@ -8,8 +8,11 @@ import com.facebook.react.devsupport.RedBoxHandler
 import com.facebook.react.devsupport.interfaces.DevBundleDownloadListener
 import com.facebook.react.packagerconnection.RequestHandler
 import expo.modules.devlauncher.DevLauncherController
+import expo.modules.devlauncher.koin.DevLauncherKoinComponent
+import expo.modules.devlauncher.launcher.DevLauncherControllerInterface
 import expo.modules.devlauncher.launcher.errors.DevLauncherAppError
 import expo.modules.devlauncher.launcher.errors.DevLauncherErrorActivity
+import org.koin.core.component.inject
 
 class DevLauncherDevSupportManager(
   applicationContext: Context?,
@@ -29,7 +32,8 @@ class DevLauncherDevSupportManager(
   devBundleDownloadListener,
   minNumShakes,
   customPackagerCommandHandlers
-) {
+), DevLauncherKoinComponent {
+  private val controller: DevLauncherControllerInterface by inject()
   override fun showNewJavaError(message: String?, e: Throwable) {
     if (!DevLauncherController.wasInitialized()) {
       Log.e("DevLauncher", "DevLauncher wasn't initialized. Couldn't intercept native error handling.")
@@ -42,7 +46,7 @@ class DevLauncherDevSupportManager(
       return
     }
 
-    DevLauncherController.instance.onAppLoadedWithError()
+    controller.onAppLoadedWithError()
     DevLauncherErrorActivity.showError(activity, DevLauncherAppError(message, e))
   }
 }

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/tests/DevLauncherDisabledTestInterceptor.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/tests/DevLauncherDisabledTestInterceptor.kt
@@ -1,0 +1,5 @@
+package expo.modules.devlauncher.tests
+
+class DevLauncherDisabledTestInterceptor : DevLauncherTestInterceptor {
+  override fun allowReinitialization() = false
+}

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/tests/DevLauncherTestInterceptor.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/tests/DevLauncherTestInterceptor.kt
@@ -1,0 +1,5 @@
+package expo.modules.devlauncher.tests
+
+interface DevLauncherTestInterceptor {
+  fun allowReinitialization(): Boolean
+}

--- a/packages/expo-dev-launcher/android/src/release/java/expo/modules/devlauncher/DevLauncherController.kt
+++ b/packages/expo-dev-launcher/android/src/release/java/expo/modules/devlauncher/DevLauncherController.kt
@@ -2,59 +2,77 @@ package expo.modules.devlauncher
 
 import android.content.Context
 import android.content.Intent
+import android.net.Uri
 import com.facebook.react.ReactActivity
 import com.facebook.react.ReactActivityDelegate
 import com.facebook.react.ReactNativeHost
 import com.facebook.react.bridge.ReactContext
 import expo.modules.devlauncher.launcher.DevLauncherClientHost
+import expo.modules.devlauncher.launcher.DevLauncherControllerInterface
 import expo.modules.devlauncher.launcher.DevLauncherReactActivityDelegateSupplier
 import expo.modules.devlauncher.launcher.manifest.DevLauncherManifest
 import expo.modules.updatesinterface.UpdatesInterface
 
 const val DEV_LAUNCHER_IS_NOT_AVAILABLE = "DevLauncher isn't available in release builds"
 
-class DevLauncherController private constructor() {
-  internal enum class Mode {
+class DevLauncherController private constructor() : DevLauncherControllerInterface {
+  enum class Mode {
     LAUNCHER, APP
   }
 
-  val latestLoadedApp: String? = null
+  override val latestLoadedApp: Uri? = null
 
-  internal val mode: Mode
+  override val mode: Mode
     get() = throw IllegalStateException(DEV_LAUNCHER_IS_NOT_AVAILABLE)
 
-  val devClientHost: DevLauncherClientHost
+  override val devClientHost: DevLauncherClientHost
     get() = throw IllegalStateException(DEV_LAUNCHER_IS_NOT_AVAILABLE)
 
-  val manifest: DevLauncherManifest
+  override val manifest: DevLauncherManifest
     get() = throw IllegalStateException(DEV_LAUNCHER_IS_NOT_AVAILABLE)
 
-  val appHost: ReactNativeHost
+  override val appHost: ReactNativeHost
     get() = throw IllegalStateException(DEV_LAUNCHER_IS_NOT_AVAILABLE)
 
   var updatesInterface: UpdatesInterface?
     get() = throw IllegalStateException(DEV_LAUNCHER_IS_NOT_AVAILABLE)
-    set(updatesInterface) {}
+    set(_) {}
 
   val useDeveloperSupport = false
 
-  fun maybeInitDevMenuDelegate(context: ReactContext) {
+  override fun maybeInitDevMenuDelegate(context: ReactContext) {
     throw IllegalStateException(DEV_LAUNCHER_IS_NOT_AVAILABLE)
   }
 
-  fun navigateToLauncher() {
+  override fun getCurrentReactActivityDelegate(activity: ReactActivity, delegateSupplierDevLauncher: DevLauncherReactActivityDelegateSupplier): ReactActivityDelegate {
     throw IllegalStateException(DEV_LAUNCHER_IS_NOT_AVAILABLE)
   }
 
-  suspend fun loadApp(appUrl: String, reactActivity: ReactActivity?) {
+  override fun handleIntent(intent: Intent?, activityToBeInvalidated: ReactActivity?): Boolean {
     throw IllegalStateException(DEV_LAUNCHER_IS_NOT_AVAILABLE)
   }
 
-  fun onAppLoaded(context: ReactContext) {
+  override fun navigateToLauncher() {
     throw IllegalStateException(DEV_LAUNCHER_IS_NOT_AVAILABLE)
   }
 
-  fun onAppLoadedWithError() {
+  override fun maybeSynchronizeDevMenuDelegate() {
+    throw IllegalStateException(DEV_LAUNCHER_IS_NOT_AVAILABLE)
+  }
+
+  override suspend fun loadApp(url: Uri, mainActivity: ReactActivity?) {
+    throw IllegalStateException(DEV_LAUNCHER_IS_NOT_AVAILABLE)
+  }
+
+  override fun onAppLoaded(context: ReactContext) {
+    throw IllegalStateException(DEV_LAUNCHER_IS_NOT_AVAILABLE)
+  }
+
+  override fun onAppLoadedWithError() {
+    throw IllegalStateException(DEV_LAUNCHER_IS_NOT_AVAILABLE)
+  }
+
+  override fun getRecentlyOpenedApps(): Map<String, String?> {
     throw IllegalStateException(DEV_LAUNCHER_IS_NOT_AVAILABLE)
   }
 

--- a/packages/expo-dev-launcher/android/src/release/java/expo/modules/devlauncher/DevLauncherController.kt
+++ b/packages/expo-dev-launcher/android/src/release/java/expo/modules/devlauncher/DevLauncherController.kt
@@ -34,11 +34,11 @@ class DevLauncherController private constructor() : DevLauncherControllerInterfa
   override val appHost: ReactNativeHost
     get() = throw IllegalStateException(DEV_LAUNCHER_IS_NOT_AVAILABLE)
 
-  var updatesInterface: UpdatesInterface?
+  override var updatesInterface: UpdatesInterface?
     get() = throw IllegalStateException(DEV_LAUNCHER_IS_NOT_AVAILABLE)
     set(_) {}
 
-  val useDeveloperSupport = false
+  override val useDeveloperSupport = false
 
   override fun maybeInitDevMenuDelegate(context: ReactContext) {
     throw IllegalStateException(DEV_LAUNCHER_IS_NOT_AVAILABLE)

--- a/packages/expo-dev-launcher/android/src/release/java/expo/modules/devlauncher/launcher/loaders/DevLauncherAppLoaderFactory.kt
+++ b/packages/expo-dev-launcher/android/src/release/java/expo/modules/devlauncher/launcher/loaders/DevLauncherAppLoaderFactory.kt
@@ -1,0 +1,8 @@
+package expo.modules.devlauncher.launcher.loaders
+
+interface DevLauncherAppLoaderFactoryInterface {
+}
+
+class DevLauncherAppLoaderFactory : DevLauncherAppLoaderFactoryInterface {
+
+}

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuManager.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuManager.kt
@@ -207,24 +207,20 @@ object DevMenuManager : DevMenuManagerInterface, LifecycleEventListener {
     Log.i(DEV_MENU_TAG, "Delegate's context was loaded.")
 
     maybeInitDevMenuHost(reactContext.currentActivity?.application
-      ?: reactContext.applicationContext as Application)
+        ?: reactContext.applicationContext as Application)
     maybeStartDetectors(devMenuHost.getContext())
 
     settings = testInterceptor.overrideSettings()
-    if (settings != null) {
-      return
-    }
-
-    settings = if (reactContext.hasNativeModule(DevMenuSettings::class.java)) {
-      reactContext.getNativeModule(DevMenuSettings::class.java)!!
-    } else {
-      DevMenuDefaultSettings()
-    }.also {
-      shouldLaunchDevMenuOnStart = it.showsAtLaunch || !it.isOnboardingFinished
-      if (shouldLaunchDevMenuOnStart) {
-        reactContext.addLifecycleEventListener(this)
-      }
-    }
+        ?: if (reactContext.hasNativeModule(DevMenuSettings::class.java)) {
+          reactContext.getNativeModule(DevMenuSettings::class.java)!!
+        } else {
+          DevMenuDefaultSettings()
+        }.also {
+          shouldLaunchDevMenuOnStart = it.showsAtLaunch || !it.isOnboardingFinished
+          if (shouldLaunchDevMenuOnStart) {
+            reactContext.addLifecycleEventListener(this)
+          }
+        }
   }
 
   //endregion

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuManager.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuManager.kt
@@ -39,6 +39,8 @@ import expo.modules.devmenu.detectors.ShakeDetector
 import expo.modules.devmenu.detectors.ThreeFingerLongPressDetector
 import expo.modules.devmenu.modules.DevMenuSettings
 import expo.modules.devmenu.react.DevMenuPackagerCommandHandlersSwapper
+import expo.modules.devmenu.tests.DevMenuDisabledTestInterceptor
+import expo.modules.devmenu.tests.DevMenuTestInterceptor
 import expo.modules.devmenu.websockets.DevMenuCommandHandlersProvider
 import java.lang.ref.WeakReference
 
@@ -56,6 +58,7 @@ object DevMenuManager : DevMenuManagerInterface, LifecycleEventListener {
   private var currentReactInstanceManager: WeakReference<ReactInstanceManager?> = WeakReference(null)
   private var currentScreenName: String? = null
   private val expoApiClient = DevMenuExpoApiClient()
+  var testInterceptor: DevMenuTestInterceptor = DevMenuDisabledTestInterceptor()
 
   //region helpers
 
@@ -206,6 +209,11 @@ object DevMenuManager : DevMenuManagerInterface, LifecycleEventListener {
     maybeInitDevMenuHost(reactContext.currentActivity?.application
       ?: reactContext.applicationContext as Application)
     maybeStartDetectors(devMenuHost.getContext())
+
+    settings = testInterceptor.overrideSettings()
+    if (settings != null) {
+      return
+    }
 
     settings = if (reactContext.hasNativeModule(DevMenuSettings::class.java)) {
       reactContext.getNativeModule(DevMenuSettings::class.java)!!

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/DevMenuDefaultSettings.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/DevMenuDefaultSettings.kt
@@ -4,7 +4,7 @@ import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.WritableMap
 import expo.interfaces.devmenu.DevMenuSettingsInterface
 
-class DevMenuDefaultSettings : DevMenuSettingsInterface {
+open class DevMenuDefaultSettings : DevMenuSettingsInterface {
   private fun methodUnavailable() {
     throw NoSuchMethodError("You cannot change the default settings. Export `DevMenuSettings` module if you want to change the settings.")
   }

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/tests/DevMenuDisabledTestInterceptor.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/tests/DevMenuDisabledTestInterceptor.kt
@@ -1,0 +1,7 @@
+package expo.modules.devmenu.tests
+
+import expo.interfaces.devmenu.DevMenuSettingsInterface
+
+class DevMenuDisabledTestInterceptor: DevMenuTestInterceptor {
+  override fun overrideSettings(): DevMenuSettingsInterface? = null
+}

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/tests/DevMenuTestInterceptor.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/tests/DevMenuTestInterceptor.kt
@@ -1,0 +1,7 @@
+package expo.modules.devmenu.tests
+
+import expo.interfaces.devmenu.DevMenuSettingsInterface
+
+interface DevMenuTestInterceptor {
+  fun overrideSettings(): DevMenuSettingsInterface?
+}


### PR DESCRIPTION
# Why

Part of https://linear.app/expo/issue/ENG-1569/instrumented-tests-on-android.

# How

To make the dev-client more testable, I've changed a couple of things: 
- used dependency injection. I chose the Koin library to do it, cause it's very lightweight and has a great API. In my opinion, it's the best choice in Kotilin.
- created an abstraction that provides the needed app loader to mock it in the tests. 
- created a TestInterceptors to change some behavior in tests scenarios. 
- added `DevLauncherConterllerInterface`.

# Test Plan

- project compiles & tests passed