### PR TITLE
[test-suite][linking] Ignore expected warning about navigation state

### DIFF
--- a/apps/test-suite/tests/Linking.js
+++ b/apps/test-suite/tests/Linking.js
@@ -1,7 +1,7 @@
 import Constants from 'expo-constants';
 import * as Linking from 'expo-linking';
 import * as WebBrowser from 'expo-web-browser';
-import { Platform } from 'react-native';
+import { LogBox, Platform } from 'react-native';
 
 import { waitFor } from './helpers';
 
@@ -9,6 +9,12 @@ const validHttpUrl = 'http://expo.io/';
 const validHttpsUrl = 'https://expo.io/';
 const validExpUrl = 'exp://expo.io/@community/native-component-list';
 const redirectingBackendUrl = 'https://backend-xxswjknyfi.now.sh/?linkingUri=';
+
+// Because the root navigator of test-suite doesn't have a matching screen for URL, it will warn.
+// This is expected as all tests are wrapped in `screens/TestScreen.js`, and not defined as separate screens.
+LogBox.ignoreLogs([
+  'navigation state parsed from the URL contains routes not present in the root navigator',
+]);
 
 export const name = 'Linking';
 


### PR DESCRIPTION
# Why

It's a bit confusing but this warning is expected. The root navigator in test suite doesn't have each test as separate screens, just the `screens/TestScreen.js`. 

# How

- Added logbox ignore statement

# Test Plan

- Open test-suite on Android
- Run Linking tests

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
