### PR TITLE
[docs] add SDK 43 blog link to upgrade guide

### DIFF
--- a/docs/pages/workflow/upgrading-expo-sdk-walkthrough.md
+++ b/docs/pages/workflow/upgrading-expo-sdk-walkthrough.md
@@ -8,6 +8,10 @@ Expo maintains ~6 months of backwards compatibility. Once an SDK version has bee
 
 > **Note**: If you are running ExpoKit inside a native project, upgrading will require extra steps. ExpoKit is deprecated and will no longer be supported after SDK 38. We recommend [migrating existing ExpoKit projects to the bare workflow](../bare/migrating-from-expokit.md).
 
+## SDK 43
+
+[Blog Post](https://blog.expo.dev/expo-sdk-43-aa9b3c7d5541)
+
 ## SDK 42
 
 [Blog Post](https://blog.expo.dev/expo-sdk-42-579aee2348b6)


### PR DESCRIPTION
# Why

The SDK 43 release is missing on the expo sdk upgrade duide

# How

Just added the link to the proper blog post

# Test Plan

Check if `/workflow/upgrading-expo-sdk-walkthrough/` has SDK 43 entry at the top linking to https://blog.expo.dev/expo-sdk-43-aa9b3c7d5541

# Checklist

no applicable
