### PR TITLE
[sweet][ios] Make some common types convertible

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Method calls on iOS now can go through the JSI instead of the bridge (opt-in feature). ([#14626](https://github.com/expo/expo/pull/14626) by [@tsapeta](https://github.com/tsapeta))
 - `AppDelegateWrapper` is now written in Swift and is independent of the singleton modules. ([#14867](https://github.com/expo/expo/pull/14867) by [@tsapeta](https://github.com/tsapeta))
 - Implemented sending native events to JavaScript in Sweet API on iOS. ([#14958](https://github.com/expo/expo/pull/14958) by [@tsapeta](https://github.com/tsapeta))
+- [Sweet API] Introduced Convertibles on iOS — a way to use custom types as method arguments if they can be converted from JavaScript values. Provided implementation for some common CoreGraphics types. ([#14988](https://github.com/expo/expo/pull/14988) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/ios/Swift/Arguments/ConvertibleArgument.swift
+++ b/packages/expo-modules-core/ios/Swift/Arguments/ConvertibleArgument.swift
@@ -1,0 +1,15 @@
+// Copyright 2018-present 650 Industries. All rights reserved.
+
+/**
+ A protocol that allows custom classes or structs to be used as method arguments.
+ It requires static `convert(from:)` function that knows how to convert incoming
+ value of `Any` type to the type implemented by this protocol. It should throw an error
+ when the value is not recognized, is invalid or doesn't meet type requirements.
+ */
+public protocol ConvertibleArgument: AnyMethodArgument {
+  /**
+   Converts any value to the instance of its class (or struct).
+   Throws an error when given value cannot be converted.
+   */
+  static func convert(from value: Any?) throws -> Self
+}

--- a/packages/expo-modules-core/ios/Swift/Arguments/Convertibles.swift
+++ b/packages/expo-modules-core/ios/Swift/Arguments/Convertibles.swift
@@ -1,0 +1,93 @@
+// Copyright 2018-present 650 Industries. All rights reserved.
+
+import UIKit
+import CoreGraphics
+
+/// Here we extend some common iOS types to implement `ConvertibleArgument` protocol and
+/// describe how they can be converted from primitive types received from JavaScript runtime.
+/// This allows these types to be used as argument types of functions callable from JavaScript.
+/// As an example, when the `CGPoint` type is used as an argument type, its instance can be
+/// created from an array of two doubles or an object with `x` and `y` fields.
+
+// MARK: - UIKit
+
+extension UIColor: ConvertibleArgument {
+  public static func convert(from value: Any?) throws -> Self {
+    if let value = value as? String {
+      return try Conversions.toColor(hexString: value) as! Self
+    }
+    if let components = value as? [Double] {
+      let alpha = components.count > 3 ? components[3] : 1.0
+      return Self.init(red: components[0], green: components[1], blue: components[2], alpha: alpha)
+    }
+    if let value = value as? Int {
+      return try Conversions.toColor(argb: UInt64(value)) as! Self
+    }
+    throw Conversions.ConvertingError<UIColor>(value: value)
+  }
+}
+
+// MARK: - CoreGraphics
+
+extension CGPoint: ConvertibleArgument {
+  public static func convert(from value: Any?) throws -> CGPoint {
+    if let value = value as? [Double], value.count == 2 {
+      return CGPoint(x: value[0], y: value[1])
+    }
+    if let value = value as? [String: Any] {
+      let args = try Conversions.pickValues(from: value, byKeys: ["x", "y"], as: Double.self)
+      return CGPoint(x: args[0], y: args[1])
+    }
+    throw Conversions.ConvertingError<CGPoint>(value: value)
+  }
+}
+
+extension CGSize: ConvertibleArgument {
+  public static func convert(from value: Any?) throws -> CGSize {
+    if let value = value as? [Double], value.count == 2 {
+      return CGSize(width: value[0], height: value[1])
+    }
+    if let value = value as? [String: Any] {
+      let args = try Conversions.pickValues(from: value, byKeys: ["width", "height"], as: Double.self)
+      return CGSize(width: args[0], height: args[1])
+    }
+    throw Conversions.ConvertingError<CGSize>(value: value)
+  }
+}
+
+extension CGVector: ConvertibleArgument {
+  public static func convert(from value: Any?) throws -> CGVector {
+    if let value = value as? [Double], value.count == 2 {
+      return CGVector(dx: value[0], dy: value[1])
+    }
+    if let value = value as? [String: Any] {
+      let args = try Conversions.pickValues(from: value, byKeys: ["dx", "dy"], as: Double.self)
+      return CGVector(dx: args[0], dy: args[1])
+    }
+    throw Conversions.ConvertingError<CGVector>(value: value)
+  }
+}
+
+extension CGRect: ConvertibleArgument {
+  public static func convert(from value: Any?) throws -> CGRect {
+    if let value = value as? [Double], value.count == 4 {
+      return CGRect(x: value[0], y: value[1], width: value[2], height: value[3])
+    }
+    if let value = value as? [String: Any] {
+      let args = try Conversions.pickValues(from: value, byKeys: ["x", "y", "width", "height"], as: Double.self)
+      return CGRect(x: args[0], y: args[1], width: args[2], height: args[3])
+    }
+    throw Conversions.ConvertingError<CGRect>(value: value)
+  }
+}
+
+extension CGColor: ConvertibleArgument {
+  public static func convert(from value: Any?) throws -> Self {
+    do {
+      return try UIColor.convert(from: value).cgColor as! Self
+    } catch _ as Conversions.ConvertingError<UIColor> {
+      // Rethrow `ConvertingError` with proper type
+      throw Conversions.ConvertingError<CGColor>(value: value)
+    }
+  }
+}

--- a/packages/expo-modules-core/ios/Swift/Conversions.swift
+++ b/packages/expo-modules-core/ios/Swift/Conversions.swift
@@ -31,12 +31,170 @@ internal class Conversions {
       throw TooManyArgumentsError(count: array.count, limit: 10)
     }
   }
-}
 
-internal struct TooManyArgumentsError: CodedError {
-  let count: Int
-  let limit: Int
-  var description: String {
-    "A number of arguments `\(count)` exceeds the limit of `\(limit)`"
+  /**
+   Picks values under given keys from the dictionary, casted to a specific type. Can throw errors when
+   - The dictionary is missing some of the given keys (`MissingKeysError`)
+   - Some of the values cannot be casted to specified type (`CastingValuesError`)
+   */
+  static func pickValues<ValueType>(from dict: [String: Any], byKeys keys: [String], as type: ValueType.Type) throws -> [ValueType] {
+    var result = (
+      values: [ValueType](),
+      missingKeys: [String](),
+      invalidKeys: [String]()
+    )
+
+    for key in keys {
+      if dict[key] == nil {
+        result.missingKeys.append(key)
+      }
+      if let value = dict[key] as? ValueType {
+        result.values.append(value)
+      } else {
+        result.invalidKeys.append(key)
+      }
+    }
+    if result.missingKeys.count > 0 {
+      throw MissingKeysError<ValueType>(keys: result.missingKeys)
+    }
+    if result.invalidKeys.count > 0 {
+      throw CastingValuesError<ValueType>(keys: result.invalidKeys)
+    }
+    return result.values
+  }
+
+  /**
+   Converts hex string to `UIColor` or throws an error if the string is corrupted.
+   */
+  static func toColor(hexString hex: String) throws -> UIColor {
+    var hexStr = hex
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+      .replacingOccurrences(of: "#", with: "")
+
+    // If just RGB, set alpha to maximum
+    if hexStr.count == 6 { hexStr += "FF" }
+    if hexStr.count == 3 { hexStr += "F" }
+
+    // Expand short form (supported by Web)
+    if hexStr.count == 4 {
+      let chars = Array(hexStr)
+      hexStr = [
+        String(repeating: chars[0], count: 2),
+        String(repeating: chars[1], count: 2),
+        String(repeating: chars[2], count: 2),
+        String(repeating: chars[3], count: 2)
+      ].joined(separator: "")
+    }
+
+    var rgba: UInt64 = 0
+
+    guard hexStr.range(of: #"^[0-9a-fA-F]{8}$"#, options: .regularExpression) != nil,
+          Scanner(string: hexStr).scanHexInt64(&rgba) else {
+      throw InvalidHexColorError(hex: hex)
+    }
+    return try toColor(rgba: rgba)
+  }
+
+  /**
+   Converts an integer for ARGB color to `UIColor`. Since the alpha channel is represented by first 8 bits,
+   it's optional out of the box. React Native converts colors to such format.
+   */
+  static func toColor(argb: UInt64) throws -> UIColor {
+    guard argb <= UInt32.max else {
+      throw HexColorOverflowError(hex: argb)
+    }
+    let alpha = CGFloat((argb >> 24) & 0xff) / 255.0
+    let red   = CGFloat((argb >> 16) & 0xff) / 255.0
+    let green = CGFloat((argb >> 8) & 0xff) / 255.0
+    let blue  = CGFloat(argb & 0xff) / 255.0
+    return UIColor(red: red, green: green, blue: blue, alpha: alpha)
+  }
+
+  /**
+   Converts an integer for RGBA color to `UIColor`.
+   */
+  static func toColor(rgba: UInt64) throws -> UIColor {
+    guard rgba <= UInt32.max else {
+      throw HexColorOverflowError(hex: rgba)
+    }
+    let red   = CGFloat((rgba >> 24) & 0xff) / 255.0
+    let green = CGFloat((rgba >> 16) & 0xff) / 255.0
+    let blue  = CGFloat((rgba >> 8) & 0xff) / 255.0
+    let alpha = CGFloat(rgba & 0xff) / 255.0
+    return UIColor(red: red, green: green, blue: blue, alpha: alpha)
+  }
+
+  /**
+   Formats an array of keys to the string with keys in apostrophes separated by commas.
+   */
+  static func formatKeys(_ keys: [String]) -> String {
+    return keys.map { "`\($0)`" }.joined(separator: ", ")
+  }
+
+  // MARK: - Errors
+
+  /**
+   An error meaning that the number of arguments exceeds the limit.
+   */
+  internal struct TooManyArgumentsError: CodedError {
+    let count: Int
+    let limit: Int
+    var description: String {
+      "A number of arguments `\(count)` exceeds the limit of `\(limit)`"
+    }
+  }
+
+  /**
+   An error that can be thrown by convertible types, when given value cannot be converted.
+   */
+  internal struct ConvertingError<TargetType>: CodedError {
+    let value: Any?
+    var code: String = "ERR_CONVERTING_FAILED"
+    var description: String {
+      "Cannot cast `\(String(describing: value))` to `\(TargetType.self)`"
+    }
+  }
+
+  /**
+   An error that can be thrown by convertible types,
+   when the values in given dictionary cannot be casted to specific type.
+   */
+  internal struct CastingValuesError<ValueType>: CodedError {
+    let keys: [String]
+    var code: String = "ERR_CASTING_VALUES_FAILED"
+    var description: String {
+      "Cannot cast keys \(formatKeys(keys)) to `\(ValueType.self)`"
+    }
+  }
+
+  /**
+   An error that can be throw by convertible types,
+   when given dictionary is missing some required keys.
+   */
+  internal struct MissingKeysError<ValueType>: CodedError {
+    let keys: [String]
+    var description: String {
+      "Missing keys \(formatKeys(keys)) of type `\(ValueType.self)`"
+    }
+  }
+
+  /**
+   An error used when the hex color string is invalid (e.g. contains non-hex characters).
+   */
+  internal struct InvalidHexColorError: CodedError {
+    let hex: String
+    var description: String {
+      "Provided hex color `\(hex)` is invalid"
+    }
+  }
+
+  /**
+   An error used when the integer value of the color would result in an overflow of `UInt32`.
+   */
+  internal struct HexColorOverflowError: CodedError {
+    let hex: UInt64
+    var description: String {
+      "Provided hex color `\(hex)` would result in an overflow"
+    }
   }
 }

--- a/packages/expo-modules-core/ios/Swift/Methods/ConcreteMethod.swift
+++ b/packages/expo-modules-core/ios/Swift/Methods/ConcreteMethod.swift
@@ -109,6 +109,11 @@ public class ConcreteMethod<Args, ReturnType>: AnyMethod {
         return try dt.init(from: arg)
       }
 
+      // Handle convertible types (e.g. CGPoint, CGRect, UIColor, ...)
+      if let dt = desiredType.castWrappedType(ConvertibleArgument.Type.self) {
+        return try dt.convert(from: arg)
+      }
+
       // TODO: (@tsapeta) Handle convertible arrays
       throw IncompatibleArgTypeError(
         argument: arg,

--- a/packages/expo-modules-core/ios/Swift/Methods/ConcreteMethod.swift
+++ b/packages/expo-modules-core/ios/Swift/Methods/ConcreteMethod.swift
@@ -93,32 +93,30 @@ public class ConcreteMethod<Args, ReturnType>: AnyMethod {
       throw InvalidArgsNumberError(received: args.count, expected: argumentsCount)
     }
     return try args.enumerated().map { (index, arg) in
-      guard let desiredType = argumentType(atIndex: index) else {
+      guard let expectedType = argumentType(atIndex: index) else {
         return nil
       }
 
-      // If the type of argument matches the desired type, just cast and return it.
+      // If the type of argument matches the expected type, just cast and return it.
       // This usually covers all cases for primitive types or plain dicts and arrays.
-      if desiredType.canCast(arg) {
-        return desiredType.cast(arg)
+      if expectedType.canCast(arg) {
+        return expectedType.cast(arg)
       }
 
-      // TODO: (@tsapeta) Handle structs convertible to dictionary
       // If we get here, the argument can be converted (not casted!) to the desired type.
-      if let arg = arg as? Record.Dict, let dt = desiredType.castWrappedType(Record.Type.self) {
+      if let arg = arg as? Record.Dict, let dt = expectedType.castWrappedType(Record.Type.self) {
         return try dt.init(from: arg)
       }
 
       // Handle convertible types (e.g. CGPoint, CGRect, UIColor, ...)
-      if let dt = desiredType.castWrappedType(ConvertibleArgument.Type.self) {
+      if let dt = expectedType.castWrappedType(ConvertibleArgument.Type.self) {
         return try dt.convert(from: arg)
       }
 
       // TODO: (@tsapeta) Handle convertible arrays
       throw IncompatibleArgTypeError(
         argument: arg,
-        atIndex: index,
-        desiredType: desiredType
+        expectedType: expectedType
       )
     }
   }
@@ -132,11 +130,13 @@ internal struct InvalidArgsNumberError: CodedError {
   }
 }
 
+/**
+ Thrown when the value cannot be casted nor converted to given type.
+ */
 internal struct IncompatibleArgTypeError<ArgumentType>: CodedError {
   let argument: ArgumentType
-  let atIndex: Int
-  let desiredType: AnyArgumentType
+  let expectedType: AnyArgumentType
   var description: String {
-    "Type `\(type(of: argument))` of argument at index `\(atIndex)` is not compatible with expected type `\(desiredType.typeName)`."
+    "Argument `\(argument)` is not compatible with expected type `\(expectedType.typeName)`"
   }
 }

--- a/packages/expo-modules-core/ios/Swift/ModuleHolder.swift
+++ b/packages/expo-modules-core/ios/Swift/ModuleHolder.swift
@@ -66,6 +66,7 @@ public class ModuleHolder {
     call(method: methodName, args: args, promise: promise)
   }
 
+  @discardableResult
   func callSync(method methodName: String, args: [Any?]) -> Any? {
     if let method = definition.methods[methodName] {
       return method.callSync(args: args)

--- a/packages/expo-modules-core/ios/Tests/ConvertiblesSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/ConvertiblesSpec.swift
@@ -1,0 +1,231 @@
+// Copyright 2018-present 650 Industries. All rights reserved.
+
+import CoreGraphics
+import Quick
+import Nimble
+
+@testable import ExpoModulesCore
+
+class ConvertiblesSpec: QuickSpec {
+  override func spec() {
+    describe("CGPoint") {
+      let x = -8.3
+      let y = 4.6
+
+      it("converts from array of doubles") {
+        let point = try CGPoint.convert(from: [x, y])
+
+        expect(point.x) == x
+        expect(point.y) == y
+      }
+
+      it("converts from dict") {
+        let point = try CGPoint.convert(from: ["x": x, "y": y])
+
+        expect(point.x) == x
+        expect(point.y) == y
+      }
+
+      it("throws when array size is unexpected") { // different than two
+        expect { try CGPoint.convert(from: []) }.to(throwError(errorType: Conversions.ConvertingError<CGPoint>.self))
+        expect { try CGPoint.convert(from: [x]) }.to(throwError(errorType: Conversions.ConvertingError<CGPoint>.self))
+        expect { try CGPoint.convert(from: [x, y, x]) }.to(throwError(errorType: Conversions.ConvertingError<CGPoint>.self))
+      }
+
+      it("throws when dict is missing some keys") {
+        expect { try CGPoint.convert(from: ["test": x]) }.to(throwError {
+          expect($0).to(beAKindOf(Conversions.MissingKeysError<Double>.self))
+          expect(($0 as! CodedError).description) == Conversions.MissingKeysError<Double>(keys: ["x", "y"]).description
+        })
+      }
+
+      it("throws when dict has uncastable keys") {
+        expect { try CGPoint.convert(from: ["x": x, "y": "string"]) }.to(throwError {
+          expect($0).to(beAKindOf(Conversions.CastingValuesError<Double>.self))
+          expect(($0 as! CodedError).description) == Conversions.CastingValuesError<Double>(keys: ["y"]).description
+        })
+      }
+    }
+
+    describe("CGSize") {
+      let width = 52.8
+      let height = 81.7
+
+      it("converts from array of doubles") {
+        let size = try CGSize.convert(from: [width, height])
+
+        expect(size.width) == width
+        expect(size.height) == height
+      }
+
+      it("converts from dict") {
+        let size = try CGSize.convert(from: ["width": width, "height": height])
+
+        expect(size.width) == width
+        expect(size.height) == height
+      }
+
+      it("throws when array size is unexpected") { // different than two
+        expect { try CGSize.convert(from: []) }.to(throwError(errorType: Conversions.ConvertingError<CGSize>.self))
+        expect { try CGSize.convert(from: [width]) }.to(throwError(errorType: Conversions.ConvertingError<CGSize>.self))
+        expect { try CGSize.convert(from: [width, height, width]) }.to(throwError(errorType: Conversions.ConvertingError<CGSize>.self))
+      }
+
+      it("throws when dict is missing some keys") {
+        expect { try CGSize.convert(from: ["width": width]) }.to(throwError {
+          expect($0).to(beAKindOf(Conversions.MissingKeysError<Double>.self))
+          expect(($0 as! CodedError).description) == Conversions.MissingKeysError<Double>(keys: ["height"]).description
+        })
+      }
+
+      it("throws when dict has uncastable keys") {
+        expect { try CGSize.convert(from: ["width": "test", "height": height]) }.to(throwError {
+          expect($0).to(beAKindOf(Conversions.CastingValuesError<Double>.self))
+          expect(($0 as! CodedError).description) == Conversions.CastingValuesError<Double>(keys: ["width"]).description
+        })
+      }
+    }
+
+    describe("CGVector") {
+      let dx = 11.6
+      let dy = -4.0
+
+      it("converts from array of doubles") {
+        let vector = try CGVector.convert(from: [dx, dy])
+
+        expect(vector.dx) == dx
+        expect(vector.dy) == dy
+      }
+
+      it("converts from dict") {
+        let vector = try CGVector.convert(from: ["dx": dx, "dy": dy])
+
+        expect(vector.dx) == dx
+        expect(vector.dy) == dy
+      }
+
+      it("throws when array size is unexpected") { // different than two
+        expect { try CGVector.convert(from: []) }.to(throwError(errorType: Conversions.ConvertingError<CGVector>.self))
+        expect { try CGVector.convert(from: [dx]) }.to(throwError(errorType: Conversions.ConvertingError<CGVector>.self))
+        expect { try CGVector.convert(from: [dx, dy, dx]) }.to(throwError(errorType: Conversions.ConvertingError<CGVector>.self))
+      }
+
+      it("throws when dict is missing some keys") {
+        expect { try CGVector.convert(from: ["dx": dx]) }.to(throwError {
+          expect($0).to(beAKindOf(Conversions.MissingKeysError<Double>.self))
+          expect(($0 as! CodedError).description) == Conversions.MissingKeysError<Double>(keys: ["dy"]).description
+        })
+      }
+
+      it("throws when dict has uncastable keys") {
+        expect { try CGVector.convert(from: ["dx": "dx", "dy": dy]) }.to(throwError {
+          expect($0).to(beAKindOf(Conversions.CastingValuesError<Double>.self))
+          expect(($0 as! CodedError).description) == Conversions.CastingValuesError<Double>(keys: ["dx"]).description
+        })
+      }
+    }
+
+    describe("CGRect") {
+      let x = -8.3
+      let y = 4.6
+      let width = 52.8
+      let height = 81.7
+
+      it("converts from array of doubles") {
+        let rect = try CGRect.convert(from: [x, y, width, height])
+
+        expect(rect.origin.x) == x
+        expect(rect.origin.y) == y
+        expect(rect.width) == width
+        expect(rect.height) == height
+      }
+
+      it("converts from dict") {
+        let rect = try CGRect.convert(from: ["x": x, "y": y, "width": width, "height": height])
+
+        expect(rect.origin.x) == x
+        expect(rect.origin.y) == y
+        expect(rect.width) == width
+        expect(rect.height) == height
+      }
+
+      it("throws when array size is unexpected") { // different than four
+        expect { try CGRect.convert(from: [x]) }.to(throwError(errorType: Conversions.ConvertingError<CGRect>.self))
+        expect { try CGRect.convert(from: [x, y]) }.to(throwError(errorType: Conversions.ConvertingError<CGRect>.self))
+        expect { try CGRect.convert(from: [x, y, width, height, y]) }.to(throwError(errorType: Conversions.ConvertingError<CGRect>.self))
+      }
+
+      it("throws when dict is missing some keys") {
+        expect { try CGRect.convert(from: ["x": x]) }.to(throwError {
+          expect($0).to(beAKindOf(Conversions.MissingKeysError<Double>.self))
+          expect(($0 as! CodedError).description) == Conversions.MissingKeysError<Double>(keys: ["y", "width", "height"]).description
+        })
+      }
+
+      it("throws when dict has uncastable keys") {
+        expect { try CGRect.convert(from: ["x": x, "y": nil, "width": width, "height": "\(height)"]) }.to(throwError {
+          expect($0).to(beAKindOf(Conversions.CastingValuesError<Double>.self))
+          expect(($0 as! CodedError).description) == Conversions.CastingValuesError<Double>(keys: ["y", "height"]).description
+        })
+      }
+    }
+
+    describe("UIColor/CGColor") {
+      func testColorComponents(_ color: CGColor, _ red: CGFloat, _ green: CGFloat, _ blue: CGFloat, _ alpha: CGFloat) {
+        expect(color.components?[0]) == red   / 255.0
+        expect(color.components?[1]) == green / 255.0
+        expect(color.components?[2]) == blue  / 255.0
+        expect(color.components?[3]) == alpha / 255.0
+      }
+      func testInvalidHexColor(_ hex: String) {
+        expect { try CGColor.convert(from: hex) }.to(throwError {
+          expect($0).to(beAKindOf(Conversions.InvalidHexColorError.self))
+          expect(($0 as! CodedError).description) == Conversions.InvalidHexColorError(hex: hex).description
+        })
+      }
+
+      it("converts from ARGB int") {
+        // NOTE: int representation has alpha channel at the beginning
+        let color = try CGColor.convert(from: 0x5147AC7F)
+        testColorComponents(color, 0x47, 0xAC, 0x7F, 0x51)
+      }
+
+      it("converts from RGBA hex string") {
+        let color = try CGColor.convert(from: "47AC7F51")
+        testColorComponents(color, 0x47, 0xAC, 0x7F, 0x51)
+      }
+
+      it("converts from #RGBA hex string") {
+        let color = try CGColor.convert(from: " #47AC7F51")
+        testColorComponents(color, 0x47, 0xAC, 0x7F, 0x51)
+      }
+
+      it("converts from 3-character shorthand hex string") {
+        let color = try CGColor.convert(from: "C2B ")
+        testColorComponents(color, 0xCC, 0x22, 0xBB, 0xFF)
+      }
+
+      it("converts from 4-character shorthand hex string") {
+        let color = try CGColor.convert(from: " #9EA5 ")
+        testColorComponents(color, 0x99, 0xEE, 0xAA, 0x55)
+      }
+
+      it("throws when hex string is invalid") {
+        testInvalidHexColor("")
+        testInvalidHexColor("#21")
+        testInvalidHexColor("ABCDEFGH")
+        testInvalidHexColor("1122334455")
+        testInvalidHexColor("XYZ")
+        testInvalidHexColor("!@#$%")
+      }
+
+      it("throws when int overflows") {
+        let hex = 0xBBAA88FF2
+        expect { try CGColor.convert(from: hex) }.to(throwError {
+          expect($0).to(beAKindOf(Conversions.HexColorOverflowError.self))
+          expect(($0 as! CodedError).description) == Conversions.HexColorOverflowError(hex: UInt64(hex)).description
+        })
+      }
+    }
+  }
+}

--- a/packages/expo-modules-core/ios/Tests/MethodWithConvertiblesSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/MethodWithConvertiblesSpec.swift
@@ -1,0 +1,66 @@
+// Copyright 2018-present 650 Industries. All rights reserved.
+
+import CoreGraphics
+import Quick
+import Nimble
+
+@testable import ExpoModulesCore
+
+class MethodWithConvertiblesSpec: QuickSpec {
+  override func spec() {
+    let appContext = AppContext()
+    let methodName = "method"
+
+    it("converts arguments to CoreGraphics types") {
+      let x = 18.3
+      let y = -4.1
+      let width = 734.6
+      let height = 592.1
+
+      mockModuleHolder(appContext) {
+        $0.method(methodName) { (point: CGPoint, size: CGSize, vector: CGVector, rect: CGRect) in
+          expect(point.x) == x
+          expect(point.y) == y
+          expect(size.width) == width
+          expect(size.height) == height
+          expect(vector.dx) == x
+          expect(vector.dy) == y
+          expect(rect.origin.x) == x
+          expect(rect.origin.y) == y
+          expect(rect.width) == width
+          expect(rect.height) == height
+        }
+      }
+      .callSync(method: methodName, args: [
+        [x, y], // point
+        ["width": width, "height": height], // size
+        ["dx": x, "dy": y], // vector
+        [x, y, width, height] // rect
+      ])
+    }
+
+    it("converts arguments to CGColor") {
+      func testColorComponents(_ color: CGColor, _ red: CGFloat, _ green: CGFloat, _ blue: CGFloat, _ alpha: CGFloat) {
+        expect(color.components?[0]) == red   / 255.0
+        expect(color.components?[1]) == green / 255.0
+        expect(color.components?[2]) == blue  / 255.0
+        expect(color.components?[3]) == alpha / 255.0
+      }
+
+      mockModuleHolder(appContext) {
+        $0.method(methodName) { (color1: CGColor, color2: CGColor, color3: CGColor, color4: CGColor) in
+          testColorComponents(color1, 0x2A, 0x4B, 0x5D, 0xFF)
+          testColorComponents(color2, 0x11, 0xFF, 0x00, 0xDD)
+          testColorComponents(color3, 0x66, 0x00, 0xCC, 0xAA)
+          testColorComponents(color4, 0x00, 0x00, 0x00, 0x00)
+        }
+      }
+      .callSync(method: methodName, args: [
+        "#2A4B5D",
+        0xDD11FF00,
+        "60CA",
+        0
+      ])
+    }
+  }
+}


### PR DESCRIPTION
# Why

Generic closures in methods give us more control on what argument types are expected by the method, so we can support various other types as argument types, such as `CGPoint`, `CGColor`

# How

- Added `ConvertibleArgument` protocol that requires `static func convert(from: Any)`
- Extended some common types from `CoreGraphics` framework to support converting from arrays and dictionaries
- Added unit tests

# Test Plan

Unit tests are passing and checked locally if it really works in reality

# To do

- Add support for arrays of convertible types
- Use the same logic in view prop setters
