### PR TITLE
GoogleAuthProvider - credential - static member

### DIFF
--- a/docs/pages/guides/authentication.md
+++ b/docs/pages/guides/authentication.md
@@ -1236,8 +1236,7 @@ export default function App() {
 
       /* @info Create a Google credential with the <code>id_token</code> */
       const auth = getAuth();
-      const provider = new GoogleAuthProvider();
-      const credential = provider.credential(id_token);
+      const credential = GoogleAuthProvider.credential(id_token);
       /* @end */
       signInWithCredential(auth, credential);
     }


### PR DESCRIPTION
# Why

```jsx
const provider = new GoogleAuthProvider();
const credential = provider.credential(id_token);
```
Doesn't work because `credential` is a static member of `GoogleAuthProvider` class.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
