### PR TITLE
[core] Fix ios app freezing in remote debugging mode

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix ios app hanging in remote debugging mode. ([#14922](https://github.com/expo/expo/pull/14922) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 0.4.5 — 2021-10-25

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix ios app hanging in remote debugging mode. ([#14922](https://github.com/expo/expo/pull/14922) by [@kudo](https://github.com/kudo))
+- Fix iOS app freezing in remote debugging mode. ([#14922](https://github.com/expo/expo/pull/14922) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/NativeModulesProxy/EXNativeModulesProxy.mm
+++ b/packages/expo-modules-core/ios/NativeModulesProxy/EXNativeModulesProxy.mm
@@ -36,6 +36,7 @@ static const NSString *methodInfoArgumentsCountKey = @"argumentsCount";
 
 @interface RCTBridge (RegisterAdditionalModuleClasses)
 
+- (NSArray<RCTModuleData *> *)registerModulesForClasses:(NSArray<Class> *)moduleClasses;
 - (void)registerAdditionalModuleClasses:(NSArray<Class> *)modules;
 
 @end
@@ -271,7 +272,7 @@ RCT_EXPORT_METHOD(callMethod:(NSString *)moduleName methodNameOrKey:(id)methodNa
   [bridge uiManager];
 
   // Register the view managers as additional modules.
-  [bridge registerAdditionalModuleClasses:additionalModuleClasses];
+  [self registerAdditionalModuleClasses:additionalModuleClasses inBridge:bridge];
 
   // Bridge's `registerAdditionalModuleClasses:` method doesn't register
   // components in UIManager — we need to register them on our own.
@@ -284,6 +285,32 @@ RCT_EXPORT_METHOD(callMethod:(NSString *)moduleName methodNameOrKey:(id)methodNa
   // Let the modules consume the registry :)
   // It calls `setModuleRegistry:` on all `EXModuleRegistryConsumer`s.
   [_exModuleRegistry initialize];
+}
+
+- (void)registerAdditionalModuleClasses:(NSArray<Class> *)moduleClasses inBridge:(RCTBridge *)bridge
+{
+  // In remote debugging mode, i.e. executorClass is `RCTWebSocketExecutor`,
+  // there is a deadlock issue in `registerAdditionalModuleClasses:` and causes app hanging.
+  //   - The JS thread acquired the `RCTCxxBridge._moduleRegistryLock` lock in `RCTCxxBridge._initializeBridgeLocked`
+  //      = it further goes into RCTObjcExecutor and tries to get module config from main thread
+  //   - The main thread is pending in `RCTCxxBridge.registerAdditionalModuleClasses` where trying to acquire the same lock.
+  // To workaround the deadlock, we tend to use the non-locked registration and mutate the bridge internal module data.
+  // Since JS thread in this situation is waiting for main thread, it's safe to mutate module data without lock.
+  // The only risk should be the internal `_moduleRegistryCreated` flag without lock protection.
+  // As we just workaround in `RCTWebSocketExecutor` case, the risk of `_moduleRegistryCreated` race condition should be lower.
+  //
+  // Learn more about the non-locked initialization:
+  // https://github.com/facebook/react-native/blob/757bb75fbf837714725d7b2af62149e8e2a7ee51/React/CxxBridge/RCTCxxBridge.mm#L922-L935
+  // See the `_moduleRegistryCreated` false case
+  if ([NSStringFromClass([bridge executorClass]) isEqualToString:@"RCTWebSocketExecutor"]) {
+    NSNumber *moduleRegistryCreated = [bridge valueForKey:@"_moduleRegistryCreated"];
+    if (![moduleRegistryCreated boolValue]) {
+      [bridge registerModulesForClasses:moduleClasses];
+      return;
+    }
+  }
+
+  [bridge registerAdditionalModuleClasses:moduleClasses];
 }
 
 - (void)registerComponentDataForModuleClasses:(NSArray<Class> *)moduleClasses inBridge:(RCTBridge *)bridge

--- a/packages/expo-modules-core/ios/NativeModulesProxy/EXNativeModulesProxy.mm
+++ b/packages/expo-modules-core/ios/NativeModulesProxy/EXNativeModulesProxy.mm
@@ -290,7 +290,7 @@ RCT_EXPORT_METHOD(callMethod:(NSString *)moduleName methodNameOrKey:(id)methodNa
 - (void)registerAdditionalModuleClasses:(NSArray<Class> *)moduleClasses inBridge:(RCTBridge *)bridge
 {
   // In remote debugging mode, i.e. executorClass is `RCTWebSocketExecutor`,
-  // there is a deadlock issue in `registerAdditionalModuleClasses:` and causes app hanging.
+  // there is a deadlock issue in `registerAdditionalModuleClasses:` and causes app freezed.
   //   - The JS thread acquired the `RCTCxxBridge._moduleRegistryLock` lock in `RCTCxxBridge._initializeBridgeLocked`
   //      = it further goes into RCTObjcExecutor and tries to get module config from main thread
   //   - The main thread is pending in `RCTCxxBridge.registerAdditionalModuleClasses` where trying to acquire the same lock.


### PR DESCRIPTION
# Why

there is a deadlock for `RCTCxxBridge.registerAdditionalModuleClasses` in remote debugging flow

>     - The JS thread acquired the `RCTCxxBridge._moduleRegistryLock` lock in `RCTCxxBridge._initializeBridgeLocked`
>        = it further goes into RCTObjcExecutor and tries to get module config from main thread
>     - The main thread is pending in `RCTCxxBridge.registerAdditionalModuleClasses` where trying to acquire the same lock.

js thread
![Screen Shot 2021-10-27 at 10 16 43 PM](https://user-images.githubusercontent.com/46429/139088423-e34f3553-6d7e-4a2e-b0f1-a7cabe1f5091.png)

main thread
![Screen Shot 2021-10-27 at 10 15 48 PM](https://user-images.githubusercontent.com/46429/139088460-94305612-b307-4ebf-bc26-5b43d5d6a33d.png)

Fixes #14875

# How

Workaround to use a non-locked initialization specific in remote debugging mode.

# Test Plan

1. `expo init sdk43`
2. patch `node_modules/expo-modules-core/ios/NativeModulesProxy/EXNativeModulesProxy.m`
3. enable remote debugging and see if the app can load.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
