### PR TITLE
[docs] remove remaining in-content ToCs

### DIFF
--- a/docs/pages/versions/unversioned/sdk/status-bar.md
+++ b/docs/pages/versions/unversioned/sdk/status-bar.md
@@ -53,24 +53,6 @@ export default class App extends React.Component {
 import { StatusBar } from 'expo-status-bar';
 ```
 
-**[Components](#components)**
-
-- [`StatusBar`](#statusbar)
-
-**[Methods](#methods)**
-
-- [`setStatusBarBackgroundColor(backgroundColor, animated)`](#setstatusbarbackgroundcolorbackgroundcolor-animated)
-- [`setStatusBarHidden(hidden, animation)`](#setstatusbarhiddenhidden-animation)
-- [`setStatusBarNetworkActivityIndicatorVisible(visible)`](#setstatusbarnetworkactivityindicatorvisiblevisible)
-- [`setStatusBarStyle(style)`](#setstatusbarstylestyle)
-- [`setStatusBarTranslucent(translucent)`](#setstatusbartranslucenttranslucent)
-
-**[Types](#types)**
-
-- [`StatusBarAnimation`](#statusbaranimation)
-- [`StatusBarProps`](#statusbarprops)
-- [`StatusBarStyle`](#statusbarstyle)
-
 ## Components
 
 ### `StatusBar`

--- a/docs/pages/versions/v39.0.0/sdk/amplitude.md
+++ b/docs/pages/versions/v39.0.0/sdk/amplitude.md
@@ -22,16 +22,6 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 import * as Amplitude from 'expo-analytics-amplitude';
 ```
 
-**[Methods](#methods)**
-
-- [`Amplitude.initialize(apiKey)`](#amplitudeinitializeapikey)
-- [`Amplitude.setUserId(userId)`](#amplitudesetuseriduserid)
-- [`Amplitude.setUserProperties(userProperties)`](#amplitudesetuserpropertiesuserproperties)
-- [`Amplitude.clearUserProperties()`](#amplitudeclearuserproperties)
-- [`Amplitude.logEvent(eventName)`](#amplitudelogeventeventname)
-- [`Amplitude.logEventWithProperties(eventName, properties)`](#amplitudelogeventwithpropertieseventname-properties)
-- [`Amplitude.setGroup(groupType, groupNames)`](#amplitudesetgroupgrouptype-groupnames)
-
 ## Methods
 
 ### `Amplitude.initialize(apiKey)`

--- a/docs/pages/versions/v39.0.0/sdk/apple-authentication.md
+++ b/docs/pages/versions/v39.0.0/sdk/apple-authentication.md
@@ -77,36 +77,6 @@ Apple's response includes a signed JWT with information about the user. To ensur
 import * as AppleAuthentication from 'expo-apple-authentication';
 ```
 
-**[Methods](#methods)**
-
-- [`AppleAuthentication.isAvailableAsync()`](#appleauthenticationisavailableasync)
-- [`AppleAuthentication.signInAsync(options)`](#appleauthenticationsigninasyncoptions)
-- [`AppleAuthentication.getCredentialStateAsync(user)`](#appleauthenticationgetcredentialstateasyncuser)
-
-**[Components](#components)**
-
-- [`AppleAuthentication.AppleAuthenticationButton`](#appleauthenticationappleauthenticationbutton)
-
-**[Prop Types](#appleauthenticationappleauthenticationbuttonprops)**
-
-- [`AppleAuthentication.AppleAuthenticationButtonProps`](#appleauthenticationappleauthenticationbuttonprops)
-
-**[Enum Types](#enum-types)**
-
-- [`AppleAuthentication.AppleAuthenticationButtonStyle`](#appleauthenticationappleauthenticationbuttonstyle)
-- [`AppleAuthentication.AppleAuthenticationButtonType`](#appleauthenticationappleauthenticationbuttontype)
-- [`AppleAuthentication.AppleAuthenticationCredentialState`](#appleauthenticationappleauthenticationcredentialstate)
-- [`AppleAuthentication.AppleAuthenticationScope`](#appleauthenticationappleauthenticationscope)
-- [`AppleAuthentication.AppleAuthenticationUserDetectionStatus`](#appleauthenticationappleauthenticationuserdetectionstatus)
-
-**[Object Types](#object-types)**
-
-- [`AppleAuthentication.AppleAuthenticationCredential`](#appleauthenticationappleauthenticationcredential)
-- [`AppleAuthentication.AppleAuthenticationFullName`](#appleauthenticationappleauthenticationfullname)
-- [`AppleAuthentication.AppleAuthenticationSignInOptions`](#appleauthenticationappleauthenticationsigninoptions)
-
-**[Error Codes](#error-codes)**
-
 ## Methods
 
 ### `AppleAuthentication.isAvailableAsync()`

--- a/docs/pages/versions/v39.0.0/sdk/device.md
+++ b/docs/pages/versions/v39.0.0/sdk/device.md
@@ -20,44 +20,6 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 import * as Device from 'expo-device';
 ```
 
-### Constants
-
-- [`Device.isDevice`](#deviceisdevice)
-- [`Device.brand`](#devicebrand)
-- [`Device.manufacturer`](#devicemanufacturer)
-- [`Device.modelName`](#devicemodelname)
-- [`Device.modelId`](#devicemodelid) (iOS only)
-- [`Device.designName`](#devicedesignname) (Android only)
-- [`Device.productName`](#deviceproductname) (Android only)
-- [`Device.deviceYearClass`](#devicedeviceyearclass)
-- [`Device.totalMemory`](#devicetotalmemory)
-- [`Device.supportedCpuArchitectures`](#devicesupportedcpuarchitectures)
-- [`Device.osName`](#deviceosname)
-- [`Device.osVersion`](#deviceosversion)
-- [`Device.osBuildId`](#deviceosbuildid)
-- [`Device.osInternalBuildId`](#deviceosinternalbuildid)
-- [`Device.osBuildFingerprint`](#deviceosbuildfingerprint) (Android only)
-- [`Device.platformApiLevel`](#deviceplatformapilevel) (Android only)
-- [`Device.deviceName`](#devicedevicename)
-
-### Methods
-
-- [`Device.getDeviceTypeAsync()`](#devicegetdevicetypeasync)
-- [`Device.getUptimeAsync()`](#devicegetuptimeasync)
-- [`Device.getMaxMemoryAsync()`](#devicegetmaxmemoryasync) (Android only)
-- [`Device.isRootedExperimentalAsync()`](#deviceisrootedexperimentalasync)
-- [`Device.isSideLoadingEnabledAsync()`](#deviceissideloadingenabledasync) (Android only)
-- [`Device.getPlatformFeaturesAsync()`](#devicegetplatformfeaturesasync) (Android only)
-- [`Device.hasPlatformFeatureAsync(feature)`](#devicehasplatformfeatureasyncfeature) (Android only)
-
-### Enum Types
-
-- [`Device.DeviceType`](#devicedevicetype)
-
-### Errors
-
-- [Error Codes](#error-codes)
-
 ## Constants
 
 ### `Device.isDevice`

--- a/docs/pages/versions/v39.0.0/sdk/network.md
+++ b/docs/pages/versions/v39.0.0/sdk/network.md
@@ -24,21 +24,6 @@ On Android, this module requires permissions to access the network and Wi-Fi sta
 import * as Network from 'expo-network';
 ```
 
-### Methods
-
-- [`Network.getNetworkStateAsync()`](#networkgetnetworkstateasync)
-- [`Network.getIpAddressAsync()`](#networkgetipaddressasync)
-- [`Network.getMacAddressAsync(interfaceName?)`](#networkgetmacaddressasyncinterfacename)
-- [`Network.isAirplaneModeEnabledAsync()`](#networkisairplanemodeenabledasync) (Android only)
-
-### Enum Types
-
-- [`Network.NetworkStateType`](#networknetworkstatetype)
-
-### Errors
-
-- [Error Codes](#error-codes)
-
 ## Methods
 
 ### `Network.getNetworkStateAsync()`

--- a/docs/pages/versions/v39.0.0/sdk/notifications.md
+++ b/docs/pages/versions/v39.0.0/sdk/notifications.md
@@ -141,52 +141,6 @@ Notifications.scheduleNotificationAsync({
 import * as Notifications from 'expo-notifications';
 ```
 
-The following methods are exported by the `expo-notifications` module:
-
-- **fetching token for sending push notifications**
-  - [`getExpoPushTokenAsync`](#getexpopushtokenasyncoptions-expotokenoptions-expopushtoken) -- resolves with an Expo push token
-  - [`getDevicePushTokenAsync`](#getdevicepushtokenasync-devicepushtoken) -- resolves with a device push token
-  - [`addPushTokenListener`](#addpushtokenlistenerlistener-pushtokenlistener-subscription) -- adds a listener called when a new push token is issued
-  - [`removePushTokenSubscription`](#removepushtokensubscriptionsubscription-subscription-void) -- removes the listener registered with `addPushTokenListener`
-  - [`removeAllPushTokenListeners`](#removeallpushtokenlisteners-void) -- removes all listeners registered with `addPushTokenListener`
-- **listening to notification events**
-  - [`addNotificationReceivedListener`](#addnotificationreceivedlistenerlistener-event-notification--void-void) -- adds a listener called whenever a new notification is received
-  - [`addNotificationsDroppedListener`](#addnotificationsdroppedlistenerlistener---void-void) -- adds a listener called whenever some notifications have been dropped
-  - [`addNotificationResponseReceivedListener`](#addnotificationresponsereceivedlistenerlistener-event-notificationresponse--void-void) -- adds a listener called whenever user interacts with a notification
-  - [`removeNotificationSubscription`](#removenotificationsubscriptionsubscription-subscription-void) -- removes the listener registered with `addNotification*Listener()`
-  - [`removeAllNotificationListeners`](#removeallnotificationlisteners-void) -- removes all listeners registered with `addNotification*Listener()`
-- **handling incoming notifications when the app is in foreground**
-  - [`setNotificationHandler`](#setnotificationhandlerhandler-notificationhandler--null-void) -- sets the handler function responsible for deciding what to do with a notification that is received when the app is in foreground
-- **fetching permissions information**
-  - [`getPermissionsAsync`](#getpermissionsasync-promisenotificationpermissionsstatus) -- fetches current permission settings related to notifications
-  - [`requestPermissionsAsync`](#requestpermissionsasyncrequest-notificationpermissionsrequest-promisenotificationpermissionsstatus) -- requests permissions related to notifications
-- **managing application badge icon**
-  - [`getBadgeCountAsync`](#getbadgecountasync-promisenumber) -- fetches the application badge number value
-  - [`setBadgeCountAsync`](#setbadgecountasyncbadgecount-number-options-setbadgecountoptions-promiseboolean) -- sets the application badge number value
-- **scheduling notifications**
-  - [`getAllScheduledNotificationsAsync`](#getallschedulednotificationsasync-promisenotification) -- fetches information about all scheduled notifications
-  - [`presentNotificationAsync`](#presentnotificationasynccontent-notificationcontentinput-identifier-string-promisestring) -- schedules a notification for immediate trigger
-  - [`scheduleNotificationAsync`](#schedulenotificationasyncnotificationrequest-notificationrequestinput-promisestring) -- schedules a notification to be triggered in the future
-  - [`cancelScheduledNotificationAsync`](#cancelschedulednotificationasyncidentifier-string-promisevoid) -- removes a specific scheduled notification
-  - [`cancelAllScheduledNotificationsAsync`](#cancelallschedulednotificationsasync-promisevoid) -- removes all scheduled notifications
-- **dismissing notifications**
-  - [`getPresentedNotificationsAsync`](#getpresentednotificationsasync-promisenotification) -- fetches information about all notifications present in the notification tray (Notification Center)
-  - [`dismissNotificationAsync`](#dismissnotificationasyncidentifier-string-promisevoid) -- removes a specific notification from the notification tray
-  - [`dismissAllNotificationsAsync`](#dismissallnotificationsasync-promisevoid) -- removes all notifications from the notification tray
-- **managing notification channels (Android-specific)**
-  - [`getNotificationChannelsAsync`](#getnotificationchannelsasync-promisenotificationchannel) -- fetches information about all known notification channels
-  - [`getNotificationChannelAsync`](#getnotificationchannelasyncidentifier-string-promisenotificationchannel--null) -- fetches information about a specific notification channel
-  - [`setNotificationChannelAsync`](#setnotificationchannelasyncidentifier-string-channel-notificationchannelinput-promisenotificationchannel--null) -- saves a notification channel configuration
-  - [`deleteNotificationChannelAsync`](#deletenotificationchannelasyncidentifier-string-promisevoid) -- deletes a notification channel
-  - [`getNotificationChannelGroupsAsync`](#getnotificationchannelgroupsasync-promisenotificationchannelgroup) -- fetches information about all known notification channel groups
-  - [`getNotificationChannelGroupAsync`](#getnotificationchannelgroupasyncidentifier-string-promisenotificationchannelgroup--null) -- fetches information about a specific notification channel group
-  - [`setNotificationChannelGroupAsync`](#setnotificationchannelgroupasyncidentifier-string-channel-notificationchannelgroupinput-promisenotificationchannelgroup--null) -- saves a notification channel group configuration
-  - [`deleteNotificationChannelGroupAsync`](#deletenotificationchannelgroupasyncidentifier-string-promisevoid) -- deletes a notification channel group
-  - **managing notification categories (interactive notifications)**
-  - [`setNotificationCategoryAsync`](#setnotificationcategoryasyncidentifier-string-actions-notificationaction-options-categoryoptions-promisenotificationcategory) -- creates a new notification category for interactive notifications
-  - [`getNotificationCategoriesAsync`](#getnotificationcategoriesasync-promisenotificationcategory) -- fetches information about all active notification categories
-  - [`deleteNotificationCategoryAsync`](#deletenotificationcategoryasyncidentifier-string-promiseboolean) -- deletes a notification category
-
 Check out the Snack below to see Notifications in action, but be sure to use a physical device! Push notifications don't work on simulators/emulators.
 
 <SnackInline label='Push Notifications' dependencies={['expo-constants', 'expo-permissions', 'expo-notifications']}>

--- a/docs/pages/versions/v39.0.0/sdk/random.md
+++ b/docs/pages/versions/v39.0.0/sdk/random.md
@@ -22,9 +22,6 @@ import * as Random from 'expo-random';
 
 ## Methods
 
-- [`Random.getRandomBytes(byteCount)`](#randomgetrandombytesbytecount)
-- [`Random.getRandomBytesAsync(byteCount)`](#networkgetipaddressasync)
-
 ### `Random.getRandomBytes(byteCount)`
 
 Generates completely random bytes using native implementations. The `byteCount` property is a `number` indicating the number of bytes to generate in the form of a `Uint8Array`.

--- a/docs/pages/versions/v39.0.0/sdk/screen-orientation.md
+++ b/docs/pages/versions/v39.0.0/sdk/screen-orientation.md
@@ -54,41 +54,6 @@ Tick the `Requires Full Screen` checkbox in Xcode. It should be located under `P
 import * as ScreenOrientation from 'expo-screen-orientation';
 ```
 
-### Methods
-
-- [`ScreenOrientation.lockAsync(orientationLock)`](#screenorientationlockasyncorientationlock)
-- [`ScreenOrientation.lockPlatformAsync(platformInfo)`](#screenorientationlockplatformasyncplatforminfo)
-- [`ScreenOrientation.unlockAsync()`](#screenorientationunlockasync)
-- [`ScreenOrientation.getOrientationAsync()`](#screenorientationgetorientationasync)
-- [`ScreenOrientation.getOrientationLockAsync()`](#screenorientationgetorientationlockasync)
-- [`ScreenOrientation.getPlatformOrientationLockAsync()`](#screenorientationgetplatformorientationlockasync)
-- [`ScreenOrientation.supportsOrientationLockAsync(orientationLock)`](#screenorientationsupportsorientationlockasyncorientationlock)
-- [`ScreenOrientation.addOrientationChangeListener(listener)`](#screenorientationaddorientationchangelistenerlistener)
-- [`ScreenOrientation.removeOrientationChangeListeners()`](#screenorientationremoveorientationchangelisteners)
-- [`ScreenOrientation.removeOrientationChangeListener(subscription)`](#screenorientationremoveorientationchangelistenersubscription)
-
-### Enum Types
-
-- [`ScreenOrientation.Orientation`](#screenorientationorientation)
-- [`ScreenOrientation.OrientationLock`](#screenorientationorientationlock)
-- [`ScreenOrientation.SizeClassIOS`](#screenorientationsizeclassios)
-- [`ScreenOrientation.WebOrientationLock`](#screenorientationweborientationlock)
-
-### Object Types
-
-- [`ScreenOrientation.PlatformOrientationInfo`](#screenorientationplatformorientationinfo)
-- [`ScreenOrientation.ScreenOrientationInfo`](#screenorientationscreenorientationinfo)
-- [`ScreenOrientation.OrientationChangeEvent`](#screenorientationorientationchangeevent)
-- [`Subscription`](#subscription)
-
-### Function Types
-
-- [`ScreenOrientation.OrientationChangeListener`](#screenorientationorientationchangelistener)
-
-### Errors
-
-- [Error Codes](#error-codes)
-
 ## Methods
 
 ### `ScreenOrientation.lockAsync(orientationLock)`

--- a/docs/pages/versions/v39.0.0/sdk/sharing.md
+++ b/docs/pages/versions/v39.0.0/sdk/sharing.md
@@ -35,11 +35,6 @@ import Video from '~/components/plugins/Video'
 import * as Sharing from 'expo-sharing';
 ```
 
-**[Methods](#methods)**
-
-- [`Sharing.isAvailableAsync()`](#sharingisavailableasync)
-- [`Sharing.shareAsync(url, options)`](#sharingshareasyncurl-options)
-
 ## Methods
 
 ### `Sharing.isAvailableAsync()`

--- a/docs/pages/versions/v39.0.0/sdk/status-bar.md
+++ b/docs/pages/versions/v39.0.0/sdk/status-bar.md
@@ -53,24 +53,6 @@ export default class App extends React.Component {
 import { StatusBar } from 'expo-status-bar';
 ```
 
-**[Components](#components)**
-
-- [`StatusBar`](#statusbar)
-
-**[Methods](#methods)**
-
-- [`setStatusBarBackgroundColor(backgroundColor, animated)`](#setstatusbarbackgroundcolorbackgroundcolor-animated)
-- [`setStatusBarHidden(hidden, animation)`](#setstatusbarhiddenhidden-animation)
-- [`setStatusBarNetworkActivityIndicatorVisible(visible)`](#setstatusbarnetworkactivityindicatorvisiblevisible)
-- [`setStatusBarStyle(style)`](#setstatusbarstylestyle)
-- [`setStatusBarTranslucent(translucent)`](#setstatusbartranslucenttranslucent)
-
-**[Types](#types)**
-
-- [`StatusBarAnimation`](#statusbaranimation)
-- [`StatusBarProps`](#statusbarprops)
-- [`StatusBarStyle`](#statusbarstyle)
-
 ## Components
 
 ### `StatusBar`

--- a/docs/pages/versions/v40.0.0/sdk/amplitude.md
+++ b/docs/pages/versions/v40.0.0/sdk/amplitude.md
@@ -22,16 +22,6 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 import * as Amplitude from 'expo-analytics-amplitude';
 ```
 
-**[Methods](#methods)**
-
-- [`Amplitude.initializeAsync(apiKey)`](#amplitudeinitializeasyncapikey)
-- [`Amplitude.setUserIdAsync(userId)`](#amplitudesetuseridasyncuserid)
-- [`Amplitude.setUserPropertiesAsync(userProperties)`](#amplitudesetuserpropertiesasyncuserproperties)
-- [`Amplitude.clearUserPropertiesAsync()`](#amplitudeclearuserpropertiesasync)
-- [`Amplitude.logEventAsync(eventName)`](#amplitudelogeventasynceventname)
-- [`Amplitude.logEventWithPropertiesAsync(eventName, properties)`](#amplitudelogeventwithpropertiesasynceventname-properties)
-- [`Amplitude.setGroupAsync(groupType, groupNames)`](#amplitudesetgroupasyncgrouptype-groupnames)
-
 ## Methods
 
 ### `Amplitude.initializeAsync(apiKey)`

--- a/docs/pages/versions/v40.0.0/sdk/apple-authentication.md
+++ b/docs/pages/versions/v40.0.0/sdk/apple-authentication.md
@@ -77,36 +77,6 @@ Apple's response includes a signed JWT with information about the user. To ensur
 import * as AppleAuthentication from 'expo-apple-authentication';
 ```
 
-**[Methods](#methods)**
-
-- [`AppleAuthentication.isAvailableAsync()`](#appleauthenticationisavailableasync)
-- [`AppleAuthentication.signInAsync(options)`](#appleauthenticationsigninasyncoptions)
-- [`AppleAuthentication.getCredentialStateAsync(user)`](#appleauthenticationgetcredentialstateasyncuser)
-
-**[Components](#components)**
-
-- [`AppleAuthentication.AppleAuthenticationButton`](#appleauthenticationappleauthenticationbutton)
-
-**[Prop Types](#appleauthenticationappleauthenticationbuttonprops)**
-
-- [`AppleAuthentication.AppleAuthenticationButtonProps`](#appleauthenticationappleauthenticationbuttonprops)
-
-**[Enum Types](#enum-types)**
-
-- [`AppleAuthentication.AppleAuthenticationButtonStyle`](#appleauthenticationappleauthenticationbuttonstyle)
-- [`AppleAuthentication.AppleAuthenticationButtonType`](#appleauthenticationappleauthenticationbuttontype)
-- [`AppleAuthentication.AppleAuthenticationCredentialState`](#appleauthenticationappleauthenticationcredentialstate)
-- [`AppleAuthentication.AppleAuthenticationScope`](#appleauthenticationappleauthenticationscope)
-- [`AppleAuthentication.AppleAuthenticationUserDetectionStatus`](#appleauthenticationappleauthenticationuserdetectionstatus)
-
-**[Object Types](#object-types)**
-
-- [`AppleAuthentication.AppleAuthenticationCredential`](#appleauthenticationappleauthenticationcredential)
-- [`AppleAuthentication.AppleAuthenticationFullName`](#appleauthenticationappleauthenticationfullname)
-- [`AppleAuthentication.AppleAuthenticationSignInOptions`](#appleauthenticationappleauthenticationsigninoptions)
-
-**[Error Codes](#error-codes)**
-
 ## Methods
 
 ### `AppleAuthentication.isAvailableAsync()`

--- a/docs/pages/versions/v40.0.0/sdk/device.md
+++ b/docs/pages/versions/v40.0.0/sdk/device.md
@@ -20,44 +20,6 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 import * as Device from 'expo-device';
 ```
 
-### Constants
-
-- [`Device.isDevice`](#deviceisdevice)
-- [`Device.brand`](#devicebrand)
-- [`Device.manufacturer`](#devicemanufacturer)
-- [`Device.modelName`](#devicemodelname)
-- [`Device.modelId`](#devicemodelid) (iOS only)
-- [`Device.designName`](#devicedesignname) (Android only)
-- [`Device.productName`](#deviceproductname) (Android only)
-- [`Device.deviceYearClass`](#devicedeviceyearclass)
-- [`Device.totalMemory`](#devicetotalmemory)
-- [`Device.supportedCpuArchitectures`](#devicesupportedcpuarchitectures)
-- [`Device.osName`](#deviceosname)
-- [`Device.osVersion`](#deviceosversion)
-- [`Device.osBuildId`](#deviceosbuildid)
-- [`Device.osInternalBuildId`](#deviceosinternalbuildid)
-- [`Device.osBuildFingerprint`](#deviceosbuildfingerprint) (Android only)
-- [`Device.platformApiLevel`](#deviceplatformapilevel) (Android only)
-- [`Device.deviceName`](#devicedevicename)
-
-### Methods
-
-- [`Device.getDeviceTypeAsync()`](#devicegetdevicetypeasync)
-- [`Device.getUptimeAsync()`](#devicegetuptimeasync)
-- [`Device.getMaxMemoryAsync()`](#devicegetmaxmemoryasync) (Android only)
-- [`Device.isRootedExperimentalAsync()`](#deviceisrootedexperimentalasync)
-- [`Device.isSideLoadingEnabledAsync()`](#deviceissideloadingenabledasync) (Android only)
-- [`Device.getPlatformFeaturesAsync()`](#devicegetplatformfeaturesasync) (Android only)
-- [`Device.hasPlatformFeatureAsync(feature)`](#devicehasplatformfeatureasyncfeature) (Android only)
-
-### Enum Types
-
-- [`Device.DeviceType`](#devicedevicetype)
-
-### Errors
-
-- [Error Codes](#error-codes)
-
 ## Constants
 
 ### `Device.isDevice`

--- a/docs/pages/versions/v40.0.0/sdk/network.md
+++ b/docs/pages/versions/v40.0.0/sdk/network.md
@@ -24,21 +24,6 @@ On Android, this module requires permissions to access the network and Wi-Fi sta
 import * as Network from 'expo-network';
 ```
 
-### Methods
-
-- [`Network.getNetworkStateAsync()`](#networkgetnetworkstateasync)
-- [`Network.getIpAddressAsync()`](#networkgetipaddressasync)
-- [`Network.getMacAddressAsync(interfaceName?)`](#networkgetmacaddressasyncinterfacename)
-- [`Network.isAirplaneModeEnabledAsync()`](#networkisairplanemodeenabledasync) (Android only)
-
-### Enum Types
-
-- [`Network.NetworkStateType`](#networknetworkstatetype)
-
-### Errors
-
-- [Error Codes](#error-codes)
-
 ## Methods
 
 ### `Network.getNetworkStateAsync()`

--- a/docs/pages/versions/v40.0.0/sdk/random.md
+++ b/docs/pages/versions/v40.0.0/sdk/random.md
@@ -22,9 +22,6 @@ import * as Random from 'expo-random';
 
 ## Methods
 
-- [`Random.getRandomBytes(byteCount)`](#randomgetrandombytesbytecount)
-- [`Random.getRandomBytesAsync(byteCount)`](#networkgetipaddressasync)
-
 ### `Random.getRandomBytes(byteCount)`
 
 Generates completely random bytes using native implementations. The `byteCount` property is a `number` indicating the number of bytes to generate in the form of a `Uint8Array`.

--- a/docs/pages/versions/v40.0.0/sdk/screen-orientation.md
+++ b/docs/pages/versions/v40.0.0/sdk/screen-orientation.md
@@ -54,41 +54,6 @@ Tick the `Requires Full Screen` checkbox in Xcode. It should be located under `P
 import * as ScreenOrientation from 'expo-screen-orientation';
 ```
 
-### Methods
-
-- [`ScreenOrientation.lockAsync(orientationLock)`](#screenorientationlockasyncorientationlock)
-- [`ScreenOrientation.lockPlatformAsync(platformInfo)`](#screenorientationlockplatformasyncplatforminfo)
-- [`ScreenOrientation.unlockAsync()`](#screenorientationunlockasync)
-- [`ScreenOrientation.getOrientationAsync()`](#screenorientationgetorientationasync)
-- [`ScreenOrientation.getOrientationLockAsync()`](#screenorientationgetorientationlockasync)
-- [`ScreenOrientation.getPlatformOrientationLockAsync()`](#screenorientationgetplatformorientationlockasync)
-- [`ScreenOrientation.supportsOrientationLockAsync(orientationLock)`](#screenorientationsupportsorientationlockasyncorientationlock)
-- [`ScreenOrientation.addOrientationChangeListener(listener)`](#screenorientationaddorientationchangelistenerlistener)
-- [`ScreenOrientation.removeOrientationChangeListeners()`](#screenorientationremoveorientationchangelisteners)
-- [`ScreenOrientation.removeOrientationChangeListener(subscription)`](#screenorientationremoveorientationchangelistenersubscription)
-
-### Enum Types
-
-- [`ScreenOrientation.Orientation`](#screenorientationorientation)
-- [`ScreenOrientation.OrientationLock`](#screenorientationorientationlock)
-- [`ScreenOrientation.SizeClassIOS`](#screenorientationsizeclassios)
-- [`ScreenOrientation.WebOrientationLock`](#screenorientationweborientationlock)
-
-### Object Types
-
-- [`ScreenOrientation.PlatformOrientationInfo`](#screenorientationplatformorientationinfo)
-- [`ScreenOrientation.ScreenOrientationInfo`](#screenorientationscreenorientationinfo)
-- [`ScreenOrientation.OrientationChangeEvent`](#screenorientationorientationchangeevent)
-- [`Subscription`](#subscription)
-
-### Function Types
-
-- [`ScreenOrientation.OrientationChangeListener`](#screenorientationorientationchangelistener)
-
-### Errors
-
-- [Error Codes](#error-codes)
-
 ## Methods
 
 ### `ScreenOrientation.lockAsync(orientationLock)`

--- a/docs/pages/versions/v40.0.0/sdk/sharing.md
+++ b/docs/pages/versions/v40.0.0/sdk/sharing.md
@@ -33,16 +33,6 @@ Currently `expo-sharing` only supports sharing *from your app to other apps* and
 import * as Sharing from 'expo-sharing';
 ```
 
-**[Methods](#methods)**
-
-- [Installation](#installation)
-- [API](#api)
-- [Methods](#methods)
-  - [`Sharing.isAvailableAsync()`](#sharingisavailableasync)
-    - [Returns](#returns)
-  - [`Sharing.shareAsync(url, options)`](#sharingshareasyncurl-options)
-    - [Arguments](#arguments)
-
 ## Methods
 
 ### `Sharing.isAvailableAsync()`

--- a/docs/pages/versions/v40.0.0/sdk/status-bar.md
+++ b/docs/pages/versions/v40.0.0/sdk/status-bar.md
@@ -53,24 +53,6 @@ export default class App extends React.Component {
 import { StatusBar } from 'expo-status-bar';
 ```
 
-**[Components](#components)**
-
-- [`StatusBar`](#statusbar)
-
-**[Methods](#methods)**
-
-- [`setStatusBarBackgroundColor(backgroundColor, animated)`](#setstatusbarbackgroundcolorbackgroundcolor-animated)
-- [`setStatusBarHidden(hidden, animation)`](#setstatusbarhiddenhidden-animation)
-- [`setStatusBarNetworkActivityIndicatorVisible(visible)`](#setstatusbarnetworkactivityindicatorvisiblevisible)
-- [`setStatusBarStyle(style)`](#setstatusbarstylestyle)
-- [`setStatusBarTranslucent(translucent)`](#setstatusbartranslucenttranslucent)
-
-**[Types](#types)**
-
-- [`StatusBarAnimation`](#statusbaranimation)
-- [`StatusBarProps`](#statusbarprops)
-- [`StatusBarStyle`](#statusbarstyle)
-
 ## Components
 
 ### `StatusBar`

--- a/docs/pages/versions/v41.0.0/sdk/device.md
+++ b/docs/pages/versions/v41.0.0/sdk/device.md
@@ -20,44 +20,6 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 import * as Device from 'expo-device';
 ```
 
-### Constants
-
-- [`Device.isDevice`](#deviceisdevice)
-- [`Device.brand`](#devicebrand)
-- [`Device.manufacturer`](#devicemanufacturer)
-- [`Device.modelName`](#devicemodelname)
-- [`Device.modelId`](#devicemodelid) (iOS only)
-- [`Device.designName`](#devicedesignname) (Android only)
-- [`Device.productName`](#deviceproductname) (Android only)
-- [`Device.deviceYearClass`](#devicedeviceyearclass)
-- [`Device.totalMemory`](#devicetotalmemory)
-- [`Device.supportedCpuArchitectures`](#devicesupportedcpuarchitectures)
-- [`Device.osName`](#deviceosname)
-- [`Device.osVersion`](#deviceosversion)
-- [`Device.osBuildId`](#deviceosbuildid)
-- [`Device.osInternalBuildId`](#deviceosinternalbuildid)
-- [`Device.osBuildFingerprint`](#deviceosbuildfingerprint) (Android only)
-- [`Device.platformApiLevel`](#deviceplatformapilevel) (Android only)
-- [`Device.deviceName`](#devicedevicename)
-
-### Methods
-
-- [`Device.getDeviceTypeAsync()`](#devicegetdevicetypeasync)
-- [`Device.getUptimeAsync()`](#devicegetuptimeasync)
-- [`Device.getMaxMemoryAsync()`](#devicegetmaxmemoryasync) (Android only)
-- [`Device.isRootedExperimentalAsync()`](#deviceisrootedexperimentalasync)
-- [`Device.isSideLoadingEnabledAsync()`](#deviceissideloadingenabledasync) (Android only)
-- [`Device.getPlatformFeaturesAsync()`](#devicegetplatformfeaturesasync) (Android only)
-- [`Device.hasPlatformFeatureAsync(feature)`](#devicehasplatformfeatureasyncfeature) (Android only)
-
-### Enum Types
-
-- [`Device.DeviceType`](#devicedevicetype)
-
-### Errors
-
-- [Error Codes](#error-codes)
-
 ## Constants
 
 ### `Device.isDevice`

--- a/docs/pages/versions/v41.0.0/sdk/network.md
+++ b/docs/pages/versions/v41.0.0/sdk/network.md
@@ -24,21 +24,6 @@ On Android, this module requires permissions to access the network and Wi-Fi sta
 import * as Network from 'expo-network';
 ```
 
-### Methods
-
-- [`Network.getNetworkStateAsync()`](#networkgetnetworkstateasync)
-- [`Network.getIpAddressAsync()`](#networkgetipaddressasync)
-- [`Network.getMacAddressAsync(interfaceName?)`](#networkgetmacaddressasyncinterfacename)
-- [`Network.isAirplaneModeEnabledAsync()`](#networkisairplanemodeenabledasync) (Android only)
-
-### Enum Types
-
-- [`Network.NetworkStateType`](#networknetworkstatetype)
-
-### Errors
-
-- [Error Codes](#error-codes)
-
 ## Methods
 
 ### `Network.getNetworkStateAsync()`

--- a/docs/pages/versions/v41.0.0/sdk/screen-orientation.md
+++ b/docs/pages/versions/v41.0.0/sdk/screen-orientation.md
@@ -54,41 +54,6 @@ Tick the `Requires Full Screen` checkbox in Xcode. It should be located under `P
 import * as ScreenOrientation from 'expo-screen-orientation';
 ```
 
-### Methods
-
-- [`ScreenOrientation.lockAsync(orientationLock)`](#screenorientationlockasyncorientationlock)
-- [`ScreenOrientation.lockPlatformAsync(platformInfo)`](#screenorientationlockplatformasyncplatforminfo)
-- [`ScreenOrientation.unlockAsync()`](#screenorientationunlockasync)
-- [`ScreenOrientation.getOrientationAsync()`](#screenorientationgetorientationasync)
-- [`ScreenOrientation.getOrientationLockAsync()`](#screenorientationgetorientationlockasync)
-- [`ScreenOrientation.getPlatformOrientationLockAsync()`](#screenorientationgetplatformorientationlockasync)
-- [`ScreenOrientation.supportsOrientationLockAsync(orientationLock)`](#screenorientationsupportsorientationlockasyncorientationlock)
-- [`ScreenOrientation.addOrientationChangeListener(listener)`](#screenorientationaddorientationchangelistenerlistener)
-- [`ScreenOrientation.removeOrientationChangeListeners()`](#screenorientationremoveorientationchangelisteners)
-- [`ScreenOrientation.removeOrientationChangeListener(subscription)`](#screenorientationremoveorientationchangelistenersubscription)
-
-### Enum Types
-
-- [`ScreenOrientation.Orientation`](#screenorientationorientation)
-- [`ScreenOrientation.OrientationLock`](#screenorientationorientationlock)
-- [`ScreenOrientation.SizeClassIOS`](#screenorientationsizeclassios)
-- [`ScreenOrientation.WebOrientationLock`](#screenorientationweborientationlock)
-
-### Object Types
-
-- [`ScreenOrientation.PlatformOrientationInfo`](#screenorientationplatformorientationinfo)
-- [`ScreenOrientation.ScreenOrientationInfo`](#screenorientationscreenorientationinfo)
-- [`ScreenOrientation.OrientationChangeEvent`](#screenorientationorientationchangeevent)
-- [`Subscription`](#subscription)
-
-### Function Types
-
-- [`ScreenOrientation.OrientationChangeListener`](#screenorientationorientationchangelistener)
-
-### Errors
-
-- [Error Codes](#error-codes)
-
 ## Methods
 
 ### `ScreenOrientation.lockAsync(orientationLock)`

--- a/docs/pages/versions/v41.0.0/sdk/status-bar.md
+++ b/docs/pages/versions/v41.0.0/sdk/status-bar.md
@@ -53,24 +53,6 @@ export default class App extends React.Component {
 import { StatusBar } from 'expo-status-bar';
 ```
 
-**[Components](#components)**
-
-- [`StatusBar`](#statusbar)
-
-**[Methods](#methods)**
-
-- [`setStatusBarBackgroundColor(backgroundColor, animated)`](#setstatusbarbackgroundcolorbackgroundcolor-animated)
-- [`setStatusBarHidden(hidden, animation)`](#setstatusbarhiddenhidden-animation)
-- [`setStatusBarNetworkActivityIndicatorVisible(visible)`](#setstatusbarnetworkactivityindicatorvisiblevisible)
-- [`setStatusBarStyle(style)`](#setstatusbarstylestyle)
-- [`setStatusBarTranslucent(translucent)`](#setstatusbartranslucenttranslucent)
-
-**[Types](#types)**
-
-- [`StatusBarAnimation`](#statusbaranimation)
-- [`StatusBarProps`](#statusbarprops)
-- [`StatusBarStyle`](#statusbarstyle)
-
 ## Components
 
 ### `StatusBar`

--- a/docs/pages/versions/v42.0.0/sdk/status-bar.md
+++ b/docs/pages/versions/v42.0.0/sdk/status-bar.md
@@ -53,24 +53,6 @@ export default class App extends React.Component {
 import { StatusBar } from 'expo-status-bar';
 ```
 
-**[Components](#components)**
-
-- [`StatusBar`](#statusbar)
-
-**[Methods](#methods)**
-
-- [`setStatusBarBackgroundColor(backgroundColor, animated)`](#setstatusbarbackgroundcolorbackgroundcolor-animated)
-- [`setStatusBarHidden(hidden, animation)`](#setstatusbarhiddenhidden-animation)
-- [`setStatusBarNetworkActivityIndicatorVisible(visible)`](#setstatusbarnetworkactivityindicatorvisiblevisible)
-- [`setStatusBarStyle(style)`](#setstatusbarstylestyle)
-- [`setStatusBarTranslucent(translucent)`](#setstatusbartranslucenttranslucent)
-
-**[Types](#types)**
-
-- [`StatusBarAnimation`](#statusbaranimation)
-- [`StatusBarProps`](#statusbarprops)
-- [`StatusBarStyle`](#statusbarstyle)
-
 ## Components
 
 ### `StatusBar`

--- a/docs/pages/versions/v43.0.0/sdk/status-bar.md
+++ b/docs/pages/versions/v43.0.0/sdk/status-bar.md
@@ -53,24 +53,6 @@ export default class App extends React.Component {
 import { StatusBar } from 'expo-status-bar';
 ```
 
-**[Components](#components)**
-
-- [`StatusBar`](#statusbar)
-
-**[Methods](#methods)**
-
-- [`setStatusBarBackgroundColor(backgroundColor, animated)`](#setstatusbarbackgroundcolorbackgroundcolor-animated)
-- [`setStatusBarHidden(hidden, animation)`](#setstatusbarhiddenhidden-animation)
-- [`setStatusBarNetworkActivityIndicatorVisible(visible)`](#setstatusbarnetworkactivityindicatorvisiblevisible)
-- [`setStatusBarStyle(style)`](#setstatusbarstylestyle)
-- [`setStatusBarTranslucent(translucent)`](#setstatusbartranslucenttranslucent)
-
-**[Types](#types)**
-
-- [`StatusBarAnimation`](#statusbaranimation)
-- [`StatusBarProps`](#statusbarprops)
-- [`StatusBarStyle`](#statusbarstyle)
-
 ## Components
 
 ### `StatusBar`


### PR DESCRIPTION
# Why

Fixes #10391

# How

This PR removes the remaining in-content Table of Contents from the SDK and guide pages.

I have left the entries untouched for the `SDK 38` pages, because this version is already scheduled for the delete anyway.

# Test Plan

The changes have been tested by ruining docs website locally.

# Checklist

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).