### PR TITLE
[expo] update react-native-safe-area-context to 3.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Package-specific changes not released in any SDK will be added here just before 
 - Updated `react-native-webview` from `11.6.2` to `11.13.0`. ([#14301](https://github.com/expo/expo/pull/14301) by [@kudo](https://github.com/kudo))
 - Updated `react-native-lottie` from `4.0.2` to `4.0.3`. ([#14331](https://github.com/expo/expo/pull/14331) by [@cruzach](https://github.com/cruzach))
 - Updated `react-native-screens` from `3.4.0` to `3.7.0`. ([#14330](https://github.com/expo/expo/pull/14330) by [@cruzach](https://github.com/cruzach))
+- Updated `react-native-safe-area-context` from `3.2.0` to `3.3.2`. ([#14303](https://github.com/expo/expo/pull/14303) by [@kudo](https://github.com/kudo))
 
 ### 🛠 Breaking changes
 

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -114,7 +114,7 @@
     "react-native-appearance": "~0.3.4",
     "react-native-gesture-handler": "~1.10.2",
     "react-native-reanimated": "~2.2.0",
-    "react-native-safe-area-context": "3.2.0",
+    "react-native-safe-area-context": "3.3.2",
     "react-native-screens": "~3.7.0",
     "react-native-shared-element": "0.8.2",
     "react-native-svg": "12.1.1",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -150,7 +150,7 @@
     "react-native-paper": "^4.0.1",
     "react-native-reanimated": "~2.2.0",
     "react-native-redash": "^14.1.1",
-    "react-native-safe-area-context": "3.2.0",
+    "react-native-safe-area-context": "3.3.2",
     "react-native-safe-area-view": "^0.14.8",
     "react-native-screens": "~3.7.0",
     "react-native-shared-element": "0.8.2",

--- a/home/package.json
+++ b/home/package.json
@@ -59,7 +59,7 @@
     "react-native-maps": "0.28.0",
     "react-native-paper": "^4.0.1",
     "react-native-reanimated": "~2.2.0",
-    "react-native-safe-area-context": "3.2.0",
+    "react-native-safe-area-context": "3.3.2",
     "react-native-screens": "~3.7.0",
     "react-redux": "^7.2.0",
     "react-string-replace": "^0.4.4",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -93,7 +93,7 @@
   "react-native-maps": "0.28.0",
   "react-native-pager-view": "5.0.12",
   "react-native-reanimated": "~2.2.0",
-  "react-native-safe-area-context": "3.2.0",
+  "react-native-safe-area-context": "3.3.2",
   "react-native-screens": "~3.7.0",
   "react-native-shared-element": "0.8.2",
   "react-native-svg": "12.1.1",

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -71,7 +71,7 @@
     "invariant": "^2.2.2",
     "md5-file": "^3.2.3",
     "pretty-format": "^26.4.0",
-    "react-native-safe-area-context": "3.2.0",
+    "react-native-safe-area-context": "3.3.2",
     "serialize-error": "^2.1.0",
     "uuid": "^3.4.0"
   },


### PR DESCRIPTION
# Why

update modules for sdk 43
close [ENG-1893](https://linear.app/expo/issue/ENG-1893/upgrade-react-native-safe-area-context)

# How

`et update-vendored-module -m react-native-safe-area-context -c v3.3.2`
there were [no native changes](https://github.com/th3rdwave/react-native-safe-area-context/compare/v3.2.0..v3.3.2) and the only change for user might be the introduction of `react-native-safe-area-context/jest/mock`. perhaps it's not necessary to update to update this module.

# Test Plan

NCL

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).