### PR TITLE
[android][expo-updates] Remove unused legacy manifest storage from shared preferences

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.kt
@@ -428,9 +428,6 @@ open class ExperienceActivity : BaseExperienceActivity(), StartReactInstanceDele
     this.manifestUrl = manifestUrl
     this.manifest = manifest
 
-    // TODO(eric): remove when deleting old AppLoader class/logic
-    exponentSharedPreferences.updateManifest(this.manifestUrl!!, manifest, bundleUrl)
-
     // Notifications logic uses this to determine which experience to route a notification to
     ExponentDB.saveExperience(ExponentDBObject(this.manifestUrl!!, manifest, bundleUrl))
 

--- a/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.kt
@@ -428,6 +428,8 @@ open class ExperienceActivity : BaseExperienceActivity(), StartReactInstanceDele
     this.manifestUrl = manifestUrl
     this.manifest = manifest
 
+    exponentSharedPreferences.removeLegacyManifest(this.manifestUrl!!)
+
     // Notifications logic uses this to determine which experience to route a notification to
     ExponentDB.saveExperience(ExponentDBObject(this.manifestUrl!!, manifest, bundleUrl))
 

--- a/android/expoview/src/main/java/host/exp/exponent/kernel/KernelConstants.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/kernel/KernelConstants.kt
@@ -8,8 +8,6 @@ import host.exp.exponent.notifications.ExponentNotification
 object KernelConstants {
   val TAG = KernelConstants::class.java.simpleName
 
-  const val MANIFEST_KEY = "manifest"
-  const val BUNDLE_URL_KEY = "bundleUrl"
   const val MANIFEST_URL_KEY = "experienceUrl"
   const val NOTIFICATION_MANIFEST_URL_KEY = "notificationExperienceUrl"
   const val NOTIFICATION_ACTION_TYPE_KEY = "actionType"

--- a/android/expoview/src/main/java/host/exp/exponent/storage/ExponentSharedPreferences.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/storage/ExponentSharedPreferences.kt
@@ -15,8 +15,6 @@ import javax.inject.Singleton
 
 @Singleton
 class ExponentSharedPreferences constructor(val context: Context) {
-  class ManifestAndBundleUrl internal constructor(val manifest: Manifest, val bundleUrl: String)
-
   private val sharedPreferences = context.getSharedPreferences(
     context.getString(R.string.preference_file_key),
     Context.MODE_PRIVATE
@@ -96,33 +94,6 @@ class ExponentSharedPreferences constructor(val context: Context) {
         null
       }
     }
-
-  fun updateManifest(manifestUrl: String, manifest: Manifest, bundleUrl: String) {
-    try {
-      val parentObject = JSONObject().apply {
-        put(KernelConstants.MANIFEST_KEY, manifest)
-        put(KernelConstants.BUNDLE_URL_KEY, bundleUrl)
-        put(SAFE_MANIFEST_KEY, manifest.getRawJson())
-      }
-      sharedPreferences.edit().putString(manifestUrl, parentObject.toString()).apply()
-    } catch (e: JSONException) {
-      EXL.e(TAG, e)
-    }
-  }
-
-  // TODO(wschurman): this is unused?
-  fun getManifest(manifestUrl: String?): ManifestAndBundleUrl? {
-    val jsonString = sharedPreferences.getString(manifestUrl, null) ?: return null
-    return try {
-      val json = JSONObject(jsonString)
-      val manifestJson = json.getJSONObject(KernelConstants.MANIFEST_KEY)
-      val bundleUrl = json.getString(KernelConstants.BUNDLE_URL_KEY)
-      ManifestAndBundleUrl(ManifestFactory.getManifestFromManifestJson(manifestJson), bundleUrl)
-    } catch (e: JSONException) {
-      EXL.e(TAG, e)
-      null
-    }
-  }
 
   fun updateExperienceMetadata(experienceKey: ExperienceKey, metadata: JSONObject) {
     sharedPreferences.edit()

--- a/android/expoview/src/main/java/host/exp/exponent/storage/ExponentSharedPreferences.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/storage/ExponentSharedPreferences.kt
@@ -2,11 +2,8 @@
 package host.exp.exponent.storage
 
 import android.content.Context
-import expo.modules.updates.manifest.ManifestFactory
-import expo.modules.manifests.core.Manifest
 import host.exp.exponent.analytics.EXL
 import host.exp.exponent.kernel.ExperienceKey
-import host.exp.exponent.kernel.KernelConstants
 import host.exp.expoview.ExpoViewBuildConfig
 import host.exp.expoview.R
 import org.json.JSONException
@@ -95,6 +92,10 @@ class ExponentSharedPreferences constructor(val context: Context) {
       }
     }
 
+  fun removeLegacyManifest(manifestUrl: String) {
+    sharedPreferences.edit().remove(manifestUrl).apply()
+  }
+
   fun updateExperienceMetadata(experienceKey: ExperienceKey, metadata: JSONObject) {
     sharedPreferences.edit()
       .putString(EXPERIENCE_METADATA_PREFIX + experienceKey.scopeKey, metadata.toString()).apply()
@@ -116,8 +117,6 @@ class ExponentSharedPreferences constructor(val context: Context) {
     private val TAG = ExponentSharedPreferences::class.java.simpleName
 
     const val EXPO_AUTH_SESSION_SECRET_KEY = "sessionSecret"
-
-    const val SAFE_MANIFEST_KEY = "safe_manifest"
 
     // Metadata
     const val EXPERIENCE_METADATA_PREFIX = "experience_metadata_"


### PR DESCRIPTION
# Why

https://github.com/expo/expo/blob/50661f5c77b26c1192492496b17ed251d4965ff0/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.kt#L431

And we can feel even safer about deleting this because the method that reads these shared preference values is unused (`getManifest`).

Closes ENG-1735.

# How

1. Remove deadcode, repeat.
1. Add new code to remove any existing key from shared preferences.

# Test Plan

Launch the same experience twice, see that the removal is idempotent.