### PR TITLE
[docs] updates "main" to "production" for eas update GHA doc

### DIFF
--- a/docs/pages/preview/eas-update/github-actions.md
+++ b/docs/pages/preview/eas-update/github-actions.md
@@ -1,10 +1,10 @@
 # Using GitHub Actions with EAS Update
 
-A GitHub Action is a cloud function that runs every time an event on GitHub occurs. We can use GitHub Actions to automate building and publishing updates when you or members on your team merge to a branch, like "main". This makes the process of deploying consistent and fast, leaving you more time to develop your app.
+A GitHub Action is a cloud function that runs every time an event on GitHub occurs. We can use GitHub Actions to automate building and publishing updates when you or members on your team merge to a branch, like "production". This makes the process of deploying consistent and fast, leaving you more time to develop your app.
 
-## Publishing when merging to "main"
+## Publishing when merging to "production"
 
-We can configure GitHub Actions to run on any GitHub event. One of the most common use cases is to publish an app when code is merged to the "main" branch. Below are the steps to publish your app every time a commit is merged to "main":
+We can configure GitHub Actions to run on any GitHub event. One of the most common use cases is to publish an app when code is merged to the "production" branch. Below are the steps to publish your app every time a commit is merged to "production":
 
 1. Create a file path named **.github/workflows/update.yml** at the root of your project.
 2. Inside **update.yml**, copy and paste this code:
@@ -13,7 +13,7 @@ We can configure GitHub Actions to run on any GitHub event. One of the most comm
    name: update
    on:
      push:
-       branches: [main]
+       branches: [production]
 
    jobs:
      update:
@@ -45,7 +45,7 @@ We can configure GitHub Actions to run on any GitHub event. One of the most comm
          - run: eas branch:publish $(echo ${{ github.ref }} | sed 's|refs/heads/||') --message "${{ github.event.head_commit.message }}"
    ```
 
-   In the code above, we set the action to run every time code is pushed to the "main" branch. In the `update` job, we set up Node, in addition to Expo's GitHub Action: `expo-github-action`. We then add a couple steps to cache any dependencies installed from the last run to speed this script up on subsequent runs. At the end, we install dependencies (`yarn install`), then create a branch on EAS, then publish the branch. The EAS branch will be named after the GitHub branch, and the message for the update will match the commit's message.
+   In the code above, we set the action to run every time code is pushed to the "production" branch. In the `update` job, we set up Node, in addition to Expo's GitHub Action: `expo-github-action`. We then add a couple steps to cache any dependencies installed from the last run to speed this script up on subsequent runs. At the end, we install dependencies (`yarn install`), then create a branch on EAS, then publish the branch. The EAS branch will be named after the GitHub branch, and the message for the update will match the commit's message.
 
 3. Finally, we need to give the script above permission to run by providing an `EXPO_TOKEN` environment variable.
    1. Navigate to [https://expo.dev/settings/access-tokens](https://expo.dev/settings/access-tokens).
@@ -55,6 +55,6 @@ We can configure GitHub Actions to run on any GitHub event. One of the most comm
    5. Click "New repository secret"
    6. Make the secret's name "EXPO_TOKEN", then paste the access token in as the value.
 
-Your GitHub Action should be set up now. Every time when someone merges code into the "main" branch, this action will build an update and publish it, making it available to all of our users with builds that have access to the "main" branch on EAS.
+Your GitHub Action should be set up now. Every time when someone merges code into the "production" branch, this action will build an update and publish it, making it available to all of our users with builds that have access to the "production" branch on EAS.
 
 > Some repositories or organizations might need to explicitly enable GitHub Workflows and allow third-party Actions.


### PR DESCRIPTION
# Why

We are moving to a pattern where we have three patterns we suggest developers do: development, preview, and production. Since we'd like for our EAS Update GitHub Action to align, I'm changing the doc to use "production" (instead of "main") as the branch in the example code. I hope this will nudge developers to set up an action that pushes to their production builds on when they push to GitHub.

# How

Updated the EAS Update "Using GitHub Actions with EAS Update" doc.

# Test Plan

Read the doc and make sure it still makes sense with the new branch name.
