### PR TITLE
[bare-expo] Adjust style settings

### DIFF
--- a/apps/bare-expo/android/.idea/codeStyles/Project.xml
+++ b/apps/bare-expo/android/.idea/codeStyles/Project.xml
@@ -176,7 +176,7 @@
     <codeStyleSettings language="kotlin">
       <indentOptions>
         <option name="INDENT_SIZE" value="2" />
-        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+        <option name="CONTINUATION_INDENT_SIZE" value="2" />
         <option name="TAB_SIZE" value="2" />
       </indentOptions>
     </codeStyleSettings>


### PR DESCRIPTION
# Why

Adjusted style settings used by Android Studio. In KtLint settings, `CONTINUATION_INDENT_SIZE` is set to 2 instead of 4. Make sure that the Android Studio has the same value.
