### PR TITLE
[location] Update error message for LocationUnavailableException

### DIFF
--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -34,6 +34,7 @@ _This version does not introduce any user-facing changes._
 
 - Fixed `Location.getCurrentPositionAsync` throwing `Location provider is unavailable.` error. ([#14281](https://github.com/expo/expo/pull/14281) by [@m1st4ke](https://github.com/m1st4ke))
 - Fix building errors from use_frameworks! in Podfile. ([#14523](https://github.com/expo/expo/pull/14523) by [@kudo](https://github.com/kudo))
+- Update error message for `LocationUnavailableException` on Android. ([#14539](https://github.com/expo/expo/pull/14539) by [@kylerjensen](https://github.com/kylerjensen))
 
 ### 💡 Others
 

--- a/packages/expo-location/android/src/main/java/expo/modules/location/exceptions/LocationUnavailableException.java
+++ b/packages/expo-location/android/src/main/java/expo/modules/location/exceptions/LocationUnavailableException.java
@@ -5,7 +5,7 @@ import expo.modules.core.errors.CodedException;
 
 public class LocationUnavailableException extends CodedException implements CodedThrowable {
   public LocationUnavailableException() {
-    super("Location provider is unavailable. Make sure that location services are enabled.");
+    super("Location is unavailable. Make sure that location services are enabled.");
   }
 
   @Override


### PR DESCRIPTION
# Why

When attempting to acquire a position on Android, the fused location provider occasionally returns `false` when this module calls `isLocationAvailable()`. This results in a `LocationUnavailableException` being thrown. We experienced this issue at @evereepay and we had a really hard time diagnosing it. Others also experienced this issue, (see #14248), which has since been addressed and partially mitigated. However, we feel like the error message for this exception, should it ever be encountered again, is still slightly misleading and should be updated for clarity.

According to the [documentation](https://developers.google.com/android/reference/com/google/android/gms/location/LocationAvailability#isLocationAvailable%28%29), "Failure to determine location may result from a _number of causes_ including disabled location settings or an inability to retrieve sensor data in the device's environment." This PR introduces a minor wording change that, in our opinion, brings the error message more in line with the actual underlying problem.

# How

1-liner; changed message of `LocationUnavailableException`.

# Test Plan

Throw a `LocationUnavailableException`, observe that the error message is different.

# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff should work correctly for `expo build` (eg: updated `@expo/xdl`). *<--- Not sure how to do this, might need guidance.*
- [x] This diff should work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).