### PR TITLE
[modules-core] Fix crashes in the project that doesn't contain any swift modules

### DIFF
--- a/packages/expo-modules-core/ios/NativeModulesProxy/EXNativeModulesProxy.m
+++ b/packages/expo-modules-core/ios/NativeModulesProxy/EXNativeModulesProxy.m
@@ -52,7 +52,7 @@ RCT_EXPORT_MODULE(NativeUnimoduleProxy)
 {
   if (self = [super init]) {
     _exModuleRegistry = moduleRegistry != nil ? moduleRegistry : [[EXModuleRegistryProvider new] moduleRegistry];
-    _swiftInteropBridge = [[SwiftInteropBridge alloc] initWithModulesProvider:[NSClassFromString(@"ExpoModulesProvider") new] legacyModuleRegistry:_exModuleRegistry];
+    _swiftInteropBridge = [[SwiftInteropBridge alloc] initWithModulesProvider:[self getExpoModulesProvider] legacyModuleRegistry:_exModuleRegistry];
     _exportedMethodsKeys = [NSMutableDictionary dictionary];
     _exportedMethodsReverseKeys = [NSMutableDictionary dictionary];
     _ownsModuleRegistry = moduleRegistry == nil;
@@ -171,6 +171,17 @@ RCT_EXPORT_METHOD(callMethod:(NSString *)moduleName methodNameOrKey:(id)methodNa
 }
 
 #pragma mark - Privates
+
+- (id<ModulesProviderObjCProtocol>)getExpoModulesProvider
+{
+  Class generatedExpoModulesProvider = NSClassFromString(@"ExpoModulesProvider");
+  // Checks if `ExpoModulesProvider` was generated
+  if (generatedExpoModulesProvider) {
+    return [generatedExpoModulesProvider new];
+  } else {
+    return [ModulesProvider new];
+  }
+}
 
 - (void)registerExpoModulesInBridge:(RCTBridge *)bridge
 {


### PR DESCRIPTION
# Why

Fixes crash in the project that doesn't contain any swift modules.

# How

If a project doesn't contain any swift modules, auto-linking doesn't generate `ExpoModulesProvider` what leads to crashes.
Cheks if that class was added, if no use empty modules provider.

# Test Plan

- simple app without any modules