### PR TITLE
[cherry-pick][ios][expo-notifications] Fix accidentally-versioned constant in EXServerRegistrationModule

### DIFF
--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXNotifications/ABI40_0_0EXNotifications/ABI40_0_0EXServerRegistrationModule.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXNotifications/ABI40_0_0EXNotifications/ABI40_0_0EXServerRegistrationModule.m
@@ -5,6 +5,7 @@
 static NSString * const kEXDeviceInstallationUUIDKey = @"EXDeviceInstallationUUIDKey";
 static NSString * const kEXDeviceInstallationUUIDLegacyKey = @"EXDeviceInstallUUIDKey";
 
+// this constant value being versioned is incorrect and is fixed in SDK >=43
 static NSString * const kEXRegistrationInfoKey = @"ABI40_0_0EXNotificationRegistrationInfoKey";
 
 @implementation ABI40_0_0EXServerRegistrationModule

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXNotifications/ABI41_0_0EXNotifications/ABI41_0_0EXServerRegistrationModule.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXNotifications/ABI41_0_0EXNotifications/ABI41_0_0EXServerRegistrationModule.m
@@ -5,6 +5,7 @@
 static NSString * const kEXDeviceInstallationUUIDKey = @"EXDeviceInstallationUUIDKey";
 static NSString * const kEXDeviceInstallationUUIDLegacyKey = @"EXDeviceInstallUUIDKey";
 
+// this constant value being versioned is incorrect and is fixed in SDK >=43
 static NSString * const kEXRegistrationInfoKey = @"ABI41_0_0EXNotificationRegistrationInfoKey";
 
 @implementation ABI41_0_0EXServerRegistrationModule

--- a/ios/versioned-react-native/ABI42_0_0/Expo/EXNotifications/ABI42_0_0EXNotifications/ABI42_0_0EXServerRegistrationModule.m
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/EXNotifications/ABI42_0_0EXNotifications/ABI42_0_0EXServerRegistrationModule.m
@@ -5,6 +5,7 @@
 static NSString * const kEXDeviceInstallationUUIDKey = @"EXDeviceInstallationUUIDKey";
 static NSString * const kEXDeviceInstallationUUIDLegacyKey = @"EXDeviceInstallUUIDKey";
 
+// this constant value being versioned is incorrect and is fixed in SDK >=43
 static NSString * const kEXRegistrationInfoKey = @"ABI42_0_0EXNotificationRegistrationInfoKey";
 
 @implementation ABI42_0_0EXServerRegistrationModule

--- a/ios/versioned/sdk43/EXNotifications/EXNotifications/ABI43_0_0EXServerRegistrationModule.m
+++ b/ios/versioned/sdk43/EXNotifications/EXNotifications/ABI43_0_0EXServerRegistrationModule.m
@@ -2,10 +2,10 @@
 
 #import <ABI43_0_0EXNotifications/ABI43_0_0EXServerRegistrationModule.h>
 
-static NSString * const kEXDeviceInstallationUUIDKey = @"ABI43_0_0EXDeviceInstallationUUIDKey";
-static NSString * const kEXDeviceInstallationUUIDLegacyKey = @"ABI43_0_0EXDeviceInstallUUIDKey";
+static NSString * const kEXDeviceInstallationUUIDKey = @"EXDeviceInstallationUUIDKey";
+static NSString * const kEXDeviceInstallationUUIDLegacyKey = @"EXDeviceInstallUUIDKey";
 
-static NSString * const kEXRegistrationInfoKey = @"ABI43_0_0EXNotificationRegistrationInfoKey";
+static NSString * const kEXRegistrationInfoKey = @"EXNotificationRegistrationInfoKey";
 
 @implementation ABI43_0_0EXServerRegistrationModule
 

--- a/packages/expo-notifications/ios/EXNotifications/EXServerRegistrationModule.m
+++ b/packages/expo-notifications/ios/EXNotifications/EXServerRegistrationModule.m
@@ -2,10 +2,13 @@
 
 #import <EXNotifications/EXServerRegistrationModule.h>
 
-static NSString * const kEXDeviceInstallationUUIDKey = @"EXDeviceInstallationUUIDKey";
-static NSString * const kEXDeviceInstallationUUIDLegacyKey = @"EXDeviceInstallUUIDKey";
+// noop (used by code transform to ensure the versioning isn't applied)
+#define EX_UNVERSIONED(symbol) symbol
 
-static NSString * const kEXRegistrationInfoKey = @"EXNotificationRegistrationInfoKey";
+static NSString * const kEXDeviceInstallationUUIDKey = EX_UNVERSIONED(@"EXDeviceInstallationUUIDKey");
+static NSString * const kEXDeviceInstallationUUIDLegacyKey = EX_UNVERSIONED(@"EXDeviceInstallUUIDKey");
+
+static NSString * const kEXRegistrationInfoKey = EX_UNVERSIONED(@"EXNotificationRegistrationInfoKey");
 
 @implementation EXServerRegistrationModule
 

--- a/tools/src/versioning/ios/transforms/injectMacros.ts
+++ b/tools/src/versioning/ios/transforms/injectMacros.ts
@@ -36,7 +36,7 @@ export function injectMacros(versionName: string): TransformPipeline {
       },
       {
         // now that this code is versioned, remove meaningless EX_UNVERSIONED declaration
-        paths: 'EXUnversioned.h',
+        paths: ['EXUnversioned.h', 'EXServerRegistrationModule.m'],
         replace: /(#define symbol[.\S\s]+?(?=\n\n)\n\n)/g,
         with: '\n',
       },


### PR DESCRIPTION
# Why

The `kEXDeviceInstallationUUIDKey` constant value shouldn't be versioned but is by the rule at https://github.com/expo/expo/blob/941f41af2742b36f543a818f9c0b3c0549c9807c/tools/src/versioning/ios/transforms/expoModulesTransforms.ts#L28 due to its value looking like `EX*`. This is causing the push notification registration to be invalidated during the upgrade to SDK 43 since push tokens depend on the installation ID.

Interestingly, it seems like these we just manually found (probably by @cruzach) and fixed in prior SDKs, which seems fairly risky. Though it seems like we forgot to fix the value of `kEXRegistrationInfoKey` (another secure key) in past SDKs, so there actually has been a bug in prod for `setAutoServerRegistrationEnabledAsync`, but luckily this is really only used with hardcoded values so it wouldn't cause issues across SDK versions. Either way this PR fixes this key as well.

# How

Unfortunately we can't change the value to something that won't be erroneously versioned without invalidating all push notification tokens, so our only other option is to apply the `EX_UNVERSIONED` sentinel to it so that the versioning script doesn't version it. Since `EX_UNVERSIONED` only exists in the core client, it needs to be duplicated to each library that uses it.

# Test Plan

1. Test the fix to the installation ID:
    1. `expo init` 42 project, paste in code that uses `expo-notifications`, `expo install expo-notifications`, `expo start`, open in Expo Go (`fastlane android start` in sdk-42 branch), write down push token
    2. copy `templates/expo-template-blank-typescript` to a new place, rename slug to match that of step 1, `yarn`, paste in code that uses `expo-notifications`, `expo install expo-notifications`, `expo start`, open in Expo Go (`fastlane android start` in sdk-42 branch), write down push token
    3. See that the push tokens from steps 1 and 2 match
2. Test that the next time this versioning runs it won't version these constants:
    1. `et add-sdk-version -f packages/expo-notifications/ios/EXNotifications/EXServerRegistrationModule.m -p ios -s 43.0.0`
    2. Inspect output file to ensure it doesn't include the define or the versioned constant values