### PR TITLE
[sweet-api][kotlin] Add ViewManager support

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/NativeModulesProxy.java
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/NativeModulesProxy.java
@@ -62,6 +62,10 @@ public class NativeModulesProxy extends ReactContextBaseJavaModule {
     );
   }
 
+  public KotlinInteropModuleRegistry getKotlinInteropModuleRegistry() {
+    return mKotlinInteropModuleRegistry;
+  }
+
   @Override
   public String getName() {
     return NAME;
@@ -97,6 +101,8 @@ public class NativeModulesProxy extends ReactContextBaseJavaModule {
     for (ViewManager viewManager : viewManagers) {
       viewManagersNames.add(viewManager.getName());
     }
+
+    viewManagersNames.addAll(mKotlinInteropModuleRegistry.exportedViewManagersNames());
 
     Map<String, Object> constants = new HashMap<>(3);
     constants.put(MODULES_CONSTANTS_KEY, modulesConstants);
@@ -141,9 +147,9 @@ public class NativeModulesProxy extends ReactContextBaseJavaModule {
       promise.reject(UNEXPECTED_ERROR, "Encountered an exception while calling native method: " + e.getMessage(), e);
     } catch (NoSuchMethodException e) {
       promise.reject(
-          UNDEFINED_METHOD_ERROR,
-          "Method " + methodName + " of Java module " + moduleName + " is undefined.",
-          e
+        UNDEFINED_METHOD_ERROR,
+        "Method " + methodName + " of Java module " + moduleName + " is undefined.",
+        e
       );
     }
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/Module.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/Module.kt
@@ -4,6 +4,6 @@ abstract class Module {
   abstract fun definition(): ModuleDefinition
 }
 
-fun module(block: ModuleDefinitionBuilder.() -> Unit): ModuleDefinition {
+inline fun module(block: ModuleDefinitionBuilder.() -> Unit): ModuleDefinition {
   return ModuleDefinitionBuilder().also(block).build()
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinition.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinition.kt
@@ -1,9 +1,11 @@
 package expo.modules.kotlin.modules
 
 import expo.modules.kotlin.methods.AnyMethod
+import expo.modules.kotlin.views.ViewManagerDefinition
 
 class ModuleDefinition(
   val name: String,
   val constantsProvider: () -> Map<String, Any?>,
-  val methods: Map<String, AnyMethod>
+  val methods: Map<String, AnyMethod>,
+  val viewManagerDefinition: ViewManagerDefinition? = null
 )

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinitionBuilder.kt
@@ -79,7 +79,7 @@ class ModuleDefinitionBuilder {
     methods[name] = PromiseMethod(name, arrayOf(TypeInformation(P0::class.java, null is P0), TypeInformation(P1::class.java, null is P1))) { args, promise -> body(args[0] as P0, args[1] as P1, promise) }
   }
 
-  fun viewManger(body: ViewManagerDefinitionBuilder.() -> Unit) {
+  fun viewManager(body: ViewManagerDefinitionBuilder.() -> Unit) {
     require(viewManagerDefinition == null) { "The module definition may have exported only one view manager." }
 
     val viewManagerDefinitionBuilder = ViewManagerDefinitionBuilder()

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/AnyViewProp.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/AnyViewProp.kt
@@ -1,0 +1,9 @@
+package expo.modules.kotlin.views
+
+import android.view.View
+
+abstract class AnyViewProp(
+  val name: String
+) {
+  abstract fun set(prop: Any?, onView: View)
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ConcreteViewProp.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ConcreteViewProp.kt
@@ -1,0 +1,15 @@
+package expo.modules.kotlin.views
+
+import android.view.View
+
+class ConcreteViewProp<ViewType : View, PropType>(
+  name: String,
+  private val setter: (view: ViewType, prop: PropType) -> Unit
+) : AnyViewProp(name) {
+
+  @Suppress("UNCHECKED_CAST")
+  override fun set(prop: Any?, onView: View) {
+    // TODO(@lukmccall): use TypeMapper to convert types
+    setter(onView as ViewType, prop as PropType)
+  }
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/GroupViewManagerWrapper.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/GroupViewManagerWrapper.kt
@@ -1,0 +1,22 @@
+package expo.modules.kotlin.views
+
+import android.view.View
+import android.view.ViewGroup
+import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.uimanager.ThemedReactContext
+import com.facebook.react.uimanager.ViewGroupManager
+import com.facebook.react.uimanager.annotations.ReactProp
+
+class GroupViewManagerWrapper(
+  private val wrapperDelegate: ViewManagerWrapperDelegate
+) : ViewGroupManager<ViewGroup>() {
+  override fun getName(): String = "ViewManagerAdapter_${wrapperDelegate.name}"
+
+  override fun createViewInstance(reactContext: ThemedReactContext): ViewGroup =
+    wrapperDelegate.createView(reactContext) as ViewGroup
+
+  @ReactProp(name = "proxiedProperties")
+  fun setProxiedProperties(view: View, proxiedProperties: ReadableMap) {
+    wrapperDelegate.setProxiedProperties(view, proxiedProperties)
+  }
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/SimpleViewManagerWrapper.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/SimpleViewManagerWrapper.kt
@@ -1,0 +1,21 @@
+package expo.modules.kotlin.views
+
+import android.view.View
+import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.uimanager.SimpleViewManager
+import com.facebook.react.uimanager.ThemedReactContext
+import com.facebook.react.uimanager.annotations.ReactProp
+
+class SimpleViewManagerWrapper(
+  private val wrapperDelegate: ViewManagerWrapperDelegate
+) : SimpleViewManager<View>() {
+  override fun getName(): String = "ViewManagerAdapter_${wrapperDelegate.name}"
+
+  override fun createViewInstance(reactContext: ThemedReactContext): View =
+    wrapperDelegate.createView(reactContext)
+
+  @ReactProp(name = "proxiedProperties")
+  fun setProxiedProperties(view: View, proxiedProperties: ReadableMap) {
+    wrapperDelegate.setProxiedProperties(view, proxiedProperties)
+  }
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerDefinition.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerDefinition.kt
@@ -1,0 +1,31 @@
+package expo.modules.kotlin.views
+
+import android.content.Context
+import android.view.View
+import android.view.ViewGroup
+import com.facebook.react.bridge.ReadableMap
+import expo.modules.core.ViewManager
+
+class ViewManagerDefinition(
+  private val viewFactory: (Context) -> View,
+  private val viewType: Class<out View>,
+  private val props: Map<String, AnyViewProp>
+) {
+
+  fun createView(context: Context): View = viewFactory(context)
+
+  fun getViewManagerType(): ViewManager.ViewManagerType {
+    if (ViewGroup::class.java.isAssignableFrom(viewType)) {
+      return ViewManager.ViewManagerType.GROUP
+    }
+
+    return ViewManager.ViewManagerType.SIMPLE
+  }
+
+  fun setProps(propsToSet: ReadableMap, onView: View) {
+    for ((propName, prop) in propsToSet.entryIterator) {
+      val propDelegate = props[propName] ?: continue
+      propDelegate.set(prop, onView)
+    }
+  }
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerDefinition.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerDefinition.kt
@@ -15,11 +15,11 @@ class ViewManagerDefinition(
   fun createView(context: Context): View = viewFactory(context)
 
   fun getViewManagerType(): ViewManager.ViewManagerType {
-    if (ViewGroup::class.java.isAssignableFrom(viewType)) {
-      return ViewManager.ViewManagerType.GROUP
+    return if (ViewGroup::class.java.isAssignableFrom(viewType)) {
+      ViewManager.ViewManagerType.GROUP
+    } else {
+      ViewManager.ViewManagerType.SIMPLE
     }
-
-    return ViewManager.ViewManagerType.SIMPLE
   }
 
   fun setProps(propsToSet: ReadableMap, onView: View) {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerDefinitionBuilder.kt
@@ -1,0 +1,35 @@
+package expo.modules.kotlin.views
+
+import android.content.Context
+import android.view.View
+
+class ViewManagerDefinitionBuilder {
+  @PublishedApi
+  internal var viewFactory: ((Context) -> View)? = null
+  @PublishedApi
+  internal var viewType: Class<out View>? = null
+  @PublishedApi
+  internal var props = mutableMapOf<String, AnyViewProp>()
+
+  fun build(): ViewManagerDefinition =
+    ViewManagerDefinition(
+      requireNotNull(viewFactory),
+      requireNotNull(viewType),
+      props
+    )
+
+  inline fun <reified ViewType : View> view(noinline body: (Context) -> ViewType) {
+    viewType = ViewType::class.java
+    viewFactory = body
+  }
+
+  inline fun <reified ViewType : View, reified PropType> prop(
+    name: String,
+    noinline body: (view: ViewType, prop: PropType) -> Unit
+  ) {
+    props[name] = ConcreteViewProp(
+      name,
+      body
+    )
+  }
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerWrapperDelegate.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerWrapperDelegate.kt
@@ -1,0 +1,21 @@
+package expo.modules.kotlin.views
+
+import android.content.Context
+import android.view.View
+import com.facebook.react.bridge.ReadableMap
+import expo.modules.kotlin.ModuleHolder
+
+class ViewManagerWrapperDelegate(private val moduleHolder: ModuleHolder) {
+  private val definition: ViewManagerDefinition
+    get() = requireNotNull(moduleHolder.definition.viewManagerDefinition)
+
+  val name: String
+    get() = moduleHolder.name
+
+  fun createView(context: Context): View =
+    definition.createView(context)
+
+  fun setProxiedProperties(view: View, proxiedProperties: ReadableMap) {
+    definition.setProps(proxiedProperties, view)
+  }
+}

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/KotlinInteropModuleRegistryTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/KotlinInteropModuleRegistryTest.kt
@@ -1,0 +1,71 @@
+package expo.modules.kotlin
+
+import com.google.common.truth.Truth
+import expo.modules.kotlin.modules.Module
+import expo.modules.kotlin.modules.module
+import io.mockk.mockk
+import org.junit.Test
+
+class DummyModule_1 : Module() {
+  override fun definition() = module {
+    name("dummy-1")
+    constants {
+      mapOf(
+        "c1" to 123,
+        "c2" to "123"
+      )
+    }
+  }
+}
+
+class DummyModule_2 : Module() {
+  override fun definition() = module {
+    name("dummy-2")
+    viewManger {
+      view { mockk() }
+    }
+  }
+}
+
+
+val provider = object : ModulesProvider {
+  override fun getModulesList(): List<Class<out Module>> {
+    return listOf(
+      DummyModule_1::class.java,
+      DummyModule_2::class.java
+    )
+  }
+}
+
+class KotlinInteropModuleRegistryTest {
+  @Test
+  fun `should register modules from provider`() {
+    val interopModuleRegistry = KotlinInteropModuleRegistry(provider, mockk())
+
+    interopModuleRegistry.hasModule("dummy-1")
+    interopModuleRegistry.hasModule("dummy-2")
+  }
+
+  @Test
+  fun `should export constants`() {
+    val interopModuleRegistry = KotlinInteropModuleRegistry(provider, mockk())
+
+    Truth.assertThat(interopModuleRegistry.exportedModulesConstants())
+      .containsExactly(
+        "dummy-1", mapOf("c1" to 123, "c2" to "123"),
+        "dummy-2", emptyMap<String, Any>()
+      )
+  }
+
+  @Test
+  fun `should export view manages`() {
+    val interopModuleRegistry = KotlinInteropModuleRegistry(provider, mockk())
+
+    val rnManagers = interopModuleRegistry.exportViewManagers()
+    val expoManagersNames = interopModuleRegistry.exportedViewManagersNames()
+
+    Truth.assertThat(rnManagers).hasSize(1)
+    Truth.assertThat(rnManagers.first().name).isEqualTo("ViewManagerAdapter_dummy-2")
+    Truth.assertThat(expoManagersNames).containsExactly("dummy-2")
+  }
+}

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/KotlinInteropModuleRegistryTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/KotlinInteropModuleRegistryTest.kt
@@ -27,7 +27,6 @@ class DummyModule_2 : Module() {
   }
 }
 
-
 val provider = object : ModulesProvider {
   override fun getModulesList(): List<Class<out Module>> {
     return listOf(

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/KotlinInteropModuleRegistryTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/KotlinInteropModuleRegistryTest.kt
@@ -21,7 +21,7 @@ class DummyModule_1 : Module() {
 class DummyModule_2 : Module() {
   override fun definition() = module {
     name("dummy-2")
-    viewManger {
+    viewManager {
       view { mockk() }
     }
   }

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/modules/ModuleDefinitionBuilderTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/modules/ModuleDefinitionBuilderTest.kt
@@ -2,6 +2,7 @@ package expo.modules.kotlin.modules
 
 import com.google.common.truth.Truth
 import expo.modules.core.Promise
+import io.mockk.mockk
 import org.junit.Assert
 import org.junit.Test
 
@@ -38,5 +39,20 @@ class ModuleDefinitionBuilderTest {
     Truth.assertThat(moduleDefinition.constantsProvider()).isSameInstanceAs(moduleConstants)
     Truth.assertThat(moduleDefinition.methods).containsKey("m1")
     Truth.assertThat(moduleDefinition.methods).containsKey("m2")
+  }
+
+  @Test
+  fun `builder should allow adding view manager`() {
+    val moduleName = "Module"
+
+    val moduleDefinition = module {
+      name(moduleName)
+      viewManger {
+        view { mockk() }
+      }
+    }
+
+    Truth.assertThat(moduleDefinition.name).isEqualTo(moduleName)
+    Truth.assertThat(moduleDefinition.viewManagerDefinition).isNotNull()
   }
 }

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/modules/ModuleDefinitionBuilderTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/modules/ModuleDefinitionBuilderTest.kt
@@ -47,7 +47,7 @@ class ModuleDefinitionBuilderTest {
 
     val moduleDefinition = module {
       name(moduleName)
-      viewManger {
+      viewManager {
         view { mockk() }
       }
     }

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/views/ConcreteViewPropTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/views/ConcreteViewPropTest.kt
@@ -1,0 +1,25 @@
+package expo.modules.kotlin.views
+
+import android.view.View
+import com.google.common.truth.Truth
+import io.mockk.mockk
+import org.junit.Test
+
+class ConcreteViewPropTest {
+  @Test
+  fun `set should call passed setter`() {
+    val mockedView = mockk<View>()
+    var providedValue = -1
+    var providedView: View? = null
+
+    val prop = ConcreteViewProp<View, Int>("name") { view, value ->
+      providedValue = value
+      providedView = view
+    }
+
+    prop.set(10, mockedView)
+
+    Truth.assertThat(providedValue).isEqualTo(10)
+    Truth.assertThat(providedView).isSameInstanceAs(mockedView)
+  }
+}

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/views/ViewManagerDefinitionBuilderTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/views/ViewManagerDefinitionBuilderTest.kt
@@ -1,0 +1,59 @@
+package expo.modules.kotlin.views
+
+import android.view.View
+import android.widget.ListView
+import com.facebook.react.bridge.JavaOnlyMap
+import com.google.common.truth.Truth
+import expo.modules.core.ViewManager
+import io.mockk.mockk
+import org.junit.Assert
+import org.junit.Test
+
+class ViewManagerDefinitionBuilderTest {
+  @Test
+  fun `builder should fail without view factory`() {
+    val builder = ViewManagerDefinitionBuilder()
+      .apply {
+        prop("only-prop") { _: View, _: Int -> }
+      }
+
+    try {
+      builder.build()
+      Assert.fail("Builder should fail without view factory.")
+    } catch (e: Exception) {
+    }
+  }
+
+  @Test
+  fun `builder should create correct definition`() {
+    var p1Calls = 0
+    var p2Calls = 0
+    var viewFactoryCalls = 0
+
+    val definition = ViewManagerDefinitionBuilder()
+      .apply {
+        view {
+          viewFactoryCalls++
+          mockk<ListView>()
+        }
+
+        prop<ListView, Int>("p1") { _, _ -> p1Calls++ }
+        prop<ListView, Int>("p2") { _, _ -> p2Calls++ }
+      }
+      .build()
+
+    definition.createView(mockk())
+    definition.setProps(
+      JavaOnlyMap().apply {
+        putInt("p1", 1)
+        putInt("p2", 2)
+      },
+      mockk<ListView>(),
+    )
+
+    Truth.assertThat(definition.getViewManagerType()).isEqualTo(ViewManager.ViewManagerType.GROUP)
+    Truth.assertThat(p1Calls).isEqualTo(1)
+    Truth.assertThat(p2Calls).isEqualTo(1)
+    Truth.assertThat(viewFactoryCalls).isEqualTo(1)
+  }
+}

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/views/ViewManagerDefinitionTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/views/ViewManagerDefinitionTest.kt
@@ -10,15 +10,15 @@ import expo.modules.core.ViewManager
 class ViewManagerDefinitionTest {
 
   @Test
-  fun `definition should deduce type of view manger`() {
+  fun `definition should deduce type of view manager`() {
     val simpleViewManagerDefinition = ViewManagerDefinition(
-      { _ -> mockk<TextView>() },
+      { mockk<TextView>() },
       TextView::class.java,
       emptyMap()
     )
 
     val groupViewManagerDefinition = ViewManagerDefinition(
-      { _ -> mockk<ListView>() },
+      { mockk<ListView>() },
       ListView::class.java,
       emptyMap()
     )

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/views/ViewManagerDefinitionTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/views/ViewManagerDefinitionTest.kt
@@ -1,0 +1,29 @@
+package expo.modules.kotlin.views
+
+import android.widget.ListView
+import android.widget.TextView
+import com.google.common.truth.Truth
+import io.mockk.mockk
+import org.junit.Test
+import expo.modules.core.ViewManager
+
+class ViewManagerDefinitionTest {
+
+  @Test
+  fun `definition should deduce type of view manger`() {
+    val simpleViewManagerDefinition = ViewManagerDefinition(
+      { _ -> mockk<TextView>() },
+      TextView::class.java,
+      emptyMap()
+    )
+
+    val groupViewManagerDefinition = ViewManagerDefinition(
+      { _ -> mockk<ListView>() },
+      ListView::class.java,
+      emptyMap()
+    )
+
+    Truth.assertThat(simpleViewManagerDefinition.getViewManagerType()).isEqualTo(ViewManager.ViewManagerType.SIMPLE)
+    Truth.assertThat(groupViewManagerDefinition.getViewManagerType()).isEqualTo(ViewManager.ViewManagerType.GROUP)
+  }
+}


### PR DESCRIPTION
# Why

Part of the new "Sweet API" in Kotlin.
Adds support for ViewManagers.

# How

- Added DLS function connected to the view manager - `viewManager`, `prop`, `view`.
- Integrated new abstraction with old `NativeModulesProxy` and `ModuleRegistryAdapter`.
- Added smaller improvements to the existing DLS methods - hide variables like `methods`, `props` & inline `module` function (huge improvement in terms of the generated bytecode). 

# Missing features (they will be added in the future)

- prop types conversion 
- events 

# Test Plan

https://user-images.githubusercontent.com/9578601/138101236-3c153288-2c63-41a7-8ccb-b1711f7a2eae.mov