### PR TITLE
[media-library][android] #10653 Issue fix

### DIFF
--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryConstants.java
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryConstants.java
@@ -25,6 +25,7 @@ final class MediaLibraryConstants {
   static final String ERROR_UNABLE_TO_ASK_FOR_PERMISSIONS = "ERR_UNABLE_TO_ASK_FOR_PERMISSIONS";
   static final String ERROR_NO_PERMISSIONS_MESSAGE = "Missing MEDIA_LIBRARY permissions.";
   static final String ERROR_NO_WRITE_PERMISSION_MESSAGE = "Missing MEDIA_LIBRARY write permission.";
+  static final String ERROR_NO_READ_PERMISSION_MESSAGE = "Missing MEDIA_LIBRARY read permission.";
   static final String ERROR_USER_DID_NOT_GRANT_WRITE_PERMISSIONS_MESSAGE = "User didn't grant write permission to requested files.";
   static final String ERROR_UNABLE_TO_ASK_FOR_PERMISSIONS_MESSAGE = "Unable to ask for permissions.";
   static final String ERROR_NO_FILE_EXTENSION = "E_NO_FILE_EXTENSION";

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryModule.java
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryModule.java
@@ -41,6 +41,7 @@ import static android.Manifest.permission.WRITE_EXTERNAL_STORAGE;
 import static expo.modules.medialibrary.MediaLibraryConstants.ERROR_NO_ALBUM;
 import static expo.modules.medialibrary.MediaLibraryConstants.ERROR_NO_PERMISSIONS;
 import static expo.modules.medialibrary.MediaLibraryConstants.ERROR_NO_PERMISSIONS_MESSAGE;
+import static expo.modules.medialibrary.MediaLibraryConstants.ERROR_NO_READ_PERMISSION_MESSAGE;
 import static expo.modules.medialibrary.MediaLibraryConstants.ERROR_NO_WRITE_PERMISSION_MESSAGE;
 import static expo.modules.medialibrary.MediaLibraryConstants.ERROR_UNABLE_TO_ASK_FOR_PERMISSIONS;
 import static expo.modules.medialibrary.MediaLibraryConstants.ERROR_UNABLE_TO_ASK_FOR_PERMISSIONS_MESSAGE;
@@ -141,7 +142,7 @@ public class MediaLibraryModule extends ExportedModule implements ActivityEventL
 
   @ExpoMethod
   public void createAssetAsync(String localUri, Promise promise) {
-    if (isMissingPermissions()) {
+    if (isMissingReadOrWritePermissions()) {
       promise.reject(ERROR_NO_PERMISSIONS, ERROR_NO_PERMISSIONS_MESSAGE);
       return;
     }
@@ -152,7 +153,7 @@ public class MediaLibraryModule extends ExportedModule implements ActivityEventL
 
   @ExpoMethod
   public void addAssetsToAlbumAsync(List<String> assetsId, String albumId, boolean copyToAlbum, Promise promise) {
-    if (isMissingPermissions()) {
+    if (isMissingReadOrWritePermissions()) {
       promise.reject(ERROR_NO_PERMISSIONS, ERROR_NO_PERMISSIONS_MESSAGE);
       return;
     }
@@ -172,7 +173,7 @@ public class MediaLibraryModule extends ExportedModule implements ActivityEventL
 
   @ExpoMethod
   public void removeAssetsFromAlbumAsync(List<String> assetsId, String albumId, Promise promise) {
-    if (isMissingPermissions()) {
+    if (isMissingReadOrWritePermissions()) {
       promise.reject(ERROR_NO_PERMISSIONS, ERROR_NO_PERMISSIONS_MESSAGE);
       return;
     }
@@ -192,7 +193,7 @@ public class MediaLibraryModule extends ExportedModule implements ActivityEventL
 
   @ExpoMethod
   public void deleteAssetsAsync(List<String> assetsId, Promise promise) {
-    if (isMissingPermissions()) {
+    if (isMissingReadOrWritePermissions()) {
       promise.reject(ERROR_NO_PERMISSIONS, ERROR_NO_PERMISSIONS_MESSAGE);
       return;
     }
@@ -212,7 +213,7 @@ public class MediaLibraryModule extends ExportedModule implements ActivityEventL
 
   @ExpoMethod
   public void getAssetInfoAsync(String assetId, Map<String, Object> options /* unused on android atm */, Promise promise) {
-    if (isMissingPermissions()) {
+    if (isMissingReadOrWritePermissions()) {
       promise.reject(ERROR_NO_PERMISSIONS, ERROR_NO_PERMISSIONS_MESSAGE);
       return;
     }
@@ -224,7 +225,7 @@ public class MediaLibraryModule extends ExportedModule implements ActivityEventL
 
   @ExpoMethod
   public void getAlbumsAsync(Map<String, Object> options /* unused on android atm */, Promise promise) {
-    if (isMissingPermissions()) {
+    if (isMissingReadOrWritePermissions()) {
       promise.reject(ERROR_NO_PERMISSIONS, ERROR_NO_PERMISSIONS_MESSAGE);
       return;
     }
@@ -235,7 +236,7 @@ public class MediaLibraryModule extends ExportedModule implements ActivityEventL
 
   @ExpoMethod
   public void getAlbumAsync(String albumName, Promise promise) {
-    if (isMissingPermissions()) {
+    if (isMissingReadOrWritePermissions()) {
       promise.reject(ERROR_NO_PERMISSIONS, ERROR_NO_PERMISSIONS_MESSAGE);
       return;
     }
@@ -246,7 +247,7 @@ public class MediaLibraryModule extends ExportedModule implements ActivityEventL
 
   @ExpoMethod
   public void createAlbumAsync(String albumName, String assetId, boolean copyAsset, Promise promise) {
-    if (isMissingPermissions()) {
+    if (isMissingReadOrWritePermissions()) {
       promise.reject(ERROR_NO_PERMISSIONS, ERROR_NO_PERMISSIONS_MESSAGE);
       return;
     }
@@ -266,7 +267,7 @@ public class MediaLibraryModule extends ExportedModule implements ActivityEventL
 
   @ExpoMethod
   public void deleteAlbumsAsync(List<String> albumIds, Promise promise) {
-    if (isMissingPermissions()) {
+    if (isMissingReadOrWritePermissions()) {
       promise.reject(ERROR_NO_PERMISSIONS, ERROR_NO_PERMISSIONS_MESSAGE);
       return;
     }
@@ -286,8 +287,8 @@ public class MediaLibraryModule extends ExportedModule implements ActivityEventL
 
   @ExpoMethod
   public void getAssetsAsync(Map<String, Object> assetOptions, Promise promise) {
-    if (isMissingPermissions()) {
-      promise.reject(ERROR_NO_PERMISSIONS, ERROR_NO_PERMISSIONS_MESSAGE);
+    if (isMissingReadPermission()) {
+      promise.reject(ERROR_NO_PERMISSIONS, ERROR_NO_READ_PERMISSION_MESSAGE);
       return;
     }
 
@@ -358,7 +359,7 @@ public class MediaLibraryModule extends ExportedModule implements ActivityEventL
 
   @ExpoMethod
   public void albumNeedsMigrationAsync(String albumId, Promise promise) {
-    if (isMissingPermissions()) {
+    if (isMissingReadOrWritePermissions()) {
       promise.reject(ERROR_NO_PERMISSIONS, ERROR_NO_PERMISSIONS_MESSAGE);
       return;
     }
@@ -431,7 +432,7 @@ public class MediaLibraryModule extends ExportedModule implements ActivityEventL
   public void onNewIntent(Intent intent) {
   }
 
-  private boolean isMissingPermissions() {
+  private boolean isMissingReadOrWritePermissions() {
     Permissions permissionsManager = mModuleRegistry.getModule(Permissions.class);
     if (permissionsManager == null) {
       return false;
@@ -447,6 +448,15 @@ public class MediaLibraryModule extends ExportedModule implements ActivityEventL
     }
 
     return !permissionsManager.hasGrantedPermissions(WRITE_EXTERNAL_STORAGE);
+  }
+
+  private boolean isMissingReadPermission() {
+    Permissions permissionsManager = mModuleRegistry.getModule(Permissions.class);
+    if (permissionsManager == null) {
+      return false;
+    }
+
+    return !permissionsManager.hasGrantedPermissions(READ_EXTERNAL_STORAGE);
   }
 
   private String[] getManifestPermissions(boolean writeOnly) {

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryModule.java
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryModule.java
@@ -213,8 +213,8 @@ public class MediaLibraryModule extends ExportedModule implements ActivityEventL
 
   @ExpoMethod
   public void getAssetInfoAsync(String assetId, Map<String, Object> options /* unused on android atm */, Promise promise) {
-    if (isMissingReadOrWritePermissions()) {
-      promise.reject(ERROR_NO_PERMISSIONS, ERROR_NO_PERMISSIONS_MESSAGE);
+    if (isMissingReadPermission()) {
+      promise.reject(ERROR_NO_PERMISSIONS, ERROR_NO_READ_PERMISSION_MESSAGE);
       return;
     }
 
@@ -225,8 +225,8 @@ public class MediaLibraryModule extends ExportedModule implements ActivityEventL
 
   @ExpoMethod
   public void getAlbumsAsync(Map<String, Object> options /* unused on android atm */, Promise promise) {
-    if (isMissingReadOrWritePermissions()) {
-      promise.reject(ERROR_NO_PERMISSIONS, ERROR_NO_PERMISSIONS_MESSAGE);
+    if (isMissingReadPermission()) {
+      promise.reject(ERROR_NO_PERMISSIONS, ERROR_NO_READ_PERMISSION_MESSAGE);
       return;
     }
 
@@ -236,8 +236,8 @@ public class MediaLibraryModule extends ExportedModule implements ActivityEventL
 
   @ExpoMethod
   public void getAlbumAsync(String albumName, Promise promise) {
-    if (isMissingReadOrWritePermissions()) {
-      promise.reject(ERROR_NO_PERMISSIONS, ERROR_NO_PERMISSIONS_MESSAGE);
+    if (isMissingReadPermission()) {
+      promise.reject(ERROR_NO_PERMISSIONS, ERROR_NO_READ_PERMISSION_MESSAGE);
       return;
     }
 


### PR DESCRIPTION
# Why

Cloeses #10653 

# How

As suggested in #10653:

1.  Implemented `isMissingReadPermission` 
2. Renamed `isMissingPermissions` method to `isMissingReadOrWritePermissions`
3. Applied `isMissingReadPermission` check where it was appropriate

Changes've been made for android only so far. 

# Test Plan

on API 27 and 30

1. test-suite
2. ncl 

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).