### PR TITLE
[babel-preset] Fix tests snapshots

### DIFF
--- a/packages/babel-preset-expo/__tests__/__snapshots__/index-test.js.snap
+++ b/packages/babel-preset-expo/__tests__/__snapshots__/index-test.js.snap
@@ -17,8 +17,8 @@ require(\\"../i-also-have-side-effects.fx\\");
 function _inlineFuncWithSideEffectsFx(){var data=_interopRequireDefault(require(\\"../inline-func-with-side-effects.fx.ts\\"));_inlineFuncWithSideEffectsFx=function _inlineFuncWithSideEffectsFx(){return data;};return data;}
 function _inlineFunc(){var data=_interopRequireDefault(require(\\"./inline-func\\"));_inlineFunc=function _inlineFunc(){return data;};return data;}function _getRequireWildcardCache(nodeInterop){if(typeof WeakMap!==\\"function\\")return null;var cacheBabelInterop=new WeakMap();var cacheNodeInterop=new WeakMap();return(_getRequireWildcardCache=function _getRequireWildcardCache(nodeInterop){return nodeInterop?cacheNodeInterop:cacheBabelInterop;})(nodeInterop);}function _interopRequireWildcard(obj,nodeInterop){if(!nodeInterop&&obj&&obj.__esModule){return obj;}if(obj===null||typeof obj!==\\"object\\"&&typeof obj!==\\"function\\"){return{default:obj};}var cache=_getRequireWildcardCache(nodeInterop);if(cache&&cache.has(obj)){return cache.get(obj);}var newObj={};var hasPropertyDescriptor=Object.defineProperty&&Object.getOwnPropertyDescriptor;for(var key in obj){if(key!==\\"default\\"&&Object.prototype.hasOwnProperty.call(obj,key)){var desc=hasPropertyDescriptor?Object.getOwnPropertyDescriptor(obj,key):null;if(desc&&(desc.get||desc.set)){Object.defineProperty(newObj,key,desc);}else{newObj[key]=obj[key];}}}newObj.default=obj;if(cache){cache.set(obj,newObj);}return newObj;}function _createSuper(Derived){var hasNativeReflectConstruct=_isNativeReflectConstruct();return function _createSuperInternal(){var Super=(0,_getPrototypeOf2.default)(Derived),result;if(hasNativeReflectConstruct){var NewTarget=(0,_getPrototypeOf2.default)(this).constructor;result=Reflect.construct(Super,arguments,NewTarget);}else{result=Super.apply(this,arguments);}return(0,_possibleConstructorReturn2.default)(this,result);};}function _isNativeReflectConstruct(){if(typeof Reflect===\\"undefined\\"||!Reflect.construct)return false;if(Reflect.construct.sham)return false;if(typeof Proxy===\\"function\\")return true;try{Boolean.prototype.valueOf.call(Reflect.construct(Boolean,[],function(){}));return true;}catch(e){return false;}}var
 
-Lazy=function(_React$Component){(0,_inherits2.default)(Lazy,_React$Component);var _super=_createSuper(Lazy);function Lazy(){(0,_classCallCheck2.default)(this,Lazy);return _super.apply(this,arguments);}(0,_createClass2.default)(Lazy,[{key:\\"componentDidMount\\",value:function componentDidMount()
-{
+Lazy=function(_React$Component){(0,_inherits2.default)(Lazy,_React$Component);var _super=_createSuper(Lazy);function Lazy(){(0,_classCallCheck2.default)(this,Lazy);return _super.apply(this,arguments);}(0,_createClass2.default)(Lazy,[{key:\\"componentDidMount\\",value:
+function componentDidMount(){
 console.log('Calling InlineFuncFromPackage()');
 (0,_inlineComp().default)();
 
@@ -29,9 +29,9 @@ console.log('Calling Boo.myFunc()');
 Boo.myFunc();
 
 _expoAsset.Asset.loadAsync([require(\\"./assets/icon.png\\")]);
-}},{key:\\"render\\",value:function render()
+}},{key:\\"render\\",value:
 
-{
+function render(){
 return(
 _react.default.createElement(_reactNative.View,null,
 _react.default.createElement(_expoAppLoading.default,null),
@@ -39,9 +39,9 @@ _react.default.createElement(_vectorIcons.Ionicons,{name:\\"md-options\\",size:2
 _react.default.createElement(_fooView.default,null)));
 
 
-}},{key:\\"unusedFunction\\",value:function unusedFunction()
+}},{key:\\"unusedFunction\\",value:
 
-{
+function unusedFunction(){
 (0,_inlineFuncWithSideEffectsFx().default)();
 }}]);return Lazy;}(_react.default.Component);var _default=
 
@@ -66,8 +66,8 @@ require(\\"../i-also-have-side-effects.fx\\");
 var _inlineFuncWithSideEffectsFx=_interopRequireDefault(require(\\"../inline-func-with-side-effects.fx.ts\\"));
 function _inlineFunc(){var data=_interopRequireDefault(require(\\"./inline-func\\"));_inlineFunc=function _inlineFunc(){return data;};return data;}function _getRequireWildcardCache(nodeInterop){if(typeof WeakMap!==\\"function\\")return null;var cacheBabelInterop=new WeakMap();var cacheNodeInterop=new WeakMap();return(_getRequireWildcardCache=function _getRequireWildcardCache(nodeInterop){return nodeInterop?cacheNodeInterop:cacheBabelInterop;})(nodeInterop);}function _interopRequireWildcard(obj,nodeInterop){if(!nodeInterop&&obj&&obj.__esModule){return obj;}if(obj===null||typeof obj!==\\"object\\"&&typeof obj!==\\"function\\"){return{default:obj};}var cache=_getRequireWildcardCache(nodeInterop);if(cache&&cache.has(obj)){return cache.get(obj);}var newObj={};var hasPropertyDescriptor=Object.defineProperty&&Object.getOwnPropertyDescriptor;for(var key in obj){if(key!==\\"default\\"&&Object.prototype.hasOwnProperty.call(obj,key)){var desc=hasPropertyDescriptor?Object.getOwnPropertyDescriptor(obj,key):null;if(desc&&(desc.get||desc.set)){Object.defineProperty(newObj,key,desc);}else{newObj[key]=obj[key];}}}newObj.default=obj;if(cache){cache.set(obj,newObj);}return newObj;}function _createSuper(Derived){var hasNativeReflectConstruct=_isNativeReflectConstruct();return function _createSuperInternal(){var Super=(0,_getPrototypeOf2().default)(Derived),result;if(hasNativeReflectConstruct){var NewTarget=(0,_getPrototypeOf2().default)(this).constructor;result=Reflect.construct(Super,arguments,NewTarget);}else{result=Super.apply(this,arguments);}return(0,_possibleConstructorReturn2().default)(this,result);};}function _isNativeReflectConstruct(){if(typeof Reflect===\\"undefined\\"||!Reflect.construct)return false;if(Reflect.construct.sham)return false;if(typeof Proxy===\\"function\\")return true;try{Boolean.prototype.valueOf.call(Reflect.construct(Boolean,[],function(){}));return true;}catch(e){return false;}}var
 
-Lazy=function(_React$Component){(0,_inherits2().default)(Lazy,_React$Component);var _super=_createSuper(Lazy);function Lazy(){(0,_classCallCheck2().default)(this,Lazy);return _super.apply(this,arguments);}(0,_createClass2().default)(Lazy,[{key:\\"componentDidMount\\",value:function componentDidMount()
-{
+Lazy=function(_React$Component){(0,_inherits2().default)(Lazy,_React$Component);var _super=_createSuper(Lazy);function Lazy(){(0,_classCallCheck2().default)(this,Lazy);return _super.apply(this,arguments);}(0,_createClass2().default)(Lazy,[{key:\\"componentDidMount\\",value:
+function componentDidMount(){
 console.log('Calling InlineFuncFromPackage()');
 (0,_inlineComp().default)();
 
@@ -78,9 +78,9 @@ console.log('Calling Boo.myFunc()');
 Boo().myFunc();
 
 _expoAsset().Asset.loadAsync([require(\\"./assets/icon.png\\")]);
-}},{key:\\"render\\",value:function render()
+}},{key:\\"render\\",value:
 
-{
+function render(){
 return(
 _react().default.createElement(_reactNative().View,null,
 _react().default.createElement(_expoAppLoading().default,null),
@@ -88,9 +88,9 @@ _react().default.createElement(_vectorIcons().Ionicons,{name:\\"md-options\\",si
 _react().default.createElement(_fooView().default,null)));
 
 
-}},{key:\\"unusedFunction\\",value:function unusedFunction()
+}},{key:\\"unusedFunction\\",value:
 
-{
+function unusedFunction(){
 (0,_inlineFuncWithSideEffectsFx.default)();
 }}]);return Lazy;}(_react().default.Component);var _default=
 
@@ -115,8 +115,8 @@ require(\\"../i-also-have-side-effects.fx\\");
 var _inlineFuncWithSideEffectsFx=_interopRequireDefault(require(\\"../inline-func-with-side-effects.fx.ts\\"));
 var _inlineFunc=_interopRequireDefault(require(\\"./inline-func\\"));function _getRequireWildcardCache(nodeInterop){if(typeof WeakMap!==\\"function\\")return null;var cacheBabelInterop=new WeakMap();var cacheNodeInterop=new WeakMap();return(_getRequireWildcardCache=function _getRequireWildcardCache(nodeInterop){return nodeInterop?cacheNodeInterop:cacheBabelInterop;})(nodeInterop);}function _interopRequireWildcard(obj,nodeInterop){if(!nodeInterop&&obj&&obj.__esModule){return obj;}if(obj===null||typeof obj!==\\"object\\"&&typeof obj!==\\"function\\"){return{default:obj};}var cache=_getRequireWildcardCache(nodeInterop);if(cache&&cache.has(obj)){return cache.get(obj);}var newObj={};var hasPropertyDescriptor=Object.defineProperty&&Object.getOwnPropertyDescriptor;for(var key in obj){if(key!==\\"default\\"&&Object.prototype.hasOwnProperty.call(obj,key)){var desc=hasPropertyDescriptor?Object.getOwnPropertyDescriptor(obj,key):null;if(desc&&(desc.get||desc.set)){Object.defineProperty(newObj,key,desc);}else{newObj[key]=obj[key];}}}newObj.default=obj;if(cache){cache.set(obj,newObj);}return newObj;}function _createSuper(Derived){var hasNativeReflectConstruct=_isNativeReflectConstruct();return function _createSuperInternal(){var Super=(0,_getPrototypeOf2.default)(Derived),result;if(hasNativeReflectConstruct){var NewTarget=(0,_getPrototypeOf2.default)(this).constructor;result=Reflect.construct(Super,arguments,NewTarget);}else{result=Super.apply(this,arguments);}return(0,_possibleConstructorReturn2.default)(this,result);};}function _isNativeReflectConstruct(){if(typeof Reflect===\\"undefined\\"||!Reflect.construct)return false;if(Reflect.construct.sham)return false;if(typeof Proxy===\\"function\\")return true;try{Boolean.prototype.valueOf.call(Reflect.construct(Boolean,[],function(){}));return true;}catch(e){return false;}}var
 
-Lazy=function(_React$Component){(0,_inherits2.default)(Lazy,_React$Component);var _super=_createSuper(Lazy);function Lazy(){(0,_classCallCheck2.default)(this,Lazy);return _super.apply(this,arguments);}(0,_createClass2.default)(Lazy,[{key:\\"componentDidMount\\",value:function componentDidMount()
-{
+Lazy=function(_React$Component){(0,_inherits2.default)(Lazy,_React$Component);var _super=_createSuper(Lazy);function Lazy(){(0,_classCallCheck2.default)(this,Lazy);return _super.apply(this,arguments);}(0,_createClass2.default)(Lazy,[{key:\\"componentDidMount\\",value:
+function componentDidMount(){
 console.log('Calling InlineFuncFromPackage()');
 (0,_inlineComp.default)();
 
@@ -127,9 +127,9 @@ console.log('Calling Boo.myFunc()');
 Boo.myFunc();
 
 _expoAsset.Asset.loadAsync([require(\\"./assets/icon.png\\")]);
-}},{key:\\"render\\",value:function render()
+}},{key:\\"render\\",value:
 
-{
+function render(){
 return(
 _react.default.createElement(_reactNative.View,null,
 _react.default.createElement(_expoAppLoading.default,null),
@@ -137,9 +137,9 @@ _react.default.createElement(_vectorIcons.Ionicons,{name:\\"md-options\\",size:2
 _react.default.createElement(_fooView.default,null)));
 
 
-}},{key:\\"unusedFunction\\",value:function unusedFunction()
+}},{key:\\"unusedFunction\\",value:
 
-{
+function unusedFunction(){
 (0,_inlineFuncWithSideEffectsFx.default)();
 }}]);return Lazy;}(_react.default.Component);var _default=
 
@@ -164,8 +164,8 @@ require(\\"../i-also-have-side-effects.fx\\");
 var _inlineFuncWithSideEffectsFx=_interopRequireDefault(require(\\"../inline-func-with-side-effects.fx.ts\\"));
 var _inlineFunc=_interopRequireDefault(require(\\"./inline-func\\"));function _getRequireWildcardCache(nodeInterop){if(typeof WeakMap!==\\"function\\")return null;var cacheBabelInterop=new WeakMap();var cacheNodeInterop=new WeakMap();return(_getRequireWildcardCache=function _getRequireWildcardCache(nodeInterop){return nodeInterop?cacheNodeInterop:cacheBabelInterop;})(nodeInterop);}function _interopRequireWildcard(obj,nodeInterop){if(!nodeInterop&&obj&&obj.__esModule){return obj;}if(obj===null||typeof obj!==\\"object\\"&&typeof obj!==\\"function\\"){return{default:obj};}var cache=_getRequireWildcardCache(nodeInterop);if(cache&&cache.has(obj)){return cache.get(obj);}var newObj={};var hasPropertyDescriptor=Object.defineProperty&&Object.getOwnPropertyDescriptor;for(var key in obj){if(key!==\\"default\\"&&Object.prototype.hasOwnProperty.call(obj,key)){var desc=hasPropertyDescriptor?Object.getOwnPropertyDescriptor(obj,key):null;if(desc&&(desc.get||desc.set)){Object.defineProperty(newObj,key,desc);}else{newObj[key]=obj[key];}}}newObj.default=obj;if(cache){cache.set(obj,newObj);}return newObj;}function _createSuper(Derived){var hasNativeReflectConstruct=_isNativeReflectConstruct();return function _createSuperInternal(){var Super=(0,_getPrototypeOf2.default)(Derived),result;if(hasNativeReflectConstruct){var NewTarget=(0,_getPrototypeOf2.default)(this).constructor;result=Reflect.construct(Super,arguments,NewTarget);}else{result=Super.apply(this,arguments);}return(0,_possibleConstructorReturn2.default)(this,result);};}function _isNativeReflectConstruct(){if(typeof Reflect===\\"undefined\\"||!Reflect.construct)return false;if(Reflect.construct.sham)return false;if(typeof Proxy===\\"function\\")return true;try{Boolean.prototype.valueOf.call(Reflect.construct(Boolean,[],function(){}));return true;}catch(e){return false;}}var
 
-Lazy=function(_React$Component){(0,_inherits2.default)(Lazy,_React$Component);var _super=_createSuper(Lazy);function Lazy(){(0,_classCallCheck2.default)(this,Lazy);return _super.apply(this,arguments);}(0,_createClass2.default)(Lazy,[{key:\\"componentDidMount\\",value:function componentDidMount()
-{
+Lazy=function(_React$Component){(0,_inherits2.default)(Lazy,_React$Component);var _super=_createSuper(Lazy);function Lazy(){(0,_classCallCheck2.default)(this,Lazy);return _super.apply(this,arguments);}(0,_createClass2.default)(Lazy,[{key:\\"componentDidMount\\",value:
+function componentDidMount(){
 console.log('Calling InlineFuncFromPackage()');
 (0,_inlineComp.default)();
 
@@ -176,9 +176,9 @@ console.log('Calling Boo.myFunc()');
 Boo.myFunc();
 
 _expoAsset.Asset.loadAsync([require(\\"./assets/icon.png\\")]);
-}},{key:\\"render\\",value:function render()
+}},{key:\\"render\\",value:
 
-{
+function render(){
 return(
 _react.default.createElement(_reactNative.View,null,
 _react.default.createElement(_expoAppLoading.default,null),
@@ -186,9 +186,9 @@ _react.default.createElement(_vectorIcons.Ionicons,{name:\\"md-options\\",size:2
 _react.default.createElement(_fooView.default,null)));
 
 
-}},{key:\\"unusedFunction\\",value:function unusedFunction()
+}},{key:\\"unusedFunction\\",value:
 
-{
+function unusedFunction(){
 (0,_inlineFuncWithSideEffectsFx.default)();
 }}]);return Lazy;}(_react.default.Component);var _default=
 
@@ -213,8 +213,8 @@ require(\\"../i-also-have-side-effects.fx\\");
 var _inlineFuncWithSideEffectsFx=_interopRequireDefault(require(\\"../inline-func-with-side-effects.fx.ts\\"));
 var _inlineFunc=_interopRequireDefault(require(\\"./inline-func\\"));function _getRequireWildcardCache(nodeInterop){if(typeof WeakMap!==\\"function\\")return null;var cacheBabelInterop=new WeakMap();var cacheNodeInterop=new WeakMap();return(_getRequireWildcardCache=function _getRequireWildcardCache(nodeInterop){return nodeInterop?cacheNodeInterop:cacheBabelInterop;})(nodeInterop);}function _interopRequireWildcard(obj,nodeInterop){if(!nodeInterop&&obj&&obj.__esModule){return obj;}if(obj===null||typeof obj!==\\"object\\"&&typeof obj!==\\"function\\"){return{default:obj};}var cache=_getRequireWildcardCache(nodeInterop);if(cache&&cache.has(obj)){return cache.get(obj);}var newObj={};var hasPropertyDescriptor=Object.defineProperty&&Object.getOwnPropertyDescriptor;for(var key in obj){if(key!==\\"default\\"&&Object.prototype.hasOwnProperty.call(obj,key)){var desc=hasPropertyDescriptor?Object.getOwnPropertyDescriptor(obj,key):null;if(desc&&(desc.get||desc.set)){Object.defineProperty(newObj,key,desc);}else{newObj[key]=obj[key];}}}newObj.default=obj;if(cache){cache.set(obj,newObj);}return newObj;}function _createSuper(Derived){var hasNativeReflectConstruct=_isNativeReflectConstruct();return function _createSuperInternal(){var Super=(0,_getPrototypeOf2().default)(Derived),result;if(hasNativeReflectConstruct){var NewTarget=(0,_getPrototypeOf2().default)(this).constructor;result=Reflect.construct(Super,arguments,NewTarget);}else{result=Super.apply(this,arguments);}return(0,_possibleConstructorReturn2().default)(this,result);};}function _isNativeReflectConstruct(){if(typeof Reflect===\\"undefined\\"||!Reflect.construct)return false;if(Reflect.construct.sham)return false;if(typeof Proxy===\\"function\\")return true;try{Boolean.prototype.valueOf.call(Reflect.construct(Boolean,[],function(){}));return true;}catch(e){return false;}}var
 
-Lazy=function(_React$Component){(0,_inherits2().default)(Lazy,_React$Component);var _super=_createSuper(Lazy);function Lazy(){(0,_classCallCheck2().default)(this,Lazy);return _super.apply(this,arguments);}(0,_createClass2().default)(Lazy,[{key:\\"componentDidMount\\",value:function componentDidMount()
-{
+Lazy=function(_React$Component){(0,_inherits2().default)(Lazy,_React$Component);var _super=_createSuper(Lazy);function Lazy(){(0,_classCallCheck2().default)(this,Lazy);return _super.apply(this,arguments);}(0,_createClass2().default)(Lazy,[{key:\\"componentDidMount\\",value:
+function componentDidMount(){
 console.log('Calling InlineFuncFromPackage()');
 (0,_inlineComp().default)();
 
@@ -225,9 +225,9 @@ console.log('Calling Boo.myFunc()');
 Boo().myFunc();
 
 _expoAsset.Asset.loadAsync([require(\\"./assets/icon.png\\")]);
-}},{key:\\"render\\",value:function render()
+}},{key:\\"render\\",value:
 
-{
+function render(){
 return(
 _react().default.createElement(_reactNative().View,null,
 _react().default.createElement(_expoAppLoading().default,null),
@@ -235,9 +235,9 @@ _react().default.createElement(_vectorIcons().Ionicons,{name:\\"md-options\\",si
 _react().default.createElement(_fooView().default,null)));
 
 
-}},{key:\\"unusedFunction\\",value:function unusedFunction()
+}},{key:\\"unusedFunction\\",value:
 
-{
+function unusedFunction(){
 (0,_inlineFuncWithSideEffectsFx.default)();
 }}]);return Lazy;}(_react().default.Component);var _default=
 


### PR DESCRIPTION
# Why

check-packages script is failing on `babel-preset-expo` package

# How

It turned out that our test snapshots are not up-to-date. I'm not actually sure what caused this, but probably some dependency version updates (nothing that has changed in `packages/babel-preset-expo` folder though)

# Test Plan

`et check-packages babel-preset-expo` passes
