### PR TITLE
[core] Fix `EXAppDefines.APP_DEBUG` returns YES in release build

### DIFF
--- a/packages/expo-modules-core/ios/EXAppDefines.h
+++ b/packages/expo-modules-core/ios/EXAppDefines.h
@@ -13,9 +13,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface EXAppDefines : NSObject
 
-@property (class, nonatomic, assign, readonly) BOOL APP_DEBUG;
-@property (class, nonatomic, assign, readonly) BOOL APP_RCT_DEBUG;
-@property (class, nonatomic, assign, readonly) BOOL APP_RCT_DEV;
+@property (class, nonatomic, assign, readonly) BOOL APP_DEBUG NS_SWIFT_NAME(APP_DEBUG);
+@property (class, nonatomic, assign, readonly) BOOL APP_RCT_DEBUG NS_SWIFT_NAME(APP_RCT_DEBUG);
+@property (class, nonatomic, assign, readonly) BOOL APP_RCT_DEV NS_SWIFT_NAME(APP_RCT_DEV);
 
 + (NSDictionary *)getAllDefines;
 

--- a/packages/expo-modules-core/ios/EXAppDefines.m
+++ b/packages/expo-modules-core/ios/EXAppDefines.m
@@ -11,19 +11,19 @@ static BOOL _loaded = NO;
 + (BOOL)APP_DEBUG
 {
   [self throwIfNotLoaded];
-  return _storage[@"APP_DEBUG"];
+  return [_storage[@"APP_DEBUG"] boolValue];
 }
 
 + (BOOL)APP_RCT_DEBUG
 {
   [self throwIfNotLoaded];
-  return _storage[@"APP_RCT_DEBUG"];
+  return [_storage[@"APP_RCT_DEBUG"] boolValue];
 }
 
 + (BOOL)APP_RCT_DEV
 {
   [self throwIfNotLoaded];
-  return _storage[@"APP_RCT_DEV"];
+  return [_storage[@"APP_RCT_DEV"] boolValue];
 }
 
 + (NSDictionary *)getAllDefines

--- a/packages/expo-modules-core/ios/Tests/EXAppDefinesTest.m
+++ b/packages/expo-modules-core/ios/Tests/EXAppDefinesTest.m
@@ -55,6 +55,17 @@
   XCTAssertEqual(EXAppDefines.APP_DEBUG, YES);
 }
 
+- (void)test_loadAndGetAppDebug_shouldMatchReleaseDefines
+{
+  NSDictionary *defines = @{
+    @"APP_DEBUG": @(NO),
+    @"APP_RCT_DEBUG": @(NO),
+    @"APP_RCT_DEV": @(NO),
+  };
+  [EXAppDefines load:defines];
+  XCTAssertEqual(EXAppDefines.APP_DEBUG, NO);
+}
+
 - (void)test_getters_returnsDefaultValues
 {
   XCTAssertNoThrow([EXAppDefines load:@{}]);


### PR DESCRIPTION
# Why

Fix `EXAppDefines.APP_DEBUG` returns YES in release build

# How

- should add `boolValue` from NSNumber.
- also an enhancement for swift to keep the same property names. 

# Test Plan

▸ EXAppDefinesTest
▸     ✓ test_loadAndGetAppDebug_shouldMatchReleaseDefines (0.001 seconds)

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
  since EXAppDefines does not published yet, i'd not to update the CHANGELOG to make confusion.
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
