### PR TITLE
[et] Fix `remove-sdk-version` (can't find TestSuiteTests.java)

### DIFF
--- a/tools/src/versioning/android/index.ts
+++ b/tools/src/versioning/android/index.ts
@@ -42,7 +42,7 @@ const expoviewConstantsPath = path.join(
 );
 const testSuiteTestsPath = path.join(
   appPath,
-  'src/androidTest/java/host/exp/exponent/TestSuiteTests.java'
+  'src/androidTest/java/host/exp/exponent/TestSuiteTests.kt'
 );
 const versionedReactAndroidPath = path.join(ANDROID_DIR, 'versioned-react-native/ReactAndroid');
 const versionedReactAndroidJniPath = path.join(versionedReactAndroidPath, 'src/main');


### PR DESCRIPTION
# Why

Fixes `remove-sdk-version`
![image](https://user-images.githubusercontent.com/9578601/132374649-b2de7ddc-dfde-4d61-8def-e21f66b4d6b0.png)

# Test Plan

- run `et remove-sdk-version` -p android