### PR TITLE
[core] Fix android handlers be skipped if the first one returns null

### DIFF
--- a/packages/expo/android/src/main/java/expo/modules/ReactActivityDelegateWrapper.kt
+++ b/packages/expo/android/src/main/java/expo/modules/ReactActivityDelegateWrapper.kt
@@ -33,8 +33,7 @@ class ReactActivityDelegateWrapper(
 
   override fun createRootView(): ReactRootView {
     return reactActivityHandlers.asSequence()
-      .map { it.createReactRootView(activity) }
-      .filterNotNull()
+      .mapNotNull { it.createReactRootView(activity) }
       .firstOrNull() ?: invokeDelegateMethod("createRootView")
   }
 

--- a/packages/expo/android/src/main/java/expo/modules/ReactActivityDelegateWrapper.kt
+++ b/packages/expo/android/src/main/java/expo/modules/ReactActivityDelegateWrapper.kt
@@ -34,6 +34,7 @@ class ReactActivityDelegateWrapper(
   override fun createRootView(): ReactRootView {
     return reactActivityHandlers.asSequence()
       .map { it.createReactRootView(activity) }
+      .filterNotNull()
       .firstOrNull() ?: invokeDelegateMethod("createRootView")
   }
 

--- a/packages/expo/android/src/main/java/expo/modules/ReactNativeHostWrapper.kt
+++ b/packages/expo/android/src/main/java/expo/modules/ReactNativeHostWrapper.kt
@@ -30,6 +30,7 @@ class ReactNativeHostWrapper(
 
     val result = reactNativeHostHandlers.asSequence()
       .map { it.createReactInstanceManager(developerSupport) }
+      .filterNotNull()
       .firstOrNull() ?: super.createReactInstanceManager()
 
     reactNativeHostHandlers.forEach { handler ->
@@ -64,12 +65,14 @@ class ReactNativeHostWrapper(
   override fun getJSBundleFile(): String? {
     return reactNativeHostHandlers.asSequence()
       .map { it.getJSBundleFile(useDeveloperSupport) }
+      .filterNotNull()
       .firstOrNull() ?: invokeDelegateMethod<String?>("getJSBundleFile")
   }
 
   override fun getBundleAssetName(): String? {
     return reactNativeHostHandlers.asSequence()
       .map { it.getBundleAssetName(useDeveloperSupport) }
+      .filterNotNull()
       .firstOrNull() ?: invokeDelegateMethod<String?>("getBundleAssetName")
   }
 

--- a/packages/expo/android/src/main/java/expo/modules/ReactNativeHostWrapper.kt
+++ b/packages/expo/android/src/main/java/expo/modules/ReactNativeHostWrapper.kt
@@ -29,8 +29,7 @@ class ReactNativeHostWrapper(
     }
 
     val result = reactNativeHostHandlers.asSequence()
-      .map { it.createReactInstanceManager(developerSupport) }
-      .filterNotNull()
+      .mapNotNull { it.createReactInstanceManager(developerSupport) }
       .firstOrNull() ?: super.createReactInstanceManager()
 
     reactNativeHostHandlers.forEach { handler ->
@@ -64,15 +63,13 @@ class ReactNativeHostWrapper(
 
   override fun getJSBundleFile(): String? {
     return reactNativeHostHandlers.asSequence()
-      .map { it.getJSBundleFile(useDeveloperSupport) }
-      .filterNotNull()
+      .mapNotNull { it.getJSBundleFile(useDeveloperSupport) }
       .firstOrNull() ?: invokeDelegateMethod<String?>("getJSBundleFile")
   }
 
   override fun getBundleAssetName(): String? {
     return reactNativeHostHandlers.asSequence()
-      .map { it.getBundleAssetName(useDeveloperSupport) }
-      .filterNotNull()
+      .mapNotNull { it.getBundleAssetName(useDeveloperSupport) }
       .firstOrNull() ?: invokeDelegateMethod<String?>("getBundleAssetName")
   }
 


### PR DESCRIPTION
# Why

there's an issue for `ReactActivityDelegateWrapper` and `ReactNativeHostWrapper` when the first handler returns null, the remaining handlers will be skipped.

# How

`mapNotNull()` to filter out null item first.

# Test Plan

CI pass

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
