### PR TITLE
[swift] Implement event listeners as part of module definition and basic lifecycle events

### DIFF
--- a/packages/expo-modules-core/ios/Swift/AppContext.swift
+++ b/packages/expo-modules-core/ios/Swift/AppContext.swift
@@ -1,3 +1,4 @@
+import UIKit
 /**
  The app context is an interface to a single Expo app.
  */
@@ -18,6 +19,8 @@ public class AppContext {
   public init(withModulesProvider provider: ModulesProviderProtocol, legacyModuleRegistry: EXModuleRegistry?) {
     self.legacyModuleRegistry = legacyModuleRegistry
     moduleRegistry.register(fromProvider: provider)
+
+    listenToClientAppNotifications()
   }
 
   /**
@@ -60,5 +63,43 @@ public class AppContext {
    */
   public var utilities: EXUtilitiesInterface? {
     return legacyModule(implementing: EXUtilitiesInterface.self)
+  }
+
+  /**
+   Starts listening to `UIApplication` notifications.
+   */
+  private func listenToClientAppNotifications() {
+    [
+      UIApplication.willEnterForegroundNotification,
+      UIApplication.didBecomeActiveNotification,
+      UIApplication.didEnterBackgroundNotification,
+    ].forEach { name in
+      NotificationCenter.default.addObserver(self, selector: #selector(handleClientAppNotification(_:)), name: name, object: nil)
+    }
+  }
+
+  /**
+   Handles app's (`UIApplication`) lifecycle notifications and posts appropriate events to the module registry.
+   */
+  @objc
+  private func handleClientAppNotification(_ notification: Notification) {
+    switch notification.name {
+    case UIApplication.willEnterForegroundNotification:
+      moduleRegistry.post(event: .appEntersForeground)
+    case UIApplication.didBecomeActiveNotification:
+      moduleRegistry.post(event: .appBecomesActive)
+    case UIApplication.didEnterBackgroundNotification:
+      moduleRegistry.post(event: .appEntersBackground)
+    default:
+      return
+    }
+  }
+
+  /**
+   Cleans things up before deallocation.
+   */
+  deinit {
+    NotificationCenter.default.removeObserver(self)
+    moduleRegistry.post(event: .appContextDestroys)
   }
 }

--- a/packages/expo-modules-core/ios/Swift/EventListener.swift
+++ b/packages/expo-modules-core/ios/Swift/EventListener.swift
@@ -1,0 +1,33 @@
+/**
+ Represents a listener for the specific event.
+ */
+internal struct EventListener: AnyDefinition {
+  let name: EventName
+  let call: (Any?) -> Void
+
+  init(_ name: EventName, _ listener: @escaping () -> Void) {
+    self.name = name
+    self.call = { payload in listener() }
+  }
+
+  init<PayloadType>(_ name: EventName, _ listener: @escaping (PayloadType?) -> Void) {
+    self.name = name
+    self.call = { payload in listener(payload as? PayloadType) }
+  }
+}
+
+internal enum EventName: Equatable {
+  case custom(_ name: String)
+
+  // MARK: Module lifecycle
+
+  case moduleCreate
+  case moduleDestroy
+  case appContextDestroys
+
+  // MARK: App (UIApplication) lifecycle
+
+  case appEntersForeground
+  case appBecomesActive
+  case appEntersBackground
+}

--- a/packages/expo-modules-core/ios/Swift/ModuleRegistry.swift
+++ b/packages/expo-modules-core/ios/Swift/ModuleRegistry.swift
@@ -46,4 +46,16 @@ public class ModuleRegistry: Sequence {
   public func makeIterator() -> IndexingIterator<[ModuleHolder]> {
     return registry.map({ $1 }).makeIterator()
   }
+
+  internal func post(event: EventName) {
+    forEach { holder in
+      holder.post(event: event)
+    }
+  }
+
+  internal func post<PayloadType>(event: EventName, payload: PayloadType? = nil) {
+    forEach { holder in
+      holder.post(event: event, payload: payload)
+    }
+  }
 }

--- a/packages/expo-modules-core/ios/Swift/Modules/ModuleDefinition.swift
+++ b/packages/expo-modules-core/ios/Swift/Modules/ModuleDefinition.swift
@@ -13,6 +13,7 @@ public struct ModuleDefinition: AnyDefinition {
   let name: String?
   let methods: [String : AnyMethod]
   let constants: [String : Any?]
+  let eventListeners: [EventListener]
 
   init(definitions: [AnyDefinition]) {
     self.name = definitions
@@ -31,6 +32,8 @@ public struct ModuleDefinition: AnyDefinition {
       .reduce(into: [String : Any?]()) { dict, definition in
         dict.merge(definition.constants) { $1 }
       }
+
+    self.eventListeners = definitions.compactMap { $0 as? EventListener }
   }
 }
 

--- a/packages/expo-modules-core/ios/Swift/Modules/ModuleDefinitionComponents.swift
+++ b/packages/expo-modules-core/ios/Swift/Modules/ModuleDefinitionComponents.swift
@@ -162,4 +162,46 @@ extension AnyModule {
       closure
     )
   }
+
+  /**
+   Creates module's lifecycle listener that is called right after module initialization.
+   */
+  public func onCreate(_ closure: @escaping () -> Void) -> AnyDefinition {
+    return EventListener(.moduleCreate, closure)
+  }
+
+  /**
+   Creates module's lifecycle listener that is called when the module is about to be deallocated.
+   */
+  public func onDestroy(_ closure: @escaping () -> Void) -> AnyDefinition {
+    return EventListener(.moduleDestroy, closure)
+  }
+
+  /**
+   Creates module's lifecycle listener that is called when the app context owning the module is about to be deallocated.
+   */
+  public func onAppContextDestroys(_ closure: @escaping () -> Void) -> AnyDefinition {
+    return EventListener(.appContextDestroys, closure)
+  }
+
+  /**
+   Creates a listener that is called when the app is about to enter the foreground mode.
+   */
+  public func onAppEntersForeground(_ closure: @escaping () -> Void) -> AnyDefinition {
+    return EventListener(.appEntersForeground, closure)
+  }
+
+  /**
+   Creates a listener that is called when the app becomes active again.
+   */
+  public func onAppBecomesActive(_ closure: @escaping () -> Void) -> AnyDefinition {
+    return EventListener(.appBecomesActive, closure)
+  }
+
+  /**
+   Creates a listener that is called when the app enters the background mode.
+   */
+  public func onAppEntersBackground(_ closure: @escaping () -> Void) -> AnyDefinition {
+    return EventListener(.appEntersBackground, closure)
+  }
 }

--- a/packages/expo-tracking-transparency/ios/EXTrackingTransparency/TrackingTransparencyModule.swift
+++ b/packages/expo-tracking-transparency/ios/EXTrackingTransparency/TrackingTransparencyModule.swift
@@ -1,15 +1,12 @@
 import ExpoModulesCore
 
 public class TrackingTransparencyModule: Module {
-  public required init(appContext: AppContext) {
-    super.init(appContext: appContext)
-
-    // TODO: (@tsapeta) Make `onCreate` lifecycle event and move it there
-    EXPermissionsMethodsDelegate.register([EXTrackingPermissionRequester()], withPermissionsManager: appContext.permissions)
-  }
-
   public func definition() -> ModuleDefinition {
     name("ExpoTrackingTransparency")
+
+    onCreate {
+      EXPermissionsMethodsDelegate.register([EXTrackingPermissionRequester()], withPermissionsManager: self.appContext?.permissions)
+    }
 
     method("getPermissionsAsync") { (promise: Promise) in
       EXPermissionsMethodsDelegate.getPermissionWithPermissionsManager(


### PR DESCRIPTION
# Why

Completing the todo from here https://github.com/expo/expo/blob/3e3188223291f659d79ac3ca940b011aa11e1784/packages/expo-tracking-transparency/ios/EXTrackingTransparency/TrackingTransparencyModule.swift#L7-L8

# How

Added mechanism for posting events to specific modules (module's lifecycle) and broadcasting other app-related events such as when the app enters foreground or background states.

# Test Plan

The `onCreate` that I added to `TrackingTransparencyModule` works as expected. Also tested the other ones locally.
