### PR TITLE
[android][location] call `jobService.jobFinished` for the finished geofencing jobs

### DIFF
--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Call `jobService.jobFinished` for the finished geofencing jobs. ([#14786](https://github.com/expo/expo/pull/14786) by [@mdmitry01](https://github.com/mdmitry01))
+
 ### 💡 Others
 
 - Extract nested `foregroundService` object from `LocationTaskOptions` type to the separate type `LocationTaskServiceOptions`. ([#14672](https://github.com/expo/expo/pull/14672) by [@Simek](https://github.com/Simek))

--- a/packages/expo-location/android/src/main/java/expo/modules/location/taskConsumers/GeofencingTaskConsumer.java
+++ b/packages/expo-location/android/src/main/java/expo/modules/location/taskConsumers/GeofencingTaskConsumer.java
@@ -26,6 +26,7 @@ import java.util.UUID;
 import org.unimodules.interfaces.taskManager.TaskConsumer;
 import org.unimodules.interfaces.taskManager.TaskManagerUtilsInterface;
 import org.unimodules.interfaces.taskManager.TaskConsumerInterface;
+import org.unimodules.interfaces.taskManager.TaskExecutionCallback;
 import org.unimodules.interfaces.taskManager.TaskInterface;
 import expo.modules.location.LocationHelpers;
 import expo.modules.location.LocationModule;
@@ -135,8 +136,16 @@ public class GeofencingTaskConsumer extends TaskConsumer implements TaskConsumer
       if (mTask == null) {
         return false;
       }
-      mTask.execute(bundle, null);
+      mTask.execute(bundle, null, new TaskExecutionCallback() {
+        @Override
+        public void onFinished(Map<String, Object> response) {
+          jobService.jobFinished(params, false);
+        }
+      });
     }
+
+    // Returning `true` indicates that the job is still running, but in async mode.
+    // In that case we're obligated to call `jobService.jobFinished` as soon as the async block finishes.
     return true;
   }
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

This PR fixes a bug where the geofence events are accumulated for 15 seconds on Android.

# How

<!--
How did you build this feature or fix this bug and why?
-->

The problem is [here](https://github.com/expo/expo/blob/67e0d981c45eeddf770b1e01b5e982604f7d0610/packages/expo-location/android/src/main/java/expo/modules/location/taskConsumers/GeofencingTaskConsumer.java#L138). The `didExecuteJob` method returns `true`, which means "[the job is still running, but in async mode. In that case we're obligated to call \`jobService.jobFinished\` as soon as the async block finishes."](https://github.com/expo/expo/blob/67e0d981c45eeddf770b1e01b5e982604f7d0610/packages/expo-location/android/src/main/java/expo/modules/location/taskConsumers/LocationTaskConsumer.java#L157-L159). If we don't call the `jobFinished` method in `didExecuteJob`, then it's called after 15 seconds timeout in [the handleJob method](https://github.com/expo/expo/blob/67e0d981c45eeddf770b1e01b5e982604f7d0610/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/TaskService.java#L337). Until the `jobFinished` method is called, the geofence events are accumulated [here](https://github.com/expo/expo/blob/67e0d981c45eeddf770b1e01b5e982604f7d0610/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/TaskManagerUtils.java#L129-L143).

# Test Plan

To reproduce the bug, run [`Location.startGeofencingAsync`](https://docs.expo.dev/versions/latest/sdk/location/#locationstartgeofencingasynctaskname-regions), `console.log()` the geofence events and simulate your GPS coordinates using an Android emulator. You should see accumulated geofence events per one location change within the 15 seconds window, meaning you should see more than one geofence event for one location change.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
