### PR TITLE
[updates] modularize expo-updates without further app setup

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -6,3 +6,4 @@ org.gradle.internal.repository.initial.backoff=1000
 android.useAndroidX=true
 android.enableJetifier=true
 android.useNewApkCreator=false
+expo.updates.createManifest=false

--- a/docs/pages/bare/installing-updates.md
+++ b/docs/pages/bare/installing-updates.md
@@ -93,13 +93,13 @@ If you're migrating from an ExpoKit project to the bare workflow with `expo-upda
 
 ## Customizing Automatic Setup for iOS
 
-By default `expo-updates` automatically install the module in the iOS AppDelegate. If you want to customize the installation, e.g. to enable updates only in some build variants, you can apply the setup manually.
+By default, `expo-updates` requires no additional setup. If you want to customize the installation, e.g. to enable updates only in some build variants, you can instead follow these manual setup steps and then apply any customizations.
 
 <ConfigurationDiff source="/static/diffs/expo-updates-ios.diff" />
 
 ## Customizing Automatic Setup for Android
 
-By default `expo-updates` automatically install the module in the Android MainApplication.java. If you want to customize the installation, e.g. to enable updates only in some build variants, you can apply the setup manually.
+By default, `expo-updates` requires no additional setup. If you want to customize the installation, e.g. to enable updates only in some build variants, you can instead follow these manual setup steps and then apply any customizations.
 
 <ConfigurationDiff source="/static/diffs/expo-updates-android.diff" />
 

--- a/docs/pages/bare/installing-updates.md
+++ b/docs/pages/bare/installing-updates.md
@@ -58,70 +58,50 @@ If you're migrating from an ExpoKit project to the bare workflow with `expo-upda
 
 ## Configuration for iOS
 
-<ConfigurationDiff source="/static/diffs/expo-updates-ios.diff" />
+- Add the `"Supporting"` directory containing `"Expo.plist"` to your project in Xcode with the following content.
 
-### Final steps to perform in Xcode
-
-Once you have applied the changes from the above diff, the following additional changes are required:
-
-<div style={{marginTop: -10}} />
-
-- Add the `"Supporting"` directory containing `"Expo.plist"` to your project in Xcode.
-- In Xcode, under the Build Phases tab of your main project, expand the phase entitled "Bundle React Native code and images." Add the following to a new line at the bottom of the script: `` `node --print "require.resolve('expo-updates/package.json').slice(0, -13) + '/scripts/create-manifest-ios.sh'"` `` (supports monorepos and non-default project structure). You can alternatively use this line: `../node_modules/expo-updates/scripts/create-manifest-ios.sh` (supports only default project structure).
-
-<div style={{marginTop: -15}} />
-
-<details><summary><h4>💡 What is the create-manifest-ios script for?</h4></summary>
-<p>
-
-This provides expo-updates with some essential metadata about the update and assets that are embedded in your IPA.
-
-</p>
-</details>
-
-<div style={{marginTop: -10}} />
-
-<details><summary><h4>💡 Are you using expo-splash-screen in your app?</h4></summary>
-<p>
-
-If you have `expo-splash-screen` installed in your bare workflow project, you'll need to make the following additional change to `AppDelegate.m`:
-
-```diff
-+#import <EXSplashScreen/EXSplashScreenService.h>
-+#import <UMCore/UMModuleRegistryProvider.h>
-
- ...
-
- - (void)appController:(EXUpdatesAppController *)appController didStartWithSuccess:(BOOL)success
- {
-   appController.bridge = [self initializeReactNativeApp];
-+  EXSplashScreenService *splashScreenService = (EXSplashScreenService *)[UMModuleRegistryProvider getSingletonModuleForClass:[EXSplashScreenService class]];
-+  [splashScreenService showSplashScreenFor:self.window.rootViewController];
- }
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>EXUpdatesSDKVersion</key>
+    <string>43.0.0</string>
+    <key>EXUpdatesURL</key>
+    <string>https://exp.host/@my-expo-username/my-app</string>
+  </dict>
+</plist>
 ```
-
-</p>
-</details>
-
-<div style={{marginTop: 50}} />
 
 ## Configuration for Android
 
+- Apply the following change to your AndroidManifest.xml.
+
+```diff
+--- a/apps/bare-update/android/app/src/main/AndroidManifest.xml
++++ b/apps/bare-update/android/app/src/main/AndroidManifest.xml
+@@ -5,6 +5,8 @@
+   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+   <application android:name=".MainApplication" android:label="@string/app_name" android:icon="@mipmap/ic_launcher" android:roundIcon="@mipmap/ic_launcher_round" android:allowBackup="false" android:theme="@style/AppTheme" android:usesCleartextTraffic="true">
++    <meta-data android:name="expo.modules.updates.EXPO_UPDATE_URL" android:value="https://exp.host/@my-expo-username/my-app"/>
++    <meta-data android:name="expo.modules.updates.EXPO_SDK_VERSION" android:value="43.0.0"/>
+     <activity android:name=".MainActivity" android:label="@string/app_name" android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode" android:launchMode="singleTask" android:windowSoftInputMode="adjustResize" android:theme="@style/Theme.App.SplashScreen">
+       <intent-filter>
+         <action android:name="android.intent.action.MAIN"/>
+```
+
+## Customizing Automatic Setup for iOS
+
+By default `expo-updates` automatically install the module in the iOS AppDelegate. If you want to customize the installation, e.g. to enable updates only in some build variants, you can apply the setup manually.
+
+<ConfigurationDiff source="/static/diffs/expo-updates-ios.diff" />
+
+## Customizing Automatic Setup for Android
+
+By default `expo-updates` automatically install the module in the Android MainApplication.java. If you want to customize the installation, e.g. to enable updates only in some build variants, you can apply the setup manually.
+
 <ConfigurationDiff source="/static/diffs/expo-updates-android.diff" />
-
-<details><summary><h4>💡 Are you using ProGuard?</h4></summary>
-<p>
-
-If you have ProGuard enabled, you'll need to add the following rule to `proguard-rules.pro`:
-
-```
--keepclassmembers class com.facebook.react.ReactInstanceManager {
-    private final com.facebook.react.bridge.JSBundleLoader mBundleLoader;
-}
-```
-
-</p>
-</details>
 
 ## Usage
 

--- a/docs/public/static/diffs/expo-updates-android.diff
+++ b/docs/public/static/diffs/expo-updates-android.diff
@@ -1,101 +1,76 @@
-diff --git a/android/app/build.gradle b/android/app/build.gradle
-index e5b1a7d..d06dfd0 100644
---- a/android/app/build.gradle
-+++ b/android/app/build.gradle
-@@ -81,10 +81,11 @@ import com.android.build.OutputFile
- project.ext.react = [
-     enableHermes: false,  // clean and rebuild if changing
- ]
-
--apply from: "../../node_modules/react-native/react.gradle"
-+apply from: new File(["node", "--print", "require.resolve('react-native/package.json')"].execute().text.trim(), "../react.gradle")
-+apply from: new File(["node", "--print", "require.resolve('expo-updates/package.json')"].execute().text.trim(), "../scripts/create-manifest-android.gradle")
-
- /**
-  * Set this to true to create two separate APKs instead of one:
-  *   - An APK that only works on ARM devices
-  *   - An APK that only works on x86 devices
-diff --git a/android/app/src/main/AndroidManifest.xml b/android/app/src/main/AndroidManifest.xml
-index 955757b..3fa4cb1 100644
---- a/android/app/src/main/AndroidManifest.xml
-+++ b/android/app/src/main/AndroidManifest.xml
-@@ -8,12 +8,15 @@
-       android:label="@string/app_name"
-       android:icon="@mipmap/ic_launcher"
-       android:roundIcon="@mipmap/ic_launcher_round"
-       android:allowBackup="false"
-       android:theme="@style/AppTheme">
-+      <meta-data android:name="expo.modules.updates.EXPO_UPDATE_URL" android:value="https://exp.host/@my-expo-username/my-app" />
-+      <meta-data android:name="expo.modules.updates.EXPO_SDK_VERSION" android:value="38.0.0" />
-+
-  <activity
-        android:name=".MainActivity"
-         android:label="@string/app_name"
-         android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
-         android:launchMode="singleTask"
-         android:windowSoftInputMode="adjustResize">
-         <intent-filter>
-diff --git a/android/app/src/main/java/com/myapp/MainApplication.java b/android/app/src/main/java/com/myapp/MainApplication.java
-index 0151e90..48cc96c 100644
---- a/android/app/src/main/java/com/myapp/MainApplication.java
-+++ b/android/app/src/main/java/com/myapp/MainApplication.java
-@@ -17,10 +17,14 @@ import java.util.Arrays;
-
- import org.unimodules.adapters.react.ModuleRegistryAdapter;
- import org.unimodules.adapters.react.ReactModuleRegistryProvider;
- import org.unimodules.core.interfaces.SingletonModule;
-
+diff --git a/apps/bare-update/android/app/src/main/AndroidManifest.xml b/apps/bare-update/android/app/src/main/AndroidManifest.xml
+index 4a74a05751..bac2b2f677 100644
+--- a/apps/bare-update/android/app/src/main/AndroidManifest.xml
++++ b/apps/bare-update/android/app/src/main/AndroidManifest.xml
+@@ -7,6 +7,7 @@
+   <application android:name=".MainApplication" android:label="@string/app_name" android:icon="@mipmap/ic_launcher" android:roundIcon="@mipmap/ic_launcher_round" android:allowBackup="false" android:theme="@style/AppTheme" android:usesCleartextTraffic="true">
+     <meta-data android:name="expo.modules.updates.EXPO_UPDATE_URL" android:value="https://exp.host/@my-expo-username/my-app"/>
+     <meta-data android:name="expo.modules.updates.EXPO_SDK_VERSION" android:value="43.0.0"/>
++    <meta-data android:name="expo.modules.updates.AUTO_SETUP" android:value="false"/>
+     <activity android:name=".MainActivity" android:label="@string/app_name" android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode" android:launchMode="singleTask" android:windowSoftInputMode="adjustResize" android:theme="@style/Theme.App.SplashScreen">
+       <intent-filter>
+         <action android:name="android.intent.action.MAIN"/>
+diff --git a/apps/bare-update/android/app/src/main/java/com/bareupdate/MainApplication.java b/apps/bare-update/android/app/src/main/java/com/bareupdate/MainApplication.java
+index 4b0d17d89d..5d6f1bb620 100644
+--- a/apps/bare-update/android/app/src/main/java/com/bareupdate/MainApplication.java
++++ b/apps/bare-update/android/app/src/main/java/com/bareupdate/MainApplication.java
+@@ -3,6 +3,7 @@ package com.bareupdate;
+ import android.app.Application;
+ import android.content.Context;
+ import android.content.res.Configuration;
 +import android.net.Uri;
+ 
+ import com.facebook.react.PackageList;
+ import com.facebook.react.ReactApplication;
+@@ -14,6 +15,7 @@ import com.facebook.soloader.SoLoader;
+ 
+ import expo.modules.adapters.react.ApplicationLifecycleDispatcher;
+ import expo.modules.adapters.react.ReactNativeHostWrapper;
 +import expo.modules.updates.UpdatesController;
+ 
+ import com.facebook.react.bridge.JSIModulePackage;
+ import com.swmansion.reanimated.ReanimatedJSIModulePackage;
+@@ -22,6 +24,7 @@ import androidx.annotation.NonNull;
+ import java.lang.reflect.InvocationTargetException;
+ import java.util.Arrays;
+ import java.util.List;
 +import javax.annotation.Nullable;
-+
+ 
  public class MainApplication extends Application implements ReactApplication {
-   private final ReactModuleRegistryProvider mModuleRegistryProvider = new ReactModuleRegistryProvider(new BasePackageList().getPackageList(), null);
-
-   private final ReactNativeHost mReactNativeHost =
-       new ReactNativeHost(this) {
-@@ -46,10 +50,28 @@ public class MainApplication extends Application implements ReactApplication {
-
-         @Override
-         protected String getJSMainModuleName() {
-           return "index";
-         }
+   private final ReactNativeHost mReactNativeHost = new ReactNativeHostWrapper(
+@@ -46,6 +49,24 @@ public class MainApplication extends Application implements ReactApplication {
+     protected JSIModulePackage getJSIModulePackage() {
+       return new ReanimatedJSIModulePackage();
+     }
 +
-+        @Override
-+        protected @Nullable String getJSBundleFile() {
-+          if (BuildConfig.DEBUG) {
-+            return super.getJSBundleFile();
-+          } else {
-+            return UpdatesController.getInstance().getLaunchAssetFile();
-+          }
-+        }
++    @Override
++    protected @Nullable String getJSBundleFile() {
++      if (BuildConfig.DEBUG) {
++        return super.getJSBundleFile();
++      } else {
++        return UpdatesController.getInstance().getLaunchAssetFile();
++      }
++    }
 +
-+        @Override
-+        protected @Nullable String getBundleAssetName() {
-+          if (BuildConfig.DEBUG) {
-+            return super.getBundleAssetName();
-+          } else {
-+            return UpdatesController.getInstance().getBundleAssetName();
-+          }
-+        }
-       };
-
++    @Override
++    protected @Nullable String getBundleAssetName() {
++      if (BuildConfig.DEBUG) {
++        return super.getBundleAssetName();
++      } else {
++        return UpdatesController.getInstance().getBundleAssetName();
++      }
++    }
+   });
+ 
    @Override
-   public ReactNativeHost getReactNativeHost() {
-     return mReactNativeHost;
-@@ -57,10 +79,15 @@ public class MainApplication extends Application implements ReactApplication {
-
-   @Override
-   public void onCreate() {
+@@ -58,6 +79,10 @@ public class MainApplication extends Application implements ReactApplication {
      super.onCreate();
      SoLoader.init(this, /* native exopackage */ false);
-+
+ 
 +    if (!BuildConfig.DEBUG) {
 +      UpdatesController.initialize(this);
 +    }
 +
      initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
+     ApplicationLifecycleDispatcher.onApplicationCreate(this);
    }
-
-   /**
-    * Loads Flipper in React Native templates. Call this in the onCreate method with something like

--- a/docs/public/static/diffs/expo-updates-android.diff
+++ b/docs/public/static/diffs/expo-updates-android.diff
@@ -24,8 +24,8 @@ index 4b0d17d89d..5d6f1bb620 100644
  import com.facebook.react.ReactApplication;
 @@ -14,6 +15,7 @@ import com.facebook.soloader.SoLoader;
  
- import expo.modules.adapters.react.ApplicationLifecycleDispatcher;
- import expo.modules.adapters.react.ReactNativeHostWrapper;
+ import expo.modules.ApplicationLifecycleDispatcher;
+ import expo.modules.ReactNativeHostWrapper;
 +import expo.modules.updates.UpdatesController;
  
  import com.facebook.react.bridge.JSIModulePackage;

--- a/docs/public/static/diffs/expo-updates-ios.diff
+++ b/docs/public/static/diffs/expo-updates-ios.diff
@@ -1,46 +1,41 @@
-diff --git a/ios/MyApp/AppDelegate.h b/ios/MyApp/AppDelegate.h
-index ef1de86..1a1a48f 100644
---- a/ios/MyApp/AppDelegate.h
-+++ b/ios/MyApp/AppDelegate.h
-@@ -1,8 +1,10 @@
-+#import <Foundation/Foundation.h>
+diff --git a/apps/bare-update/ios/bareupdate/AppDelegate.h b/apps/bare-update/ios/bareupdate/AppDelegate.h
+index e39065416f..7a2f733b9d 100644
+--- a/apps/bare-update/ios/bareupdate/AppDelegate.h
++++ b/apps/bare-update/ios/bareupdate/AppDelegate.h
+@@ -1,9 +1,10 @@
+ #import <Foundation/Foundation.h>
 +#import <EXUpdates/EXUpdatesAppController.h>
  #import <React/RCTBridgeDelegate.h>
  #import <UIKit/UIKit.h>
  
--@interface AppDelegate : UIResponder <UIApplicationDelegate, RCTBridgeDelegate>
-+#import <UMCore/UMAppDelegateWrapper.h>
+ #import <ExpoModulesCore/EXAppDelegateWrapper.h>
  
--@property (nonatomic, strong) UIWindow *window;
-+@interface AppDelegate : UMAppDelegateWrapper <RCTBridgeDelegate, EXUpdatesAppControllerDelegate>
+-@interface AppDelegate : EXAppDelegateWrapper <RCTBridgeDelegate>
++@interface AppDelegate : EXAppDelegateWrapper <RCTBridgeDelegate, EXUpdatesAppControllerDelegate>
  
  @end
-diff --git a/ios/MyApp/AppDelegate.m b/ios/MyApp/AppDelegate.m
-index c3e09a4..b26bcf7 100644
---- a/ios/MyApp/AppDelegate.m
-+++ b/ios/MyApp/AppDelegate.m
-@@ -28,10 +28,11 @@ static void InitializeFlipper(UIApplication *application) {
+diff --git a/apps/bare-update/ios/bareupdate/AppDelegate.m b/apps/bare-update/ios/bareupdate/AppDelegate.m
+index e2bd877b92..b8839389ac 100644
+--- a/apps/bare-update/ios/bareupdate/AppDelegate.m
++++ b/apps/bare-update/ios/bareupdate/AppDelegate.m
+@@ -28,6 +28,12 @@ static void InitializeFlipper(UIApplication *application) {
+ }
  #endif
  
- @interface AppDelegate () <RCTBridgeDelegate>
- 
- @property (nonatomic, strong) UMModuleRegistryAdapter *moduleRegistryAdapter;
++@interface AppDelegate () <RCTBridgeDelegate>
++
 +@property (nonatomic, strong) NSDictionary *launchOptions;
- 
- @end
- 
++
++@end
++
  @implementation AppDelegate
  
-@@ -41,23 +42,38 @@ static void InitializeFlipper(UIApplication *application) {
+ - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+@@ -36,7 +42,24 @@ - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(
    InitializeFlipper(application);
  #endif
- 
-   self.moduleRegistryAdapter = [[UMModuleRegistryAdapter alloc] initWithModuleRegistryProvider:[[UMModuleRegistryProvider alloc] init]];
- 
+   
 -  RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:launchOptions];
--  RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge
--                                                   moduleName:@"MyApp"
--                                            initialProperties:nil];
 +  self.launchOptions = launchOptions;
 +  self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
 +  #ifdef DEBUG
@@ -55,57 +50,56 @@ index c3e09a4..b26bcf7 100644
 +
 +  return YES;
 +}
- 
++
 +- (RCTBridge *)initializeReactNativeApp
 +{
 +  RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:self.launchOptions];
-+  RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge moduleName:@"MyApp" initialProperties:nil];
-   rootView.backgroundColor = [[UIColor alloc] initWithRed:1.0f green:1.0f blue:1.0f alpha:1];
+   RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge moduleName:@"main" initialProperties:nil];
+   id rootViewBackgroundColor = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"RCTRootViewBackgroundColor"];
+   if (rootViewBackgroundColor != nil) {
+@@ -45,15 +68,13 @@ - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(
+     rootView.backgroundColor = [UIColor whiteColor];
+   }
  
-   self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+-  self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
++
    UIViewController *rootViewController = [UIViewController new];
    rootViewController.view = rootView;
    self.window.rootViewController = rootViewController;
    [self.window makeKeyAndVisible];
+ 
+-  [super application:application didFinishLaunchingWithOptions:launchOptions];
+-
 -  return YES;
-+
 +  return bridge;
- }
+  }
  
  - (NSArray<id<RCTBridgeModule>> *)extraModulesForBridge:(RCTBridge *)bridge
- {
-     NSArray<id<RCTBridgeModule>> *extraModules = [_moduleRegistryAdapter extraModulesForBridge:bridge];
-@@ -69,10 +85,15 @@ static void InitializeFlipper(UIApplication *application) {
- 
- {
- #if DEBUG
+@@ -70,10 +91,14 @@ - (NSURL *)sourceURLForBridge:(RCTBridge *)bridge {
+  #ifdef DEBUG
    return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index" fallbackResource:nil];
- #else
+  #else
 -  return [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
 +  return [[EXUpdatesAppController sharedInstance] launchAssetUrl];
- #endif
+  #endif
  }
  
-+- (void)appController:(EXUpdatesAppController *)appController didStartWithSuccess:(BOOL)success
-+{
++- (void)appController:(EXUpdatesAppController *)appController didStartWithSuccess:(BOOL)success {
 +  appController.bridge = [self initializeReactNativeApp];
 +}
 +
- @end
-diff --git a/ios/MyApp/Supporting/Expo.plist b/ios/MyApp/Supporting/Expo.plist
-new file mode 100644
-index 0000000..1dd4715
---- /dev/null
-+++ b/ios/MyApp/Supporting/Expo.plist
-@@ -0,0 +1,10 @@
-+<?xml version="1.0" encoding="UTF-8"?>
-+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-+<plist version="1.0">
-+<dict>
-+        <key>EXUpdatesSDKVersion</key>
-+        <string>38.0.0</string>
-+        <key>EXUpdatesURL</key>
-+        <string>https://exp.host/@my-expo-username/my-app</string>
-+</dict>
-+</plist>
-\ No newline at end of file
+ // Linking API
+ - (BOOL)application:(UIApplication *)application openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {
+   return [RCTLinkingManager application:application openURL:url options:options];
+diff --git a/apps/bare-update/ios/bareupdate/Supporting/Expo.plist b/apps/bare-update/ios/bareupdate/Supporting/Expo.plist
+index 471ca3dde5..2abdd7a775 100644
+--- a/apps/bare-update/ios/bareupdate/Supporting/Expo.plist
++++ b/apps/bare-update/ios/bareupdate/Supporting/Expo.plist
+@@ -6,5 +6,7 @@
+     <string>42.0.0</string>
+     <key>EXUpdatesURL</key>
+     <string>https://exp.host/@my-expo-username/my-app</string>
++    <key>EXUpdatesAutoSetup</key>
++    <false/>
+   </dict>
+ </plist>

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -11,6 +11,9 @@ inhibit_all_warnings!
 # Enables Swift modules in Expo Go
 use_swift_modules!
 
+# Disable expo-updates auto create manifest in podspec script_phase
+$expo_updates_create_manifest = false
+
 abstract_target 'Expo Go' do
   # Expo Client dependencies
   pod 'Amplitude'

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### 🎉 New features
 
 - Expo modules are now being automatically registered on iOS which means less installation steps. Using `EXModuleRegistryProvider` and `EXModuleRegistryAdapter` becomes deprecated. ([#14132](https://github.com/expo/expo/pull/14132) by [@tsapeta](https://github.com/tsapeta))
+- Pass `useDeveloperSupport` value to `ReactNativeHostHandler` for expo-updates. ([#14198](https://github.com/expo/expo/pull/14198) by [@kudo](https://github.com/kudo))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/core/interfaces/ReactNativeHostHandler.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/core/interfaces/ReactNativeHostHandler.kt
@@ -42,8 +42,10 @@ interface ReactNativeHostHandler {
    *
    * @param useDeveloperSupport true if {@link ReactNativeHost} enabled developer support
    */
-  fun onRegisterJSIModules(reactApplicationContext: ReactApplicationContext,
-                           jsContext: JavaScriptContextHolder,
-                           useDeveloperSupport: Boolean) {
+  fun onRegisterJSIModules(
+    reactApplicationContext: ReactApplicationContext,
+    jsContext: JavaScriptContextHolder,
+    useDeveloperSupport: Boolean
+  ) {
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/core/interfaces/ReactNativeHostHandler.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/core/interfaces/ReactNativeHostHandler.kt
@@ -8,9 +8,10 @@ interface ReactNativeHostHandler {
   /**
    * Given chance for modules to customize {@link ReactInstanceManager}
    *
+   * @param useDeveloperSupport true if {@link ReactNativeHost} enabled developer support
    * @return instance of {@link ReactInstanceManager}, or null if not to override
    */
-  fun createReactInstanceManager(): ReactInstanceManager? {
+  fun createReactInstanceManager(useDeveloperSupport: Boolean): ReactInstanceManager? {
     return null
   }
 
@@ -18,9 +19,10 @@ interface ReactNativeHostHandler {
    * Given chance for modules to override react bundle file.
    * e.g. for expo-updates
    *
+   * @param useDeveloperSupport true if {@link ReactNativeHost} enabled developer support
    * @return custom path to bundle file, or null if not to override
    */
-  fun getJSBundleFile(): String? {
+  fun getJSBundleFile(useDeveloperSupport: Boolean): String? {
     return null
   }
 
@@ -28,15 +30,20 @@ interface ReactNativeHostHandler {
    * Given chance for modules to override react bundle asset name.
    * e.g. for expo-updates
    *
+   * @param useDeveloperSupport true if {@link ReactNativeHost} enabled developer support
    * @return custom bundle asset name, or null if not to override
    */
-  fun getBundleAssetName(): String? {
+  fun getBundleAssetName(useDeveloperSupport: Boolean): String? {
     return null
   }
 
   /**
    * Given chance for JSI modules to register, e.g. for react-native-reanimated
+   *
+   * @param useDeveloperSupport true if {@link ReactNativeHost} enabled developer support
    */
-  fun onRegisterJSIModules(reactApplicationContext: ReactApplicationContext, jsContext: JavaScriptContextHolder) {
+  fun onRegisterJSIModules(reactApplicationContext: ReactApplicationContext,
+                           jsContext: JavaScriptContextHolder,
+                           useDeveloperSupport: Boolean) {
   }
 }

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Update NewManifest field paths for new extra field format. ([#13398](https://github.com/expo/expo/pull/13398) by [@wschurman](https://github.com/wschurman))
 - Update location of EAS projectId in new manifest. ([#13739](https://github.com/expo/expo/pull/13739) by [@wschurman](https://github.com/wschurman))
 - Update location of scopeKey in new manifest. ([#13817](https://github.com/expo/expo/pull/13817) by [@wschurman](https://github.com/wschurman))
+- Introduce automatically setup where iOS AppDelegate or Android MainApplication customization is not necessary. ([#14198](https://github.com/expo/expo/pull/14198) by [@kudo](https://github.com/kudo))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-updates/README.md
+++ b/packages/expo-updates/README.md
@@ -45,53 +45,61 @@ Some build-time configuration options are available to allow your app to update 
 
 On Android, you may also define these properties at runtime by passing a `Map` as the second parameter of `UpdatesController.initialize()`. If provided, the values in this Map will override any values specified in `AndroidManifest.xml`. On iOS, you may set these properties at runtime by calling `[UpdatesController.sharedInstance setConfiguration:]` at any point _before_ calling `start` or `startAndShowLaunchScreen`, and the values in this dictionary will override Expo.plist.
 
-| iOS plist/dictionary key | Android Map key | Android meta-data name | Default | Required? |
-| --- | --- | --- | --- | --- |
-| `EXUpdatesEnabled` | `enabled` | `expo.modules.updates.ENABLED` | `true` | ❌ |
+| iOS plist/dictionary key | Android Map key | Android meta-data name         | Default | Required? |
+| ------------------------ | --------------- | ------------------------------ | ------- | --------- |
+| `EXUpdatesEnabled`       | `enabled`       | `expo.modules.updates.ENABLED` | `true`  | ❌        |
 
 Whether updates are enabled. Setting this to `false` disables all update functionality, all module methods, and forces the app to load with the manifest and assets bundled into the app binary.
 
-| iOS plist/dictionary key | Android Map key | Android meta-data name | Default | Required? |
-| --- | --- | --- | --- | --- |
-| `EXUpdatesURL` | `updateUrl` | `expo.modules.updates.EXPO_UPDATE_URL` | (none) | ✅ |
+| iOS plist/dictionary key | Android Map key | Android meta-data name                 | Default | Required? |
+| ------------------------ | --------------- | -------------------------------------- | ------- | --------- |
+| `EXUpdatesURL`           | `updateUrl`     | `expo.modules.updates.EXPO_UPDATE_URL` | (none)  | ✅        |
 
 The URL to the remote server where the app should check for updates. A request to this URL should return a valid manifest object for the latest available update and tells expo-updates how to fetch the JS bundle and other assets that comprise the update. (Example: for apps published with `expo publish`, this URL would be `https://exp.host/@username/slug`.)
 
-| iOS plist/dictionary key | Android Map key | Android meta-data name | Default | Required? |
-| --- | --- | --- | --- | --- |
-| `EXUpdatesSDKVersion` | `sdkVersion` | `expo.modules.updates.EXPO_SDK_VERSION` | (none) | (exactly one of `sdkVersion` or `runtimeVersion` is required) |
+| iOS plist/dictionary key | Android Map key | Android meta-data name                  | Default | Required?                                                     |
+| ------------------------ | --------------- | --------------------------------------- | ------- | ------------------------------------------------------------- |
+| `EXUpdatesSDKVersion`    | `sdkVersion`    | `expo.modules.updates.EXPO_SDK_VERSION` | (none)  | (exactly one of `sdkVersion` or `runtimeVersion` is required) |
 
 The SDK version string to send under the `Expo-SDK-Version` header in the manifest request. Required for apps hosted on Expo's server.
 
-| iOS plist/dictionary key | Android Map key | Android meta-data name | Default | Required? |
-| --- | --- | --- | --- | --- |
-| `EXUpdatesRuntimeVersion` | `runtimeVersion` | `expo.modules.updates.EXPO_RUNTIME_VERSION` | (none) | (exactly one of `sdkVersion` or `runtimeVersion` is required) |
+| iOS plist/dictionary key  | Android Map key  | Android meta-data name                      | Default | Required?                                                     |
+| ------------------------- | ---------------- | ------------------------------------------- | ------- | ------------------------------------------------------------- |
+| `EXUpdatesRuntimeVersion` | `runtimeVersion` | `expo.modules.updates.EXPO_RUNTIME_VERSION` | (none)  | (exactly one of `sdkVersion` or `runtimeVersion` is required) |
 
 The Runtime Version string to send under the `Expo-Runtime-Version` header in the manifest request.
 
-| iOS plist/dictionary key | Android Map key | Android meta-data name | Default | Required? |
-| --- | --- | --- | --- | --- |
-| `EXUpdatesReleaseChannel` | `releaseChannel` | `expo.modules.updates.EXPO_RELEASE_CHANNEL` | `default` | ❌ |
+| iOS plist/dictionary key  | Android Map key  | Android meta-data name                      | Default   | Required? |
+| ------------------------- | ---------------- | ------------------------------------------- | --------- | --------- |
+| `EXUpdatesReleaseChannel` | `releaseChannel` | `expo.modules.updates.EXPO_RELEASE_CHANNEL` | `default` | ❌        |
 
 The release channel string to send under the `Expo-Release-Channel` header in the manifest request.
 
-| iOS plist/dictionary key | Android Map key | Android meta-data name | Default | Required? |
-| --- | --- | --- | --- | --- |
-| `EXUpdatesCheckOnLaunch` | `checkOnLaunch` | `expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH` | `ALWAYS` | ❌ |
+| iOS plist/dictionary key | Android Map key | Android meta-data name                              | Default  | Required? |
+| ------------------------ | --------------- | --------------------------------------------------- | -------- | --------- |
+| `EXUpdatesCheckOnLaunch` | `checkOnLaunch` | `expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH` | `ALWAYS` | ❌        |
 
 The condition under which `expo-updates` should automatically check for (and download, if one exists) an update upon app launch. Possible values are `ALWAYS`, `NEVER` (if you want to exclusively control updates via this module's JS API), or `WIFI_ONLY` (if you want the app to automatically download updates only if the device is on an unmetered Wi-Fi connection when it launches).
 
-| iOS plist/dictionary key | Android Map key | Android meta-data name | Default | Required? |
-| --- | --- | --- | --- | --- |
-| `EXUpdatesLaunchWaitMs` | `launchWaitMs` | `expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS` | `0` | ❌ |
+| iOS plist/dictionary key | Android Map key | Android meta-data name                             | Default | Required? |
+| ------------------------ | --------------- | -------------------------------------------------- | ------- | --------- |
+| `EXUpdatesLaunchWaitMs`  | `launchWaitMs`  | `expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS` | `0`     | ❌        |
 
 The number of milliseconds `expo-updates` should delay the app launch and stay on the splash screen while trying to download an update, before falling back to a previously downloaded version. Setting this to `0` will cause the app to always launch with a previously downloaded update and will result in the fastest app launch possible.
+
+## Customizing automatically setup
+
+From `expo-updates@>=0.9.0`, we support the setup to iOS AppDelegate and Android MainApplication automatically. If you want to do some customizations, for instance, to enable updates only on some build variants. You could disable the auto setup and add custom logic in AppDelegate/MainApplication.
+
+| iOS Expo.plist key   | Android meta-data name            | Default | Required? |
+| -------------------- | --------------------------------- | ------- | --------- |
+| `EXUpdatesAutoSetup` | `expo.modules.updates.AUTO_SETUP` | `true`  | ❌        |
 
 # Removing pre-installed expo-updates
 
 Projects created by `expo init` and `expo eject` come with expo-updates pre-installed, because we anticipate most users will want this functionality. However, if you do not intend to use OTA updates, you can disable or uninstall the module.
 
-### Disabling expo-updates
+## Disabling expo-updates
 
 If you disable updates, the module will stay installed in case you ever want to use it in the future, but none of the OTA-updating code paths will ever be executed in your builds. To disable OTA updates, add the `EXUpdatesEnabled` key to Expo.plist with a boolean value of `NO`, and add the following line to AndroidManifest.xml:
 
@@ -99,7 +107,15 @@ If you disable updates, the module will stay installed in case you ever want to 
 <meta-data android:name="expo.modules.updates.ENABLED" android:value="false"/>
 ```
 
-### Uninstalling expo-updates
+## Uninstalling expo-updates (for expo-updates >= 0.9.0)
+
+Uninstalling the module will entirely remove all expo-updates related code from your codebase. To do so, complete the following steps:
+
+- Remove `expo-updates` from your package.json and reinstall your node modules.
+- Delete Expo.plist from your Xcode project and file system.
+- Remove all `meta-data` tags with `expo.modules.updates` in the `android:name` field from AndroidManifest.xml.
+
+## Uninstalling expo-updates (for expo-updates < 0.9.0)
 
 Uninstalling the module will entirely remove all expo-updates related code from your codebase. To do so, complete the following steps:
 
@@ -124,7 +140,7 @@ Remove`EXUpdatesAppControllerDelegate` as a protocol of your `AppDelegate`.
 
  @property (nonatomic, strong) UMModuleRegistryAdapter *moduleRegistryAdapter;
  @property (nonatomic, strong) UIWindow *window;
- ```
+```
 
 #### `AppDelegate.m`
 
@@ -247,7 +263,7 @@ Remove`EXUpdatesAppControllerDelegate` as a protocol of your `AppDelegate`.
      initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
    }
  }
- ```
+```
 
 #### Remove Pods Target EXUpdates (Optional)
 

--- a/packages/expo-updates/README.md
+++ b/packages/expo-updates/README.md
@@ -87,9 +87,9 @@ The condition under which `expo-updates` should automatically check for (and dow
 
 The number of milliseconds `expo-updates` should delay the app launch and stay on the splash screen while trying to download an update, before falling back to a previously downloaded version. Setting this to `0` will cause the app to always launch with a previously downloaded update and will result in the fastest app launch possible.
 
-## Customizing automatically setup
+## Customizing automatic setup
 
-From `expo-updates@>=0.9.0`, we support the setup to iOS AppDelegate and Android MainApplication automatically. If you want to do some customizations, for instance, to enable updates only on some build variants. You could disable the auto setup and add custom logic in AppDelegate/MainApplication.
+In `expo-updates@0.9.0` and above, we support automatic installation of the module in the iOS AppDelegate.m and Android MainApplication.java classes. If you want to customize the installation, e.g. to enable updates only in some build variants, you can add custom logic in AppDelegate/MainApplication and set the following keys to `false` in order to disable the automatic setup.
 
 | iOS Expo.plist key   | Android meta-data name            | Default | Required? |
 | -------------------- | --------------------------------- | ------- | --------- |

--- a/packages/expo-updates/android/build.gradle
+++ b/packages/expo-updates/android/build.gradle
@@ -5,6 +5,8 @@ apply plugin: 'maven'
 group = 'host.exp.exponent'
 version = '0.8.4'
 
+apply from: "../scripts/create-manifest-android.gradle"
+
 buildscript {
   // Simple helper that allows the root project to override versions declared by this library.
   ext.safeExtGet = { prop, fallback ->

--- a/packages/expo-updates/android/build.gradle
+++ b/packages/expo-updates/android/build.gradle
@@ -60,6 +60,7 @@ android {
     targetSdkVersion safeExtGet("targetSdkVersion", 30)
     versionCode 31
     versionName '0.8.4'
+    consumerProguardFiles("proguard-rules.pro")
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     // uncomment below to export the database schema when making changes
     /* javaCompileOptions {

--- a/packages/expo-updates/android/proguard-rules.pro
+++ b/packages/expo-updates/android/proguard-rules.pro
@@ -1,0 +1,3 @@
+-keepclassmembers class com.facebook.react.ReactInstanceManager {
+  private final com.facebook.react.bridge.JSBundleLoader mBundleLoader;
+}

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesPackage.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesPackage.java
@@ -2,13 +2,19 @@ package expo.modules.updates;
 
 import android.content.Context;
 
-import java.util.Arrays;
+import com.facebook.react.ReactInstanceManager;
+import com.facebook.react.bridge.JavaScriptContextHolder;
+import com.facebook.react.bridge.ReactApplicationContext;
+
 import java.util.Collections;
 import java.util.List;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import expo.modules.core.BasePackage;
 import expo.modules.core.ExportedModule;
 import expo.modules.core.interfaces.InternalModule;
+import expo.modules.core.interfaces.ReactNativeHostHandler;
 
 public class UpdatesPackage extends BasePackage {
   @Override
@@ -19,5 +25,42 @@ public class UpdatesPackage extends BasePackage {
   @Override
   public List<ExportedModule> createExportedModules(Context context) {
     return Collections.singletonList((ExportedModule) new UpdatesModule(context));
+  }
+
+  @Override
+  public List<? extends ReactNativeHostHandler> createReactNativeHostHandlers(Context context) {
+    final ReactNativeHostHandler handler = new ReactNativeHostHandler() {
+      @Nullable
+      @Override
+      public ReactInstanceManager createReactInstanceManager(boolean useDeveloperSupport) {
+        if (!useDeveloperSupport) {
+          UpdatesController.initialize(context);
+        }
+        return null;
+      }
+
+      @Nullable
+      @Override
+      public String getJSBundleFile(boolean useDeveloperSupport) {
+        return useDeveloperSupport
+          ? null
+          : UpdatesController.getInstance().getLaunchAssetFile();
+      }
+
+      @Nullable
+      @Override
+      public String getBundleAssetName(boolean useDeveloperSupport) {
+        return useDeveloperSupport
+          ? null
+          : UpdatesController.getInstance().getBundleAssetName();
+      }
+
+      @Override
+      public void onRegisterJSIModules(@NonNull ReactApplicationContext reactApplicationContext,
+                                       @NonNull JavaScriptContextHolder jsContext,
+                                       boolean useDeveloperSupport) {
+      }
+    };
+    return Collections.singletonList(handler);
   }
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesPackage.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesPackage.java
@@ -50,17 +50,17 @@ public class UpdatesPackage extends BasePackage {
       @Nullable
       @Override
       public String getJSBundleFile(boolean useDeveloperSupport) {
-        return shouldAutoSetup(context) && useDeveloperSupport
-          ? null
-          : UpdatesController.getInstance().getLaunchAssetFile();
+        return shouldAutoSetup(context) && !useDeveloperSupport
+          ? UpdatesController.getInstance().getLaunchAssetFile()
+          : null;
       }
 
       @Nullable
       @Override
       public String getBundleAssetName(boolean useDeveloperSupport) {
-        return shouldAutoSetup(context) && useDeveloperSupport
-          ? null
-          : UpdatesController.getInstance().getBundleAssetName();
+        return shouldAutoSetup(context) && !useDeveloperSupport
+          ? UpdatesController.getInstance().getBundleAssetName()
+          : null;
       }
 
       @Override
@@ -76,7 +76,7 @@ public class UpdatesPackage extends BasePackage {
           try {
             final PackageManager pm = context.getPackageManager();
             final ApplicationInfo ai = pm.getApplicationInfo(context.getPackageName(), PackageManager.GET_META_DATA);
-            mShouldAutoSetup = Boolean.valueOf(ai.metaData.getString("expo.modules.updates.AUTO_SETUP", "true"));
+            mShouldAutoSetup = ai.metaData.getBoolean("expo.modules.updates.AUTO_SETUP", true);
           } catch (Exception e) {
             Log.e(TAG, "Could not read expo-updates configuration data in AndroidManifest", e);
           }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesPackage.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesPackage.java
@@ -36,7 +36,7 @@ public class UpdatesPackage extends BasePackage {
   @Override
   public List<? extends ReactNativeHostHandler> createReactNativeHostHandlers(Context context) {
     final ReactNativeHostHandler handler = new ReactNativeHostHandler() {
-      Boolean mShouldAutoSetup = null;
+      private Boolean mShouldAutoSetup = null;
 
       @Nullable
       @Override
@@ -72,13 +72,13 @@ public class UpdatesPackage extends BasePackage {
       @UiThread
       private boolean shouldAutoSetup(final Context context) {
         if (mShouldAutoSetup == null) {
-          mShouldAutoSetup = true;
           try {
             final PackageManager pm = context.getPackageManager();
             final ApplicationInfo ai = pm.getApplicationInfo(context.getPackageName(), PackageManager.GET_META_DATA);
             mShouldAutoSetup = ai.metaData.getBoolean("expo.modules.updates.AUTO_SETUP", true);
           } catch (Exception e) {
             Log.e(TAG, "Could not read expo-updates configuration data in AndroidManifest", e);
+            mShouldAutoSetup = true;
           }
         }
         return mShouldAutoSetup;

--- a/packages/expo-updates/ios/EXUpdates.podspec
+++ b/packages/expo-updates/ios/EXUpdates.podspec
@@ -31,6 +31,18 @@ Pod::Spec.new do |s|
     s.source_files = "#{s.name}/**/*.{h,m}"
   end
 
+  s.script_phase = {
+    :name => 'Generate app.manifest for expo-updates',
+    :script => 'bash -l -c "$PODS_TARGET_SRCROOT/../scripts/create-manifest-ios.sh"',
+    :execution_position => :before_compile
+  }
+
+  # Generate EXUpdates.bundle without existing resources
+  # `create-manifest-ios.sh` will generate app.manifest in EXUpdates.bundle
+  s.resource_bundles = {
+    'EXUpdates' => []
+  }
+
   s.test_spec 'Tests' do |test_spec|
     test_spec.source_files = 'Tests/*.{h,m,swift}'
   end

--- a/packages/expo-updates/ios/EXUpdates.podspec
+++ b/packages/expo-updates/ios/EXUpdates.podspec
@@ -31,17 +31,19 @@ Pod::Spec.new do |s|
     s.source_files = "#{s.name}/**/*.{h,m}"
   end
 
-  s.script_phase = {
-    :name => 'Generate app.manifest for expo-updates',
-    :script => 'bash -l -c "$PODS_TARGET_SRCROOT/../scripts/create-manifest-ios.sh"',
-    :execution_position => :before_compile
-  }
+  if $expo_updates_create_manifest != false
+    s.script_phase = {
+      :name => 'Generate app.manifest for expo-updates',
+      :script => 'bash -l -c "$PODS_TARGET_SRCROOT/../scripts/create-manifest-ios.sh"',
+      :execution_position => :before_compile
+    }
 
-  # Generate EXUpdates.bundle without existing resources
-  # `create-manifest-ios.sh` will generate app.manifest in EXUpdates.bundle
-  s.resource_bundles = {
-    'EXUpdates' => []
-  }
+    # Generate EXUpdates.bundle without existing resources
+    # `create-manifest-ios.sh` will generate app.manifest in EXUpdates.bundle
+    s.resource_bundles = {
+      'EXUpdates' => []
+    }
+  end
 
   s.test_spec 'Tests' do |test_spec|
     test_spec.source_files = 'Tests/*.{h,m,swift}'

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesEmbeddedAppLoader.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesEmbeddedAppLoader.m
@@ -25,7 +25,10 @@ static NSString * const EXUpdatesEmbeddedAppLoaderErrorDomain = @"EXUpdatesEmbed
     if (!config.hasEmbeddedUpdate) {
       embeddedManifest = nil;
     } else if (!embeddedManifest) {
-      NSString *path = [[NSBundle mainBundle] pathForResource:EXUpdatesEmbeddedManifestName ofType:EXUpdatesEmbeddedManifestType];
+      NSBundle *frameworkBundle = [NSBundle bundleForClass:[self class]];
+      NSURL *bundleUrl = [frameworkBundle.resourceURL URLByAppendingPathComponent:@"EXUpdates.bundle"];
+      NSBundle *bundle = [NSBundle bundleWithURL:bundleUrl];
+      NSString *path = [bundle pathForResource:EXUpdatesEmbeddedManifestName ofType:EXUpdatesEmbeddedManifestType];
       NSData *manifestData = [NSData dataWithContentsOfFile:path];
       if (!manifestData) {
         @throw [NSException exceptionWithName:NSInternalInconsistencyException

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesAppDelegate.h
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesAppDelegate.h
@@ -1,0 +1,14 @@
+// Copyright 2016-present 650 Industries. All rights reserved.
+
+#import <ExpoModulesCore/EXSingletonModule.h>
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface EXUpdatesAppDelegate : EXSingletonModule <UIApplicationDelegate>
+
+- (const NSInteger)priority;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesAppDelegate.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesAppDelegate.m
@@ -1,0 +1,157 @@
+// Copyright 2016-present 650 Industries. All rights reserved.
+
+#import <EXUpdates/EXUpdatesAppDelegate.h>
+
+#import <ExpoModulesCore/EXAppDelegateWrapper.h>
+#import <ExpoModulesCore/EXDefines.h>
+#import <EXUpdates/EXUpdatesConfig.h>
+#import <EXUpdates/EXUpdatesAppController.h>
+#import <React/RCTBridgeDelegate.h>
+#import <React/RCTConvert.h>
+#import <React/RCTRootView.h>
+
+@interface EXUpdatesBridgeDelegateInterceptor : NSObject<RCTBridgeDelegate>
+
+@property (nonatomic, weak) id<RCTBridgeDelegate> bridgeDelegate;
+
+- (nonnull instancetype)initWithBridgeDelegate:(id<RCTBridgeDelegate>)bridgeDelegate;
+
+@end
+
+@interface EXUpdatesAppDelegate() <EXUpdatesAppControllerDelegate>
+
+@property (nonatomic, strong) NSDictionary *launchOptions;
+
+@end
+
+@implementation EXUpdatesAppDelegate
+
+#if !defined(DEBUG)
+
+EX_REGISTER_SINGLETON_MODULE(EXUpdatesAppDelegate)
+
+#endif
+
+- (const NSInteger)priority
+{
+  // default expo-modules priority is 0, we setup expo-updates' priority to 10
+  // and make sure `didFinishLaunchingWithOptions` runs before other expo-modules
+  return 10;
+}
+
+#pragma mark - UIApplicationDelegate
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+{
+  if (![self shouldEnableAutoSetup]) {
+    return NO;
+  }
+  EXUpdatesAppController *controller = [EXUpdatesAppController sharedInstance];
+  if (controller.isStarted) {
+    // backward compatible if main AppDelegate already has expo-updates setup,
+    // we just skip in this case.
+    return NO;
+  }
+  self.launchOptions = launchOptions;
+  controller.delegate = self;
+  [controller startAndShowLaunchScreen:application.delegate.window];
+  return YES;
+}
+
+#pragma mark - EXUpdatesAppControllerDelegate
+
+- (void)appController:(EXUpdatesAppController *)appController didStartWithSuccess:(BOOL)success
+{
+  appController.bridge = [self initializeReactNativeApp];
+}
+
+#pragma mark - Internals
+
+- (BOOL)shouldEnableAutoSetup
+{
+  // if Expo.plist not found or its content is invalid, disable the auto setup
+  NSString *configPath = [[NSBundle mainBundle] pathForResource:EXUpdatesConfigPlistName ofType:@"plist"];
+  if (!configPath) {
+    return NO;
+  }
+  NSDictionary *config = [NSDictionary dictionaryWithContentsOfFile:configPath];
+  if (!config) {
+    return NO;
+  }
+
+  // if `EXUpdatesAutoSetup` is false, disable the auto setup
+  id enableAutoSetupValue = config[EXUpdatesConfigEnableAutoSetupKey];
+  if (enableAutoSetupValue &&
+      [enableAutoSetupValue isKindOfClass:[NSNumber class]] &&
+      [enableAutoSetupValue boolValue] == false) {
+    return NO;
+  }
+
+  return YES;
+}
+
+- (RCTBridge *)initializeReactNativeApp
+{
+  if (![UIApplication.sharedApplication.delegate conformsToProtocol:@protocol(RCTBridgeDelegate)]) {
+    [NSException raise:NSInvalidArgumentException format:@"AppDelegate does not conforms to RCTBridgeDelegate"];
+  }
+  EXUpdatesBridgeDelegateInterceptor* bridgeDelegate = [[EXUpdatesBridgeDelegateInterceptor alloc]
+                                                        initWithBridgeDelegate:(id<RCTBridgeDelegate>)UIApplication.sharedApplication.delegate];
+
+  RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:bridgeDelegate launchOptions:self.launchOptions];
+  RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge moduleName:@"main" initialProperties:nil];
+  id rootViewBackgroundColor = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"RCTRootViewBackgroundColor"];
+  if (rootViewBackgroundColor != nil) {
+    rootView.backgroundColor = [RCTConvert UIColor:rootViewBackgroundColor];
+  } else {
+    rootView.backgroundColor = [UIColor whiteColor];
+  }
+
+  UIViewController *rootViewController = [UIViewController new];
+  rootViewController.view = rootView;
+  UIWindow *window = UIApplication.sharedApplication.delegate.window;
+  window.rootViewController = rootViewController;
+  [window makeKeyAndVisible];
+
+  return bridge;
+ }
+
+@end
+
+@implementation EXUpdatesBridgeDelegateInterceptor
+
+- (nonnull instancetype)initWithBridgeDelegate:(id<RCTBridgeDelegate>)bridgeDelegate
+{
+  if (self = [super init]) {
+    self.bridgeDelegate = bridgeDelegate;
+  }
+  return self;
+}
+
+- (id)forwardingTargetForSelector:(SEL)selector {
+  if ([self isInterceptedSelector:selector]) {
+    return self;
+  }
+  return self.bridgeDelegate;
+}
+
+- (BOOL)respondsToSelector:(SEL)selector {
+  if ([self isInterceptedSelector:selector]) {
+    return YES;
+  }
+  return [self.bridgeDelegate respondsToSelector:selector];
+}
+
+- (BOOL)isInterceptedSelector:(SEL)selector {
+  if (selector == @selector(sourceURLForBridge:)) {
+    return YES;
+  }
+  return NO;
+}
+
+- (NSURL *)sourceURLForBridge:(RCTBridge *)bridge
+{
+  return EXUpdatesAppController.sharedInstance.launchAssetUrl;
+}
+
+@end

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.h
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.h
@@ -10,6 +10,10 @@ typedef NS_ENUM(NSInteger, EXUpdatesCheckAutomaticallyConfig) {
   EXUpdatesCheckAutomaticallyConfigNever = 2
 };
 
+FOUNDATION_EXPORT NSString * const EXUpdatesConfigPlistName;
+FOUNDATION_EXPORT NSString * const EXUpdatesConfigEnableAutoSetupKey;
+
+
 @interface EXUpdatesConfig : NSObject
 
 @property (nonatomic, readonly) BOOL isEnabled;

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.m
@@ -20,7 +20,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-static NSString * const EXUpdatesConfigPlistName = @"Expo";
+NSString * const EXUpdatesConfigPlistName = @"Expo";
+NSString * const EXUpdatesConfigEnableAutoSetupKey = @"EXUpdatesAutoSetup";
 
 static NSString * const EXUpdatesDefaultReleaseChannelName = @"default";
 

--- a/packages/expo-updates/scripts/create-manifest-android.gradle
+++ b/packages/expo-updates/scripts/create-manifest-android.gradle
@@ -3,13 +3,6 @@
 import org.apache.tools.ant.taskdefs.condition.Os
 import org.gradle.util.GradleVersion
 
-void runBefore(String dependentTaskName, Task task) {
-  Task dependentTask = tasks.findByPath(dependentTaskName);
-  if (dependentTask != null) {
-    dependentTask.dependsOn task
-  }
-}
-
 def expoUpdatesDir = ["node", "-e", "console.log(require('path').dirname(require.resolve('expo-updates/package.json')));"].execute([], projectDir).text.trim()
 
 afterEvaluate {

--- a/packages/expo-updates/scripts/create-manifest-android.gradle
+++ b/packages/expo-updates/scripts/create-manifest-android.gradle
@@ -12,20 +12,28 @@ void runBefore(String dependentTaskName, Task task) {
 
 def expoUpdatesDir = ["node", "-e", "console.log(require('path').dirname(require.resolve('expo-updates/package.json')));"].execute([], projectDir).text.trim()
 
-def config = project.hasProperty("react") ? project.react : [];
-def nodeExecutableAndArgs = config.nodeExecutableAndArgs ?: ["node"]
-def entryFile = config.entryFile ?: "index.js"
-def assetsFile = entryFile.take(entryFile.lastIndexOf('.')) + ".assets"
-
 afterEvaluate {
-  def projectRoot = file("../../")
+  if (!android.hasProperty('libraryVariants')) {
+    // For traditional application level integration, will be no-op to prevent duplicated app.config creation.
+    return;
+  }
+
+  // From a library project role to reference app project settings such as `targetName.toLowerCase().contains("release")`,
+  // we extract the `appProject` from all projects here.
+  // things like `config`, `buildDir`, and `applicationVariants`, we will reference from appProject.
+  def appProject = rootProject.allprojects.find { it.plugins.hasPlugin('com.android.application') }
+  def config = appProject.hasProperty("react") ? appProject.react : [];
+  def nodeExecutableAndArgs = config.nodeExecutableAndArgs ?: ["node"]
+  def entryFile = config.entryFile ?: "index.js"
+  def assetsFile = entryFile.take(entryFile.lastIndexOf('.')) + ".assets"
+
+  def projectRoot = file("${rootProject.projectDir}")
   def inputExcludes = ["android/**", "ios/**"]
 
-  android.applicationVariants.each { variant ->
+  appProject.android.applicationVariants.each { variant ->
     def targetName = variant.name.capitalize()
     def targetPath = variant.dirName
-
-    def assetsDir = file("$buildDir/generated/assets/expo-updates/${targetPath}")
+    def assetsDir = file("${appProject.buildDir}/generated/assets/expo-updates/${targetPath}")
 
     def currentBundleTask = tasks.create(
         name: "create${targetName}ExpoManifest",
@@ -60,7 +68,7 @@ afterEvaluate {
         type: Copy) {
       description = "expo-updates: Copy manifest into ${targetName}."
 
-      into ("$buildDir/intermediates")
+      into ("${appProject.buildDir}/intermediates")
       into ("assets/${targetPath}") {
         from(assetsDir)
       }
@@ -82,6 +90,9 @@ afterEvaluate {
       enabled(currentBundleTask.enabled)
     }
 
-    runBefore("process${targetName}Resources", currentAssetsCopyTask)
+    Task dependentTask = appProject.tasks.findByPath("process${targetName}Resources");
+    if (dependentTask != null) {
+      dependentTask.dependsOn currentAssetsCopyTask
+    }
   }
 }

--- a/packages/expo-updates/scripts/create-manifest-android.gradle
+++ b/packages/expo-updates/scripts/create-manifest-android.gradle
@@ -13,11 +13,6 @@ void runBefore(String dependentTaskName, Task task) {
 def expoUpdatesDir = ["node", "-e", "console.log(require('path').dirname(require.resolve('expo-updates/package.json')));"].execute([], projectDir).text.trim()
 
 afterEvaluate {
-  if (!android.hasProperty('libraryVariants')) {
-    // For traditional application level integration, will be no-op to prevent duplicated app.config creation.
-    return;
-  }
-
   // From a library project role to reference app project settings such as `targetName.toLowerCase().contains("release")`,
   // we extract the `appProject` from all projects here.
   // things like `config`, `buildDir`, and `applicationVariants`, we will reference from appProject.
@@ -29,6 +24,15 @@ afterEvaluate {
 
   def projectRoot = file("${rootProject.projectDir}")
   def inputExcludes = ["android/**", "ios/**"]
+
+  if (!android.hasProperty('libraryVariants')) {
+    // For traditional application level integration, will be no-op to prevent duplicated app.config creation.
+    return;
+  }
+  if (!appProject) {
+    // For instrumented test, the appProject will be null.
+    return;
+  }
 
   appProject.android.applicationVariants.each { variant ->
     def targetName = variant.name.capitalize()

--- a/packages/expo-updates/scripts/create-manifest-android.gradle
+++ b/packages/expo-updates/scripts/create-manifest-android.gradle
@@ -33,6 +33,9 @@ afterEvaluate {
     // For instrumented test, the appProject will be null.
     return;
   }
+  if (findProperty('expo.updates.createManifest') == 'false') {
+    return;
+  }
 
   appProject.android.applicationVariants.each { variant ->
     def targetName = variant.name.capitalize()

--- a/packages/expo-updates/scripts/create-manifest-ios.sh
+++ b/packages/expo-updates/scripts/create-manifest-ios.sh
@@ -21,8 +21,8 @@ NODE_BINARY=${NODE_BINARY:-node}
 
 # ref: https://github.com/facebook/react-native/blob/c974cbff04a8d90ac0f856dbada3fc5a75c75b49/scripts/react-native-xcode.sh#L59-L65
 EXPO_UPDATES_PACKAGE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-# The project should be located next to where expo-updates is installed
-# in node_modules.
+# If PROJECT_ROOT is not specified, fallback to use Xcode PROJECT_DIR
+PROJECT_ROOT=${PROJECT_ROOT:-"$PROJECT_DIR"}
 PROJECT_ROOT=${PROJECT_ROOT:-"$EXPO_UPDATES_PACKAGE_DIR/../.."}
 
 cd "$PROJECT_ROOT" || exit
@@ -34,4 +34,10 @@ if ! [ -x "$(command -v "$NODE_BINARY")" ]; then
   exit 1
 fi
 
-"$NODE_BINARY" "${EXPO_UPDATES_PACKAGE_DIR}/scripts/createManifest.js" ios "$PROJECT_ROOT" "$DEST"
+# For traditional main project build phases integration, will be no-op to prevent duplicated app.manifest creation.
+DIR_BASENAME=$(basename $PROJECT_ROOT)
+if [ "x$DIR_BASENAME" != "xPods" ]; then
+  exit 0
+fi
+
+"$NODE_BINARY" "${EXPO_UPDATES_PACKAGE_DIR}/scripts/createManifest.js" ios "$PROJECT_ROOT/.." "$DEST/EXUpdates.bundle"

--- a/packages/expo-updates/scripts/create-manifest-ios.sh
+++ b/packages/expo-updates/scripts/create-manifest-ios.sh
@@ -22,7 +22,7 @@ NODE_BINARY=${NODE_BINARY:-node}
 # ref: https://github.com/facebook/react-native/blob/c974cbff04a8d90ac0f856dbada3fc5a75c75b49/scripts/react-native-xcode.sh#L59-L65
 EXPO_UPDATES_PACKAGE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # If PROJECT_ROOT is not specified, fallback to use Xcode PROJECT_DIR
-PROJECT_ROOT=${PROJECT_ROOT:-"$PROJECT_DIR"}
+PROJECT_ROOT=${PROJECT_ROOT:-"$PROJECT_DIR/../.."}
 PROJECT_ROOT=${PROJECT_ROOT:-"$EXPO_UPDATES_PACKAGE_DIR/../.."}
 
 cd "$PROJECT_ROOT" || exit
@@ -40,4 +40,4 @@ if [ "x$DIR_BASENAME" != "xPods" ]; then
   exit 0
 fi
 
-"$NODE_BINARY" "${EXPO_UPDATES_PACKAGE_DIR}/scripts/createManifest.js" ios "$PROJECT_ROOT/.." "$DEST/EXUpdates.bundle"
+"$NODE_BINARY" "${EXPO_UPDATES_PACKAGE_DIR}/scripts/createManifest.js" ios "$PROJECT_ROOT" "$DEST/EXUpdates.bundle"

--- a/packages/expo-updates/scripts/createManifest.js
+++ b/packages/expo-updates/scripts/createManifest.js
@@ -20,6 +20,8 @@ const filterPlatformAssetScales = require('./filterPlatformAssetScales');
     projectRoot = path.resolve(possibleProjectRoot, '..');
   }
 
+  process.chdir(projectRoot);
+
   let metroConfig;
   try {
     metroConfig = await loadAsync(projectRoot);

--- a/packages/expo/android/src/main/java/expo/modules/ReactNativeHostWrapper.kt
+++ b/packages/expo/android/src/main/java/expo/modules/ReactNativeHostWrapper.kt
@@ -13,7 +13,6 @@ import com.facebook.react.bridge.JavaScriptExecutorFactory
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.devsupport.RedBoxHandler
 import com.facebook.react.uimanager.UIImplementationProvider
-import expo.modules.core.interfaces.ReactNativeHostHandler
 import java.lang.reflect.Method
 
 class ReactNativeHostWrapper(

--- a/packages/expo/android/src/main/java/expo/modules/ReactNativeHostWrapper.kt
+++ b/packages/expo/android/src/main/java/expo/modules/ReactNativeHostWrapper.kt
@@ -25,8 +25,10 @@ class ReactNativeHostWrapper(
   private val methodMap: ArrayMap<String, Method> = ArrayMap()
 
   override fun createReactInstanceManager(): ReactInstanceManager {
-    return reactNativeHostHandlers.asSequence()
-      .map(ReactNativeHostHandler::createReactInstanceManager)
+    // map() without asSequence() gives a chance for handlers
+    // to get noticed before createReactInstanceManager()
+    return reactNativeHostHandlers
+      .map { it.createReactInstanceManager(useDeveloperSupport) }
       .firstOrNull() ?: super.createReactInstanceManager()
   }
 
@@ -53,13 +55,13 @@ class ReactNativeHostWrapper(
 
   override fun getJSBundleFile(): String? {
     return reactNativeHostHandlers.asSequence()
-      .map(ReactNativeHostHandler::getJSBundleFile)
+      .map { it.getJSBundleFile(useDeveloperSupport) }
       .firstOrNull() ?: invokeDelegateMethod<String?>("getJSBundleFile")
   }
 
   override fun getBundleAssetName(): String? {
     return reactNativeHostHandlers.asSequence()
-      .map(ReactNativeHostHandler::getBundleAssetName)
+      .map { it.getBundleAssetName(useDeveloperSupport) }
       .firstOrNull() ?: invokeDelegateMethod<String?>("getBundleAssetName")
   }
 
@@ -82,7 +84,7 @@ class ReactNativeHostWrapper(
       jsContext: JavaScriptContextHolder
     ): List<JSIModuleSpec<JSIModule>> {
       reactNativeHostHandlers.forEach { handler ->
-        handler.onRegisterJSIModules(reactApplicationContext, jsContext)
+        handler.onRegisterJSIModules(reactApplicationContext, jsContext, useDeveloperSupport)
       }
       userJSIModulePackage?.getJSIModules(reactApplicationContext, jsContext)
       return emptyList()


### PR DESCRIPTION
# Why

modularize expo-update without app project setup

# How

- [ios] introduce `EXUpdatesAppDelegate` to replace AppDelegate setup
- [ios] move create-manifest-ios.sh into podspec
- [android] leverage `ReactNativeHostWrapper` and put into UpdatePackages to replace classic MainApplication setup
- [android] move create-manifest-android.gradle into library build.gradle

# Test Plan

these changes relies on expo-modules-core. however, our `expo-template-bare-minimum` template does not migrate to expo-modules-core yet. so i initiated a project from `expo-template-bare-minimum` with expo-modules-core migration to test the functionalities. please check [bare-update project in this branch](https://github.com/expo/expo/commits/%40kudo/modularize-expo-update-test/apps/bare-update).

test steps (based on bare-update project, the update url is `https://exp.host/@kudochien/bare-update`):

1. test release build (both ios and android)
2. modify App.js and `expo publish`
3. relaunch apps twice and see if the app has the updated content.

to test backward compatible, revert the `replace expo-updates integration by in-module setup` commit and go through the steps above again.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).