### PR TITLE
[android][location] Backport google services workaround for location provider

### DIFF
--- a/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/expo/modules/location/LocationModule.java
+++ b/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/expo/modules/location/LocationModule.java
@@ -501,20 +501,21 @@ public class LocationModule extends ExportedModule implements LifecycleEventList
     final FusedLocationProviderClient locationProvider = getLocationProvider();
 
     LocationCallback locationCallback = new LocationCallback() {
+      boolean isLocationAvailable = false;
       @Override
       public void onLocationResult(LocationResult locationResult) {
         Location location = locationResult != null ? locationResult.getLastLocation() : null;
 
         if (location != null) {
           callbacks.onLocationChanged(location);
+        } else if (!isLocationAvailable) {
+          callbacks.onLocationError(new LocationUnavailableException());
         }
       }
 
       @Override
       public void onLocationAvailability(LocationAvailability locationAvailability) {
-        if (!locationAvailability.isLocationAvailable()) {
-          callbacks.onLocationError(new LocationUnavailableException());
-        }
+        isLocationAvailable = locationAvailability.isLocationAvailable();
       }
     };
 

--- a/android/versioned-abis/expoview-abi41_0_0/src/main/java/abi41_0_0/expo/modules/location/LocationModule.java
+++ b/android/versioned-abis/expoview-abi41_0_0/src/main/java/abi41_0_0/expo/modules/location/LocationModule.java
@@ -552,20 +552,21 @@ public class LocationModule extends ExportedModule implements LifecycleEventList
     final FusedLocationProviderClient locationProvider = getLocationProvider();
 
     LocationCallback locationCallback = new LocationCallback() {
+      boolean isLocationAvailable = false;
       @Override
       public void onLocationResult(LocationResult locationResult) {
         Location location = locationResult != null ? locationResult.getLastLocation() : null;
 
         if (location != null) {
           callbacks.onLocationChanged(location);
+        } else if (!isLocationAvailable) {
+          callbacks.onLocationError(new LocationUnavailableException());
         }
       }
 
       @Override
       public void onLocationAvailability(LocationAvailability locationAvailability) {
-        if (!locationAvailability.isLocationAvailable()) {
-          callbacks.onLocationError(new LocationUnavailableException());
-        }
+        isLocationAvailable = locationAvailability.isLocationAvailable();
       }
     };
 

--- a/android/versioned-abis/expoview-abi42_0_0/src/main/java/abi42_0_0/expo/modules/location/LocationModule.java
+++ b/android/versioned-abis/expoview-abi42_0_0/src/main/java/abi42_0_0/expo/modules/location/LocationModule.java
@@ -548,20 +548,21 @@ public class LocationModule extends ExportedModule implements LifecycleEventList
     final FusedLocationProviderClient locationProvider = getLocationProvider();
 
     LocationCallback locationCallback = new LocationCallback() {
+      boolean isLocationAvailable = false;
       @Override
       public void onLocationResult(LocationResult locationResult) {
         Location location = locationResult != null ? locationResult.getLastLocation() : null;
 
         if (location != null) {
           callbacks.onLocationChanged(location);
+        } else if (!isLocationAvailable) {
+          callbacks.onLocationError(new LocationUnavailableException());
         }
       }
 
       @Override
       public void onLocationAvailability(LocationAvailability locationAvailability) {
-        if (!locationAvailability.isLocationAvailable()) {
-          callbacks.onLocationError(new LocationUnavailableException());
-        }
+        isLocationAvailable = locationAvailability.isLocationAvailable();
       }
     };
 


### PR DESCRIPTION
# Why

Backported #14281 on master for SDK 43 (and 42, 41, 40), see #14248

> Note, SDKs [42](https://github.com/expo/expo/pull/14356), [41](https://github.com/expo/expo/pull/14353), [40](https://github.com/expo/expo/pull/14354), and [39](https://github.com/expo/expo/pull/14355) have all received the same backport already. This is just for `master` and to make sure SDK 43 will include this fix as well.

# How

Cherry-pick, versioning, and tested with [the devices listed here](https://github.com/expo/expo/issues/14248#issuecomment-915547919).

# Test Plan

- Build the Expo Go app
- Use the [example project](https://github.com/byCedric/google-play-services-location-workaround)
- Validate if location works and the "Location provider is unavailable" doesn't pop up

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).