### PR TITLE
Fix NODE_BINARY not found build error when using nvm via zsh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Package-specific changes not released in any SDK will be added here just before 
 ### 🎉 New features
 
 ### 🐛 Bug fixes
+- Fix NODE_BINARY not found build error when using nvm via zsh ([#14895](https://github.com/expo/expo/pull/14895) by [@filipengberg](https://github.com/filipengberg))
 
 ## 43.0.0 — 2021-10-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ Package-specific changes not released in any SDK will be added here just before 
 ### 🎉 New features
 
 ### 🐛 Bug fixes
-- Fix NODE_BINARY not found build error when using nvm via zsh ([#14895](https://github.com/expo/expo/pull/14895) by [@filipengberg](https://github.com/filipengberg))
 
 ## 43.0.0 — 2021-10-01
 

--- a/packages/expo-constants/CHANGELOG.md
+++ b/packages/expo-constants/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - Don't include fonts from family "System Font" (introduced by iOS 15) ([#14577](https://github.com/expo/expo/pull/14577) by [@brentvatne](https://github.com/brentvatne))
 - Fix `Constants.deviceId has been deprecated in favor of generating and storing your own ID.` warnings in classic react-native projects. ([#14837](https://github.com/expo/expo/pull/14837) by [@kudo](https://github.com/kudo))
+- Fix NODE_BINARY not found build error when using nvm via zsh ([#14895](https://github.com/expo/expo/pull/14895) by [@filipengberg](https://github.com/filipengberg))
 
 ### 💡 Others
 

--- a/packages/expo-constants/scripts/get-app-config-ios.sh
+++ b/packages/expo-constants/scripts/get-app-config-ios.sh
@@ -4,13 +4,11 @@ set -eo pipefail
 
 DEST="$CONFIGURATION_BUILD_DIR"
 RESOURCE_BUNDLE_NAME="EXConstants.bundle"
+# ref: https://github.com/facebook/react-native/blob/c974cbff04a8d90ac0f856dbada3fc5a75c75b49/scripts/react-native-xcode.sh#L59-L65
+# Path to expo-constants folder inside node_modules
+EXPO_CONSTANTS_PACKAGE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
-# Fix for machines using nvm
-if [[ -s "$HOME/.nvm/nvm.sh" ]]; then
-. "$HOME/.nvm/nvm.sh"
-elif [[ -x "$(command -v brew)" && -s "$(brew --prefix nvm)/nvm.sh" ]]; then
-. "$(brew --prefix nvm)/nvm.sh"
-fi
+source "$EXPO_CONSTANTS_PACKAGE_DIR/scripts/source-login-scripts.sh"
 
 NODE_BINARY=${NODE_BINARY:-node}
 
@@ -31,9 +29,6 @@ if [ "x$PROJECT_DIR_BASENAME" != "xPods" ]; then
   exit 0
 fi
 
-# ref: https://github.com/facebook/react-native/blob/c974cbff04a8d90ac0f856dbada3fc5a75c75b49/scripts/react-native-xcode.sh#L59-L65
-# Path to expo-constants folder inside node_modules
-EXPO_CONSTANTS_PACKAGE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # If PROJECT_ROOT is not specified, fallback to use Xcode PROJECT_DIR
 PROJECT_ROOT=${PROJECT_ROOT:-"$PROJECT_DIR/../.."}
 PROJECT_ROOT=${PROJECT_ROOT:-"$EXPO_CONSTANTS_PACKAGE_DIR/../.."}

--- a/packages/expo-constants/scripts/get-app-config-ios.sh
+++ b/packages/expo-constants/scripts/get-app-config-ios.sh
@@ -4,6 +4,14 @@ set -eo pipefail
 
 DEST="$CONFIGURATION_BUILD_DIR"
 RESOURCE_BUNDLE_NAME="EXConstants.bundle"
+
+# Fix for machines using nvm
+if [[ -s "$HOME/.nvm/nvm.sh" ]]; then
+. "$HOME/.nvm/nvm.sh"
+elif [[ -x "$(command -v brew)" && -s "$(brew --prefix nvm)/nvm.sh" ]]; then
+. "$(brew --prefix nvm)/nvm.sh"
+fi
+
 NODE_BINARY=${NODE_BINARY:-node}
 
 if ! [ -x "$(command -v "$NODE_BINARY")" ]; then

--- a/packages/expo-constants/scripts/source-login-scripts.sh
+++ b/packages/expo-constants/scripts/source-login-scripts.sh
@@ -1,0 +1,45 @@
+# shellcheck shell=bash disable=SC1090,SC1091
+
+# Source login scripts to simulate running in an interactive login shell to
+# configure environment variables as if the user had opened a shell. This
+# script is intended for Xcode build phase scripts on macOS and does not have
+# a shebang so it inherits the current shell.
+
+current_shell=$(ps -cp "$$" -o comm="" | sed s/^-//)
+
+if [[ "$current_shell" == zsh ]]; then
+   # Zsh's setup script order is:
+   #   /etc/zshenv
+   #   ~/.zshenv
+   #   /etc/zprofile
+   #   ~/.zprofile
+   #   /etc/zshrc
+   #   ~/.zshrc
+   #   /etc/zlogin
+   #   ~/.zlogin
+   # http://zsh.sourceforge.net/Guide/zshguide02.html
+
+   if [ -f /etc/zshenv ]; then . /etc/zshenv; fi
+   if [ -f ~/.zshenv ]; then . ~/.zshenv; fi
+   if [ -f /etc/zprofile ]; then . /etc/zprofile; fi
+   if [ -f ~/.zprofile ]; then . ~/.zprofile; fi
+   if [ -f /etc/zshrc ]; then . /etc/zshrc; fi
+   if [ -f ~/.zshrc ]; then . ~/.zshrc; fi
+   if [ -f /etc/zlogin ]; then . /etc/zlogin; fi
+   if [ -f ~/zlogin ]; then . ~/zlogin; fi
+else
+   # Bash's setup script order is:
+   #   /etc/profile (if it exists)
+   #   The first of: ~/.bash_profile, ~/.bash_login, and ~/.profile
+   # https://www.gnu.org/software/bash/manual/html_node/Bash-Startup-Files.html
+
+   if [ -f /etc/profile ]; then . /etc/profile; fi
+
+   if [ -f ~/.bash_profile ]; then
+      . ~/.bash_profile
+   elif [ -f ~/.bash_login ]; then
+      . ~/.bash_login
+   elif [ -f ~/.profile ]; then
+      . ~/.profile
+   fi
+fi


### PR DESCRIPTION
# Why
When adding expo-modules to a React native 0.66.1 project I get the following build error:

`Error: cannot find the node binary. Try setting the NODE_BINARY variable in the "Bundle React Native code and images" Build Phase to the absolute path to your node binary. You can find it by executing "which node" in a terminal window.`

This is caused by me having installed node via nvm and Expo cannot seem to find it. There was already a PR to fix this: #14047 but it does not resolve the issue for me. I guess it is because it runs the script in bash and I use zsh (which is now default in MacOS as far as I know).

I don't think it's a good recommendation to "hardcode the absolute path to your node binary" since it will only work for single developer projects.

# How

In React Native they have solved this problem by running a find-node.sh script: https://github.com/facebook/react-native/blob/main/scripts/find-node.sh that is run before checking NODE_BINARY: https://github.com/facebook/react-native/blob/f7e4c07c84b636fc33c64b434964c8a64c43438f/scripts/react-native-xcode.sh#L84

This PR just contains a snippet from that find-node.sh script. I dont think is the best solution though. Maybe we could source the find-node.sh directly from the react-native scripts folder or we could make a copy of it into the expo-constants folder? Or maybe theres an even cleaner way of solving it?

# Test Plan

1. Using .zsh as default shell. install node via nvm
1. Create a new react native project
2. Add expo-modules
3. Try to build it in XCode
4. It should fail
5. Apply this PR
6. Try to build again
7. It should succeed

# Checklist
- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).