### PR TITLE
[updates] Fix declared dependencies in expo-updates and related packages

### DIFF
--- a/packages/expo-json-utils/android/build.gradle
+++ b/packages/expo-json-utils/android/build.gradle
@@ -72,8 +72,6 @@ android {
 }
 
 dependencies {
-  implementation project(':expo-modules-core')
-
   testImplementation 'junit:junit:4.12'
   testImplementation 'androidx.test:core:1.0.0'
   testImplementation 'org.mockito:mockito-core:1.10.19'

--- a/packages/expo-json-utils/ios/EXJSONUtils.podspec
+++ b/packages/expo-json-utils/ios/EXJSONUtils.podspec
@@ -13,8 +13,6 @@ Pod::Spec.new do |s|
   s.platform       = :ios, '11.0'
   s.source         = { git: 'https://github.com/expo/expo.git' }
 
-  s.dependency 'ExpoModulesCore'
-
   s.pod_target_xcconfig = {
     'GCC_TREAT_INCOMPATIBLE_POINTER_TYPE_WARNINGS_AS_ERRORS' => 'YES',
     'GCC_TREAT_IMPLICIT_FUNCTION_DECLARATIONS_AS_ERRORS' => 'YES'

--- a/packages/expo-manifests/android/build.gradle
+++ b/packages/expo-manifests/android/build.gradle
@@ -72,7 +72,6 @@ android {
 }
 
 dependencies {
-  implementation project(':expo-modules-core')
   implementation project(':expo-json-utils')
 
   testImplementation 'junit:junit:4.12'

--- a/packages/expo-manifests/ios/EXManifests.podspec
+++ b/packages/expo-manifests/ios/EXManifests.podspec
@@ -13,7 +13,6 @@ Pod::Spec.new do |s|
   s.platform       = :ios, '11.0'
   s.source         = { git: 'https://github.com/expo/expo.git' }
 
-  s.dependency 'ExpoModulesCore'
   s.dependency 'EXJSONUtils'
 
   s.pod_target_xcconfig = {

--- a/packages/expo-structured-headers/android/build.gradle
+++ b/packages/expo-structured-headers/android/build.gradle
@@ -70,7 +70,6 @@ repositories {
 }
 
 dependencies {
-  implementation project(':expo-modules-core')
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${safeExtGet('kotlinVersion', '1.4.21')}"
   implementation "androidx.appcompat:appcompat:1.2.0"
 

--- a/packages/expo-structured-headers/ios/EXStructuredHeaders.podspec
+++ b/packages/expo-structured-headers/ios/EXStructuredHeaders.podspec
@@ -13,8 +13,6 @@ Pod::Spec.new do |s|
   s.platform       = :ios, '11.0'
   s.source         = { git: 'https://github.com/expo/expo.git' }
 
-  s.dependency 'ExpoModulesCore'
-
   if !$ExpoUseSources&.include?(package['name']) && ENV['EXPO_USE_SOURCE'].to_i == 0 && File.exist?("#{s.name}.xcframework") && Gem::Version.new(Pod::VERSION) >= Gem::Version.new('1.10.0')
     s.source_files = "#{s.name}/**/*.h"
     s.vendored_frameworks = "#{s.name}.xcframework"

--- a/packages/expo-updates-interface/android/build.gradle
+++ b/packages/expo-updates-interface/android/build.gradle
@@ -65,5 +65,7 @@ repositories {
 }
 
 dependencies {
+  implementation project(':expo-modules-core')
+
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${safeExtGet("kotlinVersion", "1.3.50")}"
 }

--- a/packages/expo-updates/package.json
+++ b/packages/expo-updates/package.json
@@ -34,19 +34,20 @@
     "preset": "expo-module-scripts"
   },
   "dependencies": {
-    "@expo/metro-config": "^0.1.81",
-    "@expo/config-plugins": "^3.0.7",
     "@expo/config": "^5.0.6",
+    "@expo/config-plugins": "^3.0.7",
+    "@expo/metro-config": "^0.1.81",
+    "expo-manifests": "~0.1.0",
+    "expo-modules-core": "~0.3.0",
     "expo-structured-headers": "~1.1.0",
     "expo-updates-interface": "~0.2.2",
-    "expo-manifests": "~0.1.0",
     "fbemitter": "^2.1.1",
-    "uuid": "^3.4.0",
-    "resolve-from": "^5.0.0"
+    "resolve-from": "^5.0.0",
+    "uuid": "^3.4.0"
   },
   "devDependencies": {
     "expo-module-scripts": "^2.0.0",
-    "memfs": "^3.2.0",
-    "fs-extra": "^9.1.0"
+    "fs-extra": "^9.1.0",
+    "memfs": "^3.2.0"
   }
 }


### PR DESCRIPTION
# Why

It turned out that 
- `expo-json-utils`, `expo-manifests`, `expo-structured-headers` declare native dependency on `expo-modules-core`, but in fact they don't depend on it
- `expo-updates-interface` is missing the dependency on `expo-modules-core` on Android
- `expo-updates` is missing the dependency on `expo-modules-core` in package.json

# How

Just fixed all of these issues mentioned above

# Test Plan

CI