### PR TITLE
[sweet-api][kotlin] Add benchmark

### DIFF
--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -65,6 +65,18 @@ android {
   kotlinOptions {
     jvmTarget = JavaVersion.VERSION_1_8
   }
+
+  testOptions {
+    unitTests.all {
+      testLogging {
+        outputs.upToDateWhen { false }
+        events "passed", "failed", "skipped", "standardError"
+        showCauses true
+        showExceptions true
+        showStandardStreams true
+      }
+    }
+  }
 }
 
 dependencies {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/NativeModulesProxy.java
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/NativeModulesProxy.java
@@ -16,6 +16,7 @@ import expo.modules.core.ViewManager;
 import expo.modules.core.interfaces.ExpoMethod;
 import expo.modules.kotlin.ExpoModulesHelper;
 import expo.modules.kotlin.KotlinInteropModuleRegistry;
+import expo.modules.kotlin.ModulesProvider;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -58,6 +59,18 @@ public class NativeModulesProxy extends ReactContextBaseJavaModule {
 
     mKotlinInteropModuleRegistry = new KotlinInteropModuleRegistry(
       Objects.requireNonNull(ExpoModulesHelper.Companion.getModulesProvider()),
+      moduleRegistry
+    );
+  }
+
+  public NativeModulesProxy(ReactApplicationContext context, ModuleRegistry moduleRegistry, ModulesProvider modulesProvider) {
+    super(context);
+    mModuleRegistry = moduleRegistry;
+    mExportedMethodsKeys = new HashMap<>();
+    mExportedMethodsReverseKeys = new HashMap<>();
+
+    mKotlinInteropModuleRegistry = new KotlinInteropModuleRegistry(
+      Objects.requireNonNull(modulesProvider),
       moduleRegistry
     );
   }

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/benchmarks/BenchmarkRule.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/benchmarks/BenchmarkRule.kt
@@ -1,0 +1,25 @@
+@file:OptIn(ExperimentalTime::class)
+
+package expo.modules.benchmarks
+
+import java.util.concurrent.TimeUnit
+import kotlin.system.measureNanoTime
+import kotlin.time.ExperimentalTime
+import kotlin.time.toDuration
+
+class BenchmarkRule(private val iteration: Int = 10) {
+  fun run(name: String, block: () -> Unit) {
+    var avg = 0.0
+    repeat(iteration) {
+      avg += measureNanoTime(block)
+    }
+    avg /= iteration
+
+    printTime(name, avg)
+  }
+
+  private fun printTime(name: String, time: Double) {
+    val duration = time.toDuration(TimeUnit.NANOSECONDS)
+    println("`$name` on average took $duration")
+  }
+}

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/benchmarks/EmptyRNPromise.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/benchmarks/EmptyRNPromise.kt
@@ -1,0 +1,27 @@
+package expo.modules.benchmarks
+
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.WritableMap
+
+class EmptyRNPromise : Promise {
+  override fun resolve(value: Any?) = Unit
+
+  override fun reject(code: String?, message: String?) = Unit
+
+  override fun reject(code: String?, throwable: Throwable?) = Unit
+
+  override fun reject(code: String?, message: String?, throwable: Throwable?) = Unit
+
+  override fun reject(throwable: Throwable?) = Unit
+  override fun reject(throwable: Throwable?, userInfo: WritableMap?) = Unit
+
+  override fun reject(code: String?, userInfo: WritableMap) = Unit
+
+  override fun reject(code: String?, throwable: Throwable?, userInfo: WritableMap?) = Unit
+
+  override fun reject(code: String?, message: String?, userInfo: WritableMap) = Unit
+
+  override fun reject(code: String?, message: String?, throwable: Throwable?, userInfo: WritableMap?) = Unit
+
+  override fun reject(message: String?) = Unit
+}

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/benchmarks/LegacyArchitectureBenchmark.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/benchmarks/LegacyArchitectureBenchmark.kt
@@ -1,0 +1,95 @@
+package expo.modules.benchmarks
+
+import com.facebook.react.bridge.Dynamic
+import com.facebook.react.bridge.DynamicFromObject
+import com.facebook.react.bridge.JavaOnlyArray
+import com.facebook.react.bridge.ReadableArray
+import expo.modules.adapters.react.NativeModulesProxy
+import expo.modules.core.ExportedModule
+import expo.modules.core.Promise
+import expo.modules.core.interfaces.ExpoMethod
+import expo.modules.kotlin.ModulesProvider
+import expo.modules.kotlin.modules.Module
+import org.junit.Before
+import org.junit.Ignore
+import org.junit.Test
+
+class LegacyArchitectureBenchmark {
+  private val benchmarkRule = BenchmarkRule(iteration = 1000000)
+  private lateinit var proxy: NativeModulesProxy
+
+  class MyModule : ExportedModule(null) {
+    private fun retNull(): Any? {
+      return null
+    }
+
+    override fun getName(): String = "MyModule"
+
+    @ExpoMethod
+    fun m1(promise: Promise) {
+      promise.resolve(retNull())
+    }
+
+    @ExpoMethod
+    fun m2(a: Int, b: Int, promise: Promise) {
+      promise.resolve(retNull())
+    }
+
+    @ExpoMethod
+    fun m3(a: IntArray, promise: Promise) {
+      promise.resolve(retNull())
+    }
+
+    @ExpoMethod
+    fun m4(s: String, promise: Promise) {
+      promise.resolve(retNull())
+    }
+  }
+
+  @Before
+  fun before() {
+    val legacyModuleRegister = expo.modules.core.ModuleRegistry(
+      emptyList(),
+      listOf(MyModule()),
+      emptyList(),
+      emptyList()
+    )
+
+    proxy = NativeModulesProxy(null, legacyModuleRegister, object : ModulesProvider {
+      override fun getModulesList(): List<Class<out Module>> = emptyList()
+    })
+  }
+
+  @Ignore("It's a benchmark")
+  @Test
+  fun `call function with simple arguments`() {
+    val testCases = listOf<Pair<Dynamic, ReadableArray>>(
+      DynamicFromObject("m1") to JavaOnlyArray(),
+      DynamicFromObject("m2") to JavaOnlyArray().apply {
+        pushInt(1)
+        pushInt(2)
+      },
+      DynamicFromObject("m3") to JavaOnlyArray().apply {
+        pushArray(
+          JavaOnlyArray().apply {
+            pushInt(1)
+            pushInt(2)
+            pushInt(3)
+          }
+        )
+      },
+      DynamicFromObject("m4") to JavaOnlyArray().apply {
+        pushString("expo is awesome")
+      }
+    )
+    val emptyPromise = EmptyRNPromise()
+
+    repeat(3) {
+      benchmarkRule.run(::`call function with simple arguments`.name) {
+        testCases.forEach { (method, args) ->
+          proxy.callMethod("MyModule", method, args, emptyPromise)
+        }
+      }
+    }
+  }
+}

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/benchmarks/NewArchitectureBenchmark.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/benchmarks/NewArchitectureBenchmark.kt
@@ -1,0 +1,81 @@
+package expo.modules.benchmarks
+
+import com.facebook.react.bridge.Dynamic
+import com.facebook.react.bridge.DynamicFromObject
+import com.facebook.react.bridge.JavaOnlyArray
+import com.facebook.react.bridge.ReadableArray
+import expo.modules.adapters.react.NativeModulesProxy
+import expo.modules.kotlin.ModulesProvider
+import expo.modules.kotlin.modules.Module
+import expo.modules.kotlin.modules.module
+import org.junit.Before
+import org.junit.Ignore
+import org.junit.Test
+
+class NewArchitectureBenchmark {
+  private val benchmarkRule = BenchmarkRule(iteration = 1000000)
+  private lateinit var proxy: NativeModulesProxy
+
+  class MyModule : Module() {
+    private fun retNull(): Any? {
+      return null
+    }
+
+    override fun definition() = module {
+      name("MyModule")
+      method("m1") { -> retNull() }
+      method("m2") { _: Int, _: Int -> retNull() }
+      method("m3") { _: IntArray -> retNull() }
+      method("m4") { _: String -> retNull() }
+    }
+  }
+
+  @Before
+  fun before() {
+    val legacyModuleRegister = expo.modules.core.ModuleRegistry(
+      emptyList(),
+      emptyList(),
+      emptyList(),
+      emptyList()
+    )
+
+    proxy = NativeModulesProxy(null, legacyModuleRegister, object : ModulesProvider {
+      override fun getModulesList(): List<Class<out Module>> =
+        listOf(MyModule::class.java)
+    })
+  }
+
+  @Ignore("It's a benchmark")
+  @Test
+  fun `call function with simple arguments`() {
+    val testCases = listOf<Pair<Dynamic, ReadableArray>>(
+      DynamicFromObject("m1") to JavaOnlyArray(),
+      DynamicFromObject("m2") to JavaOnlyArray().apply {
+        pushInt(1)
+        pushInt(2)
+      },
+      DynamicFromObject("m3") to JavaOnlyArray().apply {
+        pushArray(
+          JavaOnlyArray().apply {
+            pushInt(1)
+            pushInt(2)
+            pushInt(3)
+          }
+        )
+      },
+      DynamicFromObject("m4") to JavaOnlyArray().apply {
+        pushString("expo is awesome")
+      }
+    )
+    val emptyPromise = EmptyRNPromise()
+    repeat(3) {
+      benchmarkRule.run(::`call function with simple arguments`.name) {
+        testCases.forEach { (method, args) ->
+          proxy.callMethod("MyModule", method, args, emptyPromise)
+        }
+      }
+    }
+  }
+}
+
+


### PR DESCRIPTION
# Why

Adds simple benchmark to test new architecture in comparison to legacy one.

> Note:
This PR requires https://github.com/expo/expo/pull/14924 to work. 

# Test Plan

The new architecture is slightly faster than the legacy one. 