### PR TITLE
[dev-menu][android] Fix menu binds to all keyboard shortcuts

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed menu binds to all keyboard shortcuts on Android.
+- Fixed menu binds to all keyboard shortcuts on Android. ([#13794](https://github.com/expo/expo/pull/13794) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed menu binds to all keyboard shortcuts on Android.
+
 ### 💡 Others
 
 ## 0.7.5 — 2021-07-08

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuManager.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuManager.kt
@@ -9,6 +9,8 @@ import android.os.Bundle
 import android.util.Log
 import android.view.KeyEvent
 import android.view.MotionEvent
+import android.view.inputmethod.InputMethodManager
+import androidx.core.content.ContextCompat.getSystemService
 import com.facebook.react.ReactInstanceManager
 import com.facebook.react.ReactNativeHost
 import com.facebook.react.bridge.LifecycleEventListener
@@ -327,6 +329,15 @@ object DevMenuManager : DevMenuManagerInterface, LifecycleEventListener {
   }
 
   override fun onKeyEvent(keyCode: Int, event: KeyEvent): Boolean {
+    val imm = delegateActivity?.getSystemService(Context.INPUT_METHOD_SERVICE) as? InputMethodManager
+    // The keyboard is active. We don't want to handle events that should go to text inputs.
+    // RN uses onKeyUp to handle all events connected with dev options. We need to do the same to override them.
+    // However, this event is also triggered when input is edited. A better way to handle that case
+    // is use onKeyDown event. However, it doesn't work well with key commands and we can't override RN implementation in that approach.
+    if (imm?.isAcceptingText != false) {
+      return false
+    }
+
     if (keyCode == KeyEvent.KEYCODE_MENU) {
       delegateActivity?.let { openMenu(it) }
       return true


### PR DESCRIPTION
# Why

Closes ENG-1603.
Fixes https://github.com/expo/expo/issues/13731

# How

`onKeyUp` is fired when someone is editing the text input. On Android, inputs use `onKeyDown` and this event won't be pipe to the activity.  However, we can't use `onKeyDown` in our implementation, cause we can't override the RN keyboard shortcut in that scenario. So we are stuck with `onKeyUp`. I've added a detection if the keyboard is visible. If it's we ignore all key events.

# Test Plan

- bare-expo ✅