### PR TITLE
[camera] Add monorepo support to expo-camera for SDK 43

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Use Node module resolution for monorepos in the local expo-camera maven entry. ([#15340](https://github.com/expo/expo/pull/15340) by [@byCedric](https://github.com/byCedric))
+
 ### 💡 Others
 
 ## 12.0.3 — 2021-10-21

--- a/packages/expo-camera/plugin/build/withCamera.js
+++ b/packages/expo-camera/plugin/build/withCamera.js
@@ -8,9 +8,9 @@ const MICROPHONE_USAGE = 'Allow $(PRODUCT_NAME) to access your microphone';
 // Because we need the package to be added AFTER the React and Google maven packages, we create a new allprojects.
 // It's ok to have multiple allprojects.repositories, so we create a new one since it's cheaper than tokenizing
 // the existing block to find the correct place to insert our camera maven.
-const gradleMaven = 'allprojects { repositories { maven { url "$rootDir/../node_modules/expo-camera/android/maven" } } }';
+const gradleMaven = `allprojects { repositories { maven { url(new File(["node", "--print", "require.resolve('expo-camera/package.json')"].execute(null, rootDir).text.trim(), "../android/maven")) } } }`;
 const withAndroidCameraGradle = (config) => {
-    return config_plugins_1.withProjectBuildGradle(config, (config) => {
+    return (0, config_plugins_1.withProjectBuildGradle)(config, (config) => {
         if (config.modResults.language === 'groovy') {
             config.modResults.contents = setGradleMaven(config.modResults.contents);
         }
@@ -23,7 +23,7 @@ const withAndroidCameraGradle = (config) => {
 function setGradleMaven(buildGradle) {
     // If this specific line is present, skip.
     // This also enables users in bare workflow to comment out the line to prevent expo-camera from adding it back.
-    if (buildGradle.includes('expo-camera/android/maven')) {
+    if (buildGradle.includes('expo-camera/package.json')) {
         return buildGradle;
     }
     return buildGradle + `\n${gradleMaven}\n`;
@@ -38,7 +38,7 @@ const withCamera = (config, { cameraPermission, microphonePermission } = {}) => 
         cameraPermission || config.ios.infoPlist.NSCameraUsageDescription || CAMERA_USAGE;
     config.ios.infoPlist.NSMicrophoneUsageDescription =
         microphonePermission || config.ios.infoPlist.NSMicrophoneUsageDescription || MICROPHONE_USAGE;
-    return config_plugins_1.withPlugins(config, [
+    return (0, config_plugins_1.withPlugins)(config, [
         [
             config_plugins_1.AndroidConfig.Permissions.withPermissions,
             [
@@ -50,4 +50,4 @@ const withCamera = (config, { cameraPermission, microphonePermission } = {}) => 
         withAndroidCameraGradle,
     ]);
 };
-exports.default = config_plugins_1.createRunOncePlugin(withCamera, pkg.name, pkg.version);
+exports.default = (0, config_plugins_1.createRunOncePlugin)(withCamera, pkg.name, pkg.version);

--- a/packages/expo-camera/plugin/src/__tests__/__snapshots__/withCamera-test.ts.snap
+++ b/packages/expo-camera/plugin/src/__tests__/__snapshots__/withCamera-test.ts.snap
@@ -33,6 +33,6 @@ allprojects {
     }
 }
 
-allprojects { repositories { maven { url \\"$rootDir/../node_modules/expo-camera/android/maven\\" } } }
+allprojects { repositories { maven { url(new File([\\"node\\", \\"--print\\", \\"require.resolve('expo-camera/package.json')\\"].execute(null, rootDir).text.trim(), \\"../android/maven\\")) } } }
 "
 `;

--- a/packages/expo-camera/plugin/src/withCamera.ts
+++ b/packages/expo-camera/plugin/src/withCamera.ts
@@ -14,8 +14,7 @@ const MICROPHONE_USAGE = 'Allow $(PRODUCT_NAME) to access your microphone';
 // Because we need the package to be added AFTER the React and Google maven packages, we create a new allprojects.
 // It's ok to have multiple allprojects.repositories, so we create a new one since it's cheaper than tokenizing
 // the existing block to find the correct place to insert our camera maven.
-const gradleMaven =
-  'allprojects { repositories { maven { url "$rootDir/../node_modules/expo-camera/android/maven" } } }';
+const gradleMaven = `allprojects { repositories { maven { url(new File(["node", "--print", "require.resolve('expo-camera/package.json')"].execute(null, rootDir).text.trim(), "../android/maven")) } } }`;
 
 const withAndroidCameraGradle: ConfigPlugin = (config) => {
   return withProjectBuildGradle(config, (config) => {
@@ -31,7 +30,7 @@ const withAndroidCameraGradle: ConfigPlugin = (config) => {
 export function setGradleMaven(buildGradle: string): string {
   // If this specific line is present, skip.
   // This also enables users in bare workflow to comment out the line to prevent expo-camera from adding it back.
-  if (buildGradle.includes('expo-camera/android/maven')) {
+  if (buildGradle.includes('expo-camera/package.json')) {
     return buildGradle;
   }
 


### PR DESCRIPTION
# Why

We should have proper monorepo support for `expo-camera` starting SDK 43.

# How

Replaced hardcoded plugin path with dynamic resolve path, based on current master.

# Test Plan

See test, and https://github.com/tyrauber/eas-camera-monorepo/pull/1

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
