### PR TITLE
[babel-preset-expo] allow passing in an importSource to underlying plugin

### DIFF
--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🎉 New features
 
+- Added option `jsxImportSource` to allow passing in a custom importSource ([#15275](https://github.com/expo/expo/pull/15275) by [@kbrandwijk](https://github.com/krandwijk))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🎉 New features
 
-- Added option `jsxImportSource` to allow passing in a custom importSource ([#15275](https://github.com/expo/expo/pull/15275) by [@kbrandwijk](https://github.com/krandwijk))
+- Added option `jsxImportSource` to allow passing in a custom importSource ([#15275](https://github.com/expo/expo/pull/15275) by [@kbrandwijk](https://github.com/kbrandwijk))
 
 ### 🐛 Bug fixes
 

--- a/packages/babel-preset-expo/README.md
+++ b/packages/babel-preset-expo/README.md
@@ -60,6 +60,24 @@ If the `bundler` is not defined, it will default to checking if a `babel-loader`
 
 This property is passed down to [`@babel/plugin-transform-react-jsx`](https://babeljs.io/docs/en/babel-plugin-transform-react-jsx). This flag does nothing when `native.useTransformReactJSXExperimental` is set to `true` because `@babel/plugin-transform-react-jsx` is omitted.
 
+### [`jsxImportSource`](https://babeljs.io/docs/en/babel-plugin-transform-react-jsx#importsource)
+
+`string`, defaults to `react`
+
+This option allows specifying a custom import source for importing functions. 
+
+```js
+[
+  'babel-preset-expo',
+  {
+    jsxRuntime: 'automatic',
+    importSource: 'react',
+  },
+];
+```
+
+This property is passed down to [`@babel/plugin-transform-react-jsx`](https://babeljs.io/docs/en/babel-plugin-transform-react-jsx). This options does nothing when `jsxRuntime` is not set to `automatic`.
+
 ### [`lazyImports`](https://babeljs.io/docs/en/babel-plugin-transform-modules-commonjs#lazy)
 
 Changes Babel's compiled `import` statements to be lazily evaluated when their imported bindings are used for the first time.

--- a/packages/babel-preset-expo/index.js
+++ b/packages/babel-preset-expo/index.js
@@ -45,7 +45,7 @@ module.exports = function (api, options = {}) {
       {
         // Defaults to `automatic`, pass in `classic` to disable auto JSX transformations.
         runtime: (options && options.jsxRuntime) || 'automatic',
-        importSource: (options && options.jsxImportSource) || 'react',
+        ...(options?.jsxRuntime !== 'classic') &&  { importSource: (options && options.jsxImportSource) || 'react' },
       },
     ]);
     // Purposefully not adding the deprecated packages:

--- a/packages/babel-preset-expo/index.js
+++ b/packages/babel-preset-expo/index.js
@@ -45,6 +45,7 @@ module.exports = function (api, options = {}) {
       {
         // Defaults to `automatic`, pass in `classic` to disable auto JSX transformations.
         runtime: (options && options.jsxRuntime) || 'automatic',
+        importSource: (options && options.jsxImportSource) || 'react',
       },
     ]);
     // Purposefully not adding the deprecated packages:

--- a/packages/babel-preset-expo/index.js
+++ b/packages/babel-preset-expo/index.js
@@ -45,7 +45,9 @@ module.exports = function (api, options = {}) {
       {
         // Defaults to `automatic`, pass in `classic` to disable auto JSX transformations.
         runtime: (options && options.jsxRuntime) || 'automatic',
-        ...(options?.jsxRuntime !== 'classic') &&  { importSource: (options && options.jsxImportSource) || 'react' },
+        ...(options?.jsxRuntime !== 'classic' && {
+          importSource: (options && options.jsxImportSource) || 'react',
+        }),
       },
     ]);
     // Purposefully not adding the deprecated packages:


### PR DESCRIPTION
# Why

Some libraries (such as `why-did-you-render`) require setting a custom importSource on the jsx plugin. This property is currently not exposed.

# How

In line with the naming of the `jsxRuntime` option that is passed through to `runtime`, I added a `jsxImportSource` option that is passed through to `importSource`

# Test Plan

I have tested that not passing in `jsxImportSource` doesn't change anything.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
