### PR TITLE
[dev-menu] Fix hermes inspector opening wrong target

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix hermes inspector opening wrong target. ([#14684](https://github.com/expo/expo/pull/14684) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 0.8.2 — 2021-10-07

--- a/packages/expo-dev-menu/ios/DevMenuAppInstance.swift
+++ b/packages/expo-dev-menu/ios/DevMenuAppInstance.swift
@@ -13,6 +13,14 @@ class DevMenuAppInstance: NSObject, RCTBridgeDelegate {
     super.init()
 
     self.bridge = DevMenuRCTBridge.init(delegate: self, launchOptions: nil)
+
+    // Hermes inspector will use latest executed script for Chrome DevTools Protocol.
+    // It will be EXDevMenuApp.ios.js in our case.
+    // To let Hermes aware target bundle, we try to reload here as a workaround solution.
+    // See https://github.com/facebook/react-native/blob/ec614c16b331bf3f793fda5780fa273d181a8492/ReactCommon/hermes/inspector/Inspector.cpp#L291
+    if let appBridge = manager.delegate?.appBridge?(forDevMenuManager: manager) as? RCTBridge {
+      appBridge.requestReload()
+    }
   }
 
   /**


### PR DESCRIPTION
# Why

https://github.com/expo/expo/pull/13041/files#diff-d682042b10e77aea6286b9897fdcc7429b047f1288d31d8abe90ed877b8e0162R163-R167 but for ios. @EvanBacon also reported this issue.

# How

reload app bridge after dev-menu bridge loaded.

since dev-menu bridge is lazy loaded, there's a side effect for app to reload. the scrolling position will be reset after reload. or we may try to initialize dev-menu bridge from startup.

# Test Plan

test from bare-expo
1. set `let useDevClient: Bool = true` in bare-expo AppDelegate.swift
2. load local bare-expo app
3. open dev-menu
4. open flipper or [hermes inspector in chrome](https://reactnative.dev/docs/0.64/hermes#debugging-js-on-hermes-using-google-chromes-devtools). make sure the sources are from app but not EXDevMenu.


Wrong target
![Screen Shot 2021-10-08 at 9 22 11 PM](https://user-images.githubusercontent.com/46429/136564706-2b3b2ead-24f4-45b4-a992-711d1095c10f.png)

Correct target
![Screen Shot 2021-10-08 at 9 20 39 PM](https://user-images.githubusercontent.com/46429/136564798-ba2453e0-83a0-4dbf-a209-f8797a94c1fa.png)

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).