### PR TITLE
[docs] runtime version doc page

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -151,7 +151,7 @@ const sections = [
       'Deploying to App Stores',
       'Release Channels',
       'Advanced Release Channels',
-      'Runtime Version',
+      'Runtime Versions',
       'Build Webhooks',
       'Hosting Updates on Your Servers',
       'Building Standalone Apps on Your CI',

--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -151,6 +151,7 @@ const sections = [
       'Deploying to App Stores',
       'Release Channels',
       'Advanced Release Channels',
+      'Runtime Version',
       'Build Webhooks',
       'Hosting Updates on Your Servers',
       'Building Standalone Apps on Your CI',

--- a/docs/pages/distribution/runtime-version.md
+++ b/docs/pages/distribution/runtime-version.md
@@ -1,0 +1,41 @@
+---
+title: Runtime Version
+---
+
+Expo Update allows you to publish over the air updates to apps. The update must be for an app running a
+[compatible](../workflow/publishing/#what-version-of-the-app-will-my) runtime. You may use a runtime other than an Expo SDK, by specifying a runtime version.
+
+The runtime version should be specified in your `app.json`:
+
+```typescript
+{
+	expo: {
+		...
+		runtimeVersion: "2.718",
+	}
+}
+```
+## Publishing
+
+[Publishes](../workflow/publishing/#how-to-publish) run with the runtime version set in the `app.json` will be delivered to builds running the same runtime version.
+
+## Builds
+
+Apps running a custom runtime version can be built with [EAS Build](../build/introduction/).
+
+There are two ways to set the runtime version of a build.
+
+1. (Recommended) After setting the runtime version in your `app.json`, run `expo prebuild`.
+2. Manually edit the Plist/AndroidManifest.xml:
+
+	### iOS
+
+	```diff
+	+ <key>EXUpdatesRuntimeVersion</key>
+    + <string>2.718</string>
+	```
+	### Android
+
+	```diff
+	+ <meta-data android:name="expo.modules.updates.EXPO_RUNTIME_VERSION" android:value="2.718"/>
+	```

--- a/docs/pages/distribution/runtime-version.md
+++ b/docs/pages/distribution/runtime-version.md
@@ -2,12 +2,13 @@
 title: Runtime Version
 ---
 
-Expo Update allows you to publish over the air updates to apps. The update must be for an app running a
-[compatible](../workflow/publishing/#what-version-of-the-app-will-my) runtime. You may use a runtime other than an Expo SDK, by specifying a runtime version.
+> Custom runtime versions are not supported on the classic build system (`expo build`); these apps will always use the SDK version as the basis for determining runtime compatibility. 
+
+Over-the-air updates with `expo-updates` will only work in binaries with a [compatible](../workflow/publishing/#what-version-of-the-app-will-my) runtime. By default, the runtime version is the Expo SDK version: the runtime is the set of libraries in the Expo SDK. Apps built with EAS Build will include only the dependencies that are present at the time that the app binary is built, and so the Expo SDK version will often not properly describe the runtime of the app. In these cases, you can start using `runtimeVersion` and it will take precedence over the Expo SDK version.
 
 The runtime version should be specified in your `app.json`:
 
-```typescript
+```json
 {
 	expo: {
 		...
@@ -15,13 +16,12 @@ The runtime version should be specified in your `app.json`:
 	}
 }
 ```
-## Publishing
+## Setting the runtime version for an update
 
-[Publishes](../workflow/publishing/#how-to-publish) run with the runtime version set in the `app.json` will be delivered to builds running the same runtime version.
+[Updates](/workflow/publishing.md#how-to-publish) published with the runtime version set in the `app.json` will be delivered to builds running the same runtime version, and only to those builds.
 
-## Builds
+## Setting the runtime version for a build
 
-Apps running a custom runtime version can be built with [EAS Build](../build/introduction/).
 
 There are two ways to set the runtime version of a build.
 

--- a/docs/pages/distribution/runtime-version.md
+++ b/docs/pages/distribution/runtime-version.md
@@ -26,7 +26,7 @@ Apps running a custom runtime version can be built with [EAS Build](../build/int
 There are two ways to set the runtime version of a build.
 
 1. (Recommended) After setting the runtime version in your `app.json`, run `expo prebuild`.
-2. Manually edit the Plist/AndroidManifest.xml:
+2. Edit Expo.plist on iOS and AndroidManifest.xml on Android. In Expo.plist, add an entry whose key is `EXUpdatesRuntimeVersion` and value is a string set to the desired runtime version. In AndroidManifest.xml, add a `<meta-data>` element whose `android:name` attribute is `expo.modules.updates.EXPO_RUNTIME_VERSION` and `android:value` attribute is the desired runtime version.
 
 	### iOS
 

--- a/docs/pages/distribution/runtime-versions.md
+++ b/docs/pages/distribution/runtime-versions.md
@@ -57,7 +57,7 @@ For an Android build, add a `<meta-data>` element to the `AndroidManifest.xml` w
 
 Yes, if you want to be able to control the runtime version on a platform level, you can:
 1. Have platform specific release channels: `ios-production`, `android-production`.
-2. Have platform specific runtime versions: `ios-1.0.0, `android-1.0.0.
+2. Have platform specific runtime versions: `ios-1.0.0, `android-1.0.0`.
 
 ### Can I test updates with a custom runtime version on Expo Go?
 

--- a/docs/pages/distribution/runtime-versions.md
+++ b/docs/pages/distribution/runtime-versions.md
@@ -4,7 +4,7 @@ title: Runtime Versions
 
 > Custom runtime versions are not supported on the classic build system (`expo build`); these apps will always use the SDK version as the basis for determining runtime compatibility. 
 
-Over-the-air updates with `expo-updates` will only work in binaries with a [compatible](../workflow/publishing/#what-version-of-the-app-will-my) runtime. By default, the runtime version is the Expo SDK version: the runtime is the set of libraries in the Expo SDK. Apps built with EAS Build will include only the dependencies that are present at the time that the app binary is built, and so the Expo SDK version will often not properly describe the runtime of the app. In these cases, you can start using `runtimeVersion` and it will take precedence over the Expo SDK version.
+Over-the-air updates with `expo-updates` work only in apps with a [compatible](../workflow/publishing/#what-version-of-the-app-will-my) runtime. By default, the runtime version is the Expo SDK version: the runtime is the set of libraries in the Expo SDK. If you choose to customize your runtime by adding or removing modules with native code, the Expo SDK version will no longer properly describe the runtime of the app. In these cases, you need to specify a `runtimeVersion` to ensure your updates are delivered only to compatible clients.  This `runtimeVersion` should be updated whenever you update your project's native modules and change the JS–native interface.
 
 A runtime version must conform to this [description](../versions/latest/config/app/#runtimeversion)
 

--- a/docs/pages/distribution/runtime-versions.md
+++ b/docs/pages/distribution/runtime-versions.md
@@ -4,9 +4,9 @@ title: Runtime Versions
 
 > Custom runtime versions are not supported on the classic build system (`expo build`); these apps will always use the SDK version as the basis for determining runtime compatibility. 
 
-Every over-the-air update with `expo-updates` targets one [compatible](../workflow/publishing/#what-version-of-the-app-will-my) runtime. Each time you build a binary for your app it includes the native code present at the time of the build and only that code, and this unique combination and configuration of the build is what is represented by the runtime version.
+Each over-the-air update with `expo-updates` targets one [compatible](../workflow/publishing/#what-version-of-the-app-will-my) runtime. Each time you build a binary for your app it includes the native code present at the time of the build and only that code, and this unique combination and configuration of the build is what is represented by the runtime version.
 
-By default, the runtime version is determined by the Expo SDK version, but this will not adequately describe the different runtime versions of your app if you build more than once per SDK release. In this case, you will need to specify a `runtimeVersion` to ensure your updates are delivered only to compatible builds. This `runtimeVersion` should be updated whenever you update your project's native modules and/or change the JS–native interface.
+By default, the runtime version is determined by the Expo SDK version, but this will not adequately describe the different runtime versions of your app if you build more than once per SDK release. In this case, you will need to specify a `runtimeVersion` to ensure your updates are delivered only to compatible builds. This `runtimeVersion` should be updated whenever you update your project's native modules and change the JS–native interface.
 
 The runtime version string must conform to [this format](/versions/latest/config/app.md#runtimeversion).
 

--- a/docs/pages/distribution/runtime-versions.md
+++ b/docs/pages/distribution/runtime-versions.md
@@ -6,7 +6,11 @@ title: Runtime Versions
 
 Over-the-air updates with `expo-updates` will only work in binaries with a [compatible](../workflow/publishing/#what-version-of-the-app-will-my) runtime. By default, the runtime version is the Expo SDK version: the runtime is the set of libraries in the Expo SDK. Apps built with EAS Build will include only the dependencies that are present at the time that the app binary is built, and so the Expo SDK version will often not properly describe the runtime of the app. In these cases, you can start using `runtimeVersion` and it will take precedence over the Expo SDK version.
 
-The runtime version should be specified in your `app.json`:
+A runtime version must conform to this [description](../versions/latest/config/app/#runtimeversion)
+
+## Setting the runtime version for an update
+
+[Updates](/workflow/publishing.md#how-to-publish) published with the runtime version set in the `app.json` will be delivered to builds running the same runtime version, and only to those builds.
 
 ```json
 {
@@ -15,26 +19,31 @@ The runtime version should be specified in your `app.json`:
   }
 }
 ```
-## Setting the runtime version for an update
-
-[Updates](/workflow/publishing.md#how-to-publish) published with the runtime version set in the `app.json` will be delivered to builds running the same runtime version, and only to those builds.
-
 ## Setting the runtime version for a build
 
+### Configuration for the managed workflow
 
-There are two ways to set the runtime version of a build.
+If you are using the [managed workflow](../introduction/managed-vs-bare/#managed-workflow), than specifying the runtime version in your `app.json` is sufficient.
 
-1. (Recommended) After setting the runtime version in your `app.json`, run `expo prebuild`.
-2. Edit Expo.plist on iOS and AndroidManifest.xml on Android. In Expo.plist, add an entry whose key is `EXUpdatesRuntimeVersion` and value is a string set to the desired runtime version. In AndroidManifest.xml, add a `<meta-data>` element whose `android:name` attribute is `expo.modules.updates.EXPO_RUNTIME_VERSION` and `android:value` attribute is the desired runtime version.
-
-### Ios
-
-```DIFF
-+ <KEY>exuPDATESrUNTIMEvERSION</KEY>
-+ <STRING>2.718</STRING>
+```json
+{
+  "expo": {
+    "runtimeVersion": "2.718"
+  }
+}
 ```
-### aNDROID
 
-```DIFF
-+ <META-DATA ANDROID:NAME="EXPO.MODULES.UPDATES.expo_runtime_version" ANDROID:VALUE="2.718"/>
+### Configuration for the bare workflow
+If you are using the [bare workflow](../introduction/managed-vs-bare/#bare-workflow), you need to edit `Expo.plist` on iOS and `AndroidManifest.xml` on Android.
+
+For an iOS build, add an entry to the `Expo.plist` whose key is `EXUpdatesRuntimeVersion` and value is a string set to the desired runtime version. 
+
+```diff 
++ <key>EXUpdatesRuntimeVersion</key>
++ <string>2.718</string>
+```
+For an Android build, add a `<meta-data>` element to the `AndroidManifest.xml` whose `android:name` attribute is `expo.modules.updates.EXPO_RUNTIME_VERSION` and `android:value` attribute is the desired runtime version.
+
+```diff
++ <meta-data android:name="expo.modules.updates.EXPO_RUNTIME_VERSION" android:value="2.718"/>
 ```

--- a/docs/pages/distribution/runtime-versions.md
+++ b/docs/pages/distribution/runtime-versions.md
@@ -1,5 +1,5 @@
 ---
-title: Runtime Version
+title: Runtime Versions
 ---
 
 > Custom runtime versions are not supported on the classic build system (`expo build`); these apps will always use the SDK version as the basis for determining runtime compatibility. 
@@ -10,10 +10,9 @@ The runtime version should be specified in your `app.json`:
 
 ```json
 {
-	expo: {
-		...
-		runtimeVersion: "2.718",
-	}
+  "expo": {
+    "runtimeVersion": "2.718"
+  }
 }
 ```
 ## Setting the runtime version for an update
@@ -28,14 +27,14 @@ There are two ways to set the runtime version of a build.
 1. (Recommended) After setting the runtime version in your `app.json`, run `expo prebuild`.
 2. Edit Expo.plist on iOS and AndroidManifest.xml on Android. In Expo.plist, add an entry whose key is `EXUpdatesRuntimeVersion` and value is a string set to the desired runtime version. In AndroidManifest.xml, add a `<meta-data>` element whose `android:name` attribute is `expo.modules.updates.EXPO_RUNTIME_VERSION` and `android:value` attribute is the desired runtime version.
 
-	### iOS
+### Ios
 
-	```diff
-	+ <key>EXUpdatesRuntimeVersion</key>
-    + <string>2.718</string>
-	```
-	### Android
+```DIFF
++ <KEY>exuPDATESrUNTIMEvERSION</KEY>
++ <STRING>2.718</STRING>
+```
+### aNDROID
 
-	```diff
-	+ <meta-data android:name="expo.modules.updates.EXPO_RUNTIME_VERSION" android:value="2.718"/>
-	```
+```DIFF
++ <META-DATA ANDROID:NAME="EXPO.MODULES.UPDATES.expo_runtime_version" ANDROID:VALUE="2.718"/>
+```

--- a/docs/pages/distribution/runtime-versions.md
+++ b/docs/pages/distribution/runtime-versions.md
@@ -57,8 +57,9 @@ For an Android build, add a `<meta-data>` element to the `AndroidManifest.xml` w
 
 Yes, if you want to be able to control the runtime version on a platform level, you can:
 1. Have platform specific release channels: `ios-production`, `android-production`.
-2. Have platform specific runtime versions: `ios-1.0.0, `android-1.0.0`.
+2. Have platform specific runtime versions: `ios-1.0.0`, `android-1.0.0`.
 
+However, you cannot set a platform specific configuration field such as `ios.runtimeVersion` or `android.runtimeVersion`
 ### Can I test updates with a custom runtime version on Expo Go?
 
 Expo Go is meant for updates targeting an Expo SDK. If you want to test an update targeting a custom runtime version, you should use a [Custom Development Client](/clients/introduction.md).

--- a/docs/pages/distribution/runtime-versions.md
+++ b/docs/pages/distribution/runtime-versions.md
@@ -48,3 +48,15 @@ For an Android build, add a `<meta-data>` element to the `AndroidManifest.xml` w
 ```diff
 + <meta-data android:name="expo.modules.updates.EXPO_RUNTIME_VERSION" android:value="2.718"/>
 ```
+
+## FAQ
+
+### Can I have a different runtime version on iOS and Android?
+
+Yes, if you want to be able to control the runtime version on a platform level, you can:
+1. Have platform specific release channels: `ios-production`, `android-production`.
+2. Have platform specific runtime versions: `ios-1.0.0, `android-1.0.0.
+
+### Can I test updates with a custom runtime version on Expo Go?
+
+Expo Go is meant for updates targeting an Expo SDK. If you want to test an update targeting a custom runtime version, you should use a [Custom Development Client](/clients/introduction/)

--- a/docs/pages/distribution/runtime-versions.md
+++ b/docs/pages/distribution/runtime-versions.md
@@ -6,11 +6,11 @@ title: Runtime Versions
 
 Over-the-air updates with `expo-updates` work only in apps with a [compatible](../workflow/publishing/#what-version-of-the-app-will-my) runtime. By default, the runtime version is the Expo SDK version: the runtime is the set of libraries in the Expo SDK. If you choose to customize your runtime by adding or removing modules with native code, the Expo SDK version will no longer properly describe the runtime of the app. In these cases, you need to specify a `runtimeVersion` to ensure your updates are delivered only to compatible clients.  This `runtimeVersion` should be updated whenever you update your project's native modules and change the JS–native interface.
 
-A runtime version must conform to this [description](../versions/latest/config/app/#runtimeversion)
+The runtime version string must conform to [this format](/versions/latest/config/app.md#runtimeversion).
 
 ## Setting the runtime version for an update
 
-[Updates](/workflow/publishing.md#how-to-publish) published with the runtime version set in the `app.json` will be delivered to builds running the same runtime version, and only to those builds.
+[Updates](/workflow/publishing.md#how-to-publish) published with the runtime version set in `app.json` will be delivered to builds running the same runtime version, and only to those builds.
 
 ```json
 {
@@ -23,7 +23,7 @@ A runtime version must conform to this [description](../versions/latest/config/a
 
 ### Configuration for the managed workflow
 
-If you are using the [managed workflow](../introduction/managed-vs-bare/#managed-workflow), than specifying the runtime version in your `app.json` is sufficient.
+If you are using the [managed workflow](../introduction/managed-vs-bare/#managed-workflow), `runtimeVersion` is specified in `app.json`:
 
 ```json
 {
@@ -34,15 +34,16 @@ If you are using the [managed workflow](../introduction/managed-vs-bare/#managed
 ```
 
 ### Configuration for the bare workflow
-If you are using the [bare workflow](../introduction/managed-vs-bare/#bare-workflow), you need to edit `Expo.plist` on iOS and `AndroidManifest.xml` on Android.
 
-For an iOS build, add an entry to the `Expo.plist` whose key is `EXUpdatesRuntimeVersion` and value is a string set to the desired runtime version. 
+If you are using the [bare workflow](/introduction/managed-vs-bare.md#bare-workflow), set the runtime version in `Expo.plist` on iOS and `AndroidManifest.xml` on Android.
+
+For an iOS build, add an entry to the `Expo.plist` with the key `EXUpdatesRuntimeVersion`. The value is a string that represents the runtime version. 
 
 ```diff 
 + <key>EXUpdatesRuntimeVersion</key>
 + <string>2.718</string>
 ```
-For an Android build, add a `<meta-data>` element to the `AndroidManifest.xml` whose `android:name` attribute is `expo.modules.updates.EXPO_RUNTIME_VERSION` and `android:value` attribute is the desired runtime version.
+For an Android build, add a `<meta-data>` element to the `AndroidManifest.xml` whose `android:name` attribute is `expo.modules.updates.EXPO_RUNTIME_VERSION` and `android:value` attribute is a string that represents the desired runtime version.
 
 ```diff
 + <meta-data android:name="expo.modules.updates.EXPO_RUNTIME_VERSION" android:value="2.718"/>

--- a/docs/pages/distribution/runtime-versions.md
+++ b/docs/pages/distribution/runtime-versions.md
@@ -61,4 +61,4 @@ Yes, if you want to be able to control the runtime version on a platform level, 
 
 ### Can I test updates with a custom runtime version on Expo Go?
 
-Expo Go is meant for updates targeting an Expo SDK. If you want to test an update targeting a custom runtime version, you should use a [Custom Development Client](/clients/introduction/)
+Expo Go is meant for updates targeting an Expo SDK. If you want to test an update targeting a custom runtime version, you should use a [Custom Development Client](/clients/introduction.md).

--- a/docs/pages/distribution/runtime-versions.md
+++ b/docs/pages/distribution/runtime-versions.md
@@ -4,7 +4,9 @@ title: Runtime Versions
 
 > Custom runtime versions are not supported on the classic build system (`expo build`); these apps will always use the SDK version as the basis for determining runtime compatibility. 
 
-Over-the-air updates with `expo-updates` work only in apps with a [compatible](../workflow/publishing/#what-version-of-the-app-will-my) runtime. By default, the runtime version is the Expo SDK version: the runtime is the set of libraries in the Expo SDK. If you choose to customize your runtime by adding or removing modules with native code, the Expo SDK version will no longer properly describe the runtime of the app. In these cases, you need to specify a `runtimeVersion` to ensure your updates are delivered only to compatible clients.  This `runtimeVersion` should be updated whenever you update your project's native modules and change the JS–native interface.
+Every over-the-air update with `expo-updates` targets one [compatible](../workflow/publishing/#what-version-of-the-app-will-my) runtime. Each time you build a binary for your app it includes the native code present at the time of the build and only that code, and this unique combination and configuration of the build is what is represented by the runtime version.
+
+By default, the runtime version is determined by the Expo SDK version, but this will not adequately describe the different runtime versions of your app if you build more than once per SDK release. In this case, you will need to specify a `runtimeVersion` to ensure your updates are delivered only to compatible builds. This `runtimeVersion` should be updated whenever you update your project's native modules and/or change the JS–native interface.
 
 The runtime version string must conform to [this format](/versions/latest/config/app.md#runtimeversion).
 


### PR DESCRIPTION


# Why

Document runtime version usage.

# How

<img width="1470" alt="Screen Shot 2021-07-28 at 2 57 20 PM" src="https://user-images.githubusercontent.com/1220444/127401537-daa14153-5261-4dcd-b87a-df065b9003b5.png">

