### PR TITLE
[expo-updates][ios] add error recovery manager

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1992,6 +1992,7 @@ PODS:
     - ExpoModulesCore
     - EXStructuredHeaders
     - EXUpdatesInterface
+    - OCMockito (~> 6.0)
     - React-Core
   - EXUpdatesInterface (0.4.0)
   - EXVideoThumbnails (6.0.1):
@@ -2158,6 +2159,9 @@ PODS:
   - nanopb/decode (2.30907.0)
   - nanopb/encode (2.30907.0)
   - Nimble (9.2.0)
+  - OCHamcrest (8.0.0)
+  - OCMockito (6.0.0):
+    - OCHamcrest (~> 8.0)
   - PromisesObjC (1.2.12)
   - Protobuf (3.14.0)
   - Quick (4.0.0)
@@ -2959,6 +2963,8 @@ SPEC REPOS:
     - MLKitFaceDetection
     - MLKitVision
     - nanopb
+    - OCHamcrest
+    - OCMockito
     - PromisesObjC
     - Protobuf
     - Stripe
@@ -4202,7 +4208,7 @@ SPEC CHECKSUMS:
   EXStructuredHeaders: ba85104bb57e861129872a30e2cf7adaa348c4ac
   EXTaskManager: 7e50f7dd4121d82f26ffcc11295d82c7be105101
   EXTrackingTransparency: c196e5ee0468c389dda6962a800f5501438e6a7a
-  EXUpdates: 6ecb609984681120661469f6f4b126cfce737836
+  EXUpdates: 484722c091293bfb951e21f427e173b7c412c5b1
   EXUpdatesInterface: e1c01b4f5ec76bd1d6cc714938f9edf5ef6379b9
   EXVideoThumbnails: 889ce82cc5d3d355fac0558b3dfbfac2f769c23c
   EXWebBrowser: a3c5694129ee18c4ff4f2269b7077b3fbaf8dc35
@@ -4239,6 +4245,8 @@ SPEC CHECKSUMS:
   MLKitVision: 51385878c9100024478971856510f9271ff555b5
   nanopb: 59221d7f958fb711001e6a449489542d92ae113e
   Nimble: 9ca39ec3cb156bbb8c27f4943fd4643d28729616
+  OCHamcrest: a613690381f1dac7637c18962c10dbe8feca4bb5
+  OCMockito: 780f04370226f81a9d972c97d1203864ef609f5b
   PromisesObjC: 3113f7f76903778cf4a0586bd1ab89329a0b7b97
   Protobuf: 0cde852566359049847168e51bd1c690e0f70056
   Quick: 5dc45f9bc11236594a7acc99f7bd85ecdc9a477d

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🎉 New features
 
+- Add error recovery manager on iOS. ([#14397](https://github.com/expo/expo/pull/14397) by [@esamelson](https://github.com/esamelson))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-updates/ios/EXUpdates.podspec
+++ b/packages/expo-updates/ios/EXUpdates.podspec
@@ -48,5 +48,6 @@ Pod::Spec.new do |s|
 
   s.test_spec 'Tests' do |test_spec|
     test_spec.source_files = 'Tests/*.{h,m,swift}'
+    test_spec.dependency 'OCMockito', '~> 6.0'
   end
 end

--- a/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesAppLauncher.h
+++ b/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesAppLauncher.h
@@ -4,6 +4,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+typedef void (^EXUpdatesAppLauncherCompletionBlock)(NSError * _Nullable error, BOOL success);
+
 @protocol EXUpdatesAppLauncher
 
 @property (nullable, nonatomic, strong, readonly) EXUpdatesUpdate *launchedUpdate;

--- a/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesAppLauncherWithDatabase.h
+++ b/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesAppLauncherWithDatabase.h
@@ -5,7 +5,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef void (^EXUpdatesAppLauncherCompletionBlock)(NSError * _Nullable error, BOOL success);
 typedef void (^EXUpdatesAppLauncherUpdateCompletionBlock)(NSError * _Nullable error, EXUpdatesUpdate * _Nullable launchableUpdate);
 
 @interface EXUpdatesAppLauncherWithDatabase : NSObject <EXUpdatesAppLauncher>

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesErrorRecovery.h
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesErrorRecovery.h
@@ -1,0 +1,49 @@
+//  Copyright © 2021 650 Industries. All rights reserved.
+
+#import <EXUpdates/EXUpdatesAppLauncher.h>
+#import <EXUpdates/EXUpdatesConfig.h>
+#import <EXUpdates/EXUpdatesDatabase.h>
+#import <EXUpdates/EXUpdatesSelectionPolicy.h>
+#import <EXUpdates/EXUpdatesUpdate.h>
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef NS_ENUM(NSInteger, EXUpdatesRemoteLoadStatus) {
+  EXUpdatesRemoteLoadStatusIdle,
+  EXUpdatesRemoteLoadStatusLoading,
+  EXUpdatesRemoteLoadStatusNewUpdateLoaded
+};
+
+@protocol EXUpdatesErrorRecoveryDelegate <NSObject>
+
+@property (nonatomic, readonly, strong) EXUpdatesUpdate *launchedUpdate;
+@property (nonatomic, readonly, assign) EXUpdatesRemoteLoadStatus remoteLoadStatus;
+
+- (void)relaunchWithCompletion:(EXUpdatesAppLauncherCompletionBlock)completion;
+- (void)loadRemoteUpdate;
+
+- (void)markFailedLaunchForLaunchedUpdate;
+- (void)markSuccessfulLaunchForLaunchedUpdate;
+
+- (void)throwException:(NSException *)exception;
+
+@end
+
+@interface EXUpdatesErrorRecovery : NSObject
+
+@property (nonatomic, weak) id<EXUpdatesErrorRecoveryDelegate> delegate;
+
+// for testing purposes
+- (instancetype)initWithErrorRecoveryQueue:(dispatch_queue_t)errorRecoveryQueue
+                         remoteLoadTimeout:(NSInteger)remoteLoadTimeout;
+
+- (void)startMonitoring;
+
+- (void)handleError:(NSError *)error;
+- (void)handleException:(NSException *)exception;
+- (void)notifyNewRemoteLoadStatus:(EXUpdatesRemoteLoadStatus)newStatus;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesErrorRecovery.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesErrorRecovery.m
@@ -119,6 +119,8 @@ static NSInteger const EXUpdatesErrorRecoveryRemoteLoadTimeoutMs = 5000;
     case EXUpdatesErrorRecoveryTaskWaitForRemoteUpdate:
       [self _waitForRemoteLoaderToFinish];
       break;
+        // EXUpdatesErrorRecoveryTaskLaunchNew is called only after a new update is downloaded
+        // and added to the cache, so it equivalent to EXUpdatesErrorRecoveryTaskLaunchCached
     case EXUpdatesErrorRecoveryTaskLaunchNew:
     case EXUpdatesErrorRecoveryTaskLaunchCached:
       [self _tryRelaunchFromCache];

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesErrorRecovery.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesErrorRecovery.m
@@ -152,7 +152,6 @@ static NSInteger const EXUpdatesErrorRecoveryRemoteLoadTimeoutMs = 5000;
   } else {
     _isWaitingForRemoteUpdate = YES;
     [_delegate loadRemoteUpdate];
-    [self _runNextTask];
   }
 }
 

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesErrorRecovery.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesErrorRecovery.m
@@ -119,8 +119,8 @@ static NSInteger const EXUpdatesErrorRecoveryRemoteLoadTimeoutMs = 5000;
     case EXUpdatesErrorRecoveryTaskWaitForRemoteUpdate:
       [self _waitForRemoteLoaderToFinish];
       break;
-        // EXUpdatesErrorRecoveryTaskLaunchNew is called only after a new update is downloaded
-        // and added to the cache, so it equivalent to EXUpdatesErrorRecoveryTaskLaunchCached
+    // EXUpdatesErrorRecoveryTaskLaunchNew is called only after a new update is downloaded
+    // and added to the cache, so it is equivalent to EXUpdatesErrorRecoveryTaskLaunchCached
     case EXUpdatesErrorRecoveryTaskLaunchNew:
     case EXUpdatesErrorRecoveryTaskLaunchCached:
       [self _tryRelaunchFromCache];
@@ -241,7 +241,7 @@ static NSInteger const EXUpdatesErrorRecoveryRemoteLoadTimeoutMs = 5000;
   // wait 10s before unsetting error handlers; even though we won't try to
   // relaunch if our handlers are triggered after now, we still want to give
   // the EXUpdatesErrorRecoveryTaskWaitForRemoteUpdate task a reasonable
-  // amount of time to run and fetch a new update, in case there is one
+  // window of time to start and check for a new update is there is one
   dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 10 * NSEC_PER_SEC), _errorRecoveryQueue, ^{
     [self _unsetRCTErrorHandlers];
   });

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesErrorRecovery.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesErrorRecovery.m
@@ -1,0 +1,283 @@
+//  Copyright © 2021 650 Industries. All rights reserved.
+
+#import <EXUpdates/EXUpdatesAppLauncherWithDatabase.h>
+#import <EXUpdates/EXUpdatesErrorRecovery.h>
+#import <React/RCTAssert.h>
+#import <React/RCTBridge.h>
+#import <React/RCTRootView.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef NS_ENUM(NSInteger, EXUpdatesErrorRecoveryTask) {
+  EXUpdatesErrorRecoveryTaskWaitForRemoteUpdate,
+  EXUpdatesErrorRecoveryTaskLaunchNew,
+  EXUpdatesErrorRecoveryTaskLaunchCached,
+  EXUpdatesErrorRecoveryTaskCrash
+};
+
+static NSInteger const EXUpdatesErrorRecoveryRemoteLoadTimeoutMs = 5000;
+
+@interface EXUpdatesErrorRecovery ()
+
+@property (nonatomic, strong) NSMutableArray<NSNumber *> *pipeline;
+@property (nonatomic, assign) BOOL isRunning;
+@property (nonatomic, assign) BOOL isWaitingForRemoteUpdate;
+@property (nonatomic, assign) BOOL rctContentHasAppeared;
+@property (nonatomic, assign) NSInteger remoteLoadTimeout;
+
+@property (nonatomic, strong) dispatch_queue_t errorRecoveryQueue;
+
+@property (nonatomic, strong) NSMutableArray *encounteredErrors;
+
+@property (nonatomic, copy) RCTFatalHandler previousFatalErrorHandler;
+@property (nonatomic, copy) RCTFatalExceptionHandler previousFatalExceptionHandler;
+
+@end
+
+@implementation EXUpdatesErrorRecovery
+
+- (instancetype)init
+{
+  return [self initWithErrorRecoveryQueue:dispatch_queue_create("expo.controller.errorRecoveryQueue", DISPATCH_QUEUE_SERIAL)
+                        remoteLoadTimeout:EXUpdatesErrorRecoveryRemoteLoadTimeoutMs];
+}
+
+- (instancetype)initWithErrorRecoveryQueue:(dispatch_queue_t)errorRecoveryQueue
+                         remoteLoadTimeout:(NSInteger)remoteLoadTimeout
+{
+  if (self = [super init]) {
+    _pipeline = @[
+      @(EXUpdatesErrorRecoveryTaskWaitForRemoteUpdate),
+      @(EXUpdatesErrorRecoveryTaskLaunchCached),
+      @(EXUpdatesErrorRecoveryTaskCrash)
+    ].mutableCopy;
+    _isRunning = NO;
+    _isWaitingForRemoteUpdate = NO;
+    _rctContentHasAppeared = NO;
+    _errorRecoveryQueue = errorRecoveryQueue;
+    _remoteLoadTimeout = remoteLoadTimeout;
+    _encounteredErrors = [NSMutableArray new];
+  }
+  return self;
+}
+
+- (void)startMonitoring
+{
+  [self _setRCTErrorHandlers];
+}
+
+- (void)handleError:(NSError *)error
+{
+  [self _startPipelineWithEncounteredError:error];
+}
+
+- (void)handleException:(NSException *)exception
+{
+  [self _startPipelineWithEncounteredError:exception];
+}
+
+- (void)notifyNewRemoteLoadStatus:(EXUpdatesRemoteLoadStatus)newStatus
+{
+  dispatch_async(_errorRecoveryQueue, ^{
+    if (!self->_isWaitingForRemoteUpdate) {
+      return;
+    }
+    self->_isWaitingForRemoteUpdate = NO;
+    if (newStatus == EXUpdatesRemoteLoadStatusNewUpdateLoaded) {
+      [self->_pipeline insertObject:@(EXUpdatesErrorRecoveryTaskLaunchNew) atIndex:0];
+    }
+    [self _runNextTask];
+  });
+}
+
+# pragma mark - pipeline tasks
+
+- (void)_startPipelineWithEncounteredError:(id)encounteredError
+{
+  dispatch_async(_errorRecoveryQueue, ^{
+    [self->_encounteredErrors addObject:encounteredError];
+
+    if (self->_delegate.launchedUpdate.successfulLaunchCount > 0) {
+      [self->_pipeline removeObject:@(EXUpdatesErrorRecoveryTaskLaunchCached)];
+    } else if (!self->_rctContentHasAppeared) {
+      [self->_delegate markFailedLaunchForLaunchedUpdate];
+    }
+
+    if (!self->_isRunning) {
+      self->_isRunning = YES;
+      [self _runNextTask];
+    }
+  });
+}
+
+- (void)_runNextTask
+{
+  dispatch_assert_queue(_errorRecoveryQueue);
+  NSNumber *nextTask = _pipeline[0];
+  [_pipeline removeObjectAtIndex:0];
+  switch ((EXUpdatesErrorRecoveryTask)nextTask.integerValue) {
+    case EXUpdatesErrorRecoveryTaskWaitForRemoteUpdate:
+      [self _waitForRemoteLoaderToFinish];
+      break;
+    case EXUpdatesErrorRecoveryTaskLaunchNew:
+    case EXUpdatesErrorRecoveryTaskLaunchCached:
+      [self _tryRelaunchFromCache];
+      break;
+    case EXUpdatesErrorRecoveryTaskCrash:
+      [self _crash];
+      break;
+    default:
+      @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:@"EXUpdatesErrorRecovery cannot run the next task" userInfo:@{@"nextTaskValue": nextTask}];
+  }
+}
+
+- (void)_waitForRemoteLoaderToFinish
+{
+  dispatch_assert_queue(_errorRecoveryQueue);
+  if (_delegate.remoteLoadStatus == EXUpdatesRemoteLoadStatusLoading) {
+    _isWaitingForRemoteUpdate = YES;
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, _remoteLoadTimeout * NSEC_PER_MSEC), _errorRecoveryQueue, ^{
+      if (!self->_isWaitingForRemoteUpdate) {
+        return;
+      }
+      self->_isWaitingForRemoteUpdate = NO;
+      [self _runNextTask];
+    });
+    return;
+  } else if (_delegate.remoteLoadStatus == EXUpdatesRemoteLoadStatusNewUpdateLoaded) {
+    [_pipeline insertObject:@(EXUpdatesErrorRecoveryTaskLaunchNew) atIndex:0];
+    [self _runNextTask];
+  } else {
+    _isWaitingForRemoteUpdate = YES;
+    [_delegate loadRemoteUpdate];
+    [self _runNextTask];
+  }
+}
+
+- (void)_tryRelaunchFromCache
+{
+  dispatch_assert_queue(_errorRecoveryQueue);
+  [_delegate relaunchWithCompletion:^(NSError * _Nullable error, BOOL success) {
+    dispatch_async(self->_errorRecoveryQueue, ^{
+      if (!success) {
+        if (error) {
+          [self->_encounteredErrors addObject:error];
+        }
+        [self->_pipeline removeObject:@(EXUpdatesErrorRecoveryTaskLaunchCached)];
+        [self _runNextTask];
+      } else {
+        self->_isRunning = NO;
+      }
+    });
+  }];
+}
+
+- (void)_crash
+{
+  // create new exception object from stack of errors
+  // use the initial error and put the rest into userInfo
+  id initialError = _encounteredErrors[0];
+  [_encounteredErrors removeObjectAtIndex:0];
+
+  if ([initialError isKindOfClass:[NSError class]] && _previousFatalErrorHandler) {
+    _previousFatalErrorHandler(initialError);
+  } else if ([initialError isKindOfClass:[NSException class]] && _previousFatalExceptionHandler) {
+    _previousFatalExceptionHandler(initialError);
+  }
+
+  NSString *name;
+  NSString *reason;
+  NSMutableDictionary *userInfo;
+  if ([initialError isKindOfClass:[NSError class]]) {
+    // format these keys similar to RN -- RCTFatal in RCTAssert.m
+    name = [NSString stringWithFormat:@"%@: %@", RCTFatalExceptionName, ((NSError *)initialError).localizedDescription];
+    reason = RCTFormatError(((NSError *)initialError).localizedDescription, ((NSError *)initialError).userInfo[RCTJSStackTraceKey], 175);
+    userInfo = [((NSError *)initialError).userInfo mutableCopy];
+    userInfo[@"RCTUntruncatedMessageKey"] = RCTFormatError(((NSError *)initialError).localizedDescription, ((NSError *)initialError).userInfo[RCTJSStackTraceKey], -1);
+  } else if ([initialError isKindOfClass:[NSException class]]) {
+    name = ((NSException *)initialError).name;
+    reason = ((NSException *)initialError).reason;
+    userInfo = ((NSException *)initialError).userInfo.mutableCopy;
+  } else {
+    NSAssert(NO, @"Shouldn't add object types other than NSError or NSException to _encounteredErrors");
+  }
+
+  userInfo[@"EXUpdatesLaterEncounteredErrors"] = [_encounteredErrors copy];
+  [_delegate throwException:[NSException exceptionWithName:name reason:reason userInfo:userInfo]];
+}
+
+# pragma mark - monitoring / lifecycle
+
+- (void)_registerObservers
+{
+  [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(_handleJavaScriptDidFailToLoad) name:RCTJavaScriptDidFailToLoadNotification object:nil];
+  [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(_handleContentDidAppear) name:RCTContentDidAppearNotification object:nil];
+}
+
+- (void)_unregisterObservers
+{
+  [[NSNotificationCenter defaultCenter] removeObserver:self name:RCTJavaScriptDidFailToLoadNotification object:nil];
+  [[NSNotificationCenter defaultCenter] removeObserver:self name:RCTContentDidAppearNotification object:nil];
+}
+
+- (void)_handleJavaScriptDidFailToLoad
+{
+  [self _unregisterObservers];
+}
+
+- (void)_handleContentDidAppear
+{
+  [self _unregisterObservers];
+  [_delegate markSuccessfulLaunchForLaunchedUpdate];
+  dispatch_async(_errorRecoveryQueue, ^{
+    self->_rctContentHasAppeared = YES;
+    // the launch now counts as "successful" so we don't want to roll back;
+    // remove any extraneous tasks from the pipeline as such
+    self->_pipeline = [self->_pipeline objectsAtIndexes:[self->_pipeline indexesOfObjectsPassingTest:^BOOL(NSNumber *obj, NSUInteger idx, BOOL *stop) {
+      return obj.integerValue == EXUpdatesErrorRecoveryTaskWaitForRemoteUpdate || obj.integerValue == EXUpdatesErrorRecoveryTaskCrash;
+    }]].mutableCopy;
+  });
+  // wait 10s before unsetting error handlers; even though we won't try to
+  // relaunch if our handlers are triggered after now, we still want to give
+  // the EXUpdatesErrorRecoveryTaskWaitForRemoteUpdate task a reasonable
+  // amount of time to run and fetch a new update, in case there is one
+  dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 10 * NSEC_PER_SEC), _errorRecoveryQueue, ^{
+    [self _unsetRCTErrorHandlers];
+  });
+}
+
+- (void)_setRCTErrorHandlers
+{
+  dispatch_async(_errorRecoveryQueue, ^{
+    self->_rctContentHasAppeared = NO;
+  });
+  [self _registerObservers];
+
+  if (_previousFatalErrorHandler || _previousFatalExceptionHandler) {
+    return;
+  }
+
+  _previousFatalErrorHandler = RCTGetFatalHandler();
+  _previousFatalExceptionHandler = RCTGetFatalExceptionHandler();
+
+  RCTFatalHandler fatalErrorHandler = ^(NSError *error) {
+    [self handleError:error];
+  };
+  RCTFatalExceptionHandler fatalExceptionHandler = ^(NSException *exception) {
+    [self handleException:exception];
+  };
+  RCTSetFatalHandler(fatalErrorHandler);
+  RCTSetFatalExceptionHandler(fatalExceptionHandler);
+}
+
+- (void)_unsetRCTErrorHandlers
+{
+  RCTSetFatalHandler(_previousFatalErrorHandler);
+  RCTSetFatalExceptionHandler(_previousFatalExceptionHandler);
+  _previousFatalErrorHandler = nil;
+  _previousFatalExceptionHandler = nil;
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/ios/Tests/EXUpdatesErrorRecoveryTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesErrorRecoveryTests.m
@@ -1,0 +1,271 @@
+//  Copyright (c) 2021 650 Industries, Inc. All rights reserved.
+
+#import <XCTest/XCTest.h>
+
+#import <EXUpdates/EXUpdatesErrorRecovery.h>
+
+#import <OCHamcrest/OCHamcrest.h>
+#import <OCMockito/OCMockito.h>
+
+@interface EXUpdatesErrorRecoveryTests : XCTestCase
+
+@property (nonatomic, strong) EXUpdatesErrorRecovery *errorRecovery;
+@property (nonatomic, strong) dispatch_queue_t testQueue;
+@property (nonatomic, strong) EXUpdatesDatabase *mockDatabase;
+
+@end
+
+@implementation EXUpdatesErrorRecoveryTests
+
+- (void)setUp
+{
+  _testQueue = dispatch_queue_create("expo.errorRecoveryTestQueue", DISPATCH_QUEUE_SERIAL);
+  _errorRecovery = [[EXUpdatesErrorRecovery alloc] initWithErrorRecoveryQueue:_testQueue remoteLoadTimeout:500];
+  _mockDatabase = mock([EXUpdatesDatabase class]);
+  [given(_mockDatabase.databaseQueue) willReturn:_testQueue];
+}
+
+- (void)tearDown
+{
+  // Put teardown code here. This method is called after the invocation of each test method in the class.
+}
+
+- (void)testHandleError_NewWorkingUpdateAlreadyLoaded
+{
+  id<EXUpdatesErrorRecoveryDelegate> mockDelegate = mockProtocol(@protocol(EXUpdatesErrorRecoveryDelegate));
+  _errorRecovery.delegate = mockDelegate;
+
+  [given(mockDelegate.remoteLoadStatus) willReturnInteger:EXUpdatesRemoteLoadStatusNewUpdateLoaded];
+
+  NSError *mockError = mock([NSError class]);
+  [_errorRecovery handleError:mockError];
+  dispatch_sync(_testQueue, ^{}); // flush queue
+
+  [verify(mockDelegate) markFailedLaunchForLaunchedUpdate];
+  [self verifySuccessfulRelaunchWithCompletion_WithMockDelegate:mockDelegate];
+  [verifyCount(mockDelegate, never()) relaunchWithCompletion:(id)anything()];
+  [verifyCount(mockDelegate, never()) loadRemoteUpdate];
+  [verifyCount(mockDelegate, never()) throwException:anything()];
+}
+
+- (void)testHandleError_NewWorkingUpdateLoading
+{
+  id<EXUpdatesErrorRecoveryDelegate> mockDelegate = mockProtocol(@protocol(EXUpdatesErrorRecoveryDelegate));
+  _errorRecovery.delegate = mockDelegate;
+
+  [given(mockDelegate.remoteLoadStatus) willReturnInteger:EXUpdatesRemoteLoadStatusLoading];
+
+  NSError *mockError = mock([NSError class]);
+  [_errorRecovery handleError:mockError];
+
+  [given(mockDelegate.remoteLoadStatus) willReturnInteger:EXUpdatesRemoteLoadStatusNewUpdateLoaded];
+  [_errorRecovery notifyNewRemoteLoadStatus:EXUpdatesRemoteLoadStatusNewUpdateLoaded];
+  dispatch_sync(_testQueue, ^{}); // flush queue
+
+  [verify(mockDelegate) markFailedLaunchForLaunchedUpdate];
+  [self verifySuccessfulRelaunchWithCompletion_WithMockDelegate:mockDelegate];
+  [verifyCount(mockDelegate, never()) relaunchWithCompletion:(id)anything()];
+  [verifyCount(mockDelegate, never()) loadRemoteUpdate];
+  [verifyCount(mockDelegate, never()) throwException:anything()];
+}
+
+- (void)testHandleError_NewBrokenUpdateLoaded_WorkingUpdateCached
+{
+  id<EXUpdatesErrorRecoveryDelegate> mockDelegate = mockProtocol(@protocol(EXUpdatesErrorRecoveryDelegate));
+  _errorRecovery.delegate = mockDelegate;
+
+  [given(mockDelegate.remoteLoadStatus) willReturnInteger:EXUpdatesRemoteLoadStatusNewUpdateLoaded];
+
+  NSError *mockError = mock([NSError class]);
+  [_errorRecovery handleError:mockError];
+  dispatch_sync(_testQueue, ^{}); // flush queue
+
+  [verify(mockDelegate) markFailedLaunchForLaunchedUpdate];
+  [self verifySuccessfulRelaunchWithCompletion_WithMockDelegate:mockDelegate];
+
+  NSError *mockError2 = mock([NSError class]);
+  [_errorRecovery handleError:mockError2];
+  dispatch_sync(_testQueue, ^{}); // flush queue
+
+  [verify(mockDelegate) markFailedLaunchForLaunchedUpdate];
+  [self verifySuccessfulRelaunchWithCompletion_WithMockDelegate:mockDelegate];
+  [verifyCount(mockDelegate, never()) loadRemoteUpdate];
+  [verifyCount(mockDelegate, never()) throwException:anything()];
+}
+
+- (void)testHandleError_NewBrokenUpdateLoaded_UpdateAlreadyLaunchedSuccessfully
+{
+  // if an update has already been launched successfully, we don't want to fall back to an older update
+
+  id<EXUpdatesErrorRecoveryDelegate> mockDelegate = mockProtocol(@protocol(EXUpdatesErrorRecoveryDelegate));
+  _errorRecovery.delegate = mockDelegate;
+
+  EXUpdatesUpdate *mockUpdate = mock([EXUpdatesUpdate class]);
+  [given(mockUpdate.successfulLaunchCount) willReturnInteger:1];
+
+  [given(mockDelegate.launchedUpdate) willReturn:mockUpdate];
+  [given(mockDelegate.remoteLoadStatus) willReturnInteger:EXUpdatesRemoteLoadStatusNewUpdateLoaded];
+
+  NSError *mockError = mock([NSError class]);
+  [_errorRecovery handleError:mockError];
+  dispatch_sync(_testQueue, ^{}); // flush queue
+
+  [verifyCount(mockDelegate, never()) markFailedLaunchForLaunchedUpdate];
+  [self verifySuccessfulRelaunchWithCompletion_WithMockDelegate:mockDelegate];
+
+  [given(mockUpdate.successfulLaunchCount) willReturnInteger:0];
+  NSError *mockError2 = mock([NSError class]);
+  [_errorRecovery handleError:mockError2];
+  dispatch_sync(_testQueue, ^{}); // flush queue
+
+  [verify(mockDelegate) markFailedLaunchForLaunchedUpdate];
+  [verify(mockDelegate) throwException:anything()];
+  [verifyCount(mockDelegate, never()) relaunchWithCompletion:anything()];
+  [verifyCount(mockDelegate, never()) loadRemoteUpdate];
+}
+
+- (void)testHandleError_RemoteLoadTimesOut
+{
+  id<EXUpdatesErrorRecoveryDelegate> mockDelegate = mockProtocol(@protocol(EXUpdatesErrorRecoveryDelegate));
+  _errorRecovery.delegate = mockDelegate;
+
+  [given(mockDelegate.remoteLoadStatus) willReturnInteger:EXUpdatesRemoteLoadStatusLoading];
+
+  NSError *mockError = mock([NSError class]);
+  [_errorRecovery handleError:mockError];
+
+  // wait for more than 500ms
+  [NSThread sleepForTimeInterval:0.6f];
+  dispatch_sync(_testQueue, ^{}); // flush queue
+
+  [verify(mockDelegate) markFailedLaunchForLaunchedUpdate];
+  [self verifySuccessfulRelaunchWithCompletion_WithMockDelegate:mockDelegate];
+  [verifyCount(mockDelegate, never()) loadRemoteUpdate];
+  [verifyCount(mockDelegate, never()) throwException:anything()];
+}
+
+- (void)testHandleError_RemoteLoadTimesOut_UpdateAlreadyLaunchedSuccessfully
+{
+  // if an update has already been launched successfully, we don't want to fall back to an older update
+
+  id<EXUpdatesErrorRecoveryDelegate> mockDelegate = mockProtocol(@protocol(EXUpdatesErrorRecoveryDelegate));
+  _errorRecovery.delegate = mockDelegate;
+
+  EXUpdatesUpdate *mockUpdate = mock([EXUpdatesUpdate class]);
+  [given(mockUpdate.successfulLaunchCount) willReturnInteger:1];
+
+  [given(mockDelegate.launchedUpdate) willReturn:mockUpdate];
+  [given(mockDelegate.remoteLoadStatus) willReturnInteger:EXUpdatesRemoteLoadStatusLoading];
+
+  NSError *mockError = mock([NSError class]);
+  [_errorRecovery handleError:mockError];
+
+  // wait for more than 500ms
+  [NSThread sleepForTimeInterval:0.6f];
+  dispatch_sync(_testQueue, ^{}); // flush queue
+
+  [verify(mockDelegate) throwException:anything()];
+  [verifyCount(mockDelegate, never()) markFailedLaunchForLaunchedUpdate];
+  [verifyCount(mockDelegate, never()) relaunchWithCompletion:anything()];
+  [verifyCount(mockDelegate, never()) loadRemoteUpdate];
+}
+
+- (void)testHandleError_RemoteLoadTimesOut_RCTContentDidAppear
+{
+  id<EXUpdatesErrorRecoveryDelegate> mockDelegate = mockProtocol(@protocol(EXUpdatesErrorRecoveryDelegate));
+  _errorRecovery.delegate = mockDelegate;
+
+  [given(mockDelegate.remoteLoadStatus) willReturnInteger:EXUpdatesRemoteLoadStatusLoading];
+
+  [_errorRecovery startMonitoring];
+  [[NSNotificationCenter defaultCenter] postNotificationName:@"RCTContentDidAppearNotification" object:nil];
+  [verify(mockDelegate) markSuccessfulLaunchForLaunchedUpdate];
+
+  // if RCTContentDidAppear has already fired, we don't want to roll back to an older update
+  NSError *mockError = mock([NSError class]);
+  [_errorRecovery handleError:mockError];
+
+  // wait for more than 500ms
+  [NSThread sleepForTimeInterval:0.6f];
+  dispatch_sync(_testQueue, ^{}); // flush queue
+
+  [verify(mockDelegate) throwException:anything()];
+  [verifyCount(mockDelegate, never()) markFailedLaunchForLaunchedUpdate];
+  [verifyCount(mockDelegate, never()) relaunchWithCompletion:anything()];
+  [verifyCount(mockDelegate, never()) loadRemoteUpdate];
+}
+
+- (void)testHandleError_NoRemoteUpdate
+{
+  id<EXUpdatesErrorRecoveryDelegate> mockDelegate = mockProtocol(@protocol(EXUpdatesErrorRecoveryDelegate));
+  _errorRecovery.delegate = mockDelegate;
+
+  [given(mockDelegate.remoteLoadStatus) willReturnInteger:EXUpdatesRemoteLoadStatusIdle];
+
+  NSError *mockError = mock([NSError class]);
+  [_errorRecovery handleError:mockError];
+  dispatch_sync(_testQueue, ^{}); // flush queue
+
+  [verify(mockDelegate) markFailedLaunchForLaunchedUpdate];
+  // should try to load a remote update since we don't have one already
+  [verify(mockDelegate) loadRemoteUpdate];
+
+  // indicate there isn't a new update from the server
+  [_errorRecovery notifyNewRemoteLoadStatus:EXUpdatesRemoteLoadStatusIdle];
+  dispatch_sync(_testQueue, ^{}); // flush queue
+  [verify(mockDelegate) throwException:anything()];
+}
+
+- (void)testHandleTwoErrors
+{
+  id<EXUpdatesErrorRecoveryDelegate> mockDelegate = mockProtocol(@protocol(EXUpdatesErrorRecoveryDelegate));
+  _errorRecovery.delegate = mockDelegate;
+
+  [given(mockDelegate.remoteLoadStatus) willReturnInteger:EXUpdatesRemoteLoadStatusIdle];
+
+  NSError *mockError = mock([NSError class]);
+  [_errorRecovery handleError:mockError];
+  [_errorRecovery handleError:mockError];
+  dispatch_sync(_testQueue, ^{}); // flush queue
+
+  // the actual error recovery should only happen once despite there being two errors
+  [verifyCount(mockDelegate, times(1)) loadRemoteUpdate];
+}
+
+- (void)testHandleException
+{
+  id<EXUpdatesErrorRecoveryDelegate> mockDelegate = mockProtocol(@protocol(EXUpdatesErrorRecoveryDelegate));
+  _errorRecovery.delegate = mockDelegate;
+
+  [given(mockDelegate.remoteLoadStatus) willReturnInteger:EXUpdatesRemoteLoadStatusNewUpdateLoaded];
+
+  NSException *mockException = mock([NSException class]);
+  [_errorRecovery handleException:mockException];
+  dispatch_sync(_testQueue, ^{}); // flush queue
+
+  [verify(mockDelegate) markFailedLaunchForLaunchedUpdate];
+  [self verifySuccessfulRelaunchWithCompletion_WithMockDelegate:mockDelegate];
+  [verifyCount(mockDelegate, never()) relaunchWithCompletion:(id)anything()];
+  [verifyCount(mockDelegate, never()) loadRemoteUpdate];
+  [verifyCount(mockDelegate, never()) throwException:anything()];
+}
+
+- (void)verifySuccessfulRelaunchWithCompletion_WithMockDelegate:(id<EXUpdatesErrorRecoveryDelegate>)mockDelegate
+{
+  HCArgumentCaptor *argument = [[HCArgumentCaptor alloc] init];
+  [verify(mockDelegate) relaunchWithCompletion:(id)argument];
+  EXUpdatesAppLauncherCompletionBlock completion = argument.value;
+  completion(nil, YES);
+  dispatch_sync(_testQueue, ^{}); // flush queue
+}
+
+- (void)verifyFailedRelaunchWithCompletion_WithMockDelegate:(id<EXUpdatesErrorRecoveryDelegate>)mockDelegate
+{
+  HCArgumentCaptor *argument = [[HCArgumentCaptor alloc] init];
+  [verify(mockDelegate) relaunchWithCompletion:(id)argument];
+  EXUpdatesAppLauncherCompletionBlock completion = argument.value;
+  completion(mock([NSError class]), NO);
+  dispatch_sync(_testQueue, ^{}); // flush queue
+}
+
+@end

--- a/packages/expo-updates/ios/Tests/EXUpdatesErrorRecoveryTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesErrorRecoveryTests.m
@@ -25,11 +25,6 @@
   [given(_mockDatabase.databaseQueue) willReturn:_testQueue];
 }
 
-- (void)tearDown
-{
-  // Put teardown code here. This method is called after the invocation of each test method in the class.
-}
-
 - (void)testHandleError_NewWorkingUpdateAlreadyLoaded
 {
   id<EXUpdatesErrorRecoveryDelegate> mockDelegate = mockProtocol(@protocol(EXUpdatesErrorRecoveryDelegate));


### PR DESCRIPTION
# Why

ENG-1493

This PR adds an Error Recovery manager class to iOS expo-updates. This class is intended to be used as a single instance per app, called into whenever JS encounters a fatal error or exception, and will coordinate the app's response.

The general control flow of this class is shown in this diagram:

<img width="1164" alt="Screen Shot 2021-09-13 at 10 49 42 AM" src="https://user-images.githubusercontent.com/19958240/133132221-e4487e1b-b9df-42fd-a022-fe85abdc6729.png">

It keeps track of a list of fallback "tasks" to try in sequence, and will continue moving down the list if more errors are reported, only crashing as a last resort if nothing else can be done.

This is hooked up to the rest of expo-updates in https://github.com/expo/expo/pull/14398, in case the implementation is helpful context.

# How

- Add new method to mark an update as FAILED in the local SQLite db
- When an error is reported, call this and then start the pipeline of tasks:

1. If a remote update is in progress (due to the app just having launched), wait up to 5s for it to finish, then try to launch that update if it's new. I chose 5s because it didn't seem like too ridiculously long to wait, and also we can expect that under reasonably good internet conditions an update will be able to finish downloading in this time.
2. If that fails, or if there's no new remote update, try to launch an older cached update
3. If that fails, try to launch the embedded update as a last resort
4. If that fails, crash

# Test Plan

Added unit tests for this manager for various possible scenarios of broken/fixed updates. Verified tests pass, and also ran some e2e tests manually with https://github.com/expo/expo/pull/14398.

# Future work

Possible future work might be to add a task to start a remote load if there isn't already one in progress, and to make the fallback tasks configurable, in case developers want to skip one or more of the possible steps.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).