### PR TITLE
[ios] backport relevant changes from #14460 to versioned EXManifests

### DIFF
--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXManifests/EXManifests/ABI40_0_0EXManifestsBaseManifest.h
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXManifests/EXManifests/ABI40_0_0EXManifestsBaseManifest.h
@@ -18,6 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSString *)slug;
 - (nullable NSString *)appKey;
 - (nullable NSString *)name;
+- (nullable NSString *)version;
 - (nullable NSDictionary *)notificationPreferences;
 - (nullable NSDictionary *)updatesInfo;
 - (nullable NSDictionary *)iosConfig;

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXManifests/EXManifests/ABI40_0_0EXManifestsBaseManifest.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXManifests/EXManifests/ABI40_0_0EXManifestsBaseManifest.m
@@ -55,6 +55,14 @@
   return [expoClientConfig nullableStringForKey:@"name"];
 }
 
+- (nullable NSString *)version {
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [expoClientConfig nullableStringForKey:@"version"];
+}
+
 - (nullable NSDictionary *)notificationPreferences {
   NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
   if (!expoClientConfig) {

--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXManifests/EXManifests/ABI40_0_0EXManifestsManifest.h
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXManifests/EXManifests/ABI40_0_0EXManifestsManifest.h
@@ -48,6 +48,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSString *)slug;
 - (nullable NSString *)appKey;
 - (nullable NSString *)name;
+- (nullable NSString *)version;
 - (nullable NSDictionary *)notificationPreferences;
 - (nullable NSDictionary *)updatesInfo;
 - (nullable NSDictionary *)iosConfig;

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXManifests/EXManifests/ABI41_0_0EXManifestsBaseManifest.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXManifests/EXManifests/ABI41_0_0EXManifestsBaseManifest.h
@@ -18,6 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSString *)slug;
 - (nullable NSString *)appKey;
 - (nullable NSString *)name;
+- (nullable NSString *)version;
 - (nullable NSDictionary *)notificationPreferences;
 - (nullable NSDictionary *)updatesInfo;
 - (nullable NSDictionary *)iosConfig;

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXManifests/EXManifests/ABI41_0_0EXManifestsBaseManifest.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXManifests/EXManifests/ABI41_0_0EXManifestsBaseManifest.m
@@ -55,6 +55,14 @@
   return [expoClientConfig nullableStringForKey:@"name"];
 }
 
+- (nullable NSString *)version {
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [expoClientConfig nullableStringForKey:@"version"];
+}
+
 - (nullable NSDictionary *)notificationPreferences {
   NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
   if (!expoClientConfig) {

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXManifests/EXManifests/ABI41_0_0EXManifestsManifest.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXManifests/EXManifests/ABI41_0_0EXManifestsManifest.h
@@ -48,6 +48,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSString *)slug;
 - (nullable NSString *)appKey;
 - (nullable NSString *)name;
+- (nullable NSString *)version;
 - (nullable NSDictionary *)notificationPreferences;
 - (nullable NSDictionary *)updatesInfo;
 - (nullable NSDictionary *)iosConfig;

--- a/ios/versioned-react-native/ABI42_0_0/Expo/EXManifests/EXManifests/ABI42_0_0EXManifestsBaseManifest.h
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/EXManifests/EXManifests/ABI42_0_0EXManifestsBaseManifest.h
@@ -18,6 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSString *)slug;
 - (nullable NSString *)appKey;
 - (nullable NSString *)name;
+- (nullable NSString *)version;
 - (nullable NSDictionary *)notificationPreferences;
 - (nullable NSDictionary *)updatesInfo;
 - (nullable NSDictionary *)iosConfig;

--- a/ios/versioned-react-native/ABI42_0_0/Expo/EXManifests/EXManifests/ABI42_0_0EXManifestsBaseManifest.m
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/EXManifests/EXManifests/ABI42_0_0EXManifestsBaseManifest.m
@@ -55,6 +55,14 @@
   return [expoClientConfig nullableStringForKey:@"name"];
 }
 
+- (nullable NSString *)version {
+  NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
+  if (!expoClientConfig) {
+    return nil;
+  }
+  return [expoClientConfig nullableStringForKey:@"version"];
+}
+
 - (nullable NSDictionary *)notificationPreferences {
   NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
   if (!expoClientConfig) {

--- a/ios/versioned-react-native/ABI42_0_0/Expo/EXManifests/EXManifests/ABI42_0_0EXManifestsManifest.h
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/EXManifests/EXManifests/ABI42_0_0EXManifestsManifest.h
@@ -48,6 +48,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSString *)slug;
 - (nullable NSString *)appKey;
 - (nullable NSString *)name;
+- (nullable NSString *)version;
 - (nullable NSDictionary *)notificationPreferences;
 - (nullable NSDictionary *)updatesInfo;
 - (nullable NSDictionary *)iosConfig;


### PR DESCRIPTION
# Why

https://github.com/expo/expo/pull/14460#discussion_r712347011

# How

backport relevant changes manually

# Test Plan

Expo Go (versioned target) should build successfully; no code in Expo Go uses these new getters so this should be enough of a test

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).