### PR TITLE
[dev-client] Fix e2e tests

### DIFF
--- a/packages/expo-dev-client/e2e/android/MainActivity.java
+++ b/packages/expo-dev-client/e2e/android/MainActivity.java
@@ -6,7 +6,7 @@ import android.content.Intent;
 import expo.modules.devmenu.react.DevMenuAwareReactActivity;
 import com.facebook.react.ReactActivityDelegate;
 
-import expo.modules.adapters.react.ReactActivityDelegateWrapper;
+import expo.modules.ReactActivityDelegateWrapper;
 import expo.modules.devlauncher.DevLauncherController;
 
 public class MainActivity extends DevMenuAwareReactActivity {

--- a/packages/expo-dev-client/e2e/android/MainApplication.java
+++ b/packages/expo-dev-client/e2e/android/MainApplication.java
@@ -13,8 +13,8 @@ import com.facebook.react.ReactPackage;
 import com.facebook.soloader.SoLoader;
 
 import expo.interfaces.devmenu.DevMenuSettingsInterface;
-import expo.modules.adapters.react.ApplicationLifecycleDispatcher;
-import expo.modules.adapters.react.ReactNativeHostWrapper;
+import expo.modules.ApplicationLifecycleDispatcher;
+import expo.modules.ReactNativeHostWrapper;
 import expo.modules.devlauncher.DevLauncherController;
 import expo.modules.devmenu.DevMenuDefaultSettings;
 import expo.modules.devmenu.DevMenuManager;

--- a/packages/expo-dev-client/e2e/ios/AppDelegate.m
+++ b/packages/expo-dev-client/e2e/ios/AppDelegate.m
@@ -5,14 +5,9 @@
 #import <React/RCTRootView.h>
 #import <React/RCTLinkingManager.h>
 
-#import <UMCore/UMModuleRegistry.h>
-#import <UMReactNativeAdapter/UMNativeModulesProxy.h>
-#import <UMReactNativeAdapter/UMModuleRegistryAdapter.h>
-#import <UMCore/UMModuleRegistryProvider.h>
-
 @import EXDevMenu;
-#include <EXDevLauncher/EXDevLauncherController.h>
 
+#import <EXDevLauncher/EXDevLauncherController.h>
 
 @interface DevMenuDetoxTestInterceptor : NSObject<DevMenuTestInterceptor>
 
@@ -34,7 +29,6 @@
 
 @interface AppDelegate () <RCTBridgeDelegate>
 
-@property (nonatomic, strong) EXModuleRegistryAdapter *moduleRegistryAdapter;
 @property (nonatomic, strong) NSDictionary *launchOptions;
 
 @end
@@ -45,12 +39,11 @@
 {
   [DevMenuTestInterceptorManager setTestInterceptor:[DevMenuDetoxTestInterceptor new]];
 
-  self.moduleRegistryAdapter = [[EXModuleRegistryAdapter alloc] initWithModuleRegistryProvider:[[EXModuleRegistryProvider alloc] init]];
   self.launchOptions = launchOptions;
   self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
 
-   EXDevLauncherController *controller = [EXDevLauncherController sharedInstance];
-   [controller startWithWindow:self.window delegate:(id<EXDevLauncherControllerDelegate>)self launchOptions:launchOptions];
+  EXDevLauncherController *controller = [EXDevLauncherController sharedInstance];
+  [controller startWithWindow:self.window delegate:(id<EXDevLauncherControllerDelegate>)self launchOptions:launchOptions];
 
   [super application:application didFinishLaunchingWithOptions:launchOptions];
 
@@ -72,13 +65,6 @@
 
   return bridge;
  }
-
-- (NSArray<id<RCTBridgeModule>> *)extraModulesForBridge:(RCTBridge *)bridge
-{
-  NSArray<id<RCTBridgeModule>> *extraModules = [_moduleRegistryAdapter extraModulesForBridge:bridge];
-  // If you'd like to export some custom RCTBridgeModules that are not Expo modules, add them here!
-  return extraModules;
-}
 
 - (NSURL *)sourceURLForBridge:(RCTBridge *)bridge {
   return [[EXDevLauncherController sharedInstance] sourceUrl];

--- a/packages/expo-dev-client/package.json
+++ b/packages/expo-dev-client/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "expo-module-scripts": "^2.0.0",
-    "expo-test-runner": "0.0.5"
+    "expo-test-runner": "0.0.6"
   },
   "jest": {
     "preset": "expo-module-scripts/ios"

--- a/packages/expo-dev-client/test-runner.config.js
+++ b/packages/expo-dev-client/test-runner.config.js
@@ -16,12 +16,8 @@ module.exports = {
       },
       dependencies: [
         {
-          name: '@unimodules/core',
-          path: '../@unimodules/core',
-        },
-        {
-          name: '@unimodules/react-native-adapter',
-          path: '../@unimodules/react-native-adapter',
+          name: 'expo',
+          path: '../expo',
         },
         {
           name: 'expo-modules-core',

--- a/packages/expo-updates-interface/android/build.gradle
+++ b/packages/expo-updates-interface/android/build.gradle
@@ -49,6 +49,11 @@ uploadArchives {
 android {
   compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
+  compileOptions {
+    sourceCompatibility JavaVersion.VERSION_1_8
+    targetCompatibility JavaVersion.VERSION_1_8
+  }
+
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 28)

--- a/yarn.lock
+++ b/yarn.lock
@@ -232,7 +232,7 @@
     "@babel/template" "^7.15.4"
     "@babel/types" "^7.15.4"
 
-"@babel/helper-get-function-arity@^7.14.5", "@babel/helper-get-function-arity@^7.15.4":
+"@babel/helper-get-function-arity@^7.15.4":
   version "7.15.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.15.4.tgz#098818934a137fce78b536a3e015864be1e2879b"
   integrity sha512-1/AlxSF92CmGZzHnC515hm4SirTxtpDnLEJ0UyEMgTMZN+6bxXKg04dKhiRx5Enel+SUA1G1t5Ed/yQia0efrA==
@@ -369,7 +369,7 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.15.3.tgz#3416d9bea748052cfcb63dbcc27368105b1ed862"
   integrity sha512-O0L6v/HvqbdJawj0iBEfVQMc3/6WP+AeOsovsIgBFyJaG+W2w7eqvZB7puddATmWuARlm1SX7DwxJ/JJUnDpEA==
 
-"@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.1.6", "@babel/parser@^7.14.5", "@babel/parser@^7.14.8", "@babel/parser@^7.15.0", "@babel/parser@^7.15.4", "@babel/parser@^7.4.3", "@babel/parser@^7.9.0", "@babel/parser@^7.9.6":
+"@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.1.6", "@babel/parser@^7.14.8", "@babel/parser@^7.15.0", "@babel/parser@^7.15.4", "@babel/parser@^7.4.3", "@babel/parser@^7.9.0", "@babel/parser@^7.9.6":
   version "7.15.6"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.15.6.tgz#043b9aa3c303c0722e5377fef9197f4cf1796549"
   integrity sha512-S/TSCcsRuCkmpUuoWijua0Snt+f3ewU/8spLo+4AXJCZfT0bVCzLD5MuOKdrx0mlAptbKzn5AdgEIIKXxXkz9Q==
@@ -8681,10 +8681,10 @@ expo-pwa@0.0.80:
     commander "2.20.0"
     update-check "1.5.3"
 
-expo-test-runner@0.0.5:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/expo-test-runner/-/expo-test-runner-0.0.5.tgz#b5d2deb7a473f2724abe0959ade8d75b71369486"
-  integrity sha512-5NVLxBKsVp463alHvTUt54zBu6tlQC/GoVmWXlEiLdlBe/d95IcSGjEfNvQqbYIKj5GFEpOMPEmyll2MACq7Vw==
+expo-test-runner@0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/expo-test-runner/-/expo-test-runner-0.0.6.tgz#ac5af48e793631b61df5e4d54bdf87a6e273b70d"
+  integrity sha512-r3KxfGh+mAB5CpbqmLNdK140ZmBR4WpjtxWUXGvlT/B7lVKmy2EnO2NtKd8I5eGcytOQIT6aKa8neDGbbVYQHg==
   dependencies:
     "@babel/runtime" "7.9.0"
     "@expo/spawn-async" "^1.5.0"


### PR DESCRIPTION
# Why

Fixes failing e2e tests.

# How

- migrated project to use `expo` instead of `expo-modules-core`
- fixed error in `expo-updates-interface`:
```
* What went wrong:
Execution failed for task ':expo-updates-interface:mergeLibDexDebugAndroidTest'.
> Could not resolve all files for configuration ':expo-updates-interface:debugAndroidTestRuntimeClasspath'.
   > Failed to transform classes.jar (project :expo-modules-core) to match attributes {artifactType=android-dex, com.android.build.api.attributes.BuildTypeAttr=debug, com.android.build.api.attributes.VariantAttr=debug, dexing-enable-desugaring=false, dexing-incremental-transform=false, dexing-is-debuggable=true, dexing-min-sdk=21, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime, org.jetbrains.kotlin.platform.type=androidJvm}.
      > Execution failed for DexingNoClasspathTransform: /private/var/folders/bs/tw1fkxgx3k34ylc56zcshjgm0000gn/T/3e9d166b08c868189fb9e8ae52bc2c71/node_modules/expo-modules-core/android/build/intermediates/runtime_library_classes_jar/debug/classes.jar.
         > Error while dexing.
           The dependency contains Java 8 bytecode. Please enable desugaring by adding the following to build.gradle
           android {
               compileOptions {
                   sourceCompatibility 1.8
                   targetCompatibility 1.8
               }
           }
           See https://developer.android.com/studio/write/java8-support.html for details. Alternatively, increase the minSdkVersion to 24 or above.
```

# Test Plan

- run tests ✅