### PR TITLE
Recommend different PHP sdk for notifications

### DIFF
--- a/docs/pages/push-notifications/sending-notifications.md
+++ b/docs/pages/push-notifications/sending-notifications.md
@@ -21,7 +21,7 @@ When you're ready to send a push notification, take the Expo push token from you
 - [expo-server-sdk-ruby](https://github.com/expo/expo-server-sdk-ruby) for Ruby. Maintained by community developers.
 - [expo-server-sdk-rust](https://github.com/expo/expo-server-sdk-rust) for Rust. Maintained by community developers.
 - [ExpoNotificationsBundle](https://github.com/solvecrew/ExpoNotificationsBundle) for Symfony. Maintained by SolveCrew.
-- [exponent-server-sdk-php](https://github.com/Alymosul/exponent-server-sdk-php) for PHP. Maintained by community developers.
+- [expo-server-sdk-php](https://github.com/ctwillie/expo-server-sdk-php) for PHP. Maintained by community developers.
 - [exponent-server-sdk-golang](https://github.com/oliveroneill/exponent-server-sdk-golang) for Golang. Maintained by community developers.
 - [exponent-server-sdk-elixir](https://github.com/rdrop/exponent-server-sdk-elixir) for Elixir. Maintained by community developers.
 - [expo-server-sdk-dotnet](https://github.com/glyphard/expo-server-sdk-dotnet) for dotnet. Maintained by community developers.

--- a/docs/pages/push-notifications/sending-notifications.md
+++ b/docs/pages/push-notifications/sending-notifications.md
@@ -21,7 +21,7 @@ When you're ready to send a push notification, take the Expo push token from you
 - [expo-server-sdk-ruby](https://github.com/expo/expo-server-sdk-ruby) for Ruby. Maintained by community developers.
 - [expo-server-sdk-rust](https://github.com/expo/expo-server-sdk-rust) for Rust. Maintained by community developers.
 - [ExpoNotificationsBundle](https://github.com/solvecrew/ExpoNotificationsBundle) for Symfony. Maintained by SolveCrew.
-- [expo-server-sdk-php](https://github.com/ctwillie/expo-server-sdk-php) for PHP. Maintained by community developers.
+- [exponent-server-sdk-php](https://github.com/Alymosul/exponent-server-sdk-php) or [expo-server-sdk-php](https://github.com/ctwillie/expo-server-sdk-php) for PHP. Maintained by community developers.
 - [exponent-server-sdk-golang](https://github.com/oliveroneill/exponent-server-sdk-golang) for Golang. Maintained by community developers.
 - [exponent-server-sdk-elixir](https://github.com/rdrop/exponent-server-sdk-elixir) for Elixir. Maintained by community developers.
 - [expo-server-sdk-dotnet](https://github.com/glyphard/expo-server-sdk-dotnet) for dotnet. Maintained by community developers.


### PR DESCRIPTION
# Why

The currently recommended PHP sdk for sending push notifications has several issues.

1. Contains bugs and incorrect logic.
2. Is lacking important documentation.
3. Does not behave as documented for applications running on multiple app servers.
4. Has absolutely no tests.

What have I done before proposing we recommend another package?

Submitted a PR for the package addressing ALL of the issues above. The maintainer of the package took weeks to respond,  during which time I created another package that is properly documented and well tested.


# Test Plan

The package I am recommending is well tested and the current one is not.

The package I am recommending follows closely the logic from the node sdk and has some similar features.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).