### PR TITLE
[template] React Native Image gif and webp support

### DIFF
--- a/templates/expo-template-bare-minimum/android/app/build.gradle
+++ b/templates/expo-template-bare-minimum/android/app/build.gradle
@@ -204,7 +204,7 @@ dependencies {
     // For WebP support, including animated WebP
     if (isWebpEnabled) {
         implementation 'com.facebook.fresco:webpsupport:2.0.0'
-        implementation 'com.facebook.fresco:animated-webp:2.1.0'
+        implementation 'com.facebook.fresco:animated-webp:2.0.0'
     }
     
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.0.0"

--- a/templates/expo-template-bare-minimum/android/app/build.gradle
+++ b/templates/expo-template-bare-minimum/android/app/build.gradle
@@ -186,6 +186,27 @@ dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     //noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:+"  // From node_modules
+
+    def isGifEnabled = (findProperty('expo.gif.enabled') ?: "") == "true";
+    def isWebpEnabled = (findProperty('expo.webp.enabled') ?: "") == "true";
+
+     // If your app supports Android versions before Ice Cream Sandwich (API level 14)
+    if (isGifEnabled || isWebpEnabled) {
+        implementation 'com.facebook.fresco:fresco:2.0.0'
+        implementation 'com.facebook.fresco:imagepipeline-okhttp3:2.0.0'
+    }
+
+    // For animated GIF support
+    if (isGifEnabled) {
+        implementation 'com.facebook.fresco:animated-gif:2.0.0'
+    }
+
+    // For WebP support, including animated WebP
+    if (isWebpEnabled) {
+        implementation 'com.facebook.fresco:webpsupport:2.0.0'
+        implementation 'com.facebook.fresco:animated-webp:2.1.0'
+    }
+    
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.0.0"
     debugImplementation("com.facebook.flipper:flipper:${FLIPPER_VERSION}") {
       exclude group:'com.facebook.fbjni'

--- a/templates/expo-template-bare-minimum/android/app/build.gradle
+++ b/templates/expo-template-bare-minimum/android/app/build.gradle
@@ -189,22 +189,27 @@ dependencies {
 
     def isGifEnabled = (findProperty('expo.gif.enabled') ?: "") == "true";
     def isWebpEnabled = (findProperty('expo.webp.enabled') ?: "") == "true";
+    def isWebpAnimatedEnabled = (findProperty('expo.webp.animated') ?: "") == "true";
 
-     // If your app supports Android versions before Ice Cream Sandwich (API level 14)
+    // If your app supports Android versions before Ice Cream Sandwich (API level 14)
+    // All fresco packages should use the same version
     if (isGifEnabled || isWebpEnabled) {
         implementation 'com.facebook.fresco:fresco:2.0.0'
         implementation 'com.facebook.fresco:imagepipeline-okhttp3:2.0.0'
     }
 
-    // For animated GIF support
     if (isGifEnabled) {
+        // For animated gif support
         implementation 'com.facebook.fresco:animated-gif:2.0.0'
     }
 
-    // For WebP support, including animated WebP
     if (isWebpEnabled) {
+        // For webp support
         implementation 'com.facebook.fresco:webpsupport:2.0.0'
-        implementation 'com.facebook.fresco:animated-webp:2.0.0'
+        if (isWebpAnimatedEnabled) {
+            // Animated webp support
+            implementation 'com.facebook.fresco:animated-webp:2.0.0'
+        }
     }
     
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.0.0"

--- a/templates/expo-template-bare-minimum/android/gradle.properties
+++ b/templates/expo-template-bare-minimum/android/gradle.properties
@@ -32,8 +32,10 @@ FLIPPER_VERSION=0.54.0
 # Supported values: expo.jsEngine = "hermes" | "jsc"
 expo.jsEngine=jsc
 
-# Enable GIF support in React Native images
+# Enable GIF support in React Native images (~200 B increase)
 expo.gif.enabled=true
-
-# Enable WebP and Animated WebP support in React Native images
+# Enable webp support in React Native images (~85 KB increase)
 expo.webp.enabled=true
+# Enable animated webp support (~3.4 MB increase)
+# Disabled by default because iOS doesn't support animated webp
+expo.webp.animated=false

--- a/templates/expo-template-bare-minimum/android/gradle.properties
+++ b/templates/expo-template-bare-minimum/android/gradle.properties
@@ -31,3 +31,9 @@ FLIPPER_VERSION=0.54.0
 # The hosted JavaScript engine
 # Supported values: expo.jsEngine = "hermes" | "jsc"
 expo.jsEngine=jsc
+
+# Enable GIF support in React Native images
+expo.gif.enabled=true
+
+# Enable WebP and Animated WebP support in React Native images
+expo.webp.enabled=true


### PR DESCRIPTION
Added properties to enable/disable React Native Image gif and webp support. This is required for co-op between Turtle shell apps/Expo Go and managed EAS Build. 

`implementation 'com.facebook.fresco:fresco:2.0.0'` isn't directly required as it's included in expo-image-loader, but that seems like a loose coincidence that could easily break in the future.

Features can be disabled by removing the keys `expo.gif.enabled` and `expo.webp.enabled` or by setting them to `false`.

- resolve https://linear.app/expo/issue/ENG-1648/gif-support-on-android-with-prebuild
- resolve https://github.com/expo/expo/issues/13766

## Sizes

Base release binary:
- None: 33.3mb
- Gifs: 33.3mb
- Gifs + Webp: 33.4mb
- Gifs + Webp + Aniamted Webp: 36.8mb

## Issues

Animated webp doesn't animate on iOS in the client or the bare build on iOS 14.5 or iOS 15. Animated webp does render the first frame on iOS, whereas on Android, if we don't include the animated webp package then nothing will render. i.e. you can either get first image (ios), nothing (android) - or - first image (ios), animated (android).

# Test Plan

Added this code to a project with test images to ensure the disabled/enabled states act as expected.

- [animated webp](https://www.bandisoft.com/honeycam/howto/no-repeat-gif/repeat.webp)
- [gif](https://gist.github.com/EvanBacon/f4597fa1156772a111a44d1935d80a12/raw/49ab909de45454f5017b410d3bb20ab2c663a56c/%25F0%259F%25A7%25BD.gif)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).