### PR TITLE
[docs] Add helper components to structure installation and configuration sections

### DIFF
--- a/docs/components/plugins/ConfigSection/ConfigClassic.tsx
+++ b/docs/components/plugins/ConfigSection/ConfigClassic.tsx
@@ -1,0 +1,16 @@
+import React, { PropsWithChildren } from 'react';
+
+import { InlineCode } from '~/components/base/code';
+import { B } from '~/components/base/paragraph';
+
+type Props = PropsWithChildren<object>;
+
+export const ConfigClassic = ({ children }: Props) => (
+  <details>
+    <summary>
+      <B>Are you using the classic build system?</B> (
+      <InlineCode>expo build:[android|ios]</InlineCode>)
+    </summary>
+    {children}
+  </details>
+);

--- a/docs/components/plugins/ConfigSection/ConfigClassic.tsx
+++ b/docs/components/plugins/ConfigSection/ConfigClassic.tsx
@@ -1,16 +1,26 @@
-import React, { PropsWithChildren } from 'react';
+import React, { PropsWithChildren, useEffect } from 'react';
 
 import { InlineCode } from '~/components/base/code';
 import { B } from '~/components/base/paragraph';
 
 type Props = PropsWithChildren<object>;
 
-export const ConfigClassic = ({ children }: Props) => (
-  <details>
-    <summary>
-      <B>Are you using the classic build system?</B> (
-      <InlineCode>expo build:[android|ios]</InlineCode>)
-    </summary>
-    {children}
-  </details>
-);
+export const ConfigClassic = ({ children }: Props) => {
+  useEffect(() => {
+    if (typeof children === 'string') {
+      throw new Error(
+        `Content inside 'ConfigClassic' needs to be surrounded by new lines to be parsed as markdown.\n\nMake sure there is a blank new line before and after this content: '${children}'`
+      );
+    }
+  }, [children]);
+
+  return (
+    <details>
+      <summary>
+        <B>Are you using the classic build system?</B> (
+        <InlineCode>expo build:[android|ios]</InlineCode>)
+      </summary>
+      {children}
+    </details>
+  );
+};

--- a/docs/components/plugins/ConfigSection/ConfigPluginExample.tsx
+++ b/docs/components/plugins/ConfigSection/ConfigPluginExample.tsx
@@ -1,0 +1,12 @@
+import React, { PropsWithChildren } from 'react';
+
+import { H3 } from '~/components/plugins/Headings';
+
+type Props = PropsWithChildren<object>;
+
+export const ConfigPluginExample = ({ children }: Props) => (
+  <>
+    <H3>Example app.json with config plugin</H3>
+    {children}
+  </>
+);

--- a/docs/components/plugins/ConfigSection/ConfigPluginExample.tsx
+++ b/docs/components/plugins/ConfigSection/ConfigPluginExample.tsx
@@ -1,12 +1,22 @@
-import React, { PropsWithChildren } from 'react';
+import React, { PropsWithChildren, useEffect } from 'react';
 
 import { H3 } from '~/components/plugins/Headings';
 
 type Props = PropsWithChildren<object>;
 
-export const ConfigPluginExample = ({ children }: Props) => (
-  <>
-    <H3>Example app.json with config plugin</H3>
-    {children}
-  </>
-);
+export const ConfigPluginExample = ({ children }: Props) => {
+  useEffect(() => {
+    if (typeof children === 'string') {
+      throw new Error(
+        `Content inside 'ConfigPluginExample' needs to be surrounded by new lines to be parsed as markdown.\n\nMake sure there is a blank new line before and after this content: '${children}'`
+      );
+    }
+  }, [children]);
+
+  return (
+    <>
+      <H3>Example app.json with config plugin</H3>
+      {children}
+    </>
+  );
+}

--- a/docs/components/plugins/ConfigSection/ConfigPluginExample.tsx
+++ b/docs/components/plugins/ConfigSection/ConfigPluginExample.tsx
@@ -19,4 +19,4 @@ export const ConfigPluginExample = ({ children }: Props) => {
       {children}
     </>
   );
-}
+};

--- a/docs/components/plugins/ConfigSection/ConfigPluginProperties.tsx
+++ b/docs/components/plugins/ConfigSection/ConfigPluginProperties.tsx
@@ -1,0 +1,51 @@
+import React, { PropsWithChildren } from 'react';
+
+import { InlineCode } from '~/components/base/code';
+import { B, P } from '~/components/base/paragraph';
+import { H3 } from '~/components/plugins/Headings';
+
+type Props = PropsWithChildren<{
+  properties: PluginProperty[];
+}>;
+
+const platformNames: Record<Exclude<PluginProperty['platform'], undefined>, string> = {
+  android: 'Android',
+  ios: 'iOS',
+};
+
+export const ConfigPluginProperties = ({ children, properties }: Props) => (
+  <>
+    <H3>Configurable properties</H3>
+    {!!children && <P>{children}</P>}
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Default</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        {properties.map(property => (
+          <tr key={property.name}>
+            <td>
+              <InlineCode>{property.name}</InlineCode>
+            </td>
+            <td>{!property.default ? '-' : <InlineCode>{property.default}</InlineCode>}</td>
+            <td>
+              {!!property.platform && <B>{platformNames[property.platform]} only </B>}
+              {property.description}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </>
+);
+
+export type PluginProperty = {
+  name: string;
+  description: string;
+  default?: string;
+  platform?: 'android' | 'ios';
+};

--- a/docs/components/plugins/ConfigSection/ConfigPluginProperties.tsx
+++ b/docs/components/plugins/ConfigSection/ConfigPluginProperties.tsx
@@ -11,6 +11,7 @@ type Props = PropsWithChildren<{
 const platformNames: Record<Exclude<PluginProperty['platform'], undefined>, string> = {
   android: 'Android',
   ios: 'iOS',
+  web: 'Web',
 };
 
 export const ConfigPluginProperties = ({ children, properties }: Props) => (
@@ -47,5 +48,5 @@ export type PluginProperty = {
   name: string;
   description: string;
   default?: string;
-  platform?: 'android' | 'ios';
+  platform?: 'android' | 'ios' | 'web';
 };

--- a/docs/components/plugins/ConfigSection/ConfigReactNative.tsx
+++ b/docs/components/plugins/ConfigSection/ConfigReactNative.tsx
@@ -1,14 +1,24 @@
-import React, { PropsWithChildren } from 'react';
+import React, { PropsWithChildren, useEffect } from 'react';
 
 import { B } from '~/components/base/paragraph';
 
 type Props = PropsWithChildren<object>;
 
-export const ConfigReactNative = ({ children }: Props) => (
-  <details>
-    <summary>
-      <B>Are you using this library in a bare React Native app?</B>
-    </summary>
-    {children}
-  </details>
-);
+export const ConfigReactNative = ({ children }: Props) => {
+  useEffect(() => {
+    if (typeof children === 'string') {
+      throw new Error(
+        `Content inside 'ConfigReactNative' needs to be surrounded by new lines to be parsed as markdown.\n\nMake sure there is a blank new line before and after this content: '${children}'`
+      );
+    }
+  }, [children]);
+
+  return (
+    <details>
+      <summary>
+        <B>Are you using this library in a bare React Native app?</B>
+      </summary>
+      {children}
+    </details>
+  );
+};

--- a/docs/components/plugins/ConfigSection/ConfigReactNative.tsx
+++ b/docs/components/plugins/ConfigSection/ConfigReactNative.tsx
@@ -1,0 +1,14 @@
+import React, { PropsWithChildren } from 'react';
+
+import { B } from '~/components/base/paragraph';
+
+type Props = PropsWithChildren<object>;
+
+export const ConfigReactNative = ({ children }: Props) => (
+  <details>
+    <summary>
+      <B>Are you using this library in a bare React Native app?</B>
+    </summary>
+    {children}
+  </details>
+);

--- a/docs/components/plugins/ConfigSection/index.ts
+++ b/docs/components/plugins/ConfigSection/index.ts
@@ -1,0 +1,4 @@
+export * from './ConfigClassic';
+export * from './ConfigReactNative';
+export * from './ConfigPluginExample';
+export * from './ConfigPluginProperties';

--- a/docs/pages/versions/unversioned/sdk/notifications.md
+++ b/docs/pages/versions/unversioned/sdk/notifications.md
@@ -38,7 +38,7 @@ The **`expo-notifications`** provides an API to fetch push notification tokens a
 
 ## Configuration in app.json / app.config.js
 
-You can configure `expo-notifications` using its built-in [config plugin](../../../guides/config-plugins.md) if you use config plugins in your project ([EAS Build](/build/introduction.md) or `expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
+You can configure `expo-notifications` using its built-in [config plugin](../../../guides/config-plugins.md) if you use config plugins in your project ([EAS Build](../../../build/introduction.md) or `expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 
 <ConfigClassic>
 

--- a/docs/pages/versions/unversioned/sdk/notifications.md
+++ b/docs/pages/versions/unversioned/sdk/notifications.md
@@ -2,7 +2,8 @@
 title: Notifications
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-notifications'
 ---
-
+import { ConfigClassic, ConfigReactNative, ConfigPluginExample, ConfigPluginProperties } from '~/components/plugins/ConfigSection';
+import { AndroidPermissions } from '~/components/plugins/permissions';
 import SnackInline from '~/components/plugins/SnackInline';
 import ImageSpotlight from '~/components/plugins/ImageSpotlight'
 import InstallSection from '~/components/plugins/InstallSection';
@@ -34,44 +35,69 @@ The **`expo-notifications`** provides an API to fetch push notification tokens a
 
 <InstallSection packageName="expo-notifications" />
 
-### Config plugin setup (optional)
+## Configuraiton in app.json / app.config.js
 
-If you're using EAS Build, you can set your Android notification icon and color tint, add custom push notification sounds, and set your iOS notification environment using the `expo-notifications` config plugin ([what's a config plugin?](/guides/config-plugins.md)). To setup, just add the config plugin to the `plugins` array of your `app.json` or `app.config.js` as shown below, then rebuild the app.
+You can configure `expo-notifications` using its built-in [config plugin](../../../guides/config-plugins.md) if you use config plugins in your project ([EAS Build](/build/introduction.md) or `expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
+
+<ConfigClassic>
+
+Learn how to configure the native projects in the [installation instructions in the `expo-notifications` repository](https://github.com/expo/expo/tree/master/packages/expo-notifications#installation-in-bare-react-native-projects).
+
+</ConfigClassic>
+
+<ConfigReactNative>
+
+Learn how to configure the native projects in the [installation instructions in the `expo-notifications` repository](https://github.com/expo/expo/tree/master/packages/expo-notifications#installation-in-bare-react-native-projects).
+  
+</ConfigReactNative>
+
+<ConfigPluginExample>
 
 ```json
 {
-  "expo": {
-    ...
+  "expo" {
     "plugins": [
-      [
-        "expo-notifications",
-        {
-          "icon": "./local/path/to/myNotificationIcon.png",
-          "color": "#ffffff",
-          "sounds": ["./local/path/to/mySound.wav", "./local/path/to/myOtherSound.wav"],
-          "mode": "production"
-        }
-      ]
-    ],
+      ["expo-notifications", {
+        "icon": "./local/assets/notification-icon.png",
+        "color": "#ffffff",
+        "sounds": ["./local/assets/notification-sound.wav", "./local/assets/notification-sound-other.wav"],
+        "mode": "production"
+      }]
+    ]
   }
 }
 ```
 
-<details><summary><strong>Expand to view property descriptions and default values</strong></summary> <p>
+</ConfigPluginExample>
 
-- **icon**: Android only. Local path to an image to use as the icon for push notifications. 96x96 all-white png with transparency.
-- **color**: Android only. Tint color for the push notification image when it appears in the notification tray. Default: "#ffffff".
-- **sounds**: Array of local paths to sound files (.wav recommended) that can be used as custom notification sounds.
-- **mode**: iOS only. Environment of the app: either 'development' or 'production'. Default: 'development'.
+<ConfigPluginProperties properties={[
+  { name: 'icon', platform: 'android', description: 'Local path to an image to use as the icon for push notifications. 96x96 all-white png with transparency.' },
+  { name: 'color', default: '#ffffff', platform: 'android', description: 'Tint color for the push notification image when it appears in the notification tray.' },
+  { name: 'sounds', description: 'Array of local paths to sound files (.wav recommended) that can be used as custom notification sounds.' },
+  { name: 'mode', default: 'development', platform: 'ios', description: `Environment of the app: either 'development' or 'production'.` },
+]} />
 
-</p>
-</details>
+## Credentials configuration
 
 ### Android
 
-On Android, this module requires permission to subscribe to device boot. It's used to setup the scheduled notifications right after the device (re)starts. The `RECEIVE_BOOT_COMPLETED` permission is added automatically.
+Firebase Cloud Messaging credentials are required for all Android apps, except in Expo Go. To set up your Android app to receive push notifications using your own FCM credentials, [carefully follow this guide](../../../push-notifications/using-fcm.md).
 
-Unless you're still running your project in the Expo Go app, Firebase Cloud Messaging is required for all [managed](../../../push-notifications/sending-notifications.md) and [bare workflow](../../../push-notifications/sending-notifications-custom.md) Android apps made with Expo. To set up your Expo Android app to get push notifications using your own FCM credentials, [follow this guide closely](../../../push-notifications/using-fcm.md).
+### iOS
+
+Learn how push notification credentials can be automatically generated or uploaded [in the push notifications setup guide](../../../push-notifications/push-notifications-setup.md#credentials).
+
+## Permissions
+
+### Android
+
+On Android, this module requires permission to subscribe to device boot. It's used to setup scheduled notifications when the device (re)starts. The `RECEIVE_BOOT_COMPLETED` permission is added automatically through the library `AndroidManifest.xml`.
+
+<AndroidPermissions permissions={['RECEIVE_BOOT_COMPLETED']} />
+
+### iOS
+
+_No usage description required, see [notification-related permissions](#fetching-information-about-notifications-related-permissions)._
 
 ## Common gotchas / known issues
 

--- a/docs/pages/versions/unversioned/sdk/notifications.md
+++ b/docs/pages/versions/unversioned/sdk/notifications.md
@@ -1,6 +1,6 @@
 ---
 title: Notifications
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-43/packages/expo-notifications'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-notifications'
 ---
 
 import { ConfigClassic, ConfigReactNative, ConfigPluginExample, ConfigPluginProperties } from '~/components/plugins/ConfigSection';

--- a/docs/pages/versions/unversioned/sdk/notifications.md
+++ b/docs/pages/versions/unversioned/sdk/notifications.md
@@ -1,7 +1,8 @@
 ---
 title: Notifications
-sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-notifications'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-43/packages/expo-notifications'
 ---
+
 import { ConfigClassic, ConfigReactNative, ConfigPluginExample, ConfigPluginProperties } from '~/components/plugins/ConfigSection';
 import { AndroidPermissions } from '~/components/plugins/permissions';
 import SnackInline from '~/components/plugins/SnackInline';
@@ -35,7 +36,7 @@ The **`expo-notifications`** provides an API to fetch push notification tokens a
 
 <InstallSection packageName="expo-notifications" />
 
-## Configuraiton in app.json / app.config.js
+## Configuration in app.json / app.config.js
 
 You can configure `expo-notifications` using its built-in [config plugin](../../../guides/config-plugins.md) if you use config plugins in your project ([EAS Build](/build/introduction.md) or `expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 
@@ -48,7 +49,7 @@ Learn how to configure the native projects in the [installation instructions in 
 <ConfigReactNative>
 
 Learn how to configure the native projects in the [installation instructions in the `expo-notifications` repository](https://github.com/expo/expo/tree/master/packages/expo-notifications#installation-in-bare-react-native-projects).
-  
+
 </ConfigReactNative>
 
 <ConfigPluginExample>

--- a/docs/pages/versions/unversioned/sdk/notifications.md
+++ b/docs/pages/versions/unversioned/sdk/notifications.md
@@ -56,7 +56,7 @@ Learn how to configure the native projects in the [installation instructions in 
 
 ```json
 {
-  "expo" {
+  "expo": {
     "plugins": [
       ["expo-notifications", {
         "icon": "./local/assets/notification-icon.png",

--- a/docs/pages/versions/v43.0.0/sdk/notifications.md
+++ b/docs/pages/versions/v43.0.0/sdk/notifications.md
@@ -38,7 +38,7 @@ The **`expo-notifications`** provides an API to fetch push notification tokens a
 
 ## Configuration in app.json / app.config.js
 
-You can configure `expo-notifications` using its built-in [config plugin](../../../guides/config-plugins.md) if you use config plugins in your project ([EAS Build](/build/introduction.md) or `expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
+You can configure `expo-notifications` using its built-in [config plugin](../../../guides/config-plugins.md) if you use config plugins in your project ([EAS Build](../../../build/introduction.md) or `expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 
 <ConfigClassic>
 

--- a/docs/pages/versions/v43.0.0/sdk/notifications.md
+++ b/docs/pages/versions/v43.0.0/sdk/notifications.md
@@ -3,6 +3,8 @@ title: Notifications
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-43/packages/expo-notifications'
 ---
 
+import { ConfigClassic, ConfigReactNative, ConfigPluginExample, ConfigPluginProperties } from '~/components/plugins/ConfigSection';
+import { AndroidPermissions } from '~/components/plugins/permissions';
 import SnackInline from '~/components/plugins/SnackInline';
 import ImageSpotlight from '~/components/plugins/ImageSpotlight'
 import InstallSection from '~/components/plugins/InstallSection';
@@ -34,44 +36,69 @@ The **`expo-notifications`** provides an API to fetch push notification tokens a
 
 <InstallSection packageName="expo-notifications" />
 
-### Config plugin setup (optional)
+## Configuration in app.json / app.config.js
 
-If you're using EAS Build, you can set your Android notification icon and color tint, add custom push notification sounds, and set your iOS notification environment using the `expo-notifications` config plugin ([what's a config plugin?](/guides/config-plugins.md)). To setup, just add the config plugin to the `plugins` array of your `app.json` or `app.config.js` as shown below, then rebuild the app.
+You can configure `expo-notifications` using its built-in [config plugin](../../../guides/config-plugins.md) if you use config plugins in your project ([EAS Build](/build/introduction.md) or `expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
+
+<ConfigClassic>
+
+Learn how to configure the native projects in the [installation instructions in the `expo-notifications` repository](https://github.com/expo/expo/tree/master/packages/expo-notifications#installation-in-bare-react-native-projects).
+
+</ConfigClassic>
+
+<ConfigReactNative>
+
+Learn how to configure the native projects in the [installation instructions in the `expo-notifications` repository](https://github.com/expo/expo/tree/master/packages/expo-notifications#installation-in-bare-react-native-projects).
+
+</ConfigReactNative>
+
+<ConfigPluginExample>
 
 ```json
 {
-  "expo": {
-    ...
+  "expo" {
     "plugins": [
-      [
-        "expo-notifications",
-        {
-          "icon": "./local/path/to/myNotificationIcon.png",
-          "color": "#ffffff",
-          "sounds": ["./local/path/to/mySound.wav", "./local/path/to/myOtherSound.wav"],
-          "mode": "production"
-        }
-      ]
-    ],
+      ["expo-notifications", {
+        "icon": "./local/assets/notification-icon.png",
+        "color": "#ffffff",
+        "sounds": ["./local/assets/notification-sound.wav", "./local/assets/notification-sound-other.wav"],
+        "mode": "production"
+      }]
+    ]
   }
 }
 ```
 
-<details><summary><strong>Expand to view property descriptions and default values</strong></summary> <p>
+</ConfigPluginExample>
 
-- **icon**: Android only. Local path to an image to use as the icon for push notifications. 96x96 all-white png with transparency.
-- **color**: Android only. Tint color for the push notification image when it appears in the notification tray. Default: "#ffffff".
-- **sounds**: Array of local paths to sound files (.wav recommended) that can be used as custom notification sounds.
-- **mode**: iOS only. Environment of the app: either 'development' or 'production'. Default: 'development'.
+<ConfigPluginProperties properties={[
+  { name: 'icon', platform: 'android', description: 'Local path to an image to use as the icon for push notifications. 96x96 all-white png with transparency.' },
+  { name: 'color', default: '#ffffff', platform: 'android', description: 'Tint color for the push notification image when it appears in the notification tray.' },
+  { name: 'sounds', description: 'Array of local paths to sound files (.wav recommended) that can be used as custom notification sounds.' },
+  { name: 'mode', default: 'development', platform: 'ios', description: `Environment of the app: either 'development' or 'production'.` },
+]} />
 
-</p>
-</details>
+## Credentials configuration
 
 ### Android
 
-On Android, this module requires permission to subscribe to device boot. It's used to setup the scheduled notifications right after the device (re)starts. The `RECEIVE_BOOT_COMPLETED` permission is added automatically.
+Firebase Cloud Messaging credentials are required for all Android apps, except in Expo Go. To set up your Android app to receive push notifications using your own FCM credentials, [carefully follow this guide](../../../push-notifications/using-fcm.md).
 
-Unless you're still running your project in the Expo Go app, Firebase Cloud Messaging is required for all [managed](../../../push-notifications/sending-notifications.md) and [bare workflow](../../../push-notifications/sending-notifications-custom.md) Android apps made with Expo. To set up your Expo Android app to get push notifications using your own FCM credentials, [follow this guide closely](../../../push-notifications/using-fcm.md).
+### iOS
+
+Learn how push notification credentials can be automatically generated or uploaded [in the push notifications setup guide](../../../push-notifications/push-notifications-setup.md#credentials).
+
+## Permissions
+
+### Android
+
+On Android, this module requires permission to subscribe to device boot. It's used to setup scheduled notifications when the device (re)starts. The `RECEIVE_BOOT_COMPLETED` permission is added automatically through the library `AndroidManifest.xml`.
+
+<AndroidPermissions permissions={['RECEIVE_BOOT_COMPLETED']} />
+
+### iOS
+
+_No usage description required, see [notification-related permissions](#fetching-information-about-notifications-related-permissions)._
 
 ## Common gotchas / known issues
 

--- a/docs/pages/versions/v43.0.0/sdk/notifications.md
+++ b/docs/pages/versions/v43.0.0/sdk/notifications.md
@@ -56,7 +56,7 @@ Learn how to configure the native projects in the [installation instructions in 
 
 ```json
 {
-  "expo" {
+  "expo": {
     "plugins": [
       ["expo-notifications", {
         "icon": "./local/assets/notification-icon.png",


### PR DESCRIPTION
# Why

Add simple helper components to restructure the Installation / Configuration sections of API docs.

# How

Added components and implemented them on notifications SDK page, both unversioned and versioned.

# Test Plan

- See if CI passes
- Check if the content looks good

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
