### PR TITLE
[expo-manifests] projectId -> easProjectId

### DIFF
--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXManifests/EXManifests/ABI40_0_0EXManifestsBaseLegacyManifest.h
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXManifests/EXManifests/ABI40_0_0EXManifestsBaseLegacyManifest.h
@@ -11,7 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSString *)stableLegacyId;
 - (NSString *)scopeKey;
-- (nullable NSString *)projectId;
+- (nullable NSString *)easProjectId;
 
 - (NSString *)bundleUrl;
 - (nullable NSString *)sdkVersion;

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXManifests/EXManifests/ABI40_0_0EXManifestsBaseLegacyManifest.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXManifests/EXManifests/ABI40_0_0EXManifestsBaseLegacyManifest.m
@@ -31,7 +31,7 @@
   }
 }
 
-- (nullable NSString *)projectId {
+- (nullable NSString *)easProjectId {
   return [self.rawManifestJSON nullableStringForKey:@"projectId"];
 }
 

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXManifests/EXManifests/ABI40_0_0EXManifestsManifest.h
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXManifests/EXManifests/ABI40_0_0EXManifestsManifest.h
@@ -14,9 +14,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * A best-effort immutable legacy ID for this experience. Stable through project transfers.
- * Should be used for calling Expo and EAS APIs during their transition to projectId.
+ * Should be used for calling Expo and EAS APIs during their transition to easProjectId.
  */
-- (NSString *)stableLegacyId DEPRECATED_MSG_ATTRIBUTE("Prefer scopeKey or projectId depending on use case.");
+- (NSString *)stableLegacyId DEPRECATED_MSG_ATTRIBUTE("Prefer scopeKey or easProjectId depending on use case.");
 
 /**
  * A stable immutable scoping key for this experience. Should be used for scoping data on the
@@ -27,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * A stable UUID for this EAS project. Should be used to call EAS APIs.
  */
-- (nullable NSString *)projectId;
+- (nullable NSString *)easProjectId;
 
 /**
  * The legacy ID of this experience.
@@ -37,7 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * Use this in cases where an identifier of the current manifest is needed (experience loading for example).
  * Use scopeKey for cases where a stable key is needed to scope data to this experience.
- * Use projectId for cases where a stable UUID identifier of the experience is needed to identify over APIs.
+ * Use easProjectId for cases where a stable UUID identifier of the experience is needed to identify over EAS APIs.
  * Use stableLegacyId for cases where a stable legacy format identifier of the experience is needed (experience scoping for example).
  */
 - (NSString *)legacyId;

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXManifests/EXManifests/ABI40_0_0EXManifestsNewManifest.h
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXManifests/EXManifests/ABI40_0_0EXManifestsNewManifest.h
@@ -18,7 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSString *)stableLegacyId DEPRECATED_MSG_ATTRIBUTE("Modern manifests don't support stable legacy IDs");
 
 - (NSString *)scopeKey;
-- (nullable NSString *)projectId;
+- (nullable NSString *)easProjectId;
 
 - (NSString *)createdAt;
 - (NSString *)runtimeVersion;

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXManifests/EXManifests/ABI40_0_0EXManifestsNewManifest.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXManifests/EXManifests/ABI40_0_0EXManifestsNewManifest.m
@@ -16,7 +16,7 @@
   return [[self.rawManifestJSON dictionaryForKey:@"extra"] stringForKey:@"scopeKey"];
 }
 
-- (NSString *)projectId {
+- (nullable NSString *)easProjectId {
   if (!self.extra) {
     return nil;
   }

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXManifests/EXManifests/ABI41_0_0EXManifestsBaseLegacyManifest.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXManifests/EXManifests/ABI41_0_0EXManifestsBaseLegacyManifest.h
@@ -11,7 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSString *)stableLegacyId;
 - (NSString *)scopeKey;
-- (nullable NSString *)projectId;
+- (nullable NSString *)easProjectId;
 
 - (NSString *)bundleUrl;
 - (nullable NSString *)sdkVersion;

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXManifests/EXManifests/ABI41_0_0EXManifestsBaseLegacyManifest.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXManifests/EXManifests/ABI41_0_0EXManifestsBaseLegacyManifest.m
@@ -31,7 +31,7 @@
   }
 }
 
-- (nullable NSString *)projectId {
+- (nullable NSString *)easProjectId {
   return [self.rawManifestJSON nullableStringForKey:@"projectId"];
 }
 

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXManifests/EXManifests/ABI41_0_0EXManifestsManifest.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXManifests/EXManifests/ABI41_0_0EXManifestsManifest.h
@@ -14,9 +14,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * A best-effort immutable legacy ID for this experience. Stable through project transfers.
- * Should be used for calling Expo and EAS APIs during their transition to projectId.
+ * Should be used for calling Expo and EAS APIs during their transition to easProjectId.
  */
-- (NSString *)stableLegacyId DEPRECATED_MSG_ATTRIBUTE("Prefer scopeKey or projectId depending on use case.");
+- (NSString *)stableLegacyId DEPRECATED_MSG_ATTRIBUTE("Prefer scopeKey or easProjectId depending on use case.");
 
 /**
  * A stable immutable scoping key for this experience. Should be used for scoping data on the
@@ -27,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * A stable UUID for this EAS project. Should be used to call EAS APIs.
  */
-- (nullable NSString *)projectId;
+- (nullable NSString *)easProjectId;
 
 /**
  * The legacy ID of this experience.
@@ -37,7 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * Use this in cases where an identifier of the current manifest is needed (experience loading for example).
  * Use scopeKey for cases where a stable key is needed to scope data to this experience.
- * Use projectId for cases where a stable UUID identifier of the experience is needed to identify over APIs.
+ * Use easProjectId for cases where a stable UUID identifier of the experience is needed to identify over EAS APIs.
  * Use stableLegacyId for cases where a stable legacy format identifier of the experience is needed (experience scoping for example).
  */
 - (NSString *)legacyId;

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXManifests/EXManifests/ABI41_0_0EXManifestsNewManifest.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXManifests/EXManifests/ABI41_0_0EXManifestsNewManifest.h
@@ -18,7 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSString *)stableLegacyId DEPRECATED_MSG_ATTRIBUTE("Modern manifests don't support stable legacy IDs");
 
 - (NSString *)scopeKey;
-- (nullable NSString *)projectId;
+- (nullable NSString *)easProjectId;
 
 - (NSString *)createdAt;
 - (NSString *)runtimeVersion;

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXManifests/EXManifests/ABI41_0_0EXManifestsNewManifest.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXManifests/EXManifests/ABI41_0_0EXManifestsNewManifest.m
@@ -16,7 +16,7 @@
   return [[self.rawManifestJSON dictionaryForKey:@"extra"] stringForKey:@"scopeKey"];
 }
 
-- (NSString *)projectId {
+- (nullable NSString *)easProjectId {
   if (!self.extra) {
     return nil;
   }

--- a/ios/versioned-react-native/ABI42_0_0/Expo/EXManifests/EXManifests/ABI42_0_0EXManifestsBaseLegacyManifest.h
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/EXManifests/EXManifests/ABI42_0_0EXManifestsBaseLegacyManifest.h
@@ -11,7 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSString *)stableLegacyId;
 - (NSString *)scopeKey;
-- (nullable NSString *)projectId;
+- (nullable NSString *)easProjectId;
 
 - (NSString *)bundleUrl;
 - (nullable NSString *)sdkVersion;

--- a/ios/versioned-react-native/ABI42_0_0/Expo/EXManifests/EXManifests/ABI42_0_0EXManifestsBaseLegacyManifest.m
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/EXManifests/EXManifests/ABI42_0_0EXManifestsBaseLegacyManifest.m
@@ -31,7 +31,7 @@
   }
 }
 
-- (nullable NSString *)projectId {
+- (nullable NSString *)easProjectId {
   return [self.rawManifestJSON nullableStringForKey:@"projectId"];
 }
 

--- a/ios/versioned-react-native/ABI42_0_0/Expo/EXManifests/EXManifests/ABI42_0_0EXManifestsManifest.h
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/EXManifests/EXManifests/ABI42_0_0EXManifestsManifest.h
@@ -14,9 +14,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * A best-effort immutable legacy ID for this experience. Stable through project transfers.
- * Should be used for calling Expo and EAS APIs during their transition to projectId.
+ * Should be used for calling Expo and EAS APIs during their transition to easProjectId.
  */
-- (NSString *)stableLegacyId DEPRECATED_MSG_ATTRIBUTE("Prefer scopeKey or projectId depending on use case.");
+- (NSString *)stableLegacyId DEPRECATED_MSG_ATTRIBUTE("Prefer scopeKey or easProjectId depending on use case.");
 
 /**
  * A stable immutable scoping key for this experience. Should be used for scoping data on the
@@ -27,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * A stable UUID for this EAS project. Should be used to call EAS APIs.
  */
-- (nullable NSString *)projectId;
+- (nullable NSString *)easProjectId;
 
 /**
  * The legacy ID of this experience.
@@ -37,7 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * Use this in cases where an identifier of the current manifest is needed (experience loading for example).
  * Use scopeKey for cases where a stable key is needed to scope data to this experience.
- * Use projectId for cases where a stable UUID identifier of the experience is needed to identify over APIs.
+ * Use easProjectId for cases where a stable UUID identifier of the experience is needed to identify over EAS APIs.
  * Use stableLegacyId for cases where a stable legacy format identifier of the experience is needed (experience scoping for example).
  */
 - (NSString *)legacyId;

--- a/ios/versioned-react-native/ABI42_0_0/Expo/EXManifests/EXManifests/ABI42_0_0EXManifestsNewManifest.h
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/EXManifests/EXManifests/ABI42_0_0EXManifestsNewManifest.h
@@ -18,7 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSString *)stableLegacyId DEPRECATED_MSG_ATTRIBUTE("Modern manifests don't support stable legacy IDs");
 
 - (NSString *)scopeKey;
-- (nullable NSString *)projectId;
+- (nullable NSString *)easProjectId;
 
 - (NSString *)createdAt;
 - (NSString *)runtimeVersion;

--- a/ios/versioned-react-native/ABI42_0_0/Expo/EXManifests/EXManifests/ABI42_0_0EXManifestsNewManifest.m
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/EXManifests/EXManifests/ABI42_0_0EXManifestsNewManifest.m
@@ -16,7 +16,7 @@
   return [[self.rawManifestJSON dictionaryForKey:@"extra"] stringForKey:@"scopeKey"];
 }
 
-- (NSString *)projectId {
+- (nullable NSString *)easProjectId {
   if (!self.extra) {
     return nil;
   }

--- a/packages/expo-manifests/android/src/main/java/expo/modules/manifests/core/BaseLegacyManifest.kt
+++ b/packages/expo-manifests/android/src/main/java/expo/modules/manifests/core/BaseLegacyManifest.kt
@@ -17,7 +17,7 @@ abstract class BaseLegacyManifest(json: JSONObject) : Manifest(json) {
     getStableLegacyID()
   }
 
-  override fun getProjectID(): String? = if (json.has("projectId")) {
+  override fun getEASProjectID(): String? = if (json.has("projectId")) {
     json.optString("projectId")
   } else {
     null

--- a/packages/expo-manifests/android/src/main/java/expo/modules/manifests/core/Manifest.kt
+++ b/packages/expo-manifests/android/src/main/java/expo/modules/manifests/core/Manifest.kt
@@ -44,7 +44,7 @@ abstract class Manifest(protected val json: JSONObject) {
   /**
    * A stable UUID for this EAS project. Should be used to call EAS APIs.
    */
-  abstract fun getProjectID(): String?
+  abstract fun getEASProjectID(): String?
 
   /**
    * The legacy ID of this experience.
@@ -54,7 +54,7 @@ abstract class Manifest(protected val json: JSONObject) {
    *
    * Use this in cases where an identifier of the current manifest is needed (experience loading for example).
    * Use getScopeKey for cases where a stable key is needed to scope data to this experience.
-   * Use getProjectID for cases where a stable UUID identifier of the experience is needed to identify over APIs.
+   * Use getEASProjectID for cases where a stable UUID identifier of the experience is needed to identify over EAS APIs.
    * Use getStableLegacyID for cases where a stable legacy format identifier of the experience is needed (experience scoping for example).
    */
   @Throws(JSONException::class)

--- a/packages/expo-manifests/android/src/main/java/expo/modules/manifests/core/NewManifest.kt
+++ b/packages/expo-manifests/android/src/main/java/expo/modules/manifests/core/NewManifest.kt
@@ -24,7 +24,7 @@ class NewManifest(json: JSONObject) : Manifest(json) {
     return json.getJSONObject("extra").getString("scopeKey")
   }
 
-  override fun getProjectID(): String? {
+  override fun getEASProjectID(): String? {
     val easConfig = getExtra()?.optJSONObject("eas") ?: return null
     return if (easConfig.has("projectId")) {
       easConfig.getString("projectId")

--- a/packages/expo-manifests/ios/EXManifests/EXManifestsBaseLegacyManifest.h
+++ b/packages/expo-manifests/ios/EXManifests/EXManifestsBaseLegacyManifest.h
@@ -11,7 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSString *)stableLegacyId;
 - (NSString *)scopeKey;
-- (nullable NSString *)projectId;
+- (nullable NSString *)easProjectId;
 
 - (NSString *)bundleUrl;
 - (nullable NSString *)sdkVersion;

--- a/packages/expo-manifests/ios/EXManifests/EXManifestsBaseLegacyManifest.m
+++ b/packages/expo-manifests/ios/EXManifests/EXManifestsBaseLegacyManifest.m
@@ -31,7 +31,7 @@
   }
 }
 
-- (nullable NSString *)projectId {
+- (nullable NSString *)easProjectId {
   return [self.rawManifestJSON nullableStringForKey:@"projectId"];
 }
 

--- a/packages/expo-manifests/ios/EXManifests/EXManifestsManifest.h
+++ b/packages/expo-manifests/ios/EXManifests/EXManifestsManifest.h
@@ -14,9 +14,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * A best-effort immutable legacy ID for this experience. Stable through project transfers.
- * Should be used for calling Expo and EAS APIs during their transition to projectId.
+ * Should be used for calling Expo and EAS APIs during their transition to easProjectId.
  */
-- (NSString *)stableLegacyId DEPRECATED_MSG_ATTRIBUTE("Prefer scopeKey or projectId depending on use case.");
+- (NSString *)stableLegacyId DEPRECATED_MSG_ATTRIBUTE("Prefer scopeKey or easProjectId depending on use case.");
 
 /**
  * A stable immutable scoping key for this experience. Should be used for scoping data on the
@@ -27,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * A stable UUID for this EAS project. Should be used to call EAS APIs.
  */
-- (nullable NSString *)projectId;
+- (nullable NSString *)easProjectId;
 
 /**
  * The legacy ID of this experience.
@@ -37,7 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * Use this in cases where an identifier of the current manifest is needed (experience loading for example).
  * Use scopeKey for cases where a stable key is needed to scope data to this experience.
- * Use projectId for cases where a stable UUID identifier of the experience is needed to identify over APIs.
+ * Use easProjectId for cases where a stable UUID identifier of the experience is needed to identify over EAS APIs.
  * Use stableLegacyId for cases where a stable legacy format identifier of the experience is needed (experience scoping for example).
  */
 - (NSString *)legacyId;

--- a/packages/expo-manifests/ios/EXManifests/EXManifestsNewManifest.h
+++ b/packages/expo-manifests/ios/EXManifests/EXManifestsNewManifest.h
@@ -18,7 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSString *)stableLegacyId DEPRECATED_MSG_ATTRIBUTE("Modern manifests don't support stable legacy IDs");
 
 - (NSString *)scopeKey;
-- (nullable NSString *)projectId;
+- (nullable NSString *)easProjectId;
 
 - (NSString *)createdAt;
 - (NSString *)runtimeVersion;

--- a/packages/expo-manifests/ios/EXManifests/EXManifestsNewManifest.m
+++ b/packages/expo-manifests/ios/EXManifests/EXManifestsNewManifest.m
@@ -16,7 +16,7 @@
   return [[self.rawManifestJSON dictionaryForKey:@"extra"] stringForKey:@"scopeKey"];
 }
 
-- (NSString *)projectId {
+- (nullable NSString *)easProjectId {
   if (!self.extra) {
     return nil;
   }


### PR DESCRIPTION
# Why

This field should be named more precisely for clarity. Note that this doesn't rename the underlying field in the raw JSON.

Closes ENG-1446.

# How

Two commits:
1. android (easy rename using android studio)
2. ios (manual rename since xcode is bad and should feel bad)

# Test Plan

Build on android and iOS.