### PR TITLE
[expo-go] add reload command for simulator builds only

### DIFF
--- a/ios/Exponent/Kernel/DevSupport/EXKernelDevKeyCommands.m
+++ b/ios/Exponent/Kernel/DevSupport/EXKernelDevKeyCommands.m
@@ -68,8 +68,54 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
 @interface EXKernelDevKeyCommands ()
 
 @property (nonatomic, strong) NSMutableSet<EXKeyCommand *> *commands;
++ (void)handleKeyboardEvent:(UIEvent *)event;
 
 @end
+
+#if TARGET_IPHONE_SIMULATOR
+@interface UIEvent (UIPhysicalKeyboardEvent)
+
+@property (nonatomic) NSString *_modifiedInput;
+@property (nonatomic) NSString *_unmodifiedInput;
+@property (nonatomic) UIKeyModifierFlags _modifierFlags;
+@property (nonatomic) BOOL _isKeyDown;
+@property (nonatomic) long _keyCode;
+
+@end
+
+@implementation UIApplication (EXKeyCommands)
+
+- (void)EX_handleKeyUIEventSwizzle:(UIEvent *)event
+{
+  BOOL interactionEnabled = !UIApplication.sharedApplication.isIgnoringInteractionEvents;
+  BOOL hasFirstResponder = NO;
+  
+  if (interactionEnabled) {
+    UIResponder *firstResponder = nil;
+    for (UIWindow *window in [self windows]) {
+      firstResponder = [window valueForKey:@"firstResponder"];
+      if (firstResponder) {
+        hasFirstResponder = YES;
+        break;
+      }
+    }
+    
+    
+    // Call the original swizzled method
+    [self EX_handleKeyUIEventSwizzle:event];
+    
+    if (firstResponder) {
+      BOOL isTextField = [firstResponder isKindOfClass: [UITextField class]] || [firstResponder isKindOfClass: [UITextView class]];
+      
+      if (!isTextField) {
+        [EXKernelDevKeyCommands handleKeyboardEvent:event];
+      }
+    }
+  }
+};
+
+@end
+#endif
 
 @implementation UIResponder (EXKeyCommands)
 
@@ -122,7 +168,32 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
   RCTSwapInstanceMethods([UIResponder class],
                          @selector(keyCommands),
                          @selector(EX_keyCommands));
+
+#if TARGET_IPHONE_SIMULATOR
+  SEL originalKeyboardSelector = NSSelectorFromString(@"handleKeyUIEvent:");
+  RCTSwapInstanceMethods([UIApplication class],
+                         originalKeyboardSelector,
+                         @selector(EX_handleKeyUIEventSwizzle:));
+#endif
 }
+
+#if TARGET_IPHONE_SIMULATOR
++(void)handleKeyboardEvent:(UIEvent *)event
+{
+  static NSTimeInterval lastCommand = 0;
+
+  if (event._isKeyDown) {
+    if (CACurrentMediaTime() - lastCommand > 0.5) {
+      NSString *input = event._modifiedInput;
+      if ([input isEqualToString: @"r"]) {
+        [[EXKernel sharedInstance] reloadVisibleApp];
+      }
+      
+      lastCommand = CACurrentMediaTime();
+    }
+  }
+}
+#endif
 
 - (instancetype)init
 {


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

We've had to revert updates to the reload command because they access private APIs that are rejected by App Store reviews, however we can still include these commands (perhaps more useful anyways) on simulator builds only. 

# How

<!--
How did you build this feature or fix this bug and why?
-->

Wrapped the code in question with the `TARGET_IPHONE_SIMULATOR` macro so that it is stripped from production (archived) builds

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Reload command should work on simulator builds by using the `r` key on your keyboard. This shouldn't be applied when a text input is focused. Should not appear in the Expo Go archived build, although I'm not quite sure how to go about verifying this (inspect with the `strings` command maybe?) @brentvatne your thoughts on this would be appreciated

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
