### PR TITLE
[updates] Fix iOS app.manifest generation error in macos tmp folder

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Fix support for `react.entryFile` gradle config. ([#14934](https://github.com/expo/expo/pull/14934) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix Android app.manifest not generated when in OneSignal gradle plugin integration. ([#14938](https://github.com/expo/expo/pull/14938) by [@kudo](https://github.com/kudo))
 - Fix Android app.manifest not generated from [#14938](https://github.com/expo/expo/pull/14938) regression. ([#14953](https://github.com/expo/expo/pull/14953) by [@kudo](https://github.com/kudo))
+- Fix iOS app.manifest generation error in `eas build --local` mode. ([#14956](https://github.com/expo/expo/pull/14956) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-updates/scripts/create-manifest-ios.sh
+++ b/packages/expo-updates/scripts/create-manifest-ios.sh
@@ -37,11 +37,13 @@ if [ "x$PROJECT_DIR_BASENAME" != "xPods" ]; then
 fi
 
 # ref: https://github.com/facebook/react-native/blob/c974cbff04a8d90ac0f856dbada3fc5a75c75b49/scripts/react-native-xcode.sh#L59-L65
-EXPO_UPDATES_PACKAGE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+EXPO_UPDATES_PACKAGE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 # If PROJECT_ROOT is not specified, fallback to use Xcode PROJECT_DIR
 PROJECT_ROOT=${PROJECT_ROOT:-"$PROJECT_DIR/../.."}
 PROJECT_ROOT=${PROJECT_ROOT:-"$EXPO_UPDATES_PACKAGE_DIR/../.."}
 
 cd "$PROJECT_ROOT" || exit
+# We should get the physical path (/var/folders -> /private/var/folders) for metro to resolve correct files
+PROJECT_ROOT="$(pwd -P)"
 
 "$NODE_BINARY" "${EXPO_UPDATES_PACKAGE_DIR}/scripts/createManifest.js" ios "$PROJECT_ROOT" "$DEST/$RESOURCE_BUNDLE_NAME" "$ENTRY_FILE"


### PR DESCRIPTION
# Why

fix `eas build --local -p ios` #14951

the `${BASH_SOURCE[0]}` returns logical file path, e.g. `/var/folders/cx/877g5n014w5bxrgfsvfrljl00000gn/T/...`, where it does not follow symlink. on macos, `/var` is symlink to `/private/var`.
`pwd` by default also returns the logical file path.

on the other hand, metro uses jest-haste-map to resolve files and jest-haste-map uses watchman. watchman will follow symlink (logical -> physical), this will cause the metro resolver not able to find files.

```sh
$ mkdir /var/folders/cx/877g5n014w5bxrgfsvfrljl00000gn/T/test
$ watchman watch-project /var/folders/cx/877g5n014w5bxrgfsvfrljl00000gn/T/test
{
    "version": "2021.08.23.00",
    "watch": "/private/var/folders/cx/877g5n014w5bxrgfsvfrljl00000gn/T/test",
    "watcher": "fsevents"
}
$ watchman watch-list
{
    "version": "2021.08.23.00",
    "roots": [
        "/private/var/folders/cx/877g5n014w5bxrgfsvfrljl00000gn/T/test"
    ]
}
```
the requested path is `/var/folders/...` and watchman returns to `/private/var/folders/...`. the inconsistency makes the metro errors. 

# How

pass physical path to createManifest.js

# Test Plan

## eas local build flow

since eas local build will do prebuild and override expo-updates, it's hard to test with local change. a way to test is to patch files inside eas working dir.

1. `EAS_LOCAL_BUILD_SKIP_CLEANUP=1 eas build --local -p ios`
2. after the failure, find the workdir in /var/folders/... and patch `/var/folders/.../build/node_modules/expo-updates/scripts/create-manifest-ios.sh`
3. run xcodebuild manually.

## `expo run:ios` test

since the root cause is building from tmp folder, we can simulate the error from tmp folder.

```
$ mkdir /private/var/folders/cx/877g5n014w5bxrgfsvfrljl00000gn/T/test && cd /private/var/folders/cx/877g5n014w5bxrgfsvfrljl00000gn/T/test
$ expo init sdk43 # select bare minimal
$ cd sdk43
$ expo run:ios --configuration Release
# supposedly we can reproduce the same error
# patch `node_modules/expo-updates/scripts/create-manifest-ios.sh`
$ expo run:ios --configuration Release
# should works fine
``` 

## other workflows
test build project from $HOME/sdk43
test using xcode to build

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
