### PR TITLE
[dev-menu][ios] Update reload key command

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🛠 Breaking changes
 
-- Changed the reload key command to `r` instead of `Cmd + r` on iOS.
+- Changed the reload key command to `r` instead of `Cmd + r` on iOS. ([#14590](https://github.com/expo/expo/pull/14590) by [@lukmccall](https://github.com/lukmccall))
 
 ### 🎉 New features
 

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- Changed the reload key command to `r` instead of `Cmd + r` on iOS.
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/packages/expo-dev-menu/ios/Modules/DevMenuExtensions.swift
+++ b/packages/expo-dev-menu/ios/Modules/DevMenuExtensions.swift
@@ -74,7 +74,7 @@ open class DevMenuExtensions: NSObject, DevMenuExtensionProtocol {
     reload.label = { "Reload" }
     reload.glyphName = { "reload" }
     reload.importance = DevMenuScreenItem.ImportanceHighest
-    reload.registerKeyCommand(input: "r", modifiers: .command)
+    reload.registerKeyCommand(input: "r", modifiers: []) // "r" without modifiers
     return reload
   }
 


### PR DESCRIPTION
# Why

Closes ENG-1971
A follow-up to the https://github.com/expo/expo/pull/14202

# How

Changed the reload key command from `CMD + r` to just `r`.

# Test Plan

- bare-expo ✅