### PR TITLE
[updates] Fix Android app.manifest not generated in bare template

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Fix auto setup `EXUpdatesAppDelegate` breaking reanimated installation. ([#14755](https://github.com/expo/expo/pull/14755) by [@kudo](https://github.com/kudo))
 - Fix support for `react.entryFile` gradle config. ([#14934](https://github.com/expo/expo/pull/14934) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix Android app.manifest not generated when in OneSignal gradle plugin integration. ([#14938](https://github.com/expo/expo/pull/14938) by [@kudo](https://github.com/kudo))
+- Fix Android app.manifest not generated from [#14938](https://github.com/expo/expo/pull/14938) regression. ([#14953](https://github.com/expo/expo/pull/14953) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-updates/scripts/create-manifest-android.gradle
+++ b/packages/expo-updates/scripts/create-manifest-android.gradle
@@ -5,11 +5,23 @@ import org.gradle.util.GradleVersion
 
 def expoUpdatesDir = ["node", "-e", "console.log(require('path').dirname(require.resolve('expo-updates/package.json')));"].execute([], projectDir).text.trim()
 
-  // From a library project role to reference app project settings such as `targetName.toLowerCase().contains("release")`,
-  // we extract the `appProject` from all projects here.
-  // things like `config`, `buildDir`, and `applicationVariants`, we will reference from appProject.
+// From a library project role to reference app project settings such as `targetName.toLowerCase().contains("release")`,
+// we extract the `appProject` from all projects here.
+// things like `config`, `buildDir`, and `applicationVariants`, we will reference from appProject.
 def appProject = rootProject.allprojects.find { it.plugins.hasPlugin('com.android.application') }
-appProject.afterEvaluate {
+if (!appProject) {
+  // For instrumented test, the appProject will be null.
+  return;
+}
+if (!android.hasProperty('libraryVariants')) {
+  // For traditional application level integration, will be no-op to prevent duplicated app.manifest creation.
+  return;
+}
+if (findProperty('expo.updates.createManifest') == 'false') {
+  return;
+}
+
+def setupClosure = {
   def config = appProject.hasProperty("react") ? appProject.react : [];
   def nodeExecutableAndArgs = config.nodeExecutableAndArgs ?: ["node"]
   def entryFile = config.entryFile ?: "index.js"
@@ -17,18 +29,6 @@ appProject.afterEvaluate {
 
   def projectRoot = file("${rootProject.projectDir}")
   def inputExcludes = ["android/**", "ios/**"]
-
-  if (!android.hasProperty('libraryVariants')) {
-    // For traditional application level integration, will be no-op to prevent duplicated app.config creation.
-    return;
-  }
-  if (!appProject) {
-    // For instrumented test, the appProject will be null.
-    return;
-  }
-  if (findProperty('expo.updates.createManifest') == 'false') {
-    return;
-  }
 
   appProject.android.applicationVariants.each { variant ->
     def targetName = variant.name.capitalize()
@@ -94,5 +94,18 @@ appProject.afterEvaluate {
     if (dependentTask != null) {
       dependentTask.dependsOn currentAssetsCopyTask
     }
+  }
+}
+
+// The `appProject` may either be evaluated or not. We should check project state and setup for both cases.
+//   - If project is evaluated, we just call setupClosure and get the correct applicationVariants.
+//   - If project is not evaluated yet, we should just wait for afterEvaluate().
+// The `hasCompleted()` is actually gradle internal method as ProjectState does not provide enough state information.
+// https://github.com/gradle/gradle/blob/958d5b0f8a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectStateInternal.java#L64-L66
+if (appProject.state.hasCompleted()) {
+  setupClosure.call()
+} else {
+  appProject.afterEvaluate {
+    setupClosure.call()
   }
 }


### PR DESCRIPTION
# Why

regression from #14938 where app.manifest is not generated in normal cases.

# How

that is a timing issue.
- if appProject is evaluated, we just setup as usual.
- if appProject is not evaluated, we should wait for afterEvaluate

# Test Plan

`expo init sdk43`

1. normal case
`./gradlew clean :app:assembleRelease`
`unzip -l app/build/outputs/apk/release/app-release.apk | grep app.manifest` makes sure it exists

2. onesignal case
prepend onesignal patch to `android/app/build.gradle` at top

```
buildscript {
    repositories {
        gradlePluginPortal()
    }
    dependencies {
        classpath 'gradle.plugin.com.onesignal:onesignal-gradle-plugin:[0.12.10, 0.99.99]'
    }
}

apply plugin: 'com.onesignal.androidsdk.onesignal-gradle-plugin'
```

`./gradlew clean :app:assembleRelease`
`unzip -l app/build/outputs/apk/release/app-release.apk | grep app.manifest` makes sure it exists

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
