### PR TITLE
[splash-screens] Fix removing KVO exception if keyWindow changed

### DIFF
--- a/packages/expo-splash-screen/CHANGELOG.md
+++ b/packages/expo-splash-screen/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix `Cannot remove an observer <EXSplashScreenService> for the key path "rootViewController"` exception if applcation keyWindow changed. ([#14982](https://github.com/expo/expo/pull/14982) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 0.13.4 — 2021-10-22

--- a/packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenService.m
+++ b/packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenService.m
@@ -167,7 +167,8 @@ EX_REGISTER_SINGLETON_MODULE(SplashScreen);
 {
   NSAssert([NSThread isMainThread], @"Method must be called on main thread");
   if (self.observingRootViewController != nil) {
-    [UIApplication.sharedApplication.keyWindow removeObserver:self forKeyPath:kRootViewController context:nil];
+    UIWindow *window = self.observingRootViewController.view.window;
+    [window removeObserver:self forKeyPath:kRootViewController context:nil];
     [self.observingRootViewController removeObserver:self forKeyPath:kView context:nil];
     self.observingRootViewController = nil;
   }


### PR DESCRIPTION
# Why

fix #14982 where at the time to remove KVO, the keyWindow may change to different one. in [the case](https://github.com/expo/expo/issues/14982#issuecomment-958615074), the keyWindow is the alert window.

# How

remove KVO for the `observingRootViewController`'s window.

# Test Plan

follow [the test case](https://github.com/expo/expo/issues/14982#issuecomment-958615074) and make sure app will not crash

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
