### PR TITLE
[docs] update `BlurView` example

### DIFF
--- a/docs/pages/versions/unversioned/sdk/blur-view.md
+++ b/docs/pages/versions/unversioned/sdk/blur-view.md
@@ -32,13 +32,13 @@ export default function App() {
   return (
     <View style={styles.container}>
       <Image style={[StyleSheet.absoluteFill, styles.image]} source={{ uri }} />
-      <BlurView intensity={90} style={styles.blurContainer}>
+      <BlurView intensity={100} style={styles.blurContainer}>
         <Text style={styles.text}>{text}</Text>
       </BlurView>
-      <BlurView intensity={100} tint="light" style={styles.blurContainer}>
+      <BlurView intensity={80} tint="light" style={styles.blurContainer}>
         <Text style={styles.text}>{text}</Text>
       </BlurView>
-      <BlurView intensity={120} tint="dark" style={styles.blurContainer}>
+      <BlurView intensity={90} tint="dark" style={styles.blurContainer}>
         <Text style={[styles.text, { color: '#fff' }]}>{text}</Text>
       </BlurView>
     </View>

--- a/docs/pages/versions/unversioned/sdk/blur-view.md
+++ b/docs/pages/versions/unversioned/sdk/blur-view.md
@@ -32,7 +32,7 @@ export default function App() {
   return (
     <View style={styles.container}>
       <Image style={[StyleSheet.absoluteFill, styles.image]} source={{ uri }} />
-      <BlurView intensity={80} style={styles.blurContainer}>
+      <BlurView intensity={90} style={styles.blurContainer}>
         <Text style={styles.text}>{text}</Text>
       </BlurView>
       <BlurView intensity={100} tint="light" style={styles.blurContainer}>
@@ -58,7 +58,6 @@ const styles = StyleSheet.create({
   blurContainer: {
     flex: 1,
     padding: 20,
-    alignItems: 'stretch',
     justifyContent: 'center',
   },
   text: {

--- a/docs/pages/versions/unversioned/sdk/blur-view.md
+++ b/docs/pages/versions/unversioned/sdk/blur-view.md
@@ -28,16 +28,19 @@ import { BlurView } from 'expo-blur';
 const uri = 'https://s3.amazonaws.com/exp-icon-assets/ExpoEmptyManifest_192.png';
 
 export default function App() {
+  const text = 'Hello, my container is blurring contents underneath!';
   return (
-    <View style={{ flex: 1 }}>
-      <View style={styles.container}>
-        <Image style={styles.blurredImage} source={{ uri }} />
-
-        {/* Adjust the tint and intensity */}
-        <BlurView intensity={100} style={[StyleSheet.absoluteFill, styles.nonBlurredContent]}>
-          <Text>Hello! I am bluring contents underneath</Text>
-        </BlurView>
-      </View>
+    <View style={styles.container}>
+      <Image style={[StyleSheet.absoluteFill, styles.image]} source={{ uri }} />
+      <BlurView intensity={80} style={styles.blurContainer}>
+        <Text style={styles.text}>{text}</Text>
+      </BlurView>
+      <BlurView intensity={100} tint="light" style={styles.blurContainer}>
+        <Text style={styles.text}>{text}</Text>
+      </BlurView>
+      <BlurView intensity={120} tint="dark" style={styles.blurContainer}>
+        <Text style={[styles.text, { color: '#fff' }]}>{text}</Text>
+      </BlurView>
     </View>
   );
 }
@@ -45,17 +48,22 @@ export default function App() {
 /* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
+    flex: 1
+  },
+  image: {
+    width: '100%',
+    height: '100%',
+    resizeMode: 'cover',
+  },
+  blurContainer: {
     flex: 1,
-    alignItems: 'center',
+    padding: 20,
+    alignItems: 'stretch',
     justifyContent: 'center',
   },
-  blurredImage: {
-    width: 192,
-    height: 192,
-  },
-  nonBlurredContent: {
-    alignItems: 'center',
-    justifyContent: 'center',
+  text: {
+    fontSize: 24,
+    fontWeight: '600'
   },
 });
 /* @end */

--- a/docs/pages/versions/v42.0.0/sdk/blur-view.md
+++ b/docs/pages/versions/v42.0.0/sdk/blur-view.md
@@ -32,13 +32,13 @@ export default function App() {
   return (
     <View style={styles.container}>
       <Image style={[StyleSheet.absoluteFill, styles.image]} source={{ uri }} />
-      <BlurView intensity={90} style={styles.blurContainer}>
+      <BlurView intensity={100} style={styles.blurContainer}>
         <Text style={styles.text}>{text}</Text>
       </BlurView>
-      <BlurView intensity={100} tint="light" style={styles.blurContainer}>
+      <BlurView intensity={80} tint="light" style={styles.blurContainer}>
         <Text style={styles.text}>{text}</Text>
       </BlurView>
-      <BlurView intensity={120} tint="dark" style={styles.blurContainer}>
+      <BlurView intensity={90} tint="dark" style={styles.blurContainer}>
         <Text style={[styles.text, { color: '#fff' }]}>{text}</Text>
       </BlurView>
     </View>

--- a/docs/pages/versions/v42.0.0/sdk/blur-view.md
+++ b/docs/pages/versions/v42.0.0/sdk/blur-view.md
@@ -32,7 +32,7 @@ export default function App() {
   return (
     <View style={styles.container}>
       <Image style={[StyleSheet.absoluteFill, styles.image]} source={{ uri }} />
-      <BlurView intensity={80} style={styles.blurContainer}>
+      <BlurView intensity={90} style={styles.blurContainer}>
         <Text style={styles.text}>{text}</Text>
       </BlurView>
       <BlurView intensity={100} tint="light" style={styles.blurContainer}>
@@ -58,7 +58,6 @@ const styles = StyleSheet.create({
   blurContainer: {
     flex: 1,
     padding: 20,
-    alignItems: 'stretch',
     justifyContent: 'center',
   },
   text: {

--- a/docs/pages/versions/v42.0.0/sdk/blur-view.md
+++ b/docs/pages/versions/v42.0.0/sdk/blur-view.md
@@ -28,16 +28,19 @@ import { BlurView } from 'expo-blur';
 const uri = 'https://s3.amazonaws.com/exp-icon-assets/ExpoEmptyManifest_192.png';
 
 export default function App() {
+  const text = 'Hello, my container is blurring contents underneath!';
   return (
-    <View style={{ flex: 1 }}>
-      <View style={styles.container}>
-        <Image style={styles.blurredImage} source={{ uri }} />
-
-        {/* Adjust the tint and intensity */}
-        <BlurView intensity={100} style={[StyleSheet.absoluteFill, styles.nonBlurredContent]}>
-          <Text>Hello! I am bluring contents underneath</Text>
-        </BlurView>
-      </View>
+    <View style={styles.container}>
+      <Image style={[StyleSheet.absoluteFill, styles.image]} source={{ uri }} />
+      <BlurView intensity={80} style={styles.blurContainer}>
+        <Text style={styles.text}>{text}</Text>
+      </BlurView>
+      <BlurView intensity={100} tint="light" style={styles.blurContainer}>
+        <Text style={styles.text}>{text}</Text>
+      </BlurView>
+      <BlurView intensity={120} tint="dark" style={styles.blurContainer}>
+        <Text style={[styles.text, { color: '#fff' }]}>{text}</Text>
+      </BlurView>
     </View>
   );
 }
@@ -45,17 +48,22 @@ export default function App() {
 /* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
+    flex: 1
+  },
+  image: {
+    width: '100%',
+    height: '100%',
+    resizeMode: 'cover',
+  },
+  blurContainer: {
     flex: 1,
-    alignItems: 'center',
+    padding: 20,
+    alignItems: 'stretch',
     justifyContent: 'center',
   },
-  blurredImage: {
-    width: 192,
-    height: 192,
-  },
-  nonBlurredContent: {
-    alignItems: 'center',
-    justifyContent: 'center',
+  text: {
+    fontSize: 24,
+    fontWeight: '600'
   },
 });
 /* @end */


### PR DESCRIPTION
# Why

The current example was a bit confusing (suggested that `Text` element is blurring the content) and initial result did not show the blur effect fully.

# How

This PR updates the `BlurView` example by altering a bit structure & naming. Also the presentation was updated.

User now can delete the unwanted tints and the remaining one will cover the whole viewport, which make experimenting with library inside Snack a bit easier.

# Test Plan

The changes has been tested by running docs website on `localhost` and the example code has been tested on Snack, using links produced by website.

# Preview

### Before & After

<img align="left" width="329" alt="Screenshot 2021-08-19 at 11 16 45" src="https://user-images.githubusercontent.com/719641/130044819-2b1fe736-b3c8-4daa-bd84-8f0d6ec6269f.png">
<img width="326" alt="Screenshot 2021-08-19 at 13 05 55" src="https://user-images.githubusercontent.com/719641/130058348-9186d575-8f69-45fb-8268-4bf7c5e66027.png">

# Checklist

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).