### PR TITLE
[sweet-api][kotlin] Add accessors for legacy modules

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
@@ -1,8 +1,83 @@
 package expo.modules.kotlin
 
+import expo.modules.interfaces.barcodescanner.BarCodeScannerInterface
+import expo.modules.interfaces.camera.CameraViewInterface
+import expo.modules.interfaces.constants.ConstantsInterface
+import expo.modules.interfaces.filesystem.FilePermissionModuleInterface
+import expo.modules.interfaces.font.FontManagerInterface
+import expo.modules.interfaces.imageloader.ImageLoaderInterface
+import expo.modules.interfaces.permissions.Permissions
+import expo.modules.interfaces.sensors.SensorServiceInterface
+import expo.modules.interfaces.taskManager.TaskManagerInterface
+
 class AppContext(
   modulesProvider: ModulesProvider,
   val legacyModuleRegistry: expo.modules.core.ModuleRegistry
 ) {
   val registry = ModuleRegistry().register(modulesProvider)
+
+  /**
+   * Returns a legacy module implementing given interface.
+   */
+  inline fun <reified Module> legacyModule(): Module? {
+    return try {
+      legacyModuleRegistry.getModule(Module::class.java)
+    } catch (_: Exception) {
+      null
+    }
+  }
+
+  /**
+   * Provides access to app's constants from the legacy module registry.
+   */
+  val constants: ConstantsInterface?
+    get() = legacyModule()
+
+  /**
+   * Provides access to the file system manager from the legacy module registry.
+   */
+  val filePermission: FilePermissionModuleInterface?
+    get() = legacyModule()
+
+  /**
+   * Provides access to the permissions manager from the legacy module registry
+   */
+  val permissions: Permissions?
+    get() = legacyModule()
+
+  /**
+   * Provides access to the image loader from the legacy module registry
+   */
+  val imageLoader: ImageLoaderInterface?
+    get() = legacyModule()
+
+  /**
+   * Provides access to the bar code scanner manager from the legacy module registry
+   */
+  val barcodeScanner: BarCodeScannerInterface?
+    get() = legacyModule()
+
+  /**
+   * Provides access to the camera view manager from the legacy module registry
+   */
+  val camera: CameraViewInterface?
+    get() = legacyModule()
+
+  /**
+   * Provides access to the font manager from the legacy module registry
+   */
+  val font: FontManagerInterface?
+    get() = legacyModule()
+
+  /**
+   * Provides access to the sensor manager from the legacy module registry
+   */
+  val sensor: SensorServiceInterface?
+    get() = legacyModule()
+
+  /**
+   * Provides access to the task manager from the legacy module registry
+   */
+  val taskManager: TaskManagerInterface?
+    get() = legacyModule()
 }


### PR DESCRIPTION
# Why

Adds accessors for legacy modules. 

# How

Added a simple generic method to access any modules from the legacy module registry. 
I also added simple getters for other commonly used modules like `Permissions`, `TaskManager`.

# Test Plan

Trying to get the legacy module from the new architecture. 