### PR TITLE
[expo-auth-session] Mock hostUri in tests

### DIFF
--- a/packages/expo-auth-session/src/__tests__/AuthSession-test.native.ts
+++ b/packages/expo-auth-session/src/__tests__/AuthSession-test.native.ts
@@ -68,6 +68,7 @@ describe('Managed', () => {
         linkingUri: 'exp://exp.host/@test/test',
         manifest: {
           scheme: 'demo',
+          hostUri: 'exp.host/@test/test',
         },
         appOwnership: 'standalone',
         executionEnvironment: ExecutionEnvironment.Standalone,
@@ -116,6 +117,7 @@ describe('Managed', () => {
         linkingUri: 'exp://exp.host/@test/test',
         manifest: {
           scheme: 'demo',
+          hostUri: 'exp.host/@test/test',
         },
         appOwnership: 'expo',
         executionEnvironment: ExecutionEnvironment.StoreClient,
@@ -129,6 +131,7 @@ describe('Managed', () => {
         linkingUri: 'exp://exp.host/@test/test',
         manifest: {
           scheme: 'demo',
+          hostUri: 'exp.host/@test/test',
         },
         appOwnership: 'expo',
         executionEnvironment: ExecutionEnvironment.StoreClient,

--- a/packages/expo-auth-session/src/__tests__/SessionUrlProvider-test.ts
+++ b/packages/expo-auth-session/src/__tests__/SessionUrlProvider-test.ts
@@ -90,6 +90,7 @@ if (Platform.OS !== 'web') {
       beforeEach(() => {
         mockProperty(Constants, 'executionEnvironment', 'storeClient');
         mockProperty(Constants.manifest, 'scheme', 'my-app');
+        mockProperty(Constants.manifest, 'hostUri', 'exp.host/@test/test');
       });
       it(`checks return url`, () => {
         mockProperty(Constants.manifest, 'hostUri', 'exp.host/@example/abc');


### PR DESCRIPTION
# Why

Fix tests https://exponent-internal.slack.com/archives/C1QP38NQ5/p1626806591157000