### PR TITLE
[android][kernel] Add u.expo.dev to HTTPS_HOSTS

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/kernel/ExponentUrls.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/kernel/ExponentUrls.kt
@@ -8,7 +8,9 @@ import okhttp3.Request
 object ExponentUrls {
   private val HTTPS_HOSTS = setOf(
     "exp.host",
-    "exponentjs.com"
+    "exponentjs.com",
+    "u.expo.dev",
+    "staging-u.expo.dev"
   )
 
   private fun isHttpsHost(host: String?): Boolean {


### PR DESCRIPTION
# Why

Closes ENG-1616

# How

1. Audit callsites to ensure it is still used (it is in both legacy home bundle loading code as well as new expo-updates url construction code). 
2. Add URLs

# Test Plan

Build.