### PR TITLE
[docs] stop deploying to docs.expo.io

### DIFF
--- a/docs/deploy.sh
+++ b/docs/deploy.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 scriptdir=$(dirname "${BASH_SOURCE[0]}")
-declare -a buckets=("docs.expo.io" "docs.expo.dev")
+declare -a buckets=("docs.expo.dev")
 target="${1-$scriptdir/out}"
 
 if [ ! -d "$target" ]; then


### PR DESCRIPTION
# Why

As we start directing traffic to docs.expo.dev, we should stop uploading to our .io bucket.

# How

Removed the .io bucket name from the deploy script

