### PR TITLE
[unimodules][docs] Remove unneeded instruction

### DIFF
--- a/docs/public/static/diffs/react-native-unimodules-android.diff
+++ b/docs/public/static/diffs/react-native-unimodules-android.diff
@@ -47,7 +47,6 @@ index dc0901c..0151e90 100644
 +
 +import org.unimodules.adapters.react.ModuleRegistryAdapter;
 +import org.unimodules.adapters.react.ReactModuleRegistryProvider;
-+import org.unimodules.core.interfaces.SingletonModule;
  
  public class MainApplication extends Application implements ReactApplication {
 +  private final ReactModuleRegistryProvider mModuleRegistryProvider = new ReactModuleRegistryProvider(new BasePackageList().getPackageList(), null);


### PR DESCRIPTION
# Why

Out installation guide contains the unused import.

