### PR TITLE
[expo-linear-gradient] don't import normalizeColor from react-native-web source

### DIFF
--- a/packages/expo-linear-gradient/src/NativeLinearGradient.web.tsx
+++ b/packages/expo-linear-gradient/src/NativeLinearGradient.web.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { LayoutRectangle, View } from 'react-native';
-import normalizeColor from 'react-native-web/src/modules/normalizeColor';
+import normalizeColor from 'react-native-web/dist/cjs/modules/normalizeColor';
 
 import { NativeLinearGradientPoint, NativeLinearGradientProps } from './NativeLinearGradient.types';
 


### PR DESCRIPTION
To avoid compilation problems and to standardize the way react-native-web modules are included.

In the same way we have on this recent file,
https://github.com/expo/expo/blob/5290f1e1bce92297678578d33e7971e2ea9b7497/packages/expo-system-ui/src/ExpoSystemUI.web.ts#L3


```
import normalizeColor from 'react-native-web/dist/cjs/modules/normalizeColor';
```