### PR TITLE
[actions] Run dogfooding home kernel publish before building client

### DIFF
--- a/.github/workflows/dogfooding-clients.yml
+++ b/.github/workflows/dogfooding-clients.yml
@@ -15,27 +15,22 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: true
-      - name: ♻️ Restore workspace node modules
-        uses: actions/cache@v2
-        id: node-modules-cache
+      - uses: actions/setup-node@v2
         with:
-          path: |
-            # See "workspaces" → "packages" in the root package.json for the source of truth of
-            # which node_modules are affected by the root yarn.lock
-            node_modules
-            apps/*/node_modules
-            home/node_modules
-            packages/*/node_modules
-            packages/@unimodules/*/node_modules
-            react-native-lab/react-native/node_modules
-          key: ${{ runner.os }}-modules-${{ hashFiles('yarn.lock') }}
-      - name: ♻️ Restore node modules in tools
-        uses: actions/cache@v2
+          node-version: '14.17'
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v2
         with:
-          path: tools/node_modules
-          key: ${{ runner.os }}-tools-modules-${{ hashFiles('tools/yarn.lock') }}
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
       - name: 🧶 Yarn install
         run: yarn install --frozen-lockfile
+      - name: 🤠 Install expo-cli
+        run: yarn global add expo-cli
       - name: 💎 Setup Ruby and install gems
         uses: ruby/setup-ruby@v1
         with:
@@ -70,6 +65,10 @@ jobs:
         if: steps.cache-android-ndk.outputs.cache-hit != 'true'
         run: |
           sudo $ANDROID_SDK_ROOT/tools/bin/sdkmanager --install "ndk;19.2.5345600"
+      - name: 🦴 Publish dogfood home and generate bundled manifest
+        run: bin/expotools publish-dogfood-home
+        env:
+          EXPO_DOGFOOD_HOME_ACCESS_TOKEN: ${{ secrets.EXPO_DOGFOOD_HOME_ACCESS_TOKEN }}
       - name: 🏭 Build APK
         env:
           ANDROID_KEYSTORE_B64: ${{ secrets.ANDROID_KEYSTORE_B64 }}
@@ -112,87 +111,3 @@ jobs:
           status: ${{ job.status }}
           fields: job,message,ref,eventName,author,took
           author_name: Expo Go Dogfooding (Android)
-  build-ios:
-    runs-on: macos-11
-    steps:
-      - name: 👀 Checkout a ref for the event
-        uses: actions/checkout@v2
-        with:
-          submodules: true
-      - name: 🔨 Switch to Xcode 12.5.1
-        run: sudo xcode-select --switch /Applications/Xcode_12.5.1.app
-      - name: 🍺 Setup Homebrew
-        run: brew install git-crypt
-      - name: 🔓 decrypt secrets if possible
-        env:
-          GIT_CRYPT_KEY_BASE64: ${{ secrets.GIT_CRYPT_KEY_BASE64 }}
-        run: |
-          if [[ ${GIT_CRYPT_KEY_BASE64:-unset} = unset ]]; then
-            echo 'git-crypt key not present in environment'
-          else
-            git crypt unlock <(echo $GIT_CRYPT_KEY_BASE64 | base64 --decode)
-          fi
-      - run: echo "$(pwd)/bin" >> $GITHUB_PATH
-      - name: ♻️ Restore workspace node modules
-        uses: actions/cache@v2
-        id: node-modules-cache
-        with:
-          path: |
-            # See "workspaces" → "packages" in the root package.json for the source of truth of
-            # which node_modules are affected by the root yarn.lock
-            node_modules
-            apps/*/node_modules
-            home/node_modules
-            packages/*/node_modules
-            packages/@unimodules/*/node_modules
-            react-native-lab/react-native/node_modules
-          key: ${{ runner.os }}-modules-${{ hashFiles('yarn.lock') }}
-      - name: 🧶 Yarn install
-        run: yarn install --frozen-lockfile
-      - name: ♻️ Restore node modules in tools
-        uses: actions/cache@v2
-        with:
-          path: tools/node_modules
-          key: ${{ runner.os }}-tools-modules-${{ hashFiles('tools/yarn.lock') }}
-      - name: 🏭 Generating dynamic macros
-        run: expotools ios-generate-dynamic-macros
-      - name: 💎 Setup Ruby and install gems
-        uses: ruby/setup-ruby@v1
-        with:
-          bundler-cache: true
-      - name: ♻️ Restore ios/Pods from cache
-        uses: actions/cache@v2
-        with:
-          path: 'ios/Pods'
-          key: ${{ runner.os }}-pods-${{ hashFiles('ios/Podfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-pods-
-      - name: 🥥 Install CocoaPods in `ios`
-        run: pod install
-        working-directory: ios
-      - name: 🏗 Build Expo Go for simulator
-        run: |
-          FLAVOR="versioned"
-          expotools client-build --platform ios --flavor $FLAVOR
-        timeout-minutes: 120
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          USE_DOGFOODING_PUBLISHED_KERNEL_MANIFEST: true
-      - name: 💾 Save test results
-        if: always()
-        uses: actions/upload-artifact@v2
-        with:
-          name: fastlane-logs
-          path: ~/Library/Logs/fastlane
-      - name: 🔔 Notify on Slack
-        uses: 8398a7/action-slack@v3
-        if: failure() && (github.event.ref == 'refs/heads/master' || startsWith(github.event.ref, 'refs/heads/sdk-'))
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_ios }}
-        with:
-          channel: '#platform-ios'
-          status: ${{ job.status }}
-          fields: job,message,ref,eventName,author,took
-          author_name: Expo Go Dogfooding (iOS)

--- a/ios/Client/EXHomeAppManager.m
+++ b/ios/Client/EXHomeAppManager.m
@@ -64,7 +64,7 @@ NSString *kEXHomeManifestResourceName = @"kernel-manifest";
 
 - (void)addHistoryItemWithUrl:(NSURL *)manifestUrl manifest:(EXUpdatesRawManifest *)manifest
 {
-  if (!manifest || !manifestUrl || [manifest.legacyId isEqualToString:@"@exponent/home"]) {
+  if (!manifest || !manifestUrl || [manifest.legacyId isEqualToString:@"@exponent/home"] || [manifest.legacyId isEqualToString:@"@expo-dogfooding/home"]) {
     return;
   }
   NSDictionary *params = @{
@@ -188,8 +188,8 @@ NSString *kEXHomeManifestResourceName = @"kernel-manifest";
   if (manifestJson) {
     id manifest = RCTJSONParse(manifestJson, nil);
     if ([manifest isKindOfClass:[NSDictionary class]]) {
-      if (usesNSBundleManifest && ![manifest[@"id"] isEqualToString:@"@exponent/home"]) {
-        DDLogError(@"Bundled kernel manifest was published with an id other than @exponent/home");
+      if (usesNSBundleManifest && !([manifest[@"id"] isEqualToString:@"@exponent/home"] || [manifest[@"id"] isEqualToString:@"@expo-dogfooding/home"])) {
+        DDLogError(@"Bundled kernel manifest was published with an id other than @exponent/home or @expo-dogfooding/home");
       }
       return [EXUpdatesUpdate rawManifestForJSON:manifest];
     }

--- a/tools/src/commands/PublishDogfoodExpoHomeCommand.ts
+++ b/tools/src/commands/PublishDogfoodExpoHomeCommand.ts
@@ -7,7 +7,7 @@ import process from 'process';
 import { deepCloneObject } from '../Utils';
 import { Directories, XDL } from '../expotools';
 import AppConfig from '../typings/AppConfig';
-import { deleteKernelFields, maybeUpdateHomeSdkVersionAsync } from './PublishDevExpoHomeCommand';
+import { maybeUpdateHomeSdkVersionAsync } from './PublishDevExpoHomeCommand';
 
 const EXPO_HOME_PATH = Directories.getExpoHomeJSDir();
 const { EXPO_DOGFOOD_HOME_ACCESS_TOKEN } = process.env;
@@ -30,7 +30,6 @@ async function action(): Promise<void> {
   console.log(`Modifying home app.json...`);
   await maybeUpdateHomeSdkVersionAsync(appJson);
   appJson.expo.owner = 'expo-dogfooding';
-  deleteKernelFields(appJson);
 
   try {
     await appJsonFile.writeAsync(appJson);


### PR DESCRIPTION
# Why

There's currently an issue with the built dogfooding client (android) since it has the `@exponent/home` manifest as its bundled kernel. https://github.com/expo/expo-cli/pull/3753 allows us to publish the kernel as a robot and with the kernel fields so that this PR can call into the cli to do so.

# How

Change the script to first publish the kernel under the dogfooding package name (which changes bundled kernel locally `kernel-manifest.json`), and then build the dogfooding client APK.

This also removes the iOS stuff for now since it is much more complex and is just causing unnecessary confusion.

# Test Plan

Wait for CI.