### PR TITLE
[docs] add SDK 43 to React Native versions table

### DIFF
--- a/docs/pages/versions/unversioned/index.md
+++ b/docs/pages/versions/unversioned/index.md
@@ -34,6 +34,7 @@ Every quarter there is a new Expo SDK release that typically updates to the late
 
 | Expo SDK Version | React Native Version |
 | ---------------- | :------------------: |
+| 43.0.0           |        0.64.2        |
 | 42.0.0           |        0.63.3        |
 | 41.0.0           |        0.63.3        |
 | 40.0.0           |        0.63.3        |

--- a/docs/pages/versions/v43.0.0/index.md
+++ b/docs/pages/versions/v43.0.0/index.md
@@ -34,6 +34,7 @@ Every quarter there is a new Expo SDK release that typically updates to the late
 
 | Expo SDK Version | React Native Version |
 | ---------------- | :------------------: |
+| 43.0.0           |        0.64.2        |
 | 42.0.0           |        0.63.3        |
 | 41.0.0           |        0.63.3        |
 | 40.0.0           |        0.63.3        |


### PR DESCRIPTION
# Why

SDK 43 docs has been published as beta, but the entry for this release in version compatibility table is missing.

# How

Add SDK 43 entry to the versions table.

# Test Plan

Change has been tested by running docs website on `localhost`.

# Checklist

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).