### PR TITLE
[ci] Update Xcode to 13.0 on GitHub Actions

### DIFF
--- a/.github/workflows/client-ios.yml
+++ b/.github/workflows/client-ios.yml
@@ -40,8 +40,8 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: true
-      - name: 🔨 Switch to Xcode 12.5.1
-        run: sudo xcode-select --switch /Applications/Xcode_12.5.1.app
+      - name: 🔨 Switch to Xcode 13.0
+        run: sudo xcode-select --switch /Applications/Xcode_13.0.app
       - name: 🍺 Setup Homebrew
         run: brew install git-crypt
       - name: 🔓 decrypt secrets if possible

--- a/.github/workflows/ios-unit-tests.yml
+++ b/.github/workflows/ios-unit-tests.yml
@@ -35,6 +35,8 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
+      - name: 🔨 Switch to Xcode 13.0
+        run: sudo xcode-select --switch /Applications/Xcode_13.0.app
       - run: brew install git-crypt
       - name: decrypt secrets if possible
         env:

--- a/.github/workflows/shell-app-ios.yml
+++ b/.github/workflows/shell-app-ios.yml
@@ -28,8 +28,8 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
-      - name: 🔨 Switch to Xcode 12.5.1
-        run: sudo xcode-select --switch /Applications/Xcode_12.5.1.app
+      - name: 🔨 Switch to Xcode 13.0
+        run: sudo xcode-select --switch /Applications/Xcode_13.0.app
       - name: 🍺 Setup
         run: |
           echo "$(pwd)/bin" >> $GITHUB_PATH

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -72,6 +72,8 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: true
+      - name: 🔨 Switch to Xcode 12.5.1
+        run: sudo xcode-select --switch /Applications/Xcode_12.5.1.app
       - name: 🍺 Install required tools
         run: |
           brew tap wix/brew

--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -23,8 +23,8 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: true
-      - name: 🔨 Switch to Xcode 12.5.1
-        run: sudo xcode-select --switch /Applications/Xcode_12.5.1.app
+      - name: 🔨 Switch to Xcode 13.0
+        run: sudo xcode-select --switch /Applications/Xcode_13.0.app
       - name: 🍺 Setup Homebrew
         run: brew install git-crypt
       - name: 🔓 decrypt secrets if possible

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -56,13 +56,13 @@
         "binaryPath": "ios/build/Build/Products/Debug-iphonesimulator/BareExpoDetox.app",
         "build": "./scripts/build-detox-ios.sh Debug",
         "type": "ios.simulator",
-        "name": "iPhone 11"
+        "name": "iPhone 12"
       },
       "ios.sim.release": {
         "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/BareExpoDetox.app",
         "build": "./scripts/build-detox-ios.sh Release YES",
         "type": "ios.simulator",
-        "name": "iPhone 11"
+        "name": "iPhone 12"
       },
       "android.emu.debug": {
         "binaryPath": "android/app/build/outputs/apk/debug/app-debug.apk",


### PR DESCRIPTION
# Why

Preparing to update Xcode to 13.0 before the final version comes out

# How

- Updated steps that switch to specific Xcode version
- Added same step to jobs that were not specyfing Xcode version (imho it's better to be explicit everywhere)
- Left `test-suite` on Xcode 12.5.1 because detox doesn't support iOS 15 yet (see https://github.com/wix/Detox/issues/2895)

# Test Plan

Let's check on the CI
