### PR TITLE
[splash-screen][updates] fix auto-setup expo-updates breaking expo-screen-orientation

### DIFF
--- a/packages/expo-splash-screen/CHANGELOG.md
+++ b/packages/expo-splash-screen/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix expo-screen-orientation breaking for expo-updates + expo-splash-screen integration. ([#14519](https://github.com/expo/expo/pull/14519) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 0.13.0 — 2021-09-28

--- a/packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenService.m
+++ b/packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenService.m
@@ -162,6 +162,8 @@ EX_REGISTER_SINGLETON_MODULE(SplashScreen);
     UIView *newView = change[@"new"];
     if (newView != nil && [newView.nextResponder isKindOfClass:[UIViewController class]]) {
       UIViewController *viewController = (UIViewController *)newView.nextResponder;
+      // To show splash screen as soon as possible, we do not wait for hiding callback and call showSplashScreen immediately.
+      // GCD main queue should keep the calls in sequence.
       [self hideSplashScreenFor:viewController successCallback:^(BOOL hasEffect){} failureCallback:^(NSString *message){}];
       [self.splashScreenControllers removeObjectForKey:viewController];
       [self showSplashScreenFor:viewController];

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix expo-screen-orientation breaking for expo-updates + expo-splash-screen integration. ([#14519](https://github.com/expo/expo/pull/14519) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 0.10.1 — 2021-09-28

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesAppController.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesAppController.m
@@ -146,27 +146,27 @@ static NSString * const EXUpdatesErrorEventName = @"error";
 
 - (void)startAndShowLaunchScreen:(UIWindow *)window
 {
+  UIView *view = nil;
   NSBundle *mainBundle = [NSBundle mainBundle];
-  UIViewController *rootViewController = [UIViewController new];
   NSString *launchScreen = (NSString *)[mainBundle objectForInfoDictionaryKey:@"UILaunchStoryboardName"] ?: @"LaunchScreen";
   
   if ([mainBundle pathForResource:launchScreen ofType:@"nib"] != nil) {
     NSArray *views = [mainBundle loadNibNamed:launchScreen owner:self options:nil];
-    rootViewController.view = views.firstObject;
-    rootViewController.view.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    view = views.firstObject;
+    view.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
   } else if ([mainBundle pathForResource:launchScreen ofType:@"storyboard"] != nil ||
              [mainBundle pathForResource:launchScreen ofType:@"storyboardc"] != nil) {
     UIStoryboard *launchScreenStoryboard = [UIStoryboard storyboardWithName:launchScreen bundle:nil];
-    rootViewController = [launchScreenStoryboard instantiateInitialViewController];
+    UIViewController *viewController = [launchScreenStoryboard instantiateInitialViewController];
+    view = viewController.view;
+    viewController.view = nil;
   } else {
     NSLog(@"Launch screen could not be loaded from a .xib or .storyboard. Unexpected loading behavior may occur.");
-    UIView *view = [UIView new];
+    view = [UIView new];
     view.backgroundColor = [UIColor whiteColor];
-    rootViewController.view = view;
   }
   
-  window.rootViewController = rootViewController;
-  [window makeKeyAndVisible];
+  window.rootViewController.view = view;
 
   [self start];
 }

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesAppDelegate.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesAppDelegate.m
@@ -107,11 +107,8 @@ EX_REGISTER_SINGLETON_MODULE(EXUpdatesAppDelegate)
     rootView.backgroundColor = [UIColor whiteColor];
   }
 
-  UIViewController *rootViewController = [UIViewController new];
-  rootViewController.view = rootView;
   UIWindow *window = UIApplication.sharedApplication.delegate.window;
-  window.rootViewController = rootViewController;
-  [window makeKeyAndVisible];
+  window.rootViewController.view = rootView;
 
   return bridge;
  }


### PR DESCRIPTION
# Why

- [expo-screen-orientation requires rootViewController to be `EXScreenOrientationViewController`](https://github.com/expo/expo/tree/master/packages/expo-screen-orientation#configure-for-ios).
- however [expo-updates will replace rootViewController after initialization](https://github.com/expo/expo/blob/b5228228f3fd469d039c06ded670e4a0dce78107/packages/expo-updates/ios/EXUpdates/EXUpdatesAppDelegate.m#L110). this will break expo-screen-orientation's setup.

# How

i tried to replace root view in rootViewController and leave `rootViewController` untouched. for expo-splash-screen kvo, needs to reflect the observing target as well.

# Test Plan

```sh
expo init -t  /path/to/expo/templates/expo-template-bare-minimum extest
cd extest
yarn add file:/path/to/expo/packages/expo-splash-screen
yarn add file:/path/to/expo/packages/expo-screen-orientation
yarn add file:/path/to/expo/packages/expo-updates
cd ios
rm -rf Pods && pod install
# edit extest/AppDelegate.m as https://github.com/expo/expo/tree/master/packages/expo-screen-orientation#configure-for-ios
cd ..
# edit App.js as following
expo run:ios --configuration Release
# check the app will show splash screen for about 5 seconds.
# check the screen orientation is locked after rotation.
```

```jsx
import { StatusBar } from 'expo-status-bar';
import React, { useEffect } from 'react';
import { StyleSheet, Text, View } from 'react-native';
import * as ScreenOrientation from 'expo-screen-orientation';
import * as SplashScreen from 'expo-splash-screen';

SplashScreen.preventAutoHideAsync()

export default function App() {
  useEffect(() => {
    ScreenOrientation.lockAsync(ScreenOrientation.OrientationLock.PORTRAIT_UP);
    setTimeout(() => {
      SplashScreen.hideAsync();
    }, 5000);
  }, []);
  return (
    <View style={styles.container}>
      <Text>Open up App.js to start working on your app!</Text>
      <StatusBar style="auto" />
    </View>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    backgroundColor: '#fff',
    alignItems: 'center',
    justifyContent: 'center',
  },
});
```



# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).