### PR TITLE
[expo-dev-launcher][android] add more unit tests

### DIFF
--- a/packages/expo-dev-launcher/android/build.gradle
+++ b/packages/expo-dev-launcher/android/build.gradle
@@ -101,7 +101,8 @@ dependencies {
 
   api "io.insert-koin:koin-core:3.1.2"
 
-  testImplementation 'androidx.test:core:1.0.0'
+  testImplementation 'androidx.test:core:1.4.0'
+  testImplementation 'androidx.test:core-ktx:1.4.0'
   testImplementation "com.google.truth:truth:1.1.2"
   testImplementation 'com.squareup.okhttp3:mockwebserver:4.3.1'
   testImplementation "io.insert-koin:koin-test:3.1.2"

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/DevLauncherRecentlyOpenedAppsRegistry.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/DevLauncherRecentlyOpenedAppsRegistry.kt
@@ -20,7 +20,7 @@ class DevLauncherRecentlyOpenedAppsRegistry(context: Context) {
   fun appWasOpened(url: Uri, name: String?) {
     sharedPreferences
       .edit()
-      .putString(url.toString(), Gson().toJson(DevLauncherAppEntry(System.currentTimeMillis(), name)))
+      .putString(url.toString(), Gson().toJson(DevLauncherAppEntry(TimeHelper.getCurrentTime(), name)))
       .apply()
   }
 
@@ -30,7 +30,7 @@ class DevLauncherRecentlyOpenedAppsRegistry(context: Context) {
     val gson = Gson()
     sharedPreferences.all.forEach { (url, appEntryString) ->
       val appEntry = gson.fromJson(appEntryString as String, DevLauncherAppEntry::class.java)
-      if (System.currentTimeMillis() - appEntry.timestamp > TIME_TO_REMOVE) {
+      if (TimeHelper.getCurrentTime() - appEntry.timestamp > TIME_TO_REMOVE) {
         toRemove.add(url)
         return@forEach
       }
@@ -45,5 +45,9 @@ class DevLauncherRecentlyOpenedAppsRegistry(context: Context) {
     }.apply()
 
     return result
+  }
+
+  object TimeHelper {
+    fun getCurrentTime() = System.currentTimeMillis()
   }
 }

--- a/packages/expo-dev-launcher/android/src/test/java/expo/modules/devlauncher/launcher/DevLauncherRecentlyOpenedAppsRegistryTest.kt
+++ b/packages/expo-dev-launcher/android/src/test/java/expo/modules/devlauncher/launcher/DevLauncherRecentlyOpenedAppsRegistryTest.kt
@@ -1,0 +1,44 @@
+package expo.modules.devlauncher.launcher
+
+import android.net.Uri
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class DevLauncherRecentlyOpenedAppsRegistryTest {
+  @Test
+  fun `adds app to registry`() {
+    val urlString = "http://localhost:8081"
+    val registry = DevLauncherRecentlyOpenedAppsRegistry(ApplicationProvider.getApplicationContext())
+    registry.appWasOpened(Uri.parse(urlString), "test-app")
+    val apps = registry.getRecentlyOpenedApps()
+    Truth.assertThat(apps[urlString]).isEqualTo("test-app")
+  }
+
+  @Test
+  fun `removes app from registry after 3 days have elapsed`() {
+    val currentTime = System.currentTimeMillis()
+    val time3DaysAnd1SecondAgo = currentTime - ((1000 * 60 * 60 * 24 * 3) + 1000)
+
+    mockkObject(DevLauncherRecentlyOpenedAppsRegistry.TimeHelper)
+    every {
+      DevLauncherRecentlyOpenedAppsRegistry.TimeHelper.getCurrentTime()
+    } returns time3DaysAnd1SecondAgo
+
+    val urlString = "http://localhost:8081"
+    val registry = DevLauncherRecentlyOpenedAppsRegistry(ApplicationProvider.getApplicationContext())
+    registry.appWasOpened(Uri.parse(urlString), "test-app")
+
+    unmockkAll()
+
+    val apps = registry.getRecentlyOpenedApps()
+    Truth.assertThat(apps[urlString]).isNull()
+  }
+}

--- a/packages/expo-dev-launcher/android/src/test/java/expo/modules/devlauncher/launcher/configurators/DevLauncherExpoActivityConfiguratorTest.kt
+++ b/packages/expo-dev-launcher/android/src/test/java/expo/modules/devlauncher/launcher/configurators/DevLauncherExpoActivityConfiguratorTest.kt
@@ -1,0 +1,73 @@
+package expo.modules.devlauncher.launcher.configurators
+
+import android.app.Activity
+import android.app.ActivityManager
+import android.content.Context
+import android.content.pm.ActivityInfo
+import android.graphics.Color
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.core.app.launchActivity
+import com.facebook.react.ReactActivity
+import com.google.common.truth.Truth
+import expo.modules.devlauncher.launcher.DevLauncherActivity
+import expo.modules.devlauncher.launcher.manifest.DevLauncherManifest
+import io.mockk.confirmVerified
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+internal class DevLauncherExpoActivityConfiguratorTest {
+
+  private val context: Context = ApplicationProvider.getApplicationContext()
+
+  @Config(sdk = [28])
+  @Test
+  fun `sets task description from manifest`() {
+    val manifest = DevLauncherManifest.fromJson("{\"name\":\"test-app-name\",\"primaryColor\":\"#cccccc\",\"slug\":\"test-app-slug\",\"version\":\"1.0.0\",\"sdkVersion\":\"42.0.0\",\"bundleUrl\":\"https://d1wp6m56sqw74a.cloudfront.net/%40esamelson%2Fsdk42updates%2F1.0.0%2F67b67696b1cab67319035d39a7379786-42.0.0-ios.js\",\"hostUri\":\"exp.host/@esamelson/sdk42updates\"}".reader())
+    val configurator = DevLauncherExpoActivityConfigurator(manifest, context)
+    val mockActivity = mockk<Activity>(relaxed = true)
+    val slot = slot<ActivityManager.TaskDescription>()
+
+    configurator.applyTaskDescription(mockActivity)
+    verify { mockActivity.setTaskDescription(capture(slot)) }
+    confirmVerified(mockActivity) // no other calls were made
+
+    Truth.assertThat(slot.captured.label).isEqualTo("test-app-name")
+    Truth.assertThat(slot.captured.primaryColor).isEqualTo(Color.parseColor("#cccccc"))
+  }
+
+  @Test
+  fun `does not set task description if manifest primaryColor is invalid`() {
+    val manifest = DevLauncherManifest.fromJson("{\"name\":\"test-app-name\",\"primaryColor\":\"invalid\",\"slug\":\"test-app-slug\",\"version\":\"1.0.0\",\"sdkVersion\":\"42.0.0\",\"bundleUrl\":\"https://d1wp6m56sqw74a.cloudfront.net/%40esamelson%2Fsdk42updates%2F1.0.0%2F67b67696b1cab67319035d39a7379786-42.0.0-ios.js\",\"hostUri\":\"exp.host/@esamelson/sdk42updates\"}".reader())
+    val configurator = DevLauncherExpoActivityConfigurator(manifest, context)
+    val mockActivity = mockk<Activity>(relaxed = true)
+
+    configurator.applyTaskDescription(mockActivity)
+    confirmVerified(mockActivity) // no calls were made to mockActivity
+  }
+
+  @Test
+  fun `sets orientation from manifest`() {
+    verifyOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT, "{\"orientation\":\"portrait\",\"name\":\"sdk42updates\",\"slug\":\"sdk42updates\",\"version\":\"1.0.0\",\"sdkVersion\":\"42.0.0\",\"bundleUrl\":\"https://d1wp6m56sqw74a.cloudfront.net/%40esamelson%2Fsdk42updates%2F1.0.0%2F67b67696b1cab67319035d39a7379786-42.0.0-ios.js\",\"hostUri\":\"exp.host/@esamelson/sdk42updates\"}")
+    verifyOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE, "{\"orientation\":\"landscape\",\"name\":\"sdk42updates\",\"slug\":\"sdk42updates\",\"version\":\"1.0.0\",\"sdkVersion\":\"42.0.0\",\"bundleUrl\":\"https://d1wp6m56sqw74a.cloudfront.net/%40esamelson%2Fsdk42updates%2F1.0.0%2F67b67696b1cab67319035d39a7379786-42.0.0-ios.js\",\"hostUri\":\"exp.host/@esamelson/sdk42updates\"}")
+    verifyOrientation(ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED, "{\"orientation\":\"default\",\"name\":\"sdk42updates\",\"slug\":\"sdk42updates\",\"version\":\"1.0.0\",\"sdkVersion\":\"42.0.0\",\"bundleUrl\":\"https://d1wp6m56sqw74a.cloudfront.net/%40esamelson%2Fsdk42updates%2F1.0.0%2F67b67696b1cab67319035d39a7379786-42.0.0-ios.js\",\"hostUri\":\"exp.host/@esamelson/sdk42updates\"}")
+    // orientation key missing
+    verifyOrientation(ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED, "{\"name\":\"sdk42updates\",\"slug\":\"sdk42updates\",\"version\":\"1.0.0\",\"platforms\":[\"ios\",\"android\",\"web\"],\"sdkVersion\":\"42.0.0\",\"bundleUrl\":\"https://d1wp6m56sqw74a.cloudfront.net/%40esamelson%2Fsdk42updates%2F1.0.0%2F67b67696b1cab67319035d39a7379786-42.0.0-ios.js\",\"hostUri\":\"exp.host/@esamelson/sdk42updates\"}")
+  }
+
+  private fun verifyOrientation(expectedOrientation: Int, manifestString: String) {
+    val manifest = DevLauncherManifest.fromJson(manifestString.reader())
+    val configurator = DevLauncherExpoActivityConfigurator(manifest, context)
+    val mockActivity = mockk<ReactActivity>(relaxed = true)
+
+    configurator.applyOrientation(mockActivity)
+    verify { mockActivity.requestedOrientation = expectedOrientation }
+    confirmVerified(mockActivity) // no other calls were made
+  }
+}


### PR DESCRIPTION
# Why

chipping away at ENG-1610

# How

Added unit tests to a couple more misc. classes in expo-dev-launcher. Added a `TimeHelper` object to `DevLauncherRecentlyOpenedAppsRegistry` to allow for easier mocking in the tests.

# Test Plan

Tests pass

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).