### PR TITLE
[constants] Don't include fonts from family "System Font" (iOS 15)

### DIFF
--- a/ios/versioned/sdk43/EXConstants/EXConstants/ABI43_0_0EXConstantsService.m
+++ b/ios/versioned/sdk43/EXConstants/EXConstants/ABI43_0_0EXConstantsService.m
@@ -130,10 +130,21 @@ ABI43_0_0EX_REGISTER_MODULE();
   NSArray<NSString *> *familyNames = [UIFont familyNames];
   NSMutableArray<NSString *> *fontNames = [NSMutableArray array];
   for (NSString *familyName in familyNames) {
-    [fontNames addObject:familyName];
-    [fontNames addObjectsFromArray:[UIFont fontNamesForFamilyName:familyName]];
+    // "System Font" is added to [UIFont familyNames] in iOS 15, and the font names that
+    // correspond with it are dot prefixed .SFUI-* fonts which log the following warning
+    // when passed in to [UIFont fontNamesForFamilyName:name]:
+    // CoreText note: Client requested name “.SFUI-HeavyItalic”, it will get TimesNewRomanPSMT rather than the intended font.
+    // All system UI font access should be through proper APIs such as CTFontCreateUIFontForLanguage() or +[UIFont systemFontOfSize:]
+    //
+    if (![familyName isEqualToString:@"System Font"]) {
+      [fontNames addObject:familyName];
+      NSArray<NSString *> *names = [UIFont fontNamesForFamilyName:familyName];
+      [fontNames addObjectsFromArray:names];
+    }
   }
-  return [fontNames sortedArrayUsingSelector:@selector(caseInsensitiveCompare:)];
+
+  // Remove duplciates and sort alphabetically
+  return [[[NSSet setWithArray:fontNames] allObjects] sortedArrayUsingSelector:@selector(caseInsensitiveCompare:)];
 }
 
 # pragma mark - device info

--- a/ios/versioned/sdk43/EXConstants/EXConstants/ABI43_0_0EXConstantsService.m
+++ b/ios/versioned/sdk43/EXConstants/EXConstants/ABI43_0_0EXConstantsService.m
@@ -138,8 +138,7 @@ ABI43_0_0EX_REGISTER_MODULE();
     //
     if (![familyName isEqualToString:@"System Font"]) {
       [fontNames addObject:familyName];
-      NSArray<NSString *> *names = [UIFont fontNamesForFamilyName:familyName];
-      [fontNames addObjectsFromArray:names];
+      [fontNames addObjectsFromArray:[UIFont fontNamesForFamilyName:familyName]];
     }
   }
 

--- a/packages/expo-constants/CHANGELOG.md
+++ b/packages/expo-constants/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Don't include fonts from family "System Font" (introduced by iOS 15) ([#14577](https://github.com/expo/expo/pull/14577) by [@brentvatne](https://github.com/brentvatne))
+
 ### 💡 Others
 
 ## 12.0.0 — 2021-09-28

--- a/packages/expo-constants/ios/EXConstants/EXConstantsService.m
+++ b/packages/expo-constants/ios/EXConstants/EXConstantsService.m
@@ -130,10 +130,21 @@ EX_REGISTER_MODULE();
   NSArray<NSString *> *familyNames = [UIFont familyNames];
   NSMutableArray<NSString *> *fontNames = [NSMutableArray array];
   for (NSString *familyName in familyNames) {
-    [fontNames addObject:familyName];
-    [fontNames addObjectsFromArray:[UIFont fontNamesForFamilyName:familyName]];
+    // "System Font" is added to [UIFont familyNames] in iOS 15, and the font names that
+    // correspond with it are dot prefixed .SFUI-* fonts which log the following warning
+    // when passed in to [UIFont fontNamesForFamilyName:name]:
+    // CoreText note: Client requested name “.SFUI-HeavyItalic”, it will get TimesNewRomanPSMT rather than the intended font.
+    // All system UI font access should be through proper APIs such as CTFontCreateUIFontForLanguage() or +[UIFont systemFontOfSize:]
+    //
+    if (![familyName isEqualToString:@"System Font"]) {
+      [fontNames addObject:familyName];
+      NSArray<NSString *> *names = [UIFont fontNamesForFamilyName:familyName];
+      [fontNames addObjectsFromArray:names];
+    }
   }
-  return [fontNames sortedArrayUsingSelector:@selector(caseInsensitiveCompare:)];
+
+  // Remove duplciates and sort alphabetically
+  return [[[NSSet setWithArray:fontNames] allObjects] sortedArrayUsingSelector:@selector(caseInsensitiveCompare:)];
 }
 
 # pragma mark - device info

--- a/packages/expo-constants/ios/EXConstants/EXConstantsService.m
+++ b/packages/expo-constants/ios/EXConstants/EXConstantsService.m
@@ -138,8 +138,7 @@ EX_REGISTER_MODULE();
     //
     if (![familyName isEqualToString:@"System Font"]) {
       [fontNames addObject:familyName];
-      NSArray<NSString *> *names = [UIFont fontNamesForFamilyName:familyName];
-      [fontNames addObjectsFromArray:names];
+      [fontNames addObjectsFromArray:[UIFont fontNamesForFamilyName:familyName]];
     }
   }
 


### PR DESCRIPTION
# Why

<img width="466" alt="Screen Shot 2021-09-29 at 4 12 20 PM" src="https://user-images.githubusercontent.com/90494/135360950-66091a74-1701-483c-aa70-bfc965ed9aa6.png">

(this PR is targeting sdk-43 branch because it includes versioned code change and we didn't cherry-pick versioned code to master yet)

# How

When you call `[UIFont fontNamesForFamilyName:@"System Font"]` you will see a warning like this in Xcode logs:

```
CoreText note: Client requested name “.SFUI-HeavyItalic”, it will get TimesNewRomanPSMT rather than the intended font. All system UI font access should be through proper APIs such as CTFontCreateUIFontForLanguage() or +[UIFont systemFontOfSize:]
```

Starting with iOS 15, "System Font" is returned from `[UIFont familyNames]`, so we end up with `TimesNewRomanPSMT` all over the place (an aside - we did not actually dedupe items in the `systemFonts` array, and that is handled now in this PR also). We don't need to include this in `Constants.systemFonts`. To use this font family in React Native (the system default font, SFUI) just make `fontFamily` null/undefined (note: I'm not here arguing that this is ideal, it's just the way it works right now). So, I left out "System Font" from `Constants.systemFonts` and this resolves the issue.

As a side note, iOS 15 also removes from Courier fonts:

<img width="1064" alt="Screen Shot 2021-09-29 at 3 57 37 PM" src="https://user-images.githubusercontent.com/90494/135361353-23528f2e-0d8f-41a0-9402-3133af474720.png">

As another side note, **I do not plan to backport this to older SDK releases**. My reasoning is that we would have to rebuild all old SDK tarballs with an update to expo-constants and re-release all old simulator builds if we were to be consistent. That would take much more time than it is worth.

# Test Plan

Run this in a new SDK 43 managed app:

```jsx
import { StatusBar } from "expo-status-bar";
import React from "react";
import { ScrollView, StyleSheet, Text, View } from "react-native";
import Constants from "expo-constants";

export default function App() {
  console.log(Constants.systemFonts);
  return (
    <ScrollView style={{ flex: 1 }} contentContainerStyle={styles.container}>
      <>
        {Constants.systemFonts
          .map((name) => {
            if (!name.startsWith("T")) {
              return null;
            }
            return <Text>{name}</Text>;
          })
          .filter((item) => !!item)}
      </>
      <StatusBar style="auto" />
    </ScrollView>
  );
}

const styles = StyleSheet.create({
  container: {
    padding: 50,
    backgroundColor: "#fff",
  },
});
```

Notice that you only have one instance of `TimesNewRomanPSMT`. Also see logs for full list of fonts.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).