### PR TITLE
[android][calendar] fix `allowModifications` in android

### DIFF
--- a/packages/expo-calendar/CHANGELOG.md
+++ b/packages/expo-calendar/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 ### 🐛 Bug fixes
+- [Android] Fix `allowModifications` always return false in calendar object. ([#15307](https://github.com/expo/expo/pull/15307) by [@jekiwijaya](https://github.com/jekiwijaya))
 
 ### 💡 Others
 

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/CalendarModule.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/CalendarModule.kt
@@ -786,9 +786,9 @@ class CalendarModule(
       putBoolean(
         "allowsModifications",
         accessLevel == CalendarContract.Calendars.CAL_ACCESS_ROOT
-          or CalendarContract.Calendars.CAL_ACCESS_OWNER
-          or CalendarContract.Calendars.CAL_ACCESS_EDITOR
-          or CalendarContract.Calendars.CAL_ACCESS_CONTRIBUTOR
+          || accessLevel == CalendarContract.Calendars.CAL_ACCESS_OWNER
+          || accessLevel == CalendarContract.Calendars.CAL_ACCESS_EDITOR
+          || accessLevel == CalendarContract.Calendars.CAL_ACCESS_CONTRIBUTOR
       )
     }
     val source = Bundle().apply {


### PR DESCRIPTION
# Why
Currently `getCalendars` in Android always have `allowModifications` false.

Fix #15011
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How
Fixing the logic or operation.
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
