### PR TITLE
[expo-modules-core][expo] add parameter to onDidCreateReactInstanceManager

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Add parameter to `ReactNativeHostHandler.onDidCreateReactInstanceManager` on Android. ([#15221](https://github.com/expo/expo/pull/15221) by [@esamelson](https://github.com/esamelson))
+
 ## 0.5.0 — 2021-11-17
 
 ### 🎉 New features

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/core/interfaces/ReactNativeHostHandler.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/core/interfaces/ReactNativeHostHandler.kt
@@ -59,7 +59,7 @@ interface ReactNativeHostHandler {
   /**
    * Callback after {@link ReactInstanceManager} creation
    */
-  fun onDidCreateReactInstanceManager(useDeveloperSupport: Boolean) {}
+  fun onDidCreateReactInstanceManager(reactInstanceManager: ReactInstanceManager, useDeveloperSupport: Boolean) {}
 
   //endregion
 }

--- a/packages/expo/android/src/main/java/expo/modules/ReactNativeHostWrapper.kt
+++ b/packages/expo/android/src/main/java/expo/modules/ReactNativeHostWrapper.kt
@@ -33,7 +33,7 @@ class ReactNativeHostWrapper(
       .firstOrNull() ?: super.createReactInstanceManager()
 
     reactNativeHostHandlers.forEach { handler ->
-      handler.onDidCreateReactInstanceManager(developerSupport)
+      handler.onDidCreateReactInstanceManager(result, developerSupport)
     }
 
     return result


### PR DESCRIPTION
# Why

ENG-2164 - Android PR 4/n

For expo-updates error recovery on Android, I am using the new `onDidCreateReactInstanceManager` callback 🎉 but I need access to the ReactInstanceManager object in order to use reflection to modify the exception handler. I could not find a way to access this object without passing it through as a parameter, but perhaps I am missing something 🤔 Open to other ideas than this if so!

# How

Add a parameter to the ReactNativeHostHandler method declaration and pass in the appropriate object.

# Test Plan

Tested as part of a later PR in this stack.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
