### PR TITLE
[ios][constants] fix path and revert skipping get-app-config-ios.sh

### DIFF
--- a/packages/expo-constants/scripts/get-app-config-ios.sh
+++ b/packages/expo-constants/scripts/get-app-config-ios.sh
@@ -2,17 +2,6 @@
 
 set -eo pipefail
 
-if [[ "$SKIP_BUNDLING" ]]; then
-  echo "SKIP_BUNDLING enabled; skipping get-app-config-ios.sh."
-  exit 0;
-elif [[ "$CONFIGURATION" == *Debug* ]]; then
-  if [[ "$FORCE_BUNDLING" ]]; then
-    echo "FORCE_BUNDLING enabled; continuing get-app-config-ios.sh."
-  else
-    exit 0;
-  fi
-fi
-
 DEST="$CONFIGURATION_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH"
 NODE_BINARY=${NODE_BINARY:-node}
 
@@ -38,4 +27,5 @@ if [ "x$DIR_BASENAME" != "xPods" ]; then
   exit 0
 fi
 
-"$NODE_BINARY" "${EXPO_CONSTANTS_PACKAGE_DIR}/scripts/getAppConfig.js" "$PROJECT_ROOT/.." "$DEST/EXConstants.bundle"
+CONSTANTS_BUNDLE="EXConstants.bundle"
+"$NODE_BINARY" "${EXPO_CONSTANTS_PACKAGE_DIR}/scripts/getAppConfig.js" "$PROJECT_ROOT/.." "$DEST$CONSTANTS_BUNDLE"


### PR DESCRIPTION
# Why

After trying to run Bare Expo on the most recent master branch, I was unable to get NCL / test suite working - this was caused by two reasons:

- the path to `EXConstants.bundle` contained an extra `/` which meant the manifest e.g `app.config` could not be found
- `getAppConfig.js` was not being run due to recent changes in #14116 

Since `getAppConfig.js` isn't run, any app that uses `Linking.createURL` will run into an issue where it cannot load the manifest file - the `app.config` file needs to be copied first:
<img width="822" alt="Screen Shot 2021-09-20 at 3 49 31 PM" src="https://user-images.githubusercontent.com/40680668/134086656-d9c5110f-e61b-4023-b05d-cbde85f24556.png">

# How

I've tried a number of different ways to pass the `FORCE_BUNDLING` flag to this script with no luck - I believe this is partially due to changes in how it is invoked - e.g it is now defined and run from the `EXConstants.podspec.rb` which dynamically generates a build phase. @Kudo do you know of a way to pass env variables to this script?

In any case, this would be additional overhead for bare projects to get up and running in general, so I'm not sure it is ideal to keep this `FORCE_BUNDLING/SKIP_BUNDLING` setup at all, but I don't think I'm familiar enough so would appreciate some feedback 


<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->

1. Most important step is to clear the cache! and then try to run Bare Expo - this will lead to the error posted in the screenshot above for the reasons described above.

2. Running Bare Expo with this PR in a simulator  or device should work as expected

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).