### PR TITLE
[IAP][ios] no more extra request on purchaseItemAsync

### DIFF
--- a/packages/expo-in-app-purchases/CHANGELOG.md
+++ b/packages/expo-in-app-purchases/CHANGELOG.md
@@ -16,7 +16,7 @@
 ### 💡 Others
 
 - Updated Google Play Billing from v2 to v4. ([#13884](https://github.com/expo/expo/pull/13884) by [@cruzach](https://github.com/cruzach))
-- Cache products on iOS when calling `getProductsAsync`, so that `purchaseItemAsync` no longer needs to make a second request to StoreKit. This matches the Android implementation.
+- Cache products on iOS when calling `getProductsAsync`, so that `purchaseItemAsync` no longer needs to make a second request to StoreKit. This matches the Android implementation. ([#13961](https://github.com/expo/expo/pull/13961) by [@cruzach](https://github.com/cruzach))
 
 ## 10.2.0 — 2021-06-16
 

--- a/packages/expo-in-app-purchases/CHANGELOG.md
+++ b/packages/expo-in-app-purchases/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### 💡 Others
 
 - Updated Google Play Billing from v2 to v4. ([#13884](https://github.com/expo/expo/pull/13884) by [@cruzach](https://github.com/cruzach))
+- Cache products on iOS when calling `getProductsAsync`, so that `purchaseItemAsync` no longer needs to make a second request to StoreKit. This matches the Android implementation.
 
 ## 10.2.0 — 2021-06-16
 

--- a/packages/expo-in-app-purchases/ios/EXInAppPurchases/EXInAppPurchasesModule.m
+++ b/packages/expo-in-app-purchases/ios/EXInAppPurchases/EXInAppPurchasesModule.m
@@ -8,7 +8,7 @@
 @property (nonatomic, weak) id <UMEventEmitterService> eventEmitter;
 @property (strong, nonatomic) NSMutableDictionary *promises;
 @property (strong, nonatomic) NSMutableDictionary *pendingTransactions;
-@property (strong, nonatomic) NSMutableSet *cachedProducts;
+@property (strong, nonatomic) NSMutableSet<SKProduct *> *cachedProducts;
 @property (strong, nonatomic) SKProductsRequest *request;
 
 @end


### PR DESCRIPTION
# Why

closes https://github.com/expo/expo/issues/10654

# How

- Instead of only caching product IDs, cache the entire `SKProduct`
- If object in cache- send straight to `purchase` method
- Otherwise, reject promise (same behavior as before, no breaking change)

Some nice side effects:
- `handlePurchase` and `handleQuery` methods are no longer necessary
- no longer need to keep track of whether we are querying products or not
- fewer divergent code paths
- faster purchase flow

One change to note is that we no longer inform the user that a product is not available if they attempt to purchase one that doesn't exist ([this deleted code](https://github.com/expo/expo/compare/@cruzach/iap-fixes/10654?expand=1#diff-65514672f55b6d866d36a8831be6887d2d8ef96ad56a258a8ed39796e54f36ddL163-L166)). But users should be first querying products with `getProductsAsync`, and using those resulting IDs for purchase. If a product identifier wasn't valid, it isn't returned from that method (and isn't cached in `cachedProducts `, so `purchaseItemAsync` would reject). This matches the Android implementation, and also fails _earlier_ than it would have before (previously, users could attempt to purchase "bad" IDs because we added all requested IDs to `retrievedItems`, _now_ we only add valid IDs to our cache, so we're keeping users from making that mistake).

# Test Plan

Tested on NCL, purchasing products work like it did before

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).