### PR TITLE
[ios] Migrate expo-calendar to expo-modules-core

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -36,7 +36,6 @@ PODS:
     - ExpoModulesCore
   - EXCalendar (9.2.0):
     - ExpoModulesCore
-    - UMCore
   - EXCamera (11.1.1):
     - ExpoModulesCore
   - EXCellular (3.2.0):
@@ -1138,7 +1137,7 @@ SPEC CHECKSUMS:
   EXBattery: 65a5d98f83be408ed29b4e00f4c1a607dd585654
   EXBlur: eb7277c806220f1bed59547b4b5240e2de462aff
   EXBrightness: 4532d07a5c34ddc887e1b85eeaff42eef6882bb1
-  EXCalendar: 64807f071c86ef3d9813fec49f55c38d5854c235
+  EXCalendar: 69cfd91805f2070e0b2dc0f48d39f08d915a2de1
   EXCamera: d39ee631cecae1722c12a0b5fe4651a09b262863
   EXCellular: 73ab436dd57f6b79ce5d6d542f930fc790dac19c
   EXClipboard: 247c22246c4843351f2f89cc29b654ecd936eaa8

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1810,7 +1810,6 @@ PODS:
     - ExpoModulesCore
   - EXCalendar (9.2.0):
     - ExpoModulesCore
-    - UMCore
   - EXCamera (11.1.1):
     - ExpoModulesCore
   - EXCellular (3.2.0):
@@ -4016,7 +4015,7 @@ SPEC CHECKSUMS:
   EXBlur: eb7277c806220f1bed59547b4b5240e2de462aff
   EXBranch: ce0f9b7537d7ee1f1eb58803b05d7634c7264160
   EXBrightness: 4532d07a5c34ddc887e1b85eeaff42eef6882bb1
-  EXCalendar: 64807f071c86ef3d9813fec49f55c38d5854c235
+  EXCalendar: 69cfd91805f2070e0b2dc0f48d39f08d915a2de1
   EXCamera: d39ee631cecae1722c12a0b5fe4651a09b262863
   EXCellular: c023099c6d53230d69c03a0ed0b515fbf2ffc5eb
   EXClipboard: 247c22246c4843351f2f89cc29b654ecd936eaa8

--- a/packages/expo-calendar/CHANGELOG.md
+++ b/packages/expo-calendar/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### 💡 Others
 
 - Rewrote from Java to Kotlin, migrated from `AsyncTask` to `kotlinx.coroutines`. ([#13527](https://github.com/expo/expo/pull/13527) by [@M1ST4KE](https://github.com/M1ST4KE))
-- Migrated from `@unimodules/core` to `expo-modules-core`.
+- Migrated from `@unimodules/core` to `expo-modules-core`. ([#13756](https://github.com/expo/expo/pull/13756) by [@tsapeta](https://github.com/tsapeta))
 
 ## 9.2.0 — 2021-06-16
 

--- a/packages/expo-calendar/CHANGELOG.md
+++ b/packages/expo-calendar/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 💡 Others
 
 - Rewrote from Java to Kotlin, migrated from `AsyncTask` to `kotlinx.coroutines`. ([#13527](https://github.com/expo/expo/pull/13527) by [@M1ST4KE](https://github.com/M1ST4KE))
+- Migrated from `@unimodules/core` to `expo-modules-core`.
 
 ## 9.2.0 — 2021-06-16
 

--- a/packages/expo-calendar/ios/EXCalendar.podspec
+++ b/packages/expo-calendar/ios/EXCalendar.podspec
@@ -13,7 +13,6 @@ Pod::Spec.new do |s|
   s.platform       = :ios, '11.0'
   s.source         = { git: 'https://github.com/expo/expo.git' }
 
-  s.dependency 'UMCore'
   s.dependency 'ExpoModulesCore'
 
   if !$ExpoUseSources&.include?(package['name']) && ENV['EXPO_USE_SOURCE'].to_i == 0 && File.exist?("#{s.name}.xcframework") && Gem::Version.new(Pod::VERSION) >= Gem::Version.new('1.10.0')

--- a/packages/expo-calendar/ios/EXCalendar/EXCalendar.h
+++ b/packages/expo-calendar/ios/EXCalendar/EXCalendar.h
@@ -1,8 +1,8 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
-#import <UMCore/UMExportedModule.h>
-#import <UMCore/UMModuleRegistryConsumer.h>
+#import <ExpoModulesCore/EXExportedModule.h>
+#import <ExpoModulesCore/EXModuleRegistryConsumer.h>
 
-@interface EXCalendar : UMExportedModule <UMModuleRegistryConsumer>
+@interface EXCalendar : EXExportedModule <EXModuleRegistryConsumer>
 
 @end

--- a/packages/expo-calendar/ios/EXCalendar/EXCalendar.m
+++ b/packages/expo-calendar/ios/EXCalendar/EXCalendar.m
@@ -3,7 +3,7 @@
 #import <UIKit/UIKit.h>
 #import <EventKit/EventKit.h>
 
-#import <UMCore/UMUtilities.h>
+#import <ExpoModulesCore/EXUtilities.h>
 
 #import <EXCalendar/EXCalendar.h>
 #import <EXCalendar/EXCalendarConverter.h>
@@ -33,9 +33,9 @@
   return self;
 }
 
-UM_EXPORT_MODULE(ExpoCalendar);
+EX_EXPORT_MODULE(ExpoCalendar);
 
-- (void)setModuleRegistry:(UMModuleRegistry *)moduleRegistry
+- (void)setModuleRegistry:(EXModuleRegistry *)moduleRegistry
 {
   _permissionsManager = [moduleRegistry getModuleImplementingProtocol:@protocol(EXPermissionsInterface)];
   [EXPermissionsMethodsDelegate registerRequesters:@[
@@ -60,10 +60,10 @@ UM_EXPORT_MODULE(ExpoCalendar);
 #pragma mark -
 #pragma mark Event Store Accessors
 
-UM_EXPORT_METHOD_AS(getCalendarsAsync,
+EX_EXPORT_METHOD_AS(getCalendarsAsync,
                     getCalendarsAsync:(NSString *)typeString
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   NSArray *calendars;
   if (!typeString) {
@@ -101,9 +101,9 @@ UM_EXPORT_METHOD_AS(getCalendarsAsync,
   resolve([EXCalendarConverter serializeCalendars:calendars]);
 }
 
-UM_EXPORT_METHOD_AS(getDefaultCalendarAsync,
-                    getDefaultCalendarAsync:(UMPromiseResolveBlock)resolve
-                    rejector:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(getDefaultCalendarAsync,
+                    getDefaultCalendarAsync:(EXPromiseResolveBlock)resolve
+                    rejector:(EXPromiseRejectBlock)reject)
 {
   if (![self _checkCalendarPermissions:reject]) {
     return;
@@ -116,10 +116,10 @@ UM_EXPORT_METHOD_AS(getDefaultCalendarAsync,
   resolve([EXCalendarConverter serializeCalendar:defaultCalendar]);
 }
 
-UM_EXPORT_METHOD_AS(saveCalendarAsync,
+EX_EXPORT_METHOD_AS(saveCalendarAsync,
                     saveCalendarAsync:(NSDictionary *)details
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   if (![self _checkCalendarPermissions:reject]) {
     return;
@@ -165,7 +165,7 @@ UM_EXPORT_METHOD_AS(saveCalendarAsync,
   }
 
   if (color) {
-    calendar.CGColor = [UMUtilities UIColor:color].CGColor;
+    calendar.CGColor = [EXUtilities UIColor:color].CGColor;
   } else if (details[@"color"] == [NSNull null]) {
     calendar.CGColor = nil;
   }
@@ -181,10 +181,10 @@ UM_EXPORT_METHOD_AS(saveCalendarAsync,
   }
 }
 
-UM_EXPORT_METHOD_AS(deleteCalendarAsync,
+EX_EXPORT_METHOD_AS(deleteCalendarAsync,
                     deleteCalendarAsync:(NSString *)calendarId
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   if (![self _checkCalendarPermissions:reject]) {
     return;
@@ -208,20 +208,20 @@ UM_EXPORT_METHOD_AS(deleteCalendarAsync,
   }
 }
 
-UM_EXPORT_METHOD_AS(getEventsAsync,
+EX_EXPORT_METHOD_AS(getEventsAsync,
                     getEventsAsync:(NSString *)startDateStr
                     endDate:(NSString *)endDateStr
                     calendars:(NSArray *)calendars
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   if (![self _checkCalendarPermissions:reject]) {
     return;
   }
 
   NSMutableArray *eventCalendars;
-  NSDate *startDate = [UMUtilities NSDate:startDateStr];
-  NSDate *endDate = [UMUtilities NSDate:endDateStr];
+  NSDate *startDate = [EXUtilities NSDate:startDateStr];
+  NSDate *endDate = [EXUtilities NSDate:endDateStr];
 
   if (calendars.count) {
     eventCalendars = [[NSMutableArray alloc] init];
@@ -249,17 +249,17 @@ UM_EXPORT_METHOD_AS(getEventsAsync,
   }
 }
 
-UM_EXPORT_METHOD_AS(getEventByIdAsync,
+EX_EXPORT_METHOD_AS(getEventByIdAsync,
                     getEventByIdAsync:(NSString *)eventId
                     startDate:(NSString *)startDateStr
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   if (![self _checkCalendarPermissions:reject]) {
     return;
   }
 
-  NSDate *startDate = [UMUtilities NSDate:startDateStr];
+  NSDate *startDate = [EXUtilities NSDate:startDateStr];
   EKEvent *calendarEvent = [self _getEventWithId:eventId startDate:startDate];
 
   if (calendarEvent) {
@@ -271,11 +271,11 @@ UM_EXPORT_METHOD_AS(getEventByIdAsync,
   }
 }
 
-UM_EXPORT_METHOD_AS(saveEventAsync,
+EX_EXPORT_METHOD_AS(saveEventAsync,
                     saveEventAsync:(NSDictionary *)details
                     options:(NSDictionary *)options
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   if (![self _checkCalendarPermissions:reject]) {
     return;
@@ -286,9 +286,9 @@ UM_EXPORT_METHOD_AS(saveEventAsync,
   NSString *eventId = details[@"id"];
   NSString *title = details[@"title"];
   NSString *location = details[@"location"];
-  NSDate *startDate = [UMUtilities NSDate:details[@"startDate"]];
-  NSDate *endDate = [UMUtilities NSDate:details[@"endDate"]];
-  NSDate *instanceStartDate = [UMUtilities NSDate:details[@"instanceStartDate"]];
+  NSDate *startDate = [EXUtilities NSDate:details[@"startDate"]];
+  NSDate *endDate = [EXUtilities NSDate:details[@"endDate"]];
+  NSDate *instanceStartDate = [EXUtilities NSDate:details[@"instanceStartDate"]];
   NSNumber *allDay = details[@"allDay"];
   NSString *notes = details[@"notes"];
   NSString *timeZone = details[@"timeZone"];
@@ -420,11 +420,11 @@ UM_EXPORT_METHOD_AS(saveEventAsync,
   }
 }
 
-UM_EXPORT_METHOD_AS(deleteEventAsync,
+EX_EXPORT_METHOD_AS(deleteEventAsync,
                     deleteEventAsync:(NSDictionary *)event
                     options:(NSDictionary *)options
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   if (![self _checkCalendarPermissions:reject]) {
     return;
@@ -436,7 +436,7 @@ UM_EXPORT_METHOD_AS(deleteEventAsync,
     span = EKSpanFutureEvents;
   }
 
-  NSDate *instanceStartDate = [UMUtilities NSDate:event[@"instanceStartDate"]];
+  NSDate *instanceStartDate = [EXUtilities NSDate:event[@"instanceStartDate"]];
 
   EKEvent *calendarEvent = [self _getEventWithId:event[@"id"] startDate:instanceStartDate];
 
@@ -456,16 +456,16 @@ UM_EXPORT_METHOD_AS(deleteEventAsync,
   }
 }
 
-UM_EXPORT_METHOD_AS(getAttendeesForEventAsync,
+EX_EXPORT_METHOD_AS(getAttendeesForEventAsync,
                     getAttendeesForEventAsync:(NSDictionary *)event
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   if (![self _checkCalendarPermissions:reject]) {
     return;
   }
 
-  NSDate *instanceStartDate = [UMUtilities NSDate:event[@"instanceStartDate"]];
+  NSDate *instanceStartDate = [EXUtilities NSDate:event[@"instanceStartDate"]];
 
   EKEvent *item = [self _getEventWithId:event[@"id"] startDate:instanceStartDate];
 
@@ -482,21 +482,21 @@ UM_EXPORT_METHOD_AS(getAttendeesForEventAsync,
   }
 }
 
-UM_EXPORT_METHOD_AS(getRemindersAsync,
+EX_EXPORT_METHOD_AS(getRemindersAsync,
                     getRemindersAsync:(NSString * _Nullable)startDateStr
                     endDate:(NSString * _Nullable)endDateStr
                     calendars:(NSArray *)calendars
                     status:(NSString * _Nullable)status
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   if (![self _checkRemindersPermissions:reject]) {
     return;
   }
 
   NSMutableArray *reminderCalendars;
-  NSDate *startDate = [UMUtilities NSDate:startDateStr];
-  NSDate *endDate = [UMUtilities NSDate:endDateStr];
+  NSDate *startDate = [EXUtilities NSDate:startDateStr];
+  NSDate *endDate = [EXUtilities NSDate:endDateStr];
 
   if (calendars.count) {
     reminderCalendars = [[NSMutableArray alloc] init];
@@ -532,10 +532,10 @@ UM_EXPORT_METHOD_AS(getRemindersAsync,
   }];
 }
 
-UM_EXPORT_METHOD_AS(getReminderByIdAsync,
+EX_EXPORT_METHOD_AS(getReminderByIdAsync,
                     getReminderByIdAsync:(NSString *)reminderId
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   if (![self _checkRemindersPermissions:reject]) {
     return;
@@ -558,10 +558,10 @@ UM_EXPORT_METHOD_AS(getReminderByIdAsync,
   }
 }
 
-UM_EXPORT_METHOD_AS(saveReminderAsync,
+EX_EXPORT_METHOD_AS(saveReminderAsync,
                     saveReminderAsync:(NSDictionary *)details
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   if (![self _checkRemindersPermissions:reject]) {
     return;
@@ -570,9 +570,9 @@ UM_EXPORT_METHOD_AS(saveReminderAsync,
   EKReminder *reminder = nil;
   NSString *calendarId = details[@"calendarId"];
   NSString *reminderId = details[@"id"];
-  NSDate *startDate = [UMUtilities NSDate:details[@"startDate"]];
-  NSDate *dueDate = [UMUtilities NSDate:details[@"dueDate"]];
-  NSDate *completionDate = [UMUtilities NSDate:details[@"completionDate"]];
+  NSDate *startDate = [EXUtilities NSDate:details[@"startDate"]];
+  NSDate *dueDate = [EXUtilities NSDate:details[@"dueDate"]];
+  NSDate *completionDate = [EXUtilities NSDate:details[@"completionDate"]];
   NSNumber *completed = details[@"completed"];
   NSString *title = details[@"title"];
   NSString *location = details[@"location"];
@@ -693,10 +693,10 @@ UM_EXPORT_METHOD_AS(saveReminderAsync,
   }
 }
 
-UM_EXPORT_METHOD_AS(deleteReminderAsync,
+EX_EXPORT_METHOD_AS(deleteReminderAsync,
                     deleteReminderAsync:(NSString *)reminderId
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   if (![self _checkRemindersPermissions:reject]) {
     return;
@@ -720,9 +720,9 @@ UM_EXPORT_METHOD_AS(deleteReminderAsync,
   }
 }
 
-UM_EXPORT_METHOD_AS(getSourcesAsync,
-                    getSourcesAsync:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(getSourcesAsync,
+                    getSourcesAsync:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   NSArray *sources = [self.eventStore sources];
 
@@ -740,10 +740,10 @@ UM_EXPORT_METHOD_AS(getSourcesAsync,
   resolve(serializedSources);
 }
 
-UM_EXPORT_METHOD_AS(getSourceByIdAsync,
+EX_EXPORT_METHOD_AS(getSourceByIdAsync,
                     getSourceByIdAsync:(NSString *)sourceId
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   EKSource *source = [self.eventStore sourceWithIdentifier:sourceId];
   if (!source) {
@@ -756,9 +756,9 @@ UM_EXPORT_METHOD_AS(getSourceByIdAsync,
   resolve([EXCalendarConverter serializeSource:source]);
 }
 
-UM_EXPORT_METHOD_AS(getCalendarPermissionsAsync,
-                    getCalendarPermissionsAsync:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(getCalendarPermissionsAsync,
+                    getCalendarPermissionsAsync:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   [EXPermissionsMethodsDelegate getPermissionWithPermissionsManager:_permissionsManager
                                                       withRequester:[EXCalendarPermissionRequester class]
@@ -766,9 +766,9 @@ UM_EXPORT_METHOD_AS(getCalendarPermissionsAsync,
                                                              reject:reject];
 }
 
-UM_EXPORT_METHOD_AS(requestCalendarPermissionsAsync,
-                    requestCalendarPermissionsAsync:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(requestCalendarPermissionsAsync,
+                    requestCalendarPermissionsAsync:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   [EXPermissionsMethodsDelegate askForPermissionWithPermissionsManager:_permissionsManager
                                                          withRequester:[EXCalendarPermissionRequester class]
@@ -776,9 +776,9 @@ UM_EXPORT_METHOD_AS(requestCalendarPermissionsAsync,
                                                                 reject:reject];
 }
 
-UM_EXPORT_METHOD_AS(getRemindersPermissionsAsync,
-                    getRemindersPermissionsAsync:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(getRemindersPermissionsAsync,
+                    getRemindersPermissionsAsync:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   [EXPermissionsMethodsDelegate getPermissionWithPermissionsManager:_permissionsManager
                                                       withRequester:[EXRemindersPermissionRequester class]
@@ -786,9 +786,9 @@ UM_EXPORT_METHOD_AS(getRemindersPermissionsAsync,
                                                              reject:reject];
 }
 
-UM_EXPORT_METHOD_AS(requestRemindersPermissionsAsync,
-                    requestRemindersPermissionsAsync:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(requestRemindersPermissionsAsync,
+                    requestRemindersPermissionsAsync:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   [EXPermissionsMethodsDelegate askForPermissionWithPermissionsManager:_permissionsManager
                                                          withRequester:[EXRemindersPermissionRequester class]
@@ -835,7 +835,7 @@ UM_EXPORT_METHOD_AS(requestRemindersPermissionsAsync,
 {
   EKAlarm *calendarEventAlarm = nil;
 
-  NSDate *date = [UMUtilities NSDate:alarm[@"absoluteDate"]];
+  NSDate *date = [EXUtilities NSDate:alarm[@"absoluteDate"]];
   NSNumber *relativeOffset = alarm[@"relativeOffset"];
 
   if (date) {
@@ -907,7 +907,7 @@ UM_EXPORT_METHOD_AS(requestRemindersPermissionsAsync,
   }
 
   if (recurrenceRule[@"endDate"]) {
-      endDate = [UMUtilities NSDate:recurrenceRule[@"endDate"]];
+      endDate = [EXUtilities NSDate:recurrenceRule[@"endDate"]];
   }
 
   NSMutableArray *daysOfTheWeek = nil;
@@ -981,7 +981,7 @@ UM_EXPORT_METHOD_AS(requestRemindersPermissionsAsync,
   return EKEventAvailabilityNotSupported;
 }
 
-- (BOOL)_checkPermissions:(EKEntityType)entity reject:(UMPromiseRejectBlock)reject
+- (BOOL)_checkPermissions:(EKEntityType)entity reject:(EXPromiseRejectBlock)reject
 {
   if (_eventStore && _permittedEntities & entity) {
     return YES;
@@ -1012,12 +1012,12 @@ UM_EXPORT_METHOD_AS(requestRemindersPermissionsAsync,
   return YES;
 }
 
-- (BOOL)_checkCalendarPermissions:(UMPromiseRejectBlock)reject
+- (BOOL)_checkCalendarPermissions:(EXPromiseRejectBlock)reject
 {
   return [self _checkPermissions:EKEntityTypeEvent reject:reject];
 }
 
-- (BOOL)_checkRemindersPermissions:(UMPromiseRejectBlock)reject
+- (BOOL)_checkRemindersPermissions:(EXPromiseRejectBlock)reject
 {
   return [self _checkPermissions:EKEntityTypeReminder reject:reject];
 }

--- a/packages/expo-calendar/ios/EXCalendar/EXCalendarConverter.m
+++ b/packages/expo-calendar/ios/EXCalendar/EXCalendarConverter.m
@@ -1,6 +1,6 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
-#import <UMCore/UMUtilities.h>
+#import <ExpoModulesCore/EXUtilities.h>
 #import <EXCalendar/EXCalendarConverter.h>
 
 @implementation EXCalendarConverter
@@ -124,7 +124,7 @@
   return @{
        @"id": source.sourceIdentifier,
        @"type": [EXCalendarConverter _sourceType:source.sourceType],
-       @"name": UMNullIfNil(source.title)
+       @"name": EXNullIfNil(source.title)
        };
 }
 
@@ -132,11 +132,11 @@
 {
   NSMutableDictionary *serializedCalendar = [[NSMutableDictionary alloc] init];
 
-  serializedCalendar[@"id"] = UMNullIfNil(calendar.calendarIdentifier);
-  serializedCalendar[@"title"] = UMNullIfNil(calendar.title);
-  serializedCalendar[@"source"] = UMNullIfNil([EXCalendarConverter serializeSource:calendar.source]);
+  serializedCalendar[@"id"] = EXNullIfNil(calendar.calendarIdentifier);
+  serializedCalendar[@"title"] = EXNullIfNil(calendar.title);
+  serializedCalendar[@"source"] = EXNullIfNil([EXCalendarConverter serializeSource:calendar.source]);
   serializedCalendar[@"entityType"] = [EXCalendarConverter _entityType:calendar.allowedEntityTypes];
-  serializedCalendar[@"color"] = calendar.CGColor ? [UMUtilities hexStringWithCGColor:calendar.CGColor] : [NSNull null];
+  serializedCalendar[@"color"] = calendar.CGColor ? [EXUtilities hexStringWithCGColor:calendar.CGColor] : [NSNull null];
   serializedCalendar[@"type"] = [EXCalendarConverter _calendarType:calendar.type];
   serializedCalendar[@"allowsModifications"] = @(calendar.allowsContentModifications);
   serializedCalendar[@"allowedAvailabilities"] = [EXCalendarConverter _calendarSupportedAvailabilitiesFromMask:calendar.supportedEventAvailabilities];
@@ -183,9 +183,9 @@
     serializedItem[@"lastModifiedDate"] = [dateFormatter stringFromDate:item.lastModifiedDate];
   }
 
-  serializedItem[@"timeZone"] = UMNullIfNil(item.timeZone.name);
-  serializedItem[@"url"] = UMNullIfNil(item.URL.absoluteString.stringByRemovingPercentEncoding);
-  serializedItem[@"notes"] = UMNullIfNil(item.notes);
+  serializedItem[@"timeZone"] = EXNullIfNil(item.timeZone.name);
+  serializedItem[@"url"] = EXNullIfNil(item.URL.absoluteString.stringByRemovingPercentEncoding);
+  serializedItem[@"notes"] = EXNullIfNil(item.notes);
   serializedItem[@"alarms"] = [EXCalendarConverter _serializeAlarms:item.alarms withDateFormatter:dateFormatter];
 
   if (item.hasRecurrenceRules) {
@@ -281,7 +281,7 @@
   formedCalendarEvent[@"allDay"] = [NSNumber numberWithBool:event.allDay];
   formedCalendarEvent[@"availability"] = [EXCalendarConverter _eventAvailability:event.availability];
   formedCalendarEvent[@"status"] = [EXCalendarConverter _eventStatus:event.status];
-  formedCalendarEvent[@"organizer"] = UMNullIfNil([EXCalendarConverter _serializeAttendee:event.organizer]);
+  formedCalendarEvent[@"organizer"] = EXNullIfNil([EXCalendarConverter _serializeAttendee:event.organizer]);
 
   return formedCalendarEvent;
 }

--- a/packages/expo-calendar/ios/EXCalendar/EXCalendarPermissionRequester.m
+++ b/packages/expo-calendar/ios/EXCalendar/EXCalendarPermissionRequester.m
@@ -1,6 +1,6 @@
 #import <EXCalendar/EXCalendarPermissionRequester.h>
 #import <EventKit/EventKit.h>
-#import <UMCore/UMDefines.h>
+#import <ExpoModulesCore/EXDefines.h>
 
 @implementation EXCalendarPermissionRequester
 
@@ -16,7 +16,7 @@
   
   NSString *calendarUsageDescription = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSCalendarsUsageDescription"];
   if (!calendarUsageDescription) {
-    UMFatal(UMErrorWithMessage(@"This app is missing NSCalendarsUsageDescription, so calendar methods will fail. Add this key to your bundle's Info.plist."));
+    EXFatal(EXErrorWithMessage(@"This app is missing NSCalendarsUsageDescription, so calendar methods will fail. Add this key to your bundle's Info.plist."));
     permissions = EKAuthorizationStatusDenied;
   } else {
     permissions = [EKEventStore authorizationStatusForEntityType:EKEntityTypeEvent];
@@ -38,12 +38,12 @@
   };
 }
 
-- (void)requestPermissionsWithResolver:(UMPromiseResolveBlock)resolve rejecter:(UMPromiseRejectBlock)reject
+- (void)requestPermissionsWithResolver:(EXPromiseResolveBlock)resolve rejecter:(EXPromiseRejectBlock)reject
 {
   EKEventStore *eventStore = [[EKEventStore alloc] init];
-  UM_WEAKIFY(self)
+  EX_WEAKIFY(self)
   [eventStore requestAccessToEntityType:EKEntityTypeEvent completion:^(BOOL granted, NSError *error) {
-    UM_STRONGIFY(self)
+    EX_STRONGIFY(self)
     // Error code 100 is a when the user denies permission; in that case we don't want to reject.
     if (error && error.code != 100) {
       reject(@"E_CALENDAR_ERROR_UNKNOWN", error.localizedDescription, error);

--- a/packages/expo-calendar/ios/EXCalendar/EXRemindersPermissionRequester.m
+++ b/packages/expo-calendar/ios/EXCalendar/EXRemindersPermissionRequester.m
@@ -16,7 +16,7 @@
   
   NSString *remindersUsageDescription = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSRemindersUsageDescription"];
   if (!remindersUsageDescription) {
-    UMFatal(UMErrorWithMessage(@"This app is missing NSRemindersUsageDescription, so reminders methods will fail. Add this key to your bundle's Info.plist."));
+    EXFatal(EXErrorWithMessage(@"This app is missing NSRemindersUsageDescription, so reminders methods will fail. Add this key to your bundle's Info.plist."));
     permissions = EKAuthorizationStatusDenied;
   } else {
     permissions = [EKEventStore authorizationStatusForEntityType:EKEntityTypeReminder];
@@ -38,12 +38,12 @@
           };
 }
 
-- (void)requestPermissionsWithResolver:(UMPromiseResolveBlock)resolve rejecter:(UMPromiseRejectBlock)reject
+- (void)requestPermissionsWithResolver:(EXPromiseResolveBlock)resolve rejecter:(EXPromiseRejectBlock)reject
 {
   EKEventStore *eventStore = [[EKEventStore alloc] init];
-  UM_WEAKIFY(self)
+  EX_WEAKIFY(self)
   [eventStore requestAccessToEntityType:EKEntityTypeReminder completion:^(BOOL granted, NSError *error) {
-    UM_STRONGIFY(self)
+    EX_STRONGIFY(self)
     // Error code 100 is a when the user denies permission; in that case we don't want to reject.
     if (error && error.code != 100) {
       reject(@"E_REMINDERS_ERROR_UNKNOWN", error.localizedDescription, error);


### PR DESCRIPTION
# Why

`UMCore` is now deprecated in favor of `ExpoModulesCore`

# How

- Removed the dependency on `UMCore`
- Renamed imports and all references

# Test Plan

Examples seem to work as expected
