### PR TITLE
[home] List "unpublished" projects in home

### DIFF
--- a/home/components/AccountView.tsx
+++ b/home/components/AccountView.tsx
@@ -4,11 +4,11 @@ import { take, takeRight } from 'lodash';
 import React from 'react';
 import { ActivityIndicator, StyleSheet, View } from 'react-native';
 
-import { Project } from '../components/ProjectList';
 import { Snack } from '../components/SnackList';
 import Colors from '../constants/Colors';
 import SharedStyles from '../constants/SharedStyles';
 import { AccountData } from '../containers/Account';
+import { CommonAppDataFragment } from '../graphql/types';
 import { AllStackRoutes } from '../navigation/Navigation.types';
 import EmptyAccountProjectsNotice from './EmptyAccountProjectsNotice';
 import EmptyAccountSnacksNotice from './EmptyAccountSnacksNotice';
@@ -177,7 +177,7 @@ function AccountAppsSection({
 
   const apps = data.account.byName.apps;
 
-  const renderApp = (app: Project, i: number) => {
+  const renderApp = (app: CommonAppDataFragment, i: number) => {
     return (
       <ProjectListItem
         key={i}

--- a/home/components/ProfileView.tsx
+++ b/home/components/ProfileView.tsx
@@ -1,5 +1,4 @@
 import { StackScreenProps } from '@react-navigation/stack';
-import { Project } from 'components/ProjectList';
 import dedent from 'dedent';
 import { take, takeRight } from 'lodash';
 import React from 'react';
@@ -9,6 +8,7 @@ import FadeIn from 'react-native-fade-in-image';
 import Colors from '../constants/Colors';
 import SharedStyles from '../constants/SharedStyles';
 import { ProfileData } from '../containers/Profile';
+import { CommonAppDataFragment } from '../graphql/types';
 import { AllStackRoutes } from '../navigation/Navigation.types';
 import EmptyAccountProjectsNotice from './EmptyAccountProjectsNotice';
 import EmptyAccountSnacksNotice from './EmptyAccountSnacksNotice';
@@ -220,7 +220,7 @@ function ProfileProjectsSection({
     navigation.navigate('ProfileAllProjects', {});
   };
 
-  const renderApp = (app: Project, i: number) => {
+  const renderApp = (app: CommonAppDataFragment, i: number) => {
     return (
       <ProjectListItem
         key={i}

--- a/home/components/ProjectList.tsx
+++ b/home/components/ProjectList.tsx
@@ -6,6 +6,7 @@ import InfiniteScrollView from 'react-native-infinite-scroll-view';
 
 import Colors from '../constants/Colors';
 import SharedStyles from '../constants/SharedStyles';
+import { CommonAppDataFragment } from '../graphql/types';
 import PrimaryButton from './PrimaryButton';
 import ProjectListItem from './ProjectListItem';
 import SectionHeader from './SectionHeader';
@@ -21,22 +22,8 @@ const SERVER_ERROR_TEXT = dedent`
   Sorry about this. We will resolve the issue as soon as quickly as possible.
 `;
 
-export type Project = {
-  id: string;
-  description: string;
-  fullName: string;
-  iconUrl?: string | null;
-  published: boolean; // legacy publishes
-  lastPublishedTime: number;
-  name: string;
-  packageName: string;
-  privacy: string;
-  sdkVersion: string;
-  username: string;
-};
-
 type Props = {
-  data: { apps?: Project[]; appCount?: number };
+  data: { apps?: CommonAppDataFragment[]; appCount?: number };
   loadMoreAsync: () => Promise<any>;
   listTitle?: string;
 
@@ -130,11 +117,11 @@ function ProjectList({ data, loadMoreAsync, listTitle }: Props) {
   const totalAppCount = data.appCount ?? 0;
   const canLoadMore = currentAppCount < totalAppCount;
 
-  const renderItem = ({ item: app, index }: { item: Project; index: number }) => {
+  const renderItem = ({ item: app, index }: { item: CommonAppDataFragment; index: number }) => {
     const experienceInfo = { id: app.id, username: app.username, slug: app.packageName };
     return (
       <ProjectListItem
-        key={index.toString()}
+        key={app.id}
         url={app.fullName}
         image={app.iconUrl || require('../assets/placeholder-app-icon.png')}
         title={app.name}

--- a/home/components/ProjectListItem.tsx
+++ b/home/components/ProjectListItem.tsx
@@ -88,7 +88,7 @@ function ProjectListItem({
       onLongPress={handleLongPress}
       rightContent={renderRightContent()}
       {...props}
-      imageSize={sdkVersionNumber ? 56 : 40}
+      imageSize={56}
       renderExtraText={renderExtraText}
       subtitle={username || subtitle}
       onPressSubtitle={username ? handlePressUsername : undefined}

--- a/home/components/ProjectView.tsx
+++ b/home/components/ProjectView.tsx
@@ -125,9 +125,9 @@ function ProjectContents({ app }: { app: ProjectPageApp }) {
   return (
     <>
       <ProjectHeader app={app} />
-      <LegacyLaunchSection app={app} />
-      <NewLaunchSection app={app} />
-      <EmptySection app={app} />
+      {appHasLegacyUpdate(app) && <LegacyLaunchSection app={app} />}
+      {appHasEASUpdates(app) && <NewLaunchSection app={app} />}
+      {!appHasLegacyUpdate(app) && !appHasEASUpdates(app) && <EmptySection />}
     </>
   );
 }
@@ -194,10 +194,6 @@ function WarningBox({
 }
 
 function LegacyLaunchSection({ app }: { app: ProjectPageApp }) {
-  if (!appHasLegacyUpdate(app)) {
-    return null;
-  }
-
   const legacyUpdatesSDKMajorVersion = getSDKMajorVersionsForLegacyUpdates(app);
   const isLatestLegacyPublishDeprecated =
     legacyUpdatesSDKMajorVersion !== null &&
@@ -250,10 +246,6 @@ function LegacyLaunchSection({ app }: { app: ProjectPageApp }) {
 }
 
 function NewLaunchSection({ app }: { app: ProjectPageApp }) {
-  if (!appHasEASUpdates(app)) {
-    return null;
-  }
-
   const branchesToRender = app.updateBranches.filter(
     (updateBranch) => updateBranch.updates.length > 0
   );
@@ -298,11 +290,7 @@ function NewLaunchSection({ app }: { app: ProjectPageApp }) {
   );
 }
 
-function EmptySection({ app }: { app: ProjectPageApp }) {
-  if (appHasLegacyUpdate(app) || appHasEASUpdates(app)) {
-    return null;
-  }
-
+function EmptySection() {
   return (
     <StyledText
       style={[SharedStyles.noticeDescriptionText, styles.emptyInfo]}

--- a/home/components/ProjectView.tsx
+++ b/home/components/ProjectView.tsx
@@ -22,7 +22,7 @@ import SectionHeader from '../components/SectionHeader';
 import ShareProjectButton from '../components/ShareProjectButton';
 import Colors from '../constants/Colors';
 import SharedStyles from '../constants/SharedStyles';
-import { ProjectData, ProjectDataProject, ProjectUpdateBranch } from '../containers/Project';
+import { WebContainerProjectPage_QueryQuery } from '../graphql/types';
 import { AllStackRoutes } from '../navigation/Navigation.types';
 import Environment from '../utils/Environment';
 import * as UrlUtils from '../utils/UrlUtils';
@@ -35,11 +35,18 @@ const ERROR_TEXT = dedent`
   Sorry about this. We will resolve the issue as soon as possible.
 `;
 
+const NO_PUBLISHES_TEXT = dedent`
+  This project has not yet been published.
+`;
+
 type Props = {
   loading: boolean;
   error?: Error;
-  data?: ProjectData;
+  data?: WebContainerProjectPage_QueryQuery;
 } & StackScreenProps<AllStackRoutes, 'Project'>;
+
+type ProjectPageApp = WebContainerProjectPage_QueryQuery['app']['byId'];
+type ProjectUpdateBranch = WebContainerProjectPage_QueryQuery['app']['byId']['updateBranches'][0];
 
 export default function ProjectView({ loading, error, data, navigation }: Props) {
   let contents;
@@ -85,7 +92,7 @@ function truthy<TValue>(value: TValue | null | undefined): value is TValue {
   return !!value;
 }
 
-function getSDKMajorVersionsForLegacyUpdates(app: ProjectDataProject): number | null {
+function getSDKMajorVersionsForLegacyUpdates(app: ProjectPageApp): number | null {
   return app.sdkVersion ? semver.major(app.sdkVersion) : null;
 }
 
@@ -106,25 +113,26 @@ function getSDKMajorVersionForEASUpdateBranch(branch: ProjectUpdateBranch): numb
   );
 }
 
-function appHasLegacyUpdate(app: ProjectDataProject): boolean {
+function appHasLegacyUpdate(app: ProjectPageApp): boolean {
   return app.published;
 }
 
-function appHasEASUpdates(app: ProjectDataProject): boolean {
+function appHasEASUpdates(app: ProjectPageApp): boolean {
   return app.updateBranches.some((branch) => branch.updates.length > 0);
 }
 
-function ProjectContents({ app }: { app: ProjectDataProject }) {
+function ProjectContents({ app }: { app: ProjectPageApp }) {
   return (
     <>
       <ProjectHeader app={app} />
       <LegacyLaunchSection app={app} />
       <NewLaunchSection app={app} />
+      <EmptySection app={app} />
     </>
   );
 }
 
-function ProjectHeader(props: { app: ProjectDataProject }) {
+function ProjectHeader(props: { app: ProjectPageApp }) {
   const source = props.app.icon ? props.app.icon.url : props.app.iconUrl;
   return (
     <StyledView style={styles.header} darkBackgroundColor="#000" darkBorderColor="#000">
@@ -185,7 +193,7 @@ function WarningBox({
   );
 }
 
-function LegacyLaunchSection({ app }: { app: ProjectDataProject }) {
+function LegacyLaunchSection({ app }: { app: ProjectPageApp }) {
   if (!appHasLegacyUpdate(app)) {
     return null;
   }
@@ -241,7 +249,7 @@ function LegacyLaunchSection({ app }: { app: ProjectDataProject }) {
   );
 }
 
-function NewLaunchSection({ app }: { app: ProjectDataProject }) {
+function NewLaunchSection({ app }: { app: ProjectPageApp }) {
   if (!appHasEASUpdates(app)) {
     return null;
   }
@@ -287,6 +295,21 @@ function NewLaunchSection({ app }: { app: ProjectDataProject }) {
       <SectionHeader title="EAS branches" />
       {branchManifests.map(renderBranchManifest)}
     </View>
+  );
+}
+
+function EmptySection({ app }: { app: ProjectPageApp }) {
+  if (appHasLegacyUpdate(app) || appHasEASUpdates(app)) {
+    return null;
+  }
+
+  return (
+    <StyledText
+      style={[SharedStyles.noticeDescriptionText, styles.emptyInfo]}
+      lightColor="rgba(36, 44, 58, 0.7)"
+      darkColor="#ccc">
+      {NO_PUBLISHES_TEXT}
+    </StyledText>
   );
 }
 
@@ -374,5 +397,8 @@ const styles = StyleSheet.create({
   },
   warningLearnMoreButton: {
     textDecorationLine: 'underline',
+  },
+  emptyInfo: {
+    marginTop: 16,
   },
 });

--- a/home/containers/Account.tsx
+++ b/home/containers/Account.tsx
@@ -3,9 +3,8 @@ import { StackScreenProps } from '@react-navigation/stack';
 import * as React from 'react';
 
 import AccountView from '../components/AccountView';
-import { Project } from '../components/ProjectList';
 import { Snack } from '../components/SnackList';
-import { Home_AccountDataDocument } from '../graphql/types';
+import { Home_AccountDataDocument, CommonAppDataFragment } from '../graphql/types';
 import { AllStackRoutes } from '../navigation/Navigation.types';
 
 const APP_LIMIT = 7;
@@ -17,7 +16,7 @@ export interface AccountData {
       id: string;
       name: string;
       appCount: number;
-      apps: Project[];
+      apps: CommonAppDataFragment[];
       snacks: Snack[];
     };
   };

--- a/home/containers/Profile.tsx
+++ b/home/containers/Profile.tsx
@@ -3,9 +3,8 @@ import { StackScreenProps } from '@react-navigation/stack';
 import * as React from 'react';
 
 import ProfileView from '../components/ProfileView';
-import { Project } from '../components/ProjectList';
 import { Snack } from '../components/SnackList';
-import { Home_ProfileData2Document } from '../graphql/types';
+import { Home_ProfileData2Document, CommonAppDataFragment } from '../graphql/types';
 import { AllStackRoutes } from '../navigation/Navigation.types';
 import { useDispatch } from '../redux/Hooks';
 import SessionActions from '../redux/SessionActions';
@@ -25,7 +24,7 @@ export interface ProfileData {
       name: string;
     }[];
     appCount: number;
-    apps: Project[];
+    apps: CommonAppDataFragment[];
     snacks: Snack[];
   } | null;
 }

--- a/home/containers/Project.tsx
+++ b/home/containers/Project.tsx
@@ -9,52 +9,6 @@ import { AppPlatform, WebContainerProjectPage_QueryDocument } from '../graphql/t
 import * as Kernel from '../kernel/Kernel';
 import { AllStackRoutes } from '../navigation/Navigation.types';
 
-export interface ProjectUpdate {
-  id: string;
-  group: string;
-  message?: string | null;
-  createdAt: Date;
-  runtimeVersion: string;
-  platform: string;
-  manifestPermalink: string;
-}
-
-export interface ProjectUpdateBranch {
-  id: string;
-  name: string;
-  updates: ProjectUpdate[];
-}
-
-export type ProjectDataProject = {
-  id: string;
-  name: string;
-  slug: string;
-  fullName: string;
-  username: string;
-  published: boolean;
-  description: string;
-  githubUrl?: string | null;
-  playStoreUrl?: string | null;
-  appStoreUrl?: string | null;
-  sdkVersion: string;
-  iconUrl?: string | null;
-  privacy: string;
-  icon?: {
-    url: string;
-    primaryColor?: string;
-    colorPalette?: object;
-  } | null;
-  latestReleaseForReleaseChannel?: {
-    sdkVersion: string;
-    runtimeVersion?: string | null;
-  } | null;
-  updateBranches: ProjectUpdateBranch[];
-};
-
-export interface ProjectData {
-  app?: { byId: ProjectDataProject } | null;
-}
-
 export function ProjectContainer(
   props: { appId: string } & StackScreenProps<AllStackRoutes, 'Project'>
 ) {

--- a/home/graphql/fragments/CommonAppData.fragment.graphql
+++ b/home/graphql/fragments/CommonAppData.fragment.graphql
@@ -1,0 +1,11 @@
+fragment CommonAppData on App {
+  id
+  fullName
+  name
+  iconUrl
+  packageName
+  username
+  description
+  sdkVersion
+  privacy
+}

--- a/home/graphql/queries/AccountDataQuery.query.graphql
+++ b/home/graphql/queries/AccountDataQuery.query.graphql
@@ -4,18 +4,8 @@ query Home_AccountData($accountName: String!, $appLimit: Int!, $snackLimit: Int!
       id
       name
       appCount
-      apps(limit: $appLimit, offset: 0) {
-        id
-        fullName
-        name
-        iconUrl
-        packageName
-        username
-        description
-        sdkVersion
-        published
-        lastPublishedTime
-        privacy
+      apps(limit: $appLimit, offset: 0, includeUnpublished: true) {
+        ...CommonAppData
       }
       snacks(limit: $snackLimit, offset: 0) {
         id

--- a/home/graphql/queries/ProfileDataQuery.query.graphql
+++ b/home/graphql/queries/ProfileDataQuery.query.graphql
@@ -10,18 +10,8 @@ query Home_ProfileData2($appLimit: Int!, $snackLimit: Int!) {
       name
     }
     appCount
-    apps(limit: $appLimit, offset: 0) {
-      id
-      description
-      fullName
-      iconUrl
-      lastPublishedTime
-      name
-      packageName
-      username
-      sdkVersion
-      privacy
-      published
+    apps(limit: $appLimit, offset: 0, includeUnpublished: true) {
+      ...CommonAppData
     }
     snacks(limit: $snackLimit, offset: 0) {
       id

--- a/home/graphql/queries/ProfileProjectsQuery.query.graphql
+++ b/home/graphql/queries/ProfileProjectsQuery.query.graphql
@@ -2,18 +2,8 @@ query Home_MyApps($limit: Int!, $offset: Int!) {
   me {
     id
     appCount
-    apps(limit: $limit, offset: $offset) {
-      id
-      description
-      fullName
-      iconUrl
-      lastPublishedTime
-      name
-      username
-      packageName
-      privacy
-      sdkVersion
-      published
+    apps(limit: $limit, offset: $offset, includeUnpublished: true) {
+      ...CommonAppData
     }
   }
 }

--- a/home/graphql/queries/ProjectsListQuery.query.graphql
+++ b/home/graphql/queries/ProjectsListQuery.query.graphql
@@ -3,18 +3,8 @@ query Home_AccountApps($accountName: String!, $limit: Int!, $offset: Int!) {
     byName(accountName: $accountName) {
       id
       appCount
-      apps(limit: $limit, offset: $offset) {
-        id
-        fullName
-        name
-        iconUrl
-        packageName
-        username
-        description
-        lastPublishedTime
-        sdkVersion
-        published
-        privacy
+      apps(limit: $limit, offset: $offset, includeUnpublished: true) {
+        ...CommonAppData
       }
     }
   }


### PR DESCRIPTION
# Why

Background: https://github.com/expo/universe/pull/8403

The essentials: We no longer want to only show published apps here because we're removing the concept of "published" as we roll out EAS Update, which doesn't have a concept of "published". Therefore we want to show all apps and have sensible empty states. Expo Go will be a "browser" for all projects in accounts.

# How

Add `includeUnpublished` flag to app queries, update types to not query lastPublishedTime which is a funky required type even though it is null on unpublished apps.

# Test Plan

Load home locally, see all projects. View empty states.
<img width="416" alt="Screen Shot 2021-11-09 at 11 34 29 AM" src="https://user-images.githubusercontent.com/189568/140993773-22a3f6b2-99b4-435e-93e2-eb08c8f90d88.png">
<img width="404" alt="Screen Shot 2021-11-09 at 11 35 49 AM" src="https://user-images.githubusercontent.com/189568/140993785-d3a625e7-1db4-40a0-ae2c-75d489e7d9d8.png">


