### PR TITLE
[expo-localauthentication][android] Add nullable parameter onActivityResult

### DIFF
--- a/packages/expo-local-authentication/android/src/main/java/expo/modules/localauthentication/LocalAuthenticationModule.kt
+++ b/packages/expo-local-authentication/android/src/main/java/expo/modules/localauthentication/LocalAuthenticationModule.kt
@@ -223,7 +223,7 @@ class LocalAuthenticationModule(context: Context) : ExportedModule(context), Act
     }
   }
 
-  override fun onActivityResult(activity: Activity, requestCode: Int, resultCode: Int, data: Intent) {
+  override fun onActivityResult(activity: Activity, requestCode: Int, resultCode: Int, data: Intent?) {
     // If the user uses PIN as an authentication method, the result will be passed to the `onActivityResult`.
     // Unfortunately, react-native doesn't pass this value to the underlying fragment - we won't resolve the promise.
     // So we need to do it manually.


### PR DESCRIPTION
# Why

App was crashing because of nullPointerException

# How

- Passed Intent as nullable parameter.

# Test Plan

- Native component list.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).