### PR TITLE
[android] update hermes bytecode version for react-native 0.64

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/VersionedUtils.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/VersionedUtils.kt
@@ -41,7 +41,7 @@ object VersionedUtils {
   // Update this value when hermes-engine getting updated.
   // Currently there is no way to retrieve Hermes bytecode version from Java,
   // as an alternative, we maintain the version by hand.
-  private const val HERMES_BYTECODE_VERSION = 74
+  private const val HERMES_BYTECODE_VERSION = 76
 
   private fun toggleExpoDevMenu() {
     val currentActivity = Exponent.instance.currentActivity


### PR DESCRIPTION
# Why

react-native 0.64 uses newer hermes-engine. we need to update the bytecode version in expo-go loader.

# How

react-native 0.64 has hermes-engine@0.7.2 and [its bytecode version is 76](https://github.com/facebook/hermes/blob/v0.7.2/include/hermes/BCGen/HBC/BytecodeFileFormat.h#L33). update `VersionedUtils::HERMES_BYTECODE_VERSION` to expo-go.

# Test Plan

i am going to leave the test after versioned qa. we need to wait sdk 43 schema published, so that we can use `expo publish` or `expo export` to publish new hermes bytecode bundle. (will study if serving hermes bytecode bundle in `expo start` is possible or not)

# Checklist

- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).