### PR TITLE
[ios][versioning] Fix some vendored modules not being versioned correctly

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2230,7 +2230,11 @@ PODS:
     - glog
     - RCT-Folly (= 2020.01.13.00)
   - ABI43_0_0React-jsinspector (0.64.2)
+  - ABI43_0_0react-native-netinfo (6.0.2):
+    - ABI43_0_0React-Core
   - ABI43_0_0react-native-pager-view (5.4.4):
+    - ABI43_0_0React-Core
+  - ABI43_0_0react-native-segmented-control (2.4.0):
     - ABI43_0_0React-Core
   - ABI43_0_0react-native-webview (11.13.0):
     - ABI43_0_0React-Core
@@ -2353,6 +2357,9 @@ PODS:
   - ABI43_0_0RNScreens (3.8.0):
     - ABI43_0_0React-Core
     - ABI43_0_0React-RCTImage
+  - ABI43_0_0stripe-react-native (0.2.2):
+    - ABI43_0_0React
+    - Stripe (~> 21.8.1)
   - ABI43_0_0UMAppLoader (3.0.0)
   - ABI43_0_0UMTaskManagerInterface (7.0.0):
     - ABI43_0_0ExpoModulesCore
@@ -3443,7 +3450,9 @@ DEPENDENCIES:
   - ABI43_0_0React-jsi (from `./versioned-react-native/ABI43_0_0/ReactNative/ReactCommon/jsi`)
   - ABI43_0_0React-jsiexecutor (from `./versioned-react-native/ABI43_0_0/ReactNative/ReactCommon/jsiexecutor`)
   - ABI43_0_0React-jsinspector (from `./versioned-react-native/ABI43_0_0/ReactNative/ReactCommon/jsinspector`)
+  - "ABI43_0_0react-native-netinfo (from `./vendored/sdk43/@react-native-community/netinfo`)"
   - ABI43_0_0react-native-pager-view (from `./vendored/sdk43/react-native-pager-view`)
+  - "ABI43_0_0react-native-segmented-control (from `./vendored/sdk43/@react-native-segmented-control/segmented-control`)"
   - ABI43_0_0react-native-webview (from `./vendored/sdk43/react-native-webview`)
   - ABI43_0_0React-perflogger (from `./versioned-react-native/ABI43_0_0/ReactNative/ReactCommon/reactperflogger`)
   - ABI43_0_0React-RCTActionSheet (from `./versioned-react-native/ABI43_0_0/ReactNative/Libraries/ActionSheetIOS`)
@@ -3459,6 +3468,7 @@ DEPENDENCIES:
   - ABI43_0_0ReactCommon/turbomodule/core (from `./versioned-react-native/ABI43_0_0/ReactNative/ReactCommon`)
   - ABI43_0_0RNReanimated (from `./vendored/sdk43/react-native-reanimated`)
   - ABI43_0_0RNScreens (from `./vendored/sdk43/react-native-screens`)
+  - "ABI43_0_0stripe-react-native (from `./vendored/sdk43/@stripe/stripe-react-native`)"
   - ABI43_0_0UMAppLoader (from `./versioned/sdk43/UMAppLoader`)
   - ABI43_0_0UMTaskManagerInterface (from `./versioned/sdk43/UMTaskManagerInterface`)
   - ABI43_0_0Yoga (from `./versioned-react-native/ABI43_0_0/ReactNative/ReactCommon/yoga`)
@@ -4418,8 +4428,12 @@ EXTERNAL SOURCES:
     :path: "./versioned-react-native/ABI43_0_0/ReactNative/ReactCommon/jsiexecutor"
   ABI43_0_0React-jsinspector:
     :path: "./versioned-react-native/ABI43_0_0/ReactNative/ReactCommon/jsinspector"
+  ABI43_0_0react-native-netinfo:
+    :path: "./vendored/sdk43/@react-native-community/netinfo"
   ABI43_0_0react-native-pager-view:
     :path: "./vendored/sdk43/react-native-pager-view"
+  ABI43_0_0react-native-segmented-control:
+    :path: "./vendored/sdk43/@react-native-segmented-control/segmented-control"
   ABI43_0_0react-native-webview:
     :path: "./vendored/sdk43/react-native-webview"
   ABI43_0_0React-perflogger:
@@ -4450,6 +4464,8 @@ EXTERNAL SOURCES:
     :path: "./vendored/sdk43/react-native-reanimated"
   ABI43_0_0RNScreens:
     :path: "./vendored/sdk43/react-native-screens"
+  ABI43_0_0stripe-react-native:
+    :path: "./vendored/sdk43/@stripe/stripe-react-native"
   ABI43_0_0UMAppLoader:
     :path: "./versioned/sdk43/UMAppLoader"
   ABI43_0_0UMTaskManagerInterface:
@@ -5078,7 +5094,9 @@ SPEC CHECKSUMS:
   ABI43_0_0React-jsi: e5af4075772c2ecc0b53ea84db4e2f8aa1d00aef
   ABI43_0_0React-jsiexecutor: 430d9a230eca9bd8ab1f88f9be4ce74ac6cb1477
   ABI43_0_0React-jsinspector: 63c34e4bade90e3b6464e628c07f037fb7ecde11
+  ABI43_0_0react-native-netinfo: a175663a23a03b61d8028abfaa7d30b2b0bb5576
   ABI43_0_0react-native-pager-view: b7e2fff9851925b25a02659785064966a1a3dffb
+  ABI43_0_0react-native-segmented-control: 6faef5ee3dd155c3d38710d5bf9ecc4d9d6c4cd8
   ABI43_0_0react-native-webview: 8a19e64ee814a441110d24ffe8d9165c9eaac949
   ABI43_0_0React-perflogger: 410b7b91906f50750d1084b00df2ab0992a9fcec
   ABI43_0_0React-RCTActionSheet: 6098d10838ce2698477044dbe219251d8c9ef0de
@@ -5094,6 +5112,7 @@ SPEC CHECKSUMS:
   ABI43_0_0ReactCommon: 49ce2bdd63efe5a1d61a9cd663de13baa64d983a
   ABI43_0_0RNReanimated: f7cd484a2e1b5112ea84d57381c5d7ab6ceeab74
   ABI43_0_0RNScreens: d8e359af1191871e37501d5efd6b72b38c573e90
+  ABI43_0_0stripe-react-native: 75ba35284358f29b10851bda97d576a787ade851
   ABI43_0_0UMAppLoader: ac4c403f59e691af683873f22b44a023155bac55
   ABI43_0_0UMTaskManagerInterface: af977f83f0ab2c68d8023174a7d542a8cf465351
   ABI43_0_0Yoga: b4a69fd97272b10eb433c11dd8bb2e571e311e36

--- a/ios/vendored/sdk43/@react-native-segmented-control/segmented-control/ios/ABI43_0_0RNCSegmentedControl.m
+++ b/ios/vendored/sdk43/@react-native-segmented-control/segmented-control/ios/ABI43_0_0RNCSegmentedControl.m
@@ -9,7 +9,7 @@
 
 #import <ABI43_0_0React/ABI43_0_0RCTConvert.h>
 #import <ABI43_0_0React/ABI43_0_0RCTEventDispatcher.h>
-#import <ABI43_0_0React/UIView+ABI43_0_0React.h>
+#import <ABI43_0_0React/ABI43_0_0UIView+React.h>
 
 @implementation ABI43_0_0RNCSegmentedControl
 

--- a/ios/vendored/sdk43/@stripe/stripe-react-native/ios/ApplePayButtonManager.m
+++ b/ios/vendored/sdk43/@stripe/stripe-react-native/ios/ApplePayButtonManager.m
@@ -2,7 +2,7 @@
 #import <ABI43_0_0React/ABI43_0_0RCTBridgeModule.h>
 #import <ABI43_0_0React/ABI43_0_0RCTViewManager.h>
 
-@interface ABI43_0_0RCT_EXTERN_MODULE(ApplePayButtonManager, ABI43_0_0RCTViewManager)
+@interface ABI43_0_0RCT_EXTERN_REMAP_MODULE(ApplePayButtonManager, ABI43_0_0ApplePayButtonManager, ABI43_0_0RCTViewManager)
 ABI43_0_0RCT_EXPORT_VIEW_PROPERTY(onPressAction, ABI43_0_0RCTDirectEventBlock)
 ABI43_0_0RCT_EXPORT_VIEW_PROPERTY(type, NSNumber)
 ABI43_0_0RCT_EXPORT_VIEW_PROPERTY(buttonStyle, NSNumber)

--- a/ios/vendored/sdk43/@stripe/stripe-react-native/ios/AuBECSDebitFormManager.m
+++ b/ios/vendored/sdk43/@stripe/stripe-react-native/ios/AuBECSDebitFormManager.m
@@ -2,7 +2,7 @@
 #import <ABI43_0_0React/ABI43_0_0RCTBridgeModule.h>
 #import <ABI43_0_0React/ABI43_0_0RCTViewManager.h>
 
-@interface ABI43_0_0RCT_EXTERN_MODULE(AuBECSDebitFormManager, ABI43_0_0RCTViewManager)
+@interface ABI43_0_0RCT_EXTERN_REMAP_MODULE(AuBECSDebitFormManager, ABI43_0_0AuBECSDebitFormManager, ABI43_0_0RCTViewManager)
 ABI43_0_0RCT_EXPORT_VIEW_PROPERTY(onCompleteAction, ABI43_0_0RCTDirectEventBlock)
 ABI43_0_0RCT_EXPORT_VIEW_PROPERTY(companyName, NSString)
 ABI43_0_0RCT_EXPORT_VIEW_PROPERTY(formStyle, NSDictionary)

--- a/ios/vendored/sdk43/@stripe/stripe-react-native/ios/CardFieldManager.m
+++ b/ios/vendored/sdk43/@stripe/stripe-react-native/ios/CardFieldManager.m
@@ -2,7 +2,7 @@
 #import <ABI43_0_0React/ABI43_0_0RCTBridgeModule.h>
 #import <ABI43_0_0React/ABI43_0_0RCTViewManager.h>
 
-@interface ABI43_0_0RCT_EXTERN_MODULE(CardFieldManager, ABI43_0_0RCTViewManager)
+@interface ABI43_0_0RCT_EXTERN_REMAP_MODULE(CardFieldManager, ABI43_0_0CardFieldManager, ABI43_0_0RCTViewManager)
 ABI43_0_0RCT_EXPORT_VIEW_PROPERTY(postalCodeEnabled, BOOL)
 ABI43_0_0RCT_EXPORT_VIEW_PROPERTY(onCardChange, ABI43_0_0RCTDirectEventBlock)
 ABI43_0_0RCT_EXPORT_VIEW_PROPERTY(onFocusChange, ABI43_0_0RCTDirectEventBlock)

--- a/ios/vendored/sdk43/@stripe/stripe-react-native/ios/CardFieldView.swift
+++ b/ios/vendored/sdk43/@stripe/stripe-react-native/ios/CardFieldView.swift
@@ -40,7 +40,7 @@ class CardFieldView: UIView, STPPaymentCardTextFieldDelegate {
     @objc var autofocus: Bool = false {
         didSet {
             if autofocus == true {
-                cardField.reactFocus()
+                cardField.abi43_0_0ReactFocus()
             }
         }
     }

--- a/ios/vendored/sdk43/@stripe/stripe-react-native/ios/CardFormManager.m
+++ b/ios/vendored/sdk43/@stripe/stripe-react-native/ios/CardFormManager.m
@@ -2,7 +2,7 @@
 #import <ABI43_0_0React/ABI43_0_0RCTBridgeModule.h>
 #import <ABI43_0_0React/ABI43_0_0RCTViewManager.h>
 
-@interface ABI43_0_0RCT_EXTERN_MODULE(CardFormManager, ABI43_0_0RCTViewManager)
+@interface ABI43_0_0RCT_EXTERN_REMAP_MODULE(CardFormManager, ABI43_0_0CardFormManager, ABI43_0_0RCTViewManager)
 ABI43_0_0RCT_EXPORT_VIEW_PROPERTY(onFormComplete, ABI43_0_0RCTDirectEventBlock)
 ABI43_0_0RCT_EXPORT_VIEW_PROPERTY(dangerouslyGetFullCardDetails, BOOL)
 ABI43_0_0RCT_EXPORT_VIEW_PROPERTY(autofocus, BOOL)

--- a/ios/vendored/sdk43/@stripe/stripe-react-native/ios/StripeContainerManager.m
+++ b/ios/vendored/sdk43/@stripe/stripe-react-native/ios/StripeContainerManager.m
@@ -3,6 +3,6 @@
 #import <ABI43_0_0React/ABI43_0_0RCTViewManager.h>
 #import "ABI43_0_0React/ABI43_0_0RCTUIManager.h"
 
-@interface ABI43_0_0RCT_EXTERN_MODULE(StripeContainerManager, ABI43_0_0RCTViewManager)
+@interface ABI43_0_0RCT_EXTERN_REMAP_MODULE(StripeContainerManager, ABI43_0_0StripeContainerManager, ABI43_0_0RCTViewManager)
 ABI43_0_0RCT_EXPORT_VIEW_PROPERTY(keyboardShouldPersistTaps, BOOL)
 @end

--- a/ios/vendored/sdk43/@stripe/stripe-react-native/ios/StripeSdk.m
+++ b/ios/vendored/sdk43/@stripe/stripe-react-native/ios/StripeSdk.m
@@ -1,7 +1,7 @@
 #import <ABI43_0_0React/ABI43_0_0RCTBridgeModule.h>
 #import <ABI43_0_0React/ABI43_0_0RCTEventEmitter.h>
 
-@interface ABI43_0_0RCT_EXTERN_MODULE(StripeSdk, ABI43_0_0RCTEventEmitter)
+@interface ABI43_0_0RCT_EXTERN_REMAP_MODULE(StripeSdk, ABI43_0_0StripeSdk, ABI43_0_0RCTEventEmitter)
 
 
 ABI43_0_0RCT_EXTERN_METHOD(

--- a/ios/versioned-react-native/ABI43_0_0/dependencies.rb
+++ b/ios/versioned-react-native/ABI43_0_0/dependencies.rb
@@ -9,4 +9,4 @@ pod 'ABI43_0_0ExpoKit',
   :project_name => 'ABI43_0_0',
   :subspecs => ['Expo', 'ExpoOptional']
 
-use_pods! '{versioned,vendored}/sdk43/*/*.podspec.json', 'ABI43_0_0'
+use_pods! '{versioned,vendored}/sdk43/**/*.podspec.json', 'ABI43_0_0'

--- a/tools/src/versioning/ios/index.ts
+++ b/tools/src/versioning/ios/index.ts
@@ -403,11 +403,7 @@ async function generateExpoKitPodspecAsync(
     // `universalModulesPodNames` contains only versioned unimodules,
     // so we fall back to the original name if the module is not there
     const universalModulesDependencies = (await getListOfPackagesAsync())
-      .filter(
-        (pkg) =>
-          pkg.isIncludedInExpoClientOnPlatform('ios') &&
-          pkg.podspecName
-      )
+      .filter((pkg) => pkg.isIncludedInExpoClientOnPlatform('ios') && pkg.podspecName)
       .map(
         ({ podspecName }) =>
           `ss.dependency         "${universalModulesPodNames[podspecName!] || podspecName}"`
@@ -582,7 +578,7 @@ pod '${getVersionedExpoKitPodName(versionName)}',
 
 use_pods! '{versioned,vendored}/sdk${semver.major(
     versionNumber
-  )}/*/*.podspec.json', '${versionName}'
+  )}/**/*.podspec.json', '${versionName}'
 `;
 
   await fs.writeFile(path.join(versionedReactPodPath, 'dependencies.rb'), dependenciesContent);
@@ -824,12 +820,8 @@ function getCppLibrariesToVersion() {
 }
 
 export async function addVersionAsync(versionNumber: string, packages: Package[]) {
-  const {
-    sdkNumber,
-    versionName,
-    newVersionPath,
-    versionedPodNames,
-  } = await getConfigsFromArguments(versionNumber);
+  const { sdkNumber, versionName, newVersionPath, versionedPodNames } =
+    await getConfigsFromArguments(versionNumber);
 
   // Validate the directories we need before doing anything
   console.log(`Validating root directory ${chalk.magenta(EXPO_DIR)} ...`);
@@ -946,12 +938,8 @@ export async function reinstallPodsAsync(force?: boolean, preventReinstall?: boo
 }
 
 export async function removeVersionAsync(versionNumber: string) {
-  const {
-    sdkNumber,
-    newVersionPath,
-    versionedPodNames,
-    versionName,
-  } = await getConfigsFromArguments(versionNumber);
+  const { sdkNumber, newVersionPath, versionedPodNames, versionName } =
+    await getConfigsFromArguments(versionNumber);
 
   console.log(
     `Removing SDK version ${chalk.cyan(versionNumber)} from ${chalk.magenta(

--- a/tools/src/versioning/ios/transforms/vendoredModulesTransforms.ts
+++ b/tools/src/versioning/ios/transforms/vendoredModulesTransforms.ts
@@ -122,6 +122,14 @@ export default function vendoredModulesTransformsFactory(prefix: string): Config
         },
       ],
     },
+    '@react-native-segmented-control/segmented-control': {
+      content: [
+        {
+          find: `UIView+${prefix}React.h`,
+          replaceWith: `${prefix}UIView+React.h`,
+        },
+      ],
+    },
     'react-native-screens': {
       content: [],
     },


### PR DESCRIPTION
# Why

This PR solves two issues:
1. the Pods for certain _versioned_ vendored modules were not being installed
2. the correct versioning transforms for those vendored modules were not being run

# How

Both issues were due to the fact that some modules now have a `/` in the name, namely: `@stripe/stripe-react-native`, `@react-native-segmented-control/segmented-control`, and `@react-native-community/netinfo`

First issue is solved by changing `dependencies.rb` to recursively search for podspecs
Second is solved by changing the method that we use to find vendored module names in `versionVendoredModules.ts`:
- now, we glob for the podspec and then grab the directory names between that and the specified directory (in this case, `unversioned`)

# Test Plan

`pod install` results in new pods being installed:
<img width="500" alt="Screen Shot 2021-09-29 at 6 57 36 PM" src="https://user-images.githubusercontent.com/35579283/135362151-b9c64bc9-0fa4-4498-a365-8663b6a5ba30.png">

and also tested building versioned Expo Go & testing Stripe, netinfo, and segmented control, and you no longer get "native module cannot be null"

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).