### PR TITLE
[dev-client][android] Remove usage of the `GlobalScope`

### DIFF
--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
@@ -35,7 +35,8 @@ import expo.modules.devlauncher.react.activitydelegates.DevLauncherReactActivity
 import expo.modules.devlauncher.tests.DevLauncherTestInterceptor
 import expo.modules.manifests.core.Manifest
 import expo.modules.updatesinterface.UpdatesInterface
-import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import okhttp3.OkHttpClient
 import org.koin.core.component.get
@@ -68,6 +69,7 @@ class DevLauncherController private constructor()
     set(value) = DevLauncherKoinContext.app.koin.loadModules(listOf(module {
       single { value }
     }))
+  override val coroutineScope = CoroutineScope(Dispatchers.Default)
 
   override val devClientHost = DevLauncherClientHost((context as Application), DEV_LAUNCHER_HOST)
 
@@ -183,7 +185,7 @@ class DevLauncherController private constructor()
           return true
         }
 
-        GlobalScope.launch {
+        coroutineScope.launch {
           loadApp(appUrl, activityToBeInvalidated)
         }
         return true

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/modules/DevLauncherInternalModule.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/modules/DevLauncherInternalModule.kt
@@ -15,7 +15,6 @@ import expo.modules.devlauncher.helpers.isDevLauncherUrl
 import expo.modules.devlauncher.koin.DevLauncherKoinComponent
 import expo.modules.devlauncher.launcher.DevLauncherControllerInterface
 import expo.modules.devlauncher.launcher.DevLauncherIntentRegistryInterface
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import org.koin.core.component.inject
 
@@ -46,7 +45,7 @@ class DevLauncherInternalModule(reactContext: ReactApplicationContext?)
 
   @ReactMethod
   fun loadApp(url: String, promise: Promise) {
-    GlobalScope.launch {
+    controller.coroutineScope.launch {
       try {
         val parsedUrl = Uri.parse(url.trim())
         val appUrl = if (isDevLauncherUrl(parsedUrl)) {

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/DevLauncherControllerInterface.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/DevLauncherControllerInterface.kt
@@ -9,6 +9,7 @@ import com.facebook.react.bridge.ReactContext
 import expo.modules.devlauncher.DevLauncherController
 import expo.modules.manifests.core.Manifest
 import expo.modules.updatesinterface.UpdatesInterface
+import kotlinx.coroutines.CoroutineScope
 
 interface DevLauncherControllerInterface {
   suspend fun loadApp(url: Uri, mainActivity: ReactActivity? = null)
@@ -29,4 +30,5 @@ interface DevLauncherControllerInterface {
   val latestLoadedApp: Uri?
   val useDeveloperSupport: Boolean
   var updatesInterface: UpdatesInterface?
+  val coroutineScope: CoroutineScope
 }

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/errors/DevLauncherErrorActivity.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/errors/DevLauncherErrorActivity.kt
@@ -9,13 +9,11 @@ import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentPagerAdapter
 import com.facebook.react.ReactActivity
-import expo.modules.devlauncher.DevLauncherController
 import expo.modules.devlauncher.databinding.ErrorActivityContentViewBinding
 import expo.modules.devlauncher.koin.DevLauncherKoinComponent
 import expo.modules.devlauncher.launcher.DevLauncherControllerInterface
 import expo.modules.devlauncher.launcher.errors.fragments.DevLauncherErrorConsoleFragment
 import expo.modules.devlauncher.launcher.errors.fragments.DevLauncherErrorFragment
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import org.koin.core.component.inject
 import java.lang.ref.WeakReference
@@ -89,7 +87,7 @@ class DevLauncherErrorActivity
       return
     }
 
-    GlobalScope.launch {
+    controller.coroutineScope.launch {
       controller
         .loadApp(
           appUrl,

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/react/DevLauncherDevSupportManagerSwapper.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/react/DevLauncherDevSupportManagerSwapper.kt
@@ -8,12 +8,16 @@ import com.facebook.react.devsupport.DisabledDevSupportManager
 import com.facebook.react.packagerconnection.JSPackagerClient
 import expo.modules.devlauncher.helpers.getProtectedFieldValue
 import expo.modules.devlauncher.helpers.setProtectedDeclaredField
+import expo.modules.devlauncher.launcher.DevLauncherControllerInterface
 import expo.modules.devlauncher.rncompatibility.DevLauncherDevSupportManager
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
 
-class DevLauncherDevSupportManagerSwapper {
+class DevLauncherDevSupportManagerSwapper: KoinComponent {
+  private val controller: DevLauncherControllerInterface by inject()
+
   fun swapDevSupportManagerImpl(
     reactInstanceManager: ReactInstanceManager
   ) {
@@ -43,7 +47,7 @@ class DevLauncherDevSupportManagerSwapper {
        * and we don't know when it will be available (see [DevServerHelper.openPackagerConnection]).
        * So we just wait for connection and then we kill it.
        */
-      GlobalScope.launch {
+      controller.coroutineScope.launch {
         try {
           while (true) {
             val devServerHelper: DevServerHelper = devManagerClass.getProtectedFieldValue(

--- a/packages/expo-dev-launcher/android/src/release/java/expo/modules/devlauncher/DevLauncherController.kt
+++ b/packages/expo-dev-launcher/android/src/release/java/expo/modules/devlauncher/DevLauncherController.kt
@@ -12,6 +12,7 @@ import expo.modules.devlauncher.launcher.DevLauncherControllerInterface
 import expo.modules.devlauncher.launcher.DevLauncherReactActivityDelegateSupplier
 import expo.modules.manifests.core.Manifest
 import expo.modules.updatesinterface.UpdatesInterface
+import kotlinx.coroutines.CoroutineScope
 
 const val DEV_LAUNCHER_IS_NOT_AVAILABLE = "DevLauncher isn't available in release builds"
 
@@ -40,6 +41,9 @@ class DevLauncherController private constructor() : DevLauncherControllerInterfa
   override var updatesInterface: UpdatesInterface?
     get() = throw IllegalStateException(DEV_LAUNCHER_IS_NOT_AVAILABLE)
     set(_) {}
+
+  override val coroutineScope: CoroutineScope
+    get() = throw IllegalStateException(DEV_LAUNCHER_IS_NOT_AVAILABLE)
 
   override val useDeveloperSupport = false
 

--- a/packages/expo-dev-menu-interface/android/build.gradle
+++ b/packages/expo-dev-menu-interface/android/build.gradle
@@ -71,4 +71,5 @@ dependencies {
   implementation 'com.squareup.okhttp3:okhttp:3.14.9'
 
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${safeExtGet('kotlinVersion', '1.4.21')}"
+  implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.3"
 }

--- a/packages/expo-dev-menu-interface/android/src/main/java/expo/interfaces/devmenu/DevMenuManagerInterface.kt
+++ b/packages/expo-dev-menu-interface/android/src/main/java/expo/interfaces/devmenu/DevMenuManagerInterface.kt
@@ -8,6 +8,7 @@ import com.facebook.react.ReactNativeHost
 import com.facebook.react.bridge.ReadableMap
 import expo.interfaces.devmenu.expoapi.DevMenuExpoApiClientInterface
 import expo.interfaces.devmenu.items.DevMenuDataSourceItem
+import kotlinx.coroutines.CoroutineScope
 
 interface DevMenuManagerInterface {
   /**
@@ -116,4 +117,6 @@ interface DevMenuManagerInterface {
   fun setCanLaunchDevMenuOnStart(shouldAutoLaunch: Boolean)
 
   suspend fun fetchDataSource(id: String): List<DevMenuDataSourceItem>
+
+  val coroutineScope: CoroutineScope
 }

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuManager.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuManager.kt
@@ -43,6 +43,8 @@ import expo.modules.devmenu.react.DevMenuPackagerCommandHandlersSwapper
 import expo.modules.devmenu.tests.DevMenuDisabledTestInterceptor
 import expo.modules.devmenu.tests.DevMenuTestInterceptor
 import expo.modules.devmenu.websockets.DevMenuCommandHandlersProvider
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import java.lang.ref.WeakReference
 
 object DevMenuManager : DevMenuManagerInterface, LifecycleEventListener {
@@ -409,6 +411,8 @@ object DevMenuManager : DevMenuManagerInterface, LifecycleEventListener {
       .find { it.id == id }
       ?.run { fetchData() } ?: emptyList()
   }
+
+  override val coroutineScope = CoroutineScope(Dispatchers.Default)
 
   override fun serializedItems(): List<Bundle> = delegateRootMenuItems.map { it.serialize() }
 

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/devtools/DevMenuDevToolsDelegate.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/devtools/DevMenuDevToolsDelegate.kt
@@ -12,7 +12,6 @@ import com.facebook.react.devsupport.DevInternalSettings
 import expo.interfaces.devmenu.DevMenuManagerInterface
 import expo.modules.devmenu.DEV_MENU_TAG
 import expo.modules.devmenu.DevMenuManager
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import java.lang.ref.WeakReference
 
@@ -73,7 +72,7 @@ class DevMenuDevToolsDelegate(
     val reactContext = reactContext ?: return
     val metroHost = "http://${devSettings.packagerConnectionSettings.debugServerHost}"
 
-    GlobalScope.launch {
+    manager.coroutineScope.launch {
       try {
         DevMenuManager.metroClient.openJSInspector(metroHost, reactContext.packageName)
       } catch (e: Exception) {

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/modules/DevMenuModule.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/modules/DevMenuModule.kt
@@ -4,7 +4,6 @@ import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.bridge.ReactMethod
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 
 class DevMenuModule(reactContext: ReactApplicationContext) :
@@ -36,7 +35,7 @@ class DevMenuModule(reactContext: ReactApplicationContext) :
 
   @ReactMethod
   fun queryMyProjectsAsync(promise: Promise) {
-    GlobalScope.launch {
+    devMenuManager.coroutineScope.launch {
       try {
         devMenuManager
           .getExpoApiClient()
@@ -53,7 +52,7 @@ class DevMenuModule(reactContext: ReactApplicationContext) :
 
   @ReactMethod
   fun queryDevSessionsAsync(promise: Promise) {
-    GlobalScope.launch {
+    devMenuManager.coroutineScope.launch {
       try {
         devMenuManager
           .getExpoApiClient()

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/modules/internals/DevMenuInternalMenuControllerModule.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/modules/internals/DevMenuInternalMenuControllerModule.kt
@@ -6,7 +6,6 @@ import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.ReadableMap
 import expo.modules.devmenu.modules.DevMenuInternalMenuControllerModuleInterface
 import expo.modules.devmenu.modules.DevMenuManagerProvider
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 
 class DevMenuInternalMenuControllerModule(private val reactContext: ReactContext) :
@@ -79,7 +78,7 @@ class DevMenuInternalMenuControllerModule(private val reactContext: ReactContext
       return
     }
 
-    GlobalScope.launch {
+    devMenuManger.coroutineScope.launch {
       val data = devMenuManger.fetchDataSource(id)
       val result = Arguments.fromList(data.map { it.serialize() })
       promise.resolve(result)

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/react/DevMenuPackagerCommandHandlersSwapper.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/react/DevMenuPackagerCommandHandlersSwapper.kt
@@ -7,9 +7,9 @@ import com.facebook.react.devsupport.DevSupportManagerBase
 import com.facebook.react.devsupport.interfaces.DevSupportManager
 import com.facebook.react.packagerconnection.JSPackagerClient
 import com.facebook.react.packagerconnection.RequestHandler
+import expo.modules.devmenu.DevMenuManager
 import expo.modules.devmenu.helpers.getPrivateDeclaredFiledValue
 import expo.modules.devmenu.helpers.setPrivateDeclaredFiledValue
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
@@ -67,7 +67,7 @@ class DevMenuPackagerCommandHandlersSwapper {
     reactInstanceManager: ReactInstanceManager,
     handlers: Map<String, RequestHandler>
   ) {
-    GlobalScope.launch {
+    DevMenuManager.coroutineScope.launch {
       try {
         while (true) {
           val devSupportManager: DevSupportManagerBase =

--- a/packages/expo-dev-menu/android/src/release/java/expo/modules/devmenu/DevMenuManager.kt
+++ b/packages/expo-dev-menu/android/src/release/java/expo/modules/devmenu/DevMenuManager.kt
@@ -13,6 +13,7 @@ import expo.interfaces.devmenu.DevMenuSettingsInterface
 import expo.interfaces.devmenu.expoapi.DevMenuExpoApiClientInterface
 import expo.interfaces.devmenu.items.DevMenuDataSourceItem
 import expo.modules.devmenu.api.DevMenuMetroClient
+import kotlinx.coroutines.CoroutineScope
 
 private const val DEV_MENU_IS_NOT_AVAILABLE = "DevMenu isn't available in release builds"
 
@@ -95,4 +96,7 @@ object DevMenuManager : DevMenuManagerInterface {
   override suspend fun fetchDataSource(id: String): List<DevMenuDataSourceItem> {
     throw IllegalStateException(DEV_MENU_IS_NOT_AVAILABLE)
   }
+
+  override val coroutineScope: CoroutineScope
+    get() = throw IllegalStateException(DEV_MENU_IS_NOT_AVAILABLE)
 }


### PR DESCRIPTION
# Why

Closes ENG-1175.

# How

Replaced usage of the `GlobalScope` with custom coroutine scope.  

# Test Plan

- bare-expo ✅