### PR TITLE
[expo] Remove firebase js sdk as bundled native module

### DIFF
--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -86,7 +86,6 @@
   "expo-updates": "~0.10.3",
   "expo-video-thumbnails": "~6.0.1",
   "expo-web-browser": "~10.0.1",
-  "firebase": "9.1.0",
   "lottie-react-native": "4.0.3",
   "react-native-appearance": "~0.3.3",
   "react-native-branch": "5.0.0",


### PR DESCRIPTION
# Why

It's not a native module, versions 7..9 should work (partially) in Expo. There are a couple open issues on v9 support, forcing people to upgrade to v9 doesn't seem like a good idea for now.

# How

Remove firebase from bundled native modules list to avoid upgrading this module with `expo upgrade`

# Test Plan

Test if `expo install firebase` considers firebase as SDK compatible library (should not be the case).

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
