### PR TITLE
[expo] match dependencies to workspace versions

### DIFF
--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -68,9 +68,9 @@
     "expo-modules-autolinking": "~0.3.2",
     "expo-modules-core": "~0.4.2",
     "fbemitter": "^2.1.1",
-    "invariant": "^2.2.2",
+    "invariant": "^2.2.4",
     "md5-file": "^3.2.3",
-    "pretty-format": "^26.4.0",
+    "pretty-format": "^26.5.2",
     "uuid": "^3.4.0"
   },
   "optionalDependencies": {
@@ -78,8 +78,8 @@
   },
   "devDependencies": {
     "@types/fbemitter": "^2.0.32",
-    "@types/invariant": "^2.2.29",
-    "@types/react": "^17.0.18",
+    "@types/invariant": "^2.2.33",
+    "@types/react": "~17.0.21",
     "@types/react-native": "~0.64.12",
     "@types/react-test-renderer": "^17.0.1",
     "@types/uuid": "^3.4.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3373,7 +3373,7 @@
   resolved "https://registry.yarnpkg.com/@types/i18n-js/-/i18n-js-3.0.3.tgz#84f66fb969741fecd91b854387e0682aa7fd70b7"
   integrity sha512-GiZzazvxQ5j+EA4Zf4MtDsSaokAR/gW7FxxTlHi2p2xKFUhwAUT0B/MB8WL77P1TcqAO3MefWorFFyZS8F7s0Q==
 
-"@types/invariant@^2.2.29", "@types/invariant@^2.2.33":
+"@types/invariant@^2.2.33":
   version "2.2.34"
   resolved "https://registry.yarnpkg.com/@types/invariant/-/invariant-2.2.34.tgz#05e4f79f465c2007884374d4795452f995720bbe"
   integrity sha512-lYUtmJ9BqUN688fGY1U1HZoWT1/Jrmgigx2loq4ZcJpICECm/Om3V314BxdzypO0u5PORKGMM6x0OXaljV1YFg==
@@ -3546,7 +3546,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@>=16.9.0", "@types/react@^17.0.18", "@types/react@~17.0.21":
+"@types/react@*", "@types/react@>=16.9.0", "@types/react@~17.0.21":
   version "17.0.21"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.21.tgz#069c43177cd419afaab5ce26bb4e9056549f7ea6"
   integrity sha512-GzzXCpOthOjXvrAUFQwU/svyxu658cwu00Q9ugujS4qc1zXgLFaO0kS2SLOaMWLt2Jik781yuHCWB7UcYdGAeQ==
@@ -14553,7 +14553,7 @@ pretty-error@^2.1.1:
     renderkid "^2.0.1"
     utila "~0.4"
 
-pretty-format@^26.0.0, pretty-format@^26.4.0, pretty-format@^26.5.2, pretty-format@^26.6.2:
+pretty-format@^26.0.0, pretty-format@^26.5.2, pretty-format@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.6.2.tgz#e35c2705f14cb7fe2fe94fa078345b444120fc93"
   integrity sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==


### PR DESCRIPTION
# Why

Refs #14561

There are still a lot of warnings to fix in ManyPKG check, so I have decided to stick to one package per PR.

Also major bumps will be performed in separate PRs.

* https://github.com/expo/expo/pull/14561/checks?check_run_id=3744465703#step:6:29

# How

This PR matches most of `expo` dependencies to workspace versions. 

The package which left to bump is `uuid`, but it is used across whole repo and versions spans from `2.x` to `8.x` so this definitely will be get a dedicated PR. 😅 

# Test Plan

`build`, `lint` and `test` scripts in `expo` package directory finished successfully.

# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).