### PR TITLE
Add pedometer limitation notice to docs

### DIFF
--- a/docs/pages/versions/unversioned/sdk/pedometer.md
+++ b/docs/pages/versions/unversioned/sdk/pedometer.md
@@ -8,7 +8,7 @@ import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import SnackInline from '~/components/plugins/SnackInline';
 
-`Pedometer` from **`expo-sensors`** uses Core Motion on iOS and the system `hardware.Sensor` on Android to get the user's step count, and also allows you to subscribe to pedometer updates.
+`Pedometer` from **`expo-sensors`** uses Core Motion on iOS and the system `hardware.Sensor` on Android to get the user's step count, and also allows you to subscribe to pedometer updates. Note: `Pedometer.getStepCountAsync(start, end)` is not supported on Android
 
 <PlatformsSection android emulator ios simulator />
 


### PR DESCRIPTION
adding this since its not documented in the API even though it should be:
https://forums.expo.dev/t/pedometer-getstepcountasync-doesnt-work-on-android/50279/2

# Why


adding this since its not documented in the API :
https://forums.expo.dev/t/pedometer-getstepcountasync-doesnt-work-on-android/50279/2-->

# How

added documentation

# Test Plan

made sure the notice is clear and legible

# Checklist


- [ x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
