### PR TITLE
[unimodules] Fix `cannot find "unimodules-test-core"`

### DIFF
--- a/packages/@unimodules/core/unimodules-core.gradle
+++ b/packages/@unimodules/core/unimodules-core.gradle
@@ -1,8 +1,8 @@
 class UnimodulesPlugin implements Plugin<Project> {
     void apply(Project project) {
-        project.configurations.configureEach {
-            if (it.getName().startsWith('test') && project.file('./src/test').exists()) {
-                if (project.findProject(':unimodules-test-core')) {
+        if (project.findProject(':unimodules-test-core')) {
+            project.configurations.configureEach {
+                if (it.getName().startsWith('test') && project.file('./src/test').exists()) {       
                     project.dependencies.add(it.getName(), project.project(':unimodules-test-core'))
                 }
             }

--- a/packages/@unimodules/core/unimodules-core.gradle
+++ b/packages/@unimodules/core/unimodules-core.gradle
@@ -2,7 +2,9 @@ class UnimodulesPlugin implements Plugin<Project> {
     void apply(Project project) {
         project.configurations.configureEach {
             if (it.getName().startsWith('test') && project.file('./src/test').exists()) {
-                project.dependencies.add(it.getName(), project.project(':unimodules-test-core'))
+                if (project.findProject(':unimodules-test-core')) {
+                    project.dependencies.add(it.getName(), project.project(':unimodules-test-core'))
+                }
             }
         }
 


### PR DESCRIPTION
# Why

Fixes `cannot find "unimodules-test-core" project`.

# How

Checked if `unimodules-test-core` exists before adding it to as dependence.

We use tests internally, so we don't want to fail someone's build if they don't have `unimodules-test-core` installed.

# Test Plan

- bare-expo ✅
