### PR TITLE
[updates] Fallback to main bundle if EXUpdates.bundle doesn't exist

### DIFF
--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesEmbeddedAppLoader.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesEmbeddedAppLoader.m
@@ -31,6 +31,11 @@ static NSString * const EXUpdatesEmbeddedAppLoaderErrorDomain = @"EXUpdatesEmbed
       NSString *path = [bundle pathForResource:EXUpdatesEmbeddedManifestName ofType:EXUpdatesEmbeddedManifestType];
       NSData *manifestData = [NSData dataWithContentsOfFile:path];
       if (!manifestData) {
+        path = [[NSBundle mainBundle] pathForResource:EXUpdatesEmbeddedManifestName ofType:EXUpdatesEmbeddedManifestType];
+        manifestData = [NSData dataWithContentsOfFile:path];
+      }
+
+      if (!manifestData) {
         @throw [NSException exceptionWithName:NSInternalInconsistencyException
                                        reason:@"The embedded manifest is invalid or could not be read. Make sure you have configured expo-updates correctly in your Xcode Build Phases."
                                      userInfo:@{}];

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesEmbeddedAppLoader.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesEmbeddedAppLoader.m
@@ -30,11 +30,15 @@ static NSString * const EXUpdatesEmbeddedAppLoaderErrorDomain = @"EXUpdatesEmbed
       NSBundle *bundle = [NSBundle bundleWithURL:bundleUrl];
       NSString *path = [bundle pathForResource:EXUpdatesEmbeddedManifestName ofType:EXUpdatesEmbeddedManifestType];
       NSData *manifestData = [NSData dataWithContentsOfFile:path];
+
+      // Fallback to main bundle if the embedded manifest is not found in EXUpdates.bundle. This is a special case
+      // to support the existing structure of Expo "shell apps"
       if (!manifestData) {
         path = [[NSBundle mainBundle] pathForResource:EXUpdatesEmbeddedManifestName ofType:EXUpdatesEmbeddedManifestType];
         manifestData = [NSData dataWithContentsOfFile:path];
       }
 
+      // Not found in EXUpdates.bundle or main bundle
       if (!manifestData) {
         @throw [NSException exceptionWithName:NSInternalInconsistencyException
                                        reason:@"The embedded manifest is invalid or could not be read. Make sure you have configured expo-updates correctly in your Xcode Build Phases."


### PR DESCRIPTION
# Why & how

Shell apps on SDK 43 for iOS currently crash on startup because we can't find the embedded manifest, which moved from the main app bundle to EXUpdates.bundle in 2f6287e11c85681eae0c4a48cdfc94edf3101445. This quick fix, while perhaps not pretty, allows the app to load successfully by looking for `app.manifest` in the main bundle if it can't be found in EXUpdates.bundle (which does not currently exist in shell apps).

(I accidentally branched off of sdk-43 here so we would need to cherrypick this to master after landing if we decide to do so)

# Test Plan

Same as https://github.com/expo/expo/pull/14608 but it should not crash on the last step.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [n/a] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).