### PR TITLE
[Location][Android] Check for null value of mLocationClient to prevent a crash

### DIFF
--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 🐛 Bug fixes
 
 - Call `jobService.jobFinished` for the finished geofencing jobs. ([#14786](https://github.com/expo/expo/pull/14786) by [@mdmitry01](https://github.com/mdmitry01))
+- Check for null value of `mLocationClient` to prevent a crash ([#15023](https://github.com/expo/expo/pull/15023) by [@zakharchenkoAndrii](https://github.com/zakharchenkoAndrii))
 
 ### 💡 Others
 

--- a/packages/expo-location/android/src/main/java/expo/modules/location/taskConsumers/LocationTaskConsumer.java
+++ b/packages/expo-location/android/src/main/java/expo/modules/location/taskConsumers/LocationTaskConsumer.java
@@ -111,6 +111,10 @@ public class LocationTaskConsumer extends TaskConsumer implements TaskConsumerIn
       maybeReportDeferredLocations();
     } else {
       try {
+        if(mLocationClient == null){
+          Log.w(TAG, "LocationClient is null.");
+          return;
+        }
         mLocationClient.getLastLocation().addOnCompleteListener(new OnCompleteListener<Location>() {
           @Override
           public void onComplete(@NonNull Task<Location> task) {


### PR DESCRIPTION
# Why

Resolves #11089 

PR Fixes android crash that is produced by `mLocationClient.getLastLocation()` when `mLocationClient` is `null`

```
java.lang.NullPointerException: Attempt to invoke virtual method 'com.google.android.gms.tasks.Task com.google.android.gms.location.FusedLocationProviderClient.getLastLocation()' on a null object reference
    at expo.modules.location.taskConsumers.LocationTaskConsumer.didReceiveBroadcast(LocationTaskConsumer.java:114)
    at expo.modules.taskManager.TaskService.handleIntent(TaskService.java:313)
    at expo.modules.taskManager.TaskBroadcastReceiver.onReceive(TaskBroadcastReceiver.java:15)
    at android.app.ActivityThread.handleReceiver(ActivityThread.java:4478)
    at android.app.ActivityThread.access$1600(ActivityThread.java:301)
    at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2169)
    at android.os.Handler.dispatchMessage(Handler.java:106)
    at android.os.Looper.loop(Looper.java:246)
    at android.app.ActivityThread.main(ActivityThread.java:8595)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:602)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1130)

java.lang.RuntimeException: Unable to start receiver expo.modules.taskManager.TaskBroadcastReceiver: java.lang.NullPointerException: Attempt to invoke virtual method 'com.google.android.gms.tasks.Task com.google.android.gms.location.FusedLocationProviderClient.getLastLocation()' on a null object reference
    at android.app.ActivityThread.handleReceiver(ActivityThread.java:4487)
    at android.app.ActivityThread.access$1600(ActivityThread.java:301)
    at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2169)
    at android.os.Handler.dispatchMessage(Handler.java:106)
    at android.os.Looper.loop(Looper.java:246)
    at android.app.ActivityThread.main(ActivityThread.java:8595)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:602)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1130)
```

# How

Why:
After killing the app and destroying the Main Activity `didReceiveBroadcast` has been called and since objects were unregistered (`didUnregister`) we are calling `mLocationClient.getLastLocation()` on a null object hence receiving a crash.

How:
Added null check to prevent a crash.

# Test Plan
Unfortunately, I haven't managed to reproduce this issue on my devices. But since we are receiving Sentry crash reports about that, the issue is still valid.


# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
