### PR TITLE
[docs] EAS Build - changes after switching to no-commit workflow

### DIFF
--- a/docs/pages/build-reference/android-builds.md
+++ b/docs/pages/build-reference/android-builds.md
@@ -12,7 +12,7 @@ Let's take a closer look at the steps for building Android projects with EAS Bui
 
 The first phase happens on your computer. EAS CLI is in charge of completing the following steps:
 
-1. Check if the git index is clean - this means that there aren't any uncommitted changes. If it's not clean, an error is thrown. We use git to prepare a tarball of your project to upload to the build service.
+1. If `cli.requireCommit` is true check if the git index is clean - this means that there aren't any uncommitted changes. If it's not clean, EAS CLI will provide an option to commit local changes for you or abort build process.
 1. Prepare the credentials needed for the build unless `builds.android.PROFILE_NAME.withoutCredentials` is set to `true`.
 
    - Depending on the value of `builds.android.PROFILE_NAME.credentialsSource`, the credentials are obtained from either the local **credentials.json** file or from the EAS servers. If the `remote` mode is selected but no credentials exist yet, you're prompted to generate a new keystore.
@@ -22,7 +22,7 @@ The first phase happens on your computer. EAS CLI is in charge of completing the
    > In this step, EAS CLI checks whether `android/app/build.gradle` contains `apply from: "./eas-build.gradle"`.
    > If the project is not configured, EAS CLI runs auto-configuration steps ([learn more below](#project-auto-configuration)).
 
-1. Create the tarball containing a shallow clone of your local repository (`git clone --depth 1 ...`).
+1. Create the tarball containing copy of a repository. Actual behavior will depends on vcs workflow you are using, ([learn more here](https://expo.fyi/eas-vcs-workflow))
 1. Upload the project tarball to a private AWS S3 bucket and send the build request to EAS Build.
 
 ### Remote Steps

--- a/docs/pages/build-reference/android-builds.md
+++ b/docs/pages/build-reference/android-builds.md
@@ -12,7 +12,7 @@ Let's take a closer look at the steps for building Android projects with EAS Bui
 
 The first phase happens on your computer. EAS CLI is in charge of completing the following steps:
 
-1. If `cli.requireCommit` is true check if the git index is clean - this means that there aren't any uncommitted changes. If it's not clean, EAS CLI will provide an option to commit local changes for you or abort build process.
+1. If `cli.requireCommit` is set to `true` in `eas.json`, check if the git index is clean - this means that there aren't any uncommitted changes. If it's not clean, EAS CLI will provide an option to commit local changes for you or abort the build process.
 1. Prepare the credentials needed for the build unless `builds.android.PROFILE_NAME.withoutCredentials` is set to `true`.
 
    - Depending on the value of `builds.android.PROFILE_NAME.credentialsSource`, the credentials are obtained from either the local **credentials.json** file or from the EAS servers. If the `remote` mode is selected but no credentials exist yet, you're prompted to generate a new keystore.
@@ -22,7 +22,7 @@ The first phase happens on your computer. EAS CLI is in charge of completing the
    > In this step, EAS CLI checks whether `android/app/build.gradle` contains `apply from: "./eas-build.gradle"`.
    > If the project is not configured, EAS CLI runs auto-configuration steps ([learn more below](#project-auto-configuration)).
 
-1. Create the tarball containing copy of a repository. Actual behavior will depends on vcs workflow you are using, ([learn more here](https://expo.fyi/eas-vcs-workflow))
+1. Create the tarball containing a copy of the repository. Actual behavior depends on the VCS workflow you are using. [Learn more here](https://expo.fyi/eas-vcs-workflow).
 1. Upload the project tarball to a private AWS S3 bucket and send the build request to EAS Build.
 
 ### Remote Steps

--- a/docs/pages/build-reference/build-configuration.md
+++ b/docs/pages/build-reference/build-configuration.md
@@ -63,6 +63,6 @@ In the example above, we defined exactly the same Android application id and iOS
 #### 5. Next steps
 
 That's all there is to configuring a project to be compatible with EAS Build.
-There is one final step if you set `"cli.requireCommit": true` in your `eas.json` — you'll be prompted to commit all the changes we made for you. You can choose to review them before committing, and you can either specify the git commit message or use a default message.
+There is one final step if you set `cli.requireCommit` to `true` in your `eas.json` — you'll be prompted to commit all the changes we made for you. You can choose to review them before committing, and you can either specify the git commit message or use a default message.
 
 <ImageSpotlight alt="Application identifier prompts in eas build:configure" src="/static/images/eas-build/configure/03-next-steps.png" containerStyle={{ paddingBottom: 0 }} />

--- a/docs/pages/build-reference/build-configuration.md
+++ b/docs/pages/build-reference/build-configuration.md
@@ -63,6 +63,6 @@ In the example above, we defined exactly the same Android application id and iOS
 #### 5. Next steps
 
 That's all there is to configuring a project to be compatible with EAS Build.
-There is one final step — you'll be prompted to commit all the changes we made for you. You can choose to review them before committing, and you can either specify the git commit message or use a default message.
+There is one final step if you set `"cli.requireCommit": true` in your `eas.json` — you'll be prompted to commit all the changes we made for you. You can choose to review them before committing, and you can either specify the git commit message or use a default message.
 
 <ImageSpotlight alt="Application identifier prompts in eas build:configure" src="/static/images/eas-build/configure/03-next-steps.png" containerStyle={{ paddingBottom: 0 }} />

--- a/docs/pages/build-reference/how-tos.md
+++ b/docs/pages/build-reference/how-tos.md
@@ -80,6 +80,9 @@ e.g.
 
 ## How to use git submodules
 
+If you are using default VCS workflow, the content of your working directory will be uploaded to EAS as it is, including the content of your submodules. If you are building on CI you will need to initialize them, otherwise empty directories will be uploaded.
+
+If you have `cli.requireCommit` set to `true` in `eas.json` you will need to initialize your submodules on EAS Build worker.
 First, create a [secret](/build-reference/variables/#using-secrets-in-environment-variables) with a base64 encoded private SSH key that has permission to access submodule repositories. Next, add an `eas-build-pre-install` npm hook to check out those submodules, for example:
 
 ```bash

--- a/docs/pages/build-reference/how-tos.md
+++ b/docs/pages/build-reference/how-tos.md
@@ -80,7 +80,7 @@ e.g.
 
 ## How to use git submodules
 
-If you are using default VCS workflow, the content of your working directory will be uploaded to EAS as it is, including the content of your submodules. If you are building on CI you will need to initialize them, otherwise empty directories will be uploaded.
+If you are using the default VCS workflow, the content of your working directory will be uploaded to EAS Build as it is, including the content of Git submodules. If you are building on CI you will need to initialize them, otherwise, empty directories will be uploaded.
 
 If you have `cli.requireCommit` set to `true` in `eas.json` you will need to initialize your submodules on EAS Build worker.
 First, create a [secret](/build-reference/variables/#using-secrets-in-environment-variables) with a base64 encoded private SSH key that has permission to access submodule repositories. Next, add an `eas-build-pre-install` npm hook to check out those submodules, for example:

--- a/docs/pages/build-reference/ios-builds.md
+++ b/docs/pages/build-reference/ios-builds.md
@@ -12,14 +12,14 @@ Let's take a closer look at the steps for building iOS projects with EAS Build. 
 
 The first phase happens on your computer. EAS CLI is in charge of completing the following steps:
 
-1. Check if the git index is clean - this means if there aren't any uncommitted changes. If it's not clean an error is thrown.
-2. Prepare the credentials needed for the build.
+1. If `cli.requireCommit` is true check if the git index is clean - this means that there aren't any uncommitted changes. If it's not clean, EAS CLI will provide an option to commit local changes for you or abort build process.
+1. Prepare the credentials needed for the build.
 
    - Depending on the value of `builds.ios.PROFILE_NAME.credentialsSource`, the credentials are obtained from either the local **credentials.json** file or from the EAS servers. If the `remote` mode is selected but no credentials exist yet, you're offered to generate them.
 
-3. **Bare** projects require an additional step: check whether the Xcode project is configured to be buildable on the EAS servers (i.e. ensure the correct bundle identifier and Apple Team ID are set).
-4. Create the tarball containing a shallow clone of your local repository (`git clone --depth 1 ...`).
-5. Upload the project tarball to a private AWS S3 bucket and send the build request to EAS Build.
+1. **Bare** projects require an additional step: check whether the Xcode project is configured to be buildable on the EAS servers (i.e. ensure the correct bundle identifier and Apple Team ID are set).
+1. Create the tarball containing copy of a repository. Actual behavior will depends on vcs workflow you are using, ([learn more here](https://expo.fyi/eas-vcs-workflow))
+1. Upload the project tarball to a private AWS S3 bucket and send the build request to EAS Build.
 
 ### Remote Steps
 

--- a/docs/pages/build-reference/ios-builds.md
+++ b/docs/pages/build-reference/ios-builds.md
@@ -12,13 +12,13 @@ Let's take a closer look at the steps for building iOS projects with EAS Build. 
 
 The first phase happens on your computer. EAS CLI is in charge of completing the following steps:
 
-1. If `cli.requireCommit` is true check if the git index is clean - this means that there aren't any uncommitted changes. If it's not clean, EAS CLI will provide an option to commit local changes for you or abort build process.
+1. If `cli.requireCommit` is set to `true` in `eas.json`, check if the git index is clean - this means that there aren't any uncommitted changes. If it's not clean, EAS CLI will provide an option to commit local changes for you or abort the build process.
 1. Prepare the credentials needed for the build.
 
    - Depending on the value of `builds.ios.PROFILE_NAME.credentialsSource`, the credentials are obtained from either the local **credentials.json** file or from the EAS servers. If the `remote` mode is selected but no credentials exist yet, you're offered to generate them.
 
 1. **Bare** projects require an additional step: check whether the Xcode project is configured to be buildable on the EAS servers (i.e. ensure the correct bundle identifier and Apple Team ID are set).
-1. Create the tarball containing copy of a repository. Actual behavior will depends on vcs workflow you are using, ([learn more here](https://expo.fyi/eas-vcs-workflow))
+1. Create the tarball containing a copy of the repository. Actual behavior depends on the VCS workflow you are using. [Learn more here](https://expo.fyi/eas-vcs-workflow).
 1. Upload the project tarball to a private AWS S3 bucket and send the build request to EAS Build.
 
 ### Remote Steps

--- a/docs/pages/build/eas-json.md
+++ b/docs/pages/build/eas-json.md
@@ -62,8 +62,8 @@ Generally, the schema of this file looks like this:
 ```json
 {
   "cli": {
-    "version": /* @info semver version range compatible with the 'semver' package */"SEMVER_RANGE"/* @end */,
-    "requireCommit": /* @info If true, ensures that all changes are commited before a build. Defults to false. */boolean/* @end */
+    "version": /* @info Required EAS CLI version range. */"SEMVER_RANGE"/* @end */,
+    "requireCommit": /* @info If true, ensures that all changes are committed before a build. Defults to false. */boolean/* @end */
 
   },
   "build": {

--- a/docs/pages/build/eas-json.md
+++ b/docs/pages/build/eas-json.md
@@ -13,6 +13,9 @@ import iosSchema from '~/scripts/schemas/unversioned/eas-json-build-ios-schema.j
 
 ```json
 {
+  "cli": {
+    "version": ">= 0.34.0"
+  },
   "build": {
     "development": {
       "developmentClient": true,
@@ -30,6 +33,9 @@ or
 
 ```json
 {
+  "cli": {
+    "version": ">= 0.34.0"
+  },
   "build": {
     "development": {
       "distribution": "internal",
@@ -55,6 +61,11 @@ Generally, the schema of this file looks like this:
 <!-- prettier-ignore -->
 ```json
 {
+  "cli": {
+    "version": /* @info semver version range compatible with the 'semver' package */"SEMVER_RANGE"/* @end */,
+    "requireCommit": /* @info If true, ensures that all changes are commited before a build. Defults to false. */boolean/* @end */
+
+  },
   "build": {
     /* @info any arbitrary name - used as an identifier */"BUILD_PROFILE_NAME_1"/* @end */: {
       /* @info options common for both platforms*/...COMMON_OPTIONS/* @end */

--- a/docs/pages/submit/eas-json.md
+++ b/docs/pages/submit/eas-json.md
@@ -41,8 +41,8 @@ The schema of this file looks like this:
 ```json
 {
   "cli": {
-    "version": /* @info semver version range compatible with the 'semver' package */"SEMVER_RANGE"/* @end */,
-    "requireCommit": /* @info If true, ensures that all changes are commited before a build. Defults to false. */boolean/* @end */
+    "version": /* @info Required EAS CLI version range. */"SEMVER_RANGE"/* @end */,
+    "requireCommit": /* @info If true, ensures that all changes are committed before a build. Defults to false. */boolean/* @end */
 
   },
   "build": {

--- a/docs/pages/submit/eas-json.md
+++ b/docs/pages/submit/eas-json.md
@@ -14,6 +14,9 @@ import submitIosSchema from '~/scripts/schemas/unversioned/eas-json-submit-ios-s
 
 ```json
 {
+  "cli": {
+    "version": ">= 0.34.0"
+  },
   "submit": {
     "production": {
       "android": {
@@ -37,6 +40,11 @@ The schema of this file looks like this:
 <!-- prettier-ignore -->
 ```json
 {
+  "cli": {
+    "version": /* @info semver version range compatible with the 'semver' package */"SEMVER_RANGE"/* @end */,
+    "requireCommit": /* @info If true, ensures that all changes are commited before a build. Defults to false. */boolean/* @end */
+
+  },
   "build": {
     // EAS Build configuration
     ...


### PR DESCRIPTION
# Why

Update info about commit requirements and preparing archive to upload

# How

For now, I duplicated eas.json changes in EAS Build and EAS submit documentation, but it should be restructured in the future

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
