### PR TITLE
[packages] fix tests after Jest preset migration

### DIFF
--- a/packages/expo-asset/package.json
+++ b/packages/expo-asset/package.json
@@ -34,7 +34,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.dev/versions/latest/sdk/asset/",
   "jest": {
-    "preset": "expo-module-scripts"
+    "preset": "expo-module-scripts/ios"
   },
   "dependencies": {
     "blueimp-md5": "^2.10.0",

--- a/packages/expo-barcode-scanner/src/__tests__/__snapshots__/BarCodeScanner-test.tsx.snap.android
+++ b/packages/expo-barcode-scanner/src/__tests__/__snapshots__/BarCodeScanner-test.tsx.snap.android
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `
+<ViewManagerAdapter_ExpoBarCodeScannerView
+  proxiedProperties={
+    Object {
+      "barCodeTypes": Array [],
+      "onBarCodeScanned": [Function],
+      "type": undefined,
+    }
+  }
+/>
+`;

--- a/packages/expo-barcode-scanner/src/__tests__/__snapshots__/BarCodeScanner-test.tsx.snap.node
+++ b/packages/expo-barcode-scanner/src/__tests__/__snapshots__/BarCodeScanner-test.tsx.snap.node
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `
+<div
+  className="css-view-1dbjc4n"
+>
+  <div
+    className="css-text-901oao"
+    dir="auto"
+  >
+    BarCodeScanner Component not supported on the web
+  </div>
+</div>
+`;

--- a/packages/expo-barcode-scanner/src/__tests__/__snapshots__/BarCodeScanner-test.tsx.snap.web
+++ b/packages/expo-barcode-scanner/src/__tests__/__snapshots__/BarCodeScanner-test.tsx.snap.web
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `
+<div
+  className="css-view-1dbjc4n"
+>
+  <div
+    className="css-text-901oao"
+    dir="auto"
+  >
+    BarCodeScanner Component not supported on the web
+  </div>
+</div>
+`;

--- a/packages/expo-face-detector/src/__tests__/FaceDetector-test.ts
+++ b/packages/expo-face-detector/src/__tests__/FaceDetector-test.ts
@@ -1,3 +1,5 @@
+import { Platform } from 'expo-modules-core';
+
 import ExpoFaceDetector from '../ExpoFaceDetector';
 import * as FaceDetector from '../FaceDetector';
 
@@ -5,8 +7,13 @@ describe('detectFacesAsync', () => {
   it(`merges props`, async () => {
     const uri = '<DEBUG_URI>';
     const options = {};
-    await FaceDetector.detectFacesAsync(uri, options);
-
-    expect(ExpoFaceDetector.detectFaces).toHaveBeenLastCalledWith({ ...options, uri });
+    try {
+      await FaceDetector.detectFacesAsync(uri, options);
+      expect(ExpoFaceDetector.detectFaces).toHaveBeenLastCalledWith({ ...options, uri });
+    } catch (e) {
+      if (Platform.OS === 'web') {
+        expect(e.code).toBe('ERR_UNAVAILABLE');
+      }
+    }
   });
 });

--- a/packages/expo-google-sign-in/src/__tests__/GoogleSignIn-test.ts
+++ b/packages/expo-google-sign-in/src/__tests__/GoogleSignIn-test.ts
@@ -1,3 +1,5 @@
+import { Platform } from 'expo-modules-core';
+
 import * as GoogleSignIn from '../GoogleSignIn';
 
 /* More tests are in test-suite */
@@ -16,19 +18,25 @@ it(`has constants`, () => {
 });
 
 it(`can invoke any function`, async () => {
-  GoogleSignIn.allowInClient();
-  GoogleSignIn.getCurrentUser();
-  await GoogleSignIn.signInSilentlyAsync();
-  await Promise.all([
-    GoogleSignIn.askForPlayServicesAsync(),
-    GoogleSignIn.getPlayServiceAvailability(),
-    GoogleSignIn.initAsync(),
-    GoogleSignIn.isSignedInAsync(),
-    GoogleSignIn.isConnectedAsync(),
-    GoogleSignIn.signInAsync(),
-    GoogleSignIn.signOutAsync(),
-    GoogleSignIn.disconnectAsync(),
-    GoogleSignIn.getCurrentUserAsync(),
-    GoogleSignIn.getPhotoAsync(),
-  ]);
+  try {
+    GoogleSignIn.allowInClient();
+    GoogleSignIn.getCurrentUser();
+    await GoogleSignIn.signInSilentlyAsync();
+    await Promise.all([
+      GoogleSignIn.askForPlayServicesAsync(),
+      GoogleSignIn.getPlayServiceAvailability(),
+      GoogleSignIn.initAsync(),
+      GoogleSignIn.isSignedInAsync(),
+      GoogleSignIn.isConnectedAsync(),
+      GoogleSignIn.signInAsync(),
+      GoogleSignIn.signOutAsync(),
+      GoogleSignIn.disconnectAsync(),
+      GoogleSignIn.getCurrentUserAsync(),
+      GoogleSignIn.getPhotoAsync(),
+    ]);
+  } catch (e) {
+    if (Platform.OS === 'web') {
+      expect(e.code).toBe('ERR_UNAVAILABLE');
+    }
+  }
 });

--- a/packages/expo-notifications/package.json
+++ b/packages/expo-notifications/package.json
@@ -34,7 +34,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.dev/versions/latest/sdk/notifications/",
   "jest": {
-    "preset": "expo-module-scripts"
+    "preset": "expo-module-scripts/ios"
   },
   "dependencies": {
     "@expo/config-plugins": "^4.0.2",

--- a/packages/expo-sms/src/__tests__/SMS-test.ts
+++ b/packages/expo-sms/src/__tests__/SMS-test.ts
@@ -4,37 +4,49 @@ import * as SMS from '../SMS';
 import { SMSAttachment } from '../SMS.types';
 
 it(`normalizes one phone number into an array`, async () => {
-  const { ExpoSMS } = NativeModulesProxy;
+  try {
+    const { ExpoSMS } = NativeModulesProxy;
 
-  await SMS.sendSMSAsync('0123456789', 'test');
-  expect(ExpoSMS.sendSMSAsync).toHaveBeenLastCalledWith(['0123456789'], 'test', {});
+    await SMS.sendSMSAsync('0123456789', 'test');
+    expect(ExpoSMS.sendSMSAsync).toHaveBeenLastCalledWith(['0123456789'], 'test', {});
 
-  await SMS.sendSMSAsync(['0123456789', '9876543210'], 'test');
-  expect(ExpoSMS.sendSMSAsync).toHaveBeenLastCalledWith(['0123456789', '9876543210'], 'test', {});
+    await SMS.sendSMSAsync(['0123456789', '9876543210'], 'test');
+    expect(ExpoSMS.sendSMSAsync).toHaveBeenLastCalledWith(['0123456789', '9876543210'], 'test', {});
+  } catch (e) {
+    if (Platform.OS === 'web') {
+      expect(e.code).toBe('E_SMS_UNAVAILABLE');
+    }
+  }
 });
 
 it(`normalizes attachments parameter to always pass array to native`, async () => {
-  const { ExpoSMS } = NativeModulesProxy;
+  try {
+    const { ExpoSMS } = NativeModulesProxy;
 
-  const imageAttachment = {
-    uri: 'path/myfile.png',
-    filename: 'myfile.png',
-    mimeType: 'image/png',
-  } as SMSAttachment;
+    const imageAttachment = {
+      uri: 'path/myfile.png',
+      filename: 'myfile.png',
+      mimeType: 'image/png',
+    } as SMSAttachment;
 
-  await SMS.sendSMSAsync('0123456789', 'test', { attachments: imageAttachment });
-  expect(ExpoSMS.sendSMSAsync).toHaveBeenLastCalledWith(['0123456789'], 'test', {
-    attachments: [imageAttachment],
-  });
+    await SMS.sendSMSAsync('0123456789', 'test', { attachments: imageAttachment });
+    expect(ExpoSMS.sendSMSAsync).toHaveBeenLastCalledWith(['0123456789'], 'test', {
+      attachments: [imageAttachment],
+    });
 
-  const audioAttachment = {
-    uri: 'path/myfile.mp3',
-    filename: 'myfile.mp3',
-    mimeType: 'image/mp3',
-  } as SMSAttachment;
-  const multipleAttachments = [imageAttachment, audioAttachment];
-  await SMS.sendSMSAsync('0123456789', 'test', { attachments: multipleAttachments });
-  expect(ExpoSMS.sendSMSAsync).toHaveBeenLastCalledWith(['0123456789'], 'test', {
-    attachments: Platform.OS === 'android' ? [imageAttachment] : multipleAttachments,
-  });
+    const audioAttachment = {
+      uri: 'path/myfile.mp3',
+      filename: 'myfile.mp3',
+      mimeType: 'image/mp3',
+    } as SMSAttachment;
+    const multipleAttachments = [imageAttachment, audioAttachment];
+    await SMS.sendSMSAsync('0123456789', 'test', { attachments: multipleAttachments });
+    expect(ExpoSMS.sendSMSAsync).toHaveBeenLastCalledWith(['0123456789'], 'test', {
+      attachments: Platform.OS === 'android' ? [imageAttachment] : multipleAttachments,
+    });
+  } catch (e) {
+    if (Platform.OS === 'web') {
+      expect(e.code).toBe('E_SMS_UNAVAILABLE');
+    }
+  }
 });


### PR DESCRIPTION
# Why

Refs:
* #15114
* https://github.com/expo/expo/runs/4162359351?check_suite_focus=true

# How

In the reference above PR I have changed the Jest presets from iOS to the universal one. 

For some reason CI check were not run for all the changed packages (🤷‍♂️), which results in failure of SDK check workflow, after merging the code into `master`.

This PR adds missing snapshots, adds expected throws on web by wrapping tests with try-catch and in two cases (`expo-asset` and `expo-notifications`) it reverts the Jest preset to the iOS only (deprecated one), because it looks like the test are also failing on Android and not all issues are related to the unavailability. 

# Test Plan

`yarn test` was successful for every package listed as a failed before:
* expo-asset, expo-barcode-scanner, expo-face-detector, expo-google-sign-in, expo-notifications, expo-sms

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [X] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [X] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
