### PR TITLE
[expo-updates][android] add ERROR_RECOVERY_ONLY config option

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Move persisted error log to EXUpdatesErrorRecovery on iOS. ([#14399](https://github.com/expo/expo/pull/14399) by [@esamelson](https://github.com/esamelson))
 - Add native EXUpdatesCheckOnLaunch: ERROR_RECOVERY_ONLY setting on iOS. ([#14673](https://github.com/expo/expo/pull/14673) by [@esamelson](https://github.com/esamelson))
 - Small fixes for error recovery manager on iOS. ([#15223](https://github.com/expo/expo/pull/15223) by [@esamelson](https://github.com/esamelson))
+- Add native checkOnLaunch: ERROR_RECOVERY_ONLY setting on Android. ([#15219](https://github.com/expo/expo/pull/15219) by [@esamelson](https://github.com/esamelson))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesConfiguration.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesConfiguration.kt
@@ -7,7 +7,7 @@ import android.util.Log
 
 class UpdatesConfiguration {
   enum class CheckAutomaticallyConfiguration {
-    NEVER, WIFI_ONLY, ALWAYS
+    NEVER, ERROR_RECOVERY_ONLY, WIFI_ONLY, ALWAYS
   }
 
   var isEnabled = false

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesUtils.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesUtils.kt
@@ -185,6 +185,8 @@ object UpdatesUtils {
     }
     return when (updatesConfiguration.checkOnLaunch) {
       CheckAutomaticallyConfiguration.NEVER -> false
+      // check will happen later on if there's an error
+      CheckAutomaticallyConfiguration.ERROR_RECOVERY_ONLY -> false
       CheckAutomaticallyConfiguration.WIFI_ONLY -> {
         val cm = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager?
         if (cm == null) {


### PR DESCRIPTION
# Why

ENG-2164 - Android PR 2/n

Android equivalent of https://github.com/expo/expo/pull/14673

# How

Add ERROR_RECOVERY_ONLY to the possible enum values.

# Test Plan

Tested manually along with later PRs in this stack. Confirmed that when `expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH` is set to `ERROR_RECOVERY_ONLY` in AndroidManifest.xml, updates are not automatically downloaded on launch (swipe closed and reopen the app 3-4 times, see the same update) but if an error is triggered shortly after launch, then the next time the app is opened it will be running the newest published update. 

# Todo

Document this new setting and update the config plugin to map app.json's `checkAutomatically: 'ON_ERROR_RECOVERY'` to this setting. (Will do this in a later PR)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
