### PR TITLE
[expo-dev-launcher][expo-updates] fix opening multiple different published apps in dev client

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fixed issue where Expo-hosted manifest URLs with `/index.exp?...` suffix could not be opened properly. ([#13825](https://github.com/expo/expo/pull/13825) by [@esamelson](https://github.com/esamelson))
+- Fixed issue with opening multiple different published apps.
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fixed issue where Expo-hosted manifest URLs with `/index.exp?...` suffix could not be opened properly. ([#13825](https://github.com/expo/expo/pull/13825) by [@esamelson](https://github.com/esamelson))
-- Fixed issue with opening multiple different published apps.
+- Fixed issue with opening multiple different published apps. ([#13926](https://github.com/expo/expo/pull/13926) by [@esamelson](https://github.com/esamelson))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/helpers/DevLauncherUpdatesHelper.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/helpers/DevLauncherUpdatesHelper.kt
@@ -43,6 +43,7 @@ suspend fun UpdatesInterface.loadUpdate(
 fun createUpdatesConfigurationWithUrl(url: Uri): HashMap<String, Any> {
   return hashMapOf(
     "updateUrl" to url,
+    "scopeKey" to url.toString(),
     "hasEmbeddedUpdate" to false,
     "launchWaitMs" to 60000,
     "checkOnLaunch" to "ALWAYS",

--- a/packages/expo-dev-launcher/android/src/test/java/expo/modules/devlauncher/helpers/DevLauncherUpdatesHelperTest.kt
+++ b/packages/expo-dev-launcher/android/src/test/java/expo/modules/devlauncher/helpers/DevLauncherUpdatesHelperTest.kt
@@ -73,4 +73,19 @@ internal class DevLauncherUpdatesHelperTest {
     }
     return updatesInterface
   }
+
+  @Test
+  fun `createUpdatesConfiguration sets the correct value for scopeKey`() {
+    val urlString1 = "https://exp.host/@test/first-app"
+    val configuration1 = createUpdatesConfigurationWithUrl(Uri.parse(urlString1))
+
+    val urlString2 = "https://exp.host/@test/second-app"
+    val configuration2 = createUpdatesConfigurationWithUrl(Uri.parse(urlString2))
+
+    val scopeKey1 = configuration1["scopeKey"]
+    val scopeKey2 = configuration2["scopeKey"]
+    Truth.assertThat(scopeKey1).isNotEqualTo(scopeKey2)
+    Truth.assertThat(scopeKey1).isEqualTo(urlString1)
+    Truth.assertThat(scopeKey2).isEqualTo(urlString2)
+  }
 }

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -13,6 +13,7 @@
 #import "EXDevLauncherManifestParser.h"
 #import "EXDevLauncherLoadingView.h"
 #import "EXDevLauncherInternal.h"
+#import "EXDevLauncherUpdatesHelper.h"
 #import "RCTPackagerConnection+EXDevLauncherPackagerConnectionInterceptor.h"
 
 #import <EXDevLauncher-Swift.h>
@@ -250,16 +251,7 @@ NSString *fakeLauncherBundleUrl = @"embedded://EXDevLauncher/dummy";
     }
   }
 
-  NSDictionary *updatesConfiguration = @{
-    @"EXUpdatesURL": expoUrl.absoluteString,
-    @"EXUpdatesLaunchWaitMs": @(60000),
-    @"EXUpdatesCheckOnLaunch": @"ALWAYS",
-    @"EXUpdatesHasEmbeddedUpdate": @(NO),
-    @"EXUpdatesEnabled": @(YES),
-    @"EXUpdatesRequestHeaders": @{
-      @"Expo-Updates-Environment": @"DEVELOPMENT"
-    }
-  };
+  NSDictionary *updatesConfiguration = [EXDevLauncherUpdatesHelper createUpdatesConfigurationWithURL:expoUrl];
 
   void (^launchReactNativeApp)(void) = ^{
     self->_shouldPreferUpdatesInterfaceSourceUrl = NO;

--- a/packages/expo-dev-launcher/ios/EXDevLauncherUpdatesHelper.h
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherUpdatesHelper.h
@@ -1,0 +1,13 @@
+// Copyright 2021-present 650 Industries. All rights reserved.
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface EXDevLauncherUpdatesHelper : NSObject
+
++ (NSDictionary *)createUpdatesConfigurationWithURL:(NSURL *)url;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-dev-launcher/ios/EXDevLauncherUpdatesHelper.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherUpdatesHelper.m
@@ -1,0 +1,27 @@
+// Copyright 2021-present 650 Industries. All rights reserved.
+
+#import "EXDevLauncherUpdatesHelper.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@implementation EXDevLauncherUpdatesHelper
+
++ (NSDictionary *)createUpdatesConfigurationWithURL:(NSURL *)url
+{
+  NSString *urlString = url.absoluteString;
+  return @{
+    @"EXUpdatesURL": urlString,
+    @"EXUpdatesScopeKey": urlString,
+    @"EXUpdatesLaunchWaitMs": @(60000),
+    @"EXUpdatesCheckOnLaunch": @"ALWAYS",
+    @"EXUpdatesHasEmbeddedUpdate": @(NO),
+    @"EXUpdatesEnabled": @(YES),
+    @"EXUpdatesRequestHeaders": @{
+      @"Expo-Updates-Environment": @"DEVELOPMENT"
+    }
+  };
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-dev-launcher/ios/Tests/EXDevLauncherUpdatesHelperTests.m
+++ b/packages/expo-dev-launcher/ios/Tests/EXDevLauncherUpdatesHelperTests.m
@@ -1,0 +1,28 @@
+// Copyright 2021-present 650 Industries. All rights reserved.
+
+#import <XCTest/XCTest.h>
+
+#import <EXDevLauncher/EXDevLauncherUpdatesHelper.h>
+
+@interface EXDevLauncherUpdatesHelperTests : XCTestCase
+
+@end
+
+@implementation EXDevLauncherUpdatesHelperTests
+
+- (void)testCreateUpdatesConfiguration_scopeKey
+{
+  NSString *urlString1 = @"https://exp.host/@test/first-app";
+  NSDictionary *configuration1 = [EXDevLauncherUpdatesHelper createUpdatesConfigurationWithURL:[NSURL URLWithString:urlString1]];
+
+  NSString *urlString2 = @"https://exp.host/@test/second-app";
+  NSDictionary *configuration2 = [EXDevLauncherUpdatesHelper createUpdatesConfigurationWithURL:[NSURL URLWithString:urlString2]];
+
+  NSString *scopeKey1 = configuration1[@"EXUpdatesScopeKey"];
+  NSString *scopeKey2 = configuration2[@"EXUpdatesScopeKey"];
+  XCTAssertNotEqualObjects(scopeKey1, scopeKey2);
+  XCTAssertEqualObjects(urlString1, scopeKey1);
+  XCTAssertEqualObjects(urlString2, scopeKey2);
+}
+
+@end

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Fix `PROJECT_ROOT` path resolution in `create-manifest-ios.sh` and in `createManifest.js` ([#13439](https://github.com/expo/expo/pull/13439) by [@ajsmth](https://github.com/ajsmth))
 - Fix erroneous manifest JSON direct access. ([#13906](https://github.com/expo/expo/pull/13906) by [@wschurman](https://github.com/wschurman))
 - Fix config plugin to properly set the updates URL based on `getAccountUsername` from `@expo/config`. ([#13909](https://github.com/expo/expo/pull/13909) by [@brentvatne](https://github.com/brentvatne))
+- Fixed issue with dev-launcher integration where configuration was not set at the correct time, which caused issues when trying to open multiple different published apps.
 
 ### 💡 Others
 

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -17,7 +17,7 @@
 - Fix `PROJECT_ROOT` path resolution in `create-manifest-ios.sh` and in `createManifest.js` ([#13439](https://github.com/expo/expo/pull/13439) by [@ajsmth](https://github.com/ajsmth))
 - Fix erroneous manifest JSON direct access. ([#13906](https://github.com/expo/expo/pull/13906) by [@wschurman](https://github.com/wschurman))
 - Fix config plugin to properly set the updates URL based on `getAccountUsername` from `@expo/config`. ([#13909](https://github.com/expo/expo/pull/13909) by [@brentvatne](https://github.com/brentvatne))
-- Fixed issue with dev-launcher integration where configuration was not set at the correct time, which caused issues when trying to open multiple different published apps.
+- Fixed issue with dev-launcher integration where configuration was not set at the correct time, which caused issues when trying to open multiple different published apps. ([#13926](https://github.com/expo/expo/pull/13926) by [@esamelson](https://github.com/esamelson))
 
 ### 💡 Others
 

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesDevLauncherController.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesDevLauncherController.m
@@ -22,6 +22,12 @@ typedef NS_ENUM(NSInteger, EXUpdatesDevLauncherErrorCode) {
   EXUpdatesDevLauncherErrorCodeUpdateLaunchFailed,
 };
 
+@interface EXUpdatesDevLauncherController ()
+
+@property (nonatomic, strong) EXUpdatesConfig *tempConfig;
+
+@end
+
 @implementation EXUpdatesDevLauncherController
 
 @synthesize bridge = _bridge;
@@ -82,7 +88,11 @@ typedef NS_ENUM(NSInteger, EXUpdatesDevLauncherErrorCode) {
     return;
   }
 
+  // since controller is a singleton, save its config so we can reset to it if our request fails
+  _tempConfig = controller.config;
+
   [self _setDevelopmentSelectionPolicy];
+  [controller setConfigurationInternal:updatesConfiguration];
 
   EXUpdatesRemoteAppLoader *loader = [[EXUpdatesRemoteAppLoader alloc] initWithConfig:updatesConfiguration database:controller.database directory:controller.updatesDirectory completionQueue:controller.controllerQueue];
   [loader loadUpdateFromUrl:updatesConfiguration.updateUrl onManifest:^BOOL(EXUpdatesUpdate * _Nonnull update) {
@@ -119,11 +129,12 @@ typedef NS_ENUM(NSInteger, EXUpdatesDevLauncherErrorCode) {
   [launcher launchUpdateWithSelectionPolicy:controller.selectionPolicy completion:^(NSError * _Nullable error, BOOL success) {
     if (!success) {
       errorBlock(error ?: [NSError errorWithDomain:EXUpdatesDevLauncherControllerErrorDomain code:EXUpdatesDevLauncherErrorCodeUpdateLaunchFailed userInfo:@{NSLocalizedDescriptionKey: @"Failed to launch update with an unknown error"}]);
+      // reset controller's configuration to what it was before this request
+      [controller setConfigurationInternal:self->_tempConfig];
       return;
     }
 
     [controller setIsStarted:YES];
-    [controller setConfigurationInternal:configuration];
     [controller setLauncher:launcher];
     successBlock(launcher.launchedUpdate.rawManifest.rawManifestJSON);
     [controller runReaper];


### PR DESCRIPTION
# Why

While smoke testing dev-client@0.4.6 with self-hosted apps today, I discovered a bug where sometimes, when opening multiple different published apps, expo-updates will start returning the same manifest across all published apps.

This is due to the scope key (URL) not propagating correctly through expo-updates.

# How

The fix is twofold:
1. Set the scope key explicitly from dev-launcher, similar to what we do in Expo Go. This circumvents the default scope key (which is just the hostname of the URL) and allows opening multiple different projects from the same host, e.g. exp.host.
2. Inside of expo-updates, set the configuration before loading the update. This means the correct scope key is used when the update is instantiated.

# Test Plan

Added unit tests for the configuration in dev-launcher, and ran the following manual tests on both platforms:
- `expo init test1` -> modify App.js -> `expo publish`
- `expo init test2` -> modify App.js differently -> `expo export` and upload to github for self-hosting
- Build a dev client, open the manifest URL from test2 (github.io), see test2 app on screen
- Back to Launcher
- Open the manifest URL from test1 (exp.host), see test1 app on screen
- Back to Launcher, open test2 manifest URL again and go back and forth a few times to make sure switching continues to work

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).