### PR TITLE
[tools] fix android versioning

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/core/interfaces/Package.java
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/core/interfaces/Package.java
@@ -28,7 +28,7 @@ public interface Package {
     return Collections.emptyList();
   }
 
-  default List<? extends SingletonModule> createSingletonModules(Context context) {
+  default List<? extends expo.modules.core.interfaces.SingletonModule> createSingletonModules(Context context) {
     return Collections.emptyList();
   }
 

--- a/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/NativeResourcesBasedSplashScreenViewProvider.kt
+++ b/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/NativeResourcesBasedSplashScreenViewProvider.kt
@@ -4,9 +4,11 @@ import android.content.Context
 import androidx.core.content.ContextCompat
 
 // this needs to stay for versioning to work
+/* ktlint-disable no-unused-imports */
 import expo.modules.splashscreen.SplashScreenImageResizeMode
 import expo.modules.splashscreen.SplashScreenViewProvider
 // EXPO_VERSIONING_NEEDS_EXPOVIEW_R
+/* ktlint-enable no-unused-imports */
 
 /**
  * Default implementation that uses native resources.

--- a/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/NativeResourcesBasedSplashScreenViewProvider.kt
+++ b/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/NativeResourcesBasedSplashScreenViewProvider.kt
@@ -4,6 +4,9 @@ import android.content.Context
 import androidx.core.content.ContextCompat
 
 // this needs to stay for versioning to work
+import expo.modules.splashscreen.SplashScreenImageResizeMode
+import expo.modules.splashscreen.SplashScreenViewProvider
+// EXPO_VERSIONING_NEEDS_EXPOVIEW_R
 
 /**
  * Default implementation that uses native resources.

--- a/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/SplashScreenReactActivityLifecycleListener.kt
+++ b/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/SplashScreenReactActivityLifecycleListener.kt
@@ -9,8 +9,10 @@ import expo.modules.core.interfaces.ReactActivityLifecycleListener
 import expo.modules.splashscreen.singletons.SplashScreen
 
 // this needs to stay for versioning to work
+/* ktlint-disable no-unused-imports */
 import expo.modules.splashscreen.SplashScreenImageResizeMode
 // EXPO_VERSIONING_NEEDS_EXPOVIEW_R
+/* ktlint-enable no-unused-imports */
 
 class SplashScreenReactActivityLifecycleListener(activityContext: Context) : ReactActivityLifecycleListener {
   override fun onCreate(activity: Activity, savedInstanceState: Bundle?) {

--- a/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/SplashScreenReactActivityLifecycleListener.kt
+++ b/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/SplashScreenReactActivityLifecycleListener.kt
@@ -8,6 +8,10 @@ import com.facebook.react.ReactRootView
 import expo.modules.core.interfaces.ReactActivityLifecycleListener
 import expo.modules.splashscreen.singletons.SplashScreen
 
+// this needs to stay for versioning to work
+import expo.modules.splashscreen.SplashScreenImageResizeMode
+// EXPO_VERSIONING_NEEDS_EXPOVIEW_R
+
 class SplashScreenReactActivityLifecycleListener(activityContext: Context) : ReactActivityLifecycleListener {
   override fun onCreate(activity: Activity, savedInstanceState: Bundle?) {
     // To support backward compatible or SplashScreenImageResizeMode customization

--- a/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/SplashScreenView.kt
+++ b/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/SplashScreenView.kt
@@ -7,7 +7,9 @@ import android.widget.ImageView
 import android.widget.RelativeLayout
 
 // this needs to stay for versioning to work
+/* ktlint-disable no-unused-imports */
 import expo.modules.splashscreen.SplashScreenImageResizeMode
+/* ktlint-enable no-unused-imports */
 
 @SuppressLint("ViewConstructor")
 class SplashScreenView(

--- a/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/SplashScreenView.kt
+++ b/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/SplashScreenView.kt
@@ -6,6 +6,9 @@ import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.RelativeLayout
 
+// this needs to stay for versioning to work
+import expo.modules.splashscreen.SplashScreenImageResizeMode
+
 @SuppressLint("ViewConstructor")
 class SplashScreenView(
   context: Context

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.java
@@ -21,6 +21,9 @@ import expo.modules.updates.selectionpolicy.ReaperSelectionPolicyDevelopmentClie
 import expo.modules.updates.selectionpolicy.SelectionPolicy;
 import expo.modules.updatesinterface.UpdatesInterface;
 
+// this unused import must stay because of versioning
+import expo.modules.updates.UpdatesConfiguration;
+
 public class UpdatesDevLauncherController implements UpdatesInterface {
 
   private static UpdatesDevLauncherController sInstance;

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.java
@@ -25,7 +25,7 @@ import expo.modules.updates.loader.RemoteLoader;
 import expo.modules.updates.manifest.ManifestMetadata;
 
 // this unused import must stay because of versioning
-
+import expo.modules.updates.UpdatesConfiguration;
 
 public class UpdatesModule extends ExportedModule {
   private static final String NAME = "ExpoUpdates";

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesPackage.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesPackage.java
@@ -20,6 +20,9 @@ import expo.modules.core.ExportedModule;
 import expo.modules.core.interfaces.InternalModule;
 import expo.modules.core.interfaces.ReactNativeHostHandler;
 
+// these unused imports must stay because of versioning
+import expo.modules.updates.UpdatesController;
+
 public class UpdatesPackage extends BasePackage {
   private static final String TAG = UpdatesPackage.class.getSimpleName();
 

--- a/tools/src/versioning/android/android-copy-expo-module.sh
+++ b/tools/src/versioning/android/android-copy-expo-module.sh
@@ -43,6 +43,10 @@ do
   sed -i '' "s/temporarydonotversion.$PACKAGE/$PACKAGE/g" $UNIMODULE_MANIFEST_PATH
 done < $TOOLS_DIR/android-packages-to-keep.txt
 
+# Transform `// EXPO_VERSIONING_NEEDS_EXPOVIEW_R` comment as `import abiN_N_N.host.exp.expoview.R`
+find $VERSIONED_ABI_PATH/src/main/java/$ABI_VERSION -iname '*.java' -type f -print0 | xargs -0 sed -i '' "s/^\/\/ *EXPO_VERSIONING_NEEDS_EXPOVIEW_R/import $ABI_VERSION.host.exp.expoview.R;/g"
+find $VERSIONED_ABI_PATH/src/main/java/$ABI_VERSION -iname '*.kt' -type f -print0 | xargs -0 sed -i '' "s/^\/\/ *EXPO_VERSIONING_NEEDS_EXPOVIEW_R/import $ABI_VERSION.host.exp.expoview.R/g"
+
 java -jar $TOOLS_DIR/android-manifest-merger-3898d3a.jar \
      --main $VERSIONED_ABI_PATH/src/main/AndroidManifest.xml \
      --libs $UNIMODULE_MANIFEST_PATH \

--- a/tools/src/versioning/android/android-packages-to-keep.txt
+++ b/tools/src/versioning/android/android-packages-to-keep.txt
@@ -3,6 +3,11 @@ org.unimodules.apploader
 org.unimodules.interfaces.taskManager
 org.unimodules.core.interfaces.Consumer
 org.unimodules.core.interfaces.SingletonModule
+expo.modules.apploader
+expo.modules.interfaces.taskManager
+expo.modules.core.interfaces.Consumer
+expo.modules.core.interfaces.SingletonModule
+expo.modules.jsonutils
 expo.modules.manifests
 expo.modules.notifications.notifications.model
 expo.modules.notifications.notifications.enums
@@ -24,7 +29,9 @@ expo.modules.updates.db
 expo.modules.updates.launcher
 expo.modules.updates.loader
 expo.modules.updates.manifest
-expo.modules.splashscreen.singletons.SplashScreen
-com.facebook.proguard.annotations.DoNotStrip
 expo.modules.updates.selectionpolicy
 expo.modules.updates.UpdatesDevLauncherController
+expo.modules.splashscreen.singletons.SplashScreen
+expo.modules.splashscreen.SplashScreenViewProvider
+expo.modules.splashscreen.SplashScreenImageResizeMode
+com.facebook.proguard.annotations.DoNotStrip

--- a/tools/src/versioning/android/index.ts
+++ b/tools/src/versioning/android/index.ts
@@ -407,7 +407,7 @@ async function renameJniLibsAsync(version: string) {
   }
 }
 
-async function copyUnimodulesAsync(version: string) {
+async function copyExpoModulesAsync(version: string) {
   const packages = await getListOfPackagesAsync();
   for (const pkg of packages) {
     if (
@@ -416,7 +416,7 @@ async function copyUnimodulesAsync(version: string) {
       pkg.isVersionableOnPlatform('android')
     ) {
       await spawnAsync(
-        './android-copy-unimodule.sh',
+        './android-copy-expo-module.sh',
         [version, path.join(pkg.path, pkg.androidSubdirectory)],
         {
           shell: true,
@@ -473,11 +473,11 @@ async function cleanUpAsync(version: string) {
 
   let filesToDelete: string[] = [];
 
-  // delete PrintDocumentAdapter*Callback.java
+  // delete PrintDocumentAdapter*Callback.kt
   // their package is `android.print` and therefore they are not changed by the versioning script
   // so we will have duplicate classes
   const printCallbackFiles = await glob(
-    path.join(versionedAbiSrcPath, 'expo/modules/print/*Callback.java')
+    path.join(versionedAbiSrcPath, 'expo/modules/print/*Callback.kt')
   );
   for (const file of printCallbackFiles) {
     const contents = await fs.readFile(file, 'utf8');
@@ -501,7 +501,7 @@ async function cleanUpAsync(version: string) {
   // misc fixes for versioned code
   const versionedExponentPackagePath = path.join(
     versionedAbiSrcPath,
-    'host/exp/exponent/ExponentPackage.java'
+    'host/exp/exponent/ExponentPackage.kt'
   );
   await transformFileAsync(
     versionedExponentPackagePath,
@@ -515,7 +515,7 @@ async function cleanUpAsync(version: string) {
   );
 
   await transformFileAsync(
-    path.join(versionedAbiSrcPath, 'host/exp/exponent/VersionedUtils.java'),
+    path.join(versionedAbiSrcPath, 'host/exp/exponent/VersionedUtils.kt'),
     new RegExp('// DO NOT EDIT THIS COMMENT - used by versioning scripts[^,]+,[^,]+,'),
     'null, null,'
   );
@@ -608,6 +608,7 @@ export async function addVersionAsync(version: string) {
   console.log(' 🛠   1/11: Updating android/versioned-react-native...');
   await updateVersionedReactNativeAsync(
     Directories.getReactNativeSubmoduleDir(),
+    ANDROID_DIR,
     path.join(ANDROID_DIR, 'versioned-react-native')
   );
   console.log(' ✅  1/11: Finished\n\n');
@@ -644,8 +645,8 @@ export async function addVersionAsync(version: string) {
   await prepareReanimatedAsync(version);
   console.log(' ✅  7/11: Finished\n\n');
 
-  console.log(' 🛠   8/11: Creating versioned unimodule packages...');
-  await copyUnimodulesAsync(version);
+  console.log(' 🛠   8/11: Creating versioned expo-modules packages...');
+  await copyExpoModulesAsync(version);
   console.log(' ✅  8/11: Finished\n\n');
 
   console.log(' 🛠   9/11: Adding extra versioned activites to AndroidManifest...');

--- a/tools/src/versioning/android/versionReactNative.ts
+++ b/tools/src/versioning/android/versionReactNative.ts
@@ -6,6 +6,7 @@ import { transformFileAsync } from '../../Transforms';
 
 export async function updateVersionedReactNativeAsync(
   reactNativeRoot: string,
+  androidDir: string,
   versionedReactNativeRoot: string
 ): Promise<void> {
   // Clone whole directories
@@ -15,7 +16,7 @@ export async function updateVersionedReactNativeAsync(
   );
   await Promise.all(
     copyDirs.map((subdir) =>
-      fs.copy(path.join(reactNativeRoot, subdir), path.join(versionedReactNativeRoot, subdir))
+      fs.copy(path.join(androidDir, subdir), path.join(versionedReactNativeRoot, subdir))
     )
   );
 


### PR DESCRIPTION
# Why

support sdk 43 versioning for android client

# How

- should copy `ReactCommon` and `ReactAndroid` from `android/` folder into `android/versioned-react-native/` where with our transformed code
- update `android-packages-to-keep.txt`
- fix some broken transformation after kotlinization
- fix some broken imports which should be kept
- introduce `// EXPO_VERSIONING_NEEDS_EXPOVIEW_R` that will be transformed as `import abi43_0_0.host.exp.expoview.R`

# Test Plan

```sh
$ et add-sdk -p android -s 43.0.0
$ cd android && ./gradlew :app:assembleVersionedRelease
```