### PR TITLE
[constants] Fix build phase error in xcode for nodejs possibly not found in nvm

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -1189,7 +1189,7 @@ SPEC CHECKSUMS:
   EXCamera: ae8d2ffc917f3f6c726fadbdcf2190e6d724c6d6
   EXCellular: b416818c34a08e9ed2827885dcabd815adf89128
   EXClipboard: 0286db41a88d13d5a8b12faaa1bc3ac74a1ee680
-  EXConstants: badac838e0e6a9e741dd626e4c5e194aa6132ed7
+  EXConstants: 5fb4f6412de04130e2b0f42a108c9acbad4159d3
   EXContacts: 204931c2a86dd94e0f4a29601cc1277ff19bd410
   EXCrypto: 1c33beef27cfe7bd3a9625652647233ff56943b7
   EXDevice: 2519a0b4a54da12218da20f768f64eb5a2000e6a

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -4046,7 +4046,7 @@ SPEC CHECKSUMS:
   EXCamera: ae8d2ffc917f3f6c726fadbdcf2190e6d724c6d6
   EXCellular: b416818c34a08e9ed2827885dcabd815adf89128
   EXClipboard: 0286db41a88d13d5a8b12faaa1bc3ac74a1ee680
-  EXConstants: badac838e0e6a9e741dd626e4c5e194aa6132ed7
+  EXConstants: 5fb4f6412de04130e2b0f42a108c9acbad4159d3
   EXContacts: 204931c2a86dd94e0f4a29601cc1277ff19bd410
   EXCrypto: 1c33beef27cfe7bd3a9625652647233ff56943b7
   EXDevice: 2519a0b4a54da12218da20f768f64eb5a2000e6a

--- a/packages/expo-constants/CHANGELOG.md
+++ b/packages/expo-constants/CHANGELOG.md
@@ -16,6 +16,7 @@
 - fix `__dir__` absolute path in script_phase making an inconsistent Podfile.lock. ([#13610](https://github.com/expo/expo/pull/13610) by [@kudo](https://github.com/kudo))
 - Fix `PROJECT_ROOT` path resolution in `get-app-config-ios.sh`. ([#13439](https://github.com/expo/expo/pull/13439) by [@ajsmth](https://github.com/ajsmth))
 - Fix app.config not generated. ([#13667](https://github.com/expo/expo/pull/13667) by [@kudo](https://github.com/kudo))
+- Fix build phase error in xcode for nodejs possibly not found in nvm. ([#14047](https://github.com/expo/expo/pull/14047) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-constants/ios/EXConstants.podspec
+++ b/packages/expo-constants/ios/EXConstants.podspec
@@ -24,7 +24,7 @@ Pod::Spec.new do |s|
 
   s.script_phase = {
     :name => 'Generate app.config for prebuilt Constants.manifest',
-    :script => '$PODS_TARGET_SRCROOT/../scripts/get-app-config-ios.sh',
+    :script => 'bash -l -c "$PODS_TARGET_SRCROOT/../scripts/get-app-config-ios.sh"',
     :execution_position => :before_compile
   }
 


### PR DESCRIPTION
# Why

if user does not install nodejs by homebrew but something like nvm or volta. typically these will setup shell `$PATH`. however, building in [xcode does not honor login shell rc file](https://mgrebenets.github.io/xcode/2019/04/04/xcode-build-phases-and-environment) and getting errors for nodejs not found.

# How

execute the script with `bash -l` that will honor login shell settings.

# Test Plan

pass building bare-expo and expo-go in xcode.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).