### PR TITLE
[expo-contacts] resolve presentFormAsync when form closes

### DIFF
--- a/apps/native-component-list/src/screens/Contacts/ContactDetailScreen.tsx
+++ b/apps/native-component-list/src/screens/Contacts/ContactDetailScreen.tsx
@@ -36,6 +36,14 @@ export default function ContactDetailScreen(props: any) {
               Contacts.shareContactAsync(props.route.params.id, 'Call me :]');
             }}
           />
+          <HeaderIconButton
+            name="md-open"
+            onPress={async () => {
+              await Contacts.presentFormAsync(props.route.params.id);
+              // tslint:disable-next-line no-console
+              console.log('the native contact form has been closed');
+            }}
+          />
           {isIos && (
             <HeaderIconButton
               name="md-copy"

--- a/packages/expo-contacts/CHANGELOG.md
+++ b/packages/expo-contacts/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 🛠 Breaking changes
 
 - Added `AndroidManifest.xml` queries for intent handling. ([#13388](https://github.com/expo/expo/pull/13388) by [@EvanBacon](https://github.com/EvanBacon))
+- `Contacts.presentFormAsync` now resolves when the native form closes. ([#13699](https://github.com/expo/expo/pull/13699) by [@dsokal](https://github.com/dsokal))
 
 ### 🎉 New features
 

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/ContactsModule.java
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/ContactsModule.java
@@ -51,7 +51,7 @@ import expo.modules.interfaces.permissions.Permissions;
 import static expo.modules.contacts.models.BaseModel.decodeList;
 
 public class ContactsModule extends ExportedModule {
-  public static final int RC_EDIT_CONTACT = 2138;
+  public static final int RC_EDIT_CONTACT = 2137;
 
   private final ActivityEventListener mActivityEventListener = new ContactsActivityEventListener();
   private ModuleRegistry mModuleRegistry;

--- a/packages/expo-contacts/ios/EXContacts/EXContacts.m
+++ b/packages/expo-contacts/ios/EXContacts/EXContacts.m
@@ -185,7 +185,7 @@ UM_EXPORT_METHOD_AS(presentFormAsync,
     CNContactStore *contactStore = [self _getContactStoreOrReject:reject];
     if(!contactStore) return;
   
-  [UMUtilities performSynchronouslyOnMainThread:^{
+    [UMUtilities performSynchronouslyOnMainThread:^{
     
         EXContactsViewController *controller;
         CNMutableContact *contact;
@@ -239,15 +239,17 @@ UM_EXPORT_METHOD_AS(presentFormAsync,
             isAnimated = [options[@"preventAnimation"] boolValue];
         
         UIViewController *parent = self->_utilities.currentViewController;
-        
+
+        [controller handleViewDisappeared:^{
+            resolve(nil);
+        }];
         // We need to wrap our contact view controller in UINavigationController.
         // See: https://stackoverflow.com/questions/38748969/cnui-error-contact-view-delayed-appearance-timed-out
         UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:controller];
         navigationController.modalPresentationStyle = UIModalPresentationFullScreen;
         self.presentingViewController = navigationController;
-        [parent presentViewController:navigationController animated:isAnimated completion:^{
-            resolve(nil);
-        }];
+
+        [parent presentViewController:navigationController animated:isAnimated completion:nil];
     }];
 }
 

--- a/packages/expo-contacts/ios/EXContacts/EXContactsViewController.h
+++ b/packages/expo-contacts/ios/EXContacts/EXContactsViewController.h
@@ -9,5 +9,6 @@
 
 - (void)setCloseButton:(NSString *)title;
 - (void)closeController;
+- (void)handleViewDisappeared: (void (^)(void))handler;
 
 @end

--- a/packages/expo-contacts/ios/EXContacts/EXContactsViewController.m
+++ b/packages/expo-contacts/ios/EXContacts/EXContactsViewController.m
@@ -3,7 +3,18 @@
 #import <EXContacts/EXContactsViewController.h>
 @import Contacts;
 
+@interface EXContactsViewController()
+
+@property (nonatomic, copy) void (^onViewDisappeared)(void);
+
+@end
+
 @implementation EXContactsViewController
+
+- (void)handleViewDisappeared: (void (^)(void))handler
+{
+  self.onViewDisappeared = handler;
+}
 
 - (void)setCloseButton:(NSString *)title
 {
@@ -19,6 +30,13 @@
 
 - (void)closeController {
   [self dismissViewControllerAnimated:YES completion:nil];
+}
+
+- (void)viewDidDisappear:(BOOL)animated {
+  [super viewDidDisappear:animated];
+  if (self.onViewDisappeared) {
+    self.onViewDisappeared();
+  }
 }
 
 @end


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/8840 (and https://github.com/expo/expo/issues/3696)

Currently, `Contacts.presentFromAsync` resolves immediately after the modal/activity has appeared. This seems to be undesirable as apps usually depend on the state of the edited contact. 

# How

- I changed the iOS implementation so that the promise is resolved after the modal disappears.
- Even though the original issue was about iOS, I also updated the Android implementation so it behaves the same.
- I added a new button to the Contact screen in NCL so it's possible to test the `Contacts.presentFromAsync` there.

# Test Plan

Tested with NCL.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).