### PR TITLE
[ios] Fix registering native event emitter module

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fix imports that affect versioned code inside of Expo Go. ([#14436](https://github.com/expo/expo/pull/14436) by [@cruzach](https://github.com/cruzach))
+- Fixed event emitter being registered after module registry initialization. ([#14502](https://github.com/expo/expo/pull/14502) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/NativeModulesProxy/EXNativeModulesProxy.m
+++ b/packages/expo-modules-core/ios/NativeModulesProxy/EXNativeModulesProxy.m
@@ -237,10 +237,6 @@ RCT_EXPORT_METHOD(callMethod:(NSString *)moduleName methodNameOrKey:(id)methodNa
     }
   }
 
-  // Let the modules consume the registry :)
-  // It calls `setModuleRegistry:` on all `EXModuleRegistryConsumer`s.
-  [_exModuleRegistry initialize];
-
   // Register the view managers as additional modules.
   [bridge registerAdditionalModuleClasses:additionalModuleClasses];
 
@@ -251,7 +247,10 @@ RCT_EXPORT_METHOD(callMethod:(NSString *)moduleName methodNameOrKey:(id)methodNa
   // Get the newly created instance of `EXReactEventEmitter` bridge module and register it in expo modules registry.
   EXReactNativeEventEmitter *eventEmitter = [bridge moduleForClass:[EXReactNativeEventEmitter class]];
   [_exModuleRegistry registerInternalModule:eventEmitter];
-  [eventEmitter setModuleRegistry:_exModuleRegistry];
+
+  // Let the modules consume the registry :)
+  // It calls `setModuleRegistry:` on all `EXModuleRegistryConsumer`s.
+  [_exModuleRegistry initialize];
 }
 
 - (void)registerComponentDataForModuleClasses:(NSArray<Class> *)moduleClasses inBridge:(RCTBridge *)bridge


### PR DESCRIPTION
# Why

It turned out that after merging #14132 some modules are not able to send native events to JS. The problem is that now we register the event emitter *after* all other modules are registered, so modules shouldn't save the emitter in `setModuleRegistry` because it might be not initialized yet.

# How

The workaround is to dynamically get the emitter when we need to send an event, instead of saving it as a property on module's initialization phase.

# Test Plan

Related issues in test-suite are now passing
