### PR TITLE
[docs] Use reference to app manifest for classic notification config

### DIFF
--- a/docs/pages/versions/unversioned/sdk/notifications.md
+++ b/docs/pages/versions/unversioned/sdk/notifications.md
@@ -42,7 +42,7 @@ You can configure `expo-notifications` using its built-in [config plugin](../../
 
 <ConfigClassic>
 
-Learn how to configure the native projects in the [installation instructions in the `expo-notifications` repository](https://github.com/expo/expo/tree/master/packages/expo-notifications#installation-in-bare-react-native-projects).
+Learn how to configure notifications with the [app manifest `notification` property](../config/app.md#notification).
 
 </ConfigClassic>
 

--- a/docs/pages/versions/v43.0.0/sdk/notifications.md
+++ b/docs/pages/versions/v43.0.0/sdk/notifications.md
@@ -42,7 +42,7 @@ You can configure `expo-notifications` using its built-in [config plugin](../../
 
 <ConfigClassic>
 
-Learn how to configure the native projects in the [installation instructions in the `expo-notifications` repository](https://github.com/expo/expo/tree/master/packages/expo-notifications#installation-in-bare-react-native-projects).
+Learn how to configure notifications with the [app manifest `notification` property](../config/app.md#notification).
 
 </ConfigClassic>
 


### PR DESCRIPTION
# Why

See https://github.com/expo/expo/pull/14765#discussion_r730190630

# How

Updated text and added a reference to the app manifest page.

# Test Plan

Just a docs change

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
