### PR TITLE
[expo-updates] retain embedded asset fields when merging asset entities

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Fix iOS app.manifest generation error in `eas build --local` mode. ([#14956](https://github.com/expo/expo/pull/14956) by [@kudo](https://github.com/kudo))
 - Fix handling of unexpectedly missing assets on iOS. ([#15008](https://github.com/expo/expo/pull/15008) by [@esamelson](https://github.com/esamelson))
 - Fix issue with assets that are duplicated in the local SQLite db being reaped when they are still in use. ([#15049](https://github.com/expo/expo/pull/15049) by [@esamelson](https://github.com/esamelson))
+- Retain embedded asset fields when merging existing asset entities on Android. ([#15123](https://github.com/expo/expo/pull/15123) by [@esamelson](https://github.com/esamelson))
 
 ### 💡 Others
 

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/EmbeddedLoaderTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/EmbeddedLoaderTest.kt
@@ -59,6 +59,7 @@ class EmbeddedLoaderTest {
     )
 
     every { mockLoaderFiles.readEmbeddedManifest(any(), any()) } returns manifest
+    every { mockLoaderFiles.copyAssetAndGetHash(any(), any(), any()) } answers { callOriginal() } // test for exception cases
 
     mockCallback = mockk(relaxUnitFun = true)
     every { mockCallback.onUpdateManifestLoaded(any()) } returns true
@@ -194,6 +195,8 @@ class EmbeddedLoaderTest {
 
     // both assets should be copied regardless of what the database says
     verify(exactly = 2) { mockLoaderFiles.copyAssetAndGetHash(any(), any(), any()) }
+    // the resource asset should make it through to the inner copy method
+    verify(exactly = 1) { mockLoaderFiles.copyResourceAndGetHash(any(), any(), any()) }
 
     val updates = db.updateDao().loadAllUpdates()
     Assert.assertEquals(1, updates.size.toLong())

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/dao/AssetDao.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/dao/AssetDao.kt
@@ -95,6 +95,12 @@ abstract class AssetDao {
     }
     // we need to keep track of whether the calling class expects this asset to be the launch asset
     existingEntity.isLaunchAsset = newEntity.isLaunchAsset
+    // some fields on the asset entity are not stored in the database but might still be used by application code
+    existingEntity.embeddedAssetFilename = newEntity.embeddedAssetFilename
+    existingEntity.resourcesFilename = newEntity.resourcesFilename
+    existingEntity.resourcesFolder = newEntity.resourcesFolder
+    existingEntity.scale = newEntity.scale
+    existingEntity.scales = newEntity.scales
   }
 
   @Transaction

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/Loader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/Loader.kt
@@ -204,8 +204,8 @@ abstract class Loader protected constructor(
 
       val matchingDbEntry = database.assetDao().loadAssetWithKey(assetEntity.key)
       if (matchingDbEntry != null) {
-        // mergeAndUpdateAsset should merge all fields not stored in the database onto
-        // matchingDbEntry, in case we need them later on in this method
+        // merge all fields not stored in the database onto matchingDbEntry,
+        // in case we need them later on in this class
         database.assetDao().mergeAndUpdateAsset(matchingDbEntry, assetEntity)
         assetEntity = matchingDbEntry
       }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/Loader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/Loader.kt
@@ -204,6 +204,8 @@ abstract class Loader protected constructor(
 
       val matchingDbEntry = database.assetDao().loadAssetWithKey(assetEntity.key)
       if (matchingDbEntry != null) {
+        // mergeAndUpdateAsset should merge all fields not stored in the database onto
+        // matchingDbEntry, in case we need them later on in this method
         database.assetDao().mergeAndUpdateAsset(matchingDbEntry, assetEntity)
         assetEntity = matchingDbEntry
       }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/LoaderFiles.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/LoaderFiles.kt
@@ -38,7 +38,7 @@ open class LoaderFiles {
   }
 
   @Throws(NoSuchAlgorithmException::class, IOException::class)
-  private fun copyContextAssetAndGetHash(
+  internal fun copyContextAssetAndGetHash(
     asset: AssetEntity,
     destination: File,
     context: Context
@@ -53,7 +53,7 @@ open class LoaderFiles {
   }
 
   @Throws(NoSuchAlgorithmException::class, IOException::class)
-  private fun copyResourceAndGetHash(
+  internal fun copyResourceAndGetHash(
     asset: AssetEntity,
     destination: File,
     context: Context

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoader.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoader.m
@@ -175,11 +175,12 @@ static NSString * const EXUpdatesAppLoaderErrorDomain = @"EXUpdatesAppLoader";
         if (matchingAssetError || !matchingDbEntry || !matchingDbEntry.filename) {
           [self downloadAsset:asset];
         } else {
-          EXUpdatesAsset *assetToLoad = asset;
           NSError *mergeError;
           [self->_database mergeAsset:asset withExistingEntry:matchingDbEntry error:&mergeError];
+          EXUpdatesAsset *assetToLoad;
           if (mergeError) {
             NSLog(@"Failed to merge asset with existing database entry: %@", mergeError.localizedDescription);
+            assetToLoad = asset;
           } else {
             // mergeAsset:withExistingEntry:error: will merge all fields not stored in the database onto
             // matchingDbEntry, in case we need them later on in this method

--- a/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.m
+++ b/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.m
@@ -185,11 +185,10 @@ static NSString * const EXUpdatesDatabaseServerDefinedHeadersKey = @"serverDefin
     existingAsset.url = asset.url;
     [self updateAsset:existingAsset error:error];
   }
-  // some fields are not stored in the database but might still be used by application code
-  // so we need to preserve them here
-  existingAsset.isLaunchAsset = asset.isLaunchAsset;
-  existingAsset.mainBundleDir = asset.mainBundleDir;
-  existingAsset.mainBundleFilename = asset.mainBundleFilename;
+  // all other properties should be overridden by database values
+  asset.filename = existingAsset.filename;
+  asset.contentHash = existingAsset.contentHash;
+  asset.downloadTime = existingAsset.downloadTime;
 }
 
 - (void)markUpdateFinished:(EXUpdatesUpdate *)update error:(NSError ** _Nullable)error

--- a/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.m
+++ b/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.m
@@ -185,10 +185,11 @@ static NSString * const EXUpdatesDatabaseServerDefinedHeadersKey = @"serverDefin
     existingAsset.url = asset.url;
     [self updateAsset:existingAsset error:error];
   }
-  // all other properties should be overridden by database values
-  asset.filename = existingAsset.filename;
-  asset.contentHash = existingAsset.contentHash;
-  asset.downloadTime = existingAsset.downloadTime;
+  // some fields are not stored in the database but might still be used by application code
+  // so we need to preserve them here
+  existingAsset.isLaunchAsset = asset.isLaunchAsset;
+  existingAsset.mainBundleDir = asset.mainBundleDir;
+  existingAsset.mainBundleFilename = asset.mainBundleFilename;
 }
 
 - (void)markUpdateFinished:(EXUpdatesUpdate *)update error:(NSError ** _Nullable)error


### PR DESCRIPTION
# Why

fix for #15112

on Android, the app can't recover from the situation fixed by #15049 if a new build is immediately installed on top of the old one right after assets are mistakenly reaped. This PR fixes this issue so that the app can fix itself when there's a new embedded update.

# How

When assets are merged (https://github.com/expo/expo/blob/eeb60632cf13cfbc81afa9f1c4fe09acd8dac910/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/Loader.kt#L207) the properties that are not stored in the database are lost, so if the asset needs to be copied from the embedded bundle later on, it fails.

This PR fixes this by preserving all the extra fields when merging assets.

# Test Plan

Updated the existing unit tests to call the `copyAssetAndGetHash` method's original implementation, allowing the AssertionError it throws when fields are missing to be caught in the tests.

Verified that:
- updated tests fail without the change in AssetDao
- updated tests pass with the change in AssetDao

Additionally, ran the following manual test:
- make SDK 43 build with image and font assets
- install on device, delete image and font files from disk but keep them in the database (to simulate the outcome of issue #14930)
- make a text change in App.js, make a new build, install it over the old build

Verified that:
- before this change, the second build crashes with the same stacktrace as #15112 
- after this change, the second build runs and the assets are re-copied to disk

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
