### PR TITLE
[docs] First pass at documenting how to install multiple builds of the same app on a single device

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -88,6 +88,7 @@ const sections = [
       'Server infrastructure',
       'Troubleshooting build errors and crashes',
       'Running builds on your own infrastructure',
+      'Installing app variants on the same device',
       'Caching dependencies',
       'Build webhooks',
       'Configuration process',

--- a/docs/pages/build-reference/variants.md
+++ b/docs/pages/build-reference/variants.md
@@ -78,7 +78,7 @@ export default {
 
 > Note: if you are using any libraries that require you to register your application identifier with an external service to use the SDK, such as Google Maps, you will need to have a separate configuration for that API for the iOS Bundle Identifier and Android Package. You can also swap this configuration in using the same approach as above.
 
-To automatically set the `APP_VARIANT` environment variable, we can use `env` in **eas.json**:
+To automatically set the `APP_VARIANT` environment variable when running builds with the "development" profile, we can use `env` in **eas.json**:
 
 ```json
 {
@@ -94,7 +94,7 @@ To automatically set the `APP_VARIANT` environment variable, we can use `env` in
 }
 ```
 
-Now when you run `eas build --profile development`, the environment variable `APP_VARIANT` will be set to `"production"` when evaluating **app.config.js** both locally and on the EAS Build worker. When you start your development server, you will need to run `APP_VARIANT=development expo start` (or the platform equivalent if you use Windows); a shortcut for this could be to add a script to your **package.json** such as `"dev": "APP_VARIANT=development expo start"`.
+Now when you run `eas build --profile development`, the environment variable `APP_VARIANT` will be set to `"development"` when evaluating **app.config.js** both locally and on the EAS Build worker. When you start your development server, you will need to run `APP_VARIANT=development expo start` (or the platform equivalent if you use Windows); a shortcut for this could be to add a script to your **package.json** such as `"dev": "APP_VARIANT=development expo start"`.
 
 When you run `eas build --profile production` the `APP_VARIANT` variable environment will not be set, and the app will run as the production variant.
 

--- a/docs/pages/build-reference/variants.md
+++ b/docs/pages/build-reference/variants.md
@@ -1,0 +1,99 @@
+---
+title: Installing app variants on the same device
+---
+
+When creating [development, preview, and production builds](../eas-json.md#common-use-cases), it's common to want to install one of each build on your device at the same time. This allows you to do development work, preview the next version of your app, and run the production version all on the same device, without needing to uninstall and reinstall the app.
+
+In order to be able to have multiple instances of an app installed on your device, each instance must have a unique Application ID (Android) or Bundle Identifier (iOS).
+
+**If you have a bare project**, you can accomplish this using flavors (Android) and targets (iOS). You can then configure which flavor is used with the `gradleCommand` field on your build profile, and you can configure the target that is used with the `scheme` field for iOS. 
+
+**If you have a managed project**, this can be accomplished by using **app.config.js** and environment variables in **eas.json**.
+
+## Example: configuring development and production variants
+
+Let's say we wanted a development build and production build of our managed Expo project. Your **eas.json** might look like this:
+
+```json
+{
+  "build": {
+    "development": {
+      "developmentClient": true
+    },
+    "production": {}
+  }
+}
+```
+
+And your **app.json** might look like this:
+
+```json
+{
+  "expo": {
+    "name": "MyApp",
+    "slug": "my-app",
+    "ios": {
+      "bundleIdentifier": "com.myapp"
+    },
+    "android": {
+      "package": "com.myapp"
+    }
+  }
+}
+```
+
+Let's convert this to **app.config.js** so we can make it more dynamic:
+
+```json
+export default {
+  name: "MyApp",
+  slug: "my-app",
+  ios: {
+    bundleIdentifier: "com.myapp",
+  },
+  android: {
+    package: "com.myapp",
+  },
+};
+```
+
+Now let's switch out the iOS `bundleIdentifier` and Android `package` (which becomes the Application ID) based on the presence of an environment variable in **app.config.js**:
+
+```js
+const IS_PROD = process.env.APP_VARIANT === "production";
+
+export default {
+  // You can also switch out the app icon to more clearly differentiate the app
+  name: IS_PROD ? "MyApp" : "MyApp (Dev)",
+  slug: "my-app",
+  ios: {
+    bundleIdentifier: IS_PROD ? "com.myapp" : "com.myapp.dev",
+  },
+  android: {
+    package: IS_PROD ? "com.myapp" : "com.myapp.dev",
+  },
+};
+```
+
+> Note: if you are using any libraries that require you to register your application identifier with an external service to use the SDK, such as Google Maps, you will need to have a separate configuration for that API for the iOS Bundle Identifier and Android Package. You can also swap this configuration in using the same approach as above.
+
+To automatically set the `APP_VARIANT` environment variable, we can use `env` in **eas.json**:
+
+```json
+{
+  "build": {
+    "development": {
+      "developmentClient": true
+    },
+    "production": {
+      "env": {
+        "APP_VARIANT": "production"
+      }
+    }
+  }
+}
+```
+
+Now when you run `eas build --profile production` the `APP_VARIANT` environment variable will be set to `"production"` when evaluating **app.config.js** locally and on the EAS Build worker. [Learn more about environment variables on EAS Build](./variables.md).
+
+When you run `expo start` the `APP_VARIANT` variable environment will not be set, and the app will run as the development variant.

--- a/docs/pages/build-reference/variants.md
+++ b/docs/pages/build-reference/variants.md
@@ -6,7 +6,7 @@ When creating [development, preview, and production builds](../eas-json.md#commo
 
 In order to be able to have multiple instances of an app installed on your device, each instance must have a unique Application ID (Android) or Bundle Identifier (iOS).
 
-**If you have a bare project**, you can accomplish this using flavors (Android) and targets (iOS). You can then configure which flavor is used with the `gradleCommand` field on your build profile, and you can configure the target that is used with the `scheme` field for iOS. 
+**If you have a bare project**, you can accomplish this using flavors (Android) and targets (iOS). To configure which flavor is used, use the `gradleCommand` field on your build profile; to configure which target is used, use the `scheme` field for iOS.
 
 **If you have a managed project**, this can be accomplished by using **app.config.js** and environment variables in **eas.json**.
 
@@ -94,6 +94,6 @@ To automatically set the `APP_VARIANT` environment variable, we can use `env` in
 }
 ```
 
-Now when you run `eas build --profile production` the `APP_VARIANT` environment variable will be set to `"production"` when evaluating **app.config.js** locally and on the EAS Build worker. [Learn more about environment variables on EAS Build](./variables.md).
+Now when you run `eas build --profile production`, the environment variable `APP_VARIANT` will be set to `"production"` when evaluating **app.config.js** both locally and on the EAS Build worker.
 
 When you run `expo start` the `APP_VARIANT` variable environment will not be set, and the app will run as the development variant.

--- a/docs/pages/build-reference/variants.md
+++ b/docs/pages/build-reference/variants.md
@@ -60,17 +60,18 @@ export default {
 Now let's switch out the iOS `bundleIdentifier` and Android `package` (which becomes the Application ID) based on the presence of an environment variable in **app.config.js**:
 
 ```js
-const IS_PROD = process.env.APP_VARIANT === "production";
+const IS_DEV = process.env.APP_VARIANT === "development";
 
 export default {
-  // You can also switch out the app icon to more clearly differentiate the app
-  name: IS_PROD ? "MyApp" : "MyApp (Dev)",
+  // You can also switch out the app icon and other properties to further
+  // differentiate the app on your device.
+  name: IS_DEV ? "MyApp (Dev)" : "MyApp",
   slug: "my-app",
   ios: {
-    bundleIdentifier: IS_PROD ? "com.myapp" : "com.myapp.dev",
+    bundleIdentifier: IS_DEV ? "com.myapp.dev" : "com.myapp",
   },
   android: {
-    package: IS_PROD ? "com.myapp" : "com.myapp.dev",
+    package: IS_DEV ? "com.myapp.dev" : "com.myapp",
   },
 };
 ```
@@ -88,15 +89,13 @@ To automatically set the `APP_VARIANT` environment variable, we can use `env` in
         "APP_VARIANT": "development"
       }
     },
-    "production": {
-      "env": {
-        "APP_VARIANT": "production"
-      }
-    }
+    "production": {}
   }
 }
 ```
 
-Now when you run `eas build --profile production`, the environment variable `APP_VARIANT` will be set to `"production"` when evaluating **app.config.js** both locally and on the EAS Build worker.
+Now when you run `eas build --profile development`, the environment variable `APP_VARIANT` will be set to `"production"` when evaluating **app.config.js** both locally and on the EAS Build worker. When you start your development server, you will need to run `APP_VARIANT=development expo start` (or the platform equivalent if you use Windows); a shortcut for this could be to add a script to your **package.json** such as `"dev": "APP_VARIANT=development expo start"`.
 
-When you run `expo start` the `APP_VARIANT` variable environment will not be set, and the app will run as the development variant.
+When you run `eas build --profile production` the `APP_VARIANT` variable environment will not be set, and the app will run as the production variant.
+
+> **Note**: if you use `expo-updates` to publish JavaScript updates to your app, you should be cautious to set the correct environment variables for the app variant that you are publishing for when you run the `expo publish` command. Refer to the EAS Build ["Environment variables and secrets" guide](/build/updates.md) for more information.

--- a/docs/pages/build-reference/variants.md
+++ b/docs/pages/build-reference/variants.md
@@ -44,7 +44,7 @@ And your **app.json** might look like this:
 
 Let's convert this to **app.config.js** so we can make it more dynamic:
 
-```json
+```javascript
 export default {
   name: "MyApp",
   slug: "my-app",
@@ -83,7 +83,10 @@ To automatically set the `APP_VARIANT` environment variable, we can use `env` in
 {
   "build": {
     "development": {
-      "developmentClient": true
+      "developmentClient": true,
+      "env": {
+        "APP_VARIANT": "development"
+      }
     },
     "production": {
       "env": {

--- a/docs/pages/build-reference/variants.md
+++ b/docs/pages/build-reference/variants.md
@@ -96,6 +96,6 @@ To automatically set the `APP_VARIANT` environment variable when running builds 
 
 Now when you run `eas build --profile development`, the environment variable `APP_VARIANT` will be set to `"development"` when evaluating **app.config.js** both locally and on the EAS Build worker. When you start your development server, you will need to run `APP_VARIANT=development expo start` (or the platform equivalent if you use Windows); a shortcut for this could be to add a script to your **package.json** such as `"dev": "APP_VARIANT=development expo start"`.
 
-When you run `eas build --profile production` the `APP_VARIANT` variable environment will not be set, and the app will run as the production variant.
+When you run `eas build --profile production` the `APP_VARIANT` variable environment will not be set, and the build will run as the production variant.
 
 > **Note**: if you use `expo-updates` to publish JavaScript updates to your app, you should be cautious to set the correct environment variables for the app variant that you are publishing for when you run the `expo publish` command. Refer to the EAS Build ["Environment variables and secrets" guide](/build/updates.md) for more information.

--- a/docs/pages/build/eas-json.md
+++ b/docs/pages/build/eas-json.md
@@ -100,6 +100,10 @@ A minimal `production` profile looks like this:
 }
 ```
 
+### Installing multiple builds of the same app on a single device
+
+It's common to have development and production builds installed simultaneously on the same device. [Learn about "installing app variants on the same device"](../build-reference/variants.md).
+
 ## Configuring your build tools
 
 Every build depends either implicitly or explicitly on a specific set of versions of related tools that are needed to carry out the build process. These include, but are not limited to: Node.js, npm, yarn, Ruby, Bundler, Cocoapods, Fastlane, Xcode, and Android NDK.


### PR DESCRIPTION
# Why

This is a common need and a common question, eg: https://forums.expo.dev/t/how-can-i-install-my-preview-and-development-builds-simultaneously/59277

# How

I set up the context and then explained how to do this for managed apps, only briefly mentioning what is required for bare apps. @wkozyra95 will fill in the gaps there.

# Test Plan

Following the steps in the example should let you install the development and production builds on your app at the same time (easiest to switch to simulator builds to test).
