### PR TITLE
[updates] Fix auto setup to be enabled for iOS debug builds

### DIFF
--- a/apps/bare-expo/ios/BareExpo/AppDelegate.swift
+++ b/apps/bare-expo/ios/BareExpo/AppDelegate.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import ExpoModulesCore
 import EXDevMenuInterface
 #if EX_DEV_MENU_ENABLED
 import EXDevMenu
@@ -34,6 +35,12 @@ class AppDelegate: AppDelegateWrapper {
     } else {
       initializeReactNativeBridge(launchOptions);
     }
+
+    #if DEBUG
+    EXAppDefines.initDefines(true)
+    #else
+    EXAppDefines.initDefines(false)
+    #endif
 
     super.application(application, didFinishLaunchingWithOptions: launchOptions)
     

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Introduce EXAppDefines to get app building configurations. ([#14428](https://github.com/expo/expo/pull/14428) by [@kudo](https://github.com/kudo))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-modules-core/ios/EXAppDefines.h
+++ b/packages/expo-modules-core/ios/EXAppDefines.h
@@ -1,0 +1,28 @@
+// Copyright 2016-present 650 Industries. All rights reserved.
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+// We ship some modules in [prebuilt binaries](https://expo.fyi/prebuilt-modules),
+// classic defines like `DEBUG` or `RCT_DEV` may not like what we expected.
+// Because the prebuilt modules are always built with Release configurations.
+// This class acts as a supporter to get app build time configurations.
+//
+// Note this class is not thread-safe, please make sure to intiailize
+// in `application(_:didFinishLaunchingWithOptions:)`
+@interface EXAppDefines : NSObject
+
+@property (class, nonatomic, assign, readonly) BOOL APP_DEBUG;
+@property (class, nonatomic, assign, readonly) BOOL APP_RCT_DEBUG;
+@property (class, nonatomic, assign, readonly) BOOL APP_RCT_DEV;
+
++ (void)initDefines:(BOOL)debug;
+
++ (void)initDefines:(BOOL)debug
+           rctDebug:(BOOL)rctDebug
+             rctDev:(BOOL)rctDev;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-modules-core/ios/EXAppDefines.m
+++ b/packages/expo-modules-core/ios/EXAppDefines.m
@@ -1,0 +1,59 @@
+// Copyright 2016-present 650 Industries. All rights reserved.
+
+#import <ExpoModulesCore/EXAppDefines.h>
+
+@implementation EXAppDefines
+
+static BOOL _inited = NO;
+static BOOL _debug;
+static BOOL _rctDebug;
+static BOOL _rctDev;
+
++ (BOOL)APP_DEBUG
+{
+  [self throwIfNotInited];
+  return _debug;
+}
+
++ (BOOL)APP_RCT_DEBUG
+{
+  [self throwIfNotInited];
+  return _rctDebug;
+}
+
++ (BOOL)APP_RCT_DEV
+{
+  [self throwIfNotInited];
+  return _rctDev;
+}
+
++ (void)initDefines:(BOOL)debug
+{
+  [self initDefines:debug rctDebug:debug rctDev:debug];
+}
+
++ (void)initDefines:(BOOL)debug
+           rctDebug:(BOOL)rctDebug
+             rctDev:(BOOL)rctDev
+{
+  if (_inited) {
+    @throw [NSException exceptionWithName:NSInternalInconsistencyException
+                                   reason:@"EXAppDefines is already initialized"
+                                 userInfo:nil];
+  }
+  _inited = YES;
+  _debug = debug;
+  _rctDebug = rctDebug;
+  _rctDev = rctDev;
+}
+
++ (void)throwIfNotInited
+{
+  if (!_inited) {
+    @throw [NSException exceptionWithName:NSInternalInconsistencyException
+                                   reason:@"EXAppDefines is not yet initialized. Check https://expo.fyi/expo-modules-migration for more information."
+                                 userInfo:nil];
+  }
+}
+
+@end

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix auto setup issues on iOS. ([#14429](https://github.com/expo/expo/pull/14429) by [@kudo](https://github.com/kudo))
+- Fix auto setup in iOS is always turning on even for debug builds. ([#14429](https://github.com/expo/expo/pull/14429) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix auto setup issues on iOS. ([#14429](https://github.com/expo/expo/pull/14429) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 0.9.1 — 2021-09-09

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesAppDelegate.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesAppDelegate.m
@@ -2,6 +2,7 @@
 
 #import <EXUpdates/EXUpdatesAppDelegate.h>
 
+#import <ExpoModulesCore/EXAppDefines.h>
 #import <ExpoModulesCore/EXAppDelegateWrapper.h>
 #import <ExpoModulesCore/EXDefines.h>
 #import <EXUpdates/EXUpdatesConfig.h>
@@ -26,11 +27,7 @@
 
 @implementation EXUpdatesAppDelegate
 
-#if !defined(DEBUG)
-
 EX_REGISTER_SINGLETON_MODULE(EXUpdatesAppDelegate)
-
-#endif
 
 - (const NSInteger)priority
 {
@@ -46,13 +43,8 @@ EX_REGISTER_SINGLETON_MODULE(EXUpdatesAppDelegate)
   if (![self shouldEnableAutoSetup]) {
     return NO;
   }
-  EXUpdatesAppController *controller = [EXUpdatesAppController sharedInstance];
-  if (controller.isStarted) {
-    // backward compatible if main AppDelegate already has expo-updates setup,
-    // we just skip in this case.
-    return NO;
-  }
   self.launchOptions = launchOptions;
+  EXUpdatesAppController *controller = [EXUpdatesAppController sharedInstance];
   controller.delegate = self;
   [controller startAndShowLaunchScreen:application.delegate.window];
   return YES;
@@ -69,6 +61,18 @@ EX_REGISTER_SINGLETON_MODULE(EXUpdatesAppDelegate)
 
 - (BOOL)shouldEnableAutoSetup
 {
+  // backward compatible if main AppDelegate already has expo-updates setup,
+  // we just skip in this case.
+  EXUpdatesAppController *controller = [EXUpdatesAppController sharedInstance];
+  if (controller.isStarted) {
+    return NO;
+  }
+
+  // if app is development build
+  if (EXAppDefines.APP_RCT_DEV) {
+    return NO;
+  }
+
   // if Expo.plist not found or its content is invalid, disable the auto setup
   NSString *configPath = [[NSBundle mainBundle] pathForResource:EXUpdatesConfigPlistName ofType:@"plist"];
   if (!configPath) {

--- a/packages/expo-updates/scripts/create-manifest-ios.sh
+++ b/packages/expo-updates/scripts/create-manifest-ios.sh
@@ -18,6 +18,22 @@ ENTRY_FILE=${ENTRY_FILE:-index.js}
 RCT_METRO_PORT=${RCT_METRO_PORT:=8081}
 NODE_BINARY=${NODE_BINARY:-node}
 
+if ! [ -x "$(command -v "$NODE_BINARY")" ]; then
+  echo 'Error: cannot find the node binary. Try setting the NODE_BINARY variable in the ' \
+  '"Bundle React Native code and images" Build Phase to the absolute path to your node binary. ' \
+  'You can find it by executing "which node" in a terminal window.' >&2
+  exit 1
+fi
+
+# For classic main project build phases integration, will be no-op to prevent duplicated app.manifest creation.
+#
+# `$PROJECT_DIR` is passed by Xcode as the directory to the xcodeproj file.
+# in classic main project setup it is something like /path/to/app/ios
+# in new style pod project setup it is something like /path/to/app/ios/Pods
+PROJECT_DIR_BASENAME=$(basename $PROJECT_DIR)
+if [ "x$PROJECT_DIR_BASENAME" != "xPods" ]; then
+  exit 0
+fi
 
 # ref: https://github.com/facebook/react-native/blob/c974cbff04a8d90ac0f856dbada3fc5a75c75b49/scripts/react-native-xcode.sh#L59-L65
 EXPO_UPDATES_PACKAGE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -26,18 +42,5 @@ PROJECT_ROOT=${PROJECT_ROOT:-"$PROJECT_DIR/../.."}
 PROJECT_ROOT=${PROJECT_ROOT:-"$EXPO_UPDATES_PACKAGE_DIR/../.."}
 
 cd "$PROJECT_ROOT" || exit
-
-if ! [ -x "$(command -v "$NODE_BINARY")" ]; then
-  echo 'Error: cannot find the node binary. Try setting the NODE_BINARY variable in the ' \
-  '"Bundle React Native code and images" Build Phase to the absolute path to your node binary. ' \
-  'You can find it by executing "which node" in a terminal window.' >&2
-  exit 1
-fi
-
-# For traditional main project build phases integration, will be no-op to prevent duplicated app.manifest creation.
-DIR_BASENAME=$(basename $PROJECT_ROOT)
-if [ "x$DIR_BASENAME" != "xPods" ]; then
-  exit 0
-fi
 
 "$NODE_BINARY" "${EXPO_UPDATES_PACKAGE_DIR}/scripts/createManifest.js" ios "$PROJECT_ROOT" "$DEST/EXUpdates.bundle"

--- a/packages/expo-updates/scripts/create-manifest-ios.sh
+++ b/packages/expo-updates/scripts/create-manifest-ios.sh
@@ -18,22 +18,6 @@ ENTRY_FILE=${ENTRY_FILE:-index.js}
 RCT_METRO_PORT=${RCT_METRO_PORT:=8081}
 NODE_BINARY=${NODE_BINARY:-node}
 
-if ! [ -x "$(command -v "$NODE_BINARY")" ]; then
-  echo 'Error: cannot find the node binary. Try setting the NODE_BINARY variable in the ' \
-  '"Bundle React Native code and images" Build Phase to the absolute path to your node binary. ' \
-  'You can find it by executing "which node" in a terminal window.' >&2
-  exit 1
-fi
-
-# For classic main project build phases integration, will be no-op to prevent duplicated app.manifest creation.
-#
-# `$PROJECT_DIR` is passed by Xcode as the directory to the xcodeproj file.
-# in classic main project setup it is something like /path/to/app/ios
-# in new style pod project setup it is something like /path/to/app/ios/Pods
-PROJECT_DIR_BASENAME=$(basename $PROJECT_DIR)
-if [ "x$PROJECT_DIR_BASENAME" != "xPods" ]; then
-  exit 0
-fi
 
 # ref: https://github.com/facebook/react-native/blob/c974cbff04a8d90ac0f856dbada3fc5a75c75b49/scripts/react-native-xcode.sh#L59-L65
 EXPO_UPDATES_PACKAGE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -42,5 +26,18 @@ PROJECT_ROOT=${PROJECT_ROOT:-"$PROJECT_DIR/../.."}
 PROJECT_ROOT=${PROJECT_ROOT:-"$EXPO_UPDATES_PACKAGE_DIR/../.."}
 
 cd "$PROJECT_ROOT" || exit
+
+if ! [ -x "$(command -v "$NODE_BINARY")" ]; then
+  echo 'Error: cannot find the node binary. Try setting the NODE_BINARY variable in the ' \
+  '"Bundle React Native code and images" Build Phase to the absolute path to your node binary. ' \
+  'You can find it by executing "which node" in a terminal window.' >&2
+  exit 1
+fi
+
+# For traditional main project build phases integration, will be no-op to prevent duplicated app.manifest creation.
+DIR_BASENAME=$(basename $PROJECT_ROOT)
+if [ "x$DIR_BASENAME" != "xPods" ]; then
+  exit 0
+fi
 
 "$NODE_BINARY" "${EXPO_UPDATES_PACKAGE_DIR}/scripts/createManifest.js" ios "$PROJECT_ROOT" "$DEST/EXUpdates.bundle"


### PR DESCRIPTION
# Why

auto setup is turning on always in prebuilt xcframework because prebuilding runs in release mode and thus `DEBUG` is false

# How

based on #14428 to use `EXAppDefines` to retrieve app building configurations.

# Test Plan

test based on ongoing sdk 43 template #14409

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).