### PR TITLE
[docs] updated pwa guides

### DIFF
--- a/docs/pages/guides/progressive-web-apps.md
+++ b/docs/pages/guides/progressive-web-apps.md
@@ -4,13 +4,13 @@ title: Progressive Web Apps
 
 import { InlineCode } from '~/components/base/code';
 
-A progressive web app (or PWA for short) is a website that can be installed on the user's device and used offline. If you build your native app with Expo, then Expo CLI can generate a lot of the PWA automatically based on how the native app works. Ex: icons, splash screens, orientation, etc. Just [enable service workers](https://expo.fyi/enabling-web-service-workers) to get a complete PWA.
+A progressive web app (or PWA for short) is a website that can be installed on the user's device and used offline. If you build your native app with Expo, then Expo CLI can generate a lot of the PWA automatically based on how the native app works. Ex: icons, splash screens, orientation, etc. Just [add service workers](https://expo.fyi/enabling-web-service-workers) to get a complete PWA.
 
-You can test your PWA in an Emulator and Simulator by running `expo start:web --ios --android` then installing the PWA via the mobile browser.
+You can test your PWA in an Emulator and Simulator by running `expo start:web --https --ios --android` then installing the PWA via the mobile browser.
 
 ## Usage
 
-Expo web projects generate PWA assets and manifests by default, you only need to [enable offline web support](https://expo.fyi/enabling-web-service-workers) to get a full PWA. You can disable asset and manifest generation by passing the `--no-pwa` to `expo build:web`, this won't effect favicon generation.
+Expo web projects generate PWA assets and manifests by default, you only need to [add offline web support](https://expo.fyi/enabling-web-service-workers) to get a full PWA. You can disable asset and manifest generation by passing the `--no-pwa` to `expo build:web`, this won't effect favicon generation.
 
 When you run `expo build:web` the Webpack config reads your `app.config.js` (or `app.json`) and generates a PWA from it.
 
@@ -66,7 +66,7 @@ Safari PWAs do not use the `manifest.json`, instead they rely on meta tags in th
 
 ### Offline
 
-By default we enable offline support using the Webpack Workbox plugin, you can learn more about how Expo service workers function here: [Expo Webpack Service Workers docs](https://github.com/expo/expo-cli/tree/master/packages/webpack-config#service-workers).
+In order to add offline support, you'll need to add service workers to your project. We recommend using [Workbox](https://developers.google.com/web/tools/workbox/modules/workbox-webpack-plugin) as it handles most of the heavy lifting.
 
 ### Related Applications
 

--- a/docs/pages/workflow/web.md
+++ b/docs/pages/workflow/web.md
@@ -18,7 +18,7 @@ Progressive Web Apps
 </a>
 </H2>
 
-Expo makes it easy to create PWAs by generating web app data from your app config. You can customize your offline support to fully enable PWA features in your website. Run your app on a variety of different devices and reach a much wider user-base with a feature-filled PWA.
+Expo makes it easy to create PWAs by generating web app data from your app config. You can add offline support to fully enable PWA features in your website. Run your app on a variety of different devices and reach a much wider user-base with a feature-filled PWA.
 
 - ⭐️ **Share Icons:** Automatically reuse the App Icon and Splash Screens from your mobile app!
 - 💬 **Native Features:** Use secure features like the Sharing API in your PWA.


### PR DESCRIPTION
# Why

I plan to remove workbox from the default config and have users setup the service worker manually going forward. This PR preps the docs by removing references to the legacy system. 

I'll also be removing the custom server functionality of the next-adapter, so those docs are gone now too. Finally, I removed the manual ToC in favor of the built-in one on the sidebar.
