### PR TITLE
[docs] add missing imports to dev client expo modules installation diff

### DIFF
--- a/docs/public/static/diffs/client/app-delegate-expo-modules.diff
+++ b/docs/public/static/diffs/client/app-delegate-expo-modules.diff
@@ -2,6 +2,21 @@ diff --git a/ios/expodevexample/AppDelegate.m b/ios/expodevexample/AppDelegate.m
 index 837259e..7e619d8 100644
 --- a/ios/expodevexample/AppDelegate.m
 +++ b/ios/expodevexample/AppDelegate.m
+@@ -11,6 +11,14 @@
+ #import <EXSplashScreen/EXSplashScreenService.h>
+ #import <UMCore/UMModuleRegistryProvider.h>
+ 
++#if defined(EX_DEV_MENU_ENABLED)
++@import EXDevMenu;
++#endif
++
++#if defined(EX_DEV_LAUNCHER_ENABLED)
++#include <EXDevLauncher/EXDevLauncherController.h>
++#endif
++
+ #if defined(FB_SONARKIT_ENABLED) && __has_include(<FlipperKit/FlipperClient.h>)
+ #import <FlipperKit/FlipperClient.h>
+ #import <FlipperKitLayoutPlugin/FlipperKitLayoutPlugin.h>
 @@ -40,7 +40,23 @@ - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(
  #if defined(FB_SONARKIT_ENABLED) && __has_include(<FlipperKit/FlipperClient.h>)
    InitializeFlipper(application);


### PR DESCRIPTION
# Why

@brentvatne noticed these were missing

# How

Copied these from the unimodules setup instructions, but wondering if the EXDevMenu import is necessary? I don't see it used anywhere else in the diff.

# Test Plan

Ran docs locally to ensure this rendered correctly. Also did a quick pass over the rest of the new diffs, didn't see anything else glaring missing.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
