### PR TITLE
bump @expo/config-plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ Package-specific changes not released in any SDK will be added here just before 
 
 ### 🛠 Breaking changes
 
+- Updated `@expo/config-plugins` ([#14798](https://github.com/expo/expo/pull/14798) by [@jkhales](https://github.com/jkhales))
+- Updated `@expo/config-types` ([#14798](https://github.com/expo/expo/pull/14798) by [@jkhales](https://github.com/jkhales))
 - Removed `expo-payments-stripe`. Please use `@stripe/stripe-react-native` instead. ([#14382](https://github.com/expo/expo/pull/14382) by [@cruzach](https://github.com/cruzach))
 - Updated firebase to version 9.0.2, including support for compat libraries and new modular style. ([#14616](https://github.com/expo/expo/pull/14616) by [@sebastianwilczek](https://github.com/sebastianwilczek))
 - `navigator.geolocation` is no longer defined automatically as a side effect of the `expo` package. It previously provided a warning that you needed to install `expo-location`. ([#14441](https://github.com/expo/expo/pull/14441) by [@brentvatne](https://github.com/brentvatne)

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "react-native": "0.64.2"
   },
   "dependencies": {
-    "@expo/config-types": "^42.0.0",
+    "@expo/config-types": "^43.0.0",
     "eslint": "^7.31.0",
     "expo-yarn-workspaces": "*",
     "jsc-android": "^245459.0.0",

--- a/packages/expo-ads-admob/package.json
+++ b/packages/expo-ads-admob/package.json
@@ -35,7 +35,7 @@
     "preset": "expo-module-scripts/ios"
   },
   "dependencies": {
-    "@expo/config-plugins": "^3.1.0",
+    "@expo/config-plugins": "^4.0.2",
     "expo-modules-core": "~0.4.2"
   },
   "devDependencies": {

--- a/packages/expo-ads-facebook/package.json
+++ b/packages/expo-ads-facebook/package.json
@@ -31,7 +31,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.dev/versions/latest/sdk/facebook-ads/",
   "dependencies": {
-    "@expo/config-plugins": "^3.1.0",
+    "@expo/config-plugins": "^4.0.2",
     "expo-modules-core": "~0.4.2",
     "fbemitter": "^2.1.1",
     "nullthrows": "^1.1.0"

--- a/packages/expo-app-auth/package.json
+++ b/packages/expo-app-auth/package.json
@@ -44,7 +44,7 @@
     "preset": "expo-module-scripts"
   },
   "dependencies": {
-    "@expo/config-plugins": "^3.1.0",
+    "@expo/config-plugins": "^4.0.2",
     "expo-modules-core": "~0.4.2",
     "invariant": "^2.2.4"
   },

--- a/packages/expo-apple-authentication/package.json
+++ b/packages/expo-apple-authentication/package.json
@@ -32,7 +32,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.dev/versions/latest/sdk/apple-authentication/",
   "dependencies": {
-    "@expo/config-plugins": "^3.1.0",
+    "@expo/config-plugins": "^4.0.2",
     "expo-modules-core": "~0.4.2"
   },
   "devDependencies": {

--- a/packages/expo-av/package.json
+++ b/packages/expo-av/package.json
@@ -32,7 +32,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.dev/versions/latest/sdk/av/",
   "dependencies": {
-    "@expo/config-plugins": "^3.1.0",
+    "@expo/config-plugins": "^4.0.2",
     "expo-modules-core": "~0.4.2"
   },
   "devDependencies": {

--- a/packages/expo-background-fetch/package.json
+++ b/packages/expo-background-fetch/package.json
@@ -33,7 +33,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.dev/versions/latest/sdk/background-fetch/",
   "dependencies": {
-    "@expo/config-plugins": "^3.1.0",
+    "@expo/config-plugins": "^4.0.2",
     "expo-modules-core": "~0.4.2",
     "expo-task-manager": "~10.0.1"
   },

--- a/packages/expo-barcode-scanner/package.json
+++ b/packages/expo-barcode-scanner/package.json
@@ -35,7 +35,7 @@
     "preset": "expo-module-scripts/ios"
   },
   "dependencies": {
-    "@expo/config-plugins": "^3.1.0",
+    "@expo/config-plugins": "^4.0.2",
     "expo-image-loader": "~3.0.0",
     "expo-modules-core": "~0.4.2"
   },

--- a/packages/expo-branch/package.json
+++ b/packages/expo-branch/package.json
@@ -32,7 +32,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.dev/versions/latest/sdk/branch/",
   "dependencies": {
-    "@expo/config-plugins": "^3.1.0",
+    "@expo/config-plugins": "^4.0.2",
     "expo-modules-core": "~0.4.2",
     "react-native-branch": "5.0.0"
   },

--- a/packages/expo-brightness/package.json
+++ b/packages/expo-brightness/package.json
@@ -35,7 +35,7 @@
     "preset": "expo-module-scripts"
   },
   "dependencies": {
-    "@expo/config-plugins": "^3.1.0",
+    "@expo/config-plugins": "^4.0.2",
     "expo-modules-core": "~0.4.2"
   },
   "devDependencies": {

--- a/packages/expo-calendar/package.json
+++ b/packages/expo-calendar/package.json
@@ -35,7 +35,7 @@
     "preset": "expo-module-scripts/ios"
   },
   "dependencies": {
-    "@expo/config-plugins": "^3.1.0",
+    "@expo/config-plugins": "^4.0.2",
     "expo-modules-core": "~0.4.2"
   },
   "devDependencies": {

--- a/packages/expo-camera/package.json
+++ b/packages/expo-camera/package.json
@@ -34,7 +34,7 @@
     "preset": "expo-module-scripts"
   },
   "dependencies": {
-    "@expo/config-plugins": "^3.1.0",
+    "@expo/config-plugins": "^4.0.2",
     "@koale/useworker": "^4.0.2",
     "expo-modules-core": "~0.4.2",
     "invariant": "2.2.4"

--- a/packages/expo-camera/plugin/build/withCamera.d.ts
+++ b/packages/expo-camera/plugin/build/withCamera.d.ts
@@ -1,5 +1,6 @@
 import { ConfigPlugin } from '@expo/config-plugins';
-export declare function setGradleMaven(buildGradle: string): string;
+import { MergeResults } from '@expo/config-plugins/build/utils/generateCode';
+export declare function addCameraImport(src: string): MergeResults;
 declare const _default: ConfigPlugin<void | {
     cameraPermission?: string | undefined;
     microphonePermission?: string | undefined;

--- a/packages/expo-camera/plugin/build/withCamera.js
+++ b/packages/expo-camera/plugin/build/withCamera.js
@@ -1,18 +1,22 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.setGradleMaven = void 0;
+exports.addCameraImport = void 0;
 const config_plugins_1 = require("@expo/config-plugins");
+const generateCode_1 = require("@expo/config-plugins/build/utils/generateCode");
 const pkg = require('expo-camera/package.json');
 const CAMERA_USAGE = 'Allow $(PRODUCT_NAME) to access your camera';
 const MICROPHONE_USAGE = 'Allow $(PRODUCT_NAME) to access your microphone';
 // Because we need the package to be added AFTER the React and Google maven packages, we create a new allprojects.
 // It's ok to have multiple allprojects.repositories, so we create a new one since it's cheaper than tokenizing
 // the existing block to find the correct place to insert our camera maven.
-const gradleMaven = 'allprojects { repositories { maven { url "$rootDir/../node_modules/expo-camera/android/maven" } } }';
+const gradleMaven = [
+    `def mavenPath = new File(["node", "--print", "require.resolve('expo-camera/package.json')"].execute().text.trim(), "../android/maven")`,
+    `allprojects { repositories { maven { url(mavenPath) } } }`,
+].join('\n');
 const withAndroidCameraGradle = (config) => {
     return config_plugins_1.withProjectBuildGradle(config, (config) => {
         if (config.modResults.language === 'groovy') {
-            config.modResults.contents = setGradleMaven(config.modResults.contents);
+            config.modResults.contents = addCameraImport(config.modResults.contents).contents;
         }
         else {
             throw new Error('Cannot add camera maven gradle because the build.gradle is not groovy');
@@ -20,34 +24,50 @@ const withAndroidCameraGradle = (config) => {
         return config;
     });
 };
-function setGradleMaven(buildGradle) {
-    // If this specific line is present, skip.
-    // This also enables users in bare workflow to comment out the line to prevent expo-camera from adding it back.
-    if (buildGradle.includes('expo-camera/android/maven')) {
-        return buildGradle;
-    }
-    return buildGradle + `\n${gradleMaven}\n`;
+function addCameraImport(src) {
+    return appendContents({
+        tag: 'expo-camera-import',
+        src,
+        newSrc: gradleMaven,
+        comment: '//',
+    });
 }
-exports.setGradleMaven = setGradleMaven;
+exports.addCameraImport = addCameraImport;
+// Fork of config-plugins mergeContents, but appends the contents to the end of the file.
+function appendContents({ src, newSrc, tag, comment, }) {
+    const header = generateCode_1.createGeneratedHeaderComment(newSrc, tag, comment);
+    if (!src.includes(header)) {
+        // Ensure the old generated contents are removed.
+        const sanitizedTarget = generateCode_1.removeGeneratedContents(src, tag);
+        const contentsToAdd = [
+            // @something
+            header,
+            // contents
+            newSrc,
+            // @end
+            `${comment} @generated end ${tag}`,
+        ].join('\n');
+        return {
+            contents: sanitizedTarget !== null && sanitizedTarget !== void 0 ? sanitizedTarget : src + contentsToAdd,
+            didMerge: true,
+            didClear: !!sanitizedTarget,
+        };
+    }
+    return { contents: src, didClear: false, didMerge: false };
+}
 const withCamera = (config, { cameraPermission, microphonePermission } = {}) => {
-    if (!config.ios)
-        config.ios = {};
-    if (!config.ios.infoPlist)
-        config.ios.infoPlist = {};
-    config.ios.infoPlist.NSCameraUsageDescription =
-        cameraPermission || config.ios.infoPlist.NSCameraUsageDescription || CAMERA_USAGE;
-    config.ios.infoPlist.NSMicrophoneUsageDescription =
-        microphonePermission || config.ios.infoPlist.NSMicrophoneUsageDescription || MICROPHONE_USAGE;
-    return config_plugins_1.withPlugins(config, [
-        [
-            config_plugins_1.AndroidConfig.Permissions.withPermissions,
-            [
-                'android.permission.CAMERA',
-                // Optional
-                'android.permission.RECORD_AUDIO',
-            ],
-        ],
-        withAndroidCameraGradle,
+    config = config_plugins_1.withInfoPlist(config, (config) => {
+        config.modResults.NSCameraUsageDescription =
+            cameraPermission || config.modResults.NSCameraUsageDescription || CAMERA_USAGE;
+        config.modResults.NSMicrophoneUsageDescription =
+            microphonePermission || config.modResults.NSMicrophoneUsageDescription || MICROPHONE_USAGE;
+        return config;
+    });
+    config = config_plugins_1.AndroidConfig.Permissions.withPermissions(config, [
+        'android.permission.CAMERA',
+        // Optional
+        'android.permission.RECORD_AUDIO',
     ]);
+    return withAndroidCameraGradle(config);
 };
 exports.default = config_plugins_1.createRunOncePlugin(withCamera, pkg.name, pkg.version);

--- a/packages/expo-contacts/package.json
+++ b/packages/expo-contacts/package.json
@@ -34,7 +34,7 @@
     "preset": "expo-module-scripts"
   },
   "dependencies": {
-    "@expo/config-plugins": "^3.1.0",
+    "@expo/config-plugins": "^4.0.2",
     "expo-modules-core": "~0.4.2",
     "uuid": "^3.4.0"
   },

--- a/packages/expo-dev-client/package.json
+++ b/packages/expo-dev-client/package.json
@@ -31,7 +31,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.dev/clients/introduction/",
   "dependencies": {
-    "@expo/config-plugins": "^3.1.0",
+    "@expo/config-plugins": "^4.0.2",
     "expo-dev-launcher": "0.8.1",
     "expo-dev-menu": "0.8.2",
     "expo-dev-menu-interface": "0.4.1",

--- a/packages/expo-dev-launcher/package.json
+++ b/packages/expo-dev-launcher/package.json
@@ -28,7 +28,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.io",
   "dependencies": {
-    "@expo/config-plugins": "^3.1.0",
+    "@expo/config-plugins": "^4.0.2",
     "resolve-from": "^5.0.0",
     "semver": "^7.3.5"
   },

--- a/packages/expo-dev-menu/package.json
+++ b/packages/expo-dev-menu/package.json
@@ -41,7 +41,7 @@
     "preset": "expo-module-scripts"
   },
   "dependencies": {
-    "@expo/config-plugins": "^3.1.0",
+    "@expo/config-plugins": "^4.0.2",
     "expo-dev-menu-interface": "0.4.1"
   },
   "devDependencies": {

--- a/packages/expo-document-picker/package.json
+++ b/packages/expo-document-picker/package.json
@@ -35,7 +35,7 @@
     "preset": "expo-module-scripts/ios"
   },
   "dependencies": {
-    "@expo/config-plugins": "^3.1.0",
+    "@expo/config-plugins": "^4.0.2",
     "expo-modules-core": "~0.4.2",
     "uuid": "^3.3.2"
   },

--- a/packages/expo-facebook/package.json
+++ b/packages/expo-facebook/package.json
@@ -34,7 +34,7 @@
     "preset": "expo-module-scripts"
   },
   "dependencies": {
-    "@expo/config-plugins": "^3.1.0",
+    "@expo/config-plugins": "^4.0.2",
     "expo-modules-core": "~0.4.2"
   },
   "devDependencies": {

--- a/packages/expo-file-system/package.json
+++ b/packages/expo-file-system/package.json
@@ -35,7 +35,7 @@
     "preset": "expo-module-scripts"
   },
   "dependencies": {
-    "@expo/config-plugins": "^3.1.0",
+    "@expo/config-plugins": "^4.0.2",
     "expo-modules-core": "~0.4.2",
     "uuid": "^3.4.0"
   },

--- a/packages/expo-image-picker/package.json
+++ b/packages/expo-image-picker/package.json
@@ -36,7 +36,7 @@
     "preset": "expo-module-scripts"
   },
   "dependencies": {
-    "@expo/config-plugins": "^3.1.0",
+    "@expo/config-plugins": "^4.0.2",
     "expo-modules-core": "~0.4.2",
     "uuid": "7.0.2"
   },

--- a/packages/expo-local-authentication/package.json
+++ b/packages/expo-local-authentication/package.json
@@ -38,7 +38,7 @@
     "preset": "expo-module-scripts"
   },
   "dependencies": {
-    "@expo/config-plugins": "^3.1.0",
+    "@expo/config-plugins": "^4.0.2",
     "invariant": "^2.2.4"
   },
   "devDependencies": {

--- a/packages/expo-location/package.json
+++ b/packages/expo-location/package.json
@@ -42,7 +42,7 @@
     "expo-module-scripts": "^2.0.0"
   },
   "dependencies": {
-    "@expo/config-plugins": "^3.1.0",
+    "@expo/config-plugins": "^4.0.2",
     "expo-modules-core": "~0.4.2"
   }
 }

--- a/packages/expo-media-library/package.json
+++ b/packages/expo-media-library/package.json
@@ -38,7 +38,7 @@
     "preset": "expo-module-scripts"
   },
   "dependencies": {
-    "@expo/config-plugins": "^3.1.0",
+    "@expo/config-plugins": "^4.0.2",
     "expo-modules-core": "~0.4.2"
   },
   "devDependencies": {

--- a/packages/expo-notifications/package.json
+++ b/packages/expo-notifications/package.json
@@ -37,7 +37,7 @@
     "preset": "expo-module-scripts/ios"
   },
   "dependencies": {
-    "@expo/config-plugins": "^3.1.0",
+    "@expo/config-plugins": "^4.0.2",
     "@expo/image-utils": "^0.3.16",
     "@ide/backoff": "^1.0.0",
     "abort-controller": "^3.0.0",

--- a/packages/expo-screen-orientation/package.json
+++ b/packages/expo-screen-orientation/package.json
@@ -36,7 +36,7 @@
     "preset": "expo-module-scripts"
   },
   "dependencies": {
-    "@expo/config-plugins": "^3.1.0",
+    "@expo/config-plugins": "^4.0.2",
     "expo-modules-core": "~0.4.2"
   },
   "devDependencies": {

--- a/packages/expo-sensors/package.json
+++ b/packages/expo-sensors/package.json
@@ -40,7 +40,7 @@
     "preset": "expo-module-scripts"
   },
   "dependencies": {
-    "@expo/config-plugins": "^3.1.0",
+    "@expo/config-plugins": "^4.0.2",
     "expo-modules-core": "~0.4.2",
     "invariant": "^2.2.4"
   },

--- a/packages/expo-task-manager/package.json
+++ b/packages/expo-task-manager/package.json
@@ -33,7 +33,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.dev/versions/latest/sdk/task-manager/",
   "dependencies": {
-    "@expo/config-plugins": "^3.1.0",
+    "@expo/config-plugins": "^4.0.2",
     "expo-modules-core": "~0.4.2",
     "unimodules-app-loader": "~3.0.0",
     "unimodules-task-manager-interface": "7.0.1"

--- a/packages/expo-tracking-transparency/package.json
+++ b/packages/expo-tracking-transparency/package.json
@@ -30,7 +30,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.dev/versions/latest/sdk/module-template",
   "dependencies": {
-    "@expo/config-plugins": "^3.1.0",
+    "@expo/config-plugins": "^4.0.2",
     "expo-modules-core": "~0.4.2"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1231,7 +1231,7 @@
     mv "~2"
     safe-json-stringify "~1"
 
-"@expo/config-plugins@3.1.0", "@expo/config-plugins@^3.1.0":
+"@expo/config-plugins@3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@expo/config-plugins/-/config-plugins-3.1.0.tgz#0752ff33c5eab21cf42034a44e79df97f0f867f8"
   integrity sha512-V5qxaxCAExBM0TXmbU1QKiZcAGP3ecu7KXede8vByT15cro5PkcWu2sSdJCYbHQ/gw6Vf/i8sr8gKlN8V8TSLg==


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Bump all instances of @expo/config-plugins to 4.0.2 following discussion in slack with @brentvatne and this comment from @Simek https://github.com/expo/expo/pull/14788#issuecomment-946067642

# How

1. search replace in the various `package.json`.
2. updated the @expo/config-types version to 43 here as well: https://github.com/expo/expo/blob/sdk-43/package.json#L28

# Test Plan

ran `et check-packages`
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
