### PR TITLE
Draft: Documentation update: add appDelegateHeader mod/plugin

### DIFF
--- a/docs/pages/guides/config-plugins.md
+++ b/docs/pages/guides/config-plugins.md
@@ -245,6 +245,7 @@ module.exports = {
 The following default mods are provided by the mod compiler for common file manipulation:
 
 - `mods.ios.appDelegate` -- Modify the `ios/<name>/AppDelegate.m` as a string.
+- `mods.ios.appDelegateHeader` -- Modify the `ios/<name>/AppDelegate.h` as a string.
 - `mods.ios.infoPlist` -- Modify the `ios/<name>/Info.plist` as JSON (parsed with [`@expo/plist`](https://www.npmjs.com/package/@expo/plist)).
 - `mods.ios.entitlements` -- Modify the `ios/<name>/<product-name>.entitlements` as JSON (parsed with [`@expo/plist`](https://www.npmjs.com/package/@expo/plist)).
 - `mods.ios.expoPlist` -- Modify the `ios/<name>/Expo.plist` as JSON (Expo updates config for iOS) (parsed with [`@expo/plist`](https://www.npmjs.com/package/@expo/plist)).
@@ -272,6 +273,7 @@ Instead you should use the helper mods provided by `@expo/config-plugins`:
 
 - iOS
   - `withAppDelegate`
+  - `withAppDelegateHeader`
   - `withInfoPlist`
   - `withEntitlementsPlist`
   - `withExpoPlist`


### PR DESCRIPTION
# Why

This is a documentation update in case https://github.com/expo/expo-cli/pull/3839 is accepted.

# How

n/a

# Test Plan

n/a

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).