### PR TITLE
[dev-launcher] Cannot load url that starts with `exp` on Android

### DIFF
--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
@@ -12,6 +12,7 @@ import com.facebook.react.ReactPackage
 import com.facebook.react.bridge.ReactContext
 import expo.interfaces.devmenu.DevMenuManagerInterface
 import expo.interfaces.devmenu.DevMenuManagerProviderInterface
+import expo.modules.devlauncher.helpers.changeUrlScheme
 import expo.modules.devlauncher.helpers.getAppUrlFromDevLauncherUrl
 import expo.modules.devlauncher.helpers.getFieldInClassHierarchy
 import expo.modules.devlauncher.helpers.isDevLauncherUrl
@@ -102,7 +103,7 @@ class DevLauncherController private constructor()
     try {
       ensureHostWasCleared(appHost, activityToBeInvalidated = mainActivity)
 
-      val manifestParser = DevLauncherManifestParser(httpClient, url)
+      val manifestParser = DevLauncherManifestParser(httpClient, changeUrlScheme(url, "http"))
       val appIntent = createAppIntent()
 
       internalUpdatesInterface?.reset()


### PR DESCRIPTION
# Why

Fixes can't load URLs that start with `exp`. 

# How

`DevLauncherManifestParser` tires to request provided URL, for this operation, we should ensure that the scheme is set to `HTTP`.  

# Test Plan

- bare-expo ✅
- simple project ✅
