### PR TITLE
[docs] update "Javascript" to "JavaScript"

### DIFF
--- a/docs/pages/guides/using-clojurescript.md
+++ b/docs/pages/guides/using-clojurescript.md
@@ -126,11 +126,11 @@ Yes.
 
 ### Can I use npm modules?
 
-React Native uses JavascriptCore, so modules using built-in node like stream, fs, etc wont work. Otherwise, you can just require like: `(js/require "SomeModule")`.
+React Native uses JavaScriptCore, so modules using built-in node like stream, fs, etc wont work. Otherwise, you can just require like: `(js/require "SomeModule")`.
 
-### Do I need to restart the REPL after adding new Javascript modules or assets?
+### Do I need to restart the REPL after adding new JavaScript modules or assets?
 
-No, you do need to reload Javascript. To do that, select **Reload** from the Developer Menu. You can also press `⌘ + R` in the iOS Simulator, or press `R` twice on Android emulators.
+No, you do need to reload JavaScript. To do that, select **Reload** from the Developer Menu. You can also press `⌘ + R` in the iOS Simulator, or press `R` twice on Android emulators.
 
 ### Will it support Boot?
 

--- a/docs/pages/troubleshooting/react-native-version-mismatch.md
+++ b/docs/pages/troubleshooting/react-native-version-mismatch.md
@@ -7,7 +7,7 @@ When developing an Expo or React Native app, it's not uncommon to run into an er
 ```
 React Native version mismatch.
 
-Javascript version: X.XX.X
+JavaScript version: X.XX.X
 Native version: X.XX.X
 
 Make sure you have rebuilt the native code...

--- a/docs/pages/versions/unversioned/react-native/platformcolor.md
+++ b/docs/pages/versions/unversioned/react-native/platformcolor.md
@@ -7,7 +7,7 @@ title: PlatformColor
 PlatformColor(color1, [color2, ...colorN]);
 ```
 
-You can use the `PlatformColor` function to access native colors on the target platform by supplying the native color’s corresponding string value. You pass a string to the `PlatformColor` function, and provided it exists on that platform, that native color will be applied to the control or Javascript component specified in your style. All native color logic also translates if applicable, meaning if the native color specified is themes and/or high contrast sensitive, that logic will also transfer to the JavaScript component being colored.
+You can use the `PlatformColor` function to access native colors on the target platform by supplying the native color’s corresponding string value. You pass a string to the `PlatformColor` function, and provided it exists on that platform, that native color will be applied to the control or JavaScript component specified in your style. All native color logic also translates if applicable, meaning if the native color specified is themes and/or high contrast sensitive, that logic will also transfer to the JavaScript component being colored.
 
 ## Developer notes
 

--- a/docs/pages/versions/unversioned/sdk/gl-view.md
+++ b/docs/pages/versions/unversioned/sdk/gl-view.md
@@ -189,4 +189,4 @@ For efficiency reasons the current implementations of the methods don't perform 
 
 ## Remote Debugging & GLView
 
-This API does not function as intended with remote debugging enabled. The React Native debugger runs Javascript on your computer (not the mobile device itself), and GLView requires synchronous native calls (which are not supported in Chrome).
+This API does not function as intended with remote debugging enabled. The React Native debugger runs JavaScript on your computer (not the mobile device itself), and GLView requires synchronous native calls (which are not supported in Chrome).

--- a/docs/pages/versions/v38.0.0/sdk/gl-view.md
+++ b/docs/pages/versions/v38.0.0/sdk/gl-view.md
@@ -125,4 +125,4 @@ For efficiency reasons the current implementations of the methods don't perform 
 
 ## Remote Debugging & GLView
 
-This API does not function as intended with remote debugging enabled. The React Native debugger runs Javascript on your computer (not the mobile device itself), and GLView requires synchronous native calls (which are not supported in Chrome).
+This API does not function as intended with remote debugging enabled. The React Native debugger runs JavaScript on your computer (not the mobile device itself), and GLView requires synchronous native calls (which are not supported in Chrome).

--- a/docs/pages/versions/v39.0.0/react-native/platformcolor.md
+++ b/docs/pages/versions/v39.0.0/react-native/platformcolor.md
@@ -7,7 +7,7 @@ title: PlatformColor
 PlatformColor(color1, [color2, ...colorN]);
 ```
 
-You can use the `PlatformColor` function to access native colors on the target platform by supplying the native color’s corresponding string value. You pass a string to the `PlatformColor` function, and provided it exists on that platform, that native color will be applied to the control or Javascript component specified in your style. All native color logic also translates if applicable, meaning if the native color specified is themes and/or high contrast sensitive, that logic will also transfer to the JavaScript component being colored.
+You can use the `PlatformColor` function to access native colors on the target platform by supplying the native color’s corresponding string value. You pass a string to the `PlatformColor` function, and provided it exists on that platform, that native color will be applied to the control or JavaScript component specified in your style. All native color logic also translates if applicable, meaning if the native color specified is themes and/or high contrast sensitive, that logic will also transfer to the JavaScript component being colored.
 
 ## Developer notes
 

--- a/docs/pages/versions/v39.0.0/sdk/gl-view.md
+++ b/docs/pages/versions/v39.0.0/sdk/gl-view.md
@@ -189,4 +189,4 @@ For efficiency reasons the current implementations of the methods don't perform 
 
 ## Remote Debugging & GLView
 
-This API does not function as intended with remote debugging enabled. The React Native debugger runs Javascript on your computer (not the mobile device itself), and GLView requires synchronous native calls (which are not supported in Chrome).
+This API does not function as intended with remote debugging enabled. The React Native debugger runs JavaScript on your computer (not the mobile device itself), and GLView requires synchronous native calls (which are not supported in Chrome).

--- a/docs/pages/versions/v40.0.0/react-native/platformcolor.md
+++ b/docs/pages/versions/v40.0.0/react-native/platformcolor.md
@@ -7,7 +7,7 @@ title: PlatformColor
 PlatformColor(color1, [color2, ...colorN]);
 ```
 
-You can use the `PlatformColor` function to access native colors on the target platform by supplying the native color’s corresponding string value. You pass a string to the `PlatformColor` function, and provided it exists on that platform, that native color will be applied to the control or Javascript component specified in your style. All native color logic also translates if applicable, meaning if the native color specified is themes and/or high contrast sensitive, that logic will also transfer to the JavaScript component being colored.
+You can use the `PlatformColor` function to access native colors on the target platform by supplying the native color’s corresponding string value. You pass a string to the `PlatformColor` function, and provided it exists on that platform, that native color will be applied to the control or JavaScript component specified in your style. All native color logic also translates if applicable, meaning if the native color specified is themes and/or high contrast sensitive, that logic will also transfer to the JavaScript component being colored.
 
 ## Developer notes
 

--- a/docs/pages/versions/v40.0.0/sdk/gl-view.md
+++ b/docs/pages/versions/v40.0.0/sdk/gl-view.md
@@ -189,4 +189,4 @@ For efficiency reasons the current implementations of the methods don't perform 
 
 ## Remote Debugging & GLView
 
-This API does not function as intended with remote debugging enabled. The React Native debugger runs Javascript on your computer (not the mobile device itself), and GLView requires synchronous native calls (which are not supported in Chrome).
+This API does not function as intended with remote debugging enabled. The React Native debugger runs JavaScript on your computer (not the mobile device itself), and GLView requires synchronous native calls (which are not supported in Chrome).

--- a/docs/pages/versions/v41.0.0/react-native/platformcolor.md
+++ b/docs/pages/versions/v41.0.0/react-native/platformcolor.md
@@ -7,7 +7,7 @@ title: PlatformColor
 PlatformColor(color1, [color2, ...colorN]);
 ```
 
-You can use the `PlatformColor` function to access native colors on the target platform by supplying the native color’s corresponding string value. You pass a string to the `PlatformColor` function, and provided it exists on that platform, that native color will be applied to the control or Javascript component specified in your style. All native color logic also translates if applicable, meaning if the native color specified is themes and/or high contrast sensitive, that logic will also transfer to the JavaScript component being colored.
+You can use the `PlatformColor` function to access native colors on the target platform by supplying the native color’s corresponding string value. You pass a string to the `PlatformColor` function, and provided it exists on that platform, that native color will be applied to the control or JavaScript component specified in your style. All native color logic also translates if applicable, meaning if the native color specified is themes and/or high contrast sensitive, that logic will also transfer to the JavaScript component being colored.
 
 ## Developer notes
 

--- a/docs/pages/versions/v41.0.0/sdk/gl-view.md
+++ b/docs/pages/versions/v41.0.0/sdk/gl-view.md
@@ -189,4 +189,4 @@ For efficiency reasons the current implementations of the methods don't perform 
 
 ## Remote Debugging & GLView
 
-This API does not function as intended with remote debugging enabled. The React Native debugger runs Javascript on your computer (not the mobile device itself), and GLView requires synchronous native calls (which are not supported in Chrome).
+This API does not function as intended with remote debugging enabled. The React Native debugger runs JavaScript on your computer (not the mobile device itself), and GLView requires synchronous native calls (which are not supported in Chrome).

--- a/docs/pages/versions/v42.0.0/react-native/platformcolor.md
+++ b/docs/pages/versions/v42.0.0/react-native/platformcolor.md
@@ -7,7 +7,7 @@ title: PlatformColor
 PlatformColor(color1, [color2, ...colorN]);
 ```
 
-You can use the `PlatformColor` function to access native colors on the target platform by supplying the native color’s corresponding string value. You pass a string to the `PlatformColor` function, and provided it exists on that platform, that native color will be applied to the control or Javascript component specified in your style. All native color logic also translates if applicable, meaning if the native color specified is themes and/or high contrast sensitive, that logic will also transfer to the JavaScript component being colored.
+You can use the `PlatformColor` function to access native colors on the target platform by supplying the native color’s corresponding string value. You pass a string to the `PlatformColor` function, and provided it exists on that platform, that native color will be applied to the control or JavaScript component specified in your style. All native color logic also translates if applicable, meaning if the native color specified is themes and/or high contrast sensitive, that logic will also transfer to the JavaScript component being colored.
 
 ## Developer notes
 

--- a/docs/pages/versions/v42.0.0/sdk/gl-view.md
+++ b/docs/pages/versions/v42.0.0/sdk/gl-view.md
@@ -189,4 +189,4 @@ For efficiency reasons the current implementations of the methods don't perform 
 
 ## Remote Debugging & GLView
 
-This API does not function as intended with remote debugging enabled. The React Native debugger runs Javascript on your computer (not the mobile device itself), and GLView requires synchronous native calls (which are not supported in Chrome).
+This API does not function as intended with remote debugging enabled. The React Native debugger runs JavaScript on your computer (not the mobile device itself), and GLView requires synchronous native calls (which are not supported in Chrome).

--- a/docs/pages/workflow/already-used-react-native.md
+++ b/docs/pages/workflow/already-used-react-native.md
@@ -34,7 +34,7 @@ We talk about permissions we set within `app.json`, but there's also the [Permis
 
 ## How does Expo work?
 
-Since you write your code in Javascript, we bundle it up and serve it from S3. Every time you publish your app, we update those assets and then push them to your app so you've always got an up-to-date version.
+Since you write your code in JavaScript, we bundle it up and serve it from S3. Every time you publish your app, we update those assets and then push them to your app so you've always got an up-to-date version.
 
 ## Developing in Expo
 

--- a/docs/pages/workflow/debugging.md
+++ b/docs/pages/workflow/debugging.md
@@ -31,9 +31,9 @@ If you are able to simplify your code as much as possible, tracking down the sou
 
 Errors or bugs in your production app can be much harder to solve, mainly because you have less context around the error (i.e. where, how, and why did the error occur?). **The best first step in addressing a production error is to reproduce it locally.** Once you reproduce an error locally, you can follow the [development debugging process](#development-errors) to isolate and address the root cause.
 
-> **Hint**: sometimes, running your app in "production mode" locally will show errors that normally wouldn't be thrown. You can run an app locally in production by running `expo start --no-dev --minify`. "--no-dev" tells the server not to be run in development mode, and "--minify" will minify your code the same way it is for production Javascript bundles.
+> **Hint**: sometimes, running your app in "production mode" locally will show errors that normally wouldn't be thrown. You can run an app locally in production by running `expo start --no-dev --minify`. "--no-dev" tells the server not to be run in development mode, and "--minify" will minify your code the same way it is for production JavaScript bundles.
 
-Using an automated error logging system like [Sentry](../guides/using-sentry.md) is a huge help in identifying, tracking, and resolving Javascript errors in your production app. This will give you a good sense of how many people are running into an error, how often, when, **and it even provides sourcemaps so you will have stacktraces of your errors!** Sentry is one of those tools that if you wait until you need it to install it, then you waited too long. Also- Sentry is free up to 5000 events/month.
+Using an automated error logging system like [Sentry](../guides/using-sentry.md) is a huge help in identifying, tracking, and resolving JavaScript errors in your production app. This will give you a good sense of how many people are running into an error, how often, when, **and it even provides sourcemaps so you will have stacktraces of your errors!** Sentry is one of those tools that if you wait until you need it to install it, then you waited too long. Also- Sentry is free up to 5000 events/month.
 
 ### My production app is crashing
 
@@ -79,7 +79,7 @@ Now let's explore some of the more exciting functionalities...
 This opens up a small window giving you performance information of your app. You will see:
 
 - RAM usage of your project
-- Javascript heap (this is an easy way to know of any memory leaks in your application)
+- JavaScript heap (this is an easy way to know of any memory leaks in your application)
 - 2 numbers for Views, the top indicates the number of views for the screen, the bottom indicates the number of views in the component
 - Frames Per Second for the UI and JS threads. The UI thread is used for native Android or iOS UI rendering. The JS thread is where most of your logic will be run, including API calls, touch events, etc.
 


### PR DESCRIPTION
# Why

This should make the document more professional

# How

Replace "Javascript" with "JavaScript" under `docs/`

# Test Plan

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] ~Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).~
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).