### PR TITLE
[ios][image-manipulator] support base64 data URIs

### DIFF
--- a/apps/test-suite/tests/ImageManipulator.js
+++ b/apps/test-suite/tests/ImageManipulator.js
@@ -25,6 +25,18 @@ export async function test(t) {
         t.expect(typeof result.height).toBe('number');
       });
 
+      t.it('returns valid image from base64 data URL', async () => {
+        // 1x1 red image
+        const result = await ImageManipulator.manipulateAsync(
+          'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==',
+          [{ resize: { width: 100, height: 100 } }]
+        );
+        t.expect(result).toBeDefined();
+        t.expect(typeof result.uri).toBe('string');
+        t.expect(typeof result.width).toBe('number');
+        t.expect(typeof result.height).toBe('number');
+      });
+
       t.it('saves with default format', async () => {
         const result = await ImageManipulator.manipulateAsync(image.localUri, [
           { resize: { width: 100, height: 100 } },

--- a/apps/test-suite/tests/ImageManipulator.js
+++ b/apps/test-suite/tests/ImageManipulator.js
@@ -33,8 +33,8 @@ export async function test(t) {
         );
         t.expect(result).toBeDefined();
         t.expect(typeof result.uri).toBe('string');
-        t.expect(typeof result.width).toBe('number');
-        t.expect(typeof result.height).toBe('number');
+        t.expect(result.width).toBe(100);
+        t.expect(result.height).toBe(100);
       });
 
       t.it('saves with default format', async () => {

--- a/docs/pages/versions/unversioned/sdk/imagemanipulator.md
+++ b/docs/pages/versions/unversioned/sdk/imagemanipulator.md
@@ -95,7 +95,7 @@ Manipulate the image provided via `uri`. Available modifications are rotating, f
 
 #### Arguments
 
-- **uri (_string_)** -- URI of the file to manipulate. Should be on the local file system.
+- **uri (_string_)** -- URI of the file to manipulate. Should be on the local file system or a base64 data URI.
 - **actions (_array_)** --
 
   An array of objects representing manipulation options. Each object should have _only one_ of the following keys that corresponds to specific transformation:

--- a/packages/expo-image-manipulator/CHANGELOG.md
+++ b/packages/expo-image-manipulator/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Support loading base64 data URIs on iOS.
+
 ### 🐛 Bug fixes
 
 - Fix resize action validator to allow providing just one of `width` or `height`. ([#13369](https://github.com/expo/expo/pull/13369) by [@cruzach](https://github.com/cruzach))

--- a/packages/expo-image-manipulator/CHANGELOG.md
+++ b/packages/expo-image-manipulator/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Support loading base64 data URIs on iOS.
+- Support loading base64 data URIs on iOS. ([#13725](https://github.com/expo/expo/pull/13725) by [@mnightingale](https://github.com/mnightingale))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-image-manipulator/ios/EXImageManipulator/EXImageManipulatorModule.m
+++ b/packages/expo-image-manipulator/ios/EXImageManipulator/EXImageManipulatorModule.m
@@ -48,7 +48,7 @@ EX_EXPORT_METHOD_AS(manipulateAsync,
   NSString *path = [url.path stringByStandardizingPath];
 
   if ([[url scheme] isEqualToString:@"data"]) {
-    NSData *data = [[NSData alloc]initWithContentsOfURL:url];
+    NSData *data = [[NSData alloc] initWithContentsOfURL:url];
     if (data != nil) {
       UIImage *image = [UIImage imageWithData:data];
       image = [self fixOrientation:image];

--- a/packages/expo-image-manipulator/ios/EXImageManipulator/EXImageManipulatorModule.m
+++ b/packages/expo-image-manipulator/ios/EXImageManipulator/EXImageManipulatorModule.m
@@ -47,6 +47,16 @@ EX_EXPORT_METHOD_AS(manipulateAsync,
   }
   NSString *path = [url.path stringByStandardizingPath];
 
+  if ([[url scheme] isEqualToString:@"data"]) {
+    NSData *data = [[NSData alloc]initWithContentsOfURL:url];
+    if (data != nil) {
+      UIImage *image = [UIImage imageWithData:data];
+      image = [self fixOrientation:image];
+      [self manipulateImage:image actions:actions saveOptions:saveOptions resolver:resolve rejecter:reject];
+      return;
+    }
+  }
+
   if (!_fileSystem) {
     return reject(@"E_MISSING_MODULE", @"No FileSystem module.", nil);
   }


### PR DESCRIPTION
# Why

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

* Contrary to the documentation `web` and `android` already support base64 data URIs so I figured I may as well add it to `iOS`.

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

* Added `iOS` support for reading data URIs
* Updated the documentation
* Added loading from data URI test
* Spotted that `apps/test-suite/TestModules.js` wasn't including the image manipulator!
  * There are a bunch of failing tests for most platforms; I'm making seperate PR's to fix them and other issues rather than complicating this PR.

# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->

* Added Image Manipulator to `apps/test-suite/TestModules.js`
* Added a base64 data URI test
* Checked in bare-expo app

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).