### PR TITLE
[expo-modules][android] Extract `ModuleDestroyedException` into `expo-modules-core`

### DIFF
--- a/packages/expo-barcode-scanner/android/src/main/java/expo/modules/barcodescanner/BarCodeScannerViewFinder.kt
+++ b/packages/expo-barcode-scanner/android/src/main/java/expo/modules/barcodescanner/BarCodeScannerViewFinder.kt
@@ -8,6 +8,7 @@ import android.util.Log
 import android.view.TextureView
 import android.view.TextureView.SurfaceTextureListener
 import expo.modules.core.ModuleRegistryDelegate
+import expo.modules.core.errors.ModuleDestroyedException
 import expo.modules.interfaces.barcodescanner.BarCodeScannerInterface
 import expo.modules.interfaces.barcodescanner.BarCodeScannerProviderInterface
 import expo.modules.interfaces.barcodescanner.BarCodeScannerSettings
@@ -53,7 +54,7 @@ internal class BarCodeScannerViewFinder(
     finderSurfaceTexture = null
     stopCamera()
     try {
-      coroutineScope.cancel(ScopeCancellationException())
+      coroutineScope.cancel(ModuleDestroyedException("View destroyed, scope canceled"))
     } catch (e: Exception) {
       Log.w("ScannerViewFinder", e.message ?: "", e)
     }
@@ -203,7 +204,7 @@ internal class BarCodeScannerViewFinder(
           }
         }
         barCodeScannerTaskLock = false
-      } catch (e: ScopeCancellationException) {
+      } catch (e: ModuleDestroyedException) {
         Log.w("BarCodeScanner", e.message ?: "", e)
       }
     }

--- a/packages/expo-barcode-scanner/android/src/main/java/expo/modules/barcodescanner/ScopeCancelationException.kt
+++ b/packages/expo-barcode-scanner/android/src/main/java/expo/modules/barcodescanner/ScopeCancelationException.kt
@@ -1,5 +1,0 @@
-package expo.modules.barcodescanner
-
-import kotlinx.coroutines.CancellationException
-
-class ScopeCancellationException : CancellationException("View destroyed, scope canceled")

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.kt
@@ -15,6 +15,7 @@ import expo.modules.core.ExportedModule
 import expo.modules.core.ModuleRegistry
 import expo.modules.core.ModuleRegistryDelegate
 import expo.modules.core.Promise
+import expo.modules.core.errors.ModuleDestroyedException
 import expo.modules.core.interfaces.ActivityEventListener
 import expo.modules.core.interfaces.ActivityProvider
 import expo.modules.core.interfaces.ExpoMethod
@@ -56,7 +57,7 @@ class ImagePickerModule(
   override fun onDestroy() {
     try {
       mUIManager.unregisterLifecycleEventListener(this)
-      moduleCoroutineScope.cancel(ModuleDestroyedException())
+      moduleCoroutineScope.cancel(ModuleDestroyedException(ImagePickerConstants.PROMISES_CANCELED))
     } catch (e: IllegalStateException) {
       Log.e(ImagePickerConstants.TAG, "The scope does not have a job in it")
     }

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ModuleDestroyedException.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ModuleDestroyedException.kt
@@ -1,5 +1,0 @@
-package expo.modules.imagepicker
-
-import kotlinx.coroutines.CancellationException
-
-class ModuleDestroyedException : CancellationException(ImagePickerConstants.PROMISES_CANCELED)

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/tasks/ImageResultTask.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/tasks/ImageResultTask.kt
@@ -7,10 +7,10 @@ import android.util.Base64
 import android.util.Log
 import androidx.exifinterface.media.ExifInterface
 import expo.modules.core.Promise
+import expo.modules.core.errors.ModuleDestroyedException
 import expo.modules.imagepicker.ExifDataHandler
 import expo.modules.imagepicker.ImagePickerConstants
 import expo.modules.imagepicker.ImagePickerConstants.exifTags
-import expo.modules.imagepicker.ModuleDestroyedException
 import expo.modules.imagepicker.exporters.ImageExporter
 import expo.modules.imagepicker.exporters.ImageExporter.Listener
 import expo.modules.imagepicker.fileproviders.FileProvider

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/tasks/VideoResultTask.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/tasks/VideoResultTask.kt
@@ -6,8 +6,8 @@ import android.net.Uri
 import android.os.Bundle
 import android.util.Log
 import expo.modules.core.Promise
+import expo.modules.core.errors.ModuleDestroyedException
 import expo.modules.imagepicker.ImagePickerConstants
-import expo.modules.imagepicker.ModuleDestroyedException
 import expo.modules.imagepicker.fileproviders.FileProvider
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageModule.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageModule.kt
@@ -1,5 +1,6 @@
 package expo.modules.image
 
+import android.util.Log
 import com.bumptech.glide.Glide
 import com.bumptech.glide.load.model.GlideUrl
 import com.bumptech.glide.request.FutureTarget
@@ -9,9 +10,12 @@ import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.bridge.ReactMethod
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runInterruptible
 import java.lang.Exception
+import java.lang.IllegalStateException
+import java.util.concurrent.CancellationException
 
 /**
  * We need to convert blocking java.util.concurrent.Future result
@@ -41,5 +45,16 @@ class ExpoImageModule(val context: ReactApplicationContext) : ReactContextBaseJa
         promise.reject("ERR_IMAGE_PREFETCH_FAILURE", "Failed to prefetch the image: ${e.message}", e)
       }
     }
+  }
+
+  override fun onCatalystInstanceDestroy() {
+    try {
+      // TODO: Use [expo.modules.core.errors.ModuleDestroyedException] when migrated to Expo Module
+      moduleCoroutineScope.cancel(CancellationException("ExpoImage module is destroyed. Cancelling all jobs."))
+    } catch (e: IllegalStateException) {
+      Log.w("ExpoImageModule", "No coroutines to cancel")
+    }
+
+    super.onCatalystInstanceDestroy()
   }
 }

--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -75,6 +75,9 @@ dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${safeExtGet('kotlinVersion', '1.4.21')}"
   implementation 'androidx.annotation:annotation:1.2.0'
 
+  // used only in `expo.modules.core.errors.ModuleDestroyedException` for API export
+  compileOnly("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.3")
+
   //noinspection GradleDynamicVersion
   implementation 'com.facebook.react:react-native:+'
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/core/errors/ModuleDestroyedException.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/core/errors/ModuleDestroyedException.kt
@@ -1,0 +1,22 @@
+package expo.modules.core.errors
+
+import kotlinx.coroutines.CancellationException
+
+private const val DEFAULT_MESSAGE = "Module destroyed. All coroutines are cancelled."
+
+/**
+ * Can be passed as parameter to [kotlinx.coroutines.cancel] when module is destroyed
+ * in order to cancel all coroutines in [kotlinx.coroutines.CoroutineScope]
+ *
+ * Example usage:
+ * ```
+ * override fun onDestroy() {
+ *   try {
+ *     moduleCoroutineScope.cancel(ModuleDestroyedException())
+ *   } catch (e: IllegalStateException) {
+ *     Log.w(TAG, "The scope does not have a job in it")
+ *   }
+ * }
+ * ```
+ */
+class ModuleDestroyedException(message: String = DEFAULT_MESSAGE) : CancellationException(message)


### PR DESCRIPTION
# Why

Extracts common API across all modules that use Kotlin coroutines. Instead of recreating the same class among modules, we can use single shared codebase

cc @M1ST4KE 

# How

- Moved `ModuleDestroyedException` from `expo-image-picker` to `expo-modules-core`
- Replaced `ScopeCancellationException` in `expo-barcode-scanner` with the new exception
- Implemented missing coroutine cancellation on module destruction in `expo-image`

# Test Plan

API-only change. Built bare-expo to check if it compiles.