### PR TITLE
[expo-updates][android] Add support for multipart manifest responses

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Small fixes for error recovery manager on iOS. ([#15223](https://github.com/expo/expo/pull/15223) by [@esamelson](https://github.com/esamelson))
 - Add native checkOnLaunch: ERROR_RECOVERY_ONLY setting on Android. ([#15219](https://github.com/expo/expo/pull/15219) by [@esamelson](https://github.com/esamelson))
 - Enhance node binary resolution for Xcode build phases scripts by the vendoring source-login-scripts.sh. ([#15336](https://github.com/expo/expo/pull/15336) by [@kudo](https://github.com/kudo))
+- Add android support for multipart manifest responses. ([#15401](https://github.com/expo/expo/pull/15401) by [@wschurman](https://github.com/wschurman))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-updates/android/build.gradle
+++ b/packages/expo-updates/android/build.gradle
@@ -104,6 +104,7 @@ dependencies {
   implementation("com.squareup.okhttp3:okhttp-urlconnection:3.12.1")
   implementation("com.squareup.okio:okio:1.15.0")
   implementation("commons-io:commons-io:2.6")
+  implementation("commons-fileupload:commons-fileupload:1.4")
   implementation("org.apache.commons:commons-lang3:3.9")
 
   testImplementation 'junit:junit:4.12'

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/db/UpdatesDatabaseMigrationTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/db/UpdatesDatabaseMigrationTest.kt
@@ -357,6 +357,39 @@ class UpdatesDatabaseMigrationTest {
     Assert.assertEquals(0, cursorUpdatesAssetsOnDelete2.count.toLong())
   }
 
+  @Test
+  @Throws(IOException::class)
+  fun testMigrate8To9() {
+    var db = helper.createDatabase(TEST_DB, 8)
+
+    // db has schema version 8. insert some data using SQL queries.
+    // cannot use DAO classes because they expect the latest schema.
+    db.execSQL(
+      """INSERT INTO "assets" ("id","url","key","headers","type","metadata","download_time","relative_path","hash","hash_type","marked_for_deletion") VALUES (2,'https://url.to/b56cf690e0afa93bd4dc7756d01edd3e','b56cf690e0afa93bd4dc7756d01edd3e.png',NULL,'image/png',NULL,1614137309295,'b56cf690e0afa93bd4dc7756d01edd3e.png',NULL,0,0),
+ (3,'https://url.to/bundle-1614137308871','bundle-1614137308871',NULL,'application/javascript',NULL,1614137309513,'bundle-1614137308871',NULL,0,0),
+ (4,NULL,NULL,NULL,'js',NULL,1614137406588,'bundle-1614137401950',NULL,0,0)"""
+    )
+
+    // Prepare for the next version.
+    db.close()
+
+    // Re-open the database with version 8 and provide
+    // MIGRATION_8_9 as the migration process.
+    db = helper.runMigrationsAndValidate(TEST_DB, 9, true, UpdatesDatabase.MIGRATION_8_9)
+    db.execSQL("PRAGMA foreign_keys=ON")
+
+    // schema changes automatically verified, we just need to verify data integrity
+    val cursorAssets1 =
+      db.query("SELECT * FROM `assets` WHERE `id` = 2 AND `url` = 'https://url.to/b56cf690e0afa93bd4dc7756d01edd3e' AND `key` = 'b56cf690e0afa93bd4dc7756d01edd3e.png' AND `headers` IS NULL AND `type` = 'image/png' AND `metadata` IS NULL AND `download_time` = 1614137309295 AND `relative_path` = 'b56cf690e0afa93bd4dc7756d01edd3e.png' AND `hash` IS NULL AND `hash_type` = 0 AND `marked_for_deletion` = 0")
+    Assert.assertEquals(1, cursorAssets1.count.toLong())
+    val cursorAssets2 =
+      db.query("SELECT * FROM `assets` WHERE `id` = 3 AND `url` = 'https://url.to/bundle-1614137308871' AND `key` = 'bundle-1614137308871' AND `headers` IS NULL AND `type` = 'application/javascript' AND `metadata` IS NULL AND `download_time` = 1614137309513 AND `relative_path` = 'bundle-1614137308871' AND `hash` IS NULL AND `hash_type` = 0 AND `marked_for_deletion` = 0")
+    Assert.assertEquals(1, cursorAssets2.count.toLong())
+    val cursorAssets3 =
+      db.query("SELECT * FROM `assets` WHERE `id` = 4 AND `url` IS NULL AND `key` IS NULL AND `headers` IS NULL AND `type` = 'js' AND `metadata` IS NULL AND `download_time` = 1614137406588 AND `relative_path` = 'bundle-1614137401950' AND `hash` IS NULL AND `hash_type` = 0 AND `marked_for_deletion` = 0")
+    Assert.assertEquals(1, cursorAssets3.count.toLong())
+  }
+
   private fun execSQLExpectingException(db: SupportSQLiteDatabase, sql: String): Boolean {
     val fails: Boolean = try {
       db.execSQL(sql)

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/FileDownloaderManifestParsingTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/FileDownloaderManifestParsingTest.kt
@@ -1,0 +1,116 @@
+package expo.modules.updates.loader
+
+import android.net.Uri
+import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
+import androidx.test.platform.app.InstrumentationRegistry
+import expo.modules.updates.UpdatesConfiguration
+import expo.modules.updates.manifest.UpdateManifest
+import io.mockk.every
+import io.mockk.mockk
+import okhttp3.*
+import okio.Buffer
+import org.json.JSONException
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4ClassRunner::class)
+class FileDownloaderManifestParsingTest {
+  private val classicJSON = "{\"sdkVersion\":\"39.0.0\",\"releaseId\":\"0eef8214-4833-4089-9dff-b4138a14f196\",\"commitTime\":\"2020-11-11T00:17:54.797Z\",\"bundleUrl\":\"https://url.to/bundle.js\"}"
+
+  @Test
+  @Throws(JSONException::class)
+  fun testManifestParsing_JSONBody() {
+    val context = InstrumentationRegistry.getInstrumentation().targetContext
+    val contentType = "application/json"
+    val response = mockk<Response>().apply {
+      every { header("content-type") } returns contentType
+      every { headers() } returns Headers.of(mapOf("content-type" to contentType))
+      every { body() } returns ResponseBody.create(MediaType.parse("application/json; charset=utf-8"), classicJSON)
+    }
+
+    val configuration = UpdatesConfiguration().loadValuesFromMap(
+      mapOf(
+        "updateUrl" to Uri.parse("https://exp.host/@test/test"),
+      )
+    )
+
+    var errorOccurred = false
+    var resultUpdateManifest: UpdateManifest? = null
+
+    FileDownloader(context).parseManifestResponse(
+      response, configuration,
+      object : FileDownloader.ManifestDownloadCallback {
+        override fun onFailure(message: String, e: Exception) {
+          errorOccurred = true
+        }
+
+        override fun onSuccess(updateManifest: UpdateManifest) {
+          resultUpdateManifest = updateManifest
+        }
+      }
+    )
+
+    Assert.assertFalse(errorOccurred)
+    Assert.assertNotNull(resultUpdateManifest)
+  }
+
+  @Test
+  @Throws(JSONException::class)
+  fun testManifestParsing_MultipartBody() {
+    val context = InstrumentationRegistry.getInstrumentation().targetContext
+    val boundary = "blah"
+    val contentType = "multipart/mixed; boundary=$boundary"
+
+    val extensions = "{}"
+
+    val multipartBody = MultipartBody.Builder(boundary)
+      .setType(MultipartBody.MIXED)
+      .addPart(
+        Headers.of(mapOf("Content-Disposition" to "form-data; name=\"extraneous\"; filename=\"hello1\"")),
+        RequestBody.create(MediaType.parse("text/plain; charset=utf-8"), "hello")
+      )
+      .addPart(
+        Headers.of(mapOf("Content-Disposition" to "form-data; name=\"manifest\"; filename=\"hello2\"")),
+        RequestBody.create(MediaType.parse("application/json; charset=utf-8"), classicJSON)
+      )
+      .addPart(
+        Headers.of(mapOf("Content-Disposition" to "form-data; name=\"extensions\"; filename=\"hello3\"")),
+        RequestBody.create(MediaType.parse("application/json; charset=utf-8"), extensions)
+      )
+      .build()
+
+    val contentBuffer = Buffer().also { multipartBody.writeTo(it) }
+
+    val response = mockk<Response>().apply {
+      every { header("content-type") } returns contentType
+      every { headers() } returns Headers.of(mapOf("content-type" to contentType))
+      every { body() } returns ResponseBody.create(MultipartBody.MIXED, contentBuffer.readByteArray())
+    }
+
+    val configuration = UpdatesConfiguration().loadValuesFromMap(
+      mapOf(
+        "updateUrl" to Uri.parse("https://exp.host/@test/test"),
+      )
+    )
+
+    var errorOccurred = false
+    var resultUpdateManifest: UpdateManifest? = null
+
+    FileDownloader(context).parseManifestResponse(
+      response, configuration,
+      object : FileDownloader.ManifestDownloadCallback {
+        override fun onFailure(message: String, e: Exception) {
+          errorOccurred = true
+        }
+
+        override fun onSuccess(updateManifest: UpdateManifest) {
+          resultUpdateManifest = updateManifest
+        }
+      }
+    )
+
+    Assert.assertFalse(errorOccurred)
+    Assert.assertNotNull(resultUpdateManifest)
+  }
+}

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/manifest/NewUpdateManifestTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/manifest/NewUpdateManifestTest.kt
@@ -4,6 +4,7 @@ import android.net.Uri
 import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
 import expo.modules.updates.UpdatesConfiguration
 import expo.modules.manifests.core.NewManifest
+import okhttp3.Headers
 import org.json.JSONException
 import org.json.JSONObject
 import org.junit.Assert
@@ -20,7 +21,7 @@ class NewUpdateManifestTest {
     val manifestJson =
       "{\"runtimeVersion\":\"1\",\"id\":\"0eef8214-4833-4089-9dff-b4138a14f196\",\"createdAt\":\"2020-11-11T00:17:54.797Z\",\"launchAsset\":{\"url\":\"https://url.to/bundle.js\",\"contentType\":\"application/javascript\"}}"
     val manifest = NewManifest(JSONObject(manifestJson))
-    Assert.assertNotNull(NewUpdateManifest.fromNewManifest(manifest, null, createConfig()))
+    Assert.assertNotNull(NewUpdateManifest.fromNewManifest(manifest, Headers.of(), null, createConfig()))
   }
 
   @Test(expected = JSONException::class)
@@ -29,7 +30,7 @@ class NewUpdateManifestTest {
     val manifestJson =
       "{\"runtimeVersion\":\"1\",\"createdAt\":\"2020-11-11T00:17:54.797Z\",\"launchAsset\":{\"url\":\"https://url.to/bundle.js\",\"contentType\":\"application/javascript\"}}"
     val manifest = NewManifest(JSONObject(manifestJson))
-    NewUpdateManifest.fromNewManifest(manifest, null, createConfig())
+    NewUpdateManifest.fromNewManifest(manifest, Headers.of(), null, createConfig())
   }
 
   @Test(expected = JSONException::class)
@@ -38,7 +39,7 @@ class NewUpdateManifestTest {
     val manifestJson =
       "{\"runtimeVersion\":\"1\",\"id\":\"0eef8214-4833-4089-9dff-b4138a14f196\",\"launchAsset\":{\"url\":\"https://url.to/bundle.js\",\"contentType\":\"application/javascript\"}}"
     val manifest = NewManifest(JSONObject(manifestJson))
-    NewUpdateManifest.fromNewManifest(manifest, null, createConfig())
+    NewUpdateManifest.fromNewManifest(manifest, Headers.of(), null, createConfig())
   }
 
   @Test(expected = JSONException::class)
@@ -47,7 +48,7 @@ class NewUpdateManifestTest {
     val manifestJson =
       "{\"id\":\"0eef8214-4833-4089-9dff-b4138a14f196\",\"createdAt\":\"2020-11-11T00:17:54.797Z\",\"launchAsset\":{\"url\":\"https://url.to/bundle.js\",\"contentType\":\"application/javascript\"}}"
     val manifest = NewManifest(JSONObject(manifestJson))
-    NewUpdateManifest.fromNewManifest(manifest, null, createConfig())
+    NewUpdateManifest.fromNewManifest(manifest, Headers.of(), null, createConfig())
   }
 
   @Test(expected = JSONException::class)
@@ -56,7 +57,7 @@ class NewUpdateManifestTest {
     val manifestJson =
       "{\"runtimeVersion\":\"1\",\"id\":\"0eef8214-4833-4089-9dff-b4138a14f196\",\"createdAt\":\"2020-11-11T00:17:54.797Z\",}"
     val manifest = NewManifest(JSONObject(manifestJson))
-    NewUpdateManifest.fromNewManifest(manifest, null, createConfig())
+    NewUpdateManifest.fromNewManifest(manifest, Headers.of(), null, createConfig())
   }
 
   private fun createConfig(): UpdatesConfiguration {

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/manifest/UpdateManifestMetadataTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/manifest/UpdateManifestMetadataTest.kt
@@ -7,8 +7,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import expo.modules.manifests.core.NewManifest
 import expo.modules.updates.UpdatesConfiguration
 import expo.modules.updates.db.UpdatesDatabase
-import io.mockk.every
-import io.mockk.mockk
+import okhttp3.Headers
 import org.json.JSONException
 import org.json.JSONObject
 import org.junit.After
@@ -46,16 +45,12 @@ class UpdateManifestMetadataTest {
   @Test
   @Throws(JSONException::class)
   fun testManifestFilters_OverwriteAllFields() {
-    val response1 = mockk<ManifestResponse>(relaxed = true)
-    every { response1.header("expo-manifest-filters") } returns "branch-name=\"rollout-1\",test=\"value\""
-
-    val updateManifest1: UpdateManifest = NewUpdateManifest.fromNewManifest(manifest, response1, config)
+    val headers1 = Headers.of(mapOf("expo-manifest-filters" to "branch-name=\"rollout-1\",test=\"value\""))
+    val updateManifest1: UpdateManifest = NewUpdateManifest.fromNewManifest(manifest, headers1, null, config)
     ManifestMetadata.saveMetadata(updateManifest1, db, config)
 
-    val response2 = mockk<ManifestResponse>(relaxed = true)
-    every { response2.header("expo-manifest-filters") } returns "branch-name=\"rollout-2\""
-
-    val updateManifest2: UpdateManifest = NewUpdateManifest.fromNewManifest(manifest, response2, config)
+    val headers2 = Headers.of(mapOf("expo-manifest-filters" to "branch-name=\"rollout-2\""))
+    val updateManifest2: UpdateManifest = NewUpdateManifest.fromNewManifest(manifest, headers2, null, config)
     ManifestMetadata.saveMetadata(updateManifest2, db, config)
 
     val actual = ManifestMetadata.getManifestFilters(db, config)
@@ -67,16 +62,12 @@ class UpdateManifestMetadataTest {
   @Test
   @Throws(JSONException::class)
   fun testManifestFilters_OverwriteEmpty() {
-    val response1 = mockk<ManifestResponse>(relaxed = true)
-    every { response1.header("expo-manifest-filters") } returns "branch-name=\"rollout-1\""
-
-    val updateManifest1: UpdateManifest = NewUpdateManifest.fromNewManifest(manifest, response1, config)
+    val headers1 = Headers.of(mapOf("expo-manifest-filters" to "branch-name=\"rollout-1\""))
+    val updateManifest1: UpdateManifest = NewUpdateManifest.fromNewManifest(manifest, headers1, null, config)
     ManifestMetadata.saveMetadata(updateManifest1, db, config)
 
-    val response2 = mockk<ManifestResponse>(relaxed = true)
-    every { response2.header("expo-manifest-filters") } returns ""
-
-    val updateManifest2: UpdateManifest = NewUpdateManifest.fromNewManifest(manifest, response2, config)
+    val headers2 = Headers.of(mapOf("expo-manifest-filters" to ""))
+    val updateManifest2: UpdateManifest = NewUpdateManifest.fromNewManifest(manifest, headers2, null, config)
     ManifestMetadata.saveMetadata(updateManifest2, db, config)
 
     val actual = ManifestMetadata.getManifestFilters(db, config)
@@ -87,16 +78,12 @@ class UpdateManifestMetadataTest {
   @Test
   @Throws(JSONException::class)
   fun testManifestFilters_OverwriteNull() {
-    val response1 = mockk<ManifestResponse>(relaxed = true)
-    every { response1.header("expo-manifest-filters") } returns "branch-name=\"rollout-1\""
-
-    val updateManifest1: UpdateManifest = NewUpdateManifest.fromNewManifest(manifest, response1, config)
+    val headers1 = Headers.of(mapOf("expo-manifest-filters" to "branch-name=\"rollout-1\""))
+    val updateManifest1: UpdateManifest = NewUpdateManifest.fromNewManifest(manifest, headers1, null, config)
     ManifestMetadata.saveMetadata(updateManifest1, db, config)
 
-    val response2 = mockk<ManifestResponse>(relaxed = true)
-    every { response2.header("expo-manifest-filters") } returns null
-
-    val updateManifest2: UpdateManifest = NewUpdateManifest.fromNewManifest(manifest, response2, config)
+    val headers2 = Headers.of()
+    val updateManifest2: UpdateManifest = NewUpdateManifest.fromNewManifest(manifest, headers2, null, config)
     ManifestMetadata.saveMetadata(updateManifest2, db, config)
 
     val actual = ManifestMetadata.getManifestFilters(db, config)

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/selectionpolicy/SelectionPolicyFilterAwareTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/selectionpolicy/SelectionPolicyFilterAwareTest.kt
@@ -6,6 +6,7 @@ import expo.modules.manifests.core.NewManifest
 import expo.modules.updates.UpdatesConfiguration
 import expo.modules.updates.db.entity.UpdateEntity
 import expo.modules.updates.manifest.NewUpdateManifest
+import okhttp3.Headers
 import org.json.JSONException
 import org.json.JSONObject
 import org.junit.Assert
@@ -33,19 +34,19 @@ class SelectionPolicyFilterAwareTest {
     val configMap = mapOf<String, Any>("updateUrl" to Uri.parse("https://exp.host/@test/test"))
     val config = UpdatesConfiguration().loadValuesFromMap(configMap)
     val manifestJsonRollout0 = NewManifest(JSONObject("{\"id\":\"079cde35-8433-4c17-81c8-7117c1513e71\",\"createdAt\":\"2021-01-10T19:39:22.480Z\",\"runtimeVersion\":\"1.0\",\"launchAsset\":{\"hash\":\"DW5MBgKq155wnX8rCP1lnsW6BsTbfKLXxGXRQx1RcOA\",\"key\":\"0436e5821bff7b95a84c21f22a43cb96.bundle\",\"contentType\":\"application/javascript\",\"url\":\"https://url.to/bundle\"},\"assets\":[{\"hash\":\"JSeRsPNKzhVdHP1OEsDVsLH500Zfe4j1O7xWfa14oBo\",\"key\":\"3261e570d51777be1e99116562280926.png\",\"contentType\":\"image/png\",\"url\":\"https://url.to/asset\"}],\"metadata\":{\"branchName\":\"rollout\"}}"))
-    updateRollout0 = NewUpdateManifest.fromNewManifest(manifestJsonRollout0, null, config).updateEntity
+    updateRollout0 = NewUpdateManifest.fromNewManifest(manifestJsonRollout0, Headers.of(), null, config).updateEntity
     val manifestJsonDefault1 = NewManifest(JSONObject("{\"id\":\"079cde35-8433-4c17-81c8-7117c1513e72\",\"createdAt\":\"2021-01-11T19:39:22.480Z\",\"runtimeVersion\":\"1.0\",\"launchAsset\":{\"hash\":\"DW5MBgKq155wnX8rCP1lnsW6BsTbfKLXxGXRQx1RcOA\",\"key\":\"0436e5821bff7b95a84c21f22a43cb96.bundle\",\"contentType\":\"application/javascript\",\"url\":\"https://url.to/bundle\"},\"assets\":[{\"hash\":\"JSeRsPNKzhVdHP1OEsDVsLH500Zfe4j1O7xWfa14oBo\",\"key\":\"3261e570d51777be1e99116562280926.png\",\"contentType\":\"image/png\",\"url\":\"https://url.to/asset\"}],\"metadata\":{\"branchName\":\"default\"}}"))
-    updateDefault1 = NewUpdateManifest.fromNewManifest(manifestJsonDefault1, null, config).updateEntity
+    updateDefault1 = NewUpdateManifest.fromNewManifest(manifestJsonDefault1, Headers.of(), null, config).updateEntity
     val manifestJsonRollout1 = NewManifest(JSONObject("{\"id\":\"079cde35-8433-4c17-81c8-7117c1513e73\",\"createdAt\":\"2021-01-12T19:39:22.480Z\",\"runtimeVersion\":\"1.0\",\"launchAsset\":{\"hash\":\"DW5MBgKq155wnX8rCP1lnsW6BsTbfKLXxGXRQx1RcOA\",\"key\":\"0436e5821bff7b95a84c21f22a43cb96.bundle\",\"contentType\":\"application/javascript\",\"url\":\"https://url.to/bundle\"},\"assets\":[{\"hash\":\"JSeRsPNKzhVdHP1OEsDVsLH500Zfe4j1O7xWfa14oBo\",\"key\":\"3261e570d51777be1e99116562280926.png\",\"contentType\":\"image/png\",\"url\":\"https://url.to/asset\"}],\"metadata\":{\"branchName\":\"rollout\"}}"))
-    updateRollout1 = NewUpdateManifest.fromNewManifest(manifestJsonRollout1, null, config).updateEntity
+    updateRollout1 = NewUpdateManifest.fromNewManifest(manifestJsonRollout1, Headers.of(), null, config).updateEntity
     val manifestJsonDefault2 = NewManifest(JSONObject("{\"id\":\"079cde35-8433-4c17-81c8-7117c1513e74\",\"createdAt\":\"2021-01-13T19:39:22.480Z\",\"runtimeVersion\":\"1.0\",\"launchAsset\":{\"hash\":\"DW5MBgKq155wnX8rCP1lnsW6BsTbfKLXxGXRQx1RcOA\",\"key\":\"0436e5821bff7b95a84c21f22a43cb96.bundle\",\"contentType\":\"application/javascript\",\"url\":\"https://url.to/bundle\"},\"assets\":[{\"hash\":\"JSeRsPNKzhVdHP1OEsDVsLH500Zfe4j1O7xWfa14oBo\",\"key\":\"3261e570d51777be1e99116562280926.png\",\"contentType\":\"image/png\",\"url\":\"https://url.to/asset\"}],\"metadata\":{\"branchName\":\"default\"}}"))
-    updateDefault2 = NewUpdateManifest.fromNewManifest(manifestJsonDefault2, null, config).updateEntity
+    updateDefault2 = NewUpdateManifest.fromNewManifest(manifestJsonDefault2, Headers.of(), null, config).updateEntity
     val manifestJsonRollout2 = NewManifest(JSONObject("{\"id\":\"079cde35-8433-4c17-81c8-7117c1513e75\",\"createdAt\":\"2021-01-14T19:39:22.480Z\",\"runtimeVersion\":\"1.0\",\"launchAsset\":{\"hash\":\"DW5MBgKq155wnX8rCP1lnsW6BsTbfKLXxGXRQx1RcOA\",\"key\":\"0436e5821bff7b95a84c21f22a43cb96.bundle\",\"contentType\":\"application/javascript\",\"url\":\"https://url.to/bundle\"},\"assets\":[{\"hash\":\"JSeRsPNKzhVdHP1OEsDVsLH500Zfe4j1O7xWfa14oBo\",\"key\":\"3261e570d51777be1e99116562280926.png\",\"contentType\":\"image/png\",\"url\":\"https://url.to/asset\"}],\"metadata\":{\"branchName\":\"rollout\"}}"))
-    updateRollout2 = NewUpdateManifest.fromNewManifest(manifestJsonRollout2, null, config).updateEntity
+    updateRollout2 = NewUpdateManifest.fromNewManifest(manifestJsonRollout2, Headers.of(), null, config).updateEntity
     val manifestJsonMultipleFilters = NewManifest(JSONObject("{\"id\":\"079cde35-8433-4c17-81c8-7117c1513e72\",\"createdAt\":\"2021-01-11T19:39:22.480Z\",\"runtimeVersion\":\"1.0\",\"launchAsset\":{\"hash\":\"DW5MBgKq155wnX8rCP1lnsW6BsTbfKLXxGXRQx1RcOA\",\"key\":\"0436e5821bff7b95a84c21f22a43cb96.bundle\",\"contentType\":\"application/javascript\",\"url\":\"https://url.to/bundle\"},\"assets\":[{\"hash\":\"JSeRsPNKzhVdHP1OEsDVsLH500Zfe4j1O7xWfa14oBo\",\"key\":\"3261e570d51777be1e99116562280926.png\",\"contentType\":\"image/png\",\"url\":\"https://url.to/asset\"}],\"metadata\":{\"firstKey\": \"value1\", \"secondKey\": \"value2\"}}"))
-    updateMultipleFilters = NewUpdateManifest.fromNewManifest(manifestJsonMultipleFilters, null, config).updateEntity
+    updateMultipleFilters = NewUpdateManifest.fromNewManifest(manifestJsonMultipleFilters, Headers.of(), null, config).updateEntity
     val manifestJsonNoMetadata = NewManifest(JSONObject("{\"id\":\"079cde35-8433-4c17-81c8-7117c1513e72\",\"createdAt\":\"2021-01-11T19:39:22.480Z\",\"runtimeVersion\":\"1.0\",\"launchAsset\":{\"hash\":\"DW5MBgKq155wnX8rCP1lnsW6BsTbfKLXxGXRQx1RcOA\",\"key\":\"0436e5821bff7b95a84c21f22a43cb96.bundle\",\"contentType\":\"application/javascript\",\"url\":\"https://url.to/bundle\"},\"assets\":[{\"hash\":\"JSeRsPNKzhVdHP1OEsDVsLH500Zfe4j1O7xWfa14oBo\",\"key\":\"3261e570d51777be1e99116562280926.png\",\"contentType\":\"image/png\",\"url\":\"https://url.to/asset\"}]}"))
-    updateNoMetadata = NewUpdateManifest.fromNewManifest(manifestJsonNoMetadata, null, config).updateEntity
+    updateNoMetadata = NewUpdateManifest.fromNewManifest(manifestJsonNoMetadata, Headers.of(), null, config).updateEntity
   }
 
   @Test

--- a/packages/expo-updates/android/src/androidTest/schemas/expo.modules.updates.db.UpdatesDatabase/9.json
+++ b/packages/expo-updates/android/src/androidTest/schemas/expo.modules.updates.db.UpdatesDatabase/9.json
@@ -1,0 +1,333 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 9,
+    "identityHash": "edd919e496bef87b4e64f6cd6481762c",
+    "entities": [
+      {
+        "tableName": "updates",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`launch_asset_id` INTEGER, `manifest` TEXT, `status` INTEGER NOT NULL, `keep` INTEGER NOT NULL, `last_accessed` INTEGER NOT NULL, `successful_launch_count` INTEGER NOT NULL DEFAULT 0, `failed_launch_count` INTEGER NOT NULL DEFAULT 0, `id` BLOB NOT NULL, `commit_time` INTEGER NOT NULL, `runtime_version` TEXT NOT NULL, `scope_key` TEXT NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`launch_asset_id`) REFERENCES `assets`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "launchAssetId",
+            "columnName": "launch_asset_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "manifest",
+            "columnName": "manifest",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "keep",
+            "columnName": "keep",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessed",
+            "columnName": "last_accessed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "successfulLaunchCount",
+            "columnName": "successful_launch_count",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "failedLaunchCount",
+            "columnName": "failed_launch_count",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "commitTime",
+            "columnName": "commit_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "runtimeVersion",
+            "columnName": "runtime_version",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scopeKey",
+            "columnName": "scope_key",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_updates_launch_asset_id",
+            "unique": false,
+            "columnNames": [
+              "launch_asset_id"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_updates_launch_asset_id` ON `${TABLE_NAME}` (`launch_asset_id`)"
+          },
+          {
+            "name": "index_updates_scope_key_commit_time",
+            "unique": true,
+            "columnNames": [
+              "scope_key",
+              "commit_time"
+            ],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_updates_scope_key_commit_time` ON `${TABLE_NAME}` (`scope_key`, `commit_time`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "assets",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "launch_asset_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "updates_assets",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`update_id` BLOB NOT NULL, `asset_id` INTEGER NOT NULL, PRIMARY KEY(`update_id`, `asset_id`), FOREIGN KEY(`update_id`) REFERENCES `updates`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`asset_id`) REFERENCES `assets`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "updateId",
+            "columnName": "update_id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "assetId",
+            "columnName": "asset_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "update_id",
+            "asset_id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_updates_assets_asset_id",
+            "unique": false,
+            "columnNames": [
+              "asset_id"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_updates_assets_asset_id` ON `${TABLE_NAME}` (`asset_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "updates",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "update_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "assets",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "asset_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "assets",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `url` TEXT, `headers` TEXT, `extra_request_headers` TEXT, `metadata` TEXT, `download_time` INTEGER, `relative_path` TEXT, `hash` BLOB, `hash_type` INTEGER NOT NULL, `marked_for_deletion` INTEGER NOT NULL, `key` TEXT, `type` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "headers",
+            "columnName": "headers",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "extraRequestHeaders",
+            "columnName": "extra_request_headers",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "metadata",
+            "columnName": "metadata",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "downloadTime",
+            "columnName": "download_time",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "relativePath",
+            "columnName": "relative_path",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "hash",
+            "columnName": "hash",
+            "affinity": "BLOB",
+            "notNull": false
+          },
+          {
+            "fieldPath": "hashType",
+            "columnName": "hash_type",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "markedForDeletion",
+            "columnName": "marked_for_deletion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_assets_key",
+            "unique": true,
+            "columnNames": [
+              "key"
+            ],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_assets_key` ON `${TABLE_NAME}` (`key`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "json_data",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `key` TEXT NOT NULL, `value` TEXT NOT NULL, `last_updated` INTEGER NOT NULL, `scope_key` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUpdated",
+            "columnName": "last_updated",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scopeKey",
+            "columnName": "scope_key",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_json_data_scope_key",
+            "unique": false,
+            "columnNames": [
+              "scope_key"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_json_data_scope_key` ON `${TABLE_NAME}` (`scope_key`)"
+          }
+        ],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'edd919e496bef87b4e64f6cd6481762c')"
+    ]
+  }
+}

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/dao/AssetDao.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/dao/AssetDao.kt
@@ -89,10 +89,24 @@ abstract class AssetDao {
 
   fun mergeAndUpdateAsset(existingEntity: AssetEntity, newEntity: AssetEntity) {
     // if the existing entry came from an embedded manifest, it may not have a URL in the database
-    if (newEntity.url != null && existingEntity.url == null) {
+    var shouldUpdate = false
+    if (newEntity.url != null && (existingEntity.url == null || newEntity.url != existingEntity.url)) {
       existingEntity.url = newEntity.url
+      shouldUpdate = true
+    }
+
+    val newEntityExtraRequestHeaders = newEntity.extraRequestHeaders
+    if (newEntityExtraRequestHeaders != null &&
+      (existingEntity.extraRequestHeaders == null || newEntityExtraRequestHeaders != existingEntity.extraRequestHeaders)
+    ) {
+      existingEntity.extraRequestHeaders = newEntity.extraRequestHeaders
+      shouldUpdate = true
+    }
+
+    if (shouldUpdate) {
       updateAsset(existingEntity)
     }
+
     // we need to keep track of whether the calling class expects this asset to be the launch asset
     existingEntity.isLaunchAsset = newEntity.isLaunchAsset
     // some fields on the asset entity are not stored in the database but might still be used by application code

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/entity/AssetEntity.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/entity/AssetEntity.kt
@@ -15,6 +15,9 @@ class AssetEntity(@field:ColumnInfo(name = "key") var key: String?, var type: St
 
   var headers: JSONObject? = null
 
+  @ColumnInfo(name = "extra_request_headers")
+  var extraRequestHeaders: JSONObject? = null
+
   var metadata: JSONObject? = null
 
   @ColumnInfo(name = "download_time")

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.kt
@@ -1,16 +1,15 @@
 package expo.modules.updates.loader
 
 import android.content.Context
-import android.net.Uri
 import android.util.Log
 import expo.modules.jsonutils.getNullable
+import expo.modules.jsonutils.require
 import expo.modules.updates.UpdatesConfiguration
 import expo.modules.updates.UpdatesUtils
 import expo.modules.updates.db.entity.AssetEntity
 import expo.modules.updates.launcher.NoDatabaseLauncher
 import expo.modules.updates.loader.Crypto.RSASignatureListener
 import expo.modules.updates.manifest.ManifestFactory
-import expo.modules.updates.manifest.ManifestResponse
 import expo.modules.updates.manifest.UpdateManifest
 import expo.modules.updates.selectionpolicy.SelectionPolicies
 import okhttp3.*
@@ -21,6 +20,9 @@ import java.io.File
 import java.io.IOException
 import java.util.*
 import kotlin.math.min
+import org.apache.commons.fileupload.MultipartStream
+import org.apache.commons.fileupload.ParameterParser
+import java.io.ByteArrayOutputStream
 
 open class FileDownloader(context: Context) {
   private val client = OkHttpClient.Builder().cache(getCache(context)).build()
@@ -82,6 +84,157 @@ open class FileDownloader(context: Context) {
     )
   }
 
+  internal fun parseManifestResponse(response: Response, configuration: UpdatesConfiguration, callback: ManifestDownloadCallback) {
+    val contentType = response.header("content-type") ?: ""
+    val isMultipart = contentType.startsWith("multipart/", ignoreCase = true)
+    if (isMultipart) {
+      val boundaryParameter = ParameterParser().parse(contentType, ';')["boundary"]
+      if (boundaryParameter == null) {
+        callback.onFailure(
+          "Missing boundary in multipart manifest content-type",
+          IOException("Missing boundary in multipart manifest content-type")
+        )
+        return
+      }
+
+      parseMultipartManifestResponse(response, boundaryParameter, configuration, callback)
+    } else {
+      parseManifest(response.body()!!.string(), response.headers(), null, configuration, callback)
+    }
+  }
+
+  private fun parseHeaders(text: String): Headers {
+    val headers = mutableMapOf<String, String>()
+    val lines = text.split(CRLF)
+    for (line in lines) {
+      val indexOfSeparator = line.indexOf(":")
+      if (indexOfSeparator == -1) {
+        continue
+      }
+      val key = line.substring(0, indexOfSeparator).trim()
+      val value = line.substring(indexOfSeparator + 1).trim()
+      headers[key] = value
+    }
+    return Headers.of(headers)
+  }
+
+  private fun parseMultipartManifestResponse(response: Response, boundary: String, configuration: UpdatesConfiguration, callback: ManifestDownloadCallback) {
+    var manifestBodyAndHeaders: Pair<String, Headers>? = null
+    var extensionsBody: String? = null
+
+    val multipartStream = MultipartStream(response.body()!!.byteStream(), boundary.toByteArray())
+
+    try {
+      var nextPart = multipartStream.skipPreamble()
+      while (nextPart) {
+        val headers = parseHeaders(multipartStream.readHeaders())
+
+        // always read the body to progress the reader
+        val output = ByteArrayOutputStream()
+        multipartStream.readBodyData(output)
+
+        val contentDispositionValue = headers.get("content-disposition")
+        if (contentDispositionValue != null) {
+          val contentDispositionParameterMap = ParameterParser().parse(contentDispositionValue, ';')
+          val contentDispositionName = contentDispositionParameterMap["name"]
+          if (contentDispositionName != null) {
+            when (contentDispositionName) {
+              "manifest" -> manifestBodyAndHeaders = Pair(output.toString(), headers)
+              "extensions" -> extensionsBody = output.toString()
+            }
+          }
+        }
+        nextPart = multipartStream.readBoundary()
+      }
+    } catch (e: Exception) {
+      callback.onFailure(
+        "Error while reading multipart manifest response",
+        e
+      )
+      return
+    }
+
+    if (manifestBodyAndHeaders == null) {
+      callback.onFailure("Multipart manifest response missing manifest part", IOException("Malformed multipart manifest response"))
+      return
+    }
+
+    val extensions = try {
+      extensionsBody?.let { JSONObject(it) }
+    } catch (e: Exception) {
+      callback.onFailure(
+        "Failed to parse multipart manifest extensions",
+        e
+      )
+      return
+    }
+
+    parseManifest(manifestBodyAndHeaders.first, manifestBodyAndHeaders.second, extensions, configuration, callback)
+  }
+
+  private fun parseManifest(manifestBody: String, manifestHeaders: Headers, extensions: JSONObject?, configuration: UpdatesConfiguration, callback: ManifestDownloadCallback) {
+    try {
+      val updateResponseJson = extractUpdateResponseJson(manifestBody, configuration)
+      val isSignatureInBody =
+        updateResponseJson.has("manifestString") && updateResponseJson.has("signature")
+      val signature = if (isSignatureInBody) {
+        updateResponseJson.getNullable("signature")
+      } else {
+        manifestHeaders["expo-manifest-signature"]
+      }
+
+      /**
+       * The updateResponseJson is just the manifest when it is unsigned, or the signature is sent as a header.
+       * If the signature is in the body, the updateResponseJson looks like:
+       * {
+       *   manifestString: string;
+       *   signature: string;
+       * }
+       */
+      val manifestString =
+        if (isSignatureInBody) updateResponseJson.getString("manifestString") else manifestBody
+      val preManifest = JSONObject(manifestString)
+
+      // XDL serves unsigned manifests with the `signature` key set to "UNSIGNED".
+      // We should treat these manifests as unsigned rather than signed with an invalid signature.
+      val isUnsignedFromXDL = "UNSIGNED" == signature
+      if (signature != null && !isUnsignedFromXDL) {
+        Crypto.verifyPublicRSASignature(
+          manifestString,
+          signature,
+          this@FileDownloader,
+          object : RSASignatureListener {
+            override fun onError(exception: Exception, isNetworkError: Boolean) {
+              callback.onFailure("Could not validate signed manifest", exception)
+            }
+
+            override fun onCompleted(isValid: Boolean) {
+              if (isValid) {
+                try {
+                  createManifest(preManifest, manifestHeaders, extensions, true, configuration, callback)
+                } catch (e: Exception) {
+                  callback.onFailure("Failed to parse manifest data", e)
+                }
+              } else {
+                callback.onFailure(
+                  "Manifest signature is invalid; aborting",
+                  Exception("Manifest signature is invalid")
+                )
+              }
+            }
+          }
+        )
+      } else {
+        createManifest(preManifest, manifestHeaders, extensions, false, configuration, callback)
+      }
+    } catch (e: Exception) {
+      callback.onFailure(
+        "Failed to parse manifest data",
+        e
+      )
+    }
+  }
+
   fun downloadManifest(
     configuration: UpdatesConfiguration,
     extraHeaders: JSONObject?,
@@ -90,7 +243,7 @@ open class FileDownloader(context: Context) {
   ) {
     try {
       downloadData(
-        setHeadersForManifestUrl(configuration, extraHeaders, context),
+        createRequestForManifest(configuration, extraHeaders, context),
         object : Callback {
           override fun onFailure(call: Call, e: IOException) {
             callback.onFailure(
@@ -110,63 +263,8 @@ open class FileDownloader(context: Context) {
               )
               return
             }
-            try {
-              val updateResponseBody = response.body()!!.string()
-              val updateResponseJson = extractUpdateResponseJson(updateResponseBody, configuration)
-              val isSignatureInBody = updateResponseJson.has("manifestString") && updateResponseJson.has("signature")
-              val signature = if (isSignatureInBody) {
-                updateResponseJson.getNullable("signature")
-              } else {
-                response.header("expo-manifest-signature", null)
-              }
 
-              /**
-               * The updateResponseJson is just the manifest when it is unsigned, or the signature is sent as a header.
-               * If the signature is in the body, the updateResponseJson looks like:
-               * {
-               *   manifestString: string;
-               *   signature: string;
-               * }
-               */
-              val manifestString =
-                if (isSignatureInBody) updateResponseJson.getString("manifestString") else updateResponseBody
-              val preManifest = JSONObject(manifestString)
-
-              // XDL serves unsigned manifests with the `signature` key set to "UNSIGNED".
-              // We should treat these manifests as unsigned rather than signed with an invalid signature.
-              val isUnsignedFromXDL = "UNSIGNED" == signature
-              if (signature != null && !isUnsignedFromXDL) {
-                Crypto.verifyPublicRSASignature(
-                  manifestString,
-                  signature,
-                  this@FileDownloader,
-                  object : RSASignatureListener {
-                    override fun onError(exception: Exception, isNetworkError: Boolean) {
-                      callback.onFailure("Could not validate signed manifest", exception)
-                    }
-
-                    override fun onCompleted(isValid: Boolean) {
-                      if (isValid) {
-                        try {
-                          createManifest(preManifest, response, true, configuration, callback)
-                        } catch (e: Exception) {
-                          callback.onFailure("Failed to parse manifest data", e)
-                        }
-                      } else {
-                        callback.onFailure(
-                          "Manifest signature is invalid; aborting",
-                          Exception("Manifest signature is invalid")
-                        )
-                      }
-                    }
-                  }
-                )
-              } else {
-                createManifest(preManifest, response, false, configuration, callback)
-              }
-            } catch (e: Exception) {
-              callback.onFailure("Failed to parse manifest data", e)
-            }
+            parseManifestResponse(response, configuration, callback)
           }
         }
       )
@@ -196,7 +294,7 @@ open class FileDownloader(context: Context) {
     } else {
       try {
         downloadFileToPath(
-          setHeadersForUrl(asset.url!!, configuration),
+          createRequestForAsset(asset, configuration),
           path,
           object : FileDownloadCallback {
             override fun onFailure(e: Exception) {
@@ -241,10 +339,14 @@ open class FileDownloader(context: Context) {
   companion object {
     private val TAG = FileDownloader::class.java.simpleName
 
+    // Standard line separator for HTTP.
+    private const val CRLF = "\r\n"
+
     @Throws(Exception::class)
     private fun createManifest(
       preManifest: JSONObject,
-      response: Response,
+      headers: Headers,
+      extensions: JSONObject?,
       isVerified: Boolean,
       configuration: UpdatesConfiguration,
       callback: ManifestDownloadCallback
@@ -252,7 +354,7 @@ open class FileDownloader(context: Context) {
       if (configuration.expectsSignedManifest) {
         preManifest.put("isVerified", isVerified)
       }
-      val updateManifest = ManifestFactory.getManifest(preManifest, ManifestResponse(response), configuration)
+      val updateManifest = ManifestFactory.getManifest(preManifest, headers, extensions, configuration)
       if (!SelectionPolicies.matchesFilters(updateManifest.updateEntity!!, updateManifest.manifestFilters)) {
         val message =
           "Downloaded manifest is invalid; provides filters that do not match its content"
@@ -295,9 +397,16 @@ open class FileDownloader(context: Context) {
       throw IOException("No compatible manifest found. SDK Versions supported: " + configuration.sdkVersion + " Provided manifestString: " + manifestString)
     }
 
-    private fun setHeadersForUrl(url: Uri, configuration: UpdatesConfiguration): Request {
+    internal fun createRequestForAsset(assetEntity: AssetEntity, configuration: UpdatesConfiguration): Request {
       return Request.Builder()
-        .url(url.toString())
+        .url(assetEntity.url!!.toString())
+        .apply {
+          assetEntity.extraRequestHeaders?.let { headers ->
+            headers.keys().asSequence().forEach { key ->
+              header(key, headers.require(key))
+            }
+          }
+        }
         .header("Expo-Platform", "android")
         .header("Expo-API-Version", "1")
         .header("Expo-Updates-Environment", "BARE")
@@ -309,7 +418,7 @@ open class FileDownloader(context: Context) {
         .build()
     }
 
-    internal fun setHeadersForManifestUrl(
+    internal fun createRequestForManifest(
       configuration: UpdatesConfiguration,
       extraHeaders: JSONObject?,
       context: Context
@@ -326,7 +435,7 @@ open class FileDownloader(context: Context) {
             }
           }
         }
-        .header("Accept", "application/expo+json,application/json")
+        .header("Accept", "multipart/mixed,application/expo+json,application/json")
         .header("Expo-Platform", "android")
         .header("Expo-API-Version", "1")
         .header("Expo-Updates-Environment", "BARE")

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ManifestFactory.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ManifestFactory.kt
@@ -4,6 +4,7 @@ import expo.modules.updates.UpdatesConfiguration
 import expo.modules.manifests.core.BareManifest
 import expo.modules.manifests.core.LegacyManifest
 import expo.modules.manifests.core.NewManifest
+import okhttp3.Headers
 import org.json.JSONException
 import org.json.JSONObject
 
@@ -11,14 +12,14 @@ object ManifestFactory {
   private val TAG = ManifestFactory::class.java.simpleName
 
   @Throws(Exception::class)
-  fun getManifest(manifestJson: JSONObject, httpResponse: ManifestResponse, configuration: UpdatesConfiguration?): UpdateManifest {
-    val expoProtocolVersion = httpResponse.header("expo-protocol-version")
+  fun getManifest(manifestJson: JSONObject, responseHeaders: Headers, extensions: JSONObject?, configuration: UpdatesConfiguration?): UpdateManifest {
+    val expoProtocolVersion = responseHeaders["expo-protocol-version"]
     return when {
       expoProtocolVersion == null -> {
         LegacyUpdateManifest.fromLegacyManifest(LegacyManifest(manifestJson), configuration!!)
       }
       Integer.valueOf(expoProtocolVersion) == 0 -> {
-        NewUpdateManifest.fromNewManifest(NewManifest(manifestJson), httpResponse, configuration!!)
+        NewUpdateManifest.fromNewManifest(NewManifest(manifestJson), responseHeaders, extensions, configuration!!)
       }
       else -> {
         throw Exception("Unsupported expo-protocol-version: $expoProtocolVersion")

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/NewUpdateManifest.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/NewUpdateManifest.kt
@@ -3,6 +3,7 @@ package expo.modules.updates.manifest
 import android.net.Uri
 import android.util.Log
 import expo.modules.jsonutils.getNullable
+import expo.modules.jsonutils.require
 import expo.modules.structuredheaders.BooleanItem
 import expo.modules.structuredheaders.NumberItem
 import expo.modules.structuredheaders.Parser
@@ -13,6 +14,7 @@ import expo.modules.updates.db.entity.AssetEntity
 import expo.modules.updates.db.entity.UpdateEntity
 import expo.modules.updates.loader.EmbeddedLoader
 import expo.modules.manifests.core.NewManifest
+import okhttp3.Headers
 import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
@@ -27,6 +29,7 @@ class NewUpdateManifest private constructor(
   private val mRuntimeVersion: String,
   private val mLaunchAsset: JSONObject,
   private val mAssets: JSONArray?,
+  private val mExtensions: JSONObject?,
   private val mServerDefinedHeaders: String?,
   private val mManifestFilters: String?
 ) : UpdateManifest {
@@ -48,6 +51,11 @@ class NewUpdateManifest private constructor(
     }
   }
 
+  private val assetHeaders: Map<String, JSONObject> by lazy {
+    val assetRequestHeadersJSON = (mExtensions ?: JSONObject()).getNullable<JSONObject>("assetRequestHeaders")
+    assetRequestHeadersJSON?.let { it.keys().asSequence().associateWith { key -> it.require(key) } } ?: mapOf()
+  }
+
   override val assetEntityList: List<AssetEntity> by lazy {
     val assetList = mutableListOf<AssetEntity>()
     try {
@@ -58,6 +66,7 @@ class NewUpdateManifest private constructor(
           mLaunchAsset.getNullable("fileExtension")
         ).apply {
           url = Uri.parse(mLaunchAsset.getString("url"))
+          extraRequestHeaders = assetHeaders[mLaunchAsset.getString("key")]
           isLaunchAsset = true
           embeddedAssetFilename = EmbeddedLoader.BUNDLE_FILENAME
         }
@@ -75,6 +84,7 @@ class NewUpdateManifest private constructor(
               assetObject.getString("fileExtension")
             ).apply {
               url = Uri.parse(assetObject.getString("url"))
+              extraRequestHeaders = assetHeaders[assetObject.getString("key")]
               embeddedAssetFilename = assetObject.getNullable("embeddedAssetFilename")
             }
           )
@@ -94,7 +104,8 @@ class NewUpdateManifest private constructor(
     @Throws(JSONException::class)
     fun fromNewManifest(
       manifest: NewManifest,
-      httpResponse: ManifestResponse?,
+      responseHeaders: Headers,
+      extensions: JSONObject?,
       configuration: UpdatesConfiguration
     ): NewUpdateManifest {
       val id = UUID.fromString(manifest.getID())
@@ -107,8 +118,8 @@ class NewUpdateManifest private constructor(
         Log.e(TAG, "Could not parse manifest createdAt string; falling back to current time", e)
         Date()
       }
-      val serverDefinedHeaders = httpResponse?.header("expo-server-defined-headers")
-      val manifestFilters = httpResponse?.header("expo-manifest-filters")
+      val serverDefinedHeaders = responseHeaders["expo-server-defined-headers"]
+      val manifestFilters = responseHeaders["expo-manifest-filters"]
       return NewUpdateManifest(
         manifest,
         id,
@@ -117,6 +128,7 @@ class NewUpdateManifest private constructor(
         runtimeVersion,
         launchAsset,
         assets,
+        extensions,
         serverDefinedHeaders,
         manifestFilters
       )


### PR DESCRIPTION
# Why

Implement multipart manifest response parsing from spec change: https://github.com/expo/expo/pull/15389

# How

1. Add multipart content type to manifest `accept` header.
1. Add support for multipart parsing based on content-type of response.
1. Add support for `extensions` from multipart, supporting `assetRequestHeaders` as specified in the spec.
1. Add some basic tests for these things.

# Test Plan

Run tests.

Also will try implementing multipart in the https://github.com/expo/custom-expo-updates-server repo for testing purposes.