### PR TITLE
[docs] improve linking in `APISection` component

### DIFF
--- a/docs/components/plugins/api/APISectionProps.tsx
+++ b/docs/components/plugins/api/APISectionProps.tsx
@@ -47,11 +47,7 @@ const extractDefaultPropValue = (
 const renderInheritedProp = (ip: TypeDefinitionData) => {
   return (
     <LI key={`inherited-prop-${ip.name}-${ip.type}`}>
-      {ip?.typeArguments ? (
-        <InlineCode>{resolveTypeName(ip)}</InlineCode>
-      ) : (
-        <InlineCode>{ip.name}</InlineCode>
-      )}
+      <InlineCode>{resolveTypeName(ip)}</InlineCode>
     </LI>
   );
 };

--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -134,6 +134,8 @@ export const resolveTypeName = ({
   } else if (elementType?.name) {
     if (elementType.type === 'reference') {
       return renderWithLink(elementType.name, type);
+    } else if (type === 'array') {
+      return elementType.name + '[]';
     }
     return elementType.name + type;
   } else if (type === 'union' && types?.length) {

--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -52,20 +52,36 @@ export const mdInlineRenderers: MDRenderers = {
 };
 
 const nonLinkableTypes = [
-  'Date',
   'ColorValue',
-  'Error',
   'NativeSyntheticEvent',
   'Omit',
   'Pick',
-  'Promise',
   'React.FC',
   'StyleProp',
   'T',
   'TaskOptions',
   'Uint8Array',
-  'ViewStyle',
 ];
+
+const hardcodedTypeLinks: Record<string, string> = {
+  Date: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date',
+  Error: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error',
+  Promise:
+    'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise',
+  View: '../../react-native/view',
+  ViewProps: '../../react-native/view#props',
+  ViewStyle: '../../react-native/view-style-props/',
+};
+
+const renderWithLink = (name: string, type?: string) =>
+  nonLinkableTypes.includes(name) ? (
+    name + (type === 'array' ? '[]' : '')
+  ) : (
+    <Link href={hardcodedTypeLinks[name] || `#${name.toLowerCase()}`} key={`type-link-${name}`}>
+      {name}
+      {type === 'array' && '[]'}
+    </Link>
+  );
 
 export const resolveTypeName = ({
   elements,
@@ -97,13 +113,7 @@ export const resolveTypeName = ({
         } else {
           return (
             <>
-              {nonLinkableTypes.includes(name) ? (
-                name
-              ) : (
-                <Link href={`#${name.toLowerCase()}`} key={`type-link-${name}`}>
-                  {name}
-                </Link>
-              )}
+              {renderWithLink(name)}
               &lt;
               {typeArguments.map((type, index) => (
                 <span key={`${name}-nested-type-${index}`}>
@@ -116,33 +126,14 @@ export const resolveTypeName = ({
           );
         }
       } else {
-        if (nonLinkableTypes.includes(name)) {
-          return name;
-        } else {
-          return (
-            <Link href={`#${name.toLowerCase()}`} key={`type-link-${name}`}>
-              {name}
-            </Link>
-          );
-        }
+        return renderWithLink(name);
       }
     } else {
       return name;
     }
   } else if (elementType?.name) {
     if (elementType.type === 'reference') {
-      if (nonLinkableTypes.includes(elementType.name)) {
-        return elementType.name + (type === 'array' && '[]');
-      }
-      return (
-        <Link href={`#${elementType.name?.toLowerCase()}`} key={`type-link-${elementType.name}`}>
-          {elementType.name}
-          {type === 'array' && '[]'}
-        </Link>
-      );
-    }
-    if (type === 'array') {
-      return elementType.name + '[]';
+      return renderWithLink(elementType.name, type);
     }
     return elementType.name + type;
   } else if (type === 'union' && types?.length) {

--- a/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
+++ b/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
@@ -2,7 +2,13 @@
 
 exports[`APISectionUtils.resolveTypeName Promise 1`] = `
 <div>
-  Promise
+  <a
+    class="css-12zqqiz-STYLES_EXTERNAL_LINK"
+    href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
+    rel="noopener noreferrer"
+  >
+    Promise
+  </a>
   &lt;
   <span>
     void
@@ -13,7 +19,13 @@ exports[`APISectionUtils.resolveTypeName Promise 1`] = `
 
 exports[`APISectionUtils.resolveTypeName Promise with custom type 1`] = `
 <div>
-  Promise
+  <a
+    class="css-12zqqiz-STYLES_EXTERNAL_LINK"
+    href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
+    rel="noopener noreferrer"
+  >
+    Promise
+  </a>
   &lt;
   <span>
     <a
@@ -141,7 +153,13 @@ exports[`APISectionUtils.resolveTypeName function with arguments 1`] = `
   <span>
     error
     : 
-    Error
+    <a
+      class="css-12zqqiz-STYLES_EXTERNAL_LINK"
+      href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error"
+      rel="noopener noreferrer"
+    >
+      Error
+    </a>
   </span>
   ) 
   =&gt;
@@ -167,7 +185,13 @@ exports[`APISectionUtils.resolveTypeName function with non-linkable custom type 
   <span>
     error
     : 
-    Error
+    <a
+      class="css-12zqqiz-STYLES_EXTERNAL_LINK"
+      href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error"
+      rel="noopener noreferrer"
+    >
+      Error
+    </a>
   </span>
   ) 
   =&gt;
@@ -205,7 +229,13 @@ exports[`APISectionUtils.resolveTypeName generic type 2`] = `
 
 exports[`APISectionUtils.resolveTypeName generic type in Promise 1`] = `
 <div>
-  Promise
+  <a
+    class="css-12zqqiz-STYLES_EXTERNAL_LINK"
+    href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
+    rel="noopener noreferrer"
+  >
+    Promise
+  </a>
   &lt;
   <span>
     <a
@@ -251,7 +281,12 @@ exports[`APISectionUtils.resolveTypeName props with multiple omits 1`] = `
     Omit
     &lt;
     <span>
-      ViewStyle
+      <a
+        class="css-12zqqiz-STYLES_EXTERNAL_LINK"
+        href="/react-native/view-style-props"
+      >
+        ViewStyle
+      </a>
       , 
     </span>
     <span>


### PR DESCRIPTION
# Why

There were few types marked as non-linkable, because automatically generated links were invalid.

# How

In this small PR I have extracted to the separate method and generalized a bit more the links rendering mechanism, which now allows to hardcode links for certain types.

I'm not sure if linking JS global objects to MDN docs is a good idea, looking for feedback on that. 🙂 

# Test Plan

The changes has been tested by running docs website on `localhost`. The test snapshots has to be updated to reflect the changes to rendering logic.