### PR TITLE
docs: corrected syntax and fixed sample plugin implementation

### DIFF
--- a/docs/pages/guides/config-plugins.md
+++ b/docs/pages/guides/config-plugins.md
@@ -133,9 +133,9 @@ Consider the following example that changes the config name:
 `my-plugin.js`
 
 ```js
-module.exports = function withCustomName(config, name) {
+module.exports = function withPrefixedName(config, prefix) {
   // Modify the config
-  config.name = 'custom-' + name;
+  config.name = prefix + '-' + config.name;
   // Return the results
   return config;
 };
@@ -146,7 +146,9 @@ module.exports = function withCustomName(config, name) {
 ```json
 {
   "name": "my-app",
-  "plugins": ["./my-plugin", "app"]
+  "plugins": [
+    ["./my-plugin", "custom"]
+  ]
 }
 ```
 
@@ -157,7 +159,9 @@ module.exports = function withCustomName(config, name) {
 ```json
 {
   "name": "custom-my-app",
-  "plugins": ["./my-plugin", "app"]
+  "plugins": [
+    ["./my-plugin", "custom"]
+  ]
 }
 ```
 


### PR DESCRIPTION
# Why

I noticed that the example given for a custom plugin was incorrect. The JSON for the plugin array was invalid, and the function result was incorrect.

# How

I updated the app.json example, and changed the implementation slightly to keepthe idea behind it, but match the existing result shown.

# Test Plan

Docs, so 👀 for testing...

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] ~~This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).~~
- [ ] ~~This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).~~