### PR TITLE
[workspace] update Expo URLs in main readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <!-- Banner Image -->
 
 <p align="center">
-  <a href="https://expo.io/">
+  <a href="https://expo.dev/">
     <img alt="expo sdk" height="128" src="./.github/resources/banner.png">
     <h1 align="center">Expo</h1>
   </a>
@@ -11,7 +11,7 @@
    <a aria-label="SDK version" href="https://www.npmjs.com/package/expo" target="_blank">
     <img alt="Expo SDK version" src="https://img.shields.io/npm/v/expo.svg?style=flat-square&label=SDK&labelColor=000000&color=4630EB" />
   </a>
-  <a aria-label="Join our forums" href="https://forums.expo.io" target="_blank">
+  <a aria-label="Join our forums" href="https://forums.expo.dev" target="_blank">
     <img alt="Forums" src="https://img.shields.io/badge/Ask%20Questions%20-blue.svg?style=flat-square&logo=discourse&logoWidth=15&labelColor=000000&color=4630EB" />
   </a>
   <a aria-label="Join our Discord" href="https://discord.gg/4gtbPAdpaE" target="_blank">
@@ -26,16 +26,16 @@
 </p>
 
 <p align="center">
-  <a aria-label="try expo with snack" href="https://snack.expo.io"><b>Try Expo in the Browser</b></a>
+  <a aria-label="try expo with snack" href="https://snack.expo.dev"><b>Try Expo in the Browser</b></a>
  |
-  <a aria-label="expo documentation" href="https://docs.expo.io">Read the Documentation 📚</a>
+  <a aria-label="expo documentation" href="https://docs.expo.dev">Read the Documentation 📚</a>
 </p>
 
 <p>
   <a aria-label="Follow @expo on Twitter" href="https://twitter.com/intent/follow?screen_name=expo" target="_blank">
     <img  alt="Twitter: expo" src="https://img.shields.io/twitter/follow/expo.svg?style=flat-square&label=Follow%20%40expo&logo=TWITTER&logoColor=FFFFFF&labelColor=00aced&logoWidth=15&color=lightgray" target="_blank" />
   </a>
-  <a aria-label="Follow Expo on Medium" href="https://blog.expo.io">
+  <a aria-label="Follow Expo on Medium" href="https://blog.expo.dev">
     <img align="right" alt="Medium: exposition" src="https://img.shields.io/badge/Learn%20more%20on%20our%20blog-lightgray.svg?style=flat-square" target="_blank" />
   </a>
 </p>
@@ -52,21 +52,21 @@
 
 Expo is an open-source platform for making universal native apps that run on Android, iOS, and the web. It includes a universal runtime and libraries that let you build native apps by writing React and JavaScript. This repository is where the Expo client software is developed, and includes the client apps, modules, apps, and more. The [Expo CLI](https://github.com/expo/expo-cli) repository contains the Expo development tools.
 
-[Click here to view the Expo Community Guidelines](https://expo.io/guidelines). Thank you for helping keep the Expo community open and welcoming!
+[Click here to view the Expo Community Guidelines](https://expo.dev/guidelines). Thank you for helping keep the Expo community open and welcoming!
 
 ## 📚 Documentation
 
-<p>Learn about building and deploying universal apps <a aria-label="expo documentation" href="https://docs.expo.io">in our official docs!</a></p>
+<p>Learn about building and deploying universal apps <a aria-label="expo documentation" href="https://docs.expo.dev">in our official docs!</a></p>
 
-- [Getting Started](https://docs.expo.io/)
-- [API Reference](https://docs.expo.io/versions/latest/)
-- [Using Custom Native Modules](https://docs.expo.io/bare/exploring-bare-workflow/)
+- [Getting Started](https://docs.expo.dev/)
+- [API Reference](https://docs.expo.dev/versions/latest/)
+- [Using Custom Native Modules](https://docs.expo.dev/bare/exploring-bare-workflow/)
 
 ## 🗺 Project Layout
 
 - [`packages`](/packages) All the source code for the Unimodules, if you want to edit a library or just see how it works this is where you'll find it.
 - [`apps`](/apps) This is where you can find Expo projects which are linked to the development Unimodules. You'll do most of your testing in here.
-- [`docs`](/docs) The source code for **https://docs.expo.io**
+- [`docs`](/docs) The source code for **https://docs.expo.dev**
 - [`templates`](/templates) The template projects you get when you run `expo start`
 - [`react-native-lab`](/react-native-lab) This is our fork of `react-native`. We keep this very close to the upstream but sometimes need to add quick fixes locally before they can land.
 - [`guides`](/guides) In-depth tutorials for advanced topics like contributing to the client.
@@ -83,14 +83,14 @@ Expo is an open-source platform for making universal native apps that run on And
 Let everyone know your app can be run instantly in the _Expo Go_ app!
 <br/>
 
-[![runs with Expo Go](https://img.shields.io/badge/Runs%20with%20Expo%20Go-000.svg?style=flat-square&logo=EXPO&labelColor=f3f3f3&logoColor=000)](https://expo.io/client)
+[![runs with Expo Go](https://img.shields.io/badge/Runs%20with%20Expo%20Go-000.svg?style=flat-square&logo=EXPO&labelColor=f3f3f3&logoColor=000)](https://expo.dev/client)
 
-[![runs with Expo Go](https://img.shields.io/badge/Runs%20with%20Expo%20Go-4630EB.svg?style=flat-square&logo=EXPO&labelColor=f3f3f3&logoColor=000)](https://expo.io/client)
+[![runs with Expo Go](https://img.shields.io/badge/Runs%20with%20Expo%20Go-4630EB.svg?style=flat-square&logo=EXPO&labelColor=f3f3f3&logoColor=000)](https://expo.dev/client)
 
 ```md
-[![runs with Expo Go](https://img.shields.io/badge/Runs%20with%20Expo%20Go-000.svg?style=flat-square&logo=EXPO&labelColor=f3f3f3&logoColor=000)](https://expo.io/client)
+[![runs with Expo Go](https://img.shields.io/badge/Runs%20with%20Expo%20Go-000.svg?style=flat-square&logo=EXPO&labelColor=f3f3f3&logoColor=000)](https://expo.dev/client)
 
-[![runs with Expo Go](https://img.shields.io/badge/Runs%20with%20Expo%20Go-4630EB.svg?style=flat-square&logo=EXPO&labelColor=f3f3f3&logoColor=000)](https://expo.io/client)
+[![runs with Expo Go](https://img.shields.io/badge/Runs%20with%20Expo%20Go-4630EB.svg?style=flat-square&logo=EXPO&labelColor=f3f3f3&logoColor=000)](https://expo.dev/client)
 ```
 
 ## 👏 Contributing
@@ -99,13 +99,13 @@ If you like Expo and want to help make it better then check out our [contributin
 
 ## ❓ FAQ
 
-If you have questions about Expo and want answers, then check out our [Frequently Asked Questions](https://docs.expo.io/versions/latest/introduction/faq/)!
+If you have questions about Expo and want answers, then check out our [Frequently Asked Questions](https://docs.expo.dev/versions/latest/introduction/faq/)!
 
-If you still have questions you can ask them on our [forums](https://forums.expo.io) or on Twitter [@Expo](https://twitter.com/expo).
+If you still have questions you can ask them on our [forums](https://forums.expo.dev), [Discord](https://discord.gg/4gtbPAdpaE) or on Twitter [@Expo](https://twitter.com/expo).
 
 ## 💙 The Team
 
-Curious about who makes Expo? Here are our [team members](https://expo.io/about)!
+Curious about who makes Expo? Here are our [team members](https://expo.dev/about)!
 
 ## License
 


### PR DESCRIPTION
# Why

It looks like the main repository readme still uses the old Expo domain, let's fix it!

# How

Replace all occurrences of `expo.io` in URLs with `expo.dev`.

I have also added mention about Discord server in the FAQ section.

# Test Plan

Links worked as expected in the changes preview tab.

# Checklist

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
