### PR TITLE
[expo-updates] retain bridge delegate interceptor

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix `Updates.reloadAsync` behavior in bare apps when a new update is available (downloaded).
+
 ### 💡 Others
 
 ## 0.10.2 — 2021-10-01

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix `Updates.reloadAsync` behavior in bare apps when a new update is available (downloaded).
+- Fix `Updates.reloadAsync` behavior in bare apps when a new update is available (downloaded). ([#14706](https://github.com/expo/expo/pull/14706) by [@esamelson](https://github.com/esamelson))
 
 ### 💡 Others
 

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesAppDelegate.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesAppDelegate.m
@@ -21,6 +21,7 @@
 @interface EXUpdatesAppDelegate() <EXUpdatesAppControllerDelegate>
 
 @property (nonatomic, strong) NSDictionary *launchOptions;
+@property (nonatomic, strong) EXUpdatesBridgeDelegateInterceptor *bridgeDelegate;
 
 @end
 
@@ -95,10 +96,10 @@ EX_REGISTER_SINGLETON_MODULE(EXUpdatesAppDelegate)
   if (![UIApplication.sharedApplication.delegate conformsToProtocol:@protocol(RCTBridgeDelegate)]) {
     [NSException raise:NSInvalidArgumentException format:@"AppDelegate does not conforms to RCTBridgeDelegate"];
   }
-  EXUpdatesBridgeDelegateInterceptor* bridgeDelegate = [[EXUpdatesBridgeDelegateInterceptor alloc]
-                                                        initWithBridgeDelegate:(id<RCTBridgeDelegate>)UIApplication.sharedApplication.delegate];
+  self.bridgeDelegate = [[EXUpdatesBridgeDelegateInterceptor alloc]
+                         initWithBridgeDelegate:(id<RCTBridgeDelegate>)UIApplication.sharedApplication.delegate];
 
-  RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:bridgeDelegate launchOptions:self.launchOptions];
+  RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:self.bridgeDelegate launchOptions:self.launchOptions];
   RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge moduleName:@"main" initialProperties:nil];
   id rootViewBackgroundColor = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"RCTRootViewBackgroundColor"];
   if (rootViewBackgroundColor != nil) {


### PR DESCRIPTION
# Why

Ran into an issue with updates reload functionality while testing some unrelated changes for error recovery. Currently, reloading does not work properly when there is a new update downloaded locally and the `sourceURLForBridge` is different than it was when the app was first started. In this case, reload happens, but the source URL is not updated correctly, so we are actually running the old bundle when the rest of the expo-updates code thinks we are running the new update. (This is a bit of an edge case, but turns out to be very bad for error recovery!)

Debugged with breakpoints and traced the issue to this line, which was getting `nil` instead of the new source URL:
https://github.com/expo/react-native/blob/042b9c6b1a4f1590c6e395008b9b0f9f8c10385b/React/Base/RCTBridge.m#L340
and realized that the bridge delegate interceptor is being garbage collected too soon, so the call never makes it to `EXUpdatesAppController`.

# How

Retain the bridge delegate interceptor in EXUpdatesAppDelegate. (Is this the right place to retain it?)

# Test Plan

This situation is a bit of a pain to test; you need to download a new update after having launched the app and then be able to call `Updates.reloadAsync` from JS. I used the following steps:

- Init bare app
- Add a button in JS that calls `Updates.reloadAsync()`
- Make a local release build in Xcode
- Make some change in JS and publish a new update
- Swipe the app closed, then reopen it once. You should still see the old update while the new one downloads in the background
- Wait a second or two for the update to download, then press reload. With this change implemented, we correctly see the new update instead of the old one ✅ 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).