### PR TITLE
[ios][screen-orientation] Fix orientation lock not working in bare workflow

### DIFF
--- a/packages/expo-modules-core/ios/Services/EXReactNativeAdapter.m
+++ b/packages/expo-modules-core/ios/Services/EXReactNativeAdapter.m
@@ -217,7 +217,7 @@ EX_REGISTER_MODULE();
   } else if (
       _isForegrounded && (
        [notification.name isEqualToString:UIApplicationWillResignActiveNotification] ||
-       [notification.name isEqualToString:UIApplicationWillEnterForegroundNotification] ||
+       [notification.name isEqualToString:UIApplicationDidEnterBackgroundNotification] ||
        RCTSharedApplication().applicationState == UIApplicationStateBackground
       )
     ) {

--- a/packages/expo-screen-orientation/CHANGELOG.md
+++ b/packages/expo-screen-orientation/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Fixed an issue with building on Xcode 13. ([#13898](https://github.com/expo/expo/pull/13898) by [@cruzach](https://github.com/cruzach))
 - Fix building errors from use_frameworks! in Podfile. ([#14523](https://github.com/expo/expo/pull/14523) by [@kudo](https://github.com/kudo))
 - Fixed integration with the `react-native-screens` orientation prop. ([#14541](https://github.com/expo/expo/pull/14541) by [@lukmccall](https://github.com/lukmccall))
-- Fixed orientation lock not working in bare workflow on iOS.
+- Fixed orientation lock not working in bare workflow on iOS. ([#14543](https://github.com/expo/expo/pull/14543) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others
 

--- a/packages/expo-screen-orientation/CHANGELOG.md
+++ b/packages/expo-screen-orientation/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fixed an issue with building on Xcode 13. ([#13898](https://github.com/expo/expo/pull/13898) by [@cruzach](https://github.com/cruzach))
 - Fix building errors from use_frameworks! in Podfile. ([#14523](https://github.com/expo/expo/pull/14523) by [@kudo](https://github.com/kudo))
 - Fixed integration with the `react-native-screens` orientation prop. ([#14541](https://github.com/expo/expo/pull/14541) by [@lukmccall](https://github.com/lukmccall))
+- Fixed orientation lock not working in bare workflow on iOS.
 
 ### 💡 Others
 

--- a/packages/expo-screen-orientation/ios/EXScreenOrientation/EXScreenOrientationModule.m
+++ b/packages/expo-screen-orientation/ios/EXScreenOrientation/EXScreenOrientationModule.m
@@ -32,10 +32,15 @@ EX_EXPORT_MODULE(ExpoScreenOrientation);
 
 - (void)setModuleRegistry:(EXModuleRegistry *)moduleRegistry
 {
+  _screenOrientationRegistry = [moduleRegistry getSingletonModuleForName:@"ScreenOrientationRegistry"];
   [[moduleRegistry getModuleImplementingProtocol:@protocol(EXAppLifecycleService)] registerAppLifecycleListener:self];
   _eventEmitter = [moduleRegistry getModuleImplementingProtocol:@protocol(EXEventEmitterService)];
-  
-  _screenOrientationRegistry = [moduleRegistry getSingletonModuleForName:@"ScreenOrientationRegistry"];
+
+  // TODO: This shouldn't be here, but it temporarily fixes
+  // https://github.com/expo/expo/issues/13641 and https://github.com/expo/expo/issues/11558
+  // We're going to redesign this once we drop support for multiple apps being open in Expo Go at the same time.
+  // Then we probably won't need the screen orientation registry at all. (@tsapeta)
+  [self onAppForegrounded];
 }
 
 EX_EXPORT_METHOD_AS(lockAsync,


### PR DESCRIPTION
# Why

Fixes #13641
Fixes #11558

# How

- Fixed `UIApplicationWillEnterForegroundNotification` being used instead of `UIApplicationDidEnterBackgroundNotification`
- Ensured the screen orientation module is registered as a foregrounded module in the singleton module.

# Test Plan

Tests and examples work as expected in both Expo Go and bare-expo
