### PR TITLE
[docs] Add a section to the authentication guide about exchanging access tokens

### DIFF
--- a/docs/pages/guides/authentication.md
+++ b/docs/pages/guides/authentication.md
@@ -20,6 +20,14 @@ Here are some **important rules** that apply to all authentication providers:
 - Be sure to disable the prompt until `request` is defined.
 - You can only invoke `promptAsync` in a user-interaction on web.
 
+## Obtaining access tokens
+
+The vast majority of providers described here implement the [OAuth 2](https://oauth.net/2/) standard for secure authentication/authorization.
+In the authorization code grant, the identity provider returns a one-time code which is then exchanged for the user's access token. Because
+[your application code is not a secure place to store secrets](https://reactnative.dev/docs/security#storing-sensitive-info), it is necessary to
+exchange the authorization code in a context (e.g., your server) where you can securely store and use a client secret to access the provider's
+token endpoint.
+
 ## Guides
 
 **AuthSession** can be used for any OAuth or OpenID Connect provider, we've assembled guides for using the most requested services!

--- a/docs/pages/guides/authentication.md
+++ b/docs/pages/guides/authentication.md
@@ -22,11 +22,7 @@ Here are some **important rules** that apply to all authentication providers:
 
 ## Obtaining access tokens
 
-The vast majority of providers described here implement the [OAuth 2](https://oauth.net/2/) standard for secure authentication/authorization.
-In the authorization code grant, the identity provider returns a one-time code which is then exchanged for the user's access token. Because
-[your application code is not a secure place to store secrets](https://reactnative.dev/docs/security#storing-sensitive-info), it is necessary to
-exchange the authorization code in a context (e.g., your server) where you can securely store and use a client secret to access the provider's
-token endpoint.
+The vast majority of providers described here implement the [OAuth 2](https://oauth.net/2/) standard for secure authentication/authorization. In the authorization code grant, the identity provider returns a one-time code, which is exchanged for the user's access token. Since [your application code is not a secure place to store secrets](https://reactnative.dev/docs/security#storing-sensitive-info), it is necessary to exchange the authorization code in a context (for example, your server) where you can securely store and use a client secret to access the provider's token endpoint.
 
 ## Guides
 


### PR DESCRIPTION
# Why

Novice (and heck, even experienced) users may not realize immediately that OAuth2 providers will return an authorization code that then needs to be exchanged for a token. This must happen in a secure context, e.g. a server. We should be explicit about this.

# How

I didn't realize this (even though I'm pretty experienced with OAuth2) until I started testing. If the docs were more explicit, this would have been a better developer experience.

# Test Plan

Docs change only.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
