### PR TITLE
[ci] Add workflow testing the versioning process

### DIFF
--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -1,0 +1,100 @@
+name: Versioning Expo Go
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: '0 5 * * SUN' # 5am UTC time on each Sunday
+  pull_request:
+    paths:
+      - .github/workflows/versioning.yml
+      - tools/src/commands/AddSDKVersion.ts
+      - tools/src/commands/RemoveSDKVersion.ts
+      - tools/src/versioning/**
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ios:
+    runs-on: macos-11
+    steps:
+      - name: 👀 Checkout a ref for the event
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: 🔨 Switch to Xcode 12.5.1
+        run: sudo xcode-select --switch /Applications/Xcode_12.5.1.app
+      - name: 🍺 Setup Homebrew
+        run: brew install git-crypt
+      - name: 🔓 decrypt secrets if possible
+        env:
+          GIT_CRYPT_KEY_BASE64: ${{ secrets.GIT_CRYPT_KEY_BASE64 }}
+        run: |
+          if [[ ${GIT_CRYPT_KEY_BASE64:-unset} = unset ]]; then
+            echo 'git-crypt key not present in environment'
+          else
+            git crypt unlock <(echo $GIT_CRYPT_KEY_BASE64 | base64 --decode)
+          fi
+      - name: ➕ Add `bin` to GITHUB_PATH
+        run: echo "$(pwd)/bin" >> $GITHUB_PATH
+      - name: ♻️ Restore workspace node modules
+        uses: actions/cache@v2
+        id: node-modules-cache
+        with:
+          path: |
+            # See "workspaces" → "packages" in the root package.json for the source of truth of
+            # which node_modules are affected by the root yarn.lock
+            node_modules
+            apps/*/node_modules
+            home/node_modules
+            packages/*/node_modules
+            packages/@unimodules/*/node_modules
+            react-native-lab/react-native/node_modules
+          key: ${{ runner.os }}-modules-${{ hashFiles('yarn.lock') }}
+      - name: 🧶 Yarn install
+        run: yarn install --frozen-lockfile
+      - name: ♻️ Restore node modules in tools
+        uses: actions/cache@v2
+        with:
+          path: tools/node_modules
+          key: ${{ runner.os }}-tools-modules-${{ hashFiles('tools/yarn.lock') }}
+      - name: 🏭 Generating dynamic macros
+        run: expotools ios-generate-dynamic-macros
+      - name: 💎 Setup Ruby and install gems
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - name: ♻️ Restore ios/Pods from cache
+        uses: actions/cache@v2
+        with:
+          path: 'ios/Pods'
+          key: ${{ runner.os }}-pods-${{ hashFiles('ios/Podfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pods-
+      - name: 🥥 Install CocoaPods in `ios`
+        run: pod install
+        working-directory: ios
+      - name: 📂 Adding new SDK version
+        run: expotools add-sdk-version --platform ios --sdkVersion next --reinstall
+      - name: 🏗 Build versioned Expo Go for simulator
+        run: expotools client-build --platform ios --flavor versioned
+        timeout-minutes: 120
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      - name: 🗑 Removing SDK version
+        run: expotools remove-sdk-version --platform ios --sdkVersion latest
+      - name: 🐙 Git working dir is clean
+        run: git diff --exit-code
+      - name: 🔔 Notify on Slack
+        uses: 8398a7/action-slack@v3
+        if: failure() && (github.event.ref == 'refs/heads/master' || startsWith(github.event.ref, 'refs/heads/sdk-'))
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_ios }}
+        with:
+          channel: '#platform-ios'
+          status: ${{ job.status }}
+          fields: job,message,ref,eventName,author,took
+          author_name: Versioning Expo Go (iOS)

--- a/tools/src/dynamic-macros/IosMacrosGenerator.ts
+++ b/tools/src/dynamic-macros/IosMacrosGenerator.ts
@@ -115,7 +115,7 @@ async function writeTemplatesAsync(expoKitPath: string, templateFilesPath: strin
   }
 }
 
-async function renderExpoKitPodspecAsync(
+export async function renderExpoKitPodspecAsync(
   expoKitPath: string,
   templateFilesPath: string
 ): Promise<void> {

--- a/tools/src/versioning/ios/index.ts
+++ b/tools/src/versioning/ios/index.ts
@@ -10,6 +10,7 @@ import semver from 'semver';
 import { EXPO_DIR, IOS_DIR, VERSIONED_RN_IOS_DIR } from '../../Constants';
 import logger from '../../Logger';
 import { getListOfPackagesAsync, Package } from '../../Packages';
+import { renderExpoKitPodspecAsync } from '../../dynamic-macros/IosMacrosGenerator';
 import { runTransformPipelineAsync } from './transforms';
 import { injectMacros } from './transforms/injectMacros';
 import { kernelFilesTransforms } from './transforms/kernelFilesTransforms';
@@ -1000,6 +1001,10 @@ export async function removeVersionAsync(versionNumber: string) {
   // modify kernel files
   console.log('Rollbacking SDK modifications from kernel files...');
   await modifyKernelFilesAsync(versionName, true);
+
+  // Update `ios/ExpoKit.podspec` with the newest SDK version
+  logger.info('🎨 Updating ExpoKit podspec');
+  await renderExpoKitPodspecAsync(EXPO_DIR, path.join(EXPO_DIR, 'template-files'));
 
   await reinstallPodsAsync();
 }


### PR DESCRIPTION
# Why

Would be great to be more sure that the versioning process works

# How

Added new CI workflow that is scheduled to run on each Sunday at 5am UTC time. It does the following:
- `et add-sdk-version`
- builds versioned Expo Go
- `et remove-sdk-version`
- `git diff --exit-code` to check if the working dir is clean

For now, only for iOS.

# Test Plan

