### PR TITLE
[audio][recording][docs] Update "prepareAsync" to "prepareToRecordAsync" in Docs

### DIFF
--- a/docs/pages/versions/unversioned/sdk/audio.md
+++ b/docs/pages/versions/unversioned/sdk/audio.md
@@ -408,7 +408,7 @@ A static convenience method to construct and start a recording is also provided:
 
   // Which is equivalent to the following:
   const recording = new Audio.Recording();
-  await recording.prepareAsync(options);
+  await recording.prepareToRecordAsync(options);
   recording.setOnRecordingStatusUpdate(onRecordingStatusUpdate);
   await recording.startAsync();
   ```
@@ -573,7 +573,7 @@ In order to define your own custom recording options, you must provide a diction
 
 - `isMeteringEnabled` : a boolean that determines whether audio level information will be part of the status object under the "metering" key.
 
-- `keepAudioActiveHint` : a boolean that hints to keep the audio active after `prepareAsync` completes. Setting this value can improve the speed at which the recording starts. Only set this value to `true` when you call `startAsync` immediately after `prepareAsync`. This value is automatically set when using `Audio.recording.createAsync()`.
+- `keepAudioActiveHint` : a boolean that hints to keep the audio active after `prepareToRecordAsync` completes. Setting this value can improve the speed at which the recording starts. Only set this value to `true` when you call `startAsync` immediately after `prepareToRecordAsync`. This value is automatically set when using `Audio.recording.createAsync()`.
 
 - `android` : a dictionary of key-value pairs for the Android platform. This key is required.
 


### PR DESCRIPTION
Noticed some references to recording.prepareAsync, but checked in the source (https://github.com/expo/expo/blob/master/packages/expo-av/src/Audio/Recording.ts) and only recording.prepareToRecordAsync exists. I couldn't find any reference to recording.prepareAsync

# Why

I believe the docs incorrectly reference "recording.prepareAsync" instead of "recording.prepareToRecordAsync"

# How

Reviewed the source at https://github.com/expo/expo/blob/master/packages/expo-av/src/Audio/Recording.ts and could not find any mention of a method named "prepareAsync"

# Test Plan

N/A

# Checklist
- [✓ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).