### PR TITLE
[dev-menu-interface][ios] Prebuilding prepararion

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -152,8 +152,7 @@ PODS:
     - expo-dev-menu-interface
     - expo-dev-menu/Main (= 0.7.5)
     - React
-  - expo-dev-menu-interface (0.3.2):
-    - React
+  - expo-dev-menu-interface (0.3.2)
   - expo-dev-menu/Main (0.7.5):
     - expo-dev-menu-interface
     - expo-dev-menu/Vendored
@@ -1194,7 +1193,7 @@ SPEC CHECKSUMS:
   expo-dev-client: 6f833f384c5fcc59e96a91268601dabcd16f70f0
   expo-dev-launcher: 0b3fe43607f31238f49445e7310e185675061762
   expo-dev-menu: c1d43574828f37cb541a0bb52fe7bb7829586147
-  expo-dev-menu-interface: 848563c91c9f36f963a8456e885129a46f4cdfa1
+  expo-dev-menu-interface: 59fbd00f527c7ae65aa86144e6c8af3761fc037f
   expo-image: ea170930bd8bc42328ee74ff4dc861ca31587dc8
   ExpoModulesCore: 82ee658feb15e6804de9f3530c39c62ff900048b
   EXPrint: 61bbaa43c42c1badfa46de5be015d7d798d33583

--- a/packages/expo-dev-menu-interface/expo-dev-menu-interface.podspec
+++ b/packages/expo-dev-menu-interface/expo-dev-menu-interface.podspec
@@ -20,6 +20,4 @@ Pod::Spec.new do |s|
 
   # Swift/Objective-C compatibility
   s.pod_target_xcconfig = { "DEFINES_MODULE" => "YES" }
-
-  s.dependency 'React'
 end

--- a/packages/expo-dev-menu-interface/ios/DevMenuBridgeProtocol.swift
+++ b/packages/expo-dev-menu-interface/ios/DevMenuBridgeProtocol.swift
@@ -1,5 +1,7 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
+import Foundation
+
 @objc
 public protocol DevMenuBridgeProtocol {
   @objc

--- a/packages/expo-dev-menu-interface/ios/DevMenuDelegateProtocol.swift
+++ b/packages/expo-dev-menu-interface/ios/DevMenuDelegateProtocol.swift
@@ -1,5 +1,8 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
+import Foundation
+import UIKit
+
 @objc
 public protocol DevMenuDelegateProtocol {
   /**

--- a/packages/expo-dev-menu-interface/ios/DevMenuExtensionProtocol.swift
+++ b/packages/expo-dev-menu-interface/ios/DevMenuExtensionProtocol.swift
@@ -1,5 +1,7 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
+import Foundation
+
 @objc
 public protocol DevMenuExtensionSettingsProtocol {
   func wasRunOnDevelopmentBridge() -> Bool

--- a/packages/expo-dev-menu-interface/ios/DevMenuManagerProtocol.swift
+++ b/packages/expo-dev-menu-interface/ios/DevMenuManagerProtocol.swift
@@ -1,5 +1,7 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
+import Foundation
+
 @objc
 public protocol DevMenuManagerProtocol {
   /**

--- a/packages/expo-dev-menu-interface/ios/DevMenuManagerProviderProtocol.swift
+++ b/packages/expo-dev-menu-interface/ios/DevMenuManagerProviderProtocol.swift
@@ -1,5 +1,7 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
+import Foundation
+
 @objc
 public protocol DevMenuManagerProviderProtocol {
   

--- a/packages/expo-dev-menu-interface/ios/DevMenuUIResponderExtensionProtocol.swift
+++ b/packages/expo-dev-menu-interface/ios/DevMenuUIResponderExtensionProtocol.swift
@@ -1,5 +1,8 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
+import Foundation
+import UIKit
+
 @objc
 public protocol DevMenuUIResponderExtensionProtocol {
   

--- a/packages/expo-dev-menu-interface/ios/ExpoApiClient/DevMenuEASUpdates.swift
+++ b/packages/expo-dev-menu-interface/ios/ExpoApiClient/DevMenuEASUpdates.swift
@@ -1,5 +1,7 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
+import Foundation
+
 @objc
 public protocol DevMenuConstructibleFromDictionary {
   @objc

--- a/packages/expo-dev-menu-interface/ios/ExpoApiClient/DevMenuExpoApiClientProtocol.swift
+++ b/packages/expo-dev-menu-interface/ios/ExpoApiClient/DevMenuExpoApiClientProtocol.swift
@@ -1,5 +1,7 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
+import Foundation
+
 public typealias HTTPCompletionHandler = (Data?, URLResponse?, Error?) -> Void
 
 @objc

--- a/packages/expo-dev-menu-interface/ios/MenuItems/DevMenuAction.swift
+++ b/packages/expo-dev-menu-interface/ios/MenuItems/DevMenuAction.swift
@@ -1,5 +1,8 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
+import Foundation
+import UIKit
+
 @objc
 open class DevMenuAction: DevMenuScreenItem, DevMenuCallableProvider {
   @objc

--- a/packages/expo-dev-menu-interface/ios/MenuItems/DevMenuDataSource.swift
+++ b/packages/expo-dev-menu-interface/ios/MenuItems/DevMenuDataSource.swift
@@ -1,5 +1,7 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
+import Foundation
+
 @objc
 public protocol DevMenuDataSourceItem {
   @objc

--- a/packages/expo-dev-menu-interface/ios/MenuItems/DevMenuExportedCallable.swift
+++ b/packages/expo-dev-menu-interface/ios/MenuItems/DevMenuExportedCallable.swift
@@ -1,5 +1,8 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
+import Foundation
+import UIKit
+
 @objc
 public protocol DevMenuCallableProvider {
   @objc

--- a/packages/expo-dev-menu-interface/ios/MenuItems/DevMenuGroup.swift
+++ b/packages/expo-dev-menu-interface/ios/MenuItems/DevMenuGroup.swift
@@ -1,5 +1,7 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
+import Foundation
+
 @objc
 open class DevMenuGroup: DevMenuScreenItem, DevMenuItemsContainerProtocol {
   let container = DevMenuItemsContainer()

--- a/packages/expo-dev-menu-interface/ios/MenuItems/DevMenuItem.swift
+++ b/packages/expo-dev-menu-interface/ios/MenuItems/DevMenuItem.swift
@@ -1,5 +1,7 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
+import Foundation
+
 @objc
 open class DevMenuItem: NSObject {
   @objc(DevMenuItemType)

--- a/packages/expo-dev-menu-interface/ios/MenuItems/DevMenuItemsContainer.swift
+++ b/packages/expo-dev-menu-interface/ios/MenuItems/DevMenuItemsContainer.swift
@@ -1,5 +1,7 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
+import Foundation
+
 @objc
 public class DevMenuItemsContainer: NSObject, DevMenuItemsContainerProtocol {
   private var items: [DevMenuScreenItem] = []

--- a/packages/expo-dev-menu-interface/ios/MenuItems/DevMenuItemsContainerProtocol.swift
+++ b/packages/expo-dev-menu-interface/ios/MenuItems/DevMenuItemsContainerProtocol.swift
@@ -1,5 +1,7 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
+import Foundation
+
 @objc
 public protocol DevMenuItemsContainerProtocol {
   @objc

--- a/packages/expo-dev-menu-interface/ios/MenuItems/DevMenuLink.swift
+++ b/packages/expo-dev-menu-interface/ios/MenuItems/DevMenuLink.swift
@@ -1,5 +1,7 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
+import Foundation
+
 @objc
 public class DevMenuLink: DevMenuScreenItem {
   var target: String

--- a/packages/expo-dev-menu-interface/ios/MenuItems/DevMenuScreen.swift
+++ b/packages/expo-dev-menu-interface/ios/MenuItems/DevMenuScreen.swift
@@ -1,5 +1,7 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
+import Foundation
+
 @objc
 public class DevMenuScreen : DevMenuItem, DevMenuItemsContainerProtocol {
   let container = DevMenuItemsContainer()

--- a/packages/expo-dev-menu-interface/ios/MenuItems/DevMenuScreenItem.swift
+++ b/packages/expo-dev-menu-interface/ios/MenuItems/DevMenuScreenItem.swift
@@ -1,5 +1,7 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
+import Foundation
+
 @objc
 open class DevMenuScreenItem: DevMenuItem {
   // Static members fit better than enum as we allow any other number.

--- a/packages/expo-dev-menu-interface/ios/MenuItems/DevMenuSelectionList.swift
+++ b/packages/expo-dev-menu-interface/ios/MenuItems/DevMenuSelectionList.swift
@@ -1,5 +1,7 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
+import Foundation
+
 @objc
 public class DevMenuSelectionList: DevMenuScreenItem, DevMenuCallableProvider {
   @objc


### PR DESCRIPTION
# Why

Unfortunately, we can't pre-build this package due to the swift compiler issue - https://bugs.swift.org/browse/SR-14541. However, I downloaded swift 5.5 and everything seems to be working there. So we need to wait for the new XCode version. For now, I've just added needed imports and clean up dependencies.

# Test Plan

- bare-expo 