### PR TITLE
[screen-orientation] Fix integration with `react-native-screens` orientation prop

### DIFF
--- a/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager.h
+++ b/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager.h
@@ -36,6 +36,8 @@ typedef enum EXReactAppManagerStatus {
 - (void)appStateDidBecomeActive;
 - (void)appStateDidBecomeInactive;
 
+- (Class)versionedClassFromString:(NSString *)classString;
+
 @property (nonatomic, assign) BOOL isHeadless;
 @property (nonatomic, readonly) BOOL isBridgeRunning;
 @property (nonatomic, readonly) EXReactAppManagerStatus status;

--- a/packages/expo-screen-orientation/CHANGELOG.md
+++ b/packages/expo-screen-orientation/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Fixed an issue with building on Xcode 13. ([#13898](https://github.com/expo/expo/pull/13898) by [@cruzach](https://github.com/cruzach))
 - Fix building errors from use_frameworks! in Podfile. ([#14523](https://github.com/expo/expo/pull/14523) by [@kudo](https://github.com/kudo))
+- Fixed integration with the `react-native-screens` orientation prop.
 
 ### 💡 Others
 

--- a/packages/expo-screen-orientation/CHANGELOG.md
+++ b/packages/expo-screen-orientation/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 - Fixed an issue with building on Xcode 13. ([#13898](https://github.com/expo/expo/pull/13898) by [@cruzach](https://github.com/cruzach))
 - Fix building errors from use_frameworks! in Podfile. ([#14523](https://github.com/expo/expo/pull/14523) by [@kudo](https://github.com/kudo))
-- Fixed integration with the `react-native-screens` orientation prop.
+- Fixed integration with the `react-native-screens` orientation prop. ([#14541](https://github.com/expo/expo/pull/14541) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 


### PR DESCRIPTION
# Why

Fixes https://github.com/software-mansion/react-native-screens/issues/1152.

# How

Uses method added in https://github.com/software-mansion/react-native-screens/pull/1155 to determine if we should use screen orientation from react-native-screens. 

# Test Plan

- bare rn project ✅
- https://snack.expo.dev/9LZ5ItpXl ✅