### PR TITLE
[template] fix hermes simulator build error on m1

### DIFF
--- a/templates/expo-template-bare-minimum/ios/Podfile
+++ b/templates/expo-template-bare-minimum/ios/Podfile
@@ -36,6 +36,22 @@ target 'HelloWorld' do
         end
       end
     end
-  end
 
+    # Workaround simulator build error for hermes with react-native 0.64 on mac m1 devices
+    arm_value = `/usr/sbin/sysctl -n hw.optional.arm64 2>&1`.to_i
+    has_hermes = has_pod(installer, 'hermes-engine')
+    if arm_value == 1 && has_hermes
+      projects = installer.aggregate_targets
+        .map{ |t| t.user_project }
+        .uniq{ |p| p.path }
+        .push(installer.pods_project)
+      projects.each do |project|
+        project.build_configurations.each do |config|
+          config.build_settings["EXCLUDED_ARCHS[sdk=iphonesimulator*]"] = config.build_settings["EXCLUDED_ARCHS[sdk=iphonesimulator*]"] + ' arm64'
+        end
+        project.save()
+      end
+    end
+
+  end
 end


### PR DESCRIPTION
# Why

this is a known issue for react-native 0.64 + hermes https://github.com/facebook/hermes/issues/468. i think we can workaround this in sdk 43.

# How

force to use x86_64 arch for simulator build.

# Test Plan

```sh
# on m1 mac
$ expo init -t /path/to/expo/expo/templates/expo-template-bare-minimum sdk43
# add "jsEngine: "hermes" to app.json
$ expo run:ios
```

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).