### PR TITLE
[expo-updates] small fixes for iOS error recovery manager

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Hook up error recovery manager to rest of module on iOS. ([#14398](https://github.com/expo/expo/pull/14398) by [@esamelson](https://github.com/esamelson))
 - Move persisted error log to EXUpdatesErrorRecovery on iOS. ([#14399](https://github.com/expo/expo/pull/14399) by [@esamelson](https://github.com/esamelson))
 - Add native EXUpdatesCheckOnLaunch: ERROR_RECOVERY_ONLY setting on iOS. ([#14673](https://github.com/expo/expo/pull/14673) by [@esamelson](https://github.com/esamelson))
+- Small fixes for error recovery manager on iOS. ([#15223](https://github.com/expo/expo/pull/15223) by [@esamelson](https://github.com/esamelson))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesAppController.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesAppController.m
@@ -238,6 +238,9 @@ static NSString * const EXUpdatesErrorEventName = @"error";
 
 - (void)appLoaderTask:(EXUpdatesAppLoaderTask *)appLoaderTask didFinishWithLauncher:(id<EXUpdatesAppLauncher>)launcher isUpToDate:(BOOL)isUpToDate
 {
+  if (_remoteLoadStatus == EXUpdatesRemoteLoadStatusLoading && isUpToDate) {
+    _remoteLoadStatus = EXUpdatesRemoteLoadStatusIdle;
+  }
   _launcher = launcher;
   if (self->_delegate) {
     [EXUpdatesUtils runBlockOnMainThread:^{

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesAppController.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesAppController.m
@@ -238,6 +238,8 @@ static NSString * const EXUpdatesErrorEventName = @"error";
 
 - (void)appLoaderTask:(EXUpdatesAppLoaderTask *)appLoaderTask didFinishWithLauncher:(id<EXUpdatesAppLauncher>)launcher isUpToDate:(BOOL)isUpToDate
 {
+  // if isUpToDate is false, that means a remote update is still loading in the background (this
+  // method was called with a cached update because the timer ran out) so don't update the status
   if (_remoteLoadStatus == EXUpdatesRemoteLoadStatusLoading && isUpToDate) {
     _remoteLoadStatus = EXUpdatesRemoteLoadStatusIdle;
   }

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesErrorRecovery.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesErrorRecovery.m
@@ -153,15 +153,15 @@ static NSInteger const EXUpdatesErrorRecoveryRemoteLoadTimeoutMs = 5000;
     if (_delegate.remoteLoadStatus != EXUpdatesRemoteLoadStatusLoading) {
       [_delegate loadRemoteUpdate];
     }
-      dispatch_after(dispatch_time(DISPATCH_TIME_NOW, _remoteLoadTimeout * NSEC_PER_MSEC), _errorRecoveryQueue, ^{
-        if (!self->_isWaitingForRemoteUpdate) {
-          return;
-        }
-        self->_isWaitingForRemoteUpdate = NO;
-        [self->_pipeline removeObject:@(EXUpdatesErrorRecoveryTaskLaunchNew)];
-        [self _runNextTask];
-      });
-      return;
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, _remoteLoadTimeout * NSEC_PER_MSEC), _errorRecoveryQueue, ^{
+      if (!self->_isWaitingForRemoteUpdate) {
+        return;
+      }
+      self->_isWaitingForRemoteUpdate = NO;
+      [self->_pipeline removeObject:@(EXUpdatesErrorRecoveryTaskLaunchNew)];
+      [self _runNextTask];
+    });
+    return;
   } else {
     // there's no remote update, so move to the next step in the pipeline
     [self->_pipeline removeObject:@(EXUpdatesErrorRecoveryTaskLaunchNew)];

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesErrorRecovery.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesErrorRecovery.m
@@ -145,22 +145,23 @@ static NSInteger const EXUpdatesErrorRecoveryRemoteLoadTimeoutMs = 5000;
 - (void)_waitForRemoteLoaderToFinish
 {
   dispatch_assert_queue(_errorRecoveryQueue);
-  if (_delegate.remoteLoadStatus == EXUpdatesRemoteLoadStatusLoading) {
-    _isWaitingForRemoteUpdate = YES;
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, _remoteLoadTimeout * NSEC_PER_MSEC), _errorRecoveryQueue, ^{
-      if (!self->_isWaitingForRemoteUpdate) {
-        return;
-      }
-      self->_isWaitingForRemoteUpdate = NO;
-      [self->_pipeline removeObject:@(EXUpdatesErrorRecoveryTaskLaunchNew)];
-      [self _runNextTask];
-    });
-    return;
-  } else if (_delegate.remoteLoadStatus == EXUpdatesRemoteLoadStatusNewUpdateLoaded) {
+  if (_delegate.remoteLoadStatus == EXUpdatesRemoteLoadStatusNewUpdateLoaded) {
     [self _runNextTask];
-  } else if (_delegate.config.checkOnLaunch != EXUpdatesCheckAutomaticallyConfigNever) {
+  } else if (_delegate.config.checkOnLaunch != EXUpdatesCheckAutomaticallyConfigNever ||
+             _delegate.remoteLoadStatus == EXUpdatesRemoteLoadStatusLoading) {
     _isWaitingForRemoteUpdate = YES;
-    [_delegate loadRemoteUpdate];
+    if (_delegate.remoteLoadStatus != EXUpdatesRemoteLoadStatusLoading) {
+      [_delegate loadRemoteUpdate];
+    }
+      dispatch_after(dispatch_time(DISPATCH_TIME_NOW, _remoteLoadTimeout * NSEC_PER_MSEC), _errorRecoveryQueue, ^{
+        if (!self->_isWaitingForRemoteUpdate) {
+          return;
+        }
+        self->_isWaitingForRemoteUpdate = NO;
+        [self->_pipeline removeObject:@(EXUpdatesErrorRecoveryTaskLaunchNew)];
+        [self _runNextTask];
+      });
+      return;
   } else {
     // there's no remote update, so move to the next step in the pipeline
     [self->_pipeline removeObject:@(EXUpdatesErrorRecoveryTaskLaunchNew)];

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesErrorRecovery.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesErrorRecovery.m
@@ -253,10 +253,9 @@ static NSInteger const EXUpdatesErrorRecoveryRemoteLoadTimeoutMs = 5000;
       return obj.integerValue == EXUpdatesErrorRecoveryTaskWaitForRemoteUpdate || obj.integerValue == EXUpdatesErrorRecoveryTaskCrash;
     }]].mutableCopy;
   });
-  // wait 10s before unsetting error handlers; even though we won't try to
-  // relaunch if our handlers are triggered after now, we still want to give
-  // the EXUpdatesErrorRecoveryTaskWaitForRemoteUpdate task a reasonable
-  // window of time to start and check for a new update is there is one
+  // wait 10s before unsetting error handlers; even though we won't try to relaunch if our handlers
+  // are triggered after now, we still want to give the app a reasonable window of time to start the
+  // EXUpdatesErrorRecoveryTaskWaitForRemoteUpdate task and check for a new update is there is one
   dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 10 * NSEC_PER_SEC), _errorRecoveryQueue, ^{
     [self _unsetRCTErrorHandlers];
   });

--- a/packages/expo-updates/ios/Tests/EXUpdatesErrorRecoveryTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesErrorRecoveryTests.m
@@ -60,6 +60,24 @@
   [verify(mockDelegate) throwException:anything()];
 }
 
+- (void)testHandleError_NewUpdateLoaded_RelaunchFails
+{
+  id<EXUpdatesErrorRecoveryDelegate> mockDelegate = mockProtocol(@protocol(EXUpdatesErrorRecoveryDelegate));
+  _errorRecovery.delegate = mockDelegate;
+
+  [given(mockDelegate.remoteLoadStatus) willReturnInteger:EXUpdatesRemoteLoadStatusNewUpdateLoaded];
+
+  NSError *mockError = mock([NSError class]);
+  [_errorRecovery handleError:mockError];
+  dispatch_sync(_testQueue, ^{}); // flush queue
+
+  [verify(mockDelegate) markFailedLaunchForLaunchedUpdate];
+  [self verifyFailedRelaunchWithCompletion_WithMockDelegate:mockDelegate];
+  [verifyCount(mockDelegate, never()) relaunchWithCompletion:(id)anything()];
+  [verifyCount(mockDelegate, never()) loadRemoteUpdate];
+  [verify(mockDelegate) throwException:anything()];
+}
+
 - (void)testHandleError_NewWorkingUpdateLoading
 {
   id<EXUpdatesErrorRecoveryDelegate> mockDelegate = mockProtocol(@protocol(EXUpdatesErrorRecoveryDelegate));


### PR DESCRIPTION
# Why

Fixes for a few small issues I found while reimplementing the iOS logic on Android

# How

By commit

1. If we instruct the error recovery delegate to try to load a new update, make sure we set the timeout in this case as well (previously we only set the timeout in the case where the delegate was already loading a new update).
2. Clarify wording on this comment
3. If the initial update check finishes before the app is launched (e.g. if fallbackToCacheTimeout > 0) update the delegate status correctly so the error recovery manager doesn't think a remote load is still in progress.
4. Add a missing test case

# Test Plan

Unit tests pass

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
