### PR TITLE
[splash-screen] Fix yet another matching UIAlertController issue

### DIFF
--- a/packages/expo-splash-screen/CHANGELOG.md
+++ b/packages/expo-splash-screen/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 - On iOS, search for a view controller with a RCTRootView rather than always using the keyWindow's rootViewController. ([#13429](https://github.com/expo/expo/pull/13429) by [@esamelson](https://github.com/esamelson))
 - Fix splash screen not dismissed if there is alert view appearing. ([#14208](https://github.com/expo/expo/pull/14208) by [@kudo](https://github.com/kudo))
-- Fix yet another splash not dismissed issue while alert view appearing. ([#14213](https://github.com/expo/expo/pull/14213) by [@kudo](https://github.com/kudo))
+- Fix splash screen not dismissed while alert view appearing before RCTRootView did load. ([#14213](https://github.com/expo/expo/pull/14213) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-splash-screen/CHANGELOG.md
+++ b/packages/expo-splash-screen/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - On iOS, search for a view controller with a RCTRootView rather than always using the keyWindow's rootViewController. ([#13429](https://github.com/expo/expo/pull/13429) by [@esamelson](https://github.com/esamelson))
 - Fix splash screen not dismissed if there is alert view appearing. ([#14208](https://github.com/expo/expo/pull/14208) by [@kudo](https://github.com/kudo))
+- Fix yet another splash not dismissed issue while alert view appearing. ([#14213](https://github.com/expo/expo/pull/14213) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenModule.m
+++ b/packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenModule.m
@@ -114,7 +114,12 @@ EX_EXPORT_METHOD_AS(preventAutoHideAsync,
   UIViewController *controller = [self viewControllerContainingRCTRootView];
   if (!controller) {
     // no RCTRootView was found, so just fall back to the key window's root view controller
-    return self.utilities.currentViewController;
+    controller = self.utilities.currentViewController;
+    while ([controller isKindOfClass:[UIAlertController class]] &&
+           controller.presentingViewController != nil) {
+      controller = controller.presentingViewController;
+    }
+    return controller;
   }
 
   UIViewController *presentedController = controller.presentedViewController;


### PR DESCRIPTION
# Why

fix #14099, yet another case for starting without attached debugger and believed to be an old issue lasting for years. 

# How

if RCTRootView not found and fallback to a currentViewController, we still need to check the matching UIViewController should not be an UIAlertController.

# Test Plan

this is a race condition issue and cannot reproduced on bare-expo. we should use a bare project instead.

1. `expo init exsplash` # select bare
2. add alert view

```diff
--- a/ios/exsplash/AppDelegate.m
+++ b/ios/exsplash/AppDelegate.m
@@ -58,6 +58,24 @@ - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(

   [super application:application didFinishLaunchingWithOptions:launchOptions];

+  // BEGIN ADDED CODE
+  UIAlertController* alert = [UIAlertController
+                              alertControllerWithTitle:@"Test Alert"
+                              message:@"Test message"
+                              preferredStyle:UIAlertControllerStyleAlert];
+
+  UIAlertAction* cancelButton = [UIAlertAction
+                                  actionWithTitle:@"Cancel"
+                                  style:UIAlertActionStyleDefault
+                                  handler:^(UIAlertAction * action) {
+                                  }];
+
+  [alert addAction:cancelButton];
+
+  #define ROOTVIEW [[[UIApplication sharedApplication] keyWindow] rootViewController]
+  [ROOTVIEW presentViewController:alert animated:YES completion:^{}];
+  // END ADDED CODE
+
   return YES;
 }

```

3. `yarn ios` # or `expo run:ios` 


# Checklist


- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).