### PR TITLE
[expo-updates][ios] add more database fields for error recovery manager

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- Add local SQLite fields for error recovery manager on iOS. ([#14610](https://github.com/expo/expo/pull/14610) by [@esamelson](https://github.com/esamelson))
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.h
+++ b/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.h
@@ -28,6 +28,9 @@ typedef NS_ENUM(NSInteger, EXUpdatesDatabaseHashType) {
 - (void)mergeAsset:(EXUpdatesAsset *)asset withExistingEntry:(EXUpdatesAsset *)existingAsset error:(NSError ** _Nullable)error;
 - (void)markUpdateFinished:(EXUpdatesUpdate *)update error:(NSError ** _Nullable)error;
 - (void)markUpdateAccessed:(EXUpdatesUpdate *)update error:(NSError ** _Nullable)error;
+- (void)markUpdatesOutdated:(NSArray<EXUpdatesUpdate *> *)updates error:(NSError ** _Nullable)error;
+- (void)incrementSuccessfulLaunchCountForUpdate:(EXUpdatesUpdate *)update error:(NSError ** _Nullable)error;
+- (void)incrementFailedLaunchCountForUpdate:(EXUpdatesUpdate *)update error:(NSError ** _Nullable)error;
 - (void)setScopeKey:(NSString *)scopeKey onUpdate:(EXUpdatesUpdate *)update error:(NSError ** _Nullable)error;
 - (void)markMissingAssets:(NSArray<EXUpdatesAsset *> *)assets error:(NSError ** _Nullable)error;
 

--- a/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.h
+++ b/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.h
@@ -28,7 +28,6 @@ typedef NS_ENUM(NSInteger, EXUpdatesDatabaseHashType) {
 - (void)mergeAsset:(EXUpdatesAsset *)asset withExistingEntry:(EXUpdatesAsset *)existingAsset error:(NSError ** _Nullable)error;
 - (void)markUpdateFinished:(EXUpdatesUpdate *)update error:(NSError ** _Nullable)error;
 - (void)markUpdateAccessed:(EXUpdatesUpdate *)update error:(NSError ** _Nullable)error;
-- (void)markUpdatesOutdated:(NSArray<EXUpdatesUpdate *> *)updates error:(NSError ** _Nullable)error;
 - (void)incrementSuccessfulLaunchCountForUpdate:(EXUpdatesUpdate *)update error:(NSError ** _Nullable)error;
 - (void)incrementFailedLaunchCountForUpdate:(EXUpdatesUpdate *)update error:(NSError ** _Nullable)error;
 - (void)setScopeKey:(NSString *)scopeKey onUpdate:(EXUpdatesUpdate *)update error:(NSError ** _Nullable)error;

--- a/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.m
+++ b/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.m
@@ -57,7 +57,7 @@ static NSString * const EXUpdatesDatabaseServerDefinedHeadersKey = @"serverDefin
 - (void)addUpdate:(EXUpdatesUpdate *)update error:(NSError ** _Nullable)error
 {
   NSString * const sql = @"INSERT INTO \"updates\" (\"id\", \"scope_key\", \"commit_time\", \"runtime_version\", \"manifest\", \"status\" , \"keep\", \"last_accessed\", \"successful_launch_count\", \"failed_launch_count\")\
-  VALUES (?1, ?2, ?3, ?4, ?5, ?6, 1, ?7, ?8, ?9, ?10);";
+  VALUES (?1, ?2, ?3, ?4, ?5, ?6, 1, ?7, ?8, ?9);";
 
   [self _executeSql:sql
            withArgs:@[

--- a/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabaseInitialization.m
+++ b/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabaseInitialization.m
@@ -23,7 +23,6 @@ CREATE TABLE \"updates\" (\
 \"last_accessed\"  INTEGER NOT NULL,\
 \"successful_launch_count\"  INTEGER NOT NULL,\
 \"failed_launch_count\"  INTEGER NOT NULL,\
-\"is_outdated\"  INTEGER NOT NULL,\
 PRIMARY KEY(\"id\"),\
 FOREIGN KEY(\"launch_asset_id\") REFERENCES \"assets\"(\"id\") ON DELETE CASCADE\
 );\

--- a/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabaseInitialization.m
+++ b/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabaseInitialization.m
@@ -8,7 +8,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 static NSString * const EXUpdatesDatabaseInitializationErrorDomain = @"EXUpdatesDatabaseInitialization";
-static NSString * const EXUpdatesDatabaseLatestFilename = @"expo-v6.db";
+static NSString * const EXUpdatesDatabaseLatestFilename = @"expo-v7.db";
 
 static NSString * const EXUpdatesDatabaseInitializationLatestSchema = @"\
 CREATE TABLE \"updates\" (\
@@ -21,6 +21,9 @@ CREATE TABLE \"updates\" (\
 \"status\"  INTEGER NOT NULL,\
 \"keep\"  INTEGER NOT NULL,\
 \"last_accessed\"  INTEGER NOT NULL,\
+\"successful_launch_count\"  INTEGER NOT NULL,\
+\"failed_launch_count\"  INTEGER NOT NULL,\
+\"is_outdated\"  INTEGER NOT NULL,\
 PRIMARY KEY(\"id\"),\
 FOREIGN KEY(\"launch_asset_id\") REFERENCES \"assets\"(\"id\") ON DELETE CASCADE\
 );\

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate.h
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate.h
@@ -36,6 +36,9 @@ typedef NS_ENUM(NSInteger, EXUpdatesUpdateStatus) {
 
 @property (nonatomic, assign) EXUpdatesUpdateStatus status;
 @property (nonatomic, strong) NSDate *lastAccessed;
+@property (nonatomic, assign) NSInteger successfulLaunchCount;
+@property (nonatomic, assign) NSInteger failedLaunchCount;
+@property (nonatomic, assign) BOOL isOutdated;
 
 + (instancetype)updateWithId:(NSUUID *)updateId
                     scopeKey:(NSString *)scopeKey

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate.h
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate.h
@@ -8,13 +8,39 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+ * Download status that indicates whether or under what conditions an
+ * update is able to be launched.
+ *
+ * It's important that the integer value of each status stays constant across
+ * all versions of this library since they are stored in SQLite on user devices.
+ */
 typedef NS_ENUM(NSInteger, EXUpdatesUpdateStatus) {
-  EXUpdatesUpdateStatusFailed = 0,
+  EXUpdatesUpdateStatus0_Unused = 0,
+  /**
+   * The update has been fully downloaded and is ready to launch.
+   */
   EXUpdatesUpdateStatusReady = 1,
-  EXUpdatesUpdateStatusLaunchable = 2,
+  EXUpdatesUpdateStatus2_Unused = 2,
+  /**
+   * The update manifest has been download from the server but not all
+   * assets have finished downloading successfully.
+   */
   EXUpdatesUpdateStatusPending = 3,
-  EXUpdatesUpdateStatusUnused = 4,
+  EXUpdatesUpdateStatus4_Unused = 4,
+  /**
+   * The update has been partially loaded (copied) from its location
+   * embedded in the app bundle, but not all assets have been copied
+   * successfully. The update may be able to be launched directly from
+   * its embedded location unless a new binary version with a new
+   * embedded update has been installed.
+   */
   EXUpdatesUpdateStatusEmbedded = 5,
+  /**
+   * The update manifest has been downloaded and indicates that the
+   * update is being served from a developer tool. It can be launched by a
+   * host application that can run a development bundle.
+   */
   EXUpdatesUpdateStatusDevelopment = 6
 };
 

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate.h
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate.h
@@ -64,7 +64,6 @@ typedef NS_ENUM(NSInteger, EXUpdatesUpdateStatus) {
 @property (nonatomic, strong) NSDate *lastAccessed;
 @property (nonatomic, assign) NSInteger successfulLaunchCount;
 @property (nonatomic, assign) NSInteger failedLaunchCount;
-@property (nonatomic, assign) BOOL isOutdated;
 
 + (instancetype)updateWithId:(NSUUID *)updateId
                     scopeKey:(NSString *)scopeKey

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate.m
@@ -32,6 +32,9 @@ NSString * const EXUpdatesUpdateErrorDomain = @"EXUpdatesUpdate";
     _scopeKey = config.scopeKey;
     _status = EXUpdatesUpdateStatusPending;
     _lastAccessed = [NSDate date];
+    _successfulLaunchCount = 0;
+    _failedLaunchCount = 0;
+    _isOutdated = NO;
     _isDevelopmentMode = NO;
   }
   return self;

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate.m
@@ -34,7 +34,6 @@ NSString * const EXUpdatesUpdateErrorDomain = @"EXUpdatesUpdate";
     _lastAccessed = [NSDate date];
     _successfulLaunchCount = 0;
     _failedLaunchCount = 0;
-    _isOutdated = NO;
     _isDevelopmentMode = NO;
   }
   return self;

--- a/packages/expo-updates/ios/Tests/EXUpdatesDatabaseInitializationTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesDatabaseInitializationTests.m
@@ -97,6 +97,51 @@ CREATE INDEX \"index_updates_launch_asset_id\" ON \"updates\" (\"launch_asset_id
 CREATE INDEX \"index_json_data_scope_key\" ON \"json_data\" (\"scope_key\")\
 ";
 
+static NSString * const EXUpdatesDatabaseV6Schema = @"\
+CREATE TABLE \"updates\" (\
+\"id\"  BLOB UNIQUE,\
+\"scope_key\"  TEXT NOT NULL,\
+\"commit_time\"  INTEGER NOT NULL,\
+\"runtime_version\"  TEXT NOT NULL,\
+\"launch_asset_id\" INTEGER,\
+\"manifest\"  TEXT,\
+\"status\"  INTEGER NOT NULL,\
+\"keep\"  INTEGER NOT NULL,\
+\"last_accessed\"  INTEGER NOT NULL,\
+PRIMARY KEY(\"id\"),\
+FOREIGN KEY(\"launch_asset_id\") REFERENCES \"assets\"(\"id\") ON DELETE CASCADE\
+);\
+CREATE TABLE \"assets\" (\
+\"id\"  INTEGER PRIMARY KEY AUTOINCREMENT,\
+\"url\"  TEXT,\
+\"key\"  TEXT UNIQUE,\
+\"headers\"  TEXT,\
+\"type\"  TEXT NOT NULL,\
+\"metadata\"  TEXT,\
+\"download_time\"  INTEGER NOT NULL,\
+\"relative_path\"  TEXT NOT NULL,\
+\"hash\"  BLOB NOT NULL,\
+\"hash_type\"  INTEGER NOT NULL,\
+\"marked_for_deletion\"  INTEGER NOT NULL\
+);\
+CREATE TABLE \"updates_assets\" (\
+\"update_id\"  BLOB NOT NULL,\
+\"asset_id\" INTEGER NOT NULL,\
+FOREIGN KEY(\"update_id\") REFERENCES \"updates\"(\"id\") ON DELETE CASCADE,\
+FOREIGN KEY(\"asset_id\") REFERENCES \"assets\"(\"id\") ON DELETE CASCADE\
+);\
+CREATE TABLE \"json_data\" (\
+\"id\" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,\
+\"key\" TEXT NOT NULL,\
+\"value\" TEXT NOT NULL,\
+\"last_updated\" INTEGER NOT NULL,\
+\"scope_key\" TEXT NOT NULL\
+);\
+CREATE UNIQUE INDEX \"index_updates_scope_key_commit_time\" ON \"updates\" (\"scope_key\", \"commit_time\");\
+CREATE INDEX \"index_updates_launch_asset_id\" ON \"updates\" (\"launch_asset_id\");\
+CREATE INDEX \"index_json_data_scope_key\" ON \"json_data\" (\"scope_key\")\
+";
+
 @interface EXUpdatesDatabaseInitializationTests : XCTestCase
 
 @property (nonatomic, strong) NSURL *testDatabaseDir;

--- a/packages/expo-updates/ios/Tests/EXUpdatesDatabaseTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesDatabaseTests.m
@@ -64,6 +64,7 @@
     NSError *updatesError;
     [_db addUpdate:update error:&updatesError];
     if (updatesError) {
+      XCTFail(@"%@", updatesError.localizedDescription);
       return;
     }
 


### PR DESCRIPTION
# Why

ENG-1493

https://github.com/expo/expo/pull/14397#issuecomment-931880022

# How

Add the following database fields to `updates`:
- `successful_launch_count` -- how many times the update has launched and we've successfully received `RCTContentDidAppearNotification`. Once this is > 0 we want to mark all older updates as outdated and will no longer fall back to an older update. [This could be a boolean field, but since booleans are integers in SQLite anyway I thought it could be useful in the future to keep track of the number of launches 🤷 ]
- `failed_launch_count` -- how many times the update has failed to launch, i.e. thrown an error before the initial render. Once this is > 0 we won't try to launch the update again, and we might fall back to an older update if a newer one isn't available. [again, could be a boolean]
- `is_outdated` -- whether or not a "newer" (determined by selection policy) update has been launched successfully. If this is true we won't launch the update again. (It might still be kept around for its assets, to make server-based rollbacks quicker.)

# Test Plan

Tested as part of the full PR stack

# Todo

Once this PR stack is finalized, write the full DB migration

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).