### PR TITLE
[updates] Fix no startup rootViewController crash from manual setup

### DIFF
--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesUtils.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesUtils.m
@@ -132,8 +132,10 @@ static NSString * const EXUpdatesUtilsErrorDomain = @"EXUpdatesUtils";
     id instance = [oldRootViewController.class alloc];
     IMP imp = [instance methodForSelector:screenOrientationSelector];
     result = ((id (*)(id, SEL, UIInterfaceOrientationMask))imp)(instance, screenOrientationSelector, mask);
-  } else {
+  } else if (oldRootViewController != nil) {
     result = [oldRootViewController.class new];
+  } else {
+    result = [UIViewController new];
   }
 
   return result;


### PR DESCRIPTION
# Why

for manual setup flow, there's no existing `rootViewController`, `EXUpdatesUtils.createRootViewController` will return nil and lead to `Application windows are expected to have a root view controller at the end of application launch` crash.

# How

create `UIViewController` instance if old `rootViewController` is nil.

# Test Plan

TBD

# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
