### PR TITLE
[media][ios] remove `assets-library://` usage in favour of `ph://`

### DIFF
--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Added `isAvailableAsync` method ([#13418](https://github.com/expo/expo/pull/13418) by [@danielmark0116](https://github.com/danielmark0116))˝
+- Added `isAvailableAsync` method. ([#13418](https://github.com/expo/expo/pull/13418) by [@danielmark0116](https://github.com/danielmark0116))
 - Add `usePermissions` hook from modules factory. ([#13862](https://github.com/expo/expo/pull/13862) by [@bycedric](https://github.com/bycedric))
 
 ### 🐛 Bug fixes

--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Added `isAvailableAsync` method ([#13418](https://github.com/expo/expo/pull/13418) by [@danielmark0116](https://github.com/danielmark0116))
+- Added `isAvailableAsync` method ([#13418](https://github.com/expo/expo/pull/13418) by [@danielmark0116](https://github.com/danielmark0116))˝
 - Add `usePermissions` hook from modules factory. ([#13862](https://github.com/expo/expo/pull/13862) by [@bycedric](https://github.com/bycedric))
 
 ### 🐛 Bug fixes
@@ -15,6 +15,7 @@
 
 - Migrated from `@unimodules/core` to `expo-modules-core`. ([#13755](https://github.com/expo/expo/pull/13755) by [@tsapeta](https://github.com/tsapeta))
 - Added `AlbumType` and `MediaSubtype` types, added missing `orientation` key to the `Asset` type. ([#13936](https://github.com/expo/expo/pull/13936) by [@Simek](https://github.com/Simek))
+- Remove `assets-library://` uri scheme usage in favour of `ph://` ([#14173](https://github.com/expo/expo/pull/14173) by [@ajsmth](https://github.com/ajsmth))
 
 ## 12.1.0 — 2021-06-16
 

--- a/packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibrary.m
+++ b/packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibrary.m
@@ -817,12 +817,11 @@ EX_EXPORT_METHOD_AS(getAssetsAsync,
 {
   if (asset) {
     NSString *fileName = [asset valueForKey:@"filename"];
-    NSString *assetExtension = [fileName pathExtension];
     
     return @{
              @"id": asset.localIdentifier,
              @"filename": fileName,
-             @"uri": [EXMediaLibrary _assetUriForLocalId:asset.localIdentifier andExtension:assetExtension],
+             @"uri": [EXMediaLibrary _assetUriForLocalId:asset.localIdentifier],
              @"mediaType": [EXMediaLibrary _stringifyMediaType:asset.mediaType],
              @"mediaSubtypes": [EXMediaLibrary _stringifyMediaSubtypes:asset.mediaSubtypes],
              @"width": @(asset.pixelWidth),
@@ -916,12 +915,10 @@ EX_EXPORT_METHOD_AS(getAssetsAsync,
   return [localId stringByReplacingOccurrencesOfString:@"/.*" withString:@"" options:NSRegularExpressionSearch range:NSMakeRange(0, localId.length)];
 }
 
-+ (NSString *)_assetUriForLocalId:(nonnull NSString *)localId andExtension:(nonnull NSString *)extension
++ (NSString *)_assetUriForLocalId:(nonnull NSString *)localId
 {
   NSString *assetId = [EXMediaLibrary _assetIdFromLocalId:localId];
-  NSString *uppercasedExtension = [extension uppercaseString];
-  
-  return [NSString stringWithFormat:@"assets-library://asset/asset.%@?id=%@&ext=%@", uppercasedExtension, assetId, uppercasedExtension];
+  return [NSString stringWithFormat:@"ph://%@", assetId];
 }
 
 + (PHAssetMediaType)_assetTypeForUri:(nonnull NSString *)localUri


### PR DESCRIPTION
# Why

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

The `assets-library://` uri scheme has been deprecated since iOS 9 - our MediaLibrary implementation mostly uses PhotoKit which prefixes assets with a `ph://` scheme that utilizes part of the `asset.localIdentifier` to locate resources

The `assets-library` scheme appears in some logic in other modules as well, like FileSystem - ideally we could deprecate / add warnings for users who still use these schemes, although I would think it is a fairly safe change if users are relying on only our APIs

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

Assets are formatted via the `_exportAsset` method before being returned to JS - updating this method and the `_assetUriForLocalId` method results in the correct uris being returned.

# Test Plan


<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->

- Created a sandbox environment and loaded up image assets into a list using `MediaLibrary.getAssetsAsync()`
- Ensured the `uri` returned from this method were prefixed with `assets-library://`
- updated the implementation to return a `ph://` uri scheme for a given asset
- Ensured that the `uri` field was updated with the new scheme, and that the images were still loading

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).