### PR TITLE
[print] Support loading local fonts on iOS

### DIFF
--- a/apps/native-component-list/src/screens/PrintScreen.tsx
+++ b/apps/native-component-list/src/screens/PrintScreen.tsx
@@ -138,9 +138,14 @@ export default class PrintScreen extends React.Component<{}, State> {
           <html>
             <head>
               <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no" />
+              @font-face {
+                font-family: SpaceMono;
+                font-weight: normal;
+                src: url(fonts/SpaceMono-Regular.ttf);
+              }
             </head>
             <body style="text-align: center;">
-              <h1 style="font-size: 50px; font-family: Helvetica Neue; font-weight: normal;">
+              <h1 style="font-size: 50px; font-family: SpaceMono; font-weight: normal;">
                 Hello Expo!
               </h1>
               <img

--- a/apps/native-component-list/src/utilities/loadAssetsAsync.ts
+++ b/apps/native-component-list/src/utilities/loadAssetsAsync.ts
@@ -6,13 +6,19 @@ import * as Font from 'expo-font';
 import { Platform } from 'react-native';
 
 async function loadAssetsAsync() {
+  const promise = Font.loadAsync({
+    'space-mono': require('../../assets/fonts/SpaceMono-Regular.ttf'),
+  });
+  promise.then((value) => {
+    const asset = Asset.fromModule(require('../../assets/fonts/SpaceMono-Regular.ttf'));
+    console.log('FONT LOADED: ', asset);
+  });
+
   const assetPromises: Promise<any>[] = [
     Asset.loadAsync(StackAssets),
     Font.loadAsync(Ionicons.font),
     Font.loadAsync(MaterialIcons.font),
-    Font.loadAsync({
-      'space-mono': require('../../assets/fonts/SpaceMono-Regular.ttf'),
-    }),
+    promise,
   ];
   if (Platform.OS !== 'web') {
     assetPromises.push(

--- a/packages/expo-print/CHANGELOG.md
+++ b/packages/expo-print/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Support loading local fonts on iOS ([#14742](https://github.com/expo/expo/pull/14742) by [@IjzerenHein](https://github.com/IjzerenHein))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-print/ios/EXPrint/EXWKPDFRenderer.m
+++ b/packages/expo-print/ios/EXPrint/EXWKPDFRenderer.m
@@ -22,7 +22,9 @@
   _onRenderingFinished = handler;
   _webView = [self createWebView];
   _renderer = [[EXWKSnapshotPDFRenderer alloc] init];
-  _htmlNavigation = [_webView loadHTMLString:htmlString baseURL:nil];
+  // https://stackoverflow.com/questions/47166517/use-custom-local-font-in-wkwebview
+  NSURL* baseURL = [[NSURL alloc]initFileURLWithPath:[[NSBundle mainBundle] resourcePath]];
+  _htmlNavigation = [_webView loadHTMLString:htmlString baseURL:baseURL];
 }
 
 #pragma mark - UIWebViewDelegate


### PR DESCRIPTION
# Why

Adds support for using local custom fonts on iOS. This is made possible using the `@font-face` style, which can be provided as an URL pointing to the font-resource.

Usage:

```js
import * as Print from 'expo-print';

const { uri } = await Print.printToFileAsync({
  html: `
<html>
  <head>
    <title>${t('Results')}</title>
    <style>
      @font-face {
        font-family: 'LubalinGraphStd-Book';
        src: url(fonts/LubalinGraphStd-Book.otf);
      }
      h1 {
        font-family: LubalinGraphStd-Book;
        font-size: 19px;
        letter-spacing: 0.5px;
        line-height: 22px;
      }
    </style>
  </head>
  <body>
    <h1>This text now uses the local font LubalinGraphStd-Book<h1>
  <body>
</html>
`
});
```

# How

- Provide a `baseURL` to `WKWebView` from which it can relatively load font resources

# Test Plan

TODO