### PR TITLE
[expo-updates] sync changelog with sdk-42 branch

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -4,9 +4,6 @@
 
 ### 🛠 Breaking changes
 
-- Revert [#12734](https://github.com/expo/expo/pull/12734). expo-asset@8.3.3 or above requires expo-updates to specify assets with file extensions. ([#13733](https://github.com/expo/expo/pull/13733) by [@jkhales](https://github.com/jkhales))
-- Added reset method to UpdatesDevLauncherController. ([#13346](https://github.com/expo/expo/pull/13346) by [@esamelson](https://github.com/esamelson))
-
 ### 🎉 New features
 
 - Use stable manifest ID where applicable. ([#12964](https://github.com/expo/expo/pull/12964) by [@wschurman](https://github.com/wschurman))
@@ -16,12 +13,46 @@
 
 ### 🐛 Bug fixes
 
-- Improve behavior of dev client (with updates integration) when developer is logged out of expo-cli. ([#13310](https://github.com/expo/expo/pull/13310) by [@esamelson](https://github.com/esamelson))
-- Remove usage of deprecated `[RCTBridge reload]` method. ([#13501](https://github.com/expo/expo/pull/13501) by [@esamelson](https://github.com/esamelson))
-- Remove side effects from UpdatesDevLauncherController.initialize() method. ([#13555](https://github.com/expo/expo/pull/13555) by [@esamelson](https://github.com/esamelson))
 - Fix `PROJECT_ROOT` path resolution in `create-manifest-ios.sh` and in `createManifest.js` ([#13439](https://github.com/expo/expo/pull/13439) by [@ajsmth](https://github.com/ajsmth))
 
 ### 💡 Others
+
+## 0.8.3 — 2021-07-28
+
+### 🛠 Breaking changes
+
+- Revert [#12734](https://github.com/expo/expo/pull/12734). expo-asset@8.3.3 or above requires expo-updates to specify assets with file extensions. ([#13733](https://github.com/expo/expo/pull/13733) by [@jkhales](https://github.com/jkhales))
+
+## 0.8.2 — 2021-07-13
+
+### 🐛 Bug fixes
+
+- Remove usage of deprecated `[RCTBridge reload]` method. ([#13501](https://github.com/expo/expo/pull/13501) by [@esamelson](https://github.com/esamelson))
+- Remove side effects from UpdatesDevLauncherController.initialize() method. ([#13555](https://github.com/expo/expo/pull/13555) by [@esamelson](https://github.com/esamelson))
+
+## 0.8.1 — 2021-07-08
+
+_This version does not introduce any user-facing changes._
+
+## 0.8.0 — 2021-06-24
+
+### 🛠 Breaking changes
+
+- Added reset method to UpdatesDevLauncherController. ([#13346](https://github.com/expo/expo/pull/13346) by [@esamelson](https://github.com/esamelson))
+
+## 0.7.3 — 2021-06-24
+
+_This version does not introduce any user-facing changes._
+
+## 0.7.2 — 2021-06-23
+
+_This version does not introduce any user-facing changes._
+
+## 0.7.1 — 2021-06-22
+
+### 🐛 Bug fixes
+
+- Improve behavior of dev client (with updates integration) when developer is logged out of expo-cli. ([#13310](https://github.com/expo/expo/pull/13310) by [@esamelson](https://github.com/esamelson))
 
 ## 0.7.0 — 2021-06-16
 


### PR DESCRIPTION
# Why

expo-updates changelog on master is out of sync with the sdk-42 branch and doesn't include the latest minor version bump. This is confusing for people reading the changelog from master (https://github.com/expo/expo/issues/13879).

# How

Copy the changelog entries from the sdk-42 branch for the versions that were published from that branch (0.7.1 through 0.8.3), then remove the corresponding individual entries from the Unreleased section at the top.

We'll need to continue to manually keep this synced/ up-to-date if we publish more versions from the sdk-42 branch (which we probably will).

# Test Plan

Look over the changes manually and make sure nothing got missed.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).