### PR TITLE
[adapter][ios] update logic surrounding setAppStateToForeground

### DIFF
--- a/packages/expo-modules-core/ios/Services/EXReactNativeAdapter.m
+++ b/packages/expo-modules-core/ios/Services/EXReactNativeAdapter.m
@@ -222,7 +222,9 @@ EX_REGISTER_MODULE();
       )
     ) {
     [self setAppStateToBackground];
-  } else if (!_isForegrounded && RCTSharedApplication().applicationState == UIApplicationStateActive) {
+  }
+  
+  if (!_isForegrounded && RCTSharedApplication().applicationState == UIApplicationStateActive) {
     [self setAppStateToForeground];
   }
 }


### PR DESCRIPTION
# Why

Closes #13641 and #11558, also fixes bare-expo

ScreenOrientation is not initialized correctly in bare apps because it is missing a call to `setAppStateToForeground` - this means calls to change the orientation are not fired because the foregrounded module is not registered in the EXScreenOrientationRegistry: https://github.com/expo/expo/blob/50661f5c77b26c1192492496b17ed251d4965ff0/packages/expo-screen-orientation/ios/EXScreenOrientation/EXScreenOrientationRegistry.m#L96

For bare apps, this is always `nil` until something triggers the foreground event, and so `setMask` doesn't do anything.

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

Expo Go apps fire this event here: https://github.com/expo/expo/blob/50661f5c77b26c1192492496b17ed251d4965ff0/ios/Exponent/Versioned/Core/UniversalModules/EXScopedReactNativeAdapter.m#L18 

I've updated the EXNativeAdapter to fire this same event 


This essentially registered the module with the EXOrientationRegistry here: https://github.com/expo/expo/blob/50661f5c77b26c1192492496b17ed251d4965ff0/packages/expo-screen-orientation/ios/EXScreenOrientation/EXScreenOrientationModule.m#L169


Which then sets the foregrounded module here: https://github.com/expo/expo/blob/50661f5c77b26c1192492496b17ed251d4965ff0/packages/expo-screen-orientation/ios/EXScreenOrientation/EXScreenOrientationRegistry.m#L238

and so `setMask` behaves as expected


# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->

While the logic of this change seems to make sense to me, I'm wary of updated a module that could potentially have a larger impact than intended. I've tried to think of a way to keep this change inside the module itself, but I'm not sure the best way to do this.

In either case, NCL and Test Suite in Bare Expo and Expo Go should be the test plan 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).