### PR TITLE
[docs] fix Edit Page link issue, add tests

### DIFF
--- a/docs/components/DocumentationFooter.test.tsx
+++ b/docs/components/DocumentationFooter.test.tsx
@@ -61,7 +61,7 @@ describe('githubUrl', () => {
     expect(githubUrl('/versions/latest')).toBe(EDIT_URL_PREFIX + '/versions/unversioned/index.md');
   });
 
-  test('nested versioned page', () => {
+  test('nested latest page', () => {
     expect(githubUrl('/versions/latest/sdk/av')).toBe(
       EDIT_URL_PREFIX + '/versions/unversioned/sdk/av.md'
     );

--- a/docs/components/DocumentationFooter.test.tsx
+++ b/docs/components/DocumentationFooter.test.tsx
@@ -1,35 +1,81 @@
 import { render } from '@testing-library/react';
 import * as React from 'react';
 
-import DocumentationFooter from './DocumentationFooter';
+import DocumentationFooter, { githubUrl } from './DocumentationFooter';
 
-test('displays default links', () => {
-  const { container } = render(
-    <DocumentationFooter asPath="/" url={{ pathname: '/example/' }} title="test-title" />
-  );
+describe('DocumentationFooter', () => {
+  test('displays default links', () => {
+    const { container } = render(
+      <DocumentationFooter asPath="/" url={{ pathname: '/example/' }} title="test-title" />
+    );
 
-  expect(container).toHaveTextContent('Ask a question on the forums');
-  expect(container).toHaveTextContent('Edit this page');
+    expect(container).toHaveTextContent('Ask a question on the forums');
+    expect(container).toHaveTextContent('Edit this page');
+  });
+
+  test('displays forums link with tag', () => {
+    const { container } = render(<DocumentationFooter asPath="/sdk/" title="test-title" />);
+
+    expect(container).toHaveTextContent(
+      'Get help from the community and ask questions about test-title'
+    );
+  });
+
+  test('displays issues link', () => {
+    const { container } = render(<DocumentationFooter asPath="/sdk/" title="test-title" />);
+
+    expect(container).toHaveTextContent('View open bug reports for test-title');
+  });
+
+  test('displays source code link', () => {
+    const { container } = render(
+      <DocumentationFooter asPath="/sdk/" title="test-title" sourceCodeUrl="/" />
+    );
+
+    expect(container).toHaveTextContent('View source code for test-title');
+  });
 });
 
-test('displays forums link with tag', () => {
-  const { container } = render(<DocumentationFooter asPath="/sdk/" title="test-title" />);
+describe('githubUrl', () => {
+  const EDIT_URL_PREFIX = 'https://github.com/expo/expo/edit/master/docs/pages';
 
-  expect(container).toHaveTextContent(
-    'Get help from the community and ask questions about test-title'
-  );
-});
+  test('non-versioned page', () => {
+    expect(githubUrl('/guides')).toBe(EDIT_URL_PREFIX + '/guides.md');
+  });
 
-test('displays issues link', () => {
-  const { container } = render(<DocumentationFooter asPath="/sdk/" title="test-title" />);
+  test('nested non-versioned page', () => {
+    expect(githubUrl('/build/introduction')).toBe(EDIT_URL_PREFIX + '/build/introduction.md');
+  });
 
-  expect(container).toHaveTextContent('View open bug reports for test-title');
-});
+  test('versioned index page', () => {
+    expect(githubUrl('/versions/v42.0.0')).toBe(EDIT_URL_PREFIX + '/versions/v42.0.0/index.md');
+  });
 
-test('displays source code link', () => {
-  const { container } = render(
-    <DocumentationFooter asPath="/sdk/" title="test-title" sourceCodeUrl="/" />
-  );
+  test('nested versioned page', () => {
+    expect(githubUrl('/versions/v42.0.0/sdk/av')).toBe(
+      EDIT_URL_PREFIX + '/versions/v42.0.0/sdk/av.md'
+    );
+  });
 
-  expect(container).toHaveTextContent('View source code for test-title');
+  test('latest index page', () => {
+    expect(githubUrl('/versions/latest')).toBe(EDIT_URL_PREFIX + '/versions/unversioned/index.md');
+  });
+
+  test('nested versioned page', () => {
+    expect(githubUrl('/versions/latest/sdk/av')).toBe(
+      EDIT_URL_PREFIX + '/versions/unversioned/sdk/av.md'
+    );
+  });
+
+  test('unversioned index page', () => {
+    expect(githubUrl('/versions/unversioned')).toBe(
+      EDIT_URL_PREFIX + '/versions/unversioned/index.md'
+    );
+  });
+
+  test('nested unversioned page', () => {
+    expect(githubUrl('/versions/unversioned/sdk/av')).toBe(
+      EDIT_URL_PREFIX + '/versions/unversioned/sdk/av.md'
+    );
+  });
 });

--- a/docs/components/DocumentationFooter.tsx
+++ b/docs/components/DocumentationFooter.tsx
@@ -31,13 +31,13 @@ const STYLES_FOOTER_ICON = css`
 `;
 
 // Remove trailing slash and append .md
-function githubUrl(path: string) {
+export function githubUrl(path: string) {
+  if (path === '/versions/latest' || path === '/versions/unversioned') {
+    path = '/versions/unversioned/index';
+  }
+
   if (path.includes('/versions/latest/')) {
-    if (path === '/versions/latest') {
-      path = '/versions/unversioned/index';
-    } else {
-      path = path.replace('/versions/latest/', '/versions/unversioned/');
-    }
+    path = path.replace('/versions/latest/', '/versions/unversioned/');
   } else if (path.match(/v\d+\.\d+\.\d+\/?$/) || path === '/') {
     if (path[path.length - 1] === '/') {
       path = `${path}index`;


### PR DESCRIPTION
# Why

Currently "Edit Page" link on the few pages leads to GitHub 404:
* https://docs.expo.io/versions/latest/
* https://localhost:XXXX/versions/unversioned/

# How

I have made a small logic refactor of `githubUrl` method and I have added a few tests to the `DocumentationFooter.test.tsx` file to ensure that fix is working correctly and there are no regression.

# Tests

I have tested the problematic pages manually by running the docs on `localhost`. Also running `yarn test` in the documentation folder yields a success.

<img width="598" alt="Screenshot 2021-07-22 at 12 58 31" src="https://user-images.githubusercontent.com/719641/126629004-730cb063-3bf1-4126-a517-e0751d2f7c50.png">
