### PR TITLE
[dev-launcher][ios] Fix crashes when app does not have custom scheme

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - Fixed issue where Expo-hosted manifest URLs with `/index.exp?...` suffix could not be opened properly. ([#13825](https://github.com/expo/expo/pull/13825) by [@esamelson](https://github.com/esamelson))
 - Fixed issue with opening multiple different published apps. ([#13926](https://github.com/expo/expo/pull/13926) by [@esamelson](https://github.com/esamelson))
-- Fixed crashes when the app doesn't have custom deep link scheme on iOS.
+- Fixed crashes when the app doesn't have custom deep link scheme on iOS. ([#14026](https://github.com/expo/expo/pull/14026) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fixed issue where Expo-hosted manifest URLs with `/index.exp?...` suffix could not be opened properly. ([#13825](https://github.com/expo/expo/pull/13825) by [@esamelson](https://github.com/esamelson))
 - Fixed issue with opening multiple different published apps. ([#13926](https://github.com/expo/expo/pull/13926) by [@esamelson](https://github.com/esamelson))
+- Fixed crashes when the app doesn't have custom deep link scheme on iOS.
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/ios/EXDevLauncherInternal.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherInternal.m
@@ -59,7 +59,7 @@ NSString *ON_NEW_DEEP_LINK_EVENT = @"expo.modules.devlauncher.onnewdeeplink";
 
 - (NSDictionary *)constantsToExport
 {
-  return @{ @"clientUrlScheme": self.findClientUrlScheme };
+  return @{ @"clientUrlScheme": self.findClientUrlScheme ?: [NSNull null] };
 }
 
 - (void)onNewPendingDeepLink:(NSURL *)deepLink


### PR DESCRIPTION
# Why

Fixes app crashes when it doesn't have any custom deep links schemes.

# How

- if we can't find a custom scheme, pass `NSNull` instead of `nil`.

# Test Plan

- bare-expo ✅
- small project without a scheme.
