### PR TITLE
add missing docs for categoryIdentifier on NotificationContentInput

### DIFF
--- a/docs/pages/versions/unversioned/sdk/notifications.md
+++ b/docs/pages/versions/unversioned/sdk/notifications.md
@@ -1392,6 +1392,7 @@ export interface NotificationContentInput {
   data?: { [key: string]: unknown };
   badge?: number;
   sound?: boolean | string;
+  categoryIdentifier?: string;
 
   // Android-specific fields
   // See https://developer.android.com/reference/android/app/Notification.html#fields


### PR DESCRIPTION
# Why

Exists in types, but not in docs.

# How

Update docs.

# Test Plan

Doc update only.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).