### PR TITLE
[docs] Update using-hermes guide 

### DIFF
--- a/docs/pages/guides/using-hermes.md
+++ b/docs/pages/guides/using-hermes.md
@@ -120,14 +120,16 @@ Publishing updates with `expo publish` and `expo export` will generate Hermes by
 
 Please note that the Hermes bytecode format may change between different versions of `hermes-engine` — an update produced for a specific version of Hermes will not run on a different version of Hermes. Updating the Hermes version can be thought of in the same way as updating any other native module, and so if you update the `hermes-engine` version you should also update the `runtimeVersion` in `app.json`. If you don't do this, your app may crash on launch because the update may be loaded by an existing binary that uses an older version of `hermes-engine` that is incompatible with the updated bytecode format. See ["Update Compatibility"](https://docs.expo.dev/bare/updating-your-app/#update-compatibility) for more information.
 
-## JavaScript debugger for Hermes
+## JavaScript inspector for Hermes
 
-To use Hermes inspector for JavaScript debugging, we recommend following [the instructions from the React Native docs](https://reactnative.dev/docs/hermes#debugging-js-on-hermes-using-google-chromes-devtools).
+To use inspector for JavaScript debugging, you can start your project with `expo start` then press `j` to open the inspector in Google Chrome or Microsoft Edge.
 
-- _This is only supported on a debug build app._
-- _Execute `expo start` and make sure Expo development server is running._
+_This is only supported on a debug build app._
 
-> 💡 [Custom development clients](/clients/introduction.md) built with `expo-dev-client` simplify this process by integrating directly with Hermes inspector.
+Other than that, traditional ways to open Hermes inspector are still available:
+
+- [Open Google Chrome DevTools manually](https://reactnative.dev/docs/hermes#debugging-js-on-hermes-using-google-chromes-devtools)
+- [Flipper](https://fbflipper.com/)
 
 ## Limitations
 

--- a/docs/pages/guides/using-hermes.md
+++ b/docs/pages/guides/using-hermes.md
@@ -122,7 +122,7 @@ Please note that the Hermes bytecode format may change between different version
 
 ## JavaScript inspector for Hermes
 
-To use inspector for JavaScript debugging, you can start your project with `expo start` then press `j` to open the inspector in Google Chrome or Microsoft Edge. _This is only supported for debug builds._
+To debug JavaScript code running with Hermes, you can start your project with `expo start` then press `j` to open the inspector in Google Chrome or Microsoft Edge. _This is only supported for debug builds._
 
 
 Alternatively, you can use Hermes inspector with the following tools:

--- a/docs/pages/guides/using-hermes.md
+++ b/docs/pages/guides/using-hermes.md
@@ -50,11 +50,11 @@ Now you can build your app through `eas build` and your app will run with Hermes
 <details><summary><h4>Are you using an M1 Mac?</h4></summary>
 <p>
 
-If you encounter a simulator building error like this:
+When using Hermes for iOS, you may encounter the following error when building for the simulator:
 
 > ❌ `ld: building for iOS Simulator, but linking in dylib built for iOS, file '/path/to/projectName/ios/Pods/hermes-engine/destroot/Library/Frameworks/iphoneos/hermes.framework/hermes' for architecture arm64`
 
-It is [a known issue for React Native 0.64](https://github.com/facebook/hermes/issues/468). To workaround this, you can add the following patch to `ios/Podfile`:
+This is [a known issue for React Native 0.64](https://github.com/facebook/hermes/issues/468); to workaround it, you can add the following patch to your `ios/Podfile`:
 
 ```diff
 --- a/ios/Podfile
@@ -122,11 +122,10 @@ Please note that the Hermes bytecode format may change between different version
 
 ## JavaScript inspector for Hermes
 
-To use inspector for JavaScript debugging, you can start your project with `expo start` then press `j` to open the inspector in Google Chrome or Microsoft Edge.
+To use inspector for JavaScript debugging, you can start your project with `expo start` then press `j` to open the inspector in Google Chrome or Microsoft Edge. _This is only supported for debug builds._
 
-_This is only supported on a debug build app._
 
-Other than that, traditional ways to open Hermes inspector are still available:
+Alternatively, you can use Hermes inspector with the following tools:
 
 - [Open Google Chrome DevTools manually](https://reactnative.dev/docs/hermes#debugging-js-on-hermes-using-google-chromes-devtools)
 - [Flipper](https://fbflipper.com/)


### PR DESCRIPTION
# Why

update more information for hermes

# How

- add instruction for workaround building error on mac m1
- promote expo-cli hermes inspector

# Test Plan

`yarn dev`
ci passed