### PR TITLE
[tools] Fix obtaining PR's diff in code-review command

### DIFF
--- a/tools/src/code-review/index.ts
+++ b/tools/src/code-review/index.ts
@@ -27,22 +27,22 @@ export async function reviewPullRequestAsync(prNumber: number) {
   const pr = await GitHub.getPullRequestAsync(prNumber);
   const user = await GitHub.getAuthenticatedUserAsync();
 
-  // Fetch the base commit with a depth that is equal to the number of commits in the PR increased by one.
-  // The last one is a merge base.
-  logger.info(
-    '👾 Fetching base commit',
-    chalk.yellow.bold(pr.head.sha),
-    'with depth',
-    chalk.yellow((pr.commits + 1).toString())
-  );
+  logger.info('👾 Fetching head commit', chalk.yellow.bold(pr.head.sha));
   await Git.fetchAsync({
     remote: 'origin',
     ref: pr.head.sha,
-    depth: pr.commits + 1,
+    depth: 1,
+  });
+
+  logger.info('👾 Fetching base commit', chalk.yellow.bold(pr.base.sha));
+  await Git.fetchAsync({
+    remote: 'origin',
+    ref: pr.base.sha,
+    depth: 1,
   });
 
   // Get the diff of the pull request.
-  const diff = await Git.getDiffAsync(`${pr.head.sha}~${pr.commits}`, pr.head.sha);
+  const diff = await Git.getDiffAsync(pr.base.sha, pr.head.sha);
 
   const input: ReviewInput = {
     pullRequest: pr,


### PR DESCRIPTION
# Why

It turned out that our automated code review obtains a diff different than we see on GitHub when the PR contains a merge commit.

# How

I changed the commits that we use to get a diff.

# Test Plan

I tested it locally on a few Simek's PRs that contains merge commits.
