### PR TITLE
[media-library] Fix creating assets in Android 11

### DIFF
--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### 🐛 Bug fixes
 
 - EXIF parsing failure no longer crashes the `getAssetsAsync` and `getAssetInfoAsync`, the promise returns `exif: null` instead. ([#14408](https://github.com/expo/expo/pull/14408) by [@barthap](https://github.com/barthap))
+- Fixed `createAssetAsync` and `saveToLibraryAsync` on Android 11. ([#14518](https://github.com/expo/expo/pull/14518) by [@barthap](https://github.com/barthap))
 
 ### 💡 Others
 

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/CreateAsset.java
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/CreateAsset.java
@@ -1,21 +1,40 @@
 package expo.modules.medialibrary;
 
+import android.content.ContentResolver;
+import android.content.ContentUris;
+import android.content.ContentValues;
 import android.content.Context;
+import android.database.Cursor;
 import android.media.MediaScannerConnection;
 import android.net.Uri;
 import android.os.AsyncTask;
+import android.os.Build;
+import android.os.Bundle;
+import android.os.ParcelFileDescriptor;
 import android.provider.MediaStore;
 
+import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
 import expo.modules.core.Promise;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.channels.FileChannel;
+import java.util.ArrayList;
 
+import static expo.modules.medialibrary.MediaLibraryConstants.ASSET_PROJECTION;
 import static expo.modules.medialibrary.MediaLibraryConstants.ERROR_IO_EXCEPTION;
 import static expo.modules.medialibrary.MediaLibraryConstants.ERROR_NO_FILE_EXTENSION;
+import static expo.modules.medialibrary.MediaLibraryConstants.ERROR_UNABLE_TO_LOAD;
 import static expo.modules.medialibrary.MediaLibraryConstants.ERROR_UNABLE_TO_LOAD_PERMISSION;
 import static expo.modules.medialibrary.MediaLibraryConstants.ERROR_UNABLE_TO_SAVE;
+import static expo.modules.medialibrary.MediaLibraryConstants.EXTERNAL_CONTENT;
 import static expo.modules.medialibrary.MediaLibraryUtils.getEnvDirectoryForAssetType;
+import static expo.modules.medialibrary.MediaLibraryUtils.mineTypeToExternalUri;
 import static expo.modules.medialibrary.MediaLibraryUtils.queryAssetInfo;
 import static expo.modules.medialibrary.MediaLibraryUtils.safeCopyFile;
 
@@ -48,23 +67,82 @@ class CreateAsset extends AsyncTask<Void, Void, Void> {
     return lastSegment != null && lastSegment.contains(".");
   }
 
+  /**
+   * Creates asset entry in database
+   * @return uri to created asset
+   */
+  @RequiresApi(api = Build.VERSION_CODES.Q)
+  private Uri createAssetWithContentResolver() {
+    ContentResolver contentResolver = mContext.getContentResolver();
+
+    String mimeType = MediaLibraryUtils.getType(contentResolver, mUri);
+    String filename = mUri.getLastPathSegment();
+    String path = MediaLibraryUtils.getRelativePathForAssetType(mimeType, true);
+
+    ContentValues contentValues = new ContentValues();
+    contentValues.put(MediaStore.MediaColumns.DISPLAY_NAME, filename);
+    contentValues.put(MediaStore.MediaColumns.MIME_TYPE, mimeType);
+    contentValues.put(MediaStore.MediaColumns.RELATIVE_PATH, path);
+    contentValues.put(MediaStore.MediaColumns.IS_PENDING, 1);
+
+    Uri contentUri = mineTypeToExternalUri(mimeType);
+    return contentResolver.insert(contentUri, contentValues);
+  }
+
+  /**
+   * Same as {@link MediaLibraryUtils#safeCopyFile(File, File)} but takes Content URI as destination
+   */
+  @RequiresApi(api = Build.VERSION_CODES.R)
+  private void writeFileContentsToAsset(File localFile, Uri assetUri) throws IOException {
+    ContentResolver contentResolver = mContext.getContentResolver();
+
+    try (FileChannel in = new FileInputStream(localFile).getChannel();
+         FileChannel out = ((FileOutputStream) contentResolver.openOutputStream(assetUri)).getChannel()) {
+      final long transferred = in.transferTo(0, in.size(), out);
+      if (transferred != in.size()) {
+        contentResolver.delete(assetUri, null);
+        throw new IOException("Could not save file to " + assetUri + " Not enough space.");
+      }
+    }
+
+    // After writing contents, set IS_PENDING flag back to 0
+    ContentValues values = new ContentValues();
+    values.put(MediaStore.MediaColumns.IS_PENDING, 0);
+    contentResolver.update(assetUri, values, null, null);
+  }
+
   private File createAssetFile() throws IOException {
     File localFile = new File(mUri.getPath());
-    File destDir = getEnvDirectoryForAssetType(
-      MediaLibraryUtils.getType(mContext.getContentResolver(), mUri),
-      true
-    );
-    if (destDir == null) {
-      mPromise.reject(ERROR_UNABLE_TO_SAVE, "Could not guess file type.");
-      return null;
-    }
-    File destFile = safeCopyFile(localFile, destDir);
 
-    if (!destDir.exists() || !destFile.isFile()) {
-      mPromise.reject(ERROR_UNABLE_TO_SAVE, "Could not create asset record. Related file is not existing.");
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+      Uri assetUri = createAssetWithContentResolver();
+      writeFileContentsToAsset(localFile, assetUri);
+
+      if (resolveWithAdditionalData) {
+        final String selection = MediaStore.MediaColumns._ID + "=?";
+        final String[] args = {String.valueOf(ContentUris.parseId(assetUri))};
+        queryAssetInfo(mContext, selection, args, false, mPromise);
+      } else {
+        mPromise.resolve(null);
+      }
       return null;
+    } else {
+      File destDir = getEnvDirectoryForAssetType(
+          MediaLibraryUtils.getType(mContext.getContentResolver(), mUri),
+          true
+      );
+      if (destDir == null) {
+        mPromise.reject(ERROR_UNABLE_TO_SAVE, "Could not guess file type.");
+        return null;
+      }
+      File destFile = safeCopyFile(localFile, destDir);
+
+      if (!destDir.exists() || !destFile.isFile()) {
+        mPromise.reject(ERROR_UNABLE_TO_SAVE, "Could not create asset record. Related file is not existing.");
+        return null;
+      }
+      return destFile;
     }
-    return destFile;
   }
 
   @Override
@@ -101,6 +179,8 @@ class CreateAsset extends AsyncTask<Void, Void, Void> {
     } catch (SecurityException e) {
       mPromise.reject(ERROR_UNABLE_TO_LOAD_PERMISSION,
         "Could not get asset: need READ_EXTERNAL_STORAGE permission.", e);
+    } catch (Exception e) {
+      mPromise.reject(ERROR_UNABLE_TO_SAVE, "Could not create asset.", e);
     }
     return null;
   }

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/CreateAsset.java
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/CreateAsset.java
@@ -4,35 +4,25 @@ import android.content.ContentResolver;
 import android.content.ContentUris;
 import android.content.ContentValues;
 import android.content.Context;
-import android.database.Cursor;
 import android.media.MediaScannerConnection;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Build;
-import android.os.Bundle;
-import android.os.ParcelFileDescriptor;
 import android.provider.MediaStore;
-
-import androidx.annotation.Nullable;
-import androidx.annotation.RequiresApi;
-import expo.modules.core.Promise;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.nio.channels.FileChannel;
-import java.util.ArrayList;
 
-import static expo.modules.medialibrary.MediaLibraryConstants.ASSET_PROJECTION;
+import androidx.annotation.RequiresApi;
+import expo.modules.core.Promise;
+
 import static expo.modules.medialibrary.MediaLibraryConstants.ERROR_IO_EXCEPTION;
 import static expo.modules.medialibrary.MediaLibraryConstants.ERROR_NO_FILE_EXTENSION;
-import static expo.modules.medialibrary.MediaLibraryConstants.ERROR_UNABLE_TO_LOAD;
 import static expo.modules.medialibrary.MediaLibraryConstants.ERROR_UNABLE_TO_LOAD_PERMISSION;
 import static expo.modules.medialibrary.MediaLibraryConstants.ERROR_UNABLE_TO_SAVE;
-import static expo.modules.medialibrary.MediaLibraryConstants.EXTERNAL_CONTENT;
 import static expo.modules.medialibrary.MediaLibraryUtils.getEnvDirectoryForAssetType;
 import static expo.modules.medialibrary.MediaLibraryUtils.mineTypeToExternalUri;
 import static expo.modules.medialibrary.MediaLibraryUtils.queryAssetInfo;
@@ -125,6 +115,7 @@ class CreateAsset extends AsyncTask<Void, Void, Void> {
       } else {
         mPromise.resolve(null);
       }
+      // no further operations required, skip by returning null
       return null;
     } else {
       File destDir = getEnvDirectoryForAssetType(


### PR DESCRIPTION
# Why

Fixes #12060

# How

Old implementation based on deprecated `Environment.getExternalStoragePublicDirectory()`.

<details>
<summary>Click here to unfold the deprecation message</summary>

<img width="689" alt="Screenshot 2021-09-22 at 17 15 27 (1)" src="https://user-images.githubusercontent.com/278340/134494784-6383b94d-2bc2-41c2-8e25-f4c4cfae3210.png">

</details>

I followed the accepted answer from [this SO question](https://stackoverflow.com/questions/56468539/getexternalstoragepublicdirectory-deprecated-in-android-q) and instructions from [Android docs](https://developer.android.com/training/data-storage/shared/media#add-item).

# Test Plan

- NCL and Test Suite works on API 31 emulator.
