### PR TITLE
Keep same QR worker alive as long as possible

### DIFF
--- a/packages/expo-camera/src/useWebQRScanner.ts
+++ b/packages/expo-camera/src/useWebQRScanner.ts
@@ -39,7 +39,7 @@ const qrWorkerMethod = ({ data, width, height }: ImageData): any => {
 function useRemoteJsQR() {
   return useWorker(qrWorkerMethod, {
     remoteDependencies: ['https://cdn.jsdelivr.net/npm/jsqr@1.2.0/dist/jsQR.min.js'],
-    timeout: 5000,
+    autoTerminate: false,
   });
 }
 


### PR DESCRIPTION
# Why

Today, at each `interval` (default to [16ms ](https://github.com/expo/expo/blob/master/packages/expo-camera/src/useWebQRScanner.ts#L94)!) in order to scan the current image for a code, a request is sent to 'https://cdn.jsdelivr.net/npm/jsqr@1.2.0/dist/jsQR.min.js' to get some source code which is then loaded and executed in a new worker to look for a potential code. This could be optimized to lower network use, memory use and processing.

# How

Set `autoTerminate ` to `false` so that when a scan is done, the worker is kept awake and can be reused for the next scan. Remove `timeout` which is not (only) a timeout for one scan but for keeping the worker awake. Note that, with a timeout, when it's reached during a scan, the scan never ends so no other scan is scheduled a codes are no more detected.

# Test Plan

Before, requests to 'https://cdn.jsdelivr.net/npm/jsqr@1.2.0/dist/jsQR.min.js' every 16ms.
After, just one request when the `Camera` component is loaded and everything works fine (scanning a code, unmounting then remounting the component...).

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
