### PR TITLE
[video-thumbnails] Fix thumbnail generator tolerances to 0

### DIFF
--- a/packages/expo-video-thumbnails/CHANGELOG.md
+++ b/packages/expo-video-thumbnails/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Set thumbnail generator tolerances to 0 in order to accurately retrieve an image at a specific time. ([#14253](https://github.com/expo/expo/pull/14253) by [@tamagokun](https://github.com/tamagokun))
+
 ### 💡 Others
 
 - Migrated from `@unimodules/core` to `expo-modules-core`. ([#13757](https://github.com/expo/expo/pull/13757) by [@tsapeta](https://github.com/tsapeta))

--- a/packages/expo-video-thumbnails/ios/EXVideoThumbnails/EXVideoThumbnailsModule.m
+++ b/packages/expo-video-thumbnails/ios/EXVideoThumbnails/EXVideoThumbnailsModule.m
@@ -42,6 +42,8 @@ EX_EXPORT_METHOD_AS(getThumbnail,
   AVURLAsset *asset = [[AVURLAsset alloc] initWithURL:url options:@{@"AVURLAssetHTTPHeaderFieldsKey": headers}];
   AVAssetImageGenerator *generator = [[AVAssetImageGenerator alloc] initWithAsset:asset];
   generator.appliesPreferredTrackTransform = YES;
+  generator.requestedTimeToleranceBefore = kCMTimeZero;
+  generator.requestedTimeToleranceAfter = kCMTimeZero;
 
   NSError *err = NULL;
   CMTime time = CMTimeMake(timeInMs, 1000);


### PR DESCRIPTION
Set tolerances to 0 so that we get a thumbnail for the exact frame. This seems like it should be the default behavior for this function.

# Why

If we specify a specific time in the video, we expect to get a frame at that exact moment in the video. Maybe these tolerances can be something greater than 0, but small enough to not be noticeable within 1 ms (if possible).

This issue illustrates the existing problem: https://github.com/expo/expo/issues/10400

# How


<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

Use `VideoThumbnails.getThumbnailAsync(videoUrl, {time: 2025})` to get a thumbnail and compare it with the actual video seeked to that position. 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).