### PR TITLE
[docs][expo-updates] Update spec for multipart manifest responses

### DIFF
--- a/docs/pages/technical-specs/expo-updates-0.md
+++ b/docs/pages/technical-specs/expo-updates-0.md
@@ -58,7 +58,7 @@ expo-runtime-version: *
 
 ## Manifest Response
 
-A conformant server MUST return a response structured in at least one of two ways. A conformant server MAY support either or both response structures, and when an unsupported response structure is requested the server should respond with a `406` error.
+A conformant server MUST return a response structured in at least one of two ways. A conformant server MAY support either or both response structures, and when an unsupported response structure is requested the server SHOULD respond with an HTTP `406` error status.
 - For a response with `content-type: application/json` or `content-type: application/expo+json`, the [manifest headers](#manifest-response-headers) MUST be sent in the response headers and the [manifest body](#manifest-response-body) MUST be sent in the response body.
 - For a response with `content-type: multipart/mixed`, the response MUST be structured as specified in the [multipart manifest response](#multipart-manifest-response) section.
 

--- a/docs/pages/technical-specs/expo-updates-0.md
+++ b/docs/pages/technical-specs/expo-updates-0.md
@@ -47,7 +47,7 @@ A conformant client library MUST make a GET request with the headers:
 2. `expo-runtime-version` MUST be a runtime version compatible with the client. A runtime version stipulates the native code setup a client is running. It should be set when the client is built. For example, in an iOS client, the value may be set in a plist file.
 3. Any headers stipulated by a previous responses' [server defined headers](#manifest-response-headers).
 
-A conformant client library MUST also send at least one of `accept: application/expo+json`, `accept: application/json`, or `accept: multipart/mixed` though SHOULD send `accept: application/expo+json, application/json, multipart/mixed` with preferences expressed with "q" parameters as specified in [RFC 7231](https://datatracker.ietf.org/doc/html/rfc7231#section-5.3.1).
+A conformant client library MUST also send at least one of `accept: application/expo+json`, `accept: application/json`, or `accept: multipart/mixed` based on the supported response structures though SHOULD send `accept: application/expo+json, application/json, multipart/mixed`. A conformant client library MAY express preference using "q" parameters as specified in [RFC 7231](https://datatracker.ietf.org/doc/html/rfc7231#section-5.3.1), which default to `1`.
 
 Example:
 ```
@@ -58,7 +58,7 @@ expo-runtime-version: *
 
 ## Manifest Response
 
-A conformant server MUST return a response structured in one of two ways:
+A conformant server MUST return a response structured in at least one of two ways. A conformant server MAY support either or both response structures, and when an unsupported response structure is requested the server should respond with a `406` error.
 - For a response with `content-type: application/json` or `content-type: application/expo+json`, the [manifest headers](#manifest-response-headers) MUST be sent in the response headers and the [manifest body](#manifest-response-body) MUST be sent in the response body.
 - For a response with `content-type: multipart/mixed`, the response MUST be structured as specified in the [multipart manifest response](#multipart-manifest-response) section.
 
@@ -130,11 +130,11 @@ type Asset = {
 
 A manifest response of this format is defined by the `multipart/mixed` MIME type as defined by [RFC 2046](https://tools.ietf.org/html/rfc2046#section-5.1). Each part is defined as follows:
 1. REQUIRED `"manifest"` part:
-    - MUST have a `content-disposition` header with a name parameter equal to `manifest`. e.g. `content-disposition: inline; name="manifest"`
+    - MUST have a `content-disposition` header with a name parameter equal to `manifest`. e.g. `content-disposition: inline; name="manifest"`.
     - The [manifest headers](#manifest-response-headers) MUST be sent in the part headers.
     - The [manifest body](#manifest-response-body) MUST be sent in the part body.
 2. OPTIONAL `"extensions"` part:
-    - MUST have `content-disposition` header with a name parameter equal to `extensions`. e.g. `content-disposition: inline; name="extensions"`
+    - MUST have `content-disposition` header with a name parameter equal to `extensions`. e.g. `content-disposition: inline; name="extensions"`.
     - MUST have header `content-type: application/json`.
     - The [manifest extensions](#manifest-extensions) MUST be sent in the part body.
 

--- a/docs/pages/technical-specs/expo-updates-0.md
+++ b/docs/pages/technical-specs/expo-updates-0.md
@@ -47,11 +47,11 @@ A conformant client library MUST make a GET request with the headers:
 2. `expo-runtime-version` MUST be a runtime version compatible with the client. A runtime version stipulates the native code setup a client is running. It should be set when the client is built. For example, in an iOS client, the value may be set in a plist file.
 3. Any headers stipulated by a previous responses' [server defined headers](#manifest-response-headers).
 
-A conformant client library MUST also send at least one of `accept: application/expo+json`, `accept: application/json`, or `accept: multipart/mixed` though SHOULD send `accept: application/expo+json, application/json,multipart/mixed` with the order following the preference ordering for the accept header specified in [RFC 7231](https://tools.ietf.org/html/rfc7231#section-5.3.2).
+A conformant client library MUST also send at least one of `accept: application/expo+json`, `accept: application/json`, or `accept: multipart/mixed` though SHOULD send `accept: application/expo+json, application/json, multipart/mixed` with preferences expressed with "q" parameters as specified in [RFC 7231](https://datatracker.ietf.org/doc/html/rfc7231#section-5.3.1).
 
 Example:
 ```
-accept: application/expo+json, application/json, multipart/mixed
+accept: application/expo+json;q=0.9, application/json;q=0.8, multipart/mixed
 expo-platform: *
 expo-runtime-version: *
 ```
@@ -60,7 +60,7 @@ expo-runtime-version: *
 
 A conformant server MUST return a response structured in one of two ways:
 - For a response with `content-type: application/json` or `content-type: application/expo+json`, the [manifest headers](#manifest-response-headers) MUST be sent in the response headers and the [manifest body](#manifest-response-body) MUST be sent in the response body.
-- For a response with `content-type: multipart/mixed`, the response should be structured as specified in the [multipart manifest response](#multipart-manifest-response) section.
+- For a response with `content-type: multipart/mixed`, the response MUST be structured as specified in the [multipart manifest response](#multipart-manifest-response) section.
 
 The choice of manifest and headers are dependent on the values of the request headers. A conformant server MUST respond with a manifest for the most recent update, ordered by creation time, satisfying all parameters and constraints imposed by the [request headers](#manifest-request). The server MAY use any properties of the request like its headers and source IP address to choose amongst several updates that all satisfy the request's constraints.
 
@@ -130,11 +130,11 @@ type Asset = {
 
 A manifest response of this format is defined by the `multipart/mixed` MIME type as defined by [RFC 2046](https://tools.ietf.org/html/rfc2046#section-5.1). Each part is defined as follows:
 1. REQUIRED `"manifest"` part:
-    - MUST have header `content-disposition: inline; name="manifest"` to identify this part.
+    - MUST have a `content-disposition` header with a name parameter equal to `manifest`. e.g. `content-disposition: inline; name="manifest"`
     - The [manifest headers](#manifest-response-headers) MUST be sent in the part headers.
     - The [manifest body](#manifest-response-body) MUST be sent in the part body.
 2. OPTIONAL `"extensions"` part:
-    - MUST have header `content-disposition: inline; name="extensions"` to identify this part.
+    - MUST have `content-disposition` header with a name parameter equal to `extensions`. e.g. `content-disposition: inline; name="extensions"`
     - MUST have header `content-type: application/json`.
     - The [manifest extensions](#manifest-extensions) MUST be sent in the part body.
 
@@ -148,7 +148,7 @@ type ManifestExtensions = {
 }
 
 type ExpoAssetHeaderDictionary = {
-  [key: <asset key>]: {
+  [assetKey: string]: {
     'header-name': 'header-value',
     ...
   };
@@ -166,7 +166,7 @@ accept: image/jpeg, */*
 accept-encoding: br, gzip
 ```
 
-A conformant client library SHOULD also include any header (key, value) pairs included in [`assetRequestHeaders`](#manifest-extensions) for this asset key.
+A conformant client library MUST also include any header (key, value) pairs included in [`assetRequestHeaders`](#manifest-extensions) for this asset key.
 
 ## Asset Response
 

--- a/docs/pages/technical-specs/expo-updates-0.md
+++ b/docs/pages/technical-specs/expo-updates-0.md
@@ -5,7 +5,7 @@ sidebar_title: Expo Updates
 
 Version 0
 
-Updated 2021-05-24
+Updated 2021-12-01
 
 ---
 
@@ -31,7 +31,7 @@ Expo Updates is a protocol for assembling and delivering updates to apps running
 An app running a conformant Expo Updates client library MUST load the most recent update saved in the client library's cache, possibly after filtering by the contents of the manifest's [_metadata_](#manifest-response-body).
 
 The following describes how a conformant Expo Updates client library MUST retrieve a new update from a conformant server:
-1. The client library will make a [request](#request) for the most recent manifest, with constraints specified in the headers. 
+1. The client library will make a [request](#request) for the most recent manifest, with constraints specified in the headers.
 2. If a new manifest is downloaded, the client library will proceed to make additional requests to download and store any missing assets specified in the manifest.
 3. The client library will edit its local state to reflect that a new update has been added to the local cache. It will also update the local state with the new `expo-manifest-filters` and `expo-server-defined-headers` found in the response [headers](#manifest-response-headers).
 
@@ -44,25 +44,25 @@ A conformant client library MUST make a GET request with the headers:
     * iOS MUST be `expo-platform: ios`.
     * Android MUST be `expo-platform: android`.
     * If it is not one of these platforms, the server SHOULD return a 400 or a 404
-2. `expo-runtime-version` MUST be a runtime version compatible with the client. A runtime version stipulates the native code setup a client is running. It should be set when the client is built. For example, in an iOS client, the value may be set in a plist file. 
+2. `expo-runtime-version` MUST be a runtime version compatible with the client. A runtime version stipulates the native code setup a client is running. It should be set when the client is built. For example, in an iOS client, the value may be set in a plist file.
 3. Any headers stipulated by a previous responses' [server defined headers](#manifest-response-headers).
 
-A conformant client library MUST also send at least one of `accept: application/expo+json` or `accept: application/json`, though SHOULD send `accept: application/expo+json, application/json` with the order following the preference ordering for the accept header specified in [RFC 7231](https://tools.ietf.org/html/rfc7231#section-5.3.2).
+A conformant client library MUST also send at least one of `accept: application/expo+json`, `accept: application/json`, or `accept: multipart/mixed` though SHOULD send `accept: application/expo+json, application/json,multipart/mixed` with the order following the preference ordering for the accept header specified in [RFC 7231](https://tools.ietf.org/html/rfc7231#section-5.3.2).
 
 Example:
 ```
-accept: application/expo+json, application/json
+accept: application/expo+json, application/json, multipart/mixed
 expo-platform: *
 expo-runtime-version: *
 ```
 
 ## Manifest Response
 
-A conformant server MUST return a response containing a [manifest body](#manifest-response-body) and [headers](#manifest-response-headers).
+A conformant server MUST return a response structured in one of two ways:
+- For a response with `content-type: application/json` or `content-type: application/expo+json`, the [manifest headers](#manifest-response-headers) MUST be sent in the response headers and the [manifest body](#manifest-response-body) MUST be sent in the response body.
+- For a response with `content-type: multipart/mixed`, the response should be structured as specified in the [multipart manifest response](#multipart-manifest-response) section.
 
-The choice of manifest and headers are dependent on the values of the request headers. A conformant server MUST:
-
-* Respond with a manifest for the most recent update, ordered by creation time, satisfying all parameters and constraints imposed by the [request headers](#manifest-request). The server MAY use any properties of the request like its headers and source IP address to choose amongst several updates that all satisfy the request's constraints.
+The choice of manifest and headers are dependent on the values of the request headers. A conformant server MUST respond with a manifest for the most recent update, ordered by creation time, satisfying all parameters and constraints imposed by the [request headers](#manifest-request). The server MAY use any properties of the request like its headers and source IP address to choose amongst several updates that all satisfy the request's constraints.
 
 ### Manifest Response Headers
 
@@ -76,24 +76,17 @@ content-type: *
 ```
 
 * `expo-protocol-version` describes the version of the protocol defined in this spec and MUST be `0`.
-* `expo-sfv-version`  MUST be `0`.
+* `expo-sfv-version` MUST be `0`.
 * `expo-manifest-filters` is an [Expo SFV](expo-sfv-0.md) dictionary. It is used to filter updates stored by the client library by the `metadata` attribute found in the [manifest](#manifest-response-body). If a field is mentioned in the filter, the corresponding field in the metadata must either be missing or equal for the update to be included. The client library MUST store the manifest filters until it is overwritten by a newer response.
 * `expo-server-defined-headers` is an [Expo SFV](expo-sfv.md) dictionary. It defines headers that a client library MUST store until overwritten by a newer dictionary, and they MUST be included in every subsequent [manifest request](#manifest-request).
-* `cache-control` - A value of `cache-control: private, max-age=0` is recommended to ensure the newest manifest is returned. Setting longer cache ages could result in stale updates.
+* `cache-control` MUST be set to an appropriately short period of time. A value of `cache-control: private, max-age=0` is recommended to ensure the newest manifest is returned. Setting longer cache ages could result in stale updates.
 * `content-type` MUST be determined by _proactive negotiation_ as defined in [RFC 7231](https://tools.ietf.org/html/rfc7231#section-3.4.1). Since the client library is [required](#manifest-request) to send an `accept` header with each manifest request, this will always be either `application/expo+json`, `application/json`; otherwise the request would return a `406` error.
-
-
-The manifest endpoint MUST also be served with a `cache-control` header set to an appropriately short period of time. For example:
-
-```
-cache-control: max-age=0, private
-```
 
 ### Manifest Response Body
 
 The body of the response MUST be a manifest, which is defined as JSON conforming to both the following `Manifest` definition expressed in [TypeScript](https://www.typescriptlang.org/) and the detailed descriptions for each field:
 ```typescript
-export type Manifest = {
+type Manifest = {
   id: string;
   createdAt: string;
   runtimeVersion: string;
@@ -120,19 +113,49 @@ type Asset = {
     * `hash`: SHA-256 hash of the file to guarantee integrity.
     * `key`: Key used to reference this asset from the update's application code. This key, for example, may be generated by a separate build step that processes the application code, such as a bundler.
     * `contentType`: The MIME type of the file as defined by [RFC 2045](https://tools.ietf.org/html/rfc2045). e.g. `application/javascript`, `image/jpeg`.
-    * `fileExtension`: The suggested extension to use when a file is saved on a client. Some platforms, such as iOS, require certain file types to be saved with an extension. The extension MUST be prefixed with a `.`. e.g. **.jpeg**. In some cases, such as the launchAsset, this field will be ignored in favor of a locally determined extension. If the field is omitted and there is no locally stipulated extension, the asset will be saved without an extension, e.g. `./filename` with no `.` at the end. 
+    * `fileExtension`: The suggested extension to use when a file is saved on a client. Some platforms, such as iOS, require certain file types to be saved with an extension. The extension MUST be prefixed with a `.`. e.g. **.jpeg**. In some cases, such as the launchAsset, this field will be ignored in favor of a locally determined extension. If the field is omitted and there is no locally stipulated extension, the asset will be saved without an extension, e.g. `./filename` with no `.` at the end.
     A conforming client SHOULD prefix a file extension with a `.` if a file extension is not empty and missing the `.` prefix.
     * `url`: Location at which the file may be fetched.
   * `metadata`: The metadata associated with an update. It is a string-valued dictionary. The server MAY send back anything it wishes to be used for filtering the updates. The metadata MUST pass the filter defined in the accompanying `expo-manifest-filters` header.
   * `extra`: For storage of optional "extra" information such as third-party configuration. For example, if the update is hosted on Expo Application Services (EAS), the EAS project ID may be included:
-  ```typescript
-  extra: {
-    eas: {
-      projectId: '00000000-0000-0000-0000-000000000000'
+  ```json
+  "extra": {
+    "eas": {
+      "projectId": "00000000-0000-0000-0000-000000000000"
     }
-    ...
   }
   ```
+
+### Multipart Manifest Response
+
+A manifest response of this format is defined by the `multipart/mixed` MIME type as defined by [RFC 2046](https://tools.ietf.org/html/rfc2046#section-5.1). Each part is defined as follows:
+1. REQUIRED `"manifest"` part:
+    - MUST have header `content-disposition: inline; name="manifest"` to identify this part.
+    - The [manifest headers](#manifest-response-headers) MUST be sent in the part headers.
+    - The [manifest body](#manifest-response-body) MUST be sent in the part body.
+2. OPTIONAL `"extensions"` part:
+    - MUST have header `content-disposition: inline; name="extensions"` to identify this part.
+    - MUST have header `content-type: application/json`.
+    - The [manifest extensions](#manifest-extensions) MUST be sent in the part body.
+
+### Manifest Extensions
+
+Defined as JSON conforming to both the following `ManifestExtensions` definition expressed in [TypeScript](https://www.typescriptlang.org/) and the detailed descriptions for each field:
+```typescript
+type ManifestExtensions = {
+  assetRequestHeaders: ExpoAssetHeaderDictionary;
+  ...
+}
+
+type ExpoAssetHeaderDictionary = {
+  [key: <asset key>]: {
+    'header-name': 'header-value',
+    ...
+  };
+  ...
+}
+```
+  * `assetRequestHeaders`: MAY contain an dictionary of header (key, value) pairs to include with asset requests.
 
 ## Asset Request
 A conformant client library MUST make a GET request to the asset URLs specified by the manifest. The client library SHOULD include a header accepting the asset's content type as specified in the manifest. Additionally, the client library SHOULD specify the compression encoding the client library is capable of handling.
@@ -143,11 +166,13 @@ accept: image/jpeg, */*
 accept-encoding: br, gzip
 ```
 
+A conformant client library SHOULD also include any header (key, value) pairs included in [`assetRequestHeaders`](#manifest-extensions) for this asset key.
+
 ## Asset Response
 
 An asset located at a particular URL MUST NOT be changed or removed since client libraries may fetch assets for any update at any time.
 
-### Asset Headers
+### Asset Response Headers
 
 The asset MUST be encoded using a compression format that the client supports according to the request's `accept-encoding` header. The server MAY serve uncompressed assets. The response MUST include a `content-type` header with the MIME type of the asset.
 For example:
@@ -157,7 +182,7 @@ content-type: application/javascript
 ```
 
 An asset is RECOMMENDED to be served with a `cache-control` header set to a long duration as an asset located at a given URL must not change. For example:
-	
+
 ```
 cache-control: public, max-age=31536000, immutable
 ```


### PR DESCRIPTION
# Why

This adds specification for the alternative `multipart/mixed` response structure for manifest responses, which is needed in order to send pieces of data to the client that shouldn't/can't be within the manifest itself since dynamic data within the manifest body makes end-to-end signing of the manifest body impossible.

Closes ENG-2558.

# How

Update spec.

# Test Plan

Read new spec, ensure it makes sense.