### PR TITLE
[Docs] ENG-2060 explain how to install development alongside produciton

### DIFF
--- a/docs/pages/clients/development-workflows.md
+++ b/docs/pages/clients/development-workflows.md
@@ -28,7 +28,7 @@ You can load your application on a device that has a compatible build of your cu
 | parameter | value |
 | --------------- | ----------------------- |
 | `scheme`         | URL scheme of your client (defaults to `exp+{slug}` where slug is the value set in your app.json)       |
-| `url`         | URL of a update manifest to load  (e.g. as provided by `expo publish`)     |
+| `url`         | URL-encoded URL of a update manifest to load  (e.g. as provided by `expo publish`)     |
 
 
 ### QR Codes

--- a/docs/pages/clients/development-workflows.md
+++ b/docs/pages/clients/development-workflows.md
@@ -23,7 +23,7 @@ To get a tunneled URL, pass the `--tunnel` flag to `expo start` from the command
 
 ### Deep linking URLs
 
-You can load you application on a device that has a compatible build of your custom client by opening a URL of the form `{scheme}://expo-development-client/?url={manifestUrl}` where
+You can load your application on a device that has a compatible build of your custom client by opening a URL of the form `{scheme}://expo-development-client/?url={manifestUrl}` where
 
 | parameter | value |
 | --------------- | ----------------------- |

--- a/docs/pages/clients/development-workflows.md
+++ b/docs/pages/clients/development-workflows.md
@@ -55,7 +55,7 @@ Developers on your team with expertise working with Xcode and Android Studio can
 
 ### Side by side installation
 
-If you need to look at release builds of your project, it is convenient to not overwrite the development version of your app every time you do so.  You can accomplish this by using your [app.config.js](../workflow/configuration.md) to set the bundle identifier or package name to use based on an environment variable.  When changing the ID of your project, be aware that some modules will expect you to perform installation steps for each bundle identifier or package name you use.
+If you need to look at release builds of your project, it is convenient to not overwrite the development version of your app every time you do so.  You can accomplish this by using [app.config.js](../workflow/configuration.md) to set the bundle identifier or package name based on an environment variable.  When changing the ID of your project, be aware that some modules will expect you to perform installation steps for each bundle identifier or package name you use.
 
 ```js
 module.exports = () => {

--- a/docs/pages/clients/development-workflows.md
+++ b/docs/pages/clients/development-workflows.md
@@ -27,7 +27,7 @@ You can load your application on a device that has a compatible build of your cu
 
 | parameter | value |
 | --------------- | ----------------------- |
-| `scheme`         | URL-encoded deeplinking scheme of your client (defaults to `exp+{slug}` where slug is the value set in your app.json)       |
+| `scheme`         | URL scheme of your client (defaults to `exp+{slug}` where slug is the value set in your app.json)       |
 | `url`         | URL of a update manifest to load  (e.g. as provided by `expo publish`)     |
 
 

--- a/docs/pages/clients/development-workflows.md
+++ b/docs/pages/clients/development-workflows.md
@@ -21,6 +21,16 @@ To get a tunneled URL, pass the `--tunnel` flag to `expo start` from the command
 
 [`expo publish`](../workflow/publishing.md) packages the current state of your JavaScript and asset files into an optimized "update" stored on a free hosting service provided by Expo.  Published updates can be loaded in Expo Clients without needing to check out a particular commit or leave a development machine running.
 
+### Deep linking URLs
+
+You can load you application on a device that has a compatible build of your custom client by opening a URL of the form `{scheme}://expo-development-client/?url={manifestUrl}` where
+
+| parameter | value |
+| --------------- | ----------------------- |
+| `scheme`         | URL-encoded deeplinking scheme of your client (defaults to `exp+{slug}` where slug is the value set in your app.json)       |
+| `url`         | URL of a update manifest to load  (e.g. as provided by `expo publish`)     |
+
+
 ### QR Codes
 
 You can use our endpoint to generate a QR code that can be easily loaded by a build of your custom development client.
@@ -42,6 +52,26 @@ These are a few examples of workflows to help your team get the most out of your
 ### Development Builds
 
 Developers on your team with expertise working with Xcode and Android Studio can update, review, and test changes to the native portion of your application and release them to your team periodically. The rest of your team can install these builds on their devices and simulators and quickly iterate on the JavaScript portion of your application without needing to understand and maintain the tooling required to create a new build.
+
+### Side by side installation
+
+If you need to look at release builds of your project, it is convenient to not overwrite the development version of your app every time you do so.  You can accomplish this by using your [app.config.js](../workflow/configuration.md) to set the bundle identifier or package name to use based on an environment variable.  When changing the ID of your project, be aware that some modules will expect you to perform installation steps for each bundle identifier or package name you use.
+
+```js
+module.exports = () => {
+  if (process.env.MY_ENVIRONMENT === 'production') {
+    return {
+      ios: { bundleIdentifier: "dev.expo.example"},
+      android: { package: "dev.expo.example"}
+    };
+  } else {
+    return {
+      ios: { bundleIdentifier: "dev.expo.example.dev"},
+      android: { package: "dev.expo.example.dev"}
+    };
+  }
+};
+```
 
 ### PR Previews
 


### PR DESCRIPTION
# Why

Users have brought this up several times as a pain point, and we have an easy solution :)

# How

Added to our existing workflows page

# Test Plan

Read page over and clicked link

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).