### PR TITLE
[android] fix for versioning sdk44

### DIFF
--- a/android/expoview/build.gradle
+++ b/android/expoview/build.gradle
@@ -252,6 +252,7 @@ dependencies {
   api fileTree(dir: 'libs', include: ['*.jar'])
   api 'androidx.multidex:multidex:2.0.0'
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
+  implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
 
   testImplementation 'junit:junit:4.12'
 

--- a/packages/expo-navigation-bar/android/src/main/java/expo/modules/navigationbar/NavigationBarReactActivityLifecycleListener.kt
+++ b/packages/expo-navigation-bar/android/src/main/java/expo/modules/navigationbar/NavigationBarReactActivityLifecycleListener.kt
@@ -6,6 +6,9 @@ import android.os.Bundle
 import android.util.Log
 import expo.modules.core.interfaces.ReactActivityLifecycleListener
 
+// this needs to stay for versioning to work
+// EXPO_VERSIONING_NEEDS_EXPOVIEW_R
+
 class NavigationBarReactActivityLifecycleListener(activityContext: Context) : ReactActivityLifecycleListener {
   override fun onCreate(activity: Activity, savedInstanceState: Bundle?) {
     // Execute static tasks before the JS engine starts.

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.kt
@@ -18,9 +18,9 @@ import expo.modules.updates.loader.RemoteLoader
 import expo.modules.updates.manifest.ManifestMetadata
 import expo.modules.updates.manifest.UpdateManifest
 
-// this unused import must stay because of versioning
+// these unused imports must stay because of versioning
 /* ktlint-disable no-unused-imports */
-
+import expo.modules.updates.UpdatesConfiguration
 /* ktlint-enable no-unused-imports */
 
 class UpdatesModule(

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesPackage.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesPackage.kt
@@ -10,6 +10,10 @@ import expo.modules.core.interfaces.InternalModule
 import expo.modules.core.interfaces.ReactNativeHostHandler
 
 // these unused imports must stay because of versioning
+/* ktlint-disable no-unused-imports */
+import expo.modules.updates.UpdatesController
+/* ktlint-enable no-unused-imports */
+
 class UpdatesPackage : Package {
   override fun createInternalModules(context: Context): List<InternalModule> {
     return listOf(UpdatesService(context) as InternalModule)

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesService.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesService.kt
@@ -11,6 +11,11 @@ import expo.modules.updates.selectionpolicy.SelectionPolicy
 import java.io.File
 
 // these unused imports must stay because of versioning
+/* ktlint-disable no-unused-imports */
+import expo.modules.updates.UpdatesConfiguration
+import expo.modules.updates.UpdatesController
+/* ktlint-enable no-unused-imports */
+
 open class UpdatesService(protected var context: Context) : InternalModule, UpdatesInterface {
   override fun getExportedInterfaces(): List<Class<*>> {
     return listOf(UpdatesInterface::class.java as Class<*>)


### PR DESCRIPTION
# Why

fix errors for building sdk 44 on android

# How

- `org.jetbrains.kotlin:kotlin-reflect` for expo-modules-core
- add missing imports

# Test Plan

`et add-sdk -p android -s 44.0.0`
build versioned expo go and launch test

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
  - no user-facing changes
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
