### PR TITLE
[blur][docs] Fix docs layout

### DIFF
--- a/docs/components/plugins/APISection.tsx
+++ b/docs/components/plugins/APISection.tsx
@@ -43,7 +43,7 @@ const isListener = ({ name }: GeneratedData) =>
 const isProp = ({ name }: GeneratedData) => name.includes('Props') && name !== 'ErrorRecoveryProps';
 
 const isComponent = ({ type, extendedTypes, signatures }: GeneratedData) =>
-  type?.name === 'React.FC' ||
+  (type?.name && ['React.FC', 'ForwardRefExoticComponent'].includes(type?.name)) ||
   (extendedTypes && extendedTypes.length ? extendedTypes[0].name === 'Component' : false) ||
   (signatures && signatures[0]
     ? signatures[0].type.name === 'Element' ||
@@ -51,7 +51,8 @@ const isComponent = ({ type, extendedTypes, signatures }: GeneratedData) =>
     : false);
 
 const isConstant = ({ name, type }: GeneratedData) =>
-  name !== 'default' && name !== 'Constants' && type?.name !== 'React.FC';
+  !['default', 'Constants'].includes(name) &&
+  !(type?.name && ['React.FC', 'ForwardRefExoticComponent'].includes(type?.name));
 
 const renderAPI = (
   packageName: string,


### PR DESCRIPTION
# Why

| https://github.com/expo/expo/pull/14946    | this PR   |
|---|---|
|  <img width="1084" alt="Incorrect documentation" src="https://user-images.githubusercontent.com/16623003/144251969-091e2a4e-b7bb-45bc-9fc3-a83f5765ce59.png">  | <img width="798" alt="Better documentation" src="https://user-images.githubusercontent.com/16623003/144252402-0b7d8aed-0efd-414d-af86-f892a02936f9.png">  | 

# How

- Add support for `React.forwardRef` return type - `ForwardRefExoticComponent`
- Add support for `intersection` type coming from types intersection (`Type3 = Type1 & Type2`)
- Add `omittableTypes` to discrad internal-only types (here `RefAttributes` supporting type)
- Add `replaceableTypes` to replace misleading type names with more-recognizeable ones (here `ForwardRefExoticComponent` to `Component`)

# Test Plan

- `cd docs && yarn dev`
- open local docs and navigate to unversioned `BlurView` screen

# TODOs for external PRs:

- [ ] Fix expanding `BlurViewProps` as an argument for `Component` type
- [ ] Propose correction for union types to get rid of such fragment: (for `BlurTint`)`string - Acceptable values are: 'light', 'dark', 'default'.`. I imagine we should go with explicit narrowed down values: `BlurTint: 'light', 'dark', 'default'.` (without `string`)
- [ ] I would argue that we should clarify `Components` section alongside Component-related props. See https://docs.expo.dev/versions/latest/sdk/apple-authentication/#components - Props are not listed in the right-side navigation and this problem occurs in this component as well. Do we need to have this `Components` header at all? 🤔 