### PR TITLE
[docs] Fix tests folder name

### DIFF
--- a/docs/pages/guides/testing-with-jest.md
+++ b/docs/pages/guides/testing-with-jest.md
@@ -117,7 +117,7 @@ Now run the test again, you should see **/coverage/** in your app directory! Fin
 
 ## Structure your Tests
 
-As promised, let's talk about how to set up the tests, right now we have a single **.test.js** in the root of our Expo project. This can get messy quickly, the easiest way is to create a ****tests**** directory (anywhere you'd like) and put all the tests there. For example see below:
+As promised, let's talk about how to set up the tests, right now we have a single **.test.js** in the root of our Expo project. This can get messy quickly, the easiest way is to create a **\_\_tests\_\_** directory (anywhere you'd like) and put all the tests there. For example see below:
 
 ```sh
 __tests__/

--- a/docs/pages/guides/testing-with-jest.md
+++ b/docs/pages/guides/testing-with-jest.md
@@ -117,7 +117,7 @@ Now run the test again, you should see **/coverage/** in your app directory! Fin
 
 ## Structure your Tests
 
-As promised, let's talk about how to set up the tests, right now we have a single **.test.js** in the root of our Expo project. This can get messy quickly, the easiest way is to create a **\_\_tests\_\_** directory (anywhere you'd like) and put all the tests there. For example see below:
+As promised, let's talk about how to set up the tests, right now we have a single `.test.js` in the root of our Expo project. This can get messy quickly, the easiest way is to create a `__tests__` directory (anywhere you'd like) and put all the tests there. For example see below:
 
 ```sh
 __tests__/


### PR DESCRIPTION
# Why

There is a typo when suggesting people to create test directory. The suggested name is `**tests**` instead of `__tests__`. Check the screenshot below.

<img width="794" alt="Pasted_Image_25_11_21__07_37" src="https://user-images.githubusercontent.com/86024/143392016-cc133959-f827-4a3b-9e05-069754af4222.png">

# How

- Change `****tests****` to `**__tests__**`
- Escape the `_` character. So, change `**__tests__**` to `**\_\_tests\_\_**`. The `_` character needs to be escaped, otherwise the word surrounded by `_` gets _italic_.

# Test Plan

Run locally and verify that the suggested tests folder is **\_\_tests\_\_** instead of ****tests****.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->
N/A. No changes were made to Expo Modules

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
