### PR TITLE
[dev-launcher][ios] Add more tests

### DIFF
--- a/packages/expo-dev-launcher/expo-dev-launcher.podspec
+++ b/packages/expo-dev-launcher/expo-dev-launcher.podspec
@@ -53,6 +53,8 @@ Pod::Spec.new do |s|
   s.test_spec 'Tests' do |test_spec|
     test_spec.platform     = :ios, '12.0'
     test_spec.source_files = 'ios/Tests/**/*.{h,m,swift}'
+    test_spec.dependency 'Quick'
+    test_spec.dependency 'Nimble'
     test_spec.dependency "React-CoreModules"
     test_spec.dependency "OHHTTPStubs"
   end

--- a/packages/expo-dev-launcher/ios/EXDevLauncherMenuDelegate.swift
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherMenuDelegate.swift
@@ -1,6 +1,6 @@
 import EXDevMenuInterface
 
-private class LauncherDelegate : DevMenuDelegateProtocol {
+internal class LauncherDelegate : DevMenuDelegateProtocol {
   private let controller: EXDevLauncherController
   
   init(withController controller: EXDevLauncherController) {
@@ -25,7 +25,7 @@ private class LauncherDelegate : DevMenuDelegateProtocol {
   }
 }
 
-private class AppDelegate : DevMenuDelegateProtocol {
+internal class AppDelegate : DevMenuDelegateProtocol {
   private let controller: EXDevLauncherController
   
   init(withController controller: EXDevLauncherController) {

--- a/packages/expo-dev-launcher/ios/EXDevLauncherRecentlyOpenedAppsRegistry.swift
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherRecentlyOpenedAppsRegistry.swift
@@ -50,4 +50,8 @@ public class EXDevLauncherRecentlyOpenedAppsRegistry : NSObject {
   func getCurrentTimestamp() -> Int64 {
     return Int64(Date().timeIntervalSince1970 * 1000);
   }
+
+  func resetStorage() {
+    UserDefaults.standard.removeObject(forKey: RECENTLY_OPENED_APPS_REGISTRY_KEY)
+  }
 }

--- a/packages/expo-dev-launcher/ios/ReactNative/EXDevLauncherRCTBridge.h
+++ b/packages/expo-dev-launcher/ios/ReactNative/EXDevLauncherRCTBridge.h
@@ -6,9 +6,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface EXDevLauncherRCTCxxBridge : RCTCxxBridge
 
+- (NSArray<Class> *)filterModuleList:(NSArray<Class> *)modules;
+
 @end
 
 @interface EXDevLauncherRCTBridge : RCTBridge
+
+- (Class)bridgeClass;
 
 @end
 

--- a/packages/expo-dev-launcher/ios/ReactNative/EXDevLauncherRCTBridge.m
+++ b/packages/expo-dev-launcher/ios/ReactNative/EXDevLauncherRCTBridge.m
@@ -26,12 +26,10 @@
   return nil;
 }
 
-- (NSArray<RCTModuleData *> *)_initializeModules:(NSArray<Class> *)modules
-                               withDispatchGroup:(dispatch_group_t)dispatchGroup
-                                lazilyDiscovered:(BOOL)lazilyDiscovered
+- (NSArray<Class> *)filterModuleList:(NSArray<Class> *)modules
 {
   NSArray<NSString *> *allowedModules = @[@"RCT", @"DevMenu"];
-  NSArray<Class> *filtredModuleList = [modules filteredArrayUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(id  _Nullable clazz, NSDictionary<NSString *,id> * _Nullable bindings) {
+  NSArray<Class> *filteredModuleList = [modules filteredArrayUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(id  _Nullable clazz, NSDictionary<NSString *,id> * _Nullable bindings) {
     if ([clazz conformsToProtocol:@protocol(DevMenuExtensionProtocol)]) {
       return true;
     }
@@ -45,7 +43,14 @@
     return false;
   }]];
   
-  return [super _initializeModules:filtredModuleList withDispatchGroup:dispatchGroup lazilyDiscovered:lazilyDiscovered];
+  return filteredModuleList;
+}
+
+- (NSArray<RCTModuleData *> *)_initializeModules:(NSArray<Class> *)modules
+                               withDispatchGroup:(dispatch_group_t)dispatchGroup
+                                lazilyDiscovered:(BOOL)lazilyDiscovered
+{
+  return [super _initializeModules:[self filterModuleList:modules] withDispatchGroup:dispatchGroup lazilyDiscovered:lazilyDiscovered];
 }
 
 @end

--- a/packages/expo-dev-launcher/ios/Tests/EXDevLauncherControllerTest.swift
+++ b/packages/expo-dev-launcher/ios/Tests/EXDevLauncherControllerTest.swift
@@ -1,0 +1,40 @@
+import Quick
+import Nimble
+
+@testable import EXDevLauncher
+
+class EXDevLauncherControllerTest: QuickSpec {
+  override func spec() {
+    it("should return correct version") {
+      let version = EXDevLauncherController.version()
+    
+      expect(version).toNot(beNil())
+    }
+    
+    it("sharedInstance should always return the same instance") {
+      let sharedInstance = EXDevLauncherController.sharedInstance()
+      
+      expect(sharedInstance).toNot(beNil())
+      expect(sharedInstance).to(be(EXDevLauncherController.sharedInstance()))
+    }
+    
+    it("extraModulesForBridge should return essential modules") {
+      let module = EXDevLauncherController.sharedInstance()
+      
+      let modules = module.extraModules(for: nil)!
+      
+      expect(modules.count).to(equal(4))
+      expect(modules.first { type(of: $0).moduleName() == "RCTDevMenu"} ).toNot(beNil())
+      expect(modules.first { type(of: $0).moduleName() == "RCTAsyncLocalStorage"} ).toNot(beNil())
+      expect(modules.first { type(of: $0).moduleName() == "DevLoadingView"} ).toNot(beNil())
+      expect(modules.first { type(of: $0).moduleName() == "EXDevLauncherInternal"} ).toNot(beNil())
+    }
+    
+    it("controller should have access to managers classes") {
+      let module = EXDevLauncherController.sharedInstance()
+      
+      expect(module.errorManager()).toNot(beNil())
+      expect(module.pendingDeepLinkRegistry).toNot(beNil())
+    }
+  }
+}

--- a/packages/expo-dev-launcher/ios/Tests/EXDevLauncherMenuDelegateTest.swift
+++ b/packages/expo-dev-launcher/ios/Tests/EXDevLauncherMenuDelegateTest.swift
@@ -1,0 +1,89 @@
+import Quick
+import Nimble
+
+@testable import EXDevLauncher
+@testable import EXDevMenuInterface
+
+class EXDevLauncherMenuDelegateTest: QuickSpec {
+  class MockedApiClient: DevMenuExpoApiClientProtocol {
+    func isLoggedIn() -> Bool {
+      return false
+    }
+    
+    func setSessionSecret(_ sessionSecret: String?) {}
+    
+    func queryDevSessionsAsync(_ completionHandler: @escaping HTTPCompletionHandler) {}
+    
+    func queryUpdateChannels(appId: String, completionHandler: @escaping ([DevMenuEASUpdates.Channel]?, URLResponse?, Error?) -> Void, options: DevMenuGraphQLOptions) {}
+    
+    func queryUpdateBranches(appId: String, completionHandler: @escaping ([DevMenuEASUpdates.Branch]?, URLResponse?, Error?) -> Void, branchesOptions: DevMenuGraphQLOptions, updatesOptions: DevMenuGraphQLOptions) {}
+  }
+  
+  class MockedMene: DevMenuManagerProtocol {
+    var isVisible: Bool = false
+    
+    var delegate: DevMenuDelegateProtocol?
+    
+    func openMenu(_ screen: String?) -> Bool {
+      return true
+    }
+    
+    func openMenu() -> Bool {
+      return true
+    }
+    
+    func closeMenu() -> Bool {
+      return true
+    }
+    
+    func hideMenu() -> Bool {
+      return true
+    }
+    
+    func toggleMenu() -> Bool {
+      return true
+    }
+    
+    var expoApiClient: DevMenuExpoApiClientProtocol = MockedApiClient()
+  }
+  
+  override func spec() {
+    it("LauncherDelegate should serialize to the correct scheme") {
+      let delegate = LauncherDelegate(withController: EXDevLauncherController.sharedInstance())
+      
+      let appInfo = delegate.appInfo(forDevMenuManager: MockedMene())!
+
+      expect(appInfo["appName"] as? String).to(equal("Development Client"))
+      expect(appInfo["appVersion"] as? String).to(equal(EXDevLauncherController.version()))
+      expect(appInfo["appIcon"]).to(be(NSNull()))
+      expect(appInfo["hostUrl"]).to(be(NSNull()))
+    }
+   
+    it("LauncherDelegate shouldn't support developement tools") {
+      let delegate = LauncherDelegate(withController: EXDevLauncherController.sharedInstance())
+      
+      let supportsDevelopment = delegate.supportsDevelopment()
+      
+      expect(supportsDevelopment).to(beFalse())
+    }
+    
+    it("AppDelegate should serialize to the correct scheme") {
+      let delegate = AppDelegate(withController: EXDevLauncherController.sharedInstance())
+      
+      let appInfo = delegate.appInfo(forDevMenuManager: MockedMene())!
+
+      expect(appInfo["appName"] as? String).to(equal("Development Client - App"))
+      expect(appInfo["appVersion"]).to(be(NSNull()))
+      expect(appInfo["appIcon"]).to(be(NSNull()))
+      expect(appInfo["hostUrl"]).to(be(NSNull()))
+    }
+   
+    it("LauncherDelegate should support developement tools") {
+      let delegate = AppDelegate(withController: EXDevLauncherController.sharedInstance())
+      
+      let supportsDevelopment = delegate.supportsDevelopment()
+      
+      expect(supportsDevelopment).to(beTrue())
+    }
+  }
+}

--- a/packages/expo-dev-launcher/ios/Tests/EXDevLauncherMenuDelegateTest.swift
+++ b/packages/expo-dev-launcher/ios/Tests/EXDevLauncherMenuDelegateTest.swift
@@ -19,7 +19,7 @@ class EXDevLauncherMenuDelegateTest: QuickSpec {
     func queryUpdateBranches(appId: String, completionHandler: @escaping ([DevMenuEASUpdates.Branch]?, URLResponse?, Error?) -> Void, branchesOptions: DevMenuGraphQLOptions, updatesOptions: DevMenuGraphQLOptions) {}
   }
   
-  class MockedMene: DevMenuManagerProtocol {
+  class MockedMenu: DevMenuManagerProtocol {
     var isVisible: Bool = false
     
     var delegate: DevMenuDelegateProtocol?
@@ -51,7 +51,7 @@ class EXDevLauncherMenuDelegateTest: QuickSpec {
     it("LauncherDelegate should serialize to the correct scheme") {
       let delegate = LauncherDelegate(withController: EXDevLauncherController.sharedInstance())
       
-      let appInfo = delegate.appInfo(forDevMenuManager: MockedMene())!
+      let appInfo = delegate.appInfo(forDevMenuManager: MockedMenu())!
 
       expect(appInfo["appName"] as? String).to(equal("Development Client"))
       expect(appInfo["appVersion"] as? String).to(equal(EXDevLauncherController.version()))
@@ -70,7 +70,7 @@ class EXDevLauncherMenuDelegateTest: QuickSpec {
     it("AppDelegate should serialize to the correct scheme") {
       let delegate = AppDelegate(withController: EXDevLauncherController.sharedInstance())
       
-      let appInfo = delegate.appInfo(forDevMenuManager: MockedMene())!
+      let appInfo = delegate.appInfo(forDevMenuManager: MockedMenu())!
 
       expect(appInfo["appName"] as? String).to(equal("Development Client - App"))
       expect(appInfo["appVersion"]).to(be(NSNull()))
@@ -78,7 +78,7 @@ class EXDevLauncherMenuDelegateTest: QuickSpec {
       expect(appInfo["hostUrl"]).to(be(NSNull()))
     }
    
-    it("LauncherDelegate should support developement tools") {
+    it("AppDelegate should support development tools") {
       let delegate = AppDelegate(withController: EXDevLauncherController.sharedInstance())
       
       let supportsDevelopment = delegate.supportsDevelopment()

--- a/packages/expo-dev-launcher/ios/Tests/EXDevLauncherPendingDeepLinkRegistryTest.swift
+++ b/packages/expo-dev-launcher/ios/Tests/EXDevLauncherPendingDeepLinkRegistryTest.swift
@@ -1,0 +1,50 @@
+import Quick
+import Nimble
+
+@testable import EXDevLauncher
+
+class EXDevLauncherPendingDeepLinkRegistryTest: QuickSpec {
+  class Listener : NSObject, EXDevLauncherPendingDeepLinkListener {
+    var lastDeepLink: URL?
+    
+    func onNewPendingDeepLink(_ deepLink: URL!) {
+      lastDeepLink = deepLink
+    }
+  }
+  
+  override func spec() {
+    it("registry should inform all subscribers about new value") {
+      let listener = Listener()
+      let registry = EXDevLauncherPendingDeepLinkRegistry()
+      
+      registry.subscribe(listener)
+      registry.pendingDeepLink = URL.init(string: "http://localhost:1234")
+      
+      expect(listener.lastDeepLink?.absoluteString).to(equal("http://localhost:1234"))
+    }
+    
+    it("unsubscribe should work") {
+      let listener = Listener()
+      let registry = EXDevLauncherPendingDeepLinkRegistry()
+      
+      registry.subscribe(listener)
+      registry.unsubscribe(listener)
+      registry.pendingDeepLink = URL.init(string: "http://localhost:1234")
+      
+      expect(listener.lastDeepLink).to(beNil())
+    }
+    
+    it("consumePendingDeepLink should reset the inner value") {
+      let listener = Listener()
+      let registry = EXDevLauncherPendingDeepLinkRegistry()
+      
+      registry.subscribe(listener)
+      registry.pendingDeepLink = URL.init(string: "http://localhost:1234")
+      let consumedURL = registry.consumePendingDeepLink()
+      
+      expect(registry.pendingDeepLink).to(beNil())
+      expect(listener.lastDeepLink?.absoluteString).to(equal("http://localhost:1234"))
+      expect(listener.lastDeepLink).to(be(consumedURL))
+    }
+  }
+}

--- a/packages/expo-dev-launcher/ios/Tests/EXDevLauncherRCTBridgeTest.swift
+++ b/packages/expo-dev-launcher/ios/Tests/EXDevLauncherRCTBridgeTest.swift
@@ -1,0 +1,31 @@
+import Quick
+import Nimble
+
+@testable import EXDevLauncher
+
+class EXDevLauncherRCTBridgeTest: QuickSpec {
+  @objc(RCTAllowModule)
+  class RCTAllowModule: NSObject {}
+  @objc(NotAllowModule)
+  class NotAllowModule: NSObject {}
+  @objc(DevMenuModule)
+  class DevMenuModule: NSObject {}
+  
+  override func spec() {
+    it("should be connected with EXDevLauncherRCTCxxBridge") {
+      let bridge = EXDevLauncherRCTBridge(delegate: nil, launchOptions: nil)!
+    
+      expect(bridge.bridgeClass()).to(be(EXDevLauncherRCTCxxBridge.self))
+    }
+    
+    it("should be able to filter non essential modules") {
+      let cxxBridge = EXDevLauncherRCTBridge(delegate: nil, launchOptions: nil)!.batched as! EXDevLauncherRCTCxxBridge
+         
+      let filteredModules = cxxBridge.filterModuleList([RCTAllowModule.self, NotAllowModule.self, DevMenuModule.self])
+         
+      expect(filteredModules.count).to(equal(2))
+      expect(filteredModules[0]).to(be(RCTAllowModule.self))
+      expect(filteredModules[1]).to(be(DevMenuModule.self))
+    }
+  }
+}

--- a/packages/expo-dev-launcher/ios/Tests/EXDevLauncherRecentlyOpenedAppsRegistryTest.swift
+++ b/packages/expo-dev-launcher/ios/Tests/EXDevLauncherRecentlyOpenedAppsRegistryTest.swift
@@ -15,7 +15,7 @@ class EXDevLauncherRecentlyOpenedAppsRegistryTest: QuickSpec {
       expect(appsRegistry.recentlyOpenedApps().count).to(equal(0))
     }
     
-    it("registry should be empty on start") {
+    it("registry should update when apps are opened") {
       appsRegistry.appWasOpened("http://localhost:1234", name: "app1")
       appsRegistry.appWasOpened("http://localhost:9876", name: "app2")
       

--- a/packages/expo-dev-launcher/ios/Tests/EXDevLauncherRecentlyOpenedAppsRegistryTest.swift
+++ b/packages/expo-dev-launcher/ios/Tests/EXDevLauncherRecentlyOpenedAppsRegistryTest.swift
@@ -1,0 +1,37 @@
+import Quick
+import Nimble
+
+@testable import EXDevLauncher
+
+class EXDevLauncherRecentlyOpenedAppsRegistryTest: QuickSpec {
+  override func spec() {
+    let appsRegistry = EXDevLauncherRecentlyOpenedAppsRegistry()
+    
+    beforeEach {
+      appsRegistry.resetStorage()
+    }
+    
+    it("registry should be empty on start") {
+      expect(appsRegistry.recentlyOpenedApps().count).to(equal(0))
+    }
+    
+    it("registry should be empty on start") {
+      appsRegistry.appWasOpened("http://localhost:1234", name: "app1")
+      appsRegistry.appWasOpened("http://localhost:9876", name: "app2")
+      
+      let openedApps = appsRegistry.recentlyOpenedApps()
+      
+      expect(openedApps.count).to(equal(2))
+      expect(openedApps["http://localhost:1234"] as? String).to(equal("app1"))
+      expect(openedApps["http://localhost:9876"] as? String).to(equal("app2"))
+    }
+    
+    it("registry timestamp should be correct") {
+      let registerTimestamp = appsRegistry.getCurrentTimestamp()
+      let now = Int64(Date().timeIntervalSince1970 * 1000)
+      
+      expect(registerTimestamp).to(beLessThanOrEqualTo(now))
+      expect(registerTimestamp).to(beGreaterThan(now - 1000))
+    }
+  }
+}

--- a/packages/expo-dev-launcher/ios/Tests/EXDevLauncherTest.swift
+++ b/packages/expo-dev-launcher/ios/Tests/EXDevLauncherTest.swift
@@ -1,0 +1,17 @@
+import Quick
+import Nimble
+
+@testable import EXDevLauncher
+
+class EXDevLauncherTest: QuickSpec {
+  override func spec() {
+    it("exported constants should contain correct fields") {
+      let module = EXDevLauncher()
+      
+      let exportedConstants = module.constantsToExport()!
+      
+      expect(exportedConstants["manifestString"]).toNot(beNil())
+      expect(exportedConstants["manifestURL"]).toNot(beNil())      
+    }
+  }
+}


### PR DESCRIPTION
# Why

The second part of https://linear.app/expo/issue/ENG-1783/unit-tests-for-ios.
Adds more unit tests to the `expo-dev-launcher` package.

# How

- Added support for `Quick` and `Nimble`.
- Added more unit tests. 

# Test Plan

- run all tests ✅