### PR TITLE
[test-suite] persist selected tests when returning to SelectScreen

### DIFF
--- a/apps/test-suite/screens/SelectScreen.js
+++ b/apps/test-suite/screens/SelectScreen.js
@@ -156,7 +156,6 @@ export default class SelectScreen extends React.PureComponent {
       const query = createQueryString([...selected]);
 
       this.props.navigation.navigate('run', { tests: query });
-      this.setState({ selected: new Set() });
     }
   };
 
@@ -164,6 +163,7 @@ export default class SelectScreen extends React.PureComponent {
     const { selected } = this.state;
     const allSelected = selected.size === this.state.modules.length;
     const buttonTitle = allSelected ? 'Deselect All' : 'Select All';
+
     return (
       <React.Fragment>
         <FlatList


### PR DESCRIPTION
# Why

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

This is a small quality of life improvement - if you're running multiple test-suites it is sometimes hard to tell which ones you've already completed because the selected set is wiped after running these tests (see videos as an example)

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

Removed the logic to clear the selected items, this can be done by selecting/unselecting all if need be

Before:
https://user-images.githubusercontent.com/40680668/129107356-02034e53-2f0c-4608-a8f3-dcee2e77a986.mov

After:
https://user-images.githubusercontent.com/40680668/129107380-22572251-90c5-43d7-a3ef-b75bc9e3655b.mov




# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).