### PR TITLE
[home] Show activity indicator for all profile loading screens

### DIFF
--- a/home/screens/ProfileScreen.tsx
+++ b/home/screens/ProfileScreen.tsx
@@ -1,6 +1,6 @@
 import { StackScreenProps } from '@react-navigation/stack';
 import * as React from 'react';
-import { ActivityIndicator, StyleSheet, Text, View } from 'react-native';
+import { ActivityIndicator, StyleSheet, View } from 'react-native';
 
 import ProfileUnauthenticated from '../components/ProfileUnauthenticated';
 import Colors from '../constants/Colors';

--- a/home/screens/ProfileScreen.tsx
+++ b/home/screens/ProfileScreen.tsx
@@ -1,10 +1,11 @@
 import { StackScreenProps } from '@react-navigation/stack';
-import { AllStackRoutes } from 'navigation/Navigation.types';
 import * as React from 'react';
-import { StyleSheet, View } from 'react-native';
+import { ActivityIndicator, StyleSheet, Text, View } from 'react-native';
 
 import ProfileUnauthenticated from '../components/ProfileUnauthenticated';
+import Colors from '../constants/Colors';
 import Profile from '../containers/Profile';
+import { AllStackRoutes } from '../navigation/Navigation.types';
 import { useSelector } from '../redux/Hooks';
 import getViewerUsernameAsync from '../utils/getViewerUsernameAsync';
 import isUserAuthenticated from '../utils/isUserAuthenticated';
@@ -53,7 +54,11 @@ function ProfileView(
   }, [props.isAuthenticated]);
 
   if (viewerUsername === undefined) {
-    return <View style={styles.loadingContainer} />;
+    return (
+      <View style={styles.loadingContainer}>
+        <ActivityIndicator color={Colors.light.tintColor} />
+      </View>
+    );
   }
 
   if (!props.isAuthenticated || !viewerUsername) {
@@ -66,5 +71,7 @@ function ProfileView(
 const styles = StyleSheet.create({
   loadingContainer: {
     flex: 1,
+    padding: 30,
+    alignItems: 'center',
   },
 });


### PR DESCRIPTION
# Why

There's a loading state here that would show up as blank while fetching the username. This PR fixes this by showing an activity indicator.

# How

Show the same loading state as other profile loading states.

Note: we're going to be redesigning/re-coding this whole interface pretty soon so at that point we'll probably want to create a common screen type that handles data fetching as well as pull to refresh, loading states, etc.

# Test Plan

For some reason my android is having this issue all the time (network requests taking forever I think), so the repro here was just to load the profile and it would show a blank page with no indication of loading. After the fix it shows an activity indicator.