### PR TITLE
[modules-core][android] Use `expo-modules-core` instead of `unimodules-core` in gradle files

### DIFF
--- a/packages/expo-ads-admob/android/build.gradle
+++ b/packages/expo-ads-admob/android/build.gradle
@@ -64,16 +64,8 @@ android {
   }
 }
 
-if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-  apply from: project(":unimodules-core").file("../unimodules-core.gradle")
-} else {
-  throw new GradleException(
-      "'unimodules-core.gradle' was not found in the usual React Native dependency location. " +
-          "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
-}
-
 dependencies {
-  unimodule "unimodules-core"
+  implementation project(':expo-modules-core')
   api 'com.google.android.gms:play-services-ads:19.4.0'
 
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${safeExtGet('kotlinVersion', '1.4.21')}"

--- a/packages/expo-ads-facebook/android/build.gradle
+++ b/packages/expo-ads-facebook/android/build.gradle
@@ -64,21 +64,13 @@ android {
   }
 }
 
-if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-  apply from: project(':unimodules-core').file('../unimodules-core.gradle')
-} else {
-  throw new GradleException(
-      '\'unimodules-core.gradle\' was not found in the usual React Native dependency location. ' +
-          'This package can only be used in such projects. Are you sure you\'ve installed the dependencies properly?')
-}
-
 repositories {
   mavenCentral()
   jcenter()
 }
 
 dependencies {
-  unimodule 'unimodules-core'
+  implementation project(':expo-modules-core')
   api "com.facebook.android:audience-network-sdk:${safeExtGet('fbAudienceNetworkVersion', '6.5.0')}"
 
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${safeExtGet('kotlinVersion', '1.4.21')}"

--- a/packages/expo-analytics-amplitude/android/build.gradle
+++ b/packages/expo-analytics-amplitude/android/build.gradle
@@ -64,19 +64,15 @@ android {
   }
 }
 
-if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-  apply from: project(':unimodules-core').file('../unimodules-core.gradle')
-} else {
-  throw new GradleException(
-      '\'unimodules-core.gradle\' was not found in the usual React Native dependency location. ' +
-          'This package can only be used in such projects. Are you sure you\'ve installed the dependencies properly?')
-}
-
 dependencies {
-  testImplementation 'junit:junit:4.12'
-  testImplementation "org.robolectric:robolectric:4.5.1"
-  unimodule 'unimodules-core'
+  implementation project(':expo-modules-core')
   api 'com.amplitude:android-sdk:2.23.2'
 
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${safeExtGet('kotlinVersion', '1.4.21')}"
+
+  if (project.findProject(':unimodules-test-core')) {
+    testImplementation project(':unimodules-test-core')
+  }
+  testImplementation 'junit:junit:4.12'
+  testImplementation "org.robolectric:robolectric:4.5.1"
 }

--- a/packages/expo-analytics-segment/android/build.gradle
+++ b/packages/expo-analytics-segment/android/build.gradle
@@ -64,17 +64,8 @@ android {
   }
 }
 
-if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-  apply from: project(":unimodules-core").file("../unimodules-core.gradle")
-} else {
-  throw new GradleException(
-      "'unimodules-core.gradle' was not found in the usual React Native dependency location. " +
-          "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
-}
-
 dependencies {
-  unimodule "unimodules-core"
-  unimodule "expo-modules-core"
+  implementation project(':expo-modules-core')
 
   api 'com.segment.analytics.android:analytics:4.9.4'
   api 'com.segment.analytics.android.integrations:firebase:2.+@aar'

--- a/packages/expo-app-auth/android/build.gradle
+++ b/packages/expo-app-auth/android/build.gradle
@@ -65,17 +65,8 @@ android {
   }
 }
 
-if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-  apply from: project(":unimodules-core").file("../unimodules-core.gradle")
-} else {
-  throw new GradleException(
-      "'unimodules-core.gradle' was not found in the usual React Native dependency location. " +
-          "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
-}
-
 dependencies {
-  unimodule "unimodules-core"
-  unimodule "expo-modules-core"
+  implementation project(':expo-modules-core')
 
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${safeExtGet('kotlinVersion', '1.4.21')}"
 

--- a/packages/expo-application/android/build.gradle
+++ b/packages/expo-application/android/build.gradle
@@ -64,19 +64,15 @@ android {
   }
 }
 
-if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-  apply from: project(":unimodules-core").file("../unimodules-core.gradle")
-} else {
-  throw new GradleException(
-      '\'unimodules-core.gradle\' was not found in the usual React Native dependency location. ' +
-          'This package can only be used in such projects. Are you sure you\'ve installed the dependencies properly?')
-}
-
 dependencies {
-  testImplementation "org.robolectric:robolectric:4.5.1"
-  testImplementation 'junit:junit:4.12'
-  unimodule 'unimodules-core'
+  implementation project(':expo-modules-core')
 
   implementation 'com.android.installreferrer:installreferrer:1.0'
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${safeExtGet('kotlinVersion', '1.4.21')}"
+
+  if (project.findProject(':unimodules-test-core')) {
+    testImplementation project(':unimodules-test-core')
+  }
+  testImplementation "org.robolectric:robolectric:4.5.1"
+  testImplementation 'junit:junit:4.12'
 }

--- a/packages/expo-av/android/build.gradle
+++ b/packages/expo-av/android/build.gradle
@@ -67,20 +67,10 @@ android {
       useJUnitPlatform()
     }
   }
-
-}
-
-if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-  apply from: project(":unimodules-core").file("../unimodules-core.gradle")
-} else {
-  throw new GradleException(
-      "'unimodules-core.gradle' was not found in the usual React Native dependency location. " +
-          "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
 }
 
 dependencies {
-  unimodule "unimodules-core"
-  unimodule 'expo-modules-core'
+  implementation project(':expo-modules-core')
 
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${safeExtGet('kotlinVersion', '1.4.21')}"
 

--- a/packages/expo-background-fetch/android/build.gradle
+++ b/packages/expo-background-fetch/android/build.gradle
@@ -64,17 +64,9 @@ android {
   }
 }
 
-if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-  apply from: project(":unimodules-core").file("../unimodules-core.gradle")
-} else {
-  throw new GradleException(
-      "'unimodules-core.gradle' was not found in the usual React Native dependency location. " +
-          "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
-}
-
 dependencies {
-  unimodule "unimodules-core"
-  unimodule "unimodules-task-manager-interface"
+  implementation project(':expo-modules-core')
+  implementation project(':unimodules-task-manager-interface')
 
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${safeExtGet('kotlinVersion', '1.4.21')}"
 }

--- a/packages/expo-barcode-scanner/android/build.gradle
+++ b/packages/expo-barcode-scanner/android/build.gradle
@@ -68,17 +68,8 @@ android {
   }
 }
 
-if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-  apply from: project(":unimodules-core").file("../unimodules-core.gradle")
-} else {
-  throw new GradleException(
-      "'unimodules-core.gradle' was not found in the usual React Native dependency location. " +
-          "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
-}
-
 dependencies {
-  unimodule "unimodules-core"
-  unimodule 'expo-modules-core'
+  implementation project(':expo-modules-core')
 
   api 'com.google.android.gms:play-services-vision:19.0.0'
   api 'com.google.zxing:core:3.3.3'

--- a/packages/expo-battery/android/build.gradle
+++ b/packages/expo-battery/android/build.gradle
@@ -64,19 +64,15 @@ android {
   }
 }
 
-if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-  apply from: project(":unimodules-core").file("../unimodules-core.gradle")
-} else {
-  throw new GradleException(
-      '\'unimodules-core.gradle\' was not found in the usual React Native dependency location. ' +
-          'This package can only be used in such projects. Are you sure you\'ve installed the dependencies properly?')
-}
-
 dependencies {
-  unimodule 'unimodules-core'
+  implementation project(':expo-modules-core')
 
   api "androidx.legacy:legacy-support-v4:1.0.0"
 
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${safeExtGet('kotlinVersion', '1.4.21')}"
+
+  if (project.findProject(':unimodules-test-core')) {
+    testImplementation project(':unimodules-test-core')
+  }
   testImplementation "org.robolectric:robolectric:4.3.1"
 }

--- a/packages/expo-branch/android/build.gradle
+++ b/packages/expo-branch/android/build.gradle
@@ -77,16 +77,8 @@ android {
   }
 }
 
-if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-  apply from: project(":unimodules-core").file("../unimodules-core.gradle")
-} else {
-  throw new GradleException(
-      '\'unimodules-core.gradle\' was not found in the usual React Native dependency location. ' +
-          'This package can only be used in such projects. Are you sure you\'ve installed the dependencies properly?')
-}
-
 dependencies {
-  unimodule 'unimodules-core'
+  implementation project(':expo-modules-core')
   //noinspection GradleDynamicVersion
   implementation 'com.facebook.react:react-native:+'
   api 'io.branch.sdk.android:library:5.0.3'

--- a/packages/expo-brightness/android/build.gradle
+++ b/packages/expo-brightness/android/build.gradle
@@ -68,17 +68,8 @@ android {
   }
 }
 
-if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-  apply from: project(':unimodules-core').file('../unimodules-core.gradle')
-} else {
-  throw new GradleException(
-      '\'unimodules-core.gradle\' was not found in the usual React Native dependency location. ' +
-          'This package can only be used in such projects. Are you sure you\'ve installed the dependencies properly?')
-}
-
 dependencies {
-  unimodule 'unimodules-core'
-  unimodule 'expo-modules-core'
+  implementation project(':expo-modules-core')
 
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${safeExtGet('kotlinVersion', '1.4.21')}"
 }

--- a/packages/expo-calendar/android/build.gradle
+++ b/packages/expo-calendar/android/build.gradle
@@ -68,17 +68,8 @@ android {
   }
 }
 
-if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-  apply from: project(':unimodules-core').file('../unimodules-core.gradle')
-} else {
-  throw new GradleException(
-      '\'unimodules-core.gradle\' was not found in the usual React Native dependency location. ' +
-          'This package can only be used in such projects. Are you sure you\'ve installed the dependencies properly?')
-}
-
 dependencies {
-  unimodule 'unimodules-core'
-  unimodule 'expo-modules-core'
+  implementation project(':expo-modules-core')
 
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${safeExtGet('kotlinVersion', '1.4.21')}"
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.3")

--- a/packages/expo-camera/android/build.gradle
+++ b/packages/expo-camera/android/build.gradle
@@ -71,11 +71,8 @@ repositories {
   }
 }
 
-apply from: project(":unimodules-core").file("../unimodules-core.gradle")
-
 dependencies {
-  unimodule 'unimodules-core'
-  unimodule 'expo-modules-core'
+  implementation project(':expo-modules-core')
 
   api "androidx.exifinterface:exifinterface:1.0.0"
   api 'com.google.android:cameraview:1.0.0'

--- a/packages/expo-cellular/android/build.gradle
+++ b/packages/expo-cellular/android/build.gradle
@@ -64,16 +64,8 @@ android {
   }
 }
 
-if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-  apply from: project(":unimodules-core").file("../unimodules-core.gradle")
-} else {
-  throw new GradleException(
-      '\'unimodules-core.gradle\' was not found in the usual React Native dependency location. ' +
-          'This package can only be used in such projects. Are you sure you\'ve installed the dependencies properly?')
-}
-
 dependencies {
-  unimodule 'unimodules-core'
+  implementation project(':expo-modules-core')
 
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${safeExtGet('kotlinVersion', '1.4.21')}"
 }

--- a/packages/expo-clipboard/android/build.gradle
+++ b/packages/expo-clipboard/android/build.gradle
@@ -64,20 +64,16 @@ android {
   }
 }
 
-if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-  apply from: project(":unimodules-core").file("../unimodules-core.gradle")
-} else {
-  throw new GradleException(
-      '\'unimodules-core.gradle\' was not found in the usual React Native dependency location. ' +
-          'This package can only be used in such projects. Are you sure you\'ve installed the dependencies properly?')
-}
-
 repositories {
   mavenCentral()
 }
 
 dependencies {
-  unimodule 'unimodules-core'
+  implementation project(':expo-modules-core')
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${safeExtGet('kotlinVersion', '1.4.21')}"
+
+  if (project.findProject(':unimodules-test-core')) {
+    testImplementation project(':unimodules-test-core')
+  }
   testImplementation "org.robolectric:robolectric:4.3.1"
 }

--- a/packages/expo-constants/android/build.gradle
+++ b/packages/expo-constants/android/build.gradle
@@ -70,17 +70,8 @@ repositories {
   mavenCentral()
 }
 
-if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-  apply from: project(":unimodules-core").file("../unimodules-core.gradle")
-} else {
-  throw new GradleException(
-      "'unimodules-core.gradle' was not found in the usual React Native dependency location. " +
-          "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
-}
-
 dependencies {
-  unimodule 'unimodules-core'
-  unimodule 'expo-modules-core'
+  implementation project(':expo-modules-core')
 
   api 'com.facebook.device.yearclass:yearclass:2.1.0'
   api "androidx.annotation:annotation:1.0.0"

--- a/packages/expo-contacts/android/build.gradle
+++ b/packages/expo-contacts/android/build.gradle
@@ -64,17 +64,8 @@ android {
   }
 }
 
-if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-  apply from: project(":unimodules-core").file("../unimodules-core.gradle")
-} else {
-  throw new GradleException(
-      "'unimodules-core.gradle' was not found in the usual React Native dependency location. " +
-          "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
-}
-
 dependencies {
-  unimodule "unimodules-core"
-  unimodule 'expo-modules-core'
+  implementation project(':expo-modules-core')
 
   implementation 'androidx.annotation:annotation:1.2.0'
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${safeExtGet('kotlinVersion', '1.4.21')}"

--- a/packages/expo-crypto/android/build.gradle
+++ b/packages/expo-crypto/android/build.gradle
@@ -64,18 +64,14 @@ android {
   }
 }
 
-if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-  apply from: project(":unimodules-core").file("../unimodules-core.gradle")
-} else {
-  throw new GradleException(
-      "'unimodules-core.gradle' was not found in the usual React Native dependency location. " +
-          "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
-}
-
 dependencies {
-  unimodule "unimodules-core"
+  implementation project(':expo-modules-core')
 
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${safeExtGet('kotlinVersion', '1.4.21')}"
+
+  if (project.findProject(':unimodules-test-core')) {
+    testImplementation project(':unimodules-test-core')
+  }
   testImplementation 'junit:junit:4.12'
   testImplementation "org.robolectric:robolectric:4.3.1"
 }

--- a/packages/expo-device/android/build.gradle
+++ b/packages/expo-device/android/build.gradle
@@ -68,17 +68,8 @@ android {
   }
 }
 
-if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-  apply from: project(":unimodules-core").file("../unimodules-core.gradle")
-} else {
-  throw new GradleException(
-      '\'unimodules-core.gradle\' was not found in the usual React Native dependency location. ' +
-          'This package can only be used in such projects. Are you sure you\'ve installed the dependencies properly?')
-}
-
 dependencies {
-  unimodule 'unimodules-core'
-  unimodule 'expo-modules-core'
+  implementation project(':expo-modules-core')
 
   api 'com.facebook.device.yearclass:yearclass:2.1.0'
   api "androidx.legacy:legacy-support-v4:1.0.0"

--- a/packages/expo-document-picker/android/build.gradle
+++ b/packages/expo-document-picker/android/build.gradle
@@ -68,16 +68,8 @@ android {
   }
 }
 
-if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-  apply from: project(':unimodules-core').file('../unimodules-core.gradle')
-} else {
-  throw new GradleException(
-      '\'unimodules-core.gradle\' was not found in the usual React Native dependency location. ' +
-          'This package can only be used in such projects. Are you sure you\'ve installed the dependencies properly?')
-}
-
 dependencies {
-  unimodule 'unimodules-core'
+  implementation project(':expo-modules-core')
 
   api "androidx.annotation:annotation:1.0.0"
   api 'commons-io:commons-io:2.6'

--- a/packages/expo-error-recovery/android/build.gradle
+++ b/packages/expo-error-recovery/android/build.gradle
@@ -64,18 +64,13 @@ android {
   }
 }
 
-if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-  apply from: project(":unimodules-core").file("../unimodules-core.gradle")
-} else {
-  throw new GradleException(
-      '\'unimodules-core.gradle\' was not found in the usual React Native dependency location. ' +
-          'This package can only be used in such projects. Are you sure you\'ve installed the dependencies properly?')
-}
-
 dependencies {
+  implementation project(':expo-modules-core')
+  implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${safeExtGet('kotlinVersion', '1.4.21')}"
+
+  if (project.findProject(':unimodules-test-core')) {
+    testImplementation project(':unimodules-test-core')
+  }
   testImplementation 'junit:junit:4.12'
   testImplementation "org.robolectric:robolectric:4.3.1"
-
-  unimodule 'unimodules-core'
-  implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${safeExtGet('kotlinVersion', '1.4.21')}"
 }

--- a/packages/expo-face-detector/android/build.gradle
+++ b/packages/expo-face-detector/android/build.gradle
@@ -68,17 +68,8 @@ repositories {
   mavenCentral()
 }
 
-if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-  apply from: project(":unimodules-core").file("../unimodules-core.gradle")
-} else {
-  throw new GradleException(
-      "'unimodules-core.gradle' was not found in the usual React Native dependency location. " +
-          "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
-}
-
 dependencies {
-  unimodule 'unimodules-core'
-  unimodule 'expo-modules-core'
+  implementation project(':expo-modules-core')
 
   api "androidx.exifinterface:exifinterface:1.0.0"
   api 'com.google.firebase:firebase-ml-vision:24.0.1'

--- a/packages/expo-facebook/android/build.gradle
+++ b/packages/expo-facebook/android/build.gradle
@@ -64,16 +64,8 @@ android {
   }
 }
 
-if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-  apply from: project(":unimodules-core").file("../unimodules-core.gradle")
-} else {
-  throw new GradleException(
-      "'unimodules-core.gradle' was not found in the usual React Native dependency location. " +
-          "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
-}
-
 dependencies {
-  unimodule "unimodules-core"
+  implementation project(':expo-modules-core')
   api "com.facebook.android:facebook-core:${safeExtGet('facebookSdkVersion', '9.0.0')}"
   api "com.facebook.android:facebook-login:${safeExtGet('facebookSdkVersion', '9.0.0')}"
 

--- a/packages/expo-file-system/android/build.gradle
+++ b/packages/expo-file-system/android/build.gradle
@@ -68,17 +68,8 @@ repositories {
   mavenCentral()
 }
 
-if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-  apply from: project(":unimodules-core").file("../unimodules-core.gradle")
-} else {
-  throw new GradleException(
-      "'unimodules-core.gradle' was not found in the usual React Native dependency location. " +
-          "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
-}
-
 dependencies {
-  unimodule 'unimodules-core'
-  unimodule 'expo-modules-core'
+  implementation project(':expo-modules-core')
 
   api 'commons-codec:commons-codec:1.10'
   api 'commons-io:commons-io:1.4'

--- a/packages/expo-firebase-analytics/android/build.gradle
+++ b/packages/expo-firebase-analytics/android/build.gradle
@@ -64,17 +64,9 @@ android {
   }
 }
 
-if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-  apply from: project(":unimodules-core").file("../unimodules-core.gradle")
-} else {
-  throw new GradleException(
-      '\'unimodules-core.gradle\' was not found in the usual React Native dependency location. ' +
-          'This package can only be used in such projects. Are you sure you\'ve installed the dependencies properly?')
-}
-
 dependencies {
-  unimodule 'unimodules-core'
-  unimodule 'expo-firebase-core'
+  implementation project(':expo-modules-core')
+  implementation project(':expo-firebase-core')
 
   // We can't use BOM, cause it doesn't work with prebuilding and new autolinking.
   // > Could not find com.google.firebase:firebase-core:.

--- a/packages/expo-firebase-core/android/build.gradle
+++ b/packages/expo-firebase-core/android/build.gradle
@@ -64,16 +64,8 @@ android {
   }
 }
 
-if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-  apply from: project(":unimodules-core").file("../unimodules-core.gradle")
-} else {
-  throw new GradleException(
-      '\'unimodules-core.gradle\' was not found in the usual React Native dependency location. ' +
-          'This package can only be used in such projects. Are you sure you\'ve installed the dependencies properly?')
-}
-
 dependencies {
-  unimodule 'unimodules-core'
+  implementation project(':expo-modules-core')
 
   // We can't use BOM, cause it doesn't work with prebuilding and new autolinking.
   // > Could not find com.google.firebase:firebase-core:.

--- a/packages/expo-font/android/build.gradle
+++ b/packages/expo-font/android/build.gradle
@@ -68,17 +68,8 @@ android {
   }
 }
 
-if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-  apply from: project(":unimodules-core").file("../unimodules-core.gradle")
-} else {
-  throw new GradleException(
-      "'unimodules-core.gradle' was not found in the usual React Native dependency location. " +
-          "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
-}
-
 dependencies {
-  unimodule "unimodules-core"
-  unimodule "expo-modules-core"
+  implementation project(':expo-modules-core')
 
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${safeExtGet('kotlinVersion', '1.4.21')}"
 }

--- a/packages/expo-gl-cpp/android/build.gradle
+++ b/packages/expo-gl-cpp/android/build.gradle
@@ -112,13 +112,6 @@ repositories {
   mavenCentral()
 }
 
-if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-  apply from: project(":unimodules-core").file("../unimodules-core.gradle")
-} else {
-  throw new GradleException(
-      "'unimodules-core.gradle' was not found in the usual React Native dependency location. " +
-          "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
-}
 
 dependencies {
   compileOnly 'com.facebook.soloader:soloader:0.8.2'

--- a/packages/expo-gl/android/build.gradle
+++ b/packages/expo-gl/android/build.gradle
@@ -69,18 +69,9 @@ android {
   }
 }
 
-if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-  apply from: project(":unimodules-core").file("../unimodules-core.gradle")
-} else {
-  throw new GradleException(
-      "'unimodules-core.gradle' was not found in the usual React Native dependency location. " +
-          "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
-}
-
 dependencies {
-  unimodule 'expo-gl-cpp'
-  unimodule 'unimodules-core'
-  unimodule 'expo-modules-core'
+  implementation project(':expo-gl-cpp')
+  implementation project(':expo-modules-core')
 
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${safeExtGet('kotlinVersion', '1.4.21')}"
 }

--- a/packages/expo-google-sign-in/android/build.gradle
+++ b/packages/expo-google-sign-in/android/build.gradle
@@ -64,17 +64,8 @@ android {
   }
 }
 
-if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-  apply from: project(":unimodules-core").file("../unimodules-core.gradle")
-} else {
-  throw new GradleException(
-      "'unimodules-core.gradle' was not found in the usual React Native dependency location. " +
-          "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
-}
-
 dependencies {
-  unimodule "unimodules-core"
-  unimodule 'expo-modules-core'
+  implementation project(':expo-modules-core')
 
   api 'com.google.android.gms:play-services-auth:17.0.0'
 

--- a/packages/expo-haptics/android/build.gradle
+++ b/packages/expo-haptics/android/build.gradle
@@ -64,16 +64,8 @@ android {
   }
 }
 
-if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-  apply from: project(':unimodules-core').file('../unimodules-core.gradle')
-} else {
-  throw new GradleException(
-      '\'unimodules-core.gradle\' was not found in the usual React Native dependency location. ' +
-          'This package can only be used in such projects. Are you sure you\'ve installed the dependencies properly?')
-}
-
 dependencies {
-  unimodule 'unimodules-core'
+  implementation project(':expo-modules-core')
 
   api "androidx.annotation:annotation:1.0.0"
 

--- a/packages/expo-image-loader/android/build.gradle
+++ b/packages/expo-image-loader/android/build.gradle
@@ -68,17 +68,8 @@ repositories {
   mavenCentral()
 }
 
-if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-  apply from: project(":unimodules-core").file("../unimodules-core.gradle")
-} else {
-  throw new GradleException(
-      '\'unimodules-core.gradle\' was not found in the usual React Native dependency location. ' +
-          'This package can only be used in such projects. Are you sure you\'ve installed the dependencies properly?')
-}
-
 dependencies {
-  unimodule 'unimodules-core'
-  unimodule 'expo-modules-core'
+  implementation project(':expo-modules-core')
 
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${safeExtGet('kotlinVersion', '1.4.21')}"
   api 'com.github.bumptech.glide:glide:4.9.0'

--- a/packages/expo-image-manipulator/android/build.gradle
+++ b/packages/expo-image-manipulator/android/build.gradle
@@ -68,17 +68,8 @@ android {
   }
 }
 
-if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-  apply from: project(':unimodules-core').file('../unimodules-core.gradle')
-} else {
-  throw new GradleException(
-      '\'unimodules-core.gradle\' was not found in the usual React Native dependency location. ' +
-          'This package can only be used in such projects. Are you sure you\'ve installed the dependencies properly?')
-}
-
 dependencies {
-  unimodule 'unimodules-core'
-  unimodule 'expo-modules-core'
+  implementation project(':expo-modules-core')
 
   api "androidx.annotation:annotation:1.0.0"
 

--- a/packages/expo-image-picker/android/build.gradle
+++ b/packages/expo-image-picker/android/build.gradle
@@ -68,17 +68,8 @@ android {
   }
 }
 
-if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-  apply from: project(":unimodules-core").file("../unimodules-core.gradle")
-} else {
-  throw new GradleException(
-      "'unimodules-core.gradle' was not found in the usual React Native dependency location. " +
-          "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
-}
-
 dependencies {
-  unimodule "unimodules-core"
-  unimodule 'expo-modules-core'
+  implementation project(':expo-modules-core')
 
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${safeExtGet('kotlinVersion', '1.4.21')}"
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.3")

--- a/packages/expo-in-app-purchases/android/build.gradle
+++ b/packages/expo-in-app-purchases/android/build.gradle
@@ -64,13 +64,6 @@ android {
   }
 }
 
-if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-  apply from: project(":unimodules-core").file("../unimodules-core.gradle")
-} else {
-  throw new GradleException(
-      '\'unimodules-core.gradle\' was not found in the usual React Native dependency location. ' +
-          'This package can only be used in such projects. Are you sure you\'ve installed the dependencies properly?')
-}
 
 allprojects {
   repositories {
@@ -81,7 +74,7 @@ allprojects {
 
 dependencies {
   implementation 'androidx.annotation:annotation:1.1.0'
-  unimodule 'unimodules-core'
+  implementation project(':expo-modules-core')
   api 'com.android.billingclient:billing:4.0.0'
 
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${safeExtGet('kotlinVersion', '1.4.21')}"

--- a/packages/expo-intent-launcher/android/build.gradle
+++ b/packages/expo-intent-launcher/android/build.gradle
@@ -64,16 +64,8 @@ android {
   }
 }
 
-if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-  apply from: project(':unimodules-core').file('../unimodules-core.gradle')
-} else {
-  throw new GradleException(
-      '\'unimodules-core.gradle\' was not found in the usual React Native dependency location. ' +
-          'This package can only be used in such projects. Are you sure you\'ve installed the dependencies properly?')
-}
-
 dependencies {
-  unimodule 'unimodules-core'
+  implementation project(':expo-modules-core')
 
   api "androidx.annotation:annotation:1.0.0"
 

--- a/packages/expo-keep-awake/android/build.gradle
+++ b/packages/expo-keep-awake/android/build.gradle
@@ -68,16 +68,8 @@ android {
   }
 }
 
-if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-  apply from: project(":unimodules-core").file("../unimodules-core.gradle")
-} else {
-  throw new GradleException(
-      "'unimodules-core.gradle' was not found in the usual React Native dependency location. " +
-          "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
-}
-
 dependencies {
-  unimodule "unimodules-core"
+  implementation project(':expo-modules-core')
 
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${safeExtGet('kotlinVersion', '1.4.21')}"
 }

--- a/packages/expo-linear-gradient/android/build.gradle
+++ b/packages/expo-linear-gradient/android/build.gradle
@@ -64,16 +64,8 @@ android {
   }
 }
 
-if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-  apply from: project(":unimodules-core").file("../unimodules-core.gradle")
-} else {
-  throw new GradleException(
-      "'unimodules-core.gradle' was not found in the usual React Native dependency location. " +
-          "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
-}
-
 dependencies {
-  unimodule "unimodules-core"
+  implementation project(':expo-modules-core')
 
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${safeExtGet('kotlinVersion', '1.4.21')}"
 }

--- a/packages/expo-local-authentication/android/build.gradle
+++ b/packages/expo-local-authentication/android/build.gradle
@@ -68,16 +68,8 @@ android {
   }
 }
 
-if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-  apply from: project(":unimodules-core").file("../unimodules-core.gradle")
-} else {
-  throw new GradleException(
-      "'unimodules-core.gradle' was not found in the usual React Native dependency location. " +
-          "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
-}
-
 dependencies {
-  unimodule "unimodules-core"
+  implementation project(':expo-modules-core')
 
   api "androidx.biometric:biometric:1.1.0"
 

--- a/packages/expo-localization/android/build.gradle
+++ b/packages/expo-localization/android/build.gradle
@@ -64,16 +64,8 @@ android {
   }
 }
 
-if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-  apply from: project(":unimodules-core").file("../unimodules-core.gradle")
-} else {
-  throw new GradleException(
-      "'unimodules-core.gradle' was not found in the usual React Native dependency location. " +
-          "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
-}
-
 dependencies {
-  unimodule "unimodules-core"
+  implementation project(':expo-modules-core')
 
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${safeExtGet('kotlinVersion', '1.4.21')}"
 }

--- a/packages/expo-location/android/build.gradle
+++ b/packages/expo-location/android/build.gradle
@@ -64,18 +64,9 @@ android {
   }
 }
 
-if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-  apply from: project(":unimodules-core").file("../unimodules-core.gradle")
-} else {
-  throw new GradleException(
-      "'unimodules-core.gradle' was not found in the usual React Native dependency location. " +
-          "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
-}
-
 dependencies {
-  unimodule "unimodules-core"
-  unimodule 'expo-modules-core'
-  unimodule "unimodules-task-manager-interface"
+  implementation project(':expo-modules-core')
+  implementation project(':unimodules-task-manager-interface')
 
   api 'com.google.android.gms:play-services-location:16.0.0'
 

--- a/packages/expo-mail-composer/android/build.gradle
+++ b/packages/expo-mail-composer/android/build.gradle
@@ -64,16 +64,8 @@ android {
   }
 }
 
-if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-  apply from: project(":unimodules-core").file("../unimodules-core.gradle")
-} else {
-  throw new GradleException(
-      "'unimodules-core.gradle' was not found in the usual React Native dependency location. " +
-          "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
-}
-
 dependencies {
-  unimodule "unimodules-core"
+  implementation project(':expo-modules-core')
 
   api "androidx.appcompat:appcompat:1.2.0"
 

--- a/packages/expo-media-library/android/build.gradle
+++ b/packages/expo-media-library/android/build.gradle
@@ -65,21 +65,15 @@ android {
   }
 }
 
-if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-  apply from: project(":unimodules-core").file("../unimodules-core.gradle")
-} else {
-  throw new GradleException(
-      "'unimodules-core.gradle' was not found in the usual React Native dependency location. " +
-          "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
-}
-
 dependencies {
-  unimodule "unimodules-core"
-  unimodule 'expo-modules-core'
-
-  testImplementation "org.robolectric:robolectric:4.3.1"
+  implementation project(':expo-modules-core')
 
   api "androidx.exifinterface:exifinterface:1.0.0"
 
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${safeExtGet('kotlinVersion', '1.4.21')}"
+
+  if (project.findProject(':unimodules-test-core')) {
+    testImplementation project(':unimodules-test-core')
+  }
+  testImplementation "org.robolectric:robolectric:4.3.1"
 }

--- a/packages/expo-network/android/build.gradle
+++ b/packages/expo-network/android/build.gradle
@@ -64,16 +64,8 @@ android {
   }
 }
 
-if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-  apply from: project(":unimodules-core").file("../unimodules-core.gradle")
-} else {
-  throw new GradleException(
-      '\'unimodules-core.gradle\' was not found in the usual React Native dependency location. ' +
-          'This package can only be used in such projects. Are you sure you\'ve installed the dependencies properly?')
-}
-
 dependencies {
-  unimodule 'unimodules-core'
+  implementation project(':expo-modules-core')
 
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${safeExtGet('kotlinVersion', '1.4.21')}"
 }

--- a/packages/expo-notifications/android/build.gradle
+++ b/packages/expo-notifications/android/build.gradle
@@ -69,18 +69,9 @@ android {
   }
 }
 
-if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-  apply from: project(":unimodules-core").file("../unimodules-core.gradle")
-} else {
-  throw new GradleException(
-      '\'unimodules-core.gradle\' was not found in the usual React Native dependency location. ' +
-          'This package can only be used in such projects. Are you sure you\'ve installed the dependencies properly?')
-}
-
 dependencies {
-  unimodule 'unimodules-core'
-  unimodule 'expo-modules-core'
-  unimodule "unimodules-task-manager-interface"
+  implementation project(':expo-modules-core')
+  implementation project(':unimodules-task-manager-interface')
 
   api 'androidx.core:core:1.5.0'
   api 'androidx.lifecycle:lifecycle-runtime:2.2.0'

--- a/packages/expo-payments-stripe/android/build.gradle
+++ b/packages/expo-payments-stripe/android/build.gradle
@@ -64,16 +64,8 @@ android {
   }
 }
 
-if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-  apply from: project(":unimodules-core").file("../unimodules-core.gradle")
-} else {
-  throw new GradleException(
-      "'unimodules-core.gradle' was not found in the usual React Native dependency location. " +
-          "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
-}
-
 dependencies {
-  unimodule "unimodules-core"
+  implementation project(':expo-modules-core')
 
   api 'com.google.android.gms:play-services-wallet:15.0.1'
   api 'com.google.firebase:firebase-core:16.0.1'

--- a/packages/expo-permissions/android/build.gradle
+++ b/packages/expo-permissions/android/build.gradle
@@ -68,17 +68,8 @@ repositories {
   mavenCentral()
 }
 
-if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-  apply from: project(":unimodules-core").file("../unimodules-core.gradle")
-} else {
-  throw new GradleException(
-      "'unimodules-core.gradle' was not found in the usual React Native dependency location. " +
-          "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
-}
-
 dependencies {
-  unimodule 'unimodules-core'
-  unimodule 'expo-modules-core'
+  implementation project(':expo-modules-core')
 
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${safeExtGet('kotlinVersion', '1.4.21')}"
   api "androidx.appcompat:appcompat:1.2.0"

--- a/packages/expo-print/android/build.gradle
+++ b/packages/expo-print/android/build.gradle
@@ -64,16 +64,8 @@ android {
   }
 }
 
-if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-  apply from: project(":unimodules-core").file("../unimodules-core.gradle")
-} else {
-  throw new GradleException(
-      "'unimodules-core.gradle' was not found in the usual React Native dependency location. " +
-          "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
-}
-
 dependencies {
-  unimodule "unimodules-core"
+  implementation project(':expo-modules-core')
 
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${safeExtGet('kotlinVersion', '1.4.21')}"
 }

--- a/packages/expo-screen-capture/android/build.gradle
+++ b/packages/expo-screen-capture/android/build.gradle
@@ -64,20 +64,12 @@ android {
   }
 }
 
-if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-  apply from: project(":unimodules-core").file("../unimodules-core.gradle")
-} else {
-  throw new GradleException(
-      '\'unimodules-core.gradle\' was not found in the usual React Native dependency location. ' +
-          'This package can only be used in such projects. Are you sure you\'ve installed the dependencies properly?')
-}
-
 repositories {
   mavenCentral()
 }
 
 dependencies {
-  unimodule 'unimodules-core'
+  implementation project(':expo-modules-core')
   implementation 'androidx.appcompat:appcompat:1.2.0'
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${safeExtGet('kotlinVersion', '1.4.21')}"
 }

--- a/packages/expo-screen-orientation/android/build.gradle
+++ b/packages/expo-screen-orientation/android/build.gradle
@@ -64,16 +64,8 @@ android {
   }
 }
 
-if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-  apply from: project(":unimodules-core").file("../unimodules-core.gradle")
-} else {
-  throw new GradleException(
-      '\'unimodules-core.gradle\' was not found in the usual React Native dependency location. ' +
-          'This package can only be used in such projects. Are you sure you\'ve installed the dependencies properly?')
-}
-
 dependencies {
-  unimodule 'unimodules-core'
+  implementation project(':expo-modules-core')
 
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${safeExtGet('kotlinVersion', '1.4.21')}"
 }

--- a/packages/expo-secure-store/android/build.gradle
+++ b/packages/expo-secure-store/android/build.gradle
@@ -64,16 +64,8 @@ android {
   }
 }
 
-if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-  apply from: project(':unimodules-core').file('../unimodules-core.gradle')
-} else {
-  throw new GradleException(
-      '\'unimodules-core.gradle\' was not found in the usual React Native dependency location. ' +
-          'This package can only be used in such projects. Are you sure you\'ve installed the dependencies properly?')
-}
-
 dependencies {
-  unimodule 'unimodules-core'
+  implementation project(':expo-modules-core')
 
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${safeExtGet('kotlinVersion', '1.4.21')}"
 }

--- a/packages/expo-sensors/android/build.gradle
+++ b/packages/expo-sensors/android/build.gradle
@@ -64,17 +64,8 @@ android {
   }
 }
 
-if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-  apply from: project(":unimodules-core").file("../unimodules-core.gradle")
-} else {
-  throw new GradleException(
-      "'unimodules-core.gradle' was not found in the usual React Native dependency location. " +
-          "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
-}
-
 dependencies {
-  unimodule "unimodules-core"
-  unimodule 'expo-modules-core'
+  implementation project(':expo-modules-core')
 
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${safeExtGet('kotlinVersion', '1.4.21')}"
 }

--- a/packages/expo-sharing/android/build.gradle
+++ b/packages/expo-sharing/android/build.gradle
@@ -68,17 +68,8 @@ android {
   }
 }
 
-if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-  apply from: project(":unimodules-core").file("../unimodules-core.gradle")
-} else {
-  throw new GradleException(
-      "'unimodules-core.gradle' was not found in the usual React Native dependency location. " +
-          "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
-}
-
 dependencies {
-  unimodule 'unimodules-core'
-  unimodule 'expo-modules-core'
+  implementation project(':expo-modules-core')
 
   api "androidx.legacy:legacy-support-v4:1.0.0"
 

--- a/packages/expo-sms/android/build.gradle
+++ b/packages/expo-sms/android/build.gradle
@@ -64,20 +64,16 @@ android {
   }
 }
 
-if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-  apply from: project(":unimodules-core").file("../unimodules-core.gradle")
-} else {
-  throw new GradleException(
-      "'unimodules-core.gradle' was not found in the usual React Native dependency location. " +
-          "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
-}
-
 dependencies {
-  testImplementation "org.robolectric:robolectric:4.5.1"
-  testImplementation 'junit:junit:4.12'
-  unimodule "unimodules-core"
+  implementation project(':expo-modules-core')
 
   implementation 'androidx.annotation:annotation:1.1.0'
 
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${safeExtGet('kotlinVersion', '1.4.21')}"
+
+  if (project.findProject(':unimodules-test-core')) {
+    testImplementation project(':unimodules-test-core')
+  }
+  testImplementation "org.robolectric:robolectric:4.5.1"
+  testImplementation 'junit:junit:4.12'
 }

--- a/packages/expo-speech/android/build.gradle
+++ b/packages/expo-speech/android/build.gradle
@@ -67,16 +67,8 @@ android {
   }
 }
 
-if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-  apply from: project(":unimodules-core").file("../unimodules-core.gradle")
-} else {
-  throw new GradleException(
-      "'unimodules-core.gradle' was not found in the usual React Native dependency location. " +
-          "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
-}
-
 dependencies {
-  unimodule "unimodules-core"
+  implementation project(':expo-modules-core')
 
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${safeExtGet('kotlinVersion', '1.4.21')}"
 }

--- a/packages/expo-splash-screen/android/build.gradle
+++ b/packages/expo-splash-screen/android/build.gradle
@@ -64,16 +64,8 @@ android {
   }
 }
 
-if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-  apply from: project(':unimodules-core').file('../unimodules-core.gradle')
-} else {
-  throw new GradleException(
-      '\'unimodules-core.gradle\' was not found in the usual React Native dependency location. ' +
-          'This package can only be used in such projects. Are you sure you\'ve installed the dependencies properly?')
-}
-
 dependencies {
-  unimodule 'unimodules-core'
+  implementation project(':expo-modules-core')
 
   //noinspection GradleDynamicVersion
   implementation 'com.facebook.react:react-native:+'

--- a/packages/expo-sqlite/android/build.gradle
+++ b/packages/expo-sqlite/android/build.gradle
@@ -64,16 +64,8 @@ android {
   }
 }
 
-if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-  apply from: project(":unimodules-core").file("../unimodules-core.gradle")
-} else {
-  throw new GradleException(
-      "'unimodules-core.gradle' was not found in the usual React Native dependency location. " +
-          "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
-}
-
 dependencies {
-  unimodule "unimodules-core"
+  implementation project(':expo-modules-core')
 
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${safeExtGet('kotlinVersion', '1.4.21')}"
 }

--- a/packages/expo-store-review/android/build.gradle
+++ b/packages/expo-store-review/android/build.gradle
@@ -67,16 +67,8 @@ android {
   }
 }
 
-if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-  apply from: project(":unimodules-core").file("../unimodules-core.gradle")
-} else {
-  throw new GradleException(
-      "'unimodules-core.gradle' was not found in the usual React Native dependency location. " +
-          "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
-}
-
 dependencies {
-  unimodule "unimodules-core"
+  implementation project(':expo-modules-core')
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${safeExtGet('kotlinVersion', '1.4.21')}"
   api 'com.google.android.gms:play-services-base:17.3.0'
   api 'com.google.android.play:core:1.8.0'

--- a/packages/expo-structured-headers/android/build.gradle
+++ b/packages/expo-structured-headers/android/build.gradle
@@ -65,20 +65,12 @@ android {
   }
 }
 
-if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-  apply from: project(":unimodules-core").file("../unimodules-core.gradle")
-} else {
-  throw new GradleException(
-      '\'unimodules-core.gradle\' was not found in the usual React Native dependency location. ' +
-          'This package can only be used in such projects. Are you sure you\'ve installed the dependencies properly?')
-}
-
 repositories {
   mavenCentral()
 }
 
 dependencies {
-  unimodule 'unimodules-core'
+  implementation project(':expo-modules-core')
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${safeExtGet('kotlinVersion', '1.4.21')}"
   implementation "androidx.appcompat:appcompat:1.2.0"
 

--- a/packages/expo-task-manager/android/build.gradle
+++ b/packages/expo-task-manager/android/build.gradle
@@ -64,19 +64,11 @@ android {
   }
 }
 
-if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-  apply from: project(":unimodules-core").file("../unimodules-core.gradle")
-} else {
-  throw new GradleException(
-      "'unimodules-core.gradle' was not found in the usual React Native dependency location. " +
-          "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
-}
-
 dependencies {
-  unimodule "unimodules-core"
-  unimodule "unimodules-task-manager-interface"
-  unimodule 'expo-modules-core'
-  unimodule "unimodules-app-loader"
+  implementation project(':expo-modules-core')
+  implementation project(':unimodules-task-manager-interface')
+  implementation project(':expo-modules-core')
+  implementation project(':unimodules-app-loader')
 
   api "androidx.core:core:1.0.0"
 

--- a/packages/expo-updates/android/build.gradle
+++ b/packages/expo-updates/android/build.gradle
@@ -78,18 +78,10 @@ android {
   }
 }
 
-if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-  apply from: project(":unimodules-core").file("../unimodules-core.gradle")
-} else {
-  throw new GradleException(
-      '\'unimodules-core.gradle\' was not found in the usual React Native dependency location. ' +
-          'This package can only be used in such projects. Are you sure you\'ve installed the dependencies properly?')
-}
-
 dependencies {
-  unimodule 'unimodules-core'
-  unimodule 'expo-structured-headers'
-  unimodule 'expo-updates-interface'
+  implementation project(':expo-modules-core')
+  implementation project(':expo-structured-headers')
+  implementation project(':expo-updates-interface')
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
 

--- a/packages/expo-video-thumbnails/android/build.gradle
+++ b/packages/expo-video-thumbnails/android/build.gradle
@@ -64,17 +64,8 @@ android {
   }
 }
 
-if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-  apply from: project(":unimodules-core").file("../unimodules-core.gradle")
-} else {
-  throw new GradleException(
-      '\'unimodules-core.gradle\' was not found in the usual React Native dependency location. ' +
-          'This package can only be used in such projects. Are you sure you\'ve installed the dependencies properly?')
-}
-
 dependencies {
-  unimodule 'unimodules-core'
-  unimodule 'expo-modules-core'
+  implementation project(':expo-modules-core')
 
   api "androidx.annotation:annotation:1.0.0"
 

--- a/packages/expo-web-browser/android/build.gradle
+++ b/packages/expo-web-browser/android/build.gradle
@@ -65,20 +65,15 @@ android {
   }
 }
 
-if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-  apply from: project(':unimodules-core').file('../unimodules-core.gradle')
-} else {
-  throw new GradleException(
-      '\'unimodules-core.gradle\' was not found in the usual React Native dependency location. ' +
-          'This package can only be used in such projects. Are you sure you\'ve installed the dependencies properly?')
-}
-
 dependencies {
-  unimodule 'unimodules-core'
-
-  testImplementation "org.robolectric:robolectric:4.3.1"
+  implementation project(':expo-modules-core')
 
   api "androidx.browser:browser:1.2.0"
 
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${safeExtGet('kotlinVersion', '1.4.21')}"
+
+  if (project.findProject(':unimodules-test-core')) {
+    testImplementation project(':unimodules-test-core')
+  }
+  testImplementation "org.robolectric:robolectric:4.3.1"
 }

--- a/packages/unimodules-app-loader/android/build.gradle
+++ b/packages/unimodules-app-loader/android/build.gradle
@@ -64,20 +64,11 @@ android {
   }
 }
 
-if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-  apply from: project(":unimodules-core").file("../unimodules-core.gradle")
-} else {
-  throw new GradleException(
-      '\'unimodules-core.gradle\' was not found in the usual React Native dependency location. ' +
-          'This package can only be used in such projects. Are you sure you\'ve installed the dependencies properly?')
-}
-
 repositories {
   mavenCentral()
 }
 
 dependencies {
-  unimodule 'unimodules-core'
   api project(':expo-modules-core')
 
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${safeExtGet('kotlinVersion', '1.4.21')}"

--- a/packages/unimodules-task-manager-interface/android/build.gradle
+++ b/packages/unimodules-task-manager-interface/android/build.gradle
@@ -64,16 +64,8 @@ android {
   }
 }
 
-if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-  apply from: project(":unimodules-core").file("../unimodules-core.gradle")
-} else {
-  throw new GradleException(
-      "'unimodules-core.gradle' was not found in the usual React Native dependency location. " +
-          "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
-}
-
 dependencies {
-  unimodule "unimodules-core"
+  implementation project(':expo-modules-core')
 
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${safeExtGet('kotlinVersion', '1.4.21')}"
 }

--- a/packages/unimodules-test-core/android/build.gradle
+++ b/packages/unimodules-test-core/android/build.gradle
@@ -64,20 +64,12 @@ android {
   }
 }
 
-if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-  apply from: project(":unimodules-core").file("../unimodules-core.gradle")
-} else {
-  throw new GradleException(
-      '\'unimodules-core.gradle\' was not found in the usual React Native dependency location. ' +
-          'This package can only be used in such projects. Are you sure you\'ve installed the dependencies properly?')
-}
-
 repositories {
   mavenCentral()
 }
 
 dependencies {
-  unimodule 'unimodules-core'
+  implementation project(':expo-modules-core')
   api 'androidx.test:core:1.2.0'
   api 'junit:junit:4.12'
   api 'io.mockk:mockk:1.10.6'


### PR DESCRIPTION
# Why

Part of migration to the `expo-modules-core`.

# How

Uses `expo-module-core` instead of `unimodules-core` in Gradle files. 

# Test Plan

- compile bare-expo 
- compile Expo Go 
