### PR TITLE
[tools] Update iOS shell apps for expo modules

### DIFF
--- a/.github/workflows/shell-app-ios.yml
+++ b/.github/workflows/shell-app-ios.yml
@@ -6,9 +6,6 @@ on:
       upload:
         description: 'type "upload" to confirm upload to S3'
         required: false
-      versioned:
-        description: 'Create shell workspace from newest SDK versioned environment'
-        required: false
   schedule:
     - cron: '20 5 * * 2,4,6'
   pull_request:
@@ -61,28 +58,14 @@ jobs:
           key: ${{ runner.os }}-modules-${{ hashFiles('tools/yarn.lock') }}
       - name: 🍏 Generate dynamic macros
         run: expotools ios-generate-dynamic-macros
-      - name: 📦 Build iOS shell app for real devices (versioned)
-        if: ${{ github.event.inputs.versioned == 'true' }}
+      - name: 📦 Build iOS shell app for real devices
         timeout-minutes: 30
         run: |
           expotools ios-shell-app --action build --type archive --verbose true --skipRepoUpdate --shellAppSdkVersion UNVERSIONED
-      - name: 📦 Build iOS shell app for simulators (versioned)
-        if: ${{ github.event.inputs.versioned == 'true' }}
+      - name: 📦 Build iOS shell app for simulators
         timeout-minutes: 30
         run: |
           expotools ios-shell-app --action build --type simulator --verbose true --skipRepoUpdate --shellAppSdkVersion UNVERSIONED
-      - name: 📦 Build iOS shell app for real devices (unversioned)
-        if: ${{ github.event.inputs.versioned != 'true' }}
-        timeout-minutes: 30
-        run: |
-          expotools ios-shell-app --action build --type archive --verbose true --skipRepoUpdate --shellAppSdkVersion UNVERSIONED \
-            --packagesToInstallWhenEjecting '{"react-native": "file:../../react-native-lab/react-native", "react-native-unimodules": "file:../../packages/react-native-unimodules"}'
-      - name: 📦 Build iOS shell app for simulators (unversioned)
-        if: ${{ github.event.inputs.versioned != 'true' }}
-        timeout-minutes: 30
-        run: |
-          expotools ios-shell-app --action build --type simulator --verbose true --skipRepoUpdate --shellAppSdkVersion UNVERSIONED \
-            --packagesToInstallWhenEjecting '{"react-native": "file:../../react-native-lab/react-native", "react-native-unimodules": "file:../../packages/react-native-unimodules"}'
       - name: ✏️ Set tarball name
         id: tarball
         run: echo "::set-output name=filename::ios-shell-builder-sdk-latest-${{ github.sha }}.tar.gz"

--- a/exponent-view-template/package.json
+++ b/exponent-view-template/package.json
@@ -8,7 +8,10 @@
   },
   "author": "",
   "license": "MIT",
-  "dependencies": {},
+  "dependencies": {
+    "expo": "file:../../packages/expo",
+    "react-native": "file:../../react-native-lab/react-native"
+  },
   "devDependencies": {
     "expo-cli": "4.3.2"
   }

--- a/ios/ExpoKit.podspec
+++ b/ios/ExpoKit.podspec
@@ -40,9 +40,7 @@ Pod::Spec.new do |s|
     ss.dependency 'ReactCommon' # needed for react-native-reanimated, see https://github.com/expo/expo/pull/11096#how
 
     # Universal modules required by ExpoKit so the code compiles
-    ss.dependency 'UMCore'
     ss.dependency 'ExpoModulesCore'
-    ss.dependency 'UMReactNativeAdapter'
   end
 
   s.subspec "FaceDetector" do |ss|

--- a/template-files/ios/ExpoKit-Podfile
+++ b/template-files/ios/ExpoKit-Podfile
@@ -3,10 +3,41 @@ platform :ios, '12.0'
 # Disable expo-updates auto create manifest in podspec script_phase
 $expo_updates_create_manifest = false
 
-target '${TARGET_NAME}' do
-${EXPOKIT_DEPENDENCY}
-${PODFILE_UNVERSIONED_EXPO_MODULES_DEPENDENCIES}
-${PODFILE_UNVERSIONED_RN_DEPENDENCY}
+# Require autolinking script
+require File.join(File.dirname(`node --print "require.resolve('expo/package.json')"`), "scripts/autolinking")
+
+target 'ExpoKitApp' do
+  pod 'ExpoKit',
+    :path => "../../../ios",
+    :subspecs => [
+      "Core"
+    ],
+    :inhibit_warnings => true
+
+  # Install expo modules
+  use_expo_modules!(
+    searchPaths: ['../../../packages'],
+    exclude: [
+      'expo-bluetooth',
+      'expo-in-app-purchases',
+      'expo-payments-stripe',
+      'expo-module-template',
+      'expo-image'
+    ],
+  )
+
+  # Pods that are not expo modules
+  pod 'EXRandom', path: '../../../packages/expo-random/ios'
+
+  # Install React Native and its dependencies
+  require_relative '../node_modules/react-native/scripts/react_native_pods'
+  use_react_native!(production: true)
+
+  # Install vendored pods.
+  pod 'JKBigInteger', :podspec => '../../../ios/vendored/common/JKBigInteger.podspec.json'
+  require_relative '../../../ios/podfile_helpers.rb'
+  excluded_pods = ['stripe-react-native']
+  use_pods!('../../../ios/vendored/unversioned/**/*.podspec.json', nil, excluded_pods)
 
   post_install do |installer|
     installer.pods_project.main_group.tab_width = '2';
@@ -14,8 +45,53 @@ ${PODFILE_UNVERSIONED_RN_DEPENDENCY}
 
     installer.target_installation_results.pod_target_installation_results
       .each do |pod_name, target_installation_result|
-${PODFILE_DETACHED_POSTINSTALL}
-${PODFILE_UNVERSIONED_POSTINSTALL}
+
+      if pod_name == 'ExpoKit'
+        target_installation_result.native_target.build_configurations.each do |config|
+          config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= ['$(inherited)']
+          config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] << 'EX_DETACHED=1'
+          
+          # Enable Google Maps support
+          config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] << 'HAVE_GOOGLE_MAPS=1'
+          config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] << 'HAVE_GOOGLE_MAPS_UTILS=1'
+          
+        end
+      end
+
+      
+      if pod_name == 'Branch'
+        target_installation_result.native_target.build_configurations.each do |config|
+          config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= ['$(inherited)']
+          config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] << 'BRANCH_EXCLUDE_IDFA_CODE=1'
+        end
+      end
+
+
+
+      target_installation_result.native_target.build_configurations.each do |config|
+        config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '11.0'
+      end
+
+
+      # Can't specify this in the React podspec because we need to use those podspecs for detached
+      # projects which don't reference ExponentCPP.
+      if pod_name.start_with?('React')
+        target_installation_result.native_target.build_configurations.each do |config|
+          config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '11.0'
+          config.build_settings['HEADER_SEARCH_PATHS'] ||= ['$(inherited)']
+        end
+      end
+
+      # Build React Native with RCT_DEV enabled and RCT_ENABLE_INSPECTOR and
+      # RCT_ENABLE_PACKAGER_CONNECTION disabled
+      next unless pod_name.start_with?('React')
+      target_installation_result.native_target.build_configurations.each do |config|
+        config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= ['$(inherited)']
+        config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] << 'RCT_DEV=1'
+        config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] << 'RCT_ENABLE_INSPECTOR=0'
+        config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] << 'ENABLE_PACKAGER_CONNECTION=0'
+      end
+
     end
   end
 end

--- a/template-files/ios/ExpoKit.podspec
+++ b/template-files/ios/ExpoKit.podspec
@@ -34,9 +34,7 @@ ${IOS_EXPOKIT_DEPS}
     ss.dependency 'ReactCommon' # needed for react-native-reanimated, see https://github.com/expo/expo/pull/11096#how
 
     # Universal modules required by ExpoKit so the code compiles
-    ss.dependency 'UMCore'
     ss.dependency 'ExpoModulesCore'
-    ss.dependency 'UMReactNativeAdapter'
   end
 
   s.subspec "FaceDetector" do |ss|

--- a/tools/src/commands/IosShellApp.ts
+++ b/tools/src/commands/IosShellApp.ts
@@ -5,7 +5,11 @@ import sharp from 'sharp';
 
 import * as Directories from '../Directories';
 
-async function resizeIconWithSharpAsync(iconSizePx: number, iconFilename: string, destinationIconPath: string) {
+async function resizeIconWithSharpAsync(
+  iconSizePx: number,
+  iconFilename: string,
+  destinationIconPath: string
+) {
   const filename = path.join(destinationIconPath, iconFilename);
 
   // sharp can't have same input and output filename, so load to buffer then

--- a/tools/src/commands/WorkflowDispatch.ts
+++ b/tools/src/commands/WorkflowDispatch.ts
@@ -50,13 +50,6 @@ const CUSTOM_WORKFLOWS = {
       releaseSimulator: 'release-simulator',
     },
   },
-  'shell-app-ios-versioned': {
-    name: 'iOS Shell App (with newest SDK version)',
-    baseWorkflowSlug: 'shell-app-ios',
-    inputs: {
-      versioned: 'true',
-    },
-  },
   'shell-app-ios-upload': {
     name: 'iOS Shell App (with newest SDK version and Upload to S3)',
     baseWorkflowSlug: 'shell-app-ios',


### PR DESCRIPTION
# Why

iOS shell apps need to be updated for expo modules

# How

Actually I found it easier to... just remove some code from `@expo/xdl` 😂 So far we had three flows in xdl scripts:
- unversioned shell app
- versioned shell app
- ejected app

It turned out that we no longer need to use the `versioned` and `ejected` ones — `versioned` is something from the past when shell apps contained multiple SDKs and ejected is not used since we dropped ExpoKit. This motivated me to remove some unnecessary logic from there, and, remove all of the substitutions from `template-files/ExpoKit-Podfile`, so it's clear what the final Podfile will have and it's also in `expo/expo` repo instead of `expo/xdl`.

Then I applied appropriate changes in the Podfile to support expo modules.

# Test Plan

`expotools ios-shell-app --action create-workspace --type simulator -u "https://staging.exp.host/@andrewexpo45/native-component-list/index.exp" --verbose true -s 43.0.0 --shellAppSdkVersion UNVERSIONED` works in release configuration
