### PR TITLE
[docs] Use <ImageSpotlight /> in EAS Update preview docs

### DIFF
--- a/docs/pages/preview/eas-update/debug-updates.md
+++ b/docs/pages/preview/eas-update/debug-updates.md
@@ -2,6 +2,8 @@
 title: Debugging updates
 ---
 
+import ImageSpotlight from '~/components/plugins/ImageSpotlight'
+
 It's important to be able to tell the current state of our app at any given time. EAS Update was built with this in mind. Once you know which updates are running on which builds, we can make changes so that our apps are in the state we expect and desire.
 
 ## Inspecting the state of deployments
@@ -68,7 +70,7 @@ The output will display the message of the update, when it was created and by wh
 
 When we publish an update with EAS Update, it creates a **/dist** folder in the root of your project locally, which includes the assets that were uploaded as a part of the update.
 
-![Dist directory](/static/images/eas-update/dist.png)
+<ImageSpotlight alt="Dist directory" src="/static/images/eas-update/dist.png" />
 
 ## Undoing a bad publish
 

--- a/docs/pages/preview/eas-update/deployment-patterns.md
+++ b/docs/pages/preview/eas-update/deployment-patterns.md
@@ -2,6 +2,8 @@
 title: Deployment patterns
 ---
 
+import ImageSpotlight from '~/components/plugins/ImageSpotlight'
+
 Once we've created features and fixed bugs, we want to get our changes out to our users as soon as we can, as safely as we can. Often "safe" and "fast" are opposing forces when delivering code to our users. We could push our code directly to production, which would be fast, but it would also be unsafe since we never tested our code. On the other hand, we could make test builds, share them with a QA team, and release periodically. That would be safer, but also slower to deliver changes to our users.
 
 Depending on your project, you'll have some tolerance for how "fast" and how "safe" you'll need to be when delivering updates to your users.
@@ -38,7 +40,7 @@ Publishing updates: (a) Publish to a single branch.
 
 Diagram of flow:
 
-![Two command deployment diagram](/static/images/eas-update/deployment-two-command.png)
+<ImageSpotlight alt="Two command deployment diagram" src="/static/images/eas-update/deployment-two-command.png" style={{maxWidth: 1200}} />
 
 Explanation of flow:
 
@@ -67,7 +69,7 @@ Publishing updates: (c) Create update branches that are version based, like "ver
 
 Diagram of flow:
 
-![Branch deployment diagram](/static/images/eas-update/deployment-branch.png)
+<ImageSpotlight alt="Branch deployment diagram" src="/static/images/eas-update/deployment-branch.png" style={{maxWidth: 1200}} />
 
 Explanation of flow:
 
@@ -102,7 +104,7 @@ Publishing updates: (c) Create update branches that are environment-based, like 
 
 Diagram of flow:
 
-![Staging deployment diagram](/static/images/eas-update/deployment-staging.png)
+<ImageSpotlight alt="Staging deployment diagram" src="/static/images/eas-update/deployment-staging.png" style={{maxWidth: 1200}} />
 
 Explanation of flow:
 
@@ -134,7 +136,7 @@ Publishing updates: (c) Create update branches that are environment- and platfor
 
 Diagram of flow:
 
-![Platform specific deployment diagram](/static/images/eas-update/deployment-platform-specific.png)
+<ImageSpotlight alt="Platform specific deployment diagram" src="/static/images/eas-update/deployment-platform-specific.png" style={{maxWidth: 1200}} />
 
 Explanation of flow:
 

--- a/docs/pages/preview/eas-update/eas-update-and-eas-cli.md
+++ b/docs/pages/preview/eas-update/eas-update-and-eas-cli.md
@@ -2,13 +2,15 @@
 title: Using EAS Update with EAS CLI
 ---
 
+import ImageSpotlight from '~/components/plugins/ImageSpotlight'
+
 EAS Update works by linking _branches_ to _channels_. Channels are specified at build time and exist inside a build's native code. Branches are an ordered list of updates, similar to a Git branch, which is an ordered list of commits. With EAS Update, we can link any channel to any branch, allowing us to make different updates available to different builds.
 
-![Channel "production" linked to branch "version-1.0"](/static/images/eas-update/channel-branch-link.png)
+<ImageSpotlight alt={`Channel "production" linked to branch "version-1.0"`} src="/static/images/eas-update/channel-branch-link.png" />
 
 The diagram above visualizes this link. Here, we have the builds with the "production" channel linked to the branch named "version-1.0". When we're ready, we can adjust the channel–branch pointer. Imagine we have more fixes tested and ready on a branch named "version-2.0". We could update this link to make the "version-2.0" branch available to all builds with the "production" channel.
 
-![Channel "production" linked to branch "version-2.0"](/static/images/eas-update/channel-branch-link-2.png)
+<ImageSpotlight alt={`Channel "production" linked to branch "version-2.0"`} src="/static/images/eas-update/channel-branch-link-2.png" />
 
 ## Inspecting the state of your project's updates
 

--- a/docs/pages/preview/eas-update/how-eas-update-works.md
+++ b/docs/pages/preview/eas-update/how-eas-update-works.md
@@ -2,13 +2,15 @@
 title: How EAS Update works
 ---
 
+import ImageSpotlight from '~/components/plugins/ImageSpotlight'
+
 EAS Update is a service that allows you to deliver small bug fixes and updates to your users immediately as you work on your next app store release. Making an update available to builds involves creating a link between a build and an update.
 
 To create a link between a build and an update, we have to make sure the update can run on the build. We also want to make sure we can create a deployment process, so that we can expose certain updates to certain builds when we're ready.
 
 To illustrate how builds and updates interact, take a look at the following diagram:
 
-![Native and update layers diagram](/static/images/eas-update/layers.png)
+<ImageSpotlight alt="Native and update layers diagram" src="/static/images/eas-update/layers.png" />
 
 Builds can be thought of as two layers: a native layer that's built into the app's binary, and an update layer, that is swappable with other compatible updates. This separation allows us to ship bug fixes to builds as long as the update with the bug fix can run on the native layer inside the build.
 
@@ -26,7 +28,7 @@ When we're ready to create a build of our Expo project, we can run a command lik
 
 If we were to make two builds with the channel named "staging" and two builds with the channel named "production", we'd end up with something like this:
 
-![Build types diagram](/static/images/eas-update/builds.png)
+<ImageSpotlight alt="Build types diagram" src="/static/images/eas-update/builds.png" />
 
 This diagram is just an example of how you could create builds and name their channels, and where you could put those builds. Ultimately it's up to you which channel names you set and where you put those builds.
 
@@ -36,7 +38,7 @@ After we've created builds, we can change the update layer of our project and pu
 
 To publish an update, we can run `eas branch:publish --auto`. This command will create a local update bundle inside the **dist/** folder in our project. Once it's created an update bundle, it will upload that bundle to EAS' servers, in a database object named a _branch_. A branch has a name, and contains a list of updates, where the most recent update is the active update on the branch.
 
-![Branches with its most recent update pointed out as the active one](/static/images/eas-update/branch.png)
+<ImageSpotlight alt="Branches with its most recent update pointed out as the active one" src="/static/images/eas-update/branch.png" />
 
 **Matching updates and builds**
 
@@ -48,11 +50,11 @@ Like builds, every update on a branch includes a target runtime version and targ
 
 Let's focus on that last point. Every build has a channel, and we, as developers, can link that channel to any branch, which will make its most recent compatible update available on the channel. To simplify this linking, by default we'll auto-link a channel to a branch of the same name. For instance, if we created builds with the channel named "production", we could publish updates to a branch named "production" and our builds would get the updates on a matching branch named "production", even though we did not manually link anything.
 
-![Channel "production" linked to branch "production" by default](/static/images/eas-update/default-link.png)
+<ImageSpotlight alt={`Channel "production" linked to branch "production" by default`} src="/static/images/eas-update/default-link.png" />
 
 While this default will work in many cases, we can always change the mapping. Say we found a bug, found it, fixed it, and published it to a branch named "production-hotfix". We could then point our builds with the channel "production" at the branch "production-hotfix":
 
-![Channel "production" updated to be linked to branch "production-hotfix"](/static/images/eas-update/custom-link.png)
+<ImageSpotlight alt={`Channel "production" updated to be linked to branch "production-hotfix"`} src="/static/images/eas-update/custom-link.png" />
 
 ## Practical overview
 
@@ -68,7 +70,7 @@ To help in the second phase of this process, the `expo-updates` module will also
 
 If the app is able to download the manifest (phase 1) and all the required assets (phase 2) before the `fallbackToCacheTimeout` setting, then the app will run the new update immediately on launch. If the app is not able to get the manifest and assets in time, the app will continue to download the new update in the background. Then on the next launch of the app, assuming the update was fully downloaded successfully, the new update will run.
 
-![Update download timeline](/static/images/eas-update/process.png)
+<ImageSpotlight alt="Update download timeline" src="/static/images/eas-update/process.png" />
 
 ## Wrap up
 

--- a/docs/pages/preview/eas-update/introduction.md
+++ b/docs/pages/preview/eas-update/introduction.md
@@ -6,14 +6,20 @@ EAS (Expo Application Services) Update is a cloud service by the Expo team that 
 
 > ⚠️ Currently EAS Update is not ready for use in production apps.
 
-Docs:
+**Get Started with EAS Update**
 
-- [Custom updates server](/preview/eas-update/custom-updates-server)
-- [Debug updates](/preview/eas-update/debug-updates)
-- [Deployment patterns](/preview/eas-update/deployment-patterns)
-- [EAS Update and EAS CLI](/preview/eas-update/eas-update-and-eas-cli)
-- [FAQ](/preview/eas-update/faq)
 - [Getting started](/preview/eas-update/getting-started)
 - [GitHub Actions](/preview/eas-update/github-actions)
+
+**Guides**
+
 - [How EAS Update works](/preview/eas-update/how-eas-update-works)
+- [Deployment patterns](/preview/eas-update/deployment-patterns)
+- [Debug updates](/preview/eas-update/debug-updates)
+- [EAS Update and EAS CLI](/preview/eas-update/eas-update-and-eas-cli)
 - [Optimize assets](/preview/eas-update/optimize-assets)
+
+**More**
+
+- [Custom updates server](/preview/eas-update/custom-updates-server)
+- [FAQ](/preview/eas-update/faq)

--- a/docs/pages/preview/eas-update/optimize-assets.md
+++ b/docs/pages/preview/eas-update/optimize-assets.md
@@ -2,9 +2,11 @@
 title: How to optimize assets for EAS Update
 ---
 
+import ImageSpotlight from '~/components/plugins/ImageSpotlight'
+
 When an app finds a new update, it downloads a manifest and then downloads any new or updated assets so that it can run the update. The process is as follows:
 
-![Process](/static/images/eas-update/process.png)
+<ImageSpotlight alt="Update download timeline" src="/static/images/eas-update/process.png" style={{maxWidth: 1200}} />
 
 Many users running Android and iOS apps are using mobile connections that are not as consistent or fast as when they are using Wi-Fi, so it's important that the assets shipped as a part of an update are as small as possible.
 


### PR DESCRIPTION
# Why

Use  `<ImageSpotlight />` for the images in the EAS Update preview docs.

# Test Plan

Make sure that you can see all the images still, and that they're presented with `<ImageSpotlight />`. This will show a border around most images, so that it stands out when the docs are in dark mode.