### PR TITLE
[expo-dev-launcher][ios] add EXDevLauncherURLHelperTests

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -1191,7 +1191,7 @@ SPEC CHECKSUMS:
   EXNotifications: 296d9487163c2c08fffec5e79a5f9094bc016d9c
   EXPermissions: c7bead8f093700d5fcfb4f41238430a51702c5c8
   expo-dev-client: 6f833f384c5fcc59e96a91268601dabcd16f70f0
-  expo-dev-launcher: 0b3fe43607f31238f49445e7310e185675061762
+  expo-dev-launcher: 4b8bf23c6df5488d64d6eb7eeea15f6e9eb360da
   expo-dev-menu: c1d43574828f37cb541a0bb52fe7bb7829586147
   expo-dev-menu-interface: 59fbd00f527c7ae65aa86144e6c8af3761fc037f
   expo-image: ea170930bd8bc42328ee74ff4dc861ca31587dc8

--- a/packages/expo-dev-launcher/expo-dev-launcher.podspec
+++ b/packages/expo-dev-launcher/expo-dev-launcher.podspec
@@ -49,6 +49,7 @@ Pod::Spec.new do |s|
   end
 
   s.test_spec 'Tests' do |test_spec|
+    test_spec.platform     = :ios, '12.0'
     test_spec.source_files = 'ios/Tests/**/*.{h,m,swift}'
     test_spec.dependency "React-CoreModules"
     test_spec.dependency "OHHTTPStubs"

--- a/packages/expo-dev-launcher/ios/EXDevLauncherURLHelper.swift
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherURLHelper.swift
@@ -11,15 +11,15 @@ public class EXDevLauncherURLHelper : NSObject  {
   
   @objc
   public static func changeURLScheme(_ url: URL, to scheme: String) -> URL {
-    var componets = URLComponents.init(url: url, resolvingAgainstBaseURL: false)!
-    componets.scheme = scheme
-    return componets.url!
+    var components = URLComponents.init(url: url, resolvingAgainstBaseURL: false)!
+    components.scheme = scheme
+    return components.url!
   }
 
   @objc
   public static func getAppURLFromDevLauncherURL(_ url: URL) -> URL? {
-    let componets = URLComponents.init(url: url, resolvingAgainstBaseURL: false)
-    for parameter in componets?.queryItems ?? [] {
+    let components = URLComponents.init(url: url, resolvingAgainstBaseURL: false)
+    for parameter in components?.queryItems ?? [] {
       if parameter.name == "url" {
         return URL.init(string: parameter.value?.removingPercentEncoding ?? "")
       }

--- a/packages/expo-dev-launcher/ios/Tests/EXDevLauncherManifestParserTests.m
+++ b/packages/expo-dev-launcher/ios/Tests/EXDevLauncherManifestParserTests.m
@@ -1,9 +1,4 @@
-//
-//  EXDevLauncherManifestParserTests.m
-//  expo-dev-launcher-Unit-Tests
-//
-//  Created by Eric Samelson on 7/28/21.
-//
+// Copyright 2021-present 650 Industries. All rights reserved.
 
 #import <XCTest/XCTest.h>
 #import <OHHTTPStubs/HTTPStubs.h>

--- a/packages/expo-dev-launcher/ios/Tests/EXDevLauncherURLHelperTests.swift
+++ b/packages/expo-dev-launcher/ios/Tests/EXDevLauncherURLHelperTests.swift
@@ -1,0 +1,30 @@
+// Copyright 2021-present 650 Industries. All rights reserved.
+
+import XCTest
+
+@testable import EXDevLauncher
+
+class EXDevLauncherURLHelperTests: XCTestCase {
+  func testIsDevLauncherURL() {
+    XCTAssertTrue(EXDevLauncherURLHelper.isDevLauncherURL(URL(string: "scheme://expo-development-client")))
+    XCTAssertTrue(EXDevLauncherURLHelper.isDevLauncherURL(URL(string: "scheme://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8081")))
+    XCTAssertFalse(EXDevLauncherURLHelper.isDevLauncherURL(URL(string: "scheme://not-expo-development-client")))
+  }
+
+  func testChangeURLScheme() {
+    let actual = EXDevLauncherURLHelper.changeURLScheme(URL(string: "exp://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8081")!, to: "scheme")
+    XCTAssertEqual(URL(string: "scheme://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8081"), actual)
+  }
+
+  func testGetAppURLFromDevLauncherURL() {
+    let appURLNotNil = EXDevLauncherURLHelper.getAppURLFromDevLauncherURL(URL(string: "scheme://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8081%2Findex.bundle%3Fplatform%3Dios%26dev%3Dtrue")!)
+    XCTAssertEqual(URL(string: "http://localhost:8081/index.bundle?platform=ios&dev=true"), appURLNotNil)
+
+    let appURLNil = EXDevLauncherURLHelper.getAppURLFromDevLauncherURL(URL(string: "scheme://expo-development-client")!)
+    XCTAssertNil(appURLNil)
+
+    // parsing should happen regardless of the value of the hostname, scheme, or parsed URL
+    let appURLWeird = EXDevLauncherURLHelper.getAppURLFromDevLauncherURL(URL(string: "http://localhost/?url=exp%3A%2F%2Fapp")!)
+    XCTAssertEqual(URL(string: "exp://app"), appURLWeird)
+  }
+}

--- a/packages/expo-dev-launcher/ios/Tests/dummy.swift
+++ b/packages/expo-dev-launcher/ios/Tests/dummy.swift
@@ -1,3 +1,0 @@
-// This dummy Swift file is to persuade Xcode to include Swift runtime,
-// which is required when one of the dependency has some Swift code.
-// Read more here: https://github.com/CocoaPods/CocoaPods/issues/7170#issuecomment-339815814


### PR DESCRIPTION
# Why

chipping away at ENG-1610

# How

- Added unit tests for EXDevLauncherURLHelper.
- Had to add iOS 12 constraint to the test spec in order to get Swift tests to build & run.
- Cleaned up a few misc things I noticed while writing these tests (typos, copyright line, now-unnecessary dummy.swift file)

# Test Plan

Tests pass ✅ 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).