### PR TITLE
Add missing getReactPackageTurboModuleManagerDelegateBuilder in ReactNativeHostWrapper

### DIFF
--- a/packages/expo/android/src/main/java/expo/modules/ReactNativeHostWrapper.kt
+++ b/packages/expo/android/src/main/java/expo/modules/ReactNativeHostWrapper.kt
@@ -5,6 +5,7 @@ import androidx.collection.ArrayMap
 import com.facebook.react.ReactInstanceManager
 import com.facebook.react.ReactNativeHost
 import com.facebook.react.ReactPackage
+import com.facebook.react.ReactPackageTurboModuleManagerDelegate
 import com.facebook.react.bridge.JSIModule
 import com.facebook.react.bridge.JSIModulePackage
 import com.facebook.react.bridge.JSIModuleSpec
@@ -79,6 +80,10 @@ class ReactNativeHostWrapper(
 
   override fun getPackages(): MutableList<ReactPackage> {
     return invokeDelegateMethod("getPackages")
+  }
+
+  override fun getReactPackageTurboModuleManagerDelegateBuilder(): ReactPackageTurboModuleManagerDelegate.Builder? {
+    return invokeDelegateMethod("getReactPackageTurboModuleManagerDelegateBuilder")
   }
 
   //endregion


### PR DESCRIPTION
# Why

This method also need to be forwarded and is required when using turbomodules.

# How

Add missing method using the same technique as the other ones.

# Test Plan

Tested locally in an app that turbomodules work and the delegate is properly passed to the rnhost.

# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
