### PR TITLE
[Docs] ENG-1549 update using-libraries for modern Expo

### DIFF
--- a/docs/pages/workflow/using-libraries.md
+++ b/docs/pages/workflow/using-libraries.md
@@ -102,7 +102,7 @@ Many libraries you can use with Expo and React Native will not be compatible wit
 
 > 🙏 If you want some help determining library compatibility, [please create an issue on the React Native Directory repository](https://github.com/react-native-community/directory/issues/new/choose) and let us know. This will not just help you, it will help to ensure that other developers have an easy answer in the future!
 
-### Installing a Third-Party Library 
+### Installing a Third-Party Library
 
 > 💡 We recommend always using `expo install` instead of `npm install` or `yarn add` directly because it allows `expo-cli` to pick a compatible version of a library when possible and also warn you about known incompatibilities.
 

--- a/docs/pages/workflow/using-libraries.md
+++ b/docs/pages/workflow/using-libraries.md
@@ -98,7 +98,7 @@ Now check the following:
 
 If you answered yes to either of these questions and the library is not part of the Expo SDK, this library may not be supported in Expo Go. You can go ahead and try it in a new project to be sure! Run `expo init` and add the library to the new project and try to use it. This is a great way to experiment with a library before including it in your project in all circumstances.
 
-Many libraries you can use with Expo will not be compatible with Expo Go or `expo build:ios|android`. If you need any of them to build your app, you can create a [Custom Development Client](../clients/introduction.md) for your project using [EAS build](../build-reference/migrating.md) or [eject to the bare workflow](../workflow/customizing.md).
+Many libraries you can use with Expo and React Native will not be compatible with Expo Go or `expo build:ios|android`. If you need any of them to build your app, you can create a [Custom Development Client](../clients/introduction.md) for your project using [EAS Build](../build/introduction.md) or [eject to the bare workflow](../workflow/customizing.md).
 
 > 🙏 If you want some help determining library compatibility, [please create an issue on the React Native Directory repository](https://github.com/react-native-community/directory/issues/new/choose) and let us know. This will not just help you, it will help to ensure that other developers have an easy answer in the future!
 

--- a/docs/pages/workflow/using-libraries.md
+++ b/docs/pages/workflow/using-libraries.md
@@ -78,7 +78,7 @@ export default function App() {
 
 [React Native Directory](https://reactnative.directory) is a searchable database of libraries built specifically for React Native. If the library that you are looking for is not provided by React Native or Expo then this is the best place to look first when trying to find a library for your app.
 
-After React Native Directory, the [npm registry](https://www.npmjs.com/) is the next best place. The npm registry is the definitive source for JavaScript libraries, but the libraries that it lists may not all be compatible with React Native. React Native is one of many JavaScript programming environments, including Node.js, web browsers, Electron, and more, and npm includes libraries that work for all of these environments. Other libraries may be compatible with React Native, but not compatible with the Expo managed workflow. How do you figure this out?
+After React Native Directory, the [npm registry](https://www.npmjs.com/) is the next best place. The npm registry is the definitive source for JavaScript libraries, but the libraries that it lists may not all be compatible with React Native. React Native is one of many JavaScript programming environments, including Node.js, web browsers, Electron, and more, and npm includes libraries that work for all of these environments. Other libraries may be compatible with React Native, but not compatible with the Expo Go development client. How do you figure this out?
 
 ### Determining Third-Party Library Compatibility
 
@@ -92,17 +92,17 @@ npx npm-home --github react-native-localize
 
 Now check the following:
 
-- Does it include an `ios` and/or `android` directory?
+- Does it include an `ios` and/or `android/` directory?
 - Does the README mention linking?
 - Is it built specifically for Node.js, the web, electron, or another platform?
 
-If you answered yes to either of these questions and the library is not part of the Expo SDK, this library may not be supported in the managed workflow. You can go ahead and try it in a new project to be sure! Run `expo init` and add the library to the new project and try to use it. This is a great way to experiment with a library before including it in your project in all circumstances.
+If you answered yes to either of these questions and the library is not part of the Expo SDK, this library may not be supported in Expo Go. You can go ahead and try it in a new project to be sure! Run `expo init` and add the library to the new project and try to use it. This is a great way to experiment with a library before including it in your project in all circumstances.
 
-If the library is not compatible with the managed workflow and you need it to build your app, you may want to [eject to the bare workflow](../workflow/customizing.md).
+Many libraries you can use with Expo will not be compatible with Expo Go or `expo build:ios|android`. If you need any of them to build your app, you can create a [Custom Development Client](../clients/introduction.md) for your project using [EAS build](../build-reference/migrating.md) or [eject to the bare workflow](../workflow/customizing.md).
 
 > 🙏 If you want some help determining library compatibility, [please create an issue on the React Native Directory repository](https://github.com/react-native-community/directory/issues/new/choose) and let us know. This will not just help you, it will help to ensure that other developers have an easy answer in the future!
 
-### Installing a Third-Party Library
+### Installing a Third-Party Library 
 
 > 💡 We recommend always using `expo install` instead of `npm install` or `yarn add` directly because it allows `expo-cli` to pick a compatible version of a library when possible and also warn you about known incompatibilities.
 
@@ -117,3 +117,9 @@ Be sure to follow the project website or README for any additional configuration
 ```bash
 npx npm-home @react-navigation/native
 ```
+
+If the module needs additional native configuration, you can do so using [config plugins](../guides/config-plugins.md). 
+
+If the module is not supported in Expo Go, at this point you should:
+- Build your project [locally](../build-reference/local-builds.md) or with [EAS Build](../build/introduction.md)
+- Create [a custom client](../clients/introduction.md) to develop against


### PR DESCRIPTION
# Why

The page hasn't been updated to account for config plugins, EAS Build, or custom clients.

# How

Updated existing page to guide people towards switching to our modern options

# Test Plan

Read the page over and clicked links

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).