### PR TITLE
[modules-core] Fix `-[RCTModuleRegistry getAllExportedModules]: unrecognized selector`

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix `'-[RCTModuleRegistry getAllExportedModules]: unrecognized selector sent` was thrown while adding the event listener.
+- Fix `'-[RCTModuleRegistry getAllExportedModules]: unrecognized selector` crash while adding the event listener. ([#14130](https://github.com/expo/expo/pull/14130) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix `'-[RCTModuleRegistry getAllExportedModules]: unrecognized selector sent` was thrown while adding the event listener.
+
 ### 💡 Others
 
 ## 0.3.0-alpha.0 — 2021-08-17

--- a/packages/expo-modules-core/ios/Services/EXReactNativeEventEmitter.m
+++ b/packages/expo-modules-core/ios/Services/EXReactNativeEventEmitter.m
@@ -139,7 +139,11 @@ RCT_EXPORT_METHOD(removeProxiedListeners:(NSString *)moduleName count:(double)co
 
 - (void)setModuleRegistry:(EXModuleRegistry *)moduleRegistry
 {
-  _exModuleRegistry = moduleRegistry;
+  // We need to check if we get an object of the correct class because RN 65 tries to call this method with RTCModuleRegistry.
+  // See https://github.com/facebook/react-native/blob/2c2b83171603b47e5eec61eea55139f760dba090/React/Base/RCTModuleData.mm#L274-L289.
+  if ([moduleRegistry isKindOfClass:[EXModuleRegistry class]]) {
+    _exModuleRegistry = moduleRegistry;
+  }
 }
 
 @end


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/14092.

# How

RN tries to call out method (`setModuleRegistry`) via selector and passes `RCTModuleRegistry` there. What leads to `unrecognized selector` later. I've added a simple check if the passed module registry is `EXModuleRegistry`.

# Test Plan

- bare-expo ✅
- app with `RN 0.65.1`