### PR TITLE
[dev-launcher][splash-screen] Fix no native splash screen for dev-client integration

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix 'No native splash screen registered for given view controller' error when integrated dev-client. ([#14745](https://github.com/expo/expo/pull/14745) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 0.8.1 — 2021-10-07

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix 'No native splash screen registered for given view controller' error when integrated dev-client. ([#14745](https://github.com/expo/expo/pull/14745) by [@kudo](https://github.com/kudo))
+- Fix `No native splash screen registered for given view controller` error happening when project is using both `expo-dev-client` and `expo-splash-screen` packages. ([#14745](https://github.com/expo/expo/pull/14745) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -154,6 +154,9 @@ NSString *fakeLauncherBundleUrl = @"embedded://EXDevLauncher/dummy";
 
   if (!launchOptions[UIApplicationLaunchOptionsURLKey]) {
     [self navigateToLauncher];
+  } else {
+    // For deeplink launch, we need the keyWindow for expo-splash-screen to setup correctly.
+    [_window makeKeyWindow];
   }
 }
 

--- a/packages/expo-splash-screen/CHANGELOG.md
+++ b/packages/expo-splash-screen/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix 'No native splash screen registered for given view controller' error when integrated dev-client. ([#14745](https://github.com/expo/expo/pull/14745) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 0.13.1 — 2021-10-01

--- a/packages/expo-splash-screen/CHANGELOG.md
+++ b/packages/expo-splash-screen/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix 'No native splash screen registered for given view controller' error when integrated dev-client. ([#14745](https://github.com/expo/expo/pull/14745) by [@kudo](https://github.com/kudo))
+- Fix `No native splash screen registered for given view controller` error happening when project is using both `expo-dev-client` and `expo-splash-screen` packages. ([#14745](https://github.com/expo/expo/pull/14745) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenService.m
+++ b/packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenService.m
@@ -10,6 +10,15 @@ static NSString * const kView = @"view";
 @interface EXSplashScreenService ()
 
 @property (nonatomic, strong) NSMapTable<UIViewController *, EXSplashScreenViewController *> *splashScreenControllers;
+/**
+ * This module holds a reference to rootViewController acting as a flag to indicate KVO is enabled.
+ * When KVO is enabled, actually we are observing two targets and re-show splash screen if targets changed:
+ *   - `keyWindow.rootViewController`: it is for expo-dev-client which replaced it in startup.
+ *   - `rootViewController.rootView`: it is for expo-updates which replaced it in startup.
+ *
+ * If `rootViewController` is changed, we also need the old `rootViewController` to unregister rootView KVO.
+ * That's why we keep a weak reference here but not a boolean flag.
+ */
 @property (nonatomic, weak) UIViewController *observingRootViewController;
 
 @end
@@ -144,13 +153,11 @@ EX_REGISTER_SINGLETON_MODULE(SplashScreen);
   if (self.observingRootViewController == nil) {
     UIViewController *rootViewController = UIApplication.sharedApplication.keyWindow.rootViewController;
 
-    // `rootViewController` KVO is for expo-dev-launcher which replaced `rootViewController` in startup.
     [UIApplication.sharedApplication.keyWindow addObserver:self
                                                 forKeyPath:kRootViewController
                                                    options:NSKeyValueObservingOptionNew
                                                    context:nil];
 
-    // `rootView` KVO is for expo-updates which replaced `rootView` in startup.
     [rootViewController addObserver:self forKeyPath:kView options:NSKeyValueObservingOptionNew context:nil];
     self.observingRootViewController = rootViewController;
   }


### PR DESCRIPTION
# Why

dev-client heavily relies on `devLauncherController:didStartWithSuccess:` to show splash screen. however, as we tried to decouple splash screen with other modules. we didn't call `showSplashScreenFor:` in sdk 43 dev-client config plugin. after dev-client loaded the app, splash screen has no chances to show.

fix #14703

# How

- for launch from home, the dev-launcher ui case, i further register rootViewController KVO and re-show splash again.
  with #14519, we didn't replace rootViewController but only rootView in expo-updates. considering dev-client still uses the `initializeReactNativeApp` style with rootViewController replacement. i should further support rootViewController KVO here.
- for launch from deeplink, just make the current window as keyWindow. so that splash-screen rootViewController KVO can re-show splash after rootViewController setup in `initializeReactNativeApp`.

# Test Plan

1. `EXPO_BETA=1 expo init sdk43`
2. `expo install expo-dev-client`
3. patch code in node_modules
4. `expo run:ios` # launch from deeplink
5. kill the app and click the app from home # launch from home
6. check if "No native splash screen registered for given view controller."  happens or not.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
