### PR TITLE
[ios] Migrate expo-linear-gradient to use expo-modules-core

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -113,7 +113,7 @@ PODS:
   - EXKeepAwake (9.2.0):
     - UMCore
   - EXLinearGradient (9.2.0):
-    - UMCore
+    - ExpoModulesCore
   - EXLocalAuthentication (11.1.0):
     - UMCore
   - EXLocalization (10.2.0):
@@ -1178,7 +1178,7 @@ SPEC CHECKSUMS:
   EXImagePicker: 958720afb9395ee1168dcda28d9915345c4e7cae
   EXInAppPurchases: e54068db701c8879d975a1f304b2d00e6fc8eece
   EXKeepAwake: f4105ef469be7b283f66ce2d7234bb71ac80cd26
-  EXLinearGradient: f9ea3259f096b27008860ca50764184225dc71c9
+  EXLinearGradient: 3e1f1558e4a7f8335b432e1d171811e38217edd4
   EXLocalAuthentication: e6347880c31bc3b9693933780d3bc84823fe0698
   EXLocalization: 356f4e16a606cec21a77d6250528fde526152b45
   EXLocation: bdf1af6aa8fc4f4dc1fd21aa39760484026f8a5d

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1887,7 +1887,7 @@ PODS:
   - EXKeepAwake (9.2.0):
     - UMCore
   - EXLinearGradient (9.2.0):
-    - UMCore
+    - ExpoModulesCore
   - EXLocalAuthentication (11.1.0):
     - UMCore
   - EXLocalization (10.2.0):
@@ -4054,7 +4054,7 @@ SPEC CHECKSUMS:
   EXImageManipulator: c4a7a24d867f8b2bb15e5d0d64ff8f3c2fb35761
   EXImagePicker: 958720afb9395ee1168dcda28d9915345c4e7cae
   EXKeepAwake: f4105ef469be7b283f66ce2d7234bb71ac80cd26
-  EXLinearGradient: f9ea3259f096b27008860ca50764184225dc71c9
+  EXLinearGradient: 8eae770e0439ef89d0b8c2ab26970d63d038c0b5
   EXLocalAuthentication: e6347880c31bc3b9693933780d3bc84823fe0698
   EXLocalization: 356f4e16a606cec21a77d6250528fde526152b45
   EXLocation: bdf1af6aa8fc4f4dc1fd21aa39760484026f8a5d

--- a/packages/expo-linear-gradient/ios/EXLinearGradient.podspec
+++ b/packages/expo-linear-gradient/ios/EXLinearGradient.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.platform       = :ios, '11.0'
   s.source         = { git: 'https://github.com/expo/expo.git' }
 
-  s.dependency 'UMCore'
+  s.dependency 'ExpoModulesCore'
 
   if !$ExpoUseSources&.include?(package['name']) && ENV['EXPO_USE_SOURCE'].to_i == 0 && File.exist?("#{s.name}.xcframework") && Gem::Version.new(Pod::VERSION) >= Gem::Version.new('1.10.0')
     s.source_files = "#{s.name}/**/*.h"

--- a/packages/expo-linear-gradient/ios/EXLinearGradient/EXLinearGradient.h
+++ b/packages/expo-linear-gradient/ios/EXLinearGradient/EXLinearGradient.h
@@ -1,8 +1,6 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
 #import <UIKit/UIKit.h>
-#import <UMCore/UMModuleRegistry.h>
-#import <UMCore/UMAppLifecycleListener.h>
 
 @interface EXLinearGradient : UIView
 

--- a/packages/expo-linear-gradient/ios/EXLinearGradient/EXLinearGradient.m
+++ b/packages/expo-linear-gradient/ios/EXLinearGradient/EXLinearGradient.m
@@ -3,9 +3,9 @@
 #import <EXLinearGradient/EXLinearGradient.h>
 #import <EXLinearGradient/EXLinearGradientLayer.h>
 #import <UIKit/UIKit.h>
-#import <UMCore/UMModuleRegistry.h>
-#import <UMCore/UMAppLifecycleListener.h>
-#import <UMCore/UMUtilities.h>
+#import <ExpoModulesCore/EXModuleRegistry.h>
+#import <ExpoModulesCore/EXAppLifecycleListener.h>
+#import <ExpoModulesCore/EXUtilities.h>
 
 @interface EXLinearGradient ()
 
@@ -27,7 +27,7 @@
 {
   NSMutableArray *colors = [NSMutableArray arrayWithCapacity:colorStrings.count];
   for (NSString *colorString in colorStrings) {
-    UIColor *convertedColor = [UMUtilities UIColor:colorString];
+    UIColor *convertedColor = [EXUtilities UIColor:colorString];
     if (convertedColor) {
       [colors addObject:convertedColor];
     }

--- a/packages/expo-linear-gradient/ios/EXLinearGradient/EXLinearGradientManager.h
+++ b/packages/expo-linear-gradient/ios/EXLinearGradient/EXLinearGradientManager.h
@@ -1,8 +1,8 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
-#import <UMCore/UMViewManager.h>
-#import <UMCore/UMExportedModule.h>
+#import <ExpoModulesCore/EXViewManager.h>
+#import <ExpoModulesCore/EXExportedModule.h>
 
-@interface EXLinearGradientManager : UMViewManager
+@interface EXLinearGradientManager : EXViewManager
 
 @end

--- a/packages/expo-linear-gradient/ios/EXLinearGradient/EXLinearGradientManager.m
+++ b/packages/expo-linear-gradient/ios/EXLinearGradient/EXLinearGradientManager.m
@@ -2,7 +2,7 @@
 
 #import <EXLinearGradient/EXLinearGradientManager.h>
 #import <EXLinearGradient/EXLinearGradient.h>
-#import <UMCore/UMUIManager.h>
+#import <ExpoModulesCore/EXUIManager.h>
 
 @interface EXLinearGradientManager ()
 
@@ -10,7 +10,7 @@
 
 @implementation EXLinearGradientManager
 
-UM_EXPORT_MODULE(ExpoLinearGradientManager);
+EX_EXPORT_MODULE(ExpoLinearGradientManager);
 
 - (NSString *)viewName
 {
@@ -22,23 +22,23 @@ UM_EXPORT_MODULE(ExpoLinearGradientManager);
   return [[EXLinearGradient alloc] init];
 }
 
-UM_VIEW_PROPERTY(colors, NSArray *, EXLinearGradient) {
+EX_VIEW_PROPERTY(colors, NSArray *, EXLinearGradient) {
   [view setColors:value];
 }
 
 // NOTE: startPoint and endPoint assume that the value is an array with exactly two floats
 
-UM_VIEW_PROPERTY(startPoint, NSArray *, EXLinearGradient) {
+EX_VIEW_PROPERTY(startPoint, NSArray *, EXLinearGradient) {
   CGPoint point = CGPointMake([[value objectAtIndex:0] floatValue], [[value objectAtIndex:1] floatValue]);
   [view setStartPoint:point];
 }
 
-UM_VIEW_PROPERTY(endPoint, NSArray *, EXLinearGradient) {
+EX_VIEW_PROPERTY(endPoint, NSArray *, EXLinearGradient) {
   CGPoint point = CGPointMake([[value objectAtIndex:0] floatValue], [[value objectAtIndex:1] floatValue]);
   [view setEndPoint:point];
 }
 
-UM_VIEW_PROPERTY(locations, NSArray *, EXLinearGradient) {
+EX_VIEW_PROPERTY(locations, NSArray *, EXLinearGradient) {
   [view setLocations:value];
 }
 

--- a/packages/expo-linear-gradient/package.json
+++ b/packages/expo-linear-gradient/package.json
@@ -33,6 +33,9 @@
   "author": "650 Industries, Inc.",
   "license": "MIT",
   "homepage": "https://docs.expo.io/versions/latest/sdk/linear-gradient/",
+  "dependencies": {
+    "expo-modules-core": "~0.1.1"
+  },
   "devDependencies": {
     "expo-module-scripts": "^2.0.0"
   }


### PR DESCRIPTION
# Why

Prerequisite #13704 

# How

`expo-linear-gradient` now depends on `ExpoModulesCore` instead of `UMCore`

# Test Plan

Tested as part of #13704
