### PR TITLE
[updates] Workaround double bridge initialization

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Workaround double bridge initializaed from startup. ([#15019](https://github.com/expo/expo/pull/15019) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 0.10.11 — 2021-11-02

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Workaround double bridge initializaed from startup. ([#15019](https://github.com/expo/expo/pull/15019) by [@kudo](https://github.com/kudo))
+- Workaround for bridge being initialized twice on startup. ([#15019](https://github.com/expo/expo/pull/15019) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesAppDelegate.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesAppDelegate.m
@@ -53,9 +53,14 @@ EX_REGISTER_SINGLETON_MODULE(EXUpdatesAppDelegate)
     // we just skip in this case.
     return NO;
   }
+  UIWindow *window = application.delegate.window;
+  if ([window.rootViewController.view isKindOfClass:[RCTRootView class]]) {
+    RCTRootView *rootView = (RCTRootView *)window.rootViewController.view;
+    [rootView.bridge invalidate];
+  }
   self.launchOptions = launchOptions;
   controller.delegate = self;
-  [controller startAndShowLaunchScreen:application.delegate.window];
+  [controller startAndShowLaunchScreen:window];
   return YES;
 }
 


### PR DESCRIPTION
# Why

in expo-updates auto setup flow, we will actually initialize two bridge from startup. the first is from AppDelegate and later replaced with the one from EXUpdatesAppDelegate. if user setup some js code from launch, e.g. faceid authentication. there's chance for user to see faceid authentication twice.

# How

invalidate the first bridge as soon as possible. this is a workaround for sdk43. we will propose a better solution for modules to determine who to create the bridge in sdk44.

# Test Plan

1. keep re-launch release build app to make sure the early invalidation did not have crash.
2. `expo publish` and make sure update works.
3.  `SplashScreen.preventAutoHideAsync()` and delayed `SplashScreen.hideAsync()` after 3000ms to make sure splash screen can keep there longer.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
