### PR TITLE
[ci] reduce android unit test time 

### DIFF
--- a/.github/workflows/android-unit-tests.yml
+++ b/.github/workflows/android-unit-tests.yml
@@ -27,6 +27,8 @@ concurrency:
 jobs:
   test:
     runs-on: ubuntu-18.04
+    env:
+      NDK_ABI_FILTERS: x86_64
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
@@ -63,6 +65,9 @@ jobs:
         run: |
           sudo $ANDROID_SDK_ROOT/tools/bin/sdkmanager --install "ndk;19.2.5345600"
       - run: echo "$(pwd)/bin" >> $GITHUB_PATH
+      - name: Patch react-native to support single abi
+        run: sed -i 's/^APP_ABI := .*$/APP_ABI := $(if $(NDK_ABI_FILTERS),$(NDK_ABI_FILTERS),$(armeabi-v7a x86 arm64-v8a x86_64))/g' ReactAndroid/src/main/jni/Application.mk
+        working-directory: react-native-lab/react-native
       - name: Run Spotless lint check
         env:
           ANDROID_NDK_HOME: /usr/local/lib/android/sdk/ndk/19.2.5345600/

--- a/tools/src/commands/AndroidNativeUnitTests.ts
+++ b/tools/src/commands/AndroidNativeUnitTests.ts
@@ -85,7 +85,7 @@ export async function androidNativeUnitTests({
     console.log(chalk.yellow(pkg.packageSlug));
   });
 
-  const testCommand = type === 'instrumented' ? 'connectedAndroidTest' : 'test';
+  const testCommand = type === 'instrumented' ? 'connectedAndroidTest' : 'testDebugUnitTest';
 
   const partition = <T>(arr: T[], condition: (T) => boolean) => {
     const trues = arr.filter((el) => condition(el));


### PR DESCRIPTION
# Why

reduce android unit test ci time (idea from @lukmccall)

# How

- run unit tests for only debug variant 
- build native code for only x86_64 abi

time saving for android unit test workflow ~ 15m

# Test Plan

ci passed
