### PR TITLE
[android][expoview] Fix potential bug in RNObject.callStaticRecursive

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/RNObject.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/RNObject.kt
@@ -98,8 +98,9 @@ class RNObject {
     return callWithReceiver(null, name, *args)
   }
 
-  fun callStaticRecursive(name: String, vararg args: Any?): RNObject {
-    return wrap(callStatic(name, *args))
+  fun callStaticRecursive(name: String, vararg args: Any?): RNObject? {
+    val result = callStatic(name, *args) ?: return null
+    return wrap(result)
   }
 
   fun setField(name: String, value: Any) {
@@ -165,7 +166,7 @@ class RNObject {
 
     const val UNVERSIONED = "UNVERSIONED"
 
-    @JvmStatic fun wrap(obj: Any?): RNObject {
+    @JvmStatic fun wrap(obj: Any): RNObject {
       return RNObject(obj)
     }
 

--- a/android/expoview/src/main/java/host/exp/exponent/notifications/ExponentNotification.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/notifications/ExponentNotification.kt
@@ -41,16 +41,16 @@ open class ExponentNotification(
   fun toWriteableMap(sdkVersion: String?, origin: String?): Any {
     return RNObject("com.facebook.react.bridge.Arguments").loadVersion(sdkVersion!!)
       .callStaticRecursive("createMap")!!.apply {
-        if (origin != null) {
-          call("putString", NotificationConstants.NOTIFICATION_ORIGIN_KEY, origin)
-        }
-        call("putString", NotificationConstants.NOTIFICATION_DATA_KEY, body)
-        call("putInt", NotificationConstants.NOTIFICATION_ID_KEY, notificationId)
-        call("putBoolean", NotificationConstants.NOTIFICATION_IS_MULTIPLE_KEY, isMultiple)
-        call("putBoolean", NotificationConstants.NOTIFICATION_REMOTE_KEY, isRemote)
-        call("putString", NotificationConstants.NOTIFICATION_ACTION_TYPE, actionType)
-        call("putString", NotificationConstants.NOTIFICATION_INPUT_TEXT, inputText)
+      if (origin != null) {
+        call("putString", NotificationConstants.NOTIFICATION_ORIGIN_KEY, origin)
       }
+      call("putString", NotificationConstants.NOTIFICATION_DATA_KEY, body)
+      call("putInt", NotificationConstants.NOTIFICATION_ID_KEY, notificationId)
+      call("putBoolean", NotificationConstants.NOTIFICATION_IS_MULTIPLE_KEY, isMultiple)
+      call("putBoolean", NotificationConstants.NOTIFICATION_REMOTE_KEY, isRemote)
+      call("putString", NotificationConstants.NOTIFICATION_ACTION_TYPE, actionType)
+      call("putString", NotificationConstants.NOTIFICATION_INPUT_TEXT, inputText)
+    }
       .get()!!
   }
 

--- a/android/expoview/src/main/java/host/exp/exponent/notifications/ExponentNotification.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/notifications/ExponentNotification.kt
@@ -40,7 +40,7 @@ open class ExponentNotification(
 
   fun toWriteableMap(sdkVersion: String?, origin: String?): Any {
     return RNObject("com.facebook.react.bridge.Arguments").loadVersion(sdkVersion!!)
-      .callStaticRecursive("createMap").apply {
+      .callStaticRecursive("createMap")!!.apply {
         if (origin != null) {
           call("putString", NotificationConstants.NOTIFICATION_ORIGIN_KEY, origin)
         }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/VersionedUtils.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/VersionedUtils.kt
@@ -245,7 +245,7 @@ object VersionedUtils {
       val devSettingsModule = reactApplicationContext.catalystInstance.getNativeModule("DevSettings")
       val devSupportManagerField = devSettingsModule!!.javaClass.getDeclaredField("mDevSupportManager")
       devSupportManagerField.isAccessible = true
-      RNObject.wrap(devSupportManagerField[devSettingsModule])
+      RNObject.wrap(devSupportManagerField[devSettingsModule]!!)
     } catch (e: Throwable) {
       e.printStackTrace()
       null


### PR DESCRIPTION
# Why

https://github.com/expo/expo/pull/14042#discussion_r690907398

Closes ENG-1829.

Next up we may be able to make this class safer by making it be generic to the type of object it's wrapping, though I'm not 100% sure kotlin has the ability to do much in this area.

# How

1. Check for null result of the callStatic before wrapping the result. This is to match the other recursive methods.
2. Make `wrap` parameter non-nullable since all callsites are non-null.

# Test Plan

Compile.