### PR TITLE
[dev-client] Fix shake gesture sometimes brings two menus on Android

### DIFF
--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/react/DevLauncherDevSupportManagerSwapper.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/react/DevLauncherDevSupportManagerSwapper.kt
@@ -2,20 +2,22 @@ package expo.modules.devlauncher.react
 
 import android.util.Log
 import com.facebook.react.ReactInstanceManager
+import com.facebook.react.common.ShakeDetector
 import com.facebook.react.devsupport.DevServerHelper
 import com.facebook.react.devsupport.DevSupportManagerBase
 import com.facebook.react.devsupport.DisabledDevSupportManager
+import com.facebook.react.devsupport.interfaces.DevSupportManager
 import com.facebook.react.packagerconnection.JSPackagerClient
 import expo.modules.devlauncher.helpers.getProtectedFieldValue
 import expo.modules.devlauncher.helpers.setProtectedDeclaredField
+import expo.modules.devlauncher.koin.DevLauncherKoinComponent
 import expo.modules.devlauncher.launcher.DevLauncherControllerInterface
 import expo.modules.devlauncher.rncompatibility.DevLauncherDevSupportManager
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
-class DevLauncherDevSupportManagerSwapper: KoinComponent {
+class DevLauncherDevSupportManagerSwapper : DevLauncherKoinComponent {
   private val controller: DevLauncherControllerInterface by inject()
 
   fun swapDevSupportManagerImpl(
@@ -50,6 +52,9 @@ class DevLauncherDevSupportManagerSwapper: KoinComponent {
       controller.coroutineScope.launch {
         try {
           while (true) {
+            // Invalidate shake detector - not doing that leads to memory leaks
+            tryToStopShakeDetector(currentDevSupportManager)
+
             val devServerHelper: DevServerHelper = devManagerClass.getProtectedFieldValue(
               currentDevSupportManager,
               "mDevServerHelper"
@@ -86,6 +91,19 @@ class DevLauncherDevSupportManagerSwapper: KoinComponent {
       }
     } catch (e: Exception) {
       Log.i("DevLauncher", "Couldn't inject `DevLauncherDevSupportManager`.", e)
+    }
+  }
+
+  private fun tryToStopShakeDetector(currentDevSupportManager: DevSupportManager) {
+    try {
+      val shakeDetector: ShakeDetector =
+        DevSupportManagerBase::class.java.getProtectedFieldValue(
+          currentDevSupportManager,
+          "mShakeDetector",
+        )
+      shakeDetector.stop()
+    } catch (e: Exception) {
+      Log.w("DevLauncher", "Couldn't stop shake detector.", e)
     }
   }
 }

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuManager.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuManager.kt
@@ -40,6 +40,7 @@ import expo.modules.devmenu.detectors.ShakeDetector
 import expo.modules.devmenu.detectors.ThreeFingerLongPressDetector
 import expo.modules.devmenu.modules.DevMenuSettings
 import expo.modules.devmenu.react.DevMenuPackagerCommandHandlersSwapper
+import expo.modules.devmenu.react.DevMenuShakeDetectorListenerSwapper
 import expo.modules.devmenu.tests.DevMenuDisabledTestInterceptor
 import expo.modules.devmenu.tests.DevMenuTestInterceptor
 import expo.modules.devmenu.websockets.DevMenuCommandHandlersProvider
@@ -187,6 +188,11 @@ object DevMenuManager : DevMenuManagerInterface, LifecycleEventListener {
         reactInstanceManager,
         handlers
       )
+
+    DevMenuShakeDetectorListenerSwapper()
+      .swapShakeDetectorListener(
+        reactInstanceManager
+      ) {}
 
     if (reactInstanceManager.currentReactContext == null) {
       reactInstanceManager.addReactInstanceEventListener(object : ReactInstanceManager.ReactInstanceEventListener {

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/DevMenuActivity.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/DevMenuActivity.kt
@@ -12,8 +12,8 @@ import com.facebook.react.ReactDelegate
 import com.facebook.react.ReactInstanceManager
 import com.facebook.react.ReactRootView
 import com.facebook.react.devsupport.interfaces.DevSupportManager
-import expo.modules.devmenu.helpers.getPrivateDeclaredFiledValue
-import expo.modules.devmenu.helpers.setPrivateDeclaredFiledValue
+import expo.modules.devmenu.helpers.getPrivateDeclaredFieldValue
+import expo.modules.devmenu.helpers.setPrivateDeclaredFieldValue
 import java.util.*
 
 /**
@@ -38,10 +38,10 @@ class DevMenuActivity : ReactActivity() {
         }
 
         val reactDelegate: ReactDelegate = ReactActivityDelegate::class.java
-          .getPrivateDeclaredFiledValue("mReactDelegate", this)
+          .getPrivateDeclaredFieldValue("mReactDelegate", this)
 
         ReactDelegate::class.java
-          .setPrivateDeclaredFiledValue("mReactRootView", reactDelegate, rootView)
+          .setPrivateDeclaredFieldValue("mReactRootView", reactDelegate, rootView)
 
         // Removes the root view from the previous activity
         (rootView.parent as? ViewGroup)?.removeView(rootView)
@@ -104,7 +104,7 @@ class DevMenuActivity : ReactActivity() {
 
     if (supportsDevelopment) {
       val devSupportManager: DevSupportManager =
-        ReactInstanceManager::class.java.getPrivateDeclaredFiledValue(
+        ReactInstanceManager::class.java.getPrivateDeclaredFieldValue(
           "mDevSupportManager", instanceManager
         )
 

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/helpers/DevMenuReflectionExtensions.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/helpers/DevMenuReflectionExtensions.kt
@@ -4,13 +4,13 @@ import java.lang.reflect.Field
 import java.lang.reflect.Modifier
 
 @Suppress("UNCHECKED_CAST")
-fun <T, R> Class<out T>.getPrivateDeclaredFiledValue(filedName: String, obj: T): R {
+fun <T, R> Class<out T>.getPrivateDeclaredFieldValue(filedName: String, obj: T): R {
   val field = getDeclaredField(filedName)
   field.isAccessible = true
   return field.get(obj) as R
 }
 
-fun <T> Class<out T>.setPrivateDeclaredFiledValue(filedName: String, obj: T, newValue: Any) {
+fun <T> Class<out T>.setPrivateDeclaredFieldValue(filedName: String, obj: T, newValue: Any) {
   val field = getDeclaredField(filedName)
   val modifiersField = Field::class.java.getDeclaredField("accessFlags")
 

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/react/DevMenuPackagerCommandHandlersSwapper.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/react/DevMenuPackagerCommandHandlersSwapper.kt
@@ -8,8 +8,8 @@ import com.facebook.react.devsupport.interfaces.DevSupportManager
 import com.facebook.react.packagerconnection.JSPackagerClient
 import com.facebook.react.packagerconnection.RequestHandler
 import expo.modules.devmenu.DevMenuManager
-import expo.modules.devmenu.helpers.getPrivateDeclaredFiledValue
-import expo.modules.devmenu.helpers.setPrivateDeclaredFiledValue
+import expo.modules.devmenu.helpers.getPrivateDeclaredFieldValue
+import expo.modules.devmenu.helpers.setPrivateDeclaredFieldValue
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
@@ -20,7 +20,7 @@ class DevMenuPackagerCommandHandlersSwapper {
   ) {
     try {
       val devSupportManager: DevSupportManager =
-        ReactInstanceManager::class.java.getPrivateDeclaredFiledValue(
+        ReactInstanceManager::class.java.getPrivateDeclaredFieldValue(
           "mDevSupportManager",
           reactInstanceManager
         )
@@ -31,7 +31,7 @@ class DevMenuPackagerCommandHandlersSwapper {
       }
 
       val currentCommandHandlers: Map<String, RequestHandler>? =
-        DevSupportManagerBase::class.java.getPrivateDeclaredFiledValue(
+        DevSupportManagerBase::class.java.getPrivateDeclaredFieldValue(
           "mCustomPackagerCommandHandlers",
           devSupportManager
         )
@@ -39,7 +39,7 @@ class DevMenuPackagerCommandHandlersSwapper {
       val newCommandHandlers = currentCommandHandlers?.toMutableMap() ?: mutableMapOf()
       newCommandHandlers.putAll(handlers)
 
-      DevSupportManagerBase::class.java.setPrivateDeclaredFiledValue(
+      DevSupportManagerBase::class.java.setPrivateDeclaredFieldValue(
         "mCustomPackagerCommandHandlers",
         devSupportManager,
         newCommandHandlers
@@ -71,33 +71,33 @@ class DevMenuPackagerCommandHandlersSwapper {
       try {
         while (true) {
           val devSupportManager: DevSupportManagerBase =
-            ReactInstanceManager::class.java.getPrivateDeclaredFiledValue(
+            ReactInstanceManager::class.java.getPrivateDeclaredFieldValue(
               "mDevSupportManager",
               reactInstanceManager
             )
 
           val devServerHelper: DevServerHelper =
-            DevSupportManagerBase::class.java.getPrivateDeclaredFiledValue(
+            DevSupportManagerBase::class.java.getPrivateDeclaredFieldValue(
               "mDevServerHelper",
               devSupportManager
             )
 
           val jsPackagerClient: JSPackagerClient? =
-            DevServerHelper::class.java.getPrivateDeclaredFiledValue(
+            DevServerHelper::class.java.getPrivateDeclaredFieldValue(
               "mPackagerClient",
               devServerHelper
             )
 
           if (jsPackagerClient != null) {
             val currentCommandHandlers: Map<String, RequestHandler>? =
-              JSPackagerClient::class.java.getPrivateDeclaredFiledValue(
+              JSPackagerClient::class.java.getPrivateDeclaredFieldValue(
                 "mRequestHandlers",
                 jsPackagerClient
               )
 
             val newCommandHandlers = currentCommandHandlers?.toMutableMap() ?: mutableMapOf()
             newCommandHandlers.putAll(handlers)
-            JSPackagerClient::class.java.setPrivateDeclaredFiledValue(
+            JSPackagerClient::class.java.setPrivateDeclaredFieldValue(
               "mRequestHandlers",
               jsPackagerClient,
               newCommandHandlers

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/react/DevMenuShakeDetectorListenerSwapper.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/react/DevMenuShakeDetectorListenerSwapper.kt
@@ -1,0 +1,43 @@
+package expo.modules.devmenu.react
+
+import android.util.Log
+import com.facebook.react.ReactInstanceManager
+import com.facebook.react.common.ShakeDetector
+import com.facebook.react.devsupport.DevSupportManagerBase
+import com.facebook.react.devsupport.interfaces.DevSupportManager
+import expo.modules.devmenu.helpers.getPrivateDeclaredFiledValue
+import expo.modules.devmenu.helpers.setPrivateDeclaredFiledValue
+
+class DevMenuShakeDetectorListenerSwapper {
+  fun swapShakeDetectorListener(
+    reactInstanceManager: ReactInstanceManager,
+    newListener: ShakeDetector.ShakeListener,
+  ) {
+    try {
+      val devSupportManager: DevSupportManager =
+        ReactInstanceManager::class.java.getPrivateDeclaredFiledValue(
+          "mDevSupportManager",
+          reactInstanceManager
+        )
+
+      // We don't want to add handlers into `DisabledDevSupportManager` or other custom classes
+      if (devSupportManager !is DevSupportManagerBase) {
+        return
+      }
+
+      val shakeDetector: ShakeDetector =
+        DevSupportManagerBase::class.java.getPrivateDeclaredFiledValue(
+          "mShakeDetector",
+          devSupportManager
+        )
+
+      ShakeDetector::class.java.setPrivateDeclaredFiledValue(
+        "mShakeListener",
+        shakeDetector,
+        newListener
+      )
+    } catch (e: Exception) {
+      Log.w("DevMenu", "Couldn't swap shake detector listener: ${e.message}", e)
+    }
+  }
+}

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/react/DevMenuShakeDetectorListenerSwapper.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/react/DevMenuShakeDetectorListenerSwapper.kt
@@ -5,8 +5,8 @@ import com.facebook.react.ReactInstanceManager
 import com.facebook.react.common.ShakeDetector
 import com.facebook.react.devsupport.DevSupportManagerBase
 import com.facebook.react.devsupport.interfaces.DevSupportManager
-import expo.modules.devmenu.helpers.getPrivateDeclaredFiledValue
-import expo.modules.devmenu.helpers.setPrivateDeclaredFiledValue
+import expo.modules.devmenu.helpers.getPrivateDeclaredFieldValue
+import expo.modules.devmenu.helpers.setPrivateDeclaredFieldValue
 
 class DevMenuShakeDetectorListenerSwapper {
   fun swapShakeDetectorListener(
@@ -15,7 +15,7 @@ class DevMenuShakeDetectorListenerSwapper {
   ) {
     try {
       val devSupportManager: DevSupportManager =
-        ReactInstanceManager::class.java.getPrivateDeclaredFiledValue(
+        ReactInstanceManager::class.java.getPrivateDeclaredFieldValue(
           "mDevSupportManager",
           reactInstanceManager
         )
@@ -26,12 +26,12 @@ class DevMenuShakeDetectorListenerSwapper {
       }
 
       val shakeDetector: ShakeDetector =
-        DevSupportManagerBase::class.java.getPrivateDeclaredFiledValue(
+        DevSupportManagerBase::class.java.getPrivateDeclaredFieldValue(
           "mShakeDetector",
           devSupportManager
         )
 
-      ShakeDetector::class.java.setPrivateDeclaredFiledValue(
+      ShakeDetector::class.java.setPrivateDeclaredFieldValue(
         "mShakeListener",
         shakeDetector,
         newListener


### PR DESCRIPTION
# Why

Fixes shake gesture sometimes brings two menus on Android.

# How

We have to invalidate a shake detector when we're replacing `DevSupportManager` in dev-launcher.
In the dev-menu, we need to replace a default shake detector listener with noop. 

# Test Plan

- simple application ✅