### PR TITLE
[modules-autolinking] Fix used expo modules output list in gradle

### DIFF
--- a/packages/expo-modules-autolinking/scripts/android/autolinking_implementation.gradle
+++ b/packages/expo-modules-autolinking/scripts/android/autolinking_implementation.gradle
@@ -166,6 +166,7 @@ if (rootProject instanceof ProjectDescriptor) {
       return
     }
 
+    println ''
     println 'Using expo modules'
 
     for (module in modules) {
@@ -181,8 +182,10 @@ if (rootProject instanceof ProjectDescriptor) {
         continue
       }
 
-      println "— ${Colors.GREEN}${module.name}${Colors.RESET} (${module.version})"
+      println "  - ${Colors.GREEN}${module.name}${Colors.RESET} (${module.version})"
     }
+
+    println ''
   }
 
   // Adding dependencies


### PR DESCRIPTION
# Why

Fixes #14440 

# How

- Replaced emdash with normal dash
- Added 2 spaces as indentation
- Added a top and bottom newline

# Test Plan

Check if the list is rendered properly on:
- EAS
- Windows
- Mac

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).