### PR TITLE
[react-native-screens][SDK 44] Backport vendored react-native-screens upgrade to SDK 44

### DIFF
--- a/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/host/exp/exponent/modules/api/screens/CustomSearchView.kt
+++ b/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/host/exp/exponent/modules/api/screens/CustomSearchView.kt
@@ -1,0 +1,71 @@
+package abi44_0_0.host.exp.exponent.modules.api.screens
+
+import android.content.Context
+import androidx.activity.OnBackPressedCallback
+import androidx.appcompat.widget.SearchView
+import androidx.fragment.app.Fragment
+
+class CustomSearchView(context: Context, fragment: Fragment) : SearchView(context) {
+    /*
+        CustomSearchView uses some variables from SearchView. They are listed below with links to documentation
+        isIconified - https://developer.android.com/reference/android/widget/SearchView#setIconified(boolean)
+        maxWidth - https://developer.android.com/reference/android/widget/SearchView#setMaxWidth(int)
+        setOnSearchClickListener - https://developer.android.com/reference/android/widget/SearchView#setOnSearchClickListener(android.view.View.OnClickListener)
+        setOnCloseListener - https://developer.android.com/reference/android/widget/SearchView#setOnCloseListener(android.widget.SearchView.OnCloseListener)
+    */
+  private var mCustomOnCloseListener: OnCloseListener? = null
+  private var mCustomOnSearchClickedListener: OnClickListener? = null
+
+  private var mOnBackPressedCallback: OnBackPressedCallback =
+    object : OnBackPressedCallback(true) {
+      override fun handleOnBackPressed() {
+        isIconified = true
+      }
+    }
+  private val backPressOverrider = FragmentBackPressOverrider(fragment, mOnBackPressedCallback)
+  var overrideBackAction: Boolean
+    set(value) {
+      backPressOverrider.overrideBackAction = value
+    }
+    get() = backPressOverrider.overrideBackAction
+
+  fun focus() {
+    isIconified = false
+    requestFocusFromTouch()
+  }
+
+  override fun setOnCloseListener(listener: OnCloseListener?) {
+    mCustomOnCloseListener = listener
+  }
+
+  override fun setOnSearchClickListener(listener: OnClickListener?) {
+    mCustomOnSearchClickedListener = listener
+  }
+
+  override fun onAttachedToWindow() {
+    super.onAttachedToWindow()
+    if (!isIconified) {
+      backPressOverrider.maybeAddBackCallback()
+    }
+  }
+
+  override fun onDetachedFromWindow() {
+    super.onDetachedFromWindow()
+    backPressOverrider.removeBackCallbackIfAdded()
+  }
+
+  init {
+    super.setOnSearchClickListener { v ->
+      mCustomOnSearchClickedListener?.onClick(v)
+      backPressOverrider.maybeAddBackCallback()
+    }
+
+    super.setOnCloseListener {
+      val result = mCustomOnCloseListener?.onClose() ?: false
+      backPressOverrider.removeBackCallbackIfAdded()
+      result
+    }
+
+    maxWidth = Integer.MAX_VALUE
+  }
+}

--- a/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/host/exp/exponent/modules/api/screens/CustomToolbar.kt
+++ b/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/host/exp/exponent/modules/api/screens/CustomToolbar.kt
@@ -1,0 +1,7 @@
+package abi44_0_0.host.exp.exponent.modules.api.screens
+
+import android.content.Context
+import androidx.appcompat.widget.Toolbar
+
+// This class is used to store config closer to search bar
+open class CustomToolbar(context: Context, val config: ScreenStackHeaderConfig) : Toolbar(context)

--- a/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/host/exp/exponent/modules/api/screens/FragmentBackPressOverrider.kt
+++ b/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/host/exp/exponent/modules/api/screens/FragmentBackPressOverrider.kt
@@ -1,0 +1,29 @@
+package abi44_0_0.host.exp.exponent.modules.api.screens
+
+import androidx.activity.OnBackPressedCallback
+import androidx.fragment.app.Fragment
+
+class FragmentBackPressOverrider(
+  private val fragment: Fragment,
+  private val mOnBackPressedCallback: OnBackPressedCallback
+) {
+  private var mIsBackCallbackAdded: Boolean = false
+  var overrideBackAction: Boolean = true
+
+  fun maybeAddBackCallback() {
+    if (!mIsBackCallbackAdded && overrideBackAction) {
+      fragment.activity?.onBackPressedDispatcher?.addCallback(
+        fragment,
+        mOnBackPressedCallback
+      )
+      mIsBackCallbackAdded = true
+    }
+  }
+
+  fun removeBackCallbackIfAdded() {
+    if (mIsBackCallbackAdded) {
+      mOnBackPressedCallback.remove()
+      mIsBackCallbackAdded = false
+    }
+  }
+}

--- a/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/host/exp/exponent/modules/api/screens/RNScreensPackage.kt
+++ b/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/host/exp/exponent/modules/api/screens/RNScreensPackage.kt
@@ -15,6 +15,7 @@ class RNScreensPackage : ReactPackage {
       ScreenViewManager(),
       ScreenStackViewManager(),
       ScreenStackHeaderConfigViewManager(),
-      ScreenStackHeaderSubviewManager()
+      ScreenStackHeaderSubviewManager(),
+      SearchBarManager()
     )
 }

--- a/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/host/exp/exponent/modules/api/screens/Screen.kt
+++ b/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/host/exp/exponent/modules/api/screens/Screen.kt
@@ -1,18 +1,13 @@
 package abi44_0_0.host.exp.exponent.modules.api.screens
 
 import android.annotation.SuppressLint
-import android.content.Context
 import android.content.pm.ActivityInfo
 import android.graphics.Paint
-import android.os.Build
 import android.os.Parcelable
 import android.util.SparseArray
-import android.view.View
 import android.view.ViewGroup
 import android.view.WindowManager
-import android.view.inputmethod.InputMethodManager
 import android.webkit.WebView
-import android.widget.TextView
 import abi44_0_0.com.facebook.react.bridge.GuardedRunnable
 import abi44_0_0.com.facebook.react.bridge.ReactContext
 import abi44_0_0.com.facebook.react.uimanager.UIManagerModule
@@ -84,28 +79,6 @@ class Screen constructor(context: ReactContext?) : ViewGroup(context) {
               ?.updateNodeSize(id, width, height)
           }
         })
-    }
-  }
-
-  override fun onAttachedToWindow() {
-    super.onAttachedToWindow()
-    // This method implements a workaround for RN's autoFocus functionality. Because of the way
-    // autoFocus is implemented it sometimes gets triggered before native text view is mounted. As
-    // a result Android ignores calls for opening soft keyboard and here we trigger it manually
-    // again after the screen is attached.
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-      var view = focusedChild
-      if (view != null) {
-        while (view is ViewGroup) {
-          view = view.focusedChild
-        }
-        if (view is TextView) {
-          val textView = view
-          if (textView.showSoftInputOnFocus) {
-            textView.addOnAttachStateChangeListener(sShowSoftKeyboardOnAttach)
-          }
-        }
-      }
     }
   }
 
@@ -183,6 +156,13 @@ class Screen constructor(context: ReactContext?) : ViewGroup(context) {
     fragment?.let { ScreenWindowTraits.setOrientation(this, it.tryGetActivity()) }
   }
 
+  // Accepts one of 4 accessibility flags
+  // developer.android.com/reference/android/view/View#attr_android:importantForAccessibility
+  fun changeAccessibilityMode(mode: Int) {
+    this.importantForAccessibility = mode
+    this.headerConfig?.toolbar?.importantForAccessibility = mode
+  }
+
   var statusBarStyle: String?
     get() = mStatusBarStyle
     set(statusBarStyle) {
@@ -253,19 +233,5 @@ class Screen constructor(context: ReactContext?) : ViewGroup(context) {
 
   enum class WindowTraits {
     ORIENTATION, COLOR, STYLE, TRANSLUCENT, HIDDEN, ANIMATED
-  }
-
-  companion object {
-    private val sShowSoftKeyboardOnAttach: OnAttachStateChangeListener =
-      object : OnAttachStateChangeListener {
-        override fun onViewAttachedToWindow(view: View) {
-          val inputMethodManager =
-            view.context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
-          inputMethodManager.showSoftInput(view, 0)
-          view.removeOnAttachStateChangeListener(this)
-        }
-
-        override fun onViewDetachedFromWindow(view: View) {}
-      }
   }
 }

--- a/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/host/exp/exponent/modules/api/screens/ScreenContainer.kt
+++ b/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/host/exp/exponent/modules/api/screens/ScreenContainer.kt
@@ -11,6 +11,7 @@ import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentTransaction
 import abi44_0_0.com.facebook.react.ReactRootView
+import abi44_0_0.com.facebook.react.bridge.ReactContext
 import abi44_0_0.com.facebook.react.modules.core.ChoreographerCompat
 import abi44_0_0.com.facebook.react.modules.core.ReactChoreographer
 import abi44_0_0.host.exp.exponent.modules.api.screens.Screen.ActivityState
@@ -176,16 +177,12 @@ open class ScreenContainer<T : ScreenFragment>(context: Context?) : ViewGroup(co
     return transaction
   }
 
-  private fun attachScreen(screenFragment: ScreenFragment) {
-    createTransaction().add(id, screenFragment).commitNowAllowingStateLoss()
+  private fun attachScreen(transaction: FragmentTransaction, screenFragment: ScreenFragment) {
+    transaction.add(id, screenFragment)
   }
 
-  private fun moveToFront(screenFragment: ScreenFragment) {
-    createTransaction().remove(screenFragment).add(id, screenFragment).commitNowAllowingStateLoss()
-  }
-
-  private fun detachScreen(screenFragment: ScreenFragment) {
-    createTransaction().remove(screenFragment).commitNowAllowingStateLoss()
+  private fun detachScreen(transaction: FragmentTransaction, screenFragment: ScreenFragment) {
+    transaction.remove(screenFragment)
   }
 
   private fun getActivityState(screenFragment: ScreenFragment): ActivityState? {
@@ -276,10 +273,18 @@ open class ScreenContainer<T : ScreenFragment>(context: Context?) : ViewGroup(co
     // The exception to this rule is `updateImmediately` which is triggered by actions
     // not connected to React view hierarchy changes, but rather internal events
     mNeedUpdate = true
+    (context as? ReactContext)?.runOnUiQueueThread {
+      // We schedule the update here because LayoutAnimations of `react-native-reanimated`
+      // sometimes attach/detach screens after the layout block of `ScreensShadowNode` has
+      // already run, and we want to update the container then too. In the other cases,
+      // this code will do nothing since it will run after the UIBlock when `mNeedUpdate`
+      // will already be false.
+      performUpdates()
+    }
   }
 
   protected fun performUpdatesNow() {
-    // we want to update the immediately when the fragment manager is set or native back button
+    // we want to update immediately when the fragment manager is set or native back button
     // dismiss is dispatched or Screen's activityState changes since it is not connected to React
     // view hierarchy changes and will not trigger `onBeforeLayout` method of `ScreensShadowNode`
     mNeedUpdate = true
@@ -287,7 +292,7 @@ open class ScreenContainer<T : ScreenFragment>(context: Context?) : ViewGroup(co
   }
 
   fun performUpdates() {
-    if (!mNeedUpdate || !mIsAttached || mFragmentManager == null) {
+    if (!mNeedUpdate || !mIsAttached || mFragmentManager == null || mFragmentManager?.isDestroyed == true) {
       return
     }
     mNeedUpdate = false
@@ -296,43 +301,53 @@ open class ScreenContainer<T : ScreenFragment>(context: Context?) : ViewGroup(co
   }
 
   open fun onUpdate() {
-    // detach screens that are no longer active
-    val orphaned: MutableSet<Fragment> = HashSet(requireNotNull(mFragmentManager, { "mFragmentManager is null when performing update in ScreenContainer" }).fragments)
-    for (screenFragment in mScreenFragments) {
-      if (getActivityState(screenFragment) === ActivityState.INACTIVE &&
-        screenFragment.isAdded
-      ) {
-        detachScreen(screenFragment)
+    createTransaction().let {
+      // detach screens that are no longer active
+      val orphaned: MutableSet<Fragment> = HashSet(requireNotNull(mFragmentManager, { "mFragmentManager is null when performing update in ScreenContainer" }).fragments)
+      for (screenFragment in mScreenFragments) {
+        if (getActivityState(screenFragment) === ActivityState.INACTIVE &&
+          screenFragment.isAdded
+        ) {
+          detachScreen(it, screenFragment)
+        }
+        orphaned.remove(screenFragment)
       }
-      orphaned.remove(screenFragment)
-    }
-    if (orphaned.isNotEmpty()) {
-      val orphanedAry = orphaned.toTypedArray()
-      for (fragment in orphanedAry) {
-        if (fragment is ScreenFragment) {
-          if (fragment.screen.container == null) {
-            detachScreen(fragment)
+      if (orphaned.isNotEmpty()) {
+        val orphanedAry = orphaned.toTypedArray()
+        for (fragment in orphanedAry) {
+          if (fragment is ScreenFragment) {
+            if (fragment.screen.container == null) {
+              detachScreen(it, fragment)
+            }
           }
         }
       }
-    }
-    var transitioning = true
-    if (topScreen != null) {
-      // if there is an "onTop" screen it means the transition has ended
-      transitioning = false
-    }
 
-    // attach newly activated screens
-    var addedBefore = false
-    for (screenFragment in mScreenFragments) {
-      val activityState = getActivityState(screenFragment)
-      if (activityState !== ActivityState.INACTIVE && !screenFragment.isAdded) {
-        addedBefore = true
-        attachScreen(screenFragment)
-      } else if (activityState !== ActivityState.INACTIVE && addedBefore) {
-        moveToFront(screenFragment)
+      // if there is an "onTop" screen it means the transition has ended
+      val transitioning = topScreen == null
+
+      // attach newly activated screens
+      var addedBefore = false
+      val pendingFront: ArrayList<T> = ArrayList()
+
+      for (screenFragment in mScreenFragments) {
+        val activityState = getActivityState(screenFragment)
+        if (activityState !== ActivityState.INACTIVE && !screenFragment.isAdded) {
+          addedBefore = true
+          attachScreen(it, screenFragment)
+        } else if (activityState !== ActivityState.INACTIVE && addedBefore) {
+          // we detach the screen and then reattach it later to make it appear on front
+          detachScreen(it, screenFragment)
+          pendingFront.add(screenFragment)
+        }
+        screenFragment.screen.setTransitioning(transitioning)
       }
-      screenFragment.screen.setTransitioning(transitioning)
+
+      for (screenFragment in pendingFront) {
+        attachScreen(it, screenFragment)
+      }
+
+      it.commitNowAllowingStateLoss()
     }
   }
 

--- a/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/host/exp/exponent/modules/api/screens/ScreenFragment.kt
+++ b/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/host/exp/exponent/modules/api/screens/ScreenFragment.kt
@@ -2,6 +2,7 @@ package abi44_0_0.host.exp.exponent.modules.api.screens
 
 import android.annotation.SuppressLint
 import android.app.Activity
+import android.content.Context
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -61,7 +62,7 @@ open class ScreenFragment : Fragment {
     container: ViewGroup?,
     savedInstanceState: Bundle?
   ): View? {
-    val wrapper = context?.let { FrameLayout(it) }
+    val wrapper = context?.let { ScreensFrameLayout(it) }
 
     val params = FrameLayout.LayoutParams(
       ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT
@@ -69,6 +70,23 @@ open class ScreenFragment : Fragment {
     screen.layoutParams = params
     wrapper?.addView(recycleView(screen))
     return wrapper
+  }
+
+  private class ScreensFrameLayout(
+    context: Context,
+  ) : FrameLayout(context) {
+    /**
+     * This method implements a workaround for RN's autoFocus functionality. Because of the way
+     * autoFocus is implemented it dismisses soft keyboard in fragment transition
+     * due to change of visibility of the view at the start of the transition. Here we override the
+     * call to `clearFocus` when the visibility of view is `INVISIBLE` since `clearFocus` triggers the
+     * hiding of the keyboard in `ReactEditText.java`.
+     */
+    override fun clearFocus() {
+      if (visibility != INVISIBLE) {
+        super.clearFocus()
+      }
+    }
   }
 
   open fun onContainerUpdate() {

--- a/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/host/exp/exponent/modules/api/screens/ScreenStack.kt
+++ b/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/host/exp/exponent/modules/api/screens/ScreenStack.kt
@@ -11,6 +11,7 @@ import abi44_0_0.host.exp.exponent.modules.api.screens.events.StackFinishTransit
 import java.util.Collections
 import kotlin.collections.ArrayList
 import kotlin.collections.HashSet
+
 import host.exp.expoview.R
 
 class ScreenStack(context: Context?) : ScreenContainer<ScreenStackFragment>(context) {
@@ -121,11 +122,11 @@ class ScreenStack(context: Context?) : ScreenContainer<ScreenStackFragment>(cont
         // if the previous top screen does not exist anymore and the new top was not on the stack
         // before, probably replace or reset was called, so we play the "close animation".
         // Otherwise it's open animation
-        shouldUseOpenAnimation = (
-          mScreenFragments.contains(mTopScreen) ||
-            newTop.screen.replaceAnimation !== Screen.ReplaceAnimation.POP
-          )
-        stackAnimation = newTop.screen.stackAnimation
+        val containsTopScreen = mTopScreen?.let { mScreenFragments.contains(it) } == true
+        val isPushReplace = newTop.screen.replaceAnimation === Screen.ReplaceAnimation.PUSH
+        shouldUseOpenAnimation = containsTopScreen || isPushReplace
+        // if the replace animation is `push`, the new top screen provides the animation, otherwise the previous one
+        stackAnimation = if (shouldUseOpenAnimation) newTop.screen.stackAnimation else mTopScreen?.screen?.stackAnimation
       } else if (mTopScreen == null && newTop != null) {
         // mTopScreen was not present before so newTop is the first screen added to a stack
         // and we don't want the animation when it is entering, but we want to send the
@@ -239,8 +240,33 @@ class ScreenStack(context: Context?) : ScreenContainer<ScreenStackFragment>(cont
       mTopScreen = newTop
       mStack.clear()
       mStack.addAll(mScreenFragments)
+
+      turnOffA11yUnderTransparentScreen(visibleBottom)
+
       it.commitNowAllowingStateLoss()
     }
+  }
+
+  // only top visible screen should be accessible
+  private fun turnOffA11yUnderTransparentScreen(visibleBottom: ScreenStackFragment?) {
+    if (mScreenFragments.size > 1 && visibleBottom != null) {
+      mTopScreen?.let {
+        if (isTransparent(it)) {
+          val screenFragmentsBeneathTop = mScreenFragments.slice(0 until mScreenFragments.size - 1).asReversed()
+          // go from the top of the stack excluding the top screen
+          for (screenFragment in screenFragmentsBeneathTop) {
+            screenFragment.screen.changeAccessibilityMode(IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS)
+
+            // don't change a11y below non-transparent screens
+            if (screenFragment == visibleBottom) {
+              break
+            }
+          }
+        }
+      }
+    }
+
+    topScreen?.changeAccessibilityMode(IMPORTANT_FOR_ACCESSIBILITY_AUTO)
   }
 
   override fun notifyContainerUpdate() {

--- a/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/host/exp/exponent/modules/api/screens/ScreenStackHeaderConfig.kt
+++ b/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/host/exp/exponent/modules/api/screens/ScreenStackHeaderConfig.kt
@@ -17,13 +17,16 @@ import androidx.fragment.app.Fragment
 import abi44_0_0.com.facebook.react.ReactApplication
 import abi44_0_0.com.facebook.react.bridge.JSApplicationIllegalArgumentException
 import abi44_0_0.com.facebook.react.bridge.ReactContext
+import abi44_0_0.com.facebook.react.bridge.WritableMap
+import abi44_0_0.com.facebook.react.uimanager.events.RCTEventEmitter
 import abi44_0_0.com.facebook.react.views.text.ReactTypefaceUtils
+
 import host.exp.expoview.BuildConfig
 import host.exp.expoview.R
 
 class ScreenStackHeaderConfig(context: Context) : ViewGroup(context) {
   private val mConfigSubviews = ArrayList<ScreenStackHeaderSubview>(3)
-  val toolbar: Toolbar
+  val toolbar: CustomToolbar
   private var mTitle: String? = null
   private var mTitleColor = 0
   private var mTitleFontFamily: String? = null
@@ -64,6 +67,11 @@ class ScreenStackHeaderConfig(context: Context) : ViewGroup(context) {
     }
   }
 
+  private fun sendEvent(eventName: String, eventContent: WritableMap?) {
+    (context as ReactContext).getJSModule(RCTEventEmitter::class.java)
+      ?.receiveEvent(id, eventName, eventContent)
+  }
+
   override fun onLayout(changed: Boolean, l: Int, t: Int, r: Int, b: Int) {
     // no-op
   }
@@ -75,12 +83,14 @@ class ScreenStackHeaderConfig(context: Context) : ViewGroup(context) {
   override fun onAttachedToWindow() {
     super.onAttachedToWindow()
     mIsAttachedToWindow = true
+    sendEvent("onAttached", null)
     onUpdate()
   }
 
   override fun onDetachedFromWindow() {
     super.onDetachedFromWindow()
     mIsAttachedToWindow = false
+    sendEvent("onDetached", null)
   }
 
   private val screen: Screen?
@@ -101,7 +111,7 @@ class ScreenStackHeaderConfig(context: Context) : ViewGroup(context) {
       }
       return null
     }
-  private val screenFragment: ScreenStackFragment?
+  val screenFragment: ScreenStackFragment?
     get() {
       val screen = parent
       if (screen is Screen) {
@@ -371,7 +381,7 @@ class ScreenStackHeaderConfig(context: Context) : ViewGroup(context) {
     mDirection = direction
   }
 
-  private class DebugMenuToolbar(context: Context) : Toolbar(context) {
+  private class DebugMenuToolbar(context: Context, config: ScreenStackHeaderConfig) : CustomToolbar(context, config) {
     override fun showOverflowMenu(): Boolean {
       (context.applicationContext as ReactApplication)
         .reactNativeHost
@@ -383,7 +393,7 @@ class ScreenStackHeaderConfig(context: Context) : ViewGroup(context) {
 
   init {
     visibility = GONE
-    toolbar = if (BuildConfig.DEBUG) DebugMenuToolbar(context) else Toolbar(context)
+    toolbar = if (BuildConfig.DEBUG) DebugMenuToolbar(context, this) else CustomToolbar(context, this)
     mDefaultStartInset = toolbar.contentInsetStart
     mDefaultStartInsetWithNavigation = toolbar.contentInsetStartWithNavigation
 

--- a/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/host/exp/exponent/modules/api/screens/ScreenStackHeaderConfigViewManager.kt
+++ b/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/host/exp/exponent/modules/api/screens/ScreenStackHeaderConfigViewManager.kt
@@ -2,6 +2,7 @@ package abi44_0_0.host.exp.exponent.modules.api.screens
 
 import android.view.View
 import abi44_0_0.com.facebook.react.bridge.JSApplicationCausedNativeException
+import abi44_0_0.com.facebook.react.common.MapBuilder
 import abi44_0_0.com.facebook.react.module.annotations.ReactModule
 import abi44_0_0.com.facebook.react.uimanager.ThemedReactContext
 import abi44_0_0.com.facebook.react.uimanager.ViewGroupManager
@@ -127,6 +128,13 @@ class ScreenStackHeaderConfigViewManager : ViewGroupManager<ScreenStackHeaderCon
   @ReactProp(name = "direction")
   fun setDirection(config: ScreenStackHeaderConfig, direction: String?) {
     config.setDirection(direction)
+  }
+
+  override fun getExportedCustomDirectEventTypeConstants(): Map<String, Any>? {
+    return MapBuilder.builder<String, Any>()
+      .put("onAttached", MapBuilder.of("registrationName", "onAttached"))
+      .put("onDetached", MapBuilder.of("registrationName", "onDetached"))
+      .build()
   }
 
   companion object {

--- a/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/host/exp/exponent/modules/api/screens/ScreenStackHeaderSubview.kt
+++ b/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/host/exp/exponent/modules/api/screens/ScreenStackHeaderSubview.kt
@@ -10,6 +10,12 @@ class ScreenStackHeaderSubview(context: ReactContext?) : ReactViewGroup(context)
   private var mReactWidth = 0
   private var mReactHeight = 0
   var type = Type.RIGHT
+
+  val config: ScreenStackHeaderConfig?
+    get() {
+      return (parent as? CustomToolbar)?.config
+    }
+
   override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
     if (MeasureSpec.getMode(widthMeasureSpec) == MeasureSpec.EXACTLY &&
       MeasureSpec.getMode(heightMeasureSpec) == MeasureSpec.EXACTLY
@@ -31,6 +37,6 @@ class ScreenStackHeaderSubview(context: ReactContext?) : ReactViewGroup(context)
   }
 
   enum class Type {
-    LEFT, CENTER, RIGHT, BACK
+    LEFT, CENTER, RIGHT, BACK, SEARCH_BAR
   }
 }

--- a/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/host/exp/exponent/modules/api/screens/ScreenStackHeaderSubviewManager.kt
+++ b/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/host/exp/exponent/modules/api/screens/ScreenStackHeaderSubviewManager.kt
@@ -24,6 +24,7 @@ class ScreenStackHeaderSubviewManager : ReactViewManager() {
       "center" -> ScreenStackHeaderSubview.Type.CENTER
       "right" -> ScreenStackHeaderSubview.Type.RIGHT
       "back" -> ScreenStackHeaderSubview.Type.BACK
+      "searchBar" -> ScreenStackHeaderSubview.Type.SEARCH_BAR
       else -> throw JSApplicationIllegalArgumentException("Unknown type $type")
     }
   }

--- a/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/host/exp/exponent/modules/api/screens/SearchBarManager.kt
+++ b/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/host/exp/exponent/modules/api/screens/SearchBarManager.kt
@@ -1,0 +1,90 @@
+package abi44_0_0.host.exp.exponent.modules.api.screens
+
+import abi44_0_0.com.facebook.react.bridge.JSApplicationIllegalArgumentException
+import abi44_0_0.com.facebook.react.common.MapBuilder
+import abi44_0_0.com.facebook.react.module.annotations.ReactModule
+import abi44_0_0.com.facebook.react.uimanager.ThemedReactContext
+import abi44_0_0.com.facebook.react.uimanager.ViewGroupManager
+import abi44_0_0.com.facebook.react.uimanager.annotations.ReactProp
+
+@ReactModule(name = SearchBarManager.REACT_CLASS)
+class SearchBarManager : ViewGroupManager<SearchBarView>() {
+  override fun getName(): String {
+    return REACT_CLASS
+  }
+
+  override fun createViewInstance(context: ThemedReactContext): SearchBarView {
+    return SearchBarView(context)
+  }
+
+  override fun onAfterUpdateTransaction(view: SearchBarView) {
+    super.onAfterUpdateTransaction(view)
+    view.onUpdate()
+  }
+
+  @ReactProp(name = "autoCapitalize")
+  fun setAutoCapitalize(view: SearchBarView, autoCapitalize: String?) {
+    view.autoCapitalize = when (autoCapitalize) {
+      null, "none" -> SearchBarView.SearchBarAutoCapitalize.NONE
+      "words" -> SearchBarView.SearchBarAutoCapitalize.WORDS
+      "sentences" -> SearchBarView.SearchBarAutoCapitalize.SENTENCES
+      "characters" -> SearchBarView.SearchBarAutoCapitalize.CHARACTERS
+      else -> throw JSApplicationIllegalArgumentException(
+        "Forbidden auto capitalize value passed"
+      )
+    }
+  }
+
+  @ReactProp(name = "autoFocus")
+  fun setAutoFocus(view: SearchBarView, autoFocus: Boolean?) {
+    view.autoFocus = autoFocus ?: false
+  }
+
+  @ReactProp(name = "barTintColor", customType = "Color")
+  fun setTintColor(view: SearchBarView, color: Int?) {
+    view.tintColor = color
+  }
+
+  @ReactProp(name = "disableBackButtonOverride")
+  fun setDisableBackButtonOverride(view: SearchBarView, disableBackButtonOverride: Boolean?) {
+    view.shouldOverrideBackButton = disableBackButtonOverride != true
+  }
+
+  @ReactProp(name = "inputType")
+  fun setInputType(view: SearchBarView, inputType: String?) {
+    view.inputType = when (inputType) {
+      null, "text" -> SearchBarView.SearchBarInputTypes.TEXT
+      "phone" -> SearchBarView.SearchBarInputTypes.PHONE
+      "number" -> SearchBarView.SearchBarInputTypes.NUMBER
+      "email" -> SearchBarView.SearchBarInputTypes.EMAIL
+      else -> throw JSApplicationIllegalArgumentException(
+        "Forbidden input type value"
+      )
+    }
+  }
+
+  @ReactProp(name = "placeholder")
+  fun setPlaceholder(view: SearchBarView, placeholder: String?) {
+    view.placeholder = placeholder
+  }
+
+  @ReactProp(name = "textColor", customType = "Color")
+  fun setTextColor(view: SearchBarView, color: Int?) {
+    view.textColor = color
+  }
+
+  override fun getExportedCustomDirectEventTypeConstants(): Map<String, Any>? {
+    return MapBuilder.builder<String, Any>()
+      .put("onChangeText", MapBuilder.of("registrationName", "onChangeText"))
+      .put("onSearchButtonPress", MapBuilder.of("registrationName", "onSearchButtonPress"))
+      .put("onFocus", MapBuilder.of("registrationName", "onFocus"))
+      .put("onBlur", MapBuilder.of("registrationName", "onBlur"))
+      .put("onClose", MapBuilder.of("registrationName", "onClose"))
+      .put("onOpen", MapBuilder.of("registrationName", "onOpen"))
+      .build()
+  }
+
+  companion object {
+    const val REACT_CLASS = "RNSSearchBar"
+  }
+}

--- a/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/host/exp/exponent/modules/api/screens/SearchBarView.kt
+++ b/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/host/exp/exponent/modules/api/screens/SearchBarView.kt
@@ -1,0 +1,150 @@
+package abi44_0_0.host.exp.exponent.modules.api.screens
+
+import android.annotation.SuppressLint
+import android.text.InputType
+import androidx.appcompat.widget.SearchView
+import abi44_0_0.com.facebook.react.bridge.Arguments
+import abi44_0_0.com.facebook.react.bridge.ReactContext
+import abi44_0_0.com.facebook.react.bridge.WritableMap
+import abi44_0_0.com.facebook.react.uimanager.events.RCTEventEmitter
+import abi44_0_0.com.facebook.react.views.view.ReactViewGroup
+
+@SuppressLint("ViewConstructor")
+class SearchBarView(reactContext: ReactContext?) : ReactViewGroup(reactContext) {
+  var inputType: SearchBarInputTypes = SearchBarInputTypes.TEXT
+  var autoCapitalize: SearchBarAutoCapitalize = SearchBarAutoCapitalize.NONE
+  var textColor: Int? = null
+  var tintColor: Int? = null
+  var placeholder: String? = null
+  var shouldOverrideBackButton: Boolean = true
+  var autoFocus: Boolean = false
+
+  private var mSearchViewFormatter: SearchViewFormatter? = null
+
+  private var mAreListenersSet: Boolean = false
+
+  private val screenStackFragment: ScreenStackFragment?
+    get() {
+      val currentParent = parent
+      if (currentParent is ScreenStackHeaderSubview) {
+        return currentParent.config?.screenFragment
+      }
+      return null
+    }
+
+  fun onUpdate() {
+    setSearchViewProps()
+  }
+
+  private fun setSearchViewProps() {
+    val searchView = screenStackFragment?.searchView
+    if (searchView != null) {
+      if (!mAreListenersSet) {
+        setSearchViewListeners(searchView)
+        mAreListenersSet = true
+      }
+
+      searchView.inputType = inputType.toAndroidInputType(autoCapitalize)
+      searchView.queryHint = placeholder
+      mSearchViewFormatter?.setTextColor(textColor)
+      mSearchViewFormatter?.setTintColor(tintColor)
+      searchView.overrideBackAction = shouldOverrideBackButton
+    }
+  }
+
+  override fun onAttachedToWindow() {
+    super.onAttachedToWindow()
+
+    screenStackFragment?.onSearchViewCreate = { newSearchView ->
+      if (mSearchViewFormatter == null) mSearchViewFormatter =
+        SearchViewFormatter(newSearchView)
+      setSearchViewProps()
+      if (autoFocus) {
+        screenStackFragment?.searchView?.focus()
+      }
+    }
+  }
+
+  private fun setSearchViewListeners(searchView: SearchView) {
+    searchView.setOnQueryTextListener(object : SearchView.OnQueryTextListener {
+      override fun onQueryTextChange(newText: String?): Boolean {
+        handleTextChange(newText)
+        return true
+      }
+
+      override fun onQueryTextSubmit(query: String?): Boolean {
+        handleTextSubmit(query)
+        return true
+      }
+    })
+    searchView.setOnQueryTextFocusChangeListener { _, hasFocus ->
+      handleFocusChange(hasFocus)
+    }
+    searchView.setOnCloseListener {
+      handleClose()
+      false
+    }
+    searchView.setOnSearchClickListener {
+      handleOpen()
+    }
+  }
+
+  private fun handleTextChange(newText: String?) {
+    val event = Arguments.createMap()
+    event.putString("text", newText)
+    sendEvent("onChangeText", event)
+  }
+
+  private fun handleFocusChange(hasFocus: Boolean) {
+    sendEvent(if (hasFocus) "onFocus" else "onBlur", null)
+  }
+
+  private fun handleClose() {
+    sendEvent("onClose", null)
+  }
+
+  private fun handleOpen() {
+    sendEvent("onOpen", null)
+  }
+
+  private fun handleTextSubmit(newText: String?) {
+    val event = Arguments.createMap()
+    event.putString("text", newText)
+    sendEvent("onSearchButtonPress", event)
+  }
+
+  private fun sendEvent(eventName: String, eventContent: WritableMap?) {
+    (context as ReactContext).getJSModule(RCTEventEmitter::class.java)
+      ?.receiveEvent(id, eventName, eventContent)
+  }
+
+  enum class SearchBarAutoCapitalize {
+    NONE, WORDS, SENTENCES, CHARACTERS
+  }
+
+  enum class SearchBarInputTypes {
+    TEXT {
+      override fun toAndroidInputType(capitalize: SearchBarAutoCapitalize) =
+        when (capitalize) {
+          SearchBarAutoCapitalize.NONE -> InputType.TYPE_CLASS_TEXT
+          SearchBarAutoCapitalize.WORDS -> InputType.TYPE_TEXT_FLAG_CAP_WORDS
+          SearchBarAutoCapitalize.SENTENCES -> InputType.TYPE_TEXT_FLAG_CAP_SENTENCES
+          SearchBarAutoCapitalize.CHARACTERS -> InputType.TYPE_TEXT_FLAG_CAP_CHARACTERS
+        }
+    },
+    PHONE {
+      override fun toAndroidInputType(capitalize: SearchBarAutoCapitalize) =
+        InputType.TYPE_CLASS_PHONE
+    },
+    NUMBER {
+      override fun toAndroidInputType(capitalize: SearchBarAutoCapitalize) =
+        InputType.TYPE_CLASS_NUMBER
+    },
+    EMAIL {
+      override fun toAndroidInputType(capitalize: SearchBarAutoCapitalize) =
+        InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS
+    };
+
+    abstract fun toAndroidInputType(capitalize: SearchBarAutoCapitalize): Int
+  }
+}

--- a/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/host/exp/exponent/modules/api/screens/SearchViewFormatter.kt
+++ b/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/host/exp/exponent/modules/api/screens/SearchViewFormatter.kt
@@ -1,0 +1,40 @@
+package abi44_0_0.host.exp.exponent.modules.api.screens
+
+import android.graphics.drawable.Drawable
+import android.view.View
+import android.widget.EditText
+import androidx.appcompat.widget.SearchView
+
+class SearchViewFormatter(var searchView: SearchView) {
+  private var mDefaultTextColor: Int? = null
+  private var mDefaultTintBackground: Drawable? = null
+
+  private val searchEditText
+    get() = searchView.findViewById<View>(androidx.appcompat.R.id.search_src_text) as? EditText
+  private val searchTextPlate
+    get() = searchView.findViewById<View>(androidx.appcompat.R.id.search_plate)
+
+  fun setTextColor(textColor: Int?) {
+    val currentDefaultTextColor = mDefaultTextColor
+    if (textColor != null) {
+      if (mDefaultTextColor == null) {
+        mDefaultTextColor = searchEditText?.textColors?.defaultColor
+      }
+      searchEditText?.setTextColor(textColor)
+    } else if (currentDefaultTextColor != null) {
+      searchEditText?.setTextColor(currentDefaultTextColor)
+    }
+  }
+
+  fun setTintColor(tintColor: Int?) {
+    val currentDefaultTintColor = mDefaultTintBackground
+    if (tintColor != null) {
+      if (mDefaultTintBackground == null) {
+        mDefaultTintBackground = searchTextPlate.background
+      }
+      searchTextPlate.setBackgroundColor(tintColor)
+    } else if (currentDefaultTintColor != null) {
+      searchTextPlate.background = currentDefaultTintColor
+    }
+  }
+}

--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -740,7 +740,7 @@ PODS:
     - React-RCTVibration
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNScreens (3.10.0):
+  - RNScreens (3.10.1):
     - React-Core
     - React-RCTImage
   - RNSharedElement (0.8.3):
@@ -1398,7 +1398,7 @@ SPEC CHECKSUMS:
   RNDateTimePicker: 2224ee77a86b7123377597a015502435e2e49957
   RNGestureHandler: 51c9f32f43720c3a1c7660690a843f33acbcf01f
   RNReanimated: 64c38d47ffcc29c97fc1d8cfde9e8a73d7be7cc8
-  RNScreens: 03ba504f8c98607ad1f07808e71040e0afa335ec
+  RNScreens: 522705f2e5c9d27efb17f24aceb2bf8335bc7b8e
   RNSharedElement: 381b5e33366513cc3f449f2dc3a42c5df0f54021
   RNSVG: 551acb6562324b1d52a4e0758f7ca0ec234e278f
   SDWebImage: a7f831e1a65eb5e285e3fb046a23fcfbf08e696d

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2394,7 +2394,7 @@ PODS:
     - glog
     - RCT-Folly
     - Yoga
-  - ABI44_0_0RNScreens (3.8.0):
+  - ABI44_0_0RNScreens (3.10.1):
     - ABI44_0_0React-Core
     - ABI44_0_0React-RCTImage
   - ABI44_0_0stripe-react-native (0.2.3):
@@ -5183,7 +5183,7 @@ SPEC CHECKSUMS:
   ABI44_0_0ReactCommon: 57cd9920705425d6d7979326c5f755a7134612d0
   ABI44_0_0RNGestureHandler: 98d12054cfc7ce6a2d802f0dc2665743c938734c
   ABI44_0_0RNReanimated: 213c8dca41a4b4acb2ee5de1c66dea578d88ea1a
-  ABI44_0_0RNScreens: 83671ebe06466fcd2be9572bdef6d22518c11cb5
+  ABI44_0_0RNScreens: 7a62e5f04bfaf607a3927152dbf4efd3fcf2dc8a
   ABI44_0_0stripe-react-native: a28782c19ddabd9a3c901d9b2eb964e8d8ab7d68
   ABI44_0_0UMAppLoader: d00dfac0be21e65771e9c30abf4c2fefe0afa06f
   ABI44_0_0UMTaskManagerInterface: 8f5418a6ec14ed0eecc7c296ded84e9da8571ed1

--- a/ios/vendored/sdk44/react-native-screens/ABI44_0_0RNScreens.podspec.json
+++ b/ios/vendored/sdk44/react-native-screens/ABI44_0_0RNScreens.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "ABI44_0_0RNScreens",
-  "version": "3.8.0",
+  "version": "3.10.1",
   "summary": "Native navigation primitives for your ABI44_0_0React Native app.",
   "description": "ABI44_0_0RNScreens - first incomplete navigation solution for your ABI44_0_0React Native app",
   "homepage": "https://github.com/software-mansion/react-native-screens",
@@ -14,7 +14,7 @@
   },
   "source": {
     "git": "https://github.com/software-mansion/react-native-screens.git",
-    "tag": "3.8.0"
+    "tag": "3.10.1"
   },
   "source_files": "ios/**/*.{h,m}",
   "requires_arc": true,

--- a/ios/vendored/sdk44/react-native-screens/ios/ABI44_0_0RNSScreen.m
+++ b/ios/vendored/sdk44/react-native-screens/ios/ABI44_0_0RNSScreen.m
@@ -564,6 +564,8 @@
     _shouldNotify = NO;
   }
 
+  [self hideHeaderIfNecessary];
+
   // as per documentation of these methods
   _goingForward = [self isBeingPresented] || [self isMovingToParentViewController];
 
@@ -573,6 +575,35 @@
     [self notifyTransitionProgress:0.0 closing:_closing goingForward:_goingForward];
     [self setupProgressNotification];
   }
+}
+
+- (void)hideHeaderIfNecessary
+{
+#if !TARGET_OS_TV
+  // On iOS >=13, there is a bug when user transitions from screen with active search bar to screen without header
+  // In that case default iOS header will be shown. To fix this we hide header when the screens that appears has header
+  // hidden and search bar was active on previous screen. We need to do it asynchronously, because default header is
+  // added after viewWillAppear.
+  if (@available(iOS 13.0, *)) {
+    NSUInteger currentIndex = [self.navigationController.viewControllers indexOfObject:self];
+
+    if (currentIndex > 0 && [self.view.ABI44_0_0ReactSubviews[0] isKindOfClass:[ABI44_0_0RNSScreenStackHeaderConfig class]]) {
+      UINavigationItem *prevNavigationItem =
+          [self.navigationController.viewControllers objectAtIndex:currentIndex - 1].navigationItem;
+      ABI44_0_0RNSScreenStackHeaderConfig *config = ((ABI44_0_0RNSScreenStackHeaderConfig *)self.view.ABI44_0_0ReactSubviews[0]);
+
+      BOOL wasSearchBarActive = prevNavigationItem.searchController.active;
+      BOOL shouldHideHeader = config.hide;
+
+      if (wasSearchBarActive && shouldHideHeader) {
+        dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, 0);
+        dispatch_after(popTime, dispatch_get_main_queue(), ^(void) {
+          [self.navigationController setNavigationBarHidden:YES animated:NO];
+        });
+      }
+    }
+  }
+#endif
 }
 
 - (void)viewWillDisappear:(BOOL)animated
@@ -657,6 +688,10 @@
 
 - (void)traverseForScrollView:(UIView *)view
 {
+  if (![[self.view valueForKey:@"_bridge"] valueForKey:@"_jsThread"]) {
+    // we don't want to send `scrollViewDidEndDecelerating` event to JS before the JS thread is ready
+    return;
+  }
   if ([view isKindOfClass:[UIScrollView class]] &&
       ([[(UIScrollView *)view delegate] respondsToSelector:@selector(scrollViewDidEndDecelerating:)])) {
     [[(UIScrollView *)view delegate] scrollViewDidEndDecelerating:(id)view];

--- a/ios/vendored/sdk44/react-native-screens/ios/ABI44_0_0RNSScreenStack.m
+++ b/ios/vendored/sdk44/react-native-screens/ios/ABI44_0_0RNSScreenStack.m
@@ -425,12 +425,12 @@
   // controller is still there
   BOOL firstTimePush = ![lastTop isKindOfClass:[ABI44_0_0RNSScreen class]];
 
-  BOOL shouldAnimate = !firstTimePush && ((ABI44_0_0RNSScreenView *)lastTop.view).stackAnimation != ABI44_0_0RNSScreenStackAnimationNone;
-
   if (firstTimePush) {
     // nothing pushed yet
     [_controller setViewControllers:controllers animated:NO];
   } else if (top != lastTop) {
+    // we always provide `animated:YES` since, if the user does not want the animation, he will provide
+    // `stackAnimation: 'none'`, which will resolve in no animation anyways.
     if (![controllers containsObject:lastTop]) {
       // if the previous top screen does not exist anymore and the new top was not on the stack before, probably replace
       // was called, so we check the animation
@@ -445,7 +445,7 @@
         NSMutableArray *newControllers = [NSMutableArray arrayWithArray:controllers];
         [newControllers addObject:lastTop];
         [_controller setViewControllers:newControllers animated:NO];
-        [_controller popViewControllerAnimated:shouldAnimate];
+        [_controller popViewControllerAnimated:YES];
       }
     } else if (![_controller.viewControllers containsObject:top]) {
       // new top controller is not on the stack
@@ -454,11 +454,11 @@
       NSMutableArray *newControllers = [NSMutableArray arrayWithArray:controllers];
       [newControllers removeLastObject];
       [_controller setViewControllers:newControllers animated:NO];
-      [_controller pushViewController:top animated:shouldAnimate];
+      [_controller pushViewController:top animated:YES];
     } else {
       // don't really know what this case could be, but may need to handle it
       // somehow
-      [_controller setViewControllers:controllers animated:shouldAnimate];
+      [_controller setViewControllers:controllers animated:NO];
     }
   } else {
     // change wasn't on the top of the stack. We don't need animation.
@@ -487,6 +487,23 @@
 
   [self setPushViewControllers:pushControllers];
   [self setModalViewControllers:modalControllers];
+}
+
+// By default, the header buttons that are not inside the native hit area
+// cannot be clicked, so we check it by ourselves
+- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
+{
+  if (CGRectContainsPoint(_controller.navigationBar.frame, point)) {
+    // headerConfig should be the first subview of the topmost screen
+    UIView *headerConfig = [[_ABI44_0_0ReactSubviews.lastObject ABI44_0_0ReactSubviews] firstObject];
+    if ([headerConfig isKindOfClass:[ABI44_0_0RNSScreenStackHeaderConfig class]]) {
+      UIView *headerHitTestResult = [headerConfig hitTest:point withEvent:event];
+      if (headerHitTestResult != nil) {
+        return headerHitTestResult;
+      }
+    }
+  }
+  return [super hitTest:point withEvent:event];
 }
 
 - (void)layoutSubviews
@@ -555,7 +572,8 @@
 {
   ABI44_0_0RNSScreenView *topScreen = (ABI44_0_0RNSScreenView *)_controller.viewControllers.lastObject.view;
 
-  if (!topScreen.gestureEnabled || _controller.viewControllers.count < 2) {
+  if (![topScreen isKindOfClass:[ABI44_0_0RNSScreenView class]] || !topScreen.gestureEnabled ||
+      _controller.viewControllers.count < 2) {
     return NO;
   }
 

--- a/ios/vendored/sdk44/react-native-screens/ios/ABI44_0_0RNSScreenStackHeaderConfig.m
+++ b/ios/vendored/sdk44/react-native-screens/ios/ABI44_0_0RNSScreenStackHeaderConfig.m
@@ -118,6 +118,27 @@
   _screenView = nil;
 }
 
+// this method is never invoked by the system since this view
+// is not added to native view hierarchy so we can apply our logic
+- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
+{
+  for (ABI44_0_0RNSScreenStackHeaderSubview *subview in _ABI44_0_0ReactSubviews) {
+    if (subview.type == ABI44_0_0RNSScreenStackHeaderSubviewTypeLeft || subview.type == ABI44_0_0RNSScreenStackHeaderSubviewTypeRight) {
+      // we wrap the headerLeft/Right component in a UIBarButtonItem
+      // so we need to use the only subview of it to retrieve the correct view
+      UIView *headerComponent = subview.subviews.firstObject;
+      // we convert the point to ABI44_0_0RNSScreenStackView since it always contains the header inside it
+      CGPoint convertedPoint = [_screenView.ABI44_0_0ReactSuperview convertPoint:point toView:headerComponent];
+
+      UIView *hitTestResult = [headerComponent hitTest:convertedPoint withEvent:event];
+      if (hitTestResult != nil) {
+        return hitTestResult;
+      }
+    }
+  }
+  return nil;
+}
+
 - (void)updateViewControllerIfNeeded
 {
   UIViewController *vc = _screenView.controller;
@@ -138,10 +159,23 @@
   }
 }
 
+- (void)layoutNavigationControllerView
+{
+  UIViewController *vc = _screenView.controller;
+  UINavigationController *navctr = vc.navigationController;
+  [navctr.view setNeedsLayout];
+}
+
 - (void)didSetProps:(NSArray<NSString *> *)changedProps
 {
   [super didSetProps:changedProps];
   [self updateViewControllerIfNeeded];
+  // We need to layout navigation controller view after translucent prop changes, because otherwise
+  // frame of ABI44_0_0RNSScreen will not be changed and screen content will remain the same size.
+  // For more details look at https://github.com/software-mansion/react-native-screens/issues/1158
+  if ([changedProps containsObject:@"translucent"]) {
+    [self layoutNavigationControllerView];
+  }
 }
 
 - (void)didUpdateABI44_0_0ReactSubviews
@@ -556,6 +590,13 @@
         break;
       }
       case ABI44_0_0RNSScreenStackHeaderSubviewTypeSearchBar: {
+        if (subview.subviews == nil || [subview.subviews count] == 0) {
+          ABI44_0_0RCTLogWarn(
+              @"Failed to attach search bar to the header. We recommend using `useLayoutEffect` when managing "
+               "searchBar properties dynamically. \n\nSee: github.com/software-mansion/react-native-screens/issues/1188");
+          break;
+        }
+
         if ([subview.subviews[0] isKindOfClass:[ABI44_0_0RNSSearchBar class]]) {
 #if !TARGET_OS_TV
           if (@available(iOS 11.0, *)) {


### PR DESCRIPTION
# Why

Followup for #15416 
Backport `react-native-screens@3.10.1` update to SDK 44.

# How

- `et add-sdk-version -p ios -s 44.0.0 -v react-native-screens`
- `et add-sdk-version -p "android" -s 44.0.0`

# TODOs

- [x] Test standalone apps for both platforms
- [ ] Once merged cherry-pick to `sdk-44` branch
