### PR TITLE
[sweet-api][kotlin] Add support for activity methods

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
@@ -1,6 +1,8 @@
 package expo.modules.kotlin
 
+import android.app.Activity
 import android.content.Context
+import android.content.Intent
 import com.facebook.react.bridge.ReactApplicationContext
 import expo.modules.core.interfaces.ActivityProvider
 import expo.modules.core.interfaces.services.EventEmitter
@@ -15,6 +17,7 @@ import expo.modules.interfaces.sensors.SensorServiceInterface
 import expo.modules.interfaces.taskManager.TaskManagerInterface
 import expo.modules.kotlin.events.EventName
 import expo.modules.kotlin.events.KEventEmitterWrapper
+import expo.modules.kotlin.events.OnActivityResultPayload
 import expo.modules.kotlin.modules.Module
 import java.lang.ref.WeakReference
 
@@ -29,7 +32,10 @@ class AppContext(
   init {
     requireNotNull(reactContextHolder.get()) {
       "The app context should be created with valid react context."
-    }.addLifecycleEventListener(reactLifecycleDelegate)
+    }.apply {
+      addLifecycleEventListener(reactLifecycleDelegate)
+      addActivityEventListener(reactLifecycleDelegate)
+    }
   }
 
   /**
@@ -137,5 +143,24 @@ class AppContext(
 
   fun onHostDestroy() {
     registry.post(EventName.ACTIVITY_DESTROYS)
+  }
+
+  fun onActivityResult(activity: Activity, requestCode: Int, resultCode: Int, data: Intent?) {
+    registry.post(
+      EventName.ON_ACTIVITY_RESULT,
+      activity,
+      OnActivityResultPayload(
+        requestCode,
+        resultCode,
+        data
+      )
+    )
+  }
+
+  fun onNewIntent(intent: Intent?) {
+    registry.post(
+      EventName.ON_NEW_INTENT,
+      intent
+    )
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleHolder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleHolder.kt
@@ -3,7 +3,7 @@ package expo.modules.kotlin
 import com.facebook.react.bridge.ReadableArray
 import expo.modules.core.utilities.ifNull
 import expo.modules.kotlin.events.BasicEventListener
-import expo.modules.kotlin.events.EventListenerWithSender
+import expo.modules.kotlin.events.EventListenerWithPayload
 import expo.modules.kotlin.events.EventListenerWithSenderAndPayload
 import expo.modules.kotlin.events.EventName
 import expo.modules.kotlin.exception.MethodNotFoundException
@@ -28,9 +28,9 @@ class ModuleHolder(val module: Module) {
   }
 
   @Suppress("UNCHECKED_CAST")
-  fun <Sender> post(eventName: EventName, sender: Sender) {
+  fun <Payload> post(eventName: EventName, payload: Payload) {
     val listener = definition.eventListeners[eventName] ?: return
-    (listener as? EventListenerWithSender<Sender>)?.call(sender)
+    (listener as? EventListenerWithPayload<Payload>)?.call(payload)
   }
 
   @Suppress("UNCHECKED_CAST")

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ReactLifecycleDelegate.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ReactLifecycleDelegate.kt
@@ -1,5 +1,8 @@
 package expo.modules.kotlin
 
+import android.app.Activity
+import android.content.Intent
+import com.facebook.react.bridge.ActivityEventListener
 import com.facebook.react.bridge.LifecycleEventListener
 import java.lang.ref.WeakReference
 
@@ -11,7 +14,7 @@ import java.lang.ref.WeakReference
  * which is a supertype of 'expo.modules.kotlin.AppContext'.
  * Check your module classpath for missing or conflicting dependencies
  */
-class ReactLifecycleDelegate(appContext: AppContext) : LifecycleEventListener {
+class ReactLifecycleDelegate(appContext: AppContext) : LifecycleEventListener, ActivityEventListener {
   private val appContextHolder = WeakReference(appContext)
 
   override fun onHostResume() {
@@ -24,5 +27,13 @@ class ReactLifecycleDelegate(appContext: AppContext) : LifecycleEventListener {
 
   override fun onHostDestroy() {
     appContextHolder.get()?.onHostDestroy()
+  }
+
+  override fun onActivityResult(activity: Activity, requestCode: Int, resultCode: Int, data: Intent?) {
+    appContextHolder.get()?.onActivityResult(activity, requestCode, resultCode, data)
+  }
+
+  override fun onNewIntent(intent: Intent?) {
+    appContextHolder.get()?.onNewIntent(intent)
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/events/EventListener.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/events/EventListener.kt
@@ -1,5 +1,7 @@
 package expo.modules.kotlin.events
 
+import android.app.Activity
+
 sealed class EventListener(val eventName: EventName)
 
 /**
@@ -15,13 +17,13 @@ class BasicEventListener(
 }
 
 /**
- * Listener for events without payload.
+ * Listener for events with payload.
  */
-class EventListenerWithSender<Sender>(
+class EventListenerWithPayload<Payload>(
   eventName: EventName,
-  val body: (Sender) -> Unit
+  val body: (Payload) -> Unit
 ) : EventListener(eventName) {
-  fun call(sender: Sender) {
+  fun call(sender: Payload) {
     body(sender)
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/events/EventListener.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/events/EventListener.kt
@@ -1,7 +1,5 @@
 package expo.modules.kotlin.events
 
-import android.app.Activity
-
 sealed class EventListener(val eventName: EventName)
 
 /**

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/events/EventName.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/events/EventName.kt
@@ -17,5 +17,15 @@ enum class EventName {
   /**
    * Called when host activity receives destroy event (e.g. Activity.onDestroy)
    */
-  ACTIVITY_DESTROYS
+  ACTIVITY_DESTROYS,
+
+  /**
+   * Called when a new intent is passed to the activity
+   */
+  ON_NEW_INTENT,
+
+  /**
+   * Called when other activity returns
+   */
+  ON_ACTIVITY_RESULT
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/events/OnActivityResultPayload.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/events/OnActivityResultPayload.kt
@@ -1,0 +1,8 @@
+package expo.modules.kotlin.events
+
+import android.content.Intent
+
+/**
+ * Payload for the `onActivityResult` event.
+ */
+data class OnActivityResultPayload(val requestCode: Int, val resultCode: Int, val data: Intent?)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinitionBuilder.kt
@@ -13,11 +13,16 @@
 
 package expo.modules.kotlin.modules
 
+import android.app.Activity
+import android.content.Intent
 import expo.modules.kotlin.Promise
 import expo.modules.kotlin.events.BasicEventListener
 import expo.modules.kotlin.events.EventListener
+import expo.modules.kotlin.events.EventListenerWithPayload
+import expo.modules.kotlin.events.EventListenerWithSenderAndPayload
 import expo.modules.kotlin.events.EventName
 import expo.modules.kotlin.events.EventsDefinition
+import expo.modules.kotlin.events.OnActivityResultPayload
 import expo.modules.kotlin.methods.AnyMethod
 import expo.modules.kotlin.methods.Method
 import expo.modules.kotlin.methods.PromiseMethod
@@ -142,5 +147,14 @@ class ModuleDefinitionBuilder {
    */
   inline fun onStopObserving(crossinline body: () -> Unit) {
     method("stopObserving", body)
+  }
+
+  inline fun onNewIntent(crossinline body: (Intent) -> Unit) {
+    eventListeners[EventName.ON_NEW_INTENT] = EventListenerWithPayload<Intent>(EventName.ON_NEW_INTENT) { body(it) }
+  }
+
+  inline fun onActivityResult(crossinline body: (Activity, OnActivityResultPayload) -> Unit) {
+    eventListeners[EventName.ON_ACTIVITY_RESULT] =
+      EventListenerWithSenderAndPayload<Activity, OnActivityResultPayload>(EventName.ON_ACTIVITY_RESULT) { sender, payload -> body(sender, payload) }
   }
 }


### PR DESCRIPTION
# Why

Adds support for activity methods like `onActivityResult` and `onNewIntent`.

# How

Extended DLs: 
- `onActivityResutl`
- `onNewIntent`

# Test Plan

- bare-expo ✅