### PR TITLE
[android] add tests for AppLoaderFactory and UpdatesHelper

### DIFF
--- a/packages/expo-dev-launcher/android/build.gradle
+++ b/packages/expo-dev-launcher/android/build.gradle
@@ -101,9 +101,12 @@ dependencies {
 
   api "io.insert-koin:koin-core:3.1.2"
 
+  testImplementation 'androidx.test:core:1.0.0'
   testImplementation "com.google.truth:truth:1.1.2"
-  testImplementation "org.robolectric:robolectric:4.3.1"
-  testImplementation 'io.mockk:mockk:1.9.3'
   testImplementation 'com.squareup.okhttp3:mockwebserver:4.3.1'
+  testImplementation "io.insert-koin:koin-test:3.1.2"
+  testImplementation "io.insert-koin:koin-test-junit4:3.1.2"
+  testImplementation 'io.mockk:mockk:1.9.3'
+  testImplementation "org.robolectric:robolectric:4.3.1"
 }
 

--- a/packages/expo-dev-launcher/android/src/test/java/expo/modules/devlauncher/helpers/DevLauncherUpdatesHelperTest.kt
+++ b/packages/expo-dev-launcher/android/src/test/java/expo/modules/devlauncher/helpers/DevLauncherUpdatesHelperTest.kt
@@ -1,0 +1,76 @@
+package expo.modules.devlauncher.helpers
+
+import android.content.Context
+import android.net.Uri
+import androidx.test.core.app.ApplicationProvider
+import com.facebook.react.ReactNativeHost
+import com.google.common.truth.Truth
+import expo.modules.devlauncher.helpers.loadUpdate
+import expo.modules.devlauncher.koin.DevLauncherKoinContext
+import expo.modules.devlauncher.launcher.DevLauncherControllerInterface
+import expo.modules.devlauncher.launcher.manifest.DevLauncherManifest
+import expo.modules.devlauncher.launcher.manifest.DevLauncherManifestParser
+import expo.modules.updatesinterface.UpdatesInterface
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.slot
+import kotlinx.coroutines.runBlocking
+import org.json.JSONObject
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.koin.dsl.module
+import org.robolectric.RobolectricTestRunner
+import java.lang.Exception
+
+@RunWith(RobolectricTestRunner::class)
+internal class DevLauncherUpdatesHelperTest {
+
+  private val context: Context = ApplicationProvider.getApplicationContext()
+  private val configuration = createUpdatesConfigurationWithUrl(Uri.parse("https://exp.host/@esamelson/sdk42updates"))
+  private val mockManifest = JSONObject("{\"icon\":\"./assets/icon.png\",\"name\":\"sdk42updates\",\"slug\":\"sdk42updates\",\"splash\":{\"image\":\"./assets/splash.png\",\"imageUrl\":\"https://d1wp6m56sqw74a.cloudfront.net/~assets/201a91bd1740bb1d6a1dbad049310724\",\"resizeMode\":\"contain\",\"backgroundColor\":\"#ffffff\"},\"iconUrl\":\"https://d1wp6m56sqw74a.cloudfront.net/~assets/4e3f888fc8475f69fd5fa32f1ad5216a\",\"version\":\"1.0.0\",\"sdkVersion\":\"42.0.0\",\"orientation\":\"portrait\",\"currentFullName\":\"@esamelson/sdk42updates\",\"originalFullName\":\"@esamelson/sdk42updates\",\"id\":\"@esamelson/sdk42updates\",\"projectId\":\"04e1e9f2-b297-44da-a11c-90a6a27859bc\",\"scopeKey\":\"@esamelson/sdk42updates\",\"releaseId\":\"a2b0a544-40f0-4fd6-9972-19f094380681\",\"publishedTime\":\"2021-07-13T22:29:24.170Z\",\"commitTime\":\"2021-07-13T22:29:24.209Z\",\"bundleUrl\":\"https://d1wp6m56sqw74a.cloudfront.net/%40esamelson%2Fsdk42updates%2F1.0.0%2F8c3e605420e77ba9fe35a0a7ef8459a9-42.0.0-ios.js\",\"bundleKey\":\"8c3e605420e77ba9fe35a0a7ef8459a9\",\"releaseChannel\":\"default\",\"hostUri\":\"exp.host/@esamelson/sdk42updates\"}")
+  private val mockUpdate = object : UpdatesInterface.Update {
+    override fun getManifest(): JSONObject = mockManifest
+    override fun getLaunchAssetPath(): String = ""
+  }
+
+  @Test
+  fun `passes true shouldContinue value through to UpdatesInterface`() = runBlocking<Unit> {
+    val updatesInterface = mockUpdatesInterface {
+      Truth.assertThat(it).isTrue()
+    }
+    val loadedUpdate = updatesInterface.loadUpdate(configuration, context) { true }
+    Truth.assertThat(loadedUpdate).isEqualTo(mockUpdate)
+  }
+
+  @Test
+  fun `passes false shouldContinue value through to UpdatesInterface`() = runBlocking<Unit> {
+    val updatesInterface = mockUpdatesInterface {
+      Truth.assertThat(it).isFalse()
+    }
+    updatesInterface.loadUpdate(configuration, context) { false }
+  }
+
+  private fun mockUpdatesInterface(verifyOnManifestLoadedCallback: (Boolean) -> Unit): UpdatesInterface {
+    val updatesInterface = mockk<UpdatesInterface>()
+    val slot = slot<UpdatesInterface.UpdateCallback>()
+    every {
+      updatesInterface.fetchUpdateWithConfiguration(any(), any(), capture(slot))
+    } answers {
+      val callback = slot.captured
+      val onManifestLoadedCallbackValue = callback.onManifestLoaded(mockManifest)
+      verifyOnManifestLoadedCallback(onManifestLoadedCallbackValue)
+
+      // mock the behavior of the UpdatesDevLauncherController
+      if (onManifestLoadedCallbackValue) {
+        callback.onSuccess(mockUpdate)
+      } else {
+        callback.onSuccess(null)
+      }
+    }
+    return updatesInterface
+  }
+}

--- a/packages/expo-dev-launcher/android/src/testDebug/java/expo/modules/devlauncher/launcher/loaders/DevLauncherAppLoaderFactoryTest.kt
+++ b/packages/expo-dev-launcher/android/src/testDebug/java/expo/modules/devlauncher/launcher/loaders/DevLauncherAppLoaderFactoryTest.kt
@@ -1,0 +1,150 @@
+package expo.modules.devlauncher.launcher.loaders
+
+import android.content.Context
+import android.net.Uri
+import androidx.test.core.app.ApplicationProvider
+import com.facebook.react.ReactNativeHost
+import com.google.common.truth.Truth
+import expo.modules.devlauncher.helpers.loadUpdate
+import expo.modules.devlauncher.koin.DevLauncherKoinContext
+import expo.modules.devlauncher.launcher.DevLauncherControllerInterface
+import expo.modules.devlauncher.launcher.manifest.DevLauncherManifest
+import expo.modules.devlauncher.launcher.manifest.DevLauncherManifestParser
+import expo.modules.updatesinterface.UpdatesInterface
+import io.mockk.coEvery
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.slot
+import kotlinx.coroutines.runBlocking
+import org.json.JSONObject
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.koin.dsl.module
+import org.robolectric.RobolectricTestRunner
+import java.lang.Exception
+
+@RunWith(RobolectricTestRunner::class)
+internal class DevLauncherAppLoaderFactoryTest {
+
+  private val developmentManifestURL = Uri.parse("http://10.0.2.2:8081")
+  private val developmentManifestJSONString = "{\"name\":\"sdk42updates\",\"slug\":\"sdk42updates\",\"version\":\"1.0.0\",\"orientation\":\"portrait\",\"icon\":\"./assets/icon.png\",\"sdkVersion\":\"42.0.0\",\"developer\":{\"tool\":\"expo-cli\",\"projectRoot\":\"/Users/eric/expo/sdk42updates\"},\"packagerOpts\":{\"scheme\":null,\"hostType\":\"lan\",\"lanType\":\"ip\",\"devClient\":false,\"dev\":true,\"minify\":false,\"urlRandomness\":null,\"https\":false},\"mainModuleName\":\"node_modules/expo/AppEntry\",\"bundleUrl\":\"http://192.168.0.58:19000/node_modules/expo/AppEntry.bundle?platform=ios&dev=true&hot=false&minify=false\",\"debuggerHost\":\"192.168.0.58:19000\",\"logUrl\":\"http://192.168.0.58:19000/logs\",\"hostUri\":\"192.168.0.58:19000\",\"iconUrl\":\"http://192.168.0.58:19000/assets/./assets/icon.png\"}"
+  private val publishedManifestURL = Uri.parse("https://exp.host/@esamelson/sdk42updates")
+  private val publishedManifestJSONString = "{\"icon\":\"./assets/icon.png\",\"name\":\"sdk42updates\",\"slug\":\"sdk42updates\",\"splash\":{\"image\":\"./assets/splash.png\",\"imageUrl\":\"https://d1wp6m56sqw74a.cloudfront.net/~assets/201a91bd1740bb1d6a1dbad049310724\",\"resizeMode\":\"contain\",\"backgroundColor\":\"#ffffff\"},\"iconUrl\":\"https://d1wp6m56sqw74a.cloudfront.net/~assets/4e3f888fc8475f69fd5fa32f1ad5216a\",\"version\":\"1.0.0\",\"sdkVersion\":\"42.0.0\",\"orientation\":\"portrait\",\"currentFullName\":\"@esamelson/sdk42updates\",\"originalFullName\":\"@esamelson/sdk42updates\",\"id\":\"@esamelson/sdk42updates\",\"projectId\":\"04e1e9f2-b297-44da-a11c-90a6a27859bc\",\"scopeKey\":\"@esamelson/sdk42updates\",\"releaseId\":\"a2b0a544-40f0-4fd6-9972-19f094380681\",\"publishedTime\":\"2021-07-13T22:29:24.170Z\",\"commitTime\":\"2021-07-13T22:29:24.209Z\",\"bundleUrl\":\"https://d1wp6m56sqw74a.cloudfront.net/%40esamelson%2Fsdk42updates%2F1.0.0%2F8c3e605420e77ba9fe35a0a7ef8459a9-42.0.0-ios.js\",\"bundleKey\":\"8c3e605420e77ba9fe35a0a7ef8459a9\",\"releaseChannel\":\"default\",\"hostUri\":\"exp.host/@esamelson/sdk42updates\"}"
+
+  @Before
+  fun setup() {
+    val reactNativeHost = mockk<ReactNativeHost>(relaxed = true)
+    val devLauncherController = mockk<DevLauncherControllerInterface>(relaxed = true)
+    DevLauncherKoinContext.app.koin.loadModules(listOf(
+      module {
+        single<Context> { ApplicationProvider.getApplicationContext() }
+        single { reactNativeHost }
+        single { devLauncherController }
+        single<UpdatesInterface?> { null }
+      }
+    ))
+  }
+
+  @Test
+  fun `loads app as React Native bundle if url is not a manifest url`() = runBlocking<Unit> {
+    val appLoaderFactory = DevLauncherAppLoaderFactory()
+
+    val manifestParser = mockk<DevLauncherManifestParser>()
+    coEvery { manifestParser.isManifestUrl() } returns false
+
+    val appLoader = appLoaderFactory.createAppLoader(developmentManifestURL, manifestParser)
+    Truth.assertThat(appLoader).isInstanceOf(DevLauncherReactNativeAppLoader::class.java)
+    Truth.assertThat(appLoaderFactory.shouldUseDeveloperSupport()).isTrue()
+  }
+
+  @Test
+  fun `loads app locally if manifest indicates developer tool and no updatesInterface exists`() = runBlocking<Unit> {
+    val appLoaderFactory = DevLauncherAppLoaderFactory()
+
+    val manifestParser = mockk<DevLauncherManifestParser>()
+    val manifest = DevLauncherManifest.fromJson(developmentManifestJSONString.reader())
+    coEvery { manifestParser.isManifestUrl() } returns true
+    coEvery { manifestParser.parseManifest() } returns manifest
+
+    val appLoader = appLoaderFactory.createAppLoader(developmentManifestURL, manifestParser)
+    Truth.assertThat(appLoader).isInstanceOf(DevLauncherLocalAppLoader::class.java)
+    Truth.assertThat(appLoaderFactory.shouldUseDeveloperSupport()).isTrue()
+  }
+
+  @Test
+  fun `throws if manifest is published and no updatesInterface exists`() {
+    val appLoaderFactory = DevLauncherAppLoaderFactory()
+
+    val manifestParser = mockk<DevLauncherManifestParser>()
+    val manifest = DevLauncherManifest.fromJson(publishedManifestJSONString.reader())
+    coEvery { manifestParser.isManifestUrl() } returns true
+    coEvery { manifestParser.parseManifest() } returns manifest
+
+    Assert.assertThrows(Exception::class.java) {
+      runBlocking { appLoaderFactory.createAppLoader(publishedManifestURL, manifestParser) }
+    }
+  }
+
+  @Test
+  fun `loads app locally if manifest indicates developer tool and updatesInterface exists`() = runBlocking<Unit> {
+    mockUpdatesInterface(developmentManifestJSONString) {
+      Truth.assertThat(it).isFalse()
+    }
+    val appLoaderFactory = DevLauncherAppLoaderFactory()
+
+    val manifestParser = mockk<DevLauncherManifestParser>()
+    coEvery { manifestParser.isManifestUrl() } returns true
+
+    val appLoader = appLoaderFactory.createAppLoader(developmentManifestURL, manifestParser)
+    Truth.assertThat(appLoader).isInstanceOf(DevLauncherLocalAppLoader::class.java)
+    Truth.assertThat(appLoaderFactory.shouldUseDeveloperSupport()).isTrue()
+  }
+
+  @Test
+  fun `loads published app if manifest is published and updatesInterface exists`() = runBlocking<Unit> {
+    mockUpdatesInterface(publishedManifestJSONString) {
+      Truth.assertThat(it).isTrue()
+    }
+    val appLoaderFactory = DevLauncherAppLoaderFactory()
+
+    val manifestParser = mockk<DevLauncherManifestParser>()
+    coEvery { manifestParser.isManifestUrl() } returns true
+
+    val appLoader = appLoaderFactory.createAppLoader(publishedManifestURL, manifestParser)
+    Truth.assertThat(appLoader).isInstanceOf(DevLauncherPublishedAppLoader::class.java)
+    Truth.assertThat(appLoaderFactory.shouldUseDeveloperSupport()).isFalse()
+  }
+
+  private fun mockUpdatesInterface(manifestJSONString: String, verifyShouldContinue: (Boolean) -> Unit) {
+    val updatesInterface = mockk<UpdatesInterface>()
+    val manifest = JSONObject(manifestJSONString)
+    val slot = slot<(JSONObject) -> Boolean>()
+
+    // mock extension function defined at the module level
+    mockkStatic("expo.modules.devlauncher.helpers.DevLauncherUpdatesHelperKt")
+
+    coEvery {
+      updatesInterface.loadUpdate(
+        configuration = any(),
+        context = any(),
+        shouldContinue = capture(slot)
+      )
+    } answers {
+      // fire captured shouldContinue callback and verify return value is what we expect
+      verifyShouldContinue(slot.captured(manifest))
+
+      object : UpdatesInterface.Update {
+        override fun getManifest(): JSONObject = manifest
+        override fun getLaunchAssetPath(): String = ""
+      }
+    }
+
+    DevLauncherKoinContext.app.koin.loadModules(listOf(
+      module {
+        single { updatesInterface }
+      }
+    ))
+  }
+}


### PR DESCRIPTION
# Why

ENG-1610

# How

- Added unit tests to AppLoaderFactory that ensure the correct subclass of `DevLauncherAppLoader` is created in each case.
- Added unit tests to UpdatesHelper's `loadUpdate` function to ensure it passes the correct values back into the Java implementation of UpdatesInterface.

# Test Plan

Tests pass ✅ 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).