### PR TITLE
[ios] Migrate expo-media-library to use expo-modules-core

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -116,7 +116,6 @@ PODS:
   - EXMediaLibrary (12.1.0):
     - ExpoModulesCore
     - React-Core
-    - UMCore
   - EXNetwork (3.2.0):
     - ExpoModulesCore
   - EXNotifications (0.12.0):
@@ -1167,7 +1166,7 @@ SPEC CHECKSUMS:
   EXLocalization: 356f4e16a606cec21a77d6250528fde526152b45
   EXLocation: bdf1af6aa8fc4f4dc1fd21aa39760484026f8a5d
   EXMailComposer: d1976c864ee1d74907b15c98ec68ddf5ca2331b1
-  EXMediaLibrary: bdbcfe2435571f9c83d6ced2e28ec193d69bc40d
+  EXMediaLibrary: 3243417362d85fb5881c27bf0c944b502324f7b2
   EXNetwork: c15bb1026d72d1eb3782710faf373ed35c6eb024
   EXNotifications: 296d9487163c2c08fffec5e79a5f9094bc016d9c
   EXPermissions: c7bead8f093700d5fcfb4f41238430a51702c5c8

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1888,7 +1888,6 @@ PODS:
   - EXMediaLibrary (12.1.0):
     - ExpoModulesCore
     - React-Core
-    - UMCore
   - EXNetwork (3.2.0):
     - ExpoModulesCore
   - EXNotifications (0.12.0):
@@ -4044,7 +4043,7 @@ SPEC CHECKSUMS:
   EXLocalization: 356f4e16a606cec21a77d6250528fde526152b45
   EXLocation: bdf1af6aa8fc4f4dc1fd21aa39760484026f8a5d
   EXMailComposer: d1976c864ee1d74907b15c98ec68ddf5ca2331b1
-  EXMediaLibrary: bdbcfe2435571f9c83d6ced2e28ec193d69bc40d
+  EXMediaLibrary: 3243417362d85fb5881c27bf0c944b502324f7b2
   EXNetwork: c15bb1026d72d1eb3782710faf373ed35c6eb024
   EXNotifications: 296d9487163c2c08fffec5e79a5f9094bc016d9c
   EXPermissions: c7bead8f093700d5fcfb4f41238430a51702c5c8

--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### 💡 Others
 
-- Migrated from `@unimodules/core` to `expo-modules-core`.
+- Migrated from `@unimodules/core` to `expo-modules-core`. ([#13755](https://github.com/expo/expo/pull/13755) by [@tsapeta](https://github.com/tsapeta))
 
 ## 12.1.0 — 2021-06-16
 

--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- Migrated from `@unimodules/core` to `expo-modules-core`.
+
 ## 12.1.0 — 2021-06-16
 
 ### 🐛 Bug fixes

--- a/packages/expo-media-library/ios/EXMediaLibrary.podspec
+++ b/packages/expo-media-library/ios/EXMediaLibrary.podspec
@@ -14,7 +14,6 @@ Pod::Spec.new do |s|
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.frameworks     = 'Photos','PhotosUI'
 
-  s.dependency 'UMCore'
   s.dependency 'ExpoModulesCore'
   s.dependency 'React-Core'
 

--- a/packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibrary.h
+++ b/packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibrary.h
@@ -1,10 +1,10 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
 #import <Photos/Photos.h>
-#import <UMCore/UMExportedModule.h>
-#import <UMCore/UMEventEmitter.h>
-#import <UMCore/UMModuleRegistryConsumer.h>
+#import <ExpoModulesCore/EXExportedModule.h>
+#import <ExpoModulesCore/EXEventEmitter.h>
+#import <ExpoModulesCore/EXModuleRegistryConsumer.h>
 
-@interface EXMediaLibrary : UMExportedModule <UMModuleRegistryConsumer, PHPhotoLibraryChangeObserver, UMEventEmitter>
+@interface EXMediaLibrary : EXExportedModule <EXModuleRegistryConsumer, PHPhotoLibraryChangeObserver, EXEventEmitter>
 
 @end

--- a/packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibrary.m
+++ b/packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibrary.m
@@ -10,9 +10,9 @@
 #import <EXMediaLibrary/EXMediaLibraryMediaLibraryPermissionRequester.h>
 #import <EXMediaLibrary/EXMediaLibraryMediaLibraryWriteOnlyPermissionRequester.h>
 
-#import <UMCore/UMDefines.h>
-#import <UMCore/UMUtilities.h>
-#import <UMCore/UMEventEmitterService.h>
+#import <ExpoModulesCore/EXDefines.h>
+#import <ExpoModulesCore/EXUtilities.h>
+#import <ExpoModulesCore/EXEventEmitterService.h>
 
 #import <ExpoModulesCore/EXFileSystemInterface.h>
 #import <ExpoModulesCore/EXPermissionsInterface.h>
@@ -35,14 +35,14 @@ NSString *const EXMediaLibraryShouldDownloadFromNetworkKey = @"shouldDownloadFro
 @property (nonatomic, strong) PHFetchResult *allAssetsFetchResult;
 @property (nonatomic, weak) id<EXPermissionsInterface> permissionsManager;
 @property (nonatomic, weak) id<EXFileSystemInterface> fileSystem;
-@property (nonatomic, weak) id<UMEventEmitterService> eventEmitter;
+@property (nonatomic, weak) id<EXEventEmitterService> eventEmitter;
 @property (nonatomic, strong) NSMutableSet *saveToLibraryDelegates;
 
 @end
 
 @implementation EXMediaLibrary
 
-UM_EXPORT_MODULE(ExponentMediaLibrary);
+EX_EXPORT_MODULE(ExponentMediaLibrary);
 
 - (instancetype) init
 {
@@ -52,10 +52,10 @@ UM_EXPORT_MODULE(ExponentMediaLibrary);
   return self;
 }
 
-- (void)setModuleRegistry:(UMModuleRegistry *)moduleRegistry
+- (void)setModuleRegistry:(EXModuleRegistry *)moduleRegistry
 {
   _fileSystem = [moduleRegistry getModuleImplementingProtocol:@protocol(EXFileSystemInterface)];
-  _eventEmitter = [moduleRegistry getModuleImplementingProtocol:@protocol(UMEventEmitterService)];
+  _eventEmitter = [moduleRegistry getModuleImplementingProtocol:@protocol(EXEventEmitterService)];
   _permissionsManager = [moduleRegistry getModuleImplementingProtocol:@protocol(EXPermissionsInterface)];
   [EXPermissionsMethodsDelegate registerRequesters:@[[EXMediaLibraryMediaLibraryPermissionRequester new], [EXMediaLibraryMediaLibraryWriteOnlyPermissionRequester new]] withPermissionsManager:_permissionsManager];
 }
@@ -107,10 +107,10 @@ UM_EXPORT_MODULE(ExponentMediaLibrary);
   }
 }
 
-UM_EXPORT_METHOD_AS(getPermissionsAsync,
+EX_EXPORT_METHOD_AS(getPermissionsAsync,
                     getPermissionsAsync:(BOOL)writeOnly
-                    resolve:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolve:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   [EXPermissionsMethodsDelegate getPermissionWithPermissionsManager:_permissionsManager
                                                       withRequester:[self requesterClass:writeOnly]
@@ -118,10 +118,10 @@ UM_EXPORT_METHOD_AS(getPermissionsAsync,
                                                              reject:reject];
 }
 
-UM_EXPORT_METHOD_AS(requestPermissionsAsync,
+EX_EXPORT_METHOD_AS(requestPermissionsAsync,
                     requestPermissionsAsync:(BOOL)writeOnly
-                    resolve:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolve:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   [EXPermissionsMethodsDelegate askForPermissionWithPermissionsManager:_permissionsManager
                                                          withRequester:[self requesterClass:writeOnly]
@@ -129,9 +129,9 @@ UM_EXPORT_METHOD_AS(requestPermissionsAsync,
                                                                 reject:reject];
 }
 
-UM_EXPORT_METHOD_AS(presentPermissionsPickerAsync,
-                    presentPermissionsPickerAsync:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(presentPermissionsPickerAsync,
+                    presentPermissionsPickerAsync:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
 #ifdef __IPHONE_14_0
   if (@available(iOS 14, *)) {
@@ -147,10 +147,10 @@ UM_EXPORT_METHOD_AS(presentPermissionsPickerAsync,
 #endif
 }
 
-UM_EXPORT_METHOD_AS(createAssetAsync,
+EX_EXPORT_METHOD_AS(createAssetAsync,
                     createAssetFromLocalUri:(nonnull NSString *)localUri
-                    resolve:(UMPromiseResolveBlock)resolve
-                    reject:(UMPromiseRejectBlock)reject)
+                    resolve:(EXPromiseResolveBlock)resolve
+                    reject:(EXPromiseRejectBlock)reject)
 {
   if (![self _checkPermissions:reject]) {
     return;
@@ -196,10 +196,10 @@ UM_EXPORT_METHOD_AS(createAssetAsync,
   }];
 }
 
-UM_EXPORT_METHOD_AS(saveToLibraryAsync,
+EX_EXPORT_METHOD_AS(saveToLibraryAsync,
                     saveToLibraryAsync:(nonnull NSString *)localUri
-                    resolve:(UMPromiseResolveBlock)resolve
-                    reject:(UMPromiseRejectBlock)reject)
+                    resolve:(EXPromiseResolveBlock)resolve
+                    reject:(EXPromiseRejectBlock)reject)
 {
   if ([[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSPhotoLibraryAddUsageDescription"] == nil) {
     return reject(@"E_NO_PERMISSIONS", @"This app is missing NSPhotoLibraryAddUsageDescription. Add this entry to your bundle's Info.plist.", nil);
@@ -212,11 +212,11 @@ UM_EXPORT_METHOD_AS(saveToLibraryAsync,
   
   PHAssetMediaType assetType = [EXMediaLibrary _assetTypeForUri:localUri];
   NSURL *assetUrl = [self.class _normalizeAssetURLFromUri:localUri];
-  UM_WEAKIFY(self)
+  EX_WEAKIFY(self)
   __block EXSaveToLibraryDelegate *delegate = [EXSaveToLibraryDelegate new];
   [_saveToLibraryDelegates addObject:delegate];
   EXSaveToLibraryCallback callback = ^(id asset, NSError *error){
-    UM_STRONGIFY(self)
+    EX_STRONGIFY(self)
     [self.saveToLibraryDelegates removeObject:delegate];
     if (error) {
       return reject(@"E_SAVE_FAILED", [error localizedDescription], nil);
@@ -240,11 +240,11 @@ UM_EXPORT_METHOD_AS(saveToLibraryAsync,
   return reject(@"E_UNSUPPORTED_ASSET", @"This file type is not supported yet.", nil);
 }
 
-UM_EXPORT_METHOD_AS(addAssetsToAlbumAsync,
+EX_EXPORT_METHOD_AS(addAssetsToAlbumAsync,
                     addAssets:(NSArray<NSString *> *)assetIds
                     toAlbum:(nonnull NSString *)albumId
-                    resolve:(UMPromiseResolveBlock)resolve
-                    reject:(UMPromiseRejectBlock)reject)
+                    resolve:(EXPromiseResolveBlock)resolve
+                    reject:(EXPromiseRejectBlock)reject)
 {
   [self _runIfAllPermissionsWereGranted:reject block:^{
     [EXMediaLibrary _addAssets:assetIds toAlbum:albumId withCallback:^(BOOL success, NSError *error) {
@@ -257,11 +257,11 @@ UM_EXPORT_METHOD_AS(addAssetsToAlbumAsync,
   }];
 }
 
-UM_EXPORT_METHOD_AS(removeAssetsFromAlbumAsync,
+EX_EXPORT_METHOD_AS(removeAssetsFromAlbumAsync,
                     removeAssets:(NSArray<NSString *> *)assetIds
                     fromAlbum:(nonnull NSString *)albumId
-                    resolve:(UMPromiseResolveBlock)resolve
-                    reject:(UMPromiseRejectBlock)reject)
+                    resolve:(EXPromiseResolveBlock)resolve
+                    reject:(EXPromiseRejectBlock)reject)
 {
   [self _runIfAllPermissionsWereGranted:reject block:^{
     [[PHPhotoLibrary sharedPhotoLibrary] performChanges:^{
@@ -283,10 +283,10 @@ UM_EXPORT_METHOD_AS(removeAssetsFromAlbumAsync,
   }];
 }
 
-UM_EXPORT_METHOD_AS(deleteAssetsAsync,
+EX_EXPORT_METHOD_AS(deleteAssetsAsync,
                     deleteAssets:(NSArray<NSString *>*)assetIds
-                    resolve:(UMPromiseResolveBlock)resolve
-                    reject:(UMPromiseRejectBlock)reject)
+                    resolve:(EXPromiseResolveBlock)resolve
+                    reject:(EXPromiseRejectBlock)reject)
 {
   if (![self _checkPermissions:reject]) {
     return;
@@ -305,10 +305,10 @@ UM_EXPORT_METHOD_AS(deleteAssetsAsync,
   }];
 }
 
-UM_EXPORT_METHOD_AS(getAlbumsAsync,
+EX_EXPORT_METHOD_AS(getAlbumsAsync,
                     getAlbumsWithOptions:(NSDictionary *)options
-                    resolve:(UMPromiseResolveBlock)resolve
-                    reject:(UMPromiseRejectBlock)reject)
+                    resolve:(EXPromiseResolveBlock)resolve
+                    reject:(EXPromiseRejectBlock)reject)
 {
   [self _runIfAllPermissionsWereGranted:reject block:^{
     NSMutableArray<NSDictionary *> *albums = [NSMutableArray new];
@@ -332,9 +332,9 @@ UM_EXPORT_METHOD_AS(getAlbumsAsync,
   }];
 }
 
-UM_EXPORT_METHOD_AS(getMomentsAsync,
-                    getMoments:(UMPromiseResolveBlock)resolve
-                    reject:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(getMomentsAsync,
+                    getMoments:(EXPromiseResolveBlock)resolve
+                    reject:(EXPromiseRejectBlock)reject)
 {
   if (![self _checkPermissions:reject]) {
     return;
@@ -350,22 +350,22 @@ UM_EXPORT_METHOD_AS(getMomentsAsync,
   resolve(albums);
 }
 
-UM_EXPORT_METHOD_AS(getAlbumAsync,
+EX_EXPORT_METHOD_AS(getAlbumAsync,
                     getAlbumWithTitle:(nonnull NSString *)title
-                    resolve:(UMPromiseResolveBlock)resolve
-                    reject:(UMPromiseRejectBlock)reject)
+                    resolve:(EXPromiseResolveBlock)resolve
+                    reject:(EXPromiseRejectBlock)reject)
 {
   [self _runIfAllPermissionsWereGranted:reject block:^{
     PHAssetCollection *collection = [EXMediaLibrary _getAlbumWithTitle:title];
-    resolve(UMNullIfNil([EXMediaLibrary _exportCollection:collection]));
+    resolve(EXNullIfNil([EXMediaLibrary _exportCollection:collection]));
   }];
 }
 
-UM_EXPORT_METHOD_AS(createAlbumAsync,
+EX_EXPORT_METHOD_AS(createAlbumAsync,
                     createAlbumWithTitle:(nonnull NSString *)title
                     withAssetId:(NSString *)assetId
-                    resolve:(UMPromiseResolveBlock)resolve
-                    reject:(UMPromiseRejectBlock)reject)
+                    resolve:(EXPromiseResolveBlock)resolve
+                    reject:(EXPromiseRejectBlock)reject)
 {
   [self _runIfAllPermissionsWereGranted:reject block:^{
     [EXMediaLibrary _createAlbumWithTitle:title completion:^(PHAssetCollection *collection, NSError *error) {
@@ -373,13 +373,13 @@ UM_EXPORT_METHOD_AS(createAlbumAsync,
         if (assetId) {
           [EXMediaLibrary _addAssets:@[assetId] toAlbum:collection.localIdentifier withCallback:^(BOOL success, NSError *error) {
             if (success) {
-              resolve(UMNullIfNil([EXMediaLibrary _exportCollection:collection]));
+              resolve(EXNullIfNil([EXMediaLibrary _exportCollection:collection]));
             } else {
               reject(@"E_ALBUM_CANT_ADD_ASSET", @"Unable to add asset to the new album", error);
             }
           }];
         } else {
-          resolve(UMNullIfNil([EXMediaLibrary _exportCollection:collection]));
+          resolve(EXNullIfNil([EXMediaLibrary _exportCollection:collection]));
         }
       } else {
         reject(@"E_ALBUM_CREATE_FAILED", @"Could not create album", error);
@@ -389,11 +389,11 @@ UM_EXPORT_METHOD_AS(createAlbumAsync,
 }
 
   
-UM_EXPORT_METHOD_AS(deleteAlbumsAsync,
+EX_EXPORT_METHOD_AS(deleteAlbumsAsync,
                     deleteAlbums:(nonnull NSArray<NSString *>*)albumIds
                     assetRemove:(NSNumber *)assetRemove
-                    resolve:(UMPromiseResolveBlock)resolve
-                    reject:(UMPromiseRejectBlock)reject)
+                    resolve:(EXPromiseResolveBlock)resolve
+                    reject:(EXPromiseRejectBlock)reject)
 {
   [self _runIfAllPermissionsWereGranted:reject block:^{
     PHFetchResult *collections = [EXMediaLibrary _getAlbumsById:albumIds];
@@ -415,11 +415,11 @@ UM_EXPORT_METHOD_AS(deleteAlbumsAsync,
   }];
 }
   
-UM_EXPORT_METHOD_AS(getAssetInfoAsync,
+EX_EXPORT_METHOD_AS(getAssetInfoAsync,
                     getAssetInfo:(nonnull NSString *)assetId
                     withOptions:(nonnull NSDictionary *)options
-                    resolve:(UMPromiseResolveBlock)resolve
-                    reject:(UMPromiseRejectBlock)reject)
+                    resolve:(EXPromiseResolveBlock)resolve
+                    reject:(EXPromiseRejectBlock)reject)
 {
   if (![self _checkPermissions:reject]) {
     return;
@@ -504,10 +504,10 @@ UM_EXPORT_METHOD_AS(getAssetInfoAsync,
   }
 }
 
-UM_EXPORT_METHOD_AS(getAssetsAsync,
+EX_EXPORT_METHOD_AS(getAssetsAsync,
                     getAssetsWithOptions:(NSDictionary *)options
-                    resolve:(UMPromiseResolveBlock)resolve
-                    reject:(UMPromiseRejectBlock)reject)
+                    resolve:(EXPromiseResolveBlock)resolve
+                    reject:(EXPromiseRejectBlock)reject)
 {
   if (![self _checkPermissions:reject]) {
     return;
@@ -518,8 +518,8 @@ UM_EXPORT_METHOD_AS(getAssetsAsync,
   NSInteger first = [options[@"first"] integerValue] ?: 20;
   NSArray<NSString *> *mediaType = options[@"mediaType"];
   NSArray *sortBy = options[@"sortBy"];
-  NSDate *createdAfter = [UMUtilities NSDate:options[@"createdAfter"]];
-  NSDate *createdBefore = [UMUtilities NSDate:options[@"createdBefore"]];
+  NSDate *createdAfter = [EXUtilities NSDate:options[@"createdAfter"]];
+  NSDate *createdBefore = [EXUtilities NSDate:options[@"createdBefore"]];
   NSString *albumId = options[@"album"];
 
   if (albumId) {
@@ -624,8 +624,8 @@ UM_EXPORT_METHOD_AS(getAssetsAsync,
                createdAfter:(NSDate *)createdAfter
               createdBefore:(NSDate *)createdBefore
                  collection:(PHAssetCollection *)collection
-                    resolve:(UMPromiseResolveBlock)resolve
-                     reject:(UMPromiseRejectBlock)reject
+                    resolve:(EXPromiseResolveBlock)resolve
+                     reject:(EXPromiseRejectBlock)reject
 {
   PHFetchOptions *fetchOptions = [PHFetchOptions new];
   NSMutableArray<NSPredicate *> *predicates = [NSMutableArray new];
@@ -868,14 +868,14 @@ UM_EXPORT_METHOD_AS(getAssetsAsync,
   if (collection) {
     return @{
              @"id": [EXMediaLibrary _assetIdFromLocalId:collection.localIdentifier],
-             @"title": UMNullIfNil(collection.localizedTitle),
-             @"folderName": UMNullIfNil(folderName),
+             @"title": EXNullIfNil(collection.localizedTitle),
+             @"folderName": EXNullIfNil(folderName),
              @"type": [EXMediaLibrary _stringifyAlbumType:collection.assetCollectionType],
              @"assetCount": [EXMediaLibrary _assetCountOfCollection:collection],
              @"startTime": [EXMediaLibrary _exportDate:collection.startDate],
              @"endTime": [EXMediaLibrary _exportDate:collection.endDate],
              @"approximateLocation": [EXMediaLibrary _exportLocation:collection.approximateLocation],
-             @"locationNames": UMNullIfNil(collection.localizedLocationNames),
+             @"locationNames": EXNullIfNil(collection.localizedLocationNames),
              };
   }
   return nil;
@@ -1100,7 +1100,7 @@ UM_EXPORT_METHOD_AS(getAssetsAsync,
   return [NSURL URLWithString:uri];
 }
 
-- (void)_runIfAllPermissionsWereGranted:(UMPromiseRejectBlock)reject block:(void (^)(void))block
+- (void)_runIfAllPermissionsWereGranted:(EXPromiseRejectBlock)reject block:(void (^)(void))block
 {
   [_permissionsManager getPermissionUsingRequesterClass:[EXMediaLibraryMediaLibraryPermissionRequester class] resolve:^(id result) {
     NSDictionary *permissions = (NSDictionary *)result;
@@ -1121,7 +1121,7 @@ UM_EXPORT_METHOD_AS(getAssetsAsync,
   } reject:reject];
 }
 
-- (BOOL)_checkPermissions:(UMPromiseRejectBlock)reject
+- (BOOL)_checkPermissions:(EXPromiseRejectBlock)reject
 {
   if (![_permissionsManager hasGrantedPermissionUsingRequesterClass:[EXMediaLibraryMediaLibraryPermissionRequester class]]) {
     reject(@"E_NO_PERMISSIONS", @"MEDIA_LIBRARY permission is required to do this operation.", nil);

--- a/packages/expo-media-library/ios/EXMediaLibrary/Permissions/EXMediaLibraryMediaLibraryPermissionRequester.m
+++ b/packages/expo-media-library/ios/EXMediaLibrary/Permissions/EXMediaLibraryMediaLibraryPermissionRequester.m
@@ -61,11 +61,11 @@
   };
 }
 
-- (void)requestPermissionsWithResolver:(UMPromiseResolveBlock)resolve rejecter:(UMPromiseRejectBlock)reject
+- (void)requestPermissionsWithResolver:(EXPromiseResolveBlock)resolve rejecter:(EXPromiseRejectBlock)reject
 {
-  UM_WEAKIFY(self)
+  EX_WEAKIFY(self)
   void(^handler)(PHAuthorizationStatus) = ^(PHAuthorizationStatus status) {
-    UM_STRONGIFY(self)
+    EX_STRONGIFY(self)
     resolve([self getPermissions]);
   };
 


### PR DESCRIPTION
# Why

`UMCore` is now deprecated in favor of `ExpoModulesCore`

# How

- Removed the dependency on `UMCore`
- Renamed imports and all references

# Test Plan

Examples seem to work as expected
