### PR TITLE
[brightness] remove reverted change from changelog

### DIFF
--- a/packages/expo-brightness/CHANGELOG.md
+++ b/packages/expo-brightness/CHANGELOG.md
@@ -4,8 +4,6 @@
 
 ### 🛠 Breaking changes
 
-- Rename `useSystemBrightnessAsync` method to `resetToSystemBrightnessAsync` to avoid it being interpreted as a hook. ([#13693](https://github.com/expo/expo/pull/13693) by [@Simek](https://github.com/Simek))
-
 ### 🎉 New features
 
 ### 🐛 Bug fixes


### PR DESCRIPTION
# Why

Refs #13693

I have forgot to remove the changelog after revert, sorry!

# How

Invalid changelog entry has been removed.

# Test Plan

N/A

# Checklist

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).