### PR TITLE
[slider] upgrade react-native-slider to v4.1.4

### DIFF
--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -94,7 +94,7 @@
     "@react-native-async-storage/async-storage": "~1.15.0",
     "@react-native-community/datetimepicker": "3.5.2",
     "@react-native-community/netinfo": "6.0.0",
-    "@react-native-community/slider": "3.0.3",
+    "@react-native-community/slider": "4.1.4",
     "@react-native-community/viewpager": "5.0.11",
     "@react-native-masked-view/masked-view": "0.2.4",
     "@react-native-picker/picker": "1.16.1",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -51,7 +51,7 @@
     "@react-native-async-storage/async-storage": "~1.15.0",
     "@react-native-community/datetimepicker": "3.5.2",
     "@react-native-community/netinfo": "6.0.0",
-    "@react-native-community/slider": "3.0.3",
+    "@react-native-community/slider": "4.1.4",
     "@react-native-community/viewpager": "5.0.11",
     "@react-native-masked-view/masked-view": "0.2.4",
     "@react-native-picker/picker": "1.16.1",

--- a/ios/Exponent/Versioned/Core/Api/Components/Slider/RNCSlider.h
+++ b/ios/Exponent/Versioned/Core/Api/Components/Slider/RNCSlider.h
@@ -22,6 +22,7 @@
 @property (nonatomic, strong) UIImage *minimumTrackImage;
 @property (nonatomic, strong) UIImage *maximumTrackImage;
 @property (nonatomic, strong) UIImage *thumbImage;
+@property (nonatomic, assign) bool tapToSeek;
 @property (nonatomic, strong) NSString *accessibilityUnits;
 @property (nonatomic, strong) NSArray *accessibilityIncrements;
 

--- a/ios/Exponent/Versioned/Core/Api/Components/Slider/RNCSlider.m
+++ b/ios/Exponent/Versioned/Core/Api/Components/Slider/RNCSlider.m
@@ -10,25 +10,13 @@
 @implementation RNCSlider
 {
   float _unclippedValue;
-  UITapGestureRecognizer * tapGesturer;
+  bool _minimumTrackImageSet;
+  bool _maximumTrackImageSet;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame
 {
-    self = [super initWithFrame:frame];
-    if (self) {
-        tapGesturer = [[UITapGestureRecognizer alloc] initWithTarget: self action:@selector(tapHandler:)];
-        [tapGesturer setNumberOfTapsRequired: 1];
-        [self addGestureRecognizer:tapGesturer];
-    }
-    return self;
-}
-
-- (void)tapHandler:(UITapGestureRecognizer *)gesture {
-    CGPoint touchPoint = [gesture locationInView:self];
-    float rangeWidth = self.maximumValue - self.minimumValue;
-    float sliderPercent = touchPoint.x / self.bounds.size.width;
-    [self setValue:self.minimumValue + (rangeWidth * sliderPercent) animated: YES];
+    return [super initWithFrame:frame];
 }
 
 - (void)setValue:(float)value
@@ -78,20 +66,25 @@
   if (trackImage != _trackImage) {
     _trackImage = trackImage;
     CGFloat width = trackImage.size.width / 2;
-    UIImage *minimumTrackImage = [trackImage resizableImageWithCapInsets:(UIEdgeInsets){
-      0, width, 0, width
-    } resizingMode:UIImageResizingModeStretch];
-    UIImage *maximumTrackImage = [trackImage resizableImageWithCapInsets:(UIEdgeInsets){
-      0, width, 0, width
-    } resizingMode:UIImageResizingModeStretch];
-    [self setMinimumTrackImage:minimumTrackImage forState:UIControlStateNormal];
-    [self setMaximumTrackImage:maximumTrackImage forState:UIControlStateNormal];
+    if (!_minimumTrackImageSet) {
+      UIImage *minimumTrackImage = [trackImage resizableImageWithCapInsets:(UIEdgeInsets){
+        0, width, 0, width
+      } resizingMode:UIImageResizingModeStretch];
+      [self setMinimumTrackImage:minimumTrackImage forState:UIControlStateNormal];
+    }
+    if (!_maximumTrackImageSet) {
+      UIImage *maximumTrackImage = [trackImage resizableImageWithCapInsets:(UIEdgeInsets){
+        0, width, 0, width
+      } resizingMode:UIImageResizingModeStretch];
+      [self setMaximumTrackImage:maximumTrackImage forState:UIControlStateNormal];
+    }
   }
 }
 
 - (void)setMinimumTrackImage:(UIImage *)minimumTrackImage
 {
   _trackImage = nil;
+  _minimumTrackImageSet = true;
   minimumTrackImage = [minimumTrackImage resizableImageWithCapInsets:(UIEdgeInsets){
     0, minimumTrackImage.size.width, 0, 0
   } resizingMode:UIImageResizingModeStretch];
@@ -106,6 +99,7 @@
 - (void)setMaximumTrackImage:(UIImage *)maximumTrackImage
 {
   _trackImage = nil;
+  _maximumTrackImageSet = true;
   maximumTrackImage = [maximumTrackImage resizableImageWithCapInsets:(UIEdgeInsets){
     0, 0, 0, maximumTrackImage.size.width
   } resizingMode:UIImageResizingModeStretch];
@@ -134,11 +128,6 @@
   } else {
     self.transform = CGAffineTransformMakeScale(1, 1);
   }
-}
-
-- (BOOL)beginTrackingWithTouch:(UITouch *)touch withEvent:(UIEvent *)event
-{
-    return YES;
 }
 
 @end

--- a/ios/Exponent/Versioned/Core/Api/Components/Slider/RNCSliderManager.m
+++ b/ios/Exponent/Versioned/Core/Api/Components/Slider/RNCSliderManager.m
@@ -13,6 +13,9 @@
 #import <React/UIView+React.h>
 
 @implementation RNCSliderManager
+{
+  BOOL _isSliding;
+}
 
 RCT_EXPORT_MODULE()
 
@@ -27,25 +30,86 @@ RCT_EXPORT_MODULE()
    forControlEvents:(UIControlEventTouchUpInside |
                      UIControlEventTouchUpOutside |
                      UIControlEventTouchCancel)];
+
+  UITapGestureRecognizer *tapGesturer;
+  tapGesturer = [[UITapGestureRecognizer alloc] initWithTarget: self action:@selector(tapHandler:)];
+  [tapGesturer setNumberOfTapsRequired: 1];
+  [slider addGestureRecognizer:tapGesturer];
+
   return slider;
+}
+
+- (void)tapHandler:(UITapGestureRecognizer *)gesture {
+  // Ignore this tap if in the middle of a slide.
+  if (_isSliding) {
+    return;
+  }
+
+  // Bail out if the source view of the gesture isn't an RNCSlider.
+  if ([gesture.view class] != [RNCSlider class]) {
+    return;
+  }
+  RNCSlider *slider = (RNCSlider *)gesture.view;
+
+  if (!slider.tapToSeek) {
+    return;
+  }
+
+  CGPoint touchPoint = [gesture locationInView:slider];
+  float rangeWidth = slider.maximumValue - slider.minimumValue;
+  float sliderPercent = touchPoint.x / slider.bounds.size.width;
+  float value = slider.minimumValue + (rangeWidth * sliderPercent);
+
+  [slider setValue:discreteValue(slider, value) animated: YES];
+  
+  // Trigger onValueChange to address https://github.com/react-native-community/react-native-slider/issues/212
+  if (slider.onRNCSliderValueChange) {
+    slider.onRNCSliderValueChange(@{
+      @"value": @(slider.value),
+    });
+  }
+
+  if (slider.onRNCSliderSlidingComplete) {
+    slider.onRNCSliderSlidingComplete(@{
+      @"value": @(slider.value),
+    });
+  }
+}
+
+static float discreteValue(RNCSlider *sender, float value) {
+  // If step is set and less than or equal to difference between max and min values,
+  // pick the closest discrete multiple of step to return.
+
+  if (sender.step > 0 && sender.step <= (sender.maximumValue - sender.minimumValue)) {
+    
+    // Round up when increase, round down when decrease.
+    double (^_round)(double) = ^(double x) {
+      if (!UIAccessibilityIsVoiceOverRunning()) {
+        return round(x);
+      } else if (sender.lastValue > value) {
+        return floor(x);
+      } else {
+        return ceil(x);
+      }
+    };
+
+    return
+      MAX(sender.minimumValue,
+        MIN(sender.maximumValue,
+            sender.minimumValue + _round((value - sender.minimumValue) / sender.step) * sender.step
+        )
+      );
+  }
+
+  // Otherwise, leave value unchanged.
+  return value;
 }
 
 static void RNCSendSliderEvent(RNCSlider *sender, BOOL continuous, BOOL isSlidingStart)
 {
-  float value = sender.value;
+  float value = discreteValue(sender, sender.value);
 
-  if (sender.step > 0 &&
-      sender.step <= (sender.maximumValue - sender.minimumValue)) {
-
-    value =
-      MAX(sender.minimumValue,
-        MIN(sender.maximumValue,
-          sender.minimumValue + round((sender.value - sender.minimumValue) / sender.step) * sender.step
-        )
-      );
-
-    [sender setValue:value animated:NO];
-  }
+  [sender setValue:value animated:NO];
 
   if (continuous) {
     if (sender.onRNCSliderValueChange && sender.lastValue != value) {
@@ -77,11 +141,13 @@ static void RNCSendSliderEvent(RNCSlider *sender, BOOL continuous, BOOL isSlidin
 - (void)sliderTouchStart:(RNCSlider *)sender
 {
   RNCSendSliderEvent(sender, NO, YES);
+  _isSliding = YES;
 }
 
 - (void)sliderTouchEnd:(RNCSlider *)sender
 {
   RNCSendSliderEvent(sender, NO, NO);
+  _isSliding = NO;
 }
 
 RCT_EXPORT_VIEW_PROPERTY(value, float);
@@ -99,6 +165,7 @@ RCT_EXPORT_VIEW_PROPERTY(onRNCSliderSlidingComplete, RCTBubblingEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(thumbTintColor, UIColor);
 RCT_EXPORT_VIEW_PROPERTY(thumbImage, UIImage);
 RCT_EXPORT_VIEW_PROPERTY(inverted, BOOL);
+RCT_EXPORT_VIEW_PROPERTY(tapToSeek, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(accessibilityUnits, NSString);
 RCT_EXPORT_VIEW_PROPERTY(accessibilityIncrements, NSArray);
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -4084,7 +4084,7 @@ SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   Branch: 9a37f707974a128c37829033c49018b79c7e7a2d
   CocoaLumberjack: 2f44e60eb91c176d471fdba43b9e3eae6a721947
-  DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
+  DoubleConversion: cde416483dac037923206447da6e1454df403714
   EXAdsAdMob: 86e90081f156eb60a2d7b6da07408d3ec8c4a0d8
   EXAdsFacebook: 43c0cf0ec4e6a4fe07adaa25cf45570018653856
   EXAmplitude: f0c3dd959d629181c0c2b4bc52717580a539a600
@@ -4164,7 +4164,7 @@ SPEC CHECKSUMS:
   FirebaseCore: ac35d680a0bf32319a59966a1478e0741536b97b
   FirebaseCoreDiagnostics: 3d36e05da74cb8b7ce30e6594a8f201b982c725c
   FirebaseInstallations: a58d4f72ec5861840b84df489f2668d970df558a
-  glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
+  glog: 40a13f7840415b9a77023fbcae0f1e6f43192af3
   Google-Maps-iOS-Utils: c32891ff472eaaa1fca032beedafa1a013af7875
   Google-Mobile-Ads-SDK: 2f288748a42920d1c744946a460896a95b0e9110
   GoogleAppMeasurement: 0c3b134b2c0a90c4c24833873894bfe0e42a0384

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -4084,7 +4084,7 @@ SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   Branch: 9a37f707974a128c37829033c49018b79c7e7a2d
   CocoaLumberjack: 2f44e60eb91c176d471fdba43b9e3eae6a721947
-  DoubleConversion: cde416483dac037923206447da6e1454df403714
+  DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   EXAdsAdMob: 86e90081f156eb60a2d7b6da07408d3ec8c4a0d8
   EXAdsFacebook: 43c0cf0ec4e6a4fe07adaa25cf45570018653856
   EXAmplitude: f0c3dd959d629181c0c2b4bc52717580a539a600
@@ -4164,7 +4164,7 @@ SPEC CHECKSUMS:
   FirebaseCore: ac35d680a0bf32319a59966a1478e0741536b97b
   FirebaseCoreDiagnostics: 3d36e05da74cb8b7ce30e6594a8f201b982c725c
   FirebaseInstallations: a58d4f72ec5861840b84df489f2668d970df558a
-  glog: 40a13f7840415b9a77023fbcae0f1e6f43192af3
+  glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
   Google-Maps-iOS-Utils: c32891ff472eaaa1fca032beedafa1a013af7875
   Google-Mobile-Ads-SDK: 2f288748a42920d1c744946a460896a95b0e9110
   GoogleAppMeasurement: 0c3b134b2c0a90c4c24833873894bfe0e42a0384

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -4,7 +4,7 @@
   "@react-native-community/datetimepicker": "3.5.2",
   "@react-native-masked-view/masked-view": "0.2.4",
   "@react-native-community/netinfo": "6.0.0",
-  "@react-native-community/slider": "3.0.3",
+  "@react-native-community/slider": "4.1.4",
   "@react-native-community/viewpager": "5.0.11",
   "@react-native-picker/picker": "1.16.1",
   "@react-native-segmented-control/segmented-control": "2.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5750,10 +5750,12 @@
   resolved "https://registry.yarnpkg.com/@react-native-community/netinfo/-/netinfo-6.0.0.tgz#2a4d7190b508dd0c2293656c9c1aa068f6f60a71"
   integrity sha512-Z9M8VGcF2IZVOo2x+oUStvpCW/8HjIRi4+iQCu5n+PhC7OqCQX58KYAzdBr///alIfRXiu6oMb+lK+rXQH1FvQ==
 
-"@react-native-community/slider@3.0.3":
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/@react-native-community/slider/-/slider-3.0.3.tgz#830167fd757ba70ac638747ba3169b2dbae60330"
-  integrity sha512-8IeHfDwJ9/CTUwFs6x90VlobV3BfuPgNLjTgC6dRZovfCWigaZwVNIFFJnHBakK3pW2xErAPwhdvNR4JeNoYbw==
+"@react-native-community/slider@4.1.4":
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/@react-native-community/slider/-/slider-4.1.4.tgz#d0df032e3bbc03dd94e755a94968373ef7fb0542"
+  integrity sha512-Vg3GNC0kzyoOXFy87gPVkOkMAnYb99uRa47PDvcXiYRIOZmxBlA6lRbbp6h0i6xMavjVhVOcGJol3q7mGaQnng==
+  dependencies:
+    flow-bin "0.113.0"
 
 "@react-native-community/viewpager@5.0.11":
   version "5.0.11"
@@ -11798,6 +11800,11 @@ flatted@^3.1.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.2.tgz#64bfed5cb68fe3ca78b3eb214ad97b63bedce561"
   integrity sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==
+
+flow-bin@0.113.0:
+  version "0.113.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.113.0.tgz#6457d250dbc6f71ca51e75f00a96d23cde5d987a"
+  integrity sha512-76uE2LGNe50wm+Jup8Np4FBcMbyy5V2iE+K25PPIYLaEMGHrL1jnQfP9L0hTzA5oh2ZJlexRLMlaPqIYIKH9nw==
 
 flow-bin@^0.137.0:
   version "0.137.0"


### PR DESCRIPTION
# Why

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

Upgrading `react-native-slider` to v 4.1.4. The major bump looks to be windows support - there is no changes to Android and seemingly minor updates to iOS.

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

Ran `et uvm -m @react-native-community/slider` and updated the `package.json` with the correct version (it was undefined after running the script) 

# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->

Tested local builds for Android and iOS on NCL

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).