### PR TITLE
[tools] Fix prompt options when choosing the version to publish

### DIFF
--- a/tools/src/publish-packages/tasks/resolveReleaseTypeAndVersion.ts
+++ b/tools/src/publish-packages/tasks/resolveReleaseTypeAndVersion.ts
@@ -26,19 +26,26 @@ export const resolveReleaseTypeAndVersion = new Task<TaskArgs>(
         highestReleaseTypeReducer,
         ReleaseType.PATCH
       );
+      const allVersions = pkgView?.versions ?? [];
 
       // Make it a prerelease version if `--prerelease` was passed and assign to the state.
       state.releaseType = prerelease
         ? (('pre' + highestReleaseType) as ReleaseType)
         : highestReleaseType;
 
-      // Calculate version to should bump to.
-      state.releaseVersion = resolveSuggestedVersion(
-        pkg.packageVersion,
-        pkgView?.versions ?? [],
-        state.releaseType,
-        prerelease
-      );
+      // If the version to bump is not published yet, then we do want to use it instead,
+      // no matter which release type is suggested.
+      if (allVersions.includes(pkg.packageVersion)) {
+        // Calculate version that we should bump to.
+        state.releaseVersion = resolveSuggestedVersion(
+          pkg.packageVersion,
+          allVersions,
+          state.releaseType,
+          prerelease
+        );
+      } else {
+        state.releaseVersion = pkg.packageVersion;
+      }
     }
   }
 );
@@ -46,19 +53,12 @@ export const resolveReleaseTypeAndVersion = new Task<TaskArgs>(
 /**
  * Returns suggested version based on given current version, already published versions and suggested release type.
  */
-function resolveSuggestedVersion(
+export function resolveSuggestedVersion(
   versionToBump: string,
   otherVersions: string[],
   releaseType: ReleaseType,
   prereleaseIdentifier?: string | null
 ): string {
-  // If the version to bump is not published yet, then we do want to use it instead,
-  // no matter which release type is suggested.
-  // TODO: do we need to make an exception for prerelease versions?
-  if (!otherVersions.includes(versionToBump) && semver.valid(versionToBump)) {
-    return versionToBump;
-  }
-
   const targetPrereleaseIdentifier = prereleaseIdentifier ?? getPrereleaseIdentifier(versionToBump);
 
   // Higher version might have already been published from another place,

--- a/tools/src/publish-packages/tasks/selectPackagesToPublish.ts
+++ b/tools/src/publish-packages/tasks/selectPackagesToPublish.ts
@@ -1,13 +1,16 @@
 import chalk from 'chalk';
 import inquirer from 'inquirer';
-import semver, { ReleaseType } from 'semver';
+import semver from 'semver';
 
 import logger from '../../Logger';
 import { Task } from '../../TasksRunner';
 import { printPackageParcel } from '../helpers';
-import { CommandOptions, Parcel, TaskArgs } from '../types';
+import { CommandOptions, Parcel, ReleaseType, TaskArgs } from '../types';
 import { findUnpublished } from './findUnpublished';
-import { resolveReleaseTypeAndVersion } from './resolveReleaseTypeAndVersion';
+import {
+  resolveReleaseTypeAndVersion,
+  resolveSuggestedVersion,
+} from './resolveReleaseTypeAndVersion';
 
 const { green, cyan, red } = chalk;
 const CUSTOM_VERSION_CHOICE_VALUE = 'custom-version';
@@ -28,7 +31,7 @@ export const selectPackagesToPublish = new Task<TaskArgs>(
     for (const parcel of parcels) {
       printPackageParcel(parcel);
 
-      if (await selectPackageToPublishAsync(parcel)) {
+      if (await selectPackageToPublishAsync(parcel, options)) {
         newParcels.push(parcel);
       }
     }
@@ -44,7 +47,10 @@ export const selectPackagesToPublish = new Task<TaskArgs>(
  * Prompts the user to confirm whether the package should be published.
  * It immediately returns `true` if it's run on the CI.
  */
-async function selectPackageToPublishAsync(parcel: Parcel): Promise<boolean> {
+async function selectPackageToPublishAsync(
+  parcel: Parcel,
+  options: CommandOptions
+): Promise<boolean> {
   if (process.env.CI) {
     return true;
   }
@@ -60,7 +66,11 @@ async function selectPackageToPublishAsync(parcel: Parcel): Promise<boolean> {
     },
   ]);
   if (!selected) {
-    const incrementedVersions = incrementVersion(parcel.pkg.packageVersion);
+    const incrementedVersions = incrementVersion(
+      parcel.pkg.packageVersion,
+      parcel.pkgView?.versions ?? [],
+      options.prerelease === true ? 'rc' : options.prerelease || null
+    );
     const { version, customVersion } = await inquirer.prompt([
       {
         type: 'list',
@@ -107,10 +117,19 @@ async function selectPackageToPublishAsync(parcel: Parcel): Promise<boolean> {
 /**
  * Creates an object with possible incrementations of given version.
  */
-function incrementVersion(version: string): Record<string, string> {
-  const releaseTypes: ReleaseType[] = ['major', 'minor', 'patch'];
+function incrementVersion(
+  version: string,
+  otherVersions: string[],
+  prerelease?: string | null
+): Record<string, string> {
+  const releaseTypes: ReleaseType[] = [ReleaseType.MAJOR, ReleaseType.MINOR, ReleaseType.PATCH];
+
+  // Add more options for prerelease versions
+  if (prerelease) {
+    releaseTypes.push(ReleaseType.PREMAJOR, ReleaseType.PREMINOR, ReleaseType.PREPATCH);
+  }
   return releaseTypes.reduce((acc, type) => {
-    acc[type] = semver.inc(version, type);
+    acc[type] = resolveSuggestedVersion(version, otherVersions, type, prerelease);
     return acc;
   }, {});
 }


### PR DESCRIPTION
# Why

It became usual that versions in package jsons on master are lower than on the release branches. Status right now:
- `expo-modules-core` is `0.4.2` on master branch
- `expo-modules-core` is `0.4.8` on sdk-43 branch

Now, if we want to do the release from master, the publish script would correctly suggest to publish it as `0.5.0` (because there are new features), but when we reject the suggestion, we'll be prompted with possible other version for major/minor/patch/custom updates. Those versions don't take into account that situation, so for the patch release it would show `0.4.3` version, even though it was already published from the release branch, causing the script to fail at next step.

# How

Resolving prompt options to take into account already published versions.

# Test Plan

`et publish expo-modules-core --dry` suggests to publish changes as `0.5.0`, but when I say "no", I'll get the following options: `1.0.0`, `0.5.0` and `0.4.9` (previously `0.4.3` which is just the current version incremented by one patch).
