### PR TITLE
[docs] Webview snack example

### DIFF
--- a/docs/pages/versions/unversioned/sdk/webview.md
+++ b/docs/pages/versions/unversioned/sdk/webview.md
@@ -5,6 +5,7 @@ sourceCodeUrl: 'https://github.com/react-native-community/react-native-webview'
 
 import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
+import SnackInline from '~/components/plugins/SnackInline';
 
 **`react-native-webview`** provides a `WebView` component that renders web content in a native view.
 
@@ -18,32 +19,67 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 You should refer to the [react-native-webview docs](https://github.com/react-native-community/react-native-webview/blob/master/docs/Guide.md#react-native-webview-guide) for more information on the API and its usage. But the following example (courtesy of that repo) is a quick way to get up and running!
 
-```javascript
+<SnackInline label="Basic Webview usage" dependencies={["react-native-webview", "expo-constants"]}>
+
+```jsx
 import * as React from 'react';
 import { WebView } from 'react-native-webview';
+/* @hide */
+import { StyleSheet } from 'react-native';
+import Constants from 'expo-constants';
+/* @end */
 
-export default class App extends React.Component {
-  render() {
-    return <WebView source={{ uri: 'https://expo.io' }} style={{ marginTop: 20 }} />;
-  }
+export default function App() {
+  return (
+    <WebView 
+      style={styles.container}
+      source={{ uri: 'https://expo.io' }}
+    />
+  );
 }
+
+/* @hide const styles = StyleSheet.create({ ... }); */
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    marginTop: Constants.statusBarHeight,
+  },
+});
+/* @end */
 ```
+
+</SnackInline>
 
 Minimal example with inline HTML:
 
-```javascript
+<SnackInline label="Webview inline HTML" dependencies={["react-native-webview", "expo-constants"]}>
+
+```jsx
 import * as React from 'react';
 import { WebView } from 'react-native-webview';
+/* @hide */
+import { StyleSheet } from 'react-native';
+import Constants from 'expo-constants';
+/* @end */
 
-export default class App extends React.Component {
-  render() {
-    return (
-      <WebView
-        originWhitelist={['*']}
-        source={{ html: '<h1>Hello world</h1>' }}
-        style={{ marginTop: 20 }}
-      />
-    );
-  }
+export default function App() {
+  return (
+    <WebView
+      style={styles.container}
+      originWhitelist={['*']}
+      source={{ html: '<h1><center>Hello world</center></h1>' }}
+    />
+  );
 }
+
+/* @hide const styles = StyleSheet.create({ ... }); */
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    marginTop: Constants.statusBarHeight,
+  },
+});
+/* @end */
 ```
+
+</SnackInline>

--- a/docs/pages/versions/v42.0.0/sdk/webview.md
+++ b/docs/pages/versions/v42.0.0/sdk/webview.md
@@ -5,6 +5,7 @@ sourceCodeUrl: 'https://github.com/react-native-community/react-native-webview'
 
 import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
+import SnackInline from '~/components/plugins/SnackInline';
 
 **`react-native-webview`** provides a `WebView` component that renders web content in a native view.
 
@@ -18,32 +19,67 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 You should refer to the [react-native-webview docs](https://github.com/react-native-community/react-native-webview/blob/master/docs/Guide.md#react-native-webview-guide) for more information on the API and its usage. But the following example (courtesy of that repo) is a quick way to get up and running!
 
-```javascript
+<SnackInline label="Basic Webview usage" dependencies={["react-native-webview", "expo-constants"]}>
+
+```jsx
 import * as React from 'react';
 import { WebView } from 'react-native-webview';
+/* @hide */
+import { StyleSheet } from 'react-native';
+import Constants from 'expo-constants';
+/* @end */
 
-export default class App extends React.Component {
-  render() {
-    return <WebView source={{ uri: 'https://expo.io' }} style={{ marginTop: 20 }} />;
-  }
+export default function App() {
+  return (
+    <WebView 
+      style={styles.container}
+      source={{ uri: 'https://expo.io' }}
+    />
+  );
 }
+
+/* @hide const styles = StyleSheet.create({ ... }); */
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    marginTop: Constants.statusBarHeight,
+  },
+});
+/* @end */
 ```
+
+</SnackInline>
 
 Minimal example with inline HTML:
 
-```javascript
+<SnackInline label="Webview inline HTML" dependencies={["react-native-webview", "expo-constants"]}>
+
+```jsx
 import * as React from 'react';
 import { WebView } from 'react-native-webview';
+/* @hide */
+import { StyleSheet } from 'react-native';
+import Constants from 'expo-constants';
+/* @end */
 
-export default class App extends React.Component {
-  render() {
-    return (
-      <WebView
-        originWhitelist={['*']}
-        source={{ html: '<h1>Hello world</h1>' }}
-        style={{ marginTop: 20 }}
-      />
-    );
-  }
+export default function App() {
+  return (
+    <WebView
+      style={styles.container}
+      originWhitelist={['*']}
+      source={{ html: '<h1><center>Hello world</center></h1>' }}
+    />
+  );
 }
+
+/* @hide const styles = StyleSheet.create({ ... }); */
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    marginTop: Constants.statusBarHeight,
+  },
+});
+/* @end */
 ```
+
+</SnackInline>


### PR DESCRIPTION
# Why

Add Snack examples for `react-native-webview`. For aiding users and allowing us to quickly test webview on Snack

![image](https://user-images.githubusercontent.com/6184593/125935147-24857cce-1f34-486b-b562-531b80801eb5.png)

# How

- See #why
- Added for both unversioned and SDK 42

# Test Plan

- https://snack.expo.io/@hein_expo/basic-webview-usage
- https://snack.expo.io/@hein_expo/webview-inline-html
- Verified both examples are confirmed they look good on iOS

