### PR TITLE
[expo-av][web] Fix Video Fullscreen Functions

### DIFF
--- a/packages/expo-av/src/FullscreenUtils.web.ts
+++ b/packages/expo-av/src/FullscreenUtils.web.ts
@@ -4,21 +4,21 @@
  * https://developer.mozilla.org/en-US/docs/Web/API/Fullscreen_API
  */
 const supportsFullscreenAPI = (element: HTMLMediaElement): boolean =>
-  'requestFullscreen' in element;
+  element && 'requestFullscreen' in element;
 
 /**
  * Detect if the browser supports the non-standard webkit fullscreen API on the
  * given element (looking at you, Safari).
  */
 const supportsWebkitFullscreenAPI = (element: HTMLMediaElement): boolean =>
-  'webkitEnterFullScreen' in element;
+  element && 'webkitEnterFullScreen' in element;
 
 /**
  * Detect if the browser supports the non-standard ms fullscreen API on the
  * given element (looking at you, IE11).
  */
 const supportsMsFullscreenAPI = (element: HTMLMediaElement): boolean =>
-  'msRequestFullscreen' in element;
+  element && 'msRequestFullscreen' in element;
 
 /**
  * Detect if the browser supports the `webkitFullscreenChange` event. This is


### PR DESCRIPTION
supportsFullscreenAPI and supportsWebkitFullscreenAPI crash when element is null 

TypeError: Cannot use 'in' operator to search for 'requestFullscreen' in null

# Why

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).