### PR TITLE
[expo-go] Fix reading `userInterfaceStyle` on Android if it's in root options

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -16,6 +16,9 @@
 
 - Fix `PROJECT_ROOT` path resolution in `create-manifest-ios.sh` and in `createManifest.js` ([#13439](https://github.com/expo/expo/pull/13439) by [@ajsmth](https://github.com/ajsmth))
 - Fix erroneous manifest JSON direct access. ([#13906](https://github.com/expo/expo/pull/13906) by [@wschurman](https://github.com/wschurman))
+- Fix config plugin to properly set the updates URL based on `getAccountUsername` from `@expo/config`. ([#13909](https://github.com/expo/expo/pull/13909) by [@brentvatne](https://github.com/brentvatne))
+- Fixed issue with dev-launcher integration where configuration was not set at the correct time, which caused issues when trying to open multiple different published apps. ([#13926](https://github.com/expo/expo/pull/13926) by [@esamelson](https://github.com/esamelson))
+- Fixed `userInterfaceStyle` not being applied when only set in root `expo` options and not in `expo.android` options. ([#13959](https://github.com/expo/expo/pull/13959) by [@mrousavy](https://github.com/mrousavy))
 
 ### 💡 Others
 

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -16,8 +16,6 @@
 
 - Fix `PROJECT_ROOT` path resolution in `create-manifest-ios.sh` and in `createManifest.js` ([#13439](https://github.com/expo/expo/pull/13439) by [@ajsmth](https://github.com/ajsmth))
 - Fix erroneous manifest JSON direct access. ([#13906](https://github.com/expo/expo/pull/13906) by [@wschurman](https://github.com/wschurman))
-- Fix config plugin to properly set the updates URL based on `getAccountUsername` from `@expo/config`. ([#13909](https://github.com/expo/expo/pull/13909) by [@brentvatne](https://github.com/brentvatne))
-- Fixed issue with dev-launcher integration where configuration was not set at the correct time, which caused issues when trying to open multiple different published apps. ([#13926](https://github.com/expo/expo/pull/13926) by [@esamelson](https://github.com/esamelson))
 - Fixed `userInterfaceStyle` not being applied when only set in root `expo` options and not in `expo.android` options. ([#13959](https://github.com/expo/expo/pull/13959) by [@mrousavy](https://github.com/mrousavy))
 
 ### 💡 Others

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/raw/RawManifest.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/raw/RawManifest.kt
@@ -148,8 +148,11 @@ abstract class RawManifest(protected val json: JSONObject) {
 
   fun getAndroidUserInterfaceStyle(): String? {
     val expoClientConfig = getExpoClientConfigRootObject() ?: return null
-    val android = expoClientConfig.optJSONObject("android") ?: return null
-    return android.optString("userInterfaceStyle") ?: expoClientConfig.optString("userInterfaceStyle")
+    return try {
+      expoClientConfig.getJSONObject("android").getString("userInterfaceStyle")
+    } catch (e: JSONException) {
+      expoClientConfig.optString("userInterfaceStyle")
+    }
   }
 
   fun getAndroidStatusBarOptions(): JSONObject? {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/raw/RawManifest.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/raw/RawManifest.kt
@@ -149,7 +149,7 @@ abstract class RawManifest(protected val json: JSONObject) {
   fun getAndroidUserInterfaceStyle(): String? {
     val expoClientConfig = getExpoClientConfigRootObject() ?: return null
     val android = expoClientConfig.optJSONObject("android") ?: return null
-    return android.optString("userInterfaceStyle")
+    return android.optString("userInterfaceStyle") ?: expoClientConfig.optString("userInterfaceStyle")
   }
 
   fun getAndroidStatusBarOptions(): JSONObject? {


### PR DESCRIPTION

# Why

```
{
  "expo": {
    "userInterfaceStyle": "dark",
    "android": {
      "userInterfaceStyle": "dark"
    }
  }
}
```

this chose `dark`

```
{
  "expo": {
    "userInterfaceStyle": "dark"
  }
}
```

this did not choose `dark`.

This PR attempts to fix this so that the root options (`expo`) are used as fallback.

# How


* Fixes #13488 

# Test Plan

1. Run expo-go with `android.userInterfaceStyle` set to `dark`
2. Remove `android.userInterfaceStyle` and only set root `userInterfaceStyle`
3. Do a full-reload
4. See that it's still dark.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).