### PR TITLE
[templates] Align Android back button behavior with classic build

### DIFF
--- a/templates/expo-template-bare-minimum/android/app/src/main/java/com/helloworld/MainActivity.java
+++ b/templates/expo-template-bare-minimum/android/app/src/main/java/com/helloworld/MainActivity.java
@@ -1,5 +1,6 @@
 package com.helloworld;
 
+import android.os.Build;
 import android.os.Bundle;
 
 import com.facebook.react.ReactActivity;

--- a/templates/expo-template-bare-minimum/android/app/src/main/java/com/helloworld/MainActivity.java
+++ b/templates/expo-template-bare-minimum/android/app/src/main/java/com/helloworld/MainActivity.java
@@ -39,4 +39,24 @@ public class MainActivity extends ReactActivity {
       }
     });
   }
+
+  /**
+   * We try to align the back button behavior with Android S
+   * where moving root activities to background instead of finishing activities.
+   * @see <a href="https://developer.android.com/reference/android/app/Activity#onBackPressed()">onBackPressed</a>
+   */
+  @Override
+  public void invokeDefaultOnBackPressed() {
+    if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.R) {
+      if (!moveTaskToBack(false)) {
+        // For non-root activities, use the default implementation to finish them.
+        super.invokeDefaultOnBackPressed();
+      }
+      return;
+    }
+
+    // Use the default back button implementation on Android S
+    // because it's doing more than {@link Activity#moveTaskToBack} in fact.
+    super.invokeDefaultOnBackPressed();
+  }
 }

--- a/templates/expo-template-bare-minimum/android/app/src/main/java/com/helloworld/MainActivity.java
+++ b/templates/expo-template-bare-minimum/android/app/src/main/java/com/helloworld/MainActivity.java
@@ -41,7 +41,7 @@ public class MainActivity extends ReactActivity {
   }
 
   /**
-   * We try to align the back button behavior with Android S
+   * Align the back button behavior with Android S
    * where moving root activities to background instead of finishing activities.
    * @see <a href="https://developer.android.com/reference/android/app/Activity#onBackPressed()">onBackPressed</a>
    */


### PR DESCRIPTION
# Why

fix #15326 where we have the default Android implementation on eas build but move activities to background on [classic build](https://github.com/expo/expo/blob/28d5976df2379540936083e599b100a50bd3575d/android/expoview/src/main/java/host/exp/exponent/experience/BaseExperienceActivity.kt#L93-L103). actually, finishing activities is the default behavior on Android, so i kinda dunno which solution is better. after i found that on Android S, [the default behavior for root activities is also moving background](https://developer.android.com/about/versions/12/behavior-changes-all#back-press), i would try to align the design with Android S.

# How

- for android <= 11 + root activities, move to background.
- for android <= 11 + non-root activities, use the platform default implementation (`finish()`)
- for android > 11, use the platform default implementation. (assuming to move root activities in background) 

# Test Plan

use the [example repo](https://github.com/psnet/eastest) from #15326 + this patch
- test `expo run:android`
- test `eas build`

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- n/a This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
