### PR TITLE
🎨 Support Dark Mode on NotFoundScreen component

### DIFF
--- a/templates/expo-template-tabs/screens/NotFoundScreen.tsx
+++ b/templates/expo-template-tabs/screens/NotFoundScreen.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { StyleSheet, TouchableOpacity } from 'react-native';
+import { Text, View } from '../components/Themed';
 
 import { RootStackScreenProps } from '../types';
 
@@ -17,7 +18,6 @@ export default function NotFoundScreen({ navigation }: RootStackScreenProps<'Not
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#fff',
     alignItems: 'center',
     justifyContent: 'center',
     padding: 20,


### PR DESCRIPTION
# Why

Rest of template supports dark mode, the Not Found screen (loaded on invalid deep links) should as well.

# How

1. Import `<Text />` and `<View />` elements from themed version supporting dark mode
2. Remove white background handled by themed version of `<View />` component

# Test Plan

The simplest test is to update `navigation/index.tsx` in a sample project to load this view over TabOneScreen or TabTwoScreen

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).