### PR TITLE
[docs] update docs on the eas build local plugin

### DIFF
--- a/docs/pages/build-reference/local-builds.md
+++ b/docs/pages/build-reference/local-builds.md
@@ -8,8 +8,10 @@ You can run the same build process as we run on the EAS Build servers directly o
 
 ## Prerequisites
 
-- You need to be authenticated (either via regular login or `EXPO_TOKEN`).
-- The EAS CLI plugin needs to be installed: `npm i -g eas-cli-local-build-plugin`
+You need to be authenticated with Expo:
+
+- Run `eas login`,
+- or set `EXPO_TOKEN` ([learn more on the token-base authentication](/accounts/programmatic-access.md)).
 
 ## Use cases for local builds
 


### PR DESCRIPTION
# Why

Follow-up to https://github.com/expo/eas-cli/pull/753

# How

`eas-cli-local-build-plugin` doesn't need to be installed manually.

# Test Plan

`yarn dev`