### PR TITLE
[expo-updates] Fix username not properly supplied to expo-updates plugin

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 - Fix `PROJECT_ROOT` path resolution in `create-manifest-ios.sh` and in `createManifest.js` ([#13439](https://github.com/expo/expo/pull/13439) by [@ajsmth](https://github.com/ajsmth))
 - Fix erroneous manifest JSON direct access. ([#13906](https://github.com/expo/expo/pull/13906) by [@wschurman](https://github.com/wschurman))
-- Fix config plugin to properly set the updates URL based on `getAccountUsername` from `@expo/config`.
+- Fix config plugin to properly set the updates URL based on `getAccountUsername` from `@expo/config`. ([#13909](https://github.com/expo/expo/pull/13909) by [@brentvatne](https://github.com/brentvatne))
 
 ### 💡 Others
 

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - Fix `PROJECT_ROOT` path resolution in `create-manifest-ios.sh` and in `createManifest.js` ([#13439](https://github.com/expo/expo/pull/13439) by [@ajsmth](https://github.com/ajsmth))
 - Fix erroneous manifest JSON direct access. ([#13906](https://github.com/expo/expo/pull/13906) by [@wschurman](https://github.com/wschurman))
+- Fix config plugin to properly set the updates URL based on `getAccountUsername` from `@expo/config`.
 
 ### 💡 Others
 

--- a/packages/expo-updates/package.json
+++ b/packages/expo-updates/package.json
@@ -34,9 +34,9 @@
     "preset": "expo-module-scripts"
   },
   "dependencies": {
-    "@expo/metro-config": "^0.1.70",
-    "@expo/config-plugins": "^3.0.0",
-    "@expo/config": "5.0.6",
+    "@expo/metro-config": "^0.1.81",
+    "@expo/config-plugins": "^3.0.6",
+    "@expo/config": "^5.0.6",
     "expo-structured-headers": "~1.1.0",
     "expo-updates-interface": "~0.2.2",
     "fbemitter": "^2.1.1",

--- a/packages/expo-updates/package.json
+++ b/packages/expo-updates/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "@expo/metro-config": "^0.1.70",
     "@expo/config-plugins": "^3.0.0",
+    "@expo/config": "5.0.6",
     "expo-structured-headers": "~1.1.0",
     "expo-updates-interface": "~0.2.2",
     "fbemitter": "^2.1.1",

--- a/packages/expo-updates/plugin/build/withUpdates.js
+++ b/packages/expo-updates/plugin/build/withUpdates.js
@@ -1,13 +1,14 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+const config_1 = require("@expo/config");
 const config_plugins_1 = require("@expo/config-plugins");
 const withUpdatesAndroid_1 = require("./withUpdatesAndroid");
 const withUpdatesIOS_1 = require("./withUpdatesIOS");
 const pkg = require('expo-updates/package.json');
 const withUpdates = (config, props = {}) => {
-    var _a, _b;
-    // The username should be passed from the CLI when the plugin is automatically used.
-    const expoUsername = (_b = (_a = (props || {}).expoUsername) !== null && _a !== void 0 ? _a : process.env.EXPO_CLI_USERNAME) !== null && _b !== void 0 ? _b : null;
+    var _a;
+    // The username will be passed from the CLI when the plugin is automatically used.
+    const expoUsername = (_a = (props || {}).expoUsername) !== null && _a !== void 0 ? _a : config_1.getAccountUsername(config);
     config = withUpdatesAndroid_1.withUpdatesAndroid(config, { expoUsername });
     config = withUpdatesIOS_1.withUpdatesIOS(config, { expoUsername });
     return config;

--- a/packages/expo-updates/plugin/src/__tests__/withUpdates-test.ts
+++ b/packages/expo-updates/plugin/src/__tests__/withUpdates-test.ts
@@ -1,0 +1,50 @@
+import { getAccountUsername } from '@expo/config';
+import { ExpoConfig } from '@expo/config-types';
+
+import withUpdates from '../withUpdates';
+import { withUpdatesAndroid } from '../withUpdatesAndroid';
+import { withUpdatesIOS } from '../withUpdatesIOS';
+
+jest.mock('../withUpdatesAndroid');
+jest.mock('../withUpdatesIOS');
+jest.mock('@expo/config');
+
+describe('Updates plugin', () => {
+  it('passes in expo username, resolved by getAccountUsername', () => {
+    const expoUsername = 'some-username';
+    // @ts-ignore: return the username so we can validate it is passed to the ios/android plugins
+    getAccountUsername.mockReturnValue(expoUsername);
+
+    withUpdates(getConfig());
+
+    // @ts-ignore: this is an expect extension and is not defined on the type
+    const _ = expect.literallyAnything();
+    expect(withUpdatesAndroid).toHaveBeenCalledWith(_, { expoUsername });
+    expect(withUpdatesIOS).toHaveBeenCalledWith(_, { expoUsername });
+  });
+
+  it('passes the config object to getAccountUsername', () => {
+    withUpdates(getConfig({ owner: 'real-owner' }));
+    expect(getAccountUsername).toHaveBeenCalledWith(
+      expect.objectContaining({ owner: 'real-owner' })
+    );
+  });
+});
+
+function getConfig(options = {}): ExpoConfig {
+  return {
+    name: 'foo',
+    slug: 'my-app',
+    ...options,
+  };
+}
+
+// expect.anything() doesn't match for undefined | null
+expect.extend({
+  literallyAnything: () => {
+    return {
+      message: () => 'This value is ignored',
+      pass: true,
+    };
+  },
+});

--- a/packages/expo-updates/plugin/src/withUpdates.ts
+++ b/packages/expo-updates/plugin/src/withUpdates.ts
@@ -1,3 +1,4 @@
+import { getAccountUsername } from '@expo/config';
 import { ConfigPlugin, createRunOncePlugin } from '@expo/config-plugins';
 
 import { withUpdatesAndroid } from './withUpdatesAndroid';
@@ -6,8 +7,8 @@ import { withUpdatesIOS } from './withUpdatesIOS';
 const pkg = require('expo-updates/package.json');
 
 const withUpdates: ConfigPlugin<{ expoUsername?: string } | void> = (config, props = {}) => {
-  // The username should be passed from the CLI when the plugin is automatically used.
-  const expoUsername = (props || {}).expoUsername ?? process.env.EXPO_CLI_USERNAME ?? null;
+  // The username will be passed from the CLI when the plugin is automatically used.
+  const expoUsername = (props || {}).expoUsername ?? getAccountUsername(config);
 
   config = withUpdatesAndroid(config, { expoUsername });
   config = withUpdatesIOS(config, { expoUsername });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2340,7 +2340,7 @@
     xcode "^3.0.1"
     xml2js "^0.4.23"
 
-"@expo/config-plugins@3.0.6":
+"@expo/config-plugins@3.0.6", "@expo/config-plugins@^3.0.6":
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/@expo/config-plugins/-/config-plugins-3.0.6.tgz#1ba148de2c971cc08c989281f18274d45bf0e5bc"
   integrity sha512-hJfxEWfsWuqt4WG3X2F74+tL1JrXZomRBgShKLTMw1vvLe4md70rjTLbmaHkcGb+TfY3RtFZSK8p9oqFXCi8KA==
@@ -2459,7 +2459,7 @@
     semver "7.3.2"
     slugify "^1.3.4"
 
-"@expo/config@5.0.6":
+"@expo/config@5.0.6", "@expo/config@^5.0.6":
   version "5.0.6"
   resolved "https://registry.yarnpkg.com/@expo/config/-/config-5.0.6.tgz#beb278df78b69b9bf44049259c72560bcbed943e"
   integrity sha512-KnSEmlRYT4AsxOGa2OPEefeCEJSo4oMZI/2q3/vriiSYlI2J12/YZz2QaZtGUfKD6jm+5hCerYRQcAMhzj5/BA==
@@ -2636,6 +2636,16 @@
   dependencies:
     "@expo/config" "3.3.4"
     metro-react-native-babel-transformer "^0.58.0"
+
+"@expo/metro-config@^0.1.81":
+  version "0.1.81"
+  resolved "https://registry.yarnpkg.com/@expo/metro-config/-/metro-config-0.1.81.tgz#17570012394572a5af11e427c03de59652cd2403"
+  integrity sha512-Ta95ohtPChXnuZsCEqMMl4yWqt5hThEY1VULLMe19kT4dPa/rEQ72rtRzpDFH7adNQBRrahTz7kx9rWj6YO+MA==
+  dependencies:
+    "@expo/config" "5.0.6"
+    chalk "^4.1.0"
+    getenv "^1.0.0"
+    metro-react-native-babel-transformer "^0.59.0"
 
 "@expo/mux@^1.0.7":
   version "1.0.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2340,6 +2340,25 @@
     xcode "^3.0.1"
     xml2js "^0.4.23"
 
+"@expo/config-plugins@3.0.6":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@expo/config-plugins/-/config-plugins-3.0.6.tgz#1ba148de2c971cc08c989281f18274d45bf0e5bc"
+  integrity sha512-hJfxEWfsWuqt4WG3X2F74+tL1JrXZomRBgShKLTMw1vvLe4md70rjTLbmaHkcGb+TfY3RtFZSK8p9oqFXCi8KA==
+  dependencies:
+    "@expo/config-types" "^42.0.0"
+    "@expo/json-file" "8.2.32"
+    "@expo/plist" "0.0.13"
+    debug "^4.3.1"
+    find-up "~5.0.0"
+    fs-extra "9.0.0"
+    getenv "^1.0.0"
+    glob "7.1.6"
+    resolve-from "^5.0.0"
+    semver "^7.3.5"
+    slash "^3.0.0"
+    xcode "^3.0.1"
+    xml2js "^0.4.23"
+
 "@expo/config-plugins@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@expo/config-plugins/-/config-plugins-3.0.0.tgz#29ed1cb1c5ecf3d12f5811bd39b13ac8f3a3c2aa"
@@ -2372,6 +2391,11 @@
   version "41.0.0"
   resolved "https://registry.yarnpkg.com/@expo/config-types/-/config-types-41.0.0.tgz#ffe1444c6c26e0e3a8f7149b4afe486e357536d1"
   integrity sha512-Ax0pHuY5OQaSrzplOkT9DdpdmNzaVDnq9VySb4Ujq7UJ4U4jriLy8u93W98zunOXpcu0iiKubPsqD6lCiq0pig==
+
+"@expo/config-types@^42.0.0":
+  version "42.0.0"
+  resolved "https://registry.yarnpkg.com/@expo/config-types/-/config-types-42.0.0.tgz#3e3e125ec092c0c34dbfaf19be5480402de3d677"
+  integrity sha512-Rj02OMZke2MrGa/1Y/EScmR7VuWbDEHPJyvfFyyLbadUt+Yv6isCdeFzDt71I7gJlPR9T4fzixeYLrtXXOTq0w==
 
 "@expo/config@3.3.4":
   version "3.3.4"
@@ -2434,6 +2458,23 @@
     resolve-from "^5.0.0"
     semver "7.3.2"
     slugify "^1.3.4"
+
+"@expo/config@5.0.6":
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/@expo/config/-/config-5.0.6.tgz#beb278df78b69b9bf44049259c72560bcbed943e"
+  integrity sha512-KnSEmlRYT4AsxOGa2OPEefeCEJSo4oMZI/2q3/vriiSYlI2J12/YZz2QaZtGUfKD6jm+5hCerYRQcAMhzj5/BA==
+  dependencies:
+    "@babel/code-frame" "~7.10.4"
+    "@expo/config-plugins" "3.0.6"
+    "@expo/config-types" "^42.0.0"
+    "@expo/json-file" "8.2.32"
+    getenv "^1.0.0"
+    glob "7.1.6"
+    require-from-string "^2.0.2"
+    resolve-from "^5.0.0"
+    semver "7.3.2"
+    slugify "^1.3.4"
+    sucrase "^3.20.0"
 
 "@expo/configure-splash-screen@0.1.19":
   version "0.1.19"
@@ -2566,6 +2607,15 @@
   dependencies:
     "@babel/code-frame" "~7.10.4"
     fs-extra "9.0.0"
+    json5 "^1.0.1"
+    write-file-atomic "^2.3.0"
+
+"@expo/json-file@8.2.32":
+  version "8.2.32"
+  resolved "https://registry.yarnpkg.com/@expo/json-file/-/json-file-8.2.32.tgz#612e83433559637a3b853b170ae6d86cccb98064"
+  integrity sha512-VnpoEnjMptBQr/zgkfGHd7L8iJBme9g2AVpUIecI+aoW6qmeIRbBViPmyNABgH4UUQn3ObQCxe+q1dAdJo8KGg==
+  dependencies:
+    "@babel/code-frame" "~7.10.4"
     json5 "^1.0.1"
     write-file-atomic "^2.3.0"
 
@@ -6394,6 +6444,11 @@ any-observable@^0.3.0:
   resolved "https://registry.yarnpkg.com/any-observable/-/any-observable-0.3.0.tgz#af933475e5806a67d0d7df090dd5e8bef65d119b"
   integrity sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==
 
+any-promise@^1.0.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/any-promise/-/any-promise-1.3.0.tgz#abc6afeedcea52e809cdc0376aed3ce39635d17f"
+  integrity sha1-q8av7tzqUugJzcA3au0845Y10X8=
+
 anymatch@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-2.0.0.tgz#bcb24b4f37934d9aa7ac17b4adaf89e7c76ef2eb"
@@ -8282,7 +8337,7 @@ commander@^3.0.2:
   resolved "https://registry.yarnpkg.com/commander/-/commander-3.0.2.tgz#6837c3fb677ad9933d1cfba42dd14d5117d6b39e"
   integrity sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==
 
-commander@^4.0.1, commander@^4.1.1:
+commander@^4.0.0, commander@^4.0.1, commander@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
   integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
@@ -16373,6 +16428,15 @@ mv@2.1.1, mv@~2:
     ncp "~2.0.0"
     rimraf "~2.4.0"
 
+mz@^2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/mz/-/mz-2.7.0.tgz#95008057a56cafadc2bc63dde7f9ff6955948e32"
+  integrity sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==
+  dependencies:
+    any-promise "^1.0.0"
+    object-assign "^4.0.1"
+    thenify-all "^1.0.0"
+
 nan@^2.12.1, nan@^2.14.0:
   version "2.14.1"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.1.tgz#d7be34dfa3105b91494c3147089315eff8874b01"
@@ -20656,6 +20720,18 @@ subscriptions-transport-ws@^0.9.18:
     symbol-observable "^1.0.4"
     ws "^5.2.0"
 
+sucrase@^3.20.0:
+  version "3.20.0"
+  resolved "https://registry.yarnpkg.com/sucrase/-/sucrase-3.20.0.tgz#a80e865830e27d66a912c938491d474164b06205"
+  integrity sha512-Rsp+BX7DRuCleJvBAHN7gQ3ddk7U0rJev19XlIBF6dAq9vX4Tr5mHk4E7+ig/I7BM3DLYotCmm20lfBElT2XtQ==
+  dependencies:
+    commander "^4.0.0"
+    glob "7.1.6"
+    lines-and-columns "^1.1.6"
+    mz "^2.7.0"
+    pirates "^4.0.1"
+    ts-interface-checker "^0.1.9"
+
 sudo-prompt@9.1.1:
   version "9.1.1"
   resolved "https://registry.yarnpkg.com/sudo-prompt/-/sudo-prompt-9.1.1.tgz#73853d729770392caec029e2470db9c221754db0"
@@ -20957,6 +21033,20 @@ text-table@0.2.0, text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
+thenify-all@^1.0.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/thenify-all/-/thenify-all-1.6.0.tgz#1a1918d402d8fc3f98fbf234db0bcc8cc10e9726"
+  integrity sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=
+  dependencies:
+    thenify ">= 3.1.0 < 4"
+
+"thenify@>= 3.1.0 < 4":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/thenify/-/thenify-3.3.1.tgz#8932e686a4066038a016dd9e2ca46add9838a95f"
+  integrity sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==
+  dependencies:
+    any-promise "^1.0.0"
+
 three@^0.115.0:
   version "0.115.0"
   resolved "https://registry.yarnpkg.com/three/-/three-0.115.0.tgz#540d800c381b9da2334c024f0fbe4d23f84eb05e"
@@ -21158,6 +21248,11 @@ truncate-utf8-bytes@^1.0.0:
   integrity sha1-QFkjkJWS1W94pYGENLC3hInKXys=
   dependencies:
     utf8-byte-length "^1.0.1"
+
+ts-interface-checker@^0.1.9:
+  version "0.1.13"
+  resolved "https://registry.yarnpkg.com/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz#784fd3d679722bc103b1b4b8030bcddb5db2a699"
+  integrity sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==
 
 ts-invariant@^0.4.0, ts-invariant@^0.4.4:
   version "0.4.4"


### PR DESCRIPTION
# Why

If you add `plugins: ['expo-updates']` to your app config, it will use the expo-updates config plugin. I noticed that this will result in the updates URL being left out of the prebuild result, because we're not properly looking up the Expo username. You can see this using the preview modifier in VSCode. This fixes that problem.

# How

Use `getAccountUsername` from `@expo/config` to ensure we have a consistent strategy for determining the username.

# Test Plan

- Run unit tests
- Use preview modifier in VSCode with these changes in your node_modules

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).