### PR TITLE
[ios] Migrate expo-file-system to use expo-modules-core

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -76,7 +76,6 @@ PODS:
     - UMCore
   - EXFileSystem (11.1.0):
     - ExpoModulesCore
-    - UMCore
   - EXFirebaseAnalytics (4.1.0):
     - EXFirebaseCore
     - Firebase/Core (= 7.7.0)
@@ -1165,7 +1164,7 @@ SPEC CHECKSUMS:
   EXErrorRecovery: 404d827bc7d42f306c062d58a60b06afc4d082b3
   EXFacebook: 71cc9f6b6bbdf0bc702d65c287f23cab14cc6430
   EXFaceDetector: e0908fe9700ed402a9658975a3eac719479b5205
-  EXFileSystem: 7cda0bbbdf6695c51c0e693799c6d54c04b53c94
+  EXFileSystem: 9a77e33ba77e8b1ffbbe0625a211e3abee6f69ab
   EXFirebaseAnalytics: ca01838167729b67f838a673e4b3e0637faec118
   EXFirebaseCore: 9b5380fd62fce3c790fa1d6727a8d7cbbef4f0fb
   EXFont: 6e7d5a7a09fbd0ee801de76601b2e620c4d2f575

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1852,7 +1852,6 @@ PODS:
     - UMCore
   - EXFileSystem (11.1.0):
     - ExpoModulesCore
-    - UMCore
   - EXFirebaseAnalytics (4.1.0):
     - EXFirebaseCore
     - Firebase/Core (= 7.7.0)
@@ -4042,7 +4041,7 @@ SPEC CHECKSUMS:
   EXErrorRecovery: 404d827bc7d42f306c062d58a60b06afc4d082b3
   EXFacebook: 71cc9f6b6bbdf0bc702d65c287f23cab14cc6430
   EXFaceDetector: e0908fe9700ed402a9658975a3eac719479b5205
-  EXFileSystem: 7cda0bbbdf6695c51c0e693799c6d54c04b53c94
+  EXFileSystem: 9a77e33ba77e8b1ffbbe0625a211e3abee6f69ab
   EXFirebaseAnalytics: ca01838167729b67f838a673e4b3e0637faec118
   EXFirebaseCore: 9b5380fd62fce3c790fa1d6727a8d7cbbef4f0fb
   EXFont: 6e7d5a7a09fbd0ee801de76601b2e620c4d2f575

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### 💡 Others
 
-- Migrated from `@unimodules/core` to `expo-modules-core`.
+- Migrated from `@unimodules/core` to `expo-modules-core`. ([#13749](https://github.com/expo/expo/pull/13749) by [@tsapeta](https://github.com/tsapeta))
 
 ## 11.1.0 — 2021-06-16
 

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- Migrated from `@unimodules/core` to `expo-modules-core`.
+
 ## 11.1.0 — 2021-06-16
 
 ### 🐛 Bug fixes

--- a/packages/expo-file-system/ios/EXFileSystem.podspec
+++ b/packages/expo-file-system/ios/EXFileSystem.podspec
@@ -13,7 +13,6 @@ Pod::Spec.new do |s|
   s.platform       = :ios, '11.0'
   s.source         = { :git => 'https://github.com/expo/expo.git' }
 
-  s.dependency 'UMCore'
   s.dependency 'ExpoModulesCore'
 
   if !$ExpoUseSources&.include?(package['name']) && ENV['EXPO_USE_SOURCE'].to_i == 0 && File.exist?("#{s.name}.xcframework") && Gem::Version.new(Pod::VERSION) >= Gem::Version.new('1.10.0')

--- a/packages/expo-file-system/ios/EXFileSystem/EXFilePermissionModule.h
+++ b/packages/expo-file-system/ios/EXFileSystem/EXFilePermissionModule.h
@@ -2,12 +2,12 @@
 
 #import <Foundation/Foundation.h>
 #import <ExpoModulesCore/EXFilePermissionModuleInterface.h>
-#import <UMCore/UMInternalModule.h>
-#import <UMCore/UMModuleRegistryConsumer.h>
+#import <ExpoModulesCore/EXInternalModule.h>
+#import <ExpoModulesCore/EXModuleRegistryConsumer.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface EXFilePermissionModule : NSObject <UMInternalModule, EXFilePermissionModuleInterface, UMModuleRegistryConsumer>
+@interface EXFilePermissionModule : NSObject <EXInternalModule, EXFilePermissionModuleInterface, EXModuleRegistryConsumer>
 
 - (EXFileSystemPermissionFlags)getPathPermissions:(NSString *)path;
 

--- a/packages/expo-file-system/ios/EXFileSystem/EXFilePermissionModule.m
+++ b/packages/expo-file-system/ios/EXFileSystem/EXFilePermissionModule.m
@@ -4,13 +4,13 @@
 
 @interface EXFilePermissionModule ()
 
-@property (nonatomic, weak) UMModuleRegistry *moduleRegistry;
+@property (nonatomic, weak) EXModuleRegistry *moduleRegistry;
 
 @end
 
 @implementation EXFilePermissionModule
 
-UM_REGISTER_MODULE();
+EX_REGISTER_MODULE();
 
 + (const NSArray<Protocol *> *)exportedInterfaces
 {
@@ -61,7 +61,7 @@ UM_REGISTER_MODULE();
   return filePermissions;
 }
 
-- (void)setModuleRegistry:(UMModuleRegistry *)moduleRegistry {
+- (void)setModuleRegistry:(EXModuleRegistry *)moduleRegistry {
   _moduleRegistry = moduleRegistry;
 }
 

--- a/packages/expo-file-system/ios/EXFileSystem/EXFileSystem.h
+++ b/packages/expo-file-system/ios/EXFileSystem/EXFileSystem.h
@@ -1,12 +1,12 @@
 // Copyright 2016-present 650 Industries. All rights reserved.
 
 #import <Foundation/Foundation.h>
-#import <UMCore/UMExportedModule.h>
-#import <UMCore/UMModuleRegistryConsumer.h>
-#import <UMCore/UMEventEmitter.h>
+#import <ExpoModulesCore/EXExportedModule.h>
+#import <ExpoModulesCore/EXModuleRegistryConsumer.h>
+#import <ExpoModulesCore/EXEventEmitter.h>
 #import <ExpoModulesCore/EXFileSystemInterface.h>
 
-@interface EXFileSystem : UMExportedModule <UMEventEmitter, UMModuleRegistryConsumer, EXFileSystemInterface>
+@interface EXFileSystem : EXExportedModule <EXEventEmitter, EXModuleRegistryConsumer, EXFileSystemInterface>
 
 @property (nonatomic, readonly) NSString *documentDirectory;
 @property (nonatomic, readonly) NSString *cachesDirectory;
@@ -26,13 +26,13 @@
 
 + (void)getInfoForFile:(NSURL *)fileUri
            withOptions:(NSDictionary *)optionxs
-              resolver:(UMPromiseResolveBlock)resolve
-              rejecter:(UMPromiseRejectBlock)reject;
+              resolver:(EXPromiseResolveBlock)resolve
+              rejecter:(EXPromiseRejectBlock)reject;
 
 + (void)copyFrom:(NSURL *)from
               to:(NSURL *)to
-        resolver:(UMPromiseResolveBlock)resolve
-        rejecter:(UMPromiseRejectBlock)reject;
+        resolver:(EXPromiseResolveBlock)resolve
+        rejecter:(EXPromiseRejectBlock)reject;
 
 @end
 

--- a/packages/expo-file-system/ios/EXFileSystem/EXFileSystem.m
+++ b/packages/expo-file-system/ios/EXFileSystem/EXFileSystem.m
@@ -1,6 +1,6 @@
 // Copyright 2016-present 650 Industries. All rights reserved.
 
-#import <UMCore/UMModuleRegistry.h>
+#import <ExpoModulesCore/EXModuleRegistry.h>
 
 #import <EXFileSystem/EXFileSystem.h>
 
@@ -13,7 +13,7 @@
 #import <ExpoModulesCore/EXFileSystemInterface.h>
 #import <ExpoModulesCore/EXFilePermissionModuleInterface.h>
 
-#import <UMCore/UMEventEmitterService.h>
+#import <ExpoModulesCore/EXEventEmitterService.h>
 
 #import <EXFileSystem/EXResumablesManager.h>
 #import <EXFileSystem/EXSessionTaskDispatcher.h>
@@ -40,8 +40,8 @@ typedef NS_ENUM(NSInteger, EXFileSystemUploadType) {
 @property (nonatomic, strong) NSURLSession *foregroundSession;
 @property (nonatomic, strong) EXSessionTaskDispatcher *sessionTaskDispatcher;
 @property (nonatomic, strong) EXResumablesManager *resumableManager;
-@property (nonatomic, weak) UMModuleRegistry *moduleRegistry;
-@property (nonatomic, weak) id<UMEventEmitterService> eventEmitter;
+@property (nonatomic, weak) EXModuleRegistry *moduleRegistry;
+@property (nonatomic, weak) id<EXEventEmitterService> eventEmitter;
 @property (nonatomic, strong) NSString *documentDirectory;
 @property (nonatomic, strong) NSString *cachesDirectory;
 @property (nonatomic, strong) NSString *bundleDirectory;
@@ -50,7 +50,7 @@ typedef NS_ENUM(NSInteger, EXFileSystemUploadType) {
 
 @implementation EXFileSystem
 
-UM_REGISTER_MODULE();
+EX_REGISTER_MODULE();
 
 + (const NSString *)exportedModuleName
 {
@@ -90,10 +90,10 @@ UM_REGISTER_MODULE();
                          bundleDirectory:[NSBundle mainBundle].bundlePath];
 }
 
-- (void)setModuleRegistry:(UMModuleRegistry *)moduleRegistry
+- (void)setModuleRegistry:(EXModuleRegistry *)moduleRegistry
 {
   _moduleRegistry = moduleRegistry;
-  _eventEmitter = [_moduleRegistry getModuleImplementingProtocol:@protocol(UMEventEmitterService)];
+  _eventEmitter = [_moduleRegistry getModuleImplementingProtocol:@protocol(EXEventEmitterService)];
   
   _sessionTaskDispatcher = [[EXSessionTaskDispatcher alloc] initWithSessionHandler:[moduleRegistry getSingletonModuleForName:@"SessionHandler"]];
   _backgroundSession = [self _createSession:EXFileSystemBackgroundSession delegate:_sessionTaskDispatcher];
@@ -171,11 +171,11 @@ UM_REGISTER_MODULE();
            };
 }
 
-UM_EXPORT_METHOD_AS(getInfoAsync,
+EX_EXPORT_METHOD_AS(getInfoAsync,
                     getInfoAsyncWithURI:(NSString *)uriString
                     withOptions:(NSDictionary *)options
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   NSURL *uri = [NSURL URLWithString:uriString];
   // no scheme provided in uri, handle as a local path and add 'file://' scheme
@@ -200,11 +200,11 @@ UM_EXPORT_METHOD_AS(getInfoAsync,
   }
 }
 
-UM_EXPORT_METHOD_AS(readAsStringAsync,
+EX_EXPORT_METHOD_AS(readAsStringAsync,
                     readAsStringAsyncWithURI:(NSString *)uriString
                     withOptions:(NSDictionary *)options
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   NSURL *uri = [NSURL URLWithString:uriString];
   // no scheme provided in uri, handle as a local path and add 'file://' scheme
@@ -266,12 +266,12 @@ UM_EXPORT_METHOD_AS(readAsStringAsync,
   }
 }
 
-UM_EXPORT_METHOD_AS(writeAsStringAsync,
+EX_EXPORT_METHOD_AS(writeAsStringAsync,
                     writeAsStringAsyncWithURI:(NSString *)uriString
                     withString:(NSString *)string
                     withOptions:(NSDictionary *)options
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   NSURL *uri = [NSURL URLWithString:uriString];
   if (!([self permissionsForURI:uri] & EXFileSystemPermissionWrite)) {
@@ -327,11 +327,11 @@ UM_EXPORT_METHOD_AS(writeAsStringAsync,
   }
 }
 
-UM_EXPORT_METHOD_AS(deleteAsync,
+EX_EXPORT_METHOD_AS(deleteAsync,
                     deleteAsyncWithURI:(NSString *)uriString
                     withOptions:(NSDictionary *)options
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   NSURL *uri = [NSURL URLWithString:uriString];
   if (!([self permissionsForURI:[uri URLByAppendingPathComponent:@".."]] & EXFileSystemPermissionWrite)) {
@@ -368,10 +368,10 @@ UM_EXPORT_METHOD_AS(deleteAsync,
   }
 }
 
-UM_EXPORT_METHOD_AS(moveAsync,
+EX_EXPORT_METHOD_AS(moveAsync,
                     moveAsyncWithOptions:(NSDictionary *)options
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   NSURL *from = [NSURL URLWithString:options[@"from"]];
   if (!from) {
@@ -424,10 +424,10 @@ UM_EXPORT_METHOD_AS(moveAsync,
   }
 }
 
-UM_EXPORT_METHOD_AS(copyAsync,
+EX_EXPORT_METHOD_AS(copyAsync,
                     copyAsyncWithOptions:(NSDictionary *)options
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   NSURL *from = [NSURL URLWithString:options[@"from"]];
   if (!from) {
@@ -463,11 +463,11 @@ UM_EXPORT_METHOD_AS(copyAsync,
   }
 }
 
-UM_EXPORT_METHOD_AS(makeDirectoryAsync,
+EX_EXPORT_METHOD_AS(makeDirectoryAsync,
                     makeDirectoryAsyncWithURI:(NSString *)uriString
                     withOptions:(NSDictionary *)options
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   
   NSURL *uri = [NSURL URLWithString:uriString];
@@ -497,11 +497,11 @@ UM_EXPORT_METHOD_AS(makeDirectoryAsync,
   }
 }
 
-UM_EXPORT_METHOD_AS(readDirectoryAsync,
+EX_EXPORT_METHOD_AS(readDirectoryAsync,
                     readDirectoryAsyncWithURI:(NSString *)uriString
                     withOptions:(NSDictionary *)options
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   NSURL *uri = [NSURL URLWithString:uriString];
   if (!([self permissionsForURI:uri] & EXFileSystemPermissionRead)) {
@@ -528,12 +528,12 @@ UM_EXPORT_METHOD_AS(readDirectoryAsync,
   }
 }
 
-UM_EXPORT_METHOD_AS(downloadAsync,
+EX_EXPORT_METHOD_AS(downloadAsync,
                     downloadAsyncWithUrl:(NSString *)urlString
                                 localURI:(NSString *)localUriString
                                  options:(NSDictionary *)options
-                                resolver:(UMPromiseResolveBlock)resolve
-                                rejecter:(UMPromiseRejectBlock)reject)
+                                resolver:(EXPromiseResolveBlock)resolve
+                                rejecter:(EXPromiseRejectBlock)reject)
 {
   NSURL *url = [NSURL URLWithString:urlString];
   NSURL *localUri = [NSURL URLWithString:localUriString];
@@ -574,12 +574,12 @@ UM_EXPORT_METHOD_AS(downloadAsync,
   [task resume];
 }
 
-UM_EXPORT_METHOD_AS(uploadAsync,
+EX_EXPORT_METHOD_AS(uploadAsync,
                     uploadAsync:(NSString *)urlString
                        localURI:(NSString *)fileUriString
                         options:(NSDictionary *)options
-                       resolver:(UMPromiseResolveBlock)resolve
-                       rejecter:(UMPromiseRejectBlock)reject)
+                       resolver:(EXPromiseResolveBlock)resolve
+                       rejecter:(EXPromiseRejectBlock)reject)
 {
   NSURL *fileUri = [NSURL URLWithString:fileUriString];
   NSString *httpMethod = options[@"httpMethod"];
@@ -642,14 +642,14 @@ UM_EXPORT_METHOD_AS(uploadAsync,
   [task resume];
 }
 
-UM_EXPORT_METHOD_AS(downloadResumableStartAsync,
+EX_EXPORT_METHOD_AS(downloadResumableStartAsync,
                     downloadResumableStartAsyncWithUrl:(NSString *)urlString
                                                fileURI:(NSString *)fileUri
                                                   uuid:(NSString *)uuid
                                                options:(NSDictionary *)options
                                             resumeData:(NSString *)data
-                                              resolver:(UMPromiseResolveBlock)resolve
-                                              rejecter:(UMPromiseRejectBlock)reject)
+                                              resolver:(EXPromiseResolveBlock)resolve
+                                              rejecter:(EXPromiseRejectBlock)reject)
 {
   NSURL *url = [NSURL URLWithString:urlString];
   NSURL *localUrl = [NSURL URLWithString:fileUri];
@@ -691,10 +691,10 @@ UM_EXPORT_METHOD_AS(downloadResumableStartAsync,
                                         reject:reject];
 }
 
-UM_EXPORT_METHOD_AS(downloadResumablePauseAsync,
+EX_EXPORT_METHOD_AS(downloadResumablePauseAsync,
                     downloadResumablePauseAsyncWithUUID:(NSString *)uuid
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   NSURLSessionDownloadTask *task = [_resumableManager taskForId:uuid];
   if (!task) {
@@ -704,14 +704,14 @@ UM_EXPORT_METHOD_AS(downloadResumablePauseAsync,
     return;
   }
   
-  UM_WEAKIFY(self);
+  EX_WEAKIFY(self);
   [task cancelByProducingResumeData:^(NSData * _Nullable resumeData) {
-    UM_ENSURE_STRONGIFY(self);
-    resolve(@{ @"resumeData": UMNullIfNil([resumeData base64EncodedStringWithOptions:0]) });
+    EX_ENSURE_STRONGIFY(self);
+    resolve(@{ @"resumeData": EXNullIfNil([resumeData base64EncodedStringWithOptions:0]) });
   }];
 }
 
-UM_EXPORT_METHOD_AS(getFreeDiskStorageAsync, getFreeDiskStorageAsyncWithResolver:(UMPromiseResolveBlock)resolve rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(getFreeDiskStorageAsync, getFreeDiskStorageAsyncWithResolver:(EXPromiseResolveBlock)resolve rejecter:(EXPromiseRejectBlock)reject)
 {
   if(![self freeDiskStorage]) {
     reject(@"ERR_FILESYSTEM_CANNOT_DETERMINE_DISK_CAPACITY", @"Unable to determine free disk storage capacity", nil);
@@ -720,7 +720,7 @@ UM_EXPORT_METHOD_AS(getFreeDiskStorageAsync, getFreeDiskStorageAsyncWithResolver
   }
 }
 
-UM_EXPORT_METHOD_AS(getTotalDiskCapacityAsync, getTotalDiskCapacityAsyncWithResolver:(UMPromiseResolveBlock)resolve rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(getTotalDiskCapacityAsync, getTotalDiskCapacityAsyncWithResolver:(EXPromiseResolveBlock)resolve rejecter:(EXPromiseRejectBlock)reject)
 {
   if(![self totalDiskCapacity]) {
     reject(@"ERR_FILESYSTEM_CANNOT_DETERMINE_DISK_CAPACITY", @"Unable to determine total disk capacity", nil);
@@ -844,12 +844,12 @@ UM_EXPORT_METHOD_AS(getTotalDiskCapacityAsync, getTotalDiskCapacityAsyncWithReso
                                           uuid:(NSString *)uuid
                                         optins:(NSDictionary *)options
                                     resumeData:(NSData * _Nullable)resumeData
-                                       resolve:(UMPromiseResolveBlock)resolve
-                                        reject:(UMPromiseRejectBlock)reject
+                                       resolve:(EXPromiseResolveBlock)resolve
+                                        reject:(EXPromiseRejectBlock)reject
 {
-  UM_WEAKIFY(self);
+  EX_WEAKIFY(self);
   EXDownloadDelegateOnWriteCallback onWrite = ^(NSURLSessionDownloadTask *task, int64_t bytesWritten, int64_t totalBytesWritten, int64_t totalBytesExpectedToWrite) {
-    UM_ENSURE_STRONGIFY(self);
+    EX_ENSURE_STRONGIFY(self);
     [self sendEventWithName:EXDownloadProgressEventName
                        body:@{
                              @"uuid": uuid,

--- a/packages/expo-file-system/ios/EXFileSystem/EXFileSystemAssetLibraryHandler.m
+++ b/packages/expo-file-system/ios/EXFileSystem/EXFileSystemAssetLibraryHandler.m
@@ -7,8 +7,8 @@
 
 + (void)getInfoForFile:(NSURL *)fileUri
            withOptions:(NSDictionary *)options
-              resolver:(UMPromiseResolveBlock)resolve
-              rejecter:(UMPromiseRejectBlock)reject
+              resolver:(EXPromiseResolveBlock)resolve
+              rejecter:(EXPromiseRejectBlock)reject
 {
   NSError *error;
   PHFetchResult<PHAsset *> *fetchResult = [self fetchResultForUri:fileUri error:&error];
@@ -41,8 +41,8 @@
 
 + (void)copyFrom:(NSURL *)from
               to:(NSURL *)to
-        resolver:(UMPromiseResolveBlock)resolve
-        rejecter:(UMPromiseRejectBlock)reject
+        resolver:(EXPromiseResolveBlock)resolve
+        rejecter:(EXPromiseRejectBlock)reject
 {
   NSString *toPath = [to.path stringByStandardizingPath];
   
@@ -126,8 +126,8 @@
 
 + (void)copyData:(NSData *)data
           toPath:(NSString *)path
-        resolver:(UMPromiseResolveBlock)resolve
-        rejecter:(UMPromiseRejectBlock)reject
+        resolver:(EXPromiseResolveBlock)resolve
+        rejecter:(EXPromiseRejectBlock)reject
 {
   if ([data writeToFile:path atomically:YES]) {
     resolve(nil);

--- a/packages/expo-file-system/ios/EXFileSystem/EXFileSystemLocalFileHandler.m
+++ b/packages/expo-file-system/ios/EXFileSystem/EXFileSystemLocalFileHandler.m
@@ -5,8 +5,8 @@
 
 + (void)getInfoForFile:(NSURL *)fileUri
            withOptions:(NSDictionary *)options
-              resolver:(UMPromiseResolveBlock)resolve
-              rejecter:(UMPromiseRejectBlock)reject
+              resolver:(EXPromiseResolveBlock)resolve
+              rejecter:(EXPromiseRejectBlock)reject
 {
   NSString *path = fileUri.path;
   BOOL isDirectory;
@@ -49,8 +49,8 @@
 
 + (void)copyFrom:(NSURL *)from
               to:(NSURL *)to
-        resolver:(UMPromiseResolveBlock)resolve
-        rejecter:(UMPromiseRejectBlock)reject
+        resolver:(EXPromiseResolveBlock)resolve
+        rejecter:(EXPromiseRejectBlock)reject
 {
   NSString *fromPath = [from.path stringByStandardizingPath];
   NSString *toPath = [to.path stringByStandardizingPath];

--- a/packages/expo-file-system/ios/EXFileSystem/EXSessionTasks/EXSessionDownloadTaskDelegate.h
+++ b/packages/expo-file-system/ios/EXFileSystem/EXSessionTasks/EXSessionDownloadTaskDelegate.h
@@ -4,8 +4,8 @@
 
 @interface EXSessionDownloadTaskDelegate : EXSessionTaskDelegate
 
-- (instancetype)initWithResolve:(UMPromiseResolveBlock)resolve
-                         reject:(UMPromiseRejectBlock)reject
+- (instancetype)initWithResolve:(EXPromiseResolveBlock)resolve
+                         reject:(EXPromiseRejectBlock)reject
                        localUrl:(NSURL *)localUrl
              shouldCalculateMd5:(BOOL)shouldCalculateMd5;
 

--- a/packages/expo-file-system/ios/EXFileSystem/EXSessionTasks/EXSessionDownloadTaskDelegate.m
+++ b/packages/expo-file-system/ios/EXFileSystem/EXSessionTasks/EXSessionDownloadTaskDelegate.m
@@ -12,8 +12,8 @@
 
 @implementation EXSessionDownloadTaskDelegate
 
-- (instancetype)initWithResolve:(UMPromiseResolveBlock)resolve
-                         reject:(UMPromiseRejectBlock)reject
+- (instancetype)initWithResolve:(EXPromiseResolveBlock)resolve
+                         reject:(EXPromiseRejectBlock)reject
                        localUrl:(NSURL *)localUrl
              shouldCalculateMd5:(BOOL)shouldCalculateMd5
 {

--- a/packages/expo-file-system/ios/EXFileSystem/EXSessionTasks/EXSessionHandler.h
+++ b/packages/expo-file-system/ios/EXFileSystem/EXSessionTasks/EXSessionHandler.h
@@ -1,7 +1,7 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
 #import <Foundation/Foundation.h>
-#import <UMCore/UMSingletonModule.h>
+#import <ExpoModulesCore/EXSingletonModule.h>
 #import <UIKit/UIKit.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -12,7 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@interface EXSessionHandler : UMSingletonModule <UIApplicationDelegate, EXSessionHandler>
+@interface EXSessionHandler : EXSingletonModule <UIApplicationDelegate, EXSessionHandler>
 
 @end
 

--- a/packages/expo-file-system/ios/EXFileSystem/EXSessionTasks/EXSessionHandler.m
+++ b/packages/expo-file-system/ios/EXFileSystem/EXSessionTasks/EXSessionHandler.m
@@ -2,7 +2,7 @@
 
 #import <EXFileSystem/EXSessionHandler.h>
 
-#import <UMCore/UMDefines.h>
+#import <ExpoModulesCore/EXDefines.h>
 
 @interface EXSessionHandler ()
 
@@ -12,7 +12,7 @@
 
 @implementation EXSessionHandler
 
-UM_REGISTER_SINGLETON_MODULE(SessionHandler);
+EX_REGISTER_SINGLETON_MODULE(SessionHandler);
 
 - (instancetype)init
 {

--- a/packages/expo-file-system/ios/EXFileSystem/EXSessionTasks/EXSessionResumableDownloadTaskDelegate.h
+++ b/packages/expo-file-system/ios/EXFileSystem/EXSessionTasks/EXSessionResumableDownloadTaskDelegate.h
@@ -7,8 +7,8 @@ typedef void (^EXDownloadDelegateOnWriteCallback)(NSURLSessionDownloadTask *task
 
 @interface EXSessionResumableDownloadTaskDelegate : EXSessionDownloadTaskDelegate
 
-- (instancetype)initWithResolve:(UMPromiseResolveBlock)resolve
-                         reject:(UMPromiseRejectBlock)reject
+- (instancetype)initWithResolve:(EXPromiseResolveBlock)resolve
+                         reject:(EXPromiseRejectBlock)reject
                        localUrl:(NSURL *)localUrl
              shouldCalculateMd5:(BOOL)shouldCalculateMd5
                 onWriteCallback:(EXDownloadDelegateOnWriteCallback)onWriteCallback

--- a/packages/expo-file-system/ios/EXFileSystem/EXSessionTasks/EXSessionResumableDownloadTaskDelegate.m
+++ b/packages/expo-file-system/ios/EXFileSystem/EXSessionTasks/EXSessionResumableDownloadTaskDelegate.m
@@ -12,8 +12,8 @@
 
 @implementation EXSessionResumableDownloadTaskDelegate
 
-- (instancetype)initWithResolve:(UMPromiseResolveBlock)resolve
-                         reject:(UMPromiseRejectBlock)reject
+- (instancetype)initWithResolve:(EXPromiseResolveBlock)resolve
+                         reject:(EXPromiseRejectBlock)reject
                        localUrl:(NSURL *)localUrl
              shouldCalculateMd5:(BOOL)shouldCalculateMd5
                 onWriteCallback:(EXDownloadDelegateOnWriteCallback)onWriteCallback

--- a/packages/expo-file-system/ios/EXFileSystem/EXSessionTasks/EXSessionTaskDelegate.h
+++ b/packages/expo-file-system/ios/EXFileSystem/EXSessionTasks/EXSessionTaskDelegate.h
@@ -1,15 +1,15 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
 #import <Foundation/Foundation.h>
-#import <UMCore/UMDefines.h>
+#import <ExpoModulesCore/EXDefines.h>
 
 @interface EXSessionTaskDelegate : NSObject
 
-@property (nonatomic, strong, readonly) UMPromiseResolveBlock resolve;
-@property (nonatomic, strong, readonly) UMPromiseRejectBlock reject;
+@property (nonatomic, strong, readonly) EXPromiseResolveBlock resolve;
+@property (nonatomic, strong, readonly) EXPromiseRejectBlock reject;
 
-- (instancetype)initWithResolve:(UMPromiseResolveBlock)resolve
-                         reject:(UMPromiseRejectBlock)reject;
+- (instancetype)initWithResolve:(EXPromiseResolveBlock)resolve
+                         reject:(EXPromiseRejectBlock)reject;
 
 - (void)URLSession:(NSURLSession *)session downloadTask:(NSURLSessionDownloadTask *)downloadTask didFinishDownloadingToURL:(NSURL *)location;
 

--- a/packages/expo-file-system/ios/EXFileSystem/EXSessionTasks/EXSessionTaskDelegate.m
+++ b/packages/expo-file-system/ios/EXFileSystem/EXSessionTasks/EXSessionTaskDelegate.m
@@ -4,8 +4,8 @@
 
 @implementation EXSessionTaskDelegate
 
-- (instancetype)initWithResolve:(UMPromiseResolveBlock)resolve
-                         reject:(UMPromiseRejectBlock)reject
+- (instancetype)initWithResolve:(EXPromiseResolveBlock)resolve
+                         reject:(EXPromiseRejectBlock)reject
 {
   if (self = [super init]) {
     _resolve = resolve;
@@ -29,7 +29,7 @@
   return @{
     @"status": @([httpResponse statusCode]),
     @"headers": [httpResponse allHeaderFields],
-    @"mimeType": UMNullIfNil([httpResponse MIMEType])
+    @"mimeType": EXNullIfNil([httpResponse MIMEType])
   };
 }
 

--- a/packages/expo-file-system/ios/EXFileSystem/EXSessionTasks/EXSessionUploadTaskDelegate.m
+++ b/packages/expo-file-system/ios/EXFileSystem/EXSessionTasks/EXSessionUploadTaskDelegate.m
@@ -10,7 +10,7 @@
 
 @implementation EXSessionUploadTaskDelegate
 
-- (instancetype)initWithResolve:(UMPromiseResolveBlock)resolve reject:(UMPromiseRejectBlock)reject
+- (instancetype)initWithResolve:(EXPromiseResolveBlock)resolve reject:(EXPromiseRejectBlock)reject
 {
   if (self = [super initWithResolve:resolve reject:reject]) {
     _responseData = [NSMutableData new];
@@ -45,7 +45,7 @@
 {
   NSMutableDictionary *result = [[super parseServerResponse:response] mutableCopy];
   // TODO: add support for others response types (different encodings, files)
-  result[@"body"] = UMNullIfNil([[NSString alloc] initWithData:_responseData encoding:NSUTF8StringEncoding]);
+  result[@"body"] = EXNullIfNil([[NSString alloc] initWithData:_responseData encoding:NSUTF8StringEncoding]);
   return result;
 }
 


### PR DESCRIPTION
# Why

`UMCore` is now deprecated in favor of `ExpoModulesCore`

# How

- Removed the dependency on `UMCore`
- Renamed imports and all references

# Test Plan

Examples seem to work as expected
