### PR TITLE
[expo-updates] store assets with filename = key.fileExtension

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 🎉 New features
 
+- Store assets with filename = key.fileExtension. ([#13801](https://github.com/expo/expo/pull/13801) by [@jkhales](https://github.com/jkhales))
 - Use stable manifest ID where applicable. ([#12964](https://github.com/expo/expo/pull/12964) by [@wschurman](https://github.com/wschurman))
 - Update NewManifest field paths for new extra field format. ([#13398](https://github.com/expo/expo/pull/13398) by [@wschurman](https://github.com/wschurman))
 - Update location of EAS projectId in new manifest. ([#13739](https://github.com/expo/expo/pull/13739) by [@wschurman](https://github.com/wschurman))

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesUtils.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesUtils.java
@@ -121,17 +121,16 @@ public class UpdatesUtils {
   }
 
   public static String createFilenameForAsset(AssetEntity asset) {
+    String fileExtension = "";
+    if (asset.type != null) {
+      fileExtension = asset.type.startsWith(".") ? asset.type : "." + asset.type;
+    }
+
     if (asset.key == null) {
       // create a filename that's unlikely to collide with any other asset
-      return "asset-" + new Date().getTime() + "-" + new Random().nextInt();
+      return "asset-" + new Date().getTime() + "-" + new Random().nextInt() + fileExtension;
     }
-    if (asset.type == null) {
-      return asset.key;
-    }
-    if (asset.type.startsWith(".")) {
-      return asset.key + asset.type;
-    }
-    return asset.key + "." + asset.type;
+    return asset.key + fileExtension;
   }
 
   public static void sendEventToReactNative(@Nullable final WeakReference<ReactNativeHost> reactNativeHost, final String eventName, final WritableMap params) {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesUtils.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesUtils.java
@@ -128,7 +128,10 @@ public class UpdatesUtils {
     if (asset.type == null){
       return asset.key;
     }
-    return if (asset.type.startsWith('.')) "${asset.key}${fileExtension}" else "${asset.key}.${fileExtension}";
+    if (asset.type.startsWith(".")) {
+      return asset.key + asset.type;
+    }
+    return asset.key + "." + asset.type;
   }
 
   public static void sendEventToReactNative(@Nullable final WeakReference<ReactNativeHost> reactNativeHost, final String eventName, final WritableMap params) {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesUtils.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesUtils.java
@@ -125,7 +125,7 @@ public class UpdatesUtils {
       // create a filename that's unlikely to collide with any other asset
       return "asset-" + new Date().getTime() + "-" + new Random().nextInt();
     }
-    if (asset.type == null){
+    if (asset.type == null) {
       return asset.key;
     }
     if (asset.type.startsWith(".")) {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesUtils.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesUtils.java
@@ -125,7 +125,10 @@ public class UpdatesUtils {
       // create a filename that's unlikely to collide with any other asset
       return "asset-" + new Date().getTime() + "-" + new Random().nextInt();
     }
-    return asset.key;
+    if (asset.type == null){
+      return asset.key;
+    }
+    return if (asset.type.startsWith('.')) "${asset.key}${fileExtension}" else "${asset.key}.${fileExtension}";
   }
 
   public static void sendEventToReactNative(@Nullable final WeakReference<ReactNativeHost> reactNativeHost, final String eventName, final WritableMap params) {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/BareManifest.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/BareManifest.kt
@@ -46,7 +46,7 @@ class BareManifest private constructor(
           val assetObject = mAssets.getJSONObject(i)
           val type = assetObject.getString("type")
           val assetEntity = AssetEntity(
-            assetObject.getString("packagerHash") + "." + type,
+            assetObject.getString("packagerHash"),
             type
           ).apply {
             resourcesFilename = assetObject.optString("resourcesFilename")

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/LegacyManifest.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/LegacyManifest.kt
@@ -62,7 +62,7 @@ class LegacyManifest private constructor(
           ) else bundledAsset.substring(prefixLength)
           val type = if (extensionIndex > 0) bundledAsset.substring(extensionIndex + 1) else ""
           assetList.add(
-            AssetEntity("$hash.$type", type).apply {
+            AssetEntity(hash, type).apply {
               url = Uri.withAppendedPath(assetsUrlBase, hash)
               embeddedAssetFilename = bundledAsset
             }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/NewManifest.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/NewManifest.kt
@@ -53,6 +53,7 @@ class NewManifest private constructor(
       assetList.add(
         AssetEntity(
           mLaunchAsset.getString("key"),
+          // the fileExtension is not necessary for the launch asset and EAS servers will not include it.
           mLaunchAsset.optString("fileExtension")
         ).apply {
           url = Uri.parse(mLaunchAsset.getString("url"))

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/NewManifest.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/NewManifest.kt
@@ -53,7 +53,7 @@ class NewManifest private constructor(
       assetList.add(
         AssetEntity(
           mLaunchAsset.getString("key"),
-          mLaunchAsset.optString("fileExtension",null)
+          mLaunchAsset.optString("fileExtension")
         ).apply {
           url = Uri.parse(mLaunchAsset.getString("url"))
           isLaunchAsset = true

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/NewManifest.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/NewManifest.kt
@@ -53,7 +53,7 @@ class NewManifest private constructor(
       assetList.add(
         AssetEntity(
           mLaunchAsset.getString("key"),
-          mLaunchAsset.optString("fileExtension")
+          mLaunchAsset.optString("fileExtension",null)
         ).apply {
           url = Uri.parse(mLaunchAsset.getString("url"))
           isLaunchAsset = true

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/NewManifest.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/NewManifest.kt
@@ -53,7 +53,7 @@ class NewManifest private constructor(
       assetList.add(
         AssetEntity(
           mLaunchAsset.getString("key"),
-          mLaunchAsset.getString("type")
+          mLaunchAsset.getString("fileExtension")
         ).apply {
           url = Uri.parse(mLaunchAsset.getString("url"))
           isLaunchAsset = true
@@ -70,7 +70,7 @@ class NewManifest private constructor(
           assetList.add(
             AssetEntity(
               assetObject.getString("key"),
-              assetObject.getString("type")
+              assetObject.getString("fileExtension")
             ).apply {
               url = Uri.parse(assetObject.getString("url"))
               embeddedAssetFilename = assetObject.optString("embeddedAssetFilename")

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/NewManifest.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/NewManifest.kt
@@ -53,7 +53,7 @@ class NewManifest private constructor(
       assetList.add(
         AssetEntity(
           mLaunchAsset.getString("key"),
-          mLaunchAsset.getString("fileExtension")
+          mLaunchAsset.optString("fileExtension")
         ).apply {
           url = Uri.parse(mLaunchAsset.getString("url"))
           isLaunchAsset = true

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/NewManifest.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/NewManifest.kt
@@ -53,7 +53,7 @@ class NewManifest private constructor(
       assetList.add(
         AssetEntity(
           mLaunchAsset.getString("key"),
-          mLaunchAsset.getString("contentType")
+          mLaunchAsset.getString("type")
         ).apply {
           url = Uri.parse(mLaunchAsset.getString("url"))
           isLaunchAsset = true
@@ -70,7 +70,7 @@ class NewManifest private constructor(
           assetList.add(
             AssetEntity(
               assetObject.getString("key"),
-              assetObject.getString("contentType")
+              assetObject.getString("type")
             ).apply {
               url = Uri.parse(assetObject.getString("url"))
               embeddedAssetFilename = assetObject.optString("embeddedAssetFilename")

--- a/packages/expo-updates/android/src/test/java/expo/modules/updates/UpdatesUtilsTest.java
+++ b/packages/expo-updates/android/src/test/java/expo/modules/updates/UpdatesUtilsTest.java
@@ -35,6 +35,9 @@ public class UpdatesUtilsTest {
     AssetEntity asset1 = new AssetEntity(null, "bundle");
     AssetEntity asset2 = new AssetEntity(null, "bundle");
     Assert.assertNotEquals(UpdatesUtils.createFilenameForAsset(asset1), UpdatesUtils.createFilenameForAsset(asset2));
+
+    String asset1Name = UpdatesUtils.createFilenameForAsset(asset1);
+    Assert.assertEquals(asset1Name.substring(asset1Name.length()-7),".bundle");
   }
 
   @Test

--- a/packages/expo-updates/android/src/test/java/expo/modules/updates/UpdatesUtilsTest.java
+++ b/packages/expo-updates/android/src/test/java/expo/modules/updates/UpdatesUtilsTest.java
@@ -13,7 +13,19 @@ import static org.mockito.Mockito.*;
 public class UpdatesUtilsTest {
   @Test
   public void testCreateFilenameForAsset() {
+    AssetEntity assetEntity = new AssetEntity("key", ".png");
+    Assert.assertEquals("key.png", UpdatesUtils.createFilenameForAsset(assetEntity));
+  }
+
+  @Test
+  public void testCreateFilenameForAssetWhenMissingDotPrefix() {
     AssetEntity assetEntity = new AssetEntity("key", "png");
+    Assert.assertEquals("key.png", UpdatesUtils.createFilenameForAsset(assetEntity));
+  }
+
+  @Test
+  public void testCreateFilenameForAssetWhenMissingExtension() {
+    AssetEntity assetEntity = new AssetEntity("key", null);
     Assert.assertEquals("key", UpdatesUtils.createFilenameForAsset(assetEntity));
   }
 

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAsset.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAsset.m
@@ -28,8 +28,10 @@ NS_ASSUME_NONNULL_BEGIN
     if (!_type){
       _filename = _key
     }
-    
-    _filename = [_type hasPrefix:@"."] ? [NSString stringWithFormat:@"%@%@", _key, _type] : [NSString stringWithFormat:@"%@.%@", _key, _type];
+    if ([_type hasPrefix:@"."]){
+      _filename = [NSString stringWithFormat:@"%@%@", _key, _type]
+    }
+    _filename = [NSString stringWithFormat:@"%@.%@", _key, _type];
   }
   return _filename;
 }

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAsset.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAsset.m
@@ -24,14 +24,14 @@ NS_ASSUME_NONNULL_BEGIN
     if (!_key) {
       // create a filename that's unlikely to collide with any other asset
       _filename = [NSString stringWithFormat:@"asset-%d-%u", (int)[NSDate date].timeIntervalSince1970, arc4random()];
-    } 
-    if (!_type){
-      _filename = _key
+      return _filename;
     }
+    
     if ([_type hasPrefix:@"."]){
-      _filename = [NSString stringWithFormat:@"%@%@", _key, _type]
+      _filename = [NSString stringWithFormat:@"%@%@", _key, _type];
+    } else {
+      _filename = [NSString stringWithFormat:@"%@.%@", _key, _type];
     }
-    _filename = [NSString stringWithFormat:@"%@.%@", _key, _type];
   }
   return _filename;
 }

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAsset.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAsset.m
@@ -22,7 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
   if (!_filename) {
     if (_key) {
-      _filename = _key;
+      _filename = [NSString stringWithFormat:@"%@.%@", _key, _type];
     } else {
       // create a filename that's unlikely to collide with any other asset
       _filename = [NSString stringWithFormat:@"asset-%d-%u", (int)[NSDate date].timeIntervalSince1970, arc4random()];

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAsset.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAsset.m
@@ -21,12 +21,15 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSString *)filename
 {
   if (!_filename) {
-    if (_key) {
-      _filename = [NSString stringWithFormat:@"%@.%@", _key, _type];
-    } else {
+    if (!_key) {
       // create a filename that's unlikely to collide with any other asset
       _filename = [NSString stringWithFormat:@"asset-%d-%u", (int)[NSDate date].timeIntervalSince1970, arc4random()];
+    } 
+    if (!_type){
+      _filename = _key
     }
+    
+    _filename = [_type hasPrefix:@"."] ? [NSString stringWithFormat:@"%@%@", _key, _type] : [NSString stringWithFormat:@"%@.%@", _key, _type];
   }
   return _filename;
 }

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAsset.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAsset.m
@@ -21,16 +21,16 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSString *)filename
 {
   if (!_filename) {
-    if (!_key) {
-      // create a filename that's unlikely to collide with any other asset
-      _filename = [NSString stringWithFormat:@"asset-%d-%u", (int)[NSDate date].timeIntervalSince1970, arc4random()];
-      return _filename;
+    NSString *fileExtension = @"";
+    if (_type){
+      fileExtension = [_type hasPrefix:@"."] ? _type : [NSString stringWithFormat:@".%@", _type];
     }
     
-    if ([_type hasPrefix:@"."]){
-      _filename = [NSString stringWithFormat:@"%@%@", _key, _type];
+    if (!_key) {
+      // create a filename that's unlikely to collide with any other asset
+      _filename = [NSString stringWithFormat:@"asset-%d-%u%@", (int)[NSDate date].timeIntervalSince1970, arc4random(), fileExtension];
     } else {
-      _filename = [NSString stringWithFormat:@"%@.%@", _key, _type];
+      _filename = [NSString stringWithFormat:@"%@%@", _key, fileExtension];
     }
   }
   return _filename;

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesBareUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesBareUpdate.m
@@ -50,7 +50,7 @@ NS_ASSUME_NONNULL_BEGIN
         NSAssert([mainBundleDir isKindOfClass:[NSString class]], @"asset nsBundleDir should be a string");
       }
 
-      NSString *key = [NSString stringWithFormat:@"%@.%@", packagerHash, type];
+      NSString *key = packagerHash;
       EXUpdatesAsset *asset = [[EXUpdatesAsset alloc] initWithKey:key type:(NSString *)type];
       asset.mainBundleDir = mainBundleDir;
       asset.mainBundleFilename = mainBundleFilename;

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesLegacyUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesLegacyUpdate.m
@@ -89,7 +89,7 @@ static NSString * const EXUpdatesExpoTestDomain = @"expo.test";
 
     NSURL *url = [bundledAssetBaseUrl URLByAppendingPathComponent:hash];
 
-    NSString *key = [NSString stringWithFormat:@"%@.%@", hash, type];
+    NSString *key = hash;
     EXUpdatesAsset *asset = [[EXUpdatesAsset alloc] initWithKey:key type:(NSString *)type];
     asset.url = url;
     asset.mainBundleFilename = filename;

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesNewUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesNewUpdate.m
@@ -50,16 +50,16 @@ NS_ASSUME_NONNULL_BEGIN
       NSAssert([assetDict isKindOfClass:[NSDictionary class]], @"assets must be objects");
       id key = assetDict[@"key"];
       id urlString = assetDict[@"url"];
-      id type = assetDict[@"type"];
+      id fileExtension = assetDict[@"fileExtension"];
       id metadata = assetDict[@"metadata"];
       id mainBundleFilename = assetDict[@"mainBundleFilename"];
       NSAssert(key && [key isKindOfClass:[NSString class]], @"asset key should be a nonnull string");
       NSAssert(urlString && [urlString isKindOfClass:[NSString class]], @"asset url should be a nonnull string");
-      NSAssert(type && [type isKindOfClass:[NSString class]], @"asset contentType should be a nonnull string");
+      NSAssert(fileExtension && [fileExtension isKindOfClass:[NSString class]], @"asset fileExtension should be a nonnull string");
       NSURL *url = [NSURL URLWithString:(NSString *)urlString];
       NSAssert(url, @"asset url should be a valid URL");
       
-      EXUpdatesAsset *asset = [[EXUpdatesAsset alloc] initWithKey:key type:(NSString *)type];
+      EXUpdatesAsset *asset = [[EXUpdatesAsset alloc] initWithKey:key type:(NSString *)fileExtension];
       asset.url = url;
       
       if (metadata) {

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesNewUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesNewUpdate.m
@@ -50,7 +50,7 @@ NS_ASSUME_NONNULL_BEGIN
       NSAssert([assetDict isKindOfClass:[NSDictionary class]], @"assets must be objects");
       id key = assetDict[@"key"];
       id urlString = assetDict[@"url"];
-      id type = assetDict[@"contentType"];
+      id type = assetDict[@"type"];
       id metadata = assetDict[@"metadata"];
       id mainBundleFilename = assetDict[@"mainBundleFilename"];
       NSAssert(key && [key isKindOfClass:[NSString class]], @"asset key should be a nonnull string");

--- a/packages/expo-updates/ios/Tests/EXUpdatesSelectionPolicyFilterAwareTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesSelectionPolicyFilterAwareTests.m
@@ -32,12 +32,14 @@
     @"hash": @"DW5MBgKq155wnX8rCP1lnsW6BsTbfKLXxGXRQx1RcOA",
     @"key": @"0436e5821bff7b95a84c21f22a43cb96.bundle",
     @"contentType": @"application/javascript",
+    @"type": @"js",
     @"url": @"https://url.to/bundle"
   };
   NSDictionary *imageAsset = @{
     @"hash": @"JSeRsPNKzhVdHP1OEsDVsLH500Zfe4j1O7xWfa14oBo",
     @"key": @"3261e570d51777be1e99116562280926.png",
     @"contentType": @"image/png",
+    @"type": @"png",
     @"url": @"https://url.to/asset"
   };
 

--- a/packages/expo-updates/ios/Tests/EXUpdatesSelectionPolicyFilterAwareTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesSelectionPolicyFilterAwareTests.m
@@ -32,14 +32,14 @@
     @"hash": @"DW5MBgKq155wnX8rCP1lnsW6BsTbfKLXxGXRQx1RcOA",
     @"key": @"0436e5821bff7b95a84c21f22a43cb96.bundle",
     @"contentType": @"application/javascript",
-    @"type": @"js",
+    @"fileExtension": @".js",
     @"url": @"https://url.to/bundle"
   };
   NSDictionary *imageAsset = @{
     @"hash": @"JSeRsPNKzhVdHP1OEsDVsLH500Zfe4j1O7xWfa14oBo",
     @"key": @"3261e570d51777be1e99116562280926.png",
     @"contentType": @"image/png",
-    @"type": @"png",
+    @"fileExtension": @".png",
     @"url": @"https://url.to/asset"
   };
 

--- a/packages/expo-updates/ios/Tests/Tests.m
+++ b/packages/expo-updates/ios/Tests/Tests.m
@@ -64,5 +64,14 @@
   XCTAssertEqualObjects(filenameFromDatabase, assetSetFilename.filename, @"Should be able to override the default asset filename if the database has something different");
 }
 
+- (void)testAssetFilenameFileExtension
+{
+  EXUpdatesAsset *assetWithDotPrefix = [[EXUpdatesAsset alloc] initWithKey:@"cat" type:@".jpeg"];
+  XCTAssertEqualObjects(assetWithDotPrefix.filename, @"cat.jpeg");
+  
+  EXUpdatesAsset *assetWithoutDotPrefix = [[EXUpdatesAsset alloc] initWithKey:@"cat" type:@"jpeg"];
+  XCTAssertEqualObjects(assetWithoutDotPrefix.filename, @"cat.jpeg");
+}
+
 @end
 

--- a/packages/expo-updates/ios/Tests/Tests.m
+++ b/packages/expo-updates/ios/Tests/Tests.m
@@ -64,13 +64,23 @@
   XCTAssertEqualObjects(filenameFromDatabase, assetSetFilename.filename, @"Should be able to override the default asset filename if the database has something different");
 }
 
-- (void)testAssetFilenameFileExtension
+- (void)testAssetFilenameWithFileExtension
 {
   EXUpdatesAsset *assetWithDotPrefix = [[EXUpdatesAsset alloc] initWithKey:@"cat" type:@".jpeg"];
   XCTAssertEqualObjects(assetWithDotPrefix.filename, @"cat.jpeg");
   
   EXUpdatesAsset *assetWithoutDotPrefix = [[EXUpdatesAsset alloc] initWithKey:@"cat" type:@"jpeg"];
   XCTAssertEqualObjects(assetWithoutDotPrefix.filename, @"cat.jpeg");
+  
+  EXUpdatesAsset *assetWithoutKey = [[EXUpdatesAsset alloc] initWithKey:nil type:@"jpeg"];
+  XCTAssertEqualObjects([assetWithoutKey.filename substringFromIndex:[assetWithoutKey.filename length] - 5], @".jpeg");
+}
+
+- (void)testAssetFilenameWithoutFileExtension
+{
+  EXUpdatesAsset *assetWithDotPrefix = [[EXUpdatesAsset alloc] initWithKey:@"cat" type:nil];
+  XCTAssertEqualObjects(assetWithDotPrefix.filename, @"cat");
+
 }
 
 @end


### PR DESCRIPTION
# Why

When saving some assets on an iOS client, we need a file extension.

We also want the asset key to be their md5 hash.

# How

The previous attempt at this left `key === filename`. So when we switched the key over to being just an md5 hash, we were unable to save certain assets on iOS. 

https://github.com/expo/expo/issues/13558

(The "production build" criteria is replicated by setting the build variant to "release" instead of "debug").

Note: we don't have to worry about migrating over old assets, as this is already handled for us here: https://github.com/expo/expo/blob/efa14e19c0c5fb7d319332e46fbe370dd15ba8b6/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/RemoteLoader.java#L235-L245

 Note: this PR could have been shorter by
   1. only adjusting the iOS key/value
     - was rejected as consistency will help readability and debugging.

   2. changing EAS Update to store an asset with key = hash.type (instead of the key = hash)
     - was rejected after discussion with @esamelson and agreeing that a key without an extension is cleaner.    
   
# Test Plan

Confirmed updates with assets are loaded on a demo project with all of the PR's listed in ENG-1627 applied.
Confirmed that old assets are migrated over automatically when a build using this PR is installed over an old version of the app.
# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).