### PR TITLE
[tools] versioning libhermes.so soname for android

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -9,6 +9,8 @@ Expotools is a CLI and library that contains internal Expo tooling. It is used a
 ## Prerequisites
 Run `bundle install` in the root to install all required Ruby gems.
 
+To support versioning react-native for Android, [patchelf](https://github.com/NixOS/patchelf) is required. On macOS, could run `brew install patchelf` to install.
+
 ## Usage
 Run `expotools` or `et` from the Expo repository to run the latest version of expotools. This automatically rebuilds the code according to the latest sources.
 

--- a/tools/src/versioning/android/versionReactNative.ts
+++ b/tools/src/versioning/android/versionReactNative.ts
@@ -85,3 +85,104 @@ async function runReactNativeCodegenAndroidAsync(
     'com.facebook.fbreact.specs',
   ]);
 }
+
+export async function renameHermesEngine(versionedReactAndroidPath: string, version: string) {
+  const abiVersion = version.replace(/\./g, '_');
+  const abiName = `abi${abiVersion}`;
+  const prebuiltHermesMkPath = path.join(
+    versionedReactAndroidPath,
+    'src',
+    'main',
+    'jni',
+    'first-party',
+    'hermes',
+    'Android.mk'
+  );
+  const versionedHermesLibName = `libhermes_${abiName}.so`;
+  await transformFileAsync(prebuiltHermesMkPath, [
+    {
+      find: /^(LOCAL_SRC_FILES\s+:=\s+jni\/\$\(TARGET_ARCH_ABI\))\/libhermes.so$/gm,
+      replaceWith: `$1/${versionedHermesLibName}`,
+    },
+  ]);
+
+  const buildGradlePath = path.join(versionedReactAndroidPath, 'build.gradle');
+  // patch prepareHermes task to rename copied library and update soname
+  // the diff is something like that:
+  //
+  // ```diff
+  // --- android/versioned-react-native/ReactAndroid/build.gradle.orig       2021-08-14 00:40:18.000000000 +0800
+  // +++ android/versioned-react-native/ReactAndroid/build.gradle    2021-08-14 00:40:58.000000000 +0800
+  // @@ -114,7 +114,7 @@
+  //      into("$thirdPartyNdkDir/folly")
+  //  }
+  //
+  // -task prepareHermes(dependsOn: createNativeDepsDirectories, type: Copy) {
+  // +task prepareHermes(dependsOn: createNativeDepsDirectories) {
+  //      def hermesPackagePath = findNodeModulePath(projectDir, "hermes-engine")
+  //      if (!hermesPackagePath) {
+  //          throw new GradleScriptException("Could not find the hermes-engine npm package", null)
+  // @@ -126,12 +126,29 @@
+  //      }
+  //
+  //      def soFiles = zipTree(hermesAAR).matching({ it.include "**/*.so" })
+  // -
+  // +    copy {
+  // +
+  //      from soFiles
+  //      from "src/main/jni/first-party/hermes/Android.mk"
+  //      into "$thirdPartyNdkDir/hermes"
+  // +
+  // +        rename '(.+).so', '$1_abi43_0_0.so'
+  // +    }
+  // +    exec {
+  // +        commandLine("patchelf", "--set-soname", "libhermes_abi43_0_0.so", "$thirdPartyNdkDir/hermes/jni/arm64-v8a/libhermes_abi43_0_0.so")
+  // +    }
+  // +    exec {
+  // +        commandLine("patchelf", "--set-soname", "libhermes_abi43_0_0.so", "$thirdPartyNdkDir/hermes/jni/armeabi-v7a/libhermes_abi43_0_0.so")
+  // +    }
+  // +    exec {
+  // +        commandLine("patchelf", "--set-soname", "libhermes_abi43_0_0.so", "$thirdPartyNdkDir/hermes/jni/x86/libhermes_abi43_0_0.so")
+  // +    }
+  // +    exec {
+  // +        commandLine("patchelf", "--set-soname", "libhermes_abi43_0_0.so", "$thirdPartyNdkDir/hermes/jni/x86_64/libhermes_abi43_0_0.so")
+  // +    }
+  //  }
+  //
+  // +
+  //  task downloadGlog(dependsOn: createNativeDepsDirectories, type: Download) {
+  //      src("https://github.com/google/glog/archive/v${GLOG_VERSION}.tar.gz")
+  //      onlyIfNewer(true)
+  // ```
+  await transformFileAsync(buildGradlePath, [
+    {
+      // reset `prepareHermes` task from Copy type to generic type then we can do both copy and exec.
+      find: /^(task prepareHermes\(dependsOn: .+), type: Copy(\).+$)/m,
+      replaceWith: '$1$2',
+    },
+    {
+      // wrap copy task and append exec tasks
+      find: /(^\s*def soFiles = zipTree\(hermesAAR\).+)\n([\s\S]+?)^\}/gm,
+      replaceWith: `\
+$1
+    copy {
+        $2
+        rename '(.+).so', '$$1_abi${abiVersion}.so'
+    }
+    exec {
+        commandLine("patchelf", "--set-soname", "${versionedHermesLibName}", "$thirdPartyNdkDir/hermes/jni/arm64-v8a/${versionedHermesLibName}")
+    }
+    exec {
+        commandLine("patchelf", "--set-soname", "${versionedHermesLibName}", "$thirdPartyNdkDir/hermes/jni/armeabi-v7a/${versionedHermesLibName}")
+    }
+    exec {
+        commandLine("patchelf", "--set-soname", "${versionedHermesLibName}", "$thirdPartyNdkDir/hermes/jni/x86/${versionedHermesLibName}")
+    }
+    exec {
+        commandLine("patchelf", "--set-soname", "${versionedHermesLibName}", "$thirdPartyNdkDir/hermes/jni/x86_64/${versionedHermesLibName}")
+    }
+}
+`,
+    },
+  ]);
+}


### PR DESCRIPTION
# Why

for expo-go to load different hermes-engine version, versioning libhermes.so on filename is not enough, we should further update the `soname`. otherwise, android will use loaded soname directly.

# How

use [patchelf](https://github.com/NixOS/patchelf) to update soname in versioning stage.

# Test Plan

based on #13793 and this change, re-generate sdk-42 aar and build versioned android expo-go. load these two projects without close activity
 - load [sdk42 hermes bundle](https://expo.dev/@kudochien/sdk42) which hbc version is 74
 - load local unversioned hermes project based on react-native 0.64 (hermes-engine 0.7.2) which hbc version is 76

before the change, expo-go will crash.
after the change, expo-go could load both two projects without problems.


# Checklist

after the pr is merged, will further cherry-pick this to sdk-42 branch and re-generate aar. 