### PR TITLE
[docs] Fix web-client-id url in Authentication docs

### DIFF
--- a/docs/pages/guides/authentication.md
+++ b/docs/pages/guides/authentication.md
@@ -1187,7 +1187,7 @@ export default function App() {
   - Save "Web client ID" you'll need it later
   - Press Save
 - Replace `YOUR_GUID` with your "Web client ID" and open this link:
-  - https://console.developers.google.com/apis/credentials/oauthclient/YOUR_GUID.apps.googleusercontent.com
+  - https://console.developers.google.com/apis/credentials/oauthclient/YOUR_GUID
 - Under "URIs" add your hosts URLs
   - Web dev: https://localhost:19006
   - Expo Go Proxy: https://auth.expo.io


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
The Web client ID already contains '.apps.googleusercontent.com'

# How

<!--
How did you build this feature or fix this bug and why?
-->
**Not Applicable**

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
I checked my firebase console to verify 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
![Capture](https://user-images.githubusercontent.com/66824020/137124948-6a39e544-17d6-469b-976a-e7c3439ccbf4.PNG)

