### PR TITLE
[expo-updates] fix handling of unexpectedly missing assets

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Fix Android app.manifest not generated when in OneSignal gradle plugin integration. ([#14938](https://github.com/expo/expo/pull/14938) by [@kudo](https://github.com/kudo))
 - Fix Android app.manifest not generated from [#14938](https://github.com/expo/expo/pull/14938) regression. ([#14953](https://github.com/expo/expo/pull/14953) by [@kudo](https://github.com/kudo))
 - Fix iOS app.manifest generation error in `eas build --local` mode. ([#14956](https://github.com/expo/expo/pull/14956) by [@kudo](https://github.com/kudo))
+- Fix handling of unexpectedly missing assets on iOS.
 
 ### 💡 Others
 

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -21,7 +21,7 @@
 - Fix Android app.manifest not generated when in OneSignal gradle plugin integration. ([#14938](https://github.com/expo/expo/pull/14938) by [@kudo](https://github.com/kudo))
 - Fix Android app.manifest not generated from [#14938](https://github.com/expo/expo/pull/14938) regression. ([#14953](https://github.com/expo/expo/pull/14953) by [@kudo](https://github.com/kudo))
 - Fix iOS app.manifest generation error in `eas build --local` mode. ([#14956](https://github.com/expo/expo/pull/14956) by [@kudo](https://github.com/kudo))
-- Fix handling of unexpectedly missing assets on iOS.
+- Fix handling of unexpectedly missing assets on iOS. ([#15008](https://github.com/expo/expo/pull/15008) by [@esamelson](https://github.com/esamelson))
 
 ### 💡 Others
 

--- a/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesAppLauncherNoDatabase.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesAppLauncherNoDatabase.m
@@ -3,6 +3,7 @@
 #import <EXUpdates/EXUpdatesAsset.h>
 #import <EXUpdates/EXUpdatesAppLauncherNoDatabase.h>
 #import <EXUpdates/EXUpdatesEmbeddedAppLoader.h>
+#import <EXUpdates/EXUpdatesUtils.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -30,7 +31,7 @@ static NSString * const EXUpdatesErrorLogFile = @"expo-error.log";
 
       NSMutableDictionary *assetFilesMap = [NSMutableDictionary new];
       for (EXUpdatesAsset *asset in _launchedUpdate.assets) {
-        NSURL *localUrl = [[NSBundle mainBundle] URLForResource:asset.mainBundleFilename withExtension:asset.type];
+        NSURL *localUrl = [EXUpdatesUtils urlForBundledAsset:asset];
         if (localUrl && asset.key) {
           assetFilesMap[asset.key] = localUrl.absoluteString;
         }

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesEmbeddedAppLoader.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesEmbeddedAppLoader.m
@@ -2,6 +2,7 @@
 
 #import <EXUpdates/EXUpdatesFileDownloader.h>
 #import <EXUpdates/EXUpdatesEmbeddedAppLoader.h>
+#import <EXUpdates/EXUpdatesUtils.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -101,9 +102,7 @@ static NSString * const EXUpdatesEmbeddedAppLoaderErrorDomain = @"EXUpdatesEmbed
       });
     } else {
       NSAssert(asset.mainBundleFilename, @"embedded asset mainBundleFilename must be nonnull");
-      NSString *bundlePath = asset.mainBundleDir
-        ? [[NSBundle mainBundle] pathForResource:asset.mainBundleFilename ofType:asset.type inDirectory:asset.mainBundleDir]
-        : [[NSBundle mainBundle] pathForResource:asset.mainBundleFilename ofType:asset.type];
+      NSString *bundlePath = [EXUpdatesUtils pathForBundledAsset:asset];
       NSAssert(bundlePath, @"NSBundle must contain the expected assets");
 
       if (!bundlePath) {

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesUtils.h
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesUtils.h
@@ -2,6 +2,7 @@
 
 #import <React/RCTBridge.h>
 
+#import <EXUpdates/EXUpdatesAsset.h>
 #import <EXUpdates/EXUpdatesConfig.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -14,6 +15,8 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)sendEventToBridge:(nullable RCTBridge *)bridge withType:(NSString *)eventType body:(NSDictionary *)body;
 + (BOOL)shouldCheckForUpdateWithConfig:(EXUpdatesConfig *)config;
 + (NSString *)getRuntimeVersionWithConfig:(EXUpdatesConfig *)config;
++ (NSURL *)urlForBundledAsset:(EXUpdatesAsset *)asset;
++ (NSString *)pathForBundledAsset:(EXUpdatesAsset *)asset;
 
 @end
 

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesUtils.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesUtils.m
@@ -107,6 +107,20 @@ static NSString * const EXUpdatesUtilsErrorDomain = @"EXUpdatesUtils";
   return config.runtimeVersion ?: config.sdkVersion ?: @"1";
 }
 
++ (NSURL *)urlForBundledAsset:(EXUpdatesAsset *)asset
+{
+  return asset.mainBundleDir
+    ? [[NSBundle mainBundle] URLForResource:asset.mainBundleFilename withExtension:asset.type subdirectory:asset.mainBundleDir]
+    : [[NSBundle mainBundle] URLForResource:asset.mainBundleFilename withExtension:asset.type];
+}
+
++ (NSString *)pathForBundledAsset:(EXUpdatesAsset *)asset
+{
+  return asset.mainBundleDir
+    ? [[NSBundle mainBundle] pathForResource:asset.mainBundleFilename ofType:asset.type inDirectory:asset.mainBundleDir]
+    : [[NSBundle mainBundle] pathForResource:asset.mainBundleFilename ofType:asset.type];
+}
+
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
# Why

partially addresses #14930

The issue in #14930 is caused by assets that are unexpectedly missing, i.e. in the local SQLite db but expo-updates cannot find them on disk. It looks like the logic to handle this case wasn't properly updated after https://github.com/expo/expo/pull/8007 (no publish workflow) and does not handle assets bundled in a subdirectory of the main bundle.

This PR fixes the fallback code, which should mitigate/resolve 14930 for now. However, it does not address the root cause -- i.e. why so many people are suddenly reporting unexpectedly missing assets after upgrading to SDK 43. We will need to continue to investigate this.

# How

Use utility method to search in main bundle subdirectory if `asset.mainBundleDir` is defined (a field only set in embedded manifests where the update is bundled by RN's bundling script).

# Test Plan

1. Create SDK 43 app with expo-font and @expo/vector-icons dependencies.
2. Make release build for simulator, and swipe it closed.
3. Find application directory on disk (in `~/Library/Developer/CoreSimulator/`) and manually delete all ttf files from `Library/Application Support/.expo-internal/`.
4. Run app again and notice that ttf files reappear in the .expo-internal directory.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
