### PR TITLE
[ios] Fix versioning issues with ScreenOrientation and SplashScreen

### DIFF
--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXScreenOrientation/ABI40_0_0EXScreenOrientation/ABI40_0_0EXScreenOrientationRegistry.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXScreenOrientation/ABI40_0_0EXScreenOrientation/ABI40_0_0EXScreenOrientationRegistry.m
@@ -138,7 +138,7 @@ ABI40_0_0UM_REGISTER_SINGLETON_MODULE(ScreenOrientationRegistry)
 
 - (void)handleDeviceOrientationChange:(NSNotification *)notification
 {
-  UIInterfaceOrientation newScreenOrientation = [ABI40_0_0EXScreenOrientationUtilities interfaceOrientationFromDeviceOrientation:[notification.object orientation]];
+  UIInterfaceOrientation newScreenOrientation = [ABI40_0_0EXScreenOrientationUtilities interfaceOrientationFromDeviceOrientation:[[UIDevice currentDevice] orientation]];
   [self interfaceOrientationDidChange:newScreenOrientation];
 }
 

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXScreenOrientation/ABI41_0_0EXScreenOrientation/ABI41_0_0EXScreenOrientationRegistry.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXScreenOrientation/ABI41_0_0EXScreenOrientation/ABI41_0_0EXScreenOrientationRegistry.m
@@ -138,7 +138,7 @@ ABI41_0_0UM_REGISTER_SINGLETON_MODULE(ScreenOrientationRegistry)
 
 - (void)handleDeviceOrientationChange:(NSNotification *)notification
 {
-  UIInterfaceOrientation newScreenOrientation = [ABI41_0_0EXScreenOrientationUtilities interfaceOrientationFromDeviceOrientation:[notification.object orientation]];
+  UIInterfaceOrientation newScreenOrientation = [ABI41_0_0EXScreenOrientationUtilities interfaceOrientationFromDeviceOrientation:[[UIDevice currentDevice] orientation]];
   [self interfaceOrientationDidChange:newScreenOrientation];
 }
 

--- a/ios/versioned-react-native/ABI42_0_0/Expo/EXScreenOrientation/ABI42_0_0EXScreenOrientation/ABI42_0_0EXScreenOrientationRegistry.m
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/EXScreenOrientation/ABI42_0_0EXScreenOrientation/ABI42_0_0EXScreenOrientationRegistry.m
@@ -138,7 +138,7 @@ ABI42_0_0UM_REGISTER_SINGLETON_MODULE(ScreenOrientationRegistry)
 
 - (void)handleDeviceOrientationChange:(NSNotification *)notification
 {
-  UIInterfaceOrientation newScreenOrientation = [ABI42_0_0EXScreenOrientationUtilities interfaceOrientationFromDeviceOrientation:[notification.object orientation]];
+  UIInterfaceOrientation newScreenOrientation = [ABI42_0_0EXScreenOrientationUtilities interfaceOrientationFromDeviceOrientation:[[UIDevice currentDevice] orientation]];
   [self interfaceOrientationDidChange:newScreenOrientation];
 }
 

--- a/packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenService.m
+++ b/packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenService.m
@@ -4,7 +4,7 @@
 #import <EXSplashScreen/EXSplashScreenViewNativeProvider.h>
 #import <ExpoModulesCore/EXDefines.h>
 
-NSString * const kRootViewController = @"rootViewController";
+static const NSString *kRootViewController = @"rootViewController";
 
 @interface EXSplashScreenService ()
 


### PR DESCRIPTION
# Why

Need to fix issues with versioning on iOS

# How

- Backported #13898 
- Fixed duplicated symbols in global constants

# Test Plan

Versioned Expo Go builds as expected
