### PR TITLE
[expo-dev-launcher] fix RN version checker in build.gradle

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -6,7 +6,11 @@
 
 ### 🎉 New features
 
+- Fix compatibility with RN 0.65. ([#14064](https://github.com/expo/expo/pull/14064) by [@lukmccall](https://github.com/lukmccall))
+
 ### 🐛 Bug fixes
+
+- Fix React Native version checker in build.gradle.
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix React Native version checker in build.gradle.
+- Fix React Native version checker in build.gradle. ([#14251](https://github.com/expo/expo/pull/14251) by [@esamelson](https://github.com/esamelson))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/android/build.gradle
+++ b/packages/expo-dev-launcher/android/build.gradle
@@ -139,9 +139,10 @@ def versionToNumber(major, minor, patch) {
 }
 
 def getRNVersion() {
-  def packageJsonFile = new File(rootProject.projectDir, '../package.json')
+  def reactNativePackageJsonPath = ["node", "-e", "console.log(require.resolve('react-native/package.json'));"].execute([], projectDir).text.trim()
+  def packageJsonFile = new File(reactNativePackageJsonPath)
   def packageJson = new JsonSlurper().parseText(packageJsonFile.text)
-  def version = safeExtGet("reactNativeVersion", packageJson.dependencies["react-native"])
+  def version = safeExtGet("reactNativeVersion", packageJson.version)
 
   def coreVersion = version.split("-")[0]
 


### PR DESCRIPTION
# Why

Fix dev client CI job, regression introduced in #14064 .

The getRNVersion method that was added to build.gradle was reading the RN version from the root package dependencies, which is inaccurate but also couldn't handle the `~` or `^` character, which was causing the failure.

# How

Use `require.resolve` to find the location of the react-native node module and use `version` from its package.json, which should be more accurate and also shouldn't include illegal characters.

# Test Plan

Build succeeds locally, let's see about CI...

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).