### PR TITLE
[sweet-api][kotlin] Add support for basic system events

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/ModuleRegistryAdapter.java
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/ModuleRegistryAdapter.java
@@ -12,7 +12,6 @@ import expo.modules.core.interfaces.InternalModule;
 import expo.modules.core.interfaces.Package;
 import expo.modules.kotlin.KotlinInteropModuleRegistry;
 
-import java.lang.annotation.Native;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/NativeModulesProxy.java
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/NativeModulesProxy.java
@@ -5,6 +5,7 @@ import android.util.SparseArray;
 import com.facebook.react.bridge.Dynamic;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableArray;
@@ -18,6 +19,7 @@ import expo.modules.kotlin.ExpoModulesHelper;
 import expo.modules.kotlin.KotlinInteropModuleRegistry;
 import expo.modules.kotlin.ModulesProvider;
 
+import java.lang.ref.WeakReference;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -59,7 +61,8 @@ public class NativeModulesProxy extends ReactContextBaseJavaModule {
 
     mKotlinInteropModuleRegistry = new KotlinInteropModuleRegistry(
       Objects.requireNonNull(ExpoModulesHelper.Companion.getModulesProvider()),
-      moduleRegistry
+      moduleRegistry,
+      new WeakReference<>(context)
     );
   }
 
@@ -71,7 +74,8 @@ public class NativeModulesProxy extends ReactContextBaseJavaModule {
 
     mKotlinInteropModuleRegistry = new KotlinInteropModuleRegistry(
       Objects.requireNonNull(modulesProvider),
-      moduleRegistry
+      moduleRegistry,
+      new WeakReference<>(context)
     );
   }
 
@@ -239,5 +243,6 @@ public class NativeModulesProxy extends ReactContextBaseJavaModule {
   @Override
   public void onCatalystInstanceDestroy() {
     mModuleRegistry.onDestroy();
+    mKotlinInteropModuleRegistry.onDestroy();
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
@@ -1,5 +1,8 @@
 package expo.modules.kotlin
 
+import com.facebook.react.bridge.LifecycleEventListener
+import com.facebook.react.bridge.ReactContext
+import expo.modules.core.interfaces.ActivityProvider
 import expo.modules.interfaces.barcodescanner.BarCodeScannerInterface
 import expo.modules.interfaces.camera.CameraViewInterface
 import expo.modules.interfaces.constants.ConstantsInterface
@@ -9,12 +12,21 @@ import expo.modules.interfaces.imageloader.ImageLoaderInterface
 import expo.modules.interfaces.permissions.Permissions
 import expo.modules.interfaces.sensors.SensorServiceInterface
 import expo.modules.interfaces.taskManager.TaskManagerInterface
+import expo.modules.kotlin.events.EventName
+import java.lang.ref.WeakReference
 
 class AppContext(
   modulesProvider: ModulesProvider,
-  val legacyModuleRegistry: expo.modules.core.ModuleRegistry
-) {
-  val registry = ModuleRegistry().register(modulesProvider)
+  val legacyModuleRegistry: expo.modules.core.ModuleRegistry,
+  val reactContext: WeakReference<ReactContext>
+) : LifecycleEventListener {
+  val registry = ModuleRegistry(WeakReference(this)).register(modulesProvider)
+
+  init {
+    requireNotNull(reactContext.get()) {
+      "The app context should be created with valid react context."
+    }.addLifecycleEventListener(this)
+  }
 
   /**
    * Returns a legacy module implementing given interface.
@@ -80,4 +92,27 @@ class AppContext(
    */
   val taskManager: TaskManagerInterface?
     get() = legacyModule()
+
+  /**
+   * Provides access to the activity provider from the legacy module registry
+   */
+  val activityProvider: ActivityProvider?
+    get() = legacyModule()
+
+  fun onDestroy() {
+    reactContext.get()?.removeLifecycleEventListener(this)
+    registry.post(EventName.MODULE_DESTROY)
+  }
+
+  override fun onHostResume() {
+    registry.post(EventName.APP_ENTERS_FOREGROUND)
+  }
+
+  override fun onHostPause() {
+    registry.post(EventName.APP_ENTERS_BACKGROUND)
+  }
+
+  override fun onHostDestroy() {
+    registry.post(EventName.ACTIVITY_DESTROY)
+  }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
@@ -113,6 +113,6 @@ class AppContext(
   }
 
   override fun onHostDestroy() {
-    registry.post(EventName.ACTIVITY_DESTROY)
+    registry.post(EventName.ACTIVITY_DESTROYS)
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
@@ -105,11 +105,11 @@ class AppContext(
   }
 
   override fun onHostResume() {
-    registry.post(EventName.APP_ENTERS_FOREGROUND)
+    registry.post(EventName.ACTIVITY_ENTERS_FOREGROUND)
   }
 
   override fun onHostPause() {
-    registry.post(EventName.APP_ENTERS_BACKGROUND)
+    registry.post(EventName.ACTIVITY_ENTERS_BACKGROUND)
   }
 
   override fun onHostDestroy() {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/KotlinInteropModuleRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/KotlinInteropModuleRegistry.kt
@@ -1,11 +1,13 @@
 package expo.modules.kotlin
 
+import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.uimanager.ViewManager
 import expo.modules.core.Promise
 import expo.modules.kotlin.views.GroupViewManagerWrapper
 import expo.modules.kotlin.views.SimpleViewManagerWrapper
 import expo.modules.kotlin.views.ViewManagerWrapperDelegate
+import java.lang.ref.WeakReference
 
 private typealias ModuleName = String
 private typealias ModuleConstants = Map<String, Any?>
@@ -13,9 +15,10 @@ private typealias ModuleMethodInfo = Map<String, Any?>
 
 class KotlinInteropModuleRegistry(
   modulesProvider: ModulesProvider,
-  legacyModuleRegistry: expo.modules.core.ModuleRegistry
+  legacyModuleRegistry: expo.modules.core.ModuleRegistry,
+  reactContext: WeakReference<ReactContext>
 ) {
-  private val appContext = AppContext(modulesProvider, legacyModuleRegistry)
+  private val appContext = AppContext(modulesProvider, legacyModuleRegistry, reactContext)
   private val exportedViewManagerNames = mutableListOf<String>()
 
   private val registry: ModuleRegistry
@@ -66,6 +69,10 @@ class KotlinInteropModuleRegistry(
   }
 
   fun exportedViewManagersNames(): List<String> = exportedViewManagerNames
+
+  fun onDestroy() {
+    appContext.onDestroy()
+  }
 
   private fun registerViewManagerWrapperDelegate(viewManagerWrapperDelegate: ViewManagerWrapperDelegate) {
     exportedViewManagerNames.add(viewManagerWrapperDelegate.name)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleHolder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleHolder.kt
@@ -3,6 +3,10 @@ package expo.modules.kotlin
 import com.facebook.react.bridge.ReadableArray
 import expo.modules.core.Promise
 import expo.modules.core.utilities.ifNull
+import expo.modules.kotlin.events.BasicEventListener
+import expo.modules.kotlin.events.EventListenerWithSender
+import expo.modules.kotlin.events.EventListenerWithSenderAndPayload
+import expo.modules.kotlin.events.EventName
 import expo.modules.kotlin.modules.Module
 
 class ModuleHolder(val module: Module) {
@@ -16,5 +20,22 @@ class ModuleHolder(val module: Module) {
     }
 
     method.call(args, promise)
+  }
+
+  fun post(eventName: EventName) {
+    val listener = definition.eventListeners[eventName] ?: return
+    (listener as? BasicEventListener)?.call()
+  }
+
+  @Suppress("UNCHECKED_CAST")
+  fun <Sender> post(eventName: EventName, sender: Sender) {
+    val listener = definition.eventListeners[eventName] ?: return
+    (listener as? EventListenerWithSender<Sender>)?.call(sender)
+  }
+
+  @Suppress("UNCHECKED_CAST")
+  fun <Sender, Payload> post(eventName: EventName, sender: Sender, payload: Payload) {
+    val listener = definition.eventListeners[eventName] ?: return
+    (listener as? EventListenerWithSenderAndPayload<Sender, Payload>)?.call(sender, payload)
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleRegistry.kt
@@ -1,12 +1,18 @@
 package expo.modules.kotlin
 
+import expo.modules.kotlin.events.EventName
 import expo.modules.kotlin.modules.Module
+import java.lang.ref.WeakReference
 
-class ModuleRegistry : Iterable<ModuleHolder> {
+class ModuleRegistry(
+  private val appContext: WeakReference<AppContext>
+) : Iterable<ModuleHolder> {
   private val registry = mutableMapOf<String, ModuleHolder>()
 
   fun register(module: Module) {
     val holder = ModuleHolder(module)
+    module._appContext = requireNotNull(appContext.get()) { "Cannot create a module for invalid app context." }
+    holder.post(EventName.MODULE_CREATE)
     registry[holder.name] = holder
   }
 
@@ -22,6 +28,26 @@ class ModuleRegistry : Iterable<ModuleHolder> {
   fun getModule(name: String): Module? = registry[name]?.module
 
   fun getModuleHolder(name: String): ModuleHolder? = registry[name]
+
+  fun post(eventName: EventName) {
+    iterator().forEach {
+      it.post(eventName)
+    }
+  }
+
+  @Suppress("UNCHECKED_CAST")
+  fun <Sender> post(eventName: EventName, sender: Sender) {
+    iterator().forEach {
+      it.post(eventName, sender)
+    }
+  }
+
+  @Suppress("UNCHECKED_CAST")
+  fun <Sender, Payload> post(eventName: EventName, sender: Sender, payload: Payload) {
+    iterator().forEach {
+      it.post(eventName, sender, payload)
+    }
+  }
 
   override fun iterator(): Iterator<ModuleHolder> = registry.values.iterator()
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/events/EventListener.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/events/EventListener.kt
@@ -1,0 +1,39 @@
+package expo.modules.kotlin.events
+
+sealed class EventListener(val eventName: EventName)
+
+/**
+ * Listener for events without sender and payload.
+ */
+class BasicEventListener(
+  eventName: EventName,
+  val body: () -> Unit
+) : EventListener(eventName) {
+  fun call() {
+    body()
+  }
+}
+
+/**
+ * Listener for events without payload.
+ */
+class EventListenerWithSender<Sender>(
+  eventName: EventName,
+  val body: (Sender) -> Unit
+) : EventListener(eventName) {
+  fun call(sender: Sender) {
+    body(sender)
+  }
+}
+
+/**
+ * Listener for events that specify sender and payload.
+ */
+class EventListenerWithSenderAndPayload<Sender, Payload>(
+  eventName: EventName,
+  val body: (Sender, Payload) -> Unit
+) : EventListener(eventName) {
+  fun call(sender: Sender, payload: Payload) {
+    body(sender, payload)
+  }
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/events/EventName.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/events/EventName.kt
@@ -1,0 +1,21 @@
+package expo.modules.kotlin.events
+
+enum class EventName {
+  MODULE_CREATE,
+  MODULE_DESTROY,
+
+  /**
+   * Called when the host activity receives a resume event (e.g. Activity.onResume)
+   */
+  APP_ENTERS_FOREGROUND,
+
+  /**
+   * Called when host activity receives pause event (e.g. Activity.onPause)
+   */
+  APP_ENTERS_BACKGROUND,
+
+  /**
+   * Called when host activity receives destroy event (e.g. Activity.onDestroy)
+   */
+  ACTIVITY_DESTROY
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/events/EventName.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/events/EventName.kt
@@ -7,12 +7,12 @@ enum class EventName {
   /**
    * Called when the host activity receives a resume event (e.g. Activity.onResume)
    */
-  APP_ENTERS_FOREGROUND,
+  ACTIVITY_ENTERS_FOREGROUND,
 
   /**
    * Called when host activity receives pause event (e.g. Activity.onPause)
    */
-  APP_ENTERS_BACKGROUND,
+  ACTIVITY_ENTERS_BACKGROUND,
 
   /**
    * Called when host activity receives destroy event (e.g. Activity.onDestroy)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/events/EventName.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/events/EventName.kt
@@ -17,5 +17,5 @@ enum class EventName {
   /**
    * Called when host activity receives destroy event (e.g. Activity.onDestroy)
    */
-  ACTIVITY_DESTROY
+  ACTIVITY_DESTROYS
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/Module.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/Module.kt
@@ -1,6 +1,13 @@
 package expo.modules.kotlin.modules
 
+import expo.modules.kotlin.AppContext
+
 abstract class Module {
+  internal var _appContext: AppContext? = null
+
+  val appContext: AppContext
+    get() = requireNotNull(_appContext) { "The module wasn't created! You can't access the app context." }
+
   abstract fun definition(): ModuleDefinition
 }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinition.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinition.kt
@@ -1,5 +1,7 @@
 package expo.modules.kotlin.modules
 
+import expo.modules.kotlin.events.EventListener
+import expo.modules.kotlin.events.EventName
 import expo.modules.kotlin.methods.AnyMethod
 import expo.modules.kotlin.views.ViewManagerDefinition
 
@@ -7,5 +9,6 @@ class ModuleDefinition(
   val name: String,
   val constantsProvider: () -> Map<String, Any?>,
   val methods: Map<String, AnyMethod>,
-  val viewManagerDefinition: ViewManagerDefinition? = null
+  val viewManagerDefinition: ViewManagerDefinition? = null,
+  val eventListeners: Map<EventName, EventListener> = emptyMap()
 )

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinitionBuilder.kt
@@ -118,12 +118,12 @@ class ModuleDefinitionBuilder {
     eventListeners[EventName.MODULE_DESTROY] = BasicEventListener(EventName.MODULE_DESTROY) { body() }
   }
 
-  inline fun onAppEntersForeground(crossinline body: () -> Unit) {
-    eventListeners[EventName.APP_ENTERS_FOREGROUND] = BasicEventListener(EventName.APP_ENTERS_FOREGROUND) { body() }
+  inline fun onActivityEntersForeground(crossinline body: () -> Unit) {
+    eventListeners[EventName.ACTIVITY_ENTERS_FOREGROUND] = BasicEventListener(EventName.ACTIVITY_ENTERS_FOREGROUND) { body() }
   }
 
-  inline fun onAppEntersBackground(crossinline body: () -> Unit) {
-    eventListeners[EventName.APP_ENTERS_BACKGROUND] = BasicEventListener(EventName.APP_ENTERS_BACKGROUND) { body() }
+  inline fun onActivityEntersBackground(crossinline body: () -> Unit) {
+    eventListeners[EventName.ACTIVITY_ENTERS_BACKGROUND] = BasicEventListener(EventName.ACTIVITY_ENTERS_BACKGROUND) { body() }
   }
 
   inline fun onActivityDestroy(crossinline body: () -> Unit) {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinitionBuilder.kt
@@ -126,7 +126,7 @@ class ModuleDefinitionBuilder {
     eventListeners[EventName.ACTIVITY_ENTERS_BACKGROUND] = BasicEventListener(EventName.ACTIVITY_ENTERS_BACKGROUND) { body() }
   }
 
-  inline fun onActivityDestroy(crossinline body: () -> Unit) {
-    eventListeners[EventName.ACTIVITY_DESTROY] = BasicEventListener(EventName.ACTIVITY_DESTROY) { body() }
+  inline fun onActivityDestroys(crossinline body: () -> Unit) {
+    eventListeners[EventName.ACTIVITY_DESTROYS] = BasicEventListener(EventName.ACTIVITY_DESTROYS) { body() }
   }
 }

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/KotlinInteropModuleRegistryTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/KotlinInteropModuleRegistryTest.kt
@@ -5,6 +5,7 @@ import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.module
 import io.mockk.mockk
 import org.junit.Test
+import java.lang.ref.WeakReference
 
 class DummyModule_1 : Module() {
   override fun definition() = module {
@@ -39,7 +40,11 @@ val provider = object : ModulesProvider {
 class KotlinInteropModuleRegistryTest {
   @Test
   fun `should register modules from provider`() {
-    val interopModuleRegistry = KotlinInteropModuleRegistry(provider, mockk())
+    val interopModuleRegistry = KotlinInteropModuleRegistry(
+      provider,
+      mockk(),
+      WeakReference(mockk(relaxed = true))
+    )
 
     interopModuleRegistry.hasModule("dummy-1")
     interopModuleRegistry.hasModule("dummy-2")
@@ -47,7 +52,11 @@ class KotlinInteropModuleRegistryTest {
 
   @Test
   fun `should export constants`() {
-    val interopModuleRegistry = KotlinInteropModuleRegistry(provider, mockk())
+    val interopModuleRegistry = KotlinInteropModuleRegistry(
+      provider,
+      mockk(),
+      WeakReference(mockk(relaxed = true))
+    )
 
     Truth.assertThat(interopModuleRegistry.exportedModulesConstants())
       .containsExactly(
@@ -58,7 +67,11 @@ class KotlinInteropModuleRegistryTest {
 
   @Test
   fun `should export view manages`() {
-    val interopModuleRegistry = KotlinInteropModuleRegistry(provider, mockk())
+    val interopModuleRegistry = KotlinInteropModuleRegistry(
+      provider,
+      mockk(),
+      WeakReference(mockk(relaxed = true))
+    )
 
     val rnManagers = interopModuleRegistry.exportViewManagers()
     val expoManagersNames = interopModuleRegistry.exportedViewManagersNames()

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/ModuleRegistryTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/ModuleRegistryTest.kt
@@ -3,8 +3,10 @@ package expo.modules.kotlin
 import com.google.common.truth.Truth
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.module
+import io.mockk.mockk
 import org.junit.Assert
 import org.junit.Test
+import java.lang.ref.WeakReference
 
 class M1 : Module() {
   override fun definition() = module {
@@ -27,7 +29,7 @@ class ModuleRegistryTest {
         return listOf(M1::class.java, M2::class.java)
       }
     }
-    val moduleRegistry = ModuleRegistry()
+    val moduleRegistry = ModuleRegistry(WeakReference(mockk()))
 
     moduleRegistry.register(provider)
 
@@ -51,7 +53,7 @@ class ModuleRegistryTest {
         return listOf(IncorrectModule::class.java)
       }
     }
-    val moduleRegistry = ModuleRegistry()
+    val moduleRegistry = ModuleRegistry(mockk())
 
     try {
       moduleRegistry.register(provider)

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/modules/ModuleDefinitionBuilderTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/modules/ModuleDefinitionBuilderTest.kt
@@ -2,6 +2,7 @@ package expo.modules.kotlin.modules
 
 import com.google.common.truth.Truth
 import expo.modules.core.Promise
+import expo.modules.kotlin.events.EventName
 import io.mockk.mockk
 import org.junit.Assert
 import org.junit.Test
@@ -54,5 +55,26 @@ class ModuleDefinitionBuilderTest {
 
     Truth.assertThat(moduleDefinition.name).isEqualTo(moduleName)
     Truth.assertThat(moduleDefinition.viewManagerDefinition).isNotNull()
+  }
+
+  @Test
+  fun `builder should respect events`() {
+    val moduleName = "Module"
+
+    val moduleDefinition = module {
+      name(moduleName)
+      onCreate { }
+      onDestroy { }
+      onActivityDestroy {  }
+      onAppEntersForeground {  }
+      onAppEntersBackground {  }
+    }
+
+    Truth.assertThat(moduleDefinition.name).isEqualTo(moduleName)
+    Truth.assertThat(moduleDefinition.eventListeners[EventName.MODULE_CREATE]).isNotNull()
+    Truth.assertThat(moduleDefinition.eventListeners[EventName.MODULE_DESTROY]).isNotNull()
+    Truth.assertThat(moduleDefinition.eventListeners[EventName.APP_ENTERS_FOREGROUND]).isNotNull()
+    Truth.assertThat(moduleDefinition.eventListeners[EventName.APP_ENTERS_BACKGROUND]).isNotNull()
+    Truth.assertThat(moduleDefinition.eventListeners[EventName.ACTIVITY_DESTROY]).isNotNull()
   }
 }

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/modules/ModuleDefinitionBuilderTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/modules/ModuleDefinitionBuilderTest.kt
@@ -65,16 +65,16 @@ class ModuleDefinitionBuilderTest {
       name(moduleName)
       onCreate { }
       onDestroy { }
-      onActivityDestroy {  }
-      onAppEntersForeground {  }
-      onAppEntersBackground {  }
+      onActivityDestroy { }
+      onActivityEntersForeground { }
+      onActivityEntersBackground { }
     }
 
     Truth.assertThat(moduleDefinition.name).isEqualTo(moduleName)
     Truth.assertThat(moduleDefinition.eventListeners[EventName.MODULE_CREATE]).isNotNull()
     Truth.assertThat(moduleDefinition.eventListeners[EventName.MODULE_DESTROY]).isNotNull()
-    Truth.assertThat(moduleDefinition.eventListeners[EventName.APP_ENTERS_FOREGROUND]).isNotNull()
-    Truth.assertThat(moduleDefinition.eventListeners[EventName.APP_ENTERS_BACKGROUND]).isNotNull()
+    Truth.assertThat(moduleDefinition.eventListeners[EventName.ACTIVITY_ENTERS_FOREGROUND]).isNotNull()
+    Truth.assertThat(moduleDefinition.eventListeners[EventName.ACTIVITY_ENTERS_BACKGROUND]).isNotNull()
     Truth.assertThat(moduleDefinition.eventListeners[EventName.ACTIVITY_DESTROY]).isNotNull()
   }
 }

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/modules/ModuleDefinitionBuilderTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/modules/ModuleDefinitionBuilderTest.kt
@@ -65,7 +65,7 @@ class ModuleDefinitionBuilderTest {
       name(moduleName)
       onCreate { }
       onDestroy { }
-      onActivityDestroy { }
+      onActivityDestroys { }
       onActivityEntersForeground { }
       onActivityEntersBackground { }
     }
@@ -75,6 +75,6 @@ class ModuleDefinitionBuilderTest {
     Truth.assertThat(moduleDefinition.eventListeners[EventName.MODULE_DESTROY]).isNotNull()
     Truth.assertThat(moduleDefinition.eventListeners[EventName.ACTIVITY_ENTERS_FOREGROUND]).isNotNull()
     Truth.assertThat(moduleDefinition.eventListeners[EventName.ACTIVITY_ENTERS_BACKGROUND]).isNotNull()
-    Truth.assertThat(moduleDefinition.eventListeners[EventName.ACTIVITY_DESTROY]).isNotNull()
+    Truth.assertThat(moduleDefinition.eventListeners[EventName.ACTIVITY_DESTROYS]).isNotNull()
   }
 }

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/modules/ModuleHolderTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/modules/ModuleHolderTest.kt
@@ -1,0 +1,31 @@
+package expo.modules.kotlin.modules
+
+import com.google.common.truth.Truth
+import expo.modules.kotlin.ModuleHolder
+import expo.modules.kotlin.events.EventName
+import org.junit.Test
+
+class ModuleHolderTest {
+
+  @Test
+  fun `holder should pass events to module`() {
+    var onCreateCalls = 0
+    var onDestroyCalls = 0
+
+    class MyModule : Module() {
+      override fun definition() = module {
+        name("my-module")
+        onCreate { onCreateCalls++ }
+        onDestroy { onDestroyCalls++ }
+      }
+    }
+
+    val holder = ModuleHolder(MyModule())
+
+    holder.post(EventName.MODULE_CREATE)
+    holder.post(EventName.MODULE_DESTROY)
+
+    Truth.assertThat(onCreateCalls).isEqualTo(1)
+    Truth.assertThat(onDestroyCalls).isEqualTo(1)
+  }
+}


### PR DESCRIPTION
# Why

Adds support for basic commonly used system events like `onCreate`, or `onAppEntersBackground`.

# How

- AppContext became an RN's lifecycle listener.
- Added basic abstraction over event listeners  (note: not every type is used right now, but will be in following PRs)
- Extends DSL language to support new functions.  

# Test Plan

- unit tests ✅