### PR TITLE
[docs] Add print example and local images documentation

### DIFF
--- a/docs/pages/versions/unversioned/sdk/print.md
+++ b/docs/pages/versions/unversioned/sdk/print.md
@@ -6,6 +6,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-print'
 import APISection from '~/components/plugins/APISection';
 import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
+import SnackInline from '~/components/plugins/SnackInline';
 
 **`expo-print`** provides an API for iOS (AirPrint) and Android printing functionality.
 
@@ -14,6 +15,97 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 ## Installation
 
 <InstallSection packageName="expo-print" />
+
+## Usage
+
+<SnackInline label='Print usage' dependencies={['expo-print', 'expo-sharing']}>
+
+```jsx
+import * as React from 'react';
+import { View, StyleSheet, Button, Platform, Text } from 'react-native';
+import * as Print from 'expo-print';
+import { shareAsync } from 'expo-sharing';
+
+const html = `
+<html>
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no" />
+  </head>
+  <body style="text-align: center;">
+    <h1 style="font-size: 50px; font-family: Helvetica Neue; font-weight: normal;">
+      Hello Expo!
+    </h1>
+    <img
+      src="https://d30j33t1r58ioz.cloudfront.net/static/guides/sdk.png"
+      style="width: 90vw;" />
+  </body>
+</html>
+`;
+
+export default function App() {
+  const [selectedPrinter, setSelectedPrinter] = React.useState();
+
+  const print = async () => {
+    // On iOS/android prints the given html. On web prints the HTML from the current page.
+    /* @info */ await Print.printAsync({
+      html,
+      printerUrl: selectedPrinter?.url, // iOS only
+    });/* @end */
+
+  }
+
+  const printToFile = async () => {
+    // On iOS/android prints the given html. On web prints the HTML from the current page.
+    /* @info */const { uri } = await Print.printToFileAsync({
+      html
+    });
+    /* @end */console.log('File has been saved to:', uri);
+    await shareAsync(uri, { UTI: '.pdf', mimeType: 'application/pdf' });
+  }
+
+  const selectPrinter = async () => {
+    /* @info */const printer = await Print.selectPrinterAsync(); // iOS only
+    /* @end */
+    setSelectedPrinter(printer);
+  }
+
+  return (
+    <View style={styles.container}>
+      <Button title='Print' onPress={print}  />
+      <View style={styles.spacer} />
+      <Button title='Print to PDF file' onPress={printToFile}/>
+      {Platform.OS === 'ios' &&
+        <>
+          <View style={styles.spacer} />
+          <Button title='Select printer' onPress={selectPrinter}/>
+          <View style={styles.spacer} />
+          {selectedPrinter ? <Text style={styles.printer}>{`Selected printer: ${selectedPrinter.name}`}</Text> : undefined}
+        </>
+      }
+    </View>
+  );
+}
+
+/* @hide const styles = StyleSheet.create({ ... }); */
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    backgroundColor: '#ecf0f1',
+    flexDirection: 'column',
+    padding: 8,
+  },
+  spacer: {
+    height: 8
+  },
+  printer: {
+    textAlign: 'center',
+  }
+});
+/* @end */
+```
+
+</SnackInline>
 
 ## API
 

--- a/docs/pages/versions/unversioned/sdk/print.md
+++ b/docs/pages/versions/unversioned/sdk/print.md
@@ -115,6 +115,37 @@ import * as Print from 'expo-print';
 
 <APISection packageName="expo-print" apiName="Print" />
 
+## Local images
+
+On iOS, printing from HTML source doesn't support local asset URLs (due to WKWebView limitations). Instead, images need to be converted to base64 and inlined into the HTML.
+
+```js
+import { Asset } from 'expo-asset';
+import { printAsync } from 'expo-print';
+import { manipulateAsync } from 'expo-image-manipulator';
+
+async function generateHTML() {
+  const asset = Asset.fromModule(require('../../assets/logo.png'));
+  const image = await manipulateAsync(
+    asset.localUri ?? asset.uri,
+    [],
+    { base64: true }
+  );
+  return `
+    <html>
+      <img
+        src="data:image/jpeg;base64,${image.base64}"
+        style="width: 90vw;" />
+    </html>
+  `;
+}
+
+async function print() {
+  const html = await generateHTML();
+  await printAsync({ html });
+}
+```
+
 ## Page margins
 
 If you're using `html` option in `printAsync` or `printToFileAsync`, the resulting print might contain page margins (it depends on WebView engine).

--- a/docs/pages/versions/v42.0.0/sdk/print.md
+++ b/docs/pages/versions/v42.0.0/sdk/print.md
@@ -6,6 +6,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-42/packages/expo-print'
 import APISection from '~/components/plugins/APISection';
 import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
+import SnackInline from '~/components/plugins/SnackInline';
 
 **`expo-print`** provides an API for iOS (AirPrint) and Android printing functionality.
 
@@ -15,6 +16,97 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 <InstallSection packageName="expo-print" />
 
+## Usage
+
+<SnackInline label='Print usage' dependencies={['expo-print', 'expo-sharing']}>
+
+```jsx
+import * as React from 'react';
+import { View, StyleSheet, Button, Platform, Text } from 'react-native';
+import * as Print from 'expo-print';
+import { shareAsync } from 'expo-sharing';
+
+const html = `
+<html>
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no" />
+  </head>
+  <body style="text-align: center;">
+    <h1 style="font-size: 50px; font-family: Helvetica Neue; font-weight: normal;">
+      Hello Expo!
+    </h1>
+    <img
+      src="https://d30j33t1r58ioz.cloudfront.net/static/guides/sdk.png"
+      style="width: 90vw;" />
+  </body>
+</html>
+`;
+
+export default function App() {
+  const [selectedPrinter, setSelectedPrinter] = React.useState();
+
+  const print = async () => {
+    // On iOS/android prints the given html. On web prints the HTML from the current page.
+    /* @info */ await Print.printAsync({
+      html,
+      printerUrl: selectedPrinter?.url, // iOS only
+    });/* @end */
+
+  }
+
+  const printToFile = async () => {
+    // On iOS/android prints the given html. On web prints the HTML from the current page.
+    /* @info */const { uri } = await Print.printToFileAsync({
+      html
+    });
+    /* @end */console.log('File has been saved to:', uri);
+    await shareAsync(uri, { UTI: '.pdf', mimeType: 'application/pdf' });
+  }
+
+  const selectPrinter = async () => {
+    /* @info */const printer = await Print.selectPrinterAsync(); // iOS only
+    /* @end */
+    setSelectedPrinter(printer);
+  }
+
+  return (
+    <View style={styles.container}>
+      <Button title='Print' onPress={print}  />
+      <View style={styles.spacer} />
+      <Button title='Print to PDF file' onPress={printToFile}/>
+      {Platform.OS === 'ios' &&
+        <>
+          <View style={styles.spacer} />
+          <Button title='Select printer' onPress={selectPrinter}/>
+          <View style={styles.spacer} />
+          {selectedPrinter ? <Text style={styles.printer}>{`Selected printer: ${selectedPrinter.name}`}</Text> : undefined}
+        </>
+      }
+    </View>
+  );
+}
+
+/* @hide const styles = StyleSheet.create({ ... }); */
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    backgroundColor: '#ecf0f1',
+    flexDirection: 'column',
+    padding: 8,
+  },
+  spacer: {
+    height: 8
+  },
+  printer: {
+    textAlign: 'center',
+  }
+});
+/* @end */
+```
+
+</SnackInline>
+
 ## API
 
 ```js
@@ -22,6 +114,37 @@ import * as Print from 'expo-print';
 ```
 
 <APISection packageName="expo-print" apiName="Print" />
+
+## Local images
+
+On iOS, printing from HTML source doesn't support local asset URLs (due to WKWebView limitations). Instead, images need to be converted to base64 and inlined into the HTML.
+
+```js
+import { Asset } from 'expo-asset';
+import { printAsync } from 'expo-print';
+import { manipulateAsync } from 'expo-image-manipulator';
+
+async function generateHTML() {
+  const asset = Asset.fromModule(require('../../assets/logo.png'));
+  const image = await manipulateAsync(
+    asset.localUri ?? asset.uri,
+    [],
+    { base64: true }
+  );
+  return `
+    <html>
+      <img
+        src="data:image/jpeg;base64,${image.base64}"
+        style="width: 90vw;" />
+    </html>
+  `;
+}
+
+async function print() {
+  const html = await generateHTML();
+  await printAsync({ html });
+}
+```
 
 ## Page margins
 

--- a/docs/pages/versions/v43.0.0/sdk/print.md
+++ b/docs/pages/versions/v43.0.0/sdk/print.md
@@ -6,6 +6,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-43/packages/expo-print'
 import APISection from '~/components/plugins/APISection';
 import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
+import SnackInline from '~/components/plugins/SnackInline';
 
 **`expo-print`** provides an API for iOS (AirPrint) and Android printing functionality.
 
@@ -15,6 +16,97 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 <InstallSection packageName="expo-print" />
 
+## Usage
+
+<SnackInline label='Print usage' dependencies={['expo-print', 'expo-sharing']}>
+
+```jsx
+import * as React from 'react';
+import { View, StyleSheet, Button, Platform, Text } from 'react-native';
+import * as Print from 'expo-print';
+import { shareAsync } from 'expo-sharing';
+
+const html = `
+<html>
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no" />
+  </head>
+  <body style="text-align: center;">
+    <h1 style="font-size: 50px; font-family: Helvetica Neue; font-weight: normal;">
+      Hello Expo!
+    </h1>
+    <img
+      src="https://d30j33t1r58ioz.cloudfront.net/static/guides/sdk.png"
+      style="width: 90vw;" />
+  </body>
+</html>
+`;
+
+export default function App() {
+  const [selectedPrinter, setSelectedPrinter] = React.useState();
+
+  const print = async () => {
+    // On iOS/android prints the given html. On web prints the HTML from the current page.
+    /* @info */ await Print.printAsync({
+      html,
+      printerUrl: selectedPrinter?.url, // iOS only
+    });/* @end */
+
+  }
+
+  const printToFile = async () => {
+    // On iOS/android prints the given html. On web prints the HTML from the current page.
+    /* @info */const { uri } = await Print.printToFileAsync({
+      html
+    });
+    /* @end */console.log('File has been saved to:', uri);
+    await shareAsync(uri, { UTI: '.pdf', mimeType: 'application/pdf' });
+  }
+
+  const selectPrinter = async () => {
+    /* @info */const printer = await Print.selectPrinterAsync(); // iOS only
+    /* @end */
+    setSelectedPrinter(printer);
+  }
+
+  return (
+    <View style={styles.container}>
+      <Button title='Print' onPress={print}  />
+      <View style={styles.spacer} />
+      <Button title='Print to PDF file' onPress={printToFile}/>
+      {Platform.OS === 'ios' &&
+        <>
+          <View style={styles.spacer} />
+          <Button title='Select printer' onPress={selectPrinter}/>
+          <View style={styles.spacer} />
+          {selectedPrinter ? <Text style={styles.printer}>{`Selected printer: ${selectedPrinter.name}`}</Text> : undefined}
+        </>
+      }
+    </View>
+  );
+}
+
+/* @hide const styles = StyleSheet.create({ ... }); */
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    backgroundColor: '#ecf0f1',
+    flexDirection: 'column',
+    padding: 8,
+  },
+  spacer: {
+    height: 8
+  },
+  printer: {
+    textAlign: 'center',
+  }
+});
+/* @end */
+```
+
+</SnackInline>
+
 ## API
 
 ```js
@@ -22,6 +114,37 @@ import * as Print from 'expo-print';
 ```
 
 <APISection packageName="expo-print" apiName="Print" />
+
+## Local images
+
+On iOS, printing from HTML source doesn't support local asset URLs (due to WKWebView limitations). Instead, images need to be converted to base64 and inlined into the HTML.
+
+```js
+import { Asset } from 'expo-asset';
+import { printAsync } from 'expo-print';
+import { manipulateAsync } from 'expo-image-manipulator';
+
+async function generateHTML() {
+  const asset = Asset.fromModule(require('../../assets/logo.png'));
+  const image = await manipulateAsync(
+    asset.localUri ?? asset.uri,
+    [],
+    { base64: true }
+  );
+  return `
+    <html>
+      <img
+        src="data:image/jpeg;base64,${image.base64}"
+        style="width: 90vw;" />
+    </html>
+  `;
+}
+
+async function print() {
+  const html = await generateHTML();
+  await printAsync({ html });
+}
+```
 
 ## Page margins
 


### PR DESCRIPTION
# Why

Adds a Snack example on how to use `expo-print`, and adds documentation regarding using local images.

# How

- See why
- Updated unversioned, SDK 42, SDK 43

# Test Plan

- Saved Snack: https://snack.expo.dev/@hein_expo/print-usage
- Opened Snack on Expo Go on iOS and confirmed all buttons work
- Screenshot usage
![image](https://user-images.githubusercontent.com/6184593/138289214-6b057ce6-b5f2-40e4-a2ef-4757f5ee0de6.png)
- Screenshot local images documentation
![image](https://user-images.githubusercontent.com/6184593/138289300-b1ca6c38-5302-4d85-97a7-bd259b821c3f.png)
