### PR TITLE
[apps] Replace `@unimodules/*` imports with `expo-modules-core`

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -1163,7 +1163,7 @@ SPEC CHECKSUMS:
   AppAuth: 31bcec809a638d7bd2f86ea8a52bd45f6e81e7c7
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   CocoaLumberjack: b7e05132ff94f6ae4dfa9d5bce9141893a21d9da
-  DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
+  DoubleConversion: cde416483dac037923206447da6e1454df403714
   EXAmplitude: f0c3dd959d629181c0c2b4bc52717580a539a600
   EXAppAuth: b08cb811e9da25a3e0bde00f7f2f661de81d437e
   EXApplication: 9e62c21a7eeef9e9f65dea359c92d0efee1b3c7a
@@ -1241,7 +1241,7 @@ SPEC CHECKSUMS:
   FirebaseCore: ac35d680a0bf32319a59966a1478e0741536b97b
   FirebaseCoreDiagnostics: 3d36e05da74cb8b7ce30e6594a8f201b982c725c
   FirebaseInstallations: bf2ec8dbf36ff4c91af6b9a003d15855757680c1
-  glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
+  glog: 40a13f7840415b9a77023fbcae0f1e6f43192af3
   GoogleAppMeasurement: 0c3b134b2c0a90c4c24833873894bfe0e42a0384
   GoogleDataTransport: 8b0e733ea77c9218778e5a9e34ba9508b8328939
   GoogleMLKit: 6ca2a10de262ee1017b52ac045e8967884ace992

--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -1163,7 +1163,7 @@ SPEC CHECKSUMS:
   AppAuth: 31bcec809a638d7bd2f86ea8a52bd45f6e81e7c7
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   CocoaLumberjack: b7e05132ff94f6ae4dfa9d5bce9141893a21d9da
-  DoubleConversion: cde416483dac037923206447da6e1454df403714
+  DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   EXAmplitude: f0c3dd959d629181c0c2b4bc52717580a539a600
   EXAppAuth: b08cb811e9da25a3e0bde00f7f2f661de81d437e
   EXApplication: 9e62c21a7eeef9e9f65dea359c92d0efee1b3c7a
@@ -1241,7 +1241,7 @@ SPEC CHECKSUMS:
   FirebaseCore: ac35d680a0bf32319a59966a1478e0741536b97b
   FirebaseCoreDiagnostics: 3d36e05da74cb8b7ce30e6594a8f201b982c725c
   FirebaseInstallations: bf2ec8dbf36ff4c91af6b9a003d15855757680c1
-  glog: 40a13f7840415b9a77023fbcae0f1e6f43192af3
+  glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
   GoogleAppMeasurement: 0c3b134b2c0a90c4c24833873894bfe0e42a0384
   GoogleDataTransport: 8b0e733ea77c9218778e5a9e34ba9508b8328939
   GoogleMLKit: 6ca2a10de262ee1017b52ac045e8967884ace992

--- a/apps/bare-sandbox/package.json
+++ b/apps/bare-sandbox/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@babel/runtime": "^7.5.5",
     "expo": "~42.0.0-alpha.0",
-    "expo-modules-core": "~0.1.1",
+    "expo-modules-core": "~0.3.0-alpha.0",
     "expo-splash-screen": "~0.11.0",
     "expo-status-bar": "~1.0.4",
     "expo-dev-client": "~0.4.7",
@@ -22,7 +22,7 @@
     "react-native-reanimated": "~2.2.0",
     "react-native-screens": "~3.4.0",
     "react-native-unimodules": "~0.15.0-alpha.0",
-    "react-native-web": "~0.17.1",
+    "react-native-web": "~0.17.1"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",

--- a/apps/bare-sandbox/package.json
+++ b/apps/bare-sandbox/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@babel/runtime": "^7.5.5",
     "expo": "~42.0.0-alpha.0",
+    "expo-modules-core": "~0.1.1",
     "expo-splash-screen": "~0.11.0",
     "expo-status-bar": "~1.0.4",
     "expo-dev-client": "~0.4.7",
@@ -22,7 +23,6 @@
     "react-native-screens": "~3.4.0",
     "react-native-unimodules": "~0.15.0-alpha.0",
     "react-native-web": "~0.17.1",
-    "@unimodules/react-native-adapter": "^6.5.0-alpha.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",
@@ -34,7 +34,7 @@
   "expo-yarn-workspaces": {
     "symlinks": [
       "expo-constants",
-      "@unimodules/react-native-adapter"
+      "expo-modules-core"
     ]
   },
   "expo": {

--- a/apps/native-component-list/src/screens/AppleAuthenticationScreen.tsx
+++ b/apps/native-component-list/src/screens/AppleAuthenticationScreen.tsx
@@ -1,7 +1,7 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import Slider from '@react-native-community/slider';
-import { Subscription } from '@unimodules/core';
 import * as AppleAuthentication from 'expo-apple-authentication';
+import { Subscription } from 'expo-modules-core';
 import React from 'react';
 import { Alert, Button, ScrollView, StyleSheet, Text, View } from 'react-native';
 

--- a/apps/native-component-list/src/screens/Contacts/ContactsScreen.tsx
+++ b/apps/native-component-list/src/screens/Contacts/ContactsScreen.tsx
@@ -1,7 +1,7 @@
 import { useFocusEffect } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
-import { Platform } from '@unimodules/core';
 import * as Contacts from 'expo-contacts';
+import { Platform } from 'expo-modules-core';
 import React from 'react';
 import { RefreshControl, StyleSheet, Text, View } from 'react-native';
 

--- a/apps/native-component-list/src/screens/ExpoApisScreen.tsx
+++ b/apps/native-component-list/src/screens/ExpoApisScreen.tsx
@@ -1,5 +1,5 @@
-import { Platform } from '@unimodules/core';
 import Constants, { ExecutionEnvironment } from 'expo-constants';
+import { Platform } from 'expo-modules-core';
 import * as Notifications from 'expo-notifications';
 import React from 'react';
 

--- a/apps/native-component-list/src/screens/GL/PIXISpriteScreen.tsx
+++ b/apps/native-component-list/src/screens/GL/PIXISpriteScreen.tsx
@@ -1,7 +1,7 @@
 import './BeforePIXI';
 
-import { Platform } from '@unimodules/core';
 import { Asset } from 'expo-asset';
+import { Platform } from 'expo-modules-core';
 import * as PIXI from 'pixi.js';
 import { Dimensions } from 'react-native';
 

--- a/apps/native-component-list/src/screens/NotificationScreen.tsx
+++ b/apps/native-component-list/src/screens/NotificationScreen.tsx
@@ -1,4 +1,4 @@
-import { Subscription } from '@unimodules/core';
+import { Subscription } from 'expo-modules-core';
 import * as Notifications from 'expo-notifications';
 import * as TaskManager from 'expo-task-manager';
 import React from 'react';

--- a/apps/native-component-list/src/screens/PickerScreen.tsx
+++ b/apps/native-component-list/src/screens/PickerScreen.tsx
@@ -1,5 +1,5 @@
 import { Picker } from '@react-native-picker/picker';
-import { Platform } from '@unimodules/core';
+import { Platform } from 'expo-modules-core';
 import * as React from 'react';
 import { Text, Button } from 'react-native';
 

--- a/apps/native-component-list/src/screens/ScreenOrientationScreen.tsx
+++ b/apps/native-component-list/src/screens/ScreenOrientationScreen.tsx
@@ -1,4 +1,4 @@
-import { Platform, Subscription } from '@unimodules/core';
+import { Platform, Subscription } from 'expo-modules-core';
 import * as ScreenOrientation from 'expo-screen-orientation';
 import React from 'react';
 import { ScrollView, Text } from 'react-native';

--- a/apps/native-component-list/src/screens/SensorScreen.tsx
+++ b/apps/native-component-list/src/screens/SensorScreen.tsx
@@ -1,4 +1,4 @@
-import { Subscription } from '@unimodules/core';
+import { Subscription } from 'expo-modules-core';
 import * as Sensors from 'expo-sensors';
 import React from 'react';
 import { ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';

--- a/apps/native-component-list/src/screens/SwitchScreen.tsx
+++ b/apps/native-component-list/src/screens/SwitchScreen.tsx
@@ -1,4 +1,4 @@
-import { Platform } from '@unimodules/core';
+import { Platform } from 'expo-modules-core';
 import * as React from 'react';
 import { Switch } from 'react-native';
 

--- a/apps/native-component-list/src/screens/ViewShotScreen.tsx
+++ b/apps/native-component-list/src/screens/ViewShotScreen.tsx
@@ -1,6 +1,6 @@
-import { Platform } from '@unimodules/core';
 import { LinearGradient } from 'expo-linear-gradient';
 import * as MediaLibrary from 'expo-media-library';
+import { Platform } from 'expo-modules-core';
 import * as Permissions from 'expo-permissions';
 import React from 'react';
 import { Dimensions, Image, ScrollView, StyleSheet, Text, View } from 'react-native';

--- a/apps/test-suite/TestModules.js
+++ b/apps/test-suite/TestModules.js
@@ -1,7 +1,7 @@
 'use strict';
 
-import { Platform } from '@unimodules/core';
 import Constants from 'expo-constants';
+import { Platform } from 'expo-modules-core';
 
 import ExponentTest from './ExponentTest';
 import { isDeviceFarm } from './utils/Environment';

--- a/apps/test-suite/TestUtils.js
+++ b/apps/test-suite/TestUtils.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import { UnavailabilityError } from '@unimodules/core';
+import { UnavailabilityError } from 'expo-modules-core';
 
 import ExponentTest from './ExponentTest';
 

--- a/apps/test-suite/tests/Battery.js
+++ b/apps/test-suite/tests/Battery.js
@@ -1,6 +1,6 @@
-import { Platform } from '@unimodules/core';
 import * as Battery from 'expo-battery';
 import * as Device from 'expo-device';
+import { Platform } from 'expo-modules-core';
 
 export const name = 'Battery';
 
@@ -24,7 +24,7 @@ export async function test({ describe, it, expect, jasmine }) {
     if (isAvailable) {
       describe(`getBatteryLevelAsync()`, () => {
         it(`returns a number between 0 and 1`, async () => {
-          let batteryLevel = await Battery.getBatteryLevelAsync();
+          const batteryLevel = await Battery.getBatteryLevelAsync();
           expect(batteryLevel).toEqual(jasmine.any(Number));
           expect(batteryLevel).toBeLessThanOrEqual(1);
           expect(batteryLevel).toBeGreaterThan(0);

--- a/apps/test-suite/tests/Calendar.js
+++ b/apps/test-suite/tests/Calendar.js
@@ -1,6 +1,6 @@
 import * as Calendar from 'expo-calendar';
+import { UnavailabilityError } from 'expo-modules-core';
 import { Platform } from 'react-native';
-import { UnavailabilityError } from '@unimodules/core';
 
 import * as TestUtils from '../TestUtils';
 

--- a/apps/test-suite/tests/CalendarReminders.js
+++ b/apps/test-suite/tests/CalendarReminders.js
@@ -1,6 +1,6 @@
 import * as Calendar from 'expo-calendar';
+import { UnavailabilityError } from 'expo-modules-core';
 import { Platform } from 'react-native';
-import { UnavailabilityError } from '@unimodules/core';
 
 import * as TestUtils from '../TestUtils';
 

--- a/apps/test-suite/tests/Contacts.web.js
+++ b/apps/test-suite/tests/Contacts.web.js
@@ -1,5 +1,5 @@
 import * as Contacts from 'expo-contacts';
-import { Platform, UnavailabilityError } from '@unimodules/core';
+import { Platform, UnavailabilityError } from 'expo-modules-core';
 
 export const name = 'Contacts';
 

--- a/apps/test-suite/tests/Facebook.js
+++ b/apps/test-suite/tests/Facebook.js
@@ -1,6 +1,6 @@
-import { Platform } from '@unimodules/core';
 import * as Device from 'expo-device';
 import * as Facebook from 'expo-facebook';
+import { Platform } from 'expo-modules-core';
 
 import { isInteractive } from '../utils/Environment';
 

--- a/apps/test-suite/tests/FileSystem.js
+++ b/apps/test-suite/tests/FileSystem.js
@@ -1,9 +1,9 @@
 'use strict';
 
 import { Asset } from 'expo-asset';
-import * as FS from 'expo-file-system';
 import Constants from 'expo-constants';
-import { Platform } from '@unimodules/core';
+import * as FS from 'expo-file-system';
+import { Platform } from 'expo-modules-core';
 
 export const name = 'FileSystem';
 
@@ -53,7 +53,7 @@ export async function test({ describe, expect, it, ...t }) {
         const localUri = FS.documentDirectory + 'download1.png';
 
         const assertExists = async expectedToExist => {
-          let { exists } = await FS.getInfoAsync(localUri);
+          const { exists } = await FS.getInfoAsync(localUri);
           if (expectedToExist) {
             expect(exists).toBeTruthy();
           } else {
@@ -420,7 +420,7 @@ export async function test({ describe, expect, it, ...t }) {
       const localUri = FS.documentDirectory + 'download1.png';
 
       const assertExists = async expectedToExist => {
-        let { exists } = await FS.getInfoAsync(localUri);
+        const { exists } = await FS.getInfoAsync(localUri);
         if (expectedToExist) {
           expect(exists).toBeTruthy();
         } else {
@@ -449,7 +449,7 @@ export async function test({ describe, expect, it, ...t }) {
       const localUri = FS.documentDirectory + 'download1.png';
 
       const assertExists = async expectedToExist => {
-        let { exists } = await FS.getInfoAsync(localUri);
+        const { exists } = await FS.getInfoAsync(localUri);
         if (expectedToExist) {
           expect(exists).toBeTruthy();
         } else {

--- a/apps/test-suite/tests/GLView.js
+++ b/apps/test-suite/tests/GLView.js
@@ -1,7 +1,7 @@
 'use strict';
-import { Platform } from '@unimodules/core';
 import { Asset } from 'expo-asset';
 import { GLView } from 'expo-gl';
+import { Platform } from 'expo-modules-core';
 import React from 'react';
 
 import { mountAndWaitFor } from './helpers';

--- a/apps/test-suite/tests/GoogleSignIn.js
+++ b/apps/test-suite/tests/GoogleSignIn.js
@@ -1,6 +1,6 @@
-import { Platform } from '@unimodules/core';
 import * as GoogleSignIn from 'expo-google-sign-in';
 import * as Localization from 'expo-localization';
+import { Platform } from 'expo-modules-core';
 import { Image } from 'react-native';
 
 import { alertAndWaitForResponse } from './helpers';

--- a/apps/test-suite/tests/Notifications.js
+++ b/apps/test-suite/tests/Notifications.js
@@ -1,9 +1,9 @@
 'use strict';
 
-import { Platform } from '@unimodules/core';
 import Constants from 'expo-constants';
 import * as Device from 'expo-device';
 import * as FileSystem from 'expo-file-system';
+import { Platform } from 'expo-modules-core';
 import * as Notifications from 'expo-notifications';
 import { Alert, AppState } from 'react-native';
 

--- a/apps/test-suite/tests/SQLite.js
+++ b/apps/test-suite/tests/SQLite.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import { Platform } from '@unimodules/core';
+import { Platform } from 'expo-modules-core';
 import { Asset } from 'expo-asset';
 import * as FS from 'expo-file-system';
 import * as SQLite from 'expo-sqlite';

--- a/apps/test-suite/utils/Environment.js
+++ b/apps/test-suite/utils/Environment.js
@@ -1,5 +1,5 @@
 'use strict';
-import { Platform } from '@unimodules/core';
+import { Platform } from 'expo-modules-core';
 
 import ExponentTest from '../ExponentTest';
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -4106,7 +4106,7 @@ SPEC CHECKSUMS:
   FirebaseCore: ac35d680a0bf32319a59966a1478e0741536b97b
   FirebaseCoreDiagnostics: 3d36e05da74cb8b7ce30e6594a8f201b982c725c
   FirebaseInstallations: a58d4f72ec5861840b84df489f2668d970df558a
-  glog: 40a13f7840415b9a77023fbcae0f1e6f43192af3
+  glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
   Google-Maps-iOS-Utils: c32891ff472eaaa1fca032beedafa1a013af7875
   Google-Mobile-Ads-SDK: 2f288748a42920d1c744946a460896a95b0e9110
   GoogleAppMeasurement: 0c3b134b2c0a90c4c24833873894bfe0e42a0384

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -4106,7 +4106,7 @@ SPEC CHECKSUMS:
   FirebaseCore: ac35d680a0bf32319a59966a1478e0741536b97b
   FirebaseCoreDiagnostics: 3d36e05da74cb8b7ce30e6594a8f201b982c725c
   FirebaseInstallations: a58d4f72ec5861840b84df489f2668d970df558a
-  glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
+  glog: 40a13f7840415b9a77023fbcae0f1e6f43192af3
   Google-Maps-iOS-Utils: c32891ff472eaaa1fca032beedafa1a013af7875
   Google-Mobile-Ads-SDK: 2f288748a42920d1c744946a460896a95b0e9110
   GoogleAppMeasurement: 0c3b134b2c0a90c4c24833873894bfe0e42a0384

--- a/packages/expo/src/__tests__/Expo-test.native.ts
+++ b/packages/expo/src/__tests__/Expo-test.native.ts
@@ -148,7 +148,7 @@ describe(`importing Expo`, () => {
     };
     // Clear all the native modules as a way to simulate running outside of Expo
     const { NativeModules } = require('react-native');
-    const { NativeModulesProxy } = require('@unimodules/react-native-adapter');
+    const { NativeModulesProxy } = require('expo-modules-core');
     clearPropertiesInPlace(NativeModules);
     clearPropertiesInPlace(NativeModulesProxy);
 


### PR DESCRIPTION
# Why

Continuation of https://github.com/expo/expo/commit/8285c03287d7cfd04b3069020de245f26ff1f851

# How

Just searched for the deprecated imports `@unimodules/core` and `@unimodules/react-native-adapter` and replaced them with `expo-modules-core`.

# Test Plan

I've run following apps and clicked through them seeing no deprecation warning:
- [x] `ncl` run in Expo Go
- [x] `test-suite` run in Expo Go
- ~`bare-sandbox`~ _native build failed_

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).