### PR TITLE
Upgrade stripe-react-native to 0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Package-specific changes not released in any SDK will be added here just before 
 - Updated `@react-native-community/netinfo` from `6.0.0` to `6.0.2`. ([#14329](https://github.com/expo/expo/pull/14329) by [@cruzach](https://github.com/cruzach))
 - Updated `react-native-webview` from `11.6.2` to `11.13.0`. ([#14301](https://github.com/expo/expo/pull/14301) by [@kudo](https://github.com/kudo))
 - Updated `react-native-lottie` from `4.0.2` to `4.0.3`. ([#14331](https://github.com/expo/expo/pull/14331) by [@cruzach](https://github.com/cruzach))
-- Updated `@stripe/stripe-react-native` from `0.1.4` to `0.2.1`. ([#14357](https://github.com/expo/expo/pull/14357) by [@cruzach](https://github.com/cruzach))
+- Updated `@stripe/stripe-react-native` from `0.1.4` to `0.2.2`. ([#14357](https://github.com/expo/expo/pull/14357) & [#14452](https://github.com/expo/expo/pull/14452) by [@cruzach](https://github.com/cruzach))
 - Updated `react-native-screens` from `3.4.0` to `3.7.2`. ([#14330](https://github.com/expo/expo/pull/14330) by [@cruzach](https://github.com/cruzach))
 - Updated `react-native-safe-area-context` from `3.2.0` to `3.3.2`. ([#14303](https://github.com/expo/expo/pull/14303) by [@kudo](https://github.com/kudo))
 - Updated `@react-native-community/viewpager` from `5.0.11` to `react-native-pager-view@5.4.4`. ([#14348](https://github.com/expo/expo/pull/14348) by [@cruzach](https://github.com/cruzach))

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/reactnativestripesdk/GooglePayFragment.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/reactnativestripesdk/GooglePayFragment.kt
@@ -7,6 +7,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
 import androidx.fragment.app.Fragment
+import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import com.stripe.android.googlepaylauncher.GooglePayEnvironment
 import com.stripe.android.googlepaylauncher.GooglePayLauncher
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
@@ -16,6 +17,7 @@ class GooglePayFragment : Fragment() {
   private var googlePayMethodLauncher: GooglePayPaymentMethodLauncher? = null
   private var isGooglePayMethodLauncherReady: Boolean = false
   private var isGooglePayLauncherReady: Boolean = false
+  private lateinit var localBroadcastManager: LocalBroadcastManager
 
   private fun onGooglePayMethodLauncherReady(isReady: Boolean) {
     isGooglePayMethodLauncherReady = true
@@ -36,6 +38,7 @@ class GooglePayFragment : Fragment() {
     container: ViewGroup?,
     savedInstanceState: Bundle?
   ): View {
+    localBroadcastManager = LocalBroadcastManager.getInstance(requireContext())
     return FrameLayout(requireActivity()).also {
       it.visibility = View.GONE
     }
@@ -86,14 +89,14 @@ class GooglePayFragment : Fragment() {
     )
 
     val intent = Intent(ON_GOOGLE_PAY_FRAGMENT_CREATED)
-    activity?.sendBroadcast(intent)
+    localBroadcastManager.sendBroadcast(intent)
   }
 
   fun presentForPaymentIntent(clientSecret: String) {
     val launcher = googlePayLauncher ?: run {
       val intent = Intent(ON_GOOGLE_PAY_RESULT)
       intent.putExtra("error", "GooglePayLauncher is not initialized.")
-      activity?.sendBroadcast(intent)
+      localBroadcastManager.sendBroadcast(intent)
       return
     }
     runCatching {
@@ -101,7 +104,7 @@ class GooglePayFragment : Fragment() {
     }.onFailure {
       val intent = Intent(ON_GOOGLE_PAY_RESULT)
       intent.putExtra("error", it.localizedMessage)
-      activity?.sendBroadcast(intent)
+      localBroadcastManager.sendBroadcast(intent)
     }
   }
 
@@ -109,7 +112,7 @@ class GooglePayFragment : Fragment() {
     val launcher = googlePayLauncher ?: run {
       val intent = Intent(ON_GOOGLE_PAY_RESULT)
       intent.putExtra("error", "GooglePayLauncher is not initialized.")
-      activity?.sendBroadcast(intent)
+      localBroadcastManager.sendBroadcast(intent)
       return
     }
     runCatching {
@@ -117,7 +120,7 @@ class GooglePayFragment : Fragment() {
     }.onFailure {
       val intent = Intent(ON_GOOGLE_PAY_RESULT)
       intent.putExtra("error", it.localizedMessage)
-      activity?.sendBroadcast(intent)
+      localBroadcastManager.sendBroadcast(intent)
     }
   }
 
@@ -125,7 +128,7 @@ class GooglePayFragment : Fragment() {
     val launcher = googlePayMethodLauncher ?: run {
       val intent = Intent(ON_GOOGLE_PAYMENT_METHOD_RESULT)
       intent.putExtra("error", "GooglePayPaymentMethodLauncher is not initialized.")
-      activity?.sendBroadcast(intent)
+      localBroadcastManager.sendBroadcast(intent)
       return
     }
 
@@ -137,26 +140,26 @@ class GooglePayFragment : Fragment() {
     }.onFailure {
       val intent = Intent(ON_GOOGLE_PAYMENT_METHOD_RESULT)
       intent.putExtra("error", it.localizedMessage)
-      activity?.sendBroadcast(intent)
+      localBroadcastManager.sendBroadcast(intent)
     }
   }
 
   private fun onGooglePayReady(isReady: Boolean) {
     val intent = Intent(ON_INIT_GOOGLE_PAY)
     intent.putExtra("isReady", isReady)
-    activity?.sendBroadcast(intent)
+    localBroadcastManager.sendBroadcast(intent)
   }
 
   private fun onGooglePayResult(result: GooglePayLauncher.Result) {
     val intent = Intent(ON_GOOGLE_PAY_RESULT)
     intent.putExtra("paymentResult", result)
-    activity?.sendBroadcast(intent)
+    localBroadcastManager.sendBroadcast(intent)
   }
 
   private fun onGooglePayResult(result: GooglePayPaymentMethodLauncher.Result) {
     val intent = Intent(ON_GOOGLE_PAYMENT_METHOD_RESULT)
     intent.putExtra("paymentResult", result)
-    activity?.sendBroadcast(intent)
+    localBroadcastManager.sendBroadcast(intent)
   }
 
   private fun mapToGooglePayLauncherBillingAddressConfig(formatString: String, isRequired: Boolean, isPhoneNumberRequired: Boolean): GooglePayLauncher.BillingAddressConfig {

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/reactnativestripesdk/PaymentSheetFragment.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/reactnativestripesdk/PaymentSheetFragment.kt
@@ -15,6 +15,7 @@ import android.widget.FrameLayout
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.graphics.drawable.DrawableCompat
 import androidx.fragment.app.Fragment
+import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import com.stripe.android.paymentsheet.*
 import com.stripe.android.paymentsheet.model.PaymentOption
 import java.io.ByteArrayOutputStream
@@ -25,12 +26,14 @@ class PaymentSheetFragment : Fragment() {
   private var paymentIntentClientSecret: String? = null
   private var setupIntentClientSecret: String? = null
   private lateinit var paymentSheetConfiguration: PaymentSheet.Configuration
+  private lateinit var localBroadcastManager: LocalBroadcastManager
 
   override fun onCreateView(
     inflater: LayoutInflater,
     container: ViewGroup?,
     savedInstanceState: Bundle?
   ): View {
+    localBroadcastManager = LocalBroadcastManager.getInstance(requireContext())
     return FrameLayout(requireActivity()).also {
       it.visibility = View.GONE
     }
@@ -58,7 +61,7 @@ class PaymentSheetFragment : Fragment() {
           intent.putExtra("label", paymentOption.label)
           intent.putExtra("image", imageString)
         }
-        activity?.sendBroadcast(intent)
+        localBroadcastManager.sendBroadcast(intent)
       }
     }
 
@@ -67,7 +70,7 @@ class PaymentSheetFragment : Fragment() {
         val intent = Intent(ON_PAYMENT_RESULT_ACTION)
 
         intent.putExtra("paymentResult", paymentResult)
-        activity?.sendBroadcast(intent)
+        localBroadcastManager.sendBroadcast(intent)
       }
     }
 
@@ -89,11 +92,11 @@ class PaymentSheetFragment : Fragment() {
     } else {
       paymentSheet = PaymentSheet(this, paymentResultCallback)
       val intent = Intent(ON_INIT_PAYMENT_SHEET)
-      activity?.sendBroadcast(intent)
+      localBroadcastManager.sendBroadcast(intent)
     }
 
     val intent = Intent(ON_FRAGMENT_CREATED)
-    activity?.sendBroadcast(intent)
+    localBroadcastManager.sendBroadcast(intent)
   }
 
   fun present() {
@@ -125,7 +128,7 @@ class PaymentSheetFragment : Fragment() {
           intent.putExtra("label", paymentOption.label)
           intent.putExtra("image", imageString)
         }
-        activity?.sendBroadcast(intent)
+        localBroadcastManager.sendBroadcast(intent)
       }
     }
 

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/reactnativestripesdk/StripeSdkModule.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/reactnativestripesdk/StripeSdkModule.kt
@@ -11,6 +11,7 @@ import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
+import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import com.facebook.react.bridge.*
 import com.facebook.react.module.annotations.ReactModule
 import com.stripe.android.*
@@ -26,6 +27,7 @@ import kotlinx.coroutines.runBlocking
 class StripeSdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaModule(reactContext) {
   var cardFieldView: StripeSdkCardView? = null
   var cardFormView: CardFormView? = null
+  private lateinit var localBroadcastManager: LocalBroadcastManager
 
   override fun getName(): String {
     return "StripeSdk"
@@ -301,16 +303,17 @@ class StripeSdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJ
 
     PaymentConfiguration.init(reactApplicationContext, publishableKey, stripeAccountId)
 
-    this.currentActivity?.registerReceiver(mPaymentSheetReceiver, IntentFilter(ON_PAYMENT_RESULT_ACTION))
-    this.currentActivity?.registerReceiver(mPaymentSheetReceiver, IntentFilter(ON_PAYMENT_OPTION_ACTION))
-    this.currentActivity?.registerReceiver(mPaymentSheetReceiver, IntentFilter(ON_CONFIGURE_FLOW_CONTROLLER))
-    this.currentActivity?.registerReceiver(mPaymentSheetReceiver, IntentFilter(ON_FRAGMENT_CREATED))
-    this.currentActivity?.registerReceiver(mPaymentSheetReceiver, IntentFilter(ON_INIT_PAYMENT_SHEET))
+    val localBroadcastManager = LocalBroadcastManager.getInstance(reactApplicationContext)
+    localBroadcastManager.registerReceiver(mPaymentSheetReceiver, IntentFilter(ON_PAYMENT_RESULT_ACTION))
+    localBroadcastManager.registerReceiver(mPaymentSheetReceiver, IntentFilter(ON_PAYMENT_OPTION_ACTION))
+    localBroadcastManager.registerReceiver(mPaymentSheetReceiver, IntentFilter(ON_CONFIGURE_FLOW_CONTROLLER))
+    localBroadcastManager.registerReceiver(mPaymentSheetReceiver, IntentFilter(ON_FRAGMENT_CREATED))
+    localBroadcastManager.registerReceiver(mPaymentSheetReceiver, IntentFilter(ON_INIT_PAYMENT_SHEET))
 
-    this.currentActivity?.registerReceiver(googlePayReceiver, IntentFilter(ON_GOOGLE_PAY_FRAGMENT_CREATED))
-    this.currentActivity?.registerReceiver(googlePayReceiver, IntentFilter(ON_INIT_GOOGLE_PAY))
-    this.currentActivity?.registerReceiver(googlePayReceiver, IntentFilter(ON_GOOGLE_PAY_RESULT))
-    this.currentActivity?.registerReceiver(googlePayReceiver, IntentFilter(ON_GOOGLE_PAYMENT_METHOD_RESULT))
+    localBroadcastManager.registerReceiver(googlePayReceiver, IntentFilter(ON_GOOGLE_PAY_FRAGMENT_CREATED))
+    localBroadcastManager.registerReceiver(googlePayReceiver, IntentFilter(ON_INIT_GOOGLE_PAY))
+    localBroadcastManager.registerReceiver(googlePayReceiver, IntentFilter(ON_GOOGLE_PAY_RESULT))
+    localBroadcastManager.registerReceiver(googlePayReceiver, IntentFilter(ON_GOOGLE_PAYMENT_METHOD_RESULT))
 
     promise.resolve(null)
   }

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2431,7 +2431,7 @@ PODS:
   - Stripe (21.8.1):
     - Stripe/Stripe3DS2 (= 21.8.1)
     - StripeCore (= 21.8.1)
-  - stripe-react-native (0.2.1):
+  - stripe-react-native (0.2.2):
     - React
     - Stripe (~> 21.8.1)
   - Stripe/Stripe3DS2 (21.8.1):
@@ -4240,7 +4240,7 @@ SPEC CHECKSUMS:
   RNReanimated: 9c13c86454bfd54dab7505c1a054470bfecd2563
   RNScreens: 2a71d74b4e530f051f5684c8111d7591176722cf
   Stripe: 57c6997c64042a3f5aedae9b76e331942f8b75d2
-  stripe-react-native: b98c63486a0b24aa5ae278cf7ea87aa524651fea
+  stripe-react-native: ae53a97cc9ab084cc6228f2250da56b0e53da276
   StripeCore: a6e50d58119a0c7601773b56f274db2d394dcdac
   UMAppLoader: a2f89c43ef303ef25947497f2166463506758924
   UMCore: 7187af6e861d1e9983f3b83db7040320851b435a

--- a/ios/vendored/unversioned/@stripe/stripe-react-native/stripe-react-native.podspec.json
+++ b/ios/vendored/unversioned/@stripe/stripe-react-native/stripe-react-native.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "stripe-react-native",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "summary": "Stripe SDK for React Native",
   "homepage": "https://github.com/stripe/stripe-react-native/#readme",
   "license": "MIT",
@@ -10,7 +10,7 @@
   },
   "source": {
     "git": "https://github.com/stripe/stripe-react-native.git",
-    "tag": "0.2.1"
+    "tag": "0.2.2"
   },
   "source_files": "ios/**/*.{h,m,mm,swift}",
   "pod_target_xcconfig": {

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -8,7 +8,7 @@
   "@react-native-community/viewpager": "5.0.11",
   "@react-native-picker/picker": "2.1.0",
   "@react-native-segmented-control/segmented-control": "2.4.0",
-  "@stripe/stripe-react-native": "0.2.1",
+  "@stripe/stripe-react-native": "0.2.2",
   "@unimodules/core": "~7.2.0-alpha.0",
   "@unimodules/react-native-adapter": "~6.5.0-alpha.0",
   "expo-ads-admob": "~10.1.0",


### PR DESCRIPTION
# Why

was at 0.2.1, Stripe asked us to upgrade to 0.2.2 for some android broadcast security improvements

# How

`et uvm`

# Test Plan

CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).