### PR TITLE
[splash-screen] monitor rootViewController re-show splash if needed

### DIFF
--- a/packages/expo-splash-screen/CHANGELOG.md
+++ b/packages/expo-splash-screen/CHANGELOG.md
@@ -7,6 +7,8 @@
 ### 🎉 New features
 
 - Add warning for splash screen if visible for too long ([#12882](https://github.com/expo/expo/pull/12882) by [@ajsmth](https://github.com/ajsmth))
+- Re-show splash screen if rootViewController be replaced when splash is showing. ([#14063](https://github.com/expo/expo/pull/14063) by [@kudo](https://github.com/kudo))
+
 ### 🐛 Bug fixes
 
 - On iOS, search for a view controller with a RCTRootView rather than always using the keyWindow's rootViewController. ([#13429](https://github.com/expo/expo/pull/13429) by [@esamelson](https://github.com/esamelson))

--- a/packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenService.m
+++ b/packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenService.m
@@ -93,8 +93,16 @@ UM_REGISTER_SINGLETON_MODULE(SplashScreen);
 
   UM_WEAKIFY(self);
   return [splashScreenViewController
-          hideWithCallback:^(BOOL hasEffect) { UM_ENSURE_STRONGIFY(self); [self.splashScreenControllers removeObjectForKey:viewController]; }
-          failureCallback:^(NSString *message) { UM_ENSURE_STRONGIFY(self); [self.splashScreenControllers removeObjectForKey:viewController]; }];
+      hideWithCallback:^(BOOL hasEffect) {
+        UM_ENSURE_STRONGIFY(self);
+        [self.splashScreenControllers removeObjectForKey:viewController];
+        successCallback(hasEffect);
+      }
+      failureCallback:^(NSString *message) {
+        UM_ENSURE_STRONGIFY(self);
+        [self.splashScreenControllers removeObjectForKey:viewController];
+        failureCallback(message);
+      }];
 }
 
 - (void)onAppContentDidAppear:(UIViewController *)viewController

--- a/packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenViewController.h
+++ b/packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenViewController.h
@@ -17,8 +17,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)showWithCallback:(void (^)(void))successCallback failureCallback:(void (^)(NSString *message))failureCallback;
 - (void)preventAutoHideWithCallback:(void (^)(BOOL hasEffect))successCallback failureCallback:(void (^)(NSString *message))failureCallback;
 - (void)hideWithCallback:(void (^)(BOOL hasEffect))successCallback failureCallback:(void (^)(NSString *message))failureCallback;
-- (void)onAppContentDidAppear;
-- (void)onAppContentWillReload;
+- (BOOL)needsHideOnAppContentDidAppear;
+- (BOOL)needsShowOnAppContentWillReload;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenViewController.m
+++ b/packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenViewController.m
@@ -81,21 +81,23 @@
   });
 }
 
-- (void)onAppContentDidAppear
+- (BOOL)needsHideOnAppContentDidAppear
 {
   if (!_appContentAppeared && _autoHideEnabled) {
     _appContentAppeared = YES;
-    [self hideWithCallback:nil];
+    return YES;
   }
+  return NO;
 }
 
-- (void)onAppContentWillReload
+- (BOOL)needsShowOnAppContentWillReload
 {
   if (!_appContentAppeared) {
     _autoHideEnabled = YES;
     _appContentAppeared = NO;
-    [self showWithCallback:nil];
+    return YES;
   }
+  return NO;
 }
 
 @end


### PR DESCRIPTION
# Why

modularize expo-splash-screen and reduce additional code setup.

currently on ios, we had [splash screen code in our template](https://github.com/expo/expo/blob/265636c5ed9c71c0c00318c791776ebab43a7813/templates/expo-template-bare-minimum/ios/HelloWorld/AppDelegate.m#L102-L103). this is necessary for expo-updates b/c expo-updates' `startAndShowLaunchScreen` will reset `rootViewController` and make splash screen dismissed. if we remove these two lines in template, this will break `SplashScreen.preventAutoHideAsync()` and make splash screen dismissed immediately.  (thanks @bbarthec and @esamelson shared the insight with me).

# How

if splash screen is showing, monitor `rootViewController` by KVO and re-show splash screen again.

besides that, has some refactoring for auto hiding splash case to remove the `NSMapTable` entry. although this is weak reference table, this refactoring makes code flow to be unified.

note that the KVO might not work with swift. if we are going to migrate expo-splash-screen to swift, we might seek for alternatives like expo-updates posting notification by NSNotificationCenter when replacing the `rootViewController`. personally, i like the KVO approach right now b/c expo-splash-screen does not couple with any information from expo-updates.
 
# Test Plan

during the expo-modules-core migration time, it's hard to test template, so i had a local test to reference the template. something like that:

```shell
$ expo init -t /path/to/expo/expo/templates/expo-template-bare-minimum EXSplashScreenTest
$ yarn add /path/to/expo/expo/packages/expo-modules-core
$ yarn add /path/to/expo/expo/packages/expo-splash-screen
# in App.js, add `SplashScreen.preventAutoHideAsync()` and call in `SplashScreen.hideAsync` after 5 seconds.
# remove splash screen code in `ios/EXSplashScreenTest/AppDelegate.m`
```

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).