### PR TITLE
docs: update lottie-react-native repository's organization

### DIFF
--- a/docs/pages/versions/unversioned/sdk/lottie.md
+++ b/docs/pages/versions/unversioned/sdk/lottie.md
@@ -1,6 +1,6 @@
 ---
 title: Lottie
-sourceCodeUrl: 'https://github.com/react-native-community/lottie-react-native'
+sourceCodeUrl: 'https://github.com/lottie-react-native/lottie-react-native'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';
@@ -13,7 +13,7 @@ Expo includes support for [Lottie](https://airbnb.design/lottie/), the animation
 
 ## Installation
 
-<InstallSection packageName="lottie-react-native" href="https://github.com/react-native-community/lottie-react-native" />
+<InstallSection packageName="lottie-react-native" href="https://github.com/lottie-react-native/lottie-react-native" />
 
 ## Usage
 
@@ -86,4 +86,4 @@ const styles = StyleSheet.create({
 import LottieView from 'lottie-react-native';
 ```
 
-Refer to the [lottie-react-native repository](https://github.com/airbnb/lottie-react-native#usage) for more detailed documentation.
+Refer to the [lottie-react-native repository](https://github.com/lottie-react-native/lottie-react-native#usage) for more detailed documentation.


### PR DESCRIPTION
# Why

These URLs are old. 

* https://github.com/airbnb/lottie-react-native
* https://github.com/react-native-community/lottie-react-native

# How

change to https://github.com/lottie-react-native/lottie-react-native

# Test Plan

1. access `http://localhost:3002/versions/unversioned/sdk/lottie/`
2. click link "these additional installation instructions" and "lottie-react-native repository"

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
