### PR TITLE
[android][manifests] support platform shared jsEngine schema

### DIFF
--- a/android/versioned-abis/expoview-abi42_0_0/src/main/java/abi42_0_0/host/exp/exponent/VersionedUtils.java
+++ b/android/versioned-abis/expoview-abi42_0_0/src/main/java/abi42_0_0/host/exp/exponent/VersionedUtils.java
@@ -265,18 +265,18 @@ public class VersionedUtils {
     }
 
     final Pair<Boolean, Integer> hermesBundlePair = parseHermesBundleHeader(instanceManagerBuilderProperties.getJsBundlePath());
-    if (hermesBundlePair.first) {
-      if (hermesBundlePair.second != HERMES_BYTECODE_VERSION) {
-        final String message = String.format(Locale.US,
-                "Unable to load unsupported Hermes bundle.\n\tsupportedBytecodeVersion: %d\n\ttargetBytecodeVersion: %d",
-                HERMES_BYTECODE_VERSION, hermesBundlePair.second);
-        KernelProvider.getInstance().handleError(new RuntimeException(message));
-        return null;
-      }
-      return new HermesExecutorFactory();
+    if (hermesBundlePair.first && hermesBundlePair.second != HERMES_BYTECODE_VERSION) {
+      final String message = String.format(Locale.US,
+              "Unable to load unsupported Hermes bundle.\n\tsupportedBytecodeVersion: %d\n\ttargetBytecodeVersion: %d",
+              HERMES_BYTECODE_VERSION, hermesBundlePair.second);
+      KernelProvider.getInstance().handleError(new RuntimeException(message));
+      return null;
     }
 
-    return new JSCExecutorFactory(appName, deviceName);
+    final String jsEngineFromManifest = instanceManagerBuilderProperties.getManifest().getAndroidJsEngine();
+    return (jsEngineFromManifest != null && jsEngineFromManifest.equals("hermes"))
+            ? new HermesExecutorFactory()
+            : new JSCExecutorFactory(appName, deviceName);
   }
 
   @NonNull

--- a/packages/expo-manifests/CHANGELOG.md
+++ b/packages/expo-manifests/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Support platform shared jsEngine schema. ([#14654](https://github.com/expo/expo/pull/14654) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 0.2.0 — 2021-09-28

--- a/packages/expo-manifests/android/src/main/java/expo/modules/manifests/core/Manifest.kt
+++ b/packages/expo-manifests/android/src/main/java/expo/modules/manifests/core/Manifest.kt
@@ -170,7 +170,7 @@ abstract class Manifest(protected val json: JSONObject) {
     val expoClientConfig = getExpoClientConfigRootObject() ?: return null
     val sharedJsEngine = expoClientConfig.getNullable<String>("jsEngine")
     val androidJsEngine = expoClientConfig
-            .getNullable<JSONObject>("android")?.getNullable<String>("jsEngine")
+      .getNullable<JSONObject>("android")?.getNullable<String>("jsEngine")
     return androidJsEngine ?: sharedJsEngine ?: null
   }
 

--- a/packages/expo-manifests/android/src/main/java/expo/modules/manifests/core/Manifest.kt
+++ b/packages/expo-manifests/android/src/main/java/expo/modules/manifests/core/Manifest.kt
@@ -168,8 +168,10 @@ abstract class Manifest(protected val json: JSONObject) {
 
   fun getAndroidJsEngine(): String? {
     val expoClientConfig = getExpoClientConfigRootObject() ?: return null
-    val android = expoClientConfig.getNullable<JSONObject>("android") ?: return null
-    return android.getNullable("jsEngine")
+    val sharedJsEngine = expoClientConfig.getNullable<String>("jsEngine")
+    val androidJsEngine = expoClientConfig
+            .getNullable<JSONObject>("android")?.getNullable<String>("jsEngine")
+    return androidJsEngine ?: sharedJsEngine ?: null
   }
 
   fun getIconUrl(): String? {


### PR DESCRIPTION
# Why

fix hermes loading for Expo Go
- we introduced platform shared `jsEngine` in schema

# How

- [manifests] first try android specific `jsEngine` and then shared `jsEngine` 
- backport #13376 to `android/versioned-abis/expoview-abi42_0_0/src/main/java/abi42_0_0/host/exp/exponent/VersionedUtils.java`

# Test Plan

load sdk43 shared jsEngine hermes app: `exp://exp.host/@kudochien/hermes`
load sdk42 android specific jsEngine hermes app: `exp://exp.host/@kudochien/sdk42`

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).