### PR TITLE
[docs] display `@see` comments in `APISection` content

### DIFF
--- a/docs/components/plugins/APISection.tsx
+++ b/docs/components/plugins/APISection.tsx
@@ -133,7 +133,7 @@ const renderAPI = (
   }
 };
 
-const APISection: React.FC<Props> = ({ packageName, apiName, forceVersion }) => {
+const APISection = ({ packageName, apiName, forceVersion }: Props) => {
   const { version } = useContext(DocumentationPageContext);
   const resolvedVersion =
     forceVersion ||

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -232,6 +232,49 @@ button.
       Make sure to attach height and width via the style props as without these styles, the button will
 not appear on the screen.
     </p>
+    <blockquote
+      class="css-e76wiv-paragraph-STYLES_BLOCKQUOTE"
+      data-text="true"
+    >
+      <div>
+        <div
+          style="margin-top: 2px;"
+        >
+          <svg
+            aria-label="check"
+            fill="none"
+            height="16"
+            viewBox="0 0 24 24"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12 0C5.373 0 0 5.373 0 12s5.373 12 12 12c6.628 0 12-5.373 12-12S18.628 0 12 0zm-.015 5.419c.269-.292.596-.44.973-.44.306 0 .575.11.776.317.203.207.306.472.306.786 0 .394-.137.745-.409 1.042-.279.306-.605.462-.968.462-.3 0-.566-.113-.768-.326-.201-.208-.304-.48-.304-.809 0-.401.133-.749.394-1.032zm1.999 11.305c-.995.936-1.705 1.52-2.17 1.784-.496.284-.905.423-1.25.423-.342 0-.621-.114-.83-.338-.202-.218-.305-.51-.305-.87 0-.92.521-3.058 1.595-6.534a1.47 1.47 0 00.042-.166c-.04.017-.087.041-.14.075-.088.055-.356.265-1.14 1.03a.334.334 0 01-.438.025l-.463-.358a.334.334 0 01-.043-.49c.722-.794 1.395-1.371 2.002-1.714.636-.358 1.173-.533 1.643-.533.303 0 .548.076.729.225.196.164.3.391.3.658 0 .175-.084.63-.697 2.686-.875 2.937-1.084 4.003-1.099 4.372.166-.098.558-.376 1.395-1.162a.334.334 0 01.462.003l.411.4a.334.334 0 01-.004.484z"
+              fill="var(--expo-theme-icon-default)"
+            />
+          </svg>
+        </div>
+      </div>
+      <div>
+        <strong
+          class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+        >
+          See: 
+        </strong>
+        <span>
+          <a
+            class="css-12zqqiz-STYLES_EXTERNAL_LINK"
+            href="https://developer.apple.com/documentation/authenticationservices/asauthorizationappleidbutton"
+            rel="noopener noreferrer"
+          >
+            Apple
+Documentation
+          </a>
+          
+for more details.
+        </span>
+      </div>
+    </blockquote>
     <h3
       class="css-icxoph-h3-h3-STYLES_H3"
       data-heading="true"
@@ -2222,6 +2265,49 @@ sign-in operation.
       
 which contains all of the pertinent user and credential information.
     </p>
+    <blockquote
+      class="css-e76wiv-paragraph-STYLES_BLOCKQUOTE"
+      data-text="true"
+    >
+      <div>
+        <div
+          style="margin-top: 2px;"
+        >
+          <svg
+            aria-label="check"
+            fill="none"
+            height="16"
+            viewBox="0 0 24 24"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12 0C5.373 0 0 5.373 0 12s5.373 12 12 12c6.628 0 12-5.373 12-12S18.628 0 12 0zm-.015 5.419c.269-.292.596-.44.973-.44.306 0 .575.11.776.317.203.207.306.472.306.786 0 .394-.137.745-.409 1.042-.279.306-.605.462-.968.462-.3 0-.566-.113-.768-.326-.201-.208-.304-.48-.304-.809 0-.401.133-.749.394-1.032zm1.999 11.305c-.995.936-1.705 1.52-2.17 1.784-.496.284-.905.423-1.25.423-.342 0-.621-.114-.83-.338-.202-.218-.305-.51-.305-.87 0-.92.521-3.058 1.595-6.534a1.47 1.47 0 00.042-.166c-.04.017-.087.041-.14.075-.088.055-.356.265-1.14 1.03a.334.334 0 01-.438.025l-.463-.358a.334.334 0 01-.043-.49c.722-.794 1.395-1.371 2.002-1.714.636-.358 1.173-.533 1.643-.533.303 0 .548.076.729.225.196.164.3.391.3.658 0 .175-.084.63-.697 2.686-.875 2.937-1.084 4.003-1.099 4.372.166-.098.558-.376 1.395-1.162a.334.334 0 01.462.003l.411.4a.334.334 0 01-.004.484z"
+              fill="var(--expo-theme-icon-default)"
+            />
+          </svg>
+        </div>
+      </div>
+      <div>
+        <strong
+          class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+        >
+          See: 
+        </strong>
+        <span>
+          <a
+            class="css-12zqqiz-STYLES_EXTERNAL_LINK"
+            href="https://developer.apple.com/documentation/authenticationservices/asauthorizationappleidcredential"
+            rel="noopener noreferrer"
+          >
+            Apple
+Documentation
+          </a>
+          
+for more details.
+        </span>
+      </div>
+    </blockquote>
     <table>
       <thead>
         <tr>
@@ -2800,6 +2886,49 @@ may be
       .
 You must include the ID string of the user whose credentials you'd like to refresh.
     </p>
+    <blockquote
+      class="css-e76wiv-paragraph-STYLES_BLOCKQUOTE"
+      data-text="true"
+    >
+      <div>
+        <div
+          style="margin-top: 2px;"
+        >
+          <svg
+            aria-label="check"
+            fill="none"
+            height="16"
+            viewBox="0 0 24 24"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12 0C5.373 0 0 5.373 0 12s5.373 12 12 12c6.628 0 12-5.373 12-12S18.628 0 12 0zm-.015 5.419c.269-.292.596-.44.973-.44.306 0 .575.11.776.317.203.207.306.472.306.786 0 .394-.137.745-.409 1.042-.279.306-.605.462-.968.462-.3 0-.566-.113-.768-.326-.201-.208-.304-.48-.304-.809 0-.401.133-.749.394-1.032zm1.999 11.305c-.995.936-1.705 1.52-2.17 1.784-.496.284-.905.423-1.25.423-.342 0-.621-.114-.83-.338-.202-.218-.305-.51-.305-.87 0-.92.521-3.058 1.595-6.534a1.47 1.47 0 00.042-.166c-.04.017-.087.041-.14.075-.088.055-.356.265-1.14 1.03a.334.334 0 01-.438.025l-.463-.358a.334.334 0 01-.043-.49c.722-.794 1.395-1.371 2.002-1.714.636-.358 1.173-.533 1.643-.533.303 0 .548.076.729.225.196.164.3.391.3.658 0 .175-.084.63-.697 2.686-.875 2.937-1.084 4.003-1.099 4.372.166-.098.558-.376 1.395-1.162a.334.334 0 01.462.003l.411.4a.334.334 0 01-.004.484z"
+              fill="var(--expo-theme-icon-default)"
+            />
+          </svg>
+        </div>
+      </div>
+      <div>
+        <strong
+          class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+        >
+          See: 
+        </strong>
+        <span>
+          <a
+            class="css-12zqqiz-STYLES_EXTERNAL_LINK"
+            href="https://developer.apple.com/documentation/authenticationservices/asauthorizationopenidrequest"
+            rel="noopener noreferrer"
+          >
+            Apple
+Documentation
+          </a>
+          
+for more details.
+        </span>
+      </div>
+    </blockquote>
     <table>
       <thead>
         <tr>
@@ -3005,6 +3134,49 @@ OAuth 2.0 protocol
       .
 None of these options are required.
     </p>
+    <blockquote
+      class="css-e76wiv-paragraph-STYLES_BLOCKQUOTE"
+      data-text="true"
+    >
+      <div>
+        <div
+          style="margin-top: 2px;"
+        >
+          <svg
+            aria-label="check"
+            fill="none"
+            height="16"
+            viewBox="0 0 24 24"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12 0C5.373 0 0 5.373 0 12s5.373 12 12 12c6.628 0 12-5.373 12-12S18.628 0 12 0zm-.015 5.419c.269-.292.596-.44.973-.44.306 0 .575.11.776.317.203.207.306.472.306.786 0 .394-.137.745-.409 1.042-.279.306-.605.462-.968.462-.3 0-.566-.113-.768-.326-.201-.208-.304-.48-.304-.809 0-.401.133-.749.394-1.032zm1.999 11.305c-.995.936-1.705 1.52-2.17 1.784-.496.284-.905.423-1.25.423-.342 0-.621-.114-.83-.338-.202-.218-.305-.51-.305-.87 0-.92.521-3.058 1.595-6.534a1.47 1.47 0 00.042-.166c-.04.017-.087.041-.14.075-.088.055-.356.265-1.14 1.03a.334.334 0 01-.438.025l-.463-.358a.334.334 0 01-.043-.49c.722-.794 1.395-1.371 2.002-1.714.636-.358 1.173-.533 1.643-.533.303 0 .548.076.729.225.196.164.3.391.3.658 0 .175-.084.63-.697 2.686-.875 2.937-1.084 4.003-1.099 4.372.166-.098.558-.376 1.395-1.162a.334.334 0 01.462.003l.411.4a.334.334 0 01-.004.484z"
+              fill="var(--expo-theme-icon-default)"
+            />
+          </svg>
+        </div>
+      </div>
+      <div>
+        <strong
+          class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+        >
+          See: 
+        </strong>
+        <span>
+          <a
+            class="css-12zqqiz-STYLES_EXTERNAL_LINK"
+            href="https://developer.apple.com/documentation/authenticationservices/asauthorizationopenidrequest"
+            rel="noopener noreferrer"
+          >
+            Apple
+Documentation
+          </a>
+          
+for more details.
+        </span>
+      </div>
+    </blockquote>
     <table>
       <thead>
         <tr>
@@ -3227,6 +3399,49 @@ OAuth 2.0 protocol
       .
 You must include the ID string of the user to sign out.
     </p>
+    <blockquote
+      class="css-e76wiv-paragraph-STYLES_BLOCKQUOTE"
+      data-text="true"
+    >
+      <div>
+        <div
+          style="margin-top: 2px;"
+        >
+          <svg
+            aria-label="check"
+            fill="none"
+            height="16"
+            viewBox="0 0 24 24"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12 0C5.373 0 0 5.373 0 12s5.373 12 12 12c6.628 0 12-5.373 12-12S18.628 0 12 0zm-.015 5.419c.269-.292.596-.44.973-.44.306 0 .575.11.776.317.203.207.306.472.306.786 0 .394-.137.745-.409 1.042-.279.306-.605.462-.968.462-.3 0-.566-.113-.768-.326-.201-.208-.304-.48-.304-.809 0-.401.133-.749.394-1.032zm1.999 11.305c-.995.936-1.705 1.52-2.17 1.784-.496.284-.905.423-1.25.423-.342 0-.621-.114-.83-.338-.202-.218-.305-.51-.305-.87 0-.92.521-3.058 1.595-6.534a1.47 1.47 0 00.042-.166c-.04.017-.087.041-.14.075-.088.055-.356.265-1.14 1.03a.334.334 0 01-.438.025l-.463-.358a.334.334 0 01-.043-.49c.722-.794 1.395-1.371 2.002-1.714.636-.358 1.173-.533 1.643-.533.303 0 .548.076.729.225.196.164.3.391.3.658 0 .175-.084.63-.697 2.686-.875 2.937-1.084 4.003-1.099 4.372.166-.098.558-.376 1.395-1.162a.334.334 0 01.462.003l.411.4a.334.334 0 01-.004.484z"
+              fill="var(--expo-theme-icon-default)"
+            />
+          </svg>
+        </div>
+      </div>
+      <div>
+        <strong
+          class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+        >
+          See: 
+        </strong>
+        <span>
+          <a
+            class="css-12zqqiz-STYLES_EXTERNAL_LINK"
+            href="https://developer.apple.com/documentation/authenticationservices/asauthorizationopenidrequest"
+            rel="noopener noreferrer"
+          >
+            Apple
+Documentation
+          </a>
+          
+for more details.
+        </span>
+      </div>
+    </blockquote>
     <table>
       <thead>
         <tr>
@@ -3812,6 +4027,49 @@ OAuth 2.0 protocol
       </a>
       .
     </p>
+    <blockquote
+      class="css-e76wiv-paragraph-STYLES_BLOCKQUOTE"
+      data-text="true"
+    >
+      <div>
+        <div
+          style="margin-top: 2px;"
+        >
+          <svg
+            aria-label="check"
+            fill="none"
+            height="16"
+            viewBox="0 0 24 24"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12 0C5.373 0 0 5.373 0 12s5.373 12 12 12c6.628 0 12-5.373 12-12S18.628 0 12 0zm-.015 5.419c.269-.292.596-.44.973-.44.306 0 .575.11.776.317.203.207.306.472.306.786 0 .394-.137.745-.409 1.042-.279.306-.605.462-.968.462-.3 0-.566-.113-.768-.326-.201-.208-.304-.48-.304-.809 0-.401.133-.749.394-1.032zm1.999 11.305c-.995.936-1.705 1.52-2.17 1.784-.496.284-.905.423-1.25.423-.342 0-.621-.114-.83-.338-.202-.218-.305-.51-.305-.87 0-.92.521-3.058 1.595-6.534a1.47 1.47 0 00.042-.166c-.04.017-.087.041-.14.075-.088.055-.356.265-1.14 1.03a.334.334 0 01-.438.025l-.463-.358a.334.334 0 01-.043-.49c.722-.794 1.395-1.371 2.002-1.714.636-.358 1.173-.533 1.643-.533.303 0 .548.076.729.225.196.164.3.391.3.658 0 .175-.084.63-.697 2.686-.875 2.937-1.084 4.003-1.099 4.372.166-.098.558-.376 1.395-1.162a.334.334 0 01.462.003l.411.4a.334.334 0 01-.004.484z"
+              fill="var(--expo-theme-icon-default)"
+            />
+          </svg>
+        </div>
+      </div>
+      <div>
+        <strong
+          class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+        >
+          See: 
+        </strong>
+        <span>
+          <a
+            class="css-12zqqiz-STYLES_EXTERNAL_LINK"
+            href="https://developer.apple.com/documentation/authenticationservices/asauthorizationappleidprovidercredentialstate"
+            rel="noopener noreferrer"
+          >
+            Apple
+Documentation
+          </a>
+          
+for more details.
+        </span>
+      </div>
+    </blockquote>
     <ul
       class="css-1a9yu92-paragraph-STYLES_UNORDERED_LIST-UL"
       data-text="true"
@@ -4125,6 +4383,49 @@ You will still need to handle null values for any fields you request.
 
       </div>
     </blockquote>
+    <blockquote
+      class="css-e76wiv-paragraph-STYLES_BLOCKQUOTE"
+      data-text="true"
+    >
+      <div>
+        <div
+          style="margin-top: 2px;"
+        >
+          <svg
+            aria-label="check"
+            fill="none"
+            height="16"
+            viewBox="0 0 24 24"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12 0C5.373 0 0 5.373 0 12s5.373 12 12 12c6.628 0 12-5.373 12-12S18.628 0 12 0zm-.015 5.419c.269-.292.596-.44.973-.44.306 0 .575.11.776.317.203.207.306.472.306.786 0 .394-.137.745-.409 1.042-.279.306-.605.462-.968.462-.3 0-.566-.113-.768-.326-.201-.208-.304-.48-.304-.809 0-.401.133-.749.394-1.032zm1.999 11.305c-.995.936-1.705 1.52-2.17 1.784-.496.284-.905.423-1.25.423-.342 0-.621-.114-.83-.338-.202-.218-.305-.51-.305-.87 0-.92.521-3.058 1.595-6.534a1.47 1.47 0 00.042-.166c-.04.017-.087.041-.14.075-.088.055-.356.265-1.14 1.03a.334.334 0 01-.438.025l-.463-.358a.334.334 0 01-.043-.49c.722-.794 1.395-1.371 2.002-1.714.636-.358 1.173-.533 1.643-.533.303 0 .548.076.729.225.196.164.3.391.3.658 0 .175-.084.63-.697 2.686-.875 2.937-1.084 4.003-1.099 4.372.166-.098.558-.376 1.395-1.162a.334.334 0 01.462.003l.411.4a.334.334 0 01-.004.484z"
+              fill="var(--expo-theme-icon-default)"
+            />
+          </svg>
+        </div>
+      </div>
+      <div>
+        <strong
+          class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+        >
+          See: 
+        </strong>
+        <span>
+          <a
+            class="css-12zqqiz-STYLES_EXTERNAL_LINK"
+            href="https://developer.apple.com/documentation/authenticationservices/asauthorizationscope"
+            rel="noopener noreferrer"
+          >
+            Apple
+Documentation
+          </a>
+          
+for more details.
+        </span>
+      </div>
+    </blockquote>
     <ul
       class="css-1a9yu92-paragraph-STYLES_UNORDERED_LIST-UL"
       data-text="true"
@@ -4227,6 +4528,49 @@ You will still need to handle null values for any fields you request.
     >
       An enum whose values specify the system's best guess for how likely the current user is a real person.
     </p>
+    <blockquote
+      class="css-e76wiv-paragraph-STYLES_BLOCKQUOTE"
+      data-text="true"
+    >
+      <div>
+        <div
+          style="margin-top: 2px;"
+        >
+          <svg
+            aria-label="check"
+            fill="none"
+            height="16"
+            viewBox="0 0 24 24"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12 0C5.373 0 0 5.373 0 12s5.373 12 12 12c6.628 0 12-5.373 12-12S18.628 0 12 0zm-.015 5.419c.269-.292.596-.44.973-.44.306 0 .575.11.776.317.203.207.306.472.306.786 0 .394-.137.745-.409 1.042-.279.306-.605.462-.968.462-.3 0-.566-.113-.768-.326-.201-.208-.304-.48-.304-.809 0-.401.133-.749.394-1.032zm1.999 11.305c-.995.936-1.705 1.52-2.17 1.784-.496.284-.905.423-1.25.423-.342 0-.621-.114-.83-.338-.202-.218-.305-.51-.305-.87 0-.92.521-3.058 1.595-6.534a1.47 1.47 0 00.042-.166c-.04.017-.087.041-.14.075-.088.055-.356.265-1.14 1.03a.334.334 0 01-.438.025l-.463-.358a.334.334 0 01-.043-.49c.722-.794 1.395-1.371 2.002-1.714.636-.358 1.173-.533 1.643-.533.303 0 .548.076.729.225.196.164.3.391.3.658 0 .175-.084.63-.697 2.686-.875 2.937-1.084 4.003-1.099 4.372.166-.098.558-.376 1.395-1.162a.334.334 0 01.462.003l.411.4a.334.334 0 01-.004.484z"
+              fill="var(--expo-theme-icon-default)"
+            />
+          </svg>
+        </div>
+      </div>
+      <div>
+        <strong
+          class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+        >
+          See: 
+        </strong>
+        <span>
+          <a
+            class="css-12zqqiz-STYLES_EXTERNAL_LINK"
+            href="https://developer.apple.com/documentation/authenticationservices/asuserdetectionstatus"
+            rel="noopener noreferrer"
+          >
+            Apple
+Documentation
+          </a>
+          
+for more details.
+        </span>
+      </div>
+    </blockquote>
     <ul
       class="css-1a9yu92-paragraph-STYLES_UNORDERED_LIST-UL"
       data-text="true"

--- a/docs/components/plugins/api/APISectionComponents.tsx
+++ b/docs/components/plugins/api/APISectionComponents.tsx
@@ -30,7 +30,7 @@ const renderComponent = (
   </div>
 );
 
-const APISectionComponents: React.FC<APISectionComponentsProps> = ({ data, componentsProps }) =>
+const APISectionComponents = ({ data, componentsProps }: APISectionComponentsProps) =>
   data?.length ? (
     <>
       <H2 key="components-header">Components</H2>

--- a/docs/components/plugins/api/APISectionConstants.tsx
+++ b/docs/components/plugins/api/APISectionConstants.tsx
@@ -29,7 +29,7 @@ const renderConstant = (
   </div>
 );
 
-const APISectionConstants: React.FC<APISectionConstantsProps> = ({ data, apiName }) =>
+const APISectionConstants = ({ data, apiName }: APISectionConstantsProps) =>
   data?.length ? (
     <>
       <H2 key="constants-header">Constants</H2>

--- a/docs/components/plugins/api/APISectionEnums.tsx
+++ b/docs/components/plugins/api/APISectionEnums.tsx
@@ -46,7 +46,7 @@ const renderEnum = ({ name, children, comment }: EnumDefinitionData): JSX.Elemen
   </div>
 );
 
-const APISectionEnums: React.FC<APISectionEnumsProps> = ({ data }) =>
+const APISectionEnums = ({ data }: APISectionEnumsProps) =>
   data?.length ? (
     <>
       <H2 key="enums-header">Enums</H2>

--- a/docs/components/plugins/api/APISectionInterfaces.tsx
+++ b/docs/components/plugins/api/APISectionInterfaces.tsx
@@ -84,7 +84,7 @@ const renderInterface = ({
     </div>
   ) : null;
 
-const APISectionInterfaces: React.FC<APISectionInterfacesProps> = ({ data }) =>
+const APISectionInterfaces = ({ data }: APISectionInterfacesProps) =>
   data?.length ? (
     <>
       <H2 key="interfaces-header">Interfaces</H2>

--- a/docs/components/plugins/api/APISectionMethods.tsx
+++ b/docs/components/plugins/api/APISectionMethods.tsx
@@ -62,11 +62,7 @@ const renderMethod = (
     </div>
   ));
 
-const APISectionMethods: React.FC<APISectionMethodsProps> = ({
-  data,
-  apiName,
-  header = 'Methods',
-}) =>
+const APISectionMethods = ({ data, apiName, header = 'Methods' }: APISectionMethodsProps) =>
   data?.length ? (
     <>
       <H2 key="methods-header">{header}</H2>

--- a/docs/components/plugins/api/APISectionProps.tsx
+++ b/docs/components/plugins/api/APISectionProps.tsx
@@ -118,11 +118,7 @@ const renderProp = (
   </LI>
 );
 
-const APISectionProps: React.FC<APISectionPropsProps> = ({
-  data,
-  defaultProps,
-  header = 'Props',
-}) =>
+const APISectionProps = ({ data, defaultProps, header = 'Props' }: APISectionPropsProps) =>
   data?.length ? (
     <>
       {header === 'Props' ? (

--- a/docs/components/plugins/api/APISectionTypes.tsx
+++ b/docs/components/plugins/api/APISectionTypes.tsx
@@ -190,7 +190,7 @@ const renderType = ({ name, comment, type }: TypeGeneralData): JSX.Element | und
   return undefined;
 };
 
-const APISectionTypes: React.FC<APISectionTypesProps> = ({ data }) =>
+const APISectionTypes = ({ data }: APISectionTypesProps) =>
   data?.length ? (
     <>
       <H2 key="types-header">Types</H2>

--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -259,17 +259,17 @@ export const renderTypeOrSignatureType = (
   includeParamType: boolean = false
 ) => {
   if (type) {
-    return <InlineCode>{resolveTypeName(type)}</InlineCode>;
+    return <InlineCode key={`signature-type-${type.name}`}>{resolveTypeName(type)}</InlineCode>;
   } else if (signatures && signatures.length) {
     return signatures.map(({ name, type, parameters }) => (
       <InlineCode key={`signature-type-${name}`}>
         (
         {parameters && includeParamType
           ? parameters.map(param => (
-              <>
+              <span key={`signature-param-${param.name}`}>
                 {param.name}
                 {param.flags?.isOptional && '?'}: {resolveTypeName(param.type)}
-              </>
+              </span>
             ))
           : listParams(parameters)}
         ) =&gt; {resolveTypeName(type)}
@@ -305,12 +305,12 @@ export const getCommentOrSignatureComment = (
 export const getTagData = (tagName: string, comment?: CommentData) =>
   comment?.tags?.filter(tag => tag.tag === tagName)[0];
 
-export const CommentTextBlock: React.FC<CommentTextBlockProps> = ({
+export const CommentTextBlock = ({
   comment,
   components = mdComponents,
   withDash,
   beforeContent,
-}) => {
+}: CommentTextBlockProps) => {
   const shortText = comment?.shortText?.trim().length ? (
     <ReactMarkdown components={components} remarkPlugins={[remarkGfm]}>
       {parseCommentContent(comment.shortText)}
@@ -341,6 +341,14 @@ export const CommentTextBlock: React.FC<CommentTextBlockProps> = ({
     </Quote>
   ) : null;
 
+  const see = getTagData('see', comment);
+  const seeText = see ? (
+    <Quote>
+      <B>See: </B>
+      <ReactMarkdown components={mdInlineComponents}>{see.text}</ReactMarkdown>
+    </Quote>
+  ) : null;
+
   return (
     <>
       {deprecationNote}
@@ -348,6 +356,7 @@ export const CommentTextBlock: React.FC<CommentTextBlockProps> = ({
       {withDash && (shortText || text) && ' - '}
       {shortText}
       {text}
+      {seeText}
       {exampleText}
     </>
   );


### PR DESCRIPTION
# Why

Fixes ENG-1516

Currently few packages comments have `@see` annotations with messages. So far this content was not displayed in the docs, and this PR fixes that issue.

# How

This PR adds optional quote block at the bottom of the description if the `@see` annotation is present.

Also this changeset includes additions of few missing `key`s which results in warnings in console. 

Additionally I have removed all `React.FC` type usages from `APISection` components. A while ago we have conversation about this with @byCedric during the docs redesign discussions and it looks like `React.FC` is no longer recommended approach to typing functional components.

# Test Plan

The changes have been tested by running docs website on `localhost`.

# Example

<img width="1144" alt="Screenshot 2021-09-21 at 17 46 19" src="https://user-images.githubusercontent.com/719641/134225805-d8e02b7b-a2f7-4896-96ff-7829d1bc284e.png">
