### PR TITLE
[constants][updates] Disable build phase for simulator debug builds

### DIFF
--- a/packages/expo-constants/CHANGELOG.md
+++ b/packages/expo-constants/CHANGELOG.md
@@ -20,6 +20,8 @@
 
 ### 💡 Others
 
+- Skip running build scripts during iOS debug builds and add support for `SKIP_BUNDLING`/`FORCE_BUNDLING` environment variables.
+
 ### ⚠️ Notices
 
 - Modularized expo-constants without further app setup. ([#13424](https://github.com/expo/expo/pull/13424) by [@kudo](https://github.com/kudo))

--- a/packages/expo-constants/CHANGELOG.md
+++ b/packages/expo-constants/CHANGELOG.md
@@ -20,7 +20,7 @@
 
 ### 💡 Others
 
-- Skip running build scripts during iOS debug builds and add support for `SKIP_BUNDLING`/`FORCE_BUNDLING` environment variables.
+- Skip running build scripts during iOS debug builds and add support for `SKIP_BUNDLING`/`FORCE_BUNDLING` environment variables. ([#14116](https://github.com/expo/expo/pull/14116) by [@fson](https://github.com/fson))
 
 ### ⚠️ Notices
 

--- a/packages/expo-constants/scripts/get-app-config-ios.sh
+++ b/packages/expo-constants/scripts/get-app-config-ios.sh
@@ -2,6 +2,17 @@
 
 set -eo pipefail
 
+if [[ "$SKIP_BUNDLING" ]]; then
+  echo "SKIP_BUNDLING enabled; skipping get-app-config-ios.sh."
+  exit 0;
+elif [[ "$CONFIGURATION" == *Debug* ]] && [[ "$PLATFORM_NAME" == *simulator ]]; then
+  if [[ "$FORCE_BUNDLING" ]]; then
+    echo "FORCE_BUNDLING enabled; continuing get-app-config-ios.sh."
+  else
+    exit 0;
+  fi
+fi
+
 DEST="$CONFIGURATION_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH"
 NODE_BINARY=${NODE_BINARY:-node}
 
@@ -14,7 +25,7 @@ PROJECT_ROOT=${PROJECT_ROOT:-"$EXPO_CONSTANTS_PACKAGE_DIR/../.."}
 
 cd "$PROJECT_ROOT" || exit
 
-if ! [ -x "$(command -v $NODE_BINARY)" ]; then
+if ! [ -x "$(command -v "$NODE_BINARY")" ]; then
   echo 'Error: cannot find the node binary. Try setting the NODE_BINARY variable in the ' \
   '"Bundle React Native code and images" Build Phase to the absolute path to your node binary. ' \
   'You can find it by executing "which node" in a terminal window.' >&2
@@ -22,7 +33,7 @@ if ! [ -x "$(command -v $NODE_BINARY)" ]; then
 fi
 
 # For traditional main project build phases integration, will be no-op to prevent duplicated app.config creation.
-DIR_BASENAME=$(basename $PROJECT_ROOT)
+DIR_BASENAME=$(basename "$PROJECT_ROOT")
 if [ "x$DIR_BASENAME" != "xPods" ]; then
   exit 0
 fi

--- a/packages/expo-constants/scripts/get-app-config-ios.sh
+++ b/packages/expo-constants/scripts/get-app-config-ios.sh
@@ -5,7 +5,7 @@ set -eo pipefail
 if [[ "$SKIP_BUNDLING" ]]; then
   echo "SKIP_BUNDLING enabled; skipping get-app-config-ios.sh."
   exit 0;
-elif [[ "$CONFIGURATION" == *Debug* ]] && [[ "$PLATFORM_NAME" == *simulator ]]; then
+elif [[ "$CONFIGURATION" == *Debug* ]]; then
   if [[ "$FORCE_BUNDLING" ]]; then
     echo "FORCE_BUNDLING enabled; continuing get-app-config-ios.sh."
   else

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -21,7 +21,7 @@
 
 ### 💡 Others
 
-- Skip running build scripts during iOS debug builds and add support for `SKIP_BUNDLING`/`FORCE_BUNDLING` environment variables.
+- Skip running build scripts during iOS debug builds and add support for `SKIP_BUNDLING`/`FORCE_BUNDLING` environment variables. ([#14116](https://github.com/expo/expo/pull/14116) by [@fson](https://github.com/fson))
 
 ## 0.8.4 — 2021-08-06
 

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -21,6 +21,8 @@
 
 ### 💡 Others
 
+- Skip running build scripts during iOS debug builds and add support for `SKIP_BUNDLING`/`FORCE_BUNDLING` environment variables.
+
 ## 0.8.4 — 2021-08-06
 
 ### 🐛 Bug fixes
@@ -125,7 +127,7 @@ _This version does not introduce any user-facing changes._
 
 ### 🛠 Breaking changes
 
-- (android) remove UPDATES_CONFIGURATION_USES_LEGACY_MANIFEST_KEY constant and start respecting cache-control headers for all manifest responses. Please ensure your server defined cache-control headers are configured correctly if you are self-hosted to avoid issues such as [#13872](https://github.com/expo/expo/issues/13872)  ([#12181](https://github.com/expo/expo/pull/12181) by [@jkhales](https://github.com/jkhales))
+- (android) remove UPDATES_CONFIGURATION_USES_LEGACY_MANIFEST_KEY constant and start respecting cache-control headers for all manifest responses. Please ensure your server defined cache-control headers are configured correctly if you are self-hosted to avoid issues such as [#13872](https://github.com/expo/expo/issues/13872) ([#12181](https://github.com/expo/expo/pull/12181) by [@jkhales](https://github.com/jkhales))
 - (ios) remove EXUpdatesUsesLegacyManifest Plist constant and start respecting cache-control headers for all manifest responses Please ensure your server defined cache-control headers are configured correctly if you are self-hosted to avoid issues such as [#13872](https://github.com/expo/expo/issues/13872) ([#12249](https://github.com/expo/expo/pull/12249) by [@jkhales](https://github.com/jkhales))
 - crash if EXUpdatesRequestHeaders is not a dictionary (ios). ([#12457](https://github.com/expo/expo/pull/12457) by [@jkhales](https://github.com/jkhales))
 

--- a/packages/expo-updates/scripts/create-manifest-ios.sh
+++ b/packages/expo-updates/scripts/create-manifest-ios.sh
@@ -5,7 +5,7 @@ set -eo pipefail
 if [[ "$SKIP_BUNDLING" ]]; then
   echo "SKIP_BUNDLING enabled; skipping create-manifest-ios.sh."
   exit 0;
-elif [[ "$CONFIGURATION" == *Debug* ]] && [[ "$PLATFORM_NAME" == *simulator ]]; then
+elif [[ "$CONFIGURATION" == *Debug* ]]; then
   if [[ "$FORCE_BUNDLING" ]]; then
     echo "FORCE_BUNDLING enabled; continuing create-manifest-ios.sh."
   else

--- a/packages/expo-updates/scripts/create-manifest-ios.sh
+++ b/packages/expo-updates/scripts/create-manifest-ios.sh
@@ -2,6 +2,17 @@
 
 set -eo pipefail
 
+if [[ "$SKIP_BUNDLING" ]]; then
+  echo "SKIP_BUNDLING enabled; skipping create-manifest-ios.sh."
+  exit 0;
+elif [[ "$CONFIGURATION" == *Debug* ]] && [[ "$PLATFORM_NAME" == *simulator ]]; then
+  if [[ "$FORCE_BUNDLING" ]]; then
+    echo "FORCE_BUNDLING enabled; continuing create-manifest-ios.sh."
+  else
+    exit 0;
+  fi
+fi
+
 DEST="$CONFIGURATION_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH"
 ENTRY_FILE=${ENTRY_FILE:-index.js}
 RCT_METRO_PORT=${RCT_METRO_PORT:=8081}
@@ -16,7 +27,7 @@ PROJECT_ROOT=${PROJECT_ROOT:-"$EXPO_UPDATES_PACKAGE_DIR/../.."}
 
 cd "$PROJECT_ROOT" || exit
 
-if ! [ -x "$(command -v $NODE_BINARY)" ]; then
+if ! [ -x "$(command -v "$NODE_BINARY")" ]; then
   echo 'Error: cannot find the node binary. Try setting the NODE_BINARY variable in the ' \
   '"Bundle React Native code and images" Build Phase to the absolute path to your node binary. ' \
   'You can find it by executing "which node" in a terminal window.' >&2


### PR DESCRIPTION
# Why

`expo-constants` and `expo-updates` modules include scripts that are executed in the iOS build process as a part of the "Bundle React Native code and images" build phase.
- `expo-constants/scripts/get-app-config-ios.sh`: evaluates app config and copies it to the resource bundle of the app
- `expo-updates/scripts/create-manifest-ios.sh`: builds an asset manifest using Metro and writes it to the resource bundle of the app

These scripts take time to execute and our data shows they're also a key source of build errors in custom development client builds. However, executing the scripts when making a development build is unnecessary and can be avoided. (The app config / manifest is loaded from the 

# How

These scripts now follow the logic from [`react-native-xcode.sh`](https://github.com/expo/react-native/blob/0e9b4f9eea0f8ee316fa7ba6b7d2ad26325f8077/scripts/react-native-xcode.sh#L30-L35). If this is a simulator build using the `Debug` configuration, the scripts won't run. This behavior can be overridden using environment variables `FORCE_BUNDLING` (always run) and `SKIP_BUNDLING` (never run).

I believe we could also speed up `Debug` builds for *physical devices* by adding `SKIP_BUNDLING` to this phase in our Xcode templates, same way as we do in BareExpo:
https://github.com/expo/expo/blob/2765aaa598b50e086bbd3bc51b6c6f4619a7f8c2/apps/bare-expo/ios/BareExpo.xcodeproj/project.pbxproj#L395
However, I'd like to hear if others think this is a good idea before implemeting that change – thus saving it for a separate PR. This PR only affects simulator builds.

# Test Plan

Manually tested, both in a custom dev client and in Expo Go, that following code works after these changes:
- `<Image style={{ width: 200, height: 200 }} source={require('./assets/icon.png')} />` – image loading not affected by omitting the manifest/config from the resource bundle
- `<Text>{JSON.stringify(ExpoConstants.manifest)}</Text>` – manifest is still accessible through constants package

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).