### PR TITLE
docs: fix React Navigation integration example for notifications

### DIFF
--- a/docs/pages/versions/unversioned/sdk/notifications.md
+++ b/docs/pages/versions/unversioned/sdk/notifications.md
@@ -636,6 +636,21 @@ export default function App() {
         config: {
           // Configuration for linking
         },
+        async getInitialURL() {
+          // First, you may want to do the default deep link handling
+          // Check if app was opened from a deep link
+          const url = await Linking.getInitialURL();
+
+          if (url != null) {
+            return url;
+          }
+
+          // Handle URL from expo push notifications
+          const response = await Notifications.getLastNotificationResponseAsync();
+          const url = response?.notification.request.content.data.url;
+
+          return url;
+        }
         subscribe(listener) {
           const onReceiveURL = ({ url }: { url: string }) => listener(url);
 

--- a/docs/pages/versions/v42.0.0/sdk/notifications.md
+++ b/docs/pages/versions/v42.0.0/sdk/notifications.md
@@ -645,8 +645,9 @@ export default function App() {
             return url;
           }
                          
+          // Handle URL from expo push notifications
           const response = await Notifications.getLastNotificationResponseAsync();
-          const url = response.notification.request.content.data.url;
+          const url = response?.notification.request.content.data.url;
                          
           return url;
         }

--- a/docs/pages/versions/v42.0.0/sdk/notifications.md
+++ b/docs/pages/versions/v42.0.0/sdk/notifications.md
@@ -644,11 +644,11 @@ export default function App() {
           if (url != null) {
             return url;
           }
-                         
+
           // Handle URL from expo push notifications
           const response = await Notifications.getLastNotificationResponseAsync();
           const url = response?.notification.request.content.data.url;
-                         
+
           return url;
         }
         subscribe(listener) {

--- a/docs/pages/versions/v42.0.0/sdk/notifications.md
+++ b/docs/pages/versions/v42.0.0/sdk/notifications.md
@@ -636,6 +636,20 @@ export default function App() {
         config: {
           // Configuration for linking
         },
+        async getInitialURL() {
+          // First, you may want to do the default deep link handling
+          // Check if app was opened from a deep link
+          const url = await Linking.getInitialURL();
+
+          if (url != null) {
+            return url;
+          }
+                         
+          const response = await Notifications.getLastNotificationResponseAsync();
+          const url = response.notification.request.content.data.url;
+                         
+          return url;
+        }
         subscribe(listener) {
           const onReceiveURL = ({ url }: { url: string }) => listener(url);
 


### PR DESCRIPTION
The docs currently missing the code to handle notification when app was first opened.