### PR TITLE
[docs] add SDK 42 to the versions matrix

### DIFF
--- a/docs/pages/versions/unversioned/index.md
+++ b/docs/pages/versions/unversioned/index.md
@@ -34,6 +34,7 @@ Every quarter there is a new Expo SDK release that typically updates to the late
 
 | Expo SDK Version | React Native Version |
 | ---------------- | :------------------: |
+| 42.0.0           |        0.63.3        |
 | 41.0.0           |        0.63.3        |
 | 40.0.0           |        0.63.3        |
 | 39.0.0           |        0.63.2        |

--- a/docs/pages/versions/v42.0.0/index.md
+++ b/docs/pages/versions/v42.0.0/index.md
@@ -34,6 +34,7 @@ Every quarter there is a new Expo SDK release that typically updates to the late
 
 | Expo SDK Version | React Native Version |
 | ---------------- | :------------------: |
+| 42.0.0           |        0.63.3        |
 | 41.0.0           |        0.63.3        |
 | 40.0.0           |        0.63.3        |
 | 39.0.0           |        0.63.2        |


### PR DESCRIPTION
# Why

SDK 42 is missing in the versions matrix.

# How

Add missing entry for the latest SDK.

# Test Plan

Docs website run on `localhost`.

# Preview

<img width="1131" alt="Screenshot 2021-07-22 at 13 23 31" src="https://user-images.githubusercontent.com/719641/126631741-fa3538ab-2278-4822-9b2f-9494c6d351fc.png">
