### PR TITLE
Use `et cu` command instead of old expo-cli

### DIFF
--- a/guides/Expo Universal Module Infrastructure.md
+++ b/guides/Expo Universal Module Infrastructure.md
@@ -13,11 +13,11 @@ This guide explains the standard configuration and tools for working on universa
 
 # Generating a new universal module using `expo-cli` command
 
-`expo-cli` has specific command that would generate universal module that support TypeScript!
+`expo/tools` has specific command that would generate universal module that support TypeScript!
 Run:
 
-- `expo generate-module [new module directory]`
-  - optional `[new module directory]` parameter lets you specify module name (e.g. `expo generate-module expo-test-module` would create `expo-test-module`. If ommited, the script will prompt you about it.
+- `yarn et cu --name [new module name]` inside the `tools` directory
+  - `[new module name]` parameter lets you specify module name (e.g. `et cu expo-test-module` would create `expo-test-module`. If ommited, the script will prompt you about it.
   - optional `--template <template directory>` will try to use provided `<template directory>` in universal module creation.
 
 # The Standard Configuration


### PR DESCRIPTION
# Why

expo-cli create-module command is deprecated, use new et cu in docs.

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).