### PR TITLE
[ios] Add Hermes support in Expo Go

### DIFF
--- a/ios/Exponent.xcodeproj/project.pbxproj
+++ b/ios/Exponent.xcodeproj/project.pbxproj
@@ -2733,6 +2733,7 @@
 				347794D3234BFFC20087B402 /* Copy Bundle Resources Conditionally */,
 				FCF6D37525B34BC200808BF5 /* Embed App Extensions */,
 				88591D58C1664BBD41B3CF89 /* [CP] Copy Pods Resources */,
+				387963860E64A11F526AB986 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -2794,6 +2795,7 @@
 				F142191C262CB68600BB97E6 /* Copy Bundle Resources Conditionally */,
 				F142191D262CB68600BB97E6 /* Embed App Extensions */,
 				2F79C567F53916BB9CEA795D /* [CP] Copy Pods Resources */,
+				9C41C458339032BC774CD47B /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -3050,6 +3052,24 @@
 			shellPath = /bin/bash;
 			shellScript = "$SRCROOT/Build-Phases/cp-bundle-resources-conditionally.sh\n\n";
 		};
+		387963860E64A11F526AB986 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Expo Go-Expo Go (unversioned)/Pods-Expo Go-Expo Go (unversioned)-frameworks.sh",
+				"${PODS_ROOT}/hermes-engine/destroot/Library/Frameworks/iphoneos/hermes.framework",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/hermes.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Expo Go-Expo Go (unversioned)/Pods-Expo Go-Expo Go (unversioned)-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		78CEE2F21ACDF25E0095B124 /* Generate Dynamic Macros */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -3096,6 +3116,24 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Expo Go-Expo Go (unversioned)/Pods-Expo Go-Expo Go (unversioned)-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		9C41C458339032BC774CD47B /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Expo Go-Expo Go (versioned)/Pods-Expo Go-Expo Go (versioned)-frameworks.sh",
+				"${PODS_ROOT}/hermes-engine/destroot/Library/Frameworks/iphoneos/hermes.framework",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/hermes.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Expo Go-Expo Go (versioned)/Pods-Expo Go-Expo Go (versioned)-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		A30EDADFC4AC2E7F966D7D63 /* [CP] Check Pods Manifest.lock */ = {

--- a/ios/Exponent/Versioned/Core/EXVersionManager.mm
+++ b/ios/Exponent/Versioned/Core/EXVersionManager.mm
@@ -53,6 +53,7 @@
 #import <React/CoreModulesPlugins.h>
 #import <ReactCommon/RCTTurboModuleManager.h>
 #import <React/JSCExecutorFactory.h>
+#import <React/HermesExecutorFactory.h>
 #import <strings.h>
 
 // Import 3rd party modules that need to be scoped.
@@ -533,6 +534,10 @@ RCT_EXTERN void EXRegisterScopedModule(Class, ...);
                                  jsi::PropNameID::forAscii(runtime, "__reanimatedModuleProxy"),
                                  jsi::Object::createFromHostObject(runtime, reanimatedModule));
   };
+
+  if ([self.manifest.iosConfig[@"jsEngine"] isEqualToString:@"hermes"]) {
+    return new facebook::react::HermesExecutorFactory(RCTJSIExecutorRuntimeInstaller(executor));
+  }
   return new facebook::react::JSCExecutorFactory(RCTJSIExecutorRuntimeInstaller(executor));
 }
 

--- a/ios/Exponent/Versioned/Core/EXVersionManager.mm
+++ b/ios/Exponent/Versioned/Core/EXVersionManager.mm
@@ -32,6 +32,7 @@
 #import <React/RCTImageLoader.h>
 #import <React/RCTAsyncLocalStorage.h>
 #import <React/RCTJSIExecutorRuntimeInstaller.h>
+#import <React/RCTInspectorDevServerHelper.h>
 
 #import <objc/message.h>
 
@@ -138,6 +139,7 @@ RCT_EXTERN void EXRegisterScopedModule(Class, ...);
   if ([self _isDevModeEnabledForBridge:bridge]) {
     // Set the bundle url for the packager connection manually
     [[RCTPackagerConnection sharedPackagerConnection] setBundleURL:[bridge bundleURL]];
+    [RCTInspectorDevServerHelper connectWithBundleURL:[bridge bundleURL]];
   }
 #endif
 

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -46,6 +46,9 @@ abstract_target 'Expo Go' do
 
   # Unversioned React Native
   use_react_native! path: '../react-native-lab/react-native'
+  pod 'React-Core/Hermes', :path => '../react-native-lab/react-native/'
+  pod 'hermes-engine', '~> 0.7.2'
+  pod 'libevent', '~> 2.1.12'
 
   # Build React Native with RCT_DEV enabled and RCT_ENABLE_INSPECTOR and
   # RCT_ENABLE_PACKAGER_CONNECTION disabled
@@ -83,6 +86,25 @@ abstract_target 'Expo Go' do
         config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] << 'RCT_DEV=1'
         config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] << 'RCT_ENABLE_INSPECTOR=0'
         config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] << 'ENABLE_PACKAGER_CONNECTION=0'
+      end
+    end
+
+    installer.pod_target_subprojects.each do |subproject|
+      if subproject.project_name == 'RCT-Folly'
+        folly_dir = File.join(File.dirname(subproject.path), 'RCT-Folly')
+
+        ## Fix for RTC-Folly on iOS 14.5 - makes Hermes work again
+        find_and_replace(
+          "#{folly_dir}/folly/synchronization/DistributedMutex-inl.h",
+          'atomic_notify_one(state)',
+          'folly::atomic_notify_one(state)'
+        )
+
+        find_and_replace(
+          "#{folly_dir}/folly/synchronization/DistributedMutex-inl.h",
+          'atomic_wait_until(&state, previous | data, deadline)',
+          'folly::atomic_wait_until(&state, previous | data, deadline)'
+        )
       end
     end
   end

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2078,7 +2078,9 @@ PODS:
     - AppAuth/Core (~> 1.4)
     - GTMSessionFetcher/Core (~> 1.5)
   - GTMSessionFetcher/Core (1.5.0)
+  - hermes-engine (0.7.2)
   - JKBigInteger2 (0.0.5)
+  - libevent (2.1.12)
   - lottie-ios (3.1.9)
   - lottie-react-native (4.0.2):
     - lottie-ios (~> 3.1.8)
@@ -2120,6 +2122,11 @@ PODS:
     - boost-for-react-native
     - DoubleConversion
     - glog
+  - RCT-Folly/Futures (2020.01.13.00):
+    - boost-for-react-native
+    - DoubleConversion
+    - glog
+    - libevent
   - RCTRequired (0.64.2)
   - RCTTypeSafety (0.64.2):
     - FBLazyVector (= 0.64.2)
@@ -2175,6 +2182,16 @@ PODS:
     - React-jsi (= 0.64.2)
     - React-jsiexecutor (= 0.64.2)
     - React-jsinspector (= 0.64.2)
+    - React-perflogger (= 0.64.2)
+    - Yoga
+  - React-Core/Hermes (0.64.2):
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2020.01.13.00)
+    - RCT-Folly/Futures
+    - React-cxxreact (= 0.64.2)
+    - React-jsi (= 0.64.2)
+    - React-jsiexecutor (= 0.64.2)
     - React-perflogger (= 0.64.2)
     - Yoga
   - React-Core/RCTActionSheetHeaders (0.64.2):
@@ -2814,7 +2831,9 @@ DEPENDENCIES:
   - glog (from `../react-native-lab/react-native/third-party-podspecs/glog.podspec`)
   - Google-Maps-iOS-Utils (~> 2.1.0)
   - GoogleMaps (~> 3.6)
+  - hermes-engine (~> 0.7.2)
   - JKBigInteger2 (= 0.0.5)
+  - libevent (~> 2.1.12)
   - lottie-react-native (from `./vendored/unversioned/lottie-react-native`)
   - MBProgressHUD (~> 1.2.0)
   - Nimble (from `./Nimble.podspec`)
@@ -2826,6 +2845,7 @@ DEPENDENCIES:
   - React-callinvoker (from `../react-native-lab/react-native/ReactCommon/callinvoker`)
   - React-Core (from `../react-native-lab/react-native/`)
   - React-Core/DevSupport (from `../react-native-lab/react-native/`)
+  - React-Core/Hermes (from `../react-native-lab/react-native/`)
   - React-Core/RCTWebSocket (from `../react-native-lab/react-native/`)
   - React-CoreModules (from `../react-native-lab/react-native/React/CoreModules`)
   - React-cxxreact (from `../react-native-lab/react-native/ReactCommon/cxxreact`)
@@ -2883,7 +2903,9 @@ SPEC REPOS:
     - GoogleUtilitiesComponents
     - GTMAppAuth
     - GTMSessionFetcher
+    - hermes-engine
     - JKBigInteger2
+    - libevent
     - lottie-ios
     - MBProgressHUD
     - MLKitCommon
@@ -4120,7 +4142,9 @@ SPEC CHECKSUMS:
   GoogleUtilitiesComponents: a69c0b3b369ba443e988141e75ef49d9010b1c80
   GTMAppAuth: ad5c2b70b9a8689e1a04033c9369c4915bfcbe89
   GTMSessionFetcher: b3503b20a988c4e20cc189aa798fd18220133f52
+  hermes-engine: 7d97ba46a1e29bacf3e3c61ecb2804a5ddd02d4f
   JKBigInteger2: e91672035c42328c48b7dd015b66812ddf40ca9b
+  libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   lottie-ios: 3a3758ef5a008e762faec9c9d50a39842f26d124
   lottie-react-native: 4dff8fe8d10ddef9e7880e770080f4a56121397e
   MBProgressHUD: 3ee5efcc380f6a79a7cc9b363dd669c5e1ae7406
@@ -4167,6 +4191,6 @@ SPEC CHECKSUMS:
   Yoga: 575c581c63e0d35c9a83f4b46d01d63abc1100ac
   ZXingObjC: fdbb269f25dd2032da343e06f10224d62f537bdb
 
-PODFILE CHECKSUM: 87c05f8218d0dca71299101a58080f0d0a6ea88e
+PODFILE CHECKSUM: a37a64134f19810992d51f5599b2f471548e8086
 
 COCOAPODS: 1.10.2

--- a/ios/vendored/sdk41/react-native-reanimated/ios/native/NativeProxy.mm
+++ b/ios/vendored/sdk41/react-native-reanimated/ios/native/NativeProxy.mm
@@ -9,8 +9,8 @@
 #import <ABI41_0_0React/ABI41_0_0RCTFollyConvert.h>
 #import <ABI41_0_0React/ABI41_0_0RCTUIManager.h>
 
-#if __has_include(<hermes/hermes.h>)
-#import <hermes/hermes.h>
+#if __has_include(<ABI41_0_0hermes/ABI41_0_0hermes.h>)
+#import <ABI41_0_0hermes/ABI41_0_0hermes.h>
 #else
 #import <ABI41_0_0jsi/ABI41_0_0JSCRuntime.h>
 #endif
@@ -113,7 +113,7 @@ std::shared_ptr<NativeReanimatedModule> createReanimatedModule(std::shared_ptr<C
 
   std::shared_ptr<Scheduler> scheduler(new ABI41_0_0REAIOSScheduler(jsInvoker));
 
-#if __has_include(<hermes/hermes.h>)
+#if __has_include(<ABI41_0_0hermes/ABI41_0_0hermes.h>)
   std::unique_ptr<jsi::Runtime> animatedRuntime = ABI41_0_0facebook::hermes::makeHermesRuntime();
 #else
   std::unique_ptr<jsi::Runtime> animatedRuntime = ABI41_0_0facebook::jsc::makeJSCRuntime();

--- a/ios/vendored/sdk42/react-native-reanimated/ios/native/NativeProxy.mm
+++ b/ios/vendored/sdk42/react-native-reanimated/ios/native/NativeProxy.mm
@@ -8,8 +8,8 @@
 #import <ABI42_0_0React/ABI42_0_0RCTFollyConvert.h>
 #import <ABI42_0_0React/ABI42_0_0RCTUIManager.h>
 
-#if __has_include(<hermes/hermes.h>)
-#import <hermes/hermes.h>
+#if __has_include(<ABI42_0_0hermes/ABI42_0_0hermes.h>)
+#import <ABI42_0_0hermes/ABI42_0_0hermes.h>
 #else
 #import <ABI42_0_0jsi/ABI42_0_0JSCRuntime.h>
 #endif
@@ -111,7 +111,7 @@ std::shared_ptr<NativeReanimatedModule> createReanimatedModule(std::shared_ptr<C
   };
 
 
-#if __has_include(<hermes/hermes.h>)
+#if __has_include(<ABI42_0_0hermes/ABI42_0_0hermes.h>)
   std::unique_ptr<jsi::Runtime> animatedRuntime = ABI42_0_0facebook::hermes::makeHermesRuntime();
 #else
   std::unique_ptr<jsi::Runtime> animatedRuntime = ABI42_0_0facebook::jsc::makeJSCRuntime();

--- a/tools/src/versioning/ios/versionVendoredModules.ts
+++ b/tools/src/versioning/ios/versionVendoredModules.ts
@@ -106,6 +106,9 @@ function baseTransformsFactory(prefix: string): Required<FileTransforms> {
         },
       },
       {
+        // for react-native-reanimated, setup hermes as non-existent versioned header.
+        // it will use jsc as fallback.
+        paths: 'NativeProxy.mm',
         find: /<hermes\/hermes\.h>/g,
         replaceWith: `<${prefix}hermes/${prefix}hermes.h>`,
       },

--- a/tools/src/versioning/ios/versionVendoredModules.ts
+++ b/tools/src/versioning/ios/versionVendoredModules.ts
@@ -106,6 +106,10 @@ function baseTransformsFactory(prefix: string): Required<FileTransforms> {
         },
       },
       {
+        find: /<hermes\/hermes\.h>/g,
+        replaceWith: `<${prefix}hermes/${prefix}hermes.h>`,
+      },
+      {
         // Objective-C only, see the comment in the rule below.
         paths: '*.{h,m,mm}',
         find: /r(eactTag|eactSubviews|eactSuperview|eactViewController|eactSetFrame|eactAddControllerToClosestParent|eactZIndex)/gi,


### PR DESCRIPTION
# Why

dunno if that is a good idea or not to add this in expo-go, especially for apple review guideline.
anyway to work on this first.

# How

- add hermes related pods
- use hermes executor factory if `ios.jsEngine` is `hermes`
- add inspector connection to support inspector

this is unversioned support. for hermes-engine versioning, will be addressed next.

# Test Plan

add `{"ios": { "jsEngine" : "hermes" }}` in NCL and load by Expo Go

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).