### PR TITLE
[core] Add missing imports to iOS frameworks

### DIFF
--- a/packages/expo-modules-core/ios/Swift/CodedError.swift
+++ b/packages/expo-modules-core/ios/Swift/CodedError.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 /**
  A protocol for errors specyfing its `code` and providing the `description`.
  */

--- a/packages/expo-modules-core/ios/Swift/Methods/AnyMethod.swift
+++ b/packages/expo-modules-core/ios/Swift/Methods/AnyMethod.swift
@@ -1,3 +1,4 @@
+import Dispatch
 
 /**
  A protocol for any type-erased module's method.

--- a/packages/expo-modules-core/ios/Swift/Methods/ConcreteMethod.swift
+++ b/packages/expo-modules-core/ios/Swift/Methods/ConcreteMethod.swift
@@ -1,3 +1,4 @@
+import Dispatch
 
 public class ConcreteMethod<Args, ReturnType>: AnyMethod {
   public typealias ClosureType = (Args) -> ReturnType

--- a/packages/expo-modules-core/ios/Swift/ModuleHolder.swift
+++ b/packages/expo-modules-core/ios/Swift/ModuleHolder.swift
@@ -1,3 +1,4 @@
+import Dispatch
 
 /**
  Holds a reference to the module instance and caches its definition.

--- a/packages/expo-modules-core/ios/Swift/Modules/ModuleDefinitionComponents.swift
+++ b/packages/expo-modules-core/ios/Swift/Modules/ModuleDefinitionComponents.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 /**
  Extends all modules with the functions used to build a module definition.
  Unfortunately they need to be scoped here, but hopefully this proposal

--- a/packages/expo-modules-core/ios/Swift/Views/AnyViewProp.swift
+++ b/packages/expo-modules-core/ios/Swift/Views/AnyViewProp.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 /**
  Type-erased protocol for view props classes.
  */

--- a/packages/expo-modules-core/ios/Swift/Views/ConcreteViewProp.swift
+++ b/packages/expo-modules-core/ios/Swift/Views/ConcreteViewProp.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 /**
  Specialized class for the view prop. Specifies the prop name and its setter.
  */

--- a/packages/expo-modules-core/ios/Swift/Views/ViewFactory.swift
+++ b/packages/expo-modules-core/ios/Swift/Views/ViewFactory.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 /**
  A definition of the view factory that creates views.
  */

--- a/packages/expo-modules-core/ios/Swift/Views/ViewManagerDefinition.swift
+++ b/packages/expo-modules-core/ios/Swift/Views/ViewManagerDefinition.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 /**
  The definition of the view manager. It's part of the module definition to scope only view-related definitions.
  */

--- a/packages/expo-modules-core/ios/Swift/Views/ViewModuleWrapper.swift
+++ b/packages/expo-modules-core/ios/Swift/Views/ViewModuleWrapper.swift
@@ -1,3 +1,6 @@
+import UIKit
+import ObjectiveC
+
 /**
  A protocol that helps in identifying whether the instance of `ViewModuleWrapper` is of a dynamically created class.
  */


### PR DESCRIPTION
# Why

Importing iOS frameworks such as UIKit and Foundation is not necessary in most cases, but it's needed for prebuilds.

# How

- Locally enabled prebuilds for `expo-modules-core`
- `et prebuild expo-modules-core`
- Add missing imports based on given errors

# Test Plan

Got much less errors, but there are still some other remaining errors 😢 (we will resolve them separately)
