### PR TITLE
[expo-updates] add DEFAULT 0 to new error recovery DB columns

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add local SQLite fields for error recovery manager on iOS. ([#14610](https://github.com/expo/expo/pull/14610) by [@esamelson](https://github.com/esamelson))
 - Add DB migration for above. ([#14718](https://github.com/expo/expo/pull/14718) by [@esamelson](https://github.com/esamelson))
 - Add local SQLite fields and DB migration for error recovery manager on Android. ([#15218](https://github.com/expo/expo/pull/15218) by [@esamelson](https://github.com/esamelson))
+- Add DEFAULT 0 to new error recovery DB columns. ([#15360](https://github.com/expo/expo/pull/15360) by [@esamelson](https://github.com/esamelson))
 
 ### 🎉 New features
 

--- a/packages/expo-updates/android/build.gradle
+++ b/packages/expo-updates/android/build.gradle
@@ -95,7 +95,7 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
 
-  def room_version = "2.1.0"
+  def room_version = "2.3.0"
 
   implementation "androidx.room:room-runtime:$room_version"
   kapt "androidx.room:room-compiler:$room_version"

--- a/packages/expo-updates/android/src/androidTest/schemas/expo.modules.updates.db.UpdatesDatabase/8.json
+++ b/packages/expo-updates/android/src/androidTest/schemas/expo.modules.updates.db.UpdatesDatabase/8.json
@@ -2,11 +2,11 @@
   "formatVersion": 1,
   "database": {
     "version": 8,
-    "identityHash": "7cef8efc604ba63917f4e7c834268b9d",
+    "identityHash": "536a4a7d1c2bd53759471da31a5db6f2",
     "entities": [
       {
         "tableName": "updates",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`launch_asset_id` INTEGER, `manifest` TEXT, `status` INTEGER NOT NULL, `keep` INTEGER NOT NULL, `last_accessed` INTEGER NOT NULL, `successful_launch_count` INTEGER NOT NULL, `failed_launch_count` INTEGER NOT NULL, `id` BLOB NOT NULL, `commit_time` INTEGER NOT NULL, `runtime_version` TEXT NOT NULL, `scope_key` TEXT NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`launch_asset_id`) REFERENCES `assets`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`launch_asset_id` INTEGER, `manifest` TEXT, `status` INTEGER NOT NULL, `keep` INTEGER NOT NULL, `last_accessed` INTEGER NOT NULL, `successful_launch_count` INTEGER NOT NULL DEFAULT 0, `failed_launch_count` INTEGER NOT NULL DEFAULT 0, `id` BLOB NOT NULL, `commit_time` INTEGER NOT NULL, `runtime_version` TEXT NOT NULL, `scope_key` TEXT NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`launch_asset_id`) REFERENCES `assets`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
         "fields": [
           {
             "fieldPath": "launchAssetId",
@@ -42,13 +42,15 @@
             "fieldPath": "successfulLaunchCount",
             "columnName": "successful_launch_count",
             "affinity": "INTEGER",
-            "notNull": true
+            "notNull": true,
+            "defaultValue": "0"
           },
           {
             "fieldPath": "failedLaunchCount",
             "columnName": "failed_launch_count",
             "affinity": "INTEGER",
-            "notNull": true
+            "notNull": true,
+            "defaultValue": "0"
           },
           {
             "fieldPath": "id",
@@ -88,7 +90,7 @@
             "columnNames": [
               "launch_asset_id"
             ],
-            "createSql": "CREATE  INDEX `index_updates_launch_asset_id` ON `${TABLE_NAME}` (`launch_asset_id`)"
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_updates_launch_asset_id` ON `${TABLE_NAME}` (`launch_asset_id`)"
           },
           {
             "name": "index_updates_scope_key_commit_time",
@@ -97,7 +99,7 @@
               "scope_key",
               "commit_time"
             ],
-            "createSql": "CREATE UNIQUE INDEX `index_updates_scope_key_commit_time` ON `${TABLE_NAME}` (`scope_key`, `commit_time`)"
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_updates_scope_key_commit_time` ON `${TABLE_NAME}` (`scope_key`, `commit_time`)"
           }
         ],
         "foreignKeys": [
@@ -145,7 +147,7 @@
             "columnNames": [
               "asset_id"
             ],
-            "createSql": "CREATE  INDEX `index_updates_assets_asset_id` ON `${TABLE_NAME}` (`asset_id`)"
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_updates_assets_asset_id` ON `${TABLE_NAME}` (`asset_id`)"
           }
         ],
         "foreignKeys": [
@@ -257,7 +259,7 @@
             "columnNames": [
               "key"
             ],
-            "createSql": "CREATE UNIQUE INDEX `index_assets_key` ON `${TABLE_NAME}` (`key`)"
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_assets_key` ON `${TABLE_NAME}` (`key`)"
           }
         ],
         "foreignKeys": []
@@ -310,7 +312,7 @@
             "columnNames": [
               "scope_key"
             ],
-            "createSql": "CREATE  INDEX `index_json_data_scope_key` ON `${TABLE_NAME}` (`scope_key`)"
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_json_data_scope_key` ON `${TABLE_NAME}` (`scope_key`)"
           }
         ],
         "foreignKeys": []
@@ -319,7 +321,7 @@
     "views": [],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '7cef8efc604ba63917f4e7c834268b9d')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '536a4a7d1c2bd53759471da31a5db6f2')"
     ]
   }
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/UpdatesDatabase.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/UpdatesDatabase.kt
@@ -140,7 +140,7 @@ abstract class UpdatesDatabase : RoomDatabase() {
           database.execSQL("PRAGMA foreign_keys=OFF")
           database.beginTransaction()
           try {
-            database.execSQL("CREATE TABLE `new_updates` (`id` BLOB NOT NULL, `scope_key` TEXT NOT NULL, `commit_time` INTEGER NOT NULL, `runtime_version` TEXT NOT NULL, `launch_asset_id` INTEGER, `manifest` TEXT, `status` INTEGER NOT NULL, `keep` INTEGER NOT NULL, `last_accessed` INTEGER NOT NULL, `successful_launch_count` INTEGER NOT NULL, `failed_launch_count` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`launch_asset_id`) REFERENCES `assets`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )")
+            database.execSQL("CREATE TABLE `new_updates` (`id` BLOB NOT NULL, `scope_key` TEXT NOT NULL, `commit_time` INTEGER NOT NULL, `runtime_version` TEXT NOT NULL, `launch_asset_id` INTEGER, `manifest` TEXT, `status` INTEGER NOT NULL, `keep` INTEGER NOT NULL, `last_accessed` INTEGER NOT NULL, `successful_launch_count` INTEGER NOT NULL DEFAULT 0, `failed_launch_count` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`), FOREIGN KEY(`launch_asset_id`) REFERENCES `assets`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )")
 
             // insert `1` for successful_launch_count for all existing updates
             // to make sure we don't roll back past them

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/entity/UpdateEntity.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/entity/UpdateEntity.kt
@@ -39,9 +39,9 @@ class UpdateEntity(
   @ColumnInfo(name = "last_accessed")
   var lastAccessed: Date = Date()
 
-  @ColumnInfo(name = "successful_launch_count")
+  @ColumnInfo(name = "successful_launch_count", defaultValue = "0")
   var successfulLaunchCount = 0
 
-  @ColumnInfo(name = "failed_launch_count")
+  @ColumnInfo(name = "failed_launch_count", defaultValue = "0")
   var failedLaunchCount = 0
 }

--- a/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabaseInitialization.m
+++ b/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabaseInitialization.m
@@ -21,8 +21,8 @@ CREATE TABLE \"updates\" (\
 \"status\"  INTEGER NOT NULL,\
 \"keep\"  INTEGER NOT NULL,\
 \"last_accessed\"  INTEGER NOT NULL,\
-\"successful_launch_count\"  INTEGER NOT NULL,\
-\"failed_launch_count\"  INTEGER NOT NULL,\
+\"successful_launch_count\"  INTEGER NOT NULL DEFAULT 0,\
+\"failed_launch_count\"  INTEGER NOT NULL DEFAULT 0,\
 PRIMARY KEY(\"id\"),\
 FOREIGN KEY(\"launch_asset_id\") REFERENCES \"assets\"(\"id\") ON DELETE CASCADE\
 );\

--- a/packages/expo-updates/ios/EXUpdates/Database/Migrations/EXUpdatesDatabaseMigration6To7.m
+++ b/packages/expo-updates/ios/EXUpdates/Database/Migrations/EXUpdatesDatabaseMigration6To7.m
@@ -29,8 +29,8 @@ static NSString * const EXUpdatesDatabaseV6Filename = @"expo-v6.db";
         \"status\"  INTEGER NOT NULL,\
         \"keep\"  INTEGER NOT NULL,\
         \"last_accessed\"  INTEGER NOT NULL,\
-        \"successful_launch_count\"  INTEGER NOT NULL,\
-        \"failed_launch_count\"  INTEGER NOT NULL,\
+        \"successful_launch_count\"  INTEGER NOT NULL DEFAULT 0,\
+        \"failed_launch_count\"  INTEGER NOT NULL DEFAULT 0,\
         PRIMARY KEY(\"id\"),\
         FOREIGN KEY(\"launch_asset_id\") REFERENCES \"assets\"(\"id\") ON DELETE CASCADE\
         )"]) return NO;


### PR DESCRIPTION
# Why

Follow up from https://github.com/expo/expo/pull/15218#pullrequestreview-810148390

# How

Android:
- Upgrade room version in order to get access to `ColumnInfo.defaultValue` property
- Add default value of 0 to fields in UpdateEntity
- Add `DEFAULT 0` to new table creation in migration
- Re-export new v8 schema and ensure tests pass

iOS
- Add `DEFAULT 0` to initial schema and migration

There is no need to bump the DB version number as long as this is landed before the existing changes on master are published or released.

# Test Plan

All existing DB tests pass on both platforms. Additionally, on iOS I grepped for `successful_launch_count` to ensure there weren't any other locations that needed to know about the default value.

This default value is never used by runtime code, it's just for future proofing, so there shouldn't be any need to run further tests.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
