### PR TITLE
[expo-modules-core] revert prebuilding xcframework

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 🐛 Bug fixes
 
+- Revert prebuilt binaries on iOS to fix build errors. ([#14418](https://github.com/expo/expo/pull/14418) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 0.3.1 — 2021-09-09

--- a/packages/expo-modules-core/ios/ModuleRegistryAdapter/EXModuleRegistryAdapter.m
+++ b/packages/expo-modules-core/ios/ModuleRegistryAdapter/EXModuleRegistryAdapter.m
@@ -1,17 +1,11 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
 #import <ExpoModulesCore/EXNativeModulesProxy.h>
-#import <ExpoModulesCore/EXReactNativeEventEmitter.h>
 #import <ExpoModulesCore/EXViewManagerAdapter.h>
 #import <ExpoModulesCore/EXModuleRegistryAdapter.h>
 #import <ExpoModulesCore/EXViewManagerAdapterClassesRegistry.h>
 #import <ExpoModulesCore/EXModuleRegistryHolderReactModule.h>
-#if __has_include(<ExpoModulesCore/ExpoModulesCore-Swift.h>)
-// For prebuilding xcframework, do not use quote notation.
-#import <ExpoModulesCore/ExpoModulesCore-Swift.h>
-#elif __has_include("ExpoModulesCore-Swift.h")
 #import "ExpoModulesCore-Swift.h"
-#endif
 
 @interface EXModuleRegistryAdapter ()
 

--- a/packages/expo-modules-core/ios/NativeModulesProxy/EXNativeModulesProxy.m
+++ b/packages/expo-modules-core/ios/NativeModulesProxy/EXNativeModulesProxy.m
@@ -8,19 +8,12 @@
 #import <React/RCTModuleData.h>
 #import <React/RCTEventDispatcherProtocol.h>
 
-#import <ExpoModulesCore/EXModuleRegistryProvider.h>
-#import <ExpoModulesCore/EXReactNativeEventEmitter.h>
 #import <ExpoModulesCore/EXNativeModulesProxy.h>
 #import <ExpoModulesCore/EXEventEmitter.h>
 #import <ExpoModulesCore/EXViewManager.h>
 #import <ExpoModulesCore/EXViewManagerAdapter.h>
 #import <ExpoModulesCore/EXViewManagerAdapterClassesRegistry.h>
-#if __has_include(<ExpoModulesCore/ExpoModulesCore-Swift.h>)
-// For prebuilding xcframework, do not use quote notation.
-#import <ExpoModulesCore/ExpoModulesCore-Swift.h>
-#elif __has_include("ExpoModulesCore-Swift.h")
 #import "ExpoModulesCore-Swift.h"
-#endif
 
 static const NSString *exportedMethodsNamesKeyPath = @"exportedMethods";
 static const NSString *viewManagersNamesKeyPath = @"viewManagersNames";

--- a/tools/src/CocoaPods.ts
+++ b/tools/src/CocoaPods.ts
@@ -19,7 +19,6 @@ export type Podspec = {
   dependencies: Record<string, any>;
   info_plist: Record<string, string>;
   ios?: Podspec;
-  modulemap_file?: string;
 };
 
 /**

--- a/tools/src/prebuilds/Prebuilder.ts
+++ b/tools/src/prebuilds/Prebuilder.ts
@@ -7,9 +7,7 @@ import logger from '../Logger';
 import XcodeProject from './XcodeProject';
 import {
   createSpecFromPodspecAsync,
-  generateExpoModulesCoreModulemapAsync,
   generateXcodeProjectAsync,
-  GENERATED_MODULEMAP_FILENAME,
   INFO_PLIST_FILENAME,
 } from './XcodeGen';
 import { Flavor, Framework, XcodebuildSettings } from './XcodeProject.types';
@@ -21,7 +19,6 @@ const PODS_DIR = path.join(IOS_DIR, 'Pods');
 // We will be increasing this list slowly. Once all are enabled,
 // find a better way to ignore some packages that shouldn't be prebuilt (like interfaces).
 export const PACKAGES_TO_PREBUILD = [
-  'expo-modules-core',
   // '@unimodules/core',
   // '@unimodules/react-native-adapter',
   // 'expo-ads-admob',
@@ -163,12 +160,7 @@ export async function buildFrameworksForProjectAsync(
 export async function cleanTemporaryFilesAsync(xcodeProject: XcodeProject) {
   logger.log('   Cleaning up temporary files');
 
-  const pathsToRemove = [
-    `${xcodeProject.name}.xcodeproj`,
-    INFO_PLIST_FILENAME,
-    GENERATED_MODULEMAP_FILENAME,
-    `${xcodeProject.name}-umbrella.h`,
-  ];
+  const pathsToRemove = [`${xcodeProject.name}.xcodeproj`, INFO_PLIST_FILENAME];
 
   await Promise.all(
     pathsToRemove.map((pathToRemove) => fs.remove(path.join(xcodeProject.rootDir, pathToRemove)))
@@ -186,13 +178,6 @@ export async function generateXcodeProjectSpecAsync(pkg: Package): Promise<Xcode
   }
 
   logger.log('   Generating Xcode project spec');
-
-  if (pkg.packageName === 'expo-modules-core') {
-    const modulemapFile = await generateExpoModulesCoreModulemapAsync(
-      path.join(pkg.path, pkg.iosSubdirectory)
-    );
-    podspec.modulemap_file = modulemapFile;
-  }
 
   const spec = await createSpecFromPodspecAsync(podspec, async (dependencyName) => {
     const frameworkPath = await findFrameworkForProjectAsync(dependencyName);

--- a/tools/src/prebuilds/XcodeGen.ts
+++ b/tools/src/prebuilds/XcodeGen.ts
@@ -24,7 +24,6 @@ const PLATFORMS_MAPPING: Record<string, ProjectSpecPlatform> = {
 };
 
 export const INFO_PLIST_FILENAME = 'Info-generated.plist';
-export const GENERATED_MODULEMAP_FILENAME = 'generated.modulemap';
 
 /**
  * Generates `.xcodeproj` from given project spec and saves it at given dir.
@@ -128,7 +127,6 @@ export async function createSpecFromPodspecAsync(
         IPHONEOS_DEPLOYMENT_TARGET: podspec.platforms.ios,
         FRAMEWORK_SEARCH_PATHS: constructFrameworkSearchPaths(dependencies),
         HEADER_SEARCH_PATHS: constructHeaderSearchPaths(dependenciesNames),
-        MODULEMAP_FILE: podspec.modulemap_file ?? '',
 
         // Suppresses deprecation warnings coming from frameworks like OpenGLES.
         VALIDATE_WORKSPACE_SKIPPED_SDK_FRAMEWORKS: arrayize(podspec.frameworks).join(' '),
@@ -213,46 +211,4 @@ function podNameToBundleId(podName: string): string {
     .replace(/^EX/, 'expo')
     .replace(/(\_|[^\w\d\.])+/g, '.')
     .replace(/\.*([A-Z]+)/g, (_, p1) => `.${p1.toLowerCase()}`);
-}
-
-/**
- * Generate custom modulemap for expo-modules-core which needs to make React-Core headers modular
- */
-export async function generateExpoModulesCoreModulemapAsync(destDir: string): Promise<string> {
-  const expoModulesCoreUmbrellaHeaderName = 'ExpoModulesCore-umbrella.h';
-  const expoModulesCoreUmbrellaHeader = path.join(
-    PODS_PUBLIC_HEADERS_DIR,
-    'ExpoModulesCore',
-    expoModulesCoreUmbrellaHeaderName
-  );
-  await fs.copyFile(
-    expoModulesCoreUmbrellaHeader,
-    path.join(destDir, expoModulesCoreUmbrellaHeaderName)
-  );
-
-  const reactCoreHeaderDir = path.join(PODS_PUBLIC_HEADERS_DIR, 'React-Core');
-  const yogaUmbrellaHeader = path.join(PODS_PUBLIC_HEADERS_DIR, 'Yoga', 'Yoga-umbrella.h');
-  const modulemapContent = `
-framework module ExpoModulesCore {
-  umbrella header "ExpoModulesCore.h"
-  export *
-  module * { export * }
-
-  module React {
-    umbrella "${reactCoreHeaderDir}"
-    export *
-    module * { export * }
-  }
-
-  module Yoga {
-    umbrella header "${yogaUmbrellaHeader}"
-    export *
-    module * { export * }
-  }
-}
-`;
-
-  const modulemapFile = path.join(destDir, GENERATED_MODULEMAP_FILENAME);
-  await fs.writeFile(modulemapFile, modulemapContent);
-  return modulemapFile;
 }


### PR DESCRIPTION
# Why

the generated expo-modules-core xcframework from #14350 will cause errors when building apps.

# How

`git revert cb6a36461bb0685f747084e0548d1af1a3598efc`
