### PR TITLE
[tools] Fix versioning C++ code on iOS

### DIFF
--- a/packages/expo-av/ios/EXAV/AudioSampleCallback/AudioSampleCallbackWrapper.h
+++ b/packages/expo-av/ios/EXAV/AudioSampleCallback/AudioSampleCallbackWrapper.h
@@ -5,14 +5,14 @@
 #import <jsi/jsi.h>
 
 // TODO: Replace this with <ReactCommon/TurboModuleUtils.h> after we upgrade to RN 0.66
-#import <EXAV/ReactCallbackWrapper.h>
+#import <EXAV/CallbackWrapper.h>
 
 namespace jsi = facebook::jsi;
 using CallInvoker = facebook::react::CallInvoker;
 
 // TODO: Replace this with just facebook::react namespace after we upgrade to RN 0.66
-using JsiCallbackWrapper = expo::facebook::react::CallbackWrapper;
-using LongLivedObjectCollection = expo::facebook::react::LongLivedObjectCollection;
+using JsiCallbackWrapper = expo::CallbackWrapper;
+using LongLivedObjectCollection = expo::LongLivedObjectCollection;
 
 namespace expo {
 namespace av {

--- a/packages/expo-av/ios/EXAV/AudioSampleCallback/Utils/CallbackWrapper.h
+++ b/packages/expo-av/ios/EXAV/AudioSampleCallback/Utils/CallbackWrapper.h
@@ -28,8 +28,6 @@ using CallInvoker = facebook::react::CallInvoker;
  * We need to wrap it in another napespace, because it would conflict with existing RN implementation
  */
 namespace expo {
-namespace facebook {
-namespace react {
 
 /**
  * A simple wrapper class that can be registered to a collection that  keep it
@@ -150,6 +148,4 @@ class CallbackWrapper : public LongLivedObject {
   }
 };
 
-} // namespace react
-} // namespace facebook
 }

--- a/packages/expo-av/ios/EXAV/AudioSampleCallback/Utils/CallbackWrapper.mm
+++ b/packages/expo-av/ios/EXAV/AudioSampleCallback/Utils/CallbackWrapper.mm
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <EXAV/ReactCallbackWrapper.h>
+#import <EXAV/CallbackWrapper.h>
 
 /**
  * NOTE: This file is a copy of ReactCommon/LongLivedObject.cpp
@@ -16,8 +16,6 @@
  * We need to wrap it in another napespace, because it would conflict with existing RN implementation
  */
 namespace expo {
-namespace facebook {
-namespace react {
 
 // LongLivedObjectCollection
 LongLivedObjectCollection &LongLivedObjectCollection::get() {
@@ -53,7 +51,5 @@ void LongLivedObject::allowRelease() {
   LongLivedObjectCollection::get().remove(this);
 }
 
-} // namespace react
-} // namespace facebook
 }
 

--- a/packages/expo-av/ios/EXAV/EXAVPlayerData.m
+++ b/packages/expo-av/ios/EXAV/EXAVPlayerData.m
@@ -883,11 +883,11 @@ NSString *const EXAVPlayerDataObserverMetadataKeyPath = @"timedMetadata";
 
       callbacks.version = kMTAudioProcessingTapCallbacksVersion_0;
       callbacks.clientInfo = (__bridge void *)self,
-      callbacks.init = tapInit;
-      callbacks.finalize = tapFinalize;
-      callbacks.prepare = tapPrepare;
-      callbacks.unprepare = tapUnprepare;
-      callbacks.process = tapProcess;
+      callbacks.init = EXTapInit;
+      callbacks.finalize = EXTapFinalize;
+      callbacks.prepare = EXTapPrepare;
+      callbacks.unprepare = EXTapUnprepare;
+      callbacks.process = EXTapProcess;
 
       MTAudioProcessingTapRef audioProcessingTap;
       OSStatus status = MTAudioProcessingTapCreate(kCFAllocatorDefault, &callbacks, kMTAudioProcessingTapCreationFlag_PreEffects, &audioProcessingTap);
@@ -913,7 +913,7 @@ NSString *const EXAVPlayerDataObserverMetadataKeyPath = @"timedMetadata";
 
 #pragma mark - Audio Sample Buffer Callbacks (MTAudioProcessingTapCallbacks)
 
-void tapInit(MTAudioProcessingTapRef tap, void *clientInfo, void **tapStorageOut)
+void EXTapInit(MTAudioProcessingTapRef tap, void *clientInfo, void **tapStorageOut)
 {
   AVAudioTapProcessorContext *context = calloc(1, sizeof(AVAudioTapProcessorContext));
 
@@ -924,7 +924,7 @@ void tapInit(MTAudioProcessingTapRef tap, void *clientInfo, void **tapStorageOut
   *tapStorageOut = context;
 }
 
-void tapFinalize(MTAudioProcessingTapRef tap)
+void EXTapFinalize(MTAudioProcessingTapRef tap)
 {
   AVAudioTapProcessorContext *context = (AVAudioTapProcessorContext *)MTAudioProcessingTapGetStorage(tap);
 
@@ -934,7 +934,7 @@ void tapFinalize(MTAudioProcessingTapRef tap)
   free(context);
 }
 
-void tapPrepare(MTAudioProcessingTapRef tap, CMItemCount maxFrames, const AudioStreamBasicDescription *processingFormat)
+void EXTapPrepare(MTAudioProcessingTapRef tap, CMItemCount maxFrames, const AudioStreamBasicDescription *processingFormat)
 {
   AVAudioTapProcessorContext *context = (AVAudioTapProcessorContext *)MTAudioProcessingTapGetStorage(tap);
 
@@ -954,14 +954,14 @@ void tapPrepare(MTAudioProcessingTapRef tap, CMItemCount maxFrames, const AudioS
   }
 }
 
-void tapUnprepare(MTAudioProcessingTapRef tap)
+void EXTapUnprepare(MTAudioProcessingTapRef tap)
 {
   AVAudioTapProcessorContext *context =
     (AVAudioTapProcessorContext *)MTAudioProcessingTapGetStorage(tap);
   context->self = NULL;
 }
 
-void tapProcess(MTAudioProcessingTapRef tap, CMItemCount numberFrames, MTAudioProcessingTapFlags flags, AudioBufferList *bufferListInOut, CMItemCount *numberFramesOut, MTAudioProcessingTapFlags *flagsOut)
+void EXTapProcess(MTAudioProcessingTapRef tap, CMItemCount numberFrames, MTAudioProcessingTapFlags flags, AudioBufferList *bufferListInOut, CMItemCount *numberFramesOut, MTAudioProcessingTapFlags *flagsOut)
 {
   AVAudioTapProcessorContext *context =
     (AVAudioTapProcessorContext *)MTAudioProcessingTapGetStorage(tap);

--- a/packages/expo-modules-autolinking/scripts/ios/cocoapods/pod_target.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/cocoapods/pod_target.rb
@@ -24,7 +24,9 @@ module Pod
 
       # Make ReactCommon specs define a module. This is required for ExpoModulesCore
       # to use `ReactCommon/turbomodule/core` subspec as a module, from Swift.
-      if !original_result && name == 'ReactCommon'
+      # It also needs to handle versioned pods in Expo Go, so we check if the pod name
+      # ends with `ReactCommon` instead of checking if they're equal.
+      if !original_result && name.end_with?('ReactCommon')
         root_spec.consumer(platform).pod_target_xcconfig['DEFINES_MODULE'] = 'YES'
         return @defines_module = true
       end

--- a/tools/src/versioning/ios/transforms/expoModulesTransforms.ts
+++ b/tools/src/versioning/ios/transforms/expoModulesTransforms.ts
@@ -86,17 +86,25 @@ export function expoModulesTransforms(prefix: string): FileTransforms {
         replaceWith: `namespace ${prefix}$1`,
       },
       {
-        // Prefixes versionable namespaces (react namespace is already prefixed with uppercased "R")
-        paths: objcFilesPattern,
-        find: /\bnamespace react\b/g,
-        replaceWith: `namespace ${prefix}React`,
-      },
-      {
         // Prefixes usages of versionable namespaces
         paths: objcFilesPattern,
         find: /\b(expo|facebook)::/g,
         replaceWith: `${prefix}$1::`,
       },
+
+      // Prefixes versionable namespaces (react namespace is already prefixed with uppercased "R")
+      {
+        paths: objcFilesPattern,
+        find: /::react::/g,
+        replaceWith: `::${prefix}React::`,
+      },
+      {
+        paths: objcFilesPattern,
+        find: /\bnamespace react\b/g,
+        replaceWith: `namespace ${prefix}React`,
+      },
+
+      // Prefix umbrella header imports
       {
         paths: '*.h',
         find: /\b(\w+-umbrella\.h)\b/g,

--- a/tools/src/versioning/ios/transforms/expoModulesTransforms.ts
+++ b/tools/src/versioning/ios/transforms/expoModulesTransforms.ts
@@ -20,7 +20,7 @@ export function expoModulesTransforms(prefix: string): FileTransforms {
     ],
     content: [
       {
-        find: /\bReact/g,
+        find: /\bReact(?!Common)/g,
         replaceWith: `${prefix}React`,
       },
       {
@@ -72,6 +72,35 @@ export function expoModulesTransforms(prefix: string): FileTransforms {
         paths: ['EXNativeModulesProxy.m'],
         find: 'NSClassFromString(@"ExpoModulesProvider")',
         replaceWith: `NSClassFromString(@"${prefix}ExpoModulesProvider")`
+      },
+      {
+        // Prefixes imports from other React Native libs
+        paths: objcFilesPattern,
+        find: new RegExp(`#import <(ReactCommon|jsi)/(${prefix})?`, 'g'),
+        replaceWith: `#import <${prefix}$1/${prefix}`,
+      },
+      {
+        // Prefixes versionable namespaces
+        paths: objcFilesPattern,
+        find: /\bnamespace (expo|facebook)\b/g,
+        replaceWith: `namespace ${prefix}$1`,
+      },
+      {
+        // Prefixes versionable namespaces (react namespace is already prefixed with uppercased "R")
+        paths: objcFilesPattern,
+        find: /\bnamespace react\b/g,
+        replaceWith: `namespace ${prefix}React`,
+      },
+      {
+        // Prefixes usages of versionable namespaces
+        paths: objcFilesPattern,
+        find: /\b(expo|facebook)::/g,
+        replaceWith: `${prefix}$1::`,
+      },
+      {
+        paths: '*.h',
+        find: /\b(\w+-umbrella\.h)\b/g,
+        replaceWith: `${prefix}$1`,
       }
     ],
   };


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/runs/4058469885

# How

- Relaxed a condition in autolinking hack to make `ReactCommon` define a module in versioned code as well.
- Prefixing imports from `jsi` and `ReactCommon`.
- Prefixing `expo` and `facebook` namespaces.
- Various fixes for C++ code and `expo-av`

# Test Plan

CI is failing, but only because `yarn.lock` is not up-to-date (happens on master as well).
