### PR TITLE
[android][ios] Upgrade @stripe/stripe-react-native to 0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Package-specific changes not released in any SDK will be added here just before 
 - Updated `@react-native-community/slider` from `4.1.4` to `4.1.12`. ([#15356](https://github.com/expo/expo/pull/15356) by [@EvanBacon](https://github.com/EvanBacon))
 - Updated `@react-native-community/datetimepicker` from `3.5.2` to `4.0.0`. ([#15357](https://github.com/expo/expo/pull/15357) by [@EvanBacon](https://github.com/EvanBacon))
 - Updated `@react-native-community/netinfo` from `6.0.2` to `7.1.3`. ([#15352](https://github.com/expo/expo/pull/15352) by [@kudo](https://github.com/kudo))
+- Updated `@stripe/stripe-react-native` from `0.2.2` to `0.2.3`. ([#15396](https://github.com/expo/expo/pull/15396) by [@brentvatne](https://github.com/brentvatne) and [@kudo](https://github.com/kudo))
 
 ### 🛠 Breaking changes
 

--- a/android/expoview/build.gradle
+++ b/android/expoview/build.gradle
@@ -385,7 +385,7 @@ dependencies {
   api 'com.github.troZee:ViewPager2:v1.0.6'
 
   // stripe-react-native
-  implementation 'com.stripe:stripe-android:17.1.0'
+  implementation 'com.stripe:stripe-android:18.1.0'
   implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.0'
   implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.3.1"
   implementation 'com.google.android.material:material:1.3.0'

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/reactnativestripesdk/PaymentSheetFragment.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/reactnativestripesdk/PaymentSheetFragment.kt
@@ -2,6 +2,7 @@ package versioned.host.exp.exponent.modules.api.components.reactnativestripesdk
 
 import android.content.Context
 import android.content.Intent
+import android.content.res.ColorStateList
 import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.Color
@@ -47,6 +48,9 @@ class PaymentSheetFragment : Fragment() {
     val countryCode = arguments?.getString("merchantCountryCode").orEmpty()
     val googlePayEnabled = arguments?.getBoolean("googlePay")
     val testEnv = arguments?.getBoolean("testEnv")
+    val allowsDelayedPaymentMethods = arguments?.getBoolean("allowsDelayedPaymentMethods")
+    val primaryButtonColorHexStr = arguments?.getString("primaryButtonColor").orEmpty()
+    val billingDetailsBundle = arguments?.getBundle("defaultBillingDetails")
     paymentIntentClientSecret = arguments?.getString("paymentIntentClientSecret").orEmpty()
     setupIntentClientSecret = arguments?.getString("setupIntentClientSecret").orEmpty()
 
@@ -74,8 +78,35 @@ class PaymentSheetFragment : Fragment() {
       }
     }
 
+    var primaryButtonColor: ColorStateList? = null
+    if (primaryButtonColorHexStr != null && primaryButtonColorHexStr.isNotEmpty()) {
+      primaryButtonColor = ColorStateList.valueOf(Color.parseColor(primaryButtonColorHexStr))
+    }
+
+    var defaultBillingDetails: PaymentSheet.BillingDetails? = null
+    if (billingDetailsBundle != null) {
+      val addressBundle = billingDetailsBundle.getBundle("address")
+      val address = PaymentSheet.Address(
+        addressBundle?.getString("city"),
+        addressBundle?.getString("country"),
+        addressBundle?.getString("line1"),
+        addressBundle?.getString("line2"),
+        addressBundle?.getString("postalCode"),
+        addressBundle?.getString("state")
+      )
+      defaultBillingDetails = PaymentSheet.BillingDetails(
+        address,
+        billingDetailsBundle?.getString("email"),
+        billingDetailsBundle?.getString("name"),
+        billingDetailsBundle?.getString("phone")
+      )
+    }
+
     paymentSheetConfiguration = PaymentSheet.Configuration(
       merchantDisplayName = merchantDisplayName,
+      allowsDelayedPaymentMethods = allowsDelayedPaymentMethods ?: false,
+      primaryButtonColor = primaryButtonColor,
+      defaultBillingDetails = defaultBillingDetails,
       customer = if (customerId.isNotEmpty() && customerEphemeralKeySecret.isNotEmpty()) PaymentSheet.CustomerConfiguration(
         id = customerId,
         ephemeralKeySecret = customerEphemeralKeySecret

--- a/android/versioned-abis/expoview-abi41_0_0/build.gradle
+++ b/android/versioned-abis/expoview-abi41_0_0/build.gradle
@@ -170,5 +170,5 @@ dependencies {
   api 'com.github.troZee:ViewPager2:v1.0.6'
 
   // stripe-react-native
-  implementation 'com.stripe:stripe-android:17.1.0'
+  implementation 'com.stripe:stripe-android:18.1.0'
 }

--- a/android/versioned-abis/expoview-abi42_0_0/build.gradle
+++ b/android/versioned-abis/expoview-abi42_0_0/build.gradle
@@ -167,6 +167,6 @@ dependencies {
   api 'com.github.troZee:ViewPager2:v1.0.6'
 
   // stripe-react-native
-  implementation 'com.stripe:stripe-android:17.1.0'
+  implementation 'com.stripe:stripe-android:18.1.0'
   implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.0'
 }

--- a/android/versioned-abis/expoview-abi43_0_0/build.gradle
+++ b/android/versioned-abis/expoview-abi43_0_0/build.gradle
@@ -174,7 +174,7 @@ dependencies {
   api 'com.github.troZee:ViewPager2:v1.0.6'
 
   // stripe-react-native
-  implementation 'com.stripe:stripe-android:17.1.0'
+  implementation 'com.stripe:stripe-android:18.1.0'
   implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.0'
   implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.3.1"
   implementation 'com.google.android.material:material:1.3.0'

--- a/ios/Exponent.xcodeproj/project.pbxproj
+++ b/ios/Exponent.xcodeproj/project.pbxproj
@@ -5,6 +5,7 @@
 	};
 	objectVersion = 46;
 	objects = {
+
 /* Begin PBXBuildFile section */
 		0726F0592007E438004992E7 /* EXKernelAppRecord.m in Sources */ = {isa = PBXBuildFile; fileRef = 0726F0582007E438004992E7 /* EXKernelAppRecord.m */; };
 		0726F05C2007E446004992E7 /* EXKernelAppRegistry.m in Sources */ = {isa = PBXBuildFile; fileRef = 0726F05B2007E446004992E7 /* EXKernelAppRegistry.m */; };
@@ -2912,6 +2913,7 @@
 				"${PODS_CONFIGURATION_BUILD_DIR}/Stripe/Stripe.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/Stripe/Stripe3DS2.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/StripeCore/StripeCore.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/StripeUICore/StripeUICore.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/ABI41_0_0React-Core/ABI41_0_0AccessibilityResources.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/ABI42_0_0React-Core/ABI42_0_0AccessibilityResources.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/ABI43_0_0React-Core/ABI43_0_0AccessibilityResources.bundle",
@@ -2928,6 +2930,7 @@
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Stripe.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Stripe3DS2.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/StripeCore.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/StripeUICore.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ABI41_0_0AccessibilityResources.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ABI42_0_0AccessibilityResources.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ABI43_0_0AccessibilityResources.bundle",
@@ -2986,6 +2989,7 @@
 				"${PODS_CONFIGURATION_BUILD_DIR}/Stripe/Stripe.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/Stripe/Stripe3DS2.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/StripeCore/StripeCore.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/StripeUICore/StripeUICore.bundle",
 			);
 			name = "[CP] Copy Pods Resources";
 			outputPaths = (
@@ -2999,6 +3003,7 @@
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Stripe.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Stripe3DS2.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/StripeCore.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/StripeUICore.bundle",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -4294,7 +4294,7 @@ SPEC CHECKSUMS:
   RNReanimated: 9c13c86454bfd54dab7505c1a054470bfecd2563
   RNScreens: 6e1ea5787989f92b0671049b808aef64fa1ef98c
   Stripe: 41c3d261501e1dc84755b1bdabdaae50ebf92b53
-  stripe-react-native: 980f3d19f52a7dc4b373c6c20d30ebd760bc39e5
+  stripe-react-native: a5fcf07b49f1208bdc939e31a07320b35a88209f
   StripeCore: 2ea9531e863ef20f191a0d61f00dedb7f061baef
   StripeUICore: a0f9e40520823d34c63baec0782fc4a0c7fb7484
   UMAppLoader: 671576daa3fd3017d4879a5f23fc0dd3b36422a8

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -590,7 +590,7 @@ PODS:
     - Yoga
   - ABI41_0_0stripe-react-native (0.1.0):
     - ABI41_0_0React
-    - Stripe (~> 21.8.1)
+    - Stripe (~> 21.9.0)
   - ABI41_0_0UMAppLoader (2.1.0)
   - ABI41_0_0UMBarCodeScannerInterface (6.1.0):
     - ABI41_0_0UMCore
@@ -1198,7 +1198,7 @@ PODS:
     - ABI42_0_0React-RCTImage
   - ABI42_0_0stripe-react-native (0.1.4):
     - ABI42_0_0React
-    - Stripe (~> 21.8.1)
+    - Stripe (~> 21.9.0)
   - ABI42_0_0UMAppLoader (2.2.0)
   - ABI42_0_0UMCore (7.1.1)
   - ABI42_0_0UMReactNativeAdapter (6.3.0):
@@ -1795,7 +1795,7 @@ PODS:
     - ABI43_0_0React-RCTImage
   - ABI43_0_0stripe-react-native (0.2.2):
     - ABI43_0_0React
-    - Stripe (~> 21.8.1)
+    - Stripe (~> 21.9.0)
   - ABI43_0_0UMAppLoader (3.0.0)
   - ABI43_0_0UMTaskManagerInterface (7.0.0):
     - ABI43_0_0ExpoModulesCore
@@ -2467,15 +2467,19 @@ PODS:
   - RNScreens (3.8.0):
     - React-Core
     - React-RCTImage
-  - Stripe (21.8.1):
-    - Stripe/Stripe3DS2 (= 21.8.1)
-    - StripeCore (= 21.8.1)
-  - stripe-react-native (0.2.2):
-    - React
-    - Stripe (~> 21.8.1)
-  - Stripe/Stripe3DS2 (21.8.1):
-    - StripeCore (= 21.8.1)
-  - StripeCore (21.8.1)
+  - Stripe (21.9.0):
+    - Stripe/Stripe3DS2 (= 21.9.0)
+    - StripeCore (= 21.9.0)
+    - StripeUICore (= 21.9.0)
+  - stripe-react-native (0.2.3):
+    - React-Core
+    - Stripe (~> 21.9.0)
+  - Stripe/Stripe3DS2 (21.9.0):
+    - StripeCore (= 21.9.0)
+    - StripeUICore (= 21.9.0)
+  - StripeCore (21.9.0)
+  - StripeUICore (21.9.0):
+    - StripeCore (= 21.9.0)
   - UMAppLoader (3.0.0)
   - UMTaskManagerInterface (7.0.1):
     - ExpoModulesCore
@@ -2975,6 +2979,7 @@ SPEC REPOS:
     - Protobuf
     - Stripe
     - StripeCore
+    - StripeUICore
     - ZXingObjC
 
 EXTERNAL SOURCES:
@@ -3921,7 +3926,7 @@ SPEC CHECKSUMS:
   ABI41_0_0React-RCTVibration: ea2ae0f0559e32d2a17d28162ee1ce902fcf0f98
   ABI41_0_0ReactCommon: bedf6c58cbcd774db4ca5c5f9b39196493a683a6
   ABI41_0_0RNReanimated: 9ec256ef7b229c919835501640706028bf438678
-  ABI41_0_0stripe-react-native: 30b6621836aa6648c58515394e8fac9961d020a6
+  ABI41_0_0stripe-react-native: 9700340491c678a803aa4a2f7446bc23fcd01a59
   ABI41_0_0UMAppLoader: c44d678dc80cd36783ecf36e036690eff34a28b2
   ABI41_0_0UMBarCodeScannerInterface: 7a08c48a07b33412c5a61465f96915bb778ae789
   ABI41_0_0UMCameraInterface: be8c85a4debae7bbabb0df68720642e11d0196d1
@@ -4031,7 +4036,7 @@ SPEC CHECKSUMS:
   ABI42_0_0ReactCommon: c3bb4c4691c125880ac8c6d6a13a44744059738a
   ABI42_0_0RNReanimated: c83b815abf46671c46634e2b3d3813e434ef174f
   ABI42_0_0RNScreens: 54491fe4857af5649b9bbcdb68f80bfaea9184df
-  ABI42_0_0stripe-react-native: a35a5ca9f6ef2d6761a1856e4db6eeff8ed15bc8
+  ABI42_0_0stripe-react-native: e3d0209803fd43b26336460f738c7db88bb7b850
   ABI42_0_0UMAppLoader: dabb1f8c2f864f5559f314a0e027b6f9489d4687
   ABI42_0_0UMCore: 80a911c91edb192260601ffc5fd818e965d4aac3
   ABI42_0_0UMReactNativeAdapter: 17dc58444122eda6fd493dff06546882fe00bcf7
@@ -4139,7 +4144,7 @@ SPEC CHECKSUMS:
   ABI43_0_0ReactCommon: 6a1fcad151aa7efad288c20f318c1b5f165538d2
   ABI43_0_0RNReanimated: f7cd484a2e1b5112ea84d57381c5d7ab6ceeab74
   ABI43_0_0RNScreens: d8e359af1191871e37501d5efd6b72b38c573e90
-  ABI43_0_0stripe-react-native: 75ba35284358f29b10851bda97d576a787ade851
+  ABI43_0_0stripe-react-native: e2d9c45776c547095508a9b8b5173e8a34bb962a
   ABI43_0_0UMAppLoader: ac4c403f59e691af683873f22b44a023155bac55
   ABI43_0_0UMTaskManagerInterface: af977f83f0ab2c68d8023174a7d542a8cf465351
   ABI43_0_0Yoga: b4a69fd97272b10eb433c11dd8bb2e571e311e36
@@ -4288,9 +4293,10 @@ SPEC CHECKSUMS:
   ReactCommon: 8fea6422328e2fc093e25c9fac67adbcf0f04fb4
   RNReanimated: 9c13c86454bfd54dab7505c1a054470bfecd2563
   RNScreens: 6e1ea5787989f92b0671049b808aef64fa1ef98c
-  Stripe: 57c6997c64042a3f5aedae9b76e331942f8b75d2
-  stripe-react-native: 48a10900a95709f7527fc712231fe1adc81735ca
-  StripeCore: a6e50d58119a0c7601773b56f274db2d394dcdac
+  Stripe: 41c3d261501e1dc84755b1bdabdaae50ebf92b53
+  stripe-react-native: 980f3d19f52a7dc4b373c6c20d30ebd760bc39e5
+  StripeCore: 2ea9531e863ef20f191a0d61f00dedb7f061baef
+  StripeUICore: a0f9e40520823d34c63baec0782fc4a0c7fb7484
   UMAppLoader: 671576daa3fd3017d4879a5f23fc0dd3b36422a8
   UMTaskManagerInterface: 9655d49899096ee024248bbd7eb47e6b2c9631b2
   Yoga: e6ecf3fa25af9d4c87e94ad7d5d292eedef49749

--- a/ios/vendored/sdk41/stripe-react-native/ABI41_0_0stripe-react-native.podspec.json
+++ b/ios/vendored/sdk41/stripe-react-native/ABI41_0_0stripe-react-native.podspec.json
@@ -18,6 +18,6 @@
   },
   "dependencies": {
     "ABI41_0_0React": [],
-    "Stripe": ["~> 21.8.1"]
+    "Stripe": ["~> 21.9.0"]
   }
 }

--- a/ios/vendored/sdk42/stripe-react-native/ABI42_0_0stripe-react-native.podspec.json
+++ b/ios/vendored/sdk42/stripe-react-native/ABI42_0_0stripe-react-native.podspec.json
@@ -18,6 +18,6 @@
   },
   "dependencies": {
     "ABI42_0_0React": [],
-    "Stripe": ["~> 21.8.1"]
+    "Stripe": ["~> 21.9.0"]
   }
 }

--- a/ios/vendored/sdk43/@stripe/stripe-react-native/ABI43_0_0stripe-react-native.podspec.json
+++ b/ios/vendored/sdk43/@stripe/stripe-react-native/ABI43_0_0stripe-react-native.podspec.json
@@ -18,6 +18,6 @@
   },
   "dependencies": {
     "ABI43_0_0React": [],
-    "Stripe": ["~> 21.8.1"]
+    "Stripe": ["~> 21.9.0"]
   }
 }

--- a/ios/vendored/unversioned/@stripe/stripe-react-native/ios/StripeSdk.swift
+++ b/ios/vendored/unversioned/@stripe/stripe-react-native/ios/StripeSdk.swift
@@ -80,6 +80,35 @@ class StripeSdk: RCTEventEmitter, STPApplePayContextDelegate, STPBankSelectionVi
             configuration.merchantDisplayName = merchantDisplayName
         }
         
+        if let returnURL = params["returnURL"] as? String {
+            configuration.returnURL = returnURL
+        }
+        
+        if let buttonColorHexStr = params["primaryButtonColor"] as? String {
+            let primaryButtonColor = UIColor(hexString: buttonColorHexStr)
+            configuration.primaryButtonColor = primaryButtonColor
+        }
+        
+        if let allowsDelayedPaymentMethods = params["allowsDelayedPaymentMethods"] as? Bool {
+            configuration.allowsDelayedPaymentMethods = allowsDelayedPaymentMethods
+        }
+        
+        if let defaultBillingDetails = params["defaultBillingDetails"] as? [String: Any?] {
+            configuration.defaultBillingDetails.name = defaultBillingDetails["name"] as? String
+            configuration.defaultBillingDetails.email = defaultBillingDetails["email"] as? String
+            configuration.defaultBillingDetails.phone = defaultBillingDetails["phone"] as? String
+            
+            if let address = defaultBillingDetails["address"] as? [String: String] {
+            configuration.defaultBillingDetails.address = .init(city: address["city"],
+                                                                country: address["country"],
+                                                                line1: address["line1"],
+                                                                line2: address["line2"],
+                                                                postalCode: address["postalCode"],
+                                                                state: address["state"])
+            }
+            
+        }
+        
         if let customerId = params["customerId"] as? String {
             if let customerEphemeralKeySecret = params["customerEphemeralKeySecret"] as? String {
                 if (!Errors.isEKClientSecretValid(clientSecret: customerEphemeralKeySecret)) {

--- a/ios/vendored/unversioned/@stripe/stripe-react-native/stripe-react-native.podspec.json
+++ b/ios/vendored/unversioned/@stripe/stripe-react-native/stripe-react-native.podspec.json
@@ -18,5 +18,8 @@
     "Stripe": [
       "~> 21.9.0"
     ]
+  },
+  "pod_target_xcconfig": {
+    "HEADER_SEARCH_PATHS": "\"${PODS_ROOT}/Stripe/Stripe3DS2\" \"${PODS_ROOT}/Headers/Public/Stripe\""
   }
 }

--- a/ios/vendored/unversioned/@stripe/stripe-react-native/stripe-react-native.podspec.json
+++ b/ios/vendored/unversioned/@stripe/stripe-react-native/stripe-react-native.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "stripe-react-native",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "summary": "Stripe SDK for React Native",
   "homepage": "https://github.com/stripe/stripe-react-native/#readme",
   "license": "MIT",
@@ -10,14 +10,13 @@
   },
   "source": {
     "git": "https://github.com/stripe/stripe-react-native.git",
-    "tag": "0.2.2"
+    "tag": "0.2.3"
   },
   "source_files": "ios/**/*.{h,m,mm,swift}",
-  "pod_target_xcconfig": {
-    "HEADER_SEARCH_PATHS": "\"${PODS_ROOT}/Stripe/Stripe3DS2\" \"${PODS_ROOT}/Headers/Public/Stripe\""
-  },
   "dependencies": {
-    "React": [],
-    "Stripe": ["~> 21.8.1"]
+    "React-Core": [],
+    "Stripe": [
+      "~> 21.9.0"
+    ]
   }
 }

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -8,7 +8,7 @@
   "@react-native-community/viewpager": "5.0.11",
   "@react-native-picker/picker": "2.1.0",
   "@react-native-segmented-control/segmented-control": "2.4.0",
-  "@stripe/stripe-react-native": "0.2.2",
+  "@stripe/stripe-react-native": "0.2.3",
   "@unimodules/core": "~7.2.0",
   "@unimodules/react-native-adapter": "~6.5.0",
   "expo-ads-admob": "~11.0.3",

--- a/tools/src/vendoring/config/expoGoConfig.ts
+++ b/tools/src/vendoring/config/expoGoConfig.ts
@@ -14,7 +14,15 @@ const config: VendoringTargetConfig = {
   modules: {
     '@stripe/stripe-react-native': {
       source: 'https://github.com/stripe/stripe-react-native.git',
-      ios: {},
+      ios: {
+        mutatePodspec(podspec: Podspec) {
+          if (!podspec.pod_target_xcconfig) {
+            podspec.pod_target_xcconfig = {};
+          }
+          podspec.pod_target_xcconfig['HEADER_SEARCH_PATHS'] =
+            '"${PODS_ROOT}/Stripe/Stripe3DS2" "${PODS_ROOT}/Headers/Public/Stripe"';
+        },
+      },
       // android: {
       //   includeFiles: 'android/**',
       //   excludeFiles: ['android/gradle.properties', 'android/.settings', 'android/.project'],

--- a/tools/src/vendoring/config/expoGoConfig.ts
+++ b/tools/src/vendoring/config/expoGoConfig.ts
@@ -24,8 +24,19 @@ const config: VendoringTargetConfig = {
         },
       },
       // android: {
-      //   includeFiles: 'android/**',
-      //   excludeFiles: ['android/gradle.properties', 'android/.settings', 'android/.project'],
+      //   excludeFiles: [
+      //     'android/src/main/java/com/reactnativestripesdk/GooglePayButtonManager.kt',
+      //     'android/src/main/java/com/reactnativestripesdk/GooglePayButtonView.kt',
+      //   ],
+      //   transforms: {
+      //     content: [
+      //       {
+      //         paths: 'StripeSdkPackage.kt',
+      //         find: /, GooglePayButtonManager\(\)/,
+      //         replaceWith: '',
+      //       },
+      //     ],
+      //   },
       // },
     },
     'lottie-react-native': {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2890,10 +2890,10 @@
   resolved "https://registry.yarnpkg.com/@react-native-community/viewpager/-/viewpager-5.0.11.tgz#dbeb2d1b2452607926407c99e4de59c7db9e3019"
   integrity sha512-eboJwbDQjP1qJP3LFzVspgh88IGNF07S2qpU296j+4kL0inVuL+HXs81SuczMGtJmDZ4u19RNEBVq79of/h+jQ==
 
-"@react-native-masked-view/masked-view@0.2.5":
-  version "0.2.5"
-  resolved "https://registry.yarnpkg.com/@react-native-masked-view/masked-view/-/masked-view-0.2.5.tgz#2505f269a53b134e3306a2772d981138e11f1537"
-  integrity sha512-yXaWyV8xu1N5tfdfP8L29U0TIDvBriN4zHUI+Zs7Sw+VI8pBbEEYoITK9aFt495Y0/PPm4FsTpa35hOeTLfGPA==
+"@react-native-masked-view/masked-view@0.2.6":
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/@react-native-masked-view/masked-view/-/masked-view-0.2.6.tgz#b26c52d5db3ad0926b13deea79c69620966a9221"
+  integrity sha512-303CxmetUmgiX9NSUxatZkNh9qTYYdiM8xkGf9I3Uj20U3eGY3M78ljeNQ4UVCJA+FNGS5nC1dtS9GjIqvB4dg==
 
 "@react-native-picker/picker@2.1.0":
   version "2.1.0"
@@ -14832,10 +14832,10 @@ react-native-maps@0.28.0:
   dependencies:
     "@types/geojson" "^7946.0.7"
 
-react-native-pager-view@5.4.6:
-  version "5.4.6"
-  resolved "https://registry.yarnpkg.com/react-native-pager-view/-/react-native-pager-view-5.4.6.tgz#21d16b67136301875da1355dc9d442a4aafab1c7"
-  integrity sha512-yZiG65xlOeC8LOCNF0N8Cdc+MDQGWJnOpsmlHAndWXQhuVPjj4/KnS556BeTddcQ2EqJu/DjL7o8j0hpB+nkVg==
+react-native-pager-view@5.4.9:
+  version "5.4.9"
+  resolved "https://registry.yarnpkg.com/react-native-pager-view/-/react-native-pager-view-5.4.9.tgz#c0d40847cfeda5a4e729b53271b0ee0fedff3eb5"
+  integrity sha512-D6tzxpwMGdl6CXgtskGWhKRc5cJakCazESRGt7PkqnpyiH3N35ft1KmR82pCSQetAFlytFiToeu3a/dG5CELvA==
 
 react-native-paper@^4.0.1:
   version "4.9.2"


### PR DESCRIPTION
# Why

upgrade `@stripe/stripe-react-native` to 0.2.3 for sdk 44
close ENG-2531

# How

- `et uvm -m @stripe/stripe-react-native -c "v0.2.3"`
- backport native stripe version to old sdks' podspec and build.gradle
- [android] transform manually
  - remove `GooglePayButtonManager.kt`, `GooglePayButtonView.kt`
  - remove `GooglePayButtonManager()` in `StripeSdkPackage.kt`
  - revert `import host.exp.expoview.R` change in `CardFormView.kt`
- update verndoring code 

# Test Plan

1. clone and setup [stripe example app](https://github.com/stripe/stripe-react-native#run-the-example-app)
2. in `example/`
  - `yarn add file:/path/to/expo/packages/expo`
  - yarn add for `react-native@0.64.3`, `react@17.0.1` and other unsynced packages
  - `expo start`
3. test android/ios unversioned expo go with the local stripe example app.

stripe test api keys: https://stripe.com/docs/keys
stripe test credit card: https://stripe.com/docs/testing

since stripe did not change much from [0.2.2 to 0.2.3](https://github.com/stripe/stripe-react-native/blob/master/CHANGELOG.md#023---2021-10-18), i did not verify all functions but some simple payments.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
