### PR TITLE
[docs] update background-fetch examples

### DIFF
--- a/docs/pages/versions/unversioned/sdk/background-fetch.md
+++ b/docs/pages/versions/unversioned/sdk/background-fetch.md
@@ -42,7 +42,7 @@ TaskManager.defineTask(BACKGROUND_FETCH_TASK, async () => {
   console.log(`Got background fetch call at date: ${new Date(now).toISOString()}`);
 
   // Be sure to return the successful result type!
-  return BackgroundFetch.Result.NewData;
+  return BackgroundFetch.BackgroundFetchResult.NewData;
 });
 
 // 2. Register the task at some point in your app by providing the same name, and some configuration options for how the background fetch should behave
@@ -63,8 +63,8 @@ async function unregisterBackgroundFetchAsync() {
 }
 
 export default function BackgroundFetchScreen() {
-  const [isRegistered, setIsRegistered] = React.useState<boolean>(false);
-  const [status, setStatus] = React.useState<BackgroundFetch.Status | null>(null);
+  const [isRegistered, setIsRegistered] = React.useState(false);
+  const [status, setStatus] = React.useState(null);
 
   React.useEffect(() => {
     checkStatusAsync();
@@ -92,7 +92,9 @@ export default function BackgroundFetchScreen() {
       <View style={styles.textContainer}>
         <Text>
           Background fetch status:{' '}
-          <Text style={styles.boldText}>{status ? BackgroundFetch.Status[status] : null}</Text>
+          <Text style={styles.boldText}>
+            {status && BackgroundFetch.BackgroundFetchStatus[status]}
+          </Text>
         </Text>
         <Text>
           Background fetch task name:{' '}

--- a/docs/pages/versions/unversioned/sdk/background-fetch.md
+++ b/docs/pages/versions/unversioned/sdk/background-fetch.md
@@ -24,7 +24,7 @@ For [managed](../../../introduction/managed-vs-bare.md#managed-workflow) apps, y
 
 Below is an example that demonstrates how to use `expo-background-fetch`.
 
-<SnackInline>
+<SnackInline label="Background Fetch Usage" dependencies={['expo-background-fetch', 'expo-task-manager']}>
 
 ```tsx
 import React from 'react';

--- a/docs/pages/versions/v43.0.0/sdk/background-fetch.md
+++ b/docs/pages/versions/v43.0.0/sdk/background-fetch.md
@@ -42,7 +42,7 @@ TaskManager.defineTask(BACKGROUND_FETCH_TASK, async () => {
   console.log(`Got background fetch call at date: ${new Date(now).toISOString()}`);
 
   // Be sure to return the successful result type!
-  return BackgroundFetch.Result.NewData;
+  return BackgroundFetch.BackgroundFetchResult.NewData;
 });
 
 // 2. Register the task at some point in your app by providing the same name, and some configuration options for how the background fetch should behave
@@ -63,8 +63,8 @@ async function unregisterBackgroundFetchAsync() {
 }
 
 export default function BackgroundFetchScreen() {
-  const [isRegistered, setIsRegistered] = React.useState<boolean>(false);
-  const [status, setStatus] = React.useState<BackgroundFetch.Status | null>(null);
+  const [isRegistered, setIsRegistered] = React.useState(false);
+  const [status, setStatus] = React.useState(null);
 
   React.useEffect(() => {
     checkStatusAsync();
@@ -92,7 +92,9 @@ export default function BackgroundFetchScreen() {
       <View style={styles.textContainer}>
         <Text>
           Background fetch status:{' '}
-          <Text style={styles.boldText}>{status ? BackgroundFetch.Status[status] : null}</Text>
+          <Text style={styles.boldText}>
+            {status && BackgroundFetch.BackgroundFetchStatus[status]}
+          </Text>
         </Text>
         <Text>
           Background fetch task name:{' '}

--- a/docs/pages/versions/v43.0.0/sdk/background-fetch.md
+++ b/docs/pages/versions/v43.0.0/sdk/background-fetch.md
@@ -24,7 +24,7 @@ For [managed](../../../introduction/managed-vs-bare.md#managed-workflow) apps, y
 
 Below is an example that demonstrates how to use `expo-background-fetch`.
 
-<SnackInline>
+<SnackInline label="Background Fetch Usage" dependencies={['expo-background-fetch', 'expo-task-manager']}>
 
 ```tsx
 import React from 'react';


### PR DESCRIPTION
# Why

Refs #15320

# How

This PR updates the examples on the `background-fetch`, which still included old aliases and few TS types which have prevent the Snack code from running correctly.

I have also added missing label and dependencies for the `SnackInline` component.

Both, SDK43 and `unversioned` docs have been updated.

# Test Plan

The changes have been tested by running docs website on `localhost`.

Also there is the corrected version of the Snack example:
* https://snack.expo.dev/@simek/background-fetch

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
