### PR TITLE
[core-modules] Fix inline node scripts in readme

### DIFF
--- a/packages/expo-modules-core/README.md
+++ b/packages/expo-modules-core/README.md
@@ -61,7 +61,7 @@ apply from: new File(["node", "--print", "require.resolve('expo-updates/package.
 
 // ...
 
-apply from: new File(["node", "--print", "require.resolve('@react-native-community/cli-platform-android/package.json"].execute().text.trim(), "../native_modules.gradle");
+apply from: new File(["node", "--print", "require.resolve('@react-native-community/cli-platform-android/package.json')"].execute().text.trim(), "../native_modules.gradle");
 applyNativeModulesAppBuildGradle(project)
 ```
 
@@ -71,7 +71,7 @@ applyNativeModulesAppBuildGradle(project)
 apply from: new File(["node", "--print", "require.resolve('react-native-unimodules/package.json')"].execute().text.trim(), "../gradle.groovy");
 includeUnimodulesProjects()
 
-apply from: new File(["node", "--print", "require.resolve('@react-native-community/cli-platform-android/package.json"].execute().text.trim(), "../native_modules.gradle");
+apply from: new File(["node", "--print", "require.resolve('@react-native-community/cli-platform-android/package.json')"].execute().text.trim(), "../native_modules.gradle");
 applyNativeModulesSettingsGradle(settings)
 ```
 


### PR DESCRIPTION
# Why

I accidentally copied these over. On the good side, the error you get from Gradle is pretty good. It points directly to the line of code.

# How

Fixed Node snippet in gradle

# Test Plan

Just a docs change

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).