### PR TITLE
[docs] Add image picker config plugin and permissions

### DIFF
--- a/docs/pages/versions/unversioned/sdk/imagepicker.md
+++ b/docs/pages/versions/unversioned/sdk/imagepicker.md
@@ -3,8 +3,10 @@ title: ImagePicker
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-image-picker'
 ---
 
-import APISection from '~/components/plugins/APISection'; 
-import InstallSection from '~/components/plugins/InstallSection'; 
+import { ConfigClassic, ConfigReactNative, ConfigPluginExample, ConfigPluginProperties } from '~/components/plugins/ConfigSection';
+import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
+import APISection from '~/components/plugins/APISection';
+import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import Video from '~/components/plugins/Video';
 import SnackInline from '~/components/plugins/SnackInline';
@@ -19,9 +21,56 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 <InstallSection packageName="expo-image-picker" />
 
-## Configuration
+## Configuration in app.json / app.config.js
 
-In managed apps, the permissions to pick images, from camera ([`Permissions.CAMERA`](permissions.md#permissionscamera)) or camera roll ([`Permissions.MEDIA_LIBRARY`](permissions.md#permissionsmedia_library)), are added automatically.
+<!-- update library name here -->
+
+You can configure `expo-image-picker` using its built-in [config plugin](../../../guides/config-plugins.md) if you use config plugins in your project ([EAS Build](../../../build/introduction.md) or `expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
+
+<ConfigClassic>
+
+<!-- this is a standard type of message that will apply to many libraries. if there are no usage description keys or permissions, then you may want to say something else here -->
+
+You can configure [the permissions for this library](#permissions) using [`ios.infoPlist`](../config/app.md#infoplist) and [`android.permissions`](../config/app.md#permissions).
+
+</ConfigClassic>
+
+<ConfigReactNative>
+
+<!-- update library name and link here -->
+
+Learn how to configure the native projects in the [installation instructions in the `expo-image-picker` repository](https://github.com/expo/expo/tree/master/packages/expo-image-picker#installation-in-bare-react-native-projects).
+
+</ConfigReactNative>
+
+<ConfigPluginExample>
+
+<!-- add some example usage of the plugin. you don't need to provide every option -->
+
+```json
+{
+  "expo": {
+    "plugins": [
+      [
+        "expo-image-picker",
+        {
+          "photosPermission": "The app accesses your photos to let you share them with your friends."
+        }
+      ]
+    ]
+  }
+}
+```
+
+</ConfigPluginExample>
+
+<!-- look in the plugin directory for the library and see what the options are, then fill in the below table as needed. here's an example plugin: https://git.io/JKlrN -->
+
+<ConfigPluginProperties properties={[
+{ name: 'photosPermission', platform: 'ios', description: 'A string to set the NSPhotoLibraryUsageDescription permission message.', default: '"Allow $(PRODUCT_NAME) to access your photos"' },
+{ name: 'cameraPermission', platform: 'ios', description: 'A string to set the NSCameraUsageDescription permission message.', default: '"Allow $(PRODUCT_NAME) to access your camera"' },
+{ name: 'microphonePermission', platform: 'ios', description: 'A string to set the NSMicrophoneUsageDescription permission message.', default: '"Allow $(PRODUCT_NAME) to access your microphone"' }
+]} />
 
 ## Usage
 
@@ -87,7 +136,6 @@ When you run this example and pick an image, you will see the image that you pic
 
 Please refer to the [with-aws-storage-upload example](https://github.com/expo/examples/tree/master/with-aws-storage-upload). Follow [Amplify docs](https://docs.amplify.aws/) to set your project up correctly.
 
-
 ## Using ImagePicker with Firebase
 
 Please refer to the [with-firebase-storage-upload example](https://github.com/expo/examples/tree/master/with-firebase-storage-upload). Make sure you follow the ["Using Firebase"](/guides/using-firebase/) docs to set your project up correctly.
@@ -99,3 +147,30 @@ import * as ImagePicker from 'expo-image-picker';
 ```
 
 <APISection packageName="expo-image-picker" apiName="ImagePicker" />
+
+## Permissions
+
+### Android
+
+<!-- look in the library AndroidManifest.xml and the config plugin to see which permissions are added -->
+
+The following permissions are added automatically through the library `AndroidManifest.xml`.
+
+<AndroidPermissions permissions={['CAMERA', 'READ_EXTERNAL_STORAGE', 'WRITE_EXTERNAL_STORAGE']} />
+
+<!-- if no permissions required, just use this text: -->
+
+<!-- _No permissions required_. -->
+
+### iOS
+
+<!-- look in the README and config plugin to see what usage descriptions required, add that here -->
+
+The following usage description keys are used by the APIs in this library.
+
+<IOSPermissions permissions={[ 'NSMicrophoneUsageDescription', 'NSPhotoLibraryUsageDescription', 'NSCameraUsageDescription' ]} />
+
+<!-- if no permissions required, just use this text: -->
+
+<!-- _No usage description required_. -->
+

--- a/docs/pages/versions/v43.0.0/sdk/imagepicker.md
+++ b/docs/pages/versions/v43.0.0/sdk/imagepicker.md
@@ -3,6 +3,8 @@ title: ImagePicker
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-43/packages/expo-image-picker'
 ---
 
+import { ConfigClassic, ConfigReactNative, ConfigPluginExample, ConfigPluginProperties } from '~/components/plugins/ConfigSection';
+import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
 import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import Video from '~/components/plugins/Video';
@@ -18,9 +20,56 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 <InstallSection packageName="expo-image-picker" />
 
-## Configuration
+## Configuration in app.json / app.config.js
 
-In managed apps, the permissions to pick images, from camera ([`Permissions.CAMERA`](permissions.md#permissionscamera)) or camera roll ([`Permissions.MEDIA_LIBRARY`](permissions.md#permissionsmedia_library)), are added automatically.
+<!-- update library name here -->
+
+You can configure `expo-image-picker` using its built-in [config plugin](../../../guides/config-plugins.md) if you use config plugins in your project ([EAS Build](../../../build/introduction.md) or `expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
+
+<ConfigClassic>
+
+<!-- this is a standard type of message that will apply to many libraries. if there are no usage description keys or permissions, then you may want to say something else here -->
+
+You can configure [the permissions for this library](#permissions) using [`ios.infoPlist`](../config/app.md#infoplist) and [`android.permissions`](../config/app.md#permissions).
+
+</ConfigClassic>
+
+<ConfigReactNative>
+
+<!-- update library name and link here -->
+
+Learn how to configure the native projects in the [installation instructions in the `expo-image-picker` repository](https://github.com/expo/expo/tree/master/packages/expo-image-picker#installation-in-bare-react-native-projects).
+
+</ConfigReactNative>
+
+<ConfigPluginExample>
+
+<!-- add some example usage of the plugin. you don't need to provide every option -->
+
+```json
+{
+  "expo": {
+    "plugins": [
+      [
+        "expo-image-picker",
+        {
+          "photosPermission": "The app accesses your photos to let you share them with your friends."
+        }
+      ]
+    ]
+  }
+}
+```
+
+</ConfigPluginExample>
+
+<!-- look in the plugin directory for the library and see what the options are, then fill in the below table as needed. here's an example plugin: https://git.io/JKlrN -->
+
+<ConfigPluginProperties properties={[
+{ name: 'photosPermission', platform: 'ios', description: 'A string to set the NSPhotoLibraryUsageDescription permission message.', default: '"Allow $(PRODUCT_NAME) to access your photos"' },
+{ name: 'cameraPermission', platform: 'ios', description: 'A string to set the NSCameraUsageDescription permission message.', default: '"Allow $(PRODUCT_NAME) to access your camera"' },
+{ name: 'microphonePermission', platform: 'ios', description: 'A string to set the NSMicrophoneUsageDescription permission message.', default: '"Allow $(PRODUCT_NAME) to access your microphone"' }
+]} />
 
 ## Usage
 
@@ -308,3 +357,29 @@ Object of type `ImagePickerErrorResult` contains following keys:
 - **code (_string_)** - The error code.
 - **message (_string_)** - The error message.
 - **exception (_string | undefined_)** - The exception which caused the error.
+
+## Permissions
+
+### Android
+
+<!-- look in the library AndroidManifest.xml and the config plugin to see which permissions are added -->
+
+The following permissions are added automatically through the library `AndroidManifest.xml`.
+
+<AndroidPermissions permissions={['CAMERA', 'READ_EXTERNAL_STORAGE', 'WRITE_EXTERNAL_STORAGE']} />
+
+<!-- if no permissions required, just use this text: -->
+
+<!-- _No permissions required_. -->
+
+### iOS
+
+<!-- look in the README and config plugin to see what usage descriptions required, add that here -->
+
+The following usage description keys are used by the APIs in this library.
+
+<IOSPermissions permissions={[ 'NSMicrophoneUsageDescription', 'NSPhotoLibraryUsageDescription', 'NSCameraUsageDescription' ]} />
+
+<!-- if no permissions required, just use this text: -->
+
+<!-- _No usage description required_. -->


### PR DESCRIPTION
# Why

Starting to roll out config plugins and new permissions tables, this PR can serve as an example.

# How

Follow up from #14765. Process for creating these specific docs described in inline comments.

# Test Plan

Run the docs locally.