### PR TITLE
[image][android] Remove redefinition of propOptions

### DIFF
--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageView.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageView.kt
@@ -53,7 +53,6 @@ class ExpoImageView(context: ReactContext, private val requestManager: RequestMa
   internal var sourceMap: ReadableMap? = null
   var blurRadius: Int? = null
   var fadeDuration: Int? = null
-    private get
 
   init {
     clipToOutline = true
@@ -178,7 +177,8 @@ class ExpoImageView(context: ReactContext, private val requestManager: RequestMa
     return RequestOptions()
       .apply {
         blurRadius?.let {
-          transform(BlurTransformation(it+1, 4))
+          transform(BlurTransformation(it + 1, 4))
+        }
         fadeDuration?.let {
           alpha = 0f
           animate().alpha(1f).duration = it.toLong();

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageView.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageView.kt
@@ -121,7 +121,6 @@ class ExpoImageView(context: ReactContext, private val requestManager: RequestMa
       val options = createOptionsFromSourceMap(sourceMap)
       val propOptions = createPropOptions()
       val eventsManager = ImageLoadEventsManager(id, eventEmitter)
-      val propOptions = createPropOptions()
       progressInterceptor.registerProgressListener(sourceToLoad.toStringUrl(), eventsManager)
       eventsManager.onLoadStarted()
       requestManager

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageViewManager.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageViewManager.kt
@@ -58,6 +58,8 @@ class ExpoImageViewManager(applicationContext: ReactApplicationContext) : Simple
   @ReactProp(name = "blurRadius")
   fun setBlurRadius(view: ExpoImageView, blurRadius: Int) {
     view.blurRadius = blurRadius
+  }
+
   @ReactProp(name = "fadeDuration")
   fun setFadeDuration(view: ExpoImageView, fadeDuration: Int) {
     view.fadeDuration = fadeDuration


### PR DESCRIPTION
# Why

- Fixes mistake which occur during merging #14131

# How

- Removed duplicated line and added missing braces.
- Removed redundant setter.

# Test Plan


# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).