### PR TITLE
[expo-updates][ios] Add support for multipart manifest responses

### DIFF
--- a/ios/Exponent/Kernel/Services/EXUpdatesManager.m
+++ b/ios/Exponent/Kernel/Services/EXUpdatesManager.m
@@ -147,7 +147,7 @@ didRequestManifestWithCacheBehavior:(EXManifestCacheBehavior)cacheBehavior
                              extraHeaders:nil
                              successBlock:^(EXUpdatesUpdate *update) {
     success(update.manifest);
-  } errorBlock:^(NSError *error, NSURLResponse *response) {
+  } errorBlock:^(NSError *error) {
     failure(error);
   }];
 }

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Add native checkOnLaunch: ERROR_RECOVERY_ONLY setting on Android. ([#15219](https://github.com/expo/expo/pull/15219) by [@esamelson](https://github.com/esamelson))
 - Enhance node binary resolution for Xcode build phases scripts by the vendoring source-login-scripts.sh. ([#15336](https://github.com/expo/expo/pull/15336) by [@kudo](https://github.com/kudo))
 - Add android support for multipart manifest responses. ([#15401](https://github.com/expo/expo/pull/15401) by [@wschurman](https://github.com/wschurman))
+- Add iOS support for multipart manifest responses. ([#15426](https://github.com/expo/expo/pull/15426) by [@wschurman](https://github.com/wschurman))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesAppLauncherWithDatabase.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesAppLauncherWithDatabase.m
@@ -289,7 +289,10 @@ static NSString * const EXUpdatesAppLauncherErrorDomain = @"AppLauncher";
     completion([NSError errorWithDomain:EXUpdatesAppLauncherErrorDomain code:1007 userInfo:@{NSLocalizedDescriptionKey: @"Failed to download asset with no URL provided"}], asset, assetLocalUrl);
   }
   dispatch_async([EXUpdatesFileDownloader assetFilesQueue], ^{
-    [self.downloader downloadFileFromURL:asset.url toPath:[assetLocalUrl path] successBlock:^(NSData *data, NSURLResponse *response) {
+    [self.downloader downloadFileFromURL:asset.url
+                                  toPath:[assetLocalUrl path]
+                            extraHeaders:asset.extraRequestHeaders ?: [NSDictionary new]
+                            successBlock:^(NSData *data, NSURLResponse *response) {
       dispatch_async(self->_launcherQueue, ^{
         if ([response isKindOfClass:[NSHTTPURLResponse class]]) {
           asset.headers = ((NSHTTPURLResponse *)response).allHeaderFields;
@@ -298,7 +301,8 @@ static NSString * const EXUpdatesAppLauncherErrorDomain = @"AppLauncher";
         asset.downloadTime = [NSDate date];
         completion(nil, asset, assetLocalUrl);
       });
-    } errorBlock:^(NSError *error, NSURLResponse *response) {
+    }
+                              errorBlock:^(NSError *error) {
       dispatch_async(self->_launcherQueue, ^{
         completion(error, asset, assetLocalUrl);
       });

--- a/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesAppLauncherWithDatabase.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesAppLauncherWithDatabase.m
@@ -291,7 +291,7 @@ static NSString * const EXUpdatesAppLauncherErrorDomain = @"AppLauncher";
   dispatch_async([EXUpdatesFileDownloader assetFilesQueue], ^{
     [self.downloader downloadFileFromURL:asset.url
                                   toPath:[assetLocalUrl path]
-                            extraHeaders:asset.extraRequestHeaders ?: [NSDictionary new]
+                            extraHeaders:asset.extraRequestHeaders ?: @{}
                             successBlock:^(NSData *data, NSURLResponse *response) {
       dispatch_async(self->_launcherQueue, ^{
         if ([response isKindOfClass:[NSHTTPURLResponse class]]) {

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAsset.h
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAsset.h
@@ -16,6 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nullable, nonatomic, strong) NSString *mainBundleDir; // used for embedded assets
 @property (nullable, nonatomic, strong) NSString *mainBundleFilename; // used for embedded assets
 @property (nonatomic, assign) BOOL isLaunchAsset;
+@property (nullable, nonatomic, strong) NSDictionary *extraRequestHeaders;
 
 /**
  * properties determined at runtime by updates implementation

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesCrypto.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesCrypto.m
@@ -32,6 +32,7 @@ static NSString * const EXUpdatesCryptoPublicKeyFilename = @"manifestPublicKey.p
 
   EXUpdatesFileDownloader *fileDownloader = [[EXUpdatesFileDownloader alloc] initWithUpdatesConfig:config URLSessionConfiguration:configuration];
   [fileDownloader downloadDataFromURL:[NSURL URLWithString:EXUpdatesCryptoPublicKeyUrl]
+                         extraHeaders:[NSDictionary new]
                          successBlock:^(NSData *publicKeyData, NSURLResponse *response) {
                                         [[self class] verifyWithPublicKey:publicKeyData signature:signature signedString:data callback:^(BOOL isValid) {
                                           if (isValid) {
@@ -41,7 +42,7 @@ static NSString * const EXUpdatesCryptoPublicKeyFilename = @"manifestPublicKey.p
                                           }
                                         }];
                                       }
-                           errorBlock:^(NSError *error, NSURLResponse *response) {
+                           errorBlock:^(NSError *error) {
                                         fetchRemotelyBlock();
                                       }
    ];
@@ -58,10 +59,11 @@ static NSString * const EXUpdatesCryptoPublicKeyFilename = @"manifestPublicKey.p
 
   EXUpdatesFileDownloader *fileDownloader = [[EXUpdatesFileDownloader alloc] initWithUpdatesConfig:config URLSessionConfiguration:configuration];
   [fileDownloader downloadDataFromURL:[NSURL URLWithString:EXUpdatesCryptoPublicKeyUrl]
+                         extraHeaders:[NSDictionary new]
                          successBlock:^(NSData *publicKeyData, NSURLResponse *response) {
                                         [[self class] verifyWithPublicKey:publicKeyData signature:signature signedString:data callback:successBlock];
                                       }
-                           errorBlock:^(NSError *error, NSURLResponse *response) {
+                           errorBlock:^(NSError *error) {
                                         errorBlock(error);
                                       }
   ];

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesCrypto.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesCrypto.m
@@ -32,7 +32,7 @@ static NSString * const EXUpdatesCryptoPublicKeyFilename = @"manifestPublicKey.p
 
   EXUpdatesFileDownloader *fileDownloader = [[EXUpdatesFileDownloader alloc] initWithUpdatesConfig:config URLSessionConfiguration:configuration];
   [fileDownloader downloadDataFromURL:[NSURL URLWithString:EXUpdatesCryptoPublicKeyUrl]
-                         extraHeaders:[NSDictionary new]
+                         extraHeaders:@{}
                          successBlock:^(NSData *publicKeyData, NSURLResponse *response) {
                                         [[self class] verifyWithPublicKey:publicKeyData signature:signature signedString:data callback:^(BOOL isValid) {
                                           if (isValid) {
@@ -59,7 +59,7 @@ static NSString * const EXUpdatesCryptoPublicKeyFilename = @"manifestPublicKey.p
 
   EXUpdatesFileDownloader *fileDownloader = [[EXUpdatesFileDownloader alloc] initWithUpdatesConfig:config URLSessionConfiguration:configuration];
   [fileDownloader downloadDataFromURL:[NSURL URLWithString:EXUpdatesCryptoPublicKeyUrl]
-                         extraHeaders:[NSDictionary new]
+                         extraHeaders:@{}
                          successBlock:^(NSData *publicKeyData, NSURLResponse *response) {
                                         [[self class] verifyWithPublicKey:publicKeyData signature:signature signedString:data callback:successBlock];
                                       }

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.h
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.h
@@ -7,7 +7,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 typedef void (^EXUpdatesFileDownloaderSuccessBlock)(NSData *data, NSURLResponse *response);
 typedef void (^EXUpdatesFileDownloaderManifestSuccessBlock)(EXUpdatesUpdate *update);
-typedef void (^EXUpdatesFileDownloaderErrorBlock)(NSError *error, NSURLResponse *response);
+typedef void (^EXUpdatesFileDownloaderErrorBlock)(NSError *error);
 
 @interface EXUpdatesFileDownloader : NSObject
 
@@ -16,11 +16,13 @@ typedef void (^EXUpdatesFileDownloaderErrorBlock)(NSError *error, NSURLResponse 
               URLSessionConfiguration:(NSURLSessionConfiguration *)sessionConfiguration;
 
 - (void)downloadDataFromURL:(NSURL *)url
+               extraHeaders:(NSDictionary *)extraHeaders
                successBlock:(EXUpdatesFileDownloaderSuccessBlock)successBlock
                  errorBlock:(EXUpdatesFileDownloaderErrorBlock)errorBlock;
 
 - (void)downloadFileFromURL:(NSURL *)url
                      toPath:(NSString *)destinationPath
+               extraHeaders:(NSDictionary *)extraHeaders
                successBlock:(EXUpdatesFileDownloaderSuccessBlock)successBlock
                  errorBlock:(EXUpdatesFileDownloaderErrorBlock)errorBlock;
 
@@ -36,6 +38,12 @@ typedef void (^EXUpdatesFileDownloaderErrorBlock)(NSError *error, NSURLResponse 
  * For test purposes; shouldn't be needed in application code
  */
 - (NSURLRequest *)createManifestRequestWithURL:(NSURL *)url extraHeaders:(nullable NSDictionary *)extraHeaders;
+- (NSURLRequest *)createGenericRequestWithURL:(NSURL *)url extraHeaders:(NSDictionary *)extraHeaders;
+- (void)parseManifestResponse:(NSHTTPURLResponse *)httpResponse
+                     withData:(NSData *)data
+                     database:(EXUpdatesDatabase *)database
+                 successBlock:(EXUpdatesFileDownloaderManifestSuccessBlock)successBlock
+                   errorBlock:(EXUpdatesFileDownloaderErrorBlock)errorBlock;
 
 @end
 

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.m
@@ -142,7 +142,7 @@ NSTimeInterval const EXUpdatesDefaultTimeoutInterval = 60;
   } else {
     return [self parseManifestBodyData:data
                       headerDictionary:[httpResponse allHeaderFields]
-                            extensions:[NSDictionary new]
+                            extensions:@{}
                               database:database
                           successBlock:successBlock
                             errorBlock:errorBlock];
@@ -239,7 +239,7 @@ NSTimeInterval const EXUpdatesDefaultTimeoutInterval = 60;
                           errorBlock:errorBlock];
 }
 
-- (void)parseManifestBodyData:(NSData *)data
+- (void)parseManifestBodyData:(NSData *)manifestBodyData
              headerDictionary:(NSDictionary *)headerDictionary
                    extensions:(NSDictionary *)extensions
                      database:(EXUpdatesDatabase *)database
@@ -248,13 +248,13 @@ NSTimeInterval const EXUpdatesDefaultTimeoutInterval = 60;
   id headerSignature = headerDictionary[@"expo-manifest-signature"];
   
   NSError *err;
-  id parsedJson = [NSJSONSerialization JSONObjectWithData:data options:kNilOptions error:&err];
+  id manifestBodyJson = [NSJSONSerialization JSONObjectWithData:manifestBodyData options:kNilOptions error:&err];
   if (err) {
     errorBlock(err);
     return;
   }
 
-  NSDictionary *updateResponseDictionary = [self _extractUpdateResponseDictionary:parsedJson error:&err];
+  NSDictionary *updateResponseDictionary = [self _extractUpdateResponseDictionary:manifestBodyJson error:&err];
   if (err) {
     errorBlock(err);
     return;
@@ -265,7 +265,7 @@ NSTimeInterval const EXUpdatesDefaultTimeoutInterval = 60;
   BOOL isSignatureInBody = bodyManifestString != nil && bodySignature != nil;
 
   id signature = isSignatureInBody ? bodySignature : headerSignature;
-  id manifestString = isSignatureInBody ? bodyManifestString : [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+  id manifestString = isSignatureInBody ? bodyManifestString : [[NSString alloc] initWithData:manifestBodyData encoding:NSUTF8StringEncoding];
     
   // XDL serves unsigned manifests with the `signature` key set to "UNSIGNED".
   // We should treat these manifests as unsigned rather than signed with an invalid signature.

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.m
@@ -4,6 +4,8 @@
 #import <EXUpdates/EXUpdatesErrorRecovery.h>
 #import <EXUpdates/EXUpdatesFileDownloader.h>
 #import <EXUpdates/EXUpdatesSelectionPolicies.h>
+#import <EXUpdates/EXUpdatesMultipartStreamReader.h>
+#import <EXUpdates/EXUpdatesParameterParser.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -56,10 +58,11 @@ NSTimeInterval const EXUpdatesDefaultTimeoutInterval = 60;
 
 - (void)downloadFileFromURL:(NSURL *)url
                      toPath:(NSString *)destinationPath
+               extraHeaders:(NSDictionary *)extraHeaders
                successBlock:(EXUpdatesFileDownloaderSuccessBlock)successBlock
                  errorBlock:(EXUpdatesFileDownloaderErrorBlock)errorBlock
 {
-  [self downloadDataFromURL:url successBlock:^(NSData *data, NSURLResponse *response) {
+  [self downloadDataFromURL:url extraHeaders:extraHeaders successBlock:^(NSData *data, NSURLResponse *response) {
     NSError *error;
     if ([data writeToFile:destinationPath options:NSDataWritingAtomic error:&error]) {
       successBlock(data, response);
@@ -70,7 +73,7 @@ NSTimeInterval const EXUpdatesDefaultTimeoutInterval = 60;
                                    NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Could not write to path %@: %@", destinationPath, error.localizedDescription],
                                    NSUnderlyingErrorKey: error
                                  }
-                  ], response);
+                  ]);
     }
   } errorBlock:errorBlock];
 }
@@ -83,6 +86,252 @@ NSTimeInterval const EXUpdatesDefaultTimeoutInterval = 60;
   [self _setManifestHTTPHeaderFields:request withExtraHeaders:extraHeaders];
 
   return request;
+}
+
+- (NSURLRequest *)createGenericRequestWithURL:(NSURL *)url extraHeaders:(NSDictionary *)extraHeaders
+{
+  // pass any custom cache policy onto this specific request
+  NSURLRequestCachePolicy cachePolicy = _sessionConfiguration ? _sessionConfiguration.requestCachePolicy : NSURLRequestUseProtocolCachePolicy;
+
+  NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url cachePolicy:cachePolicy timeoutInterval:EXUpdatesDefaultTimeoutInterval];
+  [self _setHTTPHeaderFields:request extraHeaders:extraHeaders];
+  
+  return request;
+}
+
+- (void)parseManifestResponse:(NSHTTPURLResponse *)httpResponse
+                     withData:(NSData *)data
+                     database:(EXUpdatesDatabase *)database
+                 successBlock:(EXUpdatesFileDownloaderManifestSuccessBlock)successBlock
+                   errorBlock:(EXUpdatesFileDownloaderErrorBlock)errorBlock {
+  NSDictionary *headerDictionary = [httpResponse allHeaderFields];
+  id contentTypeRaw;
+  for (NSString *key in headerDictionary) {
+    if ([key caseInsensitiveCompare: @"content-type"] == NSOrderedSame) {
+      contentTypeRaw = headerDictionary[key];
+    }
+  }
+  
+  NSString *contentType;
+  if (contentTypeRaw != nil && [contentTypeRaw isKindOfClass:[NSString class]]) {
+    contentType = contentTypeRaw;
+  } else {
+    contentType = @"";
+  }
+  
+  if ([[contentType lowercaseString] hasPrefix:@"multipart/"]) {
+    NSDictionary<NSString *, NSString *> *contentTypeParameters = [[EXUpdatesParameterParser new] parseParameterString:contentType withDelimiter:@";"];
+    NSString *boundaryParameterValue = contentTypeParameters[@"boundary"];
+    
+    if (boundaryParameterValue == nil) {
+      NSError *error = [NSError errorWithDomain:EXUpdatesFileDownloaderErrorDomain
+                                           code:1047
+                                       userInfo:@{
+        NSLocalizedDescriptionKey: @"Missing boundary in multipart manifest content-type",
+      }];
+      errorBlock(error);
+      return;
+    }
+    
+    return [self parseMultipartManifestResponse:httpResponse
+                                       withData:data
+                                       database:database
+                                       boundary:boundaryParameterValue
+                                   successBlock:successBlock
+                                     errorBlock:errorBlock];
+  } else {
+    return [self parseManifestBodyData:data
+                      headerDictionary:[httpResponse allHeaderFields]
+                            extensions:[NSDictionary new]
+                              database:database
+                          successBlock:successBlock
+                            errorBlock:errorBlock];
+  }
+}
+
+- (void)parseMultipartManifestResponse:(NSHTTPURLResponse *)httpResponse
+                              withData:(NSData *)data
+                              database:(EXUpdatesDatabase *)database
+                              boundary:(NSString *)boundary
+                          successBlock:(EXUpdatesFileDownloaderManifestSuccessBlock)successBlock
+                            errorBlock:(EXUpdatesFileDownloaderErrorBlock)errorBlock {
+  NSInputStream *inputStream = [[NSInputStream alloc] initWithData:data];
+  EXUpdatesMultipartStreamReader *reader = [[EXUpdatesMultipartStreamReader alloc] initWithInputStream:inputStream boundary:boundary];
+
+  __block NSDictionary *manifestHeaders = nil;
+  __block NSData *manifestData = nil;
+  __block NSData *extensionsData = nil;
+
+  BOOL completed = [reader readAllPartsWithCompletionCallback:^(NSDictionary *headers, NSData *content, BOOL done) {
+    id contentDispositionRaw;
+    for (NSString *key in headers) {
+      if ([key caseInsensitiveCompare: @"content-disposition"] == NSOrderedSame) {
+        contentDispositionRaw = headers[key];
+      }
+    }
+    
+    NSString *contentDisposition = nil;
+    if (contentDispositionRaw != nil && [contentDispositionRaw isKindOfClass:[NSString class]]) {
+      contentDisposition = contentDispositionRaw;
+    }
+    
+    if (contentDisposition != nil) {
+      NSDictionary<NSString *, NSString *> *contentDispositionParameters = [[EXUpdatesParameterParser new] parseParameterString:contentDisposition withDelimiter:@";"];
+      NSString *contentDispositionNameFieldValue = contentDispositionParameters[@"name"];
+      if (contentDispositionNameFieldValue != nil) {
+        if ([contentDispositionNameFieldValue isEqualToString:@"manifest"]) {
+          manifestHeaders = headers;
+          manifestData = content;
+        } else if ([contentDispositionNameFieldValue isEqualToString:@"extensions"]) {
+          extensionsData = content;
+        }
+      }
+    }
+  } progressCallback:^(NSDictionary *headers, NSNumber *loaded, NSNumber *total) {}];
+  
+  if (!completed) {
+    NSError *error = [NSError errorWithDomain:EXUpdatesFileDownloaderErrorDomain
+                                         code:1044
+                                     userInfo:@{
+      NSLocalizedDescriptionKey: @"Could not read multipart manifest response",
+    }];
+    errorBlock(error);
+    return;
+  }
+  
+  if (manifestHeaders == nil || manifestData == nil) {
+    NSError *error = [NSError errorWithDomain:EXUpdatesFileDownloaderErrorDomain
+                                         code:1045
+                                     userInfo:@{
+      NSLocalizedDescriptionKey: @"Multipart manifest response missing manifest part",
+    }];
+    errorBlock(error);
+    return;
+  }
+  
+  NSDictionary *extensions;
+  if (extensionsData != nil) {
+    NSError *extensionsParsingError;
+    id parsedExtensions = [NSJSONSerialization JSONObjectWithData:extensionsData options:kNilOptions error:&extensionsParsingError];
+    if (extensionsParsingError) {
+      errorBlock(extensionsParsingError);
+      return;
+    }
+    
+    if ([parsedExtensions isKindOfClass:[NSDictionary class]]) {
+      extensions = parsedExtensions;
+    } else {
+      NSError *error = [NSError errorWithDomain:EXUpdatesFileDownloaderErrorDomain
+                                           code:1046
+                                       userInfo:@{
+        NSLocalizedDescriptionKey: @"Failed to parse multipart manifest extensions",
+      }];
+      errorBlock(error);
+      return;
+    }
+  }
+
+  return [self parseManifestBodyData:manifestData
+                    headerDictionary:manifestHeaders
+                          extensions:extensions
+                            database:database
+                        successBlock:successBlock
+                          errorBlock:errorBlock];
+}
+
+- (void)parseManifestBodyData:(NSData *)data
+             headerDictionary:(NSDictionary *)headerDictionary
+                   extensions:(NSDictionary *)extensions
+                     database:(EXUpdatesDatabase *)database
+                 successBlock:(EXUpdatesFileDownloaderManifestSuccessBlock)successBlock
+                   errorBlock:(EXUpdatesFileDownloaderErrorBlock)errorBlock {
+  id headerSignature = headerDictionary[@"expo-manifest-signature"];
+  
+  NSError *err;
+  id parsedJson = [NSJSONSerialization JSONObjectWithData:data options:kNilOptions error:&err];
+  if (err) {
+    errorBlock(err);
+    return;
+  }
+
+  NSDictionary *updateResponseDictionary = [self _extractUpdateResponseDictionary:parsedJson error:&err];
+  if (err) {
+    errorBlock(err);
+    return;
+  }
+
+  id bodyManifestString = updateResponseDictionary[@"manifestString"];
+  id bodySignature = updateResponseDictionary[@"signature"];
+  BOOL isSignatureInBody = bodyManifestString != nil && bodySignature != nil;
+
+  id signature = isSignatureInBody ? bodySignature : headerSignature;
+  id manifestString = isSignatureInBody ? bodyManifestString : [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+    
+  // XDL serves unsigned manifests with the `signature` key set to "UNSIGNED".
+  // We should treat these manifests as unsigned rather than signed with an invalid signature.
+  BOOL isUnsignedFromXDL = [(NSString *)signature isEqualToString:@"UNSIGNED"];
+
+  if (![manifestString isKindOfClass:[NSString class]]) {
+    errorBlock([NSError errorWithDomain:EXUpdatesFileDownloaderErrorDomain
+                                   code:1041
+                               userInfo:@{
+                                 NSLocalizedDescriptionKey: @"manifestString should be a string",
+                               }
+                ]);
+    return;
+  }
+  NSDictionary *manifest = [NSJSONSerialization JSONObjectWithData:[(NSString *)manifestString dataUsingEncoding:NSUTF8StringEncoding] options:kNilOptions error:&err];
+  if (err || !manifest || ![manifest isKindOfClass:[NSDictionary class]]) {
+    errorBlock([NSError errorWithDomain:EXUpdatesFileDownloaderErrorDomain
+                                   code:1042
+                               userInfo:@{
+                                 NSLocalizedDescriptionKey: @"manifest should be a valid JSON object",
+                               }
+                ]);
+    return;
+  }
+  NSMutableDictionary *mutableManifest = [manifest mutableCopy];
+    
+  if (signature != nil && !isUnsignedFromXDL) {
+    if (![signature isKindOfClass:[NSString class]]) {
+      errorBlock([NSError errorWithDomain:EXUpdatesFileDownloaderErrorDomain
+                                     code:1043
+                                 userInfo:@{
+                                   NSLocalizedDescriptionKey: @"signature should be a string",
+                                 }
+                  ]);
+      return;
+    }
+    [EXUpdatesCrypto verifySignatureWithData:(NSString *)manifestString
+                                   signature:(NSString *)signature
+                                      config:self->_config
+                                successBlock:^(BOOL isValid) {
+                                                if (isValid) {
+                                                  [self _createUpdateWithManifest:mutableManifest
+                                                                          headers:headerDictionary
+                                                                       extensions:extensions
+                                                                         database:database
+                                                                       isVerified:YES
+                                                                     successBlock:successBlock
+                                                                       errorBlock:errorBlock];
+                                                } else {
+                                                  NSError *error = [NSError errorWithDomain:EXUpdatesFileDownloaderErrorDomain code:1003 userInfo:@{NSLocalizedDescriptionKey: @"Manifest verification failed"}];
+                                                  errorBlock(error);
+                                                }
+                                              }
+                                  errorBlock:^(NSError *error) {
+                                                errorBlock(error);
+                                              }
+    ];
+  } else {
+    [self _createUpdateWithManifest:mutableManifest
+                            headers:headerDictionary
+                         extensions:extensions
+                           database:database
+                         isVerified:NO
+                       successBlock:successBlock
+                         errorBlock:errorBlock];
+  }
 }
 
 - (void)downloadManifestFromURL:(NSURL *)url
@@ -99,101 +348,20 @@ NSTimeInterval const EXUpdatesDefaultTimeoutInterval = 60;
                                  userInfo:@{
                                    NSLocalizedDescriptionKey: @"response must be a NSHTTPURLResponse",
                                  }
-                  ], response);
+                  ]);
       return;
     }
-    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
-    NSDictionary *headerDictionary = [httpResponse allHeaderFields];
-    id headerSignature = headerDictionary[@"expo-manifest-signature"];
-    
-    NSError *err;
-    id parsedJson = [NSJSONSerialization JSONObjectWithData:data options:kNilOptions error:&err];
-    if (err) {
-      errorBlock(err, response);
-      return;
-    }
-
-    NSDictionary *updateResponseDictionary = [self _extractUpdateResponseDictionary:parsedJson error:&err];
-    if (err) {
-      errorBlock(err, response);
-      return;
-    }
-
-    id bodyManifestString = updateResponseDictionary[@"manifestString"];
-    id bodySignature = updateResponseDictionary[@"signature"];
-    BOOL isSignatureInBody = bodyManifestString != nil && bodySignature != nil;
-
-    id signature = isSignatureInBody ? bodySignature : headerSignature;
-    id manifestString = isSignatureInBody ? bodyManifestString : [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-      
-    // XDL serves unsigned manifests with the `signature` key set to "UNSIGNED".
-    // We should treat these manifests as unsigned rather than signed with an invalid signature.
-    BOOL isUnsignedFromXDL = [(NSString *)signature isEqualToString:@"UNSIGNED"];
-
-    if (![manifestString isKindOfClass:[NSString class]]) {
-      errorBlock([NSError errorWithDomain:EXUpdatesFileDownloaderErrorDomain
-                                     code:1041
-                                 userInfo:@{
-                                   NSLocalizedDescriptionKey: @"manifestString should be a string",
-                                 }
-                  ], response);
-      return;
-    }
-    NSDictionary *manifest = [NSJSONSerialization JSONObjectWithData:[(NSString *)manifestString dataUsingEncoding:NSUTF8StringEncoding] options:kNilOptions error:&err];
-    if (err || !manifest || ![manifest isKindOfClass:[NSDictionary class]]) {
-      errorBlock([NSError errorWithDomain:EXUpdatesFileDownloaderErrorDomain
-                                     code:1042
-                                 userInfo:@{
-                                   NSLocalizedDescriptionKey: @"manifest should be a valid JSON object",
-                                 }
-                  ], response);
-      return;
-    }
-    NSMutableDictionary *mutableManifest = [manifest mutableCopy];
-      
-    if (signature != nil && !isUnsignedFromXDL) {
-      if (![signature isKindOfClass:[NSString class]]) {
-        errorBlock([NSError errorWithDomain:EXUpdatesFileDownloaderErrorDomain
-                                       code:1043
-                                   userInfo:@{
-                                     NSLocalizedDescriptionKey: @"signature should be a string",
-                                   }
-                    ], response);
-        return;
-      }
-      [EXUpdatesCrypto verifySignatureWithData:(NSString *)manifestString
-                                     signature:(NSString *)signature
-                                        config:self->_config
-                                  successBlock:^(BOOL isValid) {
-                                                  if (isValid) {
-                                                    [self _createUpdateWithManifest:mutableManifest
-                                                                           response:response
-                                                                           database:database
-                                                                         isVerified:YES
-                                                                       successBlock:successBlock
-                                                                         errorBlock:errorBlock];
-                                                  } else {
-                                                    NSError *error = [NSError errorWithDomain:EXUpdatesFileDownloaderErrorDomain code:1003 userInfo:@{NSLocalizedDescriptionKey: @"Manifest verification failed"}];
-                                                    errorBlock(error, response);
-                                                  }
-                                                }
-                                    errorBlock:^(NSError *error) {
-                                                  errorBlock(error, response);
-                                                }
-      ];
-    } else {
-      [self _createUpdateWithManifest:mutableManifest
-                             response:response
-                             database:database
-                           isVerified:NO
-                         successBlock:successBlock
-                           errorBlock:errorBlock];
-    }
+    return [self parseManifestResponse:(NSHTTPURLResponse *)response
+                              withData:data
+                              database:database
+                          successBlock:successBlock
+                            errorBlock:errorBlock];
   } errorBlock:errorBlock];
 }
 
 - (void)_createUpdateWithManifest:(NSMutableDictionary *)mutableManifest
-                         response:(NSURLResponse *)response
+                          headers:(NSDictionary *)headers
+                       extensions:(NSDictionary *)extensions
                          database:(EXUpdatesDatabase *)database
                        isVerified:(BOOL)isVerified
                      successBlock:(EXUpdatesFileDownloaderManifestSuccessBlock)successBlock
@@ -208,10 +376,11 @@ NSTimeInterval const EXUpdatesDefaultTimeoutInterval = 60;
   EXUpdatesUpdate *update;
   @try {
     update = [EXUpdatesUpdate updateWithManifest:mutableManifest.copy
-                                                         response:response
-                                                           config:_config
-                                                         database:database
-                                                            error:&error];
+                                         headers:headers
+                                      extensions:extensions
+                                          config:_config
+                                        database:database
+                                           error:&error];
   }
   @catch (NSException *exception) {
     // Catch any assertions related to parsing the manifest JSON,
@@ -223,7 +392,7 @@ NSTimeInterval const EXUpdatesDefaultTimeoutInterval = 60;
   }
   
   if (error) {
-    errorBlock(error, response);
+    errorBlock(error);
     return;
   }
 
@@ -231,22 +400,18 @@ NSTimeInterval const EXUpdatesDefaultTimeoutInterval = 60;
     NSError *error = [NSError errorWithDomain:EXUpdatesFileDownloaderErrorDomain
                                          code:1021
                                      userInfo:@{NSLocalizedDescriptionKey: @"Downloaded manifest is invalid; provides filters that do not match its content"}];
-    errorBlock(error, response);
+    errorBlock(error);
   } else {
     successBlock(update);
   }
 }
 
 - (void)downloadDataFromURL:(NSURL *)url
+               extraHeaders:(NSDictionary *)extraHeaders
                successBlock:(EXUpdatesFileDownloaderSuccessBlock)successBlock
                  errorBlock:(EXUpdatesFileDownloaderErrorBlock)errorBlock
 {
-  // pass any custom cache policy onto this specific request
-  NSURLRequestCachePolicy cachePolicy = _sessionConfiguration ? _sessionConfiguration.requestCachePolicy : NSURLRequestUseProtocolCachePolicy;
-
-  NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url cachePolicy:cachePolicy timeoutInterval:EXUpdatesDefaultTimeoutInterval];
-  [self _setHTTPHeaderFields:request];
-
+  NSURLRequest *request = [self createGenericRequestWithURL:url extraHeaders:extraHeaders];
   [self _downloadDataWithRequest:request successBlock:successBlock errorBlock:errorBlock];
 }
 
@@ -265,7 +430,7 @@ NSTimeInterval const EXUpdatesDefaultTimeoutInterval = 60;
     }
 
     if (error) {
-      errorBlock(error, response);
+      errorBlock(error);
     } else {
       successBlock(data, response);
     }
@@ -297,7 +462,12 @@ NSTimeInterval const EXUpdatesDefaultTimeoutInterval = 60;
 }
 
 - (void)_setHTTPHeaderFields:(NSMutableURLRequest *)request
+                extraHeaders:(NSDictionary *)extraHeaders
 {
+  for (NSString *key in extraHeaders) {
+    [request setValue:extraHeaders[key] forHTTPHeaderField:key];
+  }
+  
   [request setValue:@"ios" forHTTPHeaderField:@"Expo-Platform"];
   [request setValue:@"1" forHTTPHeaderField:@"Expo-API-Version"];
   [request setValue:@"BARE" forHTTPHeaderField:@"Expo-Updates-Environment"];

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesRemoteAppLoader.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesRemoteAppLoader.m
@@ -73,7 +73,7 @@ static NSString * const EXUpdatesRemoteAppLoaderErrorDomain = @"EXUpdatesRemoteA
     [self->_downloader downloadManifestFromURL:url withDatabase:self.database extraHeaders:extraHeaders successBlock:^(EXUpdatesUpdate *update) {
       self->_remoteUpdate = update;
       [self startLoadingFromManifest:update];
-    } errorBlock:^(NSError *error, NSURLResponse *response) {
+    } errorBlock:^(NSError *error) {
       if (self.errorBlock) {
         self.errorBlock(error);
       }
@@ -97,11 +97,15 @@ static NSString * const EXUpdatesRemoteAppLoaderErrorDomain = @"EXUpdatesRemoteA
         return;
       }
 
-      [self->_downloader downloadFileFromURL:asset.url toPath:[urlOnDisk path] successBlock:^(NSData *data, NSURLResponse *response) {
+      [self->_downloader downloadFileFromURL:asset.url
+                                      toPath:[urlOnDisk path]
+                                extraHeaders:asset.extraRequestHeaders ?: [NSDictionary new]
+                                successBlock:^(NSData *data, NSURLResponse *response) {
         dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
           [self handleAssetDownloadWithData:data response:response asset:asset];
         });
-      } errorBlock:^(NSError *error, NSURLResponse *response) {
+      }
+                                  errorBlock:^(NSError *error) {
         dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
           [self handleAssetDownloadWithError:error asset:asset];
         });

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesRemoteAppLoader.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesRemoteAppLoader.m
@@ -99,7 +99,7 @@ static NSString * const EXUpdatesRemoteAppLoaderErrorDomain = @"EXUpdatesRemoteA
 
       [self->_downloader downloadFileFromURL:asset.url
                                       toPath:[urlOnDisk path]
-                                extraHeaders:asset.extraRequestHeaders ?: [NSDictionary new]
+                                extraHeaders:asset.extraRequestHeaders ?: @{}
                                 successBlock:^(NSData *data, NSURLResponse *response) {
         dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
           [self handleAssetDownloadWithData:data response:response asset:asset];

--- a/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.m
+++ b/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.m
@@ -84,13 +84,14 @@ static NSString * const EXUpdatesDatabaseStaticBuildDataKey = @"staticBuildData"
     NSAssert(asset.filename, @"asset filename should be nonnull");
     NSAssert(asset.contentHash, @"asset contentHash should be nonnull");
 
-    NSString * const assetInsertSql = @"INSERT OR REPLACE INTO \"assets\" (\"key\", \"url\", \"headers\", \"type\", \"metadata\", \"download_time\", \"relative_path\", \"hash\", \"hash_type\", \"marked_for_deletion\")\
-    VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, 0);";
+    NSString * const assetInsertSql = @"INSERT OR REPLACE INTO \"assets\" (\"key\", \"url\", \"headers\", \"extra_request_headers\", \"type\", \"metadata\", \"download_time\", \"relative_path\", \"hash\", \"hash_type\", \"marked_for_deletion\")\
+    VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, 0);";
     if ([self _executeSql:assetInsertSql
                  withArgs:@[
                           asset.key ?: [NSNull null],
                           asset.url ? asset.url.absoluteString : [NSNull null],
                           asset.headers ?: [NSNull null],
+                          asset.extraRequestHeaders ?: [NSNull null],
                           asset.type,
                           asset.metadata ?: [NSNull null],
                           asset.downloadTime,
@@ -164,11 +165,12 @@ static NSString * const EXUpdatesDatabaseStaticBuildDataKey = @"staticBuildData"
   NSAssert(asset.filename, @"asset filename should be nonnull");
   NSAssert(asset.contentHash, @"asset contentHash should be nonnull");
 
-  NSString * const assetUpdateSql = @"UPDATE \"assets\" SET \"headers\" = ?2, \"type\" = ?3, \"metadata\" = ?4, \"download_time\" = ?5, \"relative_path\" = ?6, \"hash\" = ?7, \"url\" = ?8 WHERE \"key\" = ?1;";
+  NSString * const assetUpdateSql = @"UPDATE \"assets\" SET \"headers\" = ?2, \"extra_request_headers\" = ?2, \"type\" = ?3, \"metadata\" = ?4, \"download_time\" = ?5, \"relative_path\" = ?6, \"hash\" = ?7, \"url\" = ?8 WHERE \"key\" = ?1;";
   [self _executeSql:assetUpdateSql
            withArgs:@[
                       asset.key ?: [NSNull null],
                       asset.headers ?: [NSNull null],
+                      asset.extraRequestHeaders ?: [NSNull null],
                       asset.type,
                       asset.metadata ?: [NSNull null],
                       asset.downloadTime,
@@ -182,10 +184,21 @@ static NSString * const EXUpdatesDatabaseStaticBuildDataKey = @"staticBuildData"
 - (void)mergeAsset:(EXUpdatesAsset *)asset withExistingEntry:(EXUpdatesAsset *)existingAsset error:(NSError ** _Nullable)error
 {
   // if the existing entry came from an embedded manifest, it may not have a URL in the database
-  if (asset.url && !existingAsset.url) {
+  BOOL shouldUpdate = false;
+  if (asset.url && (!existingAsset.url || ![asset.url isEqual:existingAsset.url])) {
     existingAsset.url = asset.url;
+    shouldUpdate = true;
+  }
+  
+  if (asset.extraRequestHeaders && (!existingAsset.extraRequestHeaders || ![asset.extraRequestHeaders isEqualToDictionary:existingAsset.extraRequestHeaders])) {
+    existingAsset.extraRequestHeaders = asset.extraRequestHeaders;
+    shouldUpdate = true;
+  }
+  
+  if (shouldUpdate) {
     [self updateAsset:existingAsset error:error];
   }
+  
   // all other properties should be overridden by database values
   asset.filename = existingAsset.filename;
   asset.contentHash = existingAsset.contentHash;
@@ -592,12 +605,20 @@ static NSString * const EXUpdatesDatabaseStaticBuildDataKey = @"staticBuildData"
 
 - (EXUpdatesAsset *)_assetWithRow:(NSDictionary *)row
 {
-  NSError *error;
+  NSError *metadataDeserializationError;
   id metadata = nil;
   id rowMetadata = row[@"metadata"];
   if ([rowMetadata isKindOfClass:[NSString class]]) {
-    metadata = [NSJSONSerialization JSONObjectWithData:[(NSString *)rowMetadata dataUsingEncoding:NSUTF8StringEncoding] options:kNilOptions error:&error];
-    NSAssert(!error && metadata && [metadata isKindOfClass:[NSDictionary class]], @"Asset metadata should be a valid JSON object");
+    metadata = [NSJSONSerialization JSONObjectWithData:[(NSString *)rowMetadata dataUsingEncoding:NSUTF8StringEncoding] options:kNilOptions error:&metadataDeserializationError];
+    NSAssert(!metadataDeserializationError && metadata && [metadata isKindOfClass:[NSDictionary class]], @"Asset metadata should be a valid JSON object");
+  }
+  
+  NSError *extraRequestHeadersDeserializationError;
+  id extraRequestHeaders = nil;
+  id rowExtraRequestHeaders = row[@"extra_request_headers"];
+  if ([rowExtraRequestHeaders isKindOfClass:[NSString class]]) {
+    extraRequestHeaders = [NSJSONSerialization JSONObjectWithData:[(NSString *)rowExtraRequestHeaders dataUsingEncoding:NSUTF8StringEncoding] options:kNilOptions error:&extraRequestHeadersDeserializationError];
+    NSAssert(!extraRequestHeadersDeserializationError && extraRequestHeaders && [extraRequestHeaders isKindOfClass:[NSDictionary class]], @"Asset extra_request_headers should be a valid JSON object");
   }
 
   id launchAssetId = row[@"launch_asset_id"];
@@ -614,6 +635,7 @@ static NSString * const EXUpdatesDatabaseStaticBuildDataKey = @"staticBuildData"
   EXUpdatesAsset *asset = [[EXUpdatesAsset alloc] initWithKey:key type:row[@"type"]];
   asset.assetId = [(NSNumber *)row[@"id"] unsignedIntegerValue];
   asset.url = url;
+  asset.extraRequestHeaders = extraRequestHeaders;
   asset.downloadTime = [EXUpdatesDatabaseUtils dateFromUnixTimeMilliseconds:(NSNumber *)row[@"download_time"]];
   asset.filename = row[@"relative_path"];
   asset.contentHash = row[@"hash"];

--- a/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.m
+++ b/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.m
@@ -165,7 +165,7 @@ static NSString * const EXUpdatesDatabaseStaticBuildDataKey = @"staticBuildData"
   NSAssert(asset.filename, @"asset filename should be nonnull");
   NSAssert(asset.contentHash, @"asset contentHash should be nonnull");
 
-  NSString * const assetUpdateSql = @"UPDATE \"assets\" SET \"headers\" = ?2, \"extra_request_headers\" = ?2, \"type\" = ?3, \"metadata\" = ?4, \"download_time\" = ?5, \"relative_path\" = ?6, \"hash\" = ?7, \"url\" = ?8 WHERE \"key\" = ?1;";
+  NSString * const assetUpdateSql = @"UPDATE \"assets\" SET \"headers\" = ?2, \"extra_request_headers\" = ?3, \"type\" = ?4, \"metadata\" = ?5, \"download_time\" = ?6, \"relative_path\" = ?7, \"hash\" = ?8, \"url\" = ?9 WHERE \"key\" = ?1;";
   [self _executeSql:assetUpdateSql
            withArgs:@[
                       asset.key ?: [NSNull null],

--- a/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabaseInitialization.m
+++ b/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabaseInitialization.m
@@ -8,7 +8,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 static NSString * const EXUpdatesDatabaseInitializationErrorDomain = @"EXUpdatesDatabaseInitialization";
-static NSString * const EXUpdatesDatabaseLatestFilename = @"expo-v7.db";
+static NSString * const EXUpdatesDatabaseLatestFilename = @"expo-v8.db";
 
 static NSString * const EXUpdatesDatabaseInitializationLatestSchema = @"\
 CREATE TABLE \"updates\" (\
@@ -31,6 +31,7 @@ CREATE TABLE \"assets\" (\
 \"url\"  TEXT,\
 \"key\"  TEXT UNIQUE,\
 \"headers\"  TEXT,\
+\"extra_request_headers\"  TEXT,\
 \"type\"  TEXT NOT NULL,\
 \"metadata\"  TEXT,\
 \"download_time\"  INTEGER NOT NULL,\

--- a/packages/expo-updates/ios/EXUpdates/Database/Migrations/EXUpdatesDatabaseMigration7To8.h
+++ b/packages/expo-updates/ios/EXUpdates/Database/Migrations/EXUpdatesDatabaseMigration7To8.h
@@ -1,0 +1,11 @@
+//  Copyright © 2021 650 Industries. All rights reserved.
+
+#import <EXUpdates/EXUpdatesDatabaseMigration.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface EXUpdatesDatabaseMigration7To8 : NSObject <EXUpdatesDatabaseMigration>
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/ios/EXUpdates/Database/Migrations/EXUpdatesDatabaseMigration7To8.m
+++ b/packages/expo-updates/ios/EXUpdates/Database/Migrations/EXUpdatesDatabaseMigration7To8.m
@@ -1,0 +1,40 @@
+//  Copyright © 2021 650 Industries. All rights reserved.
+
+#import <EXUpdates/EXUpdatesDatabaseMigration7To8.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+static NSString * const EXUpdatesDatabaseV7Filename = @"expo-v7.db";
+
+@implementation EXUpdatesDatabaseMigration7To8
+
+- (NSString *)filename
+{
+  return EXUpdatesDatabaseV7Filename;
+}
+
+- (BOOL)runMigrationOnDatabase:(struct sqlite3 *)db error:(NSError ** _Nullable)error
+{
+  // https://www.sqlite.org/lang_altertable.html#otheralter
+  if (sqlite3_exec(db, "PRAGMA foreign_keys=OFF;", NULL, NULL, NULL) != SQLITE_OK) return NO;
+  if (sqlite3_exec(db, "BEGIN;", NULL, NULL, NULL) != SQLITE_OK) return NO;
+
+  if (![self _safeExecOrRollback:db sql:@"ALTER TABLE \"assets\" ADD COLUMN \"extra_request_headers\" TEXT"]) return NO;
+
+  if (sqlite3_exec(db, "COMMIT;", NULL, NULL, NULL) != SQLITE_OK) return NO;
+  if (sqlite3_exec(db, "PRAGMA foreign_keys=ON;", NULL, NULL, NULL) != SQLITE_OK) return NO;
+  return YES;
+}
+
+- (BOOL)_safeExecOrRollback:(struct sqlite3 *)db sql:(NSString *)sql
+{
+  if (sqlite3_exec(db, sql.UTF8String, NULL, NULL, NULL) != SQLITE_OK) {
+    sqlite3_exec(db, "ROLLBACK;", NULL, NULL, NULL);
+    return NO;
+  }
+  return YES;
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/ios/EXUpdates/Database/Migrations/EXUpdatesDatabaseMigration7To8.m
+++ b/packages/expo-updates/ios/EXUpdates/Database/Migrations/EXUpdatesDatabaseMigration7To8.m
@@ -16,22 +16,7 @@ static NSString * const EXUpdatesDatabaseV7Filename = @"expo-v7.db";
 - (BOOL)runMigrationOnDatabase:(struct sqlite3 *)db error:(NSError ** _Nullable)error
 {
   // https://www.sqlite.org/lang_altertable.html#otheralter
-  if (sqlite3_exec(db, "PRAGMA foreign_keys=OFF;", NULL, NULL, NULL) != SQLITE_OK) return NO;
-  if (sqlite3_exec(db, "BEGIN;", NULL, NULL, NULL) != SQLITE_OK) return NO;
-
-  if (![self _safeExecOrRollback:db sql:@"ALTER TABLE \"assets\" ADD COLUMN \"extra_request_headers\" TEXT"]) return NO;
-
-  if (sqlite3_exec(db, "COMMIT;", NULL, NULL, NULL) != SQLITE_OK) return NO;
-  if (sqlite3_exec(db, "PRAGMA foreign_keys=ON;", NULL, NULL, NULL) != SQLITE_OK) return NO;
-  return YES;
-}
-
-- (BOOL)_safeExecOrRollback:(struct sqlite3 *)db sql:(NSString *)sql
-{
-  if (sqlite3_exec(db, sql.UTF8String, NULL, NULL, NULL) != SQLITE_OK) {
-    sqlite3_exec(db, "ROLLBACK;", NULL, NULL, NULL);
-    return NO;
-  }
+  if (sqlite3_exec(db, @"ALTER TABLE \"assets\" ADD COLUMN \"extra_request_headers\" TEXT".UTF8String, NULL, NULL, NULL) != SQLITE_OK) return NO;
   return YES;
 }
 

--- a/packages/expo-updates/ios/EXUpdates/Database/Migrations/EXUpdatesDatabaseMigrationRegistry.m
+++ b/packages/expo-updates/ios/EXUpdates/Database/Migrations/EXUpdatesDatabaseMigrationRegistry.m
@@ -5,6 +5,7 @@
 #import <EXUpdates/EXUpdatesDatabaseMigration4To5.h>
 #import <EXUpdates/EXUpdatesDatabaseMigration5To6.h>
 #import <EXUpdates/EXUpdatesDatabaseMigration6To7.h>
+#import <EXUpdates/EXUpdatesDatabaseMigration7To8.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -16,7 +17,8 @@ NS_ASSUME_NONNULL_BEGIN
   return @[
     [EXUpdatesDatabaseMigration4To5 new],
     [EXUpdatesDatabaseMigration5To6 new],
-    [EXUpdatesDatabaseMigration6To7 new]
+    [EXUpdatesDatabaseMigration6To7 new],
+    [EXUpdatesDatabaseMigration7To8 new]
   ];
 }
 

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesModule.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesModule.m
@@ -115,7 +115,7 @@ EX_EXPORT_METHOD_AS(checkForUpdateAsync,
         @"isAvailable": @(NO)
       });
     }
-  } errorBlock:^(NSError *error, NSURLResponse *response) {
+  } errorBlock:^(NSError *error) {
     reject(@"ERR_UPDATES_CHECK", error.localizedDescription, error);
   }];
 }

--- a/packages/expo-updates/ios/EXUpdates/Multipart/EXUpdatesMultipartStreamReader.h
+++ b/packages/expo-updates/ios/EXUpdates/Multipart/EXUpdatesMultipartStreamReader.h
@@ -1,0 +1,20 @@
+//  Copyright © 2019 650 Industries. All rights reserved.
+
+#import <Foundation/Foundation.h>
+#import <React/RCTMultipartStreamReader.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * Fork of {@link RCTMultipartStreamReader} that doesn't necessarily
+ * expect a preamble (first boundary is not necessarily preceded by CRLF).
+ */
+@interface EXUpdatesMultipartStreamReader : NSObject
+
+- (instancetype)initWithInputStream:(NSInputStream *)stream boundary:(NSString *)boundary;
+- (BOOL)readAllPartsWithCompletionCallback:(RCTMultipartCallback)callback
+                          progressCallback:(RCTMultipartProgressCallback)progressCallback;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/ios/EXUpdates/Multipart/EXUpdatesMultipartStreamReader.h
+++ b/packages/expo-updates/ios/EXUpdates/Multipart/EXUpdatesMultipartStreamReader.h
@@ -12,8 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface EXUpdatesMultipartStreamReader : NSObject
 
 - (instancetype)initWithInputStream:(NSInputStream *)stream boundary:(NSString *)boundary;
-- (BOOL)readAllPartsWithCompletionCallback:(RCTMultipartCallback)callback
-                          progressCallback:(RCTMultipartProgressCallback)progressCallback;
+- (BOOL)readAllPartsWithCompletionCallback:(RCTMultipartCallback)callback;
 
 @end
 

--- a/packages/expo-updates/ios/EXUpdates/Multipart/EXUpdatesMultipartStreamReader.m
+++ b/packages/expo-updates/ios/EXUpdates/Multipart/EXUpdatesMultipartStreamReader.m
@@ -1,0 +1,136 @@
+//  Copyright © 2019 650 Industries. All rights reserved.
+
+#import <EXUpdates/EXUpdatesMultipartStreamReader.h>
+
+#define CRLF @"\r\n"
+
+@implementation EXUpdatesMultipartStreamReader {
+  __strong NSInputStream *_stream;
+  __strong NSString *_boundary;
+}
+
+- (instancetype)initWithInputStream:(NSInputStream *)stream boundary:(NSString *)boundary
+{
+  if (self = [super init]) {
+    _stream = stream;
+    _boundary = boundary;
+  }
+  return self;
+}
+
+- (NSDictionary<NSString *, NSString *> *)parseHeaders:(NSData *)data
+{
+  NSMutableDictionary *headers = [NSMutableDictionary new];
+  NSString *text = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+  NSArray<NSString *> *lines = [text componentsSeparatedByString:CRLF];
+  for (NSString *line in lines) {
+    NSUInteger location = [line rangeOfString:@":"].location;
+    if (location == NSNotFound) {
+      continue;
+    }
+    NSString *key = [line substringToIndex:location];
+    NSString *value = [[line substringFromIndex:location + 1] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    [headers setValue:value forKey:key];
+  }
+  return headers;
+}
+
+- (void)emitChunk:(NSData *)data headers:(NSDictionary *)headers callback:(RCTMultipartCallback)callback done:(BOOL)done
+{
+  NSData *marker = [CRLF CRLF dataUsingEncoding:NSUTF8StringEncoding];
+  NSRange range = [data rangeOfData:marker options:0 range:NSMakeRange(0, data.length)];
+  if (range.location == NSNotFound) {
+    callback(nil, data, done);
+  } else if (headers != nil) {
+    // If headers were parsed already just use that to avoid doing it twice.
+    NSInteger bodyStart = range.location + marker.length;
+    NSData *bodyData = [data subdataWithRange:NSMakeRange(bodyStart, data.length - bodyStart)];
+    callback(headers, bodyData, done);
+  } else {
+    NSData *headersData = [data subdataWithRange:NSMakeRange(0, range.location)];
+    NSInteger bodyStart = range.location + marker.length;
+    NSData *bodyData = [data subdataWithRange:NSMakeRange(bodyStart, data.length - bodyStart)];
+    callback([self parseHeaders:headersData], bodyData, done);
+  }
+}
+
+- (BOOL)readAllPartsWithCompletionCallback:(RCTMultipartCallback)callback
+                          progressCallback:(RCTMultipartProgressCallback)progressCallback
+{
+  NSInteger chunkStart = 0;
+  NSInteger bytesSeen = 0;
+
+  // first delimiter doesn't necessarily need to be preceded by CRLF (boundary can be first thing in body)
+  NSData *firstDelimiter = [[NSString stringWithFormat:@"--%@%@", _boundary, CRLF] dataUsingEncoding:NSUTF8StringEncoding];
+  NSData *restDelimiter = [[NSString stringWithFormat:@"%@--%@%@", CRLF, _boundary, CRLF] dataUsingEncoding:NSUTF8StringEncoding];
+  NSData *delimiter = firstDelimiter;
+  
+  NSData *closeDelimiter = [[NSString stringWithFormat:@"%@--%@--%@", CRLF, _boundary, CRLF] dataUsingEncoding:NSUTF8StringEncoding];
+  NSMutableData *content = [[NSMutableData alloc] initWithCapacity:1];
+  NSDictionary *currentHeaders = nil;
+  NSUInteger currentHeadersLength = 0;
+
+  const NSUInteger bufferLen = 4 * 1024;
+  uint8_t buffer[bufferLen];
+
+  [_stream open];
+  while (true) {
+    BOOL isCloseDelimiter = NO;
+    // Search only a subset of chunk that we haven't seen before + few bytes
+    // to allow for the edge case when the delimiter is cut by read call
+    NSInteger searchStart = MAX(bytesSeen - (NSInteger)closeDelimiter.length, chunkStart);
+    NSRange remainingBufferRange = NSMakeRange(searchStart, content.length - searchStart);
+
+    // Check for delimiters.
+    NSRange range = [content rangeOfData:delimiter options:0 range:remainingBufferRange];
+    if (range.location == NSNotFound) {
+      isCloseDelimiter = YES;
+      range = [content rangeOfData:closeDelimiter options:0 range:remainingBufferRange];
+    }
+
+    if (range.location == NSNotFound) {
+      if (currentHeaders == nil) {
+        // Check for the headers delimiter.
+        NSData *headersMarker = [CRLF CRLF dataUsingEncoding:NSUTF8StringEncoding];
+        NSRange headersRange = [content rangeOfData:headersMarker options:0 range:remainingBufferRange];
+        if (headersRange.location != NSNotFound) {
+          NSData *headersData = [content subdataWithRange:NSMakeRange(chunkStart, headersRange.location - chunkStart)];
+          currentHeadersLength = headersData.length;
+          currentHeaders = [self parseHeaders:headersData];
+        }
+      }
+
+      bytesSeen = content.length;
+      NSInteger bytesRead = [_stream read:buffer maxLength:bufferLen];
+      if (bytesRead <= 0 || _stream.streamError) {
+        return NO;
+      }
+      [content appendBytes:buffer length:bytesRead];
+      continue;
+    }
+
+    NSInteger chunkEnd = range.location;
+    NSInteger length = chunkEnd - chunkStart;
+    bytesSeen = chunkEnd;
+
+    // Ignore preamble
+    if (chunkStart > 0) {
+      NSData *chunk = [content subdataWithRange:NSMakeRange(chunkStart, length)];
+      [self emitChunk:chunk headers:currentHeaders callback:callback done:isCloseDelimiter];
+      currentHeaders = nil;
+      currentHeadersLength = 0;
+    }
+
+    if (isCloseDelimiter) {
+      return YES;
+    }
+
+    chunkStart = chunkEnd + delimiter.length;
+    
+    if (delimiter == firstDelimiter) {
+      delimiter = restDelimiter;
+    }
+  }
+}
+
+@end

--- a/packages/expo-updates/ios/EXUpdates/Multipart/EXUpdatesMultipartStreamReader.m
+++ b/packages/expo-updates/ios/EXUpdates/Multipart/EXUpdatesMultipartStreamReader.m
@@ -102,6 +102,7 @@
       bytesSeen = content.length;
       NSInteger bytesRead = [_stream read:buffer maxLength:bufferLen];
       if (bytesRead <= 0 || _stream.streamError) {
+        [_stream close];
         return NO;
       }
       [content appendBytes:buffer length:bytesRead];
@@ -121,6 +122,7 @@
     }
 
     if (isCloseDelimiter) {
+      [_stream close];
       return YES;
     }
 
@@ -130,7 +132,6 @@
       delimiter = restDelimiter;
     }
   }
-  [_stream close];
 }
 
 @end

--- a/packages/expo-updates/ios/EXUpdates/Multipart/EXUpdatesMultipartStreamReader.m
+++ b/packages/expo-updates/ios/EXUpdates/Multipart/EXUpdatesMultipartStreamReader.m
@@ -55,7 +55,6 @@
 }
 
 - (BOOL)readAllPartsWithCompletionCallback:(RCTMultipartCallback)callback
-                          progressCallback:(RCTMultipartProgressCallback)progressCallback
 {
   NSInteger chunkStart = 0;
   NSInteger bytesSeen = 0;
@@ -131,6 +130,7 @@
       delimiter = restDelimiter;
     }
   }
+  [_stream close];
 }
 
 @end

--- a/packages/expo-updates/ios/EXUpdates/Multipart/EXUpdatesParameterParser.h
+++ b/packages/expo-updates/ios/EXUpdates/Multipart/EXUpdatesParameterParser.h
@@ -1,0 +1,23 @@
+//  Copyright © 2019 650 Industries. All rights reserved.
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * Derivation of ParameterParser class in the apache commons file upload
+ * project: https://commons.apache.org/proper/commons-fileupload/
+ *
+ * A simple parser intended to parse sequences of name/value pairs.
+ *
+ * Parameter values are expected to be enclosed in quotes if they
+ * contain unsafe characters, such as '=' characters or separators.
+ * Parameter values are optional and can be omitted.
+ */
+@interface EXUpdatesParameterParser : NSObject
+
+- (NSDictionary<NSString *, NSString *> *)parseParameterString:(NSString *)parameterString withDelimiter:(NSString *)delimiter;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/ios/EXUpdates/Multipart/EXUpdatesParameterParser.h
+++ b/packages/expo-updates/ios/EXUpdates/Multipart/EXUpdatesParameterParser.h
@@ -16,7 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface EXUpdatesParameterParser : NSObject
 
-- (NSDictionary<NSString *, NSString *> *)parseParameterString:(NSString *)parameterString withDelimiter:(NSString *)delimiter;
+- (NSDictionary<NSString *, NSString *> *)parseParameterString:(NSString *)parameterString withDelimiter:(unichar)delimiter;
 
 @end
 

--- a/packages/expo-updates/ios/EXUpdates/Multipart/EXUpdatesParameterParser.m
+++ b/packages/expo-updates/ios/EXUpdates/Multipart/EXUpdatesParameterParser.m
@@ -1,0 +1,143 @@
+//  Copyright © 2019 650 Industries. All rights reserved.
+
+#import <EXUpdates/EXUpdatesParameterParser.h>
+
+@interface EXUpdatesParameterParser (Private)
+@end
+
+@implementation EXUpdatesParameterParser {
+  // String to be parsed.
+  NSString *_chars;
+  
+  // Current position in the string.
+  int _pos;
+  
+  // Maximum position in the string.
+  NSUInteger _len;
+  
+  // Start of a token.
+  int _i1;
+  
+  // End of a token.
+  int _i2;
+}
+
+/**
+ * A helper method to process the parsed token. This method removes
+ * leading and trailing blanks as well as enclosing quotation marks,
+ * when necessary.
+ */
+- (nullable NSString *)getTokenWithQuoted:(BOOL)quoted {
+  // Trim leading white spaces
+  while ((_i1 < _i2) && [[NSCharacterSet whitespaceCharacterSet] characterIsMember:[_chars characterAtIndex:_i1]]) {
+    _i1++;
+  }
+  
+  // Trim trailing white spaces
+  while ((_i2 > _i1) && [[NSCharacterSet whitespaceCharacterSet] characterIsMember:[_chars characterAtIndex:(_i2 - 1)]]) {
+      _i2--;
+  }
+  
+  // Strip away quotation marks if necessary
+  if (quoted
+      && ((_i2 - _i1) >= 2)
+      && ([_chars characterAtIndex:_i1] == '"')
+      && ([_chars characterAtIndex:(_i2 - 1)] == '"')) {
+      _i1++;
+      _i2--;
+  }
+  
+  NSString *result = nil;
+  if (_i2 > _i1) {
+    result = [_chars substringWithRange:NSMakeRange(_i1, _i2 - _i1)];
+  }
+  return result;
+}
+
+/**
+ * Parses out a token until any of the given terminators
+ * is encountered.
+ */
+- (NSString *)parseTokenWithTerminators:(NSCharacterSet *)terminators {
+  unichar ch;
+  _i1 = _pos;
+  _i2 = _pos;
+  while ([self hasChar]) {
+    ch = [_chars characterAtIndex:_pos];
+    if ([terminators characterIsMember:ch]) {
+      break;
+    }
+    _i2++;
+    _pos++;
+  }
+  return [self getTokenWithQuoted:false];
+}
+
+/**
+ * Parses out a token until any of the given terminators
+ * is encountered outside the quotation marks.
+ */
+- (NSString *)parseQuotedTokenWithTerminators:(NSCharacterSet *)terminators {
+  unichar ch;
+  _i1 = _pos;
+  _i2 = _pos;
+  BOOL quoted = false;
+  BOOL charEscaped = false;
+  
+  while ([self hasChar]) {
+    ch = [_chars characterAtIndex:_pos];
+    if (!quoted && [terminators characterIsMember:ch]) {
+      break;
+    }
+    if (!charEscaped && ch == '"') {
+      quoted = !quoted;
+    }
+    charEscaped = (!charEscaped && ch == '\\');
+    _i2++;
+    _pos++;
+  }
+  
+  return [self getTokenWithQuoted:true];
+}
+
+/**
+ * Are there any characters left to parse?
+ */
+- (BOOL)hasChar {
+  return _pos < _len;
+}
+
+/**
+ * Extracts a map of name/value pairs from the given string. Names are expected to be unique.
+ */
+- (NSDictionary<NSString *, NSString *> *)parseParameterString:(NSString *)parameterString withDelimiter:(NSString *)delimiter {
+  _chars = parameterString;
+  _len = parameterString.length;
+  
+  NSMutableDictionary *params = [NSMutableDictionary new];
+  
+  NSString *paramName;
+  NSString *paramValue;
+  
+  while ([self hasChar]) {
+    paramName = [self parseTokenWithTerminators:[NSCharacterSet characterSetWithCharactersInString:[NSString stringWithFormat:@"%@=", delimiter]]];
+    paramValue = nil;
+    
+    if ([self hasChar] && [_chars characterAtIndex:_pos] == '=') {
+      _pos++; // skip '='
+      paramValue = [self parseQuotedTokenWithTerminators:[NSCharacterSet characterSetWithCharactersInString:delimiter]];
+    }
+    
+    if ([self hasChar] && ([_chars characterAtIndex:_pos] == [delimiter characterAtIndex:0])) {
+      _pos++; // skip separator
+    }
+    
+    if (paramName != nil && paramName.length > 0) {
+      [params setValue:(paramValue ?: [NSNull null]) forKey:paramName];
+    }
+  }
+  
+  return params;
+}
+
+@end

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesNewUpdate.h
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesNewUpdate.h
@@ -8,7 +8,8 @@ NS_ASSUME_NONNULL_BEGIN
 @interface EXUpdatesNewUpdate : NSObject
 
 + (EXUpdatesUpdate *)updateWithNewManifest:(EXManifestsNewManifest *)manifest
-                                  response:(nullable NSURLResponse *)response
+                                   headers:(NSDictionary *)headers
+                                extensions:(NSDictionary *)extensions
                                     config:(EXUpdatesConfig *)config
                                   database:(EXUpdatesDatabase *)database;
 

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesNewUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesNewUpdate.m
@@ -12,12 +12,12 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation EXUpdatesNewUpdate
 
 + (EXUpdatesUpdate *)updateWithNewManifest:(EXManifestsNewManifest *)manifest
-                                   headers:(NSDictionary *)headersDictionary
+                                   headers:(NSDictionary *)headers
                                 extensions:(NSDictionary *)extensions
                                     config:(EXUpdatesConfig *)config
                                   database:(EXUpdatesDatabase *)database
 {
-  NSDictionary *assetHeaders = [extensions nullableDictionaryForKey:@"assetRequestHeaders"] ?: [NSDictionary new];
+  NSDictionary *assetHeaders = [extensions nullableDictionaryForKey:@"assetRequestHeaders"] ?: @{};
   
   EXUpdatesUpdate *update = [[EXUpdatesUpdate alloc] initWithManifest:manifest
                                                                config:config
@@ -91,8 +91,8 @@ NS_ASSUME_NONNULL_BEGIN
   update.bundleUrl = bundleUrl;
   update.assets = processedAssets;
   update.manifestJSON = manifest.rawManifestJSON;
-  update.serverDefinedHeaders = [[self class] dictionaryWithStructuredHeader:headersDictionary[@"expo-server-defined-headers"]];
-  update.manifestFilters = [[self class] dictionaryWithStructuredHeader:headersDictionary[@"expo-manifest-filters"]];
+  update.serverDefinedHeaders = [[self class] dictionaryWithStructuredHeader:headers[@"expo-server-defined-headers"]];
+  update.manifestFilters = [[self class] dictionaryWithStructuredHeader:headers[@"expo-manifest-filters"]];
   return update;
 }
 

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate.h
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate.h
@@ -76,7 +76,8 @@ typedef NS_ENUM(NSInteger, EXUpdatesUpdateStatus) {
                     database:(EXUpdatesDatabase *)database;
 
 + (instancetype)updateWithManifest:(NSDictionary *)manifest
-                          response:(nullable NSURLResponse *)response
+                           headers:(NSDictionary *)headers
+                        extensions:(NSDictionary *)extensions
                             config:(EXUpdatesConfig *)config
                           database:(EXUpdatesDatabase *)database
                              error:(NSError **)error;

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate.m
@@ -63,22 +63,12 @@ NSString * const EXUpdatesUpdateErrorDomain = @"EXUpdatesUpdate";
 }
 
 + (instancetype)updateWithManifest:(NSDictionary *)manifest
-                          response:(nullable NSURLResponse *)response
+                           headers:(NSDictionary *)headerDictionary
+                        extensions:(NSDictionary *)extensions
                             config:(EXUpdatesConfig *)config
                           database:(EXUpdatesDatabase *)database
                              error:(NSError ** _Nullable)error
 {
-  if (![response isKindOfClass:[NSHTTPURLResponse class]]) {
-    if(error){
-      *error = [NSError errorWithDomain:EXUpdatesUpdateErrorDomain
-                                   code:1001
-                               userInfo:@{NSLocalizedDescriptionKey:@"response must be a NSHTTPURLResponse"}];
-    }
-    return nil;
-  }
-
-  NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
-  NSDictionary *headerDictionary = [httpResponse allHeaderFields];
   NSString *expoProtocolVersion = headerDictionary[@"expo-protocol-version"];
 
   if (expoProtocolVersion == nil) {
@@ -87,7 +77,8 @@ NSString * const EXUpdatesUpdateErrorDomain = @"EXUpdatesUpdate";
                                                   database:database];
   } else if (expoProtocolVersion.integerValue == 0) {
     return [EXUpdatesNewUpdate updateWithNewManifest:[[EXManifestsNewManifest alloc] initWithRawManifestJSON:manifest]
-                                            response:response
+                                             headers:headerDictionary
+                                          extensions:extensions
                                               config:config
                                             database:database];
   } else {

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate.m
@@ -63,13 +63,13 @@ NSString * const EXUpdatesUpdateErrorDomain = @"EXUpdatesUpdate";
 }
 
 + (instancetype)updateWithManifest:(NSDictionary *)manifest
-                           headers:(NSDictionary *)headerDictionary
+                           headers:(NSDictionary *)headers
                         extensions:(NSDictionary *)extensions
                             config:(EXUpdatesConfig *)config
                           database:(EXUpdatesDatabase *)database
                              error:(NSError ** _Nullable)error
 {
-  NSString *expoProtocolVersion = headerDictionary[@"expo-protocol-version"];
+  NSString *expoProtocolVersion = headers[@"expo-protocol-version"];
 
   if (expoProtocolVersion == nil) {
     return [EXUpdatesLegacyUpdate updateWithLegacyManifest:[[EXManifestsLegacyManifest alloc] initWithRawManifestJSON:manifest]
@@ -77,7 +77,7 @@ NSString * const EXUpdatesUpdateErrorDomain = @"EXUpdatesUpdate";
                                                   database:database];
   } else if (expoProtocolVersion.integerValue == 0) {
     return [EXUpdatesNewUpdate updateWithNewManifest:[[EXManifestsNewManifest alloc] initWithRawManifestJSON:manifest]
-                                             headers:headerDictionary
+                                             headers:headers
                                           extensions:extensions
                                               config:config
                                             database:database];

--- a/packages/expo-updates/ios/Tests/EXUpdatesBuildDataTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesBuildDataTests.m
@@ -81,7 +81,7 @@ static NSString * const scopeKey = @"test";
   
   // start every test with an update
   dispatch_sync(_db.databaseQueue, ^{
-    EXUpdatesUpdate *update = [EXUpdatesNewUpdate updateWithNewManifest:_manifest response:nil config:_configChannelTest database:_db];
+    EXUpdatesUpdate *update = [EXUpdatesNewUpdate updateWithNewManifest:_manifest headers:@{} extensions:@{} config:_configChannelTest database:_db];
 
     NSError *updatesError;
     [_db addUpdate:update error:&updatesError];

--- a/packages/expo-updates/ios/Tests/EXUpdatesDatabaseInitializationTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesDatabaseInitializationTests.m
@@ -143,6 +143,53 @@ CREATE INDEX \"index_updates_launch_asset_id\" ON \"updates\" (\"launch_asset_id
 CREATE INDEX \"index_json_data_scope_key\" ON \"json_data\" (\"scope_key\")\
 ";
 
+static NSString * const EXUpdatesDatabaseV7Schema = @"\
+CREATE TABLE \"updates\" (\
+\"id\"  BLOB UNIQUE,\
+\"scope_key\"  TEXT NOT NULL,\
+\"commit_time\"  INTEGER NOT NULL,\
+\"runtime_version\"  TEXT NOT NULL,\
+\"launch_asset_id\" INTEGER,\
+\"manifest\"  TEXT,\
+\"status\"  INTEGER NOT NULL,\
+\"keep\"  INTEGER NOT NULL,\
+\"last_accessed\"  INTEGER NOT NULL,\
+\"successful_launch_count\"  INTEGER NOT NULL DEFAULT 0,\
+\"failed_launch_count\"  INTEGER NOT NULL DEFAULT 0,\
+PRIMARY KEY(\"id\"),\
+FOREIGN KEY(\"launch_asset_id\") REFERENCES \"assets\"(\"id\") ON DELETE CASCADE\
+);\
+CREATE TABLE \"assets\" (\
+\"id\"  INTEGER PRIMARY KEY AUTOINCREMENT,\
+\"url\"  TEXT,\
+\"key\"  TEXT UNIQUE,\
+\"headers\"  TEXT,\
+\"type\"  TEXT NOT NULL,\
+\"metadata\"  TEXT,\
+\"download_time\"  INTEGER NOT NULL,\
+\"relative_path\"  TEXT NOT NULL,\
+\"hash\"  BLOB NOT NULL,\
+\"hash_type\"  INTEGER NOT NULL,\
+\"marked_for_deletion\"  INTEGER NOT NULL\
+);\
+CREATE TABLE \"updates_assets\" (\
+\"update_id\"  BLOB NOT NULL,\
+\"asset_id\" INTEGER NOT NULL,\
+FOREIGN KEY(\"update_id\") REFERENCES \"updates\"(\"id\") ON DELETE CASCADE,\
+FOREIGN KEY(\"asset_id\") REFERENCES \"assets\"(\"id\") ON DELETE CASCADE\
+);\
+CREATE TABLE \"json_data\" (\
+\"id\" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,\
+\"key\" TEXT NOT NULL,\
+\"value\" TEXT NOT NULL,\
+\"last_updated\" INTEGER NOT NULL,\
+\"scope_key\" TEXT NOT NULL\
+);\
+CREATE UNIQUE INDEX \"index_updates_scope_key_commit_time\" ON \"updates\" (\"scope_key\", \"commit_time\");\
+CREATE INDEX \"index_updates_launch_asset_id\" ON \"updates\" (\"launch_asset_id\");\
+CREATE INDEX \"index_json_data_scope_key\" ON \"json_data\" (\"scope_key\")\
+";
+
 @interface EXUpdatesDatabaseInitializationTests : XCTestCase
 
 @property (nonatomic, strong) NSURL *testDatabaseDir;
@@ -593,7 +640,7 @@ CREATE INDEX \"index_json_data_scope_key\" ON \"json_data\" (\"scope_key\")\
 - (void)testMigration7To8 {
   sqlite3 *db;
   NSError *initializeError;
-  [EXUpdatesDatabaseInitialization initializeDatabaseWithSchema:EXUpdatesDatabaseV6Schema
+  [EXUpdatesDatabaseInitialization initializeDatabaseWithSchema:EXUpdatesDatabaseV7Schema
                                                        filename:@"expo-v7.db"
                                                     inDirectory:_testDatabaseDir
                                                   shouldMigrate:NO

--- a/packages/expo-updates/ios/Tests/EXUpdatesDatabaseInitializationTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesDatabaseInitializationTests.m
@@ -590,4 +590,46 @@ CREATE INDEX \"index_json_data_scope_key\" ON \"json_data\" (\"scope_key\")\
   XCTAssertEqual(0, [EXUpdatesDatabaseUtils executeSql:selectDeletedSql3 withArgs:nil onDatabase:migratedDb error:nil].count);
 }
 
+- (void)testMigration7To8 {
+  sqlite3 *db;
+  NSError *initializeError;
+  [EXUpdatesDatabaseInitialization initializeDatabaseWithSchema:EXUpdatesDatabaseV6Schema
+                                                       filename:@"expo-v7.db"
+                                                    inDirectory:_testDatabaseDir
+                                                  shouldMigrate:NO
+                                                     migrations:@[]
+                                                       database:&db
+                                                          error:&initializeError];
+  XCTAssertNil(initializeError);
+  
+  // insert test data
+  NSString * const insertAssetsSql = @"INSERT INTO \"assets\" (\"id\",\"url\",\"key\",\"headers\",\"type\",\"metadata\",\"download_time\",\"relative_path\",\"hash\",\"hash_type\",\"marked_for_deletion\") VALUES\
+  (2,'https://url.to/b56cf690e0afa93bd4dc7756d01edd3e','b56cf690e0afa93bd4dc7756d01edd3e.png',NULL,'image/png',NULL,1614137309295,'b56cf690e0afa93bd4dc7756d01edd3e.png','c4fdfc2ec388025067a0f755bda7731a0a868a2be79c84509f4de4e40d23161b',0,0),\
+  (3,'https://url.to/bundle-1614137308871','bundle-1614137308871',NULL,'application/javascript',NULL,1614137309513,'bundle-1614137308871','e4d658861e85e301fb89bcfc49c42738ebcc0f9d5c979e037556435f44a27aa2',0,0),\
+  (4,NULL,NULL,NULL,'js',NULL,1614137406588,'bundle-1614137401950','6ff4ee75b48a21c7a9ed98015ff6bfd0a47b94cd087c5e2258262e65af239952',0,0);";
+  
+  NSError *insertAssetsError;
+  [EXUpdatesDatabaseUtils executeSql:insertAssetsSql withArgs:nil onDatabase:db error:&insertAssetsError];
+  
+  XCTAssert(!insertAssetsError);
+
+  sqlite3_close(db);
+
+  // initialize a new database object the normal way and run migrations
+  sqlite3 *migratedDb;
+  NSError *migrateError;
+  // initialize without specifying migrations in order to run them all
+  [EXUpdatesDatabaseInitialization initializeDatabaseWithLatestSchemaInDirectory:_testDatabaseDir
+                                                                        database:&migratedDb
+                                                                           error:&migrateError];
+  XCTAssertNil(migrateError);
+  
+  NSString * const assetsSql1 = @"SELECT * FROM `assets` WHERE `id` = 2 AND `url` = 'https://url.to/b56cf690e0afa93bd4dc7756d01edd3e' AND `key` = 'b56cf690e0afa93bd4dc7756d01edd3e.png' AND `headers` IS NULL AND `type` = 'image/png' AND `metadata` IS NULL AND `download_time` = 1614137309295 AND `relative_path` = 'b56cf690e0afa93bd4dc7756d01edd3e.png' AND `hash` = 'c4fdfc2ec388025067a0f755bda7731a0a868a2be79c84509f4de4e40d23161b' AND `hash_type` = 0 AND `marked_for_deletion` = 0 AND `extra_request_headers` IS NULL";
+  XCTAssertEqual(1, [EXUpdatesDatabaseUtils executeSql:assetsSql1 withArgs:nil onDatabase:migratedDb error:nil].count);
+  NSString * const assetsSql2 = @"SELECT * FROM `assets` WHERE `id` = 3 AND `url` = 'https://url.to/bundle-1614137308871' AND `key` = 'bundle-1614137308871' AND `headers` IS NULL AND `type` = 'application/javascript' AND `metadata` IS NULL AND `download_time` = 1614137309513 AND `relative_path` = 'bundle-1614137308871' AND `hash` = 'e4d658861e85e301fb89bcfc49c42738ebcc0f9d5c979e037556435f44a27aa2' AND `hash_type` = 0 AND `marked_for_deletion` = 0 AND `extra_request_headers` IS NULL";
+  XCTAssertEqual(1, [EXUpdatesDatabaseUtils executeSql:assetsSql2 withArgs:nil onDatabase:migratedDb error:nil].count);
+  NSString * const assetsSql3 = @"SELECT * FROM `assets` WHERE `id` = 4 AND `url` IS NULL AND `key` IS NULL AND `headers` IS NULL AND `type` = 'js' AND `metadata` IS NULL AND `download_time` = 1614137406588 AND `relative_path` = 'bundle-1614137401950' AND `hash` = '6ff4ee75b48a21c7a9ed98015ff6bfd0a47b94cd087c5e2258262e65af239952' AND `hash_type` = 0 AND `marked_for_deletion` = 0 AND `extra_request_headers` IS NULL";
+  XCTAssertEqual(1, [EXUpdatesDatabaseUtils executeSql:assetsSql3 withArgs:nil onDatabase:migratedDb error:nil].count);
+}
+
 @end

--- a/packages/expo-updates/ios/Tests/EXUpdatesDatabaseTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesDatabaseTests.m
@@ -61,7 +61,7 @@
 - (void)testForeignKeys
 {
   __block NSError *expectedError;
-  EXUpdatesUpdate *update = [EXUpdatesNewUpdate updateWithNewManifest:_manifest response:nil config:_config database:_db];
+  EXUpdatesUpdate *update = [EXUpdatesNewUpdate updateWithNewManifest:_manifest headers:@{} extensions:@{} config:_config database:_db];
   dispatch_sync(_db.databaseQueue, ^{
     NSError *updatesError;
     [_db addUpdate:update error:&updatesError];
@@ -80,20 +80,20 @@
 
 - (void)testSetMetadata_OverwriteAllFields
 {
-  NSHTTPURLResponse *response1 = [[NSHTTPURLResponse alloc] initWithURL:[NSURL URLWithString:@"https://exp.host/"] statusCode:200 HTTPVersion:@"HTTP/2" headerFields:@{
+  NSDictionary *headers1 = @{
     @"expo-manifest-filters": @"branch-name=\"rollout-1\",test=\"value\""
-  }];
-  EXUpdatesUpdate *update1 = [EXUpdatesNewUpdate updateWithNewManifest:_manifest response:response1 config:_config database:_db];
+  };
+  EXUpdatesUpdate *update1 = [EXUpdatesNewUpdate updateWithNewManifest:_manifest headers:headers1 extensions:@{} config:_config database:_db];
   __block NSError *error1;
   dispatch_sync(_db.databaseQueue, ^{
     [_db setMetadataWithManifest:update1 error:&error1];
   });
   XCTAssertNil(error1);
 
-  NSHTTPURLResponse *response2 = [[NSHTTPURLResponse alloc] initWithURL:[NSURL URLWithString:@"https://exp.host/"] statusCode:200 HTTPVersion:@"HTTP/2" headerFields:@{
+  NSDictionary *headers2 = @{
     @"expo-manifest-filters": @"branch-name=\"rollout-2\""
-  }];
-  EXUpdatesUpdate *update2 = [EXUpdatesNewUpdate updateWithNewManifest:_manifest response:response2 config:_config database:_db];
+  };
+  EXUpdatesUpdate *update2 = [EXUpdatesNewUpdate updateWithNewManifest:_manifest headers:headers2 extensions:@{} config:_config database:_db];
   __block NSError *error2;
   dispatch_sync(_db.databaseQueue, ^{
     [_db setMetadataWithManifest:update2 error:&error2];
@@ -113,20 +113,20 @@
 
 - (void)testSetMetadata_OverwriteEmpty
 {
-  NSHTTPURLResponse *response1 = [[NSHTTPURLResponse alloc] initWithURL:[NSURL URLWithString:@"https://exp.host/"] statusCode:200 HTTPVersion:@"HTTP/2" headerFields:@{
+  NSDictionary *headers1 = @{
     @"expo-manifest-filters": @"branch-name=\"rollout-1\""
-  }];
-  EXUpdatesUpdate *update1 = [EXUpdatesNewUpdate updateWithNewManifest:_manifest response:response1 config:_config database:_db];
+  };
+  EXUpdatesUpdate *update1 = [EXUpdatesNewUpdate updateWithNewManifest:_manifest headers:headers1 extensions:@{} config:_config database:_db];
   __block NSError *error1;
   dispatch_sync(_db.databaseQueue, ^{
     [_db setMetadataWithManifest:update1 error:&error1];
   });
   XCTAssertNil(error1);
 
-  NSHTTPURLResponse *response2 = [[NSHTTPURLResponse alloc] initWithURL:[NSURL URLWithString:@"https://exp.host/"] statusCode:200 HTTPVersion:@"HTTP/2" headerFields:@{
+  NSDictionary *headers2 = @{
     @"expo-manifest-filters": @""
-  }];
-  EXUpdatesUpdate *update2 = [EXUpdatesNewUpdate updateWithNewManifest:_manifest response:response2 config:_config database:_db];
+  };
+  EXUpdatesUpdate *update2 = [EXUpdatesNewUpdate updateWithNewManifest:_manifest headers:headers2 extensions:@{} config:_config database:_db];
   __block NSError *error2;
   dispatch_sync(_db.databaseQueue, ^{
     [_db setMetadataWithManifest:update2 error:&error2];
@@ -146,18 +146,17 @@
 
 - (void)testSetMetadata_OverwriteNull
 {
-  NSHTTPURLResponse *response1 = [[NSHTTPURLResponse alloc] initWithURL:[NSURL URLWithString:@"https://exp.host/"] statusCode:200 HTTPVersion:@"HTTP/2" headerFields:@{
+  NSDictionary *headers1 =@{
     @"expo-manifest-filters": @"branch-name=\"rollout-1\""
-  }];
-  EXUpdatesUpdate *update1 = [EXUpdatesNewUpdate updateWithNewManifest:_manifest response:response1 config:_config database:_db];
+  };
+  EXUpdatesUpdate *update1 = [EXUpdatesNewUpdate updateWithNewManifest:_manifest headers:headers1 extensions:@{} config:_config database:_db];
   __block NSError *error1;
   dispatch_sync(_db.databaseQueue, ^{
     [_db setMetadataWithManifest:update1 error:&error1];
   });
   XCTAssertNil(error1);
 
-  NSHTTPURLResponse *response2 = [[NSHTTPURLResponse alloc] initWithURL:[NSURL URLWithString:@"https://exp.host/"] statusCode:200 HTTPVersion:@"HTTP/2" headerFields:@{}];
-  EXUpdatesUpdate *update2 = [EXUpdatesNewUpdate updateWithNewManifest:_manifest response:response2 config:_config database:_db];
+  EXUpdatesUpdate *update2 = [EXUpdatesNewUpdate updateWithNewManifest:_manifest headers:@{} extensions:@{} config:_config database:_db];
   __block NSError *error2;
   dispatch_sync(_db.databaseQueue, ^{
     [_db setMetadataWithManifest:update2 error:&error2];
@@ -199,8 +198,8 @@
   asset2.filename = @"same-filename.png";
   asset3.filename = @"same-filename.png";
 
-  EXUpdatesUpdate *update1 = [EXUpdatesNewUpdate updateWithNewManifest:manifest1 response:nil config:_config database:_db];
-  EXUpdatesUpdate *update2 = [EXUpdatesNewUpdate updateWithNewManifest:manifest2 response:nil config:_config database:_db];
+  EXUpdatesUpdate *update1 = [EXUpdatesNewUpdate updateWithNewManifest:manifest1 headers:@{} extensions:@{} config:_config database:_db];
+  EXUpdatesUpdate *update2 = [EXUpdatesNewUpdate updateWithNewManifest:manifest2 headers:@{} extensions:@{} config:_config database:_db];
 
   dispatch_sync(_db.databaseQueue, ^{
     NSError *update1Error;

--- a/packages/expo-updates/ios/Tests/EXUpdatesFileDownloaderManifestParsingTest.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesFileDownloaderManifestParsingTest.m
@@ -1,0 +1,115 @@
+//  Copyright (c) 2021 650 Industries, Inc. All rights reserved.
+
+#import <XCTest/XCTest.h>
+
+#import <EXUpdates/EXUpdatesConfig.h>
+#import <EXUpdates/EXUpdatesFileDownloader.h>
+
+@interface EXUpdatesFileDownloaderManifestParsingTests : XCTestCase
+
+@end
+
+@implementation EXUpdatesFileDownloaderManifestParsingTests
+
+- (NSData *)multipartDataFromManifest:(NSDictionary *)manifest withBoundary:(NSString *)boundary {
+  NSError *err;
+  NSData *manifestData = [NSJSONSerialization dataWithJSONObject:manifest options:kNilOptions error:&err];
+  if (err) {
+    @throw err;
+  }
+  
+  NSMutableData *body = [NSMutableData data];
+  [body appendData:[[NSString stringWithFormat:@"--%@\r\n", boundary] dataUsingEncoding:NSUTF8StringEncoding]];
+  [body appendData:[@"Content-Type: application/json\r\n" dataUsingEncoding:NSUTF8StringEncoding]];
+  [body appendData:[[NSString stringWithFormat:@"Content-Disposition: inline; name=\"%@\"\r\n\r\n", @"manifest"] dataUsingEncoding:NSUTF8StringEncoding]];
+  
+  [body appendData:manifestData];
+  [body appendData:[@"\r\n" dataUsingEncoding:NSUTF8StringEncoding]];
+  
+  [body appendData:[[NSString stringWithFormat:@"--%@--\r\n", boundary] dataUsingEncoding:NSUTF8StringEncoding]];
+
+  return body;
+}
+
+- (void)testManifestParsing_JSONBody
+{
+  NSDictionary *manifestJSON = @{
+    @"sdkVersion": @"39.0.0",
+    @"releaseId": @"0eef8214-4833-4089-9dff-b4138a14f196",
+    @"commitTime": @"2020-11-11T00:17:54.797Z",
+    @"bundleUrl": @"https://url.to/bundle.js"
+  };
+  
+  EXUpdatesConfig *config = [EXUpdatesConfig configWithDictionary:@{
+    @"EXUpdatesURL": @"https://exp.host/@test/test",
+  }];
+  EXUpdatesFileDownloader *downloader = [[EXUpdatesFileDownloader alloc] initWithUpdatesConfig:config];
+  
+  NSString *contentType = @"application/json";
+  
+  NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:[NSURL URLWithString:@"https://exp.host/@test/test"]
+                                                            statusCode:200
+                                                           HTTPVersion:@"HTTP/1.1"
+                                                          headerFields:@{
+    @"content-type": contentType
+  }];
+  
+  NSError *err;
+  NSData *bodyData = [NSJSONSerialization dataWithJSONObject:manifestJSON options:kNilOptions error:&err];
+  if (err) {
+    @throw err;
+  }
+  
+  __block BOOL errorOccurred;
+  __block EXUpdatesUpdate *resultUpdateManifest;
+  
+  [downloader parseManifestResponse:response withData:bodyData database:nil successBlock:^(EXUpdatesUpdate * _Nonnull update) {
+    resultUpdateManifest = update;
+  } errorBlock:^(NSError * _Nonnull error) {
+    errorOccurred = true;
+  }];
+  
+  XCTAssertFalse(errorOccurred);
+  XCTAssertNotNil(resultUpdateManifest);
+}
+
+- (void)testManifestParsing_MultipartBody
+{
+  NSDictionary *manifestJSON = @{
+    @"sdkVersion": @"39.0.0",
+    @"releaseId": @"0eef8214-4833-4089-9dff-b4138a14f196",
+    @"commitTime": @"2020-11-11T00:17:54.797Z",
+    @"bundleUrl": @"https://url.to/bundle.js"
+  };
+  
+  EXUpdatesConfig *config = [EXUpdatesConfig configWithDictionary:@{
+    @"EXUpdatesURL": @"https://exp.host/@test/test",
+  }];
+  EXUpdatesFileDownloader *downloader = [[EXUpdatesFileDownloader alloc] initWithUpdatesConfig:config];
+  
+  NSString *boundary = @"blah";
+  NSString *contentType = [NSString stringWithFormat:@"multipart/mixed; boundary=%@", boundary];
+  
+  NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:[NSURL URLWithString:@"https://exp.host/@test/test"]
+                                                            statusCode:200
+                                                           HTTPVersion:@"HTTP/1.1"
+                                                          headerFields:@{
+    @"content-type": contentType
+  }];
+  
+  NSData *bodyData = [self multipartDataFromManifest:manifestJSON withBoundary:boundary];
+  
+  __block BOOL errorOccurred;
+  __block EXUpdatesUpdate *resultUpdateManifest;
+  
+  [downloader parseManifestResponse:response withData:bodyData database:nil successBlock:^(EXUpdatesUpdate * _Nonnull update) {
+    resultUpdateManifest = update;
+  } errorBlock:^(NSError * _Nonnull error) {
+    errorOccurred = true;
+  }];
+  
+  XCTAssertFalse(errorOccurred);
+  XCTAssertNotNil(resultUpdateManifest);
+}
+
+@end

--- a/packages/expo-updates/ios/Tests/EXUpdatesFileDownloaderTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesFileDownloaderTests.m
@@ -11,16 +11,6 @@
 
 @implementation EXUpdatesFileDownloaderTests
 
-- (void)setUp
-{
-  // Put setup code here. This method is called before the invocation of each test method in the class.
-}
-
-- (void)tearDown
-{
-  // Put teardown code here. This method is called after the invocation of each test method in the class.
-}
-
 - (void)testCacheControl_LegacyManifest
 {
   EXUpdatesConfig *config = [EXUpdatesConfig configWithDictionary:@{
@@ -87,6 +77,28 @@
   };
 
   NSURLRequest *actual = [downloader createManifestRequestWithURL:[NSURL URLWithString:@"https://exp.host/manifest/00000000-0000-0000-0000-000000000000"] extraHeaders:extraHeaders];
+  XCTAssertEqualObjects(@"ios", [actual valueForHTTPHeaderField:@"expo-platform"]);
+  XCTAssertEqualObjects(@"custom", [actual valueForHTTPHeaderField:@"expo-updates-environment"]);
+}
+
+- (void)testAssetExtraHeaders_OverrideOrder
+{
+  EXUpdatesConfig *config = [EXUpdatesConfig configWithDictionary:@{
+    @"EXUpdatesURL": @"https://exp.host/manifest/00000000-0000-0000-0000-000000000000",
+    @"EXUpdatesRuntimeVersion": @"1.0",
+    @"EXUpdatesRequestHeaders": @{
+      // custom headers configured at build-time should be able to override preset headers
+      @"expo-updates-environment": @"custom"
+    }
+  }];
+  EXUpdatesFileDownloader *downloader = [[EXUpdatesFileDownloader alloc] initWithUpdatesConfig:config];
+
+  // assetRequestHeaders should not be able to override preset headers
+  NSDictionary *extraHeaders = @{
+    @"expo-platform": @"android"
+  };
+
+  NSURLRequest *actual = [downloader createGenericRequestWithURL:[NSURL URLWithString:@"https://exp.host/manifest/00000000-0000-0000-0000-000000000000"] extraHeaders:extraHeaders];
   XCTAssertEqualObjects(@"ios", [actual valueForHTTPHeaderField:@"expo-platform"]);
   XCTAssertEqualObjects(@"custom", [actual valueForHTTPHeaderField:@"expo-updates-environment"]);
 }

--- a/packages/expo-updates/ios/Tests/EXUpdatesFileDownloaderTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesFileDownloaderTests.m
@@ -28,13 +28,13 @@
 - (void)testCacheControl_NewManifest
 {
   EXUpdatesConfig *config = [EXUpdatesConfig configWithDictionary:@{
-    @"EXUpdatesURL": @"https://exp.host/manifest/00000000-0000-0000-0000-000000000000",
+    @"EXUpdatesURL": @"https://u.expo.dev/00000000-0000-0000-0000-000000000000",
     @"EXUpdatesRuntimeVersion": @"1.0",
     @"EXUpdatesUsesLegacyManifest": @(NO)
   }];
   EXUpdatesFileDownloader *downloader = [[EXUpdatesFileDownloader alloc] initWithUpdatesConfig:config];
 
-  NSURLRequest *actual = [downloader createManifestRequestWithURL:[NSURL URLWithString:@"https://exp.host/manifest/00000000-0000-0000-0000-000000000000"] extraHeaders:nil];
+  NSURLRequest *actual = [downloader createManifestRequestWithURL:[NSURL URLWithString:@"https://u.expo.dev/00000000-0000-0000-0000-000000000000"] extraHeaders:nil];
   XCTAssertEqual(NSURLRequestUseProtocolCachePolicy, actual.cachePolicy);
   XCTAssertNil([actual valueForHTTPHeaderField:@"Cache-Control"]);
 }
@@ -42,7 +42,7 @@
 - (void)testExtraHeaders_ObjectTypes
 {
   EXUpdatesConfig *config = [EXUpdatesConfig configWithDictionary:@{
-    @"EXUpdatesURL": @"https://exp.host/manifest/00000000-0000-0000-0000-000000000000",
+    @"EXUpdatesURL": @"https://u.expo.dev/00000000-0000-0000-0000-000000000000",
     @"EXUpdatesRuntimeVersion": @"1.0"
   }];
   EXUpdatesFileDownloader *downloader = [[EXUpdatesFileDownloader alloc] initWithUpdatesConfig:config];
@@ -53,7 +53,7 @@
     @"expo-boolean": @YES
   };
 
-  NSURLRequest *actual = [downloader createManifestRequestWithURL:[NSURL URLWithString:@"https://exp.host/manifest/00000000-0000-0000-0000-000000000000"] extraHeaders:extraHeaders];
+  NSURLRequest *actual = [downloader createManifestRequestWithURL:[NSURL URLWithString:@"https://u.expo.dev/00000000-0000-0000-0000-000000000000"] extraHeaders:extraHeaders];
   XCTAssertEqualObjects(@"test", [actual valueForHTTPHeaderField:@"expo-string"]);
   XCTAssertEqualObjects(@"47.5", [actual valueForHTTPHeaderField:@"expo-number"]);
   XCTAssertEqualObjects(@"true", [actual valueForHTTPHeaderField:@"expo-boolean"]);
@@ -62,7 +62,7 @@
 - (void)testExtraHeaders_OverrideOrder
 {
   EXUpdatesConfig *config = [EXUpdatesConfig configWithDictionary:@{
-    @"EXUpdatesURL": @"https://exp.host/manifest/00000000-0000-0000-0000-000000000000",
+    @"EXUpdatesURL": @"https://u.expo.dev/00000000-0000-0000-0000-000000000000",
     @"EXUpdatesRuntimeVersion": @"1.0",
     @"EXUpdatesRequestHeaders": @{
       // custom headers configured at build-time should be able to override preset headers
@@ -76,7 +76,7 @@
     @"expo-platform": @"android"
   };
 
-  NSURLRequest *actual = [downloader createManifestRequestWithURL:[NSURL URLWithString:@"https://exp.host/manifest/00000000-0000-0000-0000-000000000000"] extraHeaders:extraHeaders];
+  NSURLRequest *actual = [downloader createManifestRequestWithURL:[NSURL URLWithString:@"https://u.expo.dev/00000000-0000-0000-0000-000000000000"] extraHeaders:extraHeaders];
   XCTAssertEqualObjects(@"ios", [actual valueForHTTPHeaderField:@"expo-platform"]);
   XCTAssertEqualObjects(@"custom", [actual valueForHTTPHeaderField:@"expo-updates-environment"]);
 }
@@ -84,7 +84,7 @@
 - (void)testAssetExtraHeaders_OverrideOrder
 {
   EXUpdatesConfig *config = [EXUpdatesConfig configWithDictionary:@{
-    @"EXUpdatesURL": @"https://exp.host/manifest/00000000-0000-0000-0000-000000000000",
+    @"EXUpdatesURL": @"https://u.expo.dev/00000000-0000-0000-0000-000000000000",
     @"EXUpdatesRuntimeVersion": @"1.0",
     @"EXUpdatesRequestHeaders": @{
       // custom headers configured at build-time should be able to override preset headers
@@ -98,7 +98,7 @@
     @"expo-platform": @"android"
   };
 
-  NSURLRequest *actual = [downloader createGenericRequestWithURL:[NSURL URLWithString:@"https://exp.host/manifest/00000000-0000-0000-0000-000000000000"] extraHeaders:extraHeaders];
+  NSURLRequest *actual = [downloader createGenericRequestWithURL:[NSURL URLWithString:@"https://u.expo.dev/00000000-0000-0000-0000-000000000000"] extraHeaders:extraHeaders];
   XCTAssertEqualObjects(@"ios", [actual valueForHTTPHeaderField:@"expo-platform"]);
   XCTAssertEqualObjects(@"custom", [actual valueForHTTPHeaderField:@"expo-updates-environment"]);
 }

--- a/packages/expo-updates/ios/Tests/EXUpdatesMultipartStreamReaderTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesMultipartStreamReaderTests.m
@@ -33,8 +33,7 @@
     XCTAssertEqualObjects(headers[@"Content-Type"], @"application/json; charset=utf-8");
     XCTAssertEqualObjects([[NSString alloc] initWithData:content encoding:NSUTF8StringEncoding], @"{}");
     count++;
-  }
-                                           progressCallback:nil];
+  }];
   XCTAssertTrue(success);
   XCTAssertEqual(count, 1);
 }
@@ -62,8 +61,7 @@
     NSString *expectedBody = [NSString stringWithFormat:@"%ld", (long)count];
     NSString *actualBody = [[NSString alloc] initWithData:content encoding:NSUTF8StringEncoding];
     XCTAssertEqualObjects(actualBody, expectedBody);
-  }
-                                           progressCallback:nil];
+  }];
   XCTAssertTrue(success);
   XCTAssertEqual(count, 3);
 }
@@ -90,8 +88,7 @@
     NSString *expectedBody = [NSString stringWithFormat:@"%ld", (long)count];
     NSString *actualBody = [[NSString alloc] initWithData:content encoding:NSUTF8StringEncoding];
     XCTAssertEqualObjects(actualBody, expectedBody);
-  }
-                                           progressCallback:nil];
+  }];
   XCTAssertTrue(success);
   XCTAssertEqual(count, 3);
 }
@@ -107,8 +104,7 @@
   BOOL success = [reader readAllPartsWithCompletionCallback:^(
                                                               __unused NSDictionary *headers, __unused NSData *content, __unused BOOL done) {
                                                                 count++;
-                                                              }
-                                           progressCallback:nil];
+                                                              }];
   XCTAssertFalse(success);
   XCTAssertEqual(count, 0);
 }
@@ -131,8 +127,7 @@
   BOOL success = [reader readAllPartsWithCompletionCallback:^(
                                                               __unused NSDictionary *headers, __unused NSData *content, __unused BOOL done) {
                                                                 count++;
-                                                              }
-                                           progressCallback:nil];
+                                                              }];
   XCTAssertFalse(success);
   XCTAssertEqual(count, 1);
 }

--- a/packages/expo-updates/ios/Tests/EXUpdatesMultipartStreamReaderTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesMultipartStreamReaderTests.m
@@ -1,0 +1,140 @@
+//  Copyright (c) 2020 650 Industries, Inc. All rights reserved.
+
+#import <XCTest/XCTest.h>
+
+#import <EXUpdates/EXUpdatesMultipartStreamReader.h>
+
+/**
+ * Fork of {@link EXUpdatesMultipartStreamReaderTests}.
+ */
+@interface EXUpdatesMultipartStreamReaderTests : XCTestCase
+
+@end
+
+@implementation EXUpdatesMultipartStreamReaderTests
+
+- (void)testSimpleCase
+{
+  NSString *response =
+  @"preamble, should be ignored\r\n"
+  @"--sample_boundary\r\n"
+  @"Content-Type: application/json; charset=utf-8\r\n"
+  @"Content-Length: 2\r\n\r\n"
+  @"{}\r\n"
+  @"--sample_boundary--\r\n"
+  @"epilogue, should be ignored";
+  
+  NSInputStream *inputStream = [NSInputStream inputStreamWithData:[response dataUsingEncoding:NSUTF8StringEncoding]];
+  EXUpdatesMultipartStreamReader *reader = [[EXUpdatesMultipartStreamReader alloc] initWithInputStream:inputStream
+                                                                                              boundary:@"sample_boundary"];
+  __block NSInteger count = 0;
+  BOOL success = [reader readAllPartsWithCompletionCallback:^(NSDictionary *headers, NSData *content, BOOL done) {
+    XCTAssertTrue(done);
+    XCTAssertEqualObjects(headers[@"Content-Type"], @"application/json; charset=utf-8");
+    XCTAssertEqualObjects([[NSString alloc] initWithData:content encoding:NSUTF8StringEncoding], @"{}");
+    count++;
+  }
+                                           progressCallback:nil];
+  XCTAssertTrue(success);
+  XCTAssertEqual(count, 1);
+}
+
+- (void)testMultipleParts
+{
+  NSString *response =
+  @"preamble, should be ignored\r\n"
+  @"--sample_boundary\r\n"
+  @"1\r\n"
+  @"--sample_boundary\r\n"
+  @"2\r\n"
+  @"--sample_boundary\r\n"
+  @"3\r\n"
+  @"--sample_boundary--\r\n"
+  @"epilogue, should be ignored";
+  
+  NSInputStream *inputStream = [NSInputStream inputStreamWithData:[response dataUsingEncoding:NSUTF8StringEncoding]];
+  EXUpdatesMultipartStreamReader *reader = [[EXUpdatesMultipartStreamReader alloc] initWithInputStream:inputStream
+                                                                                              boundary:@"sample_boundary"];
+  __block NSInteger count = 0;
+  BOOL success = [reader readAllPartsWithCompletionCallback:^(__unused NSDictionary *headers, NSData *content, BOOL done) {
+    count++;
+    XCTAssertEqual(done, count == 3);
+    NSString *expectedBody = [NSString stringWithFormat:@"%ld", (long)count];
+    NSString *actualBody = [[NSString alloc] initWithData:content encoding:NSUTF8StringEncoding];
+    XCTAssertEqualObjects(actualBody, expectedBody);
+  }
+                                           progressCallback:nil];
+  XCTAssertTrue(success);
+  XCTAssertEqual(count, 3);
+}
+
+- (void)testMultiplePartsNoPreamble
+{
+  NSString *response =
+  @"--sample_boundary\r\n"
+  @"1\r\n"
+  @"--sample_boundary\r\n"
+  @"2\r\n"
+  @"--sample_boundary\r\n"
+  @"3\r\n"
+  @"--sample_boundary--\r\n"
+  @"epilogue, should be ignored";
+  
+  NSInputStream *inputStream = [NSInputStream inputStreamWithData:[response dataUsingEncoding:NSUTF8StringEncoding]];
+  EXUpdatesMultipartStreamReader *reader = [[EXUpdatesMultipartStreamReader alloc] initWithInputStream:inputStream
+                                                                                              boundary:@"sample_boundary"];
+  __block NSInteger count = 0;
+  BOOL success = [reader readAllPartsWithCompletionCallback:^(__unused NSDictionary *headers, NSData *content, BOOL done) {
+    count++;
+    XCTAssertEqual(done, count == 3);
+    NSString *expectedBody = [NSString stringWithFormat:@"%ld", (long)count];
+    NSString *actualBody = [[NSString alloc] initWithData:content encoding:NSUTF8StringEncoding];
+    XCTAssertEqualObjects(actualBody, expectedBody);
+  }
+                                           progressCallback:nil];
+  XCTAssertTrue(success);
+  XCTAssertEqual(count, 3);
+}
+
+- (void)testNoDelimiter
+{
+  NSString *response = @"Yolo";
+  
+  NSInputStream *inputStream = [NSInputStream inputStreamWithData:[response dataUsingEncoding:NSUTF8StringEncoding]];
+  EXUpdatesMultipartStreamReader *reader = [[EXUpdatesMultipartStreamReader alloc] initWithInputStream:inputStream
+                                                                                              boundary:@"sample_boundary"];
+  __block NSInteger count = 0;
+  BOOL success = [reader readAllPartsWithCompletionCallback:^(
+                                                              __unused NSDictionary *headers, __unused NSData *content, __unused BOOL done) {
+                                                                count++;
+                                                              }
+                                           progressCallback:nil];
+  XCTAssertFalse(success);
+  XCTAssertEqual(count, 0);
+}
+
+- (void)testNoCloseDelimiter
+{
+  NSString *response =
+  @"preamble, should be ignored\r\n"
+  @"--sample_boundary\r\n"
+  @"Content-Type: application/json; charset=utf-8\r\n"
+  @"Content-Length: 2\r\n\r\n"
+  @"{}\r\n"
+  @"--sample_boundary\r\n"
+  @"incomplete message...";
+  
+  NSInputStream *inputStream = [NSInputStream inputStreamWithData:[response dataUsingEncoding:NSUTF8StringEncoding]];
+  EXUpdatesMultipartStreamReader *reader = [[EXUpdatesMultipartStreamReader alloc] initWithInputStream:inputStream
+                                                                                              boundary:@"sample_boundary"];
+  __block NSInteger count = 0;
+  BOOL success = [reader readAllPartsWithCompletionCallback:^(
+                                                              __unused NSDictionary *headers, __unused NSData *content, __unused BOOL done) {
+                                                                count++;
+                                                              }
+                                           progressCallback:nil];
+  XCTAssertFalse(success);
+  XCTAssertEqual(count, 1);
+}
+
+@end

--- a/packages/expo-updates/ios/Tests/EXUpdatesNewUpdateTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesNewUpdateTests.m
@@ -40,7 +40,7 @@
     @"createdAt": @"2020-11-11T00:17:54.797Z",
     @"launchAsset": @{@"url": @"https://url.to/bundle.js", @"contentType": @"application/javascript"}
   }];
-  XCTAssert([EXUpdatesNewUpdate updateWithNewManifest:manifest response:nil config:_config database:_database] != nil);
+  XCTAssert([EXUpdatesNewUpdate updateWithNewManifest:manifest headers:@{} extensions:@{} config:_config database:_database] != nil);
 }
 
 - (void)testUpdateWithNewManifest_NoRuntimeVersion
@@ -50,7 +50,7 @@
     @"createdAt": @"2020-11-11T00:17:54.797Z",
     @"launchAsset": @{@"url": @"https://url.to/bundle.js", @"contentType": @"application/javascript"}
   }];
-  XCTAssertThrows([EXUpdatesNewUpdate updateWithNewManifest:manifest response:nil config:_config database:_database]);
+  XCTAssertThrows([EXUpdatesNewUpdate updateWithNewManifest:manifest headers:@{} extensions:@{} config:_config database:_database]);
 }
 
 - (void)testUpdateWithNewManifest_NoId
@@ -60,7 +60,7 @@
     @"createdAt": @"2020-11-11T00:17:54.797Z",
     @"launchAsset": @{@"url": @"https://url.to/bundle.js", @"contentType": @"application/javascript"}
   }];
-  XCTAssertThrows([EXUpdatesNewUpdate updateWithNewManifest:manifest response:nil config:_config database:_database]);
+  XCTAssertThrows([EXUpdatesNewUpdate updateWithNewManifest:manifest headers:@{} extensions:@{} config:_config database:_database]);
 }
 
 - (void)testUpdateWithNewManifest_NoCreatedAt
@@ -70,7 +70,7 @@
     @"id": @"0eef8214-4833-4089-9dff-b4138a14f196",
     @"launchAsset": @{@"url": @"https://url.to/bundle.js", @"contentType": @"application/javascript"}
   }];
-  XCTAssertThrows([EXUpdatesNewUpdate updateWithNewManifest:manifest response:nil config:_config database:_database]);
+  XCTAssertThrows([EXUpdatesNewUpdate updateWithNewManifest:manifest headers:@{} extensions:@{} config:_config database:_database]);
 }
 
 - (void)testUpdateWithNewManifest_NoLaunchAsset
@@ -80,7 +80,7 @@
     @"id": @"0eef8214-4833-4089-9dff-b4138a14f196",
     @"createdAt": @"2020-11-11T00:17:54.797Z"
   }];
-  XCTAssertThrows([EXUpdatesNewUpdate updateWithNewManifest:manifest response:nil config:_config database:_database]);
+  XCTAssertThrows([EXUpdatesNewUpdate updateWithNewManifest:manifest headers:@{} extensions:@{} config:_config database:_database]);
 }
 
 - (void)testDictionaryWithStructuredHeader_SupportedTypes

--- a/packages/expo-updates/ios/Tests/EXUpdatesParameterParserTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesParameterParserTests.m
@@ -1,0 +1,44 @@
+//  Copyright (c) 2020 650 Industries, Inc. All rights reserved.
+
+#import <XCTest/XCTest.h>
+
+#import <EXUpdates/EXUpdatesParameterParser.h>
+
+@interface EXUpdatesParameterParserTests : XCTestCase
+@end
+
+@implementation EXUpdatesParameterParserTests
+
+- (void)testParameterParser
+{
+  NSArray<NSArray *> *testCases = @[
+    @[@"", @{}],
+    @[@"test; test1 =  stuff   ; test2 =  \"stuff; stuff\"; test3=\"stuff",
+      @{@"test": [NSNull null], @"test1": @"stuff", @"test2": @"stuff; stuff", @"test3": @"\"stuff"}
+    ],
+    @[@"  test  ; test1=stuff   ;  ; test2=; test3; ",
+      @{@"test": [NSNull null], @"test1": @"stuff", @"test2": [NSNull null], @"test3": [NSNull null]}
+    ],
+    @[@"  test", @{@"test": [NSNull null]}],
+    @[@"  ", @{}],
+    @[@" = stuff ", @{}],
+    @[@"text/plain; Charset=UTF-8", @{@"text/plain": [NSNull null], @"Charset": @"UTF-8"}],
+    @[@"param = \"stuff\\\"; more stuff\"", @{@"param": @"stuff\\\"; more stuff"}],
+    @[@"param = \"stuff\\\\\"; anotherparam", @{@"param": @"stuff\\\\", @"anotherparam": [NSNull null]}],
+    @[@"foo/bar; param=\"baz=bat\"", @{@"foo/bar": [NSNull null], @"param": @"baz=bat"}],
+    
+    // Expo-specific tests
+    @[@"multipart/mixed; boundary=BbC04y", @{@"multipart/mixed": [NSNull null], @"boundary": @"BbC04y"}],
+    @[@"form-data; name=\"manifest\"; filename=\"hello2\"", @{@"form-data": [NSNull null], @"name": @"manifest", @"filename": @"hello2"}],
+  ];
+  
+  for (NSArray *testCase in testCases) {
+    NSString *parameterString = testCase[0];
+    NSDictionary *expectedDictionary = testCase[1];
+    
+    NSDictionary<NSString *, NSString *> *parameters = [[EXUpdatesParameterParser new] parseParameterString:parameterString withDelimiter:@";"];
+    XCTAssertTrue([expectedDictionary isEqualToDictionary:parameters], @"result did not match expected");
+  }
+}
+
+@end

--- a/packages/expo-updates/ios/Tests/EXUpdatesParameterParserTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesParameterParserTests.m
@@ -36,7 +36,7 @@
     NSString *parameterString = testCase[0];
     NSDictionary *expectedDictionary = testCase[1];
     
-    NSDictionary<NSString *, NSString *> *parameters = [[EXUpdatesParameterParser new] parseParameterString:parameterString withDelimiter:@";"];
+    NSDictionary<NSString *, NSString *> *parameters = [[EXUpdatesParameterParser new] parseParameterString:parameterString withDelimiter:';'];
     XCTAssertTrue([expectedDictionary isEqualToDictionary:parameters], @"result did not match expected");
   }
 }

--- a/packages/expo-updates/ios/Tests/EXUpdatesSelectionPolicyFilterAwareTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesSelectionPolicyFilterAwareTests.m
@@ -58,7 +58,7 @@
     @"launchAsset": launchAsset,
     @"assets": @[imageAsset],
     @"metadata": @{@"branchName": @"rollout"}
-  }] response:nil config:config database:database];
+  }] headers:[NSDictionary new] extensions:[NSDictionary new] config:config database:database];
 
   _updateDefault1 = [EXUpdatesNewUpdate updateWithNewManifest:[[EXManifestsNewManifest alloc] initWithRawManifestJSON:@{
     @"id": @"079cde35-8433-4c17-81c8-7117c1513e72",
@@ -67,7 +67,7 @@
     @"launchAsset": launchAsset,
     @"assets": @[imageAsset],
     @"metadata": @{@"branchName": @"default"}
-  }] response:nil config:config database:database];
+  }] headers:[NSDictionary new] extensions:[NSDictionary new] config:config database:database];
 
   _updateRollout1 = [EXUpdatesNewUpdate updateWithNewManifest:[[EXManifestsNewManifest alloc] initWithRawManifestJSON:@{
     @"id": @"079cde35-8433-4c17-81c8-7117c1513e73",
@@ -76,7 +76,7 @@
     @"launchAsset": launchAsset,
     @"assets": @[imageAsset],
     @"metadata": @{@"branchName": @"rollout"}
-  }] response:nil config:config database:database];
+  }] headers:[NSDictionary new] extensions:[NSDictionary new] config:config database:database];
 
   _updateDefault2 = [EXUpdatesNewUpdate updateWithNewManifest:[[EXManifestsNewManifest alloc] initWithRawManifestJSON:@{
     @"id": @"079cde35-8433-4c17-81c8-7117c1513e74",
@@ -85,7 +85,7 @@
     @"launchAsset": launchAsset,
     @"assets": @[imageAsset],
     @"metadata": @{@"branchName": @"default"}
-  }] response:nil config:config database:database];
+  }] headers:[NSDictionary new] extensions:[NSDictionary new] config:config database:database];
 
   _updateRollout2 = [EXUpdatesNewUpdate updateWithNewManifest:[[EXManifestsNewManifest alloc] initWithRawManifestJSON:@{
     @"id": @"079cde35-8433-4c17-81c8-7117c1513e75",
@@ -94,7 +94,7 @@
     @"launchAsset": launchAsset,
     @"assets": @[imageAsset],
     @"metadata": @{@"branchName": @"rollout"}
-  }] response:nil config:config database:database];
+  }] headers:[NSDictionary new] extensions:[NSDictionary new] config:config database:database];
 
   _updateMultipleFilters = [EXUpdatesNewUpdate updateWithNewManifest:[[EXManifestsNewManifest alloc] initWithRawManifestJSON:@{
     @"id": @"079cde35-8433-4c17-81c8-7117c1513e72",
@@ -103,7 +103,7 @@
     @"launchAsset": launchAsset,
     @"assets": @[imageAsset],
     @"metadata": @{@"firstKey": @"value1", @"secondKey": @"value2"}
-  }] response:nil config:config database:database];
+  }] headers:[NSDictionary new] extensions:[NSDictionary new] config:config database:database];
 
   _updateNoMetadata = [EXUpdatesNewUpdate updateWithNewManifest:[[EXManifestsNewManifest alloc] initWithRawManifestJSON:@{
     @"id": @"079cde35-8433-4c17-81c8-7117c1513e72",
@@ -111,7 +111,7 @@
     @"runtimeVersion": @"1.0",
     @"launchAsset": launchAsset,
     @"assets": @[imageAsset]
-  }] response:nil config:config database:database];
+  }] headers:[NSDictionary new] extensions:[NSDictionary new] config:config database:database];
 
   _selectionPolicy = [EXUpdatesSelectionPolicyFactory filterAwarePolicyWithRuntimeVersion:runtimeVersion];
   _manifestFilters = @{@"branchname": @"rollout"};

--- a/packages/expo-updates/ios/Tests/EXUpdatesSelectionPolicyFilterAwareTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesSelectionPolicyFilterAwareTests.m
@@ -58,7 +58,7 @@
     @"launchAsset": launchAsset,
     @"assets": @[imageAsset],
     @"metadata": @{@"branchName": @"rollout"}
-  }] headers:[NSDictionary new] extensions:[NSDictionary new] config:config database:database];
+  }] headers:@{} extensions:@{} config:config database:database];
 
   _updateDefault1 = [EXUpdatesNewUpdate updateWithNewManifest:[[EXManifestsNewManifest alloc] initWithRawManifestJSON:@{
     @"id": @"079cde35-8433-4c17-81c8-7117c1513e72",
@@ -67,7 +67,7 @@
     @"launchAsset": launchAsset,
     @"assets": @[imageAsset],
     @"metadata": @{@"branchName": @"default"}
-  }] headers:[NSDictionary new] extensions:[NSDictionary new] config:config database:database];
+  }] headers:@{} extensions:@{} config:config database:database];
 
   _updateRollout1 = [EXUpdatesNewUpdate updateWithNewManifest:[[EXManifestsNewManifest alloc] initWithRawManifestJSON:@{
     @"id": @"079cde35-8433-4c17-81c8-7117c1513e73",
@@ -76,7 +76,7 @@
     @"launchAsset": launchAsset,
     @"assets": @[imageAsset],
     @"metadata": @{@"branchName": @"rollout"}
-  }] headers:[NSDictionary new] extensions:[NSDictionary new] config:config database:database];
+  }] headers:@{} extensions:@{} config:config database:database];
 
   _updateDefault2 = [EXUpdatesNewUpdate updateWithNewManifest:[[EXManifestsNewManifest alloc] initWithRawManifestJSON:@{
     @"id": @"079cde35-8433-4c17-81c8-7117c1513e74",
@@ -85,7 +85,7 @@
     @"launchAsset": launchAsset,
     @"assets": @[imageAsset],
     @"metadata": @{@"branchName": @"default"}
-  }] headers:[NSDictionary new] extensions:[NSDictionary new] config:config database:database];
+  }] headers:@{} extensions:@{} config:config database:database];
 
   _updateRollout2 = [EXUpdatesNewUpdate updateWithNewManifest:[[EXManifestsNewManifest alloc] initWithRawManifestJSON:@{
     @"id": @"079cde35-8433-4c17-81c8-7117c1513e75",
@@ -94,7 +94,7 @@
     @"launchAsset": launchAsset,
     @"assets": @[imageAsset],
     @"metadata": @{@"branchName": @"rollout"}
-  }] headers:[NSDictionary new] extensions:[NSDictionary new] config:config database:database];
+  }] headers:@{} extensions:@{} config:config database:database];
 
   _updateMultipleFilters = [EXUpdatesNewUpdate updateWithNewManifest:[[EXManifestsNewManifest alloc] initWithRawManifestJSON:@{
     @"id": @"079cde35-8433-4c17-81c8-7117c1513e72",
@@ -103,7 +103,7 @@
     @"launchAsset": launchAsset,
     @"assets": @[imageAsset],
     @"metadata": @{@"firstKey": @"value1", @"secondKey": @"value2"}
-  }] headers:[NSDictionary new] extensions:[NSDictionary new] config:config database:database];
+  }] headers:@{} extensions:@{} config:config database:database];
 
   _updateNoMetadata = [EXUpdatesNewUpdate updateWithNewManifest:[[EXManifestsNewManifest alloc] initWithRawManifestJSON:@{
     @"id": @"079cde35-8433-4c17-81c8-7117c1513e72",
@@ -111,7 +111,7 @@
     @"runtimeVersion": @"1.0",
     @"launchAsset": launchAsset,
     @"assets": @[imageAsset]
-  }] headers:[NSDictionary new] extensions:[NSDictionary new] config:config database:database];
+  }] headers:@{} extensions:@{} config:config database:database];
 
   _selectionPolicy = [EXUpdatesSelectionPolicyFactory filterAwarePolicyWithRuntimeVersion:runtimeVersion];
   _manifestFilters = @{@"branchname": @"rollout"};

--- a/packages/expo-updates/ios/Tests/EXUpdatesUpdateTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesUpdateTests.m
@@ -58,27 +58,21 @@
 - (void)testUpdateWithManifest_Legacy
 {
   NSError *error;
-  NSURLResponse* response =  [[NSHTTPURLResponse alloc] initWithURL:[NSURL URLWithString:@"https://example.com"] statusCode:200 HTTPVersion:nil headerFields:@{}];
-
-  EXUpdatesUpdate *update = [EXUpdatesUpdate updateWithManifest:_legacyManifest response:response config:_config database:_database error:&error];
+  EXUpdatesUpdate *update = [EXUpdatesUpdate updateWithManifest:_legacyManifest headers:[NSDictionary new] extensions:[NSDictionary new] config:_config database:_database error:&error];
   XCTAssert(update != nil);
 }
 
 - (void)testUpdateWithManifest_New
 {
   NSError *error;
-  NSURLResponse* response =  [[NSHTTPURLResponse alloc] initWithURL:[NSURL URLWithString:@"https://example.com"] statusCode:200 HTTPVersion:nil headerFields:@{@"expo-protocol-version" : @"0"}];
-
-  EXUpdatesUpdate *update = [EXUpdatesUpdate updateWithManifest:_easNewManifest response:response config:_config database:_database error:&error];
+  EXUpdatesUpdate *update = [EXUpdatesUpdate updateWithManifest:_easNewManifest headers:@{@"expo-protocol-version" : @"0"} extensions:[NSDictionary new] config:_config database:_database error:&error];
   XCTAssert(update != nil);
 }
 
 - (void)testUpdateWithManifest_UnsupportedProtocolVersion
 {
   NSError *error;
-  NSURLResponse* response =  [[NSHTTPURLResponse alloc] initWithURL:[NSURL URLWithString:@"https://example.com"] statusCode:200 HTTPVersion:nil headerFields:@{@"expo-protocol-version" : @"1"}];
-
-  EXUpdatesUpdate *update = [EXUpdatesUpdate updateWithManifest:_easNewManifest response:response config:_config database:_database error:&error];
+  EXUpdatesUpdate *update = [EXUpdatesUpdate updateWithManifest:_easNewManifest headers:@{@"expo-protocol-version" : @"1"} extensions:[NSDictionary new] config:_config database:_database error:&error];
   XCTAssert(error != nil);
   XCTAssert(update == nil);
 }

--- a/packages/expo-updates/ios/Tests/EXUpdatesUpdateTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesUpdateTests.m
@@ -58,21 +58,21 @@
 - (void)testUpdateWithManifest_Legacy
 {
   NSError *error;
-  EXUpdatesUpdate *update = [EXUpdatesUpdate updateWithManifest:_legacyManifest headers:[NSDictionary new] extensions:[NSDictionary new] config:_config database:_database error:&error];
+  EXUpdatesUpdate *update = [EXUpdatesUpdate updateWithManifest:_legacyManifest headers:@{} extensions:@{} config:_config database:_database error:&error];
   XCTAssert(update != nil);
 }
 
 - (void)testUpdateWithManifest_New
 {
   NSError *error;
-  EXUpdatesUpdate *update = [EXUpdatesUpdate updateWithManifest:_easNewManifest headers:@{@"expo-protocol-version" : @"0"} extensions:[NSDictionary new] config:_config database:_database error:&error];
+  EXUpdatesUpdate *update = [EXUpdatesUpdate updateWithManifest:_easNewManifest headers:@{@"expo-protocol-version" : @"0"} extensions:@{} config:_config database:_database error:&error];
   XCTAssert(update != nil);
 }
 
 - (void)testUpdateWithManifest_UnsupportedProtocolVersion
 {
   NSError *error;
-  EXUpdatesUpdate *update = [EXUpdatesUpdate updateWithManifest:_easNewManifest headers:@{@"expo-protocol-version" : @"1"} extensions:[NSDictionary new] config:_config database:_database error:&error];
+  EXUpdatesUpdate *update = [EXUpdatesUpdate updateWithManifest:_easNewManifest headers:@{@"expo-protocol-version" : @"1"} extensions:@{} config:_config database:_database error:&error];
   XCTAssert(error != nil);
   XCTAssert(update == nil);
 }

--- a/packages/expo-updates/ios/Tests/Tests.m
+++ b/packages/expo-updates/ios/Tests/Tests.m
@@ -13,18 +13,6 @@
 
 @implementation Tests
 
-- (void)setUp
-{
-    [super setUp];
-    // Put setup code here. This method is called before the invocation of each test method in the class.
-}
-
-- (void)tearDown
-{
-    // Put teardown code here. This method is called after the invocation of each test method in the class.
-    [super tearDown];
-}
-
 - (void)testGetRuntimeVersionWithConfig
 {
   EXUpdatesConfig *sdkOnlyConfig = [[EXUpdatesConfig alloc] init];


### PR DESCRIPTION
# Why

iOS equivalent of https://github.com/expo/expo/pull/15401/. The same How and Test Plan apply, but on iOS.

# How

- `EXUpdatesParameterParser` is a translation to objective-c of ParameterParser from https://commons.apache.org/proper/commons-fileupload/. The test for it is a combination of their test cases and ours.
- `EXUpdatesMultipartStreamReader` is a fork of `RCTMultipartStreamReader` that fixes a bug in preamble skipping and removes features we don't need. A new test was added for it to test the preamble case, as well as all the other cases that were already tested.

# Test Plan

Run tests.