### PR TITLE
[docs] Add plugin to sentry-expo doc

### DIFF
--- a/docs/pages/guides/using-sentry.md
+++ b/docs/pages/guides/using-sentry.md
@@ -68,12 +68,13 @@ Sentry.Native.*
 Sentry.Browser.*
 ```
 
-- Open **app.json** and add a `postPublish hook`:
+- Open **app.json** and add a `plugin` and a `postPublish hook`:
 
 ```json
 {
   "expo": {
     // ... your existing configuration
+    "plugins": ["sentry-expo"],
     "hooks": {
       "postPublish": [
         {


### PR DESCRIPTION
For sentry to upload source maps with EAS Build, we have to provide a config plugin.