### PR TITLE
[image][android] Add a flag to check if the view needs to be reloaded

### DIFF
--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageView.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageView.kt
@@ -54,20 +54,12 @@ class ExpoImageView(context: ReactContext, private val requestManager: RequestMa
   internal var sourceMap: ReadableMap? = null
   internal var blurRadius: Int? = null
     set(value) {
-      field = if (value != null && value > 0) {
-        value
-      } else {
-        null
-      }
+      field = value?.takeIf { it > 0 }
       propsChanged = true
     }
   internal var fadeDuration: Int? = null
     set(value) {
-      field = if (value != null && value > 0) {
-        value
-      } else {
-        null
-      }
+      field = value?.takeIf { it > 0 }
       propsChanged = true
     }
 

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageView.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageView.kt
@@ -49,10 +49,27 @@ class ExpoImageView(context: ReactContext, private val requestManager: RequestMa
         }
     }
   }
+  private var propsChanged = false
   private var loadedSource: GlideUrl? = null
   internal var sourceMap: ReadableMap? = null
-  var blurRadius: Int? = null
-  var fadeDuration: Int? = null
+  internal var blurRadius: Int? = null
+    set(value) {
+      field = if (value != null && value > 0) {
+        value
+      } else {
+        null
+      }
+      propsChanged = true
+    }
+  internal var fadeDuration: Int? = null
+    set(value) {
+      field = if (value != null && value > 0) {
+        value
+      } else {
+        null
+      }
+      propsChanged = true
+    }
 
   init {
     clipToOutline = true
@@ -115,7 +132,8 @@ class ExpoImageView(context: ReactContext, private val requestManager: RequestMa
       requestManager.clear(this)
       setImageDrawable(null)
       loadedSource = null
-    } else if (sourceToLoad != loadedSource) {
+    } else if (sourceToLoad != loadedSource || propsChanged) {
+      propsChanged = false
       loadedSource = sourceToLoad
       val options = createOptionsFromSourceMap(sourceMap)
       val propOptions = createPropOptions()


### PR DESCRIPTION
# Why

ImageView wasn't reloaded after changing props `blurRadius` and `fadeDuration`. 

# How

- Set the flag `propsChanged` to determine if we have to update the view.
- Set visibility of the variables to `internal` (`public` was unnecessary).

# Test Plan

- Compare to React Native `Image`.

# Checklist


- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).