### PR TITLE
[docs] update the 'Build Webhooks' page - we now call webhook when the build is canceled

### DIFF
--- a/docs/pages/distribution/webhooks.md
+++ b/docs/pages/distribution/webhooks.md
@@ -8,7 +8,7 @@ After running that command, you'll be given a webhook signing secret, if you hav
 
 We call your webhook using an HTTP POST request and we pass data in the request body. Expo sends your webhook as a JSON object with following fields:
 
-- `status` - a string specifying whether your build has finished successfully (can be either `finished` or `errored`)
+- `status` - a string specifying whether your build has finished successfully (can be either `finished`, `errored`, or `canceled`)
 - `id` - the unique ID of your build
 - `artifactUrl` - the URL to the build artifact (only included if `status === 'finished'`)
 - `platform` - 'ios' | 'android'


### PR DESCRIPTION
# Why

https://github.com/expo/universe/pull/7924
We now call the build webhook when the build is canceled.

# How

Updated the 'Build Webhooks' page.

# Test Plan

None

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).