### PR TITLE
[expo-updates][android] hook up error recovery in rest of module

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - Add error recovery manager on Android. ([#15220](https://github.com/expo/expo/pull/15220) by [@esamelson](https://github.com/esamelson))
+- Hook up error recovery manager to rest of module on Android. ([#15222](https://github.com/expo/expo/pull/15222) by [@esamelson](https://github.com/esamelson))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.net.Uri
 import android.os.AsyncTask
 import android.os.Handler
-import android.os.HandlerThread
 import android.os.Looper
 import android.util.Log
 import com.facebook.react.ReactApplication

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.net.Uri
 import android.os.AsyncTask
 import android.os.Handler
+import android.os.HandlerThread
 import android.os.Looper
 import android.util.Log
 import com.facebook.react.ReactApplication
@@ -50,12 +51,14 @@ class UpdatesController private constructor(
 
   private var launcher: Launcher? = null
   val databaseHolder = DatabaseHolder(UpdatesDatabase.getInstance(context))
+
   // TODO: move away from DatabaseHolder pattern to Handler thread
   private val databaseHandlerThread = HandlerThread("expo-updates-database")
-  init {
+  private lateinit var databaseHandler: Handler
+  private fun initializeDatabaseHandler() {
     databaseHandlerThread.start()
+    databaseHandler = Handler(databaseHandlerThread.looper)
   }
-  private val databaseHandler = Handler(databaseHandlerThread.looper)
 
   private var loaderTask: LoaderTask? = null
   private var remoteLoadStatus = ErrorRecoveryDelegate.RemoteLoadStatus.IDLE
@@ -199,6 +202,7 @@ class UpdatesController private constructor(
       isEmergencyLaunch = true
     }
 
+    initializeDatabaseHandler()
     initializeErrorRecovery(context)
 
     val databaseLocal = getDatabase()

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesPackage.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesPackage.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.pm.PackageManager
 import android.util.Log
 import androidx.annotation.UiThread
+import com.facebook.react.ReactInstanceManager
 import expo.modules.core.ExportedModule
 import expo.modules.core.interfaces.Package
 import expo.modules.core.interfaces.InternalModule
@@ -38,6 +39,12 @@ class UpdatesPackage : Package {
       override fun onWillCreateReactInstanceManager(useDeveloperSupport: Boolean) {
         if (shouldAutoSetup(context) && !useDeveloperSupport) {
           UpdatesController.initialize(context)
+        }
+      }
+
+      override fun onDidCreateReactInstanceManager(reactInstanceManager: ReactInstanceManager, useDeveloperSupport: Boolean) {
+        if (shouldAutoSetup(context) && !useDeveloperSupport) {
+          UpdatesController.instance.onDidCreateReactInstanceManager(reactInstanceManager)
         }
       }
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/Converters.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/Converters.kt
@@ -67,31 +67,30 @@ class Converters {
     return bb.array()
   }
 
+  /**
+   * It's important that the integer values here stay constant across all versions of this library
+   * since they are stored in SQLite on user devices. (The nonconsecutive numbers are a historical
+   * artifact.)
+   */
   @TypeConverter
   fun intToStatus(value: Int): UpdateStatus {
     return when (value) {
-      0 -> UpdateStatus.FAILED
       1 -> UpdateStatus.READY
-      2 -> UpdateStatus.LAUNCHABLE
       3 -> UpdateStatus.PENDING
       5 -> UpdateStatus.EMBEDDED
       6 -> UpdateStatus.DEVELOPMENT
-      4 -> UpdateStatus.UNUSED
-      else -> UpdateStatus.UNUSED
+      else -> throw AssertionError("Invalid UpdateStatus value in database: $value")
     }
   }
 
   @TypeConverter
   fun statusToInt(status: UpdateStatus?): Int {
     return when (status) {
-      UpdateStatus.FAILED -> 0
       UpdateStatus.READY -> 1
-      UpdateStatus.LAUNCHABLE -> 2
       UpdateStatus.PENDING -> 3
       UpdateStatus.EMBEDDED -> 5
       UpdateStatus.DEVELOPMENT -> 6
-      UpdateStatus.UNUSED -> 4
-      else -> 4
+      else -> throw AssertionError("Invalid UpdateStatus value: $status")
     }
   }
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/enums/UpdateStatus.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/enums/UpdateStatus.kt
@@ -1,5 +1,29 @@
 package expo.modules.updates.db.enums
 
+/**
+ * Download status that indicates whether or under what conditions an
+ * update is able to be launched.
+ */
 enum class UpdateStatus {
-  FAILED, READY, LAUNCHABLE, PENDING, UNUSED, EMBEDDED, DEVELOPMENT
+  /**
+   * The update has been fully downloaded and is ready to launch.
+   */
+  READY,
+  /**
+   * The update manifest has been download from the server but not all assets have finished
+   * downloading successfully.
+   */
+  PENDING,
+  /**
+   * The update has been partially loaded (copied) from its location embedded in the app bundle, but
+   * not all assets have been copied successfully. The update may be able to be launched directly
+   * from its embedded location unless a new binary version with a new embedded update has been
+   * installed.
+   */
+  EMBEDDED,
+  /**
+   * The update manifest has been downloaded and indicates that the update is being served from a
+   * developer tool. It can be launched by a host application that can run a development bundle.
+   */
+  DEVELOPMENT
 }


### PR DESCRIPTION
# Why

ENG-2164 - Android PR 5/5 (for now)

Android equivalent of #14398

This PR essentially adds the rest of the miscellaneous changes needed to hook up the error recovery manager added in #15220 to the rest of the module and have it behave properly.

# How

Essentially replicated the diff from #14398; created and implemented the ErrorRecoveryDelegate inside of UpdatesController, and added a few bits of functionality in other places where needed.

I think we should move away from the DatabaseHolder (simple lock) way of restricting database access to a Handler-based strategy, more similar to the dispatch queues on iOS. For now I added a DatabaseHandlerThread and post to it in a couple places to avoid trying to acquire the database lock from the error recovery handler thread, along with a TODO to migrate the rest of the database usage at some point in the future.

Also removed some unused UpdateStatus values and added docblocks analogous to those on iOS.

# Test Plan

Did some manual testing to ensure that all the delegate methods behaved correctly in as many situations as possible. Tested the following scenarios (outcomes in parens):

- Error before content has appeared, new update is available (wait for download and reload)
- Error after content has appeared, new update is available (wait for download and then crash)
- Error before content has appeared, no new update but an older working update is available (reload with older update)
- "Fix" update and relaunch after above (older update still launches, the newer one is marked as "failed" since it didn't make it to the first render)
- Error after content has appeared, no new update but an older working update is available (crash, don't want to revert since content has appeared)
- Relaunch after above (same update appears since it made it to the first render once)
- Error before content has appeared, no newer or older update is available (crash, then try again to check for updates on the next launch)
- Error after content has appeared, no newer or older update is available (crash, then keep using the same update on future launches)
- Error before content has appeared, no other update is available, and checkOnLaunch is set to `NEVER` (crash, then revert to "emergency launch" of embedded bundle on the next launch)
- Error before content has appeared, new update is available but there's no internet connectivity (crash, but check & wait for updates on future launches with connectivity)
- Error after content has appeared, new update is available but there's no internet connectivity (crash, future launches use the same update since it made it to the first render)

To simulate an error before content has appeared, I added an invalid char to the JS bundle so it would fail to parse. To simulate an error after content has appeared, I added a button that would call a nonexistent function.

# Todos

Add documentation for this feature

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
