### PR TITLE
[stories] implement expo stories RN app

### DIFF
--- a/apps/sandbox/metro.config.js
+++ b/apps/sandbox/metro.config.js
@@ -1,3 +1,8 @@
 const { createMetroConfiguration } = require('expo-yarn-workspaces');
 
 module.exports = createMetroConfiguration(__dirname);
+
+// uncomment below to enable expo stories
+
+// const withExpoStories = require('expo-stories/metro-config')
+// module.exports = withExpoStories(createMetroConfiguration(__dirname));

--- a/packages/expo-stories/README.md
+++ b/packages/expo-stories/README.md
@@ -1,5 +1,7 @@
 # Expo Stories
+
 ## CLI
+
 The CLI generates a `stories.js` file in the specified `projectRoot` directory, which exports all of the `.stories` files that it finds in the `watchRoot` directory. The exports are formtted in a metro friendly way (e.g for use in RN apps).
 
 It provides additional configuration by parsing out `.storyConfig` static properties on each exported component to determine any extra information that might be useful in the future - these properties are likely to be fleshed out (and typed) in the near future as requirements become more clear.
@@ -9,3 +11,7 @@ There is only one command in the CLI:
 ```bash
 expo-stories start -p <projectRoot> -w <watchRoot>
 ```
+
+## Stories App
+
+This app is a RN client for the generated `stories.js` file that is built by the CLI. It reads from this file and is able to provide a basic navigation / user interaction to select some or all stories that are available in `stories.js`.

--- a/packages/expo-stories/clients/app/App.tsx
+++ b/packages/expo-stories/clients/app/App.tsx
@@ -1,0 +1,31 @@
+import { createStackNavigator } from '@react-navigation/stack';
+import * as React from 'react';
+
+import { SelectedStoriesDetail } from './screens/SelectedStoryDetails';
+import { SelectedStoryFilesList } from './screens/SelectedStoryFilesList';
+import { StoryFilesList } from './screens/StoryFilesList';
+import { RootStackParamList } from './types';
+
+const RNStack = createStackNavigator<RootStackParamList>();
+
+export function App({ title = '' }) {
+  return (
+    <RNStack.Navigator>
+      <RNStack.Screen name="Story Files" component={StoryFilesList} options={{ title }} />
+      <RNStack.Screen
+        name="Selected Stories"
+        component={SelectedStoryFilesList}
+        options={({ route }) => ({
+          title: route.params?.title || '',
+        })}
+      />
+      <RNStack.Screen
+        name="Stories Detail"
+        component={SelectedStoriesDetail}
+        options={({ route }) => ({
+          title: route.params?.title || '',
+        })}
+      />
+    </RNStack.Navigator>
+  );
+}

--- a/packages/expo-stories/clients/app/getStories.ts
+++ b/packages/expo-stories/clients/app/getStories.ts
@@ -1,0 +1,36 @@
+import { StoriesExport, File, Story } from './types';
+
+export function getByFileId(stories: StoriesExport) {
+  const filesById: Record<string, File> = Object.keys(stories).reduce((acc, storyId) => {
+    const story = stories[storyId];
+
+    if (!acc[story.file.id]) {
+      acc[story.file.id] = {
+        ...story.file,
+        storyIds: [],
+      };
+    }
+
+    acc[story.file.id].storyIds.push(storyId);
+
+    return acc;
+  }, {});
+
+  return filesById;
+}
+
+export function getByStoryId(stories: StoriesExport) {
+  const storiesById: Record<string, Story> = Object.keys(stories).reduce((acc, id) => {
+    const story = stories[id];
+
+    acc[story.storyConfig.id] = {
+      ...story.storyConfig,
+      file: story.file,
+      component: stories[story.storyConfig.id] || null,
+    };
+
+    return acc;
+  }, {});
+
+  return storiesById;
+}

--- a/packages/expo-stories/clients/app/index.tsx
+++ b/packages/expo-stories/clients/app/index.tsx
@@ -1,0 +1,12 @@
+import { NavigationContainer } from '@react-navigation/native';
+import * as React from 'react';
+
+import { App } from './App';
+
+export default function ExpoStoryApp({ title = '' }) {
+  return (
+    <NavigationContainer>
+      <App title={title} />
+    </NavigationContainer>
+  );
+}

--- a/packages/expo-stories/clients/app/screens/SelectedStoryDetails.tsx
+++ b/packages/expo-stories/clients/app/screens/SelectedStoryDetails.tsx
@@ -1,0 +1,37 @@
+import { RouteProp } from '@react-navigation/native';
+import * as React from 'react';
+import { View, SafeAreaView, StyleSheet, ScrollView } from 'react-native';
+
+import { getByStoryId } from '../getStories';
+import { styles } from '../styles';
+import { RootStackParamList, StoriesExport } from '../types';
+
+type SelectedStoriesDetailProps = {
+  route: RouteProp<RootStackParamList, 'Stories Detail'>;
+};
+
+// this is resolved via customization (extraNodeModules) in metro-config / webpack-config
+// duplication is required as wrapping the require in a function breaks fast refresh
+const stories: StoriesExport = require('generated-expo-stories');
+const storiesById = getByStoryId(stories);
+
+export function SelectedStoriesDetail({ route }: SelectedStoriesDetailProps) {
+  const { selectedStoryIds = [] } = route.params || {};
+  const selectedStories = selectedStoryIds.map(storyId => storiesById[storyId]);
+
+  return (
+    <View style={StyleSheet.absoluteFill}>
+      <SafeAreaView style={styles.flexContainer}>
+        <ScrollView style={styles.flexContainer}>
+          {selectedStories.map(story => {
+            return (
+              <View key={`${story.id}`} style={styles.storyRow}>
+                {React.createElement(story.component)}
+              </View>
+            );
+          })}
+        </ScrollView>
+      </SafeAreaView>
+    </View>
+  );
+}

--- a/packages/expo-stories/clients/app/screens/SelectedStoryFilesList.tsx
+++ b/packages/expo-stories/clients/app/screens/SelectedStoryFilesList.tsx
@@ -1,0 +1,97 @@
+import { RouteProp } from '@react-navigation/native';
+import { StackNavigationProp } from '@react-navigation/stack';
+import { ListRow, Button } from 'expo-stories/components';
+import * as React from 'react';
+import { Button as RNButton, View, SectionList, Text } from 'react-native';
+
+import { getByFileId, getByStoryId } from '../getStories';
+import { styles } from '../styles';
+import { RootStackParamList, StoriesExport } from '../types';
+
+type SelectedStoryFilesListProps = {
+  navigation: StackNavigationProp<RootStackParamList, 'Selected Stories'>;
+  route: RouteProp<RootStackParamList, 'Selected Stories'>;
+};
+
+// this is resolved via customization (extraNodeModules) in metro-config / webpack-config
+// duplication is required as wrapping the require in a function breaks fast refresh
+const stories: StoriesExport = require('generated-expo-stories');
+const filesById = getByFileId(stories);
+const storiesById = getByStoryId(stories);
+
+export function SelectedStoryFilesList({ navigation, route }: SelectedStoryFilesListProps) {
+  const [selectedStoryIds, setSelectedStoryIds] = React.useState<string[]>([]);
+
+  const { storyFileIds = [] } = route.params || {};
+
+  const storyIds = Object.keys(storiesById);
+  const allSelected = selectedStoryIds.length === storyIds.length;
+
+  React.useLayoutEffect(() => {
+    navigation.setOptions({
+      headerRight: () => {
+        const label = allSelected ? 'Clear All' : 'Select All';
+
+        function handlePress() {
+          setSelectedStoryIds(allSelected ? [] : [...storyIds]);
+        }
+
+        return <RNButton title={label} onPress={handlePress} />;
+      },
+    });
+  }, [navigation, allSelected]);
+
+  function onSelectSingle(id: string) {
+    setSelectedStoryIds(currentIds =>
+      currentIds.includes(id) ? currentIds.filter(i => id !== i) : [...currentIds, id]
+    );
+  }
+
+  function onSeeSelectionPress() {
+    navigation.navigate('Stories Detail', {
+      selectedStoryIds,
+      title: '',
+    });
+  }
+
+  const data = storyFileIds.map(fileId => {
+    const file = filesById[fileId];
+
+    return {
+      title: file.title,
+      data: file.storyIds,
+    };
+  });
+
+  return (
+    <View style={styles.flexContainer}>
+      <SectionList
+        sections={data}
+        keyExtractor={(item, index) => item + index}
+        renderSectionHeader={({ section }) => (
+          <View style={styles.sectionHeaderContainer}>
+            <Text style={styles.sectionHeader}>{section.title}</Text>
+          </View>
+        )}
+        renderItem={({ item: storyId }) => {
+          const story = storiesById[storyId];
+
+          return (
+            <ListRow
+              variant="ghost"
+              label={story.name}
+              onPress={() => onSelectSingle(story.id)}
+              isSelected={selectedStoryIds.includes(story.id)}
+              multiSelectActive
+            />
+          );
+        }}
+      />
+      {selectedStoryIds.length > 0 && (
+        <View style={styles.seeSelectionButtonContainer}>
+          <Button label="See Selection" variant="tertiary" onPress={onSeeSelectionPress} />
+        </View>
+      )}
+    </View>
+  );
+}

--- a/packages/expo-stories/clients/app/screens/StoryFilesList.tsx
+++ b/packages/expo-stories/clients/app/screens/StoryFilesList.tsx
@@ -1,0 +1,82 @@
+import { StackNavigationProp } from '@react-navigation/stack';
+import { ListRow, Button } from 'expo-stories/components';
+import * as React from 'react';
+import { Button as RNButton, FlatList, View, Text } from 'react-native';
+
+import { getByFileId } from '../getStories';
+import { styles } from '../styles';
+import { RootStackParamList } from '../types';
+
+// this is resolved via customization (extraNodeModules) in metro-config / webpack-config
+// duplication is required as wrapping the require in a function seems to break fast refresh
+const stories = require('generated-expo-stories');
+const filesById = getByFileId(stories);
+
+type StoryFilesListProps = {
+  navigation: StackNavigationProp<RootStackParamList, 'Story Files'>;
+};
+
+export function StoryFilesList({ navigation }: StoryFilesListProps) {
+  const [selectedFileIds, setSelectedFileIds] = React.useState<string[]>([]);
+
+  const fileIds = Object.keys(filesById);
+  const allSelected = selectedFileIds.length === fileIds.length;
+
+  React.useLayoutEffect(() => {
+    navigation.setOptions({
+      headerRight: () => {
+        const label = allSelected ? 'Clear All' : 'Select All';
+
+        function handlePress() {
+          setSelectedFileIds(allSelected ? [] : [...fileIds]);
+        }
+
+        return <RNButton title={label} onPress={handlePress} />;
+      },
+    });
+  }, [navigation, allSelected]);
+
+  function onSelectSingle(id: string) {
+    setSelectedFileIds(currentIds =>
+      currentIds.includes(id) ? currentIds.filter(i => id !== i) : [...currentIds, id]
+    );
+  }
+
+  function onSeeSelectionPress() {
+    navigation.navigate('Selected Stories', {
+      storyFileIds: selectedFileIds,
+      title: '',
+    });
+  }
+
+  const files = fileIds.map(id => filesById[id]);
+
+  return (
+    <View style={styles.flexContainer}>
+      <FlatList
+        data={files}
+        style={styles.listContainer}
+        keyExtractor={item => item.id}
+        renderItem={({ item: file }) => (
+          <ListRow
+            variant="ghost"
+            label={file.title}
+            onPress={() => onSelectSingle(file.id)}
+            isSelected={selectedFileIds.includes(file.id)}
+            multiSelectActive
+          />
+        )}
+        ListHeaderComponent={
+          <View style={styles.sectionHeaderContainer}>
+            <Text style={styles.sectionHeader}>Available Story Files</Text>
+          </View>
+        }
+      />
+      {selectedFileIds.length > 0 && (
+        <View style={styles.seeSelectionButtonContainer}>
+          <Button label="See Selection" variant="tertiary" onPress={onSeeSelectionPress} />
+        </View>
+      )}
+    </View>
+  );
+}

--- a/packages/expo-stories/clients/app/styles.ts
+++ b/packages/expo-stories/clients/app/styles.ts
@@ -1,0 +1,72 @@
+import { lightTheme, shadows, spacing } from '@expo/styleguide-native';
+import { StyleSheet } from 'react-native';
+
+export const styles = StyleSheet.create({
+  flexContainer: {
+    flex: 1,
+    backgroundColor: lightTheme.background.default,
+  },
+  storyRow: {},
+  storyButtonRow: {
+    padding: spacing[4],
+  },
+  storyTitle: {
+    paddingVertical: spacing[2],
+    paddingHorizontal: spacing[3],
+    marginTop: spacing[4],
+    marginBottom: spacing[1],
+    fontSize: 20,
+    fontWeight: '700',
+  },
+  storyButton: {
+    borderRadius: 4,
+    paddingVertical: spacing[4],
+    marginVertical: spacing[2],
+    backgroundColor: lightTheme.button.primary.background,
+    ...shadows.button,
+  },
+  storyButtonText: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: lightTheme.button.primary.foreground,
+    textAlign: 'center',
+  },
+  refreshButton: {
+    position: 'absolute',
+    padding: spacing[3],
+    bottom: spacing[6],
+    left: 0,
+    right: 0,
+  },
+  refreshLoader: {
+    position: 'absolute',
+    right: spacing[4],
+    bottom: 0,
+    top: 0,
+  },
+  loadingContainer: {
+    ...StyleSheet.absoluteFillObject,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  listContainer: {
+    paddingBottom: spacing[24] + spacing[6],
+  },
+  seeSelectionButtonContainer: {
+    position: 'absolute',
+    bottom: spacing[24],
+    left: 0,
+    right: 0,
+    paddingHorizontal: spacing[6],
+  },
+  sectionHeaderContainer: {
+    paddingTop: spacing[6],
+    paddingBottom: spacing[2],
+    paddingHorizontal: spacing[3],
+  },
+  sectionHeader: {
+    fontSize: 24,
+    fontWeight: '700',
+    color: lightTheme.text.default,
+  },
+});

--- a/packages/expo-stories/clients/app/types.ts
+++ b/packages/expo-stories/clients/app/types.ts
@@ -1,0 +1,40 @@
+export type RootStackParamList = {
+  ['Story Files']: undefined;
+  ['Selected Stories']: {
+    title: string;
+    storyFileIds: string[];
+  };
+  ['Stories Detail']: {
+    title: string;
+    selectedStoryIds: string[];
+  };
+};
+
+export type StoryConfig = {
+  storyConfig: {
+    id: string;
+    name: string;
+  };
+  file: {
+    id: string;
+    title: string;
+  };
+};
+
+export type File = {
+  id: string;
+  title: string;
+  storyIds: string[];
+};
+
+export type Story = {
+  id: string;
+  name: string;
+  file: {
+    id: string;
+    title: string;
+  };
+  component: React.FunctionComponent;
+};
+
+export type StoriesExport = Record<string, StoryConfig>;

--- a/packages/expo-stories/components/Button.tsx
+++ b/packages/expo-stories/components/Button.tsx
@@ -1,0 +1,52 @@
+import { spacing, lightTheme, shadows } from '@expo/styleguide-native';
+import * as React from 'react';
+import { Text, TouchableOpacity, StyleSheet, TouchableOpacityProps, TextProps } from 'react-native';
+
+type ButtonProps = TouchableOpacityProps & {
+  style?: Pick<TouchableOpacityProps, 'style'>;
+  children?: React.ReactNode;
+  labelProps?: TextProps;
+  label?: string;
+  variant?: 'primary' | 'secondary' | 'tertiary' | 'transparent' | 'ghost';
+};
+
+export function Button({
+  onPress,
+  children,
+  variant = 'primary',
+  label,
+  labelProps,
+  style,
+  ...rest
+}: ButtonProps) {
+  const backgroundColor = lightTheme.button[variant].background;
+  const foregroundColor = lightTheme.button[variant].foreground;
+
+  return (
+    <TouchableOpacity
+      style={[styles.buttonContainer, { backgroundColor }, style]}
+      onPress={onPress}
+      {...rest}>
+      {Boolean(label) && (
+        <Text style={[styles.buttonText, { color: foregroundColor }]} {...labelProps}>
+          {label}
+        </Text>
+      )}
+      {children}
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  buttonContainer: {
+    borderRadius: 4,
+    paddingVertical: spacing[4],
+    marginVertical: spacing[2],
+    ...shadows.button,
+  },
+  buttonText: {
+    fontSize: 18,
+    fontWeight: '700',
+    textAlign: 'center',
+  },
+});

--- a/packages/expo-stories/components/Container.tsx
+++ b/packages/expo-stories/components/Container.tsx
@@ -1,0 +1,85 @@
+import { spacing, lightTheme, ChevronDownIcon, iconSize } from '@expo/styleguide-native';
+import * as React from 'react';
+import { View, StyleSheet, Text, ViewProps, TouchableOpacity } from 'react-native';
+
+type ContainerProps = ViewProps & {
+  labelTop?: string;
+  labelBottom?: string;
+  children?: React.ReactNode;
+};
+
+export function Container({ children, labelTop, style, ...rest }: ContainerProps) {
+  const [isOpen, setIsOpen] = React.useState(false);
+
+  if (!labelTop) {
+    return (
+      <View style={[styles.container, style]} {...rest}>
+        <View style={styles.storyComponentContainer}>{children}</View>
+      </View>
+    );
+  }
+
+  return (
+    <>
+      <View style={[styles.container, isOpen && styles.openContainer, style]} {...rest}>
+        <TouchableOpacity style={styles.descriptionContainer} onPress={() => setIsOpen(!isOpen)}>
+          <Text style={styles.description}>{labelTop}</Text>
+          <View
+            style={[styles.chevonContainer, isOpen ? styles.chevronOpen : styles.chevronClosed]}>
+            <ChevronDownIcon size={iconSize.large} color={lightTheme.icon.default} />
+          </View>
+        </TouchableOpacity>
+        {isOpen && <View style={styles.storyComponentContainer}>{children}</View>}
+      </View>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {},
+  openContainer: {
+    marginBottom: spacing[4],
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: lightTheme.border.default,
+  },
+  descriptionContainer: {
+    paddingHorizontal: spacing[4],
+    paddingVertical: spacing[4],
+    paddingRight: 32,
+    minHeight: 56,
+    justifyContent: 'center',
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderColor: lightTheme.border.default,
+  },
+  description: {
+    fontSize: 18,
+    fontWeight: '500',
+    color: lightTheme.text.default,
+  },
+  chevonContainer: {
+    position: 'absolute',
+    right: 0,
+    top: 0,
+    bottom: 0,
+    width: 48,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  chevronOpen: {
+    transform: [
+      {
+        rotate: '0deg',
+      },
+    ],
+  },
+  chevronClosed: {
+    transform: [
+      {
+        rotate: '-90deg',
+      },
+    ],
+  },
+  storyComponentContainer: {
+    padding: spacing[4],
+  },
+});

--- a/packages/expo-stories/components/Json.tsx
+++ b/packages/expo-stories/components/Json.tsx
@@ -1,0 +1,24 @@
+import { borderRadius, lightTheme, spacing } from '@expo/styleguide-native';
+import * as React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export function Json({ json = {} }) {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>{JSON.stringify(json, null, '\t')}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: lightTheme.background.tertiary,
+    borderRadius: borderRadius.large,
+    padding: spacing[4],
+  },
+  text: {
+    fontSize: 15,
+    fontWeight: '500',
+    color: lightTheme.text.default,
+  },
+});

--- a/packages/expo-stories/components/ListRow.tsx
+++ b/packages/expo-stories/components/ListRow.tsx
@@ -1,0 +1,100 @@
+import { spacing, lightTheme, ChevronDownIcon, iconSize, CheckIcon } from '@expo/styleguide-native';
+import * as React from 'react';
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  StyleSheet,
+  TouchableOpacityProps,
+  TextProps,
+} from 'react-native';
+
+type ListRowProps = TouchableOpacityProps & {
+  style?: Pick<TouchableOpacityProps, 'style'>;
+  labelProps?: TextProps;
+  label?: string;
+  variant?: 'primary' | 'secondary' | 'tertiary' | 'transparent' | 'ghost';
+  multiSelectActive?: boolean;
+  isSelected?: boolean;
+};
+
+export function ListRow({
+  onPress,
+  variant = 'ghost',
+  label,
+  labelProps,
+  style,
+  multiSelectActive,
+  isSelected,
+  ...rest
+}: ListRowProps) {
+  const backgroundColor = lightTheme.button[variant].background;
+  const foregroundColor = lightTheme.button[variant].foreground;
+
+  return (
+    <TouchableOpacity
+      style={[
+        styles.listRowContainer,
+        { backgroundColor },
+        multiSelectActive && styles.multiSelectActive,
+        style,
+      ]}
+      onPress={onPress}
+      {...rest}>
+      {Boolean(label) && (
+        <Text style={[styles.rowText, { color: foregroundColor }]} {...labelProps}>
+          {label}
+        </Text>
+      )}
+
+      {multiSelectActive ? (
+        isSelected ? (
+          <CheckIcon size={iconSize.large} color={foregroundColor} />
+        ) : (
+          <View style={styles.selectableCircle} />
+        )
+      ) : (
+        <ChevronDownIcon
+          size={iconSize.large}
+          color={foregroundColor}
+          style={styles.rotateContainer}
+        />
+      )}
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  listRowContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingVertical: spacing[6],
+    paddingHorizontal: spacing[4],
+    borderColor: lightTheme.border.default,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+
+  multiSelectActive: {},
+
+  selectableCircle: {
+    width: iconSize.regular,
+    height: iconSize.regular,
+    borderRadius: iconSize.regular / 2,
+    borderWidth: 2,
+    borderColor: lightTheme.border.default,
+    marginRight: spacing[1],
+  },
+
+  rotateContainer: {
+    transform: [
+      {
+        rotate: '-90deg',
+      },
+    ],
+  },
+  rowText: {
+    fontSize: 20,
+    fontWeight: '600',
+  },
+});

--- a/packages/expo-stories/components/TestRunner/ExponentTest.tsx
+++ b/packages/expo-stories/components/TestRunner/ExponentTest.tsx
@@ -1,0 +1,18 @@
+import getenv from 'getenv';
+import { NativeModules } from 'react-native';
+
+// Used for bare android device farm builds
+const ExponentTest = (NativeModules && NativeModules.ExponentTest) || {
+  get isInCI() {
+    return getenv.boolish('CI', false);
+  },
+  log: console.log,
+  completed() {
+    // noop
+  },
+  action() {
+    // noop
+  },
+};
+
+export default ExponentTest;

--- a/packages/expo-stories/components/TestRunner/components/DoneText.tsx
+++ b/packages/expo-stories/components/TestRunner/components/DoneText.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+export default function DoneText({ done, numFailed, results }) {
+  return (
+    <View testID="test_suite_results" style={styles.container}>
+      {!done && (
+        <Text testID="test_suite_loading_results" style={styles.doneMessage}>
+          Running Tests...
+        </Text>
+      )}
+      {done && (
+        <Text testID="test_suite_text_results" style={styles.doneMessage}>
+          Complete: {numFailed}
+          {numFailed === 1 ? ' test' : ' tests'} failed.
+        </Text>
+      )}
+      {done && (
+        <View pointerEvents="none">
+          <Text style={styles.finalResults} testID="test_suite_final_results">
+            {results}
+          </Text>
+        </View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+  },
+  finalResults: {
+    // Hide text for Detox to read
+    position: 'absolute',
+    opacity: 0,
+  },
+  doneMessage: {
+    fontWeight: 'bold',
+    fontSize: 16,
+  },
+});

--- a/packages/expo-stories/components/TestRunner/components/PlatformTouchable.android.tsx
+++ b/packages/expo-stories/components/TestRunner/components/PlatformTouchable.android.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { TouchableNativeFeedback } from 'react-native';
+
+export default function PlatformTouchable(props) {
+  return <TouchableNativeFeedback {...props} />;
+}

--- a/packages/expo-stories/components/TestRunner/components/PlatformTouchable.tsx
+++ b/packages/expo-stories/components/TestRunner/components/PlatformTouchable.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { TouchableHighlight } from 'react-native';
+
+export default function PlatformTouchable(props) {
+  return <TouchableHighlight underlayColor="lightgray" {...props} />;
+}

--- a/packages/expo-stories/components/TestRunner/components/Portal.tsx
+++ b/packages/expo-stories/components/TestRunner/components/Portal.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+
+export default function Portal({ isVisible, children }) {
+  if (!children) {
+    return null;
+  }
+
+  return (
+    <View
+      style={[StyleSheet.absoluteFill, styles.container, { opacity: isVisible ? 0.5 : 0 }]}
+      pointerEvents="none">
+      {children}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'rgb(255, 255, 255)',
+  },
+});

--- a/packages/expo-stories/components/TestRunner/components/RunnerError.tsx
+++ b/packages/expo-stories/components/TestRunner/components/RunnerError.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+export default function RunnerError({ children }) {
+  const { top } = useSafeAreaInsets();
+
+  return (
+    <View style={[styles.container, { top: top || 18 }]}>
+      <Text style={styles.text}>{children}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  text: {
+    color: 'red',
+  },
+});

--- a/packages/expo-stories/components/TestRunner/components/SpecResult.tsx
+++ b/packages/expo-stories/components/TestRunner/components/SpecResult.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+import Colors from '../constants/Colors';
+import StatusEmojis from '../constants/StatusEmojis';
+import Statuses from '../constants/Statuses';
+
+function getStatusEmoji(status) {
+  if (status in StatusEmojis) {
+    return StatusEmojis[status];
+  }
+  return getStatusEmoji(Statuses.Disabled);
+}
+
+export default function SpecResult({ status = Statuses.Running, description, failedExpectations }) {
+  const renderExpectations = React.useMemo(
+    () => (e, i) => (
+      <Text testID="test_suite_text_spec_exception" key={i}>
+        {e.get('message')}
+      </Text>
+    ),
+    []
+  );
+
+  const borderColor = Colors[status];
+
+  const message = `${getStatusEmoji(status)} ${description} (${status})`;
+  return (
+    <View
+      testID="test_suite_view_spec_container"
+      style={[
+        styles.container,
+        {
+          borderColor,
+        },
+      ]}>
+      <Text testID="test_suite_text_spec_description" style={styles.text}>
+        {message}
+      </Text>
+      {failedExpectations.map(renderExpectations)}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    paddingLeft: 10,
+    marginVertical: 3,
+    borderLeftWidth: 3,
+  },
+  text: {
+    fontSize: 16,
+  },
+});

--- a/packages/expo-stories/components/TestRunner/components/SuiteResult.tsx
+++ b/packages/expo-stories/components/TestRunner/components/SuiteResult.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+import SpecResult from './SpecResult';
+
+export default function SuiteResult({ r, depth }) {
+  const renderSpecResult = React.useMemo(
+    () => r => {
+      const status = r.get('status');
+      const key = r.get('id');
+      const description = r.get('description');
+      const failedExpectations = r.get('failedExpectations');
+
+      return (
+        <SpecResult
+          key={`spec-result-${key}`}
+          status={status}
+          description={description}
+          failedExpectations={failedExpectations}
+        />
+      );
+    },
+    []
+  );
+
+  const renderSuiteResult = React.useMemo(
+    () => r => <SuiteResult key={r.get('result').get('id')} r={r} depth={depth + 1} />,
+    [depth]
+  );
+
+  const result = r.get('result');
+  const description = result.get('description');
+  const specs = r.get('specs');
+  const children = r.get('children');
+
+  const titleStyle = depth === 0 ? styles.titleParent : styles.titleChild;
+  const containerStyle = depth === 0 ? styles.containerParent : styles.containerChild;
+
+  return (
+    <View testID="test_suite_view_suite_container" style={containerStyle}>
+      <Text testID="test_suite_text_suite_description" style={titleStyle}>
+        {description}
+      </Text>
+      {specs.map(renderSpecResult)}
+      {children.map(renderSuiteResult)}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  containerParent: {
+    paddingLeft: 16,
+    paddingVertical: 16,
+    borderBottomWidth: 1,
+    borderColor: '#ddd',
+  },
+  containerChild: {
+    paddingLeft: 16,
+  },
+  titleParent: {
+    marginBottom: 8,
+    fontSize: 16,
+    fontWeight: 'bold',
+  },
+  titleChild: {
+    marginVertical: 8,
+    fontSize: 16,
+  },
+});

--- a/packages/expo-stories/components/TestRunner/components/Suites.tsx
+++ b/packages/expo-stories/components/TestRunner/components/Suites.tsx
@@ -1,0 +1,55 @@
+import Constants from 'expo-constants';
+import React from 'react';
+import { FlatList, StyleSheet } from 'react-native';
+
+import DoneText from './DoneText';
+import SuiteResult from './SuiteResult';
+
+export default function Suites({ suites, done, numFailed, results }) {
+  const ref = React.useRef(null);
+
+  const renderItem = ({ item }) => <SuiteResult r={item} depth={0} />;
+
+  const keyExtractor = item => item.get('result').get('id');
+
+  const scrollToEnd = React.useMemo(
+    () => () => {
+      if (ref.current) ref.current.scrollToEnd({ animated: false });
+    },
+    [ref]
+  );
+
+  React.useEffect(() => {
+    if (done && ref.current) {
+      scrollToEnd();
+    }
+  }, [ref, done]);
+
+  const ListFooterComponent = () => (
+    <DoneText done={done} numFailed={numFailed} results={results} />
+  );
+
+  return (
+    <FlatList
+      ref={ref}
+      style={styles.list}
+      contentContainerStyle={styles.contentContainerStyle}
+      data={[...suites]}
+      keyExtractor={keyExtractor}
+      renderItem={renderItem}
+      ListFooterComponent={ListFooterComponent}
+      onContentSizeChange={scrollToEnd}
+      onLayout={scrollToEnd}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  contentContainerStyle: {
+    padding: 5,
+    paddingBottom: (Constants.statusBarHeight || 24) + 128,
+  },
+  list: {
+    flex: 1,
+  },
+});

--- a/packages/expo-stories/components/TestRunner/constants/Colors.ts
+++ b/packages/expo-stories/components/TestRunner/constants/Colors.ts
@@ -1,0 +1,13 @@
+import { lightTheme } from '@expo/styleguide-native';
+
+import Statuses from './Statuses';
+
+export default {
+  [Statuses.Running]: lightTheme.status.default,
+  [Statuses.Passed]: lightTheme.status.success,
+  [Statuses.Failed]: lightTheme.status.error,
+  [Statuses.Disabled]: lightTheme.status.warning,
+  tintColor: lightTheme.status.info, // Expo Blue
+  activeTintColor: lightTheme.button.primary.background,
+  inactiveTintColor: lightTheme.button.secondary.background,
+};

--- a/packages/expo-stories/components/TestRunner/constants/StatusEmojis.ts
+++ b/packages/expo-stories/components/TestRunner/constants/StatusEmojis.ts
@@ -1,0 +1,8 @@
+import Statuses from './Statuses';
+
+export default {
+  [Statuses.Running]: '😶',
+  [Statuses.Passed]: '😄',
+  [Statuses.Failed]: '😞',
+  [Statuses.Disabled]: '🤐',
+};

--- a/packages/expo-stories/components/TestRunner/constants/Statuses.ts
+++ b/packages/expo-stories/components/TestRunner/constants/Statuses.ts
@@ -1,0 +1,7 @@
+export default {
+  Running: 'running',
+  Passed: 'passed',
+  Failed: 'failed',
+  Disabled: 'disabled',
+  Pending: 'pending',
+};

--- a/packages/expo-stories/components/TestRunner/index.tsx
+++ b/packages/expo-stories/components/TestRunner/index.tsx
@@ -1,0 +1,317 @@
+import Immutable from 'immutable';
+import jasmineModule from 'jasmine-core/lib/jasmine-core/jasmine';
+import React from 'react';
+import { Platform, StyleSheet, View } from 'react-native';
+
+import ExponentTest from './ExponentTest';
+import Portal from './components/Portal';
+import RunnerError from './components/RunnerError';
+import Suites from './components/Suites';
+
+type Props = {
+  selectedModules: { test: any }[];
+};
+
+type State = {
+  portalChildShouldBeVisible: boolean;
+  state: any;
+  testPortal: React.ReactElement<any> | null;
+  numFailed: number;
+  done: boolean;
+  testRunnerError?: null;
+  results?: any;
+};
+
+const initialState: State = {
+  portalChildShouldBeVisible: false,
+  state: Immutable.fromJS({
+    suites: [],
+    path: ['suites'], // Path to current 'children' List in state
+  }),
+  testPortal: null,
+  numFailed: 0,
+  done: false,
+  testRunnerError: null,
+  results: null,
+};
+
+export default class TestScreen extends React.Component<Props, State> {
+  state = initialState;
+  _results = '';
+  _failures = '';
+  _scrollViewRef = null;
+  _isMounted = null;
+
+  componentDidMount() {
+    // We get test modules here to make sure that React Native will reload this component when tests were changed.
+    if (!this.props.selectedModules.length) {
+      console.log('[TEST_SUITE]', 'No selected modules');
+    }
+
+    this._runTests(this.props.selectedModules);
+    this._isMounted = true;
+  }
+
+  componentWillUnmount() {
+    this._isMounted = false;
+  }
+
+  setPortalChild = testPortal => {
+    if (this._isMounted) return this.setState({ testPortal });
+  };
+
+  cleanupPortal = () => {
+    return new Promise(resolve => {
+      if (this._isMounted) this.setState({ testPortal: null }, resolve);
+    });
+  };
+
+  _runTests = async modules => {
+    // Reset results state
+    this.setState(initialState);
+
+    const { jasmineEnv, jasmine } = await this._setupJasmine();
+
+    await Promise.all(
+      modules.map(m =>
+        m.test(jasmine, {
+          setPortalChild: this.setPortalChild,
+          cleanupPortal: this.cleanupPortal,
+        })
+      )
+    );
+
+    jasmineEnv.execute();
+  };
+
+  async _setupJasmine() {
+    // Init
+    jasmineModule.DEFAULT_TIMEOUT_INTERVAL = 10000;
+    const jasmineCore = jasmineModule.core(jasmineModule);
+    const jasmineEnv = jasmineCore.getEnv();
+
+    // Add our custom reporters too
+    jasmineEnv.addReporter(this._jasmineSetStateReporter());
+    jasmineEnv.addReporter(this._jasmineConsoleReporter());
+
+    // Get the interface and make it support `async ` by default
+    const jasmine = jasmineModule.interface(jasmineCore, jasmineEnv);
+    const doneIfy = fn => async done => {
+      try {
+        await Promise.resolve(fn());
+        done();
+      } catch (e) {
+        done.fail(e);
+      }
+    };
+    const oldIt = jasmine.it;
+    jasmine.it = (desc, fn, t) => oldIt.apply(jasmine, [desc, doneIfy(fn), t]);
+    const oldXit = jasmine.xit;
+    jasmine.xit = (desc, fn, t) => oldXit.apply(jasmine, [desc, doneIfy(fn), t]);
+    const oldFit = jasmine.fit;
+    jasmine.fit = (desc, fn, t) => oldFit.apply(jasmine, [desc, doneIfy(fn), t]);
+
+    return {
+      jasmineCore,
+      jasmineEnv,
+      jasmine,
+    };
+  }
+
+  // A jasmine reporter that writes results to the console
+  _jasmineConsoleReporter() {
+    const failedSpecs = [];
+    const app = this;
+
+    return {
+      specDone(result) {
+        if (result.status === 'passed' || result.status === 'failed') {
+          // Open log group if failed
+          const grouping = result.status === 'passed' ? '---' : '+++';
+          if (ExponentTest && ExponentTest.log) {
+            ExponentTest.log(`${result.status === 'passed' ? 'PASS' : 'FAIL'} ${result.fullName}`);
+          }
+          const emoji = result.status === 'passed' ? ':green_heart:' : ':broken_heart:';
+          console.log(`${grouping} ${emoji} ${result.fullName}`);
+          app._results += `${grouping} ${result.fullName}\n`;
+
+          if (result.status === 'failed') {
+            app._failures += `${grouping} ${result.fullName}\n`;
+            result.failedExpectations.forEach(({ matcherName = 'NO_MATCHER', message }) => {
+              if (ExponentTest && ExponentTest.log) {
+                ExponentTest.log(`${matcherName}: ${message}`);
+              }
+              console.log(`${matcherName}: ${message}`);
+              app._results += `${matcherName}: ${message}\n`;
+              app._failures += `${matcherName}: ${message}\n`;
+            });
+            failedSpecs.push(result);
+            if (app._isMounted) {
+              const result = {
+                magic: '[TEST-SUITE-INPROGRESS]',
+                failed: failedSpecs.length,
+                failures: app._failures,
+                results: app._results,
+              };
+              const jsonResult = JSON.stringify(result);
+              app.setState({ numFailed: failedSpecs.length, results: jsonResult });
+            }
+          }
+        }
+      },
+
+      jasmineStarted() {
+        console.log('--- tests started');
+      },
+
+      jasmineDone() {
+        console.log('--- tests done');
+        console.log('--- sending results to runner');
+
+        const result = {
+          magic: '[TEST-SUITE-END]', // NOTE: Runner/Run.js waits to see this
+          failed: failedSpecs.length,
+          failures: app._failures,
+          results: app._results,
+        };
+
+        const jsonResult = JSON.stringify(result);
+        if (app._isMounted) {
+          app.setState({ done: true, numFailed: failedSpecs.length, results: jsonResult });
+        }
+
+        if (Platform.OS === 'web') {
+          // This log needs to be an object for puppeteer tests
+          console.log(result);
+        } else {
+          console.log(jsonResult);
+        }
+
+        if (ExponentTest) {
+          ExponentTest.completed(
+            JSON.stringify({
+              failed: failedSpecs.length,
+              failures: app._failures,
+              results: app._results,
+            })
+          );
+        }
+      },
+    };
+  }
+
+  // A jasmine reporter that writes results to this.state
+  _jasmineSetStateReporter() {
+    const app = this;
+    return {
+      suiteStarted(jasmineResult) {
+        if (app._isMounted) {
+          app.setState(({ state }) => ({
+            state: state
+              .updateIn(state.get('path'), children =>
+                children.push(
+                  Immutable.fromJS({
+                    result: jasmineResult,
+                    children: [],
+                    specs: [],
+                  })
+                )
+              )
+              .update('path', path => path.push(state.getIn(path).size, 'children')),
+          }));
+        }
+      },
+
+      suiteDone() {
+        if (app._isMounted) {
+          app.setState(({ state }) => ({
+            state: state
+              .updateIn(
+                state
+                  .get('path')
+                  .pop()
+                  .pop(),
+                children =>
+                  children.update(children.size - 1, child =>
+                    child.set('result', child.get('result'))
+                  )
+              )
+              .update('path', path => path.pop().pop()),
+          }));
+        }
+      },
+
+      specStarted(jasmineResult) {
+        if (app._isMounted) {
+          app.setState(({ state }) => ({
+            state: state.updateIn(
+              state
+                .get('path')
+                .pop()
+                .pop(),
+              children =>
+                children.update(children.size - 1, child =>
+                  child.update('specs', specs => specs.push(Immutable.fromJS(jasmineResult)))
+                )
+            ),
+          }));
+        }
+      },
+
+      specDone(jasmineResult) {
+        if (app.state.testPortal) {
+          console.warn(
+            `The test portal has not been cleaned up by \`${jasmineResult.fullName}\`. Call \`cleanupPortal\` before finishing the test.`
+          );
+        }
+        if (app._isMounted) {
+          app.setState(({ state }) => ({
+            state: state.updateIn(
+              state
+                .get('path')
+                .pop()
+                .pop(),
+              children =>
+                children.update(children.size - 1, child =>
+                  child.update('specs', specs =>
+                    specs.set(specs.size - 1, Immutable.fromJS(jasmineResult))
+                  )
+                )
+            ),
+          }));
+        }
+      },
+    };
+  }
+
+  render() {
+    const {
+      testRunnerError,
+      results,
+      done,
+      numFailed,
+      state,
+      portalChildShouldBeVisible,
+      testPortal,
+    } = this.state;
+    if (testRunnerError) {
+      return <RunnerError>{testRunnerError}</RunnerError>;
+    }
+    return (
+      <View testID="test_suite_container" style={styles.container}>
+        <Suites numFailed={numFailed} results={results} done={done} suites={state.get('suites')} />
+        <Portal isVisible={portalChildShouldBeVisible}>{testPortal}</Portal>
+      </View>
+    );
+  }
+}
+
+export { TestScreen as TestRunner };
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'stretch',
+    justifyContent: 'center',
+  },
+});

--- a/packages/expo-stories/components/Toggle.tsx
+++ b/packages/expo-stories/components/Toggle.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import { TouchableOpacity } from 'react-native';
+
+type ToggleContextProps = {
+  isOpen: boolean;
+  setIsOpen: (isOpen: boolean) => void;
+};
+
+const ToggleContext = React.createContext<ToggleContextProps>({
+  isOpen: false,
+  setIsOpen: () => {},
+});
+
+function Container({ children }) {
+  const [isOpen, setIsOpen] = React.useState(false);
+
+  return <ToggleContext.Provider value={{ isOpen, setIsOpen }}>{children}</ToggleContext.Provider>;
+}
+
+function Area({ children }) {
+  const { isOpen } = React.useContext(ToggleContext);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return <>{children}</>;
+}
+
+function Button({ children }) {
+  const { isOpen, setIsOpen } = React.useContext(ToggleContext);
+
+  return <TouchableOpacity onPress={() => setIsOpen(!isOpen)}>{children}</TouchableOpacity>;
+}
+
+export const Toggle = {
+  Container,
+  Button,
+  Area,
+};

--- a/packages/expo-stories/components/index.ts
+++ b/packages/expo-stories/components/index.ts
@@ -1,0 +1,6 @@
+export * from './Button';
+export * from './Container';
+export * from './Json';
+export * from './ListRow';
+export * from './TestRunner';
+export * from './Toggle';

--- a/packages/expo-stories/metro-config.js
+++ b/packages/expo-stories/metro-config.js
@@ -1,0 +1,32 @@
+const path = require('path');
+
+const { buildAsync } = require('./build/cli/commands/build');
+const { initAsync } = require('./build/cli/commands/init');
+const { getStoriesDir, getStoriesFile } = require('./build/cli/shared');
+
+async function withExpoStories(metroConfig) {
+  const { projectRoot } = metroConfig;
+
+  const pkg = require(path.resolve(projectRoot, 'package.json'));
+
+  const storyConfig = pkg.expoStories || {
+    projectRoot,
+    watchRoot: projectRoot,
+  };
+
+  await initAsync({
+    projectRoot: metroConfig.projectRoot,
+  });
+
+  await buildAsync(storyConfig);
+
+  const storiesDir = getStoriesDir(metroConfig);
+  const storyFile = getStoriesFile(metroConfig);
+
+  metroConfig.resolver.extraNodeModules['generated-expo-stories'] = storyFile;
+  metroConfig.watchFolders.push(storiesDir);
+
+  return metroConfig;
+}
+
+module.exports = withExpoStories;

--- a/packages/expo-stories/package.json
+++ b/packages/expo-stories/package.json
@@ -24,11 +24,17 @@
     "typescript": "~4.3.5"
   },
   "dependencies": {
+    "@expo/styleguide-native": "^0.4.0",
+    "@react-navigation/native": "^6.0.1",
+    "@react-navigation/stack": "^6.0.1",
     "acorn-loose": "^8.1.0",
     "commander": "^8.0.0",
     "esbuild": "^0.12.15",
     "fs-extra": "^9.1.0",
     "glob": "^7.1.7",
+    "react-native-safe-area-context": "3.2.0",
+    "react-native-screens": "^3.5.0",
+    "react-native-svg": "^12.1.1",
     "sane": "^5.0.1"
   }
 }

--- a/packages/expo-stories/webpack-config.js
+++ b/packages/expo-stories/webpack-config.js
@@ -1,0 +1,16 @@
+const path = require('path');
+
+const { getStoriesFile } = require('./build/server/shared');
+const { writeRequiredFiles } = require('./build/server/writeRequiredFiles');
+
+function withExpoStories(config, { projectRoot }) {
+  writeRequiredFiles({ projectRoot });
+
+  const storyFile = getStoriesFile({ projectRoot });
+
+  config.resolve.alias['generated-expo-stories'] = path.resolve(projectRoot, storyFile);
+
+  return config;
+}
+
+module.exports = withExpoStories;

--- a/yarn.lock
+++ b/yarn.lock
@@ -232,7 +232,7 @@
     "@babel/template" "^7.15.4"
     "@babel/types" "^7.15.4"
 
-"@babel/helper-get-function-arity@^7.14.5", "@babel/helper-get-function-arity@^7.15.4":
+"@babel/helper-get-function-arity@^7.15.4":
   version "7.15.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.15.4.tgz#098818934a137fce78b536a3e015864be1e2879b"
   integrity sha512-1/AlxSF92CmGZzHnC515hm4SirTxtpDnLEJ0UyEMgTMZN+6bxXKg04dKhiRx5Enel+SUA1G1t5Ed/yQia0efrA==
@@ -369,7 +369,7 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.15.3.tgz#3416d9bea748052cfcb63dbcc27368105b1ed862"
   integrity sha512-O0L6v/HvqbdJawj0iBEfVQMc3/6WP+AeOsovsIgBFyJaG+W2w7eqvZB7puddATmWuARlm1SX7DwxJ/JJUnDpEA==
 
-"@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.1.6", "@babel/parser@^7.14.5", "@babel/parser@^7.14.8", "@babel/parser@^7.15.0", "@babel/parser@^7.15.4", "@babel/parser@^7.4.3", "@babel/parser@^7.9.0", "@babel/parser@^7.9.6":
+"@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.1.6", "@babel/parser@^7.14.8", "@babel/parser@^7.15.0", "@babel/parser@^7.15.4", "@babel/parser@^7.4.3", "@babel/parser@^7.9.0", "@babel/parser@^7.9.6":
   version "7.15.6"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.15.6.tgz#043b9aa3c303c0722e5377fef9197f4cf1796549"
   integrity sha512-S/TSCcsRuCkmpUuoWijua0Snt+f3ewU/8spLo+4AXJCZfT0bVCzLD5MuOKdrx0mlAptbKzn5AdgEIIKXxXkz9Q==
@@ -1694,6 +1694,11 @@
   integrity sha512-LB7jWkqrHo+5fJHNrLAFdimuSXQ2MQ4lA7SQW5bf/HbsXuV2VrT/jN/M8f/KoWt0uJMGN4k/j7Opx4AvOOxSew==
   dependencies:
     cross-spawn "^6.0.5"
+
+"@expo/styleguide-native@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@expo/styleguide-native/-/styleguide-native-0.4.0.tgz#ee5626b08d5776e5945ddeb591a4fb1bb1cd4a27"
+  integrity sha512-rIyX3rJyxGFQVlQA4BKvAcVnlTcP2G9P1ljMpC+vOb/C3tgrPRP1TVF82h+q1wFPNlMkLO1kq01e30G9LVOxmA==
 
 "@expo/vector-icons@^12.0.4":
   version "12.0.4"
@@ -3575,7 +3580,7 @@
     color "^3.1.3"
     react-native-iphone-x-helper "^1.3.0"
 
-"@react-navigation/core@5.15.1", "@react-navigation/core@^5.14.3", "@react-navigation/core@^5.15.1":
+"@react-navigation/core@5.15.1", "@react-navigation/core@^5.15.1":
   version "5.15.1"
   resolved "https://registry.yarnpkg.com/@react-navigation/core/-/core-5.15.1.tgz#dab5192277c606d9acbea511dac407c2834b5fbe"
   integrity sha512-GDCpIVQd0NgHYCSdUMY69hrpeWKuYgj5SIRqHI2sYh9OguwGcV52ZZOafc+pQuyfuiLLIMidw34jiqb47QrlhA==
@@ -3596,6 +3601,28 @@
     query-string "^6.13.6"
     react-is "^16.13.0"
 
+"@react-navigation/core@^5.14.3":
+  version "5.14.3"
+  resolved "https://registry.yarnpkg.com/@react-navigation/core/-/core-5.14.3.tgz#6bbbfe1fb90aa64068fdb69bbb6c55120b7b24f1"
+  integrity sha512-l4zCfIfPC4DYuDcluiisaWKg7GO5yAjBrIL0pzEw8bIBj+R6vnZnyG9AWgnwo5fl241DX+1sfgzGEUQgpIJNew==
+  dependencies:
+    "@react-navigation/routers" "^5.6.2"
+    escape-string-regexp "^4.0.0"
+    nanoid "^3.1.15"
+    query-string "^6.13.6"
+    react-is "^16.13.0"
+
+"@react-navigation/core@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@react-navigation/core/-/core-6.0.1.tgz#4424ee1f83e2e305ef80d27c2778fb82fba852a0"
+  integrity sha512-mVdvBDYdz8uzLQHokmVdX/xC4rS7NIkD1FN/yaGdovVzYApAhM+UGd3w1zskjyCSyXaVHHOwV59ZGVew+84xfQ==
+  dependencies:
+    "@react-navigation/routers" "^6.0.1"
+    escape-string-regexp "^4.0.0"
+    nanoid "^3.1.23"
+    query-string "^7.0.0"
+    react-is "^16.13.0"
+
 "@react-navigation/drawer@~5.11.3":
   version "5.11.3"
   resolved "https://registry.yarnpkg.com/@react-navigation/drawer/-/drawer-5.11.3.tgz#0bc3c57861a0e033fda3df558c95685facb2e196"
@@ -3603,6 +3630,11 @@
   dependencies:
     color "^3.1.3"
     react-native-iphone-x-helper "^1.3.0"
+
+"@react-navigation/elements@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@react-navigation/elements/-/elements-1.1.0.tgz#483155ccf5a8f18d015db283bed34cc2255e2e9e"
+  integrity sha512-jZncciZPGuoP6B6f+Wpf6MYSSYy86B2HJDbFTCtT5xZV0w6V9GgCeqvSTOEAxifZrmKl8uDxsr0GrIxgQE8NxA==
 
 "@react-navigation/material-bottom-tabs@~5.3.9":
   version "5.3.9"
@@ -3626,6 +3658,15 @@
     hoist-non-react-statics "^3.3.2"
     react-native-safe-area-view "^0.14.9"
 
+"@react-navigation/native@^6.0.1":
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/@react-navigation/native/-/native-6.0.2.tgz#6bdb3cfafb6a9cfb603c1555dd61faafca35b7c2"
+  integrity sha512-HDqEwgvQ4Cu16vz8jQ55lfyNK9CGbECI1wM9cPOcUa+gkOQEDZ/95VFfFjGGflXZs3ybPvGXlMC4ZAyh1CcO6w==
+  dependencies:
+    "@react-navigation/core" "^6.0.1"
+    escape-string-regexp "^4.0.0"
+    nanoid "^3.1.23"
+
 "@react-navigation/native@~5.8.9":
   version "5.8.9"
   resolved "https://registry.yarnpkg.com/@react-navigation/native/-/native-5.8.9.tgz#67ee2afef6af6ef40c425e02264bd25d1530b361"
@@ -3635,12 +3676,26 @@
     escape-string-regexp "^4.0.0"
     nanoid "^3.1.15"
 
+"@react-navigation/routers@^5.6.2":
+  version "5.7.4"
+  resolved "https://registry.yarnpkg.com/@react-navigation/routers/-/routers-5.7.4.tgz#8b5460e841a0c64f6c9a5fbc2a1eb832432d4fb0"
+  integrity sha512-0N202XAqsU/FlE53Nmh6GHyMtGm7g6TeC93mrFAFJOqGRKznT0/ail+cYlU6tNcPA9AHzZu1Modw1eoDINSliQ==
+  dependencies:
+    nanoid "^3.1.15"
+
 "@react-navigation/routers@^5.7.1":
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/@react-navigation/routers/-/routers-5.7.1.tgz#ba56cabdaabc521ef29c26529e868590949429b1"
   integrity sha512-M5R4AFgJZ0uBUV+DjMyNy2HXRfvo0ldM+59Gj1NQWXaYnst3m0xJTfWiln94mnrbrHEq087gMP4ZLHGIJ8D1Ig==
   dependencies:
     nanoid "^3.1.15"
+
+"@react-navigation/routers@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@react-navigation/routers/-/routers-6.0.1.tgz#ae50f07c776c18bd9fdc87f17e9f3afc3fd59d19"
+  integrity sha512-5ctB49rmtTRQuTSBVgqMsEzBUjPP2ByUzBjNivA7jmvk+PDCl4oZsiR8KAm/twhxe215GYThfi2vUWXKAg6EEQ==
+  dependencies:
+    nanoid "^3.1.23"
 
 "@react-navigation/stack@5.14.2":
   version "5.14.2"
@@ -3649,6 +3704,15 @@
   dependencies:
     color "^3.1.3"
     react-native-iphone-x-helper "^1.3.0"
+
+"@react-navigation/stack@^6.0.1":
+  version "6.0.7"
+  resolved "https://registry.yarnpkg.com/@react-navigation/stack/-/stack-6.0.7.tgz#305e66129d0b425802bb6ed4f24dbd2fb56ab74f"
+  integrity sha512-hxwhRZbn6zD2rInhItBeHTCPYzmurz+/8/MhtRevBEdLG0+61dik8Y+evg/mu6AsOU0WrDakTsLcHdf/9zkXzw==
+  dependencies:
+    "@react-navigation/elements" "^1.1.0"
+    color "^3.1.3"
+    warn-once "^0.1.0"
 
 "@react-navigation/stack@~5.12.6":
   version "5.12.6"
@@ -9058,6 +9122,11 @@ fill-range@^7.0.1:
   dependencies:
     to-regex-range "^5.0.1"
 
+filter-obj@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/filter-obj/-/filter-obj-1.1.0.tgz#9b311112bc6c6127a16e016c6c5d7f19e0805c5b"
+  integrity sha1-mzERErxsYSehbgFsbF1/GeCAXFs=
+
 finalhandler@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.1.1.tgz#eebf4ed840079c83f4249038c9d703008301b105"
@@ -13927,6 +13996,11 @@ nanoid@^3.1.15:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.16.tgz#b21f0a7d031196faf75314d7c65d36352beeef64"
   integrity sha512-+AK8MN0WHji40lj8AEuwLOvLSbWYApQpre/aFJZD71r43wVRLrOYS4FmJOPQYon1TqB462RzrrxlfA74XRES8w==
 
+nanoid@^3.1.23:
+  version "3.1.25"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.25.tgz#09ca32747c0e543f0e1814b7d3793477f9c8e152"
+  integrity sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -15807,12 +15881,31 @@ query-string@^5.0.1:
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
 
-query-string@^6.13.6, query-string@^6.2.0:
+query-string@^6.13.6:
   version "6.13.7"
   resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.13.7.tgz#af53802ff6ed56f3345f92d40a056f93681026ee"
   integrity sha512-CsGs8ZYb39zu0WLkeOhe0NMePqgYdAuCqxOYKDR5LVCytDZYMGx3Bb+xypvQvPHVPijRXB0HZNFllCzHRe4gEA==
   dependencies:
     decode-uri-component "^0.2.0"
+    split-on-first "^1.0.0"
+    strict-uri-encode "^2.0.0"
+
+query-string@^6.2.0:
+  version "6.13.2"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.13.2.tgz#3585aa9412c957cbd358fd5eaca7466f05586dda"
+  integrity sha512-BMmDaUiLDFU1hlM38jTFcRt7HYiGP/zt1sRzrIWm5zpeEuO1rkbPS0ELI3uehoLuuhHDCS8u8lhFN3fEN4JzPQ==
+  dependencies:
+    decode-uri-component "^0.2.0"
+    split-on-first "^1.0.0"
+    strict-uri-encode "^2.0.0"
+
+query-string@^7.0.0:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-7.0.1.tgz#45bd149cf586aaa582dffc7ec7a8ad97dd02f75d"
+  integrity sha512-uIw3iRvHnk9to1blJCG3BTc+Ro56CBowJXKmNNAm3RulvPBzWLRqKSiiDk+IplJhsydwtuNMHi8UGQFcCLVfkA==
+  dependencies:
+    decode-uri-component "^0.2.0"
+    filter-obj "^1.1.0"
     split-on-first "^1.0.0"
     strict-uri-encode "^2.0.0"
 
@@ -16113,6 +16206,11 @@ react-native-redash@^14.1.1:
     normalize-svg-path "^1.0.1"
     parse-svg-path "^0.1.2"
 
+react-native-safe-area-context@3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-3.2.0.tgz#06113c6b208f982d68ab5c3cebd199ca93db6941"
+  integrity sha512-k2Nty4PwSnrg9HwrYeeE+EYqViYJoOFwEy9LxL5RIRfoqxAq/uQXNGwpUg2/u4gnKpBbEPa9eRh15KKMe/VHkA==
+
 react-native-safe-area-context@3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-3.3.2.tgz#9549a2ce580f2374edb05e49d661258d1b8bcaed"
@@ -16132,6 +16230,13 @@ react-native-safe-modules@^1.0.3:
   dependencies:
     dedent "^0.6.0"
 
+react-native-screens@^3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-3.5.0.tgz#c40be78dff8e2dff1b00ba8fa670b2e429e632d2"
+  integrity sha512-xew4x0YX0RaDduNYM4gZXkphPwGZIbbu9fTU85xOtT1tOUPm3OU4pFMiN6PF54haMCsaMQRvdOXvLicUVRiptA==
+  dependencies:
+    warn-once "^0.1.0"
+
 react-native-screens@~3.7.0:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-3.7.2.tgz#933cb0b6564b84a624a1e6ee0481e81415030ea9"
@@ -16149,7 +16254,7 @@ react-native-shared-element@0.8.2:
   resolved "https://registry.yarnpkg.com/react-native-shared-element/-/react-native-shared-element-0.8.2.tgz#64124ec7e19369b78b6924c93808e1ed058c8109"
   integrity sha512-IalCG1Sn6Vq171JMh0cbHzf0dJxwUIGwf5baxWhZ6busLQ2AL0A0pFb86sLgOUtv+NZdZX2R1Xd+Ylqj8neuLw==
 
-react-native-svg@12.1.1:
+react-native-svg@12.1.1, react-native-svg@^12.1.1:
   version "12.1.1"
   resolved "https://registry.yarnpkg.com/react-native-svg/-/react-native-svg-12.1.1.tgz#5f292410b8bcc07bbc52b2da7ceb22caf5bcaaee"
   integrity sha512-NIAJ8jCnXGCqGWXkkJ1GTzO4a3Md5at5sagYV8Vh4MXYnL4z5Rh428Wahjhh+LIjx40EE5xM5YtwyJBqOIba2Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3580,7 +3580,7 @@
     color "^3.1.3"
     react-native-iphone-x-helper "^1.3.0"
 
-"@react-navigation/core@5.15.1", "@react-navigation/core@^5.15.1":
+"@react-navigation/core@5.15.1", "@react-navigation/core@^5.14.3", "@react-navigation/core@^5.15.1":
   version "5.15.1"
   resolved "https://registry.yarnpkg.com/@react-navigation/core/-/core-5.15.1.tgz#dab5192277c606d9acbea511dac407c2834b5fbe"
   integrity sha512-GDCpIVQd0NgHYCSdUMY69hrpeWKuYgj5SIRqHI2sYh9OguwGcV52ZZOafc+pQuyfuiLLIMidw34jiqb47QrlhA==
@@ -3598,17 +3598,6 @@
   dependencies:
     hoist-non-react-statics "^3.3.2"
     path-to-regexp "^1.8.0"
-    query-string "^6.13.6"
-    react-is "^16.13.0"
-
-"@react-navigation/core@^5.14.3":
-  version "5.14.3"
-  resolved "https://registry.yarnpkg.com/@react-navigation/core/-/core-5.14.3.tgz#6bbbfe1fb90aa64068fdb69bbb6c55120b7b24f1"
-  integrity sha512-l4zCfIfPC4DYuDcluiisaWKg7GO5yAjBrIL0pzEw8bIBj+R6vnZnyG9AWgnwo5fl241DX+1sfgzGEUQgpIJNew==
-  dependencies:
-    "@react-navigation/routers" "^5.6.2"
-    escape-string-regexp "^4.0.0"
-    nanoid "^3.1.15"
     query-string "^6.13.6"
     react-is "^16.13.0"
 
@@ -3676,17 +3665,10 @@
     escape-string-regexp "^4.0.0"
     nanoid "^3.1.15"
 
-"@react-navigation/routers@^5.6.2":
+"@react-navigation/routers@^5.6.2", "@react-navigation/routers@^5.7.1":
   version "5.7.4"
   resolved "https://registry.yarnpkg.com/@react-navigation/routers/-/routers-5.7.4.tgz#8b5460e841a0c64f6c9a5fbc2a1eb832432d4fb0"
   integrity sha512-0N202XAqsU/FlE53Nmh6GHyMtGm7g6TeC93mrFAFJOqGRKznT0/ail+cYlU6tNcPA9AHzZu1Modw1eoDINSliQ==
-  dependencies:
-    nanoid "^3.1.15"
-
-"@react-navigation/routers@^5.7.1":
-  version "5.7.1"
-  resolved "https://registry.yarnpkg.com/@react-navigation/routers/-/routers-5.7.1.tgz#ba56cabdaabc521ef29c26529e868590949429b1"
-  integrity sha512-M5R4AFgJZ0uBUV+DjMyNy2HXRfvo0ldM+59Gj1NQWXaYnst3m0xJTfWiln94mnrbrHEq087gMP4ZLHGIJ8D1Ig==
   dependencies:
     nanoid "^3.1.15"
 
@@ -13991,12 +13973,7 @@ nan@^2.12.1, nan@^2.14.0:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.1.tgz#d7be34dfa3105b91494c3147089315eff8874b01"
   integrity sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==
 
-nanoid@^3.1.15:
-  version "3.1.16"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.16.tgz#b21f0a7d031196faf75314d7c65d36352beeef64"
-  integrity sha512-+AK8MN0WHji40lj8AEuwLOvLSbWYApQpre/aFJZD71r43wVRLrOYS4FmJOPQYon1TqB462RzrrxlfA74XRES8w==
-
-nanoid@^3.1.23:
+nanoid@^3.1.15, nanoid@^3.1.23:
   version "3.1.25"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.25.tgz#09ca32747c0e543f0e1814b7d3793477f9c8e152"
   integrity sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==
@@ -15881,19 +15858,10 @@ query-string@^5.0.1:
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
 
-query-string@^6.13.6:
+query-string@^6.13.6, query-string@^6.2.0:
   version "6.13.7"
   resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.13.7.tgz#af53802ff6ed56f3345f92d40a056f93681026ee"
   integrity sha512-CsGs8ZYb39zu0WLkeOhe0NMePqgYdAuCqxOYKDR5LVCytDZYMGx3Bb+xypvQvPHVPijRXB0HZNFllCzHRe4gEA==
-  dependencies:
-    decode-uri-component "^0.2.0"
-    split-on-first "^1.0.0"
-    strict-uri-encode "^2.0.0"
-
-query-string@^6.2.0:
-  version "6.13.2"
-  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.13.2.tgz#3585aa9412c957cbd358fd5eaca7466f05586dda"
-  integrity sha512-BMmDaUiLDFU1hlM38jTFcRt7HYiGP/zt1sRzrIWm5zpeEuO1rkbPS0ELI3uehoLuuhHDCS8u8lhFN3fEN4JzPQ==
   dependencies:
     decode-uri-component "^0.2.0"
     split-on-first "^1.0.0"
@@ -16230,14 +16198,7 @@ react-native-safe-modules@^1.0.3:
   dependencies:
     dedent "^0.6.0"
 
-react-native-screens@^3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-3.5.0.tgz#c40be78dff8e2dff1b00ba8fa670b2e429e632d2"
-  integrity sha512-xew4x0YX0RaDduNYM4gZXkphPwGZIbbu9fTU85xOtT1tOUPm3OU4pFMiN6PF54haMCsaMQRvdOXvLicUVRiptA==
-  dependencies:
-    warn-once "^0.1.0"
-
-react-native-screens@~3.7.0:
+react-native-screens@^3.5.0, react-native-screens@~3.7.0:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-3.7.2.tgz#933cb0b6564b84a624a1e6ee0481e81415030ea9"
   integrity sha512-TUmCE2ZIr6SFCUqsUqLsYQZ7EWo+tKyxSVFj3G5BCkGFOl3MwXEPgT/ihNCnL1aUAgr6TEMWVHg+awLkkQgYyQ==


### PR DESCRIPTION
# Why

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

This is another PR aimed to break up RFC #13637 into smaller chunks

The app is a react native client that can read and render the components that are generated by the stories CLI. It also includes a set of base components that the RN app and other story (future) `.stories` files can use, as well as the TestRunner component for including `test-suite` files in stories

## Demo: 


https://user-images.githubusercontent.com/40680668/130497495-117f178c-6109-4a87-a990-72a31845d7a0.mov



# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

The CLI puts the generated `stories.js` file in the `__generated__` folder of a project, which contains all the components and configuration for a given package. 

The app uses a patched metro config to read from this file and render the components in a relatively dynamic way

# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->

The best way to test this would be to use a sandbox app in `expo/expo`: 
- create a `.stories` file with an exported component in new app directory
- run the expo stories cli from the app directory - ensure the files are in `__generated__`
- update the metro config to use the exported `metro-config` from `expo-stories/metro-config`
- import `<ExpoStoriesApp />`  from 'expo-stories/clients/app` and run as the root navigator

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).