### PR TITLE
[swift] Move setting method's queue to separate function

### DIFF
--- a/packages/expo-modules-core/ios/Swift/Methods/AnyMethod.swift
+++ b/packages/expo-modules-core/ios/Swift/Methods/AnyMethod.swift
@@ -22,4 +22,9 @@ public protocol AnyMethod: AnyDefinition {
    Calls the method with given arguments and a promise.
    */
   func call(args: [Any?], promise: Promise) -> Void
+
+  /**
+   Specifies on which queue the method should run.
+   */
+  func runOnQueue(_ queue: DispatchQueue?) -> Self
 }

--- a/packages/expo-modules-core/ios/Swift/Methods/ConcreteMethod.swift
+++ b/packages/expo-modules-core/ios/Swift/Methods/ConcreteMethod.swift
@@ -1,5 +1,5 @@
 
-public struct ConcreteMethod<Args, ReturnType>: AnyMethod {
+public class ConcreteMethod<Args, ReturnType>: AnyMethod {
   public typealias ClosureType = (Args) -> ReturnType
 
   public let name: String
@@ -21,12 +21,10 @@ public struct ConcreteMethod<Args, ReturnType>: AnyMethod {
   init(
     _ name: String,
     argTypes: [AnyArgumentType],
-    queue: DispatchQueue? = nil,
     _ closure: @escaping ClosureType
   ) {
     self.name = name
     self.argTypes = argTypes
-    self.queue = queue
     self.closure = closure
   }
 
@@ -50,6 +48,11 @@ public struct ConcreteMethod<Args, ReturnType>: AnyMethod {
     if !takesPromise {
       promise.resolve(returnedValue)
     }
+  }
+
+  public func runOnQueue(_ queue: DispatchQueue?) -> Self {
+    self.queue = queue
+    return self
   }
 
   private func argumentType(atIndex index: Int) -> AnyArgumentType? {

--- a/packages/expo-modules-core/ios/Swift/Modules/ModuleDefinitionComponents.swift
+++ b/packages/expo-modules-core/ios/Swift/Modules/ModuleDefinitionComponents.swift
@@ -24,13 +24,11 @@ extension AnyModule {
    */
   public func method<R>(
     _ name: String,
-    queue: DispatchQueue? = nil,
     _ closure: @escaping () -> R
   ) -> AnyMethod {
     return ConcreteMethod(
       name,
       argTypes: [],
-      queue: queue,
       closure
     )
   }
@@ -40,13 +38,11 @@ extension AnyModule {
    */
   public func method<R, A0: AnyMethodArgument>(
     _ name: String,
-    queue: DispatchQueue? = nil,
     _ closure: @escaping (A0) -> R
   ) -> AnyMethod {
     return ConcreteMethod(
       name,
       argTypes: [AnyArgumentType(A0.self)],
-      queue: queue,
       closure
     )
   }
@@ -56,13 +52,11 @@ extension AnyModule {
    */
   public func method<R, A0: AnyMethodArgument, A1: AnyMethodArgument>(
     _ name: String,
-    queue: DispatchQueue? = nil,
     _ closure: @escaping (A0, A1) -> R
   ) -> AnyMethod {
     return ConcreteMethod(
       name,
       argTypes: [AnyArgumentType(A0.self), AnyArgumentType(A1.self)],
-      queue: queue,
       closure
     )
   }
@@ -72,13 +66,11 @@ extension AnyModule {
    */
   public func method<R, A0: AnyMethodArgument, A1: AnyMethodArgument, A2: AnyMethodArgument>(
     _ name: String,
-    queue: DispatchQueue? = nil,
     _ closure: @escaping (A0, A1, A2) -> R
   ) -> AnyMethod {
     return ConcreteMethod(
       name,
       argTypes: [AnyArgumentType(A0.self), AnyArgumentType(A1.self), AnyArgumentType(A2.self)],
-      queue: queue,
       closure
     )
   }
@@ -88,13 +80,11 @@ extension AnyModule {
    */
   public func method<R, A0: AnyMethodArgument, A1: AnyMethodArgument, A2: AnyMethodArgument, A3: AnyMethodArgument>(
     _ name: String,
-    queue: DispatchQueue? = nil,
     _ closure: @escaping (A0, A1, A2, A3) -> R
   ) -> AnyMethod {
     return ConcreteMethod(
       name,
       argTypes: [AnyArgumentType(A0.self), AnyArgumentType(A1.self), AnyArgumentType(A2.self), AnyArgumentType(A3.self)],
-      queue: queue,
       closure
     )
   }
@@ -104,13 +94,11 @@ extension AnyModule {
    */
   public func method<R, A0: AnyMethodArgument, A1: AnyMethodArgument, A2: AnyMethodArgument, A3: AnyMethodArgument, A4: AnyMethodArgument>(
     _ name: String,
-    queue: DispatchQueue? = nil,
     _ closure: @escaping (A0, A1, A2, A3, A4) -> R
   ) -> AnyMethod {
     return ConcreteMethod(
       name,
       argTypes: [AnyArgumentType(A0.self), AnyArgumentType(A1.self), AnyArgumentType(A2.self), AnyArgumentType(A3.self), AnyArgumentType(A4.self)],
-      queue: queue,
       closure
     )
   }
@@ -120,13 +108,11 @@ extension AnyModule {
    */
   public func method<R, A0: AnyMethodArgument, A1: AnyMethodArgument, A2: AnyMethodArgument, A3: AnyMethodArgument, A4: AnyMethodArgument, A5: AnyMethodArgument>(
     _ name: String,
-    queue: DispatchQueue? = nil,
     _ closure: @escaping (A0, A1, A2, A3, A4, A5) -> R
   ) -> AnyMethod {
     return ConcreteMethod(
       name,
       argTypes: [AnyArgumentType(A0.self), AnyArgumentType(A1.self), AnyArgumentType(A2.self), AnyArgumentType(A3.self), AnyArgumentType(A4.self), AnyArgumentType(A5.self)],
-      queue: queue,
       closure
     )
   }
@@ -136,13 +122,11 @@ extension AnyModule {
    */
   public func method<R, A0: AnyMethodArgument, A1: AnyMethodArgument, A2: AnyMethodArgument, A3: AnyMethodArgument, A4: AnyMethodArgument, A5: AnyMethodArgument, A6: AnyMethodArgument>(
     _ name: String,
-    queue: DispatchQueue? = nil,
     _ closure: @escaping (A0, A1, A2, A3, A4, A5, A6) -> R
   ) -> AnyMethod {
     return ConcreteMethod(
       name,
       argTypes: [AnyArgumentType(A0.self), AnyArgumentType(A1.self), AnyArgumentType(A2.self), AnyArgumentType(A3.self), AnyArgumentType(A4.self), AnyArgumentType(A5.self), AnyArgumentType(A6.self)],
-      queue: queue,
       closure
     )
   }
@@ -152,13 +136,11 @@ extension AnyModule {
    */
   public func method<R, A0: AnyMethodArgument, A1: AnyMethodArgument, A2: AnyMethodArgument, A3: AnyMethodArgument, A4: AnyMethodArgument, A5: AnyMethodArgument, A6: AnyMethodArgument, A7: AnyMethodArgument>(
     _ name: String,
-    queue: DispatchQueue? = nil,
     _ closure: @escaping (A0, A1, A2, A3, A4, A5, A6, A7) -> R
   ) -> AnyMethod {
     return ConcreteMethod(
       name,
       argTypes: [AnyArgumentType(A0.self), AnyArgumentType(A1.self), AnyArgumentType(A2.self), AnyArgumentType(A3.self), AnyArgumentType(A4.self), AnyArgumentType(A5.self), AnyArgumentType(A6.self), AnyArgumentType(A7.self)],
-      queue: queue,
       closure
     )
   }


### PR DESCRIPTION
# Why

To reduce the boilerplate code we have for many different versions of `method` function. This solution also seems nicer than passing it in the constructor 😉 

# How

- Removed `queue` param from all generic `method` functions
- Added `runOnQueue` method to set method's queue (this required me to change the `ConcreteMethod` from struct to class, to make it mutable)

# Test Plan

It compiles and I tested it locally after adding this call on one of the exported methods
