### PR TITLE
[core] Fix UIManager has not setter or ivar error when reloading app

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix UIManager has not setter or ivar error when reloading app. ([#14741](https://github.com/expo/expo/pull/14741) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 0.4.2 — 2021-10-01

--- a/packages/expo-modules-core/ios/NativeModulesProxy/EXNativeModulesProxy.m
+++ b/packages/expo-modules-core/ios/NativeModulesProxy/EXNativeModulesProxy.m
@@ -245,8 +245,8 @@ RCT_EXPORT_METHOD(callMethod:(NSString *)moduleName methodNameOrKey:(id)methodNa
   }
 
   // `registerAdditionalModuleClasses:` call below is not thread-safe if RCTUIManager is not initialized.
-  // The case happens especially with reanimated which access `bridge.uiManager` and intialize bridge in js thread.
-  // Accessing uiManager here, we try to make sure RCTUIManager is initiailized.
+  // The case happens especially with reanimated which accesses `bridge.uiManager` and initialize bridge in js thread.
+  // Accessing uiManager here, we try to make sure RCTUIManager is initialized.
   [bridge uiManager];
 
   // Register the view managers as additional modules.

--- a/packages/expo-modules-core/ios/NativeModulesProxy/EXNativeModulesProxy.m
+++ b/packages/expo-modules-core/ios/NativeModulesProxy/EXNativeModulesProxy.m
@@ -244,6 +244,11 @@ RCT_EXPORT_METHOD(callMethod:(NSString *)moduleName methodNameOrKey:(id)methodNa
     }
   }
 
+  // `registerAdditionalModuleClasses:` call below is not thread-safe if RCTUIManager is not initialized.
+  // The case happens especially with reanimated which access `bridge.uiManager` and intialize bridge in js thread.
+  // Accessing uiManager here, we try to make sure RCTUIManager is initiailized.
+  [bridge uiManager];
+
   // Register the view managers as additional modules.
   [bridge registerAdditionalModuleClasses:additionalModuleClasses];
 


### PR DESCRIPTION
# Why

close [ENG-2132](https://linear.app/expo/issue/ENG-2132/[beta]-warning-on-load-and-quickly-reloading-bare-app-causes-exception)

this is a race condition issue happening with expo-modules-core + reanimated. the error is actually from exception `*** Collection <__NSArrayM: 0x600000ef6910> was mutated while being enumerated.`, `_bridge.moduleClasses`  enumeration inside RCTUIManager `setBridge:`. 

when RCTUIManager is not initialized yet, the first one to access `bridge.uiManager` will do the initialization. in this case, it's reanimated in js thread.


![Screen Shot 2021-10-14 at 8 07 22 PM](https://user-images.githubusercontent.com/46429/137314295-3e8c18a5-89d0-4adf-8d68-6ea7d07cbc36.png)

expo-modules-core at the same time, mutates moduleClasses in main thread.

![Screen Shot 2021-10-14 at 8 06 32 PM](https://user-images.githubusercontent.com/46429/137314133-160b83be-3647-4c17-b7c6-b2a51d631515.png)


# How

accessing `bridge.uiManager` and make sure it's initialized before calling `registerAdditionalModuleClasses:`

# Test Plan

```
EXPO_BETA=1 expo init sdk43
# select bare minimal
# patch `node_modules/expo-modules-core/ios/NativeModulesProxy/EXNativeModulesProxy.m`
expo run:ios
# keep pressing `r` key to reload app and see if the `UIManager has not setter or ivar error when reloading app` redbox happens
```

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
