### PR TITLE
[tools] Another try to fix obtaining PR's diff

### DIFF
--- a/tools/src/code-review/index.ts
+++ b/tools/src/code-review/index.ts
@@ -1,6 +1,5 @@
 import chalk from 'chalk';
 
-import Git from '../Git';
 import * as GitHub from '../GitHub';
 import logger from '../Logger';
 import { COMMENT_HEADER, generateReportFromOutputs } from './reports';
@@ -27,22 +26,8 @@ export async function reviewPullRequestAsync(prNumber: number) {
   const pr = await GitHub.getPullRequestAsync(prNumber);
   const user = await GitHub.getAuthenticatedUserAsync();
 
-  logger.info('👾 Fetching head commit', chalk.yellow.bold(pr.head.sha));
-  await Git.fetchAsync({
-    remote: 'origin',
-    ref: pr.head.sha,
-    depth: 1,
-  });
-
-  logger.info('👾 Fetching base commit', chalk.yellow.bold(pr.base.sha));
-  await Git.fetchAsync({
-    remote: 'origin',
-    ref: pr.base.sha,
-    depth: 1,
-  });
-
   // Get the diff of the pull request.
-  const diff = await Git.getDiffAsync(pr.base.sha, pr.head.sha);
+  const diff = await GitHub.getPullRequestDiffAsync(prNumber);
 
   const input: ReviewInput = {
     pullRequest: pr,


### PR DESCRIPTION
# Why

Bot's comment is incorrect again 😭 See https://github.com/expo/expo/pull/14343#issuecomment-915166513

# How

Changed the way how we get PR's diff. Now it uses GitHub API to get it (I checked how `github-cli` does it), previously we used `git` command.

# Test Plan

Tested locally on aforementioned PR
