### PR TITLE
[expo-modules-core] Fix generated ExpoModulesPackageList cannot access core

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - Fix `'-[RCTModuleRegistry getAllExportedModules]: unrecognized selector` crash while adding the event listener. ([#14130](https://github.com/expo/expo/pull/14130) by [@lukmccall](https://github.com/lukmccall))
+- Fix generated ExpoModulesPackageList cannot find package expo.modules.core.interfaces. ([#14256](https://github.com/expo/expo/pull/14256) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/android-linker/build.gradle
+++ b/packages/expo-modules-core/android-linker/build.gradle
@@ -81,6 +81,7 @@ android {
 }
 
 dependencies { dependencyHandler ->
+  implementation project(':expo-modules-core')
   // Link expo modules as dependencies of the adapter. It uses `api` configuration so they all will be visible for the app as well.
   // A collection of the dependencies depends on the options passed to `useExpoModules` in your project's `settings.gradle`.
   addExpoModulesDependencies(dependencyHandler, project)


### PR DESCRIPTION
# Why

fix building errors on android

```
> Task :expo-modules-core:compileDebugJavaWithJavac FAILED
/Users/kudo/01_Work/Repos/expo/expo/packages/expo-modules-core/android-linker/build/generated/expo/src/main/java/expo/modules/linker/ExpoModulesPackageList.java:5: error: package expo.modules.core.interfaces does not exist
import expo.modules.core.interfaces.Package;
                                   ^
/Users/kudo/01_Work/Repos/expo/expo/packages/expo-modules-core/android-linker/build/generated/expo/src/main/java/expo/modules/linker/ExpoModulesPackageList.java:10: error: package expo.modules.analytics.amplitude does not exist
      new expo.modules.analytics.amplitude.AmplitudePackage(),
                                          ^
/Users/kudo/01_Work/Repos/expo/expo/packages/expo-modules-core/android-linker/build/generated/expo/src/main/java/expo/modules/linker/ExpoModulesPackageList.java:11: error: package expo.modules.analytics.segment does not exist
      new expo.modules.analytics.segment.SegmentPackage(),
                                        ^
/Users/kudo/01_Work/Repos/expo/expo/packages/expo-modules-core/android-linker/build/generated/expo/src/main/java/expo/modules/linker/ExpoModulesPackageList.java:12: error: package expo.modules.appauth does not exist
      new expo.modules.appauth.AppAuthPackage(),
...
```

# How

android-linker should depend on expo-modules-core for `ExpoModulesPackageList.java` to access expo-modules-core's packages.

# Test Plan

```sh
cd apps/bare-expo/android
./gradlew clean :app:assembleDebug
```