### PR TITLE
[docs] Update apple authentication to reflect EAS usage

### DIFF
--- a/docs/pages/versions/unversioned/sdk/apple-authentication.md
+++ b/docs/pages/versions/unversioned/sdk/apple-authentication.md
@@ -19,7 +19,33 @@ Beginning with iOS 13, any app that includes third-party authentication options 
 
 ## Configuration
 
-1. Enable the "Sign In with Apple" capability in your app. For bare projects, enable the capability in Xcode under "Signing & Capabilities" -- you'll need to be on Xcode 11 or later. For managed projects, set `ios.usesAppleSignIn` to `true` in app.json.
+### EAS Build
+
+This guide assumes [auto capability sync](../../build-reference/ios-capabilities) is enabled (Default). Otherwise you'll need to manually enable the capabilities for your bundle identifier through the Apple Developer Console.
+
+#### Managed Workflow
+
+1. Build with `eas build -p ios`. EAS Build and the config plugin will automatically configure this service with Apple.
+
+#### Bare Workflow
+
+1. Ensure you've added enabled the Apple Sign In capability, either through the Xcode:
+
+- Signing & Capabilities > + Capability > Sign in with Apple
+- Or by adding the entitlement to your `ios/[app]/[app].entitlements` file
+  ```xml
+  <key>com.apple.developer.applesignin</key>
+  <array>
+    <string>Default</string>
+  </array>
+  ```
+
+2. Add `"CFBundleAllowMixedLocalizations": true` to your `ios/[app]/Info.plist` to ensure the sign in button uses the device locale.
+3. Build with `eas build -p ios`. EAS Build will automatically configure this service with Apple.
+
+### Classic Build
+
+1. For managed projects, set `ios.usesAppleSignIn` to `true` in `app.json`. For bare, enable the "Sign In with Apple" capability in your app. For bare projects, enable the capability in Xcode under "Signing & Capabilities" -- you'll need to be on Xcode 11 or later.
 2. Log into the Apple Developer Console, go to "Certificates, Identifiers, & Profiles" and then "Identifiers".
 3. You need to choose a primary app for the Apple Sign In configuration. This is the app whose icon will show up in the Apple Sign In system UI. If you have a set of related apps you might choose the "main" app as the primary, but most likely you'll want to just use the app you're working on now as the primary.
 4. In the list of identifiers, click on the one corresponding to your primary app. Enable the "Sign In with Apple" capability, click "Edit", and choose the "Enable as a primary App ID" option. Save the new configuration.

--- a/docs/pages/versions/unversioned/sdk/apple-authentication.md
+++ b/docs/pages/versions/unversioned/sdk/apple-authentication.md
@@ -21,7 +21,7 @@ Beginning with iOS 13, any app that includes third-party authentication options 
 
 ### EAS Build
 
-This guide assumes [auto capability sync](../../build-reference/ios-capabilities) is enabled (Default). Otherwise you'll need to manually enable the capabilities for your bundle identifier through the Apple Developer Console.
+This guide assumes [auto capability sync](../../../build-reference/ios-capabilities) is enabled (Default). Otherwise you'll need to manually enable the capabilities for your bundle identifier through the Apple Developer Console.
 
 #### Managed Workflow
 

--- a/docs/pages/versions/v43.0.0/sdk/apple-authentication.md
+++ b/docs/pages/versions/v43.0.0/sdk/apple-authentication.md
@@ -19,7 +19,33 @@ Beginning with iOS 13, any app that includes third-party authentication options 
 
 ## Configuration
 
-1. Enable the "Sign In with Apple" capability in your app. For bare projects, enable the capability in Xcode under "Signing & Capabilities" -- you'll need to be on Xcode 11 or later. For managed projects, set `ios.usesAppleSignIn` to `true` in app.json.
+### EAS Build
+
+This guide assumes [auto capability sync](../../../build-reference/ios-capabilities) is enabled (Default). Otherwise you'll need to manually enable the capabilities for your bundle identifier through the Apple Developer Console.
+
+#### Managed Workflow
+
+1. Build with `eas build -p ios`. EAS Build and the config plugin will automatically configure this service with Apple.
+
+#### Bare Workflow
+
+1. Ensure you've added enabled the Apple Sign In capability, either through the Xcode:
+
+- Signing & Capabilities > + Capability > Sign in with Apple
+- Or by adding the entitlement to your `ios/[app]/[app].entitlements` file
+  ```xml
+  <key>com.apple.developer.applesignin</key>
+  <array>
+    <string>Default</string>
+  </array>
+  ```
+
+2. Add `"CFBundleAllowMixedLocalizations": true` to your `ios/[app]/Info.plist` to ensure the sign in button uses the device locale.
+3. Build with `eas build -p ios`. EAS Build will automatically configure this service with Apple.
+
+### Classic Build
+
+1. For managed projects, set `ios.usesAppleSignIn` to `true` in `app.json`. For bare, enable the "Sign In with Apple" capability in your app. For bare projects, enable the capability in Xcode under "Signing & Capabilities" -- you'll need to be on Xcode 11 or later.
 2. Log into the Apple Developer Console, go to "Certificates, Identifiers, & Profiles" and then "Identifiers".
 3. You need to choose a primary app for the Apple Sign In configuration. This is the app whose icon will show up in the Apple Sign In system UI. If you have a set of related apps you might choose the "main" app as the primary, but most likely you'll want to just use the app you're working on now as the primary.
 4. In the list of identifiers, click on the one corresponding to your primary app. Enable the "Sign In with Apple" capability, click "Edit", and choose the "Enable as a primary App ID" option. Save the new configuration.


### PR DESCRIPTION
# Why

EAS Build works a bit differently to the classic build service