### PR TITLE
[android] fix android shell app errors from unimodules autolinking

### DIFF
--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -18,7 +18,9 @@ apply from: new File(["node", "--print", "require.resolve('expo/package.json')"]
 useExpoModules([
     exclude: [
         'expo-module-template',
-        'expo-in-app-purchases'
+        'expo-in-app-purchases',
+        '@unimodules/core',
+        '@unimodules/react-native-adapter',
     ],
     searchPaths: [
       'enabled-modules'


### PR DESCRIPTION
# Why

fix android shell app errors. it is for `sdk-43` branch because we haven't removed unimodules there.
related to #14613 

# How

exclude unimodules autolinking explicitly

# Test Plan

`et android-build-packages --packages all`
`et android-shell-app --url "https://staging.exp.host/@kudochien/native-component-list-next/index.exp?sdkVersion=43.0.0" --sdkVersion 43.0.0 --privateConfigFile privateConfig.json`

# Checklist

- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).