### PR TITLE
[docs] add page on upgrading dev client

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -94,9 +94,12 @@ const sections = [
       'Introduction',
       'Getting Started',
       'Installation in React Native and Bare workflow projects',
+      'Upgrading',
       'Building with EAS',
       'Development Workflows',
-      'Extending the Development Menu',
+      'Extending the Dev Menu',
+      'Compatibility',
+      'Troubleshooting',
     ],
   },
   {

--- a/docs/pages/clients/upgrading.md
+++ b/docs/pages/clients/upgrading.md
@@ -1,0 +1,32 @@
+---
+title: Upgrading
+sidebar_title: Upgrading
+---
+
+While we try to make upgrading the `expo-dev-client` package as painless as possible, occasionally you will need to make small changes to your project which are listed on this page.
+
+## 0.6.0
+
+**For managed workflow projects, and bare projects with the `expo` or `react-native-unimodules` package**, no additional changes are needed. 🎉
+
+**For bare workflow projects with no other Expo modules nor `react-native-unimodules`**, the following additional changes are needed when upgrading to `expo-dev-client@0.6.x`:
+
+### 🍏 iOS
+
+In `ios/Podfile`, change the deployment target to `platform :ios, '12.0'` and add the following lines inside the main target:
+```ruby
+pod 'EXJSONUtils', path: '../node_modules/expo-json-utils/ios', :configurations => :debug
+pod 'EXManifests', path: '../node_modules/expo-manifests/ios', :configurations => :debug
+```
+Rerun `pod install` before reopening your project.
+
+### 🤖 Android
+
+In `android/settings.gradle`, add the following lines:
+```groovy
+include ':expo-json-utils'
+project(':expo-json-utils').projectDir = new File('../node_modules/expo-json-utils/android')
+
+include ':expo-manifests'
+project(':expo-manifests').projectDir = new File('../node_modules/expo-manifests/android')
+```


### PR DESCRIPTION
# Why

Now that expo-dev-client@0.6.0 with new expo module dependencies is released, people using this package without unimodules will need to follow some extra steps in order to upgrade. I propose adding this docs page to make this easily discoverable.

# How

Add new page, copied upgrade steps from package changelog.

Also added to navbar, along with some existing pages in order to preserve the current ordering.

# Test Plan

Ran docs locally

<img width="1272" alt="Screen Shot 2021-10-07 at 2 52 22 PM" src="https://user-images.githubusercontent.com/19958240/136467661-aa68c863-7119-416e-bd4c-8504158b8062.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).