### PR TITLE
[docs] "JavaScript inspector" wording consistency

### DIFF
--- a/docs/pages/guides/using-hermes.md
+++ b/docs/pages/guides/using-hermes.md
@@ -122,14 +122,14 @@ Please note that the Hermes bytecode format may change between different version
 
 ## JavaScript inspector for Hermes
 
-To debug JavaScript code running with Hermes, you can start your project with `expo start` then press `j` to open the inspector in Google Chrome or Microsoft Edge. _This is only supported for debug builds._
+To debug JavaScript code running with Hermes, you can start your project with `expo start` then press `j` to open the JavaScript inspector in Google Chrome or Microsoft Edge. _This is only supported for debug builds._
 
-Alternatively, you can use Hermes inspector with the following tools:
+Alternatively, you can use the JavaScript inspector from the following tools:
 
 - [Open Google Chrome DevTools manually](https://reactnative.dev/docs/hermes#debugging-js-on-hermes-using-google-chromes-devtools)
 - [Flipper](https://fbflipper.com/)
 
-> 💡 [Development builds](/development/introduction.md) built with `expo-dev-client` simplify this process by integrating directly with Hermes inspector.
+> 💡 [Development builds](/development/introduction.md) built with `expo-dev-client` simplify this process by integrating directly with the JavaScript inspector in Hermes.
 
 ## Limitations
 


### PR DESCRIPTION
Minor wording tweaks to make it clear that all of these approaches are for the exact same thing: debugging JavaScript running under the Hermes engine.

# Why

Previous wording left the reader wondering if there were multiple concepts being discussed here.

- Javascript inspector for Hermes
- Hermes inspector
- inspector in Chrome/Edge
- Hermes inspector with the following tools.

