### PR TITLE
[core][ios] Make the no-argument module initializer unavailable

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### 💡 Others
 
 - Add parameter to `ReactNativeHostHandler.onDidCreateReactInstanceManager` on Android. ([#15221](https://github.com/expo/expo/pull/15221) by [@esamelson](https://github.com/esamelson))
-- Make the no-argument module initializer unavailable — `onCreate` definition component should be used instead.
+- Make the no-argument module initializer unavailable — `onCreate` definition component should be used instead. ([#15262](https://github.com/expo/expo/pull/15262) by [@tsapeta](https://github.com/tsapeta))
 
 ## 0.5.0 — 2021-11-17
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 💡 Others
 
 - Add parameter to `ReactNativeHostHandler.onDidCreateReactInstanceManager` on Android. ([#15221](https://github.com/expo/expo/pull/15221) by [@esamelson](https://github.com/esamelson))
+- Make the no-argument module initializer unavailable — `onCreate` definition component should be used instead.
 
 ## 0.5.0 — 2021-11-17
 

--- a/packages/expo-modules-core/ios/Swift/Modules/Module.swift
+++ b/packages/expo-modules-core/ios/Swift/Modules/Module.swift
@@ -1,3 +1,4 @@
+// Copyright 2021-present 650 Industries. All rights reserved.
 
 /**
  `BaseModule` is just a stub class that fulfils `AnyModule` protocol requirement of public default initializer,
@@ -6,6 +7,9 @@
  */
 open class BaseModule {
   public private(set) weak var appContext: AppContext?
+
+  @available(*, unavailable, message: "Module's initializer cannot be overriden, use \"onCreate\" definition component instead.")
+  public init() {}
 
   required public init(appContext: AppContext) {
     self.appContext = appContext


### PR DESCRIPTION
# Why

Make `init` unavailable so no one is tempted to override it. `onCreate` should be used instead.

# How

Added `@available` attribute to module's `init()`

# Test Plan

We don't use this init, so nothing can break. I tried overriding the initializer and got Xcode error, as expected.