### PR TITLE
[android][kernel] Fix ReactNativeStaticHelpers.getBundleUrlForActivityId argument order

### DIFF
--- a/android/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.java
+++ b/android/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.java
@@ -391,7 +391,7 @@ public class DevServerHelper {
 
     private String createBundleURL(String mainModuleID, BundleType type, String host) {
         try {
-            return (String) Class.forName("host.exp.exponent.ReactNativeStaticHelpers").getMethod("getBundleUrlForActivityId", int.class, String.class, String.class, String.class, boolean.class, boolean.class).invoke(null, mSettings.exponentActivityId, mainModuleID, type.typeID(), host, getDevMode(), getJSMinifyMode());
+            return (String) Class.forName("host.exp.exponent.ReactNativeStaticHelpers").getMethod("getBundleUrlForActivityId", int.class, String.class, String.class, String.class, boolean.class, boolean.class).invoke(null, mSettings.exponentActivityId, host, mainModuleID, type.typeID(), getDevMode(), getJSMinifyMode());
         } catch (Exception expoHandleErrorException) {
             expoHandleErrorException.printStackTrace();
             return null;
@@ -404,16 +404,7 @@ public class DevServerHelper {
 
     private String createBundleURL(String mainModuleID, BundleType type, String host, boolean modulesOnly, boolean runModule) {
         try {
-            return (String) Class.forName("host.exp.exponent.ReactNativeStaticHelpers")
-                    .getMethod(
-                            "getBundleUrlForActivityId",
-                            int.class,
-                            String.class,
-                            String.class,
-                            String.class,
-                            boolean.class,
-                            boolean.class
-                    ).invoke(null, mSettings.exponentActivityId, host, mainModuleID, type.typeID(), getDevMode(), getJSMinifyMode());
+            return (String) Class.forName("host.exp.exponent.ReactNativeStaticHelpers").getMethod("getBundleUrlForActivityId", int.class, String.class, String.class, String.class, boolean.class, boolean.class).invoke(null, mSettings.exponentActivityId, host, mainModuleID, type.typeID(), getDevMode(), getJSMinifyMode());
         } catch (Exception expoHandleErrorException) {
             expoHandleErrorException.printStackTrace();
             return null;

--- a/android/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.java
+++ b/android/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.java
@@ -404,7 +404,16 @@ public class DevServerHelper {
 
     private String createBundleURL(String mainModuleID, BundleType type, String host, boolean modulesOnly, boolean runModule) {
         try {
-            return (String) Class.forName("host.exp.exponent.ReactNativeStaticHelpers").getMethod("getBundleUrlForActivityId", int.class, String.class, String.class, String.class, boolean.class, boolean.class).invoke(null, mSettings.exponentActivityId, mainModuleID, type.typeID(), host, getDevMode(), getJSMinifyMode());
+            return (String) Class.forName("host.exp.exponent.ReactNativeStaticHelpers")
+                    .getMethod(
+                            "getBundleUrlForActivityId",
+                            int.class,
+                            String.class,
+                            String.class,
+                            String.class,
+                            boolean.class,
+                            boolean.class
+                    ).invoke(null, mSettings.exponentActivityId, host, mainModuleID, type.typeID(), getDevMode(), getJSMinifyMode());
         } catch (Exception expoHandleErrorException) {
             expoHandleErrorException.printStackTrace();
             return null;

--- a/android/expoview/src/main/java/host/exp/exponent/ReactNativeStaticHelpers.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/ReactNativeStaticHelpers.kt
@@ -34,14 +34,13 @@ object ReactNativeStaticHelpers {
   @DoNotStrip
   @JvmStatic fun getBundleUrlForActivityId(
     activityId: Int,
+    host: String?,
     mainModuleId: String?,
     bundleTypeId: String?,
-    host: String?,
     devMode: Boolean,
     jsMinify: Boolean
   ): String? {
     return try {
-      // TODO(wschurman): the argument order here looks out of order
       Class.forName("host.exp.exponent.kernel.Kernel")
         .getMethod(
           "getBundleUrlForActivityId",
@@ -52,7 +51,7 @@ object ReactNativeStaticHelpers {
           Boolean::class.javaPrimitiveType,
           Boolean::class.javaPrimitiveType
         )
-        .invoke(null, activityId, mainModuleId, bundleTypeId, host, devMode, jsMinify) as String
+        .invoke(null, activityId, host, mainModuleId, bundleTypeId, devMode, jsMinify) as String
     } catch (e: Exception) {
       bundleUrl
     }

--- a/android/tools/src/main/java/host/exp/exponent/tools/ReactAndroidCodeTransformer.java
+++ b/android/tools/src/main/java/host/exp/exponent/tools/ReactAndroidCodeTransformer.java
@@ -142,7 +142,7 @@ public class ReactAndroidCodeTransformer {
             BlockStmt stmt = JavaParser.parseBlock(getCallMethodReflectionBlock(
                 "host.exp.exponent.ReactNativeStaticHelpers",
                 "\"getBundleUrlForActivityId\", int.class, String.class, String.class, String.class, boolean.class, boolean.class",
-                "null, mSettings.exponentActivityId, mainModuleID, type.typeID(), host, getDevMode(), getJSMinifyMode()",
+                "null, mSettings.exponentActivityId, host, mainModuleID, type.typeID(), getDevMode(), getJSMinifyMode()",
                 "return (String) ",
                 "return null;"));
             n.setBody(stmt);


### PR DESCRIPTION
# Why

Noticed this while converting this to kotlin, but the bug is that the argument order doesn't match the argument order in kernel, so the incorrect arguments are being passed. Not sure of the effects of this bug, though since it's only used in `DevServerHelper` I'm assuming it isn't too bad, but this PR fixes it.

Closes ENG-1802.

# How

Update ordering to match kernel. 

For reviewers: if there's something I'm missing here about old SDKs needing the `ReactNativeStaticHelpers` method parameter order not to change let me know, but as far as I can tell `DevServerHelper.java` is not versioned so we're in the clear to change the parameter ordering.

# Test Plan

Build.