### PR TITLE
fix: crash on launch for incomplete OTA

### DIFF
--- a/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesAppLauncherWithDatabase.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesAppLauncherWithDatabase.m
@@ -260,8 +260,12 @@ static NSString * const EXUpdatesAppLauncherErrorDomain = @"AppLauncher";
     }
 
     if (matchingAsset && matchingAsset.mainBundleFilename) {
+      NSString *bundlePath = [[NSBundle mainBundle] pathForResource:matchingAsset.mainBundleFilename ofType:matchingAsset.type];
+      if (bundlePath == nil) {
+        completion(NO, nil);
+        return;
+      }
       dispatch_async([EXUpdatesFileDownloader assetFilesQueue], ^{
-        NSString *bundlePath = [[NSBundle mainBundle] pathForResource:matchingAsset.mainBundleFilename ofType:matchingAsset.type];
         NSError *error;
         BOOL success = [NSFileManager.defaultManager copyItemAtPath:bundlePath toPath:[assetLocalUrl path] error:&error];
         dispatch_async(self->_launcherQueue, ^{


### PR DESCRIPTION
Fixes #14930 

This does not fix the root cause of this issue but rather just adding a defend code around this case.

still, I think this change make sense on itself as well.
