### PR TITLE
Use expo start instead of react-native start

### DIFF
--- a/templates/expo-template-bare-minimum/package.json
+++ b/templates/expo-template-bare-minimum/package.json
@@ -7,7 +7,7 @@
     "android": "expo run:android",
     "ios": "expo run:ios",
     "web": "expo start --web",
-    "start": "react-native start"
+    "start": "expo start --dev-client"
   },
   "dependencies": {
     "expo": "~43.0.0-beta.3",


### PR DESCRIPTION
# Why

https://github.com/expo/expo-cli/pull/3972
