### PR TITLE
[docs] Fix typos in "Existing Apps"

### DIFF
--- a/docs/pages/bare/existing-apps.md
+++ b/docs/pages/bare/existing-apps.md
@@ -7,13 +7,13 @@ If you want to use parts of the Expo SDK in your existing React Native app, you 
 
 **Most packages in the Expo SDK depend on a module tooling installed with the [expo](https://github.com/expo/expo/tree/master/packages/expo) package. Once it is installed and configured in your app, you can install other packages from the Expo SDK just as you would any other React Native library.**
 
-## Setting up the `expo` packag
+## Setting up the `expo` package
 
 Follow the the [installing Expo modules guide](../bare/installing-expo-modules.md). It should take about five minutes to configure in an existing app.
 
 ## Install libraries from the Expo SDK
 
-The short version: find an Expo package that you would like to use in the API reference or by searching this documentation, eg: [expo-web-browser](../versions/latest/sdk/webbrowser.md),install it with npm, then run `npx pod-install` and re-build your app.
+The short version: find an Expo package that you would like to use in the API reference or by searching this documentation, eg: [expo-web-browser](../versions/latest/sdk/webbrowser.md), install it with npm, then run `npx pod-install` and re-build your app.
 
 The longer, more detailed version: check out [Install an Expo SDK package](hello-world.md#install-an-expo-sdk-package) in the "Up and Running" guide.
 


### PR DESCRIPTION
# Why

To fix what seems to be two tiny typos, I'm guessing somebody would do this at some point anyways.

# How

Changed "packag" to "package",  and added space after a comma that didn't have it.

# Test Plan

Outside looking at the diff and maybe running something like `grep -Ri 'packag\s\|packag$' docs`, I'm not really sure what to add.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).

These checkboxes aren't really applicable in this case, I believe.
