### PR TITLE
[dev-client] Try to fix `java.net.BindException` in unit tests on CI

### DIFF
--- a/packages/expo-dev-launcher/android/src/test/java/expo/modules/devlauncher/launcher/manifest/DevLauncherManifestParserTest.kt
+++ b/packages/expo-dev-launcher/android/src/test/java/expo/modules/devlauncher/launcher/manifest/DevLauncherManifestParserTest.kt
@@ -20,7 +20,7 @@ internal class DevLauncherManifestParserTest {
 
   @Before
   fun setup() {
-    server.start(9090)
+    server.start()
   }
 
   @After

--- a/packages/expo-dev-menu/android/src/test/java/expo/modules/devmenu/helpers/DevMenuOkHttpExtensionTest.kt
+++ b/packages/expo-dev-menu/android/src/test/java/expo/modules/devmenu/helpers/DevMenuOkHttpExtensionTest.kt
@@ -22,7 +22,7 @@ internal class DevMenuOkHttpExtensionTest {
 
   @Before
   fun setup() {
-    server.start(9090)
+    server.start()
   }
 
   @After


### PR DESCRIPTION
# Why

Tries to fix:
```
java.net.BindException at DevLauncherManifestParserTest.kt:23
```

# How

According to the documentation of the start method:
````
Starts the server on the loopback interface for the given port.
Params:
port - the port to listen to, or 0 for any available port. Automated tests should always use port 0 to avoid flakiness when a specific port is unavailable. 
````
We shouldn't bind to the specific port. 

# Test Plan

- run unit tests locally ✅