### PR TITLE
[updates] Fix reanimated not installed

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix auto setup `EXUpdatesAppDelegate` breaking reanimated installation. ([#14755](https://github.com/expo/expo/pull/14755) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 0.10.3 — 2021-10-12

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesAppDelegate.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesAppDelegate.m
@@ -126,6 +126,11 @@ EX_REGISTER_SINGLETON_MODULE(EXUpdatesAppDelegate)
   return self;
 }
 
+- (BOOL)conformsToProtocol:(Protocol *)protocol
+{
+  return [self.bridgeDelegate conformsToProtocol:protocol];
+}
+
 - (id)forwardingTargetForSelector:(SEL)selector {
   if ([self isInterceptedSelector:selector]) {
     return self;


### PR DESCRIPTION
# Why

reanimated extends AppDelegate and installs module by [`UIResponder+Reanimated.h` with `RCTCxxBridgeDelegate` protocol](https://github.com/software-mansion/react-native-reanimated/blob/aa6f837f2bb49f12d9dec359a1d63b399314e726/ios/native/UIResponder%2BReanimated.h#L6). for sdk 43 in release build, EXUpdatesAppDelegate will be the one to setup bridge. when [react-native checking the bridge's delegate](https://github.com/facebook/react-native/blob/757bb75fbf837714725d7b2af62149e8e2a7ee51/React/CxxBridge/RCTCxxBridge.mm#L395-L398), the delegate is not AppDelegate but `EXUpdatesBridgeDelegateInterceptor`. it doesn't conform to `RCTCxxBridgeDelegate` and skip reanimated setup.

close [ENG-2140](https://linear.app/expo/issue/ENG-2140/[beta]-fix-reanimated-crash-in-release-mode)
fix #14746 

# How

`EXUpdatesBridgeDelegateInterceptor`'s `conformsToProtocol:` should also proxy to AppDelegate

# Test Plan

1. `EXPO_BETA=1 expo init sdk43`
2. `yarn install react-native-reanimated` and update babel.config.js for reanimated
3. patch `node_modules/expo-updates/ios/EXUpdates/EXUpdatesAppDelegate.m`
4. `expo run:ios --configuration Release`

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
