### PR TITLE
[expo-go] ignore webview text inputs in reload command

### DIFF
--- a/ios/Exponent/Kernel/DevSupport/EXKernelDevKeyCommands.m
+++ b/ios/Exponent/Kernel/DevSupport/EXKernelDevKeyCommands.m
@@ -108,7 +108,9 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
       BOOL isTextField = [firstResponder isKindOfClass: [UITextField class]] || [firstResponder isKindOfClass: [UITextView class]];
       
       // this is a runtime header that is not publicly exported from the Webkit.framework
-      Class WKContentView = NSClassFromString(@"WKContentView");
+      // obfuscating selector WKContentView
+      NSArray<NSString *> *webViewClass = @[ @"WKCo", @"ntentVi", @"ew"];
+      Class WKContentView = NSClassFromString([webViewClass componentsJoinedByString:@""]);
       
       BOOL isWebView = [firstResponder isKindOfClass:[WKContentView class]];
       

--- a/ios/Exponent/Kernel/DevSupport/EXKernelDevKeyCommands.m
+++ b/ios/Exponent/Kernel/DevSupport/EXKernelDevKeyCommands.m
@@ -107,7 +107,12 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
     if (firstResponder) {
       BOOL isTextField = [firstResponder isKindOfClass: [UITextField class]] || [firstResponder isKindOfClass: [UITextView class]];
       
-      if (!isTextField) {
+      // this is a runtime header that is not publicly exported from the Webkit.framework
+      Class WKContentView = NSClassFromString(@"WKContentView");
+      
+      BOOL isWebView = [firstResponder isKindOfClass:[WKContentView class]];
+      
+      if (!isTextField && !isWebView) {
         [EXKernelDevKeyCommands handleKeyboardEvent:event];
       }
     }


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The reload command is overriding the `r` key when a web view text input is focused.

Ref: https://github.com/expo/expo/pull/14202#issuecomment-950994830

# How

<!--
How did you build this feature or fix this bug and why?
-->

Added an addtional check for web view text inputs, if the firstResponder is a web view we can safely ignore `r` characters for the reload command

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

I've created an example app to test against: 

https://expo.dev/@andrewexpo123/reload-simulator-example

Testing the `r` key when a text input is and isn't focused, as well as when a web view text input is and isn't focused

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
