### PR TITLE
[workflows] update `setup-node` action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - name: Install Node 14
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: '14.17'
       - name: Check out repository

--- a/.github/workflows/publish-demo.yml
+++ b/.github/workflows/publish-demo.yml
@@ -29,7 +29,7 @@ jobs:
           path: .git/lfs
           key: ${{ steps.git-lfs.outputs.sha256 }}
       - run: git lfs pull
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: '14.17'
       - run: yarn global add expo-cli@3

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -27,7 +27,7 @@ jobs:
           path: .git/lfs
           key: ${{ steps.git-lfs.outputs.sha256 }}
       - run: git lfs pull
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: '14.17'
       - run: yarn global add expo-cli@3


### PR DESCRIPTION
# Why

Currently most of the workflow uses `v2` of `setup-node` action already, but there were a few job which used the old version.

# How

This PR bumps the remaining `setup-node` actions to `v2`.

# Test Plan

Run the CI.