### PR TITLE
[NCL][AV] Add JSI Audio visualisation

### DIFF
--- a/apps/native-component-list/src/screens/AV/JsiAudioBar.tsx
+++ b/apps/native-component-list/src/screens/AV/JsiAudioBar.tsx
@@ -1,0 +1,90 @@
+import { Audio } from 'expo-av';
+import { UnavailabilityError } from 'expo-modules-core';
+import React from 'react';
+import { Platform, Text, StyleSheet, View } from 'react-native';
+import Reanimated, {
+  Extrapolate,
+  interpolate,
+  runOnUI,
+  useAnimatedStyle,
+  useSharedValue,
+  withSpring,
+} from 'react-native-reanimated';
+
+import Colors from '../../constants/Colors';
+
+// for some reason, iOS returns much smaller sample values
+// TODO (barthap): Fix the root cause and normalize them between platforms
+const inputRange = Platform.OS === 'ios' ? [0, 0.3] : [0, 1];
+
+export function JsiAudioBar({ sound, isPlaying }: { sound: Audio.Sound; isPlaying: boolean }) {
+  const isJsiAudioSupported = React.useMemo(() => {
+    try {
+      // @ts-expect-error that method is private
+      sound?._updateAudioSampleReceivedCallback();
+      return true;
+    } catch (e: unknown) {
+      if (e instanceof UnavailabilityError) {
+        return false;
+      }
+      throw e;
+    }
+  }, [sound]);
+
+  const audioRmsValue = useSharedValue(0);
+  const animatedStyle = useAnimatedStyle(() => {
+    const barWidth = interpolate(audioRmsValue.value, inputRange, [1, 500], Extrapolate.CLAMP);
+    return {
+      width: withSpring(barWidth, {
+        mass: 1,
+        damping: 500,
+        stiffness: 1000,
+      }),
+    };
+  }, [audioRmsValue]);
+
+  React.useEffect(() => {
+    if (isJsiAudioSupported && isPlaying && !sound?._onAudioSampleReceived) {
+      sound?.setOnAudioSampleReceived((sample) => {
+        const frames = sample.channels[0].frames;
+        const frameSum = frames.slice(0, 200).reduce((prev, curr) => prev + curr ** 2, 0);
+        const rmsValue = Math.sqrt(frameSum / 200);
+
+        runOnUI(() => {
+          audioRmsValue.value = rmsValue;
+        })();
+      });
+    }
+  }, [sound, isPlaying]);
+
+  if (!isJsiAudioSupported) {
+    return <Text style={styles.errorText}>JSI Audio is not supported on this platform</Text>;
+  }
+
+  if (!sound || !sound._onAudioSampleReceived) {
+    return <Text style={styles.infoText}>Press play to set JSI audioSampleCallback</Text>;
+  }
+
+  return (
+    <View style={styles.barContainer}>
+      <Reanimated.View style={[styles.bar, animatedStyle]} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  barContainer: {
+    height: 19,
+  },
+  bar: {
+    height: 8,
+    borderRadius: 4,
+    backgroundColor: Colors.tintColor,
+  },
+  errorText: {
+    color: Colors.errorBackground,
+  },
+  infoText: {
+    color: Colors.tintColor,
+  },
+});

--- a/apps/native-component-list/src/screens/AV/Player.tsx
+++ b/apps/native-component-list/src/screens/AV/Player.tsx
@@ -29,6 +29,7 @@ interface Props {
       }
     | (() => React.ReactNode)
   )[];
+  extraIndicator?: JSX.Element;
   style?: StyleProp<ViewStyle>;
 
   // Functions
@@ -178,6 +179,8 @@ export default function Player(props: Props) {
       </View>
 
       <Text>{props.metadata?.title ?? ''}</Text>
+
+      <View style={styles.container}>{props.extraIndicator}</View>
 
       <View style={styles.container}>
         <VolumeSlider


### PR DESCRIPTION
# Why

Adds a way to test JSI audio in NCL.

# How

Added bar with [re]animated width - it dynamically stretches when the sound gets louder and shrinks when average sound is lower.

<details>
<summary>Screenshot</summary>

![Nov-30-2021 12-33-38](https://user-images.githubusercontent.com/278340/144040109-8942d829-20e7-4584-99f5-82b0348aa256.gif)

</details>

# Test Plan

NCL
