### PR TITLE
[expo-dev-client][plugin] Fix android adding duplicate schemes

### DIFF
--- a/packages/expo-dev-client/CHANGELOG.md
+++ b/packages/expo-dev-client/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [plugin] Fix android adding duplicate schemes. ([#15057](https://github.com/expo/expo/pull/15057) by [@EvanBacon](https://github.com/EvanBacon))
+
 ### 💡 Others
 
 ## 0.6.0 — 2021-10-07

--- a/packages/expo-dev-client/plugin/build/constants.d.ts
+++ b/packages/expo-dev-client/plugin/build/constants.d.ts
@@ -1,0 +1,1 @@
+export declare const InstallationPage = "https://docs.expo.dev/clients/installation/";

--- a/packages/expo-dev-client/plugin/build/constants.js
+++ b/packages/expo-dev-client/plugin/build/constants.js
@@ -1,0 +1,4 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.InstallationPage = void 0;
+exports.InstallationPage = 'https://docs.expo.dev/clients/installation/';

--- a/packages/expo-dev-client/plugin/build/getDefaultScheme.d.ts
+++ b/packages/expo-dev-client/plugin/build/getDefaultScheme.d.ts
@@ -1,0 +1,2 @@
+import { ExpoConfig } from '@expo/config-types';
+export default function getDefaultScheme(config: Pick<ExpoConfig, 'slug'>): string;

--- a/packages/expo-dev-client/plugin/build/getDefaultScheme.js
+++ b/packages/expo-dev-client/plugin/build/getDefaultScheme.js
@@ -1,0 +1,26 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+/*
+ * Converts the slug from app configuration to a string that's a valid URI scheme.
+ * From RFC3986 Section 3.1.
+ * scheme      = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
+ */
+function getDefaultScheme(config) {
+    if (typeof config !== 'object') {
+        throw new TypeError('getDefaultScheme: config is not object');
+    }
+    if (!config.slug || typeof config.slug !== 'string') {
+        throw new TypeError('getDefaultScheme: config missing required property "slug"');
+    }
+    // Remove unallowed characters. Also remove `-` to keep this shorter.
+    let scheme = config.slug.replace(/[^A-Za-z0-9+\-.]/g, '');
+    // Edge case: if the slug didn't include any allowed characters we may end up with an empty string.
+    if (scheme.length === 0) {
+        throw new Error('Could not autogenerate a scheme. Please make sure the "slug" property in app config consists of URL friendly characters.');
+    }
+    // Lowercasing might not be strictly necessary, but let's do it for stylistic purposes.
+    scheme = scheme.toLowerCase();
+    // Add a prefix to avoid leading digits and to distinguish from user-defined schemes.
+    return `exp+${scheme}`;
+}
+exports.default = getDefaultScheme;

--- a/packages/expo-dev-client/plugin/build/withDevClient.d.ts
+++ b/packages/expo-dev-client/plugin/build/withDevClient.d.ts
@@ -1,0 +1,2 @@
+declare const _default: import("@expo/config-plugins").ConfigPlugin<unknown>;
+export default _default;

--- a/packages/expo-dev-client/plugin/build/withDevClient.js
+++ b/packages/expo-dev-client/plugin/build/withDevClient.js
@@ -1,0 +1,57 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const config_plugins_1 = require("@expo/config-plugins");
+// @ts-expect-error missing types
+const app_plugin_1 = __importDefault(require("expo-dev-launcher/app.plugin"));
+// @ts-expect-error missing types
+const app_plugin_2 = __importDefault(require("expo-dev-menu/app.plugin"));
+const fs_1 = __importDefault(require("fs"));
+const path_1 = __importDefault(require("path"));
+const constants_1 = require("./constants");
+const withGeneratedAndroidScheme_1 = require("./withGeneratedAndroidScheme");
+const withGeneratedIosScheme_1 = require("./withGeneratedIosScheme");
+const pkg = require('expo-dev-client/package.json');
+const REACT_NATIVE_CONFIG_JS = `// File created by expo-dev-client/app.plugin.js
+
+module.exports = {
+  dependencies: {
+    ...require('expo-dev-client/dependencies'),
+  },
+};
+`;
+function withReactNativeConfigJs(config) {
+    config = (0, config_plugins_1.withDangerousMod)(config, ['android', addReactNativeConfigAsync]);
+    config = (0, config_plugins_1.withDangerousMod)(config, ['ios', addReactNativeConfigAsync]);
+    return config;
+}
+const addReactNativeConfigAsync = async (config) => {
+    const filename = path_1.default.join(config.modRequest.projectRoot, 'react-native.config.js');
+    try {
+        const config = fs_1.default.readFileSync(filename, 'utf8');
+        if (!config.includes('expo-dev-client/dependencies')) {
+            throw new Error(`Could not add expo-dev-client dependencies to existing file ${filename}. See expo-dev-client installation instructions to add them manually: ${constants_1.InstallationPage}`);
+        }
+    }
+    catch (error) {
+        if (error.code === 'ENOENT') {
+            // The file doesn't exist, so we create it.
+            fs_1.default.writeFileSync(filename, REACT_NATIVE_CONFIG_JS);
+        }
+        else {
+            throw error;
+        }
+    }
+    return config;
+};
+function withDevClient(config) {
+    config = (0, app_plugin_2.default)(config);
+    config = (0, app_plugin_1.default)(config);
+    config = withReactNativeConfigJs(config);
+    config = (0, withGeneratedAndroidScheme_1.withGeneratedAndroidScheme)(config);
+    config = (0, withGeneratedIosScheme_1.withGeneratedIosScheme)(config);
+    return config;
+}
+exports.default = (0, config_plugins_1.createRunOncePlugin)(withDevClient, pkg.name, pkg.version);

--- a/packages/expo-dev-client/plugin/build/withGeneratedAndroidScheme.d.ts
+++ b/packages/expo-dev-client/plugin/build/withGeneratedAndroidScheme.d.ts
@@ -1,0 +1,4 @@
+import { AndroidManifest, ConfigPlugin } from '@expo/config-plugins';
+import { ExpoConfig } from '@expo/config-types';
+export declare const withGeneratedAndroidScheme: ConfigPlugin;
+export declare function setGeneratedAndroidScheme(config: Pick<ExpoConfig, 'scheme' | 'slug'>, androidManifest: AndroidManifest): AndroidManifest;

--- a/packages/expo-dev-client/plugin/build/withGeneratedAndroidScheme.js
+++ b/packages/expo-dev-client/plugin/build/withGeneratedAndroidScheme.js
@@ -1,0 +1,24 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.setGeneratedAndroidScheme = exports.withGeneratedAndroidScheme = void 0;
+const config_plugins_1 = require("@expo/config-plugins");
+const getDefaultScheme_1 = __importDefault(require("./getDefaultScheme"));
+const withGeneratedAndroidScheme = (config) => {
+    return (0, config_plugins_1.withAndroidManifest)(config, (config) => {
+        config.modResults = setGeneratedAndroidScheme(config, config.modResults);
+        return config;
+    });
+};
+exports.withGeneratedAndroidScheme = withGeneratedAndroidScheme;
+function setGeneratedAndroidScheme(config, androidManifest) {
+    // Generate a cross-platform scheme used to launch the dev client.
+    const scheme = (0, getDefaultScheme_1.default)(config);
+    if (!config_plugins_1.AndroidConfig.Scheme.hasScheme(scheme, androidManifest)) {
+        androidManifest = config_plugins_1.AndroidConfig.Scheme.appendScheme(scheme, androidManifest);
+    }
+    return androidManifest;
+}
+exports.setGeneratedAndroidScheme = setGeneratedAndroidScheme;

--- a/packages/expo-dev-client/plugin/build/withGeneratedIosScheme.d.ts
+++ b/packages/expo-dev-client/plugin/build/withGeneratedIosScheme.d.ts
@@ -1,0 +1,4 @@
+import { IOSConfig, InfoPlist, ConfigPlugin } from '@expo/config-plugins';
+import { ExpoConfig } from '@expo/config-types';
+export declare const withGeneratedIosScheme: ConfigPlugin;
+export declare function setGeneratedIosScheme(config: Pick<ExpoConfig, 'scheme' | 'slug'>, infoPlist: InfoPlist): IOSConfig.InfoPlist;

--- a/packages/expo-dev-client/plugin/build/withGeneratedIosScheme.js
+++ b/packages/expo-dev-client/plugin/build/withGeneratedIosScheme.js
@@ -1,0 +1,24 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.setGeneratedIosScheme = exports.withGeneratedIosScheme = void 0;
+const config_plugins_1 = require("@expo/config-plugins");
+const getDefaultScheme_1 = __importDefault(require("./getDefaultScheme"));
+const withGeneratedIosScheme = (config) => {
+    return (0, config_plugins_1.withInfoPlist)(config, (config) => {
+        config.modResults = setGeneratedIosScheme(config, config.modResults);
+        return config;
+    });
+};
+exports.withGeneratedIosScheme = withGeneratedIosScheme;
+function setGeneratedIosScheme(config, infoPlist) {
+    // Generate a cross-platform scheme used to launch the dev client.
+    const scheme = (0, getDefaultScheme_1.default)(config);
+    if (!config_plugins_1.IOSConfig.Scheme.hasScheme(scheme, infoPlist)) {
+        infoPlist = config_plugins_1.IOSConfig.Scheme.appendScheme(scheme, infoPlist);
+    }
+    return infoPlist;
+}
+exports.setGeneratedIosScheme = setGeneratedIosScheme;

--- a/packages/expo-dev-client/plugin/src/__tests__/withGeneratedAndroidScheme-test.ts
+++ b/packages/expo-dev-client/plugin/src/__tests__/withGeneratedAndroidScheme-test.ts
@@ -1,0 +1,64 @@
+import { AndroidConfig, AndroidManifest } from '@expo/config-plugins';
+
+import { setGeneratedAndroidScheme } from '../withGeneratedAndroidScheme';
+
+describe(setGeneratedAndroidScheme, () => {
+  it(`prevents adding duplicates`, () => {
+    let androidManifest: AndroidManifest = {
+      manifest: {
+        application: [
+          {
+            activity: [
+              {
+                $: {
+                  'android:name': '.MainActivity',
+                  'android:launchMode': 'singleTask',
+                },
+                'intent-filter': [
+                  {
+                    action: [
+                      {
+                        $: {
+                          'android:name': 'android.intent.action.VIEW',
+                        },
+                      },
+                    ],
+                    category: [
+                      {
+                        $: {
+                          'android:name': 'android.intent.category.DEFAULT',
+                        },
+                      },
+                      {
+                        $: {
+                          'android:name': 'android.intent.category.BROWSABLE',
+                        },
+                      },
+                    ],
+                    data: [],
+                  },
+                ],
+              },
+            ],
+            $: {
+              'android:name': '.MainApplication',
+            },
+          },
+        ],
+        $: {
+          'xmlns:android': 'http://schemas.android.com/apk/res/android',
+          package: 'com.placeholder.appid',
+        },
+      },
+    };
+    const config = { slug: 'cello' };
+
+    for (let i = 0; i < 2; i++) {
+      androidManifest = setGeneratedAndroidScheme(config, androidManifest);
+
+      expect(AndroidConfig.Scheme.getSchemesFromManifest(androidManifest)).toStrictEqual([
+        'exp+cello',
+      ]);
+    }
+  });
+});

--- a/packages/expo-dev-client/plugin/src/__tests__/withGeneratedIosScheme-test.ts
+++ b/packages/expo-dev-client/plugin/src/__tests__/withGeneratedIosScheme-test.ts
@@ -15,3 +15,23 @@ it(`adds a scheme generated from slug`, () => {
     }
   `);
 });
+
+it(`prevents adding a duplicate scheme`, () => {
+  let infoPlist = {};
+  const config = { slug: 'cello' };
+
+  for (let i = 0; i < 2; i++) {
+    infoPlist = setGeneratedIosScheme(config, infoPlist);
+    expect(infoPlist).toMatchInlineSnapshot(`
+      Object {
+        "CFBundleURLTypes": Array [
+          Object {
+            "CFBundleURLSchemes": Array [
+              "exp+cello",
+            ],
+          },
+        ],
+      }
+    `);
+  }
+});

--- a/packages/expo-dev-client/plugin/src/withDevClient.ts
+++ b/packages/expo-dev-client/plugin/src/withDevClient.ts
@@ -8,8 +8,8 @@ import fs from 'fs';
 import path from 'path';
 
 import { InstallationPage } from './constants';
-import withGeneratedAndroidScheme from './withGeneratedAndroidScheme';
-import withGeneratedIosScheme from './withGeneratedIosScheme';
+import { withGeneratedAndroidScheme } from './withGeneratedAndroidScheme';
+import { withGeneratedIosScheme } from './withGeneratedIosScheme';
 
 const pkg = require('expo-dev-client/package.json');
 

--- a/packages/expo-dev-client/plugin/src/withGeneratedAndroidScheme.ts
+++ b/packages/expo-dev-client/plugin/src/withGeneratedAndroidScheme.ts
@@ -1,10 +1,19 @@
-import { AndroidConfig, AndroidManifest } from '@expo/config-plugins';
-import { createAndroidManifestPlugin } from '@expo/config-plugins/build/plugins/android-plugins';
+import {
+  AndroidConfig,
+  AndroidManifest,
+  ConfigPlugin,
+  withAndroidManifest,
+} from '@expo/config-plugins';
 import { ExpoConfig } from '@expo/config-types';
 
 import getDefaultScheme from './getDefaultScheme';
 
-export default createAndroidManifestPlugin(setGeneratedAndroidScheme, 'withGeneratedAndroidScheme');
+export const withGeneratedAndroidScheme: ConfigPlugin = (config) => {
+  return withAndroidManifest(config, (config) => {
+    config.modResults = setGeneratedAndroidScheme(config, config.modResults);
+    return config;
+  });
+};
 
 export function setGeneratedAndroidScheme(
   config: Pick<ExpoConfig, 'scheme' | 'slug'>,
@@ -12,5 +21,8 @@ export function setGeneratedAndroidScheme(
 ): AndroidManifest {
   // Generate a cross-platform scheme used to launch the dev client.
   const scheme = getDefaultScheme(config);
-  return AndroidConfig.Scheme.appendScheme(scheme, androidManifest);
+  if (!AndroidConfig.Scheme.hasScheme(scheme, androidManifest)) {
+    androidManifest = AndroidConfig.Scheme.appendScheme(scheme, androidManifest);
+  }
+  return androidManifest;
 }

--- a/packages/expo-dev-client/plugin/src/withGeneratedIosScheme.ts
+++ b/packages/expo-dev-client/plugin/src/withGeneratedIosScheme.ts
@@ -1,10 +1,14 @@
-import { IOSConfig, InfoPlist } from '@expo/config-plugins';
-import { createInfoPlistPlugin } from '@expo/config-plugins/build/plugins/ios-plugins';
+import { IOSConfig, InfoPlist, withInfoPlist, ConfigPlugin } from '@expo/config-plugins';
 import { ExpoConfig } from '@expo/config-types';
 
 import getDefaultScheme from './getDefaultScheme';
 
-export default createInfoPlistPlugin(setGeneratedIosScheme, 'withGeneratedIosScheme');
+export const withGeneratedIosScheme: ConfigPlugin = (config) => {
+  return withInfoPlist(config, (config) => {
+    config.modResults = setGeneratedIosScheme(config, config.modResults);
+    return config;
+  });
+};
 
 export function setGeneratedIosScheme(
   config: Pick<ExpoConfig, 'scheme' | 'slug'>,
@@ -12,6 +16,9 @@ export function setGeneratedIosScheme(
 ): IOSConfig.InfoPlist {
   // Generate a cross-platform scheme used to launch the dev client.
   const scheme = getDefaultScheme(config);
-  const result = IOSConfig.Scheme.appendScheme(scheme, infoPlist);
-  return result;
+
+  if (!IOSConfig.Scheme.hasScheme(scheme, infoPlist)) {
+    infoPlist = IOSConfig.Scheme.appendScheme(scheme, infoPlist);
+  }
+  return infoPlist;
 }


### PR DESCRIPTION
# Why

- fix https://github.com/expo/expo-cli/issues/3961


# How

Check if schemes exist before adding new ones, in the future we could potentially label the schemes to ensure this plugin only ever adds one.

# Test Plan

Added tests

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
