### PR TITLE
[image][android] Add `resizeMode: "repeat"` support

### DIFF
--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageModule.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageModule.kt
@@ -2,7 +2,6 @@ package expo.modules.image
 
 import com.bumptech.glide.Glide
 import com.bumptech.glide.load.model.GlideUrl
-import com.bumptech.glide.request.FutureTarget
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
@@ -10,14 +9,7 @@ import com.facebook.react.bridge.ReactMethod
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runInterruptible
 import java.lang.Exception
-
-/**
- * We need to convert blocking java.util.concurrent.Future result
- * into non-blocking suspend function. We use extension function for that
- */
-suspend fun <T> FutureTarget<T>.awaitGet() = runInterruptible(Dispatchers.IO) { get() }
 
 class ExpoImageModule(val context: ReactApplicationContext) : ReactContextBaseJavaModule(context) {
   private val moduleCoroutineScope = CoroutineScope(Dispatchers.IO)

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageView.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageView.kt
@@ -237,7 +237,9 @@ class ExpoImageView(
   }
 
   /**
-   * Called when Glide "injects" drawable into the view
+   * Called when Glide "injects" drawable into the view.
+   * When `resizeMode = REPEAT`, we need to update
+   * received drawable (unless null) and set correct tiling.
    */
   override fun setImageDrawable(drawable: Drawable?) {
     val maybeUpdatedDrawable = drawable

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageView.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageView.kt
@@ -1,14 +1,11 @@
 package expo.modules.image
 
 import android.annotation.SuppressLint
-import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.Canvas
 import android.graphics.PorterDuff
 import android.graphics.Shader
-import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.Drawable
-import android.graphics.drawable.PictureDrawable
 import androidx.appcompat.widget.AppCompatImageView
 import com.bumptech.glide.RequestManager
 import com.bumptech.glide.integration.webp.decoder.WebpDrawable
@@ -16,7 +13,6 @@ import com.bumptech.glide.integration.webp.decoder.WebpDrawableTransformation
 import com.bumptech.glide.load.model.GlideUrl
 import com.bumptech.glide.load.resource.bitmap.FitCenter
 import com.bumptech.glide.request.RequestOptions
-import com.bumptech.glide.request.target.ImageViewTarget
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.modules.i18nmanager.I18nUtil
@@ -155,19 +151,6 @@ class ExpoImageView(
         }
         .apply(propOptions)
         .into(this)
-        // Way 1 - to create anonymous view target and override setResource()
-
-//        .into(object : ImageViewTarget<Drawable>(this) {
-//          override fun setResource(resource: Drawable?) {
-//            if (resource != null && this@ExpoImageView.resizeMode == ImageResizeMode.REPEAT) {
-//              val bitmapDrawable = toBitmapDrawable(resource)
-//              bitmapDrawable.setTileModeXY(Shader.TileMode.REPEAT, Shader.TileMode.REPEAT)
-//              view.setImageDrawable(bitmapDrawable)
-//            } else {
-//              view.setImageDrawable(resource)
-//            }
-//          }
-//        })
 
       requestManager
         .`as`(BitmapFactory.Options::class.java)
@@ -222,19 +205,6 @@ class ExpoImageView(
         }
       }
   }
-
-  // TODO: Investigate performance impact
-  private fun toBitmapDrawable(drawable: Drawable): BitmapDrawable =
-      when (drawable) {
-        is BitmapDrawable -> drawable
-        is PictureDrawable -> {
-          val bitmap = Bitmap.createBitmap(drawable.intrinsicWidth, drawable.intrinsicHeight, Bitmap.Config.ARGB_8888)
-          val canvas = Canvas(bitmap)
-          canvas.drawPicture(drawable.picture)
-          BitmapDrawable(resources, bitmap)
-        }
-        else -> throw IllegalArgumentException("Drawable must be either BitmapDrawable or PictureDrawable")
-      }
   // endregion
 
   // region Drawing overrides
@@ -265,31 +235,18 @@ class ExpoImageView(
       }
     }
   }
-  // endregion
 
-  // region Other overrides
-
-  // Way 2 - to override setImageDrawable which is called in Glide...into(this)
+  /**
+   * Called when Glide "injects" drawable into the view
+   */
   override fun setImageDrawable(drawable: Drawable?) {
-    if (drawable != null && resizeMode == ImageResizeMode.REPEAT) {
-      val bitmapDrawable = toBitmapDrawable(drawable)
-      bitmapDrawable.setTileModeXY(Shader.TileMode.REPEAT, Shader.TileMode.REPEAT)
-      super.setImageDrawable(bitmapDrawable)
-    } else {
-      super.setImageDrawable(drawable)
-    }
+    val maybeUpdatedDrawable = drawable
+      ?.takeIf { resizeMode == ImageResizeMode.REPEAT }
+      ?.toBitmapDrawable(resources)
+      ?.apply {
+        setTileModeXY(Shader.TileMode.REPEAT, Shader.TileMode.REPEAT)
+      }
+    super.setImageDrawable(maybeUpdatedDrawable ?: drawable)
   }
-
-  // probably this is never called - I think we always receive Drawable (method above)
-  override fun setImageBitmap(bm: Bitmap?) {
-    if (bm != null && resizeMode == ImageResizeMode.REPEAT) {
-      val bitmapDrawable = BitmapDrawable(resources, bm)
-      bitmapDrawable.setTileModeXY(Shader.TileMode.REPEAT, Shader.TileMode.REPEAT)
-      super.setImageDrawable(bitmapDrawable)
-    } else {
-      super.setImageBitmap(bm)
-    }
-  }
-
   // endregion
 }

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageView.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageView.kt
@@ -76,7 +76,7 @@ class ExpoImageView(
       field = value?.takeIf { it > 0 }
       propsChanged = true
     }
-  internal var resizeMode = ImageResizeMode.COVER
+  internal var resizeMode = ImageResizeMode.COVER.also { scaleType = it.scaleType }
     set(value) {
       field = value
       scaleType = value.scaleType

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageViewManager.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageViewManager.kt
@@ -52,7 +52,7 @@ class ExpoImageViewManager(applicationContext: ReactApplicationContext) : Simple
   @ReactProp(name = "resizeMode")
   fun setResizeMode(view: ExpoImageView, stringValue: String) {
     val resizeMode = ImageResizeMode.fromStringValue(stringValue)
-    view.setResizeMode(resizeMode)
+    view.resizeMode = resizeMode
   }
 
   @ReactProp(name = "blurRadius")

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ImageUtils.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ImageUtils.kt
@@ -11,15 +11,15 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runInterruptible
 
 /**
- * Converts blocking java.util.concurrent.Future result into non-blocking suspend function.
+ * Converts blocking [java.util.concurrent.Future] result into non-blocking suspend function.
  */
 internal suspend fun <T> FutureTarget<T>.awaitGet(): T = runInterruptible(Dispatchers.IO) { get() }
 
 /**
- * Converts `Drawable` to `BitmapDrawable`
- * Supported drawable types: `PictureDrawable`, `BitmapDrawable`
+ * Converts [Drawable] to [BitmapDrawable]
+ * Supported drawable types: [PictureDrawable], [BitmapDrawable]
  * @param appResources Android application's resources
- * @throws IllegalArgumentException when given `Drawable` is not convertible into bitmap
+ * @throws IllegalArgumentException when conversion of given [Drawable] is not supported
  */
 internal fun Drawable.toBitmapDrawable(appResources: Resources): BitmapDrawable =
   when (this) {

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ImageUtils.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ImageUtils.kt
@@ -1,0 +1,34 @@
+package expo.modules.image
+
+import android.content.res.Resources
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.drawable.BitmapDrawable
+import android.graphics.drawable.Drawable
+import android.graphics.drawable.PictureDrawable
+import com.bumptech.glide.request.FutureTarget
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runInterruptible
+
+/**
+ * Converts blocking java.util.concurrent.Future result into non-blocking suspend function.
+ */
+internal suspend fun <T> FutureTarget<T>.awaitGet(): T = runInterruptible(Dispatchers.IO) { get() }
+
+/**
+ * Converts `Drawable` to `BitmapDrawable`
+ * Supported drawable types: `PictureDrawable`, `BitmapDrawable`
+ * @param appResources Android application's resources
+ * @throws IllegalArgumentException when given `Drawable` is not convertible into bitmap
+ */
+internal fun Drawable.toBitmapDrawable(appResources: Resources): BitmapDrawable =
+  when (this) {
+    is BitmapDrawable -> this
+    is PictureDrawable -> {
+      val bitmap = Bitmap.createBitmap(intrinsicWidth, intrinsicHeight, Bitmap.Config.ARGB_8888)
+      val canvas = Canvas(bitmap)
+      canvas.drawPicture(picture)
+      BitmapDrawable(appResources, bitmap)
+    }
+    else -> throw IllegalArgumentException("Drawable must be either BitmapDrawable or PictureDrawable")
+  }


### PR DESCRIPTION
# Why

To mirror RN `<Image resizeMode="repeat" />` support.

# How

Glide doesn't support repeatable image out of the box. 
What it does is to provide image "resource" into "image view" (`ExpoImageView`).
In our case, the resource is always `android.graphics.Drawable`, because it works with all supported file formats. Other options could be `File`, `Gif` or `Bitmap`.
The drawable is injected into view during `.into(this)` call, but not directly. A [`DrawableImageViewTarget` instance is created](https://github.com/bumptech/glide/blob/master/library/src/main/java/com/bumptech/glide/request/target/ImageViewTargetFactory.java), which is a Glide "target" for `ImageView` components. It [internally uses `view.setImageDrawable(drawable)`](https://github.com/bumptech/glide/blob/10acc31a16b4c1b5684f69e8de3117371dfa77a8/library/src/main/java/com/bumptech/glide/request/target/DrawableImageViewTarget.java#L24) to finally update the view.
There are two places where we can disrupt this process:
1. Create a custom target: `ImaveViewTarget<Drawable>` implementation and manually call `view.setImageDrawable()` there.
2. Override `ImageView.setImageDrawable()` inside `ExpoImageView` as it is called anyway in Glide's internal `DrawableImageViewTarget` implementation. I like this approach more, because it avoids anonymous objects.

`Drawable` is abstract base class for both `BitmapDrawable` and `PictureDrawable` implementations. Only the former supports image tiling (repeating), but some formats (including SVG - [see `SVGDrawableTranscoder.kt`](https://github.com/expo/expo/blob/9b7b1ecefd6bc9d6424acd17d896f7e0712a1d3f/packages/expo-image/android/src/main/java/expo/modules/image/svg/SVGDrawableTranscoder.kt#L20)) give us instance of the latter. So a conversion Picture->Bitmap drawable is needed.
Unfortunately, this conversion requires creating a canvas and re-drawing the image, which may have negative performance impact, but not tested yet

# Test Plan

- [x] bare-expo Image NCL: 
![Screenshot 2021-08-31 at 12 02 10](https://user-images.githubusercontent.com/278340/131486870-b3d9d483-d0f7-49fb-811b-0226e43f510f.png)

# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).