### PR TITLE
[expo-manifests] dev client compatibility

### DIFF
--- a/packages/expo-manifests/CHANGELOG.md
+++ b/packages/expo-manifests/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Added `version` getter to both platforms, and `hostUri` getter to Android, for compatibility with expo-dev-client. ([#14460](https://github.com/expo/expo/pull/14460) by [@esamelson](https://github.com/esamelson))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-manifests/android/src/main/java/expo/modules/manifests/core/Manifest.kt
+++ b/packages/expo-manifests/android/src/main/java/expo/modules/manifests/core/Manifest.kt
@@ -99,6 +99,7 @@ abstract class Manifest(protected val json: JSONObject) {
 
   fun getDebuggerHost(): String = getExpoGoConfigRootObject()!!.require("debuggerHost")
   fun getMainModuleName(): String = getExpoGoConfigRootObject()!!.require("mainModuleName")
+  fun getHostUri(): String? = getExpoGoConfigRootObject()?.getNullable("hostUri")
 
   fun isVerified(): Boolean = json.require("isVerified")
 
@@ -107,6 +108,11 @@ abstract class Manifest(protected val json: JSONObject) {
   fun getName(): String? {
     val expoClientConfig = getExpoClientConfigRootObject() ?: return null
     return expoClientConfig.getNullable("name")
+  }
+
+  fun getVersion(): String? {
+    val expoClientConfig = getExpoClientConfigRootObject() ?: return null
+    return expoClientConfig.getNullable("version")
   }
 
   fun getUpdatesInfo(): JSONObject? {

--- a/packages/expo-manifests/ios/EXManifests.podspec
+++ b/packages/expo-manifests/ios/EXManifests.podspec
@@ -20,6 +20,9 @@ Pod::Spec.new do |s|
     'GCC_TREAT_IMPLICIT_FUNCTION_DECLARATIONS_AS_ERRORS' => 'YES'
   }
 
+  # Swift/Objective-C compatibility
+  s.pod_target_xcconfig = { "DEFINES_MODULE" => "YES" }
+
   if !$ExpoUseSources&.include?(package['name']) && ENV['EXPO_USE_SOURCE'].to_i == 0 && File.exist?("#{s.name}.xcframework") && Gem::Version.new(Pod::VERSION) >= Gem::Version.new('1.10.0')
     s.source_files = "#{s.name}/**/*.h"
     s.vendored_frameworks = "#{s.name}.xcframework"

--- a/packages/expo-manifests/ios/EXManifests/EXManifestsBaseManifest.h
+++ b/packages/expo-manifests/ios/EXManifests/EXManifestsBaseManifest.h
@@ -18,6 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSString *)slug;
 - (nullable NSString *)appKey;
 - (nullable NSString *)name;
+- (nullable NSString *)version;
 - (nullable NSDictionary *)notificationPreferences;
 - (nullable NSDictionary *)updatesInfo;
 - (nullable NSDictionary *)iosConfig;

--- a/packages/expo-manifests/ios/EXManifests/EXManifestsBaseManifest.m
+++ b/packages/expo-manifests/ios/EXManifests/EXManifestsBaseManifest.m
@@ -55,6 +55,14 @@
   return [expoClientConfig nullableStringForKey:@"name"];
 }
 
+- (nullable NSString *)version {
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [expoClientConfig nullableStringForKey:@"version"];
+}
+
 - (nullable NSDictionary *)notificationPreferences {
   NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
   if (!expoClientConfig) {

--- a/packages/expo-manifests/ios/EXManifests/EXManifestsManifest.h
+++ b/packages/expo-manifests/ios/EXManifests/EXManifestsManifest.h
@@ -48,6 +48,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSString *)slug;
 - (nullable NSString *)appKey;
 - (nullable NSString *)name;
+- (nullable NSString *)version;
 - (nullable NSDictionary *)notificationPreferences;
 - (nullable NSDictionary *)updatesInfo;
 - (nullable NSDictionary *)iosConfig;


### PR DESCRIPTION
# Why

PR 1/4 in ENG-1883

# How

- Add DEFINES_MODULE setting to EXManifests podspec so we can depend on it from expo-dev-launcher (which includes Swift code).
- Additionally, add a few getters (`version` on both platforms and `hostUri` on Android) that the dev launcher needs, which weren't previously there.

# Test Plan

Module builds fine; more comprehensive tests were added/done later in the PR stack

# Todo

Once approved and landed, backport these changes if necessary

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).