### PR TITLE
[android] Add back background location permission for Expo Go

### DIFF
--- a/android/expoview/src/main/AndroidManifest.xml
+++ b/android/expoview/src/main/AndroidManifest.xml
@@ -33,6 +33,7 @@
   <uses-permission android:name="android.permission.CAMERA" />
   <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
   <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+  <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
   <uses-permission android:name="android.permission.ACCESS_MEDIA_LOCATION" />
 
 

--- a/android/versioned-abis/expoview-abi44_0_0/src/main/AndroidManifest.xml
+++ b/android/versioned-abis/expoview-abi44_0_0/src/main/AndroidManifest.xml
@@ -25,6 +25,7 @@
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_MEDIA_LOCATION" />
 
     <uses-feature


### PR DESCRIPTION
# Why

- Fixes the background location usage in Expo Go.

# How

- Added it to Expoview manifest
- [Validated the permission is blacklisted and removed](https://github.com/expo/xdl/blob/main/packages/xdl/src/detach/AndroidShellApp.js#L945) (when not defined in app.json's `expo.android.permissions` list)

# Test Plan

- Build Expo Go
- Open NCL
- Try requesting background location permission

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
