### PR TITLE
[core][ios] Fix Double to CGFloat conversion to support Xcode 12

### DIFF
--- a/packages/expo-modules-core/ios/Swift/Arguments/Convertibles.swift
+++ b/packages/expo-modules-core/ios/Swift/Arguments/Convertibles.swift
@@ -32,7 +32,7 @@ extension UIColor: ConvertibleArgument {
     }
     if let components = value as? [Double] {
       let alpha = components.count > 3 ? components[3] : 1.0
-      return Self.init(red: components[0], green: components[1], blue: components[2], alpha: alpha)
+      return Self.init(red: CGFloat(components[0]), green: CGFloat(components[1]), blue: CGFloat(components[2]), alpha: CGFloat(alpha))
     }
     if let value = value as? Int {
       return try Conversions.toColor(argb: UInt64(value)) as! Self


### PR DESCRIPTION
# Why

I've been working with @tsapeta to test out the upcoming updates for expo-modules-core. I ran into an issue where the local build would fail because I was using xcode 12, where double's and CGFloats require explicit coercion. Mutating the code locally like this fixed my issue!

# How

I installed the new expo 44 beta, expo-modules-core 5.0 and ran `expo prebuild` and then `expo run:ios`

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
