### PR TITLE
[tools] Fix versioning the ObjC name of the Swift modules provider

### DIFF
--- a/packages/expo-modules-core/ios/NativeModulesProxy/EXNativeModulesProxy.m
+++ b/packages/expo-modules-core/ios/NativeModulesProxy/EXNativeModulesProxy.m
@@ -189,6 +189,8 @@ RCT_EXPORT_METHOD(callMethod:(NSString *)moduleName methodNameOrKey:(id)methodNa
 
 - (id<ModulesProviderObjCProtocol>)getExpoModulesProvider
 {
+  // Dynamically gets the modules provider class.
+  // NOTE: This needs to be versioned in Expo Go.
   Class generatedExpoModulesProvider = NSClassFromString(@"ExpoModulesProvider");
   // Checks if `ExpoModulesProvider` was generated
   if (generatedExpoModulesProvider) {

--- a/tools/src/versioning/ios/transforms/expoModulesTransforms.ts
+++ b/tools/src/versioning/ios/transforms/expoModulesTransforms.ts
@@ -67,6 +67,12 @@ export function expoModulesTransforms(prefix: string): FileTransforms {
         find: new RegExp(`#import <${prefix}(EXGL_CPP)\\b`),
         replaceWith: '#import <$1',
       },
+      {
+        // Prefixes Objective-C name of the Swift modules provider.
+        paths: ['EXNativeModulesProxy.m'],
+        find: 'NSClassFromString(@"ExpoModulesProvider")',
+        replaceWith: `NSClassFromString(@"${prefix}ExpoModulesProvider")`
+      }
     ],
   };
 }


### PR DESCRIPTION
# Why

Fixes versioning tool for the future SDK versions (manually applied to SDK43 here https://github.com/expo/expo/commit/c6b2622629b3bd3b2d7e43c5eb453fda57cfa076)

# How

Added new transform to `EXNativeModulesProxy.m` to version the class name in `NSClassFromString(@"ExpoModulesProvider")`

# Test Plan

Confirmed that `et add-sdk -p ios` correctly versions this class name. CI job also passes.