### PR TITLE
[autolinking] Resolve race condition when generating ExpoModulesProvider.swift

### DIFF
--- a/packages/expo-modules-autolinking/scripts/ios/autolinking_manager.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/autolinking_manager.rb
@@ -57,7 +57,7 @@ module Expo
 
     # Spawns `expo-module-autolinking generate-package-list` command.
     public def generate_package_list(target_name, target_path)
-      IO.popen(generate_package_list_command_args(target_path))
+      Process.wait IO.popen(generate_package_list_command_args(target_path)).pid
     end
 
     # If there is any package to autolink.


### PR DESCRIPTION


# Why

My iOS builds were succeeding locally, but failling on CircleCI due to:

```
❌  error: Build input file cannot be found: '/Users/distiller/project/packages/oui-aviva/ios/Pods/Target Support Files/Pods-Aviva/ExpoModulesProvider.swift' (in target 'Aviva' from project 'Aviva')
```

The process that generates ExpoModulesProvider.swift is spawned from `pod install`, but as it stands, may not finish generation before the parent is exited. In that case, the generated file is nowhere to be found and subsequent iOS builds fail.

# How

Wait for the child process to fix.

# Test Plan

This unbreaks my CircleCI builds

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
