### PR TITLE
Update ImagePicker.types.ts

### DIFF
--- a/packages/expo-image-picker/src/ImagePicker.types.ts
+++ b/packages/expo-image-picker/src/ImagePicker.types.ts
@@ -60,6 +60,7 @@ export type ImageInfo = {
   type?: 'image' | 'video';
   exif?: { [key: string]: any };
   base64?: string;
+  duration?: number;
 };
 
 export type ImagePickerErrorResult = {


### PR DESCRIPTION
# Why
The documentation here https://docs.expo.dev/versions/v43.0.0/sdk/imagepicker/#returns-4 states that if the selected item is a video, the duration will be specified. However, it is missing from the types resulting in TS errors.

# How
Adds the TS type

# Test Plan
I tested locally using patch-package

# Checklist
- [n/a] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [n/a] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [n/a] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
