### PR TITLE
[dev-launcher][android] Force kotlin version

### DIFF
--- a/packages/expo-dev-launcher/android/build.gradle
+++ b/packages/expo-dev-launcher/android/build.gradle
@@ -107,3 +107,12 @@ dependencies {
   testImplementation 'com.squareup.okhttp3:mockwebserver:4.3.1'
 }
 
+// Koin uses a different version of Kotlin under the hood.
+configurations.all {
+  resolutionStrategy.eachDependency { DependencyResolveDetails details ->
+    def requested = details.requested
+    if (requested.group == 'org.jetbrains.kotlin') {
+      details.useVersion safeExtGet('kotlinVersion', '1.4.21')
+    }
+  }
+}


### PR DESCRIPTION
# Why

Forces the same version of kotlin in `dev-launcher package.

# How

The Koin uses a different Kotlin version under the hood - `1.5.X`. The AS will generate a warning because of that. To remove it, we force Koin to use our version of Kotlin. It should be safe, cause the are not that many differences between those two versions. Moreover, we will upgrade Kotlin too eventually.

# Test Plan

- bare-expo ✅