### PR TITLE
[expo-manifests] Update home environment detection to support using projectID

### DIFF
--- a/home/utils/Environment.ts
+++ b/home/utils/Environment.ts
@@ -4,10 +4,13 @@ import semver from 'semver';
 
 import * as Kernel from '../kernel/Kernel';
 
+const PRODUCTION_EXPONENT_HOME_PROJECT_ID = '6b6c6660-df76-11e6-b9b4-59d1587e6774';
+
 const isProduction = !!(
   (Constants.manifest?.originalFullName === '@exponent/home' ||
     Constants.manifest?.id === '@exponent/home' ||
-    Constants.manifest2?.extra?.expoClient?.originalFullName === '@exponent/home') &&
+    Constants.manifest?.projectId === PRODUCTION_EXPONENT_HOME_PROJECT_ID ||
+    Constants.manifest2?.extra?.eas?.projectId === PRODUCTION_EXPONENT_HOME_PROJECT_ID) &&
   (Constants.manifest?.publishedTime || Constants.manifest2?.extra?.expoClient?.publishedTime)
 );
 


### PR DESCRIPTION
# Why

Item 4 in the how section of https://github.com/expo/expo/pull/14265.

Expo Home environment detection still uses originalFullName. Instead we need it to support EAS project ID for EAS manifests when we do start using the EAS manifest instead for the home app (no idea when this will be though).

# How

Look up the ID for the production `@exponent/home` project, embed it in the check.

# Test Plan

Inspect, `yarn tsc`