### PR TITLE
[docs] update using-hermes for ios support

### DIFF
--- a/docs/pages/guides/using-hermes.md
+++ b/docs/pages/guides/using-hermes.md
@@ -3,36 +3,73 @@ title: Using Hermes Engine
 sidebar_title: Using Hermes
 ---
 
-> Hermes is currently only supported for Android apps using SDK 42 or higher, built with [EAS Build](https://docs.expo.dev/build/introduction/). There are no plans to backport support to `expo build`. [Jump to "Limitations"](#limitations).
+> Hermes is supported for apps built with [EAS Build](https://docs.expo.dev/build/introduction/). There are no plans to backport support to `expo build`. [Jump to "Limitations"](#limitations).
 
 [Hermes](https://hermesengine.dev/) is a JavaScript engine optimized for React Native. By compiling JavaScript into bytecode ahead of time, Hermes can improve your app start-up time. The binary size of Hermes is also smaller than other JavaScript engines, such as JavaScriptCore (JSC). It also uses less memory at runtime, which is particularly valuable on lower-end Android devices.
 
-A limitation with JavaScriptCore is that the debugger does not work with modules built on top of [JSI](https://github.com/react-native-community/discussions-and-proposals/issues/91). This means that if your app uses [react-native-reanimated](https://github.com/software-mansion/react-native-reanimated) version 2, for example, [remote JS debugging will not work](https://docs.swmansion.com/react-native-reanimated/docs/#known-problems-and-limitations). Hermes makes it possible to debug your app even when using JSI modules.
+A limitation with JavaScriptCore is that the debugger does not work with modules built on top of [JSI](https://github.com/react-native-community/discussions-and-proposals/issues/91). It means if your app uses [react-native-reanimated](https://github.com/software-mansion/react-native-reanimated) version 2, for example, [remote JS debugging will not work](https://docs.swmansion.com/react-native-reanimated/docs/#known-problems-and-limitations). Hermes makes it possible to debug your app even when using JSI modules.
 
 ## Android setup
 
-To get started, open your `app.json` and add `jsEngine` field under the `android` section:
+> Hermes for Android is supported from SDK 42 or above. For bare apps created or ejected before SDK 42, [follow these instructions to update your project configuration](https://expo.fyi/hermes-android-config).
+
+To get started, open your `app.json` and add `jsEngine` field:
 
 <!-- prettier-ignore -->
 ```json
 {
   "expo": {
-    "android": {
-      /* @info Add jsEngine field here. Supported values are hermes or jsc  */
-      "jsEngine": "hermes"/* @end */
-
-    }
+    /* @info Add jsEngine field here. Supported values are hermes or jsc */
+    "jsEngine": "hermes"
+  /* @end */
   }
 }
 ```
 
 Now you can build an APK or AAB through `eas build` and your app will run with Hermes instead of JavaScriptCore.
 
-> For bare apps created or ejected before SDK 42, [follow these instructions to update your project configuration](https://expo.fyi/hermes-android-config).
+## iOS setup
+
+> Hermes for iOS is supported from SDK 43 or above. For bare apps created or ejected before SDK 43, [follow these instructions to update your project configuration](https://expo.fyi/hermes-ios-config).
+
+To get started, open your `app.json` and add `jsEngine` field:
+
+<!-- prettier-ignore -->
+```json
+{
+  "expo": {
+    /* @info Add jsEngine field here. Supported values are hermes or jsc */
+    "jsEngine": "hermes"
+  /* @end */
+  }
+}
+```
+
+Now you can build your app through `eas build` and your app will run with Hermes instead of JavaScriptCore.
+
+## Advanced setup
+
+### Use different JavaScript engines on platforms
+
+In case you want to use different JavaScript engines on platforms. For example, to use Hermes on all platforms but leave JavaScriptCore on iOS. We also support this use case:
+
+<!-- prettier-ignore -->
+```json
+{
+  "expo": {
+    "jsEngine": "hermes",
+    "ios": {
+      /* @info jsEngine inside platform section will take precedence over the common field */
+      "jsEngine": "jsc"
+    /* @end */
+    }
+  }
+}
+```
 
 ## Publish Over-the-Air updates
 
-Publishing updates with both `expo publish` and `expo export` will generate Hermes bytecode bundles and their sourcemaps.
+Publishing updates with `expo publish` and `expo export` will generate Hermes bytecode bundles and their source maps.
 
 Please note that the Hermes bytecode format may change between different versions of `hermes-engine` — an update produced for a specific version of Hermes will not run on a different version of Hermes. Updating the Hermes version can be thought of in the same way as updating any other native module, and so if you update the `hermes-engine` version you should also update the `runtimeVersion` in `app.json`. If you don't do this, your app may crash on launch because the update may be loaded by an existing binary that uses an older version of `hermes-engine` that is incompatible with the updated bytecode format. See ["Update Compatibility"](https://docs.expo.dev/bare/updating-your-app/#update-compatibility) for more information.
 
@@ -46,10 +83,6 @@ To use Hermes inspector for JavaScript debugging, we recommend following [the in
 > 💡 [Custom development clients](/clients/introduction.md) built with `expo-dev-client` simplify this process by integrating directly with Hermes inspector.
 
 ## Limitations
-
-### iOS apps are not supported
-
-iOS is not supported yet — Hermes support was added to React Native for iOS in `react-native@0.64` and will likely be added to Expo projects when it has been used successfully in production more broadly.
 
 ### Standalone apps created with `expo build` are not supported
 

--- a/docs/pages/guides/using-hermes.md
+++ b/docs/pages/guides/using-hermes.md
@@ -7,11 +7,11 @@ sidebar_title: Using Hermes
 
 [Hermes](https://hermesengine.dev/) is a JavaScript engine optimized for React Native. By compiling JavaScript into bytecode ahead of time, Hermes can improve your app start-up time. The binary size of Hermes is also smaller than other JavaScript engines, such as JavaScriptCore (JSC). It also uses less memory at runtime, which is particularly valuable on lower-end Android devices.
 
-A limitation with JavaScriptCore is that the debugger does not work with modules built on top of [JSI](https://github.com/react-native-community/discussions-and-proposals/issues/91). It means if your app uses [react-native-reanimated](https://github.com/software-mansion/react-native-reanimated) version 2, for example, [remote JS debugging will not work](https://docs.swmansion.com/react-native-reanimated/docs/#known-problems-and-limitations). Hermes makes it possible to debug your app even when using JSI modules.
+A limitation with JavaScriptCore is that the debugger does not work with modules built on top of [JSI](https://github.com/react-native-community/discussions-and-proposals/issues/91). If your app uses [react-native-reanimated](https://github.com/software-mansion/react-native-reanimated) version 2, for example, [remote JS debugging will not work](https://docs.swmansion.com/react-native-reanimated/docs/#known-problems-and-limitations). Hermes makes it possible to debug your app even when using JSI modules.
 
 ## Android setup
 
-> Hermes for Android is supported from SDK 42 or above. For bare apps created or ejected before SDK 42, [follow these instructions to update your project configuration](https://expo.fyi/hermes-android-config).
+> Hermes for Android is supported from SDK 42 and above. For bare apps created before SDK 42, [follow these instructions to update your project configuration](https://expo.fyi/hermes-android-config).
 
 To get started, open your `app.json` and add `jsEngine` field:
 
@@ -19,7 +19,7 @@ To get started, open your `app.json` and add `jsEngine` field:
 ```json
 {
   "expo": {
-    /* @info Add jsEngine field here. Supported values are hermes or jsc */
+    /* @info Add the "jsEngine" field here. Supported values are "hermes" or "jsc" */
     "jsEngine": "hermes"
   /* @end */
   }
@@ -30,7 +30,7 @@ Now you can build an APK or AAB through `eas build` and your app will run with H
 
 ## iOS setup
 
-> Hermes for iOS is supported from SDK 43 or above. For bare apps created or ejected before SDK 43, [follow these instructions to update your project configuration](https://expo.fyi/hermes-ios-config).
+> Hermes for iOS is supported from SDK 43 and above. For bare apps created before SDK 43, [follow these instructions to update your project configuration](https://expo.fyi/hermes-ios-config).
 
 To get started, open your `app.json` and add `jsEngine` field:
 
@@ -38,7 +38,7 @@ To get started, open your `app.json` and add `jsEngine` field:
 ```json
 {
   "expo": {
-    /* @info Add jsEngine field here. Supported values are hermes or jsc */
+    /* @info Add the "jsEngine" field here. Supported values are "hermes" or "jsc" */
     "jsEngine": "hermes"
   /* @end */
   }
@@ -49,9 +49,9 @@ Now you can build your app through `eas build` and your app will run with Hermes
 
 ## Advanced setup
 
-### Use different JavaScript engines on platforms
+### Switch JavaScript engine on a specific platform
 
-In case you want to use different JavaScript engines on platforms. For example, to use Hermes on all platforms but leave JavaScriptCore on iOS. We also support this use case:
+You may want to use Hermes on one platform and JSC on another. One way to do this is to set the `"jsEngine"` to `"hermes"` at the top level and then override it with `"jsc"` under the `"ios"` key. You may alternatively prefer to explicitly set `"hermes"` on just the `"android"` key in this case.
 
 <!-- prettier-ignore -->
 ```json


### PR DESCRIPTION
# Why

we have ios support from sdk 43

# How

update doc

# Test Plan

`yarn dev` and check updated document locally

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).