### PR TITLE
[docs] Localization.getLocalizationAsync: fix info quote

### DIFF
--- a/packages/expo-localization/src/Localization.ts
+++ b/packages/expo-localization/src/Localization.ts
@@ -90,7 +90,7 @@ export const region = ExpoLocalization.region;
  * Get the latest native values from the device. Locale can be changed on some Android devices
  * without resetting the app.
  * > On iOS, changing the locale will cause the device to reset meaning the constants will always be
- * correct.
+ * > correct.
  *
  * @example
  * ```ts


### PR DESCRIPTION
# Why

I noticed an issue in docs:

<img width="1070" alt="image" src="https://user-images.githubusercontent.com/4335166/144676915-478b14ad-9c9e-499f-8bf8-8229b02b18dd.png">

I guess the issue appeared because of max line width (chars).

# How

I hope the change fixes that.

# Test Plan

> Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.

That's a good question. Could someone guide me how I can do this? Should I just follow https://github.com/expo/expo/blob/sdk-43/CONTRIBUTING.md#-updating-documentation?

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
