### PR TITLE
[home] Publish to @expo-dogfooding/home on every commit

### DIFF
--- a/.github/workflows/home.yml
+++ b/.github/workflows/home.yml
@@ -55,3 +55,39 @@ jobs:
           status: ${{ job.status }}
           fields: job,message,ref,eventName,author,took
           author_name: Home app
+
+  publish-dogfood-home:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    needs: build
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14.17'
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v2
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - run: yarn install --frozen-lockfile
+      - name: 🦴 Publish dogfood home
+        run: expotools publish-dogfood-home
+        env:
+          EXPO_DOGFOOD_HOME_ACCESS_TOKEN: ${{ secrets.EXPO_DOGFOOD_HOME_ACCESS_TOKEN }}
+      - name: 🔔 Notify on Slack
+        uses: 8398a7/action-slack@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_api }}
+        with:
+          channel: '#api'
+          status: ${{ job.status }}
+          fields: job,message,ref,eventName,author,took
+          author_name: Home app

--- a/tools/src/ExpoCLI.ts
+++ b/tools/src/ExpoCLI.ts
@@ -1,6 +1,6 @@
+import spawnAsync from '@expo/spawn-async';
 import path from 'path';
 import process from 'process';
-import spawnAsync from '@expo/spawn-async';
 
 import { EXPO_DIR } from './Constants';
 

--- a/tools/src/XDL.ts
+++ b/tools/src/XDL.ts
@@ -4,6 +4,7 @@ import * as ExpoCLI from './ExpoCLI';
 import * as Log from './Log';
 
 type Options = {
+  accessToken?: string;
   userpass?: {
     username: string;
     password: string;
@@ -19,14 +20,19 @@ export async function publishProjectWithExpoCliAsync(
 ): Promise<void> {
   process.env.EXPO_NO_DOCTOR = '1';
 
-  const username = options.userpass?.username || process.env.EXPO_CI_ACCOUNT_USERNAME;
-  const password = options.userpass?.password || process.env.EXPO_CI_ACCOUNT_PASSWORD;
-
-  if (username && password) {
-    Log.collapsed('Logging in...');
-    await ExpoCLI.runExpoCliAsync('login', ['-u', username, '-p', password]);
+  if (options.accessToken) {
+    Log.collapsed('Using access token...');
+    process.env.EXPO_TOKEN = options.accessToken;
   } else {
-    Log.collapsed('Expo username and password not specified. Using currently logged-in account.');
+    const username = options.userpass?.username || process.env.EXPO_CI_ACCOUNT_USERNAME;
+    const password = options.userpass?.password || process.env.EXPO_CI_ACCOUNT_PASSWORD;
+
+    if (username && password) {
+      Log.collapsed('Logging in...');
+      await ExpoCLI.runExpoCliAsync('login', ['-u', username, '-p', password]);
+    } else {
+      Log.collapsed('Expo username and password not specified. Using currently logged-in account.');
+    }
   }
 
   Log.collapsed('Publishing...');

--- a/tools/src/commands/PublishDevExpoHomeCommand.ts
+++ b/tools/src/commands/PublishDevExpoHomeCommand.ts
@@ -8,10 +8,10 @@ import process from 'process';
 import semver from 'semver';
 
 import * as ExpoCLI from '../ExpoCLI';
-import { deepCloneObject } from '../Utils';
-import AppConfig from '../typings/AppConfig';
 import { getNewestSDKVersionAsync } from '../ProjectVersions';
+import { deepCloneObject } from '../Utils';
 import { Directories, HashDirectory, XDL } from '../expotools';
+import AppConfig from '../typings/AppConfig';
 
 type ActionOptions = {
   dry: boolean;
@@ -30,7 +30,7 @@ const { EXPO_HOME_DEV_ACCOUNT_USERNAME, EXPO_HOME_DEV_ACCOUNT_PASSWORD } = proce
  * Finds target SDK version for home app based on the newest SDK versions of all supported platforms.
  * If multiple different versions have been found then the highest one is used.
  */
-async function findTargetSdkVersionAsync(): Promise<string> {
+export async function findTargetSdkVersionAsync(): Promise<string> {
   const iosSdkVersion = await getNewestSDKVersionAsync('ios');
   const androidSdkVersion = await getNewestSDKVersionAsync('android');
 
@@ -45,7 +45,7 @@ async function findTargetSdkVersionAsync(): Promise<string> {
 /**
  * Sets `sdkVersion` and `version` fields in app configuration if needed.
  */
-async function maybeUpdateHomeSdkVersionAsync(appJson: AppConfig): Promise<void> {
+export async function maybeUpdateHomeSdkVersionAsync(appJson: AppConfig): Promise<void> {
   const targetSdkVersion = await findTargetSdkVersionAsync();
 
   if (appJson.expo.sdkVersion !== targetSdkVersion) {
@@ -83,7 +83,7 @@ async function setExpoCliStateAsync(newState: object): Promise<void> {
 /**
  * Deletes kernel fields that needs to be removed from published manifest.
  */
-function deleteKernelFields(appJson: AppConfig): void {
+export function deleteKernelFields(appJson: AppConfig): void {
   console.log(`Deleting kernel-related fields...`);
 
   // @tsapeta: Using `delete` keyword here would change the order of keys in app.json.
@@ -96,7 +96,7 @@ function deleteKernelFields(appJson: AppConfig): void {
 /**
  * Restores kernel fields that have been removed in previous steps - we don't want them to be present in published manifest.
  */
-function restoreKernelFields(appJson: AppConfig, appJsonBackup: AppConfig): void {
+export function restoreKernelFields(appJson: AppConfig, appJsonBackup: AppConfig): void {
   console.log('Restoring kernel-related fields...');
 
   appJson.expo.kernel = appJsonBackup.expo.kernel;

--- a/tools/src/commands/PublishDogfoodExpoHomeCommand.ts
+++ b/tools/src/commands/PublishDogfoodExpoHomeCommand.ts
@@ -1,0 +1,61 @@
+import { Command } from '@expo/commander';
+import JsonFile from '@expo/json-file';
+import chalk from 'chalk';
+import path from 'path';
+import process from 'process';
+
+import { deepCloneObject } from '../Utils';
+import { Directories, XDL } from '../expotools';
+import AppConfig from '../typings/AppConfig';
+import { deleteKernelFields, maybeUpdateHomeSdkVersionAsync } from './PublishDevExpoHomeCommand';
+
+const EXPO_HOME_PATH = Directories.getExpoHomeJSDir();
+const { EXPO_DOGFOOD_HOME_ACCESS_TOKEN } = process.env;
+
+/**
+ * Main action that runs once the command is invoked.
+ */
+async function action(): Promise<void> {
+  if (!EXPO_DOGFOOD_HOME_ACCESS_TOKEN) {
+    throw new Error('EXPO_DOGFOOD_HOME_ACCESS_TOKEN must be set in your environment.');
+  }
+
+  const appJsonFilePath = path.join(EXPO_HOME_PATH, 'app.json');
+  const appJsonFile = new JsonFile<AppConfig>(appJsonFilePath);
+  const appJson = await appJsonFile.readAsync();
+
+  console.log(`Creating backup of ${chalk.magenta('app.json')} file...`);
+  const appJsonBackup = deepCloneObject<AppConfig>(appJson);
+
+  console.log(`Modifying home app.json...`);
+  await maybeUpdateHomeSdkVersionAsync(appJson);
+  appJson.expo.owner = 'expo-dogfooding';
+  deleteKernelFields(appJson);
+
+  try {
+    await appJsonFile.writeAsync(appJson);
+
+    console.log(`Publishing ${chalk.green('@expo-dogfooding/home')}...`);
+
+    await XDL.publishProjectWithExpoCliAsync(EXPO_HOME_PATH, {
+      accessToken: EXPO_DOGFOOD_HOME_ACCESS_TOKEN,
+    });
+
+    console.log(`Finished publishing ${chalk.green('@expo-dogfooding/home')}`);
+  } finally {
+    // always restore from backup
+    console.log(`Restoring ${chalk.magenta('app.json')} file from backup...`);
+    await appJsonFile.writeAsync(appJsonBackup);
+  }
+
+  console.log(chalk.yellow(`Done.`));
+}
+
+export default (program: Command) => {
+  program
+    .command('publish-dogfood-home')
+    .description(
+      `Automatically publishes @expo-dogfooding/home using access token stored in EXPO_DOGFOOD_HOME_ACCESS_TOKEN environment variable.`
+    )
+    .asyncAction(action);
+};

--- a/tools/src/typings/AppConfig.ts
+++ b/tools/src/typings/AppConfig.ts
@@ -3,6 +3,7 @@ import { JSONObject } from '@expo/json-file';
 export default interface AppConfig extends JSONObject {
   expo: {
     name: string;
+    owner?: string;
     description: string;
     slug: string;
     privacy: string;


### PR DESCRIPTION
# Why

We'd like to start internally dogfooding what is on master. To do this we need to:
- Publish to a new package, `@expo-dogfooding/home`, for use in the new builds. (this PR)
- Create new flavors of Expo Go builds that use `@expo-dogfooding/home` for home and also embed the latest version of it.

# How

1. Create new tools command, `et publish-dogfood-home` that automatically publishes `@expo-dogfooding/home` using the access token stored in the `EXPO_DOGFOOD_HOME_ACCESS_TOKEN` environment variable. The access token belongs to a robot user with publish permision on the `expo-dogfooding` account and can be revoked easily.
2. Add environment variable to repository secrets.
3. Add CI step that runs on push to master that runs the new tools command.

# Test Plan

1. Manually run the new tools command with the environment variable set locally.
2. Wait for GH actions to validate action yml
3. Push to master (test it live) to see if it publishes a new version.