### PR TITLE
[hotfix][expoview][android] Fix proguard strip annotation in ExpoHeadlessAppLoader

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/taskManager/ExpoHeadlessAppLoader.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/taskManager/ExpoHeadlessAppLoader.kt
@@ -2,12 +2,12 @@ package host.exp.exponent.taskManager
 
 import android.content.Context
 import android.util.Log
-import com.facebook.proguard.annotations.DoNotStrip
 import expo.modules.adapters.react.apploader.HeadlessAppLoaderNotifier
 import expo.modules.apploader.AppLoaderProvider
 import expo.modules.apploader.HeadlessAppLoader
 import expo.modules.apploader.HeadlessAppLoader.AppConfigurationError
 import expo.modules.core.interfaces.Consumer
+import expo.modules.core.interfaces.DoNotStrip
 import host.exp.exponent.headless.InternalHeadlessAppLoader
 import java.util.*
 

--- a/android/expoview/src/main/java/host/exp/exponent/taskManager/ExpoHeadlessAppLoader.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/taskManager/ExpoHeadlessAppLoader.kt
@@ -2,12 +2,12 @@ package host.exp.exponent.taskManager
 
 import android.content.Context
 import android.util.Log
+import com.facebook.proguard.annotations.DoNotStrip
 import expo.modules.adapters.react.apploader.HeadlessAppLoaderNotifier
 import expo.modules.apploader.AppLoaderProvider
 import expo.modules.apploader.HeadlessAppLoader
 import expo.modules.apploader.HeadlessAppLoader.AppConfigurationError
 import expo.modules.core.interfaces.Consumer
-import expo.modules.core.interfaces.DoNotStrip
 import host.exp.exponent.headless.InternalHeadlessAppLoader
 import java.util.*
 

--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -56,6 +56,7 @@ android {
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 30)
+    consumerProguardFiles 'proguard-rules.pro'
     versionCode 1
     versionName "0.4.2"
   }


### PR DESCRIPTION
# Why

My unproven hypothesis is that something about this change https://github.com/expo/expo/commit/9cd697533d64cdee216c641b792fda7952d1afcf caused the proguard skip annotation not to have an effect in this module.

It's really difficult to test though.

Update: it was https://github.com/expo/expo/commit/9cd697533d64cdee216c641b792fda7952d1afcf as it forgot to add `consumerProguardFiles` to the library's gradle.

# What makes me think this

Run gradle `assembleRelease` in master, look at `android/app/build/outputs/mapping/configuration.txt` (the combined proguard configuration) and don't see the one that matches the `expo.modules.core.interfaces.DoNotStrip` annotation. Note that I have no way to prove that the previous unimodules one would have been in there but maybe the way dependencies work it was being included.

Note that there is `-keep @**.expo.core.interfaces.DoNotStrip class *` (no idea why) but not `-keep @**.expo.core.modules.interfaces.DoNotStrip class *`.

Update: The unimodules module does have `consumerProguardFiles` so that's the difference.

# How

My guess is that if we use the DoNotStrip annotation from FB the same as we do in other places in the expoview module it won't be stripped, so this PR goes with that approach. I know that this annotation is respected in proguard config.

Edit: Instead, just add `consumerProguardFiles`.

# Test Plan

Hypothetical test plan:
1. `et android-shell-app` on sdk branch with this patched in
2. Build release build
3. Decompile release build
4. Ensure `ExpoHeadlessAppLoader` is in there

Also do those steps without it patched in and verify that it isn't in there.