### PR TITLE
[docs] update platforms data for picker and intent launcher

### DIFF
--- a/docs/pages/versions/unversioned/sdk/intent-launcher.md
+++ b/docs/pages/versions/unversioned/sdk/intent-launcher.md
@@ -9,7 +9,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`expo-intent-launcher`** provides a way to launch Android intents. For example, you can use this API to open a specific settings screen.
 
-<PlatformsSection android emulator ios simulator />
+<PlatformsSection android emulator />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/picker.md
+++ b/docs/pages/versions/unversioned/sdk/picker.md
@@ -13,7 +13,7 @@ A component that provides access to the system UI for picking between several op
 
 > 💡 This library was formerly known as `@react-native-community/picker`. If you have that library in your SDK 40+ project, you can uninstall it and install this one instead.
 
-<PlatformsSection android emulator ios simulator />
+<PlatformsSection android emulator ios simulator web />
 
 ## Installation
 

--- a/docs/pages/versions/v38.0.0/sdk/intent-launcher.md
+++ b/docs/pages/versions/v38.0.0/sdk/intent-launcher.md
@@ -8,7 +8,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`expo-intent-launcher`** provides a way to launch Android intents. For example, you can use this API to open a specific settings screen.
 
-<PlatformsSection android emulator ios simulator />
+<PlatformsSection android emulator />
 
 ## Installation
 

--- a/docs/pages/versions/v38.0.0/sdk/picker.md
+++ b/docs/pages/versions/v38.0.0/sdk/picker.md
@@ -11,11 +11,11 @@ import Video from '~/components/plugins/Video'
 
 A component that provides access to the system UI for picking between several options.
 
-<PlatformsSection android emulator ios simulator />
+<PlatformsSection android emulator ios simulator web />
 
 ## Installation
 
-<InstallSection packageName="@react-native-community/picker" href="https://github.com/react-native-community/react-native-picker#getting-started" />
+<InstallSection packageName="@react-native-picker/picker" href="https://github.com/react-native-picker/picker#getting-started" />
 
 ## Usage
 

--- a/docs/pages/versions/v39.0.0/sdk/intent-launcher.md
+++ b/docs/pages/versions/v39.0.0/sdk/intent-launcher.md
@@ -8,7 +8,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`expo-intent-launcher`** provides a way to launch Android intents. For example, you can use this API to open a specific settings screen.
 
-<PlatformsSection android emulator ios simulator />
+<PlatformsSection android emulator />
 
 ## Installation
 

--- a/docs/pages/versions/v39.0.0/sdk/picker.md
+++ b/docs/pages/versions/v39.0.0/sdk/picker.md
@@ -11,11 +11,11 @@ import Video from '~/components/plugins/Video'
 
 A component that provides access to the system UI for picking between several options.
 
-<PlatformsSection android emulator ios simulator />
+<PlatformsSection android emulator ios simulator web />
 
 ## Installation
 
-<InstallSection packageName="@react-native-community/picker" href="https://github.com/react-native-community/react-native-picker#getting-started" />
+<InstallSection packageName="@react-native-picker/picker" href="https://github.com/react-native-picker/picker#getting-started" />
 
 ## Usage
 

--- a/docs/pages/versions/v40.0.0/sdk/intent-launcher.md
+++ b/docs/pages/versions/v40.0.0/sdk/intent-launcher.md
@@ -8,7 +8,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`expo-intent-launcher`** provides a way to launch Android intents. For example, you can use this API to open a specific settings screen.
 
-<PlatformsSection android emulator ios simulator />
+<PlatformsSection android emulator />
 
 ## Installation
 

--- a/docs/pages/versions/v40.0.0/sdk/picker.md
+++ b/docs/pages/versions/v40.0.0/sdk/picker.md
@@ -13,7 +13,7 @@ A component that provides access to the system UI for picking between several op
 
 > 💡 This library was formerly known as `@react-native-community/picker`. If you have that library in your SDK 40+ project, you can uninstall it and install this one instead.
 
-<PlatformsSection android emulator ios simulator />
+<PlatformsSection android emulator ios simulator web />
 
 ## Installation
 

--- a/docs/pages/versions/v41.0.0/sdk/intent-launcher.md
+++ b/docs/pages/versions/v41.0.0/sdk/intent-launcher.md
@@ -8,7 +8,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`expo-intent-launcher`** provides a way to launch Android intents. For example, you can use this API to open a specific settings screen.
 
-<PlatformsSection android emulator ios simulator />
+<PlatformsSection android emulator />
 
 ## Installation
 

--- a/docs/pages/versions/v41.0.0/sdk/picker.md
+++ b/docs/pages/versions/v41.0.0/sdk/picker.md
@@ -13,7 +13,7 @@ A component that provides access to the system UI for picking between several op
 
 > 💡 This library was formerly known as `@react-native-community/picker`. If you have that library in your SDK 40+ project, you can uninstall it and install this one instead.
 
-<PlatformsSection android emulator ios simulator />
+<PlatformsSection android emulator ios simulator web />
 
 ## Installation
 

--- a/docs/pages/versions/v42.0.0/sdk/intent-launcher.md
+++ b/docs/pages/versions/v42.0.0/sdk/intent-launcher.md
@@ -8,7 +8,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`expo-intent-launcher`** provides a way to launch Android intents. For example, you can use this API to open a specific settings screen.
 
-<PlatformsSection android emulator ios simulator />
+<PlatformsSection android emulator />
 
 ## Installation
 

--- a/docs/pages/versions/v42.0.0/sdk/picker.md
+++ b/docs/pages/versions/v42.0.0/sdk/picker.md
@@ -13,7 +13,7 @@ A component that provides access to the system UI for picking between several op
 
 > 💡 This library was formerly known as `@react-native-community/picker`. If you have that library in your SDK 40+ project, you can uninstall it and install this one instead.
 
-<PlatformsSection android emulator ios simulator />
+<PlatformsSection android emulator ios simulator web />
 
 ## Installation
 


### PR DESCRIPTION
# Why

Superseds #11495, #13815

Currently Picker and Intent Launcher supported platform tables are not correct.

# How

This changeset apply the mentioned in PRs above fixes to the all existing docs files from SDK38 to unversioned.

# Test Plan

The changes have been tested by running docs website on `localhost`.
