### PR TITLE
[android][expo-file-system] Fix buffer usage for compatibility with RN 0.65.1

### DIFF
--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix buffer usage for compatibility with RN 0.65.1
+
 ### 💡 Others
 
 ## 13.0.1 — 2021-10-01

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix buffer usage for compatibility with RN 0.65.1
+- Fix buffer usage for compatibility with RN 0.65.1 ([#14714](https://github.com/expo/expo/pull/14714) by [@hannojg](https://github.com/hannojg))
 
 ### 💡 Others
 

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/CountingRequestBody.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/CountingRequestBody.kt
@@ -1,11 +1,7 @@
 package expo.modules.filesystem
 
 import okhttp3.RequestBody
-import okio.Buffer
-import okio.BufferedSink
-import okio.ForwardingSink
-import okio.Okio
-import okio.Sink
+import okio.*
 import java.io.IOException
 
 @FunctionalInterface
@@ -44,7 +40,7 @@ class CountingRequestBody(
 
   override fun writeTo(sink: BufferedSink) {
     val countingSink = CountingSink(sink, this, progressListener)
-    val bufferedSink = Okio.buffer(countingSink)
+    val bufferedSink = countingSink.buffer()
     requestBody.writeTo(bufferedSink)
     bufferedSink.flush()
   }


### PR DESCRIPTION
# Why

When upgraded to expo SDK 43 and thus expo-file-system to 13.0.1 I couldn't build the android project due to this error.
Note: I am using react native 0.65.1 and I think the okio version has been changed there.

# How

It works in accordance to the new okio lib.

# Test Plan
🤷‍♂️ 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).