### PR TITLE
[media-library][android] Add null-check in createAsset

### DIFF
--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fix permissions always returning denied on android api < 29. ([#14570](https://github.com/expo/expo/pull/14570) by [@kudo](https://github.com/kudo))
+- Fix unhandled rejection when asset creation fails on Android. ([#14583](https://github.com/expo/expo/pull/14583) by [@barthap](https://github.com/barthap))
 
 ### 💡 Others
 

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/CreateAsset.java
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/CreateAsset.java
@@ -106,6 +106,10 @@ class CreateAsset extends AsyncTask<Void, Void, Void> {
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
       Uri assetUri = createAssetWithContentResolver();
+      if (assetUri == null) {
+        promise.reject(ERROR_UNABLE_TO_SAVE, "Could not create content entry.");
+        return null;
+      }
       writeFileContentsToAsset(localFile, assetUri);
 
       if (resolveWithAdditionalData) {


### PR DESCRIPTION
# Why

When I was kotlinizing media-library, I discovered that `contentResolver.insert()` returns nullable Uri.

> This is a reason why kotlinizing this package was a good move 😉 

**This should be cherry-picked to the `sdk-43` branch.**

# How

Added a null-check.

# Test Plan

None