### PR TITLE
[ios] upgrade amazon-cognito-identity-js native module

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/cognito/RNAWSCognitoModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/cognito/RNAWSCognitoModule.java
@@ -1,5 +1,10 @@
 package versioned.host.exp.exponent.modules.api.cognito;
 
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+
+import android.util.Base64;
+
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
@@ -38,6 +43,16 @@ public class RNAWSCognitoModule extends ReactContextBaseJavaModule {
   @Override
   public String getName() {
     return "RNAWSCognito";
+  }
+
+  @ReactMethod(isBlockingSynchronousMethod = true)
+  public String getRandomBase64(int byteLength) throws NoSuchAlgorithmException {
+    byte[] data = new byte[byteLength];
+    SecureRandom random = new SecureRandom();
+
+    random.nextBytes(data);
+
+    return Base64.encodeToString(data, Base64.NO_WRAP);
   }
 
   @ReactMethod

--- a/ios/Exponent/Versioned/Core/Api/Cognito/RNAWSCognito.h
+++ b/ios/Exponent/Versioned/Core/Api/Cognito/RNAWSCognito.h
@@ -16,8 +16,8 @@
 #import <React/RCTUtils.h>
 #endif
 
-#import <JKBigInteger.h>
+#import "JKBigInteger.h"
 
 @interface RNAWSCognito : NSObject <RCTBridgeModule>
-
+-(NSString*)getRandomBase64:(NSUInteger)byteLength;
 @end

--- a/ios/Exponent/Versioned/Core/Api/Cognito/RNAWSCognito.m
+++ b/ios/Exponent/Versioned/Core/Api/Cognito/RNAWSCognito.m
@@ -9,6 +9,15 @@ static NSString* N_IN_HEX = @"FFFFFFFFFFFFFFFFC90FDAA22168C234C4C6628B80DC1CD129
 }
 RCT_EXPORT_MODULE()
 
+RCT_EXPORT_SYNCHRONOUS_TYPED_METHOD(NSString*, getRandomBase64:(NSUInteger)byteLength) {
+    NSMutableData *data = [NSMutableData dataWithLength:byteLength];
+    int result = SecRandomCopyBytes(kSecRandomDefault, byteLength, data.mutableBytes);
+    if (result != errSecSuccess) {
+        @throw([NSException exceptionWithName:@"NO_RANDOM_BYTES" reason:@"Failed to acquire secure random bytes" userInfo:nil]);
+    }
+    return [data base64EncodedStringWithOptions:0];
+}
+
 RCT_EXPORT_METHOD(computeModPow:(NSDictionary *)values
                   callback:(RCTResponseSenderBlock)callback) {
     JKBigInteger *target = [[JKBigInteger alloc] initWithString:values[@"target"] andRadix:16];

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -17,7 +17,7 @@ abstract_target 'Expo Go' do
   pod 'CocoaLumberjack', '~> 3.5.3'
   pod 'GoogleMaps', '~> 3.6'
   pod 'Google-Maps-iOS-Utils', '~> 2.1.0'
-  pod 'JKBigInteger2', '0.0.5'
+  pod 'JKBigInteger', :podspec => 'vendored/common/JKBigInteger.podspec.json'
   pod 'MBProgressHUD', '~> 1.2.0'
 
   # Expo modules

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -234,7 +234,7 @@ PODS:
     - Google-Mobile-Ads-SDK
     - GoogleMaps
     - GoogleSignIn
-    - JKBigInteger2
+    - JKBigInteger
     - lottie-ios
     - RCT-Folly
   - ABI40_0_0ExpoKit/ExpoOptional (40.0.0):
@@ -806,7 +806,7 @@ PODS:
     - Google-Mobile-Ads-SDK
     - GoogleMaps
     - GoogleSignIn
-    - JKBigInteger2
+    - JKBigInteger
     - lottie-ios
     - RCT-Folly
   - ABI41_0_0ExpoKit/ExpoOptional (41.0.0):
@@ -1401,7 +1401,7 @@ PODS:
     - Google-Mobile-Ads-SDK
     - GoogleMaps
     - GoogleSignIn
-    - JKBigInteger2
+    - JKBigInteger
     - lottie-ios
     - RCT-Folly
   - ABI42_0_0ExpoKit/ExpoOptional (42.0.0):
@@ -2098,7 +2098,7 @@ PODS:
     - AppAuth/Core (~> 1.4)
     - GTMSessionFetcher/Core (~> 1.5)
   - GTMSessionFetcher/Core (1.5.0)
-  - JKBigInteger2 (0.0.5)
+  - JKBigInteger (0.0.6)
   - lottie-ios (3.2.3)
   - lottie-react-native (4.0.3):
     - lottie-ios (~> 3.2.3)
@@ -2854,7 +2854,7 @@ DEPENDENCIES:
   - glog (from `../react-native-lab/react-native/third-party-podspecs/glog.podspec`)
   - Google-Maps-iOS-Utils (~> 2.1.0)
   - GoogleMaps (~> 3.6)
-  - JKBigInteger2 (= 0.0.5)
+  - JKBigInteger (from `vendored/common/JKBigInteger.podspec.json`)
   - lottie-react-native (from `./vendored/unversioned/lottie-react-native`)
   - MBProgressHUD (~> 1.2.0)
   - Nimble (from `./Nimble.podspec`)
@@ -2926,7 +2926,6 @@ SPEC REPOS:
     - GoogleUtilitiesComponents
     - GTMAppAuth
     - GTMSessionFetcher
-    - JKBigInteger2
     - lottie-ios
     - MBProgressHUD
     - MLKitCommon
@@ -3708,6 +3707,8 @@ EXTERNAL SOURCES:
     :path: "../react-native-lab/react-native/React/FBReactNativeSpec"
   glog:
     :podspec: "../react-native-lab/react-native/third-party-podspecs/glog.podspec"
+  JKBigInteger:
+    :podspec: vendored/common/JKBigInteger.podspec.json
   lottie-react-native:
     :path: "./vendored/unversioned/lottie-react-native"
   Nimble:
@@ -3833,7 +3834,7 @@ SPEC CHECKSUMS:
   ABI40_0_0EXNetwork: 3fde803c18582fb40eb74a6b7457bd2d873d71de
   ABI40_0_0EXNotifications: a768e9f838636410c2efb4f45294a25b1f67bdb5
   ABI40_0_0EXPermissions: 1f03cb4f28663d9889e7a7f4649a44b431d35bba
-  ABI40_0_0ExpoKit: c0e43ba3c45c0865e4de4ce8444155158dd15fd8
+  ABI40_0_0ExpoKit: cc35e53b5732abeacd3c0dd8ab826a900d435e87
   ABI40_0_0EXPrint: 28c0b0b1c7a5fcf7bb162402effd18bfc2609580
   ABI40_0_0EXRandom: 0a65d0035142a3f4546ec9a370f33689fea55960
   ABI40_0_0EXScreenCapture: 64f2e26f8f63d550eee5bed11a88e541a3874036
@@ -3935,7 +3936,7 @@ SPEC CHECKSUMS:
   ABI41_0_0EXNetwork: 7063020fbd68cbe249290a3ed20929874f59e3d6
   ABI41_0_0EXNotifications: c02652d5aa32c1de9f3aeff610e36a7825c46c8a
   ABI41_0_0EXPermissions: 7340fb1182368cf96296476dc7708c8f1398c656
-  ABI41_0_0ExpoKit: 5be6c62fb301b7e3bac49460b1b91c250bce9605
+  ABI41_0_0ExpoKit: 20db5aaeae24edf4b1d8df31b54c6215ec3b3128
   ABI41_0_0EXPrint: 7401d385395553865479f30cfbaf371340d776f4
   ABI41_0_0EXRandom: 457ad8c71b497fc4fda20d70152fbce8f7dc0919
   ABI41_0_0EXScreenCapture: 96a7760db8e34a62ad5bdeaf65e265defdb7dc79
@@ -4042,7 +4043,7 @@ SPEC CHECKSUMS:
   ABI42_0_0EXNetwork: 0176a370ca963ed0c9c7bec2d6938cff05e94a1e
   ABI42_0_0EXNotifications: 36428b03b301a9b51de900910313e12e150a07b0
   ABI42_0_0EXPermissions: 7f0f7a1334056db7f51c3563fd977d0a6393c998
-  ABI42_0_0ExpoKit: 05df697b069c3105eed5ff2b7d90d32e14f86745
+  ABI42_0_0ExpoKit: 314e91dcab92ec8a886d1fa5a9c3f8b457d24440
   ABI42_0_0ExpoModulesCore: 85d79294f8c6c297f1b1c1af7a5ef292dd21a643
   ABI42_0_0EXPrint: 104311da09fe260e5d21d83d235c0c557d826282
   ABI42_0_0EXRandom: e692f2004e285512b969c9a0ce488283b6149370
@@ -4197,7 +4198,7 @@ SPEC CHECKSUMS:
   GoogleUtilitiesComponents: a69c0b3b369ba443e988141e75ef49d9010b1c80
   GTMAppAuth: ad5c2b70b9a8689e1a04033c9369c4915bfcbe89
   GTMSessionFetcher: b3503b20a988c4e20cc189aa798fd18220133f52
-  JKBigInteger2: e91672035c42328c48b7dd015b66812ddf40ca9b
+  JKBigInteger: 5c72131974815e969c0782c41e3452f1bbe5619f
   lottie-ios: c058aeafa76daa4cf64d773554bccc8385d0150e
   lottie-react-native: abf7a5255678c0cbb3b418b9f2f403efe6f54561
   MBProgressHUD: 3ee5efcc380f6a79a7cc9b363dd669c5e1ae7406
@@ -4248,6 +4249,6 @@ SPEC CHECKSUMS:
   Yoga: 575c581c63e0d35c9a83f4b46d01d63abc1100ac
   ZXingObjC: fdbb269f25dd2032da343e06f10224d62f537bdb
 
-PODFILE CHECKSUM: 0a1030c468c8f7af9c070ac2aa393e6f1453bc50
+PODFILE CHECKSUM: 7c71ae606a1e83e2827e31f0cce4ef247399610e
 
 COCOAPODS: 1.11.0

--- a/ios/vendored/common/JKBigInteger.podspec.json
+++ b/ios/vendored/common/JKBigInteger.podspec.json
@@ -1,0 +1,19 @@
+{
+  "name": "JKBigInteger",
+  "version": "0.0.6",
+  "requires_arc": true,
+  "license": "MIT",
+  "homepage": "https://github.com/kirsteins/JKBigInteger",
+  "authors": "Jānis Kiršteins",
+  "summary": "Library for working with big integers in Objective-C.",
+  "description": "JKBigInteger is a small library to facilitate easy working with big integers in Objective-C. JKBigInteger is\na Objective-C wrapper around LibTomMath C library. It is inspired by the Java's BigInteger.",
+  "social_media_url": "https://twitter.com/janiskirsteins",
+  "source": {
+    "git": "https://github.com/kirsteins/JKBigInteger.git",
+    "commit": "04b6d6fbff445ecca1ccaa5ff498e7503d0d7c88"
+  },
+  "source_files": "JKBigInteger/**/*.{c,h,m}",
+  "platforms": {
+    "ios": "12.0"
+  }
+}

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/ABI40_0_0ExpoKit.podspec
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/ABI40_0_0ExpoKit.podspec
@@ -130,7 +130,7 @@ Pod::Spec.new do |s|
     ss.dependency         "GoogleMaps"
     ss.dependency         "Google-Maps-iOS-Utils"
     ss.dependency         "lottie-ios"
-    ss.dependency         "JKBigInteger2"
+    ss.dependency         "JKBigInteger"
     ss.dependency         "Branch"
     ss.dependency         "Google-Mobile-Ads-SDK"
     ss.dependency         "RCT-Folly"

--- a/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/Api/Cognito/ABI40_0_0RNAWSCognito.h
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/ExpoKit/Core/Api/Cognito/ABI40_0_0RNAWSCognito.h
@@ -16,7 +16,7 @@
 #import <ABI40_0_0React/ABI40_0_0RCTUtils.h>
 #endif
 
-#import <JKBigInteger.h>
+#import "JKBigInteger.h"
 
 @interface ABI40_0_0RNAWSCognito : NSObject <ABI40_0_0RCTBridgeModule>
 

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/ABI41_0_0ExpoKit.podspec
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/ABI41_0_0ExpoKit.podspec
@@ -132,7 +132,7 @@ Pod::Spec.new do |s|
     ss.dependency         "GoogleMaps"
     ss.dependency         "Google-Maps-iOS-Utils"
     ss.dependency         "lottie-ios"
-    ss.dependency         "JKBigInteger2"
+    ss.dependency         "JKBigInteger"
     ss.dependency         "Branch"
     ss.dependency         "Google-Mobile-Ads-SDK"
     ss.dependency         "RCT-Folly"

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/Api/Cognito/ABI41_0_0RNAWSCognito.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/Api/Cognito/ABI41_0_0RNAWSCognito.h
@@ -16,7 +16,7 @@
 #import <ABI41_0_0React/ABI41_0_0RCTUtils.h>
 #endif
 
-#import <JKBigInteger.h>
+#import "JKBigInteger.h"
 
 @interface ABI41_0_0RNAWSCognito : NSObject <ABI41_0_0RCTBridgeModule>
 

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/ABI42_0_0ExpoKit.podspec
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/ABI42_0_0ExpoKit.podspec
@@ -127,7 +127,7 @@ Pod::Spec.new do |s|
     ss.dependency         "GoogleMaps"
     ss.dependency         "Google-Maps-iOS-Utils"
     ss.dependency         "lottie-ios"
-    ss.dependency         "JKBigInteger2"
+    ss.dependency         "JKBigInteger"
     ss.dependency         "Branch"
     ss.dependency         "Google-Mobile-Ads-SDK"
     ss.dependency         "RCT-Folly"

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/Api/Cognito/ABI42_0_0RNAWSCognito.h
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/Api/Cognito/ABI42_0_0RNAWSCognito.h
@@ -16,7 +16,7 @@
 #import <ABI42_0_0React/ABI42_0_0RCTUtils.h>
 #endif
 
-#import <JKBigInteger.h>
+#import "JKBigInteger.h"
 
 @interface ABI42_0_0RNAWSCognito : NSObject <ABI42_0_0RCTBridgeModule>
 


### PR DESCRIPTION
# Why

upgrade modules for sdk 43 release
close [ENG-1890](https://linear.app/expo/issue/ENG-1890/upgrade-amazon-cognito-identity-js)

# How

- `et update-vendored-module -m amazon-cognito-identity-js -c aws-amplify@4.2.9`
- update JKBigInteger which amazon-cognito-identity-js has local fork. fortunately, the upstream have the change just not published to cocoapods repository. i added a local podspec in `ios/vendored/common/JKBigInteger.podspec.json`.

# Test Plan

expo go ios build passed (both unversioned and versioned)