### PR TITLE
[picker][android] multiline support for RNPicker

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/picker/ReactPickerManager.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/picker/ReactPickerManager.java
@@ -33,6 +33,7 @@ import com.facebook.react.uimanager.events.EventDispatcher;
 import java.util.Map;
 
 import javax.annotation.Nullable;
+import host.exp.expoview.R;
 
 /**
  * {@link ViewManager} for the {@link ReactPicker} view. This is abstract because the

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/picker/ReactPickerManager.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/picker/ReactPickerManager.java
@@ -241,8 +241,8 @@ public abstract class ReactPickerManager extends BaseViewManager<ReactPicker, Re
 
       if (convertView == null) {
         int layoutResId = isDropdown
-              ? android.R.layout.simple_spinner_dropdown_item
-              : android.R.layout.simple_spinner_item;
+              ? R.layout.simple_spinner_dropdown_item
+              : R.layout.simple_spinner_item;
         convertView = mInflater.inflate(layoutResId, parent, false);
       }
 

--- a/android/expoview/src/main/res/layout/simple_spinner_dropdown_item.xml
+++ b/android/expoview/src/main/res/layout/simple_spinner_dropdown_item.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<com.reactnativecommunity.picker.CheckedTextViewImpl
+<versioned.host.exp.exponent.modules.api.components.picker.CheckedTextViewImpl
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@android:id/text1"

--- a/android/expoview/src/main/res/layout/simple_spinner_item.xml
+++ b/android/expoview/src/main/res/layout/simple_spinner_item.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<com.reactnativecommunity.picker.TextViewImpl
+<versioned.host.exp.exponent.modules.api.components.picker.TextViewImpl
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@android:id/text1"

--- a/apps/native-component-list/src/screens/PickerScreen.tsx
+++ b/apps/native-component-list/src/screens/PickerScreen.tsx
@@ -1,4 +1,4 @@
-import { Picker } from '@react-native-picker/picker';
+import { Picker, PickerProps } from '@react-native-picker/picker';
 import { Platform } from 'expo-modules-core';
 import * as React from 'react';
 import { Text, Button } from 'react-native';
@@ -72,9 +72,7 @@ PickerScreen.navigationOptions = {
   title: 'Picker',
 };
 
-function GenericPicker(
-  props: Partial<React.ComponentProps<typeof Picker>> & { children?: React.ReactNode }
-) {
+function GenericPicker(props: React.PropsWithChildren<PickerProps>) {
   const [value, setValue] = React.useState<any>('java');
 
   return (

--- a/apps/native-component-list/src/screens/PickerScreen.tsx
+++ b/apps/native-component-list/src/screens/PickerScreen.tsx
@@ -26,6 +26,22 @@ export default function PickerScreen() {
       )}
 
       {Platform.OS === 'android' && (
+        <Section title="Multiline picker item">
+          <GenericPicker numberOfLines={2}>
+            <Picker.Item label="Really really really really really really really long label" />
+          </GenericPicker>
+        </Section>
+      )}
+
+      {Platform.OS === 'android' && (
+        <Section title="Single line picker item">
+          <GenericPicker numberOfLines={1}>
+            <Picker.Item label="Really really really really really really really long label" />
+          </GenericPicker>
+        </Section>
+      )}
+
+      {Platform.OS === 'android' && (
         <Section title="Dropdown mode">
           <GenericPicker mode="dropdown" />
         </Section>
@@ -56,7 +72,9 @@ PickerScreen.navigationOptions = {
   title: 'Picker',
 };
 
-function GenericPicker(props: Partial<React.ComponentProps<typeof Picker>>) {
+function GenericPicker(
+  props: Partial<React.ComponentProps<typeof Picker>> & { children?: React.ReactNode }
+) {
   const [value, setValue] = React.useState<any>('java');
 
   return (
@@ -66,6 +84,7 @@ function GenericPicker(props: Partial<React.ComponentProps<typeof Picker>>) {
         <Picker.Item label="JavaScript" value="js" />
         <Picker.Item label="Objective C" value="objc" />
         <Picker.Item label="Swift" value="swift" />
+        {props.children}
       </Picker>
       <Text>Selected: {value}</Text>
     </>


### PR DESCRIPTION
# Why

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

Multiline picker items were added in a recent release of RNPicker. While we upgraded to this version, the required layout components were not included in our versioned SDKs. This PR restores the multiline functionality. As a safeguard, I've included these examples in NCL to verify after versioning QA. 

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

Initially tested the existing functionality on SDK 42 with Expo Go by adding examples to NCL that make use of the `numberOfLines` prop.  Any label that expands beyond the width of the container appears to shrink the text down instead of wrapping to multiple lines.

Then I updated the implementation on Bare expo and verified that correcting the resource files that RNPicker is using leads to the expected multiline behaviour

# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->

NCL captures the expected behaviour, this will probably not have any issues on unversioned QA but will definitely need to be confirmed on versioned for SDK 43

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).