### PR TITLE
[jest-expo] replace missing `fbjs-scripts` require with Jest package

### DIFF
--- a/packages/jest-expo/package.json
+++ b/packages/jest-expo/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "@expo/config": "^5.0.9",
+    "@jest/create-cache-key-function": "^26.6.2",
     "babel-jest": "^26.6.3",
     "find-up": "^5.0.0",
     "jest": "^26.6.3",

--- a/packages/jest-expo/src/preset/assetFileTransformer.js
+++ b/packages/jest-expo/src/preset/assetFileTransformer.js
@@ -1,4 +1,4 @@
-const createCacheKeyFunction = require('fbjs-scripts/jest/createCacheKeyFunction');
+const createCacheKeyFunction = require('@jest/create-cache-key-function');
 
 module.exports = {
   process: (_, filename) => `module.exports = 1;`,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2453,7 +2453,7 @@
     slash "^3.0.0"
     strip-ansi "^6.0.0"
 
-"@jest/create-cache-key-function@^26.5.0":
+"@jest/create-cache-key-function@^26.5.0", "@jest/create-cache-key-function@^26.6.2":
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/@jest/create-cache-key-function/-/create-cache-key-function-26.6.2.tgz#04cf439207a4fd12418d8aee551cddc86f9ac5f5"
   integrity sha512-LgEuqU1f/7WEIPYqwLPIvvHuc1sB6gMVbT6zWhin3txYUNYK/kGQrC1F2WR4gR34YlI9bBtViTm5z98RqVZAaw==


### PR DESCRIPTION
# Why

Fixes #14789

# How

As described in the issue `fbjs-scripts` is no longer vendored with RN from 0.64 upward (no `fbjs-scripts` in SDK 43 ABI).

`jest-expo` included direct require for one of the methods in that package which started causing an error for beta users.

The method now is published as a separate Jest package `@jest/create-cache-key-function`, so we can just switch to that package to fix the issue.

# Test Plan

`yarn`, `yarn test` and `yarn lint` commands in `jest-expo` directory yield a success.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [X] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
