### PR TITLE
[iOS][Expo Go] Remove pre SDK 11 code path

### DIFF
--- a/ios/Exponent/Kernel/Core/EXKernel.m
+++ b/ios/Exponent/Kernel/Core/EXKernel.m
@@ -156,11 +156,6 @@ NSString * const kEXReloadActiveAppRequest = @"EXReloadActiveAppRequest";
     id batchedBridge = [destinationBridge batchedBridge];
     id moduleData = [batchedBridge moduleDataForName:moduleName];
     
-    // React Native before SDK 11 didn't strip the "RCT" prefix from module names
-    if (!moduleData && ![moduleName hasPrefix:@"RCT"]) {
-      moduleData = [batchedBridge moduleDataForName:[@"RCT" stringByAppendingString:moduleName]];
-    }
-    
     if (moduleData) {
       return [moduleData instance];
     }


### PR DESCRIPTION
This very old code path does not seem to be used anymore.

# Why

Extracted from #14690 as requested in https://github.com/expo/expo/pull/14690/files#r725231229

# How

N/A

# Test Plan

Expo Go compiles and run. Should not affect the codebase as it's a dead code path.
