### PR TITLE
[android] Use increment.build for android versionCode auto-incrementing

### DIFF
--- a/.github/workflows/dogfooding-clients.yml
+++ b/.github/workflows/dogfooding-clients.yml
@@ -87,7 +87,7 @@ jobs:
           else
             echo "Internal build detected, APK will be signed"
             echo $ANDROID_KEYSTORE_B64 | base64 -d > android/app/release-key.jks
-            bin/fastlane android build build_type:$BUILD_TYPE flavor:$FLAVOR
+            bin/fastlane android build build_type:$BUILD_TYPE flavor:$FLAVOR get_version_number_from_increment:true
           fi
       - name: 💾 Upload APK artifact
         uses: actions/upload-artifact@v2

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -29,9 +29,10 @@ android {
     applicationId 'host.exp.exponent'
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 30)
+
     // ADD VERSIONS HERE
     // BEGIN VERSIONS
-    versionCode 148
+    versionCode project.hasProperty('versionCode') ? project.property('versionCode') as int : 148
     versionName '2.19.2'
     // END VERSIONS
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -325,20 +325,30 @@ platform :android do
     devicefarm_follow_run("arn:aws:devicefarm:us-west-2:274251141632:run:#{result_info[:project_id]}/#{result_info[:run_id]}")
   end
 
-  lane :build do |build_type: "Debug", flavor: "versioned", sign: true|
+  lane :build do |build_type: "Debug", flavor: "versioned", sign: true, get_version_number_from_increment: false|
     ENV['ANDROID_UNSIGNED'] = '1' unless sign
+
+    properties_dict = if get_version_number_from_increment
+      {
+        "versionCode" => Net::HTTP.get(URI('https://increment.build/kx54nve3mh5hygef')).to_i
+      }
+    else
+      {}
+    end
+
     gradle(
       project_dir: "android",
       task: "app:assemble",
       flavor: flavor,
       build_type: build_type,
+      properties: properties_dict,
     )
   end
 
   lane :prod_release do
     build_gradle = File.read("../android/app/build.gradle")
 
-    verify_changelog_exists(version_code: build_gradle.match(/versionCode (\d+)/)[1])
+    verify_changelog_exists(version_code: build_gradle.match(/versionCode.+\s(\d+)$/)[1])
     verify_upload_to_staging(version_name: build_gradle.match(/versionName '([\d\.]+)'/)[1])
 
     supply(

--- a/guides/releasing/Release Workflow.md
+++ b/guides/releasing/Release Workflow.md
@@ -396,7 +396,7 @@ Web is comparatively well-tested in CI, so a few manual smoke tests suffice for 
 
 - **Android**:
   - Unlike for iOS, we will not submit the Android app to the store at this point. We just need to bump the version so we can do an APK build for distribution through Expo CLI.
-  - Bump the `versionCode` and `versionName` in android/app/build.gradle. Commit this to master and cherry-pick to the release branch. You might need to check the previous release branch to make sure the new `versionCode` is greater than the previous patch version, in case that commit never made it to master.
+  - Bump the `versionName` in android/app/build.gradle. Commit this to master and cherry-pick to the release branch.
   - The APK will be available as an artifact from the "Android Client" CI job. If no CI jobs are running on the release branch, you just need to open a PR from the release branch to master. (Don't merge it; it only exists to make CI jobs run.)
   - Download the APK and do a quick smoke test: install it in your local emulator or on a device and open a project.
 
@@ -576,6 +576,7 @@ Publish a blog post that includes the following information:
 - **iOS**:
   - Log into [App Store Connect](https://appstoreconnect.apple.com) and release the approved version.
 - **Android**:
+  - Update the fallback `versionCode` (end of ternary expression) in `app/build.gradle` to the output of navigating to https://increment.build/kx54nve3mh5hygef
   - Add a new file under `/fastlane/android/metadata/en-US/changelogs/[versionCode].txt` (it should usually read “Add support for Expo SDK XX”).
   - Open `Android Client` workflow on GitHub Actions and when it completes, download the APK from Artifacts and do a smoke test -- install it on a fresh Android device, turn on airplane mode, and make sure Home loads.
   - Run `et dispatch client-android-release` to trigger appropriate job on GitHub Actions. About 45 minutes later the update should be **downloadable** via Play Store.


### PR DESCRIPTION
# Why

During an android APK upload, the `versionCode` must be greater than that of all prior uploads. To accomplish this without needing to make commits in the repo all the time we need to get that value from outside the repo.

# How

This was more challenging that anticipated due to our existing workflow for production builds which requires the `versionCode` to be known in code ahead of build time so that a fastlane changelog can be added for it. So, we do the following:

Production:
- add a step that fetches the next versionCode that the person doing the release will hardcode in `build.gradle` (as the fallback)
- When the android-client workflow is run (with or without the release step), it will build the binary using the hardcoded versionCode and upload its release notes.

Dogfooding:
- Pass in an arg saying that the versionCode should be supplied from the auto-incremented value. That way the generated APK is guaranteed to have a version code that is higher than all builds prior to it.

# Some notes

- Some other solutions that were considered: 
  - a separate repo containing just the build number (so that we can commit it without triggering a CI run)
  - an auto-increment service in www (essentially build the increment.build functionality into www and require a secret token for auth)
- I considered putting the increment.build URL in a secret, but it made trying to share it for manual use during the release impossible. It doesn't need to be secret unless we're concerned about someone abusing it (setting it to max_int or something, which is totally an attack vector). 

# Test Plan

This is fairly hard to test in isolation/locally as all affected things are during prod deployments or in CI actions. That being said, I manually ran the changes to the fastfile to verify no syntax errors by putting them in their own actions. For example, the following test ensured that the version code was still parsed correctly:
```ruby
lane :wat do
  build_gradle = File.read("../android/app/build.gradle")
  puts build_gradle.match(/versionCode.+\s(\d+)$/)[1]
end
```