### PR TITLE
[android] Fix build packages

### DIFF
--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -56,7 +56,6 @@ useExpoModules([
     autolink: false,
     exclude : [
         'expo-module-template',
-        'expo-in-app-purchases'
     ]
 ])
 // WHEN_DISTRIBUTING_REMOVE_TO_HERE

--- a/tools/src/commands/AndroidBuildPackages.ts
+++ b/tools/src/commands/AndroidBuildPackages.ts
@@ -27,6 +27,8 @@ export const EXCLUDED_PACKAGE_SLUGS = [
   'expo-dev-menu-interface',
   'expo-module-template',
   'unimodules-test-core',
+  'unimodules-core',
+  'unimodules-react-native-adapter',
 ];
 
 const EXPO_ROOT_DIR = Directories.getExpoRepositoryRootDir();


### PR DESCRIPTION
# Why

Fixes `et android-build-packages` which is needed by the standalone application. 

# How

- Added `expo-in-app-purchases` to root android project. It's removed when building standalone, but we need to have it just for building the aar. In the future, we can remove it from both places. I believe we don't use it anyway 🤷‍♂️ 
- Excluded `@unimodules/*` package from being prebuilt. 

# Test Plan

- https://exponent-internal.slack.com/archives/C1QNF5L3C/p1629398301006600 ✅