### PR TITLE
[docs] ios submissions with latest ASC API Key directions

### DIFF
--- a/docs/pages/submit/ios.md
+++ b/docs/pages/submit/ios.md
@@ -68,7 +68,7 @@ You must do the following:
 You'll also need to configure your submission credentials **one** of the following ways:
 
 - Set up your App Store Connect API Key with EAS Servers. You can check the state of your credentials by running `eas credentials` or by running `eas submit -p ios` interactively.
-- Pass in your App Store Connect Api Key with the `ascApiKeyPath`, `ascApiKeyIssuerId`, and `ascApiKeyId` fields set in **eas.json**.
+- Pass in your App Store Connect API Key with the `ascApiKeyPath`, `ascApiKeyIssuerId`, and `ascApiKeyId` fields set in **eas.json**.
 - Set the `EXPO_APPLE_APP_SPECIFIC_PASSWORD` environment variable along with your Apple ID Username (`appleId` in **eas.json**).
 
 Example usage:

--- a/docs/pages/submit/ios.md
+++ b/docs/pages/submit/ios.md
@@ -37,11 +37,15 @@ The command will perform the following steps:
 
   > If you already have an App Store Connect app, this step can be skipped by providing the `ascAppId` in the submit profile. The [ASC App ID](https://expo.fyi/asc-app-id) can be found either on App Store Connect, or later during this command in the _Submission Summary_ table.
 
-- Ensure you have the proper credentials set up. If none can be found, you can:
+- Ensure you have the proper credentials set up. If none can be found, you can let EAS CLI set some up for you.
+  <details><summary><h4>🔐 Do you want to use your own credentials?</h4></summary>
+  <p>
 
-  - Let EAS CLI set one up for you.
-  - Upload your own [App Store Connect API Key](https://expo.fyi/creating-asc-api-key). Alternatively, you can set it with the `ascApiKeyPath`, `ascApiKeyIssuerId`, and `ascApiKeyId` fields in **eas.json**.
-  - Provide your [Apple app-specific password](https://expo.fyi/apple-app-specific-password) and Apple ID Username. Pass them in with the `EXPO_APPLE_APP_SPECIFIC_PASSWORD` environment variable and `--apple-id` parameter, respectively.
+  **App Store Connect API Key:** Create your own [API Key](https://expo.fyi/creating-asc-api-key) then set it with the `ascApiKeyPath`, `ascApiKeyIssuerId`, and `ascApiKeyId` fields in **eas.json**.
+
+  **App Specific Password:** Provide your [password](https://expo.fyi/apple-app-specific-password) and Apple ID Username by passing them in with the `EXPO_APPLE_APP_SPECIFIC_PASSWORD` environment variable and `appleId` field in **eas.json**, respectively.
+  </p>
+  </details>
 
 - Ask for which binary to submit. You can select one of the following:
 
@@ -64,17 +68,20 @@ You must do the following:
 - Provide the archive source (`--latest`, `--id`, `--path`, or `--url`).
 - Make sure that the iOS Bundle Identifier is present in your [app config file](/workflow/configuration.md).
 - Set the ASC App ID (`ascAppId` in **eas.json**). The ASC App ID is required to skip the Apple developer log-in process, which will likely not be possible on CI due to the 2FA prompt.
-
-You'll also need to configure your submission credentials **one** of the following ways:
-
 - Set up your App Store Connect API Key with EAS Servers. You can check the state of your credentials by running `eas credentials` or by running `eas submit -p ios` interactively.
-- Pass in your App Store Connect API Key with the `ascApiKeyPath`, `ascApiKeyIssuerId`, and `ascApiKeyId` fields set in **eas.json**.
-- Set the `EXPO_APPLE_APP_SPECIFIC_PASSWORD` environment variable along with your Apple ID Username (`appleId` in **eas.json**).
+  <details><summary><h4>🔐 Do you want to use your own credentials?</h4></summary>
+  <p>
+
+  **App Store Connect API Key:** Create your own [API Key](https://expo.fyi/creating-asc-api-key) then set it with the `ascApiKeyPath`, `ascApiKeyIssuerId`, and `ascApiKeyId` fields in **eas.json**.
+
+  **App Specific Password:** Provide your [password](https://expo.fyi/apple-app-specific-password) and Apple ID Username by passing them in with the `EXPO_APPLE_APP_SPECIFIC_PASSWORD` environment variable and `appleId` field in **eas.json**, respectively.
+  </p>
+  </details>
 
 Example usage:
 
 ```sh
-EXPO_APPLE_APP_SPECIFIC_PASSWORD=xxxxx eas submit -p ios --latest --profile foobar
+eas submit -p ios --latest --profile foobar
 ```
 
 ## Automating submissions

--- a/docs/pages/submit/ios.md
+++ b/docs/pages/submit/ios.md
@@ -20,7 +20,7 @@ To submit the binary to the App Store, run `eas submit -p ios` from inside your 
 
 > Although it's possible to upload any binary to the store, each submission is associated with an Expo project. That's why it's important to start a submission from inside your project's directory - that's where your [app configuration](../workflow/configuration.md) is defined.
 
-**Important**: You'll have to generate an [Apple app-specific password](https://expo.fyi/apple-app-specific-password) or an [App Store Connect Api Key](https://expo.fyi/creating-asc-api-key) before submitting an app with EAS CLI.
+If you have not generated an App Store Connect API Key yet, you can let EAS CLI take care of that for you by signing into your Apple Developer Program account and following the prompts. You can also upload your own [API Key](https://expo.fyi/creating-asc-api-key) or pass in an [Apple app-specific password](https://expo.fyi/apple-app-specific-password).
 
 To upload your iOS app to the Apple App Store, run `eas submit --platform ios` and follow the instructions on the screen.
 
@@ -37,7 +37,12 @@ The command will perform the following steps:
 
   > If you already have an App Store Connect app, this step can be skipped by providing the `ascAppId` in the submit profile. The [ASC App ID](https://expo.fyi/asc-app-id) can be found either on App Store Connect, or later during this command in the _Submission Summary_ table.
 
-- Ask for your Apple ID (if not provided earlier) and for your Apple app-specific password. They can be also provided using `--apple-id` param and `EXPO_APPLE_APP_SPECIFIC_PASSWORD` environment variable, respectively. Alternatively, you can provide an App Store Connect Api Key instead, setting the `ascApiKeyPath`, `ascApiKeyIssuerId`, and `ascApiKeyId` fields in **eas.json**.
+- Ensure you have the proper credentials set up. If none can be found, you can:
+
+  - Let EAS CLI set one up for you.
+  - Upload your own [App Store Connect API Key](https://expo.fyi/creating-asc-api-key). Alternatively, you can set it with the `ascApiKeyPath`, `ascApiKeyIssuerId`, and `ascApiKeyId` fields in **eas.json**.
+  - Provide your [Apple app-specific password](https://expo.fyi/apple-app-specific-password) and Apple ID Username. Pass them in with the `EXPO_APPLE_APP_SPECIFIC_PASSWORD` environment variable and `--apple-id` parameter, respectively.
+
 - Ask for which binary to submit. You can select one of the following:
 
   - The latest successful iOS build for the project on EAS servers.
@@ -52,12 +57,19 @@ The command will perform the following steps:
 
 ## Submitting your app using CI
 
-The `eas submit` command is able to perform submissions from a CI environment. All you have to do is ensure that all required information is provided with **eas.json** and environment variables. Mainly, providing the archive source (`--latest`, `--id`, `--path`, or `--url`) is essential. Also, make sure that the iOS Bundle Identifier is present in your [app config file](/workflow/configuration.md).
+The `eas submit` command is able to perform submissions from a CI environment. All you have to do is ensure that all required information is provided with **eas.json** and environment variables.
 
-For iOS submissions, you must provide either:
+You must do the following:
 
-- `EXPO_APPLE_APP_SPECIFIC_PASSWORD` environment variable along with Apple ID and ASC App ID (`appleId` and `ascAppId` in **eas.json**). The ASC App ID is required to skip the Apple developer log-in process, which will likely not be possible on CI due to the 2FA prompt.
-- Your App Store Connect Api Key with the `ascApiKeyPath`, `ascApiKeyIssuerId`, and `ascApiKeyId` fields set in **eas.json**.
+- Provide the archive source (`--latest`, `--id`, `--path`, or `--url`).
+- Make sure that the iOS Bundle Identifier is present in your [app config file](/workflow/configuration.md).
+- Set the ASC App ID (`ascAppId` in **eas.json**). The ASC App ID is required to skip the Apple developer log-in process, which will likely not be possible on CI due to the 2FA prompt.
+
+You'll also need to configure your submission credentials **one** of the following ways:
+
+- Setup your App Store Connect API Key with EAS Servers. You can check the state of your credentials by running `eas credentials` or by running `eas submit -p ios` interactively.
+- Pass in your App Store Connect Api Key with the `ascApiKeyPath`, `ascApiKeyIssuerId`, and `ascApiKeyId` fields set in **eas.json**.
+- Set the `EXPO_APPLE_APP_SPECIFIC_PASSWORD` environment variable along with your Apple ID Username (`appleId` in **eas.json**).
 
 Example usage:
 

--- a/docs/pages/submit/ios.md
+++ b/docs/pages/submit/ios.md
@@ -67,7 +67,7 @@ You must do the following:
 
 You'll also need to configure your submission credentials **one** of the following ways:
 
-- Setup your App Store Connect API Key with EAS Servers. You can check the state of your credentials by running `eas credentials` or by running `eas submit -p ios` interactively.
+- Set up your App Store Connect API Key with EAS Servers. You can check the state of your credentials by running `eas credentials` or by running `eas submit -p ios` interactively.
 - Pass in your App Store Connect Api Key with the `ascApiKeyPath`, `ascApiKeyIssuerId`, and `ascApiKeyId` fields set in **eas.json**.
 - Set the `EXPO_APPLE_APP_SPECIFIC_PASSWORD` environment variable along with your Apple ID Username (`appleId` in **eas.json**).
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Reflect the current state of our cli code because we support generating ASC Api Keys in iOS submissions now. 

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
