### PR TITLE
[Expo Go][Android] Add expo-system-ui

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.kt
@@ -4,6 +4,7 @@ package host.exp.exponent.experience
 import android.app.Activity
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.graphics.Color
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
@@ -211,10 +212,24 @@ abstract class ReactNativeActivity :
       layoutParams.height = FrameLayout.LayoutParams.MATCH_PARENT
       containerView.layoutParams = layoutParams
     }
+
+    try {
+      // NOTE(evanbacon): Use the same view as the `expo-system-ui` module.
+      // Set before the application code runs to ensure immediate SystemUI calls overwrite the app.json value.
+      var rootView = this.window.decorView
+      ExperienceActivityUtils.setRootViewBackgroundColor(manifest!!, rootView)
+    } catch (e: Exception) {
+      EXL.e(TAG, e)
+    }
+
     waitForReactRootViewToHaveChildrenAndRunCallback {
       onDoneLoading()
       try {
-        ExperienceActivityUtils.setRootViewBackgroundColor(manifest!!, rootView!!)
+        // NOTE(evanbacon): The hierarchy at this point looks like:
+        // window.decorView > [4 other views] > containerView > reactContainerView > rootView > [RN App]
+        // This can be inspected using Android Studio: View > Tool Windows > Layout Inspector.
+        // Container background color is set for "loading" view state, we need to set it to transparent to prevent obstructing the root view.
+        containerView!!.setBackgroundColor(Color.TRANSPARENT)
       } catch (e: Exception) {
         EXL.e(TAG, e)
       }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/ExperiencePackagePicker.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/ExperiencePackagePicker.kt
@@ -57,6 +57,7 @@ import expo.modules.storereview.StoreReviewPackage
 import expo.modules.taskManager.TaskManagerPackage
 import expo.modules.updates.UpdatesPackage
 import expo.modules.manifests.core.Manifest
+import expo.modules.systemui.SystemUIPackage
 import expo.modules.videothumbnails.VideoThumbnailsPackage
 import expo.modules.webbrowser.WebBrowserPackage
 
@@ -115,6 +116,7 @@ object ExperiencePackagePicker {
     SharingPackage(),
     SpeechPackage(),
     SplashScreenPackage(),
+    SystemUIPackage(),
     TaskManagerPackage(),
     UpdatesPackage(),
     VideoThumbnailsPackage(),

--- a/apps/native-component-list/src/screens/SystemUIScreen.tsx
+++ b/apps/native-component-list/src/screens/SystemUIScreen.tsx
@@ -33,7 +33,7 @@ function BackgroundColorExample() {
       />
       <Button
         onPress={async () => setColor(await SystemUI.getBackgroundColorAsync())}
-        title={`Get background color to random color: ${color?.toString()}`}
+        title={`Get background color: ${color?.toString()}`}
       />
     </>
   );


### PR DESCRIPTION
# Why

- Android companion to https://github.com/expo/expo/pull/15128
- ENG-2472

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

- Expose expo-system-ui to Expo Go Android projects
- Make the app.json value set the activity decor view background color instead of one of the child views. This ensures that Expo Go uses the same view as `expo-system-ui`.
- Set the `containerView` to transparent on app loaded so it doesn't obstruct the decor view. 

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

- Case 1 (Expo Go):
  - `app.json`: 
    - `android.backgroundColor = undefined` 
    - `splash.backgroundColor = undefined` 
  - `App.js`: nothing
  - -> Splash is white, App background color is `white`, reloading app is `white`
- Case 2 (Expo Go + Config + Splash):
  - `app.json`: 
    - `android.backgroundColor = 'yellow'` 
    - `splash.backgroundColor = 'green'` 
  - `App.js`: nothing
  - -> Splash is green, App background color is `yellow`, reloading app is still `yellow`, changing backgroundColor in app.json and reloading should update background color.
- Case 3 (Expo Go + Config + API):
  - `app.json`: 
    - `android.backgroundColor = 'yellow'` 
    - `splash.backgroundColor = undefined` 
  - `App.js`: `SystemUI.setBackgroundColorAsync('blue')` (ASAP) 
  - -> Splash is white, App background color is `blue`, reloading app is still `blue`
- Case 4: [This works as expected](https://github.com/expo/examples/blob/master/with-splash-screen/App.js).

## Before

<img width="231" alt="Screen Shot 2021-12-01 at 3 34 15 PM" src="https://user-images.githubusercontent.com/9664363/144330112-2935581a-ff9a-4065-bf5c-d3358a386071.png">

## After

<img width="162" alt="Screen Shot 2021-12-01 at 4 23 22 PM" src="https://user-images.githubusercontent.com/9664363/144330169-9b21442c-0b47-49c1-98e1-287989ebf937.png">




<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
