### PR TITLE
[expo-document-picker][android] Fix file uri

### DIFF
--- a/packages/expo-document-picker/CHANGELOG.md
+++ b/packages/expo-document-picker/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - Added `AndroidManifest.xml` queries for intent handling. ([#13388](https://github.com/expo/expo/pull/13388) by [@EvanBacon](https://github.com/EvanBacon))
 
-- Fixed file uri.
+- Fixed file uri. ([#13678](https://github.com/expo/expo/pull/13678) by [@mstach60161](https://github.com/mstach60161))
 
 ### 💡 Others
 

--- a/packages/expo-document-picker/CHANGELOG.md
+++ b/packages/expo-document-picker/CHANGELOG.md
@@ -9,7 +9,6 @@
 ### 🐛 Bug fixes
 
 - Added `AndroidManifest.xml` queries for intent handling. ([#13388](https://github.com/expo/expo/pull/13388) by [@EvanBacon](https://github.com/EvanBacon))
-
 - Fixed file uri.
 
 ### 💡 Others

--- a/packages/expo-document-picker/CHANGELOG.md
+++ b/packages/expo-document-picker/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 - Added `AndroidManifest.xml` queries for intent handling. ([#13388](https://github.com/expo/expo/pull/13388) by [@EvanBacon](https://github.com/EvanBacon))
 
+- Fixed file uri.
+
 ### 💡 Others
 
 ## 9.2.0 — 2021-06-16

--- a/packages/expo-document-picker/android/src/main/java/expo/modules/documentpicker/DocumentPickerModule.kt
+++ b/packages/expo-document-picker/android/src/main/java/expo/modules/documentpicker/DocumentPickerModule.kt
@@ -120,10 +120,10 @@ class DocumentPickerModule(
       "DocumentPicker",
       FilenameUtils.getExtension(name)
     )
-
+    val outputFile = File(outputFilePath)
     try {
       context.contentResolver.openInputStream(documentUri).use { inputStream ->
-        FileOutputStream(File(outputFilePath)).use { outputStream ->
+        FileOutputStream(outputFile).use { outputStream ->
           IOUtils.copy(inputStream, outputStream)
         }
       }
@@ -131,7 +131,6 @@ class DocumentPickerModule(
       e.printStackTrace()
       return null
     }
-
-    return "file://$outputFilePath"
+    return Uri.fromFile(outputFile).toString()
   }
 }

--- a/packages/expo-document-picker/android/src/main/java/expo/modules/documentpicker/DocumentPickerModule.kt
+++ b/packages/expo-document-picker/android/src/main/java/expo/modules/documentpicker/DocumentPickerModule.kt
@@ -132,6 +132,6 @@ class DocumentPickerModule(
       return null
     }
 
-    return outputFilePath
+    return "file://$outputFilePath"
   }
 }


### PR DESCRIPTION
# Why

- Fixes #13627.
- File uri didn't have prefix "file://".

# How

- Added file prefix to output file path.

# Test Plan

- Native component list.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).