### PR TITLE
[camera][ios] remove permission validation from init method

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Update video codec validation to properly reject an invalid codec option. ([#13341](https://github.com/expo/expo/pull/13341) by [@ajsmth](https://github.com/ajsmth))
 - Add `get/requestMicrophonePermissionsAsync()` and `get/requestCameraPermissionsAsync()` methods to named exports. ([#13621](https://github.com/expo/expo/pull/13621) by [@ajsmth](https://github.com/ajsmth))
 - Fix regression in video quality option of recordAsync() ([#13659](https://github.com/expo/expo/pull/13659) by [@ajsmth](https://github.com/ajsmth))
+- Update permission validation to check for only camera permissions in `initWithModuleRegistry()` ([#13690](https://github.com/expo/expo/pull/13690) by [@ajsmth](https://github.com/ajsmth))
 
 
 ### 💡 Others

--- a/packages/expo-camera/ios/EXCamera/EXCamera.m
+++ b/packages/expo-camera/ios/EXCamera/EXCamera.m
@@ -648,10 +648,6 @@ previewPhotoSampleBuffer:(CMSampleBufferRef)previewPhotoSampleBuffer
 #if TARGET_IPHONE_SIMULATOR
   return;
 #endif
-  if (![_permissionsManager hasGrantedPermissionUsingRequesterClass:[EXCameraPermissionRequester class]]) {
-    [self onMountingError:@{@"message": @"Camera permissions not granted - component could not be rendered."}];
-    return;
-  }
   UM_WEAKIFY(self);
   dispatch_async(_sessionQueue, ^{
     UM_ENSURE_STRONGIFY(self);

--- a/packages/expo-camera/ios/EXCamera/EXCamera.m
+++ b/packages/expo-camera/ios/EXCamera/EXCamera.m
@@ -4,7 +4,7 @@
 #import <EXCamera/EXCamera.h>
 #import <EXCamera/EXCameraUtils.h>
 #import <EXCamera/EXCameraManager.h>
-#import <EXCamera/EXCameraPermissionRequester.h>
+#import <EXCamera/EXCameraCameraPermissionRequester.h>
 #import <UMCore/UMAppLifecycleService.h>
 #import <UMCore/UMUtilities.h>
 #import <ExpoModulesCore/EXFaceDetectorManagerInterface.h>
@@ -648,6 +648,10 @@ previewPhotoSampleBuffer:(CMSampleBufferRef)previewPhotoSampleBuffer
 #if TARGET_IPHONE_SIMULATOR
   return;
 #endif
+  if (![_permissionsManager hasGrantedPermissionUsingRequesterClass:[EXCameraCameraPermissionRequester class]]) {
+    [self onMountingError:@{@"message": @"Camera permissions not granted - component could not be rendered."}];
+    return;
+  }
   UM_WEAKIFY(self);
   dispatch_async(_sessionQueue, ^{
     UM_ENSURE_STRONGIFY(self);


### PR DESCRIPTION
# Why

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

Possibly resolves #11736

I'm not sure how I missed this during QA, but there is an extra validation that checks for Plist entries in `initWithModuleRegistry` which is performing the same check that `requestPermissions` would do - e.g it validates that both camera and microphone permissions are in the target Info plist, and throws if they are not

Since we're expanding the API to pick and choose camera or microphone permissions, I don't think it makes sense to perform this check at all - any missing plist values will crash the app anyways, and if anything this method makes it more difficult to debug because the error message is clobbered by the validation, so it seems like the new APIs just aren't working

TLDR - If I install `expo-camera` in a bare app and use and include the camera permission APIs, this validation will still crash the app. 

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

Removed the check in the init method

# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->


Install in a bare ios app, include one permission value (microphone or camera),  and ensure that the app doesn't crash when using the Camera module permissions APIs - e.g `Camera.requestCameraPermissionAsync()`
