### PR TITLE
[ci] Upgrade detox and xcode 13 for test-suite ios

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -72,8 +72,8 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: true
-      - name: 🔨 Switch to Xcode 12.5.1
-        run: sudo xcode-select --switch /Applications/Xcode_12.5.1.app
+      - name: 🔨 Switch to Xcode 13.0
+        run: sudo xcode-select --switch /Applications/Xcode_13.0.app
       - name: 🍺 Install required tools
         run: |
           brew tap wix/brew

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -129,7 +129,7 @@
     "@types/react-native": "~0.64.12",
     "babel-plugin-module-resolver": "^4.1.0",
     "babel-preset-expo": "~8.5.1",
-    "detox": "^18.20.1",
+    "detox": "^18.23.1",
     "expo-module-scripts": "^2.0.0",
     "expo-yarn-workspaces": "^1.6.0",
     "jest-expo": "~43.0.0-beta.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7053,10 +7053,10 @@ detect-port-alt@1.1.6:
     address "^1.0.1"
     debug "^2.6.0"
 
-detox@^18.20.1:
-  version "18.23.0"
-  resolved "https://registry.yarnpkg.com/detox/-/detox-18.23.0.tgz#000f0aa3535e4e655932a6191a97880fe58e74cd"
-  integrity sha512-QixjyEFRH8iUVb/H9Dn4RqGQAyf3J6rn1Rjh+gCVHvfsTj15e0sm6X7FUavdtOJnCKM15z2vgjFFez57H1mYxA==
+detox@^18.23.1:
+  version "18.23.1"
+  resolved "https://registry.yarnpkg.com/detox/-/detox-18.23.1.tgz#f09f5e50291cdab3d62dc40ff2e8bb5cfb3cb776"
+  integrity sha512-MnOXfTcBBcXTrlLk3EeHq1nEfob79nChZbfOtlEummyec/X+PQzEvmKk2cvsUzu1f7GiNbCiBKN66w47Z7b/CQ==
   dependencies:
     bunyan "^1.8.12"
     bunyan-debug-stream "^1.1.0"


### PR DESCRIPTION
# Why

previous test-suite ios was broken on xcode 13 and new detox fixed the issue.

# How

upgrades detox and uses xcode 13 for test-suite ios

# Test Plan

ci passed
