### PR TITLE
[dev-client][android] Fix compatibility with RN 0.65

### DIFF
--- a/packages/expo-dev-launcher/android/build.gradle
+++ b/packages/expo-dev-launcher/android/build.gradle
@@ -53,7 +53,7 @@ android {
   }
 
   sourceSets {
-    debug {
+    main {
       java {
         def rnVersion = getRNVersion()
 

--- a/packages/expo-dev-launcher/android/build.gradle
+++ b/packages/expo-dev-launcher/android/build.gradle
@@ -1,3 +1,5 @@
+import groovy.json.JsonSlurper
+
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'maven'
@@ -51,6 +53,17 @@ android {
   }
 
   sourceSets {
+    debug {
+      java {
+        def rnVersion = getRNVersion()
+
+        if (rnVersion >= versionToNumber(0, 65, 0)) {
+          srcDirs += "src/react-native-65"
+        } else {
+          srcDirs += 'src/react-native-64'
+        }
+      }
+    }
     releaseWithDevLauncher {
       setRoot 'src/debug'
     }
@@ -119,4 +132,24 @@ configurations.all {
       details.useVersion safeExtGet('kotlinVersion', '1.4.21')
     }
   }
+}
+
+def versionToNumber(major, minor, patch) {
+  return patch * 100 + minor * 10000 + major * 1000000
+}
+
+def getRNVersion() {
+  def packageJsonFile = new File(rootProject.projectDir, '../package.json')
+  def packageJson = new JsonSlurper().parseText(packageJsonFile.text)
+  def version = safeExtGet("reactNativeVersion", packageJson.dependencies["react-native"])
+
+  def coreVersion = version.split("-")[0]
+
+  def (major, minor, patch) = coreVersion.tokenize('.').collect { it.toInteger() }
+
+  return versionToNumber(
+      major,
+      minor,
+      patch
+  )
 }

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/manifest/DevLauncherManifestParser.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/manifest/DevLauncherManifestParser.kt
@@ -24,6 +24,7 @@ class DevLauncherManifestParser(
     if (!response.isSuccessful) {
       throw Exception("Failed to open app.\n\nIf you are trying to load the app from a development server, check your network connectivity and make sure you can access the server from your device.\n\nIf you are trying to open a published project, install a compatible version of expo-updates and follow all setup and integration steps.")
     }
+    @Suppress("DEPRECATION_ERROR")
     return response.body()!!.charStream()
   }
 

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/react/DevLauncherDevSupportManagerSwapper.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/react/DevLauncherDevSupportManagerSwapper.kt
@@ -8,6 +8,7 @@ import com.facebook.react.devsupport.DisabledDevSupportManager
 import com.facebook.react.packagerconnection.JSPackagerClient
 import expo.modules.devlauncher.helpers.getProtectedFieldValue
 import expo.modules.devlauncher.helpers.setProtectedDeclaredField
+import expo.modules.devlauncher.rncompatibility.DevLauncherDevSupportManager
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -25,7 +26,7 @@ class DevLauncherDevSupportManagerSwapper {
       val devManagerClass = DevSupportManagerBase::class.java
       val newDevSupportManager = DevLauncherDevSupportManager(
         applicationContext = devManagerClass.getProtectedFieldValue(currentDevSupportManager, "mApplicationContext"),
-        reactInstanceManagerHelper = devManagerClass.getProtectedFieldValue(currentDevSupportManager, "mReactInstanceManagerHelper"),
+        reactInstanceManagerHelper = devManagerClass.getProtectedFieldValue(currentDevSupportManager, DevLauncherDevSupportManager.getDevHelperInternalFieldName()),
         packagerPathForJSBundleName = devManagerClass.getProtectedFieldValue(currentDevSupportManager, "mJSAppBundleName"),
         enableOnCreate = true,
         redBoxHandler = devManagerClass.getProtectedFieldValue(currentDevSupportManager, "mRedBoxHandler"),

--- a/packages/expo-dev-launcher/android/src/react-native-64/expo/modules/devlauncher/rncompatibility/DevLauncherDevSupportManager.kt
+++ b/packages/expo-dev-launcher/android/src/react-native-64/expo/modules/devlauncher/rncompatibility/DevLauncherDevSupportManager.kt
@@ -1,4 +1,4 @@
-package expo.modules.devlauncher.react
+package expo.modules.devlauncher.rncompatibility
 
 import android.content.Context
 import android.util.Log
@@ -48,5 +48,9 @@ class DevLauncherDevSupportManager(
 
     controller.onAppLoadedWithError()
     DevLauncherErrorActivity.showError(activity, DevLauncherAppError(message, e))
+  }
+
+  companion object {
+    fun getDevHelperInternalFieldName() = "mReactInstanceManagerHelper"
   }
 }

--- a/packages/expo-dev-launcher/android/src/react-native-65/expo/modules/devlauncher/rncompatibility/DevLauncherDevSupportManager.kt
+++ b/packages/expo-dev-launcher/android/src/react-native-65/expo/modules/devlauncher/rncompatibility/DevLauncherDevSupportManager.kt
@@ -1,0 +1,56 @@
+package expo.modules.devlauncher.rncompatibility
+
+import android.content.Context
+import android.util.Log
+import com.facebook.react.devsupport.DevSupportManagerBase
+import com.facebook.react.devsupport.ReactInstanceDevHelper
+import com.facebook.react.devsupport.RedBoxHandler
+import com.facebook.react.devsupport.interfaces.DevBundleDownloadListener
+import com.facebook.react.packagerconnection.RequestHandler
+import expo.modules.devlauncher.DevLauncherController
+import expo.modules.devlauncher.koin.DevLauncherKoinComponent
+import expo.modules.devlauncher.launcher.DevLauncherControllerInterface
+import expo.modules.devlauncher.launcher.errors.DevLauncherAppError
+import expo.modules.devlauncher.launcher.errors.DevLauncherErrorActivity
+import org.koin.core.component.inject
+
+class DevLauncherDevSupportManager(
+    applicationContext: Context?,
+    val reactInstanceManagerHelper: ReactInstanceDevHelper?,
+    packagerPathForJSBundleName: String?,
+    enableOnCreate: Boolean,
+    redBoxHandler: RedBoxHandler?,
+    devBundleDownloadListener: DevBundleDownloadListener?,
+    minNumShakes: Int,
+    customPackagerCommandHandlers: MutableMap<String, RequestHandler>?
+) : DevSupportManagerBase(
+    applicationContext,
+    reactInstanceManagerHelper,
+    packagerPathForJSBundleName,
+    enableOnCreate,
+    redBoxHandler,
+    devBundleDownloadListener,
+    minNumShakes,
+    customPackagerCommandHandlers
+), DevLauncherKoinComponent {
+  private val controller: DevLauncherControllerInterface by inject()
+  override fun showNewJavaError(message: String?, e: Throwable) {
+    if (!DevLauncherController.wasInitialized()) {
+      Log.e("DevLauncher", "DevLauncher wasn't initialized. Couldn't intercept native error handling.")
+      super.showNewJavaError(message, e)
+      return
+    }
+
+    val activity = reactInstanceManagerHelper?.currentActivity
+    if (activity == null || activity.isFinishing || activity.isDestroyed) {
+      return
+    }
+
+    controller.onAppLoadedWithError()
+    DevLauncherErrorActivity.showError(activity, DevLauncherAppError(message, e))
+  }
+
+  companion object {
+    fun getDevHelperInternalFieldName() = "mReactInstanceDevHelper"
+  }
+}

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/api/DevMenuExpoApiClient.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/api/DevMenuExpoApiClient.kt
@@ -79,7 +79,7 @@ class DevMenuExpoApiClient : DevMenuExpoApiClientInterface {
     ).await(httpClient)
 
     return Response(
-      status = okHttpResponse.code(),
+      status = @Suppress("DEPRECATION_ERROR") okHttpResponse.code(),
       data = parseGraphQLResponse(okHttpResponse, "data", "app", "byId", "updateChannels")
     )
   }
@@ -112,7 +112,7 @@ class DevMenuExpoApiClient : DevMenuExpoApiClientInterface {
     ).await(httpClient)
 
     return Response(
-      status = okHttpResponse.code(),
+      status = @Suppress("DEPRECATION_ERROR") okHttpResponse.code(),
       data = parseGraphQLResponse(okHttpResponse, "data", "app", "byId", "updateBranches")
     )
   }
@@ -125,7 +125,7 @@ class DevMenuExpoApiClient : DevMenuExpoApiClientInterface {
     if (!okHttpResponse.isSuccessful) {
       return null
     }
-
+    @Suppress("DEPRECATION_ERROR")
     val bodyReader = okHttpResponse.body()?.charStream()?.readText() ?: return null
     val gson = Gson()
     var json: JsonElement = gson.fromJson(bodyReader, JsonObject::class.java)

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/helpers/DevMenuOkHttpExtension.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/helpers/DevMenuOkHttpExtension.kt
@@ -54,6 +54,7 @@ fun fetchGraphQL(url: Uri, query: String, authHeader: Pair<String, String>? = nu
     .url(url.toString())
     .method(
       "POST",
+      @Suppress("DEPRECATION_ERROR")
       RequestBody.create(MediaType.parse("application/json"), "{\"query\": \"${
         query
           .trimIndent()

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/modules/DevMenuModule.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/modules/DevMenuModule.kt
@@ -42,6 +42,7 @@ class DevMenuModule(reactContext: ReactApplicationContext) :
           .getExpoApiClient()
           .queryMyProjects()
           .use {
+            @Suppress("DEPRECATION_ERROR")
             promise.resolve(it.body()?.charStream()?.readText() ?: "")
           }
       } catch (e: Exception) {
@@ -58,6 +59,7 @@ class DevMenuModule(reactContext: ReactApplicationContext) :
           .getExpoApiClient()
           .queryDevSessions()
           .use {
+            @Suppress("DEPRECATION_ERROR")
             promise.resolve(it.body()?.charStream()?.readText() ?: "")
           }
       } catch (e: Exception) {


### PR DESCRIPTION
# Why

Closes ENG-1752.
Fixes https://github.com/expo/expo/issues/13928.

# How

- Fixes problems with `okhttp` - suppressing deprecation warnings. 
- Fixes problems with `ReactInstanceManagerDevHelper` - this class was renamed. We can't use reflection here, cause we need to use it when calling the super constructor. So I've added separate source files for that class and only one of them is included (depends on the RN version).

# Test Plan

- simple project with RN 0.65-rc.4 and with 0.64.2 ✅