### PR TITLE
[android][tools] fix android shell app errors for sdk 43

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -184,7 +184,7 @@ dependencies {
   testImplementation 'org.mockito:mockito-core:1.10.19'
 
   /* UNCOMMENT WHEN DISTRIBUTING
-  implementation('host.exp.exponent:expoview:42.0.0@aar') {
+  implementation('host.exp.exponent:expoview:43.0.0@aar') {
     transitive = true
     exclude group: 'com.squareup.okhttp3', module: 'okhttp'
     exclude group: 'com.squareup.okhttp3', module: 'okhttp-urlconnection'

--- a/android/expoview/build.gradle
+++ b/android/expoview/build.gradle
@@ -7,7 +7,7 @@ apply plugin: 'kotlin-kapt'
 // WHEN_VERSIONING_REMOVE_FROM_HERE
 //maven repository info
 group = 'host.exp.exponent'
-version = '42.0.0'
+version = '43.0.0'
 
 
 //Upload android library to maven with javadoc and android sources
@@ -272,7 +272,7 @@ dependencies {
   api 'org.webkit:android-jsc:r245459' // needs to be before react-native
 
   /* UNCOMMENT WHEN DISTRIBUTING
-  api 'com.facebook.react:react-native:42.0.0'
+  api 'com.facebook.react:react-native:43.0.0'
   compileOnly project(':expo')
   compileOnly project(':expo-random')
   END UNCOMMENT WHEN DISTRIBUTING */

--- a/android/expoview/src/main/java/host/exp/exponent/experience/DetachedModuleRegistryAdapter.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/DetachedModuleRegistryAdapter.kt
@@ -27,7 +27,7 @@ open class DetachedModuleRegistryAdapter(moduleRegistryProvider: ReactModuleRegi
     val reactApplicationContext = scopedContext.context as ReactApplicationContext
 
     // We only use React application context, because we're detached -- no scopes
-    val moduleRegistry = mModuleRegistryProvider[scopedContext]
+    val moduleRegistry = mModuleRegistryProvider[reactApplicationContext]
 
     moduleRegistry.registerInternalModule(
       ConstantsBinding(

--- a/tools/package.json
+++ b/tools/package.json
@@ -27,7 +27,7 @@
     "@expo/json-file": "^8.2.6",
     "@expo/spawn-async": "^1.5.0",
     "@expo/xcodegen": "2.18.0-patch.1",
-    "@expo/xdl": "^59.1.5",
+    "@expo/xdl": "^59.1.7",
     "@octokit/rest": "^18.5.3",
     "@types/base-64": "^0.1.2",
     "@types/concat-stream": "^1.6.0",

--- a/tools/src/commands/AndroidShellApp.ts
+++ b/tools/src/commands/AndroidShellApp.ts
@@ -65,5 +65,9 @@ export default (program: any) => {
     .option('--keystoreAlias [string]', 'Keystore alias (optional)')
     .option('--keystorePassword [string]', 'Keystore password (optional)')
     .option('--keyPassword [string]', 'Key password (optional)')
+    .option(
+      '--privateConfigFile [string]',
+      'Path to privateConfig file (aka exp.android.config in app.json) (optional)'
+    )
     .asyncAction(action);
 };

--- a/tools/yarn.lock
+++ b/tools/yarn.lock
@@ -2611,10 +2611,10 @@
   resolved "https://registry.yarnpkg.com/@expo/xcodegen/-/xcodegen-2.18.0-patch.1.tgz#40514e973ee6769e5abd5d1c16d40dbe85c1d9aa"
   integrity sha512-Caz2ChzVe/U3GkaK+DKlXqYorARzLZ1yM6D03LHvasnyA4T+pW6DGXHPy7cfK5AlbsV6Fi5ZtZ9gqW4jGWIFwQ==
 
-"@expo/xdl@^59.1.5":
-  version "59.1.5"
-  resolved "https://registry.yarnpkg.com/@expo/xdl/-/xdl-59.1.5.tgz#e631aedceb03ca8fe3e7d5cab6b407554ca632fb"
-  integrity sha512-8SlNyyzpOdMwJXYqKDb09Yxp8zqxMMDSy8El0bLTibgHCyHrNgrfvWZi3f8O10+4M26LyITZ/OZy2Io2P/3uRg==
+"@expo/xdl@^59.1.7":
+  version "59.1.7"
+  resolved "https://registry.yarnpkg.com/@expo/xdl/-/xdl-59.1.7.tgz#b11463b1b72493e9608b5de7492e62cf855198a5"
+  integrity sha512-tOW95XRegMryP5QVu+UNIMcia1Sp/1Qb7ieMuB7QC4k6K5KkuIADtlbKD/SsrFFz+DBUorj9pZW+Cw+qUd89Vw==
   dependencies:
     "@expo/bunyan" "4.0.0"
     "@expo/config" "3.3.30"


### PR DESCRIPTION
# Why

fix android shell app for sdk 43

# How

- `et android-build-packages`
- fix an exception for `ScopedContext` cannot downcast to `ReactContext`. the exception is from here: https://github.com/expo/expo/blob/b319832785511f1b253530e5d2357ea7c394bc28/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/ReactAdapterPackage.java#L26-L29
i checked sdk-42 code where it also passing `scopedContext` in `DetachedModuleRegistryAdapter`. since there are much change, i didn't trace down which commit cause the change. anyway it looks like passing `reactContext` make sense.
- support to pass `--privateConfigFile` in `et android-shell-app` 
- xdl also needs some changes: https://github.com/expo/xdl/pull/40

# Test Plan

`et android-build-packages --packages all`
`et android-shell-app --url "https://staging.exp.host/@kudochien/native-component-list-next/index.exp?sdkVersion=43.0.0" --sdkVersion 43.0.0 --privateConfigFile privateConfig.json`

# Checklist

- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).