### PR TITLE
[babel-preset] add missing plugin dependency

### DIFF
--- a/packages/babel-preset-expo/__tests__/__snapshots__/index-test.js.snap
+++ b/packages/babel-preset-expo/__tests__/__snapshots__/index-test.js.snap
@@ -260,8 +260,8 @@ require(\\"@expo/vector-icons\\");"
 `;
 
 exports[`metro supports automatic JSX runtime 1`] = `
-"Object.defineProperty(exports,\\"__esModule\\",{value:true});exports.default=App;var _jsxRuntime=require(\\"react/jsx-runtime\\");
-var _reactNative=require(\\"react-native\\");
+"Object.defineProperty(exports,\\"__esModule\\",{value:true});exports.default=App;
+var _reactNative=require(\\"react-native\\");var _jsxRuntime=require(\\"react/jsx-runtime\\");
 function App(){
 return(0,_jsxRuntime.jsx)(_reactNative.View,{children:(0,_jsxRuntime.jsx)(_reactNative.Text,{children:\\"Hello World\\"})});
 }"
@@ -287,7 +287,7 @@ import\\"@expo/vector-icons\\";"
 `;
 
 exports[`webpack supports automatic JSX runtime 1`] = `
-"import{jsx as _jsx}from\\"react/jsx-runtime\\";import Text from\\"react-native-web/dist/exports/Text\\";import View from\\"react-native-web/dist/exports/View\\";
+"import Text from\\"react-native-web/dist/exports/Text\\";import View from\\"react-native-web/dist/exports/View\\";import{jsx as _jsx}from\\"react/jsx-runtime\\";
 
 export default function App(){
 return _jsx(View,{children:_jsx(Text,{children:\\"Hello World\\"})});

--- a/packages/babel-preset-expo/package.json
+++ b/packages/babel-preset-expo/package.json
@@ -46,6 +46,7 @@
   },
   "dependencies": {
     "@babel/plugin-proposal-decorators": "^7.12.9",
+    "@babel/plugin-transform-react-jsx": "^7.12.17",
     "@babel/preset-env": "^7.12.9",
     "babel-plugin-module-resolver": "^4.1.0",
     "babel-plugin-react-native-web": "~0.17.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1399,6 +1399,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
+"@babel/plugin-syntax-jsx@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.14.5.tgz#000e2e25d8673cce49300517a3eda44c263e4201"
+  integrity sha512-ohuFIsOMXJnbOMRfX7/w7LocdR6R7whhuRD4ax8IipLcLPlZGJKkBxgHp++U4N/vKyU16/YDQr2f5seajD3jIw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.14.5"
+
 "@babel/plugin-syntax-logical-assignment-operators@^7.10.4", "@babel/plugin-syntax-logical-assignment-operators@^7.8.3":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz#ca91ef46303530448b906652bac2e9fe9941f699"
@@ -2112,6 +2119,17 @@
     "@babel/helper-builder-react-jsx-experimental" "^7.10.4"
     "@babel/helper-plugin-utils" "^7.10.4"
     "@babel/plugin-syntax-jsx" "^7.10.4"
+
+"@babel/plugin-transform-react-jsx@^7.12.17":
+  version "7.14.9"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.14.9.tgz#3314b2163033abac5200a869c4de242cd50a914c"
+  integrity sha512-30PeETvS+AeD1f58i1OVyoDlVYQhap/K20ZrMjLmmzmC2AYR/G43D4sdJAaDAqCD3MYpSWbmrz3kES158QSLjw==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.14.5"
+    "@babel/helper-module-imports" "^7.14.5"
+    "@babel/helper-plugin-utils" "^7.14.5"
+    "@babel/plugin-syntax-jsx" "^7.14.5"
+    "@babel/types" "^7.14.9"
 
 "@babel/plugin-transform-regenerator@^7.0.0", "@babel/plugin-transform-regenerator@^7.10.4":
   version "7.10.4"
@@ -5377,10 +5395,10 @@
     "@babel/runtime" "^7.7.2"
     core-js "^3.4.1"
 
-"@koale/useworker@^3.2.1":
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/@koale/useworker/-/useworker-3.2.1.tgz#3d45593887e1df7ae8b469f1512fbaff85e4db2f"
-  integrity sha512-oTATxVRYceI0ZrlcAYGwhXU5l+rHd14yFlAyQfgbwi+vfFnnMX9EwU85RlGHIKf0BT4rrIIJm73L9lgz/+/EnA==
+"@koale/useworker@^4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@koale/useworker/-/useworker-4.0.2.tgz#cb540a2581cd6025307c3ca6685bc60748773e58"
+  integrity sha512-xPIPADtom8/3/4FLNj7MvNcBM/Z2FleH85Fdx2O869eoKW8+PoEgtSVvoxWjCWMA46Sm9A5/R1TyzNGc+yM0wg==
   dependencies:
     dequal "^1.0.0"
 


### PR DESCRIPTION
# Why

Refs: #14152

During the work on the `react-native-bundle-visualizer` bump I have spotted that the current and newest version fail to generate report in `/home` app due to an error:

<img width="1503" alt="Screenshot 2021-08-23 at 14 28 56" src="https://user-images.githubusercontent.com/719641/130447471-43b7a2a7-1cb2-4015-b2f8-2b2f52bfecc5.png">

It looks like the plugin is required conditionally in this line (since #13945):
* https://github.com/expo/expo/blob/master/packages/babel-preset-expo/index.js#L44

But it is not present in the project dependencies.

# How

This PR adds the missing `@babel/plugin-transform-react-jsx` dependency to the `babel-preset-expo` package.

# Test Plan

After those changes `yarn report` run in `/home` directory succeeds and output a result.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [X] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [X] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).