### PR TITLE
[sensors][Android] Remove error from `assertSubscriptionAlive` to prevent crash

### DIFF
--- a/packages/expo-sensors/CHANGELOG.md
+++ b/packages/expo-sensors/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix Android crash caused by `assertSubscriptionAlive` method ([#14720](https://github.com/expo/expo/pull/14720) by [@zakharchenkoAndrii](https://github.com/zakharchenkoAndrii))
+
 ### 💡 Others
 
 ## 10.2.2 — 2021-06-24

--- a/packages/expo-sensors/android/src/main/java/expo/modules/sensors/services/SensorServiceSubscription.java
+++ b/packages/expo-sensors/android/src/main/java/expo/modules/sensors/services/SensorServiceSubscription.java
@@ -19,7 +19,9 @@ public class SensorServiceSubscription implements SensorServiceSubscriptionInter
   }
 
   public void start() {
-    assertSubscriptionIsAlive();
+    if (mHasBeenReleased) {
+      return;
+    }
     if (!mIsEnabled) {
       mIsEnabled = true;
       mSubscribableSensorService.onSubscriptionEnabledChanged(this);
@@ -39,7 +41,9 @@ public class SensorServiceSubscription implements SensorServiceSubscriptionInter
   }
 
   public void setUpdateInterval(long updateInterval) {
-    assertSubscriptionIsAlive();
+    if (mHasBeenReleased) {
+      return;
+    }
     mUpdateInterval = updateInterval;
   }
 
@@ -54,12 +58,6 @@ public class SensorServiceSubscription implements SensorServiceSubscriptionInter
     if (!mHasBeenReleased) {
       mSubscribableSensorService.removeSubscription(this);
       mHasBeenReleased = true;
-    }
-  }
-
-  private void assertSubscriptionIsAlive() {
-    if (mHasBeenReleased) {
-      throw new IllegalStateException("Subscription has been released, cannot call methods on a released subscription.");
     }
   }
 }


### PR DESCRIPTION
# Why

Resolves #6204 

PR Fixes android crash that is produced by assertSubscriptionIsAlive.

```
java.lang.IllegalStateException: Subscription has been released, cannot call methods on a released subscription.
    at expo.modules.sensors.services.SensorServiceSubscription.assertSubscriptionIsAlive(SensorServiceSubscription.java:60)
    at expo.modules.sensors.services.SensorServiceSubscription.start(SensorServiceSubscription.java:20)
    at expo.modules.sensors.modules.BaseSensorModule.onHostResume(BaseSensorModule.java:98)
    at org.unimodules.adapters.react.services.UIManagerModuleWrapper$3.onHostResume(UIManagerModuleWrapper.java:127)
    at com.facebook.react.bridge.ReactContext.onHostResume(ReactContext.java:240)
    at com.facebook.react.ReactInstanceManager.moveToResumedLifecycleState(ReactInstanceManager.java:715)
    at com.facebook.react.ReactInstanceManager.onHostResume(ReactInstanceManager.java:619)
    at com.facebook.react.ReactInstanceManager.onHostResume(ReactInstanceManager.java:576)
    at com.facebook.react.ReactDelegate.onHostResume(ReactDelegate.java:53)
    at com.facebook.react.ReactActivityDelegate.onResume(ReactActivityDelegate.java:99)
    at com.facebook.react.ReactActivity.onResume(ReactActivity.java:57)
    at android.app.Instrumentation.callActivityOnResume(Instrumentation.java:1308)
    at android.app.Activity.performResume(Activity.java:6067)
    at android.app.ActivityThread.performResumeActivity(ActivityThread.java:3322)
    at android.app.ActivityThread.handleResumeActivity(ActivityThread.java:3374)
    at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1482)
    at android.os.Handler.dispatchMessage(Handler.java:106)
    at android.os.Looper.loop(Looper.java:209)
    at android.app.ActivityThread.main(ActivityThread.java:5900)
    at java.lang.reflect.Method.invoke(Method.java)
    at java.lang.reflect.Method.invoke(Method.java:372)
    at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1005)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:800)

java.lang.RuntimeException: Unable to resume activity {<redacted>/<redacted>.MainActivity}: java.lang.IllegalStateException: Subscription has been released, cannot call methods on a released subscription.
    at android.app.ActivityThread.performResumeActivity(ActivityThread.java:3343)
    at android.app.ActivityThread.handleResumeActivity(ActivityThread.java:3374)
    at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1482)
    at android.os.Handler.dispatchMessage(Handler.java:106)
    at android.os.Looper.loop(Looper.java:209)
    at android.app.ActivityThread.main(ActivityThread.java:5900)
    at java.lang.reflect.Method.invoke(Method.java)
    at java.lang.reflect.Method.invoke(Method.java:372)
    at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1005)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:800)
```

# How
Make the logic of platforms consistent. Android hard crashes while iOS silently fails. 
Silent return from the `assertSubscriptionIsAlive` method instead of crash seems like fix the problem. 

# Test Plan

For testing I called the `getSensorKernelServiceSubscription().release();` method `onHostPause`  instead of `onHostDestroy`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
