### PR TITLE
[android][ncl][image] Add test screen for `prefetch` method

### DIFF
--- a/apps/native-component-list/src/screens/Image/ImageMethods.tsx
+++ b/apps/native-component-list/src/screens/Image/ImageMethods.tsx
@@ -1,24 +1,41 @@
 import ExpoImage from 'expo-image';
+import React from 'react';
+import { View, Text } from 'react-native';
 
-import { ImageMethodNames, ImageMethodResult } from './types';
+import { ImageMethodResult } from './types';
 
 export async function getImageMethodResult(
-  methodName: ImageMethodNames,
+  method: Function,
   uri: string
 ): Promise<ImageMethodResult> {
-  let result = '';
-  const time = 0; // TODO: measure time
-  if (methodName === ImageMethodNames.Prefetch) {
-    result = await ExpoImage.prefetch(uri)
+  let message = '';
+  const startTime = performance.now();
+  if (method.name === 'prefetch') {
+    message = await ExpoImage.prefetch(uri)
       .then(() => {
-        return 'succes';
+        return 'success';
       })
       .catch(() => {
         return 'failure';
       });
   }
   return {
-    result,
-    time,
+    message,
+    time: performance.now() - startTime,
   };
+}
+
+type PropsType = {
+  methodResult: ImageMethodResult;
+};
+
+export function MethodResultView({ methodResult }: PropsType) {
+  const message = methodResult.message;
+  const time = methodResult.time;
+  return message && time ? (
+    <View>
+      <Text>Method result: {message}</Text>
+      <Text>Time: {time.toFixed(0)}ms</Text>
+    </View>
+  ) : null;
 }

--- a/apps/native-component-list/src/screens/Image/ImageMethods.tsx
+++ b/apps/native-component-list/src/screens/Image/ImageMethods.tsx
@@ -1,0 +1,24 @@
+import ExpoImage from 'expo-image';
+
+import { ImageMethodNames, ImageMethodResult } from './types';
+
+export async function getImageMethodResult(
+  methodName: ImageMethodNames,
+  uri: string
+): Promise<ImageMethodResult> {
+  let result = '';
+  const time = 0; // TODO: measure time
+  if (methodName === ImageMethodNames.Prefetch) {
+    result = await ExpoImage.prefetch(uri)
+      .then(() => {
+        return 'succes';
+      })
+      .catch(() => {
+        return 'failure';
+      });
+  }
+  return {
+    result,
+    time,
+  };
+}

--- a/apps/native-component-list/src/screens/Image/ImageTestScreen.tsx
+++ b/apps/native-component-list/src/screens/Image/ImageTestScreen.tsx
@@ -12,10 +12,11 @@ import {
   setSelectedCompareComponent,
 } from './ImageComponents';
 import ImageEventsView from './ImageEventsView';
+import { getImageMethodResult } from './ImageMethods';
 import ImageStylesView from './ImageStylesView';
 import ImageTestView from './ImageTestView';
 import { resolveProps } from './resolveProps';
-import { ImageTest, Links } from './types';
+import { ImageMethodNames, ImageTest, Links } from './types';
 
 const AnimatedImage = Animated.Image;
 AnimatedImage.displayName = 'Image';
@@ -36,6 +37,7 @@ export default function ImageTestScreen({ navigation, route }: Props) {
   const [viewKey, setViewKey] = React.useState<string>('initial');
   const [events, setEvents] = React.useState<string[]>([]);
   const [loadDemanded, setLoadDemanded] = React.useState<boolean>(false);
+  const [methodResult, setMethodResult] = React.useState<string>('');
 
   React.useLayoutEffect(() => {
     const { test } = route.params;
@@ -106,6 +108,13 @@ export default function ImageTestScreen({ navigation, route }: Props) {
     setLoadDemanded(true);
   };
 
+  const onPressMethod = async () => {
+    if (test.method != null) {
+      const methodResult = await getImageMethodResult(test.method, test.props.source.uri);
+      setMethodResult(methodResult.result);
+    }
+  };
+
   const onClearEvents = () => setEvents([]);
 
   const isComponentLoaded = () => !loadOnDemand || loadDemanded;
@@ -136,9 +145,16 @@ export default function ImageTestScreen({ navigation, route }: Props) {
         </View>
       )}
       {!isComponentLoaded() && (
-        <View>
-          <Button title="Load" onPress={onPressLoad} />
-        </View>
+        <>
+          {test.method != null && (
+            <View style={{ borderBottomWidth: 10, borderBottomColor: 'transparent' }}>
+              <Button title={ImageMethodNames[test.method]} onPress={onPressMethod} />
+            </View>
+          )}
+          <View>
+            <Button title="Load" onPress={onPressLoad} />
+          </View>
+        </>
       )}
       <CompareBar
         collapsed={!compareEnabled}
@@ -156,6 +172,14 @@ export default function ImageTestScreen({ navigation, route }: Props) {
         </View>
       )}
       {hasEvents && <ImageEventsView onClear={onClearEvents} events={events} />}
+      {}
+      {test.method != null && methodResult.length > 0 && (
+        <View>
+          <Text>
+            {ImageMethodNames[test.method]} result: {methodResult}
+          </Text>
+        </View>
+      )}
     </View>
   );
 }

--- a/apps/native-component-list/src/screens/Image/ImageTestScreen.tsx
+++ b/apps/native-component-list/src/screens/Image/ImageTestScreen.tsx
@@ -1,6 +1,6 @@
 import { StackScreenProps } from '@react-navigation/stack';
 import * as React from 'react';
-import { Animated, StyleSheet, View, Button, Text, Image as ReactImage } from 'react-native';
+import { Animated, StyleSheet, View, Button, Text } from 'react-native';
 
 import HeaderIconButton, { HeaderContainerRight } from '../../components/HeaderIconButton';
 import AnimationBar from './AnimationBar';

--- a/apps/native-component-list/src/screens/Image/images/images.ts
+++ b/apps/native-component-list/src/screens/Image/images/images.ts
@@ -15,6 +15,7 @@ const images = {
   uri_jpg: { uri: 'https://docs.expo.io/static/images/flappy_00.jpg' },
   uri_gif: { uri: 'https://docs.expo.io/static/images/flappy_03.gif' },
   uri_ico: { uri: 'https://docs.expo.io/static/images/favicon.ico' },
+  uri_lorem_picsum: { uri: 'https://picsum.photos/800' },
   uri_youtube_svg: {
     uri: 'https://www.youtube.com/about/static/svgs/icons/brand-resources/YouTube-logo-full_color_light.svg?cache=72a5d9c',
   },

--- a/apps/native-component-list/src/screens/Image/tests/index.tsx
+++ b/apps/native-component-list/src/screens/Image/tests/index.tsx
@@ -4,6 +4,7 @@ import AppearanceTests from './appearance';
 import BorderTests from './borders';
 import EventTests from './events';
 import IOSTests from './ios';
+import MethodsTests from './methods';
 import ShadowsTests from './shadows';
 import SourcesTests from './sources';
 
@@ -17,6 +18,7 @@ const tests: ImageTestGroup = {
     EventTests,
     IOSTests,
     AndroidTests,
+    MethodsTests,
   ],
 };
 

--- a/apps/native-component-list/src/screens/Image/tests/methods.tsx
+++ b/apps/native-component-list/src/screens/Image/tests/methods.tsx
@@ -1,0 +1,19 @@
+import { images } from '../images';
+import { ImageMethodNames, ImageTestGroup } from '../types';
+
+const imageTests: ImageTestGroup = {
+  name: 'Methods',
+  tests: [
+    {
+      name: 'prefetch',
+      props: {
+        source: images.uri_png,
+        defaultSource: images.require_monochrome,
+      },
+      loadOnDemand: true,
+      method: ImageMethodNames.Prefetch,
+    },
+  ],
+};
+
+export default imageTests;

--- a/apps/native-component-list/src/screens/Image/tests/methods.tsx
+++ b/apps/native-component-list/src/screens/Image/tests/methods.tsx
@@ -1,5 +1,8 @@
+import ExpoImage from 'expo-image';
+import { Image as ReactImage } from 'react-native';
+
 import { images } from '../images';
-import { ImageMethodNames, ImageTestGroup } from '../types';
+import { ImageTestGroup } from '../types';
 
 const imageTests: ImageTestGroup = {
   name: 'Methods',
@@ -7,11 +10,12 @@ const imageTests: ImageTestGroup = {
     {
       name: 'prefetch',
       props: {
-        source: images.uri_png,
+        source: images.uri_lorem_picsum,
         defaultSource: images.require_monochrome,
       },
       loadOnDemand: true,
-      method: ImageMethodNames.Prefetch,
+      method: ExpoImage.prefetch,
+      reactMethod: ReactImage.prefetch,
     },
   ],
 };

--- a/apps/native-component-list/src/screens/Image/types.ts
+++ b/apps/native-component-list/src/screens/Image/types.ts
@@ -16,24 +16,17 @@ export type ImageTestPropsFn = (input: ImageTestPropsFnInput) => ImageProps;
 
 export type ImageTestProps = ImageProps | ImageTestPropsFn;
 
-export enum ImageMethodNames {
-  AbortPrefetch,
-  GetSize,
-  GetSizeWithHeaders,
-  Prefetch,
-  QueryCache,
-}
-
 export type ImageMethodResult = {
-  result: string;
-  time: number;
+  message?: string;
+  time?: number;
 };
 
 export interface ImageTest {
   name: string;
   props: ImageTestProps;
   loadOnDemand?: boolean;
-  method?: ImageMethodNames;
+  method?: Function;
+  reactMethod?: Function;
   testInformation?: string;
 }
 

--- a/apps/native-component-list/src/screens/Image/types.ts
+++ b/apps/native-component-list/src/screens/Image/types.ts
@@ -16,10 +16,24 @@ export type ImageTestPropsFn = (input: ImageTestPropsFnInput) => ImageProps;
 
 export type ImageTestProps = ImageProps | ImageTestPropsFn;
 
+export enum ImageMethodNames {
+  AbortPrefetch,
+  GetSize,
+  GetSizeWithHeaders,
+  Prefetch,
+  QueryCache,
+}
+
+export type ImageMethodResult = {
+  result: string;
+  time: number;
+};
+
 export interface ImageTest {
   name: string;
   props: ImageTestProps;
   loadOnDemand?: boolean;
+  method?: ImageMethodNames;
   testInformation?: string;
 }
 


### PR DESCRIPTION
# Why

To test `prefetch` method

# How

- Added optional button to run static method
- Added optional text to display result of static method
- Added new `ImageTestGroup` `methods`
- Added test screen for `prefetch` method

# Test Plan

Native component list.

<img width="169" alt="Screenshot 2021-09-09 at 15 55 43" src="https://user-images.githubusercontent.com/56194058/132699160-a872ff50-0e68-4acc-a3d5-723f46662648.png">

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).