### PR TITLE
[expo-gl-cpp] wrap prepareJSI with doLast

### DIFF
--- a/packages/expo-gl-cpp/android/build.gradle
+++ b/packages/expo-gl-cpp/android/build.gradle
@@ -219,13 +219,15 @@ task prepareGlog(dependsOn: dependenciesPath ? [] : [downloadGlog], type: Copy) 
 }
 
 task prepareJSI() {
-  def hermesPackagePath = findNodeModulePath(projectDir, "hermes-engine")
-  if (!hermesPackagePath) {
-    throw new GradleScriptException("Could not find the hermes-engine npm package")
-  }
-  copy {
-    from("../../../android/ReactCommon/jsi")
-    into "$thirdPartyNdkDir/jsi"
+  doLast {
+    def hermesPackagePath = findNodeModulePath(projectDir, "hermes-engine")
+    if (!hermesPackagePath) {
+      throw new GradleScriptException("Could not find the hermes-engine npm package", null)
+    }
+    copy {
+      from("../../../android/ReactCommon/jsi")
+      into "$thirdPartyNdkDir/jsi"
+    }
   }
 }
 


### PR DESCRIPTION
# Why

wrap prepareJSI with doLast to make sure that it's executed only if buildNdkLib task is called

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

tested by manually modifying code on stagin turtle

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).