### PR TITLE
[babel-preset-expo] Switch to automatic jsxRuntime by default

### DIFF
--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## Unpublished
+
+### 🛠 Breaking changes
+
+- Changed default value of `jsxRuntime` to `automatic` ([#14995](https://github.com/expo/expo/pull/14995) by [@EvanBacon](https://github.com/EvanBacon))
+
+### 🎉 New features
+
+### 🐛 Bug fixes
+
+### 💡 Others

--- a/packages/babel-preset-expo/README.md
+++ b/packages/babel-preset-expo/README.md
@@ -44,10 +44,19 @@ If the `bundler` is not defined, it will default to checking if a `babel-loader`
 
 ### [`jsxRuntime`](https://babeljs.io/docs/en/babel-plugin-transform-react-jsx#runtime)
 
-`classic | automatic`, defaults to `classic`
+`classic | automatic`, defaults to `automatic`
 
 - `automatic` automatically convert JSX to JS without the need to `import React from 'react'` in every file. Be sure to follow the rest of the [setup guide](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html#how-to-upgrade-to-the-new-jsx-transform) after enabling this, otherwise ESLint and other tools will throw warnings.
 - `classic` does not automatically import anything, React must imported into every file that uses JSX syntax.
+
+```js
+[
+  'babel-preset-expo',
+  {
+    jsxRuntime: 'classic',
+  },
+];
+```
 
 This property is passed down to [`@babel/plugin-transform-react-jsx`](https://babeljs.io/docs/en/babel-plugin-transform-react-jsx). This flag does nothing when `native.useTransformReactJSXExperimental` is set to `true` because `@babel/plugin-transform-react-jsx` is omitted.
 

--- a/packages/babel-preset-expo/__tests__/__snapshots__/index-test.js.snap
+++ b/packages/babel-preset-expo/__tests__/__snapshots__/index-test.js.snap
@@ -15,7 +15,7 @@ require(\\"Foo\\");
 require(\\"./local-file/i-have-side-effects.fx.js\\");
 require(\\"../i-also-have-side-effects.fx\\");
 function _inlineFuncWithSideEffectsFx(){var data=_interopRequireDefault(require(\\"../inline-func-with-side-effects.fx.ts\\"));_inlineFuncWithSideEffectsFx=function _inlineFuncWithSideEffectsFx(){return data;};return data;}
-function _inlineFunc(){var data=_interopRequireDefault(require(\\"./inline-func\\"));_inlineFunc=function _inlineFunc(){return data;};return data;}function _getRequireWildcardCache(nodeInterop){if(typeof WeakMap!==\\"function\\")return null;var cacheBabelInterop=new WeakMap();var cacheNodeInterop=new WeakMap();return(_getRequireWildcardCache=function _getRequireWildcardCache(nodeInterop){return nodeInterop?cacheNodeInterop:cacheBabelInterop;})(nodeInterop);}function _interopRequireWildcard(obj,nodeInterop){if(!nodeInterop&&obj&&obj.__esModule){return obj;}if(obj===null||typeof obj!==\\"object\\"&&typeof obj!==\\"function\\"){return{default:obj};}var cache=_getRequireWildcardCache(nodeInterop);if(cache&&cache.has(obj)){return cache.get(obj);}var newObj={};var hasPropertyDescriptor=Object.defineProperty&&Object.getOwnPropertyDescriptor;for(var key in obj){if(key!==\\"default\\"&&Object.prototype.hasOwnProperty.call(obj,key)){var desc=hasPropertyDescriptor?Object.getOwnPropertyDescriptor(obj,key):null;if(desc&&(desc.get||desc.set)){Object.defineProperty(newObj,key,desc);}else{newObj[key]=obj[key];}}}newObj.default=obj;if(cache){cache.set(obj,newObj);}return newObj;}function _createSuper(Derived){var hasNativeReflectConstruct=_isNativeReflectConstruct();return function _createSuperInternal(){var Super=(0,_getPrototypeOf2.default)(Derived),result;if(hasNativeReflectConstruct){var NewTarget=(0,_getPrototypeOf2.default)(this).constructor;result=Reflect.construct(Super,arguments,NewTarget);}else{result=Super.apply(this,arguments);}return(0,_possibleConstructorReturn2.default)(this,result);};}function _isNativeReflectConstruct(){if(typeof Reflect===\\"undefined\\"||!Reflect.construct)return false;if(Reflect.construct.sham)return false;if(typeof Proxy===\\"function\\")return true;try{Boolean.prototype.valueOf.call(Reflect.construct(Boolean,[],function(){}));return true;}catch(e){return false;}}var
+function _inlineFunc(){var data=_interopRequireDefault(require(\\"./inline-func\\"));_inlineFunc=function _inlineFunc(){return data;};return data;}var _jsxRuntime=require(\\"react/jsx-runtime\\");function _getRequireWildcardCache(nodeInterop){if(typeof WeakMap!==\\"function\\")return null;var cacheBabelInterop=new WeakMap();var cacheNodeInterop=new WeakMap();return(_getRequireWildcardCache=function _getRequireWildcardCache(nodeInterop){return nodeInterop?cacheNodeInterop:cacheBabelInterop;})(nodeInterop);}function _interopRequireWildcard(obj,nodeInterop){if(!nodeInterop&&obj&&obj.__esModule){return obj;}if(obj===null||typeof obj!==\\"object\\"&&typeof obj!==\\"function\\"){return{default:obj};}var cache=_getRequireWildcardCache(nodeInterop);if(cache&&cache.has(obj)){return cache.get(obj);}var newObj={};var hasPropertyDescriptor=Object.defineProperty&&Object.getOwnPropertyDescriptor;for(var key in obj){if(key!==\\"default\\"&&Object.prototype.hasOwnProperty.call(obj,key)){var desc=hasPropertyDescriptor?Object.getOwnPropertyDescriptor(obj,key):null;if(desc&&(desc.get||desc.set)){Object.defineProperty(newObj,key,desc);}else{newObj[key]=obj[key];}}}newObj.default=obj;if(cache){cache.set(obj,newObj);}return newObj;}function _createSuper(Derived){var hasNativeReflectConstruct=_isNativeReflectConstruct();return function _createSuperInternal(){var Super=(0,_getPrototypeOf2.default)(Derived),result;if(hasNativeReflectConstruct){var NewTarget=(0,_getPrototypeOf2.default)(this).constructor;result=Reflect.construct(Super,arguments,NewTarget);}else{result=Super.apply(this,arguments);}return(0,_possibleConstructorReturn2.default)(this,result);};}function _isNativeReflectConstruct(){if(typeof Reflect===\\"undefined\\"||!Reflect.construct)return false;if(Reflect.construct.sham)return false;if(typeof Proxy===\\"function\\")return true;try{Boolean.prototype.valueOf.call(Reflect.construct(Boolean,[],function(){}));return true;}catch(e){return false;}}var
 
 Lazy=function(_React$Component){(0,_inherits2.default)(Lazy,_React$Component);var _super=_createSuper(Lazy);function Lazy(){(0,_classCallCheck2.default)(this,Lazy);return _super.apply(this,arguments);}(0,_createClass2.default)(Lazy,[{key:\\"componentDidMount\\",value:
 function componentDidMount(){
@@ -33,10 +33,10 @@ _expoAsset.Asset.loadAsync([require(\\"./assets/icon.png\\")]);
 
 function render(){
 return(
-_react.default.createElement(_reactNative.View,null,
-_react.default.createElement(_expoAppLoading.default,null),
-_react.default.createElement(_vectorIcons.Ionicons,{name:\\"md-options\\",size:28}),
-_react.default.createElement(_fooView.default,null)));
+(0,_jsxRuntime.jsxs)(_reactNative.View,{children:[
+(0,_jsxRuntime.jsx)(_expoAppLoading.default,{}),
+(0,_jsxRuntime.jsx)(_vectorIcons.Ionicons,{name:\\"md-options\\",size:28}),
+(0,_jsxRuntime.jsx)(_fooView.default,{})]}));
 
 
 }},{key:\\"unusedFunction\\",value:
@@ -64,7 +64,7 @@ require(\\"Foo\\");
 require(\\"./local-file/i-have-side-effects.fx.js\\");
 require(\\"../i-also-have-side-effects.fx\\");
 var _inlineFuncWithSideEffectsFx=_interopRequireDefault(require(\\"../inline-func-with-side-effects.fx.ts\\"));
-function _inlineFunc(){var data=_interopRequireDefault(require(\\"./inline-func\\"));_inlineFunc=function _inlineFunc(){return data;};return data;}function _getRequireWildcardCache(nodeInterop){if(typeof WeakMap!==\\"function\\")return null;var cacheBabelInterop=new WeakMap();var cacheNodeInterop=new WeakMap();return(_getRequireWildcardCache=function _getRequireWildcardCache(nodeInterop){return nodeInterop?cacheNodeInterop:cacheBabelInterop;})(nodeInterop);}function _interopRequireWildcard(obj,nodeInterop){if(!nodeInterop&&obj&&obj.__esModule){return obj;}if(obj===null||typeof obj!==\\"object\\"&&typeof obj!==\\"function\\"){return{default:obj};}var cache=_getRequireWildcardCache(nodeInterop);if(cache&&cache.has(obj)){return cache.get(obj);}var newObj={};var hasPropertyDescriptor=Object.defineProperty&&Object.getOwnPropertyDescriptor;for(var key in obj){if(key!==\\"default\\"&&Object.prototype.hasOwnProperty.call(obj,key)){var desc=hasPropertyDescriptor?Object.getOwnPropertyDescriptor(obj,key):null;if(desc&&(desc.get||desc.set)){Object.defineProperty(newObj,key,desc);}else{newObj[key]=obj[key];}}}newObj.default=obj;if(cache){cache.set(obj,newObj);}return newObj;}function _createSuper(Derived){var hasNativeReflectConstruct=_isNativeReflectConstruct();return function _createSuperInternal(){var Super=(0,_getPrototypeOf2().default)(Derived),result;if(hasNativeReflectConstruct){var NewTarget=(0,_getPrototypeOf2().default)(this).constructor;result=Reflect.construct(Super,arguments,NewTarget);}else{result=Super.apply(this,arguments);}return(0,_possibleConstructorReturn2().default)(this,result);};}function _isNativeReflectConstruct(){if(typeof Reflect===\\"undefined\\"||!Reflect.construct)return false;if(Reflect.construct.sham)return false;if(typeof Proxy===\\"function\\")return true;try{Boolean.prototype.valueOf.call(Reflect.construct(Boolean,[],function(){}));return true;}catch(e){return false;}}var
+function _inlineFunc(){var data=_interopRequireDefault(require(\\"./inline-func\\"));_inlineFunc=function _inlineFunc(){return data;};return data;}function _jsxRuntime(){var data=require(\\"react/jsx-runtime\\");_jsxRuntime=function _jsxRuntime(){return data;};return data;}function _getRequireWildcardCache(nodeInterop){if(typeof WeakMap!==\\"function\\")return null;var cacheBabelInterop=new WeakMap();var cacheNodeInterop=new WeakMap();return(_getRequireWildcardCache=function _getRequireWildcardCache(nodeInterop){return nodeInterop?cacheNodeInterop:cacheBabelInterop;})(nodeInterop);}function _interopRequireWildcard(obj,nodeInterop){if(!nodeInterop&&obj&&obj.__esModule){return obj;}if(obj===null||typeof obj!==\\"object\\"&&typeof obj!==\\"function\\"){return{default:obj};}var cache=_getRequireWildcardCache(nodeInterop);if(cache&&cache.has(obj)){return cache.get(obj);}var newObj={};var hasPropertyDescriptor=Object.defineProperty&&Object.getOwnPropertyDescriptor;for(var key in obj){if(key!==\\"default\\"&&Object.prototype.hasOwnProperty.call(obj,key)){var desc=hasPropertyDescriptor?Object.getOwnPropertyDescriptor(obj,key):null;if(desc&&(desc.get||desc.set)){Object.defineProperty(newObj,key,desc);}else{newObj[key]=obj[key];}}}newObj.default=obj;if(cache){cache.set(obj,newObj);}return newObj;}function _createSuper(Derived){var hasNativeReflectConstruct=_isNativeReflectConstruct();return function _createSuperInternal(){var Super=(0,_getPrototypeOf2().default)(Derived),result;if(hasNativeReflectConstruct){var NewTarget=(0,_getPrototypeOf2().default)(this).constructor;result=Reflect.construct(Super,arguments,NewTarget);}else{result=Super.apply(this,arguments);}return(0,_possibleConstructorReturn2().default)(this,result);};}function _isNativeReflectConstruct(){if(typeof Reflect===\\"undefined\\"||!Reflect.construct)return false;if(Reflect.construct.sham)return false;if(typeof Proxy===\\"function\\")return true;try{Boolean.prototype.valueOf.call(Reflect.construct(Boolean,[],function(){}));return true;}catch(e){return false;}}var
 
 Lazy=function(_React$Component){(0,_inherits2().default)(Lazy,_React$Component);var _super=_createSuper(Lazy);function Lazy(){(0,_classCallCheck2().default)(this,Lazy);return _super.apply(this,arguments);}(0,_createClass2().default)(Lazy,[{key:\\"componentDidMount\\",value:
 function componentDidMount(){
@@ -82,10 +82,10 @@ _expoAsset().Asset.loadAsync([require(\\"./assets/icon.png\\")]);
 
 function render(){
 return(
-_react().default.createElement(_reactNative().View,null,
-_react().default.createElement(_expoAppLoading().default,null),
-_react().default.createElement(_vectorIcons().Ionicons,{name:\\"md-options\\",size:28}),
-_react().default.createElement(_fooView().default,null)));
+(0,_jsxRuntime().jsxs)(_reactNative().View,{children:[
+(0,_jsxRuntime().jsx)(_expoAppLoading().default,{}),
+(0,_jsxRuntime().jsx)(_vectorIcons().Ionicons,{name:\\"md-options\\",size:28}),
+(0,_jsxRuntime().jsx)(_fooView().default,{})]}));
 
 
 }},{key:\\"unusedFunction\\",value:
@@ -113,7 +113,7 @@ require(\\"Foo\\");
 require(\\"./local-file/i-have-side-effects.fx.js\\");
 require(\\"../i-also-have-side-effects.fx\\");
 var _inlineFuncWithSideEffectsFx=_interopRequireDefault(require(\\"../inline-func-with-side-effects.fx.ts\\"));
-var _inlineFunc=_interopRequireDefault(require(\\"./inline-func\\"));function _getRequireWildcardCache(nodeInterop){if(typeof WeakMap!==\\"function\\")return null;var cacheBabelInterop=new WeakMap();var cacheNodeInterop=new WeakMap();return(_getRequireWildcardCache=function _getRequireWildcardCache(nodeInterop){return nodeInterop?cacheNodeInterop:cacheBabelInterop;})(nodeInterop);}function _interopRequireWildcard(obj,nodeInterop){if(!nodeInterop&&obj&&obj.__esModule){return obj;}if(obj===null||typeof obj!==\\"object\\"&&typeof obj!==\\"function\\"){return{default:obj};}var cache=_getRequireWildcardCache(nodeInterop);if(cache&&cache.has(obj)){return cache.get(obj);}var newObj={};var hasPropertyDescriptor=Object.defineProperty&&Object.getOwnPropertyDescriptor;for(var key in obj){if(key!==\\"default\\"&&Object.prototype.hasOwnProperty.call(obj,key)){var desc=hasPropertyDescriptor?Object.getOwnPropertyDescriptor(obj,key):null;if(desc&&(desc.get||desc.set)){Object.defineProperty(newObj,key,desc);}else{newObj[key]=obj[key];}}}newObj.default=obj;if(cache){cache.set(obj,newObj);}return newObj;}function _createSuper(Derived){var hasNativeReflectConstruct=_isNativeReflectConstruct();return function _createSuperInternal(){var Super=(0,_getPrototypeOf2.default)(Derived),result;if(hasNativeReflectConstruct){var NewTarget=(0,_getPrototypeOf2.default)(this).constructor;result=Reflect.construct(Super,arguments,NewTarget);}else{result=Super.apply(this,arguments);}return(0,_possibleConstructorReturn2.default)(this,result);};}function _isNativeReflectConstruct(){if(typeof Reflect===\\"undefined\\"||!Reflect.construct)return false;if(Reflect.construct.sham)return false;if(typeof Proxy===\\"function\\")return true;try{Boolean.prototype.valueOf.call(Reflect.construct(Boolean,[],function(){}));return true;}catch(e){return false;}}var
+var _inlineFunc=_interopRequireDefault(require(\\"./inline-func\\"));var _jsxRuntime=require(\\"react/jsx-runtime\\");function _getRequireWildcardCache(nodeInterop){if(typeof WeakMap!==\\"function\\")return null;var cacheBabelInterop=new WeakMap();var cacheNodeInterop=new WeakMap();return(_getRequireWildcardCache=function _getRequireWildcardCache(nodeInterop){return nodeInterop?cacheNodeInterop:cacheBabelInterop;})(nodeInterop);}function _interopRequireWildcard(obj,nodeInterop){if(!nodeInterop&&obj&&obj.__esModule){return obj;}if(obj===null||typeof obj!==\\"object\\"&&typeof obj!==\\"function\\"){return{default:obj};}var cache=_getRequireWildcardCache(nodeInterop);if(cache&&cache.has(obj)){return cache.get(obj);}var newObj={};var hasPropertyDescriptor=Object.defineProperty&&Object.getOwnPropertyDescriptor;for(var key in obj){if(key!==\\"default\\"&&Object.prototype.hasOwnProperty.call(obj,key)){var desc=hasPropertyDescriptor?Object.getOwnPropertyDescriptor(obj,key):null;if(desc&&(desc.get||desc.set)){Object.defineProperty(newObj,key,desc);}else{newObj[key]=obj[key];}}}newObj.default=obj;if(cache){cache.set(obj,newObj);}return newObj;}function _createSuper(Derived){var hasNativeReflectConstruct=_isNativeReflectConstruct();return function _createSuperInternal(){var Super=(0,_getPrototypeOf2.default)(Derived),result;if(hasNativeReflectConstruct){var NewTarget=(0,_getPrototypeOf2.default)(this).constructor;result=Reflect.construct(Super,arguments,NewTarget);}else{result=Super.apply(this,arguments);}return(0,_possibleConstructorReturn2.default)(this,result);};}function _isNativeReflectConstruct(){if(typeof Reflect===\\"undefined\\"||!Reflect.construct)return false;if(Reflect.construct.sham)return false;if(typeof Proxy===\\"function\\")return true;try{Boolean.prototype.valueOf.call(Reflect.construct(Boolean,[],function(){}));return true;}catch(e){return false;}}var
 
 Lazy=function(_React$Component){(0,_inherits2.default)(Lazy,_React$Component);var _super=_createSuper(Lazy);function Lazy(){(0,_classCallCheck2.default)(this,Lazy);return _super.apply(this,arguments);}(0,_createClass2.default)(Lazy,[{key:\\"componentDidMount\\",value:
 function componentDidMount(){
@@ -131,10 +131,10 @@ _expoAsset.Asset.loadAsync([require(\\"./assets/icon.png\\")]);
 
 function render(){
 return(
-_react.default.createElement(_reactNative.View,null,
-_react.default.createElement(_expoAppLoading.default,null),
-_react.default.createElement(_vectorIcons.Ionicons,{name:\\"md-options\\",size:28}),
-_react.default.createElement(_fooView.default,null)));
+(0,_jsxRuntime.jsxs)(_reactNative.View,{children:[
+(0,_jsxRuntime.jsx)(_expoAppLoading.default,{}),
+(0,_jsxRuntime.jsx)(_vectorIcons.Ionicons,{name:\\"md-options\\",size:28}),
+(0,_jsxRuntime.jsx)(_fooView.default,{})]}));
 
 
 }},{key:\\"unusedFunction\\",value:
@@ -162,7 +162,7 @@ require(\\"Foo\\");
 require(\\"./local-file/i-have-side-effects.fx.js\\");
 require(\\"../i-also-have-side-effects.fx\\");
 var _inlineFuncWithSideEffectsFx=_interopRequireDefault(require(\\"../inline-func-with-side-effects.fx.ts\\"));
-var _inlineFunc=_interopRequireDefault(require(\\"./inline-func\\"));function _getRequireWildcardCache(nodeInterop){if(typeof WeakMap!==\\"function\\")return null;var cacheBabelInterop=new WeakMap();var cacheNodeInterop=new WeakMap();return(_getRequireWildcardCache=function _getRequireWildcardCache(nodeInterop){return nodeInterop?cacheNodeInterop:cacheBabelInterop;})(nodeInterop);}function _interopRequireWildcard(obj,nodeInterop){if(!nodeInterop&&obj&&obj.__esModule){return obj;}if(obj===null||typeof obj!==\\"object\\"&&typeof obj!==\\"function\\"){return{default:obj};}var cache=_getRequireWildcardCache(nodeInterop);if(cache&&cache.has(obj)){return cache.get(obj);}var newObj={};var hasPropertyDescriptor=Object.defineProperty&&Object.getOwnPropertyDescriptor;for(var key in obj){if(key!==\\"default\\"&&Object.prototype.hasOwnProperty.call(obj,key)){var desc=hasPropertyDescriptor?Object.getOwnPropertyDescriptor(obj,key):null;if(desc&&(desc.get||desc.set)){Object.defineProperty(newObj,key,desc);}else{newObj[key]=obj[key];}}}newObj.default=obj;if(cache){cache.set(obj,newObj);}return newObj;}function _createSuper(Derived){var hasNativeReflectConstruct=_isNativeReflectConstruct();return function _createSuperInternal(){var Super=(0,_getPrototypeOf2.default)(Derived),result;if(hasNativeReflectConstruct){var NewTarget=(0,_getPrototypeOf2.default)(this).constructor;result=Reflect.construct(Super,arguments,NewTarget);}else{result=Super.apply(this,arguments);}return(0,_possibleConstructorReturn2.default)(this,result);};}function _isNativeReflectConstruct(){if(typeof Reflect===\\"undefined\\"||!Reflect.construct)return false;if(Reflect.construct.sham)return false;if(typeof Proxy===\\"function\\")return true;try{Boolean.prototype.valueOf.call(Reflect.construct(Boolean,[],function(){}));return true;}catch(e){return false;}}var
+var _inlineFunc=_interopRequireDefault(require(\\"./inline-func\\"));var _jsxRuntime=require(\\"react/jsx-runtime\\");function _getRequireWildcardCache(nodeInterop){if(typeof WeakMap!==\\"function\\")return null;var cacheBabelInterop=new WeakMap();var cacheNodeInterop=new WeakMap();return(_getRequireWildcardCache=function _getRequireWildcardCache(nodeInterop){return nodeInterop?cacheNodeInterop:cacheBabelInterop;})(nodeInterop);}function _interopRequireWildcard(obj,nodeInterop){if(!nodeInterop&&obj&&obj.__esModule){return obj;}if(obj===null||typeof obj!==\\"object\\"&&typeof obj!==\\"function\\"){return{default:obj};}var cache=_getRequireWildcardCache(nodeInterop);if(cache&&cache.has(obj)){return cache.get(obj);}var newObj={};var hasPropertyDescriptor=Object.defineProperty&&Object.getOwnPropertyDescriptor;for(var key in obj){if(key!==\\"default\\"&&Object.prototype.hasOwnProperty.call(obj,key)){var desc=hasPropertyDescriptor?Object.getOwnPropertyDescriptor(obj,key):null;if(desc&&(desc.get||desc.set)){Object.defineProperty(newObj,key,desc);}else{newObj[key]=obj[key];}}}newObj.default=obj;if(cache){cache.set(obj,newObj);}return newObj;}function _createSuper(Derived){var hasNativeReflectConstruct=_isNativeReflectConstruct();return function _createSuperInternal(){var Super=(0,_getPrototypeOf2.default)(Derived),result;if(hasNativeReflectConstruct){var NewTarget=(0,_getPrototypeOf2.default)(this).constructor;result=Reflect.construct(Super,arguments,NewTarget);}else{result=Super.apply(this,arguments);}return(0,_possibleConstructorReturn2.default)(this,result);};}function _isNativeReflectConstruct(){if(typeof Reflect===\\"undefined\\"||!Reflect.construct)return false;if(Reflect.construct.sham)return false;if(typeof Proxy===\\"function\\")return true;try{Boolean.prototype.valueOf.call(Reflect.construct(Boolean,[],function(){}));return true;}catch(e){return false;}}var
 
 Lazy=function(_React$Component){(0,_inherits2.default)(Lazy,_React$Component);var _super=_createSuper(Lazy);function Lazy(){(0,_classCallCheck2.default)(this,Lazy);return _super.apply(this,arguments);}(0,_createClass2.default)(Lazy,[{key:\\"componentDidMount\\",value:
 function componentDidMount(){
@@ -180,10 +180,10 @@ _expoAsset.Asset.loadAsync([require(\\"./assets/icon.png\\")]);
 
 function render(){
 return(
-_react.default.createElement(_reactNative.View,null,
-_react.default.createElement(_expoAppLoading.default,null),
-_react.default.createElement(_vectorIcons.Ionicons,{name:\\"md-options\\",size:28}),
-_react.default.createElement(_fooView.default,null)));
+(0,_jsxRuntime.jsxs)(_reactNative.View,{children:[
+(0,_jsxRuntime.jsx)(_expoAppLoading.default,{}),
+(0,_jsxRuntime.jsx)(_vectorIcons.Ionicons,{name:\\"md-options\\",size:28}),
+(0,_jsxRuntime.jsx)(_fooView.default,{})]}));
 
 
 }},{key:\\"unusedFunction\\",value:
@@ -211,7 +211,7 @@ require(\\"Foo\\");
 require(\\"./local-file/i-have-side-effects.fx.js\\");
 require(\\"../i-also-have-side-effects.fx\\");
 var _inlineFuncWithSideEffectsFx=_interopRequireDefault(require(\\"../inline-func-with-side-effects.fx.ts\\"));
-var _inlineFunc=_interopRequireDefault(require(\\"./inline-func\\"));function _getRequireWildcardCache(nodeInterop){if(typeof WeakMap!==\\"function\\")return null;var cacheBabelInterop=new WeakMap();var cacheNodeInterop=new WeakMap();return(_getRequireWildcardCache=function _getRequireWildcardCache(nodeInterop){return nodeInterop?cacheNodeInterop:cacheBabelInterop;})(nodeInterop);}function _interopRequireWildcard(obj,nodeInterop){if(!nodeInterop&&obj&&obj.__esModule){return obj;}if(obj===null||typeof obj!==\\"object\\"&&typeof obj!==\\"function\\"){return{default:obj};}var cache=_getRequireWildcardCache(nodeInterop);if(cache&&cache.has(obj)){return cache.get(obj);}var newObj={};var hasPropertyDescriptor=Object.defineProperty&&Object.getOwnPropertyDescriptor;for(var key in obj){if(key!==\\"default\\"&&Object.prototype.hasOwnProperty.call(obj,key)){var desc=hasPropertyDescriptor?Object.getOwnPropertyDescriptor(obj,key):null;if(desc&&(desc.get||desc.set)){Object.defineProperty(newObj,key,desc);}else{newObj[key]=obj[key];}}}newObj.default=obj;if(cache){cache.set(obj,newObj);}return newObj;}function _createSuper(Derived){var hasNativeReflectConstruct=_isNativeReflectConstruct();return function _createSuperInternal(){var Super=(0,_getPrototypeOf2().default)(Derived),result;if(hasNativeReflectConstruct){var NewTarget=(0,_getPrototypeOf2().default)(this).constructor;result=Reflect.construct(Super,arguments,NewTarget);}else{result=Super.apply(this,arguments);}return(0,_possibleConstructorReturn2().default)(this,result);};}function _isNativeReflectConstruct(){if(typeof Reflect===\\"undefined\\"||!Reflect.construct)return false;if(Reflect.construct.sham)return false;if(typeof Proxy===\\"function\\")return true;try{Boolean.prototype.valueOf.call(Reflect.construct(Boolean,[],function(){}));return true;}catch(e){return false;}}var
+var _inlineFunc=_interopRequireDefault(require(\\"./inline-func\\"));function _jsxRuntime(){var data=require(\\"react/jsx-runtime\\");_jsxRuntime=function _jsxRuntime(){return data;};return data;}function _getRequireWildcardCache(nodeInterop){if(typeof WeakMap!==\\"function\\")return null;var cacheBabelInterop=new WeakMap();var cacheNodeInterop=new WeakMap();return(_getRequireWildcardCache=function _getRequireWildcardCache(nodeInterop){return nodeInterop?cacheNodeInterop:cacheBabelInterop;})(nodeInterop);}function _interopRequireWildcard(obj,nodeInterop){if(!nodeInterop&&obj&&obj.__esModule){return obj;}if(obj===null||typeof obj!==\\"object\\"&&typeof obj!==\\"function\\"){return{default:obj};}var cache=_getRequireWildcardCache(nodeInterop);if(cache&&cache.has(obj)){return cache.get(obj);}var newObj={};var hasPropertyDescriptor=Object.defineProperty&&Object.getOwnPropertyDescriptor;for(var key in obj){if(key!==\\"default\\"&&Object.prototype.hasOwnProperty.call(obj,key)){var desc=hasPropertyDescriptor?Object.getOwnPropertyDescriptor(obj,key):null;if(desc&&(desc.get||desc.set)){Object.defineProperty(newObj,key,desc);}else{newObj[key]=obj[key];}}}newObj.default=obj;if(cache){cache.set(obj,newObj);}return newObj;}function _createSuper(Derived){var hasNativeReflectConstruct=_isNativeReflectConstruct();return function _createSuperInternal(){var Super=(0,_getPrototypeOf2().default)(Derived),result;if(hasNativeReflectConstruct){var NewTarget=(0,_getPrototypeOf2().default)(this).constructor;result=Reflect.construct(Super,arguments,NewTarget);}else{result=Super.apply(this,arguments);}return(0,_possibleConstructorReturn2().default)(this,result);};}function _isNativeReflectConstruct(){if(typeof Reflect===\\"undefined\\"||!Reflect.construct)return false;if(Reflect.construct.sham)return false;if(typeof Proxy===\\"function\\")return true;try{Boolean.prototype.valueOf.call(Reflect.construct(Boolean,[],function(){}));return true;}catch(e){return false;}}var
 
 Lazy=function(_React$Component){(0,_inherits2().default)(Lazy,_React$Component);var _super=_createSuper(Lazy);function Lazy(){(0,_classCallCheck2().default)(this,Lazy);return _super.apply(this,arguments);}(0,_createClass2().default)(Lazy,[{key:\\"componentDidMount\\",value:
 function componentDidMount(){
@@ -229,10 +229,10 @@ _expoAsset.Asset.loadAsync([require(\\"./assets/icon.png\\")]);
 
 function render(){
 return(
-_react().default.createElement(_reactNative().View,null,
-_react().default.createElement(_expoAppLoading().default,null),
-_react().default.createElement(_vectorIcons().Ionicons,{name:\\"md-options\\",size:28}),
-_react().default.createElement(_fooView().default,null)));
+(0,_jsxRuntime().jsxs)(_reactNative().View,{children:[
+(0,_jsxRuntime().jsx)(_expoAppLoading().default,{}),
+(0,_jsxRuntime().jsx)(_vectorIcons().Ionicons,{name:\\"md-options\\",size:28}),
+(0,_jsxRuntime().jsx)(_fooView().default,{})]}));
 
 
 }},{key:\\"unusedFunction\\",value:
@@ -267,6 +267,14 @@ return(0,_jsxRuntime.jsx)(_reactNative.View,{children:(0,_jsxRuntime.jsx)(_react
 }"
 `;
 
+exports[`metro supports classic JSX runtime 1`] = `
+"Object.defineProperty(exports,\\"__esModule\\",{value:true});exports.default=App;
+var _reactNative=require(\\"react-native\\");
+function App(){
+return React.createElement(_reactNative.View,null,React.createElement(_reactNative.Text,null,\\"Hello World\\"));
+}"
+`;
+
 exports[`metro uses the platform's react-native import 1`] = `
 "
 var _reactNative=require(\\"react-native\\");"
@@ -291,6 +299,14 @@ exports[`webpack supports automatic JSX runtime 1`] = `
 
 export default function App(){
 return _jsx(View,{children:_jsx(Text,{children:\\"Hello World\\"})});
+}"
+`;
+
+exports[`webpack supports classic JSX runtime 1`] = `
+"import Text from\\"react-native-web/dist/exports/Text\\";import View from\\"react-native-web/dist/exports/View\\";
+
+export default function App(){
+return React.createElement(View,null,React.createElement(Text,null,\\"Hello World\\"));
 }"
 `;
 

--- a/packages/babel-preset-expo/__tests__/index-test.js
+++ b/packages/babel-preset-expo/__tests__/index-test.js
@@ -69,6 +69,30 @@ export default function App() {
     expect(code).toMatchSnapshot();
   });
 
+  it(`supports classic JSX runtime`, () => {
+    const options = {
+      babelrc: false,
+      presets: [[preset, { jsxRuntime: 'classic' }]],
+      filename: 'unknown',
+      // Make the snapshot easier to read
+      retainLines: true,
+      caller,
+    };
+
+    // No React import...
+    const sourceCode = `
+import { Text, View } from 'react-native';
+export default function App() {
+  return (<View><Text>Hello World</Text></View>);
+}`;
+    const { code } = babel.transform(sourceCode, options);
+
+    expect(code).not.toMatch(/"react\/jsx-runtime"/);
+
+    expect(code).not.toMatch(isMetro ? /_jsxRuntime.jsx/ : /_jsx\(View/);
+    expect(code).toMatchSnapshot();
+  });
+
   it(`aliases @expo/vector-icons`, () => {
     const options = {
       babelrc: false,

--- a/packages/babel-preset-expo/index.js
+++ b/packages/babel-preset-expo/index.js
@@ -43,8 +43,8 @@ module.exports = function (api, options = {}) {
     extraPlugins.push([
       require('@babel/plugin-transform-react-jsx'),
       {
-        // Defaults to `classic`, pass in `automatic` for auto JSX transformations.
-        runtime: options && options.jsxRuntime,
+        // Defaults to `automatic`, pass in `classic` to disable auto JSX transformations.
+        runtime: (options && options.jsxRuntime) || 'automatic',
       },
     ]);
     // Purposefully not adding the deprecated packages:


### PR DESCRIPTION
# Why

We introduced the feature as opt-in in SDK 43, now we should enable the feature by default since it appears to be pretty stable and other React frameworks do this.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Switch default `jsxRuntime` to `automatic`

# Test Plan

Updated tests

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
