### PR TITLE
[android] remove unused bintray maven repos

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -16,8 +16,8 @@ buildscript {
   }
   repositories {
     google()
+    mavenCentral()
     jcenter()
-    maven { url 'https://dl.bintray.com/android/android-tools/' }
   }
   dependencies {
     classpath "com.android.tools.build:gradle:${gradlePluginVersion}"
@@ -57,6 +57,7 @@ allprojects {
       url "$rootDir/versioned-abis/maven"
     }
     google()
+    mavenCentral()
     jcenter()
     maven {
       // Local Maven repo containing AARs with JSC built for Android
@@ -71,8 +72,6 @@ allprojects {
       dirs 'libs'
       // dirs project(':expoview').file('libs')
     }
-    // https://github.com/google/ExoPlayer/issues/5225#issuecomment-445739013
-    maven { url 'https://google.bintray.com/exoplayer' }
     // Using www.jitpack.io instead of plain jitpack.io due to
     // https://github.com/jitpack/jitpack.io/issues/4002
     maven { url "https://www.jitpack.io" }

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,5 +1,6 @@
 pluginManagement {
   repositories {
+    mavenCentral()
     gradlePluginPortal()
     mavenLocal()
     google()


### PR DESCRIPTION
# Why

the explicit and unused bintray maven repos returns http 502 now and cause gradle failures.

https://github.com/expo/expo/runs/4363771020
https://status.expo.dev/incidents/yr02d5lvlw0v

# How

remove these unused maven repos and add `mavenCentral()`.

# Test Plan

CI passed

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
