### PR TITLE
[native-component-list] Inform user about required API key for google geocoding

### DIFF
--- a/apps/native-component-list/src/components/SimpleActionDemo.tsx
+++ b/apps/native-component-list/src/components/SimpleActionDemo.tsx
@@ -26,6 +26,7 @@ export default function SimpleActionDemo(props: SimpleActionDemoProps) {
       const value = await props.action(setValue);
       setValue(value);
     } catch (error) {
+      console.error(error);
       setValue(error);
     }
     setLoading(false);

--- a/apps/native-component-list/src/screens/Location/GeocodingScreen.tsx
+++ b/apps/native-component-list/src/screens/Location/GeocodingScreen.tsx
@@ -5,7 +5,12 @@ import { Platform, ScrollView, StyleSheet, Text, View } from 'react-native';
 import SimpleActionDemo from '../../components/SimpleActionDemo';
 import TitleSwitch from '../../components/TitledSwitch';
 import usePermissions from '../../utilities/usePermissions';
-// Location.setGoogleApiKey('<PROVIDE_YOUR_OWN_API_KEY HERE>');
+
+const GOOGLE_MAPS_API_KEY = null; // Provide your own Google Maps API Key here
+
+if (GOOGLE_MAPS_API_KEY) {
+  Location.setGoogleApiKey(GOOGLE_MAPS_API_KEY);
+}
 
 const forwardGeocodingAddresses = [
   '1 Hacker Way, CA',
@@ -28,7 +33,15 @@ export default function GeocodingScreen() {
 
   const [useGoogleMaps, setGoogleMaps] = React.useState(false);
 
-  const toggleGoogleMaps = () => setGoogleMaps((value) => !value);
+  const toggleGoogleMaps = () => {
+    if (!GOOGLE_MAPS_API_KEY) {
+      throw new Error(
+        'Must supply GOOGLE_MAPS_API_KEY in GeocodingScreen.tsx to use Google Maps API'
+      );
+    } else {
+      setGoogleMaps((value) => !value);
+    }
+  };
 
   return (
     <ScrollView style={styles.container}>


### PR DESCRIPTION
# Why

During QA it was unclear why these weren't working. This PR throws an error when the user attempts to use google geocoding without specifying an API key in the code.

# How

throw an error

# Test Plan

Run the NCL experience, see that an error is shown when a key isn't supplied.