### PR TITLE
[android][ios] Fix anonymous manifest detection and behavior

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/ExponentManifest.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/ExponentManifest.kt
@@ -143,8 +143,7 @@ class ExponentManifest @Inject constructor(
 
   fun isAnonymousExperience(manifest: Manifest): Boolean {
     return try {
-      val id = manifest.getLegacyID()
-      id.startsWith(ANONYMOUS_EXPERIENCE_PREFIX)
+      manifest.getScopeKey().startsWith(ANONYMOUS_SCOPE_KEY_PREFIX)
     } catch (e: JSONException) {
       false
     }
@@ -261,7 +260,7 @@ class ExponentManifest @Inject constructor(
 
     private const val MAX_BITMAP_SIZE = 192
     private const val REDIRECT_SNIPPET = "exp.host/--/to-exp/"
-    private const val ANONYMOUS_EXPERIENCE_PREFIX = "@anonymous/"
+    private const val ANONYMOUS_SCOPE_KEY_PREFIX = "@anonymous/"
     private const val EMBEDDED_KERNEL_MANIFEST_ASSET = "kernel-manifest.json"
     private const val EXPONENT_SERVER_HEADER = "Exponent-Server"
 


### PR DESCRIPTION
# Why

As far as I can tell there is currently a bug in the following case:
1. `expo-cli` is offline or not authenticated
2. `expo start` serves anonymous manifest
3. The client (both iOS and android) executes the block meant for third-party apps instead of using the anonymous verification method. This means that the `id` field becomes something like `UNVERIFIED-exp://172.20.10.2:19000-myApp`, when it's fine for it to be left as `@anonymous/...` (I think).

This PR also fixes anonymous verification for expo-update manifests (new manifests).

Closes ENG-1514.

# How

1. Update code to not run the third-party app manifest processing code for anonymous offline eas-cli-served manifests.
2. Update the anonymous detection method to look at the scope key.

# Test Plan

Run an experience on both iOS and android in eas-cli not-signed-in mode, ensure it works.
