### PR TITLE
[actions] Fix dogfood action by installing expo-cli globally

### DIFF
--- a/.github/workflows/home.yml
+++ b/.github/workflows/home.yml
@@ -77,6 +77,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
       - run: yarn install --frozen-lockfile
+      - run: yarn global add expo-cli
       - name: 🦴 Publish dogfood home
         run: bin/expotools publish-dogfood-home
         env:


### PR DESCRIPTION
# Why

The CI action is failing this time because I had assumed expo-cli was a dev dependency, when in fact it is not. Blame #13871.

# How

To fix, apply the same solution as other actions by installing the package globally. See other workflow example: https://github.com/expo/expo/blob/master/.github/workflows/publish-demo.yml#L35

# Test Plan

Wait for CI.