### PR TITLE
[actions] Fix home dogfood publish GH action

### DIFF
--- a/.github/workflows/home.yml
+++ b/.github/workflows/home.yml
@@ -78,7 +78,7 @@ jobs:
             ${{ runner.os }}-yarn-
       - run: yarn install --frozen-lockfile
       - name: 🦴 Publish dogfood home
-        run: expotools publish-dogfood-home
+        run: bin/expotools publish-dogfood-home
         env:
           EXPO_DOGFOOD_HOME_ACCESS_TOKEN: ${{ secrets.EXPO_DOGFOOD_HOME_ACCESS_TOKEN }}
       - name: 🔔 Notify on Slack


### PR DESCRIPTION
# Why

https://github.com/expo/expo/pull/13871 used the incorrect pwd (expotools not in path). Either we could add bin to the path or just call the script relatively, this PR opts for the latter.

# How

Call `bin/expotools` like some other actions do.

# Test Plan

Wait for CI.