### PR TITLE
[bare-expo] Change `cleartextTrafficPermitted` setting

### DIFF
--- a/apps/bare-expo/android/app/src/debug/res/xml/network_security_config.xml
+++ b/apps/bare-expo/android/app/src/debug/res/xml/network_security_config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config xmlns:tools="http://schemas.android.com/tools">
+  <base-config
+    cleartextTrafficPermitted="true"
+    tools:ignore="InsecureBaseConfiguration" />
+</network-security-config>

--- a/apps/bare-expo/android/app/src/main/res/xml/network_security_config.xml
+++ b/apps/bare-expo/android/app/src/main/res/xml/network_security_config.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<network-security-config xmlns:tools="http://schemas.android.com/tools">
-  <base-config
-    cleartextTrafficPermitted="true"
-    tools:ignore="InsecureBaseConfiguration" />
+<network-security-config>
+  <domain-config cleartextTrafficPermitted="true">
+    <!-- for detox testing on release build, we need cleartext traffic from local server -->
+    <domain includeSubdomains="true">10.0.2.2</domain>
+    <domain includeSubdomains="true">localhost</domain>
+  </domain-config>
 </network-security-config>

--- a/apps/bare-expo/android/app/src/main/res/xml/network_security_config.xml
+++ b/apps/bare-expo/android/app/src/main/res/xml/network_security_config.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<network-security-config>
-    <domain-config cleartextTrafficPermitted="true">
-        <!-- for detox testing on release build, we need cleartext traffic from local server -->
-        <domain includeSubdomains="true">10.0.2.2</domain>
-        <domain includeSubdomains="true">localhost</domain>
-    </domain-config>
+<network-security-config xmlns:tools="http://schemas.android.com/tools">
+  <base-config
+    cleartextTrafficPermitted="true"
+    tools:ignore="InsecureBaseConfiguration" />
 </network-security-config>


### PR DESCRIPTION
# Why

During `expo-dev-client` QA, I noticed that I wasn't able to connect to any application due to a cleartext traffic error on Android 11+. 
This setting is by default set to true in react-native projects.  

# Test Plan

- dev-client in bare-expo is now working on Android 11+ ✅