### PR TITLE
[ncl] refactor components, improve typing

### DIFF
--- a/apps/native-component-list/App.tsx
+++ b/apps/native-component-list/App.tsx
@@ -6,7 +6,7 @@ import { AppearanceProvider } from 'react-native-appearance';
 import RootNavigation from './src/navigation/RootNavigation';
 import loadAssetsAsync from './src/utilities/loadAssetsAsync';
 
-function useSplashScreen(loadingFunction: () => void | Promise<void>) {
+function useSplashScreen(loadingFunction: () => void) {
   const [isLoadingCompleted, setLoadingComplete] = React.useState(false);
 
   // Load any resources or data that we need prior to rendering the app
@@ -20,7 +20,7 @@ function useSplashScreen(loadingFunction: () => void | Promise<void>) {
         console.warn(e);
       } finally {
         setLoadingComplete(true);
-        SplashScreen.hideAsync();
+        await SplashScreen.hideAsync();
       }
     }
 
@@ -30,7 +30,7 @@ function useSplashScreen(loadingFunction: () => void | Promise<void>) {
   return isLoadingCompleted;
 }
 
-export default function App(props: any) {
+const App = () => {
   const isLoadingCompleted = useSplashScreen(async () => {
     if (Platform.OS === 'ios') {
       StatusBar.setBarStyle('dark-content', false);
@@ -38,13 +38,11 @@ export default function App(props: any) {
     await loadAssetsAsync();
   });
 
-  if (!isLoadingCompleted) {
-    return null;
-  }
-
-  return (
+  return isLoadingCompleted ? (
     <AppearanceProvider>
-      <RootNavigation {...props} />
+      <RootNavigation />
     </AppearanceProvider>
-  );
-}
+  ) : null;
+};
+
+export default App;

--- a/apps/native-component-list/src/components/Button.tsx
+++ b/apps/native-component-list/src/components/Button.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { PropsWithChildren } from 'react';
 import {
   ActivityIndicator,
   StyleSheet,
@@ -11,14 +11,15 @@ import {
 
 import Colors from '../constants/Colors';
 
-interface Props extends TouchableHighlightProps {
-  disabled?: boolean;
-  loading?: boolean;
-  title?: string;
-  buttonStyle?: ViewStyle;
-}
+type Props = PropsWithChildren<
+  TouchableHighlightProps & {
+    loading?: boolean;
+    title?: string;
+    buttonStyle?: ViewStyle;
+  }
+>;
 
-const Button: React.FunctionComponent<Props> = ({
+const Button = ({
   disabled,
   loading,
   title,
@@ -27,7 +28,7 @@ const Button: React.FunctionComponent<Props> = ({
   style,
   buttonStyle,
   children,
-}) => (
+}: Props) => (
   <View style={[styles.container, style]}>
     <TouchableHighlight
       style={[styles.button, disabled && styles.disabledButton, buttonStyle]}

--- a/apps/native-component-list/src/components/ExpoAPIIcon.tsx
+++ b/apps/native-component-list/src/components/ExpoAPIIcon.tsx
@@ -1,15 +1,16 @@
 import React from 'react';
-import { Image, ImageStyle, StyleProp } from 'react-native';
+import { Image, ImageStyle } from 'react-native';
 
 import Icons from '../constants/Icons';
 
-export default function ExpoAPIIcon({
-  name,
-  style,
-}: {
+type Props = {
   name: string;
-  style?: StyleProp<ImageStyle>;
-}) {
+  style?: ImageStyle;
+};
+
+const ExpoAPIIcon = ({ name, style }: Props) => {
   const icon = React.useMemo(() => (Icons[name] || Icons.Default)(), [name]);
   return <Image source={icon} style={[{ width: 24, height: 24 }, style]} />;
-}
+};
+
+export default ExpoAPIIcon;

--- a/apps/native-component-list/src/components/GoogleSignInButton.tsx
+++ b/apps/native-component-list/src/components/GoogleSignInButton.tsx
@@ -1,41 +1,31 @@
-import React from 'react';
+import React, { PropsWithChildren } from 'react';
 import {
   Image,
-  StyleProp,
   StyleSheet,
   Text,
   TouchableOpacity,
+  TouchableOpacityProps,
   View,
-  ViewStyle,
 } from 'react-native';
 
 const googleIcon = {
   uri: 'https://upload.wikimedia.org/wikipedia/commons/thumb/5/53/Google_%22G%22_Logo.svg/200px-Google_%22G%22_Logo.svg.png',
 };
 
-export default class GoogleSignInButton extends React.PureComponent<{
-  style?: StyleProp<ViewStyle>;
-  disabled?: boolean;
-}> {
-  static defaultProps = {
-    onPress() {},
-  };
-  render() {
-    const { children, style, disabled, ...props } = this.props;
-    return (
-      <TouchableOpacity
-        disabled={disabled}
-        activeOpacity={0.6}
-        style={StyleSheet.flatten([styles.touchable, style])}
-        {...props}>
-        <View style={styles.content}>
-          <Image source={googleIcon} style={styles.icon} />
-          <Text style={styles.text}>{children}</Text>
-        </View>
-      </TouchableOpacity>
-    );
-  }
-}
+type Props = PropsWithChildren<TouchableOpacityProps>;
+
+const GoogleSignInButton = ({ children, style, disabled, ...props }: Props) => (
+  <TouchableOpacity
+    disabled={disabled}
+    activeOpacity={0.6}
+    style={StyleSheet.flatten([styles.touchable, style])}
+    {...props}>
+    <View style={styles.content}>
+      <Image source={googleIcon} style={styles.icon} />
+      <Text style={styles.text}>{children}</Text>
+    </View>
+  </TouchableOpacity>
+);
 
 const styles = StyleSheet.create({
   touchable: {
@@ -57,3 +47,5 @@ const styles = StyleSheet.create({
   icon: { width: 24, aspectRatio: 1 },
   text: { color: 'gray', marginLeft: 12, fontSize: 16, fontWeight: '600' },
 });
+
+export default GoogleSignInButton;

--- a/apps/native-component-list/src/components/HeaderContainerRight.tsx
+++ b/apps/native-component-list/src/components/HeaderContainerRight.tsx
@@ -1,0 +1,15 @@
+import React, { PropsWithChildren } from 'react';
+import { StyleSheet, View, ViewProps } from 'react-native';
+
+const HeaderContainerRight = (props: PropsWithChildren<ViewProps>) => (
+  <View {...props} style={[styles.container, props.style]} />
+);
+
+const styles = StyleSheet.create({
+  container: {
+    paddingRight: 8,
+    flexDirection: 'row',
+  },
+});
+
+export default HeaderContainerRight;

--- a/apps/native-component-list/src/components/HeaderIconButton.tsx
+++ b/apps/native-component-list/src/components/HeaderIconButton.tsx
@@ -1,11 +1,6 @@
 import Ionicons from '@expo/vector-icons/build/Ionicons';
-import * as React from 'react';
-import { PropsWithChildren } from 'react';
-import { StyleSheet, TouchableOpacity, TouchableOpacityProps, View, ViewProps } from 'react-native';
-
-const HeaderContainerRight = (props: PropsWithChildren<ViewProps>) => (
-  <View {...props} style={[styles.container, props.style]} />
-);
+import React from 'react';
+import { StyleSheet, TouchableOpacity, TouchableOpacityProps } from 'react-native';
 
 type Props = TouchableOpacityProps & {
   color?: string;
@@ -20,13 +15,9 @@ const HeaderIconButton = ({ color = 'blue', disabled, name, onPress, size = 24 }
 );
 
 const styles = StyleSheet.create({
-  container: {
-    paddingRight: 8,
-    flexDirection: 'row',
-  },
   iconButton: {
     paddingHorizontal: 12,
   },
 });
 
-export { HeaderContainerRight, HeaderIconButton };
+export default HeaderIconButton;

--- a/apps/native-component-list/src/components/HeaderIconButton.tsx
+++ b/apps/native-component-list/src/components/HeaderIconButton.tsx
@@ -1,33 +1,32 @@
 import Ionicons from '@expo/vector-icons/build/Ionicons';
 import * as React from 'react';
-import { TouchableOpacity, View } from 'react-native';
+import { PropsWithChildren } from 'react';
+import { StyleSheet, TouchableOpacity, TouchableOpacityProps, View, ViewProps } from 'react-native';
 
-export function HeaderContainerRight(
-  props: React.ComponentProps<typeof View> & {
-    children?: any;
-  }
-) {
-  return <View {...props} style={[{ paddingRight: 8, flexDirection: 'row' }, props.style]} />;
-}
+const HeaderContainerRight = (props: PropsWithChildren<ViewProps>) => (
+  <View {...props} style={[styles.container, props.style]} />
+);
 
-type Props = {
+type Props = TouchableOpacityProps & {
   color?: string;
-  disabled?: boolean;
   name: string;
-  onPress: () => void;
   size?: number;
 };
 
-export default function HeaderIconButton({
-  color = 'blue',
-  disabled,
-  name,
-  onPress,
-  size = 24,
-}: Props) {
-  return (
-    <TouchableOpacity disabled={disabled} style={{ paddingHorizontal: 12 }} onPress={onPress}>
-      <Ionicons size={size} color={color} name={name as any} />
-    </TouchableOpacity>
-  );
-}
+const HeaderIconButton = ({ color = 'blue', disabled, name, onPress, size = 24 }: Props) => (
+  <TouchableOpacity disabled={disabled} style={styles.iconButton} onPress={onPress}>
+    <Ionicons size={size} color={color} name={name as any} />
+  </TouchableOpacity>
+);
+
+const styles = StyleSheet.create({
+  container: {
+    paddingRight: 8,
+    flexDirection: 'row',
+  },
+  iconButton: {
+    paddingHorizontal: 12,
+  },
+});
+
+export { HeaderContainerRight, HeaderIconButton };

--- a/apps/native-component-list/src/components/HeadingText.tsx
+++ b/apps/native-component-list/src/components/HeadingText.tsx
@@ -1,16 +1,11 @@
-import React from 'react';
-import { StyleProp, StyleSheet, Text, TextStyle, View } from 'react-native';
+import React, { PropsWithChildren } from 'react';
+import { StyleSheet, Text, TextProps, View } from 'react-native';
 
-export default function HeadingText(props: {
-  style?: StyleProp<TextStyle>;
-  children?: string | React.ReactChildren;
-}) {
-  return (
-    <View style={styles.container}>
-      <Text style={[styles.headingText, props.style]}>{props.children}</Text>
-    </View>
-  );
-}
+const HeadingText = ({ children, style }: PropsWithChildren<TextProps>) => (
+  <View style={styles.container}>
+    <Text style={[styles.headingText, style]}>{children}</Text>
+  </View>
+);
 
 const styles = StyleSheet.create({
   container: {
@@ -21,3 +16,5 @@ const styles = StyleSheet.create({
     fontSize: 18,
   },
 });
+
+export default HeadingText;

--- a/apps/native-component-list/src/components/ListButton.tsx
+++ b/apps/native-component-list/src/components/ListButton.tsx
@@ -3,43 +3,30 @@ import {
   PixelRatio,
   StyleSheet,
   Text,
-  TextStyle,
   TouchableHighlight,
   TouchableHighlightProps,
   View,
-  ViewStyle,
 } from 'react-native';
 
 import Colors from '../constants/Colors';
 
-interface Props extends TouchableHighlightProps {
+type Props = TouchableHighlightProps & {
   title: string;
-}
+};
 
-export default class ListButton extends React.Component<Props> {
-  render() {
-    const style: ViewStyle[] = [styles.button];
-    const labelStyles: TextStyle[] = [styles.label];
-    if (this.props.disabled) {
-      style.push(styles.disabledButton);
-      labelStyles.push(styles.disabledLabel);
-    }
-    return (
-      <View style={[styles.container, this.props.style]}>
-        <TouchableHighlight
-          style={style}
-          disabled={this.props.disabled}
-          onPress={this.props.onPress}
-          underlayColor="#dddddd">
-          <Text style={labelStyles}>{this.props.title}</Text>
-        </TouchableHighlight>
-      </View>
-    );
-  }
-}
+const ListButton = ({ disabled, onPress, style, title }: Props) => {
+  const buttonStyles = [styles.button, disabled && styles.disabledButton];
+  const labelStyles = [styles.label, disabled && styles.disabledLabel];
+  return (
+    <View style={[buttonStyles]}>
+      <TouchableHighlight style={style} disabled={disabled} onPress={onPress} underlayColor="#ddd">
+        <Text style={labelStyles}>{title}</Text>
+      </TouchableHighlight>
+    </View>
+  );
+};
 
 const styles = StyleSheet.create({
-  container: {},
   button: {
     paddingVertical: 10,
     backgroundColor: 'transparent',
@@ -55,3 +42,5 @@ const styles = StyleSheet.create({
     color: '#999999',
   },
 });
+
+export default ListButton;

--- a/apps/native-component-list/src/components/MonoText.tsx
+++ b/apps/native-component-list/src/components/MonoText.tsx
@@ -1,27 +1,29 @@
 import { Code } from '@expo/html-elements';
-import React from 'react';
-import { StyleSheet, View, StyleProp, ViewStyle, TextStyle } from 'react-native';
+import React, { PropsWithChildren } from 'react';
+import { StyleSheet, View, ViewStyle, TextStyle } from 'react-native';
 
-const MonoText: React.FunctionComponent<{
-  containerStyle?: StyleProp<ViewStyle>;
-  textStyle?: StyleProp<TextStyle>;
-}> = ({ children, containerStyle, textStyle }) => (
+type Props = PropsWithChildren<{
+  containerStyle?: ViewStyle;
+  textStyle?: TextStyle;
+}>;
+
+const MonoText = ({ children, containerStyle, textStyle }: Props) => (
   <View style={[styles.container, containerStyle]}>
     <Code style={[styles.monoText, textStyle]}>{children}</Code>
   </View>
 );
 
-export default MonoText;
-
 const styles = StyleSheet.create({
   container: {
-    backgroundColor: '#ffffff',
+    backgroundColor: '#fff',
     padding: 6,
     marginVertical: 8,
     borderWidth: 1,
-    borderColor: '#666666',
+    borderColor: '#666',
   },
   monoText: {
     fontSize: 10,
   },
 });
+
+export default MonoText;

--- a/apps/native-component-list/src/components/Page.tsx
+++ b/apps/native-component-list/src/components/Page.tsx
@@ -1,29 +1,41 @@
 import { H4 } from '@expo/html-elements';
 import * as React from 'react';
+import { PropsWithChildren } from 'react';
 import { StyleSheet, View, ScrollView } from 'react-native';
 
-export function Page({ children }: { children: any }) {
-  return <View style={{ paddingHorizontal: 12, paddingBottom: 12 }}>{children}</View>;
-}
+const Page = ({ children }: PropsWithChildren<object>) => (
+  <View style={styles.page}>{children}</View>
+);
 
-export function ScrollPage({ children }: { children: any }) {
-  return (
-    <ScrollView style={{ flex: 1, paddingHorizontal: 12, paddingBottom: 12 }}>
-      {children}
-    </ScrollView>
-  );
-}
+const ScrollPage = ({ children }: PropsWithChildren<object>) => (
+  <ScrollView style={[styles.page, styles.scrollPage]}>{children}</ScrollView>
+);
 
-export function Section({ title, children, row }: { title: string; children: any; row?: boolean }) {
-  return (
-    <View
-      style={{
-        borderBottomColor: 'rgba(0,0,0,0.1)',
-        borderBottomWidth: StyleSheet.hairlineWidth,
-        paddingBottom: 8,
-      }}>
-      <H4 style={{ marginTop: 8 }}>{title}</H4>
-      <View style={{ flexDirection: row ? 'row' : 'column' }}>{children}</View>
-    </View>
-  );
-}
+type SectionProps = PropsWithChildren<{ title: string; row?: boolean }>;
+
+const Section = ({ title, children, row }: SectionProps) => (
+  <View style={styles.section}>
+    <H4 style={styles.sectionHeader}>{title}</H4>
+    <View style={{ flexDirection: row ? 'row' : 'column' }}>{children}</View>
+  </View>
+);
+
+const styles = StyleSheet.create({
+  page: {
+    paddingHorizontal: 12,
+    paddingBottom: 12,
+  },
+  scrollPage: {
+    flex: 1,
+  },
+  section: {
+    borderBottomColor: 'rgba(0,0,0,0.1)',
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    paddingBottom: 8,
+  },
+  sectionHeader: {
+    marginTop: 8,
+  },
+});
+
+export { Page, ScrollPage, Section };

--- a/apps/native-component-list/src/components/SimpleActionDemo.tsx
+++ b/apps/native-component-list/src/components/SimpleActionDemo.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import {
   ActivityIndicator,
   PixelRatio,
@@ -16,28 +16,28 @@ type SimpleActionDemoProps = {
   action: (setValue: (value: any) => any) => any;
 };
 
-export default function SimpleActionDemo(props: SimpleActionDemoProps) {
-  const [loading, setLoading] = React.useState(false);
-  const [value, setValue] = React.useState<any>(undefined);
+const SimpleActionDemo = ({ action, title }: SimpleActionDemoProps) => {
+  const [loading, setLoading] = useState(false);
+  const [value, setValue] = useState<any>(undefined);
 
-  const runAction = React.useCallback(async () => {
+  const runAction = useCallback(async () => {
     setLoading(true);
     try {
-      const value = await props.action(setValue);
+      const value = await action(setValue);
       setValue(value);
     } catch (error) {
       setValue(error);
     }
     setLoading(false);
-  }, [props.action]);
+  }, [action]);
 
-  const monoContainerStyle = value instanceof Error ? styles.demoMonoContainerError : null;
+  const monoContainerStyle = value instanceof Error ? styles.demoMonoContainerError : {};
 
   return (
     <View style={styles.demoContainer}>
       <TouchableOpacity onPress={runAction}>
         <View style={styles.demoHeaderContainer}>
-          <Text style={styles.demoHeader}>{props.title}</Text>
+          <Text style={styles.demoHeader}>{title}</Text>
           {loading && <ActivityIndicator style={styles.demoActivityIndicator} size={10} />}
         </View>
       </TouchableOpacity>
@@ -48,7 +48,7 @@ export default function SimpleActionDemo(props: SimpleActionDemoProps) {
       </View>
     </View>
   );
-}
+};
 
 const styles = StyleSheet.create({
   demoContainer: {
@@ -74,3 +74,5 @@ const styles = StyleSheet.create({
     borderColor: Colors.errorBackground,
   },
 });
+
+export default SimpleActionDemo;

--- a/apps/native-component-list/src/components/TabIcon.tsx
+++ b/apps/native-component-list/src/components/TabIcon.tsx
@@ -4,21 +4,19 @@ import { Platform } from 'react-native';
 
 import { Colors } from '../constants';
 
-interface Props {
+type Props = {
   name: string;
   focused?: boolean;
   size?: number;
-}
+};
 
-export default class TabIcon extends React.PureComponent<Props> {
-  render() {
-    const { size = 27, name, focused } = this.props;
-    const color = focused ? Colors.tabIconSelected : Colors.tabIconDefault;
+const TabIcon = ({ size = 27, name, focused }: Props) => {
+  const color = focused ? Colors.tabIconSelected : Colors.tabIconDefault;
+  const platformSize = Platform.select({
+    ios: size,
+    default: size - 2,
+  });
+  return <MaterialCommunityIcons name={name as any} size={platformSize} color={color} />;
+};
 
-    const platformSize = Platform.select({
-      ios: size,
-      default: size - 2,
-    });
-    return <MaterialCommunityIcons name={name as any} size={platformSize} color={color} />;
-  }
-}
+export default TabIcon;

--- a/apps/native-component-list/src/components/TitledPicker.tsx
+++ b/apps/native-component-list/src/components/TitledPicker.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { StyleSheet, View, TextStyle, ViewStyle } from 'react-native';
 
 type Props = {
-  style: ViewStyle;
+  style?: ViewStyle;
   titleStyle?: TextStyle;
   title?: string;
   value: string;

--- a/apps/native-component-list/src/components/TitledPicker.tsx
+++ b/apps/native-component-list/src/components/TitledPicker.tsx
@@ -1,27 +1,20 @@
 import { B } from '@expo/html-elements';
 import { Picker } from '@react-native-picker/picker';
-import * as React from 'react';
+import React from 'react';
 import { StyleSheet, View, TextStyle, ViewStyle } from 'react-native';
 
-export default function TitledPicker({
-  style,
-  titleStyle,
-  title,
-  value,
-  setValue,
-  items,
-  disabled,
-}: {
-  style?: ViewStyle;
+type Props = {
+  style: ViewStyle;
   titleStyle?: TextStyle;
   title?: string;
   value: string;
   items: { key: string; value: string }[];
   disabled?: boolean;
   setValue: (value: string) => void;
-}) {
-  const outputTitle = disabled ? `${title} (Disabled)` : title;
+};
 
+const TitledPicker = ({ style, titleStyle, title, value, setValue, items, disabled }: Props) => {
+  const outputTitle = disabled ? `${title} (Disabled)` : title;
   return (
     <View style={[styles.container, style]}>
       <B style={[styles.title, titleStyle]}>{outputTitle}</B>
@@ -35,7 +28,7 @@ export default function TitledPicker({
       </Picker>
     </View>
   );
-}
+};
 
 const styles = StyleSheet.create({
   container: {
@@ -53,3 +46,5 @@ const styles = StyleSheet.create({
     marginHorizontal: 10,
   },
 });
+
+export default TitledPicker;

--- a/apps/native-component-list/src/components/TitledSwitch.tsx
+++ b/apps/native-component-list/src/components/TitledSwitch.tsx
@@ -2,21 +2,16 @@ import { B } from '@expo/html-elements';
 import React from 'react';
 import { StyleSheet, Switch, View, TextStyle, ViewStyle } from 'react-native';
 
-export default function TitleSwitch({
-  style,
-  titleStyle,
-  title,
-  value,
-  setValue,
-  disabled,
-}: {
+type Props = {
   style?: ViewStyle;
   titleStyle?: TextStyle;
   title?: string;
   value: boolean;
   disabled?: boolean;
   setValue: (value: boolean) => void;
-}) {
+};
+
+const TitleSwitch = ({ style, titleStyle, title, value, setValue, disabled }: Props) => {
   const outputTitle = disabled ? `${title} (Disabled)` : title;
   return (
     <View style={[styles.container, style]}>
@@ -24,7 +19,7 @@ export default function TitleSwitch({
       <Switch disabled={disabled} value={value} onValueChange={(value) => setValue(value)} />
     </View>
   );
-}
+};
 
 const styles = StyleSheet.create({
   container: {
@@ -42,3 +37,5 @@ const styles = StyleSheet.create({
     marginHorizontal: 10,
   },
 });
+
+export default TitleSwitch;

--- a/apps/native-component-list/src/screens/Contacts/ContactDetailScreen.tsx
+++ b/apps/native-component-list/src/screens/Contacts/ContactDetailScreen.tsx
@@ -6,7 +6,7 @@ import * as Linking from 'expo-linking';
 import * as React from 'react';
 import { Platform, RefreshControl, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
-import HeaderIconButton, { HeaderContainerRight } from '../../components/HeaderIconButton';
+import { HeaderIconButton, HeaderContainerRight } from '../../components/HeaderIconButton';
 import Colors from '../../constants/Colors';
 import usePermissions from '../../utilities/usePermissions';
 import ContactDetailList, { DetailListItem } from './ContactDetailList';

--- a/apps/native-component-list/src/screens/Contacts/ContactDetailScreen.tsx
+++ b/apps/native-component-list/src/screens/Contacts/ContactDetailScreen.tsx
@@ -6,7 +6,8 @@ import * as Linking from 'expo-linking';
 import * as React from 'react';
 import { Platform, RefreshControl, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
-import { HeaderIconButton, HeaderContainerRight } from '../../components/HeaderIconButton';
+import HeaderContainerRight from '../../components/HeaderContainerRight';
+import HeaderIconButton from '../../components/HeaderIconButton';
 import Colors from '../../constants/Colors';
 import usePermissions from '../../utilities/usePermissions';
 import ContactDetailList, { DetailListItem } from './ContactDetailList';

--- a/apps/native-component-list/src/screens/Contacts/ContactsScreen.tsx
+++ b/apps/native-component-list/src/screens/Contacts/ContactsScreen.tsx
@@ -5,7 +5,8 @@ import { Platform } from 'expo-modules-core';
 import React from 'react';
 import { RefreshControl, StyleSheet, Text, View } from 'react-native';
 
-import { HeaderIconButton, HeaderContainerRight } from '../../components/HeaderIconButton';
+import HeaderContainerRight from '../../components/HeaderContainerRight';
+import HeaderIconButton from '../../components/HeaderIconButton';
 import usePermissions from '../../utilities/usePermissions';
 import { useResolvedValue } from '../../utilities/useResolvedValue';
 import * as ContactUtils from './ContactUtils';

--- a/apps/native-component-list/src/screens/Contacts/ContactsScreen.tsx
+++ b/apps/native-component-list/src/screens/Contacts/ContactsScreen.tsx
@@ -5,7 +5,7 @@ import { Platform } from 'expo-modules-core';
 import React from 'react';
 import { RefreshControl, StyleSheet, Text, View } from 'react-native';
 
-import HeaderIconButton, { HeaderContainerRight } from '../../components/HeaderIconButton';
+import { HeaderIconButton, HeaderContainerRight } from '../../components/HeaderIconButton';
 import usePermissions from '../../utilities/usePermissions';
 import { useResolvedValue } from '../../utilities/useResolvedValue';
 import * as ContactUtils from './ContactUtils';

--- a/apps/native-component-list/src/screens/Image/ImageAllTestsScreen.tsx
+++ b/apps/native-component-list/src/screens/Image/ImageAllTestsScreen.tsx
@@ -2,7 +2,7 @@ import { StackScreenProps } from '@react-navigation/stack';
 import * as React from 'react';
 import { SectionList, StyleSheet, Text, View } from 'react-native';
 
-import HeaderIconButton, { HeaderContainerRight } from '../../components/HeaderIconButton';
+import { HeaderIconButton, HeaderContainerRight } from '../../components/HeaderIconButton';
 import Colors from '../../constants/Colors';
 import { addSelectedComponentChangeListener } from './ImageComponents';
 import ImageTestListItem from './ImageTestListItem';

--- a/apps/native-component-list/src/screens/Image/ImageAllTestsScreen.tsx
+++ b/apps/native-component-list/src/screens/Image/ImageAllTestsScreen.tsx
@@ -2,7 +2,8 @@ import { StackScreenProps } from '@react-navigation/stack';
 import * as React from 'react';
 import { SectionList, StyleSheet, Text, View } from 'react-native';
 
-import { HeaderIconButton, HeaderContainerRight } from '../../components/HeaderIconButton';
+import HeaderContainerRight from '../../components/HeaderContainerRight';
+import HeaderIconButton from '../../components/HeaderIconButton';
 import Colors from '../../constants/Colors';
 import { addSelectedComponentChangeListener } from './ImageComponents';
 import ImageTestListItem from './ImageTestListItem';

--- a/apps/native-component-list/src/screens/Image/ImageComponents.tsx
+++ b/apps/native-component-list/src/screens/Image/ImageComponents.tsx
@@ -1,4 +1,5 @@
 import ExpoImage from 'expo-image';
+import { ComponentType } from 'react';
 import { Animated } from 'react-native';
 
 const AnimatedExpoImage = Animated.createAnimatedComponent(ExpoImage);
@@ -9,19 +10,19 @@ AnimatedImage.displayName = 'Image';
 const AnimatedView = Animated.View;
 AnimatedView.displayName = 'View';
 
-const compareComponents: React.ComponentType<any>[] = [AnimatedImage, AnimatedView];
+const compareComponents: ComponentType<any>[] = [AnimatedImage, AnimatedView];
 let selectedCompareComponent = compareComponents[0];
 const listeners: any[] = [];
 
-export function getImageComponent(): React.ComponentType<any> {
+export function getImageComponent(): ComponentType<any> {
   return AnimatedExpoImage;
 }
 
-export function getSelectedCompareComponent(): React.ComponentType<any> {
+export function getSelectedCompareComponent(): ComponentType<any> {
   return selectedCompareComponent;
 }
 
-export function setSelectedCompareComponent(Component: React.ComponentType<any>) {
+export function setSelectedCompareComponent(Component: ComponentType<any>) {
   if (selectedCompareComponent !== Component) {
     selectedCompareComponent = Component;
     listeners.forEach((listener) => listener());

--- a/apps/native-component-list/src/screens/Image/ImageTestScreen.tsx
+++ b/apps/native-component-list/src/screens/Image/ImageTestScreen.tsx
@@ -2,7 +2,7 @@ import { StackScreenProps } from '@react-navigation/stack';
 import * as React from 'react';
 import { Animated, StyleSheet, View, Button, Text } from 'react-native';
 
-import HeaderIconButton, { HeaderContainerRight } from '../../components/HeaderIconButton';
+import { HeaderIconButton, HeaderContainerRight } from '../../components/HeaderIconButton';
 import AnimationBar from './AnimationBar';
 import CompareBar from './CompareBar';
 import {

--- a/apps/native-component-list/src/screens/Image/ImageTestScreen.tsx
+++ b/apps/native-component-list/src/screens/Image/ImageTestScreen.tsx
@@ -2,7 +2,8 @@ import { StackScreenProps } from '@react-navigation/stack';
 import * as React from 'react';
 import { Animated, StyleSheet, View, Button, Text } from 'react-native';
 
-import { HeaderIconButton, HeaderContainerRight } from '../../components/HeaderIconButton';
+import HeaderContainerRight from '../../components/HeaderContainerRight';
+import HeaderIconButton from '../../components/HeaderIconButton';
 import AnimationBar from './AnimationBar';
 import CompareBar from './CompareBar';
 import {


### PR DESCRIPTION
# Why

Currently the NCL components were written in few different conventions, this PR standardize the code for most of the components, improves the typing and cleans up small things here and there.

# How

All components have been refactored to be the functional ones, the prop types utilize now `PropsWithChildren` type where applicable, most of the inline styles has been extracted to stylesheets and few minor type issues, that updated types have caught, has been fixed.

# Test Plan

All the following commands succeed while running in NCL directory:
* `yarn tsc`
* `yarn lint`

I have also run the app on iOS and web and I did not spot any regression or issues.

# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).