### PR TITLE
[file-system] fix okio build error on react-native 0.65 or above

### DIFF
--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix okio build error for react-native 0.65 or above. ([#14761](https://github.com/expo/expo/pull/14761) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 13.0.1 — 2021-10-01

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix okio build error for react-native 0.65 or above. ([#14761](https://github.com/expo/expo/pull/14761) by [@kudo](https://github.com/kudo))
+- Fix `okio` library build error for `react-native@0.65` or above. ([#14761](https://github.com/expo/expo/pull/14761) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/CountingRequestBody.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/CountingRequestBody.kt
@@ -44,7 +44,17 @@ class CountingRequestBody(
 
   override fun writeTo(sink: BufferedSink) {
     val countingSink = CountingSink(sink, this, progressListener)
+
+    // `Okio.buffer` is deprecated in okio 2.x.
+    // To be compatible across react-native versions where
+    // react-native < 0.65, okio is 1.x
+    // react-native >= 0.65, okio is 2.x
+    // We just suppress the error.
+    // In okio 2.x, `Okio.buffer` is still an extension method proxied to `countingSink.buffer()`.
+    // See: https://github.com/square/okio/blob/b0f78aaa46/okio/src/jvmMain/kotlin/okio/-DeprecatedOkio.kt#L48-L56
+    @Suppress("DEPRECATION_ERROR")
     val bufferedSink = Okio.buffer(countingSink)
+
     requestBody.writeTo(bufferedSink)
     bufferedSink.flush()
   }


### PR DESCRIPTION
# Why

fix #14697

# How

[Okio 2.x is .kt source-incompatible with Okio 1.x](https://square.github.io/okio/changelog/#version-200-rc1). however, it's just an intension to leverage kotlin extension function. [the old `Okio.buffer()` is still supported](https://github.com/square/okio/blob/b0f78aaa46/okio/src/jvmMain/kotlin/okio/-DeprecatedOkio.kt#L48-L56). to be compatible with react-native versions, i just suppress this error.

# Test Plan

## 0.64 build
ci bare-expo passed

## 0.65 build

initialize an react-native 0.65 project.
adopt to expo-modules.
`yarn android` to test build

## 0.65 functional test

follow #13318 test plan to test the upload call path

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
