### PR TITLE
[issue template] use double quotes

### DIFF
--- a/.github/ISSUE_TEMPLATE/dev_client_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/dev_client_bug_report.yml
@@ -1,4 +1,4 @@
-name: '\U0001F6E0 expo-dev-client Bug Report'
+name: "\U0001F6E0 expo-dev-client Bug Report"
 description: 'Report a reproducible issue with a development build'
 labels: ['expo-dev-client', 'needs review']
 body:


### PR DESCRIPTION
# Why

The emoji was not showing up in the title of this issue report, perhaps due to not having double quotes. This PR adds double quotes in an effort to get the emoji to render.