### PR TITLE
Fixes eas install command

### DIFF
--- a/docs/pages/submit/ios.md
+++ b/docs/pages/submit/ios.md
@@ -11,7 +11,7 @@ A paid developer account is required to submit an app &mdash; you can create an 
 
 ## 1. Build a standalone app
 
-You'll need a native app binary signed for store submission. You can either use the [EAS Build](introduction.md) service or do it on your own. You will also need to have EAS CLI installed and authenticated with your Expo account: `npm install -g eas-cli & eas login`.
+You'll need a native app binary signed for store submission. You can either use the [EAS Build](introduction.md) service or do it on your own. You will also need to have EAS CLI installed and authenticated with your Expo account: `npm install -g eas-cli && eas login`.
 
 ## 2. Start the submission
 


### PR DESCRIPTION
# Why

I was following the installation instruction from this page and it returned an error indicating the `eas` command was not found.

# How

Adds another `&` to the install command to run one command after the other instead of running the first one in the background.

# Test Plan

Run the install command

# Checklist

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).