### PR TITLE
[ios] Fix simulator build broken on m1

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -62,6 +62,9 @@ abstract_target 'Expo Go' do
 
       target_installation_result.native_target.build_configurations.each do |config|
         config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '11.0'
+
+        # Fix building failures on M1
+        config.build_settings['EXCLUDED_ARCHS[sdk=iphonesimulator*]'] = 'arm64'
       end
 
       if pod_name == 'Branch'
@@ -81,14 +84,6 @@ abstract_target 'Expo Go' do
         config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] << 'ENABLE_PACKAGER_CONNECTION=0'
       end
     end
-
-    # Fix building failures on M1
-    installer.target_installation_results.pod_target_installation_results.each do |pod_name, target_installation_result|
-      target_installation_result.native_target.build_configurations.each do |config|
-        config.build_settings['EXCLUDED_ARCHS[sdk=iphonesimulator*]'] = 'arm64'
-      end
-    end
-
   end
 
   # Target for development, contains only unversioned code

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -81,6 +81,17 @@ abstract_target 'Expo Go' do
         config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] << 'ENABLE_PACKAGER_CONNECTION=0'
       end
     end
+
+    # Fix building failures on M1
+    installer.generated_projects.each do |project|
+      project.targets.each do |target|
+        target.build_configurations.each do |config|
+          config.build_settings["EXCLUDED_ARCHS[sdk=iphonesimulator*]"] = "arm64"
+        end
+      end
+      project.save()
+    end
+
   end
 
   # Target for development, contains only unversioned code

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -83,13 +83,10 @@ abstract_target 'Expo Go' do
     end
 
     # Fix building failures on M1
-    installer.generated_projects.each do |project|
-      project.targets.each do |target|
-        target.build_configurations.each do |config|
-          config.build_settings["EXCLUDED_ARCHS[sdk=iphonesimulator*]"] = "arm64"
-        end
+    installer.target_installation_results.pod_target_installation_results.each do |pod_name, target_installation_result|
+      target_installation_result.native_target.build_configurations.each do |config|
+        config.build_settings['EXCLUDED_ARCHS[sdk=iphonesimulator*]'] = 'arm64'
       end
-      project.save()
     end
 
   end


### PR DESCRIPTION
# Why

typically, on m1 we used to exclude arm64 for simulator builds. however, expo-go podfile uses `generate_multiple_pod_projects` making it difficult to exclude arm64 for each pod projects.

# How

uses post_install script to add `EXCLUDED_ARCHS[sdk=iphonesimulator*] = "arm64"` for each generated pod projects.

# Test Plan

1. ci passed
2. expo-go build passed for simulator on m1.