### PR TITLE
[android][screen-capture] Refactor deprecated function

### DIFF
--- a/packages/expo-screen-capture/CHANGELOG.md
+++ b/packages/expo-screen-capture/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 💡 Others
 
 - Export missing `Subscription` type. ([#13352](https://github.com/expo/expo/pull/13352) by [@Simek](https://github.com/Simek))
+- Refactor deprecated `Handler()` constructor([#13843](https://github.com/expo/expo/pull/13843) by [m1st4ke](https://github.com/m1st4ke))
 
 ## 3.2.0 — 2021-06-16
 

--- a/packages/expo-screen-capture/android/src/main/java/expo/modules/screencapture/ScreenShotEventEmitter.kt
+++ b/packages/expo-screen-capture/android/src/main/java/expo/modules/screencapture/ScreenShotEventEmitter.kt
@@ -7,18 +7,15 @@ import android.database.ContentObserver
 import android.net.Uri
 import android.os.Bundle
 import android.os.Handler
+import android.os.Looper
 import android.provider.MediaStore
 import android.util.Log
-
-import androidx.core.content.ContextCompat
 import androidx.annotation.Nullable
-
+import androidx.core.content.ContextCompat
 import expo.modules.core.ModuleRegistry
 import expo.modules.core.interfaces.LifecycleEventListener
 import expo.modules.core.interfaces.services.EventEmitter
 import expo.modules.core.interfaces.services.UIManager
-
-import java.lang.Exception
 
 class ScreenshotEventEmitter(val context: Context, moduleRegistry: ModuleRegistry) : LifecycleEventListener {
   private val onScreenshotEventName: String = "onScreenshot"
@@ -29,8 +26,10 @@ class ScreenshotEventEmitter(val context: Context, moduleRegistry: ModuleRegistr
   init {
     moduleRegistry.getModule(UIManager::class.java).registerLifecycleEventListener(this)
     eventEmitter = moduleRegistry.getModule(EventEmitter::class.java)
-
-    val contentObserver: ContentObserver = object : ContentObserver(Handler()) {
+    val looper = Looper.myLooper()
+        ?: throw RuntimeException(
+            "Can't create handler inside thread ${Thread.currentThread()}")
+    val contentObserver: ContentObserver = object : ContentObserver(Handler(looper)) {
       override fun onChange(selfChange: Boolean, uri: Uri?) {
         super.onChange(selfChange, uri)
         if (isListening) {

--- a/packages/expo-screen-capture/android/src/main/java/expo/modules/screencapture/ScreenShotEventEmitter.kt
+++ b/packages/expo-screen-capture/android/src/main/java/expo/modules/screencapture/ScreenShotEventEmitter.kt
@@ -27,8 +27,9 @@ class ScreenshotEventEmitter(val context: Context, moduleRegistry: ModuleRegistr
     moduleRegistry.getModule(UIManager::class.java).registerLifecycleEventListener(this)
     eventEmitter = moduleRegistry.getModule(EventEmitter::class.java)
     val looper = Looper.myLooper()
-        ?: throw RuntimeException(
-            "Can't create handler inside thread ${Thread.currentThread()}")
+      ?: throw RuntimeException(
+        "Can't create handler inside thread ${Thread.currentThread()}"
+      )
     val contentObserver: ContentObserver = object : ContentObserver(Handler(looper)) {
       override fun onChange(selfChange: Boolean, uri: Uri?) {
         super.onChange(selfChange, uri)


### PR DESCRIPTION
# Why

Current [`Handler`](https://developer.android.com/reference/android/os/Handler#Handler()) constructor was deprecated.

# How

Used another [`Handler`](https://developer.android.com/reference/android/os/Handler#Handler(android.os.Looper)) constructor

# Test Plan

Tested in bare-expo app

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).