### PR TITLE
[expo-constants][ios] Fix app.config not generated

### DIFF
--- a/packages/expo-constants/CHANGELOG.md
+++ b/packages/expo-constants/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 - fix `__dir__` absolute path in script_phase making an inconsistent Podfile.lock. ([#13610](https://github.com/expo/expo/pull/13610) by [@kudo](https://github.com/kudo))
 - Fix `PROJECT_ROOT` path resolution in `get-app-config-ios.sh`. ([#13439](https://github.com/expo/expo/pull/13439) by [@ajsmth](https://github.com/ajsmth))
-
+- Fix app.config not generated. ([#13667](https://github.com/expo/expo/pull/13667) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-constants/scripts/get-app-config-ios.sh
+++ b/packages/expo-constants/scripts/get-app-config-ios.sh
@@ -8,8 +8,8 @@ NODE_BINARY=${NODE_BINARY:-node}
 # ref: https://github.com/facebook/react-native/blob/c974cbff04a8d90ac0f856dbada3fc5a75c75b49/scripts/react-native-xcode.sh#L59-L65
 # Path to expo-constants folder inside node_modules
 EXPO_CONSTANTS_PACKAGE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-# The project should be located next to where expo-constants is installed
-# in node_modules.
+# If PROJECT_ROOT is not specified, fallback to use Xcode PROJECT_DIR
+PROJECT_ROOT=${PROJECT_ROOT:-"$PROJECT_DIR"}
 PROJECT_ROOT=${PROJECT_ROOT:-"$EXPO_CONSTANTS_PACKAGE_DIR/../.."}
 
 cd "$PROJECT_ROOT" || exit
@@ -27,4 +27,4 @@ if [ "x$DIR_BASENAME" != "xPods" ]; then
   exit 0
 fi
 
-"$NODE_BINARY" "${EXPO_CONSTANTS_PACKAGE_DIR}/scripts/getAppConfig.js" "$PROJECT_ROOT" "$DEST"
+"$NODE_BINARY" "${EXPO_CONSTANTS_PACKAGE_DIR}/scripts/getAppConfig.js" "$PROJECT_ROOT/.." "$DEST/EXConstants.bundle"

--- a/packages/expo-constants/scripts/getAppConfig.js
+++ b/packages/expo-constants/scripts/getAppConfig.js
@@ -13,6 +13,8 @@ if (fs.existsSync(path.join(possibleProjectRoot, 'package.json'))) {
   projectRoot = path.resolve(possibleProjectRoot, '..');
 }
 
+process.chdir(projectRoot);
+
 const { exp } = getConfig(projectRoot, {
   isPublicConfig: true,
   skipSDKVersionRequirement: true,


### PR DESCRIPTION
# Why

fix #13656 

# How

expo-constants generation changes to in-module podspec script-phase from #13424 but be overwritten from #13439.
app.config does not generated because PROJECT_ROOT is fallback to expo root dir.
https://github.com/expo/expo/blob/e21def8bb6a1042fe91ecc5a6ac0bae7d0d22054/packages/expo-constants/scripts/get-app-config-ios.sh#L13
e.g. `PROJECT_ROOT === '/path/to/expo'`
in this case, we will return without error for backward compatible.
https://github.com/expo/expo/blob/e21def8bb6a1042fe91ecc5a6ac0bae7d0d22054/packages/expo-constants/scripts/get-app-config-ios.sh#L24-L28

this pr tries to use xcode PROJECT_DIR as first fallback. in this case, it will be `/path/to/expo/apps/bare-expo/ios/Pods` that will continue getAppConfig.js execution.

# Test Plan

- use xcode to run bare-expo
- `yarn ios` inside bare-expo

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).