### PR TITLE
[sweet][ios] Handle optional types in method arguments

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -12,7 +12,7 @@
 - [Sweet API] Introduced Convertibles on iOS — a way to use custom types as method arguments if they can be converted from JavaScript values. Provided implementation for some common CoreGraphics types. ([#14988](https://github.com/expo/expo/pull/14988) by [@tsapeta](https://github.com/tsapeta))
 - Introduce `ReactActivityHandler` and support `createReactRootView` hook. ([#14883](https://github.com/expo/expo/pull/14883) by [@kudo](https://github.com/kudo))
 - [Sweet API] Added support for array types in method arguments on iOS. ([#15042](https://github.com/expo/expo/pull/15042) by [@tsapeta](https://github.com/tsapeta))
-- [Sweet API] Added support for optional types in method arguments on iOS.
+- [Sweet API] Added support for optional types in method arguments on iOS. ([#15068](https://github.com/expo/expo/pull/15068) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -11,6 +11,8 @@
 - Implemented sending native events to JavaScript in Sweet API on iOS. ([#14958](https://github.com/expo/expo/pull/14958) by [@tsapeta](https://github.com/tsapeta))
 - [Sweet API] Introduced Convertibles on iOS — a way to use custom types as method arguments if they can be converted from JavaScript values. Provided implementation for some common CoreGraphics types. ([#14988](https://github.com/expo/expo/pull/14988) by [@tsapeta](https://github.com/tsapeta))
 - Introduce `ReactActivityHandler` and support `createReactRootView` hook. ([#14883](https://github.com/expo/expo/pull/14883) by [@kudo](https://github.com/kudo))
+- [Sweet API] Added support for array types in method arguments on iOS. ([#15042](https://github.com/expo/expo/pull/15042) by [@tsapeta](https://github.com/tsapeta))
+- [Sweet API] Added support for optional types in method arguments on iOS.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/ios/Swift/Arguments/AnyArgumentType.swift
+++ b/packages/expo-modules-core/ios/Swift/Arguments/AnyArgumentType.swift
@@ -6,6 +6,11 @@
  */
 internal protocol AnyArgumentType: CustomStringConvertible {
   /**
+   Bool value indicating whether the wrapped type is an optional type.
+   */
+  var isOptional: Bool { get }
+
+  /**
    Returns a boolean value that indicates whether the wrapped type inherits or conforms to the given type.
    */
   func isKindOf<ParentType>(_ type: ParentType.Type) -> Bool

--- a/packages/expo-modules-core/ios/Swift/Arguments/CollectionArgumentType.swift
+++ b/packages/expo-modules-core/ios/Swift/Arguments/CollectionArgumentType.swift
@@ -11,7 +11,7 @@ internal final class CollectionArgumentType<InnerType: RandomAccessCollection>: 
     super.init(InnerType.self)
   }
 
-  override func cast<ArgType>(_ value: ArgType) throws -> Any {
+  override func castNonOptional<ArgType>(_ value: ArgType) throws -> Any {
     if let value = value as? [Any] {
       return try value.map { try elementType.cast($0) }
     }

--- a/packages/expo-modules-core/ios/Swift/Arguments/RawArgumentType.swift
+++ b/packages/expo-modules-core/ios/Swift/Arguments/RawArgumentType.swift
@@ -6,15 +6,26 @@
 internal class RawArgumentType<InnerType>: AnyArgumentType, CustomStringConvertible {
   let innerType: Any.Type
 
+  let isOptional: Bool
+
   init(_ innerType: InnerType.Type) {
     self.innerType = innerType
+    self.isOptional = innerType is AnyOptional.Type
   }
 
   func isKindOf<ParentType>(_ type: ParentType.Type) -> Bool {
-    return InnerType.self is ParentType.Type
+    return innerType is ParentType.Type
   }
 
   func cast<ArgType>(_ value: ArgType) throws -> Any {
+    // Precheck against nil passed to non-optional type.
+    guard isOptional || !Optional.isNil(value) else {
+      throw Conversions.NullCastError<InnerType>()
+    }
+    return try castNonOptional(value)
+  }
+
+  func castNonOptional<ArgType>(_ value: ArgType) throws -> Any {
     if let ConvertibleInnerType = InnerType.self as? ConvertibleArgument.Type {
       return try ConvertibleInnerType.convert(from: value)
     }
@@ -28,5 +39,25 @@ internal class RawArgumentType<InnerType>: AnyArgumentType, CustomStringConverti
 
   var description: String {
     return String(describing: InnerType.self)
+  }
+}
+
+/**
+ A type-erased protocol used to recognize if the generic type is an optional type.
+ `Optional` is a generic enum, so it's impossible to check the inheritance directly.
+ */
+internal protocol AnyOptional {}
+
+/**
+ Make generic `Optional` implement non-generic `AnyOptional` and add handy check against type-erased `nil`.
+ */
+extension Optional: AnyOptional {
+  static func isNil(_ object: Wrapped) -> Bool {
+    switch object as Any {
+    case Optional<Any>.none:
+      return true
+    default:
+      return false
+    }
   }
 }

--- a/packages/expo-modules-core/ios/Swift/Conversions.swift
+++ b/packages/expo-modules-core/ios/Swift/Conversions.swift
@@ -190,6 +190,15 @@ internal final class Conversions {
   }
 
   /**
+   An error that is thrown when null value is tried to be casted to non-optional type.
+   */
+  internal struct NullCastError<TargetType>: CodedError {
+    var description: String {
+      "Cannot cast null value to non-optional `\(TargetType.self)`"
+    }
+  }
+
+  /**
    An error used when the hex color string is invalid (e.g. contains non-hex characters).
    */
   internal struct InvalidHexColorError: CodedError {

--- a/packages/expo-modules-core/ios/Tests/ArgumentTypeSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/ArgumentTypeSpec.swift
@@ -16,6 +16,27 @@ class ArgumentTypeSpec: QuickSpec {
       expect(try type.cast(anyValue)).to(be(value))
     }
 
+    it("casts optional types") {
+      let type = ArgumentType(Double?.self)
+      let value: Double? = nil
+      let anyValue = value as Any
+      let result = try type.cast(anyValue)
+
+      expect(result).to(beAKindOf(Double?.self))
+
+      // Since this `nil` is in fact of non-optional `Any` type, under the hood it's described as `Optional` enum.
+      // Simply checking `result == nil` does NOT work here, see `Optional.isNil` extension implementation.
+      expect(Optional.isNil(result)) == true
+    }
+
+    it("throws null cast error") {
+      let type = ArgumentType(Double.self) // non-optional (!)
+      let value: Double? = nil
+      let anyValue = value as Any
+
+      expect { try type.cast(anyValue) }.to(throwError(errorType: Conversions.NullCastError<Double>.self))
+    }
+
     it("casts arrays") {
       let type = ArgumentType([Double].self)
       let value = 9.9

--- a/packages/expo-modules-core/ios/Tests/MethodSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/MethodSpec.swift
@@ -56,6 +56,17 @@ class MethodSpec: QuickSpec {
       testMethodReturning(value: ["expo", "modules", "core"])
     }
 
+    it("is called with nil value") {
+      let str: String? = nil
+
+      mockModuleHolder(appContext) {
+        $0.method(methodName) { (a: String?) in
+          expect(a) == nil
+        }
+      }
+      .callSync(method: methodName, args: [str as Any])
+    }
+
     describe("converting dicts to records") {
       struct TestRecord: Record {
         @Field var property: String = "expo"


### PR DESCRIPTION
# Why

Followup #14988 and #15042

# How

- Added detection whether the type wrapped by `ArgumentType` is an optional type
- Prechecking against `nil`s passed to non-optional types
- Introduced new `NullCastError` error that is thrown when the precheck fails.
- Added tests

# Test Plan

New tests are passing
