### PR TITLE
[docs] Add packageName to page context

### DIFF
--- a/docs/components/DocumentationPage.tsx
+++ b/docs/components/DocumentationPage.tsx
@@ -54,6 +54,8 @@ type Props = {
   title: string;
   asPath: string;
   sourceCodeUrl?: string;
+  /** API Page NPM package name, exposed through context for various React components that consistently use the package name. */
+  packageName?: string;
   tocVisible: boolean;
   /* If the page should not show up in the Algolia Docsearch results */
   hideFromSearch?: boolean;
@@ -319,7 +321,8 @@ export default class DocumentationPage extends React.Component<Props, State> {
         {!this.state.isMenuActive ? (
           <div css={STYLES_DOCUMENT}>
             <H1>{this.props.title}</H1>
-            <DocumentationPageContext.Provider value={{ version }}>
+            <DocumentationPageContext.Provider
+              value={{ version, packageName: this.props.packageName }}>
               {this.props.children}
             </DocumentationPageContext.Provider>
             <DocumentationFooter
@@ -333,7 +336,8 @@ export default class DocumentationPage extends React.Component<Props, State> {
           <div>
             <div css={[STYLES_DOCUMENT, HIDDEN_ON_MOBILE]}>
               <H1>{this.props.title}</H1>
-              <DocumentationPageContext.Provider value={{ version }}>
+              <DocumentationPageContext.Provider
+                value={{ version, packageName: this.props.packageName }}>
                 {this.props.children}
               </DocumentationPageContext.Provider>
               <DocumentationFooter

--- a/docs/components/DocumentationPageContext.ts
+++ b/docs/components/DocumentationPageContext.ts
@@ -1,3 +1,3 @@
 import * as React from 'react';
 
-export default React.createContext<{ version?: string }>({});
+export default React.createContext<{ version?: string; packageName?: string }>({});

--- a/docs/components/page-higher-order/DocumentationElements.tsx
+++ b/docs/components/page-higher-order/DocumentationElements.tsx
@@ -25,6 +25,7 @@ export default function DocumentationElements(props: DocumentationElementsProps)
         title={props.meta.title || ''}
         url={router}
         asPath={router.asPath}
+        packageName={props.meta.packageName}
         sourceCodeUrl={props.meta.sourceCodeUrl}
         tocVisible={!props.meta.hideTOC}
         hideFromSearch={props.meta.hideFromSearch}>

--- a/docs/components/plugins/InstallSection.tsx
+++ b/docs/components/plugins/InstallSection.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/react';
 import { theme } from '@expo/styleguide';
 import * as React from 'react';
 
+import DocumentationPageContext from '../DocumentationPageContext';
 import TerminalBlock from './TerminalBlock';
 
 import * as Constants from '~/constants/theme';
@@ -65,3 +66,8 @@ const InstallSection: React.FC<Props> = ({
 );
 
 export default InstallSection;
+
+export const APIInstallSection: React.FC<Props> = props => {
+  const context = React.useContext(DocumentationPageContext);
+  return <InstallSection {...props} packageName={props.packageName ?? context.packageName} />;
+};

--- a/docs/pages/versions/unversioned/sdk/accelerometer.md
+++ b/docs/pages/versions/unversioned/sdk/accelerometer.md
@@ -1,6 +1,7 @@
 ---
 title: Accelerometer
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-sensors'
+packageName: 'expo-sensors'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/accelerometer.md
+++ b/docs/pages/versions/unversioned/sdk/accelerometer.md
@@ -4,7 +4,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-sensors'
 packageName: 'expo-sensors'
 ---
 
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import SnackInline from '~/components/plugins/SnackInline';
 
 import PlatformsSection from '~/components/plugins/PlatformsSection';
@@ -15,7 +15,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 ## Installation
 
-<InstallSection packageName="expo-sensors" />
+<APIInstallSection />
 
 ## Usage
 

--- a/docs/pages/versions/unversioned/sdk/admob.md
+++ b/docs/pages/versions/unversioned/sdk/admob.md
@@ -1,6 +1,7 @@
 ---
 title: Admob
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-ads-admob'
+packageName: 'expo-ads-admob'
 ---
 
 import { ConfigClassic, ConfigReactNative, ConfigPluginExample, ConfigPluginProperties } from '~/components/plugins/ConfigSection';

--- a/docs/pages/versions/unversioned/sdk/admob.md
+++ b/docs/pages/versions/unversioned/sdk/admob.md
@@ -7,7 +7,7 @@ packageName: 'expo-ads-admob'
 import { ConfigClassic, ConfigReactNative, ConfigPluginExample, ConfigPluginProperties } from '~/components/plugins/ConfigSection';
 import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
 import APISection from '~/components/plugins/APISection';
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 Expo includes support for the [Google AdMob SDK](https://www.google.com/admob/) for mobile advertising, including components for banner ads and imperative APIs for interstitial and rewarded video ads. **`expo-ads-admob`** is largely based of the [react-native-admob](https://github.com/sbugert/react-native-admob) module, as the documentation and questions surrounding that module may prove helpful. A simple example implementing AdMob SDK can be found [here](https://github.com/deadcoder0904/expo-google-admob).
@@ -16,7 +16,7 @@ Expo includes support for the [Google AdMob SDK](https://www.google.com/admob/) 
 
 ## Installation
 
-<InstallSection packageName="expo-ads-admob" />
+<APIInstallSection />
 
 ## Configuration in app.json / app.config.js
 

--- a/docs/pages/versions/unversioned/sdk/amplitude.md
+++ b/docs/pages/versions/unversioned/sdk/amplitude.md
@@ -1,6 +1,7 @@
 ---
 title: Amplitude
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-analytics-amplitude'
+packageName: 'expo-analytics-amplitude'
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/amplitude.md
+++ b/docs/pages/versions/unversioned/sdk/amplitude.md
@@ -5,7 +5,7 @@ packageName: 'expo-analytics-amplitude'
 ---
 
 import APISection from '~/components/plugins/APISection';
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`expo-analytics-amplitude`** provides access to [Amplitude](https://amplitude.com/) mobile analytics which allows you track and log various events and data. This module wraps Amplitude's [iOS](https://github.com/amplitude/Amplitude-iOS) and [Android](https://github.com/amplitude/Amplitude-Android) SDKs. For a great example of usage, see the [Expo app source code](https://github.com/expo/expo/blob/master/home/api/Analytics.ts).
@@ -16,7 +16,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 ## Installation
 
-<InstallSection packageName="expo-analytics-amplitude" />
+<APIInstallSection />
 
 ## API
 

--- a/docs/pages/versions/unversioned/sdk/app-auth.md
+++ b/docs/pages/versions/unversioned/sdk/app-auth.md
@@ -1,6 +1,7 @@
 ---
 title: AppAuth
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-app-auth'
+packageName: 'expo-app-auth'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/app-auth.md
+++ b/docs/pages/versions/unversioned/sdk/app-auth.md
@@ -4,7 +4,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-app-auth'
 packageName: 'expo-app-auth'
 ---
 
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import SnackInline from '~/components/plugins/SnackInline';
 
 import PlatformsSection from '~/components/plugins/PlatformsSection';
@@ -23,7 +23,7 @@ If you are trying to implement sign in with [Google](google-sign-in.md) or [Face
 
 ## Installation
 
-<InstallSection packageName="expo-app-auth" />
+<APIInstallSection />
 
 ## Managed Workflow
 

--- a/docs/pages/versions/unversioned/sdk/app-loading.md
+++ b/docs/pages/versions/unversioned/sdk/app-loading.md
@@ -1,6 +1,7 @@
 ---
 title: AppLoading
-sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo/src/launch'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-app-loading'
+packageName: 'expo-app-loading'
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/app-loading.md
+++ b/docs/pages/versions/unversioned/sdk/app-loading.md
@@ -5,7 +5,7 @@ packageName: 'expo-app-loading'
 ---
 
 import APISection from '~/components/plugins/APISection';
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`expo-app-loading`** tells `expo-splash-screen` to keep the splash screen visible while the AppLoading component is mounted.
@@ -16,7 +16,7 @@ This is useful to download and cache fonts, logos, icon images and other assets 
 
 ## Installation
 
-<InstallSection packageName="expo-app-loading" />
+<APIInstallSection />
 
 ## Usage
 

--- a/docs/pages/versions/unversioned/sdk/apple-authentication.md
+++ b/docs/pages/versions/unversioned/sdk/apple-authentication.md
@@ -1,10 +1,11 @@
 ---
 title: AppleAuthentication
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-apple-authentication'
+packageName: 'expo-apple-authentication'
 ---
 
 import APISection from '~/components/plugins/APISection';
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`expo-apple-authentication`** provides Apple authentication for iOS 13+. It does not yet support lower iOS versions, Android, or web.
@@ -15,7 +16,7 @@ Beginning with iOS 13, any app that includes third-party authentication options 
 
 ## Installation
 
-<InstallSection packageName="expo-apple-authentication" />
+<APIInstallSection />
 
 ## Configuration
 

--- a/docs/pages/versions/unversioned/sdk/application.md
+++ b/docs/pages/versions/unversioned/sdk/application.md
@@ -5,7 +5,7 @@ packageName: 'expo-application'
 ---
 
 import APISection from '~/components/plugins/APISection';
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`expo-application`** provides useful information about the native application, itself, such as the ID, app name, and build version.
@@ -14,7 +14,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 ## Installation
 
-<InstallSection packageName="expo-application" />
+<APIInstallSection />
 
 ## API
 

--- a/docs/pages/versions/unversioned/sdk/application.md
+++ b/docs/pages/versions/unversioned/sdk/application.md
@@ -1,6 +1,7 @@
 ---
 title: Application
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-application'
+packageName: 'expo-application'
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/asset.md
+++ b/docs/pages/versions/unversioned/sdk/asset.md
@@ -5,7 +5,7 @@ packageName: 'expo-asset'
 ---
 
 import APISection from '~/components/plugins/APISection';
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`expo-asset`** provides an interface to Expo's asset system. An asset is any file that lives alongside the source code of your app that the app needs at runtime. Examples include images, fonts, and sounds. Expo's asset system integrates with React Native's, so that you can refer to files with `require('path/to/file')`. This is how you refer to static image files in React Native for use in an `Image` component, for example. Check out React Native's [documentation on static image resources](https://reactnative.dev/docs/images.html#static-image-resources) for more information. This method of referring to static image resources works out of the box with Expo.
@@ -14,7 +14,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 ## Installation
 
-<InstallSection packageName="expo-asset" />
+<APIInstallSection />
 
 ## API
 

--- a/docs/pages/versions/unversioned/sdk/asset.md
+++ b/docs/pages/versions/unversioned/sdk/asset.md
@@ -1,6 +1,7 @@
 ---
 title: Asset
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-asset'
+packageName: 'expo-asset'
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/async-storage.md
+++ b/docs/pages/versions/unversioned/sdk/async-storage.md
@@ -1,6 +1,7 @@
 ---
 title: AsyncStorage
 sourceCodeUrl: 'https://github.com/react-native-async-storage/async-storage'
+packageName: '@react-native-async-storage/async-storage'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/async-storage.md
+++ b/docs/pages/versions/unversioned/sdk/async-storage.md
@@ -4,7 +4,7 @@ sourceCodeUrl: 'https://github.com/react-native-async-storage/async-storage'
 packageName: '@react-native-async-storage/async-storage'
 ---
 
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 An asynchronous, unencrypted, persistent, key-value storage API.
@@ -13,7 +13,7 @@ An asynchronous, unencrypted, persistent, key-value storage API.
 
 ## Installation
 
-<InstallSection packageName="@react-native-async-storage/async-storage" href="https://react-native-async-storage.github.io/async-storage/docs/install" />
+<APIInstallSection href="https://react-native-async-storage.github.io/async-storage/docs/install" />
 
 ## Usage
 

--- a/docs/pages/versions/unversioned/sdk/audio.md
+++ b/docs/pages/versions/unversioned/sdk/audio.md
@@ -1,6 +1,7 @@
 ---
 title: Audio
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-av'
+packageName: 'expo-av'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/audio.md
+++ b/docs/pages/versions/unversioned/sdk/audio.md
@@ -4,7 +4,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-av'
 packageName: 'expo-av'
 ---
 
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import SnackInline from '~/components/plugins/SnackInline';
 
@@ -18,7 +18,7 @@ Try the [playlist example app](https://expo.dev/@documentation/playlist-example)
 
 ## Installation
 
-<InstallSection packageName="expo-av" />
+<APIInstallSection />
 
 ## Usage
 

--- a/docs/pages/versions/unversioned/sdk/auth-session.md
+++ b/docs/pages/versions/unversioned/sdk/auth-session.md
@@ -1,6 +1,7 @@
 ---
 title: AuthSession
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-auth-session'
+packageName: 'expo-auth-session'
 ---
 
 import PlatformsSection from '~/components/plugins/PlatformsSection';

--- a/docs/pages/versions/unversioned/sdk/auth-session.md
+++ b/docs/pages/versions/unversioned/sdk/auth-session.md
@@ -5,7 +5,7 @@ packageName: 'expo-auth-session'
 ---
 
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 
 import { SocialGrid, SocialGridItem, CreateAppButton } from '~/components/plugins/AuthSessionElements';
 import TerminalBlock from '~/components/plugins/TerminalBlock';
@@ -20,7 +20,7 @@ import { InlineCode } from '~/components/base/code';
 
 > `expo-random` is a peer dependency and must be installed alongside `expo-auth-session`.
 
-<InstallSection packageName="expo-auth-session expo-random" />
+<APIInstallSection packageName="expo-auth-session expo-random" />
 
 In **bare-workflow** you can use the [`uri-scheme` package][n-uri-scheme] to easily add, remove, list, and open your URIs.
 

--- a/docs/pages/versions/unversioned/sdk/av.md
+++ b/docs/pages/versions/unversioned/sdk/av.md
@@ -1,6 +1,7 @@
 ---
 title: AV
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-av'
+packageName: 'expo-av'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/av.md
+++ b/docs/pages/versions/unversioned/sdk/av.md
@@ -4,7 +4,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-av'
 packageName: 'expo-av'
 ---
 
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 The [`Audio.Sound`](audio.md) objects and [`Video`](video.md) components share a unified imperative API for media playback.
@@ -17,7 +17,7 @@ Try the [playlist example app](http://expo.dev/@community/playlist) (source code
 
 ## Installation
 
-<InstallSection packageName="expo-av" />
+<APIInstallSection />
 
 ## API
 

--- a/docs/pages/versions/unversioned/sdk/background-fetch.md
+++ b/docs/pages/versions/unversioned/sdk/background-fetch.md
@@ -1,6 +1,7 @@
 ---
 title: BackgroundFetch
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-background-fetch'
+packageName: 'expo-background-fetch'
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/bar-code-scanner.md
+++ b/docs/pages/versions/unversioned/sdk/bar-code-scanner.md
@@ -5,7 +5,7 @@ packageName: 'expo-barcode-scanner'
 ---
 
 import APISection from '~/components/plugins/APISection';
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import SnackInline from '~/components/plugins/SnackInline';
 
@@ -17,7 +17,7 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 ## Installation
 
-<InstallSection packageName="expo-barcode-scanner" />
+<APIInstallSection />
 
 ## Configuration
 

--- a/docs/pages/versions/unversioned/sdk/bar-code-scanner.md
+++ b/docs/pages/versions/unversioned/sdk/bar-code-scanner.md
@@ -1,6 +1,7 @@
 ---
 title: BarCodeScanner
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-barcode-scanner'
+packageName: 'expo-barcode-scanner'
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/barometer.md
+++ b/docs/pages/versions/unversioned/sdk/barometer.md
@@ -4,7 +4,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-sensors'
 packageName: 'expo-sensors'
 ---
 
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import SnackInline from '~/components/plugins/SnackInline';
 
@@ -16,7 +16,7 @@ import { InlineCode } from '~/components/base/code';
 
 ## Installation
 
-<InstallSection packageName="expo-sensors" />
+<APIInstallSection />
 
 ## Usage
 

--- a/docs/pages/versions/unversioned/sdk/barometer.md
+++ b/docs/pages/versions/unversioned/sdk/barometer.md
@@ -1,6 +1,7 @@
 ---
 title: Barometer
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-sensors'
+packageName: 'expo-sensors'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/battery.md
+++ b/docs/pages/versions/unversioned/sdk/battery.md
@@ -5,7 +5,7 @@ packageName: 'expo-battery'
 ---
 
 import APISection from '~/components/plugins/APISection';
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import SnackInline from '~/components/plugins/SnackInline';
 
@@ -15,7 +15,7 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 ## Installation
 
-<InstallSection packageName="expo-battery" />
+<APIInstallSection />
 
 ## Usage
 

--- a/docs/pages/versions/unversioned/sdk/battery.md
+++ b/docs/pages/versions/unversioned/sdk/battery.md
@@ -1,6 +1,7 @@
 ---
 title: Battery
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-battery'
+packageName: 'expo-battery'
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/blur-view.md
+++ b/docs/pages/versions/unversioned/sdk/blur-view.md
@@ -5,7 +5,7 @@ packageName: 'expo-blur'
 ---
 
 import APISection from '~/components/plugins/APISection';
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import SnackInline from '~/components/plugins/SnackInline';
 
@@ -15,7 +15,7 @@ A React component that blurs everything underneath the view. On iOS, it renders 
 
 ## Installation
 
-<InstallSection packageName="expo-blur" />
+<APIInstallSection />
 
 ## Usage
 

--- a/docs/pages/versions/unversioned/sdk/blur-view.md
+++ b/docs/pages/versions/unversioned/sdk/blur-view.md
@@ -1,6 +1,7 @@
 ---
 title: BlurView
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-blur'
+packageName: 'expo-blur'
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/branch.md
+++ b/docs/pages/versions/unversioned/sdk/branch.md
@@ -1,6 +1,7 @@
 ---
 title: Branch
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-branch'
+packageName: 'expo-branch'
 ---
 
 import PlatformsSection from '~/components/plugins/PlatformsSection';

--- a/docs/pages/versions/unversioned/sdk/brightness.md
+++ b/docs/pages/versions/unversioned/sdk/brightness.md
@@ -1,6 +1,7 @@
 ---
 title: Brightness
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-brightness'
+packageName: 'expo-brightness'
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/brightness.md
+++ b/docs/pages/versions/unversioned/sdk/brightness.md
@@ -5,7 +5,7 @@ packageName: 'expo-brightness'
 ---
 
 import APISection from '~/components/plugins/APISection';
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import SnackInline from '~/components/plugins/SnackInline';
 
@@ -17,7 +17,7 @@ On Android, there is a global system-wide brightness setting, and each app has i
 
 ## Installation
 
-<InstallSection packageName="expo-brightness" />
+<APIInstallSection />
 
 ## Usage
 

--- a/docs/pages/versions/unversioned/sdk/calendar.md
+++ b/docs/pages/versions/unversioned/sdk/calendar.md
@@ -1,6 +1,7 @@
 ---
 title: Calendar
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-calendar'
+packageName: 'expo-calendar'
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/calendar.md
+++ b/docs/pages/versions/unversioned/sdk/calendar.md
@@ -5,7 +5,7 @@ packageName: 'expo-calendar'
 ---
 
 import APISection from '~/components/plugins/APISection';
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import SnackInline from '~/components/plugins/SnackInline';
 
@@ -15,7 +15,7 @@ Provides an API for interacting with the device's system calendars, events, remi
 
 ## Installation
 
-<InstallSection packageName="expo-calendar" />
+<APIInstallSection />
 
 ## Configuration
 

--- a/docs/pages/versions/unversioned/sdk/camera.md
+++ b/docs/pages/versions/unversioned/sdk/camera.md
@@ -1,6 +1,7 @@
 ---
 title: Camera
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-camera'
+packageName: 'expo-camera'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/camera.md
+++ b/docs/pages/versions/unversioned/sdk/camera.md
@@ -4,7 +4,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-camera'
 packageName: 'expo-camera'
 ---
 
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import SnackInline from '~/components/plugins/SnackInline';
 
@@ -16,7 +16,7 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 ## Installation
 
-<InstallSection packageName="expo-camera" />
+<APIInstallSection />
 
 ## Configuration
 

--- a/docs/pages/versions/unversioned/sdk/captureRef.md
+++ b/docs/pages/versions/unversioned/sdk/captureRef.md
@@ -4,7 +4,7 @@ sourceCodeUrl: 'https://github.com/gre/react-native-view-shot'
 packageName: 'react-native-view-shot'
 ---
 
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 Given a view, `captureRef` will essentially screenshot that view and return an image for you. This is very useful for things like signature pads, where the user draws something and then you want to save an image from it.
@@ -15,7 +15,7 @@ If you're interested in taking snapshots from the GLView, we recommend you use [
 
 ## Installation
 
-<InstallSection packageName="react-native-view-shot" href="https://github.com/gre/react-native-view-shot" />
+<APIInstallSection href="https://github.com/gre/react-native-view-shot" />
 
 ## API
 

--- a/docs/pages/versions/unversioned/sdk/captureRef.md
+++ b/docs/pages/versions/unversioned/sdk/captureRef.md
@@ -1,6 +1,7 @@
 ---
 title: captureRef
 sourceCodeUrl: 'https://github.com/gre/react-native-view-shot'
+packageName: 'react-native-view-shot'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/cellular.md
+++ b/docs/pages/versions/unversioned/sdk/cellular.md
@@ -5,7 +5,7 @@ packageName: 'expo-cellular'
 ---
 
 import APISection from '~/components/plugins/APISection';
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`expo-cellular`** provides information about the user’s cellular service provider, such as its unique identifier, cellular connection type, and whether it allows VoIP calls on its network.
@@ -14,7 +14,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 ## Installation
 
-<InstallSection packageName="expo-cellular" />
+<APIInstallSection />
 
 ## API
 

--- a/docs/pages/versions/unversioned/sdk/cellular.md
+++ b/docs/pages/versions/unversioned/sdk/cellular.md
@@ -1,6 +1,7 @@
 ---
 title: Cellular
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-cellular'
+packageName: 'expo-cellular'
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/checkbox.md
+++ b/docs/pages/versions/unversioned/sdk/checkbox.md
@@ -5,7 +5,7 @@ packageName: 'expo-checkbox'
 ---
 
 import APISection from '~/components/plugins/APISection';
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import SnackInline from '~/components/plugins/SnackInline';
 
@@ -15,7 +15,7 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 ## Installation
 
-<InstallSection packageName="expo-checkbox" hideBareInstructions />
+<APIInstallSection hideBareInstructions />
 
 ## Usage
 

--- a/docs/pages/versions/unversioned/sdk/checkbox.md
+++ b/docs/pages/versions/unversioned/sdk/checkbox.md
@@ -1,6 +1,7 @@
 ---
 title: Checkbox
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-checkbox'
+packageName: 'expo-checkbox'
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/clipboard.md
+++ b/docs/pages/versions/unversioned/sdk/clipboard.md
@@ -5,7 +5,7 @@ packageName: 'expo-clipboard'
 ---
 
 import APISection from '~/components/plugins/APISection';
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import SnackInline from '~/components/plugins/SnackInline';
 
@@ -15,7 +15,7 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 ## Installation
 
-<InstallSection packageName="expo-clipboard" />
+<APIInstallSection />
 
 ## Usage
 

--- a/docs/pages/versions/unversioned/sdk/clipboard.md
+++ b/docs/pages/versions/unversioned/sdk/clipboard.md
@@ -1,6 +1,7 @@
 ---
 title: Clipboard
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-clipboard'
+packageName: 'expo-clipboard'
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/constants.md
+++ b/docs/pages/versions/unversioned/sdk/constants.md
@@ -5,7 +5,7 @@ packageName: 'expo-constants'
 ---
 
 import APISection from '~/components/plugins/APISection';
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`expo-constants`** provides system information that remains constant throughout the lifetime of your app's install.
@@ -14,7 +14,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 ## Installation
 
-<InstallSection packageName="expo-constants" />
+<APIInstallSection />
 
 ## API
 

--- a/docs/pages/versions/unversioned/sdk/constants.md
+++ b/docs/pages/versions/unversioned/sdk/constants.md
@@ -1,6 +1,7 @@
 ---
 title: Constants
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-constants'
+packageName: 'expo-constants'
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/contacts.md
+++ b/docs/pages/versions/unversioned/sdk/contacts.md
@@ -1,6 +1,7 @@
 ---
 title: Contacts
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-contacts'
+packageName: 'expo-contacts'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/contacts.md
+++ b/docs/pages/versions/unversioned/sdk/contacts.md
@@ -4,7 +4,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-contacts'
 packageName: 'expo-contacts'
 ---
 
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import SnackInline from '~/components/plugins/SnackInline';
 
@@ -14,7 +14,7 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 ## Installation
 
-<InstallSection packageName="expo-contacts" />
+<APIInstallSection />
 
 ## Configuration
 

--- a/docs/pages/versions/unversioned/sdk/crypto.md
+++ b/docs/pages/versions/unversioned/sdk/crypto.md
@@ -4,7 +4,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-crypto'
 packageName: 'expo-crypto'
 ---
 
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import SnackInline from '~/components/plugins/SnackInline';
 
@@ -14,7 +14,7 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 ## Installation
 
-<InstallSection packageName="expo-crypto" />
+<APIInstallSection />
 
 ## Usage
 

--- a/docs/pages/versions/unversioned/sdk/crypto.md
+++ b/docs/pages/versions/unversioned/sdk/crypto.md
@@ -1,6 +1,7 @@
 ---
 title: Crypto
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-crypto'
+packageName: 'expo-crypto'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/date-time-picker.md
+++ b/docs/pages/versions/unversioned/sdk/date-time-picker.md
@@ -1,6 +1,7 @@
 ---
 title: DateTimePicker
 sourceCodeUrl: 'https://github.com/react-native-community/react-native-datetimepicker'
+packageName: '@react-native-community/datetimepicker'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/date-time-picker.md
+++ b/docs/pages/versions/unversioned/sdk/date-time-picker.md
@@ -4,7 +4,7 @@ sourceCodeUrl: 'https://github.com/react-native-community/react-native-datetimep
 packageName: '@react-native-community/datetimepicker'
 ---
 
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import Video from '~/components/plugins/Video'
 
@@ -16,7 +16,7 @@ A component that provides access to the system UI for date and time selection.
 
 ## Installation
 
-<InstallSection packageName="@react-native-community/datetimepicker" href="https://github.com/react-native-community/react-native-datetimepicker#linking" />
+<APIInstallSection href="https://github.com/react-native-community/react-native-datetimepicker#linking" />
 
 ## Usage
 

--- a/docs/pages/versions/unversioned/sdk/device.md
+++ b/docs/pages/versions/unversioned/sdk/device.md
@@ -1,6 +1,7 @@
 ---
 title: Device
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-device'
+packageName: 'expo-device'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/device.md
+++ b/docs/pages/versions/unversioned/sdk/device.md
@@ -4,7 +4,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-device'
 packageName: 'expo-device'
 ---
 
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`expo-device`** provides access to system information about the physical device, such as its manufacturer and model.
@@ -13,7 +13,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 ## Installation
 
-<InstallSection packageName="expo-device" />
+<APIInstallSection />
 
 ## API
 

--- a/docs/pages/versions/unversioned/sdk/devicemotion.md
+++ b/docs/pages/versions/unversioned/sdk/devicemotion.md
@@ -1,6 +1,7 @@
 ---
 title: DeviceMotion
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-sensors'
+packageName: 'expo-sensors'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/devicemotion.md
+++ b/docs/pages/versions/unversioned/sdk/devicemotion.md
@@ -4,7 +4,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-sensors'
 packageName: 'expo-sensors'
 ---
 
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 `DeviceMotion` from **`expo-sensors`** provides access to the device motion and orientation sensors. All data is presented in terms of three axes that run through a device. According to portrait orientation: X runs from left to right, Y from bottom to top and Z perpendicularly through the screen from back to front.
@@ -13,7 +13,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 ## Installation
 
-<InstallSection packageName="expo-sensors" />
+<APIInstallSection />
 
 ## API
 

--- a/docs/pages/versions/unversioned/sdk/document-picker.md
+++ b/docs/pages/versions/unversioned/sdk/document-picker.md
@@ -5,7 +5,7 @@ packageName: 'expo-document-picker'
 ---
 
 import APISection from '~/components/plugins/APISection';
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import Video from '~/components/plugins/Video'
 
@@ -17,7 +17,7 @@ Provides access to the system's UI for selecting documents from the available pr
 
 ## Installation
 
-<InstallSection packageName="expo-document-picker" />
+<APIInstallSection />
 
 ## Configuration
 

--- a/docs/pages/versions/unversioned/sdk/document-picker.md
+++ b/docs/pages/versions/unversioned/sdk/document-picker.md
@@ -1,6 +1,7 @@
 ---
 title: DocumentPicker
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-document-picker'
+packageName: 'expo-document-picker'
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/error-recovery.md
+++ b/docs/pages/versions/unversioned/sdk/error-recovery.md
@@ -6,7 +6,7 @@ packageName: 'expo-error-recovery'
 
 import APISection from '~/components/plugins/APISection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 
 This module provides utilities for helping you gracefully handle crashes due to fatal JavaScript errors.
 
@@ -14,7 +14,7 @@ This module provides utilities for helping you gracefully handle crashes due to 
 
 ## Installation
 
-<InstallSection packageName="expo-error-recovery" />
+<APIInstallSection />
 
 ## API
 

--- a/docs/pages/versions/unversioned/sdk/error-recovery.md
+++ b/docs/pages/versions/unversioned/sdk/error-recovery.md
@@ -1,6 +1,7 @@
 ---
 title: ErrorRecovery
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-error-recovery'
+packageName: 'expo-error-recovery'
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/facebook-ads.md
+++ b/docs/pages/versions/unversioned/sdk/facebook-ads.md
@@ -1,6 +1,7 @@
 ---
 title: FacebookAds
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-ads-facebook'
+packageName: 'expo-ads-facebook'
 ---
 
 import { ConfigClassic, ConfigReactNative, ConfigPluginExample, ConfigPluginProperties } from '~/components/plugins/ConfigSection';

--- a/docs/pages/versions/unversioned/sdk/facebook-ads.md
+++ b/docs/pages/versions/unversioned/sdk/facebook-ads.md
@@ -7,7 +7,7 @@ packageName: 'expo-ads-facebook'
 import { ConfigClassic, ConfigReactNative, ConfigPluginExample, ConfigPluginProperties } from '~/components/plugins/ConfigSection';
 import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
 import APISection from '~/components/plugins/APISection';
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`expo-ads-facebook`** provides access to the Facebook Audience SDK, allowing you to monetize your app with targeted ads.
@@ -16,7 +16,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 ## Installation
 
-<InstallSection packageName="expo-ads-facebook" />
+<APIInstallSection />
 
 For bare apps, you will also need to follow [Facebook's Get Started guide](https://developers.facebook.com/docs/audience-network/get-started).
 

--- a/docs/pages/versions/unversioned/sdk/facebook.md
+++ b/docs/pages/versions/unversioned/sdk/facebook.md
@@ -7,7 +7,7 @@ packageName: 'expo-facebook'
 import { ConfigClassic, ConfigReactNative, ConfigPluginExample, ConfigPluginProperties } from '~/components/plugins/ConfigSection';
 import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
 import APISection from '~/components/plugins/APISection';
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 
 **`expo-facebook`** provides Facebook integration, such as logging in through Facebook, for React Native apps. Expo exposes a minimal native API since you can access Facebook's [Graph API](https://developers.facebook.com/docs/graph-api) directly through HTTP (using [fetch](https://reactnative.dev/docs/network.html#fetch), for example).
 
@@ -15,7 +15,7 @@ import InstallSection from '~/components/plugins/InstallSection';
 
 ## Installation
 
-<InstallSection packageName="expo-facebook" />
+<APIInstallSection />
 
 For bare apps, here are links to the [iOS Installation Walkthrough](https://developers.facebook.com/docs/ios/getting-started/#step-3---configure-your-project) and the [Android Installation Walkthrough](https://developers.facebook.com/docs/android/getting-started#app_id).
 

--- a/docs/pages/versions/unversioned/sdk/facebook.md
+++ b/docs/pages/versions/unversioned/sdk/facebook.md
@@ -1,6 +1,7 @@
 ---
 title: Facebook
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-facebook'
+packageName: 'expo-facebook'
 ---
 
 import { ConfigClassic, ConfigReactNative, ConfigPluginExample, ConfigPluginProperties } from '~/components/plugins/ConfigSection';

--- a/docs/pages/versions/unversioned/sdk/facedetector.md
+++ b/docs/pages/versions/unversioned/sdk/facedetector.md
@@ -1,6 +1,7 @@
 ---
 title: FaceDetector
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-face-detector'
+packageName: 'expo-face-detector'
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/facedetector.md
+++ b/docs/pages/versions/unversioned/sdk/facedetector.md
@@ -5,7 +5,7 @@ packageName: 'expo-face-detector'
 ---
 
 import APISection from '~/components/plugins/APISection';
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import SnackInline from '~/components/plugins/SnackInline';
 
@@ -15,7 +15,7 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 ## Installation
 
-<InstallSection packageName="expo-face-detector" />
+<APIInstallSection />
 
 ## Usage
 

--- a/docs/pages/versions/unversioned/sdk/filesystem.md
+++ b/docs/pages/versions/unversioned/sdk/filesystem.md
@@ -8,7 +8,7 @@ import ImageSpotlight from '~/components/plugins/ImageSpotlight'
 import { ConfigClassic, ConfigReactNative } from '~/components/plugins/ConfigSection';
 import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
 import APISection from '~/components/plugins/APISection';
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 import SnackInline from '~/components/plugins/SnackInline';
@@ -23,7 +23,7 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 ## Installation
 
-<InstallSection packageName="expo-file-system" />
+<APIInstallSection />
 
 ## Configuration in app.json / app.config.js
 

--- a/docs/pages/versions/unversioned/sdk/filesystem.md
+++ b/docs/pages/versions/unversioned/sdk/filesystem.md
@@ -1,6 +1,7 @@
 ---
 title: FileSystem
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-file-system'
+packageName: 'expo-file-system'
 ---
 
 import ImageSpotlight from '~/components/plugins/ImageSpotlight'

--- a/docs/pages/versions/unversioned/sdk/firebase-analytics.md
+++ b/docs/pages/versions/unversioned/sdk/firebase-analytics.md
@@ -5,7 +5,7 @@ packageName: 'expo-firebase-analytics'
 ---
 
 import APISection from '~/components/plugins/APISection';
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 import { InlineCode } from '~/components/base/code';
@@ -19,7 +19,7 @@ Learn more in the official [Firebase Docs](https://firebase.google.com/docs/anal
 
 ## Installation
 
-<InstallSection packageName="expo-firebase-analytics" />
+<APIInstallSection />
 
 When using the web-platform, you'll also need to run `expo install firebase`, which install the Firebase JS SDK.
 

--- a/docs/pages/versions/unversioned/sdk/firebase-analytics.md
+++ b/docs/pages/versions/unversioned/sdk/firebase-analytics.md
@@ -1,6 +1,7 @@
 ---
 title: FirebaseAnalytics
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-firebase-analytics'
+packageName: 'expo-firebase-analytics'
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/firebase-core.md
+++ b/docs/pages/versions/unversioned/sdk/firebase-core.md
@@ -1,6 +1,7 @@
 ---
 title: FirebaseCore
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-firebase-core'
+packageName: 'expo-firebase-core'
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/firebase-core.md
+++ b/docs/pages/versions/unversioned/sdk/firebase-core.md
@@ -5,7 +5,7 @@ packageName: 'expo-firebase-core'
 ---
 
 import APISection from '~/components/plugins/APISection';
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`expo-firebase-core`** provides access to the Firebase configuration and performs initialisation
@@ -15,7 +15,7 @@ of the native Firebase App.
 
 ## Installation
 
-<InstallSection packageName="expo-firebase-core" />
+<APIInstallSection />
 
 ## Configuration
 

--- a/docs/pages/versions/unversioned/sdk/firebase-recaptcha.md
+++ b/docs/pages/versions/unversioned/sdk/firebase-recaptcha.md
@@ -1,6 +1,7 @@
 ---
 title: FirebaseRecaptcha
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-firebase-recaptcha'
+packageName: 'expo-firebase-recaptcha'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/firebase-recaptcha.md
+++ b/docs/pages/versions/unversioned/sdk/firebase-recaptcha.md
@@ -4,7 +4,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-firebase-
 packageName: 'expo-firebase-recaptcha'
 ---
 
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import SnackInline from '~/components/plugins/SnackInline';
 
@@ -16,7 +16,7 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 ## Installation
 
-<InstallSection packageName="expo-firebase-recaptcha" />
+<APIInstallSection />
 
 Additionally, you'll also need to install the webview using `expo install react-native-webview`
 

--- a/docs/pages/versions/unversioned/sdk/font.md
+++ b/docs/pages/versions/unversioned/sdk/font.md
@@ -1,6 +1,7 @@
 ---
 title: Font
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-font'
+packageName: 'expo-font'
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/font.md
+++ b/docs/pages/versions/unversioned/sdk/font.md
@@ -5,7 +5,7 @@ packageName: 'expo-font'
 ---
 
 import APISection from '~/components/plugins/APISection';
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import SnackInline from '~/components/plugins/SnackInline';
 
@@ -15,7 +15,7 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 ## Installation
 
-<InstallSection packageName="expo-font" />
+<APIInstallSection />
 
 ## Usage
 

--- a/docs/pages/versions/unversioned/sdk/gesture-handler.md
+++ b/docs/pages/versions/unversioned/sdk/gesture-handler.md
@@ -4,7 +4,7 @@ sourceCodeUrl: 'https://github.com/software-mansion/react-native-gesture-handler
 packageName: 'react-native-gesture-handler'
 ---
 
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 An API for handling complex gestures. From the project's README:
@@ -15,7 +15,7 @@ An API for handling complex gestures. From the project's README:
 
 ## Installation
 
-<InstallSection packageName="react-native-gesture-handler" href="https://docs.swmansion.com/react-native-gesture-handler/docs/" />
+<APIInstallSection href="https://docs.swmansion.com/react-native-gesture-handler/docs/" />
 
 ## API
 

--- a/docs/pages/versions/unversioned/sdk/gesture-handler.md
+++ b/docs/pages/versions/unversioned/sdk/gesture-handler.md
@@ -1,6 +1,7 @@
 ---
 title: GestureHandler
 sourceCodeUrl: 'https://github.com/software-mansion/react-native-gesture-handler'
+packageName: 'react-native-gesture-handler'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/gl-view.md
+++ b/docs/pages/versions/unversioned/sdk/gl-view.md
@@ -4,7 +4,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-gl'
 packageName: 'expo-gl'
 ---
 
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import SnackInline from '~/components/plugins/SnackInline';
 
@@ -14,7 +14,7 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 ## Installation
 
-<InstallSection packageName="expo-gl" />
+<APIInstallSection />
 
 ## Usage
 

--- a/docs/pages/versions/unversioned/sdk/gl-view.md
+++ b/docs/pages/versions/unversioned/sdk/gl-view.md
@@ -1,6 +1,7 @@
 ---
 title: GLView
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-gl'
+packageName: 'expo-gl'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/google-sign-in.md
+++ b/docs/pages/versions/unversioned/sdk/google-sign-in.md
@@ -1,6 +1,7 @@
 ---
 title: GoogleSignIn
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-google-sign-in'
+packageName: 'expo-google-sign-in'
 ---
 
 import PlatformsSection from '~/components/plugins/PlatformsSection';

--- a/docs/pages/versions/unversioned/sdk/google.md
+++ b/docs/pages/versions/unversioned/sdk/google.md
@@ -1,6 +1,7 @@
 ---
 title: Google
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-google-app-auth'
+packageName: 'expo-google-app-auth'
 ---
 
 import PlatformsSection from '~/components/plugins/PlatformsSection';

--- a/docs/pages/versions/unversioned/sdk/gyroscope.md
+++ b/docs/pages/versions/unversioned/sdk/gyroscope.md
@@ -1,6 +1,7 @@
 ---
 title: Gyroscope
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-sensors'
+packageName: 'expo-sensors'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/gyroscope.md
+++ b/docs/pages/versions/unversioned/sdk/gyroscope.md
@@ -4,7 +4,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-sensors'
 packageName: 'expo-sensors'
 ---
 
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import SnackInline from '~/components/plugins/SnackInline';
 
@@ -14,7 +14,7 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 ## Installation
 
-<InstallSection packageName="expo-sensors" />
+<APIInstallSection />
 
 ## Usage
 

--- a/docs/pages/versions/unversioned/sdk/haptics.md
+++ b/docs/pages/versions/unversioned/sdk/haptics.md
@@ -1,6 +1,7 @@
 ---
 title: Haptics
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-haptics'
+packageName: 'expo-haptics'
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/haptics.md
+++ b/docs/pages/versions/unversioned/sdk/haptics.md
@@ -5,7 +5,7 @@ packageName: 'expo-haptics'
 ---
 
 import APISection from '~/components/plugins/APISection';
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import SnackInline from '~/components/plugins/SnackInline';
 
@@ -27,7 +27,7 @@ On iOS, _the Taptic engine will do nothing if any of the following conditions ar
 
 ## Installation
 
-<InstallSection packageName="expo-haptics" />
+<APIInstallSection />
 
 ## Configuration
 

--- a/docs/pages/versions/unversioned/sdk/imagemanipulator.md
+++ b/docs/pages/versions/unversioned/sdk/imagemanipulator.md
@@ -1,6 +1,7 @@
 ---
 title: ImageManipulator
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-image-manipulator'
+packageName: 'expo-image-manipulator'
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/imagemanipulator.md
+++ b/docs/pages/versions/unversioned/sdk/imagemanipulator.md
@@ -5,7 +5,7 @@ packageName: 'expo-image-manipulator'
 ---
 
 import APISection from '~/components/plugins/APISection';
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import SnackInline from '~/components/plugins/SnackInline';
 
@@ -15,7 +15,7 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 ## Installation
 
-<InstallSection packageName="expo-image-manipulator" />
+<APIInstallSection />
 
 ## Usage
 

--- a/docs/pages/versions/unversioned/sdk/imagepicker.md
+++ b/docs/pages/versions/unversioned/sdk/imagepicker.md
@@ -1,6 +1,7 @@
 ---
 title: ImagePicker
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-image-picker'
+packageName: 'expo-image-picker'
 ---
 
 import { ConfigClassic, ConfigReactNative, ConfigPluginExample, ConfigPluginProperties } from '~/components/plugins/ConfigSection';

--- a/docs/pages/versions/unversioned/sdk/imagepicker.md
+++ b/docs/pages/versions/unversioned/sdk/imagepicker.md
@@ -7,7 +7,7 @@ packageName: 'expo-image-picker'
 import { ConfigClassic, ConfigReactNative, ConfigPluginExample, ConfigPluginProperties } from '~/components/plugins/ConfigSection';
 import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
 import APISection from '~/components/plugins/APISection';
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import Video from '~/components/plugins/Video';
 import SnackInline from '~/components/plugins/SnackInline';
@@ -20,7 +20,7 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 ## Installation
 
-<InstallSection packageName="expo-image-picker" />
+<APIInstallSection />
 
 ## Configuration in app.json / app.config.js
 

--- a/docs/pages/versions/unversioned/sdk/in-app-purchases.md
+++ b/docs/pages/versions/unversioned/sdk/in-app-purchases.md
@@ -4,6 +4,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-in-app-pu
 packageName: 'expo-in-app-purchases'
 ---
 
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import APISection from '~/components/plugins/APISection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
@@ -12,6 +13,8 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 <PlatformsSection android ios />
 
 ## Installation
+
+<APIInstallSection hideBareInstructions />
 
 This module is currently only available in the [bare](../../../introduction/managed-vs-bare.md#bare-workflow) workflow.
 

--- a/docs/pages/versions/unversioned/sdk/in-app-purchases.md
+++ b/docs/pages/versions/unversioned/sdk/in-app-purchases.md
@@ -1,6 +1,7 @@
 ---
 title: InAppPurchases
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-in-app-purchases'
+packageName: 'expo-in-app-purchases'
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/intent-launcher.md
+++ b/docs/pages/versions/unversioned/sdk/intent-launcher.md
@@ -5,7 +5,7 @@ packageName: 'expo-intent-launcher'
 ---
 
 import APISection from '~/components/plugins/APISection';
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`expo-intent-launcher`** provides a way to launch Android intents. For example, you can use this API to open a specific settings screen.
@@ -14,7 +14,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 ## Installation
 
-<InstallSection packageName="expo-intent-launcher" />
+<APIInstallSection />
 
 #### Example
 

--- a/docs/pages/versions/unversioned/sdk/intent-launcher.md
+++ b/docs/pages/versions/unversioned/sdk/intent-launcher.md
@@ -1,6 +1,7 @@
 ---
 title: IntentLauncher
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-intent-launcher'
+packageName: 'expo-intent-launcher'
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/keep-awake.md
+++ b/docs/pages/versions/unversioned/sdk/keep-awake.md
@@ -1,6 +1,7 @@
 ---
 title: KeepAwake
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-keep-awake'
+packageName: 'expo-keep-awake'
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/keep-awake.md
+++ b/docs/pages/versions/unversioned/sdk/keep-awake.md
@@ -5,7 +5,7 @@ packageName: 'expo-keep-awake'
 ---
 
 import APISection from '~/components/plugins/APISection';
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import SnackInline from '~/components/plugins/SnackInline';
 
@@ -15,7 +15,7 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 ## Installation
 
-<InstallSection packageName="expo-keep-awake" />
+<APIInstallSection />
 
 ## Usage
 

--- a/docs/pages/versions/unversioned/sdk/linear-gradient.md
+++ b/docs/pages/versions/unversioned/sdk/linear-gradient.md
@@ -1,6 +1,7 @@
 ---
 title: LinearGradient
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-linear-gradient'
+packageName: 'expo-linear-gradient'
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/linear-gradient.md
+++ b/docs/pages/versions/unversioned/sdk/linear-gradient.md
@@ -5,7 +5,7 @@ packageName: 'expo-linear-gradient'
 ---
 
 import APISection from '~/components/plugins/APISection';
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import SnackInline from '~/components/plugins/SnackInline';
 
@@ -15,7 +15,7 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 ## Installation
 
-<InstallSection packageName="expo-linear-gradient" />
+<APIInstallSection />
 
 ## Usage
 

--- a/docs/pages/versions/unversioned/sdk/linking.md
+++ b/docs/pages/versions/unversioned/sdk/linking.md
@@ -5,7 +5,7 @@ packageName: 'expo-linking'
 ---
 
 import APISection from '~/components/plugins/APISection';
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 `expo-linking` provides utilities for your app to interact with other installed apps using deep links. It also provides helper methods for constructing and parsing deep links into your app. This module is an extension of the React Native [Linking](https://reactnative.dev/docs/linking.html) module.
@@ -16,7 +16,7 @@ For a more comprehensive explanation of how to use `expo-linking`, refer to the 
 
 ## Installation
 
-<InstallSection packageName="expo-linking" />
+<APIInstallSection />
 
 ## API
 

--- a/docs/pages/versions/unversioned/sdk/linking.md
+++ b/docs/pages/versions/unversioned/sdk/linking.md
@@ -1,6 +1,7 @@
 ---
 title: Linking
-sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo/src/Linking'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-linking'
+packageName: 'expo-linking'
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/local-authentication.md
+++ b/docs/pages/versions/unversioned/sdk/local-authentication.md
@@ -5,7 +5,7 @@ packageName: 'expo-local-authentication'
 ---
 
 import APISection from '~/components/plugins/APISection';
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`expo-local-authentication`** allows you to use FaceID and TouchID (iOS) or the Biometric Prompt (Android) to authenticate the user with a face or fingerprint scan.
@@ -14,7 +14,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 ## Installation
 
-<InstallSection packageName="expo-local-authentication" />
+<APIInstallSection />
 
 ## Configuration
 

--- a/docs/pages/versions/unversioned/sdk/local-authentication.md
+++ b/docs/pages/versions/unversioned/sdk/local-authentication.md
@@ -1,6 +1,7 @@
 ---
 title: LocalAuthentication
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-local-authentication'
+packageName: 'expo-local-authentication'
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/localization.md
+++ b/docs/pages/versions/unversioned/sdk/localization.md
@@ -1,6 +1,7 @@
 ---
 title: Localization
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-localization'
+packageName: 'expo-localization'
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/localization.md
+++ b/docs/pages/versions/unversioned/sdk/localization.md
@@ -5,7 +5,7 @@ packageName: 'expo-localization'
 ---
 
 import APISection from '~/components/plugins/APISection';
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import SnackInline from '~/components/plugins/SnackInline';
 
@@ -16,7 +16,7 @@ Using the popular library [`i18n-js`](https://github.com/fnando/i18n-js) with `e
 
 ## Installation
 
-<InstallSection packageName="expo-localization" />
+<APIInstallSection />
 
 ## Usage
 

--- a/docs/pages/versions/unversioned/sdk/location.md
+++ b/docs/pages/versions/unversioned/sdk/location.md
@@ -1,6 +1,7 @@
 ---
 title: Location
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-location'
+packageName: 'expo-location'
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/location.md
+++ b/docs/pages/versions/unversioned/sdk/location.md
@@ -5,7 +5,7 @@ packageName: 'expo-location'
 ---
 
 import APISection from '~/components/plugins/APISection';
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import SnackInline from '~/components/plugins/SnackInline';
 
@@ -15,7 +15,7 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 ## Installation
 
-<InstallSection packageName="expo-location" />
+<APIInstallSection />
 
 ## Configuration
 

--- a/docs/pages/versions/unversioned/sdk/lottie.md
+++ b/docs/pages/versions/unversioned/sdk/lottie.md
@@ -4,7 +4,7 @@ sourceCodeUrl: 'https://github.com/lottie-react-native/lottie-react-native'
 packageName: 'lottie-react-native'
 ---
 
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import SnackInline from '~/components/plugins/SnackInline';
 
@@ -14,7 +14,7 @@ Expo includes support for [Lottie](https://airbnb.design/lottie/), the animation
 
 ## Installation
 
-<InstallSection packageName="lottie-react-native" href="https://github.com/lottie-react-native/lottie-react-native" />
+<APIInstallSection href="https://github.com/lottie-react-native/lottie-react-native" />
 
 ## Usage
 

--- a/docs/pages/versions/unversioned/sdk/lottie.md
+++ b/docs/pages/versions/unversioned/sdk/lottie.md
@@ -1,6 +1,7 @@
 ---
 title: Lottie
 sourceCodeUrl: 'https://github.com/lottie-react-native/lottie-react-native'
+packageName: 'lottie-react-native'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/magnetometer.md
+++ b/docs/pages/versions/unversioned/sdk/magnetometer.md
@@ -1,6 +1,7 @@
 ---
 title: Magnetometer
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-sensors'
+packageName: 'expo-sensors'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/magnetometer.md
+++ b/docs/pages/versions/unversioned/sdk/magnetometer.md
@@ -4,7 +4,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-sensors'
 packageName: 'expo-sensors'
 ---
 
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import SnackInline from '~/components/plugins/SnackInline';
 
@@ -14,7 +14,7 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 ## Installation
 
-<InstallSection packageName="expo-sensors" />
+<APIInstallSection />
 
 ## Usage
 

--- a/docs/pages/versions/unversioned/sdk/mail-composer.md
+++ b/docs/pages/versions/unversioned/sdk/mail-composer.md
@@ -1,6 +1,7 @@
 ---
 title: MailComposer
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-mail-composer'
+packageName: 'expo-mail-composer'
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/mail-composer.md
+++ b/docs/pages/versions/unversioned/sdk/mail-composer.md
@@ -5,7 +5,7 @@ packageName: 'expo-mail-composer'
 ---
 
 import APISection from '~/components/plugins/APISection';
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import Video from '~/components/plugins/Video';
 
@@ -17,7 +17,7 @@ import Video from '~/components/plugins/Video';
 
 ## Installation
 
-<InstallSection packageName="expo-mail-composer" />
+<APIInstallSection />
 
 ## API
 

--- a/docs/pages/versions/unversioned/sdk/map-view.md
+++ b/docs/pages/versions/unversioned/sdk/map-view.md
@@ -1,6 +1,7 @@
 ---
 title: MapView
 sourceCodeUrl: 'https://github.com/react-native-community/react-native-maps'
+packageName: 'react-native-maps'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/map-view.md
+++ b/docs/pages/versions/unversioned/sdk/map-view.md
@@ -4,7 +4,7 @@ sourceCodeUrl: 'https://github.com/react-native-community/react-native-maps'
 packageName: 'react-native-maps'
 ---
 
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import SnackInline from '~/components/plugins/SnackInline';
 
@@ -14,7 +14,7 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 ## Installation
 
-<InstallSection packageName="react-native-maps" href="https://github.com/react-native-maps/react-native-maps/blob/master/docs/installation.md" />
+<APIInstallSection href="https://github.com/react-native-maps/react-native-maps/blob/master/docs/installation.md" />
 
 ## Usage
 

--- a/docs/pages/versions/unversioned/sdk/masked-view.md
+++ b/docs/pages/versions/unversioned/sdk/masked-view.md
@@ -4,7 +4,7 @@ sourceCodeUrl: 'https://github.com/react-native-masked-view/masked-view'
 packageName: '@react-native-masked-view/masked-view'
 ---
 
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`@react-native-masked-view/masked-view`** provides a masked view which only displays the pixels that overlap with the view rendered in its mask element.
@@ -17,7 +17,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 ## Installation
 
-<InstallSection packageName="@react-native-masked-view/masked-view" href="https://github.com/react-native-masked-view/masked-view#getting-started" />
+<APIInstallSection href="https://github.com/react-native-masked-view/masked-view#getting-started" />
 
 ## Usage
 

--- a/docs/pages/versions/unversioned/sdk/masked-view.md
+++ b/docs/pages/versions/unversioned/sdk/masked-view.md
@@ -1,6 +1,7 @@
 ---
 title: MaskedView
 sourceCodeUrl: 'https://github.com/react-native-masked-view/masked-view'
+packageName: '@react-native-masked-view/masked-view'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/media-library.md
+++ b/docs/pages/versions/unversioned/sdk/media-library.md
@@ -7,7 +7,7 @@ packageName: 'expo-media-library'
 import { ConfigClassic, ConfigReactNative, ConfigPluginExample, ConfigPluginProperties } from '~/components/plugins/ConfigSection';
 import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
 import APISection from '~/components/plugins/APISection';
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`expo-media-library`** provides access to the user's media library, allowing them to access their existing images and videos from your app, as well as save new ones. You can also subscribe to any updates made to the user's media library.
@@ -18,7 +18,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 ## Installation
 
-<InstallSection packageName="expo-media-library" />
+<APIInstallSection />
 
 ## Configuration in app.json / app.config.js
 

--- a/docs/pages/versions/unversioned/sdk/media-library.md
+++ b/docs/pages/versions/unversioned/sdk/media-library.md
@@ -1,6 +1,7 @@
 ---
 title: MediaLibrary
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-media-library'
+packageName: 'expo-media-library'
 ---
 
 import { ConfigClassic, ConfigReactNative, ConfigPluginExample, ConfigPluginProperties } from '~/components/plugins/ConfigSection';

--- a/docs/pages/versions/unversioned/sdk/navigation-bar.md
+++ b/docs/pages/versions/unversioned/sdk/navigation-bar.md
@@ -5,7 +5,7 @@ packageName: 'expo-navigation-bar'
 ---
 
 import APISection from '~/components/plugins/APISection';
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`expo-navigation-bar`** enables you to modify and observe the native navigation bar on Android devices. Due to some Android platform restrictions, parts of this API overlap with the `expo-status-bar` API.
@@ -17,7 +17,7 @@ Properties are named after style properties; visibility, position, backgroundCol
 
 ## Installation
 
-<InstallSection packageName="expo-navigation-bar" />
+<APIInstallSection />
 
 ## API
 

--- a/docs/pages/versions/unversioned/sdk/navigation-bar.md
+++ b/docs/pages/versions/unversioned/sdk/navigation-bar.md
@@ -1,6 +1,7 @@
 ---
 title: NavigationBar
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-navigation-bar'
+packageName: 'expo-navigation-bar'
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/netinfo.md
+++ b/docs/pages/versions/unversioned/sdk/netinfo.md
@@ -4,7 +4,7 @@ sourceCodeUrl: 'https://github.com/react-native-community/react-native-netinfo'
 packageName: '@react-native-community/netinfo'
 ---
 
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`@react-native-community/netinfo`** allows you to get information about connection type and connection quality.
@@ -13,7 +13,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 ## Installation
 
-<InstallSection packageName="@react-native-community/netinfo" href="https://github.com/react-native-community/react-native-netinfo#getting-started" />
+<APIInstallSection href="https://github.com/react-native-community/react-native-netinfo#getting-started" />
 
 ## API
 

--- a/docs/pages/versions/unversioned/sdk/netinfo.md
+++ b/docs/pages/versions/unversioned/sdk/netinfo.md
@@ -1,6 +1,7 @@
 ---
 title: NetInfo
 sourceCodeUrl: 'https://github.com/react-native-community/react-native-netinfo'
+packageName: '@react-native-community/netinfo'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/network.md
+++ b/docs/pages/versions/unversioned/sdk/network.md
@@ -5,7 +5,7 @@ packageName: 'expo-network'
 ---
 
 import APISection from '~/components/plugins/APISection';
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`expo-network`** provides useful information about the device's network such as its IP address, MAC address, and airplane mode status.
@@ -14,7 +14,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 ## Installation
 
-<InstallSection packageName="expo-network" />
+<APIInstallSection />
 
 ## Configuration
 

--- a/docs/pages/versions/unversioned/sdk/network.md
+++ b/docs/pages/versions/unversioned/sdk/network.md
@@ -1,6 +1,7 @@
 ---
 title: Network
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-network'
+packageName: 'expo-network'
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/notifications.md
+++ b/docs/pages/versions/unversioned/sdk/notifications.md
@@ -1,6 +1,7 @@
 ---
 title: Notifications
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-notifications'
+packageName: 'expo-notifications'
 ---
 
 import { ConfigClassic, ConfigReactNative, ConfigPluginExample, ConfigPluginProperties } from '~/components/plugins/ConfigSection';

--- a/docs/pages/versions/unversioned/sdk/notifications.md
+++ b/docs/pages/versions/unversioned/sdk/notifications.md
@@ -8,7 +8,7 @@ import { ConfigClassic, ConfigReactNative, ConfigPluginExample, ConfigPluginProp
 import { AndroidPermissions } from '~/components/plugins/permissions';
 import SnackInline from '~/components/plugins/SnackInline';
 import ImageSpotlight from '~/components/plugins/ImageSpotlight'
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 The **`expo-notifications`** provides an API to fetch push notification tokens and to present, schedule, receive and respond to notifications.
@@ -35,7 +35,7 @@ The **`expo-notifications`** provides an API to fetch push notification tokens a
 
 ## Installation
 
-<InstallSection packageName="expo-notifications" />
+<APIInstallSection />
 
 ## Configuration in app.json / app.config.js
 

--- a/docs/pages/versions/unversioned/sdk/pedometer.md
+++ b/docs/pages/versions/unversioned/sdk/pedometer.md
@@ -5,7 +5,7 @@ packageName: 'expo-sensors'
 ---
 
 import APISection from '~/components/plugins/APISection';
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import SnackInline from '~/components/plugins/SnackInline';
 
@@ -15,7 +15,7 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 ## Installation
 
-<InstallSection packageName="expo-sensors" />
+<APIInstallSection />
 
 ## Usage
 

--- a/docs/pages/versions/unversioned/sdk/pedometer.md
+++ b/docs/pages/versions/unversioned/sdk/pedometer.md
@@ -1,6 +1,7 @@
 ---
 title: Pedometer
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-sensors'
+packageName: 'expo-sensors'
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/picker.md
+++ b/docs/pages/versions/unversioned/sdk/picker.md
@@ -1,6 +1,7 @@
 ---
 title: Picker
 sourceCodeUrl: 'https://github.com/react-native-picker/picker'
+packageName: '@react-native-picker/picker'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/picker.md
+++ b/docs/pages/versions/unversioned/sdk/picker.md
@@ -4,7 +4,7 @@ sourceCodeUrl: 'https://github.com/react-native-picker/picker'
 packageName: '@react-native-picker/picker'
 ---
 
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import Video from '~/components/plugins/Video'
 
@@ -18,7 +18,7 @@ A component that provides access to the system UI for picking between several op
 
 ## Installation
 
-<InstallSection packageName="@react-native-picker/picker" href="https://github.com/react-native-picker/picker#getting-started" />
+<APIInstallSection href="https://github.com/react-native-picker/picker#getting-started" />
 
 ## Usage
 

--- a/docs/pages/versions/unversioned/sdk/print.md
+++ b/docs/pages/versions/unversioned/sdk/print.md
@@ -1,6 +1,7 @@
 ---
 title: Print
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-print'
+packageName: 'expo-print'
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/print.md
+++ b/docs/pages/versions/unversioned/sdk/print.md
@@ -5,7 +5,7 @@ packageName: 'expo-print'
 ---
 
 import APISection from '~/components/plugins/APISection';
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import SnackInline from '~/components/plugins/SnackInline';
 
@@ -15,7 +15,7 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 ## Installation
 
-<InstallSection packageName="expo-print" />
+<APIInstallSection />
 
 ## Usage
 

--- a/docs/pages/versions/unversioned/sdk/random.md
+++ b/docs/pages/versions/unversioned/sdk/random.md
@@ -5,7 +5,7 @@ packageName: 'expo-random'
 ---
 
 import APISection from '~/components/plugins/APISection';
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 `expo-random` provides a native interface for creating strong random bytes. With `Random` you can create values equivalent to Node.js core `crypto.randomBytes` API. `expo-random` also works with `expo-standard-web-crypto`, which implements the W3C Crypto API for generating random bytes.
@@ -14,7 +14,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 ## Installation
 
-<InstallSection packageName="expo-random" />
+<APIInstallSection />
 
 ## API
 

--- a/docs/pages/versions/unversioned/sdk/random.md
+++ b/docs/pages/versions/unversioned/sdk/random.md
@@ -1,6 +1,7 @@
 ---
 title: Random
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-random'
+packageName: 'expo-random'
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/reanimated.md
+++ b/docs/pages/versions/unversioned/sdk/reanimated.md
@@ -4,7 +4,7 @@ sourceCodeUrl: 'https://github.com/software-mansion/react-native-reanimated'
 packageName: 'react-native-reanimated'
 ---
 
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`react-native-reanimated`** provides an API that greatly simplifies the process of creating smooth, powerful, and maintainable animations.
@@ -13,7 +13,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 ## Installation
 
-<InstallSection packageName="react-native-reanimated" href="https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/installation" />
+<APIInstallSection href="https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/installation" />
 
 After the installation completed, add the Babel plugin to **babel.config.js**:
 

--- a/docs/pages/versions/unversioned/sdk/reanimated.md
+++ b/docs/pages/versions/unversioned/sdk/reanimated.md
@@ -1,6 +1,7 @@
 ---
 title: Reanimated
 sourceCodeUrl: 'https://github.com/software-mansion/react-native-reanimated'
+packageName: 'react-native-reanimated'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/register-root-component.md
+++ b/docs/pages/versions/unversioned/sdk/register-root-component.md
@@ -4,6 +4,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo/src/launc
 packageName: 'expo'
 ---
 
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 This function tells Expo what component to use as the root component for your app.
@@ -13,6 +14,8 @@ This function tells Expo what component to use as the root component for your ap
 ## Installation
 
 This API is pre-installed in [managed](../../../introduction/managed-vs-bare.md#managed-workflow) apps. It is not available for [bare](../../../introduction/managed-vs-bare.md#bare-workflow) React Native apps.
+
+<APIInstallSection hideBareInstructions />
 
 ## API
 

--- a/docs/pages/versions/unversioned/sdk/register-root-component.md
+++ b/docs/pages/versions/unversioned/sdk/register-root-component.md
@@ -1,6 +1,7 @@
 ---
 title: registerRootComponent
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo/src/launch'
+packageName: 'expo'
 ---
 
 import PlatformsSection from '~/components/plugins/PlatformsSection';

--- a/docs/pages/versions/unversioned/sdk/safe-area-context.md
+++ b/docs/pages/versions/unversioned/sdk/safe-area-context.md
@@ -4,7 +4,7 @@ sourceCodeUrl: 'https://github.com/th3rdwave/react-native-safe-area-context'
 packageName: 'react-native-safe-area-context'
 ---
 
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`react-native-safe-area-context`** provides a flexible API for accessing device safe area inset information. This allows you to position your content appropriately around notches, status bars, home indicators, and other such device and operating system interface elements. It also provides a `SafeAreaView` component that you can use in place of `View` to automatically inset your views to account for safe areas.
@@ -13,7 +13,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 ## Installation
 
-<InstallSection packageName="react-native-safe-area-context" href="https://github.com/th3rdwave/react-native-safe-area-context#getting-started" />
+<APIInstallSection href="https://github.com/th3rdwave/react-native-safe-area-context#getting-started" />
 
 ## API
 

--- a/docs/pages/versions/unversioned/sdk/safe-area-context.md
+++ b/docs/pages/versions/unversioned/sdk/safe-area-context.md
@@ -1,6 +1,7 @@
 ---
 title: SafeAreaContext
 sourceCodeUrl: 'https://github.com/th3rdwave/react-native-safe-area-context'
+packageName: 'react-native-safe-area-context'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/screen-capture.md
+++ b/docs/pages/versions/unversioned/sdk/screen-capture.md
@@ -5,7 +5,7 @@ packageName: 'expo-screen-capture'
 ---
 
 import APISection from '~/components/plugins/APISection';
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import SnackInline from '~/components/plugins/SnackInline';
 
@@ -22,7 +22,7 @@ This is especially important on Android, since the [`android.media.projection`](
 
 ## Installation
 
-<InstallSection packageName="expo-screen-capture" />
+<APIInstallSection />
 
 ## Usage
 

--- a/docs/pages/versions/unversioned/sdk/screen-capture.md
+++ b/docs/pages/versions/unversioned/sdk/screen-capture.md
@@ -1,6 +1,7 @@
 ---
 title: ScreenCapture
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-screen-capture'
+packageName: 'expo-screen-capture'
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/screen-orientation.md
+++ b/docs/pages/versions/unversioned/sdk/screen-orientation.md
@@ -7,7 +7,7 @@ packageName: 'expo-screen-orientation'
 import { palette } from '@expo/styleguide';
 import APISection from '~/components/plugins/APISection'
 import ImageSpotlight from '~/components/plugins/ImageSpotlight'
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 Screen Orientation is defined as the orientation in which graphics are painted on the device. For example, the figure below has a device in a vertical and horizontal physical orientation, but a portrait screen orientation. For physical device orientation, see the orientation section of [Device Motion](devicemotion.md).
@@ -24,7 +24,7 @@ On both iOS and Android platforms, changes to the screen orientation will overri
 
 ## Installation
 
-<InstallSection packageName="expo-screen-orientation" />
+<APIInstallSection />
 
 ### Warning
 

--- a/docs/pages/versions/unversioned/sdk/screen-orientation.md
+++ b/docs/pages/versions/unversioned/sdk/screen-orientation.md
@@ -1,6 +1,7 @@
 ---
 title: ScreenOrientation
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-screen-orientation'
+packageName: 'expo-screen-orientation'
 ---
 
 import { palette } from '@expo/styleguide';

--- a/docs/pages/versions/unversioned/sdk/screens.md
+++ b/docs/pages/versions/unversioned/sdk/screens.md
@@ -4,7 +4,7 @@ sourceCodeUrl: 'https://github.com/software-mansion/react-native-screens'
 packageName: 'react-native-screens'
 ---
 
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`react-native-screens`** provides native primitives to represent screens instead of plain `<View>` components in order to better take advantage of operating system behavior and optimizations around screens. This capability is used by library authors and unlikely to be used directly by most app developers. It also provides the native components needed for React Navigation's [createNativeStackNavigator](https://reactnavigation.org/docs/native-stack-navigator).
@@ -15,7 +15,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 ## Installation
 
-<InstallSection packageName="react-native-screens" href="https://github.com/software-mansion/react-native-screens" />
+<APIInstallSection href="https://github.com/software-mansion/react-native-screens" />
 
 ## API
 

--- a/docs/pages/versions/unversioned/sdk/screens.md
+++ b/docs/pages/versions/unversioned/sdk/screens.md
@@ -1,6 +1,7 @@
 ---
 title: Screens
 sourceCodeUrl: 'https://github.com/software-mansion/react-native-screens'
+packageName: 'react-native-screens'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/securestore.md
+++ b/docs/pages/versions/unversioned/sdk/securestore.md
@@ -5,7 +5,7 @@ packageName: 'expo-secure-store'
 ---
 
 import APISection from '~/components/plugins/APISection';
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import SnackInline from '~/components/plugins/SnackInline';
 
@@ -23,7 +23,7 @@ Android: Values are stored in [`SharedPreferences`](https://developer.android.co
 
 ## Installation
 
-<InstallSection packageName="expo-secure-store" />
+<APIInstallSection />
 
 ## Usage
 

--- a/docs/pages/versions/unversioned/sdk/securestore.md
+++ b/docs/pages/versions/unversioned/sdk/securestore.md
@@ -1,6 +1,7 @@
 ---
 title: SecureStore
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-secure-store'
+packageName: 'expo-secure-store'
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/segment.md
+++ b/docs/pages/versions/unversioned/sdk/segment.md
@@ -1,6 +1,7 @@
 ---
 title: Segment
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-analytics-segment'
+packageName: 'expo-analytics-segment'
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/segment.md
+++ b/docs/pages/versions/unversioned/sdk/segment.md
@@ -5,7 +5,7 @@ packageName: 'expo-analytics-segment'
 ---
 
 import APISection from '~/components/plugins/APISection';
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`expo-analytics-segment`** provides access to <https://segment.com/> mobile analytics. Wraps Segment's [iOS](https://segment.com/docs/sources/mobile/ios/) and [Android](https://segment.com/docs/sources/mobile/android/) sources.
@@ -16,7 +16,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 ## Installation
 
-<InstallSection packageName="expo-analytics-segment" />
+<APIInstallSection />
 
 ## API
 

--- a/docs/pages/versions/unversioned/sdk/segmented-control.md
+++ b/docs/pages/versions/unversioned/sdk/segmented-control.md
@@ -4,7 +4,7 @@ sourceCodeUrl: 'https://github.com/react-native-community/segmented-control'
 packageName: '@react-native-segmented-control/segmented-control'
 ---
 
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 It's like a fancy radio button, or in Apple's words: "A horizontal control that consists of multiple segments, each segment functioning as a discrete button" ([source](https://developer.apple.com/documentation/uikit/uisegmentedcontrol)]). This component renders to a [`UISegmentedControl`](https://developer.apple.com/documentation/uikit/uisegmentedcontrol) on iOS, and to faithful recreations of that control on Android and web (because no equivalent exists on those platforms' standard libraries).
@@ -13,7 +13,7 @@ It's like a fancy radio button, or in Apple's words: "A horizontal control that 
 
 ## Installation
 
-<InstallSection packageName="@react-native-segmented-control/segmented-control" href="https://github.com/react-native-segmented-control/segmented-control#getting-started" />
+<APIInstallSection href="https://github.com/react-native-segmented-control/segmented-control#getting-started" />
 
 ## Usage
 

--- a/docs/pages/versions/unversioned/sdk/segmented-control.md
+++ b/docs/pages/versions/unversioned/sdk/segmented-control.md
@@ -1,6 +1,7 @@
 ---
 title: SegmentedControl
 sourceCodeUrl: 'https://github.com/react-native-community/segmented-control'
+packageName: '@react-native-segmented-control/segmented-control'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/sensors.md
+++ b/docs/pages/versions/unversioned/sdk/sensors.md
@@ -4,7 +4,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-sensors'
 packageName: 'expo-sensors'
 ---
 
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`expo-sensors`** provides various APIs for accessing device sensors to measure motion, orientation, pressure, magnetic fields, and step count.
@@ -13,7 +13,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 ## Installation
 
-<InstallSection packageName="expo-sensors" />
+<APIInstallSection />
 
 ## API
 

--- a/docs/pages/versions/unversioned/sdk/sensors.md
+++ b/docs/pages/versions/unversioned/sdk/sensors.md
@@ -1,6 +1,7 @@
 ---
 title: Sensors
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-sensors'
+packageName: 'expo-sensors'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/shared-element.md
+++ b/docs/pages/versions/unversioned/sdk/shared-element.md
@@ -1,6 +1,7 @@
 ---
 title: SharedElement
 sourceCodeUrl: 'https://github.com/IjzerenHein/react-native-shared-element'
+packageName: 'react-native-shared-element'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/shared-element.md
+++ b/docs/pages/versions/unversioned/sdk/shared-element.md
@@ -4,7 +4,7 @@ sourceCodeUrl: 'https://github.com/IjzerenHein/react-native-shared-element'
 packageName: 'react-native-shared-element'
 ---
 
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import Video from '~/components/plugins/Video'
 
@@ -18,7 +18,7 @@ import Video from '~/components/plugins/Video'
 
 ## Installation
 
-<InstallSection packageName="react-native-shared-element" href="https://github.com/IjzerenHein/react-native-shared-element#installation" />
+<APIInstallSection href="https://github.com/IjzerenHein/react-native-shared-element#installation" />
 
 ## API
 

--- a/docs/pages/versions/unversioned/sdk/sharing.md
+++ b/docs/pages/versions/unversioned/sdk/sharing.md
@@ -1,6 +1,7 @@
 ---
 title: Sharing
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-sharing'
+packageName: 'expo-sharing'
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/sharing.md
+++ b/docs/pages/versions/unversioned/sdk/sharing.md
@@ -5,7 +5,7 @@ packageName: 'expo-sharing'
 ---
 
 import APISection from '~/components/plugins/APISection';
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import Video from '~/components/plugins/Video'
 
@@ -27,7 +27,7 @@ Currently `expo-sharing` only supports sharing *from your app to other apps* and
 
 ## Installation
 
-<InstallSection packageName="expo-sharing" />
+<APIInstallSection />
 
 ## API
 

--- a/docs/pages/versions/unversioned/sdk/slider.md
+++ b/docs/pages/versions/unversioned/sdk/slider.md
@@ -1,6 +1,7 @@
 ---
 title: Slider
 sourceCodeUrl: 'https://github.com/react-native-community/react-native-slider'
+packageName: 'react-native-slider'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/slider.md
+++ b/docs/pages/versions/unversioned/sdk/slider.md
@@ -4,7 +4,7 @@ sourceCodeUrl: 'https://github.com/react-native-community/react-native-slider'
 packageName: 'react-native-slider'
 ---
 
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import Video from '~/components/plugins/Video'
 
@@ -16,7 +16,7 @@ A component that provides access to the system UI for a slider control, that all
 
 ## Installation
 
-<InstallSection packageName="@react-native-community/slider" href="https://github.com/react-native-community/react-native-slider#getting-started" />
+<APIInstallSection href="https://github.com/react-native-community/react-native-slider#getting-started" />
 
 ## Usage
 

--- a/docs/pages/versions/unversioned/sdk/sms.md
+++ b/docs/pages/versions/unversioned/sdk/sms.md
@@ -5,7 +5,7 @@ packageName: 'expo-sms'
 ---
 
 import APISection from '~/components/plugins/APISection';
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`expo-sms`** provides access to the system's UI/app for sending SMS messages.
@@ -14,7 +14,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 ## Installation
 
-<InstallSection packageName="expo-sms" />
+<APIInstallSection />
 
 ## API
 

--- a/docs/pages/versions/unversioned/sdk/sms.md
+++ b/docs/pages/versions/unversioned/sdk/sms.md
@@ -1,6 +1,7 @@
 ---
 title: SMS
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-sms'
+packageName: 'expo-sms'
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/speech.md
+++ b/docs/pages/versions/unversioned/sdk/speech.md
@@ -1,6 +1,7 @@
 ---
 title: Speech
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-speech'
+packageName: 'expo-speech'
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/speech.md
+++ b/docs/pages/versions/unversioned/sdk/speech.md
@@ -5,7 +5,7 @@ packageName: 'expo-speech'
 ---
 
 import APISection from '~/components/plugins/APISection';
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import SnackInline from '~/components/plugins/SnackInline';
 
@@ -15,7 +15,7 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 ## Installation
 
-<InstallSection packageName="expo-speech" />
+<APIInstallSection />
 
 ## Usage
 

--- a/docs/pages/versions/unversioned/sdk/splash-screen.md
+++ b/docs/pages/versions/unversioned/sdk/splash-screen.md
@@ -5,7 +5,7 @@ packageName: 'expo-splash-screen'
 ---
 
 import APISection from '~/components/plugins/APISection';
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 The `SplashScreen` module tells the splash screen to remain visible until it has been explicitly told to hide. This is useful to do some work behind the scenes before displaying your app (eg: make API calls) and to animated your splash screen (eg: fade out or slide away, or switch from a static splash screen to an animated splash screen).
@@ -16,7 +16,7 @@ Read more about [creating a splash screen image](../../../guides/splash-screens.
 
 ## Installation
 
-<InstallSection packageName="expo-splash-screen" />
+<APIInstallSection />
 
 ## Usage
 

--- a/docs/pages/versions/unversioned/sdk/splash-screen.md
+++ b/docs/pages/versions/unversioned/sdk/splash-screen.md
@@ -1,6 +1,7 @@
 ---
 title: SplashScreen
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-splash-screen'
+packageName: 'expo-splash-screen'
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/sqlite.md
+++ b/docs/pages/versions/unversioned/sdk/sqlite.md
@@ -5,7 +5,7 @@ packageName: 'expo-sqlite'
 ---
 
 import APISection from '~/components/plugins/APISection';
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`expo-sqlite`** gives your app access to a database that can be queried through a [WebSQL](https://www.w3.org/TR/webdatabase/)-like API. The database is persisted across restarts of your app.
@@ -64,7 +64,7 @@ db.exec([{ sql: 'PRAGMA foreign_keys = ON;', args: [] }], false, () =>
 
 ## Installation
 
-<InstallSection packageName="expo-sqlite" />
+<APIInstallSection />
 
 ## API
 

--- a/docs/pages/versions/unversioned/sdk/sqlite.md
+++ b/docs/pages/versions/unversioned/sdk/sqlite.md
@@ -1,6 +1,7 @@
 ---
 title: SQLite
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-sqlite'
+packageName: 'expo-sqlite'
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/status-bar.md
+++ b/docs/pages/versions/unversioned/sdk/status-bar.md
@@ -6,7 +6,7 @@ packageName: 'expo-status-bar'
 ---
 
 import APISection from '~/components/plugins/APISection';
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import SnackInline from '~/components/plugins/SnackInline';
 
@@ -20,7 +20,7 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 ## Installation
 
-<InstallSection packageName="expo-status-bar" />
+<APIInstallSection />
 
 ## Usage
 

--- a/docs/pages/versions/unversioned/sdk/status-bar.md
+++ b/docs/pages/versions/unversioned/sdk/status-bar.md
@@ -2,6 +2,7 @@
 id: statusbar
 title: StatusBar
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-status-bar'
+packageName: 'expo-status-bar'
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/storereview.md
+++ b/docs/pages/versions/unversioned/sdk/storereview.md
@@ -1,6 +1,7 @@
 ---
 title: StoreReview
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-store-review'
+packageName: 'expo-store-review'
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/storereview.md
+++ b/docs/pages/versions/unversioned/sdk/storereview.md
@@ -6,7 +6,7 @@ packageName: 'expo-store-review'
 
 import APISection from '~/components/plugins/APISection';
 import ImageSpotlight from '~/components/plugins/ImageSpotlight'
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`expo-store-review`** provides access to the `SKStoreReviewController` API in iOS 10.3+ devices, and `ReviewManager` API in Android 5.0+ allowing you to ask the user to rate your app without ever having to leave the app itself.
@@ -19,7 +19,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 > `expo-linking` is a peer dependency and must be installed alongside `expo-store-review`.
 
-<InstallSection packageName="expo-store-review expo-linking" />
+<APIInstallSection packageName="expo-store-review expo-linking" />
 
 ## Usage
 

--- a/docs/pages/versions/unversioned/sdk/stripe.md
+++ b/docs/pages/versions/unversioned/sdk/stripe.md
@@ -1,6 +1,7 @@
 ---
 title: Stripe
 sourceCodeUrl: 'https://github.com/stripe/stripe-react-native'
+packageName: '@stripe/stripe-react-native'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/stripe.md
+++ b/docs/pages/versions/unversioned/sdk/stripe.md
@@ -4,7 +4,7 @@ sourceCodeUrl: 'https://github.com/stripe/stripe-react-native'
 packageName: '@stripe/stripe-react-native'
 ---
 
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import SnackInline from '~/components/plugins/SnackInline';
 
@@ -20,7 +20,7 @@ If you're looking for a quick example, check out [this Snack](https://snack.expo
 
 Each Expo SDK version requires a specific `@stripe/stripe-react-native` version. See the [Stripe CHANGELOG](https://github.com/stripe/stripe-react-native/blob/master/CHANGELOG.md) for a mapping of versions. To automatically install the correct version for your Expo SDK version, run:
 
-<InstallSection packageName="@stripe/stripe-react-native" href="https://github.com/stripe/stripe-react-native" />
+<APIInstallSection href="https://github.com/stripe/stripe-react-native" />
 
 ### Config plugin setup (optional)
 

--- a/docs/pages/versions/unversioned/sdk/svg.md
+++ b/docs/pages/versions/unversioned/sdk/svg.md
@@ -4,7 +4,7 @@ sourceCodeUrl: 'https://github.com/react-native-community/react-native-svg'
 packageName: 'react-native-svg'
 ---
 
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import SnackInline from '~/components/plugins/SnackInline';
 
@@ -14,7 +14,7 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 ## Installation
 
-<InstallSection packageName="react-native-svg" href="https://github.com/react-native-community/react-native-svg#with-react-native-cli" />
+<APIInstallSection href="https://github.com/react-native-community/react-native-svg#with-react-native-cli" />
 
 ## API
 

--- a/docs/pages/versions/unversioned/sdk/svg.md
+++ b/docs/pages/versions/unversioned/sdk/svg.md
@@ -1,6 +1,7 @@
 ---
 title: Svg
 sourceCodeUrl: 'https://github.com/react-native-community/react-native-svg'
+packageName: 'react-native-svg'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/system-ui.md
+++ b/docs/pages/versions/unversioned/sdk/system-ui.md
@@ -5,7 +5,7 @@ packageName: 'expo-system-ui'
 ---
 
 import APISection from '~/components/plugins/APISection';
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`expo-system-ui`** enables you to interact with UI elements that fall outside of the React tree. Specifically the root view background color, and locking the user interface style globally on Android.
@@ -14,7 +14,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 ## Installation
 
-<InstallSection packageName="expo-system-ui" />
+<APIInstallSection />
 
 ## API
 

--- a/docs/pages/versions/unversioned/sdk/system-ui.md
+++ b/docs/pages/versions/unversioned/sdk/system-ui.md
@@ -1,6 +1,7 @@
 ---
 title: SystemUI
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-system-ui'
+packageName: 'expo-system-ui'
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/task-manager.md
+++ b/docs/pages/versions/unversioned/sdk/task-manager.md
@@ -4,6 +4,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-task-mana
 packageName: 'expo-task-manager'
 ---
 
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import APISection from '~/components/plugins/APISection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import SnackInline from '~/components/plugins/SnackInline';
@@ -18,7 +19,7 @@ Some features of this module are used by other modules under the hood. Here is a
 
 ## Installation
 
-For [managed](/introduction/managed-vs-bare.md#managed-workflow) apps, you'll need to run `expo install expo-task-manager`. To use it in [bare](/introduction/managed-vs-bare.md#bare-workflow) React Native app, follow its [installation instructions](https://github.com/expo/expo/tree/master/packages/expo-task-manager);
+<APIInstallSection />
 
 ## Configuration for standalone apps
 

--- a/docs/pages/versions/unversioned/sdk/task-manager.md
+++ b/docs/pages/versions/unversioned/sdk/task-manager.md
@@ -1,6 +1,7 @@
 ---
 title: TaskManager
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-task-manager'
+packageName: 'expo-task-manager'
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/tracking-transparency.md
+++ b/docs/pages/versions/unversioned/sdk/tracking-transparency.md
@@ -1,6 +1,7 @@
 ---
 title: TrackingTransparency
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-tracking-transparency'
+packageName: 'expo-tracking-transparency'
 ---
 
 import { ConfigClassic, ConfigReactNative, ConfigPluginExample, ConfigPluginProperties } from '~/components/plugins/ConfigSection';

--- a/docs/pages/versions/unversioned/sdk/tracking-transparency.md
+++ b/docs/pages/versions/unversioned/sdk/tracking-transparency.md
@@ -7,7 +7,7 @@ packageName: 'expo-tracking-transparency'
 import { ConfigClassic, ConfigReactNative, ConfigPluginExample, ConfigPluginProperties } from '~/components/plugins/ConfigSection';
 import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
 import APISection from '~/components/plugins/APISection';
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import SnackInline from '~/components/plugins/SnackInline';
 
@@ -19,7 +19,7 @@ For more information on Apple's new App Tracking Transparency framework, please 
 
 ## Installation
 
-<InstallSection packageName="expo-tracking-transparency" />
+<APIInstallSection />
 
 ## Configuration in app.json / app.config.js
 

--- a/docs/pages/versions/unversioned/sdk/updates.md
+++ b/docs/pages/versions/unversioned/sdk/updates.md
@@ -1,6 +1,7 @@
 ---
 title: Updates
-sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo/src/Updates'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-updates'
+packageName: 'expo-updates'
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/updates.md
+++ b/docs/pages/versions/unversioned/sdk/updates.md
@@ -5,7 +5,7 @@ packageName: 'expo-updates'
 ---
 
 import APISection from '~/components/plugins/APISection';
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 The `expo-updates` library allows you to programmatically control and respond to new updates made available to your app.
@@ -14,7 +14,7 @@ The `expo-updates` library allows you to programmatically control and respond to
 
 ## Installation
 
-<InstallSection packageName="expo-updates" href="/bare/installing-updates/" />
+<APIInstallSection href="/bare/installing-updates/" />
 
 ## Usage
 

--- a/docs/pages/versions/unversioned/sdk/video-thumbnails.md
+++ b/docs/pages/versions/unversioned/sdk/video-thumbnails.md
@@ -5,7 +5,7 @@ packageName: 'expo-video-thumbnails'
 ---
 
 import APISection from '~/components/plugins/APISection';
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import SnackInline from '~/components/plugins/SnackInline';
 
@@ -15,7 +15,7 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 ## Installation
 
-<InstallSection packageName="expo-video-thumbnails" />
+<APIInstallSection />
 
 ## Usage
 

--- a/docs/pages/versions/unversioned/sdk/video-thumbnails.md
+++ b/docs/pages/versions/unversioned/sdk/video-thumbnails.md
@@ -1,6 +1,7 @@
 ---
 title: VideoThumbnails
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-video-thumbnails'
+packageName: 'expo-video-thumbnails'
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/video.md
+++ b/docs/pages/versions/unversioned/sdk/video.md
@@ -4,7 +4,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-av'
 packageName: 'expo-av'
 ---
 
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import SnackInline from '~/components/plugins/SnackInline';
 
@@ -16,7 +16,7 @@ Much of Video and Audio have common APIs that are documented in [AV documentatio
 
 ## Installation
 
-<InstallSection packageName="expo-av" />
+<APIInstallSection />
 
 ## Usage
 

--- a/docs/pages/versions/unversioned/sdk/video.md
+++ b/docs/pages/versions/unversioned/sdk/video.md
@@ -1,6 +1,7 @@
 ---
 title: Video
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-av'
+packageName: 'expo-av'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/view-pager.md
+++ b/docs/pages/versions/unversioned/sdk/view-pager.md
@@ -1,6 +1,7 @@
 ---
 title: ViewPager
 sourceCodeUrl: 'https://github.com/callstack/react-native-pager-view'
+packageName: 'react-native-pager-view'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/view-pager.md
+++ b/docs/pages/versions/unversioned/sdk/view-pager.md
@@ -4,7 +4,7 @@ sourceCodeUrl: 'https://github.com/callstack/react-native-pager-view'
 packageName: 'react-native-pager-view'
 ---
 
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import Video from '~/components/plugins/Video'
 
@@ -16,7 +16,7 @@ import Video from '~/components/plugins/Video'
 
 ## Installation
 
-<InstallSection packageName="react-native-pager-view" href="https://github.com/callstack/react-native-pager-view#linking" />
+<APIInstallSection href="https://github.com/callstack/react-native-pager-view#linking" />
 
 ## Usage
 

--- a/docs/pages/versions/unversioned/sdk/webbrowser.md
+++ b/docs/pages/versions/unversioned/sdk/webbrowser.md
@@ -1,6 +1,7 @@
 ---
 title: WebBrowser
 sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-web-browser'
+packageName: 'expo-web-browser'
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/webbrowser.md
+++ b/docs/pages/versions/unversioned/sdk/webbrowser.md
@@ -5,7 +5,7 @@ packageName: 'expo-web-browser'
 ---
 
 import APISection from '~/components/plugins/APISection';
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import SnackInline from '~/components/plugins/SnackInline';
 
@@ -15,7 +15,7 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 ## Installation
 
-<InstallSection packageName="expo-web-browser" />
+<APIInstallSection />
 
 ## Usage
 

--- a/docs/pages/versions/unversioned/sdk/webview.md
+++ b/docs/pages/versions/unversioned/sdk/webview.md
@@ -1,6 +1,7 @@
 ---
 title: WebView
 sourceCodeUrl: 'https://github.com/react-native-community/react-native-webview'
+packageName: 'react-native-webview'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/webview.md
+++ b/docs/pages/versions/unversioned/sdk/webview.md
@@ -4,7 +4,7 @@ sourceCodeUrl: 'https://github.com/react-native-community/react-native-webview'
 packageName: 'react-native-webview'
 ---
 
-import InstallSection from '~/components/plugins/InstallSection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import SnackInline from '~/components/plugins/SnackInline';
 
@@ -14,7 +14,7 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 ## Installation
 
-<InstallSection packageName="react-native-webview" href="https://github.com/react-native-community/react-native-webview/blob/master/docs/Getting-Started.md#react-native-webview-getting-started-guide" />
+<APIInstallSection href="https://github.com/react-native-community/react-native-webview/blob/master/docs/Getting-Started.md#react-native-webview-getting-started-guide" />
 
 ## Usage
 

--- a/docs/types/common.ts
+++ b/docs/types/common.ts
@@ -1,6 +1,7 @@
 export type PageMetadata = {
   title?: string;
   sourceCodeUrl?: string;
+  packageName?: string;
   maxHeadingDepth?: number;
   /* If the page should not show up in the Algolia Docsearch results */
   hideFromSearch?: boolean;


### PR DESCRIPTION
# Why

While adding config plugin docs I ended up having to copy package names around a lot, given that only I work on config plugins, the docs need to be a bit more automated so they don't get out of date too quickly. 

This PR surfaces the `packageName` on API pages so child components can automatically get the name of the package.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Everything is link based so the CI to check broken links should work, that said, I did find some broken links for expo-updates, expo-linking, and expo-app-loading so maybe the CI isn't checking correctly.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
