### PR TITLE
[ios] fix ios shell app error from RNAWSCognito.h

### DIFF
--- a/ios/Exponent/Versioned/Core/Api/Cognito/RNAWSCognito.h
+++ b/ios/Exponent/Versioned/Core/Api/Cognito/RNAWSCognito.h
@@ -1,21 +1,14 @@
-#if __has_include("RCTBridgeModule.h")
-#import "RCTBridgeModule.h"
-#else
+/**
+ NOTE: the imports are slightly changed by hand for expo versioning.
+ since cognito sdk does not change frequently, these changes do not include in `update-vendored-module` script and you should update manually after upgrading the module.
+ changes we did:
+   - replace imports from double-quote "" to bracket <> for xcode to find the correct versioning headers and clang modules.
+ */
+
 #import <React/RCTBridgeModule.h>
-#endif
-
-#if __has_include("RCTLog.h")
-#import "RCTLog.h"
-#else
 #import <React/RCTLog.h>
-#endif
-
-#if __has_include("RCTUtils.h")
-#import "RCTUtils.h"
-#else
 #import <React/RCTUtils.h>
-#endif
-// Must use brackets instead of quotes for importing JKBigInteger otherwise this is broken by versioning
+
 #import <JKBigInteger.h>
 
 @interface RNAWSCognito : NSObject <RCTBridgeModule>

--- a/ios/Exponent/Versioned/Core/Api/Cognito/RNAWSCognito.h
+++ b/ios/Exponent/Versioned/Core/Api/Cognito/RNAWSCognito.h
@@ -1,6 +1,6 @@
 /**
  NOTE: the imports are slightly changed by hand for expo versioning.
- since cognito sdk does not change frequently, these changes do not include in `update-vendored-module` script and you should update manually after upgrading the module.
+ since cognito sdk does not change frequently, these changes are not included in `update-vendored-module` script. you should modify manually whenever upgrading the module.
  changes we did:
    - replace imports from double-quote "" to bracket <> for xcode to find the correct versioning headers and clang modules.
  */

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/Api/Cognito/ABI41_0_0RNAWSCognito.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/Api/Cognito/ABI41_0_0RNAWSCognito.h
@@ -1,6 +1,6 @@
 /**
  NOTE: the imports are slightly changed by hand for expo versioning.
- since cognito sdk does not change frequently, these changes do not include in `update-vendored-module` script and you should update manually after upgrading the module.
+ since cognito sdk does not change frequently, these changes are not included in `update-vendored-module` script. you should modify manually whenever upgrading the module.
  changes we did:
    - replace imports from double-quote "" to bracket <> for xcode to find the correct versioning headers and clang modules.
  */

--- a/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/Api/Cognito/ABI41_0_0RNAWSCognito.h
+++ b/ios/versioned-react-native/ABI41_0_0/Expo/ExpoKit/Core/Api/Cognito/ABI41_0_0RNAWSCognito.h
@@ -1,20 +1,13 @@
-#if __has_include("ABI41_0_0RCTBridgeModule.h")
-#import "ABI41_0_0RCTBridgeModule.h"
-#else
+/**
+ NOTE: the imports are slightly changed by hand for expo versioning.
+ since cognito sdk does not change frequently, these changes do not include in `update-vendored-module` script and you should update manually after upgrading the module.
+ changes we did:
+   - replace imports from double-quote "" to bracket <> for xcode to find the correct versioning headers and clang modules.
+ */
+
 #import <ABI41_0_0React/ABI41_0_0RCTBridgeModule.h>
-#endif
-
-#if __has_include("ABI41_0_0RCTLog.h")
-#import "ABI41_0_0RCTLog.h"
-#else
 #import <ABI41_0_0React/ABI41_0_0RCTLog.h>
-#endif
-
-#if __has_include("ABI41_0_0RCTUtils.h")
-#import "ABI41_0_0RCTUtils.h"
-#else
 #import <ABI41_0_0React/ABI41_0_0RCTUtils.h>
-#endif
 
 #import <JKBigInteger.h>
 

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/Api/Cognito/ABI42_0_0RNAWSCognito.h
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/Api/Cognito/ABI42_0_0RNAWSCognito.h
@@ -1,20 +1,13 @@
-#if __has_include("ABI42_0_0RCTBridgeModule.h")
-#import "ABI42_0_0RCTBridgeModule.h"
-#else
+/**
+ NOTE: the imports are slightly changed by hand for expo versioning.
+ since cognito sdk does not change frequently, these changes do not include in `update-vendored-module` script and you should update manually after upgrading the module.
+ changes we did:
+   - replace imports from double-quote "" to bracket <> for xcode to find the correct versioning headers and clang modules.
+ */
+
 #import <ABI42_0_0React/ABI42_0_0RCTBridgeModule.h>
-#endif
-
-#if __has_include("ABI42_0_0RCTLog.h")
-#import "ABI42_0_0RCTLog.h"
-#else
 #import <ABI42_0_0React/ABI42_0_0RCTLog.h>
-#endif
-
-#if __has_include("ABI42_0_0RCTUtils.h")
-#import "ABI42_0_0RCTUtils.h"
-#else
 #import <ABI42_0_0React/ABI42_0_0RCTUtils.h>
-#endif
 
 #import <JKBigInteger.h>
 

--- a/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/Api/Cognito/ABI42_0_0RNAWSCognito.h
+++ b/ios/versioned-react-native/ABI42_0_0/Expo/ExpoKit/Core/Api/Cognito/ABI42_0_0RNAWSCognito.h
@@ -1,6 +1,6 @@
 /**
  NOTE: the imports are slightly changed by hand for expo versioning.
- since cognito sdk does not change frequently, these changes do not include in `update-vendored-module` script and you should update manually after upgrading the module.
+ since cognito sdk does not change frequently, these changes are not included in `update-vendored-module` script. you should modify manually whenever upgrading the module.
  changes we did:
    - replace imports from double-quote "" to bracket <> for xcode to find the correct versioning headers and clang modules.
  */

--- a/ios/versioned-react-native/ABI43_0_0/Expo/ExpoKit/Core/Api/Cognito/ABI43_0_0RNAWSCognito.h
+++ b/ios/versioned-react-native/ABI43_0_0/Expo/ExpoKit/Core/Api/Cognito/ABI43_0_0RNAWSCognito.h
@@ -1,21 +1,14 @@
-#if __has_include("ABI43_0_0RCTBridgeModule.h")
-#import "ABI43_0_0RCTBridgeModule.h"
-#else
+/**
+ NOTE: the imports are slightly changed by hand for expo versioning.
+ since cognito sdk does not change frequently, these changes do not include in `update-vendored-module` script and you should update manually after upgrading the module.
+ changes we did:
+   - replace imports from double-quote "" to bracket <> for xcode to find the correct versioning headers and clang modules.
+ */
+
 #import <ABI43_0_0React/ABI43_0_0RCTBridgeModule.h>
-#endif
-
-#if __has_include("ABI43_0_0RCTLog.h")
-#import "ABI43_0_0RCTLog.h"
-#else
 #import <ABI43_0_0React/ABI43_0_0RCTLog.h>
-#endif
-
-#if __has_include("ABI43_0_0RCTUtils.h")
-#import "ABI43_0_0RCTUtils.h"
-#else
 #import <ABI43_0_0React/ABI43_0_0RCTUtils.h>
-#endif
-// Must use brackets instead of quotes for importing JKBigInteger otherwise this is broken by versioning
+
 #import <JKBigInteger.h>
 
 @interface ABI43_0_0RNAWSCognito : NSObject <ABI43_0_0RCTBridgeModule>

--- a/ios/versioned-react-native/ABI43_0_0/Expo/ExpoKit/Core/Api/Cognito/ABI43_0_0RNAWSCognito.h
+++ b/ios/versioned-react-native/ABI43_0_0/Expo/ExpoKit/Core/Api/Cognito/ABI43_0_0RNAWSCognito.h
@@ -1,6 +1,6 @@
 /**
  NOTE: the imports are slightly changed by hand for expo versioning.
- since cognito sdk does not change frequently, these changes do not include in `update-vendored-module` script and you should update manually after upgrading the module.
+ since cognito sdk does not change frequently, these changes are not included in `update-vendored-module` script. you should modify manually whenever upgrading the module.
  changes we did:
    - replace imports from double-quote "" to bracket <> for xcode to find the correct versioning headers and clang modules.
  */

--- a/ios/versioned-react-native/ABI44_0_0/Expo/ExpoKit/Core/Api/Cognito/ABI44_0_0RNAWSCognito.h
+++ b/ios/versioned-react-native/ABI44_0_0/Expo/ExpoKit/Core/Api/Cognito/ABI44_0_0RNAWSCognito.h
@@ -1,21 +1,14 @@
-#if __has_include("ABI44_0_0RCTBridgeModule.h")
-#import "ABI44_0_0RCTBridgeModule.h"
-#else
+/**
+ NOTE: the imports are slightly changed by hand for expo versioning.
+ since cognito sdk does not change frequently, these changes do not include in `update-vendored-module` script and you should update manually after upgrading the module.
+ changes we did:
+   - replace imports from double-quote "" to bracket <> for xcode to find the correct versioning headers and clang modules.
+ */
+
 #import <ABI44_0_0React/ABI44_0_0RCTBridgeModule.h>
-#endif
-
-#if __has_include("ABI44_0_0RCTLog.h")
-#import "ABI44_0_0RCTLog.h"
-#else
 #import <ABI44_0_0React/ABI44_0_0RCTLog.h>
-#endif
-
-#if __has_include("ABI44_0_0RCTUtils.h")
-#import "ABI44_0_0RCTUtils.h"
-#else
 #import <ABI44_0_0React/ABI44_0_0RCTUtils.h>
-#endif
-// Must use brackets instead of quotes for importing JKBigInteger otherwise this is broken by versioning
+
 #import <JKBigInteger.h>
 
 @interface ABI44_0_0RNAWSCognito : NSObject <ABI44_0_0RCTBridgeModule>

--- a/ios/versioned-react-native/ABI44_0_0/Expo/ExpoKit/Core/Api/Cognito/ABI44_0_0RNAWSCognito.h
+++ b/ios/versioned-react-native/ABI44_0_0/Expo/ExpoKit/Core/Api/Cognito/ABI44_0_0RNAWSCognito.h
@@ -1,6 +1,6 @@
 /**
  NOTE: the imports are slightly changed by hand for expo versioning.
- since cognito sdk does not change frequently, these changes do not include in `update-vendored-module` script and you should update manually after upgrading the module.
+ since cognito sdk does not change frequently, these changes are not included in `update-vendored-module` script. you should modify manually whenever upgrading the module.
  changes we did:
    - replace imports from double-quote "" to bracket <> for xcode to find the correct versioning headers and clang modules.
  */


### PR DESCRIPTION
# Why

fix ios shell app building error in `RNAWSCognito.m` which duplicated react definitions from different file paths.
the error was like this: https://github.com/expo/expo/runs/4439955300

# How

should use `#import <React/RCTLog.h>` instead of `#import "RCTLog.h"` and make xcode to find correct headers / clang modules. 

# Test Plan

- expo go ios versioned build passed
- ios shell app build passed: https://github.com/expo/expo/runs/4440313881

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
