### PR TITLE
[updates] Always expose release channel on iOS

### DIFF
--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesModule.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesModule.m
@@ -28,14 +28,16 @@ EX_EXPORT_MODULE(ExpoUpdates);
   if (!_updatesService.isStarted) {
     return @{
       @"isEnabled": @(NO),
-      @"isMissingRuntimeVersion": @(_updatesService.config.isMissingRuntimeVersion)
+      @"isMissingRuntimeVersion": @(_updatesService.config.isMissingRuntimeVersion),
+      @"releaseChannel": _updatesService.config.releaseChannel
     };
   }
   EXUpdatesUpdate *launchedUpdate = _updatesService.launchedUpdate;
   if (!launchedUpdate) {
     return @{
       @"isEnabled": @(NO),
-      @"isMissingRuntimeVersion": @(_updatesService.config.isMissingRuntimeVersion)
+      @"isMissingRuntimeVersion": @(_updatesService.config.isMissingRuntimeVersion),
+      @"releaseChannel": _updatesService.config.releaseChannel
     };
   } else {
     return @{


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/eas-cli/issues/819

There is a small, but slightly confusing difference in behavior on Android and iOS.

# How

When working with dev-clients, setting a release channel will always be exposed through `Updates.releaseChannel` on Android. On iOS, this is only exposed when loading an OTA or update. 

This behavior causes issues for people using the release channel to determine the app configuration (as [described in our docs](https://docs.expo.dev/distribution/release-channels/#using-release-channels-for-environment-variable-configuration))

This change always passes the release channel set in the `Expo.plist`, even when loading a local bundle (through `expo start --dev-client`)

# Test Plan

- Create a dev client with a different release channel (e.g. `pre-pod`)
- Build through EAS (or locally, but manually set the release channel in `Expo.plist`)

#### Local bundler
- Load a local instance and render `import { releaseChannel } from 'expo-updates';`
- Behavior should be:
  - Android: output the custom release channel (current behavior)
  - iOS: output the custom release channel (fixed behavior)

#### Update
- Load from published bundle (e.g. `https://exp.host/@bycedric/abc-123`)
- Behavior should be:
  - Android: `pre-prod`/custom release channel name should be rendered (current behavior)
  - iOS: `pre-prod`/custom release channel name should be rendered (current behavior)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
