### PR TITLE
[module-template] Fix ios build error from wrong view name

### DIFF
--- a/packages/expo-module-template/ios/ExpoModuleTemplateModule.swift
+++ b/packages/expo-module-template/ios/ExpoModuleTemplateModule.swift
@@ -10,10 +10,10 @@ public class ExpoModuleTemplateModule: Module {
     
     viewManager {
       view {
-        ModuleTemplateView()
+        ExpoModuleTemplateView()
       }
 
-      prop("someGreatProp") { (view: ModuleTemplateView, prop: Int) in
+      prop("someGreatProp") { (view: ExpoModuleTemplateView, prop: Int) in
         print("prop")
       }
     }

--- a/packages/expo-module-template/ios/ExpoModuleTemplateView.swift
+++ b/packages/expo-module-template/ios/ExpoModuleTemplateView.swift
@@ -1,3 +1,3 @@
 import UIKit
 
-class View: UIView {}
+class ExpoModuleTemplateView: UIView {}


### PR DESCRIPTION
# Why

fix CI error https://github.com/expo/expo/runs/4341197827

# How

Use the correct view name

# Test Plan

CI pass

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
