### PR TITLE
[packages] match few dependencies to the workspace versions

### DIFF
--- a/packages/expo-ads-facebook/CHANGELOG.md
+++ b/packages/expo-ads-facebook/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Update `nullthrows` dependency.
+
 ## 11.0.1 — 2021-10-01
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-ads-facebook/CHANGELOG.md
+++ b/packages/expo-ads-facebook/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Update `nullthrows` dependency.
+- Update `nullthrows` dependency. ([#15069](https://github.com/expo/expo/pull/15069) by [@Simek](https://github.com/Simek))
 
 ## 11.0.1 — 2021-10-01
 

--- a/packages/expo-ads-facebook/package.json
+++ b/packages/expo-ads-facebook/package.json
@@ -34,7 +34,7 @@
     "@expo/config-plugins": "^4.0.2",
     "expo-modules-core": "~0.4.2",
     "fbemitter": "^2.1.1",
-    "nullthrows": "^1.1.0"
+    "nullthrows": "^1.1.1"
   },
   "devDependencies": {
     "expo-module-scripts": "^2.0.0"

--- a/packages/expo-camera/package.json
+++ b/packages/expo-camera/package.json
@@ -37,7 +37,7 @@
     "@expo/config-plugins": "^4.0.2",
     "@koale/useworker": "^4.0.2",
     "expo-modules-core": "~0.4.2",
-    "invariant": "2.2.4"
+    "invariant": "^2.2.4"
   },
   "devDependencies": {
     "expo-module-scripts": "^2.0.0"

--- a/packages/expo-dev-menu/package.json
+++ b/packages/expo-dev-menu/package.json
@@ -45,7 +45,7 @@
     "expo-dev-menu-interface": "0.4.1"
   },
   "devDependencies": {
-    "@apollo/client": "^3.2.0",
+    "@apollo/client": "^3.4.10",
     "@react-navigation/core": "5.15.1",
     "@react-navigation/native": "5.9.2",
     "@react-navigation/stack": "5.14.2",
@@ -54,7 +54,7 @@
     "babel-plugin-module-resolver": "^4.1.0",
     "expo-module-scripts": "^2.0.0",
     "fuse.js": "^6.4.6",
-    "graphql": "^14.2.1",
+    "graphql": "^15.3.0",
     "graphql-tag": "^2.10.1",
     "react": "17.0.1",
     "react-native": "0.64.2",

--- a/packages/expo-linking/CHANGELOG.md
+++ b/packages/expo-linking/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Update `qs` dependency.
+- Update `qs` dependency. ([#15069](https://github.com/expo/expo/pull/15069) by [@Simek](https://github.com/Simek))
 
 ## 2.4.1 — 2021-10-01
 

--- a/packages/expo-linking/CHANGELOG.md
+++ b/packages/expo-linking/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Update `qs` dependency.
+
 ## 2.4.1 — 2021-10-01
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-linking/package.json
+++ b/packages/expo-linking/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "expo-constants": "~12.1.0",
     "invariant": "^2.2.4",
-    "qs": "^6.5.0",
+    "qs": "^6.9.1",
     "url-parse": "^1.4.4"
   },
   "devDependencies": {

--- a/packages/expo-modules-autolinking/package.json
+++ b/packages/expo-modules-autolinking/package.json
@@ -44,7 +44,7 @@
     "chalk": "^4.1.0",
     "commander": "^7.2.0",
     "fast-glob": "^3.2.5",
-    "find-up": "~5.0.0",
+    "find-up": "^5.0.0",
     "fs-extra": "^9.1.0"
   }
 }

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Update `fs-extra` dependency.
+- Update `fs-extra` dependency. ([#15069](https://github.com/expo/expo/pull/15069) by [@Simek](https://github.com/Simek))
 
 ## 0.13.1 — 2021-10-01
 

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Update `fs-extra` dependency.
+
 ## 0.13.1 — 2021-10-01
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-notifications/package.json
+++ b/packages/expo-notifications/package.json
@@ -46,7 +46,7 @@
     "expo-application": "~4.0.0",
     "expo-constants": "~12.1.0",
     "expo-modules-core": "~0.4.2",
-    "fs-extra": "^9.0.1",
+    "fs-extra": "^9.1.0",
     "unimodules-task-manager-interface": "~7.0.1",
     "uuid": "^3.4.0"
   },
@@ -54,7 +54,7 @@
     "@types/node-fetch": "^2.5.7",
     "@types/uuid": "^3.4.7",
     "expo-module-scripts": "^2.0.0",
-    "memfs": "^2.15.5",
+    "memfs": "^3.2.0",
     "node-fetch": "^2.6.1"
   }
 }

--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Update `lodash` dependency.
+
 ## 10.0.1 — 2021-10-01
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Update `lodash` dependency.
+- Update `lodash` dependency. ([#15069](https://github.com/expo/expo/pull/15069) by [@Simek](https://github.com/Simek))
 
 ## 10.0.1 — 2021-10-01
 

--- a/packages/expo-sqlite/package.json
+++ b/packages/expo-sqlite/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@expo/websql": "^1.0.1",
     "expo-modules-core": "~0.4.2",
-    "lodash": "^4.17.15"
+    "lodash": "^4.17.19"
   },
   "devDependencies": {
     "@types/lodash.zipobject": "^4.1.4",

--- a/packages/expo-yarn-workspaces/CHANGELOG.md
+++ b/packages/expo-yarn-workspaces/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Update `debug` and `glob` dependencies.
+- Update `debug` and `glob` dependencies. ([#15069](https://github.com/expo/expo/pull/15069) by [@Simek](https://github.com/Simek))
 
 ## 1.6.0 — 2021-09-28
 

--- a/packages/expo-yarn-workspaces/CHANGELOG.md
+++ b/packages/expo-yarn-workspaces/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Update `debug` and `glob` dependencies.
+
 ## 1.6.0 — 2021-09-28
 
 ### 🎉 New features

--- a/packages/expo-yarn-workspaces/package.json
+++ b/packages/expo-yarn-workspaces/package.json
@@ -22,9 +22,9 @@
   "dependencies": {
     "@expo/metro-config": "~0.2.6",
     "@expo/webpack-config": "~0.16.6",
-    "debug": "^4.1.1",
+    "debug": "^4.3.2",
     "find-yarn-workspace-root": "^2.0.0",
-    "glob": "^7.1.6",
+    "glob": "^7.1.7",
     "minimist": "^1.2.5",
     "mkdirp": "^0.5.1"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@apollo/client@^3.2.0", "@apollo/client@^3.4.10":
+"@apollo/client@^3.4.10":
   version "3.4.16"
   resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.4.16.tgz#67090d5655aa843fa64d26f1913315e384a5fa0f"
   integrity sha512-iF4zEYwvebkri0BZQyv8zfavPfVEafsK0wkOofa6eC2yZu50J18uTutKtC174rjHZ2eyxZ8tV7NvAPKRT+OtZw==
@@ -8133,11 +8133,6 @@ fast-diff@^1.1.2:
   resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
   integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
-fast-extend@0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/fast-extend/-/fast-extend-0.0.2.tgz#f5ec42cf40b9460f521a6387dfb52deeed671dbd"
-  integrity sha1-9exCz0C5Rg9SGmOH37Ut7u1nHb0=
-
 fast-glob@^3.1.1, fast-glob@^3.2.4, fast-glob@^3.2.5:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.7.tgz#fd6cb7a2d7e9aa7a7846111e85a196d6b2f766a1"
@@ -8704,7 +8699,7 @@ fs-extra@^8.1.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-extra@^9.0.0, fs-extra@^9.0.1, fs-extra@^9.1.0:
+fs-extra@^9.0.0, fs-extra@^9.1.0:
   version "9.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.1.0.tgz#5954460c764a8da2094ba3554bf839e6b9a7c86d"
   integrity sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==
@@ -8732,11 +8727,6 @@ fs-monkey@1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/fs-monkey/-/fs-monkey-1.0.3.tgz#ae3ac92d53bb328efe0e9a1d9541f6ad8d48e2d3"
   integrity sha512-cybjIfiiE+pTWicSCLFHSrXZ6EilF30oh91FDP9S2B051prEa7QWfrVTQm10/dDpswBDXZugPa1Ogu8Yh+HV0Q==
-
-fs-monkey@^0.3.3:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/fs-monkey/-/fs-monkey-0.3.3.tgz#7960bb2b1fa2653731b9d0e2e84812a7e8b3664a"
-  integrity sha512-FNUvuTAJ3CqCQb5ELn+qCbGR/Zllhf2HtwsdAtBi59s1WeCjKMT81fHcSu7dwIskqGVK+MmOrb7VOBlq3/SItw==
 
 fs-readdir-recursive@^1.1.0:
   version "1.1.0"
@@ -9107,13 +9097,6 @@ graphql-ws@^5.4.1:
   version "5.5.3"
   resolved "https://registry.yarnpkg.com/graphql-ws/-/graphql-ws-5.5.3.tgz#1495c1c1ad7dcd3cf76a46db629810a55d3b2d18"
   integrity sha512-Okp3gE3vq9OoeqsYVbmzKvPcvlinKNXrfVajH7D3ul1UdCg2+K2zVYbWKmqxehkAZ+GKVfngK5fzyXSsfpe+pA==
-
-graphql@^14.2.1:
-  version "14.7.0"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.7.0.tgz#7fa79a80a69be4a31c27dda824dc04dac2035a72"
-  integrity sha512-l0xWZpoPKpppFzMfvVyFmp9vLN7w/ZZJPefUicMCepfJeQ8sMcztloGYY9DfjVPo6tIUDzU5Hw3MUbIjj9AVVA==
-  dependencies:
-    iterall "^1.2.2"
 
 graphql@^15.3.0:
   version "15.6.1"
@@ -10455,7 +10438,7 @@ istanbul-reports@^3.0.2:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
 
-iterall@^1.2.1, iterall@^1.2.2:
+iterall@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.3.0.tgz#afcb08492e2915cbd8a0884eb93a8c94d0d72fea"
   integrity sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==
@@ -12070,14 +12053,6 @@ media-typer@0.3.0:
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
   integrity sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=
 
-memfs@^2.15.5:
-  version "2.17.1"
-  resolved "https://registry.yarnpkg.com/memfs/-/memfs-2.17.1.tgz#bfcc11b6308214b4fb33eaca101132722d22e103"
-  integrity sha512-4kAcqibPAd8DN8/UIW/6OwvbhNq6MqwsQ0pxjo+2ZmxPlQAbn9TAepnRpdeYfw4Qq0Y+QqwE6wngLUowo2fcjg==
-  dependencies:
-    fast-extend "0.0.2"
-    fs-monkey "^0.3.3"
-
 memfs@^3.2.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/memfs/-/memfs-3.3.0.tgz#4da2d1fc40a04b170a56622c7164c6be2c4cbef2"
@@ -13053,7 +13028,7 @@ nth-check@^2.0.0:
   dependencies:
     boolbase "^1.0.0"
 
-nullthrows@1.1.1, nullthrows@^1.1.0, nullthrows@^1.1.1:
+nullthrows@1.1.1, nullthrows@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/nullthrows/-/nullthrows-1.1.1.tgz#7818258843856ae971eae4208ad7d7eb19a431b1"
   integrity sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==
@@ -14547,7 +14522,7 @@ qs@6.9.1:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.1.tgz#20082c65cb78223635ab1a9eaca8875a29bf8ec9"
   integrity sha512-Cxm7/SS/y/Z3MHWSxXb8lIFqgqBowP5JMlTUFyJN88y0SGQhVmZnqFK/PeuMX9LzUyWsqqhNxIyg0jlzq946yA==
 
-qs@^6.5.0:
+qs@^6.9.1:
   version "6.10.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.1.tgz#4931482fa8d647a5aab799c5271d2133b981fb6a"
   integrity sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==
@@ -18243,10 +18218,8 @@ watchpack@^1.6.1:
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.7.5.tgz#1267e6c55e0b9b5be44c2023aed5437a2c26c453"
   integrity sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==
   dependencies:
-    chokidar "^3.4.1"
     graceful-fs "^4.1.2"
     neo-async "^2.5.0"
-    watchpack-chokidar2 "^2.0.1"
   optionalDependencies:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.1"


### PR DESCRIPTION
# Why

Refs #14561

# How

This PR bumps the few dependencies in the Expo `packages` to match theirs versions to the latest versions used in the  workspace.

# Test Plan

`yarn` and `yarn test` (if available) commands in the modified packages directories have ended with success.

# Checklist

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
