### PR TITLE
[eyw] Keep compatibility with React Native <= 63 by using blacklist it is available

### DIFF
--- a/packages/expo-yarn-workspaces/CHANGELOG.md
+++ b/packages/expo-yarn-workspaces/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Support React Native 0.64 while also maintaining backwards compatibility with 0.63 and earlier. ([#14136](https://github.com/expo/expo/pull/14136) by [@brentvatne](https://github.com/brentvatne))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-yarn-workspaces/index.js
+++ b/packages/expo-yarn-workspaces/index.js
@@ -6,10 +6,26 @@ const findYarnWorkspaceRoot = require('find-yarn-workspace-root');
 // TODO: Use the vendored metro config in a future version after SDK 41 is released
 // const { getDefaultConfig } = require('expo/metro-config');
 const { assetExts } = require('metro-config/src/defaults/defaults');
-const exclusionList = require('metro-config/src/defaults/exclusionList');
 const path = require('path');
 
 const getSymlinkedNodeModulesForDirectory = require('./common/get-symlinked-modules');
+
+let exclusionList;
+try {
+  // blacklist was removed in the metro-config version used by
+  // react-native@0.64, but the interface is the same as the replacement,
+  // exclusionList, so we can use blacklist if it's available and otherwise
+  // use exclusionList.
+  exclusionList = require('metro-config/src/defaults/blacklist');
+} catch (e) {
+  if (e.code !== 'MODULE_NOT_FOUND') {
+    throw e;
+  }
+
+  // Require exclusionList after attempting to load blacklist, so if an error is
+  // thrown then it is the same as if we only required exclusionList.
+  exclusionList = require('metro-config/src/defaults/exclusionList');
+}
 
 /**
  * Returns a configuration object in the format expected for "metro.config.js" files. The


### PR DESCRIPTION
# Why

#10086 - blacklist was renamed to exclusionList in the metro-config version used by react-native@0.64, but it's not too big of a hassle to ensure eyw works with both 63 and 64 so we should do this. This is especially meaningful because we don't integrate eyw with `expo install` currently, so you just get the latest version when you install it.

# How

Use blacklist if available, otherwise fall back to exclusionList.

# Test Plan

- Modify directly in source code for our expo/examples with-yarn-workspaces, verify it works
- Verify apps in expo/expo work

# Checklist

- [n/a] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [n/a] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [n/a] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).