### PR TITLE
[docs] ApiSection: initial support for classes

### DIFF
--- a/docs/components/plugins/APISection.tsx
+++ b/docs/components/plugins/APISection.tsx
@@ -3,6 +3,7 @@ import React, { useContext } from 'react';
 import DocumentationPageContext from '~/components/DocumentationPageContext';
 import { P } from '~/components/base/paragraph';
 import { GeneratedData } from '~/components/plugins/api/APIDataTypes';
+import APISectionClasses from '~/components/plugins/api/APISectionClasses';
 import APISectionComponents from '~/components/plugins/api/APISectionComponents';
 import APISectionConstants from '~/components/plugins/api/APISectionConstants';
 import APISectionEnums from '~/components/plugins/api/APISectionEnums';
@@ -107,9 +108,12 @@ const renderAPI = (
       componentsPropNames.includes(entry.name)
     );
 
+    const classes = filterDataByKind(data, TypeDocKind.Class, entry => !isComponent(entry));
+
     return (
       <>
         <APISectionComponents data={components} componentsProps={componentsProps} />
+        <APISectionClasses data={classes} />
         <APISectionConstants data={constants} apiName={apiName} />
         <APISectionMethods data={hooks} header="Hooks" />
         <APISectionMethods data={methods} apiName={apiName} />

--- a/docs/components/plugins/api/APIDataTypes.ts
+++ b/docs/components/plugins/api/APIDataTypes.ts
@@ -75,17 +75,6 @@ export type ConstantDefinitionData = {
   type?: TypeDefinitionData;
 };
 
-// Class section
-
-export type ClassDefinitionData = {
-  name: string;
-  comment?: CommentData;
-  kind: TypeDocKind;
-  extendedTypes?: TypeDefinitionData[];
-  children?: MethodDefinitionData[];
-  type?: TypeDefinitionData;
-};
-
 // Enums section
 
 export type EnumDefinitionData = {
@@ -106,17 +95,17 @@ export type EnumValueData = {
 
 export type InterfaceDefinitionData = {
   name: string;
-  children: InterfaceValueData[];
+  children: PropData[];
   comment?: CommentData;
   kind: TypeDocKind;
 };
 
-export type InterfaceValueData = {
-  name: string;
+// Classes section
+
+export type ClassDefinitionData = InterfaceDefinitionData & {
+  extendedTypes?: TypeDefinitionData[];
   type?: TypeDefinitionData;
-  flags?: TypePropertyDataFlags;
-  comment?: CommentData;
-} & MethodDefinitionData;
+};
 
 // Methods section
 
@@ -133,7 +122,7 @@ export type MethodSignatureData = {
   type: TypeDefinitionData;
 };
 
-// Props section
+// Properties section
 
 export type PropsDefinitionData = {
   name: string;
@@ -143,6 +132,7 @@ export type PropsDefinitionData = {
 
 export type PropData = {
   name: string;
+  kind?: TypeDocKind;
   comment?: CommentData;
   type: TypeDefinitionData;
   flags?: TypePropertyDataFlags;

--- a/docs/components/plugins/api/APIDataTypes.ts
+++ b/docs/components/plugins/api/APIDataTypes.ts
@@ -138,6 +138,7 @@ export type PropData = {
   flags?: TypePropertyDataFlags;
   defaultValue?: string;
   signatures?: MethodSignatureData[];
+  overwrites?: TypeDefinitionData;
 };
 
 export type DefaultPropsDefinitionData = {

--- a/docs/components/plugins/api/APISectionClasses.tsx
+++ b/docs/components/plugins/api/APISectionClasses.tsx
@@ -1,0 +1,111 @@
+import { css } from '@emotion/react';
+import React from 'react';
+
+import { InlineCode } from '~/components/base/code';
+import { UL, LI } from '~/components/base/list';
+import { B, P } from '~/components/base/paragraph';
+import { H2, H4, H3Code } from '~/components/plugins/Headings';
+import {
+  ClassDefinitionData,
+  CommentData,
+  GeneratedData,
+  MethodSignatureData,
+  PropData,
+} from '~/components/plugins/api/APIDataTypes';
+import {
+  CommentTextBlock,
+  listParams,
+  mdInlineComponents,
+  renderParam,
+  renderTypeOrSignatureType,
+  resolveTypeName,
+  STYLES_OPTIONAL,
+  TypeDocKind,
+} from '~/components/plugins/api/APISectionUtils';
+
+export type APISectionClassesProps = {
+  data: GeneratedData[];
+};
+
+const renderPropertyComment = (comment?: CommentData, signatures?: MethodSignatureData[]) => {
+  if (signatures && signatures.length) {
+    const { type, parameters, comment: signatureComment } = signatures[0];
+    return (
+      <>
+        <UL>
+          {parameters?.map(param => renderParam(param))}
+          <LI returnType>
+            <InlineCode>{resolveTypeName(type)}</InlineCode>
+          </LI>
+        </UL>
+        {signatureComment && (
+          <CommentTextBlock comment={signatureComment} components={mdInlineComponents} />
+        )}
+      </>
+    );
+  } else {
+    return comment ? <CommentTextBlock comment={comment} components={mdInlineComponents} /> : null;
+  }
+};
+
+const renderProperty = ({ name, signatures, flags, type, comment }: PropData) => (
+  <LI customCss={css({ marginBottom: 6 })}>
+    <B>
+      {name}
+      {signatures && signatures.length ? `(${listParams(signatures[0].parameters)})` : null}
+    </B>
+    {!signatures ? <>&emsp;{renderTypeOrSignatureType(type, signatures)}</> : null}
+    {flags?.isOptional ? <span css={STYLES_OPTIONAL}>&emsp;&bull;&emsp;optional</span> : null}
+    {!signatures ? <br /> : null}
+    {renderPropertyComment(comment, signatures)}
+  </LI>
+);
+
+const renderClass = ({
+  name,
+  comment,
+  type,
+  extendedTypes,
+  children,
+}: ClassDefinitionData): JSX.Element => {
+  const properties = children?.filter(child => child.kind === TypeDocKind.Property);
+  const methods = children?.filter(child => child.kind === TypeDocKind.Method);
+  return (
+    <div key={`class-definition-${name}`}>
+      <H3Code>
+        <InlineCode>{name}</InlineCode>
+      </H3Code>
+      {extendedTypes?.length && (
+        <P>
+          <B>Type: </B>
+          {type ? <InlineCode>{resolveTypeName(type)}</InlineCode> : 'Class'}
+          <span> extends </span>
+          <InlineCode>{resolveTypeName(extendedTypes[0])}</InlineCode>
+        </P>
+      )}
+      <CommentTextBlock comment={comment} />
+      {properties?.length ? (
+        <>
+          <H4>Properties:</H4>
+          <UL>{properties.map(child => renderProperty(child))}</UL>
+        </>
+      ) : null}
+      {methods?.length ? (
+        <>
+          <H4>Methods:</H4>
+          <UL>{methods.map(child => renderProperty(child))}</UL>
+        </>
+      ) : null}
+    </div>
+  );
+};
+
+const APISectionClasses = ({ data }: APISectionClassesProps) =>
+  data?.length ? (
+    <>
+      <H2 key="classes-header">Classes</H2>
+      {data.map(cls => renderClass(cls))}
+    </>
+  ) : null;
+
+export default APISectionClasses;

--- a/docs/components/plugins/api/APISectionClasses.tsx
+++ b/docs/components/plugins/api/APISectionClasses.tsx
@@ -49,7 +49,7 @@ const renderPropertyComment = (comment?: CommentData, signatures?: MethodSignatu
 };
 
 const renderProperty = ({ name, signatures, flags, type, comment }: PropData) => (
-  <LI customCss={css({ marginBottom: 6 })}>
+  <LI customCss={css({ marginBottom: 6 })} key={`class-property-${name}`}>
     <B>
       {name}
       {signatures && signatures.length ? `(${listParams(signatures[0].parameters)})` : null}
@@ -68,8 +68,10 @@ const renderClass = ({
   extendedTypes,
   children,
 }: ClassDefinitionData): JSX.Element => {
-  const properties = children?.filter(child => child.kind === TypeDocKind.Property);
-  const methods = children?.filter(child => child.kind === TypeDocKind.Method);
+  const properties = children?.filter(
+    child => child.kind === TypeDocKind.Property && !child.overwrites
+  );
+  const methods = children?.filter(child => child.kind === TypeDocKind.Method && !child.overwrites);
   return (
     <div key={`class-definition-${name}`}>
       <H3Code>

--- a/docs/components/plugins/api/APISectionComponents.tsx
+++ b/docs/components/plugins/api/APISectionComponents.tsx
@@ -5,7 +5,7 @@ import { B, P } from '~/components/base/paragraph';
 import { H2, H3Code } from '~/components/plugins/Headings';
 import {
   GeneratedData,
-  MethodDefinitionData,
+  PropData,
   PropsDefinitionData,
 } from '~/components/plugins/api/APIDataTypes';
 import APISectionProps from '~/components/plugins/api/APISectionProps';
@@ -16,10 +16,10 @@ export type APISectionComponentsProps = {
   componentsProps: PropsDefinitionData[];
 };
 
-const getComponentName = (name?: string, children: MethodDefinitionData[] = []) => {
+const getComponentName = (name?: string, children: PropData[] = []) => {
   if (name && name !== 'default') return name;
-  const ctor = children.filter((child: MethodDefinitionData) => child.name === 'constructor')[0];
-  return ctor.signatures[0]?.type?.name || 'default';
+  const ctor = children.filter((child: PropData) => child.name === 'constructor')[0];
+  return ctor && ctor?.signatures?.length ? ctor?.signatures[0]?.type?.name : 'default';
 };
 
 const renderComponent = (

--- a/docs/components/plugins/api/APISectionInterfaces.tsx
+++ b/docs/components/plugins/api/APISectionInterfaces.tsx
@@ -6,8 +6,8 @@ import { H2, H3Code } from '~/components/plugins/Headings';
 import {
   CommentData,
   InterfaceDefinitionData,
-  InterfaceValueData,
   MethodSignatureData,
+  PropData,
 } from '~/components/plugins/api/APIDataTypes';
 import {
   CommentTextBlock,
@@ -46,7 +46,7 @@ const renderInterfacePropertyRow = ({
   type,
   comment,
   signatures,
-}: InterfaceValueData): JSX.Element => (
+}: PropData): JSX.Element => (
   <tr key={name}>
     <td>
       <B>

--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -26,6 +26,7 @@ export enum TypeDocKind {
   Class = 128,
   Interface = 256,
   Property = 1024,
+  Method = 2048,
   TypeAlias = 4194304,
 }
 
@@ -117,8 +118,6 @@ export const resolveTypeName = ({
   declaration,
   value,
   queryType,
-  checkType,
-  extendsType,
 }: TypeDefinitionData): string | JSX.Element | (string | JSX.Element)[] => {
   try {
     if (name) {


### PR DESCRIPTION
# Why

The last, big missing piecie in the auto generated API rendering in docs were classes, due to some degree of complexity and sparse usage in Expo codebase.

# How

This PR adds an initial support for rendering class types in `ApiSection` components. 

I have worked on this feature along side the `expo-google-sign-in` package conversion, but unfortunately there are other problem which I had solve before I can push the conversion, so I have decided to extract classes support to the separate PR.

The presentation/formatting isn't final and will be improved in time. This is how the classes are displayed on `GoogleSignIn` page right now:
* https://docs.expo.dev/versions/latest/sdk/google-sign-in/#googleauthdata

The changeset also includes API related types tweaks and simplifications.

# Test Plan

The changes have been tested by running docs website on `localhost`. The docs test runs were successful.

There is no page on which you can see the section, but it will change in time.

# Preview

<img width="874" alt="Screenshot 2021-10-11 at 11 25 13" src="https://user-images.githubusercontent.com/719641/136766601-17e207cd-7e94-4322-8c60-655c6ebc16b9.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).