### PR TITLE
[docs] `StoreReview` move Usage above API

### DIFF
--- a/docs/pages/versions/unversioned/sdk/storereview.md
+++ b/docs/pages/versions/unversioned/sdk/storereview.md
@@ -20,22 +20,6 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 <InstallSection packageName="expo-store-review expo-linking" />
 
-## API
-
-```js
-import * as StoreReview from 'expo-store-review';
-```
-
-<APISection packageName="expo-store-review" apiName="StoreReview" />
-
-## Error Codes
-
-### `E_STORE_REVIEW_UNSUPPORTED`
-
-Requesting an App Store review is not supported on this device. The device must be iOS 10.3 or greater. Android and web are not supported. Be sure to check for support with `isAvailableAsync()` to avoid this error.
-
----
-
 ## Usage
 
 It is important that you follow the [Human Interface Guidelines](https://developer.apple.com/ios/human-interface-guidelines/system-capabilities/ratings-and-reviews/) for iOS and [Guidelines](https://developer.android.com/guide/playcore/in-app-review#when-to-request) for Android when using this API.
@@ -43,7 +27,7 @@ It is important that you follow the [Human Interface Guidelines](https://develop
 **Specifically:**
 
 - Don't call `StoreReview.requestReview()` from a button - instead try calling it after the user has finished some signature interaction in the app.
-- Don't spam the user
+- Don't spam the user.
 - Don't request a review when the user is doing something time sensitive like navigating.
 - Don't ask the user any questions before or while presenting the rating button or card.
 
@@ -76,3 +60,17 @@ Linking.openURL(
 // Open the Android Play Store directly
 Linking.openURL(`market://details?id=${androidPackageName}&showAllReviews=true`);
 ```
+
+## API
+
+```js
+import * as StoreReview from 'expo-store-review';
+```
+
+<APISection packageName="expo-store-review" apiName="StoreReview" />
+
+## Error Codes
+
+### `E_STORE_REVIEW_UNSUPPORTED`
+
+Requesting an App Store review is not supported on this device. The device must be iOS 10.3 or greater. Android and web are not supported. Be sure to check for support with `isAvailableAsync()` to avoid this error.

--- a/docs/pages/versions/v43.0.0/sdk/storereview.md
+++ b/docs/pages/versions/v43.0.0/sdk/storereview.md
@@ -20,22 +20,6 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 <InstallSection packageName="expo-store-review expo-linking" />
 
-## API
-
-```js
-import * as StoreReview from 'expo-store-review';
-```
-
-<APISection packageName="expo-store-review" apiName="StoreReview" />
-
-## Error Codes
-
-### `E_STORE_REVIEW_UNSUPPORTED`
-
-Requesting an App Store review is not supported on this device. The device must be iOS 10.3 or greater. Android and web are not supported. Be sure to check for support with `isAvailableAsync()` to avoid this error.
-
----
-
 ## Usage
 
 It is important that you follow the [Human Interface Guidelines](https://developer.apple.com/ios/human-interface-guidelines/system-capabilities/ratings-and-reviews/) for iOS and [Guidelines](https://developer.android.com/guide/playcore/in-app-review#when-to-request) for Android when using this API.
@@ -43,7 +27,7 @@ It is important that you follow the [Human Interface Guidelines](https://develop
 **Specifically:**
 
 - Don't call `StoreReview.requestReview()` from a button - instead try calling it after the user has finished some signature interaction in the app.
-- Don't spam the user
+- Don't spam the user.
 - Don't request a review when the user is doing something time sensitive like navigating.
 - Don't ask the user any questions before or while presenting the rating button or card.
 
@@ -76,3 +60,17 @@ Linking.openURL(
 // Open the Android Play Store directly
 Linking.openURL(`market://details?id=${androidPackageName}&showAllReviews=true`);
 ```
+
+## API
+
+```js
+import * as StoreReview from 'expo-store-review';
+```
+
+<APISection packageName="expo-store-review" apiName="StoreReview" />
+
+## Error Codes
+
+### `E_STORE_REVIEW_UNSUPPORTED`
+
+Requesting an App Store review is not supported on this device. The device must be iOS 10.3 or greater. Android and web are not supported. Be sure to check for support with `isAvailableAsync()` to avoid this error.


### PR DESCRIPTION
# Why

The common pattern across the docs is that Usage section appears above the API section. 

# How

On the `StoreReview` doc page the order of section has been reverted, this PR fixes that order for `unversioned` and SDK 43 docs.

# Test Plan

The change has been tested by running docs website on `localhost`.

<img width="286" alt="Screenshot 2021-11-15 at 08 45 39" src="https://user-images.githubusercontent.com/719641/141742064-98726012-9dc9-458f-aa8c-f745d44b38a9.png">

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
