### PR TITLE
[home] Fix home dev menu broken gesture controls

### DIFF
--- a/dev-home-config.json
+++ b/dev-home-config.json
@@ -1,3 +1,3 @@
 {
-  "url": "exp://expo.io/@expo-home-dev/expo-home-dev-25a7353b409a6b97f5abd27e3ea15b95e27145cf"
+  "url": "exp://expo.io/@expo-home-dev/expo-home-dev-c4b05bddcd310cae98a2ff1627631b2f4cc8286a"
 }

--- a/home/App.tsx
+++ b/home/App.tsx
@@ -3,6 +3,7 @@ import * as SplashScreen from 'expo-splash-screen';
 import * as React from 'react';
 import { Platform } from 'react-native';
 import { AppearanceProvider } from 'react-native-appearance';
+import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { enableScreens } from 'react-native-screens';
 import { Provider as ReduxProvider } from 'react-redux';
 
@@ -19,12 +20,14 @@ SplashScreen.preventAutoHideAsync();
 
 export default function App() {
   return (
-    <AppearanceProvider>
-      <ReduxProvider store={Store}>
-        <ApolloProvider client={ApolloClient}>
-          <HomeApp />
-        </ApolloProvider>
-      </ReduxProvider>
-    </AppearanceProvider>
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <AppearanceProvider>
+        <ReduxProvider store={Store}>
+          <ApolloProvider client={ApolloClient}>
+            <HomeApp />
+          </ApolloProvider>
+        </ReduxProvider>
+      </AppearanceProvider>
+    </GestureHandlerRootView>
   );
 }

--- a/home/menu/DevMenuApp.tsx
+++ b/home/menu/DevMenuApp.tsx
@@ -2,6 +2,7 @@ import { ThemeProvider } from '@react-navigation/native';
 import React from 'react';
 import { AppRegistry } from 'react-native';
 import { AppearanceProvider, useColorScheme } from 'react-native-appearance';
+import { GestureHandlerRootView } from 'react-native-gesture-handler';
 
 import { ColorTheme } from '../constants/Colors';
 import Themes from '../constants/Themes';
@@ -44,13 +45,15 @@ class DevMenuRoot extends React.PureComponent<{ task: { [key: string]: any }; uu
 function DevMenuApp(props: { task: { [key: string]: any }; uuid: string }) {
   const theme = useAppColorScheme(props.uuid);
   return (
-    <AppearanceProvider>
-      <DevMenuBottomSheet uuid={props.uuid}>
-        <ThemeProvider value={Themes[theme]}>
-          <DevMenuView {...props} />
-        </ThemeProvider>
-      </DevMenuBottomSheet>
-    </AppearanceProvider>
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <AppearanceProvider>
+        <DevMenuBottomSheet uuid={props.uuid}>
+          <ThemeProvider value={Themes[theme]}>
+            <DevMenuView {...props} />
+          </ThemeProvider>
+        </DevMenuBottomSheet>
+      </AppearanceProvider>
+    </GestureHandlerRootView>
   );
 }
 


### PR DESCRIPTION
# Why

for react-native-gesture-handler 2.0, native `RNGestureHandlerEnabledRootView` is deprecated in favor of `<GestureHandlerRootView />` component. i removed `RNGestureHandlerEnabledRootView` in https://github.com/expo/expo/pull/15404/files#diff-8577547e46982bd4a9595033ce80dc5047655e8a392fcb5d209db8a396241b55R9 but not adding the new component. that's why gesture is broken in expo go dev menu.

# How

- wrap home app components with `<GestureHandlerRootView />`
- `et publish-dev-home`

# Test Plan

test expo go dev menu gesture functions

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
