### PR TITLE
[docs] update Next.js guide

### DIFF
--- a/docs/pages/guides/using-nextjs.md
+++ b/docs/pages/guides/using-nextjs.md
@@ -136,16 +136,23 @@ Optionally you can set the project up manually (not recommended).
 
 - Update the Next.js `next.config.js` file to support loading React Native and Expo packages:
 
+  - yarn add -D next-compose-plugins next-transpile-modules
+
   - `touch next.config.js`
 
   `next.config.js`
 
   ```js
   const { withExpo } = require('@expo/next-adapter');
+  const withPlugins = require('next-compose-plugins');
+  const withTM = require('next-transpile-modules')(['react-native-web']);
 
-  module.exports = withExpo({
-    projectRoot: __dirname,
-  });
+  const nextConfig = {};
+
+  module.exports = withPlugins(
+    [withTM, [withExpo, { projectRoot: __dirname }]],
+    nextConfig
+  );
   ```
 
 - You can now start your Expo web + Next.js project with `yarn next dev` 🎉


### PR DESCRIPTION
# Why

We added support for Next.js 11 and Webpack since `@expo/next-adapter@3.0.0`

# How

Updated the required `next.config.js` to transpile `react-native-web`

# Test Plan

Follow the manual install guide and make sure that it's working