### PR TITLE
[sweet][kotlin] Implement sending events from native to JavaScript

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
@@ -3,6 +3,7 @@ package expo.modules.kotlin
 import com.facebook.react.bridge.LifecycleEventListener
 import com.facebook.react.bridge.ReactApplicationContext
 import expo.modules.core.interfaces.ActivityProvider
+import expo.modules.core.interfaces.services.EventEmitter
 import expo.modules.interfaces.barcodescanner.BarCodeScannerInterface
 import expo.modules.interfaces.camera.CameraViewInterface
 import expo.modules.interfaces.constants.ConstantsInterface
@@ -13,6 +14,8 @@ import expo.modules.interfaces.permissions.Permissions
 import expo.modules.interfaces.sensors.SensorServiceInterface
 import expo.modules.interfaces.taskManager.TaskManagerInterface
 import expo.modules.kotlin.events.EventName
+import expo.modules.kotlin.events.KEventEmitterWrapper
+import expo.modules.kotlin.modules.Module
 import java.lang.ref.WeakReference
 
 class AppContext(
@@ -104,6 +107,19 @@ class AppContext(
    */
   val reactContext: ReactApplicationContext?
     get() = reactContextHolder.get()
+
+  /**
+   * Provides access to the event emitter
+   */
+  fun eventEmitter(module: Module): EventEmitter? {
+    val legacyEventEmitter = legacyModule<EventEmitter>() ?: return null
+    return KEventEmitterWrapper(
+      requireNotNull(registry.getModuleHolder(module)) {
+        "Cannot create an event emitter for the module that isn't present in the current module registry."
+      },
+      legacyEventEmitter
+    )
+  }
 
   fun onDestroy() {
     reactContextHolder.get()?.removeLifecycleEventListener(this)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
@@ -115,7 +115,7 @@ class AppContext(
     val legacyEventEmitter = legacyModule<EventEmitter>() ?: return null
     return KEventEmitterWrapper(
       requireNotNull(registry.getModuleHolder(module)) {
-        "Cannot create an event emitter for the module that isn't present in the current module registry."
+        "Cannot create an event emitter for the module that isn't present in the module registry."
       },
       legacyEventEmitter
     )

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleRegistry.kt
@@ -29,22 +29,25 @@ class ModuleRegistry(
 
   fun getModuleHolder(name: String): ModuleHolder? = registry[name]
 
+  fun getModuleHolder(module: Module): ModuleHolder? =
+    registry.values.find { it.module === module }
+
   fun post(eventName: EventName) {
-    iterator().forEach {
+    forEach {
       it.post(eventName)
     }
   }
 
   @Suppress("UNCHECKED_CAST")
   fun <Sender> post(eventName: EventName, sender: Sender) {
-    iterator().forEach {
+    forEach {
       it.post(eventName, sender)
     }
   }
 
   @Suppress("UNCHECKED_CAST")
   fun <Sender, Payload> post(eventName: EventName, sender: Sender, payload: Payload) {
-    iterator().forEach {
+    forEach {
       it.post(eventName, sender, payload)
     }
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/events/EventsDefinition.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/events/EventsDefinition.kt
@@ -1,0 +1,3 @@
+package expo.modules.kotlin.events
+
+class EventsDefinition(val names: Array<out String>)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/events/KEventEmitterWrapper.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/events/KEventEmitterWrapper.kt
@@ -1,0 +1,26 @@
+package expo.modules.kotlin.events
+
+import android.os.Bundle
+import expo.modules.core.interfaces.services.EventEmitter
+import expo.modules.kotlin.ModuleHolder
+
+/**
+ * In Swift, we check if the event is supported. Otherwise, we can't send such event through the bridge.
+ * However, in Kotlin this is unnecessary, but to make our API consistent, we added similar check.
+ * But because of that, we had to create a wrapper for EventEmitter.
+ */
+class KEventEmitterWrapper(
+  private val moduleHolder: ModuleHolder,
+  private val legacyEventEmitter: EventEmitter
+) : EventEmitter by legacyEventEmitter {
+  override fun emit(eventName: String, eventBody: Bundle?) {
+    require(
+      moduleHolder
+        .definition
+        .eventsDefinition
+        ?.names
+        ?.contains(eventName) == true
+    ) { "Unsupported event: $eventName." }
+    legacyEventEmitter.emit(eventName, eventBody)
+  }
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/Module.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/Module.kt
@@ -1,12 +1,19 @@
 package expo.modules.kotlin.modules
 
+import android.os.Bundle
 import expo.modules.kotlin.AppContext
 
 abstract class Module {
   internal var _appContext: AppContext? = null
 
+  private val moduleEventEmitter by lazy { appContext.eventEmitter(this) }
+
   val appContext: AppContext
     get() = requireNotNull(_appContext) { "The module wasn't created! You can't access the app context." }
+
+  fun sendEvent(name: String, body: Bundle?) {
+    moduleEventEmitter?.emit(name, body)
+  }
 
   abstract fun definition(): ModuleDefinition
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinition.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinition.kt
@@ -2,6 +2,7 @@ package expo.modules.kotlin.modules
 
 import expo.modules.kotlin.events.EventListener
 import expo.modules.kotlin.events.EventName
+import expo.modules.kotlin.events.EventsDefinition
 import expo.modules.kotlin.methods.AnyMethod
 import expo.modules.kotlin.views.ViewManagerDefinition
 
@@ -10,5 +11,6 @@ class ModuleDefinition(
   val constantsProvider: () -> Map<String, Any?>,
   val methods: Map<String, AnyMethod>,
   val viewManagerDefinition: ViewManagerDefinition? = null,
-  val eventListeners: Map<EventName, EventListener> = emptyMap()
+  val eventListeners: Map<EventName, EventListener> = emptyMap(),
+  val eventsDefinition: EventsDefinition? = null
 )

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinitionBuilder.kt
@@ -17,6 +17,7 @@ import expo.modules.kotlin.events.BasicEventListener
 import expo.modules.kotlin.events.EventListener
 import expo.modules.kotlin.events.EventName
 import expo.modules.kotlin.Promise
+import expo.modules.kotlin.events.EventsDefinition
 import expo.modules.kotlin.methods.AnyMethod
 import expo.modules.kotlin.methods.Method
 import expo.modules.kotlin.methods.PromiseMethod
@@ -27,6 +28,7 @@ import kotlin.reflect.typeOf
 class ModuleDefinitionBuilder {
   private var name: String? = null
   private var constantsProvider = { emptyMap<String, Any?>() }
+  private var eventsDefinition: EventsDefinition? = null
 
   @PublishedApi
   internal var methods = mutableMapOf<String, AnyMethod>()
@@ -43,7 +45,8 @@ class ModuleDefinitionBuilder {
       constantsProvider,
       methods,
       viewManagerDefinition,
-      eventListeners
+      eventListeners,
+      eventsDefinition
     )
   }
 
@@ -128,5 +131,26 @@ class ModuleDefinitionBuilder {
 
   inline fun onActivityDestroys(crossinline body: () -> Unit) {
     eventListeners[EventName.ACTIVITY_DESTROYS] = BasicEventListener(EventName.ACTIVITY_DESTROYS) { body() }
+  }
+
+  /**
+   * Defines event names that this module can send to JavaScript.
+   */
+  fun events(vararg events: String) {
+    eventsDefinition = EventsDefinition(events)
+  }
+
+  /**
+   * Method that is invoked when the first event listener is added.
+   */
+  inline fun onStartObserving(crossinline body: () -> Unit) {
+    method("startObserving", body)
+  }
+
+  /**
+   * Method that is invoked when all event listeners are removed.
+   */
+  inline fun onStopObserving(crossinline body: () -> Unit) {
+    method("stopObserving", body)
   }
 }

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/ModuleRegistryTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/ModuleRegistryTest.kt
@@ -61,4 +61,21 @@ class ModuleRegistryTest {
     } catch (e: Exception) {
     }
   }
+
+  @Test
+  fun `should return holder for module`() {
+    val provider = object : ModulesProvider {
+      override fun getModulesList(): List<Class<out Module>> {
+        return listOf(M1::class.java)
+      }
+    }
+
+    val moduleRegistry = ModuleRegistry(WeakReference(mockk()))
+    moduleRegistry.register(provider)
+    val m1 = moduleRegistry.getModule("m1")!!
+    val holder = moduleRegistry.getModuleHolder(m1)
+
+    Truth.assertThat(holder).isNotNull()
+    Truth.assertThat(holder).isSameInstanceAs(moduleRegistry.getModuleHolder("m1"))
+  }
 }

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/modules/ModuleDefinitionBuilderTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/modules/ModuleDefinitionBuilderTest.kt
@@ -82,7 +82,7 @@ class ModuleDefinitionBuilderTest {
   fun `onStartObserving should be translate into method`() {
     val moduleDefinition = module {
       name("module")
-      onStartObserving {  }
+      onStartObserving { }
     }
 
     Truth.assertThat(moduleDefinition.methods).containsKey("startObserving")
@@ -92,7 +92,7 @@ class ModuleDefinitionBuilderTest {
   fun `onStopObserving should be translate into method`() {
     val moduleDefinition = module {
       name("module")
-      onStopObserving {  }
+      onStopObserving { }
     }
 
     Truth.assertThat(moduleDefinition.methods).containsKey("stopObserving")

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/modules/ModuleDefinitionBuilderTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/modules/ModuleDefinitionBuilderTest.kt
@@ -79,7 +79,7 @@ class ModuleDefinitionBuilderTest {
   }
 
   @Test
-  fun `onStartObserving should be translate into method`() {
+  fun `onStartObserving should be translated into method`() {
     val moduleDefinition = module {
       name("module")
       onStartObserving { }
@@ -89,7 +89,7 @@ class ModuleDefinitionBuilderTest {
   }
 
   @Test
-  fun `onStopObserving should be translate into method`() {
+  fun `onStopObserving should be translated into method`() {
     val moduleDefinition = module {
       name("module")
       onStopObserving { }

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/modules/ModuleDefinitionBuilderTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/modules/ModuleDefinitionBuilderTest.kt
@@ -77,4 +77,24 @@ class ModuleDefinitionBuilderTest {
     Truth.assertThat(moduleDefinition.eventListeners[EventName.ACTIVITY_ENTERS_BACKGROUND]).isNotNull()
     Truth.assertThat(moduleDefinition.eventListeners[EventName.ACTIVITY_DESTROYS]).isNotNull()
   }
+
+  @Test
+  fun `onStartObserving should be translate into method`() {
+    val moduleDefinition = module {
+      name("module")
+      onStartObserving {  }
+    }
+
+    Truth.assertThat(moduleDefinition.methods).containsKey("startObserving")
+  }
+
+  @Test
+  fun `onStopObserving should be translate into method`() {
+    val moduleDefinition = module {
+      name("module")
+      onStopObserving {  }
+    }
+
+    Truth.assertThat(moduleDefinition.methods).containsKey("stopObserving")
+  }
 }


### PR DESCRIPTION
# Why

Added a way of sending events from native to JS. 

# How

Added new DSL components:

- events — takes a list of event names supported by the module.
- onStartObserving — called when JS starts listening to module's events
- onStopObserving — called when JS removes the last listener from the module

> Note
The events function isn't needed. In Java, we don't have to provide a list of events that can be sent through the bridge. 
However, to make the API consistent, I added similar checks known from iOS.

# Test Plan

- bare-expo ✅
