### PR TITLE
[bare-expo][android] Install reanimated v2

### DIFF
--- a/apps/bare-expo/android/app/src/main/java/dev/expo/payments/MainApplication.java
+++ b/apps/bare-expo/android/app/src/main/java/dev/expo/payments/MainApplication.java
@@ -7,11 +7,14 @@ import com.facebook.react.PackageList;
 import com.facebook.react.ReactApplication;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.JSIModulePackage;
 import com.facebook.soloader.SoLoader;
+import com.swmansion.reanimated.ReanimatedJSIModulePackage;
 
 import java.util.List;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import expo.modules.ReactNativeHostWrapper;
 import expo.modules.ApplicationLifecycleDispatcher;
 import expo.modules.devlauncher.DevLauncherController;
@@ -36,7 +39,13 @@ public class MainApplication extends Application implements ReactApplication {
     protected String getJSMainModuleName() {
       return "index";
     }
-  });
+
+    @Nullable
+    @Override
+    protected JSIModulePackage getJSIModulePackage() {
+      return new ReanimatedJSIModulePackage();
+    }
+    });
 
   @Override
   public ReactNativeHost getReactNativeHost() {

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -85,7 +85,8 @@
       "expo-constants",
       "expo-camera",
       "expo-updates",
-      "detox"
+      "detox",
+      "react-native-reanimated"
     ]
   },
   "dependencies": {


### PR DESCRIPTION
# Why

Currently, react-native-reanimated wasn't installed in the bare-expo project on Android.

# How

- Added symlink, otherwise, the reaniamted's aar won't be linked correctly. 
- Added `JSIModulePackage` to app host.

# Test Plan

- bare-expo with NCL reanimated example 🟢 