### PR TITLE
[babel-preset-expo] Overwrite the object rest spread plugin without l…

### DIFF
--- a/packages/babel-preset-expo/index.js
+++ b/packages/babel-preset-expo/index.js
@@ -96,6 +96,7 @@ module.exports = function(api, options = {}) {
       ],
     ],
     plugins: [
+      getObjectRestSpreadPlugin(),
       ...extraPlugins,
       getAliasPlugin(),
       [require.resolve('@babel/plugin-proposal-decorators'), { legacy: true }],
@@ -121,6 +122,15 @@ function getAliasPlugin() {
     ];
   }
   return null;
+}
+
+/**
+ * This uses the `{ loose: true }` option in Metro, it breaks all getters and setters.
+ * We need to add this plugin ourself without that option.
+ * @see https://github.com/expo/expo/pull/11960#issuecomment-887796455
+ */
+function getObjectRestSpreadPlugin() {
+  return [require.resolve('@babel/plugin-proposal-object-rest-spread'), { loose: false }];
 }
 
 function hasModule(name) {

--- a/packages/babel-preset-expo/index.js
+++ b/packages/babel-preset-expo/index.js
@@ -125,8 +125,8 @@ function getAliasPlugin() {
 }
 
 /**
- * This uses the `{ loose: true }` option in Metro, it breaks all getters and setters.
- * We need to add this plugin ourself without that option.
+ * metro-react-native-babel-preset configures this plugin with `{ loose: true }`, which breaks all
+ * getters and setters in spread objects. We need to add this plugin ourself without that option.
  * @see https://github.com/expo/expo/pull/11960#issuecomment-887796455
  */
 function getObjectRestSpreadPlugin() {


### PR DESCRIPTION
# Why

This overwrites the `{ loose: true }` object rest spread plugin from metro. 

> ~~This PR is chained into https://github.com/expo/expo/pull/13983, to fully "cleanse" all jest issues. Can detach it if necessary~~ That PR is merged, and this one is rebased on master

# How

Because Metro only supplied `[<plugin>, <options>]`, and not a 3rd `<name>` option, this should be [overwritten when merged](https://babeljs.io/docs/en/configuration#pluginpreset-merging).

# Test Plan

- Run tests, all but `expo-linking` should pass

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).