### PR TITLE
[ci] Move spotless ktlint check before tests

### DIFF
--- a/.github/workflows/android-unit-tests.yml
+++ b/.github/workflows/android-unit-tests.yml
@@ -36,6 +36,7 @@ jobs:
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
       - uses: actions/cache@v2
+        name: Restore yarn cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
@@ -43,17 +44,14 @@ jobs:
             ${{ runner.os }}-yarn-
       - run: yarn install --frozen-lockfile
       - uses: actions/cache@v2
+        name: Restore Gradle cache
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('android/*.gradle*') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
-      - name: Run Spotless lint check
-        env:
-          ANDROID_NDK_HOME: /usr/local/lib/android/sdk/ndk/19.2.5345600/
-        working-directory: android
-        run: ./gradlew spotlessCheck || { echo '::error Spotless lint failed. Run `./gradlew spotlessApply` to automatically fix formatting.' && exit 1; }
       - uses: actions/cache@v2
+        name: Restore NDK cache
         id: cache-android-ndk
         with:
           path: /usr/local/lib/android/sdk/ndk/19.2.5345600/
@@ -65,6 +63,12 @@ jobs:
         run: |
           sudo $ANDROID_SDK_ROOT/tools/bin/sdkmanager --install "ndk;19.2.5345600"
       - run: echo "$(pwd)/bin" >> $GITHUB_PATH
+      - name: Run Spotless lint check
+        env:
+          ANDROID_NDK_HOME: /usr/local/lib/android/sdk/ndk/19.2.5345600/
+        working-directory: android
+        run: ./gradlew spotlessCheck || { echo '::error Spotless lint failed. Run `./gradlew spotlessApply` to automatically fix formatting.' && exit 1; }
+
       - name: Run native Android unit tests
         env:
           ANDROID_NDK_HOME: /usr/local/lib/android/sdk/ndk/19.2.5345600/

--- a/.github/workflows/android-unit-tests.yml
+++ b/.github/workflows/android-unit-tests.yml
@@ -48,6 +48,11 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('android/*.gradle*') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
+      - name: Run Spotless lint check
+        env:
+          ANDROID_NDK_HOME: /usr/local/lib/android/sdk/ndk/19.2.5345600/
+        working-directory: android
+        run: ./gradlew spotlessCheck || { echo '::error Spotless lint failed. Run `./gradlew spotlessApply` to automatically fix formatting.' && exit 1; }
       - uses: actions/cache@v2
         id: cache-android-ndk
         with:
@@ -70,8 +75,3 @@ jobs:
         with:
           name: test-results
           path: packages/**/build/test-results/**/*xml
-      - name: Run Spotless lint check
-        env:
-          ANDROID_NDK_HOME: /usr/local/lib/android/sdk/ndk/19.2.5345600/
-        working-directory: android
-        run: ./gradlew spotlessCheck || { echo '::error Spotless lint failed. Run `./gradlew spotlessApply` to automatically fix formatting.' && exit 1; }

--- a/.github/workflows/android-unit-tests.yml
+++ b/.github/workflows/android-unit-tests.yml
@@ -68,7 +68,6 @@ jobs:
           ANDROID_NDK_HOME: /usr/local/lib/android/sdk/ndk/19.2.5345600/
         working-directory: android
         run: ./gradlew spotlessCheck || { echo '::error Spotless lint failed. Run `./gradlew spotlessApply` to automatically fix formatting.' && exit 1; }
-
       - name: Run native Android unit tests
         env:
           ANDROID_NDK_HOME: /usr/local/lib/android/sdk/ndk/19.2.5345600/


### PR DESCRIPTION
# Why

To more quickly fail CI if kotlin linter displays an error. Waiting 30 min for all tests only to see ktlint error is frustrating. The lint step takes only ~3 min, while tests are ~27 min.

# How

Updated "Android unit tests" CI job.
Moved spotless ktlint CI step before running tests. 

# Test Plan

- CI passes
- Compared time before and after:
   - Before: any previous successful check, e.g. https://github.com/expo/expo/runs/3176282717?check_suite_focus=true
   - After: This PR checks.

The total CI time is rather constant. The ktlint step takes about 30s more (due to expotools yarn install), and unit test step is shorter by that time

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).