### PR TITLE
[ci] disable blur detox test

### DIFF
--- a/apps/bare-expo/e2e/TestSuite-test.native.js
+++ b/apps/bare-expo/e2e/TestSuite-test.native.js
@@ -9,7 +9,7 @@ let TESTS = [
   // 'FileSystem',
   // 'Font',
   'Permissions',
-  'Blur',
+  // 'Blur',
   'LinearGradient',
   'Constants',
   // 'Contacts',


### PR DESCRIPTION
# Why

expo-blur + detox will crash on ios. it's a detox issue reported in https://github.com/wix/DetoxSync/issues/23

# How

disable blur test first, will revert the change once detox fixing the issue

# Test Plan

ci green

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
