### PR TITLE
[ncl] fix Camera.requestPermissionsAsync deprecated warning

### DIFF
--- a/apps/native-component-list/src/screens/Camera/CameraScreen.tsx
+++ b/apps/native-component-list/src/screens/Camera/CameraScreen.tsx
@@ -112,7 +112,7 @@ export default class CameraScreen extends React.Component<{}, State> {
     if (Platform.OS !== 'web') {
       this.ensureDirectoryExistsAsync();
     }
-    Camera.requestPermissionsAsync().then(({ status }) => {
+    Camera.requestCameraPermissionsAsync().then(({ status }) => {
       this.setState({ permission: status, permissionsGranted: status === 'granted' });
     });
   }


### PR DESCRIPTION
# Why

android versioned qa findings

# How

replace `Camera.requestPermissionsAsync` with `Camera.requestCameraPermissionsAsync`

# Test Plan

use expo-go to load ncl and test camera screen
