### PR TITLE
[media-library] fix permission not granted on android api < 29

### DIFF
--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix permissions always returning denied on android api < 29. ([#14570](https://github.com/expo/expo/pull/14570) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 13.0.0 — 2021-09-28

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryModule.java
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryModule.java
@@ -28,6 +28,7 @@ import expo.modules.core.interfaces.services.EventEmitter;
 import expo.modules.core.interfaces.services.UIManager;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -451,17 +452,15 @@ public class MediaLibraryModule extends ExportedModule implements ActivityEventL
   }
 
   private String[] getManifestPermissions(boolean writeOnly) {
-    if (writeOnly) {
-      return new String[]{
-        WRITE_EXTERNAL_STORAGE,
-        ACCESS_MEDIA_LOCATION
-      };
+    final List<String> permissions = new ArrayList<>();
+    permissions.add(WRITE_EXTERNAL_STORAGE);
+    if (!writeOnly) {
+      permissions.add(READ_EXTERNAL_STORAGE);
     }
-    return new String[]{
-      READ_EXTERNAL_STORAGE,
-      WRITE_EXTERNAL_STORAGE,
-      ACCESS_MEDIA_LOCATION,
-    };
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+      permissions.add(ACCESS_MEDIA_LOCATION);
+    }
+    return permissions.toArray(new String[0]);
   }
 
   private void runActionWithPermissions(List<String> assetsId, Action action, Promise promise) {


### PR DESCRIPTION
# Why

[versioned qa][android] test-suite "MediaLibrary" show `Tests were skipped - not enough permissions to run them.` on android 8 device

# How

requesting `ACCESS_MEDIA_LOCATION` permission only on android 10+

# Test Plan

bare-expo test-suite "MediaLibrary" on android 8 device
for android 10 emulator, which is expected failed as #14413 mentioned.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).