### PR TITLE
[face-detector] remove unused firebase import

### DIFF
--- a/packages/expo-face-detector/ios/EXFaceDetector/EXFaceDetector.m
+++ b/packages/expo-face-detector/ios/EXFaceDetector/EXFaceDetector.m
@@ -6,7 +6,6 @@
 //
 
 #import <EXFaceDetector/EXFaceDetector.h>
-#import <Firebase/Firebase.h>
 #import <MLKitFaceDetection/MLKitFaceDetection.h>
 
 @implementation EXFaceDetector


### PR DESCRIPTION
# Why

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

I ran into this import while working on `expo-stories` - from what I can tell this import isn't used in the package at all and the dependency is not declared in the Podfile

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

Removed the import - let me know if this is correct!
