### PR TITLE
[sweet][kotlin] Handle `Unit` as a return type

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/KPromiseWrapper.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/KPromiseWrapper.kt
@@ -10,6 +10,7 @@ class KPromiseWrapper(
   override fun resolve(value: Any?) {
     bridgePromise.resolve(
       when (value) {
+        is Unit -> null
         is Bundle -> Arguments.fromBundle(value as Bundle?)
         is List<*> -> Arguments.fromList(value as List<*>?)
         else -> value

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/KPromiseWrapperTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/KPromiseWrapperTest.kt
@@ -1,0 +1,22 @@
+package expo.modules.kotlin
+
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Test
+
+class KPromiseWrapperTest {
+  @Test
+  fun `should convert Unit to null`() {
+    val bridgePromiseMock = mockk<com.facebook.react.bridge.Promise>().apply {
+      every { resolve(any()) } returns Unit
+    }
+    val promise = KPromiseWrapper(mockk())
+
+    promise.resolve(Unit)
+
+    verify { bridgePromiseMock.resolve(null) }
+    confirmVerified(bridgePromiseMock)
+  }
+}

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/KPromiseWrapperTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/KPromiseWrapperTest.kt
@@ -12,7 +12,7 @@ class KPromiseWrapperTest {
     val bridgePromiseMock = mockk<com.facebook.react.bridge.Promise>().apply {
       every { resolve(any()) } returns Unit
     }
-    val promise = KPromiseWrapper(mockk())
+    val promise = KPromiseWrapper(bridgePromiseMock)
 
     promise.resolve(Unit)
 


### PR DESCRIPTION
# Why

Handles `Unit` as return types. 

# How

I want to enable structure like this:
```
function("f") {
	print("Hello")
}
```
currently, it isn't supported because this function returns `Unit` and RN can't transform it through the bridge. 
So I've added a simple instruction that converts every Unit into null.
# Test Plan

- unit-tests ✅
