### PR TITLE
[sweat][kotlin] Add support for Pair and float type

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/BasicTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/BasicTypeConverter.kt
@@ -3,7 +3,6 @@ package expo.modules.kotlin.types
 import com.facebook.react.bridge.Dynamic
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
-import kotlin.reflect.KClassifier
 
 class BasicTypeConverter : TypeConverter {
   interface SimpleDynamicConverter<ConvertToType : Any> {
@@ -16,6 +15,10 @@ class BasicTypeConverter : TypeConverter {
 
   class DoubleConverter : SimpleDynamicConverter<Double> {
     override fun cast(value: Dynamic): Double = value.asDouble()
+  }
+
+  class FloatConverter : SimpleDynamicConverter<Float> {
+    override fun cast(value: Dynamic): Float = value.asDouble().toFloat()
   }
 
   class BoolConverter : SimpleDynamicConverter<Boolean> {
@@ -42,7 +45,11 @@ class BasicTypeConverter : TypeConverter {
     override fun cast(value: Dynamic): DoubleArray = value.asArray().toArrayList().map { (it as Double) }.toDoubleArray()
   }
 
-  private val fromDynamicTypeMapper = mapOf<KClassifier, SimpleDynamicConverter<*>>(
+  class PrimitiveFloatArray : SimpleDynamicConverter<FloatArray> {
+    override fun cast(value: Dynamic): FloatArray = value.asArray().toArrayList().map { (it as Double).toFloat() }.toFloatArray()
+  }
+
+  private val fromDynamicTypeMapper = mapOf(
     Int::class to IntConverter(),
     java.lang.Integer::class to IntConverter(),
 
@@ -52,6 +59,9 @@ class BasicTypeConverter : TypeConverter {
     Boolean::class to BoolConverter(),
     java.lang.Boolean::class to BoolConverter(),
 
+    Float::class to FloatConverter(),
+    java.lang.Float::class to FloatConverter(),
+
     String::class to StringConverter(),
 
     ReadableArray::class to ReadableArrayConverter(),
@@ -59,6 +69,7 @@ class BasicTypeConverter : TypeConverter {
 
     IntArray::class to PrimitiveIntArrayConverter(),
     DoubleArray::class to PrimitiveDoubleArrayConverter(),
+    FloatArray::class to PrimitiveFloatArray()
   )
 
   override fun canHandleConversion(toType: KClassTypeWrapper): Boolean =

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/PairTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/PairTypeConverter.kt
@@ -1,0 +1,22 @@
+package expo.modules.kotlin.types
+
+import com.facebook.react.bridge.Dynamic
+
+class PairTypeConverter : TypeConverter {
+  override fun canHandleConversion(toType: KClassTypeWrapper): Boolean =
+    toType.classifier == Pair::class
+
+  override fun convert(jsValue: Dynamic, toType: KClassTypeWrapper): Any {
+    val firstParameterType = toType.arguments[0].type
+    requireNotNull(firstParameterType) { "The pair type should contain the type of the first parameter." }
+    val secondParameterType = toType.arguments[1].type
+    requireNotNull(secondParameterType) { "The pair type should contain the type of the second parameter." }
+
+    val jsArray = jsValue.asArray()
+
+    return Pair(
+      TypeConverterHelper.convert(jsArray.getDynamic(0), firstParameterType),
+      TypeConverterHelper.convert(jsArray.getDynamic(1), secondParameterType)
+    )
+  }
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterHelper.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterHelper.kt
@@ -14,7 +14,8 @@ object TypeConverterHelper {
     ListTypeConverter(),
     MapTypeConverter(),
     RecordTypeConverter(),
-    EnumTypeConverter()
+    EnumTypeConverter(),
+    PairTypeConverter()
   )
 
   @Suppress("UNCHECKED_CAST")

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/types/BasicTypeConverterTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/types/BasicTypeConverterTest.kt
@@ -1,0 +1,29 @@
+@file:OptIn(ExperimentalStdlibApi::class)
+
+package expo.modules.kotlin.types
+
+import com.facebook.react.bridge.DynamicFromObject
+import com.facebook.react.bridge.JavaOnlyArray
+import com.google.common.truth.Truth
+import org.junit.Test
+import kotlin.reflect.typeOf
+
+class BasicTypeConverterTest {
+  private val converter = BasicTypeConverter()
+
+  @Test
+  fun `should convert to float array`() {
+    val dynamic = DynamicFromObject(
+      JavaOnlyArray().apply {
+        pushDouble(1.0)
+        pushDouble(2.0)
+        pushDouble(3.0)
+      }
+    )
+
+    val converted = converter.convert(dynamic, KClassTypeWrapper(typeOf<FloatArray>()))
+
+    Truth.assertThat(converted).isInstanceOf(FloatArray::class.java)
+    Truth.assertThat(converted as FloatArray).usingExactEquality().containsExactly(1f, 2f, 3f)
+  }
+}

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/types/PairTypeConverterTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/types/PairTypeConverterTest.kt
@@ -1,0 +1,45 @@
+@file:OptIn(ExperimentalStdlibApi::class)
+
+package expo.modules.kotlin.types
+
+import com.facebook.react.bridge.DynamicFromObject
+import com.facebook.react.bridge.JavaOnlyArray
+import com.google.common.truth.Truth
+import org.junit.Test
+import kotlin.reflect.typeOf
+
+class PairTypeConverterTest {
+  private val converter = PairTypeConverter()
+
+  @Test
+  fun `should concert array to pair`() {
+    val array = DynamicFromObject(
+      JavaOnlyArray().apply {
+        pushInt(1)
+        pushInt(2)
+      }
+    )
+
+    val converted = converter.convert(array, KClassTypeWrapper(typeOf<Pair<Int, Int>>()))
+
+    Truth.assertThat(converted).isInstanceOf(Pair::class.java)
+    Truth.assertThat((converted as Pair<*, *>).first).isEqualTo(1)
+    Truth.assertThat(converted.second).isEqualTo(2)
+  }
+
+  @Test
+  fun `should concert array with two different type to pair`() {
+    val array = DynamicFromObject(
+      JavaOnlyArray().apply {
+        pushInt(1)
+        pushString("second")
+      }
+    )
+
+    val converted = converter.convert(array, KClassTypeWrapper(typeOf<Pair<Int, String>>()))
+
+    Truth.assertThat(converted).isInstanceOf(Pair::class.java)
+    Truth.assertThat((converted as Pair<*, *>).first).isEqualTo(1)
+    Truth.assertThat(converted.second).isEqualTo("second")
+  }
+}

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/types/PairTypeConverterTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/types/PairTypeConverterTest.kt
@@ -12,7 +12,7 @@ class PairTypeConverterTest {
   private val converter = PairTypeConverter()
 
   @Test
-  fun `should concert array to pair`() {
+  fun `should convert array to pair`() {
     val array = DynamicFromObject(
       JavaOnlyArray().apply {
         pushInt(1)
@@ -28,7 +28,7 @@ class PairTypeConverterTest {
   }
 
   @Test
-  fun `should concert array with two different type to pair`() {
+  fun `should convert array with two different types to pair`() {
     val array = DynamicFromObject(
       JavaOnlyArray().apply {
         pushInt(1)


### PR DESCRIPTION
# Why

Adds support for Pair and float as a method argument. 
Those types are very handy in `expo-linear-gradient` module.

# How

- Added Pari converted. 
- Extended `BasicTypeConverter` to support float type.

# Test Plan

- units ✅
- `expo-linear-gradient` ✅