### PR TITLE
[docs] Drop mention of "mode" property from expo-notifications config plugin.

### DIFF
--- a/docs/pages/versions/unversioned/sdk/notifications.md
+++ b/docs/pages/versions/unversioned/sdk/notifications.md
@@ -52,6 +52,8 @@ Learn how to configure the native projects in the [installation instructions in 
 
 </ConfigReactNative>
 
+> The iOS APNS entitlement is _always_ set to 'development'. Xcode automatically changes this to 'production' during archive. [Learn more](https://stackoverflow.com/a/42293632/4047926).
+
 <ConfigPluginExample>
 
 ```json
@@ -66,8 +68,7 @@ Learn how to configure the native projects in the [installation instructions in 
           "sounds": [
             "./local/assets/notification-sound.wav",
             "./local/assets/notification-sound-other.wav"
-          ],
-          "mode": "production"
+          ]
         }
       ]
     ]
@@ -78,10 +79,9 @@ Learn how to configure the native projects in the [installation instructions in 
 </ConfigPluginExample>
 
 <ConfigPluginProperties properties={[
-  { name: 'icon', platform: 'android', description: 'Local path to an image to use as the icon for push notifications. 96x96 all-white png with transparency.' },
-  { name: 'color', default: '#ffffff', platform: 'android', description: 'Tint color for the push notification image when it appears in the notification tray.' },
-  { name: 'sounds', description: 'Array of local paths to sound files (.wav recommended) that can be used as custom notification sounds.' },
-  { name: 'mode', default: 'development', platform: 'ios', description: `Environment of the app: either 'development' or 'production'.` },
+{ name: 'icon', platform: 'android', description: 'Local path to an image to use as the icon for push notifications. 96x96 all-white png with transparency.' },
+{ name: 'color', default: '#ffffff', platform: 'android', description: 'Tint color for the push notification image when it appears in the notification tray.' },
+{ name: 'sounds', description: 'Array of local paths to sound files (.wav recommended) that can be used as custom notification sounds.' },
 ]} />
 
 ## Credentials configuration

--- a/docs/pages/versions/v42.0.0/sdk/notifications.md
+++ b/docs/pages/versions/v42.0.0/sdk/notifications.md
@@ -38,6 +38,8 @@ The **`expo-notifications`** provides an API to fetch push notification tokens a
 
 If you're using EAS Build, you can set your Android notification icon and color tint, add custom push notification sounds, and set your iOS notification environment using the `expo-notifications` config plugin ([what's a config plugin?](/guides/config-plugins.md)). To setup, just add the config plugin to the `plugins` array of your **app.json** or **app.config.js** as shown below, then rebuild the app.
 
+> The iOS APNS entitlement is _always_ set to 'development'. Xcode automatically changes this to 'production' during archive. [Learn more](https://stackoverflow.com/a/42293632/4047926).
+
 ```json
 {
   "expo": {
@@ -48,8 +50,7 @@ If you're using EAS Build, you can set your Android notification icon and color 
         {
           "icon": "./local/path/to/myNotificationIcon.png",
           "color": "#ffffff",
-          "sounds": ["./local/path/to/mySound.wav", "./local/path/to/myOtherSound.wav"],
-          "mode": "production"
+          "sounds": ["./local/path/to/mySound.wav", "./local/path/to/myOtherSound.wav"]
         }
       ]
     ],
@@ -62,7 +63,6 @@ If you're using EAS Build, you can set your Android notification icon and color 
 - **icon**: Android only. Local path to an image to use as the icon for push notifications. 96x96 all-white png with transparency.
 - **color**: Android only. Tint color for the push notification image when it appears in the notification tray. Default: "#ffffff".
 - **sounds**: Array of local paths to sound files (.wav recommended) that can be used as custom notification sounds.
-- **mode**: iOS only. Environment of the app: either 'development' or 'production'. Default: 'development'.
 
 </p>
 </details>

--- a/docs/pages/versions/v43.0.0/sdk/notifications.md
+++ b/docs/pages/versions/v43.0.0/sdk/notifications.md
@@ -52,6 +52,8 @@ Learn how to configure the native projects in the [installation instructions in 
 
 </ConfigReactNative>
 
+> The iOS APNS entitlement is _always_ set to 'development'. Xcode automatically changes this to 'production' during archive. [Learn more](https://stackoverflow.com/a/42293632/4047926).
+
 <ConfigPluginExample>
 
 ```json
@@ -66,8 +68,7 @@ Learn how to configure the native projects in the [installation instructions in 
           "sounds": [
             "./local/assets/notification-sound.wav",
             "./local/assets/notification-sound-other.wav"
-          ],
-          "mode": "production"
+          ]
         }
       ]
     ]
@@ -78,10 +79,9 @@ Learn how to configure the native projects in the [installation instructions in 
 </ConfigPluginExample>
 
 <ConfigPluginProperties properties={[
-  { name: 'icon', platform: 'android', description: 'Local path to an image to use as the icon for push notifications. 96x96 all-white png with transparency.' },
-  { name: 'color', default: '#ffffff', platform: 'android', description: 'Tint color for the push notification image when it appears in the notification tray.' },
-  { name: 'sounds', description: 'Array of local paths to sound files (.wav recommended) that can be used as custom notification sounds.' },
-  { name: 'mode', default: 'development', platform: 'ios', description: `Environment of the app: either 'development' or 'production'.` },
+{ name: 'icon', platform: 'android', description: 'Local path to an image to use as the icon for push notifications. 96x96 all-white png with transparency.' },
+{ name: 'color', default: '#ffffff', platform: 'android', description: 'Tint color for the push notification image when it appears in the notification tray.' },
+{ name: 'sounds', description: 'Array of local paths to sound files (.wav recommended) that can be used as custom notification sounds.' }
 ]} />
 
 ## Credentials configuration


### PR DESCRIPTION
Add more info on the APNS entitlement.

[Discord message](https://discord.com/channels/695411232856997968/809586753719238656/916046089054978048).