### PR TITLE
[ios] Migrate expo-av to use expo-modules-core

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -21,7 +21,6 @@ PODS:
     - UMCore
   - EXAV (9.2.0):
     - ExpoModulesCore
-    - UMCore
   - EXBackgroundFetch (9.2.0):
     - UMCore
     - UMTaskManagerInterface
@@ -1147,7 +1146,7 @@ SPEC CHECKSUMS:
   EXAmplitude: b3ef1ed2ae853bccd08a685d2f0352c603b215fe
   EXAppAuth: b7ecb4ce7634676985f67d2489054ea7727cd5e3
   EXApplication: 9ff2a206009d6e55bca6c20b3f33d07986b51ef3
-  EXAV: 1e88c98d82a22cb21865e83ba8a9a11f75b6b12b
+  EXAV: 7f27c872fb45479d66e762a88484f58d52174131
   EXBackgroundFetch: 5a15dc52d77d5ea4b0896c283679e271447921d4
   EXBarCodeScanner: 22f8d8ea393de371e80f9529664c07900e1e7639
   EXBattery: 6adbf9706bbe00d266b17b7846d556db9dea82c2

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1793,7 +1793,6 @@ PODS:
     - UMCore
   - EXAV (9.2.0):
     - ExpoModulesCore
-    - UMCore
   - EXBackgroundFetch (9.2.0):
     - UMCore
     - UMTaskManagerInterface
@@ -4023,7 +4022,7 @@ SPEC CHECKSUMS:
   EXAppAuth: b7ecb4ce7634676985f67d2489054ea7727cd5e3
   EXAppleAuthentication: 5994731faf4a3dd32be4a4b3e9feb930c2fa25c1
   EXApplication: 9ff2a206009d6e55bca6c20b3f33d07986b51ef3
-  EXAV: 1e88c98d82a22cb21865e83ba8a9a11f75b6b12b
+  EXAV: 7f27c872fb45479d66e762a88484f58d52174131
   EXBackgroundFetch: 5a15dc52d77d5ea4b0896c283679e271447921d4
   EXBarCodeScanner: 22f8d8ea393de371e80f9529664c07900e1e7639
   EXBattery: 6adbf9706bbe00d266b17b7846d556db9dea82c2

--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### 💡 Others
 
+- Migrated from `@unimodules/core` to `expo-modules-core`.
+
 ## 9.2.3 — 2021-06-30
 
 ### 🎉 New features

--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ### 💡 Others
 
-- Migrated from `@unimodules/core` to `expo-modules-core`.
+- Migrated from `@unimodules/core` to `expo-modules-core`. ([#13745](https://github.com/expo/expo/pull/13745) by [@tsapeta](https://github.com/tsapeta))
 
 ## 9.2.3 — 2021-06-30
 

--- a/packages/expo-av/ios/EXAV.podspec
+++ b/packages/expo-av/ios/EXAV.podspec
@@ -13,7 +13,6 @@ Pod::Spec.new do |s|
   s.platform       = :ios, '11.0'
   s.source         = { git: 'https://github.com/expo/expo.git' }
 
-  s.dependency 'UMCore'
   s.dependency 'ExpoModulesCore'
 
   if !$ExpoUseSources&.include?(package['name']) && ENV['EXPO_USE_SOURCE'].to_i == 0 && File.exist?("#{s.name}.xcframework") && Gem::Version.new(Pod::VERSION) >= Gem::Version.new('1.10.0')

--- a/packages/expo-av/ios/EXAV/EXAV.h
+++ b/packages/expo-av/ios/EXAV/EXAV.h
@@ -2,10 +2,10 @@
 
 #import <AVFoundation/AVFoundation.h>
 
-#import <UMCore/UMModuleRegistryConsumer.h>
-#import <UMCore/UMAppLifecycleListener.h>
-#import <UMCore/UMExportedModule.h>
-#import <UMCore/UMEventEmitter.h>
+#import <ExpoModulesCore/EXModuleRegistryConsumer.h>
+#import <ExpoModulesCore/EXAppLifecycleListener.h>
+#import <ExpoModulesCore/EXExportedModule.h>
+#import <ExpoModulesCore/EXEventEmitter.h>
 #import <EXAV/EXAVObject.h>
 
 typedef NS_OPTIONS(NSUInteger, EXAudioInterruptionMode)
@@ -53,7 +53,7 @@ typedef NS_OPTIONS(NSUInteger, EXAudioRecordingOptionBitRateStrategy)
 
 @end
 
-@interface EXAV : UMExportedModule <UMEventEmitter, UMAppLifecycleListener, UMModuleRegistryConsumer, EXAVInterface>
+@interface EXAV : EXExportedModule <EXEventEmitter, EXAppLifecycleListener, EXModuleRegistryConsumer, EXAVInterface>
 
 - (void)handleMediaServicesReset:(NSNotification *)notification;
 - (void)handleAudioSessionInterruption:(NSNotification *)notification;

--- a/packages/expo-av/ios/EXAV/EXAV.m
+++ b/packages/expo-av/ios/EXAV/EXAV.m
@@ -2,9 +2,9 @@
 
 #import <AVFoundation/AVFoundation.h>
 
-#import <UMCore/UMUIManager.h>
-#import <UMCore/UMEventEmitterService.h>
-#import <UMCore/UMAppLifecycleService.h>
+#import <ExpoModulesCore/EXUIManager.h>
+#import <ExpoModulesCore/EXEventEmitterService.h>
+#import <ExpoModulesCore/EXAppLifecycleService.h>
 #import <ExpoModulesCore/EXFileSystemInterface.h>
 #import <ExpoModulesCore/EXPermissionsInterface.h>
 #import <ExpoModulesCore/EXPermissionsMethodsDelegate.h>
@@ -57,14 +57,14 @@ NSString *const EXDidUpdatePlaybackStatusEventName = @"didUpdatePlaybackStatus";
 @property (nonatomic, assign) BOOL audioRecorderShouldBeginRecording;
 @property (nonatomic, assign) int audioRecorderDurationMillis;
 
-@property (nonatomic, weak) UMModuleRegistry *moduleRegistry;
+@property (nonatomic, weak) EXModuleRegistry *moduleRegistry;
 @property (nonatomic, weak) id<EXPermissionsInterface> permissionsManager;
 
 @end
 
 @implementation EXAV
 
-UM_EXPORT_MODULE(ExponentAV);
+EX_EXPORT_MODULE(ExponentAV);
 
 - (instancetype)init
 {
@@ -111,15 +111,15 @@ UM_EXPORT_MODULE(ExponentAV);
 
 #pragma mark - Expo experience lifecycle
 
-- (void)setModuleRegistry:(UMModuleRegistry *)moduleRegistry
+- (void)setModuleRegistry:(EXModuleRegistry *)moduleRegistry
 {
-  [[_moduleRegistry getModuleImplementingProtocol:@protocol(UMAppLifecycleService)] unregisterAppLifecycleListener:self];
+  [[_moduleRegistry getModuleImplementingProtocol:@protocol(EXAppLifecycleService)] unregisterAppLifecycleListener:self];
   _moduleRegistry = moduleRegistry;
   _kernelAudioSessionManagerDelegate = [_moduleRegistry getSingletonModuleForName:@"AudioSessionManager"];
   if (!_isBackgrounded) {
     [_kernelAudioSessionManagerDelegate moduleDidForeground:self];
   }
-  [[_moduleRegistry getModuleImplementingProtocol:@protocol(UMAppLifecycleService)] registerAppLifecycleListener:self];
+  [[_moduleRegistry getModuleImplementingProtocol:@protocol(EXAppLifecycleService)] registerAppLifecycleListener:self];
   _permissionsManager = [_moduleRegistry getModuleImplementingProtocol:@protocol(EXPermissionsInterface)];
   [EXPermissionsMethodsDelegate registerRequesters:@[[EXAudioRecordingPermissionRequester new]] withPermissionsManager:_permissionsManager];
 }
@@ -194,11 +194,11 @@ UM_EXPORT_MODULE(ExponentAV);
   BOOL shouldPlayInBackground = ((NSNumber *)mode[@"staysActiveInBackground"]).boolValue;
   
   if (!playsInSilentMode && interruptionMode == EXAudioInterruptionModeDuckOthers) {
-    return UMErrorWithMessage(@"Impossible audio mode: playsInSilentMode == false and duckOthers == true cannot be set on iOS.");
+    return EXErrorWithMessage(@"Impossible audio mode: playsInSilentMode == false and duckOthers == true cannot be set on iOS.");
   } else if (!playsInSilentMode && allowsRecording) {
-    return UMErrorWithMessage(@"Impossible audio mode: playsInSilentMode == false and allowsRecording == true cannot be set on iOS.");
+    return EXErrorWithMessage(@"Impossible audio mode: playsInSilentMode == false and allowsRecording == true cannot be set on iOS.");
   } else if (!playsInSilentMode && shouldPlayInBackground) {
-    return UMErrorWithMessage(@"Impossible audio mode: playsInSilentMode == false and staysActiveInBackground == true cannot be set on iOS.");
+    return EXErrorWithMessage(@"Impossible audio mode: playsInSilentMode == false and staysActiveInBackground == true cannot be set on iOS.");
   } else {
     if (!allowsRecording) {
       if (_audioRecorder && [_audioRecorder isRecording]) {
@@ -279,10 +279,10 @@ UM_EXPORT_MODULE(ExponentAV);
 - (NSError *)promoteAudioSessionIfNecessary
 {
   if (!_audioIsEnabled) {
-    return UMErrorWithMessage(@"Expo Audio is disabled, so the audio session could not be activated.");
+    return EXErrorWithMessage(@"Expo Audio is disabled, so the audio session could not be activated.");
   }
   if (_isBackgrounded && !_staysActiveInBackground && ![_kernelAudioSessionManagerDelegate isActiveForModule:self]) {
-    return UMErrorWithMessage(@"This experience is currently in the background, so the audio session could not be activated.");
+    return EXErrorWithMessage(@"This experience is currently in the background, so the audio session could not be activated.");
   }
   
   EXAVAudioSessionMode audioSessionModeRequired = [self _getAudioSessionModeRequired];
@@ -387,7 +387,7 @@ UM_EXPORT_MODULE(ExponentAV);
 
 - (void)_runBlock:(void (^)(EXAVPlayerData *data))block
   withSoundForKey:(nonnull NSNumber *)key
-     withRejecter:(UMPromiseRejectBlock)reject
+     withRejecter:(EXPromiseRejectBlock)reject
 {
   EXAVPlayerData *data = _soundDictionary[key];
   if (data) {
@@ -411,11 +411,11 @@ UM_EXPORT_MODULE(ExponentAV);
 
 - (void)_runBlock:(void (^)(EXVideoView *view))block
 withEXVideoViewForTag:(nonnull NSNumber *)reactTag
-     withRejecter:(UMPromiseRejectBlock)reject
+     withRejecter:(EXPromiseRejectBlock)reject
 {
   // TODO check that the bridge is still valid after the dispatch
   // TODO check if the queues are ok
-  [[_moduleRegistry getModuleImplementingProtocol:@protocol(UMUIManager)] executeUIBlock:^(id view) {
+  [[_moduleRegistry getModuleImplementingProtocol:@protocol(EXUIManager)] executeUIBlock:^(id view) {
     if ([view isKindOfClass:[EXVideoView class]]) {
       block(view);
     } else {
@@ -500,13 +500,13 @@ withEXVideoViewForTag:(nonnull NSNumber *)reactTag
 - (NSError *)_createNewAudioRecorder
 {
   if (_audioRecorder) {
-    return UMErrorWithMessage(@"Recorder is already prepared.");
+    return EXErrorWithMessage(@"Recorder is already prepared.");
   }
   
   id<EXFileSystemInterface> fileSystem = [_moduleRegistry getModuleImplementingProtocol:@protocol(EXFileSystemInterface)];
   
   if (!fileSystem) {
-    return UMErrorWithMessage(@"No FileSystem module.");
+    return EXErrorWithMessage(@"No FileSystem module.");
   }
   
   NSString *directory = [fileSystem.cachesDirectory stringByAppendingPathComponent:@"AV"];
@@ -554,7 +554,7 @@ withEXVideoViewForTag:(nonnull NSNumber *)reactTag
   }
 }
 
-- (BOOL)_checkAudioRecorderExistsOrReject:(UMPromiseRejectBlock)reject
+- (BOOL)_checkAudioRecorderExistsOrReject:(EXPromiseRejectBlock)reject
 {
   if (_audioRecorder == nil) {
     reject(@"E_AUDIO_NORECORDER", @"Recorder does not exist. Prepare it first using Audio.prepareToRecordAsync.", nil);
@@ -583,10 +583,10 @@ withEXVideoViewForTag:(nonnull NSNumber *)reactTag
 
 #pragma mark - Audio API: Global settings
 
-UM_EXPORT_METHOD_AS(setAudioIsEnabled,
+EX_EXPORT_METHOD_AS(setAudioIsEnabled,
                     setAudioIsEnabled:(BOOL)value
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   _audioIsEnabled = value;
   
@@ -596,10 +596,10 @@ UM_EXPORT_METHOD_AS(setAudioIsEnabled,
   resolve(nil);
 }
 
-UM_EXPORT_METHOD_AS(setAudioMode,
+EX_EXPORT_METHOD_AS(setAudioMode,
                     setAudioMode:(NSDictionary *)mode
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   NSError *error = [self _setAudioMode:mode];
   
@@ -612,20 +612,20 @@ UM_EXPORT_METHOD_AS(setAudioMode,
 
 #pragma mark - Unified playback API - Audio
 
-UM_EXPORT_METHOD_AS(loadForSound,
+EX_EXPORT_METHOD_AS(loadForSound,
                     loadForSound:(NSDictionary *)source
                     withStatus:(NSDictionary *)status
-                    resolver:(UMPromiseResolveBlock)loadSuccess
-                    rejecter:(UMPromiseRejectBlock)loadError)
+                    resolver:(EXPromiseResolveBlock)loadSuccess
+                    rejecter:(EXPromiseRejectBlock)loadError)
 {
   NSNumber *key = @(_soundDictionaryKeyCount++);
   
-  UM_WEAKIFY(self);
+  EX_WEAKIFY(self);
   EXAVPlayerData *data = [[EXAVPlayerData alloc] initWithEXAV:self
                                                    withSource:source
                                                    withStatus:status
                                           withLoadFinishBlock:^(BOOL success, NSDictionary *successStatus, NSString *error) {
-    UM_ENSURE_STRONGIFY(self);
+    EX_ENSURE_STRONGIFY(self);
     if (success) {
       loadSuccess(@[key, successStatus]);
     } else {
@@ -634,7 +634,7 @@ UM_EXPORT_METHOD_AS(loadForSound,
     }
   }];
   data.errorCallback = ^(NSString *error) {
-    UM_ENSURE_STRONGIFY(self);
+    EX_ENSURE_STRONGIFY(self);
     [self sendEventWithName:@"ExponentAV.onError" body:@{
       @"key": key,
       @"error": error
@@ -643,7 +643,7 @@ UM_EXPORT_METHOD_AS(loadForSound,
   };
   
   data.statusUpdateCallback = ^(NSDictionary *status) {
-    UM_ENSURE_STRONGIFY(self);
+    EX_ENSURE_STRONGIFY(self);
     if (self.isBeingObserved) {
       NSDictionary<NSString *, id> *response = @{@"key": key, @"status": status};
       [self sendEventWithName:EXDidUpdatePlaybackStatusEventName body:response];
@@ -655,13 +655,13 @@ UM_EXPORT_METHOD_AS(loadForSound,
 
 - (void)sendEventWithName:(NSString *)eventName body:(NSDictionary *)body
 {
-  [[_moduleRegistry getModuleImplementingProtocol:@protocol(UMEventEmitterService)] sendEventWithName:eventName body:body];
+  [[_moduleRegistry getModuleImplementingProtocol:@protocol(EXEventEmitterService)] sendEventWithName:eventName body:body];
 }
 
-UM_EXPORT_METHOD_AS(unloadForSound,
+EX_EXPORT_METHOD_AS(unloadForSound,
                     unloadForSound:(NSNumber *)key
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   [self _runBlock:^(EXAVPlayerData *data) {
     [self _removeSoundForKey:key];
@@ -669,11 +669,11 @@ UM_EXPORT_METHOD_AS(unloadForSound,
   } withSoundForKey:key withRejecter:reject];
 }
 
-UM_EXPORT_METHOD_AS(setStatusForSound,
+EX_EXPORT_METHOD_AS(setStatusForSound,
                     setStatusForSound:(NSNumber *)key
                     withStatus:(NSDictionary *)status
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   [self _runBlock:^(EXAVPlayerData *data) {
     [data setStatus:status
@@ -682,10 +682,10 @@ UM_EXPORT_METHOD_AS(setStatusForSound,
   } withSoundForKey:key withRejecter:reject];
 }
 
-UM_EXPORT_METHOD_AS(getStatusForSound,
+EX_EXPORT_METHOD_AS(getStatusForSound,
                     getStatusForSound:(NSNumber *)key
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   [self _runBlock:^(EXAVPlayerData *data) {
     NSDictionary *status = [data getStatus];
@@ -693,11 +693,11 @@ UM_EXPORT_METHOD_AS(getStatusForSound,
   } withSoundForKey:key withRejecter:reject];
 }
 
-UM_EXPORT_METHOD_AS(replaySound,
+EX_EXPORT_METHOD_AS(replaySound,
                     replaySound:(NSNumber *)key
                     withStatus:(NSDictionary *)status
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   [self _runBlock:^(EXAVPlayerData *data) {
     [data replayWithStatus:status
@@ -708,54 +708,54 @@ UM_EXPORT_METHOD_AS(replaySound,
 
 #pragma mark - Unified playback API - Video
 
-UM_EXPORT_METHOD_AS(loadForVideo,
+EX_EXPORT_METHOD_AS(loadForVideo,
                     loadForVideo:(NSNumber *)reactTag
                     source:(NSDictionary *)source
                     withStatus:(NSDictionary *)status
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   [self _runBlock:^(EXVideoView *view) {
     [view setSource:source withStatus:status resolver:resolve rejecter:reject];
   } withEXVideoViewForTag:reactTag withRejecter:reject];
 }
 
-UM_EXPORT_METHOD_AS(unloadForVideo,
+EX_EXPORT_METHOD_AS(unloadForVideo,
                     unloadForVideo:(NSNumber *)reactTag
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   [self _runBlock:^(EXVideoView *view) {
     [view setSource:nil withStatus:nil resolver:resolve rejecter:reject];
   } withEXVideoViewForTag:reactTag withRejecter:reject];
 }
 
-UM_EXPORT_METHOD_AS(setStatusForVideo,
+EX_EXPORT_METHOD_AS(setStatusForVideo,
                     setStatusForVideo:(NSNumber *)reactTag
                     withStatus:(NSDictionary *)status
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   [self _runBlock:^(EXVideoView *view) {
     [view setStatus:status resolver:resolve rejecter:reject];
   } withEXVideoViewForTag:reactTag withRejecter:reject];
 }
 
-UM_EXPORT_METHOD_AS(replayVideo,
+EX_EXPORT_METHOD_AS(replayVideo,
                     replayVideo:(NSNumber *)reactTag
                     withStatus:(NSDictionary *)status
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   [self _runBlock:^(EXVideoView *view) {
     [view replayWithStatus:status resolver:resolve rejecter:reject];
   } withEXVideoViewForTag:reactTag withRejecter:reject];
 }
 
-UM_EXPORT_METHOD_AS(getStatusForVideo,
+EX_EXPORT_METHOD_AS(getStatusForVideo,
                     getStatusForVideo:(NSNumber *)reactTag
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   [self _runBlock:^(EXVideoView *view) {
     resolve(view.status);
@@ -766,9 +766,9 @@ UM_EXPORT_METHOD_AS(getStatusForVideo,
 
 #pragma mark - Audio API: Recording
 
-UM_EXPORT_METHOD_AS(getPermissionsAsync,
-                    getPermissionsAsync:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(getPermissionsAsync,
+                    getPermissionsAsync:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   [EXPermissionsMethodsDelegate getPermissionWithPermissionsManager:_permissionsManager
                                                       withRequester:[EXAudioRecordingPermissionRequester class]
@@ -776,9 +776,9 @@ UM_EXPORT_METHOD_AS(getPermissionsAsync,
                                                              reject:reject];
 }
 
-UM_EXPORT_METHOD_AS(requestPermissionsAsync,
-                    requestPermissionsAsync:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(requestPermissionsAsync,
+                    requestPermissionsAsync:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   [EXPermissionsMethodsDelegate askForPermissionWithPermissionsManager:_permissionsManager
                                                          withRequester:[EXAudioRecordingPermissionRequester class]
@@ -786,10 +786,10 @@ UM_EXPORT_METHOD_AS(requestPermissionsAsync,
                                                                 reject:reject];
 }
 
-UM_EXPORT_METHOD_AS(prepareAudioRecorder,
+EX_EXPORT_METHOD_AS(prepareAudioRecorder,
                     prepareAudioRecorder:(NSDictionary *)options
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   if (![_permissionsManager hasGrantedPermissionUsingRequesterClass:[EXAudioRecordingPermissionRequester class]]) {
     reject(@"E_MISSING_PERMISSION", @"Missing audio recording permission.", nil);
@@ -832,9 +832,9 @@ UM_EXPORT_METHOD_AS(prepareAudioRecorder,
   }
 }
 
-UM_EXPORT_METHOD_AS(startAudioRecording,
-                    startAudioRecording:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(startAudioRecording,
+                    startAudioRecording:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   if (![_permissionsManager hasGrantedPermissionUsingRequesterClass:[EXAudioRecordingPermissionRequester class]]) {
     reject(@"E_MISSING_PERMISSION", @"Missing audio recording permission.", nil);
@@ -862,9 +862,9 @@ UM_EXPORT_METHOD_AS(startAudioRecording,
   _audioRecorderShouldBeginRecording = false;
 }
 
-UM_EXPORT_METHOD_AS(pauseAudioRecording,
-                    pauseAudioRecording:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(pauseAudioRecording,
+                    pauseAudioRecording:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   if ([self _checkAudioRecorderExistsOrReject:reject]) {
     if (_audioRecorder.recording) {
@@ -875,9 +875,9 @@ UM_EXPORT_METHOD_AS(pauseAudioRecording,
   }
 }
 
-UM_EXPORT_METHOD_AS(stopAudioRecording,
-                    stopAudioRecording:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(stopAudioRecording,
+                    stopAudioRecording:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   if ([self _checkAudioRecorderExistsOrReject:reject]) {
     if (_audioRecorder.recording) {
@@ -889,18 +889,18 @@ UM_EXPORT_METHOD_AS(stopAudioRecording,
   }
 }
 
-UM_EXPORT_METHOD_AS(getAudioRecordingStatus,
-                    getAudioRecordingStatus:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(getAudioRecordingStatus,
+                    getAudioRecordingStatus:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   if ([self _checkAudioRecorderExistsOrReject:reject]) {
     resolve([self _getAudioRecorderStatus]);
   }
 }
 
-UM_EXPORT_METHOD_AS(unloadAudioRecorder,
-                    unloadAudioRecorder:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(unloadAudioRecorder,
+                    unloadAudioRecorder:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   if ([self _checkAudioRecorderExistsOrReject:reject]) {
     [self _removeAudioRecorder:YES];
@@ -913,7 +913,7 @@ UM_EXPORT_METHOD_AS(unloadAudioRecorder,
 - (void)dealloc
 {
   [_kernelAudioSessionManagerDelegate moduleWillDeallocate:self];
-  [[_moduleRegistry getModuleImplementingProtocol:@protocol(UMAppLifecycleService)] unregisterAppLifecycleListener:self];
+  [[_moduleRegistry getModuleImplementingProtocol:@protocol(EXAppLifecycleService)] unregisterAppLifecycleListener:self];
   [[NSNotificationCenter defaultCenter] removeObserver:self];
   
   // This will clear all @properties and deactivate the audio session:

--- a/packages/expo-av/ios/EXAV/EXAVPlayerData.h
+++ b/packages/expo-av/ios/EXAV/EXAVPlayerData.h
@@ -20,13 +20,13 @@
          withLoadFinishBlock:(void (^)(BOOL success, NSDictionary *successStatus, NSString *error))loadFinishBlock;
 
 - (void)setStatus:(NSDictionary *)parameters
-         resolver:(UMPromiseResolveBlock)resolve
-         rejecter:(UMPromiseRejectBlock)reject;
+         resolver:(EXPromiseResolveBlock)resolve
+         rejecter:(EXPromiseRejectBlock)reject;
 
 - (NSDictionary *)getStatus;
 
 - (void)replayWithStatus:(NSDictionary *)status
-                resolver:(UMPromiseResolveBlock)resolve
-                rejecter:(UMPromiseRejectBlock)reject;
+                resolver:(EXPromiseResolveBlock)resolve
+                rejecter:(EXPromiseRejectBlock)reject;
 
 @end

--- a/packages/expo-av/ios/EXAV/EXAVPlayerData.m
+++ b/packages/expo-av/ios/EXAV/EXAVPlayerData.m
@@ -54,7 +54,7 @@ NSString *const EXAVPlayerDataObserverPlaybackBufferEmptyKeyPath = @"playbackBuf
 @property (nonatomic, assign) BOOL isLooping;
 @property (nonatomic, strong) NSArray<AVPlayerItem *> *items;
 
-@property (nonatomic, strong) UMPromiseResolveBlock replayResolve;
+@property (nonatomic, strong) EXPromiseResolveBlock replayResolve;
 
 @end
 
@@ -119,9 +119,9 @@ NSString *const EXAVPlayerDataObserverPlaybackBufferEmptyKeyPath = @"playbackBuf
   
   // unless we preload, the asset will not necessarily load the duration by the time we try to play it.
   // http://stackoverflow.com/questions/20581567/avplayer-and-avfoundationerrordomain-code-11819
-  UM_WEAKIFY(self);
+  EX_WEAKIFY(self);
   [avAsset loadValuesAsynchronouslyForKeys:@[ @"duration" ] completionHandler:^{
-    UM_ENSURE_STRONGIFY(self);
+    EX_ENSURE_STRONGIFY(self);
 
     // We prepare three items for AVQueuePlayer, so when the first finishes playing,
     // second can start playing and the third can start preparing to play.
@@ -148,13 +148,13 @@ NSString *const EXAVPlayerDataObserverPlaybackBufferEmptyKeyPath = @"playbackBuf
 - (void)_finishLoadingNewPlayer
 {
   // Set up player with parameters
-  UM_WEAKIFY(self);
+  EX_WEAKIFY(self);
   [_player seekToTime:_currentPosition completionHandler:^(BOOL finished) {
-    UM_ENSURE_STRONGIFY(self);
+    EX_ENSURE_STRONGIFY(self);
     __strong EXAV *strongEXAV = self.exAV;
     if (strongEXAV) {
       dispatch_async(self.exAV.methodQueue, ^{
-        UM_ENSURE_STRONGIFY(self);
+        EX_ENSURE_STRONGIFY(self);
         self.currentPosition = self.player.currentTime;
 
         self.player.currentItem.audioTimePitchAlgorithm = self.pitchCorrectionQuality;
@@ -208,8 +208,8 @@ NSString *const EXAVPlayerDataObserverPlaybackBufferEmptyKeyPath = @"playbackBuf
 }
 
 - (void)setStatus:(NSDictionary *)parameters
-         resolver:(UMPromiseResolveBlock)resolve
-         rejecter:(UMPromiseRejectBlock)reject
+         resolver:(EXPromiseResolveBlock)resolve
+         rejecter:(EXPromiseRejectBlock)reject
 {
   BOOL mustUpdateTimeObserver = NO;
   BOOL mustSeek = NO;
@@ -300,9 +300,9 @@ NSString *const EXAVPlayerDataObserverPlaybackBufferEmptyKeyPath = @"playbackBuf
     _player.volume = _volume.floatValue;
     
     // Apply parameters necessary after seek.
-    UM_WEAKIFY(self);
+    EX_WEAKIFY(self);
     void (^applyPostSeekParameters)(BOOL) = ^(BOOL seekSucceeded) {
-      UM_ENSURE_STRONGIFY(self);
+      EX_ENSURE_STRONGIFY(self);
       self.currentPosition = self.player.currentTime;
 
       if (mustUpdateTimeObserver) {
@@ -317,7 +317,7 @@ NSString *const EXAVPlayerDataObserverPlaybackBufferEmptyKeyPath = @"playbackBuf
         }
       } else if (!seekSucceeded) {
         if (reject) {
-          reject(@"E_AV_SEEKING", nil, UMErrorWithMessage(@"Seeking interrupted."));
+          reject(@"E_AV_SEEKING", nil, EXErrorWithMessage(@"Seeking interrupted."));
         }
       } else if (resolve) {
         resolve([self getStatus]);
@@ -477,8 +477,8 @@ NSString *const EXAVPlayerDataObserverPlaybackBufferEmptyKeyPath = @"playbackBuf
 #pragma mark - Replay
 
 - (void)replayWithStatus:(NSDictionary *)status
-                resolver:(UMPromiseResolveBlock)resolve
-                rejecter:(UMPromiseRejectBlock)reject
+                resolver:(EXPromiseResolveBlock)resolve
+                rejecter:(EXPromiseRejectBlock)reject
 {
   [self _callStatusUpdateCallbackWithExtraFields:@{
                                                    EXAVPlayerDataStatusHasJustBeenInterruptedKeyPath: @([self _isPlayerPlaying]),
@@ -579,14 +579,14 @@ NSString *const EXAVPlayerDataObserverPlaybackBufferEmptyKeyPath = @"playbackBuf
 - (void)_addObserversForPlayerItem:(AVPlayerItem *)playerItem
 {
   NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
-  UM_WEAKIFY(self);
+  EX_WEAKIFY(self);
   
   void (^didPlayToEndTimeObserverBlock)(NSNotification *note) = ^(NSNotification *note) {
-    UM_ENSURE_STRONGIFY(self);
+    EX_ENSURE_STRONGIFY(self);
     __strong EXAV *strongEXAV = self.exAV;
     if (strongEXAV) {
       dispatch_async(strongEXAV.methodQueue, ^{
-        UM_ENSURE_STRONGIFY(self);
+        EX_ENSURE_STRONGIFY(self);
         [self _callStatusUpdateCallbackWithExtraFields:@{EXAVPlayerDataStatusDidJustFinishKeyPath: @(YES)}];
         // If the player is looping, we would only like to advance to next item (which is handled by actionAtItemEnd)
         if (!self.isLooping) {
@@ -607,7 +607,7 @@ NSString *const EXAVPlayerDataObserverPlaybackBufferEmptyKeyPath = @"playbackBuf
                                     usingBlock:didPlayToEndTimeObserverBlock];
   
   void (^playbackStalledObserverBlock)(NSNotification *note) = ^(NSNotification *note) {
-    UM_ENSURE_STRONGIFY(self);
+    EX_ENSURE_STRONGIFY(self);
     [self _callStatusUpdateCallback];
   };
   
@@ -623,16 +623,16 @@ NSString *const EXAVPlayerDataObserverPlaybackBufferEmptyKeyPath = @"playbackBuf
 {
   [self _removeTimeObserver];
   
-  UM_WEAKIFY(self);
+  EX_WEAKIFY(self);
   
   CMTime interval = CMTimeMakeWithSeconds(_progressUpdateIntervalMillis.floatValue / 1000.0, NSEC_PER_SEC);
   
   void (^timeObserverBlock)(CMTime time) = ^(CMTime time) {
-    UM_ENSURE_STRONGIFY(self);
+    EX_ENSURE_STRONGIFY(self);
     __strong EXAV *strongEXAV = self.exAV;
     if (strongEXAV) {
       dispatch_async(strongEXAV.methodQueue, ^{
-        UM_ENSURE_STRONGIFY(self);
+        EX_ENSURE_STRONGIFY(self);
         
         if (self && self.player.status == AVPlayerStatusReadyToPlay) {
           self.currentPosition = time; // We keep track of _currentPosition to reset the AVPlayer in handleMediaServicesReset.
@@ -859,9 +859,9 @@ NSString *const EXAVPlayerDataObserverPlaybackBufferEmptyKeyPath = @"playbackBuf
   void (^callback)(NSDictionary *) = _statusUpdateCallback;
   _statusUpdateCallback = nil;
     
-  UM_WEAKIFY(self);
+  EX_WEAKIFY(self);
   _loadFinishBlock = ^(BOOL success, NSDictionary *successStatus, NSString *error) {
-    UM_ENSURE_STRONGIFY(self);
+    EX_ENSURE_STRONGIFY(self);
     if (finishCallback != nil) {
       finishCallback();
     }

--- a/packages/expo-av/ios/EXAV/EXAudioRecordingPermissionRequester.m
+++ b/packages/expo-av/ios/EXAV/EXAudioRecordingPermissionRequester.m
@@ -1,7 +1,7 @@
 // Copyright 2016-present 650 Industries. All rights reserved.
 
 #import <EXAV/EXAudioRecordingPermissionRequester.h>
-#import <UMCore/UMDefines.h>
+#import <ExpoModulesCore/EXDefines.h>
 
 #import <AVFoundation/AVFoundation.h>
 
@@ -19,7 +19,7 @@
 
   NSString *microphoneUsageDescription = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSMicrophoneUsageDescription"];
   if (!microphoneUsageDescription) {
-    UMFatal(UMErrorWithMessage(@"This app is missing NSMicrophoneUsageDescription, so audio services will fail. Add one of these keys to your bundle's Info.plist."));
+    EXFatal(EXErrorWithMessage(@"This app is missing NSMicrophoneUsageDescription, so audio services will fail. Add one of these keys to your bundle's Info.plist."));
     systemStatus = AVAudioSessionRecordPermissionDenied;
   } else {
     systemStatus = [[AVAudioSession sharedInstance] recordPermission];
@@ -41,11 +41,11 @@
   };
 }
 
-- (void)requestPermissionsWithResolver:(UMPromiseResolveBlock)resolve rejecter:(UMPromiseRejectBlock)reject
+- (void)requestPermissionsWithResolver:(EXPromiseResolveBlock)resolve rejecter:(EXPromiseRejectBlock)reject
 {
-  UM_WEAKIFY(self)
+  EX_WEAKIFY(self)
   [[AVAudioSession sharedInstance] requestRecordPermission:^(BOOL granted) {
-    UM_STRONGIFY(self)
+    EX_STRONGIFY(self)
     resolve([self getPermissions]);
   }];
 }

--- a/packages/expo-av/ios/EXAV/EXAudioSessionManager.h
+++ b/packages/expo-av/ios/EXAV/EXAudioSessionManager.h
@@ -1,9 +1,8 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
-#import <UMCore/UMSingletonModule.h>
+#import <ExpoModulesCore/EXSingletonModule.h>
 #import <EXAV/EXAV.h>
 
-@interface EXAudioSessionManager : UMSingletonModule <EXAVScopedModuleDelegate>
+@interface EXAudioSessionManager : EXSingletonModule <EXAVScopedModuleDelegate>
 
 @end
-

--- a/packages/expo-av/ios/EXAV/EXAudioSessionManager.m
+++ b/packages/expo-av/ios/EXAV/EXAudioSessionManager.m
@@ -2,7 +2,7 @@
 
 #import <AVFoundation/AVFoundation.h>
 
-#import <UMCore/UMDefines.h>
+#import <ExpoModulesCore/EXDefines.h>
 
 #import <EXAV/EXAudioSessionManager.h>
 
@@ -23,7 +23,7 @@
 
 @implementation EXAudioSessionManager
 
-UM_REGISTER_SINGLETON_MODULE(AudioSessionManager);
+EX_REGISTER_SINGLETON_MODULE(AudioSessionManager);
 
 - (instancetype)init
 {

--- a/packages/expo-av/ios/EXAV/Video/EXVideoManager.h
+++ b/packages/expo-av/ios/EXAV/Video/EXVideoManager.h
@@ -1,8 +1,8 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
-#import <UMCore/UMViewManager.h>
-#import <UMCore/UMModuleRegistryConsumer.h>
+#import <ExpoModulesCore/EXViewManager.h>
+#import <ExpoModulesCore/EXModuleRegistryConsumer.h>
 
-@interface EXVideoManager : UMViewManager <UMModuleRegistryConsumer>
+@interface EXVideoManager : EXViewManager <EXModuleRegistryConsumer>
 
 @end

--- a/packages/expo-av/ios/EXAV/Video/EXVideoManager.m
+++ b/packages/expo-av/ios/EXAV/Video/EXVideoManager.m
@@ -4,24 +4,24 @@
 
 #import <EXAV/EXVideoManager.h>
 #import <EXAV/EXVideoView.h>
-#import <UMCore/UMUIManager.h>
+#import <ExpoModulesCore/EXUIManager.h>
 
 @interface EXVideoManager ()
 
-@property (nonatomic, weak) UMModuleRegistry *moduleRegistry;
+@property (nonatomic, weak) EXModuleRegistry *moduleRegistry;
 
 @end
 
 @implementation EXVideoManager
 
-UM_EXPORT_MODULE(ExpoVideoManager);
+EX_EXPORT_MODULE(ExpoVideoManager);
 
 - (NSString *)viewName
 {
   return @"ExpoVideoView";
 }
 
-- (void)setModuleRegistry:(UMModuleRegistry *)moduleRegistry
+- (void)setModuleRegistry:(EXModuleRegistry *)moduleRegistry
 {
   _moduleRegistry = moduleRegistry;
 }
@@ -40,22 +40,22 @@ UM_EXPORT_MODULE(ExpoVideoManager);
 }
 
 // Props set directly in <Video> component
-UM_VIEW_PROPERTY(status, NSDictionary *, EXVideoView)
+EX_VIEW_PROPERTY(status, NSDictionary *, EXVideoView)
 {
   [view setStatus:value];
 }
 
-UM_VIEW_PROPERTY(useNativeControls, BOOL, EXVideoView)
+EX_VIEW_PROPERTY(useNativeControls, BOOL, EXVideoView)
 {
   [view setUseNativeControls:value];
 }
 
 // Native only props -- set by Video.js
-UM_VIEW_PROPERTY(source, NSDictionary *, EXVideoView)
+EX_VIEW_PROPERTY(source, NSDictionary *, EXVideoView)
 {
   [view setSource:value];
 }
-UM_VIEW_PROPERTY(resizeMode, NSString *, EXVideoView)
+EX_VIEW_PROPERTY(resizeMode, NSString *, EXVideoView)
 {
   [view setNativeResizeMode:value];
 }
@@ -74,24 +74,24 @@ UM_VIEW_PROPERTY(resizeMode, NSString *, EXVideoView)
 
 - (void)_runBlock:(void (^)(EXVideoView *view))block
 withEXVideoViewForTag:(nonnull NSNumber *)viewTag
-     withRejecter:(UMPromiseRejectBlock)reject
+     withRejecter:(EXPromiseRejectBlock)reject
 {
-  id<UMUIManager> uiManager = [_moduleRegistry getModuleImplementingProtocol:@protocol(UMUIManager)];
+  id<EXUIManager> uiManager = [_moduleRegistry getModuleImplementingProtocol:@protocol(EXUIManager)];
   [uiManager executeUIBlock:^(id view) {
     if ([view isKindOfClass:[EXVideoView class]]) {
       block((EXVideoView *)view);
     } else {
       NSString *errorMessage = [NSString stringWithFormat:@"Invalid view returned from registry, expecting EXVideo, got: %@", view];
-      reject(@"E_VIDEO_TAGINCORRECT", errorMessage, UMErrorWithMessage(errorMessage));
+      reject(@"E_VIDEO_TAGINCORRECT", errorMessage, EXErrorWithMessage(errorMessage));
     }
   } forView:viewTag ofClass:[EXVideoView class]];
 }
 
-UM_EXPORT_METHOD_AS(setFullscreen,
+EX_EXPORT_METHOD_AS(setFullscreen,
                     setFullscreen:(NSNumber *)viewTag
                     toValue:(BOOL)value
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   [self _runBlock:^(EXVideoView *view) {
     [view setFullscreen:value resolver:resolve rejecter:reject];

--- a/packages/expo-av/ios/EXAV/Video/EXVideoView.h
+++ b/packages/expo-av/ios/EXAV/Video/EXVideoView.h
@@ -1,6 +1,6 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
-#import <UMCore/UMModuleRegistry.h>
+#import <ExpoModulesCore/EXModuleRegistry.h>
 
 #import <EXAV/EXAVObject.h>
 #import <EXAV/EXVideoPlayerViewControllerDelegate.h>
@@ -19,30 +19,30 @@ typedef NS_OPTIONS(NSUInteger, EXVideoFullscreenUpdate)
 @property (nonatomic, strong) NSDictionary *source;
 @property (nonatomic, assign) BOOL useNativeControls;
 @property (nonatomic, strong) NSString *nativeResizeMode;
-@property (nonatomic, copy) UMDirectEventBlock onLoadStart;
-@property (nonatomic, copy) UMDirectEventBlock onLoad;
-@property (nonatomic, copy) UMDirectEventBlock onError;
-@property (nonatomic, copy) UMDirectEventBlock onStatusUpdate;
-@property (nonatomic, copy) UMDirectEventBlock onReadyForDisplay;
-@property (nonatomic, copy) UMDirectEventBlock onFullscreenUpdate;
+@property (nonatomic, copy) EXDirectEventBlock onLoadStart;
+@property (nonatomic, copy) EXDirectEventBlock onLoad;
+@property (nonatomic, copy) EXDirectEventBlock onError;
+@property (nonatomic, copy) EXDirectEventBlock onStatusUpdate;
+@property (nonatomic, copy) EXDirectEventBlock onReadyForDisplay;
+@property (nonatomic, copy) EXDirectEventBlock onFullscreenUpdate;
 
-- (instancetype)initWithModuleRegistry:(UMModuleRegistry *)moduleRegistry;
+- (instancetype)initWithModuleRegistry:(EXModuleRegistry *)moduleRegistry;
 
 - (void)setStatus:(NSDictionary *)status
-         resolver:(UMPromiseResolveBlock)resolve
-         rejecter:(UMPromiseRejectBlock)reject;
+         resolver:(EXPromiseResolveBlock)resolve
+         rejecter:(EXPromiseRejectBlock)reject;
 
 - (void)replayWithStatus:(NSDictionary *)status
-                resolver:(UMPromiseResolveBlock)resolve
-                rejecter:(UMPromiseRejectBlock)reject;
+                resolver:(EXPromiseResolveBlock)resolve
+                rejecter:(EXPromiseRejectBlock)reject;
 
 - (void)setSource:(NSDictionary *)source
        withStatus:(NSDictionary *)initialStatus
-         resolver:(UMPromiseResolveBlock)resolve
-         rejecter:(UMPromiseRejectBlock)reject;
+         resolver:(EXPromiseResolveBlock)resolve
+         rejecter:(EXPromiseRejectBlock)reject;
 
 - (void)setFullscreen:(BOOL)value
-             resolver:(UMPromiseResolveBlock)resolve
-             rejecter:(UMPromiseRejectBlock)reject;
+             resolver:(EXPromiseResolveBlock)resolve
+             rejecter:(EXPromiseRejectBlock)reject;
 
 @end

--- a/packages/expo-av/ios/EXAV/Video/EXVideoView.m
+++ b/packages/expo-av/ios/EXAV/Video/EXVideoView.m
@@ -1,7 +1,7 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
 #import <AVFoundation/AVFoundation.h>
-#import <UMCore/UMUtilities.h>
+#import <ExpoModulesCore/EXUtilities.h>
 #import <EXAV/EXAV.h>
 #import <EXAV/EXVideoView.h>
 #import <EXAV/EXAVPlayerData.h>
@@ -24,8 +24,8 @@ static NSString *const EXAVFullScreenViewControllerClassName = @"AVFullScreenVie
 
 @property (nonatomic, assign) BOOL fullscreenPlayerIsDismissing;
 @property (nonatomic, strong) EXVideoPlayerViewController *fullscreenPlayerViewController;
-@property (nonatomic, strong) UMPromiseResolveBlock requestedFullscreenChangeResolver;
-@property (nonatomic, strong) UMPromiseRejectBlock requestedFullscreenChangeRejecter;
+@property (nonatomic, strong) EXPromiseResolveBlock requestedFullscreenChangeResolver;
+@property (nonatomic, strong) EXPromiseRejectBlock requestedFullscreenChangeRejecter;
 @property (nonatomic, assign) BOOL requestedFullscreenChange;
 
 @property (nonatomic, strong) UIViewController *presentingViewController;
@@ -34,7 +34,7 @@ static NSString *const EXAVFullScreenViewControllerClassName = @"AVFullScreenVie
 @property (nonatomic, strong) NSDictionary *lastSetSource;
 @property (nonatomic, strong) NSMutableDictionary *statusToSet;
 
-@property (nonatomic, weak) UMModuleRegistry *moduleRegistry;
+@property (nonatomic, weak) EXModuleRegistry *moduleRegistry;
 
 @end
 
@@ -42,7 +42,7 @@ static NSString *const EXAVFullScreenViewControllerClassName = @"AVFullScreenVie
 
 #pragma mark - EXVideoView interface methods
 
-- (instancetype)initWithModuleRegistry:(UMModuleRegistry *)moduleRegistry
+- (instancetype)initWithModuleRegistry:(EXModuleRegistry *)moduleRegistry
 {
   if ((self = [super init])) {
     _moduleRegistry = moduleRegistry;
@@ -87,8 +87,8 @@ static NSString *const EXAVFullScreenViewControllerClassName = @"AVFullScreenVie
 
 #pragma mark - Player and source
 
-- (void)_tryUpdateDataStatus:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject
+- (void)_tryUpdateDataStatus:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject
 {
   if (_data) {
     if ([_statusToSet count] > 0) {
@@ -139,15 +139,15 @@ static NSString *const EXAVFullScreenViewControllerClassName = @"AVFullScreenVie
   
   // Any ViewController/layer updates need to be
   // executed on the main UI thread.
-  UM_WEAKIFY(self);
+  EX_WEAKIFY(self);
   void (^block)(void) = ^ {
-    UM_ENSURE_STRONGIFY(self);
+    EX_ENSURE_STRONGIFY(self);
     [self _removeFullscreenPlayerViewController];
     [self _removePlayerLayer];
     [self _removePlayerViewController];
   };
   _playerHasLoaded = NO;
-  [UMUtilities performSynchronouslyOnMainThread:block];
+  [EXUtilities performSynchronouslyOnMainThread:block];
 }
 
 #pragma mark - _playerViewController / _playerLayer management
@@ -284,8 +284,8 @@ static NSString *const EXAVFullScreenViewControllerClassName = @"AVFullScreenVie
 
 - (void)setSource:(NSDictionary *)source
        withStatus:(NSDictionary *)initialStatus
-         resolver:(UMPromiseResolveBlock)resolve
-         rejecter:(UMPromiseRejectBlock)reject
+         resolver:(EXPromiseResolveBlock)resolve
+         rejecter:(EXPromiseRejectBlock)reject
 {
   if (_data) {
     [_statusToSet addEntriesFromDictionary:[_data getStatus]];
@@ -308,17 +308,17 @@ static NSString *const EXAVFullScreenViewControllerClassName = @"AVFullScreenVie
   NSMutableDictionary *statusToInitiallySet = [NSMutableDictionary dictionaryWithDictionary:_statusToSet];
   [_statusToSet removeAllObjects];
   
-  UM_WEAKIFY(self);
+  EX_WEAKIFY(self);
   
   void (^statusUpdateCallback)(NSDictionary *) = ^(NSDictionary *status) {
-    UM_ENSURE_STRONGIFY(self);
+    EX_ENSURE_STRONGIFY(self);
     if (self.onStatusUpdate) {
       self.onStatusUpdate(status);
     }
   };
   
   void (^errorCallback)(NSString *) = ^(NSString *error) {
-    UM_ENSURE_STRONGIFY(self);
+    EX_ENSURE_STRONGIFY(self);
     [self _removeData];
     [self _removePlayer];
     [self _callErrorCallback:error];
@@ -328,7 +328,7 @@ static NSString *const EXAVFullScreenViewControllerClassName = @"AVFullScreenVie
                                     withSource:source
                                     withStatus:statusToInitiallySet
                            withLoadFinishBlock:^(BOOL success, NSDictionary *successStatus, NSString *error) {
-    UM_ENSURE_STRONGIFY(self);
+    EX_ENSURE_STRONGIFY(self);
     if (success) {
       [self _updateForNewPlayer];
       if (resolve) {
@@ -348,7 +348,7 @@ static NSString *const EXAVFullScreenViewControllerClassName = @"AVFullScreenVie
   
   // Call onLoadStart on next run loop, otherwise it might not be set yet (if it is set at the same time as uri, via props)
   dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t) 0), dispatch_get_main_queue(), ^{
-    UM_ENSURE_STRONGIFY(self);
+    EX_ENSURE_STRONGIFY(self);
     if (self.onLoadStart) {
       self.onLoadStart(nil);
     }
@@ -356,8 +356,8 @@ static NSString *const EXAVFullScreenViewControllerClassName = @"AVFullScreenVie
 }
 
 - (void)setStatus:(NSDictionary *)status
-         resolver:(UMPromiseResolveBlock)resolve
-         rejecter:(UMPromiseRejectBlock)reject
+         resolver:(EXPromiseResolveBlock)resolve
+         rejecter:(EXPromiseRejectBlock)reject
 {
   if (status != nil) {
     [_statusToSet addEntriesFromDictionary:status];
@@ -366,8 +366,8 @@ static NSString *const EXAVFullScreenViewControllerClassName = @"AVFullScreenVie
 }
 
 - (void)replayWithStatus:(NSDictionary *)status
-                resolver:(UMPromiseResolveBlock)resolve
-                rejecter:(UMPromiseRejectBlock)reject
+                resolver:(EXPromiseResolveBlock)resolve
+                rejecter:(EXPromiseRejectBlock)reject
 {
   if (status != nil) {
     [_statusToSet addEntriesFromDictionary:status];
@@ -380,8 +380,8 @@ static NSString *const EXAVFullScreenViewControllerClassName = @"AVFullScreenVie
 }
 
 - (void)setFullscreen:(BOOL)value
-             resolver:(UMPromiseResolveBlock)resolve
-             rejecter:(UMPromiseRejectBlock)reject
+             resolver:(EXPromiseResolveBlock)resolve
+             rejecter:(EXPromiseRejectBlock)reject
 {
   if (!_data) {
     // Tried to set fullscreen for an unloaded component.
@@ -400,7 +400,7 @@ static NSString *const EXAVFullScreenViewControllerClassName = @"AVFullScreenVie
     _requestedFullscreenChangeResolver = resolve;
     return;
   } else {
-    UM_WEAKIFY(self);
+    EX_WEAKIFY(self);
     if (value && !_fullscreenPlayerPresented && !_fullscreenPlayerViewController) {
       _fullscreenPlayerViewController = [self _createNewPlayerViewController];
       
@@ -423,10 +423,10 @@ static NSString *const EXAVFullScreenViewControllerClassName = @"AVFullScreenVie
       [self _callFullscreenCallbackForUpdate:EXVideoFullscreenUpdatePlayerWillPresent];
       
       dispatch_async(dispatch_get_main_queue(), ^{
-        UM_ENSURE_STRONGIFY(self);
+        EX_ENSURE_STRONGIFY(self);
         self.fullscreenPlayerViewController.showsPlaybackControls = YES;
         [self.presentingViewController presentViewController:self.fullscreenPlayerViewController animated:YES completion:^{
-          UM_ENSURE_STRONGIFY(self);
+          EX_ENSURE_STRONGIFY(self);
           self.fullscreenPlayerPresented = YES;
           [self _callFullscreenCallbackForUpdate:EXVideoFullscreenUpdatePlayerDidPresent];
           if (resolve) {
@@ -438,9 +438,9 @@ static NSString *const EXAVFullScreenViewControllerClassName = @"AVFullScreenVie
       [self videoPlayerViewControllerWillDismiss:_fullscreenPlayerViewController];
       
       dispatch_async(dispatch_get_main_queue(), ^{
-        UM_ENSURE_STRONGIFY(self);
+        EX_ENSURE_STRONGIFY(self);
         [self.presentingViewController dismissViewControllerAnimated:YES completion:^{
-          UM_ENSURE_STRONGIFY(self);
+          EX_ENSURE_STRONGIFY(self);
           [self videoPlayerViewControllerDidDismiss:self.fullscreenPlayerViewController];
           if (resolve) {
             resolve([self getStatus]);
@@ -471,9 +471,9 @@ static NSString *const EXAVFullScreenViewControllerClassName = @"AVFullScreenVie
 - (void)setSource:(NSDictionary *)source
 {
   if (![source isEqualToDictionary:_lastSetSource]) {
-    UM_WEAKIFY(self);
+    EX_WEAKIFY(self);
     dispatch_async(_exAV.methodQueue, ^{
-      UM_ENSURE_STRONGIFY(self);
+      EX_ENSURE_STRONGIFY(self);
       self.lastSetSource = source;
       [self setSource:source withStatus:nil resolver:nil rejecter:nil];
     });
@@ -495,9 +495,9 @@ static NSString *const EXAVFullScreenViewControllerClassName = @"AVFullScreenVie
     return;
   }
   
-  UM_WEAKIFY(self);
+  EX_WEAKIFY(self);
   dispatch_async(dispatch_get_main_queue(), ^{
-    UM_ENSURE_STRONGIFY(self);
+    EX_ENSURE_STRONGIFY(self);
     if (!self.playerHasLoaded) {
       return;
     }
@@ -554,9 +554,9 @@ static NSString *const EXAVFullScreenViewControllerClassName = @"AVFullScreenVie
 
 - (void)setStatus:(NSDictionary *)status
 {
-  UM_WEAKIFY(self);
+  EX_WEAKIFY(self);
   dispatch_async(_exAV.methodQueue, ^{
-    UM_ENSURE_STRONGIFY(self);
+    EX_ENSURE_STRONGIFY(self);
     [self setStatus:status resolver:nil rejecter:nil];
   });
 }
@@ -696,7 +696,7 @@ willEndFullScreenPresentationWithAnimationCoordinator:(id<UIViewControllerTransi
 {
   if (_data) {
     [_data appDidBackgroundStayActive:stayActive];
-      
+
     if (stayActive) {
       _playerViewController.player = nil;
       _playerLayer.player = nil;
@@ -719,9 +719,9 @@ willEndFullScreenPresentationWithAnimationCoordinator:(id<UIViewControllerTransi
     }
     [self _removePlayer];
     
-    UM_WEAKIFY(self);
+    EX_WEAKIFY(self);
     [_data handleMediaServicesReset:^{
-      UM_STRONGIFY(self);
+      EX_STRONGIFY(self);
       if (self) {
         [self _updateForNewPlayer];
       }


### PR DESCRIPTION
# Why

`UMCore` is now deprecated in favor of `ExpoModulesCore`

# How

- Removed the dependency on `UMCore`
- Renamed imports and all references

# Test Plan

Examples seem to work as expected
