### PR TITLE
[facebook][ios] update app id in bare expo, fix error handler 

### DIFF
--- a/apps/bare-expo/ios/BareExpo/Info.plist
+++ b/apps/bare-expo/ios/BareExpo/Info.plist
@@ -32,7 +32,7 @@
 		<dict>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>fb629712900716487</string>
+				<string>fb1696089354000816</string>
 			</array>
 		</dict>
 	</array>
@@ -108,7 +108,7 @@
 	<key>CFBundleDisplayName</key>
 	<string>BareExpo</string>
 	<key>FacebookAppID</key>
-	<string>629712900716487</string>
+  <string>1696089354000816</string>
 	<key>FacebookDisplayName</key>
 	<string>Expo APIs</string>
 </dict>

--- a/apps/bare-expo/ios/BareExpo/Info.plist
+++ b/apps/bare-expo/ios/BareExpo/Info.plist
@@ -108,7 +108,7 @@
 	<key>CFBundleDisplayName</key>
 	<string>BareExpo</string>
 	<key>FacebookAppID</key>
-  <string>1696089354000816</string>
+  	<string>1696089354000816</string>
 	<key>FacebookDisplayName</key>
 	<string>Expo APIs</string>
 </dict>

--- a/packages/expo-facebook/CHANGELOG.md
+++ b/packages/expo-facebook/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### 🐛 Bug fixes
 
 - `logPurchaseAsync` on iOS now accepts an `NSNumber` type, which has no user-facing impact besides fixing an error message in the App Events console. ([#13369](https://github.com/expo/expo/pull/13369) by [@cruzach](https://github.com/cruzach))
+- Update error handler for `logInWithReadPermissionsAsync` to handle empty userInfo in native exception. ([#14492](https://github.com/expo/expo/pull/14492) by [@ajsmth](https://github.com/ajsmth))
 
 ### 💡 Others
 

--- a/packages/expo-facebook/ios/EXFacebook/EXFacebook.m
+++ b/packages/expo-facebook/ios/EXFacebook/EXFacebook.m
@@ -161,12 +161,11 @@ EX_EXPORT_METHOD_AS(logInWithReadPermissionsAsync,
         accessToken[@"type"] = @"success";
         resolve(accessToken);
       }];
-    }
-    @catch (NSException *exception) {
+    } @catch (NSException *exception) {
       NSError *error = [[NSError alloc] initWithDomain:EXFacebookLoginErrorDomain code:650 userInfo:@{
         NSLocalizedDescriptionKey: exception.description,
         NSLocalizedFailureReasonErrorKey: exception.reason,
-        @"ExceptionUserInfo": exception.userInfo,
+        @"ExceptionUserInfo": exception.userInfo ?: @{},
         @"ExceptionCallStackSymbols": exception.callStackSymbols,
         @"ExceptionCallStackReturnAddresses": exception.callStackReturnAddresses,
         @"ExceptionName": exception.name


### PR DESCRIPTION
# Why

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

Bare Expo was crashing after running test suite - turns out it was due to the app id not being registered and the exception handler that would reject the login method was throwing an exception itself 

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

- updated the app id in Info.plist and added a null check in the exception handler

# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->

Bare Expo + Test Suite + Facebook tests should pass

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).