### PR TITLE
[expo-dev-launcher][expo-dev-menu] add flag to disable dev menu auto-launch

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Fix compatibility with RN 0.65. ([#14064](https://github.com/expo/expo/pull/14064) by [@lukmccall](https://github.com/lukmccall))
 - Add manifestURL to exported constants. ([#14195](https://github.com/expo/expo/pull/14195) by [@esamelson](https://github.com/esamelson))
+- Add flag to disable auto-launch of dev menu on start. ([#14196](https://github.com/expo/expo/pull/14196) by [@esamelson](https://github.com/esamelson))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
@@ -78,7 +78,7 @@ class DevLauncherController private constructor()
     private set
   override var latestLoadedApp: Uri? = null
   override var useDeveloperSupport = true
-  var autoLaunchDevMenu = true
+  var canLaunchDevMenuOnStart = true
 
   enum class Mode {
     LAUNCHER, APP
@@ -169,8 +169,8 @@ class DevLauncherController private constructor()
       ?.let { uri ->
         // used by appetize for snack
         if (intent.getBooleanExtra("EXDevMenuDisableAutoLaunch", false)) {
-          autoLaunchDevMenu = false
-          this.devMenuManager?.setShouldAutoLaunch(autoLaunchDevMenu)
+          canLaunchDevMenuOnStart = false
+          this.devMenuManager?.setCanLaunchDevMenuOnStart(canLaunchDevMenuOnStart)
         }
 
         if (!isDevLauncherUrl(uri)) {
@@ -229,7 +229,7 @@ class DevLauncherController private constructor()
       } as? DevMenuManagerProviderInterface
 
     val devMenuManager = devMenuManagerProvider?.getDevMenuManager() ?: return
-    devMenuManager.setShouldAutoLaunch(autoLaunchDevMenu)
+    devMenuManager.setCanLaunchDevMenuOnStart(canLaunchDevMenuOnStart)
     devMenuManager.setDelegate(DevLauncherMenuDelegate(instance))
     this.devMenuManager = devMenuManager
   }

--- a/packages/expo-dev-launcher/android/src/test/java/expo/modules/devlauncher/DevLauncherControllerTest.kt
+++ b/packages/expo-dev-launcher/android/src/test/java/expo/modules/devlauncher/DevLauncherControllerTest.kt
@@ -35,7 +35,7 @@ class DevLauncherControllerTest {
     val controller = DevLauncherController.instance as DevLauncherController
     val mockDevMenuManager = mockk<DevMenuManagerInterface>(relaxed = true)
     controller.devMenuManager = mockDevMenuManager
-    Truth.assertThat(controller.autoLaunchDevMenu).isTrue()
+    Truth.assertThat(controller.canLaunchDevMenuOnStart).isTrue()
 
     controller.handleIntent(Intent().apply {
       data = Uri.parse("https://expo-development-client")
@@ -43,8 +43,8 @@ class DevLauncherControllerTest {
     }, null)
 
     verify {
-      mockDevMenuManager.setShouldAutoLaunch(false)
+      mockDevMenuManager.setCanLaunchDevMenuOnStart(false)
     }
-    Truth.assertThat(controller.autoLaunchDevMenu).isFalse()
+    Truth.assertThat(controller.canLaunchDevMenuOnStart).isFalse()
   }
 }

--- a/packages/expo-dev-launcher/android/src/test/java/expo/modules/devlauncher/DevLauncherControllerTest.kt
+++ b/packages/expo-dev-launcher/android/src/test/java/expo/modules/devlauncher/DevLauncherControllerTest.kt
@@ -1,0 +1,50 @@
+package expo.modules.devlauncher
+
+import android.content.Intent
+import android.net.Uri
+import androidx.test.core.app.ApplicationProvider
+import com.facebook.react.ReactNativeHost
+import com.google.common.truth.Truth
+import expo.interfaces.devmenu.DevMenuManagerInterface
+import expo.modules.devlauncher.koin.DevLauncherKoinContext
+import expo.modules.devlauncher.tests.DevLauncherTestInterceptor
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class DevLauncherControllerTest {
+
+  internal class DevLauncherTestInterceptorAllowReinitialization : DevLauncherTestInterceptor {
+    override fun allowReinitialization() = true
+  }
+
+  @Before
+  fun setup() {
+    val reactNativeHost = mockk<ReactNativeHost>(relaxed = true)
+    DevLauncherKoinContext.reinitialize()
+    DevLauncherKoinContext.app.koin.declare(DevLauncherTestInterceptorAllowReinitialization())
+    DevLauncherController.initialize(ApplicationProvider.getApplicationContext(), reactNativeHost)
+  }
+
+  @Test
+  fun `sets shouldAutoLaunch on dev menu manager`() {
+    val controller = DevLauncherController.instance as DevLauncherController
+    val mockDevMenuManager = mockk<DevMenuManagerInterface>(relaxed = true)
+    controller.devMenuManager = mockDevMenuManager
+    Truth.assertThat(controller.autoLaunchDevMenu).isTrue()
+
+    controller.handleIntent(Intent().apply {
+      data = Uri.parse("https://expo-development-client")
+      putExtra("EXDevMenuDisableAutoLaunch", true)
+    }, null)
+
+    verify {
+      mockDevMenuManager.setShouldAutoLaunch(false)
+    }
+    Truth.assertThat(controller.autoLaunchDevMenu).isFalse()
+  }
+}

--- a/packages/expo-dev-menu-interface/android/src/main/java/expo/interfaces/devmenu/DevMenuManagerInterface.kt
+++ b/packages/expo-dev-menu-interface/android/src/main/java/expo/interfaces/devmenu/DevMenuManagerInterface.kt
@@ -110,5 +110,10 @@ interface DevMenuManagerInterface {
    */
   fun isInitialized(): Boolean
 
+  /**
+   * Whether to automatically show the dev menu on app load. Defaults to true if not set.
+   */
+  fun setShouldAutoLaunch(shouldAutoLaunch: Boolean)
+
   suspend fun fetchDataSource(id: String): List<DevMenuDataSourceItem>
 }

--- a/packages/expo-dev-menu-interface/android/src/main/java/expo/interfaces/devmenu/DevMenuManagerInterface.kt
+++ b/packages/expo-dev-menu-interface/android/src/main/java/expo/interfaces/devmenu/DevMenuManagerInterface.kt
@@ -113,7 +113,7 @@ interface DevMenuManagerInterface {
   /**
    * Whether to automatically show the dev menu on app load. Defaults to true if not set.
    */
-  fun setShouldAutoLaunch(shouldAutoLaunch: Boolean)
+  fun setCanLaunchDevMenuOnStart(shouldAutoLaunch: Boolean)
 
   suspend fun fetchDataSource(id: String): List<DevMenuDataSourceItem>
 }

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add flag to disable auto-launch of dev menu on start. ([#14196](https://github.com/expo/expo/pull/14196) by [@esamelson](https://github.com/esamelson))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuManager.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuManager.kt
@@ -59,7 +59,7 @@ object DevMenuManager : DevMenuManagerInterface, LifecycleEventListener {
   private var currentReactInstanceManager: WeakReference<ReactInstanceManager?> = WeakReference(null)
   private var currentScreenName: String? = null
   private val expoApiClient = DevMenuExpoApiClient()
-  private var shouldAutoLaunch = true
+  private var canLaunchDevMenuOnStart = true
   var testInterceptor: DevMenuTestInterceptor = DevMenuDisabledTestInterceptor()
 
   //region helpers
@@ -218,7 +218,7 @@ object DevMenuManager : DevMenuManagerInterface, LifecycleEventListener {
         } else {
           DevMenuDefaultSettings()
         }).also {
-          shouldLaunchDevMenuOnStart = shouldAutoLaunch && (it.showsAtLaunch || !it.isOnboardingFinished)
+          shouldLaunchDevMenuOnStart = canLaunchDevMenuOnStart && (it.showsAtLaunch || !it.isOnboardingFinished)
           if (shouldLaunchDevMenuOnStart) {
             reactContext.addLifecycleEventListener(this)
           }
@@ -422,8 +422,8 @@ object DevMenuManager : DevMenuManagerInterface, LifecycleEventListener {
 
   override fun getExpoApiClient(): DevMenuExpoApiClientInterface = expoApiClient
 
-  override fun setShouldAutoLaunch(shouldAutoLaunch: Boolean) {
-    this.shouldAutoLaunch = shouldAutoLaunch
+  override fun setCanLaunchDevMenuOnStart(canLaunchDevMenuOnStart: Boolean) {
+    this.canLaunchDevMenuOnStart = canLaunchDevMenuOnStart
   }
 
   override fun synchronizeDelegate() {

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuManager.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuManager.kt
@@ -10,7 +10,6 @@ import android.util.Log
 import android.view.KeyEvent
 import android.view.MotionEvent
 import android.view.inputmethod.InputMethodManager
-import androidx.core.content.ContextCompat.getSystemService
 import com.facebook.react.ReactInstanceManager
 import com.facebook.react.ReactNativeHost
 import com.facebook.react.bridge.LifecycleEventListener
@@ -60,6 +59,7 @@ object DevMenuManager : DevMenuManagerInterface, LifecycleEventListener {
   private var currentReactInstanceManager: WeakReference<ReactInstanceManager?> = WeakReference(null)
   private var currentScreenName: String? = null
   private val expoApiClient = DevMenuExpoApiClient()
+  private var shouldAutoLaunch = true
   var testInterceptor: DevMenuTestInterceptor = DevMenuDisabledTestInterceptor()
 
   //region helpers
@@ -212,13 +212,13 @@ object DevMenuManager : DevMenuManagerInterface, LifecycleEventListener {
         ?: reactContext.applicationContext as Application)
     maybeStartDetectors(devMenuHost.getContext())
 
-    settings = testInterceptor.overrideSettings()
+    settings = (testInterceptor.overrideSettings()
         ?: if (reactContext.hasNativeModule(DevMenuSettings::class.java)) {
           reactContext.getNativeModule(DevMenuSettings::class.java)!!
         } else {
           DevMenuDefaultSettings()
-        }.also {
-          shouldLaunchDevMenuOnStart = it.showsAtLaunch || !it.isOnboardingFinished
+        }).also {
+          shouldLaunchDevMenuOnStart = shouldAutoLaunch && (it.showsAtLaunch || !it.isOnboardingFinished)
           if (shouldLaunchDevMenuOnStart) {
             reactContext.addLifecycleEventListener(this)
           }
@@ -421,6 +421,10 @@ object DevMenuManager : DevMenuManagerInterface, LifecycleEventListener {
   override fun getMenuHost(): ReactNativeHost = devMenuHost
 
   override fun getExpoApiClient(): DevMenuExpoApiClientInterface = expoApiClient
+
+  override fun setShouldAutoLaunch(shouldAutoLaunch: Boolean) {
+    this.shouldAutoLaunch = shouldAutoLaunch
+  }
 
   override fun synchronizeDelegate() {
     val newReactInstanceManager = requireNotNull(delegate).reactInstanceManager()

--- a/packages/expo-dev-menu/ios/DevMenuManager.swift
+++ b/packages/expo-dev-menu/ios/DevMenuManager.swift
@@ -63,6 +63,7 @@ open class DevMenuManager: NSObject, DevMenuManagerProtocol {
   var packagerConnectionHandler: DevMenuPackagerConnectionHandler?
   lazy var expoSessionDelegate: DevMenuExpoSessionDelegate = DevMenuExpoSessionDelegate(manager: self)
   lazy var extensionSettings: DevMenuExtensionSettingsProtocol = DevMenuExtensionDefaultSettings(manager: self)
+  var shouldAutoLaunch = true
   
   public var expoApiClient: DevMenuExpoApiClientProtocol = DevMenuExpoApiClient()
   
@@ -95,7 +96,7 @@ open class DevMenuManager: NSObject, DevMenuManagerProtocol {
   @objc
   public var delegate: DevMenuDelegateProtocol? {
     didSet {
-      guard DevMenuSettings.showsAtLaunch || !DevMenuSettings.isOnboardingFinished, let bridge = delegate?.appBridge?(forDevMenuManager: self) as? RCTBridge else {
+      guard self.shouldAutoLaunch && (DevMenuSettings.showsAtLaunch || !DevMenuSettings.isOnboardingFinished), let bridge = delegate?.appBridge?(forDevMenuManager: self) as? RCTBridge else {
         return
       }
       if bridge.isLoading {
@@ -130,6 +131,7 @@ open class DevMenuManager: NSObject, DevMenuManagerProtocol {
     self.packagerConnectionHandler = DevMenuPackagerConnectionHandler(manager: self)
     self.packagerConnectionHandler?.setup()
     DevMenuSettings.setup()
+    self.readAutoLaunchState()
     self.expoSessionDelegate.restoreSession()
   }
 
@@ -320,6 +322,14 @@ open class DevMenuManager: NSObject, DevMenuManagerProtocol {
    */
   func shouldShowOnboarding() -> Bool {
     return delegate?.shouldShowOnboarding?(manager: self) ?? !DevMenuSettings.isOnboardingFinished
+  }
+
+  func readAutoLaunchState() {
+    let userDefaultsValue = UserDefaults.standard.bool(forKey: "EXDevMenuDisableAutoLaunch")
+    if (userDefaultsValue) {
+      self.shouldAutoLaunch = false
+      UserDefaults.standard.removeObject(forKey: "EXDevMenuDisableAutoLaunch")
+    }
   }
 
   @available(iOS 12.0, *)

--- a/packages/expo-dev-menu/ios/DevMenuManager.swift
+++ b/packages/expo-dev-menu/ios/DevMenuManager.swift
@@ -63,7 +63,7 @@ open class DevMenuManager: NSObject, DevMenuManagerProtocol {
   var packagerConnectionHandler: DevMenuPackagerConnectionHandler?
   lazy var expoSessionDelegate: DevMenuExpoSessionDelegate = DevMenuExpoSessionDelegate(manager: self)
   lazy var extensionSettings: DevMenuExtensionSettingsProtocol = DevMenuExtensionDefaultSettings(manager: self)
-  var shouldAutoLaunch = true
+  var canLaunchDevMenuOnStart = true
   
   public var expoApiClient: DevMenuExpoApiClientProtocol = DevMenuExpoApiClient()
   
@@ -96,7 +96,7 @@ open class DevMenuManager: NSObject, DevMenuManagerProtocol {
   @objc
   public var delegate: DevMenuDelegateProtocol? {
     didSet {
-      guard self.shouldAutoLaunch && (DevMenuSettings.showsAtLaunch || !DevMenuSettings.isOnboardingFinished), let bridge = delegate?.appBridge?(forDevMenuManager: self) as? RCTBridge else {
+      guard self.canLaunchDevMenuOnStart && (DevMenuSettings.showsAtLaunch || !DevMenuSettings.isOnboardingFinished), let bridge = delegate?.appBridge?(forDevMenuManager: self) as? RCTBridge else {
         return
       }
       if bridge.isLoading {
@@ -131,7 +131,7 @@ open class DevMenuManager: NSObject, DevMenuManagerProtocol {
     self.packagerConnectionHandler = DevMenuPackagerConnectionHandler(manager: self)
     self.packagerConnectionHandler?.setup()
     DevMenuSettings.setup()
-    self.readAutoLaunchState()
+    self.readAutoLaunchDisabledState()
     self.expoSessionDelegate.restoreSession()
   }
 
@@ -324,11 +324,13 @@ open class DevMenuManager: NSObject, DevMenuManagerProtocol {
     return delegate?.shouldShowOnboarding?(manager: self) ?? !DevMenuSettings.isOnboardingFinished
   }
 
-  func readAutoLaunchState() {
+  func readAutoLaunchDisabledState() {
     let userDefaultsValue = UserDefaults.standard.bool(forKey: "EXDevMenuDisableAutoLaunch")
     if (userDefaultsValue) {
-      self.shouldAutoLaunch = false
+      self.canLaunchDevMenuOnStart = false
       UserDefaults.standard.removeObject(forKey: "EXDevMenuDisableAutoLaunch")
+    } else {
+      self.canLaunchDevMenuOnStart = true
     }
   }
 


### PR DESCRIPTION
# Why

ENG-1771

Replicate snack's ability in Expo Go to disable the new user experience (dev menu auto launch) in dev clients.

# How

Looked at where `EXKernelDisableNuxDefaultsKey` was used in Expo Go and added similar code to the dev clients. It uses a different key that I've named `EXDevMenuDisableAutoLaunch` which we'll need to add to the snack launch logic for appetize.

# Test Plan

Tested manually on iOS by inverting the logic and ensuring the dev menu launches / does not launch depending on the presence of the key. Also added some UI tests that ensure the behavior is correct.
On Android I spent some time trying to add UI tests for this but haven't been successful yet; will keep working on it but added a unit test for now. I also tested manually by using adb to send an intent with the extra flag.

Will need to send a PR to snack in order to test this e2e.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).