### PR TITLE
[template] Fix hermes command not found on monorepo

### DIFF
--- a/templates/expo-template-bare-minimum/android/app/build.gradle
+++ b/templates/expo-template-bare-minimum/android/app/build.gradle
@@ -79,7 +79,9 @@ import com.android.build.OutputFile
 
 project.ext.react = [
     enableHermes: (findProperty('expo.jsEngine') ?: "jsc") == "hermes",
-    cliPath: new File(["node", "--print", "require.resolve('react-native/package.json')"].execute(null, rootDir).text.trim(), "../cli.js"),
+    cliPath: new File(["node", "--print", "require.resolve('react-native/package.json')"].execute(null, rootDir).text.trim()).getParentFile().getAbsolutePath() + "/cli.js",
+    hermesCommand: new File(["node", "--print", "require.resolve('hermes-engine/package.json')"].execute(null, rootDir).text.trim()).getParentFile().getAbsolutePath() + "/%OS-BIN%/hermesc",
+    composeSourceMapsPath: new File(["node", "--print", "require.resolve('react-native/package.json')"].execute(null, rootDir).text.trim()).getParentFile().getAbsolutePath() + "/scripts/compose-source-maps.js",
 ]
 
 apply from: new File(["node", "--print", "require.resolve('react-native/package.json')"].execute(null, rootDir).text.trim(), "../react.gradle")


### PR DESCRIPTION
# Why

when hermes is enabled, react-native uses a fixed path to search hermes related command:
https://github.com/facebook/react-native/blob/6df04ae6668275d8c3231ddf290d72b45a32d2d4/react.gradle#L38-L46
this fixed path breaks monorepo support.


# How

passing node resolved path. since react.gradle will do some normalization and path like `package.json/../%OS-BIN%/hermesc` is not supported. the fix uses a slightly different solution to get the absolute path.

# Test Plan

https://gitlab.com/kudochien/sdkmono
build from `./packages/sdk43`

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
