### PR TITLE
[expo-updates] add iOS database migration for error recovery fields

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### 🛠 Breaking changes
 
 - Add local SQLite fields for error recovery manager on iOS. ([#14610](https://github.com/expo/expo/pull/14610) by [@esamelson](https://github.com/esamelson))
-- Add DB migration for above.
+- Add DB migration for above. ([#14718](https://github.com/expo/expo/pull/14718) by [@esamelson](https://github.com/esamelson))
 
 ### 🎉 New features
 

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 🛠 Breaking changes
 
 - Add local SQLite fields for error recovery manager on iOS. ([#14610](https://github.com/expo/expo/pull/14610) by [@esamelson](https://github.com/esamelson))
+- Add DB migration for above.
 
 ### 🎉 New features
 

--- a/packages/expo-updates/ios/EXUpdates/Database/Migrations/EXUpdatesDatabaseMigration6To7.h
+++ b/packages/expo-updates/ios/EXUpdates/Database/Migrations/EXUpdatesDatabaseMigration6To7.h
@@ -1,0 +1,11 @@
+//  Copyright © 2021 650 Industries. All rights reserved.
+
+#import <EXUpdates/EXUpdatesDatabaseMigration.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface EXUpdatesDatabaseMigration6To7 : NSObject <EXUpdatesDatabaseMigration>
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/ios/EXUpdates/Database/Migrations/EXUpdatesDatabaseMigration6To7.m
+++ b/packages/expo-updates/ios/EXUpdates/Database/Migrations/EXUpdatesDatabaseMigration6To7.m
@@ -1,0 +1,64 @@
+//  Copyright © 2021 650 Industries. All rights reserved.
+
+#import <EXUpdates/EXUpdatesDatabaseMigration6To7.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+static NSString * const EXUpdatesDatabaseV6Filename = @"expo-v6.db";
+
+@implementation EXUpdatesDatabaseMigration6To7
+
+- (NSString *)filename
+{
+  return EXUpdatesDatabaseV6Filename;
+}
+
+- (BOOL)runMigrationOnDatabase:(struct sqlite3 *)db error:(NSError ** _Nullable)error
+{
+  // https://www.sqlite.org/lang_altertable.html#otheralter
+  if (sqlite3_exec(db, "PRAGMA foreign_keys=OFF;", NULL, NULL, NULL) != SQLITE_OK) return NO;
+  if (sqlite3_exec(db, "BEGIN;", NULL, NULL, NULL) != SQLITE_OK) return NO;
+
+  if (![self _safeExecOrRollback:db sql:@"CREATE TABLE \"new_updates\" (\
+        \"id\"  BLOB UNIQUE,\
+        \"scope_key\"  TEXT NOT NULL,\
+        \"commit_time\"  INTEGER NOT NULL,\
+        \"runtime_version\"  TEXT NOT NULL,\
+        \"launch_asset_id\" INTEGER,\
+        \"manifest\"  TEXT,\
+        \"status\"  INTEGER NOT NULL,\
+        \"keep\"  INTEGER NOT NULL,\
+        \"last_accessed\"  INTEGER NOT NULL,\
+        \"successful_launch_count\"  INTEGER NOT NULL,\
+        \"failed_launch_count\"  INTEGER NOT NULL,\
+        PRIMARY KEY(\"id\"),\
+        FOREIGN KEY(\"launch_asset_id\") REFERENCES \"assets\"(\"id\") ON DELETE CASCADE\
+        )"]) return NO;
+
+  // insert `1` for successful_launch_count for all existing updates
+  // to make sure we don't roll back past them
+  if (![self _safeExecOrRollback:db
+                             sql:@"INSERT INTO `new_updates` (`id`, `scope_key`, `commit_time`, `runtime_version`, `launch_asset_id`, `manifest`, `status`, `keep`, `last_accessed`, `successful_launch_count`, `failed_launch_count`)\
+        SELECT `id`, `scope_key`, `commit_time`, `runtime_version`, `launch_asset_id`, `manifest`, `status`, `keep`, `last_accessed`, 1 AS `successful_launch_count`, 0 AS `failed_launch_count` FROM `updates`"]) return NO;
+  if (![self _safeExecOrRollback:db sql:@"DROP TABLE `updates`"]) return NO;
+  if (![self _safeExecOrRollback:db sql:@"ALTER TABLE `new_updates` RENAME TO `updates`"]) return NO;
+  if (![self _safeExecOrRollback:db sql:@"CREATE UNIQUE INDEX \"index_updates_scope_key_commit_time\" ON \"updates\" (\"scope_key\", \"commit_time\")"]) return NO;
+  if (![self _safeExecOrRollback:db sql:@"CREATE INDEX \"index_updates_launch_asset_id\" ON \"updates\" (\"launch_asset_id\")"]) return NO;
+
+  if (sqlite3_exec(db, "COMMIT;", NULL, NULL, NULL) != SQLITE_OK) return NO;
+  if (sqlite3_exec(db, "PRAGMA foreign_keys=ON;", NULL, NULL, NULL) != SQLITE_OK) return NO;
+  return YES;
+}
+
+- (BOOL)_safeExecOrRollback:(struct sqlite3 *)db sql:(NSString *)sql
+{
+  if (sqlite3_exec(db, sql.UTF8String, NULL, NULL, NULL) != SQLITE_OK) {
+    sqlite3_exec(db, "ROLLBACK;", NULL, NULL, NULL);
+    return NO;
+  }
+  return YES;
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/ios/EXUpdates/Database/Migrations/EXUpdatesDatabaseMigrationRegistry.m
+++ b/packages/expo-updates/ios/EXUpdates/Database/Migrations/EXUpdatesDatabaseMigrationRegistry.m
@@ -4,6 +4,7 @@
 
 #import <EXUpdates/EXUpdatesDatabaseMigration4To5.h>
 #import <EXUpdates/EXUpdatesDatabaseMigration5To6.h>
+#import <EXUpdates/EXUpdatesDatabaseMigration6To7.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -14,11 +15,11 @@ NS_ASSUME_NONNULL_BEGIN
   // migrations should be added here in the order they should be performed (e.g. oldest first)
   return @[
     [EXUpdatesDatabaseMigration4To5 new],
-    [EXUpdatesDatabaseMigration5To6 new]
+    [EXUpdatesDatabaseMigration5To6 new],
+    [EXUpdatesDatabaseMigration6To7 new]
   ];
 }
 
 @end
 
 NS_ASSUME_NONNULL_END
-

--- a/packages/expo-updates/ios/Tests/EXUpdatesDatabaseInitializationTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesDatabaseInitializationTests.m
@@ -268,8 +268,8 @@ CREATE INDEX \"index_json_data_scope_key\" ON \"json_data\" (\"scope_key\")\
   XCTAssertEqual(1, [EXUpdatesDatabaseUtils executeSql:updatesAssetsSql3 withArgs:nil onDatabase:migratedDb error:nil].count);
 
   // make sure multiple migrations are running
-  NSString * const lastAccessedSql1 = @"SELECT DISTINCT `last_accessed` FROM `updates` WHERE `last_accessed` IS NOT NULL";
-  XCTAssertEqual(1, [EXUpdatesDatabaseUtils executeSql:lastAccessedSql1 withArgs:nil onDatabase:migratedDb error:nil].count);
+  NSString * const lastAccessedSql = @"SELECT DISTINCT `last_accessed` FROM `updates` WHERE `last_accessed` IS NOT NULL";
+  XCTAssertEqual(1, [EXUpdatesDatabaseUtils executeSql:lastAccessedSql withArgs:nil onDatabase:migratedDb error:nil].count);
   NSString * const successfulLaunchCountSql = @"SELECT * FROM `updates` WHERE `successful_launch_count` = 1";
   XCTAssertEqual(2, [EXUpdatesDatabaseUtils executeSql:successfulLaunchCountSql withArgs:nil onDatabase:migratedDb error:nil].count);
 }

--- a/packages/expo-updates/ios/Tests/EXUpdatesDatabaseInitializationTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesDatabaseInitializationTests.m
@@ -5,6 +5,7 @@
 #import <EXUpdates/EXUpdatesDatabaseInitialization+Tests.h>
 #import <EXUpdates/EXUpdatesDatabaseMigration4To5.h>
 #import <EXUpdates/EXUpdatesDatabaseMigration5To6.h>
+#import <EXUpdates/EXUpdatesDatabaseMigration6To7.h>
 #import <EXUpdates/EXUpdatesDatabaseUtils.h>
 
 #import <sqlite3.h>
@@ -267,8 +268,10 @@ CREATE INDEX \"index_json_data_scope_key\" ON \"json_data\" (\"scope_key\")\
   XCTAssertEqual(1, [EXUpdatesDatabaseUtils executeSql:updatesAssetsSql3 withArgs:nil onDatabase:migratedDb error:nil].count);
 
   // make sure multiple migrations are running
-  NSString * const lastAccessedSql1 = @"SELECT DISTINCT last_accessed FROM `updates`";
+  NSString * const lastAccessedSql1 = @"SELECT DISTINCT `last_accessed` FROM `updates` WHERE `last_accessed` IS NOT NULL";
   XCTAssertEqual(1, [EXUpdatesDatabaseUtils executeSql:lastAccessedSql1 withArgs:nil onDatabase:migratedDb error:nil].count);
+  NSString * const successfulLaunchCountSql = @"SELECT * FROM `updates` WHERE `successful_launch_count` = 1";
+  XCTAssertEqual(2, [EXUpdatesDatabaseUtils executeSql:successfulLaunchCountSql withArgs:nil onDatabase:migratedDb error:nil].count);
 }
 
 - (void)testMigration4To5
@@ -448,6 +451,119 @@ CREATE INDEX \"index_json_data_scope_key\" ON \"json_data\" (\"scope_key\")\
   // try to insert an update with a non-existent launch asset id (47)
   NSString * const foreignKeyInsertBadSql1 = @"INSERT INTO \"updates\" (\"id\",\"scope_key\",\"commit_time\",\"runtime_version\",\"launch_asset_id\",\"manifest\",\"status\",\"keep\", \"last_accessed\") VALUES\
   (X'E1AC9D5F55E041BBA5A9193DD1C1123A','https://exp.host/@esamelson/sdk41updates',1620168547318,'41.0.0',47,NULL,1,1,1619647642456)";
+  NSError *foreignKeyError1;
+  [EXUpdatesDatabaseUtils executeSql:foreignKeyInsertBadSql1 withArgs:nil onDatabase:migratedDb error:&foreignKeyError1];
+  XCTAssertNotNil(foreignKeyError1);
+  XCTAssertEqual(787, foreignKeyError1.code); // SQLITE_CONSTRAINT_FOREIGNKEY
+
+  // try to insert an entry in updates_assets that references a nonexistent update
+  NSString * const foreignKeyInsertBadSql2 = @"INSERT INTO `updates_assets` (`update_id`, `asset_id`) VALUES (X'3CF0A835CB3A4A5D9C14DFA3D55DE44D', 3)";
+  NSError *foreignKeyError2;
+  [EXUpdatesDatabaseUtils executeSql:foreignKeyInsertBadSql2 withArgs:nil onDatabase:migratedDb error:&foreignKeyError2];
+  XCTAssertNotNil(foreignKeyError2);
+  XCTAssertEqual(787, foreignKeyError2.code); // SQLITE_CONSTRAINT_FOREIGNKEY
+
+  // test updates on delete cascade
+  NSString * const deleteSql = @"DELETE FROM `assets` WHERE `id` = 3";
+  NSString * const selectDeletedSql1 = @"SELECT * FROM `updates` WHERE `id` = X'8C263F9DE3FF48888496E3244C788661'";
+  [EXUpdatesDatabaseUtils executeSql:deleteSql withArgs:nil onDatabase:migratedDb error:nil];
+  XCTAssertEqual(0, [EXUpdatesDatabaseUtils executeSql:selectDeletedSql1 withArgs:nil onDatabase:migratedDb error:nil].count);
+
+  // test updates_assets on delete cascade
+  // previous deletion should have deleted the update, which then should have deleted both entries in updates_assets
+  NSString * const selectDeletedSql2 = @"SELECT * FROM `updates_assets` WHERE `update_id` = X'8C263F9DE3FF48888496E3244C788661' AND `asset_id` = 2";
+  XCTAssertEqual(0, [EXUpdatesDatabaseUtils executeSql:selectDeletedSql2 withArgs:nil onDatabase:migratedDb error:nil].count);
+  NSString * const selectDeletedSql3 = @"SELECT * FROM `updates_assets` WHERE `update_id` = X'8C263F9DE3FF48888496E3244C788661' AND `asset_id` = 3";
+  XCTAssertEqual(0, [EXUpdatesDatabaseUtils executeSql:selectDeletedSql3 withArgs:nil onDatabase:migratedDb error:nil].count);
+}
+
+- (void)testMigration6To7
+{
+  sqlite3 *db;
+  NSError *initializeError;
+  [EXUpdatesDatabaseInitialization initializeDatabaseWithSchema:EXUpdatesDatabaseV6Schema
+                                                       filename:@"expo-v6.db"
+                                                    inDirectory:_testDatabaseDir
+                                                  shouldMigrate:NO
+                                                     migrations:@[]
+                                                       database:&db
+                                                          error:&initializeError];
+  XCTAssertNil(initializeError);
+
+  // insert test data
+  NSString * const insertAssetsSql = @"INSERT INTO \"assets\" (\"id\",\"url\",\"key\",\"headers\",\"type\",\"metadata\",\"download_time\",\"relative_path\",\"hash\",\"hash_type\",\"marked_for_deletion\") VALUES\
+  (2,'https://url.to/b56cf690e0afa93bd4dc7756d01edd3e','b56cf690e0afa93bd4dc7756d01edd3e.png',NULL,'image/png',NULL,1614137309295,'b56cf690e0afa93bd4dc7756d01edd3e.png','c4fdfc2ec388025067a0f755bda7731a0a868a2be79c84509f4de4e40d23161b',0,0),\
+  (3,'https://url.to/bundle-1614137308871','bundle-1614137308871',NULL,'application/javascript',NULL,1614137309513,'bundle-1614137308871','e4d658861e85e301fb89bcfc49c42738ebcc0f9d5c979e037556435f44a27aa2',0,0),\
+  (4,NULL,NULL,NULL,'js',NULL,1614137406588,'bundle-1614137401950','6ff4ee75b48a21c7a9ed98015ff6bfd0a47b94cd087c5e2258262e65af239952',0,0);";
+  NSString * const insertUpdatesSql = @"INSERT INTO \"updates\" (\"id\",\"scope_key\",\"commit_time\",\"runtime_version\",\"launch_asset_id\",\"manifest\",\"status\",\"keep\", \"last_accessed\") VALUES\
+  (X'8C263F9DE3FF48888496E3244C788661','http://192.168.4.44:3000',1614137308871,'40.0.0',3,'{\\\"metadata\\\":{\\\"updateGroup\\\":\\\"34993d39-57e6-46cf-8fa2-eba836f40828\\\",\\\"branchName\\\":\\\"rollout\\\"}}',1,1,1619647642456),\
+  (X'594100ea066e4804b5c7c907c773f980','http://192.168.4.44:3000',1614137401950,'40.0.0',4,NULL,1,1,1619647642457);";
+  NSString * const insertUpdatesAssetsSql = @"INSERT INTO \"updates_assets\" (\"update_id\",\"asset_id\") VALUES\
+  (X'8C263F9DE3FF48888496E3244C788661',2),\
+  (X'8C263F9DE3FF48888496E3244C788661',3),\
+  (X'594100ea066e4804b5c7c907c773f980',4);";
+  NSError *insertAssetsError;
+  [EXUpdatesDatabaseUtils executeSql:insertAssetsSql withArgs:nil onDatabase:db error:&insertAssetsError];
+  NSError *insertUpdatesError;
+  [EXUpdatesDatabaseUtils executeSql:insertUpdatesSql withArgs:nil onDatabase:db error:&insertUpdatesError];
+  NSError *insertUpdatesAssetsError;
+  [EXUpdatesDatabaseUtils executeSql:insertUpdatesAssetsSql withArgs:nil onDatabase:db error:&insertUpdatesAssetsError];
+  XCTAssert(!insertAssetsError && !insertUpdatesError && !insertUpdatesAssetsError);
+
+  sqlite3_close(db);
+
+  // initialize a new database object the normal way and run migrations
+  sqlite3 *migratedDb;
+  NSError *migrateError;
+  [EXUpdatesDatabaseInitialization initializeDatabaseWithLatestSchemaInDirectory:_testDatabaseDir
+                                                                        database:&migratedDb
+                                                                      migrations:@[[EXUpdatesDatabaseMigration6To7 new]]
+                                                                           error:&migrateError];
+  XCTAssertNil(migrateError);
+
+  // verify data integrity
+  NSString * const updatesSql1 = @"SELECT * FROM `updates` WHERE `id` = X'8C263F9DE3FF48888496E3244C788661' AND `scope_key` = 'http://192.168.4.44:3000' AND `commit_time` = 1614137308871 AND `runtime_version` = '40.0.0' AND `launch_asset_id` = 3 AND `manifest` IS NOT NULL AND `status` = 1 AND `keep` = 1 AND `last_accessed` = 1619647642456 AND `successful_launch_count` = 1 AND `failed_launch_count` = 0";
+  XCTAssertEqual(1, [EXUpdatesDatabaseUtils executeSql:updatesSql1 withArgs:nil onDatabase:migratedDb error:nil].count);
+  NSString * const updatesSql2 = @"SELECT * FROM `updates` WHERE `id` = X'594100ea066e4804b5c7c907c773f980' AND `scope_key` = 'http://192.168.4.44:3000' AND `commit_time` = 1614137401950 AND `runtime_version` = '40.0.0' AND `launch_asset_id` = 4 AND `manifest` IS NULL AND `status` = 1 AND `keep` = 1 AND `last_accessed` = 1619647642457 AND `successful_launch_count` = 1 AND `failed_launch_count` = 0";
+  XCTAssertEqual(1, [EXUpdatesDatabaseUtils executeSql:updatesSql2 withArgs:nil onDatabase:migratedDb error:nil].count);
+
+  NSString * const assetsSql1 = @"SELECT * FROM `assets` WHERE `id` = 2 AND `url` = 'https://url.to/b56cf690e0afa93bd4dc7756d01edd3e' AND `key` = 'b56cf690e0afa93bd4dc7756d01edd3e.png' AND `headers` IS NULL AND `type` = 'image/png' AND `metadata` IS NULL AND `download_time` = 1614137309295 AND `relative_path` = 'b56cf690e0afa93bd4dc7756d01edd3e.png' AND `hash` = 'c4fdfc2ec388025067a0f755bda7731a0a868a2be79c84509f4de4e40d23161b' AND `hash_type` = 0 AND `marked_for_deletion` = 0";
+  XCTAssertEqual(1, [EXUpdatesDatabaseUtils executeSql:assetsSql1 withArgs:nil onDatabase:migratedDb error:nil].count);
+  NSString * const assetsSql2 = @"SELECT * FROM `assets` WHERE `id` = 3 AND `url` = 'https://url.to/bundle-1614137308871' AND `key` = 'bundle-1614137308871' AND `headers` IS NULL AND `type` = 'application/javascript' AND `metadata` IS NULL AND `download_time` = 1614137309513 AND `relative_path` = 'bundle-1614137308871' AND `hash` = 'e4d658861e85e301fb89bcfc49c42738ebcc0f9d5c979e037556435f44a27aa2' AND `hash_type` = 0 AND `marked_for_deletion` = 0";
+  XCTAssertEqual(1, [EXUpdatesDatabaseUtils executeSql:assetsSql2 withArgs:nil onDatabase:migratedDb error:nil].count);
+  NSString * const assetsSql3 = @"SELECT * FROM `assets` WHERE `id` = 4 AND `url` IS NULL AND `key` IS NULL AND `headers` IS NULL AND `type` = 'js' AND `metadata` IS NULL AND `download_time` = 1614137406588 AND `relative_path` = 'bundle-1614137401950' AND `hash` = '6ff4ee75b48a21c7a9ed98015ff6bfd0a47b94cd087c5e2258262e65af239952' AND `hash_type` = 0 AND `marked_for_deletion` = 0";
+  XCTAssertEqual(1, [EXUpdatesDatabaseUtils executeSql:assetsSql3 withArgs:nil onDatabase:migratedDb error:nil].count);
+
+  NSString * const updatesAssetsSql1 = @"SELECT * FROM `updates_assets` WHERE `update_id` = X'8C263F9DE3FF48888496E3244C788661' AND `asset_id` = 2";
+  XCTAssertEqual(1, [EXUpdatesDatabaseUtils executeSql:updatesAssetsSql1 withArgs:nil onDatabase:migratedDb error:nil].count);
+  NSString * const updatesAssetsSql2 = @"SELECT * FROM `updates_assets` WHERE `update_id` = X'8C263F9DE3FF48888496E3244C788661' AND `asset_id` = 3";
+  XCTAssertEqual(1, [EXUpdatesDatabaseUtils executeSql:updatesAssetsSql2 withArgs:nil onDatabase:migratedDb error:nil].count);
+  NSString * const updatesAssetsSql3 = @"SELECT * FROM `updates_assets` WHERE `update_id` = X'594100ea066e4804b5c7c907c773f980' AND `asset_id` = 4";
+  XCTAssertEqual(1, [EXUpdatesDatabaseUtils executeSql:updatesAssetsSql3 withArgs:nil onDatabase:migratedDb error:nil].count);
+
+  // make sure successful_launch_count and failed_launch_count columns were filled in properly
+  NSString * const successfulLaunchCountSql = @"SELECT DISTINCT `successful_launch_count` FROM `updates`";
+  XCTAssertEqual(1, [EXUpdatesDatabaseUtils executeSql:successfulLaunchCountSql withArgs:nil onDatabase:migratedDb error:nil].count);
+  NSString * const failedLaunchCount = @"SELECT DISTINCT `failed_launch_count` FROM `updates`";
+  XCTAssertEqual(1, [EXUpdatesDatabaseUtils executeSql:failedLaunchCount withArgs:nil onDatabase:migratedDb error:nil].count);
+
+  // make sure we can modify successful and failed launch counts
+  NSError *modifySuccessfulLaunchCountError;
+  NSString * const modifySuccessfulLaunchCountSql = @"UPDATE `updates` SET `successful_launch_count` = 2 WHERE `id` = X'8C263F9DE3FF48888496E3244C788661';";
+  [EXUpdatesDatabaseUtils executeSql:modifySuccessfulLaunchCountSql withArgs:nil onDatabase:migratedDb error:&modifySuccessfulLaunchCountError];
+  XCTAssertNil(modifySuccessfulLaunchCountError);
+  NSError *modifyFailedLaunchCountError;
+  NSString * const modifyFailedLaunchCountSql = @"UPDATE `updates` SET `failed_launch_count` = 1 WHERE `id` = X'594100ea066e4804b5c7c907c773f980';";
+  [EXUpdatesDatabaseUtils executeSql:modifyFailedLaunchCountSql withArgs:nil onDatabase:migratedDb error:&modifyFailedLaunchCountError];
+  XCTAssertNil(modifyFailedLaunchCountError);
+  NSString * const checkFailedLaunchCountSql = @"SELECT `id` FROM `updates` WHERE `failed_launch_count` > 0";
+  XCTAssertEqual(1, [EXUpdatesDatabaseUtils executeSql:checkFailedLaunchCountSql withArgs:nil onDatabase:migratedDb error:nil].count);
+
+  // make sure foreign key constraints still work
+
+  // try to insert an update with a non-existent launch asset id (47)
+  NSString * const foreignKeyInsertBadSql1 = @"INSERT INTO \"updates\" (\"id\",\"scope_key\",\"commit_time\",\"runtime_version\",\"launch_asset_id\",\"manifest\",\"status\",\"keep\", \"last_accessed\",\"successful_launch_count\",\"failed_launch_count\") VALUES\
+  (X'E1AC9D5F55E041BBA5A9193DD1C1123A','https://exp.host/@esamelson/sdk41updates',1620168547318,'41.0.0',47,NULL,1,1,1619647642456,0,0)";
   NSError *foreignKeyError1;
   [EXUpdatesDatabaseUtils executeSql:foreignKeyInsertBadSql1 withArgs:nil onDatabase:migratedDb error:&foreignKeyError1];
   XCTAssertNotNil(foreignKeyError1);


### PR DESCRIPTION
# Why

follow up to #14610 - add a migration to add these new fields to existing DBs

# How

followed our new handy-dandy [migration guide](https://www.notion.so/expo/expo-updates-SQLite-migrations-b62aa6a5502b4b5eb4667bb4761d007b) 😄  and basically copied what I had done for the previous migration (which was also adding a column to the same table)

# Test Plan

Added a new unit test for the new migration, and ensured all existing tests still pass

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
