### PR TITLE
[android] Bump android versionCode for a dogfood build

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -31,7 +31,7 @@ android {
     targetSdkVersion safeExtGet("targetSdkVersion", 30)
     // ADD VERSIONS HERE
     // BEGIN VERSIONS
-    versionCode 148
+    versionCode 156
     versionName '2.19.2'
     // END VERSIONS
 


### PR DESCRIPTION
# Why

https://github.com/expo/expo/pull/13985 didn't work out. We'd still like to get a dogfooding build up, so instead of trying to set up the system for auto-incrementing builds now, just increment it manually.

# How

Last one uploaded looks like it was 155 (checked in play console), so bump to 156.

# Test Plan

N/A