### PR TITLE
Rewrite from AsyncTask to Kotlin coroutines

### DIFF
--- a/packages/expo-barcode-scanner/android/build.gradle
+++ b/packages/expo-barcode-scanner/android/build.gradle
@@ -84,4 +84,6 @@ dependencies {
   api 'com.google.zxing:core:3.3.3'
 
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${safeExtGet('kotlinVersion', '1.4.21')}"
+  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.3")
+  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.1")
 }

--- a/packages/expo-barcode-scanner/android/src/main/java/expo/modules/barcodescanner/BarCodeScannerView.kt
+++ b/packages/expo-barcode-scanner/android/src/main/java/expo/modules/barcodescanner/BarCodeScannerView.kt
@@ -98,10 +98,10 @@ class BarCodeScannerView(
     type = cameraType
     if (!::viewFinder.isInitialized) {
       viewFinder = BarCodeScannerViewFinder(
-          viewContext,
-          cameraType,
-          this,
-          moduleRegistryDelegate
+        viewContext,
+        cameraType,
+        this,
+        moduleRegistryDelegate
       )
       addView(viewFinder)
     } else {

--- a/packages/expo-barcode-scanner/android/src/main/java/expo/modules/barcodescanner/BarCodeScannerView.kt
+++ b/packages/expo-barcode-scanner/android/src/main/java/expo/modules/barcodescanner/BarCodeScannerView.kt
@@ -17,7 +17,7 @@ import kotlin.math.roundToInt
 
 class BarCodeScannerView(
   private val viewContext: Context,
-  private val moduleRegistryDelegate: ModuleRegistryDelegate = ModuleRegistryDelegate()
+  private val moduleRegistryDelegate: ModuleRegistryDelegate
 ) : ViewGroup(viewContext) {
   private val orientationListener = object : OrientationEventListener(
     viewContext,
@@ -97,7 +97,12 @@ class BarCodeScannerView(
   fun setCameraType(cameraType: Int) {
     type = cameraType
     if (!::viewFinder.isInitialized) {
-      viewFinder = BarCodeScannerViewFinder(viewContext, cameraType, this, moduleRegistryDelegate)
+      viewFinder = BarCodeScannerViewFinder(
+          viewContext,
+          cameraType,
+          this,
+          moduleRegistryDelegate
+      )
       addView(viewFinder)
     } else {
       viewFinder.setCameraType(cameraType)

--- a/packages/expo-barcode-scanner/android/src/main/java/expo/modules/barcodescanner/BarCodeScannerViewFinder.kt
+++ b/packages/expo-barcode-scanner/android/src/main/java/expo/modules/barcodescanner/BarCodeScannerViewFinder.kt
@@ -176,7 +176,7 @@ internal class BarCodeScannerViewFinder(
     barCodeScanner.setSettings(settings)
   }
 
-  private fun barCodeScannerAsyncTask(camera: Camera?, mImageData: ByteArray) {
+  private fun scanForBarcodes(camera: Camera?, mImageData: ByteArray) {
     coroutineScope.launch {
       try {
         if (!coroutineScope.isActive) {

--- a/packages/expo-barcode-scanner/android/src/main/java/expo/modules/barcodescanner/BarCodeScannerViewFinder.kt
+++ b/packages/expo-barcode-scanner/android/src/main/java/expo/modules/barcodescanner/BarCodeScannerViewFinder.kt
@@ -191,8 +191,8 @@ internal class BarCodeScannerViewFinder(
           val height = size.height
           val properRotation = ExpoBarCodeScanner.instance.rotation
           val result = barCodeScanner.scan(
-              mImageData, width,
-              height, properRotation
+            mImageData, width,
+            height, properRotation
           )
           if (result != null) {
             withContext(Dispatchers.Main) {

--- a/packages/expo-barcode-scanner/android/src/main/java/expo/modules/barcodescanner/BarCodeScannerViewFinder.kt
+++ b/packages/expo-barcode-scanner/android/src/main/java/expo/modules/barcodescanner/BarCodeScannerViewFinder.kt
@@ -19,10 +19,10 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 internal class BarCodeScannerViewFinder(
-    context: Context,
-    private var cameraType: Int,
-    private var barCodeScannerView: BarCodeScannerView,
-    private val moduleRegistryDelegate: ModuleRegistryDelegate
+  context: Context,
+  private var cameraType: Int,
+  private var barCodeScannerView: BarCodeScannerView,
+  private val moduleRegistryDelegate: ModuleRegistryDelegate
 ) : TextureView(context), SurfaceTextureListener, PreviewCallback {
   private var finderSurfaceTexture: SurfaceTexture? = null
   private val coroutineScope = CoroutineScope(Dispatchers.Default)
@@ -39,7 +39,6 @@ internal class BarCodeScannerViewFinder(
   @Volatile
   private var isChanging = false
   private var camera: Camera? = null
-
 
   // Scanner instance for the barcode scanning
   private lateinit var barCodeScanner: BarCodeScannerInterface
@@ -112,11 +111,11 @@ internal class BarCodeScannerViewFinder(
           // set picture size
           // defaults to max available size
           val optimalPictureSize =
-              ExpoBarCodeScanner.instance.getBestSize(
-                  temporaryParameters.supportedPictureSizes,
-                  Int.MAX_VALUE,
-                  Int.MAX_VALUE
-              )
+            ExpoBarCodeScanner.instance.getBestSize(
+              temporaryParameters.supportedPictureSizes,
+              Int.MAX_VALUE,
+              Int.MAX_VALUE
+            )
           temporaryParameters?.setPictureSize(optimalPictureSize.width, optimalPictureSize.height)
           parameters = temporaryParameters
           setPreviewTexture(finderSurfaceTexture)
@@ -201,9 +200,6 @@ internal class BarCodeScannerViewFinder(
                 barCodeScannerView.onBarCodeScanned(result)
               }
             }
-//              Handler(Looper.getMainLooper()).post {
-//                barCodeScannerView.onBarCodeScanned(result)
-//              }
           }
         }
         barCodeScannerTaskLock = false

--- a/packages/expo-barcode-scanner/android/src/main/java/expo/modules/barcodescanner/BarCodeScannerViewManager.kt
+++ b/packages/expo-barcode-scanner/android/src/main/java/expo/modules/barcodescanner/BarCodeScannerViewManager.kt
@@ -1,15 +1,11 @@
 package expo.modules.barcodescanner
 
 import android.content.Context
-import android.util.Log
 import expo.modules.core.ModuleRegistry
 import expo.modules.core.ModuleRegistryDelegate
 import expo.modules.core.ViewManager
 import expo.modules.core.interfaces.ExpoProp
 import expo.modules.interfaces.barcodescanner.BarCodeScannerSettings
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.cancel
 import java.util.*
 
 class BarCodeScannerViewManager(

--- a/packages/expo-barcode-scanner/android/src/main/java/expo/modules/barcodescanner/BarCodeScannerViewManager.kt
+++ b/packages/expo-barcode-scanner/android/src/main/java/expo/modules/barcodescanner/BarCodeScannerViewManager.kt
@@ -1,11 +1,15 @@
 package expo.modules.barcodescanner
 
 import android.content.Context
+import android.util.Log
 import expo.modules.core.ModuleRegistry
 import expo.modules.core.ModuleRegistryDelegate
 import expo.modules.core.ViewManager
 import expo.modules.core.interfaces.ExpoProp
 import expo.modules.interfaces.barcodescanner.BarCodeScannerSettings
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
 import java.util.*
 
 class BarCodeScannerViewManager(

--- a/packages/expo-barcode-scanner/android/src/main/java/expo/modules/barcodescanner/ScopeCancelationException.kt
+++ b/packages/expo-barcode-scanner/android/src/main/java/expo/modules/barcodescanner/ScopeCancelationException.kt
@@ -1,0 +1,5 @@
+package expo.modules.barcodescanner
+
+import kotlinx.coroutines.CancellationException
+
+class ScopeCancellationException : CancellationException("View destroyed, scope canceled")

--- a/packages/expo-sharing/CHANGELOG.md
+++ b/packages/expo-sharing/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 - Migrated from `@unimodules/core` to `expo-modules-core`. ([#13757](https://github.com/expo/expo/pull/13757) by [@tsapeta](https://github.com/tsapeta))
 - Rewrote Android part from Java to Kotlin ([#14010](https://github.com/expo/expo/pull/14010) by [@m1st4ke](https://github.com/m1st4ke))
-- Migrated from `AsyncTask` to Kotlin concurrency utilities. ([#14029](https://github.com/expo/expo/pull/14029) by [@m1st4ke](https://github.com/m1st4ke))
+- Migrated from `AsyncTask` to Kotlin coroutines. ([#14029](https://github.com/expo/expo/pull/14029) by [@m1st4ke](https://github.com/m1st4ke))
 
 ## 9.2.0 — 2021-06-16
 

--- a/packages/expo-sharing/CHANGELOG.md
+++ b/packages/expo-sharing/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Migrated from `@unimodules/core` to `expo-modules-core`. ([#13757](https://github.com/expo/expo/pull/13757) by [@tsapeta](https://github.com/tsapeta))
 - Rewrote Android part from Java to Kotlin ([#14010](https://github.com/expo/expo/pull/14010) by [@m1st4ke](https://github.com/m1st4ke))
+- Migrated from `AsyncTask` to Kotlin concurrency utilities. ([#14029](https://github.com/expo/expo/pull/14029) by [@m1st4ke](https://github.com/m1st4ke))
 
 ## 9.2.0 — 2021-06-16
 


### PR DESCRIPTION
# Why

`AsyncTask` is deprecated since api level 30, it's recommended to use the standard java.util.concurrent or Kotlin concurrency utilities instead.

# How

Rewrote classes extending AsyncTask, to use kotlin concurrency utilities

# Test Plan

Checked module in bare-expo app
Ran test-suite tests

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).