### PR TITLE
[Docs] update eas build example config for changes

### DIFF
--- a/docs/pages/clients/eas-build.md
+++ b/docs/pages/clients/eas-build.md
@@ -15,71 +15,28 @@ You can set up your project to use EAS by running `eas build:configure`.  If you
 
 If you have already have an `eas.json` file in your project, you'll need to update your config to create builds of your custom client.
 
-<Tabs tabs={["With config plugins", "If you are directly managing your native projects"]}>
-
-<Tab >
-
-`expo-dev-client` does not modify your application's behavior in a build you would submit to the Play Store or App Store, so you must specify `development-client` as your `buildType` to create a custom development client.
-To share the build with your internal team, use [`internal` distribution](/build/internal-distribution.md).
+To create a custom development client instead of a release build, set the `developmentClient` value to `true`.
+To create the build that can be installed on a physical device, set the `distribution` value to [`internal`](/build/internal-distribution.md).
+To create a simulator build, set the `ios.simulator` value to `true`.
 
 An example configuration would look like this:
 ```json
 {
-  "builds": {
-    "android": {
-      "release": {
-        "buildType": "app-bundle"
-      },
-      "development": {
-        "distribution": "internal",
-        "buildType": "development-client"
-      }
+  "build": {
+    "release": {},
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal"
     },
-    "ios": {
-      "release": {
-        "buildType": "release"
-      },
-      "development": {
-        "distribution": "internal",
-        "buildType": "development-client"
+    "development-simulator": {
+      "developmentClient": true,
+      "ios": {
+        "simulator": true
       }
     }
   }
 }
 ```
-</Tab>
-<Tab>
-
-`expo-dev-client` does not modify your application's behavior in a "Release" build, so you must create a "Debug" build via `gradleCommand` (Android) or `schemeBuildConfiguraiton` (iOS) to create a custom development client.
-To share the build with your internal team, use [`internal` distribution](/build/internal-distribution.md).
-
-An example configuration would look like this:
-```json
-{
-  "builds": {
-    "android": {
-      "release": {
-        "gradleCommand": ":app:bundleRelease"
-      },
-      "development": {
-        "distribution": "internal",
-        "gradleCommand": ":app:assembleDebug"
-      }
-    },
-    "ios": {
-      "release": {
-        "schemeBuildConfiguration": "Release"
-      },
-      "development": {
-        "distribution": "internal",
-        "schemeBuildConfiguration": "Debug"
-      }
-    }
-  }
-}
-```
-</Tab>
-</Tabs>
 
 ## Generating your first build
 


### PR DESCRIPTION
DO NOT MERGE BEFORE CORRESPONDING eas-cli IS RELEASED

# Why

eas.json is getting a new format!

# How

Followed the lead of changes in https://github.com/expo/expo/pull/13813/files

# Test Plan

Ran locally.  It looks like this:
![image](https://user-images.githubusercontent.com/4551666/127578973-0af9fd4c-25ab-46fc-8025-5ca3466ddf3a.png)
