### PR TITLE
[expo] Use jest require actual for jest 26 support

### DIFF
--- a/packages/expo/src/__mocks__/Constants-development.ts
+++ b/packages/expo/src/__mocks__/Constants-development.ts
@@ -3,7 +3,7 @@
  * Use it by importing and returning it from a `jest.mock` call explicitly.
  */
 
-const Constants = (require as any).requireActual('expo-constants').default;
+const Constants = jest.requireActual('expo-constants').default;
 
 const MockConstants = Object.create(Constants);
 MockConstants.__rawManifest_TEST = {


### PR DESCRIPTION
# Why

`require.requireActual` was [replaced by `jest.requireActual`](https://jestjs.io/docs/jest-object#jestrequireactualmodulename) in Jest 26 and up. This applies that change for the `expo-constants` mock and makes the test pass again.

# How

- Just a replace

# Test Plan

- `$ et check-packages expo`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).