### PR TITLE
[av] Fix JNI detected error in application: java_object == null

### DIFF
--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed `JNI DETECTED ERROR IN APPLICATION: java_object == null in call to GetObjectClass from void versioned.host.exp.exponent.modules.api.reanimated.NativeProxy$EventHandler.receiveEvent` on Android.
+- Fixed `JNI DETECTED ERROR IN APPLICATION: java_object == null in call to GetObjectClass from void versioned.host.exp.exponent.modules.api.reanimated.NativeProxy$EventHandler.receiveEvent` on Android. ([#14569](https://github.com/expo/expo/pull/14569) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed `JNI DETECTED ERROR IN APPLICATION: java_object == null in call to GetObjectClass from void versioned.host.exp.exponent.modules.api.reanimated.NativeProxy$EventHandler.receiveEvent` on Android.
+
 ### 💡 Others
 
 ## 10.0.0 — 2021-09-28

--- a/packages/expo-av/android/src/main/java/expo/modules/av/player/SimpleExoPlayerData.java
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/player/SimpleExoPlayerData.java
@@ -123,6 +123,7 @@ class SimpleExoPlayerData extends PlayerData
   public synchronized void release() {
     if (mSimpleExoPlayer != null) {
       mSimpleExoPlayer.release();
+      stopUpdatingProgressIfNecessary();
       mSimpleExoPlayer = null;
     }
   }

--- a/packages/expo-av/android/src/main/java/expo/modules/av/player/SimpleExoPlayerData.java
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/player/SimpleExoPlayerData.java
@@ -121,9 +121,9 @@ class SimpleExoPlayerData extends PlayerData
 
   @Override
   public synchronized void release() {
+    stopUpdatingProgressIfNecessary();
     if (mSimpleExoPlayer != null) {
       mSimpleExoPlayer.release();
-      stopUpdatingProgressIfNecessary();
       mSimpleExoPlayer = null;
     }
   }


### PR DESCRIPTION
# Why

Closes ENG-2013.

# How

The event emitter from the Video component wasn't stoped correctly. It was emitting events even after the component was unmounted. That leads to crashes in the reanimated event handler. The cpp code tries to access unavailable context. 

# Test Plan

- run test-suite in Expo Go
- run Video tests
- refresh application 
