### PR TITLE
[expo-updates-interface] remove unnecessary dependency on expo-modules-core

### DIFF
--- a/packages/expo-updates-interface/CHANGELOG.md
+++ b/packages/expo-updates-interface/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Removed unnecessary gradle dependency on expo-modules-core. ([#14464](https://github.com/expo/expo/pull/14464) by [@esamelson](https://github.com/esamelson))
+
 ### 💡 Others
 
 ## 0.3.1 — 2021-09-16

--- a/packages/expo-updates-interface/android/build.gradle
+++ b/packages/expo-updates-interface/android/build.gradle
@@ -70,7 +70,5 @@ repositories {
 }
 
 dependencies {
-  implementation project(':expo-modules-core')
-
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${safeExtGet("kotlinVersion", "1.3.50")}"
 }


### PR DESCRIPTION
# Why

While testing ENG-1883 I noticed that the Android dependency on expo-modules-core added in #14362 to expo-updates-interface is unnecessary, and (unsurprisingly) breaks dev client builds in projects without expo-modules.

# How

Remove this dependency in build.gradle. AFAICT no files in this package use anything from expo-modules-core.

# Test Plan

Dev client build succeeds without expo-modules ✅ 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).