### PR TITLE
[expo-updates][ios] move persisted error log to EXUpdatesErrorRecovery

### DIFF
--- a/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
+++ b/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
@@ -17,6 +17,7 @@
 #import <EXUpdates/EXUpdatesAppLoaderTask.h>
 #import <EXUpdates/EXUpdatesConfig.h>
 #import <EXUpdates/EXUpdatesDatabase.h>
+#import <EXUpdates/EXUpdatesErrorRecovery.h>
 #import <EXUpdates/EXUpdatesFileDownloader.h>
 #import <EXUpdates/EXUpdatesLauncherSelectionPolicyFilterAware.h>
 #import <EXUpdates/EXUpdatesLoaderSelectionPolicyFilterAware.h>
@@ -391,7 +392,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)_launchWithNoDatabaseAndError:(nullable NSError *)error
 {
   EXUpdatesAppLauncherNoDatabase *appLauncher = [[EXUpdatesAppLauncherNoDatabase alloc] init];
-  [appLauncher launchUpdateWithConfig:_config fatalError:error];
+  [appLauncher launchUpdateWithConfig:_config];
 
   _confirmedManifest = [self _processManifest:appLauncher.launchedUpdate.manifest];
   if (_confirmedManifest == nil) {
@@ -404,6 +405,8 @@ NS_ASSUME_NONNULL_BEGIN
     [self.delegate appLoader:self didLoadOptimisticManifest:_confirmedManifest];
     [self.delegate appLoader:self didFinishLoadingManifest:_confirmedManifest bundle:_bundle];
   }
+
+  [[EXUpdatesErrorRecovery new] writeErrorOrExceptionToLog:error];
 }
 
 - (void)_runReaper

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Add error recovery manager on iOS. ([#14397](https://github.com/expo/expo/pull/14397) by [@esamelson](https://github.com/esamelson))
 - Hook up error recovery manager to rest of module on iOS. ([#14398](https://github.com/expo/expo/pull/14398) by [@esamelson](https://github.com/esamelson))
+- Move persisted error log to EXUpdatesErrorRecovery on iOS. ([#14399](https://github.com/expo/expo/pull/14399) by [@esamelson](https://github.com/esamelson))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesAppLauncherNoDatabase.h
+++ b/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesAppLauncherNoDatabase.h
@@ -8,8 +8,6 @@ NS_ASSUME_NONNULL_BEGIN
 @interface EXUpdatesAppLauncherNoDatabase : NSObject <EXUpdatesAppLauncher>
 
 - (void)launchUpdateWithConfig:(EXUpdatesConfig *)config;
-- (void)launchUpdateWithConfig:(EXUpdatesConfig *)config fatalError:(NSError *)error;
-+ (nullable NSString *)consumeError;
 
 @end
 

--- a/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesAppLauncherNoDatabase.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesAppLauncherNoDatabase.m
@@ -45,65 +45,6 @@ static NSString * const EXUpdatesErrorLogFile = @"expo-error.log";
   return _assetFilesMap == nil;
 }
 
-- (void)launchUpdateWithConfig:(EXUpdatesConfig *)config fatalError:(NSError *)error;
-{
-  [self launchUpdateWithConfig:config];
-  dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-    [self _writeErrorToLog:error];
-  });
-}
-
-+ (nullable NSString *)consumeError;
-{
-  NSString *errorLogFilePath = [[self class] _errorLogFilePath]; 
-  NSData *data = [NSData dataWithContentsOfFile:errorLogFilePath options:kNilOptions error:nil];
-  if (data) {
-    NSError *err;
-    if (![NSFileManager.defaultManager removeItemAtPath:errorLogFilePath error:&err]) {
-      NSLog(@"Could not delete error log: %@", err.localizedDescription);
-    }
-    return [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-  } else {
-    return nil;
-  }
-}
-
-- (void)_writeErrorToLog:(NSError *)error
-{
-  NSString *serializedError = [NSString stringWithFormat:@"Expo encountered a fatal error: %@", [self _serializeError:error]];
-  NSData *data = [serializedError dataUsingEncoding:NSUTF8StringEncoding];
-
-  NSError *err;
-  if (![data writeToFile:[[self class] _errorLogFilePath] options:NSDataWritingAtomic error:&err]) {
-    NSLog(@"Could not write fatal error to log: %@", error.localizedDescription);
-  }
-}
-
-- (NSString *)_serializeError:(NSError *)error
-{
-  NSString *localizedFailureReason = error.localizedFailureReason;
-  NSError *underlyingError = error.userInfo[NSUnderlyingErrorKey];
-  
-  NSMutableString *serialization = [[NSString stringWithFormat:@"Time: %f\nDomain: %@\nCode: %li\nDescription: %@",
-                                    [[NSDate date] timeIntervalSince1970] * 1000,
-                                    error.domain,
-                                    (long)error.code,
-                                    error.localizedDescription] mutableCopy];
-  if (localizedFailureReason) {
-    [serialization appendFormat:@"\nFailure Reason: %@", localizedFailureReason];
-  }
-  if (underlyingError) {
-    [serialization appendFormat:@"\n\nUnderlying Error:\n%@", [self _serializeError:underlyingError]];
-  }
-  return serialization;
-}
-
-+ (NSString *)_errorLogFilePath
-{
-  NSURL *applicationDocumentsDirectory = [[NSFileManager.defaultManager URLsForDirectory:NSApplicationSupportDirectory inDomains:NSUserDomainMask] lastObject];
-  return [[applicationDocumentsDirectory URLByAppendingPathComponent:EXUpdatesErrorLogFile] path];
-}
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.m
@@ -1,7 +1,7 @@
 //  Copyright © 2019 650 Industries. All rights reserved.
 
-#import <EXUpdates/EXUpdatesAppLauncherNoDatabase.h>
 #import <EXUpdates/EXUpdatesCrypto.h>
+#import <EXUpdates/EXUpdatesErrorRecovery.h>
 #import <EXUpdates/EXUpdatesFileDownloader.h>
 #import <EXUpdates/EXUpdatesSelectionPolicies.h>
 
@@ -342,7 +342,7 @@ NSTimeInterval const EXUpdatesDefaultTimeoutInterval = 60;
     [request setValue:_config.sdkVersion forHTTPHeaderField:@"Expo-SDK-Version"];
   }
 
-  NSString *previousFatalError = [EXUpdatesAppLauncherNoDatabase consumeError];
+  NSString *previousFatalError = [EXUpdatesErrorRecovery consumeErrorLog];
   if (previousFatalError) {
     // some servers can have max length restrictions for headers,
     // so we restrict the length of the string to 1024 characters --

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesAppController.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesAppController.m
@@ -412,13 +412,15 @@ static NSString * const EXUpdatesErrorEventName = @"error";
 
   EXUpdatesAppLauncherNoDatabase *launcher = [[EXUpdatesAppLauncherNoDatabase alloc] init];
   _launcher = launcher;
-  [launcher launchUpdateWithConfig:_config fatalError:error];
+  [launcher launchUpdateWithConfig:_config];
 
   if (_delegate) {
     [EXUpdatesUtils runBlockOnMainThread:^{
       [self->_delegate appController:self didStartWithSuccess:self.launchAssetUrl != nil];
     }];
   }
+
+  [_errorRecovery writeErrorOrExceptionToLog:error];
 }
 
 @end

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesErrorRecovery.h
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesErrorRecovery.h
@@ -36,6 +36,7 @@ typedef NS_ENUM(NSInteger, EXUpdatesRemoteLoadStatus) {
 
 // for testing purposes
 - (instancetype)initWithErrorRecoveryQueue:(dispatch_queue_t)errorRecoveryQueue
+                            diskWriteQueue:(nullable dispatch_queue_t)diskWriteQueue
                          remoteLoadTimeout:(NSInteger)remoteLoadTimeout;
 
 - (void)startMonitoring;
@@ -43,6 +44,9 @@ typedef NS_ENUM(NSInteger, EXUpdatesRemoteLoadStatus) {
 - (void)handleError:(NSError *)error;
 - (void)handleException:(NSException *)exception;
 - (void)notifyNewRemoteLoadStatus:(EXUpdatesRemoteLoadStatus)newStatus;
+
++ (nullable NSString *)consumeErrorLog;
+- (void)writeErrorOrExceptionToLog:(id)errorOrException;
 
 @end
 


### PR DESCRIPTION
# Why

Currently we have a somewhat primitive system for persisting information about encountered errors and sending them back to the server in a manifest request header. It lives in EXUpdatesAppLauncherNoDatabase, but now that we have EXUpdatesErrorRecovery, we should move it there and also make use of it.

This is especially important since we are now attempting to avoid native crashes in certain scenarios, so some error logging libraries might miss crashes that we are catching.

# How

Move the error log code from EXUpdatesAppLauncherNoDatabase to EXUpdatesErrorRecovery, and add the ability to persist multiple errors at once. Switch all usages to the new location.

# Test Plan

Added unit tests, they pass ✅ 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).