### PR TITLE
[dev-client][plugin] Remove unneeded `react-native.config.js` modification

### DIFF
--- a/packages/expo-dev-client/plugin/build/withDevClient.js
+++ b/packages/expo-dev-client/plugin/build/withDevClient.js
@@ -8,48 +8,12 @@ const config_plugins_1 = require("@expo/config-plugins");
 const app_plugin_1 = __importDefault(require("expo-dev-launcher/app.plugin"));
 // @ts-expect-error missing types
 const app_plugin_2 = __importDefault(require("expo-dev-menu/app.plugin"));
-const fs_1 = __importDefault(require("fs"));
-const path_1 = __importDefault(require("path"));
-const constants_1 = require("./constants");
 const withGeneratedAndroidScheme_1 = require("./withGeneratedAndroidScheme");
 const withGeneratedIosScheme_1 = require("./withGeneratedIosScheme");
 const pkg = require('expo-dev-client/package.json');
-const REACT_NATIVE_CONFIG_JS = `// File created by expo-dev-client/app.plugin.js
-
-module.exports = {
-  dependencies: {
-    ...require('expo-dev-client/dependencies'),
-  },
-};
-`;
-function withReactNativeConfigJs(config) {
-    config = (0, config_plugins_1.withDangerousMod)(config, ['android', addReactNativeConfigAsync]);
-    config = (0, config_plugins_1.withDangerousMod)(config, ['ios', addReactNativeConfigAsync]);
-    return config;
-}
-const addReactNativeConfigAsync = async (config) => {
-    const filename = path_1.default.join(config.modRequest.projectRoot, 'react-native.config.js');
-    try {
-        const config = fs_1.default.readFileSync(filename, 'utf8');
-        if (!config.includes('expo-dev-client/dependencies')) {
-            throw new Error(`Could not add expo-dev-client dependencies to existing file ${filename}. See expo-dev-client installation instructions to add them manually: ${constants_1.InstallationPage}`);
-        }
-    }
-    catch (error) {
-        if (error.code === 'ENOENT') {
-            // The file doesn't exist, so we create it.
-            fs_1.default.writeFileSync(filename, REACT_NATIVE_CONFIG_JS);
-        }
-        else {
-            throw error;
-        }
-    }
-    return config;
-};
 function withDevClient(config) {
     config = (0, app_plugin_2.default)(config);
     config = (0, app_plugin_1.default)(config);
-    config = withReactNativeConfigJs(config);
     config = (0, withGeneratedAndroidScheme_1.withGeneratedAndroidScheme)(config);
     config = (0, withGeneratedIosScheme_1.withGeneratedIosScheme)(config);
     return config;

--- a/packages/expo-dev-client/plugin/src/withDevClient.ts
+++ b/packages/expo-dev-client/plugin/src/withDevClient.ts
@@ -1,57 +1,18 @@
-import { createRunOncePlugin, Mod, withDangerousMod } from '@expo/config-plugins';
+import { createRunOncePlugin } from '@expo/config-plugins';
 import { ExpoConfig } from '@expo/config-types';
 // @ts-expect-error missing types
 import withDevLauncher from 'expo-dev-launcher/app.plugin';
 // @ts-expect-error missing types
 import withDevMenu from 'expo-dev-menu/app.plugin';
-import fs from 'fs';
-import path from 'path';
 
-import { InstallationPage } from './constants';
 import { withGeneratedAndroidScheme } from './withGeneratedAndroidScheme';
 import { withGeneratedIosScheme } from './withGeneratedIosScheme';
 
 const pkg = require('expo-dev-client/package.json');
 
-const REACT_NATIVE_CONFIG_JS = `// File created by expo-dev-client/app.plugin.js
-
-module.exports = {
-  dependencies: {
-    ...require('expo-dev-client/dependencies'),
-  },
-};
-`;
-
-function withReactNativeConfigJs(config: ExpoConfig): ExpoConfig {
-  config = withDangerousMod(config, ['android', addReactNativeConfigAsync]);
-  config = withDangerousMod(config, ['ios', addReactNativeConfigAsync]);
-  return config;
-}
-
-const addReactNativeConfigAsync: Mod = async (config) => {
-  const filename = path.join(config.modRequest.projectRoot, 'react-native.config.js');
-  try {
-    const config = fs.readFileSync(filename, 'utf8');
-    if (!config.includes('expo-dev-client/dependencies')) {
-      throw new Error(
-        `Could not add expo-dev-client dependencies to existing file ${filename}. See expo-dev-client installation instructions to add them manually: ${InstallationPage}`
-      );
-    }
-  } catch (error: any) {
-    if (error.code === 'ENOENT') {
-      // The file doesn't exist, so we create it.
-      fs.writeFileSync(filename, REACT_NATIVE_CONFIG_JS);
-    } else {
-      throw error;
-    }
-  }
-  return config;
-};
-
 function withDevClient(config: ExpoConfig) {
   config = withDevMenu(config);
   config = withDevLauncher(config);
-  config = withReactNativeConfigJs(config);
   config = withGeneratedAndroidScheme(config);
   config = withGeneratedIosScheme(config);
   return config;


### PR DESCRIPTION
# Why

Closes ENG-1694

# How

After we land https://github.com/expo/expo/pull/15379, we won't longer need to link our dependencies through `react-native.config.js`. So we can remove it ;)

# Test Plan

- Run config plugin and see if `react-native.config.js` was created ✅