### PR TITLE
[modules-core][android] Make `onActivityResult` intent nullable

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/core/interfaces/ActivityEventListener.java
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/core/interfaces/ActivityEventListener.java
@@ -3,8 +3,10 @@ package expo.modules.core.interfaces;
 import android.app.Activity;
 import android.content.Intent;
 
+import androidx.annotation.Nullable;
+
 public interface ActivityEventListener {
-  public void onActivityResult(Activity activity, int requestCode, int resultCode, Intent data);
+  public void onActivityResult(Activity activity, int requestCode, int resultCode, @Nullable Intent data);
 
   // Called when a new intent is passed to the activity
   public void onNewIntent(Intent intent);


### PR DESCRIPTION
# Why

- https://github.com/expo/expo/commit/cab6e8d53f714f218a29b833a508338aed89903b
- https://github.com/expo/expo/pull/14572#discussion_r719415584

When converting modules to Kotlin, Android Studio deduces non-nullable `onActivityResult(/* ... */, data: Intent)` instead of nullable `data: Intent?`. This leads to runtime errors:
> `IllegalArgumentException: Parameter specified as non-null is null`

# How

Annotated `Intent data` parameter as `@Nullable` - this should help Android Studio to properly treat this parameter as nullable.

# Test Plan

- CI passes
- Kotlinized a module before and after (Android Studio -> Code menu -> Convert Java to Kotlin file)