### PR TITLE
[core][ios] Make Foundation.URL a convertible type

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Made `Foundation.URL` a convertible type to consistently normalize file paths to file URLs.
+- Made `Foundation.URL` a convertible type to consistently normalize file paths to file URLs. ([#15278](https://github.com/expo/expo/pull/15278) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Made `Foundation.URL` a convertible type to consistently normalize file paths to file URLs.
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-modules-core/ios/Swift/Arguments/Convertibles.swift
+++ b/packages/expo-modules-core/ios/Swift/Arguments/Convertibles.swift
@@ -9,6 +9,20 @@ import CoreGraphics
 /// As an example, when the `CGPoint` type is used as an argument type, its instance can be
 /// created from an array of two doubles or an object with `x` and `y` fields.
 
+// MARK: - Foundation
+
+extension URL: ConvertibleArgument {
+  public static func convert(from value: Any?) throws -> Self {
+    if let uri = value as? String, let url = URL(string: uri) {
+      // `URL(string:)` is an optional init but it doesn't imply it's a valid URL,
+      // so here we don't check for the correctness of the URL.
+      // If it has no scheme, we assume it was the file path.
+      return url.scheme != nil ? url : URL(fileURLWithPath: uri)
+    }
+    throw Conversions.ConvertingError<URL>(value: value)
+  }
+}
+
 // MARK: - UIKit
 
 extension UIColor: ConvertibleArgument {

--- a/packages/expo-modules-core/ios/Tests/ConvertiblesSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/ConvertiblesSpec.swift
@@ -8,6 +8,40 @@ import Nimble
 
 class ConvertiblesSpec: QuickSpec {
   override func spec() {
+    describe("URL") {
+      it("converts from remote url") {
+        let remoteUrlString = "https://expo.dev"
+        let url = try URL.convert(from: remoteUrlString)
+
+        expect(url.path) == ""
+        expect(url.absoluteString) == remoteUrlString
+      }
+
+      it("converts from file url") {
+        let fileUrlString = "file:///expo/tmp"
+        let url = try URL.convert(from: fileUrlString)
+
+        expect(url.path) == "/expo/tmp"
+        expect(url.absoluteString) == fileUrlString
+        expect(url.isFileURL) == true
+      }
+
+      it("converts from file path") {
+        let filePath = "/expo/image.png"
+        let url = try URL.convert(from: filePath)
+
+        expect(url.path) == filePath
+        expect(url.absoluteString) == "file://\(filePath)"
+        expect(url.isFileURL) == true
+      }
+
+      it("throws when no string") {
+        expect { try URL.convert(from: 29.5) }.to(
+          throwError(errorType: Conversions.ConvertingError<URL>.self)
+        )
+      }
+    }
+
     describe("CGPoint") {
       let x = -8.3
       let y = 4.6


### PR DESCRIPTION
# Why

Some modules are trying to normalize file paths to file urls on their own (e.g. image manipulator), but it's not always consistent. Making `Foundation.URL` a convertible type will consistently normalize `/file/path` URI to `file:///file/path` URL.

# How

- Added extension to `URL` to make it conform to `ConvertibleArgument`
- Added unit tests

# Test Plan

Tests are passing + tested as part of #15277 
