### PR TITLE
docs: quick fix for new jsxImportSource option

### DIFF
--- a/packages/babel-preset-expo/README.md
+++ b/packages/babel-preset-expo/README.md
@@ -71,7 +71,7 @@ This option allows specifying a custom import source for importing functions.
   'babel-preset-expo',
   {
     jsxRuntime: 'automatic',
-    importSource: 'react',
+    jsxImportSource: 'react',
   },
 ];
 ```


### PR DESCRIPTION
# Why

I missed a little glitch in the example code for the new option

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
