### PR TITLE
[sweet-api][kotlin] Use type converter to convert props

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/AnyViewProp.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/AnyViewProp.kt
@@ -1,9 +1,10 @@
 package expo.modules.kotlin.views
 
 import android.view.View
+import com.facebook.react.bridge.Dynamic
 
 abstract class AnyViewProp(
   val name: String
 ) {
-  abstract fun set(prop: Any?, onView: View)
+  abstract fun set(prop: Dynamic, onView: View)
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ConcreteViewProp.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ConcreteViewProp.kt
@@ -1,15 +1,18 @@
 package expo.modules.kotlin.views
 
 import android.view.View
+import com.facebook.react.bridge.Dynamic
+import expo.modules.kotlin.types.TypeConverterHelper
+import kotlin.reflect.KType
 
 class ConcreteViewProp<ViewType : View, PropType>(
   name: String,
-  private val setter: (view: ViewType, prop: PropType) -> Unit
+  private val propType: KType,
+  private val setter: (view: ViewType, prop: PropType) -> Unit,
 ) : AnyViewProp(name) {
 
   @Suppress("UNCHECKED_CAST")
-  override fun set(prop: Any?, onView: View) {
-    // TODO(@lukmccall): use TypeConverterHelper to convert types
-    setter(onView as ViewType, prop as PropType)
+  override fun set(prop: Dynamic, onView: View) {
+    setter(onView as ViewType, TypeConverterHelper.convert(prop, propType) as PropType)
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerDefinition.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerDefinition.kt
@@ -23,9 +23,11 @@ class ViewManagerDefinition(
   }
 
   fun setProps(propsToSet: ReadableMap, onView: View) {
-    for ((propName, prop) in propsToSet.entryIterator) {
-      val propDelegate = props[propName] ?: continue
-      propDelegate.set(prop, onView)
+    val iterator = propsToSet.keySetIterator()
+    while (iterator.hasNextKey()) {
+      val key = iterator.nextKey()
+      val propDelegate = props[key] ?: continue
+      propDelegate.set(propsToSet.getDynamic(key), onView)
     }
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerDefinitionBuilder.kt
@@ -1,7 +1,10 @@
+@file:OptIn(ExperimentalStdlibApi::class)
+
 package expo.modules.kotlin.views
 
 import android.content.Context
 import android.view.View
+import kotlin.reflect.typeOf
 
 class ViewManagerDefinitionBuilder {
   @PublishedApi
@@ -29,6 +32,7 @@ class ViewManagerDefinitionBuilder {
   ) {
     props[name] = ConcreteViewProp(
       name,
+      typeOf<PropType>(),
       body
     )
   }

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/views/ConcreteViewPropTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/views/ConcreteViewPropTest.kt
@@ -1,9 +1,16 @@
+@file:OptIn(ExperimentalStdlibApi::class)
+
 package expo.modules.kotlin.views
 
 import android.view.View
+import com.facebook.react.bridge.DynamicFromObject
+import com.facebook.react.bridge.JavaOnlyMap
 import com.google.common.truth.Truth
+import expo.modules.kotlin.records.Field
+import expo.modules.kotlin.records.Record
 import io.mockk.mockk
 import org.junit.Test
+import kotlin.reflect.typeOf
 
 class ConcreteViewPropTest {
   @Test
@@ -12,14 +19,45 @@ class ConcreteViewPropTest {
     var providedValue = -1
     var providedView: View? = null
 
-    val prop = ConcreteViewProp<View, Int>("name") { view, value ->
+    val prop = ConcreteViewProp<View, Int>("name", typeOf<Int>()) { view, value ->
       providedValue = value
       providedView = view
     }
 
-    prop.set(10, mockedView)
+    prop.set(DynamicFromObject(10.0), mockedView)
 
     Truth.assertThat(providedValue).isEqualTo(10)
     Truth.assertThat(providedView).isSameInstanceAs(mockedView)
+  }
+
+  @Test
+  fun `should be able to convert records`() {
+    class MyRecord : Record {
+      @Field
+      lateinit var id: String
+
+      @Field
+      lateinit var name: String
+    }
+
+    val mockedView = mockk<View>()
+    var providedValue: MyRecord? = null
+
+    val prop = ConcreteViewProp<View, MyRecord>("name", typeOf<MyRecord>()) { _, value ->
+      providedValue = value
+    }
+
+    prop.set(
+      DynamicFromObject(
+        JavaOnlyMap().apply {
+          putString("id", "1234")
+          putString("name", "name")
+        }
+      ),
+      mockedView
+    )
+
+    Truth.assertThat(providedValue?.id).isEqualTo("1234")
+    Truth.assertThat(providedValue?.name).isEqualTo("name")
   }
 }


### PR DESCRIPTION
# Why

Uses type converter to convert props. 

# Test Plan

- unit tests ✅