### PR TITLE
Update background-fetch.md for better understanding of the minimumInterval configuration parameter.

### DIFF
--- a/docs/pages/versions/unversioned/sdk/background-fetch.md
+++ b/docs/pages/versions/unversioned/sdk/background-fetch.md
@@ -49,7 +49,7 @@ TaskManager.defineTask(BACKGROUND_FETCH_TASK, async () => {
 // Note: This does NOT need to be in the global scope and CAN be used in your React components!
 async function registerBackgroundFetchAsync() {
   return BackgroundFetch.registerTaskAsync(BACKGROUND_FETCH_TASK, {
-    minimumInterval: 60 * 15, // 15 minutes
+    minimumInterval: 60 * 15, // 60 seconds * 15 = 15 minutes
     stopOnTerminate: false, // android only,
     startOnBoot: true, // android only
   });
@@ -150,7 +150,7 @@ For Android, you can set the `minimumInterval` option of your task to a small nu
 ```tsx
 async function registerBackgroundFetchAsync() {
   return BackgroundFetch.registerTaskAsync(BACKGROUND_FETCH_TASK, {
-    minimumInterval: 1, // task will fire 1 minute after app is backgrounded
+    minimumInterval: 1, // even though the values here refers to seconds, this task will fire 1 minute after app is backgrounded
   });
 }
 ```


### PR DESCRIPTION
# Why

Me personally along with others dev members got confused with the minimumInterval attribute, it is first presented as seconds and then it tells you that in order to test the execution in android you can provide the number 1, one can understand that the background task would execute every one seconds but it doesn't behave like that for sftware reasons I suppose (battery optimization I guess).