### PR TITLE
Upgrade @react-native-masked-view/masked-view

### DIFF
--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -96,7 +96,7 @@
     "@react-native-community/netinfo": "6.0.2",
     "@react-native-community/slider": "4.1.4",
     "@react-native-community/viewpager": "5.0.11",
-    "@react-native-masked-view/masked-view": "0.2.5",
+    "@react-native-masked-view/masked-view": "0.2.6",
     "@react-native-picker/picker": "2.1.0",
     "@react-native-segmented-control/segmented-control": "2.4.0",
     "expo": "~44.0.0-alpha.0",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -45,7 +45,7 @@
     "@react-native-community/datetimepicker": "3.5.2",
     "@react-native-community/netinfo": "6.0.2",
     "@react-native-community/slider": "4.1.4",
-    "@react-native-masked-view/masked-view": "0.2.5",
+    "@react-native-masked-view/masked-view": "0.2.6",
     "@react-native-picker/picker": "2.1.0",
     "@react-native-segmented-control/segmented-control": "2.4.0",
     "@react-navigation/bottom-tabs": "~5.11.1",

--- a/ios/Exponent.xcodeproj/project.pbxproj
+++ b/ios/Exponent.xcodeproj/project.pbxproj
@@ -5,7 +5,6 @@
 	};
 	objectVersion = 46;
 	objects = {
-
 /* Begin PBXBuildFile section */
 		0726F0592007E438004992E7 /* EXKernelAppRecord.m in Sources */ = {isa = PBXBuildFile; fileRef = 0726F0582007E438004992E7 /* EXKernelAppRecord.m */; };
 		0726F05C2007E446004992E7 /* EXKernelAppRegistry.m in Sources */ = {isa = PBXBuildFile; fileRef = 0726F05B2007E446004992E7 /* EXKernelAppRegistry.m */; };

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -2,7 +2,7 @@
   "@expo/vector-icons": "^12.0.0",
   "@react-native-async-storage/async-storage": "~1.15.0",
   "@react-native-community/datetimepicker": "3.5.2",
-  "@react-native-masked-view/masked-view": "0.2.5",
+  "@react-native-masked-view/masked-view": "0.2.6",
   "@react-native-community/netinfo": "6.0.2",
   "@react-native-community/slider": "4.1.7",
   "@react-native-community/viewpager": "5.0.11",


### PR DESCRIPTION
# Why

Fixes ENG-2538

# How

`et update-vendored-module -m @react-native-masked-view` (main branch points to 0.2.6 release commit)

# Test Plan

Tested in NCL on iOS and Android