### PR TITLE
[dev-launcher] Fix main activity when onNewIntent exists

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix plugin when MainActivity onNewIntent exists. ([#15459](https://github.com/expo/expo/pull/15459) by [@janicduplessis](https://github.com/janicduplessis))
+- Fix plugin when `MainActivity.onNewIntent` exists. ([#15459](https://github.com/expo/expo/pull/15459) by [@janicduplessis](https://github.com/janicduplessis))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix plugin when MainActivity onNewIntent exists. ([#15459](https://github.com/expo/expo/pull/15459) by [@janicduplessis](https://github.com/janicduplessis))
+
 ### 💡 Others
 
 ## 0.9.0 — 2021-12-03

--- a/packages/expo-dev-launcher/plugin/build/withDevLauncher.d.ts
+++ b/packages/expo-dev-launcher/plugin/build/withDevLauncher.d.ts
@@ -1,3 +1,4 @@
 import { ConfigPlugin } from '@expo/config-plugins';
+export declare function modifyJavaMainActivity(content: string): string;
 declare const _default: ConfigPlugin<unknown>;
 export default _default;

--- a/packages/expo-dev-launcher/plugin/src/__tests__/__snapshots__/withDevLauncher-test.ts.snap
+++ b/packages/expo-dev-launcher/plugin/src/__tests__/__snapshots__/withDevLauncher-test.ts.snap
@@ -1,0 +1,55 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`modifyJavaMainActivity modifies the MainActivity file for dev-launcher 1`] = `
+"import android.content.Intent;
+import expo.modules.devlauncher.DevLauncherController;
+import com.facebook.react.ReactActivity;
+
+public class MainActivity extends ReactActivity {
+
+  @Override
+  public void onNewIntent(Intent intent) {
+    if (DevLauncherController.tryToHandleIntent(this, intent)) {
+      return;
+    }
+    super.onNewIntent(intent);
+  }
+
+  /**
+    * Returns the name of the main component registered from JavaScript. This is used to schedule
+    * rendering of the component.
+    */
+  @Override
+  protected String getMainComponentName() {
+    return \\"react-native-project\\";
+  }
+}
+"
+`;
+
+exports[`modifyJavaMainActivity modifies the MainActivity file for dev-launcher when onNewIntent exists 1`] = `
+"import android.content.Intent;
+import expo.modules.devlauncher.DevLauncherController;
+import com.facebook.react.ReactActivity;
+
+public class MainActivity extends ReactActivity {
+  /**
+    * Returns the name of the main component registered from JavaScript. This is used to schedule
+    * rendering of the component.
+    */
+  @Override
+  protected String getMainComponentName() {
+    return \\"react-native-project\\";
+  }
+
+  @Override
+  protected void onNewIntent(Intent intent) {
+    if (DevLauncherController.tryToHandleIntent(this, intent)) {
+      return;
+    }
+    super.onNewIntent(intent);
+    setIntent(intent);
+  }
+}
+"
+`;

--- a/packages/expo-dev-launcher/plugin/src/__tests__/fixtures/MainActivity-react-native.java
+++ b/packages/expo-dev-launcher/plugin/src/__tests__/fixtures/MainActivity-react-native.java
@@ -1,0 +1,12 @@
+import com.facebook.react.ReactActivity;
+
+public class MainActivity extends ReactActivity {
+  /**
+    * Returns the name of the main component registered from JavaScript. This is used to schedule
+    * rendering of the component.
+    */
+  @Override
+  protected String getMainComponentName() {
+    return "react-native-project";
+  }
+}

--- a/packages/expo-dev-launcher/plugin/src/__tests__/fixtures/MainActivity-with-on-new-intent.java
+++ b/packages/expo-dev-launcher/plugin/src/__tests__/fixtures/MainActivity-with-on-new-intent.java
@@ -1,0 +1,18 @@
+import com.facebook.react.ReactActivity;
+
+public class MainActivity extends ReactActivity {
+  /**
+    * Returns the name of the main component registered from JavaScript. This is used to schedule
+    * rendering of the component.
+    */
+  @Override
+  protected String getMainComponentName() {
+    return "react-native-project";
+  }
+
+  @Override
+  protected void onNewIntent(Intent intent) {
+    super.onNewIntent(intent);
+    setIntent(intent);
+  }
+}

--- a/packages/expo-dev-launcher/plugin/src/__tests__/withDevLauncher-test.ts
+++ b/packages/expo-dev-launcher/plugin/src/__tests__/withDevLauncher-test.ts
@@ -1,0 +1,33 @@
+import fs from 'fs';
+import path from 'path';
+
+import { modifyJavaMainActivity } from '../withDevLauncher';
+
+describe(modifyJavaMainActivity, () => {
+  it(`modifies the MainActivity file for dev-launcher`, () => {
+    const fixture = fs.readFileSync(
+      path.join(__dirname, 'fixtures', 'MainActivity-react-native.java'),
+      'utf8'
+    );
+    expect(modifyJavaMainActivity(fixture)).toMatchSnapshot();
+  });
+
+  it(`modifies the MainActivity file for dev-launcher when onNewIntent exists`, () => {
+    const fixture = fs.readFileSync(
+      path.join(__dirname, 'fixtures', 'MainActivity-with-on-new-intent.java'),
+      'utf8'
+    );
+    expect(modifyJavaMainActivity(fixture)).toMatchSnapshot();
+  });
+
+  it(`modifying MainActivity twice doesn't change the content`, () => {
+    const firstModification = fs.readFileSync(
+      path.join(__dirname, 'fixtures', 'MainActivity-react-native.java'),
+      'utf8'
+    );
+    modifyJavaMainActivity(firstModification);
+    const secondModification = `${firstModification}`;
+    modifyJavaMainActivity(secondModification);
+    expect(secondModification).toBe(firstModification);
+  });
+});


### PR DESCRIPTION
# Why

If another plugin adds `onNewIntent` the dev-launcher plugin will cause the method to be added twice and fail building.

# How

Separate adding the code in 2 steps, first check if the method exist and add it if it doesn't, second add the code inside the method.

# Test Plan

- Add tests for main activity
- Test in an app that has another plugin that adds code to onNewIntent.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
