### PR TITLE
[ios] Migrate some packages to use expo-modules-core

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -13,7 +13,7 @@ PODS:
   - DoubleConversion (1.1.6)
   - EXAmplitude (10.2.0):
     - Amplitude (~> 6.0.0)
-    - UMCore
+    - ExpoModulesCore
   - EXAppAuth (10.2.0):
     - AppAuth (~> 1.2)
     - UMCore
@@ -22,20 +22,18 @@ PODS:
   - EXAV (9.2.0):
     - ExpoModulesCore
   - EXBackgroundFetch (9.2.0):
-    - UMCore
+    - ExpoModulesCore
     - UMTaskManagerInterface
   - EXBarCodeScanner (10.2.0):
     - ExpoModulesCore
-    - UMCore
     - ZXingObjC/OneD
     - ZXingObjC/PDF417
   - EXBattery (5.0.0):
-    - UMCore
+    - ExpoModulesCore
   - EXBlur (9.0.3):
-    - UMCore
+    - ExpoModulesCore
   - EXBrightness (9.2.0):
     - ExpoModulesCore
-    - UMCore
   - EXCalendar (9.2.0):
     - ExpoModulesCore
     - UMCore
@@ -44,7 +42,7 @@ PODS:
   - EXCellular (3.2.0):
     - ExpoModulesCore
   - EXClipboard (1.1.0):
-    - UMCore
+    - ExpoModulesCore
   - EXConstants (11.0.0):
     - ExpoModulesCore
     - UMCore
@@ -52,26 +50,23 @@ PODS:
     - ExpoModulesCore
     - UMCore
   - EXCrypto (9.2.0):
-    - UMCore
+    - ExpoModulesCore
   - EXDevice (3.3.0):
-    - UMCore
+    - ExpoModulesCore
   - EXDocumentPicker (9.2.0):
     - ExpoModulesCore
-    - UMCore
   - EXErrorRecovery (2.2.0):
-    - UMCore
+    - ExpoModulesCore
   - EXFacebook (11.2.0):
     - ExpoModulesCore
     - FacebookSDK/CoreKit (= 9.2.0)
     - FacebookSDK/LoginKit (= 9.2.0)
-    - UMCore
   - EXFaceDetector (10.1.0):
     - ExpoModulesCore
     - GoogleMLKit/FaceDetection (= 2.1.0)
     - MLKitCommon (= 2.1.0)
     - MLKitFaceDetection (= 1.2.0)
     - MLKitVision (= 1.2.0)
-    - UMCore
   - EXFileSystem (11.1.0):
     - ExpoModulesCore
   - EXFirebaseAnalytics (4.1.0):
@@ -87,7 +82,6 @@ PODS:
   - EXGL (10.4.0):
     - EXGL_CPP
     - ExpoModulesCore
-    - UMCore
   - EXGL_CPP (10.4.0):
     - React-jsi
   - EXGoogleSignIn (9.2.0):
@@ -101,7 +95,6 @@ PODS:
     - UMCore
   - EXImageManipulator (9.2.0):
     - ExpoModulesCore
-    - UMCore
   - EXImagePicker (10.2.0):
     - ExpoModulesCore
     - UMCore
@@ -121,19 +114,17 @@ PODS:
     - UMTaskManagerInterface
   - EXMailComposer (10.2.0):
     - ExpoModulesCore
-    - UMCore
   - EXMediaLibrary (12.1.0):
     - ExpoModulesCore
     - React-Core
     - UMCore
   - EXNetwork (3.2.0):
-    - UMCore
+    - ExpoModulesCore
   - EXNotifications (0.12.0):
     - ExpoModulesCore
     - UMCore
   - EXPermissions (12.1.0):
     - ExpoModulesCore
-    - UMCore
   - expo-dev-client (0.4.5):
     - expo-dev-launcher
     - expo-dev-menu
@@ -176,7 +167,6 @@ PODS:
     - React-Core
   - EXPrint (10.2.0):
     - ExpoModulesCore
-    - UMCore
   - EXRandom (11.2.0):
     - React-Core
   - EXScreenCapture (3.2.0):
@@ -185,20 +175,19 @@ PODS:
     - React-Core
     - UMCore
   - EXSecureStore (10.2.0):
-    - UMCore
+    - ExpoModulesCore
   - EXSegment (10.2.0):
     - Analytics (= 4.0.4)
-    - UMCore
+    - ExpoModulesCore
   - EXSensors (10.2.0):
     - ExpoModulesCore
     - UMCore
   - EXSharing (9.2.0):
     - ExpoModulesCore
-    - UMCore
   - EXSMS (9.2.0):
-    - UMCore
+    - ExpoModulesCore
   - EXSpeech (9.2.0):
-    - UMCore
+    - ExpoModulesCore
   - EXSplashScreen (0.11.0):
     - React-Core
     - UMCore
@@ -206,7 +195,7 @@ PODS:
     - ExpoModulesCore
     - UMCore
   - EXStoreReview (4.1.0):
-    - UMCore
+    - ExpoModulesCore
   - EXStructuredHeaders (1.1.0):
     - UMCore
   - EXTaskManager (9.2.0):
@@ -219,9 +208,8 @@ PODS:
   - EXUpdatesInterface (0.2.2)
   - EXVideoThumbnails (5.2.0):
     - ExpoModulesCore
-    - UMCore
   - EXWebBrowser (9.2.0):
-    - UMCore
+    - ExpoModulesCore
   - FacebookSDK/CoreKit (9.2.0):
     - FBSDKCoreKit (~> 9.2.0)
   - FacebookSDK/LoginKit (9.2.0):
@@ -1141,37 +1129,37 @@ SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   CocoaLumberjack: b7e05132ff94f6ae4dfa9d5bce9141893a21d9da
   DoubleConversion: cde416483dac037923206447da6e1454df403714
-  EXAmplitude: b3ef1ed2ae853bccd08a685d2f0352c603b215fe
+  EXAmplitude: 19866218bc855e6ac7a29e5c8ec1b24eab81b40c
   EXAppAuth: b7ecb4ce7634676985f67d2489054ea7727cd5e3
   EXApplication: 9ff2a206009d6e55bca6c20b3f33d07986b51ef3
   EXAV: 7f27c872fb45479d66e762a88484f58d52174131
-  EXBackgroundFetch: 5a15dc52d77d5ea4b0896c283679e271447921d4
-  EXBarCodeScanner: 22f8d8ea393de371e80f9529664c07900e1e7639
-  EXBattery: 6adbf9706bbe00d266b17b7846d556db9dea82c2
-  EXBlur: 50d490040f3b14898ed8198d5125dc699189f4d9
-  EXBrightness: b0eb62f204669cd7ae926847794b5bfabd595a4f
+  EXBackgroundFetch: aeaddb8ff64e13b1c2766f1e4a09bb727a6330aa
+  EXBarCodeScanner: afd5eb520bb133688dc680453465842ffbcef47c
+  EXBattery: 65a5d98f83be408ed29b4e00f4c1a607dd585654
+  EXBlur: eb7277c806220f1bed59547b4b5240e2de462aff
+  EXBrightness: 4532d07a5c34ddc887e1b85eeaff42eef6882bb1
   EXCalendar: 64807f071c86ef3d9813fec49f55c38d5854c235
   EXCamera: d39ee631cecae1722c12a0b5fe4651a09b262863
   EXCellular: 73ab436dd57f6b79ce5d6d542f930fc790dac19c
-  EXClipboard: c66f7d22ba754496b0fc6b23a2cb9a3e10fa1581
+  EXClipboard: 247c22246c4843351f2f89cc29b654ecd936eaa8
   EXConstants: 0c200d22d140d3f1834dc51c4ebe0465ddaa82c5
   EXContacts: bc06f42aa1bc7fb5ed0f5b29287f772faa33ad55
-  EXCrypto: 46e28f1eb7ec3e2ae5aab652fe1dc4d46bafb386
-  EXDevice: 6f1eed02c099f5b382a12a40406c58868892aba6
-  EXDocumentPicker: fa00c1852b1780ddecbdeb1bb6e74165d5d44a45
-  EXErrorRecovery: 404d827bc7d42f306c062d58a60b06afc4d082b3
-  EXFacebook: 71cc9f6b6bbdf0bc702d65c287f23cab14cc6430
-  EXFaceDetector: e0908fe9700ed402a9658975a3eac719479b5205
+  EXCrypto: e64a6d6d3f785801384004a4197b0f95a23a2761
+  EXDevice: 74b193bafc7fc162eb435b8810b72143ab7743af
+  EXDocumentPicker: 52183e4bdffbbd50e61726066f529455227c5daa
+  EXErrorRecovery: 500f15bfbced54161641cf82c45d39103d33462a
+  EXFacebook: 052783a39c092ad47015e2e2af8e6d33e9d92089
+  EXFaceDetector: 47c8c4a10c5b86c5ea9c77ca7b517102833a6d9b
   EXFileSystem: 9a77e33ba77e8b1ffbbe0625a211e3abee6f69ab
   EXFirebaseAnalytics: ca01838167729b67f838a673e4b3e0637faec118
   EXFirebaseCore: 9b5380fd62fce3c790fa1d6727a8d7cbbef4f0fb
   EXFont: 6e7d5a7a09fbd0ee801de76601b2e620c4d2f575
-  EXGL: 6c3cb47b094c185c6e3fdac50449a504458052c2
+  EXGL: 468113f7d19c139873e8e2b809ddef064ba847c0
   EXGL_CPP: dcca866c4f6af6694a12217fb2db3325acd19b57
   EXGoogleSignIn: d61beec381962b350f6ed60c9b65ae46ca26ef12
   EXHaptics: 7b00d17689431152ab194ab2b800d6e752b2737d
   EXImageLoader: d3531a3fe530b22925c19977cb53bb43e3821fe6
-  EXImageManipulator: c4a7a24d867f8b2bb15e5d0d64ff8f3c2fb35761
+  EXImageManipulator: a5bec1d69308fa1f091378f6461ae348ec83105d
   EXImagePicker: 958720afb9395ee1168dcda28d9915345c4e7cae
   EXInAppPurchases: e54068db701c8879d975a1f304b2d00e6fc8eece
   EXKeepAwake: f4105ef469be7b283f66ce2d7234bb71ac80cd26
@@ -1179,36 +1167,36 @@ SPEC CHECKSUMS:
   EXLocalAuthentication: e6347880c31bc3b9693933780d3bc84823fe0698
   EXLocalization: 356f4e16a606cec21a77d6250528fde526152b45
   EXLocation: bdf1af6aa8fc4f4dc1fd21aa39760484026f8a5d
-  EXMailComposer: 3eefb2b73dd4587856a8b1f82daaed6156451b36
+  EXMailComposer: d1976c864ee1d74907b15c98ec68ddf5ca2331b1
   EXMediaLibrary: bdbcfe2435571f9c83d6ced2e28ec193d69bc40d
-  EXNetwork: 6682b2bbbd90e66c4738159abaf8cd206c25e8b8
+  EXNetwork: c15bb1026d72d1eb3782710faf373ed35c6eb024
   EXNotifications: 296d9487163c2c08fffec5e79a5f9094bc016d9c
-  EXPermissions: 8eb648bd5c2115d01a39dc7c2ad4c94a5846e4cb
+  EXPermissions: c7bead8f093700d5fcfb4f41238430a51702c5c8
   expo-dev-client: 6f833f384c5fcc59e96a91268601dabcd16f70f0
   expo-dev-launcher: 696f20b99996080a3eebdaa723627a614e526ada
   expo-dev-menu: c1d43574828f37cb541a0bb52fe7bb7829586147
   expo-dev-menu-interface: 848563c91c9f36f963a8456e885129a46f4cdfa1
   expo-image: ea170930bd8bc42328ee74ff4dc861ca31587dc8
   ExpoModulesCore: 82ee658feb15e6804de9f3530c39c62ff900048b
-  EXPrint: 2dbe4d320687e559b46fdb01e330fdf875137094
+  EXPrint: 61bbaa43c42c1badfa46de5be015d7d798d33583
   EXRandom: ecb71f5d01991f29bb0277f8a2c35d168f85d637
   EXScreenCapture: c51844407fbac8bbca4415467bc43f2b7764d225
   EXScreenOrientation: e95cb77bbbbfee0d9cfa419fc713e1ab8a06eaba
-  EXSecureStore: 1aa80d49a3a101418bbd2675e2a0d32dceea10c2
-  EXSegment: 6d0d771e91760767a585db3e6746bda0d826f588
+  EXSecureStore: 351de40f612b4d6e44a69dc8f12d55403b45ec5d
+  EXSegment: e82309549eb4a0281c24940100f3dedc774ef75b
   EXSensors: 67423141a4aefbce82f04e61260570615b25b761
-  EXSharing: 0770022e43cdda54968fdd4166c3fcabd243c897
-  EXSMS: 1a1fcc1e825543b8b9256c230faf7663f0dec51d
-  EXSpeech: 0c4eb2bb758bab41f9cbf455cf673d2e344cc186
+  EXSharing: 6a3a3f675fc44d9442f761b1ec8351aba1e813f3
+  EXSMS: 4cd1d71d88a9c980bc215d33afeabb49a5a8d720
+  EXSpeech: 35e7d593b8a369ca7e219957bd61ac74aa7b23bd
   EXSplashScreen: da00ad1d61c395c5c81b252c5987e8f83cba230a
   EXSQLite: faed80cf1f7ec5a116c44aae3ca9abff7315553b
-  EXStoreReview: 40674cc897a6d7fd249969b86d1833f67b99170a
+  EXStoreReview: c7148fdc794a7e32a454eedda801360226fa8b4e
   EXStructuredHeaders: 384ccdf0c09ed0be8fc73d4b2d70e436cd195975
   EXTaskManager: 91fef764a2ec7690aa8070f862098df064facdc4
   EXTrackingTransparency: dc21f285b53a1780e77d40fd888573f50615ccfc
   EXUpdatesInterface: b68e78b912a03fff7901a5f46ec200c45e3506a5
-  EXVideoThumbnails: f8a7d2330578131361c0a4f6e981a6e58baf1290
-  EXWebBrowser: 76783ba5dcb8699237746ecf41a9643d428a4cc5
+  EXVideoThumbnails: 0a74ef339680e1aa52e30c53bc56990e9d8af0e8
+  EXWebBrowser: b244cd85281a2b8f90a4ce81d674e3dc4f4ccc5e
   FacebookSDK: 4b9bb8e2824898b47f18c666dc145c09b40609e6
   FBLazyVector: 3ef4a7f62e7db01092f9d517d2ebc0d0677c4a37
   FBReactNativeSpec: dc7fa9088f0f2a998503a352b0554d69a4391c5a

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXFacebook/EXScopedFacebook.h
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXFacebook/EXScopedFacebook.h
@@ -3,10 +3,10 @@
 #if __has_include(<EXFacebook/EXFacebook.h>)
 #import <Foundation/Foundation.h>
 #import <EXFacebook/EXFacebook.h>
-#import <UMCore/UMAppLifecycleListener.h>
+#import <ExpoModulesCore/EXAppLifecycleListener.h>
 #import <EXUpdates/EXUpdatesRawManifest.h>
 
-@interface EXScopedFacebook : EXFacebook <UMAppLifecycleListener>
+@interface EXScopedFacebook : EXFacebook <EXAppLifecycleListener>
 
 - (instancetype)initWithScopeKey:(NSString *)scopeKey manifest:(EXUpdatesRawManifest *)manifest;
 

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXFacebook/EXScopedFacebook.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXFacebook/EXScopedFacebook.m
@@ -3,28 +3,28 @@
 #if __has_include(<EXFacebook/EXFacebook.h>)
 #import "EXScopedFacebook.h"
 #import <FBSDKCoreKit/FBSDKSettings.h>
-#import <UMCore/UMAppLifecycleService.h>
+#import <ExpoModulesCore/EXAppLifecycleService.h>
 #import <FBSDKCoreKit/FBSDKApplicationDelegate.h>
 
 @interface EXFacebook (ExportedMethods)
 
 - (void)initializeAsync:(NSDictionary *)options
-               resolver:(UMPromiseResolveBlock)resolve
-               rejecter:(UMPromiseRejectBlock)reject;
+               resolver:(EXPromiseResolveBlock)resolve
+               rejecter:(EXPromiseRejectBlock)reject;
 
 - (void)logInWithReadPermissionsWithConfig:(NSDictionary *)config
-                                  resolver:(UMPromiseResolveBlock)resolve
-                                  rejecter:(UMPromiseRejectBlock)reject;
+                                  resolver:(EXPromiseResolveBlock)resolve
+                                  rejecter:(EXPromiseRejectBlock)reject;
 
-- (void)logOutAsync:(UMPromiseResolveBlock)resolve
-           rejecter:(UMPromiseRejectBlock)reject;
+- (void)logOutAsync:(EXPromiseResolveBlock)resolve
+           rejecter:(EXPromiseRejectBlock)reject;
 
-- (void)getAuthenticationCredentialAsync:(UMPromiseResolveBlock)resolve
-                   rejecter:(UMPromiseRejectBlock)reject;
+- (void)getAuthenticationCredentialAsync:(EXPromiseResolveBlock)resolve
+                   rejecter:(EXPromiseRejectBlock)reject;
 
 - (void)setAutoInitEnabled:(BOOL)enabled
-                  resolver:(UMPromiseResolveBlock)resolve
-                  rejecter:(UMPromiseRejectBlock)reject;
+                  resolver:(EXPromiseResolveBlock)resolve
+                  rejecter:(EXPromiseRejectBlock)reject;
 
 @end
 
@@ -64,10 +64,10 @@ static NSString *AUTO_INIT_KEY = @"autoInitEnabled";
         [FBSDKApplicationDelegate initializeSDK:nil];
         _isInitialized = YES;
         if (manifestFacebookAppId) {
-          UMLogInfo(@"Overriding Facebook App ID with Expo Go's. To test your own Facebook App ID, you'll need to build a standalone app. Refer to our documentation for more info- https://docs.expo.io/versions/latest/sdk/facebook/");
+          EXLogInfo(@"Overriding Facebook App ID with Expo Go's. To test your own Facebook App ID, you'll need to build a standalone app. Refer to our documentation for more info- https://docs.expo.io/versions/latest/sdk/facebook/");
         }
       } else {
-        UMLogWarn(@"FacebookAutoInit is enabled, but no FacebookAppId has been provided. Facebook SDK initialization aborted.");
+        EXLogWarn(@"FacebookAutoInit is enabled, but no FacebookAppId has been provided. Facebook SDK initialization aborted.");
       }
     }
   }
@@ -75,12 +75,12 @@ static NSString *AUTO_INIT_KEY = @"autoInitEnabled";
 }
 
 - (void)initializeAsync:(NSDictionary *)options
-               resolver:(UMPromiseResolveBlock)resolve
-               rejecter:(UMPromiseRejectBlock)reject
+               resolver:(EXPromiseResolveBlock)resolve
+               rejecter:(EXPromiseRejectBlock)reject
 {
   _isInitialized = YES;
   if (options[@"appId"]) {
-    UMLogInfo(@"Overriding Facebook App ID with Expo Go's. To test your own Facebook App ID, you'll need to build a standalone app. Refer to our documentation for more info- https://docs.expo.io/versions/latest/sdk/facebook/");
+    EXLogInfo(@"Overriding Facebook App ID with Expo Go's. To test your own Facebook App ID, you'll need to build a standalone app. Refer to our documentation for more info- https://docs.expo.io/versions/latest/sdk/facebook/");
   }
 
   NSString *scopedFacebookAppId = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"FacebookAppID"];
@@ -92,7 +92,7 @@ static NSString *AUTO_INIT_KEY = @"autoInitEnabled";
   [super initializeAsync:nativeOptions resolver:resolve rejecter:reject];
 }
 
-- (void)setAutoInitEnabled:(BOOL)enabled resolver:(UMPromiseResolveBlock)resolve rejecter:(UMPromiseRejectBlock)reject
+- (void)setAutoInitEnabled:(BOOL)enabled resolver:(EXPromiseResolveBlock)resolve rejecter:(EXPromiseRejectBlock)reject
 {
   if (enabled) {
     [_settings setBool:enabled forKey:AUTO_INIT_KEY];
@@ -102,7 +102,7 @@ static NSString *AUTO_INIT_KEY = @"autoInitEnabled";
   [super setAutoInitEnabled:enabled resolver:resolve rejecter:reject];
 }
 
-- (void)logInWithReadPermissionsWithConfig:(NSDictionary *)config resolver:(UMPromiseResolveBlock)resolve rejecter:(UMPromiseRejectBlock)reject
+- (void)logInWithReadPermissionsWithConfig:(NSDictionary *)config resolver:(EXPromiseResolveBlock)resolve rejecter:(EXPromiseRejectBlock)reject
 {
   // If the developer didn't initialize the SDK, let them know.
   if (!_isInitialized) {
@@ -112,7 +112,7 @@ static NSString *AUTO_INIT_KEY = @"autoInitEnabled";
   [super logInWithReadPermissionsWithConfig:config resolver:resolve rejecter:reject];
 }
 
-- (void)getAuthenticationCredentialAsync:(UMPromiseResolveBlock)resolve rejecter:(UMPromiseRejectBlock)reject
+- (void)getAuthenticationCredentialAsync:(EXPromiseResolveBlock)resolve rejecter:(EXPromiseRejectBlock)reject
 {
   // If the developer didn't initialize the SDK, let them know.
   if (!_isInitialized) {
@@ -122,7 +122,7 @@ static NSString *AUTO_INIT_KEY = @"autoInitEnabled";
   [super getAuthenticationCredentialAsync:resolve rejecter:reject];
 }
 
-- (void)logOutAsync:(UMPromiseResolveBlock)resolve rejecter:(UMPromiseRejectBlock)reject
+- (void)logOutAsync:(EXPromiseResolveBlock)resolve rejecter:(EXPromiseRejectBlock)reject
 {
   // If the developer didn't initialize the SDK, let them know.
   if (!_isInitialized) {
@@ -134,11 +134,11 @@ static NSString *AUTO_INIT_KEY = @"autoInitEnabled";
 
 # pragma mark - UMModuleRegistryConsumer
 
-- (void)setModuleRegistry:(UMModuleRegistry *)moduleRegistry
+- (void)setModuleRegistry:(EXModuleRegistry *)moduleRegistry
 {
   [super setModuleRegistry:moduleRegistry];
   
-  id<UMAppLifecycleService> appLifecycleService = [moduleRegistry getModuleImplementingProtocol:@protocol(UMAppLifecycleService)];
+  id<EXAppLifecycleService> appLifecycleService = [moduleRegistry getModuleImplementingProtocol:@protocol(EXAppLifecycleService)];
   [appLifecycleService registerAppLifecycleListener:self];
 }
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1776,42 +1776,38 @@ PODS:
   - EXAdsAdMob (10.1.0):
     - ExpoModulesCore
     - Google-Mobile-Ads-SDK (= 7.69.0)
-    - UMCore
   - EXAdsFacebook (10.1.0):
     - ExpoModulesCore
     - FBAudienceNetwork (= 6.5.0)
-    - UMCore
   - EXAmplitude (10.2.0):
     - Amplitude (~> 6.0.0)
-    - UMCore
+    - ExpoModulesCore
   - EXAppAuth (10.2.0):
     - AppAuth (~> 1.2)
     - UMCore
   - EXAppleAuthentication (3.2.0):
-    - UMCore
+    - ExpoModulesCore
   - EXApplication (3.2.0):
     - UMCore
   - EXAV (9.2.0):
     - ExpoModulesCore
   - EXBackgroundFetch (9.2.0):
-    - UMCore
+    - ExpoModulesCore
     - UMTaskManagerInterface
   - EXBarCodeScanner (10.2.0):
     - ExpoModulesCore
-    - UMCore
     - ZXingObjC/OneD
     - ZXingObjC/PDF417
   - EXBattery (5.0.0):
-    - UMCore
+    - ExpoModulesCore
   - EXBlur (9.0.3):
-    - UMCore
+    - ExpoModulesCore
   - EXBranch (4.2.0):
     - Branch (= 0.35.0)
+    - ExpoModulesCore
     - React-Core
-    - UMCore
   - EXBrightness (9.2.0):
     - ExpoModulesCore
-    - UMCore
   - EXCalendar (9.2.0):
     - ExpoModulesCore
     - UMCore
@@ -1820,7 +1816,7 @@ PODS:
   - EXCellular (3.2.0):
     - ExpoModulesCore
   - EXClipboard (1.1.0):
-    - UMCore
+    - ExpoModulesCore
   - EXConstants (11.0.0):
     - ExpoModulesCore
     - UMCore
@@ -1828,26 +1824,23 @@ PODS:
     - ExpoModulesCore
     - UMCore
   - EXCrypto (9.2.0):
-    - UMCore
+    - ExpoModulesCore
   - EXDevice (3.3.0):
-    - UMCore
+    - ExpoModulesCore
   - EXDocumentPicker (9.2.0):
     - ExpoModulesCore
-    - UMCore
   - EXErrorRecovery (2.2.0):
-    - UMCore
+    - ExpoModulesCore
   - EXFacebook (11.2.0):
     - ExpoModulesCore
     - FacebookSDK/CoreKit (= 9.2.0)
     - FacebookSDK/LoginKit (= 9.2.0)
-    - UMCore
   - EXFaceDetector (10.1.0):
     - ExpoModulesCore
     - GoogleMLKit/FaceDetection (= 2.1.0)
     - MLKitCommon (= 2.1.0)
     - MLKitFaceDetection (= 1.2.0)
     - MLKitVision (= 1.2.0)
-    - UMCore
   - EXFileSystem (11.1.0):
     - ExpoModulesCore
   - EXFirebaseAnalytics (4.1.0):
@@ -1863,7 +1856,6 @@ PODS:
   - EXGL (10.4.0):
     - EXGL_CPP
     - ExpoModulesCore
-    - UMCore
   - EXGL_CPP (10.4.0):
     - React-jsi
   - EXGoogleSignIn (9.2.0):
@@ -1877,7 +1869,6 @@ PODS:
     - UMCore
   - EXImageManipulator (9.2.0):
     - ExpoModulesCore
-    - UMCore
   - EXImagePicker (10.2.0):
     - ExpoModulesCore
     - UMCore
@@ -1895,26 +1886,23 @@ PODS:
     - UMTaskManagerInterface
   - EXMailComposer (10.2.0):
     - ExpoModulesCore
-    - UMCore
   - EXMediaLibrary (12.1.0):
     - ExpoModulesCore
     - React-Core
     - UMCore
   - EXNetwork (3.2.0):
-    - UMCore
+    - ExpoModulesCore
   - EXNotifications (0.12.0):
     - ExpoModulesCore
     - UMCore
   - EXPermissions (12.1.0):
     - ExpoModulesCore
-    - UMCore
   - ExpoModulesCore (0.1.1):
     - React-Core
   - ExpoModulesCore/Tests (0.1.1):
     - React-Core
   - EXPrint (10.2.0):
     - ExpoModulesCore
-    - UMCore
   - EXRandom (11.2.0):
     - React-Core
   - EXScreenCapture (3.2.0):
@@ -1923,20 +1911,19 @@ PODS:
     - React-Core
     - UMCore
   - EXSecureStore (10.2.0):
-    - UMCore
+    - ExpoModulesCore
   - EXSegment (10.2.0):
     - Analytics (= 4.0.4)
-    - UMCore
+    - ExpoModulesCore
   - EXSensors (10.2.0):
     - ExpoModulesCore
     - UMCore
   - EXSharing (9.2.0):
     - ExpoModulesCore
-    - UMCore
   - EXSMS (9.2.0):
-    - UMCore
+    - ExpoModulesCore
   - EXSpeech (9.2.0):
-    - UMCore
+    - ExpoModulesCore
   - EXSplashScreen (0.11.0):
     - React-Core
     - UMCore
@@ -1944,7 +1931,7 @@ PODS:
     - ExpoModulesCore
     - UMCore
   - EXStoreReview (4.1.0):
-    - UMCore
+    - ExpoModulesCore
   - EXStructuredHeaders (1.1.0):
     - UMCore
   - EXStructuredHeaders/Tests (1.1.0):
@@ -1969,9 +1956,8 @@ PODS:
   - EXUpdatesInterface (0.2.2)
   - EXVideoThumbnails (5.2.0):
     - ExpoModulesCore
-    - UMCore
   - EXWebBrowser (9.2.0):
-    - UMCore
+    - ExpoModulesCore
   - FacebookSDK/CoreKit (9.2.0):
     - FBSDKCoreKit (~> 9.2.0)
   - FacebookSDK/LoginKit (9.2.0):
@@ -4017,73 +4003,73 @@ SPEC CHECKSUMS:
   Branch: 9a37f707974a128c37829033c49018b79c7e7a2d
   CocoaLumberjack: 2f44e60eb91c176d471fdba43b9e3eae6a721947
   DoubleConversion: cde416483dac037923206447da6e1454df403714
-  EXAdsAdMob: 07f64532e06b3dda91f8acae6dcc580df6833861
-  EXAdsFacebook: 8301dd6f17c436a731bbdad68c5be90b7dbaad24
-  EXAmplitude: b3ef1ed2ae853bccd08a685d2f0352c603b215fe
+  EXAdsAdMob: aeb474fc44d29866b259f6573c3726311befc664
+  EXAdsFacebook: 32a8b46b1df6cd3eec72a8cfa2213e313acc5887
+  EXAmplitude: 19866218bc855e6ac7a29e5c8ec1b24eab81b40c
   EXAppAuth: b7ecb4ce7634676985f67d2489054ea7727cd5e3
-  EXAppleAuthentication: 5994731faf4a3dd32be4a4b3e9feb930c2fa25c1
+  EXAppleAuthentication: a977ae8d2d0e39b2d838141ff82ba3fe54b329bf
   EXApplication: 9ff2a206009d6e55bca6c20b3f33d07986b51ef3
   EXAV: 7f27c872fb45479d66e762a88484f58d52174131
-  EXBackgroundFetch: 5a15dc52d77d5ea4b0896c283679e271447921d4
-  EXBarCodeScanner: 22f8d8ea393de371e80f9529664c07900e1e7639
-  EXBattery: 6adbf9706bbe00d266b17b7846d556db9dea82c2
-  EXBlur: 50d490040f3b14898ed8198d5125dc699189f4d9
-  EXBranch: 9c65961edddfb785cc26d8642f8f50e7e3c2e5ad
-  EXBrightness: b0eb62f204669cd7ae926847794b5bfabd595a4f
+  EXBackgroundFetch: aeaddb8ff64e13b1c2766f1e4a09bb727a6330aa
+  EXBarCodeScanner: afd5eb520bb133688dc680453465842ffbcef47c
+  EXBattery: 65a5d98f83be408ed29b4e00f4c1a607dd585654
+  EXBlur: eb7277c806220f1bed59547b4b5240e2de462aff
+  EXBranch: ce0f9b7537d7ee1f1eb58803b05d7634c7264160
+  EXBrightness: 4532d07a5c34ddc887e1b85eeaff42eef6882bb1
   EXCalendar: 64807f071c86ef3d9813fec49f55c38d5854c235
   EXCamera: d39ee631cecae1722c12a0b5fe4651a09b262863
   EXCellular: c023099c6d53230d69c03a0ed0b515fbf2ffc5eb
-  EXClipboard: c66f7d22ba754496b0fc6b23a2cb9a3e10fa1581
+  EXClipboard: 247c22246c4843351f2f89cc29b654ecd936eaa8
   EXConstants: 0c200d22d140d3f1834dc51c4ebe0465ddaa82c5
   EXContacts: bc06f42aa1bc7fb5ed0f5b29287f772faa33ad55
-  EXCrypto: 46e28f1eb7ec3e2ae5aab652fe1dc4d46bafb386
-  EXDevice: 6f1eed02c099f5b382a12a40406c58868892aba6
-  EXDocumentPicker: fa00c1852b1780ddecbdeb1bb6e74165d5d44a45
-  EXErrorRecovery: 404d827bc7d42f306c062d58a60b06afc4d082b3
-  EXFacebook: 71cc9f6b6bbdf0bc702d65c287f23cab14cc6430
-  EXFaceDetector: e0908fe9700ed402a9658975a3eac719479b5205
+  EXCrypto: e64a6d6d3f785801384004a4197b0f95a23a2761
+  EXDevice: 74b193bafc7fc162eb435b8810b72143ab7743af
+  EXDocumentPicker: 52183e4bdffbbd50e61726066f529455227c5daa
+  EXErrorRecovery: 500f15bfbced54161641cf82c45d39103d33462a
+  EXFacebook: 052783a39c092ad47015e2e2af8e6d33e9d92089
+  EXFaceDetector: 47c8c4a10c5b86c5ea9c77ca7b517102833a6d9b
   EXFileSystem: 9a77e33ba77e8b1ffbbe0625a211e3abee6f69ab
   EXFirebaseAnalytics: ca01838167729b67f838a673e4b3e0637faec118
   EXFirebaseCore: 9b5380fd62fce3c790fa1d6727a8d7cbbef4f0fb
   EXFont: 6e7d5a7a09fbd0ee801de76601b2e620c4d2f575
-  EXGL: 6c3cb47b094c185c6e3fdac50449a504458052c2
+  EXGL: 468113f7d19c139873e8e2b809ddef064ba847c0
   EXGL_CPP: dcca866c4f6af6694a12217fb2db3325acd19b57
   EXGoogleSignIn: d61beec381962b350f6ed60c9b65ae46ca26ef12
   EXHaptics: 718e4b457673bd88384a7fbb6f357c2138c771b0
   EXImageLoader: d3531a3fe530b22925c19977cb53bb43e3821fe6
-  EXImageManipulator: c4a7a24d867f8b2bb15e5d0d64ff8f3c2fb35761
+  EXImageManipulator: a5bec1d69308fa1f091378f6461ae348ec83105d
   EXImagePicker: 958720afb9395ee1168dcda28d9915345c4e7cae
   EXKeepAwake: f4105ef469be7b283f66ce2d7234bb71ac80cd26
   EXLinearGradient: 36053f529a48cc7534d6125b0ddc8dd17e091fdd
   EXLocalAuthentication: e6347880c31bc3b9693933780d3bc84823fe0698
   EXLocalization: 356f4e16a606cec21a77d6250528fde526152b45
   EXLocation: bdf1af6aa8fc4f4dc1fd21aa39760484026f8a5d
-  EXMailComposer: 3eefb2b73dd4587856a8b1f82daaed6156451b36
+  EXMailComposer: d1976c864ee1d74907b15c98ec68ddf5ca2331b1
   EXMediaLibrary: bdbcfe2435571f9c83d6ced2e28ec193d69bc40d
-  EXNetwork: 6682b2bbbd90e66c4738159abaf8cd206c25e8b8
+  EXNetwork: c15bb1026d72d1eb3782710faf373ed35c6eb024
   EXNotifications: 296d9487163c2c08fffec5e79a5f9094bc016d9c
-  EXPermissions: 8eb648bd5c2115d01a39dc7c2ad4c94a5846e4cb
+  EXPermissions: c7bead8f093700d5fcfb4f41238430a51702c5c8
   ExpoModulesCore: 82ee658feb15e6804de9f3530c39c62ff900048b
-  EXPrint: 2dbe4d320687e559b46fdb01e330fdf875137094
+  EXPrint: 61bbaa43c42c1badfa46de5be015d7d798d33583
   EXRandom: ecb71f5d01991f29bb0277f8a2c35d168f85d637
   EXScreenCapture: c51844407fbac8bbca4415467bc43f2b7764d225
   EXScreenOrientation: e95cb77bbbbfee0d9cfa419fc713e1ab8a06eaba
-  EXSecureStore: 1aa80d49a3a101418bbd2675e2a0d32dceea10c2
-  EXSegment: 6d0d771e91760767a585db3e6746bda0d826f588
+  EXSecureStore: 351de40f612b4d6e44a69dc8f12d55403b45ec5d
+  EXSegment: e82309549eb4a0281c24940100f3dedc774ef75b
   EXSensors: 67423141a4aefbce82f04e61260570615b25b761
-  EXSharing: 0770022e43cdda54968fdd4166c3fcabd243c897
-  EXSMS: 1a1fcc1e825543b8b9256c230faf7663f0dec51d
-  EXSpeech: 0c4eb2bb758bab41f9cbf455cf673d2e344cc186
+  EXSharing: 6a3a3f675fc44d9442f761b1ec8351aba1e813f3
+  EXSMS: 4cd1d71d88a9c980bc215d33afeabb49a5a8d720
+  EXSpeech: 35e7d593b8a369ca7e219957bd61ac74aa7b23bd
   EXSplashScreen: da00ad1d61c395c5c81b252c5987e8f83cba230a
   EXSQLite: faed80cf1f7ec5a116c44aae3ca9abff7315553b
-  EXStoreReview: 40674cc897a6d7fd249969b86d1833f67b99170a
+  EXStoreReview: c7148fdc794a7e32a454eedda801360226fa8b4e
   EXStructuredHeaders: 384ccdf0c09ed0be8fc73d4b2d70e436cd195975
   EXTaskManager: 91fef764a2ec7690aa8070f862098df064facdc4
   EXTrackingTransparency: 212dcc45e24c0e3ec8ea89e4d93c1d123c5a1fb4
   EXUpdates: 555bae578b14cfd76cc9e46cbd0a010dc6edddd2
   EXUpdatesInterface: b68e78b912a03fff7901a5f46ec200c45e3506a5
-  EXVideoThumbnails: f8a7d2330578131361c0a4f6e981a6e58baf1290
-  EXWebBrowser: 76783ba5dcb8699237746ecf41a9643d428a4cc5
+  EXVideoThumbnails: 0a74ef339680e1aa52e30c53bc56990e9d8af0e8
+  EXWebBrowser: b244cd85281a2b8f90a4ce81d674e3dc4f4ccc5e
   FacebookSDK: 4b9bb8e2824898b47f18c666dc145c09b40609e6
   FBAudienceNetwork: cfe55330dcc4e9a1df083c34a346ca7f8e32951e
   FBLazyVector: 3ef4a7f62e7db01092f9d517d2ebc0d0677c4a37

--- a/packages/expo-ads-admob/CHANGELOG.md
+++ b/packages/expo-ads-admob/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Migrated from `@unimodules/core` to `expo-modules-core`.
+
 ## 10.1.0 — 2021-06-16
 
 ### 🎉 New features

--- a/packages/expo-ads-admob/CHANGELOG.md
+++ b/packages/expo-ads-admob/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Migrated from `@unimodules/core` to `expo-modules-core`.
+- Migrated from `@unimodules/core` to `expo-modules-core`. ([#13757](https://github.com/expo/expo/pull/13757) by [@tsapeta](https://github.com/tsapeta))
 
 ## 10.1.0 — 2021-06-16
 

--- a/packages/expo-ads-admob/ios/EXAdsAdMob.podspec
+++ b/packages/expo-ads-admob/ios/EXAdsAdMob.podspec
@@ -13,7 +13,6 @@ Pod::Spec.new do |s|
   s.platform       = :ios, '11.0'
   s.source         = { git: 'https://github.com/expo/expo.git' }
 
-  s.dependency 'UMCore'
   s.dependency 'ExpoModulesCore'
   s.dependency 'Google-Mobile-Ads-SDK', "7.69.0"
 

--- a/packages/expo-ads-admob/ios/EXAdsAdMob/EXAdsAdMob.h
+++ b/packages/expo-ads-admob/ios/EXAdsAdMob/EXAdsAdMob.h
@@ -1,10 +1,10 @@
 // Copyright 2019-present 650 Industries. All rights reserved.
 
-#import <UMCore/UMModuleRegistry.h>
-#import <UMCore/UMModuleRegistryConsumer.h>
+#import <ExpoModulesCore/EXModuleRegistry.h>
+#import <ExpoModulesCore/EXModuleRegistryConsumer.h>
 
 #import <UIKit/UIKit.h>
 
-@interface EXAdsAdMob : UMExportedModule <UMModuleRegistryConsumer>
+@interface EXAdsAdMob : EXExportedModule <EXModuleRegistryConsumer>
 
 @end

--- a/packages/expo-ads-admob/ios/EXAdsAdMob/EXAdsAdMob.m
+++ b/packages/expo-ads-admob/ios/EXAdsAdMob/EXAdsAdMob.m
@@ -16,17 +16,17 @@
 
 @implementation EXAdsAdMob
 
-UM_EXPORT_MODULE(ExpoAdsAdMob);
+EX_EXPORT_MODULE(ExpoAdsAdMob);
 
-- (void)setModuleRegistry:(UMModuleRegistry *)moduleRegistry
+- (void)setModuleRegistry:(EXModuleRegistry *)moduleRegistry
 {
   _permissionsManager = [moduleRegistry getModuleImplementingProtocol:@protocol(EXPermissionsInterface)];
   [EXPermissionsMethodsDelegate registerRequesters:@[[EXAdsAdMobAppTrackingPermissionRequester new]] withPermissionsManager:_permissionsManager];
 }
 
-UM_EXPORT_METHOD_AS(getPermissionsAsync,
-                    getPermissionsAsync:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(getPermissionsAsync,
+                    getPermissionsAsync:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   [EXPermissionsMethodsDelegate getPermissionWithPermissionsManager:_permissionsManager
                                                       withRequester:[EXAdsAdMobAppTrackingPermissionRequester class]
@@ -34,9 +34,9 @@ UM_EXPORT_METHOD_AS(getPermissionsAsync,
                                                              reject:reject];
 }
 
-UM_EXPORT_METHOD_AS(requestPermissionsAsync,
-                    requestPermissionsAsync:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(requestPermissionsAsync,
+                    requestPermissionsAsync:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   [EXPermissionsMethodsDelegate askForPermissionWithPermissionsManager:_permissionsManager
                                                          withRequester:[EXAdsAdMobAppTrackingPermissionRequester class]
@@ -44,10 +44,10 @@ UM_EXPORT_METHOD_AS(requestPermissionsAsync,
                                                                 reject:reject];
 }
 
-UM_EXPORT_METHOD_AS(setTestDeviceIDAsync,
+EX_EXPORT_METHOD_AS(setTestDeviceIDAsync,
                     setTestDeviceID:(NSString *)testDeviceID
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   NSArray<NSString *>* testDeviceIdentifiers = nil;
   if (testDeviceID && ![testDeviceID isEqualToString:@""]) {

--- a/packages/expo-ads-admob/ios/EXAdsAdMob/EXAdsAdMobAppTrackingPermissionRequester.m
+++ b/packages/expo-ads-admob/ios/EXAdsAdMob/EXAdsAdMobAppTrackingPermissionRequester.m
@@ -37,12 +37,12 @@
   };
 }
 
-- (void)requestPermissionsWithResolver:(UMPromiseResolveBlock)resolve rejecter:(UMPromiseRejectBlock)reject
+- (void)requestPermissionsWithResolver:(EXPromiseResolveBlock)resolve rejecter:(EXPromiseRejectBlock)reject
 {
   if (@available(iOS 14, *)) {
-    UM_WEAKIFY(self)
+    EX_WEAKIFY(self)
     [ATTrackingManager requestTrackingAuthorizationWithCompletionHandler:^(ATTrackingManagerAuthorizationStatus status) {
-      UM_STRONGIFY(self)
+      EX_STRONGIFY(self)
       resolve([self getPermissions]);
     }];
   } else {

--- a/packages/expo-ads-admob/ios/EXAdsAdMob/EXAdsAdMobBannerView.h
+++ b/packages/expo-ads-admob/ios/EXAdsAdMob/EXAdsAdMobBannerView.h
@@ -1,5 +1,5 @@
-#import <UMCore/UMDefines.h>
-#import <UMCore/UMModuleRegistry.h>
+#import <ExpoModulesCore/EXDefines.h>
+#import <ExpoModulesCore/EXModuleRegistry.h>
 #import <GoogleMobileAds/GoogleMobileAds.h>
 
 @interface EXAdsAdMobBannerView : UIView <GADBannerViewDelegate>
@@ -8,13 +8,13 @@
 @property (nonatomic, copy) NSString *adUnitID;
 @property (nonatomic, copy) NSDictionary *additionalRequestParams;
 
-@property (nonatomic, copy) UMDirectEventBlock onSizeChange;
-@property (nonatomic, copy) UMDirectEventBlock onAdViewDidReceiveAd;
-@property (nonatomic, copy) UMDirectEventBlock onDidFailToReceiveAdWithError;
-@property (nonatomic, copy) UMDirectEventBlock onAdViewWillPresentScreen;
-@property (nonatomic, copy) UMDirectEventBlock onAdViewWillDismissScreen;
-@property (nonatomic, copy) UMDirectEventBlock onAdViewDidDismissScreen;
-@property (nonatomic, copy) UMDirectEventBlock onAdViewWillLeaveApplication;
+@property (nonatomic, copy) EXDirectEventBlock onSizeChange;
+@property (nonatomic, copy) EXDirectEventBlock onAdViewDidReceiveAd;
+@property (nonatomic, copy) EXDirectEventBlock onDidFailToReceiveAdWithError;
+@property (nonatomic, copy) EXDirectEventBlock onAdViewWillPresentScreen;
+@property (nonatomic, copy) EXDirectEventBlock onAdViewWillDismissScreen;
+@property (nonatomic, copy) EXDirectEventBlock onAdViewDidDismissScreen;
+@property (nonatomic, copy) EXDirectEventBlock onAdViewWillLeaveApplication;
 
 - (GADAdSize)getAdSizeFromString:(NSString *)bannerSize;
 - (void)loadBanner;

--- a/packages/expo-ads-admob/ios/EXAdsAdMob/EXAdsAdMobBannerView.m
+++ b/packages/expo-ads-admob/ios/EXAdsAdMob/EXAdsAdMobBannerView.m
@@ -1,5 +1,5 @@
 #import <EXAdsAdMob/EXAdsAdMobBannerView.h>
-#import <UMCore/UMEventEmitterService.h>
+#import <ExpoModulesCore/EXEventEmitterService.h>
 
 @implementation EXAdsAdMobBannerView {
   GADBannerView *_bannerView;
@@ -48,13 +48,13 @@
   }
 }
 
-- (void)setOnSizeChange:(UMDirectEventBlock)block
+- (void)setOnSizeChange:(EXDirectEventBlock)block
 {
   _onSizeChange = block;
   [self loadBanner];
 }
 
-- (void)setOnDidFailToReceiveAdWithError:(UMDirectEventBlock)block
+- (void)setOnDidFailToReceiveAdWithError:(EXDirectEventBlock)block
 {
   _onDidFailToReceiveAdWithError = block;
   [self loadBanner];

--- a/packages/expo-ads-admob/ios/EXAdsAdMob/EXAdsAdMobBannerViewManager.h
+++ b/packages/expo-ads-admob/ios/EXAdsAdMob/EXAdsAdMobBannerViewManager.h
@@ -1,6 +1,6 @@
 #import <AVFoundation/AVFoundation.h>
-#import <UMCore/UMViewManager.h>
+#import <ExpoModulesCore/EXViewManager.h>
 
-@interface EXAdsAdMobBannerViewManager : UMViewManager
+@interface EXAdsAdMobBannerViewManager : EXViewManager
 
 @end

--- a/packages/expo-ads-admob/ios/EXAdsAdMob/EXAdsAdMobBannerViewManager.m
+++ b/packages/expo-ads-admob/ios/EXAdsAdMob/EXAdsAdMobBannerViewManager.m
@@ -4,7 +4,7 @@
 
 @implementation EXAdsAdMobBannerViewManager
 
-UM_EXPORT_MODULE(ExpoAdsAdMobBannerView);
+EX_EXPORT_MODULE(ExpoAdsAdMobBannerView);
 
 - (NSString *)viewName
 {
@@ -29,17 +29,17 @@ UM_EXPORT_MODULE(ExpoAdsAdMobBannerView);
   return [[EXAdsAdMobBannerView alloc] init];
 }
 
-UM_VIEW_PROPERTY(bannerSize, NSString *, EXAdsAdMobBannerView)
+EX_VIEW_PROPERTY(bannerSize, NSString *, EXAdsAdMobBannerView)
 {
   [view setBannerSize:value];
 }
 
-UM_VIEW_PROPERTY(adUnitID, NSString *, EXAdsAdMobBannerView)
+EX_VIEW_PROPERTY(adUnitID, NSString *, EXAdsAdMobBannerView)
 {
   [view setAdUnitID:value];
 }
 
-UM_VIEW_PROPERTY(additionalRequestParams, NSDictionary *, EXAdsAdMobBannerView)
+EX_VIEW_PROPERTY(additionalRequestParams, NSDictionary *, EXAdsAdMobBannerView)
 {
   [view setAdditionalRequestParams:value];
 }

--- a/packages/expo-ads-admob/ios/EXAdsAdMob/EXAdsAdMobDFPManager.h
+++ b/packages/expo-ads-admob/ios/EXAdsAdMob/EXAdsAdMobDFPManager.h
@@ -1,6 +1,6 @@
 #import <AVFoundation/AVFoundation.h>
-#import <UMCore/UMViewManager.h>
+#import <ExpoModulesCore/EXViewManager.h>
 
-@interface EXAdsAdMobDFPManager : UMViewManager
+@interface EXAdsAdMobDFPManager : EXViewManager
 
 @end

--- a/packages/expo-ads-admob/ios/EXAdsAdMob/EXAdsAdMobDFPManager.m
+++ b/packages/expo-ads-admob/ios/EXAdsAdMob/EXAdsAdMobDFPManager.m
@@ -4,7 +4,7 @@
 
 @implementation EXAdsAdMobDFPManager
 
-UM_EXPORT_MODULE(ExpoPublisherBannerView);
+EX_EXPORT_MODULE(ExpoPublisherBannerView);
 
 - (NSString *)viewName
 {
@@ -30,17 +30,17 @@ UM_EXPORT_MODULE(ExpoPublisherBannerView);
   return [[EXAdsDFPBannerView alloc] init];
 }
 
-UM_VIEW_PROPERTY(bannerSize, NSString *, EXAdsDFPBannerView)
+EX_VIEW_PROPERTY(bannerSize, NSString *, EXAdsDFPBannerView)
 {
   [view setBannerSize:value];
 }
 
-UM_VIEW_PROPERTY(adUnitID, NSString *, EXAdsDFPBannerView)
+EX_VIEW_PROPERTY(adUnitID, NSString *, EXAdsDFPBannerView)
 {
   [view setAdUnitID:value];
 }
 
-UM_VIEW_PROPERTY(additionalRequestParams, NSDictionary *, EXAdsDFPBannerView)
+EX_VIEW_PROPERTY(additionalRequestParams, NSDictionary *, EXAdsDFPBannerView)
 {
   [view setAdditionalRequestParams:value];
 }

--- a/packages/expo-ads-admob/ios/EXAdsAdMob/EXAdsAdMobInterstitial.h
+++ b/packages/expo-ads-admob/ios/EXAdsAdMob/EXAdsAdMobInterstitial.h
@@ -1,8 +1,8 @@
-#import <UMCore/UMDefines.h>
-#import <UMCore/UMEventEmitter.h>
-#import <UMCore/UMModuleRegistryConsumer.h>
+#import <ExpoModulesCore/EXDefines.h>
+#import <ExpoModulesCore/EXEventEmitter.h>
+#import <ExpoModulesCore/EXModuleRegistryConsumer.h>
 
 #import <GoogleMobileAds/GoogleMobileAds.h>
 
-@interface EXAdsAdMobInterstitial : UMExportedModule <UMEventEmitter, UMModuleRegistryConsumer, GADInterstitialDelegate>
+@interface EXAdsAdMobInterstitial : EXExportedModule <EXEventEmitter, EXModuleRegistryConsumer, GADInterstitialDelegate>
 @end

--- a/packages/expo-ads-admob/ios/EXAdsAdMob/EXAdsAdMobInterstitial.m
+++ b/packages/expo-ads-admob/ios/EXAdsAdMob/EXAdsAdMobInterstitial.m
@@ -1,6 +1,6 @@
-#import <UMCore/UMUIManager.h>
-#import <UMCore/UMEventEmitterService.h>
-#import <UMCore/UMUtilitiesInterface.h>
+#import <ExpoModulesCore/EXUIManager.h>
+#import <ExpoModulesCore/EXEventEmitterService.h>
+#import <ExpoModulesCore/EXUtilitiesInterface.h>
 #import <EXAdsAdMob/EXAdsAdMobInterstitial.h>
 
 static NSString *const EXAdsAdMobInterstitialDidLoad = @"interstitialDidLoad";
@@ -11,8 +11,8 @@ static NSString *const EXAdsAdMobInterstitialWillLeaveApplication = @"interstiti
 
 @interface EXAdsAdMobInterstitial ()
 
-@property (nonatomic, weak) id<UMEventEmitterService> eventEmitter;
-@property (nonatomic, weak) id<UMUtilitiesInterface> utilities;
+@property (nonatomic, weak) id<EXEventEmitterService> eventEmitter;
+@property (nonatomic, weak) id<EXUtilitiesInterface> utilities;
 
 @end
 
@@ -20,17 +20,17 @@ static NSString *const EXAdsAdMobInterstitialWillLeaveApplication = @"interstiti
   GADInterstitial  *_interstitial;
   NSString *_adUnitID;
   bool _hasListeners;
-  UMPromiseResolveBlock _showAdResolver;
-  UMPromiseResolveBlock _requestAdResolver;
-  UMPromiseRejectBlock _requestAdRejecter;
+  EXPromiseResolveBlock _showAdResolver;
+  EXPromiseResolveBlock _requestAdResolver;
+  EXPromiseRejectBlock _requestAdRejecter;
 }
 
-UM_EXPORT_MODULE(ExpoAdsAdMobInterstitialManager);
+EX_EXPORT_MODULE(ExpoAdsAdMobInterstitialManager);
 
-- (void)setModuleRegistry:(UMModuleRegistry *)moduleRegistry
+- (void)setModuleRegistry:(EXModuleRegistry *)moduleRegistry
 {
-  _utilities = [moduleRegistry getModuleImplementingProtocol:@protocol(UMUtilitiesInterface)];
-  _eventEmitter = [moduleRegistry getModuleImplementingProtocol:@protocol(UMEventEmitterService)];
+  _utilities = [moduleRegistry getModuleImplementingProtocol:@protocol(EXUtilitiesInterface)];
+  _eventEmitter = [moduleRegistry getModuleImplementingProtocol:@protocol(EXEventEmitterService)];
 }
 
 - (NSArray<NSString *> *)supportedEvents
@@ -58,19 +58,19 @@ UM_EXPORT_MODULE(ExpoAdsAdMobInterstitialManager);
   _hasListeners = NO;
 }
 
-UM_EXPORT_METHOD_AS(setAdUnitID,
+EX_EXPORT_METHOD_AS(setAdUnitID,
                     setAdUnitID:(NSString *)adUnitID
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   _adUnitID = adUnitID;
   resolve(nil);
 }
 
-UM_EXPORT_METHOD_AS(requestAd,
+EX_EXPORT_METHOD_AS(requestAd,
                     requestAdWithAdditionalRequestParams:(NSDictionary *)additionalRequestParams
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   if ([_interstitial hasBeenUsed] || _interstitial == nil) {
     _requestAdResolver = resolve;
@@ -91,15 +91,15 @@ UM_EXPORT_METHOD_AS(requestAd,
   }
 }
 
-UM_EXPORT_METHOD_AS(showAd,
-                    showAd:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(showAd,
+                    showAd:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   if ([_interstitial isReady] && _showAdResolver == nil) {
     _showAdResolver = resolve;
-    UM_WEAKIFY(self);
+    EX_WEAKIFY(self);
     dispatch_async(dispatch_get_main_queue(), ^{
-      UM_ENSURE_STRONGIFY(self);
+      EX_ENSURE_STRONGIFY(self);
       [self->_interstitial presentFromRootViewController:self.utilities.currentViewController];
     });
   } else if (_showAdResolver != nil) {
@@ -109,18 +109,18 @@ UM_EXPORT_METHOD_AS(showAd,
   }
 }
 
-UM_EXPORT_METHOD_AS(dismissAd,
-                    dismissAd:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(dismissAd,
+                    dismissAd:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
-  UM_WEAKIFY(self);
+  EX_WEAKIFY(self);
   dispatch_async(dispatch_get_main_queue(), ^{
-    UM_ENSURE_STRONGIFY(self);
+    EX_ENSURE_STRONGIFY(self);
     UIViewController *presentedViewController = self.utilities.currentViewController;
     if (presentedViewController != nil && [NSStringFromClass([presentedViewController class]) hasPrefix:@"GAD"]) {
       [presentedViewController dismissViewControllerAnimated:true completion:^{
         resolve(nil);
-        UM_ENSURE_STRONGIFY(self);
+        EX_ENSURE_STRONGIFY(self);
         self->_interstitial = nil;
       }];
     } else {
@@ -129,9 +129,9 @@ UM_EXPORT_METHOD_AS(dismissAd,
   });
 }
 
-UM_EXPORT_METHOD_AS(getIsReady,
-                    getIsReady:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(getIsReady,
+                    getIsReady:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   resolve([NSNumber numberWithBool:[_interstitial isReady]]);
 }

--- a/packages/expo-ads-admob/ios/EXAdsAdMob/EXAdsAdMobRewarded.h
+++ b/packages/expo-ads-admob/ios/EXAdsAdMob/EXAdsAdMobRewarded.h
@@ -1,7 +1,7 @@
-#import <UMCore/UMDefines.h>
-#import <UMCore/UMEventEmitter.h>
-#import <UMCore/UMModuleRegistryConsumer.h>
+#import <ExpoModulesCore/EXDefines.h>
+#import <ExpoModulesCore/EXEventEmitter.h>
+#import <ExpoModulesCore/EXModuleRegistryConsumer.h>
 #import <GoogleMobileAds/GoogleMobileAds.h>
 
-@interface EXAdsAdMobRewarded : UMExportedModule <UMEventEmitter, UMModuleRegistryConsumer, GADRewardedAdDelegate>
+@interface EXAdsAdMobRewarded : EXExportedModule <EXEventEmitter, EXModuleRegistryConsumer, GADRewardedAdDelegate>
 @end

--- a/packages/expo-ads-admob/ios/EXAdsAdMob/EXAdsAdMobRewarded.m
+++ b/packages/expo-ads-admob/ios/EXAdsAdMob/EXAdsAdMobRewarded.m
@@ -1,7 +1,7 @@
-#import <UMCore/UMUIManager.h>
-#import <UMCore/UMEventEmitterService.h>
+#import <ExpoModulesCore/EXUIManager.h>
+#import <ExpoModulesCore/EXEventEmitterService.h>
 #import <EXAdsAdMob/EXAdsAdMobRewarded.h>
-#import <UMCore/UMUtilitiesInterface.h>
+#import <ExpoModulesCore/EXUtilitiesInterface.h>
 
 static NSString *const EXAdsAdMobRewardedUserDidEarnReward = @"rewardedVideoUserDidEarnReward";
 static NSString *const EXAdsAdMobRewardedDidLoad = @"rewardedVideoDidLoad";
@@ -12,8 +12,8 @@ static NSString *const EXAdsAdMobRewardedDidDismiss = @"rewardedVideoDidDismiss"
 
 @interface EXAdsAdMobRewarded ()
 
-@property (nonatomic, weak) id<UMEventEmitterService> eventEmitter;
-@property (nonatomic, weak) id<UMUtilitiesInterface> utilities;
+@property (nonatomic, weak) id<EXEventEmitterService> eventEmitter;
+@property (nonatomic, weak) id<EXUtilitiesInterface> utilities;
 @property (nonatomic, strong) GADRewardedAd *rewardedAd;
 
 @end
@@ -21,17 +21,17 @@ static NSString *const EXAdsAdMobRewardedDidDismiss = @"rewardedVideoDidDismiss"
 @implementation EXAdsAdMobRewarded {
   NSString *_adUnitID;
   BOOL _hasListeners;
-  UMPromiseResolveBlock _requestAdResolver;
-  UMPromiseRejectBlock _requestAdRejecter;
-  UMPromiseResolveBlock _showAdResolver;
+  EXPromiseResolveBlock _requestAdResolver;
+  EXPromiseRejectBlock _requestAdRejecter;
+  EXPromiseResolveBlock _showAdResolver;
 }
 
-UM_EXPORT_MODULE(ExpoAdsAdMobRewardedVideoAdManager);
+EX_EXPORT_MODULE(ExpoAdsAdMobRewardedVideoAdManager);
 
-- (void)setModuleRegistry:(UMModuleRegistry *)moduleRegistry
+- (void)setModuleRegistry:(EXModuleRegistry *)moduleRegistry
 {
-  _utilities = [moduleRegistry getModuleImplementingProtocol:@protocol(UMUtilitiesInterface)];
-  _eventEmitter = [moduleRegistry getModuleImplementingProtocol:@protocol(UMEventEmitterService)];
+  _utilities = [moduleRegistry getModuleImplementingProtocol:@protocol(EXUtilitiesInterface)];
+  _eventEmitter = [moduleRegistry getModuleImplementingProtocol:@protocol(EXEventEmitterService)];
 }
 
 - (NSArray<NSString *> *)supportedEvents
@@ -60,19 +60,19 @@ UM_EXPORT_MODULE(ExpoAdsAdMobRewardedVideoAdManager);
   _hasListeners = NO;
 }
 
-UM_EXPORT_METHOD_AS(setAdUnitID,
+EX_EXPORT_METHOD_AS(setAdUnitID,
                     setAdUnitID:(NSString *)adUnitID
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   _adUnitID = adUnitID;
   resolve(nil);
 }
 
-UM_EXPORT_METHOD_AS(requestAd,
+EX_EXPORT_METHOD_AS(requestAd,
                     requestAdWithAdditionalRequestParams:(NSDictionary *)additionalRequestParams
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   if (_requestAdRejecter == nil) {
     _requestAdResolver = resolve;
@@ -85,12 +85,12 @@ UM_EXPORT_METHOD_AS(requestAd,
       extras.additionalParameters = additionalRequestParams;
       [request registerAdNetworkExtras:extras];
     }
-    UM_WEAKIFY(self);
+    EX_WEAKIFY(self);
     dispatch_async(dispatch_get_main_queue(), ^{
-      UM_ENSURE_STRONGIFY(self);
+      EX_ENSURE_STRONGIFY(self);
       [self.rewardedAd loadRequest:request
                  completionHandler:^(GADRequestError * _Nullable error) {
-        UM_ENSURE_STRONGIFY(self);
+        EX_ENSURE_STRONGIFY(self);
         if (error) {
           [self _maybeSendEventWithName:EXAdsAdMobRewardedDidFailToLoad
                                    body:@{ @"name": [error description] }];
@@ -108,15 +108,15 @@ UM_EXPORT_METHOD_AS(requestAd,
   }
 }
 
-UM_EXPORT_METHOD_AS(showAd,
-                    showAd:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(showAd,
+                    showAd:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   if (_showAdResolver == nil && self.rewardedAd.isReady) {
     _showAdResolver = resolve;
-    UM_WEAKIFY(self);
+    EX_WEAKIFY(self);
     dispatch_async(dispatch_get_main_queue(), ^{
-      UM_ENSURE_STRONGIFY(self);
+      EX_ENSURE_STRONGIFY(self);
       [self.rewardedAd presentFromRootViewController:self.utilities.currentViewController delegate:self];
     });
   } else if (self.rewardedAd.isReady) {
@@ -126,13 +126,13 @@ UM_EXPORT_METHOD_AS(showAd,
   }
 }
 
-UM_EXPORT_METHOD_AS(dismissAd,
-                    dismissAd:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(dismissAd,
+                    dismissAd:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
-  UM_WEAKIFY(self);
+  EX_WEAKIFY(self);
   dispatch_async(dispatch_get_main_queue(), ^{
-    UM_ENSURE_STRONGIFY(self);
+    EX_ENSURE_STRONGIFY(self);
     UIViewController *presentedViewController = self.utilities.currentViewController;
     if (presentedViewController != nil && [NSStringFromClass([presentedViewController class]) isEqualToString:@"GADInterstitialViewController"]) {
       [presentedViewController dismissViewControllerAnimated:true completion:^{
@@ -144,9 +144,9 @@ UM_EXPORT_METHOD_AS(dismissAd,
   });
 }
 
-UM_EXPORT_METHOD_AS(getIsReady,
-                    getIsReady:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(getIsReady,
+                    getIsReady:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   resolve([NSNumber numberWithBool:self.rewardedAd.isReady]);
 }

--- a/packages/expo-ads-admob/ios/EXAdsAdMob/EXAdsDFPBannerView.h
+++ b/packages/expo-ads-admob/ios/EXAdsAdMob/EXAdsDFPBannerView.h
@@ -1,5 +1,5 @@
-#import <UMCore/UMDefines.h>
-#import <UMCore/UMModuleRegistry.h>
+#import <ExpoModulesCore/EXDefines.h>
+#import <ExpoModulesCore/EXModuleRegistry.h>
 #import <GoogleMobileAds/GoogleMobileAds.h>
 
 @interface EXAdsDFPBannerView : UIView <GADBannerViewDelegate, GADAppEventDelegate>
@@ -8,14 +8,14 @@
 @property (nonatomic, copy) NSString *adUnitID;
 @property (nonatomic, copy) NSDictionary *additionalRequestParams;
 
-@property (nonatomic, copy) UMDirectEventBlock onSizeChange;
-@property (nonatomic, copy) UMDirectEventBlock onAdmobDispatchAppEvent;
-@property (nonatomic, copy) UMDirectEventBlock onAdViewDidReceiveAd;
-@property (nonatomic, copy) UMDirectEventBlock onDidFailToReceiveAdWithError;
-@property (nonatomic, copy) UMDirectEventBlock onAdViewWillPresentScreen;
-@property (nonatomic, copy) UMDirectEventBlock onAdViewWillDismissScreen;
-@property (nonatomic, copy) UMDirectEventBlock onAdViewDidDismissScreen;
-@property (nonatomic, copy) UMDirectEventBlock onAdViewWillLeaveApplication;
+@property (nonatomic, copy) EXDirectEventBlock onSizeChange;
+@property (nonatomic, copy) EXDirectEventBlock onAdmobDispatchAppEvent;
+@property (nonatomic, copy) EXDirectEventBlock onAdViewDidReceiveAd;
+@property (nonatomic, copy) EXDirectEventBlock onDidFailToReceiveAdWithError;
+@property (nonatomic, copy) EXDirectEventBlock onAdViewWillPresentScreen;
+@property (nonatomic, copy) EXDirectEventBlock onAdViewWillDismissScreen;
+@property (nonatomic, copy) EXDirectEventBlock onAdViewDidDismissScreen;
+@property (nonatomic, copy) EXDirectEventBlock onAdViewWillLeaveApplication;
 
 - (GADAdSize)getAdSizeFromString:(NSString *)bannerSize;
 - (void)loadBanner;

--- a/packages/expo-ads-admob/ios/EXAdsAdMob/EXAdsDFPBannerView.m
+++ b/packages/expo-ads-admob/ios/EXAdsAdMob/EXAdsDFPBannerView.m
@@ -1,9 +1,9 @@
-#import <UMCore/UMEventEmitterService.h>
+#import <ExpoModulesCore/EXEventEmitterService.h>
 #import <EXAdsAdMob/EXAdsDFPBannerView.h>
 
 @implementation EXAdsDFPBannerView {
   DFPBannerView *_bannerView;
-  id<UMEventEmitterService> _eventEmitter;
+  id<EXEventEmitterService> _eventEmitter;
 }
 
 - (GADAdSize)getAdSizeFromString:(NSString *)bannerSize {
@@ -50,13 +50,13 @@
   }
 }
 
-- (void)setOnSizeChange:(UMDirectEventBlock)block
+- (void)setOnSizeChange:(EXDirectEventBlock)block
 {
   _onSizeChange = block;
   [self loadBanner];
 }
 
-- (void)setOnDidFailToReceiveAdWithError:(UMDirectEventBlock)block
+- (void)setOnDidFailToReceiveAdWithError:(EXDirectEventBlock)block
 {
   _onDidFailToReceiveAdWithError = block;
   [self loadBanner];

--- a/packages/expo-ads-facebook/CHANGELOG.md
+++ b/packages/expo-ads-facebook/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Migrated from `@unimodules/core` to `expo-modules-core`.
+- Migrated from `@unimodules/core` to `expo-modules-core`. ([#13757](https://github.com/expo/expo/pull/13757) by [@tsapeta](https://github.com/tsapeta))
 
 ## 10.1.0 — 2021-06-16
 

--- a/packages/expo-ads-facebook/CHANGELOG.md
+++ b/packages/expo-ads-facebook/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Migrated from `@unimodules/core` to `expo-modules-core`.
+
 ## 10.1.0 — 2021-06-16
 
 ### 🐛 Bug fixes

--- a/packages/expo-ads-facebook/ios/EXAdsFacebook.podspec
+++ b/packages/expo-ads-facebook/ios/EXAdsFacebook.podspec
@@ -13,7 +13,6 @@ Pod::Spec.new do |s|
   s.platform       = :ios, '11.0'
   s.source         = { git: 'https://github.com/expo/expo.git' }
 
-  s.dependency 'UMCore'
   s.dependency 'ExpoModulesCore'
   s.dependency 'FBAudienceNetwork', $FBAudienceNetworkVersion || '6.5.0'
 

--- a/packages/expo-ads-facebook/ios/EXAdsFacebook/EXAdIconViewManager.h
+++ b/packages/expo-ads-facebook/ios/EXAdsFacebook/EXAdIconViewManager.h
@@ -1,6 +1,6 @@
-#import <UMCore/UMViewManager.h>
+#import <ExpoModulesCore/EXViewManager.h>
 #import <FBAudienceNetwork/FBAudienceNetwork.h>
 #import <UIKit/UIKit.h>
 
-@interface EXAdIconViewManager : UMViewManager
+@interface EXAdIconViewManager : EXViewManager
 @end

--- a/packages/expo-ads-facebook/ios/EXAdsFacebook/EXAdIconViewManager.m
+++ b/packages/expo-ads-facebook/ios/EXAdsFacebook/EXAdIconViewManager.m
@@ -2,7 +2,7 @@
 
 @implementation EXAdIconViewManager
 
-UM_EXPORT_MODULE(AdIconViewManager)
+EX_EXPORT_MODULE(AdIconViewManager)
 
 - (NSString *)viewName
 {

--- a/packages/expo-ads-facebook/ios/EXAdsFacebook/EXAdOptionsViewManager.h
+++ b/packages/expo-ads-facebook/ios/EXAdsFacebook/EXAdOptionsViewManager.h
@@ -1,9 +1,9 @@
 // Copyright 2016-present 650 Industries. All rights reserved.
-#import <UMCore/UMViewManager.h>
+#import <ExpoModulesCore/EXViewManager.h>
 #import <FBAudienceNetwork/FBAudienceNetwork.h>
-#import <UMCore/UMModuleRegistryConsumer.h>
+#import <ExpoModulesCore/EXModuleRegistryConsumer.h>
 #import <UIKit/UIKit.h>
 
-@interface EXAdOptionsViewManager : UMViewManager <UMModuleRegistryConsumer>
+@interface EXAdOptionsViewManager : EXViewManager <EXModuleRegistryConsumer>
 @end
 

--- a/packages/expo-ads-facebook/ios/EXAdsFacebook/EXAdOptionsViewManager.m
+++ b/packages/expo-ads-facebook/ios/EXAdsFacebook/EXAdOptionsViewManager.m
@@ -1,18 +1,18 @@
 // Copyright 2016-present 650 Industries. All rights reserved.
 #import <EXAdsFacebook/EXAdOptionsViewManager.h>
-#import <UMCore/UMUtilities.h>
-#import <UMCore/UMUIManager.h>
+#import <ExpoModulesCore/EXUtilities.h>
+#import <ExpoModulesCore/EXUIManager.h>
 #import <EXAdsFacebook/EXNativeAdView.h>
 
 @interface EXAdOptionsViewManager ()
 
-@property (nonatomic, weak) UMModuleRegistry *moduleRegistry;
+@property (nonatomic, weak) EXModuleRegistry *moduleRegistry;
 
 @end
 
 @implementation EXAdOptionsViewManager
 
-UM_EXPORT_MODULE(AdOptionsViewManager)
+EX_EXPORT_MODULE(AdOptionsViewManager)
 
 - (NSString *)viewName
 {
@@ -24,20 +24,20 @@ UM_EXPORT_MODULE(AdOptionsViewManager)
   return [[FBAdOptionsView alloc] init];
 }
 
-- (void)setModuleRegistry:(UMModuleRegistry *)moduleRegistry
+- (void)setModuleRegistry:(EXModuleRegistry *)moduleRegistry
 {
   _moduleRegistry = moduleRegistry;
 }
 
-UM_VIEW_PROPERTY(nativeAdViewTag, NSNumber *, FBAdOptionsView)
+EX_VIEW_PROPERTY(nativeAdViewTag, NSNumber *, FBAdOptionsView)
 {
-  id<UMUIManager> uiManager = [_moduleRegistry getModuleImplementingProtocol:@protocol(UMUIManager)];
+  id<EXUIManager> uiManager = [_moduleRegistry getModuleImplementingProtocol:@protocol(EXUIManager)];
   [uiManager addUIBlock:^(EXNativeAdView *view) {
     [view setNativeAd:view.nativeAd];
   } forView:value ofClass:[EXNativeAdView class]];
 }
 
-UM_VIEW_PROPERTY(iconColor, NSString *, FBAdOptionsView)
+EX_VIEW_PROPERTY(iconColor, NSString *, FBAdOptionsView)
 {
   view.foregroundColor = [EXAdOptionsViewManager colorFromHexString:value];
 }

--- a/packages/expo-ads-facebook/ios/EXAdsFacebook/EXAdSettingsManager.h
+++ b/packages/expo-ads-facebook/ios/EXAdsFacebook/EXAdSettingsManager.h
@@ -1,7 +1,7 @@
-#import <UMCore/UMExportedModule.h>
-#import <UMCore/UMModuleRegistryConsumer.h>
-#import <UMCore/UMAppLifecycleListener.h>
+#import <ExpoModulesCore/EXExportedModule.h>
+#import <ExpoModulesCore/EXModuleRegistryConsumer.h>
+#import <ExpoModulesCore/EXAppLifecycleListener.h>
 
-@interface EXAdSettingsManager : UMExportedModule <UMModuleRegistryConsumer, UMAppLifecycleListener>
+@interface EXAdSettingsManager : EXExportedModule <EXModuleRegistryConsumer, EXAppLifecycleListener>
 
 @end

--- a/packages/expo-ads-facebook/ios/EXAdsFacebook/EXAdSettingsManager.m
+++ b/packages/expo-ads-facebook/ios/EXAdsFacebook/EXAdSettingsManager.m
@@ -3,7 +3,7 @@
 
 #import <FBAudienceNetwork/FBAudienceNetwork.h>
 
-#import <UMCore/UMAppLifecycleService.h>
+#import <ExpoModulesCore/EXAppLifecycleService.h>
 #import <ExpoModulesCore/EXPermissionsInterface.h>
 #import <ExpoModulesCore/EXPermissionsMethodsDelegate.h>
 
@@ -12,7 +12,7 @@
 @property (nonatomic) BOOL isChildDirected;
 @property (nonatomic, strong) NSString *mediationService;
 @property (nonatomic, strong, nullable) NSString *urlPrefix;
-@property (nonatomic, weak) UMModuleRegistry *moduleRegistry;
+@property (nonatomic, weak) EXModuleRegistry *moduleRegistry;
 @property (nonatomic, weak) id<EXPermissionsInterface> permissionsManager;
 @property (nonatomic) FBAdLogLevel logLevel;
 @property (nonatomic, strong) NSMutableArray<NSString*> *testDevices;
@@ -21,7 +21,7 @@
 
 @implementation EXAdSettingsManager
 
-UM_EXPORT_MODULE(CTKAdSettingsManager)
+EX_EXPORT_MODULE(CTKAdSettingsManager)
 
 - (instancetype)init {
   if (self = [super init]) {
@@ -31,18 +31,18 @@ UM_EXPORT_MODULE(CTKAdSettingsManager)
   return self;
 }
 
-- (void)setModuleRegistry:(UMModuleRegistry *)moduleRegistry
+- (void)setModuleRegistry:(EXModuleRegistry *)moduleRegistry
 {
   _moduleRegistry = moduleRegistry;
-  [[_moduleRegistry getModuleImplementingProtocol:@protocol(UMAppLifecycleService)] registerAppLifecycleListener:self];
+  [[_moduleRegistry getModuleImplementingProtocol:@protocol(EXAppLifecycleService)] registerAppLifecycleListener:self];
   
   _permissionsManager = [_moduleRegistry getModuleImplementingProtocol:@protocol(EXPermissionsInterface)];
   [EXPermissionsMethodsDelegate registerRequesters:@[[EXFacebookAdsAppTrackingPermissionRequester new]] withPermissionsManager:_permissionsManager];
 }
 
-UM_EXPORT_METHOD_AS(getPermissionsAsync,
-                    getPermissionsAsync:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(getPermissionsAsync,
+                    getPermissionsAsync:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   [EXPermissionsMethodsDelegate getPermissionWithPermissionsManager:_permissionsManager
                                                       withRequester:[EXFacebookAdsAppTrackingPermissionRequester class]
@@ -50,9 +50,9 @@ UM_EXPORT_METHOD_AS(getPermissionsAsync,
                                                              reject:reject];
 }
 
-UM_EXPORT_METHOD_AS(requestPermissionsAsync,
-                    requestPermissionsAsync:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(requestPermissionsAsync,
+                    requestPermissionsAsync:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   [EXPermissionsMethodsDelegate askForPermissionWithPermissionsManager:_permissionsManager
                                                          withRequester:[EXFacebookAdsAppTrackingPermissionRequester class]
@@ -60,37 +60,37 @@ UM_EXPORT_METHOD_AS(requestPermissionsAsync,
                                                                 reject:reject];
 }
 
-UM_EXPORT_METHOD_AS(setAdvertiserTrackingEnabled,
+EX_EXPORT_METHOD_AS(setAdvertiserTrackingEnabled,
                     setAdvertiserTrackingEnabled:(BOOL)enabled
-                    resolve:(UMPromiseResolveBlock)resolve
-                    reject:(UMPromiseRejectBlock)reject)
+                    resolve:(EXPromiseResolveBlock)resolve
+                    reject:(EXPromiseRejectBlock)reject)
 {
   [FBAdSettings setAdvertiserTrackingEnabled:enabled];
   resolve(nil);
 }
 
-UM_EXPORT_METHOD_AS(addTestDevice,
+EX_EXPORT_METHOD_AS(addTestDevice,
                     addTestDevice:(NSString *)deviceHash
-                    resolve:(UMPromiseResolveBlock)resolver
-                    reject:(UMPromiseRejectBlock)rejecter)
+                    resolve:(EXPromiseResolveBlock)resolver
+                    reject:(EXPromiseRejectBlock)rejecter)
 {
   [FBAdSettings addTestDevice:deviceHash];
   [_testDevices addObject:deviceHash];
   resolver(nil);
 }
 
-UM_EXPORT_METHOD_AS(clearTestDevices,
-                    clearTestDevicesWithResolver:(UMPromiseResolveBlock)resolver
-                    reject:(UMPromiseRejectBlock)rejecter)
+EX_EXPORT_METHOD_AS(clearTestDevices,
+                    clearTestDevicesWithResolver:(EXPromiseResolveBlock)resolver
+                    reject:(EXPromiseRejectBlock)rejecter)
 {
   [FBAdSettings clearTestDevices];
   [_testDevices removeAllObjects];
 }
 
-UM_EXPORT_METHOD_AS(setLogLevel,
+EX_EXPORT_METHOD_AS(setLogLevel,
                     setLogLevel:(NSString *)logLevelKey
-                    resolve:(UMPromiseResolveBlock)resolver
-                    reject:(UMPromiseRejectBlock)rejecter)
+                    resolve:(EXPromiseResolveBlock)resolver
+                    reject:(EXPromiseRejectBlock)rejecter)
 {
   FBAdLogLevel logLevel = [@{
                            @"none": @(FBAdLogLevelNone),
@@ -105,30 +105,30 @@ UM_EXPORT_METHOD_AS(setLogLevel,
   resolver(nil);
 }
 
-UM_EXPORT_METHOD_AS(setIsChildDirected,
+EX_EXPORT_METHOD_AS(setIsChildDirected,
                     setIsChildDirected:(BOOL)isDirected
-                    resolve:(UMPromiseResolveBlock)resolver
-                    reject:(UMPromiseRejectBlock)rejecter)
+                    resolve:(EXPromiseResolveBlock)resolver
+                    reject:(EXPromiseRejectBlock)rejecter)
 {
   [FBAdSettings setIsChildDirected:isDirected];
   _isChildDirected = isDirected;
   resolver(nil);
 }
 
-UM_EXPORT_METHOD_AS(setMeditationService,
+EX_EXPORT_METHOD_AS(setMeditationService,
                     setMediationService:(NSString *)mediationService
-                    resolve:(UMPromiseResolveBlock)resolver
-                    reject:(UMPromiseRejectBlock)rejecter)
+                    resolve:(EXPromiseResolveBlock)resolver
+                    reject:(EXPromiseRejectBlock)rejecter)
 {
   [FBAdSettings setMediationService:mediationService];
   _mediationService = mediationService;
   resolver(nil);
 }
 
-UM_EXPORT_METHOD_AS(setUrlPrefix,
+EX_EXPORT_METHOD_AS(setUrlPrefix,
                     setUrlPrefix:(NSString *)urlPrefix
-                    resolve:(UMPromiseResolveBlock)resolver
-                    reject:(UMPromiseRejectBlock)rejecter)
+                    resolve:(EXPromiseResolveBlock)resolver
+                    reject:(EXPromiseRejectBlock)rejecter)
 {
   [FBAdSettings setUrlPrefix:urlPrefix];
   resolver(nil);

--- a/packages/expo-ads-facebook/ios/EXAdsFacebook/EXBannerView.h
+++ b/packages/expo-ads-facebook/ios/EXAdsFacebook/EXBannerView.h
@@ -1,15 +1,15 @@
 #import <UIKit/UIKit.h>
-#import <UMCore/UMDefines.h>
-#import <UMCore/UMModuleRegistry.h>
+#import <ExpoModulesCore/EXDefines.h>
+#import <ExpoModulesCore/EXModuleRegistry.h>
 
 @interface EXBannerView : UIView
 
-@property (nonatomic, copy) UMDirectEventBlock onAdPress;
-@property (nonatomic, copy) UMDirectEventBlock onAdError;
+@property (nonatomic, copy) EXDirectEventBlock onAdPress;
+@property (nonatomic, copy) EXDirectEventBlock onAdError;
 
 @property (nonatomic, strong) NSNumber *size;
 @property (nonatomic, strong) NSString *placementId;
 
-- (instancetype)initWithModuleRegistry:(UMModuleRegistry *)moduleRegistry;
+- (instancetype)initWithModuleRegistry:(EXModuleRegistry *)moduleRegistry;
 
 @end

--- a/packages/expo-ads-facebook/ios/EXAdsFacebook/EXBannerView.m
+++ b/packages/expo-ads-facebook/ios/EXAdsFacebook/EXBannerView.m
@@ -1,17 +1,17 @@
 #import <EXAdsFacebook/EXBannerView.h>
 #import <FBAudienceNetwork/FBAudienceNetwork.h>
-#import <UMCore/UMUtilitiesInterface.h>
+#import <ExpoModulesCore/EXUtilitiesInterface.h>
 
 @interface EXBannerView () <FBAdViewDelegate>
 
 @property (nonatomic, strong) FBAdView *adView;
-@property (nonatomic, weak) UMModuleRegistry *moduleRegistry;
+@property (nonatomic, weak) EXModuleRegistry *moduleRegistry;
 
 @end
 
 @implementation EXBannerView
 
-- (instancetype)initWithModuleRegistry:(UMModuleRegistry *)moduleRegistry
+- (instancetype)initWithModuleRegistry:(EXModuleRegistry *)moduleRegistry
 {
   if (self = [super init]) {
     _moduleRegistry = moduleRegistry;
@@ -43,7 +43,7 @@
   }
   
   FBAdSize fbAdSize = [self fbAdSizeForHeight:_size];
-  UIViewController *rootViewController = [[_moduleRegistry getModuleImplementingProtocol:@protocol(UMUtilitiesInterface)] currentViewController];
+  UIViewController *rootViewController = [[_moduleRegistry getModuleImplementingProtocol:@protocol(EXUtilitiesInterface)] currentViewController];
   FBAdView *adView = [[FBAdView alloc] initWithPlacementID:_placementId
                                                     adSize:fbAdSize
                                         rootViewController:rootViewController];
@@ -85,7 +85,7 @@
   if (_onAdError) {
     _onAdError(@{ @"message": error.description, @"userInfo": error.userInfo });
   } else {
-    UMLogError(@"%@: %@", error.localizedDescription, error.userInfo);
+    EXLogError(@"%@: %@", error.localizedDescription, error.userInfo);
   }
 }
 

--- a/packages/expo-ads-facebook/ios/EXAdsFacebook/EXBannerViewManager.h
+++ b/packages/expo-ads-facebook/ios/EXAdsFacebook/EXBannerViewManager.h
@@ -1,5 +1,5 @@
-#import <UMCore/UMViewManager.h>
+#import <ExpoModulesCore/EXViewManager.h>
 
-@interface EXBannerViewManager : UMViewManager
+@interface EXBannerViewManager : EXViewManager
 
 @end

--- a/packages/expo-ads-facebook/ios/EXAdsFacebook/EXBannerViewManager.m
+++ b/packages/expo-ads-facebook/ios/EXAdsFacebook/EXBannerViewManager.m
@@ -3,7 +3,7 @@
 
 @implementation EXBannerViewManager
 
-UM_EXPORT_MODULE(CTKBannerViewManager)
+EX_EXPORT_MODULE(CTKBannerViewManager)
 
 - (UIView *)view
 {
@@ -20,12 +20,12 @@ UM_EXPORT_MODULE(CTKBannerViewManager)
   return @[@"onAdPress", @"onAdError"];
 }
 
-UM_VIEW_PROPERTY(size, NSNumber *, EXBannerView)
+EX_VIEW_PROPERTY(size, NSNumber *, EXBannerView)
 {
   [view setSize:value];
 }
 
-UM_VIEW_PROPERTY(placementId, NSString *, EXBannerView)
+EX_VIEW_PROPERTY(placementId, NSString *, EXBannerView)
 {
   [view setPlacementId:value];
 }

--- a/packages/expo-ads-facebook/ios/EXAdsFacebook/EXFacebookAdsAppTrackingPermissionRequester.m
+++ b/packages/expo-ads-facebook/ios/EXAdsFacebook/EXFacebookAdsAppTrackingPermissionRequester.m
@@ -37,12 +37,12 @@
   };
 }
 
-- (void)requestPermissionsWithResolver:(UMPromiseResolveBlock)resolve rejecter:(UMPromiseRejectBlock)reject
+- (void)requestPermissionsWithResolver:(EXPromiseResolveBlock)resolve rejecter:(EXPromiseRejectBlock)reject
 {
   if (@available(iOS 14, *)) {
-    UM_WEAKIFY(self)
+    EX_WEAKIFY(self)
     [ATTrackingManager requestTrackingAuthorizationWithCompletionHandler:^(ATTrackingManagerAuthorizationStatus status) {
-      UM_STRONGIFY(self)
+      EX_STRONGIFY(self)
       resolve([self getPermissions]);
     }];
   } else {

--- a/packages/expo-ads-facebook/ios/EXAdsFacebook/EXInterstitialAdManager.h
+++ b/packages/expo-ads-facebook/ios/EXAdsFacebook/EXInterstitialAdManager.h
@@ -1,6 +1,6 @@
-#import <UMCore/UMExportedModule.h>
-#import <UMCore/UMModuleRegistryConsumer.h>
+#import <ExpoModulesCore/EXExportedModule.h>
+#import <ExpoModulesCore/EXModuleRegistryConsumer.h>
 
-@interface EXInterstitialAdManager : UMExportedModule <UMModuleRegistryConsumer>
+@interface EXInterstitialAdManager : EXExportedModule <EXModuleRegistryConsumer>
 
 @end

--- a/packages/expo-ads-facebook/ios/EXAdsFacebook/EXInterstitialAdManager.m
+++ b/packages/expo-ads-facebook/ios/EXAdsFacebook/EXInterstitialAdManager.m
@@ -1,33 +1,33 @@
 #import <EXAdsFacebook/EXInterstitialAdManager.h>
-#import <UMCore/UMUtilities.h>
+#import <ExpoModulesCore/EXUtilities.h>
 
 #import <FBAudienceNetwork/FBAudienceNetwork.h>
 
 @interface EXInterstitialAdManager () <FBInterstitialAdDelegate>
 
-@property (nonatomic, strong) UMPromiseResolveBlock resolve;
-@property (nonatomic, strong) UMPromiseRejectBlock reject;
+@property (nonatomic, strong) EXPromiseResolveBlock resolve;
+@property (nonatomic, strong) EXPromiseRejectBlock reject;
 @property (nonatomic, strong) FBInterstitialAd *interstitialAd;
 @property (nonatomic, strong) UIViewController *adViewController;
 @property (nonatomic) bool didClick;
 @property (nonatomic) bool isBackground;
-@property (nonatomic, weak) UMModuleRegistry *moduleRegistry;
+@property (nonatomic, weak) EXModuleRegistry *moduleRegistry;
 
 @end
 
 @implementation EXInterstitialAdManager
 
-UM_EXPORT_MODULE(CTKInterstitialAdManager)
+EX_EXPORT_MODULE(CTKInterstitialAdManager)
 
-- (void)setModuleRegistry:(UMModuleRegistry *)moduleRegistry
+- (void)setModuleRegistry:(EXModuleRegistry *)moduleRegistry
 {
   _moduleRegistry = moduleRegistry;
 }
 
-UM_EXPORT_METHOD_AS(showAd,
+EX_EXPORT_METHOD_AS(showAd,
                     showAd:(NSString *)placementId
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   if (_resolve != nil || _reject != nil) {
     reject(@"E_NO_CONCURRENT", @"Only one `showAd` can be called at once", nil);
@@ -43,7 +43,7 @@ UM_EXPORT_METHOD_AS(showAd,
   
   _interstitialAd = [[FBInterstitialAd alloc] initWithPlacementID:placementId];
   _interstitialAd.delegate = self;
-  [UMUtilities performSynchronouslyOnMainThread:^{
+  [EXUtilities performSynchronouslyOnMainThread:^{
     [self->_interstitialAd loadAd];
   }];
 }
@@ -52,7 +52,7 @@ UM_EXPORT_METHOD_AS(showAd,
 
 - (void)interstitialAdDidLoad:(__unused FBInterstitialAd *)interstitialAd
 {
-  [_interstitialAd showAdFromRootViewController:[[_moduleRegistry getModuleImplementingProtocol:@protocol(UMUtilitiesInterface)] currentViewController]];
+  [_interstitialAd showAdFromRootViewController:[[_moduleRegistry getModuleImplementingProtocol:@protocol(EXUtilitiesInterface)] currentViewController]];
 }
 
 - (void)interstitialAd:(FBInterstitialAd *)interstitialAd didFailWithError:(NSError *)error
@@ -79,7 +79,7 @@ UM_EXPORT_METHOD_AS(showAd,
   _isBackground = false;
   
   if (_adViewController) {
-    [[[_moduleRegistry getModuleImplementingProtocol:@protocol(UMUtilitiesInterface)] currentViewController] presentViewController:_adViewController animated:NO completion:nil];
+    [[[_moduleRegistry getModuleImplementingProtocol:@protocol(EXUtilitiesInterface)] currentViewController] presentViewController:_adViewController animated:NO completion:nil];
     _adViewController = nil;
   }
 }
@@ -89,7 +89,7 @@ UM_EXPORT_METHOD_AS(showAd,
   _isBackground = true;
   
   if (_interstitialAd) {
-    _adViewController = [[_moduleRegistry getModuleImplementingProtocol:@protocol(UMUtilitiesInterface)] currentViewController];
+    _adViewController = [[_moduleRegistry getModuleImplementingProtocol:@protocol(EXUtilitiesInterface)] currentViewController];
     [_adViewController dismissViewControllerAnimated:NO completion:nil];
   }
 }

--- a/packages/expo-ads-facebook/ios/EXAdsFacebook/EXNativeAdManager.h
+++ b/packages/expo-ads-facebook/ios/EXAdsFacebook/EXNativeAdManager.h
@@ -1,7 +1,7 @@
-#import <UMCore/UMViewManager.h>
-#import <UMCore/UMModuleRegistryConsumer.h>
-#import <UMCore/UMEventEmitter.h>
+#import <ExpoModulesCore/EXViewManager.h>
+#import <ExpoModulesCore/EXModuleRegistryConsumer.h>
+#import <ExpoModulesCore/EXEventEmitter.h>
 
-@interface EXNativeAdManager : UMViewManager <UMModuleRegistryConsumer, UMEventEmitter>
+@interface EXNativeAdManager : EXViewManager <EXModuleRegistryConsumer, EXEventEmitter>
 
 @end

--- a/packages/expo-ads-facebook/ios/EXAdsFacebook/EXNativeAdManager.m
+++ b/packages/expo-ads-facebook/ios/EXAdsFacebook/EXNativeAdManager.m
@@ -2,15 +2,15 @@
 #import <EXAdsFacebook/EXNativeAdView.h>
 
 #import <FBAudienceNetwork/FBAudienceNetwork.h>
-#import <UMCore/UMUtilities.h>
-#import <UMCore/UMUIManager.h>
-#import <UMCore/UMEventEmitterService.h>
+#import <ExpoModulesCore/EXUtilities.h>
+#import <ExpoModulesCore/EXUIManager.h>
+#import <ExpoModulesCore/EXEventEmitterService.h>
 
 @class EXAdManagerDelegate;
 
 @interface EXNativeAdManager ()
 
-@property (nonatomic, weak) UMModuleRegistry *moduleRegistry;
+@property (nonatomic, weak) EXModuleRegistry *moduleRegistry;
 @property (nonatomic, strong) NSMutableDictionary<NSString*, FBNativeAdsManager*> *adsManagers;
 @property (nonatomic, strong) NSMutableDictionary<NSString*, EXAdManagerDelegate*> *adsManagersDelegates;
 
@@ -58,7 +58,7 @@
 
 @implementation EXNativeAdManager
 
-UM_EXPORT_MODULE(CTKNativeAdManager)
+EX_EXPORT_MODULE(CTKNativeAdManager)
 
 - (instancetype)init
 {
@@ -75,7 +75,7 @@ UM_EXPORT_MODULE(CTKNativeAdManager)
   return @"CTKNativeAd";
 }
 
-- (void)setModuleRegistry:(UMModuleRegistry *)moduleRegistry
+- (void)setModuleRegistry:(EXModuleRegistry *)moduleRegistry
 {
   _moduleRegistry = moduleRegistry;
 }
@@ -85,15 +85,15 @@ UM_EXPORT_MODULE(CTKNativeAdManager)
   return @[@"CTKNativeAdsManagersChanged", @"CTKNativeAdManagerErrored", @"onAdLoaded"];
 }
 
-UM_EXPORT_METHOD_AS(registerViewsForInteraction,
+EX_EXPORT_METHOD_AS(registerViewsForInteraction,
                     registerViewsForInteraction:(NSNumber *)nativeAdViewTag
                     mediaViewTag:(NSNumber *)mediaViewTag
                     adIconViewTag:(NSNumber *)adIconViewTag
                     clickableViewsTags:(NSArray *)tags
-                    resolve:(UMPromiseResolveBlock)resolve
-                    reject:(UMPromiseRejectBlock)reject)
+                    resolve:(EXPromiseResolveBlock)resolve
+                    reject:(EXPromiseRejectBlock)reject)
 {
-  id<UMUIManager> uiManager = [_moduleRegistry getModuleImplementingProtocol:@protocol(UMUIManager)];
+  id<EXUIManager> uiManager = [_moduleRegistry getModuleImplementingProtocol:@protocol(EXUIManager)];
   [uiManager executeUIBlock:^(NSDictionary<id,UIView *> * viewRegistry) {
     UIView *mediaView = nil;
     UIView *adIconView = nil;
@@ -149,11 +149,11 @@ UM_EXPORT_METHOD_AS(registerViewsForInteraction,
   }];
 }
 
-UM_EXPORT_METHOD_AS(init,
+EX_EXPORT_METHOD_AS(init,
                     init:(NSString *)placementId
                     withAdsToRequest:(NSNumber *)adsToRequest
-                    resolve:(UMPromiseResolveBlock)resolve
-                    reject:(UMPromiseRejectBlock)reject)
+                    resolve:(EXPromiseResolveBlock)resolve
+                    reject:(EXPromiseRejectBlock)reject)
 {
   FBNativeAdsManager *adsManager = [[FBNativeAdsManager alloc] initWithPlacementID:placementId
                                                                 forNumAdsRequested:[adsToRequest intValue]];
@@ -162,7 +162,7 @@ UM_EXPORT_METHOD_AS(init,
   _adsManagersDelegates[placementId] = delegate;
   [adsManager setDelegate:delegate];
 
-  [UMUtilities performSynchronouslyOnMainThread:^{
+  [EXUtilities performSynchronouslyOnMainThread:^{
     [adsManager loadAds];
   }];
 
@@ -170,11 +170,11 @@ UM_EXPORT_METHOD_AS(init,
   resolve(nil);
 }
 
-UM_EXPORT_METHOD_AS(setMediaCachePolicy,
+EX_EXPORT_METHOD_AS(setMediaCachePolicy,
                     setMediaCachePolicy:(NSString *)placementId
                     cachePolicy:(NSString *)cachePolicy
-                    resolve:(UMPromiseResolveBlock)resolve
-                    reject:(UMPromiseRejectBlock)reject)
+                    resolve:(EXPromiseResolveBlock)resolve
+                    reject:(EXPromiseRejectBlock)reject)
 {
   FBNativeAdsCachePolicy policy = [@{
                                      @"none": @(FBNativeAdsCachePolicyNone),
@@ -184,10 +184,10 @@ UM_EXPORT_METHOD_AS(setMediaCachePolicy,
   resolve(nil);
 }
 
-UM_EXPORT_METHOD_AS(disableAutoRefresh,
+EX_EXPORT_METHOD_AS(disableAutoRefresh,
                     disableAutoRefresh:(NSString*)placementId
-                    resolve:(UMPromiseResolveBlock)resolve
-                    reject:(UMPromiseRejectBlock)reject)
+                    resolve:(EXPromiseResolveBlock)resolve
+                    reject:(EXPromiseRejectBlock)reject)
 {
   [_adsManagers[placementId] disableAutoRefresh];
   resolve(nil);
@@ -201,12 +201,12 @@ UM_EXPORT_METHOD_AS(disableAutoRefresh,
     [adsManagersState setValue:@([adManager isValid]) forKey:key];
   }];
 
-  [[_moduleRegistry getModuleImplementingProtocol:@protocol(UMEventEmitterService)] sendEventWithName:@"CTKNativeAdsManagersChanged" body:adsManagersState];
+  [[_moduleRegistry getModuleImplementingProtocol:@protocol(EXEventEmitterService)] sendEventWithName:@"CTKNativeAdsManagersChanged" body:adsManagersState];
 }
 
 - (void)nativeAdForPlacementId:(NSString *)placementId failedToLoadWithError:(NSError *)error
 {
-  [[_moduleRegistry getModuleImplementingProtocol:@protocol(UMEventEmitterService)] sendEventWithName:@"CTKNativeAdManagerErrored" body:@{
+  [[_moduleRegistry getModuleImplementingProtocol:@protocol(EXEventEmitterService)] sendEventWithName:@"CTKNativeAdManagerErrored" body:@{
     @"placementId": placementId,
     @"error": @{
         @"message": error.localizedDescription ?: error.description,
@@ -220,7 +220,7 @@ UM_EXPORT_METHOD_AS(disableAutoRefresh,
   return [[EXNativeAdView alloc] initWithModuleRegistry:_moduleRegistry];
 }
 
-UM_VIEW_PROPERTY(adsManager, NSString *, EXNativeAdView)
+EX_VIEW_PROPERTY(adsManager, NSString *, EXNativeAdView)
 {
   [view setNativeAd:[_adsManagers[value] nextNativeAd]];
 }

--- a/packages/expo-ads-facebook/ios/EXAdsFacebook/EXNativeAdView.h
+++ b/packages/expo-ads-facebook/ios/EXAdsFacebook/EXNativeAdView.h
@@ -1,17 +1,17 @@
 #import <FBAudienceNetwork/FBNativeAd.h>
 #import <UIKit/UIKit.h>
-#import <UMCore/UMDefines.h>
-#import <UMCore/UMModuleRegistry.h>
+#import <ExpoModulesCore/EXDefines.h>
+#import <ExpoModulesCore/EXModuleRegistry.h>
 
 @interface EXNativeAdView : UIView
 
 // `onAdLoaded` event called when ad has been loaded
-@property (nonatomic, copy) UMDirectEventBlock onAdLoaded;
+@property (nonatomic, copy) EXDirectEventBlock onAdLoaded;
 
 // NativeAd this view has been loaded with
 @property (nonatomic, strong) FBNativeAd *nativeAd;
 
-- (instancetype)initWithModuleRegistry:(UMModuleRegistry *)moduleRegistry;
+- (instancetype)initWithModuleRegistry:(EXModuleRegistry *)moduleRegistry;
 - (void)registerViewsForInteraction:(FBMediaView *)mediaView adIcon:(FBAdIconView *)adIconView clickableViews:(NSArray<UIView *> *)clickable;
 
 @end

--- a/packages/expo-ads-facebook/ios/EXAdsFacebook/EXNativeAdView.m
+++ b/packages/expo-ads-facebook/ios/EXAdsFacebook/EXNativeAdView.m
@@ -1,16 +1,16 @@
 #import <EXAdsFacebook/EXNativeAdView.h>
 #import <FBAudienceNetwork/FBAudienceNetwork.h>
-#import <UMCore/UMUtilitiesInterface.h>
+#import <ExpoModulesCore/EXUtilitiesInterface.h>
 
 @interface EXNativeAdView ()
 
-@property (nonatomic, weak) UMModuleRegistry *moduleRegistry;
+@property (nonatomic, weak) EXModuleRegistry *moduleRegistry;
 
 @end
 
 @implementation EXNativeAdView
 
-- (instancetype)initWithModuleRegistry:(UMModuleRegistry *)moduleRegistry
+- (instancetype)initWithModuleRegistry:(EXModuleRegistry *)moduleRegistry
 {
   if (self = [super init]) {
     _moduleRegistry = moduleRegistry;
@@ -18,7 +18,7 @@
   return self;
 }
 
-- (void)setOnAdLoaded:(UMDirectEventBlock)onAdLoaded
+- (void)setOnAdLoaded:(EXDirectEventBlock)onAdLoaded
 {
   _onAdLoaded = onAdLoaded;
   
@@ -59,7 +59,7 @@
       [strongSelf.nativeAd registerViewForInteraction:strongSelf
                                             mediaView:mediaView
                                              iconView:adIconView
-                                       viewController:[[strongSelf.moduleRegistry getModuleImplementingProtocol:@protocol(UMUtilitiesInterface)] currentViewController]
+                                       viewController:[[strongSelf.moduleRegistry getModuleImplementingProtocol:@protocol(EXUtilitiesInterface)] currentViewController]
                                        clickableViews:clickable];
     }
   });

--- a/packages/expo-ads-facebook/ios/EXAdsFacebook/EXNativeMediaViewManager.h
+++ b/packages/expo-ads-facebook/ios/EXAdsFacebook/EXNativeMediaViewManager.h
@@ -1,5 +1,5 @@
-#import <UMCore/UMViewManager.h>
+#import <ExpoModulesCore/EXViewManager.h>
 #import <UIKit/UIKit.h>
 
-@interface EXNativeMediaViewManager : UMViewManager
+@interface EXNativeMediaViewManager : EXViewManager
 @end

--- a/packages/expo-ads-facebook/ios/EXAdsFacebook/EXNativeMediaViewManager.m
+++ b/packages/expo-ads-facebook/ios/EXAdsFacebook/EXNativeMediaViewManager.m
@@ -5,7 +5,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation EXNativeMediaViewManager
 
-UM_EXPORT_MODULE(MediaViewManager)
+EX_EXPORT_MODULE(MediaViewManager)
 
 - (NSString *)viewName
 {

--- a/packages/expo-analytics-amplitude/CHANGELOG.md
+++ b/packages/expo-analytics-amplitude/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 💡 Others
 
 - Replace the generic object types with `Record`s. ([#13675](https://github.com/expo/expo/pull/13675) by [@Simek](https://github.com/Simek))
+- Migrated from `@unimodules/core` to `expo-modules-core`.
 
 ## 10.2.0 — 2021-06-16
 
@@ -50,7 +51,7 @@
   - `logEventWithProperties` to `logEventWithPropertiesAsync`
   - `setGroup` to `setGroupAsync`
   - `setTrackingOptions` to `setTrackingOptionsAsync`
-([#9212](https://github.com/expo/expo/pull/9212/) by [@cruzach](https://github.com/cruzach))
+    ([#9212](https://github.com/expo/expo/pull/9212/) by [@cruzach](https://github.com/cruzach))
 - All methods now return a Promise. ([#9212](https://github.com/expo/expo/pull/9212/) by [@cruzach](https://github.com/cruzach))
 
 ## 8.3.1 — 2020-08-24

--- a/packages/expo-analytics-amplitude/CHANGELOG.md
+++ b/packages/expo-analytics-amplitude/CHANGELOG.md
@@ -13,7 +13,7 @@
 ### 💡 Others
 
 - Replace the generic object types with `Record`s. ([#13675](https://github.com/expo/expo/pull/13675) by [@Simek](https://github.com/Simek))
-- Migrated from `@unimodules/core` to `expo-modules-core`.
+- Migrated from `@unimodules/core` to `expo-modules-core`. ([#13757](https://github.com/expo/expo/pull/13757) by [@tsapeta](https://github.com/tsapeta))
 
 ## 10.2.0 — 2021-06-16
 

--- a/packages/expo-analytics-amplitude/ios/EXAmplitude.podspec
+++ b/packages/expo-analytics-amplitude/ios/EXAmplitude.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.platform       = :ios, '11.0'
   s.source         = { git: 'https://github.com/expo/expo.git' }
 
-  s.dependency 'UMCore'
+  s.dependency 'ExpoModulesCore'
   s.dependency 'Amplitude', '~> 6.0.0'
 
   if !$ExpoUseSources&.include?(package['name']) && ENV['EXPO_USE_SOURCE'].to_i == 0 && File.exist?("#{s.name}.xcframework") && Gem::Version.new(Pod::VERSION) >= Gem::Version.new('1.10.0')

--- a/packages/expo-analytics-amplitude/ios/EXAmplitude/EXAmplitude.h
+++ b/packages/expo-analytics-amplitude/ios/EXAmplitude/EXAmplitude.h
@@ -1,6 +1,6 @@
 //  Copyright © 2018 650 Industries. All rights reserved.
 
-#import <UMCore/UMExportedModule.h>
+#import <ExpoModulesCore/EXExportedModule.h>
 
-@interface EXAmplitude : UMExportedModule
+@interface EXAmplitude : EXExportedModule
 @end

--- a/packages/expo-analytics-amplitude/ios/EXAmplitude/EXAmplitude.m
+++ b/packages/expo-analytics-amplitude/ios/EXAmplitude/EXAmplitude.m
@@ -7,17 +7,17 @@
 
 @implementation EXAmplitude
 
-UM_EXPORT_MODULE(ExpoAmplitude);
+EX_EXPORT_MODULE(ExpoAmplitude);
 
 - (Amplitude *)amplitudeInstance
 {
   return [Amplitude instance];
 }
 
-UM_EXPORT_METHOD_AS(initializeAsync,
+EX_EXPORT_METHOD_AS(initializeAsync,
                     initializeAsync:(NSString *)apiKey
-                    resolve:(UMPromiseResolveBlock)resolve
-                    reject:(UMPromiseRejectBlock)reject)
+                    resolve:(EXPromiseResolveBlock)resolve
+                    reject:(EXPromiseRejectBlock)reject)
 {
   // TODO: remove the UIApplicationWillEnterForegroundNotification and
   // UIApplicationDidEnterBackgroundNotification observers and call enterForeground
@@ -26,65 +26,65 @@ UM_EXPORT_METHOD_AS(initializeAsync,
   resolve(nil);
 }
 
-UM_EXPORT_METHOD_AS(setUserIdAsync,
+EX_EXPORT_METHOD_AS(setUserIdAsync,
                     setUserIdAsync:(NSString *)userId
-                    resolve:(UMPromiseResolveBlock)resolve
-                    reject:(UMPromiseRejectBlock)reject)
+                    resolve:(EXPromiseResolveBlock)resolve
+                    reject:(EXPromiseRejectBlock)reject)
 {
   [[self amplitudeInstance] setUserId:userId];
   resolve(nil);
 }
 
-UM_EXPORT_METHOD_AS(setUserPropertiesAsync,
+EX_EXPORT_METHOD_AS(setUserPropertiesAsync,
                     setUserPropertiesAsync:(NSDictionary *)properties
-                    resolve:(UMPromiseResolveBlock)resolve
-                    reject:(UMPromiseRejectBlock)reject)
+                    resolve:(EXPromiseResolveBlock)resolve
+                    reject:(EXPromiseRejectBlock)reject)
 {
   [[self amplitudeInstance] setUserProperties:properties];
   resolve(nil);
 }
 
-UM_EXPORT_METHOD_AS(clearUserPropertiesAsync,
-                    clearUserPropertiesAsyncWithResolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(clearUserPropertiesAsync,
+                    clearUserPropertiesAsyncWithResolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   [[self amplitudeInstance] clearUserProperties];
   resolve(nil);
 }
 
-UM_EXPORT_METHOD_AS(logEventAsync,
+EX_EXPORT_METHOD_AS(logEventAsync,
                     logEventAsync:(NSString *)eventName
-                    resolve:(UMPromiseResolveBlock)resolve
-                    reject:(UMPromiseRejectBlock)reject)
+                    resolve:(EXPromiseResolveBlock)resolve
+                    reject:(EXPromiseRejectBlock)reject)
 {
   [[self amplitudeInstance] logEvent:eventName];
   resolve(nil);
 }
 
-UM_EXPORT_METHOD_AS(logEventWithPropertiesAsync,
+EX_EXPORT_METHOD_AS(logEventWithPropertiesAsync,
                     logEventWithPropertiesAsync:(NSString *)eventName
                     withProperties:(NSDictionary *)properties
-                    resolve:(UMPromiseResolveBlock)resolve
-                    reject:(UMPromiseRejectBlock)reject)
+                    resolve:(EXPromiseResolveBlock)resolve
+                    reject:(EXPromiseRejectBlock)reject)
 {
   [[self amplitudeInstance] logEvent:eventName withEventProperties:properties];
   resolve(nil);
 }
 
-UM_EXPORT_METHOD_AS(setGroupAsync,
+EX_EXPORT_METHOD_AS(setGroupAsync,
                     setGroupAsync:(NSString *)groupType
                     withGroupNames:(NSArray *)groupNames
-                    resolve:(UMPromiseResolveBlock)resolve
-                    reject:(UMPromiseRejectBlock)reject)
+                    resolve:(EXPromiseResolveBlock)resolve
+                    reject:(EXPromiseRejectBlock)reject)
 {
   [[self amplitudeInstance] setGroup:groupType groupName:groupNames];
   resolve(nil);
 }
 
-UM_EXPORT_METHOD_AS(setTrackingOptionsAsync,
+EX_EXPORT_METHOD_AS(setTrackingOptionsAsync,
                     setTrackingOptionsAsync:(NSDictionary *)options
-                    resolve:(UMPromiseResolveBlock)resolve
-                    reject:(UMPromiseRejectBlock)reject)
+                    resolve:(EXPromiseResolveBlock)resolve
+                    reject:(EXPromiseRejectBlock)reject)
 {
   AMPTrackingOptions *trackingOptions = [AMPTrackingOptions options];
   

--- a/packages/expo-analytics-amplitude/package.json
+++ b/packages/expo-analytics-amplitude/package.json
@@ -33,8 +33,8 @@
     "preset": "expo-module-scripts"
   },
   "homepage": "https://docs.expo.io/versions/latest/sdk/amplitude/",
-  "unimodulePeerDependencies": {
-    "@unimodules/core": "*"
+  "dependencies": {
+    "expo-modules-core": "~0.1.1"
   },
   "devDependencies": {
     "expo-module-scripts": "^2.0.0"

--- a/packages/expo-analytics-segment/CHANGELOG.md
+++ b/packages/expo-analytics-segment/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- Migrated from `@unimodules/core` to `expo-modules-core`.
+
 ## 10.2.0 — 2021-06-16
 
 ### 🐛 Bug fixes

--- a/packages/expo-analytics-segment/CHANGELOG.md
+++ b/packages/expo-analytics-segment/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### 💡 Others
 
-- Migrated from `@unimodules/core` to `expo-modules-core`.
+- Migrated from `@unimodules/core` to `expo-modules-core`. ([#13757](https://github.com/expo/expo/pull/13757) by [@tsapeta](https://github.com/tsapeta))
 
 ## 10.2.0 — 2021-06-16
 

--- a/packages/expo-analytics-segment/ios/EXSegment.podspec
+++ b/packages/expo-analytics-segment/ios/EXSegment.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
   s.platform       = :ios, '11.0'
   s.source         = { git: 'https://github.com/expo/expo.git' }
 
-  s.dependency 'UMCore'
+  s.dependency 'ExpoModulesCore'
   s.dependency 'Analytics', segment_analytics_version
 
   if !$ExpoUseSources&.include?(package['name']) && ENV['EXPO_USE_SOURCE'].to_i == 0 && File.exist?("#{s.name}.xcframework") && Gem::Version.new(Pod::VERSION) >= Gem::Version.new('1.10.0')

--- a/packages/expo-analytics-segment/ios/EXSegment/EXSegment.h
+++ b/packages/expo-analytics-segment/ios/EXSegment/EXSegment.h
@@ -1,9 +1,9 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
-#import <UMCore/UMExportedModule.h>
+#import <ExpoModulesCore/EXExportedModule.h>
 
-@interface EXSegment : UMExportedModule
+@interface EXSegment : EXExportedModule
 
-- (void)setEnabled:(BOOL)enabled withResolver:(UMPromiseResolveBlock)resolve rejecter:(UMPromiseRejectBlock)reject;
+- (void)setEnabled:(BOOL)enabled withResolver:(EXPromiseResolveBlock)resolve rejecter:(EXPromiseRejectBlock)reject;
 
 @end

--- a/packages/expo-analytics-segment/ios/EXSegment/EXSegment.m
+++ b/packages/expo-analytics-segment/ios/EXSegment/EXSegment.m
@@ -13,12 +13,12 @@ static NSString *const EXSegmentEnabledKey = @"EXSegmentEnabledKey";
 
 @implementation EXSegment
 
-UM_EXPORT_MODULE(ExponentSegment)
+EX_EXPORT_MODULE(ExponentSegment)
 
-UM_EXPORT_METHOD_AS(initialize,
+EX_EXPORT_METHOD_AS(initialize,
                     initialize:(NSString *)writeKey
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   SEGAnalyticsConfiguration *configuration = [SEGAnalyticsConfiguration configurationWithWriteKey:writeKey];
   NSNumber *enabledSetting = [[NSUserDefaults standardUserDefaults] objectForKey:EXSegmentEnabledKey];
@@ -29,10 +29,10 @@ UM_EXPORT_METHOD_AS(initialize,
   resolve(nil);
 }
 
-UM_EXPORT_METHOD_AS(identify,
+EX_EXPORT_METHOD_AS(identify,
                     identify:(NSString *)userId
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   if (_instance) {
     [_instance identify:userId];
@@ -41,12 +41,12 @@ UM_EXPORT_METHOD_AS(identify,
 }
 
 
- UM_EXPORT_METHOD_AS(identifyWithTraits,
+ EX_EXPORT_METHOD_AS(identifyWithTraits,
                      identifyWithTraits:(NSString *)userId
                      withTraits:(NSDictionary *)traits
                      withOptions:(nullable NSDictionary *)options
-                     resolver:(UMPromiseResolveBlock)resolve
-                     rejecter:(UMPromiseRejectBlock)reject)
+                     resolver:(EXPromiseResolveBlock)resolve
+                     rejecter:(EXPromiseRejectBlock)reject)
 {
   if (_instance) {
     [_instance identify:userId traits:traits options:options];
@@ -54,10 +54,10 @@ UM_EXPORT_METHOD_AS(identify,
   resolve(nil);
 }
 
-UM_EXPORT_METHOD_AS(track,
+EX_EXPORT_METHOD_AS(track,
                     track:(NSString *)event
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   if (_instance) {
     [_instance track:event];
@@ -65,12 +65,12 @@ UM_EXPORT_METHOD_AS(track,
   resolve(nil);
 }
 
-UM_EXPORT_METHOD_AS(trackWithProperties,
+EX_EXPORT_METHOD_AS(trackWithProperties,
                     trackWithProperties:(NSString *)event 
                     withProperties:(NSDictionary *)properties
                     withOptions:(nullable NSDictionary *)options
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   if (_instance) {
     [_instance track:event properties:properties options:options];
@@ -78,10 +78,10 @@ UM_EXPORT_METHOD_AS(trackWithProperties,
   resolve(nil);
 }
 
-UM_EXPORT_METHOD_AS(group,
+EX_EXPORT_METHOD_AS(group,
                     group:(NSString *)groupId
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   if (_instance) {
     [_instance group:groupId];
@@ -89,12 +89,12 @@ UM_EXPORT_METHOD_AS(group,
   resolve(nil);
 }
 
-UM_EXPORT_METHOD_AS(groupWithTraits,
+EX_EXPORT_METHOD_AS(groupWithTraits,
                     groupWithTraits:(NSString *)groupId
                     withTraits:(NSDictionary *)traits
                     withOptions:(nullable NSDictionary *)options
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   if (_instance) {
     [_instance group:groupId traits:traits options:options];
@@ -102,25 +102,25 @@ UM_EXPORT_METHOD_AS(groupWithTraits,
   resolve(nil);
 }
 
-UM_EXPORT_METHOD_AS(alias,
+EX_EXPORT_METHOD_AS(alias,
                     alias:(NSString *)newId
                     withOptions:(nullable NSDictionary *)options
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   SEGAnalytics *analytics = _instance;
   if (analytics) {
     [analytics alias:newId options:options];
-    resolve(UMNullIfNil(nil));
+    resolve(EXNullIfNil(nil));
   } else {
     reject(@"E_NO_SEG", @"Segment instance has not been initialized yet, have you tried calling Segment.initialize prior to calling Segment.alias?", nil);
   }
 }
 
-UM_EXPORT_METHOD_AS(screen,
+EX_EXPORT_METHOD_AS(screen,
                     screen:(NSString *)screenName
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   if (_instance) {
     [_instance screen:screenName];
@@ -128,12 +128,12 @@ UM_EXPORT_METHOD_AS(screen,
   resolve(nil);
 }
 
-UM_EXPORT_METHOD_AS(screenWithProperties,
+EX_EXPORT_METHOD_AS(screenWithProperties,
                     screenWithProperties:(NSString *)screenName
                     withProperties:(NSDictionary *)properties
                     withOptions:(NSDictionary *)options
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   if (_instance) {
     [_instance screen:screenName properties:properties options:options];
@@ -141,9 +141,9 @@ UM_EXPORT_METHOD_AS(screenWithProperties,
   resolve(nil);
 }
 
-UM_EXPORT_METHOD_AS(reset,
-                    resetWithResolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(reset,
+                    resetWithResolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   if (_instance) {
     [_instance reset];
@@ -151,9 +151,9 @@ UM_EXPORT_METHOD_AS(reset,
   resolve(nil);
 }
 
-UM_EXPORT_METHOD_AS(flush,
-                    flushWithResolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(flush,
+                    flushWithResolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   if (_instance) {
     [_instance flush];
@@ -161,19 +161,19 @@ UM_EXPORT_METHOD_AS(flush,
   resolve(nil);
 }
 
-UM_EXPORT_METHOD_AS(getEnabledAsync,
-                    getEnabledWithResolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(getEnabledAsync,
+                    getEnabledWithResolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   NSNumber *optOutSetting = [[NSUserDefaults standardUserDefaults] objectForKey:EXSegmentEnabledKey];
   // default is enabled: true
   resolve(optOutSetting ?: @(YES));
 }
 
-UM_EXPORT_METHOD_AS(setEnabledAsync,
+EX_EXPORT_METHOD_AS(setEnabledAsync,
                     setEnabled:(BOOL)enabled
-                    withResolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    withResolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   [[NSUserDefaults standardUserDefaults] setBool:enabled forKey:EXSegmentEnabledKey];
   if (_instance) {

--- a/packages/expo-apple-authentication/CHANGELOG.md
+++ b/packages/expo-apple-authentication/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Extend the `AppleAuthenticationButton` component type by the `View` component type. ([#13567](https://github.com/expo/expo/pull/13567) by [@Simek](https://github.com/Simek))
 - Exclude `backgroundColor` and `borderRadius` properties from the `AppleAuthenticationButton`'s style prop. These two are invalid for `AppleAuthenticationButton`, but TypeScript allowed the usage of them; instead use `buttonStyle` and `cornerRadius` props repsectively. ([#13567](https://github.com/expo/expo/pull/13567) by [@Simek](https://github.com/Simek))
+- Migrated from `@unimodules/core` to `expo-modules-core`.
 
 ## 3.2.0 — 2021-06-16
 

--- a/packages/expo-apple-authentication/CHANGELOG.md
+++ b/packages/expo-apple-authentication/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 - Extend the `AppleAuthenticationButton` component type by the `View` component type. ([#13567](https://github.com/expo/expo/pull/13567) by [@Simek](https://github.com/Simek))
 - Exclude `backgroundColor` and `borderRadius` properties from the `AppleAuthenticationButton`'s style prop. These two are invalid for `AppleAuthenticationButton`, but TypeScript allowed the usage of them; instead use `buttonStyle` and `cornerRadius` props repsectively. ([#13567](https://github.com/expo/expo/pull/13567) by [@Simek](https://github.com/Simek))
-- Migrated from `@unimodules/core` to `expo-modules-core`.
+- Migrated from `@unimodules/core` to `expo-modules-core`. ([#13757](https://github.com/expo/expo/pull/13757) by [@tsapeta](https://github.com/tsapeta))
 
 ## 3.2.0 — 2021-06-16
 

--- a/packages/expo-apple-authentication/ios/EXAppleAuthentication.podspec
+++ b/packages/expo-apple-authentication/ios/EXAppleAuthentication.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.platform       = :ios, '11.0'
   s.source         = { git: 'https://github.com/expo/expo.git' }
 
-  s.dependency 'UMCore'
+  s.dependency 'ExpoModulesCore'
 
   if !$ExpoUseSources&.include?(package['name']) && ENV['EXPO_USE_SOURCE'].to_i == 0 && File.exist?("#{s.name}.xcframework") && Gem::Version.new(Pod::VERSION) >= Gem::Version.new('1.10.0')
     s.source_files = "#{s.name}/**/*.h"

--- a/packages/expo-apple-authentication/ios/EXAppleAuthentication/EXAppleAuthentication.h
+++ b/packages/expo-apple-authentication/ios/EXAppleAuthentication/EXAppleAuthentication.h
@@ -1,12 +1,12 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
-#import <UMCore/UMExportedModule.h>
-#import <UMCore/UMModuleRegistryConsumer.h>
-#import <UMCore/UMEventEmitter.h>
-#import <UMCore/UMEventEmitterService.h>
+#import <ExpoModulesCore/EXExportedModule.h>
+#import <ExpoModulesCore/EXModuleRegistryConsumer.h>
+#import <ExpoModulesCore/EXEventEmitter.h>
+#import <ExpoModulesCore/EXEventEmitterService.h>
 
 @import AuthenticationServices;
 
-@interface EXAppleAuthentication : UMExportedModule <UMModuleRegistryConsumer, UMEventEmitter>
+@interface EXAppleAuthentication : EXExportedModule <EXModuleRegistryConsumer, EXEventEmitter>
 
 @end

--- a/packages/expo-apple-authentication/ios/EXAppleAuthentication/EXAppleAuthentication.m
+++ b/packages/expo-apple-authentication/ios/EXAppleAuthentication/EXAppleAuthentication.m
@@ -4,22 +4,22 @@
 #import <EXAppleAuthentication/EXAppleAuthenticationRequest.h>
 #import <EXAppleAuthentication/EXAppleAuthenticationMappings.h>
 
-#import <UMCore/UMUtilities.h>
-#import <UMCore/UMErrorCodes.h>
+#import <ExpoModulesCore/EXUtilities.h>
+#import <ExpoModulesCore/EXErrorCodes.h>
 
 static NSString *const EXAppleIDCredentialRevokedEvent = @"Expo.appleIdCredentialRevoked";
 
 @interface EXAppleAuthentication ()
 
-@property (nonatomic, weak) UMModuleRegistry *moduleRegistry;
+@property (nonatomic, weak) EXModuleRegistry *moduleRegistry;
 
 @end
 
 @implementation EXAppleAuthentication
 
-UM_EXPORT_MODULE(ExpoAppleAuthentication);
+EX_EXPORT_MODULE(ExpoAppleAuthentication);
 
-- (void)setModuleRegistry:(UMModuleRegistry *)moduleRegistry
+- (void)setModuleRegistry:(EXModuleRegistry *)moduleRegistry
 {
   _moduleRegistry = moduleRegistry;
 }
@@ -50,13 +50,13 @@ UM_EXPORT_MODULE(ExpoAppleAuthentication);
 
 - (void)didRevokeCredential:(NSNotification *)notification
 {
-  id<UMEventEmitterService> eventEmitter = [_moduleRegistry getModuleImplementingProtocol:@protocol(UMEventEmitterService)];
+  id<EXEventEmitterService> eventEmitter = [_moduleRegistry getModuleImplementingProtocol:@protocol(EXEventEmitterService)];
   [eventEmitter sendEventWithName:EXAppleIDCredentialRevokedEvent body:@{}];
 }
 
-UM_EXPORT_METHOD_AS(isAvailableAsync,
-                    isAvailableAsync:(UMPromiseResolveBlock)resolve
-                            rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(isAvailableAsync,
+                    isAvailableAsync:(EXPromiseResolveBlock)resolve
+                            rejecter:(EXPromiseRejectBlock)reject)
 {
   if (@available(iOS 13.0, *)) {
     resolve(@(YES));
@@ -65,10 +65,10 @@ UM_EXPORT_METHOD_AS(isAvailableAsync,
   }
 }
 
-UM_EXPORT_METHOD_AS(requestAsync,
+EX_EXPORT_METHOD_AS(requestAsync,
                     requestAsync:(NSDictionary *)options
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   if (@available(iOS 13.0, *)) {
     [self requestWithOptions:options
@@ -79,10 +79,10 @@ UM_EXPORT_METHOD_AS(requestAsync,
   }
 }
 
-UM_EXPORT_METHOD_AS(getCredentialStateAsync,
+EX_EXPORT_METHOD_AS(getCredentialStateAsync,
                     getCredentialStateAsync:(NSString *)userID
-                                   resolver:(UMPromiseResolveBlock)resolve
-                                   rejecter:(UMPromiseRejectBlock)reject)
+                                   resolver:(EXPromiseResolveBlock)resolve
+                                   rejecter:(EXPromiseRejectBlock)reject)
 {
   if (@available(iOS 13.0, *)) {
     ASAuthorizationAppleIDProvider *appleIDProvider = [[ASAuthorizationAppleIDProvider alloc] init];
@@ -102,8 +102,8 @@ UM_EXPORT_METHOD_AS(getCredentialStateAsync,
 #pragma mark - helpers
 
 - (void)requestWithOptions:(NSDictionary *)options
-                  resolver:(UMPromiseResolveBlock)resolve
-                  rejecter:(UMPromiseRejectBlock)reject API_AVAILABLE(ios(13.0))
+                  resolver:(EXPromiseResolveBlock)resolve
+                  rejecter:(EXPromiseRejectBlock)reject API_AVAILABLE(ios(13.0))
 {
   ASAuthorizationProviderAuthorizationOperation operation = [EXAppleAuthenticationMappings importOperation:options[@"requestedOperation"]];
   __block EXAppleAuthenticationRequest *request = [EXAppleAuthenticationRequest performOperation:operation
@@ -112,7 +112,7 @@ UM_EXPORT_METHOD_AS(getCredentialStateAsync,
     if (error) {
       if (error.code == 1001) {
         // User canceled authentication attempt.
-        reject(UMErrorCodeCanceled, @"The Apple authentication request has been canceled by the user.", nil);
+        reject(EXErrorCodeCanceled, @"The Apple authentication request has been canceled by the user.", nil);
       } else {
         reject(@"ERR_APPLE_AUTHENTICATION_REQUEST_FAILED", error.localizedDescription, nil);
       }

--- a/packages/expo-apple-authentication/ios/EXAppleAuthentication/EXAppleAuthenticationButton.h
+++ b/packages/expo-apple-authentication/ios/EXAppleAuthentication/EXAppleAuthenticationButton.h
@@ -1,12 +1,12 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
-#import <UMCore/UMUtilities.h>
+#import <ExpoModulesCore/EXUtilities.h>
 
 @import AuthenticationServices;
 
 API_AVAILABLE(ios(13.0))
 @interface EXAppleAuthenticationButton : ASAuthorizationAppleIDButton
 
-@property (nonatomic, copy) UMDirectEventBlock onButtonPress;
+@property (nonatomic, copy) EXDirectEventBlock onButtonPress;
 
 @end

--- a/packages/expo-apple-authentication/ios/EXAppleAuthentication/EXAppleAuthenticationButtonViewManagers.m
+++ b/packages/expo-apple-authentication/ios/EXAppleAuthentication/EXAppleAuthenticationButtonViewManagers.m
@@ -1,6 +1,6 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
-#import <UMCore/UMViewManager.h>
+#import <ExpoModulesCore/EXViewManager.h>
 #import <EXAppleAuthentication/EXAppleAuthenticationButton.h>
 
 @import AuthenticationServices;
@@ -9,11 +9,11 @@
 // ASAuthorizationAppleIDButton#style and ASAuthorizationAppleIDButton#type can only be specified at creation time
 
 #define EX_REGISTER_APPLE_AUTHENTICATION_VIEW_MANAGER(type, style, module_name, ios_version) \
-@interface EXAppleAuthenticationButton ## type ## style ## ViewManager : UMViewManager @end \
+@interface EXAppleAuthenticationButton ## type ## style ## ViewManager : EXViewManager @end \
 \
 @implementation EXAppleAuthenticationButton ## type ## style ## ViewManager \
 \
-  UM_REGISTER_MODULE(); \
+  EX_REGISTER_MODULE(); \
 \
   + (const NSString *)exportedModuleName { return @#module_name; } \
 \
@@ -23,17 +23,17 @@
 \
   - (NSArray<NSString *> *)supportedEvents { return @[@"onButtonPress"]; } \
 \
-  UM_VIEW_PROPERTY(cornerRadius, NSNumber *, EXAppleAuthenticationButton) API_AVAILABLE(ios(ios_version)) { view.cornerRadius = [value floatValue]; } \
+  EX_VIEW_PROPERTY(cornerRadius, NSNumber *, EXAppleAuthenticationButton) API_AVAILABLE(ios(ios_version)) { view.cornerRadius = [value floatValue]; } \
 \
 @end
 
 // below commented code serves as template for above macro
 
-//@interface EXAppleAuthenticationButtonSignInWhiteViewManager : UMViewManager @end
+//@interface EXAppleAuthenticationButtonSignInWhiteViewManager : EXViewManager @end
 //
 //@implementation EXAppleAuthenticationButtonSignInWhiteViewManager
 //
-//UM_REGISTER_MODULE();
+//EX_REGISTER_MODULE();
 //
 //+ (const NSString *)exportedModuleName { return @"ExpoAppleAuthenticationButtonSignInWhite"; }
 //
@@ -43,7 +43,7 @@
 //
 //- (NSArray<NSString *> *)supportedEvents { return @[@"onButtonPress"]; }
 //
-//UM_VIEW_PROPERTY(cornerRadius, NSNumber *, EXAppleAuthenticationButton) API_AVAILABLE(ios(13.0)) { view.cornerRadius = [value floatValue]; }
+//EX_VIEW_PROPERTY(cornerRadius, NSNumber *, EXAppleAuthenticationButton) API_AVAILABLE(ios(13.0)) { view.cornerRadius = [value floatValue]; }
 //
 //@end
 

--- a/packages/expo-apple-authentication/ios/EXAppleAuthentication/EXAppleAuthenticationMappings.m
+++ b/packages/expo-apple-authentication/ios/EXAppleAuthentication/EXAppleAuthenticationMappings.m
@@ -1,7 +1,7 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
 #import <EXAppleAuthentication/EXAppleAuthenticationMappings.h>
-#import <UMCore/UMLogManager.h>
+#import <ExpoModulesCore/EXLogManager.h>
 
 @implementation EXAppleAuthenticationMappings
 
@@ -77,12 +77,12 @@
 + (NSDictionary *)exportFullName:(NSPersonNameComponents *)nameComponents
 {
   return @{
-           @"namePrefix": UMNullIfNil(nameComponents.namePrefix),
-           @"givenName": UMNullIfNil(nameComponents.givenName),
-           @"middleName": UMNullIfNil(nameComponents.middleName),
-           @"familyName": UMNullIfNil(nameComponents.familyName),
-           @"nameSuffix": UMNullIfNil(nameComponents.nameSuffix),
-           @"nickname": UMNullIfNil(nameComponents.nickname)
+           @"namePrefix": EXNullIfNil(nameComponents.namePrefix),
+           @"givenName": EXNullIfNil(nameComponents.givenName),
+           @"middleName": EXNullIfNil(nameComponents.middleName),
+           @"familyName": EXNullIfNil(nameComponents.familyName),
+           @"nameSuffix": EXNullIfNil(nameComponents.nameSuffix),
+           @"nickname": EXNullIfNil(nameComponents.nickname)
            };
 }
 

--- a/packages/expo-apple-authentication/ios/EXAppleAuthentication/EXAppleAuthenticationRequest.m
+++ b/packages/expo-apple-authentication/ios/EXAppleAuthentication/EXAppleAuthenticationRequest.m
@@ -3,7 +3,7 @@
 #import <EXAppleAuthentication/EXAppleAuthenticationRequest.h>
 #import <EXAppleAuthentication/EXAppleAuthenticationMappings.h>
 
-#import <UMCore/UMDefines.h>
+#import <ExpoModulesCore/EXDefines.h>
 
 @interface EXAppleAuthenticationRequest ()
 
@@ -82,13 +82,13 @@
   }
 
   NSDictionary *response = @{
-                         @"fullName": UMNullIfNil(fullName),
-                         @"email": UMNullIfNil(credential.email),
+                         @"fullName": EXNullIfNil(fullName),
+                         @"email": EXNullIfNil(credential.email),
                          @"user": credential.user,
                          @"realUserStatus": [EXAppleAuthenticationMappings exportRealUserStatus:credential.realUserStatus],
-                         @"state": UMNullIfNil(credential.state),
-                         @"authorizationCode": UMNullIfNil(authorizationCode),
-                         @"identityToken": UMNullIfNil(identityToken),
+                         @"state": EXNullIfNil(credential.state),
+                         @"authorizationCode": EXNullIfNil(authorizationCode),
+                         @"identityToken": EXNullIfNil(identityToken),
                          };
 
   if (_callback) {

--- a/packages/expo-apple-authentication/package.json
+++ b/packages/expo-apple-authentication/package.json
@@ -32,7 +32,8 @@
   "license": "MIT",
   "homepage": "https://docs.expo.io/versions/latest/sdk/apple-authentication/",
   "dependencies": {
-    "@expo/config-plugins": "^3.0.0"
+    "@expo/config-plugins": "^3.0.0",
+    "expo-modules-core": "~0.1.1"
   },
   "devDependencies": {
     "expo-module-scripts": "^2.0.0"

--- a/packages/expo-background-fetch/CHANGELOG.md
+++ b/packages/expo-background-fetch/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 ### 💡 Others
 
+- Migrated from `@unimodules/core` to `expo-modules-core`.
+
 ## 9.2.0 — 2021-06-16
 
 ### 🐛 Bug fixes

--- a/packages/expo-background-fetch/CHANGELOG.md
+++ b/packages/expo-background-fetch/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### 💡 Others
 
-- Migrated from `@unimodules/core` to `expo-modules-core`.
+- Migrated from `@unimodules/core` to `expo-modules-core`. ([#13757](https://github.com/expo/expo/pull/13757) by [@tsapeta](https://github.com/tsapeta))
 
 ## 9.2.0 — 2021-06-16
 

--- a/packages/expo-background-fetch/ios/EXBackgroundFetch.podspec
+++ b/packages/expo-background-fetch/ios/EXBackgroundFetch.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.platform       = :ios, '11.0'
   s.source         = { git: 'https://github.com/expo/expo.git' }
 
-  s.dependency 'UMCore'
+  s.dependency 'ExpoModulesCore'
   s.dependency 'UMTaskManagerInterface'
 
   if !$ExpoUseSources&.include?(package['name']) && ENV['EXPO_USE_SOURCE'].to_i == 0 && File.exist?("#{s.name}.xcframework") && Gem::Version.new(Pod::VERSION) >= Gem::Version.new('1.10.0')

--- a/packages/expo-background-fetch/ios/EXBackgroundFetch/EXBackgroundFetch.h
+++ b/packages/expo-background-fetch/ios/EXBackgroundFetch/EXBackgroundFetch.h
@@ -1,7 +1,7 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
-#import <UMCore/UMExportedModule.h>
-#import <UMCore/UMModuleRegistryConsumer.h>
+#import <ExpoModulesCore/EXExportedModule.h>
+#import <ExpoModulesCore/EXModuleRegistryConsumer.h>
 
 // Background fetch result
 typedef NS_ENUM(NSUInteger, EXBackgroundFetchResult) {
@@ -17,6 +17,6 @@ typedef NS_ENUM(NSUInteger, EXBackgroundFetchStatus) {
   EXBackgroundFetchStatusAvailable = 3,
 };
 
-@interface EXBackgroundFetch : UMExportedModule <UMModuleRegistryConsumer>
+@interface EXBackgroundFetch : EXExportedModule <EXModuleRegistryConsumer>
 
 @end

--- a/packages/expo-background-fetch/ios/EXBackgroundFetch/EXBackgroundFetch.m
+++ b/packages/expo-background-fetch/ios/EXBackgroundFetch/EXBackgroundFetch.m
@@ -1,6 +1,6 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
-#import <UMCore/UMDefines.h>
+#import <ExpoModulesCore/EXDefines.h>
 #import <EXBackgroundFetch/EXBackgroundFetch.h>
 #import <EXBackgroundFetch/EXBackgroundFetchTaskConsumer.h>
 #import <UMTaskManagerInterface/UMTaskManagerInterface.h>
@@ -13,26 +13,26 @@
 
 @implementation EXBackgroundFetch
 
-UM_EXPORT_MODULE(ExpoBackgroundFetch);
+EX_EXPORT_MODULE(ExpoBackgroundFetch);
 
-- (void)setModuleRegistry:(UMModuleRegistry *)moduleRegistry
+- (void)setModuleRegistry:(EXModuleRegistry *)moduleRegistry
 {
   _taskManager = [moduleRegistry getModuleImplementingProtocol:@protocol(UMTaskManagerInterface)];
 }
 
-UM_EXPORT_METHOD_AS(getStatusAsync,
-                    getStatus:(UMPromiseResolveBlock)resolve
-                    reject:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(getStatusAsync,
+                    getStatus:(EXPromiseResolveBlock)resolve
+                    reject:(EXPromiseRejectBlock)reject)
 {
   dispatch_async(dispatch_get_main_queue(), ^{
     resolve(@([self _getStatus]));
   });
 }
 
-UM_EXPORT_METHOD_AS(setMinimumIntervalAsync,
+EX_EXPORT_METHOD_AS(setMinimumIntervalAsync,
                     setMinimumInterval:(nonnull NSNumber *)minimumInterval
-                    resolve:(UMPromiseResolveBlock)resolve
-                    reject:(UMPromiseRejectBlock)reject)
+                    resolve:(EXPromiseResolveBlock)resolve
+                    reject:(EXPromiseRejectBlock)reject)
 {
   dispatch_async(dispatch_get_main_queue(), ^{
     NSTimeInterval timeInterval = [minimumInterval doubleValue];
@@ -41,11 +41,11 @@ UM_EXPORT_METHOD_AS(setMinimumIntervalAsync,
   });
 }
 
-UM_EXPORT_METHOD_AS(registerTaskAsync,
+EX_EXPORT_METHOD_AS(registerTaskAsync,
                     registerTaskWithName:(nonnull NSString *)taskName
                     options:(nullable NSDictionary *)options
-                    resolve:(UMPromiseResolveBlock)resolve
-                    reject:(UMPromiseRejectBlock)reject)
+                    resolve:(EXPromiseResolveBlock)resolve
+                    reject:(EXPromiseRejectBlock)reject)
 {
   if (![_taskManager hasBackgroundModeEnabled:@"fetch"]) {
     return reject(
@@ -66,10 +66,10 @@ UM_EXPORT_METHOD_AS(registerTaskAsync,
   resolve(nil);
 }
 
-UM_EXPORT_METHOD_AS(unregisterTaskAsync,
+EX_EXPORT_METHOD_AS(unregisterTaskAsync,
                     unregisterTaskWithName:(nonnull NSString *)taskName
-                    resolve:(UMPromiseResolveBlock)resolve
-                    reject:(UMPromiseRejectBlock)reject)
+                    resolve:(EXPromiseResolveBlock)resolve
+                    reject:(EXPromiseRejectBlock)reject)
 {
   @try {
     [_taskManager unregisterTaskWithName:taskName consumerClass:[EXBackgroundFetchTaskConsumer class]];

--- a/packages/expo-background-fetch/package.json
+++ b/packages/expo-background-fetch/package.json
@@ -32,12 +32,9 @@
   "author": "650 Industries, Inc.",
   "license": "MIT",
   "homepage": "https://docs.expo.io/versions/latest/sdk/background-fetch/",
-  "unimodulePeerDependencies": {
-    "@unimodules/core": "*",
-    "unimodules-task-manager-interface": "*"
-  },
   "dependencies": {
     "@expo/config-plugins": "^3.0.0",
+    "expo-modules-core": "~0.1.1",
     "expo-task-manager": "~9.2.0"
   },
   "devDependencies": {

--- a/packages/expo-barcode-scanner/CHANGELOG.md
+++ b/packages/expo-barcode-scanner/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Migrated from `@unimodules/core` to `expo-modules-core`.
+
 ## 10.2.0 — 2021-06-16
 
 ### 🐛 Bug fixes

--- a/packages/expo-barcode-scanner/CHANGELOG.md
+++ b/packages/expo-barcode-scanner/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Migrated from `@unimodules/core` to `expo-modules-core`.
+- Migrated from `@unimodules/core` to `expo-modules-core`. ([#13757](https://github.com/expo/expo/pull/13757) by [@tsapeta](https://github.com/tsapeta))
 
 ## 10.2.0 — 2021-06-16
 

--- a/packages/expo-barcode-scanner/ios/EXBarCodeScanner.podspec
+++ b/packages/expo-barcode-scanner/ios/EXBarCodeScanner.podspec
@@ -13,7 +13,6 @@ Pod::Spec.new do |s|
   s.platform       = :ios, '11.0'
   s.source         = { git: 'https://github.com/expo/expo.git' }
 
-  s.dependency 'UMCore'
   s.dependency 'ExpoModulesCore'
   s.dependency 'ZXingObjC/PDF417'
   s.dependency 'ZXingObjC/OneD'

--- a/packages/expo-barcode-scanner/ios/EXBarCodeScanner/EXBarCodeCameraRequester.m
+++ b/packages/expo-barcode-scanner/ios/EXBarCodeScanner/EXBarCodeCameraRequester.m
@@ -1,7 +1,7 @@
 // Copyright 2016-present 650 Industries. All rights reserved.
 
 #import <EXBarCodeScanner/EXBarCodeCameraRequester.h>
-#import <UMCore/UMDefines.h>
+#import <ExpoModulesCore/EXDefines.h>
 #import <ExpoModulesCore/EXPermissionsInterface.h>
 
 #import <AVFoundation/AVFoundation.h>
@@ -19,7 +19,7 @@
   EXPermissionStatus status;
   NSString *cameraUsageDescription = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSCameraUsageDescription"];
   if (!cameraUsageDescription) {
-    UMFatal(UMErrorWithMessage(@"This app is missing 'NSCameraUsageDescription', so video services will fail. Add this entry to your bundle's Info.plist."));
+    EXFatal(EXErrorWithMessage(@"This app is missing 'NSCameraUsageDescription', so video services will fail. Add this entry to your bundle's Info.plist."));
     systemStatus = AVAuthorizationStatusDenied;
   } else {
     systemStatus = [AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo];
@@ -41,11 +41,11 @@
   };
 }
 
-- (void)requestPermissionsWithResolver:(UMPromiseResolveBlock)resolve rejecter:(UMPromiseRejectBlock)reject
+- (void)requestPermissionsWithResolver:(EXPromiseResolveBlock)resolve rejecter:(EXPromiseRejectBlock)reject
 {
-  UM_WEAKIFY(self)
+  EX_WEAKIFY(self)
   [AVCaptureDevice requestAccessForMediaType:AVMediaTypeVideo completionHandler:^(BOOL granted) {
-    UM_STRONGIFY(self)
+    EX_STRONGIFY(self)
     resolve([self getPermissions]);
   }];
 }

--- a/packages/expo-barcode-scanner/ios/EXBarCodeScanner/EXBarCodeScanner.m
+++ b/packages/expo-barcode-scanner/ios/EXBarCodeScanner/EXBarCodeScanner.m
@@ -2,7 +2,7 @@
 
 #import <EXBarCodeScanner/EXBarCodeScanner.h>
 #import <EXBarCodeScanner/EXBarCodeScannerUtils.h>
-#import <UMCore/UMDefines.h>
+#import <ExpoModulesCore/EXDefines.h>
 #import <ZXingObjC/ZXingObjCCore.h>
 #import <ZXingObjC/ZXingObjCPDF417.h>
 #import <ZXingObjC/ZXingObjCOneD.h>
@@ -63,9 +63,9 @@ NSString *const EX_BARCODE_TYPES_KEY = @"barCodeTypes";
         _settings = nextSettings;
         NSSet *zxingCoveredTypes = [NSSet setWithArray:[_zxingBarcodeReaders allKeys]];
         _zxingEnabled = [zxingCoveredTypes intersectsSet:newTypes];
-        UM_WEAKIFY(self);
+        EX_WEAKIFY(self);
         [self _runBlockIfQueueIsPresent:^{
-          UM_ENSURE_STRONGIFY(self);
+          EX_ENSURE_STRONGIFY(self);
           [self maybeStartBarCodeScanning];
         }];
       }
@@ -79,9 +79,9 @@ NSString *const EX_BARCODE_TYPES_KEY = @"barCodeTypes";
     return;
   }
   _barCodesScanning = newBarCodeScanning;
-  UM_WEAKIFY(self);
+  EX_WEAKIFY(self);
   [self _runBlockIfQueueIsPresent:^{
-    UM_ENSURE_STRONGIFY(self);
+    EX_ENSURE_STRONGIFY(self);
     if ([self isScanningBarCodes]) {
       if (self.metadataOutput) {
         [self _setConnectionsEnabled:true];

--- a/packages/expo-barcode-scanner/ios/EXBarCodeScanner/EXBarCodeScannerModule.h
+++ b/packages/expo-barcode-scanner/ios/EXBarCodeScanner/EXBarCodeScannerModule.h
@@ -1,14 +1,14 @@
 // Copyright 2016-present 650 Industries. All rights reserved.
 
 #import <AVFoundation/AVFoundation.h>
-#import <UMCore/UMExportedModule.h>
-#import <UMCore/UMModuleRegistryConsumer.h>
+#import <ExpoModulesCore/EXExportedModule.h>
+#import <ExpoModulesCore/EXModuleRegistryConsumer.h>
 
 typedef NS_ENUM(NSInteger, EXCameraType) {
   EXCameraTypeFront = AVCaptureDevicePositionFront,
   EXCameraTypeBack = AVCaptureDevicePositionBack,
 };
 
-@interface EXBarCodeScannerModule : UMExportedModule <UMModuleRegistryConsumer>
+@interface EXBarCodeScannerModule : EXExportedModule <EXModuleRegistryConsumer>
 
 @end

--- a/packages/expo-barcode-scanner/ios/EXBarCodeScanner/EXBarCodeScannerModule.m
+++ b/packages/expo-barcode-scanner/ios/EXBarCodeScanner/EXBarCodeScannerModule.m
@@ -9,7 +9,7 @@
 
 @interface EXBarCodeScannerModule ()
 
-@property (nonatomic, weak) UMModuleRegistry *moduleRegistry;
+@property (nonatomic, weak) EXModuleRegistry *moduleRegistry;
 @property (nonatomic, weak) id<EXImageLoaderInterface> imageLoader;
 @property (nonatomic, weak) id<EXPermissionsInterface> permissionsManager;
 
@@ -17,9 +17,9 @@
 
 @implementation EXBarCodeScannerModule
 
-UM_EXPORT_MODULE(ExpoBarCodeScannerModule);
+EX_EXPORT_MODULE(ExpoBarCodeScannerModule);
 
-- (void)setModuleRegistry:(UMModuleRegistry *)moduleRegistry
+- (void)setModuleRegistry:(EXModuleRegistry *)moduleRegistry
 {
   _moduleRegistry = moduleRegistry;
   _imageLoader = [moduleRegistry getModuleImplementingProtocol:@protocol(EXImageLoaderInterface)];
@@ -38,9 +38,9 @@ UM_EXPORT_MODULE(ExpoBarCodeScannerModule);
            };
 }
 
-UM_EXPORT_METHOD_AS(getPermissionsAsync,
-                    getPermissionsAsync:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(getPermissionsAsync,
+                    getPermissionsAsync:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   [EXPermissionsMethodsDelegate getPermissionWithPermissionsManager:_permissionsManager
                                                       withRequester:[EXBareCodeCameraRequester class]
@@ -48,9 +48,9 @@ UM_EXPORT_METHOD_AS(getPermissionsAsync,
                                                              reject:reject];
 }
 
-UM_EXPORT_METHOD_AS(requestPermissionsAsync,
-                    requestPermissionsAsync:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(requestPermissionsAsync,
+                    requestPermissionsAsync:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   [EXPermissionsMethodsDelegate askForPermissionWithPermissionsManager:_permissionsManager
                                                          withRequester:[EXBareCodeCameraRequester class]
@@ -58,11 +58,11 @@ UM_EXPORT_METHOD_AS(requestPermissionsAsync,
                                                                 reject:reject];
 }
 
-UM_EXPORT_METHOD_AS(scanFromURLAsync,
+EX_EXPORT_METHOD_AS(scanFromURLAsync,
                     scanFromURLAsync:(NSString *)url
                     barCodeTypes:(NSArray *)barCodeTypes
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   // We only support QR codes, so barCodeTypes is ignored
   NSURL *imageURL = [NSURL URLWithString:url];

--- a/packages/expo-barcode-scanner/ios/EXBarCodeScanner/EXBarCodeScannerProvider.h
+++ b/packages/expo-barcode-scanner/ios/EXBarCodeScanner/EXBarCodeScannerProvider.h
@@ -1,9 +1,9 @@
 // Copyright 2016-present 650 Industries. All rights reserved.
 
 #import <Foundation/Foundation.h>
-#import <UMCore/UMInternalModule.h>
+#import <ExpoModulesCore/EXInternalModule.h>
 #import <ExpoModulesCore/EXBarCodeScannerProviderInterface.h>
 
-@interface EXBarCodeScannerProvider : NSObject <UMInternalModule, EXBarCodeScannerProviderInterface>
+@interface EXBarCodeScannerProvider : NSObject <EXInternalModule, EXBarCodeScannerProviderInterface>
 
 @end

--- a/packages/expo-barcode-scanner/ios/EXBarCodeScanner/EXBarCodeScannerProvider.m
+++ b/packages/expo-barcode-scanner/ios/EXBarCodeScanner/EXBarCodeScannerProvider.m
@@ -5,7 +5,7 @@
 
 @implementation EXBarCodeScannerProvider
 
-UM_REGISTER_MODULE();
+EX_REGISTER_MODULE();
 
 + (const NSArray<Protocol *> *)exportedInterfaces
 {

--- a/packages/expo-barcode-scanner/ios/EXBarCodeScanner/EXBarCodeScannerView.h
+++ b/packages/expo-barcode-scanner/ios/EXBarCodeScanner/EXBarCodeScannerView.h
@@ -2,16 +2,16 @@
 
 #import <AVFoundation/AVFoundation.h>
 #import <UIKit/UIKit.h>
-#import <UMCore/UMModuleRegistry.h>
-#import <UMCore/UMAppLifecycleListener.h>
+#import <ExpoModulesCore/EXModuleRegistry.h>
+#import <ExpoModulesCore/EXAppLifecycleListener.h>
 #import <EXBarCodeScanner/EXBarCodeScannerView.h>
 
-@interface EXBarCodeScannerView : UIView <UMAppLifecycleListener>
+@interface EXBarCodeScannerView : UIView <EXAppLifecycleListener>
 
 @property (nonatomic, assign) NSInteger presetCamera;
 @property (nonatomic, strong) NSArray *barCodeTypes;
 
-- (instancetype)initWithModuleRegistry:(UMModuleRegistry *)moduleRegistry;
+- (instancetype)initWithModuleRegistry:(EXModuleRegistry *)moduleRegistry;
 - (void)onReady;
 - (void)onMountingError:(NSDictionary *)event;
 - (void)onBarCodeScanned:(NSDictionary *)event;

--- a/packages/expo-barcode-scanner/ios/EXBarCodeScanner/EXBarCodeScannerView.m
+++ b/packages/expo-barcode-scanner/ios/EXBarCodeScanner/EXBarCodeScannerView.m
@@ -5,8 +5,8 @@
 #import <EXBarCodeScanner/EXBarCodeScannerUtils.h>
 #import <EXBarCodeScanner/EXBarCodeCameraRequester.h>
 #import <ExpoModulesCore/EXPermissionsInterface.h>
-#import <UMCore/UMAppLifecycleService.h>
-#import <UMCore/UMUtilities.h>
+#import <ExpoModulesCore/EXAppLifecycleService.h>
+#import <ExpoModulesCore/EXUtilities.h>
 
 @interface EXBarCodeScannerView ()
 
@@ -18,28 +18,28 @@
 @property (nonatomic, strong) id runtimeErrorHandlingObserver;
 @property (nonatomic, strong) EXBarCodeScanner *barCodeScanner;
 
-@property (nonatomic, weak) UMModuleRegistry *moduleRegistry;
+@property (nonatomic, weak) EXModuleRegistry *moduleRegistry;
 @property (nonatomic, weak) id<EXPermissionsInterface> permissionsManager;
-@property (nonatomic, weak) id<UMAppLifecycleService> lifecycleManager;
+@property (nonatomic, weak) id<EXAppLifecycleService> lifecycleManager;
 
 @property (nonatomic, assign, getter=isSessionPaused) BOOL paused;
 
-@property (nonatomic, copy) UMDirectEventBlock onCameraReady;
-@property (nonatomic, copy) UMDirectEventBlock onMountError;
-@property (nonatomic, copy) UMDirectEventBlock onBarCodeScanned;
+@property (nonatomic, copy) EXDirectEventBlock onCameraReady;
+@property (nonatomic, copy) EXDirectEventBlock onMountError;
+@property (nonatomic, copy) EXDirectEventBlock onBarCodeScanned;
 
 @end
 
 @implementation EXBarCodeScannerView
 
-- (instancetype)initWithModuleRegistry:(UMModuleRegistry *)moduleRegistry
+- (instancetype)initWithModuleRegistry:(EXModuleRegistry *)moduleRegistry
 {
   if ((self = [super init])) {
     _presetCamera = AVCaptureDevicePositionBack;
     _moduleRegistry = moduleRegistry;
     _session = [AVCaptureSession new];
     _sessionQueue = dispatch_queue_create("barCodeScannerQueue", DISPATCH_QUEUE_SERIAL);
-    _lifecycleManager = [moduleRegistry getModuleImplementingProtocol:@protocol(UMAppLifecycleListener)];
+    _lifecycleManager = [moduleRegistry getModuleImplementingProtocol:@protocol(EXAppLifecycleListener)];
     _permissionsManager = [moduleRegistry getModuleImplementingProtocol:@protocol(EXPermissionsInterface)];
     _barCodeScanner = [self createBarCodeScanner];
     
@@ -94,9 +94,9 @@
     return;
   }
   _presetCamera = presetCamera;
-  UM_WEAKIFY(self);
+  EX_WEAKIFY(self);
   dispatch_async(_sessionQueue, ^{
-    UM_ENSURE_STRONGIFY(self);
+    EX_ENSURE_STRONGIFY(self);
     [self initializeSession];
   });
 }
@@ -133,9 +133,9 @@
 {
   if (![_session isRunning] && [self isSessionPaused]) {
     _paused = NO;
-    UM_WEAKIFY(self);
+    EX_WEAKIFY(self);
     dispatch_async(_sessionQueue, ^{
-      UM_ENSURE_STRONGIFY(self);
+      EX_ENSURE_STRONGIFY(self);
       [self.session startRunning];
     });
   }
@@ -145,9 +145,9 @@
 {
   if ([_session isRunning] && ![self isSessionPaused]) {
     _paused = YES;
-    UM_WEAKIFY(self);
+    EX_WEAKIFY(self);
     dispatch_async(_sessionQueue, ^{
-      UM_ENSURE_STRONGIFY(self);
+      EX_ENSURE_STRONGIFY(self);
       [self.session stopRunning];
     });
   }
@@ -163,10 +163,10 @@
 
 - (void)changePreviewOrientation:(UIInterfaceOrientation)orientation
 {
-  UM_WEAKIFY(self);
+  EX_WEAKIFY(self);
   AVCaptureVideoOrientation videoOrientation = [EXBarCodeScannerUtils videoOrientationForInterfaceOrientation:orientation];
-  [UMUtilities performSynchronouslyOnMainThread:^{
-    UM_ENSURE_STRONGIFY(self);
+  [EXUtilities performSynchronouslyOnMainThread:^{
+    EX_ENSURE_STRONGIFY(self);
     if (self.previewLayer.connection.isVideoOrientationSupported) {
       [self.previewLayer.connection setVideoOrientation:videoOrientation];
     }
@@ -191,14 +191,14 @@
   }
   
   __block UIInterfaceOrientation interfaceOrientation;
-  [UMUtilities performSynchronouslyOnMainThread:^{
+  [EXUtilities performSynchronouslyOnMainThread:^{
     interfaceOrientation = [[UIApplication sharedApplication] statusBarOrientation];
   }];
   AVCaptureVideoOrientation orientation = [EXBarCodeScannerUtils videoOrientationForInterfaceOrientation:interfaceOrientation];
   
-  UM_WEAKIFY(self);
+  EX_WEAKIFY(self);
   dispatch_async(_sessionQueue, ^{
-    UM_ENSURE_STRONGIFY(self);
+    EX_ENSURE_STRONGIFY(self);
     
     [self.session beginConfiguration];
     
@@ -244,9 +244,9 @@
     return;
   };
 
-  UM_WEAKIFY(self);
+  EX_WEAKIFY(self);
   dispatch_async(_sessionQueue, ^{
-    UM_ENSURE_STRONGIFY(self);
+    EX_ENSURE_STRONGIFY(self);
     
     if (self.presetCamera == AVCaptureDevicePositionUnspecified) {
       return;
@@ -257,9 +257,9 @@
                                                        object:self.session
                                                         queue:nil
                                                    usingBlock:^(NSNotification *note) {
-      UM_ENSURE_STRONGIFY(self);
+      EX_ENSURE_STRONGIFY(self);
       dispatch_async(self.sessionQueue, ^{
-        UM_ENSURE_STRONGIFY(self);
+        EX_ENSURE_STRONGIFY(self);
         // Manually restarting the session since it must have been stopped due to an error.
         [self.session startRunning];
         [self onReady];
@@ -279,9 +279,9 @@
 #if TARGET_IPHONE_SIMULATOR
   return;
 #endif
-  UM_WEAKIFY(self);
+  EX_WEAKIFY(self);
   dispatch_async(_sessionQueue, ^{
-    UM_ENSURE_STRONGIFY(self);
+    EX_ENSURE_STRONGIFY(self);
     
     [self.barCodeScanner stopBarCodeScanning];
     
@@ -305,9 +305,9 @@
   EXBarCodeScanner *barCodeScanner = [EXBarCodeScanner new];
   [barCodeScanner setSession:_session];
   [barCodeScanner setSessionQueue:_sessionQueue];
-  UM_WEAKIFY(self);
+  EX_WEAKIFY(self);
   [barCodeScanner setOnBarCodeScanned:^(NSDictionary *body) {
-    UM_ENSURE_STRONGIFY(self);
+    EX_ENSURE_STRONGIFY(self);
     [self onBarCodeScanned:body];
   }];
   [barCodeScanner setIsEnabled:true];

--- a/packages/expo-barcode-scanner/ios/EXBarCodeScanner/EXBarCodeScannerViewManager.h
+++ b/packages/expo-barcode-scanner/ios/EXBarCodeScanner/EXBarCodeScannerViewManager.h
@@ -1,9 +1,9 @@
 // Copyright 2016-present 650 Industries. All rights reserved.
 
 #import <AVFoundation/AVFoundation.h>
-#import <UMCore/UMViewManager.h>
-#import <UMCore/UMModuleRegistryConsumer.h>
+#import <ExpoModulesCore/EXViewManager.h>
+#import <ExpoModulesCore/EXModuleRegistryConsumer.h>
 
-@interface EXBarCodeScannerViewManager : UMViewManager <UMModuleRegistryConsumer>
+@interface EXBarCodeScannerViewManager : EXViewManager <EXModuleRegistryConsumer>
 
 @end

--- a/packages/expo-barcode-scanner/ios/EXBarCodeScanner/EXBarCodeScannerViewManager.m
+++ b/packages/expo-barcode-scanner/ios/EXBarCodeScanner/EXBarCodeScannerViewManager.m
@@ -5,13 +5,13 @@
 
 @interface EXBarCodeScannerViewManager ()
 
-@property (nonatomic, weak) UMModuleRegistry *moduleRegistry;
+@property (nonatomic, weak) EXModuleRegistry *moduleRegistry;
 
 @end
 
 @implementation EXBarCodeScannerViewManager
 
-UM_REGISTER_MODULE();
+EX_REGISTER_MODULE();
 
 + (const NSString *)exportedModuleName
 {
@@ -23,7 +23,7 @@ UM_REGISTER_MODULE();
   return @"ExpoBarCodeScannerView";
 }
 
-- (void)setModuleRegistry:(UMModuleRegistry *)moduleRegistry
+- (void)setModuleRegistry:(EXModuleRegistry *)moduleRegistry
 {
   _moduleRegistry = moduleRegistry;
 }
@@ -40,12 +40,12 @@ UM_REGISTER_MODULE();
            ];
 }
 
-UM_VIEW_PROPERTY(type, NSNumber *, EXBarCodeScannerView)
+EX_VIEW_PROPERTY(type, NSNumber *, EXBarCodeScannerView)
 {
   [view setPresetCamera:[value integerValue]];
 }
 
-UM_VIEW_PROPERTY(barCodeTypes, NSArray *, EXBarCodeScannerView)
+EX_VIEW_PROPERTY(barCodeTypes, NSArray *, EXBarCodeScannerView)
 {
   [view setBarCodeTypes:value];
 }

--- a/packages/expo-battery/CHANGELOG.md
+++ b/packages/expo-battery/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 - Rewrite BatteryModule from Java to Kotlin. ([#13504](https://github.com/expo/expo/pull/13504) by [@mstach60161](https://github.com/mstach60161))
 - Add unit tests. ([#13629](https://github.com/expo/expo/pull/13629) by [@mstach60161](https://github.com/mstach60161))
-- Migrated from `@unimodules/core` to `expo-modules-core`.
+- Migrated from `@unimodules/core` to `expo-modules-core`. ([#13757](https://github.com/expo/expo/pull/13757) by [@tsapeta](https://github.com/tsapeta))
 
 ## 5.0.0 — 2021-06-16
 

--- a/packages/expo-battery/CHANGELOG.md
+++ b/packages/expo-battery/CHANGELOG.md
@@ -11,14 +11,14 @@
 ### 💡 Others
 
 - Rewrite BatteryModule from Java to Kotlin. ([#13504](https://github.com/expo/expo/pull/13504) by [@mstach60161](https://github.com/mstach60161))
-([#13504](https://github.com/expo/expo/pull/13504) by [@mstach60161](https://github.com/mstach60161))
 - Add unit tests. ([#13629](https://github.com/expo/expo/pull/13629) by [@mstach60161](https://github.com/mstach60161))
+- Migrated from `@unimodules/core` to `expo-modules-core`.
 
 ## 5.0.0 — 2021-06-16
 
 ### 🛠 Breaking changes
 
-- Removed following types: `BatteryLevelUpdateListener `, `BatteryStateUpdateListener` and `PowerModeUpdateListener` as they were only wrapping one-argument events responses. Use event types explicitly instead: `BatteryLevelEvent `, `BatteryStateEvent` and `PowerModeEvent`. ([#12592](https://github.com/expo/expo/pull/12592) by [@Simek](https://github.com/simek))
+- Removed following types: `BatteryLevelUpdateListener`, `BatteryStateUpdateListener` and `PowerModeUpdateListener` as they were only wrapping one-argument events responses. Use event types explicitly instead: `BatteryLevelEvent`, `BatteryStateEvent` and `PowerModeEvent`. ([#12592](https://github.com/expo/expo/pull/12592) by [@Simek](https://github.com/simek))
 
 ### 🎉 New features
 

--- a/packages/expo-battery/ios/EXBattery.podspec
+++ b/packages/expo-battery/ios/EXBattery.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.platform       = :ios, '11.0'
   s.source         = { git: 'https://github.com/expo/expo.git' }
 
-  s.dependency 'UMCore'
+  s.dependency 'ExpoModulesCore'
 
   if !$ExpoUseSources&.include?(package['name']) && ENV['EXPO_USE_SOURCE'].to_i == 0 && File.exist?("#{s.name}.xcframework") && Gem::Version.new(Pod::VERSION) >= Gem::Version.new('1.10.0')
     s.source_files = "#{s.name}/**/*.h"

--- a/packages/expo-battery/ios/EXBattery/EXBattery.h
+++ b/packages/expo-battery/ios/EXBattery/EXBattery.h
@@ -1,10 +1,10 @@
 //  Copyright © 2018 650 Industries. All rights reserved.
 
-#import <UMCore/UMExportedModule.h>
-#import <UMCore/UMModuleRegistryConsumer.h>
+#import <ExpoModulesCore/EXExportedModule.h>
+#import <ExpoModulesCore/EXModuleRegistryConsumer.h>
 #import <Foundation/Foundation.h>
-#import <UMCore/UMEventEmitter.h>
-#import <UMCore/UMEventEmitterService.h>
+#import <ExpoModulesCore/EXEventEmitter.h>
+#import <ExpoModulesCore/EXEventEmitterService.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -17,7 +17,7 @@ typedef NS_ENUM(NSInteger, EXBatteryState) {
 };
 
 
-@interface EXBattery : UMExportedModule <UMModuleRegistryConsumer, UMEventEmitter>
+@interface EXBattery : EXExportedModule <EXModuleRegistryConsumer, EXEventEmitter>
 
 @end
 

--- a/packages/expo-battery/ios/EXBattery/EXBattery.m
+++ b/packages/expo-battery/ios/EXBattery/EXBattery.m
@@ -1,12 +1,12 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
 #import <EXBattery/EXBattery.h>
-#import <UMCore/UMUtilities.h>
+#import <ExpoModulesCore/EXUtilities.h>
 
 @interface EXBattery ()
 
-@property (nonatomic, weak) UMModuleRegistry *moduleRegistry;
-@property (nonatomic, weak) id <UMEventEmitterService> eventEmitter;
+@property (nonatomic, weak) EXModuleRegistry *moduleRegistry;
+@property (nonatomic, weak) id <EXEventEmitterService> eventEmitter;
 @property (nonatomic, assign) BOOL hasListeners;
 @property (nonatomic, readonly) EXBatteryState batteryState;
 
@@ -14,7 +14,7 @@
 
 @implementation EXBattery
 
-UM_EXPORT_MODULE(ExpoBattery);
+EX_EXPORT_MODULE(ExpoBattery);
 
 - (NSDictionary *)constantsToExport
 {
@@ -32,13 +32,13 @@ UM_EXPORT_MODULE(ExpoBattery);
   return dispatch_get_main_queue();
 }
 
-- (void)setModuleRegistry:(UMModuleRegistry *)moduleRegistry
+- (void)setModuleRegistry:(EXModuleRegistry *)moduleRegistry
 {
   if (_moduleRegistry) {
     [self invalidate];
   }
   _moduleRegistry = moduleRegistry;
-  _eventEmitter = [moduleRegistry getModuleImplementingProtocol:@protocol(UMEventEmitterService)];
+  _eventEmitter = [moduleRegistry getModuleImplementingProtocol:@protocol(EXEventEmitterService)];
   
   if (moduleRegistry) {
     UIDevice.currentDevice.batteryMonitoringEnabled = YES;
@@ -118,22 +118,22 @@ UM_EXPORT_MODULE(ExpoBattery);
   [_eventEmitter sendEventWithName:@"Expo.powerModeDidChange" body:result];
 }
 
-UM_EXPORT_METHOD_AS(getBatteryLevelAsync,
-                    getBatteryLevelAsyncWithResolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(getBatteryLevelAsync,
+                    getBatteryLevelAsyncWithResolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   resolve(@(UIDevice.currentDevice.batteryLevel));
 }
 
-UM_EXPORT_METHOD_AS(getBatteryStateAsync,
-                    getBatteryStateAsyncWithResolver:(UMPromiseResolveBlock)resolve rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(getBatteryStateAsync,
+                    getBatteryStateAsyncWithResolver:(EXPromiseResolveBlock)resolve rejecter:(EXPromiseRejectBlock)reject)
 {
   resolve(@([self batteryState]));
 }
 
-UM_EXPORT_METHOD_AS(isLowPowerModeEnabledAsync,
-                    isLowPowerModeEnabledAsyncWithResolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(isLowPowerModeEnabledAsync,
+                    isLowPowerModeEnabledAsyncWithResolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   resolve(@(NSProcessInfo.processInfo.isLowPowerModeEnabled));
 }

--- a/packages/expo-battery/package.json
+++ b/packages/expo-battery/package.json
@@ -29,6 +29,9 @@
   "author": "650 Industries, Inc.",
   "license": "MIT",
   "homepage": "https://docs.expo.io/versions/latest/sdk/battery/",
+  "dependencies": {
+    "expo-modules-core": "~0.1.1"
+  },
   "devDependencies": {
     "expo-module-scripts": "^2.0.0"
   }

--- a/packages/expo-blur/CHANGELOG.md
+++ b/packages/expo-blur/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Migrated from `@unimodules/core` to `expo-modules-core`.
+- Migrated from `@unimodules/core` to `expo-modules-core`. ([#13757](https://github.com/expo/expo/pull/13757) by [@tsapeta](https://github.com/tsapeta))
 
 ## 9.0.3 — 2021-03-30
 

--- a/packages/expo-blur/CHANGELOG.md
+++ b/packages/expo-blur/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ### 🐛 Bug fixes
 
+### 💡 Others
+
+- Migrated from `@unimodules/core` to `expo-modules-core`.
+
 ## 9.0.3 — 2021-03-30
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-blur/ios/EXBlur.podspec
+++ b/packages/expo-blur/ios/EXBlur.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.platform       = :ios, '11.0'
   s.source         = { git: 'https://github.com/expo/expo.git' }
 
-  s.dependency 'UMCore'
+  s.dependency 'ExpoModulesCore'
 
   if !$ExpoUseSources&.include?(package['name']) && ENV['EXPO_USE_SOURCE'].to_i == 0 && File.exist?("#{s.name}.xcframework") && Gem::Version.new(Pod::VERSION) >= Gem::Version.new('1.10.0')
     s.source_files = "#{s.name}/**/*.h"

--- a/packages/expo-blur/ios/EXBlur/EXBlurViewManager.h
+++ b/packages/expo-blur/ios/EXBlur/EXBlurViewManager.h
@@ -1,8 +1,8 @@
 // Copyright 2016-present 650 Industries. All rights reserved.
 
-#import <UMCore/UMViewManager.h>
-#import <UMCore/UMModuleRegistryConsumer.h>
+#import <ExpoModulesCore/EXViewManager.h>
+#import <ExpoModulesCore/EXModuleRegistryConsumer.h>
 
-@interface EXBlurViewManager : UMViewManager <UMModuleRegistryConsumer>
+@interface EXBlurViewManager : EXViewManager <EXModuleRegistryConsumer>
 
 @end

--- a/packages/expo-blur/ios/EXBlur/EXBlurViewManager.m
+++ b/packages/expo-blur/ios/EXBlur/EXBlurViewManager.m
@@ -2,19 +2,19 @@
 
 #import <EXBlur/EXBlurView.h>
 #import <EXBlur/EXBlurViewManager.h>
-#import <UMCore/UMUIManager.h>
+#import <ExpoModulesCore/EXUIManager.h>
 
 @interface EXBlurViewManager ()
 
-@property (weak, nonatomic) UMModuleRegistry *moduleRegistry;
+@property (weak, nonatomic) EXModuleRegistry *moduleRegistry;
 
 @end
 
 @implementation EXBlurViewManager
 
-UM_EXPORT_MODULE(ExpoBlurViewManager);
+EX_EXPORT_MODULE(ExpoBlurViewManager);
 
-- (void)setModuleRegistry:(UMModuleRegistry *)moduleRegistry {
+- (void)setModuleRegistry:(EXModuleRegistry *)moduleRegistry {
   _moduleRegistry = moduleRegistry;
 }
 
@@ -28,25 +28,25 @@ UM_EXPORT_MODULE(ExpoBlurViewManager);
   return @"ExpoBlurView";
 }
 
-UM_VIEW_PROPERTY(tint, NSString *, EXBlurView)
+EX_VIEW_PROPERTY(tint, NSString *, EXBlurView)
 {
   [view setTint:value];
   [view didSetProps:@[@"tint"]];
 }
 
-UM_VIEW_PROPERTY(intensity, NSNumber *, EXBlurView)
+EX_VIEW_PROPERTY(intensity, NSNumber *, EXBlurView)
 {
   [view setIntensity:value];
   [view didSetProps:@[@"intensity"]];
 }
 
-UM_EXPORT_METHOD_AS(updateProps,
+EX_EXPORT_METHOD_AS(updateProps,
                     updateProps:(NSDictionary *)props
                     onViewOfId:(id)viewId
-                    resolve:(UMPromiseResolveBlock)resolver
-                    reject:(UMPromiseRejectBlock)rejecter)
+                    resolve:(EXPromiseResolveBlock)resolver
+                    reject:(EXPromiseRejectBlock)rejecter)
 {
-  [[_moduleRegistry getModuleImplementingProtocol:@protocol(UMUIManager)] executeUIBlock:^(id view) {
+  [[_moduleRegistry getModuleImplementingProtocol:@protocol(EXUIManager)] executeUIBlock:^(id view) {
     if ([view isKindOfClass:[EXBlurView class]]) {
       EXBlurView *blurView = view;
       NSMutableArray *changedProps = [NSMutableArray new];

--- a/packages/expo-blur/package.json
+++ b/packages/expo-blur/package.json
@@ -33,6 +33,9 @@
   "author": "650 Industries, Inc.",
   "license": "MIT",
   "homepage": "https://docs.expo.io/versions/latest/sdk/blur-view/",
+  "dependencies": {
+    "expo-modules-core": "~0.1.1"
+  },
   "devDependencies": {
     "expo-module-scripts": "^2.0.0"
   }

--- a/packages/expo-branch/CHANGELOG.md
+++ b/packages/expo-branch/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Migrated from `@unimodules/core` to `expo-modules-core`.
+
 ## 4.2.0 — 2021-06-16
 
 ### 🎉 New features

--- a/packages/expo-branch/CHANGELOG.md
+++ b/packages/expo-branch/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Migrated from `@unimodules/core` to `expo-modules-core`.
+- Migrated from `@unimodules/core` to `expo-modules-core`. ([#13757](https://github.com/expo/expo/pull/13757) by [@tsapeta](https://github.com/tsapeta))
 
 ## 4.2.0 — 2021-06-16
 

--- a/packages/expo-branch/ios/EXBranch.podspec
+++ b/packages/expo-branch/ios/EXBranch.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
 
   s.compiler_flags = %[-DRNBRANCH_VERSION=@\\"#{package["dependencies"]["react-native-branch"]}\\"]
 
-  s.dependency 'UMCore'
+  s.dependency 'ExpoModulesCore'
   s.dependency 'React-Core'
   s.dependency 'Branch', '0.35.0'
 

--- a/packages/expo-branch/ios/EXBranch/EXBranchManager.h
+++ b/packages/expo-branch/ios/EXBranch/EXBranchManager.h
@@ -1,12 +1,12 @@
 // Copyright 2019-present 650 Industries. All rights reserved.
 
 #import <UIKit/UIKit.h>
-#import <UMCore/UMSingletonModule.h>
+#import <ExpoModulesCore/EXSingletonModule.h>
 #import <EXBranch/RNBranch.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface EXBranchManager : UMSingletonModule <UIApplicationDelegate>
+@interface EXBranchManager : EXSingletonModule <UIApplicationDelegate>
 
 + (BOOL)isBranchEnabled;
 

--- a/packages/expo-branch/ios/EXBranch/EXBranchManager.m
+++ b/packages/expo-branch/ios/EXBranch/EXBranchManager.m
@@ -1,12 +1,12 @@
 // Copyright 2019-present 650 Industries. All rights reserved.
 
 #import <EXBranch/EXBranchManager.h>
-#import <UMCore/UMDefines.h>
+#import <ExpoModulesCore/EXDefines.h>
 #import <Branch/Branch.h>
 
 @implementation EXBranchManager
 
-UM_REGISTER_SINGLETON_MODULE(BranchManager)
+EX_REGISTER_SINGLETON_MODULE(BranchManager)
 
 + (BOOL)isBranchEnabled
 {

--- a/packages/expo-branch/package.json
+++ b/packages/expo-branch/package.json
@@ -33,6 +33,7 @@
   "homepage": "https://docs.expo.io/versions/latest/sdk/branch/",
   "dependencies": {
     "@expo/config-plugins": "^3.0.0",
+    "expo-modules-core": "~0.1.1",
     "react-native-branch": "5.0.0"
   },
   "devDependencies": {

--- a/packages/expo-brightness/CHANGELOG.md
+++ b/packages/expo-brightness/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Migrated from `@unimodules/core` to `expo-modules-core`.
+- Migrated from `@unimodules/core` to `expo-modules-core`. ([#13757](https://github.com/expo/expo/pull/13757) by [@tsapeta](https://github.com/tsapeta))
 
 ## 9.2.0 — 2021-06-16
 

--- a/packages/expo-brightness/CHANGELOG.md
+++ b/packages/expo-brightness/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Migrated from `@unimodules/core` to `expo-modules-core`.
+
 ## 9.2.0 — 2021-06-16
 
 ### 🐛 Bug fixes

--- a/packages/expo-brightness/ios/EXBrightness.podspec
+++ b/packages/expo-brightness/ios/EXBrightness.podspec
@@ -13,7 +13,6 @@ Pod::Spec.new do |s|
   s.platform       = :ios, '11.0'
   s.source         = { git: 'https://github.com/expo/expo.git' }
 
-  s.dependency 'UMCore'
   s.dependency 'ExpoModulesCore'
 
   if !$ExpoUseSources&.include?(package['name']) && ENV['EXPO_USE_SOURCE'].to_i == 0 && File.exist?("#{s.name}.xcframework") && Gem::Version.new(Pod::VERSION) >= Gem::Version.new('1.10.0')

--- a/packages/expo-brightness/ios/EXBrightness/EXBrightness.h
+++ b/packages/expo-brightness/ios/EXBrightness/EXBrightness.h
@@ -1,6 +1,6 @@
-#import <UMCore/UMExportedModule.h>
-#import <UMCore/UMModuleRegistryConsumer.h>
+#import <ExpoModulesCore/EXExportedModule.h>
+#import <ExpoModulesCore/EXModuleRegistryConsumer.h>
 
-@interface EXBrightness : UMExportedModule <UMModuleRegistryConsumer>
+@interface EXBrightness : EXExportedModule <EXModuleRegistryConsumer>
 
 @end

--- a/packages/expo-brightness/ios/EXBrightness/EXBrightness.m
+++ b/packages/expo-brightness/ios/EXBrightness/EXBrightness.m
@@ -1,6 +1,6 @@
 #import <EXBrightness/EXBrightness.h>
 #import <EXBrightness/EXSystemBrightnessPermissionRequester.h>
-#import <UMCore/UMUtilities.h>
+#import <ExpoModulesCore/EXUtilities.h>
 #import <ExpoModulesCore/EXPermissionsInterface.h>
 #import <ExpoModulesCore/EXPermissionsMethodsDelegate.h>
 
@@ -14,17 +14,17 @@
 
 @implementation EXBrightness
 
-UM_EXPORT_MODULE(ExpoBrightness);
+EX_EXPORT_MODULE(ExpoBrightness);
 
-- (void)setModuleRegistry:(UMModuleRegistry *)moduleRegistry
+- (void)setModuleRegistry:(EXModuleRegistry *)moduleRegistry
 {
   _permissionsManager = [moduleRegistry getModuleImplementingProtocol:@protocol(EXPermissionsInterface)];
   [EXPermissionsMethodsDelegate registerRequesters:@[[EXSystemBrightnessPermissionRequester new]] withPermissionsManager:_permissionsManager];
 }
 
-UM_EXPORT_METHOD_AS(getPermissionsAsync,
-                    getPermissionsAsync:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(getPermissionsAsync,
+                    getPermissionsAsync:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   [EXPermissionsMethodsDelegate getPermissionWithPermissionsManager:_permissionsManager
                                                       withRequester:[EXSystemBrightnessPermissionRequester class]
@@ -32,9 +32,9 @@ UM_EXPORT_METHOD_AS(getPermissionsAsync,
                                                              reject:reject];
 }
 
-UM_EXPORT_METHOD_AS(requestPermissionsAsync,
-                    requestPermissionsAsync:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(requestPermissionsAsync,
+                    requestPermissionsAsync:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   [EXPermissionsMethodsDelegate askForPermissionWithPermissionsManager:_permissionsManager
                                                          withRequester:[EXSystemBrightnessPermissionRequester class]
@@ -42,66 +42,66 @@ UM_EXPORT_METHOD_AS(requestPermissionsAsync,
                                                                 reject:reject];
 }
 
-UM_EXPORT_METHOD_AS(setBrightnessAsync,
+EX_EXPORT_METHOD_AS(setBrightnessAsync,
                     setBrightnessAsync:(NSNumber *)brightnessValue
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
-  [UMUtilities performSynchronouslyOnMainThread:^{
+  [EXUtilities performSynchronouslyOnMainThread:^{
     [UIScreen mainScreen].brightness = [brightnessValue floatValue];
   }];
   resolve(nil);
 }
 
-UM_EXPORT_METHOD_AS(getBrightnessAsync,
-                    getBrightnessAsyncWithResolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(getBrightnessAsync,
+                    getBrightnessAsyncWithResolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   __block float result = 0;
-  [UMUtilities performSynchronouslyOnMainThread:^{
+  [EXUtilities performSynchronouslyOnMainThread:^{
     result = [UIScreen mainScreen].brightness;
   }];
   resolve(@(result));
 }
 
-UM_EXPORT_METHOD_AS(getSystemBrightnessAsync,
-                    getSystemBrightnessAsync:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(getSystemBrightnessAsync,
+                    getSystemBrightnessAsync:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   // stub for jest-expo-mock-generator
 }
 
-UM_EXPORT_METHOD_AS(setSystemBrightnessAsync,
-                    setSystemBrightnessAsync:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(setSystemBrightnessAsync,
+                    setSystemBrightnessAsync:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   // stub for jest-expo-mock-generator
 }
 
-UM_EXPORT_METHOD_AS(useSystemBrightnessAsync,
-                    useSystemBrightnessAsync:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(useSystemBrightnessAsync,
+                    useSystemBrightnessAsync:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   // stub for jest-expo-mock-generator
 }
 
-UM_EXPORT_METHOD_AS(isUsingSystemBrightnessAsync,
-                    isUsingSystemBrightnessAsync:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(isUsingSystemBrightnessAsync,
+                    isUsingSystemBrightnessAsync:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   // stub for jest-expo-mock-generator
 }
 
-UM_EXPORT_METHOD_AS(getSystemBrightnessModeAsync,
-                    getSystemBrightnessModeAsync:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(getSystemBrightnessModeAsync,
+                    getSystemBrightnessModeAsync:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   // stub for jest-expo-mock-generator
 }
 
-UM_EXPORT_METHOD_AS(setSystemBrightnessModeAsync,
-                    setSystemBrightnessModeAsync:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(setSystemBrightnessModeAsync,
+                    setSystemBrightnessModeAsync:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   // stub for jest-expo-mock-generator
 }

--- a/packages/expo-brightness/ios/EXBrightness/EXSystemBrightnessPermissionRequester.m
+++ b/packages/expo-brightness/ios/EXBrightness/EXSystemBrightnessPermissionRequester.m
@@ -15,7 +15,7 @@
            };
 }
 
-- (void)requestPermissionsWithResolver:(UMPromiseResolveBlock)resolve rejecter:(UMPromiseRejectBlock)reject
+- (void)requestPermissionsWithResolver:(EXPromiseResolveBlock)resolve rejecter:(EXPromiseRejectBlock)reject
 {
   resolve([self getPermissions]);
 }

--- a/packages/expo-clipboard/CHANGELOG.md
+++ b/packages/expo-clipboard/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### 💡 Others
 
 - Clean up Android code. ([#13517](https://github.com/expo/expo/pull/13517) by [@mstach60161](https://github.com/mstach60161))
-([#13517](https://github.com/expo/expo/pull/13517) by [@mstach60161](https://github.com/mstach60161))
+- Migrated from `@unimodules/core` to `expo-modules-core`.
 
 ## 1.1.0 — 2021-06-16
 

--- a/packages/expo-clipboard/CHANGELOG.md
+++ b/packages/expo-clipboard/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### 💡 Others
 
 - Clean up Android code. ([#13517](https://github.com/expo/expo/pull/13517) by [@mstach60161](https://github.com/mstach60161))
-- Migrated from `@unimodules/core` to `expo-modules-core`.
+- Migrated from `@unimodules/core` to `expo-modules-core`. ([#13757](https://github.com/expo/expo/pull/13757) by [@tsapeta](https://github.com/tsapeta))
 
 ## 1.1.0 — 2021-06-16
 

--- a/packages/expo-clipboard/ios/EXClipboard.podspec
+++ b/packages/expo-clipboard/ios/EXClipboard.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.preserve_paths = 'EXClipboard/**/*.{h,m}'
   s.requires_arc   = true
 
-  s.dependency 'UMCore'
+  s.dependency 'ExpoModulesCore'
 
   if !$ExpoUseSources&.include?(package['name']) && ENV['EXPO_USE_SOURCE'].to_i == 0 && File.exist?("#{s.name}.xcframework") && Gem::Version.new(Pod::VERSION) >= Gem::Version.new('1.10.0')
     s.source_files = "#{s.name}/**/*.h"

--- a/packages/expo-clipboard/ios/EXClipboard/EXClipboardModule.h
+++ b/packages/expo-clipboard/ios/EXClipboard/EXClipboardModule.h
@@ -1,8 +1,8 @@
 //  Copyright © 2021 650 Industries. All rights reserved.
 
-#import <UMCore/UMExportedModule.h>
-#import <UMCore/UMModuleRegistryConsumer.h>
-#import <UMCore/UMEventEmitter.h>
+#import <ExpoModulesCore/EXExportedModule.h>
+#import <ExpoModulesCore/EXModuleRegistryConsumer.h>
+#import <ExpoModulesCore/EXEventEmitter.h>
 
-@interface EXClipboardModule : UMExportedModule <UMModuleRegistryConsumer, UMEventEmitter>
+@interface EXClipboardModule : EXExportedModule <EXModuleRegistryConsumer, EXEventEmitter>
 @end

--- a/packages/expo-clipboard/ios/EXClipboard/EXClipboardModule.m
+++ b/packages/expo-clipboard/ios/EXClipboard/EXClipboardModule.m
@@ -2,51 +2,51 @@
 
 #import <EXClipboard/EXClipboardModule.h>
 
-#import <UMCore/UMEventEmitterService.h>
+#import <ExpoModulesCore/EXEventEmitterService.h>
 
 static NSString * const onClipboardEventName = @"onClipboardChanged";
 
 @interface EXClipboardModule ()
 
-@property (nonatomic, weak) UMModuleRegistry *moduleRegistry;
+@property (nonatomic, weak) EXModuleRegistry *moduleRegistry;
 @property (nonatomic, assign) BOOL isListening;
 @property (nonatomic, assign) BOOL isBeingObserved;
-@property (nonatomic, weak) id<UMEventEmitterService> eventEmitter;
+@property (nonatomic, weak) id<EXEventEmitterService> eventEmitter;
 
 @end
 
 @implementation EXClipboardModule
 
-UM_EXPORT_MODULE(ExpoClipboard);
+EX_EXPORT_MODULE(ExpoClipboard);
 
-# pragma mark - UMModuleRegistryConsumer
+# pragma mark - EXModuleRegistryConsumer
 
-- (void)setModuleRegistry:(UMModuleRegistry *)moduleRegistry
+- (void)setModuleRegistry:(EXModuleRegistry *)moduleRegistry
 {
   _moduleRegistry = moduleRegistry;
-  _eventEmitter = [moduleRegistry getModuleImplementingProtocol:@protocol(UMEventEmitterService)];
+  _eventEmitter = [moduleRegistry getModuleImplementingProtocol:@protocol(EXEventEmitterService)];
 }
 
 # pragma mark - Exported methods
 
-UM_EXPORT_METHOD_AS(getStringAsync,
-                    getStringAsyncWithResolver:(UMPromiseResolveBlock)resolve
-                    reject:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(getStringAsync,
+                    getStringAsyncWithResolver:(EXPromiseResolveBlock)resolve
+                    reject:(EXPromiseRejectBlock)reject)
 {
   UIPasteboard *clipboard = [UIPasteboard generalPasteboard];
   resolve((clipboard.string ?: @""));
 }
 
-UM_EXPORT_METHOD_AS(setString,
+EX_EXPORT_METHOD_AS(setString,
                     setStringWithContent:(NSString *)content
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   UIPasteboard *clipboard = [UIPasteboard generalPasteboard];
   clipboard.string = (content ? : @"");
 }
 
-# pragma mark - UMEventEmitter
+# pragma mark - EXEventEmitter
 
 - (NSArray<NSString *> *)supportedEvents
 {

--- a/packages/expo-clipboard/package.json
+++ b/packages/expo-clipboard/package.json
@@ -29,6 +29,9 @@
   "author": "650 Industries, Inc.",
   "license": "MIT",
   "homepage": "https://docs.expo.io/versions/latest/sdk/clipboard",
+  "dependencies": {
+    "expo-modules-core": "~0.1.1"
+  },
   "devDependencies": {
     "expo-module-scripts": "^2.0.0"
   },

--- a/packages/expo-crypto/CHANGELOG.md
+++ b/packages/expo-crypto/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### 💡 Others
 
 - Add tests. ([#13592](https://github.com/expo/expo/pull/13592) by [@mstach60161](https://github.com/mstach60161))
-- Migrated from `@unimodules/core` to `expo-modules-core`.
+- Migrated from `@unimodules/core` to `expo-modules-core`. ([#13757](https://github.com/expo/expo/pull/13757) by [@tsapeta](https://github.com/tsapeta))
 
 ## 9.2.0 — 2021-06-16
 

--- a/packages/expo-crypto/CHANGELOG.md
+++ b/packages/expo-crypto/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 💡 Others
 
 - Add tests. ([#13592](https://github.com/expo/expo/pull/13592) by [@mstach60161](https://github.com/mstach60161))
+- Migrated from `@unimodules/core` to `expo-modules-core`.
 
 ## 9.2.0 — 2021-06-16
 

--- a/packages/expo-crypto/ios/EXCrypto.podspec
+++ b/packages/expo-crypto/ios/EXCrypto.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.platform       = :ios, '11.0'
   s.source         = { git: 'https://github.com/expo/expo.git' }
 
-  s.dependency 'UMCore'
+  s.dependency 'ExpoModulesCore'
 
   if !$ExpoUseSources&.include?(package['name']) && ENV['EXPO_USE_SOURCE'].to_i == 0 && File.exist?("#{s.name}.xcframework") && Gem::Version.new(Pod::VERSION) >= Gem::Version.new('1.10.0')
     s.source_files = "#{s.name}/**/*.h"

--- a/packages/expo-crypto/ios/EXCrypto/EXCrypto.h
+++ b/packages/expo-crypto/ios/EXCrypto/EXCrypto.h
@@ -1,7 +1,7 @@
 // Copyright 2019-present 650 Industries. All rights reserved.
 
-#import <UMCore/UMExportedModule.h>
+#import <ExpoModulesCore/EXExportedModule.h>
 
-@interface EXCrypto : UMExportedModule
+@interface EXCrypto : EXExportedModule
 
 @end

--- a/packages/expo-crypto/ios/EXCrypto/EXCrypto.m
+++ b/packages/expo-crypto/ios/EXCrypto/EXCrypto.m
@@ -5,14 +5,14 @@
 
 @implementation EXCrypto
 
-UM_EXPORT_MODULE(ExpoCrypto);
+EX_EXPORT_MODULE(ExpoCrypto);
 
-UM_EXPORT_METHOD_AS(digestStringAsync,
+EX_EXPORT_METHOD_AS(digestStringAsync,
                     digestStringAsync:(NSString *)algorithm
                     data:(NSString *)data
                     options:(NSDictionary *)options
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   NSString *encoding = options[@"encoding"];
   

--- a/packages/expo-crypto/package.json
+++ b/packages/expo-crypto/package.json
@@ -38,8 +38,8 @@
   "jest": {
     "preset": "expo-module-scripts"
   },
-  "unimodulePeerDependencies": {
-    "@unimodules/core": "*"
+  "dependencies": {
+    "expo-modules-core": "~0.1.1"
   },
   "devDependencies": {
     "expo-module-scripts": "^2.0.0"

--- a/packages/expo-device/CHANGELOG.md
+++ b/packages/expo-device/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Migrated from `@unimodules/core` to `expo-modules-core`.
+
 ## 3.3.0 — 2021-06-16
 
 ### 🎉 New features

--- a/packages/expo-device/CHANGELOG.md
+++ b/packages/expo-device/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Migrated from `@unimodules/core` to `expo-modules-core`.
+- Migrated from `@unimodules/core` to `expo-modules-core`. ([#13757](https://github.com/expo/expo/pull/13757) by [@tsapeta](https://github.com/tsapeta))
 
 ## 3.3.0 — 2021-06-16
 

--- a/packages/expo-device/ios/EXDevice.podspec
+++ b/packages/expo-device/ios/EXDevice.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.platform       = :ios, '11.0'
   s.source         = { git: 'https://github.com/expo/expo.git' }
 
-  s.dependency 'UMCore'
+  s.dependency 'ExpoModulesCore'
 
   if !$ExpoUseSources&.include?(package['name']) && ENV['EXPO_USE_SOURCE'].to_i == 0 && File.exist?("#{s.name}.xcframework") && Gem::Version.new(Pod::VERSION) >= Gem::Version.new('1.10.0')
     s.source_files = "#{s.name}/**/*.h"

--- a/packages/expo-device/ios/EXDevice/EXDevice.h
+++ b/packages/expo-device/ios/EXDevice/EXDevice.h
@@ -1,6 +1,6 @@
 // Copyright 2019-present 650 Industries. All rights reserved.
 
-#import <UMCore/UMExportedModule.h>
+#import <ExpoModulesCore/EXExportedModule.h>
 #import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -14,7 +14,7 @@ typedef NS_ENUM(NSInteger, EXDeviceType) {
     EXDeviceTypeTV,
 };
 
-@interface EXDevice : UMExportedModule
+@interface EXDevice : EXExportedModule
 
 @end
 

--- a/packages/expo-device/ios/EXDevice/EXDevice.m
+++ b/packages/expo-device/ios/EXDevice/EXDevice.m
@@ -7,8 +7,8 @@
 #import <mach-o/arch.h>
 #import <sys/utsname.h>
 
-#import <UMCore/UMUtilitiesInterface.h>
-#import <UMCore/UMUtilities.h>
+#import <ExpoModulesCore/EXUtilitiesInterface.h>
+#import <ExpoModulesCore/EXUtilities.h>
 
 #if !(TARGET_OS_TV)
 @import Darwin.sys.sysctl;
@@ -22,7 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation EXDevice
 
-UM_EXPORT_MODULE(ExpoDevice);
+EX_EXPORT_MODULE(ExpoDevice);
 
 - (dispatch_queue_t)methodQueue
 {
@@ -38,10 +38,10 @@ UM_EXPORT_MODULE(ExpoDevice);
            @"isDevice": @([[self class] isDevice]),
            @"brand": @"Apple",
            @"manufacturer": @"Apple",
-           @"modelId": UMNullIfNil([[self class] modelId]),
+           @"modelId": EXNullIfNil([[self class] modelId]),
            @"deviceYearClass": [[self class] deviceYear],
            @"totalMemory": @(NSProcessInfo.processInfo.physicalMemory),
-           @"supportedCpuArchitectures": UMNullIfNil([[self class] cpuArchitectures]),
+           @"supportedCpuArchitectures": EXNullIfNil([[self class] cpuArchitectures]),
            @"osName": currentDevice.systemName,
            @"osVersion": currentDevice.systemVersion,
            @"osBuildId": osBuildId,
@@ -50,24 +50,24 @@ UM_EXPORT_MODULE(ExpoDevice);
            };
 }
 
-UM_EXPORT_METHOD_AS(getDeviceTypeAsync,
-                    getDeviceTypeAsyncWithResolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(getDeviceTypeAsync,
+                    getDeviceTypeAsyncWithResolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   resolve(@([[self class] deviceType]));
 }
 
-UM_EXPORT_METHOD_AS(getUptimeAsync,
-                    getUptimeAsyncWithResolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(getUptimeAsync,
+                    getUptimeAsyncWithResolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   double uptimeMs = NSProcessInfo.processInfo.systemUptime * 1000;
   resolve(@(uptimeMs));
 }
 
-UM_EXPORT_METHOD_AS(isRootedExperimentalAsync,
-                    isRootedExperimentalAsyncWithResolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(isRootedExperimentalAsync,
+                    isRootedExperimentalAsyncWithResolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   resolve(@([[self class] isRooted]));
 }

--- a/packages/expo-device/package.json
+++ b/packages/expo-device/package.json
@@ -32,10 +32,8 @@
   "author": "650 Industries, Inc.",
   "license": "MIT",
   "homepage": "https://docs.expo.io/versions/latest/sdk/device/",
-  "unimodulePeerDependencies": {
-    "@unimodules/core": "*"
-  },
   "dependencies": {
+    "expo-modules-core": "~0.1.1",
     "ua-parser-js": "^0.7.19"
   },
   "devDependencies": {

--- a/packages/expo-document-picker/CHANGELOG.md
+++ b/packages/expo-document-picker/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ### 💡 Others
 
-- Migrated from `@unimodules/core` to `expo-modules-core`.
+- Migrated from `@unimodules/core` to `expo-modules-core`. ([#13757](https://github.com/expo/expo/pull/13757) by [@tsapeta](https://github.com/tsapeta))
 
 ## 9.2.0 — 2021-06-16
 

--- a/packages/expo-document-picker/CHANGELOG.md
+++ b/packages/expo-document-picker/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### 💡 Others
 
+- Migrated from `@unimodules/core` to `expo-modules-core`.
+
 ## 9.2.0 — 2021-06-16
 
 ### 🐛 Bug fixes

--- a/packages/expo-document-picker/ios/EXDocumentPicker.podspec
+++ b/packages/expo-document-picker/ios/EXDocumentPicker.podspec
@@ -13,7 +13,6 @@ Pod::Spec.new do |s|
   s.platform       = :ios, '11.0'
   s.source         = { git: 'https://github.com/expo/expo.git' }
 
-  s.dependency 'UMCore'
   s.dependency 'ExpoModulesCore'
 
   if !$ExpoUseSources&.include?(package['name']) && ENV['EXPO_USE_SOURCE'].to_i == 0 && File.exist?("#{s.name}.xcframework") && Gem::Version.new(Pod::VERSION) >= Gem::Version.new('1.10.0')

--- a/packages/expo-document-picker/ios/EXDocumentPicker/EXDocumentPickerModule.h
+++ b/packages/expo-document-picker/ios/EXDocumentPicker/EXDocumentPickerModule.h
@@ -1,7 +1,7 @@
 //  Copyright © 2018 650 Industries. All rights reserved.
 
-#import <UMCore/UMExportedModule.h>
-#import <UMCore/UMModuleRegistryConsumer.h>
+#import <ExpoModulesCore/EXExportedModule.h>
+#import <ExpoModulesCore/EXModuleRegistryConsumer.h>
 
-@interface EXDocumentPickerModule : UMExportedModule <UMModuleRegistryConsumer>
+@interface EXDocumentPickerModule : EXExportedModule <EXModuleRegistryConsumer>
 @end

--- a/packages/expo-document-picker/ios/EXDocumentPicker/EXDocumentPickerModule.m
+++ b/packages/expo-document-picker/ios/EXDocumentPicker/EXDocumentPickerModule.m
@@ -2,7 +2,7 @@
 
 
 #import <EXDocumentPicker/EXDocumentPickerModule.h>
-#import <UMCore/UMUtilitiesInterface.h>
+#import <ExpoModulesCore/EXUtilitiesInterface.h>
 #import <ExpoModulesCore/EXFileSystemInterface.h>
 
 #import <UIKit/UIKit.h>
@@ -62,12 +62,12 @@ static NSString * EXConvertMimeTypeToUTI(NSString *mimeType)
 
 @interface EXDocumentPickerModule () <UIDocumentPickerDelegate, UIAdaptivePresentationControllerDelegate>
 
-@property (nonatomic, weak) UMModuleRegistry *moduleRegistry;
+@property (nonatomic, weak) EXModuleRegistry *moduleRegistry;
 @property (nonatomic, weak) id<EXFileSystemInterface> fileSystem;
-@property (nonatomic, weak) id<UMUtilitiesInterface> utilities;
+@property (nonatomic, weak) id<EXUtilitiesInterface> utilities;
 
-@property (nonatomic, strong) UMPromiseResolveBlock resolve;
-@property (nonatomic, strong) UMPromiseRejectBlock reject;
+@property (nonatomic, strong) EXPromiseResolveBlock resolve;
+@property (nonatomic, strong) EXPromiseRejectBlock reject;
 
 @property (nonatomic, assign) BOOL shouldCopyToCacheDirectory;
 
@@ -75,22 +75,22 @@ static NSString * EXConvertMimeTypeToUTI(NSString *mimeType)
 
 @implementation EXDocumentPickerModule
 
-UM_EXPORT_MODULE(ExpoDocumentPicker);
+EX_EXPORT_MODULE(ExpoDocumentPicker);
 
-- (void)setModuleRegistry:(UMModuleRegistry *)moduleRegistry
+- (void)setModuleRegistry:(EXModuleRegistry *)moduleRegistry
 {
   _moduleRegistry = moduleRegistry;
   
   if (_moduleRegistry != nil) {
     _fileSystem = [moduleRegistry getModuleImplementingProtocol:@protocol(EXFileSystemInterface)];
-    _utilities = [moduleRegistry getModuleImplementingProtocol:@protocol(UMUtilitiesInterface)];
+    _utilities = [moduleRegistry getModuleImplementingProtocol:@protocol(EXUtilitiesInterface)];
   }
 }
 
-UM_EXPORT_METHOD_AS(getDocumentAsync,
+EX_EXPORT_METHOD_AS(getDocumentAsync,
                     options:(NSDictionary *)options
-                    resolve:(UMPromiseResolveBlock)resolve
-                    reject:(UMPromiseRejectBlock)reject)
+                    resolve:(EXPromiseResolveBlock)resolve
+                    reject:(EXPromiseRejectBlock)reject)
 {
   if (_resolve != nil) {
     return reject(@"E_DOCUMENT_PICKER", @"Different document picking in progress. Await other document picking first.", nil);
@@ -102,10 +102,10 @@ UM_EXPORT_METHOD_AS(getDocumentAsync,
   
   _shouldCopyToCacheDirectory = options[@"copyToCacheDirectory"] && [options[@"copyToCacheDirectory"] boolValue] == YES;
 
-  UM_WEAKIFY(self);
+  EX_WEAKIFY(self);
 
   dispatch_async(dispatch_get_main_queue(), ^{
-    UM_ENSURE_STRONGIFY(self);
+    EX_ENSURE_STRONGIFY(self);
     UIDocumentPickerViewController *documentPickerVC;
 
     @try {

--- a/packages/expo-document-picker/package.json
+++ b/packages/expo-document-picker/package.json
@@ -39,9 +39,6 @@
     "expo-modules-core": "~0.1.1",
     "uuid": "^3.3.2"
   },
-  "unimodulePeerDependencies": {
-    "@unimodules/core": "*"
-  },
   "devDependencies": {
     "expo-module-scripts": "^2.0.0"
   }

--- a/packages/expo-error-recovery/CHANGELOG.md
+++ b/packages/expo-error-recovery/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Migrated from `@unimodules/core` to `expo-modules-core`.
+- Migrated from `@unimodules/core` to `expo-modules-core`. ([#13757](https://github.com/expo/expo/pull/13757) by [@tsapeta](https://github.com/tsapeta))
 
 ## 2.2.0 — 2021-06-16
 

--- a/packages/expo-error-recovery/CHANGELOG.md
+++ b/packages/expo-error-recovery/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Migrated from `@unimodules/core` to `expo-modules-core`.
+
 ## 2.2.0 — 2021-06-16
 
 ### 🐛 Bug fixes

--- a/packages/expo-error-recovery/ios/EXErrorRecovery.podspec
+++ b/packages/expo-error-recovery/ios/EXErrorRecovery.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.platform       = :ios, '11.0'
   s.source         = { git: 'https://github.com/expo/expo.git' }
 
-  s.dependency 'UMCore'
+  s.dependency 'ExpoModulesCore'
 
   if !$ExpoUseSources&.include?(package['name']) && ENV['EXPO_USE_SOURCE'].to_i == 0 && File.exist?("#{s.name}.xcframework") && Gem::Version.new(Pod::VERSION) >= Gem::Version.new('1.10.0')
     s.source_files = "#{s.name}/**/*.h"

--- a/packages/expo-error-recovery/ios/EXErrorRecovery/EXErrorRecoveryModule.h
+++ b/packages/expo-error-recovery/ios/EXErrorRecovery/EXErrorRecoveryModule.h
@@ -1,9 +1,9 @@
 // Copyright © 2018 650 Industries. All rights reserved.
 
-#import <UMCore/UMExportedModule.h>
-#import <UMCore/UMModuleRegistryConsumer.h>
+#import <ExpoModulesCore/EXExportedModule.h>
+#import <ExpoModulesCore/EXModuleRegistryConsumer.h>
 
-@interface EXErrorRecoveryModule : UMExportedModule
+@interface EXErrorRecoveryModule : EXExportedModule
 
 - (NSString *)userDefaultsKey;
 

--- a/packages/expo-error-recovery/ios/EXErrorRecovery/EXErrorRecoveryModule.m
+++ b/packages/expo-error-recovery/ios/EXErrorRecovery/EXErrorRecoveryModule.m
@@ -4,12 +4,12 @@
 
 @implementation EXErrorRecoveryModule
 
-UM_EXPORT_MODULE(ExpoErrorRecovery);
+EX_EXPORT_MODULE(ExpoErrorRecovery);
 
-UM_EXPORT_METHOD_AS(saveRecoveryProps,
+EX_EXPORT_METHOD_AS(saveRecoveryProps,
                     saveRecoveryProps:(NSString *)props
-                    resolve:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolve:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   if (props) {
     if (![self setRecoveryProps:props]) {
@@ -22,7 +22,7 @@ UM_EXPORT_METHOD_AS(saveRecoveryProps,
 - (NSDictionary *)constantsToExport
 {
   return @{
-           @"recoveredProps": UMNullIfNil([self consumeRecoveryProps])
+           @"recoveredProps": EXNullIfNil([self consumeRecoveryProps])
            };
 }
 

--- a/packages/expo-error-recovery/package.json
+++ b/packages/expo-error-recovery/package.json
@@ -31,8 +31,10 @@
   "author": "650 Industries, Inc.",
   "license": "MIT",
   "homepage": "https://docs.expo.io/versions/latest/sdk/error-recovery/",
+  "dependencies": {
+    "expo-modules-core": "~0.1.1"
+  },
   "devDependencies": {
     "expo-module-scripts": "^2.0.0"
-  },
-  "dependencies": {}
+  }
 }

--- a/packages/expo-face-detector/CHANGELOG.md
+++ b/packages/expo-face-detector/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Migrated from `@unimodules/core` to `expo-modules-core`.
+- Migrated from `@unimodules/core` to `expo-modules-core`. ([#13757](https://github.com/expo/expo/pull/13757) by [@tsapeta](https://github.com/tsapeta))
 
 ## 10.1.0 — 2021-06-16
 

--- a/packages/expo-face-detector/CHANGELOG.md
+++ b/packages/expo-face-detector/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Migrated from `@unimodules/core` to `expo-modules-core`.
+
 ## 10.1.0 — 2021-06-16
 
 ### 🐛 Bug fixes

--- a/packages/expo-face-detector/ios/EXFaceDetector.podspec
+++ b/packages/expo-face-detector/ios/EXFaceDetector.podspec
@@ -13,7 +13,6 @@ Pod::Spec.new do |s|
   s.platform       = :ios, '11.0'
   s.source         = { git: 'https://github.com/expo/expo.git' }
 
-  s.dependency 'UMCore'
   s.dependency 'ExpoModulesCore'
 
   # even though `GoogleMLKit/FaceDetection` depends on all `MLKit*` references below

--- a/packages/expo-face-detector/ios/EXFaceDetector/EXFaceDetectorManager.m
+++ b/packages/expo-face-detector/ios/EXFaceDetector/EXFaceDetectorManager.m
@@ -70,9 +70,9 @@ static const NSString *kMinDetectionInterval = @"minDetectionInterval";
   // It allows us to smoothly toggle face detection without interrupting preview and reconfiguring camera session.
   if ([self isDetectingFaceEnabled] != newFaceDetecting) {
     _faceDetectionEnabled = newFaceDetecting;
-    UM_WEAKIFY(self);
+    EX_WEAKIFY(self);
     [self _runBlockIfQueueIsPresent:^{
-      UM_ENSURE_STRONGIFY(self);
+      EX_ENSURE_STRONGIFY(self);
       if ([self isDetectingFaceEnabled] && ![self isFaceDetecionRunning]) {
         [self tryEnablingFaceDetection];
       }
@@ -145,10 +145,10 @@ static const NSString *kMinDetectionInterval = @"minDetectionInterval";
       if([_session canAddOutput:output]) {
         [_session addOutput:output];
       } else {
-        UMLogError(@"Unable to add output to camera session! Face detection aborted!");
+        EXLogError(@"Unable to add output to camera session! Face detection aborted!");
       }
     } @catch (NSException *exception) {
-      UMLogWarn(@"%@", [exception description]);
+      EXLogWarn(@"%@", [exception description]);
     }
   }
 

--- a/packages/expo-face-detector/ios/EXFaceDetector/EXFaceDetectorManagerProvider.h
+++ b/packages/expo-face-detector/ios/EXFaceDetector/EXFaceDetectorManagerProvider.h
@@ -1,8 +1,8 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
-#import <UMCore/UMInternalModule.h>
+#import <ExpoModulesCore/EXInternalModule.h>
 #import <ExpoModulesCore/EXFaceDetectorManagerProviderInterface.h>
 
-@interface EXFaceDetectorManagerProvider : NSObject <UMInternalModule, EXFaceDetectorManagerProviderInterface>
+@interface EXFaceDetectorManagerProvider : NSObject <EXInternalModule, EXFaceDetectorManagerProviderInterface>
 
 @end

--- a/packages/expo-face-detector/ios/EXFaceDetector/EXFaceDetectorManagerProvider.m
+++ b/packages/expo-face-detector/ios/EXFaceDetector/EXFaceDetectorManagerProvider.m
@@ -6,7 +6,7 @@
 
 @implementation EXFaceDetectorManagerProvider
 
-UM_REGISTER_MODULE();
+EX_REGISTER_MODULE();
 
 + (const NSArray<Protocol *> *)exportedInterfaces {
   return @[@protocol(EXFaceDetectorManagerProviderInterface)];

--- a/packages/expo-face-detector/ios/EXFaceDetector/EXFaceDetectorModule.h
+++ b/packages/expo-face-detector/ios/EXFaceDetector/EXFaceDetectorModule.h
@@ -6,8 +6,8 @@
 //  Copyright © 2017 650 Industries. All rights reserved.
 //
 
-#import <UMCore/UMExportedModule.h>
-#import <UMCore/UMModuleRegistryConsumer.h>
+#import <ExpoModulesCore/EXExportedModule.h>
+#import <ExpoModulesCore/EXModuleRegistryConsumer.h>
 
-@interface EXFaceDetectorModule : UMExportedModule <UMModuleRegistryConsumer>
+@interface EXFaceDetectorModule : EXExportedModule <EXModuleRegistryConsumer>
 @end

--- a/packages/expo-face-detector/ios/EXFaceDetector/EXFaceDetectorModule.m
+++ b/packages/expo-face-detector/ios/EXFaceDetector/EXFaceDetectorModule.m
@@ -10,13 +10,13 @@
 #import <EXFaceDetector/EXFaceDetector.h>
 #import <ExpoModulesCore/EXFileSystemInterface.h>
 #import <EXFaceDetector/EXFaceDetectorUtils.h>
-#import <UMCore/UMModuleRegistry.h>
+#import <ExpoModulesCore/EXModuleRegistry.h>
 #import <EXFaceDetector/EXFaceEncoder.h>
 #import <EXFaceDetector/EXCSBufferOrientationCalculator.h>
 
 @interface EXFaceDetectorModule ()
 
-@property (nonatomic, weak) UMModuleRegistry *moduleRegistry;
+@property (nonatomic, weak) EXModuleRegistry *moduleRegistry;
 
 @end
 
@@ -25,7 +25,7 @@
 static NSFileManager *fileManager = nil;
 static NSDictionary *defaultDetectorOptions = nil;
 
-- (instancetype)initWithModuleRegistry:(UMModuleRegistry *)moduleRegistry
+- (instancetype)initWithModuleRegistry:(EXModuleRegistry *)moduleRegistry
 {
   self = [super init];
   if (self) {
@@ -35,19 +35,19 @@ static NSDictionary *defaultDetectorOptions = nil;
   return self;
 }
 
-UM_EXPORT_MODULE(ExpoFaceDetector);
+EX_EXPORT_MODULE(ExpoFaceDetector);
 
 - (NSDictionary *)constantsToExport
 {
   return [EXFaceDetectorUtils constantsToExport];
 }
 
-- (void)setModuleRegistry:(UMModuleRegistry *)moduleRegistry
+- (void)setModuleRegistry:(EXModuleRegistry *)moduleRegistry
 {
   _moduleRegistry = moduleRegistry;
 }
 
-UM_EXPORT_METHOD_AS(detectFaces, detectFaces:(nonnull NSDictionary *)options resolver:(UMPromiseResolveBlock)resolve rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(detectFaces, detectFaces:(nonnull NSDictionary *)options resolver:(EXPromiseResolveBlock)resolve rejecter:(EXPromiseRejectBlock)reject)
 {
   NSString *uri = options[@"uri"];
   if (uri == nil) {

--- a/packages/expo-face-detector/package.json
+++ b/packages/expo-face-detector/package.json
@@ -35,9 +35,6 @@
   "jest": {
     "preset": "expo-module-scripts/ios"
   },
-  "unimodulePeerDependencies": {
-    "@unimodules/core": "*"
-  },
   "dependencies": {
     "expo-modules-core": "~0.1.1"
   },

--- a/packages/expo-facebook/CHANGELOG.md
+++ b/packages/expo-facebook/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - More TypeScript doc blocks. ([#13657](https://github.com/expo/expo/pull/13657) by [@cruzach](https://github.com/cruzach))
 - Export `FacebookInitializationOptions`
+- Migrated from `@unimodules/core` to `expo-modules-core`.
 
 ## 11.2.0 — 2021-06-16
 

--- a/packages/expo-facebook/CHANGELOG.md
+++ b/packages/expo-facebook/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 - More TypeScript doc blocks. ([#13657](https://github.com/expo/expo/pull/13657) by [@cruzach](https://github.com/cruzach))
 - Export `FacebookInitializationOptions`
-- Migrated from `@unimodules/core` to `expo-modules-core`.
+- Migrated from `@unimodules/core` to `expo-modules-core`. ([#13757](https://github.com/expo/expo/pull/13757) by [@tsapeta](https://github.com/tsapeta))
 
 ## 11.2.0 — 2021-06-16
 

--- a/packages/expo-facebook/ios/EXFacebook.podspec
+++ b/packages/expo-facebook/ios/EXFacebook.podspec
@@ -13,7 +13,6 @@ Pod::Spec.new do |s|
   s.platform       = :ios, '11.0'
   s.source         = { git: 'https://github.com/expo/expo.git' }
 
-  s.dependency 'UMCore'
   s.dependency 'ExpoModulesCore'
   s.dependency 'FacebookSDK/CoreKit', $FacebookSDKVersion || '9.2.0'
   s.dependency 'FacebookSDK/LoginKit', $FacebookSDKVersion || '9.2.0'

--- a/packages/expo-facebook/ios/EXFacebook/EXFacebook.h
+++ b/packages/expo-facebook/ios/EXFacebook/EXFacebook.h
@@ -1,8 +1,8 @@
 // Copyright 2016-present 650 Industries. All rights reserved.
 
-#import <UMCore/UMExportedModule.h>
-#import <UMCore/UMModuleRegistryConsumer.h>
+#import <ExpoModulesCore/EXExportedModule.h>
+#import <ExpoModulesCore/EXModuleRegistryConsumer.h>
 
-@interface EXFacebook : UMExportedModule <UMModuleRegistryConsumer>
+@interface EXFacebook : EXExportedModule <EXModuleRegistryConsumer>
 
 @end

--- a/packages/expo-facebook/ios/EXFacebook/EXFacebook.m
+++ b/packages/expo-facebook/ios/EXFacebook/EXFacebook.m
@@ -23,17 +23,17 @@ static NSString *const FBSDKAppEventsPushPayloadCampaignKey = @"campaign";
 
 @implementation EXFacebook
 
-UM_EXPORT_MODULE(ExponentFacebook)
+EX_EXPORT_MODULE(ExponentFacebook)
 
-- (void)setModuleRegistry:(UMModuleRegistry *)moduleRegistry
+- (void)setModuleRegistry:(EXModuleRegistry *)moduleRegistry
 {
   _permissionsManager = [moduleRegistry getModuleImplementingProtocol:@protocol(EXPermissionsInterface)];
   [EXPermissionsMethodsDelegate registerRequesters:@[[EXFacebookAppTrackingPermissionRequester new]] withPermissionsManager:_permissionsManager];
 }
 
-UM_EXPORT_METHOD_AS(getPermissionsAsync,
-                    getPermissionsAsync:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(getPermissionsAsync,
+                    getPermissionsAsync:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   [EXPermissionsMethodsDelegate getPermissionWithPermissionsManager:_permissionsManager
                                                       withRequester:[EXFacebookAppTrackingPermissionRequester class]
@@ -41,9 +41,9 @@ UM_EXPORT_METHOD_AS(getPermissionsAsync,
                                                              reject:reject];
 }
 
-UM_EXPORT_METHOD_AS(requestPermissionsAsync,
-                    requestPermissionsAsync:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(requestPermissionsAsync,
+                    requestPermissionsAsync:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   [EXPermissionsMethodsDelegate askForPermissionWithPermissionsManager:_permissionsManager
                                                          withRequester:[EXFacebookAppTrackingPermissionRequester class]
@@ -51,28 +51,28 @@ UM_EXPORT_METHOD_AS(requestPermissionsAsync,
                                                                 reject:reject];
 }
 
-UM_EXPORT_METHOD_AS(setAdvertiserTrackingEnabledAsync,
+EX_EXPORT_METHOD_AS(setAdvertiserTrackingEnabledAsync,
                     setAdvertiserTrackingEnabled:(BOOL)enabled
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   BOOL result = [FBSDKSettings setAdvertiserTrackingEnabled:enabled];
   resolve(@(result));
 }
 
-UM_EXPORT_METHOD_AS(setAutoLogAppEventsEnabledAsync,
+EX_EXPORT_METHOD_AS(setAutoLogAppEventsEnabledAsync,
                     setAutoLogAppEventsEnabled:(BOOL)enabled
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   [FBSDKSettings setAutoLogAppEventsEnabled:enabled];
   resolve(nil);
 }
 
-UM_EXPORT_METHOD_AS(initializeAsync,
+EX_EXPORT_METHOD_AS(initializeAsync,
                     initializeAsync:(NSDictionary *)options
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   // Caller overrides buildtime settings
   if (options[@"appId"]) {
@@ -97,37 +97,37 @@ UM_EXPORT_METHOD_AS(initializeAsync,
   resolve(nil);
 }
 
-UM_EXPORT_METHOD_AS(setAdvertiserIDCollectionEnabledAsync,
+EX_EXPORT_METHOD_AS(setAdvertiserIDCollectionEnabledAsync,
                     setAdvertiserIDCollectionEnabled:(BOOL)enabled
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   // Caller overrides buildtime settings
   [FBSDKSettings setAdvertiserIDCollectionEnabled:enabled];
   resolve(nil);
 }
 
-UM_EXPORT_METHOD_AS(logOutAsync,
-                    logOutAsync:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(logOutAsync,
+                    logOutAsync:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   FBSDKLoginManager *loginManager = [[FBSDKLoginManager alloc] init];
   [loginManager logOut];
   resolve(nil);
 }
 
-UM_EXPORT_METHOD_AS(getAuthenticationCredentialAsync,
-                    getAuthenticationCredentialAsync:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(getAuthenticationCredentialAsync,
+                    getAuthenticationCredentialAsync:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   FBSDKAccessToken *currentAccessToken = [FBSDKAccessToken currentAccessToken];
-  resolve(UMNullIfNil([EXFacebook accessTokenNativeToJSON:currentAccessToken]));
+  resolve(EXNullIfNil([EXFacebook accessTokenNativeToJSON:currentAccessToken]));
 }
 
-UM_EXPORT_METHOD_AS(logInWithReadPermissionsAsync,
+EX_EXPORT_METHOD_AS(logInWithReadPermissionsAsync,
                     logInWithReadPermissionsWithConfig:(NSDictionary *)config
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   if (![FBSDKSettings appID]) {
     reject(EXFacebookMisconfiguredErrorDomain, @"No appId configured, required for initialization. Please ensure that you're either providing `appId` to `initializeAsync` as an argument or inside Info.plist.", nil);
@@ -197,12 +197,12 @@ UM_EXPORT_METHOD_AS(logInWithReadPermissionsAsync,
   };
 }
 
-UM_EXPORT_METHOD_AS(logEventAsync,
+EX_EXPORT_METHOD_AS(logEventAsync,
                     logEvent:(NSString *)eventName
                     valueToSum:(nonnull NSNumber *)valueToSum
                     parameters:(NSDictionary *)parameters
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   parameters = dictionaryWithNullValuesAsStrings(parameters);
   
@@ -213,12 +213,12 @@ UM_EXPORT_METHOD_AS(logEventAsync,
   resolve(nil);
 }
 
-UM_EXPORT_METHOD_AS(logPurchaseAsync,
+EX_EXPORT_METHOD_AS(logPurchaseAsync,
                     logPurchase:(NSNumber *)purchaseAmount
                     currency:(NSString *)currency
                     parameters:(NSDictionary *)parameters
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   parameters = dictionaryWithNullValuesAsStrings(parameters);
   
@@ -229,10 +229,10 @@ UM_EXPORT_METHOD_AS(logPurchaseAsync,
   resolve(nil);
 }
 
-UM_EXPORT_METHOD_AS(logPushNotificationOpenAsync,
+EX_EXPORT_METHOD_AS(logPushNotificationOpenAsync,
                     logPushNotificationOpen:(NSString *)campaign
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   NSDictionary *payload = @{
     FBSDKAppEventsPushPayloadKey: @{
@@ -243,25 +243,25 @@ UM_EXPORT_METHOD_AS(logPushNotificationOpenAsync,
   resolve(nil);
 }
 
-UM_EXPORT_METHOD_AS(setUserIDAsync,
+EX_EXPORT_METHOD_AS(setUserIDAsync,
                     setUserID:(NSString *)userID
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   [FBSDKAppEvents setUserID:userID];
   resolve(nil);
 }
 
-UM_EXPORT_METHOD_AS(getUserIDAsync,
-                    getUserID:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(getUserIDAsync,
+                    getUserID:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   resolve([FBSDKAppEvents userID]);
 }
 
-UM_EXPORT_METHOD_AS(getAnonymousIDAsync,
-                    getAnonymousID:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(getAnonymousIDAsync,
+                    getAnonymousID:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   @try {
     NSString *anonymousID = [FBSDKAppEvents anonymousID];
@@ -272,9 +272,9 @@ UM_EXPORT_METHOD_AS(getAnonymousIDAsync,
   }
 }
 
-UM_EXPORT_METHOD_AS(getAdvertiserIDAsync,
-                    getAdvertiserID:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(getAdvertiserIDAsync,
+                    getAdvertiserID:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   @try {
     NSString *advertiserID = [FBSDKAppEventsUtility advertiserID];
@@ -285,10 +285,10 @@ UM_EXPORT_METHOD_AS(getAdvertiserIDAsync,
   }
 }
 
-UM_EXPORT_METHOD_AS(setUserDataAsync,
+EX_EXPORT_METHOD_AS(setUserDataAsync,
                     setUserData:(NSDictionary *)userData
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   userData = dictionaryWithNullValuesAsStrings(userData);
   
@@ -305,18 +305,18 @@ UM_EXPORT_METHOD_AS(setUserDataAsync,
   resolve(nil);
 }
 
-UM_EXPORT_METHOD_AS(setFlushBehaviorAsync,
+EX_EXPORT_METHOD_AS(setFlushBehaviorAsync,
                     setFlushBehavior:(FBSDKAppEventsFlushBehavior)flushBehavior
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   [FBSDKAppEvents setFlushBehavior:flushBehavior];
   resolve(nil);
 }
 
-UM_EXPORT_METHOD_AS(flushAsync,
-                    flush:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(flushAsync,
+                    flush:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   [FBSDKAppEvents flush];
   resolve(nil);

--- a/packages/expo-facebook/ios/EXFacebook/EXFacebookAppDelegate.h
+++ b/packages/expo-facebook/ios/EXFacebook/EXFacebookAppDelegate.h
@@ -2,11 +2,11 @@
 
 #import <UIKit/UIKit.h>
 #import <Foundation/Foundation.h>
-#import <UMCore/UMSingletonModule.h>
+#import <ExpoModulesCore/EXSingletonModule.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface EXFacebookAppDelegate : UMSingletonModule <UIApplicationDelegate>
+@interface EXFacebookAppDelegate : EXSingletonModule <UIApplicationDelegate>
 
 @end
 

--- a/packages/expo-facebook/ios/EXFacebook/EXFacebookAppDelegate.m
+++ b/packages/expo-facebook/ios/EXFacebook/EXFacebookAppDelegate.m
@@ -3,12 +3,12 @@
 #import <EXFacebook/EXFacebookAppDelegate.h>
 #import <EXFacebook/EXFacebook.h>
 #import <FBSDKCoreKit/FBSDKCoreKit.h>
-#import <UMCore/UMAppDelegateWrapper.h>
+#import <ExpoModulesCore/EXAppDelegateWrapper.h>
 #import <objc/runtime.h>
 
 @implementation EXFacebookAppDelegate
 
-UM_REGISTER_SINGLETON_MODULE(EXFacebookAppDelegate)
+EX_REGISTER_SINGLETON_MODULE(EXFacebookAppDelegate)
 
 - (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options
 {

--- a/packages/expo-facebook/ios/EXFacebook/EXFacebookAppTrackingPermissionRequester.m
+++ b/packages/expo-facebook/ios/EXFacebook/EXFacebookAppTrackingPermissionRequester.m
@@ -37,12 +37,12 @@
   };
 }
 
-- (void)requestPermissionsWithResolver:(UMPromiseResolveBlock)resolve rejecter:(UMPromiseRejectBlock)reject
+- (void)requestPermissionsWithResolver:(EXPromiseResolveBlock)resolve rejecter:(EXPromiseRejectBlock)reject
 {
   if (@available(iOS 14, *)) {
-    UM_WEAKIFY(self)
+    EX_WEAKIFY(self)
     [ATTrackingManager requestTrackingAuthorizationWithCompletionHandler:^(ATTrackingManagerAuthorizationStatus status) {
-      UM_STRONGIFY(self)
+      EX_STRONGIFY(self)
       resolve([self getPermissions]);
     }];
   } else {

--- a/packages/expo-facebook/package.json
+++ b/packages/expo-facebook/package.json
@@ -33,14 +33,11 @@
   "jest": {
     "preset": "expo-module-scripts"
   },
-  "unimodulePeerDependencies": {
-    "@unimodules/core": "*"
-  },
-  "devDependencies": {
-    "expo-module-scripts": "^2.0.0"
-  },
   "dependencies": {
     "@expo/config-plugins": "^3.0.0",
     "expo-modules-core": "~0.1.1"
+  },
+  "devDependencies": {
+    "expo-module-scripts": "^2.0.0"
   }
 }

--- a/packages/expo-gl/CHANGELOG.md
+++ b/packages/expo-gl/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Migrated from `@unimodules/core` to `expo-modules-core`.
+
 ## 10.4.0 — 2021-06-16
 
 ### 🐛 Bug fixes

--- a/packages/expo-gl/CHANGELOG.md
+++ b/packages/expo-gl/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Migrated from `@unimodules/core` to `expo-modules-core`.
+- Migrated from `@unimodules/core` to `expo-modules-core`. ([#13757](https://github.com/expo/expo/pull/13757) by [@tsapeta](https://github.com/tsapeta))
 
 ## 10.4.0 — 2021-06-16
 

--- a/packages/expo-gl/ios/EXGL.podspec
+++ b/packages/expo-gl/ios/EXGL.podspec
@@ -13,7 +13,6 @@ Pod::Spec.new do |s|
   s.platform        = :ios, '11.0'
   s.source          = { git: 'https://github.com/expo/expo-gl.git' }
 
-  s.dependency 'UMCore'
   s.dependency 'ExpoModulesCore'
   s.dependency 'EXGL_CPP'
 

--- a/packages/expo-gl/ios/EXGL/EXGLContext.h
+++ b/packages/expo-gl/ios/EXGL/EXGLContext.h
@@ -2,7 +2,7 @@
 
 #import <OpenGLES/EAGL.h>
 #import <EXGL_CPP/UEXGL.h>
-#import <UMCore/UMModuleRegistry.h>
+#import <ExpoModulesCore/EXModuleRegistry.h>
 
 @class EXGLContext;
 
@@ -17,13 +17,13 @@
 
 @interface EXGLContext : NSObject
 
-- (nullable instancetype)initWithDelegate:(nullable id<EXGLContextDelegate>)delegate andModuleRegistry:(nonnull UMModuleRegistry *)moduleRegistry;
+- (nullable instancetype)initWithDelegate:(nullable id<EXGLContextDelegate>)delegate andModuleRegistry:(nonnull EXModuleRegistry *)moduleRegistry;
 - (void)initialize:(nullable void(^)(BOOL))callback;
 - (BOOL)isInitialized;
 - (nullable EAGLContext *)createSharedEAGLContext;
 - (void)runAsync:(nonnull void(^)(void))callback;
 - (void)runInEAGLContext:(nonnull EAGLContext*)context callback:(nonnull void(^)(void))callback;
-- (void)takeSnapshotWithOptions:(nonnull NSDictionary *)options resolve:(nonnull UMPromiseResolveBlock)resolve reject:(nonnull UMPromiseRejectBlock)reject;
+- (void)takeSnapshotWithOptions:(nonnull NSDictionary *)options resolve:(nonnull EXPromiseResolveBlock)resolve reject:(nonnull EXPromiseRejectBlock)reject;
 - (void)destroy;
 
 // "protected"

--- a/packages/expo-gl/ios/EXGL/EXGLContext.m
+++ b/packages/expo-gl/ios/EXGL/EXGLContext.m
@@ -3,9 +3,9 @@
 #import <EXGL/EXGLContext.h>
 #import <EXGL/EXGLObjectManager.h>
 
-#import <UMCore/UMUtilities.h>
-#import <UMCore/UMUIManager.h>
-#import <UMCore/UMJavaScriptContextProvider.h>
+#import <ExpoModulesCore/EXUtilities.h>
+#import <ExpoModulesCore/EXUIManager.h>
+#import <ExpoModulesCore/EXJavaScriptContextProvider.h>
 #import <ExpoModulesCore/EXFileSystemInterface.h>
 
 #include <OpenGLES/ES3/gl.h>
@@ -16,14 +16,14 @@
 @interface EXGLContext ()
 
 @property (nonatomic, strong) dispatch_queue_t glQueue;
-@property (nonatomic, weak) UMModuleRegistry *moduleRegistry;
+@property (nonatomic, weak) EXModuleRegistry *moduleRegistry;
 @property (nonatomic, weak) EXGLObjectManager *objectManager;
 
 @end
 
 @implementation EXGLContext
 
-- (instancetype)initWithDelegate:(id<EXGLContextDelegate>)delegate andModuleRegistry:(nonnull UMModuleRegistry *)moduleRegistry
+- (instancetype)initWithDelegate:(id<EXGLContextDelegate>)delegate andModuleRegistry:(nonnull EXModuleRegistry *)moduleRegistry
 {
   if (self = [super init]) {
     self.delegate = delegate;
@@ -65,8 +65,8 @@
 
 - (void)initialize:(void(^)(BOOL))callback
 {
-  id<UMUIManager> uiManager = [_moduleRegistry getModuleImplementingProtocol:@protocol(UMUIManager)];
-  id<UMJavaScriptContextProvider> jsContextProvider = [_moduleRegistry getModuleImplementingProtocol:@protocol(UMJavaScriptContextProvider)];
+  id<EXUIManager> uiManager = [_moduleRegistry getModuleImplementingProtocol:@protocol(EXUIManager)];
+  id<EXJavaScriptContextProvider> jsContextProvider = [_moduleRegistry getModuleImplementingProtocol:@protocol(EXJavaScriptContextProvider)];
 
   void *jsRuntimePtr = [jsContextProvider javaScriptRuntimePointer];
 
@@ -76,7 +76,7 @@
 
     [uiManager dispatchOnClientThread:^{
       EXGLContext *self = weakSelf;
-      id<UMUIManager> uiManager = weakUIManager;
+      id<EXUIManager> uiManager = weakUIManager;
 
       if (!self || !uiManager) {
         BLOCK_SAFE_RUN(callback, NO);
@@ -97,7 +97,7 @@
     }];
   } else {
     BLOCK_SAFE_RUN(callback, NO);
-    UMLogWarn(@"EXGL: Can only run on JavaScriptCore! Do you have 'Remote Debugging' enabled in your app's Developer Menu (https://reactnative.dev/docs/debugging)? EXGL is not supported while using Remote Debugging, you will need to disable it to use EXGL.");
+    EXLogWarn(@"EXGL: Can only run on JavaScriptCore! Do you have 'Remote Debugging' enabled in your app's Developer Menu (https://reactnative.dev/docs/debugging)? EXGL is not supported while using Remote Debugging, you will need to disable it to use EXGL.");
   }
 }
 
@@ -140,8 +140,8 @@
 // - `format`: "jpeg" or "png" - specifies what type of compression and file extension should be used.
 // - `compress`: A value in 0 - 1 range specyfing compression level. JPEG format only.
 - (void)takeSnapshotWithOptions:(nonnull NSDictionary *)options
-                        resolve:(UMPromiseResolveBlock)resolve
-                         reject:(UMPromiseRejectBlock)reject
+                        resolve:(EXPromiseResolveBlock)resolve
+                         reject:(EXPromiseRejectBlock)reject
 {
   [self flush];
 
@@ -174,7 +174,7 @@
       reject(
              @"E_GL_NO_FRAMEBUFFER",
              nil,
-             UMErrorWithMessage(@"No framebuffer bound. Create and bind one to take a snapshot from it.")
+             EXErrorWithMessage(@"No framebuffer bound. Create and bind one to take a snapshot from it.")
              );
       return;
     }
@@ -182,7 +182,7 @@
       reject(
              @"E_GL_INVALID_VIEWPORT",
              nil,
-             UMErrorWithMessage(@"Rect's width and height must be greater than 0. If you didn't set `rect` option, check if the viewport is set correctly.")
+             EXErrorWithMessage(@"Rect's width and height must be greater than 0. If you didn't set `rect` option, check if the viewport is set correctly.")
              );
       return;
     }
@@ -203,7 +203,7 @@
                                         providerRef, NULL, true, kCGRenderingIntentDefault);
 
     // Begin image context
-    CGFloat scale = [UMUtilities screenScale];
+    CGFloat scale = [EXUtilities screenScale];
     NSInteger widthInPoints = width / scale;
     NSInteger heightInPoints = height / scale;
     UIGraphicsBeginImageContextWithOptions(CGSizeMake(widthInPoints, heightInPoints), NO, scale);
@@ -231,7 +231,7 @@
     NSString *extension;
 
     if ([format isEqualToString:@"webp"]) {
-      UMLogWarn(@"iOS doesn't support 'webp' representation, so 'takeSnapshot' won't work with that format. The image is going to be exported as 'png', but consider using a different code for iOS. Check this docs to learn how to do platform specific code (https://reactnative.dev/docs/platform-specific-code)");
+      EXLogWarn(@"iOS doesn't support 'webp' representation, so 'takeSnapshot' won't work with that format. The image is going to be exported as 'png', but consider using a different code for iOS. Check this docs to learn how to do platform specific code (https://reactnative.dev/docs/platform-specific-code)");
       imageData = UIImagePNGRepresentation(image);
       extension = @".png";
     }

--- a/packages/expo-gl/ios/EXGL/EXGLObjectManager.h
+++ b/packages/expo-gl/ios/EXGL/EXGLObjectManager.h
@@ -1,14 +1,14 @@
 // Copyright 2016-present 650 Industries. All rights reserved.
 
-#import <UMCore/UMExportedModule.h>
-#import <UMCore/UMModuleRegistryConsumer.h>
+#import <ExpoModulesCore/EXExportedModule.h>
+#import <ExpoModulesCore/EXModuleRegistryConsumer.h>
 
-#import <UMCore/UMUIManager.h>
+#import <ExpoModulesCore/EXUIManager.h>
 #import <ExpoModulesCore/EXFileSystemInterface.h>
 
-@interface EXGLObjectManager : UMExportedModule <UMModuleRegistryConsumer>
+@interface EXGLObjectManager : EXExportedModule <EXModuleRegistryConsumer>
 
-@property (nonatomic, weak, nullable) id<UMUIManager> uiManager;
+@property (nonatomic, weak, nullable) id<EXUIManager> uiManager;
 @property (nonatomic, weak, nullable) id<EXFileSystemInterface> fileSystem;
 
 - (void)saveContext:(nonnull id)glContext;

--- a/packages/expo-gl/ios/EXGL/EXGLObjectManager.m
+++ b/packages/expo-gl/ios/EXGL/EXGLObjectManager.m
@@ -1,7 +1,7 @@
 // Copyright 2016-present 650 Industries. All rights reserved.
 
-#import <UMCore/UMModuleRegistry.h>
-#import <UMCore/UMUIManager.h>
+#import <ExpoModulesCore/EXModuleRegistry.h>
+#import <ExpoModulesCore/EXUIManager.h>
 #import <ExpoModulesCore/EXCameraInterface.h>
 
 #import <EXGL/EXGLObjectManager.h>
@@ -11,7 +11,7 @@
 
 @interface EXGLObjectManager ()
 
-@property (nonatomic, weak) UMModuleRegistry *moduleRegistry;
+@property (nonatomic, weak) EXModuleRegistry *moduleRegistry;
 @property (nonatomic, strong) NSMutableDictionary<NSNumber *, EXGLContext *> *glContexts;
 @property (nonatomic, strong) NSMutableDictionary<NSNumber *, EXGLObject *> *objects; // Key is `EXGLObjectId`
 
@@ -19,7 +19,7 @@
 
 @implementation EXGLObjectManager
 
-UM_REGISTER_MODULE();
+EX_REGISTER_MODULE();
 
 + (const NSString *)exportedModuleName
 {
@@ -40,10 +40,10 @@ UM_REGISTER_MODULE();
   return dispatch_queue_create("host.exp.exponent.GLObjectManager", DISPATCH_QUEUE_SERIAL);
 }
 
-- (void)setModuleRegistry:(UMModuleRegistry *)moduleRegistry
+- (void)setModuleRegistry:(EXModuleRegistry *)moduleRegistry
 {
   _moduleRegistry = moduleRegistry;
-  _uiManager = [moduleRegistry getModuleImplementingProtocol:@protocol(UMUIManager)];
+  _uiManager = [moduleRegistry getModuleImplementingProtocol:@protocol(EXUIManager)];
   _fileSystem = [moduleRegistry getModuleImplementingProtocol:@protocol(EXFileSystemInterface)];
 }
 
@@ -74,16 +74,16 @@ UM_REGISTER_MODULE();
 
 # pragma mark - Snapshots
 
-UM_EXPORT_METHOD_AS(takeSnapshotAsync,
+EX_EXPORT_METHOD_AS(takeSnapshotAsync,
                     takeSnapshotWithContextId:(nonnull NSNumber *)exglCtxId
                     andOptions:(nonnull NSDictionary *)options
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   EXGLContext *glContext = [self getContextWithId:exglCtxId];
   
   if (glContext == nil) {
-    reject(@"E_GL_BAD_VIEW_TAG", nil, UMErrorWithMessage(@"ExponentGLObjectManager.takeSnapshotAsync: EXGLContext not found for given context id."));
+    reject(@"E_GL_BAD_VIEW_TAG", nil, EXErrorWithMessage(@"ExponentGLObjectManager.takeSnapshotAsync: EXGLContext not found for given context id."));
     return;
   }
   
@@ -92,9 +92,9 @@ UM_EXPORT_METHOD_AS(takeSnapshotAsync,
 
 # pragma mark - Headless Context
 
-UM_EXPORT_METHOD_AS(createContextAsync,
-                    createContext:(UMPromiseResolveBlock)resolve
-                    reject:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(createContextAsync,
+                    createContext:(EXPromiseResolveBlock)resolve
+                    reject:(EXPromiseRejectBlock)reject)
 {
   EXGLContext *glContext = [[EXGLContext alloc] initWithDelegate:nil andModuleRegistry:_moduleRegistry];
   
@@ -105,16 +105,16 @@ UM_EXPORT_METHOD_AS(createContextAsync,
       reject(
              @"E_GL_CONTEXT_NOT_INITIALIZED",
              nil,
-             UMErrorWithMessage(@"ExponentGLObjectManager.createContextAsync: Unexpected error occurred when initializing headless context")
+             EXErrorWithMessage(@"ExponentGLObjectManager.createContextAsync: Unexpected error occurred when initializing headless context")
              );
     }
   }];
 }
 
-UM_EXPORT_METHOD_AS(destroyContextAsync,
+EX_EXPORT_METHOD_AS(destroyContextAsync,
                     destroyContextWithId:(nonnull NSNumber *)exglCtxId
-                    resolve:(UMPromiseResolveBlock)resolve
-                    reject:(UMPromiseRejectBlock)reject)
+                    resolve:(EXPromiseResolveBlock)resolve
+                    reject:(EXPromiseRejectBlock)reject)
 {
   EXGLContext *glContext = [self getContextWithId:exglCtxId];
   
@@ -128,31 +128,31 @@ UM_EXPORT_METHOD_AS(destroyContextAsync,
 
 # pragma mark - Camera integration
 
-UM_EXPORT_METHOD_AS(destroyObjectAsync,
+EX_EXPORT_METHOD_AS(destroyObjectAsync,
                     destroyObjectAsync:(nonnull NSNumber *)exglObjId
-                    resolve:(UMPromiseResolveBlock)resolve
-                    reject:(UMPromiseRejectBlock)reject)
+                    resolve:(EXPromiseResolveBlock)resolve
+                    reject:(EXPromiseRejectBlock)reject)
 {
   _objects[exglObjId] = nil;
   resolve(@(YES));
 }
 
-UM_EXPORT_METHOD_AS(createCameraTextureAsync,
+EX_EXPORT_METHOD_AS(createCameraTextureAsync,
                     createTextureForContextWithId:(nonnull NSNumber *)exglCtxId
                     andCameraWithReactTag:(nonnull NSNumber *)cameraViewTag
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   [_uiManager executeUIBlock:^(id view) {
     EXGLContext *glContext = [self getContextWithId:exglCtxId];
     id<EXCameraInterface> cameraView = (id<EXCameraInterface>)view;
     
     if (glContext == nil) {
-      reject(@"E_GL_BAD_VIEW_TAG", nil, UMErrorWithMessage(@"ExponentGLObjectManager.createCameraTextureAsync: Expected an EXGLView"));
+      reject(@"E_GL_BAD_VIEW_TAG", nil, EXErrorWithMessage(@"ExponentGLObjectManager.createCameraTextureAsync: Expected an EXGLView"));
       return;
     }
     if (cameraView == nil) {
-      reject(@"E_GL_BAD_CAMERA_VIEW_TAG", nil, UMErrorWithMessage(@"ExponentGLObjectManager.createCameraTextureAsync: Expected an EXCamera"));
+      reject(@"E_GL_BAD_CAMERA_VIEW_TAG", nil, EXErrorWithMessage(@"ExponentGLObjectManager.createCameraTextureAsync: Expected an EXCamera"));
       return;
     }
     

--- a/packages/expo-gl/ios/EXGL/EXGLView.h
+++ b/packages/expo-gl/ios/EXGL/EXGLView.h
@@ -2,20 +2,20 @@
 
 #import <EXGL_CPP/UEXGL.h>
 #import <EXGL/EXGLContext.h>
-#import <UMCore/UMModuleRegistry.h>
+#import <ExpoModulesCore/EXModuleRegistry.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface EXGLView : UIView <EXGLContextDelegate>
 
-- (instancetype)initWithModuleRegistry:(UMModuleRegistry *)moduleRegistry;
+- (instancetype)initWithModuleRegistry:(EXModuleRegistry *)moduleRegistry;
 - (UEXGLContextId)exglCtxId;
 
 // AR
 - (void)setArSessionManager:(id)arSessionManager;
 - (void)maybeStopARSession;
 
-@property (nonatomic, copy, nullable) UMDirectEventBlock onSurfaceCreate;
+@property (nonatomic, copy, nullable) EXDirectEventBlock onSurfaceCreate;
 @property (nonatomic, assign) NSNumber *msaaSamples;
 
 // "protected"

--- a/packages/expo-gl/ios/EXGL/EXGLView.m
+++ b/packages/expo-gl/ios/EXGL/EXGLView.m
@@ -1,6 +1,6 @@
 // Copyright 2016-present 650 Industries. All rights reserved.
 
-#import <UMCore/UMUtilities.h>
+#import <ExpoModulesCore/EXUtilities.h>
 #import <EXGL/EXGLView.h>
 #import <EXGL/EXGLContext.h>
 
@@ -40,14 +40,14 @@
   return [CAEAGLLayer class];
 }
 
-- (instancetype)initWithModuleRegistry:(UMModuleRegistry *)moduleRegistry
+- (instancetype)initWithModuleRegistry:(EXModuleRegistry *)moduleRegistry
 {
   if ((self = [super init])) {
     _isLayouted = NO;
     _renderbufferPresented = YES;
     _viewBuffersSize = CGSizeZero;
     
-    self.contentScaleFactor = [UMUtilities screenScale];
+    self.contentScaleFactor = [EXUtilities screenScale];
     
     // Initialize properties of our backing CAEAGLLayer
     CAEAGLLayer *eaglLayer = (CAEAGLLayer *) self.layer;
@@ -102,7 +102,7 @@
   [self maybeCallSurfaceCreated];
 }
 
-- (void)setOnSurfaceCreate:(UMDirectEventBlock)onSurfaceCreate
+- (void)setOnSurfaceCreate:(EXDirectEventBlock)onSurfaceCreate
 {
   _onSurfaceCreate = onSurfaceCreate;
   [self maybeCallSurfaceCreated];

--- a/packages/expo-gl/ios/EXGL/EXGLViewManager.h
+++ b/packages/expo-gl/ios/EXGL/EXGLViewManager.h
@@ -1,8 +1,8 @@
 // Copyright 2016-present 650 Industries. All rights reserved.
 
-#import <UMCore/UMViewManager.h>
-#import <UMCore/UMModuleRegistryConsumer.h>
+#import <ExpoModulesCore/EXViewManager.h>
+#import <ExpoModulesCore/EXModuleRegistryConsumer.h>
 
-@interface EXGLViewManager : UMViewManager <UMModuleRegistryConsumer>
+@interface EXGLViewManager : EXViewManager <EXModuleRegistryConsumer>
 
 @end

--- a/packages/expo-gl/ios/EXGL/EXGLViewManager.m
+++ b/packages/expo-gl/ios/EXGL/EXGLViewManager.m
@@ -2,17 +2,17 @@
 
 #import <EXGL/EXGLView.h>
 #import <EXGL/EXGLViewManager.h>
-#import <UMCore/UMUIManager.h>
+#import <ExpoModulesCore/EXUIManager.h>
 
 @interface EXGLViewManager ()
 
-@property (nonatomic, weak) UMModuleRegistry *moduleRegistry;
+@property (nonatomic, weak) EXModuleRegistry *moduleRegistry;
 
 @end
 
 @implementation EXGLViewManager
 
-UM_EXPORT_MODULE(ExponentGLViewManager);
+EX_EXPORT_MODULE(ExponentGLViewManager);
 
 - (UIView *)view
 {
@@ -29,12 +29,12 @@ UM_EXPORT_MODULE(ExponentGLViewManager);
   return @[@"onSurfaceCreate"];
 }
 
-UM_VIEW_PROPERTY(msaaSamples, NSNumber *, EXGLView)
+EX_VIEW_PROPERTY(msaaSamples, NSNumber *, EXGLView)
 {
   [view setMsaaSamples:value];
 }
 
-- (void)setModuleRegistry:(UMModuleRegistry *)moduleRegistry
+- (void)setModuleRegistry:(EXModuleRegistry *)moduleRegistry
 {
   _moduleRegistry = moduleRegistry;
 }

--- a/packages/expo-image-manipulator/CHANGELOG.md
+++ b/packages/expo-image-manipulator/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 ### 💡 Others
 
+- Migrated from `@unimodules/core` to `expo-modules-core`.
+
 ## 9.2.0 — 2021-06-16
 
 ### 🐛 Bug fixes

--- a/packages/expo-image-manipulator/CHANGELOG.md
+++ b/packages/expo-image-manipulator/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ### 💡 Others
 
-- Migrated from `@unimodules/core` to `expo-modules-core`.
+- Migrated from `@unimodules/core` to `expo-modules-core`. ([#13757](https://github.com/expo/expo/pull/13757) by [@tsapeta](https://github.com/tsapeta))
 
 ## 9.2.0 — 2021-06-16
 

--- a/packages/expo-image-manipulator/ios/EXImageManipulator.podspec
+++ b/packages/expo-image-manipulator/ios/EXImageManipulator.podspec
@@ -13,7 +13,6 @@ Pod::Spec.new do |s|
   s.platform       = :ios, '11.0'
   s.source         = { git: 'https://github.com/expo/expo.git' }
 
-  s.dependency 'UMCore'
   s.dependency 'ExpoModulesCore'
 
   if !$ExpoUseSources&.include?(package['name']) && ENV['EXPO_USE_SOURCE'].to_i == 0 && File.exist?("#{s.name}.xcframework") && Gem::Version.new(Pod::VERSION) >= Gem::Version.new('1.10.0')

--- a/packages/expo-image-manipulator/ios/EXImageManipulator/EXImageManipulatorModule.h
+++ b/packages/expo-image-manipulator/ios/EXImageManipulator/EXImageManipulatorModule.h
@@ -1,7 +1,7 @@
 //  Copyright © 2018 650 Industries. All rights reserved.
 
-#import <UMCore/UMExportedModule.h>
-#import <UMCore/UMModuleRegistryConsumer.h>
+#import <ExpoModulesCore/EXExportedModule.h>
+#import <ExpoModulesCore/EXModuleRegistryConsumer.h>
 
-@interface EXImageManipulatorModule : UMExportedModule <UMModuleRegistryConsumer>
+@interface EXImageManipulatorModule : EXExportedModule <EXModuleRegistryConsumer>
 @end

--- a/packages/expo-image-manipulator/ios/EXImageManipulator/EXImageManipulatorModule.m
+++ b/packages/expo-image-manipulator/ios/EXImageManipulator/EXImageManipulatorModule.m
@@ -7,7 +7,7 @@
 
 @interface EXImageManipulatorModule ()
 
-@property (nonatomic, weak) UMModuleRegistry *moduleRegistry;
+@property (nonatomic, weak) EXModuleRegistry *moduleRegistry;
 @property (nonatomic, weak) id<EXFileSystemInterface> fileSystem;
 @property (nonatomic, weak) id<EXImageLoaderInterface> imageLoader;
 
@@ -24,21 +24,21 @@ static NSString* const SAVE_OPTIONS_KEY_BASE64 = @"base64";
 
 @implementation EXImageManipulatorModule
 
-UM_EXPORT_MODULE(ExpoImageManipulator);
+EX_EXPORT_MODULE(ExpoImageManipulator);
 
-- (void)setModuleRegistry:(UMModuleRegistry *)moduleRegistry
+- (void)setModuleRegistry:(EXModuleRegistry *)moduleRegistry
 {
   _moduleRegistry = moduleRegistry;
   _fileSystem = [moduleRegistry getModuleImplementingProtocol:@protocol(EXFileSystemInterface)];
   _imageLoader = [moduleRegistry getModuleImplementingProtocol:@protocol(EXImageLoaderInterface)];
 }
 
-UM_EXPORT_METHOD_AS(manipulateAsync,
+EX_EXPORT_METHOD_AS(manipulateAsync,
                     uri:(NSString *)uri
                     actions:(NSArray *)actions
                     saveOptions:(NSDictionary *)saveOptions
-                    resolve:(UMPromiseResolveBlock)resolve
-                    reject:(UMPromiseRejectBlock)reject)
+                    resolve:(EXPromiseResolveBlock)resolve
+                    reject:(EXPromiseRejectBlock)reject)
 {
   NSURL *url = [NSURL URLWithString:uri];
   // no scheme provided in uri, handle as a local path and add 'file://' scheme
@@ -218,8 +218,8 @@ UM_EXPORT_METHOD_AS(manipulateAsync,
 -(void)manipulateImage:(UIImage *)image
                actions:(NSArray *)actions
            saveOptions:(NSDictionary *)saveOptions
-              resolver:(UMPromiseResolveBlock)resolve
-              rejecter:(UMPromiseRejectBlock)reject
+              resolver:(EXPromiseResolveBlock)resolve
+              rejecter:(EXPromiseRejectBlock)reject
 {
   for (NSDictionary *action in actions) {
     if (action[ACTION_KEY_RESIZE]) {

--- a/packages/expo-image-manipulator/package.json
+++ b/packages/expo-image-manipulator/package.json
@@ -30,9 +30,6 @@
   "author": "650 Industries, Inc.",
   "license": "MIT",
   "homepage": "https://docs.expo.io/versions/latest/sdk/imagemanipulator/",
-  "unimodulePeerDependencies": {
-    "@unimodules/core": "*"
-  },
   "dependencies": {
     "expo-modules-core": "~0.1.1"
   },

--- a/packages/expo-mail-composer/CHANGELOG.md
+++ b/packages/expo-mail-composer/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- Migrated from `@unimodules/core` to `expo-modules-core`.
+
 ## 10.2.0 — 2021-06-16
 
 ### 🐛 Bug fixes

--- a/packages/expo-mail-composer/CHANGELOG.md
+++ b/packages/expo-mail-composer/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### 💡 Others
 
-- Migrated from `@unimodules/core` to `expo-modules-core`.
+- Migrated from `@unimodules/core` to `expo-modules-core`. ([#13757](https://github.com/expo/expo/pull/13757) by [@tsapeta](https://github.com/tsapeta))
 
 ## 10.2.0 — 2021-06-16
 

--- a/packages/expo-mail-composer/ios/EXMailComposer.podspec
+++ b/packages/expo-mail-composer/ios/EXMailComposer.podspec
@@ -13,7 +13,6 @@ Pod::Spec.new do |s|
   s.platform       = :ios, '11.0'
   s.source         = { git: 'https://github.com/expo/expo.git' }
 
-  s.dependency 'UMCore'
   s.dependency 'ExpoModulesCore'
 
   if !$ExpoUseSources&.include?(package['name']) && ENV['EXPO_USE_SOURCE'].to_i == 0 && File.exist?("#{s.name}.xcframework") && Gem::Version.new(Pod::VERSION) >= Gem::Version.new('1.10.0')

--- a/packages/expo-mail-composer/ios/EXMailComposer/EXMailComposer.h
+++ b/packages/expo-mail-composer/ios/EXMailComposer/EXMailComposer.h
@@ -1,9 +1,9 @@
 // Copyright 2017-present 650 Industries. All rights reserved.
 
-#import <UMCore/UMExportedModule.h>
-#import <UMCore/UMModuleRegistryConsumer.h>
+#import <ExpoModulesCore/EXExportedModule.h>
+#import <ExpoModulesCore/EXModuleRegistryConsumer.h>
 
 #import <MessageUI/MessageUI.h>
 
-@interface EXMailComposer : UMExportedModule <UMModuleRegistryConsumer, MFMailComposeViewControllerDelegate>
+@interface EXMailComposer : EXExportedModule <EXModuleRegistryConsumer, MFMailComposeViewControllerDelegate>
 @end

--- a/packages/expo-mail-composer/ios/EXMailComposer/EXMailComposer.m
+++ b/packages/expo-mail-composer/ios/EXMailComposer/EXMailComposer.m
@@ -3,23 +3,23 @@
 #import <EXMailComposer/EXMailComposer.h>
 #import <MobileCoreServices/MobileCoreServices.h>
 
-#import <UMCore/UMUtilitiesInterface.h>
+#import <ExpoModulesCore/EXUtilitiesInterface.h>
 #import <ExpoModulesCore/EXFileSystemInterface.h>
 
 @interface EXMailComposer ()
 
-@property (nonatomic, weak) UMModuleRegistry *moduleRegistry;
+@property (nonatomic, weak) EXModuleRegistry *moduleRegistry;
 
-@property (nonatomic, strong) UMPromiseResolveBlock resolve;
-@property (nonatomic, strong) UMPromiseRejectBlock reject;
+@property (nonatomic, strong) EXPromiseResolveBlock resolve;
+@property (nonatomic, strong) EXPromiseRejectBlock reject;
 
 @end
 
 @implementation EXMailComposer
 
-UM_EXPORT_MODULE(ExpoMailComposer);
+EX_EXPORT_MODULE(ExpoMailComposer);
 
-- (void)setModuleRegistry:(UMModuleRegistry *)moduleRegistry
+- (void)setModuleRegistry:(EXModuleRegistry *)moduleRegistry
 {
   _moduleRegistry = moduleRegistry;
 }
@@ -29,18 +29,18 @@ UM_EXPORT_MODULE(ExpoMailComposer);
   return dispatch_get_main_queue();
 }
 
-UM_EXPORT_METHOD_AS(isAvailableAsync,
-                    isAvailable:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(isAvailableAsync,
+                    isAvailable:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   resolve(@([MFMailComposeViewController canSendMail]));
 }
 
 
-UM_EXPORT_METHOD_AS(composeAsync,
+EX_EXPORT_METHOD_AS(composeAsync,
                     composeAsync:(NSDictionary *)options
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   if (![MFMailComposeViewController canSendMail]) {
     reject(@"E_COMPOSE_UNAVAILABLE", @"Mail services are not available. Make sure you're signed into the Mail app", nil);
@@ -118,7 +118,7 @@ UM_EXPORT_METHOD_AS(composeAsync,
 
   self.resolve = resolve;
   self.reject = reject;
-  id<UMUtilitiesInterface> utilities = [_moduleRegistry getModuleImplementingProtocol:@protocol(UMUtilitiesInterface)];
+  id<EXUtilitiesInterface> utilities = [_moduleRegistry getModuleImplementingProtocol:@protocol(EXUtilitiesInterface)];
   [utilities.currentViewController presentViewController:composeController animated:YES completion:nil];
 }
 

--- a/packages/expo-mail-composer/package.json
+++ b/packages/expo-mail-composer/package.json
@@ -34,9 +34,6 @@
   "jest": {
     "preset": "expo-module-scripts/ios"
   },
-  "unimodulePeerDependencies": {
-    "@unimodules/core": "*"
-  },
   "dependencies": {
     "expo-modules-core": "~0.1.1",
     "query-string": "^6.2.0"

--- a/packages/expo-network/CHANGELOG.md
+++ b/packages/expo-network/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Migrated from `@unimodules/core` to `expo-modules-core`.
+
 ## 3.2.0 — 2021-06-16
 
 ### 🐛 Bug fixes

--- a/packages/expo-network/CHANGELOG.md
+++ b/packages/expo-network/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Migrated from `@unimodules/core` to `expo-modules-core`.
+- Migrated from `@unimodules/core` to `expo-modules-core`. ([#13757](https://github.com/expo/expo/pull/13757) by [@tsapeta](https://github.com/tsapeta))
 
 ## 3.2.0 — 2021-06-16
 

--- a/packages/expo-network/ios/EXNetwork.podspec
+++ b/packages/expo-network/ios/EXNetwork.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.platform       = :ios, '11.0'
   s.source         = { git: 'https://github.com/expo/expo.git' }
 
-  s.dependency 'UMCore'
+  s.dependency 'ExpoModulesCore'
   
   if !$ExpoUseSources&.include?(package['name']) && ENV['EXPO_USE_SOURCE'].to_i == 0 && File.exist?("#{s.name}.xcframework") && Gem::Version.new(Pod::VERSION) >= Gem::Version.new('1.10.0')
     s.source_files = "#{s.name}/**/*.h"

--- a/packages/expo-network/ios/EXNetwork/EXNetwork.h
+++ b/packages/expo-network/ios/EXNetwork/EXNetwork.h
@@ -1,7 +1,7 @@
 //  Copyright © 2018 650 Industries. All rights reserved.
 
-#import <UMCore/UMExportedModule.h>
-#import <UMCore/UMModuleRegistryConsumer.h>
+#import <ExpoModulesCore/EXExportedModule.h>
+#import <ExpoModulesCore/EXModuleRegistryConsumer.h>
 
 static NSString *const EXNetworkTypeUnknown = @"UNKNOWN";
 static NSString *const EXNetworkTypeNone = @"NONE";
@@ -9,5 +9,5 @@ static NSString *const EXNetworkTypeWifi = @"WIFI";
 static NSString *const EXNetworkTypeCellular = @"CELLULAR";
 
 
-@interface EXNetwork : UMExportedModule <UMModuleRegistryConsumer>
+@interface EXNetwork : EXExportedModule <EXModuleRegistryConsumer>
 @end

--- a/packages/expo-network/ios/EXNetwork/EXNetwork.m
+++ b/packages/expo-network/ios/EXNetwork/EXNetwork.m
@@ -9,7 +9,7 @@
 
 @interface EXNetwork ()
 
-@property (nonatomic, weak) UMModuleRegistry *moduleRegistry;
+@property (nonatomic, weak) EXModuleRegistry *moduleRegistry;
 @property (nonatomic) SCNetworkReachabilityRef reachabilityRef;
 @property (nonatomic) SCNetworkReachabilityFlags lastFlags;
 @property (nonatomic) NSString *type;
@@ -28,15 +28,15 @@
   return self;
 }
 
-UM_EXPORT_MODULE(ExpoNetwork);
+EX_EXPORT_MODULE(ExpoNetwork);
 
-- (void)setModuleRegistry:(UMModuleRegistry *)moduleRegistry
+- (void)setModuleRegistry:(EXModuleRegistry *)moduleRegistry
 {
   _moduleRegistry = moduleRegistry;
 }
 
-UM_EXPORT_METHOD_AS(getIpAddressAsync,
-                    getIpAddressAsyncWithResolver:(UMPromiseResolveBlock)resolve rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(getIpAddressAsync,
+                    getIpAddressAsyncWithResolver:(EXPromiseResolveBlock)resolve rejecter:(EXPromiseRejectBlock)reject)
 {
   NSString *address = @"0.0.0.0";
   struct ifaddrs *interfaces = NULL;
@@ -69,9 +69,9 @@ UM_EXPORT_METHOD_AS(getIpAddressAsync,
   freeifaddrs(interfaces);
 }
 
-UM_EXPORT_METHOD_AS(getNetworkStateAsync,
-                    getNetworkStateAsyncWithResolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(getNetworkStateAsync,
+                    getNetworkStateAsyncWithResolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   _reachabilityRef =  [self createReachabilityRef];
   SCNetworkReachabilityFlags flags = [self lastFlags];

--- a/packages/expo-network/package.json
+++ b/packages/expo-network/package.json
@@ -26,10 +26,13 @@
   "bugs": {
     "url": "https://github.com/expo/expo/issues"
   },
-  "devDependencies": {
-    "expo-module-scripts": "^2.0.0"
-  },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/network/"
+  "homepage": "https://docs.expo.io/versions/latest/sdk/network/",
+  "dependencies": {
+    "expo-modules-core": "~0.1.1"
+  },
+  "devDependencies": {
+    "expo-module-scripts": "^2.0.0"
+  }
 }

--- a/packages/expo-permissions/CHANGELOG.md
+++ b/packages/expo-permissions/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Migrated from `@unimodules/core` to `expo-modules-core`.
+
 ## 12.1.0 — 2021-06-16
 
 ### 🐛 Bug fixes

--- a/packages/expo-permissions/CHANGELOG.md
+++ b/packages/expo-permissions/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Migrated from `@unimodules/core` to `expo-modules-core`.
+- Migrated from `@unimodules/core` to `expo-modules-core`. ([#13757](https://github.com/expo/expo/pull/13757) by [@tsapeta](https://github.com/tsapeta))
 
 ## 12.1.0 — 2021-06-16
 

--- a/packages/expo-permissions/ios/EXPermissions.podspec
+++ b/packages/expo-permissions/ios/EXPermissions.podspec
@@ -13,7 +13,6 @@ Pod::Spec.new do |s|
   s.platform        = :ios, '11.0'
   s.source          = { git: 'https://github.com/expo/expo.git' }
 
-  s.dependency 'UMCore'
   s.dependency 'ExpoModulesCore'
 
   if !$ExpoUseSources&.include?(package['name']) && ENV['EXPO_USE_SOURCE'].to_i == 0 && File.exist?("#{s.name}.xcframework") && Gem::Version.new(Pod::VERSION) >= Gem::Version.new('1.10.0')

--- a/packages/expo-permissions/ios/EXPermissions/EXPermissions.h
+++ b/packages/expo-permissions/ios/EXPermissions/EXPermissions.h
@@ -1,8 +1,8 @@
 // Copyright 2016-present 650 Industries. All rights reserved.
 
-#import <UMCore/UMExportedModule.h>
-#import <UMCore/UMModuleRegistryConsumer.h>
+#import <ExpoModulesCore/EXExportedModule.h>
+#import <ExpoModulesCore/EXModuleRegistryConsumer.h>
 
-@interface EXPermissions : UMExportedModule <UMModuleRegistryConsumer>
+@interface EXPermissions : EXExportedModule <EXModuleRegistryConsumer>
 
 @end

--- a/packages/expo-permissions/ios/EXPermissions/EXPermissions.m
+++ b/packages/expo-permissions/ios/EXPermissions/EXPermissions.m
@@ -12,19 +12,19 @@
 
 @implementation EXPermissions
 
-UM_EXPORT_MODULE(ExpoPermissions);
+EX_EXPORT_MODULE(ExpoPermissions);
 
-- (void)setModuleRegistry:(UMModuleRegistry *)moduleRegistry
+- (void)setModuleRegistry:(EXModuleRegistry *)moduleRegistry
 {
   _permissionsService = [moduleRegistry getModuleImplementingProtocol:@protocol(EXPermissionsInterface)];
 }
 
 # pragma mark - Exported methods
 
-UM_EXPORT_METHOD_AS(getAsync,
+EX_EXPORT_METHOD_AS(getAsync,
                     getPermissionWithType:(NSString *)permissionType
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   id<EXPermissionsRequester> requester = [_permissionsService getPermissionRequesterForType:permissionType];
   if (requester == nil) {
@@ -35,10 +35,10 @@ UM_EXPORT_METHOD_AS(getAsync,
                                                  reject:reject];
 }
 
-UM_EXPORT_METHOD_AS(askAsync,
+EX_EXPORT_METHOD_AS(askAsync,
                     askAsyncForPermission:(NSString *)permissionType
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   id<EXPermissionsRequester> requester = [_permissionsService getPermissionRequesterForType:permissionType];
   if (requester == nil) {

--- a/packages/expo-print/CHANGELOG.md
+++ b/packages/expo-print/CHANGELOG.md
@@ -13,7 +13,7 @@
 ### 💡 Others
 
 - Rewrite print module from Java to Kotlin. ([#13538](https://github.com/expo/expo/pull/13538) by [@mstach60161](https://github.com/mstach60161))
-- Migrated from `@unimodules/core` to `expo-modules-core`.
+- Migrated from `@unimodules/core` to `expo-modules-core`. ([#13757](https://github.com/expo/expo/pull/13757) by [@tsapeta](https://github.com/tsapeta))
 
 ## 10.2.0 — 2021-06-16
 

--- a/packages/expo-print/CHANGELOG.md
+++ b/packages/expo-print/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 💡 Others
 
 - Rewrite print module from Java to Kotlin. ([#13538](https://github.com/expo/expo/pull/13538) by [@mstach60161](https://github.com/mstach60161))
+- Migrated from `@unimodules/core` to `expo-modules-core`.
 
 ## 10.2.0 — 2021-06-16
 

--- a/packages/expo-print/ios/EXPrint.podspec
+++ b/packages/expo-print/ios/EXPrint.podspec
@@ -13,7 +13,6 @@ Pod::Spec.new do |s|
   s.platform       = :ios, '11.0'
   s.source         = { git: 'https://github.com/expo/expo.git' }
 
-  s.dependency 'UMCore'
   s.dependency 'ExpoModulesCore'
 
   if !$ExpoUseSources&.include?(package['name']) && ENV['EXPO_USE_SOURCE'].to_i == 0 && File.exist?("#{s.name}.xcframework") && Gem::Version.new(Pod::VERSION) >= Gem::Version.new('1.10.0')

--- a/packages/expo-print/ios/EXPrint/EXPrint.h
+++ b/packages/expo-print/ios/EXPrint/EXPrint.h
@@ -1,10 +1,10 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
-#import <UMCore/UMModuleRegistry.h>
-#import <UMCore/UMAppLifecycleListener.h>
-#import <UMCore/UMModuleRegistryConsumer.h>
+#import <ExpoModulesCore/EXModuleRegistry.h>
+#import <ExpoModulesCore/EXAppLifecycleListener.h>
+#import <ExpoModulesCore/EXModuleRegistryConsumer.h>
 #import <UIKit/UIKit.h>
 
-@interface EXPrint : UMExportedModule <UMModuleRegistryConsumer>
+@interface EXPrint : EXExportedModule <EXModuleRegistryConsumer>
 
 @end

--- a/packages/expo-print/ios/EXPrint/EXPrint.m
+++ b/packages/expo-print/ios/EXPrint/EXPrint.m
@@ -2,7 +2,7 @@
 
 #import <EXPrint/EXPrint.h>
 #import <EXPrint/EXWKPDFRenderer.h>
-#import <UMCore/UMUtilitiesInterface.h>
+#import <ExpoModulesCore/EXUtilitiesInterface.h>
 #import <ExpoModulesCore/EXFileSystemInterface.h>
 
 NSString *const EXPrintOrientationPortrait = @"portrait";
@@ -12,13 +12,13 @@ NSString *const EXPrintOrientationLandscape = @"landscape";
 
 @property (nonatomic, strong) NSMutableDictionary<NSString *, UIPrinter *> *printers;
 
-@property (nonatomic, weak) UMModuleRegistry *moduleRegistry;
+@property (nonatomic, weak) EXModuleRegistry *moduleRegistry;
 
 @end
 
 @implementation EXPrint
 
-UM_EXPORT_MODULE(ExponentPrint);
+EX_EXPORT_MODULE(ExponentPrint);
 
 - (instancetype)init
 {
@@ -28,7 +28,7 @@ UM_EXPORT_MODULE(ExponentPrint);
   return self;
 }
 
-- (void)setModuleRegistry:(UMModuleRegistry *)moduleRegistry
+- (void)setModuleRegistry:(EXModuleRegistry *)moduleRegistry
 {
   _moduleRegistry = moduleRegistry;
 }
@@ -53,14 +53,14 @@ UM_EXPORT_MODULE(ExponentPrint);
            };
 }
 
-UM_EXPORT_METHOD_AS(print,
+EX_EXPORT_METHOD_AS(print,
                     print:(NSDictionary *)options
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   [self _getPrintingDataForOptions:options callback:^(NSData *printingData, NSDictionary *errorDetails) {
     if (errorDetails != nil) {
-      reject(errorDetails[@"code"], errorDetails[@"message"], UMErrorWithMessage(errorDetails[@"message"]));
+      reject(errorDetails[@"code"], errorDetails[@"message"], EXErrorWithMessage(errorDetails[@"message"]));
       return;
     }
     
@@ -79,7 +79,7 @@ UM_EXPORT_METHOD_AS(print,
           printInteractionController.printFormatter = formatter;
         } else {
           NSString *message = [NSString stringWithFormat:@"The specified html string is not valid for printing."];
-          reject(@"E_HTML_INVALID", message, UMErrorWithMessage(message));
+          reject(@"E_HTML_INVALID", message, EXErrorWithMessage(message));
           return;
         }
       } else {
@@ -134,8 +134,8 @@ UM_EXPORT_METHOD_AS(print,
   }];
 }
 
-UM_EXPORT_METHOD_AS(selectPrinter,selectPrinter:(UMPromiseResolveBlock)resolve
-                  rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(selectPrinter,selectPrinter:(EXPromiseResolveBlock)resolve
+                  rejecter:(EXPromiseRejectBlock)reject)
 {
   UIPrinterPickerController *printPicker = [UIPrinterPickerController printerPickerControllerWithInitiallySelectedPrinter:nil];
   
@@ -168,10 +168,10 @@ UM_EXPORT_METHOD_AS(selectPrinter,selectPrinter:(UMPromiseResolveBlock)resolve
   }
 }
 
-UM_EXPORT_METHOD_AS(printToFileAsync,
+EX_EXPORT_METHOD_AS(printToFileAsync,
                     printToFileWithOptions:(nonnull NSDictionary *)options
-                    resolve:(UMPromiseResolveBlock)resolve
-                    reject:(UMPromiseRejectBlock)reject)
+                    resolve:(EXPromiseResolveBlock)resolve
+                    reject:(EXPromiseRejectBlock)reject)
 {
   NSString *format = options[@"format"];
   
@@ -221,7 +221,7 @@ UM_EXPORT_METHOD_AS(printToFileAsync,
 
 - (UIViewController *)printInteractionControllerParentViewController:(UIPrintInteractionController *)printInteractionController
 {
-  id<UMUtilitiesInterface> utils = [_moduleRegistry getModuleImplementingProtocol:@protocol(UMUtilitiesInterface)];
+  id<EXUtilitiesInterface> utils = [_moduleRegistry getModuleImplementingProtocol:@protocol(EXUtilitiesInterface)];
   return utils.currentViewController;
 }
 
@@ -229,7 +229,7 @@ UM_EXPORT_METHOD_AS(printToFileAsync,
 
 - (UIViewController *)printerPickerControllerParentViewController:(UIPrinterPickerController *)printerPickerController
 {
-  id<UMUtilitiesInterface> utils = [_moduleRegistry getModuleImplementingProtocol:@protocol(UMUtilitiesInterface)];
+  id<EXUtilitiesInterface> utils = [_moduleRegistry getModuleImplementingProtocol:@protocol(EXUtilitiesInterface)];
   return utils.currentViewController;
 }
 

--- a/packages/expo-print/ios/EXPrint/EXWKPDFRenderer.m
+++ b/packages/expo-print/ios/EXPrint/EXWKPDFRenderer.m
@@ -1,7 +1,7 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
 #import <EXPrint/EXWKPDFRenderer.h>
-#import <UMCore/UMDefines.h>
+#import <ExpoModulesCore/EXDefines.h>
 #import <EXPrint/EXWKSnapshotPDFRenderer.h>
 
 @interface EXWKPDFRenderer () <WKNavigationDelegate>
@@ -33,9 +33,9 @@
     return;
   }
 
-  UM_WEAKIFY(self);
+  EX_WEAKIFY(self);
   [_renderer PDFFromWebView:webView completionHandler:^(NSError * _Nullable error, NSData * _Nullable data, int pagesCount) {
-    UM_ENSURE_STRONGIFY(self);
+    EX_ENSURE_STRONGIFY(self);
     self.onRenderingFinished(error, data, pagesCount);
   }];
 }

--- a/packages/expo-print/ios/EXPrint/EXWKSnapshotPDFRenderer.m
+++ b/packages/expo-print/ios/EXPrint/EXWKSnapshotPDFRenderer.m
@@ -1,7 +1,7 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
 #import <EXPrint/EXWKSnapshotPDFRenderer.h>
-#import <UMCore/UMDefines.h>
+#import <ExpoModulesCore/EXDefines.h>
 
 @interface EXWKSnapshotPDFRenderer ()
 
@@ -11,9 +11,9 @@
 
 - (void)PDFFromWebView:(WKWebView *)webView completionHandler:(void (^)(NSError * _Nullable, NSData * _Nullable, int))handler
 {
-  UM_WEAKIFY(self);
+  EX_WEAKIFY(self);
   [webView evaluateJavaScript:@"window.innerHeight + ' ' + document.documentElement.scrollHeight" completionHandler:^(id jsResult, NSError * _Nullable error) {
-    UM_ENSURE_STRONGIFY(self);
+    EX_ENSURE_STRONGIFY(self);
     NSString *jsResultString = jsResult;
     NSArray *items = [jsResultString componentsSeparatedByString:@" "];
     CGFloat pageHeight = [items[0] doubleValue];
@@ -58,7 +58,7 @@
       }
     }];
   } else {
-    NSError *error = UMErrorWithMessage(@"Unexpected error occurred - on iOS under 11.0 use EXWKViewPDFRenderer.");
+    NSError *error = EXErrorWithMessage(@"Unexpected error occurred - on iOS under 11.0 use EXWKViewPDFRenderer.");
     completionHandler(error);
   }
 }

--- a/packages/expo-secure-store/CHANGELOG.md
+++ b/packages/expo-secure-store/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Migrated from `@unimodules/core` to `expo-modules-core`.
+
 ## 10.2.0 — 2021-06-16
 
 ### 🐛 Bug fixes

--- a/packages/expo-secure-store/CHANGELOG.md
+++ b/packages/expo-secure-store/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Migrated from `@unimodules/core` to `expo-modules-core`.
+- Migrated from `@unimodules/core` to `expo-modules-core`. ([#13757](https://github.com/expo/expo/pull/13757) by [@tsapeta](https://github.com/tsapeta))
 
 ## 10.2.0 — 2021-06-16
 

--- a/packages/expo-secure-store/ios/EXSecureStore.podspec
+++ b/packages/expo-secure-store/ios/EXSecureStore.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.platform       = :ios, '11.0'
   s.source         = { git: 'https://github.com/expo/expo.git' }
 
-  s.dependency 'UMCore'
+  s.dependency 'ExpoModulesCore'
 
   if !$ExpoUseSources&.include?(package['name']) && ENV['EXPO_USE_SOURCE'].to_i == 0 && File.exist?("#{s.name}.xcframework") && Gem::Version.new(Pod::VERSION) >= Gem::Version.new('1.10.0')
     s.source_files = "#{s.name}/**/*.h"

--- a/packages/expo-secure-store/ios/EXSecureStore/EXSecureStore.h
+++ b/packages/expo-secure-store/ios/EXSecureStore/EXSecureStore.h
@@ -1,7 +1,7 @@
 //  Copyright © 2018 650 Industries. All rights reserved.
 
-#import <UMCore/UMExportedModule.h>
-#import <UMCore/UMModuleRegistryConsumer.h>
+#import <ExpoModulesCore/EXExportedModule.h>
+#import <ExpoModulesCore/EXModuleRegistryConsumer.h>
 
 typedef NS_ENUM(NSInteger, EXSecureStoreAccessible) {
   EXSecureStoreAccessibleAfterFirstUnlock = 0,
@@ -13,6 +13,6 @@ typedef NS_ENUM(NSInteger, EXSecureStoreAccessible) {
   EXSecureStoreAccessibleWhenUnlockedThisDeviceOnly = 6
 };
 
-@interface EXSecureStore : UMExportedModule
+@interface EXSecureStore : EXExportedModule
 
 @end

--- a/packages/expo-secure-store/ios/EXSecureStore/EXSecureStore.m
+++ b/packages/expo-secure-store/ios/EXSecureStore/EXSecureStore.m
@@ -200,18 +200,18 @@
            };
 };
 
-UM_EXPORT_MODULE(ExpoSecureStore);
+EX_EXPORT_MODULE(ExpoSecureStore);
 
-UM_EXPORT_METHOD_AS(setValueWithKeyAsync,
+EX_EXPORT_METHOD_AS(setValueWithKeyAsync,
                     setValueWithKeyAsync:(NSString *)value
                     key:(NSString *)key
                     options:(NSDictionary *)options
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   NSString *validatedKey = [self validatedKey:key];
   if (!validatedKey) {
-    reject(@"E_SECURESTORE_SETVALUEFAIL", nil, UMErrorWithMessage(@"Invalid key."));
+    reject(@"E_SECURESTORE_SETVALUEFAIL", nil, EXErrorWithMessage(@"Invalid key."));
   } else {
     NSError *error;
     BOOL setValue = [self _setValue:value
@@ -221,20 +221,20 @@ UM_EXPORT_METHOD_AS(setValueWithKeyAsync,
     if (setValue) {
       resolve(nil);
     } else {
-      reject(@"E_SECURESTORE_SETVALUEFAIL", nil, UMErrorWithMessage([[self class] _messageForError:error]));
+      reject(@"E_SECURESTORE_SETVALUEFAIL", nil, EXErrorWithMessage([[self class] _messageForError:error]));
     }
   }
 }
 
-UM_EXPORT_METHOD_AS(getValueWithKeyAsync,
+EX_EXPORT_METHOD_AS(getValueWithKeyAsync,
                     getValueWithKeyAsync:(NSString *)key
                     options:(NSDictionary *)options
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   NSString *validatedKey = [self validatedKey:key];
   if (!validatedKey) {
-    reject(@"E_SECURESTORE_GETVALUEFAIL", nil, UMErrorWithMessage(@"Invalid key."));
+    reject(@"E_SECURESTORE_GETVALUEFAIL", nil, EXErrorWithMessage(@"Invalid key."));
   } else {
     NSError *error;
     NSString *value = [self _getValueWithKey:validatedKey
@@ -244,7 +244,7 @@ UM_EXPORT_METHOD_AS(getValueWithKeyAsync,
       if (error.code == errSecItemNotFound) {
         resolve([NSNull null]);
       } else {
-        reject(@"E_SECURESTORE_GETVALUEFAIL", nil, UMErrorWithMessage([[self class] _messageForError:error]));
+        reject(@"E_SECURESTORE_GETVALUEFAIL", nil, EXErrorWithMessage([[self class] _messageForError:error]));
       }
     } else {
       resolve(value);
@@ -252,15 +252,15 @@ UM_EXPORT_METHOD_AS(getValueWithKeyAsync,
   }
 }
 
-UM_EXPORT_METHOD_AS(deleteValueWithKeyAsync,
+EX_EXPORT_METHOD_AS(deleteValueWithKeyAsync,
                     deleteValueWithKeyAsync:(NSString *)key
                     options:(NSDictionary *)options
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   NSString *validatedKey = [self validatedKey:key];
   if (!validatedKey) {
-    reject(@"E_SECURESTORE_DELETEVALUEFAIL", nil, UMErrorWithMessage(@"Invalid key."));
+    reject(@"E_SECURESTORE_DELETEVALUEFAIL", nil, EXErrorWithMessage(@"Invalid key."));
   } else {
     [self _deleteValueWithKey:validatedKey
                   withOptions:options];

--- a/packages/expo-secure-store/package.json
+++ b/packages/expo-secure-store/package.json
@@ -35,8 +35,8 @@
   "jest": {
     "preset": "expo-module-scripts"
   },
-  "unimodulePeerDependencies": {
-    "@unimodules/core": "*"
+  "dependencies": {
+    "expo-modules-core": "~0.1.1"
   },
   "devDependencies": {
     "expo-module-scripts": "^2.0.0"

--- a/packages/expo-sharing/CHANGELOG.md
+++ b/packages/expo-sharing/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Migrated from `@unimodules/core` to `expo-modules-core`.
+- Migrated from `@unimodules/core` to `expo-modules-core`. ([#13757](https://github.com/expo/expo/pull/13757) by [@tsapeta](https://github.com/tsapeta))
 
 ## 9.2.0 — 2021-06-16
 

--- a/packages/expo-sharing/CHANGELOG.md
+++ b/packages/expo-sharing/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Migrated from `@unimodules/core` to `expo-modules-core`.
+
 ## 9.2.0 — 2021-06-16
 
 ### 🐛 Bug fixes

--- a/packages/expo-sharing/ios/EXSharing.podspec
+++ b/packages/expo-sharing/ios/EXSharing.podspec
@@ -13,7 +13,6 @@ Pod::Spec.new do |s|
   s.platform       = :ios, '11.0'
   s.source         = { git: 'https://github.com/expo/expo.git' }
 
-  s.dependency 'UMCore'
   s.dependency 'ExpoModulesCore'
 
   if !$ExpoUseSources&.include?(package['name']) && ENV['EXPO_USE_SOURCE'].to_i == 0 && File.exist?("#{s.name}.xcframework") && Gem::Version.new(Pod::VERSION) >= Gem::Version.new('1.10.0')

--- a/packages/expo-sharing/ios/EXSharing/EXSharingModule.h
+++ b/packages/expo-sharing/ios/EXSharing/EXSharingModule.h
@@ -1,8 +1,8 @@
 //  Copyright © 2018 650 Industries. All rights reserved.
 
-#import <UMCore/UMExportedModule.h>
-#import <UMCore/UMModuleRegistryConsumer.h>
+#import <ExpoModulesCore/EXExportedModule.h>
+#import <ExpoModulesCore/EXModuleRegistryConsumer.h>
 #import <UIKit/UIKit.h>
 
-@interface EXSharingModule : UMExportedModule <UMModuleRegistryConsumer, UIDocumentInteractionControllerDelegate>
+@interface EXSharingModule : EXExportedModule <EXModuleRegistryConsumer, UIDocumentInteractionControllerDelegate>
 @end

--- a/packages/expo-sharing/ios/EXSharing/EXSharingModule.m
+++ b/packages/expo-sharing/ios/EXSharing/EXSharingModule.m
@@ -1,37 +1,37 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
 #import <EXSharing/EXSharingModule.h>
-#import <UMCore/UMUtilitiesInterface.h>
+#import <ExpoModulesCore/EXUtilitiesInterface.h>
 #import <ExpoModulesCore/EXFileSystemInterface.h>
 #import <ExpoModulesCore/EXFilePermissionModuleInterface.h>
 
 @interface EXSharingModule ()
 
-@property (nonatomic, weak) UMModuleRegistry *moduleRegistry;
+@property (nonatomic, weak) EXModuleRegistry *moduleRegistry;
 @property (nonatomic, strong) UIDocumentInteractionController *documentInteractionController;
 
-@property (nonatomic, strong) UMPromiseResolveBlock pendingResolver;
+@property (nonatomic, strong) EXPromiseResolveBlock pendingResolver;
 
 @end
 
 @implementation EXSharingModule
 
-UM_EXPORT_MODULE(ExpoSharing);
+EX_EXPORT_MODULE(ExpoSharing);
 
-- (void)setModuleRegistry:(UMModuleRegistry *)moduleRegistry
+- (void)setModuleRegistry:(EXModuleRegistry *)moduleRegistry
 {
   _moduleRegistry = moduleRegistry;
 }
 
-UM_EXPORT_METHOD_AS(shareAsync,
+EX_EXPORT_METHOD_AS(shareAsync,
                     fileUrl:(NSString *)fileUrl
                     params:(NSDictionary *)params
-                    resolve:(UMPromiseResolveBlock)resolve
-                    reject:(UMPromiseRejectBlock)reject)
+                    resolve:(EXPromiseResolveBlock)resolve
+                    reject:(EXPromiseRejectBlock)reject)
 {
   if (_documentInteractionController) {
     NSString *errorMessage = @"Another item is being shared. Await the `shareAsync` request and then share the item again.";
-    reject(@"E_SHARING_MUL", errorMessage, UMErrorWithMessage(errorMessage));
+    reject(@"E_SHARING_MUL", errorMessage, EXErrorWithMessage(errorMessage));
     return;
   }
 
@@ -40,7 +40,7 @@ UM_EXPORT_METHOD_AS(shareAsync,
   id<EXFilePermissionModuleInterface> filePermissionsModule = [_moduleRegistry getModuleImplementingProtocol:@protocol(EXFilePermissionModuleInterface)];
   if (filePermissionsModule && !([filePermissionsModule getPathPermissions:url.path] & EXFileSystemPermissionRead)) {
     NSString *errorMessage = @"You don't have access to provided file.";
-    reject(@"E_SHARING_PERM", errorMessage, UMErrorWithMessage(errorMessage));
+    reject(@"E_SHARING_PERM", errorMessage, EXErrorWithMessage(errorMessage));
     return;
   }
 
@@ -48,11 +48,11 @@ UM_EXPORT_METHOD_AS(shareAsync,
   _documentInteractionController.delegate = self;
   _documentInteractionController.UTI = params[@"UTI"];
 
-  UIViewController *viewController = [[_moduleRegistry getModuleImplementingProtocol:@protocol(UMUtilitiesInterface)] currentViewController];
+  UIViewController *viewController = [[_moduleRegistry getModuleImplementingProtocol:@protocol(EXUtilitiesInterface)] currentViewController];
 
-  UM_WEAKIFY(self);
+  EX_WEAKIFY(self);
   dispatch_async(dispatch_get_main_queue(), ^{
-    UM_ENSURE_STRONGIFY(self);
+    EX_ENSURE_STRONGIFY(self);
     UIView *rootView = [viewController view];
     if ([self.documentInteractionController presentOpenInMenuFromRect:CGRectZero inView:rootView animated:YES]) {
       self.pendingResolver = resolve;

--- a/packages/expo-sharing/package.json
+++ b/packages/expo-sharing/package.json
@@ -30,9 +30,6 @@
   "author": "650 Industries, Inc.",
   "license": "MIT",
   "homepage": "https://docs.expo.io/versions/latest/sdk/sharing/",
-  "unimodulePeerDependencies": {
-    "@unimodules/core": "*"
-  },
   "dependencies": {
     "expo-modules-core": "~0.1.1"
   },

--- a/packages/expo-sms/CHANGELOG.md
+++ b/packages/expo-sms/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### 💡 Others
 
 - Added unit tests ([#13674](https://github.com/expo/expo/pull/13674) by [@kkafar](https://github.com/kkafar))
+- Migrated from `@unimodules/core` to `expo-modules-core`.
 
 ## 9.2.0 — 2021-06-16
 

--- a/packages/expo-sms/CHANGELOG.md
+++ b/packages/expo-sms/CHANGELOG.md
@@ -16,7 +16,7 @@
 ### 💡 Others
 
 - Added unit tests ([#13674](https://github.com/expo/expo/pull/13674) by [@kkafar](https://github.com/kkafar))
-- Migrated from `@unimodules/core` to `expo-modules-core`.
+- Migrated from `@unimodules/core` to `expo-modules-core`. ([#13757](https://github.com/expo/expo/pull/13757) by [@tsapeta](https://github.com/tsapeta))
 
 ## 9.2.0 — 2021-06-16
 

--- a/packages/expo-sms/ios/EXSMS.podspec
+++ b/packages/expo-sms/ios/EXSMS.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.platform       = :ios, '11.0'
   s.source         = { git: 'https://github.com/expo/expo.git' }
 
-  s.dependency 'UMCore'
+  s.dependency 'ExpoModulesCore'
 
   if !$ExpoUseSources&.include?(package['name']) && ENV['EXPO_USE_SOURCE'].to_i == 0 && File.exist?("#{s.name}.xcframework") && Gem::Version.new(Pod::VERSION) >= Gem::Version.new('1.10.0')
     s.source_files = "#{s.name}/**/*.h"

--- a/packages/expo-sms/ios/EXSMS/EXSMSModule.h
+++ b/packages/expo-sms/ios/EXSMS/EXSMSModule.h
@@ -1,7 +1,7 @@
 //  Copyright © 2018 650 Industries. All rights reserved.
 
-#import <UMCore/UMExportedModule.h>
-#import <UMCore/UMModuleRegistryConsumer.h>
+#import <ExpoModulesCore/EXExportedModule.h>
+#import <ExpoModulesCore/EXModuleRegistryConsumer.h>
 
-@interface EXSMSModule : UMExportedModule <UMModuleRegistryConsumer>
+@interface EXSMSModule : EXExportedModule <EXModuleRegistryConsumer>
 @end

--- a/packages/expo-sms/ios/EXSMS/EXSMSModule.m
+++ b/packages/expo-sms/ios/EXSMS/EXSMSModule.m
@@ -2,7 +2,7 @@
 
 #import <MessageUI/MessageUI.h>
 #import <EXSMS/EXSMSModule.h>
-#import <UMCore/UMUtilities.h>
+#import <ExpoModulesCore/EXUtilities.h>
 #if SD_MAC
 #import <CoreServices/CoreServices.h>
 #else
@@ -11,15 +11,15 @@
 
 @interface EXSMSModule () <MFMessageComposeViewControllerDelegate>
 
-@property (nonatomic, weak) id<UMUtilitiesInterface> utils;
-@property (nonatomic, strong) UMPromiseResolveBlock resolve;
-@property (nonatomic, strong) UMPromiseRejectBlock reject;
+@property (nonatomic, weak) id<EXUtilitiesInterface> utils;
+@property (nonatomic, strong) EXPromiseResolveBlock resolve;
+@property (nonatomic, strong) EXPromiseRejectBlock reject;
 
 @end
 
 @implementation EXSMSModule
 
-UM_EXPORT_MODULE(ExpoSMS);
+EX_EXPORT_MODULE(ExpoSMS);
 
 - (dispatch_queue_t)methodQueue
 {
@@ -28,24 +28,24 @@ UM_EXPORT_MODULE(ExpoSMS);
   return dispatch_get_main_queue();
 }
 
-- (void)setModuleRegistry:(UMModuleRegistry *)moduleRegistry
+- (void)setModuleRegistry:(EXModuleRegistry *)moduleRegistry
 {
-  _utils = [moduleRegistry getModuleImplementingProtocol:@protocol(UMUtilitiesInterface)];
+  _utils = [moduleRegistry getModuleImplementingProtocol:@protocol(EXUtilitiesInterface)];
 }
 
-UM_EXPORT_METHOD_AS(isAvailableAsync,
-                    isAvailable:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(isAvailableAsync,
+                    isAvailable:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   resolve(@([MFMessageComposeViewController canSendText]));
 }
 
-UM_EXPORT_METHOD_AS(sendSMSAsync,
+EX_EXPORT_METHOD_AS(sendSMSAsync,
                     sendSMS:(NSArray<NSString *> *)addresses
                     message:(NSString *)message
                     options:(NSDictionary *)options
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   if (![MFMessageComposeViewController canSendText]) {
     reject(@"E_SMS_UNAVAILABLE", @"SMS service not available", nil);
@@ -116,9 +116,9 @@ UM_EXPORT_METHOD_AS(sendSMSAsync,
       rejectMessage = @"SMS message sending failed with unknown error";
       break;
   }
-  UM_WEAKIFY(self);
+  EX_WEAKIFY(self);
   [controller dismissViewControllerAnimated:YES completion:^{
-    UM_ENSURE_STRONGIFY(self);
+    EX_ENSURE_STRONGIFY(self);
     if (rejectMessage) {
       self->_reject(@"E_SMS_SENDING_FAILED", rejectMessage, nil);
     } else {

--- a/packages/expo-sms/package.json
+++ b/packages/expo-sms/package.json
@@ -33,6 +33,9 @@
   "jest": {
     "preset": "expo-module-scripts/ios"
   },
+  "dependencies": {
+    "expo-modules-core": "~0.1.1"
+  },
   "devDependencies": {
     "expo-module-scripts": "^2.0.0"
   }

--- a/packages/expo-speech/CHANGELOG.md
+++ b/packages/expo-speech/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- Migrated from `@unimodules/core` to `expo-modules-core`.
+
 ## 9.2.0 — 2021-06-16
 
 ### 🐛 Bug fixes

--- a/packages/expo-speech/CHANGELOG.md
+++ b/packages/expo-speech/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### 💡 Others
 
-- Migrated from `@unimodules/core` to `expo-modules-core`.
+- Migrated from `@unimodules/core` to `expo-modules-core`. ([#13757](https://github.com/expo/expo/pull/13757) by [@tsapeta](https://github.com/tsapeta))
 
 ## 9.2.0 — 2021-06-16
 

--- a/packages/expo-speech/ios/EXSpeech.podspec
+++ b/packages/expo-speech/ios/EXSpeech.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.platform       = :ios, '11.0'
   s.source         = { git: 'https://github.com/expo/expo.git' }
 
-  s.dependency 'UMCore'
+  s.dependency 'ExpoModulesCore'
 
   if !$ExpoUseSources&.include?(package['name']) && ENV['EXPO_USE_SOURCE'].to_i == 0 && File.exist?("#{s.name}.xcframework") && Gem::Version.new(Pod::VERSION) >= Gem::Version.new('1.10.0')
     s.source_files = "#{s.name}/**/*.h"

--- a/packages/expo-speech/ios/EXSpeech/EXSpeech.h
+++ b/packages/expo-speech/ios/EXSpeech/EXSpeech.h
@@ -1,9 +1,9 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
-#import <UMCore/UMExportedModule.h>
-#import <UMCore/UMModuleRegistryConsumer.h>
-#import <UMCore/UMEventEmitter.h>
+#import <ExpoModulesCore/EXExportedModule.h>
+#import <ExpoModulesCore/EXModuleRegistryConsumer.h>
+#import <ExpoModulesCore/EXEventEmitter.h>
 
-@interface EXSpeech : UMExportedModule <UMEventEmitter, UMModuleRegistryConsumer>
+@interface EXSpeech : EXExportedModule <EXEventEmitter, EXModuleRegistryConsumer>
 
 @end

--- a/packages/expo-speech/ios/EXSpeech/EXSpeech.m
+++ b/packages/expo-speech/ios/EXSpeech/EXSpeech.m
@@ -2,7 +2,7 @@
 
 #import <AVFoundation/AVFoundation.h>
 
-#import <UMCore/UMEventEmitterService.h>
+#import <ExpoModulesCore/EXEventEmitterService.h>
 #import <EXSpeech/EXSpeech.h>
 
 @interface EXSpeechUtteranceWithId : AVSpeechUtterance
@@ -32,15 +32,15 @@ static NSString *const INVALID_VOICE_ERROR_MSG = @"Cannot find voice with identi
 @interface EXSpeech () <AVSpeechSynthesizerDelegate>
 
 @property (nonatomic, strong) AVSpeechSynthesizer *synthesizer;
-@property (nonatomic, weak) UMModuleRegistry *moduleRegistry;
+@property (nonatomic, weak) EXModuleRegistry *moduleRegistry;
 
 @end
 
 @implementation EXSpeech
 
-UM_EXPORT_MODULE(ExponentSpeech)
+EX_EXPORT_MODULE(ExponentSpeech)
 
-- (void)setModuleRegistry:(UMModuleRegistry *)moduleRegistry
+- (void)setModuleRegistry:(EXModuleRegistry *)moduleRegistry
 {
   _moduleRegistry = moduleRegistry;
 }
@@ -61,7 +61,7 @@ UM_EXPORT_MODULE(ExponentSpeech)
 - (void)speechSynthesizer:(AVSpeechSynthesizer *)synthesizer
   didStartSpeechUtterance:(AVSpeechUtterance *)utterance
 {
-  id<UMEventEmitterService> emitter = [_moduleRegistry getModuleImplementingProtocol:@protocol(UMEventEmitterService)];
+  id<EXEventEmitterService> emitter = [_moduleRegistry getModuleImplementingProtocol:@protocol(EXEventEmitterService)];
   if (emitter != nil) {
     [emitter sendEventWithName:@"Exponent.speakingStarted" body:@{ @"id": ((EXSpeechUtteranceWithId *) utterance).utteranceId }];
   }
@@ -70,7 +70,7 @@ UM_EXPORT_MODULE(ExponentSpeech)
 - (void)speechSynthesizer:(AVSpeechSynthesizer *)synthesizer
  didCancelSpeechUtterance:(AVSpeechUtterance *)utterance
 {
-  id<UMEventEmitterService> emitter = [_moduleRegistry getModuleImplementingProtocol:@protocol(UMEventEmitterService)];
+  id<EXEventEmitterService> emitter = [_moduleRegistry getModuleImplementingProtocol:@protocol(EXEventEmitterService)];
   if (emitter != nil) {
     [emitter sendEventWithName:@"Exponent.speakingStopped" body:@{ @"id": ((EXSpeechUtteranceWithId *) utterance).utteranceId }];
   }
@@ -79,19 +79,19 @@ UM_EXPORT_MODULE(ExponentSpeech)
 - (void)speechSynthesizer:(AVSpeechSynthesizer *)synthesizer
  didFinishSpeechUtterance:(AVSpeechUtterance *)utterance
 {
-  id<UMEventEmitterService> emitter = [_moduleRegistry getModuleImplementingProtocol:@protocol(UMEventEmitterService)];
+  id<EXEventEmitterService> emitter = [_moduleRegistry getModuleImplementingProtocol:@protocol(EXEventEmitterService)];
   if (emitter != nil) {
     [emitter sendEventWithName:@"Exponent.speakingDone" body:@{ @"id": ((EXSpeechUtteranceWithId *) utterance).utteranceId }];
   }
 }
 
 
-UM_EXPORT_METHOD_AS(speak,
+EX_EXPORT_METHOD_AS(speak,
                     speak:(nonnull NSString *)utteranceId
                     text:(nonnull NSString *)text
                     options:(NSDictionary *)options
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject) {
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject) {
   if (_synthesizer == nil) {
     _synthesizer = [[AVSpeechSynthesizer alloc] init];
     _synthesizer.delegate = self;
@@ -125,9 +125,9 @@ UM_EXPORT_METHOD_AS(speak,
   resolve(nil);
 }
 
-UM_EXPORT_METHOD_AS(getVoices,
-                    getVoices:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject) {
+EX_EXPORT_METHOD_AS(getVoices,
+                    getVoices:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject) {
   NSArray<AVSpeechSynthesisVoice *> *availableVoices = [AVSpeechSynthesisVoice speechVoices];
   NSMutableArray<NSDictionary *> *availableVoicesResult = [NSMutableArray array];
   for (AVSpeechSynthesisVoice* voice in availableVoices) {
@@ -146,30 +146,30 @@ UM_EXPORT_METHOD_AS(getVoices,
   resolve([availableVoicesResult mutableCopy]);
 }
 
-UM_EXPORT_METHOD_AS(stop,
-                    stop:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject) {
+EX_EXPORT_METHOD_AS(stop,
+                    stop:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject) {
   [_synthesizer stopSpeakingAtBoundary:AVSpeechBoundaryImmediate];
   resolve(nil);
 }
 
-UM_EXPORT_METHOD_AS(pause,
-                    pause:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject) {
+EX_EXPORT_METHOD_AS(pause,
+                    pause:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject) {
   [_synthesizer pauseSpeakingAtBoundary:AVSpeechBoundaryImmediate];
   resolve(nil);
 }
 
-UM_EXPORT_METHOD_AS(resume,
-                    resume:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject) {
+EX_EXPORT_METHOD_AS(resume,
+                    resume:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject) {
   [_synthesizer continueSpeaking];
   resolve(nil);
 }
 
-UM_EXPORT_METHOD_AS(isSpeaking,
-                    isSpeaking:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject) {
+EX_EXPORT_METHOD_AS(isSpeaking,
+                    isSpeaking:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject) {
   resolve(@([_synthesizer isSpeaking]));
 }
 

--- a/packages/expo-speech/package.json
+++ b/packages/expo-speech/package.json
@@ -35,6 +35,9 @@
   "jest": {
     "preset": "expo-module-scripts/ios"
   },
+  "dependencies": {
+    "expo-modules-core": "~0.1.1"
+  },
   "devDependencies": {
     "expo-module-scripts": "^2.0.0"
   }

--- a/packages/expo-store-review/CHANGELOG.md
+++ b/packages/expo-store-review/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- Migrated from `@unimodules/core` to `expo-modules-core`.
+
 ## 4.1.0 — 2021-06-16
 
 ### 🐛 Bug fixes

--- a/packages/expo-store-review/CHANGELOG.md
+++ b/packages/expo-store-review/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### 💡 Others
 
-- Migrated from `@unimodules/core` to `expo-modules-core`.
+- Migrated from `@unimodules/core` to `expo-modules-core`. ([#13757](https://github.com/expo/expo/pull/13757) by [@tsapeta](https://github.com/tsapeta))
 
 ## 4.1.0 — 2021-06-16
 

--- a/packages/expo-store-review/ios/EXStoreReview.podspec
+++ b/packages/expo-store-review/ios/EXStoreReview.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.platform       = :ios, '11.0'
   s.source         = { git: 'https://github.com/expo/expo.git' }
 
-  s.dependency 'UMCore'
+  s.dependency 'ExpoModulesCore'
 
   if !$ExpoUseSources&.include?(package['name']) && ENV['EXPO_USE_SOURCE'].to_i == 0 && File.exist?("#{s.name}.xcframework") && Gem::Version.new(Pod::VERSION) >= Gem::Version.new('1.10.0')
     s.source_files = "#{s.name}/**/*.h"

--- a/packages/expo-store-review/ios/EXStoreReview/EXStoreReviewModule.h
+++ b/packages/expo-store-review/ios/EXStoreReview/EXStoreReviewModule.h
@@ -1,8 +1,8 @@
 //  Copyright © 2018 650 Industries. All rights reserved.
 
-#import <UMCore/UMExportedModule.h>
-#import <UMCore/UMModuleRegistryConsumer.h>
+#import <ExpoModulesCore/EXExportedModule.h>
+#import <ExpoModulesCore/EXModuleRegistryConsumer.h>
 
-@interface EXStoreReviewModule : UMExportedModule
+@interface EXStoreReviewModule : EXExportedModule
 
 @end

--- a/packages/expo-store-review/ios/EXStoreReview/EXStoreReviewModule.m
+++ b/packages/expo-store-review/ios/EXStoreReview/EXStoreReviewModule.m
@@ -5,19 +5,19 @@
 
 @implementation EXStoreReviewModule
 
-UM_EXPORT_MODULE(ExpoStoreReview);
+EX_EXPORT_MODULE(ExpoStoreReview);
 
-UM_EXPORT_METHOD_AS(isAvailableAsync,
-                    isAvailableAsync:(UMPromiseResolveBlock)resolve
-                            rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(isAvailableAsync,
+                    isAvailableAsync:(EXPromiseResolveBlock)resolve
+                            rejecter:(EXPromiseRejectBlock)reject)
 {
   BOOL isAvailable = [SKStoreReviewController class] ? YES : NO;
   resolve(@(isAvailable));
 }
 
-UM_EXPORT_METHOD_AS(requestReview,
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(requestReview,
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   dispatch_async(dispatch_get_main_queue(), ^{
     [SKStoreReviewController requestReview];

--- a/packages/expo-store-review/package.json
+++ b/packages/expo-store-review/package.json
@@ -29,6 +29,9 @@
   "author": "650 Industries, Inc.",
   "license": "MIT",
   "homepage": "https://docs.expo.io/versions/latest/sdk/storereview/",
+  "dependencies": {
+    "expo-modules-core": "~0.1.1"
+  },
   "devDependencies": {
     "expo-module-scripts": "^2.0.0"
   }

--- a/packages/expo-video-thumbnails/CHANGELOG.md
+++ b/packages/expo-video-thumbnails/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Migrated from `@unimodules/core` to `expo-modules-core`.
+
 ## 5.2.0 — 2021-06-16
 
 ### 🐛 Bug fixes

--- a/packages/expo-video-thumbnails/CHANGELOG.md
+++ b/packages/expo-video-thumbnails/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Migrated from `@unimodules/core` to `expo-modules-core`.
+- Migrated from `@unimodules/core` to `expo-modules-core`. ([#13757](https://github.com/expo/expo/pull/13757) by [@tsapeta](https://github.com/tsapeta))
 
 ## 5.2.0 — 2021-06-16
 

--- a/packages/expo-video-thumbnails/ios/EXVideoThumbnails.podspec
+++ b/packages/expo-video-thumbnails/ios/EXVideoThumbnails.podspec
@@ -13,7 +13,6 @@ Pod::Spec.new do |s|
   s.platform       = :ios, '11.0'
   s.source         = { git: 'https://github.com/expo/expo.git' }
 
-  s.dependency 'UMCore'
   s.dependency 'ExpoModulesCore'
 
   if !$ExpoUseSources&.include?(package['name']) && ENV['EXPO_USE_SOURCE'].to_i == 0 && File.exist?("#{s.name}.xcframework") && Gem::Version.new(Pod::VERSION) >= Gem::Version.new('1.10.0')

--- a/packages/expo-video-thumbnails/ios/EXVideoThumbnails/EXVideoThumbnailsModule.h
+++ b/packages/expo-video-thumbnails/ios/EXVideoThumbnails/EXVideoThumbnailsModule.h
@@ -1,11 +1,11 @@
 //  Copyright © 2018 650 Industries. All rights reserved.
-#import <UMCore/UMExportedModule.h>
-#import <UMCore/UMModuleRegistryConsumer.h>
+#import <ExpoModulesCore/EXExportedModule.h>
+#import <ExpoModulesCore/EXModuleRegistryConsumer.h>
 #import <ExpoModulesCore/EXFileSystemInterface.h>
 
-@interface EXVideoThumbnailsModule : UMExportedModule <UMModuleRegistryConsumer>
+@interface EXVideoThumbnailsModule : EXExportedModule <EXModuleRegistryConsumer>
 
-@property (nonatomic, weak) UMModuleRegistry *moduleRegistry;
+@property (nonatomic, weak) EXModuleRegistry *moduleRegistry;
 @property (nonatomic, weak) id<EXFileSystemInterface> fileSystem;
 
 @end

--- a/packages/expo-video-thumbnails/ios/EXVideoThumbnails/EXVideoThumbnailsModule.m
+++ b/packages/expo-video-thumbnails/ios/EXVideoThumbnails/EXVideoThumbnailsModule.m
@@ -11,19 +11,19 @@ static NSString* const OPTIONS_KEY_HEADERS = @"headers";
 
 @implementation EXVideoThumbnailsModule
 
-UM_EXPORT_MODULE(ExpoVideoThumbnails);
+EX_EXPORT_MODULE(ExpoVideoThumbnails);
 
-- (void)setModuleRegistry:(UMModuleRegistry *)moduleRegistry
+- (void)setModuleRegistry:(EXModuleRegistry *)moduleRegistry
 {
   _moduleRegistry = moduleRegistry;
   _fileSystem = [moduleRegistry getModuleImplementingProtocol:@protocol(EXFileSystemInterface)];
 }
 
-UM_EXPORT_METHOD_AS(getThumbnail,
+EX_EXPORT_METHOD_AS(getThumbnail,
                     sourceFilename:(NSString *)source
                     options:(NSDictionary *)options
-                    resolve:(UMPromiseResolveBlock)resolve
-                    reject:(UMPromiseRejectBlock)reject)
+                    resolve:(EXPromiseResolveBlock)resolve
+                    reject:(EXPromiseRejectBlock)reject)
 {
   NSURL *url = [NSURL URLWithString:source];
   if ([url isFileURL]) {

--- a/packages/expo-web-browser/CHANGELOG.md
+++ b/packages/expo-web-browser/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Migrated from `@unimodules/core` to `expo-modules-core`.
+
 ## 9.2.0 — 2021-06-16
 
 ### 🎉 New features

--- a/packages/expo-web-browser/CHANGELOG.md
+++ b/packages/expo-web-browser/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Migrated from `@unimodules/core` to `expo-modules-core`.
+- Migrated from `@unimodules/core` to `expo-modules-core`. ([#13757](https://github.com/expo/expo/pull/13757) by [@tsapeta](https://github.com/tsapeta))
 
 ## 9.2.0 — 2021-06-16
 

--- a/packages/expo-web-browser/ios/EXWebBrowser.podspec
+++ b/packages/expo-web-browser/ios/EXWebBrowser.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.platform       = :ios, '11.0'
   s.source         = { git: 'https://github.com/expo/expo.git' }
 
-  s.dependency 'UMCore'
+  s.dependency 'ExpoModulesCore'
 
   if !$ExpoUseSources&.include?(package['name']) && ENV['EXPO_USE_SOURCE'].to_i == 0 && File.exist?("#{s.name}.xcframework") && Gem::Version.new(Pod::VERSION) >= Gem::Version.new('1.10.0')
     s.source_files = "#{s.name}/**/*.h"

--- a/packages/expo-web-browser/ios/EXWebBrowser/EXWebBrowser.h
+++ b/packages/expo-web-browser/ios/EXWebBrowser/EXWebBrowser.h
@@ -1,9 +1,9 @@
 //  Copyright © 2018 650 Industries. All rights reserved.
 
-#import <UMCore/UMExportedModule.h>
-#import <UMCore/UMModuleRegistryConsumer.h>
+#import <ExpoModulesCore/EXExportedModule.h>
+#import <ExpoModulesCore/EXModuleRegistryConsumer.h>
 
-@interface EXWebBrowser : UMExportedModule <UMModuleRegistryConsumer>
+@interface EXWebBrowser : EXExportedModule <EXModuleRegistryConsumer>
 
 
 @end

--- a/packages/expo-web-browser/ios/EXWebBrowser/EXWebBrowser.m
+++ b/packages/expo-web-browser/ios/EXWebBrowser/EXWebBrowser.m
@@ -3,7 +3,7 @@
 #import <SafariServices/SafariServices.h>
 #import <EXWebBrowser/EXWebBrowser.h>
 
-#import <UMCore/UMUtilities.h>
+#import <ExpoModulesCore/EXUtilities.h>
 
 static NSString* const WebBrowserErrorCode = @"WebBrowser";
 static NSString* const WebBrowserControlsColorKey = @"controlsColor";
@@ -11,9 +11,9 @@ static NSString* const WebBrowserToolbarColorKey = @"toolbarColor";
 
 @interface EXWebBrowser () <SFSafariViewControllerDelegate>
 
-@property (nonatomic, copy) UMPromiseResolveBlock redirectResolve;
-@property (nonatomic, copy) UMPromiseRejectBlock redirectReject;
-@property (nonatomic, weak) UMModuleRegistry *moduleRegistry;
+@property (nonatomic, copy) EXPromiseResolveBlock redirectResolve;
+@property (nonatomic, copy) EXPromiseRejectBlock redirectReject;
+@property (nonatomic, weak) EXModuleRegistry *moduleRegistry;
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wpartial-availability"
@@ -27,18 +27,18 @@ static NSString* const WebBrowserToolbarColorKey = @"toolbarColor";
   UIStatusBarStyle _initialStatusBarStyle;
 }
 
-UM_EXPORT_MODULE(ExpoWebBrowser)
+EX_EXPORT_MODULE(ExpoWebBrowser)
 
 - (dispatch_queue_t)methodQueue
 {
   return dispatch_get_main_queue();
 }
 
-UM_EXPORT_METHOD_AS(openAuthSessionAsync,
+EX_EXPORT_METHOD_AS(openAuthSessionAsync,
                     openAuthSessionAsync:(NSString *)authURL
                     redirectURL:(NSString *)redirectURL
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   [self initializeWebBrowserWithResolver:resolve andRejecter:reject];
 
@@ -79,11 +79,11 @@ UM_EXPORT_METHOD_AS(openAuthSessionAsync,
 }
 
 
-UM_EXPORT_METHOD_AS(openBrowserAsync,
+EX_EXPORT_METHOD_AS(openBrowserAsync,
                     openBrowserAsync:(NSString *)authURL
                     withArguments:(NSDictionary *)arguments
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   if (![self initializeWebBrowserWithResolver:resolve andRejecter:reject]) {
     return;
@@ -139,9 +139,9 @@ UM_EXPORT_METHOD_AS(openBrowserAsync,
   [currentViewController presentViewController:safariHackVC animated:true completion:nil];
 }
 
-UM_EXPORT_METHOD_AS(dismissBrowser,
-                    dismissBrowserWithResolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(dismissBrowser,
+                    dismissBrowserWithResolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   __weak typeof(self) weakSelf = self;
   UIViewController *currentViewController = [UIApplication sharedApplication].keyWindow.rootViewController;
@@ -162,9 +162,9 @@ UM_EXPORT_METHOD_AS(dismissBrowser,
   }];
 }
 
-UM_EXPORT_METHOD_AS(dismissAuthSession,
-                    dismissAuthSessionWithResolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(dismissAuthSession,
+                    dismissAuthSessionWithResolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   if (@available(iOS 11, *)) {
     [_authSession cancel];
@@ -181,34 +181,34 @@ UM_EXPORT_METHOD_AS(dismissAuthSession,
   }
 }
 
-UM_EXPORT_METHOD_AS(warmUpAsync,
+EX_EXPORT_METHOD_AS(warmUpAsync,
                     warmUpAsyncWithPackage:(NSString*)browserPackage
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   // stub for jest-expo-mock-generator
 }
 
-UM_EXPORT_METHOD_AS(coolDownAsync,
+EX_EXPORT_METHOD_AS(coolDownAsync,
                     coolDownAsyncWithPackage:(NSString*)browserPackage
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   // stub for jest-expo-mock-generator
 }
 
-UM_EXPORT_METHOD_AS(getCustomTabsSupportingBrowsers,
-                    getCustomTabsSupportingBrowsersWithPackage:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+EX_EXPORT_METHOD_AS(getCustomTabsSupportingBrowsers,
+                    getCustomTabsSupportingBrowsersWithPackage:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   // stub for jest-expo-mock-generator
 }
 
-UM_EXPORT_METHOD_AS(mayInitWithUrlAsync,
+EX_EXPORT_METHOD_AS(mayInitWithUrlAsync,
                      warmUpAsyncWithUrl:(NSString*)url
                      browserPackage:(NSString*)package
-                    resolver:(UMPromiseResolveBlock)resolve
-                    rejecter:(UMPromiseRejectBlock)reject)
+                    resolver:(EXPromiseResolveBlock)resolve
+                    rejecter:(EXPromiseRejectBlock)reject)
 {
   // stub for jest-expo-mock-generator
 }
@@ -216,7 +216,7 @@ UM_EXPORT_METHOD_AS(mayInitWithUrlAsync,
 /**
  * Helper that is used in openBrowserAsync and openAuthSessionAsync
  */
-- (BOOL)initializeWebBrowserWithResolver:(UMPromiseResolveBlock)resolve andRejecter:(UMPromiseRejectBlock)reject {
+- (BOOL)initializeWebBrowserWithResolver:(EXPromiseResolveBlock)resolve andRejecter:(EXPromiseRejectBlock)reject {
   if (_redirectResolve) {
     reject(WebBrowserErrorCode, @"Another WebBrowser is already being presented.", nil);
     return NO;
@@ -255,7 +255,7 @@ UM_EXPORT_METHOD_AS(mayInitWithUrlAsync,
   _redirectReject = nil;
 }
 
-- (void)setModuleRegistry:(UMModuleRegistry *)moduleRegistry
+- (void)setModuleRegistry:(EXModuleRegistry *)moduleRegistry
 {
   _moduleRegistry = moduleRegistry;
 }

--- a/packages/expo-web-browser/package.json
+++ b/packages/expo-web-browser/package.json
@@ -35,10 +35,11 @@
   "jest": {
     "preset": "expo-module-scripts"
   },
+  "dependencies": {
+    "compare-urls": "^2.0.0",
+    "expo-modules-core": "~0.1.1"
+  },
   "devDependencies": {
     "expo-module-scripts": "^2.0.0"
-  },
-  "dependencies": {
-    "compare-urls": "^2.0.0"
   }
 }


### PR DESCRIPTION
# Why

`UMCore` is now deprecated in favor of `ExpoModulesCore`

# How

Randomly picked some packages and on each I did the following:
- Removed the dependency on `UMCore` in the podspec
- Replaced `#import <UMCore/UM` with `#import <ExpoModulesCore/EX`
- Renamed prefixes from all references (`UM` -> `EX`)
- Ensured the package has `expo-modules-core` in the dependencies
- Removed `unimodulePeerDependencies`

# Test Plan

I'm not able to manually test everything, but the project compiles and should pass CI jobs
