### PR TITLE
[ci] run iOS Client workflow on lock changes

### DIFF
--- a/.github/workflows/client-ios.yml
+++ b/.github/workflows/client-ios.yml
@@ -17,6 +17,7 @@ on:
       - fastlane/**
       - Gemfile.lock
       - .ruby-version
+      - yarn.lock
   push:
     branches: [master, sdk-*]
     paths:
@@ -27,6 +28,7 @@ on:
       - fastlane/**
       - Gemfile.lock
       - .ruby-version
+      - yarn.lock
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}


### PR DESCRIPTION
# Why

Currently the Android Client workflow runs on the Yarn lock changes (https://github.com/expo/expo/blob/master/.github/workflows/client-android.yml#L22) and since iOS workflow also includes installing dependencies step I think we should run this workflow on lock changes too.

# How

Add `yarn.lock` to the paths is `client-ios.yml` workflow file.

# Test Plan

Check if the workflow runs on the next Yarn lock change, after the merge? 🤷‍♂️ 
