### PR TITLE
[bare-expo] Make Gradle faster

### DIFF
--- a/apps/bare-expo/android/app/build.gradle
+++ b/apps/bare-expo/android/app/build.gradle
@@ -78,7 +78,7 @@ project.ext.react = [
     enableHermes: (findProperty('expo.jsEngine') ?: "jsc") == "hermes",  // clean and rebuild if changing
 ]
 
-apply from: new File(["node", "--print", "require.resolve('react-native/package.json')"].execute().text.trim(), "../react.gradle");
+apply from: new File(["node", "--print", "require.resolve('react-native/package.json')"].execute().text.trim(), "../react.gradle")
 
 /**
  * Set this to true to create two separate APKs instead of one:
@@ -115,7 +115,7 @@ def jscFlavor = 'org.webkit:android-jsc:+'
  * on project.ext.react, JavaScript will not be compiled to Hermes Bytecode
  * and the benefits of using Hermes will therefore be sharply reduced.
  */
-def enableHermes = project.ext.react.get("enableHermes", false);
+def enableHermes = project.ext.react.get("enableHermes", false)
 
 android {
     ndkVersion rootProject.ext.ndkVersion
@@ -198,7 +198,7 @@ dependencies {
     implementation "com.facebook.react:react-native:+"  // From node_modules
 
     if (enableHermes) {
-        def hermesPath = "../../node_modules/hermes-engine/android/";
+        def hermesPath = "../../node_modules/hermes-engine/android/"
         debugImplementation files(hermesPath + "hermes-debug.aar")
         releaseImplementation files(hermesPath + "hermes-release.aar")
     } else {
@@ -235,40 +235,21 @@ class ExecuteSetupAndroidProject implements Plugin<Project> {
     @Override
     void apply(Project target) {
         target.exec {
-            workingDir '../..'
-            commandLine "./scripts/setup-android-project.sh"
-        }
-    }
-}
-
-apply plugin: ExecuteSetupAndroidProject
-
-import org.apache.tools.ant.taskdefs.condition.Os
-
-class GenerateDynamicMacrosPlugin implements Plugin<Project> {
-    @Override
-    void apply(Project target) {
-        target.exec {
             def configuration = target.gradle.startParameter.taskNames.any {
                 it.toLowerCase().contains("release")
             } ? "release" : "debug"
 
-            workingDir '../../../../tools/bin'
-
-            if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                commandLine 'cmd.exe', '/c', "expotools.js android-generate-dynamic-macros --configuration ${configuration}"
-            } else {
-                commandLine "./expotools.js", "android-generate-dynamic-macros", "--configuration", configuration
-            }
+            workingDir '../..'
+            commandLine "./scripts/setup-android-project.sh", configuration
         }
     }
 }
 
-apply from: new File(["node", "--print", "require.resolve('@react-native-community/cli-platform-android/package.json')"].execute().text.trim(), "../native_modules.gradle");
+//apply plugin: ExecuteSetupAndroidProject
+
+apply from: new File(["node", "--print", "require.resolve('@react-native-community/cli-platform-android/package.json')"].execute().text.trim(), "../native_modules.gradle")
 applyNativeModulesAppBuildGradle(project)
 
-// [Custom]: Add Google Services file
-apply plugin: GenerateDynamicMacrosPlugin
 apply plugin: 'com.google.gms.google-services'
 
 // Make sure JS bundle to be merged for gradle android plugin 4.1.0+

--- a/apps/bare-expo/android/app/build.gradle
+++ b/apps/bare-expo/android/app/build.gradle
@@ -245,7 +245,7 @@ class ExecuteSetupAndroidProject implements Plugin<Project> {
     }
 }
 
-//apply plugin: ExecuteSetupAndroidProject
+apply plugin: ExecuteSetupAndroidProject
 
 apply from: new File(["node", "--print", "require.resolve('@react-native-community/cli-platform-android/package.json')"].execute().text.trim(), "../native_modules.gradle")
 applyNativeModulesAppBuildGradle(project)

--- a/apps/bare-expo/android/gradle.properties
+++ b/apps/bare-expo/android/gradle.properties
@@ -18,6 +18,9 @@
 # org.gradle.parallel=true
 
 org.gradle.jvmargs=-Xmx10240M -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.vfs.watch=true
+org.gradle.parallel=true
+
 android.useAndroidX=true
 android.enableJetifier=true
 

--- a/apps/bare-expo/scripts/setup-android-project.sh
+++ b/apps/bare-expo/scripts/setup-android-project.sh
@@ -9,13 +9,7 @@ else
     yarn
 fi
 
-# 1. yarn why react-native : ... Found "react-native@0.62.2" ...
-# 2. grep Found            : Found "react-native@0.62.2"
-# 3. cut -d '@' -f2        : 0.62.2"
-# 4. rev                   : "2.26.0
-# 5. cut -c 2-             : 2.26.0
-# 6. rev                   : 0.62.2
-REACT_NATIVE_VERSION=$(yarn why react-native | grep Found | cut -d '@' -f2 | rev | cut -c 2- | rev)
+REACT_NATIVE_VERSION=$(node --print "require('react-native/package.json').version")
 
 if [ -d "node_modules/react-native/android/com/facebook/react/react-native/$REACT_NATIVE_VERSION" ]; then
     echo " ✅ React Android is installed"
@@ -41,3 +35,6 @@ else
 
     echo " ✅ React Android is now installed!"
 fi
+
+../../tools/bin/expotools.js android-generate-dynamic-macros --configuration $1 --bare
+echo " ✅ Generete dynamic macros"

--- a/tools/src/commands/AndroidGenerateDynamicMacros.ts
+++ b/tools/src/commands/AndroidGenerateDynamicMacros.ts
@@ -19,6 +19,7 @@ async function generateAction(options): Promise<void> {
     platform: 'android',
     expoKitPath: EXPO_DIR,
     templateFilesPath: TEMPLATE_FILES_DIR,
+    bareExpo: options.bare,
     configuration,
   });
 }
@@ -34,6 +35,7 @@ export default (program: Command) => {
       '--configuration [string]',
       'Build configuration. Defaults to `process.env.CONFIGURATION` or "debug".'
     )
+    .option('--bare', 'Generate macros only for the bare-expo project.')
     .description('Generates dynamic macros for Android client.')
     .asyncAction(generateAction);
 };


### PR DESCRIPTION
# Why

Makes Gradle a little bit faster in the `bare-expo` project.

# How

- Combined `GenerateDynamicMacrosPlugin` and `ExecuteSetupAndroidProject` into one plugin. 
- Allowed Gradle to run in parallel.
- Allowed Gradle to use file watchers to speed up the compilation.
- Exclude some unneeded operations from the generating dynamic macros command. 
- Changed how `setup-android-project.sh` detect RN version. 

You can check https://proandroiddev.com/how-we-reduced-our-gradle-build-times-by-over-80-51f2b6d6b05b to get more information about some of the optimizations I made. 

# Test Plan

Made several tests involving clean and incremental builds. 
The biggest gain is in the clean builds - there are two times faster. The incremental builds are also faster, but here the difference is more subtle. We can save about from 4 to 8 seconds. It is not a lot, but still an improvement. 