### PR TITLE
[updates] Fix Android app.manifest not generated in onesignal integration

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### 🐛 Bug fixes
 
 - Fix auto setup `EXUpdatesAppDelegate` breaking reanimated installation. ([#14755](https://github.com/expo/expo/pull/14755) by [@kudo](https://github.com/kudo))
+- Fix Android app.manifest not generated when in OneSignal gradle plugin integration. ([#14938](https://github.com/expo/expo/pull/14938) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-updates/scripts/create-manifest-android.gradle
+++ b/packages/expo-updates/scripts/create-manifest-android.gradle
@@ -5,11 +5,11 @@ import org.gradle.util.GradleVersion
 
 def expoUpdatesDir = ["node", "-e", "console.log(require('path').dirname(require.resolve('expo-updates/package.json')));"].execute([], projectDir).text.trim()
 
-afterEvaluate {
   // From a library project role to reference app project settings such as `targetName.toLowerCase().contains("release")`,
   // we extract the `appProject` from all projects here.
   // things like `config`, `buildDir`, and `applicationVariants`, we will reference from appProject.
-  def appProject = rootProject.allprojects.find { it.plugins.hasPlugin('com.android.application') }
+def appProject = rootProject.allprojects.find { it.plugins.hasPlugin('com.android.application') }
+appProject.afterEvaluate {
   def config = appProject.hasProperty("react") ? appProject.react : [];
   def nodeExecutableAndArgs = config.nodeExecutableAndArgs ?: ["node"]
   def entryFile = config.entryFile ?: "index.js"


### PR DESCRIPTION
# Why

onesignal gradle plugin takes longer time to mutate project, expo-updates gradle plugin does not wait enough to add tasks.

# How

instead wait for `libraryProject.afterEvaluate`, we should further use the `appProject.afterEvaluate`

# Test Plan

1. git clone https://github.com/brentvatne/updatesmanifest.git
2. patch `node_modules/expo-updates/scripts/create-manifest-android.gradle`
3. `cd android && ./gradlew clean :app:assembleRelease`
4. make sure app.manifest is generated by `unzip -l app/build/outputs/apk/release/app-release.apk | grep app.manifest`

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
