### PR TITLE
Update example in calendar docs to use getDefaultCalendarAsync

### DIFF
--- a/docs/pages/versions/unversioned/sdk/calendar.md
+++ b/docs/pages/versions/unversioned/sdk/calendar.md
@@ -51,9 +51,8 @@ export default function App() {
 }
 
 async function getDefaultCalendarSource() {
-  const calendars = await Calendar.getCalendarsAsync(Calendar.EntityTypes.EVENT);
-  const defaultCalendars = calendars.filter(each => each.source.name === 'Default');
-  return defaultCalendars[0].source;
+  const defaultCalendar = await Calendar.getDefaultCalendarAsync();
+  return defaultCalendar.source;
 }
 
 async function createCalendar() {

--- a/docs/pages/versions/v43.0.0/sdk/calendar.md
+++ b/docs/pages/versions/v43.0.0/sdk/calendar.md
@@ -51,9 +51,8 @@ export default function App() {
 }
 
 async function getDefaultCalendarSource() {
-  const calendars = await Calendar.getCalendarsAsync(Calendar.EntityTypes.EVENT);
-  const defaultCalendars = calendars.filter(each => each.source.name === 'Default');
-  return defaultCalendars[0].source;
+  const defaultCalendar = await Calendar.getDefaultCalendarAsync();
+  return defaultCalendar.source;
 }
 
 async function createCalendar() {


### PR DESCRIPTION
Simple PR that changes how default calendar source is retrieved on iOS (getDefaultCalendarAsync instead of looping through all calendars).
Fixes #14935.