### PR TITLE
[dev-menu][android] Fix `Only fullscreen opaque activities can request orientation`

### DIFF
--- a/packages/expo-dev-menu/android/src/main/AndroidManifest.xml
+++ b/packages/expo-dev-menu/android/src/main/AndroidManifest.xml
@@ -4,7 +4,6 @@
   <application>
     <activity
       android:name=".DevMenuActivity"
-      android:screenOrientation="portrait"
       android:theme="@style/Theme.AppCompat.Transparent.NoActionBar"
       android:launchMode="singleTask">
     <intent-filter>

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/DevMenuActivity.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/DevMenuActivity.kt
@@ -1,6 +1,8 @@
 package expo.modules.devmenu
 
 import android.content.Context
+import android.content.pm.ActivityInfo
+import android.os.Build
 import android.os.Bundle
 import android.view.KeyEvent
 import android.view.ViewGroup
@@ -67,6 +69,18 @@ class DevMenuActivity : ReactActivity() {
 
       override fun createRootView() = createRootView(this@DevMenuActivity)
     }
+  }
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    // Due to a bug in API 26, we can't set the orientation in translucent activity.
+    // See https://stackoverflow.com/questions/48072438/java-lang-illegalstateexception-only-fullscreen-opaque-activities-can-request-o
+    requestedOrientation = if (Build.VERSION.SDK_INT == Build.VERSION_CODES.O) {
+      ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
+    } else {
+      ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+    }
+
+    super.onCreate(savedInstanceState)
   }
 
   override fun onKeyUp(keyCode: Int, event: KeyEvent): Boolean {


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/13965.
Closes ENG-1795.

# How

Due to an issue with API 26, we can't request orientation when the activity is translucent. Unfortunately, this isn't an ideal solution, cause on API 26 users may open the dev-menu in landscape orientation. There may be some visual bugs. So in the future, we may want to add support for landscape orientation. For now, I removed crashes. 

# Test Plan

- new project with dev-menu ✅