### PR TITLE
[android][image] Fix bug related to drawing curved borders

### DIFF
--- a/packages/expo-image/android/src/main/java/expo/modules/image/drawing/BorderDrawable.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/drawing/BorderDrawable.kt
@@ -105,7 +105,7 @@ class BorderDrawable(private val mContext: Context) : Drawable() {
     }
     if (mBorderCornerRadii != null) {
       for (borderRadii in mBorderCornerRadii!!) {
-        if (isYogaPositive(mBorderRadius)) {
+        if (isYogaPositive(borderRadii)) {
           return true
         }
       }


### PR DESCRIPTION
# Why

There is a bug, causing curved borders to be displayed incorrectly in certain cases. 

Using `expo-image` native `Image` component, if you set `borderRadius={0}` (or do not set this property at all) and any (one or more) of properties:
* `borderTopLeftRadius`
* `borderTopRightRadius`
* `borderBottomLeftRadius`
* `borderBottomRightRadius`

to a value greater than 0, then appropriate border corner is drawn incorrectly as on image below:

![image](https://user-images.githubusercontent.com/50801299/130961669-73ac0fa4-3a93-41e4-ba76-d4f9edefad04.png)

Should be: 

![image](https://user-images.githubusercontent.com/50801299/130961717-5d6d01ed-02cd-4992-8696-dfa60380d7b0.png)



# How

* Fixed `BorderDrawable#hasRoundedBorders()` method to properly determine whether given drawable has at least one corner rounded.

Earlier this method returned `false` in cases described above, causing `BorderDrawable#draw(canvas: Canvas)` method to call `drawRectangularBackgroundWithBorders(canvas)` instead of `drawRoundedBackgroundWithBorders(canvas)`

# Reproducible demo or steps to reproduce from a blank project

* Create blank project with `expo init`
* Install `expo-image` module **(!!!)**:
    * clone `expo` repository (or download only `/packages/expo-image` folder)
    * checkout at version e.g. from this commit `358fcd1b424d9a175b879e92f902393936dfa9a0`
    * add the dependency to your `package.json` file && run `yarn install --force`:
```json
  "dependencies": {
    ...
    "expo-image": "file:<path-to-expo-image-folder>",
    ...
```

* `App.js` (replace `<path-to-your-local-asset>`):
```js
import React from 'react';
import { StyleSheet, Text, View, NativeSyntheticEvent } from 'react-native';
import Image from 'expo-image';

export default function App() {
  return (
    <View style={styles.container} >
      <Image 
        source={require(<path-to-your-local-asset>)}
        borderStyle="solid"
        borderColor="rgb(0, 0, 0)"
        borderRadius={0}
        borderTopLeftRadius={80}
        borderWidth={15}
        style={styles.image}
      />
    </View>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    backgroundColor: 'rgb(120, 120, 120)',
    alignItems: 'center',
    justifyContent: 'center',
    width: 400,
    height: 400,
  },
  image: {
    width: 250,
    height: 250,
  }
});

``` 
* Run app && toggle `borderRadius` prop value between 0 and some positive value (e.g. 1)

**(!!!)** Installing version provided in sdk 42 via `expo install expo-image` command results in app crash even before bundling, in my case. 

# Test Plan

--

# Checklist


- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).

