### PR TITLE
[sweet][kotlin] Fix incorrect context in view managers after reload

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/GroupViewManagerWrapper.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/GroupViewManagerWrapper.kt
@@ -8,15 +8,15 @@ import com.facebook.react.uimanager.ViewGroupManager
 import com.facebook.react.uimanager.annotations.ReactProp
 
 class GroupViewManagerWrapper(
-  private val wrapperDelegate: ViewManagerWrapperDelegate
-) : ViewGroupManager<ViewGroup>() {
-  override fun getName(): String = "ViewManagerAdapter_${wrapperDelegate.name}"
+  override val viewWrapperDelegate: ViewManagerWrapperDelegate
+) : ViewGroupManager<ViewGroup>(), ViewWrapperDelegateHolder {
+  override fun getName(): String = "ViewManagerAdapter_${viewWrapperDelegate.name}"
 
   override fun createViewInstance(reactContext: ThemedReactContext): ViewGroup =
-    wrapperDelegate.createView(reactContext) as ViewGroup
+    viewWrapperDelegate.createView(reactContext) as ViewGroup
 
   @ReactProp(name = "proxiedProperties")
   fun setProxiedProperties(view: View, proxiedProperties: ReadableMap) {
-    wrapperDelegate.setProxiedProperties(view, proxiedProperties)
+    viewWrapperDelegate.setProxiedProperties(view, proxiedProperties)
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/SimpleViewManagerWrapper.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/SimpleViewManagerWrapper.kt
@@ -7,15 +7,15 @@ import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.annotations.ReactProp
 
 class SimpleViewManagerWrapper(
-  private val wrapperDelegate: ViewManagerWrapperDelegate
-) : SimpleViewManager<View>() {
-  override fun getName(): String = "ViewManagerAdapter_${wrapperDelegate.name}"
+  override val viewWrapperDelegate: ViewManagerWrapperDelegate
+) : SimpleViewManager<View>(), ViewWrapperDelegateHolder {
+  override fun getName(): String = "ViewManagerAdapter_${viewWrapperDelegate.name}"
 
   override fun createViewInstance(reactContext: ThemedReactContext): View =
-    wrapperDelegate.createView(reactContext)
+    viewWrapperDelegate.createView(reactContext)
 
   @ReactProp(name = "proxiedProperties")
   fun setProxiedProperties(view: View, proxiedProperties: ReadableMap) {
-    wrapperDelegate.setProxiedProperties(view, proxiedProperties)
+    viewWrapperDelegate.setProxiedProperties(view, proxiedProperties)
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerWrapperDelegate.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerWrapperDelegate.kt
@@ -5,7 +5,7 @@ import android.view.View
 import com.facebook.react.bridge.ReadableMap
 import expo.modules.kotlin.ModuleHolder
 
-class ViewManagerWrapperDelegate(private val moduleHolder: ModuleHolder) {
+class ViewManagerWrapperDelegate(internal var moduleHolder: ModuleHolder) {
   private val definition: ViewManagerDefinition
     get() = requireNotNull(moduleHolder.definition.viewManagerDefinition)
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewWrapperDelegateHolder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewWrapperDelegateHolder.kt
@@ -1,0 +1,5 @@
+package expo.modules.kotlin.views
+
+interface ViewWrapperDelegateHolder {
+  val viewWrapperDelegate: ViewManagerWrapperDelegate
+}


### PR DESCRIPTION
# Why

When I was trying to rewrite `expo-linear-gradient`,  I noticed something weird. The view managers weren't in sync with the most recent module registry. And as it turns out, the view managers are only created once, but other modules are created after each reloads.  So we have to synchronize them manually. 

# How

- Save kotlin view managers in `ModuleRegistryAdapter`.
- Updated module holder in saved view managers when new modules are created.
- Changed how we obtain view managers' names. 

# Test Plan

- bare-expo ✅