### PR TITLE
[docs] Improve wording about app.json settings for Google Sign-in

### DIFF
--- a/docs/pages/versions/unversioned/sdk/google-sign-in.md
+++ b/docs/pages/versions/unversioned/sdk/google-sign-in.md
@@ -27,9 +27,12 @@ When using Firebase, also configure the Google-services configuration files:
 3. (**Android only**) Go to your Firebase project's settings, scroll down to "Your apps" and select your Android app. Under `SHA certificate fingerprints`, click `Add fingerprint`, and paste the value of you get for `Google Certificate Fingerprint` when running `expo fetch:android:hashes`.
    > If you haven't already run `expo build:android` for this project, you'll need to do that first before getting the Google Certificate Fingerprint.
 4. Download the `GoogleService-Info.plist` (iOS) & the `google-services.json` (Android) from your Firebase project settings page. Move them to your Expo project.
-5. In `app.json`, set your `expo.ios.config.googleSignIn.reservedClientId` to the value of `REVERSED_CLIENT_ID` in the `GoogleService-Info.plist`.
-6. Also in `app.json`, set `expo.ios.googleServicesFile` to the relative path of your `GoogleService-Info.plist`. Make sure the file is located somewhere in your Expo project.
-7. And also in `app.json`, set `expo.android.googleServicesFile` to the relative path of your `google-services.json`. Make sure the file is located somewhere in your Expo project.
+5. Modify `app.json`:
+   - For iOS
+     - Set your `expo.ios.config.googleSignIn.reservedClientId` to the value of `REVERSED_CLIENT_ID` in the `GoogleService-Info.plist`.
+     - Set `expo.ios.googleServicesFile` to the relative path of your `GoogleService-Info.plist`. Make sure the file is located somewhere in your Expo project.
+   - For Android
+     - Set `expo.android.googleServicesFile` to the relative path of your `google-services.json`. Make sure the file is located somewhere in your Expo project.
 
 ```js
  // app.json

--- a/docs/pages/versions/unversioned/sdk/google-sign-in.md
+++ b/docs/pages/versions/unversioned/sdk/google-sign-in.md
@@ -16,7 +16,7 @@ For [managed](../../../introduction/managed-vs-bare.md#managed-workflow) apps, y
 ## Configuration
 
 1. Go to your `app.json` and make sure you define your `ios.bundleIdentifier` and the `android.package` you want to use.
-2. In `app.json`, set `expo.ios.config.googleSignIn.reservedClientId` to your reversed client ID.
+2. For iOS also set `expo.ios.config.googleSignIn.reservedClientId` to your reversed client ID.
 
 ### Usage with Firebase
 

--- a/docs/pages/versions/unversioned/sdk/google-sign-in.md
+++ b/docs/pages/versions/unversioned/sdk/google-sign-in.md
@@ -16,7 +16,7 @@ For [managed](../../../introduction/managed-vs-bare.md#managed-workflow) apps, y
 ## Configuration
 
 1. Go to your `app.json` and make sure you define your `ios.bundleIdentifier` and the `android.package` you want to use.
-2. For iOS also set `expo.ios.config.googleSignIn.reservedClientId` to your reversed client ID.
+2. For iOS, also set `expo.ios.config.googleSignIn.reservedClientId` to your reversed client ID.
 
 ### Usage with Firebase
 


### PR DESCRIPTION
Original wording does not bring attention to the fact that this is an ios-only settings. The only way to conclude that is to read the json path, which is easily ignored in favor of copy/pasting. The words "Reversed client id" don't mean much to an Android developer and can lead to confusion.

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] ~This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).~
- [ ] ~This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).~