### PR TITLE
[devicefarm] Remove device farm

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -15,7 +15,6 @@ buildscript {
 }
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
-apply plugin: 'devicefarm'
 
 android {
   compileSdkVersion safeExtGet("compileSdkVersion", 30)
@@ -110,17 +109,6 @@ android {
     // TODO: Remove when we drop support for SDK 41
     pickFirst "lib/**/libhermes-inspector.so"
     pickFirst "lib/**/libfolly_futures.so"
-  }
-}
-
-devicefarm {
-  projectName System.getenv("DEVICEFARM_PROJECT_NAME")
-  devicePool System.getenv("DEVICEFARM_DEVICE_POOL")
-  executionTimeoutMinutes 40
-  authentication {
-
-    accessKey System.getenv("AWS_ACCESS_KEY_ID")
-    secretKey System.getenv("AWS_SECRET_ACCESS_KEY")
   }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,10 +23,6 @@ buildscript {
     classpath "com.android.tools.build:gradle:${gradlePluginVersion}"
     classpath 'com.google.gms:google-services:4.3.5'
     classpath "de.undercouch:gradle-download-task:$gradleDownloadTaskVersion"
-
-    // https://github.com/awslabs/aws-device-farm-gradle-plugin/releases
-    classpath 'com.amazonaws:aws-devicefarm-gradle-plugin:1.3'
-
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
   }
 }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -289,42 +289,6 @@ platform :android do
     adb(command: "shell am start -n host.exp.exponent/host.exp.exponent.LauncherActivity")
   end
 
-  def devicefarm_run(arn)
-    JSON.load(`aws devicefarm --region us-west-2 get-run --arn #{arn}`)
-  end
-
-  def devicefarm_follow_run(arn)
-    until (run = devicefarm_run(arn)["run"]) && run["result"]  != "PENDING"
-      UI.message("Run pending...")
-      sleep 60
-    end
-    UI.shell_error!("Run #{run["result"]}") unless run["result"] == "PASSED"
-    UI.success("Run successful")
-  end
-
-  lane :devicefarm do
-    commit_info = last_git_commit
-    channel = commit_info[:commit_hash]
-    ENV["TEST_SUITE_URI"] = "exp://exp.host/@exponent_ci_bot/test-suite/--/all?release-channel=#{channel}"
-    ENV["TEST_CONFIG"] = {
-      includeModules:  '.*',
-      includeSdkVersions: ['UNVERSIONED'],
-      includeTestTypes: ['test-suite'],
-      isInCI: true,
-    }.to_json
-    ENV["DEVICEFARM_PROJECT_NAME"] = "exponent"
-    ENV["DEVICEFARM_DEVICE_POOL"] = "android-test-device-pool"
-    ENV["AWS_ACCESS_KEY_ID"] ||= `aws configure get aws_access_key_id`.chomp
-    ENV["AWS_SECRET_ACCESS_KEY"] ||= `aws configure get aws_secret_access_key`.chomp
-    upload_result = gradle(
-      project_dir: "android",
-      task: "app:devicefarmUpload",
-    )
-    result_info = upload_result.match(/View the INSTRUMENTATION run.*\/projects\/(?<project_id>.*)\/runs\/(?<run_id>.*)$/)
-    UI.shell_error!("Apks not uploaded!") unless result_info
-    devicefarm_follow_run("arn:aws:devicefarm:us-west-2:274251141632:run:#{result_info[:project_id]}/#{result_info[:run_id]}")
-  end
-
   lane :build do |build_type: "Debug", flavor: "versioned", sign: true|
     ENV['ANDROID_UNSIGNED'] = '1' unless sign
     gradle(

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -55,11 +55,6 @@ fastlane ios release
 fastlane android start
 ```
 
-### android devicefarm
-```
-fastlane android devicefarm
-```
-
 ### android build
 ```
 fastlane android build


### PR DESCRIPTION
# Why

Devicefarm is no longer used nor are the tests maintained. I'm planning to run these tests in GH actions instead in a similar manner to how we run module instrumented tests. That being said, we also already run the test-suite in bare-expo in CI in a similar fashion so maybe we don't need it to run at all.

# How

Somewhat a revert of https://github.com/expo/expo/pull/2845.

# Test Plan

Inspect. Wait for CI.