### PR TITLE
[tools] Don't update dep version when it's satisfying current range

### DIFF
--- a/tools/src/publish-packages/tasks/updateWorkspaceProjects.ts
+++ b/tools/src/publish-packages/tasks/updateWorkspaceProjects.ts
@@ -1,6 +1,7 @@
 import JsonFile from '@expo/json-file';
 import chalk from 'chalk';
 import path from 'path';
+import semver from 'semver';
 
 import { EXPO_DIR } from '../../Constants';
 import logger from '../../Logger';
@@ -66,7 +67,10 @@ export const updateWorkspaceProjects = new Task<TaskArgs>(
           for (const { pkg, state } of projectDependencies) {
             const currentVersionRange = dependenciesObject[pkg.packageName];
 
-            if (!currentVersionRange) {
+            if (
+              !currentVersionRange ||
+              !shouldUpdateDependencyVersion(projectName, currentVersionRange, state.releaseVersion)
+            ) {
               continue;
             }
 
@@ -88,9 +92,24 @@ export const updateWorkspaceProjects = new Task<TaskArgs>(
         // Save project's `package.json`.
         await JsonFile.writeAsync(projectPackageJsonPath, projectPackageJson);
 
-        // Flush batched logs.
-        batch.flush();
+        // Flush batched logs if there is at least one version change in the project.
+        if (batch.batchedLogs.length > 1) {
+          batch.flush();
+        }
       })
     );
   }
 );
+
+/**
+ * Returns boolean indicating if the version range should be updated. Our policy assumes that `expo` package controls versions
+ * of other expo packages (e.g. expo-modules-core, expo-modules-autolinking). Any other package (or workspace project)
+ * doesn't need to be updated as long as the new version still satisfies the version range.
+ *
+ * @param packageName Name of the package to update
+ * @param currentRange Current version range of the dependency
+ * @param version The new version of the dependency
+ */
+function shouldUpdateDependencyVersion(packageName: string, currentRange: string, version: string) {
+  return packageName === 'expo' || !semver.satisfies(version, currentRange);
+}


### PR DESCRIPTION
# Why

Until now, in the publish script, we're updating dependency versions in each workspace project. We've got some reports that is not always working well, especially when version ranges for `expo-modules-core` differ across installed expo modules. Since this package is not intended to be installed on its own, we have no control on which version is used by the project. As a solution, we can make `expo` package depend on strict versions `expo-modules-core` and `expo-modules-autolinking` — which hopefully will give us more control.

Updating the versions on each publish is also causing changes in other packages, making them "dirty" and so the publish script thinks there are some changes to publish in those packages (but in fact, it's not needed).

# How

Stopped updating dependency version (in packages other than `expo`) if the current version range is still satisfied.

# Test Plan

I tried `et publish expo-modules-core --dry` and confirmed that:
- publishing `0.5.0` causes updates in dependency versions in each workspace project
- publishing `0.4.9` causes changes only in `expo` package as the current version ranges (`~0.4.x`) are still satisfied
- in both scenarios, `yarn workspaces info` doesn't return any mismatched workspace dependencies 
