### PR TITLE
Correct documentation-related links in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ Expo is an open-source platform for making universal native apps that run on And
 <p>Learn about building and deploying universal apps <a aria-label="expo documentation" href="https://docs.expo.io">in our official docs!</a></p>
 
 - [Getting Started](https://docs.expo.io/)
-- [API Reference](https://docs.expo.io/versions/latest/sdk/overview/)
-- [Using Custom Native Modules](https://docs.expo.io/versions/latest/bare/exploring-bare-workflow/)
+- [API Reference](https://docs.expo.io/versions/latest/)
+- [Using Custom Native Modules](https://docs.expo.io/bare/exploring-bare-workflow/)
 
 ## 🗺 Project Layout
 


### PR DESCRIPTION
# Why

Currently two links in the Documentation sections leads to moved pages and results in redirects.

# How

I have updated the problematic links, so they points now to the correct URL and do not procure extensive redirects

# Test Plan

The links has been tested in the `Preview` tab, when creating this PR.