### PR TITLE
[sweet][kotlin] Fix versioning

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/ExperiencePackagePicker.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/ExperiencePackagePicker.kt
@@ -13,6 +13,7 @@ import expo.modules.battery.BatteryPackage
 import expo.modules.brightness.BrightnessPackage
 import expo.modules.calendar.CalendarPackage
 import expo.modules.camera.CameraPackage
+import expo.modules.cellular.CellularModule
 import expo.modules.clipboard.ClipboardPackage
 import expo.modules.constants.ConstantsPackage
 import expo.modules.contacts.ContactsPackage
@@ -35,11 +36,16 @@ import expo.modules.imagemanipulator.ImageManipulatorPackage
 import expo.modules.imagepicker.ImagePickerPackage
 import expo.modules.intentlauncher.IntentLauncherPackage
 import expo.modules.keepawake.KeepAwakePackage
+import expo.modules.kotlin.ModulesProvider
+import expo.modules.kotlin.modules.Module
+import expo.modules.lineargradient.LinearGradientModule
 import expo.modules.localauthentication.LocalAuthenticationPackage
 import expo.modules.localization.LocalizationPackage
 import expo.modules.location.LocationPackage
 import expo.modules.mailcomposer.MailComposerPackage
+import expo.modules.manifests.core.Manifest
 import expo.modules.medialibrary.MediaLibraryPackage
+import expo.modules.navigationbar.NavigationBarPackage
 import expo.modules.network.NetworkPackage
 import expo.modules.notifications.NotificationsPackage
 import expo.modules.permissions.PermissionsPackage
@@ -54,15 +60,13 @@ import expo.modules.speech.SpeechPackage
 import expo.modules.splashscreen.SplashScreenPackage
 import expo.modules.sqlite.SQLitePackage
 import expo.modules.storereview.StoreReviewPackage
+import expo.modules.systemui.SystemUIPackage
 import expo.modules.taskManager.TaskManagerPackage
 import expo.modules.updates.UpdatesPackage
-import expo.modules.manifests.core.Manifest
-import expo.modules.navigationbar.NavigationBarPackage
-import expo.modules.systemui.SystemUIPackage
 import expo.modules.videothumbnails.VideoThumbnailsPackage
 import expo.modules.webbrowser.WebBrowserPackage
 
-object ExperiencePackagePicker {
+object ExperiencePackagePicker : ModulesProvider {
   private val EXPO_MODULES_PACKAGES = listOf(
     AVPackage(),
     AdMobPackage(),
@@ -139,4 +143,9 @@ object ExperiencePackagePicker {
   fun packages(manifest: Manifest?): List<Package> {
     return EXPO_MODULES_PACKAGES
   }
+
+  override fun getModulesList(): List<Class<out Module>> = listOf(
+    CellularModule::class.java,
+    LinearGradientModule::class.java
+  )
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/ExponentPackage.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/ExponentPackage.kt
@@ -10,6 +10,7 @@ import com.facebook.react.uimanager.ViewManager
 import expo.modules.adapters.react.ReactModuleRegistryProvider
 import expo.modules.core.interfaces.Package
 import expo.modules.core.interfaces.SingletonModule
+import expo.modules.kotlin.ModulesProvider
 import expo.modules.random.RandomModule
 import expo.modules.manifests.core.Manifest
 import host.exp.exponent.Constants
@@ -98,7 +99,7 @@ class ExponentPackage : ReactPackage {
       registryAdapter = delegate.getScopedModuleRegistryAdapterForPackages(packages, singletonModules)
     }
     if (registryAdapter == null) {
-      registryAdapter = createDefaultModuleRegistryAdapterForPackages(packages, singletonModules)
+      registryAdapter = createDefaultModuleRegistryAdapterForPackages(packages, singletonModules, ExperiencePackagePicker)
     }
     return registryAdapter
   }
@@ -214,9 +215,10 @@ class ExponentPackage : ReactPackage {
 
   private fun createDefaultModuleRegistryAdapterForPackages(
     packages: List<Package>,
-    singletonModules: List<SingletonModule>?
+    singletonModules: List<SingletonModule>?,
+    modulesProvider: ModulesProvider? = null
   ): ExpoModuleRegistryAdapter {
-    return ExpoModuleRegistryAdapter(ReactModuleRegistryProvider(packages, singletonModules))
+    return ExpoModuleRegistryAdapter(ReactModuleRegistryProvider(packages, singletonModules), modulesProvider)
   }
 
   companion object {

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ExpoModuleRegistryAdapter.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ExpoModuleRegistryAdapter.kt
@@ -5,6 +5,7 @@ import com.facebook.react.bridge.ReactApplicationContext
 import expo.modules.adapters.react.ModuleRegistryAdapter
 import expo.modules.adapters.react.ReactModuleRegistryProvider
 import expo.modules.core.interfaces.RegistryLifecycleListener
+import expo.modules.kotlin.ModulesProvider
 import expo.modules.manifests.core.Manifest
 import host.exp.exponent.utils.ScopedContext
 import host.exp.exponent.kernel.ExperienceKey
@@ -15,8 +16,8 @@ import versioned.host.exp.exponent.modules.universal.notifications.*
 import versioned.host.exp.exponent.modules.universal.sensors.*
 import java.lang.RuntimeException
 
-open class ExpoModuleRegistryAdapter(moduleRegistryProvider: ReactModuleRegistryProvider?) :
-  ModuleRegistryAdapter(moduleRegistryProvider), ScopedModuleRegistryAdapter {
+open class ExpoModuleRegistryAdapter(moduleRegistryProvider: ReactModuleRegistryProvider?, modulesProvider: ModulesProvider? = null) :
+  ModuleRegistryAdapter(moduleRegistryProvider, modulesProvider), ScopedModuleRegistryAdapter {
   override fun createNativeModules(
     scopedContext: ScopedContext,
     experienceKey: ExperienceKey,

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/ModuleRegistryAdapter.java
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/ModuleRegistryAdapter.java
@@ -15,6 +15,7 @@ import expo.modules.core.ModuleRegistry;
 import expo.modules.core.interfaces.InternalModule;
 import expo.modules.core.interfaces.Package;
 import expo.modules.kotlin.KotlinInteropModuleRegistry;
+import expo.modules.kotlin.ModulesProvider;
 import expo.modules.kotlin.views.ViewWrapperDelegateHolder;
 
 /**
@@ -24,6 +25,7 @@ import expo.modules.kotlin.views.ViewWrapperDelegateHolder;
  */
 public class ModuleRegistryAdapter implements ReactPackage {
   protected ReactModuleRegistryProvider mModuleRegistryProvider;
+  protected ModulesProvider mModulesProvider;
   protected ReactAdapterPackage mReactAdapterPackage = new ReactAdapterPackage();
   private NativeModulesProxy mModulesProxy;
   // We need to save all view holders to update them when the new kotlin module registry will be created.
@@ -35,6 +37,11 @@ public class ModuleRegistryAdapter implements ReactPackage {
 
   public ModuleRegistryAdapter(ReactModuleRegistryProvider moduleRegistryProvider) {
     mModuleRegistryProvider = moduleRegistryProvider;
+  }
+
+  public ModuleRegistryAdapter(ReactModuleRegistryProvider moduleRegistryProvider, ModulesProvider modulesProvider) {
+    mModuleRegistryProvider = moduleRegistryProvider;
+    mModulesProvider = modulesProvider;
   }
 
   @Override
@@ -57,7 +64,7 @@ public class ModuleRegistryAdapter implements ReactPackage {
   protected List<NativeModule> getNativeModulesFromModuleRegistry(ReactApplicationContext reactContext, ModuleRegistry moduleRegistry) {
     List<NativeModule> nativeModulesList = new ArrayList<>(2);
 
-    mModulesProxy = new NativeModulesProxy(reactContext, moduleRegistry);
+    mModulesProxy = createNativeModulesProxy(reactContext, moduleRegistry);
     nativeModulesList.add(mModulesProxy);
 
     // Add listener that will notify expo.modules.core.ModuleRegistry when all modules are ready
@@ -96,5 +103,13 @@ public class ModuleRegistryAdapter implements ReactPackage {
     viewManagerList.addAll(kViewManager);
 
     return viewManagerList;
+  }
+
+  private NativeModulesProxy createNativeModulesProxy(ReactApplicationContext reactContext, ModuleRegistry moduleRegistry) {
+    if (mModulesProvider != null) {
+      return new NativeModulesProxy(reactContext, moduleRegistry, mModulesProvider);
+    } else {
+      return new NativeModulesProxy(reactContext, moduleRegistry);
+    }
   }
 }


### PR DESCRIPTION
# Why

The modules created using the new sweet API weren't versioned correctly. 

# How

Made an `ExperiencePackagePicker` a module provider that exports all the modules available in expo go.
Noticed that `ExpoModulesPackageList` won't be versioned and that is correct behavior. This class won't be used by expo go anymore. 

# Test Plan

- expo go ✅
- run `et add-sdk -p android -s 44.0.0` and everything was looking good. I couldn't test it, cause I got a crash at the start of the application. However, it also occurred without my changes. But this might be an issue on my end. 