### PR TITLE
[sweet-api][kotlin] Add a way of getting the ReactApplicationContext

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/NativeModulesProxy.java
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/NativeModulesProxy.java
@@ -5,19 +5,10 @@ import android.util.SparseArray;
 import com.facebook.react.bridge.Dynamic;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
-import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableType;
-
-import expo.modules.core.ExportedModule;
-import expo.modules.core.ModuleRegistry;
-import expo.modules.core.ViewManager;
-import expo.modules.core.interfaces.ExpoMethod;
-import expo.modules.kotlin.ExpoModulesHelper;
-import expo.modules.kotlin.KotlinInteropModuleRegistry;
-import expo.modules.kotlin.ModulesProvider;
 
 import java.lang.ref.WeakReference;
 import java.lang.reflect.Method;
@@ -29,6 +20,14 @@ import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Nullable;
+
+import expo.modules.core.ExportedModule;
+import expo.modules.core.ModuleRegistry;
+import expo.modules.core.ViewManager;
+import expo.modules.core.interfaces.ExpoMethod;
+import expo.modules.kotlin.ExpoModulesHelper;
+import expo.modules.kotlin.KotlinInteropModuleRegistry;
+import expo.modules.kotlin.ModulesProvider;
 
 /**
  * A wrapper/proxy for all {@link ExportedModule}s, gets exposed as {@link com.facebook.react.bridge.NativeModule},

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
@@ -1,7 +1,7 @@
 package expo.modules.kotlin
 
 import com.facebook.react.bridge.LifecycleEventListener
-import com.facebook.react.bridge.ReactContext
+import com.facebook.react.bridge.ReactApplicationContext
 import expo.modules.core.interfaces.ActivityProvider
 import expo.modules.interfaces.barcodescanner.BarCodeScannerInterface
 import expo.modules.interfaces.camera.CameraViewInterface
@@ -18,12 +18,12 @@ import java.lang.ref.WeakReference
 class AppContext(
   modulesProvider: ModulesProvider,
   val legacyModuleRegistry: expo.modules.core.ModuleRegistry,
-  val reactContext: WeakReference<ReactContext>
+  private val reactContextHolder: WeakReference<ReactApplicationContext>
 ) : LifecycleEventListener {
   val registry = ModuleRegistry(WeakReference(this)).register(modulesProvider)
 
   init {
-    requireNotNull(reactContext.get()) {
+    requireNotNull(reactContextHolder.get()) {
       "The app context should be created with valid react context."
     }.addLifecycleEventListener(this)
   }
@@ -99,8 +99,14 @@ class AppContext(
   val activityProvider: ActivityProvider?
     get() = legacyModule()
 
+  /**
+   * Provides access to the react application context
+   */
+  val reactContext: ReactApplicationContext?
+    get() = reactContextHolder.get()
+
   fun onDestroy() {
-    reactContext.get()?.removeLifecycleEventListener(this)
+    reactContextHolder.get()?.removeLifecycleEventListener(this)
     registry.post(EventName.MODULE_DESTROY)
   }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/KotlinInteropModuleRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/KotlinInteropModuleRegistry.kt
@@ -1,6 +1,6 @@
 package expo.modules.kotlin
 
-import com.facebook.react.bridge.ReactContext
+import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.uimanager.ViewManager
 import expo.modules.core.Promise
@@ -16,7 +16,7 @@ private typealias ModuleMethodInfo = Map<String, Any?>
 class KotlinInteropModuleRegistry(
   modulesProvider: ModulesProvider,
   legacyModuleRegistry: expo.modules.core.ModuleRegistry,
-  reactContext: WeakReference<ReactContext>
+  reactContext: WeakReference<ReactApplicationContext>
 ) {
   private val appContext = AppContext(modulesProvider, legacyModuleRegistry, reactContext)
   private val exportedViewManagerNames = mutableListOf<String>()


### PR DESCRIPTION
# Why

Adds a way of getting the `ReactApplicationContext`.

# How

Provided a way of accessing the `ReactApplicationContext` from the module. I've tried to rewrite the cellular module, but to do it, I need to obtain the react context somehow.

# Test Plan

- unit tests ✅