### PR TITLE
Move background location to the expo-location package

### DIFF
--- a/packages/expo-background-fetch/CHANGELOG.md
+++ b/packages/expo-background-fetch/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 🛠 Breaking changes
 
+- [plugin] Moved `UIBackgroundModes` `location` to the `expo-location` plugin ([#14142](https://github.com/expo/expo/pull/14142) by [@EvanBacon](https://github.com/EvanBacon))
 - Remove exported enums aliases for `BackgroundFetchResult` and `BackgroundFetchStatus`. ([#12716](https://github.com/expo/expo/pull/13267) by [@Simek](https://github.com/Simek))
 
 ### 🎉 New features

--- a/packages/expo-background-fetch/plugin/build/withBackgroundFetch.js
+++ b/packages/expo-background-fetch/plugin/build/withBackgroundFetch.js
@@ -3,16 +3,16 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const config_plugins_1 = require("@expo/config-plugins");
 const pkg = require('expo-background-fetch/package.json');
 const withBackgroundFetch = config => {
-    if (!config.ios)
-        config.ios = {};
-    if (!config.ios.infoPlist)
-        config.ios.infoPlist = {};
-    if (!config.ios.infoPlist.UIBackgroundModes)
-        config.ios.infoPlist.UIBackgroundModes = [];
     // TODO: Maybe entitlements are needed
-    config.ios.infoPlist.UIBackgroundModes = [
-        ...new Set(config.ios.infoPlist.UIBackgroundModes.concat(['location', 'fetch'])),
-    ];
+    config = config_plugins_1.withInfoPlist(config, config => {
+        if (!Array.isArray(config.modResults.UIBackgroundModes)) {
+            config.modResults.UIBackgroundModes = [];
+        }
+        if (!config.modResults.UIBackgroundModes.includes('fetch')) {
+            config.modResults.UIBackgroundModes.push('fetch');
+        }
+        return config;
+    });
     return config_plugins_1.AndroidConfig.Permissions.withPermissions(config, [
         'android.permission.RECEIVE_BOOT_COMPLETED',
         'android.permission.WAKE_LOCK',

--- a/packages/expo-background-fetch/plugin/src/withBackgroundFetch.ts
+++ b/packages/expo-background-fetch/plugin/src/withBackgroundFetch.ts
@@ -1,16 +1,24 @@
-import { AndroidConfig, ConfigPlugin, createRunOncePlugin } from '@expo/config-plugins';
+import {
+  AndroidConfig,
+  ConfigPlugin,
+  createRunOncePlugin,
+  withInfoPlist,
+} from '@expo/config-plugins';
 
 const pkg = require('expo-background-fetch/package.json');
 
 const withBackgroundFetch: ConfigPlugin = config => {
-  if (!config.ios) config.ios = {};
-  if (!config.ios.infoPlist) config.ios.infoPlist = {};
-  if (!config.ios.infoPlist.UIBackgroundModes) config.ios.infoPlist.UIBackgroundModes = [];
-
   // TODO: Maybe entitlements are needed
-  config.ios.infoPlist.UIBackgroundModes = [
-    ...new Set(config.ios.infoPlist.UIBackgroundModes.concat(['location', 'fetch'])),
-  ];
+
+  config = withInfoPlist(config, config => {
+    if (!Array.isArray(config.modResults.UIBackgroundModes)) {
+      config.modResults.UIBackgroundModes = [];
+    }
+    if (!config.modResults.UIBackgroundModes.includes('fetch')) {
+      config.modResults.UIBackgroundModes.push('fetch');
+    }
+    return config;
+  });
 
   return AndroidConfig.Permissions.withPermissions(config, [
     'android.permission.RECEIVE_BOOT_COMPLETED',

--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 🎉 New features
 
+- [plugin] Added `isIosBackgroundLocationEnabled` to enable the background location UIMode ([#14142](https://github.com/expo/expo/pull/14142) by [@EvanBacon](https://github.com/EvanBacon))
 - Use stable manifest ID where applicable. ([#12964](https://github.com/expo/expo/pull/12964) by [@wschurman](https://github.com/wschurman))
 - Add useForegroundPermissions and useBackgroundPermissions hooks from modules factory. ([#13860](https://github.com/expo/expo/pull/13860) by [@bycedric](https://github.com/bycedric))
 

--- a/packages/expo-location/plugin/build/withLocation.d.ts
+++ b/packages/expo-location/plugin/build/withLocation.d.ts
@@ -3,6 +3,7 @@ declare const _default: ConfigPlugin<void | {
     locationAlwaysAndWhenInUsePermission?: string | undefined;
     locationAlwaysPermission?: string | undefined;
     locationWhenInUsePermission?: string | undefined;
+    isIosBackgroundLocationEnabled?: boolean | undefined;
     isAndroidBackgroundLocationEnabled?: boolean | undefined;
 }>;
 export default _default;

--- a/packages/expo-location/plugin/build/withLocation.js
+++ b/packages/expo-location/plugin/build/withLocation.js
@@ -3,23 +3,36 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const config_plugins_1 = require("@expo/config-plugins");
 const pkg = require('expo-location/package.json');
 const LOCATION_USAGE = 'Allow $(PRODUCT_NAME) to access your location';
-const withLocation = (config, { locationAlwaysAndWhenInUsePermission, locationAlwaysPermission, locationWhenInUsePermission, isAndroidBackgroundLocationEnabled, } = {}) => {
-    if (!config.ios)
-        config.ios = {};
-    if (!config.ios.infoPlist)
-        config.ios.infoPlist = {};
-    config.ios.infoPlist.NSLocationAlwaysAndWhenInUseUsageDescription =
-        locationAlwaysAndWhenInUsePermission ||
-            config.ios.infoPlist.NSLocationAlwaysAndWhenInUseUsageDescription ||
-            LOCATION_USAGE;
-    config.ios.infoPlist.NSLocationAlwaysUsageDescription =
-        locationAlwaysPermission ||
-            config.ios.infoPlist.NSLocationAlwaysUsageDescription ||
-            LOCATION_USAGE;
-    config.ios.infoPlist.NSLocationWhenInUseUsageDescription =
-        locationWhenInUsePermission ||
-            config.ios.infoPlist.NSLocationWhenInUseUsageDescription ||
-            LOCATION_USAGE;
+const withBackgroundLocation = config => {
+    return config_plugins_1.withInfoPlist(config, config => {
+        if (!Array.isArray(config.modResults.UIBackgroundModes)) {
+            config.modResults.UIBackgroundModes = [];
+        }
+        if (!config.modResults.UIBackgroundModes.includes('location')) {
+            config.modResults.UIBackgroundModes.push('location');
+        }
+        return config;
+    });
+};
+const withLocation = (config, { locationAlwaysAndWhenInUsePermission, locationAlwaysPermission, locationWhenInUsePermission, isIosBackgroundLocationEnabled, isAndroidBackgroundLocationEnabled, } = {}) => {
+    if (isIosBackgroundLocationEnabled) {
+        config = withBackgroundLocation(config);
+    }
+    config = config_plugins_1.withInfoPlist(config, config => {
+        config.modResults.NSLocationAlwaysAndWhenInUseUsageDescription =
+            locationAlwaysAndWhenInUsePermission ||
+                config.modResults.NSLocationAlwaysAndWhenInUseUsageDescription ||
+                LOCATION_USAGE;
+        config.modResults.NSLocationAlwaysUsageDescription =
+            locationAlwaysPermission ||
+                config.modResults.NSLocationAlwaysUsageDescription ||
+                LOCATION_USAGE;
+        config.modResults.NSLocationWhenInUseUsageDescription =
+            locationWhenInUsePermission ||
+                config.modResults.NSLocationWhenInUseUsageDescription ||
+                LOCATION_USAGE;
+        return config;
+    });
     return config_plugins_1.AndroidConfig.Permissions.withPermissions(config, [
         'android.permission.ACCESS_COARSE_LOCATION',
         'android.permission.ACCESS_FINE_LOCATION',

--- a/packages/expo-location/plugin/src/withLocation.ts
+++ b/packages/expo-location/plugin/src/withLocation.ts
@@ -1,12 +1,30 @@
-import { AndroidConfig, ConfigPlugin, createRunOncePlugin } from '@expo/config-plugins';
+import {
+  AndroidConfig,
+  ConfigPlugin,
+  createRunOncePlugin,
+  withInfoPlist,
+} from '@expo/config-plugins';
 
 const pkg = require('expo-location/package.json');
 const LOCATION_USAGE = 'Allow $(PRODUCT_NAME) to access your location';
+
+const withBackgroundLocation: ConfigPlugin = config => {
+  return withInfoPlist(config, config => {
+    if (!Array.isArray(config.modResults.UIBackgroundModes)) {
+      config.modResults.UIBackgroundModes = [];
+    }
+    if (!config.modResults.UIBackgroundModes.includes('location')) {
+      config.modResults.UIBackgroundModes.push('location');
+    }
+    return config;
+  });
+};
 
 const withLocation: ConfigPlugin<{
   locationAlwaysAndWhenInUsePermission?: string;
   locationAlwaysPermission?: string;
   locationWhenInUsePermission?: string;
+  isIosBackgroundLocationEnabled?: boolean;
   isAndroidBackgroundLocationEnabled?: boolean;
 } | void> = (
   config,
@@ -14,23 +32,30 @@ const withLocation: ConfigPlugin<{
     locationAlwaysAndWhenInUsePermission,
     locationAlwaysPermission,
     locationWhenInUsePermission,
+    isIosBackgroundLocationEnabled,
     isAndroidBackgroundLocationEnabled,
   } = {}
 ) => {
-  if (!config.ios) config.ios = {};
-  if (!config.ios.infoPlist) config.ios.infoPlist = {};
-  config.ios.infoPlist.NSLocationAlwaysAndWhenInUseUsageDescription =
-    locationAlwaysAndWhenInUsePermission ||
-    config.ios.infoPlist.NSLocationAlwaysAndWhenInUseUsageDescription ||
-    LOCATION_USAGE;
-  config.ios.infoPlist.NSLocationAlwaysUsageDescription =
-    locationAlwaysPermission ||
-    config.ios.infoPlist.NSLocationAlwaysUsageDescription ||
-    LOCATION_USAGE;
-  config.ios.infoPlist.NSLocationWhenInUseUsageDescription =
-    locationWhenInUsePermission ||
-    config.ios.infoPlist.NSLocationWhenInUseUsageDescription ||
-    LOCATION_USAGE;
+  if (isIosBackgroundLocationEnabled) {
+    config = withBackgroundLocation(config);
+  }
+
+  config = withInfoPlist(config, config => {
+    config.modResults.NSLocationAlwaysAndWhenInUseUsageDescription =
+      locationAlwaysAndWhenInUsePermission ||
+      config.modResults.NSLocationAlwaysAndWhenInUseUsageDescription ||
+      LOCATION_USAGE;
+    config.modResults.NSLocationAlwaysUsageDescription =
+      locationAlwaysPermission ||
+      config.modResults.NSLocationAlwaysUsageDescription ||
+      LOCATION_USAGE;
+    config.modResults.NSLocationWhenInUseUsageDescription =
+      locationWhenInUsePermission ||
+      config.modResults.NSLocationWhenInUseUsageDescription ||
+      LOCATION_USAGE;
+
+    return config;
+  });
 
   return AndroidConfig.Permissions.withPermissions(
     config,

--- a/packages/expo-task-manager/CHANGELOG.md
+++ b/packages/expo-task-manager/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- [plugin] Moved `UIBackgroundModes` `location` to the `expo-location` plugin ([#14142](https://github.com/expo/expo/pull/14142) by [@EvanBacon](https://github.com/EvanBacon))
+
 ### 🎉 New features
 
 - Use stable manifest ID where applicable. ([#12964](https://github.com/expo/expo/pull/12964) by [@wschurman](https://github.com/wschurman))

--- a/packages/expo-task-manager/plugin/build/withTaskManager.js
+++ b/packages/expo-task-manager/plugin/build/withTaskManager.js
@@ -3,16 +3,15 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const config_plugins_1 = require("@expo/config-plugins");
 const pkg = require('expo-task-manager/package.json');
 const withTaskManager = config => {
-    if (!config.ios)
-        config.ios = {};
-    if (!config.ios.infoPlist)
-        config.ios.infoPlist = {};
-    if (!config.ios.infoPlist.UIBackgroundModes)
-        config.ios.infoPlist.UIBackgroundModes = [];
-    // TODO: Maybe entitlements are needed
-    config.ios.infoPlist.UIBackgroundModes = [
-        ...new Set(config.ios.infoPlist.UIBackgroundModes.concat(['location', 'fetch'])),
-    ];
+    config = config_plugins_1.withInfoPlist(config, config => {
+        if (!Array.isArray(config.modResults.UIBackgroundModes)) {
+            config.modResults.UIBackgroundModes = [];
+        }
+        if (!config.modResults.UIBackgroundModes.includes('fetch')) {
+            config.modResults.UIBackgroundModes.push('fetch');
+        }
+        return config;
+    });
     return config;
 };
 exports.default = config_plugins_1.createRunOncePlugin(withTaskManager, pkg.name, pkg.version);

--- a/packages/expo-task-manager/plugin/src/withTaskManager.ts
+++ b/packages/expo-task-manager/plugin/src/withTaskManager.ts
@@ -1,16 +1,17 @@
-import { ConfigPlugin, createRunOncePlugin } from '@expo/config-plugins';
+import { ConfigPlugin, createRunOncePlugin, withInfoPlist } from '@expo/config-plugins';
 
 const pkg = require('expo-task-manager/package.json');
 
 const withTaskManager: ConfigPlugin = config => {
-  if (!config.ios) config.ios = {};
-  if (!config.ios.infoPlist) config.ios.infoPlist = {};
-  if (!config.ios.infoPlist.UIBackgroundModes) config.ios.infoPlist.UIBackgroundModes = [];
-
-  // TODO: Maybe entitlements are needed
-  config.ios.infoPlist.UIBackgroundModes = [
-    ...new Set(config.ios.infoPlist.UIBackgroundModes.concat(['location', 'fetch'])),
-  ];
+  config = withInfoPlist(config, config => {
+    if (!Array.isArray(config.modResults.UIBackgroundModes)) {
+      config.modResults.UIBackgroundModes = [];
+    }
+    if (!config.modResults.UIBackgroundModes.includes('fetch')) {
+      config.modResults.UIBackgroundModes.push('fetch');
+    }
+    return config;
+  });
 
   return config;
 };


### PR DESCRIPTION
# Why

Move the location UIBackgroundMode to the `expo-location` config plugin, behind the `isIosBackgroundLocationEnabled` property, and remove it from `expo-task-manager` and `expo-background-fetch`.

Resolve ENG-1642
Resolve https://github.com/expo/expo/issues/14098