### PR TITLE
[android][expo-manifests] Audit usage of getSDKVersion to ensure lack of requirement

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.kt
@@ -226,7 +226,7 @@ class ExpoUpdatesAppLoader @JvmOverloads constructor(
         override fun onRemoteUpdateManifestLoaded(updateManifest: UpdateManifest) {
           // expo-cli does not always respect our SDK version headers and respond with a compatible update or an error
           // so we need to check the compatibility here
-          val sdkVersion = updateManifest.manifest.getSDKVersionNullable()
+          val sdkVersion = updateManifest.manifest.getSDKVersion()
           if (!isValidSdkVersion(sdkVersion)) {
             callback.onError(formatExceptionForIncompatibleSdk(sdkVersion ?: "null"))
             didAbort = true

--- a/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.kt
@@ -441,7 +441,7 @@ open class ExperienceActivity : BaseExperienceActivity(), StartReactInstanceDele
     task.activityId = activityId
     task.bundleUrl = bundleUrl
 
-    sdkVersion = manifest.getSDKVersionNullable()
+    sdkVersion = manifest.getSDKVersion()
     isShellApp = this.manifestUrl == Constants.INITIAL_URL
 
     // Sometime we want to release a new version without adding a new .aar. Use TEMPORARY_ABI_VERSION

--- a/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.kt
@@ -234,7 +234,7 @@ abstract class ReactNativeActivity :
     if (reactRootViewRNClass != null) {
       return reactRootViewRNClass as Class<out ViewGroup>
     }
-    var sdkVersion = manifest.getSDKVersionNullable()
+    var sdkVersion = manifest.getSDKVersion()
     if (Constants.TEMPORARY_ABI_VERSION != null && Constants.TEMPORARY_ABI_VERSION == this.sdkVersion) {
       sdkVersion = RNObject.UNVERSIONED
     }

--- a/android/expoview/src/main/java/host/exp/exponent/fcm/ExpoFirebaseMessagingDelegate.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/fcm/ExpoFirebaseMessagingDelegate.kt
@@ -48,7 +48,7 @@ class ExpoFirebaseMessagingDelegate(context: Context) : FirebaseMessagingDelegat
       return
     }
 
-    val sdkVersionString = exponentDBObject.manifest.getSDKVersionNullable()
+    val sdkVersionString = exponentDBObject.manifest.getSDKVersion()
     if (sdkVersionString == null) {
       dispatchToNextNotificationModule(remoteMessage)
       return

--- a/android/expoview/src/main/java/host/exp/exponent/headless/InternalHeadlessAppLoader.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/headless/InternalHeadlessAppLoader.kt
@@ -106,7 +106,7 @@ class InternalHeadlessAppLoader(private val context: Context) :
   private fun setManifest(manifestUrl: String, manifest: Manifest, bundleUrl: String?) {
     this.manifestUrl = manifestUrl
     this.manifest = manifest
-    sdkVersion = manifest.getSDKVersionNullable()
+    sdkVersion = manifest.getSDKVersion()
 
     // Notifications logic uses this to determine which experience to route a notification to
     ExponentDB.saveExperience(ExponentDBObject(this.manifestUrl!!, manifest, bundleUrl!!))

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ScopedErrorRecoveryModule.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ScopedErrorRecoveryModule.kt
@@ -13,7 +13,7 @@ class ScopedErrorRecoveryModule(
   val experienceKey: ExperienceKey
 ) : ErrorRecoveryModule(context) {
   override val mSharedPreferences: SharedPreferences = run {
-    val currentSDKVersion = manifest.getSDKVersionNullable()
+    val currentSDKVersion = manifest.getSDKVersion()
     context.applicationContext.getSharedPreferences(
       "$RECOVERY_STORE.$currentSDKVersion",
       Context.MODE_PRIVATE

--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/host/exp/exponent/modules/universal/ScopedErrorRecoveryModule.kt
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/host/exp/exponent/modules/universal/ScopedErrorRecoveryModule.kt
@@ -13,7 +13,7 @@ class ScopedErrorRecoveryModule(
   val experienceKey: ExperienceKey
 ) : ErrorRecoveryModule(context) {
   override val mSharedPreferences: SharedPreferences = run {
-    val currentSDKVersion = manifest.getSDKVersionNullable()
+    val currentSDKVersion = manifest.getSDKVersion()
     context.applicationContext.getSharedPreferences(
       "$RECOVERY_STORE.$currentSDKVersion",
       Context.MODE_PRIVATE

--- a/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/host/exp/exponent/modules/universal/ScopedErrorRecoveryModule.kt
+++ b/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/host/exp/exponent/modules/universal/ScopedErrorRecoveryModule.kt
@@ -13,7 +13,7 @@ class ScopedErrorRecoveryModule(
   val experienceKey: ExperienceKey
 ) : ErrorRecoveryModule(context) {
   override val mSharedPreferences: SharedPreferences = run {
-    val currentSDKVersion = manifest.getSDKVersionNullable()
+    val currentSDKVersion = manifest.getSDKVersion()
     context.applicationContext.getSharedPreferences(
       "$RECOVERY_STORE.$currentSDKVersion",
       Context.MODE_PRIVATE

--- a/android/versioned-abis/expoview-abi41_0_0/src/main/java/abi41_0_0/host/exp/exponent/modules/universal/ScopedErrorRecoveryModule.kt
+++ b/android/versioned-abis/expoview-abi41_0_0/src/main/java/abi41_0_0/host/exp/exponent/modules/universal/ScopedErrorRecoveryModule.kt
@@ -13,7 +13,7 @@ class ScopedErrorRecoveryModule(
   val experienceKey: ExperienceKey
 ) : ErrorRecoveryModule(context) {
   override val mSharedPreferences: SharedPreferences = run {
-    val currentSDKVersion = manifest.getSDKVersionNullable()
+    val currentSDKVersion = manifest.getSDKVersion()
     context.applicationContext.getSharedPreferences(
       "$RECOVERY_STORE.$currentSDKVersion",
       Context.MODE_PRIVATE

--- a/android/versioned-abis/expoview-abi42_0_0/src/main/java/abi42_0_0/host/exp/exponent/modules/universal/ScopedErrorRecoveryModule.kt
+++ b/android/versioned-abis/expoview-abi42_0_0/src/main/java/abi42_0_0/host/exp/exponent/modules/universal/ScopedErrorRecoveryModule.kt
@@ -13,7 +13,7 @@ class ScopedErrorRecoveryModule(
   val experienceKey: ExperienceKey
 ) : ErrorRecoveryModule(context) {
   override val mSharedPreferences: SharedPreferences = run {
-    val currentSDKVersion = manifest.getSDKVersionNullable()
+    val currentSDKVersion = manifest.getSDKVersion()
     context.applicationContext.getSharedPreferences(
       "$RECOVERY_STORE.$currentSDKVersion",
       Context.MODE_PRIVATE

--- a/packages/expo-manifests/android/src/androidTest/java/expo/modules/manifests/core/NewManifestTest.kt
+++ b/packages/expo-manifests/android/src/androidTest/java/expo/modules/manifests/core/NewManifestTest.kt
@@ -15,7 +15,7 @@ class NewManifestTest {
     val manifestJson =
       "{\"runtimeVersion\":\"$runtimeVersion\"}"
     val manifest = NewManifest(JSONObject(manifestJson))
-    Assert.assertEquals(manifest.getSDKVersionNullable(), "39.0.0")
+    Assert.assertEquals(manifest.getSDKVersion(), "39.0.0")
   }
 
   @Test
@@ -33,7 +33,7 @@ class NewManifestTest {
       val manifestJson =
         "{\"runtimeVersion\":\"$runtimeVersion\"}"
       val manifest = NewManifest(JSONObject(manifestJson))
-      Assert.assertNull(manifest.getSDKVersionNullable())
+      Assert.assertNull(manifest.getSDKVersion())
     }
   }
 }

--- a/packages/expo-manifests/android/src/main/java/expo/modules/manifests/core/BaseLegacyManifest.kt
+++ b/packages/expo-manifests/android/src/main/java/expo/modules/manifests/core/BaseLegacyManifest.kt
@@ -20,10 +20,7 @@ abstract class BaseLegacyManifest(json: JSONObject) : Manifest(json) {
   @Throws(JSONException::class)
   override fun getBundleURL(): String = json.require("bundleUrl")
 
-  override fun getSDKVersionNullable(): String? = json.getNullable("sdkVersion")
-
-  @Throws(JSONException::class)
-  override fun getSDKVersion(): String = json.require("sdkVersion")
+  override fun getSDKVersion(): String? = json.getNullable("sdkVersion")
 
   override fun getExpoGoConfigRootObject(): JSONObject? {
     return json

--- a/packages/expo-manifests/android/src/main/java/expo/modules/manifests/core/Manifest.kt
+++ b/packages/expo-manifests/android/src/main/java/expo/modules/manifests/core/Manifest.kt
@@ -69,10 +69,7 @@ abstract class Manifest(protected val json: JSONObject) {
   @Throws(JSONException::class)
   fun getRevisionId(): String = getExpoClientConfigRootObject()!!.require("revisionId")
 
-  abstract fun getSDKVersionNullable(): String?
-
-  @Throws(JSONException::class)
-  abstract fun getSDKVersion(): String
+  abstract fun getSDKVersion(): String?
 
   abstract fun getAssets(): JSONArray?
 

--- a/packages/expo-manifests/android/src/main/java/expo/modules/manifests/core/NewManifest.kt
+++ b/packages/expo-manifests/android/src/main/java/expo/modules/manifests/core/NewManifest.kt
@@ -37,7 +37,7 @@ class NewManifest(json: JSONObject) : Manifest(json) {
   @Throws(JSONException::class)
   override fun getBundleURL(): String = getLaunchAsset().require("url")
 
-  override fun getSDKVersionNullable(): String? {
+  override fun getSDKVersion(): String? {
     val runtimeVersion = getRuntimeVersion()
     val expoSDKRuntimeVersionRegex: Pattern = Pattern.compile("^exposdk:(\\d+\\.\\d+\\.\\d+)$")
     val expoSDKRuntimeVersionMatch: Matcher = expoSDKRuntimeVersionRegex.matcher(runtimeVersion)
@@ -45,12 +45,6 @@ class NewManifest(json: JSONObject) : Manifest(json) {
       return expoSDKRuntimeVersionMatch.group(1)!!
     }
     return null
-  }
-
-  @Throws(JSONException::class)
-  override fun getSDKVersion(): String {
-    return getSDKVersionNullable()
-      ?: throw JSONException("SDKVersion not found for runtimeVersion ${getRuntimeVersion()}")
   }
 
   @Throws(JSONException::class)

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/LegacyUpdateManifest.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/LegacyUpdateManifest.kt
@@ -111,7 +111,7 @@ class LegacyUpdateManifest private constructor(
         }
       }
 
-      val runtimeVersion = manifest.getRuntimeVersion() ?: manifest.getSDKVersion()
+      val runtimeVersion = manifest.getRuntimeVersion() ?: manifest.getSDKVersion() ?: throw Exception("sdkVersion should not be null")
       val bundleUrl = Uri.parse(manifest.getBundleURL())
       val bundledAssets = manifest.getBundledAssets()
       return LegacyUpdateManifest(


### PR DESCRIPTION
# Why

As we move to a world where SDK versions are a special case of a runtime version, we can no longer require them anywhere. This PR audits that and codifies that by making them always nullable in the manifest method.

Closes ENG-1736.

# How

The end result is that all external accesses see this as nullable, and the one internal access (access where the type is known to be a legacy manifest) still sees it as nullable but throws at the callsite (how it is done on iOS: https://github.com/expo/expo/blob/master/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesLegacyUpdate.m#L53).

# Test Plan

Build.