### PR TITLE
[expo-updates] check for duplicate asset rows when reaping

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Fix Android app.manifest not generated from [#14938](https://github.com/expo/expo/pull/14938) regression. ([#14953](https://github.com/expo/expo/pull/14953) by [@kudo](https://github.com/kudo))
 - Fix iOS app.manifest generation error in `eas build --local` mode. ([#14956](https://github.com/expo/expo/pull/14956) by [@kudo](https://github.com/kudo))
 - Fix handling of unexpectedly missing assets on iOS. ([#15008](https://github.com/expo/expo/pull/15008) by [@esamelson](https://github.com/esamelson))
+- Fix issue with assets that are duplicated in the local SQLite db being reaped when they are still in use. ([#15049](https://github.com/expo/expo/pull/15049) by [@esamelson](https://github.com/esamelson))
 
 ### 💡 Others
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/dao/AssetDao.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/dao/AssetDao.kt
@@ -34,6 +34,14 @@ abstract class AssetDao {
   )
   abstract fun _unmarkUsedAssetsFromDeletion()
 
+  @Query(
+    "UPDATE assets SET marked_for_deletion = 0 WHERE relative_path IN (" +
+      " SELECT relative_path" +
+      " FROM assets" +
+      " WHERE marked_for_deletion = 0);"
+  )
+  abstract fun _unmarkDuplicateUsedAssetsFromDeletion()
+
   @Query("SELECT * FROM assets WHERE marked_for_deletion = 1;")
   abstract fun _loadAssetsMarkedForDeletion(): List<AssetEntity>
 
@@ -112,6 +120,8 @@ abstract class AssetDao {
     // this is safe since this is a transaction and will be rolled back upon failure
     _markAllAssetsForDeletion()
     _unmarkUsedAssetsFromDeletion()
+    // check for duplicate rows representing a single file on disk
+    _unmarkDuplicateUsedAssetsFromDeletion()
     val deletedAssets = _loadAssetsMarkedForDeletion()
     _deleteAssetsMarkedForDeletion()
     return deletedAssets

--- a/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.m
+++ b/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.m
@@ -291,6 +291,17 @@ static NSString * const EXUpdatesDatabaseServerDefinedHeadersKey = @"serverDefin
     return nil;
   }
 
+  // check for duplicate rows representing a single file on disk
+  NSString * const update3Sql = @"UPDATE assets SET marked_for_deletion = 0 WHERE relative_path IN (\
+  SELECT relative_path\
+  FROM assets\
+  WHERE marked_for_deletion = 0\
+  );";
+  if ([self _executeSql:update3Sql withArgs:nil error:error] == nil) {
+    sqlite3_exec(_db, "ROLLBACK;", NULL, NULL, NULL);
+    return nil;
+  }
+
   NSString * const selectSql = @"SELECT * FROM assets WHERE marked_for_deletion = 1;";
   NSArray<NSDictionary *> *rows = [self _executeSql:selectSql withArgs:nil error:error];
   if (!rows) {

--- a/packages/expo-updates/ios/Tests/EXUpdatesDatabaseTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesDatabaseTests.m
@@ -2,6 +2,8 @@
 
 #import <XCTest/XCTest.h>
 
+#import <EXManifests/EXManifestsNewManifest.h>
+#import <EXUpdates/EXUpdatesAsset.h>
 #import <EXUpdates/EXUpdatesConfig.h>
 #import <EXUpdates/EXUpdatesDatabase+Tests.h>
 #import <EXUpdates/EXUpdatesNewUpdate.h>
@@ -171,6 +173,87 @@
   XCTAssertNil(readError);
   XCTAssertNotNil(actual);
   XCTAssertEqualObjects(expected, actual);
+}
+
+- (void)testDeleteUnusedAssets_DuplicateFilenames
+{
+  EXManifestsNewManifest *manifest1 = [[EXManifestsNewManifest alloc] initWithRawManifestJSON:@{
+    @"runtimeVersion": @"1",
+    @"id": @"0eef8214-4833-4089-9dff-b4138a14f196",
+    @"createdAt": @"2020-11-11T00:17:54.797Z",
+    @"launchAsset": @{@"url": @"https://url.to/bundle1.js", @"contentType": @"application/javascript"}
+  }];
+  EXManifestsNewManifest *manifest2 = [[EXManifestsNewManifest alloc] initWithRawManifestJSON:@{
+    @"runtimeVersion": @"1",
+    @"id": @"0eef8214-4833-4089-9dff-b4138a14f197",
+    @"createdAt": @"2020-11-11T00:17:55.797Z",
+    @"launchAsset": @{@"url": @"https://url.to/bundle2.js", @"contentType": @"application/javascript"}
+  }];
+
+  EXUpdatesAsset *asset1 = [self createMockAssetWithKey:@"key1"];
+  EXUpdatesAsset *asset2 = [self createMockAssetWithKey:@"key2"];
+  EXUpdatesAsset *asset3 = [self createMockAssetWithKey:@"key3"];
+
+  // simulate two assets with different keys that share a file on disk
+  // this can happen if we, for example, change the format of asset keys that we serve
+  asset2.filename = @"same-filename.png";
+  asset3.filename = @"same-filename.png";
+
+  EXUpdatesUpdate *update1 = [EXUpdatesNewUpdate updateWithNewManifest:manifest1 response:nil config:_config database:_db];
+  EXUpdatesUpdate *update2 = [EXUpdatesNewUpdate updateWithNewManifest:manifest2 response:nil config:_config database:_db];
+
+  dispatch_sync(_db.databaseQueue, ^{
+    NSError *update1Error;
+    [_db addUpdate:update1 error:&update1Error];
+    NSError *update2Error;
+    [_db addUpdate:update2 error:&update2Error];
+    NSError *updateAsset1Error;
+    [_db addNewAssets:@[asset1, asset2] toUpdateWithId:update1.updateId error:&updateAsset1Error];
+    NSError *updateAsset2Error;
+    [_db addNewAssets:@[asset3] toUpdateWithId:update2.updateId error:&updateAsset2Error];
+    if (update1Error || update2Error || updateAsset1Error || updateAsset2Error) {
+      XCTFail(@"%@ %@ %@ %@", update1Error.localizedDescription, update2Error.localizedDescription, updateAsset1Error.localizedDescription, updateAsset2Error.localizedDescription);
+      return;
+    }
+
+    // simulate update1 being reaped, update2 being kept
+    NSError *deleteUpdateError;
+    [_db deleteUpdates:@[update1] error:&deleteUpdateError];
+    if (deleteUpdateError) {
+      XCTFail(@"%@", deleteUpdateError.localizedDescription);
+      return;
+    }
+
+    NSArray<EXUpdatesAsset *> *assets = [_db allAssetsWithError:nil];
+    XCTAssertEqual(3, assets.count); // two bundles and asset1 and asset2
+
+    NSError *deleteAssetsError;
+    NSArray<EXUpdatesAsset *> *deletedAssets = [_db deleteUnusedAssetsWithError:&deleteAssetsError];
+    if (deleteAssetsError) {
+      XCTFail(@"%@", deleteAssetsError.localizedDescription);
+      return;
+    }
+
+    // asset1 should have been deleted, but asset2 should have been kept
+    // since it shared a filename with asset3, which is still in use
+    XCTAssertEqual(1, deletedAssets.count);
+    for (EXUpdatesAsset *deletedAsset in deletedAssets) {
+      XCTAssertEqualObjects(@"key1", deletedAsset.key);
+    }
+
+    XCTAssertNil([_db assetWithKey:@"key1" error:nil]);
+    XCTAssertNotNil([_db assetWithKey:@"key2" error:nil]);
+    XCTAssertNotNil([_db assetWithKey:@"key3" error:nil]);
+  });
+}
+
+- (EXUpdatesAsset *)createMockAssetWithKey:(NSString *)key
+{
+  EXUpdatesAsset *asset = [[EXUpdatesAsset alloc] initWithKey:key type:@"png"];
+  asset.downloadTime = [NSDate date];
+  asset.contentHash = key;
+  asset.filename = [NSString stringWithFormat:@"%@.png", key];
+  return asset;
 }
 
 @end


### PR DESCRIPTION
# Why

Assets with duplicate database entries (due to the fact that the format for asset keys changed between SDK 42 and 43) are being deleted from disk when they are, in fact, still in use.

# How

When choosing which assets to delete from the database, check for any filename duplicates and make sure that all duplicate rows are kept if any of them are still in use (i.e. not marked for deletion).

Later we'll modify the loader behavior to prevent duplicates from occurring, but this is the best fix for now, and is a good safeguard to have here regardless.

# Test Plan

Added unit tests for this case, verified they fail before the fix and pass after.

Also tested manually using the following scenario:
- Build SDK 42 app with expo-updates 0.8.4, and some image and font assets
- Install and launch it
- Update to SDK 43 (don't change anything else) and make a new build
- Install over top of the old one
- Publish an update, swipe closed and relaunch the app to download the update.
- Watch the .expo-internal folder on the simulator's FS, and swipe closed and relaunch the app again to launch the new update.

Before this fix, all assets shared between the updates (images and fonts) get deleted from disk right after the update is launched. After this fix, the only asset that is deleted is the initial SDK 42 bundle, which is correct.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
