### PR TITLE
[dev-client] Adjust e2e tests timeouts

### DIFF
--- a/packages/expo-dev-client/e2e/DevLauncher.e2e.ts
+++ b/packages/expo-dev-client/e2e/DevLauncher.e2e.ts
@@ -35,6 +35,7 @@ async function openMenu(): Promise<void> {
 describe('DevLauncher', () => {
   beforeEach(async () => {
     await device.launchApp({ newInstance: true });
+    await device.disableSynchronization();
   });
 
   it('should render main screen', async () => {

--- a/packages/expo-dev-client/e2e/DevLauncher.e2e.ts
+++ b/packages/expo-dev-client/e2e/DevLauncher.e2e.ts
@@ -1,8 +1,8 @@
 import { element, expect, waitFor, by, device } from 'detox';
 
-const MenuTimeout = 50000;
-const LauncherMainScreenTimeout = 30000;
-const LocalAppTimeout = 60000;
+const MenuTimeout = 70 * 1000;
+const LauncherMainScreenTimeout = 50 * 1000;
+const LocalAppTimeout = 80 * 1000;
 
 function getInvocationManager() {
   // @ts-ignore
@@ -92,9 +92,7 @@ describe('DevLauncher', () => {
 
     const backToLauncher = element(by.text('Back to Launcher'));
 
-    await waitFor(backToLauncher)
-      .toBeVisible()
-      .withTimeout(MenuTimeout);
+    await waitFor(backToLauncher).toBeVisible().withTimeout(MenuTimeout);
     await backToLauncher.tap();
 
     await waitFor(element(by.id('DevLauncherMainScreen')))

--- a/packages/expo-dev-client/e2e/config.json
+++ b/packages/expo-dev-client/e2e/config.json
@@ -2,7 +2,7 @@
   "maxWorkers": 1,
   "testEnvironment": "./environments",
   "testRunner": "jest-circus/runner",
-  "testTimeout": 120000,
+  "testTimeout": 180000,
   "testRegex": "\\.e2e\\.ts$",
   "reporters": ["detox/runners/jest/streamlineReporter"],
   "verbose": true


### PR DESCRIPTION
# Why

Adjusts timeouts of e2e tests. 
The detox tests often fail because of the timeouts. To prevent them from failing, I increased timeouts.