### PR TITLE
[docs] Fixed broken link

### DIFF
--- a/docs/pages/build/automating-submissions.md
+++ b/docs/pages/build/automating-submissions.md
@@ -4,7 +4,7 @@ title: Automating submissions
 
 Many mobile deployment processes eventually evolve to the point where the app is automatically submitted to the respective store once an appropriate build is completed. This saves developers from having to wait around for the build to complete, avoids a bit of manual work, and eliminates the need to coordinate providing app store credentials to the team.
 
-EAS Build gives you automatic submissions out of the box with the `--auto-submit` flag. This flag tells EAS Build to pass the build along to EAS Submit with the appropriate submission profile upon completion. Refer to the [EAS Submit documentation](https://docs.expo.dev/submit/introduction/) for more information on how to set up and configure submissions.
+EAS Build gives you automatic submissions out of the box with the `--auto-submit` flag. This flag tells EAS Build to pass the build along to EAS Submit with the appropriate submission profile upon completion. Refer to the [EAS Submit documentation](/submit/introduction) for more information on how to set up and configure submissions.
 
 When you run `eas build --auto-submit` you will be provided with a link to a submission details page, where you can track the progress of the submission. You can also find this page at any time on the [submissions dashboard for your project](https://expo.dev/accounts/[account]/projects/[project]/submissions), and it is linked from your build detials page.
 

--- a/docs/pages/build/automating-submissions.md
+++ b/docs/pages/build/automating-submissions.md
@@ -4,7 +4,7 @@ title: Automating submissions
 
 Many mobile deployment processes eventually evolve to the point where the app is automatically submitted to the respective store once an appropriate build is completed. This saves developers from having to wait around for the build to complete, avoids a bit of manual work, and eliminates the need to coordinate providing app store credentials to the team.
 
-EAS Build gives you automatic submissions out of the box with the `--auto-submit` flag. This flag tells EAS Build to pass the build along to EAS Submit with the appropriate submission profile upon completion. Refer to the [EAS Submit documentation](http://localhost:3002/submit/introduction/) for more information on how to set up and configure submissions.
+EAS Build gives you automatic submissions out of the box with the `--auto-submit` flag. This flag tells EAS Build to pass the build along to EAS Submit with the appropriate submission profile upon completion. Refer to the [EAS Submit documentation](https://docs.expo.dev/submit/introduction/) for more information on how to set up and configure submissions.
 
 When you run `eas build --auto-submit` you will be provided with a link to a submission details page, where you can track the progress of the submission. You can also find this page at any time on the [submissions dashboard for your project](https://expo.dev/accounts/[account]/projects/[project]/submissions), and it is linked from your build detials page.
 


### PR DESCRIPTION
# Why

The url prefix to `EAS Submit documentation` was `localhost` instead of `docs.expo.dev`.

