### PR TITLE
[dev-client][docs][ios] Adjust installation steps for new bare template - SDK 43

### DIFF
--- a/docs/pages/clients/installation.md
+++ b/docs/pages/clients/installation.md
@@ -11,7 +11,9 @@ The installation steps on this page are only required to add expo-dev-client to 
 
 To initialize a new Bare project or to add a development client to an existing managed project, see our [Getting Started guide](getting-started.md).
 
-If you created your project with `expo init`, or already you have `react-native-unimodules` and/or other Expo modules up and running, use the tabs marked **With unimodules** (most projects will fall under this category).
+If you created your project with `expo init`, or already you have `expo` and/or other Expo modules up and running, use the tabs marked **With Expo modules** (most projects will fall under this category).
+
+If you created your project with `expo init` before SDK 43, or already you have `react-native-unimodules` up and running, use the tabs marked **With unimodules**.
 
 If you created your project with `npx react-native init` and do not have `react-native-unimodules` or any other Expo packages installed, use the tabs marked **Without unimodules**.
 
@@ -25,7 +27,7 @@ Add the `expo-dev-client` package to your package.json.
 
 Add the following lines to your `Podfile`:
 
-<Tabs tabs={["With unimodules", "Without unimodules"]}>
+<Tabs tabs={["With Expo modules/unimodules", "Without unimodules"]}>
 
 <Tab >
 <ConfigurationDiff source="/static/diffs/client/podfile.diff" />
@@ -59,7 +61,7 @@ To do that, you need to open Xcode, go to `Project settings` > `General` > `Depl
 
 ### 🤖 Android
 
-<Tabs tabs={["With unimodules", "Without unimodules"]}>
+<Tabs tabs={["With Expo modules/unimodules", "Without unimodules"]}>
 
 <Tab >
 
@@ -93,7 +95,11 @@ See the [uri-scheme package](https://www.npmjs.com/package/uri-scheme) for more 
 
 Make the following changes to allow the Development Client to control project initialization in the **DEBUG** mode.
 
-<Tabs tabs={["With unimodules", "Without unimodules"]}>
+<Tabs tabs={["With Expo modules", "With unimodules", "Without unimodules"]}>
+
+<Tab >
+<ConfigurationDiff source="/static/diffs/client/app-delegate-expo-modules.diff" />
+</Tab>
 
 <Tab >
 <ConfigurationDiff source="/static/diffs/client/app-delegate.diff" />
@@ -133,7 +139,7 @@ There are a few more changes you can make to get the best experience, but you [c
 
 ### Enable development with Expo CLI
 
-Expo CLI requires you to have the `expo` package installed so it can maintain consistent behavior in your project when new versions of the Expo SDK are released.  The package will not be used directly by your project unless you import it in your application code, which is not recommended.
+Expo CLI requires you to have the `expo` package installed so it can maintain consistent behavior in your project when new versions of the Expo SDK are released. The package will not be used directly by your project unless you import it in your application code, which is not recommended.
 
 <InstallSection packageName="expo" cmd={["npm install expo --save-dev"]} hideBareInstructions />
 

--- a/docs/pages/clients/installation.md
+++ b/docs/pages/clients/installation.md
@@ -11,9 +11,9 @@ The installation steps on this page are only required to add expo-dev-client to 
 
 To initialize a new Bare project or to add a development client to an existing managed project, see our [Getting Started guide](getting-started.md).
 
-If you created your project with `expo init`, or already you have `expo` and/or other Expo modules up and running, use the tabs marked **With Expo modules** (most projects will fall under this category).
+If you created your project with `expo init`, or you already have `expo` and/or other Expo modules up and running, use the tabs marked **With Expo modules** (most projects will fall under this category).
 
-If you created your project with `expo init` before SDK 43, or already you have `react-native-unimodules` up and running, use the tabs marked **With unimodules**.
+If you created your project with `expo init` before SDK 43, or you already have `react-native-unimodules` up and running, use the tabs marked **With unimodules**.
 
 If you created your project with `npx react-native init` and do not have `react-native-unimodules` or any other Expo packages installed, use the tabs marked **Without unimodules**.
 

--- a/docs/public/static/diffs/client/app-delegate-expo-modules.diff
+++ b/docs/public/static/diffs/client/app-delegate-expo-modules.diff
@@ -1,0 +1,89 @@
+diff --git a/ios/expodevexample/AppDelegate.m b/ios/expodevexample/AppDelegate.m
+index 837259e..7e619d8 100644
+--- a/ios/expodevexample/AppDelegate.m
++++ b/ios/expodevexample/AppDelegate.m
+@@ -40,7 +40,23 @@ - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(
+ #if defined(FB_SONARKIT_ENABLED) && __has_include(<FlipperKit/FlipperClient.h>)
+   InitializeFlipper(application);
+ #endif
+-  
++
++  self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
++
++#if defined(EX_DEV_LAUNCHER_ENABLED)
++  EXDevLauncherController *controller = [EXDevLauncherController sharedInstance];
++  [controller startWithWindow:self.window delegate:(id<EXDevLauncherControllerDelegate>)self launchOptions:launchOptions];
++#else
++  [self initializeReactNativeApp:launchOptions];
++#endif
++
++  [super application:application didFinishLaunchingWithOptions:launchOptions];
++
++  return YES;
++ }
++
++- (RCTBridge *)initializeReactNativeApp:(NSDictionary *)launchOptions
++{
+   RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:launchOptions];
+   RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge moduleName:@"main" initialProperties:nil];
+   id rootViewBackgroundColor = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"RCTRootViewBackgroundColor"];
+@@ -50,16 +66,13 @@ - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(
+     rootView.backgroundColor = [UIColor whiteColor];
+   }
+ 
+-  self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+   UIViewController *rootViewController = [UIViewController new];
+   rootViewController.view = rootView;
+   self.window.rootViewController = rootViewController;
+   [self.window makeKeyAndVisible];
+ 
+-  [super application:application didFinishLaunchingWithOptions:launchOptions];
+-
+-  return YES;
+- }
++  return bridge;
++}
+ 
+ - (NSArray<id<RCTBridgeModule>> *)extraModulesForBridge:(RCTBridge *)bridge
+ {
+@@ -69,7 +82,11 @@ - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(
+ 
+ - (NSURL *)sourceURLForBridge:(RCTBridge *)bridge {
+  #ifdef DEBUG
+-  return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index" fallbackResource:nil];
++  #if defined(EX_DEV_LAUNCHER_ENABLED)
++    return [[EXDevLauncherController sharedInstance] sourceUrl];
++  #else
++    return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index" fallbackResource:nil];
++  #endif 
+  #else
+   return [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
+  #endif
+@@ -77,6 +94,11 @@ - (NSURL *)sourceURLForBridge:(RCTBridge *)bridge {
+ 
+ // Linking API
+ - (BOOL)application:(UIApplication *)application openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {
++#if defined(EX_DEV_LAUNCHER_ENABLED)
++  if ([EXDevLauncherController.sharedInstance onDeepLink:url options:options]) {
++      return true;
++  }
++#endif
+   return [RCTLinkingManager application:application openURL:url options:options];
+ }
+ 
+@@ -88,3 +110,15 @@ - (BOOL)application:(UIApplication *)application continueUserActivity:(nonnull N
+ }
+ 
+ @end
++
++#if defined(EX_DEV_LAUNCHER_ENABLED)
++@implementation AppDelegate (EXDevLauncherControllerDelegate)
++ 
++- (void)devLauncherController:(EXDevLauncherController *)developmentClientController
++          didStartWithSuccess:(BOOL)success
++{
++  developmentClientController.appBridge = [self initializeReactNativeApp:[EXDevLauncherController.sharedInstance getLaunchOptions]];
++}
++ 
++@end
++#endif

--- a/docs/public/static/diffs/client/podfile.diff
+++ b/docs/public/static/diffs/client/podfile.diff
@@ -7,7 +7,7 @@ index 55100df..375d171 100644
  require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
  
 -platform :ios, '10.0'
-+platform :ios, '11.0'
++platform :ios, '12.0'
  
  target 'devclient201227' do
    use_unimodules!


### PR DESCRIPTION
# Why

Closes ENG-2066.
Adjusted installation steps for the new bare templated using SDK 43 on iOS.

# How

Updated the installation steps.

# Test Plan

- manually apply changes and see if dev-client works ✅