### PR TITLE
[shared-element] Update react-native-shared-element to 0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Package-specific changes not released in any SDK will be added here just before 
 
 ### 📚 3rd party library updates
 
+- Updated `react-native-shared-element` from `0.7.0` to `0.8.2`. ([#14245](https://github.com/expo/expo/pull/14245) by [@IjzerenHein](https://github.com/IjzerenHein))
+
 ### 🛠 Breaking changes
 
 ### 🎉 New features

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/sharedelement/RNSharedElementContent.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/sharedelement/RNSharedElementContent.java
@@ -18,11 +18,9 @@ class RNSharedElementContent {
       GenericDraweeView imageView = (GenericDraweeView) view;
       DraweeController controller = imageView.getController();
       GenericDraweeHierarchy hierarchy = imageView.getHierarchy();
-      String controllerDetails = controller.toString();
-      if (controllerDetails.contains("fetchedImage=0,")) {
+      if (controller == null || controller.toString().contains("fetchedImage=0,")) {
         return null;
       }
-      Drawable drawable = imageView.getDrawable();
       RectF imageBounds = new RectF();
       hierarchy.getActualImageBounds(imageBounds);
       return imageBounds;

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/sharedelement/RNSharedElementDrawable.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/sharedelement/RNSharedElementDrawable.java
@@ -1,6 +1,6 @@
 package versioned.host.exp.exponent.modules.api.components.sharedelement;
 
-import android.util.Log;
+// import android.util.Log;
 import android.view.View;
 import android.graphics.Rect;
 import android.graphics.RectF;
@@ -18,7 +18,6 @@ import com.facebook.react.views.view.ReactViewGroup;
 import com.facebook.react.views.view.ReactViewBackgroundDrawable;
 
 import com.facebook.drawee.generic.GenericDraweeHierarchy;
-import com.facebook.drawee.interfaces.DraweeController;
 import com.facebook.drawee.drawable.ScalingUtils.ScaleType;
 import com.facebook.drawee.generic.RoundingParams;
 
@@ -41,7 +40,7 @@ class RNSharedElementDrawable extends Drawable {
     }
   }
 
-  static private String LOG_TAG = "RNSharedElementDrawable";
+  // static final private String LOG_TAG = "RNSharedElementDrawable";
 
   private RNSharedElementContent mContent = null;
   private RNSharedElementStyle mStyle = null;
@@ -88,25 +87,17 @@ class RNSharedElementDrawable extends Drawable {
       switch (viewType) {
         case REACTIMAGEVIEW:
         case IMAGEVIEW:
-          if ((mStyle.compare(style) &
+          //Log.d(LOG_TAG, "drawableChanged, viewType: " + viewType + ", changes: " + mStyle.compare(style));
+          invalidated = (mStyle.compare(style) &
                   (RNSharedElementStyle.PROP_BORDER
                           | RNSharedElementStyle.PROP_BACKGROUND_COLOR
-                          | RNSharedElementStyle.PROP_SCALETYPE)) != 0) {
-            //Log.d(LOG_TAG, "drawableChanged, viewType: " + viewType + ", changes: " + mStyle.compare(style));
-            invalidated = true;
-          } else {
-            invalidated = false;
-          }
+                          | RNSharedElementStyle.PROP_SCALETYPE)) != 0;
           break;
         case PLAIN:
-          if ((mStyle.compare(style) &
+          //Log.d(LOG_TAG, "drawableChanged, viewType: " + viewType + ", changes: " + mStyle.compare(style));
+          invalidated = (mStyle.compare(style) &
                   (RNSharedElementStyle.PROP_BORDER
-                          | RNSharedElementStyle.PROP_BACKGROUND_COLOR)) != 0) {
-            //Log.d(LOG_TAG, "drawableChanged, viewType: " + viewType + ", changes: " + mStyle.compare(style));
-            invalidated = true;
-          } else {
-            invalidated = false;
-          }
+                          | RNSharedElementStyle.PROP_BACKGROUND_COLOR)) != 0;
           break;
         case GENERIC:
           // nop
@@ -118,7 +109,7 @@ class RNSharedElementDrawable extends Drawable {
     // Update position
     mPosition = position;
 
-    // Invalidate if neccessary
+    // Invalidate if necessary
     if (invalidated) {
       invalidateSelf();
     }
@@ -236,7 +227,6 @@ class RNSharedElementDrawable extends Drawable {
 
     ReactImageView imageView = (ReactImageView) mContent.view;
     RNSharedElementStyle style = mStyle;
-    DraweeController controller = imageView.getController();
     GenericDraweeHierarchy hierarchy = imageView.getHierarchy();
     Drawable drawable = hierarchy.getTopLevelDrawable();
 
@@ -315,8 +305,8 @@ class RNSharedElementDrawable extends Drawable {
     drawable.setColor(style.backgroundColor);
 
     // Set border
-    float borderColorRGB = (float) ((int) style.borderColor & 0x00FFFFFF);
-    float borderColorAlpha = (float) ((int) style.borderColor >>> 24);
+    float borderColorRGB = (float) (style.borderColor & 0x00FFFFFF);
+    float borderColorAlpha = (float) (style.borderColor >>> 24);
     drawable.setBorderStyle(style.borderStyle);
     for (int i = 0; i < 4; i++) {
       drawable.setBorderColor(i, borderColorRGB, borderColorAlpha);

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/sharedelement/RNSharedElementModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/sharedelement/RNSharedElementModule.java
@@ -1,27 +1,28 @@
 package versioned.host.exp.exponent.modules.api.components.sharedelement;
 
+import androidx.annotation.NonNull;
+
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableMap;
-import com.facebook.react.uimanager.UIBlock;
 import com.facebook.react.uimanager.UIManagerModule;
-import com.facebook.react.uimanager.NativeViewHierarchyManager;
 import com.facebook.react.module.annotations.ReactModule;
 
 @ReactModule(name = RNSharedElementModule.MODULE_NAME)
 public class RNSharedElementModule extends ReactContextBaseJavaModule {
   public static final String MODULE_NAME = "RNSharedElementTransition";
-  static String LOG_TAG = "RNSharedElementModule";
+  // private final static String LOG_TAG = "RNSharedElementModule";
 
-  private RNSharedElementNodeManager mNodeManager;
+  private final RNSharedElementNodeManager mNodeManager;
 
   public RNSharedElementModule(ReactApplicationContext reactContext) {
     super(reactContext);
     mNodeManager = new RNSharedElementNodeManager(reactContext);
   }
 
+  @NonNull
   @Override
   public String getName() {
     return MODULE_NAME;
@@ -39,11 +40,8 @@ public class RNSharedElementModule extends ReactContextBaseJavaModule {
     // start- and end props are set on the Transition view.
     final ReactApplicationContext context = getReactApplicationContext();
     final UIManagerModule uiManager = context.getNativeModule(UIManagerModule.class);
-    uiManager.prependUIBlock(new UIBlock() {
-      @Override
-      public void execute(NativeViewHierarchyManager nativeViewHierarchyManager) {
-        mNodeManager.setNativeViewHierarchyManager(nativeViewHierarchyManager);
-      }
-    });
+    uiManager.prependUIBlock(mNodeManager::setNativeViewHierarchyManager);
+
+    promise.resolve(true);
   }
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/sharedelement/RNSharedElementNode.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/sharedelement/RNSharedElementNode.java
@@ -29,15 +29,15 @@ abstract class RetryRunnable implements Runnable {
 }
 
 class RNSharedElementNode {
-  static private String LOG_TAG = "RNSharedElementNode";
+  static private final String LOG_TAG = "RNSharedElementNode";
 
-  private Context mContext;
-  private int mReactTag;
+  private final Context mContext;
+  private final int mReactTag;
   private View mView;
   private View mAncestorView;
-  private boolean mIsParent;
+  private final boolean mIsParent;
   private ReadableMap mStyleConfig;
-  private RNSharedElementStyle mResolveStyle;
+  private final RNSharedElementStyle mResolveStyle;
   private View mResolvedView;
   private int mRefCount;
   private int mHideRefCount;
@@ -150,7 +150,7 @@ class RNSharedElementNode {
       if (childCount == 1) {
         view = ((ViewGroup) mView).getChildAt(0);
       } else if (childCount <= 0) {
-        Log.d(LOG_TAG, "Child for parent doesnt exist");
+        Log.d(LOG_TAG, "Child for parent doesn't exist");
         return null;
       }
     }
@@ -163,7 +163,7 @@ class RNSharedElementNode {
       callback.invoke(mStyleCache, this);
       return;
     }
-    if (mStyleCallbacks == null) mStyleCallbacks = new ArrayList<Callback>();
+    if (mStyleCallbacks == null) mStyleCallbacks = new ArrayList<>();
     mStyleCallbacks.add(callback);
     if (!fetchInitialStyle()) {
       startRetryLoop();
@@ -181,34 +181,16 @@ class RNSharedElementNode {
     int width = view.getWidth();
     int height = view.getHeight();
     if (width == 0 && height == 0) return false;
-    Matrix transform = RNSharedElementStyle.getAbsoluteViewTransform(view, true);
-    Matrix ancestorTransform = RNSharedElementStyle.getAbsoluteViewTransform(mAncestorView, true);
+    Matrix transform = RNSharedElementStyle.getAbsoluteViewTransform(view);
+    Matrix ancestorTransform = RNSharedElementStyle.getAbsoluteViewTransform(mAncestorView);
     if ((transform == null) || (ancestorTransform == null)) return false;
     Rect frame = new Rect(left, top, left + width, top + height);
 
-    // Get absolute position on screen (left/top)
-    int[] location = new int[2];
-    view.getLocationOnScreen(location);
-    left = location[0];
-    top = location[1];
-
-    // In case the view has a scale transform applied, the calculate
-    // the correct visual width & height of the view
-    float[] f = new float[9];
-    transform.getValues(f);
-    float scaleX = f[Matrix.MSCALE_X];
-    float scaleY = f[Matrix.MSCALE_Y];
-    width = (int) ((float) width * scaleX);
-    height = (int) ((float) height * scaleY);
-
-    // Create absolute layout rect
-    Rect layout = new Rect(left, top, left + width, top + height);
-
     // Create style
     RNSharedElementStyle style = new RNSharedElementStyle(mStyleConfig, mContext);
-    style.layout = layout;
+    RNSharedElementStyle.getLayoutOnScreen(view, style.layout);
     style.frame = frame;
-    style.transform = transform;
+    RNSharedElementStyle.getLayoutOnScreen(mAncestorView, style.ancestorLayout);
     style.ancestorTransform = ancestorTransform;
 
     // Get opacity
@@ -238,7 +220,7 @@ class RNSharedElementNode {
       callback.invoke(mContentCache, this);
       return;
     }
-    if (mContentCallbacks == null) mContentCallbacks = new ArrayList<Callback>();
+    if (mContentCallbacks == null) mContentCallbacks = new ArrayList<>();
     mContentCallbacks.add(callback);
     if (!fetchInitialContent()) {
       startRetryLoop();
@@ -288,7 +270,7 @@ class RNSharedElementNode {
     //Log.d(LOG_TAG, "Starting retry loop...");
 
     mRetryHandler = new Handler();
-    final long startTime = System.nanoTime();
+    // final long startTime = System.nanoTime();
     mRetryHandler.postDelayed(new RetryRunnable() {
 
       @Override

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/sharedelement/RNSharedElementNodeManager.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/sharedelement/RNSharedElementNodeManager.java
@@ -10,9 +10,9 @@ import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.uimanager.NativeViewHierarchyManager;
 
 class RNSharedElementNodeManager {
-  private Map<Integer, RNSharedElementNode> mNodes = new HashMap<Integer, RNSharedElementNode>();
+  private final Map<Integer, RNSharedElementNode> mNodes = new HashMap<>();
   private NativeViewHierarchyManager mNativeViewHierarchyManager;
-  private Context mContext;
+  private final Context mContext;
 
   RNSharedElementNodeManager(Context context) {
     mContext = context;

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/sharedelement/RNSharedElementPackage.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/sharedelement/RNSharedElementPackage.java
@@ -1,5 +1,7 @@
 package versioned.host.exp.exponent.modules.api.components.sharedelement;
 
+import androidx.annotation.NonNull;
+
 import java.util.*;
 
 import com.facebook.react.ReactPackage;
@@ -9,13 +11,15 @@ import com.facebook.react.uimanager.ViewManager;
 
 public class RNSharedElementPackage implements ReactPackage {
 
+  @NonNull
   @Override
-  public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
-    return Arrays.<NativeModule>asList(new RNSharedElementModule(reactContext));
+  public List<NativeModule> createNativeModules(@NonNull ReactApplicationContext reactContext) {
+    return Collections.singletonList(new RNSharedElementModule(reactContext));
   }
 
+  @NonNull
   @Override
-  public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
-    return Arrays.<ViewManager>asList(new RNSharedElementTransitionManager(reactContext));
+  public List<ViewManager> createViewManagers(@NonNull ReactApplicationContext reactContext) {
+    return Collections.singletonList(new RNSharedElementTransitionManager(reactContext));
   }
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/sharedelement/RNSharedElementTransitionItem.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/sharedelement/RNSharedElementTransitionItem.java
@@ -1,23 +1,23 @@
 package versioned.host.exp.exponent.modules.api.components.sharedelement;
 
-import android.util.Log;
+// import android.util.Log;
 import android.view.View;
 import android.view.ViewParent;
 import android.view.ViewGroup;
-import android.graphics.Rect;
+import android.graphics.RectF;
 
 class RNSharedElementTransitionItem {
-  static private String LOG_TAG = "RNSharedElementTransitionItem";
+  // static private final String LOG_TAG = "RNSharedElementTransitionItem";
 
-  private RNSharedElementNodeManager mNodeManager;
-  private String mName;
+  private final RNSharedElementNodeManager mNodeManager;
+  private final String mName;
   private RNSharedElementNode mNode;
   private boolean mHidden;
   private boolean mNeedsStyle;
   private RNSharedElementStyle mStyle;
   private boolean mNeedsContent;
   private RNSharedElementContent mContent;
-  private Rect mClippedLayoutCache;
+  private RectF mClippedLayoutCache;
   private boolean mHasCalledOnMeasure;
 
   RNSharedElementTransitionItem(RNSharedElementNodeManager nodeManager, String name) {
@@ -119,29 +119,23 @@ class RNSharedElementTransitionItem {
     return (mNode != null) ? mNode.getResolvedView() : null;
   }
 
-  Rect getClippedLayout() {
+  RectF getClippedLayout() {
     if (mClippedLayoutCache != null) return mClippedLayoutCache;
     if (mStyle == null) return null;
 
-    View view = getView();
     View ancestorView = mNode.getAncestorView();
 
     // Get visible area (some parts may be clipped in a scrollview or something)
-    Rect clippedLayout = new Rect(mStyle.layout);
-    ViewParent parentView = view.getParent();
-    int[] location = new int[2];
-    Rect bounds = new Rect();
+    RectF clippedLayout = new RectF(mStyle.layout);
+    ViewParent parentView = getView().getParent();
+    RectF bounds = new RectF();
     while (parentView != null) {
       if (!(parentView instanceof ViewGroup)) break;
       ViewGroup viewGroup = (ViewGroup) parentView;
-      viewGroup.getLocationOnScreen(location);
-
-      bounds.left = location[0];
-      bounds.top = location[1];
-      bounds.right = location[0] + (viewGroup.getWidth());
-      bounds.bottom = location[1] + (viewGroup.getHeight());
 
       if (viewGroup.getClipChildren()) {
+        RNSharedElementStyle.getLayoutOnScreen(viewGroup, bounds);
+
         if (!clippedLayout.intersect(bounds)) {
           if (clippedLayout.bottom < bounds.top) {
             clippedLayout.top = bounds.top;
@@ -165,7 +159,6 @@ class RNSharedElementTransitionItem {
       if (parentView == ancestorView) {
         break;
       }
-      view = (View) parentView;
       parentView = parentView.getParent();
     }
 

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/sharedelement/RNSharedElementTransitionManager.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/sharedelement/RNSharedElementTransitionManager.java
@@ -4,12 +4,14 @@ import java.util.Map;
 
 import android.view.View;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.SimpleViewManager;
 import com.facebook.react.bridge.ReadableMap;
-import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactApplicationContext;
 
 public class RNSharedElementTransitionManager extends SimpleViewManager<RNSharedElementTransition> {
@@ -19,14 +21,16 @@ public class RNSharedElementTransitionManager extends SimpleViewManager<RNShared
     super();
   }
 
+  @NonNull
   @Override
   public String getName() {
     return REACT_CLASS;
   }
 
+  @Nullable
   @Override
-  public Map getExportedCustomBubblingEventTypeConstants() {
-    return MapBuilder.builder()
+  public Map<String, Object> getExportedCustomBubblingEventTypeConstants() {
+    return MapBuilder.<String, Object>builder()
             .put(
                     "onMeasureNode",
                     MapBuilder.of(
@@ -35,14 +39,15 @@ public class RNSharedElementTransitionManager extends SimpleViewManager<RNShared
             .build();
   }
 
+  @NonNull
   @Override
   public RNSharedElementTransition createViewInstance(ThemedReactContext reactContext) {
-    RNSharedElementModule module = (RNSharedElementModule) reactContext.getNativeModule(RNSharedElementModule.class);
+    RNSharedElementModule module = reactContext.getNativeModule(RNSharedElementModule.class);
     return new RNSharedElementTransition(reactContext, module.getNodeManager());
   }
 
   @Override
-  public void onDropViewInstance(RNSharedElementTransition view) {
+  public void onDropViewInstance(@NonNull RNSharedElementTransition view) {
     super.onDropViewInstance(view);
     view.releaseData();
   }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/sharedelement/RNSharedElementView.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/sharedelement/RNSharedElementView.java
@@ -1,6 +1,6 @@
 package versioned.host.exp.exponent.modules.api.components.sharedelement;
 
-import android.util.Log;
+// import android.util.Log;
 import android.view.View;
 import android.graphics.Rect;
 import android.graphics.RectF;
@@ -8,9 +8,9 @@ import android.graphics.RectF;
 import com.facebook.react.uimanager.ThemedReactContext;
 
 class RNSharedElementView extends View {
-  static private String LOG_TAG = "RNSharedElementView";
+  // static private final String LOG_TAG = "RNSharedElementView";
 
-  private RNSharedElementDrawable mDrawable;
+  private final RNSharedElementDrawable mDrawable;
   private RNSharedElementDrawable.ViewType mViewType;
 
   RNSharedElementView(ThemedReactContext context) {
@@ -32,7 +32,7 @@ class RNSharedElementView extends View {
   void updateViewAndDrawable(
           RectF layout,
           RectF parentLayout,
-          Rect originalLayout,
+          RectF originalLayout,
           Rect originalFrame,
           RNSharedElementContent content,
           RNSharedElementStyle style,
@@ -77,8 +77,8 @@ class RNSharedElementView extends View {
             break;
           case CLIP:
           case NONE:
-            scaleX = (float) originalWidth / (float) originalLayout.width();
-            scaleY = (float) originalHeight / (float) originalLayout.height();
+            scaleX = (float) originalWidth / originalLayout.width();
+            scaleY = (float) originalHeight / originalLayout.height();
             break;
         }
 

--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -677,7 +677,7 @@ PODS:
   - RNScreens (3.4.0):
     - React-Core
     - React-RCTImage
-  - RNSharedElement (0.7.0):
+  - RNSharedElement (0.8.2):
     - React
   - RNSVG (12.1.1):
     - React
@@ -1297,7 +1297,7 @@ SPEC CHECKSUMS:
   RNGestureHandler: e66feb0fda7da74ea6a3094656b3c1efe05f5c07
   RNReanimated: 9c13c86454bfd54dab7505c1a054470bfecd2563
   RNScreens: 21b73c94c9117e1110a79ee0ee80c93ccefed8ce
-  RNSharedElement: 00b1a1420d213a34459bb9a5aacabb38107d7948
+  RNSharedElement: 87baf6d04da5b068f000dd8c953d28a1196999c0
   RNSVG: 551acb6562324b1d52a4e0758f7ca0ec234e278f
   SDWebImage: 7acbb57630ac7db4a495547fb73916ff3e432f6b
   SDWebImageSVGKitPlugin: 8797e1c9b9baf80bd50d28e673e16a12359af1c9

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -117,7 +117,7 @@
     "react-native-reanimated": "~2.2.0",
     "react-native-safe-area-context": "3.2.0",
     "react-native-screens": "~3.4.0",
-    "react-native-shared-element": "0.7.0",
+    "react-native-shared-element": "0.8.2",
     "react-native-svg": "12.1.1",
     "react-native-unimodules": "~0.15.0-alpha.0",
     "react-native-view-shot": "3.1.2",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -161,7 +161,7 @@
     "react-native-web": "~0.17.1",
     "react-native-webview": "11.6.2",
     "react-navigation": "^4.4.0",
-    "react-navigation-shared-element": "^3.0.0",
+    "react-navigation-shared-element": "^3.1.2",
     "react-navigation-stack": "^2.8.2",
     "regl": "^1.3.0",
     "three": "^0.115.0",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -154,7 +154,7 @@
     "react-native-safe-area-context": "3.2.0",
     "react-native-safe-area-view": "^0.14.8",
     "react-native-screens": "~3.4.0",
-    "react-native-shared-element": "0.7.0",
+    "react-native-shared-element": "0.8.2",
     "react-native-svg": "12.1.1",
     "react-native-unimodules": "~0.15.0-alpha.0",
     "react-native-view-shot": "3.1.2",

--- a/apps/native-component-list/src/screens/SharedElementScreen.tsx
+++ b/apps/native-component-list/src/screens/SharedElementScreen.tsx
@@ -12,8 +12,6 @@ const Stack = createSharedElementStackNavigator();
 export function DetailScreen() {
   return (
     <View style={styles.detailContainer}>
-      {/* `style` isn't properly typed on SharedElement
-    // @ts-ignore */}
       <SharedElement id="image" style={StyleSheet.absoluteFill}>
         <Image
           style={styles.detailImage}
@@ -28,11 +26,7 @@ export function DetailScreen() {
   );
 }
 
-interface Props {
-  navigation: StackNavigationProp<{ Detail: undefined }>;
-}
-
-function MainScreen({ navigation }: Props) {
+function MainScreen({ navigation }: { navigation: StackNavigationProp<{ Detail: undefined }> }) {
   return (
     <TouchableOpacity
       style={styles.flex}

--- a/ios/Exponent.xcodeproj/project.pbxproj
+++ b/ios/Exponent.xcodeproj/project.pbxproj
@@ -5,7 +5,6 @@
 	};
 	objectVersion = 46;
 	objects = {
-
 /* Begin PBXBuildFile section */
 		0726F0592007E438004992E7 /* EXKernelAppRecord.m in Sources */ = {isa = PBXBuildFile; fileRef = 0726F0582007E438004992E7 /* EXKernelAppRecord.m */; };
 		0726F05C2007E446004992E7 /* EXKernelAppRegistry.m in Sources */ = {isa = PBXBuildFile; fileRef = 0726F05B2007E446004992E7 /* EXKernelAppRegistry.m */; };

--- a/ios/Exponent/Versioned/Core/Api/Components/SharedElement/RNSharedElementTransition.h
+++ b/ios/Exponent/Versioned/Core/Api/Components/SharedElement/RNSharedElementTransition.h
@@ -17,11 +17,11 @@
 @property (nonatomic, assign) RNSharedElementAnimation animation;
 @property (nonatomic, assign) RNSharedElementResize resize;
 @property (nonatomic, assign) RNSharedElementAlign align;
-@property (nonatomic, assign) RNSharedElementNode* startNode;
-@property (nonatomic, assign) RNSharedElementNode* startAncestor;
+@property (nonatomic, strong) RNSharedElementNode* startNode;
+@property (nonatomic, strong) RNSharedElementNode* startAncestor;
 @property (nonatomic, copy) RCTDirectEventBlock onMeasureNode;
-@property (nonatomic, assign) RNSharedElementNode* endNode;
-@property (nonatomic, assign) RNSharedElementNode* endAncestor;
+@property (nonatomic, strong) RNSharedElementNode* endNode;
+@property (nonatomic, strong) RNSharedElementNode* endAncestor;
 
 - (instancetype)initWithNodeManager:(RNSharedElementNodeManager*)nodeManager;
 

--- a/ios/Exponent/Versioned/Core/Api/Components/SharedElement/RNSharedElementTransitionItem.h
+++ b/ios/Exponent/Versioned/Core/Api/Components/SharedElement/RNSharedElementTransitionItem.h
@@ -13,13 +13,13 @@
 @property (nonatomic, readonly) RNSharedElementNodeManager* nodeManager;
 @property (nonatomic, readonly) BOOL isAncestor;
 @property (nonatomic, readonly) NSString* name;
-@property (nonatomic, assign) RNSharedElementNode* node;
+@property (nonatomic, strong) RNSharedElementNode* node;
 @property (nonatomic, assign) BOOL hidden;
 @property (nonatomic, assign) BOOL needsLayout;
 @property (nonatomic, assign) BOOL needsContent;
 @property (nonatomic, assign) BOOL hasCalledOnMeasure;
-@property (nonatomic, assign) RNSharedElementStyle* style;
-@property (nonatomic, assign) RNSharedElementContent* content;
+@property (nonatomic, strong) RNSharedElementStyle* style;
+@property (nonatomic, strong) RNSharedElementContent* content;
 
 - (instancetype)initWithNodeManager:(RNSharedElementNodeManager*)nodeManager name:(NSString*)name isAncestor:(BOOL)isAncestor;
 

--- a/ios/Exponent/Versioned/Core/Api/Components/SharedElement/RNSharedElementTransitionManager.m
+++ b/ios/Exponent/Versioned/Core/Api/Components/SharedElement/RNSharedElementTransitionManager.m
@@ -39,7 +39,7 @@ RCT_EXPORT_MODULE(RNSharedElementTransition);
 {
   if (json == nil) return nil;
   NSNumber* nodeHandle = [json valueForKey:@"nodeHandle"];
-  NSNumber* isParent =[json valueForKey:@"isParent"];
+  NSNumber* isParent = [json valueForKey:@"isParent"];
   if ([nodeHandle isKindOfClass:[NSNumber class]]) {
     UIView *sourceView = [self.bridge.uiManager viewForReactTag:nodeHandle];
     return [_nodeManager acquire:nodeHandle view:sourceView isParent:[isParent boolValue]];

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -96,7 +96,7 @@
   "react-native-reanimated": "~2.2.0",
   "react-native-safe-area-context": "3.2.0",
   "react-native-screens": "~3.4.0",
-  "react-native-shared-element": "0.7.0",
+  "react-native-shared-element": "0.8.2",
   "react-native-svg": "12.1.1",
   "react-native-unimodules": "~0.15.0-alpha.0",
   "react-native-view-shot": "3.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19583,10 +19583,10 @@ react-native-scrollable-mixin@^1.0.0:
   resolved "https://registry.yarnpkg.com/react-native-scrollable-mixin/-/react-native-scrollable-mixin-1.0.1.tgz#34a32167b64248594154fd0d6a8b03f22740548e"
   integrity sha1-NKMhZ7ZCSFlBVP0NaosD8idAVI4=
 
-react-native-shared-element@0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/react-native-shared-element/-/react-native-shared-element-0.7.0.tgz#c5e02eb372f6e38e48eb1030fd59be8f3d8c7a1f"
-  integrity sha512-TJTGwQceABYete+vH3ahNSgzVzXz7X2SPv3thT91gdcFCrm7ht7IKXBXJiYjOA+4TfdqnGEAWkspCy80oEnOgw==
+react-native-shared-element@0.8.2:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/react-native-shared-element/-/react-native-shared-element-0.8.2.tgz#64124ec7e19369b78b6924c93808e1ed058c8109"
+  integrity sha512-IalCG1Sn6Vq171JMh0cbHzf0dJxwUIGwf5baxWhZ6busLQ2AL0A0pFb86sLgOUtv+NZdZX2R1Xd+Ylqj8neuLw==
 
 react-native-svg@12.1.1:
   version "12.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -19622,10 +19622,10 @@ react-native-webview@11.6.2:
     escape-string-regexp "2.0.0"
     invariant "2.2.4"
 
-react-navigation-shared-element@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/react-navigation-shared-element/-/react-navigation-shared-element-3.0.0.tgz#3dfa6a71f138e4ceb457a91aea3ef2a8ab2a6a32"
-  integrity sha512-nSmbgf4+hKSZU1Rzi5Bm1Is5mt0Z+xY5sXeTx4t5KMnmNW4lz5M83p9oTW6mKDoXUeCocUfeVwbCmsAjlyTLQw==
+react-navigation-shared-element@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/react-navigation-shared-element/-/react-navigation-shared-element-3.1.2.tgz#9e79c141ebb3a56ab01227c25cbf12a66d360c27"
+  integrity sha512-TQ7WEjgoJZMqK4gCzQN/PcuoPEuiAKBjyAW6qmy5HONXx1HkXJ4JK1n20FYchidJWuHRjhheHpdyCuilSMCPcg==
   dependencies:
     hoist-non-react-statics "^3.3.2"
 


### PR DESCRIPTION
# Why

Updates `react-native-shared-element` to version `0.8.2`. This fixes various rendering issues on both Android and iOS, as well as adds support for React Native 0.65.

https://github.com/IjzerenHein/react-native-shared-element/releases

# How

- `et update-vendored-module --module react-native-shared-element --commit main`
- Updated Shared Element test in `test-suite` (to `react-navigation-shared-element@3.1.2`)
- Ran `npx pod install` in `apps/bare-expo/ios`
- Updated global `CHANGELOG.md`

# Test Plan

- Build and ran Expo Go on iOS (using XCode 12.5.1) (see video below)
- Build and ran Expo Go on Android Emulator (Pixel 2, API 30) (see video below)

**shared-element in test-suite on iOS**

https://user-images.githubusercontent.com/6184593/131666541-4be55b8f-98b6-4df4-889e-db7daa4eeca3.mp4

** shared-element in test-suite on Android**

https://user-images.githubusercontent.com/6184593/131828291-68cf95a3-af25-490c-af4c-60b526390a5b.mp4


