### PR TITLE
[github] add Discord link to the issue form

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: Expo Community Support
-    url: https://forums.expo.io/
-    about: Please ask and answer questions regarding Expo here
+    url: https://forums.expo.dev/
+    about: Please ask and answer questions regarding Expo here.
+  - name: Expo Developers Discord
+    url: https://chat.expo.dev/
+    about: Join other developers in discussions regarding Expo.


### PR DESCRIPTION
# Why

To expose Discord server existence a bit more. The link is already present in few places, like website footer, or Readme file but I think it won't hurt to add it also to the issue form. 😉 

# How

This PR adds link at the bottom of the issues form which will take user to the Expo Developers Discord server. 

It's added in the similar way as Forums link, according to the GitHub guide:
* https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser

# Test Plan

🤷‍♂️ 
