### PR TITLE
[expo-updates][ios] add native setting for checkAutomatically: ON_ERROR_RECOVERY

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Add error recovery manager on iOS. ([#14397](https://github.com/expo/expo/pull/14397) by [@esamelson](https://github.com/esamelson))
 - Hook up error recovery manager to rest of module on iOS. ([#14398](https://github.com/expo/expo/pull/14398) by [@esamelson](https://github.com/esamelson))
 - Move persisted error log to EXUpdatesErrorRecovery on iOS. ([#14399](https://github.com/expo/expo/pull/14399) by [@esamelson](https://github.com/esamelson))
+- Add native EXUpdatesCheckOnLaunch: ERROR_RECOVERY_ONLY setting on iOS. ([#14673](https://github.com/expo/expo/pull/14673) by [@esamelson](https://github.com/esamelson))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.h
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.h
@@ -7,7 +7,8 @@ NS_ASSUME_NONNULL_BEGIN
 typedef NS_ENUM(NSInteger, EXUpdatesCheckAutomaticallyConfig) {
   EXUpdatesCheckAutomaticallyConfigAlways = 0,
   EXUpdatesCheckAutomaticallyConfigWifiOnly = 1,
-  EXUpdatesCheckAutomaticallyConfigNever = 2
+  EXUpdatesCheckAutomaticallyConfigNever = 2,
+  EXUpdatesCheckAutomaticallyConfigErrorRecoveryOnly = 3
 };
 
 FOUNDATION_EXPORT NSString * const EXUpdatesConfigPlistName;

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.m
@@ -38,6 +38,7 @@ static NSString * const EXUpdatesConfigHasEmbeddedUpdateKey = @"EXUpdatesHasEmbe
 
 static NSString * const EXUpdatesConfigAlwaysString = @"ALWAYS";
 static NSString * const EXUpdatesConfigWifiOnlyString = @"WIFI_ONLY";
+static NSString * const EXUpdatesConfigErrorRecoveryOnlyString = @"ERROR_RECOVERY_ONLY";
 static NSString * const EXUpdatesConfigNeverString = @"NEVER";
 
 @implementation EXUpdatesConfig
@@ -140,6 +141,8 @@ static NSString * const EXUpdatesConfigNeverString = @"NEVER";
   if (checkOnLaunch && [checkOnLaunch isKindOfClass:[NSString class]]) {
     if ([EXUpdatesConfigNeverString isEqualToString:(NSString *)checkOnLaunch]) {
       _checkOnLaunch = EXUpdatesCheckAutomaticallyConfigNever;
+    } else if ([EXUpdatesConfigErrorRecoveryOnlyString isEqualToString:(NSString *)checkOnLaunch]) {
+      _checkOnLaunch = EXUpdatesCheckAutomaticallyConfigErrorRecoveryOnly;
     } else if ([EXUpdatesConfigWifiOnlyString isEqualToString:(NSString *)checkOnLaunch]) {
       _checkOnLaunch = EXUpdatesCheckAutomaticallyConfigWifiOnly;
     } else if ([EXUpdatesConfigAlwaysString isEqualToString:(NSString *)checkOnLaunch]) {

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesErrorRecovery.h
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesErrorRecovery.h
@@ -2,8 +2,6 @@
 
 #import <EXUpdates/EXUpdatesAppLauncher.h>
 #import <EXUpdates/EXUpdatesConfig.h>
-#import <EXUpdates/EXUpdatesDatabase.h>
-#import <EXUpdates/EXUpdatesSelectionPolicy.h>
 #import <EXUpdates/EXUpdatesUpdate.h>
 #import <Foundation/Foundation.h>
 
@@ -17,6 +15,7 @@ typedef NS_ENUM(NSInteger, EXUpdatesRemoteLoadStatus) {
 
 @protocol EXUpdatesErrorRecoveryDelegate <NSObject>
 
+@property (nonatomic, readonly, strong) EXUpdatesConfig *config;
 @property (nonatomic, readonly, strong) EXUpdatesUpdate *launchedUpdate;
 @property (nonatomic, readonly, assign) EXUpdatesRemoteLoadStatus remoteLoadStatus;
 

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesErrorRecovery.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesErrorRecovery.m
@@ -158,9 +158,13 @@ static NSInteger const EXUpdatesErrorRecoveryRemoteLoadTimeoutMs = 5000;
     return;
   } else if (_delegate.remoteLoadStatus == EXUpdatesRemoteLoadStatusNewUpdateLoaded) {
     [self _runNextTask];
-  } else {
+  } else if (_delegate.config.checkOnLaunch != EXUpdatesCheckAutomaticallyConfigNever) {
     _isWaitingForRemoteUpdate = YES;
     [_delegate loadRemoteUpdate];
+  } else {
+    // there's no remote update, so move to the next step in the pipeline
+    [self->_pipeline removeObject:@(EXUpdatesErrorRecoveryTaskLaunchNew)];
+    [self _runNextTask];
   }
 }
 

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesUtils.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesUtils.m
@@ -78,6 +78,9 @@ static NSString * const EXUpdatesUtilsErrorDomain = @"EXUpdatesUtils";
   switch (config.checkOnLaunch) {
     case EXUpdatesCheckAutomaticallyConfigNever:
       return NO;
+    case EXUpdatesCheckAutomaticallyConfigErrorRecoveryOnly:
+      // check will happen later on if there's an error
+      return NO;
     case EXUpdatesCheckAutomaticallyConfigWifiOnly: {
       struct sockaddr_in zeroAddress;
       bzero(&zeroAddress, sizeof(zeroAddress));


### PR DESCRIPTION
# Why

https://github.com/expo/expo/pull/14397#discussion_r721070672

We don't have a native setting that corresponds to app.json's `updates.checkAutomatically: 'ON_ERROR_RECOVERY'`. Currently this is mapped to the native setting `EXUpdatesCheckOnLaunch: NEVER` (which has been the closest match in the past, since expo-updates didn't yet have error recovery code outside of the Expo Go/turtle v1 codebase), but it doesn't seem correct to change the behavior of `NEVER` to actually be "never, except for when recovering from an error."

This PR adds `EXUpdatesCheckOnLaunch: ERROR_RECOVERY_ONLY` to correspond with the existing app.json setting without compromising the behavior of `NEVER`.

# How

- add new enum value and set it with the corresponding string
- ensure that the native setting `ERROR_RECOVERY_ONLY` does not trigger an update check on launch
- when recovering from an error, only initiate a remote launch if the native setting is not `NEVER`

# Test Plan

Added error recovery unit tests to account for this case, all tests pass

# Todos

Add documentation for this new native setting, and update the expo-updates config plugin to map `updates.checkAutomatically: 'ON_ERROR_RECOVERY'` to `EXUpdatesCheckOnLaunch: ERROR_RECOVERY_ONLY`.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).