### PR TITLE
use a more specific variable name for the expo-camera gradle plugin

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 💡 Others
 
 - Rewrite module to Kotlin. ([#14717](https://github.com/expo/expo/pull/14717) by [@mstach60161](https://github.com/mstach60161))
+- [plugin] Use more specific gradle variable name. ([#14966](https://github.com/expo/expo/pull/14966) by [@EvanBacon](https://github.com/EvanBacon))
 
 ## 12.0.1 — 2021-10-01
 

--- a/packages/expo-camera/plugin/build/withCamera.js
+++ b/packages/expo-camera/plugin/build/withCamera.js
@@ -10,11 +10,11 @@ const MICROPHONE_USAGE = 'Allow $(PRODUCT_NAME) to access your microphone';
 // It's ok to have multiple allprojects.repositories, so we create a new one since it's cheaper than tokenizing
 // the existing block to find the correct place to insert our camera maven.
 const gradleMaven = [
-    `def mavenPath = new File(["node", "--print", "require.resolve('expo-camera/package.json')"].execute().text.trim(), "../android/maven")`,
-    `allprojects { repositories { maven { url(mavenPath) } } }`,
+    `def expoCameraMavenPath = new File(["node", "--print", "require.resolve('expo-camera/package.json')"].execute().text.trim(), "../android/maven")`,
+    `allprojects { repositories { maven { url(expoCameraMavenPath) } } }`,
 ].join('\n');
 const withAndroidCameraGradle = (config) => {
-    return config_plugins_1.withProjectBuildGradle(config, (config) => {
+    return (0, config_plugins_1.withProjectBuildGradle)(config, (config) => {
         if (config.modResults.language === 'groovy') {
             config.modResults.contents = addCameraImport(config.modResults.contents).contents;
         }
@@ -35,10 +35,10 @@ function addCameraImport(src) {
 exports.addCameraImport = addCameraImport;
 // Fork of config-plugins mergeContents, but appends the contents to the end of the file.
 function appendContents({ src, newSrc, tag, comment, }) {
-    const header = generateCode_1.createGeneratedHeaderComment(newSrc, tag, comment);
+    const header = (0, generateCode_1.createGeneratedHeaderComment)(newSrc, tag, comment);
     if (!src.includes(header)) {
         // Ensure the old generated contents are removed.
-        const sanitizedTarget = generateCode_1.removeGeneratedContents(src, tag);
+        const sanitizedTarget = (0, generateCode_1.removeGeneratedContents)(src, tag);
         const contentsToAdd = [
             // @something
             header,
@@ -56,7 +56,7 @@ function appendContents({ src, newSrc, tag, comment, }) {
     return { contents: src, didClear: false, didMerge: false };
 }
 const withCamera = (config, { cameraPermission, microphonePermission } = {}) => {
-    config = config_plugins_1.withInfoPlist(config, (config) => {
+    config = (0, config_plugins_1.withInfoPlist)(config, (config) => {
         config.modResults.NSCameraUsageDescription =
             cameraPermission || config.modResults.NSCameraUsageDescription || CAMERA_USAGE;
         config.modResults.NSMicrophoneUsageDescription =
@@ -70,4 +70,4 @@ const withCamera = (config, { cameraPermission, microphonePermission } = {}) => 
     ]);
     return withAndroidCameraGradle(config);
 };
-exports.default = config_plugins_1.createRunOncePlugin(withCamera, pkg.name, pkg.version);
+exports.default = (0, config_plugins_1.createRunOncePlugin)(withCamera, pkg.name, pkg.version);

--- a/packages/expo-camera/plugin/src/__tests__/__snapshots__/withCamera-test.ts.snap
+++ b/packages/expo-camera/plugin/src/__tests__/__snapshots__/withCamera-test.ts.snap
@@ -32,8 +32,8 @@ allprojects {
         maven { url 'https://www.jitpack.io' }
     }
 }
-// @generated begin expo-camera-import - expo prebuild (DO NOT MODIFY) sync-6f8efa4e48bf2b9e71b6c79aa2482b44d24d5e43
-def mavenPath = new File([\\"node\\", \\"--print\\", \\"require.resolve('expo-camera/package.json')\\"].execute().text.trim(), \\"../android/maven\\")
-allprojects { repositories { maven { url(mavenPath) } } }
+// @generated begin expo-camera-import - expo prebuild (DO NOT MODIFY) sync-3759ae8612e1220a5ed4b916e93faa7a72d11968
+def expoCameraMavenPath = new File([\\"node\\", \\"--print\\", \\"require.resolve('expo-camera/package.json')\\"].execute().text.trim(), \\"../android/maven\\")
+allprojects { repositories { maven { url(expoCameraMavenPath) } } }
 // @generated end expo-camera-import"
 `;

--- a/packages/expo-camera/plugin/src/withCamera.ts
+++ b/packages/expo-camera/plugin/src/withCamera.ts
@@ -20,8 +20,8 @@ const MICROPHONE_USAGE = 'Allow $(PRODUCT_NAME) to access your microphone';
 // It's ok to have multiple allprojects.repositories, so we create a new one since it's cheaper than tokenizing
 // the existing block to find the correct place to insert our camera maven.
 const gradleMaven = [
-  `def mavenPath = new File(["node", "--print", "require.resolve('expo-camera/package.json')"].execute().text.trim(), "../android/maven")`,
-  `allprojects { repositories { maven { url(mavenPath) } } }`,
+  `def expoCameraMavenPath = new File(["node", "--print", "require.resolve('expo-camera/package.json')"].execute().text.trim(), "../android/maven")`,
+  `allprojects { repositories { maven { url(expoCameraMavenPath) } } }`,
 ].join('\n');
 
 const withAndroidCameraGradle: ConfigPlugin = (config) => {


### PR DESCRIPTION
# Why

- squatting a common variable name
- code gen should ensure it updates nicely
- tests are updated
