### PR TITLE
Enable CoreSimulator module by default for dog fooding

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -10,6 +10,10 @@ export ANDROID_HOME="${ANDROID_SDK_ROOT:=$ANDROID_SDK}"
 # Enable experimental dev server in expo-cli
 export EXPO_USE_DEV_SERVER=true
 
+# Enable experimental JS version of simctl for opening iOS simulators `expo start -i`
+# and listing simulators `expo run:ios -d` and `shift+i` in `expo start`.
+export EXPO_USE_CORE_SIM=1
+
 # Force all Expo modules to be compiled from source
 export EXPO_USE_SOURCE=1
 


### PR DESCRIPTION
Get the team trying out our new simulator tooling