### PR TITLE
[sweet-api][kotlin] Add basic support for records

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/allocators/ObjectConstructor.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/allocators/ObjectConstructor.kt
@@ -1,0 +1,5 @@
+package expo.modules.kotlin.allocators
+
+fun interface ObjectConstructor<T> {
+  fun construct(): T
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/allocators/ObjectConstructorFactory.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/allocators/ObjectConstructorFactory.kt
@@ -4,24 +4,18 @@ package expo.modules.kotlin.allocators
  * This class was created based on https://github.com/google/gson/blob/master/gson/src/main/java/com/google/gson/internal/ConstructorConstructor.java.
  */
 class ObjectConstructorFactory {
-  fun <T> get(clazz: Class<T>): ObjectConstructor<T> {
-    val defaultCtr = tryToUseDefaultConstructor(clazz)
-    if (defaultCtr != null) {
-      return defaultCtr
-    }
-
-    return useUnsafeAllocator(clazz)
-  }
+  fun <T> get(clazz: Class<T>): ObjectConstructor<T> =
+    tryToUseDefaultConstructor(clazz) ?: useUnsafeAllocator(clazz)
 
   private fun <T> tryToUseDefaultConstructor(clazz: Class<T>): ObjectConstructor<T>? {
     return try {
-      val ctr = clazz.getDeclaredConstructor()
-      if (!ctr.isAccessible) {
-        ctr.isAccessible = true
+      val ctor = clazz.getDeclaredConstructor()
+      if (!ctor.isAccessible) {
+        ctor.isAccessible = true
       }
 
       ObjectConstructor {
-        ctr.newInstance() as T
+        ctor.newInstance() as T
       }
     } catch (e: NoSuchMethodException) {
       null

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/allocators/ObjectConstructorFactory.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/allocators/ObjectConstructorFactory.kt
@@ -1,0 +1,37 @@
+package expo.modules.kotlin.allocators
+
+/**
+ * This class was created based on https://github.com/google/gson/blob/master/gson/src/main/java/com/google/gson/internal/ConstructorConstructor.java.
+ */
+class ObjectConstructorFactory {
+  fun <T> get(clazz: Class<T>): ObjectConstructor<T> {
+    val defaultCtr = tryToUseDefaultConstructor(clazz)
+    if (defaultCtr != null) {
+      return defaultCtr
+    }
+
+    return useUnsafeAllocator(clazz)
+  }
+
+  private fun <T> tryToUseDefaultConstructor(clazz: Class<T>): ObjectConstructor<T>? {
+    return try {
+      val ctr = clazz.getDeclaredConstructor()
+      if (!ctr.isAccessible) {
+        ctr.isAccessible = true
+      }
+
+      ObjectConstructor {
+        ctr.newInstance() as T
+      }
+    } catch (e: NoSuchMethodException) {
+      null
+    }
+  }
+
+  private fun <T> useUnsafeAllocator(clazz: Class<T>): ObjectConstructor<T> {
+    val allocator = UnsafeAllocator.createAllocator(clazz)
+    return ObjectConstructor {
+      allocator.newInstance()
+    }
+  }
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/allocators/UnsafeAllocator.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/allocators/UnsafeAllocator.kt
@@ -1,0 +1,49 @@
+package expo.modules.kotlin.allocators
+
+import android.annotation.SuppressLint
+import java.io.ObjectStreamClass
+import kotlin.jvm.Throws
+
+/**
+ * Base on https://github.com/google/gson/blob/master/gson/src/main/java/com/google/gson/internal/UnsafeAllocator.java.
+ */
+fun interface UnsafeAllocator<T> {
+  @Throws(Exception::class)
+  fun newInstance(): T
+
+  companion object {
+    @SuppressLint("DiscouragedPrivateApi")
+    @Suppress("UNCHECKED_CAST")
+    fun <T> createAllocator(clazz: Class<T>): UnsafeAllocator<T> {
+      // try DalvikVM
+      try {
+        val getConstructorId = ObjectStreamClass::class.java.getDeclaredMethod("getConstructorId", Class::class.java)
+        getConstructorId.isAccessible = true
+        val constructorId = getConstructorId.invoke(null, Object::class.java) as Int
+        val newInstance = ObjectStreamClass::class.java.getDeclaredMethod("newInstance", Class::class.java, Int::class.java)
+        newInstance.isAccessible = true
+        return UnsafeAllocator {
+          newInstance.invoke(null, clazz, constructorId) as T
+        }
+      } catch (_: Throwable) {
+      }
+
+      // try JVM (for unit tests)
+      try {
+        val unsafeClass = Class.forName("sun.misc.Unsafe")
+        val theUnsafe = unsafeClass.getDeclaredField("theUnsafe")
+        theUnsafe.isAccessible = true
+        val unsafeObj = theUnsafe.get(null)
+        val allocateInstance = unsafeClass.getMethod("allocateInstance", Class::class.java)
+        return UnsafeAllocator {
+          allocateInstance.invoke(unsafeObj, clazz) as T
+        }
+      } catch (_: Throwable) {
+      }
+
+      return UnsafeAllocator {
+        throw IllegalArgumentException("Can't allocate $clazz")
+      }
+    }
+  }
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/allocators/UnsafeAllocator.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/allocators/UnsafeAllocator.kt
@@ -42,7 +42,7 @@ fun interface UnsafeAllocator<T> {
       }
 
       return UnsafeAllocator {
-        throw IllegalArgumentException("Can't allocate $clazz")
+        throw IllegalArgumentException("Cannot allocate $clazz")
       }
     }
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/methods/TypeMapper.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/methods/TypeMapper.kt
@@ -39,7 +39,7 @@ object TypeMapper {
 
     val type = toClass.type
 
-    // TODO(@lukmccall): handel collection
+    // TODO(@lukmccall): handle collection
     val caster = typeMap[type] as? TypeCaster<T>
     if (caster != null) {
       return caster.cast(jsValue)
@@ -49,6 +49,6 @@ object TypeMapper {
       return recordCaster.cast(jsValue.asMap(), type as Class<Record>) as T
     }
 
-    throw java.lang.IllegalArgumentException("Cannot converted JavaScript object into $type")
+    throw java.lang.IllegalArgumentException("Cannot convert JavaScript object into $type")
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/records/Field.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/records/Field.kt
@@ -1,0 +1,5 @@
+package expo.modules.kotlin.records
+
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class Field(val key: String = "")

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/records/Record.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/records/Record.kt
@@ -1,0 +1,3 @@
+package expo.modules.kotlin.records
+
+interface Record

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/records/RecordCaster.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/records/RecordCaster.kt
@@ -1,0 +1,48 @@
+package expo.modules.kotlin.records
+
+import com.facebook.react.bridge.ReadableMap
+import expo.modules.kotlin.methods.TypeInformation
+import expo.modules.kotlin.methods.TypeMapper
+import expo.modules.kotlin.allocators.ObjectConstructor
+import expo.modules.kotlin.allocators.ObjectConstructorFactory
+import kotlin.reflect.full.findAnnotation
+import kotlin.reflect.full.memberProperties
+import kotlin.reflect.jvm.javaField
+
+class RecordCaster {
+  private val objectConstructorFactory = ObjectConstructorFactory()
+
+  fun <T : Record> cast(jsValue: ReadableMap, toClass: Class<T>): T {
+    val instance = getObjectConstructor(toClass).construct()
+
+    toClass.kotlin
+      .memberProperties
+      .map { property ->
+        val filedInformation = property.findAnnotation<Field>() ?: return@map
+        val jsKey = filedInformation.key.takeUnless { it == "" } ?: property.name
+
+        if (!jsValue.hasKey(jsKey)) {
+          // TODO(@lukmccall): handle required keys
+          return@map
+        }
+
+        val value = jsValue.getDynamic(jsKey)
+
+        val javaField = property.javaField!!
+
+        val casted = TypeMapper.cast(
+          value,
+          TypeInformation(javaField.type, property.returnType.isMarkedNullable)
+        )
+
+        javaField.isAccessible = true
+        javaField.set(instance, casted)
+      }
+
+    return instance
+  }
+
+  private fun <T> getObjectConstructor(clazz: Class<T>): ObjectConstructor<T> {
+    return objectConstructorFactory.get(clazz)
+  }
+}

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/allocators/ObjectConstructorFactoryTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/allocators/ObjectConstructorFactoryTest.kt
@@ -1,0 +1,66 @@
+package expo.modules.kotlin.allocators
+
+import com.google.common.truth.Truth
+import org.junit.Test
+
+var ctrCalls = 0
+
+// Cannot be inline in test function, cause then it won't have the default constructor.
+// Kotlin needs a way of connecting it to the function, so it'll generate constructor to do it.
+class Clazz {
+  init {
+    ctrCalls++
+  }
+}
+
+class ClazzPrivate private constructor() {
+  init {
+    ctrCalls++
+  }
+}
+
+class ClazzWithoutDefaultCtr(@Suppress("unused") val ignored: Int) {
+  val valWithValue = 20
+  var varWithValue = "value"
+  init {
+    ctrCalls++
+  }
+}
+
+class ObjectConstructorFactoryTest {
+  private val ctrFactory = ObjectConstructorFactory()
+
+  @Test
+  fun `should invoke default constructor if possible`() = synchronized(ctrCalls) {
+    ctrCalls = 0
+
+    val instance = ctrFactory.get(Clazz::class.java).construct()
+
+    Truth.assertThat(ctrCalls).isEqualTo(1)
+    Truth.assertThat(instance).isInstanceOf(Clazz::class.java)
+  }
+
+  @Test
+  fun `should invoke private default constructor`() = synchronized(ctrCalls) {
+    ctrCalls = 0
+
+    val instance = ctrFactory.get(ClazzPrivate::class.java).construct()
+
+    Truth.assertThat(ctrCalls).isEqualTo(1)
+    Truth.assertThat(instance).isInstanceOf(ClazzPrivate::class.java)
+  }
+
+  @Test
+  fun `should be able construct object without default constructor`() = synchronized(ctrCalls) {
+    ctrCalls = 0
+
+    val instance = ctrFactory.get(ClazzWithoutDefaultCtr::class.java).construct()
+
+    Truth.assertThat(ctrCalls).isEqualTo(0)
+    Truth.assertThat(instance).isInstanceOf(ClazzWithoutDefaultCtr::class.java)
+    // The init block won't be invoke in that case.
+    // So properties won't be initialized.
+    Truth.assertThat(instance.valWithValue).isEqualTo(0)
+    Truth.assertThat(instance.varWithValue).isEqualTo(null)
+  }
+}

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/records/RecordCasterTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/records/RecordCasterTest.kt
@@ -1,0 +1,193 @@
+package expo.modules.kotlin.records
+
+import com.facebook.react.bridge.JavaOnlyArray
+import com.facebook.react.bridge.JavaOnlyMap
+import com.google.common.truth.Truth
+import org.junit.Test
+
+
+class RecordCasterTest {
+  private val caster = RecordCaster()
+
+  @Test
+  fun `should convert map to mutable record`() {
+    class MyRecord : Record {
+      @Field
+      var int: Int = 0
+
+      @Field
+      var string: String = ""
+    }
+
+    val map = JavaOnlyMap().apply {
+      putInt("int", 10)
+      putString("string", "expo")
+    }
+
+    val myRecord = caster.cast(map, MyRecord::class.java)
+
+    Truth.assertThat(myRecord.int).isEqualTo(10)
+    Truth.assertThat(myRecord.string).isEqualTo("expo")
+  }
+
+  @Test
+  fun `should convert map to not mutable record`() {
+    class MyRecord : Record {
+      @Field
+      val int: Int = 0
+
+      @Field
+      val string: String = ""
+    }
+
+    val map = JavaOnlyMap().apply {
+      putInt("int", 10)
+      putString("string", "expo")
+    }
+
+    val myRecord = caster.cast(map, MyRecord::class.java)
+
+    Truth.assertThat(myRecord.int).isEqualTo(10)
+    Truth.assertThat(myRecord.string).isEqualTo("expo")
+  }
+
+  @Test
+  fun `should convert map to lateinit record`() {
+    class MyRecord : Record {
+      @Field
+      lateinit var string: String
+    }
+
+    val map = JavaOnlyMap().apply {
+      putString("string", "expo")
+    }
+
+    val myRecord = caster.cast(map, MyRecord::class.java)
+
+    Truth.assertThat(myRecord.string).isEqualTo("expo")
+  }
+
+
+  @Test
+  fun `should convert map to mixed record`() {
+    class MyRecord : Record {
+      @Field
+      val int: Int = 0
+
+      @Field
+      var int2: Int = -10
+
+      @Field
+      lateinit var string: String
+    }
+
+    val map = JavaOnlyMap().apply {
+      putInt("int", 10)
+      putInt("int2", 20)
+      putString("string", "expo")
+    }
+
+    val myRecord = caster.cast(map, MyRecord::class.java)
+
+    Truth.assertThat(myRecord.int).isEqualTo(10)
+    Truth.assertThat(myRecord.int2).isEqualTo(20)
+    Truth.assertThat(myRecord.string).isEqualTo("expo")
+  }
+
+  @Test
+  fun `should respect custom js key`() {
+    class MyRecord : Record {
+      @Field(key = "point1")
+      val int: Int = 0
+
+      @Field(key = "point2")
+      var int2: Int = -10
+
+      @Field(key = "str")
+      lateinit var string: String
+    }
+
+    val map = JavaOnlyMap().apply {
+      putInt("point1", 10)
+      putInt("point2", 20)
+      putString("str", "expo")
+    }
+
+    val myRecord = caster.cast(map, MyRecord::class.java)
+
+    Truth.assertThat(myRecord.int).isEqualTo(10)
+    Truth.assertThat(myRecord.int2).isEqualTo(20)
+    Truth.assertThat(myRecord.string).isEqualTo("expo")
+  }
+
+  @Test
+  fun `should respect non required value`() {
+    class MyRecord : Record {
+      @Field
+      val required: Int = 10
+
+      @Field
+      val int: Int = 20
+
+      @Field
+      val string: String? = null
+    }
+
+    val map = JavaOnlyMap().apply {
+      putInt("required", 2137)
+    }
+
+    val myRecord = caster.cast(map, MyRecord::class.java)
+
+    Truth.assertThat(myRecord.required).isEqualTo(2137)
+    Truth.assertThat(myRecord.int).isEqualTo(20)
+    Truth.assertThat(myRecord.string).isEqualTo(null)
+  }
+
+  @Test
+  fun `should work with complex types`() {
+    class InnerRecord : Record {
+      @Field
+      lateinit var name: String
+
+      override fun hashCode(): Int {
+        return name.hashCode()
+      }
+
+      override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as InnerRecord
+
+        if (name != other.name) return false
+
+        return true
+      }
+    }
+
+    class MyRecord : Record {
+      @Field
+      lateinit var points: List<Double>
+
+      @Field
+      lateinit var innerRecord: InnerRecord
+    }
+
+    val map = JavaOnlyMap().apply {
+      putArray("points", JavaOnlyArray().apply {
+        pushDouble(1.0)
+        pushDouble(2.0)
+        pushDouble(3.0)
+      })
+      putMap("innerRecord", JavaOnlyMap().apply {
+        putString("name", "value")
+      })
+    }
+
+    val myRecord = caster.cast(map, MyRecord::class.java)
+
+    Truth.assertThat(myRecord.innerRecord).isEqualTo(InnerRecord().apply { name = "value" })
+    Truth.assertThat(myRecord.points).isEqualTo(listOf(1.0, 2.0, 3.0))
+  }
+}

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/records/RecordCasterTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/records/RecordCasterTest.kt
@@ -5,7 +5,6 @@ import com.facebook.react.bridge.JavaOnlyMap
 import com.google.common.truth.Truth
 import org.junit.Test
 
-
 class RecordCasterTest {
   private val caster = RecordCaster()
 
@@ -31,7 +30,7 @@ class RecordCasterTest {
   }
 
   @Test
-  fun `should convert map to not mutable record`() {
+  fun `should convert map to immutable record`() {
     class MyRecord : Record {
       @Field
       val int: Int = 0
@@ -66,7 +65,6 @@ class RecordCasterTest {
 
     Truth.assertThat(myRecord.string).isEqualTo("expo")
   }
-
 
   @Test
   fun `should convert map to mixed record`() {
@@ -175,14 +173,20 @@ class RecordCasterTest {
     }
 
     val map = JavaOnlyMap().apply {
-      putArray("points", JavaOnlyArray().apply {
-        pushDouble(1.0)
-        pushDouble(2.0)
-        pushDouble(3.0)
-      })
-      putMap("innerRecord", JavaOnlyMap().apply {
-        putString("name", "value")
-      })
+      putArray(
+        "points",
+        JavaOnlyArray().apply {
+          pushDouble(1.0)
+          pushDouble(2.0)
+          pushDouble(3.0)
+        }
+      )
+      putMap(
+        "innerRecord",
+        JavaOnlyMap().apply {
+          putString("name", "value")
+        }
+      )
     }
 
     val myRecord = caster.cast(map, MyRecord::class.java)


### PR DESCRIPTION
# Why

Adds basic support for records.
Similar functionality was added in https://github.com/expo/expo/pull/14009.

# How

- Added `Record` interface, which will mark each of the auto-convertable classes.
- Added `Field` annotation, which will mark every property that should be converted.
- Added a way of creating an instance of a class that doesn't have a default constructor. 

# TODO 

- Handle collections (and generic types).

# Test Plan

- unit tests ✅