### PR TITLE
[modules-core] Fix compatibility with RN 0.65 (view manager installation)

### DIFF
--- a/packages/expo-modules-core/ios/NativeModulesProxy/EXNativeModulesProxy.m
+++ b/packages/expo-modules-core/ios/NativeModulesProxy/EXNativeModulesProxy.m
@@ -6,6 +6,7 @@
 #import <React/RCTUIManager.h>
 #import <React/RCTComponentData.h>
 #import <React/RCTModuleData.h>
+#import <React/RCTEventDispatcherProtocol.h>
 
 #import <ExpoModulesCore/EXNativeModulesProxy.h>
 #import <ExpoModulesCore/EXEventEmitter.h>
@@ -25,6 +26,13 @@ static const NSString *methodInfoArgumentsCountKey = @"argumentsCount";
 @interface RCTBridge (RegisterAdditionalModuleClasses)
 
 - (void)registerAdditionalModuleClasses:(NSArray<Class> *)modules;
+
+@end
+
+@interface RCTComponentData (EXRCTComponentData)
+
+- (instancetype)initWithManagerClass:(Class)managerClass bridge:(RCTBridge *)bridge eventDispatcher:(id<RCTEventDispatcherProtocol>) eventDispatcher; // available in RN 0.65+
+- (instancetype)initWithManagerClass:(Class)managerClass bridge:(RCTBridge *)bridge;
 
 @end
 
@@ -243,31 +251,15 @@ RCT_EXPORT_METHOD(callMethod:(NSString *)moduleName methodNameOrKey:(id)methodNa
     NSString *className = NSStringFromClass(moduleClass);
 
     if ([moduleClass isSubclassOfClass:[RCTViewManager class]] && !componentDataByName[className]) {
-      SEL componentDataInit;
-      bool attachEventDispatcher = false;
       RCTComponentData *componentData = [RCTComponentData alloc];
-      
-      // Init method was changed in RN 0.65
-      if ([componentData respondsToSelector:NSSelectorFromString(@"initWithManagerClass:bridge:eventDispatcher:")]) {
-        componentDataInit = NSSelectorFromString(@"initWithManagerClass:bridge:eventDispatcher:");
-        attachEventDispatcher = true;
+      if ([componentData respondsToSelector:@selector(initWithManagerClass:bridge:eventDispatcher:)]) {
+        // Init method was changed in RN 0.65
+        [componentData initWithManagerClass:moduleClass bridge:bridge eventDispatcher:bridge.eventDispatcher];
       } else {
         // fallback for older RNs
-        componentDataInit = NSSelectorFromString(@"initWithManagerClass:bridge:");
+        [componentData initWithManagerClass:moduleClass bridge:bridge];
       }
       
-      NSMethodSignature *signature = [componentData methodSignatureForSelector:componentDataInit];
-      NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
-      
-      [invocation setTarget:componentData];
-      [invocation setSelector:componentDataInit];
-      [invocation setArgument:&moduleClass atIndex:2];
-      [invocation setArgument:&bridge atIndex:3];
-      if (attachEventDispatcher) {
-        [invocation setArgument:(__bridge void * _Nonnull)(bridge.eventDispatcher) atIndex:4];
-      }
-      
-      [invocation invoke];
       componentDataByName[className] = componentData;
     }
   }

--- a/packages/expo-modules-core/ios/NativeModulesProxy/EXNativeModulesProxy.m
+++ b/packages/expo-modules-core/ios/NativeModulesProxy/EXNativeModulesProxy.m
@@ -29,7 +29,7 @@ static const NSString *methodInfoArgumentsCountKey = @"argumentsCount";
 
 @end
 
-@interface RCTComponentData (EXRCTComponentData)
+@interface RCTComponentData (EXNativeModulesProxy)
 
 - (instancetype)initWithManagerClass:(Class)managerClass bridge:(RCTBridge *)bridge eventDispatcher:(id<RCTEventDispatcherProtocol>) eventDispatcher; // available in RN 0.65+
 - (instancetype)initWithManagerClass:(Class)managerClass bridge:(RCTBridge *)bridge;


### PR DESCRIPTION
# Why

Fixes the new installation method of view managers that doesn't compile with RN 0.65.

# How

In the newest RN, the Facebook team changed the signature of the `RCTComponentData` constructor. 

# Test Plan

- simple app with RN 0.65
```js
import React from "react";
import { StyleSheet, Text, View } from "react-native";
import { LinearGradient } from "expo-linear-gradient";

export default function App() {
  return (
    <View style={styles.container} testID="LocalAppMainScreen">
      <LinearGradient
        // Background Linear Gradient
        colors={["rgba(0,0,0,0.8)", "transparent"]}
        style={styles.background}
      />
      <Text>Open up App.js to start working on your app!</Text>
    </View>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    backgroundColor: "#fff",
    alignItems: "center",
    justifyContent: "center",
  },
  background: {
    position: "absolute",
    left: 0,
    right: 0,
    top: 0,
    height: 300,
  },
});
```