### PR TITLE
[dev-launcher][android] Add crash handler

### DIFF
--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
@@ -306,7 +306,7 @@ class DevLauncherController private constructor()
     }.apply { addFlags(NEW_ACTIVITY_FLAGS) }
 
   companion object {
-    private var sErrorHandlerWasInitialize = false
+    private var sErrorHandlerWasInitialized = false
     private var sLauncherClass: Class<*>? = null
     internal var sAdditionalPackages: List<ReactPackage>? = null
 
@@ -328,13 +328,13 @@ class DevLauncherController private constructor()
       if (!testInterceptor.allowReinitialization()) {
         check(!wasInitialized()) { "DevelopmentClientController was initialized." }
       }
-      if (!sErrorHandlerWasInitialize && context is Application) {
+      if (!sErrorHandlerWasInitialized && context is Application) {
         val handler = DevLauncherUncaughtExceptionHandler(
           context,
           Thread.getDefaultUncaughtExceptionHandler()
         )
         Thread.setDefaultUncaughtExceptionHandler(handler)
-        sErrorHandlerWasInitialize = true
+        sErrorHandlerWasInitialized = true
       }
 
       MenuDelegateWasInitialized = false

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
@@ -27,6 +27,7 @@ import expo.modules.devlauncher.launcher.DevLauncherIntentRegistryInterface
 import expo.modules.devlauncher.launcher.DevLauncherLifecycle
 import expo.modules.devlauncher.launcher.DevLauncherReactActivityDelegateSupplier
 import expo.modules.devlauncher.launcher.DevLauncherRecentlyOpenedAppsRegistry
+import expo.modules.devlauncher.launcher.errors.DevLauncherUncaughtExceptionHandler
 import expo.modules.devlauncher.launcher.loaders.DevLauncherAppLoaderFactoryInterface
 import expo.modules.devlauncher.launcher.manifest.DevLauncherManifestParser
 import expo.modules.devlauncher.launcher.menu.DevLauncherMenuDelegate
@@ -305,6 +306,7 @@ class DevLauncherController private constructor()
     }.apply { addFlags(NEW_ACTIVITY_FLAGS) }
 
   companion object {
+    private var sErrorHandlerWasInitialize = false
     private var sLauncherClass: Class<*>? = null
     internal var sAdditionalPackages: List<ReactPackage>? = null
 
@@ -325,6 +327,14 @@ class DevLauncherController private constructor()
       val testInterceptor = DevLauncherKoinContext.app.koin.get<DevLauncherTestInterceptor>()
       if (!testInterceptor.allowReinitialization()) {
         check(!wasInitialized()) { "DevelopmentClientController was initialized." }
+      }
+      if (!sErrorHandlerWasInitialize && context is Application) {
+        val handler = DevLauncherUncaughtExceptionHandler(
+          context,
+          Thread.getDefaultUncaughtExceptionHandler()
+        )
+        Thread.setDefaultUncaughtExceptionHandler(handler)
+        sErrorHandlerWasInitialize = true
       }
 
       MenuDelegateWasInitialized = false

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/errors/DevLauncherErrorActivity.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/errors/DevLauncherErrorActivity.kt
@@ -1,6 +1,7 @@
 package expo.modules.devlauncher.launcher.errors
 
 import android.app.Activity
+import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.widget.BaseAdapter
@@ -9,7 +10,6 @@ import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentPagerAdapter
 import com.facebook.react.ReactActivity
-import expo.modules.devlauncher.DevLauncherController
 import expo.modules.devlauncher.databinding.ErrorActivityContentViewBinding
 import expo.modules.devlauncher.koin.DevLauncherKoinComponent
 import expo.modules.devlauncher.launcher.DevLauncherControllerInterface
@@ -119,6 +119,19 @@ class DevLauncherErrorActivity
           Intent(activity, DevLauncherErrorActivity::class.java)
         )
       }
+    }
+
+    fun showFatalError(context: Context, error: DevLauncherAppError) {
+      addError(error)
+      
+      context.startActivity(
+        Intent(context, DevLauncherErrorActivity::class.java).apply {
+          addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or
+            Intent.FLAG_ACTIVITY_CLEAR_TASK or
+            Intent.FLAG_ACTIVITY_NO_ANIMATION
+          )
+        }
+      )
     }
 
     fun addError(error: DevLauncherAppError) {

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/errors/DevLauncherUncaughtExceptionHandler.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/errors/DevLauncherUncaughtExceptionHandler.kt
@@ -52,6 +52,7 @@ class DevLauncherUncaughtExceptionHandler(
     }
 
     exceptionWasReported = true
+    Log.e("DevLauncher", "DevLauncher tries to handle uncaught exception.", exception)
     applicationHolder.get()?.let {
       DevLauncherErrorActivity.showFatalError(
         it,

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/errors/DevLauncherUncaughtExceptionHandler.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/errors/DevLauncherUncaughtExceptionHandler.kt
@@ -1,0 +1,84 @@
+package expo.modules.devlauncher.launcher.errors
+
+import android.app.Activity
+import android.app.Application
+import android.os.Bundle
+import android.os.Process
+import android.util.Log
+import java.lang.ref.WeakReference
+import java.util.*
+import kotlin.concurrent.schedule
+import kotlin.system.exitProcess
+
+class DevLauncherUncaughtExceptionHandler(
+  application: Application,
+  private val defaultUncaughtHandler: Thread.UncaughtExceptionHandler?
+) : Thread.UncaughtExceptionHandler {
+  private val applicationHolder = WeakReference(application)
+  private var exceptionWasReported = false
+  private var timerTask: TimerTask? = null
+
+  init {
+    application.registerActivityLifecycleCallbacks(object : Application.ActivityLifecycleCallbacks {
+      override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
+        if (exceptionWasReported && activity is DevLauncherErrorActivity) {
+          timerTask?.cancel()
+          timerTask = null
+          exceptionWasReported = false
+          return
+        }
+      }
+
+      override fun onActivityStarted(activity: Activity) = Unit
+
+      override fun onActivityResumed(activity: Activity) = Unit
+
+      override fun onActivityPaused(activity: Activity) = Unit
+
+      override fun onActivityStopped(activity: Activity) = Unit
+
+      override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) = Unit
+
+      override fun onActivityDestroyed(activity: Activity) = Unit
+    })
+
+  }
+
+  override fun uncaughtException(thread: Thread, exception: Throwable) {
+    // The same exception can be reported multiple times.
+    // We handle only the first one.
+    if (exceptionWasReported) {
+      return
+    }
+
+    exceptionWasReported = true
+    applicationHolder.get()?.let {
+      DevLauncherErrorActivity.showFatalError(
+        it,
+        DevLauncherAppError(exception.message, exception)
+      )
+    }
+
+    // We don't know if the error screen will show up.
+    // That's why we schedule a simple function which will check
+    // if the error was handle properly or will fallback
+    // to the default exception handler.
+    timerTask = Timer().schedule(2000) {
+      if (!exceptionWasReported) {
+        // Exception was handle, we should suppress error here
+        return@schedule
+      }
+
+      // The error screen didn't appear in time.
+      // We fallback to the default exception handler.
+      if (defaultUncaughtHandler != null) {
+        defaultUncaughtHandler.uncaughtException(thread, exception)
+      } else {
+        // This scenario should never occur. It can only happen if there was no defaultUncaughtHandler when the handler was set up.
+        Log.e("UNCAUGHT_EXCEPTION", "exception", exception) // print exception in 'Logcat' tab.
+        Process.killProcess(Process.myPid())
+        exitProcess(0)
+      }
+    }
+  }
+}

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/errors/DevLauncherUncaughtExceptionHandler.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/errors/DevLauncherUncaughtExceptionHandler.kt
@@ -61,6 +61,8 @@ class DevLauncherUncaughtExceptionHandler(
     }
 
     // We don't know if the error screen will show up.
+    // For instance, if the exception was thrown in `MainApplication.onCreate` method,
+    // the erorr screen won't show up.  
     // That's why we schedule a simple function which will check
     // if the error was handle properly or will fallback
     // to the default exception handler.


### PR DESCRIPTION
# Why

Part of ENG-2293 - only Android

# How

Added `UncaughtExceptionHandler` to catch exceptions that will cause crashes and display them in our error screen.

# Test Plan

- bare-expo ✅