### PR TITLE
[android][ios] Upgrade react-native-shared-element to 0.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Package-specific changes not released in any SDK will be added here just before 
 
 ### 📚 3rd party library updates
 
+- Updated `react-native-shared-element` from `0.8.2` to `0.8.3`. ([#15338](https://github.com/expo/expo/pull/15338) by [@kudo](https://github.com/kudo))
+
 ### 🛠 Breaking changes
 
 ### 🎉 New features

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -117,7 +117,7 @@
     "react-native-reanimated": "~2.2.0",
     "react-native-safe-area-context": "3.3.2",
     "react-native-screens": "~3.8.0",
-    "react-native-shared-element": "0.8.2",
+    "react-native-shared-element": "0.8.3",
     "react-native-svg": "12.1.1",
     "react-native-view-shot": "3.1.2",
     "react-native-webview": "11.13.0",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -160,7 +160,7 @@
     "react-native-safe-area-context": "3.3.2",
     "react-native-safe-area-view": "^0.14.8",
     "react-native-screens": "~3.8.0",
-    "react-native-shared-element": "0.8.2",
+    "react-native-shared-element": "0.8.3",
     "react-native-svg": "^12.1.1",
     "react-native-view-shot": "3.1.2",
     "react-native-web": "~0.17.1",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -100,7 +100,7 @@
   "react-native-reanimated": "~2.2.0",
   "react-native-safe-area-context": "3.3.2",
   "react-native-screens": "~3.8.0",
-  "react-native-shared-element": "0.8.2",
+  "react-native-shared-element": "0.8.3",
   "react-native-svg": "12.1.1",
   "react-native-unimodules": "~0.15.0",
   "react-native-view-shot": "3.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14903,10 +14903,10 @@ react-native-scrollable-mixin@^1.0.0:
   resolved "https://registry.yarnpkg.com/react-native-scrollable-mixin/-/react-native-scrollable-mixin-1.0.1.tgz#34a32167b64248594154fd0d6a8b03f22740548e"
   integrity sha1-NKMhZ7ZCSFlBVP0NaosD8idAVI4=
 
-react-native-shared-element@0.8.2:
-  version "0.8.2"
-  resolved "https://registry.yarnpkg.com/react-native-shared-element/-/react-native-shared-element-0.8.2.tgz#64124ec7e19369b78b6924c93808e1ed058c8109"
-  integrity sha512-IalCG1Sn6Vq171JMh0cbHzf0dJxwUIGwf5baxWhZ6busLQ2AL0A0pFb86sLgOUtv+NZdZX2R1Xd+Ylqj8neuLw==
+react-native-shared-element@0.8.3:
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/react-native-shared-element/-/react-native-shared-element-0.8.3.tgz#c49b6acdca9e5ac27acc73ec7e7ddbaa7af35248"
+  integrity sha512-mbL0gWBaZgWc5YQUwwlzyUOToMbfE+QdNxlSK8MdRGX6ItssVH+JLbq8ilLRTNEO+cTFFosXdQwqBUAC4IPSww==
 
 react-native-svg@12.1.1, react-native-svg@^12.1.1:
   version "12.1.1"


### PR DESCRIPTION
# Why

upgrade react-native-shared-element to 0.8.3 for SDK 44.
close ENG-2540

# How

`et uvm -m react-native-shared-element -c "v0.8.3"`
v0.8.3 had just one fix and the risk is low: https://github.com/IjzerenHein/react-native-shared-element/pull/81

# Test Plan

android unversioned Expo Go + NCL
ios unversioned Expo Go + NCL

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
