### PR TITLE
[ios][tools] Fix shell app building errors

### DIFF
--- a/template-files/ios/ExpoKit-Podfile-versioned
+++ b/template-files/ios/ExpoKit-Podfile-versioned
@@ -7,6 +7,7 @@ ${PODFILE_UNVERSIONED_RN_DEPENDENCY}
 ${PODFILE_VERSIONED_RN_DEPENDENCIES}
 
   # Install vendored pods.
+  pod 'JKBigInteger', :podspec => '../../../ios/vendored/common/JKBigInteger.podspec.json'
   require_relative '../../../ios/podfile_helpers.rb'
   excluded_pods = ['stripe-react-native']
   use_pods!('../../../ios/vendored/unversioned/**/*.podspec.json', nil, excluded_pods)

--- a/tools/src/commands/IosShellApp.ts
+++ b/tools/src/commands/IosShellApp.ts
@@ -40,6 +40,8 @@ async function action(providedOptions: ActionOptions) {
   };
 
   if (options.action === 'build') {
+    // in building shell apps, `app.manifest` in expo-updates is not necessary.
+    process.env['SKIP_BUNDLING'] = '1';
     return await IosShellApp.buildAndCopyArtifactAsync(options);
   } else if (options.action === 'configure') {
     return await IosShellApp.configureAndCopyArchiveAsync(options);


### PR DESCRIPTION
# Why

fix ios shell app building errors:
1. `JKBigInteger` pod dependency not found
2. expo-updates build phase script `createManifest.js` error

# How

i tried not to touch @expo/xdl, so update in expo repo as more as possible.
1. add `JKBigInteger` pod in ios shell app Podfile template.
2. add `SKIP_BUNDLING` into environment variable and skip `createManifest.js` operation.

# Test Plan

ios shell app ci passed: https://github.com/expo/expo/runs/3673639353


# Checklist

- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).