### PR TITLE
[ios] Fix casing in import path to barcode scanner interface

### DIFF
--- a/packages/expo-modules-core/ios/Interfaces/BarcodeScanner/EXBarcodeScannerProviderInterface.h
+++ b/packages/expo-modules-core/ios/Interfaces/BarcodeScanner/EXBarcodeScannerProviderInterface.h
@@ -1,6 +1,6 @@
 // Copyright 2016-present 650 Industries. All rights reserved.
 
-#import <ExpoModulesCore/EXBarCodeScannerInterface.h>
+#import <ExpoModulesCore/EXBarcodeScannerInterface.h>
 
 @protocol EXBarCodeScannerProviderInterface
 


### PR DESCRIPTION
Fix import error on case-sensitive filesystem.

# Why
The import was using wrong case and causes file not found error during build on a case-sensitive filesystem.

