### PR TITLE
[client] Add dogfood home build option

### DIFF
--- a/.github/workflows/dogfooding-clients.yml
+++ b/.github/workflows/dogfooding-clients.yml
@@ -1,0 +1,198 @@
+name: Dogfooding Clients
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-android:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: 👀 Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: ♻️ Restore workspace node modules
+        uses: actions/cache@v2
+        id: node-modules-cache
+        with:
+          path: |
+            # See "workspaces" → "packages" in the root package.json for the source of truth of
+            # which node_modules are affected by the root yarn.lock
+            node_modules
+            apps/*/node_modules
+            home/node_modules
+            packages/*/node_modules
+            packages/@unimodules/*/node_modules
+            react-native-lab/react-native/node_modules
+          key: ${{ runner.os }}-modules-${{ hashFiles('yarn.lock') }}
+      - name: ♻️ Restore node modules in tools
+        uses: actions/cache@v2
+        with:
+          path: tools/node_modules
+          key: ${{ runner.os }}-tools-modules-${{ hashFiles('tools/yarn.lock') }}
+      - name: 🧶 Yarn install
+        run: yarn install --frozen-lockfile
+      - name: 💎 Setup Ruby and install gems
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - name: 🐙 Install git-crypt
+        run: sudo apt-get install git-crypt
+      - name: 🔓 Decrypt secrets if possible
+        env:
+          GIT_CRYPT_KEY_BASE64: ${{ secrets.GIT_CRYPT_KEY_BASE64 }}
+        run: |
+          if [ -z "${GIT_CRYPT_KEY_BASE64}" ]; then
+            echo 'git-crypt key not present in environment'
+          else
+            git crypt unlock <(echo $GIT_CRYPT_KEY_BASE64 | base64 --decode)
+          fi
+      - name: ♻️ Restore Gradle caches
+        uses: actions/cache@v2
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('android/*.gradle*') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+      - name: ♻️ Restore Android NDK from cache
+        uses: actions/cache@v2
+        id: cache-android-ndk
+        with:
+          path: /usr/local/lib/android/sdk/ndk/19.2.5345600/
+          key: ${{ runner.os }}-ndk-19.2.5345600
+          restore-keys: |
+            ${{ runner.os }}-ndk-
+      - name: 🛠 Install NDK
+        if: steps.cache-android-ndk.outputs.cache-hit != 'true'
+        run: |
+          sudo $ANDROID_SDK_ROOT/tools/bin/sdkmanager --install "ndk;19.2.5345600"
+      - name: 🏭 Build APK
+        env:
+          ANDROID_KEYSTORE_B64: ${{ secrets.ANDROID_KEYSTORE_B64 }}
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ExponentKey
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+          ANDROID_NDK_HOME: /usr/local/lib/android/sdk/ndk/19.2.5345600/
+          USE_DOGFOODING_PUBLISHED_KERNEL_MANIFEST: true
+        run: |
+          BUILD_TYPE="Release"
+          FLAVOR="Versioned"
+          echo "Building with $FLAVOR flavor"
+          if [ -z "$ANDROID_KEYSTORE_B64" ]; then
+            echo "External build detected, only signed dogfooding builds are supported"
+            exit 1;
+          else
+            echo "Internal build detected, APK will be signed"
+            echo $ANDROID_KEYSTORE_B64 | base64 -d > android/app/release-key.jks
+            bin/fastlane android build build_type:$BUILD_TYPE flavor:$FLAVOR
+          fi
+      - name: 💾 Upload APK artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: android-apk
+          path: android/app/build/outputs/apk
+      - name: 💾 Store daemon logs for debugging crashes
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+          name: gradle-daemon-logs
+          path: ~/.gradle/daemon
+      - name: 🔔 Notify on Slack
+        uses: 8398a7/action-slack@v3
+        if: failure() && (github.event.ref == 'refs/heads/master' || startsWith(github.event.ref, 'refs/heads/sdk-'))
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_android }}
+        with:
+          channel: '#platform-android'
+          status: ${{ job.status }}
+          fields: job,message,ref,eventName,author,took
+          author_name: Expo Go Dogfooding (Android)
+  build-ios:
+    runs-on: macos-11
+    steps:
+      - name: 👀 Checkout a ref for the event
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: 🔨 Switch to Xcode 12.5.1
+        run: sudo xcode-select --switch /Applications/Xcode_12.5.1.app
+      - name: 🍺 Setup Homebrew
+        run: brew install git-crypt
+      - name: 🔓 decrypt secrets if possible
+        env:
+          GIT_CRYPT_KEY_BASE64: ${{ secrets.GIT_CRYPT_KEY_BASE64 }}
+        run: |
+          if [[ ${GIT_CRYPT_KEY_BASE64:-unset} = unset ]]; then
+            echo 'git-crypt key not present in environment'
+          else
+            git crypt unlock <(echo $GIT_CRYPT_KEY_BASE64 | base64 --decode)
+          fi
+      - run: echo "$(pwd)/bin" >> $GITHUB_PATH
+      - name: ♻️ Restore workspace node modules
+        uses: actions/cache@v2
+        id: node-modules-cache
+        with:
+          path: |
+            # See "workspaces" → "packages" in the root package.json for the source of truth of
+            # which node_modules are affected by the root yarn.lock
+            node_modules
+            apps/*/node_modules
+            home/node_modules
+            packages/*/node_modules
+            packages/@unimodules/*/node_modules
+            react-native-lab/react-native/node_modules
+          key: ${{ runner.os }}-modules-${{ hashFiles('yarn.lock') }}
+      - name: 🧶 Yarn install
+        run: yarn install --frozen-lockfile
+      - name: ♻️ Restore node modules in tools
+        uses: actions/cache@v2
+        with:
+          path: tools/node_modules
+          key: ${{ runner.os }}-tools-modules-${{ hashFiles('tools/yarn.lock') }}
+      - name: 🏭 Generating dynamic macros
+        run: expotools ios-generate-dynamic-macros
+      - name: 💎 Setup Ruby and install gems
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - name: ♻️ Restore ios/Pods from cache
+        uses: actions/cache@v2
+        with:
+          path: 'ios/Pods'
+          key: ${{ runner.os }}-pods-${{ hashFiles('ios/Podfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pods-
+      - name: 🥥 Install CocoaPods in `ios`
+        run: pod install
+        working-directory: ios
+      - name: 🏗 Build Expo Go for simulator
+        run: |
+          FLAVOR="versioned"
+          expotools client-build --platform ios --flavor $FLAVOR
+        timeout-minutes: 120
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          USE_DOGFOODING_PUBLISHED_KERNEL_MANIFEST: true
+      - name: 💾 Save test results
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: fastlane-logs
+          path: ~/Library/Logs/fastlane
+      - name: 🔔 Notify on Slack
+        uses: 8398a7/action-slack@v3
+        if: failure() && (github.event.ref == 'refs/heads/master' || startsWith(github.event.ref, 'refs/heads/sdk-'))
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_ios }}
+        with:
+          channel: '#platform-ios'
+          status: ${{ job.status }}
+          fields: job,message,ref,eventName,author,took
+          author_name: Expo Go Dogfooding (iOS)

--- a/ios/Exponent/Kernel/Environment/EXBuildConstants.h
+++ b/ios/Exponent/Kernel/Environment/EXBuildConstants.h
@@ -6,6 +6,7 @@ typedef enum EXKernelDevManifestSource {
   kEXKernelDevManifestSourceNone,
   kEXKernelDevManifestSourceLocal,
   kEXKernelDevManifestSourcePublished,
+  kEXKernelDevManifestSourceDogfooding,
 } EXKernelDevManifestSource;
 
 @interface EXBuildConstants : NSObject

--- a/ios/Exponent/Kernel/Environment/EXBuildConstants.m
+++ b/ios/Exponent/Kernel/Environment/EXBuildConstants.m
@@ -45,6 +45,9 @@
   } else if (_kernelDevManifestSource == kEXKernelDevManifestSourcePublished) {
     // dev published kernel. use published manifest.
     _kernelManifestJsonString = config[@"DEV_PUBLISHED_KERNEL_MANIFEST"];
+  } else if (_kernelDevManifestSource == kEXKernelDevManifestSourceDogfooding) {
+    // dogfooding published kernel. use published dogfooding manifest.
+    _kernelManifestJsonString = config[@"DOGFOODING_PUBLISHED_KERNEL_MANIFEST"];
   }
   _apiServerEndpoint = [NSURL URLWithString:config[@"API_SERVER_ENDPOINT"]];
   _temporarySdkVersion = config[@"TEMPORARY_SDK_VERSION"];
@@ -63,6 +66,8 @@
     return kEXKernelDevManifestSourceLocal;
   } else if ([sourceString isEqualToString:@"PUBLISHED"]) {
     return kEXKernelDevManifestSourcePublished;
+  } else if ([sourceString isEqualToString:@"DOGFOODING"]) {
+    return kEXKernelDevManifestSourceDogfooding;
   }
   return kEXKernelDevManifestSourceNone;
 }

--- a/tools/src/commands/WorkflowDispatch.ts
+++ b/tools/src/commands/WorkflowDispatch.ts
@@ -64,11 +64,6 @@ const CUSTOM_WORKFLOWS = {
       checkAll: 'check-all',
     },
   },
-  'dogfooding-clients': {
-    name: 'Dogfooding Clients',
-    baseWorkflowSlug: 'dogfooding-clients',
-    inputs: {},
-  },
 };
 
 export default (program: Command) => {

--- a/tools/src/commands/WorkflowDispatch.ts
+++ b/tools/src/commands/WorkflowDispatch.ts
@@ -11,8 +11,8 @@ import {
   Workflow,
   getJobsForWorkflowRunAsync,
 } from '../GitHubActions';
-import { deepCloneObject, retryAsync } from '../Utils';
 import logger from '../Logger';
+import { deepCloneObject, retryAsync } from '../Utils';
 
 type CommandOptions = {
   ref?: string;
@@ -63,6 +63,11 @@ const CUSTOM_WORKFLOWS = {
     inputs: {
       checkAll: 'check-all',
     },
+  },
+  'dogfooding-clients': {
+    name: 'Dogfooding Clients',
+    baseWorkflowSlug: 'dogfooding-clients',
+    inputs: {},
   },
 };
 

--- a/tools/src/dynamic-macros/AndroidMacrosGenerator.ts
+++ b/tools/src/dynamic-macros/AndroidMacrosGenerator.ts
@@ -1,6 +1,6 @@
-import path from 'path';
-import fs from 'fs-extra';
 import chalk from 'chalk';
+import fs from 'fs-extra';
+import path from 'path';
 
 import * as Directories from '../Directories';
 
@@ -45,15 +45,18 @@ export async function generateAndroidBuildConstantsFromMacrosAsync(macros) {
   const isLocalManifestEmpty =
     !macros.BUILD_MACHINE_KERNEL_MANIFEST || macros.BUILD_MACHINE_KERNEL_MANIFEST === '';
 
-  if (isLocalManifestEmpty) {
+  let versionUsed = 'local';
+  if (process.env.USE_DOGFOODING_PUBLISHED_KERNEL_MANIFEST) {
+    macros.BUILD_MACHINE_KERNEL_MANIFEST = macros.DOGFOODING_PUBLISHED_KERNEL_MANIFEST;
+    versionUsed = 'doogfooding';
+  } else if (isLocalManifestEmpty) {
     macros.BUILD_MACHINE_KERNEL_MANIFEST = macros.DEV_PUBLISHED_KERNEL_MANIFEST;
+    versionUsed = 'published dev';
   }
-
-  console.log(
-    `Using ${chalk.yellow(isLocalManifestEmpty ? 'published dev' : 'local')} version of Expo Home.`
-  );
+  console.log(`Using ${chalk.yellow(versionUsed)} version of Expo Home.`);
 
   delete macros['DEV_PUBLISHED_KERNEL_MANIFEST'];
+  delete macros['DOGFOODING_PUBLISHED_KERNEL_MANIFEST'];
 
   const definitions = Object.entries(macros).map(
     ([name, value]) =>

--- a/tools/src/dynamic-macros/IosMacrosGenerator.ts
+++ b/tools/src/dynamic-macros/IosMacrosGenerator.ts
@@ -1,8 +1,8 @@
 import { IosPlist, IosPodsTools } from '@expo/xdl';
 import chalk from 'chalk';
-import plist from 'plist';
 import fs from 'fs-extra';
 import path from 'path';
+import plist from 'plist';
 
 import * as Directories from '../Directories';
 import * as ProjectVersions from '../ProjectVersions';
@@ -71,8 +71,8 @@ async function generateBuildConstantsFromMacrosAsync(
 function validateBuildConstants(config, buildConfiguration) {
   config.USE_GENERATED_DEFAULTS = true;
 
-  let IS_DEV_KERNEL,
-    DEV_KERNEL_SOURCE = '';
+  let IS_DEV_KERNEL = false;
+  let DEV_KERNEL_SOURCE = '';
   if (buildConfiguration === 'Debug') {
     IS_DEV_KERNEL = true;
     DEV_KERNEL_SOURCE = config.DEV_KERNEL_SOURCE;
@@ -93,6 +93,13 @@ function validateBuildConstants(config, buildConfiguration) {
 
     if (DEV_KERNEL_SOURCE === 'PUBLISHED' && !config.DEV_PUBLISHED_KERNEL_MANIFEST) {
       throw new Error(`Error downloading DEV published kernel manifest.\n`);
+    }
+
+    if (process.env.USE_DOGFOODING_PUBLISHED_KERNEL_MANIFEST) {
+      if (!config.DOGFOODING_PUBLISHED_KERNEL_MANIFEST) {
+        throw new Error(`Error downloading DOGFOODING published kernel manifest.\n`);
+      }
+      DEV_KERNEL_SOURCE = 'DOGFOODING';
     }
   }
 

--- a/tools/src/dynamic-macros/macros.ts
+++ b/tools/src/dynamic-macros/macros.ts
@@ -19,6 +19,8 @@ interface Manifest {
 // some files are absent on turtle builders and we don't want log errors there
 const isTurtle = !!process.env.TURTLE_WORKING_DIR_PATH;
 
+const dogfoodingHomeUrl = 'exp://expo.io/@expo-dogfooding/home';
+
 const EXPO_DIR = getExpoRepositoryRootDir();
 
 async function getManifestAsync(
@@ -131,6 +133,20 @@ export default {
       manifest = await getManifestAsync(savedDevHomeUrl, platform, sdkVersion);
     } catch (e) {
       const msg = `Unable to download manifest from ${savedDevHomeUrl}: ${e.message}`;
+      console[isTurtle ? 'debug' : 'error'](msg);
+      return '';
+    }
+
+    return kernelManifestObjectToJson(manifest);
+  },
+
+  async DOGFOODING_PUBLISHED_KERNEL_MANIFEST(platform) {
+    let manifest: Manifest;
+    try {
+      const sdkVersion = await this.TEMPORARY_SDK_VERSION();
+      manifest = await getManifestAsync(dogfoodingHomeUrl, platform, sdkVersion);
+    } catch (e) {
+      const msg = `Unable to download manifest from ${dogfoodingHomeUrl}: ${e.message}`;
       console[isTurtle ? 'debug' : 'error'](msg);
       return '';
     }


### PR DESCRIPTION
# Why

Part 2 of https://github.com/expo/expo/pull/13871.

# How

This PR adds the option to use the dogfooding client manifest when the `USE_DOGFOODING_PUBLISHED_KERNEL_MANIFEST` is supplied instead of the published dev home or local.

Then, it also adds a manually-triggered github actions workflow for building these flavors (no automatic upload yet, that'll be in a follow-up).

# Test Plan

- Build with env variable set locally for android, see signing error upon install (expected). Will need to test in GH action to verify.
- Build with env variable set for iOS, drag built app to simulator, see it opens. Need to verify that it is getting the correct manifest though.