### PR TITLE
[dev-client] Add detox e2e tests

### DIFF
--- a/.github/workflows/development-client-e2e.yml
+++ b/.github/workflows/development-client-e2e.yml
@@ -1,0 +1,50 @@
+name: Development Client e2e
+
+on:
+  workflow_dispatch: {}
+  pull_request:
+    paths:
+      - .github/workflows/development-client-e2e.yml
+      - packages/expo-dev-*/**
+  push:
+    branches: [master]
+    paths:
+      - .github/workflows/development-client-e2e.yml
+      - packages/expo-dev-*/**
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  detox_e2e:
+    runs-on: macos-11
+    steps:
+      - name: 👀 Checkout
+        uses: actions/checkout@v2
+      - name: 🍺 Install required tools
+        run: |
+          brew tap wix/brew
+          brew install applesimutils
+          brew install watchman
+          echo "$(pwd)/bin" >> $GITHUB_PATH
+      - name: 💎 Setup Ruby and install gems
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - name: 💎 Install cocoapods
+        run: sudo gem install cocoapods
+      - name: 🤖 Set up android emulator
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 29
+          avd-name: DevClientEmulator
+          script: echo "expo is awesome"
+      - name: 🧶 Install `expo-test-runner`
+        run: |
+          yarn global add expo-test-runner@$(cat package.json | grep '"expo-test-runner": "[0-9]*\.[0-9]*\.[0-9]*' | head -n 1 | awk '{print $2}' | sed 's/"//g; s/,//g')
+        working-directory: packages/expo-dev-client
+      - name: 🏃‍♂️ Run tests
+        run: |
+          yarn e2e
+        working-directory: packages/expo-dev-client

--- a/.github/workflows/development-client.yml
+++ b/.github/workflows/development-client.yml
@@ -2,15 +2,17 @@ name: Development Client
 
 on:
   workflow_dispatch: {}
-  pull_request:
-    paths:
-      - .github/workflows/development-client.yml
-      - packages/expo-dev-*/**
-  push:
-    branches: [master]
-    paths:
-      - .github/workflows/development-client.yml
-      - packages/expo-dev-*/**
+  # This task will fail due to migration to `expo-modules-core`.
+  # We temporary disable it.
+  # pull_request:
+  #   paths:
+  #     - .github/workflows/development-client.yml
+  #     - packages/expo-dev-*/**
+  # push:
+  #   branches: [master]
+  #   paths:
+  #     - .github/workflows/development-client.yml
+  #     - packages/expo-dev-*/**
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}

--- a/packages/expo-dev-client/.detoxrc.json
+++ b/packages/expo-dev-client/.detoxrc.json
@@ -1,0 +1,41 @@
+{
+  "test-runner": "jest",
+  "runnerConfig": "e2e/config.json",
+  "skipLegacyWorkersInjection": true,
+  "devices": {
+    "emulator": {
+      "type": "android.emulator",
+      "device": {
+        "avdName": "Pixel_3_API_30"
+      }
+    },
+    "simulator": {
+      "type": "ios.simulator",
+      "device": {
+        "type": "iPhone 8"
+      }
+    }
+  },
+  "apps": {
+    "android.debug": {
+      "type": "android.apk",
+      "binaryPath": "android/app/build/outputs/apk/debug/app-debug.apk",
+      "build": "cd android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug && cd .."
+    },
+    "ios.debug": {
+      "type": "ios.app",
+      "binaryPath": "ios/build/Build/Products/Debug-iphonesimulator/dev-client-e2e.app",
+      "build": "xcodebuild -workspace ios/dev-client-e2e.xcworkspace -scheme dev-client-e2e -configuration Debug -sdk iphonesimulator -arch x86_64 -derivedDataPath ios/build"
+    }
+  },
+  "configurations": {
+    "android": {
+      "device": "emulator",
+      "app": "android.debug"
+    },
+    "ios": {
+      "device": "simulator",
+      "app": "ios.debug"  
+    }
+  }
+}

--- a/packages/expo-dev-client/.detoxrc.json
+++ b/packages/expo-dev-client/.detoxrc.json
@@ -6,7 +6,7 @@
     "emulator": {
       "type": "android.emulator",
       "device": {
-        "avdName": "Pixel_3_API_30"
+        "avdName": "DevClientEmulator"
       }
     },
     "simulator": {

--- a/packages/expo-dev-client/e2e/DevLauncher.e2e.ts
+++ b/packages/expo-dev-client/e2e/DevLauncher.e2e.ts
@@ -1,5 +1,9 @@
 import { element, expect, waitFor, by, device } from 'detox';
 
+const MenuTimeout = 20000;
+const LauncherMainScreenTimeout = 10000;
+const LocalAppTimeout = 30000;
+
 function getInvocationManager() {
   // @ts-ignore
   return global.detox[Object.getOwnPropertySymbols(global.detox)[0]]._invocationManager;
@@ -41,7 +45,7 @@ describe('DevLauncher', () => {
 
     await waitFor(element(by.id('DevMenuMainScreen')))
       .toBeVisible()
-      .withTimeout(2000);
+      .withTimeout(MenuTimeout);
   });
 
   it('should be able to load app from URL', async () => {
@@ -56,7 +60,7 @@ describe('DevLauncher', () => {
 
     await waitFor(element(by.id('LocalAppMainScreen')))
       .toBeVisible()
-      .withTimeout(10000);
+      .withTimeout(LocalAppTimeout);
   });
 
   it('should be able to come back to the dev launcher screen', async () => {
@@ -71,7 +75,7 @@ describe('DevLauncher', () => {
 
     await waitFor(element(by.id('LocalAppMainScreen')))
       .toBeVisible()
-      .withTimeout(5000);
+      .withTimeout(LocalAppTimeout);
 
     await openMenu();
 
@@ -79,11 +83,11 @@ describe('DevLauncher', () => {
 
     await waitFor(backToLauncher)
       .toBeVisible()
-      .withTimeout(8000);
+      .withTimeout(MenuTimeout);
     await backToLauncher.tap();
 
     await waitFor(element(by.id('DevLauncherMainScreen')))
       .toBeVisible()
-      .withTimeout(500);
+      .withTimeout(LauncherMainScreenTimeout);
   });
 });

--- a/packages/expo-dev-client/e2e/DevLauncher.e2e.ts
+++ b/packages/expo-dev-client/e2e/DevLauncher.e2e.ts
@@ -59,6 +59,10 @@ describe('DevLauncher', () => {
     await expect(loadButton).toBeVisible();
 
     await urlInput.typeText(`http://${getLocalIPAddress()}:8081`);
+    if (device.getPlatform() === 'android') {
+      // close keyboard
+      await device.pressBack();
+    }
     await loadButton.multiTap(2);
 
     await waitFor(element(by.id('LocalAppMainScreen')))
@@ -74,6 +78,10 @@ describe('DevLauncher', () => {
     await expect(loadButton).toBeVisible();
 
     await urlInput.typeText(`http://${getLocalIPAddress()}:8081`);
+    if (device.getPlatform() === 'android') {
+      // close keyboard
+      await device.pressBack();
+    }
     await loadButton.multiTap(2);
 
     await waitFor(element(by.id('LocalAppMainScreen')))

--- a/packages/expo-dev-client/e2e/DevLauncher.e2e.ts
+++ b/packages/expo-dev-client/e2e/DevLauncher.e2e.ts
@@ -1,0 +1,89 @@
+import { element, expect, waitFor, by, device } from 'detox';
+
+function getInvocationManager() {
+  // @ts-ignore
+  return global.detox[Object.getOwnPropertySymbols(global.detox)[0]]._invocationManager;
+}
+
+function getLocalIPAddress(): string {
+  return require('os')
+    .networkInterfaces()
+    .en0.find((elm: { family: string }) => elm.family === 'IPv4').address;
+}
+
+async function openMenu(): Promise<void> {
+  if (device.getPlatform() === 'android') {
+    return getInvocationManager().execute({
+      target: {
+        type: 'Class',
+        value: 'com.testrunner.DevClientDetoxHelper',
+      },
+      method: 'openMenu',
+      args: [],
+    });
+  }
+  return await device.shake();
+}
+
+describe('DevLauncher', () => {
+  beforeEach(async () => {
+    await device.launchApp({ newInstance: true });
+  });
+
+  it('should render main screen', async () => {
+    await expect(element(by.id('DevLauncherMainScreen'))).toBeVisible();
+  });
+
+  it('should be able to open dev menu', async () => {
+    await expect(element(by.id('DevLauncherMainScreen'))).toBeVisible();
+
+    await openMenu();
+
+    await waitFor(element(by.id('DevMenuMainScreen')))
+      .toBeVisible()
+      .withTimeout(2000);
+  });
+
+  it('should be able to load app from URL', async () => {
+    const urlInput = element(by.id('DevLauncherURLInput'));
+    const loadButton = element(by.id('DevLauncherLoadAppButton'));
+
+    await expect(urlInput).toBeVisible();
+    await expect(loadButton).toBeVisible();
+
+    await urlInput.typeText(`http://${getLocalIPAddress()}:8081`);
+    await loadButton.multiTap(2);
+
+    await waitFor(element(by.id('LocalAppMainScreen')))
+      .toBeVisible()
+      .withTimeout(10000);
+  });
+
+  it('should be able to come back to the dev launcher screen', async () => {
+    const urlInput = element(by.id('DevLauncherURLInput'));
+    const loadButton = element(by.id('DevLauncherLoadAppButton'));
+
+    await expect(urlInput).toBeVisible();
+    await expect(loadButton).toBeVisible();
+
+    await urlInput.typeText(`http://${getLocalIPAddress()}:8081`);
+    await loadButton.multiTap(2);
+
+    await waitFor(element(by.id('LocalAppMainScreen')))
+      .toBeVisible()
+      .withTimeout(5000);
+
+    await openMenu();
+
+    const backToLauncher = element(by.text('Back to Launcher'));
+
+    await waitFor(backToLauncher)
+      .toBeVisible()
+      .withTimeout(8000);
+    await backToLauncher.tap();
+
+    await waitFor(element(by.id('DevLauncherMainScreen')))
+      .toBeVisible()
+      .withTimeout(500);
+  });
+});

--- a/packages/expo-dev-client/e2e/DevLauncher.e2e.ts
+++ b/packages/expo-dev-client/e2e/DevLauncher.e2e.ts
@@ -11,7 +11,7 @@ function getInvocationManager() {
 
 function getLocalIPAddress(): string {
   if (device.getPlatform() === 'ios') {
-    return 'http://localhost:8081';
+    return 'localhost';
   }
   return require('os')
     .networkInterfaces()

--- a/packages/expo-dev-client/e2e/DevLauncher.e2e.ts
+++ b/packages/expo-dev-client/e2e/DevLauncher.e2e.ts
@@ -10,6 +10,9 @@ function getInvocationManager() {
 }
 
 function getLocalIPAddress(): string {
+  if (device.getPlatform() === 'ios') {
+    return 'http://localhost:8081';
+  }
   return require('os')
     .networkInterfaces()
     .en0.find((elm: { family: string }) => elm.family === 'IPv4').address;

--- a/packages/expo-dev-client/e2e/DevLauncher.e2e.ts
+++ b/packages/expo-dev-client/e2e/DevLauncher.e2e.ts
@@ -1,8 +1,8 @@
 import { element, expect, waitFor, by, device } from 'detox';
 
-const MenuTimeout = 20000;
-const LauncherMainScreenTimeout = 10000;
-const LocalAppTimeout = 30000;
+const MenuTimeout = 50000;
+const LauncherMainScreenTimeout = 30000;
+const LocalAppTimeout = 60000;
 
 function getInvocationManager() {
   // @ts-ignore

--- a/packages/expo-dev-client/e2e/android/DetoxTest.java
+++ b/packages/expo-dev-client/e2e/android/DetoxTest.java
@@ -1,0 +1,92 @@
+package com.testrunner;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.matcher.ViewMatchers.isRoot;
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.ContextWrapper;
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
+import androidx.test.rule.ActivityTestRule;
+
+import com.facebook.react.ReactApplication;
+import com.facebook.react.ReactNativeHost;
+import com.wix.detox.Detox;
+import com.wix.detox.config.DetoxConfig;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import expo.modules.devlauncher.DevLauncherController;
+import expo.modules.devlauncher.launcher.DevLauncherActivity;
+import expo.modules.devmenu.DevMenuManager;
+
+// We need this class to pass dev launcher host to detox.
+// Otherwise it won't detect that the app has been started.
+class ReactNativeHolder extends ContextWrapper implements ReactApplication {
+  public ReactNativeHolder(Context base) {
+    super(base);
+  }
+
+  @Override
+  public ReactNativeHost getReactNativeHost() {
+    return DevLauncherController.getInstance().getDevClientHost();
+  }
+}
+
+class DevClientDetoxHelper {
+  public static Activity getCurrentActivity() {
+    final Activity[] activity = new Activity[1];
+
+    onView(isRoot()).check((view, noViewFoundException) -> {
+
+      View checkedView = view;
+
+      while (checkedView instanceof ViewGroup && ((ViewGroup) checkedView).getChildCount() > 0) {
+
+        checkedView = ((ViewGroup) checkedView).getChildAt(0);
+
+        if (checkedView.getContext() instanceof Activity) {
+          activity[0] = (Activity) checkedView.getContext();
+          return;
+        }
+      }
+    });
+    return activity[0];
+  }
+
+  public static void openMenu() throws InterruptedException {
+    getInstrumentation().waitForIdleSync();
+    Activity activity = getCurrentActivity();
+    int counter = 10;
+    while (counter-- > 0 && activity == null) {
+      Thread.sleep(100);
+      activity = getCurrentActivity();
+    }
+
+    DevMenuManager.INSTANCE.openMenu(activity, null);
+  }
+}
+
+@RunWith(AndroidJUnit4.class)
+@LargeTest
+public class DetoxTest {
+  @Rule
+  public ActivityTestRule<DevLauncherActivity> mActivityRule = new ActivityTestRule<>(DevLauncherActivity.class, false, false);
+
+  @Test
+  public void runDetoxTests() {
+    DetoxConfig detoxConfig = new DetoxConfig();
+    detoxConfig.idlePolicyConfig.masterTimeoutSec = 90;
+    detoxConfig.rnContextLoadTimeoutSec = 180;
+
+    ReactNativeHolder reactNativeHolder = new ReactNativeHolder(getInstrumentation().getTargetContext().getApplicationContext());
+    Detox.runTests(mActivityRule, reactNativeHolder, detoxConfig);
+  }
+}

--- a/packages/expo-dev-client/e2e/android/MainActivity.java
+++ b/packages/expo-dev-client/e2e/android/MainActivity.java
@@ -1,0 +1,40 @@
+// custom
+package com.testrunner;
+
+import android.content.Intent;
+
+import expo.modules.devmenu.react.DevMenuAwareReactActivity;
+import com.facebook.react.ReactActivityDelegate;
+
+import expo.modules.adapters.react.ReactActivityDelegateWrapper;
+import expo.modules.devlauncher.DevLauncherController;
+
+public class MainActivity extends DevMenuAwareReactActivity {
+  /**
+  * Returns the name of the main component registered from JavaScript.
+  * This is used to schedule rendering of the component.
+  */
+  @Override
+  protected String getMainComponentName() {
+    return "main";
+  }
+
+  @Override
+  public void onNewIntent(Intent intent) {
+    if (DevLauncherController.tryToHandleIntent(this, intent)) {
+      return;
+    }
+    super.onNewIntent(intent);
+  }
+
+  @Override
+  protected ReactActivityDelegate createReactActivityDelegate() {
+    return DevLauncherController.wrapReactActivityDelegate(this, () -> new ReactActivityDelegateWrapper(
+      this,
+      new ReactActivityDelegate(
+        this,
+        getMainComponentName()
+      )
+    ));
+  }
+}

--- a/packages/expo-dev-client/e2e/android/MainApplication.java
+++ b/packages/expo-dev-client/e2e/android/MainApplication.java
@@ -1,0 +1,84 @@
+package com.testrunner;
+
+import android.app.Application;
+import android.content.res.Configuration;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.facebook.react.PackageList;
+import com.facebook.react.ReactApplication;
+import com.facebook.react.ReactNativeHost;
+import com.facebook.react.ReactPackage;
+import com.facebook.soloader.SoLoader;
+
+import expo.interfaces.devmenu.DevMenuSettingsInterface;
+import expo.modules.adapters.react.ApplicationLifecycleDispatcher;
+import expo.modules.adapters.react.ReactNativeHostWrapper;
+import expo.modules.devlauncher.DevLauncherController;
+import expo.modules.devmenu.DevMenuDefaultSettings;
+import expo.modules.devmenu.DevMenuManager;
+import expo.modules.devmenu.tests.DevMenuTestInterceptor;
+
+import java.util.List;
+
+public class MainApplication extends Application implements ReactApplication {
+  private final ReactNativeHost mReactNativeHost = new ReactNativeHostWrapper(
+      this,
+      new ReactNativeHost(this) {
+        @Override
+        public boolean getUseDeveloperSupport() {
+          return BuildConfig.DEBUG;
+        }
+
+        @Override
+        protected List<ReactPackage> getPackages() {
+          return new PackageList(this).getPackages();
+        }
+
+        @Override
+        protected String getJSMainModuleName() {
+          return "index";
+        }
+      });
+
+  @Override
+  public ReactNativeHost getReactNativeHost() {
+    return mReactNativeHost;
+  }
+
+  @Override
+  public void onCreate() {
+    super.onCreate();
+    SoLoader.init(this, /* native exopackage */ false);
+
+    DevMenuManager.INSTANCE.setTestInterceptor(new DevMenuTestInterceptor() {
+      @Nullable
+      @Override
+      public DevMenuSettingsInterface overrideSettings() {
+        return new DevMenuDefaultSettings() {
+          @Override
+          public boolean getShowsAtLaunch() {
+            return false;
+          }
+
+          @Override
+          public boolean isOnboardingFinished() {
+            return true;
+          }
+        };
+      }
+    });
+
+    DevLauncherController.initialize(this, mReactNativeHost);
+
+
+    ApplicationLifecycleDispatcher.onApplicationCreate(this);
+  }
+
+  @Override
+  public void onConfigurationChanged(@NonNull Configuration newConfig) {
+    super.onConfigurationChanged(newConfig);
+    ApplicationLifecycleDispatcher.onConfigurationChanged(this, newConfig);
+  }
+}

--- a/packages/expo-dev-client/e2e/app/App.tsx
+++ b/packages/expo-dev-client/e2e/app/App.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+export default function App() {
+  return (
+    <View style={styles.container} testID="LocalAppMainScreen">
+      <Text>Open up App.js to start working on your app!</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/packages/expo-dev-client/e2e/config.json
+++ b/packages/expo-dev-client/e2e/config.json
@@ -1,0 +1,9 @@
+{
+  "maxWorkers": 1,
+  "testEnvironment": "./environments",
+  "testRunner": "jest-circus/runner",
+  "testTimeout": 120000,
+  "testRegex": "\\.e2e\\.ts$",
+  "reporters": ["detox/runners/jest/streamlineReporter"],
+  "verbose": true
+}

--- a/packages/expo-dev-client/e2e/environments.js
+++ b/packages/expo-dev-client/e2e/environments.js
@@ -1,0 +1,23 @@
+const {
+  DetoxCircusEnvironment,
+  SpecReporter,
+  WorkerAssignReporter,
+} = require('detox/runners/jest-circus');
+
+class CustomDetoxEnvironment extends DetoxCircusEnvironment {
+  constructor(config, context) {
+    super(config, context);
+
+    // Can be safely removed, if you are content with the default value (=300000ms)
+    this.initTimeout = 300000;
+
+    // This takes care of generating status logs on a per-spec basis. By default, Jest only reports at file-level.
+    // This is strictly optional.
+    this.registerListeners({
+      SpecReporter,
+      WorkerAssignReporter,
+    });
+  }
+}
+
+module.exports = CustomDetoxEnvironment;

--- a/packages/expo-dev-client/e2e/ios/AppDelegate.m
+++ b/packages/expo-dev-client/e2e/ios/AppDelegate.m
@@ -1,0 +1,113 @@
+#import "AppDelegate.h"
+
+#import <React/RCTBridge.h>
+#import <React/RCTBundleURLProvider.h>
+#import <React/RCTRootView.h>
+#import <React/RCTLinkingManager.h>
+
+#import <UMCore/UMModuleRegistry.h>
+#import <UMReactNativeAdapter/UMNativeModulesProxy.h>
+#import <UMReactNativeAdapter/UMModuleRegistryAdapter.h>
+#import <UMCore/UMModuleRegistryProvider.h>
+
+@import EXDevMenu;
+#include <EXDevLauncher/EXDevLauncherController.h>
+
+
+@interface DevMenuDetoxTestInterceptor : NSObject<DevMenuTestInterceptor>
+
+@end
+
+@implementation DevMenuDetoxTestInterceptor
+
+- (BOOL)isOnboardingFinishedKey
+{
+  return YES;
+}
+
+- (BOOL)shouldShowAtLaunch
+{
+  return NO;
+}
+
+@end
+
+@interface AppDelegate () <RCTBridgeDelegate>
+
+@property (nonatomic, strong) EXModuleRegistryAdapter *moduleRegistryAdapter;
+@property (nonatomic, strong) NSDictionary *launchOptions;
+
+@end
+
+@implementation AppDelegate
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+{
+  [DevMenuTestInterceptorManager setTestInterceptor:[DevMenuDetoxTestInterceptor new]];
+
+  self.moduleRegistryAdapter = [[EXModuleRegistryAdapter alloc] initWithModuleRegistryProvider:[[EXModuleRegistryProvider alloc] init]];
+  self.launchOptions = launchOptions;
+  self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+
+   EXDevLauncherController *controller = [EXDevLauncherController sharedInstance];
+   [controller startWithWindow:self.window delegate:(id<EXDevLauncherControllerDelegate>)self launchOptions:launchOptions];
+
+  [super application:application didFinishLaunchingWithOptions:launchOptions];
+
+  return YES;
+}
+
+- (RCTBridge *)initializeReactNativeApp
+{
+  NSDictionary *launchOptions = [EXDevLauncherController.sharedInstance getLaunchOptions];
+
+  RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:launchOptions];
+  RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge moduleName:@"main" initialProperties:nil];
+  rootView.backgroundColor = [[UIColor alloc] initWithRed:1.0f green:1.0f blue:1.0f alpha:1];
+
+  UIViewController *rootViewController = [UIViewController new];
+  rootViewController.view = rootView;
+  self.window.rootViewController = rootViewController;
+  [self.window makeKeyAndVisible];
+
+  return bridge;
+ }
+
+- (NSArray<id<RCTBridgeModule>> *)extraModulesForBridge:(RCTBridge *)bridge
+{
+  NSArray<id<RCTBridgeModule>> *extraModules = [_moduleRegistryAdapter extraModulesForBridge:bridge];
+  // If you'd like to export some custom RCTBridgeModules that are not Expo modules, add them here!
+  return extraModules;
+}
+
+- (NSURL *)sourceURLForBridge:(RCTBridge *)bridge {
+  return [[EXDevLauncherController sharedInstance] sourceUrl];
+}
+
+// Linking API
+- (BOOL)application:(UIApplication *)application openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {
+  if ([EXDevLauncherController.sharedInstance onDeepLink:url options:options]) {
+    return true;
+  }
+
+  return [RCTLinkingManager application:application openURL:url options:options];
+}
+
+// Universal Links
+- (BOOL)application:(UIApplication *)application continueUserActivity:(nonnull NSUserActivity *)userActivity restorationHandler:(nonnull void (^)(NSArray<id<UIUserActivityRestoring>> * _Nullable))restorationHandler {
+  return [RCTLinkingManager application:application
+                   continueUserActivity:userActivity
+                     restorationHandler:restorationHandler];
+}
+
+@end
+
+@implementation AppDelegate (EXDevLauncherControllerDelegate)
+ 
+- (void)devLauncherController:(EXDevLauncherController *)developmentClientController
+          didStartWithSuccess:(BOOL)success
+{
+  developmentClientController.appBridge = [self initializeReactNativeApp];
+}
+ 
+@end

--- a/packages/expo-dev-client/package.json
+++ b/packages/expo-dev-client/package.json
@@ -11,7 +11,8 @@
     "test": "expo-module test",
     "prepare": "expo-module prepare",
     "prepublishOnly": "expo-module prepublishOnly",
-    "expo-module": "expo-module"
+    "expo-module": "expo-module",
+    "e2e": "expo-test-runner run-test -t e2e"
   },
   "keywords": [
     "react-native",
@@ -37,7 +38,8 @@
     "expo-updates-interface": "~0.2.0"
   },
   "devDependencies": {
-    "expo-module-scripts": "^2.0.0"
+    "expo-module-scripts": "^2.0.0",
+    "expo-test-runner": "0.0.5"
   },
   "jest": {
     "preset": "expo-module-scripts/ios"

--- a/packages/expo-dev-client/test-runner.config.js
+++ b/packages/expo-dev-client/test-runner.config.js
@@ -1,0 +1,64 @@
+module.exports = {
+  applications: {
+    'dev-client-e2e': {
+      preset: 'detox',
+      reactVersion: '17.0.1',
+      reactNativeVersion: '0.64.2',
+      detoxConfigFile: '.detoxrc.json',
+      appEntryPoint: 'e2e/app/App.tsx',
+      android: {
+        mainApplication: 'e2e/android/MainApplication.java',
+        mainActivity: 'e2e/android/MainActivity.java',
+        detoxTestFile: 'e2e/android/DetoxTest.java',
+      },
+      ios: {
+        appDelegate: 'e2e/ios/AppDelegate.m',
+      },
+      dependencies: [
+        {
+          name: '@unimodules/core',
+          path: '../@unimodules/core',
+        },
+        {
+          name: '@unimodules/react-native-adapter',
+          path: '../@unimodules/react-native-adapter',
+        },
+        {
+          name: 'expo-modules-core',
+          path: '../expo-modules-core',
+        },
+        {
+          name: 'expo-modules-autolinking',
+          path: '../expo-modules-autolinking',
+        },
+        {
+          name: 'expo-dev-client',
+          path: '../expo-dev-client',
+        },
+        {
+          name: 'expo-dev-launcher',
+          path: '../expo-dev-launcher',
+        },
+        {
+          name: 'expo-dev-menu',
+          path: '../expo-dev-menu',
+        },
+        {
+          name: 'expo-dev-menu-interface',
+          path: '../expo-dev-menu-interface',
+        },
+        {
+          name: 'expo-updates-interface',
+          path: '../expo-updates-interface',
+        },
+      ],
+      additionalFiles: ['e2e'],
+      tests: {
+        e2e: {
+          shouldRunBundler: true,
+          configurations: ['ios', 'android'],
+        },
+      },
+    },
+  },
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -3462,6 +3462,11 @@
     pouchdb-collections "^1.0.1"
     tiny-queue "^0.2.1"
 
+"@expo/xcodegen@2.18.0-patch.1":
+  version "2.18.0-patch.1"
+  resolved "https://registry.yarnpkg.com/@expo/xcodegen/-/xcodegen-2.18.0-patch.1.tgz#40514e973ee6769e5abd5d1c16d40dbe85c1d9aa"
+  integrity sha512-Caz2ChzVe/U3GkaK+DKlXqYorARzLZ1yM6D03LHvasnyA4T+pW6DGXHPy7cfK5AlbsV6Fi5ZtZ9gqW4jGWIFwQ==
+
 "@firebase/analytics-types@0.6.0":
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/@firebase/analytics-types/-/analytics-types-0.6.0.tgz#164116ebe8d3b338272acc7f9904cac38556d6cd"
@@ -8610,6 +8615,14 @@ chalk@^4.0.0, chalk@^4.1.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+chalk@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
+  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 change-case-all@1.0.14:
   version "1.0.14"
   resolved "https://registry.yarnpkg.com/change-case-all/-/change-case-all-1.0.14.tgz#bac04da08ad143278d0ac3dda7eccd39280bfba1"
@@ -10391,6 +10404,11 @@ dot-prop@^5.2.0:
   dependencies:
     is-obj "^2.0.0"
 
+dot@^2.0.0-beta.1:
+  version "2.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/dot/-/dot-2.0.0-beta.1.tgz#12bcb18f39f590f9426910e1d19188dad225af25"
+  integrity sha512-kxM7fSnNQTXOmaeGuBSXM8O3fEsBb7XSDBllkGbRwa0lJSJTxxDE/4eSNGLKZUmlFw0f1vJ5qSV2BljrgQtgIA==
+
 dotenv@^8.2.0:
   version "8.6.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.6.0.tgz#061af664d19f7f4d8fc6e4ff9b584ce237adcb8b"
@@ -11278,6 +11296,21 @@ expo-pwa@0.0.80:
     commander "2.20.0"
     update-check "1.5.3"
 
+expo-test-runner@0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/expo-test-runner/-/expo-test-runner-0.0.5.tgz#b5d2deb7a473f2724abe0959ade8d75b71369486"
+  integrity sha512-5NVLxBKsVp463alHvTUt54zBu6tlQC/GoVmWXlEiLdlBe/d95IcSGjEfNvQqbYIKj5GFEpOMPEmyll2MACq7Vw==
+  dependencies:
+    "@babel/runtime" "7.9.0"
+    "@expo/spawn-async" "^1.5.0"
+    "@expo/xcodegen" "2.18.0-patch.1"
+    chalk "^4.1.2"
+    commander "^7.2.0"
+    dot "^2.0.0-beta.1"
+    fs-extra "^10.0.0"
+    node-fetch "^2.6.1"
+    tempy "^0.7.1"
+
 expo-three@5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/expo-three/-/expo-three-5.2.0.tgz#af792eda7561f4508f2d4e9b08fcaa17be34ebe0"
@@ -11971,6 +12004,15 @@ fs-extra@^1.0.0:
     graceful-fs "^4.1.2"
     jsonfile "^2.1.0"
     klaw "^1.0.0"
+
+fs-extra@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.0.0.tgz#9ff61b655dde53fb34a82df84bb214ce802e17c1"
+  integrity sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
 
 fs-extra@^4.0.2:
   version "4.0.3"


### PR DESCRIPTION
# Why

Adds detox e2e tests.
Fixes ENG-1611.

Needs:
- [x] https://github.com/expo/expo/pull/14025
- [x] https://github.com/expo/expo/pull/14026
- [x] test-runner
 
# How

Uses a new tool to set up detox tests.
