### PR TITLE
[docs][dev-client] Add information about the required version by SDK 43

### DIFF
--- a/docs/pages/clients/installation.md
+++ b/docs/pages/clients/installation.md
@@ -15,6 +15,8 @@ If you created your project with `expo init`, or already you have `react-native-
 
 If you created your project with `npx react-native init` and do not have `react-native-unimodules` or any other Expo packages installed, use the tabs marked **Without unimodules**.
 
+> **Note**: if you are using **SDK 43 or above**, you need to install **`expo-dev-client@0.6.0` or above**.
+
 ## 1. Installation
 
 Add the `expo-dev-client` package to your package.json.


### PR DESCRIPTION
# Why

A follow-up to the https://github.com/expo/expo/pull/14617#pullrequestreview-771782417.

> Note: Version 0.6.0 wasn't published yet. 