### PR TITLE
[expo-dev-launcher] interpret URLs that return a JSON content-type as manifest URLs

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -141,6 +141,7 @@ PODS:
   - expo-dev-launcher/Tests (0.6.5):
     - expo-dev-menu-interface
     - EXUpdatesInterface
+    - OHHTTPStubs
     - React
     - React-CoreModules
   - expo-dev-launcher/Unsafe (0.6.5):
@@ -357,6 +358,19 @@ PODS:
     - nanopb/encode (= 2.30907.0)
   - nanopb/decode (2.30907.0)
   - nanopb/encode (2.30907.0)
+  - OHHTTPStubs (9.1.0):
+    - OHHTTPStubs/Default (= 9.1.0)
+  - OHHTTPStubs/Core (9.1.0)
+  - OHHTTPStubs/Default (9.1.0):
+    - OHHTTPStubs/Core
+    - OHHTTPStubs/JSON
+    - OHHTTPStubs/NSURLSession
+    - OHHTTPStubs/OHPathHelpers
+  - OHHTTPStubs/JSON (9.1.0):
+    - OHHTTPStubs/Core
+  - OHHTTPStubs/NSURLSession (9.1.0):
+    - OHHTTPStubs/Core
+  - OHHTTPStubs/OHPathHelpers (9.1.0)
   - PromisesObjC (1.2.12)
   - Protobuf (3.15.8)
   - RCTRequired (0.63.2)
@@ -820,6 +834,7 @@ SPEC REPOS:
     - MLKitFaceDetection
     - MLKitVision
     - nanopb
+    - OHHTTPStubs
     - PromisesObjC
     - Protobuf
     - SDWebImage
@@ -1177,7 +1192,7 @@ SPEC CHECKSUMS:
   EXNotifications: 296d9487163c2c08fffec5e79a5f9094bc016d9c
   EXPermissions: c7bead8f093700d5fcfb4f41238430a51702c5c8
   expo-dev-client: 6f833f384c5fcc59e96a91268601dabcd16f70f0
-  expo-dev-launcher: 820a1c30483718a054a2ef0498a99cd588bfa82a
+  expo-dev-launcher: 0b3fe43607f31238f49445e7310e185675061762
   expo-dev-menu: c1d43574828f37cb541a0bb52fe7bb7829586147
   expo-dev-menu-interface: 848563c91c9f36f963a8456e885129a46f4cdfa1
   expo-image: ea170930bd8bc42328ee74ff4dc861ca31587dc8
@@ -1226,6 +1241,7 @@ SPEC CHECKSUMS:
   MLKitFaceDetection: 5b92261dd6e4205e3dab0df62537ac3f4e90e5db
   MLKitVision: 51385878c9100024478971856510f9271ff555b5
   nanopb: 59221d7f958fb711001e6a449489542d92ae113e
+  OHHTTPStubs: 90eac6d8f2c18317baeca36698523dc67c513831
   PromisesObjC: 3113f7f76903778cf4a0586bd1ab89329a0b7b97
   Protobuf: adb85cd18a15bd1a777c158af9fd6e612a0e6d69
   RCTRequired: f13f25e7b12f925f1f6a6a8c69d929a03c0129fe

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed issue where Expo-hosted manifest URLs with `/index.exp?...` suffix could not be opened properly.
+- Fixed issue where Expo-hosted manifest URLs with `/index.exp?...` suffix could not be opened properly. ([#13825](https://github.com/expo/expo/pull/13825) by [@esamelson](https://github.com/esamelson))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed issue where Expo-hosted manifest URLs with `/index.exp?...` suffix could not be opened properly.
+
 ### 💡 Others
 
 - Add basic setup for iOS unit tests. ([#13824](https://github.com/expo/expo/pull/13824) by [@esamelson](https://github.com/esamelson))

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/manifest/DevLauncherManifestParser.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/manifest/DevLauncherManifestParser.kt
@@ -12,8 +12,11 @@ class DevLauncherManifestParser(
 ) {
   suspend fun isManifestUrl(): Boolean {
     val response = fetch(url, "HEAD").await(httpClient)
-    // published projects should respond unsuccessfully to HEAD requests sent with no headers
-    return !response.isSuccessful || response.header("Exponent-Server", null) != null
+    val contentType = response.header("Content-Type")
+    // published projects may respond unsuccessfully to HEAD requests sent with no headers
+    return !response.isSuccessful
+        || response.header("Exponent-Server", null) != null
+        || (contentType != null && contentType.startsWith("application/json"))
   }
 
   private suspend fun downloadManifest(): Reader {

--- a/packages/expo-dev-launcher/android/src/test/java/expo/modules/devlauncher/launcher/manifest/DevLauncherManifestParserTest.kt
+++ b/packages/expo-dev-launcher/android/src/test/java/expo/modules/devlauncher/launcher/manifest/DevLauncherManifestParserTest.kt
@@ -29,20 +29,64 @@ internal class DevLauncherManifestParserTest {
   }
 
   @Test
-  fun `checks if isManifestUrl detects expo server`() = runBlocking {
+  fun `isManifestUrl assumes unsuccessful responses indicate manifest URLs`() = runBlocking {
+    val manifestParser = DevLauncherManifestParser(
+        client,
+        Uri.parse(server.url("/").toString())
+    )
+
+    server.enqueue(MockResponse().setResponseCode(200))
+    Truth.assertThat(manifestParser.isManifestUrl()).isFalse()
+
+    server.enqueue(MockResponse().setResponseCode(400))
+    Truth.assertThat(manifestParser.isManifestUrl()).isTrue()
+
+    server.enqueue(MockResponse().setResponseCode(500))
+    Truth.assertThat(manifestParser.isManifestUrl()).isTrue()
+  }
+
+  @Test
+  fun `isManifestUrl checks content-type header`() = runBlocking {
+    val manifestParser = DevLauncherManifestParser(
+        client,
+        Uri.parse(server.url("/").toString())
+    )
+
+    server.enqueue(MockResponse().setResponseCode(200)
+        .setHeader("Content-Type", "application/json"))
+    Truth.assertThat(manifestParser.isManifestUrl()).isTrue()
+
+    server.enqueue(MockResponse().setResponseCode(200)
+        .setHeader("Content-Type", "application/json; charset=UTF-8"))
+    Truth.assertThat(manifestParser.isManifestUrl()).isTrue()
+
+    server.enqueue(MockResponse().setResponseCode(200)
+        .setHeader("Content-Type", "application/javascript"))
+    Truth.assertThat(manifestParser.isManifestUrl()).isFalse()
+
+    server.enqueue(MockResponse().setResponseCode(200)
+        .setHeader("Content-Type", "text/javascript"))
+    Truth.assertThat(manifestParser.isManifestUrl()).isFalse()
+
+    // content-type of response from http://localhost:8081 (no path) after running `react-native start`
+    server.enqueue(MockResponse().setResponseCode(200)
+        .setHeader("Content-Type", "text/html"))
+    Truth.assertThat(manifestParser.isManifestUrl()).isFalse()
+  }
+
+  @Test
+  fun `isManifestUrl detects expo dev server`() = runBlocking {
     val manifestParser = DevLauncherManifestParser(
       client,
       Uri.parse(server.url("/").toString())
     )
 
-    server.enqueue(MockResponse().setResponseCode(200).setHeader("Exponent-Server", "exponent server"))
+    server.enqueue(MockResponse().setResponseCode(200)
+        .setHeader("Exponent-Server", "exponent server"))
+    Truth.assertThat(manifestParser.isManifestUrl()).isTrue()
+
     server.enqueue(MockResponse().setResponseCode(200))
-
-    val isManifestUrl = manifestParser.isManifestUrl()
-    val isNotManifestUrl = manifestParser.isManifestUrl()
-
-    Truth.assertThat(isManifestUrl).isTrue()
-    Truth.assertThat(isNotManifestUrl).isFalse()
+    Truth.assertThat(manifestParser.isManifestUrl()).isFalse()
   }
 
   @Test

--- a/packages/expo-dev-launcher/expo-dev-launcher.podspec
+++ b/packages/expo-dev-launcher/expo-dev-launcher.podspec
@@ -51,6 +51,7 @@ Pod::Spec.new do |s|
   s.test_spec 'Tests' do |test_spec|
     test_spec.source_files = 'ios/Tests/**/*.{h,m,swift}'
     test_spec.dependency "React-CoreModules"
+    test_spec.dependency "OHHTTPStubs"
   end
   
   s.default_subspec = 'Main'

--- a/packages/expo-dev-launcher/ios/Manifest/EXDevLauncherManifestParser.m
+++ b/packages/expo-dev-launcher/ios/Manifest/EXDevLauncherManifestParser.m
@@ -42,6 +42,11 @@ typedef void (^CompletionHandler)(NSData *data, NSURLResponse *response);
       return;
     }
 
+    if ([headers[@"Content-Type"] hasPrefix:@"application/json"]) {
+      completion(YES);
+      return;
+    }
+
     completion(NO);
   }];
 }

--- a/packages/expo-dev-launcher/ios/Tests/EXDevLauncherManifestParserTests.m
+++ b/packages/expo-dev-launcher/ios/Tests/EXDevLauncherManifestParserTests.m
@@ -1,0 +1,124 @@
+//
+//  EXDevLauncherManifestParserTests.m
+//  expo-dev-launcher-Unit-Tests
+//
+//  Created by Eric Samelson on 7/28/21.
+//
+
+#import <XCTest/XCTest.h>
+#import <OHHTTPStubs/HTTPStubs.h>
+
+#import <EXDevLauncher/EXDevLauncherManifestParser.h>
+
+@interface EXDevLauncherManifestParserTests : XCTestCase
+
+@end
+
+@implementation EXDevLauncherManifestParserTests
+
+- (void)setUp
+{
+  // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown
+{
+  [HTTPStubs removeAllStubs];
+}
+
+- (void)testIsManifestURLNoHeaders
+{
+  [HTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest * _Nonnull request) {
+    return [request.URL.host isEqualToString:@"ohhttpstubs"] && [request.URL.path isEqualToString:@"/200"];
+  } withStubResponse:^HTTPStubsResponse * _Nonnull(NSURLRequest * _Nonnull request) {
+    return [HTTPStubsResponse responseWithData:[NSData new] statusCode:200 headers:nil];
+  }];
+  [HTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest * _Nonnull request) {
+    return [request.URL.host isEqualToString:@"ohhttpstubs"] && [request.URL.path isEqualToString:@"/400"];
+  } withStubResponse:^HTTPStubsResponse * _Nonnull(NSURLRequest * _Nonnull request) {
+    return [HTTPStubsResponse responseWithData:[NSData new] statusCode:400 headers:nil];
+  }];
+  [HTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest * _Nonnull request) {
+    return [request.URL.host isEqualToString:@"ohhttpstubs"] && [request.URL.path isEqualToString:@"/500"];
+  } withStubResponse:^HTTPStubsResponse * _Nonnull(NSURLRequest * _Nonnull request) {
+    return [HTTPStubsResponse responseWithData:[NSData new] statusCode:500 headers:nil];
+  }];
+
+  [self _testIsManifestURLString:@"http://ohhttpstubs/200" expected:NO description:@"should assume a successful (200) response with no headers means not a manifest URL"];
+  [self _testIsManifestURLString:@"http://ohhttpstubs/400" expected:YES description:@"should assume a failed (400) response indicates a manifest URL"];
+  [self _testIsManifestURLString:@"http://ohhttpstubs/500" expected:YES description:@"should assume a failed (500) response indicates a manifest URL"];
+}
+
+- (void)testIsManifestURLContentType
+{
+  [HTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest * _Nonnull request) {
+    return [request.URL.host isEqualToString:@"ohhttpstubs"] && [request.URL.path isEqualToString:@"/json1"];
+  } withStubResponse:^HTTPStubsResponse * _Nonnull(NSURLRequest * _Nonnull request) {
+    return [HTTPStubsResponse responseWithData:[NSData new] statusCode:200 headers:@{@"Content-Type": @"application/json"}];
+  }];
+  [HTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest * _Nonnull request) {
+    return [request.URL.host isEqualToString:@"ohhttpstubs"] && [request.URL.path isEqualToString:@"/json2"];
+  } withStubResponse:^HTTPStubsResponse * _Nonnull(NSURLRequest * _Nonnull request) {
+    return [HTTPStubsResponse responseWithData:[NSData new] statusCode:200 headers:@{@"Content-Type": @"application/json; charset=UTF-8"}];
+  }];
+  [HTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest * _Nonnull request) {
+    return [request.URL.host isEqualToString:@"ohhttpstubs"] && [request.URL.path isEqualToString:@"/js1"];
+  } withStubResponse:^HTTPStubsResponse * _Nonnull(NSURLRequest * _Nonnull request) {
+    return [HTTPStubsResponse responseWithData:[NSData new] statusCode:200 headers:@{@"Content-Type": @"application/javascript"}];
+  }];
+  [HTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest * _Nonnull request) {
+    return [request.URL.host isEqualToString:@"ohhttpstubs"] && [request.URL.path isEqualToString:@"/js2"];
+  } withStubResponse:^HTTPStubsResponse * _Nonnull(NSURLRequest * _Nonnull request) {
+    return [HTTPStubsResponse responseWithData:[NSData new] statusCode:200 headers:@{@"Content-Type": @"text/javascript"}];
+  }];
+  [HTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest * _Nonnull request) {
+    return [request.URL.host isEqualToString:@"ohhttpstubs"] && [request.URL.path isEqualToString:@"/html"];
+  } withStubResponse:^HTTPStubsResponse * _Nonnull(NSURLRequest * _Nonnull request) {
+    return [HTTPStubsResponse responseWithData:[NSData new] statusCode:200 headers:@{@"Content-Type": @"text/html"}];
+  }];
+
+  [self _testIsManifestURLString:@"http://ohhttpstubs/json1" expected:YES description:@"should assume a JSON content-type indicates a manifest URL"];
+  [self _testIsManifestURLString:@"http://ohhttpstubs/json2" expected:YES description:@"should assume a JSON content-type indicates a manifest URL"];
+  [self _testIsManifestURLString:@"http://ohhttpstubs/js1" expected:NO description:@"should assume a javascript content-type indicates a bundler server"];
+  [self _testIsManifestURLString:@"http://ohhttpstubs/js2" expected:NO description:@"should assume a javascript content-type indicates a bundler server"];
+
+  // content-type of response from http://localhost:8081 (no path) after running `react-native start`
+  [self _testIsManifestURLString:@"http://ohhttpstubs/html" expected:NO description:@"should assume an HTML content-type indicates a bundler server"];
+}
+
+- (void)testIsManifestURLExpoDevServer
+{
+  [HTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest * _Nonnull request) {
+    return [request.URL.host isEqualToString:@"ohhttpstubs"] && [request.URL.path isEqualToString:@"/no-expo-server"];
+  } withStubResponse:^HTTPStubsResponse * _Nonnull(NSURLRequest * _Nonnull request) {
+    return [HTTPStubsResponse responseWithData:[NSData new] statusCode:200 headers:nil];
+  }];
+  [HTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest * _Nonnull request) {
+    return [request.URL.host isEqualToString:@"ohhttpstubs"] && [request.URL.path isEqualToString:@"/expo-server"];
+  } withStubResponse:^HTTPStubsResponse * _Nonnull(NSURLRequest * _Nonnull request) {
+    return [HTTPStubsResponse responseWithData:[NSData new] statusCode:200 headers:@{@"Exponent-Server": @"exponent server"}];
+  }];
+  
+  [self _testIsManifestURLString:@"http://ohhttpstubs/no-expo-server" expected:NO description:@"should assume a response with no exponent-server header means not a manifest URL"];
+  [self _testIsManifestURLString:@"http://ohhttpstubs/expo-server" expected:YES description:@"should detect exponent-server header from expo dev server"];
+}
+
+- (void)_testIsManifestURLString:(NSString *)urlString expected:(BOOL)expectedIsManifestUrl description:(NSString *)description
+{
+  NSURL *url = [NSURL URLWithString:urlString];
+  EXDevLauncherManifestParser *parser = [[EXDevLauncherManifestParser alloc] initWithURL:url session:NSURLSession.sharedSession];
+  
+  XCTestExpectation *expectation = [self expectationWithDescription:description];
+  
+  [parser isManifestURLWithCompletion:^(BOOL isManifestURL) {
+    XCTAssertEqual(expectedIsManifestUrl, isManifestURL);
+    [expectation fulfill];
+  } onError:^(NSError * _Nonnull error) {
+    XCTFail(@"Response should have been successful");
+    [expectation fulfill];
+  }];
+  
+  [self waitForExpectationsWithTimeout:5 handler:nil];
+}
+
+@end


### PR DESCRIPTION
# Why

Fixes #13711 

exp.host project URLs with `/index.exp?sdkVersion=42.0.0` respond with 200s even if no special headers are sent. This breaks our assumption in the `DevLauncherManifestParser.isManifestUrl` method.

# How

If the HEAD request comes back with `Content-Type: application/json` assume it is a manifest URL.

# Test Plan

Tested this manually by ensuring on both platforms that the following URLs opened successfully:
- `https://exp.host/@esamelson/sdk42updates`
- `https://exp.host/@esamelson/sdk42updates/index.exp?sdkVersion=42.0.0`
- `http://localhost:8081` after running `react-native start` in a bare project
- `http://localhost:8081/index.bundle?platform=[ios,android]&dev=true&hot=false&minify=false`

Also added unit tests on both platforms. Relies on https://github.com/expo/expo/pull/13824 for the iOS unit test setup.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).