### PR TITLE
[template] Update onConfigurationChanged for Android

### DIFF
--- a/templates/expo-template-bare-minimum/android/app/src/main/java/com/helloworld/MainActivity.java
+++ b/templates/expo-template-bare-minimum/android/app/src/main/java/com/helloworld/MainActivity.java
@@ -1,5 +1,6 @@
 package com.helloworld;
 
+import android.content.res.Configuration;
 import android.os.Bundle;
 
 import com.facebook.react.ReactActivity;
@@ -10,6 +11,7 @@ import com.swmansion.gesturehandler.react.RNGestureHandlerEnabledRootView;
 import expo.modules.ReactActivityDelegateWrapper;
 
 public class MainActivity extends ReactActivity {
+
   @Override
   protected void onCreate(Bundle savedInstanceState) {
     // Set the theme to AppTheme BEFORE onCreate to support 
@@ -17,6 +19,12 @@ public class MainActivity extends ReactActivity {
     // This is required for expo-splash-screen.
     setTheme(R.style.AppTheme);
     super.onCreate(null);
+  }
+
+  @Override
+  public void onConfigurationChanged(Configuration newConfig) {
+    super.onConfigurationChanged(newConfig);
+    getReactInstanceManager().onConfigurationChanged(this, newConfig);
   }
 
   /**


### PR DESCRIPTION
# Why

Move this out of the dangerous unversioned config plugin which appears to always run. Also it appears that the Appearance API doesn't update when using the [older syntax](https://github.com/expo/expo-cli/blob/fd7219a31dc46f424fd24195d03ff9682158e19b/packages/config-plugins/src/android/UserInterfaceStyle.ts#L17-L20).

This function won't be needed when Expo supports this PR https://github.com/facebook/react-native/pull/29106

# Test Plan

In a new project, expo run:ios, then toggle the emulator appearance:
```
𝝠 adb shell "cmd uimode night no" 
𝝠 adb shell "cmd uimode night yes"
```

With the old syntax, this didn't update the Appearance module, with the new syntax it does.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
