### PR TITLE
[notifications][android] upgrade firebase messaging and replace "getInstanceId" call

### DIFF
--- a/android/expoview/build.gradle
+++ b/android/expoview/build.gradle
@@ -354,7 +354,7 @@ dependencies {
   api 'com.google.android.material:material:1.1.0'
 
   api 'com.google.firebase:firebase-core:17.2.3'
-  api 'com.google.firebase:firebase-messaging:20.2.4'
+  api 'com.google.firebase:firebase-messaging:22.0.0'
   api 'com.google.maps.android:android-maps-utils:0.5'
   // Remember to update DetachAppTemplate build.gradle if you add any excludes or transitive = false here!
 

--- a/android/expoview/build.gradle
+++ b/android/expoview/build.gradle
@@ -354,7 +354,7 @@ dependencies {
   api 'com.google.android.material:material:1.1.0'
 
   api 'com.google.firebase:firebase-core:17.2.3'
-  api 'com.google.firebase:firebase-messaging:21.0.0'
+  api 'com.google.firebase:firebase-messaging:21.1.0'
   api 'com.google.maps.android:android-maps-utils:0.5'
   // Remember to update DetachAppTemplate build.gradle if you add any excludes or transitive = false here!
 

--- a/android/expoview/build.gradle
+++ b/android/expoview/build.gradle
@@ -354,7 +354,7 @@ dependencies {
   api 'com.google.android.material:material:1.1.0'
 
   api 'com.google.firebase:firebase-core:17.2.3'
-  api 'com.google.firebase:firebase-messaging:22.0.0'
+  api 'com.google.firebase:firebase-messaging:21.0.0'
   api 'com.google.maps.android:android-maps-utils:0.5'
   // Remember to update DetachAppTemplate build.gradle if you add any excludes or transitive = false here!
 

--- a/android/versioned-abis/expoview-abi43_0_0/build.gradle
+++ b/android/versioned-abis/expoview-abi43_0_0/build.gradle
@@ -143,7 +143,7 @@ dependencies {
   api 'com.google.android.material:material:1.1.0'
 
   api 'com.google.firebase:firebase-core:17.2.3'
-  api 'com.google.firebase:firebase-messaging:22.0.0'
+  api 'com.google.firebase:firebase-messaging:21.0.0'
   api 'com.google.maps.android:android-maps-utils:0.5'
   // Remember to update DetachAppTemplate build.gradle if you add any excludes or transitive = false here!
 

--- a/android/versioned-abis/expoview-abi43_0_0/build.gradle
+++ b/android/versioned-abis/expoview-abi43_0_0/build.gradle
@@ -143,7 +143,7 @@ dependencies {
   api 'com.google.android.material:material:1.1.0'
 
   api 'com.google.firebase:firebase-core:17.2.3'
-  api 'com.google.firebase:firebase-messaging:21.0.0'
+  api 'com.google.firebase:firebase-messaging:21.1.0'
   api 'com.google.maps.android:android-maps-utils:0.5'
   // Remember to update DetachAppTemplate build.gradle if you add any excludes or transitive = false here!
 

--- a/android/versioned-abis/expoview-abi43_0_0/build.gradle
+++ b/android/versioned-abis/expoview-abi43_0_0/build.gradle
@@ -143,7 +143,7 @@ dependencies {
   api 'com.google.android.material:material:1.1.0'
 
   api 'com.google.firebase:firebase-core:17.2.3'
-  api 'com.google.firebase:firebase-messaging:20.2.4'
+  api 'com.google.firebase:firebase-messaging:22.0.0'
   api 'com.google.maps.android:android-maps-utils:0.5'
   // Remember to update DetachAppTemplate build.gradle if you add any excludes or transitive = false here!
 

--- a/android/versioned-abis/expoview-abi43_0_0/src/main/java/abi43_0_0/expo/modules/notifications/tokens/PushTokenModule.java
+++ b/android/versioned-abis/expoview-abi43_0_0/src/main/java/abi43_0_0/expo/modules/notifications/tokens/PushTokenModule.java
@@ -5,8 +5,7 @@ import android.os.Bundle;
 
 import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.Task;
-import com.google.firebase.iid.FirebaseInstanceId;
-import com.google.firebase.iid.InstanceIdResult;
+import com.google.firebase.messaging.FirebaseMessaging;
 
 import abi43_0_0.expo.modules.core.ExportedModule;
 import abi43_0_0.expo.modules.core.ModuleRegistry;
@@ -61,10 +60,10 @@ public class PushTokenModule extends ExportedModule implements PushTokenListener
    */
   @ExpoMethod
   public void getDevicePushTokenAsync(final Promise promise) {
-    FirebaseInstanceId.getInstance().getInstanceId()
-        .addOnCompleteListener(new OnCompleteListener<InstanceIdResult>() {
+    FirebaseMessaging.getInstance().getToken()
+        .addOnCompleteListener(new OnCompleteListener<String>() {
           @Override
-          public void onComplete(@NonNull Task<InstanceIdResult> task) {
+          public void onComplete(@NonNull Task<String> task) {
             if (!task.isSuccessful() || task.getResult() == null) {
               if (task.getException() == null) {
                 promise.reject(REGISTRATION_FAIL_CODE, "Fetching the token failed.");
@@ -74,7 +73,7 @@ public class PushTokenModule extends ExportedModule implements PushTokenListener
               return;
             }
 
-            String token = task.getResult().getToken();
+            String token = task.getResult();
 
             promise.resolve(token);
             onNewToken(token);

--- a/android/versioned-abis/expoview-abi44_0_0/build.gradle
+++ b/android/versioned-abis/expoview-abi44_0_0/build.gradle
@@ -144,7 +144,7 @@ dependencies {
   api 'com.google.android.material:material:1.1.0'
 
   api 'com.google.firebase:firebase-core:17.2.3'
-  api 'com.google.firebase:firebase-messaging:20.2.4'
+  api 'com.google.firebase:firebase-messaging:22.0.0'
   api 'com.google.maps.android:android-maps-utils:0.5'
   // Remember to update DetachAppTemplate build.gradle if you add any excludes or transitive = false here!
 

--- a/android/versioned-abis/expoview-abi44_0_0/build.gradle
+++ b/android/versioned-abis/expoview-abi44_0_0/build.gradle
@@ -144,7 +144,7 @@ dependencies {
   api 'com.google.android.material:material:1.1.0'
 
   api 'com.google.firebase:firebase-core:17.2.3'
-  api 'com.google.firebase:firebase-messaging:22.0.0'
+  api 'com.google.firebase:firebase-messaging:21.0.0'
   api 'com.google.maps.android:android-maps-utils:0.5'
   // Remember to update DetachAppTemplate build.gradle if you add any excludes or transitive = false here!
 

--- a/android/versioned-abis/expoview-abi44_0_0/build.gradle
+++ b/android/versioned-abis/expoview-abi44_0_0/build.gradle
@@ -144,7 +144,7 @@ dependencies {
   api 'com.google.android.material:material:1.1.0'
 
   api 'com.google.firebase:firebase-core:17.2.3'
-  api 'com.google.firebase:firebase-messaging:21.0.0'
+  api 'com.google.firebase:firebase-messaging:21.1.0'
   api 'com.google.maps.android:android-maps-utils:0.5'
   // Remember to update DetachAppTemplate build.gradle if you add any excludes or transitive = false here!
 

--- a/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/expo/modules/notifications/tokens/PushTokenModule.java
+++ b/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/expo/modules/notifications/tokens/PushTokenModule.java
@@ -5,8 +5,7 @@ import android.os.Bundle;
 
 import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.Task;
-import com.google.firebase.iid.FirebaseInstanceId;
-import com.google.firebase.iid.InstanceIdResult;
+import com.google.firebase.messaging.FirebaseMessaging;
 
 import abi44_0_0.expo.modules.core.ExportedModule;
 import abi44_0_0.expo.modules.core.ModuleRegistry;
@@ -61,10 +60,10 @@ public class PushTokenModule extends ExportedModule implements PushTokenListener
    */
   @ExpoMethod
   public void getDevicePushTokenAsync(final Promise promise) {
-    FirebaseInstanceId.getInstance().getInstanceId()
-        .addOnCompleteListener(new OnCompleteListener<InstanceIdResult>() {
+    FirebaseMessaging.getInstance().getToken()
+        .addOnCompleteListener(new OnCompleteListener<String>() {
           @Override
-          public void onComplete(@NonNull Task<InstanceIdResult> task) {
+          public void onComplete(@NonNull Task<String> task) {
             if (!task.isSuccessful() || task.getResult() == null) {
               if (task.getException() == null) {
                 promise.reject(REGISTRATION_FAIL_CODE, "Fetching the token failed.");
@@ -74,7 +73,7 @@ public class PushTokenModule extends ExportedModule implements PushTokenListener
               return;
             }
 
-            String token = task.getResult().getToken();
+            String token = task.getResult();
 
             promise.resolve(token);
             onNewToken(token);

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Upgrade firebase messaging dependency to v21. This means `expo-notifications` no longer relies on `FirebaseInstanceId`. If you added `com.google.firebase:firebase-iid` to your `android/app/build.gradle` file for this library, it is no longer required and you can safely remove that dependency. ([#15010](https://github.com/expo/expo/pull/15010) by [@cruzach](https://github.com/cruzach))
+
 ### 💡 Others
 
 - Updated `@expo/config-plugins` from `4.0.2` to `4.0.14` and `@expo/image-utils` from `^0.3.16` to `^0.3.18` ([#15621](https://github.com/expo/expo/pull/15621) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/expo-notifications/android/build.gradle
+++ b/packages/expo-notifications/android/build.gradle
@@ -93,7 +93,7 @@ dependencies {
 
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
 
-  api 'com.google.firebase:firebase-messaging:20.2.4'
+  api 'com.google.firebase:firebase-messaging:22.0.0'
 
   api 'me.leolin:ShortcutBadger:1.1.22@aar'
 }

--- a/packages/expo-notifications/android/build.gradle
+++ b/packages/expo-notifications/android/build.gradle
@@ -93,7 +93,7 @@ dependencies {
 
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
 
-  api 'com.google.firebase:firebase-messaging:22.0.0'
+  api 'com.google.firebase:firebase-messaging:21.0.0'
 
   api 'me.leolin:ShortcutBadger:1.1.22@aar'
 }

--- a/packages/expo-notifications/android/build.gradle
+++ b/packages/expo-notifications/android/build.gradle
@@ -93,7 +93,7 @@ dependencies {
 
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
 
-  api 'com.google.firebase:firebase-messaging:21.0.0'
+  api 'com.google.firebase:firebase-messaging:21.1.0'
 
   api 'me.leolin:ShortcutBadger:1.1.22@aar'
 }

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/tokens/PushTokenModule.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/tokens/PushTokenModule.java
@@ -5,8 +5,7 @@ import android.os.Bundle;
 
 import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.Task;
-import com.google.firebase.iid.FirebaseInstanceId;
-import com.google.firebase.iid.InstanceIdResult;
+import com.google.firebase.messaging.FirebaseMessaging;
 
 import expo.modules.core.ExportedModule;
 import expo.modules.core.ModuleRegistry;
@@ -61,10 +60,10 @@ public class PushTokenModule extends ExportedModule implements PushTokenListener
    */
   @ExpoMethod
   public void getDevicePushTokenAsync(final Promise promise) {
-    FirebaseInstanceId.getInstance().getInstanceId()
-        .addOnCompleteListener(new OnCompleteListener<InstanceIdResult>() {
+    FirebaseMessaging.getInstance().getToken()
+        .addOnCompleteListener(new OnCompleteListener<String>() {
           @Override
-          public void onComplete(@NonNull Task<InstanceIdResult> task) {
+          public void onComplete(@NonNull Task<String> task) {
             if (!task.isSuccessful() || task.getResult() == null) {
               if (task.getException() == null) {
                 promise.reject(REGISTRATION_FAIL_CODE, "Fetching the token failed.");
@@ -74,7 +73,7 @@ public class PushTokenModule extends ExportedModule implements PushTokenListener
               return;
             }
 
-            String token = task.getResult().getToken();
+            String token = task.getResult();
 
             promise.resolve(token);
             onNewToken(token);


### PR DESCRIPTION
# Why

closes https://github.com/expo/expo/issues/14860

also users no longer need to manually add the firebase instance ID library if they are using a higher version of Firebase in their app (see https://forums.expo.dev/t/cant-get-expotoken-in-expo-notification-due-to-failed-resolution-of-lcom-google-firebase-iid-firebaseinstanceid/53265)

# How

https://firebase.google.com/docs/projects/manage-installations#retrieving-an-identifier

# Test Plan

Tested in a bare app, expo push token and device push token are the same as before the changes

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
