### PR TITLE
[home] fix tsc error reported in CI

### DIFF
--- a/home/utils/Environment.ts
+++ b/home/utils/Environment.ts
@@ -33,7 +33,7 @@ if (SupportedExpoSdks.length > 0) {
 
 const supportedSdksString = `SDK${
   SupportedExpoSdks.length === 1 ? ':' : 's:'
-} ${sortedSupportedExpoSdks.map(semver.major).join(', ')}`;
+} ${sortedSupportedExpoSdks.map((sdk) => semver.major(sdk)).join(', ')}`;
 
 export default {
   isProduction,


### PR DESCRIPTION
# Why

* https://github.com/expo/expo/runs/4372665635?check_suite_focus=true

# How

Do not pass `semver.major` method directly to `map`.

# Test Plan

`yarn tsc` yield no errors.

# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
