### PR TITLE
[docs] add new eas json profile names

### DIFF
--- a/docs/pages/build-reference/apk.md
+++ b/docs/pages/build-reference/apk.md
@@ -9,6 +9,7 @@ The default file format used when building Android apps with EAS Build is an [An
 ### Managed projects
 
 By default, EAS Build produces Android App Bundle, you can change it by:
+
 - setting `buildType` to `apk`
 - setting `developmentClient` to true
 - setting `gradleCommand` to `:app:assembleRelease`, `:app:assembleDebug` or any other gradle command that produces APK
@@ -16,7 +17,6 @@ By default, EAS Build produces Android App Bundle, you can change it by:
 ```json
 {
   "build": {
-    "release": {},
     "preview": {
       "android": {
         "buildType": "apk"
@@ -29,7 +29,8 @@ By default, EAS Build produces Android App Bundle, you can change it by:
     },
     "preview3": {
       "developmentClient": true
-    }
+    },
+    "production": {}
   }
 }
 ```

--- a/docs/pages/build-reference/build-configuration.md
+++ b/docs/pages/build-reference/build-configuration.md
@@ -19,22 +19,24 @@ If you only want to use EAS Build for a single platform, that's fine. If you cha
 
 The command will create an `eas.json` file in the root directory with the default configuration. It looks something like this:
 
-
 ```json
 {
   "build": {
-    "release": {},
     "development": {
       "developmentClient": true,
       "distribution": "internal"
-    }
+    },
+    "preview": {
+      "distribution": "internal"
+    },
+    "production": {}
   }
 }
 ```
 
 If you have a bare project, it will look a bit different.
 
-This is your EAS Build configuration. It defines two build profiles named `release` and `development` (you can have multiple build profiles like `release`, `debug`, `testing`, etc.) for each platform. If you want to learn more about `eas.json` see the [Configuration with eas.json](/build/eas-json.md) page.
+This is your EAS Build configuration. It defines three build profiles named `development`, `preview`, and `production` (you can have multiple build profiles like `production`, `debug`, `testing`, etc.) for each platform. If you want to learn more about `eas.json` see the [Configuration with eas.json](/build/eas-json.md) page.
 
 #### 3. Configure the project
 

--- a/docs/pages/build-reference/simulators.md
+++ b/docs/pages/build-reference/simulators.md
@@ -11,12 +11,12 @@ To build your app for installation into an iOS simulator, you can create a new p
 ```json
 {
   "build": {
-    "release": {},
     "preview": {
       "ios": {
         "simulator": true
       }
-    }
+    },
+    "production": {}
   }
 }
 ```

--- a/docs/pages/build-reference/variables.md
+++ b/docs/pages/build-reference/variables.md
@@ -17,7 +17,7 @@ You can specify environment variables for specific build jobs using `eas.json`:
 ```json
 {
   "build": {
-    "release": {
+    "production": {
       "env": {
         "API_URL": "https://api.production.com"
       }
@@ -31,14 +31,14 @@ You can access these variables in your application using the techniques describe
 ```json
 {
   "build": {
-    "release": {
+    "production": {
       "env": {
         "API_URL": "https://api.production.com"
       }
     },
     "test": {
       "distribution": "internal",
-      "extends": "release"
+      "extends": "production"
     }
   }
 }
@@ -141,7 +141,7 @@ The following environment variables are exposed to each build job:
 - `CI=1` - indicates this is a CI environment
 - `EAS_BUILD=true` - indicates this is an EAS Build environment
 - `EAS_BUILD_ID` - the build ID, e.g. `f51831f0-ea30-406a-8c5f-f8e1cc57d39c`
-- `EAS_BUILD_PROFILE` - the name of the build profile from `eas.json`, e.g. `release`
+- `EAS_BUILD_PROFILE` - the name of the build profile from `eas.json`, e.g. `production`
 - `EAS_BUILD_GIT_COMMIT_HASH` - the hash of the Git commit, e.g. `88f28ab5ea39108ade978de2d0d1adeedf0ece76`
 - `EAS_BUILD_NPM_CACHE_URL` - the URL of the npm cache ([learn more](/build-reference/private-npm-packages))
 - `EAS_BUILD_USERNAME` - the username of the user initiating the build (it's undefined for bot users)

--- a/docs/pages/build/eas-json.md
+++ b/docs/pages/build/eas-json.md
@@ -14,11 +14,14 @@ import iosSchema from '~/scripts/schemas/unversioned/eas-json-build-ios-schema.j
 ```json
 {
   "build": {
-    "release": {},
     "development": {
       "developmentClient": true,
       "distribution": "internal"
-    }
+    },
+    "preview": {
+      "distribution": "internal"
+    },
+    "production": {}
   }
 }
 ```
@@ -28,7 +31,6 @@ or
 ```json
 {
   "build": {
-    "release": {},
     "development": {
       "distribution": "internal",
       "android": {
@@ -37,12 +39,16 @@ or
       "ios": {
         "buildConfiguration": "Debug"
       }
-    }
+    },
+    "preview": {
+      "distribution": "internal"
+    },
+    "production": {}
   }
 }
 ```
 
-The JSON object under the `build` key can contain multiple build profiles. Every build profile can have an arbitrary name. The default profile that is expected by EAS CLI to exist is `release` (if you'd like to build your app using another build profile you need to specify it with a parameter - `eas build --platform android --profile foobar`). In the example, there are two build profiles (`release` and `development`), however they could be named `foo` or `bar` or whatever you'd like. Inside each build profile you can specify `android` and `ios` fields that contain platform-specific configuration for the build, any common options can be also stored there or in the root of the build profile.
+The JSON object under the `build` key can contain multiple build profiles. Every build profile can have an arbitrary name. The default profile that is expected by EAS CLI to exist is `production` (if you'd like to build your app using another build profile you need to specify it with a parameter - `eas build --platform android --profile foobar`). In the example, there are three build profiles (`development`, `preview`, and `production`), however they could be named `foo` or `bar` or whatever you'd like. Inside each build profile you can specify `android` and `ios` fields that contain platform-specific configuration for the build, any common options can be also stored there or in the root of the build profile.
 
 Generally, the schema of this file looks like this:
 
@@ -103,22 +109,6 @@ If you're also using EAS Submit, [see how to use `eas.json` to configure your su
         }
       }
     },
-    "release": {
-      "extends": "base",
-      "env": {
-        "ENVIRONMENT": "production"
-      }
-    },
-    "staging": {
-      "extends": "base",
-      "env": {
-        "ENVIRONMENT": "staging"
-      },
-      "distribution": "internal",
-      "android": {
-        "buildType": "apk"
-      }
-    },
     "development": {
       "extends": "base",
       "developmentClient": true,
@@ -131,6 +121,22 @@ If you're also using EAS Submit, [see how to use `eas.json` to configure your su
       },
       "ios": {
         "simulator": true
+      }
+    },
+    "staging": {
+      "extends": "base",
+      "env": {
+        "ENVIRONMENT": "staging"
+      },
+      "distribution": "internal",
+      "android": {
+        "buildType": "apk"
+      }
+    },
+    "production": {
+      "extends": "base",
+      "env": {
+        "ENVIRONMENT": "production"
       }
     }
   }
@@ -159,22 +165,6 @@ If you're also using EAS Submit, [see how to use `eas.json` to configure your su
         "yarn": "1.22.5"
       }
     },
-    "release": {
-      "extends": "base",
-      "env": {
-        "ENVIRONMENT": "production"
-      }
-    },
-    "staging": {
-      "extends": "base",
-      "env": {
-        "ENVIRONMENT": "staging"
-      },
-      "distribution": "internal",
-      "android": {
-        "gradleCommand": ":app:assembleRelease"
-      }
-    },
     "development": {
       "extends": "base",
       "env": {
@@ -188,6 +178,22 @@ If you're also using EAS Submit, [see how to use `eas.json` to configure your su
       "ios": {
         "simulator": true,
         "buildConfiguration": "Debug"
+      }
+    },
+    "staging": {
+      "extends": "base",
+      "env": {
+        "ENVIRONMENT": "staging"
+      },
+      "distribution": "internal",
+      "android": {
+        "gradleCommand": ":app:assembleRelease"
+      }
+    },
+    "production": {
+      "extends": "base",
+      "env": {
+        "ENVIRONMENT": "production"
       }
     }
   }

--- a/docs/pages/build/updates.md
+++ b/docs/pages/build/updates.md
@@ -10,12 +10,12 @@ EAS Build includes some special affordances for Expo's over-the-air updates libr
 
 Each [build profile](./eas-json.md#build-profiles) can be assigned to a release channel, so updates for builds produced for a given profile will pull only those releases that are published to its release channel. If a release channel is not specified, the value will be `"default"`.
 
-The following example demonstrates how you might use the `"production"` release channel for release builds, and the `"staging"` release channel for test builds distributed with [internal distribution](internal-distribution.md).
+The following example demonstrates how you might use the `"production"` release channel for production builds, and the `"staging"` release channel for test builds distributed with [internal distribution](internal-distribution.md).
 
 ```json
 {
   "build": {
-    "release": {
+    "production": {
       "releaseChannel": "production"
     },
     "team": {

--- a/docs/pages/clients/eas-build.md
+++ b/docs/pages/clients/eas-build.md
@@ -7,23 +7,21 @@ import { Tab, Tabs } from '~/components/plugins/Tabs';
 
 ## Setting up EAS
 
-You can set up your project to use EAS by running `eas build:configure`.  If you have not installed EAS CLI yet, you can do so by running `npm install -g eas-cli` (or `yarn global add eas-cli`.)
-
-
+You can set up your project to use EAS by running `eas build:configure`. If you have not installed EAS CLI yet, you can do so by running `npm install -g eas-cli` (or `yarn global add eas-cli`.)
 
 ### Modifying an existing eas.json
 
 If you have already have an `eas.json` file in your project, you'll need to update your config to create builds of your custom client.
 
-To create a custom development client instead of a release build, set the `developmentClient` value to `true`.
+To create a custom development client instead of a production build, set the `developmentClient` value to `true`.
 To create the build that can be installed on a physical device, set the `distribution` value to [`internal`](/build/internal-distribution.md).
 To create a simulator build, set the `ios.simulator` value to `true`.
 
 An example configuration would look like this:
+
 ```json
 {
   "build": {
-    "release": {},
     "development": {
       "developmentClient": true,
       "distribution": "internal"
@@ -33,7 +31,8 @@ An example configuration would look like this:
       "ios": {
         "simulator": true
       }
-    }
+    },
+    "production": {}
   }
 }
 ```
@@ -50,7 +49,7 @@ Register any devices you would like to use your development client on to your ad
 Generate the build signed with your ad hoc provisioning profile.
 <InstallSection packageName="expo-dev-launcher" cmd={["eas build --profile development --platform ios"]} hideBareInstructions />
 
-You will need to generate a new build to install successfully on any new devices added to your provisioning profile.  [You can find more guidance on distributing your app to your team here.](https://docs.expo.dev/build/internal-distribution/)
+You will need to generate a new build to install successfully on any new devices added to your provisioning profile. [You can find more guidance on distributing your app to your team here.](https://docs.expo.dev/build/internal-distribution/)
 
 ### For Android:
 

--- a/docs/pages/preview/eas-update/getting-started.md
+++ b/docs/pages/preview/eas-update/getting-started.md
@@ -88,12 +88,12 @@ Setting up EAS Update allows you to push critical bug fixes and improvements tha
 
    Then follow the prompts.
 
-   This will create a file named **eas.json**. Inside the `release` profile, add the `channel` property with a value of `"production"`:
+   This will create a file named **eas.json**. Inside the `production` profile, add the `channel` property with a value of `"production"`:
 
    ```bash
    {
      "build": {
-        "release": {
+        "production": {
           "channel": "production"
         },
        ...

--- a/docs/pages/submit/eas-json.md
+++ b/docs/pages/submit/eas-json.md
@@ -15,7 +15,7 @@ import submitIosSchema from '~/scripts/schemas/unversioned/eas-json-submit-ios-s
 ```json
 {
   "submit": {
-    "release": {
+    "production": {
       "android": {
         "serviceAccountKeyPath": "../path/to/api-xxx-yyy-zzz.json",
         "track": "internal"
@@ -30,7 +30,7 @@ import submitIosSchema from '~/scripts/schemas/unversioned/eas-json-submit-ios-s
 }
 ```
 
-The JSON object under the `submit` key can contain multiple submit profiles. Every submit profile can have an arbitrary name. If you run `eas submit` without a profile name specified and you have the `release` profile defined in `eas.json`, it'll be used to configure your submission. If you'd like EAS CLI to pick up another submit profile, you need to specify it with a parameter, e.g. `eas submit --platform ios --profile foobar`.
+The JSON object under the `submit` key can contain multiple submit profiles. Every submit profile can have an arbitrary name. If you run `eas submit` without a profile name specified and you have the `production` profile defined in `eas.json`, it'll be used to configure your submission. If you'd like EAS CLI to pick up another submit profile, you need to specify it with a parameter, e.g. `eas submit --platform ios --profile foobar`.
 
 The schema of this file looks like this:
 


### PR DESCRIPTION
# Why

We updated the default **eas.json** configuration in https://github.com/expo/eas-cli/pull/677. This PR adds those defaults to the docs.

# Test Plan

Read through the "Configuring EAS Build with eas.json" doc, and make sure it still makes sense with the new names, and that it matches the default configuration in the PR mentioned above.
