### PR TITLE
[go] Add warning for unsupported classic update runtime version

### DIFF
--- a/home/components/ListItem.tsx
+++ b/home/components/ListItem.tsx
@@ -16,6 +16,7 @@ type Props = {
   imageSize?: number;
   onPress?: () => any;
   onLongPress?: () => any;
+  disabled?: boolean;
   title?: string;
   subtitle?: string;
   onPressSubtitle?: () => any;
@@ -43,13 +44,20 @@ export default class ListItem extends React.PureComponent<Props> {
       margins,
       title,
       subtitle,
+      disabled,
     } = this.props;
     return (
       <View style={last && margins !== false ? styles.marginBottomLast : undefined}>
         <StyledButton
           onPress={onPress}
           onLongPress={onLongPress}
-          style={[styles.container, last && styles.containerLast, style]}>
+          style={[
+            styles.container,
+            last && styles.containerLast,
+            style,
+            disabled && styles.disabled,
+          ]}
+          disabled={disabled}>
           {this.renderImage()}
           <StyledView style={[styles.contentContainer, !last && styles.contentContainerNotLast]}>
             <View
@@ -174,6 +182,9 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     minHeight: 44,
     paddingStart: 15,
+  },
+  disabled: {
+    opacity: 0.5,
   },
   containerLast: {
     borderBottomWidth: StyleSheet.hairlineWidth * 2,

--- a/home/components/ProjectView.tsx
+++ b/home/components/ProjectView.tsx
@@ -1,6 +1,7 @@
 import { getSDKVersionFromRuntimeVersion } from '@expo/sdk-runtime-versions';
 import { StackScreenProps } from '@react-navigation/stack';
 import dedent from 'dedent';
+import * as WebBrowser from 'expo-web-browser';
 import * as React from 'react';
 import {
   ActivityIndicator,
@@ -15,6 +16,7 @@ import {
 import FadeIn from 'react-native-fade-in-image';
 import semver from 'semver';
 
+import { Ionicons } from '../components/Icons';
 import ListItem from '../components/ListItem';
 import SectionHeader from '../components/SectionHeader';
 import ShareProjectButton from '../components/ShareProjectButton';
@@ -147,6 +149,42 @@ function ProjectHeader(props: { app: ProjectDataProject }) {
   );
 }
 
+function WarningBox({
+  title,
+  message,
+  showLearnMore,
+  onLearnMorePress,
+}: {
+  title: string;
+  message: string;
+  showLearnMore?: boolean;
+  onLearnMorePress?: () => void;
+}) {
+  const learnMoreButton = showLearnMore ? (
+    <StyledText
+      onPress={onLearnMorePress}
+      style={[styles.warningMessage, styles.warningLearnMoreButton]}>
+      Learn more
+    </StyledText>
+  ) : null;
+  return (
+    <View style={styles.warningContainer}>
+      <View style={styles.warningHeaderContainer}>
+        <Ionicons
+          name={Platform.select({ ios: 'ios-warning', default: 'md-warning' })}
+          size={18}
+          lightColor="#735C0F"
+          darkColor="#735C0F"
+          style={styles.warningHeaderIcon}
+        />
+        <StyledText style={styles.warningTitle}>{title}</StyledText>
+      </View>
+      <StyledText style={styles.warningMessage}>{message}</StyledText>
+      {learnMoreButton}
+    </View>
+  );
+}
+
 function LegacyLaunchSection({ app }: { app: ProjectDataProject }) {
   if (!appHasLegacyUpdate(app)) {
     return null;
@@ -156,29 +194,49 @@ function LegacyLaunchSection({ app }: { app: ProjectDataProject }) {
   const isLatestLegacyPublishDeprecated =
     legacyUpdatesSDKMajorVersion !== null &&
     legacyUpdatesSDKMajorVersion < Environment.lowestSupportedSdkVersion;
+  const doesLatestLegacyPublishHaveRuntimeVersion =
+    app.latestReleaseForReleaseChannel?.runtimeVersion !== null;
 
   const moreLegacyBranchesText =
     Platform.OS === 'ios'
       ? 'To launch from another classic release channel, follow the instructions on the project webpage.'
       : 'To launch from another classic release channel, scan the QR code on the project webpage.';
 
+  let warning: JSX.Element | null = null;
+  if (doesLatestLegacyPublishHaveRuntimeVersion) {
+    warning = (
+      <WarningBox
+        title="Incompatible update"
+        message="The latest update uses a runtime version that is not compatible with Expo Go. To continue, create a custom dev client."
+        showLearnMore
+        onLearnMorePress={() => {
+          WebBrowser.openBrowserAsync('https://docs.expo.dev/clients/getting-started/');
+        }}
+      />
+    );
+  } else if (isLatestLegacyPublishDeprecated) {
+    warning = (
+      <WarningBox
+        title="Unsupported SDK version"
+        message={`This project's SDK version (${legacyUpdatesSDKMajorVersion}) is no longer supported.`}
+        showLearnMore={false}
+      />
+    );
+  }
+
   return (
     <View>
       <SectionHeader title="Classic release channels" />
       <ListItem
         title="default"
+        disabled={warning !== null}
         onPress={() => {
-          if (isLatestLegacyPublishDeprecated) {
-            Alert.alert(
-              `This project's SDK version (${legacyUpdatesSDKMajorVersion}) is no longer supported.`
-            );
-          } else {
-            Linking.openURL(UrlUtils.normalizeUrl(app.fullName));
-          }
+          Linking.openURL(UrlUtils.normalizeUrl(app.fullName));
         }}
         last
       />
       <Text style={styles.moreLegacyBranchesText}>{moreLegacyBranchesText}</Text>
+      {warning}
     </View>
   );
 }
@@ -282,5 +340,35 @@ const styles = StyleSheet.create({
     color: Colors.light.greyText,
     marginBottom: 20,
     marginHorizontal: 16,
+  },
+  warningContainer: {
+    borderRadius: 4,
+    padding: 16,
+    backgroundColor: '#FFFBDD',
+    borderColor: '#FFEA7F',
+    borderWidth: 1,
+    marginBottom: 20,
+    marginHorizontal: 16,
+  },
+  warningHeaderContainer: {
+    flexDirection: 'row',
+  },
+  warningHeaderIcon: {
+    marginRight: 4,
+  },
+  warningTitle: {
+    color: '#735C0F',
+    fontWeight: '600',
+    fontSize: 15,
+    marginBottom: 6,
+    lineHeight: 22,
+  },
+  warningMessage: {
+    color: '#1B1F23',
+    fontSize: 16,
+    lineHeight: 24,
+  },
+  warningLearnMoreButton: {
+    textDecorationLine: 'underline',
   },
 });

--- a/home/containers/Project.tsx
+++ b/home/containers/Project.tsx
@@ -44,6 +44,10 @@ export type ProjectDataProject = {
     primaryColor?: string;
     colorPalette?: object;
   } | null;
+  latestReleaseForReleaseChannel?: {
+    sdkVersion: string;
+    runtimeVersion?: string | null;
+  } | null;
   updateBranches: ProjectUpdateBranch[];
 };
 

--- a/home/graphql/queries/ProjectQuery.query.generated.ts
+++ b/home/graphql/queries/ProjectQuery.query.generated.ts
@@ -10,7 +10,7 @@ export type WebContainerProjectPage_QueryVariables = Types.Exact<{
 }>;
 
 
-export type WebContainerProjectPage_Query = { __typename?: 'RootQuery', app?: Types.Maybe<{ __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, name: string, slug: string, fullName: string, username: string, published: boolean, description: string, githubUrl?: Types.Maybe<string>, playStoreUrl?: Types.Maybe<string>, appStoreUrl?: Types.Maybe<string>, sdkVersion: string, iconUrl?: Types.Maybe<string>, privacy: string, icon?: Types.Maybe<{ __typename?: 'AppIcon', url: string }>, updateBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updates: Array<{ __typename?: 'Update', id: string, group: string, message?: Types.Maybe<string>, createdAt: any, runtimeVersion: string, platform: string, manifestPermalink: string }> }> } }> };
+export type WebContainerProjectPage_Query = { __typename?: 'RootQuery', app?: Types.Maybe<{ __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, name: string, slug: string, fullName: string, username: string, published: boolean, description: string, githubUrl?: Types.Maybe<string>, playStoreUrl?: Types.Maybe<string>, appStoreUrl?: Types.Maybe<string>, sdkVersion: string, iconUrl?: Types.Maybe<string>, privacy: string, icon?: Types.Maybe<{ __typename?: 'AppIcon', url: string }>, latestReleaseForReleaseChannel?: Types.Maybe<{ __typename?: 'AppRelease', sdkVersion: string, runtimeVersion?: Types.Maybe<string> }>, updateBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updates: Array<{ __typename?: 'Update', id: string, group: string, message?: Types.Maybe<string>, createdAt: any, runtimeVersion: string, platform: string, manifestPermalink: string }> }> } }> };
 
 
 export const WebContainerProjectPage_QueryDocument = gql`
@@ -32,6 +32,10 @@ export const WebContainerProjectPage_QueryDocument = gql`
       privacy
       icon {
         url
+      }
+      latestReleaseForReleaseChannel(platform: $platform, releaseChannel: "default") {
+        sdkVersion
+        runtimeVersion
       }
       updateBranches(limit: 100, offset: 0) {
         id

--- a/home/graphql/queries/ProjectQuery.query.graphql
+++ b/home/graphql/queries/ProjectQuery.query.graphql
@@ -21,6 +21,10 @@ query WebContainerProjectPage_Query(
       icon {
         url
       }
+      latestReleaseForReleaseChannel(platform: $platform, releaseChannel: "default") {
+        sdkVersion
+        runtimeVersion
+      }
       updateBranches(limit: 100, offset: 0) {
         id
         name


### PR DESCRIPTION
# Why

Closes ENG-1814. Closes ENG-1626.

This adds a warning and disables launching a classic update in Expo Go when the most recent publish uses runtimeVersion (a dev client should be used instead in this case).

# How

Implement design. Depends on https://github.com/expo/universe/pull/8033 (the server PR that added the new GraphQL field used here).

This also changes the warning for an unsupported SDK version to this new design instead of an alert like the old one.

# Test Plan

Not supported warning:
![Simulator Screen Shot - iPhone 11 - 2021-08-17 at 10 54 47](https://user-images.githubusercontent.com/189568/129769329-02bda3ef-f923-4026-be39-60c1ccac3048.png)

SDK not supported warning:
![Simulator Screen Shot - iPhone 11 - 2021-08-17 at 10 55 32](https://user-images.githubusercontent.com/189568/129769332-e70edb83-5293-423f-8804-953fb0c7bdcc.png)

Learn more link:
![Simulator Screen Shot - iPhone 11 - 2021-08-17 at 10 55 20](https://user-images.githubusercontent.com/189568/129769334-d1255b6c-ca30-4b82-a19e-f426622839d6.png)
