### PR TITLE
[sweet][cellular] Use new API on Android

### DIFF
--- a/packages/expo-cellular/android/build.gradle
+++ b/packages/expo-cellular/android/build.gradle
@@ -52,6 +52,10 @@ android {
     sourceCompatibility JavaVersion.VERSION_1_8
     targetCompatibility JavaVersion.VERSION_1_8
   }
+  
+  kotlinOptions {
+    jvmTarget = JavaVersion.VERSION_1_8
+  }
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)

--- a/packages/expo-cellular/android/src/main/java/expo/modules/cellular/CellularModule.kt
+++ b/packages/expo-cellular/android/src/main/java/expo/modules/cellular/CellularModule.kt
@@ -16,7 +16,7 @@ class CellularModule : Module() {
     name(moduleName)
     constants {
       val telephonyManager = telephonyManager()
-      mutableMapOf(
+      mapOf(
         "allowsVoip" to SipManager.isVoipSupported(context),
         "isoCountryCode" to telephonyManager?.simCountryIso,
         "carrier" to telephonyManager?.simOperatorName,
@@ -25,7 +25,7 @@ class CellularModule : Module() {
       )
     }
 
-    method("getCellularGenerationAsync") { ->
+    method("getCellularGenerationAsync") {
       try {
         getCurrentGeneration()
       } catch (e: SecurityException) {
@@ -34,23 +34,23 @@ class CellularModule : Module() {
       }
     }
 
-    method("allowsVoipAsync") { ->
+    method("allowsVoipAsync") {
       SipManager.isVoipSupported(context)
     }
 
-    method("getIsoCountryCodeAsync") { ->
+    method("getIsoCountryCodeAsync") {
       telephonyManager()?.simCountryIso
     }
 
-    method("getCarrierNameAsync") { ->
+    method("getCarrierNameAsync") {
       telephonyManager()?.simOperatorName
     }
 
-    method("getMobileCountryCodeAsync") { ->
+    method("getMobileCountryCodeAsync") {
       telephonyManager()?.simOperator?.substring(0, 3)
     }
 
-    method("getMobileNetworkCodeAsync") { ->
+    method("getMobileNetworkCodeAsync") {
       telephonyManager()?.simOperator?.substring(3)
     }
   }

--- a/packages/expo-cellular/android/src/main/java/expo/modules/cellular/CellularPackage.kt
+++ b/packages/expo-cellular/android/src/main/java/expo/modules/cellular/CellularPackage.kt
@@ -1,9 +1,0 @@
-package expo.modules.cellular
-
-import android.content.Context
-import expo.modules.core.BasePackage
-
-class CellularPackage : BasePackage() {
-  override fun createExportedModules(context: Context) =
-    listOf(CellularModule(context))
-}

--- a/packages/expo-cellular/expo-module.config.json
+++ b/packages/expo-cellular/expo-module.config.json
@@ -3,5 +3,8 @@
   "platforms": ["ios", "android", "web"],
   "ios": {
     "modulesClassNames": ["CellularModule"]
+  },
+  "android": {
+    "modulesClassNames": ["expo.modules.cellular.CellularModule"]
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ReactLifecycleDelegate.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ReactLifecycleDelegate.kt
@@ -1,0 +1,28 @@
+package expo.modules.kotlin
+
+import com.facebook.react.bridge.LifecycleEventListener
+import java.lang.ref.WeakReference
+
+/**
+ * We had to extract this from AppContext, because otherwise, we can't access AppContext
+ * in a package that doesn't depend on the React Native directly.
+ * Due to:
+ * Cannot access 'com.facebook.react.bridge.LifecycleEventListener'
+ * which is a supertype of 'expo.modules.kotlin.AppContext'.
+ * Check your module classpath for missing or conflicting dependencies
+ */
+class ReactLifecycleDelegate(appContext: AppContext) : LifecycleEventListener {
+  private val appContextHolder = WeakReference(appContext)
+
+  override fun onHostResume() {
+    appContextHolder.get()?.onHostResume()
+  }
+
+  override fun onHostPause() {
+    appContextHolder.get()?.onHostPause()
+  }
+
+  override fun onHostDestroy() {
+    appContextHolder.get()?.onHostDestroy()
+  }
+}


### PR DESCRIPTION
# Why

Uses the new API on Android to rewrite the `expo-cellular` module.

# How

- Used DSL methods instead of `ExpoMethod` annotation.
- Had to extract LifecycleLisntere from AppDelegate to a separate class. More info in a code. 

# Test Plan

- bare-expo - NCL ✅
