### PR TITLE
[ncl][image][android] Add tests for `accessible` & `accessibilityLabel` properties

### DIFF
--- a/apps/native-component-list/src/screens/Image/ImageTestScreen.tsx
+++ b/apps/native-component-list/src/screens/Image/ImageTestScreen.tsx
@@ -1,6 +1,6 @@
 import { StackScreenProps } from '@react-navigation/stack';
 import * as React from 'react';
-import { Animated, StyleSheet, View } from 'react-native';
+import { Animated, StyleSheet, View, Text } from 'react-native';
 
 import HeaderIconButton, { HeaderContainerRight } from '../../components/HeaderIconButton';
 import AnimationBar from './AnimationBar';
@@ -112,6 +112,7 @@ export default function ImageTestScreen({ navigation, route }: Props) {
   return (
     <View style={styles.container} key={viewKey}>
       {isAnimatable && <AnimationBar onAnimationValue={onAnimationValue} />}
+      {test.testInformation && <Text>{test.testInformation}</Text>}
       <View style={styles.content}>
         <ImageTestView imageProps={imageProps} ImageComponent={getImageComponent()} />
         {!compareEnabled && (

--- a/apps/native-component-list/src/screens/Image/tests/android.tsx
+++ b/apps/native-component-list/src/screens/Image/tests/android.tsx
@@ -8,12 +8,16 @@ const imageTests: ImageTestGroup = {
       props: {
         accessible: true,
       },
+      testInformation:
+        'To properly conduct test:\n1. Turn on TalkBack.\n2. Click on image.\nExpected behaviour: the component should be bordered and default sound should be played',
     },
     {
       name: 'accessibilityLabel',
       props: {
         accessibilityLabel: 'Test passed',
       },
+      testInformation:
+        'To properly conduct test:\n1. Turn on TalkBack.\n2. Click on image.\nExpected behaviour: the component should be bordered and you should hear text specified as a value of `accessibleLabel` property: "text passed"',
     },
     {
       name: 'Resize method: auto',

--- a/apps/native-component-list/src/screens/Image/tests/android.tsx
+++ b/apps/native-component-list/src/screens/Image/tests/android.tsx
@@ -4,6 +4,18 @@ const imageTests: ImageTestGroup = {
   name: 'Android',
   tests: [
     {
+      name: 'accessible',
+      props: {
+        accessible: true,
+      },
+    },
+    {
+      name: 'accessibilityLabel',
+      props: {
+        accessibilityLabel: 'Test passed',
+      },
+    },
+    {
       name: 'Resize method: auto',
       props: {
         resizeMethod: 'auto',

--- a/apps/native-component-list/src/screens/Image/tests/android.tsx
+++ b/apps/native-component-list/src/screens/Image/tests/android.tsx
@@ -9,7 +9,7 @@ const imageTests: ImageTestGroup = {
         accessible: true,
       },
       testInformation:
-        'To properly conduct test:\n1. Turn on TalkBack.\n2. Click on image.\nExpected behaviour: the component should be bordered and default sound should be played',
+        'To properly conduct the test scenario:\n1. Turn on TalkBack.\n2. Click on the image.\nExpected behaviour: the component should be bordered and default sound should be played',
     },
     {
       name: 'accessibilityLabel',
@@ -17,7 +17,7 @@ const imageTests: ImageTestGroup = {
         accessibilityLabel: 'Test passed',
       },
       testInformation:
-        'To properly conduct test:\n1. Turn on TalkBack.\n2. Click on image.\nExpected behaviour: the component should be bordered and you should hear text specified as a value of `accessibleLabel` property: "text passed"',
+        'To properly conduct the test scenario:\n1. Turn on TalkBack.\n2. Click on the image.\nExpected behaviour: the component should be bordered and you should hear text specified by `accessibleLabel` property: "text passed"',
     },
     {
       name: 'Resize method: auto',

--- a/apps/native-component-list/src/screens/Image/types.ts
+++ b/apps/native-component-list/src/screens/Image/types.ts
@@ -19,6 +19,7 @@ export type ImageTestProps = ImageProps | ImageTestPropsFn;
 export interface ImageTest {
   name: string;
   props: ImageTestProps;
+  testInformation?: string;
 }
 
 export interface ImageTestGroup {

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageViewManager.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageViewManager.kt
@@ -110,6 +110,11 @@ class ExpoImageViewManager(applicationContext: ReactApplicationContext) : Simple
     view.setTintColor(color)
   }
 
+  @ReactProp(name = "accessible")
+  fun setFocusable(view: ExpoImageView, accessible: Boolean) {
+    view.isFocusable = accessible // setFocusable(bool)
+  }
+
   // View lifecycle
   public override fun createViewInstance(context: ThemedReactContext): ExpoImageView {
     return ExpoImageView(context, mRequestManager, mProgressInterceptor)


### PR DESCRIPTION
# Why

Tests for change introduced in #14109. 

# How

* Added two tests to already existing screen in NCL

# Test Plan

To test those props it is necessary to [enable accessibility services (TalkBack)](https://support.google.com/accessibility/android/answer/6007100?hl=en) on your testing device.

1. Open BareExpo
2. Go to test screen 
3. Turn on [TalkBack](https://support.google.com/accessibility/android/answer/6007100?hl=en) 
4. Click on image

#### Expected behaviour

 * `accessible`: the component should be selectable (after you click on it, it should be bordered and some default sound should be played).
 * `accessibleLabel`: same as in case of `accessible` but instead of default sound, you should hear text specified as a value of `accessibleLabel` property - "test passed"



# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).