### PR TITLE
[android] Fix ktlint settings

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -117,7 +117,16 @@ subprojects {
     }
     kotlin {
       target '**/*.kt'
-      ktlint("0.41.0")
+      ktlint("0.41.0").userData([
+        "disabled_rules"           : "no-wildcard-imports,import-ordering",
+        "charset"                  : "utf-8",
+        "end_of_line"              : "lf",
+        "indent_size"              : "2",
+        "indent_style"             : "space",
+        "insert_final_newline"     : "true",
+        "tab_width"                : "2",
+        "trim_trailing_whitespace" : "true"
+      ])
       trimTrailingWhitespace()
       indentWithSpaces()
       endWithNewline()

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -117,11 +117,7 @@ subprojects {
     }
     kotlin {
       target '**/*.kt'
-      ktlint("0.41.0").userData([
-          "disabled_rules"          : "no-wildcard-imports,import-ordering",
-          "indent_size"             : "2",
-          "continuation_indent_size": "4"
-      ])
+      ktlint("0.41.0")
       trimTrailingWhitespace()
       indentWithSpaces()
       endWithNewline()

--- a/apps/bare-expo/android/build.gradle
+++ b/apps/bare-expo/android/build.gradle
@@ -83,11 +83,7 @@ subprojects {
   spotless {
     kotlin {
       target '**/*.kt'
-      ktlint().userData([
-          "disabled_rules"          : "no-wildcard-imports,import-ordering",
-          "indent_size"             : "2",
-          "continuation_indent_size": "4"
-      ])
+      ktlint("0.41.0")
       trimTrailingWhitespace()
       indentWithSpaces()
       endWithNewline()

--- a/apps/bare-expo/android/build.gradle
+++ b/apps/bare-expo/android/build.gradle
@@ -83,7 +83,16 @@ subprojects {
   spotless {
     kotlin {
       target '**/*.kt'
-      ktlint("0.41.0")
+      ktlint("0.41.0").userData([
+        "disabled_rules"           : "no-wildcard-imports,import-ordering",
+        "charset"                  : "utf-8",
+        "end_of_line"              : "lf",
+        "indent_size"              : "2",
+        "indent_style"             : "space",
+        "insert_final_newline"     : "true",
+        "tab_width"                : "2",
+        "trim_trailing_whitespace" : "true"
+      ])
       trimTrailingWhitespace()
       indentWithSpaces()
       endWithNewline()


### PR DESCRIPTION
# Why

- `CONTINUATION_INDENT_SIZE` in ktlint settings didn't work
- In Java, all types of intents were set to 2 spaces, so I wanted to keep these settings in Kotlin.

# How

- Removed not-working rules.
- Added some more rules which are already satisfied.
