### PR TITLE
[ios] Fix versioning ExpoModulesCore imports

### DIFF
--- a/tools/src/versioning/ios/index.ts
+++ b/tools/src/versioning/ios/index.ts
@@ -1169,7 +1169,7 @@ function _getReactNativeTransformRules(versionPrefix, reactPodName) {
     },
     {
       flags: '-Ei',
-      pattern: `s/(#import |__has_include\\()<(Expo|RNReanimated)/#import <${versionPrefix}\\1/g`,
+      pattern: `s/(#import |__has_include\\()<(Expo|RNReanimated)/\\1<${versionPrefix}\\2/g`,
     },
   ];
 }


### PR DESCRIPTION
# Why

Fixing https://github.com/expo/expo/runs/3987369426
In versioned ExpoKit `#import <ExpoModulesCore/` was incorrectly versioned to `#import <ABIX_0_0#import ModulesCore/`.

# How

I found an issue in one of the rules (which I introduced 🙈).

# Test Plan

1. `et add-sdk -p ios` seems to version that correctly
2. Let's see on the CI if it builds after all

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
