### PR TITLE
Hermes Engine documentation: Grammatical Change removal of Extra Word

### DIFF
--- a/docs/pages/guides/using-hermes.md
+++ b/docs/pages/guides/using-hermes.md
@@ -49,7 +49,7 @@ To use Hermes inspector for JavaScript debugging, we recommend following [the in
 
 ### iOS apps are not supported
 
-iOS is not supported yet — Hermes support was added to React Native for iOS in `react-native@0.64` and will likely to be added to Expo projects when it has been used successfully in production more broadly.
+iOS is not supported yet — Hermes support was added to React Native for iOS in `react-native@0.64` and will likely be added to Expo projects when it has been used successfully in production more broadly.
 
 ### Standalone apps created with `expo build` are not supported
 


### PR DESCRIPTION
Changing line 52 from 'and will likely to be' -> 'and will likely be' to help readability and grammatical consistency.

# Why

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).