### PR TITLE
Update local-authentication docs to show that infoPlist is located in ios.infoPlist and not at top level of app.json

### DIFF
--- a/docs/pages/versions/unversioned/sdk/local-authentication.md
+++ b/docs/pages/versions/unversioned/sdk/local-authentication.md
@@ -63,7 +63,7 @@ Note that on Android devices prior to M, `SECRET` can be returned if only the SI
 
 Attempts to authenticate via Fingerprint/TouchID (or FaceID if available on the device).
 
-> **Note:** Apple requires apps which use FaceID to provide a description of why they use this API. If you try to use FaceID on an iPhone with FaceID without providing `infoPlist.NSFaceIDUsageDescription` in `app.json`, the module will authenticate using device passcode. For more information about usage descriptions on iOS, see [Deploying to App Stores](../../../distribution/app-stores.md#system-permissions-dialogs-on-ios).
+> **Note:** Apple requires apps which use FaceID to provide a description of why they use this API. If you try to use FaceID on an iPhone with FaceID without providing `ios.infoPlist.NSFaceIDUsageDescription` in `app.json`, the module will authenticate using device passcode. For more information about usage descriptions on iOS, see [Deploying to App Stores](../../../distribution/app-stores.md#system-permissions-dialogs-on-ios).
 
 #### Arguments
 


### PR DESCRIPTION
# Why

The current documentation skips over the fact that infoPlist is located in ios.infoPlist, as explained more clearly in the linked documentation [here](https://docs.expo.io/distribution/app-stores/#system-permissions-dialogs-on-ios) and [here](https://docs.expo.io/distribution/app-stores/#localizing-your-ios-app)

# How

Documentation update

# Test Plan

No tests required for a documentation update

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).