### PR TITLE
[ci] Reduce file changes in tools that trigger iOS jobs to run

### DIFF
--- a/.github/workflows/client-ios.yml
+++ b/.github/workflows/client-ios.yml
@@ -12,7 +12,10 @@ on:
     paths:
       - .github/workflows/client-ios.yml
       - ios/**
-      - tools/**
+      - tools/src/dynamic-macros/**
+      - tools/src/commands/IosGenerateDynamicMacros.ts
+      - tools/src/client-build/**
+      - tools/src/commands/ClientBuild.ts
       - secrets/**
       - fastlane/**
       - Gemfile.lock
@@ -22,7 +25,10 @@ on:
     paths:
       - .github/workflows/client-ios.yml
       - ios/**
-      - tools/**
+      - tools/src/dynamic-macros/**
+      - tools/src/commands/IosGenerateDynamicMacros.ts
+      - tools/src/client-build/**
+      - tools/src/commands/ClientBuild.ts
       - secrets/**
       - fastlane/**
       - Gemfile.lock

--- a/.github/workflows/ios-unit-tests.yml
+++ b/.github/workflows/ios-unit-tests.yml
@@ -7,7 +7,10 @@ on:
       - .github/workflows/ios-unit-tests.yml
       - ios/**
       - packages/**/ios/**
-      - tools/**
+      - tools/src/dynamic-macros/**
+      - tools/src/commands/IosGenerateDynamicMacros.ts
+      - tools/src/commands/IosNativeUnitTests.ts
+      - tools/src/commands/NativeUnitTests.ts
       - secrets/**
       - fastlane/**
       - Gemfile.lock
@@ -18,7 +21,10 @@ on:
       - .github/workflows/ios-unit-tests.yml
       - ios/**
       - packages/**/ios/**
-      - tools/**
+      - tools/src/dynamic-macros/**
+      - tools/src/commands/IosGenerateDynamicMacros.ts
+      - tools/src/commands/IosNativeUnitTests.ts
+      - tools/src/commands/NativeUnitTests.ts
       - secrets/**
       - fastlane/**
       - Gemfile.lock


### PR DESCRIPTION
# Why

- Trying to reduce the usage of macOS workflow runners
- It's annoying that you have to wait for these long-running jobs even if you don't touch the tools that may impact them.

# How

Limited `client-ios` and `ios-unit-tests` workflows not to run on any change in `tools`, but just for the commands that may impact these jobs. I'm leaving other jobs (Android ones and SDK) as they are because they don't take so much time and they run on Ubuntu runners.

# Test Plan

We'll see next time we change something in tools
