### PR TITLE
[autolinking] Fix circular dependency

### DIFF
--- a/packages/expo-modules-autolinking/scripts/android/autolinking_implementation.gradle
+++ b/packages/expo-modules-autolinking/scripts/android/autolinking_implementation.gradle
@@ -234,7 +234,11 @@ if (rootProject instanceof ProjectDescriptor) {
   }
 
   // Adding dependencies
-  ext.addExpoModulesDependencies = { DependencyHandler handler ->
+  ext.addExpoModulesDependencies = { DependencyHandler handler, Project project ->
+    if (project.path == ":expo-modules-core" || project.path.startsWith("host.exp.exponent:expo-modules-core")) {
+      logger.warn("`addExpoModulesDependencies` was called with the `expo-modules-core` project.")
+      return
+    }
     addDependencies(handler) { module -> rootProject.project(":${module.projectName}") }
   }
 

--- a/packages/expo-modules-autolinking/scripts/android/autolinking_implementation.gradle
+++ b/packages/expo-modules-autolinking/scripts/android/autolinking_implementation.gradle
@@ -235,6 +235,9 @@ if (rootProject instanceof ProjectDescriptor) {
 
   // Adding dependencies
   ext.addExpoModulesDependencies = { DependencyHandler handler, Project project ->
+    // `addExpoModulesDependencies` can't be called in `expo-modules-core`, because it would lead to the circular dependency.
+    // For some reason Gradle sometimes tries to call this function in `expo-modules-core` - maybe because `expo-modules-core` adds `expo-modules-linker`
+    // and Gradle tries to parse linker project with the wrong context. So for now, we're just ignoring that and waiting for the correct invocation. 
     if (project.path == ":expo-modules-core" || project.path.startsWith("host.exp.exponent:expo-modules-core")) {
       logger.warn("`addExpoModulesDependencies` was called with the `expo-modules-core` project.")
       return

--- a/packages/expo-modules-core/android-linker/build.gradle
+++ b/packages/expo-modules-core/android-linker/build.gradle
@@ -83,7 +83,7 @@ android {
 dependencies { dependencyHandler ->
   // Link expo modules as dependencies of the adapter. It uses `api` configuration so they all will be visible for the app as well.
   // A collection of the dependencies depends on the options passed to `useExpoModules` in your project's `settings.gradle`.
-  addExpoModulesDependencies(dependencyHandler)
+  addExpoModulesDependencies(dependencyHandler, project)
 }
 
 // A task generating a package list of expo modules.


### PR DESCRIPTION
# Why

Fixes circular dependency caused by auto-linking.

# How

For some reason, sometimes Gradle calls `addExpoModulesDependencies` with the incorrect project (`expo-modules-core` instead of `expo-modules-linker`) which leads to a circular dependency.  For now, we just ignore that case and wait for the correct invocation of `addExpoModulesDependencies`.

# Test Plan

- bare-expo ✅
- run `Android Shell App` task ✅