### PR TITLE
[file-system][iOS] Modernized/corrected getFreeDiskStorageAsync implementation

### DIFF
--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- `getFreeDiskStorageAsync` now correctly reports free disk space on iOS. ([#14279](https://github.com/expo/expo/pull/14279) by [mickmaccallum](https://github.com/mickmaccallum))
+
 ### 💡 Others
 
 - Migrated from `@unimodules/core` to `expo-modules-core`. ([#13749](https://github.com/expo/expo/pull/13749) by [@tsapeta](https://github.com/tsapeta))

--- a/packages/expo-file-system/ios/EXFileSystem/EXFileSystem.m
+++ b/packages/expo-file-system/ios/EXFileSystem/EXFileSystem.m
@@ -1043,7 +1043,7 @@ EX_EXPORT_METHOD_AS(getTotalDiskCapacityAsync, getTotalDiskCapacityAsyncWithReso
   return [directory stringByAppendingPathComponent:fileName];
 }
 
-- (NSNumber *)totalDiskCapacityWithError(NSError **)error
+- (NSNumber *)totalDiskCapacityWithError:(NSError **)error
 {
   NSDictionary *results = [self documentFileResourcesForKeys:@[NSURLVolumeTotalCapacityKey] 
                                                        error:error];
@@ -1051,7 +1051,7 @@ EX_EXPORT_METHOD_AS(getTotalDiskCapacityAsync, getTotalDiskCapacityAsyncWithReso
   return results[NSURLVolumeTotalCapacityKey];
 }
 
-- (NSNumber *)freeDiskStorageWithError(NSError **)error
+- (NSNumber *)freeDiskStorageWithError:(NSError **)error
 {
   NSDictionary *results = [self documentFileResourcesForKeys:@[NSURLVolumeAvailableCapacityForImportantUsageKey] 
                                                        error:error];


### PR DESCRIPTION
# Why

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

The method being used to calculate free space on an iOS device is out of date and giving incorrect values. See Apple's documentation on how to calculate free disk space here: https://developer.apple.com/documentation/foundation/nsurlresourcekey/checking_volume_storage_capacity?language=objc

On my personal device the current implementation of `getFreeDiskStorageAsync` tells me that I have 2.5GB of free space on my device, but after these changes, it reports about 22GB (which is inline with what I am shown in system settings). I believe this also brings the iOS implementation in line with the values shown when invoking this same method on Android.


# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

Instead of using attributes from the file manager we use resources for the documents directory URL. This is an API that was introduced in iOS 11 (matching the version required in the expo-file-system Podspec). Using this new method of checking for free space, we're able to get a more accurate picture of "usable" free space. I also updated the `getTotalDiskCapacityAsync` implementation to use the more modern method of making this check, but this doesn't produce different results like the change to `getFreeDiskStorageAsync`.

# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->

Run a sample app both with and without these changes and observer the value provided by `getFreeDiskStorageAsync` it should vary, but I can't say how much since this will depend on the device the test is being run on.
