### PR TITLE
[ios][BareExpo] Install expo-screen-orientation module

### DIFF
--- a/apps/bare-expo/ios/BareExpo-Bridging-Header.h
+++ b/apps/bare-expo/ios/BareExpo-Bridging-Header.h
@@ -32,3 +32,4 @@
 // Dev Client
 
 #import <EXDevLauncher/EXDevLauncherController.h>
+#import <EXScreenOrientation/EXScreenOrientationViewController.h>

--- a/apps/bare-expo/ios/BareExpo/AppDelegate.swift
+++ b/apps/bare-expo/ios/BareExpo/AppDelegate.swift
@@ -46,7 +46,7 @@ class AppDelegate: AppDelegateWrapper {
   func initializeReactNativeBridge(_ launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> RCTBridge? {
     if let bridge = RCTBridge(delegate: self, launchOptions: launchOptions) {
       let rootView = RCTRootView(bridge: bridge, moduleName: "main", initialProperties: nil)
-      let rootViewController = UIViewController()
+      let rootViewController = EXScreenOrientationViewController()!
       rootView.backgroundColor = UIColor.white
       rootViewController.view = rootView
 


### PR DESCRIPTION
# Why

`expo-screen-orientation` package is not properly installed in BareExpo app ==> it results in invalid behaviour while testing.

# How

Followed specification provided [here](https://github.com/expo/expo/tree/master/packages/expo-screen-orientation#installation-in-managed-expo-projects)

# Test Plan

BareExpo: NCL

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).