### PR TITLE
[home] Use more modern graphql-codegen for queries and types

### DIFF
--- a/home/components/AccountView.tsx
+++ b/home/components/AccountView.tsx
@@ -4,11 +4,13 @@ import { take, takeRight } from 'lodash';
 import React from 'react';
 import { ActivityIndicator, StyleSheet, View } from 'react-native';
 
-import { Snack } from '../components/SnackList';
 import Colors from '../constants/Colors';
 import SharedStyles from '../constants/SharedStyles';
-import { AccountData } from '../containers/Account';
-import { CommonAppDataFragment } from '../graphql/types';
+import {
+  CommonAppDataFragment,
+  CommonSnackDataFragment,
+  Home_AccountDataQuery,
+} from '../graphql/types';
 import { AllStackRoutes } from '../navigation/Navigation.types';
 import EmptyAccountProjectsNotice from './EmptyAccountProjectsNotice';
 import EmptyAccountSnacksNotice from './EmptyAccountSnacksNotice';
@@ -43,7 +45,7 @@ type QueryProps = {
   loading: boolean;
   error?: Error;
   refetch: (props: any) => void;
-  data?: AccountData;
+  data?: Home_AccountDataQuery;
 };
 
 type Props = AccountViewProps & QueryProps;
@@ -233,7 +235,7 @@ function AccountSnacksSection({
 
   const snacks = data.account.byName.snacks;
 
-  const renderSnack = (snack: Snack, i: number) => {
+  const renderSnack = (snack: CommonSnackDataFragment, i: number) => {
     return (
       <SnackListItem
         key={i}

--- a/home/components/ProfileView.tsx
+++ b/home/components/ProfileView.tsx
@@ -7,8 +7,7 @@ import FadeIn from 'react-native-fade-in-image';
 
 import Colors from '../constants/Colors';
 import SharedStyles from '../constants/SharedStyles';
-import { ProfileData } from '../containers/Profile';
-import { CommonAppDataFragment } from '../graphql/types';
+import { CommonAppDataFragment, Home_ProfileData2Query } from '../graphql/types';
 import { AllStackRoutes } from '../navigation/Navigation.types';
 import EmptyAccountProjectsNotice from './EmptyAccountProjectsNotice';
 import EmptyAccountSnacksNotice from './EmptyAccountSnacksNotice';
@@ -42,7 +41,7 @@ type QueryProps = {
   loading: boolean;
   error?: Error;
   refetch: (props: any) => void;
-  data?: ProfileData;
+  data?: Home_ProfileData2Query;
 };
 
 type Props = ProfileViewProps & QueryProps;

--- a/home/components/ProjectView.tsx
+++ b/home/components/ProjectView.tsx
@@ -22,7 +22,7 @@ import SectionHeader from '../components/SectionHeader';
 import ShareProjectButton from '../components/ShareProjectButton';
 import Colors from '../constants/Colors';
 import SharedStyles from '../constants/SharedStyles';
-import { WebContainerProjectPage_QueryQuery } from '../graphql/types';
+import { WebContainerProjectPage_Query } from '../graphql/types';
 import { AllStackRoutes } from '../navigation/Navigation.types';
 import Environment from '../utils/Environment';
 import * as UrlUtils from '../utils/UrlUtils';
@@ -42,11 +42,11 @@ const NO_PUBLISHES_TEXT = dedent`
 type Props = {
   loading: boolean;
   error?: Error;
-  data?: WebContainerProjectPage_QueryQuery;
+  data?: WebContainerProjectPage_Query;
 } & StackScreenProps<AllStackRoutes, 'Project'>;
 
-type ProjectPageApp = WebContainerProjectPage_QueryQuery['app']['byId'];
-type ProjectUpdateBranch = WebContainerProjectPage_QueryQuery['app']['byId']['updateBranches'][0];
+type ProjectPageApp = WebContainerProjectPage_Query['app']['byId'];
+type ProjectUpdateBranch = WebContainerProjectPage_Query['app']['byId']['updateBranches'][0];
 
 export default function ProjectView({ loading, error, data, navigation }: Props) {
   let contents;

--- a/home/components/SnackList.tsx
+++ b/home/components/SnackList.tsx
@@ -4,18 +4,11 @@ import { ActivityIndicator, FlatList, View } from 'react-native';
 import InfiniteScrollView from 'react-native-infinite-scroll-view';
 
 import Colors from '../constants/Colors';
+import { CommonSnackDataFragment } from '../graphql/types';
 import SnackListItem from './SnackListItem';
 
-export type Snack = {
-  name: string;
-  fullName: string;
-  slug: string;
-  description: string;
-  isDraft?: boolean;
-};
-
 type Props = {
-  data: Snack[];
+  data: CommonSnackDataFragment[];
   loadMoreAsync: () => Promise<any>;
 };
 

--- a/home/containers/Account.tsx
+++ b/home/containers/Account.tsx
@@ -2,24 +2,11 @@ import { StackScreenProps } from '@react-navigation/stack';
 import * as React from 'react';
 
 import AccountView from '../components/AccountView';
-import { Snack } from '../components/SnackList';
-import { useHome_AccountDataQuery, CommonAppDataFragment } from '../graphql/types';
+import { useHome_AccountDataQuery } from '../graphql/types';
 import { AllStackRoutes } from '../navigation/Navigation.types';
 
 const APP_LIMIT = 7;
 const SNACK_LIMIT = 4;
-
-export interface AccountData {
-  account: {
-    byName: {
-      id: string;
-      name: string;
-      appCount: number;
-      apps: CommonAppDataFragment[];
-      snacks: Snack[];
-    };
-  };
-}
 
 export default function Account(
   props: {

--- a/home/containers/Account.tsx
+++ b/home/containers/Account.tsx
@@ -1,10 +1,9 @@
-import { useQuery } from '@apollo/client';
 import { StackScreenProps } from '@react-navigation/stack';
 import * as React from 'react';
 
 import AccountView from '../components/AccountView';
 import { Snack } from '../components/SnackList';
-import { Home_AccountDataDocument, CommonAppDataFragment } from '../graphql/types';
+import { useHome_AccountDataQuery, CommonAppDataFragment } from '../graphql/types';
 import { AllStackRoutes } from '../navigation/Navigation.types';
 
 const APP_LIMIT = 7;
@@ -27,7 +26,7 @@ export default function Account(
     accountName: string;
   } & StackScreenProps<AllStackRoutes, 'Account'>
 ) {
-  const query = useQuery(Home_AccountDataDocument, {
+  const query = useHome_AccountDataQuery({
     fetchPolicy: 'cache-and-network',
     variables: {
       accountName: props.accountName,

--- a/home/containers/Profile.tsx
+++ b/home/containers/Profile.tsx
@@ -1,10 +1,9 @@
-import { useQuery } from '@apollo/client';
 import { StackScreenProps } from '@react-navigation/stack';
 import * as React from 'react';
 
 import ProfileView from '../components/ProfileView';
 import { Snack } from '../components/SnackList';
-import { Home_ProfileData2Document, CommonAppDataFragment } from '../graphql/types';
+import { useHome_ProfileData2Query, CommonAppDataFragment } from '../graphql/types';
 import { AllStackRoutes } from '../navigation/Navigation.types';
 import { useDispatch } from '../redux/Hooks';
 import SessionActions from '../redux/SessionActions';
@@ -31,7 +30,7 @@ export interface ProfileData {
 
 export default function Profile(props: StackScreenProps<AllStackRoutes, 'Profile'>) {
   const dispatch = useDispatch();
-  const query = useQuery(Home_ProfileData2Document, {
+  const query = useHome_ProfileData2Query({
     fetchPolicy: 'cache-and-network',
     variables: {
       appLimit: APP_LIMIT,

--- a/home/containers/Profile.tsx
+++ b/home/containers/Profile.tsx
@@ -2,31 +2,13 @@ import { StackScreenProps } from '@react-navigation/stack';
 import * as React from 'react';
 
 import ProfileView from '../components/ProfileView';
-import { Snack } from '../components/SnackList';
-import { useHome_ProfileData2Query, CommonAppDataFragment } from '../graphql/types';
+import { useHome_ProfileData2Query } from '../graphql/types';
 import { AllStackRoutes } from '../navigation/Navigation.types';
 import { useDispatch } from '../redux/Hooks';
 import SessionActions from '../redux/SessionActions';
 
 const APP_LIMIT = 3;
 const SNACK_LIMIT = 3;
-
-export interface ProfileData {
-  me?: {
-    id: string;
-    username: string;
-    firstName?: string | null;
-    lastName?: string | null;
-    profilePhoto: string;
-    accounts: {
-      id: string;
-      name: string;
-    }[];
-    appCount: number;
-    apps: CommonAppDataFragment[];
-    snacks: Snack[];
-  } | null;
-}
 
 export default function Profile(props: StackScreenProps<AllStackRoutes, 'Profile'>) {
   const dispatch = useDispatch();

--- a/home/containers/ProfileProjectsList.tsx
+++ b/home/containers/ProfileProjectsList.tsx
@@ -1,11 +1,10 @@
-import { useQuery } from '@apollo/client';
 import * as React from 'react';
 
 import ProjectList from '../components/ProjectList';
-import { Home_MyAppsDocument } from '../graphql/types';
+import { useHome_MyAppsQuery } from '../graphql/types';
 
 function useProfileProjectsQuery() {
-  const { data, fetchMore, loading, error, refetch } = useQuery(Home_MyAppsDocument, {
+  const { data, fetchMore, loading, error, refetch } = useHome_MyAppsQuery({
     variables: {
       limit: 15,
       offset: 0,

--- a/home/containers/ProfileSnacksList.tsx
+++ b/home/containers/ProfileSnacksList.tsx
@@ -1,11 +1,10 @@
-import { useQuery } from '@apollo/client';
 import * as React from 'react';
 
 import SnackList from '../components/SnackList';
-import { Home_ProfileSnacksDocument } from '../graphql/types';
+import { useHome_ProfileSnacksQuery } from '../graphql/types';
 
 function useProfileSnacksQuery() {
-  const { data, fetchMore } = useQuery(Home_ProfileSnacksDocument, {
+  const { data, fetchMore } = useHome_ProfileSnacksQuery({
     variables: {
       limit: 15,
       offset: 0,

--- a/home/containers/Project.tsx
+++ b/home/containers/Project.tsx
@@ -1,18 +1,17 @@
-import { useQuery } from '@apollo/client';
 import { getRuntimeVersionForSDKVersion } from '@expo/sdk-runtime-versions';
 import { StackScreenProps } from '@react-navigation/stack';
 import * as React from 'react';
 import { Platform } from 'react-native';
 
 import ProjectView from '../components/ProjectView';
-import { AppPlatform, WebContainerProjectPage_QueryDocument } from '../graphql/types';
+import { AppPlatform, useWebContainerProjectPage_Query } from '../graphql/types';
 import * as Kernel from '../kernel/Kernel';
 import { AllStackRoutes } from '../navigation/Navigation.types';
 
 export function ProjectContainer(
   props: { appId: string } & StackScreenProps<AllStackRoutes, 'Project'>
 ) {
-  const query = useQuery(WebContainerProjectPage_QueryDocument, {
+  const query = useWebContainerProjectPage_Query({
     fetchPolicy: 'cache-and-network',
     variables: {
       appId: props.appId,

--- a/home/containers/ProjectsList.tsx
+++ b/home/containers/ProjectsList.tsx
@@ -1,11 +1,10 @@
-import { useQuery } from '@apollo/client';
 import * as React from 'react';
 
 import ProjectList from '../components/ProjectList';
-import { Home_AccountAppsDocument } from '../graphql/types';
+import { useHome_AccountAppsQuery } from '../graphql/types';
 
 function useOtherProjectsQuery({ accountName }: { accountName: string }) {
-  const { data, fetchMore, loading, error, refetch } = useQuery(Home_AccountAppsDocument, {
+  const { data, fetchMore, loading, error, refetch } = useHome_AccountAppsQuery({
     variables: {
       accountName,
       limit: 15,

--- a/home/containers/SnacksList.tsx
+++ b/home/containers/SnacksList.tsx
@@ -1,11 +1,10 @@
-import { useQuery } from '@apollo/client';
 import * as React from 'react';
 
 import SnackList from '../components/SnackList';
-import { Home_AccountSnacksDocument } from '../graphql/types';
+import { useHome_AccountSnacksQuery } from '../graphql/types';
 
 function useSnacksQuery({ accountName }: { accountName: string }) {
-  const { data, fetchMore } = useQuery(Home_AccountSnacksDocument, {
+  const { data, fetchMore } = useHome_AccountSnacksQuery({
     variables: {
       accountName,
       limit: 15,

--- a/home/graphql-codegen.yml
+++ b/home/graphql-codegen.yml
@@ -8,4 +8,10 @@ generates:
     plugins:
       - typescript
       - typescript-operations
-      - typed-document-node
+      - typescript-react-apollo
+    config:
+      withHooks: true
+      withRefetchFn: true
+      reactApolloVersion: 3
+      preResolveTypes: true
+      dedupeOperationSuffix: true

--- a/home/graphql/fragments/CommonSnackData.fragment.graphql
+++ b/home/graphql/fragments/CommonSnackData.fragment.graphql
@@ -1,0 +1,8 @@
+fragment CommonSnackData on Snack {
+  id
+  name
+  description
+  fullName
+  slug
+  isDraft
+}

--- a/home/graphql/queries/AccountDataQuery.query.graphql
+++ b/home/graphql/queries/AccountDataQuery.query.graphql
@@ -8,12 +8,7 @@ query Home_AccountData($accountName: String!, $appLimit: Int!, $snackLimit: Int!
         ...CommonAppData
       }
       snacks(limit: $snackLimit, offset: 0) {
-        id
-        name
-        description
-        fullName
-        slug
-        isDraft
+        ...CommonSnackData
       }
     }
   }

--- a/home/graphql/queries/ProfileDataQuery.query.graphql
+++ b/home/graphql/queries/ProfileDataQuery.query.graphql
@@ -14,12 +14,7 @@ query Home_ProfileData2($appLimit: Int!, $snackLimit: Int!) {
       ...CommonAppData
     }
     snacks(limit: $snackLimit, offset: 0) {
-      id
-      name
-      description
-      fullName
-      slug
-      isDraft
+      ...CommonSnackData
     }
   }
 }

--- a/home/graphql/queries/ProfileSnacksQuery.query.graphql
+++ b/home/graphql/queries/ProfileSnacksQuery.query.graphql
@@ -2,12 +2,7 @@ query Home_ProfileSnacks($limit: Int!, $offset: Int!) {
   me {
     id
     snacks(limit: $limit, offset: $offset) {
-      id
-      name
-      description
-      fullName
-      slug
-      isDraft
+      ...CommonSnackData
     }
   }
 }

--- a/home/graphql/queries/SnacksListQuery.query.graphql
+++ b/home/graphql/queries/SnacksListQuery.query.graphql
@@ -4,12 +4,7 @@ query Home_AccountSnacks($accountName: String!, $limit: Int!, $offset: Int!) {
       id
       name
       snacks(limit: $limit, offset: $offset) {
-        id
-        name
-        description
-        fullName
-        slug
-        isDraft
+        ...CommonSnackData
       }
     }
   }

--- a/home/graphql/types.ts
+++ b/home/graphql/types.ts
@@ -1,8 +1,10 @@
-import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
+import { gql } from '@apollo/client';
+import * as Apollo from '@apollo/client';
 export type Maybe<T> = T | null;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+const defaultOptions =  {}
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;
@@ -3582,14 +3584,14 @@ export type Home_ProfileSnacksQueryVariables = Exact<{
 
 export type Home_ProfileSnacksQuery = { __typename?: 'RootQuery', me?: { __typename?: 'User', id: string, snacks: Array<{ __typename?: 'Snack', id: string, name: string, description: string, fullName: string, slug: string, isDraft: boolean }> } | null | undefined };
 
-export type WebContainerProjectPage_QueryQueryVariables = Exact<{
+export type WebContainerProjectPage_QueryVariables = Exact<{
   appId: Scalars['String'];
   platform: AppPlatform;
   runtimeVersions: Array<Scalars['String']> | Scalars['String'];
 }>;
 
 
-export type WebContainerProjectPage_QueryQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, name: string, slug: string, fullName: string, username: string, published: boolean, description: string, githubUrl?: string | null | undefined, playStoreUrl?: string | null | undefined, appStoreUrl?: string | null | undefined, sdkVersion: string, iconUrl?: string | null | undefined, privacy: string, icon?: { __typename?: 'AppIcon', url: string } | null | undefined, latestReleaseForReleaseChannel?: { __typename?: 'AppRelease', sdkVersion: string, runtimeVersion?: string | null | undefined } | null | undefined, updateBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updates: Array<{ __typename?: 'Update', id: string, group: string, message?: string | null | undefined, createdAt: any, runtimeVersion: string, platform: string, manifestPermalink: string }> }> } } };
+export type WebContainerProjectPage_Query = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, name: string, slug: string, fullName: string, username: string, published: boolean, description: string, githubUrl?: string | null | undefined, playStoreUrl?: string | null | undefined, appStoreUrl?: string | null | undefined, sdkVersion: string, iconUrl?: string | null | undefined, privacy: string, icon?: { __typename?: 'AppIcon', url: string } | null | undefined, latestReleaseForReleaseChannel?: { __typename?: 'AppRelease', sdkVersion: string, runtimeVersion?: string | null | undefined } | null | undefined, updateBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updates: Array<{ __typename?: 'Update', id: string, group: string, message?: string | null | undefined, createdAt: any, runtimeVersion: string, platform: string, manifestPermalink: string }> }> } } };
 
 export type Home_AccountAppsQueryVariables = Exact<{
   accountName: Scalars['String'];
@@ -3614,12 +3616,433 @@ export type Home_ViewerUsernameQueryVariables = Exact<{ [key: string]: never; }>
 
 export type Home_ViewerUsernameQuery = { __typename?: 'RootQuery', me?: { __typename?: 'User', id: string, username: string } | null | undefined };
 
-export const CommonAppDataFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"CommonAppData"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"App"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"fullName"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"iconUrl"}},{"kind":"Field","name":{"kind":"Name","value":"packageName"}},{"kind":"Field","name":{"kind":"Name","value":"username"}},{"kind":"Field","name":{"kind":"Name","value":"description"}},{"kind":"Field","name":{"kind":"Name","value":"sdkVersion"}},{"kind":"Field","name":{"kind":"Name","value":"privacy"}}]}}]} as unknown as DocumentNode<CommonAppDataFragment, unknown>;
-export const Home_AccountDataDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"Home_AccountData"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"accountName"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"appLimit"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"snackLimit"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"account"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"byName"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"accountName"},"value":{"kind":"Variable","name":{"kind":"Name","value":"accountName"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"appCount"}},{"kind":"Field","name":{"kind":"Name","value":"apps"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"limit"},"value":{"kind":"Variable","name":{"kind":"Name","value":"appLimit"}}},{"kind":"Argument","name":{"kind":"Name","value":"offset"},"value":{"kind":"IntValue","value":"0"}},{"kind":"Argument","name":{"kind":"Name","value":"includeUnpublished"},"value":{"kind":"BooleanValue","value":true}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"CommonAppData"}}]}},{"kind":"Field","name":{"kind":"Name","value":"snacks"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"limit"},"value":{"kind":"Variable","name":{"kind":"Name","value":"snackLimit"}}},{"kind":"Argument","name":{"kind":"Name","value":"offset"},"value":{"kind":"IntValue","value":"0"}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"description"}},{"kind":"Field","name":{"kind":"Name","value":"fullName"}},{"kind":"Field","name":{"kind":"Name","value":"slug"}},{"kind":"Field","name":{"kind":"Name","value":"isDraft"}}]}}]}}]}}]}},...CommonAppDataFragmentDoc.definitions]} as unknown as DocumentNode<Home_AccountDataQuery, Home_AccountDataQueryVariables>;
-export const Home_ProfileData2Document = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"Home_ProfileData2"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"appLimit"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"snackLimit"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"me"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"username"}},{"kind":"Field","name":{"kind":"Name","value":"firstName"}},{"kind":"Field","name":{"kind":"Name","value":"lastName"}},{"kind":"Field","name":{"kind":"Name","value":"profilePhoto"}},{"kind":"Field","name":{"kind":"Name","value":"accounts"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}},{"kind":"Field","name":{"kind":"Name","value":"appCount"}},{"kind":"Field","name":{"kind":"Name","value":"apps"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"limit"},"value":{"kind":"Variable","name":{"kind":"Name","value":"appLimit"}}},{"kind":"Argument","name":{"kind":"Name","value":"offset"},"value":{"kind":"IntValue","value":"0"}},{"kind":"Argument","name":{"kind":"Name","value":"includeUnpublished"},"value":{"kind":"BooleanValue","value":true}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"CommonAppData"}}]}},{"kind":"Field","name":{"kind":"Name","value":"snacks"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"limit"},"value":{"kind":"Variable","name":{"kind":"Name","value":"snackLimit"}}},{"kind":"Argument","name":{"kind":"Name","value":"offset"},"value":{"kind":"IntValue","value":"0"}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"description"}},{"kind":"Field","name":{"kind":"Name","value":"fullName"}},{"kind":"Field","name":{"kind":"Name","value":"slug"}},{"kind":"Field","name":{"kind":"Name","value":"isDraft"}}]}}]}}]}},...CommonAppDataFragmentDoc.definitions]} as unknown as DocumentNode<Home_ProfileData2Query, Home_ProfileData2QueryVariables>;
-export const Home_MyAppsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"Home_MyApps"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"limit"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"offset"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"me"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"appCount"}},{"kind":"Field","name":{"kind":"Name","value":"apps"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"limit"},"value":{"kind":"Variable","name":{"kind":"Name","value":"limit"}}},{"kind":"Argument","name":{"kind":"Name","value":"offset"},"value":{"kind":"Variable","name":{"kind":"Name","value":"offset"}}},{"kind":"Argument","name":{"kind":"Name","value":"includeUnpublished"},"value":{"kind":"BooleanValue","value":true}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"CommonAppData"}}]}}]}}]}},...CommonAppDataFragmentDoc.definitions]} as unknown as DocumentNode<Home_MyAppsQuery, Home_MyAppsQueryVariables>;
-export const Home_ProfileSnacksDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"Home_ProfileSnacks"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"limit"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"offset"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"me"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"snacks"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"limit"},"value":{"kind":"Variable","name":{"kind":"Name","value":"limit"}}},{"kind":"Argument","name":{"kind":"Name","value":"offset"},"value":{"kind":"Variable","name":{"kind":"Name","value":"offset"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"description"}},{"kind":"Field","name":{"kind":"Name","value":"fullName"}},{"kind":"Field","name":{"kind":"Name","value":"slug"}},{"kind":"Field","name":{"kind":"Name","value":"isDraft"}}]}}]}}]}}]} as unknown as DocumentNode<Home_ProfileSnacksQuery, Home_ProfileSnacksQueryVariables>;
-export const WebContainerProjectPage_QueryDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"WebContainerProjectPage_Query"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"appId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"platform"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"AppPlatform"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"runtimeVersions"}},"type":{"kind":"NonNullType","type":{"kind":"ListType","type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"app"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"byId"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"appId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"appId"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"slug"}},{"kind":"Field","name":{"kind":"Name","value":"fullName"}},{"kind":"Field","name":{"kind":"Name","value":"username"}},{"kind":"Field","name":{"kind":"Name","value":"published"}},{"kind":"Field","name":{"kind":"Name","value":"description"}},{"kind":"Field","name":{"kind":"Name","value":"githubUrl"}},{"kind":"Field","name":{"kind":"Name","value":"playStoreUrl"}},{"kind":"Field","name":{"kind":"Name","value":"appStoreUrl"}},{"kind":"Field","name":{"kind":"Name","value":"sdkVersion"}},{"kind":"Field","name":{"kind":"Name","value":"iconUrl"}},{"kind":"Field","name":{"kind":"Name","value":"privacy"}},{"kind":"Field","name":{"kind":"Name","value":"icon"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"url"}}]}},{"kind":"Field","name":{"kind":"Name","value":"latestReleaseForReleaseChannel"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"platform"},"value":{"kind":"Variable","name":{"kind":"Name","value":"platform"}}},{"kind":"Argument","name":{"kind":"Name","value":"releaseChannel"},"value":{"kind":"StringValue","value":"default","block":false}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"sdkVersion"}},{"kind":"Field","name":{"kind":"Name","value":"runtimeVersion"}}]}},{"kind":"Field","name":{"kind":"Name","value":"updateBranches"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"limit"},"value":{"kind":"IntValue","value":"100"}},{"kind":"Argument","name":{"kind":"Name","value":"offset"},"value":{"kind":"IntValue","value":"0"}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"updates"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"limit"},"value":{"kind":"IntValue","value":"1"}},{"kind":"Argument","name":{"kind":"Name","value":"offset"},"value":{"kind":"IntValue","value":"0"}},{"kind":"Argument","name":{"kind":"Name","value":"filter"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"platform"},"value":{"kind":"Variable","name":{"kind":"Name","value":"platform"}}},{"kind":"ObjectField","name":{"kind":"Name","value":"runtimeVersions"},"value":{"kind":"Variable","name":{"kind":"Name","value":"runtimeVersions"}}}]}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"group"}},{"kind":"Field","name":{"kind":"Name","value":"message"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}},{"kind":"Field","name":{"kind":"Name","value":"runtimeVersion"}},{"kind":"Field","name":{"kind":"Name","value":"platform"}},{"kind":"Field","name":{"kind":"Name","value":"manifestPermalink"}}]}}]}}]}}]}}]}}]} as unknown as DocumentNode<WebContainerProjectPage_QueryQuery, WebContainerProjectPage_QueryQueryVariables>;
-export const Home_AccountAppsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"Home_AccountApps"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"accountName"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"limit"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"offset"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"account"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"byName"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"accountName"},"value":{"kind":"Variable","name":{"kind":"Name","value":"accountName"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"appCount"}},{"kind":"Field","name":{"kind":"Name","value":"apps"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"limit"},"value":{"kind":"Variable","name":{"kind":"Name","value":"limit"}}},{"kind":"Argument","name":{"kind":"Name","value":"offset"},"value":{"kind":"Variable","name":{"kind":"Name","value":"offset"}}},{"kind":"Argument","name":{"kind":"Name","value":"includeUnpublished"},"value":{"kind":"BooleanValue","value":true}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"CommonAppData"}}]}}]}}]}}]}},...CommonAppDataFragmentDoc.definitions]} as unknown as DocumentNode<Home_AccountAppsQuery, Home_AccountAppsQueryVariables>;
-export const Home_AccountSnacksDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"Home_AccountSnacks"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"accountName"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"limit"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"offset"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"account"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"byName"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"accountName"},"value":{"kind":"Variable","name":{"kind":"Name","value":"accountName"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"snacks"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"limit"},"value":{"kind":"Variable","name":{"kind":"Name","value":"limit"}}},{"kind":"Argument","name":{"kind":"Name","value":"offset"},"value":{"kind":"Variable","name":{"kind":"Name","value":"offset"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"description"}},{"kind":"Field","name":{"kind":"Name","value":"fullName"}},{"kind":"Field","name":{"kind":"Name","value":"slug"}},{"kind":"Field","name":{"kind":"Name","value":"isDraft"}}]}}]}}]}}]}}]} as unknown as DocumentNode<Home_AccountSnacksQuery, Home_AccountSnacksQueryVariables>;
-export const Home_ViewerUsernameDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"Home_ViewerUsername"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"me"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"username"}}]}}]}}]} as unknown as DocumentNode<Home_ViewerUsernameQuery, Home_ViewerUsernameQueryVariables>;
+export const CommonAppDataFragmentDoc = gql`
+    fragment CommonAppData on App {
+  id
+  fullName
+  name
+  iconUrl
+  packageName
+  username
+  description
+  sdkVersion
+  privacy
+}
+    `;
+export const Home_AccountDataDocument = gql`
+    query Home_AccountData($accountName: String!, $appLimit: Int!, $snackLimit: Int!) {
+  account {
+    byName(accountName: $accountName) {
+      id
+      name
+      appCount
+      apps(limit: $appLimit, offset: 0, includeUnpublished: true) {
+        ...CommonAppData
+      }
+      snacks(limit: $snackLimit, offset: 0) {
+        id
+        name
+        description
+        fullName
+        slug
+        isDraft
+      }
+    }
+  }
+}
+    ${CommonAppDataFragmentDoc}`;
+
+/**
+ * __useHome_AccountDataQuery__
+ *
+ * To run a query within a React component, call `useHome_AccountDataQuery` and pass it any options that fit your needs.
+ * When your component renders, `useHome_AccountDataQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useHome_AccountDataQuery({
+ *   variables: {
+ *      accountName: // value for 'accountName'
+ *      appLimit: // value for 'appLimit'
+ *      snackLimit: // value for 'snackLimit'
+ *   },
+ * });
+ */
+export function useHome_AccountDataQuery(baseOptions: Apollo.QueryHookOptions<Home_AccountDataQuery, Home_AccountDataQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<Home_AccountDataQuery, Home_AccountDataQueryVariables>(Home_AccountDataDocument, options);
+      }
+export function useHome_AccountDataLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Home_AccountDataQuery, Home_AccountDataQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<Home_AccountDataQuery, Home_AccountDataQueryVariables>(Home_AccountDataDocument, options);
+        }
+export type Home_AccountDataQueryHookResult = ReturnType<typeof useHome_AccountDataQuery>;
+export type Home_AccountDataLazyQueryHookResult = ReturnType<typeof useHome_AccountDataLazyQuery>;
+export type Home_AccountDataQueryResult = Apollo.QueryResult<Home_AccountDataQuery, Home_AccountDataQueryVariables>;
+export function refetchHome_AccountDataQuery(variables: Home_AccountDataQueryVariables) {
+      return { query: Home_AccountDataDocument, variables: variables }
+    }
+export const Home_ProfileData2Document = gql`
+    query Home_ProfileData2($appLimit: Int!, $snackLimit: Int!) {
+  me {
+    id
+    username
+    firstName
+    lastName
+    profilePhoto
+    accounts {
+      id
+      name
+    }
+    appCount
+    apps(limit: $appLimit, offset: 0, includeUnpublished: true) {
+      ...CommonAppData
+    }
+    snacks(limit: $snackLimit, offset: 0) {
+      id
+      name
+      description
+      fullName
+      slug
+      isDraft
+    }
+  }
+}
+    ${CommonAppDataFragmentDoc}`;
+
+/**
+ * __useHome_ProfileData2Query__
+ *
+ * To run a query within a React component, call `useHome_ProfileData2Query` and pass it any options that fit your needs.
+ * When your component renders, `useHome_ProfileData2Query` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useHome_ProfileData2Query({
+ *   variables: {
+ *      appLimit: // value for 'appLimit'
+ *      snackLimit: // value for 'snackLimit'
+ *   },
+ * });
+ */
+export function useHome_ProfileData2Query(baseOptions: Apollo.QueryHookOptions<Home_ProfileData2Query, Home_ProfileData2QueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<Home_ProfileData2Query, Home_ProfileData2QueryVariables>(Home_ProfileData2Document, options);
+      }
+export function useHome_ProfileData2LazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Home_ProfileData2Query, Home_ProfileData2QueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<Home_ProfileData2Query, Home_ProfileData2QueryVariables>(Home_ProfileData2Document, options);
+        }
+export type Home_ProfileData2QueryHookResult = ReturnType<typeof useHome_ProfileData2Query>;
+export type Home_ProfileData2LazyQueryHookResult = ReturnType<typeof useHome_ProfileData2LazyQuery>;
+export type Home_ProfileData2QueryResult = Apollo.QueryResult<Home_ProfileData2Query, Home_ProfileData2QueryVariables>;
+export function refetchHome_ProfileData2Query(variables: Home_ProfileData2QueryVariables) {
+      return { query: Home_ProfileData2Document, variables: variables }
+    }
+export const Home_MyAppsDocument = gql`
+    query Home_MyApps($limit: Int!, $offset: Int!) {
+  me {
+    id
+    appCount
+    apps(limit: $limit, offset: $offset, includeUnpublished: true) {
+      ...CommonAppData
+    }
+  }
+}
+    ${CommonAppDataFragmentDoc}`;
+
+/**
+ * __useHome_MyAppsQuery__
+ *
+ * To run a query within a React component, call `useHome_MyAppsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useHome_MyAppsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useHome_MyAppsQuery({
+ *   variables: {
+ *      limit: // value for 'limit'
+ *      offset: // value for 'offset'
+ *   },
+ * });
+ */
+export function useHome_MyAppsQuery(baseOptions: Apollo.QueryHookOptions<Home_MyAppsQuery, Home_MyAppsQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<Home_MyAppsQuery, Home_MyAppsQueryVariables>(Home_MyAppsDocument, options);
+      }
+export function useHome_MyAppsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Home_MyAppsQuery, Home_MyAppsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<Home_MyAppsQuery, Home_MyAppsQueryVariables>(Home_MyAppsDocument, options);
+        }
+export type Home_MyAppsQueryHookResult = ReturnType<typeof useHome_MyAppsQuery>;
+export type Home_MyAppsLazyQueryHookResult = ReturnType<typeof useHome_MyAppsLazyQuery>;
+export type Home_MyAppsQueryResult = Apollo.QueryResult<Home_MyAppsQuery, Home_MyAppsQueryVariables>;
+export function refetchHome_MyAppsQuery(variables: Home_MyAppsQueryVariables) {
+      return { query: Home_MyAppsDocument, variables: variables }
+    }
+export const Home_ProfileSnacksDocument = gql`
+    query Home_ProfileSnacks($limit: Int!, $offset: Int!) {
+  me {
+    id
+    snacks(limit: $limit, offset: $offset) {
+      id
+      name
+      description
+      fullName
+      slug
+      isDraft
+    }
+  }
+}
+    `;
+
+/**
+ * __useHome_ProfileSnacksQuery__
+ *
+ * To run a query within a React component, call `useHome_ProfileSnacksQuery` and pass it any options that fit your needs.
+ * When your component renders, `useHome_ProfileSnacksQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useHome_ProfileSnacksQuery({
+ *   variables: {
+ *      limit: // value for 'limit'
+ *      offset: // value for 'offset'
+ *   },
+ * });
+ */
+export function useHome_ProfileSnacksQuery(baseOptions: Apollo.QueryHookOptions<Home_ProfileSnacksQuery, Home_ProfileSnacksQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<Home_ProfileSnacksQuery, Home_ProfileSnacksQueryVariables>(Home_ProfileSnacksDocument, options);
+      }
+export function useHome_ProfileSnacksLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Home_ProfileSnacksQuery, Home_ProfileSnacksQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<Home_ProfileSnacksQuery, Home_ProfileSnacksQueryVariables>(Home_ProfileSnacksDocument, options);
+        }
+export type Home_ProfileSnacksQueryHookResult = ReturnType<typeof useHome_ProfileSnacksQuery>;
+export type Home_ProfileSnacksLazyQueryHookResult = ReturnType<typeof useHome_ProfileSnacksLazyQuery>;
+export type Home_ProfileSnacksQueryResult = Apollo.QueryResult<Home_ProfileSnacksQuery, Home_ProfileSnacksQueryVariables>;
+export function refetchHome_ProfileSnacksQuery(variables: Home_ProfileSnacksQueryVariables) {
+      return { query: Home_ProfileSnacksDocument, variables: variables }
+    }
+export const WebContainerProjectPage_QueryDocument = gql`
+    query WebContainerProjectPage_Query($appId: String!, $platform: AppPlatform!, $runtimeVersions: [String!]!) {
+  app {
+    byId(appId: $appId) {
+      id
+      name
+      slug
+      fullName
+      username
+      published
+      description
+      githubUrl
+      playStoreUrl
+      appStoreUrl
+      sdkVersion
+      iconUrl
+      privacy
+      icon {
+        url
+      }
+      latestReleaseForReleaseChannel(platform: $platform, releaseChannel: "default") {
+        sdkVersion
+        runtimeVersion
+      }
+      updateBranches(limit: 100, offset: 0) {
+        id
+        name
+        updates(
+          limit: 1
+          offset: 0
+          filter: {platform: $platform, runtimeVersions: $runtimeVersions}
+        ) {
+          id
+          group
+          message
+          createdAt
+          runtimeVersion
+          platform
+          manifestPermalink
+        }
+      }
+    }
+  }
+}
+    `;
+
+/**
+ * __useWebContainerProjectPage_Query__
+ *
+ * To run a query within a React component, call `useWebContainerProjectPage_Query` and pass it any options that fit your needs.
+ * When your component renders, `useWebContainerProjectPage_Query` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useWebContainerProjectPage_Query({
+ *   variables: {
+ *      appId: // value for 'appId'
+ *      platform: // value for 'platform'
+ *      runtimeVersions: // value for 'runtimeVersions'
+ *   },
+ * });
+ */
+export function useWebContainerProjectPage_Query(baseOptions: Apollo.QueryHookOptions<WebContainerProjectPage_Query, WebContainerProjectPage_QueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<WebContainerProjectPage_Query, WebContainerProjectPage_QueryVariables>(WebContainerProjectPage_QueryDocument, options);
+      }
+export function useWebContainerProjectPage_QueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<WebContainerProjectPage_Query, WebContainerProjectPage_QueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<WebContainerProjectPage_Query, WebContainerProjectPage_QueryVariables>(WebContainerProjectPage_QueryDocument, options);
+        }
+export type WebContainerProjectPage_QueryHookResult = ReturnType<typeof useWebContainerProjectPage_Query>;
+export type WebContainerProjectPage_QueryLazyQueryHookResult = ReturnType<typeof useWebContainerProjectPage_QueryLazyQuery>;
+export type WebContainerProjectPage_QueryQueryResult = Apollo.QueryResult<WebContainerProjectPage_Query, WebContainerProjectPage_QueryVariables>;
+export function refetchWebContainerProjectPage_Query(variables: WebContainerProjectPage_QueryVariables) {
+      return { query: WebContainerProjectPage_QueryDocument, variables: variables }
+    }
+export const Home_AccountAppsDocument = gql`
+    query Home_AccountApps($accountName: String!, $limit: Int!, $offset: Int!) {
+  account {
+    byName(accountName: $accountName) {
+      id
+      appCount
+      apps(limit: $limit, offset: $offset, includeUnpublished: true) {
+        ...CommonAppData
+      }
+    }
+  }
+}
+    ${CommonAppDataFragmentDoc}`;
+
+/**
+ * __useHome_AccountAppsQuery__
+ *
+ * To run a query within a React component, call `useHome_AccountAppsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useHome_AccountAppsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useHome_AccountAppsQuery({
+ *   variables: {
+ *      accountName: // value for 'accountName'
+ *      limit: // value for 'limit'
+ *      offset: // value for 'offset'
+ *   },
+ * });
+ */
+export function useHome_AccountAppsQuery(baseOptions: Apollo.QueryHookOptions<Home_AccountAppsQuery, Home_AccountAppsQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<Home_AccountAppsQuery, Home_AccountAppsQueryVariables>(Home_AccountAppsDocument, options);
+      }
+export function useHome_AccountAppsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Home_AccountAppsQuery, Home_AccountAppsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<Home_AccountAppsQuery, Home_AccountAppsQueryVariables>(Home_AccountAppsDocument, options);
+        }
+export type Home_AccountAppsQueryHookResult = ReturnType<typeof useHome_AccountAppsQuery>;
+export type Home_AccountAppsLazyQueryHookResult = ReturnType<typeof useHome_AccountAppsLazyQuery>;
+export type Home_AccountAppsQueryResult = Apollo.QueryResult<Home_AccountAppsQuery, Home_AccountAppsQueryVariables>;
+export function refetchHome_AccountAppsQuery(variables: Home_AccountAppsQueryVariables) {
+      return { query: Home_AccountAppsDocument, variables: variables }
+    }
+export const Home_AccountSnacksDocument = gql`
+    query Home_AccountSnacks($accountName: String!, $limit: Int!, $offset: Int!) {
+  account {
+    byName(accountName: $accountName) {
+      id
+      name
+      snacks(limit: $limit, offset: $offset) {
+        id
+        name
+        description
+        fullName
+        slug
+        isDraft
+      }
+    }
+  }
+}
+    `;
+
+/**
+ * __useHome_AccountSnacksQuery__
+ *
+ * To run a query within a React component, call `useHome_AccountSnacksQuery` and pass it any options that fit your needs.
+ * When your component renders, `useHome_AccountSnacksQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useHome_AccountSnacksQuery({
+ *   variables: {
+ *      accountName: // value for 'accountName'
+ *      limit: // value for 'limit'
+ *      offset: // value for 'offset'
+ *   },
+ * });
+ */
+export function useHome_AccountSnacksQuery(baseOptions: Apollo.QueryHookOptions<Home_AccountSnacksQuery, Home_AccountSnacksQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<Home_AccountSnacksQuery, Home_AccountSnacksQueryVariables>(Home_AccountSnacksDocument, options);
+      }
+export function useHome_AccountSnacksLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Home_AccountSnacksQuery, Home_AccountSnacksQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<Home_AccountSnacksQuery, Home_AccountSnacksQueryVariables>(Home_AccountSnacksDocument, options);
+        }
+export type Home_AccountSnacksQueryHookResult = ReturnType<typeof useHome_AccountSnacksQuery>;
+export type Home_AccountSnacksLazyQueryHookResult = ReturnType<typeof useHome_AccountSnacksLazyQuery>;
+export type Home_AccountSnacksQueryResult = Apollo.QueryResult<Home_AccountSnacksQuery, Home_AccountSnacksQueryVariables>;
+export function refetchHome_AccountSnacksQuery(variables: Home_AccountSnacksQueryVariables) {
+      return { query: Home_AccountSnacksDocument, variables: variables }
+    }
+export const Home_ViewerUsernameDocument = gql`
+    query Home_ViewerUsername {
+  me {
+    id
+    username
+  }
+}
+    `;
+
+/**
+ * __useHome_ViewerUsernameQuery__
+ *
+ * To run a query within a React component, call `useHome_ViewerUsernameQuery` and pass it any options that fit your needs.
+ * When your component renders, `useHome_ViewerUsernameQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useHome_ViewerUsernameQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useHome_ViewerUsernameQuery(baseOptions?: Apollo.QueryHookOptions<Home_ViewerUsernameQuery, Home_ViewerUsernameQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<Home_ViewerUsernameQuery, Home_ViewerUsernameQueryVariables>(Home_ViewerUsernameDocument, options);
+      }
+export function useHome_ViewerUsernameLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Home_ViewerUsernameQuery, Home_ViewerUsernameQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<Home_ViewerUsernameQuery, Home_ViewerUsernameQueryVariables>(Home_ViewerUsernameDocument, options);
+        }
+export type Home_ViewerUsernameQueryHookResult = ReturnType<typeof useHome_ViewerUsernameQuery>;
+export type Home_ViewerUsernameLazyQueryHookResult = ReturnType<typeof useHome_ViewerUsernameLazyQuery>;
+export type Home_ViewerUsernameQueryResult = Apollo.QueryResult<Home_ViewerUsernameQuery, Home_ViewerUsernameQueryVariables>;
+export function refetchHome_ViewerUsernameQuery(variables?: Home_ViewerUsernameQueryVariables) {
+      return { query: Home_ViewerUsernameDocument, variables: variables }
+    }

--- a/home/graphql/types.ts
+++ b/home/graphql/types.ts
@@ -3551,6 +3551,8 @@ export type DeleteApplePushKeyResult = {
 
 export type CommonAppDataFragment = { __typename?: 'App', id: string, fullName: string, name: string, iconUrl?: string | null | undefined, packageName: string, username: string, description: string, sdkVersion: string, privacy: string };
 
+export type CommonSnackDataFragment = { __typename?: 'Snack', id: string, name: string, description: string, fullName: string, slug: string, isDraft: boolean };
+
 export type Home_AccountDataQueryVariables = Exact<{
   accountName: Scalars['String'];
   appLimit: Scalars['Int'];
@@ -3629,6 +3631,16 @@ export const CommonAppDataFragmentDoc = gql`
   privacy
 }
     `;
+export const CommonSnackDataFragmentDoc = gql`
+    fragment CommonSnackData on Snack {
+  id
+  name
+  description
+  fullName
+  slug
+  isDraft
+}
+    `;
 export const Home_AccountDataDocument = gql`
     query Home_AccountData($accountName: String!, $appLimit: Int!, $snackLimit: Int!) {
   account {
@@ -3640,17 +3652,13 @@ export const Home_AccountDataDocument = gql`
         ...CommonAppData
       }
       snacks(limit: $snackLimit, offset: 0) {
-        id
-        name
-        description
-        fullName
-        slug
-        isDraft
+        ...CommonSnackData
       }
     }
   }
 }
-    ${CommonAppDataFragmentDoc}`;
+    ${CommonAppDataFragmentDoc}
+${CommonSnackDataFragmentDoc}`;
 
 /**
  * __useHome_AccountDataQuery__
@@ -3701,16 +3709,12 @@ export const Home_ProfileData2Document = gql`
       ...CommonAppData
     }
     snacks(limit: $snackLimit, offset: 0) {
-      id
-      name
-      description
-      fullName
-      slug
-      isDraft
+      ...CommonSnackData
     }
   }
 }
-    ${CommonAppDataFragmentDoc}`;
+    ${CommonAppDataFragmentDoc}
+${CommonSnackDataFragmentDoc}`;
 
 /**
  * __useHome_ProfileData2Query__
@@ -3791,16 +3795,11 @@ export const Home_ProfileSnacksDocument = gql`
   me {
     id
     snacks(limit: $limit, offset: $offset) {
-      id
-      name
-      description
-      fullName
-      slug
-      isDraft
+      ...CommonSnackData
     }
   }
 }
-    `;
+    ${CommonSnackDataFragmentDoc}`;
 
 /**
  * __useHome_ProfileSnacksQuery__
@@ -3964,17 +3963,12 @@ export const Home_AccountSnacksDocument = gql`
       id
       name
       snacks(limit: $limit, offset: $offset) {
-        id
-        name
-        description
-        fullName
-        slug
-        isDraft
+        ...CommonSnackData
       }
     }
   }
 }
-    `;
+    ${CommonSnackDataFragmentDoc}`;
 
 /**
  * __useHome_AccountSnacksQuery__

--- a/home/package.json
+++ b/home/package.json
@@ -71,10 +71,10 @@
     "url": "^0.11.0"
   },
   "devDependencies": {
-    "@graphql-codegen/cli": "^2.2.0",
-    "@graphql-codegen/typed-document-node": "^2.1.3",
-    "@graphql-codegen/typescript": "^2.2.1",
-    "@graphql-codegen/typescript-operations": "^2.1.3",
+    "@graphql-codegen/cli": "^2.2.2",
+    "@graphql-codegen/typescript": "^2.3.1",
+    "@graphql-codegen/typescript-operations": "^2.2.0",
+    "@graphql-codegen/typescript-react-apollo": "^3.2.1",
     "@types/dedent": "^0.7.0",
     "@types/jest": "^26.0.24",
     "@types/react-redux": "^7.1.16",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1889,13 +1889,13 @@
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.2.tgz#30aa825f11d438671d585bd44e7fd564535fc210"
   integrity sha512-82cpyJyKRoQoRi+14ibCeGPu0CwypgtBAdBhq1WfvagpCZNKqwXbKwXllYSMG91DhmG4jt9gN8eP6lGOtozuaw==
 
-"@graphql-codegen/cli@^2.2.0":
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/@graphql-codegen/cli/-/cli-2.2.1.tgz#0bfe7bc64c1d6aa84d679fb2139f5d76337459cc"
-  integrity sha512-pFb/41kUpUhC40O/ZgdhqsUaGO2NPYBxQNLNR5frRhIIpXkjk8Uj2BstUlAmK0Nz2bkSiC4k5Q6aGW7OBkxcaA==
+"@graphql-codegen/cli@^2.2.2":
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/cli/-/cli-2.2.2.tgz#f079af082ade06b7639b73a7fc12754c704dada7"
+  integrity sha512-QTijlvgmzBkSQ/7+VTxQbkcEoSfX/qpX2yg6xXQPISU71Q+6k2dGvYfRrjchwGu7/cNeSaYfgh8S/MhkmNg7Uw==
   dependencies:
-    "@graphql-codegen/core" "2.2.0"
-    "@graphql-codegen/plugin-helpers" "^2.2.0"
+    "@graphql-codegen/core" "2.3.0"
+    "@graphql-codegen/plugin-helpers" "^2.3.0"
     "@graphql-tools/apollo-engine-loader" "^7.0.5"
     "@graphql-tools/code-file-loader" "^7.0.6"
     "@graphql-tools/git-loader" "^7.0.5"
@@ -1935,66 +1935,76 @@
     yaml "^1.10.0"
     yargs "^17.0.0"
 
-"@graphql-codegen/core@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@graphql-codegen/core/-/core-2.2.0.tgz#218512dfd383ac8182c2cee7f9c336a597c633d4"
-  integrity sha512-xy0t0riVM6Lrv7wAL9vCvX+iJIQyEry/Up83JMtcSPhKWXbWOWGKQp2G0pJ1tZNvNdz4jO59/f8AiBsThwUEGg==
+"@graphql-codegen/core@2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/core/-/core-2.3.0.tgz#0903b315e90a1b7575b5684401c8d0c26256ff4f"
+  integrity sha512-dGBd5DEOB1hJ3Ddd6l+3U4cbDZ91e0BIJQGTyZPLRYyffqJP+Y7IEYm4lMaBNY9m6qVXeGq+fgCS2SXlXEzJoA==
   dependencies:
-    "@graphql-codegen/plugin-helpers" "^2.2.0"
+    "@graphql-codegen/plugin-helpers" "^2.3.0"
     "@graphql-tools/schema" "^8.1.2"
     "@graphql-tools/utils" "^8.1.1"
     tslib "~2.3.0"
 
-"@graphql-codegen/plugin-helpers@^2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@graphql-codegen/plugin-helpers/-/plugin-helpers-2.2.0.tgz#f74bbba009cd3685db33187880e980d609065420"
-  integrity sha512-7t3LFd6DHUWPh0f7qY7wde2r4KCsU8WDcTxQ0QuHuokTqZYnRk+UH3xNDUiyb+1LGTBUqIaKxLwQXh8EDyZK7A==
+"@graphql-codegen/plugin-helpers@^2.3.0":
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/plugin-helpers/-/plugin-helpers-2.3.1.tgz#b66c742d3209a85bc2f72f9e2eceb6b08fc81f85"
+  integrity sha512-rWH7igcjYqZ6rqNFTb4Wyp31863fRmmVpsRN8VHzBCltrepOO97jwTwB93aAw+T6Dm8aZto3QFfDIC79u8wA2Q==
   dependencies:
-    "@graphql-tools/utils" "^8.1.1"
+    "@graphql-tools/utils" "^8.5.2"
     change-case-all "1.0.14"
     common-tags "1.8.0"
     import-from "4.0.0"
     lodash "~4.17.0"
     tslib "~2.3.0"
 
-"@graphql-codegen/typed-document-node@^2.1.3":
-  version "2.1.6"
-  resolved "https://registry.yarnpkg.com/@graphql-codegen/typed-document-node/-/typed-document-node-2.1.6.tgz#8f3011ad972e4dabb64c84912e8f961294e107a5"
-  integrity sha512-NMFhAgZ9RneutscDr7xL6h3+ZWQP9hsalbBQ8OBe0mQRPaYmrbxOZIIJC8pAHdgiaR+lhdK2KXFmFSIuNeyPFQ==
+"@graphql-codegen/schema-ast@^2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/schema-ast/-/schema-ast-2.4.0.tgz#a41fdf2bacf88ec8318c78fdf03f19e620e5534a"
+  integrity sha512-xsLd4mF0H3mPp7Z2PHZ2Sv1KKIb/FOORqhDc9XHCnHJJ/h9nmaleKSTxTGzSUfIAQ1aCNzVilcaUwlenK+MMBQ==
   dependencies:
-    "@graphql-codegen/plugin-helpers" "^2.2.0"
-    "@graphql-codegen/visitor-plugin-common" "2.4.0"
+    "@graphql-codegen/plugin-helpers" "^2.3.0"
+    "@graphql-tools/utils" "^8.1.1"
+    tslib "~2.3.0"
+
+"@graphql-codegen/typescript-operations@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/typescript-operations/-/typescript-operations-2.2.0.tgz#73bf9261a9e28708952aa74c3a0c659fb8005483"
+  integrity sha512-AffhdHoJC2Wh95/LjOWF3vziZRurQ4JhAn3Odjd2AIBJsGx6TL41GYh9hX9GuBQYrBPjf4x+mXrmQ/vsFWH0ng==
+  dependencies:
+    "@graphql-codegen/plugin-helpers" "^2.3.0"
+    "@graphql-codegen/typescript" "^2.3.0"
+    "@graphql-codegen/visitor-plugin-common" "2.5.0"
+    auto-bind "~4.0.0"
+    tslib "~2.3.0"
+
+"@graphql-codegen/typescript-react-apollo@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/typescript-react-apollo/-/typescript-react-apollo-3.2.1.tgz#a11aad061d6251ab38a9c2be08968e73cfcae1eb"
+  integrity sha512-fA99uAGwPxLVd8ANbdSkZTnalmSX2ScNQY7rBTzxhnHQWlheYWj22QBpVwO3gbGwQKMpHPnmlAZS0js5C/f4lQ==
+  dependencies:
+    "@graphql-codegen/plugin-helpers" "^2.3.0"
+    "@graphql-codegen/visitor-plugin-common" "2.5.0"
     auto-bind "~4.0.0"
     change-case-all "1.0.14"
     tslib "~2.3.0"
 
-"@graphql-codegen/typescript-operations@^2.1.3":
-  version "2.1.8"
-  resolved "https://registry.yarnpkg.com/@graphql-codegen/typescript-operations/-/typescript-operations-2.1.8.tgz#07f0df130a5f04844188cea1b7f1a45ca28e68ad"
-  integrity sha512-doUN4Eaitzkuo2UVPOGfFvs8YuTJvHHTAd3q19KjaFKId1nNbfiDvrop1ZrHJpH+Sa6BcOvOPWHnCcMTSu6mww==
+"@graphql-codegen/typescript@^2.3.0", "@graphql-codegen/typescript@^2.3.1":
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/typescript/-/typescript-2.3.1.tgz#ad557cc28f20aa8a9ad9f153c3c8ac8b6e09075a"
+  integrity sha512-5wfuJhXnDVdufznLZG2/YlPMy5qGVYAEodBACVT8Dfgnt7T8eQOdaTfEPh04hqf/WR6DDoiLrJDcdyqWUO305w==
   dependencies:
-    "@graphql-codegen/plugin-helpers" "^2.2.0"
-    "@graphql-codegen/typescript" "^2.2.4"
-    "@graphql-codegen/visitor-plugin-common" "2.4.0"
+    "@graphql-codegen/plugin-helpers" "^2.3.0"
+    "@graphql-codegen/schema-ast" "^2.4.0"
+    "@graphql-codegen/visitor-plugin-common" "2.5.0"
     auto-bind "~4.0.0"
     tslib "~2.3.0"
 
-"@graphql-codegen/typescript@^2.2.1", "@graphql-codegen/typescript@^2.2.4":
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/@graphql-codegen/typescript/-/typescript-2.2.4.tgz#e7fef7e83f04e69e297ae7e4ed101803623db8ee"
-  integrity sha512-NTST7i1+Rot/t5hUJtnvIh1iqBlB9tyN2oD5XC1c2cMwz0cr7JaAgVYGfLO7XOQ5eG2IAw/D3umQ5JROa3cumw==
+"@graphql-codegen/visitor-plugin-common@2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-2.5.0.tgz#e412fade4ca3178a19e7ea122a4cb3463f2bf585"
+  integrity sha512-a1kJ/5YBivCj9X20YuhNU2mPY9xjUVmJO0VjHBu06PyvC27GsR1PmvgRALIXrb6QwV+9DDUda3ewKzgne2Qc+A==
   dependencies:
-    "@graphql-codegen/plugin-helpers" "^2.2.0"
-    "@graphql-codegen/visitor-plugin-common" "2.4.0"
-    auto-bind "~4.0.0"
-    tslib "~2.3.0"
-
-"@graphql-codegen/visitor-plugin-common@2.4.0":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-2.4.0.tgz#a00441f1bbadac660905c4bc01fc443433bd09b9"
-  integrity sha512-wcUqpbvhLlOwsriyI+ZTuE0Fx7AIIbcL80+KjgNGrMjLZJLTyMJGpYwc87I876EPIcyC35+LO15nwy2cR2tbxQ==
-  dependencies:
-    "@graphql-codegen/plugin-helpers" "^2.2.0"
+    "@graphql-codegen/plugin-helpers" "^2.3.0"
     "@graphql-tools/optimize" "^1.0.1"
     "@graphql-tools/relay-operation-optimizer" "^6.3.7"
     "@graphql-tools/utils" "^8.3.0"
@@ -2213,6 +2223,13 @@
   version "8.4.0"
   resolved "https://registry.yarnpkg.com/@graphql-tools/utils/-/utils-8.4.0.tgz#bcf104f4e882a4d96ce8a4bc651907b883b180f0"
   integrity sha512-rHp4aOdStGDj4xR4PbLm0cyasfTKQUcEKSAP6Ls/83/rmCGdZn9lMxJUSnyK2OfBzpS28kBmSTMaYQ+MeXUFlA==
+  dependencies:
+    tslib "~2.3.0"
+
+"@graphql-tools/utils@^8.5.2":
+  version "8.5.3"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/utils/-/utils-8.5.3.tgz#404062e62cae9453501197039687749c4885356e"
+  integrity sha512-HDNGWFVa8QQkoQB0H1lftvaO1X5xUaUDk1zr1qDe0xN1NL0E/CrQdJ5UKLqOvH4hkqVUPxQsyOoAZFkaH6rLHg==
   dependencies:
     tslib "~2.3.0"
 
@@ -18213,8 +18230,10 @@ watchpack@^1.6.1:
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.7.5.tgz#1267e6c55e0b9b5be44c2023aed5437a2c26c453"
   integrity sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==
   dependencies:
+    chokidar "^3.4.1"
     graceful-fs "^4.1.2"
     neo-async "^2.5.0"
+    watchpack-chokidar2 "^2.0.1"
   optionalDependencies:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.1"


### PR DESCRIPTION
# Why

This upgrades some packages related to graphql-codegen and uses the new generated hooks for queries in the app.

# How

Upgrade packages, upgrade codegen config, replace manual queries with hooks.

# Test Plan

Run home, see all the data loading works.