### PR TITLE
[docs] Modernize the Firestore example

### DIFF
--- a/docs/pages/guides/using-firebase.md
+++ b/docs/pages/guides/using-firebase.md
@@ -215,7 +215,7 @@ Here's is an example of storing a document named "mario" inside of a collection 
 
 ```javascript
 import { initializeApp } from 'firebase/app';
-import { getFirestore, setDoc, doc } from 'firebase/firestore';
+import { getFirestore } from 'firebase/firestore';
 
 const firebaseConfig = { ... }  // apiKey, authDomain, etc. (see above)
 
@@ -223,14 +223,12 @@ initializeApp(firebaseConfig);
 
 const firestore = getFirestore();
 
-await setDoc(doc(firestore, "characters", "mario"), {
+await firestore.collection("characters").doc("mario").set({
   employment: "plumber",
   outfitColor: "red",
   specialAttack: "fireball"
 });
 ```
-
-This sample was borrowed and edited from [this forum post](https://forums.expo.dev/t/open-when-an-expo-firebase-firestore-platform/4126/29).
 
 ## Recording events with Analytics
 


### PR DESCRIPTION
The example used a very old version of the Firestore API and the linked-to article no longer seems to have appropriate code example to reference.

So:
1. remove the link to the old article
2. update the example to reflect API examples that are now promoted in Firestore docs and tutorials.

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
