### PR TITLE
[splashscreen][ios] have warning timer wait for js bundle to load

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.kt
@@ -86,6 +86,7 @@ open class ExperienceActivity : BaseExperienceActivity(), StartReactInstanceDele
    */
   lateinit var loadingProgressPopupController: LoadingProgressPopupController
   var managedAppSplashScreenViewProvider: ManagedAppSplashScreenViewProvider? = null
+  var managedAppSplashScreenViewController: ManagedAppSplashScreenViewController? = null
 
   @Inject
   lateinit var exponentManifest: ExponentManifest
@@ -108,6 +109,9 @@ open class ExperienceActivity : BaseExperienceActivity(), StartReactInstanceDele
       override fun onSuccess() {
         UiThreadUtil.runOnUiThread {
           loadingProgressPopupController.hide()
+          if (managedAppSplashScreenViewController) {
+            managedAppSplashScreenViewController.startSplashScreenWarningTimer()
+          }
           finishLoading()
         }
       }
@@ -352,7 +356,7 @@ open class ExperienceActivity : BaseExperienceActivity(), StartReactInstanceDele
       )
       managedAppSplashScreenViewProvider = ManagedAppSplashScreenViewProvider(config)
       val splashScreenView = managedAppSplashScreenViewProvider!!.createSplashScreenView(this)
-      val controller = ManagedAppSplashScreenViewController(
+      managedAppSplashScreenViewController = ManagedAppSplashScreenViewController(
         this,
         getRootViewClass(
           manifest

--- a/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.kt
@@ -109,9 +109,7 @@ open class ExperienceActivity : BaseExperienceActivity(), StartReactInstanceDele
       override fun onSuccess() {
         UiThreadUtil.runOnUiThread {
           loadingProgressPopupController.hide()
-          if (managedAppSplashScreenViewController) {
-            managedAppSplashScreenViewController.startSplashScreenWarningTimer()
-          }
+          managedAppSplashScreenViewController?.startSplashScreenWarningTimer()
           finishLoading()
         }
       }

--- a/android/expoview/src/main/java/host/exp/exponent/experience/splashscreen/ManagedAppSplashScreenViewController.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/splashscreen/ManagedAppSplashScreenViewController.kt
@@ -19,32 +19,29 @@ class ManagedAppSplashScreenViewController(
   private var mSnackbar: Snackbar? = null
   private var mRunnable: Runnable? = null
 
-  private fun startSplashScreenWarningTimer() {
-    mRunnable = Runnable {
-      mSnackbar = Snackbar.make(splashScreenView, "Stuck on splash screen?", Snackbar.LENGTH_LONG)
-      mSnackbar!!.setAction(
-        "Info",
-        View.OnClickListener { v ->
-          val url = "https://expo.fyi/splash-screen-hanging"
-          val webpage = Uri.parse(url)
-          val intent = Intent(Intent.ACTION_VIEW, webpage)
-          v.context.startActivity(intent)
-          mSnackbar!!.dismiss()
-        }
-      )
-      mSnackbar!!.show()
-    }
+  fun startSplashScreenWarningTimer() {
+    if (BuildConfig.DEBUG) {
+      mRunnable = Runnable {
+          mSnackbar = Snackbar.make(splashScreenView, "Stuck on splash screen?", Snackbar.LENGTH_LONG)
+          mSnackbar!!.setAction(
+            "Info",
+            View.OnClickListener { v ->
+              val url = "https://expo.fyi/splash-screen-hanging"
+              val webpage = Uri.parse(url)
+              val intent = Intent(Intent.ACTION_VIEW, webpage)
+              v.context.startActivity(intent)
+              mSnackbar!!.dismiss()
+            }
+          )
+        mSnackbar!!.show()
+      }
 
-    mWarningHandler.postDelayed(mRunnable!!, 20000)
+      mWarningHandler.postDelayed(mRunnable!!, 20000)
+    }
   }
 
   override fun showSplashScreen(successCallback: () -> Unit) {
     super.showSplashScreen {
-
-      if (BuildConfig.DEBUG) {
-        startSplashScreenWarningTimer()
-      }
-
       successCallback()
     }
   }

--- a/ios/Exponent/Kernel/Views/EXAppViewController.m
+++ b/ios/Exponent/Kernel/Views/EXAppViewController.m
@@ -461,11 +461,6 @@ NS_ASSUME_NONNULL_BEGIN
 {
   if (self->_appRecord.appManager.status != kEXReactAppManagerStatusRunning) {
     [self.appLoadingProgressWindowController updateStatusWithProgress:progress];
-    float progressPercent = ([progress.done floatValue] / [progress.total floatValue]);
-    
-    if (progressPercent == 1.0) {
-  
-    }
   }
 }
 

--- a/ios/Exponent/Kernel/Views/EXAppViewController.m
+++ b/ios/Exponent/Kernel/Views/EXAppViewController.m
@@ -84,6 +84,7 @@ NS_ASSUME_NONNULL_BEGIN
  * See also EXHomeAppSplashScreenViewProvider in self.viewDidLoad
  */
 @property (nonatomic, strong, nullable) EXManagedAppSplashScreenViewProvider *managedAppSplashScreenViewProvider;
+@property (nonatomic, strong, nullable) EXManagedAppSplashScreenViewController *managedViewController;
 
 /*
  * This view is available in managed apps run in Expo Go only.
@@ -143,6 +144,7 @@ NS_ASSUME_NONNULL_BEGIN
   if (self.isHomeApp) {
     EXHomeAppSplashScreenViewProvider *homeAppSplashScreenViewProvider = [EXHomeAppSplashScreenViewProvider new];
     [self _showSplashScreenWithProvider:homeAppSplashScreenViewProvider];
+    
   } else if (self.isStandalone) {
     [self _showSplashScreenWithProvider:[EXSplashScreenViewNativeProvider new]];
   }
@@ -417,10 +419,10 @@ NS_ASSUME_NONNULL_BEGIN
 
     UIView *rootView = self.view;
     UIView *splashScreenView = [provider createSplashScreenView];
-    EXManagedAppSplashScreenViewController *controller = [[EXManagedAppSplashScreenViewController alloc] initWithRootView:rootView
+    self.managedViewController = [[EXManagedAppSplashScreenViewController alloc] initWithRootView:rootView
                                                                                                  splashScreenView:splashScreenView];
     [splashScreenService showSplashScreenFor:self
-                      splashScreenController:controller
+                      splashScreenController:self.managedViewController
                              successCallback:^{}
                              failureCallback:^(NSString *message){ EXLogWarn(@"%@", message); }];
   });
@@ -430,6 +432,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)hideLoadingProgressWindow
 {
   [self.appLoadingProgressWindowController hide];
+  if (self.managedViewController) {
+    [self.managedViewController startSplashScreenVisibleTimer];
+  }
 }
 
 #pragma mark - EXAppLoaderDelegate
@@ -456,6 +461,11 @@ NS_ASSUME_NONNULL_BEGIN
 {
   if (self->_appRecord.appManager.status != kEXReactAppManagerStatusRunning) {
     [self.appLoadingProgressWindowController updateStatusWithProgress:progress];
+    float progressPercent = ([progress.done floatValue] / [progress.total floatValue]);
+    
+    if (progressPercent == 1.0) {
+  
+    }
   }
 }
 

--- a/ios/Exponent/Kernel/Views/EXAppViewController.m
+++ b/ios/Exponent/Kernel/Views/EXAppViewController.m
@@ -84,7 +84,7 @@ NS_ASSUME_NONNULL_BEGIN
  * See also EXHomeAppSplashScreenViewProvider in self.viewDidLoad
  */
 @property (nonatomic, strong, nullable) EXManagedAppSplashScreenViewProvider *managedAppSplashScreenViewProvider;
-@property (nonatomic, strong, nullable) EXManagedAppSplashScreenViewController *managedViewController;
+@property (nonatomic, strong, nullable) EXManagedAppSplashScreenViewController *managedSplashScreenController;
 
 /*
  * This view is available in managed apps run in Expo Go only.
@@ -419,10 +419,10 @@ NS_ASSUME_NONNULL_BEGIN
 
     UIView *rootView = self.view;
     UIView *splashScreenView = [provider createSplashScreenView];
-    self.managedViewController = [[EXManagedAppSplashScreenViewController alloc] initWithRootView:rootView
+    self.managedSplashScreenController = [[EXManagedAppSplashScreenViewController alloc] initWithRootView:rootView
                                                                                                  splashScreenView:splashScreenView];
     [splashScreenService showSplashScreenFor:self
-                      splashScreenController:self.managedViewController
+                      splashScreenController:self.managedSplashScreenController
                              successCallback:^{}
                              failureCallback:^(NSString *message){ EXLogWarn(@"%@", message); }];
   });
@@ -432,8 +432,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)hideLoadingProgressWindow
 {
   [self.appLoadingProgressWindowController hide];
-  if (self.managedViewController) {
-    [self.managedViewController startSplashScreenVisibleTimer];
+  if (self.managedSplashScreenController) {
+    [self.managedSplashScreenController startSplashScreenVisibleTimer];
   }
 }
 

--- a/ios/Exponent/Kernel/Views/EXAppViewController.m
+++ b/ios/Exponent/Kernel/Views/EXAppViewController.m
@@ -144,7 +144,6 @@ NS_ASSUME_NONNULL_BEGIN
   if (self.isHomeApp) {
     EXHomeAppSplashScreenViewProvider *homeAppSplashScreenViewProvider = [EXHomeAppSplashScreenViewProvider new];
     [self _showSplashScreenWithProvider:homeAppSplashScreenViewProvider];
-    
   } else if (self.isStandalone) {
     [self _showSplashScreenWithProvider:[EXSplashScreenViewNativeProvider new]];
   }

--- a/ios/Exponent/Kernel/Views/Loading/EXManagedAppSplashScreenViewController.h
+++ b/ios/Exponent/Kernel/Views/Loading/EXManagedAppSplashScreenViewController.h
@@ -5,7 +5,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface EXManagedAppSplashScreenViewController : EXSplashScreenViewController
 
--(void) startSplashScreenVisibleTimer;
+- (void)startSplashScreenVisibleTimer;
 
 @end
 

--- a/ios/Exponent/Kernel/Views/Loading/EXManagedAppSplashScreenViewController.h
+++ b/ios/Exponent/Kernel/Views/Loading/EXManagedAppSplashScreenViewController.h
@@ -5,6 +5,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface EXManagedAppSplashScreenViewController : EXSplashScreenViewController
 
+-(void) startSplashScreenVisibleTimer;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/Exponent/Kernel/Views/Loading/EXManagedAppSplashScreenViewController.m
+++ b/ios/Exponent/Kernel/Views/Loading/EXManagedAppSplashScreenViewController.m
@@ -24,7 +24,6 @@
 - (void)showWithCallback:(void (^)(void))successCallback failureCallback:(void (^)(NSString * _Nonnull))failureCallback
 {
   [super showWithCallback:^{
-    [self startSplashScreenVisibleTimer];
     if (successCallback) {
       successCallback();
     }


### PR DESCRIPTION
# Why

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

Long running / large bundles can take longer than 20s to load, so the splash screen warning timer was popping up behind the progress bar. It makes more sense to wait for the bundle to load before starting the timer to show the warning

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

Hooked into the progress bar dismiss method and started the timer there 

# Test Plan

- Testing with a clear cache and NCL usually takes upwards of 20s - ensure the warning doesn't pop up
- Testing with a thrown error and ensure the warning does pop up after 20s :

eg: 
```js
async function prepare() {
  await SplashScreen.preventAutoHideAsync();
  throw new Error('123')
  await SplashScreen.hideAsync();
}
```

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->
Android still WIP

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).