### PR TITLE
[splash][android] prevent native crash in splashscreen warning timer

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/experience/splashscreen/ManagedAppSplashScreenViewController.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/splashscreen/ManagedAppSplashScreenViewController.kt
@@ -21,18 +21,24 @@ class ManagedAppSplashScreenViewController(
 
   private fun startSplashScreenWarningTimer() {
     mRunnable = Runnable {
-      mSnackbar = Snackbar.make(splashScreenView, "Stuck on splash screen?", Snackbar.LENGTH_LONG)
-      mSnackbar!!.setAction(
-        "Info",
-        View.OnClickListener { v ->
-          val url = "https://expo.fyi/splash-screen-hanging"
-          val webpage = Uri.parse(url)
-          val intent = Intent(Intent.ACTION_VIEW, webpage)
-          v.context.startActivity(intent)
-          mSnackbar!!.dismiss()
-        }
-      )
-      mSnackbar!!.show()
+      // this runnable is being executed after the parent view has been destroyed, causing a crash
+      // an easy way to trigger this is to toggle the debug JS option in the dev menu
+//    // this causes the whole app to remount, I suspect this is why the timer isn't cleaned up
+      // TODO: cancel runnable when app is unmounted / reloaded
+      if (splashScreenView?.parent != null) {
+        mSnackbar = Snackbar.make(splashScreenView, "Stuck on splash screen?", Snackbar.LENGTH_LONG)
+        mSnackbar!!.setAction(
+          "Info",
+          View.OnClickListener { v ->
+            val url = "https://expo.fyi/splash-screen-hanging"
+            val webpage = Uri.parse(url)
+            val intent = Intent(Intent.ACTION_VIEW, webpage)
+            v.context.startActivity(intent)
+            mSnackbar!!.dismiss()
+          }
+        )
+        mSnackbar!!.show()
+      }
     }
 
     mWarningHandler.postDelayed(mRunnable!!, 20000)


### PR DESCRIPTION
# Why

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->
@wschurman found a native crash event when toggling the debug JS menu in Expo Go (thank you will!)

I've added a patch that prevents the crash from happening

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

The crash was occurring because the parent of the splash screen view is unmounted by the time this timer callback is executed. I added a check to see if it still exists before adding the Snackbar warning. 

I suspect this is happening because a full refresh of the app doesn't clean up the timer - I think the right approach would also be to cleanup the timer for the right lifecycle (I'm not sure which one that would be yet)

We've also updated where the timer gets fired which appears to be missing in this branch - this might help as we don't start the timer until the JS has fully loaded. Not sure if that will fix anything though

# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->

Previously, this would result in a crash - I found that the best way to trigger this is to toggle the debug menu a bunch - the timer takes 20 seconds so eventually it will crash

- check out sdk-43 branch
- fastlane android start
- init blank 43 project (copy from templates dir)
- expo start
- open project
- play around with the app some, start/stop remote JS debugging, just general usage seems to trigger hard crash. Consistent repro but amount of time that elapses before the crash is variable


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).