### PR TITLE
[firebase-core] Fix launch crash in ios classic build

### DIFF
--- a/packages/expo-firebase-core/CHANGELOG.md
+++ b/packages/expo-firebase-core/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix launch crash in ios classic build where no `GoogleService-Info.plist` configured in apps. ([#14811](https://github.com/expo/expo/pull/14811) by [@kudo](https://github.com/kudo))
+- Fix crash on launch in iOS classic builds where `GoogleService-Info.plist` is not configured. ([#14811](https://github.com/expo/expo/pull/14811) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-firebase-core/CHANGELOG.md
+++ b/packages/expo-firebase-core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix launch crash in ios classic build where no `GoogleService-Info.plist` configured in apps. ([#14811](https://github.com/expo/expo/pull/14811) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 4.0.2 — 2021-10-15

--- a/packages/expo-firebase-core/ios/EXFirebaseCore/EXFirebaseCoreAppDelegate.m
+++ b/packages/expo-firebase-core/ios/EXFirebaseCore/EXFirebaseCoreAppDelegate.m
@@ -16,7 +16,10 @@ EX_REGISTER_SINGLETON_MODULE(EXFirebaseCoreAppDelegate)
   // Instead, the user should expect the default app to use a `GoogleService-Info.plist` file,
   // alternatively they can also setup the default app first.
   if ([FIRApp defaultApp] == nil) {
-    [FIRApp configure];
+    NSString *plistFile = [[NSBundle mainBundle] pathForResource:@"GoogleService-Info" ofType:@"plist"];
+    if (plistFile) {
+      [FIRApp configure];
+    }
   }
   return YES;
 }


### PR DESCRIPTION
# Why

for classic ios build without `googleServicesFile`, xdl will not generate the `GoogleService-Info.plist`. the auto setup firebase-core will crash here:

![Screen Shot 2021-10-20 at 1 58 34 PM](https://user-images.githubusercontent.com/46429/138036510-66dba0c4-20cc-4734-be35-65a3e31722af.png)

# How

only initialize firebase if `GoogleService-Info.plist` exists.

# Test Plan

1. CI passed
2. confirmed shell app without GoogleService-Info.plist works
```
et ios-shell-app --action build --type simulator --configuration Release
et ios-shell-app --url https://staging.exp.host/@kudochien/sdk432 --action configure --type simulator -s 43.0.0 --archivePath shellAppBase-simulator/Build/Products/Release-iphonesimulator/ExpoKitApp.app --output app.tar.gz
```

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
