### PR TITLE
[docs] revert installing-updates change and will land again after sdk43 release

### DIFF
--- a/docs/public/static/diffs/expo-updates-android.diff
+++ b/docs/public/static/diffs/expo-updates-android.diff
@@ -1,76 +1,101 @@
-diff --git a/apps/bare-update/android/app/src/main/AndroidManifest.xml b/apps/bare-update/android/app/src/main/AndroidManifest.xml
-index 4a74a05751..bac2b2f677 100644
---- a/apps/bare-update/android/app/src/main/AndroidManifest.xml
-+++ b/apps/bare-update/android/app/src/main/AndroidManifest.xml
-@@ -7,6 +7,7 @@
-   <application android:name=".MainApplication" android:label="@string/app_name" android:icon="@mipmap/ic_launcher" android:roundIcon="@mipmap/ic_launcher_round" android:allowBackup="false" android:theme="@style/AppTheme" android:usesCleartextTraffic="true">
-     <meta-data android:name="expo.modules.updates.EXPO_UPDATE_URL" android:value="https://exp.host/@my-expo-username/my-app"/>
-     <meta-data android:name="expo.modules.updates.EXPO_SDK_VERSION" android:value="43.0.0"/>
-+    <meta-data android:name="expo.modules.updates.AUTO_SETUP" android:value="false"/>
-     <activity android:name=".MainActivity" android:label="@string/app_name" android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode" android:launchMode="singleTask" android:windowSoftInputMode="adjustResize" android:theme="@style/Theme.App.SplashScreen">
-       <intent-filter>
-         <action android:name="android.intent.action.MAIN"/>
-diff --git a/apps/bare-update/android/app/src/main/java/com/bareupdate/MainApplication.java b/apps/bare-update/android/app/src/main/java/com/bareupdate/MainApplication.java
-index 4b0d17d89d..5d6f1bb620 100644
---- a/apps/bare-update/android/app/src/main/java/com/bareupdate/MainApplication.java
-+++ b/apps/bare-update/android/app/src/main/java/com/bareupdate/MainApplication.java
-@@ -3,6 +3,7 @@ package com.bareupdate;
- import android.app.Application;
- import android.content.Context;
- import android.content.res.Configuration;
+diff --git a/android/app/build.gradle b/android/app/build.gradle
+index e5b1a7d..d06dfd0 100644
+--- a/android/app/build.gradle
++++ b/android/app/build.gradle
+@@ -81,10 +81,11 @@ import com.android.build.OutputFile
+ project.ext.react = [
+     enableHermes: false,  // clean and rebuild if changing
+ ]
+
+-apply from: "../../node_modules/react-native/react.gradle"
++apply from: new File(["node", "--print", "require.resolve('react-native/package.json')"].execute().text.trim(), "../react.gradle")
++apply from: new File(["node", "--print", "require.resolve('expo-updates/package.json')"].execute().text.trim(), "../scripts/create-manifest-android.gradle")
+
+ /**
+  * Set this to true to create two separate APKs instead of one:
+  *   - An APK that only works on ARM devices
+  *   - An APK that only works on x86 devices
+diff --git a/android/app/src/main/AndroidManifest.xml b/android/app/src/main/AndroidManifest.xml
+index 955757b..3fa4cb1 100644
+--- a/android/app/src/main/AndroidManifest.xml
++++ b/android/app/src/main/AndroidManifest.xml
+@@ -8,12 +8,15 @@
+       android:label="@string/app_name"
+       android:icon="@mipmap/ic_launcher"
+       android:roundIcon="@mipmap/ic_launcher_round"
+       android:allowBackup="false"
+       android:theme="@style/AppTheme">
++      <meta-data android:name="expo.modules.updates.EXPO_UPDATE_URL" android:value="https://exp.host/@my-expo-username/my-app" />
++      <meta-data android:name="expo.modules.updates.EXPO_SDK_VERSION" android:value="38.0.0" />
++
+  <activity
+        android:name=".MainActivity"
+         android:label="@string/app_name"
+         android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
+         android:launchMode="singleTask"
+         android:windowSoftInputMode="adjustResize">
+         <intent-filter>
+diff --git a/android/app/src/main/java/com/myapp/MainApplication.java b/android/app/src/main/java/com/myapp/MainApplication.java
+index 0151e90..48cc96c 100644
+--- a/android/app/src/main/java/com/myapp/MainApplication.java
++++ b/android/app/src/main/java/com/myapp/MainApplication.java
+@@ -17,10 +17,14 @@ import java.util.Arrays;
+
+ import org.unimodules.adapters.react.ModuleRegistryAdapter;
+ import org.unimodules.adapters.react.ReactModuleRegistryProvider;
+ import org.unimodules.core.interfaces.SingletonModule;
+
 +import android.net.Uri;
- 
- import com.facebook.react.PackageList;
- import com.facebook.react.ReactApplication;
-@@ -14,6 +15,7 @@ import com.facebook.soloader.SoLoader;
- 
- import expo.modules.ApplicationLifecycleDispatcher;
- import expo.modules.ReactNativeHostWrapper;
 +import expo.modules.updates.UpdatesController;
- 
- import com.facebook.react.bridge.JSIModulePackage;
- import com.swmansion.reanimated.ReanimatedJSIModulePackage;
-@@ -22,6 +24,7 @@ import androidx.annotation.NonNull;
- import java.lang.reflect.InvocationTargetException;
- import java.util.Arrays;
- import java.util.List;
 +import javax.annotation.Nullable;
- 
++
  public class MainApplication extends Application implements ReactApplication {
-   private final ReactNativeHost mReactNativeHost = new ReactNativeHostWrapper(
-@@ -46,6 +49,24 @@ public class MainApplication extends Application implements ReactApplication {
-     protected JSIModulePackage getJSIModulePackage() {
-       return new ReanimatedJSIModulePackage();
-     }
+   private final ReactModuleRegistryProvider mModuleRegistryProvider = new ReactModuleRegistryProvider(new BasePackageList().getPackageList(), null);
+
+   private final ReactNativeHost mReactNativeHost =
+       new ReactNativeHost(this) {
+@@ -46,10 +50,28 @@ public class MainApplication extends Application implements ReactApplication {
+
+         @Override
+         protected String getJSMainModuleName() {
+           return "index";
+         }
 +
-+    @Override
-+    protected @Nullable String getJSBundleFile() {
-+      if (BuildConfig.DEBUG) {
-+        return super.getJSBundleFile();
-+      } else {
-+        return UpdatesController.getInstance().getLaunchAssetFile();
-+      }
-+    }
++        @Override
++        protected @Nullable String getJSBundleFile() {
++          if (BuildConfig.DEBUG) {
++            return super.getJSBundleFile();
++          } else {
++            return UpdatesController.getInstance().getLaunchAssetFile();
++          }
++        }
 +
-+    @Override
-+    protected @Nullable String getBundleAssetName() {
-+      if (BuildConfig.DEBUG) {
-+        return super.getBundleAssetName();
-+      } else {
-+        return UpdatesController.getInstance().getBundleAssetName();
-+      }
-+    }
-   });
- 
++        @Override
++        protected @Nullable String getBundleAssetName() {
++          if (BuildConfig.DEBUG) {
++            return super.getBundleAssetName();
++          } else {
++            return UpdatesController.getInstance().getBundleAssetName();
++          }
++        }
+       };
+
    @Override
-@@ -58,6 +79,10 @@ public class MainApplication extends Application implements ReactApplication {
+   public ReactNativeHost getReactNativeHost() {
+     return mReactNativeHost;
+@@ -57,10 +79,15 @@ public class MainApplication extends Application implements ReactApplication {
+
+   @Override
+   public void onCreate() {
      super.onCreate();
      SoLoader.init(this, /* native exopackage */ false);
- 
++
 +    if (!BuildConfig.DEBUG) {
 +      UpdatesController.initialize(this);
 +    }
 +
      initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
-     ApplicationLifecycleDispatcher.onApplicationCreate(this);
    }
+
+   /**
+    * Loads Flipper in React Native templates. Call this in the onCreate method with something like

--- a/docs/public/static/diffs/expo-updates-ios.diff
+++ b/docs/public/static/diffs/expo-updates-ios.diff
@@ -1,41 +1,46 @@
-diff --git a/apps/bare-update/ios/bareupdate/AppDelegate.h b/apps/bare-update/ios/bareupdate/AppDelegate.h
-index e39065416f..7a2f733b9d 100644
---- a/apps/bare-update/ios/bareupdate/AppDelegate.h
-+++ b/apps/bare-update/ios/bareupdate/AppDelegate.h
-@@ -1,9 +1,10 @@
- #import <Foundation/Foundation.h>
+diff --git a/ios/MyApp/AppDelegate.h b/ios/MyApp/AppDelegate.h
+index ef1de86..1a1a48f 100644
+--- a/ios/MyApp/AppDelegate.h
++++ b/ios/MyApp/AppDelegate.h
+@@ -1,8 +1,10 @@
++#import <Foundation/Foundation.h>
 +#import <EXUpdates/EXUpdatesAppController.h>
  #import <React/RCTBridgeDelegate.h>
  #import <UIKit/UIKit.h>
  
- #import <ExpoModulesCore/EXAppDelegateWrapper.h>
+-@interface AppDelegate : UIResponder <UIApplicationDelegate, RCTBridgeDelegate>
++#import <UMCore/UMAppDelegateWrapper.h>
  
--@interface AppDelegate : EXAppDelegateWrapper <RCTBridgeDelegate>
-+@interface AppDelegate : EXAppDelegateWrapper <RCTBridgeDelegate, EXUpdatesAppControllerDelegate>
+-@property (nonatomic, strong) UIWindow *window;
++@interface AppDelegate : UMAppDelegateWrapper <RCTBridgeDelegate, EXUpdatesAppControllerDelegate>
  
  @end
-diff --git a/apps/bare-update/ios/bareupdate/AppDelegate.m b/apps/bare-update/ios/bareupdate/AppDelegate.m
-index e2bd877b92..b8839389ac 100644
---- a/apps/bare-update/ios/bareupdate/AppDelegate.m
-+++ b/apps/bare-update/ios/bareupdate/AppDelegate.m
-@@ -28,6 +28,12 @@ static void InitializeFlipper(UIApplication *application) {
- }
+diff --git a/ios/MyApp/AppDelegate.m b/ios/MyApp/AppDelegate.m
+index c3e09a4..b26bcf7 100644
+--- a/ios/MyApp/AppDelegate.m
++++ b/ios/MyApp/AppDelegate.m
+@@ -28,10 +28,11 @@ static void InitializeFlipper(UIApplication *application) {
  #endif
  
-+@interface AppDelegate () <RCTBridgeDelegate>
-+
+ @interface AppDelegate () <RCTBridgeDelegate>
+ 
+ @property (nonatomic, strong) UMModuleRegistryAdapter *moduleRegistryAdapter;
 +@property (nonatomic, strong) NSDictionary *launchOptions;
-+
-+@end
-+
+ 
+ @end
+ 
  @implementation AppDelegate
  
- - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
-@@ -36,7 +42,24 @@ - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(
+@@ -41,23 +42,38 @@ static void InitializeFlipper(UIApplication *application) {
    InitializeFlipper(application);
  #endif
-   
+ 
+   self.moduleRegistryAdapter = [[UMModuleRegistryAdapter alloc] initWithModuleRegistryProvider:[[UMModuleRegistryProvider alloc] init]];
+ 
 -  RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:launchOptions];
+-  RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge
+-                                                   moduleName:@"MyApp"
+-                                            initialProperties:nil];
 +  self.launchOptions = launchOptions;
 +  self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
 +  #ifdef DEBUG
@@ -50,56 +55,57 @@ index e2bd877b92..b8839389ac 100644
 +
 +  return YES;
 +}
-+
+ 
 +- (RCTBridge *)initializeReactNativeApp
 +{
 +  RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:self.launchOptions];
-   RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge moduleName:@"main" initialProperties:nil];
-   id rootViewBackgroundColor = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"RCTRootViewBackgroundColor"];
-   if (rootViewBackgroundColor != nil) {
-@@ -45,15 +68,13 @@ - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(
-     rootView.backgroundColor = [UIColor whiteColor];
-   }
++  RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge moduleName:@"MyApp" initialProperties:nil];
+   rootView.backgroundColor = [[UIColor alloc] initWithRed:1.0f green:1.0f blue:1.0f alpha:1];
  
--  self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
-+
+   self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
    UIViewController *rootViewController = [UIViewController new];
    rootViewController.view = rootView;
    self.window.rootViewController = rootViewController;
    [self.window makeKeyAndVisible];
- 
--  [super application:application didFinishLaunchingWithOptions:launchOptions];
--
 -  return YES;
++
 +  return bridge;
-  }
- 
- - (NSArray<id<RCTBridgeModule>> *)extraModulesForBridge:(RCTBridge *)bridge
-@@ -70,10 +91,14 @@ - (NSURL *)sourceURLForBridge:(RCTBridge *)bridge {
-  #ifdef DEBUG
-   return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index" fallbackResource:nil];
-  #else
--  return [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
-+  return [[EXUpdatesAppController sharedInstance] launchAssetUrl];
-  #endif
  }
  
-+- (void)appController:(EXUpdatesAppController *)appController didStartWithSuccess:(BOOL)success {
+ - (NSArray<id<RCTBridgeModule>> *)extraModulesForBridge:(RCTBridge *)bridge
+ {
+     NSArray<id<RCTBridgeModule>> *extraModules = [_moduleRegistryAdapter extraModulesForBridge:bridge];
+@@ -69,10 +85,15 @@ static void InitializeFlipper(UIApplication *application) {
+ 
+ {
+ #if DEBUG
+   return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index" fallbackResource:nil];
+ #else
+-  return [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
++  return [[EXUpdatesAppController sharedInstance] launchAssetUrl];
+ #endif
+ }
+ 
++- (void)appController:(EXUpdatesAppController *)appController didStartWithSuccess:(BOOL)success
++{
 +  appController.bridge = [self initializeReactNativeApp];
 +}
 +
- // Linking API
- - (BOOL)application:(UIApplication *)application openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {
-   return [RCTLinkingManager application:application openURL:url options:options];
-diff --git a/apps/bare-update/ios/bareupdate/Supporting/Expo.plist b/apps/bare-update/ios/bareupdate/Supporting/Expo.plist
-index 471ca3dde5..2abdd7a775 100644
---- a/apps/bare-update/ios/bareupdate/Supporting/Expo.plist
-+++ b/apps/bare-update/ios/bareupdate/Supporting/Expo.plist
-@@ -6,5 +6,7 @@
-     <string>42.0.0</string>
-     <key>EXUpdatesURL</key>
-     <string>https://exp.host/@my-expo-username/my-app</string>
-+    <key>EXUpdatesAutoSetup</key>
-+    <false/>
-   </dict>
- </plist>
+ @end
+diff --git a/ios/MyApp/Supporting/Expo.plist b/ios/MyApp/Supporting/Expo.plist
+new file mode 100644
+index 0000000..1dd4715
+--- /dev/null
++++ b/ios/MyApp/Supporting/Expo.plist
+@@ -0,0 +1,10 @@
++<?xml version="1.0" encoding="UTF-8"?>
++<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
++<plist version="1.0">
++<dict>
++        <key>EXUpdatesSDKVersion</key>
++        <string>38.0.0</string>
++        <key>EXUpdatesURL</key>
++        <string>https://exp.host/@my-expo-username/my-app</string>
++</dict>
++</plist>
+\ No newline at end of file


### PR DESCRIPTION
# Why

because the guide is shared across all sdks, we should land the change after sdk 43 released. 

# How

`git checkout 2f6287e11c85681eae0c4a48cdfc94edf3101445~1 -- docs/pages/bare/installing-updates.md  docs/public/static/diffs/expo-updates-android.diff docs/public/static/diffs/expo-updates-ios.diff`

will create a linear task as reminder to reland the change in sdk43 release process.

# Test Plan

ci passed