### PR TITLE
[expo-go][android] revert non-nullabillity

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/UpdatesBinding.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/UpdatesBinding.kt
@@ -63,12 +63,12 @@ class UpdatesBinding(context: Context, experienceProperties: Map<String, Any?>) 
     return true
   }
 
-  override fun getLaunchedUpdate(): UpdateEntity {
-    return appLoader!!.launcher.launchedUpdate!!
+  override fun getLaunchedUpdate(): UpdateEntity? {
+    return appLoader!!.launcher.launchedUpdate
   }
 
-  override fun getLocalAssetFiles(): Map<AssetEntity, String> {
-    return appLoader!!.launcher.localAssetFiles!!
+  override fun getLocalAssetFiles(): Map<AssetEntity, String>? {
+    return appLoader!!.launcher.localAssetFiles
   }
 
   override fun relaunchReactApplication(callback: LauncherCallback) {


### PR DESCRIPTION
# Why

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

We were getting the expo-updates warnings when loading projects in Android Expo Go clients:

https://linear.app/expo/issue/ENG-2005/expo-updates-warning-on-fresh-initialization-of-app

The issue turned out to be a null pointer exception thrown by `getLocalAssetFiles` which the client tried to recover from by loading the `runtimeVersion`/`sdkVersion` from the wrong place: https://github.com/expo/expo/blob/master/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.java#L64

The origin of the incorrect non-null enforcement is from the translation to kotlin here: https://github.com/expo/expo/pull/14168/files

Confirmed this with @wschurman who pointed out that the nullability of the function had to be correct since the call sites had null checks. In doing so also noticed that `getLaunchedUpdate` should be nullable.

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

made functions nullable.

Will cherry pick to sdk-43 after landing on master.

# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->

confirmed `Expo Go` (with client build off sdk-43 with current PR's changes) now loads projects without any warning.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).