### PR TITLE
[NCL][test-suite] sort test cases by name

### DIFF
--- a/apps/native-component-list/src/screens/ComponentListScreen.tsx
+++ b/apps/native-component-list/src/screens/ComponentListScreen.tsx
@@ -106,7 +106,7 @@ export default function ComponentListScreen(props: Props) {
         }
         return 1;
       }
-      return 0;
+      return a.name.toLowerCase() > b.name.toLowerCase() ? 1 : -1;
     });
   }, [props.apis]);
 

--- a/apps/test-suite/TestModules.js
+++ b/apps/test-suite/TestModules.js
@@ -175,5 +175,5 @@ export function getTestModules() {
     modules.push(optionalRequire(() => require('./tests/Cellular')));
     modules.push(optionalRequire(() => require('./tests/BarCodeScanner')));
   }
-  return modules.filter(Boolean).sort((a, b) => a.name.toLowerCase() > b.name.toLowerCase());
+  return modules.filter(Boolean).sort((a, b) => a.name.toLowerCase() > b.name.toLowerCase() ? 1 : -1);
 }


### PR DESCRIPTION
# Why

1. test-suites are not sorted in hermes runtime:
returning boolean in sort compareFunction is undefined result in hermes whereas jsc can sort still.

```
# hermes repl
>> ['apple', 'banana', 'orange', 'mango', 'lemon', 'cherry', 'papaya'].sort((a, b) => a.toLowerCase() > b.toLowerCase())
[ "apple", "lemon", "papaya", "cherry", "mango", "banana", "orange", [length]: 7 ]

# jsc repl
>>> ['apple', 'banana', 'orange', 'mango', 'lemon', 'cherry', 'papaya'].sort((a, b) => a.toLowerCase() > b.toLowerCase())
apple,banana,cherry,lemon,mango,orange,papaya
```

2. NCL test cases are not sorted in hermes runtime:
returning 0 in sort compareFunction, hermes will be unstable order whereas jsc will keep original order

```
# hermes repl
>> ['apple', 'banana', 'orange', 'mango', 'lemon', 'cherry', 'papaya'].sort((a, b) => 0)
[ "apple", "lemon", "papaya", "cherry", "mango", "banana", "orange", [length]: 7 ]

# jsc repl
>>> ['apple', 'banana', 'orange', 'mango', 'lemon', 'cherry', 'papaya'].sort((a, b) => 0)
apple,banana,orange,mango,lemon,cherry,papaya
```

# How

1. [test-suite] return integer in sort compareFunction
2. [NCL] explicit sort by name and returns integer

before
<img width="200" src="https://user-images.githubusercontent.com/46429/133618111-7f13e497-93cd-482c-b605-e1b3c332fa9a.png" />


after
<img width="200" src="https://user-images.githubusercontent.com/46429/133617545-07a9267e-d514-4361-9046-5d237d5ed362.png" />

# Test Plan

test cases in bare-expo should be in sorted order.
