### PR TITLE
[splash-screen] Fix warning when reload apps

### DIFF
--- a/packages/expo-splash-screen/CHANGELOG.md
+++ b/packages/expo-splash-screen/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix 'No native splash screen registered' wanring from reloading apps. ([#14467](https://github.com/expo/expo/pull/14467) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 - Updated `@expo/configure-splash-screen`, `@expo/prebuild-config` ([#14443](https://github.com/expo/expo/pull/14443) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/expo-splash-screen/CHANGELOG.md
+++ b/packages/expo-splash-screen/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix 'No native splash screen registered' wanring from reloading apps. ([#14467](https://github.com/expo/expo/pull/14467) by [@kudo](https://github.com/kudo))
+- Fix 'No native splash screen registered' warning from reloading apps. ([#14467](https://github.com/expo/expo/pull/14467) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenService.m
+++ b/packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenService.m
@@ -92,19 +92,8 @@ EX_REGISTER_SINGLETON_MODULE(SplashScreen);
   }
   [self removeRootViewControllerListener];
 
-  EXSplashScreenViewController *splashScreenViewController = [self.splashScreenControllers objectForKey:viewController];
-  EX_WEAKIFY(self);
-  return [splashScreenViewController
-      hideWithCallback:^(BOOL hasEffect) {
-        EX_ENSURE_STRONGIFY(self);
-        [self.splashScreenControllers removeObjectForKey:viewController];
-        successCallback(hasEffect);
-      }
-      failureCallback:^(NSString *message) {
-        EX_ENSURE_STRONGIFY(self);
-        [self.splashScreenControllers removeObjectForKey:viewController];
-        failureCallback(message);
-      }];
+  return [[self.splashScreenControllers objectForKey:viewController] hideWithCallback:successCallback
+                                                                      failureCallback:failureCallback];
 }
 
 - (void)onAppContentDidAppear:(UIViewController *)viewController


### PR DESCRIPTION
# Why

regression of #14063, which i originally thought to remove splash screen controller reference after splash screen shown. however from reloading case, we still need the reference to show splash screen again.

# How

revert change from #14063:
https://github.com/expo/expo/pull/14063/files#diff-49ab5289b088a3bcfef227d5fd1d8406d055ebd8f64325c009c55924600f21acL89-L90

# Test Plan

1. splash screen can show in bare-expo
2. reload app in bare-expo, should not show the `No native splash screen registered for given view controller. Call 'SplashScreen.show' for given view controller first.` yellow box warning.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).