### PR TITLE
[native-component-list] fix modal onRequestClose behavior

### DIFF
--- a/apps/native-component-list/src/screens/ModalScreen.tsx
+++ b/apps/native-component-list/src/screens/ModalScreen.tsx
@@ -27,6 +27,7 @@ export default class ModalScreen extends React.Component<{}, State> {
         <Modal
           visible={false}
           onRequestClose={() => {
+            this.setState({ modalVisible: false });
             alert('Modal has been closed.');
           }}>
           <View />
@@ -37,6 +38,7 @@ export default class ModalScreen extends React.Component<{}, State> {
           transparent={false}
           visible={this.state.modalVisible}
           onRequestClose={() => {
+            this.setState({ modalVisible: false });
             alert('Modal has been closed.');
           }}>
           <View style={styles.modalContainer}>


### PR DESCRIPTION
# Why

In the NCL modal screen, seeing an alert saying "Modal has been closed" and then seeing that the modal is not closed is counterintuitive. This PR closes the modal in `onRequestClose` in addition to displaying the alert.

Noticed by kudo in https://linear.app/expo/issue/ENG-2014#comment-6921c8bf

# How

Set state to close.

# Test Plan

Press android back button, see more intuitive behavior.