### PR TITLE
[updates] Add error when entrypoint file is not found

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -27,6 +27,7 @@
 
 ### 💡 Others
 
+- Add error when entryfile is not found in expo-updates scripts. ([#15234](https://github.com/expo/expo/pull/15234) by [@AamuLumi](https://github.com/AamuLumi))
 - Update `@expo/config` and `@expo/metro-config` dependencies. ([#14801](https://github.com/expo/expo/pull/14801) by [@Simek](https://github.com/Simek))
 - Refactor and unify Loader classes on Android. ([#14334](https://github.com/expo/expo/pull/14334) by [@esamelson](https://github.com/esamelson))
 - Kotlinize expo-updates. ([#14818](https://github.com/expo/expo/pull/14334) by [@wschurman](https://github.com/wschurman))

--- a/packages/expo-updates/scripts/createManifest.js
+++ b/packages/expo-updates/scripts/createManifest.js
@@ -18,6 +18,8 @@ const filterPlatformAssetScales = require('./filterPlatformAssetScales');
     projectRoot = path.resolve(possibleProjectRoot);
   } else if (fs.existsSync(path.join(possibleProjectRoot, '..', entryFile))) {
     projectRoot = path.resolve(possibleProjectRoot, '..');
+  } else {
+    throw new Error('Error loading application entrypoint. If your entrypoint is not index.js, please set ENTRY_FILE environment variable with your app entrypoint.')
   }
 
   process.chdir(projectRoot);


### PR DESCRIPTION
# Why

Having a bad entrypoint is currently hard to debug during the compilation. Adding an understandable error will help developers to setup correctly their projects with special entrypoints.

An issue with reproducible repository is open [here](https://github.com/expo/expo/issues/15232).

# How

This error happened when `projectRoot` is `undefined`. The cause is the condition with the `else` case uncovered, leading to a crash at [this line](https://github.com/expo/expo/blob/ad28204781a0555e471f231b80dcb2d88a337433/packages/expo-updates/scripts/createManifest.js#L23).

# Test Plan

Use [this repository](https://github.com/AamuLumi/expo-entryFile-crash) with the updated code. You will get the new error instead of `The "directory" argument must be of type string. Received undefined`.
