### PR TITLE
[babel] Added no-anonymous-default-export babel plugin

### DIFF
--- a/packages/babel-preset-expo/README.md
+++ b/packages/babel-preset-expo/README.md
@@ -51,6 +51,17 @@ If the `bundler` is not defined, it will default to checking if a `babel-loader`
 
 This property is passed down to [`@babel/plugin-transform-react-jsx`](https://babeljs.io/docs/en/babel-plugin-transform-react-jsx). This flag does nothing when `native.useTransformReactJSXExperimental` is set to `true` because `@babel/plugin-transform-react-jsx` is omitted.
 
+### [`no-anonymous-default-export`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-anonymous-default-export.md)
+
+`false | undefined`, defaults to `undefined`
+
+- `false` disable the `no-anonymous-default-export` babel plugin.
+
+This property is used to configure or disable the Babel plugin [`no-anonymous-default-export`](./plugins/no-anonymous-default-export.js). This plugin warns the user to remove any anonymous functions as default exports (specifically as a React component). The transform helps to avoid the main pitfall of React Refresh (AKA Fast Refresh), which prevents the runtime from storing updates on anonymous functional components.
+
+This babel plugin will only be enabled with specific Metro transformers or Webpack `babel-loader`s, that add the `onWarning` Babel caller.
+Currently this is only done in `@expo/metro-config` when the experimental `EXPO_USE_EXOTIC` environment variable is enabled.
+
 ### [`lazyImports`](https://babeljs.io/docs/en/babel-plugin-transform-modules-commonjs#lazy)
 
 Changes Babel's compiled `import` statements to be lazily evaluated when their imported bindings are used for the first time.

--- a/packages/babel-preset-expo/__tests__/__snapshots__/index-test.js.snap
+++ b/packages/babel-preset-expo/__tests__/__snapshots__/index-test.js.snap
@@ -17,8 +17,8 @@ require(\\"../i-also-have-side-effects.fx\\");
 function _inlineFuncWithSideEffectsFx(){var data=_interopRequireDefault(require(\\"../inline-func-with-side-effects.fx.ts\\"));_inlineFuncWithSideEffectsFx=function _inlineFuncWithSideEffectsFx(){return data;};return data;}
 function _inlineFunc(){var data=_interopRequireDefault(require(\\"./inline-func\\"));_inlineFunc=function _inlineFunc(){return data;};return data;}function _getRequireWildcardCache(nodeInterop){if(typeof WeakMap!==\\"function\\")return null;var cacheBabelInterop=new WeakMap();var cacheNodeInterop=new WeakMap();return(_getRequireWildcardCache=function _getRequireWildcardCache(nodeInterop){return nodeInterop?cacheNodeInterop:cacheBabelInterop;})(nodeInterop);}function _interopRequireWildcard(obj,nodeInterop){if(!nodeInterop&&obj&&obj.__esModule){return obj;}if(obj===null||typeof obj!==\\"object\\"&&typeof obj!==\\"function\\"){return{default:obj};}var cache=_getRequireWildcardCache(nodeInterop);if(cache&&cache.has(obj)){return cache.get(obj);}var newObj={};var hasPropertyDescriptor=Object.defineProperty&&Object.getOwnPropertyDescriptor;for(var key in obj){if(key!==\\"default\\"&&Object.prototype.hasOwnProperty.call(obj,key)){var desc=hasPropertyDescriptor?Object.getOwnPropertyDescriptor(obj,key):null;if(desc&&(desc.get||desc.set)){Object.defineProperty(newObj,key,desc);}else{newObj[key]=obj[key];}}}newObj.default=obj;if(cache){cache.set(obj,newObj);}return newObj;}function _createSuper(Derived){var hasNativeReflectConstruct=_isNativeReflectConstruct();return function _createSuperInternal(){var Super=(0,_getPrototypeOf2.default)(Derived),result;if(hasNativeReflectConstruct){var NewTarget=(0,_getPrototypeOf2.default)(this).constructor;result=Reflect.construct(Super,arguments,NewTarget);}else{result=Super.apply(this,arguments);}return(0,_possibleConstructorReturn2.default)(this,result);};}function _isNativeReflectConstruct(){if(typeof Reflect===\\"undefined\\"||!Reflect.construct)return false;if(Reflect.construct.sham)return false;if(typeof Proxy===\\"function\\")return true;try{Boolean.prototype.valueOf.call(Reflect.construct(Boolean,[],function(){}));return true;}catch(e){return false;}}var
 
-Lazy=function(_React$Component){(0,_inherits2.default)(Lazy,_React$Component);var _super=_createSuper(Lazy);function Lazy(){(0,_classCallCheck2.default)(this,Lazy);return _super.apply(this,arguments);}(0,_createClass2.default)(Lazy,[{key:\\"componentDidMount\\",value:function componentDidMount()
-{
+Lazy=function(_React$Component){(0,_inherits2.default)(Lazy,_React$Component);var _super=_createSuper(Lazy);function Lazy(){(0,_classCallCheck2.default)(this,Lazy);return _super.apply(this,arguments);}(0,_createClass2.default)(Lazy,[{key:\\"componentDidMount\\",value:
+function componentDidMount(){
 console.log('Calling InlineFuncFromPackage()');
 (0,_inlineComp().default)();
 
@@ -29,9 +29,9 @@ console.log('Calling Boo.myFunc()');
 Boo.myFunc();
 
 _expoAsset.Asset.loadAsync([require(\\"./assets/icon.png\\")]);
-}},{key:\\"render\\",value:function render()
+}},{key:\\"render\\",value:
 
-{
+function render(){
 return(
 _react.default.createElement(_reactNative.View,null,
 _react.default.createElement(_expoAppLoading.default,null),
@@ -39,9 +39,9 @@ _react.default.createElement(_vectorIcons.Ionicons,{name:\\"md-options\\",size:2
 _react.default.createElement(_fooView.default,null)));
 
 
-}},{key:\\"unusedFunction\\",value:function unusedFunction()
+}},{key:\\"unusedFunction\\",value:
 
-{
+function unusedFunction(){
 (0,_inlineFuncWithSideEffectsFx().default)();
 }}]);return Lazy;}(_react.default.Component);var _default=
 
@@ -66,8 +66,8 @@ require(\\"../i-also-have-side-effects.fx\\");
 var _inlineFuncWithSideEffectsFx=_interopRequireDefault(require(\\"../inline-func-with-side-effects.fx.ts\\"));
 function _inlineFunc(){var data=_interopRequireDefault(require(\\"./inline-func\\"));_inlineFunc=function _inlineFunc(){return data;};return data;}function _getRequireWildcardCache(nodeInterop){if(typeof WeakMap!==\\"function\\")return null;var cacheBabelInterop=new WeakMap();var cacheNodeInterop=new WeakMap();return(_getRequireWildcardCache=function _getRequireWildcardCache(nodeInterop){return nodeInterop?cacheNodeInterop:cacheBabelInterop;})(nodeInterop);}function _interopRequireWildcard(obj,nodeInterop){if(!nodeInterop&&obj&&obj.__esModule){return obj;}if(obj===null||typeof obj!==\\"object\\"&&typeof obj!==\\"function\\"){return{default:obj};}var cache=_getRequireWildcardCache(nodeInterop);if(cache&&cache.has(obj)){return cache.get(obj);}var newObj={};var hasPropertyDescriptor=Object.defineProperty&&Object.getOwnPropertyDescriptor;for(var key in obj){if(key!==\\"default\\"&&Object.prototype.hasOwnProperty.call(obj,key)){var desc=hasPropertyDescriptor?Object.getOwnPropertyDescriptor(obj,key):null;if(desc&&(desc.get||desc.set)){Object.defineProperty(newObj,key,desc);}else{newObj[key]=obj[key];}}}newObj.default=obj;if(cache){cache.set(obj,newObj);}return newObj;}function _createSuper(Derived){var hasNativeReflectConstruct=_isNativeReflectConstruct();return function _createSuperInternal(){var Super=(0,_getPrototypeOf2().default)(Derived),result;if(hasNativeReflectConstruct){var NewTarget=(0,_getPrototypeOf2().default)(this).constructor;result=Reflect.construct(Super,arguments,NewTarget);}else{result=Super.apply(this,arguments);}return(0,_possibleConstructorReturn2().default)(this,result);};}function _isNativeReflectConstruct(){if(typeof Reflect===\\"undefined\\"||!Reflect.construct)return false;if(Reflect.construct.sham)return false;if(typeof Proxy===\\"function\\")return true;try{Boolean.prototype.valueOf.call(Reflect.construct(Boolean,[],function(){}));return true;}catch(e){return false;}}var
 
-Lazy=function(_React$Component){(0,_inherits2().default)(Lazy,_React$Component);var _super=_createSuper(Lazy);function Lazy(){(0,_classCallCheck2().default)(this,Lazy);return _super.apply(this,arguments);}(0,_createClass2().default)(Lazy,[{key:\\"componentDidMount\\",value:function componentDidMount()
-{
+Lazy=function(_React$Component){(0,_inherits2().default)(Lazy,_React$Component);var _super=_createSuper(Lazy);function Lazy(){(0,_classCallCheck2().default)(this,Lazy);return _super.apply(this,arguments);}(0,_createClass2().default)(Lazy,[{key:\\"componentDidMount\\",value:
+function componentDidMount(){
 console.log('Calling InlineFuncFromPackage()');
 (0,_inlineComp().default)();
 
@@ -78,9 +78,9 @@ console.log('Calling Boo.myFunc()');
 Boo().myFunc();
 
 _expoAsset().Asset.loadAsync([require(\\"./assets/icon.png\\")]);
-}},{key:\\"render\\",value:function render()
+}},{key:\\"render\\",value:
 
-{
+function render(){
 return(
 _react().default.createElement(_reactNative().View,null,
 _react().default.createElement(_expoAppLoading().default,null),
@@ -88,9 +88,9 @@ _react().default.createElement(_vectorIcons().Ionicons,{name:\\"md-options\\",si
 _react().default.createElement(_fooView().default,null)));
 
 
-}},{key:\\"unusedFunction\\",value:function unusedFunction()
+}},{key:\\"unusedFunction\\",value:
 
-{
+function unusedFunction(){
 (0,_inlineFuncWithSideEffectsFx.default)();
 }}]);return Lazy;}(_react().default.Component);var _default=
 
@@ -115,8 +115,8 @@ require(\\"../i-also-have-side-effects.fx\\");
 var _inlineFuncWithSideEffectsFx=_interopRequireDefault(require(\\"../inline-func-with-side-effects.fx.ts\\"));
 var _inlineFunc=_interopRequireDefault(require(\\"./inline-func\\"));function _getRequireWildcardCache(nodeInterop){if(typeof WeakMap!==\\"function\\")return null;var cacheBabelInterop=new WeakMap();var cacheNodeInterop=new WeakMap();return(_getRequireWildcardCache=function _getRequireWildcardCache(nodeInterop){return nodeInterop?cacheNodeInterop:cacheBabelInterop;})(nodeInterop);}function _interopRequireWildcard(obj,nodeInterop){if(!nodeInterop&&obj&&obj.__esModule){return obj;}if(obj===null||typeof obj!==\\"object\\"&&typeof obj!==\\"function\\"){return{default:obj};}var cache=_getRequireWildcardCache(nodeInterop);if(cache&&cache.has(obj)){return cache.get(obj);}var newObj={};var hasPropertyDescriptor=Object.defineProperty&&Object.getOwnPropertyDescriptor;for(var key in obj){if(key!==\\"default\\"&&Object.prototype.hasOwnProperty.call(obj,key)){var desc=hasPropertyDescriptor?Object.getOwnPropertyDescriptor(obj,key):null;if(desc&&(desc.get||desc.set)){Object.defineProperty(newObj,key,desc);}else{newObj[key]=obj[key];}}}newObj.default=obj;if(cache){cache.set(obj,newObj);}return newObj;}function _createSuper(Derived){var hasNativeReflectConstruct=_isNativeReflectConstruct();return function _createSuperInternal(){var Super=(0,_getPrototypeOf2.default)(Derived),result;if(hasNativeReflectConstruct){var NewTarget=(0,_getPrototypeOf2.default)(this).constructor;result=Reflect.construct(Super,arguments,NewTarget);}else{result=Super.apply(this,arguments);}return(0,_possibleConstructorReturn2.default)(this,result);};}function _isNativeReflectConstruct(){if(typeof Reflect===\\"undefined\\"||!Reflect.construct)return false;if(Reflect.construct.sham)return false;if(typeof Proxy===\\"function\\")return true;try{Boolean.prototype.valueOf.call(Reflect.construct(Boolean,[],function(){}));return true;}catch(e){return false;}}var
 
-Lazy=function(_React$Component){(0,_inherits2.default)(Lazy,_React$Component);var _super=_createSuper(Lazy);function Lazy(){(0,_classCallCheck2.default)(this,Lazy);return _super.apply(this,arguments);}(0,_createClass2.default)(Lazy,[{key:\\"componentDidMount\\",value:function componentDidMount()
-{
+Lazy=function(_React$Component){(0,_inherits2.default)(Lazy,_React$Component);var _super=_createSuper(Lazy);function Lazy(){(0,_classCallCheck2.default)(this,Lazy);return _super.apply(this,arguments);}(0,_createClass2.default)(Lazy,[{key:\\"componentDidMount\\",value:
+function componentDidMount(){
 console.log('Calling InlineFuncFromPackage()');
 (0,_inlineComp.default)();
 
@@ -127,9 +127,9 @@ console.log('Calling Boo.myFunc()');
 Boo.myFunc();
 
 _expoAsset.Asset.loadAsync([require(\\"./assets/icon.png\\")]);
-}},{key:\\"render\\",value:function render()
+}},{key:\\"render\\",value:
 
-{
+function render(){
 return(
 _react.default.createElement(_reactNative.View,null,
 _react.default.createElement(_expoAppLoading.default,null),
@@ -137,9 +137,9 @@ _react.default.createElement(_vectorIcons.Ionicons,{name:\\"md-options\\",size:2
 _react.default.createElement(_fooView.default,null)));
 
 
-}},{key:\\"unusedFunction\\",value:function unusedFunction()
+}},{key:\\"unusedFunction\\",value:
 
-{
+function unusedFunction(){
 (0,_inlineFuncWithSideEffectsFx.default)();
 }}]);return Lazy;}(_react.default.Component);var _default=
 
@@ -164,8 +164,8 @@ require(\\"../i-also-have-side-effects.fx\\");
 var _inlineFuncWithSideEffectsFx=_interopRequireDefault(require(\\"../inline-func-with-side-effects.fx.ts\\"));
 var _inlineFunc=_interopRequireDefault(require(\\"./inline-func\\"));function _getRequireWildcardCache(nodeInterop){if(typeof WeakMap!==\\"function\\")return null;var cacheBabelInterop=new WeakMap();var cacheNodeInterop=new WeakMap();return(_getRequireWildcardCache=function _getRequireWildcardCache(nodeInterop){return nodeInterop?cacheNodeInterop:cacheBabelInterop;})(nodeInterop);}function _interopRequireWildcard(obj,nodeInterop){if(!nodeInterop&&obj&&obj.__esModule){return obj;}if(obj===null||typeof obj!==\\"object\\"&&typeof obj!==\\"function\\"){return{default:obj};}var cache=_getRequireWildcardCache(nodeInterop);if(cache&&cache.has(obj)){return cache.get(obj);}var newObj={};var hasPropertyDescriptor=Object.defineProperty&&Object.getOwnPropertyDescriptor;for(var key in obj){if(key!==\\"default\\"&&Object.prototype.hasOwnProperty.call(obj,key)){var desc=hasPropertyDescriptor?Object.getOwnPropertyDescriptor(obj,key):null;if(desc&&(desc.get||desc.set)){Object.defineProperty(newObj,key,desc);}else{newObj[key]=obj[key];}}}newObj.default=obj;if(cache){cache.set(obj,newObj);}return newObj;}function _createSuper(Derived){var hasNativeReflectConstruct=_isNativeReflectConstruct();return function _createSuperInternal(){var Super=(0,_getPrototypeOf2.default)(Derived),result;if(hasNativeReflectConstruct){var NewTarget=(0,_getPrototypeOf2.default)(this).constructor;result=Reflect.construct(Super,arguments,NewTarget);}else{result=Super.apply(this,arguments);}return(0,_possibleConstructorReturn2.default)(this,result);};}function _isNativeReflectConstruct(){if(typeof Reflect===\\"undefined\\"||!Reflect.construct)return false;if(Reflect.construct.sham)return false;if(typeof Proxy===\\"function\\")return true;try{Boolean.prototype.valueOf.call(Reflect.construct(Boolean,[],function(){}));return true;}catch(e){return false;}}var
 
-Lazy=function(_React$Component){(0,_inherits2.default)(Lazy,_React$Component);var _super=_createSuper(Lazy);function Lazy(){(0,_classCallCheck2.default)(this,Lazy);return _super.apply(this,arguments);}(0,_createClass2.default)(Lazy,[{key:\\"componentDidMount\\",value:function componentDidMount()
-{
+Lazy=function(_React$Component){(0,_inherits2.default)(Lazy,_React$Component);var _super=_createSuper(Lazy);function Lazy(){(0,_classCallCheck2.default)(this,Lazy);return _super.apply(this,arguments);}(0,_createClass2.default)(Lazy,[{key:\\"componentDidMount\\",value:
+function componentDidMount(){
 console.log('Calling InlineFuncFromPackage()');
 (0,_inlineComp.default)();
 
@@ -176,9 +176,9 @@ console.log('Calling Boo.myFunc()');
 Boo.myFunc();
 
 _expoAsset.Asset.loadAsync([require(\\"./assets/icon.png\\")]);
-}},{key:\\"render\\",value:function render()
+}},{key:\\"render\\",value:
 
-{
+function render(){
 return(
 _react.default.createElement(_reactNative.View,null,
 _react.default.createElement(_expoAppLoading.default,null),
@@ -186,9 +186,9 @@ _react.default.createElement(_vectorIcons.Ionicons,{name:\\"md-options\\",size:2
 _react.default.createElement(_fooView.default,null)));
 
 
-}},{key:\\"unusedFunction\\",value:function unusedFunction()
+}},{key:\\"unusedFunction\\",value:
 
-{
+function unusedFunction(){
 (0,_inlineFuncWithSideEffectsFx.default)();
 }}]);return Lazy;}(_react.default.Component);var _default=
 
@@ -213,8 +213,8 @@ require(\\"../i-also-have-side-effects.fx\\");
 var _inlineFuncWithSideEffectsFx=_interopRequireDefault(require(\\"../inline-func-with-side-effects.fx.ts\\"));
 var _inlineFunc=_interopRequireDefault(require(\\"./inline-func\\"));function _getRequireWildcardCache(nodeInterop){if(typeof WeakMap!==\\"function\\")return null;var cacheBabelInterop=new WeakMap();var cacheNodeInterop=new WeakMap();return(_getRequireWildcardCache=function _getRequireWildcardCache(nodeInterop){return nodeInterop?cacheNodeInterop:cacheBabelInterop;})(nodeInterop);}function _interopRequireWildcard(obj,nodeInterop){if(!nodeInterop&&obj&&obj.__esModule){return obj;}if(obj===null||typeof obj!==\\"object\\"&&typeof obj!==\\"function\\"){return{default:obj};}var cache=_getRequireWildcardCache(nodeInterop);if(cache&&cache.has(obj)){return cache.get(obj);}var newObj={};var hasPropertyDescriptor=Object.defineProperty&&Object.getOwnPropertyDescriptor;for(var key in obj){if(key!==\\"default\\"&&Object.prototype.hasOwnProperty.call(obj,key)){var desc=hasPropertyDescriptor?Object.getOwnPropertyDescriptor(obj,key):null;if(desc&&(desc.get||desc.set)){Object.defineProperty(newObj,key,desc);}else{newObj[key]=obj[key];}}}newObj.default=obj;if(cache){cache.set(obj,newObj);}return newObj;}function _createSuper(Derived){var hasNativeReflectConstruct=_isNativeReflectConstruct();return function _createSuperInternal(){var Super=(0,_getPrototypeOf2().default)(Derived),result;if(hasNativeReflectConstruct){var NewTarget=(0,_getPrototypeOf2().default)(this).constructor;result=Reflect.construct(Super,arguments,NewTarget);}else{result=Super.apply(this,arguments);}return(0,_possibleConstructorReturn2().default)(this,result);};}function _isNativeReflectConstruct(){if(typeof Reflect===\\"undefined\\"||!Reflect.construct)return false;if(Reflect.construct.sham)return false;if(typeof Proxy===\\"function\\")return true;try{Boolean.prototype.valueOf.call(Reflect.construct(Boolean,[],function(){}));return true;}catch(e){return false;}}var
 
-Lazy=function(_React$Component){(0,_inherits2().default)(Lazy,_React$Component);var _super=_createSuper(Lazy);function Lazy(){(0,_classCallCheck2().default)(this,Lazy);return _super.apply(this,arguments);}(0,_createClass2().default)(Lazy,[{key:\\"componentDidMount\\",value:function componentDidMount()
-{
+Lazy=function(_React$Component){(0,_inherits2().default)(Lazy,_React$Component);var _super=_createSuper(Lazy);function Lazy(){(0,_classCallCheck2().default)(this,Lazy);return _super.apply(this,arguments);}(0,_createClass2().default)(Lazy,[{key:\\"componentDidMount\\",value:
+function componentDidMount(){
 console.log('Calling InlineFuncFromPackage()');
 (0,_inlineComp().default)();
 
@@ -225,9 +225,9 @@ console.log('Calling Boo.myFunc()');
 Boo().myFunc();
 
 _expoAsset.Asset.loadAsync([require(\\"./assets/icon.png\\")]);
-}},{key:\\"render\\",value:function render()
+}},{key:\\"render\\",value:
 
-{
+function render(){
 return(
 _react().default.createElement(_reactNative().View,null,
 _react().default.createElement(_expoAppLoading().default,null),
@@ -235,9 +235,9 @@ _react().default.createElement(_vectorIcons().Ionicons,{name:\\"md-options\\",si
 _react().default.createElement(_fooView().default,null)));
 
 
-}},{key:\\"unusedFunction\\",value:function unusedFunction()
+}},{key:\\"unusedFunction\\",value:
 
-{
+function unusedFunction(){
 (0,_inlineFuncWithSideEffectsFx.default)();
 }}]);return Lazy;}(_react().default.Component);var _default=
 

--- a/packages/babel-preset-expo/__tests__/no-anonymous-default-export-test.js
+++ b/packages/babel-preset-expo/__tests__/no-anonymous-default-export-test.js
@@ -1,0 +1,60 @@
+const babel = require('@babel/core');
+
+function createOptions() {
+  const plugin = require('../plugins/no-anonymous-default-export');
+  const options = {
+    babelrc: false,
+    plugins: [plugin],
+    filename: 'unknown',
+    caller: {
+      name: 'metro',
+    },
+  };
+  // Surface a warning function so babel linters can be used.
+  Object.defineProperty(options.caller, 'onWarning', {
+    enumerable: false,
+    writable: false,
+    value: jest.fn(),
+  });
+  return options;
+}
+
+let options = createOptions();
+
+it(`Warns about default export as a function`, () => {
+  const sourceCode = `export default function () {}`;
+
+  const { code } = babel.transform(sourceCode, options);
+  // no transform
+  expect(code).toBe(sourceCode);
+  // warnings were sent
+  expect(options.caller.onWarning).toHaveBeenLastCalledWith(
+    expect.stringMatching(
+      /Anonymous functions cannot be used as React components with React Refresh/
+    )
+  );
+});
+
+it(`Warns about default export as an anonymous function`, () => {
+  const sourceCode = `export default (() => {});`;
+
+  const { code } = babel.transform(sourceCode, options);
+  // no transform
+  expect(code).toBe(sourceCode);
+  // warnings were sent
+  expect(options.caller.onWarning).toHaveBeenLastCalledWith(
+    expect.stringMatching(
+      /Anonymous arrow functions cannot be used as React components with React Refresh/
+    )
+  );
+});
+
+it(`Does not warn about named default export`, () => {
+  const sourceCode = `export default function Custom() {}`;
+  options = createOptions();
+  const { code } = babel.transform(sourceCode, options);
+  // no transform
+  expect(code).toBe(sourceCode);
+  // warnings were sent
+  expect(options.caller.onWarning).toHaveBeenCalledTimes(0);
+});

--- a/packages/babel-preset-expo/index.js
+++ b/packages/babel-preset-expo/index.js
@@ -102,6 +102,10 @@ module.exports = function (api, options = {}) {
       [require.resolve('@babel/plugin-proposal-decorators'), { legacy: true }],
       platform === 'web' && [require.resolve('babel-plugin-react-native-web')],
       isWebpack && platform !== 'web' && [require.resolve('./plugins/disable-ambiguous-requires')],
+      // Allow users to disable this plugin with [ 'no-anonymous-default-export': false ]
+      // by default the plugin won't be enabled unless the bundler provides `onWarning` in the caller.
+      options['no-anonymous-default-export'] !== false &&
+        require.resolve('./plugins/no-anonymous-default-export'),
     ].filter(Boolean),
   };
 };

--- a/packages/babel-preset-expo/plugins/no-anonymous-default-export.js
+++ b/packages/babel-preset-expo/plugins/no-anonymous-default-export.js
@@ -46,7 +46,7 @@ function getLogger(caller) {
  *
  */
 module.exports = function ({ types, ...babel }) {
-  let onWarning = getLogger(babel.caller);
+  const onWarning = getLogger(babel.caller);
   if (typeof onWarning !== 'function') {
     return { visitor: {} };
   }

--- a/packages/babel-preset-expo/plugins/no-anonymous-default-export.js
+++ b/packages/babel-preset-expo/plugins/no-anonymous-default-export.js
@@ -1,0 +1,106 @@
+// Borrows from Next.js, modified to work in certain Metro environments (exotic transformer)
+// https://github.com/vercel/next.js/blob/canary/packages/next/build/babel/plugins/no-anonymous-default-export.ts
+
+const chalk = require('chalk');
+
+// Anonymous functions cannot be used as React components with React Refresh.
+// Ensure your function is named, then refresh the app:
+//
+// export default function () { /* ... */ }
+//
+//       ↓ ↓ ↓ ↓ ↓ ↓
+//
+// export default function Named() { /* ... */ }
+//
+function logLintWarning(log, title, before, after) {
+  log(
+    [
+      chalk.yellow.bold(title),
+      'Ensure your function is named, then refresh the app:',
+      '',
+      before,
+      '',
+      chalk.bold('      ↓ ↓ ↓ ↓ ↓ ↓      '),
+      '',
+      after,
+      '',
+    ].join('\n')
+  );
+}
+
+function getLogger(caller) {
+  let onWarning;
+  caller((caller) => {
+    onWarning = caller.onWarning;
+    // Prevent updating the cache.
+    return '';
+  });
+  return onWarning;
+}
+
+/**
+ * Provide a linting warning about React Refresh using anonymous functions.
+ *
+ * Without this operation, users will notice that their development client will say
+ * it was "Fast Refreshed" but no changes will occur.
+ *
+ */
+module.exports = function ({ types, ...babel }) {
+  let onWarning = getLogger(babel.caller);
+  if (typeof onWarning !== 'function') {
+    return { visitor: {} };
+  }
+  return {
+    visitor: {
+      ExportDefaultDeclaration({ node: { declaration } }) {
+        switch (declaration.type) {
+          case 'ArrowFunctionExpression': {
+            logLintWarning(
+              onWarning,
+              'Anonymous arrow functions cannot be used as React components with React Refresh.',
+              // export default () => <View />
+              chalk.magenta`export default` +
+                ' () ' +
+                chalk.magenta`=> ` +
+                '<' +
+                chalk.cyanBright`View` +
+                ' />',
+              // const Custom = () => <View />
+              chalk.magenta`const ` +
+                chalk.greenBright`Custom` +
+                chalk.magenta` =` +
+                ' () ' +
+                chalk.magenta`=> ` +
+                '<' +
+                chalk.cyanBright`View` +
+                ' />' +
+                '\n' +
+                // export default Custom
+                chalk.magenta`export default ` +
+                chalk.greenBright`Custom`
+            );
+            break;
+          }
+          case 'FunctionDeclaration': {
+            const isAnonymous = !declaration.id;
+            if (isAnonymous) {
+              logLintWarning(
+                onWarning,
+                'Anonymous functions cannot be used as React components with React Refresh.',
+                // export default function () { /* ... */ }
+                chalk.magenta`export default function ` + '() { ' + chalk.dim`/* ... */ ` + '}',
+                // export default function Named() { /* ... */ }
+                chalk.magenta`export default function ` +
+                  chalk.greenBright`Named` +
+                  '() { ' +
+                  chalk.dim`/* ... */ ` +
+                  '}'
+              );
+            }
+            break;
+          }
+        }
+      },
+    },
+  };
+};

--- a/packages/babel-preset-expo/plugins/no-anonymous-default-export.js
+++ b/packages/babel-preset-expo/plugins/no-anonymous-default-export.js
@@ -30,7 +30,7 @@ function logLintWarning(log, title, before, after) {
 
 function getLogger(caller) {
   let onWarning;
-  caller((caller) => {
+  caller((caller = {}) => {
     onWarning = caller.onWarning;
     // Prevent updating the cache.
     return '';


### PR DESCRIPTION
# Why

- We can now use complex babel plugins with the exotic transformer. This plugin will be disabled when used with the default transformer, as it doesn't define the `onWarning` caller property.
- This particular React Refresh pitfall is quite annoying.

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How

- Added a babel plugin to warn the user when they're using an anonymous function as a default export.

<img width="553" alt="Screen Shot 2021-09-21 at 2 55 40 PM" src="https://user-images.githubusercontent.com/9664363/134246351-e4556c93-4df5-416e-be37-50bd8b685833.png">


# Test Plan

- Add this plugin, and run `EXPO_USE_EXOTIC=1 expo start -c` with the latest Expo CLI. Be sure to have an anon function component.
- [x] Unit test