### PR TITLE
Update expo-in-app-purchases build.gradle to depend on expo-modules-core

### DIFF
--- a/packages/expo-in-app-purchases/android/build.gradle
+++ b/packages/expo-in-app-purchases/android/build.gradle
@@ -82,6 +82,7 @@ allprojects {
 dependencies {
   implementation 'androidx.annotation:annotation:1.1.0'
   unimodule 'unimodules-core'
+  unimodule 'expo-modules-core'
   api 'com.android.billingclient:billing:4.0.0'
 
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${safeExtGet('kotlinVersion', '1.4.21')}"


### PR DESCRIPTION
# Why

The new version of expo-in-app-purchases depends on expo-modules-core. However, there is no dependency in the Gradle file. Additionally, the task to release expo-in-app-purchases (`expo-in-app-purchases:compileReleaseJavaWithJavac`) runs before the task to compile expo-modules-core (this is not fixed by this PR).

# How

Added an import to expo-in-app-purchases Gradle file.

# Test Plan

Using the bare workflow have an app that uses expo-in-app-purchases. Try to build the app with ./gradlew bundleRelease.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).