### PR TITLE
[sweet][ios] Partially revert static module definition

### DIFF
--- a/packages/expo-cellular/ios/EXCellular/CellularModule.swift
+++ b/packages/expo-cellular/ios/EXCellular/CellularModule.swift
@@ -2,35 +2,35 @@ import CoreTelephony
 import ExpoModulesCore
 
 public class CellularModule: Module {
-  public static func definition() -> ModuleDefinition {
+  public func definition() -> ModuleDefinition {
     name("ExpoCellular")
 
     constants {
-      getCurrentCellularInfo()
+      Self.getCurrentCellularInfo()
     }
 
     method("getCellularGenerationAsync") { () -> Int in
-      currentCellularGeneration().rawValue
+      Self.currentCellularGeneration().rawValue
     }
 
     method("allowsVoipAsync") { () -> Bool? in
-      currentCarrier()?.allowsVOIP
+      Self.currentCarrier()?.allowsVOIP
     }
 
     method("getIsoCountryCodeAsync") { () -> String? in
-      currentCarrier()?.isoCountryCode
+      Self.currentCarrier()?.isoCountryCode
     }
 
     method("getCarrierNameAsync") { () -> String? in
-      currentCarrier()?.carrierName
+      Self.currentCarrier()?.carrierName
     }
 
     method("getMobileCountryCodeAsync") { () -> String? in
-      currentCarrier()?.mobileCountryCode
+      Self.currentCarrier()?.mobileCountryCode
     }
 
     method("getMobileNetworkCodeAsync") { () -> String? in
-      currentCarrier()?.mobileNetworkCode
+      Self.currentCarrier()?.mobileNetworkCode
     }
   }
 

--- a/packages/expo-haptics/ios/EXHaptics/HapticsModule.swift
+++ b/packages/expo-haptics/ios/EXHaptics/HapticsModule.swift
@@ -1,10 +1,10 @@
 import ExpoModulesCore
 
 public class HapticsModule: Module {
-  public static func definition() -> ModuleDefinition {
+  public func definition() -> ModuleDefinition {
     name("ExpoHaptics")
 
-    method("notificationAsync") { (_, notificationType: String, promise: Promise) in
+    method("notificationAsync") { (notificationType: String, promise: Promise) in
       guard let feedbackType = NotificationType(rawValue: notificationType)?.toFeedbackType() else {
         promise.reject("E_HAPTICS_INVALID_ARG", "Notification type must be one of: 'success', 'warning', 'error'. Obtained '\(notificationType)'")
         return
@@ -15,7 +15,7 @@ public class HapticsModule: Module {
       promise.resolve()
     }
 
-    method("impactAsync") { (_, style: String, promise: Promise) in
+    method("impactAsync") { (style: String, promise: Promise) in
       guard let feedbackStyle = ImpactStyle(rawValue: style)?.toFeedbackStyle() else {
         promise.reject("E_HAPTICS_INVALID_ARG", "Impact style must be one of: 'light', 'medium', 'heavy'. Obtained '\(style)'")
         return

--- a/packages/expo-linear-gradient/ios/EXLinearGradient/LinearGradientModule.swift
+++ b/packages/expo-linear-gradient/ios/EXLinearGradient/LinearGradientModule.swift
@@ -1,7 +1,7 @@
 import ExpoModulesCore
 
 public class LinearGradientModule: Module {
-  public static func definition() -> ModuleDefinition {
+  public func definition() -> ModuleDefinition {
     name("ExpoLinearGradient")
 
     viewManager {

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -4,8 +4,6 @@
 
 ### 🛠 Breaking changes
 
-- Swift's module definition is now a static function which also makes modules lazy by default. ([#14645](https://github.com/expo/expo/pull/14645) by [@tsapeta](https://github.com/tsapeta))
-
 ### 🎉 New features
 
 - Method calls on iOS now can go through the JSI instead of the bridge (opt-in feature). ([#14626](https://github.com/expo/expo/pull/14626) by [@tsapeta](https://github.com/tsapeta))

--- a/packages/expo-modules-core/ios/Swift/Methods/AnyMethod.swift
+++ b/packages/expo-modules-core/ios/Swift/Methods/AnyMethod.swift
@@ -27,13 +27,13 @@ public protocol AnyMethod: AnyDefinition {
   /**
    Calls the method on given module with arguments and a promise.
    */
-  func call(module: AnyModule, args: [Any?], promise: Promise) -> Void
+  func call(args: [Any?], promise: Promise) -> Void
 
   /**
    Synchronously calls the method with given arguments. If the method takes a promise,
    the current thread will be locked until the promise rejects or resolves with the return value.
    */
-  func callSync(module: AnyModule, args: [Any?]) -> Any?
+  func callSync(args: [Any?]) -> Any?
 
   /**
    Specifies on which queue the method should run.

--- a/packages/expo-modules-core/ios/Swift/Methods/ConcreteMethod.swift
+++ b/packages/expo-modules-core/ios/Swift/Methods/ConcreteMethod.swift
@@ -19,24 +19,17 @@ public class ConcreteMethod<Args, ReturnType>: AnyMethod {
 
   let argTypes: [AnyArgumentType]
 
-  /**
-   Determines whether the method should be called with the module instance.
-   */
-  let detached: Bool
-
   init(
     _ name: String,
     argTypes: [AnyArgumentType],
-    _ closure: @escaping ClosureType,
-    detached: Bool = false
+    _ closure: @escaping ClosureType
   ) {
     self.name = name
     self.argTypes = argTypes
     self.closure = closure
-    self.detached = detached
   }
 
-  public func call(module: AnyModule, args: [Any?], promise: Promise) {
+  public func call(args: [Any?], promise: Promise) {
     let takesPromise = self.takesPromise
     let returnedValue: ReturnType?
 
@@ -45,10 +38,6 @@ public class ConcreteMethod<Args, ReturnType>: AnyMethod {
 
       if takesPromise {
         finalArgs.append(promise)
-      }
-
-      if !self.detached {
-        finalArgs.insert(module, at: 0)
       }
 
       let tuple = try Conversions.toTuple(finalArgs) as! Args
@@ -65,7 +54,7 @@ public class ConcreteMethod<Args, ReturnType>: AnyMethod {
     }
   }
 
-  public func callSync(module: AnyModule, args: [Any?]) -> Any? {
+  public func callSync(args: [Any?]) -> Any? {
     if takesPromise {
       var result: Any?
       let semaphore = DispatchSemaphore(value: 0)
@@ -76,7 +65,7 @@ public class ConcreteMethod<Args, ReturnType>: AnyMethod {
       } rejecter: { error in
         semaphore.signal()
       }
-      call(module: module, args: args, promise: promise)
+      call(args: args, promise: promise)
       semaphore.wait()
       return result
     } else {

--- a/packages/expo-modules-core/ios/Swift/ModuleRegistry.swift
+++ b/packages/expo-modules-core/ios/Swift/ModuleRegistry.swift
@@ -11,20 +11,22 @@ public class ModuleRegistry: Sequence {
   }
 
   /**
-   Registers a module by its definition.
+   Registers an instance of module holder.
    */
-  public func register(definition: ModuleDefinition) {
-    guard let appContext = appContext else {
-      return
-    }
-    registry[definition.name] = ModuleHolder(appContext: appContext, definition: definition)
+  internal func register(holder: ModuleHolder) {
+    registry[holder.name] = holder
   }
 
   /**
    Registers a module by its type.
    */
   public func register(moduleType: AnyModule.Type) {
-    register(definition: moduleType.definition().withType(moduleType))
+    guard let appContext = appContext else {
+      return
+    }
+    let module = moduleType.init(appContext: appContext)
+    let holder = ModuleHolder(appContext: appContext, module: module)
+    register(holder: holder)
   }
 
   /**
@@ -58,7 +60,7 @@ public class ModuleRegistry: Sequence {
   }
 
   public func get(moduleWithName moduleName: String) -> AnyModule? {
-    return try? registry[moduleName]?.getInstance()
+    return registry[moduleName]?.module
   }
 
   public func makeIterator() -> IndexingIterator<[ModuleHolder]> {

--- a/packages/expo-modules-core/ios/Swift/Modules/AnyModule.swift
+++ b/packages/expo-modules-core/ios/Swift/Modules/AnyModule.swift
@@ -16,7 +16,7 @@ public protocol AnyModule: AnyObject, AnyMethodArgument {
    # Example
 
    ```
-   public static func definition() -> ModuleDefinition {
+   public func definition() -> ModuleDefinition {
      name("MyModule")
      method("myMethod") { (a: String, b: String) in
        "\(a) \(b)"
@@ -47,8 +47,8 @@ public protocol AnyModule: AnyObject, AnyMethodArgument {
    */
   #if swift(>=5.4)
   @ModuleDefinitionBuilder
-  static func definition() -> ModuleDefinition
+  func definition() -> ModuleDefinition
   #else
-  static func definition() -> ModuleDefinition
+  func definition() -> ModuleDefinition
   #endif
 }

--- a/packages/expo-modules-core/ios/Swift/Modules/ModuleDefinitionComponents.swift
+++ b/packages/expo-modules-core/ios/Swift/Modules/ModuleDefinitionComponents.swift
@@ -12,7 +12,7 @@ extension AnyModule {
   /**
    Sets the name of the module that is exported to the JavaScript world.
    */
-  public static func name(_ name: String) -> AnyDefinition {
+  public func name(_ name: String) -> AnyDefinition {
     return ModuleNameDefinition(name: name)
   }
 
@@ -21,33 +21,18 @@ extension AnyModule {
   /**
    Definition function setting the module's constants to export.
    */
-  public static func constants(_ closure: () -> [String : Any?]) -> AnyDefinition {
+  public func constants(_ closure: () -> [String : Any?]) -> AnyDefinition {
     return ConstantsDefinition(constants: closure())
   }
 
   // MARK: - Methods
 
   /**
-   Factory function for methods without the module instance and arguments.
-   */
-  public static func method<R>(
-    _ name: String,
-    _ closure: @escaping () -> R
-  ) -> AnyMethod {
-    return ConcreteMethod(
-      name,
-      argTypes: [],
-      closure,
-      detached: true
-    )
-  }
-
-  /**
    Factory function for methods without arguments.
    */
-  public static func method<R>(
+  public func method<R>(
     _ name: String,
-    _ closure: @escaping (Self) -> R
+    _ closure: @escaping () -> R
   ) -> AnyMethod {
     return ConcreteMethod(
       name,
@@ -59,9 +44,9 @@ extension AnyModule {
   /**
    Factory function for methods with one argument.
    */
-  public static func method<R, A0: AnyMethodArgument>(
+  public func method<R, A0: AnyMethodArgument>(
     _ name: String,
-    _ closure: @escaping (Self, A0) -> R
+    _ closure: @escaping (A0) -> R
   ) -> AnyMethod {
     return ConcreteMethod(
       name,
@@ -73,9 +58,9 @@ extension AnyModule {
   /**
    Factory function for methods with 2 arguments.
    */
-  public static func method<R, A0: AnyMethodArgument, A1: AnyMethodArgument>(
+  public func method<R, A0: AnyMethodArgument, A1: AnyMethodArgument>(
     _ name: String,
-    _ closure: @escaping (Self, A0, A1) -> R
+    _ closure: @escaping (A0, A1) -> R
   ) -> AnyMethod {
     return ConcreteMethod(
       name,
@@ -87,9 +72,9 @@ extension AnyModule {
   /**
    Factory function for methods with 3 arguments.
    */
-  public static func method<R, A0: AnyMethodArgument, A1: AnyMethodArgument, A2: AnyMethodArgument>(
+  public func method<R, A0: AnyMethodArgument, A1: AnyMethodArgument, A2: AnyMethodArgument>(
     _ name: String,
-    _ closure: @escaping (Self, A0, A1, A2) -> R
+    _ closure: @escaping (A0, A1, A2) -> R
   ) -> AnyMethod {
     return ConcreteMethod(
       name,
@@ -101,9 +86,9 @@ extension AnyModule {
   /**
    Factory function for methods with 4 arguments.
    */
-  public static func method<R, A0: AnyMethodArgument, A1: AnyMethodArgument, A2: AnyMethodArgument, A3: AnyMethodArgument>(
+  public func method<R, A0: AnyMethodArgument, A1: AnyMethodArgument, A2: AnyMethodArgument, A3: AnyMethodArgument>(
     _ name: String,
-    _ closure: @escaping (Self, A0, A1, A2, A3) -> R
+    _ closure: @escaping (A0, A1, A2, A3) -> R
   ) -> AnyMethod {
     return ConcreteMethod(
       name,
@@ -115,9 +100,9 @@ extension AnyModule {
   /**
    Factory function for methods with 5 arguments.
    */
-  public static func method<R, A0: AnyMethodArgument, A1: AnyMethodArgument, A2: AnyMethodArgument, A3: AnyMethodArgument, A4: AnyMethodArgument>(
+  public func method<R, A0: AnyMethodArgument, A1: AnyMethodArgument, A2: AnyMethodArgument, A3: AnyMethodArgument, A4: AnyMethodArgument>(
     _ name: String,
-    _ closure: @escaping (Self, A0, A1, A2, A3, A4) -> R
+    _ closure: @escaping (A0, A1, A2, A3, A4) -> R
   ) -> AnyMethod {
     return ConcreteMethod(
       name,
@@ -129,9 +114,9 @@ extension AnyModule {
   /**
    Factory function for methods with 6 arguments.
    */
-  public static func method<R, A0: AnyMethodArgument, A1: AnyMethodArgument, A2: AnyMethodArgument, A3: AnyMethodArgument, A4: AnyMethodArgument, A5: AnyMethodArgument>(
+  public func method<R, A0: AnyMethodArgument, A1: AnyMethodArgument, A2: AnyMethodArgument, A3: AnyMethodArgument, A4: AnyMethodArgument, A5: AnyMethodArgument>(
     _ name: String,
-    _ closure: @escaping (Self, A0, A1, A2, A3, A4, A5) -> R
+    _ closure: @escaping (A0, A1, A2, A3, A4, A5) -> R
   ) -> AnyMethod {
     return ConcreteMethod(
       name,
@@ -143,9 +128,9 @@ extension AnyModule {
   /**
    Factory function for methods with 7 arguments.
    */
-  public static func method<R, A0: AnyMethodArgument, A1: AnyMethodArgument, A2: AnyMethodArgument, A3: AnyMethodArgument, A4: AnyMethodArgument, A5: AnyMethodArgument, A6: AnyMethodArgument>(
+  public func method<R, A0: AnyMethodArgument, A1: AnyMethodArgument, A2: AnyMethodArgument, A3: AnyMethodArgument, A4: AnyMethodArgument, A5: AnyMethodArgument, A6: AnyMethodArgument>(
     _ name: String,
-    _ closure: @escaping (Self, A0, A1, A2, A3, A4, A5, A6) -> R
+    _ closure: @escaping (A0, A1, A2, A3, A4, A5, A6) -> R
   ) -> AnyMethod {
     return ConcreteMethod(
       name,
@@ -157,9 +142,9 @@ extension AnyModule {
   /**
    Factory function for methods with 8 arguments.
    */
-  public static func method<R, A0: AnyMethodArgument, A1: AnyMethodArgument, A2: AnyMethodArgument, A3: AnyMethodArgument, A4: AnyMethodArgument, A5: AnyMethodArgument, A6: AnyMethodArgument, A7: AnyMethodArgument>(
+  public func method<R, A0: AnyMethodArgument, A1: AnyMethodArgument, A2: AnyMethodArgument, A3: AnyMethodArgument, A4: AnyMethodArgument, A5: AnyMethodArgument, A6: AnyMethodArgument, A7: AnyMethodArgument>(
     _ name: String,
-    _ closure: @escaping (Self, A0, A1, A2, A3, A4, A5, A6, A7) -> R
+    _ closure: @escaping (A0, A1, A2, A3, A4, A5, A6, A7) -> R
   ) -> AnyMethod {
     return ConcreteMethod(
       name,
@@ -168,99 +153,47 @@ extension AnyModule {
     )
   }
 
-  // MARK: - `onCreate`
+  // MARK: - Module's lifecycle
 
   /**
    Creates module's lifecycle listener that is called right after module initialization.
    */
-  public static func onCreate(_ closure: @escaping () -> Void) -> AnyDefinition {
+  public func onCreate(_ closure: @escaping () -> Void) -> AnyDefinition {
     return EventListener(.moduleCreate, closure)
-  }
-
-  /**
-   Creates module's lifecycle listener that is called right after module initialization.
-   */
-  public static func onCreate(_ closure: @escaping (Self) -> Void) -> AnyDefinition {
-    return EventListener(.moduleCreate, closure)
-  }
-
-  // MARK: - `onDestroy`
-
-  /**
-   Creates module's lifecycle listener that is called when the module is about to be deallocated.
-   */
-  public static func onDestroy(_ closure: @escaping () -> Void) -> AnyDefinition {
-    return EventListener(.moduleDestroy, closure)
   }
 
   /**
    Creates module's lifecycle listener that is called when the module is about to be deallocated.
    */
-  public static func onDestroy(_ closure: @escaping (Self) -> Void) -> AnyDefinition {
+  public func onDestroy(_ closure: @escaping () -> Void) -> AnyDefinition {
     return EventListener(.moduleDestroy, closure)
   }
 
-  // MARK: - `onAppContextDestroys`
-
   /**
    Creates module's lifecycle listener that is called when the app context owning the module is about to be deallocated.
    */
-  public static func onAppContextDestroys(_ closure: @escaping () -> Void) -> AnyDefinition {
+  public func onAppContextDestroys(_ closure: @escaping () -> Void) -> AnyDefinition {
     return EventListener(.appContextDestroys, closure)
-  }
-
-  /**
-   Creates module's lifecycle listener that is called when the app context owning the module is about to be deallocated.
-   */
-  public static func onAppContextDestroys(_ closure: @escaping (Self) -> Void) -> AnyDefinition {
-    return EventListener(.appContextDestroys, closure)
-  }
-
-  // MARK: - `onAppEntersForeground`
-
-  /**
-   Creates a listener that is called when the app is about to enter the foreground mode.
-   */
-  public static func onAppEntersForeground(_ closure: @escaping () -> Void) -> AnyDefinition {
-    return EventListener(.appEntersForeground, closure)
   }
 
   /**
    Creates a listener that is called when the app is about to enter the foreground mode.
    */
-  public static func onAppEntersForeground(_ closure: @escaping (Self) -> Void) -> AnyDefinition {
+  public func onAppEntersForeground(_ closure: @escaping () -> Void) -> AnyDefinition {
     return EventListener(.appEntersForeground, closure)
   }
 
-  // MARK: - `onAppBecomesActive`
-
   /**
    Creates a listener that is called when the app becomes active again.
    */
-  public static func onAppBecomesActive(_ closure: @escaping () -> Void) -> AnyDefinition {
+  public func onAppBecomesActive(_ closure: @escaping () -> Void) -> AnyDefinition {
     return EventListener(.appBecomesActive, closure)
-  }
-
-  /**
-   Creates a listener that is called when the app becomes active again.
-   */
-  public static func onAppBecomesActive(_ closure: @escaping (Self) -> Void) -> AnyDefinition {
-    return EventListener(.appBecomesActive, closure)
-  }
-
-  // MARK: - `onAppEntersBackground`
-
-  /**
-   Creates a listener that is called when the app enters the background mode.
-   */
-  public static func onAppEntersBackground(_ closure: @escaping () -> Void) -> AnyDefinition {
-    return EventListener(.appEntersBackground, closure)
   }
 
   /**
    Creates a listener that is called when the app enters the background mode.
    */
-  public static func onAppEntersBackground(_ closure: @escaping (Self) -> Void) -> AnyDefinition {
+  public func onAppEntersBackground(_ closure: @escaping () -> Void) -> AnyDefinition {
     return EventListener(.appEntersBackground, closure)
   }
 
@@ -269,21 +202,21 @@ extension AnyModule {
   /**
    Creates the view manager definition that scopes other view-related definitions.
    */
-  public static func viewManager(@ViewManagerDefinitionBuilder _ closure: @escaping () -> ViewManagerDefinition) -> AnyDefinition {
+  public func viewManager(@ViewManagerDefinitionBuilder _ closure: @escaping () -> ViewManagerDefinition) -> AnyDefinition {
     return closure()
   }
+}
 
-  /**
-   Defines the factory creating a native view when the module is used as a view.
-   */
-  public static func view(_ closure: @escaping () -> UIView) -> AnyDefinition {
-    return ViewFactory(closure)
-  }
+/**
+ Defines the factory creating a native view when the module is used as a view.
+ */
+public func view(_ closure: @escaping () -> UIView) -> AnyDefinition {
+  return ViewFactory(closure)
+}
 
-  /**
-   Creates a view prop that defines its name and setter.
-   */
-  public static func prop<ViewType: UIView, PropType>(_ name: String, _ setter: @escaping (ViewType, PropType) -> Void) -> AnyDefinition {
-    return ConcreteViewProp(name, setter)
-  }
+/**
+ Creates a view prop that defines its name and setter.
+ */
+public func prop<ViewType: UIView, PropType>(_ name: String, _ setter: @escaping (ViewType, PropType) -> Void) -> AnyDefinition {
+  return ConcreteViewProp(name, setter)
 }

--- a/packages/expo-modules-core/ios/Tests/MethodSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/MethodSpec.swift
@@ -70,7 +70,7 @@ class MethodSpec: QuickSpec {
       it("converts to simple record when passed as an argument") {
         waitUntil { done in
           mockModuleHolder(appContext) {
-            $0.method(methodName) { (module, a: TestRecord) in
+            $0.method(methodName) { (a: TestRecord) in
               return a.property
             }
           }
@@ -86,7 +86,7 @@ class MethodSpec: QuickSpec {
       it("converts to record with custom key") {
         waitUntil { done in
           mockModuleHolder(appContext) {
-            $0.method(methodName) { (module, a: TestRecord) in
+            $0.method(methodName) { (a: TestRecord) in
               return a.customKeyProperty
             }
           }
@@ -102,7 +102,7 @@ class MethodSpec: QuickSpec {
       it("returns the record back") {
         waitUntil { done in
           mockModuleHolder(appContext) {
-            $0.method(methodName) { (module, a: TestRecord) in
+            $0.method(methodName) { (a: TestRecord) in
               return a.toDictionary()
             }
           }
@@ -123,7 +123,7 @@ class MethodSpec: QuickSpec {
     it("throws when called with more arguments than expected") {
       waitUntil { done in
         mockModuleHolder(appContext) {
-          $0.method(methodName) { (module, a: Int) in
+          $0.method(methodName) { (a: Int) in
             return "something"
           }
         }
@@ -141,7 +141,7 @@ class MethodSpec: QuickSpec {
     it("throws when called with arguments of incompatible types") {
       waitUntil { done in
         mockModuleHolder(appContext) {
-          $0.method(methodName) { (module, a: String) in
+          $0.method(methodName) { (a: String) in
             return "something"
           }
         }

--- a/packages/expo-modules-core/ios/Tests/Mocks/ModuleMocks.swift
+++ b/packages/expo-modules-core/ios/Tests/Mocks/ModuleMocks.swift
@@ -1,31 +1,40 @@
 @testable import ExpoModulesCore
 
 class UnnamedModule: Module {
-  static func definition() -> ModuleDefinition {}
+  func definition() -> ModuleDefinition {}
 }
 
 class NamedModule: Module {
   static let namedModuleName = "MyModule"
 
-  static func definition() -> ModuleDefinition {
-    name(namedModuleName)
+  func definition() -> ModuleDefinition {
+    name(Self.namedModuleName)
   }
 }
 
 class CustomModule: Module {
-  static func definition() -> ModuleDefinition {}
+  let body: MockedDefinitionFunc
+
+  func definition() -> ModuleDefinition {
+    return body(self)
+  }
+
+  init(appContext: AppContext, _ body: @escaping MockedDefinitionFunc) {
+    self.body = body
+    super.init(appContext: appContext)
+  }
+
+  required init(appContext: AppContext) {
+    fatalError("`init(appContext:)` is unavailable in mocked module class.")
+  }
 }
 
-typealias MockedDefinitionFunc = (CustomModule.Type) -> ModuleDefinition
+typealias MockedDefinitionFunc = (CustomModule) -> ModuleDefinition
 
-func mockDefinition(@ModuleDefinitionBuilder _ definition: @escaping () -> ModuleDefinition) -> ModuleDefinition {
-  return definition().withType(CustomModule.self)
+func mockModuleHolder(_ appContext: AppContext, @ModuleDefinitionBuilder _ definitionBody: @escaping () -> ModuleDefinition) -> ModuleHolder {
+  return ModuleHolder(appContext: appContext, module: CustomModule(appContext: appContext, { module in definitionBody() }))
 }
 
-func mockDefinition(@ModuleDefinitionBuilder _ definition: @escaping MockedDefinitionFunc) -> ModuleDefinition {
-  return definition(CustomModule.self).withType(CustomModule.self)
-}
-
-func mockModuleHolder(_ appContext: AppContext, @ModuleDefinitionBuilder _ definition: @escaping MockedDefinitionFunc) -> ModuleHolder {
-  return ModuleHolder(appContext: appContext, definition: mockDefinition(definition))
+func mockModuleHolder(_ appContext: AppContext, @ModuleDefinitionBuilder _ definitionBody: @escaping (CustomModule) -> ModuleDefinition) -> ModuleHolder {
+  return ModuleHolder(appContext: appContext, module: CustomModule(appContext: appContext, { module in definitionBody(module) }))
 }

--- a/packages/expo-modules-core/ios/Tests/ModuleEventListenersSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/ModuleEventListenersSpec.swift
@@ -21,41 +21,38 @@ class ModuleEventListenersSpec: QuickSpec {
 
     it("calls onCreate once the module instance is created") {
       waitUntil { done in
-        let definition = mockDefinition {
+        let _ = mockModuleHolder(appContext) {
           $0.onCreate {
             done()
           }
         }
-        appContext.moduleRegistry.register(definition: definition)
-        // `get(moduleWithName:)` automatically creates a module instance if needed.
-        let _ = appContext.moduleRegistry.get(moduleWithName: definition.name)
       }
     }
 
     it("calls onDestroy once the module is about to be deallocated") {
       waitUntil { done in
         let moduleName = "mockedModule"
-        let definition = mockDefinition {
+        let holder = mockModuleHolder(appContext) {
           $0.name(moduleName)
           $0.onDestroy {
             done()
           }
         }
-        appContext.moduleRegistry.register(definition: definition)
+        appContext.moduleRegistry.register(holder: holder)
         // Unregister the module to deallocate its holder
-        appContext.moduleRegistry.unregister(moduleName: moduleName)
+        appContext.moduleRegistry.unregister(moduleName: holder.name)
         // The `module` object is actually still alive, but its holder is dead
       }
     }
 
     it("calls onAppContextDestroys once the context destroys") {
       waitUntil { done in
-        let definition = mockDefinition {
+        let holder = mockModuleHolder(appContext) {
           $0.onAppContextDestroys {
             done()
           }
         }
-        appContext.moduleRegistry.register(definition: definition)
+        appContext.moduleRegistry.register(holder: holder)
         appContext = nil // This must deallocate the app context
       }
     }
@@ -63,48 +60,48 @@ class ModuleEventListenersSpec: QuickSpec {
     it("calls custom event listener when the event is sent to the registry") {
       waitUntil { done in
         let event = EventName.custom("custom event name")
-        let definition = mockDefinition {
+        let holder = mockModuleHolder(appContext) {
           EventListener(event) {
             done()
           }
         }
-        appContext.moduleRegistry.register(definition: definition)
+        appContext.moduleRegistry.register(holder: holder)
         appContext.moduleRegistry.post(event: event)
       }
     }
 
     it("calls onAppEntersForeground when system's willEnterForegroundNotification is sent") {
       waitUntil { done in
-        let definition = mockDefinition {
+        let holder = mockModuleHolder(appContext) {
           $0.onAppEntersForeground {
             done()
           }
         }
-        appContext.moduleRegistry.register(definition: definition)
+        appContext.moduleRegistry.register(holder: holder)
         NotificationCenter.default.post(name: UIApplication.willEnterForegroundNotification, object: nil)
       }
     }
 
     it("calls onAppBecomesActive when system's didBecomeActiveNotification is sent") {
       waitUntil { done in
-        let definition = mockDefinition {
+        let holder = mockModuleHolder(appContext) {
           $0.onAppBecomesActive {
             done()
           }
         }
-        appContext.moduleRegistry.register(definition: definition)
+        appContext.moduleRegistry.register(holder: holder)
         NotificationCenter.default.post(name: UIApplication.didBecomeActiveNotification, object: nil)
       }
     }
 
     it("calls onAppEntersBackground when system's didEnterBackgroundNotification is sent") {
       waitUntil { done in
-        let definition = mockDefinition {
+        let holder = mockModuleHolder(appContext) {
           $0.onAppEntersBackground {
             done()
           }
         }
-        appContext.moduleRegistry.register(definition: definition)
+        appContext.moduleRegistry.register(holder: holder)
         NotificationCenter.default.post(name: UIApplication.didEnterBackgroundNotification, object: nil)
       }
     }

--- a/packages/expo-modules-core/ios/Tests/ModuleRegistrySpec.swift
+++ b/packages/expo-modules-core/ios/Tests/ModuleRegistrySpec.swift
@@ -21,7 +21,6 @@ class ModuleRegistrySpec: QuickSpec {
       moduleRegistry.register(moduleType: moduleType)
 
       expect(moduleRegistry.has(moduleWithName: name)).to(beTrue())
-      expect(moduleRegistry.contains { $0.isOfType(ModuleType.self) }).to(beTrue())
     }
   }
 }

--- a/packages/expo-tracking-transparency/ios/EXTrackingTransparency/TrackingTransparencyModule.swift
+++ b/packages/expo-tracking-transparency/ios/EXTrackingTransparency/TrackingTransparencyModule.swift
@@ -1,25 +1,25 @@
 import ExpoModulesCore
 
 public class TrackingTransparencyModule: Module {
-  public static func definition() -> ModuleDefinition {
+  public func definition() -> ModuleDefinition {
     name("ExpoTrackingTransparency")
 
-    onCreate { module in
-      EXPermissionsMethodsDelegate.register([EXTrackingPermissionRequester()], withPermissionsManager: module.appContext?.permissions)
+    onCreate {
+      EXPermissionsMethodsDelegate.register([EXTrackingPermissionRequester()], withPermissionsManager: self.appContext?.permissions)
     }
 
-    method("getPermissionsAsync") { (module, promise: Promise) in
+    method("getPermissionsAsync") { (promise: Promise) in
       EXPermissionsMethodsDelegate.getPermissionWithPermissionsManager(
-        module.appContext?.permissions,
+        self.appContext?.permissions,
         withRequester: EXTrackingPermissionRequester.self,
         resolve: promise.resolver,
         reject: promise.legacyRejecter
       )
     }
 
-    method("requestPermissionsAsync") { (module, promise: Promise) in
+    method("requestPermissionsAsync") { (promise: Promise) in
       EXPermissionsMethodsDelegate.askForPermission(
-        withPermissionsManager: module.appContext?.permissions,
+        withPermissionsManager: self.appContext?.permissions,
         withRequester: EXTrackingPermissionRequester.self,
         resolve: promise.resolver,
         reject: promise.legacyRejecter


### PR DESCRIPTION
# Why

Once we started working on Kotlin implementation, it turned out that having static definition would make the differences between Kotlin and Swift more visible. In Kotlin we would have to additionally use `companion object` because there are no static functions as we know from Swift.
There are not that much gains in static definition and non-static would be easier for users, so I'm reverting it.

# How

Partially reverted #14645

# Test Plan

expo-modules-core builds and unit tests are passing
