### PR TITLE
[apps] Fix `bare-sandbox` gradle error

### DIFF
--- a/apps/bare-sandbox/android/app/build.gradle
+++ b/apps/bare-sandbox/android/app/build.gradle
@@ -206,5 +206,5 @@ task copyDownloadableDepsToLibs(type: Copy) {
     into 'libs'
 }
 
-apply from: new File(["node", "--print", "require.resolve('@react-native-community/cli-platform-android/package.json"].execute().text.trim(), "../native_modules.gradle");
+apply from: new File(["node", "--print", "require.resolve('@react-native-community/cli-platform-android/package.json')"].execute().text.trim(), "../native_modules.gradle");
 applyNativeModulesAppBuildGradle(project)

--- a/apps/bare-sandbox/android/settings.gradle
+++ b/apps/bare-sandbox/android/settings.gradle
@@ -3,7 +3,7 @@ rootProject.name = 'bare-sandbox'
 apply from: new File(["node", "--print", "require.resolve('expo-modules-core/package.json')"].execute().text.trim(), "../scripts/autolinking.gradle");
 useExpoModules([:])
 
-apply from: new File(["node", "--print", "require.resolve('@react-native-community/cli-platform-android/package.json"].execute().text.trim(), "../native_modules.gradle");
+apply from: new File(["node", "--print", "require.resolve('@react-native-community/cli-platform-android/package.json')"].execute().text.trim(), "../native_modules.gradle");
 applyNativeModulesSettingsGradle(settings)
 
 include(":unimodules-test-core")


### PR DESCRIPTION
# Why

Fixes Gradle failing when trying to do anything:

```
A problem occurred evaluating project ':app'.
> String index out of range: 0
```

# How

A typo

# Test Plan

Built `bare-sandbox` successfully
