### PR TITLE
[tools] Remove unwanted local xcframeworks when publishing

### DIFF
--- a/tools/src/publish-packages/tasks/prebuildPackagesTask.ts
+++ b/tools/src/publish-packages/tasks/prebuildPackagesTask.ts
@@ -2,9 +2,12 @@ import chalk from 'chalk';
 
 import logger from '../../Logger';
 import { Task } from '../../TasksRunner';
+import {
+  canPrebuildPackage,
+  cleanFrameworksAsync,
+  prebuildPackageAsync,
+} from '../../prebuilds/Prebuilder';
 import { Parcel, TaskArgs } from '../types';
-
-import { canPrebuildPackage, prebuildPackageAsync } from '../../prebuilds/Prebuilder';
 
 /**
  * Prebuilds iOS packages that are being distributed with prebuilt binaries.
@@ -18,6 +21,8 @@ export const prebuildPackagesTask = new Task<TaskArgs>(
   async (parcels: Parcel[]) => {
     for (const { pkg } of parcels) {
       if (!canPrebuildPackage(pkg)) {
+        logger.info('\n👷‍♀️ Removing local prebuilt binaries from %s', chalk.green(pkg.packageName));
+        await cleanFrameworksAsync([pkg]);
         continue;
       }
       logger.info('\n👷‍♀️ Prebuilding %s', chalk.green(pkg.packageName));


### PR DESCRIPTION
# Why

I accidentally published `expo-modules-core` with prebuilt `.xcframework` that I had locally, even though we disabled prebuilding for that package in the meantime. This would prevent such cases.

# How

Remove local `.xcframework` when prebuilding is disabled for the package

# Test Plan

Tried with `et publish expo-modules-core --dry`
