### PR TITLE
@tc/drop custom go

### DIFF
--- a/docs/pages/introduction/walkthrough.md
+++ b/docs/pages/introduction/walkthrough.md
@@ -79,7 +79,7 @@ You may have noticed that when we ran `expo publish` the CLI warned us about opt
 
 Upon publishing you are given a persistent URL that you can share with colleagues, in this case it was [https://expo.dev/@notbrent/blearexp](https://expo.dev/@notbrent/blearexp). This is determined by your Expo account username and the `slug` field in your project `app.json`.
 
-On iOS, only you can open projects that you have built unless you have a [priority plan](https://expo.dev/developer-services), in which case your teammates can open your projects as well. Another option to open any published managed app is to do a custom build of an Expo iOS client. [Read more about that here](../guides/adhoc-builds.md).
+If you're interesting in sharing your project with other members of your team, you're ready for a [development build](../development/introduction.md) of your app.
 
 ## Building and deploying
 

--- a/docs/pages/versions/unversioned/sdk/facebook.md
+++ b/docs/pages/versions/unversioned/sdk/facebook.md
@@ -27,7 +27,7 @@ Follow [Facebook's developer documentation](https://developers.facebook.com/docs
 
 Then follow these steps based on the platforms you're targeting. This will need to be done from the [Facebook developer site](https://developers.facebook.com/).
 
-Expo Go from the Android Play Store will use the Facebook App ID that you provide. however, all Facebook API calls in the **Expo Go from the iOS App Store will use Expo's own Facebook App ID**. This is due to underlying configuration limitations, and the downside to this is that you can't customize which permissions your app requests from Facebook (like `user_photos` or `user_friends`), or integrate Facebook login with other services like Firebase auth. If you need that functionality on iOS, you can create a [development build](../development/introduction.md) of you app.
+Expo Go from the Android Play Store will use the Facebook App ID that you provide. however, all Facebook API calls in the **Expo Go from the iOS App Store will use Expo's own Facebook App ID**. This is due to underlying configuration limitations, and the downside to this is that you can't customize which permissions your app requests from Facebook (like `user_photos` or `user_friends`), or integrate Facebook login with other services like Firebase auth. If you need that functionality on iOS, you can create a [development build](../development/introduction.md) of your app.
 
 #### Configure `app.json`
 

--- a/docs/pages/versions/unversioned/sdk/facebook.md
+++ b/docs/pages/versions/unversioned/sdk/facebook.md
@@ -27,7 +27,7 @@ Follow [Facebook's developer documentation](https://developers.facebook.com/docs
 
 Then follow these steps based on the platforms you're targeting. This will need to be done from the [Facebook developer site](https://developers.facebook.com/).
 
-Expo Go from the Android Play Store will use the Facebook App ID that you provide, however, all Facebook API calls in the **Expo Go from the iOS App Store will use Expo's own Facebook App ID**. This is due to underlying configuration limitations, but the good news is it means less setup for you! The slight downside to this is that you can't customize which permissions your app requests from Facebook (like `user_photos` or `user_friends`), or integrate Facebook login with other services like Firebase auth. If you need that functionality on iOS, you can build a standalone app. An easy way to test this is to run `expo build:ios -t simulator` and install the app in your simulator.
+Expo Go from the Android Play Store will use the Facebook App ID that you provide. however, all Facebook API calls in the **Expo Go from the iOS App Store will use Expo's own Facebook App ID**. This is due to underlying configuration limitations, and the downside to this is that you can't customize which permissions your app requests from Facebook (like `user_photos` or `user_friends`), or integrate Facebook login with other services like Firebase auth. If you need that functionality on iOS, you can create a [development build](../development/introduction.md) of you app.
 
 #### Configure `app.json`
 

--- a/docs/pages/versions/unversioned/sdk/task-manager.md
+++ b/docs/pages/versions/unversioned/sdk/task-manager.md
@@ -23,7 +23,7 @@ For [managed](/introduction/managed-vs-bare.md#managed-workflow) apps, you'll ne
 
 ### Background modes on iOS
 
-`TaskManager` works out of the box in the Expo Go app on Android, but on iOS you'll need to test using [a custom Expo Go build](/guides/adhoc-builds.md).
+`TaskManager` works out of the box in the Expo Go app on Android, but on iOS you'll need to test using [a development build](../development/introduction.md) of your app.
 
 Standalone apps need some extra configuration: on iOS, each background feature requires a special key in `UIBackgroundModes` array in your `Info.plist` file. In standalone apps this array is empty by default, so in order to use background features you will need to add appropriate keys to your `app.json` configuration.
 Here is an example of an `app.json` configuration that enables background location and background fetch:

--- a/docs/pages/versions/v42.0.0/sdk/facebook.md
+++ b/docs/pages/versions/v42.0.0/sdk/facebook.md
@@ -27,7 +27,7 @@ Follow [Facebook's developer documentation](https://developers.facebook.com/docs
 
 Then follow these steps based on the platforms you're targeting. This will need to be done from the [Facebook developer site](https://developers.facebook.com/).
 
-Expo Go from the Android Play Store will use the Facebook App ID that you provide. however, all Facebook API calls in the **Expo Go from the iOS App Store will use Expo's own Facebook App ID**. This is due to underlying configuration limitations, and the downside to this is that you can't customize which permissions your app requests from Facebook (like `user_photos` or `user_friends`), or integrate Facebook login with other services like Firebase auth. If you need that functionality on iOS, you can create a [development build](../development/introduction.md) of you app.
+Expo Go from the Android Play Store will use the Facebook App ID that you provide. however, all Facebook API calls in the **Expo Go from the iOS App Store will use Expo's own Facebook App ID**. This is due to underlying configuration limitations, and the downside to this is that you can't customize which permissions your app requests from Facebook (like `user_photos` or `user_friends`), or integrate Facebook login with other services like Firebase auth. If you need that functionality on iOS, you can create a [development build](../development/introduction.md) of your app.
 
 #### Configure `app.json`
 

--- a/docs/pages/versions/v42.0.0/sdk/facebook.md
+++ b/docs/pages/versions/v42.0.0/sdk/facebook.md
@@ -27,7 +27,7 @@ Follow [Facebook's developer documentation](https://developers.facebook.com/docs
 
 Then follow these steps based on the platforms you're targeting. This will need to be done from the [Facebook developer site](https://developers.facebook.com/).
 
-Expo Go from the Android Play Store will use the Facebook App ID that you provide, however, all Facebook API calls in the **Expo Go from the iOS App Store will use Expo's own Facebook App ID**. This is due to underlying configuration limitations, but the good news is it means less setup for you! The slight downside to this is that you can't customize which permissions your app requests from Facebook (like `user_photos` or `user_friends`), or integrate Facebook login with other services like Firebase auth. If you need that functionality on iOS, you can build a standalone app. An easy way to test this is to run `expo build:ios -t simulator` and install the app in your simulator.
+Expo Go from the Android Play Store will use the Facebook App ID that you provide. however, all Facebook API calls in the **Expo Go from the iOS App Store will use Expo's own Facebook App ID**. This is due to underlying configuration limitations, and the downside to this is that you can't customize which permissions your app requests from Facebook (like `user_photos` or `user_friends`), or integrate Facebook login with other services like Firebase auth. If you need that functionality on iOS, you can create a [development build](../development/introduction.md) of you app.
 
 #### Configure `app.json`
 

--- a/docs/pages/versions/v42.0.0/sdk/task-manager.md
+++ b/docs/pages/versions/v42.0.0/sdk/task-manager.md
@@ -23,7 +23,7 @@ For [managed](/introduction/managed-vs-bare.md#managed-workflow) apps, you'll ne
 
 ### Background modes on iOS
 
-`TaskManager` works out of the box in the Expo Go app on Android, but on iOS you'll need to test using [a custom Expo Go build](/guides/adhoc-builds.md).
+`TaskManager` works out of the box in the Expo Go app on Android, but on iOS you'll need to test using [a development build](../development/introduction.md) of your app.
 
 Standalone apps need some extra configuration: on iOS, each background feature requires a special key in `UIBackgroundModes` array in your `Info.plist` file. In standalone apps this array is empty by default, so in order to use background features you will need to add appropriate keys to your `app.json` configuration.
 Here is an example of an `app.json` configuration that enables background location and background fetch:

--- a/docs/pages/versions/v43.0.0/sdk/facebook.md
+++ b/docs/pages/versions/v43.0.0/sdk/facebook.md
@@ -27,7 +27,7 @@ Follow [Facebook's developer documentation](https://developers.facebook.com/docs
 
 Then follow these steps based on the platforms you're targeting. This will need to be done from the [Facebook developer site](https://developers.facebook.com/).
 
-Expo Go from the Android Play Store will use the Facebook App ID that you provide. however, all Facebook API calls in the **Expo Go from the iOS App Store will use Expo's own Facebook App ID**. This is due to underlying configuration limitations, and the downside to this is that you can't customize which permissions your app requests from Facebook (like `user_photos` or `user_friends`), or integrate Facebook login with other services like Firebase auth. If you need that functionality on iOS, you can create a [development build](../development/introduction.md) of you app.
+Expo Go from the Android Play Store will use the Facebook App ID that you provide. however, all Facebook API calls in the **Expo Go from the iOS App Store will use Expo's own Facebook App ID**. This is due to underlying configuration limitations, and the downside to this is that you can't customize which permissions your app requests from Facebook (like `user_photos` or `user_friends`), or integrate Facebook login with other services like Firebase auth. If you need that functionality on iOS, you can create a [development build](../development/introduction.md) of your app.
 
 #### Configure `app.json`
 

--- a/docs/pages/versions/v43.0.0/sdk/facebook.md
+++ b/docs/pages/versions/v43.0.0/sdk/facebook.md
@@ -27,7 +27,7 @@ Follow [Facebook's developer documentation](https://developers.facebook.com/docs
 
 Then follow these steps based on the platforms you're targeting. This will need to be done from the [Facebook developer site](https://developers.facebook.com/).
 
-Expo Go from the Android Play Store will use the Facebook App ID that you provide, however, all Facebook API calls in the **Expo Go from the iOS App Store will use Expo's own Facebook App ID**. This is due to underlying configuration limitations, but the good news is it means less setup for you! The slight downside to this is that you can't customize which permissions your app requests from Facebook (like `user_photos` or `user_friends`), or integrate Facebook login with other services like Firebase auth. If you need that functionality on iOS, you can build a standalone app. An easy way to test this is to run `expo build:ios -t simulator` and install the app in your simulator.
+Expo Go from the Android Play Store will use the Facebook App ID that you provide. however, all Facebook API calls in the **Expo Go from the iOS App Store will use Expo's own Facebook App ID**. This is due to underlying configuration limitations, and the downside to this is that you can't customize which permissions your app requests from Facebook (like `user_photos` or `user_friends`), or integrate Facebook login with other services like Firebase auth. If you need that functionality on iOS, you can create a [development build](../development/introduction.md) of you app.
 
 #### Configure `app.json`
 

--- a/docs/pages/versions/v43.0.0/sdk/task-manager.md
+++ b/docs/pages/versions/v43.0.0/sdk/task-manager.md
@@ -23,7 +23,7 @@ For [managed](/introduction/managed-vs-bare.md#managed-workflow) apps, you'll ne
 
 ### Background modes on iOS
 
-`TaskManager` works out of the box in the Expo Go app on Android, but on iOS you'll need to test using [a custom Expo Go build](/guides/adhoc-builds.md).
+`TaskManager` works out of the box in the Expo Go app on Android, but on iOS you'll need to test using [a development build](../development/introduction.md) of your app.
 
 Standalone apps need some extra configuration: on iOS, each background feature requires a special key in `UIBackgroundModes` array in your `Info.plist` file. In standalone apps this array is empty by default, so in order to use background features you will need to add appropriate keys to your `app.json` configuration.
 Here is an example of an `app.json` configuration that enables background location and background fetch:


### PR DESCRIPTION
# Why

Development builds provide a better alternative at this point

# How

Update links to point to development builds.  (Assumes jon will have moved the pages to the expected path

# Test Plan

Viewed pages with yarn dev.