### PR TITLE
[dev-menu][ios] Add test interceptor

### DIFF
--- a/packages/expo-dev-menu/ios/DevMenuSettings.swift
+++ b/packages/expo-dev-menu/ios/DevMenuSettings.swift
@@ -76,7 +76,7 @@ public class DevMenuSettings: NSObject {
    */
   static var showsAtLaunch: Bool {
     get {
-      return boolForKey(showsAtLaunchKey)
+      return DevMenuTestInterceptorManager.interceptor?.shouldShowAtLaunch ?? boolForKey(showsAtLaunchKey)
     }
     set {
       setBool(newValue, forKey: showsAtLaunchKey)
@@ -88,7 +88,7 @@ public class DevMenuSettings: NSObject {
    */
   static var isOnboardingFinished: Bool {
     get {
-      return boolForKey(isOnboardingFinishedKey)
+      return DevMenuTestInterceptorManager.interceptor?.isOnboardingFinishedKey ?? boolForKey(isOnboardingFinishedKey)
     }
     set {
       setBool(newValue, forKey: isOnboardingFinishedKey)

--- a/packages/expo-dev-menu/ios/DevMenuTestInterceptor.swift
+++ b/packages/expo-dev-menu/ios/DevMenuTestInterceptor.swift
@@ -1,0 +1,22 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import Foundation
+
+@objc
+public protocol DevMenuTestInterceptor {
+  @objc
+  var shouldShowAtLaunch: Bool { get }
+  
+  @objc
+  var isOnboardingFinishedKey: Bool { get }
+}
+
+@objc
+public class DevMenuTestInterceptorManager: NSObject {
+  static var interceptor: DevMenuTestInterceptor? = nil
+  
+  @objc
+  public static func setTestInterceptor(_ interceptor: DevMenuTestInterceptor?) {
+    DevMenuTestInterceptorManager.interceptor = interceptor
+  }
+}


### PR DESCRIPTION
# Why

Adds test interceptor to the dev-menu implementation. Needed by detox tests.


# Test Plan

- bare-expo