### PR TITLE
[ios][android] Deprecate react-native-unimodules autolinking

### DIFF
--- a/packages/@unimodules/react-native-adapter/scripts/ios/autolinking_manager.rb
+++ b/packages/@unimodules/react-native-adapter/scripts/ios/autolinking_manager.rb
@@ -118,7 +118,7 @@ module Expo
       ]
 
       if !search_paths.nil? && !search_paths.empty?
-        args.concat(searchPaths)
+        args.concat(search_paths)
       end
 
       if !ignore_paths.nil? && !ignore_paths.empty?

--- a/packages/react-native-unimodules/cocoapods.rb
+++ b/packages/react-native-unimodules/cocoapods.rb
@@ -1,9 +1,11 @@
-require 'json'
-require 'pathname'
-require 'open3'
-require 'optparse'
+require File.join(`node --print "require.resolve('@unimodules/react-native-adapter/package.json')"`, "../scripts/autolinking")
+require 'colored2'
 
 def use_unimodules!(custom_options = {})
+  puts '⚠️  Package '.yellow.bold << 'react-native-unimodules'.green.bold << ' is deprecated in favor of '.yellow.bold << 'expo-modules-core'.green.bold
+  puts '⚠️  Please follow this guide to migrate: '.yellow.bold << 'https://expo.fyi/expo-modules-core-migration'.blue.bold
+  puts
+
   root_package_json = JSON.parse(File.read(find_project_package_json_path))
   json_options = root_package_json.fetch('react-native-unimodules', {}).fetch('ios', {}).transform_keys(&:to_sym)
 
@@ -15,126 +17,10 @@ def use_unimodules!(custom_options = {})
     flags: {}
   }.deep_merge(json_options).deep_merge(custom_options)
 
-  modules_paths = options.fetch(:modules_paths)
-  modules_to_exclude = options.fetch(:exclude)
-  target = options.fetch(:target)
-  flags = options.fetch(:flags)
-  tests = options.fetch(:tests)
-
-  unimodules = {}
-  unimodules_duplicates = []
-
-  project_directory = Pod::Config.instance.project_root
-
-  modules_paths.each do |module_path|
-    canonical_module_path = Pathname.new(File.join(project_directory, module_path)).cleanpath
-    glob_pattern = File.join(canonical_module_path, '**/*/**', 'unimodule.json')
-
-    Dir.glob(glob_pattern) do |module_config_path|
-      unimodule_json = JSON.parse(File.read(module_config_path))
-      directory = File.dirname(module_config_path)
-      platforms = unimodule_json['platforms'] || ['ios']
-      targets = unimodule_json['targets'] || ['react-native']
-
-      if unimodule_supports_platform(platforms, 'ios') && unimodule_supports_target(targets, target)
-        package_json_path = File.join(directory, 'package.json')
-        package_json = JSON.parse(File.read(package_json_path))
-        package_name = unimodule_json['name'] || package_json['name']
-
-        unless modules_to_exclude.include?(package_name)
-          unimodule_config = { 'subdirectory' => 'ios' }.merge(unimodule_json.fetch('ios', {}))
-          unimodule_version = package_json['version']
-
-          unimodules_duplicates.push(package_name) if unimodules[package_name]
-
-          if !unimodules[package_name] || Gem::Version.new(unimodule_version) >= Gem::Version.new(unimodules[package_name][:version])
-            unimodules[package_name] = {
-              name: package_name,
-              directory: directory,
-              version: unimodule_version,
-              config: unimodule_config,
-              tests: tests.include?(package_name),
-              warned: false
-            }
-          end
-        end
-      end
-    end
-  end
-
-  if unimodules.values.length > 0
-    puts brown 'Installing unimodules:'
-
-    unimodules.values.sort! { |x, y| x[:name] <=> y[:name] }.each do |unimodule|
-      directory = unimodule[:directory]
-      config = unimodule[:config]
-
-      subdirectory = config['subdirectory']
-      pod_name = config.fetch('podName', find_pod_name(directory, subdirectory))
-      podspec_directory = Pathname.new("#{directory}/#{subdirectory}").relative_path_from(project_directory)
-
-      puts " #{green unimodule[:name]}#{cyan '@'}#{magenta unimodule[:version]} from #{blue podspec_directory}"
-
-      pod_options = flags.merge({ path: podspec_directory.to_s })
-      if unimodule[:tests]
-        pod_options = pod_options.merge({ testspecs: ['Tests'] })
-      end
-
-      pod pod_name.to_s, pod_options
-    end
-
-    if unimodules_duplicates.length > 0
-      puts
-      puts brown 'Found some duplicated unimodule packages. Installed the ones with the highest version number.'
-      puts brown 'Make sure following dependencies of your project are resolving to one specific version:'
-
-      puts ' ' + unimodules_duplicates
-                 .uniq
-                 .map { |package_name| green(package_name) }
-                 .join(', ')
-    end
-  else
-    puts
-    puts brown "No unimodules found. Are you sure you've installed JS dependencies before installing pods?"
-  end
-
-  puts
+  use_expo_modules!(options)
 end
 
 def find_project_package_json_path
   stdout, _stderr, _status = Open3.capture3('node -e "const findUp = require(\'find-up\'); console.log(findUp.sync(\'package.json\'));"')
   stdout.strip!
-end
-
-def find_pod_name(package_path, subdirectory)
-  podspec_path = Dir.glob(File.join(package_path, subdirectory, '*.podspec')).first
-  podspec_path && File.basename(podspec_path).chomp('.podspec')
-end
-
-def unimodule_supports_platform(platforms, platform)
-  platforms.class == Array && platforms.include?(platform)
-end
-
-def unimodule_supports_target(targets, target)
-  targets.class == Array && targets.include?(target)
-end
-
-def green(message)
-  "\e[32m#{message}\e[0m"
-end
-
-def brown(message)
-  "\e[33m#{message}\e[0m"
-end
-
-def blue(message)
-  "\e[34m#{message}\e[0m"
-end
-
-def magenta(message)
-  "\e[35m#{message}\e[0m"
-end
-
-def cyan(message)
-  "\e[36m#{message}\e[0m"
 end

--- a/packages/react-native-unimodules/cocoapods.rb
+++ b/packages/react-native-unimodules/cocoapods.rb
@@ -2,8 +2,8 @@ require File.join(`node --print "require.resolve('@unimodules/react-native-adapt
 require 'colored2'
 
 def use_unimodules!(custom_options = {})
-  puts '⚠️  Package '.yellow.bold << 'react-native-unimodules'.green.bold << ' is deprecated in favor of '.yellow.bold << 'expo-modules-core'.green.bold
-  puts '⚠️  Please follow this guide to migrate: '.yellow.bold << 'https://expo.fyi/expo-modules-core-migration'.blue.bold
+  puts '⚠️ ' << 'react-native-unimodules'.green.bold << ' is deprecated in favor of '.yellow.bold << 'expo-modules-core'.green.bold
+  puts '⚠️ Follow this guide to migrate: '.yellow.bold << 'https://expo.fyi/expo-modules-core-migration'.blue.bold
   puts
 
   root_package_json = JSON.parse(File.read(find_project_package_json_path))

--- a/packages/react-native-unimodules/gradle.groovy
+++ b/packages/react-native-unimodules/gradle.groovy
@@ -1,27 +1,6 @@
 import groovy.json.JsonSlurper
-import org.gradle.util.VersionNumber
 
-import java.nio.file.Paths
-import java.util.regex.Pattern
-
-class Unimodule {
-  String name
-  List platforms
-  List targets
-  List androidPackages
-  String directory
-  String version
-  String androidGroup
-  String androidSubdirectory
-
-  boolean supportsPlatform(String platform) {
-    return platforms instanceof List && platforms.contains(platform)
-  }
-
-  boolean supportsTarget(String target) {
-    return targets.size() == 0 || targets.contains(target)
-  }
-}
+apply from: new File(["node", "--print", "require.resolve('expo-modules-core/package.json')"].execute().text.trim(), "../scripts/autolinking.gradle")
 
 def getProjectPackageJson(File projectRoot) {
   String resolveScript = """
@@ -59,238 +38,30 @@ def spawnProcess(String[] cmd, File directory) {
   }
 }
 
-def readPackageFromJavaOrKotlinFile(String filePath) {
-  def file = new File(filePath)
-  def fileReader = new BufferedReader(new FileReader(file))
-  def fileContent = ""
-  while ((fileContent = fileReader.readLine()) != null) {
-    def match = fileContent =~ /^package ([0-9a-zA-Z._]*);?$/
-    if (match.size() == 1 && match[0].size() == 2) {
-      fileReader.close()
-      return match[0][1]
-    }
-  }
-  fileReader.close()
-
-  throw new GradleException("Java or Kotlin file $file does not include package declaration")
-}
-
-def readFromBuildGradle(String file) {
-  def gradleFile = new File(file)
-  if (!gradleFile.exists()) {
-    return [:]
-  }
-  def fileReader = new BufferedReader(new FileReader(gradleFile))
-  def result = [:]
-  for (def line = fileReader.readLine(); line != null; line = fileReader.readLine()) {
-    def versionMatch = line.trim() =~ /^version ?= ?'([\w.-]+)'$/
-    def groupMatch = line.trim() =~ /^group ?= ?'([\w.]+)'$/
-    if (versionMatch.size() == 1 && versionMatch[0].size() == 2) {
-      result.version = versionMatch[0][1]
-    }
-    if (groupMatch.size() == 1 && groupMatch[0].size() == 2) {
-      result.group = groupMatch[0][1]
-    }
-  }
-  fileReader.close()
-  return result
-}
-
-def findDefaultBasePackage(String packageDir) {
-  def pathsJava = new FileNameFinder().getFileNames(packageDir, "android/src/**/*Package.java")
-  def pathsKt = new FileNameFinder().getFileNames(packageDir, "android/src/**/*Package.kt")
-  def paths = pathsJava + pathsKt
-
-  if (paths.size != 1) {
-    return []
-  }
-
-  def packageName = readPackageFromJavaOrKotlinFile(paths[0])
-  def className = new File(paths[0]).getName().split(Pattern.quote("."))[0]
-  return ["$packageName.$className"]
-}
-
-def generateBasePackageList(List<Unimodule> unimodules) {
-  def findMainJavaApp = new FileNameFinder().getFileNames(rootProject.getProjectDir().getPath(), '**/MainApplication.java', '')
-  def findMainKtApp = new FileNameFinder().getFileNames(rootProject.getProjectDir().getPath(), '**/MainApplication.kt', '')
-  
-  if (findMainJavaApp.size() != 1 && findMainKtApp.size() != 1) {
-    throw new GradleException("You need to have MainApplication in your project")
-  }
-
-  def findMainApp = (findMainJavaApp.size() == 1) ? findMainJavaApp : findMainKtApp
-  def mainAppDirectory = new File(findMainApp[0]).parentFile
-  def packageName = readPackageFromJavaOrKotlinFile(findMainApp[0])
-
-  def fileBuilder = new StringBuilder()
-  fileBuilder.append("package ${packageName}.generated;\n\n")
-
-  fileBuilder.append("import java.util.Arrays;\n")
-  fileBuilder.append("import java.util.List;\n")
-  fileBuilder.append("import expo.modules.core.interfaces.Package;\n\n")
-
-  fileBuilder.append("public class BasePackageList {\n")
-  fileBuilder.append("  public List<Package> getPackageList() {\n")
-  fileBuilder.append("    return Arrays.<Package>asList(\n")
-  def isEmptyList = true
-  for (module in unimodules) {
-    for (pkg in module.androidPackages) {
-      fileBuilder.append("        new $pkg(),\n")
-      isEmptyList = false
-    }
-  }
-  if (!isEmptyList) {
-    fileBuilder.deleteCharAt(fileBuilder.length() - 2) // remove last comma in a list
-  }
-  fileBuilder.append("    );\n")
-  fileBuilder.append("  }\n")
-  fileBuilder.append("}\n")
-
-
-  new File(mainAppDirectory, "generated").mkdirs()
-  def javaFile = new File(mainAppDirectory, "generated/BasePackageList.java")
-  javaFile.createNewFile()
-  def javaFileWriter = new BufferedWriter(new FileWriter(javaFile))
-  javaFileWriter.write(fileBuilder.toString())
-  javaFileWriter.close()
-}
-
-
-def findUnimodules(String target, List exclude, List modulesPaths) {
-  def unimodules = [:]
-  def unimodulesDuplicates = []
-
-  for (modulesPath in modulesPaths) {
-    def baseDir = new File(rootProject.getBuildFile(), modulesPath).toString()
-    def moduleConfigPaths = new FileNameFinder().getFileNames(baseDir, '**/unimodule.json', '')
-
-    for (moduleConfigPath in moduleConfigPaths) {
-      def unimoduleConfig = Paths.get(moduleConfigPath).toRealPath().toFile()
-      def unimoduleJson = new JsonSlurper().parseText(unimoduleConfig.text)
-      def directory = unimoduleConfig.getParent()
-      def buildGradle = readFromBuildGradle(new File(directory, "android/build.gradle").toString())
-      def packageJsonFile = new File(directory, 'package.json')
-      def packageJson = new JsonSlurper().parseText(packageJsonFile.text)
-
-      def unimodule = new Unimodule()
-      unimodule.name = unimoduleJson.name ?: packageJson.name
-      unimodule.directory = directory
-      unimodule.version = buildGradle.version ?: packageJson.version ?: "UNVERSIONED"
-      unimodule.androidGroup = buildGradle.group ?: "org.unimodules"
-      unimodule.androidSubdirectory = unimoduleJson.android?.subdirectory ?: "android"
-      unimodule.platforms = unimoduleJson.platforms != null ? unimoduleJson.platforms : []
-      assert unimodule.platforms instanceof List
-      unimodule.targets = unimoduleJson.targets != null ? unimoduleJson.targets : []
-      assert unimodule.targets instanceof List
-      unimodule.androidPackages = unimoduleJson.android?.packages != null ?
-          unimoduleJson.android.packages : findDefaultBasePackage(directory)
-      assert unimodule.androidPackages instanceof List
-
-      if (unimodule.supportsPlatform('android') && unimodule.supportsTarget(target)) {
-        if (!exclude.contains(unimodule.name)) {
-          if (unimodules[unimodule.name]) {
-            unimodulesDuplicates.add(unimodule.name)
-          }
-
-          if (!unimodules[unimodule.name] ||
-              VersionNumber.parse(unimodule.version) >= VersionNumber.parse(unimodules[unimodule.name].version)) {
-            unimodules[unimodule.name] = unimodule
-          }
-        }
-      }
-    }
-  }
-  return [
-      unimodules: unimodules.collect { entry -> entry.value },
-      duplicates: unimodulesDuplicates.unique()
-  ]
-}
-
-
 class Colors {
   static final String NORMAL = "\u001B[0m"
-  static final String RED = "\u001B[31m"
   static final String GREEN = "\u001B[32m"
   static final String YELLOW = "\u001B[33m"
-  static final String MAGENTA = "\u001B[35m"
-}
-
-def addUnimodulesDependencies(String target, List exclude, List modulesPaths, Closure<Boolean> addUnimodule) {
-  if (!(new File(project.rootProject.projectDir.parentFile, 'package.json').exists())) {
-    // There's no package.json
-    throw new GradleException(
-        "'addUnimodulesDependencies()' is being used in a project that doesn't seem to be a React Native project."
-    )
-  }
-
-  def results = findUnimodules(target, exclude, modulesPaths)
-  def unimodules = results.unimodules
-  def duplicates = results.duplicates
-  generateBasePackageList(unimodules)
-
-  if (unimodules.size() > 0) {
-    println()
-    println Colors.YELLOW + 'Installing unimodules:' + Colors.NORMAL
-    for (unimodule in unimodules) {
-      println ' ' + Colors.GREEN + unimodule.name + Colors.YELLOW + '@' + Colors.RED + unimodule.version + Colors.NORMAL + ' from ' + Colors.MAGENTA + unimodule.directory + Colors.NORMAL
-      addUnimodule(unimodule)
-    }
-
-    if (duplicates.size() > 0) {
-      println()
-      println Colors.YELLOW + 'Found some duplicated unimodule packages. Installed the ones with the highest version number.' + Colors.NORMAL
-      println Colors.YELLOW + 'Make sure following dependencies of your project are resolving to one specific version:' + Colors.NORMAL
-
-      println ' ' + duplicates
-          .collect { unimoduleName -> Colors.GREEN + unimoduleName + Colors.NORMAL }
-          .join(', ')
-    }
-  } else {
-    println()
-    println Colors.YELLOW + "No unimodules found. Are you sure you've installed JS dependencies?" + Colors.NORMAL
-  }
+  static final String BLUE = "\u001B[34m"
 }
 
 ext.addUnimodulesDependencies = { Map customOptions = [:] ->
-  def options = [
-      modulesPaths : ['../../node_modules'],
-      configuration: 'implementation',
-      target       : 'react-native',
-      exclude      : [],
-  ] << getAndroidConfig(rootProject.projectDir) << customOptions
-  addUnimodulesDependencies(options.target, options.exclude, options.modulesPaths, {unimodule ->
-    Object dependency = project.project(':' + unimodule.name)
-    project.dependencies.add(options.configuration, dependency)
-  })
+  // no-op, autolinking v2 adds dependencies automatically
 }
 
 ext.addMavenUnimodulesDependencies = { Map customOptions = [:] ->
-  def options = [
-      modulesPaths : ['../../node_modules'],
-      configuration: 'implementation',
-      target       : 'react-native',
-      exclude      : [],
-  ] << getAndroidConfig(rootProject.projectDir) << customOptions
-
-  addUnimodulesDependencies(options.target, options.exclude, options.modulesPaths, {unimodule ->
-    project.dependencies.add(
-        options.configuration,
-        "${unimodule.androidGroup}:${unimodule.name}:${unimodule.version}"
-    )
-  })
+  // no-op, autolinking v2 adds dependencies automatically
 }
 
 ext.includeUnimodulesProjects = { Map customOptions = [:] ->
+  println Colors.YELLOW + '⚠️  Package ' + Colors.GREEN + 'react-native-unimodules' + Colors.YELLOW + ' is deprecated in favor of ' + Colors.GREEN + 'expo-modules-core' + Colors.NORMAL
+  println Colors.YELLOW + '⚠️  Please follow this guide to migrate: ' + Colors.BLUE + 'https://expo.fyi/expo-modules-core-migration' + Colors.NORMAL
+  println()
+
   def options = [
       modulesPaths: ['../../node_modules'],
-      target      : 'react-native',
       exclude     : [],
   ] << getAndroidConfig(rootProject.projectDir) << customOptions
 
-  def unimodules = findUnimodules(options.target, options.exclude, options.modulesPaths).unimodules
-
-  for (unimodule in unimodules) {
-    include ":${unimodule.name}"
-    project(":${unimodule.name}").projectDir = new File(unimodule.directory, unimodule.androidSubdirectory)
-  }
+  ext.useExpoModules(options)
 }

--- a/packages/react-native-unimodules/gradle.groovy
+++ b/packages/react-native-unimodules/gradle.groovy
@@ -54,8 +54,8 @@ ext.addMavenUnimodulesDependencies = { Map customOptions = [:] ->
 }
 
 ext.includeUnimodulesProjects = { Map customOptions = [:] ->
-  println Colors.YELLOW + '⚠️  Package ' + Colors.GREEN + 'react-native-unimodules' + Colors.YELLOW + ' is deprecated in favor of ' + Colors.GREEN + 'expo-modules-core' + Colors.NORMAL
-  println Colors.YELLOW + '⚠️  Please follow this guide to migrate: ' + Colors.BLUE + 'https://expo.fyi/expo-modules-core-migration' + Colors.NORMAL
+  println '⚠️ ' + Colors.GREEN + 'react-native-unimodules' + Colors.YELLOW + ' is deprecated in favor of ' + Colors.GREEN + 'expo-modules-core' + Colors.NORMAL
+  println Colors.YELLOW + '⚠️ Follow this guide to migrate: ' + Colors.BLUE + 'https://expo.fyi/expo-modules-core-migration' + Colors.NORMAL
   println()
 
   def options = [


### PR DESCRIPTION
# Why

`react-native-unimodules` will be deprecated in the next release, in favor of `expo-modules-core`. We want to make the migration smooth, so the old autolinking has to call the new one so everything will work as expected even without migrating.

# How

- Ensured `react-native-unimodules` has `expo-modules-core` in the dependencies.
- Made Ruby and Gradle methods fall back to autolinking v2
- Added deprecation warning
```
⚠️  Package react-native-unimodules is deprecated in favor of expo-modules-core
⚠️  Please follow this guide to migrate: https://expo.fyi/expo-modules-core-migration
```

# To do

Write up this `expo-modules-core-migration` FYI guide.

# Test Plan

I locally switched autolinking in bare-expo to the old version and it seemed to work as expected. CI jobs are passing.