### PR TITLE
[native-component-list] Make segmented control behavior clearer

### DIFF
--- a/apps/native-component-list/src/screens/SegmentedControlScreen.tsx
+++ b/apps/native-component-list/src/screens/SegmentedControlScreen.tsx
@@ -22,6 +22,10 @@ const SegmentedControlScreen = () => {
 
   return (
     <ScrollView contentContainerStyle={styles.container}>
+      <Text style={styles.text}>
+        Note: Only the last control on this screen is expected to change state
+      </Text>
+
       <View style={styles.segmentContainer}>
         <Text style={styles.text}>Segmented controls can have values and images</Text>
         <SegmentedControl values={['One', 'Two', require('../../assets/images/user.png')]} />


### PR DESCRIPTION
# Why

This clarifies the expected behavior of this screen to indicate that most segmented controls don't change state.

Noticed by @Kudo in https://linear.app/expo/issue/ENG-2014#comment-6921c8bf

# How

Add a label at the top indicating the expected behavior so that subsequent QA runs don't get confused.

# Test Plan

Use page, see label.