### PR TITLE
[template] Remove old metadata

### DIFF
--- a/templates/expo-template-bare-minimum/android/app/src/main/res/drawable/splashscreen.xml
+++ b/templates/expo-template-bare-minimum/android/app/src/main/res/drawable/splashscreen.xml
@@ -1,7 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
-  This file was created by '@expo/configure-splash-screen' and some of it's content shouldn't be modified by hand
--->
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
   <item android:drawable="@color/splashscreen_background"/>
 </layer-list>

--- a/templates/expo-template-bare-minimum/android/app/src/main/res/values/colors.xml
+++ b/templates/expo-template-bare-minimum/android/app/src/main/res/values/colors.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <resources>
-  <!-- Below line is handled by '@expo/configure-splash-screen' command and it's discouraged to modify it manually -->
   <color name="splashscreen_background">#FFFFFF</color>
 </resources>

--- a/templates/expo-template-bare-minimum/android/app/src/main/res/values/styles.xml
+++ b/templates/expo-template-bare-minimum/android/app/src/main/res/values/styles.xml
@@ -8,9 +8,7 @@
     <item name="android:textColorHint">#c8c8c8</item>
     <item name="android:textColor">@android:color/black</item>
   </style>
-  <style name="Theme.App.SplashScreen" parent="Theme.AppCompat.Light.NoActionBar">
-    <!-- Below line is handled by '@expo/configure-splash-screen' command and it's discouraged to modify it manually -->
+  <style name="Theme.App.SplashScreen" parent="AppTheme">
     <item name="android:windowBackground">@drawable/splashscreen</item>
-    <!-- Customize your splash screen theme here -->
   </style>
 </resources>


### PR DESCRIPTION
# Why

Remove comments and other values that are stripped by config plugins to reduce the disparity between the template and what users actually get.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
