### PR TITLE
[ios] Migrate expo-camera to use expo-modules-core

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -42,7 +42,6 @@ PODS:
     - UMCore
   - EXCamera (11.1.1):
     - ExpoModulesCore
-    - UMCore
   - EXCellular (3.2.0):
     - ExpoModulesCore
   - EXClipboard (1.1.0):
@@ -1154,7 +1153,7 @@ SPEC CHECKSUMS:
   EXBlur: 50d490040f3b14898ed8198d5125dc699189f4d9
   EXBrightness: b0eb62f204669cd7ae926847794b5bfabd595a4f
   EXCalendar: 64807f071c86ef3d9813fec49f55c38d5854c235
-  EXCamera: 5a90a462cd0965bbf5e5ddb725115ac5109869e9
+  EXCamera: d39ee631cecae1722c12a0b5fe4651a09b262863
   EXCellular: 73ab436dd57f6b79ce5d6d542f930fc790dac19c
   EXClipboard: c66f7d22ba754496b0fc6b23a2cb9a3e10fa1581
   EXConstants: 0c200d22d140d3f1834dc51c4ebe0465ddaa82c5

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1818,7 +1818,6 @@ PODS:
     - UMCore
   - EXCamera (11.1.1):
     - ExpoModulesCore
-    - UMCore
   - EXCellular (3.2.0):
     - ExpoModulesCore
   - EXClipboard (1.1.0):
@@ -4031,7 +4030,7 @@ SPEC CHECKSUMS:
   EXBranch: 9c65961edddfb785cc26d8642f8f50e7e3c2e5ad
   EXBrightness: b0eb62f204669cd7ae926847794b5bfabd595a4f
   EXCalendar: 64807f071c86ef3d9813fec49f55c38d5854c235
-  EXCamera: 5a90a462cd0965bbf5e5ddb725115ac5109869e9
+  EXCamera: d39ee631cecae1722c12a0b5fe4651a09b262863
   EXCellular: c023099c6d53230d69c03a0ed0b515fbf2ffc5eb
   EXClipboard: c66f7d22ba754496b0fc6b23a2cb9a3e10fa1581
   EXConstants: 0c200d22d140d3f1834dc51c4ebe0465ddaa82c5

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -13,8 +13,9 @@
 - Fix regression in video quality option of recordAsync() ([#13659](https://github.com/expo/expo/pull/13659) by [@ajsmth](https://github.com/ajsmth))
 - Update permission validation to check for only camera permissions in `initWithModuleRegistry()` ([#13690](https://github.com/expo/expo/pull/13690) by [@ajsmth](https://github.com/ajsmth))
 
-
 ### 💡 Others
+
+- Migrated from `@unimodules/core` to `expo-modules-core`.
 
 ## 11.1.1 — 2021-06-16
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ### 💡 Others
 
-- Migrated from `@unimodules/core` to `expo-modules-core`.
+- Migrated from `@unimodules/core` to `expo-modules-core`. ([#13750](https://github.com/expo/expo/pull/13750) by [@tsapeta](https://github.com/tsapeta))
 
 ## 11.1.1 — 2021-06-16
 

--- a/packages/expo-camera/ios/EXCamera.podspec
+++ b/packages/expo-camera/ios/EXCamera.podspec
@@ -13,7 +13,6 @@ Pod::Spec.new do |s|
   s.platform       = :ios, '11.0'
   s.source         = { :git => "https://github.com/expo/expo.git" }
 
-  s.dependency 'UMCore'
   s.dependency 'ExpoModulesCore'
 
   if !$ExpoUseSources&.include?(package['name']) && ENV['EXPO_USE_SOURCE'].to_i == 0 && File.exist?("#{s.name}.xcframework") && Gem::Version.new(Pod::VERSION) >= Gem::Version.new('1.10.0')

--- a/packages/expo-camera/ios/EXCamera/EXCamera.h
+++ b/packages/expo-camera/ios/EXCamera/EXCamera.h
@@ -1,8 +1,8 @@
 #import <AVFoundation/AVFoundation.h>
 #import <UIKit/UIKit.h>
 #import <EXCamera/EXCameraManager.h>
-#import <UMCore/UMModuleRegistry.h>
-#import <UMCore/UMAppLifecycleListener.h>
+#import <ExpoModulesCore/EXModuleRegistry.h>
+#import <ExpoModulesCore/EXAppLifecycleListener.h>
 #import <ExpoModulesCore/EXCameraInterface.h>
 
 @class EXCameraManager;
@@ -64,7 +64,7 @@ typedef NS_ENUM(NSInteger, EXCameraVideoCodec) {
   EXCameraVideoCodecAppleProRes4444 = 4,
 };
 
-@interface EXCamera : UIView <AVCaptureMetadataOutputObjectsDelegate, AVCaptureFileOutputRecordingDelegate, UMAppLifecycleListener, EXCameraInterface, AVCapturePhotoCaptureDelegate>
+@interface EXCamera : UIView <AVCaptureMetadataOutputObjectsDelegate, AVCaptureFileOutputRecordingDelegate, EXAppLifecycleListener, EXCameraInterface, AVCapturePhotoCaptureDelegate>
 
 @property (nonatomic, strong) dispatch_queue_t sessionQueue;
 @property (nonatomic, strong) AVCaptureSession *session;
@@ -87,7 +87,7 @@ typedef NS_ENUM(NSInteger, EXCameraVideoCodec) {
 @property (nonatomic, assign) BOOL isDetectingFaces;
 @property (nonatomic, assign) AVVideoCodecType videoCodecType;
 
-- (id)initWithModuleRegistry:(UMModuleRegistry *)moduleRegistry;
+- (id)initWithModuleRegistry:(EXModuleRegistry *)moduleRegistry;
 - (void)updateType;
 - (void)updateFlashMode;
 - (void)updateFocusMode;
@@ -97,8 +97,8 @@ typedef NS_ENUM(NSInteger, EXCameraVideoCodec) {
 - (void)updatePictureSize;
 - (void)updateFaceDetectorSettings:(NSDictionary *)settings;
 - (void)setBarCodeScannerSettings:(NSDictionary *)settings;
-- (void)takePicture:(NSDictionary *)options resolve:(UMPromiseResolveBlock)resolve reject:(UMPromiseRejectBlock)reject;
-- (void)record:(NSDictionary *)options resolve:(UMPromiseResolveBlock)resolve reject:(UMPromiseRejectBlock)reject;
+- (void)takePicture:(NSDictionary *)options resolve:(EXPromiseResolveBlock)resolve reject:(EXPromiseRejectBlock)reject;
+- (void)record:(NSDictionary *)options resolve:(EXPromiseResolveBlock)resolve reject:(EXPromiseRejectBlock)reject;
 - (void)stopRecording;
 - (void)resumePreview;
 - (void)pausePreview;

--- a/packages/expo-camera/ios/EXCamera/EXCamera.m
+++ b/packages/expo-camera/ios/EXCamera/EXCamera.m
@@ -5,8 +5,8 @@
 #import <EXCamera/EXCameraUtils.h>
 #import <EXCamera/EXCameraManager.h>
 #import <EXCamera/EXCameraCameraPermissionRequester.h>
-#import <UMCore/UMAppLifecycleService.h>
-#import <UMCore/UMUtilities.h>
+#import <ExpoModulesCore/EXAppLifecycleService.h>
+#import <ExpoModulesCore/EXUtilities.h>
 #import <ExpoModulesCore/EXFaceDetectorManagerInterface.h>
 #import <ExpoModulesCore/EXFaceDetectorManagerProviderInterface.h>
 #import <ExpoModulesCore/EXFileSystemInterface.h>
@@ -15,28 +15,28 @@
 @interface EXCamera ()
 
 @property (nonatomic, weak) id<EXFileSystemInterface> fileSystem;
-@property (nonatomic, weak) UMModuleRegistry *moduleRegistry;
+@property (nonatomic, weak) EXModuleRegistry *moduleRegistry;
 @property (nonatomic, strong) id<EXFaceDetectorManagerInterface> faceDetectorManager;
 @property (nonatomic, strong) id<EXBarCodeScannerInterface> barCodeScanner;
 @property (nonatomic, weak) id<EXPermissionsInterface> permissionsManager;
-@property (nonatomic, weak) id<UMAppLifecycleService> lifecycleManager;
+@property (nonatomic, weak) id<EXAppLifecycleService> lifecycleManager;
 
 @property (nonatomic, assign, getter=isSessionPaused) BOOL paused;
 @property (nonatomic, assign) BOOL isValidVideoOptions;
 
 @property (nonatomic, strong) NSDictionary *photoCaptureOptions;
-@property (nonatomic, strong) UMPromiseResolveBlock photoCapturedResolve;
-@property (nonatomic, strong) UMPromiseRejectBlock photoCapturedReject;
+@property (nonatomic, strong) EXPromiseResolveBlock photoCapturedResolve;
+@property (nonatomic, strong) EXPromiseRejectBlock photoCapturedReject;
 
-@property (nonatomic, strong) UMPromiseResolveBlock videoRecordedResolve;
-@property (nonatomic, strong) UMPromiseRejectBlock videoRecordedReject;
+@property (nonatomic, strong) EXPromiseResolveBlock videoRecordedResolve;
+@property (nonatomic, strong) EXPromiseRejectBlock videoRecordedReject;
 
-@property (nonatomic, copy) UMDirectEventBlock onCameraReady;
-@property (nonatomic, copy) UMDirectEventBlock onMountError;
-@property (nonatomic, copy) UMDirectEventBlock onPictureSaved;
+@property (nonatomic, copy) EXDirectEventBlock onCameraReady;
+@property (nonatomic, copy) EXDirectEventBlock onMountError;
+@property (nonatomic, copy) EXDirectEventBlock onPictureSaved;
 
-@property (nonatomic, copy) UMDirectEventBlock onBarCodeScanned;
-@property (nonatomic, copy) UMDirectEventBlock onFacesDetected;
+@property (nonatomic, copy) EXDirectEventBlock onBarCodeScanned;
+@property (nonatomic, copy) EXDirectEventBlock onFacesDetected;
 
 @end
 
@@ -44,7 +44,7 @@
 
 static NSDictionary *defaultFaceDetectorOptions = nil;
 
-- (id)initWithModuleRegistry:(UMModuleRegistry *)moduleRegistry
+- (id)initWithModuleRegistry:(EXModuleRegistry *)moduleRegistry
 {
   if ((self = [super init])) {
     _moduleRegistry = moduleRegistry;
@@ -52,7 +52,7 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
     _sessionQueue = dispatch_queue_create("cameraQueue", DISPATCH_QUEUE_SERIAL);
     _faceDetectorManager = [self createFaceDetectorManager];
     _barCodeScanner = [self createBarCodeScanner];
-    _lifecycleManager = [moduleRegistry getModuleImplementingProtocol:@protocol(UMAppLifecycleService)];
+    _lifecycleManager = [moduleRegistry getModuleImplementingProtocol:@protocol(EXAppLifecycleService)];
     _fileSystem = [moduleRegistry getModuleImplementingProtocol:@protocol(EXFileSystemInterface)];
     _permissionsManager = [moduleRegistry getModuleImplementingProtocol:@protocol(EXPermissionsInterface)];
 #if !(TARGET_IPHONE_SIMULATOR)
@@ -133,9 +133,9 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
 
 - (void)updateType
 {
-  UM_WEAKIFY(self);
+  EX_WEAKIFY(self);
   dispatch_async(_sessionQueue, ^{
-    UM_ENSURE_STRONGIFY(self);
+    EX_ENSURE_STRONGIFY(self);
     [self initializeCaptureSessionInput];
     if (!self.session.isRunning) {
       [self startSession];
@@ -155,7 +155,7 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
 
     if (![device lockForConfiguration:&error]) {
       if (error) {
-        UMLogInfo(@"%s: %@", __func__, error);
+        EXLogInfo(@"%s: %@", __func__, error);
       }
       return;
     }
@@ -166,7 +166,7 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
         [device unlockForConfiguration];
       } else {
         if (error) {
-          UMLogInfo(@"%s: %@", __func__, error);
+          EXLogInfo(@"%s: %@", __func__, error);
         }
       }
     }
@@ -177,7 +177,7 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
 
     if (![device lockForConfiguration:&error]) {
       if (error) {
-        UMLogInfo(@"%s: %@", __func__, error);
+        EXLogInfo(@"%s: %@", __func__, error);
       }
       return;
     }
@@ -191,7 +191,7 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
         [device unlockForConfiguration];
       } else {
         if (error) {
-          UMLogInfo(@"%s: %@", __func__, error);
+          EXLogInfo(@"%s: %@", __func__, error);
         }
       }
     }
@@ -207,7 +207,7 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
 
   if (![device lockForConfiguration:&error]) {
     if (error) {
-      UMLogInfo(@"%s: %@", __func__, error);
+      EXLogInfo(@"%s: %@", __func__, error);
     }
     return;
   }
@@ -217,7 +217,7 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
       [device setFocusMode:_autoFocus];
     } else {
       if (error) {
-        UMLogInfo(@"%s: %@", __func__, error);
+        EXLogInfo(@"%s: %@", __func__, error);
       }
     }
   }
@@ -237,20 +237,20 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
   if ([device isLockingFocusWithCustomLensPositionSupported]) {
     if (![device lockForConfiguration:&error]) {
       if (error) {
-        UMLogInfo(@"%s: %@", __func__, error);
+        EXLogInfo(@"%s: %@", __func__, error);
       }
       return;
     }
 
-    UM_WEAKIFY(device);
+    EX_WEAKIFY(device);
     [device setFocusModeLockedWithLensPosition:_focusDepth completionHandler:^(CMTime syncTime) {
-      UM_ENSURE_STRONGIFY(device);
+      EX_ENSURE_STRONGIFY(device);
       [device unlockForConfiguration];
     }];
     return;
   }
 
-  UMLogInfo(@"%s: Setting focusDepth isn't supported for this camera device", __func__);
+  EXLogInfo(@"%s: Setting focusDepth isn't supported for this camera device", __func__);
   return;
 }
 
@@ -260,7 +260,7 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
 
   if (![device lockForConfiguration:&error]) {
     if (error) {
-      UMLogInfo(@"%s: %@", __func__, error);
+      EXLogInfo(@"%s: %@", __func__, error);
     }
     return;
   }
@@ -277,7 +277,7 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
 
   if (![device lockForConfiguration:&error]) {
     if (error) {
-      UMLogInfo(@"%s: %@", __func__, error);
+      EXLogInfo(@"%s: %@", __func__, error);
     }
     return;
   }
@@ -292,14 +292,14 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
     };
     AVCaptureWhiteBalanceGains rgbGains = [device deviceWhiteBalanceGainsForTemperatureAndTintValues:temperatureAndTint];
     if ([device lockForConfiguration:&error]) {
-      UM_WEAKIFY(device);
+      EX_WEAKIFY(device);
       [device setWhiteBalanceModeLockedWithDeviceWhiteBalanceGains:rgbGains completionHandler:^(CMTime syncTime) {
-        UM_ENSURE_STRONGIFY(device);
+        EX_ENSURE_STRONGIFY(device);
         [device unlockForConfiguration];
       }];
     } else {
       if (error) {
-        UMLogInfo(@"%s: %@", __func__, error);
+        EXLogInfo(@"%s: %@", __func__, error);
       }
     }
   }
@@ -317,7 +317,7 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
   if (_barCodeScanner) {
     [_barCodeScanner setIsEnabled:barCodeScanning];
   } else if (barCodeScanning) {
-    UMLogError(@"BarCodeScanner module not found. Make sure `expo-barcode-scanner` is installed and linked correctly.");
+    EXLogError(@"BarCodeScanner module not found. Make sure `expo-barcode-scanner` is installed and linked correctly.");
   }
 }
 
@@ -333,7 +333,7 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
   if (_faceDetectorManager) {
     [_faceDetectorManager setIsEnabled:faceDetecting];
   } else if (faceDetecting) {
-    UMLogError(@"FaceDetector module not found. Make sure `expo-face-detector` is installed and linked correctly.");
+    EXLogError(@"FaceDetector module not found. Make sure `expo-face-detector` is installed and linked correctly.");
   }
 }
 
@@ -344,7 +344,7 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
   }
 }
 
-- (void)takePicture:(NSDictionary *)options resolve:(UMPromiseResolveBlock)resolve reject:(UMPromiseRejectBlock)reject
+- (void)takePicture:(NSDictionary *)options resolve:(EXPromiseResolveBlock)resolve reject:(EXPromiseRejectBlock)reject
 {
   if (_photoCapturedResolve) {
     reject(@"E_ANOTHER_CAPTURE", @"Another photo capture is already being processed. Await the first call.", nil);
@@ -390,8 +390,8 @@ previewPhotoSampleBuffer:(CMSampleBufferRef)previewPhotoSampleBuffer
                 error:(NSError *)error
 {
   NSDictionary *options = _photoCaptureOptions;
-  UMPromiseRejectBlock reject = _photoCapturedReject;
-  UMPromiseResolveBlock resolve = _photoCapturedResolve;
+  EXPromiseRejectBlock reject = _photoCapturedReject;
+  EXPromiseResolveBlock resolve = _photoCapturedResolve;
   _photoCapturedResolve = nil;
   _photoCapturedReject = nil;
   _photoCaptureOptions = nil;
@@ -417,8 +417,8 @@ previewPhotoSampleBuffer:(CMSampleBufferRef)previewPhotoSampleBuffer
 - (void)captureOutput:(AVCapturePhotoOutput *)output didFinishProcessingPhoto:(AVCapturePhoto *)photo error:(NSError *)error API_AVAILABLE(ios(11.0))
 {
   NSDictionary *options = _photoCaptureOptions;
-  UMPromiseRejectBlock reject = _photoCapturedReject;
-  UMPromiseResolveBlock resolve = _photoCapturedResolve;
+  EXPromiseRejectBlock reject = _photoCapturedReject;
+  EXPromiseResolveBlock resolve = _photoCapturedResolve;
   _photoCapturedResolve = nil;
   _photoCapturedReject = nil;
   _photoCaptureOptions = nil;
@@ -437,7 +437,7 @@ previewPhotoSampleBuffer:(CMSampleBufferRef)previewPhotoSampleBuffer
   [self handleCapturedImageData:imageData metadata:photo.metadata options:options resolver:resolve reject:reject];
 }
 
-- (void)handleCapturedImageData:(NSData *)imageData metadata:(NSDictionary *)metadata options:(NSDictionary *)options resolver:(UMPromiseResolveBlock)resolve reject:(UMPromiseRejectBlock)reject
+- (void)handleCapturedImageData:(NSData *)imageData metadata:(NSDictionary *)metadata options:(NSDictionary *)options resolver:(EXPromiseResolveBlock)resolve reject:(EXPromiseRejectBlock)reject
 {
   UIImage *takenImage = [UIImage imageWithData:imageData];
   BOOL useFastMode = [options[@"fastMode"] boolValue];
@@ -498,7 +498,7 @@ previewPhotoSampleBuffer:(CMSampleBufferRef)previewPhotoSampleBuffer
   }
 }
 
-- (void)record:(NSDictionary *)options resolve:(UMPromiseResolveBlock)resolve reject:(UMPromiseRejectBlock)reject
+- (void)record:(NSDictionary *)options resolve:(EXPromiseResolveBlock)resolve reject:(EXPromiseRejectBlock)reject
 {
   if (_movieFileOutput == nil) {
     // At the time of writing AVCaptureMovieFileOutput and AVCaptureVideoDataOutput (> GMVDataOutput)
@@ -517,7 +517,7 @@ previewPhotoSampleBuffer:(CMSampleBufferRef)previewPhotoSampleBuffer
     AVCaptureConnection *connection = [_movieFileOutput connectionWithMediaType:AVMediaTypeVideo];
     // TODO: Add support for videoStabilizationMode (right now it is not only read, never written to)
     if (connection.isVideoStabilizationSupported == NO) {
-      UMLogWarn(@"%s: Video Stabilization is not supported on this device.", __func__);
+      EXLogWarn(@"%s: Video Stabilization is not supported on this device.", __func__);
     } else {
       [connection setPreferredVideoStabilizationMode:self.videoStabilizationMode];
     }
@@ -543,9 +543,9 @@ previewPhotoSampleBuffer:(CMSampleBufferRef)previewPhotoSampleBuffer
       [connection setVideoMirrored:shouldBeMirrored];
     }
 
-    UM_WEAKIFY(self);
+    EX_WEAKIFY(self);
     dispatch_async(self.sessionQueue, ^{
-      UM_STRONGIFY(self);
+      EX_STRONGIFY(self);
       // it is possible that the session has been invalidated at this point
       // for example, the video codec option is invalid and so this call has already rejected
       if (!self.isValidVideoOptions) {
@@ -572,11 +572,11 @@ previewPhotoSampleBuffer:(CMSampleBufferRef)previewPhotoSampleBuffer
 
 // Video options are set in an async block to prevent the possible race condition outlined here:
 // https://github.com/react-native-camera/react-native-camera/pull/2694
-- (void)setVideoOptions:(NSDictionary *)options forConnection:(AVCaptureConnection *)connection onReject:(UMPromiseRejectBlock)reject
+- (void)setVideoOptions:(NSDictionary *)options forConnection:(AVCaptureConnection *)connection onReject:(EXPromiseRejectBlock)reject
 {
-  UM_WEAKIFY(self);
+  EX_WEAKIFY(self);
   dispatch_async(_sessionQueue, ^{
-    UM_STRONGIFY(self);
+    EX_STRONGIFY(self);
     // Reset validation flag
     self.isValidVideoOptions = YES;
 
@@ -652,9 +652,9 @@ previewPhotoSampleBuffer:(CMSampleBufferRef)previewPhotoSampleBuffer
     [self onMountingError:@{@"message": @"Camera permissions not granted - component could not be rendered."}];
     return;
   }
-  UM_WEAKIFY(self);
+  EX_WEAKIFY(self);
   dispatch_async(_sessionQueue, ^{
-    UM_ENSURE_STRONGIFY(self);
+    EX_ENSURE_STRONGIFY(self);
 
     if (self.presetCamera == AVCaptureDevicePositionUnspecified) {
       return;
@@ -670,9 +670,9 @@ previewPhotoSampleBuffer:(CMSampleBufferRef)previewPhotoSampleBuffer
 
     [self setRuntimeErrorHandlingObserver:
      [[NSNotificationCenter defaultCenter] addObserverForName:AVCaptureSessionRuntimeErrorNotification object:self.session queue:nil usingBlock:^(NSNotification *note) {
-      UM_ENSURE_STRONGIFY(self);
+      EX_ENSURE_STRONGIFY(self);
       dispatch_async(self.sessionQueue, ^{
-        UM_ENSURE_STRONGIFY(self)
+        EX_ENSURE_STRONGIFY(self)
         // Manually restarting the session since it must
         // have been stopped due to an error.
         [self.session startRunning];
@@ -684,7 +684,7 @@ previewPhotoSampleBuffer:(CMSampleBufferRef)previewPhotoSampleBuffer
     // when BarCodeScanner is enabled since the beginning of camera component lifecycle,
     // some race condition occurs in reconfiguration and barcodes aren't scanned at all
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 50 * NSEC_PER_USEC), self.sessionQueue, ^{
-      UM_ENSURE_STRONGIFY(self);
+      EX_ENSURE_STRONGIFY(self);
       [self maybeStartFaceDetection:self.presetCamera!=1];
       if (self.barCodeScanner) {
         [self.barCodeScanner maybeStartBarCodeScanning];
@@ -703,9 +703,9 @@ previewPhotoSampleBuffer:(CMSampleBufferRef)previewPhotoSampleBuffer
 #if TARGET_IPHONE_SIMULATOR
   return;
 #endif
-  UM_WEAKIFY(self);
+  EX_WEAKIFY(self);
   dispatch_async(_sessionQueue, ^{
-    UM_ENSURE_STRONGIFY(self);
+    EX_ENSURE_STRONGIFY(self);
 
     if (self.faceDetectorManager) {
       [self.faceDetectorManager stopFaceDetection];
@@ -733,14 +733,14 @@ previewPhotoSampleBuffer:(CMSampleBufferRef)previewPhotoSampleBuffer
   }
 
   __block UIInterfaceOrientation interfaceOrientation;
-  [UMUtilities performSynchronouslyOnMainThread:^{
+  [EXUtilities performSynchronouslyOnMainThread:^{
     interfaceOrientation = [[UIApplication sharedApplication] statusBarOrientation];
   }];
   AVCaptureVideoOrientation orientation = [EXCameraUtils videoOrientationForInterfaceOrientation:interfaceOrientation];
 
-  UM_WEAKIFY(self);
+  EX_WEAKIFY(self);
   dispatch_async(_sessionQueue, ^{
-    UM_ENSURE_STRONGIFY(self);
+    EX_ENSURE_STRONGIFY(self);
 
     [self.session beginConfiguration];
 
@@ -779,9 +779,9 @@ previewPhotoSampleBuffer:(CMSampleBufferRef)previewPhotoSampleBuffer
 // - torchMode: https://stackoverflow.com/a/53666293/4337317
 - (void)ensureSessionConfiguration
 {
-  UM_WEAKIFY(self);
+  EX_WEAKIFY(self);
   dispatch_async(_sessionQueue, ^{
-    UM_ENSURE_STRONGIFY(self);
+    EX_ENSURE_STRONGIFY(self);
     [self updateFlashMode];
   });
 }
@@ -792,9 +792,9 @@ previewPhotoSampleBuffer:(CMSampleBufferRef)previewPhotoSampleBuffer
 {
 #if !(TARGET_IPHONE_SIMULATOR)
   if (preset) {
-    UM_WEAKIFY(self);
+    EX_WEAKIFY(self);
     dispatch_async(_sessionQueue, ^{
-      UM_ENSURE_STRONGIFY(self);
+      EX_ENSURE_STRONGIFY(self);
       [self.session beginConfiguration];
       if ([self.session canSetSessionPreset:preset]) {
         self.session.sessionPreset = preset;
@@ -807,9 +807,9 @@ previewPhotoSampleBuffer:(CMSampleBufferRef)previewPhotoSampleBuffer
 
 - (void)updateSessionAudioIsMuted:(BOOL)isMuted
 {
-  UM_WEAKIFY(self);
+  EX_WEAKIFY(self);
   dispatch_async(_sessionQueue, ^{
-    UM_ENSURE_STRONGIFY(self);
+    EX_ENSURE_STRONGIFY(self);
     [self.session beginConfiguration];
 
     for (AVCaptureDeviceInput* input in [self.session inputs]) {
@@ -829,7 +829,7 @@ previewPhotoSampleBuffer:(CMSampleBufferRef)previewPhotoSampleBuffer
       AVCaptureDeviceInput *audioDeviceInput = [AVCaptureDeviceInput deviceInputWithDevice:audioCaptureDevice error:&error];
 
       if (error || audioDeviceInput == nil) {
-        UMLogInfo(@"%s: %@", __func__, error);
+        EXLogInfo(@"%s: %@", __func__, error);
         return;
       }
 
@@ -846,9 +846,9 @@ previewPhotoSampleBuffer:(CMSampleBufferRef)previewPhotoSampleBuffer
 {
   if (![_session isRunning] && [self isSessionPaused]) {
     _paused = NO;
-    UM_WEAKIFY(self);
+    EX_WEAKIFY(self);
     dispatch_async(_sessionQueue, ^{
-      UM_ENSURE_STRONGIFY(self);
+      EX_ENSURE_STRONGIFY(self);
       [self.session startRunning];
       [self ensureSessionConfiguration];
     });
@@ -859,9 +859,9 @@ previewPhotoSampleBuffer:(CMSampleBufferRef)previewPhotoSampleBuffer
 {
   if ([_session isRunning] && ![self isSessionPaused]) {
     _paused = YES;
-    UM_WEAKIFY(self);
+    EX_WEAKIFY(self);
     dispatch_async(_sessionQueue, ^{
-      UM_ENSURE_STRONGIFY(self);
+      EX_ENSURE_STRONGIFY(self);
       [self.session stopRunning];
     });
   }
@@ -875,10 +875,10 @@ previewPhotoSampleBuffer:(CMSampleBufferRef)previewPhotoSampleBuffer
 
 - (void)changePreviewOrientation:(UIInterfaceOrientation)orientation
 {
-  UM_WEAKIFY(self);
+  EX_WEAKIFY(self);
   AVCaptureVideoOrientation videoOrientation = [EXCameraUtils videoOrientationForInterfaceOrientation:orientation];
-  [UMUtilities performSynchronouslyOnMainThread:^{
-    UM_ENSURE_STRONGIFY(self);
+  [EXUtilities performSynchronouslyOnMainThread:^{
+    EX_ENSURE_STRONGIFY(self);
     if (self.previewLayer.connection.isVideoOrientationSupported) {
       [self.previewLayer.connection setVideoOrientation:videoOrientation];
     }
@@ -942,9 +942,9 @@ previewPhotoSampleBuffer:(CMSampleBufferRef)previewPhotoSampleBuffer
   if (faceDetectorProvider) {
     id<EXFaceDetectorManagerInterface> faceDetector = [faceDetectorProvider createFaceDetectorManager];
     if (faceDetector) {
-      UM_WEAKIFY(self);
+      EX_WEAKIFY(self);
       [faceDetector setOnFacesDetected:^(NSArray<NSDictionary *> *faces) {
-        UM_ENSURE_STRONGIFY(self);
+        EX_ENSURE_STRONGIFY(self);
         if (self.onFacesDetected) {
           self.onFacesDetected(@{
                                  @"type": @"face",
@@ -967,11 +967,11 @@ previewPhotoSampleBuffer:(CMSampleBufferRef)previewPhotoSampleBuffer
   if (barCodeScannerProvider) {
     id<EXBarCodeScannerInterface> barCodeScanner = [barCodeScannerProvider createBarCodeScanner];
     if (barCodeScanner) {
-      UM_WEAKIFY(self);
+      EX_WEAKIFY(self);
       [barCodeScanner setSession:_session];
       [barCodeScanner setSessionQueue:_sessionQueue];
       [barCodeScanner setOnBarCodeScanned:^(NSDictionary *body) {
-        UM_ENSURE_STRONGIFY(self);
+        EX_ENSURE_STRONGIFY(self);
         [self onBarCodeScanned:body];
       }];
     }

--- a/packages/expo-camera/ios/EXCamera/EXCameraCameraPermissionRequester.m
+++ b/packages/expo-camera/ios/EXCamera/EXCameraCameraPermissionRequester.m
@@ -1,7 +1,7 @@
 // Copyright 2016-present 650 Industries. All rights reserved.
 
 #import <EXCamera/EXCameraCameraPermissionRequester.h>
-#import <UMCore/UMDefines.h>
+#import <ExpoModulesCore/EXDefines.h>
 #import <ExpoModulesCore/EXPermissionsInterface.h>
 
 #import <AVFoundation/AVFoundation.h>
@@ -20,7 +20,7 @@
   NSString *cameraUsageDescription = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSCameraUsageDescription"];
   
   if (!cameraUsageDescription) {
-    UMFatal(UMErrorWithMessage(@"This app is missing NSCameraUsageDescription, so video services will fail. Add this entry to your bundle's Info.plist."));
+    EXFatal(EXErrorWithMessage(@"This app is missing NSCameraUsageDescription, so video services will fail. Add this entry to your bundle's Info.plist."));
     systemStatus = AVAuthorizationStatusDenied;
   } else {
     systemStatus = [AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo];
@@ -42,11 +42,11 @@
   };
 }
 
-- (void)requestPermissionsWithResolver:(UMPromiseResolveBlock)resolve rejecter:(UMPromiseRejectBlock)reject
+- (void)requestPermissionsWithResolver:(EXPromiseResolveBlock)resolve rejecter:(EXPromiseRejectBlock)reject
 {
-  UM_WEAKIFY(self)
+  EX_WEAKIFY(self)
   [AVCaptureDevice requestAccessForMediaType:AVMediaTypeVideo completionHandler:^(BOOL granted) {
-    UM_STRONGIFY(self)
+    EX_STRONGIFY(self)
     resolve([self getPermissions]);
   }];
 }

--- a/packages/expo-camera/ios/EXCamera/EXCameraManager.h
+++ b/packages/expo-camera/ios/EXCamera/EXCameraManager.h
@@ -1,9 +1,9 @@
 #import <AVFoundation/AVFoundation.h>
-#import <UMCore/UMViewManager.h>
-#import <UMCore/UMExportedModule.h>
-#import <UMCore/UMModuleRegistryConsumer.h>
+#import <ExpoModulesCore/EXViewManager.h>
+#import <ExpoModulesCore/EXExportedModule.h>
+#import <ExpoModulesCore/EXModuleRegistryConsumer.h>
 #import <EXCamera/EXCamera.h>
 
-@interface EXCameraManager : UMViewManager <UMModuleRegistryConsumer>
+@interface EXCameraManager : EXViewManager <EXModuleRegistryConsumer>
 
 @end

--- a/packages/expo-camera/ios/EXCamera/EXCameraManager.m
+++ b/packages/expo-camera/ios/EXCamera/EXCameraManager.m
@@ -5,7 +5,7 @@
 #import <EXCamera/EXCameraCameraPermissionRequester.h>
 #import <EXCamera/EXCameraMicrophonePermissionRequester.h>
 
-#import <UMCore/UMUIManager.h>
+#import <ExpoModulesCore/EXUIManager.h>
 #import <ExpoModulesCore/EXFileSystemInterface.h>
 #import <ExpoModulesCore/EXPermissionsInterface.h>
 #import <ExpoModulesCore/EXPermissionsMethodsDelegate.h>
@@ -13,25 +13,25 @@
 @interface EXCameraManager ()
 
 @property (nonatomic, weak) id<EXFileSystemInterface> fileSystem;
-@property (nonatomic, weak) id<UMUIManager> uiManager;
-@property (nonatomic, weak) UMModuleRegistry *moduleRegistry;
+@property (nonatomic, weak) id<EXUIManager> uiManager;
+@property (nonatomic, weak) EXModuleRegistry *moduleRegistry;
 @property (nonatomic, weak) id<EXPermissionsInterface> permissionsManager;
 @end
 
 @implementation EXCameraManager
 
-UM_EXPORT_MODULE(ExponentCameraManager);
+EX_EXPORT_MODULE(ExponentCameraManager);
 
 - (NSString *)viewName
 {
   return @"ExponentCamera";
 }
 
-- (void)setModuleRegistry:(UMModuleRegistry *)moduleRegistry
+- (void)setModuleRegistry:(EXModuleRegistry *)moduleRegistry
 {
   _moduleRegistry = moduleRegistry;
   _fileSystem = [moduleRegistry getModuleImplementingProtocol:@protocol(EXFileSystemInterface)];
-  _uiManager = [moduleRegistry getModuleImplementingProtocol:@protocol(UMUIManager)];
+  _uiManager = [moduleRegistry getModuleImplementingProtocol:@protocol(EXUIManager)];
   _permissionsManager = [moduleRegistry getModuleImplementingProtocol:@protocol(EXPermissionsInterface)];
   [EXPermissionsMethodsDelegate registerRequesters:@[[EXCameraPermissionRequester new]] withPermissionsManager:_permissionsManager];
   [EXPermissionsMethodsDelegate registerRequesters:@[[EXCameraCameraPermissionRequester new]] withPermissionsManager:_permissionsManager];
@@ -114,7 +114,7 @@ UM_EXPORT_MODULE(ExponentCameraManager);
            };
 }
 
-UM_VIEW_PROPERTY(type, NSNumber *, EXCamera)
+EX_VIEW_PROPERTY(type, NSNumber *, EXCamera)
 {
   long longValue = [value longValue];
   if (view.presetCamera != longValue) {
@@ -123,7 +123,7 @@ UM_VIEW_PROPERTY(type, NSNumber *, EXCamera)
   }
 }
 
-UM_VIEW_PROPERTY(flashMode, NSNumber *, EXCamera)
+EX_VIEW_PROPERTY(flashMode, NSNumber *, EXCamera)
 {
   long longValue = [value longValue];
   if (longValue != view.flashMode) {
@@ -132,17 +132,17 @@ UM_VIEW_PROPERTY(flashMode, NSNumber *, EXCamera)
   }
 }
 
-UM_VIEW_PROPERTY(faceDetectorSettings, NSDictionary *, EXCamera)
+EX_VIEW_PROPERTY(faceDetectorSettings, NSDictionary *, EXCamera)
 {
   [view updateFaceDetectorSettings:value];
 }
 
-UM_VIEW_PROPERTY(barCodeScannerSettings, NSDictionary *, EXCamera)
+EX_VIEW_PROPERTY(barCodeScannerSettings, NSDictionary *, EXCamera)
 {
   [view setBarCodeScannerSettings:value];
 }
 
-UM_VIEW_PROPERTY(autoFocus, NSNumber *, EXCamera)
+EX_VIEW_PROPERTY(autoFocus, NSNumber *, EXCamera)
 {
   long longValue = [value longValue];
   if (longValue != view.autoFocus) {
@@ -151,7 +151,7 @@ UM_VIEW_PROPERTY(autoFocus, NSNumber *, EXCamera)
   }
 }
 
-UM_VIEW_PROPERTY(focusDepth, NSNumber *, EXCamera)
+EX_VIEW_PROPERTY(focusDepth, NSNumber *, EXCamera)
 {
   float floatValue = [value floatValue];
   if (fabsf(view.focusDepth - floatValue) > FLT_EPSILON) {
@@ -160,7 +160,7 @@ UM_VIEW_PROPERTY(focusDepth, NSNumber *, EXCamera)
   }
 }
 
-UM_VIEW_PROPERTY(zoom, NSNumber *, EXCamera)
+EX_VIEW_PROPERTY(zoom, NSNumber *, EXCamera)
 {
   double doubleValue = [value doubleValue];
   if (fabs(view.zoom - doubleValue) > DBL_EPSILON) {
@@ -169,7 +169,7 @@ UM_VIEW_PROPERTY(zoom, NSNumber *, EXCamera)
   }
 }
 
-UM_VIEW_PROPERTY(whiteBalance, NSNumber *, EXCamera)
+EX_VIEW_PROPERTY(whiteBalance, NSNumber *, EXCamera)
 {
   long longValue = [value longValue];
   if (longValue != view.whiteBalance) {
@@ -178,12 +178,12 @@ UM_VIEW_PROPERTY(whiteBalance, NSNumber *, EXCamera)
   }
 }
 
-UM_VIEW_PROPERTY(pictureSize, NSString *, EXCamera) {
+EX_VIEW_PROPERTY(pictureSize, NSString *, EXCamera) {
   [view setPictureSize:[[self class] pictureSizes][value]];
   [view updatePictureSize];
 }
 
-UM_VIEW_PROPERTY(faceDetectorEnabled, NSNumber *, EXCamera)
+EX_VIEW_PROPERTY(faceDetectorEnabled, NSNumber *, EXCamera)
 {
   bool boolValue = [value boolValue];
   if ([view isDetectingFaces] != boolValue) {
@@ -191,7 +191,7 @@ UM_VIEW_PROPERTY(faceDetectorEnabled, NSNumber *, EXCamera)
   }
 }
 
-UM_VIEW_PROPERTY(barCodeScannerEnabled, NSNumber *, EXCamera)
+EX_VIEW_PROPERTY(barCodeScannerEnabled, NSNumber *, EXCamera)
 {
   bool boolValue = [value boolValue];
   if ([view isScanningBarCodes] != boolValue) {
@@ -199,11 +199,11 @@ UM_VIEW_PROPERTY(barCodeScannerEnabled, NSNumber *, EXCamera)
   }
 }
 
-UM_EXPORT_METHOD_AS(takePicture,
+EX_EXPORT_METHOD_AS(takePicture,
                     takePictureWithOptions:(NSDictionary *)options
                     reactTag:(nonnull NSNumber *)reactTag
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
 #if TARGET_IPHONE_SIMULATOR
   __weak EXCameraManager *weakSelf = self;
@@ -251,11 +251,11 @@ UM_EXPORT_METHOD_AS(takePicture,
 
 }
 
-UM_EXPORT_METHOD_AS(record,
+EX_EXPORT_METHOD_AS(record,
                     recordWithOptions:(NSDictionary *)options
                     reactTag:(nonnull NSNumber *)reactTag
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunreachable-code"
@@ -274,25 +274,25 @@ UM_EXPORT_METHOD_AS(record,
 #pragma clang diagnostic pop
 }
 
-UM_EXPORT_METHOD_AS(stopRecording,
+EX_EXPORT_METHOD_AS(stopRecording,
                     stopRecordingOfReactTag:(nonnull NSNumber *)reactTag
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   [_uiManager executeUIBlock:^(id view) {
     if (view != nil) {
       [view stopRecording];
       resolve(nil);
     } else {
-      UMLogError(@"Invalid view returned from registry, expected EXCamera, got: %@", view);
+      EXLogError(@"Invalid view returned from registry, expected EXCamera, got: %@", view);
     }
   } forView:reactTag ofClass:[EXCamera class]];
 }
 
-UM_EXPORT_METHOD_AS(resumePreview,
+EX_EXPORT_METHOD_AS(resumePreview,
                     resumePreview:(nonnull NSNumber *)tag
-                         resolver:(UMPromiseResolveBlock)resolve
-                         rejecter:(UMPromiseRejectBlock)reject)
+                         resolver:(EXPromiseResolveBlock)resolve
+                         rejecter:(EXPromiseRejectBlock)reject)
 {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunreachable-code"
@@ -305,16 +305,16 @@ UM_EXPORT_METHOD_AS(resumePreview,
       [view resumePreview];
       resolve(nil);
     } else {
-      UMLogError(@"Invalid view returned from registry, expected EXCamera, got: %@", view);
+      EXLogError(@"Invalid view returned from registry, expected EXCamera, got: %@", view);
     }
   } forView:tag ofClass:[EXCamera class]];
 #pragma clang diagnostic pop
 }
 
-UM_EXPORT_METHOD_AS(pausePreview,
+EX_EXPORT_METHOD_AS(pausePreview,
                     pausePreview:(nonnull NSNumber *)tag
-                        resolver:(UMPromiseResolveBlock)resolve
-                         rejecter:(UMPromiseRejectBlock)reject)
+                        resolver:(EXPromiseResolveBlock)resolve
+                         rejecter:(EXPromiseRejectBlock)reject)
 {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunreachable-code"
@@ -327,24 +327,24 @@ UM_EXPORT_METHOD_AS(pausePreview,
       [view pausePreview];
       resolve(nil);
     } else {
-      UMLogError(@"Invalid view returned from registry, expected EXCamera, got: %@", view);
+      EXLogError(@"Invalid view returned from registry, expected EXCamera, got: %@", view);
     }
   } forView:tag ofClass:[EXCamera class]];
 #pragma clang diagnostic pop
 }
 
-UM_EXPORT_METHOD_AS(getAvailablePictureSizes,
+EX_EXPORT_METHOD_AS(getAvailablePictureSizes,
                      getAvailablePictureSizesWithRatio:(NSString *)ratio
                                                    tag:(nonnull NSNumber *)tag
-                                              resolver:(UMPromiseResolveBlock)resolve
-                                              rejecter:(UMPromiseRejectBlock)reject)
+                                              resolver:(EXPromiseResolveBlock)resolve
+                                              rejecter:(EXPromiseRejectBlock)reject)
 {
   resolve([[[self class] pictureSizes] allKeys]);
 }
 
-UM_EXPORT_METHOD_AS(getAvailableVideoCodecsAsync,
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(getAvailableVideoCodecsAsync,
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   AVCaptureSession *session = [AVCaptureSession new];   
   [session beginConfiguration];
@@ -367,9 +367,9 @@ UM_EXPORT_METHOD_AS(getAvailableVideoCodecsAsync,
   resolve([movieFileOutput availableVideoCodecTypes]);
 }
 
-UM_EXPORT_METHOD_AS(getPermissionsAsync,
-                    getPermissionsAsync:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(getPermissionsAsync,
+                    getPermissionsAsync:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   [EXPermissionsMethodsDelegate getPermissionWithPermissionsManager:_permissionsManager
                                                       withRequester:[EXCameraPermissionRequester class]
@@ -377,9 +377,9 @@ UM_EXPORT_METHOD_AS(getPermissionsAsync,
                                                              reject:reject];
 }
 
-UM_EXPORT_METHOD_AS(requestPermissionsAsync,
-                    requestPermissionsAsync:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(requestPermissionsAsync,
+                    requestPermissionsAsync:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   [EXPermissionsMethodsDelegate askForPermissionWithPermissionsManager:_permissionsManager
                                                          withRequester:[EXCameraPermissionRequester class]
@@ -388,9 +388,9 @@ UM_EXPORT_METHOD_AS(requestPermissionsAsync,
 }
 
 
-UM_EXPORT_METHOD_AS(getCameraPermissionsAsync,
-                    getCameraPermissionsAsync:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(getCameraPermissionsAsync,
+                    getCameraPermissionsAsync:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   [EXPermissionsMethodsDelegate getPermissionWithPermissionsManager:_permissionsManager
                                                       withRequester:[EXCameraCameraPermissionRequester class]
@@ -399,9 +399,9 @@ UM_EXPORT_METHOD_AS(getCameraPermissionsAsync,
 }
 
 
-UM_EXPORT_METHOD_AS(requestCameraPermissionsAsync,
-                    requestCameraPermissionsAsync:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(requestCameraPermissionsAsync,
+                    requestCameraPermissionsAsync:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   [EXPermissionsMethodsDelegate askForPermissionWithPermissionsManager:_permissionsManager
                                                          withRequester:[EXCameraCameraPermissionRequester class]
@@ -411,9 +411,9 @@ UM_EXPORT_METHOD_AS(requestCameraPermissionsAsync,
 
 
 
-UM_EXPORT_METHOD_AS(getMicrophonePermissionsAsync,
-                    getMicrophonePermissionsAsync:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(getMicrophonePermissionsAsync,
+                    getMicrophonePermissionsAsync:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   [EXPermissionsMethodsDelegate getPermissionWithPermissionsManager:_permissionsManager
                                                       withRequester:[EXCameraMicrophonePermissionRequester class]
@@ -422,9 +422,9 @@ UM_EXPORT_METHOD_AS(getMicrophonePermissionsAsync,
 }
 
 
-UM_EXPORT_METHOD_AS(requestMicrophonePermissionsAsync,
-                    requestMicrophonePermissionsAsync:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(requestMicrophonePermissionsAsync,
+                    requestMicrophonePermissionsAsync:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   [EXPermissionsMethodsDelegate askForPermissionWithPermissionsManager:_permissionsManager
                                                          withRequester:[EXCameraMicrophonePermissionRequester class]

--- a/packages/expo-camera/ios/EXCamera/EXCameraMicrophonePermissionRequester.m
+++ b/packages/expo-camera/ios/EXCamera/EXCameraMicrophonePermissionRequester.m
@@ -1,7 +1,7 @@
 // Copyright 2016-present 650 Industries. All rights reserved.
 
 #import <EXCamera/EXCameraMicrophonePermissionRequester.h>
-#import <UMCore/UMDefines.h>
+#import <ExpoModulesCore/EXDefines.h>
 #import <ExpoModulesCore/EXPermissionsInterface.h>
 
 #import <AVFoundation/AVFoundation.h>
@@ -20,7 +20,7 @@
   NSString *microphoneUsageDescription = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSMicrophoneUsageDescription"];
     
   if (!microphoneUsageDescription) {
-    UMFatal(UMErrorWithMessage(@"This app is missing NSMicrophoneUsageDescription, so audio services will fail. Add this entry to your bundle's Info.plist."));
+    EXFatal(EXErrorWithMessage(@"This app is missing NSMicrophoneUsageDescription, so audio services will fail. Add this entry to your bundle's Info.plist."));
     systemStatus = AVAuthorizationStatusDenied;
   } else {
     systemStatus = [AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeAudio];
@@ -42,11 +42,11 @@
   };
 }
 
-- (void)requestPermissionsWithResolver:(UMPromiseResolveBlock)resolve rejecter:(UMPromiseRejectBlock)reject
+- (void)requestPermissionsWithResolver:(EXPromiseResolveBlock)resolve rejecter:(EXPromiseRejectBlock)reject
 {
-  UM_WEAKIFY(self)
+  EX_WEAKIFY(self)
   [AVCaptureDevice requestAccessForMediaType:AVMediaTypeAudio completionHandler:^(BOOL granted) {
-    UM_STRONGIFY(self)
+    EX_STRONGIFY(self)
     resolve([self getPermissions]);
   }];
 }

--- a/packages/expo-camera/ios/EXCamera/EXCameraPermissionRequester.m
+++ b/packages/expo-camera/ios/EXCamera/EXCameraPermissionRequester.m
@@ -1,7 +1,7 @@
 // Copyright 2016-present 650 Industries. All rights reserved.
 
 #import <EXCamera/EXCameraPermissionRequester.h>
-#import <UMCore/UMDefines.h>
+#import <ExpoModulesCore/EXDefines.h>
 #import <ExpoModulesCore/EXPermissionsInterface.h>
 
 #import <AVFoundation/AVFoundation.h>
@@ -20,7 +20,7 @@
   NSString *cameraUsageDescription = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSCameraUsageDescription"];
   NSString *microphoneUsageDescription = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSMicrophoneUsageDescription"];
   if (!(cameraUsageDescription && microphoneUsageDescription)) {
-    UMFatal(UMErrorWithMessage(@"This app is missing either NSCameraUsageDescription or NSMicrophoneUsageDescription, so audio/video services will fail. Add one of these entries to your bundle's Info.plist."));
+    EXFatal(EXErrorWithMessage(@"This app is missing either NSCameraUsageDescription or NSMicrophoneUsageDescription, so audio/video services will fail. Add one of these entries to your bundle's Info.plist."));
     systemStatus = AVAuthorizationStatusDenied;
   } else {
     systemStatus = [AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo];
@@ -42,11 +42,11 @@
   };
 }
 
-- (void)requestPermissionsWithResolver:(UMPromiseResolveBlock)resolve rejecter:(UMPromiseRejectBlock)reject
+- (void)requestPermissionsWithResolver:(EXPromiseResolveBlock)resolve rejecter:(EXPromiseRejectBlock)reject
 {
-  UM_WEAKIFY(self)
+  EX_WEAKIFY(self)
   [AVCaptureDevice requestAccessForMediaType:AVMediaTypeVideo completionHandler:^(BOOL granted) {
-    UM_STRONGIFY(self)
+    EX_STRONGIFY(self)
     resolve([self getPermissions]);
   }];
 }


### PR DESCRIPTION
# Why

`UMCore` is now deprecated in favor of `ExpoModulesCore`

# How

- Removed the dependency on `UMCore`
- Renamed imports and all references

# Test Plan

Examples seem to work as expected

(SDK check on the CI is failing, but it's unrelated)
