### PR TITLE
[expo-dev-client] add expo-manifests dependency

### DIFF
--- a/docs/public/static/diffs/client/podfile-no-unimodules.diff
+++ b/docs/public/static/diffs/client/podfile-no-unimodules.diff
@@ -2,18 +2,20 @@ diff --git a/ios/Podfile b/ios/Podfile
 index 0de9cd2..64fd635 100644
 --- a/ios/Podfile
 +++ b/ios/Podfile
-@@ -1,13 +1,17 @@
+@@ -1,13 +1,19 @@
  require_relative '../node_modules/react-native/scripts/react_native_pods'
  require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
  
 -platform :ios, '10.0'
-+platform :ios, '11.0'
++platform :ios, '12.0'
  
  target 'AwesomeProject' do
    config = use_native_modules!
  
    use_react_native!(:path => config["reactNativePath"])
  
++  pod 'EXJSONUtils', path: '../node_modules/expo-json-utils/ios', :configurations => :debug
++  pod 'EXManifests', path: '../node_modules/expo-manifests/ios', :configurations => :debug
 +  pod 'EXUpdatesInterface', path: '../node_modules/expo-updates-interface/ios'
 +  pod 'expo-dev-launcher', path: '../node_modules/expo-dev-launcher', :configurations => :debug
 +  pod 'expo-dev-menu', path: '../node_modules/expo-dev-menu', :configurations => :debug

--- a/docs/public/static/diffs/client/settings-gradle-no-unimodules.diff
+++ b/docs/public/static/diffs/client/settings-gradle-no-unimodules.diff
@@ -2,10 +2,16 @@ diff --git a/android/settings.gradle b/android/settings.gradle
 index 342f14f..9d9fc07 100644
 --- a/android/settings.gradle
 +++ b/android/settings.gradle
-@@ -1,4 +1,7 @@
+@@ -1,4 +1,10 @@
  rootProject.name = 'AwesomeProject'
  apply from: file("../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesSettingsGradle(settings)
  
++include ':expo-json-utils'
++project(':expo-json-utils').projectDir = new File('../node_modules/expo-json-utils/android')
++
++include ':expo-manifests'
++project(':expo-manifests').projectDir = new File('../node_modules/expo-manifests/android')
++
 +include ':expo-updates-interface'
 +project(':expo-updates-interface').projectDir = new File('../node_modules/expo-updates-interface/android')
 +

--- a/packages/expo-dev-client/CHANGELOG.md
+++ b/packages/expo-dev-client/CHANGELOG.md
@@ -4,6 +4,23 @@
 
 ### 🛠 Breaking changes
 
+- Added a native dependency on the `expo-manifests` package. ([#14461](https://github.com/expo/expo/pull/14461) by [@esamelson](https://github.com/esamelson))
+  - This is a breaking change for projects **without `react-native-unimodules` or `expo-modules-core` installed**. In order to upgrade from `expo-dev-client@0.5.1` or below to this version in such projects, the following changes must be made:
+    - In `ios/Podfile`, change the deployment target to `platform :ios, '12.0'` and add the following lines inside the main target:
+    ```ruby
+    pod 'EXJSONUtils', path: '../node_modules/expo-json-utils/ios', :configurations => :debug
+    pod 'EXManifests', path: '../node_modules/expo-manifests/ios', :configurations => :debug
+    ```
+    - In `android/settings.gradle`, add the following lines:
+    ```groovy
+    include ':expo-json-utils'
+    project(':expo-json-utils').projectDir = new File('../node_modules/expo-json-utils/android')
+
+    include ':expo-manifests'
+    project(':expo-manifests').projectDir = new File('../node_modules/expo-manifests/android')
+    ```
+  - No additional setup is necessary for projects already using `react-native-unimodules` or `expo-modules-core`.
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/packages/expo-dev-client/android/build.gradle
+++ b/packages/expo-dev-client/android/build.gradle
@@ -81,6 +81,7 @@ dependencies {
   androidTestImplementation project(":expo-updates-interface")
   androidTestImplementation project(":expo-dev-menu")
   androidTestImplementation project(":expo-dev-launcher")
+  androidTestImplementation project(":expo-manifests")
 
   //noinspection GradleDynamicVersion
   androidTestImplementation 'com.facebook.react:react-native:+'  // From node_modules

--- a/packages/expo-dev-client/dependencies.js
+++ b/packages/expo-dev-client/dependencies.js
@@ -10,6 +10,9 @@ module.exports = {
   'expo-dev-menu-interface': {
     root: resolve('expo-dev-menu-interface'),
   },
+  'expo-manifests': {
+    root: resolve('expo-manifests'),
+  },
   'expo-updates-interface': {
     root: resolve('expo-updates-interface'),
   },

--- a/packages/expo-dev-client/expo-dev-client.podspec
+++ b/packages/expo-dev-client/expo-dev-client.podspec
@@ -17,5 +17,6 @@ Pod::Spec.new do |s|
   s.dependency 'expo-dev-launcher', :configurations => :debug
   s.dependency 'expo-dev-menu', :configurations => :debug
   s.dependency 'expo-dev-menu-interface'
+  s.dependency 'EXManifests', :configurations => :debug
   s.dependency 'EXUpdatesInterface'
 end

--- a/packages/expo-dev-client/package.json
+++ b/packages/expo-dev-client/package.json
@@ -35,6 +35,7 @@
     "expo-dev-launcher": "0.7.0",
     "expo-dev-menu": "0.8.1",
     "expo-dev-menu-interface": "0.4.0",
+    "expo-manifests": "~0.1.0",
     "expo-updates-interface": "~0.3.1"
   },
   "devDependencies": {

--- a/packages/expo-dev-client/test-runner.config.js
+++ b/packages/expo-dev-client/test-runner.config.js
@@ -44,6 +44,10 @@ module.exports = {
           path: '../expo-dev-menu-interface',
         },
         {
+          name: 'expo-manifests',
+          path: '../expo-manifests',
+        },
+        {
           name: 'expo-updates-interface',
           path: '../expo-updates-interface',
         },

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -4,6 +4,23 @@
 
 ### 🛠 Breaking changes
 
+- Added a native dependency on the `expo-manifests` package. ([#14461](https://github.com/expo/expo/pull/14461) by [@esamelson](https://github.com/esamelson))
+  - This is a breaking change for projects **without `react-native-unimodules` or `expo-modules-core` installed**. In order to upgrade from `expo-dev-client@0.5.1` or below to this version in such projects, the following changes must be made:
+    - In `ios/Podfile`, change the deployment target to `platform :ios, '12.0'` and add the following lines inside the main target:
+    ```ruby
+    pod 'EXJSONUtils', path: '../node_modules/expo-json-utils/ios', :configurations => :debug
+    pod 'EXManifests', path: '../node_modules/expo-manifests/ios', :configurations => :debug
+    ```
+    - In `android/settings.gradle`, add the following lines:
+    ```groovy
+    include ':expo-json-utils'
+    project(':expo-json-utils').projectDir = new File('../node_modules/expo-json-utils/android')
+
+    include ':expo-manifests'
+    project(':expo-manifests').projectDir = new File('../node_modules/expo-manifests/android')
+    ```
+  - No additional setup is necessary for projects already using `react-native-unimodules` or `expo-modules-core`.
+
 ### 🎉 New features
 
 - Suppress the `"main" has not been registered` exception if it was caused by a different error. ([#14363](https://github.com/expo/expo/pull/14363) by [@lukmccall](https://github.com/lukmccall))

--- a/packages/expo-dev-launcher/android/build.gradle
+++ b/packages/expo-dev-launcher/android/build.gradle
@@ -91,6 +91,7 @@ repositories {
 
 dependencies {
   implementation project(":expo-dev-menu-interface")
+  implementation project(":expo-manifests")
   implementation project(":expo-updates-interface")
 
   //noinspection GradleDynamicVersion

--- a/packages/expo-dev-launcher/expo-dev-launcher.podspec
+++ b/packages/expo-dev-launcher/expo-dev-launcher.podspec
@@ -37,6 +37,7 @@ Pod::Spec.new do |s|
   
   s.dependency "React-Core"
   s.dependency "expo-dev-menu-interface"
+  s.dependency "EXManifests"
   s.dependency "EXUpdatesInterface"
   
   s.subspec 'Unsafe' do |unsafe|


### PR DESCRIPTION
# Why

PR 2/4 in ENG-1883

`expo-manifests` contains the canonical native manifest wrappers, and switching over to using them will give us EAS Update manifest support for free. This PR adds the package as a native dependency.

# How

- Grepped the package and docs for references to `expo-updates-interface` and `EXUpdatesInterface` and added expo-manifests/EXManifests alongside them (they have the same process since they are both expo modules).
- Additionally, added expo-json-utils/EXJSONUtils to the installation instructions for projects without unimodules/expo-modules, since this package is a dependency of expo-manifests but cannot be autolinked without expo-modules.

# Test Plan

Tested manually to confirm that the following apps build (following the additional new setup steps for the project without unimodules):
- iOS dev client project with unimodules
- Android dev client project with unimodules
- iOS dev client project without unimodules
- Android dev client project without unimodules

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).