### PR TITLE
[bare-expo] Fix start-metro script on Linux

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,8 @@ Manual smoke tests are included in `apps/native-component-list`, this is a good 
    - iOS: `yarn ios`
    - Android: `yarn android`
 
+    If you are working on a Linux distribution, make sure to set the `TERMINAL` environment variable to your preferred terminal application. (e.g. `export TERMINAL="Konsole"`)
+ 
 8. You are now running the `test-suite` app via the `bare-expo` project. The next section explains how you can begin to make changes to SDK packages.
 
 > If this didn't work for you as described, please [open an issue.](https://github.com/expo/expo/issues/new/choose)

--- a/apps/bare-expo/scripts/start-metro.sh
+++ b/apps/bare-expo/scripts/start-metro.sh
@@ -26,13 +26,14 @@ EOF
         open ${commandFile}
         ;;
      *)
-       # Spawns a new terminal window and detaches it
-       # Assuming the non-standard variable $TERMINAL is set
+        # Spawns a new terminal window and detaches it
+        # Assuming the non-standard variable $TERMINAL is set
         if [ -z "$TERMINAL" ]; then
-          echo "Could not open a new terminal window. Please make sure to export TERMINAL='your-terminal' "
+          echo "Could not open a new terminal window. Please make sure to export TERMINAL='your-terminal'"
         else
           nohup "$TERMINAL" -e "${commandFile}" </dev/null >/dev/null 2>&1 &
-        fi ;;
+        fi
+        ;;
   esac
 
 fi

--- a/apps/bare-expo/scripts/start-metro.sh
+++ b/apps/bare-expo/scripts/start-metro.sh
@@ -21,6 +21,15 @@ yarn start --port ${port}
 EOF
   # execute the file in a new command line window
   chmod 0755 ${commandFile}
-  open ${commandFile}
-  
+  case "$OSTYPE" in
+     darwin*)
+        open ${commandFile}
+        ;;
+     *)
+       # Spawns a new terminal window and detaches it
+       # Assuming the non-standard variable $TERMINAL is set
+        nohup "$TERMINAL" -e "${commandFile}" </dev/null >/dev/null 2>&1 &
+        ;;
+  esac
+
 fi

--- a/apps/bare-expo/scripts/start-metro.sh
+++ b/apps/bare-expo/scripts/start-metro.sh
@@ -28,8 +28,11 @@ EOF
      *)
        # Spawns a new terminal window and detaches it
        # Assuming the non-standard variable $TERMINAL is set
-        nohup "$TERMINAL" -e "${commandFile}" </dev/null >/dev/null 2>&1 &
-        ;;
+        if [ -z "$TERMINAL" ]; then
+          echo "Could not open a new terminal window. Please make sure to export TERMINAL='your-terminal' "
+        else
+          nohup "$TERMINAL" -e "${commandFile}" </dev/null >/dev/null 2>&1 &
+        fi ;;
   esac
 
 fi


### PR DESCRIPTION
# Why

Running `yarn android` as per documentation on a linux distribution (Manjaro/Arch) fails to successfully run the `start-metro.sh` script with the error `open: command not found`. Upon investigation and research i found that indeed there is no such thing as `open` on linux. The closest thing to it it's `xdg-open`, but executing the `commandFile` with that utility would most probably open it with the default text editor instead of actually executing it.

# How

My humble solution is to check if the OS type is not MacOS and spawn a new default terminal (set by the non-standard `TERMINAL` env variable since i don't currently know any better way to get the default terminal application on linux) window with nohup and redirecting all the output to /dev/null so that it doesn't create the `nohup.out` file...

# Test Plan

On linux, following the CONTRIBUTION.md docs the `start-metro.sh` script should fail with the error `open: command not found`. I did NOT test this on windows/WSL yet but i'm fairly sure the error would be the same.

# Checklist

- [x] Documentation is up to date to reflect these changes (CONTRIBUTION.md)
- [x] Check for os in apps/bare-expo/scripts/start-metro.sh and fix on linux

### Personal notes
My first open source PR :)