### PR TITLE
Revert "[expo-update][iOS][android] save asset with a key that does n…

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 🛠 Breaking changes
 
+- Revert [#12734](https://github.com/expo/expo/pull/12734). expo-asset@8.3.3 or above requires expo-updates to specify assets with file extensions. ([#13733](https://github.com/expo/expo/pull/13733) by [@jkhales](https://github.com/jkhales))
 - Added reset method to UpdatesDevLauncherController. ([#13346](https://github.com/expo/expo/pull/13346) by [@esamelson](https://github.com/esamelson))
 
 ### 🎉 New features

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/BareManifest.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/BareManifest.kt
@@ -46,7 +46,7 @@ class BareManifest private constructor(
           val assetObject = mAssets.getJSONObject(i)
           val type = assetObject.getString("type")
           val assetEntity = AssetEntity(
-            assetObject.getString("packagerHash"),
+            assetObject.getString("packagerHash") + "." + type,
             type
           ).apply {
             resourcesFilename = assetObject.optString("resourcesFilename")

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/LegacyManifest.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/LegacyManifest.kt
@@ -62,7 +62,7 @@ class LegacyManifest private constructor(
           ) else bundledAsset.substring(prefixLength)
           val type = if (extensionIndex > 0) bundledAsset.substring(extensionIndex + 1) else ""
           assetList.add(
-            AssetEntity(hash, type).apply {
+            AssetEntity("$hash.$type", type).apply {
               url = Uri.withAppendedPath(assetsUrlBase, hash)
               embeddedAssetFilename = bundledAsset
             }

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesBareUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesBareUpdate.m
@@ -50,7 +50,7 @@ NS_ASSUME_NONNULL_BEGIN
         NSAssert([mainBundleDir isKindOfClass:[NSString class]], @"asset nsBundleDir should be a string");
       }
 
-      NSString *key = packagerHash;
+      NSString *key = [NSString stringWithFormat:@"%@.%@", packagerHash, type];
       EXUpdatesAsset *asset = [[EXUpdatesAsset alloc] initWithKey:key type:(NSString *)type];
       asset.mainBundleDir = mainBundleDir;
       asset.mainBundleFilename = mainBundleFilename;

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesLegacyUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesLegacyUpdate.m
@@ -89,7 +89,7 @@ static NSString * const EXUpdatesExpoTestDomain = @"expo.test";
 
     NSURL *url = [bundledAssetBaseUrl URLByAppendingPathComponent:hash];
 
-    NSString *key = hash;
+    NSString *key = [NSString stringWithFormat:@"%@.%@", hash, type];
     EXUpdatesAsset *asset = [[EXUpdatesAsset alloc] initWithKey:key type:(NSString *)type];
     asset.url = url;
     asset.mainBundleFilename = filename;


### PR DESCRIPTION
…ot include an extension. (#12734)"

This reverts commit 63a0bdc0e2163dafdeb82ec3db7fbff6a49a3c50.

# Why

With the reversion detailed here: https://github.com/expo/expo/issues/13558#issuecomment-883581702

We need to also revert this commit which relied on assets to be stored in the format introduced there.

# Test Plan

Confirmed publishes of images worked and loaded from local source:

<img width="431" alt="Screen Shot 2021-07-21 at 6 27 56 PM" src="https://user-images.githubusercontent.com/1220444/126578932-67ce5bc8-3039-440c-971d-7e021ae4fcda.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).