### PR TITLE
[swift] Add basic unit tests for the new API

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -1189,7 +1189,7 @@ SPEC CHECKSUMS:
   expo-dev-menu: c1d43574828f37cb541a0bb52fe7bb7829586147
   expo-dev-menu-interface: 848563c91c9f36f963a8456e885129a46f4cdfa1
   expo-image: ea170930bd8bc42328ee74ff4dc861ca31587dc8
-  ExpoModulesCore: a70ccb0e2d7483de92f7a5b368f524b63809788c
+  ExpoModulesCore: 82ee658feb15e6804de9f3530c39c62ff900048b
   EXPrint: 2dbe4d320687e559b46fdb01e330fdf875137094
   EXRandom: ecb71f5d01991f29bb0277f8a2c35d168f85d637
   EXScreenCapture: c51844407fbac8bbca4415467bc43f2b7764d225

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -29,6 +29,7 @@ abstract_target 'Expo Go' do
     ],
     # Modules for which to include Tests subspec
     tests: [
+      'expo-modules-core',
       'expo-updates',
       'expo-structured-headers',
     ],

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1910,6 +1910,8 @@ PODS:
     - UMCore
   - ExpoModulesCore (0.1.1):
     - React-Core
+  - ExpoModulesCore/Tests (0.1.1):
+    - React-Core
   - EXPrint (10.2.0):
     - ExpoModulesCore
     - UMCore
@@ -2784,6 +2786,7 @@ DEPENDENCIES:
   - EXNotifications (from `../packages/expo-notifications/ios`)
   - EXPermissions (from `../packages/expo-permissions/ios`)
   - ExpoModulesCore (from `../packages/expo-modules-core/ios`)
+  - ExpoModulesCore/Tests (from `../packages/expo-modules-core/ios`)
   - EXPrint (from `../packages/expo-print/ios`)
   - EXRandom (from `../packages/expo-random/ios`)
   - EXScreenCapture (from `../packages/expo-screen-capture/ios`)
@@ -4060,7 +4063,7 @@ SPEC CHECKSUMS:
   EXNetwork: 6682b2bbbd90e66c4738159abaf8cd206c25e8b8
   EXNotifications: 296d9487163c2c08fffec5e79a5f9094bc016d9c
   EXPermissions: 8eb648bd5c2115d01a39dc7c2ad4c94a5846e4cb
-  ExpoModulesCore: a70ccb0e2d7483de92f7a5b368f524b63809788c
+  ExpoModulesCore: 82ee658feb15e6804de9f3530c39c62ff900048b
   EXPrint: 2dbe4d320687e559b46fdb01e330fdf875137094
   EXRandom: ecb71f5d01991f29bb0277f8a2c35d168f85d637
   EXScreenCapture: c51844407fbac8bbca4415467bc43f2b7764d225
@@ -4148,6 +4151,6 @@ SPEC CHECKSUMS:
   Yoga: 7740b94929bbacbddda59bf115b5317e9a161598
   ZXingObjC: fdbb269f25dd2032da343e06f10224d62f537bdb
 
-PODFILE CHECKSUM: aedc9740dc0df246ce92a2b37bfa1b77c655d633
+PODFILE CHECKSUM: 69ce016b5097862f7c506e7daafaf3ed664304bb
 
 COCOAPODS: 1.10.1

--- a/packages/expo-modules-core/ios/ExpoModulesCore.podspec
+++ b/packages/expo-modules-core/ios/ExpoModulesCore.podspec
@@ -28,4 +28,10 @@ Pod::Spec.new do |s|
   else
     s.source_files = '**/*.{h,m,swift}'
   end
+
+  s.exclude_files = 'Tests/'
+
+  s.test_spec 'Tests' do |test_spec|
+    test_spec.source_files = 'Tests/**/*.swift'
+  end
 end

--- a/packages/expo-modules-core/ios/Swift/AppContext.swift
+++ b/packages/expo-modules-core/ios/Swift/AppContext.swift
@@ -11,16 +11,22 @@ public class AppContext {
   /**
    The legacy module registry with modules written in the old-fashioned way.
    */
-  public let legacyModuleRegistry: EXModuleRegistry?
+  public private(set) var legacyModuleRegistry: EXModuleRegistry?
+
+  /**
+   Designated initializer without modules provider.
+   */
+  public init() {
+    listenToClientAppNotifications()
+  }
 
   /**
    Initializes the app context and registers provided modules in the module registry.
    */
-  public init(withModulesProvider provider: ModulesProviderProtocol, legacyModuleRegistry: EXModuleRegistry?) {
+  public convenience init(withModulesProvider provider: ModulesProviderProtocol, legacyModuleRegistry: EXModuleRegistry?) {
+    self.init()
     self.legacyModuleRegistry = legacyModuleRegistry
     moduleRegistry.register(fromProvider: provider)
-
-    listenToClientAppNotifications()
   }
 
   /**

--- a/packages/expo-modules-core/ios/Swift/ModuleRegistry.swift
+++ b/packages/expo-modules-core/ios/Swift/ModuleRegistry.swift
@@ -31,6 +31,15 @@ public class ModuleRegistry: Sequence {
     }
   }
 
+  /**
+   Unregisters given module from the registry.
+   */
+  public func unregister(module: AnyModule) {
+    if let index = registry.firstIndex(where: { $1.module === module }) {
+      registry.remove(at: index)
+    }
+  }
+
   public func has(moduleWithName moduleName: String) -> Bool {
     return registry[moduleName] != nil
   }

--- a/packages/expo-modules-core/ios/Tests/Mocks/ModuleMocks.swift
+++ b/packages/expo-modules-core/ios/Tests/Mocks/ModuleMocks.swift
@@ -1,0 +1,26 @@
+import ExpoModulesCore
+
+class UnnamedModule: Module {
+  func definition() -> ModuleDefinition {}
+}
+
+class NamedModule: Module {
+  static let namedModuleName = "MyModule"
+
+  func definition() -> ModuleDefinition {
+    name(Self.namedModuleName)
+  }
+}
+
+class CustomModule: Module {
+  var customDefinition: ((CustomModule) -> ModuleDefinition)!
+
+  convenience init(appContext: AppContext, @ModuleDefinitionBuilder _ customDefinition: @escaping (CustomModule) -> ModuleDefinition) {
+    self.init(appContext: appContext)
+    self.customDefinition = customDefinition
+  }
+
+  func definition() -> ModuleDefinition {
+    return customDefinition(self)
+  }
+}

--- a/packages/expo-modules-core/ios/Tests/Mocks/ModulesProviderMock.swift
+++ b/packages/expo-modules-core/ios/Tests/Mocks/ModulesProviderMock.swift
@@ -1,0 +1,9 @@
+import ExpoModulesCore
+
+public class ModulesProviderMock: ModulesProvider {
+  public override func exportedModules() -> [AnyModule.Type] {
+    return [
+
+    ]
+  }
+}

--- a/packages/expo-modules-core/ios/Tests/ModuleEventListenersTests.swift
+++ b/packages/expo-modules-core/ios/Tests/ModuleEventListenersTests.swift
@@ -1,0 +1,105 @@
+import XCTest
+
+@testable import ExpoModulesCore
+
+/**
+ This test case covers module's event listeners which can listen to:
+ - module's lifecycle events
+ - app's lifecycle notifications
+ - custom events sent to the module registry
+
+ NOTE: Each test registers the module because only registered modules can capture events.
+ */
+class ModuleEventListenersTests: XCTestCase {
+  var appContext: AppContext!
+
+  override func setUp() {
+    appContext = AppContext()
+  }
+
+  func testOnCreate() {
+    let expect = expectation(description: "onCreate is called once the module registers in the registry")
+    let module = CustomModule(appContext: appContext) {
+      $0.onCreate {
+        expect.fulfill()
+      }
+    }
+    appContext.moduleRegistry.register(module: module)
+    waitForExpectations(timeout: 0)
+  }
+
+  func testOnDestroy() {
+    let expect = expectation(description: "onDestroy is called when the module is about to be deallocated")
+    let module = CustomModule(appContext: appContext) {
+      $0.onDestroy {
+        expect.fulfill()
+      }
+    }
+    appContext.moduleRegistry.register(module: module)
+    // Unregister the module to deallocate its holder
+    appContext.moduleRegistry.unregister(module: module)
+    // The `module` object is actually still alive, but its holder is dead
+    waitForExpectations(timeout: 0)
+  }
+
+  func testOnAppContextDestroys() {
+    let expect = expectation(description: "onAppContextDestroys is called once the context destroys")
+    let module = CustomModule(appContext: appContext) {
+      $0.onAppContextDestroys {
+        expect.fulfill()
+      }
+    }
+    appContext.moduleRegistry.register(module: module)
+    self.appContext = nil // This must deallocate the app context
+    waitForExpectations(timeout: 0)
+  }
+
+  func testOnCustomEvent() {
+    let expect = expectation(description: "custom event listener is called when the event is sent to the registry")
+    let event = EventName.custom("custom event name")
+    let module = CustomModule(appContext: appContext) { _ in
+      EventListener(event) {
+        expect.fulfill()
+      }
+    }
+    appContext.moduleRegistry.register(module: module)
+    appContext.moduleRegistry.post(event: event)
+    waitForExpectations(timeout: 0)
+  }
+
+  func testOnAppEntersForeground() {
+    let expect = expectation(description: "onAppEntersForeground is called when system's willEnterForegroundNotification is sent")
+    let module = CustomModule(appContext: appContext) {
+      $0.onAppEntersForeground {
+        expect.fulfill()
+      }
+    }
+    appContext.moduleRegistry.register(module: module)
+    NotificationCenter.default.post(name: UIApplication.willEnterForegroundNotification, object: nil)
+    waitForExpectations(timeout: 0)
+  }
+
+  func testOnAppBecomesActive() {
+    let expect = expectation(description: "onAppBecomesActive is called when system's didBecomeActiveNotification is sent")
+    let module = CustomModule(appContext: appContext) {
+      $0.onAppBecomesActive {
+        expect.fulfill()
+      }
+    }
+    appContext.moduleRegistry.register(module: module)
+    NotificationCenter.default.post(name: UIApplication.didBecomeActiveNotification, object: nil)
+    waitForExpectations(timeout: 0)
+  }
+
+  func testOnAppEntersBackground() {
+    let expect = expectation(description: "onAppEntersBackground is called when system's didEnterBackgroundNotification is sent")
+    let module = CustomModule(appContext: appContext) {
+      $0.onAppEntersBackground {
+        expect.fulfill()
+      }
+    }
+    appContext.moduleRegistry.register(module: module)
+    NotificationCenter.default.post(name: UIApplication.didEnterBackgroundNotification, object: nil)
+    waitForExpectations(timeout: 0)
+  }
+}

--- a/packages/expo-modules-core/ios/Tests/ModuleRegistryTests.swift
+++ b/packages/expo-modules-core/ios/Tests/ModuleRegistryTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+
+@testable import ExpoModulesCore
+
+class ModuleRegistryTests: XCTestCase {
+  var appContext: AppContext!
+
+  override func setUp() {
+    appContext = AppContext()
+  }
+
+  func testRegisterWithUnnamedModule() {
+    testRegister(module: UnnamedModule(appContext: appContext), name: String(describing: UnnamedModule.self))
+  }
+
+  func testRegisterWithNamedModule() {
+    testRegister(module: NamedModule(appContext: appContext), name: NamedModule.namedModuleName)
+  }
+
+  private func testRegister(module: Module, name: String) {
+    let moduleRegistry = appContext.moduleRegistry
+
+    moduleRegistry.register(module: module)
+
+    XCTAssertTrue(
+      moduleRegistry.has(moduleWithName: name),
+      "Module with name \(name) exists in the registry"
+    )
+    XCTAssert(
+      moduleRegistry.get(moduleWithName: name) === module,
+      "Module registry returns correct module when asking by name \(name)"
+    )
+    XCTAssertTrue(
+      moduleRegistry.contains { holder in holder.module === module },
+      "Module registry contains the holder with newly created module"
+    )
+    XCTAssert(
+      moduleRegistry.get(moduleHolderForName: name)?.module === module,
+      "Module registry returns the holder with newly created module"
+    )
+  }
+}


### PR DESCRIPTION
# Why

It would be good to have some unit tests for the Sweet API, so we don't introduce any regressions in the future.

# How

I've just set things up, added a few basic tests and made some small changes required for these tests.

# Test Plan

All these tests are passing, as expected.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).