### PR TITLE
[module-scripts] Fix source-login-scripts.sh be generated in other expo modules

### DIFF
--- a/packages/expo-module-scripts/README.md
+++ b/packages/expo-module-scripts/README.md
@@ -67,7 +67,7 @@ Running `yarn` will now run the `prepare` script, which generates any missing fi
 
 Besides, running `yarn prepare` script will also synchronize optional files from `expo-module-scripts` when the file is present and contains the `@generated` pattern:
 
-- [`source-login-scripts.sh`](./templates/scripts/source-login-scripts.sh) A Xcode build phases scripts helper for nodejs binary resolution. For example, we need to source login shell config for `nvm`.
+- [`source-login-scripts.sh`](./templates/scripts/source-login-scripts.sh): An Xcode build phase script helper for Node.js binary resolution. For example, we need to source login shell configs for `nvm`.
 
 ### 🔌 Config Plugin
 

--- a/packages/expo-module-scripts/README.md
+++ b/packages/expo-module-scripts/README.md
@@ -65,6 +65,10 @@ Running `yarn` will now run the `prepare` script, which generates any missing fi
   - Try and incorporate a table of contents (TOC).
 - [`tsconfig.json`](./templates/tsconfig.json) ([docs](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html)) extends [`tsconfig.base.json`](./tsconfig.base.json) this is important for ensuring all Unimodules use the same version of TypeScript.
 
+Besides, running `yarn prepare` script will also synchronize optional files from `expo-module-scripts` when the file is present and contains the `@generated` pattern:
+
+- [`source-login-scripts.sh`](./templates/scripts/source-login-scripts.sh) A Xcode build phases scripts helper for nodejs binary resolution. For example, we need to source login shell config for `nvm`.
+
 ### 🔌 Config Plugin
 
 To create a [config plugin](https://github.com/expo/expo-cli/blob/master/packages/config-plugins/README.md) that automatically configures your native code, you have two options:

--- a/packages/expo-module-scripts/bin/expo-module-configure
+++ b/packages/expo-module-scripts/bin/expo-module-configure
@@ -6,14 +6,14 @@ script_dir="$(dirname "$0")"
 
 shopt -s dotglob
 
-# an optional template file will only be synced if target file is present in file system,
-# and its content contains `@generated` pattern.
+# an optional template file will be synced only if the target file is present in the file system,
+# and its content contains the string `@generated`.
 OPTIONAL_TEMPLATE_FILES=(
-  # add a relative file path from `templates/` for new optional file
+  # add a relative file path from `templates/` for each new optional file
   "scripts/source-login-scripts.sh"
 )
 
-# returns relative file paths inside a given directory.
+# returns relative file paths inside a given directory without the leading "./".
 # usage: get_relative_files "/path/to/dir"
 get_relative_files() {
   pushd $1 > /dev/null
@@ -23,7 +23,7 @@ get_relative_files() {
 }
 
 
-# sync file if target file is missing or the existing file contains `@generated` pattern.
+# syncs the source file if the target file is missing or the existing file contains `@generated`.
 # usage: sync_file_if_missing "/path/source_path" "/path/target_path"
 sync_file_if_missing() {
   local source=$1
@@ -34,7 +34,7 @@ sync_file_if_missing() {
   fi
 }
 
-# sync file if target file is present in file system and its content contains `@generated` pattern.
+# syncs the source file if the target file is present in the file system and its content contains `@generated`.
 # usage: sync_file_if_present "/path/source_path" "/path/target_path"
 sync_file_if_present() {
   local source=$1
@@ -46,7 +46,7 @@ sync_file_if_present() {
 }
 
 # check if a file is listed in `OPTIONAL_TEMPLATE_FILES`.
-# usage: if is_optional_file "/path/to/file"; then ... fi
+# usage: if is_optional_file "path/to/file"; then ... fi
 is_optional_file() {
   local file=$1
   for optional_file in "${OPTIONAL_TEMPLATE_FILES[@]}"; do

--- a/packages/expo-module-scripts/bin/expo-module-configure
+++ b/packages/expo-module-scripts/bin/expo-module-configure
@@ -6,8 +6,15 @@ script_dir="$(dirname "$0")"
 
 shopt -s dotglob
 
-# this function returns relative file paths inside a given directory.
-# usage: get_relative_files /path/to/dir
+# an optional template file will only be synced if target file is present in file system,
+# and its content contains `@generated` pattern.
+OPTIONAL_TEMPLATE_FILES=(
+  # add a relative file path from `templates/` for new optional file
+  "scripts/source-login-scripts.sh"
+)
+
+# returns relative file paths inside a given directory.
+# usage: get_relative_files "/path/to/dir"
 get_relative_files() {
   pushd $1 > /dev/null
   local files=$(find . -type f | cut -c 3-)
@@ -16,13 +23,54 @@ get_relative_files() {
 }
 
 
+# sync file if target file is missing or the existing file contains `@generated` pattern.
+# usage: sync_file_if_missing "/path/source_path" "/path/target_path"
+sync_file_if_missing() {
+  local source=$1
+  local target=$2
+  # echo "sync_file_if_missing $source -> $target"
+  if [ ! -f "$target" ] || grep --quiet "@generated" "$target"; then
+    rsync --checksum "$source" "$target"
+  fi
+}
+
+# sync file if target file is present in file system and its content contains `@generated` pattern.
+# usage: sync_file_if_present "/path/source_path" "/path/target_path"
+sync_file_if_present() {
+  local source=$1
+  local target=$2
+  # echo "sync_file_if_present $source -> $target"
+  if [ -f "$target" ] && grep --quiet "@generated" "$target"; then
+    rsync --checksum "$source" "$target"
+  fi
+}
+
+# check if a file is listed in `OPTIONAL_TEMPLATE_FILES`.
+# usage: if is_optional_file "/path/to/file"; then ... fi
+is_optional_file() {
+  local file=$1
+  for optional_file in "${OPTIONAL_TEMPLATE_FILES[@]}"; do
+    if [ "$file" = "$optional_file" ]; then
+      true
+      return
+    fi
+  done
+
+  false
+  return
+}
+
+#
+# script main starts from here
+#
+
 "$script_dir/expo-module-readme"
 
 template_files=$(get_relative_files "$script_dir/../templates")
 for template_relative_file in $template_files; do
-  output_file=$template_relative_file
-  source_template_file="$script_dir/../templates/$template_relative_file"
-  if [ ! -f "$output_file" ] || grep --quiet "@generated" "$output_file"; then
-    rsync --checksum "$source_template_file" "$output_file"
+  if is_optional_file "$template_relative_file"; then
+    sync_file_if_present "$script_dir/../templates/$template_relative_file" "$template_relative_file"
+  else
+    sync_file_if_missing "$script_dir/../templates/$template_relative_file" "$template_relative_file"
   fi
 done


### PR DESCRIPTION
# Why

regression of #15336, where we should not sync `source-login-scripts.sh` to other expo modules.
i just misread the `if [ ! -f "$output_file" ] || grep --quiet "@generated" "$output_file"; then` line.

# How

- introduce `source-login-scripts.sh` as an optional template file which only to sync if it's present and contains `@generated` pattern as described in https://github.com/expo/expo/pull/15336#discussion_r758905459

# Test Plan

- `yarn prepare` in expo-device and make sure `source-login-scripts.sh` not be generated.
- change `source-login-scripts.sh` and `yarn prepare` in expo-constants. check it's updated.

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
  - #15336 is not published yet, i'm not going to update changelog again.
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
