### PR TITLE
[android] Add .editorconfig for Kotlin

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[{*.kt,*.kts}]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+max_line_length = 120
+tab_width = 2
+trim_trailing_whitespace = true

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,7 @@
 {
   "recommendations": [
     "dbaeumer.vscode-eslint",
+    "editorconfig.editorconfig",
     "esbenp.prettier-vscode",
     "stkb.rewrap"
   ]

--- a/android/.editorconfig
+++ b/android/.editorconfig
@@ -1,0 +1,1 @@
+.editorconfig

--- a/apps/bare-expo/android/.editorconfig
+++ b/apps/bare-expo/android/.editorconfig
@@ -1,0 +1,1 @@
+.editorconfig


### PR DESCRIPTION
# Why

- For bare-expo Android Studio lint settings were different than ktlint settings.
- Expo-go didn't have any Android Studio lint settings.
- Kotlin lint settings were messy.

# How

- Added `.editorconfig` file and symlinks to it in expo-go and bare-expo android directories.
- Set ktlint to take properties from `.editorconfig` file.
- Added suggested [editorconfig plugin](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig) for VS Code.
