### PR TITLE
[test-suite][image-manipulator] Add web support to tests

### DIFF
--- a/apps/test-suite/TestModules.js
+++ b/apps/test-suite/TestModules.js
@@ -71,6 +71,7 @@ export function getTestModules() {
     require('./tests/FirebaseAnalytics'),
     require('./tests/FirebaseRecaptcha'),
     require('./tests/FirebaseJSSDK'),
+    require('./tests/ImageManipulator'),
     optionalRequire(() => require('./tests/SQLite'))
   );
 

--- a/apps/test-suite/tests/ImageManipulator.js
+++ b/apps/test-suite/tests/ImageManipulator.js
@@ -1,6 +1,7 @@
-import * as ImageManipulator from 'expo-image-manipulator';
-import * as FileSystem from 'expo-file-system';
 import { Asset } from 'expo-asset';
+import * as FileSystem from 'expo-file-system';
+import * as ImageManipulator from 'expo-image-manipulator';
+import { Platform } from 'react-native';
 
 export const name = 'ImageManipulator';
 
@@ -28,7 +29,12 @@ export async function test(t) {
         const result = await ImageManipulator.manipulateAsync(image.localUri, [
           { resize: { width: 100, height: 100 } },
         ]);
-        t.expect(result.uri.endsWith('.jpg')).toBe(true);
+
+        if (Platform.OS === 'web') {
+          t.expect(result.uri.startsWith('data:image/jpeg;base64,')).toBe(true);
+        } else {
+          t.expect(result.uri.endsWith('.jpg')).toBe(true);
+        }
       });
 
       t.it('saves as JPEG', async () => {
@@ -40,7 +46,11 @@ export async function test(t) {
           }
         );
 
-        t.expect(result.uri.endsWith('.jpg')).toBe(true);
+        if (Platform.OS === 'web') {
+          t.expect(result.uri.startsWith('data:image/jpeg;base64,')).toBe(true);
+        } else {
+          t.expect(result.uri.endsWith('.jpg')).toBe(true);
+        }
       });
 
       t.it('saves as PNG', async () => {
@@ -52,7 +62,11 @@ export async function test(t) {
           }
         );
 
-        t.expect(result.uri.endsWith('.png')).toBe(true);
+        if (Platform.OS === 'web') {
+          t.expect(result.uri.startsWith('data:image/png;base64,')).toBe(true);
+        } else {
+          t.expect(result.uri.endsWith('.png')).toBe(true);
+        }
       });
 
       t.it('provides Base64 with no newline terminator', async () => {
@@ -78,10 +92,17 @@ export async function test(t) {
           }
         );
 
-        const imageInfo = await FileSystem.getInfoAsync(image.localUri);
-        const resultInfo = await FileSystem.getInfoAsync(result.uri);
+        if (Platform.OS === 'web') {
+          const imageInfo = await fetch(image.localUri).then(a => a.blob());
+          const resultInfo = await fetch(result.uri).then(a => a.blob());
 
-        t.expect(imageInfo.size).toBeGreaterThan(resultInfo.size);
+          t.expect(imageInfo.size).toBeGreaterThan(resultInfo.size);
+        } else {
+          const imageInfo = await FileSystem.getInfoAsync(image.localUri);
+          const resultInfo = await FileSystem.getInfoAsync(result.uri);
+
+          t.expect(imageInfo.size).toBeGreaterThan(resultInfo.size);
+        }
       });
 
       t.it('rotates images', async () => {
@@ -113,7 +134,7 @@ export async function test(t) {
         t.expect(result.width).toBe(100);
       });
 
-      t.it('cropes image', async () => {
+      t.it('crops image', async () => {
         const result = await ImageManipulator.manipulateAsync(image.localUri, [
           { crop: { originX: 20, originY: 20, width: 100, height: 100 } },
         ]);


### PR DESCRIPTION
# Why

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

Because otherwise the tests fail?

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

Platform checks to check the data URIs web returns.

# Test Plan

* bare-expo
* A test still fails (another PR coming soon)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).