### PR TITLE
[android][ios] Update react-native-screens to 3.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Package-specific changes not released in any SDK will be added here just before 
 - Updated `react-native-safe-area-context` from `3.2.0` to `3.3.2`. ([#14303](https://github.com/expo/expo/pull/14303) by [@kudo](https://github.com/kudo))
 - Updated `@react-native-community/viewpager` from `5.0.11` to `react-native-pager-view@5.4.4`. ([#14348](https://github.com/expo/expo/pull/14348) by [@cruzach](https://github.com/cruzach))
 - Updated `@react-native-picker/picker` from `1.6.7` to `2.1.0`. ([#14358](https://github.com/expo/expo/pull/14358) by [@ajsmth](https://github.com/ajsmth))
-- Updated `react-native-screens` from `3.7.2` to `3.8.0`. ([#14542](https://github.com/expo/expo/pull/14542) by [@kudo](https://github.com/kudo))
+- Updated `react-native-screens` from `3.7.2` to `3.8.0`. ([#14544](https://github.com/expo/expo/pull/14544) by [@kudo](https://github.com/kudo))
 
 ### 🛠 Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,10 @@ Package-specific changes not released in any SDK will be added here just before 
 - Updated `react-native-webview` from `11.6.2` to `11.13.0`. ([#14301](https://github.com/expo/expo/pull/14301) by [@kudo](https://github.com/kudo))
 - Updated `react-native-lottie` from `4.0.2` to `4.0.3`. ([#14331](https://github.com/expo/expo/pull/14331) by [@cruzach](https://github.com/cruzach))
 - Updated `@stripe/stripe-react-native` from `0.1.4` to `0.2.2`. ([#14357](https://github.com/expo/expo/pull/14357) & [#14452](https://github.com/expo/expo/pull/14452) by [@cruzach](https://github.com/cruzach))
-- Updated `react-native-screens` from `3.4.0` to `3.7.2`. ([#14330](https://github.com/expo/expo/pull/14330) by [@cruzach](https://github.com/cruzach))
 - Updated `react-native-safe-area-context` from `3.2.0` to `3.3.2`. ([#14303](https://github.com/expo/expo/pull/14303) by [@kudo](https://github.com/kudo))
 - Updated `@react-native-community/viewpager` from `5.0.11` to `react-native-pager-view@5.4.4`. ([#14348](https://github.com/expo/expo/pull/14348) by [@cruzach](https://github.com/cruzach))
 - Updated `@react-native-picker/picker` from `1.6.7` to `2.1.0`. ([#14358](https://github.com/expo/expo/pull/14358) by [@ajsmth](https://github.com/ajsmth))
-- Updated `react-native-screens` from `3.7.2` to `3.8.0`. ([#14544](https://github.com/expo/expo/pull/14544) by [@kudo](https://github.com/kudo))
+- Updated `react-native-screens` from `3.4.0` to `3.8.0`. ([#14330](https://github.com/expo/expo/pull/14330) by [@cruzach](https://github.com/cruzach)) ([#14544](https://github.com/expo/expo/pull/14544) by [@kudo](https://github.com/kudo))
 
 ### 🛠 Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Package-specific changes not released in any SDK will be added here just before 
 - Updated `react-native-safe-area-context` from `3.2.0` to `3.3.2`. ([#14303](https://github.com/expo/expo/pull/14303) by [@kudo](https://github.com/kudo))
 - Updated `@react-native-community/viewpager` from `5.0.11` to `react-native-pager-view@5.4.4`. ([#14348](https://github.com/expo/expo/pull/14348) by [@cruzach](https://github.com/cruzach))
 - Updated `@react-native-picker/picker` from `1.6.7` to `2.1.0`. ([#14358](https://github.com/expo/expo/pull/14358) by [@ajsmth](https://github.com/ajsmth))
+- Updated `react-native-screens` from `3.7.2` to `3.8.0`. ([#14542](https://github.com/expo/expo/pull/14542) by [@kudo](https://github.com/kudo))
 
 ### 🛠 Breaking changes
 

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenStack.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenStack.kt
@@ -11,6 +11,7 @@ import versioned.host.exp.exponent.modules.api.screens.events.StackFinishTransit
 import java.util.Collections
 import kotlin.collections.ArrayList
 import kotlin.collections.HashSet
+import host.exp.expoview.R
 
 class ScreenStack(context: Context?) : ScreenContainer<ScreenStackFragment>(context) {
   private val mStack = ArrayList<ScreenStackFragment>()

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenStackFragment.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenStackFragment.kt
@@ -145,9 +145,6 @@ class ScreenStackFragment : ScreenFragment {
     return view
   }
 
-  val isDismissible: Boolean
-    get() = screen.isGestureEnabled
-
   fun canNavigateBack(): Boolean {
     val container: ScreenContainer<*>? = screen.container
     check(container is ScreenStack) { "ScreenStackFragment added into a non-stack container" }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenStackHeaderConfig.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenStackHeaderConfig.kt
@@ -18,6 +18,8 @@ import com.facebook.react.ReactApplication
 import com.facebook.react.bridge.JSApplicationIllegalArgumentException
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.views.text.ReactTypefaceUtils
+import host.exp.expoview.BuildConfig
+import host.exp.expoview.R
 
 class ScreenStackHeaderConfig(context: Context) : ViewGroup(context) {
   private val mConfigSubviews = ArrayList<ScreenStackHeaderSubview>(3)

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenStackHeaderConfig.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenStackHeaderConfig.kt
@@ -18,8 +18,6 @@ import com.facebook.react.ReactApplication
 import com.facebook.react.bridge.JSApplicationIllegalArgumentException
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.views.text.ReactTypefaceUtils
-import host.exp.expoview.BuildConfig
-import host.exp.expoview.R
 
 class ScreenStackHeaderConfig(context: Context) : ViewGroup(context) {
   private val mConfigSubviews = ArrayList<ScreenStackHeaderSubview>(3)

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -115,7 +115,7 @@
     "react-native-gesture-handler": "~1.10.2",
     "react-native-reanimated": "~2.2.0",
     "react-native-safe-area-context": "3.3.2",
-    "react-native-screens": "~3.7.0",
+    "react-native-screens": "~3.8.0",
     "react-native-shared-element": "0.8.2",
     "react-native-svg": "12.1.1",
     "react-native-unimodules": "~0.15.0-alpha.0",

--- a/apps/bare-sandbox/package.json
+++ b/apps/bare-sandbox/package.json
@@ -19,7 +19,7 @@
     "react-native": "0.64.2",
     "react-native-gesture-handler": "~1.10.2",
     "react-native-reanimated": "~2.2.0",
-    "react-native-screens": "~3.7.0",
+    "react-native-screens": "~3.8.0",
     "react-native-unimodules": "~0.15.0-alpha.0",
     "react-native-web": "~0.17.1"
   },

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -152,7 +152,7 @@
     "react-native-redash": "^14.1.1",
     "react-native-safe-area-context": "3.3.2",
     "react-native-safe-area-view": "^0.14.8",
-    "react-native-screens": "~3.7.0",
+    "react-native-screens": "~3.8.0",
     "react-native-shared-element": "0.8.2",
     "react-native-svg": "12.1.1",
     "react-native-unimodules": "~0.15.0-alpha.0",

--- a/home/package.json
+++ b/home/package.json
@@ -60,7 +60,7 @@
     "react-native-paper": "^4.0.1",
     "react-native-reanimated": "~2.2.0",
     "react-native-safe-area-context": "3.3.2",
-    "react-native-screens": "~3.7.0",
+    "react-native-screens": "~3.8.0",
     "react-redux": "^7.2.0",
     "react-string-replace": "^0.4.4",
     "reanimated-bottom-sheet": "^1.0.0-alpha.18",

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2425,7 +2425,7 @@ PODS:
     - React-RCTVibration
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNScreens (3.7.0):
+  - RNScreens (3.8.0):
     - React-Core
     - React-RCTImage
   - Stripe (21.8.1):
@@ -4238,7 +4238,7 @@ SPEC CHECKSUMS:
   React-runtimeexecutor: a9904c6d0218fb9f8b19d6dd88607225927668f9
   ReactCommon: 149906e01aa51142707a10665185db879898e966
   RNReanimated: 9c13c86454bfd54dab7505c1a054470bfecd2563
-  RNScreens: 2a71d74b4e530f051f5684c8111d7591176722cf
+  RNScreens: 6e1ea5787989f92b0671049b808aef64fa1ef98c
   Stripe: 57c6997c64042a3f5aedae9b76e331942f8b75d2
   stripe-react-native: 48a10900a95709f7527fc712231fe1adc81735ca
   StripeCore: a6e50d58119a0c7601773b56f274db2d394dcdac

--- a/ios/vendored/unversioned/react-native-screens/RNScreens.podspec.json
+++ b/ios/vendored/unversioned/react-native-screens/RNScreens.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "RNScreens",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "summary": "Native navigation primitives for your React Native app.",
   "description": "RNScreens - first incomplete navigation solution for your React Native app",
   "homepage": "https://github.com/software-mansion/react-native-screens",
@@ -14,7 +14,7 @@
   },
   "source": {
     "git": "https://github.com/software-mansion/react-native-screens.git",
-    "tag": "3.7.0"
+    "tag": "3.8.0"
   },
   "source_files": "ios/**/*.{h,m}",
   "requires_arc": true,

--- a/ios/vendored/unversioned/react-native-screens/ios/RNSFullWindowOverlay.m
+++ b/ios/vendored/unversioned/react-native-screens/ios/RNSFullWindowOverlay.m
@@ -33,7 +33,7 @@
     _container = self.container;
     [self show];
   }
-  
+
   return self;
 }
 
@@ -53,7 +53,7 @@
   if (_container == nil) {
     _container = [[RNSFullWindowOverlayContainer alloc] initWithFrame:_reactFrame];
   }
-  
+
   return _container;
 }
 
@@ -68,7 +68,7 @@
   if (!_container) {
     return;
   }
-  
+
   [_container removeFromSuperview];
 }
 

--- a/ios/vendored/unversioned/react-native-screens/ios/RNSScreen.h
+++ b/ios/vendored/unversioned/react-native-screens/ios/RNSScreen.h
@@ -65,6 +65,7 @@ typedef NS_ENUM(NSInteger, RNSWindowTrait) {
 
 - (instancetype)initWithView:(UIView *)view;
 - (void)notifyFinishTransitioning;
+- (UIViewController *)findChildVCForConfigAndTrait:(RNSWindowTrait)trait includingModals:(BOOL)includingModals;
 
 @end
 

--- a/ios/vendored/unversioned/react-native-screens/ios/RNSScreen.m
+++ b/ios/vendored/unversioned/react-native-screens/ios/RNSScreen.m
@@ -35,7 +35,7 @@
     _hasStatusBarHiddenSet = NO;
     _hasOrientationSet = NO;
   }
-  
+
   return self;
 }
 
@@ -88,7 +88,7 @@
   switch (stackPresentation) {
     case RNSScreenStackPresentationModal:
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
-__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
       if (@available(iOS 13.0, tvOS 13.0, *)) {
         _controller.modalPresentationStyle = UIModalPresentationAutomatic;
       } else {
@@ -131,7 +131,7 @@ __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
     _controller.presentationController.delegate = self;
   } else if (_stackPresentation != RNSScreenStackPresentationPush) {
     RCTLogError(
-                @"Screen presentation updated from modal to push, this may likely result in a screen object leakage. If you need to change presentation style create a new screen object instead");
+        @"Screen presentation updated from modal to push, this may likely result in a screen object leakage. If you need to change presentation style create a new screen object instead");
   }
   _stackPresentation = stackPresentation;
 }
@@ -139,7 +139,7 @@ __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
 - (void)setStackAnimation:(RNSScreenStackAnimation)stackAnimation
 {
   _stackAnimation = stackAnimation;
-  
+
   switch (stackAnimation) {
     case RNSScreenStackAnimationFade:
       _controller.modalTransitionStyle = UIModalTransitionStyleCrossDissolve;
@@ -162,12 +162,12 @@ __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
 - (void)setGestureEnabled:(BOOL)gestureEnabled
 {
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
-__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
   if (@available(iOS 13.0, tvOS 13.0, *)) {
     _controller.modalInPresentation = !gestureEnabled;
   }
 #endif
-  
+
   _gestureEnabled = gestureEnabled;
 }
 
@@ -288,7 +288,7 @@ __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
       @"progress" : @(progress),
       @"closing" : @(closing ? 1 : 0),
       @"goingForward" : @(goingForward ? 1 : 0),
-                              });
+    });
   }
 }
 
@@ -419,7 +419,7 @@ __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
 - (UIStatusBarAnimation)preferredStatusBarUpdateAnimation
 {
   UIViewController *vc = [self findChildVCForConfigAndTrait:RNSWindowTraitAnimation includingModals:NO];
-  
+
   if ([vc isKindOfClass:[RNSScreen class]]) {
     return ((RNSScreenView *)vc.view).statusBarAnimation;
   }
@@ -429,7 +429,7 @@ __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
 - (UIInterfaceOrientationMask)supportedInterfaceOrientations
 {
   UIViewController *vc = [self findChildVCForConfigAndTrait:RNSWindowTraitOrientation includingModals:YES];
-  
+
   if ([vc isKindOfClass:[RNSScreen class]]) {
     return ((RNSScreenView *)vc.view).screenOrientation;
   }
@@ -452,11 +452,11 @@ __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
     // asks them by itself, so we can stop traversing here.
     // for screen orientation, we need to start the search again from that modal
     return !includingModals
-    ? nil
-    : [(RNSScreen *)lastViewController findChildVCForConfigAndTrait:trait includingModals:includingModals]
-    ?: lastViewController;
+        ? nil
+        : [(RNSScreen *)lastViewController findChildVCForConfigAndTrait:trait includingModals:includingModals]
+            ?: lastViewController;
   }
-  
+
   UIViewController *selfOrNil = [self hasTraitSet:trait] ? self : nil;
   if (lastViewController == nil) {
     return selfOrNil;
@@ -469,7 +469,7 @@ __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
       UIViewController *childScreen = [lastViewController childViewControllerForStatusBarStyle];
       if ([childScreen isKindOfClass:[RNSScreen class]]) {
         return [(RNSScreen *)childScreen findChildVCForConfigAndTrait:trait includingModals:includingModals]
-        ?: selfOrNil;
+            ?: selfOrNil;
       } else {
         return selfOrNil;
       }
@@ -507,14 +507,14 @@ __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
 - (void)viewDidLayoutSubviews
 {
   [super viewDidLayoutSubviews];
-  
+
   // The below code makes the screen view adapt dimensions provided by the system. We take these
   // into account only when the view is mounted under RNScreensNavigationController in which case system
   // provides additional padding to account for possible header, and in the case when screen is
   // shown as a native modal, as the final dimensions of the modal on iOS 12+ are shorter than the
   // screen size
   BOOL isDisplayedWithinUINavController =
-  [self.parentViewController isKindOfClass:[RNScreensNavigationController class]];
+      [self.parentViewController isKindOfClass:[RNScreensNavigationController class]];
   BOOL isPresentedAsNativeModal = self.parentViewController == nil && self.presentingViewController != nil;
   if ((isDisplayedWithinUINavController || isPresentedAsNativeModal) &&
       !CGRectEqualToRect(_lastViewFrame, self.view.frame)) {
@@ -551,7 +551,7 @@ __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
 - (void)viewWillAppear:(BOOL)animated
 {
   [super viewWillAppear:animated];
-  
+
   if (!_isSwiping) {
     [((RNSScreenView *)self.view) notifyWillAppear];
     if (self.transitionCoordinator.isInteractive) {
@@ -563,10 +563,10 @@ __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
     // The _isSwiping is still true, but we don't want to notify then
     _shouldNotify = NO;
   }
-  
+
   // as per documentation of these methods
   _goingForward = [self isBeingPresented] || [self isMovingToParentViewController];
-  
+
   [RNSScreenWindowTraits updateWindowTraits];
   if (_shouldNotify) {
     _closing = NO;
@@ -578,7 +578,7 @@ __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
 - (void)viewWillDisappear:(BOOL)animated
 {
   [super viewWillDisappear:animated];
-  
+
   if (!self.transitionCoordinator.isInteractive) {
     // user might have long pressed ios 14 back button item,
     // so he can go back more than one screen and we need to dismiss more screens in JS stack then.
@@ -591,7 +591,7 @@ __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
   } else {
     _dismissCount = 1;
   }
-  
+
   // same flow as in viewWillAppear
   if (!_isSwiping) {
     [((RNSScreenView *)self.view) notifyWillDisappear];
@@ -601,10 +601,10 @@ __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
   } else {
     _shouldNotify = NO;
   }
-  
+
   // as per documentation of these methods
   _goingForward = !([self isBeingDismissed] || [self isMovingFromParentViewController]);
-  
+
   if (_shouldNotify) {
     _closing = YES;
     [self notifyTransitionProgress:0.0 closing:_closing goingForward:_goingForward];
@@ -615,14 +615,14 @@ __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
 - (void)viewDidAppear:(BOOL)animated
 {
   [super viewDidAppear:animated];
-  
+
   if (!_isSwiping || _shouldNotify) {
     // we are going forward or dismissing without swipe
     // or successfully swiped back
     [((RNSScreenView *)self.view) notifyAppear];
     [self notifyTransitionProgress:1.0 closing:NO goingForward:_goingForward];
   }
-  
+
   _isSwiping = NO;
   _shouldNotify = YES;
 }
@@ -630,7 +630,7 @@ __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
 - (void)viewDidDisappear:(BOOL)animated
 {
   [super viewDidDisappear:animated];
-  
+
   if (self.parentViewController == nil && self.presentingViewController == nil) {
     if (((RNSScreenView *)self.view).preventNativeDismiss) {
       // if we want to prevent the native dismiss, we do not send dismissal event,
@@ -642,16 +642,16 @@ __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
       [((RNSScreenView *)self.view) notifyDismissedWithCount:_dismissCount];
     }
   }
-  
+
   // same flow as in viewDidAppear
   if (!_isSwiping || _shouldNotify) {
     [((RNSScreenView *)self.view) notifyDisappear];
     [self notifyTransitionProgress:1.0 closing:YES goingForward:_goingForward];
   }
-  
+
   _isSwiping = NO;
   _shouldNotify = YES;
-  
+
   [self traverseForScrollView:self.view];
 }
 
@@ -691,17 +691,17 @@ __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
   if (self.transitionCoordinator != nil) {
     _fakeView.alpha = 0.0;
     [self.transitionCoordinator
-     animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext> _Nonnull context) {
-      [[context containerView] addSubview:self->_fakeView];
-      self->_fakeView.alpha = 1.0;
-      self->_animationTimer = [CADisplayLink displayLinkWithTarget:self selector:@selector(handleAnimation)];
-      [self->_animationTimer addToRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
-    }
-     completion:^(id<UIViewControllerTransitionCoordinatorContext> _Nonnull context) {
-      [self->_animationTimer setPaused:YES];
-      [self->_animationTimer invalidate];
-      [self->_fakeView removeFromSuperview];
-    }];
+        animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext> _Nonnull context) {
+          [[context containerView] addSubview:self->_fakeView];
+          self->_fakeView.alpha = 1.0;
+          self->_animationTimer = [CADisplayLink displayLinkWithTarget:self selector:@selector(handleAnimation)];
+          [self->_animationTimer addToRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
+        }
+        completion:^(id<UIViewControllerTransitionCoordinatorContext> _Nonnull context) {
+          [self->_animationTimer setPaused:YES];
+          [self->_animationTimer invalidate];
+          [self->_fakeView removeFromSuperview];
+        }];
   }
 }
 
@@ -762,55 +762,55 @@ RCT_EXPORT_VIEW_PROPERTY(statusBarStyle, RNSStatusBarStyle)
 @implementation RCTConvert (RNSScreen)
 
 RCT_ENUM_CONVERTER(
-                   RNSScreenStackPresentation,
-                   (@{
-                     @"push" : @(RNSScreenStackPresentationPush),
-                     @"modal" : @(RNSScreenStackPresentationModal),
-                     @"fullScreenModal" : @(RNSScreenStackPresentationFullScreenModal),
-                     @"formSheet" : @(RNSScreenStackPresentationFormSheet),
-                     @"containedModal" : @(RNSScreenStackPresentationContainedModal),
-                     @"transparentModal" : @(RNSScreenStackPresentationTransparentModal),
-                     @"containedTransparentModal" : @(RNSScreenStackPresentationContainedTransparentModal)
-                    }),
-                   RNSScreenStackPresentationPush,
-                   integerValue)
+    RNSScreenStackPresentation,
+    (@{
+      @"push" : @(RNSScreenStackPresentationPush),
+      @"modal" : @(RNSScreenStackPresentationModal),
+      @"fullScreenModal" : @(RNSScreenStackPresentationFullScreenModal),
+      @"formSheet" : @(RNSScreenStackPresentationFormSheet),
+      @"containedModal" : @(RNSScreenStackPresentationContainedModal),
+      @"transparentModal" : @(RNSScreenStackPresentationTransparentModal),
+      @"containedTransparentModal" : @(RNSScreenStackPresentationContainedTransparentModal)
+    }),
+    RNSScreenStackPresentationPush,
+    integerValue)
 
 RCT_ENUM_CONVERTER(
-                   RNSScreenStackAnimation,
-                   (@{
-                     @"default" : @(RNSScreenStackAnimationDefault),
-                     @"none" : @(RNSScreenStackAnimationNone),
-                     @"fade" : @(RNSScreenStackAnimationFade),
-                     @"fade_from_bottom" : @(RNSScreenStackAnimationFadeFromBottom),
-                     @"flip" : @(RNSScreenStackAnimationFlip),
-                     @"simple_push" : @(RNSScreenStackAnimationSimplePush),
-                     @"slide_from_bottom" : @(RNSScreenStackAnimationSlideFromBottom),
-                     @"slide_from_right" : @(RNSScreenStackAnimationDefault),
-                     @"slide_from_left" : @(RNSScreenStackAnimationDefault),
-                    }),
-                   RNSScreenStackAnimationDefault,
-                   integerValue)
+    RNSScreenStackAnimation,
+    (@{
+      @"default" : @(RNSScreenStackAnimationDefault),
+      @"none" : @(RNSScreenStackAnimationNone),
+      @"fade" : @(RNSScreenStackAnimationFade),
+      @"fade_from_bottom" : @(RNSScreenStackAnimationFadeFromBottom),
+      @"flip" : @(RNSScreenStackAnimationFlip),
+      @"simple_push" : @(RNSScreenStackAnimationSimplePush),
+      @"slide_from_bottom" : @(RNSScreenStackAnimationSlideFromBottom),
+      @"slide_from_right" : @(RNSScreenStackAnimationDefault),
+      @"slide_from_left" : @(RNSScreenStackAnimationDefault),
+    }),
+    RNSScreenStackAnimationDefault,
+    integerValue)
 
 RCT_ENUM_CONVERTER(
-                   RNSScreenReplaceAnimation,
-                   (@{
-                     @"push" : @(RNSScreenReplaceAnimationPush),
-                     @"pop" : @(RNSScreenReplaceAnimationPop),
-                    }),
-                   RNSScreenReplaceAnimationPop,
-                   integerValue)
+    RNSScreenReplaceAnimation,
+    (@{
+      @"push" : @(RNSScreenReplaceAnimationPush),
+      @"pop" : @(RNSScreenReplaceAnimationPop),
+    }),
+    RNSScreenReplaceAnimationPop,
+    integerValue)
 
 #if !TARGET_OS_TV
 RCT_ENUM_CONVERTER(
-                   RNSStatusBarStyle,
-                   (@{
-                     @"auto" : @(RNSStatusBarStyleAuto),
-                     @"inverted" : @(RNSStatusBarStyleInverted),
-                     @"light" : @(RNSStatusBarStyleLight),
-                     @"dark" : @(RNSStatusBarStyleDark),
-                    }),
-                   RNSStatusBarStyleAuto,
-                   integerValue)
+    RNSStatusBarStyle,
+    (@{
+      @"auto" : @(RNSStatusBarStyleAuto),
+      @"inverted" : @(RNSStatusBarStyleInverted),
+      @"light" : @(RNSStatusBarStyleLight),
+      @"dark" : @(RNSStatusBarStyleDark),
+    }),
+    RNSStatusBarStyleAuto,
+    integerValue)
 
 + (UIInterfaceOrientationMask)UIInterfaceOrientationMask:(id)json
 {

--- a/ios/vendored/unversioned/react-native-screens/ios/RNSScreenContainer.h
+++ b/ios/vendored/unversioned/react-native-screens/ios/RNSScreenContainer.h
@@ -13,6 +13,8 @@
 
 @interface RNScreensViewController : UIViewController <RNScreensViewControllerDelegate>
 
+- (UIViewController *)findActiveChildVC;
+
 @end
 
 @interface RNSScreenContainerManager : RCTViewManager

--- a/ios/vendored/unversioned/react-native-screens/ios/RNSScreenContainer.m
+++ b/ios/vendored/unversioned/react-native-screens/ios/RNSScreenContainer.m
@@ -148,7 +148,7 @@
     screenRemoved = YES;
     [self detachScreen:screen];
   }
-  
+
   // detect if new screen is going to be activated
   BOOL screenAdded = NO;
   for (RNSScreenView *screen in _reactSubviews) {
@@ -156,7 +156,7 @@
       screenAdded = YES;
     }
   }
-  
+
   if (screenAdded) {
     // add new screens in order they are placed in subviews array
     NSInteger index = 0;
@@ -173,13 +173,13 @@
       }
     }
   }
-  
+
   for (RNSScreenView *screen in _reactSubviews) {
     if (screen.activityState == RNSActivityStateOnTop) {
       [screen notifyFinishTransitioning];
     }
   }
-  
+
   if (screenRemoved || screenAdded) {
     [self maybeDismissVC];
   }

--- a/ios/vendored/unversioned/react-native-screens/ios/RNSScreenNavigationContainer.m
+++ b/ios/vendored/unversioned/react-native-screens/ios/RNSScreenNavigationContainer.m
@@ -25,7 +25,7 @@
       [screen notifyFinishTransitioning];
     }
   }
-  
+
   [self maybeDismissVC];
 }
 

--- a/ios/vendored/unversioned/react-native-screens/ios/RNSScreenStack.m
+++ b/ios/vendored/unversioned/react-native-screens/ios/RNSScreenStack.m
@@ -12,10 +12,10 @@
 #import <React/RCTUIManagerUtils.h>
 
 @interface RNSScreenStackView () <
-UINavigationControllerDelegate,
-UIAdaptivePresentationControllerDelegate,
-UIGestureRecognizerDelegate,
-UIViewControllerTransitioningDelegate>
+    UINavigationControllerDelegate,
+    UIAdaptivePresentationControllerDelegate,
+    UIGestureRecognizerDelegate,
+    UIViewControllerTransitioningDelegate>
 
 @property (nonatomic) NSMutableArray<UIViewController *> *presentedModals;
 @property (nonatomic) BOOL updatingModals;
@@ -84,7 +84,7 @@ UIViewControllerTransitioningDelegate>
     _presentedModals = [NSMutableArray new];
     _controller = [[RNScreensNavigationController alloc] init];
     _controller.delegate = self;
-    
+
 #if !TARGET_OS_TV
     [self setupGestureHandlers];
 #endif
@@ -266,25 +266,25 @@ UIViewControllerTransitioningDelegate>
     _scheduleModalsUpdate = YES;
     return;
   }
-  
+
   // when there is no change we return immediately. This check is important because sometime we may
   // accidently trigger modal dismiss if we don't verify to run the below code only when an actual
   // change in the list of presented modal was made.
   if ([_presentedModals isEqualToArray:controllers]) {
     return;
   }
-  
+
   // if view controller is not yet attached to window we skip updates now and run them when view
   // is attached
   if (self.window == nil && _presentedModals.lastObject.view.window == nil) {
     return;
   }
-  
+
   _updatingModals = YES;
-  
+
   NSMutableArray<UIViewController *> *newControllers = [NSMutableArray arrayWithArray:controllers];
   [newControllers removeObjectsInArray:_presentedModals];
-  
+
   // find bottom-most controller that should stay on the stack for the duration of transition
   NSUInteger changeRootIndex = 0;
   UIViewController *changeRootController = _controller;
@@ -296,7 +296,7 @@ UIViewControllerTransitioningDelegate>
       break;
     }
   }
-  
+
   // we verify that controllers added on top of changeRootIndex are all new. Unfortunately modal
   // VCs cannot be reshuffled (there are some visual glitches when we try to dismiss then show as
   // even non-animated dismissal has delay and updates the screen several times)
@@ -305,9 +305,9 @@ UIViewControllerTransitioningDelegate>
       RCTAssert(false, @"Modally presented controllers are being reshuffled, this is not allowed");
     }
   }
-  
+
   __weak RNSScreenStackView *weakSelf = self;
-  
+
   void (^afterTransitions)(void) = ^{
     if (weakSelf.onFinishTransitioning) {
       weakSelf.onFinishTransitioning(nil);
@@ -324,14 +324,14 @@ UIViewControllerTransitioningDelegate>
     // neither `viewWillAppear` nor `presentationControllerDidDismiss` are called, same for status bar.
     [RNSScreenWindowTraits updateWindowTraits];
   };
-  
+
   void (^finish)(void) = ^{
     NSUInteger oldCount = weakSelf.presentedModals.count;
     if (changeRootIndex < oldCount) {
       [weakSelf.presentedModals removeObjectsInRange:NSMakeRange(changeRootIndex, oldCount - changeRootIndex)];
     }
     BOOL isAttached =
-    changeRootController.parentViewController != nil || changeRootController.presentingViewController != nil;
+        changeRootController.parentViewController != nil || changeRootController.presentingViewController != nil;
     if (!isAttached || changeRootIndex >= controllers.count) {
       // if change controller view is not attached, presenting modals will silently fail on iOS.
       // In such a case we trigger controllers update from didMoveToWindow.
@@ -344,38 +344,38 @@ UIViewControllerTransitioningDelegate>
       for (NSUInteger i = changeRootIndex; i < controllers.count; i++) {
         UIViewController *next = controllers[i];
         BOOL lastModal = (i == controllers.count - 1);
-        
+
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
-__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
         if (@available(iOS 13.0, tvOS 13.0, *)) {
           // Inherit UI style from its parent - solves an issue with incorrect style being applied to some UIKit views
           // like date picker or segmented control.
           next.overrideUserInterfaceStyle = self->_controller.overrideUserInterfaceStyle;
         }
 #endif
-        
+
         BOOL shouldAnimate = lastModal && [next isKindOfClass:[RNSScreen class]] &&
-        ((RNSScreenView *)next.view).stackAnimation != RNSScreenStackAnimationNone;
-        
+            ((RNSScreenView *)next.view).stackAnimation != RNSScreenStackAnimationNone;
+
         [previous presentViewController:next
                                animated:shouldAnimate
                              completion:^{
-          [weakSelf.presentedModals addObject:next];
-          if (lastModal) {
-            afterTransitions();
-          };
-        }];
+                               [weakSelf.presentedModals addObject:next];
+                               if (lastModal) {
+                                 afterTransitions();
+                               };
+                             }];
         previous = next;
       }
     }
   };
-  
+
   if (changeRootController.presentedViewController != nil &&
       [_presentedModals containsObject:changeRootController.presentedViewController]) {
     BOOL shouldAnimate = changeRootIndex == controllers.count &&
-    [changeRootController.presentedViewController isKindOfClass:[RNSScreen class]] &&
-    ((RNSScreenView *)changeRootController.presentedViewController.view).stackAnimation !=
-    RNSScreenStackAnimationNone;
+        [changeRootController.presentedViewController isKindOfClass:[RNSScreen class]] &&
+        ((RNSScreenView *)changeRootController.presentedViewController.view).stackAnimation !=
+            RNSScreenStackAnimationNone;
     [changeRootController dismissViewControllerAnimated:shouldAnimate completion:finish];
   } else {
     finish();
@@ -388,7 +388,7 @@ __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
   if ([_controller.viewControllers isEqualToArray:controllers]) {
     return;
   }
-  
+
   // if view controller is not yet attached to window we skip updates now and run them when view
   // is attached
   if (self.window == nil) {
@@ -405,28 +405,28 @@ __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
       _updateScheduled = YES;
       __weak RNSScreenStackView *weakSelf = self;
       [_controller.transitionCoordinator
-       animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext> _Nonnull context) {
-        // do nothing here, we only want to be notified when transition is complete
-      }
-       completion:^(id<UIViewControllerTransitionCoordinatorContext> _Nonnull context) {
-        self->_updateScheduled = NO;
-        [weakSelf updateContainer];
-      }];
+          animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext> _Nonnull context) {
+            // do nothing here, we only want to be notified when transition is complete
+          }
+          completion:^(id<UIViewControllerTransitionCoordinatorContext> _Nonnull context) {
+            self->_updateScheduled = NO;
+            [weakSelf updateContainer];
+          }];
     }
     return;
   }
-  
+
   UIViewController *top = controllers.lastObject;
   UIViewController *lastTop = _controller.viewControllers.lastObject;
-  
+
   // at the start we set viewControllers to contain a single UIVIewController
   // instance. This is a workaround for header height adjustment bug (see comment
   // in the init function). Here, we need to detect if the initial empty
   // controller is still there
   BOOL firstTimePush = ![lastTop isKindOfClass:[RNSScreen class]];
-  
+
   BOOL shouldAnimate = !firstTimePush && ((RNSScreenView *)lastTop.view).stackAnimation != RNSScreenStackAnimationNone;
-  
+
   if (firstTimePush) {
     // nothing pushed yet
     [_controller setViewControllers:controllers animated:NO];
@@ -484,7 +484,7 @@ __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
       }
     }
   }
-  
+
   [self setPushViewControllers:pushControllers];
   [self setModalViewControllers:modalControllers];
 }
@@ -554,11 +554,11 @@ __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
 - (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer
 {
   RNSScreenView *topScreen = (RNSScreenView *)_controller.viewControllers.lastObject.view;
-  
+
   if (!topScreen.gestureEnabled || _controller.viewControllers.count < 2) {
     return NO;
   }
-  
+
 #if TARGET_OS_TV
   [self cancelTouchesInParent];
   return YES;
@@ -573,15 +573,15 @@ __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
     }
     return NO;
   }
-  
+
   if (topScreen.customAnimationOnSwipe && [RNSScreenStackAnimator isCustomAnimation:topScreen.stackAnimation]) {
     if ([gestureRecognizer isKindOfClass:[RNSScreenEdgeGestureRecognizer class]]) {
       // if we do not set any explicit `semanticContentAttribute`, it is `UISemanticContentAttributeUnspecified` instead
       // of `UISemanticContentAttributeForceLeftToRight`, so we just check if it is RTL or not
       BOOL isCorrectEdge = (_controller.view.semanticContentAttribute == UISemanticContentAttributeForceRightToLeft &&
                             ((RNSScreenEdgeGestureRecognizer *)gestureRecognizer).edges == UIRectEdgeRight) ||
-      (_controller.view.semanticContentAttribute != UISemanticContentAttributeForceRightToLeft &&
-       ((RNSScreenEdgeGestureRecognizer *)gestureRecognizer).edges == UIRectEdgeLeft);
+          (_controller.view.semanticContentAttribute != UISemanticContentAttributeForceRightToLeft &&
+           ((RNSScreenEdgeGestureRecognizer *)gestureRecognizer).edges == UIRectEdgeLeft);
       if (isCorrectEdge) {
         [self cancelTouchesInParent];
         return YES;
@@ -607,17 +607,17 @@ __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
 {
   // gesture recognizers for custom stack animations
   RNSScreenEdgeGestureRecognizer *leftEdgeSwipeGestureRecognizer =
-  [[RNSScreenEdgeGestureRecognizer alloc] initWithTarget:self action:@selector(handleSwipe:)];
+      [[RNSScreenEdgeGestureRecognizer alloc] initWithTarget:self action:@selector(handleSwipe:)];
   leftEdgeSwipeGestureRecognizer.edges = UIRectEdgeLeft;
   leftEdgeSwipeGestureRecognizer.delegate = self;
   [self addGestureRecognizer:leftEdgeSwipeGestureRecognizer];
-  
+
   RNSScreenEdgeGestureRecognizer *rightEdgeSwipeGestureRecognizer =
-  [[RNSScreenEdgeGestureRecognizer alloc] initWithTarget:self action:@selector(handleSwipe:)];
+      [[RNSScreenEdgeGestureRecognizer alloc] initWithTarget:self action:@selector(handleSwipe:)];
   rightEdgeSwipeGestureRecognizer.edges = UIRectEdgeRight;
   rightEdgeSwipeGestureRecognizer.delegate = self;
   [self addGestureRecognizer:rightEdgeSwipeGestureRecognizer];
-  
+
   // gesture recognizer for full width swipe gesture
   RNSPanGestureRecognizer *panRecognizer = [[RNSPanGestureRecognizer alloc] initWithTarget:self
                                                                                     action:@selector(handleSwipe:)];
@@ -635,26 +635,26 @@ __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
     translation = -translation;
     velocity = -velocity;
   }
-  
+
   float transitionProgress = (translation / distance);
-  
+
   switch (gestureRecognizer.state) {
     case UIGestureRecognizerStateBegan: {
       _interactionController = [UIPercentDrivenInteractiveTransition new];
       [_controller popViewControllerAnimated:YES];
       break;
     }
-      
+
     case UIGestureRecognizerStateChanged: {
       [_interactionController updateInteractiveTransition:transitionProgress];
       break;
     }
-      
+
     case UIGestureRecognizerStateCancelled: {
       [_interactionController cancelInteractiveTransition];
       break;
     }
-      
+
     case UIGestureRecognizerStateEnded: {
       // values taken from
       // https://github.com/react-navigation/react-navigation/blob/54739828598d7072c1bf7b369659e3682db3edc5/packages/stack/src/views/Stack/Card.tsx#L316
@@ -675,13 +675,13 @@ __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
 
 - (id<UIViewControllerInteractiveTransitioning>)navigationController:(UINavigationController *)navigationController
                          interactionControllerForAnimationController:
-(id<UIViewControllerAnimatedTransitioning>)animationController
+                             (id<UIViewControllerAnimatedTransitioning>)animationController
 {
   return _interactionController;
 }
 
 - (id<UIViewControllerInteractiveTransitioning>)interactionControllerForDismissal:
-(id<UIViewControllerAnimatedTransitioning>)animator
+    (id<UIViewControllerAnimatedTransitioning>)animator
 {
   return _interactionController;
 }

--- a/ios/vendored/unversioned/react-native-screens/ios/RNSScreenStackAnimator.m
+++ b/ios/vendored/unversioned/react-native-screens/ios/RNSScreenStackAnimator.m
@@ -21,14 +21,14 @@
   RNSScreenView *screen;
   if (_operation == UINavigationControllerOperationPush) {
     UIViewController *toViewController =
-    [transitionContext viewControllerForKey:UITransitionContextToViewControllerKey];
+        [transitionContext viewControllerForKey:UITransitionContextToViewControllerKey];
     screen = (RNSScreenView *)toViewController.view;
   } else if (_operation == UINavigationControllerOperationPop) {
     UIViewController *fromViewController =
-    [transitionContext viewControllerForKey:UITransitionContextFromViewControllerKey];
+        [transitionContext viewControllerForKey:UITransitionContextFromViewControllerKey];
     screen = (RNSScreenView *)fromViewController.view;
   }
-  
+
   if (screen != nil && screen.stackAnimation == RNSScreenStackAnimationNone) {
     return 0;
   }
@@ -39,16 +39,16 @@
 {
   UIViewController *toViewController = [transitionContext viewControllerForKey:UITransitionContextToViewControllerKey];
   UIViewController *fromViewController =
-  [transitionContext viewControllerForKey:UITransitionContextFromViewControllerKey];
+      [transitionContext viewControllerForKey:UITransitionContextFromViewControllerKey];
   toViewController.view.frame = [transitionContext finalFrameForViewController:toViewController];
-  
+
   RNSScreenView *screen;
   if (_operation == UINavigationControllerOperationPush) {
     screen = (RNSScreenView *)toViewController.view;
   } else if (_operation == UINavigationControllerOperationPop) {
     screen = (RNSScreenView *)fromViewController.view;
   }
-  
+
   if (screen != nil) {
     if (screen.fullScreenSwipeEnabled && transitionContext.isInteractive) {
       // we are swiping with full width gesture
@@ -78,32 +78,32 @@
 {
   float containerWidth = transitionContext.containerView.bounds.size.width;
   float belowViewWidth = containerWidth * 0.3;
-  
+
   CGAffineTransform rightTransform = CGAffineTransformMakeTranslation(containerWidth, 0);
   CGAffineTransform leftTransform = CGAffineTransformMakeTranslation(-belowViewWidth, 0);
-  
+
   if (toViewController.navigationController.view.semanticContentAttribute ==
       UISemanticContentAttributeForceRightToLeft) {
     rightTransform = CGAffineTransformMakeTranslation(-containerWidth, 0);
     leftTransform = CGAffineTransformMakeTranslation(belowViewWidth, 0);
   }
-  
+
   if (_operation == UINavigationControllerOperationPush) {
     toViewController.view.transform = rightTransform;
     [[transitionContext containerView] addSubview:toViewController.view];
     [UIView animateWithDuration:[self transitionDuration:transitionContext]
-                     animations:^{
-      fromViewController.view.transform = leftTransform;
-      toViewController.view.transform = CGAffineTransformIdentity;
-    }
-                     completion:^(BOOL finished) {
-      fromViewController.view.transform = CGAffineTransformIdentity;
-      [transitionContext completeTransition:![transitionContext transitionWasCancelled]];
-    }];
+        animations:^{
+          fromViewController.view.transform = leftTransform;
+          toViewController.view.transform = CGAffineTransformIdentity;
+        }
+        completion:^(BOOL finished) {
+          fromViewController.view.transform = CGAffineTransformIdentity;
+          [transitionContext completeTransition:![transitionContext transitionWasCancelled]];
+        }];
   } else if (_operation == UINavigationControllerOperationPop) {
     toViewController.view.transform = leftTransform;
     [[transitionContext containerView] insertSubview:toViewController.view belowSubview:fromViewController.view];
-    
+
     void (^animationBlock)(void) = ^{
       toViewController.view.transform = CGAffineTransformIdentity;
       fromViewController.view.transform = rightTransform;
@@ -114,7 +114,7 @@
       }
       [transitionContext completeTransition:![transitionContext transitionWasCancelled]];
     };
-    
+
     if (!transitionContext.isInteractive) {
       [UIView animateWithDuration:[self transitionDuration:transitionContext]
                        animations:animationBlock
@@ -135,30 +135,30 @@
                                   fromVC:(UIViewController *)fromViewController
 {
   toViewController.view.frame = [transitionContext finalFrameForViewController:toViewController];
-  
+
   if (_operation == UINavigationControllerOperationPush) {
     [[transitionContext containerView] addSubview:toViewController.view];
     toViewController.view.alpha = 0.0;
     [UIView animateWithDuration:[self transitionDuration:transitionContext]
-                     animations:^{
-      toViewController.view.alpha = 1.0;
-    }
-                     completion:^(BOOL finished) {
-      [transitionContext completeTransition:![transitionContext transitionWasCancelled]];
-    }];
+        animations:^{
+          toViewController.view.alpha = 1.0;
+        }
+        completion:^(BOOL finished) {
+          [transitionContext completeTransition:![transitionContext transitionWasCancelled]];
+        }];
   } else if (_operation == UINavigationControllerOperationPop) {
     [[transitionContext containerView] insertSubview:toViewController.view belowSubview:fromViewController.view];
-    
+
     [UIView animateWithDuration:[self transitionDuration:transitionContext]
-                     animations:^{
-      fromViewController.view.alpha = 0.0;
-    }
-                     completion:^(BOOL finished) {
-      if (transitionContext.transitionWasCancelled) {
-        toViewController.view.transform = CGAffineTransformIdentity;
-      }
-      [transitionContext completeTransition:![transitionContext transitionWasCancelled]];
-    }];
+        animations:^{
+          fromViewController.view.alpha = 0.0;
+        }
+        completion:^(BOOL finished) {
+          if (transitionContext.transitionWasCancelled) {
+            toViewController.view.transform = CGAffineTransformIdentity;
+          }
+          [transitionContext completeTransition:![transitionContext transitionWasCancelled]];
+        }];
   }
 }
 
@@ -167,31 +167,31 @@
                                              fromVC:(UIViewController *)fromViewController
 {
   CGAffineTransform topBottomTransform =
-  CGAffineTransformMakeTranslation(0, transitionContext.containerView.bounds.size.height);
-  
+      CGAffineTransformMakeTranslation(0, transitionContext.containerView.bounds.size.height);
+
   if (_operation == UINavigationControllerOperationPush) {
     toViewController.view.transform = topBottomTransform;
     [[transitionContext containerView] addSubview:toViewController.view];
     [UIView animateWithDuration:[self transitionDuration:transitionContext]
-                     animations:^{
-      fromViewController.view.transform = CGAffineTransformIdentity;
-      toViewController.view.transform = CGAffineTransformIdentity;
-    }
-                     completion:^(BOOL finished) {
-      fromViewController.view.transform = CGAffineTransformIdentity;
-      [transitionContext completeTransition:![transitionContext transitionWasCancelled]];
-    }];
+        animations:^{
+          fromViewController.view.transform = CGAffineTransformIdentity;
+          toViewController.view.transform = CGAffineTransformIdentity;
+        }
+        completion:^(BOOL finished) {
+          fromViewController.view.transform = CGAffineTransformIdentity;
+          [transitionContext completeTransition:![transitionContext transitionWasCancelled]];
+        }];
   } else if (_operation == UINavigationControllerOperationPop) {
     toViewController.view.transform = CGAffineTransformIdentity;
     [[transitionContext containerView] insertSubview:toViewController.view belowSubview:fromViewController.view];
     [UIView animateWithDuration:[self transitionDuration:transitionContext]
-                     animations:^{
-      toViewController.view.transform = CGAffineTransformIdentity;
-      fromViewController.view.transform = topBottomTransform;
-    }
-                     completion:^(BOOL finished) {
-      [transitionContext completeTransition:![transitionContext transitionWasCancelled]];
-    }];
+        animations:^{
+          toViewController.view.transform = CGAffineTransformIdentity;
+          fromViewController.view.transform = topBottomTransform;
+        }
+        completion:^(BOOL finished) {
+          [transitionContext completeTransition:![transitionContext transitionWasCancelled]];
+        }];
   }
 }
 
@@ -200,56 +200,56 @@
                                             fromVC:(UIViewController *)fromViewController
 {
   CGAffineTransform topBottomTransform =
-  CGAffineTransformMakeTranslation(0, 0.08 * transitionContext.containerView.bounds.size.height);
-  
+      CGAffineTransformMakeTranslation(0, 0.08 * transitionContext.containerView.bounds.size.height);
+
   if (_operation == UINavigationControllerOperationPush) {
     toViewController.view.transform = topBottomTransform;
     toViewController.view.alpha = 0.0;
     [[transitionContext containerView] addSubview:toViewController.view];
-    
+
     // Android Nougat open animation
     // http://aosp.opersys.com/xref/android-7.1.2_r37/xref/frameworks/base/core/res/res/anim/activity_open_enter.xml
     [UIView animateWithDuration:0.35
-                          delay:0
-                        options:UIViewAnimationOptionCurveEaseOut
-                     animations:^{
-      fromViewController.view.transform = CGAffineTransformIdentity;
-      toViewController.view.transform = CGAffineTransformIdentity;
-    }
-                     completion:^(BOOL finished) {
-      fromViewController.view.transform = CGAffineTransformIdentity;
-      [transitionContext completeTransition:![transitionContext transitionWasCancelled]];
-    }];
+        delay:0
+        options:UIViewAnimationOptionCurveEaseOut
+        animations:^{
+          fromViewController.view.transform = CGAffineTransformIdentity;
+          toViewController.view.transform = CGAffineTransformIdentity;
+        }
+        completion:^(BOOL finished) {
+          fromViewController.view.transform = CGAffineTransformIdentity;
+          [transitionContext completeTransition:![transitionContext transitionWasCancelled]];
+        }];
     [UIView animateWithDuration:0.2
                           delay:0
                         options:UIViewAnimationOptionCurveEaseOut
                      animations:^{
-      toViewController.view.alpha = 1.0;
-    }
+                       toViewController.view.alpha = 1.0;
+                     }
                      completion:nil];
-    
+
   } else if (_operation == UINavigationControllerOperationPop) {
     toViewController.view.transform = CGAffineTransformIdentity;
     [[transitionContext containerView] insertSubview:toViewController.view belowSubview:fromViewController.view];
-    
+
     // Android Nougat exit animation
     // http://aosp.opersys.com/xref/android-7.1.2_r37/xref/frameworks/base/core/res/res/anim/activity_close_exit.xml
     [UIView animateWithDuration:0.25
-                          delay:0
-                        options:UIViewAnimationOptionCurveEaseIn
-                     animations:^{
-      toViewController.view.transform = CGAffineTransformIdentity;
-      fromViewController.view.transform = topBottomTransform;
-    }
-                     completion:^(BOOL finished) {
-      [transitionContext completeTransition:![transitionContext transitionWasCancelled]];
-    }];
+        delay:0
+        options:UIViewAnimationOptionCurveEaseIn
+        animations:^{
+          toViewController.view.transform = CGAffineTransformIdentity;
+          fromViewController.view.transform = topBottomTransform;
+        }
+        completion:^(BOOL finished) {
+          [transitionContext completeTransition:![transitionContext transitionWasCancelled]];
+        }];
     [UIView animateWithDuration:0.15
                           delay:0.1
                         options:UIViewAnimationOptionCurveLinear
                      animations:^{
-      fromViewController.view.alpha = 0.0;
-    }
+                       fromViewController.view.alpha = 0.0;
+                     }
                      completion:nil];
   }
 }

--- a/ios/vendored/unversioned/react-native-screens/ios/RNSScreenStackHeaderConfig.m
+++ b/ios/vendored/unversioned/react-native-screens/ios/RNSScreenStackHeaderConfig.m
@@ -64,7 +64,7 @@
 }
 
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_14_0) && \
-__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_14_0
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_14_0
 - (void)setMenu:(UIMenu *)menu
 {
   if (@available(iOS 14.0, *)) {
@@ -130,7 +130,7 @@ __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_14_0
     // problem when config gets updated while the transition is ongoing.
     nextVC = nav.topViewController;
   }
-  
+
   BOOL isInFullScreenModal = nav == nil && _screenView.stackPresentation == RNSScreenStackPresentationFullScreenModal;
   // if nav is nil, it means we can be in a fullScreen modal, so there is no nextVC, but we still want to update
   if (vc != nil && (nextVC == vc || isInFullScreenModal)) {
@@ -159,7 +159,7 @@ __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_14_0
   // seems to load the custom back image so we change the tint color's alpha by a very small amount and then set it to
   // the one it should have.
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_14_0) && \
-__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_14_0
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_14_0
   // it brakes the behavior of `headerRight` in iOS 14, where the bug desribed above seems to be fixed, so we do nothing
   // in iOS 14
   if (@available(iOS 14.0, *)) {
@@ -169,16 +169,16 @@ __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_14_0
     [navbar setTintColor:[config.color colorWithAlphaComponent:CGColorGetAlpha(config.color.CGColor) - 0.01]];
   }
   [navbar setTintColor:config.color];
-  
+
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
-__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
   if (@available(iOS 13.0, *)) {
     // font customized on the navigation item level, so nothing to do here
   } else
 #endif
   {
     BOOL hideShadow = config.hideShadow;
-    
+
     if (config.backgroundColor && CGColorGetAlpha(config.backgroundColor.CGColor) == 0.) {
       [navbar setBackgroundImage:[UIImage new] forBarMetrics:UIBarMetricsDefault];
       [navbar setBarTintColor:[UIColor clearColor]];
@@ -189,14 +189,14 @@ __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
     }
     [navbar setTranslucent:config.translucent];
     [navbar setValue:@(hideShadow ? YES : NO) forKey:@"hidesShadow"];
-    
+
     if (config.titleFontFamily || config.titleFontSize || config.titleFontWeight || config.titleColor) {
       NSMutableDictionary *attrs = [NSMutableDictionary new];
-      
+
       if (config.titleColor) {
         attrs[NSForegroundColorAttributeName] = config.titleColor;
       }
-      
+
       NSString *family = config.titleFontFamily ?: nil;
       NSNumber *size = config.titleFontSize ?: @17;
       NSString *weight = config.titleFontWeight ?: nil;
@@ -213,7 +213,7 @@ __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
       }
       [navbar setTitleTextAttributes:attrs];
     }
-    
+
 #if !TARGET_OS_TV
     if (@available(iOS 11.0, *)) {
       if (config.largeTitle &&
@@ -222,7 +222,7 @@ __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
         NSMutableDictionary *largeAttrs = [NSMutableDictionary new];
         if (config.largeTitleColor || config.titleColor) {
           largeAttrs[NSForegroundColorAttributeName] =
-          config.largeTitleColor ? config.largeTitleColor : config.titleColor;
+              config.largeTitleColor ? config.largeTitleColor : config.titleColor;
         }
         NSString *largeFamily = config.largeTitleFontFamily ?: nil;
         NSNumber *largeSize = config.largeTitleFontSize ?: @34;
@@ -271,10 +271,10 @@ __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
         // in order to trigger proper reload that'd update the image attribute.
         RCTImageSource *source = imageView.imageSources[0];
         [imageView reactSetFrame:CGRectMake(
-                                            imageView.frame.origin.x,
-                                            imageView.frame.origin.y,
-                                            source.size.width,
-                                            source.size.height)];
+                                     imageView.frame.origin.x,
+                                     imageView.frame.origin.y,
+                                     source.size.width,
+                                     source.size.height)];
       }
       UIImage *image = imageView.image;
       // IMPORTANT!!!
@@ -303,18 +303,18 @@ __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
         // image on load to trigger, but that would require even more private method hacking.
         if (vc.transitionCoordinator) {
           [vc.transitionCoordinator
-           animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext> _Nonnull context) {
-            // nothing, we just want completion
-          }
-           completion:^(id<UIViewControllerTransitionCoordinatorContext> _Nonnull context) {
-            // in order for new back button image to be loaded we need to trigger another change
-            // in back button props that'd make UIKit redraw the button. Otherwise the changes are
-            // not reflected. Here we change back button visibility which is then immediately restored
+              animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext> _Nonnull context) {
+                // nothing, we just want completion
+              }
+              completion:^(id<UIViewControllerTransitionCoordinatorContext> _Nonnull context) {
+          // in order for new back button image to be loaded we need to trigger another change
+          // in back button props that'd make UIKit redraw the button. Otherwise the changes are
+          // not reflected. Here we change back button visibility which is then immediately restored
 #if !TARGET_OS_TV
-            vc.navigationItem.hidesBackButton = YES;
+                vc.navigationItem.hidesBackButton = YES;
 #endif
-            [config updateViewControllerIfNeeded];
-          }];
+                [config updateViewControllerIfNeeded];
+              }];
         }
         return [UIImage new];
       } else {
@@ -333,39 +333,39 @@ __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
 }
 
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
-__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
 + (UINavigationBarAppearance *)buildAppearance:(UIViewController *)vc
                                     withConfig:(RNSScreenStackHeaderConfig *)config API_AVAILABLE(ios(13.0))
 {
   UINavigationBarAppearance *appearance = [UINavigationBarAppearance new];
-  
+
   if (config.backgroundColor && CGColorGetAlpha(config.backgroundColor.CGColor) == 0.) {
     // transparent background color
     [appearance configureWithTransparentBackground];
   } else {
     [appearance configureWithOpaqueBackground];
   }
-  
+
   // set background color if specified
   if (config.backgroundColor) {
     appearance.backgroundColor = config.backgroundColor;
   }
-  
+
   if (config.blurEffect) {
     appearance.backgroundEffect = [UIBlurEffect effectWithStyle:config.blurEffect];
   }
-  
+
   if (config.hideShadow) {
     appearance.shadowColor = nil;
   }
-  
+
   if (config.titleFontFamily || config.titleFontSize || config.titleFontWeight || config.titleColor) {
     NSMutableDictionary *attrs = [NSMutableDictionary new];
-    
+
     if (config.titleColor) {
       attrs[NSForegroundColorAttributeName] = config.titleColor;
     }
-    
+
     NSString *family = config.titleFontFamily ?: nil;
     NSNumber *size = config.titleFontSize ?: @17;
     NSString *weight = config.titleFontWeight ?: nil;
@@ -382,15 +382,15 @@ __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
     }
     appearance.titleTextAttributes = attrs;
   }
-  
+
   if (config.largeTitleFontFamily || config.largeTitleFontSize || config.largeTitleFontWeight ||
       config.largeTitleColor || config.titleColor) {
     NSMutableDictionary *largeAttrs = [NSMutableDictionary new];
-    
+
     if (config.largeTitleColor || config.titleColor) {
       largeAttrs[NSForegroundColorAttributeName] = config.largeTitleColor ? config.largeTitleColor : config.titleColor;
     }
-    
+
     NSString *largeFamily = config.largeTitleFontFamily ?: nil;
     NSNumber *largeSize = config.largeTitleFontSize ?: @34;
     NSString *largeWeight = config.largeTitleFontWeight ?: nil;
@@ -405,10 +405,10 @@ __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
     } else {
       largeAttrs[NSFontAttributeName] = [UIFont systemFontOfSize:[largeSize floatValue] weight:UIFontWeightBold];
     }
-    
+
     appearance.largeTitleTextAttributes = largeAttrs;
   }
-  
+
   UIImage *backButtonImage = [self loadBackButtonImageInViewController:vc withConfig:config];
   if (backButtonImage) {
     [appearance setBackIndicatorImage:backButtonImage transitionMaskImage:backButtonImage];
@@ -425,14 +425,14 @@ __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
 {
   UINavigationItem *navitem = vc.navigationItem;
   UINavigationController *navctr = (UINavigationController *)vc.parentViewController;
-  
+
   NSUInteger currentIndex = [navctr.viewControllers indexOfObject:vc];
   UINavigationItem *prevItem =
-  currentIndex > 0 ? [navctr.viewControllers objectAtIndex:currentIndex - 1].navigationItem : nil;
-  
+      currentIndex > 0 ? [navctr.viewControllers objectAtIndex:currentIndex - 1].navigationItem : nil;
+
   BOOL wasHidden = navctr.navigationBarHidden;
   BOOL shouldHide = config == nil || config.hide;
-  
+
   if (!shouldHide && !config.translucent) {
     // when nav bar is not translucent we chage edgesForExtendedLayout to avoid system laying out
     // the screen underneath navigation controllers
@@ -441,19 +441,21 @@ __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
     // system default is UIRectEdgeAll
     vc.edgesForExtendedLayout = UIRectEdgeAll;
   }
-  
+
   [navctr setNavigationBarHidden:shouldHide animated:animated];
-  
-  if (config.direction == UISemanticContentAttributeForceLeftToRight ||
-      config.direction == UISemanticContentAttributeForceRightToLeft) {
+
+  if ((config.direction == UISemanticContentAttributeForceLeftToRight ||
+       config.direction == UISemanticContentAttributeForceRightToLeft) &&
+      // iOS 12 cancels swipe gesture when direction is changed. See #1091
+      navctr.view.semanticContentAttribute != config.direction) {
     navctr.view.semanticContentAttribute = config.direction;
     navctr.navigationBar.semanticContentAttribute = config.direction;
   }
-  
+
   if (shouldHide) {
     return;
   }
-  
+
   navitem.title = config.title;
 #if !TARGET_OS_TV
   if (config.backTitle != nil || config.backTitleFontFamily || config.backTitleFontSize ||
@@ -462,9 +464,9 @@ __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
                                                                                 style:UIBarButtonItemStylePlain
                                                                                target:nil
                                                                                action:nil];
-    
+
     [backBarButtonItem setMenuHidden:config.disableBackButtonMenu];
-    
+
     prevItem.backBarButtonItem = backBarButtonItem;
     if (config.backTitleFontFamily || config.backTitleFontSize) {
       NSMutableDictionary *attrs = [NSMutableDictionary new];
@@ -485,25 +487,25 @@ __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
   } else {
     prevItem.backBarButtonItem = nil;
   }
-  
+
   if (@available(iOS 11.0, *)) {
     if (config.largeTitle) {
       navctr.navigationBar.prefersLargeTitles = YES;
     }
     navitem.largeTitleDisplayMode =
-    config.largeTitle ? UINavigationItemLargeTitleDisplayModeAlways : UINavigationItemLargeTitleDisplayModeNever;
+        config.largeTitle ? UINavigationItemLargeTitleDisplayModeAlways : UINavigationItemLargeTitleDisplayModeNever;
   }
 #endif
-  
+
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
-__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
   if (@available(iOS 13.0, tvOS 13.0, *)) {
     UINavigationBarAppearance *appearance = [self buildAppearance:vc withConfig:config];
     navitem.standardAppearance = appearance;
     navitem.compactAppearance = appearance;
-    
+
     UINavigationBarAppearance *scrollEdgeAppearance =
-    [[UINavigationBarAppearance alloc] initWithBarAppearance:appearance];
+        [[UINavigationBarAppearance alloc] initWithBarAppearance:appearance];
     if (config.largeTitleBackgroundColor != nil) {
       scrollEdgeAppearance.backgroundColor = config.largeTitleBackgroundColor;
     }
@@ -569,7 +571,7 @@ __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
       }
     }
   }
-  
+
   if (animated && vc.transitionCoordinator != nil &&
       vc.transitionCoordinator.presentationStyle == UIModalPresentationNone && !wasHidden) {
     // when there is an ongoing transition we may need to update navbar setting in animation block
@@ -580,22 +582,22 @@ __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
     // types of transitions there is no "shared" navigation bar that needs to be updated in an animated
     // way.
     [vc.transitionCoordinator
-     animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext> _Nonnull context) {
-      [self setAnimatedConfig:vc withConfig:config];
-    }
-     completion:^(id<UIViewControllerTransitionCoordinatorContext> _Nonnull context) {
-      if ([context isCancelled]) {
-        UIViewController *fromVC = [context viewControllerForKey:UITransitionContextFromViewControllerKey];
-        RNSScreenStackHeaderConfig *config = nil;
-        for (UIView *subview in fromVC.view.reactSubviews) {
-          if ([subview isKindOfClass:[RNSScreenStackHeaderConfig class]]) {
-            config = (RNSScreenStackHeaderConfig *)subview;
-            break;
-          }
+        animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext> _Nonnull context) {
+          [self setAnimatedConfig:vc withConfig:config];
         }
-        [self setAnimatedConfig:fromVC withConfig:config];
-      }
-    }];
+        completion:^(id<UIViewControllerTransitionCoordinatorContext> _Nonnull context) {
+          if ([context isCancelled]) {
+            UIViewController *fromVC = [context viewControllerForKey:UITransitionContextFromViewControllerKey];
+            RNSScreenStackHeaderConfig *config = nil;
+            for (UIView *subview in fromVC.view.reactSubviews) {
+              if ([subview isKindOfClass:[RNSScreenStackHeaderConfig class]]) {
+                config = (RNSScreenStackHeaderConfig *)subview;
+                break;
+              }
+            }
+            [self setAnimatedConfig:fromVC withConfig:config];
+          }
+        }];
   } else {
     [self setAnimatedConfig:vc withConfig:config];
   }
@@ -651,7 +653,7 @@ RCT_EXPORT_VIEW_PROPERTY(translucent, BOOL)
     @"light" : @(UIBlurEffectStyleLight),
     @"dark" : @(UIBlurEffectStyleDark),
   }];
-  
+
   if (@available(iOS 10.0, *)) {
     [blurEffects addEntriesFromDictionary:@{
       @"regular" : @(UIBlurEffectStyleRegular),
@@ -659,7 +661,7 @@ RCT_EXPORT_VIEW_PROPERTY(translucent, BOOL)
     }];
   }
 #if !TARGET_OS_TV && defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
-__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
   if (@available(iOS 13.0, *)) {
     [blurEffects addEntriesFromDictionary:@{
       @"systemUltraThinMaterial" : @(UIBlurEffectStyleSystemUltraThinMaterial),
@@ -684,26 +686,26 @@ __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
 }
 
 RCT_ENUM_CONVERTER(
-                   RNSScreenStackHeaderSubviewType,
-                   (@{
-                     @"back" : @(RNSScreenStackHeaderSubviewTypeBackButton),
-                     @"left" : @(RNSScreenStackHeaderSubviewTypeLeft),
-                     @"right" : @(RNSScreenStackHeaderSubviewTypeRight),
-                     @"title" : @(RNSScreenStackHeaderSubviewTypeTitle),
-                     @"center" : @(RNSScreenStackHeaderSubviewTypeCenter),
-                     @"searchBar" : @(RNSScreenStackHeaderSubviewTypeSearchBar),
-                    }),
-                   RNSScreenStackHeaderSubviewTypeTitle,
-                   integerValue)
+    RNSScreenStackHeaderSubviewType,
+    (@{
+      @"back" : @(RNSScreenStackHeaderSubviewTypeBackButton),
+      @"left" : @(RNSScreenStackHeaderSubviewTypeLeft),
+      @"right" : @(RNSScreenStackHeaderSubviewTypeRight),
+      @"title" : @(RNSScreenStackHeaderSubviewTypeTitle),
+      @"center" : @(RNSScreenStackHeaderSubviewTypeCenter),
+      @"searchBar" : @(RNSScreenStackHeaderSubviewTypeSearchBar),
+    }),
+    RNSScreenStackHeaderSubviewTypeTitle,
+    integerValue)
 
 RCT_ENUM_CONVERTER(
-                   UISemanticContentAttribute,
-                   (@{
-                     @"ltr" : @(UISemanticContentAttributeForceLeftToRight),
-                     @"rtl" : @(UISemanticContentAttributeForceRightToLeft),
-                    }),
-                   UISemanticContentAttributeUnspecified,
-                   integerValue)
+    UISemanticContentAttribute,
+    (@{
+      @"ltr" : @(UISemanticContentAttributeForceLeftToRight),
+      @"rtl" : @(UISemanticContentAttributeForceRightToLeft),
+    }),
+    UISemanticContentAttributeUnspecified,
+    integerValue)
 
 RCT_ENUM_CONVERTER(UIBlurEffectStyle, ([self blurEffectsForIOSVersion]), UIBlurEffectStyleExtraLight, integerValue)
 

--- a/ios/vendored/unversioned/react-native-screens/ios/RNSScreenWindowTraits.h
+++ b/ios/vendored/unversioned/react-native-screens/ios/RNSScreenWindowTraits.h
@@ -17,4 +17,9 @@
 + (UIInterfaceOrientationMask)maskFromOrientation:(UIInterfaceOrientation)orientation;
 #endif
 
++ (BOOL)shouldAskScreensForTrait:(RNSWindowTrait)trait
+                 includingModals:(BOOL)includingModals
+                inViewController:(UIViewController *)vc;
++ (BOOL)shouldAskScreensForScreenOrientationInViewController:(UIViewController *)vc;
+
 @end

--- a/ios/vendored/unversioned/react-native-screens/ios/RNSScreenWindowTraits.m
+++ b/ios/vendored/unversioned/react-native-screens/ios/RNSScreenWindowTraits.m
@@ -1,5 +1,7 @@
 #import "RNSScreenWindowTraits.h"
 #import "RNSScreen.h"
+#import "RNSScreenContainer.h"
+#import "RNSScreenStack.h"
 
 @implementation RNSScreenWindowTraits
 
@@ -10,11 +12,11 @@
   static bool viewControllerBasedAppearence;
   dispatch_once(&once, ^{
     viewControllerBasedAppearence =
-    [[[NSBundle mainBundle] objectForInfoDictionaryKey:@"UIViewControllerBasedStatusBarAppearance"] boolValue];
+        [[[NSBundle mainBundle] objectForInfoDictionaryKey:@"UIViewControllerBasedStatusBarAppearance"] boolValue];
   });
   if (!viewControllerBasedAppearence) {
     RCTLogError(@"If you want to change the appearance of status bar, you have to change \
-                UIViewControllerBasedStatusBarAppearance key in the Info.plist to YES");
+    UIViewControllerBasedStatusBarAppearance key in the Info.plist to YES");
   }
 }
 #endif
@@ -25,18 +27,18 @@
   [UIView animateWithDuration:0.4
                    animations:^{ // duration based on "Programming iOS 13" p. 311 implementation
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
-__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
-    if (@available(iOS 13, *)) {
-      UIWindow *firstWindow = [[[UIApplication sharedApplication] windows] firstObject];
-      if (firstWindow != nil) {
-        [[firstWindow rootViewController] setNeedsStatusBarAppearanceUpdate];
-      }
-    } else
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
+                     if (@available(iOS 13, *)) {
+                       UIWindow *firstWindow = [[[UIApplication sharedApplication] windows] firstObject];
+                       if (firstWindow != nil) {
+                         [[firstWindow rootViewController] setNeedsStatusBarAppearanceUpdate];
+                       }
+                     } else
 #endif
-    {
-      [UIApplication.sharedApplication.keyWindow.rootViewController setNeedsStatusBarAppearanceUpdate];
-    }
-  }];
+                     {
+                       [UIApplication.sharedApplication.keyWindow.rootViewController setNeedsStatusBarAppearanceUpdate];
+                     }
+                   }];
 #endif
 }
 
@@ -44,17 +46,17 @@ __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
 + (UIStatusBarStyle)statusBarStyleForRNSStatusBarStyle:(RNSStatusBarStyle)statusBarStyle
 {
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
-__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
   if (@available(iOS 13.0, *)) {
     switch (statusBarStyle) {
       case RNSStatusBarStyleAuto:
         return [UITraitCollection.currentTraitCollection userInterfaceStyle] == UIUserInterfaceStyleDark
-        ? UIStatusBarStyleLightContent
-        : UIStatusBarStyleDarkContent;
+            ? UIStatusBarStyleLightContent
+            : UIStatusBarStyleDarkContent;
       case RNSStatusBarStyleInverted:
         return [UITraitCollection.currentTraitCollection userInterfaceStyle] == UIUserInterfaceStyleDark
-        ? UIStatusBarStyleDarkContent
-        : UIStatusBarStyleLightContent;
+            ? UIStatusBarStyleDarkContent
+            : UIStatusBarStyleLightContent;
       case RNSStatusBarStyleLight:
         return UIStatusBarStyleLightContent;
       case RNSStatusBarStyleDark:
@@ -94,7 +96,7 @@ __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
       return UIInterfaceOrientationPortrait;
     case UIDeviceOrientationPortraitUpsideDown:
       return UIInterfaceOrientationPortraitUpsideDown;
-      // UIDevice and UIInterface landscape orientations are switched
+    // UIDevice and UIInterface landscape orientations are switched
     case UIDeviceOrientationLandscapeLeft:
       return UIInterfaceOrientationLandscapeRight;
     case UIDeviceOrientationLandscapeRight:
@@ -116,7 +118,7 @@ __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
   dispatch_async(dispatch_get_main_queue(), ^{
     UIInterfaceOrientationMask orientationMask = UIInterfaceOrientationMaskAllButUpsideDown;
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
-__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
     if (@available(iOS 13, *)) {
       UIWindow *firstWindow = [[[UIApplication sharedApplication] windows] firstObject];
       if (firstWindow != nil) {
@@ -128,7 +130,7 @@ __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
       orientationMask = UIApplication.sharedApplication.keyWindow.rootViewController.supportedInterfaceOrientations;
     }
     UIInterfaceOrientation currentDeviceOrientation =
-    [RNSScreenWindowTraits interfaceOrientationFromDeviceOrientation:[[UIDevice currentDevice] orientation]];
+        [RNSScreenWindowTraits interfaceOrientationFromDeviceOrientation:[[UIDevice currentDevice] orientation]];
     UIInterfaceOrientation currentInterfaceOrientation = [RNSScreenWindowTraits interfaceOrientation];
     UIInterfaceOrientation newOrientation = UIInterfaceOrientationUnknown;
     if ([RNSScreenWindowTraits maskFromOrientation:currentDeviceOrientation] & orientationMask) {
@@ -171,7 +173,7 @@ __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
 + (UIInterfaceOrientation)interfaceOrientation
 {
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
-__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
   if (@available(iOS 13.0, *)) {
     UIWindow *firstWindow = [[[UIApplication sharedApplication] windows] firstObject];
     if (firstWindow == nil) {
@@ -189,5 +191,32 @@ __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
   }
 }
 #endif
+
+// method to be used in Expo for checking if RNScreens have trait set
++ (BOOL)shouldAskScreensForTrait:(RNSWindowTrait)trait
+                 includingModals:(BOOL)includingModals
+                inViewController:(UIViewController *)vc
+{
+  UIViewController *lastViewController = [[vc childViewControllers] lastObject];
+  if ([lastViewController conformsToProtocol:@protocol(RNScreensViewControllerDelegate)]) {
+    UIViewController *vc = nil;
+    if ([lastViewController isKindOfClass:[RNScreensViewController class]]) {
+      vc = [(RNScreensViewController *)lastViewController findActiveChildVC];
+    } else if ([lastViewController isKindOfClass:[RNScreensNavigationController class]]) {
+      vc = [(RNScreensNavigationController *)lastViewController topViewController];
+    }
+    return [vc isKindOfClass:[RNSScreen class]] &&
+        [(RNSScreen *)vc findChildVCForConfigAndTrait:trait includingModals:includingModals] != nil;
+  }
+  return NO;
+}
+
+// same method as above, but directly for orientation
++ (BOOL)shouldAskScreensForScreenOrientationInViewController:(UIViewController *)vc
+{
+  return [RNSScreenWindowTraits shouldAskScreensForTrait:RNSWindowTraitOrientation
+                                         includingModals:YES
+                                        inViewController:vc];
+}
 
 @end

--- a/ios/vendored/unversioned/react-native-screens/ios/RNSSearchBar.m
+++ b/ios/vendored/unversioned/react-native-screens/ios/RNSSearchBar.m
@@ -55,7 +55,7 @@
 - (void)setBarTintColor:(UIColor *)barTintColor
 {
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
-__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0 && !TARGET_OS_TV
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0 && !TARGET_OS_TV
   if (@available(iOS 13.0, *)) {
     [_controller.searchBar.searchTextField setBackgroundColor:barTintColor];
   }
@@ -65,7 +65,7 @@ __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0 && !TARGET_OS_TV
 - (void)setTextColor:(UIColor *)textColor
 {
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
-__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0 && !TARGET_OS_TV
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0 && !TARGET_OS_TV
   _textColor = textColor;
   if (@available(iOS 13.0, *)) {
     [_controller.searchBar.searchTextField setTextColor:_textColor];
@@ -107,7 +107,7 @@ __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0 && !TARGET_OS_TV
 - (void)searchBarTextDidBeginEditing:(UISearchBar *)searchBar
 {
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
-__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0 && !TARGET_OS_TV
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0 && !TARGET_OS_TV
   if (@available(iOS 13.0, *)) {
     // for some reason, the color does not change when set at the beginning,
     // so we apply it again here
@@ -116,10 +116,10 @@ __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0 && !TARGET_OS_TV
     }
   }
 #endif
-  
+
   [self showCancelButton];
   [self becomeFirstResponder];
-  
+
   if (self.onFocus) {
     self.onFocus(@{});
   }
@@ -138,7 +138,7 @@ __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0 && !TARGET_OS_TV
   if (self.onChangeText) {
     self.onChangeText(@{
       @"text" : _controller.searchBar.text,
-                      });
+    });
   }
 }
 
@@ -147,7 +147,7 @@ __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0 && !TARGET_OS_TV
   if (self.onSearchButtonPress) {
     self.onSearchButtonPress(@{
       @"text" : _controller.searchBar.text,
-                             });
+    });
   }
 }
 
@@ -157,14 +157,14 @@ __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0 && !TARGET_OS_TV
   _controller.searchBar.text = @"";
   [self resignFirstResponder];
   [self hideCancelButton];
-  
+
   if (self.onCancelButtonPress) {
     self.onCancelButtonPress(@{});
   }
   if (self.onChangeText) {
     self.onChangeText(@{
       @"text" : _controller.searchBar.text,
-                      });
+    });
   }
 }
 #endif

--- a/ios/vendored/unversioned/react-native-screens/ios/UIViewController+RNScreens.m
+++ b/ios/vendored/unversioned/react-native-screens/ios/UIViewController+RNScreens.m
@@ -22,7 +22,7 @@
 {
   UIViewController *childVC = [self findChildRNScreensViewController];
   return childVC ? childVC.preferredStatusBarUpdateAnimation
-  : [self reactNativeScreensPreferredStatusBarUpdateAnimation];
+                 : [self reactNativeScreensPreferredStatusBarUpdateAnimation];
 }
 
 - (UIInterfaceOrientationMask)reactNativeScreensSupportedInterfaceOrientations
@@ -45,22 +45,22 @@
   static dispatch_once_t once_token;
   dispatch_once(&once_token, ^{
     Class uiVCClass = [UIViewController class];
-    
+
     method_exchangeImplementations(
-                                   class_getInstanceMethod(uiVCClass, @selector(childViewControllerForStatusBarStyle)),
-                                   class_getInstanceMethod(uiVCClass, @selector(reactNativeScreensChildViewControllerForStatusBarStyle)));
-    
+        class_getInstanceMethod(uiVCClass, @selector(childViewControllerForStatusBarStyle)),
+        class_getInstanceMethod(uiVCClass, @selector(reactNativeScreensChildViewControllerForStatusBarStyle)));
+
     method_exchangeImplementations(
-                                   class_getInstanceMethod(uiVCClass, @selector(childViewControllerForStatusBarHidden)),
-                                   class_getInstanceMethod(uiVCClass, @selector(reactNativeScreensChildViewControllerForStatusBarHidden)));
-    
+        class_getInstanceMethod(uiVCClass, @selector(childViewControllerForStatusBarHidden)),
+        class_getInstanceMethod(uiVCClass, @selector(reactNativeScreensChildViewControllerForStatusBarHidden)));
+
     method_exchangeImplementations(
-                                   class_getInstanceMethod(uiVCClass, @selector(preferredStatusBarUpdateAnimation)),
-                                   class_getInstanceMethod(uiVCClass, @selector(reactNativeScreensPreferredStatusBarUpdateAnimation)));
-    
+        class_getInstanceMethod(uiVCClass, @selector(preferredStatusBarUpdateAnimation)),
+        class_getInstanceMethod(uiVCClass, @selector(reactNativeScreensPreferredStatusBarUpdateAnimation)));
+
     method_exchangeImplementations(
-                                   class_getInstanceMethod(uiVCClass, @selector(supportedInterfaceOrientations)),
-                                   class_getInstanceMethod(uiVCClass, @selector(reactNativeScreensSupportedInterfaceOrientations)));
+        class_getInstanceMethod(uiVCClass, @selector(supportedInterfaceOrientations)),
+        class_getInstanceMethod(uiVCClass, @selector(reactNativeScreensSupportedInterfaceOrientations)));
   });
 }
 #endif

--- a/packages/expo-stories/package.json
+++ b/packages/expo-stories/package.json
@@ -33,7 +33,7 @@
     "fs-extra": "^9.1.0",
     "glob": "^7.1.7",
     "react-native-safe-area-context": "3.2.0",
-    "react-native-screens": "^3.5.0",
+    "react-native-screens": "~3.8.0",
     "react-native-svg": "^12.1.1",
     "sane": "^5.0.1"
   }

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -94,7 +94,7 @@
   "react-native-pager-view": "5.4.4",
   "react-native-reanimated": "~2.2.0",
   "react-native-safe-area-context": "3.3.2",
-  "react-native-screens": "~3.7.0",
+  "react-native-screens": "~3.8.0",
   "react-native-shared-element": "0.8.2",
   "react-native-svg": "12.1.1",
   "react-native-unimodules": "~0.15.0-alpha.0",


### PR DESCRIPTION
# Why

update vendored module for sdk 43 and fix these issues from 3.7.2
1. android ScreenStack crash
2. https://github.com/software-mansion/react-native-screens/issues/1152

# How

`et update-vendored-module -m react-native-screens -c 3.8.0`

# Test Plan

CI passed and NCL for screens test.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).