### PR TITLE
[expoview] Bump `com.theartofdev.edmodo:android-image-cropper`

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -158,7 +158,7 @@ dependencies {
   implementation 'com.facebook.device.yearclass:yearclass:2.1.0'
   implementation 'commons-io:commons-io:1.4'
   implementation 'me.leolin:ShortcutBadger:1.1.4@aar'
-  implementation 'com.theartofdev.edmodo:android-image-cropper:2.7.0'
+  implementation 'com.theartofdev.edmodo:android-image-cropper:2.8.0'
   implementation 'commons-codec:commons-codec:1.10'
   implementation 'com.segment.analytics.android:analytics:4.3.0'
   implementation 'com.google.zxing:core:3.3.3'

--- a/android/expoview/build.gradle
+++ b/android/expoview/build.gradle
@@ -341,7 +341,7 @@ dependencies {
   releaseApi 'com.squareup.leakcanary:leakcanary-android-no-op:1.4-beta1'
   api 'commons-io:commons-io:2.6'
   api 'me.leolin:ShortcutBadger:1.1.4@aar'
-  api 'com.theartofdev.edmodo:android-image-cropper:2.7.0'
+  api 'com.theartofdev.edmodo:android-image-cropper:2.8.0'
   api 'commons-codec:commons-codec:1.10'
   api 'net.openid:appauth:0.7.1'
   api 'com.airbnb.android:lottie:3.4.0'


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/13822

# How

The expoview uses a different version of `android-image-cropper` than the `expo-image-picker` which leads to crashes in the standalone app. 

# Test Plan

Build expo go locally ✅  However, I didn't test the standalone apps, cause it is very hard to do it locally.