### PR TITLE
[swift] Add Swift implementation of expo-linear-gradient

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -1178,7 +1178,7 @@ SPEC CHECKSUMS:
   EXImagePicker: 958720afb9395ee1168dcda28d9915345c4e7cae
   EXInAppPurchases: e54068db701c8879d975a1f304b2d00e6fc8eece
   EXKeepAwake: f4105ef469be7b283f66ce2d7234bb71ac80cd26
-  EXLinearGradient: 3e1f1558e4a7f8335b432e1d171811e38217edd4
+  EXLinearGradient: eac99517b8e66a8480fe0e212bdc7c0d5a12e163
   EXLocalAuthentication: e6347880c31bc3b9693933780d3bc84823fe0698
   EXLocalization: 356f4e16a606cec21a77d6250528fde526152b45
   EXLocation: bdf1af6aa8fc4f4dc1fd21aa39760484026f8a5d

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -4054,7 +4054,7 @@ SPEC CHECKSUMS:
   EXImageManipulator: c4a7a24d867f8b2bb15e5d0d64ff8f3c2fb35761
   EXImagePicker: 958720afb9395ee1168dcda28d9915345c4e7cae
   EXKeepAwake: f4105ef469be7b283f66ce2d7234bb71ac80cd26
-  EXLinearGradient: 8eae770e0439ef89d0b8c2ab26970d63d038c0b5
+  EXLinearGradient: 36053f529a48cc7534d6125b0ddc8dd17e091fdd
   EXLocalAuthentication: e6347880c31bc3b9693933780d3bc84823fe0698
   EXLocalization: 356f4e16a606cec21a77d6250528fde526152b45
   EXLocation: bdf1af6aa8fc4f4dc1fd21aa39760484026f8a5d

--- a/packages/expo-linear-gradient/expo-module.config.json
+++ b/packages/expo-linear-gradient/expo-module.config.json
@@ -1,0 +1,7 @@
+{
+  "name": "expo-linear-gradient",
+  "platforms": ["ios", "android"],
+  "ios": {
+    "modulesClassNames": ["LinearGradientModule"]
+  }
+}

--- a/packages/expo-linear-gradient/ios/EXLinearGradient.podspec
+++ b/packages/expo-linear-gradient/ios/EXLinearGradient.podspec
@@ -11,14 +11,21 @@ Pod::Spec.new do |s|
   s.author         = package['author']
   s.homepage       = package['homepage']
   s.platform       = :ios, '11.0'
+  s.swift_version  = '5.4'
   s.source         = { git: 'https://github.com/expo/expo.git' }
 
   s.dependency 'ExpoModulesCore'
+
+  # Swift/Objective-C compatibility
+  s.pod_target_xcconfig = {
+    'DEFINES_MODULE' => 'YES'
+  }
 
   if !$ExpoUseSources&.include?(package['name']) && ENV['EXPO_USE_SOURCE'].to_i == 0 && File.exist?("#{s.name}.xcframework") && Gem::Version.new(Pod::VERSION) >= Gem::Version.new('1.10.0')
     s.source_files = "#{s.name}/**/*.h"
     s.vendored_frameworks = "#{s.name}.xcframework"
   else
-    s.source_files = "#{s.name}/**/*.{h,m}"
+    source_extensions = $ExpoUseExperimentalSwiftModules ? 'h,m,swift' : 'h,m'
+    s.source_files = "#{s.name}/**/*.{#{source_extensions}}"
   end
 end

--- a/packages/expo-linear-gradient/ios/EXLinearGradient/LinearGradientModule.swift
+++ b/packages/expo-linear-gradient/ios/EXLinearGradient/LinearGradientModule.swift
@@ -1,0 +1,29 @@
+import ExpoModulesCore
+
+public class LinearGradientModule: Module {
+  public func definition() -> ModuleDefinition {
+    name("ExpoLinearGradient")
+
+    viewManager {
+      view {
+        EXLinearGradient()
+      }
+
+      prop("colors") { (view: EXLinearGradient, colors: [Int]) in
+        view.setColors(colors)
+      }
+
+      prop("startPoint") { (view: EXLinearGradient, startPoint: [Double]) in
+        view.setStart(CGPoint(x: startPoint[0], y: startPoint[1]))
+      }
+
+      prop("endPoint") { (view: EXLinearGradient, endPoint: [Double]) in
+        view.setEnd(CGPoint(x: endPoint[0], y: endPoint[1]))
+      }
+
+      prop("locations") { (view: EXLinearGradient, locations: [Double]) in
+        view.setLocations(locations)
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Why

We need an example implementation that maps to view managers.

# How

Configured `expo-linear-gradient` to be a Swift module and added pretty simple implementation in `LinearGradientModule.swift`.

# Test Plan

NCL example works as expected
