### PR TITLE
Remove podfile cocoapods.rb extension

### DIFF
--- a/docs/public/static/diffs/react-native-unimodules-ios.diff
+++ b/docs/public/static/diffs/react-native-unimodules-ios.diff
@@ -90,7 +90,7 @@ index a452872..e21468a 100644
 -require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
 +require File.join(`node --print "require.resolve('react-native/package.json')"`, "../scripts/react_native_pods")
 +require File.join(`node --print "require.resolve('@react-native-community/cli-platform-ios/package.json')"`, "../native_modules")
-+require File.join(`node --print "require.resolve('react-native-unimodules/package.json')"`, "../cocoapods.rb")
++require File.join(`node --print "require.resolve('react-native-unimodules/package.json')"`, "../cocoapods")
 
 - platform :ios, '10.0'
 + platform :ios, '11.0'


### PR DESCRIPTION
Following instructions for bare unimodules setup, pod install fails without this change:

```
[!] Invalid `Podfile` file: cannot load such file -- /Users/ray/workspace/xxx/node_modules/react-native-unimodules/package.json
/../cocoapods.rb.
```