### PR TITLE
[expo-dev-launcher][ios] add basic unit test setup

### DIFF
--- a/apps/bare-expo/ios/Podfile
+++ b/apps/bare-expo/ios/Podfile
@@ -17,6 +17,8 @@ abstract_target 'BareExpoMain' do
 
   use_react_native!(path: config['reactNativePath'])
 
+  pod 'expo-dev-launcher', path: '../../../packages/expo-dev-launcher', :testspecs => ['Tests']
+
   # Fix Google Sign-in and Flipper
   post_install do |installer|
     installer.target_installation_results.pod_target_installation_results.each do |pod_name, target_installation_result|

--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -138,6 +138,11 @@ PODS:
     - expo-dev-menu-interface
     - EXUpdatesInterface
     - React
+  - expo-dev-launcher/Tests (0.6.5):
+    - expo-dev-menu-interface
+    - EXUpdatesInterface
+    - React
+    - React-CoreModules
   - expo-dev-launcher/Unsafe (0.6.5):
     - expo-dev-menu-interface
     - EXUpdatesInterface
@@ -714,6 +719,7 @@ DEPENDENCIES:
   - EXPermissions (from `../../../packages/expo-permissions/ios`)
   - expo-dev-client (from `../../../packages/expo-dev-client`)
   - expo-dev-launcher (from `../../../packages/expo-dev-launcher`)
+  - expo-dev-launcher/Tests (from `../../../packages/expo-dev-launcher`)
   - expo-dev-menu (from `../../../packages/expo-dev-menu`)
   - expo-dev-menu-interface (from `../../../packages/expo-dev-menu-interface`)
   - expo-image (from `../../../packages/expo-image`)
@@ -1171,7 +1177,7 @@ SPEC CHECKSUMS:
   EXNotifications: 296d9487163c2c08fffec5e79a5f9094bc016d9c
   EXPermissions: c7bead8f093700d5fcfb4f41238430a51702c5c8
   expo-dev-client: 6f833f384c5fcc59e96a91268601dabcd16f70f0
-  expo-dev-launcher: 696f20b99996080a3eebdaa723627a614e526ada
+  expo-dev-launcher: 820a1c30483718a054a2ef0498a99cd588bfa82a
   expo-dev-menu: c1d43574828f37cb541a0bb52fe7bb7829586147
   expo-dev-menu-interface: 848563c91c9f36f963a8456e885129a46f4cdfa1
   expo-image: ea170930bd8bc42328ee74ff4dc861ca31587dc8
@@ -1270,6 +1276,6 @@ SPEC CHECKSUMS:
   Yoga: 7740b94929bbacbddda59bf115b5317e9a161598
   ZXingObjC: fdbb269f25dd2032da343e06f10224d62f537bdb
 
-PODFILE CHECKSUM: 0bc068eb4bf5e58571139cbf292a92e626939289
+PODFILE CHECKSUM: f331210d64cfd0446d6e7c8df31842a096c50f66
 
 COCOAPODS: 1.10.1

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Add basic setup for iOS unit tests. ([#13824](https://github.com/expo/expo/pull/13824) by [@esamelson](https://github.com/esamelson))
+
 ## 0.6.5 — 2021-07-16
 
 ### 🐛 Bug fixes

--- a/packages/expo-dev-launcher/expo-dev-launcher.podspec
+++ b/packages/expo-dev-launcher/expo-dev-launcher.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.source         = { :git => 'https://github.com/github_account/expo-development-client.git', :tag => "#{s.version}" }
   s.source_files   = 'ios/**/*.{h,m,swift,cpp}'
   s.preserve_paths = 'ios/**/*.{h,m,swift}'
-  s.exclude_files  = 'ios/Unsafe/**/*.{h,m,mm,swift,cpp}'
+  s.exclude_files  = ['ios/Unsafe/**/*.{h,m,mm,swift,cpp}', 'ios/Tests/**/*.{h,m,swift}']
   s.requires_arc   = true
   s.header_dir     = 'EXDevLauncher'
 
@@ -46,6 +46,11 @@ Pod::Spec.new do |s|
   
   s.subspec 'Main' do |main|
     main.dependency "expo-dev-launcher/Unsafe"
+  end
+
+  s.test_spec 'Tests' do |test_spec|
+    test_spec.source_files = 'ios/Tests/**/*.{h,m,swift}'
+    test_spec.dependency "React-CoreModules"
   end
   
   s.default_subspec = 'Main'

--- a/packages/expo-dev-launcher/ios/Tests/dummy.swift
+++ b/packages/expo-dev-launcher/ios/Tests/dummy.swift
@@ -1,0 +1,3 @@
+// This dummy Swift file is to persuade Xcode to include Swift runtime,
+// which is required when one of the dependency has some Swift code.
+// Read more here: https://github.com/CocoaPods/CocoaPods/issues/7170#issuecomment-339815814


### PR DESCRIPTION
# Why

Add some basic configuration for iOS unit tests in expo-dev-launcher. Needed for  https://github.com/expo/expo/pull/13825.

# How

- Added a test subspec to the podspec, as well as a dummy.swift file, following the pattern from expo-updates.
- Changed the way the package is installed in bare-expo so it also includes the test spec. This allows us to use the Bare Expo project to run the tests (either from the Xcode GUI or CLI).

This PR does not set up any CI job to run tests in this package; that will need to be done separately.

# Test Plan

- pod install in bare-expo works and project builds
- tests added in https://github.com/expo/expo/pull/13825 run

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).