### PR TITLE
[docs] Fix Snacks after dev domain migration

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -215,7 +215,7 @@ import SnackInline from '~/components/plugins/SnackInline';
 // You can use:
 /* @hide Content that is still shown, like a preview. */
   Everything in here is hidden in the example Snack until
-  you open it in snack.expo.io
+  you open it in snack.expo.dev
 /* @end */
 // to shorten the length of the Snack shown in our docs. Common example are hiding useless code in examples, like StyleSheets
 

--- a/docs/common/snack.ts
+++ b/docs/common/snack.ts
@@ -1,4 +1,4 @@
-export const SNACK_URL = 'https://snack.expo.io';
+export const SNACK_URL = 'https://snack.expo.dev';
 // export const SNACK_URL = 'http://snack.expo.test';
 
 type Config = {

--- a/docs/components/plugins/SnackEmbed.tsx
+++ b/docs/components/plugins/SnackEmbed.tsx
@@ -22,7 +22,7 @@ export default class SnackEmbed extends React.Component<Props> {
     // inject script if it hasn't been loaded by a previous page
     if (!script) {
       script = document.createElement('script');
-      script.src = `${this.props.snackId ? 'https://snack.expo.io' : SNACK_URL}/embed.js`;
+      script.src = `${this.props.snackId ? 'https://snack.expo.dev' : SNACK_URL}/embed.js`;
       script.async = true;
       script.id = 'snack';
 

--- a/docs/pages/guides/color-schemes.md
+++ b/docs/pages/guides/color-schemes.md
@@ -137,4 +137,4 @@ While you're developing, you may want to change your simulator's or device's app
 
 - If working with an iOS emulator locally, you can use the `command` + `shift` + `a` shortcut to toggle between light and dark mode.
 - If using a real device or an Android emulator, you can toggle the system dark mode setting in the device's settings.
-- [Snack](https://snack.expo.io) is locked to light mode.
+- [Snack](https://snack.expo.dev) is locked to light mode.

--- a/docs/pages/versions/unversioned/sdk/stripe.md
+++ b/docs/pages/versions/unversioned/sdk/stripe.md
@@ -9,7 +9,7 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 Expo includes support for [`@stripe/stripe-react-native`](https://github.com/stripe/stripe-react-native), which allows you to build delightful payment experiences in your native Android and iOS apps using React Native & Expo. This library provides powerful and customizable UI screens and elements that can be used out-of-the-box to collect your users' payment details.
 
-If you're looking for a quick example, check out [this Snack](https://snack.expo.io/@charliecruzan/stripe-react-native-example?platform=mydevice)!
+If you're looking for a quick example, check out [this Snack](https://snack.expo.dev/@charliecruzan/stripe-react-native-example?platform=mydevice)!
 
 > Migrating from Expo's `expo-payments-stripe` module? [Here's a guide to help make the transition as easy as possible](https://github.com/expo/fyi/blob/master/payments-migration-guide.md#how-to-migrate-from-expo-payments-stripe-to-the-new-stripestripe-react-native-library).
 
@@ -47,7 +47,7 @@ Then rebuild the app. If you're using the bare workflow, make sure to run `expo 
 
 ## Example
 
-Trying out Stripe takes just a few seconds. First, connect to [this Snack](https://snack.expo.io/@charliecruzan/stripe-react-native-example?platform=mydevice) on your device.
+Trying out Stripe takes just a few seconds. First, connect to [this Snack](https://snack.expo.dev/@charliecruzan/stripe-react-native-example?platform=mydevice) on your device.
 
 Under the hood, that example connects to [this Glitch server code](https://glitch.com/edit/#!/expo-stripe-server-example), so you'll need to open that page to spin up the server. Feel free to run your own Glitch server and copy that code!
 

--- a/docs/pages/workflow/already-used-react-native.md
+++ b/docs/pages/workflow/already-used-react-native.md
@@ -54,7 +54,7 @@ If you prefer to build your app on your own machine, you can [follow these steps
 
 ## Helpful Tools & Resources
 
-- [snack.expo.io](https://snack.expo.io)
+- [snack.expo.dev](https://snack.expo.dev)
   - The best way to test and share examples and small projects directly from your browser. Point your phone at the QR code and you have a sandbox environment you can build in the browser and test directly on your device.
 - [docs.expo.io](/versions/latest/)
   - If there's something you don't understand or wish to learn more about, this is a great place to start.

--- a/docs/pages/workflow/glossary-of-terms.md
+++ b/docs/pages/workflow/glossary-of-terms.md
@@ -105,7 +105,7 @@ We use the word "slug" in [app.json](#appjson) to refer to the name to use for y
 
 ### Snack
 
-[Snack](https://snack.expo.io/) is an in-browser development environment where you can build Expo [experiences](#experience) without installing any tools on your phone or computer.
+[Snack](https://snack.expo.dev/) is an in-browser development environment where you can build Expo [experiences](#experience) without installing any tools on your phone or computer.
 
 ### Standalone app
 

--- a/docs/pages/workflow/snack.md
+++ b/docs/pages/workflow/snack.md
@@ -11,7 +11,7 @@ Snack solves precisely that problem. It's an open-source platform for running Re
 
 ## Let's get started
 
-Head over to [https://snack.expo.io](https://snack.expo.io) and start typing! On the right, you'll see the preview of the changes you make. By going to the "Android" or "iOS" tabs, you can preview it on a simulator directly in the browser. To open it on your device, go to the "My Device" tab and open it in the Expo Go app.
+Head over to [https://snack.expo.dev](https://snack.expo.dev) and start typing! On the right, you'll see the preview of the changes you make. By going to the "Android" or "iOS" tabs, you can preview it on a simulator directly in the browser. To open it on your device, go to the "My Device" tab and open it in the Expo Go app.
 
 ## Adding a library
 


### PR DESCRIPTION
# Why

Fixes Snack not loading the example code (but instead loading the default Snack example). This is caused by the automatic redirect from `.io` -> `.dev` which does not carry the information to the new domain

# How

- Update snack domain in  to `.dev`
- Update Snack urls to `.dev`

# Test Plan

- Verified locally and confirmed the example loads correctly after changing `.io` -> `.dev`
