### PR TITLE
Added user interface locking to android splash screen module

### DIFF
--- a/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/SplashScreenModule.kt
+++ b/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/SplashScreenModule.kt
@@ -8,6 +8,7 @@ import expo.modules.core.Promise
 import expo.modules.core.errors.CurrentActivityNotFoundException
 import expo.modules.core.interfaces.ActivityProvider
 import expo.modules.core.interfaces.ExpoMethod
+import expo.modules.splashscreen.helpers.ReflectionExtensions
 
 // Below import must be kept unversioned even in versioned code to provide a redirection from
 // versioned code realm to unversioned code realm.
@@ -23,12 +24,64 @@ class SplashScreenModule(context: Context) : ExportedModule(context) {
 
   private lateinit var activityProvider: ActivityProvider
 
+  // TODO: Is this the safest approach?
+  private val appearance by lazy {
+    (context as ReactContext)
+            .getNativeModule(AppearanceModule::class.java)!!
+  }
+
   override fun getName(): String {
     return NAME
   }
 
   override fun onCreate(moduleRegistry: ModuleRegistry) {
     activityProvider = moduleRegistry.getModule(ActivityProvider::class.java)
+
+    updateUserInterfaceStyle();
+  }
+
+  /**
+   * Overwrite the Appearance API to lock it based on the 
+   * static `expo_splash_screen_user_interface_style` value.
+   */
+  private fun updateUserInterfaceStyle() {
+    val activity = activityProvider.currentActivity
+    var style = context.getString(R.string.expo_splash_screen_user_interface_style).toLowerCase()
+
+    // Default to "light" unless set otherwise.
+    if (style == "") style = "light"
+
+    // Update the UI mode in case it changed between reloads.
+    SplashScreen.setUserInterfaceStyle(activity, style);
+
+    if ((style == "dark" || style == "light")) {
+      // TODO: How do we ensure this doesn't break Expo Go, or Dev Client manifest overrides.
+      appearance.let { appearanceModule ->
+        try {
+          appearanceModule::class.java.setProtectedDeclaredField(
+                  obj = appearanceModule,
+                  filedName = "mOverrideColorScheme",
+                  newValue = object : AppearanceModule.OverrideColorScheme {
+                    override fun getScheme(): String {
+                      return style
+                    }
+                  },
+                  predicate = { currentValue -> currentValue == null }
+          )
+
+          appearanceModule::class.java.setProtectedDeclaredField(
+                  obj = appearanceModule,
+                  filedName = "mColorScheme",
+                  newValue = style
+          )
+        } catch (e: Exception) {
+          Log.e("SplashScreen", e)
+        }
+      }
+
+      // Update Appearance listeners
+      appearance.emitAppearanceChanged(style);
+    }
   }
 
   @ExpoMethod

--- a/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/SplashScreenReactActivityLifecycleListener.kt
+++ b/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/SplashScreenReactActivityLifecycleListener.kt
@@ -29,7 +29,7 @@ class SplashScreenReactActivityLifecycleListener(activityContext: Context) : Rea
       )
     }
 
-    SplashScreen.setUserInterfaceStyle(activity, getUserInterfaceStyle(activity));
+    SplashScreen.setUserInterfaceStyle(getUserInterfaceStyle(activity));
   }
 
   private fun getResizeMode(context: Context): SplashScreenImageResizeMode =

--- a/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/SplashScreenReactActivityLifecycleListener.kt
+++ b/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/SplashScreenReactActivityLifecycleListener.kt
@@ -28,6 +28,8 @@ class SplashScreenReactActivityLifecycleListener(activityContext: Context) : Rea
         getStatusBarTranslucent(activity)
       )
     }
+
+    SplashScreen.setUserInterfaceStyle(activity, getUserInterfaceStyle(activity));
   }
 
   private fun getResizeMode(context: Context): SplashScreenImageResizeMode =
@@ -38,4 +40,7 @@ class SplashScreenReactActivityLifecycleListener(activityContext: Context) : Rea
 
   private fun getStatusBarTranslucent(context: Context): Boolean =
     context.getString(R.string.expo_splash_screen_status_bar_translucent).toBoolean()
+
+  private fun getUserInterfaceStyle(context: Context): String =
+    context.getString(R.string.expo_splash_screen_user_interface_style).toLowerCase()
 }

--- a/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/helpers/ReflectionExtensions.kt
+++ b/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/helpers/ReflectionExtensions.kt
@@ -1,4 +1,4 @@
-package expo.modules.splashscreen
+package expo.modules.splashscreen.helpers
 
 import java.lang.reflect.Field
 import java.lang.reflect.Modifier

--- a/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/helpers/ReflectionExtensions.kt
+++ b/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/helpers/ReflectionExtensions.kt
@@ -1,0 +1,24 @@
+package expo.modules.splashscreen
+
+import java.lang.reflect.Field
+import java.lang.reflect.Modifier
+
+// From `expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/helpers/DevLauncherReflectionExtensions.kt`
+fun <T> Class<out T>.setProtectedDeclaredField(obj: T, filedName: String, newValue: Any, predicate: (Any?) -> Boolean = { true }) {
+  val field = getDeclaredField(filedName)
+  val modifiersField = Field::class.java.getDeclaredField("accessFlags")
+
+  field.isAccessible = true
+  modifiersField.isAccessible = true
+
+  modifiersField.setInt(
+          field,
+          field.modifiers and Modifier.FINAL.inv()
+  )
+
+  if (!predicate.invoke(field.get(obj))) {
+    return
+  }
+
+  field.set(obj, newValue)
+}

--- a/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/singletons/SplashScreen.kt
+++ b/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/singletons/SplashScreen.kt
@@ -1,8 +1,10 @@
 package expo.modules.splashscreen.singletons
 
 import android.app.Activity
+import android.os.Build
 import android.util.Log
 import android.view.ViewGroup
+import androidx.appcompat.app.AppCompatDelegate
 import expo.modules.splashscreen.*
 import expo.modules.core.interfaces.SingletonModule
 import java.util.*
@@ -149,5 +151,29 @@ object SplashScreen : SingletonModule {
   @JvmStatic
   fun hide(activity: Activity) {
     hide(activity, {}, {})
+  }
+
+
+  fun setUserInterfaceStyle(
+                            style: String,
+                            successCallback: () -> Unit,
+                            failureCallback: (reason: String) -> Unit) {
+    var mode = when (style) {
+      // Empty string (undefined) defaults to 'light'.
+      "", "light" -> AppCompatDelegate.MODE_NIGHT_NO
+      "dark" -> AppCompatDelegate.MODE_NIGHT_YES
+      "automatic" -> if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) AppCompatDelegate.MODE_NIGHT_AUTO_BATTERY else AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
+      else -> {
+        return failureCallback("Invalid user interface style: '$style'. Expected one of: 'light', 'dark', 'automatic'")
+      }
+    }
+
+    AppCompatDelegate.setDefaultNightMode(mode)
+    successCallback()
+  }
+
+  @JvmStatic
+  fun setUserInterfaceStyle(style: String) {
+    setUserInterfaceStyle(style, {}, { m -> Log.e(TAG, m) })
   }
 }

--- a/packages/expo-splash-screen/android/src/main/res/values/strings.xml
+++ b/packages/expo-splash-screen/android/src/main/res/values/strings.xml
@@ -2,4 +2,5 @@
 <resources>
   <string name="expo_splash_screen_resize_mode" translatable="false">contain</string>
   <string name="expo_splash_screen_status_bar_translucent" translatable="false">false</string>
+  <string name="expo_splash_screen_user_interface_style" translatable="false">light</string>
 </resources>


### PR DESCRIPTION
# Why

We need the ability to lock the user interface (appearance) based on the Expo config. The appearance API currently lives in the `react-native` package and doesn't support the MainApplication proxy or reading from static `strings.xml` values, so in order to set the initial / locked states we must override it (similar to [expo-dev-launcher](https://github.com/expo/expo/blob/d00eec9ec2ad7ab8be8e5d71afee0333bc0617d8/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/loaders/DevLauncherExpoAppLoader.kt#L48-L70)).

This functionality could be in one of four possible locations:

1. A standalone module: Potentially something like `expo-system-ui` but we've decided to merge most of the functionality in `expo-navigation-bar` which would mean this package would be pretty focused on UI locking. Given that Appearance API is in `react-native`, we probably don't want to introduce a duplicative module which functions a bit differently.
2. The default template: This was our initial thinking before realizing how complex the feature needed to be, we want to keep the template as simple as possible for migration purposes.
3. `expo-modules-core`: We’d have to introduce a config plugin, add a dependency `@expo/config-plugins`, and add `expo-modules-core` as an auto plugin in `expo-cli` which is a lot to do for a misplaced feature.
4. `expo-splash-screen`: Not great, but we currently implement the iOS version of interface locking via `expo-splash-screen` so it's not totally out of place. We also basically require this package in every project at the moment which would serve as a close compromise to what we'd get by including in `expo-modules-core`.



<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Implement `expo_splash_screen_user_interface_style` strings.xml value which can be used to lock the interface and update on reloads.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

- [ ] TBD

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
