### PR TITLE
the import of Clipboard was not done properly

### DIFF
--- a/docs/pages/versions/unversioned/sdk/clipboard.md
+++ b/docs/pages/versions/unversioned/sdk/clipboard.md
@@ -23,7 +23,7 @@ import SnackInline from '~/components/plugins/SnackInline';
 ```jsx
 import * as React from 'react';
 import { View, Text, Button, StyleSheet } from 'react-native';
-import * as Clipboard from 'expo-clipboard';
+import Clipboard from 'expo-clipboard';
 
 export default function App() {
   const [copiedText, setCopiedText] = React.useState('');


### PR DESCRIPTION
The Clipboard Object was not imported properly, that is why it was not working with expo ~41.0.0
Just updated it.

# Why

I tried to import it, however, it was causing crash.  


# How


It is just an update in documentation. 


# Test Plan


1- Create a simple expo project.
2- install expo-clipboard 
             #expo install expo-clipboard

3- Try importing 
           #import * as Clipboard from 'expo-clipboard';  
           # Clipboard.setString('mail.google.com'); // this will give error TS2339: Property 'setString' does not exist on type 'typeof import

4- Change it to
         #import Clipboard from 'expo-clipboard';  
         # Clipboard.setString('mail.google.com'); //works fine


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).