### PR TITLE
[ncl][barcode-scanner] Use built-in permission requester in example

### DIFF
--- a/apps/native-component-list/src/screens/BarCodeScannerScreen.tsx
+++ b/apps/native-component-list/src/screens/BarCodeScannerScreen.tsx
@@ -1,10 +1,8 @@
-import { BarCodeScanner, BarCodePoint, BarCodeBounds } from 'expo-barcode-scanner';
+import { BarCodeScanner, BarCodePoint, BarCodeBounds, usePermissions } from 'expo-barcode-scanner';
 import * as ScreenOrientation from 'expo-screen-orientation';
 import React from 'react';
 import { Button, Platform, StyleSheet, Text, View } from 'react-native';
 import * as Svg from 'react-native-svg';
-
-import usePermissions from '../utilities/usePermissions';
 
 const BUTTON_COLOR = Platform.OS === 'ios' ? '#fff' : '#666';
 
@@ -39,17 +37,24 @@ function reducer(state: State, action: Partial<State>): State {
 }
 
 export default function BarcodeScannerScreen() {
-  const [isPermissionsGranted] = usePermissions(BarCodeScanner.requestPermissionsAsync);
+  const [permission, requestPermission] = usePermissions();
 
-  if (!isPermissionsGranted) {
-    return (
-      <View style={styles.container}>
-        <Text>You have not granted permission to use the camera on this device!</Text>
-      </View>
-    );
+  if (!permission) {
+    return null;
   }
 
-  return <BarcodeScannerExample />;
+  if (permission.granted) {
+    return <BarcodeScannerExample />;
+  }
+
+  return (
+    <View style={[styles.container, { justifyContent: 'center', alignItems: 'center' }]}>
+      <Text style={{ margin: 16 }}>
+        You have not granted permission to use the camera on this device!
+      </Text>
+      <Button onPress={requestPermission} title="Grant permission" />
+    </View>
+  );
 }
 
 function BarcodeScannerExample() {

--- a/apps/native-component-list/src/screens/BarCodeScannerScreen.tsx
+++ b/apps/native-component-list/src/screens/BarCodeScannerScreen.tsx
@@ -176,9 +176,21 @@ function BarcodeScannerExample() {
       <View style={styles.toolbar}>
         <Button color={BUTTON_COLOR} title="Direction" onPress={toggleType} />
         <Button color={BUTTON_COLOR} title="Orientation" onPress={toggleScreenOrientationState} />
-        <Button color={BUTTON_COLOR} title="Bounding box" onPress={toggleBoundingBox} />
-        <Button color={BUTTON_COLOR} title="Text" onPress={toggleText} />
-        <Button color={BUTTON_COLOR} title="Alerting" onPress={toggleAlertingAboutResult} />
+        <Button
+          title="Bounding box"
+          onPress={toggleBoundingBox}
+          color={state.showBoundingBox ? undefined : BUTTON_COLOR}
+        />
+        <Button
+          title="Text"
+          onPress={toggleText}
+          color={state.showText ? undefined : BUTTON_COLOR}
+        />
+        <Button
+          title="Alerting"
+          onPress={toggleAlertingAboutResult}
+          color={state.alerting ? undefined : BUTTON_COLOR}
+        />
       </View>
     </View>
   );


### PR DESCRIPTION
# Why

During QA the barcode scanner never requested permission.

# How

- Replaced the old `usePermission` hook with the Barcode specific use permission hook
- For bounding box, text, and alerting: made button toggle to blue when enabled

# Test Plan

- Run NCL
- Open barcode scanner API screen
  - When not requested: it should show a button with "grant permission" and some text
  - When requested: it should show the barcode scanner

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
