### PR TITLE
Fix React Native key commands getting disabled after dev menu is shown

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix keyboard commands getting ignored after dev menu is shown.
+- Fix keyboard commands getting ignored after dev menu is shown. ([#14266](https://github.com/expo/expo/pull/14266) by [@fson](https://github.com/fson))
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix keyboard commands getting ignored after dev menu is shown.
+
 ### 💡 Others
 
 ## 0.7.7 — 2021-08-06

--- a/packages/expo-dev-menu/ios/DevMenuRootView.m
+++ b/packages/expo-dev-menu/ios/DevMenuRootView.m
@@ -27,4 +27,10 @@
 
 - (void)bundleFinishedLoading:(RCTBridge *)bridge {}
 
+- (bool)becomeFirstResponder
+{
+  // Avoid first responder status so that it won't hijack React Native keyboard commands.
+  return NO;
+}
+
 @end


### PR DESCRIPTION
# Why

After opening dev menu once (e.g. press Cmd+D or shake device) and closing it, keyboard commands provided by React Native such as refresh (Cmd+R), show inspector, etc. stop working.

See https://github.com/facebook/react-native/blob/53c6494615fcc19e555adf7900cd443b88ce562a/React/Base/RCTKeyCommands.m#L144-L146: `RCTKeyCommands` ignores key commands if there's an active first responder. After dev menu is shown, the `DevMenuRootView` becomes first responder.

# How

I changed `DevMenuRootView` so it does not accept first responder status.

# Test Plan

Tested the changes in a RN 0.65 app.

Verified that:
- `Cmd+R` kept working after opening/closing dev menu using `Cmd+D` numerous times.
- It was still possible to enter text into a `TextInput` field.
- `Cmd+D` kept working.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).