### PR TITLE
[media-library] Do not reject on EXIF parsing failure

### DIFF
--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### 🐛 Bug fixes
 
+- EXIF parsing failure no longer crashes the `getAssetsAsync` and `getAssetInfoAsync`, the promise returns `exif: null` instead.
+
 ### 💡 Others
 
 - Migrated from `@unimodules/core` to `expo-modules-core`. ([#13755](https://github.com/expo/expo/pull/13755) by [@tsapeta](https://github.com/tsapeta))

--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ### 🐛 Bug fixes
 
-- EXIF parsing failure no longer crashes the `getAssetsAsync` and `getAssetInfoAsync`, the promise returns `exif: null` instead.
+- EXIF parsing failure no longer crashes the `getAssetsAsync` and `getAssetInfoAsync`, the promise returns `exif: null` instead. ([#14408](https://github.com/expo/expo/pull/14408) by [@barthap](https://github.com/barthap))
 
 ### 💡 Others
 

--- a/packages/expo-media-library/android/build.gradle
+++ b/packages/expo-media-library/android/build.gradle
@@ -68,6 +68,7 @@ android {
 dependencies {
   implementation project(':expo-modules-core')
 
+  implementation "androidx.annotation:annotation:1.2.0"
   api "androidx.exifinterface:exifinterface:1.3.3"
 
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${safeExtGet('kotlinVersion', '1.4.21')}"

--- a/packages/expo-media-library/android/build.gradle
+++ b/packages/expo-media-library/android/build.gradle
@@ -68,7 +68,7 @@ android {
 dependencies {
   implementation project(':expo-modules-core')
 
-  api "androidx.exifinterface:exifinterface:1.0.0"
+  api "androidx.exifinterface:exifinterface:1.3.3"
 
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${safeExtGet('kotlinVersion', '1.4.21')}"
 

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/GetAssets.java
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/GetAssets.java
@@ -60,7 +60,7 @@ class GetAssets extends AsyncTask<Void, Void, Void> {
       mPromise.reject(ERROR_UNABLE_TO_LOAD_PERMISSION,
           "Could not get asset: need READ_EXTERNAL_STORAGE permission.", e);
     } catch (IOException e) {
-      mPromise.reject(ERROR_UNABLE_TO_LOAD, "Could not read file or parse EXIF tags", e);
+      mPromise.reject(ERROR_UNABLE_TO_LOAD, "Could not read file", e);
     }
     return null;
   }

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryUtils.java
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryUtils.java
@@ -179,7 +179,12 @@ final class MediaLibraryUtils {
 
       ExifInterface exifInterface = null;
       if (mediaType == Files.FileColumns.MEDIA_TYPE_IMAGE) {
-        exifInterface = new ExifInterface(path);
+        try {
+          exifInterface = new ExifInterface(path);
+        } catch (IOException e) {
+          Log.w("expo-media-library", "Could not parse EXIF tags for " + localUri);
+          e.printStackTrace();
+        }
       }
 
       int[] size = getSizeFromCursor(contentResolver, exifInterface, cursor, mediaType, localUriIndex);

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryUtils.java
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryUtils.java
@@ -155,7 +155,7 @@ final class MediaLibraryUtils {
       promise.reject(ERROR_UNABLE_TO_LOAD_PERMISSION,
         "Could not get asset: need READ_EXTERNAL_STORAGE permission.", e);
     } catch (IOException e) {
-      promise.reject(ERROR_IO_EXCEPTION, "Could not read file or parse EXIF tags", e);
+      promise.reject(ERROR_IO_EXCEPTION, "Could not read file", e);
     }
   }
 


### PR DESCRIPTION
# Why

Ref: https://github.com/expo/expo/issues/10398#issuecomment-917464440

On some images from e.g. Telegram app, Android MediaLibrary fails to parse EXIF tags. Because `getAssetsAsync()` rejects in that case, some photos cannot be even listed with expo-media-library.

We reject promises since https://github.com/expo/expo/commit/c6f36778f2442fb595e935338ab87f131c998d79#diff-f2e71e0bfb46ae7a4ad7318cef063900adc8da1cc47b9984da9e46d556f21408L63 - before that commit they were never resolved due to another bug

Related issues:
- #10398 (already closed, but comments active)
- closes #11067 - _old issue, very similar, most likely this was the cause (besides some permission issues, already resolved)_
- closes #11878 - _old issue, no repro, error message identical to this case_

# How

- Updated `exifinterface` from `1.0.0` to `1.3.3` - [there were several bugfixes](https://developer.android.com/jetpack/androidx/releases/exifinterface) between these versions
- Separated exception handling logic for EXIF tags - when parsing fails, the `getAssetsAsync`/`getAssetInfoAsync` no longer rejects the promise, but sets result `exif` field to `null` instead (it was nullable already).

# Test Plan

- [x] NCL still works
- [x] Test Suite passes
- [ ] Test on photos from "unknown sources" like Telegram (could not reproduce, EXIF always works now 🤷 )

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).