### PR TITLE
[template-files] Don't create expo-updates manifest when building shell app project

### DIFF
--- a/template-files/ios/ExpoKit-Podfile
+++ b/template-files/ios/ExpoKit-Podfile
@@ -1,5 +1,8 @@
 platform :ios, '12.0'
 
+# Disable expo-updates auto create manifest in podspec script_phase
+$expo_updates_create_manifest = false
+
 target '${TARGET_NAME}' do
 ${EXPOKIT_DEPENDENCY}
 ${PODFILE_UNVERSIONED_EXPO_MODULES_DEPENDENCIES}

--- a/template-files/ios/ExpoKit-Podfile-versioned
+++ b/template-files/ios/ExpoKit-Podfile-versioned
@@ -1,5 +1,8 @@
 platform :ios, '12.0'
 
+# Disable expo-updates auto create manifest in podspec script_phase
+$expo_updates_create_manifest = false
+
 target '${TARGET_NAME}' do
 ${EXPOKIT_DEPENDENCY}
 ${PODFILE_UNVERSIONED_EXPO_MODULES_DEPENDENCIES}


### PR DESCRIPTION
# Why

It won't work - this is meant for the standard bare app context.

# How

Add `$expo_updates_create_manifest = false` to Podfile templates. Alternatively, I could have added this to [IosPodTools](https://github.com/expo/xdl/blob/main/packages/xdl/src/detach/IosPodsTools.js) in xdl, but I didn't see a good reason to do so and it was more work.

# Test Plan

- `et ios-shell-app --action create-workspace -u "https://staging.exp.host/@notbrent/runverter/index.exp?sdkVersion=43.0.0" -s 43.0.0 --skipRepoUpdate`
- `xed shellAppWorkspaces/default/ios`
- Drag files from `shellAppWorkspaces/default/ios/ExpoKitApp/Supporting` into `Supporting` in Xcode, except for Info.plist and Assets.car.
- Build in release mode.
- The build will succeed (but crash on startup because expo-updates still looks in the `EXUpdates` bundle for `app.manifest` but it's in the main bundle in shell apps)