### PR TITLE
[updates] Fixing app.manifest does not generated from Xcode build phase script

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixing app.manifest does not generated from Xcode build phase script. ([#14438](https://github.com/expo/expo/pull/14438) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 0.9.1 — 2021-09-09

--- a/packages/expo-updates/scripts/create-manifest-ios.sh
+++ b/packages/expo-updates/scripts/create-manifest-ios.sh
@@ -18,6 +18,22 @@ ENTRY_FILE=${ENTRY_FILE:-index.js}
 RCT_METRO_PORT=${RCT_METRO_PORT:=8081}
 NODE_BINARY=${NODE_BINARY:-node}
 
+if ! [ -x "$(command -v "$NODE_BINARY")" ]; then
+  echo 'Error: cannot find the node binary. Try setting the NODE_BINARY variable in the ' \
+  '"Bundle React Native code and images" Build Phase to the absolute path to your node binary. ' \
+  'You can find it by executing "which node" in a terminal window.' >&2
+  exit 1
+fi
+
+# For classic main project build phases integration, will be no-op to prevent duplicated app.manifest creation.
+#
+# `$PROJECT_DIR` is passed by Xcode as the directory to the xcodeproj file.
+# in classic main project setup it is something like /path/to/app/ios
+# in new style pod project setup it is something like /path/to/app/ios/Pods
+PROJECT_DIR_BASENAME=$(basename $PROJECT_DIR)
+if [ "x$PROJECT_DIR_BASENAME" != "xPods" ]; then
+  exit 0
+fi
 
 # ref: https://github.com/facebook/react-native/blob/c974cbff04a8d90ac0f856dbada3fc5a75c75b49/scripts/react-native-xcode.sh#L59-L65
 EXPO_UPDATES_PACKAGE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -26,18 +42,5 @@ PROJECT_ROOT=${PROJECT_ROOT:-"$PROJECT_DIR/../.."}
 PROJECT_ROOT=${PROJECT_ROOT:-"$EXPO_UPDATES_PACKAGE_DIR/../.."}
 
 cd "$PROJECT_ROOT" || exit
-
-if ! [ -x "$(command -v "$NODE_BINARY")" ]; then
-  echo 'Error: cannot find the node binary. Try setting the NODE_BINARY variable in the ' \
-  '"Bundle React Native code and images" Build Phase to the absolute path to your node binary. ' \
-  'You can find it by executing "which node" in a terminal window.' >&2
-  exit 1
-fi
-
-# For traditional main project build phases integration, will be no-op to prevent duplicated app.manifest creation.
-DIR_BASENAME=$(basename $PROJECT_ROOT)
-if [ "x$DIR_BASENAME" != "xPods" ]; then
-  exit 0
-fi
 
 "$NODE_BINARY" "${EXPO_UPDATES_PACKAGE_DIR}/scripts/createManifest.js" ios "$PROJECT_ROOT" "$DEST/EXUpdates.bundle"


### PR DESCRIPTION
# Why

manifest is not generated because `$PROJECT_ROOT` has `../..` suffix and dirname getting `..`

# How

dirname check xcode provided `$PROJECT_DIR` directly and add more comments.

# Test Plan

test based on ongoing sdk 43 template #14409

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).