### PR TITLE
[expo-dev-launcher] add warning to write_embedded_bundle.sh

### DIFF
--- a/packages/expo-dev-launcher/write_embedded_bundle.sh
+++ b/packages/expo-dev-launcher/write_embedded_bundle.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# TODO: remove once we're confident about dropping SDK 42 support
+REACT_NATIVE_VERSION=$(node --print "require('react-native/package.json').version")
+if ! [[ "$REACT_NATIVE_VERSION" =~ ^0\.63\.[0-9]+$ ]]; then
+  echo -e "\033[1;33mWarning: bundles made with this version of React Native ($REACT_NATIVE_VERSION) will not work in SDK 42.\033[0m"
+fi
 
 # iOS
 


### PR DESCRIPTION
# Why

As https://github.com/expo/expo/issues/14773 showed, building the dev launcher JS bundle against the react-native version on master will result in a bundle that is not compatible with RN 63 / SDK 42 projects.

This PR adds a warning to the write_embedded_bundle.sh script as a reminder the next time we create new bundles -- this way we can be clear and intentional about dropping or keeping support for SDK 42.

# How

Add a warning if the resolved version of react-native is not 0.63.x.

# Test Plan

Ran the script a few times with different number comparisons to confirm it works as expected.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
