### PR TITLE
[sms][android] Issue #7395- duplicated recipients and messages

### DIFF
--- a/packages/expo-sms/CHANGELOG.md
+++ b/packages/expo-sms/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🐛 Bug fixes
 
+- Fixed duplicate recipients & message bodies ([#13651](https://github.com/expo/expo/pull/13651) by [@kkafar](https://github.com/kkafar))
 - Fixed Android intent XML parsing issues. ([#13401](https://github.com/expo/expo/pull/13401) by [@quicksnap](https://github.com/quicksnap))
 
 ### 💡 Others
@@ -23,7 +24,6 @@
 ### 💡 Others
 
 - Converted Android code to Kotlin ([#13505](https://github.com/expo/expo/pull/13505) by [@kkafar](https://github.com/kkafar))
-
 - Build Android code using Java 8 to fix Android instrumented test build error. ([#12939](https://github.com/expo/expo/pull/12939) by [@kudo](https://github.com/kudo))
 - Removed unnecessary dependency on `unimodules-permissions-interface`. ([#12961](https://github.com/expo/expo/pull/12961) by [@tsapeta](https://github.com/tsapeta))
 - Export missing types used by the API: `SMSAttachment` and `SMSOptions`. ([#13240](https://github.com/expo/expo/pull/13240) by [@Simek](https://github.com/Simek))

--- a/packages/expo-sms/android/src/main/java/expo/modules/sms/SMSModule.kt
+++ b/packages/expo-sms/android/src/main/java/expo/modules/sms/SMSModule.kt
@@ -88,7 +88,6 @@ class SMSModule(context: Context) : ExportedModule(context), LifecycleEventListe
     }
     smsIntent.putExtra("exit_on_sent", true)
     smsIntent.putExtra("compose_mode", true)
-    smsIntent.putExtra(Intent.EXTRA_TEXT, message)
     smsIntent.putExtra("sms_body", message)
     mPendingPromise = promise
     val activityProvider = mModuleRegistry.getModule(


### PR DESCRIPTION
# Why

Closes https://github.com/expo/expo/issues/7535

# How

This PR removes line responsible for duplicating message body.
PR (https://github.com/expo/expo/pull/13505) solved duplicate recipients part of the issue. 

# Test Plan

test suite (via BareExpo running on phone with Android 9)
ncl

Google Messages App && Textra

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).