### PR TITLE
[camera][ios] fix video quality regression

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 - Update video codec validation to properly reject an invalid codec option. ([#13341](https://github.com/expo/expo/pull/13341) by [@ajsmth](https://github.com/ajsmth))
 - Add `get/requestMicrophonePermissionsAsync()` and `get/requestCameraPermissionsAsync()` methods to named exports. ([#13621](https://github.com/expo/expo/pull/13621) by [@ajsmth](https://github.com/ajsmth))
+- Fix regression in video quality option of recordAsync() ([#13659](https://github.com/expo/expo/pull/13659) by [@ajsmth](https://github.com/ajsmth))
+
 
 ### 💡 Others
 

--- a/packages/expo-camera/ios/EXCamera/EXCamera.m
+++ b/packages/expo-camera/ios/EXCamera/EXCamera.m
@@ -523,6 +523,18 @@ previewPhotoSampleBuffer:(CMSampleBufferRef)previewPhotoSampleBuffer
     }
     [connection setVideoOrientation:[EXCameraUtils videoOrientationForDeviceOrientation:[[UIDevice currentDevice] orientation]]];
     
+    AVCaptureSessionPreset preset;
+    if (options[@"quality"]) {
+      EXCameraVideoResolution resolution = [options[@"quality"] integerValue];
+      preset = [EXCameraUtils captureSessionPresetForVideoResolution:resolution];
+    } else if ([self.session.sessionPreset isEqual:AVCaptureSessionPresetPhoto]) {
+      preset = AVCaptureSessionPresetHigh;
+    }
+
+    if (preset != nil) {
+      [self updateSessionPreset:preset];
+    }
+    
     [self setVideoOptions:options forConnection:connection onReject:reject];
     
     bool canBeMirrored = connection.isVideoMirroringSupported;
@@ -575,18 +587,6 @@ previewPhotoSampleBuffer:(CMSampleBufferRef)previewPhotoSampleBuffer
 
     if (options[@"maxFileSize"]) {
       self.movieFileOutput.maxRecordedFileSize = [options[@"maxFileSize"] integerValue];
-    }
-    
-    AVCaptureSessionPreset preset;
-    if (options[@"quality"]) {
-      EXCameraVideoResolution resolution = [options[@"quality"] integerValue];
-      preset = [EXCameraUtils captureSessionPresetForVideoResolution:resolution];
-    } else if ([self.session.sessionPreset isEqual:AVCaptureSessionPresetPhoto]) {
-      preset = AVCaptureSessionPresetHigh;
-    }
-
-    if (preset != nil) {
-      [self updateSessionPreset:preset];
     }
     
     if (options[@"codec"]) {


### PR DESCRIPTION
# Why

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

Closes #13625 

This regression can be more accurately described as being caused by the video quality option. In the initial implementation, `setVideoOptions` was wrapped in an async block to prevent a race condition that was identified by `react-native-video` authors, however my implementation was wrong because the `quality` option is an async operation itself. By including it in an async block, it is executing after the `setVideoOptions` method in the async queue, where we need it to happen before

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

Moved the quality option outside of the `setVideoOptions` block

# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->

gist: https://gist.github.com/ajsmth/2323d2654dacc32f5262714845566afb

Before this PR, adding any video quality option to `recordAsync()` results in it exiting the recording session immediately. Afterwards it behaves as normal