### PR TITLE
[expo-manifests] Support exposdk:UNVERSIONED runtimeVersion

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.kt
@@ -140,10 +140,9 @@ class ExpoUpdatesAppLoader @JvmOverloads constructor(
     configMap["expectsSignedManifest"] = true
     val configuration = UpdatesConfiguration().loadValuesFromMap(configMap)
     val sdkVersionsList = mutableListOf<String>().apply {
-      addAll(Constants.SDK_VERSIONS_LIST)
-      add(RNObject.UNVERSIONED)
-      for (sdkVersion in Constants.SDK_VERSIONS_LIST) {
-        add("exposdk:$sdkVersion")
+      (Constants.SDK_VERSIONS_LIST + listOf(RNObject.UNVERSIONED)).forEach {
+        add(it)
+        add("exposdk:$it")
       }
     }
     val selectionPolicy = SelectionPolicy(

--- a/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
+++ b/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
@@ -358,8 +358,8 @@ NS_ASSUME_NONNULL_BEGIN
   for (NSString *sdkVersion in sdkVersions) {
     [sdkVersionRuntimeVersions addObject:[NSString stringWithFormat:@"exposdk:%@", sdkVersion]];
   }
+  [sdkVersionRuntimeVersions addObject:@"exposdk:UNVERSIONED"];
   [sdkVersions addObjectsFromArray:sdkVersionRuntimeVersions];
-  [sdkVersions addObject:@"exposdk:UNVERSIONED"];
   
 
   _selectionPolicy = [[EXUpdatesSelectionPolicy alloc]

--- a/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
+++ b/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
@@ -359,6 +359,8 @@ NS_ASSUME_NONNULL_BEGIN
     [sdkVersionRuntimeVersions addObject:[NSString stringWithFormat:@"exposdk:%@", sdkVersion]];
   }
   [sdkVersions addObjectsFromArray:sdkVersionRuntimeVersions];
+  [sdkVersions addObject:@"exposdk:UNVERSIONED"];
+  
 
   _selectionPolicy = [[EXUpdatesSelectionPolicy alloc]
                       initWithLauncherSelectionPolicy:[[EXUpdatesLauncherSelectionPolicyFilterAware alloc] initWithRuntimeVersions:sdkVersions]

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -4084,7 +4084,7 @@ SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   Branch: 9a37f707974a128c37829033c49018b79c7e7a2d
   CocoaLumberjack: 2f44e60eb91c176d471fdba43b9e3eae6a721947
-  DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
+  DoubleConversion: cde416483dac037923206447da6e1454df403714
   EXAdsAdMob: 86e90081f156eb60a2d7b6da07408d3ec8c4a0d8
   EXAdsFacebook: 43c0cf0ec4e6a4fe07adaa25cf45570018653856
   EXAmplitude: f0c3dd959d629181c0c2b4bc52717580a539a600
@@ -4164,7 +4164,7 @@ SPEC CHECKSUMS:
   FirebaseCore: ac35d680a0bf32319a59966a1478e0741536b97b
   FirebaseCoreDiagnostics: 3d36e05da74cb8b7ce30e6594a8f201b982c725c
   FirebaseInstallations: a58d4f72ec5861840b84df489f2668d970df558a
-  glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
+  glog: 40a13f7840415b9a77023fbcae0f1e6f43192af3
   Google-Maps-iOS-Utils: c32891ff472eaaa1fca032beedafa1a013af7875
   Google-Mobile-Ads-SDK: 2f288748a42920d1c744946a460896a95b0e9110
   GoogleAppMeasurement: 0c3b134b2c0a90c4c24833873894bfe0e42a0384

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXManifests/EXManifests/ABI40_0_0EXManifestsNewManifest.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXManifests/EXManifests/ABI40_0_0EXManifestsNewManifest.m
@@ -33,6 +33,10 @@
 
 - (nullable NSString *)sdkVersion {
   NSString *runtimeVersion = self.runtimeVersion;
+  if ([runtimeVersion isEqualToString:@"exposdk:UNVERSIONED"]) {
+    return @"UNVERSIONED";
+  }
+  
   NSRegularExpression *regex =
       [NSRegularExpression regularExpressionWithPattern:@"^exposdk:(\\d+\\.\\d+\\.\\d+)$"
                                                 options:0

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXManifests/EXManifests/ABI41_0_0EXManifestsNewManifest.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXManifests/EXManifests/ABI41_0_0EXManifestsNewManifest.m
@@ -33,6 +33,10 @@
 
 - (nullable NSString *)sdkVersion {
   NSString *runtimeVersion = self.runtimeVersion;
+  if ([runtimeVersion isEqualToString:@"exposdk:UNVERSIONED"]) {
+    return @"UNVERSIONED";
+  }
+  
   NSRegularExpression *regex =
       [NSRegularExpression regularExpressionWithPattern:@"^exposdk:(\\d+\\.\\d+\\.\\d+)$"
                                                 options:0

--- a/ios/versioned-react-native/ABI42_0_0/Expo/EXManifests/EXManifests/ABI42_0_0EXManifestsNewManifest.m
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/EXManifests/EXManifests/ABI42_0_0EXManifestsNewManifest.m
@@ -33,6 +33,10 @@
 
 - (nullable NSString *)sdkVersion {
   NSString *runtimeVersion = self.runtimeVersion;
+  if ([runtimeVersion isEqualToString:@"exposdk:UNVERSIONED"]) {
+    return @"UNVERSIONED";
+  }
+  
   NSRegularExpression *regex =
       [NSRegularExpression regularExpressionWithPattern:@"^exposdk:(\\d+\\.\\d+\\.\\d+)$"
                                                 options:0

--- a/packages/expo-manifests/android/src/androidTest/java/expo/modules/manifests/core/NewManifestTest.kt
+++ b/packages/expo-manifests/android/src/androidTest/java/expo/modules/manifests/core/NewManifestTest.kt
@@ -20,6 +20,16 @@ class NewManifestTest {
 
   @Test
   @Throws(Exception::class)
+  fun testGetSDKVersionNullable_ValidCaseUnversioned() {
+    val runtimeVersion = "exposdk:UNVERSIONED"
+    val manifestJson =
+      "{\"runtimeVersion\":\"$runtimeVersion\"}"
+    val manifest = NewManifest(JSONObject(manifestJson))
+    Assert.assertEquals(manifest.getSDKVersion(), "UNVERSIONED")
+  }
+
+  @Test
+  @Throws(Exception::class)
   fun testGetSDKVersionNullable_NotSDKRuntimeVersionCases() {
     val runtimeVersions = listOf(
       "exposdk:123",

--- a/packages/expo-manifests/android/src/main/java/expo/modules/manifests/core/NewManifest.kt
+++ b/packages/expo-manifests/android/src/main/java/expo/modules/manifests/core/NewManifest.kt
@@ -39,6 +39,10 @@ class NewManifest(json: JSONObject) : Manifest(json) {
 
   override fun getSDKVersion(): String? {
     val runtimeVersion = getRuntimeVersion()
+    if (runtimeVersion == "exposdk:UNVERSIONED") {
+      return "UNVERSIONED"
+    }
+
     val expoSDKRuntimeVersionRegex: Pattern = Pattern.compile("^exposdk:(\\d+\\.\\d+\\.\\d+)$")
     val expoSDKRuntimeVersionMatch: Matcher = expoSDKRuntimeVersionRegex.matcher(runtimeVersion)
     if (expoSDKRuntimeVersionMatch.find()) {

--- a/packages/expo-manifests/ios/EXManifests/EXManifestsNewManifest.m
+++ b/packages/expo-manifests/ios/EXManifests/EXManifestsNewManifest.m
@@ -33,6 +33,10 @@
 
 - (nullable NSString *)sdkVersion {
   NSString *runtimeVersion = self.runtimeVersion;
+  if ([runtimeVersion isEqualToString:@"exposdk:UNVERSIONED"]) {
+    return @"UNVERSIONED";
+  }
+  
   NSRegularExpression *regex =
       [NSRegularExpression regularExpressionWithPattern:@"^exposdk:(\\d+\\.\\d+\\.\\d+)$"
                                                 options:0

--- a/packages/expo-manifests/ios/Tests/EXManifestsNewManifestTests.m
+++ b/packages/expo-manifests/ios/Tests/EXManifestsNewManifestTests.m
@@ -10,13 +10,22 @@
 
 @implementation EXManifestsNewManifestTests
 
-- (void)testSDKVersion_ValidCases {
+- (void)testSDKVersion_ValidCaseNumeric {
   NSString *runtimeVersion = @"exposdk:39.0.0";
   NSDictionary *manifestJson = @{
     @"runtimeVersion": runtimeVersion
   };
   EXManifestsNewManifest *manifest = [[EXManifestsNewManifest alloc] initWithRawManifestJSON:manifestJson];
   XCTAssert([manifest.sdkVersion isEqualToString:@"39.0.0"], @"%@", manifest.sdkVersion);
+}
+
+- (void)testSDKVersion_ValidCaseUnversioned {
+  NSString *runtimeVersion = @"exposdk:UNVERSIONED";
+  NSDictionary *manifestJson = @{
+    @"runtimeVersion": runtimeVersion
+  };
+  EXManifestsNewManifest *manifest = [[EXManifestsNewManifest alloc] initWithRawManifestJSON:manifestJson];
+  XCTAssert([manifest.sdkVersion isEqualToString:@"UNVERSIONED"], @"%@", manifest.sdkVersion);
 }
 
 - (void)testSDKVersion_NotSDKRuntimeVersionCases {


### PR DESCRIPTION
# Why

We want to be able to load EAS updates in Expo Go for experiences that supply `exposdk:UNVERSIONED` in their `runtimeVersion`. This is because this is the automatic translation to runtime version when only `sdkVersion: "UNVERSIONED"` is supplied in the app.json.

Closes ENG-1903.

# How

Add support on both platforms.

# Test Plan

1. In `apps/native-component-list`, run `expo start`
2. See that the experience doesn't throw with "Invalid SDK Version" or related errors.