### PR TITLE
[expo-dev-launcher] add manifestURL to exported constants for snack

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - Fix compatibility with RN 0.65. ([#14064](https://github.com/expo/expo/pull/14064) by [@lukmccall](https://github.com/lukmccall))
+- Add manifestURL to exported constants. ([#14195](https://github.com/expo/expo/pull/14195) by [@esamelson](https://github.com/esamelson))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
@@ -74,6 +74,8 @@ class DevLauncherController private constructor()
   private val recentlyOpedAppsRegistry = DevLauncherRecentlyOpenedAppsRegistry(context)
   override var manifest: DevLauncherManifest? = null
     private set
+  override var manifestURL: Uri? = null
+    private set
   override var latestLoadedApp: Uri? = null
   override var useDeveloperSupport = true
 
@@ -105,6 +107,7 @@ class DevLauncherController private constructor()
       val appLoader = appLoaderFactory.createAppLoader(url, manifestParser)
       useDeveloperSupport = appLoaderFactory.shouldUseDeveloperSupport()
       manifest = appLoaderFactory.getManifest()
+      manifestURL = url
 
       val appLoaderListener = appLoader.createOnDelegateWillBeCreatedListener()
       lifecycle.addListener(appLoaderListener)
@@ -120,6 +123,7 @@ class DevLauncherController private constructor()
         // The app couldn't be loaded. For now, we just return to the launcher.
         mode = Mode.LAUNCHER
         manifest = null
+        manifestURL = null
       }
     } catch (e: Exception) {
       synchronized(this) {
@@ -154,6 +158,7 @@ class DevLauncherController private constructor()
 
     mode = Mode.LAUNCHER
     manifest = null
+    manifestURL = null
     context.applicationContext.startActivity(createLauncherIntent())
   }
 

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/modules/DevLauncherModule.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/modules/DevLauncherModule.kt
@@ -19,9 +19,15 @@ class DevLauncherModule(reactContext: ReactApplicationContext?) : ReactContextBa
     } catch (_: IllegalStateException) {
       null
     }
+    val manifestURLString = try {
+      controller?.manifestURL?.toString()
+    } catch (_: IllegalStateException) {
+      null
+    }
 
     return mapOf<String, Any?>(
-      "manifestString" to manifestString
+      "manifestString" to manifestString,
+      "manifestURL" to manifestURLString
     )
   }
 }

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/DevLauncherControllerInterface.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/DevLauncherControllerInterface.kt
@@ -22,6 +22,7 @@ interface DevLauncherControllerInterface {
   fun handleIntent(intent: Intent?, activityToBeInvalidated: ReactActivity?): Boolean
 
   val manifest: DevLauncherManifest?
+  val manifestURL: Uri?
   val devClientHost: DevLauncherClientHost
   val mode: DevLauncherController.Mode
   val appHost: ReactNativeHost

--- a/packages/expo-dev-launcher/android/src/release/java/expo/modules/devlauncher/DevLauncherController.kt
+++ b/packages/expo-dev-launcher/android/src/release/java/expo/modules/devlauncher/DevLauncherController.kt
@@ -31,6 +31,9 @@ class DevLauncherController private constructor() : DevLauncherControllerInterfa
   override val manifest: DevLauncherManifest
     get() = throw IllegalStateException(DEV_LAUNCHER_IS_NOT_AVAILABLE)
 
+  override val manifestURL: Uri
+    get() = throw IllegalStateException(DEV_LAUNCHER_IS_NOT_AVAILABLE)
+
   override val appHost: ReactNativeHost
     get() = throw IllegalStateException(DEV_LAUNCHER_IS_NOT_AVAILABLE)
 

--- a/packages/expo-dev-launcher/android/src/test/java/expo/modules/devlauncher/modules/DevLauncherModuleTest.kt
+++ b/packages/expo-dev-launcher/android/src/test/java/expo/modules/devlauncher/modules/DevLauncherModuleTest.kt
@@ -1,0 +1,38 @@
+package expo.modules.devlauncher.modules
+
+import android.net.Uri
+import com.facebook.react.bridge.ReactApplicationContext
+import com.google.common.truth.Truth
+import expo.modules.devlauncher.koin.DevLauncherKoinContext
+import expo.modules.devlauncher.launcher.DevLauncherControllerInterface
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.koin.dsl.module
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class DevLauncherModuleTest {
+
+  @Test
+  fun `exports manifestURL for currently loaded app`() {
+    // used by snack
+
+    val urlString = "https://exp.host/@test/test?query=param"
+    val manifestURL = Uri.parse(urlString)
+
+    val devLauncherController = mockk<DevLauncherControllerInterface>(relaxed = true)
+    DevLauncherKoinContext.app.koin.loadModules(listOf(
+        module {
+          single { devLauncherController }
+        }
+    ))
+    every { devLauncherController.manifestURL } returns manifestURL
+
+    val reactApplicationContext = mockk<ReactApplicationContext>(relaxed = true)
+    val module = DevLauncherModule(reactApplicationContext)
+    val constants = module.constants
+    Truth.assertThat(constants["manifestURL"]).isEqualTo(urlString)
+  }
+}

--- a/packages/expo-dev-launcher/ios/EXDevLauncher.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncher.m
@@ -17,7 +17,11 @@ RCT_EXPORT_MODULE()
 - (NSDictionary *)constantsToExport
 {
   NSString *manifestString = [EXDevLauncherController.sharedInstance appManifest].rawData;
-  return @{ @"manifestString": manifestString ?: [NSNull null] };
+  NSString *manifestURLString = [EXDevLauncherController.sharedInstance appManifestURL].absoluteString;
+  return @{
+    @"manifestString": manifestString ?: [NSNull null],
+    @"manifestURL": manifestURLString ?: [NSNull null]
+  };
 }
 
 @end

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.h
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.h
@@ -44,6 +44,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (EXDevLauncherManifest * _Nullable)appManifest;
 
+- (NSURL * _Nullable)appManifestURL;
+
 - (BOOL)isAppRunning;
 
 - (UIWindow * _Nullable)currentWindow;

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -41,6 +41,7 @@ NSString *fakeLauncherBundleUrl = @"embedded://EXDevLauncher/dummy";
 @property (nonatomic, assign) BOOL shouldPreferUpdatesInterfaceSourceUrl;
 @property (nonatomic, strong) EXDevLauncherRecentlyOpenedAppsRegistry *recentlyOpenedAppsRegistry;
 @property (nonatomic, strong) EXDevLauncherManifest *manifest;
+@property (nonatomic, strong) NSURL *manifestURL;
 @property (nonatomic, strong) EXDevLauncherErrorManager *errorManager;
 
 @end
@@ -122,6 +123,11 @@ NSString *fakeLauncherBundleUrl = @"embedded://EXDevLauncher/dummy";
   return self.manifest;
 }
 
+- (NSURL * _Nullable)appManifestURL
+{
+  return self.manifestURL;
+}
+
 - (UIWindow *)currentWindow
 {
   return _window;
@@ -147,6 +153,7 @@ NSString *fakeLauncherBundleUrl = @"embedded://EXDevLauncher/dummy";
 {
   [_appBridge invalidate];
   self.manifest = nil;
+  self.manifestURL = nil;
 
   if (@available(iOS 12, *)) {
     [self _applyUserInterfaceStyle:UIUserInterfaceStyleUnspecified];
@@ -258,9 +265,9 @@ NSString *fakeLauncherBundleUrl = @"embedded://EXDevLauncher/dummy";
     RCTDevLoadingViewSetEnabled(NO);
     [self.recentlyOpenedAppsRegistry appWasOpened:expoUrl.absoluteString name:nil];
     if ([expoUrl.path isEqual:@"/"] || [expoUrl.path isEqual:@""]) {
-      [self _initApp:[NSURL URLWithString:@"index.bundle?platform=ios&dev=true&minify=false" relativeToURL:expoUrl] manifest:nil];
+      [self _initAppWithUrl:expoUrl bundleUrl:[NSURL URLWithString:@"index.bundle?platform=ios&dev=true&minify=false" relativeToURL:expoUrl] manifest:nil];
     } else {
-      [self _initApp:expoUrl manifest:nil];
+      [self _initAppWithUrl:expoUrl bundleUrl:expoUrl manifest:nil];
     }
     if (onSuccess) {
       onSuccess();
@@ -271,7 +278,7 @@ NSString *fakeLauncherBundleUrl = @"embedded://EXDevLauncher/dummy";
     self->_shouldPreferUpdatesInterfaceSourceUrl = !manifest.isUsingDeveloperTool;
     RCTDevLoadingViewSetEnabled(manifest.isUsingDeveloperTool);
     [self.recentlyOpenedAppsRegistry appWasOpened:expoUrl.absoluteString name:manifest.name];
-    [self _initApp:bundleURL manifest:manifest];
+    [self _initAppWithUrl:expoUrl bundleUrl:bundleURL manifest:manifest];
     if (onSuccess) {
       onSuccess();
     }
@@ -318,9 +325,10 @@ NSString *fakeLauncherBundleUrl = @"embedded://EXDevLauncher/dummy";
   } onError:onError];
 }
 
-- (void)_initApp:(NSURL *)bundleUrl manifest:(EXDevLauncherManifest * _Nullable)manifest
+- (void)_initAppWithUrl:(NSURL *)appUrl bundleUrl:(NSURL *)bundleUrl manifest:(EXDevLauncherManifest * _Nullable)manifest
 {
   self.manifest = manifest;
+  self.manifestURL = appUrl;
   __block UIInterfaceOrientation orientation = manifest.orientation;
   __block UIColor *backgroundColor = manifest.backgroundColor;
   

--- a/packages/expo-dev-launcher/ios/Tests/EXDevLauncherModuleTests.m
+++ b/packages/expo-dev-launcher/ios/Tests/EXDevLauncherModuleTests.m
@@ -1,0 +1,72 @@
+// Copyright 2021-present 650 Industries. All rights reserved.
+
+#import <XCTest/XCTest.h>
+
+#import <objc/runtime.h>
+#import <EXDevLauncher/EXDevLauncher.h>
+#import <EXDevLauncher/EXDevLauncherController.h>
+
+@interface EXDevLauncherController (EXDevLauncherModuleTests)
+
+- (NSURL *)mockAppManifestURL;
+
+@end
+
+@implementation EXDevLauncherController (EXDevLauncherModuleTests)
+
+- (NSURL *)mockAppManifestURL
+{
+  return [NSURL URLWithString:@"https://exp.host/@test/test?query=param"];
+}
+
+@end
+
+@interface EXDevLauncherModuleTests : XCTestCase
+
+@end
+
+@implementation EXDevLauncherModuleTests
+
+// https://nshipster.com/method-swizzling/
+- (void)swizzleMethodForClass:(Class)class
+             originalSelector:(SEL)originalSelector
+             swizzledSelector:(SEL)swizzledSelector
+{
+  Method originalMethod = class_getInstanceMethod(class, originalSelector);
+  Method swizzledMethod = class_getInstanceMethod(class, swizzledSelector);
+
+  BOOL didAddMethod =
+  class_addMethod(class,
+                  originalSelector,
+                  method_getImplementation(swizzledMethod),
+                  method_getTypeEncoding(swizzledMethod));
+
+  if (didAddMethod) {
+    class_replaceMethod(class,
+                        swizzledSelector,
+                        method_getImplementation(originalMethod),
+                        method_getTypeEncoding(originalMethod));
+  } else {
+    method_exchangeImplementations(originalMethod, swizzledMethod);
+  }
+}
+
+- (void)testConstantsToExportManifestURL
+{
+  // used by snack
+
+  [self swizzleMethodForClass:[EXDevLauncherController class]
+             originalSelector:@selector(appManifestURL)
+             swizzledSelector:@selector(mockAppManifestURL)];
+
+  EXDevLauncher *module = [EXDevLauncher new];
+  NSDictionary *constants = [module constantsToExport];
+  XCTAssertEqualObjects(@"https://exp.host/@test/test?query=param", constants[@"manifestURL"]);
+
+  // clean up
+  [self swizzleMethodForClass:[EXDevLauncherController class]
+             originalSelector:@selector(appManifestURL)
+             swizzledSelector:@selector(mockAppManifestURL)];
+}
+
+@end


### PR DESCRIPTION
# Why

ENG-1771

In order to reliably provide snack with the URL used to open the project, we should add it as a separate exported constant, rather than overloading `Linking.getInitialURL()` as we do in Expo Go.

# How

Save the manifest URL as state on the DevLauncherController, and export it to JS in the same way that we currently export the manifest itself.

# Test Plan

Tested the export manually and added unit tests to ensure this isn't accidentally removed or changed in the future, since it will only be used by external code (snack). An additional PR will be required to the snack runtime in order to make use of this, so I haven't yet tested e2e.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).