### PR TITLE
[config-universe] match dependencies to the workspace versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "eslint": "^7.31.0",
     "expo-yarn-workspaces": "*",
     "jsc-android": "^245459.0.0",
-    "prettier": "^2.3.1",
+    "prettier": "^2.4.1",
     "yarn-deduplicate": "^3.1.0"
   }
 }

--- a/packages/eslint-config-universe/.prettierrc
+++ b/packages/eslint-config-universe/.prettierrc
@@ -2,6 +2,6 @@
   "printWidth": 100,
   "tabWidth": 2,
   "singleQuote": true,
-  "jsxBracketSameLine": true,
+  "bracketSameLine": true,
   "trailingComma": "es5"
 }

--- a/packages/eslint-config-universe/CHANGELOG.md
+++ b/packages/eslint-config-universe/CHANGELOG.md
@@ -4,18 +4,18 @@
 
 ### 🛠 Breaking changes
 
-- Change Prettier minimal version to `2.4+`, to avoid issues with renamed option. [See the Prettier changelog](https://prettier.io/blog/2021/09/09/2.4.0.html).
+- Change Prettier minimal version to `2.4+`, to avoid issues with renamed option. [See the Prettier changelog](https://prettier.io/blog/2021/09/09/2.4.0.html). ([#15167](https://github.com/expo/expo/pull/15167) by [@Simek](https://github.com/Simek))
 
 ### 🎉 New features
 
 ### 🐛 Bug fixes
 
-- Rename Prettier option from `jsxBracketSameLine` to `bracketSameLine` to fix the warning.
+- Rename Prettier option from `jsxBracketSameLine` to `bracketSameLine` to fix the warning. ([#15167](https://github.com/expo/expo/pull/15167) by [@Simek](https://github.com/Simek))
 
 ### 💡 Others
 
-- Update Babel related dependencies to `7.12+`.
-- Update Jest to the latest version from `26` release.
+- Update Babel related dependencies to `7.12+`. ([#15167](https://github.com/expo/expo/pull/15167) by [@Simek](https://github.com/Simek))
+- Update Jest to the latest version from `26` release. ([#15167](https://github.com/expo/expo/pull/15167) by [@Simek](https://github.com/Simek))
 
 ## 8.0.0 — 2021-09-08
 

--- a/packages/eslint-config-universe/CHANGELOG.md
+++ b/packages/eslint-config-universe/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 ### 💡 Others
 
+- Update Babel related dependencies to `7.12+`.
+- Update Jest to the latest version from `26` release.
+
 ## 8.0.0 — 2021-09-08
 
 ### 🛠 Breaking changes

--- a/packages/eslint-config-universe/CHANGELOG.md
+++ b/packages/eslint-config-universe/CHANGELOG.md
@@ -4,9 +4,13 @@
 
 ### 🛠 Breaking changes
 
+- Change Prettier minimal version to `2.4+`, to avoid issues with renamed option. [See the Prettier changelog](https://prettier.io/blog/2021/09/09/2.4.0.html).
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes
+
+- Rename Prettier option from `jsxBracketSameLine` to `bracketSameLine` to fix the warning.
 
 ### 💡 Others
 

--- a/packages/eslint-config-universe/README.md
+++ b/packages/eslint-config-universe/README.md
@@ -43,7 +43,7 @@ If you would like to customize the Prettier settings, create a file named `.pret
   "printWidth": 100,
   "tabWidth": 2,
   "singleQuote": true,
-  "jsxBracketSameLine": true,
+  "bracketSameLine": true,
   "trailingComma": "es5"
 }
 ```

--- a/packages/eslint-config-universe/package.json
+++ b/packages/eslint-config-universe/package.json
@@ -41,8 +41,8 @@
   },
   "homepage": "https://github.com/expo/expo/tree/master/packages/eslint-config-universe",
   "dependencies": {
-    "@babel/eslint-parser": "^7.11.5",
-    "@babel/eslint-plugin": "^7.11.5",
+    "@babel/eslint-parser": "^7.12.17",
+    "@babel/eslint-plugin": "^7.12.13",
     "@typescript-eslint/eslint-plugin": "^4.28.5",
     "@typescript-eslint/parser": "^4.28.5",
     "eslint-config-prettier": "^8.3.0",
@@ -52,7 +52,7 @@
     "eslint-plugin-react-hooks": "^4.2.0"
   },
   "peerDependencies": {
-    "@babel/core": ">=7.11.0",
+    "@babel/core": ">=7.12.0",
     "eslint": ">= 7",
     "prettier": ">= 2"
   },
@@ -62,10 +62,10 @@
     }
   },
   "devDependencies": {
-    "@babel/core": "^7.11.6",
+    "@babel/core": "^7.12.9",
     "@expo/spawn-async": "^1.5.0",
     "eslint": "^7.31.0",
-    "jest": "^26.4.1",
+    "jest": "^26.6.3",
     "prettier": "^2.3.1"
   }
 }

--- a/packages/eslint-config-universe/package.json
+++ b/packages/eslint-config-universe/package.json
@@ -54,7 +54,7 @@
   "peerDependencies": {
     "@babel/core": ">=7.12.0",
     "eslint": ">= 7",
-    "prettier": ">= 2"
+    "prettier": ">= 2.4"
   },
   "peerDependenciesMeta": {
     "@babel/core": {

--- a/packages/eslint-config-universe/package.json
+++ b/packages/eslint-config-universe/package.json
@@ -66,6 +66,6 @@
     "@expo/spawn-async": "^1.5.0",
     "eslint": "^7.31.0",
     "jest": "^26.6.3",
-    "prettier": "^2.3.1"
+    "prettier": "^2.4.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -84,7 +84,7 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/core@^7.0.0", "@babel/core@^7.1.0", "@babel/core@^7.1.6", "@babel/core@^7.11.6", "@babel/core@^7.12.3", "@babel/core@^7.12.9", "@babel/core@^7.7.5":
+"@babel/core@^7.0.0", "@babel/core@^7.1.0", "@babel/core@^7.1.6", "@babel/core@^7.12.3", "@babel/core@^7.12.9", "@babel/core@^7.7.5":
   version "7.15.8"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.15.8.tgz#195b9f2bffe995d2c6c159e72fe525b4114e8c10"
   integrity sha512-3UG9dsxvYBMYwRv+gS41WKHno4K60/9GPy1CJaH6xy3Elq8CTtvtjT5R5jmNhXfCYLX2mTw+7/aq5ak/gOE0og==
@@ -105,16 +105,16 @@
     semver "^6.3.0"
     source-map "^0.5.0"
 
-"@babel/eslint-parser@^7.11.5":
-  version "7.15.8"
-  resolved "https://registry.yarnpkg.com/@babel/eslint-parser/-/eslint-parser-7.15.8.tgz#8988660b59d739500b67d0585fd4daca218d9f11"
-  integrity sha512-fYP7QFngCvgxjUuw8O057SVH5jCXsbFFOoE77CFDcvzwBVgTOkMD/L4mIC5Ud1xf8chK/no2fRbSSn1wvNmKuQ==
+"@babel/eslint-parser@^7.12.17":
+  version "7.16.3"
+  resolved "https://registry.yarnpkg.com/@babel/eslint-parser/-/eslint-parser-7.16.3.tgz#2a6b1702f3f5aea48e00cea5a5bcc241c437e459"
+  integrity sha512-iB4ElZT0jAt7PKVaeVulOECdGe6UnmA/O0P9jlF5g5GBOwDVbna8AXhHRu4s27xQf6OkveyA8iTDv1jHdDejgQ==
   dependencies:
     eslint-scope "^5.1.1"
     eslint-visitor-keys "^2.1.0"
     semver "^6.3.0"
 
-"@babel/eslint-plugin@^7.11.5":
+"@babel/eslint-plugin@^7.12.13":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/eslint-plugin/-/eslint-plugin-7.14.5.tgz#70b76608d49094062e8da2a2614d50fec775c00f"
   integrity sha512-nzt/YMnOOIRikvSn2hk9+W2omgJBy6U8TN0R+WTTmqapA+HnZTuviZaketdTE9W7/k/+E/DfZlt1ey1NSE39pg==
@@ -11048,7 +11048,7 @@ jest-worker@^26.0.0, jest-worker@^26.2.1, jest-worker@^26.6.2:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
 
-jest@^26.4.1, jest@^26.6.3:
+jest@^26.6.3:
   version "26.6.3"
   resolved "https://registry.yarnpkg.com/jest/-/jest-26.6.3.tgz#40e8fdbe48f00dfa1f0ce8121ca74b88ac9148ef"
   integrity sha512-lGS5PXGAzR4RF7V5+XObhqz2KZIDUA1yD0DG6pBVmy10eh0ZIXQImRuzocsI/N2XZ1GrLFwTS27In2i2jlpq1Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -14250,7 +14250,7 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^2.3.1:
+prettier@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.4.1.tgz#671e11c89c14a4cfc876ce564106c4a6726c9f5c"
   integrity sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==


### PR DESCRIPTION
# Why

Refs:
* https://github.com/expo/expo/pull/14561

# How

This PR bumps the Babel and Jest dependencies in the `eslint-config-universe` package to match the workspace versions.

It also bumps the minimum Prettier version to `2.4` to ensure there will be no errors after the option name change, which has been performed to fix the warning when formatting packages/modules or running tests:

<img width="411" alt="Screenshot 2021-11-12 at 16 01 21" src="https://user-images.githubusercontent.com/719641/141487703-3cfc16e4-ef48-4404-a256-01620b52d6b3.png">

# Test Plan

`yarn test` and `yarn lint` commands run in package directory do not yield any errors.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
