### PR TITLE
[linking] Replace full manifest overwrite with mocks

### DIFF
--- a/packages/expo-linking/src/__tests__/Linking-test.ts
+++ b/packages/expo-linking/src/__tests__/Linking-test.ts
@@ -1,9 +1,17 @@
 import Constants, { ExecutionEnvironment } from 'expo-constants';
+import { mockProperty, unmockAllProperties } from 'jest-expo';
 
 import * as Linking from '../Linking';
 import { QueryParams } from '../Linking.types';
 
 describe('parse', () => {
+  beforeAll(() => {
+    mockProperty(Constants.manifest, 'hostUri', 'exp.host/@test/test');
+  });
+  afterAll(() => {
+    unmockAllProperties();
+  });
+
   test.each<string>([
     'exp://127.0.0.1:19000/',
     'exp://127.0.0.1:19000/--/test/path?query=param',
@@ -29,22 +37,20 @@ describe('parse', () => {
 
 describe(Linking.createURL, () => {
   const consoleWarn = console.warn;
-  const manifest = Constants.__rawManifest_TEST;
   const executionEnvironment = Constants.executionEnvironment;
+
   describe('queries', () => {
     beforeEach(() => {
       console.warn = jest.fn();
       Constants.executionEnvironment = ExecutionEnvironment.StoreClient;
-      Constants.__rawManifest_TEST = {
-        ...Constants.__rawManifest_TEST,
-        scheme: 'demo',
-      };
+      mockProperty(Constants.manifest, 'hostUri', 'exp.host/@test/test');
+      mockProperty(Constants.manifest, 'scheme', 'demo');
     });
 
     afterEach(() => {
       console.warn = consoleWarn;
       Constants.executionEnvironment = executionEnvironment;
-      Constants.__rawManifest_TEST = manifest;
+      unmockAllProperties();
     });
 
     test.each<QueryParams>([
@@ -61,21 +67,19 @@ describe(Linking.createURL, () => {
       expect(Linking.createURL(path)).toMatchSnapshot();
     });
   });
+
   describe('bare', () => {
     beforeEach(() => {
       console.warn = jest.fn();
       Constants.executionEnvironment = ExecutionEnvironment.Bare;
-      Constants.__rawManifest_TEST = {
-        ...Constants.__rawManifest_TEST,
-        hostUri: null,
-        scheme: 'demo',
-      };
+      mockProperty(Constants.manifest, 'hostUri', null);
+      mockProperty(Constants.manifest, 'scheme', 'demo');
     });
 
     afterEach(() => {
       console.warn = consoleWarn;
       Constants.executionEnvironment = executionEnvironment;
-      Constants.__rawManifest_TEST = manifest;
+      unmockAllProperties();
     });
 
     test.each<QueryParams>([


### PR DESCRIPTION
# Why

This is the last (currently) failing module. 

# How

Replaced the full manifest mock overwrites with just a few properties overwrites.

# Test Plan

`et check-package expo-linking`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).