### PR TITLE
[android][expo-image] Add `accessible` prop to ExpoImage component

### DIFF
--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageViewManager.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageViewManager.kt
@@ -110,6 +110,11 @@ class ExpoImageViewManager(applicationContext: ReactApplicationContext) : Simple
     view.setTintColor(color)
   }
 
+  @ReactProp(name = "accessible")
+  fun setFocusable(view: ExpoImageView, accessible: Boolean) {
+    view.isFocusable = accessible // setFocusable(bool)
+  }
+
   // View lifecycle
   public override fun createViewInstance(context: ThemedReactContext): ExpoImageView {
     return ExpoImageView(context, mRequestManager, mProgressInterceptor)


### PR DESCRIPTION
# Why

Extending functionality of ExpoImage component

# How

Followed [this guideline](https://reactnative.dev/docs/native-components-android#3-expose-view-property-setters-using-reactprop-or-reactpropgroup-annotation) to add a react property. 

# Test Plan

Tested on physical device with accessibility options (TalkBack) turned on:

1. Created mock application (only displaying single image)
2. Checked if toggling prop `accessible={[true|false]}` gives desired effect

Manual tests added to NCL in #14177.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).