### PR TITLE
[android] Use autolinking v2 in Expo Go

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -130,8 +130,6 @@ configurations.all {
   }
 }
 
-apply from: new File(["node", "--print", "require.resolve('react-native-unimodules/package.json')"].execute().text.trim(), "../gradle.groovy")
-
 dependencies {
   implementation fileTree(dir: 'libs', include: ['*.jar'])
 
@@ -250,18 +248,7 @@ dependencies {
 
   // WHEN_DETACHING_REMOVE_FROM_HERE
   /* UNCOMMENT WHEN DISTRIBUTING
-  addMavenUnimodulesDependencies([
-      modulesPaths : [
-        '../enabled-modules'
-      ],
-      configuration: 'api',
-      target       : 'react-native',
-      exclude      : [
-        'expo-module-template',
-        'expo-in-app-purchases',
-        'expo-payments-stripe'
-      ]
-  ])
+  implementation project(':expo-modules-linker')
   implementation 'host.exp.exponent:expo-random:+'
   END UNCOMMENT WHEN DISTRIBUTING */
   // WHEN_DETACHING_REMOVE_TO_HERE

--- a/android/app/src/main/java/host/exp/exponent/MainApplication.java
+++ b/android/app/src/main/java/host/exp/exponent/MainApplication.java
@@ -2,13 +2,12 @@ package host.exp.exponent;
 
 import com.facebook.react.ReactPackage;
 
-import expo.modules.apploader.AppLoaderPackagesProviderInterface;
-import expo.modules.core.interfaces.Package;
-
 import java.util.Arrays;
 import java.util.List;
 
-import host.exp.exponent.generated.BasePackageList;
+import expo.modules.adapters.react.ExpoModulesPackageListDelegate;
+import expo.modules.apploader.AppLoaderPackagesProviderInterface;
+import expo.modules.core.interfaces.Package;
 
 // Needed for `react-native link`
 // import com.facebook.react.ReactApplication;
@@ -32,6 +31,6 @@ public class MainApplication extends ExpoApplication implements AppLoaderPackage
   }
 
   public List<Package> getExpoPackages() {
-    return new BasePackageList().getPackageList();
+    return ExpoModulesPackageListDelegate.getPackageList();
   }
 }

--- a/android/expoview/build.gradle
+++ b/android/expoview/build.gradle
@@ -141,7 +141,7 @@ android {
             "-DFBJNI_HEADERS_DIR=${FBJNI_HEADERS_DIR}",
             "-DCMAKE_OUTPUT_DIR=${CMAKE_OUTPUT_DIR}"
         abiFilters = []
-        abiFilters.addAll(ABI_FILTERS.split(',').collect{ (it as String).trim() })
+        abiFilters.addAll(ABI_FILTERS.split(',').collect { (it as String).trim() })
       }
     }
 
@@ -164,13 +164,13 @@ android {
     // Gradle will add cmake target dependencies into packaging.
     // Theses files are intermediated linking files to build reanimated and should not be in final package.
     excludes = [
-      "**/libc++_shared.so",
-      "**/libreactnativejni.so",
-      "**/libglog.so",
-      "**/libjscexecutor.so",
-      "**/libfbjni.so",
-      "**/libfolly_json.so",
-      "**/libhermes.so",
+        "**/libc++_shared.so",
+        "**/libreactnativejni.so",
+        "**/libglog.so",
+        "**/libjscexecutor.so",
+        "**/libfbjni.so",
+        "**/libfolly_json.so",
+        "**/libhermes.so",
     ]
   }
 
@@ -243,8 +243,6 @@ configurations.all {
   }
 }
 
-// Import gradle helpers for unimodules.
-apply from: new File(["node", "--print", "require.resolve('react-native-unimodules/package.json')"].execute().text.trim(), "../gradle.groovy")
 // WHEN_VERSIONING_REMOVE_TO_HERE
 
 dependencies {
@@ -272,15 +270,7 @@ dependencies {
 
   /* UNCOMMENT WHEN DISTRIBUTING
   api 'com.facebook.react:react-native:42.0.0'
-  addUnimodulesDependencies([
-      modulesPaths : ['../../packages'],
-      configuration: 'compileOnly',
-      target       : 'react-native',
-      exclude      : [
-        'expo-module-template',
-        'expo-in-app-purchases'
-      ]
-  ])
+  compileOnly project(':expo-modules-linker')
   compileOnly project(':expo-random')
   END UNCOMMENT WHEN DISTRIBUTING */
 
@@ -293,15 +283,7 @@ dependencies {
 
   // Universal modules
   // In distribution they're "compileOnly" and it's the app/build.gradle who manages them.
-  addUnimodulesDependencies([
-      modulesPaths : ['../../packages'],
-      configuration: 'api',
-      target       : 'react-native',
-      exclude      : [
-          'expo-module-template',
-          'expo-in-app-purchases',
-      ]
-  ])
+  api project(':expo-modules-linker')
 
   // expo-random is no longer a unimodule
   api project(':expo-random')

--- a/android/expoview/build.gradle
+++ b/android/expoview/build.gradle
@@ -164,13 +164,13 @@ android {
     // Gradle will add cmake target dependencies into packaging.
     // Theses files are intermediated linking files to build reanimated and should not be in final package.
     excludes = [
-        "**/libc++_shared.so",
-        "**/libreactnativejni.so",
-        "**/libglog.so",
-        "**/libjscexecutor.so",
-        "**/libfbjni.so",
-        "**/libfolly_json.so",
-        "**/libhermes.so",
+      "**/libc++_shared.so",
+      "**/libreactnativejni.so",
+      "**/libglog.so",
+      "**/libjscexecutor.so",
+      "**/libfbjni.so",
+      "**/libfolly_json.so",
+      "**/libhermes.so",
     ]
   }
 

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -16,7 +16,7 @@ apply from: new File(["node", "--print", "require.resolve('expo-modules-core/pac
 
 /* UNCOMMENT WHEN DISTRIBUTING
 useExpoModules([
-    installAutomatically: false,
+    autolink: false,
     exclude: [
         'expo-module-template',
         'expo-in-app-purchases',
@@ -53,8 +53,8 @@ project(":expo-random").projectDir = new File("../packages/expo-random/android")
 })
 
 useExpoModules([
-    installAutomatically: false,
-    exclude             : [
+    autolink: false,
+    exclude : [
         'expo-module-template',
         'expo-in-app-purchases'
     ]

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,9 +1,9 @@
 pluginManagement {
-    repositories {
-        gradlePluginPortal()
-        mavenLocal()
-        google()
-    }
+  repositories {
+    gradlePluginPortal()
+    mavenLocal()
+    google()
+  }
 }
 
 include ':app'
@@ -11,6 +11,24 @@ include ':app'
 include ':packages:react-native-codegen:android'
 project(':packages:react-native-codegen:android').projectDir = new File('../react-native-lab/react-native/packages/react-native-codegen/android')
 includeBuild('../react-native-lab/react-native/packages/react-native-codegen/android')
+
+apply from: new File(["node", "--print", "require.resolve('expo-modules-core/package.json')"].execute().text.trim(), "../scripts/autolinking.gradle")
+
+/* UNCOMMENT WHEN DISTRIBUTING
+useExpoModules([
+    installAutomatically: false,
+    exclude: [
+        'expo-module-template',
+        'expo-in-app-purchases',
+        'expo-payments-stripe'
+    ],
+    searchPaths: [
+      'enabled-modules'
+    ],
+    useAAR: true
+])
+END UNCOMMENT WHEN DISTRIBUTING */
+
 
 // WHEN_DISTRIBUTING_REMOVE_FROM_HERE
 include ':expoview'
@@ -33,20 +51,12 @@ project(":expo-random").projectDir = new File("../packages/expo-random/android")
   include ":expoview-$abiVariant"
   project(":expoview-$abiVariant").projectDir = new File(rootDir, "versioned-abis/expoview-$abiVariant")
 })
-// WHEN_DISTRIBUTING_REMOVE_TO_HERE
 
-// Import gradle helpers for unimodules.
-apply from: new File(["node", "--print", "require.resolve('react-native-unimodules/package.json')"].execute().text.trim(), "../gradle.groovy")
-
-// Include unimodules.
-includeUnimodulesProjects(
-// WHEN_DISTRIBUTING_REMOVE_FROM_HERE
-    [
-        modulesPaths: ['../../packages'],
-        target      : 'react-native',
-        exclude     : [
-            'expo-module-template',
-        ]
+useExpoModules([
+    installAutomatically: false,
+    exclude             : [
+        'expo-module-template',
+        'expo-in-app-purchases'
     ]
-// WHEN_DISTRIBUTING_REMOVE_TO_HERE
-)
+])
+// WHEN_DISTRIBUTING_REMOVE_TO_HER

--- a/packages/expo-firebase-analytics/android/build.gradle
+++ b/packages/expo-firebase-analytics/android/build.gradle
@@ -75,10 +75,16 @@ if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
 dependencies {
   unimodule 'unimodules-core'
   unimodule 'expo-firebase-core'
-  api platform("com.google.firebase:firebase-bom:24.1.0")
-  api 'com.google.firebase:firebase-core'
-  api 'com.google.firebase:firebase-common'
-  api 'com.google.firebase:firebase-analytics'
+
+  // We can't use BOM, cause it doesn't work with prebuilding and new autolinking.
+  // > Could not find com.google.firebase:firebase-core:.
+  // Required by:
+  // project :expo-modules-linker > host.exp.exponent:expo-firebase-analytics:X.X.X
+  // project :expo-modules-linker > host.exp.exponent:expo-firebase-core:X.X.X
+  // api platform("com.google.firebase:firebase-bom:24.1.0")
+  api 'com.google.firebase:firebase-core:17.2.1'
+  api 'com.google.firebase:firebase-common:19.0.0'
+  api 'com.google.firebase:firebase-analytics:17.2.1'
 
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${safeExtGet('kotlinVersion', '1.4.21')}"
 }

--- a/packages/expo-firebase-core/android/build.gradle
+++ b/packages/expo-firebase-core/android/build.gradle
@@ -75,9 +75,14 @@ if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
 dependencies {
   unimodule 'unimodules-core'
 
-  api platform("com.google.firebase:firebase-bom:24.1.0")
-  api 'com.google.firebase:firebase-core'
-  api 'com.google.firebase:firebase-common'
+  // We can't use BOM, cause it doesn't work with prebuilding and new autolinking.
+  // > Could not find com.google.firebase:firebase-core:.
+  // Required by:
+  // project :expo-modules-linker > host.exp.exponent:expo-firebase-analytics:X.X.X
+  // project :expo-modules-linker > host.exp.exponent:expo-firebase-core:X.X.X
+  // api platform("com.google.firebase:firebase-bom:24.1.0")
+  api 'com.google.firebase:firebase-core:17.2.1'
+  api 'com.google.firebase:firebase-common:19.0.0'
 
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${safeExtGet('kotlinVersion', '1.4.21')}"
 }

--- a/packages/expo-modules-core/android-linker/build.gradle
+++ b/packages/expo-modules-core/android-linker/build.gradle
@@ -5,6 +5,8 @@ apply plugin: 'maven'
 // Import autolinking script
 apply from: "../scripts/autolinking.gradle"
 
+ensureDependeciesWereEvaluated(project)
+
 group = 'host.exp.exponent'
 version = '0.1.1'
 

--- a/packages/expo-modules-core/scripts/autolinking.gradle
+++ b/packages/expo-modules-core/scripts/autolinking.gradle
@@ -210,7 +210,7 @@ if (rootProject instanceof ProjectDescriptor) {
       return
     }
     
-    if (options.installAutomatically == false) {
+    if (options.autolink == false) {
       return
     }
 

--- a/packages/expo-modules-core/scripts/autolinking.gradle
+++ b/packages/expo-modules-core/scripts/autolinking.gradle
@@ -52,6 +52,10 @@ class ExpoAutolinkingManager {
     return json
   }
 
+  boolean shouldUseAAR() {
+    return options?.useAAR == true
+  }
+
   ExpoModule[] getModules() {
     Object json = resolve()
     return json.modules.collect { new ExpoModule(it) }
@@ -103,7 +107,7 @@ class ExpoAutolinkingManager {
     ]
 
     if (options?.searchPaths) {
-      args.addAll(options.searchPaths)
+      args += options.searchPaths
     }
 
     if (options?.ignorePaths) {
@@ -155,15 +159,15 @@ if (rootProject instanceof ProjectDescriptor) {
     gradle.ext.expoAutolinkingManager = manager
   }
 } else {
-  def addDependencies = { Project project, Closure<Object> projectNameResolver ->
+  def addDependencies = { Project project, Closure<Project> projectNameResolver ->
     // Return early if `useExpoModules` was not called in `settings.gradle`
     if (!gradle.ext.has('expoAutolinkingManager')) {
       // TODO(@tsapeta): Temporarily muted this error — uncomment it once we start migrating from autolinking v1 to v2
       // logger.error('Autolinking is not set up in `settings.gradle`: expo modules won\'t be autolinked.')
       return
     }
-
-    def modules = gradle.ext.expoAutolinkingManager.getModules()
+    ExpoAutolinkingManager manager = gradle.ext.expoAutolinkingManager
+    def modules = manager.getModules()
 
     if (!modules.length) {
       return
@@ -172,15 +176,19 @@ if (rootProject instanceof ProjectDescriptor) {
     println 'Using expo modules'
 
     for (module in modules) {
-      Object dependency = projectNameResolver(module)
+      Project dependency = projectNameResolver(module)
 
       // Don't link itself 
       if (module.name == "expo-modules-core") {
         continue
       }
 
-      project.dependencies.add('api', dependency)
-
+      if (manager.shouldUseAAR()) {
+        project.dependencies.add('api', "${dependency.group}:${module.projectName}:${dependency.version}")
+      } else {
+        project.dependencies.add('api', dependency)
+      }
+      
       // Can remove this once we move all the interfaces into the core.
       if (dependency.name.endsWith('-interface')) {
         continue
@@ -197,23 +205,37 @@ if (rootProject instanceof ProjectDescriptor) {
   }
 
   ext.addLinkerPackage = { Project project -> 
-    Project appProject = findAppProject(project)  
-    Project linkerProject = rootProject.findProject(":${ExpoAutolinkingManager.modulesLinkerName}")
-    if (linkerProject == null) {
-      logger.warn("Can't find `expo-modules-linker` project. Please, make sure that `useExpoModules` was called in `settings.gradle`")
+    Map options = gradle.ext.has('expoAutolinkingManager') ? gradle.ext.expoAutolinkingManager.options : null
+    if (options == null) {
+      return
+    }
+    
+    if (options.installAutomatically == false) {
       return
     }
 
-    appProject.dependencies.add('implementation', linkerProject)
+    Project appProject = findAppProject(project)  
+    if (appProject == null) {
+      logger.warn("Can't add `expo-modules-linker` automatically. The app android project wasn't found.")
+      return
+    }
+
+    Project linkerProject = rootProject.findProject(":${ExpoAutolinkingManager.modulesLinkerName}")
+    if (linkerProject == null) {
+      logger.warn("Can't find `expo-modules-linker` project. Please, make sure that `useExpoModules` was called in `settings.gradle`.")
+      return
+    }
+
+    if (appProject.configurations.findByName("implementation")) {
+      appProject.dependencies.add('implementation', linkerProject)
+    } else { 
+      logger.warn("Can't add `expo-modules-linker` automatically. Couldn't find configuration.")
+    }
   }
 
   // Adding dependencies
   ext.addExpoModulesDependencies = { Project project ->
     addDependencies(project) { module -> rootProject.project(":${module.projectName}") }
-  }
-
-  ext.addExpoModulesMavenDependencies = { Project project ->
-    addDependencies(project) { module -> "${module.androidGroup}:${module.projectName}:${module.version}" }
   }
 
   // Generating the package list
@@ -228,5 +250,22 @@ if (rootProject instanceof ProjectDescriptor) {
       // logger.error('Autolinking is not set up in `settings.gradle`: generated package list with expo modules will be empty.')
     }
     ExpoAutolinkingManager.generatePackageList(project, options)
+  }
+
+  ext.ensureDependeciesWereEvaluated = { Project project -> 
+    if (!gradle.ext.has('expoAutolinkingManager')) {
+      return
+    }
+
+    def modules = gradle.ext.expoAutolinkingManager.getModules()
+    for (module in modules) {
+      def dependency = project.findProject(":${module.projectName}")
+      if (dependency == null) {
+        logger.warn("Coudn't find project ${module.projectName}. Please, make sure that `useExpoModules` was called in `settings.gradle`.")
+        continue
+      }
+
+      project.evaluationDependsOn(":${module.projectName}")
+    }
   }
 }

--- a/packages/expo-modules-core/scripts/autolinking.gradle
+++ b/packages/expo-modules-core/scripts/autolinking.gradle
@@ -265,6 +265,10 @@ if (rootProject instanceof ProjectDescriptor) {
         continue
       }
 
+      if (module.projectName == "expo-modules-core") {
+        continue
+      }
+      
       project.evaluationDependsOn(":${module.projectName}")
     }
   }

--- a/tools/package.json
+++ b/tools/package.json
@@ -27,7 +27,7 @@
     "@expo/json-file": "^8.2.6",
     "@expo/spawn-async": "^1.5.0",
     "@expo/xcodegen": "2.18.0-patch.1",
-    "@expo/xdl": "^59.1.2",
+    "@expo/xdl": "^59.1.3",
     "@octokit/rest": "^18.5.3",
     "@types/base-64": "^0.1.2",
     "@types/concat-stream": "^1.6.0",


### PR DESCRIPTION
# Why

Uses a new autolinking in Expo Go on Android.
Needs https://github.com/expo/xdl/pull/37 to be able to build standalone apps.

# How

- Sets up the new autolinking 
- Adds logic to link AAR instead of source code 
- Fixes problem with firebase-bom
- To get group, I enured that all dependencies will be evaluated before `expo-modules-linker`

# Test Plan

- Expo Go ✅
- et android-shell-app --url ... --sdkVersion 42.0.0 ✅