### PR TITLE
[ci] fix sdk-43 ios ci failures

### DIFF
--- a/.github/workflows/client-ios.yml
+++ b/.github/workflows/client-ios.yml
@@ -86,8 +86,8 @@ jobs:
         with:
           path: 'ios/Pods'
           key: ${{ runner.os }}-pods-${{ hashFiles('ios/Podfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-pods-
+          # restore-keys: |
+          #   ${{ runner.os }}-pods-
       - name: 🥥 Install CocoaPods in `ios`
         run: pod install
         working-directory: ios

--- a/.github/workflows/ios-unit-tests.yml
+++ b/.github/workflows/ios-unit-tests.yml
@@ -75,8 +75,8 @@ jobs:
         with:
           path: 'ios/Pods'
           key: ${{ runner.os }}-pods-${{ hashFiles('ios/Podfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-pods-
+          # restore-keys: |
+          #   ${{ runner.os }}-pods-
       - name: 🥥 Install CocoaPods in `ios`
         run: pod install
         working-directory: ios

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -106,8 +106,8 @@ jobs:
         with:
           path: 'apps/bare-expo/ios/Pods'
           key: ${{ runner.os }}-bare-expo-pods-${{ hashFiles('apps/bare-expo/ios/Podfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-bare-expo-pods-
+          # restore-keys: |
+          #   ${{ runner.os }}-bare-expo-pods-
       - name: 🕵️ Debug CocoaPods lockfiles
         run: git diff Podfile.lock Pods/Manifest.lock
         working-directory: apps/bare-expo/ios


### PR DESCRIPTION
# Why

we added a cocoapods plugin in master branch and makes pods incompatible between sdk-43 and master. as on sdk-43, we still apply some changes. it's better to make ci works.

# How

remove fallback restore-keys on sdk-43.

# Test Plan

ci green

