### PR TITLE
[file-system] fix: upload async when using binary content

### DIFF
--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug fixes
 
+- Fixed `uploadAsync` failing to resolve when using `BINARY_CONTENT`.
 - Fix `okio` library build error for `react-native@0.65` or above. ([#14761](https://github.com/expo/expo/pull/14761) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed `uploadAsync` failing to resolve when using `BINARY_CONTENT`.
+- Fixed `uploadAsync` failing to resolve when using `BINARY_CONTENT`. ([#14764](https://github.com/expo/expo/pull/14764) by [@cruzach](https://github.com/cruzach))
 - Fix `okio` library build error for `react-native@0.65` or above. ([#14761](https://github.com/expo/expo/pull/14761) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemModule.java
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemModule.java
@@ -395,7 +395,7 @@ public class FileSystemModule extends ExportedModule implements ActivityEventLis
             promise.resolve(null);
           } else {
             promise.reject("ERR_FILESYSTEM_CANNOT_FIND_FILE",
-                    "File '" + uri + "' could not be deleted because it could not be found");
+              "File '" + uri + "' could not be deleted because it could not be found");
           }
         }
       } else if (isSAFUri(uri)) {
@@ -408,7 +408,7 @@ public class FileSystemModule extends ExportedModule implements ActivityEventLis
             promise.resolve(null);
           } else {
             promise.reject("ERR_FILESYSTEM_CANNOT_FIND_FILE",
-                    "File '" + uri + "' could not be deleted because it could not be found");
+              "File '" + uri + "' could not be deleted because it could not be found");
           }
         }
       } else {
@@ -443,7 +443,7 @@ public class FileSystemModule extends ExportedModule implements ActivityEventLis
           promise.resolve(null);
         } else {
           promise.reject("ERR_FILESYSTEM_CANNOT_MOVE_FILE",
-                  "File '" + fromUri + "' could not be moved to '" + toUri + "'");
+            "File '" + fromUri + "' could not be moved to '" + toUri + "'");
         }
       } else if (isSAFUri(fromUri)) {
         DocumentFile documentFile = getNearestSAFFile(fromUri);
@@ -575,7 +575,7 @@ public class FileSystemModule extends ExportedModule implements ActivityEventLis
           promise.resolve(null);
         } else {
           promise.reject("ERR_FILESYSTEM_CANNOT_CREATE_DIRECTORY",
-                  "Directory '" + uri + "' could not be created or already exists.");
+            "Directory '" + uri + "' could not be created or already exists.");
         }
       } else {
         throw new IOException("Unsupported scheme for location '" + uri + "'.");
@@ -602,11 +602,11 @@ public class FileSystemModule extends ExportedModule implements ActivityEventLis
           promise.resolve(result);
         } else {
           promise.reject("ERR_FILESYSTEM_CANNOT_READ_DIRECTORY",
-                  "Directory '" + uri + "' could not be read.");
+            "Directory '" + uri + "' could not be read.");
         }
       } else if (isSAFUri(uri)) {
         promise.reject("ERR_FILESYSTEM_UNSUPPORTED_SCHEME",
-                "Can't read Storage Access Framework directory, use StorageAccessFramework.readDirectoryAsync() instead.");
+          "Can't read Storage Access Framework directory, use StorageAccessFramework.readDirectoryAsync() instead.");
       } else {
         throw new IOException("Unsupported scheme for location '" + uri + "'.");
       }
@@ -686,7 +686,7 @@ public class FileSystemModule extends ExportedModule implements ActivityEventLis
         DocumentFile file = DocumentFile.fromTreeUri(getContext(), uri);
         if (file == null || !file.exists() || !file.isDirectory()) {
           promise.reject("ERR_FILESYSTEM_CANNOT_READ_DIRECTORY",
-                  "Uri '" + uri + "' doesn't exist or isn't a directory.");
+            "Uri '" + uri + "' doesn't exist or isn't a directory.");
           return;
         }
         DocumentFile[] children = file.listFiles();
@@ -816,7 +816,7 @@ public class FileSystemModule extends ExportedModule implements ActivityEventLis
         }
       }
 
-      RequestBody body = this.createRequestBody(options, decorator, uriToFile(fileUri));
+      RequestBody body = this.createRequestBody(requestBuilder, decorator, uriToFile(fileUri), options);
       return requestBuilder.method(method, body).build();
     } catch (Exception e) {
       Log.e(TAG, e.getMessage());
@@ -826,7 +826,7 @@ public class FileSystemModule extends ExportedModule implements ActivityEventLis
     return null;
   }
 
-  private RequestBody createRequestBody(final Map<String, Object> options, final RequestBodyDecorator decorator, final File file) {
+  private RequestBody createRequestBody(Request.Builder requestBuilder, RequestBodyDecorator decorator, File file, Map<String, Object> options) {
     UploadType uploadType = UploadType.fromInt(((Double) options.get("uploadType")).intValue());
 
     if (uploadType == UploadType.BINARY_CONTENT) {
@@ -924,11 +924,11 @@ public class FileSystemModule extends ExportedModule implements ActivityEventLis
     };
 
     Request request = createUploadRequest(
-            url,
-            fileUriString,
-            options,
-            promise,
-            requestBody -> new CountingRequestBody(requestBody, progressListener)
+      url,
+      fileUriString,
+      options,
+      promise,
+      requestBody -> new CountingRequestBody(requestBody, progressListener)
     );
     if (request == null) {
       return;
@@ -1092,17 +1092,17 @@ public class FileSystemModule extends ExportedModule implements ActivityEventLis
       };
 
       OkHttpClient client =
-              getOkHttpClient().newBuilder()
-                      .addNetworkInterceptor(new Interceptor() {
-                        @Override
-                        public Response intercept(Chain chain) throws IOException {
-                          Response originalResponse = chain.proceed(chain.request());
-                          return originalResponse.newBuilder()
-                                  .body(new ProgressResponseBody(originalResponse.body(), progressListener))
-                                  .build();
-                        }
-                      })
-                      .build();
+        getOkHttpClient().newBuilder()
+          .addNetworkInterceptor(new Interceptor() {
+            @Override
+            public Response intercept(Chain chain) throws IOException {
+              Response originalResponse = chain.proceed(chain.request());
+              return originalResponse.newBuilder()
+                .body(new ProgressResponseBody(originalResponse.body(), progressListener))
+                .build();
+            }
+          })
+          .build();
 
       Request.Builder requestBuilder = new Request.Builder();
       if (isResume) {
@@ -1169,7 +1169,7 @@ public class FileSystemModule extends ExportedModule implements ActivityEventLis
         Uri treeUri = data.getData();
 
         final int takeFlags = data.getFlags()
-                & (Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
+          & (Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
         activity.getContentResolver().takePersistableUriPermission(treeUri, takeFlags);
 
         result.putBoolean("granted", true);
@@ -1294,8 +1294,8 @@ public class FileSystemModule extends ExportedModule implements ActivityEventLis
       // multiple values for the same header
       if (responseHeaders.get(headerName) != null) {
         responseHeaders.putString(
-                headerName,
-                responseHeaders.getString(headerName) + ", " + headers.value(i));
+          headerName,
+          responseHeaders.getString(headerName) + ", " + headers.value(i));
       } else {
         responseHeaders.putString(headerName, headers.value(i));
       }
@@ -1373,10 +1373,10 @@ public class FileSystemModule extends ExportedModule implements ActivityEventLis
   private synchronized OkHttpClient getOkHttpClient() {
     if (mClient == null) {
       OkHttpClient.Builder builder =
-              new OkHttpClient.Builder()
-                      .connectTimeout(60, TimeUnit.SECONDS)
-                      .readTimeout(60, TimeUnit.SECONDS)
-                      .writeTimeout(60, TimeUnit.SECONDS);
+        new OkHttpClient.Builder()
+          .connectTimeout(60, TimeUnit.SECONDS)
+          .readTimeout(60, TimeUnit.SECONDS)
+          .writeTimeout(60, TimeUnit.SECONDS);
 
       CookieHandler cookieHandler = mModuleRegistry.getModule(CookieHandler.class);
       if (cookieHandler != null) {

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemModule.java
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemModule.java
@@ -816,7 +816,7 @@ public class FileSystemModule extends ExportedModule implements ActivityEventLis
         }
       }
 
-      RequestBody body = this.createRequestBody(requestBuilder, decorator, uriToFile(fileUri), options);
+      RequestBody body = this.createRequestBody(options, decorator, uriToFile(fileUri));
       return requestBuilder.method(method, body).build();
     } catch (Exception e) {
       Log.e(TAG, e.getMessage());
@@ -826,7 +826,7 @@ public class FileSystemModule extends ExportedModule implements ActivityEventLis
     return null;
   }
 
-  private RequestBody createRequestBody(Request.Builder requestBuilder, RequestBodyDecorator decorator, File file, Map<String, Object> options) {
+  private RequestBody createRequestBody(final Map<String, Object> options, final RequestBodyDecorator decorator, final File file) {
     UploadType uploadType = UploadType.fromInt(((Double) options.get("uploadType")).intValue());
 
     if (uploadType == UploadType.BINARY_CONTENT) {

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemModule.java
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemModule.java
@@ -807,7 +807,6 @@ public class FileSystemModule extends ExportedModule implements ActivityEventLis
         promise.reject("ERR_FILESYSTEM_MISSING_UPLOAD_TYPE", "Missing upload type.", null);
         return null;
       }
-      UploadType uploadType = UploadType.fromInt(((Double) options.get("uploadType")).intValue());
 
       Request.Builder requestBuilder = new Request.Builder().url(url);
       if (options.containsKey(HEADER_KEY)) {
@@ -817,45 +816,48 @@ public class FileSystemModule extends ExportedModule implements ActivityEventLis
         }
       }
 
-      File file = uriToFile(fileUri);
-      if (uploadType == UploadType.BINARY_CONTENT) {
-        RequestBody body = decorator.decorate(RequestBody.create(null, file));
-        requestBuilder.method(method, body);
-      } else if (uploadType == UploadType.MULTIPART) {
-        MultipartBody.Builder bodyBuilder = new MultipartBody.Builder().setType(MultipartBody.FORM);
-
-        if (options.containsKey("parameters")) {
-          Map<String, Object> parametersMap = (Map<String, Object>) options.get("parameters");
-          for (String key : parametersMap.keySet()) {
-            bodyBuilder.addFormDataPart(key, String.valueOf(parametersMap.get(key)));
-          }
-        }
-
-        String mimeType;
-        if (options.containsKey("mimeType")) {
-          mimeType = (String) options.get("mimeType");
-        } else {
-          mimeType = URLConnection.guessContentTypeFromName(file.getName());
-        }
-
-        String fieldName = file.getName();
-        if (options.containsKey("fieldName")) {
-          fieldName = (String) options.get("fieldName");
-        }
-
-        bodyBuilder.addFormDataPart(fieldName, file.getName(), decorator.decorate(RequestBody.create(mimeType != null ? MediaType.parse(mimeType) : null, file)));
-        requestBuilder.method(method, bodyBuilder.build());
-        return requestBuilder.build();
-      } else {
-        promise.reject("ERR_FILESYSTEM_INVALID_UPLOAD_TYPE", String.format("Invalid upload type: %s.", options.get("uploadType")), null);
-        return null;
-      }
+      RequestBody body = this.createRequestBody(requestBuilder, decorator, uriToFile(fileUri), options);
+      return requestBuilder.method(method, body).build();
     } catch (Exception e) {
       Log.e(TAG, e.getMessage());
       promise.reject(e);
     }
 
     return null;
+  }
+
+  private RequestBody createRequestBody(Request.Builder requestBuilder, RequestBodyDecorator decorator, File file, Map<String, Object> options) {
+    UploadType uploadType = UploadType.fromInt(((Double) options.get("uploadType")).intValue());
+
+    if (uploadType == UploadType.BINARY_CONTENT) {
+      return decorator.decorate(RequestBody.create(null, file));
+    } else if (uploadType == UploadType.MULTIPART) {
+      MultipartBody.Builder bodyBuilder = new MultipartBody.Builder().setType(MultipartBody.FORM);
+
+      if (options.containsKey("parameters")) {
+        Map<String, Object> parametersMap = (Map<String, Object>) options.get("parameters");
+        for (String key : parametersMap.keySet()) {
+          bodyBuilder.addFormDataPart(key, String.valueOf(parametersMap.get(key)));
+        }
+      }
+
+      String mimeType;
+      if (options.containsKey("mimeType")) {
+        mimeType = (String) options.get("mimeType");
+      } else {
+        mimeType = URLConnection.guessContentTypeFromName(file.getName());
+      }
+
+      String fieldName = file.getName();
+      if (options.containsKey("fieldName")) {
+        fieldName = (String) options.get("fieldName");
+      }
+
+      bodyBuilder.addFormDataPart(fieldName, file.getName(), decorator.decorate(RequestBody.create(mimeType != null ? MediaType.parse(mimeType) : null, file)));
+      return bodyBuilder.build();
+    } else {
+      throw new IllegalArgumentException("ERR_FILESYSTEM_INVALID_UPLOAD_TYPE. " + String.format("Invalid upload type: %s.", options.get("uploadType")));
+    }
   }
 
   @ExpoMethod

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemModule.java
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemModule.java
@@ -395,7 +395,7 @@ public class FileSystemModule extends ExportedModule implements ActivityEventLis
             promise.resolve(null);
           } else {
             promise.reject("ERR_FILESYSTEM_CANNOT_FIND_FILE",
-              "File '" + uri + "' could not be deleted because it could not be found");
+                    "File '" + uri + "' could not be deleted because it could not be found");
           }
         }
       } else if (isSAFUri(uri)) {
@@ -408,7 +408,7 @@ public class FileSystemModule extends ExportedModule implements ActivityEventLis
             promise.resolve(null);
           } else {
             promise.reject("ERR_FILESYSTEM_CANNOT_FIND_FILE",
-              "File '" + uri + "' could not be deleted because it could not be found");
+                    "File '" + uri + "' could not be deleted because it could not be found");
           }
         }
       } else {
@@ -443,7 +443,7 @@ public class FileSystemModule extends ExportedModule implements ActivityEventLis
           promise.resolve(null);
         } else {
           promise.reject("ERR_FILESYSTEM_CANNOT_MOVE_FILE",
-            "File '" + fromUri + "' could not be moved to '" + toUri + "'");
+                  "File '" + fromUri + "' could not be moved to '" + toUri + "'");
         }
       } else if (isSAFUri(fromUri)) {
         DocumentFile documentFile = getNearestSAFFile(fromUri);
@@ -575,7 +575,7 @@ public class FileSystemModule extends ExportedModule implements ActivityEventLis
           promise.resolve(null);
         } else {
           promise.reject("ERR_FILESYSTEM_CANNOT_CREATE_DIRECTORY",
-            "Directory '" + uri + "' could not be created or already exists.");
+                  "Directory '" + uri + "' could not be created or already exists.");
         }
       } else {
         throw new IOException("Unsupported scheme for location '" + uri + "'.");
@@ -602,11 +602,11 @@ public class FileSystemModule extends ExportedModule implements ActivityEventLis
           promise.resolve(result);
         } else {
           promise.reject("ERR_FILESYSTEM_CANNOT_READ_DIRECTORY",
-            "Directory '" + uri + "' could not be read.");
+                  "Directory '" + uri + "' could not be read.");
         }
       } else if (isSAFUri(uri)) {
         promise.reject("ERR_FILESYSTEM_UNSUPPORTED_SCHEME",
-          "Can't read Storage Access Framework directory, use StorageAccessFramework.readDirectoryAsync() instead.");
+                "Can't read Storage Access Framework directory, use StorageAccessFramework.readDirectoryAsync() instead.");
       } else {
         throw new IOException("Unsupported scheme for location '" + uri + "'.");
       }
@@ -686,7 +686,7 @@ public class FileSystemModule extends ExportedModule implements ActivityEventLis
         DocumentFile file = DocumentFile.fromTreeUri(getContext(), uri);
         if (file == null || !file.exists() || !file.isDirectory()) {
           promise.reject("ERR_FILESYSTEM_CANNOT_READ_DIRECTORY",
-            "Uri '" + uri + "' doesn't exist or isn't a directory.");
+                  "Uri '" + uri + "' doesn't exist or isn't a directory.");
           return;
         }
         DocumentFile[] children = file.listFiles();
@@ -816,7 +816,7 @@ public class FileSystemModule extends ExportedModule implements ActivityEventLis
         }
       }
 
-      RequestBody body = this.createRequestBody(requestBuilder, decorator, uriToFile(fileUri), options);
+      RequestBody body = this.createRequestBody(options, decorator, uriToFile(fileUri));
       return requestBuilder.method(method, body).build();
     } catch (Exception e) {
       Log.e(TAG, e.getMessage());
@@ -826,7 +826,7 @@ public class FileSystemModule extends ExportedModule implements ActivityEventLis
     return null;
   }
 
-  private RequestBody createRequestBody(Request.Builder requestBuilder, RequestBodyDecorator decorator, File file, Map<String, Object> options) {
+  private RequestBody createRequestBody(final Map<String, Object> options, final RequestBodyDecorator decorator, final File file) {
     UploadType uploadType = UploadType.fromInt(((Double) options.get("uploadType")).intValue());
 
     if (uploadType == UploadType.BINARY_CONTENT) {
@@ -924,11 +924,11 @@ public class FileSystemModule extends ExportedModule implements ActivityEventLis
     };
 
     Request request = createUploadRequest(
-      url,
-      fileUriString,
-      options,
-      promise,
-      requestBody -> new CountingRequestBody(requestBody, progressListener)
+            url,
+            fileUriString,
+            options,
+            promise,
+            requestBody -> new CountingRequestBody(requestBody, progressListener)
     );
     if (request == null) {
       return;
@@ -1092,17 +1092,17 @@ public class FileSystemModule extends ExportedModule implements ActivityEventLis
       };
 
       OkHttpClient client =
-        getOkHttpClient().newBuilder()
-          .addNetworkInterceptor(new Interceptor() {
-            @Override
-            public Response intercept(Chain chain) throws IOException {
-              Response originalResponse = chain.proceed(chain.request());
-              return originalResponse.newBuilder()
-                .body(new ProgressResponseBody(originalResponse.body(), progressListener))
-                .build();
-            }
-          })
-          .build();
+              getOkHttpClient().newBuilder()
+                      .addNetworkInterceptor(new Interceptor() {
+                        @Override
+                        public Response intercept(Chain chain) throws IOException {
+                          Response originalResponse = chain.proceed(chain.request());
+                          return originalResponse.newBuilder()
+                                  .body(new ProgressResponseBody(originalResponse.body(), progressListener))
+                                  .build();
+                        }
+                      })
+                      .build();
 
       Request.Builder requestBuilder = new Request.Builder();
       if (isResume) {
@@ -1169,7 +1169,7 @@ public class FileSystemModule extends ExportedModule implements ActivityEventLis
         Uri treeUri = data.getData();
 
         final int takeFlags = data.getFlags()
-          & (Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
+                & (Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
         activity.getContentResolver().takePersistableUriPermission(treeUri, takeFlags);
 
         result.putBoolean("granted", true);
@@ -1294,8 +1294,8 @@ public class FileSystemModule extends ExportedModule implements ActivityEventLis
       // multiple values for the same header
       if (responseHeaders.get(headerName) != null) {
         responseHeaders.putString(
-          headerName,
-          responseHeaders.getString(headerName) + ", " + headers.value(i));
+                headerName,
+                responseHeaders.getString(headerName) + ", " + headers.value(i));
       } else {
         responseHeaders.putString(headerName, headers.value(i));
       }
@@ -1373,10 +1373,10 @@ public class FileSystemModule extends ExportedModule implements ActivityEventLis
   private synchronized OkHttpClient getOkHttpClient() {
     if (mClient == null) {
       OkHttpClient.Builder builder =
-        new OkHttpClient.Builder()
-          .connectTimeout(60, TimeUnit.SECONDS)
-          .readTimeout(60, TimeUnit.SECONDS)
-          .writeTimeout(60, TimeUnit.SECONDS);
+              new OkHttpClient.Builder()
+                      .connectTimeout(60, TimeUnit.SECONDS)
+                      .readTimeout(60, TimeUnit.SECONDS)
+                      .writeTimeout(60, TimeUnit.SECONDS);
 
       CookieHandler cookieHandler = mModuleRegistry.getModule(CookieHandler.class);
       if (cookieHandler != null) {


### PR DESCRIPTION
# Why

`uploadAsync` would never resolve because of a missing `return` statement when using BINARY_CONTENT

# How

Extracted out request body creation to `createRequestBody` method to simplify things, and added return statement

# Test Plan

Tested locally with https://github.com/xrash/FileSystemSandbox

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
