### PR TITLE
[expo-dev-launcher][ios] add EXDevLauncherRecentlyOpenedAppsRegistryTests

### DIFF
--- a/packages/expo-dev-launcher/ios/EXDevLauncherRecentlyOpenedAppsRegistry.swift
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherRecentlyOpenedAppsRegistry.swift
@@ -47,7 +47,7 @@ public class EXDevLauncherRecentlyOpenedAppsRegistry : NSObject {
     return result
   }
   
-  private func getCurrentTimestamp() -> Int64 {
+  func getCurrentTimestamp() -> Int64 {
     return Int64(Date().timeIntervalSince1970 * 1000);
   }
 }

--- a/packages/expo-dev-launcher/ios/Tests/EXDevLauncherRecentlyOpenedAppsRegistryTests.swift
+++ b/packages/expo-dev-launcher/ios/Tests/EXDevLauncherRecentlyOpenedAppsRegistryTests.swift
@@ -1,0 +1,48 @@
+// Copyright 2021-present 650 Industries. All rights reserved.
+
+import XCTest
+
+@testable import EXDevLauncher
+
+class EXDevLauncherRecentlyOpenedAppsRegistry3DaysAgo: EXDevLauncherRecentlyOpenedAppsRegistry {
+  override func getCurrentTimestamp() -> Int64 {
+    return Int64((Date().timeIntervalSince1970 - (60 * 60 * 24 * 3) - 1) * 1000); // 3 days and 1 second ago
+  }
+}
+
+class EXDevLauncherRecentlyOpenedAppsRegistryTests: XCTestCase {
+  func testAddAppToRegistry() {
+    let urlString = "http://localhost:8081"
+    let name = "test-app"
+    let registry = EXDevLauncherRecentlyOpenedAppsRegistry()
+    registry.appWasOpened(urlString, name: name)
+    let recentlyOpenedApps = registry.recentlyOpenedApps()
+    XCTAssertEqual(name, recentlyOpenedApps[urlString] as! String)
+  }
+
+  func testRegistryPersistence() {
+    // instance of the registry class shouldn't matter
+    // if this fails, testRemoveOldAppFromRegistry could have a false positive
+    let urlString = "http://localhost:8081"
+    let name = "test-app"
+
+    let registry1 = EXDevLauncherRecentlyOpenedAppsRegistry()
+    registry1.appWasOpened(urlString, name: name)
+
+    let registry2 = EXDevLauncherRecentlyOpenedAppsRegistry()
+    let recentlyOpenedApps = registry2.recentlyOpenedApps()
+    XCTAssertEqual(name, recentlyOpenedApps[urlString] as! String)
+  }
+
+  func testRemoveOldAppFromRegistry() {
+    let urlString = "http://localhost:8081"
+    let name = "test-app"
+
+    let registryOld = EXDevLauncherRecentlyOpenedAppsRegistry3DaysAgo()
+    registryOld.appWasOpened(urlString, name: name)
+
+    let registryNew = EXDevLauncherRecentlyOpenedAppsRegistry()
+    let recentlyOpenedApps = registryNew.recentlyOpenedApps()
+    XCTAssertNil(recentlyOpenedApps[urlString])
+  }
+}


### PR DESCRIPTION
# Why

chipping away at ENG-1610

# How

- Added EXDevLauncherRecentlyOpenedAppsRegistryTests (which is maybe one of the longest class names I've created 😂 )
- Changed `getCurrentTimestamp` access level to internal to be able to modify its behavior in a subclass

# Test Plan

Tests pass ✅ 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).