### PR TITLE
[dev-client] Sync versions & changelog with SDK-42 branch

### DIFF
--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -102,7 +102,7 @@
     "@unimodules/react-native-adapter": "^6.4.0",
     "expo": "~42.0.0-alpha.0",
     "expo-camera": "~11.1.1",
-    "expo-dev-client": "~0.3.0",
+    "expo-dev-client": "~0.4.4",
     "expo-face-detector": "~10.1.0",
     "expo-image": "~1.0.0-alpha.1",
     "expo-notifications": "~0.12.0",

--- a/apps/bare-sandbox/package.json
+++ b/apps/bare-sandbox/package.json
@@ -13,7 +13,7 @@
     "expo": "~42.0.0-alpha.0",
     "expo-splash-screen": "~0.11.0",
     "expo-status-bar": "~1.0.4",
-    "expo-dev-client": "~0.3.0",
+    "expo-dev-client": "~0.4.4",
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "react-native": "0.63.2",

--- a/packages/expo-dev-client/CHANGELOG.md
+++ b/packages/expo-dev-client/CHANGELOG.md
@@ -8,9 +8,25 @@
 
 ### 🐛 Bug fixes
 
+### 💡 Others
+
+## 0.4.4 — 2021-07-08
+
+_This version does not introduce any user-facing changes._
+
+## 0.4.3 — 2021-06-30
+
+_This version does not introduce any user-facing changes._
+
+## 0.4.2 — 2021-06-30
+
+### 🐛 Bug fixes
+
 - Pin versions of expo-dev-launcher, expo-dev-menu, and expo-dev-menu-interface packages. ([#13430](https://github.com/expo/expo/pull/13430) by [@esamelson](https://github.com/esamelson))
 
-### 💡 Others
+## 0.4.1 — 2021-06-24
+
+_This version does not introduce any user-facing changes._
 
 ## 0.3.0 — 2021-06-10
 

--- a/packages/expo-dev-client/package.json
+++ b/packages/expo-dev-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-dev-client",
-  "version": "0.3.0",
+  "version": "0.4.4",
   "description": "Expo Development Client",
   "main": "build/DevClient.js",
   "types": "build/DevClient.d.ts",
@@ -31,10 +31,10 @@
   "homepage": "https://docs.expo.io/clients/introduction/",
   "dependencies": {
     "@expo/config-plugins": "^3.0.0",
-    "expo-dev-launcher": "0.5.1",
-    "expo-dev-menu": "0.7.0",
-    "expo-dev-menu-interface": "0.3.1",
-    "expo-updates-interface": "~0.1.0"
+    "expo-dev-launcher": "0.6.4",
+    "expo-dev-menu": "0.7.5",
+    "expo-dev-menu-interface": "0.3.2",
+    "expo-updates-interface": "~0.2.0"
   },
   "devDependencies": {
     "expo-module-scripts": "^2.0.0"

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -4,6 +4,41 @@
 
 ### 🛠 Breaking changes
 
+### 🎉 New features
+
+### 🐛 Bug fixes
+
+- Fixed compatibility with React Native 0.64.X. ([#13632](https://github.com/expo/expo/pull/13632) by [@lukmccall](https://github.com/lukmccall))
+
+### 💡 Others
+
+## 0.6.4 — 2021-07-08
+
+### 🐛 Bug fixes
+
+- Fixed Android release builds. ([#13544](https://github.com/expo/expo/pull/13544) by [@esamelson](https://github.com/esamelson))
+- Fixed web compatibility. ([#13535](https://github.com/expo/expo/pull/13535) by [@lukmccall](https://github.com/lukmccall))
+
+## 0.6.3 — 2021-06-30
+
+### 🐛 Bug fixes
+
+- [plugin] Fixed error handlers weren't initialize after running `expo run:ios`. ([#13438](https://github.com/expo/expo/pull/13438) by [@lukmccall](https://github.com/lukmccall))
+- Order dev menu items consistently across platforms. ([#13449](https://github.com/expo/expo/pull/13449) by [@lukmccall](https://github.com/lukmccall))
+- Fixed error message when trying to load a production app without expo-updates. ([#13458](https://github.com/expo/expo/pull/13458) by [@esamelson](https://github.com/esamelson))
+
+## 0.6.2 — 2021-06-28
+
+### 🐛 Bug fixes
+
+- Fixed can't reload app from the blue screen. ([#13422](https://github.com/expo/expo/pull/13422) by [@lukmccall](https://github.com/lukmccall))
+- Fixed `JSPackagerClient` wasn't close on React Native 0.63.4 what may lead to various bugs on Android. ([#13423](https://github.com/expo/expo/pull/13423) by [@lukmccall](https://github.com/lukmccall))
+- Fixed the blue screen was shown instead of the LogBox on iOS. ([#13421](https://github.com/expo/expo/pull/13421) by [@lukmccall](https://github.com/lukmccall))
+
+## 0.6.1 — 2021-06-24
+
+### 🛠 Breaking changes
+
 - Reset Updates module state on each dev client load. ([#13346](https://github.com/expo/expo/pull/13346) by [@esamelson](https://github.com/esamelson))
 - Ensure error handler is initialized. ([#13384](https://github.com/expo/expo/pull/13384) by [@lukmccall](https://github.com/lukmccall))
 
@@ -16,17 +51,6 @@
 - Fixed switching from published to local bundle loading on Android. ([#13363](https://github.com/expo/expo/pull/13363) by [@esamelson](https://github.com/esamelson))
 - [plugin] Use Node module resolution to find package paths for Podfile ([#13382](https://github.com/expo/expo/pull/13382) by [@fson](https://github.com/fson))
 - Send expo-updates-environment: DEVELOPMENT header in manifest requests. ([#13375](https://github.com/expo/expo/pull/13375) by [@esamelson](https://github.com/esamelson))
-- Fixed can't reload app from the blue screen. ([#13422](https://github.com/expo/expo/pull/13422) by [@lukmccall](https://github.com/lukmccall))
-- Fixed `JSPackagerClient` wasn't close on React Native 0.63.4 what may lead to various bugs on Android. ([#13423](https://github.com/expo/expo/pull/13423) by [@lukmccall](https://github.com/lukmccall))
-- Fixed the blue screen was shown instead of the LogBox on iOS. ([#13421](https://github.com/expo/expo/pull/13421) by [@lukmccall](https://github.com/lukmccall))
-- [plugin] Fixed error handlers weren't initialize after running `expo run:ios`. ([#13438](https://github.com/expo/expo/pull/13438) by [@lukmccall](https://github.com/lukmccall))
-- Order dev menu items consistently across platforms. ([#13449](https://github.com/expo/expo/pull/13449) by [@lukmccall](https://github.com/lukmccall))
-- Fixed error message when trying to load a production app without expo-updates. ([#13458](https://github.com/expo/expo/pull/13458) by [@esamelson](https://github.com/esamelson))
-- Fixed Android release builds. ([#13544](https://github.com/expo/expo/pull/13544) by [@esamelson](https://github.com/esamelson))
-- Fixed web compatibility. ([#13535](https://github.com/expo/expo/pull/13535) by [@lukmccall](https://github.com/lukmccall))
-- Fixed compatibility with React Native 0.64.X. ([#13632](https://github.com/expo/expo/pull/13632) by [@lukmccall](https://github.com/lukmccall))
-
-### 💡 Others
 
 ## 0.5.1 — 2021-06-16
 

--- a/packages/expo-dev-launcher/android/build.gradle
+++ b/packages/expo-dev-launcher/android/build.gradle
@@ -23,7 +23,7 @@ android {
     minSdkVersion safeExtGet('minSdkVersion', 21)
     targetSdkVersion safeExtGet('targetSdkVersion', 30)
     versionCode 9
-    versionName "0.5.1"
+    versionName "0.6.4"
   }
   lintOptions {
     abortOnError false

--- a/packages/expo-dev-launcher/package.json
+++ b/packages/expo-dev-launcher/package.json
@@ -33,7 +33,7 @@
     "semver": "^7.3.5"
   },
   "devDependencies": {
-    "babel-preset-expo": "~8.4.1",
+    "babel-preset-expo": "~8.4.0",
     "expo-module-scripts": "^2.0.0",
     "react": "16.13.1",
     "react-native": "0.63.2"

--- a/packages/expo-dev-launcher/package.json
+++ b/packages/expo-dev-launcher/package.json
@@ -1,7 +1,7 @@
 {
   "name": "expo-dev-launcher",
   "title": "Expo Development Launcher",
-  "version": "0.5.1",
+  "version": "0.6.4",
   "description": "Pre-release version of the Expo development launcher package for testing.",
   "main": "build/DevLauncher.js",
   "types": "build/DevLauncher.d.ts",
@@ -33,7 +33,7 @@
     "semver": "^7.3.5"
   },
   "devDependencies": {
-    "babel-preset-expo": "~8.4.0",
+    "babel-preset-expo": "~8.4.1",
     "expo-module-scripts": "^2.0.0",
     "react": "16.13.1",
     "react-native": "0.63.2"

--- a/packages/expo-dev-menu-interface/android/build.gradle
+++ b/packages/expo-dev-menu-interface/android/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'maven'
 
 group = 'host.exp.exponent'
-version = '0.3.1'
+version = '0.3.2'
 
 buildscript {
   // Simple helper that allows the root project to override versions declared by this library.
@@ -57,7 +57,7 @@ android {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 30)
     versionCode 6
-    versionName '0.3.1'
+    versionName '0.3.2'
   }
   lintOptions {
     abortOnError false

--- a/packages/expo-dev-menu-interface/package.json
+++ b/packages/expo-dev-menu-interface/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-dev-menu-interface",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Interface for expo-dev-menu",
   "main": "index.js",
   "keywords": [

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -8,13 +8,32 @@
 
 ### 🐛 Bug fixes
 
-- [plugin] Use Node module resolution to find package paths for Podfile ([#13382](https://github.com/expo/expo/pull/13382) by [@fson](https://github.com/fson))
-- Fixed WebSocket handlers weren't registered properly on iOS. ([#13403](https://github.com/expo/expo/pull/13403) by [@lukmccall](https://github.com/lukmccall))
-- Fix crash from inspector request failures. ([#13393](https://github.com/expo/expo/pull/13393) by [@kudo](https://github.com/kudo))
-- Order dev menu items consistently across platforms. ([#13449](https://github.com/expo/expo/pull/13449) by [@lukmccall](https://github.com/lukmccall))
+### 💡 Others
+
+## 0.7.5 — 2021-07-08
+
+### 🐛 Bug fixes
+
 - Fixed web compatibility. ([#13535](https://github.com/expo/expo/pull/13535) by [@lukmccall](https://github.com/lukmccall))
 
-### 💡 Others
+## 0.7.4 — 2021-06-30
+
+### 🐛 Bug fixes
+
+- Order dev menu items consistently across platforms. ([#13449](https://github.com/expo/expo/pull/13449) by [@lukmccall](https://github.com/lukmccall))
+
+## 0.7.3 — 2021-06-28
+
+### 🐛 Bug fixes
+
+- Fixed WebSocket handlers weren't registered properly on iOS. ([#13403](https://github.com/expo/expo/pull/13403) by [@lukmccall](https://github.com/lukmccall))
+- Fix crash from inspector request failures. ([#13393](https://github.com/expo/expo/pull/13393) by [@kudo](https://github.com/kudo))
+
+## 0.7.2 — 2021-06-24
+
+### 🐛 Bug fixes
+
+- [plugin] Use Node module resolution to find package paths for Podfile ([#13382](https://github.com/expo/expo/pull/13382) by [@fson](https://github.com/fson))
 
 ## 0.7.0 — 2021-06-10
 

--- a/packages/expo-dev-menu/android/build.gradle
+++ b/packages/expo-dev-menu/android/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'maven'
 
 group = 'host.exp.exponent'
-version = '0.7.0'
+version = '0.7.5'
 
 buildscript {
   // Simple helper that allows the root project to override versions declared by this library.
@@ -57,7 +57,7 @@ android {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 30)
     versionCode 10
-    versionName '0.7.0'
+    versionName '0.7.5'
   }
   lintOptions {
     abortOnError false

--- a/packages/expo-dev-menu/package.json
+++ b/packages/expo-dev-menu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-dev-menu",
-  "version": "0.7.0",
+  "version": "0.7.5",
   "description": "Expo/React Native module with the developer menu.",
   "main": "build/DevMenu.js",
   "types": "build/DevMenu.d.ts",
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@expo/config-plugins": "^3.0.0",
-    "expo-dev-menu-interface": "0.3.1"
+    "expo-dev-menu-interface": "0.3.2"
   },
   "devDependencies": {
     "@react-navigation/core": "5.15.1",

--- a/packages/expo-updates-interface/CHANGELOG.md
+++ b/packages/expo-updates-interface/CHANGELOG.md
@@ -4,15 +4,23 @@
 
 ### 🛠 Breaking changes
 
-- Added method to reset Updates module state. ([#13346](https://github.com/expo/expo/pull/13346) by [@esamelson](https://github.com/esamelson))
-
 ### 🎉 New features
+
+### 🐛 Bug fixes
+
+### 💡 Others
+
+## 0.2.2 — 2021-07-05
 
 ### 🐛 Bug fixes
 
 - Remove unnecessary gradle dependency on unimodules-core. ([#13481](https://github.com/expo/expo/pull/13481) by [@esamelson](https://github.com/esamelson))
 
-### 💡 Others
+## 0.2.1 — 2021-06-24
+
+### 🛠 Breaking changes
+
+- Added method to reset Updates module state. ([#13346](https://github.com/expo/expo/pull/13346) by [@esamelson](https://github.com/esamelson))
 
 ## 0.1.0 — 2021-06-10
 

--- a/packages/expo-updates-interface/android/build.gradle
+++ b/packages/expo-updates-interface/android/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'kotlin-android-extensions'
 apply plugin: 'maven'
 
 group = 'host.exp.exponent'
-version = '0.1.0'
+version = '0.2.2'
 
 buildscript {
   // Simple helper that allows the root project to override versions declared by this library.
@@ -53,7 +53,7 @@ android {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 1
-    versionName '0.1.0'
+    versionName '0.2.2'
   }
   lintOptions {
     abortOnError false

--- a/packages/expo-updates-interface/package.json
+++ b/packages/expo-updates-interface/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-updates-interface",
-  "version": "0.1.0",
+  "version": "0.2.2",
   "description": "Native interface for modules that optionally depend on expo-updates, e.g. expo-dev-launcher.",
   "main": "index.js",
   "keywords": [

--- a/packages/expo-updates/package.json
+++ b/packages/expo-updates/package.json
@@ -37,7 +37,7 @@
     "@expo/metro-config": "^0.1.70",
     "@expo/config-plugins": "^3.0.0",
     "expo-structured-headers": "~1.1.0",
-    "expo-updates-interface": "~0.1.0",
+    "expo-updates-interface": "~0.2.2",
     "fbemitter": "^2.1.1",
     "uuid": "^3.4.0",
     "resolve-from": "^5.0.0"


### PR DESCRIPTION
# Why

Keeps in sync changelogs and versions with the SDK-42 branch. 
