### PR TITLE
[docs] update eas ios submissions with asc api key

### DIFF
--- a/docs/pages/submit/ios.md
+++ b/docs/pages/submit/ios.md
@@ -29,8 +29,7 @@ The command will perform the following steps:
 - Log in to your Expo account and ensure that your app project exists on EAS servers.
 - Ensure that your app exists on App Store Connect and its [Bundle Identifier](https://expo.fyi/bundle-identifier) is registered on Apple Developer Portal:
 
-  - You will be asked to log in to your Apple Developer account and select your team. You can also provide this information in `eas.json` by setting `appleId` and `appleTeamId` in the submit profile.
-  - The App Specific Password has to be set with the `EXPO_APPLE_PASSWORD` environment variable. If you are using an App Store Connect Api Key, set the `ascApiKeyPath`, `ascApiKeyIssuerId`, and `ascApiKeyId` fields in `eas.json`
+  - You will be asked to log in to your Apple Developer account and select your team. You can also provide this information in `eas.json` by setting `appleId` and `appleTeamId` in the submit profile. The Apple ID password has to be set with the `EXPO_APPLE_PASSWORD` environment variable.
   - The command will look for `ios.bundleIdentifier` in the app config.
   - If you are submitting your app for the first time, it will be automatically created.
     Unless `expo.name` in your app configuration is found or `appName` is provided in `eas.json`, you will be prompted for the app name.
@@ -38,7 +37,7 @@ The command will perform the following steps:
 
   > If you already have an App Store Connect app, this step can be skipped by providing the `ascAppId` in the submit profile. The [ASC App ID](https://expo.fyi/asc-app-id) can be found either on App Store Connect, or later during this command in the _Submission Summary_ table.
 
-- Ask for your Apple ID (if not provided earlier) and for your Apple app-specific password. They can be also provided using `--apple-id` param and `EXPO_APPLE_APP_SPECIFIC_PASSWORD` environment variable, respectively.
+- Ask for your Apple ID (if not provided earlier) and for your Apple app-specific password. They can be also provided using `--apple-id` param and `EXPO_APPLE_APP_SPECIFIC_PASSWORD` environment variable, respectively. Alternatively, you can provide an App Store Connect Api Key instead, setting the `ascApiKeyPath`, `ascApiKeyIssuerId`, and `ascApiKeyId` fields in `eas.json`.
 - Ask for which binary to submit. You can select one of the following:
 
   - The latest successful iOS build for the project on EAS servers.

--- a/docs/pages/submit/ios.md
+++ b/docs/pages/submit/ios.md
@@ -55,7 +55,10 @@ The command will perform the following steps:
 
 The `eas submit` command is able to perform submissions from a CI environment. All you have to do is ensure that all required information is provided with `eas.json` and environment variables. Mainly, providing the archive source (`--latest`, `--id`, `--path`, or `--url`) is essential. Also, make sure that the iOS Bundle Identifier is present in your [app config file](/workflow/configuration.md).
 
-For iOS submissions, you must provide `EXPO_APPLE_APP_SPECIFIC_PASSWORD` environment variable along with Apple ID and ASC App ID (`appleId` and `ascAppId` in `eas.json`). The ASC App ID is required to skip the Apple developer log-in process, which will likely not be possible on CI due to the 2FA prompt.
+For iOS submissions, you must provide either:
+
+- `EXPO_APPLE_APP_SPECIFIC_PASSWORD` environment variable along with Apple ID and ASC App ID (`appleId` and `ascAppId` in `eas.json`). The ASC App ID is required to skip the Apple developer log-in process, which will likely not be possible on CI due to the 2FA prompt.
+- Your App Store Connect Api Key with the `ascApiKeyPath`, `ascApiKeyIssuerId`, and `ascApiKeyId` fields set in `eas.json`.
 
 Example usage:
 

--- a/docs/pages/submit/ios.md
+++ b/docs/pages/submit/ios.md
@@ -20,7 +20,7 @@ To submit the binary to the App Store, run `eas submit -p ios` from inside your 
 
 > Although it's possible to upload any binary to the store, each submission is associated with an Expo project. That's why it's important to start a submission from inside your project's directory - that's where your [app configuration](../workflow/configuration.md) is defined.
 
-**Important**: You'll have to generate an [Apple app-specific password](https://expo.fyi/apple-app-specific-password) before submitting an app with EAS CLI.
+**Important**: You'll have to generate an [Apple app-specific password](https://expo.fyi/apple-app-specific-password) or an [App Store Connect Api Key](https://expo.fyi/creating-asc-api-key) before submitting an app with EAS CLI.
 
 To upload your iOS app to the Apple App Store, run `eas submit --platform ios` and follow the instructions on the screen.
 
@@ -29,7 +29,8 @@ The command will perform the following steps:
 - Log in to your Expo account and ensure that your app project exists on EAS servers.
 - Ensure that your app exists on App Store Connect and its [Bundle Identifier](https://expo.fyi/bundle-identifier) is registered on Apple Developer Portal:
 
-  - You will be asked to log in to your Apple Developer account and select your team. You can also provide this information in `eas.json` by setting `appleId` and `appleTeamId` in the submit profile. The Apple ID password has to be set with the `EXPO_APPLE_PASSWORD` environment variable.
+  - You will be asked to log in to your Apple Developer account and select your team. You can also provide this information in `eas.json` by setting `appleId` and `appleTeamId` in the submit profile.
+  - The App Specific Password has to be set with the `EXPO_APPLE_PASSWORD` environment variable. If you are using an App Store Connect Api Key, set the `ascApiKeyPath`, `ascApiKeyIssuerId`, and `ascApiKeyId` fields in `eas.json`
   - The command will look for `ios.bundleIdentifier` in the app config.
   - If you are submitting your app for the first time, it will be automatically created.
     Unless `expo.name` in your app configuration is found or `appName` is provided in `eas.json`, you will be prompted for the app name.

--- a/docs/scripts/schemas/unversioned/eas-json-submit-ios-schema.js
+++ b/docs/scripts/schemas/unversioned/eas-json-submit-ios-schema.js
@@ -47,7 +47,7 @@ export default [
     name: 'ascApiKeyPath',
     type: 'string',
     description: [
-      'The path to your App Store Connect Api Key .p8 file. [Learn more](https://expo.fyi/creating-asc-api-key.md).',
+      'The path to your App Store Connect Api Key .p8 file. [Learn more](https://expo.fyi/creating-asc-api-key).',
     ],
   },
   {

--- a/docs/scripts/schemas/unversioned/eas-json-submit-ios-schema.js
+++ b/docs/scripts/schemas/unversioned/eas-json-submit-ios-schema.js
@@ -54,7 +54,7 @@ export default [
     name: 'ascApiKeyIssuerId',
     type: 'string',
     description: [
-      'The Issuer ID of your App Store Connect Api Key. [Learn more](https://expo.fyi/creating-asc-api-key.md).',
+      'The Issuer ID of your App Store Connect Api Key. [Learn more](https://expo.fyi/creating-asc-api-key).',
     ],
   },
   {

--- a/docs/scripts/schemas/unversioned/eas-json-submit-ios-schema.js
+++ b/docs/scripts/schemas/unversioned/eas-json-submit-ios-schema.js
@@ -9,8 +9,8 @@ export default [
     type: 'string',
     description: [
       'App Store Connect unique application Apple ID number. When set, results in skipping the app creation step.',
-      '[Learn more on this](https://expo.fyi/asc-app-id).'
-    ]
+      '[Learn more on this](https://expo.fyi/asc-app-id).',
+    ],
   },
   {
     name: 'appleTeamId',
@@ -20,21 +20,48 @@ export default [
   {
     name: 'sku',
     type: 'string',
-    description: ['An unique ID for your app that is not visible on the App Store, will be generated unless provided.'],
+    description: [
+      'An unique ID for your app that is not visible on the App Store, will be generated unless provided.',
+    ],
   },
   {
     name: 'language',
     type: 'string',
-    description: ['Primary language. Defaults to "en-US".']
+    description: ['Primary language. Defaults to "en-US".'],
   },
   {
     name: 'companyName',
     type: 'string',
-    description: ['The name of your company, needed only for the first submission of any app to the App Store.'],
+    description: [
+      'The name of your company, needed only for the first submission of any app to the App Store.',
+    ],
   },
   {
     name: 'appName',
     type: 'string',
-    description: ['The name of your app as it will appear on the App Store. Defaults to `expo.name` from the app config.'],
+    description: [
+      'The name of your app as it will appear on the App Store. Defaults to `expo.name` from the app config.',
+    ],
   },
-]
+  {
+    name: 'ascApiKeyPath',
+    type: 'string',
+    description: [
+      'The path to your App Store Connect Api Key .p8 file. [Learn more](https://expo.fyi/creating-asc-api-key.md).',
+    ],
+  },
+  {
+    name: 'ascApiKeyIssuerId',
+    type: 'string',
+    description: [
+      'The Issuer ID of your App Store Connect Api Key. [Learn more](https://expo.fyi/creating-asc-api-key.md).',
+    ],
+  },
+  {
+    name: 'ascApiKeyId',
+    type: 'string',
+    description: [
+      'The Key ID of your App Store Connect Api Key. [Learn more](https://expo.fyi/creating-asc-api-key.md).',
+    ],
+  },
+];

--- a/docs/scripts/schemas/unversioned/eas-json-submit-ios-schema.js
+++ b/docs/scripts/schemas/unversioned/eas-json-submit-ios-schema.js
@@ -61,7 +61,7 @@ export default [
     name: 'ascApiKeyId',
     type: 'string',
     description: [
-      'The Key ID of your App Store Connect Api Key. [Learn more](https://expo.fyi/creating-asc-api-key.md).',
+      'The Key ID of your App Store Connect Api Key. [Learn more](https://expo.fyi/creating-asc-api-key).',
     ],
   },
 ];


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Reflect the current state of our cli code because we support ASC Api Keys in iOS submissions now. 

# How

<!--
How did you build this feature or fix this bug and why?
-->

We are in an in-between state where we: 
- accept both the App Specific Password and ASC Api key
- are not autogenerating any credentials yet
- havent made `Apple ID` optional in the cli/www in the case where user passes in ASC Api key

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
