### PR TITLE
fix: release build won't install on Android 12

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix: release build won't install on Android 12. ([#15429](https://github.com/expo/expo/pull/15429) by [@zhigang1992](https://github.com/zhigang1992))
+
 ### 💡 Others
 
 ## 0.8.6 — 2021-12-03

--- a/packages/expo-dev-menu/android/src/main/AndroidManifest.xml
+++ b/packages/expo-dev-menu/android/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <activity
       android:name=".DevMenuActivity"
       android:theme="@style/Theme.AppCompat.Transparent.NoActionBar"
+      android:exported="true"
       android:launchMode="singleTask">
     <intent-filter>
       <action android:name="android.intent.action.VIEW"/>


### PR DESCRIPTION
# Why

On Android 31 and up, any activity with intent-filter need to have this flag set explicitly 

# Test Plan

Create a release build with dev-client, and test them out on https://appetize.io/ with Pixel 6 Pro
