### PR TITLE
Update markdown on expo-cli.md

### DIFF
--- a/docs/pages/workflow/expo-cli.md
+++ b/docs/pages/workflow/expo-cli.md
@@ -49,23 +49,23 @@ Run `yarn introspect md` in expo-cli/packages/expo-cli then paste the results be
 </summary>
 <p>
 
-| Option                        | Description                                                            |
-| ----------------------------- | ---------------------------------------------------------------------- | ---------------------------- |
-| `--platform [all⎮android      | ios]`                                                                  | Platforms: android, ios, all |
-| `-p, --public-url [url]`      | The public url that will host the static files (required)              |
-| `-c, --clear`                 | Clear the Metro bundler cache                                          |
-| `--output-dir [dir]`          | The directory to export the static files to                            |
-| `-a, --asset-url [url]`       | The absolute or relative url that will host the asset files            |
-| `-d, --dump-assetmap`         | Dump the asset map for further processing                              |
-| `--dev`                       | Configure static files for developing locally using a non-https server |
-| `-s, --dump-sourcemap`        | Dump the source map for debugging the JS bundle                        |
-| `-q, --quiet`                 | Suppress verbose output                                                |
-| `-t, --target [managed⎮bare]` | Target environment for which this export is intended                   |
-| `--merge-src-dir [dir]`       | A repeatable source dir to merge in                                    |
-| `--merge-src-url [url]`       | A repeatable source tar.gz file URL to merge in                        |
-| `--max-workers [num]`         | Maximum number of tasks to allow Metro to spawn                        |
-| `--experimental-bundle`       | export bundles for use with EAS updates                                |
-| `--config [file]`             | Deprecated: Use app.config.js to switch config files instead.          |
+| Option                          | Description                                                            |
+| ------------------------------- | ---------------------------------------------------------------------- | 
+| `--platform [android⎮ios\|all]` | Platforms to sync: ios, android, all. Default: all                     | 
+| `-p, --public-url [url]`        | The public url that will host the static files (required)              |
+| `-c, --clear`                   | Clear the Metro bundler cache                                          |
+| `--output-dir [dir]`            | The directory to export the static files to                            |
+| `-a, --asset-url [url]`         | The absolute or relative url that will host the asset files            |
+| `-d, --dump-assetmap`           | Dump the asset map for further processing                              |
+| `--dev`                         | Configure static files for developing locally using a non-https server |
+| `-s, --dump-sourcemap`          | Dump the source map for debugging the JS bundle                        |
+| `-q, --quiet`                   | Suppress verbose output                                                |
+| `-t, --target [managed⎮bare]`   | Target environment for which this export is intended                   |
+| `--merge-src-dir [dir]`         | A repeatable source dir to merge in                                    |
+| `--merge-src-url [url]`         | A repeatable source tar.gz file URL to merge in                        |
+| `--max-workers [num]`           | Maximum number of tasks to allow Metro to spawn                        |
+| `--experimental-bundle`         | export bundles for use with EAS updates                                |
+| `--config [file]`               | Deprecated: Use app.config.js to switch config files instead.          |
 
 </p>
 </details>
@@ -935,12 +935,12 @@ Alias: `expo ui`
 </summary>
 <p>
 
-| Option                       | Description                                                           |
-| ---------------------------- | --------------------------------------------------------------------- | -------------------------------------------------- |
-| `--no-install`               | Skip installing npm packages and CocoaPods.                           |
-| `--npm`                      | Use npm to install dependencies. (default when Yarn is not installed) |
-| `-p, --platform [all⎮android | ios]`                                                                 | Platforms to sync: ios, android, all. Default: all |
-| `--config [file]`            | Deprecated: Use app.config.js to switch config files instead.         |
+| Option                          | Description                                                           |
+| ------------------------------- | --------------------------------------------------------------------- |
+| `--no-install`                  | Skip installing npm packages and CocoaPods.                           |
+| `--npm`                         | Use npm to install dependencies. (default when Yarn is not installed) |
+| `--platform [android⎮ios\|all]` | Platforms to sync: ios, android, all. Default: all                    | 
+| `--config [file]`               | Deprecated: Use app.config.js to switch config files instead.         |
 
 </p>
 </details>
@@ -953,12 +953,12 @@ Alias: `expo ui`
 <p>
 
 | Option                                    | Description                                                                             |
-| ----------------------------------------- | --------------------------------------------------------------------------------------- | -------------------------------------------------- |
+| ----------------------------------------- | --------------------------------------------------------------------------------------- |
 | `--no-install`                            | Skip installing npm packages and CocoaPods.                                             |
 | `--clean`                                 | Delete the native folders and regenerate them before applying changes                   |
 | `--npm`                                   | Use npm to install dependencies. (default when Yarn is not installed)                   |
 | `--template [template]`                   | Project template to clone from. File path pointing to a local tar file or a github repo |
-| `-p, --platform [all⎮android              | ios]`                                                                                   | Platforms to sync: ios, android, all. Default: all |
+| `--platform [android⎮ios\|all]`           | Platforms to sync: ios, android, all. Default: all                                      | 
 | `--skip-dependency-update [dependencies]` | Preserves versions of listed packages in package.json (comma separated list)            |
 | `--config [file]`                         | Deprecated: Use app.config.js to switch config files instead.                           |
 


### PR DESCRIPTION
The current markdown does not escape the second pipe character (`|`) used when describing passing the platform arg to `prebuild`, `eject`, or `export`. This PR fixes this issue, which allows the tables to have two columns instead of three, and have the code inside `` render as expected.

# Why

Currently, the tables render incorrectly:
![image](https://user-images.githubusercontent.com/61734478/134041464-bf05ff0e-d5df-4def-a903-b7a73faf830a.png)

# How

Edited the markdown.

| Before (on web) | After (on markdown preview) | 
| ----------------- | ----------------- |
| ![image](https://user-images.githubusercontent.com/61734478/134041888-8ccd794c-4710-420b-8b33-e1f458b9e04d.png) | ![image](https://user-images.githubusercontent.com/61734478/134042209-e92ef61a-6396-43cb-836e-176a5104649f.png) | 




# Test Plan

To test, preview the markdown before and after the changes

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md). *no change*
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`). *no change*
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin). *no change*