### PR TITLE
[babel] remap native imports

### DIFF
--- a/packages/babel-preset-expo/README.md
+++ b/packages/babel-preset-expo/README.md
@@ -100,3 +100,29 @@ Enabling this option will allow your project to run with older JavaScript syntax
     }
 ],
 ```
+
+### `native.useRemap`
+
+> This setting provides native parity with `react-native-web`, which also remaps imports to their exact locations.
+
+Enabling this option will remap all React Native imports to internal imports. This plugin lets you skip over the main entry file of `react-native` and effectively bundle less code, faster.
+The drawback is that you won't see any deprecations warnings provided by the `react-native` re-export file.
+
+Importing everything (`import * as RN from 'react-native'`), or anything invalid module (`import { foobar } from 'react-native'`) will effectively break the plugin and cause everything in React Native to be bundled (default behavior without this plugin).
+
+The only legitimate reason to do this, is to access the flow type `HostComponent` which is only implemented in the `react-native` entry file, and cannot be remapped.
+
+Importing any of the already deprecated packages will also cause everything to be bundled, but they'll throw a useful error message so you can remove the import, this includes:
+
+ART, ListView, SwipeableListView, WebView, NetInfo, CameraRoll, ImageStore, ImageEditor, TimePickerAndroid, ToolbarAndroid, ViewPagerAndroid.
+
+**default:** `false`
+
+```js
+[
+    'babel-preset-expo',
+    {
+        native: { useRemap: true }
+    }
+],
+```

--- a/packages/babel-preset-expo/index.js
+++ b/packages/babel-preset-expo/index.js
@@ -102,6 +102,7 @@ module.exports = function(api, options = {}) {
       [require.resolve('@babel/plugin-proposal-decorators'), { legacy: true }],
       platform === 'web' && [require.resolve('babel-plugin-react-native-web')],
       isWebpack && platform !== 'web' && [require.resolve('./plugins/disable-ambiguous-requires')],
+      platform !== 'web' && [require.resolve('./plugins/remap-react-native-imports')],
     ].filter(Boolean),
   };
 };

--- a/packages/babel-preset-expo/index.js
+++ b/packages/babel-preset-expo/index.js
@@ -101,8 +101,9 @@ module.exports = function(api, options = {}) {
       getAliasPlugin(),
       [require.resolve('@babel/plugin-proposal-decorators'), { legacy: true }],
       platform === 'web' && [require.resolve('babel-plugin-react-native-web')],
+      native.useRemap &&
+        platform !== 'web' && [require.resolve('./plugins/remap-react-native-imports')],
       isWebpack && platform !== 'web' && [require.resolve('./plugins/disable-ambiguous-requires')],
-      platform !== 'web' && [require.resolve('./plugins/remap-react-native-imports')],
     ].filter(Boolean),
   };
 };

--- a/packages/babel-preset-expo/package.json
+++ b/packages/babel-preset-expo/package.json
@@ -52,6 +52,7 @@
     "metro-react-native-babel-preset": "~0.64.0"
   },
   "devDependencies": {
+    "babel-plugin-tester": "^10.1.0",
     "@babel/core": "^7.12.9",
     "jest": "^26.6.3"
   }

--- a/packages/babel-preset-expo/plugins/__tests__/__snapshots__/remap-react-native-imports-test.js.snap
+++ b/packages/babel-preset-expo/plugins/__tests__/__snapshots__/remap-react-native-imports-test.js.snap
@@ -1,0 +1,102 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Rewrite react-native to internal imports export from "react-native": export from "react-native" 1`] = `
+
+export { View, findNodeHandle } from 'react-native';
+export { StyleSheet, Text } from 'react-native';
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+export { default as View } from 'react-native/Libraries/Components/View/View';
+export { findNodeHandle } from 'react-native/Libraries/Renderer/shims/ReactNative';
+export { default as StyleSheet } from 'react-native/Libraries/StyleSheet/StyleSheet';
+export { default as Text } from 'react-native/Libraries/Text/Text';
+
+
+`;
+
+exports[`Rewrite react-native to internal imports import from "native-native": import from "native-native" 1`] = `
+
+import ReactNative from 'react-native';
+import { View, Pressable, findNodeHandle } from 'react-native';
+import { Invalid, View as MyView } from 'react-native';
+import * as ReactNativeModules from 'react-native';
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import ReactNative from 'react-native/index';
+import View from 'react-native/Libraries/Components/View/View';
+import Pressable from 'react-native/Libraries/Components/Pressable/Pressable';
+import { findNodeHandle } from 'react-native/Libraries/Renderer/shims/ReactNative';
+import { Invalid } from 'react-native/index';
+import MyView from 'react-native/Libraries/Components/View/View';
+import * as ReactNativeModules from 'react-native/index';
+
+
+`;
+
+exports[`Rewrite react-native to internal imports import from "native-native": import from "native-native" 2`] = `
+
+import ReactNative from 'react-native';
+import { View, Pressable, findNodeHandle } from 'react-native';
+import { Invalid, View as MyView } from 'react-native';
+import * as ReactNativeModules from 'react-native';
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import ReactNative from 'react-native/index';
+import View from 'react-native/Libraries/Components/View/View';
+import Pressable from 'react-native/Libraries/Components/Pressable/Pressable';
+import { findNodeHandle } from 'react-native/Libraries/Renderer/shims/ReactNative';
+import { Invalid } from 'react-native/index';
+import MyView from 'react-native/Libraries/Components/View/View';
+import * as ReactNativeModules from 'react-native/index';
+
+
+`;
+
+exports[`Rewrite react-native to internal imports require "react-native": require "react-native" 1`] = `
+
+const ReactNative = require('react-native');
+const { View, Pressable, findNodeHandle } = require('react-native');
+const { StyleSheet, TouchableOpacity } = require('react-native');
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+const ReactNative = require('react-native/index');
+
+const View = require('react-native/Libraries/Components/View/View');
+
+const Pressable = require('react-native/Libraries/Components/Pressable/Pressable').default;
+
+const findNodeHandle = require('react-native/Libraries/Renderer/shims/ReactNative').findNodeHandle;
+
+const StyleSheet = require('react-native/Libraries/StyleSheet/StyleSheet');
+
+const TouchableOpacity = require('react-native/Libraries/Components/Touchable/TouchableOpacity');
+
+
+`;
+
+exports[`Rewrite react-native to internal imports require "react-native": require "react-native" 2`] = `
+
+const ReactNative = require('react-native');
+const { View, Pressable, findNodeHandle } = require('react-native');
+const { StyleSheet, TouchableOpacity } = require('react-native');
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+const ReactNative = require('react-native/index');
+
+const View = require('react-native/Libraries/Components/View/View');
+
+const Pressable = require('react-native/Libraries/Components/Pressable/Pressable').default;
+
+const findNodeHandle = require('react-native/Libraries/Renderer/shims/ReactNative').findNodeHandle;
+
+const StyleSheet = require('react-native/Libraries/StyleSheet/StyleSheet');
+
+const TouchableOpacity = require('react-native/Libraries/Components/Touchable/TouchableOpacity');
+
+
+`;

--- a/packages/babel-preset-expo/plugins/__tests__/remap-react-native-imports-test.js
+++ b/packages/babel-preset-expo/plugins/__tests__/remap-react-native-imports-test.js
@@ -1,0 +1,57 @@
+const plugin = require('../remap-react-native-imports');
+const pluginTester = require('babel-plugin-tester').default;
+
+const tests = [
+  // import react-native
+  {
+    title: 'import from "native-native"',
+    code: `import ReactNative from 'react-native';
+import { View, Pressable, findNodeHandle } from 'react-native';
+import { Invalid, View as MyView } from 'react-native';
+import * as ReactNativeModules from 'react-native';`,
+    snapshot: true,
+  },
+  {
+    title: 'import from "native-native"',
+    code: `import ReactNative from 'react-native';
+import { View, Pressable, findNodeHandle } from 'react-native';
+import { Invalid, View as MyView } from 'react-native';
+import * as ReactNativeModules from 'react-native';`,
+    snapshot: true,
+    pluginOptions: { commonjs: true },
+  },
+  {
+    title: 'export from "react-native"',
+    code: `export { View, findNodeHandle } from 'react-native';
+export { StyleSheet, Text } from 'react-native';`,
+    snapshot: true,
+  },
+  {
+    title: 'require "react-native"',
+    code: `const ReactNative = require('react-native');
+const { View, Pressable, findNodeHandle } = require('react-native');
+const { StyleSheet, TouchableOpacity } = require('react-native');`,
+    snapshot: true,
+  },
+  {
+    title: 'require "react-native"',
+    code: `const ReactNative = require('react-native');
+const { View, Pressable, findNodeHandle } = require('react-native');
+const { StyleSheet, TouchableOpacity } = require('react-native');`,
+    snapshot: true,
+    pluginOptions: { commonjs: true },
+  },
+];
+
+pluginTester({
+  babelOptions: {
+    generatorOpts: {
+      jsescOption: {
+        quotes: 'single',
+      },
+    },
+  },
+  plugin,
+  pluginName: 'Rewrite react-native to internal imports',
+  tests,
+});

--- a/packages/babel-preset-expo/plugins/remap-react-native-imports.js
+++ b/packages/babel-preset-expo/plugins/remap-react-native-imports.js
@@ -1,0 +1,279 @@
+/**
+ * Copyright (c) Expo.
+ * Copyright (c) Nicolas Gallagher.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Based on the react-native-web babel plugin which also remaps imports to their exact location.
+// This plugin lets you skip over the main entry file of `react-native` and effectively bundle less code, faster.
+// The drawback is that you won't see any deprecations warnings provided by the react-native re-export file.
+
+// Importing anything that isn't listed below will effectively break the plugin and cause everything to be bundled.
+// The only legitimate reason to do this, is to access the flow type `HostComponent` which is only implemented in the RN entry file.
+// Importing any of the already deprecated packages will also cause everything to be bundled, but they'll throw a useful error message.
+// This includes:
+// ART, ListView, SwipeableListView, WebView, NetInfo, CameraRoll, ImageStore, ImageEditor, TimePickerAndroid, ToolbarAndroid, ViewPagerAndroid.
+
+const MAPPING = {
+  AccessibilityInfo: 'Libraries/Components/AccessibilityInfo/AccessibilityInfo',
+  ActivityIndicator: 'Libraries/Components/ActivityIndicator/ActivityIndicator',
+  Button: 'Libraries/Components/Button',
+  CheckBox: 'Libraries/Components/CheckBox/CheckBox',
+  DatePickerIOS: 'Libraries/Components/DatePicker/DatePickerIOS',
+  DrawerLayoutAndroid: 'Libraries/Components/DrawerAndroid/DrawerLayoutAndroid',
+  FlatList: 'Libraries/Lists/FlatList',
+  Image: 'Libraries/Image/Image',
+  ImageBackground: 'Libraries/Image/ImageBackground',
+  InputAccessoryView: 'Libraries/Components/TextInput/InputAccessoryView',
+  KeyboardAvoidingView: 'Libraries/Components/Keyboard/KeyboardAvoidingView',
+  MaskedViewIOS: 'Libraries/Components/MaskedView/MaskedViewIOS',
+  Modal: 'Libraries/Modal/Modal',
+  Picker: 'Libraries/Components/Picker/Picker',
+  PickerIOS: 'Libraries/Components/Picker/PickerIOS',
+  Pressable: ['Libraries/Components/Pressable/Pressable', 'default'],
+  ProgressBarAndroid: 'Libraries/Components/ProgressBarAndroid/ProgressBarAndroid',
+  ProgressViewIOS: 'Libraries/Components/ProgressViewIOS/ProgressViewIOS',
+  SafeAreaView: 'Libraries/Components/SafeAreaView/SafeAreaView',
+  ScrollView: 'Libraries/Components/ScrollView/ScrollView',
+  SectionList: 'Libraries/Lists/SectionList',
+  SegmentedControlIOS: 'Libraries/Components/SegmentedControlIOS/SegmentedControlIOS',
+  Slider: 'Libraries/Components/Slider/Slider',
+  Switch: 'Libraries/Components/Switch/Switch',
+  RefreshControl: 'Libraries/Components/RefreshControl/RefreshControl',
+  StatusBar: 'Libraries/Components/StatusBar/StatusBar',
+  Text: 'Libraries/Text/Text',
+  TextInput: 'Libraries/Components/TextInput/TextInput',
+  Touchable: 'Libraries/Components/Touchable/Touchable',
+  TouchableHighlight: 'Libraries/Components/Touchable/TouchableHighlight',
+  TouchableNativeFeedback: 'Libraries/Components/Touchable/TouchableNativeFeedback',
+  TouchableOpacity: 'Libraries/Components/Touchable/TouchableOpacity',
+  TouchableWithoutFeedback: 'Libraries/Components/Touchable/TouchableWithoutFeedback',
+  View: 'Libraries/Components/View/View',
+  VirtualizedList: 'Libraries/Lists/VirtualizedList',
+  VirtualizedSectionList: 'Libraries/Lists/VirtualizedSectionList',
+  ActionSheetIOS: 'Libraries/ActionSheetIOS/ActionSheetIOS',
+  Alert: 'Libraries/Alert/Alert',
+  Animated: 'Libraries/Animated/src/Animated',
+  Appearance: 'Libraries/Utilities/Appearance',
+  AppRegistry: 'Libraries/ReactNative/AppRegistry',
+  AppState: 'Libraries/AppState/AppState',
+  AsyncStorage: 'Libraries/Storage/AsyncStorage',
+  BackHandler: 'Libraries/Utilities/BackHandler',
+  Clipboard: 'Libraries/Components/Clipboard/Clipboard',
+  DatePickerAndroid: 'Libraries/Components/DatePickerAndroid/DatePickerAndroid',
+  DeviceInfo: 'Libraries/Utilities/DeviceInfo',
+  DevSettings: 'Libraries/Utilities/DevSettings',
+  Dimensions: 'Libraries/Utilities/Dimensions',
+  Easing: 'Libraries/Animated/src/Easing',
+  findNodeHandle: ['Libraries/Renderer/shims/ReactNative', 'findNodeHandle'],
+  I18nManager: 'Libraries/ReactNative/I18nManager',
+  ImagePickerIOS: 'Libraries/Image/ImagePickerIOS',
+  InteractionManager: 'Libraries/Interaction/InteractionManager',
+  Keyboard: 'Libraries/Components/Keyboard/Keyboard',
+  LayoutAnimation: 'Libraries/LayoutAnimation/LayoutAnimation',
+  Linking: 'Libraries/Linking/Linking',
+  LogBox: 'Libraries/LogBox/LogBox',
+  NativeDialogManagerAndroid: [
+    'Libraries/NativeModules/specs/NativeDialogManagerAndroid',
+    'default',
+  ],
+  NativeEventEmitter: 'Libraries/EventEmitter/NativeEventEmitter',
+  Networking: 'Libraries/Network/RCTNetworking',
+  PanResponder: 'Libraries/Interaction/PanResponder',
+  PermissionsAndroid: 'Libraries/PermissionsAndroid/PermissionsAndroid',
+  PixelRatio: 'Libraries/Utilities/PixelRatio',
+  PushNotificationIOS: 'Libraries/PushNotificationIOS/PushNotificationIOS',
+  Settings: 'Libraries/Settings/Settings',
+  Share: 'Libraries/Share/Share',
+  StatusBarIOS: 'Libraries/Components/StatusBar/StatusBarIOS',
+  StyleSheet: 'Libraries/StyleSheet/StyleSheet',
+  Systrace: 'Libraries/Performance/Systrace',
+  ToastAndroid: 'Libraries/Components/ToastAndroid/ToastAndroid',
+  TurboModuleRegistry: 'Libraries/TurboModule/TurboModuleRegistry',
+  TVEventHandler: 'Libraries/Components/AppleTV/TVEventHandler',
+  UIManager: 'Libraries/ReactNative/UIManager',
+  unstable_batchedUpdates: ['Libraries/Renderer/shims/ReactNative', 'unstable_batchedUpdates'],
+  useColorScheme: ['Libraries/Utilities/useColorScheme', 'default'],
+  useWindowDimensions: ['Libraries/Utilities/useWindowDimensions', 'default'],
+  UTFSequence: 'Libraries/UTFSequence',
+  Vibration: 'Libraries/Vibration/Vibration',
+  YellowBox: 'Libraries/YellowBox/YellowBoxDeprecated',
+  DeviceEventEmitter: 'Libraries/EventEmitter/RCTDeviceEventEmitter',
+  NativeAppEventEmitter: 'Libraries/EventEmitter/RCTNativeAppEventEmitter',
+  NativeModules: 'Libraries/BatchedBridge/NativeModules',
+  Platform: 'Libraries/Utilities/Platform',
+  processColor: 'Libraries/StyleSheet/processColor',
+  PlatformColor: ['Libraries/StyleSheet/PlatformColorValueTypes', 'PlatformColor'],
+  DynamicColorIOS: ['Libraries/StyleSheet/PlatformColorValueTypesIOS', 'DynamicColorIOS'],
+  ColorAndroid: ['Libraries/StyleSheet/PlatformColorValueTypesAndroid', 'ColorAndroid'],
+  requireNativeComponent: 'Libraries/ReactNative/requireNativeComponent',
+  unstable_RootTagContext: 'Libraries/ReactNative/RootTagContext',
+  ColorPropType: 'Libraries/DeprecatedPropTypes/DeprecatedColorPropType',
+  EdgeInsetsPropType: 'Libraries/DeprecatedPropTypes/DeprecatedEdgeInsetsPropType',
+  PointPropType: 'Libraries/DeprecatedPropTypes/DeprecatedPointPropType',
+  ViewPropTypes: 'Libraries/DeprecatedPropTypes/DeprecatedViewPropTypes',
+};
+
+const pkg = 'react-native';
+
+const getDistLocation = importName => {
+  if (!importName || importName === 'index') {
+    // to prevent checking again and causing a loop
+    return 'react-native/index';
+  }
+
+  if (importName && importName in MAPPING) {
+    if (Array.isArray(MAPPING[importName])) {
+      return [`react-native/${MAPPING[importName][0]}`, MAPPING[importName][1]];
+    }
+    return `react-native/${MAPPING[importName]}`;
+  }
+};
+
+const isReactNativeRequire = (t, node) => {
+  const { declarations } = node;
+  if (declarations.length > 1) {
+    return false;
+  }
+  const { id, init } = declarations[0];
+  return (
+    (t.isObjectPattern(id) || t.isIdentifier(id)) &&
+    t.isCallExpression(init) &&
+    t.isIdentifier(init.callee) &&
+    init.callee.name === 'require' &&
+    init.arguments.length === 1 &&
+    init.arguments[0].value === pkg
+  );
+};
+
+const isReactNativeModule = ({ source, specifiers }) =>
+  source && source.value === pkg && specifiers.length;
+
+module.exports = function({ types: t }) {
+  return {
+    name: 'Rewrite react-native to internal imports',
+    visitor: {
+      ImportDeclaration(path) {
+        const { specifiers } = path.node;
+        if (isReactNativeModule(path.node)) {
+          const imports = specifiers
+            .map(specifier => {
+              if (t.isImportSpecifier(specifier)) {
+                const importName = specifier.imported.name;
+                let distLocation = getDistLocation(importName);
+
+                // omit default
+                if (Array.isArray(distLocation) && distLocation[1] === 'default') {
+                  distLocation = distLocation[0];
+                }
+
+                if (Array.isArray(distLocation)) {
+                  return t.importDeclaration(
+                    [
+                      t.importSpecifier(
+                        t.identifier(specifier.local.name),
+                        t.identifier(distLocation[1])
+                      ),
+                    ],
+                    t.stringLiteral(distLocation[0])
+                  );
+                } else if (distLocation) {
+                  return t.importDeclaration(
+                    [t.importDefaultSpecifier(t.identifier(specifier.local.name))],
+                    t.stringLiteral(distLocation)
+                  );
+                }
+              }
+
+              return t.importDeclaration([specifier], t.stringLiteral(getDistLocation()));
+            })
+            .filter(Boolean);
+          path.replaceWithMultiple(imports);
+        }
+      },
+      ExportNamedDeclaration(path) {
+        const { specifiers } = path.node;
+        if (isReactNativeModule(path.node)) {
+          const exports = specifiers
+            .map(specifier => {
+              if (t.isExportSpecifier(specifier)) {
+                const exportName = specifier.exported.name;
+                const localName = specifier.local.name;
+                const distLocation = getDistLocation(localName);
+
+                if (Array.isArray(distLocation)) {
+                  return t.exportNamedDeclaration(
+                    null,
+                    [
+                      t.exportSpecifier(
+                        t.identifier(distLocation[1]),
+                        t.identifier(specifier.local.name)
+                      ),
+                    ],
+                    t.stringLiteral(distLocation[0])
+                  );
+                } else if (distLocation) {
+                  return t.exportNamedDeclaration(
+                    null,
+                    [t.exportSpecifier(t.identifier('default'), t.identifier(exportName))],
+                    t.stringLiteral(distLocation)
+                  );
+                }
+              }
+              const distLocation = getDistLocation();
+              return t.exportNamedDeclaration(null, [specifier], t.stringLiteral(distLocation));
+            })
+            .filter(Boolean);
+
+          path.replaceWithMultiple(exports);
+        }
+      },
+      VariableDeclaration(path) {
+        if (isReactNativeRequire(t, path.node)) {
+          const { id } = path.node.declarations[0];
+          if (t.isObjectPattern(id)) {
+            const imports = id.properties
+              .map(identifier => {
+                const distLocation = getDistLocation(identifier.key.name);
+                if (Array.isArray(distLocation)) {
+                  return t.variableDeclaration(path.node.kind, [
+                    t.variableDeclarator(
+                      t.identifier(identifier.value.name),
+                      t.memberExpression(
+                        t.callExpression(t.identifier('require'), [
+                          t.stringLiteral(distLocation[0]),
+                        ]),
+                        t.identifier(distLocation[1])
+                      )
+                    ),
+                  ]);
+                } else if (distLocation) {
+                  return t.variableDeclaration(path.node.kind, [
+                    t.variableDeclarator(
+                      t.identifier(identifier.value.name),
+                      t.callExpression(t.identifier('require'), [t.stringLiteral(distLocation)])
+                    ),
+                  ]);
+                }
+              })
+              .filter(Boolean);
+
+            path.replaceWithMultiple(imports);
+          } else if (t.isIdentifier(id)) {
+            const name = id.name;
+            const importIndex = t.variableDeclaration(path.node.kind, [
+              t.variableDeclarator(
+                t.identifier(name),
+                t.callExpression(t.identifier('require'), [t.stringLiteral(getDistLocation())])
+              ),
+            ]);
+
+            path.replaceWith(importIndex);
+          }
+        }
+      },
+    },
+  };
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -5955,6 +5955,25 @@
   resolved "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.1.tgz#336badc1beecb9dacc38bea2cf32adf627a8421a"
   integrity sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA==
 
+"@types/babel-plugin-tester@^9.0.0":
+  version "9.0.4"
+  resolved "https://registry.yarnpkg.com/@types/babel-plugin-tester/-/babel-plugin-tester-9.0.4.tgz#f5f9274149c6c789984f69ae4edbc383e33f679c"
+  integrity sha512-s7SxUNtUWO/bWZZqJbFqY/tbqJFoYnW/M2zPkTHl406PAPoWVSaVyYElo/O3GcRAQ5CV/pLPTFV4tQYTpMDWEQ==
+  dependencies:
+    "@types/babel__core" "*"
+    "@types/prettier" "*"
+
+"@types/babel__core@*":
+  version "7.1.15"
+  resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.15.tgz#2ccfb1ad55a02c83f8e0ad327cbc332f55eb1024"
+  integrity sha512-bxlMKPDbY8x5h6HBwVzEOk2C8fb6SLfYQ5Jw3uBYuYF1lfWk/kbLd81la82vrIkBb0l+JdmrZaDikPrNxpS/Ew==
+  dependencies:
+    "@babel/parser" "^7.1.0"
+    "@babel/types" "^7.0.0"
+    "@types/babel__generator" "*"
+    "@types/babel__template" "*"
+    "@types/babel__traverse" "*"
+
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.7":
   version "7.1.9"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.9.tgz#77e59d438522a6fb898fa43dc3455c6e72f3963d"
@@ -6243,6 +6262,11 @@
   version "4.8.9"
   resolved "https://registry.yarnpkg.com/@types/pixi.js/-/pixi.js-4.8.9.tgz#207d8719f655d84eaa28adcfb3c62e414450dc56"
   integrity sha512-PCqd9/TaGOAqg73u8cQKH2sg8pdkRzU6VKu8lWrV+/+p5QiDRtrT8chY5yveVM8A/hWLNtvIQlWpojDomTSNQQ==
+
+"@types/prettier@*":
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.3.2.tgz#fc8c2825e4ed2142473b4a81064e6e081463d1b3"
+  integrity sha512-eI5Yrz3Qv4KPUa/nSIAi0h+qX0XyewOliug5F2QAtuRg6Kjg6jfmxe1GIwoIRhZspD1A0RP8ANrPwvEXXtRFog==
 
 "@types/prettier@^1.19.0":
   version "1.19.1"
@@ -7690,6 +7714,16 @@ babel-plugin-syntax-trailing-function-commas@^7.0.0-beta.0:
   version "7.0.0-beta.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-7.0.0-beta.0.tgz#aa213c1435e2bffeb6fca842287ef534ad05d5cf"
   integrity sha512-Xj9XuRuz3nTSbaTXWv3itLOcxyF4oPD8douBBmj7U9BBC6nEBYfyOJYQMf/8PJAFotC62UY5dFfIGEPr7WswzQ==
+
+babel-plugin-tester@^10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-tester/-/babel-plugin-tester-10.1.0.tgz#e099ee1d8dec538439c427a7d12aad132885757b"
+  integrity sha512-4P2tNaM/Mtg6ytA9YAqmgONnMYqWvdbGDuwRTpIIC9yFZGQrEHoyvDPCx+X1QALAufVb5DKieOPGj5dffiEiNg==
+  dependencies:
+    "@types/babel-plugin-tester" "^9.0.0"
+    lodash.mergewith "^4.6.2"
+    prettier "^2.0.1"
+    strip-indent "^3.0.0"
 
 babel-plugin-transform-object-rest-spread@^6.26.0:
   version "6.26.0"
@@ -15998,6 +16032,11 @@ lodash.memoize@4.x, lodash.memoize@^4.1.2:
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
 
+lodash.mergewith@^4.6.2:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz#617121f89ac55f59047c7aec1ccd6654c6590f55"
+  integrity sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==
+
 lodash.omit@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.omit/-/lodash.omit-4.5.0.tgz#6eb19ae5a1ee1dd9df0b969e66ce0b7fa30b5e60"
@@ -16915,6 +16954,11 @@ min-document@^2.19.0:
   integrity sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=
   dependencies:
     dom-walk "^0.1.0"
+
+min-indent@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
+  integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
 
 mini-css-extract-plugin@^0.5.0:
   version "0.5.0"
@@ -18823,6 +18867,11 @@ prettier@^1.19.1:
   version "1.19.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
   integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
+
+prettier@^2.0.1:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.2.tgz#ef280a05ec253712e486233db5c6f23441e7342d"
+  integrity sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==
 
 pretty-bytes@^4.0.2:
   version "4.0.2"
@@ -21365,6 +21414,13 @@ strip-final-newline@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
   integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
+
+strip-indent@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-3.0.0.tgz#c32e1cee940b6b3432c771bc2c54bcce73cd3001"
+  integrity sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==
+  dependencies:
+    min-indent "^1.0.0"
 
 strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   version "3.1.1"


### PR DESCRIPTION
# Why

> Just for fun

I'm constantly seeing unused modules like `TVEventHandler` getting bundled and added to my project, this increases bundling time, and bundle size. Here, I've created a native version of `babel-plugin-react-native-web` which remaps `react-native` imports in a way that dodges the main entry file `react-native/index`.

This technique is generally fragile and can be easily broken by any third-party package, which is definitely a strong reason not to introduce it. 


# Test Plan

I wrote transform tests and I've also tried it in a local project. Along with the tests, here are the iOS stats before/after:

`expo bundle -p ios`

### Before

Modules: 476
iOS Bundling complete 12615ms

Bundle                 Size
┌ index.ios.js       829 kB
└ index.ios.js.map  3.29 MB

### After

Modules: 378
iOS Bundling complete 11476ms

Bundle                 Size
┌ index.ios.js       686 kB
└ index.ios.js.map  2.74 MB


About 17% bundle/source map reduction in production on a blank app. Obviously this reduces linearly in real projects.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).