### PR TITLE
Fix tiny typo on Limitations docs page

### DIFF
--- a/docs/pages/build-reference/limitations.md
+++ b/docs/pages/build-reference/limitations.md
@@ -2,7 +2,7 @@
 title: Limitations
 ---
 
-EAS Build is a new service and we plan to address many of the currnet limitations in time. Some of these missing features could prevent you from being able to use the service for your applications, and others might just be inconveniences.
+EAS Build is a new service and we plan to address many of the current limitations in time. Some of these missing features could prevent you from being able to use the service for your applications, and others might just be inconveniences.
 
 ## Current limitations
 


### PR DESCRIPTION
# Why

This update fixes a small typo on the Limitations docs page.

# How

`s/currnet/current`

# Test Plan

N/A

# Checklist

N/A

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
