### PR TITLE
[docs] Add temporary client-side redirect for dev clients

### DIFF
--- a/docs/common/error-utilities.ts
+++ b/docs/common/error-utilities.ts
@@ -217,4 +217,16 @@ const RENAMED_PAGES: Record<string, string> = {
 
   // updates
   '/guides/configuring-ota-updates/': '/guides/configuring-updates/',
+
+  // Rename of clients -> development
+  // should be temporary until https://github.com/expo/expo/pull/15201 lands
+  '/clients/compatibility/': '/development/compatibility/',
+  '/clients/development-workflows/': '/development/development-workflows/',
+  '/clients/eas-build/': '/development/eas-build/',
+  '/clients/extending-the-dev-menu/': '/development/extending-the-dev-menu/',
+  '/clients/getting-started/': '/development/getting-started/',
+  '/clients/installation/': '/development/installation/',
+  '/clients/introduction/': '/development/introduction/',
+  '/clients/troubleshooting/': '/development/troubleshooting/',
+  '/clients/upgrading/': '/development/upgrading/',
 };


### PR DESCRIPTION
# Why

It's broken now, and there is some stuff to discuss or add in #15201

# How

Added client-side redirects for these pages, it shouldn't change the indexed URLs but we want to go for client-side redirects asap. That should tell the crawlers that this was moved (302/301) instead of a 404 response (current response).

# Test Plan

Try https://docs.expo.dev/clients/getting-started

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
