### PR TITLE
[cherry-pick][ios][expo-notifications] Fix accidentally-versioned constant in EXServerRegistrationModule (#14576)

### DIFF
--- a/ios/versioned-react-native/ABI40_0_0/Expo/EXNotifications/ABI40_0_0EXNotifications/ABI40_0_0EXServerRegistrationModule.m
+++ b/ios/versioned-react-native/ABI40_0_0/Expo/EXNotifications/ABI40_0_0EXNotifications/ABI40_0_0EXServerRegistrationModule.m
@@ -5,6 +5,7 @@
 static NSString * const kEXDeviceInstallationUUIDKey = @"EXDeviceInstallationUUIDKey";
 static NSString * const kEXDeviceInstallationUUIDLegacyKey = @"EXDeviceInstallUUIDKey";
 
+// this constant value being versioned is incorrect and is fixed in SDK >=43
 static NSString * const kEXRegistrationInfoKey = @"ABI40_0_0EXNotificationRegistrationInfoKey";
 
 @implementation ABI40_0_0EXServerRegistrationModule

--- a/ios/versioned-react-native/ABI41_0_0/Expo/EXNotifications/ABI41_0_0EXNotifications/ABI41_0_0EXServerRegistrationModule.m
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/EXNotifications/ABI41_0_0EXNotifications/ABI41_0_0EXServerRegistrationModule.m
@@ -5,6 +5,7 @@
 static NSString * const kEXDeviceInstallationUUIDKey = @"EXDeviceInstallationUUIDKey";
 static NSString * const kEXDeviceInstallationUUIDLegacyKey = @"EXDeviceInstallUUIDKey";
 
+// this constant value being versioned is incorrect and is fixed in SDK >=43
 static NSString * const kEXRegistrationInfoKey = @"ABI41_0_0EXNotificationRegistrationInfoKey";
 
 @implementation ABI41_0_0EXServerRegistrationModule

--- a/ios/versioned-react-native/ABI42_0_0/Expo/EXNotifications/ABI42_0_0EXNotifications/ABI42_0_0EXServerRegistrationModule.m
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/EXNotifications/ABI42_0_0EXNotifications/ABI42_0_0EXServerRegistrationModule.m
@@ -5,6 +5,7 @@
 static NSString * const kEXDeviceInstallationUUIDKey = @"EXDeviceInstallationUUIDKey";
 static NSString * const kEXDeviceInstallationUUIDLegacyKey = @"EXDeviceInstallUUIDKey";
 
+// this constant value being versioned is incorrect and is fixed in SDK >=43
 static NSString * const kEXRegistrationInfoKey = @"ABI42_0_0EXNotificationRegistrationInfoKey";
 
 @implementation ABI42_0_0EXServerRegistrationModule

--- a/packages/expo-notifications/ios/EXNotifications/EXServerRegistrationModule.m
+++ b/packages/expo-notifications/ios/EXNotifications/EXServerRegistrationModule.m
@@ -2,10 +2,13 @@
 
 #import <EXNotifications/EXServerRegistrationModule.h>
 
-static NSString * const kEXDeviceInstallationUUIDKey = @"EXDeviceInstallationUUIDKey";
-static NSString * const kEXDeviceInstallationUUIDLegacyKey = @"EXDeviceInstallUUIDKey";
+// noop (used by code transform to ensure the versioning isn't applied)
+#define EX_UNVERSIONED(symbol) symbol
 
-static NSString * const kEXRegistrationInfoKey = @"EXNotificationRegistrationInfoKey";
+static NSString * const kEXDeviceInstallationUUIDKey = EX_UNVERSIONED(@"EXDeviceInstallationUUIDKey");
+static NSString * const kEXDeviceInstallationUUIDLegacyKey = EX_UNVERSIONED(@"EXDeviceInstallUUIDKey");
+
+static NSString * const kEXRegistrationInfoKey = EX_UNVERSIONED(@"EXNotificationRegistrationInfoKey");
 
 @implementation EXServerRegistrationModule
 

--- a/tools/src/versioning/ios/transforms/injectMacros.ts
+++ b/tools/src/versioning/ios/transforms/injectMacros.ts
@@ -36,7 +36,7 @@ export function injectMacros(versionName: string): TransformPipeline {
       },
       {
         // now that this code is versioned, remove meaningless EX_UNVERSIONED declaration
-        paths: 'EXUnversioned.h',
+        paths: ['EXUnversioned.h', 'EXServerRegistrationModule.m'],
         replace: /(#define symbol[.\S\s]+?(?=\n\n)\n\n)/g,
         with: '\n',
       },


### PR DESCRIPTION
# Why

Cherry picking 860d2008cbd04c14ef4935690a50a4612e682819 from sdk-43 branch to master.

# How

`git cherry-pick 860d2008cbd04c14ef4935690a50a4612e682819`

# Test Plan

N/A