### PR TITLE
[expo-modules-core] introduce EXAppDefines to get app building configurations

### DIFF
--- a/apps/bare-expo/ios/BareExpo/AppDelegate.swift
+++ b/apps/bare-expo/ios/BareExpo/AppDelegate.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import ExpoModulesCore
 import EXDevMenuInterface
 #if EX_DEV_MENU_ENABLED
 import EXDevMenu

--- a/apps/bare-expo/ios/BareExpo/AppDelegate.swift
+++ b/apps/bare-expo/ios/BareExpo/AppDelegate.swift
@@ -7,7 +7,6 @@
 //
 
 import Foundation
-import ExpoModulesCore
 import EXDevMenuInterface
 #if EX_DEV_MENU_ENABLED
 import EXDevMenu
@@ -35,12 +34,6 @@ class AppDelegate: ExpoAppDelegate {
     } else {
       initializeReactNativeBridge(launchOptions);
     }
-
-    #if DEBUG
-    EXAppDefines.initDefines(true)
-    #else
-    EXAppDefines.initDefines(false)
-    #endif
 
     super.application(application, didFinishLaunchingWithOptions: launchOptions)
     

--- a/apps/bare-expo/ios/BareExpo/AppDelegate.swift
+++ b/apps/bare-expo/ios/BareExpo/AppDelegate.swift
@@ -36,6 +36,12 @@ class AppDelegate: ExpoAppDelegate {
       initializeReactNativeBridge(launchOptions);
     }
 
+    #if DEBUG
+    EXAppDefines.initDefines(true)
+    #else
+    EXAppDefines.initDefines(false)
+    #endif
+
     super.application(application, didFinishLaunchingWithOptions: launchOptions)
     
     return true

--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -1307,7 +1307,7 @@ SPEC CHECKSUMS:
   ExpoHaptics: c0c014eabfdd1353a908f857f168b01fafd526db
   ExpoLinearGradient: 841746b0ef9c771d1f37fa5463f39eb25b6aae77
   ExpoLocalization: 882eeed58daf9aa9d7265fff537a3ddae3834d2f
-  ExpoModulesCore: 3339f23adf96e5b39e6315d5f32b4585ecd4cd43
+  ExpoModulesCore: 1c28b20c381edd3817be74505499cdaa9658fc97
   ExpoSystemUI: 3c969e3db290fcd5edb9c466d585f183d934b421
   EXPrint: a224501bbb89072567c58a5127f2d125b8776ea2
   EXRandom: 9ed4600d410cf2fe58d22b3121865624065a16e9

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -4199,7 +4199,7 @@ SPEC CHECKSUMS:
   ExpoHaptics: c0c014eabfdd1353a908f857f168b01fafd526db
   ExpoLinearGradient: 841746b0ef9c771d1f37fa5463f39eb25b6aae77
   ExpoLocalization: 882eeed58daf9aa9d7265fff537a3ddae3834d2f
-  ExpoModulesCore: 3339f23adf96e5b39e6315d5f32b4585ecd4cd43
+  ExpoModulesCore: 1c28b20c381edd3817be74505499cdaa9658fc97
   ExpoSystemUI: 3c969e3db290fcd5edb9c466d585f183d934b421
   EXPrint: a224501bbb89072567c58a5127f2d125b8776ea2
   EXRandom: 9ed4600d410cf2fe58d22b3121865624065a16e9

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -26,6 +26,7 @@
 - [Sweet API] Added support for enums in method arguments on iOS. ([#15129](https://github.com/expo/expo/pull/15129) by [@tsapeta](https://github.com/tsapeta))
 - [Sweet API] Automatic conversion is now available for view props setters. ([#15132](https://github.com/expo/expo/pull/15132) by [@tsapeta](https://github.com/tsapeta))
 - [Sweet API] Added experimental implementation of the new API in Kotlin. (by [@lukmccall](https://github.com/lukmccall))
+- Introduce EXAppDefines to get app building configurations. ([#14428](https://github.com/expo/expo/pull/14428) by [@kudo](https://github.com/kudo))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/ios/EXAppDefines.h
+++ b/packages/expo-modules-core/ios/EXAppDefines.h
@@ -1,0 +1,28 @@
+// Copyright 2016-present 650 Industries. All rights reserved.
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+// We ship some modules in [prebuilt binaries](https://expo.fyi/prebuilt-modules),
+// classic defines like `DEBUG` or `RCT_DEV` may not like what we expected.
+// Because the prebuilt modules are always built with Release configurations.
+// This class acts as a supporter to get app build time configurations.
+//
+// Note this class is not thread-safe, please make sure to intiailize
+// in `application(_:didFinishLaunchingWithOptions:)`
+@interface EXAppDefines : NSObject
+
+@property (class, nonatomic, assign, readonly) BOOL APP_DEBUG;
+@property (class, nonatomic, assign, readonly) BOOL APP_RCT_DEBUG;
+@property (class, nonatomic, assign, readonly) BOOL APP_RCT_DEV;
+
++ (void)initDefines:(BOOL)debug;
+
++ (void)initDefines:(BOOL)debug
+           rctDebug:(BOOL)rctDebug
+             rctDev:(BOOL)rctDev;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-modules-core/ios/EXAppDefines.h
+++ b/packages/expo-modules-core/ios/EXAppDefines.h
@@ -9,19 +9,11 @@ NS_ASSUME_NONNULL_BEGIN
 // Because the prebuilt modules are always built with Release configurations.
 // This class acts as a supporter to get app build time configurations.
 //
-// Note this class is not thread-safe, please make sure to intiailize
-// in `application(_:didFinishLaunchingWithOptions:)`
 @interface EXAppDefines : NSObject
 
 @property (class, nonatomic, assign, readonly) BOOL APP_DEBUG;
 @property (class, nonatomic, assign, readonly) BOOL APP_RCT_DEBUG;
 @property (class, nonatomic, assign, readonly) BOOL APP_RCT_DEV;
-
-+ (void)initDefines:(BOOL)debug;
-
-+ (void)initDefines:(BOOL)debug
-           rctDebug:(BOOL)rctDebug
-             rctDev:(BOOL)rctDev;
 
 @end
 

--- a/packages/expo-modules-core/ios/EXAppDefines.h
+++ b/packages/expo-modules-core/ios/EXAppDefines.h
@@ -17,7 +17,9 @@ NS_ASSUME_NONNULL_BEGIN
 @property (class, nonatomic, assign, readonly) BOOL APP_RCT_DEBUG;
 @property (class, nonatomic, assign, readonly) BOOL APP_RCT_DEV;
 
-+ (void)load:(BOOL)APP_DEBUG APP_RCT_DEBUG:(BOOL)APP_RCT_DEBUG APP_RCT_DEV:(BOOL)APP_RCT_DEV;
++ (NSDictionary *)getAllDefines;
+
++ (void)load:(NSDictionary *)defines;
 
 @end
 

--- a/packages/expo-modules-core/ios/EXAppDefines.h
+++ b/packages/expo-modules-core/ios/EXAppDefines.h
@@ -4,16 +4,20 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-// We ship some modules in [prebuilt binaries](https://expo.fyi/prebuilt-modules),
-// classic defines like `DEBUG` or `RCT_DEV` may not like what we expected.
-// Because the prebuilt modules are always built with Release configurations.
-// This class acts as a supporter to get app build time configurations.
-//
+/**
+ For expo modules to get app build time preprocessor values.
+ We ship some modules in [prebuilt binaries](https://expo.fyi/prebuilt-modules),
+ classic defines like `DEBUG` or `RCT_DEV` may not work as expected
+ because the prebuilt modules are always built with Release configuration.
+ This class acts as a supporter to get app build time preprocessor values.
+ */
 @interface EXAppDefines : NSObject
 
 @property (class, nonatomic, assign, readonly) BOOL APP_DEBUG;
 @property (class, nonatomic, assign, readonly) BOOL APP_RCT_DEBUG;
 @property (class, nonatomic, assign, readonly) BOOL APP_RCT_DEV;
+
++ (void)load:(BOOL)APP_DEBUG APP_RCT_DEBUG:(BOOL)APP_RCT_DEBUG APP_RCT_DEV:(BOOL)APP_RCT_DEV;
 
 @end
 

--- a/packages/expo-modules-core/ios/EXAppDefines.m
+++ b/packages/expo-modules-core/ios/EXAppDefines.m
@@ -1,0 +1,59 @@
+// Copyright 2016-present 650 Industries. All rights reserved.
+
+#import <ExpoModulesCore/EXAppDefines.h>
+
+@implementation EXAppDefines
+
+static BOOL _inited = NO;
+static BOOL _debug;
+static BOOL _rctDebug;
+static BOOL _rctDev;
+
++ (BOOL)APP_DEBUG
+{
+  [self throwIfNotInited];
+  return _debug;
+}
+
++ (BOOL)APP_RCT_DEBUG
+{
+  [self throwIfNotInited];
+  return _rctDebug;
+}
+
++ (BOOL)APP_RCT_DEV
+{
+  [self throwIfNotInited];
+  return _rctDev;
+}
+
++ (void)initDefines:(BOOL)debug
+{
+  [self initDefines:debug rctDebug:debug rctDev:debug];
+}
+
++ (void)initDefines:(BOOL)debug
+           rctDebug:(BOOL)rctDebug
+             rctDev:(BOOL)rctDev
+{
+  if (_inited) {
+    @throw [NSException exceptionWithName:NSInternalInconsistencyException
+                                   reason:@"EXAppDefines is already initialized"
+                                 userInfo:nil];
+  }
+  _inited = YES;
+  _debug = debug;
+  _rctDebug = rctDebug;
+  _rctDev = rctDev;
+}
+
++ (void)throwIfNotInited
+{
+  if (!_inited) {
+    @throw [NSException exceptionWithName:NSInternalInconsistencyException
+                                   reason:@"EXAppDefines is not yet initialized. Check https://expo.fyi/expo-modules-migration for more information."
+                                 userInfo:nil];
+  }
+}
+
+@end

--- a/packages/expo-modules-core/ios/EXAppDefines.m
+++ b/packages/expo-modules-core/ios/EXAppDefines.m
@@ -1,59 +1,27 @@
 // Copyright 2016-present 650 Industries. All rights reserved.
 
 #import <ExpoModulesCore/EXAppDefines.h>
+#import <React/RCTDefines.h>
+
+// Assuming ExpoModulesCore is not shipping as prebuilt xcframework,
+// so that `DEBUG` and other definitions are same as app building definitions.
+// Other prebuilt module can leverage these `APP_*` to get the app building definitions.
 
 @implementation EXAppDefines
 
-static BOOL _inited = NO;
-static BOOL _debug;
-static BOOL _rctDebug;
-static BOOL _rctDev;
-
 + (BOOL)APP_DEBUG
 {
-  [self throwIfNotInited];
-  return _debug;
+  return DEBUG;
 }
 
 + (BOOL)APP_RCT_DEBUG
 {
-  [self throwIfNotInited];
-  return _rctDebug;
+  return RCT_DEBUG;
 }
 
 + (BOOL)APP_RCT_DEV
 {
-  [self throwIfNotInited];
-  return _rctDev;
-}
-
-+ (void)initDefines:(BOOL)debug
-{
-  [self initDefines:debug rctDebug:debug rctDev:debug];
-}
-
-+ (void)initDefines:(BOOL)debug
-           rctDebug:(BOOL)rctDebug
-             rctDev:(BOOL)rctDev
-{
-  if (_inited) {
-    @throw [NSException exceptionWithName:NSInternalInconsistencyException
-                                   reason:@"EXAppDefines is already initialized"
-                                 userInfo:nil];
-  }
-  _inited = YES;
-  _debug = debug;
-  _rctDebug = rctDebug;
-  _rctDev = rctDev;
-}
-
-+ (void)throwIfNotInited
-{
-  if (!_inited) {
-    @throw [NSException exceptionWithName:NSInternalInconsistencyException
-                                   reason:@"EXAppDefines is not yet initialized. Check https://expo.fyi/expo-modules-migration for more information."
-                                 userInfo:nil];
-  }
+  return RCT_DEV;
 }
 
 @end

--- a/packages/expo-modules-core/ios/EXAppDefines.m
+++ b/packages/expo-modules-core/ios/EXAppDefines.m
@@ -11,7 +11,11 @@
 
 + (BOOL)APP_DEBUG
 {
-  return DEBUG;
+#if DEBUG
+  return YES;
+#else
+  return NO;
+#endif
 }
 
 + (BOOL)APP_RCT_DEBUG

--- a/packages/expo-modules-core/ios/EXAppDefines.m
+++ b/packages/expo-modules-core/ios/EXAppDefines.m
@@ -5,39 +5,47 @@
 
 @implementation EXAppDefines
 
-static BOOL _debug;
-static BOOL _rctDebug;
-static BOOL _rctDev;
+static NSDictionary *_storage;
 static BOOL _loaded = NO;
 
 + (BOOL)APP_DEBUG
 {
   [self throwIfNotLoaded];
-  return _debug;
+  return _storage[@"APP_DEBUG"];
 }
 
 + (BOOL)APP_RCT_DEBUG
 {
   [self throwIfNotLoaded];
-  return _rctDebug;
+  return _storage[@"APP_RCT_DEBUG"];
 }
 
 + (BOOL)APP_RCT_DEV
 {
   [self throwIfNotLoaded];
-  return _rctDev;
+  return _storage[@"APP_RCT_DEV"];
 }
 
-+ (void)load:(BOOL)APP_DEBUG APP_RCT_DEBUG:(BOOL)APP_RCT_DEBUG APP_RCT_DEV:(BOOL)APP_RCT_DEV
++ (NSDictionary *)getAllDefines
+{
+  return _storage;
+}
+
++ (void)load:(NSDictionary *)defines
 {
   NSAssert([NSThread isMainThread], @"This function must be called on main thread");
   NSAssert(!_loaded, @"EXAppDefines is already loaded");
   if (!_loaded) {
-    _debug = APP_DEBUG;
-    _rctDebug = APP_RCT_DEBUG;
-    _rctDev = APP_RCT_DEV;
+    _storage = defines;
     _loaded = YES;
   }
+}
+
+// Private function for EXAppDefinesTest to unload the current state.
++ (void)_unload
+{
+  _storage = nil;
+  _loaded = NO;
 }
 
 + (void)throwIfNotLoaded
@@ -48,5 +56,6 @@ static BOOL _loaded = NO;
                                  userInfo:nil];
   }
 }
+
 
 @end

--- a/packages/expo-modules-core/ios/EXAppDefines.m
+++ b/packages/expo-modules-core/ios/EXAppDefines.m
@@ -3,29 +3,50 @@
 #import <ExpoModulesCore/EXAppDefines.h>
 #import <React/RCTDefines.h>
 
-// Assuming ExpoModulesCore is not shipping as prebuilt xcframework,
-// so that `DEBUG` and other definitions are same as app building definitions.
-// Other prebuilt module can leverage these `APP_*` to get the app building definitions.
-
 @implementation EXAppDefines
+
+static BOOL _debug;
+static BOOL _rctDebug;
+static BOOL _rctDev;
+static BOOL _loaded = NO;
 
 + (BOOL)APP_DEBUG
 {
-#if DEBUG
-  return YES;
-#else
-  return NO;
-#endif
+  [self throwIfNotLoaded];
+  return _debug;
 }
 
 + (BOOL)APP_RCT_DEBUG
 {
-  return RCT_DEBUG;
+  [self throwIfNotLoaded];
+  return _rctDebug;
 }
 
 + (BOOL)APP_RCT_DEV
 {
-  return RCT_DEV;
+  [self throwIfNotLoaded];
+  return _rctDev;
+}
+
++ (void)load:(BOOL)APP_DEBUG APP_RCT_DEBUG:(BOOL)APP_RCT_DEBUG APP_RCT_DEV:(BOOL)APP_RCT_DEV
+{
+  NSAssert([NSThread isMainThread], @"This function must be called on main thread");
+  NSAssert(!_loaded, @"EXAppDefines is already loaded");
+  if (!_loaded) {
+    _debug = APP_DEBUG;
+    _rctDebug = APP_RCT_DEBUG;
+    _rctDev = APP_RCT_DEV;
+    _loaded = YES;
+  }
+}
+
++ (void)throwIfNotLoaded
+{
+  if (!_loaded) {
+    @throw [NSException exceptionWithName:NSInternalInconsistencyException
+                                   reason:@"EXAppDefines is not loaded."
+                                 userInfo:nil];
+  }
 }
 
 @end

--- a/packages/expo-modules-core/ios/ExpoModulesCore.podspec
+++ b/packages/expo-modules-core/ios/ExpoModulesCore.podspec
@@ -41,6 +41,6 @@ Pod::Spec.new do |s|
     test_spec.dependency 'Quick'
     test_spec.dependency 'Nimble'
 
-    test_spec.source_files = 'Tests/**/*.swift'
+    test_spec.source_files = 'Tests/**/*.{m,swift}'
   end
 end

--- a/packages/expo-modules-core/ios/Tests/EXAppDefinesTest.m
+++ b/packages/expo-modules-core/ios/Tests/EXAppDefinesTest.m
@@ -1,0 +1,88 @@
+// Copyright 2016-present 650 Industries. All rights reserved.
+
+#import <XCTest/XCTest.h>
+#import <ExpoModulesCore/EXAppDefines.h>
+
+@interface EXAppDefines (EXAppDefinesWithUnloader)
+
++ (void)_unload;
+
+@end
+
+@interface EXAppDefinesTest : XCTestCase
+
+@end
+
+@implementation EXAppDefinesTest
+
+- (void)setUp
+{
+  // EXAppDefines expects to load just once.
+  // To make it testable with difference test cases,
+  // we call the internal private `_unload` method to reset state.
+  [EXAppDefines performSelector:@selector(_unload)];
+}
+
+- (void)test_load
+{
+  NSDictionary *defines = @{
+    @"APP_DEBUG": @(YES),
+    @"APP_RCT_DEBUG": @(YES),
+    @"APP_RCT_DEV": @(YES),
+  };
+  XCTAssertNoThrow([EXAppDefines load:defines]);
+}
+
+- (void)test_load_throwIfLoadedTwice
+{
+  NSDictionary *defines = @{
+    @"APP_DEBUG": @(YES),
+    @"APP_RCT_DEBUG": @(YES),
+    @"APP_RCT_DEV": @(YES),
+  };
+  XCTAssertNoThrow([EXAppDefines load:defines]);
+  XCTAssertThrows([EXAppDefines load:defines]);
+}
+
+- (void)test_loadAndgetAppDebug_shouldMatchDebugDefines
+{
+  NSDictionary *defines = @{
+    @"APP_DEBUG": @(YES),
+    @"APP_RCT_DEBUG": @(YES),
+    @"APP_RCT_DEV": @(YES),
+  };
+  [EXAppDefines load:defines];
+  XCTAssertEqual(EXAppDefines.APP_DEBUG, YES);
+}
+
+- (void)test_getters_returnsDefaultValues
+{
+  XCTAssertNoThrow([EXAppDefines load:@{}]);
+  XCTAssertEqual(EXAppDefines.APP_DEBUG, NO);
+  XCTAssertEqual(EXAppDefines.APP_RCT_DEBUG, NO);
+  XCTAssertEqual(EXAppDefines.APP_RCT_DEV, NO);
+  XCTAssertEqual(EXAppDefines.getAllDefines.count, 0u);
+}
+
+- (void)test_getAppDebug_throwIfNotLoaded
+{
+  XCTAssertThrows(EXAppDefines.APP_DEBUG);
+}
+
+- (void)test_passExtraDefines_shouldGetMatchedDefines
+{
+  NSDictionary *defines = @{
+    @"APP_DEBUG": @(YES),
+    @"APP_RCT_DEBUG": @(YES),
+    @"APP_RCT_DEV": @(YES),
+    @"foo": @1,
+    @"bar": @2,
+  };
+
+  [EXAppDefines load:defines];
+  NSDictionary *result = EXAppDefines.getAllDefines;
+  XCTAssertEqual([result[@"foo"] intValue], 1);
+  XCTAssertEqual([result[@"bar"] intValue], 2);
+}
+
+@end

--- a/packages/expo-modules-core/ios/Tests/EXAppDefinesTest.m
+++ b/packages/expo-modules-core/ios/Tests/EXAppDefinesTest.m
@@ -44,7 +44,7 @@
   XCTAssertThrows([EXAppDefines load:defines]);
 }
 
-- (void)test_loadAndgetAppDebug_shouldMatchDebugDefines
+- (void)test_loadAndGetAppDebug_shouldMatchDebugDefines
 {
   NSDictionary *defines = @{
     @"APP_DEBUG": @(YES),

--- a/packages/expo/ios/EXAppDefinesLoader.h
+++ b/packages/expo/ios/EXAppDefinesLoader.h
@@ -1,0 +1,14 @@
+// Copyright 2016-present 650 Industries. All rights reserved.
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ This class loads some preprocessors and pass into `EXAppDefines` of ExpoModulesCore.
+ */
+@interface EXAppDefinesLoader : NSObject
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo/ios/EXAppDefinesLoader.m
+++ b/packages/expo/ios/EXAppDefinesLoader.m
@@ -1,0 +1,15 @@
+// Copyright 2016-present 650 Industries. All rights reserved.
+
+#import <Expo/EXAppDefinesLoader.h>
+
+#import <ExpoModulesCore/ExpoModulesCore.h>
+#import <React/RCTDefines.h>
+
+@implementation EXAppDefinesLoader
+
++ (void)load
+{
+  [EXAppDefines load:DEBUG APP_RCT_DEBUG:RCT_DEBUG APP_RCT_DEV:RCT_DEV];
+}
+
+@end

--- a/packages/expo/ios/EXAppDefinesLoader.m
+++ b/packages/expo/ios/EXAppDefinesLoader.m
@@ -9,7 +9,16 @@
 
 + (void)load
 {
-  [EXAppDefines load:DEBUG APP_RCT_DEBUG:RCT_DEBUG APP_RCT_DEV:RCT_DEV];
+  BOOL APP_DEBUG;
+  [EXAppDefines load:@{
+#if DEBUG
+    @"APP_DEBUG": @(YES),
+#else
+    @"APP_DEBUG": @(NO),
+#endif
+    @"APP_RCT_DEBUG": @(RCT_DEBUG),
+    @"APP_RCT_DEV": @(RCT_DEV),
+  }];
 }
 
 @end

--- a/packages/expo/ios/Expo.h
+++ b/packages/expo/ios/Expo.h
@@ -1,1 +1,2 @@
 #import <ExpoModulesCore/ExpoModulesCore.h>
+#import <Expo/EXAppDefinesLoader.h>


### PR DESCRIPTION
# Why

because we ship some modules in prebuilt xcframework binaries, classic `DEBUG` define and react-native's `RCT_DEBUG` or `RCT_DEV` is not available in modules. these values are determined in xcframework prebuilding time, thus to always be false even the app is building with debug configurations.

besides, this will also benefit swift files because swift does not have the `DEBUG` preprocessor by default.

# How

introduce `EXAppDefines`.

# Test Plan

▸ EXAppDefinesTest
▸     ✓ test_getAppDebug_throwIfNotLoaded (0.004 seconds)
▸     ✓ test_getters_returnsDefaultValues (0.002 seconds)
▸     ✓ test_load (0.001 seconds)
▸     ✓ test_load_throwIfLoadedTwice (0.004 seconds)
▸     ✓ test_loadAndGetAppDebug_shouldMatchDebugDefines (0.001 seconds)
▸     ✓ test_passExtraDefines_shouldGetMatchedDefines (0.001 seconds)

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).