### PR TITLE
[tools] API Generation: avoid OOM issue, bump TypeDoc

### DIFF
--- a/tools/package.json
+++ b/tools/package.json
@@ -90,7 +90,7 @@
     "tar": "^4.4.18",
     "terminal-link": "^2.1.1",
     "transformer-proxy": "^0.3.4",
-    "typedoc": "^0.22.7",
+    "typedoc": "^0.22.10",
     "uuid": "^3.1.0",
     "ws": "^7.4.6",
     "xcode": "^2.0.0"

--- a/tools/yarn.lock
+++ b/tools/yarn.lock
@@ -15862,10 +15862,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typedoc@^0.22.7:
-  version "0.22.7"
-  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.22.7.tgz#e5e095ab14676296f4b12ac3355321eae650e447"
-  integrity sha512-ndxxp+tU1Wczvdxp4u2/PvT1qjD6hdFdSdehpORHjE+JXmMkl2bftXCR0upHmsnesBG7VCcr8vfgloGHIH8glQ==
+typedoc@^0.22.10:
+  version "0.22.10"
+  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.22.10.tgz#221e1a2b17bcb71817ef027dc4c4969d572e7620"
+  integrity sha512-hQYZ4WtoMZ61wDC6w10kxA42+jclWngdmztNZsDvIz7BMJg7F2xnT+uYsUa7OluyKossdFj9E9Ye4QOZKTy8SA==
   dependencies:
     glob "^7.2.0"
     lunr "^2.3.9"


### PR DESCRIPTION
# Why

Currently, the list of the packages using autogenerated docs grow so much, that executing extract tasks for all of them in parallel, might result in heap OOM issues.

# How

To fix this problem I have used `cwait` library, which already has been used in few `tools` commands and I have set the max number of concurrent tasks to the CPUs count. I have also extracted the packages mapping to the single file-scoped constant, mainly for the readability.

I have also updated TypeDoc in this PR, but there were no changes directly to the generation part, so after files regeneration there were no changes in JSON files.

# Test Plan

After the change, extracting data for all of the packages (`et gdad`) no longer ends on heap OOM on one of my test devices.

# Checklist
- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
