### PR TITLE
[splash-screen] Fix splash screen not dismissed if alert appearing

### DIFF
--- a/packages/expo-splash-screen/CHANGELOG.md
+++ b/packages/expo-splash-screen/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### 🐛 Bug fixes
 
 - On iOS, search for a view controller with a RCTRootView rather than always using the keyWindow's rootViewController. ([#13429](https://github.com/expo/expo/pull/13429) by [@esamelson](https://github.com/esamelson))
+- Fix splash screen not dismissed if there is alert view appearing. ([#14208](https://github.com/expo/expo/pull/14208) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenModule.m
+++ b/packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenModule.m
@@ -118,7 +118,9 @@ EX_EXPORT_METHOD_AS(preventAutoHideAsync,
   }
 
   UIViewController *presentedController = controller.presentedViewController;
-  while (presentedController && ![presentedController isBeingDismissed]) {
+  while (presentedController &&
+         ![presentedController isBeingDismissed] &&
+         ![presentedController isKindOfClass:[UIAlertController class]]) {
     controller = presentedController;
     presentedController = controller.presentedViewController;
   }


### PR DESCRIPTION
# Why

fixes #14099

# How

if the `presentedViewController` is an `UIAlertController`, we should not return as current view controller. otherwise, `onAppContentDidAppear` will get the UIAlertController and show `No native splash screen registered for given view controller. Call 'SplashScreen.show' for given view controller first.` error. 

# Test Plan

test bare-expo with this patch (thanks @srmagura to provide the minimal repros)

```diff
--- a/apps/bare-expo/ios/BareExpo/AppDelegate.swift
+++ b/apps/bare-expo/ios/BareExpo/AppDelegate.swift
@@ -37,6 +37,16 @@ class AppDelegate: AppDelegateWrapper {

     super.application(application, didFinishLaunchingWithOptions: launchOptions)

+    // BEGIN ADDED CODE
+    let alert = UIAlertController(title: "Test Alert", message: "Test message", preferredStyle: UIAlertController.Style.alert)
+    let cancelButton = UIAlertAction(title: "Cancel", style: UIAlertAction.Style.default) { UIAlertAction in
+    }
+    alert.addAction(cancelButton)
+    let rootView = application.keyWindow?.rootViewController
+    rootView?.present(alert, animated: true) {
+    }
+    // END ADDED CODE
+
     return true
   }

```

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).