### PR TITLE
[docs] disallow docs.expo.io and allow docs.expo.dev web crawling

### DIFF
--- a/docs/public/docs.expo.dev-robots.txt
+++ b/docs/public/docs.expo.dev-robots.txt
@@ -1,1 +1,3 @@
-User-agent: * Disallow: /
+User-agent: *
+Allow: /
+Sitemap: https://docs.expo.dev/sitemap.xml

--- a/docs/public/docs.expo.io-robots.txt
+++ b/docs/public/docs.expo.io-robots.txt
@@ -1,3 +1,1 @@
-User-agent: *
-Allow: /
-Sitemap: https://docs.expo.dev/sitemap.xml
+User-agent: * Disallow: /


### PR DESCRIPTION
# Why

We initially wanted to not allow docs.expo.dev to be crawled by search engines, but now we want it to since it's the main site.

# How

Disallowed docs.expo.io in robots.txt and allow docs.expo.dev in robots.txt
