### PR TITLE
[expo-dev-launcher] Display linking scheme used by app in URL field

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 💡 Others
 
 - Add basic setup for iOS unit tests. ([#13824](https://github.com/expo/expo/pull/13824) by [@esamelson](https://github.com/esamelson))
+- Display linking scheme used by app in launcher URL field
 
 ## 0.6.5 — 2021-07-16
 

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -13,7 +13,7 @@
 ### 💡 Others
 
 - Add basic setup for iOS unit tests. ([#13824](https://github.com/expo/expo/pull/13824) by [@esamelson](https://github.com/esamelson))
-- Display linking scheme used by app in launcher URL field
+- Display linking scheme used by app in launcher URL field ([#13930](https://github.com/expo/expo/pull/13930) by [@fson](https://github.com/fson))
 
 ## 0.6.5 — 2021-07-16
 

--- a/packages/expo-dev-launcher/bundle/DevLauncherInternal.ts
+++ b/packages/expo-dev-launcher/bundle/DevLauncherInternal.ts
@@ -24,3 +24,5 @@ export async function openCamera(): Promise<void> {
 export function addDeepLinkListener(callback: (string) => void): EventSubscription {
   return EventEmitter.addListener(ON_NEW_DEEP_LINK_EVENT, callback);
 }
+
+export const clientUrlScheme = DevLauncher.clientUrlScheme;

--- a/packages/expo-dev-launcher/bundle/components/UrlInput.tsx
+++ b/packages/expo-dev-launcher/bundle/components/UrlInput.tsx
@@ -5,6 +5,7 @@ import { MainText } from '../components/Text';
 import Colors from '../constants/Colors';
 import { useThemeName } from '../hooks/useThemeName';
 import Button from './Button';
+import { clientUrlScheme } from '../DevLauncherInternal';
 
 type Props = {
   onPress: (url: string) => void;
@@ -41,7 +42,7 @@ export default ({ onPress }: Props) => {
       <TextInput
         testID="DevLauncherURLInput"
         style={[styles.urlTextInput, { borderColor, color }]}
-        placeholder="exp://192..."
+        placeholder={`${clientUrlScheme}://...`}
         placeholderTextColor="#b0b0ba"
         autoCapitalize="none"
         autoCorrect={false}

--- a/packages/expo-dev-launcher/bundle/components/UrlInput.tsx
+++ b/packages/expo-dev-launcher/bundle/components/UrlInput.tsx
@@ -42,7 +42,7 @@ export default ({ onPress }: Props) => {
       <TextInput
         testID="DevLauncherURLInput"
         style={[styles.urlTextInput, { borderColor, color }]}
-        placeholder={`${clientUrlScheme || 'exp'}://...`}
+        placeholder={`${clientUrlScheme || 'myapp'}://expo-development-client/...`}
         placeholderTextColor="#b0b0ba"
         autoCapitalize="none"
         autoCorrect={false}

--- a/packages/expo-dev-launcher/bundle/components/UrlInput.tsx
+++ b/packages/expo-dev-launcher/bundle/components/UrlInput.tsx
@@ -42,7 +42,7 @@ export default ({ onPress }: Props) => {
       <TextInput
         testID="DevLauncherURLInput"
         style={[styles.urlTextInput, { borderColor, color }]}
-        placeholder={`${clientUrlScheme}://...`}
+        placeholder={`${clientUrlScheme || 'exp'}://...`}
         placeholderTextColor="#b0b0ba"
         autoCapitalize="none"
         autoCorrect={false}

--- a/packages/expo-dev-launcher/ios/EXDevLauncherInternal.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherInternal.m
@@ -54,7 +54,7 @@ NSString *ON_NEW_DEEP_LINK_EVENT = @"expo.modules.devlauncher.onnewdeeplink";
       }
     }
   }
-  return clientUrlScheme ?: @"exp";
+  return clientUrlScheme;
 }
 
 - (NSDictionary *)constantsToExport

--- a/packages/expo-dev-launcher/ios/EXDevLauncherInternal.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherInternal.m
@@ -37,6 +37,31 @@ NSString *ON_NEW_DEEP_LINK_EVENT = @"expo.modules.devlauncher.onnewdeeplink";
   return NO;
 }
 
+- (NSString *)findClientUrlScheme
+{
+  NSString *clientUrlScheme = nil;
+  if ([[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleURLTypes"]) {
+    NSArray *urlTypes = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleURLTypes"];
+    for (NSDictionary *urlType in urlTypes) {
+      if (urlType[@"CFBundleURLSchemes"]) {
+        NSArray *urlSchemes = urlType[@"CFBundleURLSchemes"];
+        for (NSString *urlScheme in urlSchemes) {
+          // Find a scheme with a prefix or fall back to the first scheme defined.
+          if ([urlScheme hasPrefix:@"exp+"] || !clientUrlScheme) {
+            clientUrlScheme = urlScheme;
+          }
+        }
+      }
+    }
+  }
+  return clientUrlScheme ?: @"exp";
+}
+
+- (NSDictionary *)constantsToExport
+{
+  return @{ @"clientUrlScheme": self.findClientUrlScheme };
+}
+
 - (void)onNewPendingDeepLink:(NSURL *)deepLink
 {
   [self sendEventWithName:ON_NEW_DEEP_LINK_EVENT body:deepLink.absoluteString];


### PR DESCRIPTION
# Why

This makes it clearer that you're supposed to enter a development client URL instead of a managed app URL.

# How

We show the URL scheme starting with "exp+" (this is added by the dev client plugin) or (if not found) fall back to the first URL scheme listed in the configuration.

# Test Plan

Verified the correct URL scheme shows up in the simulator.

# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).