### PR TITLE
[docs] add redirect to deploy script

### DIFF
--- a/docs/common/error-utilities.ts
+++ b/docs/common/error-utilities.ts
@@ -217,16 +217,4 @@ const RENAMED_PAGES: Record<string, string> = {
 
   // updates
   '/guides/configuring-ota-updates/': '/guides/configuring-updates/',
-
-  // Rename of clients -> development
-  // should be temporary until https://github.com/expo/expo/pull/15201 lands
-  '/clients/compatibility/': '/development/compatibility/',
-  '/clients/development-workflows/': '/development/development-workflows/',
-  '/clients/eas-build/': '/development/eas-build/',
-  '/clients/extending-the-dev-menu/': '/development/extending-the-dev-menu/',
-  '/clients/getting-started/': '/development/getting-started/',
-  '/clients/installation/': '/development/installation/',
-  '/clients/introduction/': '/development/introduction/',
-  '/clients/troubleshooting/': '/development/troubleshooting/',
-  '/clients/upgrading/': '/development/upgrading/',
 };

--- a/docs/deploy.sh
+++ b/docs/deploy.sh
@@ -99,7 +99,15 @@ redirects[distribution/turtle-cli]=classic/turtle-cli/
 redirects[distribution/app-signing]=app-signing/app-credentials/
 redirects[guides/adhoc-builds]=archived/adhoc-builds/
 # clients is now development
-redirects[clients]=development/
+redirects[clients/compatibility]=development/compatibility/
+redirects[clients/development-workflows]=development/development-workflows/
+redirects[clients/eas-build]=development/eas-build/
+redirects[clients/extending-the-dev-menu]=development/extending-the-dev-menu/
+redirects[clients/getting-started]=development/getting-started/
+redirects[clients/installation]=development/installation/
+redirects[clients/introduction]=development/introduction/
+redirects[clients/troubleshooting]=development/troubleshooting/
+redirects[clients/upgrading]=development/upgrading/
 
 echo "::group::[5/6] Add custom redirects"
 for i in "${!redirects[@]}" # iterate over keys

--- a/docs/deploy.sh
+++ b/docs/deploy.sh
@@ -98,6 +98,8 @@ redirects[distribution/webhooks]=build-reference/build-webhook/
 redirects[distribution/turtle-cli]=classic/turtle-cli/
 redirects[distribution/app-signing]=app-signing/app-credentials/
 redirects[guides/adhoc-builds]=archived/adhoc-builds/
+# clients is now development
+redirects[clients]=development/
 
 echo "::group::[5/6] Add custom redirects"
 for i in "${!redirects[@]}" # iterate over keys


### PR DESCRIPTION
Adds a redirect from the clients route to the new development route, since we moved the expo-dev-client routes from /clients to /development.