### PR TITLE
[expo] Update homepage paths to expo.dev

### DIFF
--- a/packages/expo-ads-admob/package.json
+++ b/packages/expo-ads-admob/package.json
@@ -30,7 +30,7 @@
   "bugs": {
     "url": "https://github.com/expo/expo/issues"
   },
-  "homepage": "https://docs.expo.io/versions/latest/sdk/admob/",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/admob/",
   "jest": {
     "preset": "expo-module-scripts/ios"
   },

--- a/packages/expo-ads-facebook/package.json
+++ b/packages/expo-ads-facebook/package.json
@@ -29,7 +29,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/facebook-ads/",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/facebook-ads/",
   "dependencies": {
     "@expo/config-plugins": "^3.0.0",
     "expo-modules-core": "~0.1.1",

--- a/packages/expo-analytics-amplitude/package.json
+++ b/packages/expo-analytics-amplitude/package.json
@@ -32,7 +32,7 @@
   "jest": {
     "preset": "expo-module-scripts"
   },
-  "homepage": "https://docs.expo.io/versions/latest/sdk/amplitude/",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/amplitude/",
   "dependencies": {
     "expo-modules-core": "~0.1.1"
   },

--- a/packages/expo-analytics-segment/package.json
+++ b/packages/expo-analytics-segment/package.json
@@ -30,7 +30,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/segment/",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/segment/",
   "jest": {
     "preset": "expo-module-scripts"
   },

--- a/packages/expo-app-auth/package.json
+++ b/packages/expo-app-auth/package.json
@@ -39,7 +39,7 @@
   ],
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/app-auth/",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/app-auth/",
   "jest": {
     "preset": "expo-module-scripts"
   },

--- a/packages/expo-app-loading/package.json
+++ b/packages/expo-app-loading/package.json
@@ -29,7 +29,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/app-loading",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/app-loading",
   "unimodulePeerDependencies": {
     "@unimodules/core": "*"
   },

--- a/packages/expo-apple-authentication/package.json
+++ b/packages/expo-apple-authentication/package.json
@@ -30,7 +30,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/apple-authentication/",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/apple-authentication/",
   "dependencies": {
     "@expo/config-plugins": "^3.0.0",
     "expo-modules-core": "~0.1.1"

--- a/packages/expo-application/package.json
+++ b/packages/expo-application/package.json
@@ -28,7 +28,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/application/",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/application/",
   "devDependencies": {
     "expo-module-scripts": "^2.0.0"
   }

--- a/packages/expo-asset/package.json
+++ b/packages/expo-asset/package.json
@@ -32,7 +32,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/asset/",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/asset/",
   "jest": {
     "preset": "expo-module-scripts/ios"
   },

--- a/packages/expo-auth-session/package.json
+++ b/packages/expo-auth-session/package.json
@@ -32,7 +32,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/auth-session",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/auth-session",
   "dependencies": {
     "expo-constants": "~11.0.0",
     "expo-crypto": "~9.2.0",

--- a/packages/expo-av/package.json
+++ b/packages/expo-av/package.json
@@ -30,7 +30,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/av/",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/av/",
   "dependencies": {
     "@expo/config-plugins": "^3.0.0",
     "expo-modules-core": "~0.1.1"

--- a/packages/expo-background-fetch/package.json
+++ b/packages/expo-background-fetch/package.json
@@ -31,7 +31,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/background-fetch/",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/background-fetch/",
   "dependencies": {
     "@expo/config-plugins": "^3.0.0",
     "expo-modules-core": "~0.1.1",

--- a/packages/expo-barcode-scanner/package.json
+++ b/packages/expo-barcode-scanner/package.json
@@ -30,7 +30,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/bar-code-scanner/",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/bar-code-scanner/",
   "jest": {
     "preset": "expo-module-scripts/ios"
   },

--- a/packages/expo-battery/package.json
+++ b/packages/expo-battery/package.json
@@ -28,7 +28,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/battery/",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/battery/",
   "dependencies": {
     "expo-modules-core": "~0.1.1"
   },

--- a/packages/expo-blur/package.json
+++ b/packages/expo-blur/package.json
@@ -32,7 +32,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/blur-view/",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/blur-view/",
   "dependencies": {
     "expo-modules-core": "~0.1.1"
   },

--- a/packages/expo-branch/package.json
+++ b/packages/expo-branch/package.json
@@ -30,7 +30,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/branch/",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/branch/",
   "dependencies": {
     "@expo/config-plugins": "^3.0.0",
     "expo-modules-core": "~0.1.1",

--- a/packages/expo-brightness/package.json
+++ b/packages/expo-brightness/package.json
@@ -30,7 +30,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/brightness/",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/brightness/",
   "jest": {
     "preset": "expo-module-scripts"
   },

--- a/packages/expo-calendar/package.json
+++ b/packages/expo-calendar/package.json
@@ -30,7 +30,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/calendar/",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/calendar/",
   "jest": {
     "preset": "expo-module-scripts/ios"
   },

--- a/packages/expo-camera/package.json
+++ b/packages/expo-camera/package.json
@@ -29,7 +29,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/camera/",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/camera/",
   "jest": {
     "preset": "expo-module-scripts"
   },

--- a/packages/expo-cellular/package.json
+++ b/packages/expo-cellular/package.json
@@ -28,7 +28,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/cellular/",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/cellular/",
   "devDependencies": {
     "expo-module-scripts": "^2.0.0"
   }

--- a/packages/expo-checkbox/package.json
+++ b/packages/expo-checkbox/package.json
@@ -28,7 +28,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/checkbox",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/checkbox",
   "devDependencies": {
     "expo-module-scripts": "^2.0.0"
   },

--- a/packages/expo-clipboard/package.json
+++ b/packages/expo-clipboard/package.json
@@ -28,7 +28,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/clipboard",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/clipboard",
   "dependencies": {
     "expo-modules-core": "~0.1.1"
   },

--- a/packages/expo-constants/package.json
+++ b/packages/expo-constants/package.json
@@ -29,7 +29,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/constants/",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/constants/",
   "jest": {
     "preset": "expo-module-scripts"
   },

--- a/packages/expo-contacts/package.json
+++ b/packages/expo-contacts/package.json
@@ -29,7 +29,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/contacts/",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/contacts/",
   "jest": {
     "preset": "expo-module-scripts"
   },

--- a/packages/expo-crypto/package.json
+++ b/packages/expo-crypto/package.json
@@ -34,7 +34,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/crypto/",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/crypto/",
   "jest": {
     "preset": "expo-module-scripts"
   },

--- a/packages/expo-dev-client/package.json
+++ b/packages/expo-dev-client/package.json
@@ -28,7 +28,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/clients/introduction/",
+  "homepage": "https://docs.expo.dev/clients/introduction/",
   "dependencies": {
     "@expo/config-plugins": "^3.0.0",
     "expo-dev-launcher": "0.6.7",

--- a/packages/expo-device/package.json
+++ b/packages/expo-device/package.json
@@ -31,7 +31,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/device/",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/device/",
   "dependencies": {
     "expo-modules-core": "~0.1.1",
     "ua-parser-js": "^0.7.19"

--- a/packages/expo-document-picker/package.json
+++ b/packages/expo-document-picker/package.json
@@ -30,7 +30,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/document-picker/",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/document-picker/",
   "jest": {
     "preset": "expo-module-scripts/ios"
   },

--- a/packages/expo-error-recovery/package.json
+++ b/packages/expo-error-recovery/package.json
@@ -30,7 +30,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/error-recovery/",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/error-recovery/",
   "dependencies": {
     "expo-modules-core": "~0.1.1"
   },

--- a/packages/expo-face-detector/package.json
+++ b/packages/expo-face-detector/package.json
@@ -31,7 +31,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/facedetector/",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/facedetector/",
   "jest": {
     "preset": "expo-module-scripts/ios"
   },

--- a/packages/expo-facebook/package.json
+++ b/packages/expo-facebook/package.json
@@ -29,7 +29,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/facebook/",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/facebook/",
   "jest": {
     "preset": "expo-module-scripts"
   },

--- a/packages/expo-file-system/package.json
+++ b/packages/expo-file-system/package.json
@@ -30,7 +30,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/filesystem/",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/filesystem/",
   "jest": {
     "preset": "expo-module-scripts"
   },

--- a/packages/expo-firebase-analytics/package.json
+++ b/packages/expo-firebase-analytics/package.json
@@ -31,7 +31,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/firebase-analytics/",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/firebase-analytics/",
   "jest": {
     "preset": "expo-module-scripts"
   },

--- a/packages/expo-firebase-core/package.json
+++ b/packages/expo-firebase-core/package.json
@@ -29,7 +29,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/firebase-core",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/firebase-core",
   "unimodulePeerDependencies": {
     "@unimodules/core": "*",
     "expo-constants": "*"

--- a/packages/expo-firebase-recaptcha/package.json
+++ b/packages/expo-firebase-recaptcha/package.json
@@ -31,7 +31,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/firebase-recaptcha/",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/firebase-recaptcha/",
   "devDependencies": {
     "expo-module-scripts": "^2.0.0"
   },

--- a/packages/expo-font/package.json
+++ b/packages/expo-font/package.json
@@ -29,7 +29,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/font/",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/font/",
   "jest": {
     "preset": "expo-module-scripts"
   },

--- a/packages/expo-gl-cpp/package.json
+++ b/packages/expo-gl-cpp/package.json
@@ -24,5 +24,5 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/gl-view/"
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/gl-view/"
 }

--- a/packages/expo-gl/package.json
+++ b/packages/expo-gl/package.json
@@ -30,7 +30,7 @@
   "bugs": {
     "url": "https://github.com/expo/expo/issues"
   },
-  "homepage": "https://docs.expo.io/versions/latest/sdk/gl-view/",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/gl-view/",
   "author": "650 Industries, Inc.",
   "license": "MIT",
   "jest": {

--- a/packages/expo-google-app-auth/package.json
+++ b/packages/expo-google-app-auth/package.json
@@ -29,7 +29,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/google/",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/google/",
   "jest": {
     "preset": "expo-module-scripts"
   },

--- a/packages/expo-google-sign-in/package.json
+++ b/packages/expo-google-sign-in/package.json
@@ -36,7 +36,7 @@
   ],
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/google-sign-in/",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/google-sign-in/",
   "jest": {
     "preset": "expo-module-scripts/ios"
   },

--- a/packages/expo-haptics/package.json
+++ b/packages/expo-haptics/package.json
@@ -30,7 +30,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/haptics/",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/haptics/",
   "unimodulePeerDependencies": {
     "@unimodules/core": "*"
   },

--- a/packages/expo-image-manipulator/package.json
+++ b/packages/expo-image-manipulator/package.json
@@ -29,7 +29,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/imagemanipulator/",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/imagemanipulator/",
   "dependencies": {
     "expo-modules-core": "~0.1.1"
   },

--- a/packages/expo-image-picker/package.json
+++ b/packages/expo-image-picker/package.json
@@ -31,7 +31,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/imagepicker/",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/imagepicker/",
   "jest": {
     "preset": "expo-module-scripts"
   },

--- a/packages/expo-image/package.json
+++ b/packages/expo-image/package.json
@@ -15,7 +15,7 @@
     "prepublishOnly": "expo-module prepublishOnly",
     "expo-module": "expo-module"
   },
-  "homepage": "https://docs.expo.io/versions/latest/sdk/image/",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/image/",
   "repository": {
     "type": "git",
     "url": "https://github.com/expo/expo.git",

--- a/packages/expo-in-app-purchases/package.json
+++ b/packages/expo-in-app-purchases/package.json
@@ -28,7 +28,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/in-app-purchases/",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/in-app-purchases/",
   "devDependencies": {
     "expo-module-scripts": "^2.0.0"
   }

--- a/packages/expo-intent-launcher/package.json
+++ b/packages/expo-intent-launcher/package.json
@@ -31,7 +31,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/intent-launcher/",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/intent-launcher/",
   "unimodulePeerDependencies": {
     "@unimodules/core": "*"
   },

--- a/packages/expo-keep-awake/package.json
+++ b/packages/expo-keep-awake/package.json
@@ -30,7 +30,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/keep-awake/",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/keep-awake/",
   "devDependencies": {
     "expo-module-scripts": "^2.0.0"
   }

--- a/packages/expo-linear-gradient/package.json
+++ b/packages/expo-linear-gradient/package.json
@@ -32,7 +32,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/linear-gradient/",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/linear-gradient/",
   "dependencies": {
     "expo-modules-core": "~0.1.1"
   },

--- a/packages/expo-linking/package.json
+++ b/packages/expo-linking/package.json
@@ -28,7 +28,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/linking",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/linking",
   "dependencies": {
     "expo-constants": "~11.0.0",
     "invariant": "^2.2.4",

--- a/packages/expo-local-authentication/package.json
+++ b/packages/expo-local-authentication/package.json
@@ -33,7 +33,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/local-authentication/",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/local-authentication/",
   "jest": {
     "preset": "expo-module-scripts"
   },

--- a/packages/expo-localization/package.json
+++ b/packages/expo-localization/package.json
@@ -34,7 +34,7 @@
   ],
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/localization/",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/localization/",
   "jest": {
     "preset": "expo-module-scripts"
   },

--- a/packages/expo-location/package.json
+++ b/packages/expo-location/package.json
@@ -34,7 +34,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/location/",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/location/",
   "jest": {
     "preset": "expo-module-scripts"
   },

--- a/packages/expo-mail-composer/package.json
+++ b/packages/expo-mail-composer/package.json
@@ -30,7 +30,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/mail-composer/",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/mail-composer/",
   "jest": {
     "preset": "expo-module-scripts/ios"
   },

--- a/packages/expo-media-library/package.json
+++ b/packages/expo-media-library/package.json
@@ -33,7 +33,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/media-library/",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/media-library/",
   "jest": {
     "preset": "expo-module-scripts"
   },

--- a/packages/expo-module-template/package.json
+++ b/packages/expo-module-template/package.json
@@ -22,5 +22,5 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/module-template"
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/module-template"
 }

--- a/packages/expo-network/package.json
+++ b/packages/expo-network/package.json
@@ -28,7 +28,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/network/",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/network/",
   "dependencies": {
     "expo-modules-core": "~0.1.1"
   },

--- a/packages/expo-notifications/package.json
+++ b/packages/expo-notifications/package.json
@@ -32,7 +32,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/notifications/",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/notifications/",
   "jest": {
     "preset": "expo-module-scripts/ios"
   },

--- a/packages/expo-payments-stripe/package.json
+++ b/packages/expo-payments-stripe/package.json
@@ -31,7 +31,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/payments/",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/payments/",
   "dependencies": {
     "@expo/config-plugins": "^3.0.0",
     "prop-types": "^15.6.0"

--- a/packages/expo-permissions/package.json
+++ b/packages/expo-permissions/package.json
@@ -29,7 +29,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/permissions/",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/permissions/",
   "jest": {
     "preset": "expo-module-scripts/ios"
   },

--- a/packages/expo-print/package.json
+++ b/packages/expo-print/package.json
@@ -29,7 +29,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/print/",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/print/",
   "jest": {
     "preset": "expo-module-scripts/ios"
   },

--- a/packages/expo-random/package.json
+++ b/packages/expo-random/package.json
@@ -34,7 +34,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/random/",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/random/",
   "jest": {
     "preset": "expo-module-scripts"
   },

--- a/packages/expo-screen-capture/package.json
+++ b/packages/expo-screen-capture/package.json
@@ -28,7 +28,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/screen-capture",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/screen-capture",
   "dependencies": {
     "@unimodules/core": "~7.1.1"
   },

--- a/packages/expo-screen-orientation/package.json
+++ b/packages/expo-screen-orientation/package.json
@@ -31,7 +31,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/screen-orientation/",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/screen-orientation/",
   "jest": {
     "preset": "expo-module-scripts"
   },

--- a/packages/expo-secure-store/package.json
+++ b/packages/expo-secure-store/package.json
@@ -31,7 +31,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/securestore/",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/securestore/",
   "jest": {
     "preset": "expo-module-scripts"
   },

--- a/packages/expo-sensors/package.json
+++ b/packages/expo-sensors/package.json
@@ -35,7 +35,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/sensors/",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/sensors/",
   "jest": {
     "preset": "expo-module-scripts"
   },

--- a/packages/expo-sharing/package.json
+++ b/packages/expo-sharing/package.json
@@ -29,7 +29,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/sharing/",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/sharing/",
   "dependencies": {
     "expo-modules-core": "~0.1.1"
   },

--- a/packages/expo-sms/package.json
+++ b/packages/expo-sms/package.json
@@ -29,7 +29,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/sms/",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/sms/",
   "jest": {
     "preset": "expo-module-scripts/ios"
   },

--- a/packages/expo-speech/package.json
+++ b/packages/expo-speech/package.json
@@ -31,7 +31,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/speech/",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/speech/",
   "jest": {
     "preset": "expo-module-scripts/ios"
   },

--- a/packages/expo-splash-screen/package.json
+++ b/packages/expo-splash-screen/package.json
@@ -32,7 +32,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/splash-screen/",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/splash-screen/",
   "unimodulePeerDependencies": {
     "@unimodules/core": "*"
   },

--- a/packages/expo-sqlite/package.json
+++ b/packages/expo-sqlite/package.json
@@ -31,7 +31,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/sqlite/",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/sqlite/",
   "jest": {
     "preset": "expo-module-scripts/ios"
   },

--- a/packages/expo-status-bar/package.json
+++ b/packages/expo-status-bar/package.json
@@ -28,7 +28,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/status-bar/",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/status-bar/",
   "devDependencies": {
     "expo-module-scripts": "^2.0.0"
   },

--- a/packages/expo-store-review/package.json
+++ b/packages/expo-store-review/package.json
@@ -28,7 +28,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/storereview/",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/storereview/",
   "dependencies": {
     "expo-modules-core": "~0.1.1"
   },

--- a/packages/expo-task-manager/package.json
+++ b/packages/expo-task-manager/package.json
@@ -31,7 +31,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/task-manager/",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/task-manager/",
   "dependencies": {
     "@expo/config-plugins": "^3.0.0",
     "expo-modules-core": "~0.1.1",

--- a/packages/expo-tracking-transparency/package.json
+++ b/packages/expo-tracking-transparency/package.json
@@ -28,7 +28,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/module-template",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/module-template",
   "dependencies": {
     "@expo/config-plugins": "^3.0.0",
     "expo-modules-core": "~0.1.1"

--- a/packages/expo-updates-interface/package.json
+++ b/packages/expo-updates-interface/package.json
@@ -18,5 +18,5 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/module-template"
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/module-template"
 }

--- a/packages/expo-updates/package.json
+++ b/packages/expo-updates/package.json
@@ -29,7 +29,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/updates/",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/updates/",
   "jest": {
     "preset": "expo-module-scripts"
   },

--- a/packages/expo-video-thumbnails/package.json
+++ b/packages/expo-video-thumbnails/package.json
@@ -28,7 +28,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/video-thumbnails/",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/video-thumbnails/",
   "dependencies": {
     "expo-modules-core": "~0.1.1"
   },

--- a/packages/expo-web-browser/package.json
+++ b/packages/expo-web-browser/package.json
@@ -31,7 +31,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/webbrowser/",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/webbrowser/",
   "jest": {
     "preset": "expo-module-scripts"
   },

--- a/packages/react-native-unimodules/package.json
+++ b/packages/react-native-unimodules/package.json
@@ -31,7 +31,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/bare/installing-unimodules/",
+  "homepage": "https://docs.expo.dev/bare/installing-unimodules/",
   "jest": {
     "preset": "expo-module-scripts/ios"
   },


### PR DESCRIPTION
# Why

We [moved over to expo.dev](https://blog.expo.dev/introducing-expo-dev-a70818bf336e), let's make sure npm knows about that too!

# How

- Updated all `docs.expo.io` references in `package.json`'s `homepage` to `docs.expo.dev`.

# Test Plan

Just a property change to include the right domain in newer packages.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).