### PR TITLE
[dev-launcher] Fix intent that started activity isn't passed further

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix intent that started activity isn't passed further.
+- Fix intent that started activity isn't passed further. ([#14097](https://github.com/expo/expo/pull/14097) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix intent that started activity isn't passed further.
+
 ### 💡 Others
 
 ## 0.7.0 — 2021-09-02

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
@@ -188,6 +188,11 @@ class DevLauncherController private constructor()
         }
         return true
       }
+
+    intent?.let {
+      return handleExternalIntent(it)
+    }
+
     return false
   }
 

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/modules/DevLauncherInternalModule.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/modules/DevLauncherInternalModule.kt
@@ -100,7 +100,11 @@ class DevLauncherInternalModule(reactContext: ReactApplicationContext?)
 
   @ReactMethod
   fun getPendingDeepLink(promise: Promise) {
-    promise.resolve(intentRegistry.intent?.data?.toString())
+    intentRegistry.intent?.data?.let {
+      promise.resolve(it.toString())
+    }
+
+    promise.resolve(intentRegistry.intent?.action)
   }
 
   private fun onNewPendingIntent(intent: Intent) {

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/modules/DevLauncherInternalModule.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/modules/DevLauncherInternalModule.kt
@@ -102,6 +102,7 @@ class DevLauncherInternalModule(reactContext: ReactApplicationContext?)
   fun getPendingDeepLink(promise: Promise) {
     intentRegistry.intent?.data?.let {
       promise.resolve(it.toString())
+      return
     }
 
     promise.resolve(intentRegistry.intent?.action)


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/13992.

# How

Saves intent without data as a pending intent too.

# Test Plan

- bare-expo ✅