### PR TITLE
[template] Add react-native-safe-area-context to expo-template-bare-minimum

### DIFF
--- a/templates/expo-template-bare-minimum/package.json
+++ b/templates/expo-template-bare-minimum/package.json
@@ -19,6 +19,7 @@
     "react-native": "~0.63.4",
     "react-native-gesture-handler": "~1.10.2",
     "react-native-reanimated": "~2.2.0",
+    "react-native-safe-area-context": "3.2.0",
     "react-native-screens": "~3.3.0",
     "react-native-unimodules": "~0.14.1",
     "react-native-web": "~0.13.12"


### PR DESCRIPTION
# Why

We include `react-native-safe-area-context` as a dependency of `expo` and so users can import it in their app without having actually installed it when using Expo Go. This is problematic on EAS Build because it won't be autolinked in this case, because it's just a transitive dependency. In the event that this goes wrong for the user, there are no useful logs output in a release build, and they would need to run `expo run:ios` locally and understand that it's necessary to then install `react-native-safe-area-context` based on the error:

<img width="564" alt="Screen_Shot_2021-07-29_at_1 39 57_PM" src="https://user-images.githubusercontent.com/90494/127592340-5cb04f8e-a803-47b4-885e-30915d253966.png">

So, one solution to this could be to include `react-native-safe-area-context` in the template.

# How

n/a

# Test Plan

Import react-native-safe-area-context without installing it to your app dependencies, then run prebuild with this template. It should work.

# Checklist

- [n/a] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).