### PR TITLE
Update installing-expo-modules.md

### DIFF
--- a/docs/pages/bare/installing-expo-modules.md
+++ b/docs/pages/bare/installing-expo-modules.md
@@ -61,7 +61,7 @@ console.log(Constants.systemFonts);
 
 ### Using Expo SDK packages
 
-Once the `expo` package is installed and configured in your project, you can use `expo install` to add any other Expo module from the SDK. Learn more in ["Using Libraries"](../using-libraries.md).
+Once the `expo` package is installed and configured in your project, you can use `expo install` to add any other Expo module from the SDK. Learn more in ["Using Libraries"](../bare/using-libraries.md).
 
 ### Expo modules included in the `expo` package
 


### PR DESCRIPTION
Fixed a link :)

# Why

Because it was leading to a 404 page.

# How

By changing `["Using Libraries"](../using-libraries.md)` to `["Using Libraries"](../bare/using-libraries.md)`

# Test Plan

I tested it in my browser, it works.

