### PR TITLE
[actions] Remove home dogfooding slack publish on success

### DIFF
--- a/.github/workflows/home.yml
+++ b/.github/workflows/home.yml
@@ -84,6 +84,7 @@ jobs:
           EXPO_DOGFOOD_HOME_ACCESS_TOKEN: ${{ secrets.EXPO_DOGFOOD_HOME_ACCESS_TOKEN }}
       - name: 🔔 Notify on Slack
         uses: 8398a7/action-slack@v3
+        if: failure()
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_api }}


### PR DESCRIPTION
# Why

#13871 accidentally made this send a message to slack on all statuses, not just failures. This PR makes the slack message only send on failure.

# How

Add `if` condition.

# Test Plan

Wait for CI.