### PR TITLE
[expo-av][ios] Fix crash when audio callback is removed

### DIFF
--- a/packages/expo-av/ios/EXAV/AudioSampleCallback/AudioSampleCallbackWrapper.mm
+++ b/packages/expo-av/ios/EXAV/AudioSampleCallback/AudioSampleCallbackWrapper.mm
@@ -27,9 +27,13 @@ void AudioSampleCallbackWrapper::call(AudioBuffer* buffer, double timestamp)
     return;
   }
 
+  // we want to capture only the wrapper, not the whole `this` object,
+  // because it may no longer exist when the lambda is invoked
+  auto weakWrapper = this->weakWrapper;
+  
   // We need to invoke the callback from the JS thread, otherwise Hermes complains
-  strongWrapper->jsInvoker().invokeAsync([buffer, this, timestamp]{
-    auto jsiCallbackWrapper = this->weakWrapper.lock();
+  strongWrapper->jsInvoker().invokeAsync([weakWrapper, buffer, timestamp]{
+    auto jsiCallbackWrapper = weakWrapper.lock();
     if (!jsiCallbackWrapper || !buffer) {
       return;
     }


### PR DESCRIPTION
# Why

When implemented #14904 in [my music test app](https://github.com/barthap/expo-mega-demo), I encountered some random crashes when removing the audio callback.

They weren't happening every time, but only sometimes (more often on Hermes than JSC, and only on real device, couldn't repro on simulator), so it had to be a race condition. After some debugging, it appeared to be `EXC_BAD_ACCESS` when trying to get `this->weakWrapper`.
I couldn't observe that in a simple NCL app, but only on a more complex one like my app. Despite both callback execution and destruction are happening on the same JS thread, I suspect that due to JS asynchronous nature, they can be placed at different positions in the event loop, so destruction could occur _before_ last callback was called (and debugger confirmed that).

# How

Instead of capturing the whole `this` pointer, I only capture the weak pointer to JSI callback wrapper. I understand it like this: When this weak ptr is locked inside the lambda and it existed during calling the `.lock()` method, it exists as long as the lambda is executing, even if meanwhile the `AudioSampleCallbackWrapper` destructor gets called. [This example](https://onlinegdb.com/CaXD_0S8t) seems to confirm my thoughts. And in cases that the JSI wrapper was destroyed before lambda was called, the `lock()` returns `nullptr` and the lambda finishes early.

# Test Plan

My app no longer crashes, played and paused it (equivalent to creating and destroying the callback object) around 100 times, no crash. 
