### PR TITLE
[navigation-bar] fix deps

### DIFF
--- a/packages/expo-navigation-bar/package.json
+++ b/packages/expo-navigation-bar/package.json
@@ -26,19 +26,19 @@
   "bugs": {
     "url": "https://github.com/expo/expo/issues"
   },
+  "jest": {
+    "preset": "expo-module-scripts/ios"
+  },
   "author": "650 Industries, Inc.",
   "license": "MIT",
   "homepage": "https://docs.expo.io/versions/latest/sdk/navigation-bar",
   "dependencies": {
     "@expo/config-plugins": "^4.0.2",
     "@react-native/normalize-color": "^2.0.0",
-    "debug": "^4.3.2",
-    "expo-module-scripts": "^2.0.0"
-  },
-  "jest": {
-    "preset": "expo-module-scripts/ios"
+    "debug": "^4.3.2"
   },
   "devDependencies": {
-    "@types/debug": "^4.1.7"
+    "@types/debug": "^4.1.7",
+    "expo-module-scripts": "^2.0.0"
   }
 }

--- a/packages/expo-navigation-bar/package.json
+++ b/packages/expo-navigation-bar/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "@expo/config-plugins": "^4.0.2",
     "@react-native/normalize-color": "^2.0.0",
+    "expo-modules-core": "~0.4.2",
     "debug": "^4.3.2"
   },
   "devDependencies": {


### PR DESCRIPTION
# Why

- Added missing `expo-modules-core`
- Moved `expo-module-scripts` to dev deps

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
