### PR TITLE
[core][ios] Lazy loading module constants

### DIFF
--- a/packages/expo-modules-core/ios/Swift/ModuleHolder.swift
+++ b/packages/expo-modules-core/ios/Swift/ModuleHolder.swift
@@ -38,6 +38,17 @@ public final class ModuleHolder {
     post(event: .moduleCreate)
   }
 
+  // MARK: Constants
+
+  /**
+   Merges all `constants` definitions into one dictionary.
+   */
+  func getConstants() -> [String: Any?] {
+    return definition.constants.reduce(into: [String: Any?]()) { dict, definition in
+      dict.merge(definition.body()) { $1 }
+    }
+  }
+
   // MARK: Calling functions
 
   func call(function functionName: String, args: [Any], promise: Promise) {

--- a/packages/expo-modules-core/ios/Swift/Modules/ModuleDefinition.swift
+++ b/packages/expo-modules-core/ios/Swift/Modules/ModuleDefinition.swift
@@ -21,7 +21,7 @@ public final class ModuleDefinition: AnyDefinition {
   var name: String
 
   let functions: [String : AnyFunction]
-  let constants: [String : Any?]
+  let constants: [ConstantsDefinition]
   let eventListeners: [EventListener]
   let viewManager: ViewManagerDefinition?
 
@@ -45,11 +45,7 @@ public final class ModuleDefinition: AnyDefinition {
         dict[function.name] = function
       }
 
-    self.constants = definitions
-      .compactMap { $0 as? ConstantsDefinition }
-      .reduce(into: [String : Any?]()) { dict, definition in
-        dict.merge(definition.constants) { $1 }
-      }
+    self.constants = definitions.compactMap { $0 as? ConstantsDefinition }
 
     self.eventListeners = definitions.compactMap { $0 as? EventListener }
 
@@ -90,7 +86,7 @@ internal struct ModuleNameDefinition: AnyDefinition {
  A definition for module's constants. Returned by `constants(() -> SomeType)` in module's definition.
  */
 internal struct ConstantsDefinition: AnyDefinition {
-  let constants: [String : Any?]
+  let body: () -> [String: Any?]
 }
 
 /**

--- a/packages/expo-modules-core/ios/Swift/Modules/ModuleDefinitionComponents.swift
+++ b/packages/expo-modules-core/ios/Swift/Modules/ModuleDefinitionComponents.swift
@@ -21,8 +21,15 @@ extension AnyModule {
   /**
    Definition function setting the module's constants to export.
    */
-  public func constants(_ closure: () -> [String : Any?]) -> AnyDefinition {
-    return ConstantsDefinition(constants: closure())
+  public func constants(_ body: @escaping () -> [String: Any?]) -> AnyDefinition {
+    return ConstantsDefinition(body: body)
+  }
+
+  /**
+   Definition function setting the module's constants to export.
+   */
+  public func constants(_ body: @autoclosure @escaping () -> [String: Any?]) -> AnyDefinition {
+    return ConstantsDefinition(body: body)
   }
 
   // MARK: - Functions

--- a/packages/expo-modules-core/ios/Swift/SwiftInteropBridge.swift
+++ b/packages/expo-modules-core/ios/Swift/SwiftInteropBridge.swift
@@ -67,7 +67,7 @@ public final class SwiftInteropBridge: NSObject {
   @objc
   public func exportedModulesConstants() -> [String: Any] {
     return registry.reduce(into: [String: Any]()) { acc, holder in
-      acc[holder.name] = holder.definition.constants
+      acc[holder.name] = holder.getConstants()
     }
   }
 

--- a/packages/expo-modules-core/ios/Tests/ConstantsSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/ConstantsSpec.swift
@@ -1,0 +1,36 @@
+import Quick
+import Nimble
+
+@testable import ExpoModulesCore
+
+class ConstantsSpec: QuickSpec {
+  override func spec() {
+    let appContext = AppContext()
+
+    it("takes closure resolving to dictionary") {
+      let holder = mockModuleHolder(appContext) {
+        $0.constants {
+          return ["test": 123]
+        }
+      }
+      expect(holder.getConstants()["test"] as? Int) == 123
+    }
+
+    it("takes the dictionary") {
+      let holder = mockModuleHolder(appContext) {
+        $0.constants(["test": 123])
+      }
+      expect(holder.getConstants()["test"] as? Int) == 123
+    }
+
+    it("merges multiple constants definitions") {
+      let holder = mockModuleHolder(appContext) {
+        $0.constants(["test": 456, "test2": 789])
+        $0.constants(["test": 123])
+      }
+      let consts = holder.getConstants()
+      expect(consts["test"] as? Int) == 123
+      expect(consts["test2"] as? Int) == 789
+    }
+  }
+}


### PR DESCRIPTION
# Why

Module constants can actually be computed lazily and accept dictionaries (not only closure that returns dictionary)

# How

- `ConstantsDefinition` stores a closure returning the dictionary instead of already computed dictionary
- Added another `constants` component signature that takes the dictionary with `@autoclosure` attribute
- Added test spec for `constants` component

# Test Plan

New tests are passing
