### PR TITLE
[swift] Make definition function static

### DIFF
--- a/packages/expo-cellular/ios/EXCellular/CellularModule.swift
+++ b/packages/expo-cellular/ios/EXCellular/CellularModule.swift
@@ -2,28 +2,35 @@ import CoreTelephony
 import ExpoModulesCore
 
 public class CellularModule: Module {
-  public func definition() -> ModuleDefinition {
+  public static func definition() -> ModuleDefinition {
     name("ExpoCellular")
+
     constants {
-      Self.getCurrentCellularInfo()
+      getCurrentCellularInfo()
     }
+
     method("getCellularGenerationAsync") { () -> Int in
-      Self.currentCellularGeneration().rawValue
+      currentCellularGeneration().rawValue
     }
+
     method("allowsVoipAsync") { () -> Bool? in
-      Self.currentCarrier()?.allowsVOIP
+      currentCarrier()?.allowsVOIP
     }
+
     method("getIsoCountryCodeAsync") { () -> String? in
-      Self.currentCarrier()?.isoCountryCode
+      currentCarrier()?.isoCountryCode
     }
+
     method("getCarrierNameAsync") { () -> String? in
-      Self.currentCarrier()?.carrierName
+      currentCarrier()?.carrierName
     }
+
     method("getMobileCountryCodeAsync") { () -> String? in
-      Self.currentCarrier()?.mobileCountryCode
+      currentCarrier()?.mobileCountryCode
     }
+
     method("getMobileNetworkCodeAsync") { () -> String? in
-      Self.currentCarrier()?.mobileNetworkCode
+      currentCarrier()?.mobileNetworkCode
     }
   }
 

--- a/packages/expo-haptics/ios/EXHaptics/HapticsModule.swift
+++ b/packages/expo-haptics/ios/EXHaptics/HapticsModule.swift
@@ -1,10 +1,10 @@
 import ExpoModulesCore
 
 public class HapticsModule: Module {
-  public func definition() -> ModuleDefinition {
+  public static func definition() -> ModuleDefinition {
     name("ExpoHaptics")
 
-    method("notificationAsync") { (notificationType: String, promise: Promise) in
+    method("notificationAsync") { (_, notificationType: String, promise: Promise) in
       guard let feedbackType = NotificationType(rawValue: notificationType)?.toFeedbackType() else {
         promise.reject("E_HAPTICS_INVALID_ARG", "Notification type must be one of: 'success', 'warning', 'error'. Obtained '\(notificationType)'")
         return
@@ -15,7 +15,7 @@ public class HapticsModule: Module {
       promise.resolve()
     }
 
-    method("impactAsync") { (style: String, promise: Promise) in
+    method("impactAsync") { (_, style: String, promise: Promise) in
       guard let feedbackStyle = ImpactStyle(rawValue: style)?.toFeedbackStyle() else {
         promise.reject("E_HAPTICS_INVALID_ARG", "Impact style must be one of: 'light', 'medium', 'heavy'. Obtained '\(style)'")
         return

--- a/packages/expo-linear-gradient/ios/EXLinearGradient/LinearGradientModule.swift
+++ b/packages/expo-linear-gradient/ios/EXLinearGradient/LinearGradientModule.swift
@@ -1,7 +1,7 @@
 import ExpoModulesCore
 
 public class LinearGradientModule: Module {
-  public func definition() -> ModuleDefinition {
+  public static func definition() -> ModuleDefinition {
     name("ExpoLinearGradient")
 
     viewManager {

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- Swift's module definition is now a static function which also makes modules lazy by default. ([#14645](https://github.com/expo/expo/pull/14645) by [@tsapeta](https://github.com/tsapeta))
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/packages/expo-modules-core/ios/Swift/AppContext.swift
+++ b/packages/expo-modules-core/ios/Swift/AppContext.swift
@@ -108,4 +108,10 @@ public class AppContext {
     NotificationCenter.default.removeObserver(self)
     moduleRegistry.post(event: .appContextDestroys)
   }
+
+  // MARK: Errors
+
+  struct DeallocatedAppContextError: CodedError {
+    var description: String = "The app context has been deallocated."
+  }
 }

--- a/packages/expo-modules-core/ios/Swift/EventListener.swift
+++ b/packages/expo-modules-core/ios/Swift/EventListener.swift
@@ -3,20 +3,52 @@
  */
 internal struct EventListener: AnyDefinition {
   let name: EventName
-  let call: (Any?) -> Void
+  let call: (Any?, Any?) throws -> Void
 
+  /**
+   Listener initializer for events without sender and payload.
+   */
   init(_ name: EventName, _ listener: @escaping () -> Void) {
     self.name = name
-    self.call = { payload in listener() }
+    self.call = { (sender, payload) in listener() }
   }
 
-  init<PayloadType>(_ name: EventName, _ listener: @escaping (PayloadType?) -> Void) {
+  /**
+   Listener initializer for events with no payload.
+   */
+  init<Sender>(_ name: EventName, _ listener: @escaping (Sender) -> Void) {
     self.name = name
-    self.call = { payload in listener(payload as? PayloadType) }
+    self.call = { (sender, payload) in
+      guard let sender = sender as? Sender else {
+        throw InvalidSenderTypeError(eventName: name, senderType: Sender.self)
+      }
+      listener(sender)
+    }
+  }
+
+  /**
+   Listener initializer for events that specify the payload.
+   */
+  init<Sender, PayloadType>(_ name: EventName, _ listener: @escaping (Sender, PayloadType?) -> Void) {
+    self.name = name
+    self.call = { (sender, payload) in
+      guard let sender = sender as? Sender else {
+        throw InvalidSenderTypeError(eventName: name, senderType: Sender.self)
+      }
+      listener(sender, payload as? PayloadType)
+    }
   }
 }
 
-internal enum EventName: Equatable {
+struct InvalidSenderTypeError: CodedError {
+  var eventName: EventName
+  var senderType: Any.Type
+  var description: String {
+    "Sender for event `\(eventName)` must be of type `\(senderType)`."
+  }
+}
+
+public enum EventName: Equatable {
   case custom(_ name: String)
 
   // MARK: Module lifecycle

--- a/packages/expo-modules-core/ios/Swift/Methods/AnyMethod.swift
+++ b/packages/expo-modules-core/ios/Swift/Methods/AnyMethod.swift
@@ -20,9 +20,9 @@ public protocol AnyMethod: AnyDefinition {
   var queue: DispatchQueue? { get }
 
   /**
-   Calls the method with given arguments and a promise.
+   Calls the method on given module with arguments and a promise.
    */
-  func call(args: [Any?], promise: Promise) -> Void
+  func call(module: AnyModule, args: [Any?], promise: Promise) -> Void
 
   /**
    Specifies on which queue the method should run.

--- a/packages/expo-modules-core/ios/Swift/Methods/ConcreteMethod.swift
+++ b/packages/expo-modules-core/ios/Swift/Methods/ConcreteMethod.swift
@@ -19,22 +19,30 @@ public class ConcreteMethod<Args, ReturnType>: AnyMethod {
 
   let argTypes: [AnyArgumentType]
 
+  let detached: Bool
+
   init(
     _ name: String,
     argTypes: [AnyArgumentType],
-    _ closure: @escaping ClosureType
+    _ closure: @escaping ClosureType,
+    detached: Bool = false
   ) {
     self.name = name
     self.argTypes = argTypes
     self.closure = closure
+    self.detached = detached
   }
 
-  public func call(args: [Any?], promise: Promise) {
+  public func call(module: AnyModule, args: [Any?], promise: Promise) {
     let takesPromise = self.takesPromise
     let returnedValue: ReturnType?
 
     do {
       var finalArgs = try castArguments(args)
+
+      if !self.detached {
+        finalArgs.insert(module, at: 0)
+      }
 
       if takesPromise {
         finalArgs.append(promise)

--- a/packages/expo-modules-core/ios/Swift/Methods/ConcreteMethod.swift
+++ b/packages/expo-modules-core/ios/Swift/Methods/ConcreteMethod.swift
@@ -19,6 +19,9 @@ public class ConcreteMethod<Args, ReturnType>: AnyMethod {
 
   let argTypes: [AnyArgumentType]
 
+  /**
+   Determines whether the method should be called with the module instance.
+   */
   let detached: Bool
 
   init(
@@ -40,12 +43,12 @@ public class ConcreteMethod<Args, ReturnType>: AnyMethod {
     do {
       var finalArgs = try castArguments(args)
 
-      if !self.detached {
-        finalArgs.insert(module, at: 0)
-      }
-
       if takesPromise {
         finalArgs.append(promise)
+      }
+
+      if !self.detached {
+        finalArgs.insert(module, at: 0)
       }
 
       let tuple = try Conversions.toTuple(finalArgs) as! Args

--- a/packages/expo-modules-core/ios/Swift/ModuleHolder.swift
+++ b/packages/expo-modules-core/ios/Swift/ModuleHolder.swift
@@ -4,30 +4,71 @@ import Dispatch
  Holds a reference to the module instance and caches its definition.
  */
 public class ModuleHolder {
-  private(set) var module: AnyModule
+  /**
+   Lazy-loaded instance of the module. Created from module's definition.
+   */
+  private(set) var module: AnyModule?
 
-  private(set) lazy var definition: ModuleDefinition = module.definition()
+  /**
+   A weak reference to the app context.
+   */
+  private(set) weak var appContext: AppContext?
 
-  var name: String {
-    return definition.name ?? String(describing: type(of: module))
+  /**
+   Caches the definition of the module type.
+   */
+  let definition: ModuleDefinition
+
+  /**
+   Shorthand form of `definition.name`.
+   */
+  var name: String { definition.name }
+
+  init(appContext: AppContext, definition: ModuleDefinition) {
+    self.appContext = appContext
+    self.definition = definition
   }
 
-  init(module: AnyModule) {
-    self.module = module
+  /**
+   Creates (if needed) and returns the module based on associated definition and then returns it.
+   */
+  func getInstance() throws -> AnyModule? {
+    guard let appContext = appContext else {
+      throw AppContext.DeallocatedAppContextError()
+    }
+    if module == nil, let moduleType = definition.type {
+      module = moduleType.init(appContext: appContext)
+      post(event: .moduleCreate)
+    }
+    return module
+  }
 
-    post(event: .moduleCreate)
+  /**
+   Whether held module is or would be (instance may not be created yet) of given type.
+   */
+  func isOfType<ModuleType>(_ type: ModuleType.Type) -> Bool {
+    return definition.type is ModuleType.Type
   }
 
   // MARK: Calling methods
 
   func call(method methodName: String, args: [Any?], promise: Promise) {
-    if let method = definition.methods[methodName] {
-      let queue = method.queue ?? DispatchQueue.global(qos: .default)
-      queue.async {
-        method.call(args: args, promise: promise)
+    do {
+      guard let module = try getInstance() else {
+        throw ModuleNotFoundError(moduleName: self.name)
       }
-    } else {
-      promise.reject(MethodNotFoundError(methodName: methodName, moduleName: self.name))
+      guard let method = definition.methods[methodName] else {
+        throw MethodNotFoundError(methodName: methodName, moduleName: self.name)
+      }
+      let queue = method.queue ?? DispatchQueue.global(qos: .default)
+
+      queue.async {
+        method.call(module: module, args: args, promise: promise)
+      }
+    } catch let error as CodedError {
+      promise.reject(error)
+    } catch {
+      promise.reject(UnexpectedError(error))
     }
   }
 
@@ -50,13 +91,13 @@ public class ModuleHolder {
 
   func post(event: EventName) {
     listeners(forEvent: event).forEach {
-      $0.call(nil)
+      try? $0.call(module, nil)
     }
   }
 
   func post<PayloadType>(event: EventName, payload: PayloadType?) {
     listeners(forEvent: event).forEach {
-      $0.call(payload)
+      try? $0.call(module, payload)
     }
   }
 
@@ -67,6 +108,13 @@ public class ModuleHolder {
   }
 
   // MARK: Errors
+
+  struct ModuleNotFoundError: CodedError {
+    let moduleName: String
+    var description: String {
+      "Cannot find module `\(moduleName)`"
+    }
+  }
 
   struct MethodNotFoundError: CodedError {
     let methodName: String

--- a/packages/expo-modules-core/ios/Swift/ModuleRegistry.swift
+++ b/packages/expo-modules-core/ios/Swift/ModuleRegistry.swift
@@ -46,7 +46,7 @@ public class ModuleRegistry: Sequence {
   }
 
   public func unregister(moduleName: String) {
-    registry.removeValue(forKey: moduleName)
+    registry[moduleName] = nil
   }
 
   public func has(moduleWithName moduleName: String) -> Bool {
@@ -57,7 +57,6 @@ public class ModuleRegistry: Sequence {
     return registry[moduleName]
   }
 
-  @discardableResult
   public func get(moduleWithName moduleName: String) -> AnyModule? {
     return try? registry[moduleName]?.getInstance()
   }

--- a/packages/expo-modules-core/ios/Swift/Modules/AnyModule.swift
+++ b/packages/expo-modules-core/ios/Swift/Modules/AnyModule.swift
@@ -2,7 +2,7 @@
 /**
  A protocol for any type-erased module that provides methods used by the core.
  */
-public protocol AnyModule: AnyObject {
+public protocol AnyModule: AnyObject, AnyMethodArgument {
   /**
    The default initializer. Must be public, but the module class does *not* need to
    define it as it is implemented in protocol composition, see `BaseModule` class.
@@ -16,7 +16,7 @@ public protocol AnyModule: AnyObject {
    # Example
 
    ```
-   public func definition() -> ModuleDefinition {
+   public static func definition() -> ModuleDefinition {
      name("MyModule")
      method("myMethod") { (a: String, b: String) in
        "\(a) \(b)"
@@ -47,8 +47,8 @@ public protocol AnyModule: AnyObject {
    */
   #if swift(>=5.4)
   @ModuleDefinitionBuilder
-  func definition() -> ModuleDefinition
+  static func definition() -> ModuleDefinition
   #else
-  func definition() -> ModuleDefinition
+  static func definition() -> ModuleDefinition
   #endif
 }

--- a/packages/expo-modules-core/ios/Swift/Modules/ModuleDefinition.swift
+++ b/packages/expo-modules-core/ios/Swift/Modules/ModuleDefinition.swift
@@ -9,18 +9,30 @@ public protocol AnyDefinition {}
  of the module and what it exports to the JavaScript world.
  See `ModuleDefinitionBuilder` for more details on how to create it.
  */
-public struct ModuleDefinition: AnyDefinition {
-  let name: String?
+public class ModuleDefinition: AnyDefinition {
+  /**
+   The module's type associated with the definition. It's used to create the module instance.
+   */
+  var type: AnyModule.Type?
+
+  /**
+   Name of the defined module. Falls back to the type name if not provided in the definition.
+   */
+  var name: String
+
   let methods: [String : AnyMethod]
   let constants: [String : Any?]
   let eventListeners: [EventListener]
   let viewManager: ViewManagerDefinition?
 
+  /**
+   Initializer that is called by the `ModuleDefinitionBuilder` results builder.
+   */
   init(definitions: [AnyDefinition]) {
     self.name = definitions
       .compactMap { $0 as? ModuleNameDefinition }
       .last?
-      .name
+      .name ?? ""
 
     self.methods = definitions
       .compactMap { $0 as? AnyMethod }
@@ -39,6 +51,20 @@ public struct ModuleDefinition: AnyDefinition {
     self.viewManager = definitions
       .compactMap { $0 as? ViewManagerDefinition }
       .last
+  }
+
+  /**
+   Sets the module type that the definition is associated with. We can't pass this in the initializer
+   as it's called by the results builder that doesn't have access to the type.
+   */
+  func withType(_ type: AnyModule.Type) -> Self {
+    self.type = type
+
+    // Use the type name if the name is not in the definition or was defined empty.
+    if name.isEmpty {
+      name = String(describing: type)
+    }
+    return self
   }
 }
 

--- a/packages/expo-modules-core/ios/Swift/Modules/ModuleDefinitionComponents.swift
+++ b/packages/expo-modules-core/ios/Swift/Modules/ModuleDefinitionComponents.swift
@@ -10,23 +10,38 @@ extension AnyModule {
   /**
    Sets the name of the module that is exported to the JavaScript world.
    */
-  public func name(_ name: String) -> AnyDefinition {
+  public static func name(_ name: String) -> AnyDefinition {
     return ModuleNameDefinition(name: name)
   }
 
   /**
    Definition function setting the module's constants to export.
    */
-  public func constants(_ closure: () -> [String : Any?]) -> AnyDefinition {
+  public static func constants(_ closure: () -> [String : Any?]) -> AnyDefinition {
     return ConstantsDefinition(constants: closure())
+  }
+
+  /**
+   Factory function for methods without the module instance and arguments.
+   */
+  public static func method<R>(
+    _ name: String,
+    _ closure: @escaping () -> R
+  ) -> AnyMethod {
+    return ConcreteMethod(
+      name,
+      argTypes: [],
+      closure,
+      detached: true
+    )
   }
 
   /**
    Factory function for methods without arguments.
    */
-  public func method<R>(
+  public static func method<R>(
     _ name: String,
-    _ closure: @escaping () -> R
+    _ closure: @escaping (Self) -> R
   ) -> AnyMethod {
     return ConcreteMethod(
       name,
@@ -38,9 +53,9 @@ extension AnyModule {
   /**
    Factory function for methods with one argument.
    */
-  public func method<R, A0: AnyMethodArgument>(
+  public static func method<R, A0: AnyMethodArgument>(
     _ name: String,
-    _ closure: @escaping (A0) -> R
+    _ closure: @escaping (Self, A0) -> R
   ) -> AnyMethod {
     return ConcreteMethod(
       name,
@@ -52,9 +67,9 @@ extension AnyModule {
   /**
    Factory function for methods with 2 arguments.
    */
-  public func method<R, A0: AnyMethodArgument, A1: AnyMethodArgument>(
+  public static func method<R, A0: AnyMethodArgument, A1: AnyMethodArgument>(
     _ name: String,
-    _ closure: @escaping (A0, A1) -> R
+    _ closure: @escaping (Self, A0, A1) -> R
   ) -> AnyMethod {
     return ConcreteMethod(
       name,
@@ -66,9 +81,9 @@ extension AnyModule {
   /**
    Factory function for methods with 3 arguments.
    */
-  public func method<R, A0: AnyMethodArgument, A1: AnyMethodArgument, A2: AnyMethodArgument>(
+  public static func method<R, A0: AnyMethodArgument, A1: AnyMethodArgument, A2: AnyMethodArgument>(
     _ name: String,
-    _ closure: @escaping (A0, A1, A2) -> R
+    _ closure: @escaping (Self, A0, A1, A2) -> R
   ) -> AnyMethod {
     return ConcreteMethod(
       name,
@@ -80,9 +95,9 @@ extension AnyModule {
   /**
    Factory function for methods with 4 arguments.
    */
-  public func method<R, A0: AnyMethodArgument, A1: AnyMethodArgument, A2: AnyMethodArgument, A3: AnyMethodArgument>(
+  public static func method<R, A0: AnyMethodArgument, A1: AnyMethodArgument, A2: AnyMethodArgument, A3: AnyMethodArgument>(
     _ name: String,
-    _ closure: @escaping (A0, A1, A2, A3) -> R
+    _ closure: @escaping (Self, A0, A1, A2, A3) -> R
   ) -> AnyMethod {
     return ConcreteMethod(
       name,
@@ -94,9 +109,9 @@ extension AnyModule {
   /**
    Factory function for methods with 5 arguments.
    */
-  public func method<R, A0: AnyMethodArgument, A1: AnyMethodArgument, A2: AnyMethodArgument, A3: AnyMethodArgument, A4: AnyMethodArgument>(
+  public static func method<R, A0: AnyMethodArgument, A1: AnyMethodArgument, A2: AnyMethodArgument, A3: AnyMethodArgument, A4: AnyMethodArgument>(
     _ name: String,
-    _ closure: @escaping (A0, A1, A2, A3, A4) -> R
+    _ closure: @escaping (Self, A0, A1, A2, A3, A4) -> R
   ) -> AnyMethod {
     return ConcreteMethod(
       name,
@@ -108,9 +123,9 @@ extension AnyModule {
   /**
    Factory function for methods with 6 arguments.
    */
-  public func method<R, A0: AnyMethodArgument, A1: AnyMethodArgument, A2: AnyMethodArgument, A3: AnyMethodArgument, A4: AnyMethodArgument, A5: AnyMethodArgument>(
+  public static func method<R, A0: AnyMethodArgument, A1: AnyMethodArgument, A2: AnyMethodArgument, A3: AnyMethodArgument, A4: AnyMethodArgument, A5: AnyMethodArgument>(
     _ name: String,
-    _ closure: @escaping (A0, A1, A2, A3, A4, A5) -> R
+    _ closure: @escaping (Self, A0, A1, A2, A3, A4, A5) -> R
   ) -> AnyMethod {
     return ConcreteMethod(
       name,
@@ -122,9 +137,9 @@ extension AnyModule {
   /**
    Factory function for methods with 7 arguments.
    */
-  public func method<R, A0: AnyMethodArgument, A1: AnyMethodArgument, A2: AnyMethodArgument, A3: AnyMethodArgument, A4: AnyMethodArgument, A5: AnyMethodArgument, A6: AnyMethodArgument>(
+  public static func method<R, A0: AnyMethodArgument, A1: AnyMethodArgument, A2: AnyMethodArgument, A3: AnyMethodArgument, A4: AnyMethodArgument, A5: AnyMethodArgument, A6: AnyMethodArgument>(
     _ name: String,
-    _ closure: @escaping (A0, A1, A2, A3, A4, A5, A6) -> R
+    _ closure: @escaping (Self, A0, A1, A2, A3, A4, A5, A6) -> R
   ) -> AnyMethod {
     return ConcreteMethod(
       name,
@@ -136,9 +151,9 @@ extension AnyModule {
   /**
    Factory function for methods with 8 arguments.
    */
-  public func method<R, A0: AnyMethodArgument, A1: AnyMethodArgument, A2: AnyMethodArgument, A3: AnyMethodArgument, A4: AnyMethodArgument, A5: AnyMethodArgument, A6: AnyMethodArgument, A7: AnyMethodArgument>(
+  public static func method<R, A0: AnyMethodArgument, A1: AnyMethodArgument, A2: AnyMethodArgument, A3: AnyMethodArgument, A4: AnyMethodArgument, A5: AnyMethodArgument, A6: AnyMethodArgument, A7: AnyMethodArgument>(
     _ name: String,
-    _ closure: @escaping (A0, A1, A2, A3, A4, A5, A6, A7) -> R
+    _ closure: @escaping (Self, A0, A1, A2, A3, A4, A5, A6, A7) -> R
   ) -> AnyMethod {
     return ConcreteMethod(
       name,
@@ -150,63 +165,81 @@ extension AnyModule {
   /**
    Creates module's lifecycle listener that is called right after module initialization.
    */
-  public func onCreate(_ closure: @escaping () -> Void) -> AnyDefinition {
+  public static func onCreate(_ closure: @escaping () -> Void) -> AnyDefinition {
+    return EventListener(.moduleCreate, closure)
+  }
+  public static func onCreate(_ closure: @escaping (Self) -> Void) -> AnyDefinition {
     return EventListener(.moduleCreate, closure)
   }
 
   /**
    Creates module's lifecycle listener that is called when the module is about to be deallocated.
    */
-  public func onDestroy(_ closure: @escaping () -> Void) -> AnyDefinition {
+  public static func onDestroy(_ closure: @escaping () -> Void) -> AnyDefinition {
+    return EventListener(.moduleDestroy, closure)
+  }
+  public static func onDestroy(_ closure: @escaping (Self) -> Void) -> AnyDefinition {
     return EventListener(.moduleDestroy, closure)
   }
 
   /**
    Creates module's lifecycle listener that is called when the app context owning the module is about to be deallocated.
    */
-  public func onAppContextDestroys(_ closure: @escaping () -> Void) -> AnyDefinition {
+  public static func onAppContextDestroys(_ closure: @escaping () -> Void) -> AnyDefinition {
+    return EventListener(.appContextDestroys, closure)
+  }
+  public static func onAppContextDestroys(_ closure: @escaping (Self) -> Void) -> AnyDefinition {
     return EventListener(.appContextDestroys, closure)
   }
 
   /**
    Creates a listener that is called when the app is about to enter the foreground mode.
    */
-  public func onAppEntersForeground(_ closure: @escaping () -> Void) -> AnyDefinition {
+  public static func onAppEntersForeground(_ closure: @escaping () -> Void) -> AnyDefinition {
+    return EventListener(.appEntersForeground, closure)
+  }
+  public static func onAppEntersForeground(_ closure: @escaping (Self) -> Void) -> AnyDefinition {
     return EventListener(.appEntersForeground, closure)
   }
 
   /**
    Creates a listener that is called when the app becomes active again.
    */
-  public func onAppBecomesActive(_ closure: @escaping () -> Void) -> AnyDefinition {
+  public static func onAppBecomesActive(_ closure: @escaping () -> Void) -> AnyDefinition {
+    return EventListener(.appBecomesActive, closure)
+  }
+  public static func onAppBecomesActive(_ closure: @escaping (Self) -> Void) -> AnyDefinition {
     return EventListener(.appBecomesActive, closure)
   }
 
   /**
    Creates a listener that is called when the app enters the background mode.
    */
-  public func onAppEntersBackground(_ closure: @escaping () -> Void) -> AnyDefinition {
+  public static func onAppEntersBackground(_ closure: @escaping () -> Void) -> AnyDefinition {
     return EventListener(.appEntersBackground, closure)
   }
-}
+  public static func onAppEntersBackground(_ closure: @escaping (Self) -> Void) -> AnyDefinition {
+    return EventListener(.appEntersBackground, closure)
+  }
 
-/**
- Creates the view manager definition that scopes other view-related definitions.
- */
-public func viewManager(@ViewManagerDefinitionBuilder _ closure: @escaping () -> ViewManagerDefinition) -> AnyDefinition {
-  return closure()
-}
+  /**
+   Creates the view manager definition that scopes other view-related definitions.
+   */
+  public static func viewManager(@ViewManagerDefinitionBuilder _ closure: @escaping () -> ViewManagerDefinition) -> AnyDefinition {
+    return closure()
+  }
 
-/**
- Defines the factory creating a native view when the module is used as a view.
- */
-public func view(_ closure: @escaping () -> UIView) -> AnyDefinition {
-  return ViewFactory(closure)
-}
+  /**
+   Defines the factory creating a native view when the module is used as a view.
+   */
+  public static func view(_ closure: @escaping () -> UIView) -> AnyDefinition {
+    return ViewFactory(closure)
+  }
 
-/**
- Creates a view prop that defines its name and setter.
- */
-public func prop<ViewType: UIView, PropType>(_ name: String, _ setter: @escaping (ViewType, PropType) -> Void) -> AnyDefinition {
-  return ConcreteViewProp(name, setter)
+  /**
+   Creates a view prop that defines its name and setter.
+   */
+  public static func prop<ViewType: UIView, PropType>(_ name: String, _ setter: @escaping (ViewType, PropType) -> Void) -> AnyDefinition {
+    return ConcreteViewProp(name, setter)
+  }
 }

--- a/packages/expo-modules-core/ios/Swift/Modules/ModuleDefinitionComponents.swift
+++ b/packages/expo-modules-core/ios/Swift/Modules/ModuleDefinitionComponents.swift
@@ -7,6 +7,8 @@ import UIKit
  will be implemented in the future.
  */
 extension AnyModule {
+  // MARK: - Module name
+
   /**
    Sets the name of the module that is exported to the JavaScript world.
    */
@@ -14,12 +16,16 @@ extension AnyModule {
     return ModuleNameDefinition(name: name)
   }
 
+  // MARK: - Constants
+
   /**
    Definition function setting the module's constants to export.
    */
   public static func constants(_ closure: () -> [String : Any?]) -> AnyDefinition {
     return ConstantsDefinition(constants: closure())
   }
+
+  // MARK: - Methods
 
   /**
    Factory function for methods without the module instance and arguments.
@@ -162,15 +168,23 @@ extension AnyModule {
     )
   }
 
+  // MARK: - `onCreate`
+
   /**
    Creates module's lifecycle listener that is called right after module initialization.
    */
   public static func onCreate(_ closure: @escaping () -> Void) -> AnyDefinition {
     return EventListener(.moduleCreate, closure)
   }
+
+  /**
+   Creates module's lifecycle listener that is called right after module initialization.
+   */
   public static func onCreate(_ closure: @escaping (Self) -> Void) -> AnyDefinition {
     return EventListener(.moduleCreate, closure)
   }
+
+  // MARK: - `onDestroy`
 
   /**
    Creates module's lifecycle listener that is called when the module is about to be deallocated.
@@ -178,9 +192,15 @@ extension AnyModule {
   public static func onDestroy(_ closure: @escaping () -> Void) -> AnyDefinition {
     return EventListener(.moduleDestroy, closure)
   }
+
+  /**
+   Creates module's lifecycle listener that is called when the module is about to be deallocated.
+   */
   public static func onDestroy(_ closure: @escaping (Self) -> Void) -> AnyDefinition {
     return EventListener(.moduleDestroy, closure)
   }
+
+  // MARK: - `onAppContextDestroys`
 
   /**
    Creates module's lifecycle listener that is called when the app context owning the module is about to be deallocated.
@@ -188,9 +208,15 @@ extension AnyModule {
   public static func onAppContextDestroys(_ closure: @escaping () -> Void) -> AnyDefinition {
     return EventListener(.appContextDestroys, closure)
   }
+
+  /**
+   Creates module's lifecycle listener that is called when the app context owning the module is about to be deallocated.
+   */
   public static func onAppContextDestroys(_ closure: @escaping (Self) -> Void) -> AnyDefinition {
     return EventListener(.appContextDestroys, closure)
   }
+
+  // MARK: - `onAppEntersForeground`
 
   /**
    Creates a listener that is called when the app is about to enter the foreground mode.
@@ -198,9 +224,15 @@ extension AnyModule {
   public static func onAppEntersForeground(_ closure: @escaping () -> Void) -> AnyDefinition {
     return EventListener(.appEntersForeground, closure)
   }
+
+  /**
+   Creates a listener that is called when the app is about to enter the foreground mode.
+   */
   public static func onAppEntersForeground(_ closure: @escaping (Self) -> Void) -> AnyDefinition {
     return EventListener(.appEntersForeground, closure)
   }
+
+  // MARK: - `onAppBecomesActive`
 
   /**
    Creates a listener that is called when the app becomes active again.
@@ -208,9 +240,15 @@ extension AnyModule {
   public static func onAppBecomesActive(_ closure: @escaping () -> Void) -> AnyDefinition {
     return EventListener(.appBecomesActive, closure)
   }
+
+  /**
+   Creates a listener that is called when the app becomes active again.
+   */
   public static func onAppBecomesActive(_ closure: @escaping (Self) -> Void) -> AnyDefinition {
     return EventListener(.appBecomesActive, closure)
   }
+
+  // MARK: - `onAppEntersBackground`
 
   /**
    Creates a listener that is called when the app enters the background mode.
@@ -218,9 +256,15 @@ extension AnyModule {
   public static func onAppEntersBackground(_ closure: @escaping () -> Void) -> AnyDefinition {
     return EventListener(.appEntersBackground, closure)
   }
+
+  /**
+   Creates a listener that is called when the app enters the background mode.
+   */
   public static func onAppEntersBackground(_ closure: @escaping (Self) -> Void) -> AnyDefinition {
     return EventListener(.appEntersBackground, closure)
   }
+
+  // MARK: - View Manager
 
   /**
    Creates the view manager definition that scopes other view-related definitions.

--- a/packages/expo-modules-core/ios/Tests/Mocks/ModuleMocks.swift
+++ b/packages/expo-modules-core/ios/Tests/Mocks/ModuleMocks.swift
@@ -1,26 +1,31 @@
-import ExpoModulesCore
+@testable import ExpoModulesCore
 
 class UnnamedModule: Module {
-  func definition() -> ModuleDefinition {}
+  static func definition() -> ModuleDefinition {}
 }
 
 class NamedModule: Module {
   static let namedModuleName = "MyModule"
 
-  func definition() -> ModuleDefinition {
-    name(Self.namedModuleName)
+  static func definition() -> ModuleDefinition {
+    name(namedModuleName)
   }
 }
 
 class CustomModule: Module {
-  var customDefinition: ((CustomModule) -> ModuleDefinition)!
+  static func definition() -> ModuleDefinition {}
+}
 
-  convenience init(appContext: AppContext, @ModuleDefinitionBuilder _ customDefinition: @escaping (CustomModule) -> ModuleDefinition) {
-    self.init(appContext: appContext)
-    self.customDefinition = customDefinition
-  }
+typealias MockedDefinitionFunc = (CustomModule.Type) -> ModuleDefinition
 
-  func definition() -> ModuleDefinition {
-    return customDefinition(self)
-  }
+func mockDefinition(@ModuleDefinitionBuilder _ definition: @escaping () -> ModuleDefinition) -> ModuleDefinition {
+  return definition().withType(CustomModule.self)
+}
+
+func mockDefinition(@ModuleDefinitionBuilder _ definition: @escaping MockedDefinitionFunc) -> ModuleDefinition {
+  return definition(CustomModule.self).withType(CustomModule.self)
+}
+
+func mockModuleHolder(_ appContext: AppContext, @ModuleDefinitionBuilder _ definition: @escaping MockedDefinitionFunc) -> ModuleHolder {
+  return ModuleHolder(appContext: appContext, definition: mockDefinition(definition))
 }

--- a/packages/expo-modules-core/ios/Tests/ModuleEventListenersSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/ModuleEventListenersSpec.swift
@@ -27,7 +27,8 @@ class ModuleEventListenersSpec: QuickSpec {
           }
         }
         appContext.moduleRegistry.register(definition: definition)
-        appContext.moduleRegistry.get(moduleWithName: definition.name)
+        // `get(moduleWithName:)` automatically creates a module instance if needed.
+        let _ = appContext.moduleRegistry.get(moduleWithName: definition.name)
       }
     }
 

--- a/packages/expo-modules-core/ios/Tests/ModuleEventListenersSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/ModuleEventListenersSpec.swift
@@ -19,39 +19,42 @@ class ModuleEventListenersSpec: QuickSpec {
       appContext = AppContext()
     }
 
-    it("calls onCreate once the module is registered") {
+    it("calls onCreate once the module instance is created") {
       waitUntil { done in
-        let module = CustomModule(appContext: appContext) {
+        let definition = mockDefinition {
           $0.onCreate {
             done()
           }
         }
-        appContext.moduleRegistry.register(module: module)
+        appContext.moduleRegistry.register(definition: definition)
+        appContext.moduleRegistry.get(moduleWithName: definition.name)
       }
     }
 
     it("calls onDestroy once the module is about to be deallocated") {
       waitUntil { done in
-        let module = CustomModule(appContext: appContext) {
+        let moduleName = "mockedModule"
+        let definition = mockDefinition {
+          $0.name(moduleName)
           $0.onDestroy {
             done()
           }
         }
-        appContext.moduleRegistry.register(module: module)
+        appContext.moduleRegistry.register(definition: definition)
         // Unregister the module to deallocate its holder
-        appContext.moduleRegistry.unregister(module: module)
+        appContext.moduleRegistry.unregister(moduleName: moduleName)
         // The `module` object is actually still alive, but its holder is dead
       }
     }
 
     it("calls onAppContextDestroys once the context destroys") {
       waitUntil { done in
-        let module = CustomModule(appContext: appContext) {
+        let definition = mockDefinition {
           $0.onAppContextDestroys {
             done()
           }
         }
-        appContext.moduleRegistry.register(module: module)
+        appContext.moduleRegistry.register(definition: definition)
         appContext = nil // This must deallocate the app context
       }
     }
@@ -59,48 +62,48 @@ class ModuleEventListenersSpec: QuickSpec {
     it("calls custom event listener when the event is sent to the registry") {
       waitUntil { done in
         let event = EventName.custom("custom event name")
-        let module = CustomModule(appContext: appContext) { _ in
+        let definition = mockDefinition {
           EventListener(event) {
             done()
           }
         }
-        appContext.moduleRegistry.register(module: module)
+        appContext.moduleRegistry.register(definition: definition)
         appContext.moduleRegistry.post(event: event)
       }
     }
 
     it("calls onAppEntersForeground when system's willEnterForegroundNotification is sent") {
       waitUntil { done in
-        let module = CustomModule(appContext: appContext) {
+        let definition = mockDefinition {
           $0.onAppEntersForeground {
             done()
           }
         }
-        appContext.moduleRegistry.register(module: module)
+        appContext.moduleRegistry.register(definition: definition)
         NotificationCenter.default.post(name: UIApplication.willEnterForegroundNotification, object: nil)
       }
     }
 
     it("calls onAppBecomesActive when system's didBecomeActiveNotification is sent") {
       waitUntil { done in
-        let module = CustomModule(appContext: appContext) {
+        let definition = mockDefinition {
           $0.onAppBecomesActive {
             done()
           }
         }
-        appContext.moduleRegistry.register(module: module)
+        appContext.moduleRegistry.register(definition: definition)
         NotificationCenter.default.post(name: UIApplication.didBecomeActiveNotification, object: nil)
       }
     }
 
     it("calls onAppEntersBackground when system's didEnterBackgroundNotification is sent") {
       waitUntil { done in
-        let module = CustomModule(appContext: appContext) {
+        let definition = mockDefinition {
           $0.onAppEntersBackground {
             done()
           }
         }
-        appContext.moduleRegistry.register(module: module)
+        appContext.moduleRegistry.register(definition: definition)
         NotificationCenter.default.post(name: UIApplication.didEnterBackgroundNotification, object: nil)
       }
     }

--- a/packages/expo-modules-core/ios/Tests/ModuleRegistrySpec.swift
+++ b/packages/expo-modules-core/ios/Tests/ModuleRegistrySpec.swift
@@ -8,22 +8,20 @@ class ModuleRegistrySpec: QuickSpec {
     let appContext = AppContext()
 
     it("registers unnamed module") {
-      testRegister(module: UnnamedModule(appContext: appContext), name: String(describing: UnnamedModule.self))
+      testRegister(moduleType: UnnamedModule.self, name: String(describing: UnnamedModule.self))
     }
 
     it("registers named module") {
-      testRegister(module: NamedModule(appContext: appContext), name: NamedModule.namedModuleName)
+      testRegister(moduleType: NamedModule.self, name: NamedModule.namedModuleName)
     }
 
-    func testRegister(module: Module, name: String) {
+    func testRegister<ModuleType: AnyModule>(moduleType: ModuleType.Type, name: String) {
       let moduleRegistry = appContext.moduleRegistry
 
-      moduleRegistry.register(module: module)
+      moduleRegistry.register(moduleType: moduleType)
 
       expect(moduleRegistry.has(moduleWithName: name)).to(beTrue())
-      expect(moduleRegistry.get(moduleWithName: name)).to(beIdenticalTo(module))
-      expect(moduleRegistry.contains { $0.module === module }).to(beTrue())
-      expect(moduleRegistry.get(moduleHolderForName: name)?.module).to(beIdenticalTo(module))
+      expect(moduleRegistry.contains { $0.isOfType(ModuleType.self) }).to(beTrue())
     }
   }
 }

--- a/packages/expo-tracking-transparency/ios/EXTrackingTransparency/TrackingTransparencyModule.swift
+++ b/packages/expo-tracking-transparency/ios/EXTrackingTransparency/TrackingTransparencyModule.swift
@@ -1,25 +1,25 @@
 import ExpoModulesCore
 
 public class TrackingTransparencyModule: Module {
-  public func definition() -> ModuleDefinition {
+  public static func definition() -> ModuleDefinition {
     name("ExpoTrackingTransparency")
 
-    onCreate {
-      EXPermissionsMethodsDelegate.register([EXTrackingPermissionRequester()], withPermissionsManager: self.appContext?.permissions)
+    onCreate { module in
+      EXPermissionsMethodsDelegate.register([EXTrackingPermissionRequester()], withPermissionsManager: module.appContext?.permissions)
     }
 
-    method("getPermissionsAsync") { (promise: Promise) in
+    method("getPermissionsAsync") { (module, promise: Promise) in
       EXPermissionsMethodsDelegate.getPermissionWithPermissionsManager(
-        self.appContext?.permissions,
+        module.appContext?.permissions,
         withRequester: EXTrackingPermissionRequester.self,
         resolve: promise.resolver,
         reject: promise.legacyRejecter
       )
     }
 
-    method("requestPermissionsAsync") { (promise: Promise) in
+    method("requestPermissionsAsync") { (module, promise: Promise) in
       EXPermissionsMethodsDelegate.askForPermission(
-        withPermissionsManager: self.appContext?.permissions,
+        withPermissionsManager: module.appContext?.permissions,
         withRequester: EXTrackingPermissionRequester.self,
         resolve: promise.resolver,
         reject: promise.legacyRejecter


### PR DESCRIPTION
# Why

I'm going to implement a way to create JSI objects from Swift. It would be great if we can also have a definition of the JS prototype for these objects. Unfortunately the definition for objects will have to be static, because it's needed before the first object is initialized. It made me think more about our syntax and I think it's better when these two object types (module and object) have the same protocol requirement (`static func definition()`). Since it is static, the DSL functions have to receive the instance of the module/object as a closure argument, but on the other side we will be able to reuse those DSL functions in the object definition.

# How

Made the `func definition() -> ModuleDefinition` static and updated code accordingly. As a result and one more advantage — all modules are lazy-loaded now (I'll let them opt-in to be loaded eagerly in a separate PR).

# Test Plan

Updated unit tests, things seem to work fine

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).