### PR TITLE
[media-library][android] retrieve location data from photos on androi…

### DIFF
--- a/android/expoview/src/main/AndroidManifest.xml
+++ b/android/expoview/src/main/AndroidManifest.xml
@@ -33,6 +33,8 @@
   <uses-permission android:name="android.permission.CAMERA" />
   <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
   <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+  <uses-permission android:name="android.permission.ACCESS_MEDIA_LOCATION" />
+
 
   <uses-feature
     android:name="android.hardware.camera"

--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### 🐛 Bug fixes
 
+- Restore location exif data getter for Android 10+ devices. ([#14413](https://github.com/expo/expo/pull/14413) by [@ajsmth](https://github.com/ajsmth))
 - EXIF parsing failure no longer crashes the `getAssetsAsync` and `getAssetInfoAsync`, the promise returns `exif: null` instead. ([#14408](https://github.com/expo/expo/pull/14408) by [@barthap](https://github.com/barthap))
 
 ### 💡 Others

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/GetAssets.java
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/GetAssets.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import expo.modules.core.Promise;
 
 import static expo.modules.medialibrary.MediaLibraryConstants.ASSET_PROJECTION;
+import static expo.modules.medialibrary.MediaLibraryConstants.ERROR_NO_PERMISSIONS;
 import static expo.modules.medialibrary.MediaLibraryConstants.ERROR_UNABLE_TO_LOAD;
 import static expo.modules.medialibrary.MediaLibraryConstants.ERROR_UNABLE_TO_LOAD_PERMISSION;
 import static expo.modules.medialibrary.MediaLibraryConstants.EXTERNAL_CONTENT;
@@ -61,6 +62,9 @@ class GetAssets extends AsyncTask<Void, Void, Void> {
           "Could not get asset: need READ_EXTERNAL_STORAGE permission.", e);
     } catch (IOException e) {
       mPromise.reject(ERROR_UNABLE_TO_LOAD, "Could not read file", e);
+    } catch (UnsupportedOperationException e) {
+      e.printStackTrace();
+      mPromise.reject(ERROR_NO_PERMISSIONS, e.getMessage());
     }
     return null;
   }

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryModule.java
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryModule.java
@@ -38,6 +38,7 @@ import expo.modules.interfaces.permissions.Permissions;
 
 import static android.Manifest.permission.READ_EXTERNAL_STORAGE;
 import static android.Manifest.permission.WRITE_EXTERNAL_STORAGE;
+import static android.Manifest.permission.ACCESS_MEDIA_LOCATION;
 import static expo.modules.medialibrary.MediaLibraryConstants.ERROR_NO_ALBUM;
 import static expo.modules.medialibrary.MediaLibraryConstants.ERROR_NO_PERMISSIONS;
 import static expo.modules.medialibrary.MediaLibraryConstants.ERROR_NO_PERMISSIONS_MESSAGE;
@@ -452,12 +453,14 @@ public class MediaLibraryModule extends ExportedModule implements ActivityEventL
   private String[] getManifestPermissions(boolean writeOnly) {
     if (writeOnly) {
       return new String[]{
-        WRITE_EXTERNAL_STORAGE
+        WRITE_EXTERNAL_STORAGE,
+        ACCESS_MEDIA_LOCATION
       };
     }
     return new String[]{
       READ_EXTERNAL_STORAGE,
-      WRITE_EXTERNAL_STORAGE
+      WRITE_EXTERNAL_STORAGE,
+      ACCESS_MEDIA_LOCATION,
     };
   }
 

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryUtils.java
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryUtils.java
@@ -24,17 +24,21 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
 import java.nio.channels.FileChannel;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.RequiresApi;
 import androidx.exifinterface.media.ExifInterface;
 
 import static expo.modules.medialibrary.MediaLibraryConstants.ASSET_PROJECTION;
 import static expo.modules.medialibrary.MediaLibraryConstants.ERROR_IO_EXCEPTION;
 import static expo.modules.medialibrary.MediaLibraryConstants.ERROR_NO_ASSET;
+import static expo.modules.medialibrary.MediaLibraryConstants.ERROR_NO_PERMISSIONS;
 import static expo.modules.medialibrary.MediaLibraryConstants.ERROR_UNABLE_TO_DELETE;
 import static expo.modules.medialibrary.MediaLibraryConstants.ERROR_UNABLE_TO_LOAD;
 import static expo.modules.medialibrary.MediaLibraryConstants.ERROR_UNABLE_TO_LOAD_PERMISSION;
@@ -156,10 +160,13 @@ final class MediaLibraryUtils {
         "Could not get asset: need READ_EXTERNAL_STORAGE permission.", e);
     } catch (IOException e) {
       promise.reject(ERROR_IO_EXCEPTION, "Could not read file", e);
+    } catch (UnsupportedOperationException e)  {
+      e.printStackTrace();
+      promise.reject(ERROR_NO_PERMISSIONS, e.getMessage());
     }
   }
 
-  static void putAssetsInfo(ContentResolver contentResolver, Cursor cursor, ArrayList<Bundle> response, int limit, int offset, boolean fullInfo) throws IOException {
+  static void putAssetsInfo(ContentResolver contentResolver, Cursor cursor, ArrayList<Bundle> response, int limit, int offset, boolean fullInfo) throws IOException, UnsupportedOperationException {
     final int idIndex = cursor.getColumnIndex(MediaStore.Images.Media._ID);
     final int filenameIndex = cursor.getColumnIndex(MediaStore.Images.Media.DISPLAY_NAME);
     final int mediaTypeIndex = cursor.getColumnIndex(Files.FileColumns.MEDIA_TYPE);
@@ -203,11 +210,16 @@ final class MediaLibraryUtils {
 
       if (fullInfo) {
         if (exifInterface != null) {
-          getExifFullInfo(exifInterface, asset);
-          getExifLocation(exifInterface, asset);
+          if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            Uri photoUri = Uri.withAppendedPath(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, cursor.getString(idIndex));
+            getExifFullInfo(exifInterface, asset);
+            getExifLocationForUri(contentResolver, photoUri, asset);
+          } else {
+            getExifFullInfo(exifInterface, asset);
+            getExifLocation(exifInterface, asset);
+          }
+          asset.putString("localUri", localUri);
         }
-
-        asset.putString("localUri", localUri);
       }
       cursor.moveToNext();
       response.add(asset);
@@ -363,8 +375,46 @@ final class MediaLibraryUtils {
     response.putParcelable("exif", exifMap);
   }
 
+  // API 29+ adds "scoped storage" which requires extra permissions (ACCESS_MEDIA_LOCATION) to access photo data
+  // Reference: https://developer.android.com/training/data-storage/shared/media#location-info-photos
+  @RequiresApi(api = Build.VERSION_CODES.Q)
+  static void getExifLocationForUri(ContentResolver contentResolver, Uri photoUri, Bundle asset) throws UnsupportedOperationException, IOException {
+    InputStream stream;
+
+    try {
+      // Exception occurs if ACCESS_MEDIA_LOCATION permission isn't granted
+      photoUri = MediaStore.setRequireOriginal(photoUri);
+      stream = contentResolver.openInputStream(photoUri);
+    } catch (UnsupportedOperationException e) {
+      throw new UnsupportedOperationException("Cannot access ExifInterface because of missing ACCESS_MEDIA_LOCATION permission");
+    }
+
+    if (stream != null) {
+      try {
+        // If exif data cannot be found on the stream, set location to null instead of rejecting
+        ExifInterface exifInterface = new ExifInterface(stream);
+        double[] latLong = exifInterface.getLatLong();
+
+        if (latLong != null) {
+          Bundle location = new Bundle();
+          location.putDouble("latitude", latLong[0]);
+          location.putDouble("longitude", latLong[1]);
+          asset.putParcelable("location", location);
+        } else {
+          asset.putParcelable("location", null);
+        }
+      } catch(IOException e) {
+        asset.putParcelable("location", null);
+      } finally {
+        stream.close();
+      }
+    }
+  }
+
   static void getExifLocation(ExifInterface exifInterface, Bundle asset) {
+
     double[] latLong = exifInterface.getLatLong();
+
     if (latLong == null) {
       asset.putParcelable("location", null);
       return;

--- a/packages/expo-media-library/plugin/src/withMediaLibrary.ts
+++ b/packages/expo-media-library/plugin/src/withMediaLibrary.ts
@@ -32,7 +32,11 @@ const withMediaLibraryExternalStorage: ConfigPlugin = (config) => {
 const withMediaLibrary: ConfigPlugin<{
   photosPermission?: string;
   savePhotosPermission?: string;
-} | void> = (config, { photosPermission, savePhotosPermission } = {}) => {
+  isAccessMediaLocationEnabled?: boolean;
+} | void> = (
+  config,
+  { photosPermission, savePhotosPermission, isAccessMediaLocationEnabled } = {}
+) => {
   if (!config.ios) config.ios = {};
   if (!config.ios.infoPlist) config.ios.infoPlist = {};
   config.ios.infoPlist.NSPhotoLibraryUsageDescription =
@@ -45,7 +49,11 @@ const withMediaLibrary: ConfigPlugin<{
   return withPlugins(config, [
     [
       AndroidConfig.Permissions.withPermissions,
-      ['android.permission.READ_EXTERNAL_STORAGE', 'android.permission.WRITE_EXTERNAL_STORAGE'],
+      [
+        'android.permission.READ_EXTERNAL_STORAGE',
+        'android.permission.WRITE_EXTERNAL_STORAGE',
+        isAccessMediaLocationEnabled ?? 'android.permission.ACCESS_MEDIA_LOCATION',
+      ].filter(Boolean),
     ],
     withMediaLibraryExternalStorage,
   ]);


### PR DESCRIPTION
# Why

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

Closes #14361 

Android 10+ requires an additional permission and getter implementation to get exif location data for photos. 

From what I can tell, the old implementation still seems to work via the `requestLegacyExternalStorage` key in Android manifest, but as of 11 this no longer seems to work

I was able to reproduce the location data being missing via a emulator running Android 11

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

The new implementation checks whether or not the device is running Android 10+ and if so, runs a different call to retrieve location info. This method throws an exception if the `ACCESS_MEDIA_LOCATION` permission is missing from `AndroidManifest` - so I also added  this value as well as handled the exception

# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->

From what I can tell, this implementation still doesn't seem to work on the emulator, which is unfortunate, but I was able to confirm that it works on a real device running Android 10

Also - the permissions prompt doesn't seem to change at all between this implementation and the previous, the only concern might be if adding this additional permission would cause issues with app submissions 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).