### PR TITLE
[expo-media-library] prebuild fails when withMediaLibrary plugin enabled

### DIFF
--- a/packages/expo-media-library/plugin/build/withMediaLibrary.js
+++ b/packages/expo-media-library/plugin/build/withMediaLibrary.js
@@ -37,7 +37,7 @@ const withMediaLibrary = (config, { photosPermission, savePhotosPermission, isAc
             [
                 'android.permission.READ_EXTERNAL_STORAGE',
                 'android.permission.WRITE_EXTERNAL_STORAGE',
-                isAccessMediaLocationEnabled !== null && isAccessMediaLocationEnabled !== void 0 ? isAccessMediaLocationEnabled : 'android.permission.ACCESS_MEDIA_LOCATION',
+                isAccessMediaLocationEnabled && 'android.permission.ACCESS_MEDIA_LOCATION',
             ].filter(Boolean),
         ],
         withMediaLibraryExternalStorage,

--- a/packages/expo-media-library/plugin/src/withMediaLibrary.ts
+++ b/packages/expo-media-library/plugin/src/withMediaLibrary.ts
@@ -52,7 +52,7 @@ const withMediaLibrary: ConfigPlugin<{
       [
         'android.permission.READ_EXTERNAL_STORAGE',
         'android.permission.WRITE_EXTERNAL_STORAGE',
-        isAccessMediaLocationEnabled ?? 'android.permission.ACCESS_MEDIA_LOCATION',
+        isAccessMediaLocationEnabled && 'android.permission.ACCESS_MEDIA_LOCATION',
       ].filter(Boolean),
     ],
     withMediaLibraryExternalStorage,


### PR DESCRIPTION
# Why

Fixes an Android bug caused by `expo prebuild` when the `expo-media-library` plugin is enabled. Previous code caused the boolean value of `true` to be passed in as the Android permission key rather than the correct string. This created a bug stemming from no string type check inside `@expo/config-plugins` on `permission.includes`.

# How

# Test Plan

To replicate add the `expo-media-library` plugin with `accessMediaLocation` enabled and run `expo prebuild`. Observe that there is an error like "no function for permission.includes".

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
