### PR TITLE
[updates] Fix autolayout broken in ipad rotation

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix iOS auto-layout breaking for RCTRootView. on a iPad simulator, the view is not updated after rotation. ([#15100](https://github.com/expo/expo/pull/15100) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 0.10.14 — 2021-11-09

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesAppController.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesAppController.m
@@ -146,7 +146,7 @@ static NSString * const EXUpdatesErrorEventName = @"error";
 
 - (void)startAndShowLaunchScreen:(UIWindow *)window
 {
-  UIViewController* rootViewController = [EXUpdatesUtils createRootViewController:window];
+  UIViewController *rootViewController = [EXUpdatesUtils createRootViewController:window];
   NSBundle *mainBundle = [NSBundle mainBundle];
   NSString *launchScreen = (NSString *)[mainBundle objectForInfoDictionaryKey:@"UILaunchStoryboardName"] ?: @"LaunchScreen";
   

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesAppController.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesAppController.m
@@ -146,27 +146,30 @@ static NSString * const EXUpdatesErrorEventName = @"error";
 
 - (void)startAndShowLaunchScreen:(UIWindow *)window
 {
-  UIView *view = nil;
+  UIViewController* rootViewController = [EXUpdatesUtils createRootViewController:window];
   NSBundle *mainBundle = [NSBundle mainBundle];
   NSString *launchScreen = (NSString *)[mainBundle objectForInfoDictionaryKey:@"UILaunchStoryboardName"] ?: @"LaunchScreen";
   
   if ([mainBundle pathForResource:launchScreen ofType:@"nib"] != nil) {
     NSArray *views = [mainBundle loadNibNamed:launchScreen owner:self options:nil];
-    view = views.firstObject;
-    view.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    rootViewController.view = views.firstObject;
+    rootViewController.view.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
   } else if ([mainBundle pathForResource:launchScreen ofType:@"storyboard"] != nil ||
              [mainBundle pathForResource:launchScreen ofType:@"storyboardc"] != nil) {
     UIStoryboard *launchScreenStoryboard = [UIStoryboard storyboardWithName:launchScreen bundle:nil];
     UIViewController *viewController = [launchScreenStoryboard instantiateInitialViewController];
-    view = viewController.view;
+    UIView *view = viewController.view;
     viewController.view = nil;
+    rootViewController.view = view;
   } else {
     NSLog(@"Launch screen could not be loaded from a .xib or .storyboard. Unexpected loading behavior may occur.");
-    view = [UIView new];
+    UIView *view = [UIView new];
     view.backgroundColor = [UIColor whiteColor];
+    rootViewController.view = view;
   }
   
-  window.rootViewController.view = view;
+  window.rootViewController = rootViewController;
+  [window makeKeyAndVisible];
 
   [self start];
 }

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesAppDelegate.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesAppDelegate.m
@@ -6,6 +6,7 @@
 #import <ExpoModulesCore/EXDefines.h>
 #import <EXUpdates/EXUpdatesConfig.h>
 #import <EXUpdates/EXUpdatesAppController.h>
+#import <EXUpdates/EXUpdatesUtils.h>
 #import <React/RCTBridgeDelegate.h>
 #import <React/RCTConvert.h>
 #import <React/RCTRootView.h>
@@ -114,7 +115,10 @@ EX_REGISTER_SINGLETON_MODULE(EXUpdatesAppDelegate)
   }
 
   UIWindow *window = UIApplication.sharedApplication.delegate.window;
-  window.rootViewController.view = rootView;
+  UIViewController* rootViewController = [EXUpdatesUtils createRootViewController:window];
+  rootViewController.view = rootView;
+  window.rootViewController = rootViewController;
+  [window makeKeyAndVisible];
 
   return bridge;
  }

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesAppDelegate.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesAppDelegate.m
@@ -115,7 +115,7 @@ EX_REGISTER_SINGLETON_MODULE(EXUpdatesAppDelegate)
   }
 
   UIWindow *window = UIApplication.sharedApplication.delegate.window;
-  UIViewController* rootViewController = [EXUpdatesUtils createRootViewController:window];
+  UIViewController *rootViewController = [EXUpdatesUtils createRootViewController:window];
   rootViewController.view = rootView;
   window.rootViewController = rootViewController;
   [window makeKeyAndVisible];

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesUtils.h
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesUtils.h
@@ -17,6 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (NSString *)getRuntimeVersionWithConfig:(EXUpdatesConfig *)config;
 + (NSURL *)urlForBundledAsset:(EXUpdatesAsset *)asset;
 + (NSString *)pathForBundledAsset:(EXUpdatesAsset *)asset;
++ (UIViewController *)createRootViewController:(UIWindow *)window;
 
 @end
 

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesUtils.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesUtils.m
@@ -118,6 +118,27 @@ static NSString * const EXUpdatesUtilsErrorDomain = @"EXUpdatesUtils";
     : [[NSBundle mainBundle] pathForResource:asset.mainBundleFilename ofType:asset.type];
 }
 
+// Recreate a UIViewController from old `window.rootViewController`
++ (UIViewController *)createRootViewController:(UIWindow *)window
+{
+  UIViewController* result;
+  UIViewController* oldRootViewController = window.rootViewController;
+
+  SEL screenOrientationSelector = NSSelectorFromString(@"initWithDefaultScreenOrientationMask:");
+  // Support expo-screen-orientation's designated initializer
+  if ([oldRootViewController respondsToSelector:screenOrientationSelector]) {
+    NSNumber *maskValue = (NSNumber *) [oldRootViewController valueForKey:@"defaultOrientationMask"];
+    UIInterfaceOrientationMask mask = (UIInterfaceOrientationMask) [maskValue intValue];
+    id instance = [oldRootViewController.class alloc];
+    IMP imp = [instance methodForSelector:screenOrientationSelector];
+    result = ((id (*)(id, SEL, UIInterfaceOrientationMask))imp)(instance, screenOrientationSelector, mask);
+  } else {
+    result = [oldRootViewController.class new];
+  }
+
+  return result;
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesUtils.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesUtils.m
@@ -121,13 +121,13 @@ static NSString * const EXUpdatesUtilsErrorDomain = @"EXUpdatesUtils";
 // Recreate a UIViewController from old `window.rootViewController`
 + (UIViewController *)createRootViewController:(UIWindow *)window
 {
-  UIViewController* result;
-  UIViewController* oldRootViewController = window.rootViewController;
+  UIViewController *result;
+  UIViewController *oldRootViewController = window.rootViewController;
 
   SEL screenOrientationSelector = NSSelectorFromString(@"initWithDefaultScreenOrientationMask:");
   // Support expo-screen-orientation's designated initializer
   if ([oldRootViewController respondsToSelector:screenOrientationSelector]) {
-    NSNumber *maskValue = (NSNumber *) [oldRootViewController valueForKey:@"defaultOrientationMask"];
+    NSNumber *maskValue = (NSNumber *)[oldRootViewController valueForKey:@"defaultOrientationMask"];
     UIInterfaceOrientationMask mask = (UIInterfaceOrientationMask) [maskValue intValue];
     id instance = [oldRootViewController.class alloc];
     IMP imp = [instance methodForSelector:screenOrientationSelector];


### PR DESCRIPTION
# Why

the ipad simulator rotation is breaking after #14519, (not triggered from the true device rotation cmd-left key, but the  bottom right rotate button). 
![Screen Shot 2021-11-09 at 12 53 22 AM](https://user-images.githubusercontent.com/46429/140784326-ecb19019-1d74-4414-baf4-025f65200dc7.png)

the thing is like autolayout broken because we cannot reuse rootViewController for new view, otherwise view's frame or bounds will not update.

fixed #14967 

# How

so far i didn't find a better solution and back to create a new `rootViewController`. to be compatible with expo-screen-orientation, i use the its selector/property. maybe we should do it in expo-module-core interfaces ? 

# Test Plan

expo init sdk43 + this patch to expo-updates
test ipad simulator rotation
test cmd-left device rotation
test `expo publish` and make sure update works
test `SplashScreen.preventAutoHideAsync()` and make sure splash screen keeps there.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
