### PR TITLE
[sweet][ios] Handle enums in method arguments

### DIFF
--- a/packages/expo-haptics/CHANGELOG.md
+++ b/packages/expo-haptics/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### 💡 Others
 
 - Removed legacy Objective-C implementation and changed the pod name to `ExpoHaptics`. ([#15083](https://github.com/expo/expo/pull/15083) by [@tsapeta](https://github.com/tsapeta))
-- Simplified iOS implementation with enums as argument types.
+- Simplified iOS implementation with enums as argument types. ([#15129](https://github.com/expo/expo/pull/15129) by [@tsapeta](https://github.com/tsapeta))
 
 ## 11.0.1 — 2021-10-01
 

--- a/packages/expo-haptics/CHANGELOG.md
+++ b/packages/expo-haptics/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 💡 Others
 
 - Removed legacy Objective-C implementation and changed the pod name to `ExpoHaptics`. ([#15083](https://github.com/expo/expo/pull/15083) by [@tsapeta](https://github.com/tsapeta))
+- Simplified iOS implementation with enums as argument types.
 
 ## 11.0.1 — 2021-10-01
 

--- a/packages/expo-haptics/ios/HapticsModule.swift
+++ b/packages/expo-haptics/ios/HapticsModule.swift
@@ -4,26 +4,16 @@ public class HapticsModule: Module {
   public func definition() -> ModuleDefinition {
     name("ExpoHaptics")
 
-    method("notificationAsync") { (notificationType: String, promise: Promise) in
-      guard let feedbackType = NotificationType(rawValue: notificationType)?.toFeedbackType() else {
-        promise.reject("E_HAPTICS_INVALID_ARG", "Notification type must be one of: 'success', 'warning', 'error'. Obtained '\(notificationType)'")
-        return
-      }
+    method("notificationAsync") { (notificationType: NotificationType) in
       let generator = UINotificationFeedbackGenerator()
       generator.prepare()
-      generator.notificationOccurred(feedbackType)
-      promise.resolve()
+      generator.notificationOccurred(notificationType.toFeedbackType())
     }
 
-    method("impactAsync") { (style: String, promise: Promise) in
-      guard let feedbackStyle = ImpactStyle(rawValue: style)?.toFeedbackStyle() else {
-        promise.reject("E_HAPTICS_INVALID_ARG", "Impact style must be one of: 'light', 'medium', 'heavy'. Obtained '\(style)'")
-        return
-      }
-      let generator = UIImpactFeedbackGenerator(style: feedbackStyle)
+    method("impactAsync") { (style: ImpactStyle) in
+      let generator = UIImpactFeedbackGenerator(style: style.toFeedbackStyle())
       generator.prepare()
       generator.impactOccurred()
-      promise.resolve()
     }
 
     method("selectionAsync") {
@@ -33,7 +23,7 @@ public class HapticsModule: Module {
     }
   }
 
-  enum NotificationType: String {
+  enum NotificationType: String, EnumArgument {
     case success
     case warning
     case error
@@ -50,7 +40,7 @@ public class HapticsModule: Module {
     }
   }
 
-  enum ImpactStyle: String {
+  enum ImpactStyle: String, EnumArgument {
     case light
     case medium
     case heavy

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Introduce `ReactActivityHandler` and support `createReactRootView` hook. ([#14883](https://github.com/expo/expo/pull/14883) by [@kudo](https://github.com/kudo))
 - [Sweet API] Added support for array types in method arguments on iOS. ([#15042](https://github.com/expo/expo/pull/15042) by [@tsapeta](https://github.com/tsapeta))
 - [Sweet API] Added support for optional types in method arguments on iOS. ([#15068](https://github.com/expo/expo/pull/15068) by [@tsapeta](https://github.com/tsapeta))
-- [Sweet API] Added support for enums in method arguments on iOS.
+- [Sweet API] Added support for enums in method arguments on iOS. ([#15129](https://github.com/expo/expo/pull/15129) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Introduce `ReactActivityHandler` and support `createReactRootView` hook. ([#14883](https://github.com/expo/expo/pull/14883) by [@kudo](https://github.com/kudo))
 - [Sweet API] Added support for array types in method arguments on iOS. ([#15042](https://github.com/expo/expo/pull/15042) by [@tsapeta](https://github.com/tsapeta))
 - [Sweet API] Added support for optional types in method arguments on iOS. ([#15068](https://github.com/expo/expo/pull/15068) by [@tsapeta](https://github.com/tsapeta))
+- [Sweet API] Added support for enums in method arguments on iOS.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/ios/Swift/Arguments/ArgumentType.swift
+++ b/packages/expo-modules-core/ios/Swift/Arguments/ArgumentType.swift
@@ -14,6 +14,9 @@ internal func ArgumentType<T>(_ type: T.Type) -> AnyArgumentType {
   if let ConvertibleType = T.self as? ConvertibleArgument.Type {
     return ConvertibleArgumentType(innerType: ConvertibleType)
   }
+  if let EnumType = T.self as? EnumArgument.Type {
+    return EnumArgumentType(innerType: EnumType)
+  }
   if T.self is Promise.Type {
     return PromiseArgumentType()
   }

--- a/packages/expo-modules-core/ios/Swift/Arguments/Types/EnumArgumentType.swift
+++ b/packages/expo-modules-core/ios/Swift/Arguments/Types/EnumArgumentType.swift
@@ -1,0 +1,105 @@
+// Copyright 2021-present 650 Industries. All rights reserved.
+
+/**
+ An argument type representing an enum that conforms to `EnumArgument`.
+ */
+internal struct EnumArgumentType: AnyArgumentType {
+  let innerType: EnumArgument.Type
+
+  func cast<ArgType>(_ value: ArgType) throws -> Any {
+    return try innerType.create(fromRawValue: value)
+  }
+
+  var description: String {
+    "Enum<\(innerType)>"
+  }
+}
+
+/**
+ A protocol that allows converting raw values to enum cases.
+ */
+public protocol EnumArgument: AnyArgument {
+  /**
+   Tries to create an enum case using given raw value.
+   May throw errors, e.g. when the raw value doesn't match any case.
+   */
+  static func create<ArgType>(fromRawValue rawValue: ArgType) throws -> Self
+
+  /**
+   Returns an array of all raw values available in the enum.
+   */
+  static var allRawValues: [Any] { get }
+
+  /**
+   Type-erased enum's raw value.
+   */
+  var anyRawValue: Any { get }
+}
+
+/**
+ Extension for `EnumArgument` that also conforms to `RawRepresentable`.
+ This constraint allows us to reference the associated `RawValue` type.
+ */
+public extension EnumArgument where Self: RawRepresentable, Self: Hashable {
+  static func create<ArgType>(fromRawValue rawValue: ArgType) throws -> Self {
+    guard let rawValue = rawValue as? RawValue else {
+      throw EnumCastingError(type: RawValue.self, value: rawValue)
+    }
+    guard let enumCase = Self.init(rawValue: rawValue) else {
+      throw EnumNoSuchValueError(type: Self.self, value: rawValue)
+    }
+    return enumCase
+  }
+
+  var anyRawValue: Any {
+    rawValue
+  }
+
+  static var allRawValues: [Any] {
+    // Be careful — it operates on unsafe pointers!
+    let sequence = AnySequence { () -> AnyIterator<RawValue> in
+      var raw = 0
+      return AnyIterator {
+        let current: Self? = withUnsafePointer(to: &raw) { ptr in
+          ptr.withMemoryRebound(to: Self.self, capacity: 1) { $0.pointee }
+        }
+        guard let value = current?.rawValue else {
+          return nil
+        }
+        raw += 1
+        return value
+      }
+    }
+    return Array(sequence)
+  }
+}
+
+/**
+ An error that is thrown when the value cannot be casted to associated `RawValue`.
+ */
+internal struct EnumCastingError: CodedError {
+  let type: Any.Type
+  let value: Any
+
+  var description: String {
+    "Cannot cast value `\(value)` to expected type `\(type)`"
+  }
+}
+
+/**
+ An error that is thrown when the value doesn't match any available case.
+ */
+internal struct EnumNoSuchValueError: CodedError {
+  let type: EnumArgument.Type
+  let value: Any
+
+  var allRawValuesFormatted: String {
+    return type.allRawValues
+      .map { "`\($0)`" }
+      .joined(separator: ", ")
+  }
+
+  var description: String {
+    "Cannot create `\(type)` enum from value `\(value)`. It must be one of: \(allRawValuesFormatted)"
+  }
+}

--- a/packages/expo-modules-core/ios/Tests/ArgumentTypeSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/ArgumentTypeSpec.swift
@@ -73,6 +73,55 @@ class ArgumentTypeSpec: QuickSpec {
       expect(result).to(beAKindOf([[ConvertibleTestStruct]].self))
       expect((result as! [[ConvertibleTestStruct]]).first!.first!.value) == value.first!.first
     }
+
+    describe("EnumArgumentType") {
+      it("casts from String") {
+        let type = ArgumentType(StringTestEnum.self)
+        let input = "expo"
+        let output = try type.cast(input)
+
+        expect(output).to(beAKindOf(StringTestEnum.self))
+        expect(output as? StringTestEnum) == StringTestEnum.expo
+        expect(output as? StringTestEnum) == StringTestEnum(rawValue: input)
+        expect((output as! StringTestEnum).rawValue) == input
+        expect((output as! EnumArgument).anyRawValue).to(beAKindOf(String.self))
+      }
+
+      it("casts from Int") {
+        let type = ArgumentType(IntTestEnum.self)
+        let input: Int = -1
+        let output = try type.cast(input)
+
+        expect(output).to(beAKindOf(IntTestEnum.self))
+        expect(output as? IntTestEnum) == IntTestEnum.negative
+        expect(output as? IntTestEnum) == IntTestEnum(rawValue: input)
+        expect((output as! IntTestEnum).rawValue) == input
+        expect((output as! EnumArgument).anyRawValue).to(beAKindOf(Int.self))
+      }
+
+      it("throws casting error") {
+        let type = ArgumentType(IntTestEnum.self)
+
+        // "841" is not a raw value of any `IntTestEnum` case
+        expect { try type.cast("string instead of int") }.to(throwError {
+          expect($0).to(beAKindOf(EnumCastingError.self))
+        })
+      }
+
+      it("throws no such value error") {
+        let type = ArgumentType(IntTestEnum.self)
+
+        // "841" is not a raw value of any `IntTestEnum` case
+        expect { try type.cast(841) }.to(throwError {
+          expect($0).to(beAKindOf(EnumNoSuchValueError.self))
+        })
+      }
+
+      it("gets a list of all raw values") {
+        expect(StringTestEnum.allRawValues as? [String]) == ["hello", "expo"]
+        expect(IntTestEnum.allRawValues as? [Int]) == [-1, 1]
+      }
+    }
   }
 }
 
@@ -83,4 +132,14 @@ struct ConvertibleTestStruct: ConvertibleArgument {
     guard let str = value as? String else { fatalError() }
     return ConvertibleTestStruct(value: str)
   }
+}
+
+enum StringTestEnum: String, EnumArgument {
+  case hello
+  case expo
+}
+
+enum IntTestEnum: Int, EnumArgument {
+  case negative = -1
+  case positive = 1
 }


### PR DESCRIPTION
# Why

Followup #15042, #15068 and #15088 

# How

- Added another argument type, this time for enums.
- Added unit tests
- Updated `expo-haptics` implementation to use this feature

# Test Plan

- Unit tests are passing
- Tested haptics examples in NCL
