### PR TITLE
[docs] refresh pages title design

### DIFF
--- a/docs/components/base/headings.tsx
+++ b/docs/components/base/headings.tsx
@@ -13,7 +13,7 @@ const attributes = {
 const STYLES_H1 = css`
   ${h1}
   margin-top: 0.5rem;
-  margin-bottom: 1rem;
+  margin-bottom: 1.5rem;
   padding-bottom: 0.5rem;
   border-bottom: 1px solid ${theme.border.default};
 `;

--- a/docs/components/base/typography.tsx
+++ b/docs/components/base/typography.tsx
@@ -6,11 +6,14 @@ import * as Constants from '~/constants/theme';
 export const h1 = css`
   font-family: ${Constants.fonts.black};
   color: ${theme.text.default};
-  font-size: 44px;
+  font-size: 48px;
   line-height: 120%;
-  letter-spacing: -0.021em;
-  font-weight: 900;
-  background-image: linear-gradient(60deg, #9e3ab7, var(--expo-theme-link-default));
+  letter-spacing: -0.025em;
+  font-weight: 700;
+  // Initial design
+  // background-image: linear-gradient(60deg, #9e3ab7, var(--expo-theme-link-default) 66%);
+  // Alternative design
+  background-image: linear-gradient(35deg, #6b4ce8, #da3f9c 70%);
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
 `;

--- a/docs/components/base/typography.tsx
+++ b/docs/components/base/typography.tsx
@@ -4,12 +4,14 @@ import { theme } from '@expo/styleguide';
 import * as Constants from '~/constants/theme';
 
 export const h1 = css`
-  font-family: ${Constants.fonts.bold};
+  font-family: ${Constants.fonts.black};
   color: ${theme.text.default};
-  font-size: 48px;
+  font-size: 44px;
   line-height: 120%;
-  letter-spacing: -0.022em;
-  font-weight: 500;
+  font-weight: 800;
+  background-image: linear-gradient(60deg, #9e3ab7, var(--expo-theme-link-default));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
 `;
 
 export const h2 = css`

--- a/docs/components/base/typography.tsx
+++ b/docs/components/base/typography.tsx
@@ -8,7 +8,8 @@ export const h1 = css`
   color: ${theme.text.default};
   font-size: 44px;
   line-height: 120%;
-  font-weight: 800;
+  letter-spacing: -0.021em;
+  font-weight: 900;
   background-image: linear-gradient(60deg, #9e3ab7, var(--expo-theme-link-default));
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;

--- a/docs/constants/theme.js
+++ b/docs/constants/theme.js
@@ -1,4 +1,5 @@
 export const fonts = {
+  black: 'expo-brand-black',
   bold: 'expo-brand-bold',
   book: 'expo-brand-book',
   demi: 'expo-brand-demi',
@@ -9,6 +10,7 @@ export const fonts = {
 const fontStack = `system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,'Noto Sans',sans-serif,'Apple Color Emoji','Segoe UI Emoji','Segoe UI Symbol','Noto Color Emoji'`;
 
 export const fontFamilies = {
+  black: `${fonts.black}`,
   bold: `${fonts.bold}`,
   book: `${fonts.book}`,
   demi: `${fonts.demi}`,

--- a/docs/global-styles/fonts.ts
+++ b/docs/global-styles/fonts.ts
@@ -6,7 +6,7 @@ export const globalFonts = css`
   @font-face {
     font-family: ${Constants.fonts.black};
     font-style: normal;
-    font-weight: 900;
+    font-weight: 700;
     src: url('/static/fonts/Inter-Bold.woff2?v=3.15') format('woff2'),
       url('/static/fonts/Inter-Bold.woff?v=3.15') format('woff');
   }

--- a/docs/global-styles/fonts.ts
+++ b/docs/global-styles/fonts.ts
@@ -4,6 +4,14 @@ import * as Constants from '~/constants/theme';
 
 export const globalFonts = css`
   @font-face {
+    font-family: ${Constants.fonts.black};
+    font-style: normal;
+    font-weight: 900;
+    src: url('/static/fonts/Inter-Bold.woff2?v=3.15') format('woff2'),
+      url('/static/fonts/Inter-Bold.woff?v=3.15') format('woff');
+  }
+
+  @font-face {
     font-family: ${Constants.fonts.bold};
     font-style: normal;
     font-weight: 600;

--- a/docs/global-styles/reset.ts
+++ b/docs/global-styles/reset.ts
@@ -133,4 +133,8 @@ export const globalReset = css`
     background-color: ${theme.highlight.accent};
     color: ${theme.text.default};
   }
+
+  h1::selection {
+    -webkit-text-fill-color: ${theme.text.default};
+  }
 `;


### PR DESCRIPTION
# Why

The docs are mostly monochromatic beyond the Expo violet color (in comparison to the vibrant Expo landing page for example), so I thought it would be nice to break this a bit by introducing gradient page titles, inspired by Expo main page section:

<img width="960" alt="Screenshot 2021-07-23 at 13 30 56" src="https://user-images.githubusercontent.com/719641/126777665-0390ebe2-3b45-4ee7-81f2-b4781dc5f74e.png">

# How

This is only a proposition, I can fully understand if it do not land on production. 🙂 

I have added the missing `black` option for the Expo font, tweak page titles styles a bit and I have ensure that `::selection` styles are correct. For gradient I have used one hardcoded color and CSS link color variable, which also result in small shift of appearance of heading between the modes (which was intentional). Of course I'm open to tweak or change the gradient colors completely.

 Unfortunately to mimic fully the `black` font from main page we will need to add new font (`Inter-Black`) which is not currently in docs `/static`s, but I want to avoid embedding new font file just for one element.

# Test Plan

The changes has been tested by running docs website on `localhost`. 

### Test Matrix

* macOS
  * Chrome, Edge, Safari

* Win
  * Chrome, Edge, FF

# Preview
<img width="1920" alt="Screenshot 2021-07-23 at 14 52 39" src="https://user-images.githubusercontent.com/719641/126784803-5cc83bc5-daa7-4329-8a8d-2efbe98ef4e0.png">
<img width="1920" alt="Screenshot 2021-07-23 at 14 52 35" src="https://user-images.githubusercontent.com/719641/126784816-86b2d533-aeba-40d6-a8d4-6ce848f6b248.png">
<img width="1912" alt="Screenshot 2021-07-23 at 14 59 02" src="https://user-images.githubusercontent.com/719641/126784976-4f15bb8a-d4f4-4e04-a8a8-2e5d0f617d4b.png">
