### PR TITLE
[dev-launcher] attempt to fix CI test on Android

### DIFF
--- a/packages/expo-dev-launcher/android/build.gradle
+++ b/packages/expo-dev-launcher/android/build.gradle
@@ -143,7 +143,7 @@ def getRNVersion() {
   def packageJson = new JsonSlurper().parseText(packageJsonFile.text)
   def version = safeExtGet("reactNativeVersion", packageJson.dependencies["react-native"])
 
-  def coreVersion = version.split("-")[0]
+  def coreVersion = version.replace('~', '').split("-")[0]
 
   def (major, minor, patch) = coreVersion.tokenize('.').collect { it.toInteger() }
 


### PR DESCRIPTION
# Why

As far I can understand the issue on the Android CI looks like it is originated by the build-in `package.json` version parser, which fails when passed `major` includes the semver prefix.

# How

This fix is very basic, in the future should be replaced by Regex or filter (maybe `isLetterOrDigit` used wise?) of some kind to cover more cases like `^`.

# Test Plan

Run the Dev Client CI.