### PR TITLE
[core] Fix autolinking failure on Android R8

### DIFF
--- a/packages/expo/android/proguard-rules.pro
+++ b/packages/expo/android/proguard-rules.pro
@@ -8,3 +8,11 @@
 -keepclassmembers public class com.facebook.react.ReactNativeHost {
   protected *;
 }
+
+# For ExpoModulesPackage autolinking
+-keepclassmembers public class expo.modules.ExpoModulesPackageList {
+  public *;
+}
+
+-keepnames class * extends expo.modules.core.BasePackage
+-keepnames class * implements expo.modules.core.interfaces.Package


### PR DESCRIPTION
# Why

Android R8 would obfuscate class and method names which making this reflection error:
https://github.com/expo/expo/blob/6332730a51dfba118536f2456f834ed089946605/packages/expo/android/src/main/java/expo/modules/ExpoModulesPackage.kt#L21-L30
fixes #15062 
 
# How

keep necessary class and method names
 
# Test Plan

## Test on SDK 43 project

1. classic RN 0.66 project + `npx install-expo-modules`
2. set `def enableProguardInReleaseBuilds = true` in `android/app/build.gradle`
3. expo run:android --variant release and check adb logcat if there is `Couldn't get expo package list.` 

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
