### PR TITLE
[android][ios] Upgrade @react-native-picker/picker to 2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Package-specific changes not released in any SDK will be added here just before 
 - Updated `@react-native-community/slider` from `4.1.4` to `4.1.12`. ([#15356](https://github.com/expo/expo/pull/15356) by [@EvanBacon](https://github.com/EvanBacon))
 - Updated `@react-native-community/datetimepicker` from `3.5.2` to `4.0.0`. ([#15357](https://github.com/expo/expo/pull/15357) by [@EvanBacon](https://github.com/EvanBacon))
 - Updated `@react-native-community/netinfo` from `6.0.2` to `7.1.3`. ([#15352](https://github.com/expo/expo/pull/15352) by [@kudo](https://github.com/kudo))
+- Updated `@react-native-picker/picker` from `2.1.0` to `2.2.1`. ([#15358](https://github.com/expo/expo/pull/15358) by [@bycedric](https://github.com/bycedric))
 
 ### 🛠 Breaking changes
 

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/picker/ReactPicker.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/picker/ReactPicker.java
@@ -29,7 +29,6 @@ import com.facebook.react.modules.i18nmanager.I18nUtil;
 import com.facebook.react.uimanager.UIManagerModule;
 
 import javax.annotation.Nullable;
-import host.exp.expoview.R;
 
 public class ReactPicker extends AppCompatSpinner {
 

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/picker/ReactPicker.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/picker/ReactPicker.java
@@ -30,6 +30,8 @@ import com.facebook.react.uimanager.UIManagerModule;
 
 import javax.annotation.Nullable;
 
+import host.exp.expoview.R;
+
 public class ReactPicker extends AppCompatSpinner {
 
   private int mMode = Spinner.MODE_DIALOG;

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/picker/ReactPickerManager.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/picker/ReactPickerManager.java
@@ -32,7 +32,6 @@ import com.facebook.react.uimanager.events.EventDispatcher;
 import java.util.Map;
 
 import javax.annotation.Nullable;
-import host.exp.expoview.R;
 
 /**
  * {@link ViewManager} for the {@link ReactPicker} view. This is abstract because the

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/picker/ReactPickerManager.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/picker/ReactPickerManager.java
@@ -33,6 +33,8 @@ import java.util.Map;
 
 import javax.annotation.Nullable;
 
+import host.exp.expoview.R;
+
 /**
  * {@link ViewManager} for the {@link ReactPicker} view. This is abstract because the
  * {@link Spinner} doesn't support setting the mode (dropdown/dialog) outside the constructor, so

--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -701,9 +701,9 @@ PODS:
     - React-perflogger (= 0.64.3)
   - RNCAsyncStorage (1.15.9):
     - React-Core
-  - RNCMaskedView (0.2.5):
+  - RNCMaskedView (0.2.6):
     - React-Core
-  - RNCPicker (2.1.0):
+  - RNCPicker (2.2.1):
     - React-Core
   - RNDateTimePicker (4.0.0):
     - React-Core
@@ -1391,8 +1391,8 @@ SPEC CHECKSUMS:
   React-runtimeexecutor: 493d9abb8b23c3f84e19ae221eeba92cadcb70dc
   ReactCommon: 8fea6422328e2fc093e25c9fac67adbcf0f04fb4
   RNCAsyncStorage: 26f25150da507524a7815f2ada06ca0967f65633
-  RNCMaskedView: b7a3b119b1d738734a9d761e4220c6850bb248a3
-  RNCPicker: f7a40b21b915b7a187624d52f52b7bc2f73ea413
+  RNCMaskedView: c298b644a10c0c142055b3ae24d83879ecb13ccd
+  RNCPicker: cb57c823d5ce8d2d0b5dfb45ad97b737260dc59e
   RNDateTimePicker: 2224ee77a86b7123377597a015502435e2e49957
   RNGestureHandler: a479ebd5ed4221a810967000735517df0d2db211
   RNReanimated: 64c38d47ffcc29c97fc1d8cfde9e8a73d7be7cc8

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -97,7 +97,7 @@
     "@react-native-community/slider": "4.1.12",
     "@react-native-community/viewpager": "5.0.11",
     "@react-native-masked-view/masked-view": "0.2.6",
-    "@react-native-picker/picker": "2.1.0",
+    "@react-native-picker/picker": "2.2.1",
     "@react-native-segmented-control/segmented-control": "2.4.0",
     "expo": "~44.0.0-alpha.0",
     "expo-camera": "~12.0.1",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -46,7 +46,7 @@
     "@react-native-community/netinfo": "7.1.3",
     "@react-native-community/slider": "4.1.12",
     "@react-native-masked-view/masked-view": "0.2.6",
-    "@react-native-picker/picker": "2.1.0",
+    "@react-native-picker/picker": "2.2.1",
     "@react-native-segmented-control/segmented-control": "2.4.0",
     "@react-navigation/bottom-tabs": "~5.11.1",
     "@react-navigation/drawer": "~5.11.3",

--- a/ios/Exponent.xcodeproj/project.pbxproj
+++ b/ios/Exponent.xcodeproj/project.pbxproj
@@ -5,6 +5,7 @@
 	};
 	objectVersion = 46;
 	objects = {
+
 /* Begin PBXBuildFile section */
 		0726F0592007E438004992E7 /* EXKernelAppRecord.m in Sources */ = {isa = PBXBuildFile; fileRef = 0726F0582007E438004992E7 /* EXKernelAppRecord.m */; };
 		0726F05C2007E446004992E7 /* EXKernelAppRegistry.m in Sources */ = {isa = PBXBuildFile; fileRef = 0726F05B2007E446004992E7 /* EXKernelAppRegistry.m */; };
@@ -126,6 +127,7 @@
 		4FA89DFCDD9842F7AAFC1CAF /* RNSVGPathMeasure.m in Sources */ = {isa = PBXBuildFile; fileRef = 5E8A7DA8E798407CA5410CF6 /* RNSVGPathMeasure.m */; settings = {COMPILER_FLAGS = "-w"; }; };
 		50620A8F1BBC4330AF4B4E26 /* AIRGoogleMapHeatmapManager.m in Sources */ = {isa = PBXBuildFile; fileRef = A5B705024D7B4371B0EB68EC /* AIRGoogleMapHeatmapManager.m */; settings = {COMPILER_FLAGS = "-w"; }; };
 		50659F05B6314F5192BC2215 /* RNSharedElementStyle.m in Sources */ = {isa = PBXBuildFile; fileRef = 391920741A374C4AB61BDB48 /* RNSharedElementStyle.m */; settings = {COMPILER_FLAGS = "-w"; }; };
+		5C125576DAE64294975CF6D4 /* RNCPickerLabel.m in Sources */ = {isa = PBXBuildFile; fileRef = 3D15D90AE40B475DB908EC75 /* RNCPickerLabel.m */; settings = {COMPILER_FLAGS = "-w"; }; };
 		65945A8A5EFCAD9BB688728F /* libPods-Tests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = EB9A99C3D4234AE6ED00CE1B /* libPods-Tests.a */; };
 		6782D340A0024AF58B3805D0 /* RNSVGTopAlignedLabel.ios.m in Sources */ = {isa = PBXBuildFile; fileRef = F4B751B511314328B86D13C6 /* RNSVGTopAlignedLabel.ios.m */; settings = {COMPILER_FLAGS = "-w"; }; };
 		7043DF762283303800272D74 /* RNSVGPainterBrush.m in Sources */ = {isa = PBXBuildFile; fileRef = 7043DEFF2283303800272D74 /* RNSVGPainterBrush.m */; settings = {COMPILER_FLAGS = "-w"; }; };
@@ -626,9 +628,6 @@
 		FCF6D37025B34BC200808BF5 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCF6D36F25B34BC200808BF5 /* NotificationService.swift */; };
 		FCF6D37425B34BC200808BF5 /* ExpoNotificationServiceExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = FCF6D36D25B34BC200808BF5 /* ExpoNotificationServiceExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		FE8D4A1FC2BDC25C8D4684F8 /* ExpoModulesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C849D84FFC04012BBF6DFFD /* ExpoModulesProvider.swift */; };
-		A55AB920150243ACAA249F76 /* RNCPicker.m in Sources */ = {isa = PBXBuildFile; fileRef = C1C2106811C34CB4B9804EF2 /* RNCPicker.m */; settings = {COMPILER_FLAGS = "-w"; }; };
-		5C125576DAE64294975CF6D4 /* RNCPickerLabel.m in Sources */ = {isa = PBXBuildFile; fileRef = 3D15D90AE40B475DB908EC75 /* RNCPickerLabel.m */; settings = {COMPILER_FLAGS = "-w"; }; };
-		B9F55E4D0C2F42B7BB63D59F /* RNCPickerManager.m in Sources */ = {isa = PBXBuildFile; fileRef = EB9CF85A7D224B3D86D33F95 /* RNCPickerManager.m */; settings = {COMPILER_FLAGS = "-w"; }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -752,6 +751,7 @@
 		19382BA81EC2EACC001ED4A1 /* EXScopedBranchManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EXScopedBranchManager.m; sourceTree = "<group>"; };
 		19B2EF731FB25A1A003F2E1B /* EXCachedResourceManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EXCachedResourceManager.h; sourceTree = "<group>"; };
 		19B2EF741FB25A1A003F2E1B /* EXCachedResourceManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EXCachedResourceManager.m; sourceTree = "<group>"; };
+		1CC901538F9947439D43E69A /* RNCPickerLabel.h */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.c.h; name = RNCPickerLabel.h; path = Picker/RNCPickerLabel.h; sourceTree = "<group>"; };
 		1CF1D8E66E5B4C7A9476C145 /* RNCSliderManager.h */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.c.h; path = RNCSliderManager.h; sourceTree = "<group>"; };
 		1E9033E268A74098A882CCEB /* RNSharedElementTransitionManager.m */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.c.objc; path = RNSharedElementTransitionManager.m; sourceTree = "<group>"; };
 		2168B25A23E3058500A94C0D /* EXScopedFirebaseCore.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EXScopedFirebaseCore.m; sourceTree = "<group>"; };
@@ -921,6 +921,7 @@
 		3451876A2368FE9E008C4171 /* cp-bundle-resources-conditionally.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "cp-bundle-resources-conditionally.sh"; sourceTree = "<group>"; };
 		35005E2F0ED24BB98E4DC990 /* RNCMaskedView.m */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.c.objc; path = RNCMaskedView.m; sourceTree = "<group>"; };
 		391920741A374C4AB61BDB48 /* RNSharedElementStyle.m */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.c.objc; path = RNSharedElementStyle.m; sourceTree = "<group>"; };
+		3D15D90AE40B475DB908EC75 /* RNCPickerLabel.m */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.c.objc; name = RNCPickerLabel.m; path = Picker/RNCPickerLabel.m; sourceTree = "<group>"; };
 		417AEE2C283C4782885B8C12 /* RNSVGMarkerPosition.m */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.c.objc; path = RNSVGMarkerPosition.m; sourceTree = "<group>"; };
 		476C8FFA59854F80BD436259 /* RNCMaskedViewManager.h */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.c.h; path = RNCMaskedViewManager.h; sourceTree = "<group>"; };
 		522580D8EA8D0267870DC600 /* ExpoModulesProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExpoModulesProvider.swift; path = "Pods/Target Support Files/Pods-Expo Go-Expo Go (versioned)/ExpoModulesProvider.swift"; sourceTree = "<group>"; };
@@ -1340,12 +1341,6 @@
 		FCF6D36D25B34BC200808BF5 /* ExpoNotificationServiceExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = ExpoNotificationServiceExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		FCF6D36F25B34BC200808BF5 /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
 		FCF6D37125B34BC200808BF5 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		C8125860CA594B978340A46A /* RNCPicker.h */ = {isa = PBXFileReference; name = "RNCPicker.h"; path = "RNCPicker.h"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; explicitFileType = undefined; includeInIndex = 0; };
-		C1C2106811C34CB4B9804EF2 /* RNCPicker.m */ = {isa = PBXFileReference; name = "RNCPicker.m"; path = "RNCPicker.m"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; explicitFileType = undefined; includeInIndex = 0; };
-		1CC901538F9947439D43E69A /* RNCPickerLabel.h */ = {isa = PBXFileReference; name = "RNCPickerLabel.h"; path = "RNCPickerLabel.h"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; explicitFileType = undefined; includeInIndex = 0; };
-		3D15D90AE40B475DB908EC75 /* RNCPickerLabel.m */ = {isa = PBXFileReference; name = "RNCPickerLabel.m"; path = "RNCPickerLabel.m"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; explicitFileType = undefined; includeInIndex = 0; };
-		C674AC2F809245C59EE36B18 /* RNCPickerManager.h */ = {isa = PBXFileReference; name = "RNCPickerManager.h"; path = "RNCPickerManager.h"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; explicitFileType = undefined; includeInIndex = 0; };
-		EB9CF85A7D224B3D86D33F95 /* RNCPickerManager.m */ = {isa = PBXFileReference; name = "RNCPickerManager.m"; path = "RNCPickerManager.m"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; explicitFileType = undefined; includeInIndex = 0; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1400,12 +1395,8 @@
 				07CB4DC826045AFE0057443E /* RNCPicker.m */,
 				07CB4DC926045AFE0057443E /* RNCPickerManager.h */,
 				07CB4DCA26045AFE0057443E /* RNCPickerManager.m */,
-				C8125860CA594B978340A46A /* RNCPicker.h */,
-				C1C2106811C34CB4B9804EF2 /* RNCPicker.m */,
 				1CC901538F9947439D43E69A /* RNCPickerLabel.h */,
 				3D15D90AE40B475DB908EC75 /* RNCPickerLabel.m */,
-				C674AC2F809245C59EE36B18 /* RNCPickerManager.h */,
-				EB9CF85A7D224B3D86D33F95 /* RNCPickerManager.m */,
 			);
 			name = Picker;
 			sourceTree = "<group>";
@@ -3411,9 +3402,7 @@
 				8B1448C54DEB4CFDB79D7E45 /* RNCSafeAreaViewMode.m in Sources */,
 				6782D340A0024AF58B3805D0 /* RNSVGTopAlignedLabel.ios.m in Sources */,
 				827A699919CED163689E655D /* ExpoModulesProvider.swift in Sources */,
-				A55AB920150243ACAA249F76 /* RNCPicker.m in Sources */,
 				5C125576DAE64294975CF6D4 /* RNCPickerLabel.m in Sources */,
-				B9F55E4D0C2F42B7BB63D59F /* RNCPickerManager.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/Exponent.xcodeproj/project.pbxproj
+++ b/ios/Exponent.xcodeproj/project.pbxproj
@@ -626,6 +626,9 @@
 		FCF6D37025B34BC200808BF5 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCF6D36F25B34BC200808BF5 /* NotificationService.swift */; };
 		FCF6D37425B34BC200808BF5 /* ExpoNotificationServiceExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = FCF6D36D25B34BC200808BF5 /* ExpoNotificationServiceExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		FE8D4A1FC2BDC25C8D4684F8 /* ExpoModulesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C849D84FFC04012BBF6DFFD /* ExpoModulesProvider.swift */; };
+		A55AB920150243ACAA249F76 /* RNCPicker.m in Sources */ = {isa = PBXBuildFile; fileRef = C1C2106811C34CB4B9804EF2 /* RNCPicker.m */; settings = {COMPILER_FLAGS = "-w"; }; };
+		5C125576DAE64294975CF6D4 /* RNCPickerLabel.m in Sources */ = {isa = PBXBuildFile; fileRef = 3D15D90AE40B475DB908EC75 /* RNCPickerLabel.m */; settings = {COMPILER_FLAGS = "-w"; }; };
+		B9F55E4D0C2F42B7BB63D59F /* RNCPickerManager.m in Sources */ = {isa = PBXBuildFile; fileRef = EB9CF85A7D224B3D86D33F95 /* RNCPickerManager.m */; settings = {COMPILER_FLAGS = "-w"; }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1337,6 +1340,12 @@
 		FCF6D36D25B34BC200808BF5 /* ExpoNotificationServiceExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = ExpoNotificationServiceExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		FCF6D36F25B34BC200808BF5 /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
 		FCF6D37125B34BC200808BF5 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		C8125860CA594B978340A46A /* RNCPicker.h */ = {isa = PBXFileReference; name = "RNCPicker.h"; path = "RNCPicker.h"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; explicitFileType = undefined; includeInIndex = 0; };
+		C1C2106811C34CB4B9804EF2 /* RNCPicker.m */ = {isa = PBXFileReference; name = "RNCPicker.m"; path = "RNCPicker.m"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; explicitFileType = undefined; includeInIndex = 0; };
+		1CC901538F9947439D43E69A /* RNCPickerLabel.h */ = {isa = PBXFileReference; name = "RNCPickerLabel.h"; path = "RNCPickerLabel.h"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; explicitFileType = undefined; includeInIndex = 0; };
+		3D15D90AE40B475DB908EC75 /* RNCPickerLabel.m */ = {isa = PBXFileReference; name = "RNCPickerLabel.m"; path = "RNCPickerLabel.m"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; explicitFileType = undefined; includeInIndex = 0; };
+		C674AC2F809245C59EE36B18 /* RNCPickerManager.h */ = {isa = PBXFileReference; name = "RNCPickerManager.h"; path = "RNCPickerManager.h"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; explicitFileType = undefined; includeInIndex = 0; };
+		EB9CF85A7D224B3D86D33F95 /* RNCPickerManager.m */ = {isa = PBXFileReference; name = "RNCPickerManager.m"; path = "RNCPickerManager.m"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; explicitFileType = undefined; includeInIndex = 0; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1391,6 +1400,12 @@
 				07CB4DC826045AFE0057443E /* RNCPicker.m */,
 				07CB4DC926045AFE0057443E /* RNCPickerManager.h */,
 				07CB4DCA26045AFE0057443E /* RNCPickerManager.m */,
+				C8125860CA594B978340A46A /* RNCPicker.h */,
+				C1C2106811C34CB4B9804EF2 /* RNCPicker.m */,
+				1CC901538F9947439D43E69A /* RNCPickerLabel.h */,
+				3D15D90AE40B475DB908EC75 /* RNCPickerLabel.m */,
+				C674AC2F809245C59EE36B18 /* RNCPickerManager.h */,
+				EB9CF85A7D224B3D86D33F95 /* RNCPickerManager.m */,
 			);
 			name = Picker;
 			sourceTree = "<group>";
@@ -3396,6 +3411,9 @@
 				8B1448C54DEB4CFDB79D7E45 /* RNCSafeAreaViewMode.m in Sources */,
 				6782D340A0024AF58B3805D0 /* RNSVGTopAlignedLabel.ios.m in Sources */,
 				827A699919CED163689E655D /* ExpoModulesProvider.swift in Sources */,
+				A55AB920150243ACAA249F76 /* RNCPicker.m in Sources */,
+				5C125576DAE64294975CF6D4 /* RNCPickerLabel.m in Sources */,
+				B9F55E4D0C2F42B7BB63D59F /* RNCPickerManager.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/Exponent/Versioned/Core/Api/Components/Picker/RNCPicker.h
+++ b/ios/Exponent/Versioned/Core/Api/Components/Picker/RNCPicker.h
@@ -9,6 +9,8 @@
 
 #import <React/UIView+React.h>
 
+#import "RNCPickerLabel.h"
+
 @interface RNCPicker : UIPickerView
 
 @property (nonatomic, copy) NSArray<NSDictionary *> *items;
@@ -17,6 +19,8 @@
 @property (nonatomic, strong) UIColor *color;
 @property (nonatomic, strong) UIFont *font;
 @property (nonatomic, assign) NSTextAlignment textAlign;
+
+@property (nonatomic, assign) NSInteger numberOfLines;
 
 @property (nonatomic, copy) RCTBubblingEventBlock onChange;
 

--- a/ios/Exponent/Versioned/Core/Api/Components/Picker/RNCPickerLabel.h
+++ b/ios/Exponent/Versioned/Core/Api/Components/Picker/RNCPickerLabel.h
@@ -1,0 +1,10 @@
+#import <UIKit/UIKit.h>
+
+@interface RNCPickerLabel : UILabel
+
+@property (nonatomic, assign) CGFloat topInset;
+@property (nonatomic, assign) CGFloat bottomInset;
+@property (nonatomic, assign) CGFloat leftInset;
+@property (nonatomic, assign) CGFloat rightInset;
+
+@end

--- a/ios/Exponent/Versioned/Core/Api/Components/Picker/RNCPickerLabel.m
+++ b/ios/Exponent/Versioned/Core/Api/Components/Picker/RNCPickerLabel.m
@@ -1,0 +1,31 @@
+#import "RNCPickerLabel.h"
+
+@implementation RNCPickerLabel
+
+- (instancetype)initWithFrame:(CGRect)frame
+{
+    self = [super initWithFrame:frame];
+    if (self) {
+        self.topInset = 0.0;
+        self.bottomInset = 0.0;
+        self.leftInset = 0.0;
+        self.rightInset = 0.0;
+    }
+    return self;
+}
+
+- (void)drawTextInRect:(CGRect)rect
+{
+    UIEdgeInsets insets = UIEdgeInsetsMake(self.topInset, self.leftInset, self.bottomInset, self.rightInset);
+    [super drawTextInRect:UIEdgeInsetsInsetRect(rect, insets)];
+}
+
+- (CGSize)intrinsicContentSize
+{
+    CGSize intrinsicSuperViewContentSize = [super intrinsicContentSize];
+    intrinsicSuperViewContentSize.height += self.topInset + self.bottomInset;
+    intrinsicSuperViewContentSize.width += self.leftInset + self.rightInset;
+    return intrinsicSuperViewContentSize;
+}
+
+@end

--- a/ios/Exponent/Versioned/Core/Api/Components/Picker/RNCPickerManager.m
+++ b/ios/Exponent/Versioned/Core/Api/Components/Picker/RNCPickerManager.m
@@ -25,6 +25,7 @@ RCT_EXPORT_VIEW_PROPERTY(selectedIndex, NSInteger)
 RCT_EXPORT_VIEW_PROPERTY(onChange, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(color, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(textAlign, NSTextAlignment)
+RCT_EXPORT_VIEW_PROPERTY(numberOfLines, NSInteger)
 RCT_CUSTOM_VIEW_PROPERTY(fontSize, NSNumber, RNCPicker)
 {
   view.font = [RCTFont updateFont:view.font withSize:json ?: @(defaultView.font.pointSize)];

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -6,7 +6,7 @@
   "@react-native-community/netinfo": "7.1.3",
   "@react-native-community/slider": "4.1.12",
   "@react-native-community/viewpager": "5.0.11",
-  "@react-native-picker/picker": "2.1.0",
+  "@react-native-picker/picker": "2.2.1",
   "@react-native-segmented-control/segmented-control": "2.4.0",
   "@stripe/stripe-react-native": "0.2.2",
   "@unimodules/core": "~7.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2890,15 +2890,15 @@
   resolved "https://registry.yarnpkg.com/@react-native-community/viewpager/-/viewpager-5.0.11.tgz#dbeb2d1b2452607926407c99e4de59c7db9e3019"
   integrity sha512-eboJwbDQjP1qJP3LFzVspgh88IGNF07S2qpU296j+4kL0inVuL+HXs81SuczMGtJmDZ4u19RNEBVq79of/h+jQ==
 
-"@react-native-masked-view/masked-view@0.2.5":
-  version "0.2.5"
-  resolved "https://registry.yarnpkg.com/@react-native-masked-view/masked-view/-/masked-view-0.2.5.tgz#2505f269a53b134e3306a2772d981138e11f1537"
-  integrity sha512-yXaWyV8xu1N5tfdfP8L29U0TIDvBriN4zHUI+Zs7Sw+VI8pBbEEYoITK9aFt495Y0/PPm4FsTpa35hOeTLfGPA==
+"@react-native-masked-view/masked-view@0.2.6":
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/@react-native-masked-view/masked-view/-/masked-view-0.2.6.tgz#b26c52d5db3ad0926b13deea79c69620966a9221"
+  integrity sha512-303CxmetUmgiX9NSUxatZkNh9qTYYdiM8xkGf9I3Uj20U3eGY3M78ljeNQ4UVCJA+FNGS5nC1dtS9GjIqvB4dg==
 
-"@react-native-picker/picker@2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@react-native-picker/picker/-/picker-2.1.0.tgz#1ef22d4e9b2e555d44b43453f51a46d8631f3182"
-  integrity sha512-iJ/QaDrBMBaW6cFuQyR3DXzcn2h7c5O7mGgmNLCBQHTTtLNBZR+Sxogy6YleFPeToNdysG5mTTkXqBmlWHMQqg==
+"@react-native-picker/picker@2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@react-native-picker/picker/-/picker-2.2.1.tgz#32b9f540d8e88a73d8856f73cca88251cecb9614"
+  integrity sha512-EC7yv22QLHlTfnbC1ez9IUdXTOh1W31x96Oir0PfskSGFFJMWWdLTg4VrcE2DsGLzbfjjkBk123c173vf2a5MQ==
 
 "@react-native-segmented-control/segmented-control@2.4.0":
   version "2.4.0"
@@ -14832,10 +14832,10 @@ react-native-maps@0.28.0:
   dependencies:
     "@types/geojson" "^7946.0.7"
 
-react-native-pager-view@5.4.6:
-  version "5.4.6"
-  resolved "https://registry.yarnpkg.com/react-native-pager-view/-/react-native-pager-view-5.4.6.tgz#21d16b67136301875da1355dc9d442a4aafab1c7"
-  integrity sha512-yZiG65xlOeC8LOCNF0N8Cdc+MDQGWJnOpsmlHAndWXQhuVPjj4/KnS556BeTddcQ2EqJu/DjL7o8j0hpB+nkVg==
+react-native-pager-view@5.4.9:
+  version "5.4.9"
+  resolved "https://registry.yarnpkg.com/react-native-pager-view/-/react-native-pager-view-5.4.9.tgz#c0d40847cfeda5a4e729b53271b0ee0fedff3eb5"
+  integrity sha512-D6tzxpwMGdl6CXgtskGWhKRc5cJakCazESRGt7PkqnpyiH3N35ft1KmR82pCSQetAFlytFiToeu3a/dG5CELvA==
 
 react-native-paper@^4.0.1:
   version "4.9.2"


### PR DESCRIPTION
# Why

Fixes [ENG-2541](https://linear.app/expo/issue/ENG-2541/react-native-pickerpicker-210-221)

# How

- `$ et uvm --module "@react-native-picker/picker" --commit "v2.2.1" --target "expo-go"`
- `$ yarn && et pod-install -f`

# Test Plan

- [X] Android (unversioned) works
- [x] iOS (unversioned) works

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
