### PR TITLE
[ios] update reload key command in Expo Go 

### DIFF
--- a/docs/pages/guides/using-clojurescript.md
+++ b/docs/pages/guides/using-clojurescript.md
@@ -130,7 +130,7 @@ React Native uses JavaScriptCore, so modules using built-in node like stream, fs
 
 ### Do I need to restart the REPL after adding new JavaScript modules or assets?
 
-No, you do need to reload JavaScript. To do that, select **Reload** from the Developer Menu. You can also press `⌘ + R` in the iOS Simulator, or press `R` twice on Android emulators.
+No, you do need to reload JavaScript. To do that, select **Reload** from the Developer Menu. You can also press `r` in the iOS Simulator, or press `R` twice on Android emulators.
 
 ### Will it support Boot?
 

--- a/docs/pages/guides/using-clojurescript.md
+++ b/docs/pages/guides/using-clojurescript.md
@@ -130,7 +130,7 @@ React Native uses JavaScriptCore, so modules using built-in node like stream, fs
 
 ### Do I need to restart the REPL after adding new JavaScript modules or assets?
 
-No, you do need to reload JavaScript. To do that, select **Reload** from the Developer Menu. You can also press `r` in the iOS Simulator, or press `R` twice on Android emulators.
+No, you do need to reload JavaScript. To do that, select **Reload** from the Developer Menu. You can also press `r` in the iOS Simulator, or press `r` twice on Android emulators.
 
 ### Will it support Boot?
 

--- a/ios/Exponent/Kernel/DevSupport/EXKernelDevKeyCommands.m
+++ b/ios/Exponent/Kernel/DevSupport/EXKernelDevKeyCommands.m
@@ -100,13 +100,14 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
       }
     }
     
+    
+    // Call the original swizzled method
+    [self EX_handleKeyUIEventSwizzle:event];
+    
     if (firstResponder) {
       BOOL isTextField = [firstResponder isKindOfClass: [UITextField class]] || [firstResponder isKindOfClass: [UITextView class]];
       
-      if (isTextField) {
-        // Call the original swizzled method
-        [self EX_handleKeyUIEventSwizzle:event];
-      } else {
+      if (!isTextField) {
         [EXKernelDevKeyCommands handleKeyboardEvent:event];
       }
     }
@@ -183,6 +184,8 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
       if ([input isEqualToString: @"r"]) {
         [[EXKernel sharedInstance] reloadVisibleApp];
       }
+      
+      lastCommand = CACurrentMediaTime();
     }
   }
 }

--- a/ios/Exponent/Kernel/DevSupport/EXKernelDevKeyCommands.m
+++ b/ios/Exponent/Kernel/DevSupport/EXKernelDevKeyCommands.m
@@ -100,11 +100,15 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
       }
     }
     
-    if (firstResponder && [firstResponder isKindOfClass: [UITextField class]]) {
-      // call the original swizzled method
-      [self EX_handleKeyUIEventSwizzle:event];
-    } else {
-      [EXKernelDevKeyCommands handleKeyboardEvent:event];
+    if (firstResponder) {
+      BOOL isTextField = [firstResponder isKindOfClass: [UITextField class]] || [firstResponder isKindOfClass: [UITextView class]];
+      
+      if (isTextField) {
+        // Call the original swizzled method
+        [self EX_handleKeyUIEventSwizzle:event];
+      } else {
+        [EXKernelDevKeyCommands handleKeyboardEvent:event];
+      }
     }
   }
 };


### PR DESCRIPTION
# Why

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

The most recent iOS simulators have commandeered  the `Cmd + R` key command for screen recordings. This PR pairs the reload function to the `r` key input from a physical device (e.g a physical keyboard)

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

After a number of different attempts, the most reliable event was is the `handleKeyUIEvent` in `UIApplication` 

Simply binding the 'r' key to a command isn't prudent because it would break text inputs that need to type the 'r' key as well. 

To get around this, the event handler determines if the first responder to the current even is a text input, and if so, delegates to that text input. If its not a text input, then it will fire the reload command.

Note: This implementation was found in the react-native source: https://github.com/facebook/react-native/blob/main/React/Base/RCTKeyCommands.m#L109 and adapted for our needs. 

There is a bit of duplication involved here - I think it would be simplest to refactor this file and provide these commands as static methods on `EXKernelDevKeyCommands` so that we can reuse the command implementations in both swizzled methods - but I didn't want to preemptively change all of that without feedback

# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->

Demo: 

The text input should take precedence over the reload command if it is focused

https://user-images.githubusercontent.com/40680668/131177725-17b87f89-10db-4431-9c8e-cf0065785174.mov



# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).