### PR TITLE
[android] Use JSONObjectUtils in client code

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.net.Uri
 import android.os.Build
 import android.util.Log
+import expo.modules.jsonutils.getNullable
 import expo.modules.updates.UpdatesConfiguration
 import expo.modules.updates.UpdatesUtils
 import expo.modules.updates.db.DatabaseHolder
@@ -329,9 +330,7 @@ class ExpoUpdatesAppLoader @JvmOverloads constructor(
       val protocol = parsedManifestUrl.scheme
       val securityPrefix = if (protocol == "https" || protocol == "exps") "" else "UNVERIFIED-"
       val path = if (parsedManifestUrl.path != null) parsedManifestUrl.path else ""
-      val slug = if (manifestJson.has(ExponentManifest.MANIFEST_SLUG)) manifestJson.getString(
-        ExponentManifest.MANIFEST_SLUG
-      ) else ""
+      val slug = manifestJson.getNullable<String>(ExponentManifest.MANIFEST_SLUG) ?: ""
       val sandboxedId = securityPrefix + parsedManifestUrl.host + path + "-" + slug
       manifestJson.put(ExponentManifest.MANIFEST_ID_KEY, sandboxedId)
       manifestJson.put(ExponentManifest.MANIFEST_IS_VERIFIED_KEY, true)

--- a/android/expoview/src/main/java/host/exp/exponent/experience/splashscreen/ManagedAppSplashScreenConfiguration.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/splashscreen/ManagedAppSplashScreenConfiguration.kt
@@ -2,6 +2,7 @@ package host.exp.exponent.experience.splashscreen
 
 import android.graphics.Color
 import androidx.annotation.ColorInt
+import expo.modules.jsonutils.getNullable
 import expo.modules.splashscreen.SplashScreenImageResizeMode
 import expo.modules.manifests.core.Manifest
 import host.exp.exponent.ExponentManifest
@@ -40,27 +41,16 @@ class ManagedAppSplashScreenConfiguration private constructor() {
     private fun parseResizeMode(manifest: Manifest): SplashScreenImageResizeMode? {
       val androidSplashInfo = manifest.getAndroidSplashInfo()
       val rootSplashInfo = manifest.getRootSplashInfo()
-      val resizeMode = if (androidSplashInfo != null && androidSplashInfo.has(ExponentManifest.MANIFEST_SPLASH_RESIZE_MODE_KEY)) {
-        androidSplashInfo.getString(ExponentManifest.MANIFEST_SPLASH_RESIZE_MODE_KEY)
-      } else if (rootSplashInfo != null && rootSplashInfo.has(ExponentManifest.MANIFEST_SPLASH_RESIZE_MODE_KEY)) {
-        rootSplashInfo.getString(ExponentManifest.MANIFEST_SPLASH_RESIZE_MODE_KEY)
-      } else {
-        null
-      }
-
+      val resizeMode = androidSplashInfo?.getNullable<String>(ExponentManifest.MANIFEST_SPLASH_RESIZE_MODE_KEY)
+        ?: rootSplashInfo?.getNullable(ExponentManifest.MANIFEST_SPLASH_RESIZE_MODE_KEY)
       return SplashScreenImageResizeMode.fromString(resizeMode)
     }
 
     private fun parseBackgroundColor(manifest: Manifest): Int? {
       val androidSplashInfo = manifest.getAndroidSplashInfo()
       val rootSplashInfo = manifest.getRootSplashInfo()
-      val backgroundColor = if (androidSplashInfo != null && androidSplashInfo.has(ExponentManifest.MANIFEST_SPLASH_BACKGROUND_COLOR_KEY)) {
-        androidSplashInfo.getString(ExponentManifest.MANIFEST_SPLASH_BACKGROUND_COLOR_KEY)
-      } else if (rootSplashInfo != null && rootSplashInfo.has(ExponentManifest.MANIFEST_SPLASH_BACKGROUND_COLOR_KEY)) {
-        rootSplashInfo.getString(ExponentManifest.MANIFEST_SPLASH_BACKGROUND_COLOR_KEY)
-      } else {
-        null
-      }
+      val backgroundColor = androidSplashInfo?.getNullable<String>(ExponentManifest.MANIFEST_SPLASH_BACKGROUND_COLOR_KEY)
+        ?: rootSplashInfo?.getNullable(ExponentManifest.MANIFEST_SPLASH_BACKGROUND_COLOR_KEY)
 
       return if (ColorParser.isValid(backgroundColor)) {
         Color.parseColor(backgroundColor)
@@ -92,13 +82,8 @@ class ManagedAppSplashScreenConfiguration private constructor() {
 
       val androidSplashInfo = manifest.getAndroidSplashInfo()
       val rootSplashInfo = manifest.getRootSplashInfo()
-      return if (androidSplashInfo != null && androidSplashInfo.has(ExponentManifest.MANIFEST_SPLASH_IMAGE_URL_KEY)) {
-        androidSplashInfo.getString(ExponentManifest.MANIFEST_SPLASH_IMAGE_URL_KEY)
-      } else if (rootSplashInfo != null && rootSplashInfo.has(ExponentManifest.MANIFEST_SPLASH_IMAGE_URL_KEY)) {
-        rootSplashInfo.getString(ExponentManifest.MANIFEST_SPLASH_IMAGE_URL_KEY)
-      } else {
-        null
-      }
+      return androidSplashInfo?.getNullable(ExponentManifest.MANIFEST_SPLASH_IMAGE_URL_KEY)
+        ?: rootSplashInfo?.getNullable(ExponentManifest.MANIFEST_SPLASH_IMAGE_URL_KEY)
     }
 
     private fun getStringFromJSONObject(jsonObject: JSONObject, vararg paths: Array<String>): String? {
@@ -120,7 +105,7 @@ class ManagedAppSplashScreenConfiguration private constructor() {
           break
         }
         if (isLastKey) {
-          return json.optString(key)
+          return json.getNullable(key)
         }
         json = json.optJSONObject(key)
       }

--- a/android/expoview/src/main/java/host/exp/exponent/kernel/services/PermissionsKernelService.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/kernel/services/PermissionsKernelService.kt
@@ -3,6 +3,7 @@ package host.exp.exponent.kernel.services
 import android.content.Context
 import android.content.pm.PackageManager
 import android.content.pm.PermissionInfo
+import expo.modules.jsonutils.getNullable
 import host.exp.exponent.Constants
 import host.exp.exponent.kernel.ExperienceKey
 import host.exp.exponent.storage.ExponentSharedPreferences
@@ -19,16 +20,8 @@ class PermissionsKernelService(
       if (metadata == null) {
         metadata = JSONObject()
       }
-      val permissions: JSONObject = if (metadata.has(ExponentSharedPreferences.EXPERIENCE_METADATA_PERMISSIONS)) {
-        metadata.getJSONObject(ExponentSharedPreferences.EXPERIENCE_METADATA_PERMISSIONS)
-      } else {
-        JSONObject()
-      }
-      val permissionObject: JSONObject = if (permissions.has(permission)) {
-        permissions.getJSONObject(permission)
-      } else {
-        JSONObject()
-      }
+      val permissions: JSONObject = metadata.getNullable(ExponentSharedPreferences.EXPERIENCE_METADATA_PERMISSIONS) ?: JSONObject()
+      val permissionObject: JSONObject = permissions.getNullable(permission) ?: JSONObject()
       permissionObject.put("status", "granted")
       permissions.put(permission, permissionObject)
       metadata.put(ExponentSharedPreferences.EXPERIENCE_METADATA_PERMISSIONS, permissions)
@@ -67,7 +60,7 @@ class PermissionsKernelService(
           metadata.getJSONObject(ExponentSharedPreferences.EXPERIENCE_METADATA_PERMISSIONS)
         if (permissions.has(permission)) {
           val permissionsObject = permissions.getJSONObject(permission)
-          return permissionsObject.has("status") && permissionsObject.getString("status") == "granted"
+          return permissionsObject.getNullable<String>("status") == "granted"
         }
       }
     } catch (e: JSONException) {

--- a/android/expoview/src/main/java/host/exp/exponent/notifications/ExponentNotification.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/notifications/ExponentNotification.kt
@@ -1,6 +1,7 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 package host.exp.exponent.notifications
 
+import expo.modules.jsonutils.getNullable
 import host.exp.exponent.analytics.EXL.e
 import host.exp.exponent.RNObject
 import org.json.JSONException
@@ -62,23 +63,12 @@ open class ExponentNotification(
         null
       } else try {
         val jsonObject = JSONObject(json)
-        val body = if (jsonObject.has(NotificationConstants.NOTIFICATION_DATA_KEY)) {
-          jsonObject.getString(NotificationConstants.NOTIFICATION_DATA_KEY)
-        } else {
-          if (jsonObject.has(NotificationConstants.NOTIFICATION_MESSAGE_KEY)) {
-            jsonObject.getString(NotificationConstants.NOTIFICATION_MESSAGE_KEY)
-          } else {
-            null
-          }
-        }
+        val body = jsonObject.getNullable(NotificationConstants.NOTIFICATION_DATA_KEY)
+          ?: jsonObject.getString(NotificationConstants.NOTIFICATION_MESSAGE_KEY)
+        val experienceScopeKey = jsonObject.getNullable(NotificationConstants.NOTIFICATION_EXPERIENCE_SCOPE_KEY_KEY)
+          ?: jsonObject.getString(NotificationConstants.NOTIFICATION_EXPERIENCE_ID_KEY)
         ExponentNotification(
-          if (jsonObject.has(NotificationConstants.NOTIFICATION_EXPERIENCE_SCOPE_KEY_KEY)) {
-            jsonObject.optString(
-              NotificationConstants.NOTIFICATION_EXPERIENCE_SCOPE_KEY_KEY
-            )
-          } else {
-            jsonObject.getString(NotificationConstants.NOTIFICATION_EXPERIENCE_ID_KEY)
-          },
+          experienceScopeKey,
           body,
           jsonObject.getInt(NotificationConstants.NOTIFICATION_ID_KEY),
           jsonObject.getBoolean(NotificationConstants.NOTIFICATION_IS_MULTIPLE_KEY),

--- a/android/expoview/src/main/java/host/exp/exponent/notifications/ExponentNotificationManager.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/notifications/ExponentNotificationManager.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import android.os.Build
 import androidx.core.app.NotificationManagerCompat
+import expo.modules.jsonutils.getNullable
 import expo.modules.manifests.core.Manifest
 import host.exp.exponent.Constants
 import host.exp.exponent.analytics.EXL
@@ -93,11 +94,7 @@ class ExponentNotificationManager(private val context: Context) {
   ) {
     try {
       val metadata = exponentSharedPreferences.getExperienceMetadata(experienceKey) ?: JSONObject()
-      val allChannels: JSONObject = if (metadata.has(ExponentSharedPreferences.EXPERIENCE_METADATA_NOTIFICATION_CHANNELS)) {
-        metadata.getJSONObject(ExponentSharedPreferences.EXPERIENCE_METADATA_NOTIFICATION_CHANNELS)
-      } else {
-        JSONObject()
-      }
+      val allChannels: JSONObject = metadata.getNullable(ExponentSharedPreferences.EXPERIENCE_METADATA_NOTIFICATION_CHANNELS) ?: JSONObject()
       allChannels.put(channelId, JSONObject(details))
       metadata.put(ExponentSharedPreferences.EXPERIENCE_METADATA_NOTIFICATION_CHANNELS, allChannels)
       exponentSharedPreferences.updateExperienceMetadata(experienceKey, metadata)
@@ -108,14 +105,8 @@ class ExponentNotificationManager(private val context: Context) {
 
   fun readChannelSettings(experienceKey: ExperienceKey, channelId: String?): JSONObject? {
     try {
-      val metadata = exponentSharedPreferences.getExperienceMetadata(
-        experienceKey
-      ) ?: JSONObject()
-      val allChannels: JSONObject = if (metadata.has(ExponentSharedPreferences.EXPERIENCE_METADATA_NOTIFICATION_CHANNELS)) {
-        metadata.getJSONObject(ExponentSharedPreferences.EXPERIENCE_METADATA_NOTIFICATION_CHANNELS)
-      } else {
-        JSONObject()
-      }
+      val metadata = exponentSharedPreferences.getExperienceMetadata(experienceKey) ?: JSONObject()
+      val allChannels: JSONObject = metadata.getNullable(ExponentSharedPreferences.EXPERIENCE_METADATA_NOTIFICATION_CHANNELS) ?: JSONObject()
       return allChannels.optJSONObject(channelId)
     } catch (e: JSONException) {
       EXL.e(TAG, "Could not read channel from shared preferences: " + e.message)

--- a/android/expoview/src/main/java/host/exp/exponent/notifications/NotificationHelper.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/notifications/NotificationHelper.kt
@@ -14,6 +14,7 @@ import android.text.format.DateUtils
 import androidx.core.app.NotificationCompat
 import de.greenrobot.event.EventBus
 import expo.modules.core.errors.InvalidArgumentException
+import expo.modules.jsonutils.getNullable
 import expo.modules.manifests.core.Manifest
 import host.exp.exponent.Constants
 import host.exp.exponent.ExponentManifest
@@ -52,7 +53,7 @@ object NotificationHelper {
     manifest: Manifest,
     exponentManifest: ExponentManifest
   ): Int {
-    val colorStringLocal = colorString ?: manifest.getNotificationPreferences()?.optString(ExponentManifest.MANIFEST_NOTIFICATION_COLOR_KEY)
+    val colorStringLocal = colorString ?: manifest.getNotificationPreferences()?.getNullable(ExponentManifest.MANIFEST_NOTIFICATION_COLOR_KEY)
     return if (colorString != null && ColorParser.isValid(colorStringLocal)) {
       Color.parseColor(colorString)
     } else {
@@ -71,11 +72,7 @@ object NotificationHelper {
     if (url == null) {
       iconUrl = manifest.getIconUrl()
       if (notificationPreferences != null) {
-        iconUrl = if (notificationPreferences.has(ExponentManifest.MANIFEST_NOTIFICATION_ICON_URL_KEY)) {
-          notificationPreferences.optString(ExponentManifest.MANIFEST_NOTIFICATION_ICON_URL_KEY)
-        } else {
-          null
-        }
+        iconUrl = notificationPreferences.getNullable(ExponentManifest.MANIFEST_NOTIFICATION_ICON_URL_KEY)
       }
     } else {
       iconUrl = url
@@ -224,21 +221,9 @@ object NotificationHelper {
     try {
       // we want to throw immediately if there is no channel name
       val channelName = details.getString(NotificationConstants.NOTIFICATION_CHANNEL_NAME)
-      val description: String? = if (!details.isNull(NotificationConstants.NOTIFICATION_CHANNEL_DESCRIPTION)) {
-        details.optString(NotificationConstants.NOTIFICATION_CHANNEL_DESCRIPTION)
-      } else {
-        null
-      }
-      val priority: String? = if (!details.isNull(NotificationConstants.NOTIFICATION_CHANNEL_PRIORITY)) {
-        details.optString(NotificationConstants.NOTIFICATION_CHANNEL_PRIORITY)
-      } else {
-        null
-      }
-      val sound: Boolean? = if (!details.isNull(NotificationConstants.NOTIFICATION_CHANNEL_SOUND)) {
-        details.optBoolean(NotificationConstants.NOTIFICATION_CHANNEL_SOUND)
-      } else {
-        null
-      }
+      val description: String? = details.getNullable(NotificationConstants.NOTIFICATION_CHANNEL_DESCRIPTION)
+      val priority: String? = details.getNullable(NotificationConstants.NOTIFICATION_CHANNEL_PRIORITY)
+      val sound: Boolean? = details.getNullable(NotificationConstants.NOTIFICATION_CHANNEL_SOUND)
       val badge: Boolean? = if (!details.isNull(NotificationConstants.NOTIFICATION_CHANNEL_BADGE)) {
         details.optBoolean(NotificationConstants.NOTIFICATION_CHANNEL_BADGE, true)
       } else {
@@ -421,7 +406,7 @@ object NotificationHelper {
                       builder.setDefaults(NotificationCompat.DEFAULT_SOUND)
                     }
 
-                    builder.priority = when (storedChannelDetails.optString(NotificationConstants.NOTIFICATION_CHANNEL_PRIORITY)) {
+                    builder.priority = when (storedChannelDetails.getNullable<String>(NotificationConstants.NOTIFICATION_CHANNEL_PRIORITY)) {
                       "max" -> NotificationCompat.PRIORITY_MAX
                       "high" -> NotificationCompat.PRIORITY_HIGH
                       "low" -> NotificationCompat.PRIORITY_LOW

--- a/android/expoview/src/main/java/host/exp/exponent/notifications/PushNotificationHelper.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/notifications/PushNotificationHelper.kt
@@ -10,6 +10,7 @@ import android.os.Build
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import de.greenrobot.event.EventBus
+import expo.modules.jsonutils.getNullable
 import expo.modules.manifests.core.Manifest
 import host.exp.exponent.Constants
 import host.exp.exponent.ExponentManifest
@@ -110,7 +111,7 @@ class PushNotificationHelper {
 
           // Modes
           if (notificationPreferences != null) {
-            val modeString = notificationPreferences.optString(ExponentManifest.MANIFEST_NOTIFICATION_ANDROID_MODE)
+            val modeString = notificationPreferences.getNullable<String>(ExponentManifest.MANIFEST_NOTIFICATION_ANDROID_MODE)
             if (NotificationConstants.NOTIFICATION_COLLAPSE_MODE == modeString) {
               mode = Mode.COLLAPSE
             }
@@ -123,11 +124,7 @@ class PushNotificationHelper {
           // Collapse mode fields
           if (mode == Mode.COLLAPSE) {
             unreadNotifications = getUnreadNotificationsFromMetadata(experienceKey)
-            val collapsedTitleRaw = if (notificationPreferences!!.has(ExponentManifest.MANIFEST_NOTIFICATION_ANDROID_COLLAPSED_TITLE)) {
-              notificationPreferences.optString(ExponentManifest.MANIFEST_NOTIFICATION_ANDROID_COLLAPSED_TITLE)
-            } else {
-              null
-            }
+            val collapsedTitleRaw = notificationPreferences!!.getNullable<String>(ExponentManifest.MANIFEST_NOTIFICATION_ANDROID_COLLAPSED_TITLE)
             if (collapsedTitleRaw != null) {
               collapsedTitle = collapsedTitleRaw.replace(NotificationConstants.NOTIFICATION_UNREAD_COUNT_KEY, "" + unreadNotifications.length())
             }

--- a/android/expoview/src/main/java/host/exp/exponent/utils/ExperienceActivityUtils.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/utils/ExperienceActivityUtils.kt
@@ -17,6 +17,7 @@ import androidx.annotation.UiThread
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.view.ViewCompat
+import expo.modules.jsonutils.getNullable
 import host.exp.exponent.analytics.EXL
 
 object ExperienceActivityUtils {
@@ -92,8 +93,8 @@ object ExperienceActivityUtils {
    */
   fun configureStatusBar(manifest: Manifest, activity: Activity) {
     val statusBarOptions = manifest.getAndroidStatusBarOptions()
-    val statusBarStyle = statusBarOptions?.optString(ExponentManifest.MANIFEST_STATUS_BAR_APPEARANCE)
-    val statusBarBackgroundColor = statusBarOptions?.optString(ExponentManifest.MANIFEST_STATUS_BAR_BACKGROUND_COLOR, null)
+    val statusBarStyle = statusBarOptions?.getNullable<String>(ExponentManifest.MANIFEST_STATUS_BAR_APPEARANCE)
+    val statusBarBackgroundColor = statusBarOptions?.getNullable<String>(ExponentManifest.MANIFEST_STATUS_BAR_BACKGROUND_COLOR)
 
     val statusBarHidden = statusBarOptions != null && statusBarOptions.optBoolean(
       ExponentManifest.MANIFEST_STATUS_BAR_HIDDEN,
@@ -249,9 +250,7 @@ object ExperienceActivityUtils {
     val navBarOptions = manifest.getAndroidNavigationBarOptions() ?: return
 
     // Set background color of navigation bar
-    val navBarColor = if (navBarOptions.has(ExponentManifest.MANIFEST_NAVIGATION_BAR_BACKGROUND_COLOR)) {
-      navBarOptions.optString(ExponentManifest.MANIFEST_NAVIGATION_BAR_BACKGROUND_COLOR)
-    } else null
+    val navBarColor = navBarOptions.getNullable<String>(ExponentManifest.MANIFEST_NAVIGATION_BAR_BACKGROUND_COLOR)
     if (navBarColor != null && ColorParser.isValid(navBarColor)) {
       try {
         activity.window.clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_NAVIGATION)
@@ -262,9 +261,7 @@ object ExperienceActivityUtils {
     }
 
     // Set icon color of navigation bar
-    val navBarAppearance = if (navBarOptions.has(ExponentManifest.MANIFEST_NAVIGATION_BAR_APPEARANCE)) {
-      navBarOptions.optString(ExponentManifest.MANIFEST_NAVIGATION_BAR_APPEARANCE)
-    } else null
+    val navBarAppearance = navBarOptions.getNullable<String>(ExponentManifest.MANIFEST_NAVIGATION_BAR_APPEARANCE)
     if (navBarAppearance != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
       try {
         activity.window.clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_NAVIGATION)
@@ -281,9 +278,7 @@ object ExperienceActivityUtils {
     }
 
     // Set visibility of navigation bar
-    val navBarVisible = if (navBarOptions.has(ExponentManifest.MANIFEST_NAVIGATION_BAR_VISIBLILITY)) {
-      navBarOptions.optString(ExponentManifest.MANIFEST_NAVIGATION_BAR_VISIBLILITY)
-    } else null
+    val navBarVisible = navBarOptions.getNullable<String>(ExponentManifest.MANIFEST_NAVIGATION_BAR_VISIBLILITY)
     if (navBarVisible != null) {
       // Hide both the navigation bar and the status bar. The Android docs recommend, "you should
       // design your app to hide the status bar whenever you hide the navigation bar."

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/VersionedUtils.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/VersionedUtils.kt
@@ -21,6 +21,7 @@ import com.facebook.react.modules.systeminfo.AndroidInfoHelpers
 import com.facebook.react.packagerconnection.NotificationOnlyHandler
 import com.facebook.react.packagerconnection.RequestHandler
 import com.facebook.react.shell.MainReactPackage
+import expo.modules.jsonutils.getNullable
 import host.exp.exponent.Constants
 import host.exp.exponent.RNObject
 import host.exp.exponent.experience.ExperienceActivity
@@ -145,11 +146,7 @@ object VersionedUtils {
     packagerCommandHandlers["sendDevCommand"] = object : NotificationOnlyHandler() {
       override fun onNotification(params: Any?) {
         if (params != null && params is JSONObject) {
-          val name = if (params.has("name")) {
-            params.optString("name")
-          } else null
-
-          when (name) {
+          when (params.getNullable<String>("name")) {
             "reload" -> reloadExpoApp()
             "toggleDevMenu" -> toggleExpoDevMenu()
             "toggleRemoteDebugging" -> {

--- a/packages/expo-updates/android/build.gradle
+++ b/packages/expo-updates/android/build.gradle
@@ -83,6 +83,7 @@ dependencies {
   implementation project(':expo-structured-headers')
   implementation project(':expo-updates-interface')
   implementation project(':expo-manifests')
+  implementation project(':expo-json-utils')
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/BareUpdateManifest.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/BareUpdateManifest.kt
@@ -1,6 +1,7 @@
 package expo.modules.updates.manifest
 
 import android.util.Log
+import expo.modules.jsonutils.getNullable
 import expo.modules.updates.UpdatesConfiguration
 import expo.modules.updates.UpdatesUtils
 import expo.modules.updates.db.entity.AssetEntity
@@ -49,10 +50,10 @@ class BareUpdateManifest private constructor(
             assetObject.getString("packagerHash"),
             type
           ).apply {
-            resourcesFilename = assetObject.optString("resourcesFilename")
-            resourcesFolder = assetObject.optString("resourcesFolder")
+            resourcesFilename = assetObject.getNullable("resourcesFilename")
+            resourcesFolder = assetObject.getNullable("resourcesFolder")
           }
-          val scales = assetObject.optJSONArray("scales")
+          val scales = assetObject.getNullable<JSONArray>("scales")
           // if there's only one scale we don't to decide later on which one to copy
           // so we avoid this work now
           if (scales != null && scales.length() > 1) {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/NewUpdateManifest.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/NewUpdateManifest.kt
@@ -2,6 +2,7 @@ package expo.modules.updates.manifest
 
 import android.net.Uri
 import android.util.Log
+import expo.modules.jsonutils.getNullable
 import expo.modules.structuredheaders.BooleanItem
 import expo.modules.structuredheaders.NumberItem
 import expo.modules.structuredheaders.Parser
@@ -54,7 +55,7 @@ class NewUpdateManifest private constructor(
         AssetEntity(
           mLaunchAsset.getString("key"),
           // the fileExtension is not necessary for the launch asset and EAS servers will not include it.
-          mLaunchAsset.optString("fileExtension")
+          mLaunchAsset.getNullable("fileExtension")
         ).apply {
           url = Uri.parse(mLaunchAsset.getString("url"))
           isLaunchAsset = true
@@ -74,7 +75,7 @@ class NewUpdateManifest private constructor(
               assetObject.getString("fileExtension")
             ).apply {
               url = Uri.parse(assetObject.getString("url"))
-              embeddedAssetFilename = assetObject.optString("embeddedAssetFilename")
+              embeddedAssetFilename = assetObject.getNullable("embeddedAssetFilename")
             }
           )
         } catch (e: JSONException) {


### PR DESCRIPTION
# Why

These callsites can be greatly simplified using the new JSONObjectIUtils. Note that these utils only work in kotlin code since they are reified functions.

# How

Grep for `.optString(` and `.has(` and manually assess each case.

# Test Plan

Build and run NCL.