### PR TITLE
[jest-expo] update and simplify `transformIgnorePatters`

### DIFF
--- a/docs/pages/guides/testing-with-jest.md
+++ b/docs/pages/guides/testing-with-jest.md
@@ -40,7 +40,7 @@ We would like to point out [transformIgnorePatterns](https://jestjs.io/docs/conf
 "jest": {
   "preset": "jest-expo",
   "transformIgnorePatterns": [
-    "node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg)",
+    "node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg)"
   ]
 }
 ```

--- a/packages/jest-expo/jest-preset.js
+++ b/packages/jest-expo/jest-preset.js
@@ -38,7 +38,7 @@ if (!Array.isArray(jestPreset.transformIgnorePatterns)) {
 
 // Also please keep `testing-with-jest.md` file up to date
 jestPreset.transformIgnorePatterns = [
-  'node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg)',
+  'node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg)',
 ];
 
 // setupFiles


### PR DESCRIPTION
# Why

Fixes #14526

# How

This PR updates and simplifies `transformIgnorePatters` in `jest-expo` package and on the docs page.

It look like the to unescaped `/` was a reason why `@expo-google-fonts` did not match the current RegExp, so I have decided to simplify the matchers so they match Expo packages with `/` in the name as well as those one starting with `@`. The same simplification have been also added to the `react-navigation` and `unimodules` cases.

If you think that RegExp changes introduce too broad matches, let me know, I can revert them and add  special case for the `@expo-google-fonts` package.

# Test Plan

The RegExp changes have been test using https://regexr.com/ and I have use the basic example from https://docs.expo.dev/guides/using-custom-fonts/#using-custom-fonts to test the changes in local project. 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
