### PR TITLE
[sweet][ios] Implement sending events from native to JavaScript

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Method calls on iOS now can go through the JSI instead of the bridge (opt-in feature). ([#14626](https://github.com/expo/expo/pull/14626) by [@tsapeta](https://github.com/tsapeta))
 - `AppDelegateWrapper` is now written in Swift and is independent of the singleton modules. ([#14867](https://github.com/expo/expo/pull/14867) by [@tsapeta](https://github.com/tsapeta))
+- Implemented sending native events to JavaScript in Sweet API on iOS.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 - Method calls on iOS now can go through the JSI instead of the bridge (opt-in feature). ([#14626](https://github.com/expo/expo/pull/14626) by [@tsapeta](https://github.com/tsapeta))
 - `AppDelegateWrapper` is now written in Swift and is independent of the singleton modules. ([#14867](https://github.com/expo/expo/pull/14867) by [@tsapeta](https://github.com/tsapeta))
-- Implemented sending native events to JavaScript in Sweet API on iOS.
+- Implemented sending native events to JavaScript in Sweet API on iOS. ([#14958](https://github.com/expo/expo/pull/14958) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/ios/NativeModulesProxy/EXNativeModulesProxy.mm
+++ b/packages/expo-modules-core/ios/NativeModulesProxy/EXNativeModulesProxy.mm
@@ -274,8 +274,10 @@ RCT_EXPORT_METHOD(callMethod:(NSString *)moduleName methodNameOrKey:(id)methodNa
   // components in UIManager — we need to register them on our own.
   [self registerComponentDataForModuleClasses:additionalModuleClasses inBridge:bridge];
 
-  // Get the newly created instance of `EXReactEventEmitter` bridge module and register it in expo modules registry.
+  // Get the newly created instance of `EXReactEventEmitter` bridge module,
+  // pass event names supported by Swift modules and register it in legacy modules registry.
   EXReactNativeEventEmitter *eventEmitter = [bridge moduleForClass:[EXReactNativeEventEmitter class]];
+  [eventEmitter setSwiftInteropBridge:_swiftInteropBridge];
   [_exModuleRegistry registerInternalModule:eventEmitter];
 
   // Let the modules consume the registry :)

--- a/packages/expo-modules-core/ios/Services/EXReactNativeEventEmitter.h
+++ b/packages/expo-modules-core/ios/Services/EXReactNativeEventEmitter.h
@@ -7,6 +7,12 @@
 #import <ExpoModulesCore/EXModuleRegistryConsumer.h>
 #import <ExpoModulesCore/EXBridgeModule.h>
 
+// Swift compatibility headers (e.g. `ExpoModulesCore-Swift.h`) are not available in headers,
+// so we use class forward declaration here. Swift header must be imported in the `.m` file.
+@class SwiftInteropBridge;
+
 @interface EXReactNativeEventEmitter : RCTEventEmitter <EXInternalModule, EXBridgeModule, EXModuleRegistryConsumer, EXEventEmitterService>
+
+@property (nonatomic, strong) SwiftInteropBridge *swiftInteropBridge;
 
 @end

--- a/packages/expo-modules-core/ios/Swift/AppContext.swift
+++ b/packages/expo-modules-core/ios/Swift/AppContext.swift
@@ -72,6 +72,13 @@ public class AppContext {
   }
 
   /**
+   Provides access to the event emitter from legacy module registry.
+   */
+  public var eventEmitter: EXEventEmitterService? {
+    return legacyModule(implementing: EXEventEmitterService.self)
+  }
+
+  /**
    Starts listening to `UIApplication` notifications.
    */
   private func listenToClientAppNotifications() {

--- a/packages/expo-modules-core/ios/Swift/ModuleHolder.swift
+++ b/packages/expo-modules-core/ios/Swift/ModuleHolder.swift
@@ -26,6 +26,11 @@ public class ModuleHolder {
     return definition.name.isEmpty ? String(describing: type(of: module)) : definition.name
   }
 
+  /**
+   Number of JavaScript listeners attached to the module.
+   */
+  var listenersCount: Int = 0
+
   init(appContext: AppContext, module: AnyModule) {
     self.appContext = appContext
     self.module = module
@@ -68,7 +73,7 @@ public class ModuleHolder {
     return nil
   }
 
-  // MARK: Listening to events
+  // MARK: Listening to native events
 
   func listeners(forEvent event: EventName) -> [EventListener] {
     return definition.eventListeners.filter {
@@ -86,6 +91,20 @@ public class ModuleHolder {
     listeners(forEvent: event).forEach {
       try? $0.call(module, payload)
     }
+  }
+
+  // MARK: JavaScript events
+
+  /**
+   Modifies module's listeners count and calls `onStartObserving` or `onStopObserving` accordingly.
+   */
+  func modifyListenersCount(_ count: Int) {
+    if count > 0 && listenersCount == 0 {
+      let _ = definition.methods["startObserving"]?.callSync(args: [])
+    } else if count < 0 && listenersCount + count <= 0 {
+      let _ = definition.methods["stopObserving"]?.callSync(args: [])
+    }
+    listenersCount = max(0, listenersCount + count)
   }
 
   // MARK: Deallocation

--- a/packages/expo-modules-core/ios/Swift/Modules/Module.swift
+++ b/packages/expo-modules-core/ios/Swift/Modules/Module.swift
@@ -10,6 +10,13 @@ open class BaseModule {
   required public init(appContext: AppContext) {
     self.appContext = appContext
   }
+
+  /**
+   Sends an event with given name and body to JavaScript.
+   */
+  public func sendEvent(_ eventName: String, _ body: [String: Any?] = [:]) {
+    appContext?.eventEmitter?.sendEvent(withName: eventName, body: body)
+  }
 }
 
 /**

--- a/packages/expo-modules-core/ios/Swift/Modules/ModuleDefinition.swift
+++ b/packages/expo-modules-core/ios/Swift/Modules/ModuleDefinition.swift
@@ -26,6 +26,11 @@ public class ModuleDefinition: AnyDefinition {
   let viewManager: ViewManagerDefinition?
 
   /**
+   Names of the events that the module can send to JavaScript.
+   */
+  let eventNames: [String]
+
+  /**
    Initializer that is called by the `ModuleDefinitionBuilder` results builder.
    */
   init(definitions: [AnyDefinition]) {
@@ -51,6 +56,12 @@ public class ModuleDefinition: AnyDefinition {
     self.viewManager = definitions
       .compactMap { $0 as? ViewManagerDefinition }
       .last
+
+    self.eventNames = Array(
+      definitions
+        .compactMap { ($0 as? EventsDefinition)?.names }
+        .joined()
+    )
   }
 
   /**
@@ -80,4 +91,11 @@ internal struct ModuleNameDefinition: AnyDefinition {
  */
 internal struct ConstantsDefinition: AnyDefinition {
   let constants: [String : Any?]
+}
+
+/**
+ A definition for module's events that can be sent to JavaScript.
+ */
+internal struct EventsDefinition: AnyDefinition {
+  let names: [String]
 }

--- a/packages/expo-modules-core/ios/Swift/Modules/ModuleDefinitionComponents.swift
+++ b/packages/expo-modules-core/ios/Swift/Modules/ModuleDefinitionComponents.swift
@@ -205,6 +205,29 @@ extension AnyModule {
   public func viewManager(@ViewManagerDefinitionBuilder _ closure: @escaping () -> ViewManagerDefinition) -> AnyDefinition {
     return closure()
   }
+
+  // MARK: - Events
+
+  /**
+   Defines event names that this module can send to JavaScript.
+   */
+  public func events(_ names: String...) -> AnyDefinition {
+    return EventsDefinition(names: names)
+  }
+
+  /**
+   Method that is invoked when the first event listener is added.
+   */
+  public func onStartObserving(_ body: @escaping () -> ()) -> AnyMethod {
+    return ConcreteMethod("startObserving", argTypes: [], body)
+  }
+
+  /**
+   Method that is invoked when all event listeners are removed.
+   */
+  public func onStopObserving(_ body: @escaping () -> ()) -> AnyMethod {
+    return ConcreteMethod("stopObserving", argTypes: [], body)
+  }
 }
 
 /**

--- a/packages/expo-modules-core/ios/Swift/SwiftInteropBridge.swift
+++ b/packages/expo-modules-core/ios/Swift/SwiftInteropBridge.swift
@@ -91,4 +91,27 @@ public class SwiftInteropBridge: NSObject {
       }
     }
   }
+
+  // MARK: - Events
+
+  /**
+   Returns an array of event names supported by all Swift modules.
+   */
+  @objc
+  public func getSupportedEvents() -> [String] {
+    return registry.reduce(into: [String]()) { events, holder in
+      events.append(contentsOf: holder.definition.eventNames)
+    }
+  }
+
+  /**
+   Modifies listeners count for module with given name. Depending on the listeners count,
+   `onStartObserving` and `onStopObserving` are called.
+   */
+  @objc
+  public func modifyEventListenersCount(_ moduleName: String, count: Int) {
+    registry
+      .get(moduleHolderForName: moduleName)?
+      .modifyListenersCount(count)
+  }
 }


### PR DESCRIPTION
# Why

Sending events from native to JS was a missing piece in Sweet API on iOS in order to build modules such as `expo-clipboard`.

# How

Added new DSL components:
- `events` — takes a list of event names supported by the module, equivalent of `supportedEvents` in the old architecture.
- `onStartObserving` — called when JS starts listening to module's events, equivalent of `startObserving`.
- `onStopObserving` — called when JS removes the last listener from the module, equivalent of `stopObserving`.

Hooked into existing `EXReactNativeEventEmitter` so no JS changes were required.
# Test Plan

I've tested it as part of another PR that rewrites `expo-clipboard`: #14959
I'll add unit tests for that separately.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
