### PR TITLE
[gl-cpp] fix gradle error for deprecated GradleScriptException

### DIFF
--- a/packages/expo-gl-cpp/android/build.gradle
+++ b/packages/expo-gl-cpp/android/build.gradle
@@ -221,7 +221,7 @@ task prepareGlog(dependsOn: dependenciesPath ? [] : [downloadGlog], type: Copy) 
 task prepareJSI() {
   def hermesPackagePath = findNodeModulePath(projectDir, "hermes-engine")
   if (!hermesPackagePath) {
-    throw new GradleScriptException("Could not find the hermes-engine npm package")
+    throw new GradleScriptException("Could not find the hermes-engine npm package", null)
   }
   copy {
     from("../../../android/ReactCommon/jsi")


### PR DESCRIPTION
# Why

```
stderr] A problem occurred evaluating project ':expo-gl-cpp'.
[stderr] > Could not find matching constructor for: org.gradle.api.GradleScriptException(String)
```

# How

replace with `GradleStringException(String, Throwable)` 

# Test Plan

CI passed

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).