### PR TITLE
[screen-orientation][ios] fix building on Xcode 13

### DIFF
--- a/packages/expo-screen-orientation/CHANGELOG.md
+++ b/packages/expo-screen-orientation/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed an issue with building on Xcode 13.
+- Fixed an issue with building on Xcode 13. ([#13898](https://github.com/expo/expo/pull/13898) by [@cruzach](https://github.com/cruzach))
 
 ### 💡 Others
 

--- a/packages/expo-screen-orientation/CHANGELOG.md
+++ b/packages/expo-screen-orientation/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed an issue with building on Xcode 13.
+
 ### 💡 Others
 
 ## 3.2.0 — 2021-06-16

--- a/packages/expo-screen-orientation/ios/EXScreenOrientation/EXScreenOrientationRegistry.m
+++ b/packages/expo-screen-orientation/ios/EXScreenOrientation/EXScreenOrientationRegistry.m
@@ -138,7 +138,7 @@ UM_REGISTER_SINGLETON_MODULE(ScreenOrientationRegistry)
 
 - (void)handleDeviceOrientationChange:(NSNotification *)notification
 {
-  UIInterfaceOrientation newScreenOrientation = [EXScreenOrientationUtilities interfaceOrientationFromDeviceOrientation:[notification.object orientation]];
+  UIInterfaceOrientation newScreenOrientation = [EXScreenOrientationUtilities interfaceOrientationFromDeviceOrientation:[[UIDevice currentDevice] orientation]];
   [self interfaceOrientationDidChange:newScreenOrientation];
 }
 


### PR DESCRIPTION
# Why

fixes https://github.com/expo/expo/issues/13668

# How

[Docs](https://developer.apple.com/documentation/uikit/uideviceorientationdidchangenotification#discussion) now state: "You can obtain the new orientation by getting the value of the [orientation](https://developer.apple.com/documentation/uikit/uidevice/1620053-orientation?language=objc) property." 

# Test Plan

test-suite and NCL

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).