### PR TITLE
[docs] Add installing-expo-modules doc and hide/update unimodules guide

### DIFF
--- a/docs/components/DocumentationSidebarLink.tsx
+++ b/docs/components/DocumentationSidebarLink.tsx
@@ -101,7 +101,15 @@ export default class DocumentationSidebarLink extends React.Component<Props> {
     return false;
   }
 
+  isHidden() {
+    return this.props.info.hidden;
+  }
+
   render() {
+    if (this.isHidden()) {
+      return null;
+    }
+
     const customDataAttributes = this.isSelected()
       ? {
           'data-sidebar-anchor-selected': true,

--- a/docs/constants/navigation-data.js
+++ b/docs/constants/navigation-data.js
@@ -66,11 +66,14 @@ const generateGeneralNavLinks = (path_, arr = null) => {
     // Only process markdown files that are not index pages
     if (ext === '.md' && name !== 'index') {
       try {
-        const title = fm(fs.readFileSync(filePath, 'utf8')).attributes.title;
-        const sidebarTitle = fm(fs.readFileSync(filePath, 'utf8')).attributes.sidebar_title;
+        const attributes = fm(fs.readFileSync(filePath, 'utf8')).attributes;
+        const title = attributes.title;
+        const hidden = !!attributes.hidden;
+        const sidebarTitle = attributes.sidebar_title;
         const obj = {
           name: title,
           sidebarTitle,
+          hidden,
           href: processUrl(filePath),
         };
         arr.push(obj);

--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -266,6 +266,7 @@ const sections = [
       'Up and Running',
       'Using Libraries',
       'Existing Apps',
+      'Installing Expo modules',
       'Installing react-native-unimodules',
       'Installing expo-updates',
       'Supported Expo SDK APIs',

--- a/docs/pages/bare/installing-expo-modules.md
+++ b/docs/pages/bare/installing-expo-modules.md
@@ -11,9 +11,13 @@ In order to use Expo modules in your app, you will need to install and configure
 
 The `expo` package has a small footprint; it includes only a minimal set of packages that are needed in nearly every app and the module and autolinking infrastructure that other Expo SDK packages are built with. Once the `expo` package is installed and configured in your project, you can use `expo install` to add any other Expo module from the SDK.
 
+The easiest way to get started with Expo modules is to initialize a new bare workflow project with Expo CLI: `expo init --template bare-minimum`.
+
+If you have an existing project without Expo modules installed (perhaps created with `npx react-native init`), please follow the automatic or manual installation instructions below.
+
 ## Automatic installation
 
-The easiest way to get up and running is with the `install-expo-modules` command.
+Aside from initializing a new project with `expo-cli`, the easiest way to get up and running is with the `install-expo-modules` command.
 
 <InstallSection packageName="expo" cmd={["# Install and configure the expo package automatically", "npx install-expo-modules"]} hideBareInstructions />
 

--- a/docs/pages/bare/installing-expo-modules.md
+++ b/docs/pages/bare/installing-expo-modules.md
@@ -1,0 +1,107 @@
+---
+title: Installing Expo modules
+---
+
+import InstallSection from '~/components/plugins/InstallSection';
+import ConfigurationDiff from '~/components/plugins/ConfigurationDiff';
+
+> Are you migrating from `react-native-unimodules`? Please refer to [the Expo modules migration guide](https://expo.fyi/expo-modules-migration).
+
+In order to use Expo modules in your app, you will need to install and configure the `expo` package.
+
+The `expo` package has a small footprint; it includes only a minimal set of packages that are needed in nearly every app and the module and autolinking infrastructure that other Expo SDK packages are built with. Once the `expo` package is installed and configured in your project, you can use `expo install` to add any other Expo module from the SDK.
+
+## Automatic installation
+
+The easiest way to get up and running is with the `install-expo-modules` command.
+
+<InstallSection packageName="expo" cmd={["# Install and configure the expo package automatically", "npx install-expo-modules"]} hideBareInstructions />
+
+- ✅ **When the command succeeds**, you will be able any Expo module in your app! Proceed to [Usage](#usage) for more information.
+- ❌ **If the command fails**, please follow the manual installation instructions. Updating code programmatically can be tricky, and if your project deviates significantly from a default React Native project then manual installation is needed in order to adapt the instructions to your codebase.
+
+## Manual installation
+
+<InstallSection packageName="expo" cmd={["npm install expo"]} hideBareInstructions />
+
+<br />
+
+Once installation is complete, apply the changes from the following diffs to configure Expo modules in your project. This is expected to take about five minutes, and you may need to adapt it slightly depending on how customized your project is.
+
+### Configuration for iOS
+
+<ConfigurationDiff source="/static/diffs/expo-ios.diff" />
+
+Save all of your changes. In Xcode, update the iOS Deployment Target under `Target → Build Settings → Deployment` to `iOS 12.0`. The last step is to install the project's CocoaPods again in order to pull in Expo modules that are detected by `use_expo_modules!` directive that we added to the `Podfile`:
+
+<InstallSection packageName="expo" cmd={["# Install pods", "npx pod-install", "", "# Alternatively, the run command will install them for you", "expo run:ios"]} hideBareInstructions />
+
+<div style={{marginTop: 50}} />
+
+### Configuration for Android
+
+<ConfigurationDiff source="/static/diffs/expo-android.diff" />
+
+<div style={{marginTop: -10}} />
+
+## Usage
+
+### Verifying installation
+
+You can verify that installation was successful by logging a value from [expo-constants](/versions/latest/sdk/constants/). Run `expo install expo-constants`, then run `expo run:[android|ios]` and modify your app JavaScript code to add the following:
+
+```js
+import Constants from 'expo-constants';
+console.log(Constants.systemFonts);
+```
+
+### Using Expo SDK packages
+
+Once the `expo` package is installed and configured in your project, you can use `expo install` to add any other Expo module from the SDK. Learn more in ["Using Libraries"](../using-libraries.md).
+
+### Expo modules included in the `expo` package
+
+The following Expo modules are brought in as dependencies of the `expo` package:
+
+- [expo-application](/versions/latest/sdk/application.md) - Generates the installation id in remote logging in development. This module is optional and can be safely removed if you do not use `expo-dev-client`.
+- [expo-asset](/versions/latest/sdk/asset.md) - A JavaScript-only package that builds around `expo-file-system` and provides a common foundation for assets across all Expo modules.
+- [expo-constants](/versions/latest/sdk/constants.md) - Provides access to the manifest.
+- [expo-file-system](/versions/latest/sdk/filesystem.md) - Interact with the device file system. Used by `expo-asset` and many other Expo modules. Commonly used directly by developers in application code.
+- [expo-font](/versions/latest/sdk/font.md) - Load fonts at runtime. This module is optional and can be safely removed, however; it is recommended if you use `expo-dev-client` for development and it is required by `@expo/vector-icons`.
+- [expo-keep-wake](/versions/latest/sdk/keep-awake.md) - Prevents your device from going to sleep while developing your app. This module is optional and can be safely removed.
+
+To exclude any of these modules, refer to the following guide on [excluding modules from autolinking](#excluding-specific-modules-from-autolinking).
+
+
+### Excluding specific modules from autolinking
+
+If you need to exclude Expo modules that you are not using but they got installed by other dependencies, you can use the `expo.autolinking` field in `package.json`:
+
+```json
+{
+  "name": "...",
+  "dependencies": {},
+  "expo": {
+    "autolinking": {
+      "exclude": ["expo-keep-awake"]
+    }
+  }
+}
+```
+
+You can exclude only for a specific platform by using `exclude` under the platform key:
+
+```json
+{
+  "name": "...",
+  "dependencies": {},
+  "expo": {
+    "autolinking": {
+      "exclude": ["expo-font"],
+      "ios": {
+        "exclude": ["expo-keep-awake"]
+      }
+    }
+  }
+}
+```

--- a/docs/pages/bare/installing-unimodules.md
+++ b/docs/pages/bare/installing-unimodules.md
@@ -1,16 +1,20 @@
 ---
 title: Installing react-native-unimodules
+hidden: true
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';
-
 import ConfigurationDiff from '~/components/plugins/ConfigurationDiff';
+
+> 🚨 **This library is deprecated!**
+>
+> As of Expo SDK 43, [react-native-unimodules is deprecated in favor of the expo package](https://blog.expo.dev/whats-new-in-expo-modules-infrastructure-7a7cdda81ebc). Please refer to the [Installing Expo modules guide](../installing-expo-modules.md).
 
 This library contains infrastructure and a small set of foundational libraries and interfaces that are commonly depended on by other modules. You can install react-native-unimodules in any react-native app, and once it is installed you can use most of the libraries from the Expo SDK, like expo-camera, expo-media-library and many more.
 
-> 💡 If you are creating a new project, we recommend using `npx create-react-native-app` instead of `npx react-native init` because it will handle the following configuration for you automatically.
-
 ## Installation
+
+> The following instructions for installing `react-native-unimodules` are present only for archival purposes, we advise that you do not install the library in any new projects and that you [use Expo modules instead](../bare/installing-expo-modules.md).
 
 <InstallSection packageName="react-native-unimodules" cmd={["npm install react-native-unimodules", "npx pod-install"]} hideBareInstructions />
 

--- a/docs/public/static/diffs/expo-android.diff
+++ b/docs/public/static/diffs/expo-android.diff
@@ -1,0 +1,83 @@
+diff --git a/android/app/src/main/java/com/myapp/MainActivity.java b/android/app/src/main/java/com/myapp/MainActivity.java
+index 557797a..2ccae2e 100644
+--- a/android/app/src/main/java/com/myapp/MainActivity.java
++++ b/android/app/src/main/java/com/myapp/MainActivity.java
+@@ -1,4 +1,6 @@
+ package com.myapp;
++import expo.modules.ReactActivityDelegateWrapper;
++import com.facebook.react.ReactActivityDelegate;
+ 
+ import com.facebook.react.ReactActivity;
+ 
+@@ -12,4 +14,11 @@ public class MainActivity extends ReactActivity {
+   protected String getMainComponentName() {
+     return "Example";
+   }
++
++  @Override
++  protected ReactActivityDelegate createReactActivityDelegate() {
++    return new ReactActivityDelegateWrapper(this,
++      new ReactActivityDelegate(this, getMainComponentName())
++    );
++  }
+ }
+diff --git a/android/app/src/main/java/com/myapp/MainApplication.java b/android/app/src/main/java/com/myapp/MainApplication.java
+index fd8ec88..73cbea8 100644
+--- a/android/app/src/main/java/com/myapp/MainApplication.java
++++ b/android/app/src/main/java/com/myapp/MainApplication.java
+@@ -1,4 +1,7 @@
+ package com.myapp;
++import android.content.res.Configuration;
++import expo.modules.ApplicationLifecycleDispatcher;
++import expo.modules.ReactNativeHostWrapper;
+ 
+ import android.app.Application;
+ import android.content.Context;
+@@ -14,7 +17,7 @@ import java.util.List;
+ public class MainApplication extends Application implements ReactApplication {
+ 
+   private final ReactNativeHost mReactNativeHost =
+-      new ReactNativeHost(this) {
++      new ReactNativeHostWrapper(this, new ReactNativeHost(this) {
+         @Override
+         public boolean getUseDeveloperSupport() {
+           return BuildConfig.DEBUG;
+@@ -33,7 +36,7 @@ public class MainApplication extends Application implements ReactApplication {
+         protected String getJSMainModuleName() {
+           return "index";
+         }
+-      };
++      });
+ 
+   @Override
+   public ReactNativeHost getReactNativeHost() {
+@@ -45,6 +48,7 @@ public class MainApplication extends Application implements ReactApplication {
+     super.onCreate();
+     SoLoader.init(this, /* native exopackage */ false);
+     initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
++    ApplicationLifecycleDispatcher.onApplicationCreate(this);
+   }
+ 
+   /**
+@@ -77,4 +81,10 @@ public class MainApplication extends Application implements ReactApplication {
+       }
+     }
+   }
++
++  @Override
++  public void onConfigurationChanged(Configuration newConfig) {
++    super.onConfigurationChanged(newConfig);
++    ApplicationLifecycleDispatcher.onConfigurationChanged(this, newConfig);
++  }
+ }
+diff --git a/android/settings.gradle b/android/settings.gradle
+index 47725a0..e787ab1 100644
+--- a/android/settings.gradle
++++ b/android/settings.gradle
+@@ -1,3 +1,6 @@
+ rootProject.name = 'Example'
+ apply from: file("../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesSettingsGradle(settings)
+ include ':app'
++
++apply from: new File(["node", "--print", "require.resolve('expo/package.json')"].execute().text.trim(), "../scripts/autolinking.gradle")
++useExpoModules()

--- a/docs/public/static/diffs/expo-ios.diff
+++ b/docs/public/static/diffs/expo-ios.diff
@@ -1,0 +1,43 @@
+diff --git a/ios/MyApp/AppDelegate.h b/ios/MyApp/AppDelegate.h
+index ef1de86..d3d75b0 100644
+--- a/ios/MyApp/AppDelegate.h
++++ b/ios/MyApp/AppDelegate.h
+@@ -1,7 +1,8 @@
+ #import <React/RCTBridgeDelegate.h>
++#import <Expo/Expo.h>
+ #import <UIKit/UIKit.h>
+ 
+-@interface AppDelegate : UIResponder <UIApplicationDelegate, RCTBridgeDelegate>
++@interface AppDelegate : EXAppDelegateWrapper <UIApplicationDelegate, RCTBridgeDelegate>
+ 
+ @property (nonatomic, strong) UIWindow *window;
+ 
+diff --git a/ios/MyApp/AppDelegate.m b/ios/MyApp/AppDelegate.m
+index 785ed86..9ea037f 100644
+--- a/ios/MyApp/AppDelegate.m
++++ b/ios/MyApp/AppDelegate.m
+@@ -47,6 +47,7 @@ - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(
+   rootViewController.view = rootView;
+   self.window.rootViewController = rootViewController;
+   [self.window makeKeyAndVisible];
++  [super application:application didFinishLaunchingWithOptions:launchOptions];
+   return YES;
+ }
+ 
+diff --git a/ios/Podfile b/ios/Podfile
+index 8ad9250..e95b97b 100644
+--- a/ios/Podfile
++++ b/ios/Podfile
+@@ -1,9 +1,11 @@
++require File.join(File.dirname(`node --print "require.resolve('expo/package.json')"`), "scripts/autolinking")
+ require_relative '../node_modules/react-native/scripts/react_native_pods'
+ require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
+ 
+-platform :ios, '11.0'
++platform :ios, '12.0'
+ 
+ target 'MyApp' do
++  use_expo_modules!
+   config = use_native_modules!
+ 
+   use_react_native!(

--- a/docs/types/common.ts
+++ b/docs/types/common.ts
@@ -27,11 +27,12 @@ export type Url = {
 };
 
 export type NavigationRoute = {
-  name: string;
-  href: string;
   as?: string;
-  weight?: number;
+  hidden: boolean;
+  href: string;
+  name: string;
   sidebarTitle?: string;
+  weight?: number;
   children?: NavigationRoute[];
   posts?: NavigationRoute[];
 };


### PR DESCRIPTION
# Why

To be released alongside SDK 43, this PR will add instructions for installing the new Expo modules infrastructure and will remove "Installing react-native-unimodules" from the sidebar + add deprecation messages to that page for direct links.

We should merge this when we merge #14733.

# How

Used @Kudo's wonderful `npx install-expo-modules` package to provide easy instructions, then took the diff from applying that to a new project and used that as the basis as the manual installation instructions.

<img width="1904" alt="Screen Shot 2021-10-19 at 3 28 23 PM" src="https://user-images.githubusercontent.com/90494/137999279-79c40b47-a214-45b8-bfda-e06ab95fc580.png">

I also ported over instructions from react-native-unimodules docs for excluding packages from autolinking. Lastly, I resolved ENG-1958 by listing which Expo modules are included in the `expo` package and which can be excluded for a minimal installation.

# Test Plan

Pull down this PR, give it a read.

# Follow-up

- I did not go into much detail about autolinking, I only included what was needed. We likely want to have a full docs page about this.
- I did not elaborate on module infrastructure at all, we plan to work on new Expo module authorship docs that we can link to from here in the future.
