### PR TITLE
[ci] reduce android testing time by building x86_64 only

### DIFF
--- a/.github/workflows/android-instrumentation-tests.yml
+++ b/.github/workflows/android-instrumentation-tests.yml
@@ -25,6 +25,8 @@ concurrency:
 jobs:
   test:
     runs-on: macos-11
+    env:
+      NDK_ABI_FILTERS: x86_64
     steps:
       - name: 👀 Check out repository
         uses: actions/checkout@v2
@@ -58,6 +60,9 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('android/*.gradle*') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
+      - name: 💿 Patch react-native to support single abi
+        run: sed -i '' 's/^APP_ABI := .*$/APP_ABI := $(if $(NDK_ABI_FILTERS),$(NDK_ABI_FILTERS),$(armeabi-v7a x86 arm64-v8a x86_64))/g' ReactAndroid/src/main/jni/Application.mk
+        working-directory: react-native-lab/react-native
       - name: 🎸 Run instrumented unit tests
         uses: reactivecircus/android-emulator-runner@v2
         with:

--- a/.github/workflows/android-instrumentation-tests.yml
+++ b/.github/workflows/android-instrumentation-tests.yml
@@ -67,4 +67,5 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 29
+          arch: x86_64
           script: bin/expotools android-native-unit-tests --type instrumented

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -149,6 +149,8 @@ jobs:
 
   android:
     runs-on: macos-11
+    env:
+      NDK_ABI_FILTERS: x86_64
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v2
@@ -186,6 +188,9 @@ jobs:
       - name: Clean Detox
         run: yarn detox:clean
         working-directory: apps/bare-expo
+      - name: Patch react-native to support single abi
+        run: sed -i '' 's/^APP_ABI := .*$/APP_ABI := $(if $(NDK_ABI_FILTERS),$(NDK_ABI_FILTERS),$(armeabi-v7a x86 arm64-v8a x86_64))/g' ReactAndroid/src/main/jni/Application.mk
+        working-directory: react-native-lab/react-native
       - name: Prebuild react-native AAR
         # Workaround for next `yarn android:detox:build:release` occasionally failed at gradle fetching libraries on GitHub Actions
         # Just to introduce another trail for gradle building.
@@ -204,6 +209,7 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 29
+          arch: x86_64
           avd-name: bare-expo
           script: yarn android:detox:test:release
           working-directory: ./apps/bare-expo

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -188,7 +188,7 @@ jobs:
       - name: Clean Detox
         run: yarn detox:clean
         working-directory: apps/bare-expo
-      - name: Patch react-native to support single abi
+      - name: 💿 Patch react-native to support single abi
         run: sed -i '' 's/^APP_ABI := .*$/APP_ABI := $(if $(NDK_ABI_FILTERS),$(NDK_ABI_FILTERS),$(armeabi-v7a x86 arm64-v8a x86_64))/g' ReactAndroid/src/main/jni/Application.mk
         working-directory: react-native-lab/react-native
       - name: Prebuild react-native AAR

--- a/apps/bare-expo/android/app/build.gradle
+++ b/apps/bare-expo/android/app/build.gradle
@@ -137,7 +137,9 @@ android {
             // [Custom]: Required for expo-app-auth
             appAuthRedirectScheme: "dev.expo.payments"
         ]
-
+        ndk {
+            abiFilters(*(System.getenv('NDK_ABI_FILTERS') ?: 'armeabi-v7a x86 arm64-v8a x86_64').split(' '))
+        }
         testBuildType System.getProperty('testBuildType', 'debug')
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }


### PR DESCRIPTION
# Why

as we have more ci jobs now, this pr tries to reduce android ci testing time by building x86_64 only.

# How

that is pretty much like what we did in Android Client job but patch the code on the fly.
time savings:
- test suite android ~ 10m
- android instrumented test ~15m

# Test Plan

ci jobs passed.
