### PR TITLE
[barecode-scanner] Fix crashes caused by Zxing scanner on Android.

### DIFF
--- a/packages/expo-barcode-scanner/CHANGELOG.md
+++ b/packages/expo-barcode-scanner/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed crashes caused by the Zxing scanner on Android.
+
 ### 💡 Others
 
 ## 11.1.0 — 2021-10-01

--- a/packages/expo-barcode-scanner/CHANGELOG.md
+++ b/packages/expo-barcode-scanner/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed crashes caused by the Zxing scanner on Android.
+- Fixed crashes caused by the Zxing scanner on Android. ([#15394](https://github.com/expo/expo/pull/15394) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-barcode-scanner/android/src/main/java/expo/modules/barcodescanner/scanners/ZxingBarCodeScanner.kt
+++ b/packages/expo-barcode-scanner/android/src/main/java/expo/modules/barcodescanner/scanners/ZxingBarCodeScanner.kt
@@ -32,7 +32,7 @@ class ZxingBarCodeScanner(context: Context) : ExpoBarCodeScanner(context) {
 
   override val isAvailable = true
 
-  override fun scan(data: ByteArray, width: Int, height: Int, rotation: Int): BarCodeScannerResult {
+  override fun scan(data: ByteArray, width: Int, height: Int, rotation: Int): BarCodeScannerResult? {
     // rotate for zxing if orientation is portrait
     var innerData = data
     var innerWidth = width
@@ -53,9 +53,7 @@ class ZxingBarCodeScanner(context: Context) : ExpoBarCodeScanner(context) {
       innerWidth -= innerHeight
       innerData = rotated
     }
-    return requireNotNull(
-      scan(generateSourceFromImageData(innerData, innerWidth, innerHeight))
-    ) { "Scan output cannot be null" }
+    return scan(generateSourceFromImageData(innerData, innerWidth, innerHeight))
   }
 
   private fun scan(source: LuminanceSource): BarCodeScannerResult? {


### PR DESCRIPTION
# Why

Fixes crashes caused by Zxing scanner on Android.
This problem was mentioned in comments under https://github.com/expo/expo/issues/13049.

# How

`scan(data: ByteArray, width: Int, height: Int, rotation: Int)` can return nullable type. 

# Test Plan

- Expo Go & NCL ✅