### PR TITLE
[ios] Temporarily apply iOS only sdk 44 reanimated versioned code

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2365,7 +2365,7 @@ PODS:
     - RCT-Folly (= 2020.01.13.00)
   - ABI44_0_0RNGestureHandler (2.0.0):
     - ABI44_0_0React-Core
-  - ABI44_0_0RNReanimated (2.2.0):
+  - ABI44_0_0RNReanimated (2.3.0):
     - ABI44_0_0RCTRequired
     - ABI44_0_0RCTTypeSafety
     - ABI44_0_0React
@@ -2386,7 +2386,6 @@ PODS:
     - ABI44_0_0React-RCTNetwork
     - ABI44_0_0React-RCTSettings
     - ABI44_0_0React-RCTText
-    - ABI44_0_0React-RCTVibration
     - ABI44_0_0ReactCommon/turbomodule/core
     - DoubleConversion
     - FBLazyVector

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -5180,7 +5180,7 @@ SPEC CHECKSUMS:
   ABI44_0_0React-runtimeexecutor: e896ce310401b7a6c55c8e9ebd05d329425704f0
   ABI44_0_0ReactCommon: 57cd9920705425d6d7979326c5f755a7134612d0
   ABI44_0_0RNGestureHandler: 98d12054cfc7ce6a2d802f0dc2665743c938734c
-  ABI44_0_0RNReanimated: 213c8dca41a4b4acb2ee5de1c66dea578d88ea1a
+  ABI44_0_0RNReanimated: a5713baac42d25465b994404d8b3fbbf2caeda69
   ABI44_0_0RNScreens: 7a62e5f04bfaf607a3927152dbf4efd3fcf2dc8a
   ABI44_0_0stripe-react-native: a28782c19ddabd9a3c901d9b2eb964e8d8ab7d68
   ABI44_0_0UMAppLoader: d00dfac0be21e65771e9c30abf4c2fefe0afa06f

--- a/ios/vendored/sdk44/react-native-reanimated/ABI44_0_0RNReanimated.podspec.json
+++ b/ios/vendored/sdk44/react-native-reanimated/ABI44_0_0RNReanimated.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "ABI44_0_0RNReanimated",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "summary": "More powerful alternative to Animated library for ABI44_0_0React Native.",
   "description": "ABI44_0_0RNReanimated",
   "homepage": "https://github.com/software-mansion/react-native-reanimated",
@@ -14,7 +14,7 @@
   },
   "source": {
     "git": "https://github.com/software-mansion/react-native-reanimated.git",
-    "tag": "2.2.0"
+    "tag": "2.3.0"
   },
   "source_files": [
     "ios/**/*.{mm,h,m}",
@@ -26,12 +26,12 @@
   ],
   "pod_target_xcconfig": {
     "USE_HEADERMAP": "YES",
-    "HEADER_SEARCH_PATHS": "\"$(PODS_TARGET_SRCROOT)/ABI44_0_0ReactCommon\" \"$(PODS_TARGET_SRCROOT)\" \"$(PODS_ROOT)/RCT-Folly\" \"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/DoubleConversion\" \"$(PODS_ROOT)/Headers/Private/ABI44_0_0React-Core\" "
+    "HEADER_SEARCH_PATHS": "\"$(PODS_TARGET_SRCROOT)/ABI44_0_0ReactCommon\" \"$(PODS_TARGET_SRCROOT)\" \"$(PODS_ROOT)/RCT-Folly\" \"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/DoubleConversion\" \"$(PODS_ROOT)/Headers/Private/ABI44_0_0React-Core\" "
   },
   "compiler_flags": "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DRNVERSION=64 -Wno-comma -Wno-shorten-64-to-32 -Wno-documentation",
   "xcconfig": {
     "CLANG_CXX_LANGUAGE_STANDARD": "c++14",
-    "HEADER_SEARCH_PATHS": "\"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/glog\" \"$(PODS_ROOT)/RCT-Folly\"",
+    "HEADER_SEARCH_PATHS": "\"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/glog\" \"$(PODS_ROOT)/RCT-Folly\" \"${PODS_ROOT}/Headers/Public/ABI44_0_0React-hermes\" \"${PODS_ROOT}/Headers/Public/hermes-engine\"",
     "OTHER_CFLAGS": "$(inherited) -DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DRNVERSION=64"
   },
   "requires_arc": true,
@@ -51,7 +51,6 @@
     "ABI44_0_0React-RCTBlob": [],
     "ABI44_0_0React-RCTSettings": [],
     "ABI44_0_0React-RCTText": [],
-    "ABI44_0_0React-RCTVibration": [],
     "ABI44_0_0React-RCTImage": [],
     "ABI44_0_0React-Core/RCTWebSocket": [],
     "ABI44_0_0React-cxxreact": [],

--- a/ios/vendored/sdk44/react-native-reanimated/Common/cpp/LayoutAnimations/LayoutAnimationsProxy.cpp
+++ b/ios/vendored/sdk44/react-native-reanimated/Common/cpp/LayoutAnimations/LayoutAnimationsProxy.cpp
@@ -1,0 +1,43 @@
+#include "LayoutAnimationsProxy.h"
+#include "FrozenObject.h"
+#include "MutableValue.h"
+#include "ShareableValue.h"
+#include "ValueWrapper.h"
+
+namespace ABI44_0_0reanimated {
+
+const long long idOffset = 1e9;
+
+LayoutAnimationsProxy::LayoutAnimationsProxy(
+    std::function<void(int, jsi::Object newProps)> _notifyAboutProgress,
+    std::function<void(int, bool)> _notifyAboutEnd)
+    : notifyAboutProgress(std::move(_notifyAboutProgress)),
+      notifyAboutEnd(std::move(_notifyAboutEnd)) {}
+
+void LayoutAnimationsProxy::startObserving(
+    int tag,
+    std::shared_ptr<MutableValue> sv,
+    jsi::Runtime &rt) {
+  observedValues[tag] = sv;
+  sv->addListener(tag + idOffset, [sv, tag, this, &rt]() {
+    std::shared_ptr<FrozenObject> newValue =
+        ValueWrapper::asFrozenObject(sv->value->valueContainer);
+    this->notifyAboutProgress(tag, newValue->shallowClone(rt));
+  });
+}
+
+void LayoutAnimationsProxy::stopObserving(int tag, bool finished) {
+  if (observedValues.count(tag) == 0) {
+    return;
+  }
+  std::shared_ptr<MutableValue> sv = observedValues[tag];
+  sv->removeListener(tag + idOffset);
+  observedValues.erase(tag);
+  this->notifyAboutEnd(tag, !finished);
+}
+
+void LayoutAnimationsProxy::notifyAboutCancellation(int tag) {
+  this->notifyAboutEnd(tag, false);
+}
+
+} // namespace reanimated

--- a/ios/vendored/sdk44/react-native-reanimated/Common/cpp/NativeModules/NativeReanimatedModule.cpp
+++ b/ios/vendored/sdk44/react-native-reanimated/Common/cpp/NativeModules/NativeReanimatedModule.cpp
@@ -1,129 +1,177 @@
 #include "NativeReanimatedModule.h"
-#include "ShareableValue.h"
-#include "MapperRegistry.h"
-#include "Mapper.h"
-#include "RuntimeDecorator.h"
-#include "EventHandlerRegistry.h"
-#include "WorkletEventHandler.h"
-#include "FrozenObject.h"
 #include <functional>
-#include <thread>
 #include <memory>
+#include <thread>
+#include "EventHandlerRegistry.h"
+#include "FeaturesConfig.h"
+#include "FrozenObject.h"
 #include "JSIStoreValueUser.h"
+#include "Mapper.h"
+#include "MapperRegistry.h"
+#include "ReanimatedHiddenHeaders.h"
+#include "RuntimeDecorator.h"
+#include "ShareableValue.h"
+#include "WorkletEventHandler.h"
 
 using namespace ABI44_0_0facebook;
 
-namespace ABI44_0_0reanimated
-{
+namespace ABI44_0_0reanimated {
 
-void extractMutables(jsi::Runtime &rt,
-                     std::shared_ptr<ShareableValue> sv,
-                     std::vector<std::shared_ptr<MutableValue>> &res)
-{
-  switch (sv->type)
-  {
-  case ValueType::MutableValueType: {
-    auto& mutableValue = ValueWrapper::asMutableValue(sv->valueContainer);
-    res.push_back(mutableValue);
-    break;
-  }
-  case ValueType::FrozenArrayType:
-    for (auto &it : ValueWrapper::asFrozenArray(sv->valueContainer))
-    {
-      extractMutables(rt, it, res);
+void extractMutables(
+    jsi::Runtime &rt,
+    std::shared_ptr<ShareableValue> sv,
+    std::vector<std::shared_ptr<MutableValue>> &res) {
+  switch (sv->type) {
+    case ValueType::MutableValueType: {
+      auto &mutableValue = ValueWrapper::asMutableValue(sv->valueContainer);
+      res.push_back(mutableValue);
+      break;
     }
-    break;
-  case ValueType::RemoteObjectType:
-  case ValueType::FrozenObjectType:
-    for (auto &it : ValueWrapper::asFrozenObject(sv->valueContainer)->map)
-    {
-      extractMutables(rt, it.second, res);
-    }
-    break;
-  default:
-    break;
+    case ValueType::FrozenArrayType:
+      for (auto &it : ValueWrapper::asFrozenArray(sv->valueContainer)) {
+        extractMutables(rt, it, res);
+      }
+      break;
+    case ValueType::RemoteObjectType:
+    case ValueType::FrozenObjectType:
+      for (auto &it : ValueWrapper::asFrozenObject(sv->valueContainer)->map) {
+        extractMutables(rt, it.second, res);
+      }
+      break;
+    default:
+      break;
   }
 }
 
-std::vector<std::shared_ptr<MutableValue>> extractMutablesFromArray(jsi::Runtime &rt, const jsi::Array &array, NativeReanimatedModule *module)
-{
+std::vector<std::shared_ptr<MutableValue>> extractMutablesFromArray(
+    jsi::Runtime &rt,
+    const jsi::Array &array,
+    NativeReanimatedModule *module) {
   std::vector<std::shared_ptr<MutableValue>> res;
-  for (size_t i = 0, size = array.size(rt); i < size; i++)
-  {
-    auto shareable = ShareableValue::adapt(rt, array.getValueAtIndex(rt, i), module);
+  for (size_t i = 0, size = array.size(rt); i < size; i++) {
+    auto shareable =
+        ShareableValue::adapt(rt, array.getValueAtIndex(rt, i), module);
     extractMutables(rt, shareable, res);
   }
   return res;
 }
 
-NativeReanimatedModule::NativeReanimatedModule(std::shared_ptr<CallInvoker> jsInvoker,
-                                               std::shared_ptr<Scheduler> scheduler,
-                                               std::unique_ptr<jsi::Runtime> rt,
-                                               std::shared_ptr<ErrorHandler> errorHandler,
-                                               std::function<jsi::Value(jsi::Runtime &, const int, const jsi::String &)> propObtainer,
-                                               PlatformDepMethodsHolder platformDepMethodsHolder) :
-                                                  NativeReanimatedModuleSpec(jsInvoker),
-                                                  RuntimeManager(std::move(rt), errorHandler, scheduler),
-                                                  mapperRegistry(std::make_shared<MapperRegistry>()),
-                                                  eventHandlerRegistry(std::make_shared<EventHandlerRegistry>()),
-                                                  requestRender(platformDepMethodsHolder.requestRender),
-                                                  propObtainer(propObtainer)
-{
-
+NativeReanimatedModule::NativeReanimatedModule(
+    std::shared_ptr<CallInvoker> jsInvoker,
+    std::shared_ptr<Scheduler> scheduler,
+    std::shared_ptr<jsi::Runtime> rt,
+    std::shared_ptr<ErrorHandler> errorHandler,
+    std::function<jsi::Value(jsi::Runtime &, const int, const jsi::String &)>
+        propObtainer,
+    std::shared_ptr<LayoutAnimationsProxy> layoutAnimationsProxy,
+    PlatformDepMethodsHolder platformDepMethodsHolder)
+    : NativeReanimatedModuleSpec(jsInvoker),
+      RuntimeManager(rt, errorHandler, scheduler, RuntimeType::UI),
+      mapperRegistry(std::make_shared<MapperRegistry>()),
+      eventHandlerRegistry(std::make_shared<EventHandlerRegistry>()),
+      requestRender(platformDepMethodsHolder.requestRender),
+      propObtainer(propObtainer) {
   auto requestAnimationFrame = [=](FrameCallback callback) {
     frameCallbacks.push_back(callback);
     maybeRequestRender();
   };
-  RuntimeDecorator::decorateUIRuntime(*runtime,
-                                      platformDepMethodsHolder.updaterFunction,
-                                      requestAnimationFrame,
-                                      platformDepMethodsHolder.scrollToFunction,
-                                      platformDepMethodsHolder.measuringFunction,
-                                      platformDepMethodsHolder.getCurrentTime);
+
+  this->layoutAnimationsProxy = layoutAnimationsProxy;
+
+  RuntimeDecorator::decorateUIRuntime(
+      *runtime,
+      platformDepMethodsHolder.updaterFunction,
+      requestAnimationFrame,
+      platformDepMethodsHolder.scrollToFunction,
+      platformDepMethodsHolder.measuringFunction,
+      platformDepMethodsHolder.getCurrentTime,
+      platformDepMethodsHolder.setGestureStateFunction,
+      layoutAnimationsProxy);
+  onRenderCallback = [this](double timestampMs) {
+    this->renderRequested = false;
+    this->onRender(timestampMs);
+  };
+  updaterFunction = platformDepMethodsHolder.updaterFunction;
 }
 
-void NativeReanimatedModule::installCoreFunctions(jsi::Runtime &rt, const jsi::Value &valueSetter)
-{
+void NativeReanimatedModule::installCoreFunctions(
+    jsi::Runtime &rt,
+    const jsi::Value &valueSetter) {
   this->valueSetter = ShareableValue::adapt(rt, valueSetter, this);
 }
 
-jsi::Value NativeReanimatedModule::makeShareable(jsi::Runtime &rt, const jsi::Value &value)
-{
+jsi::Value NativeReanimatedModule::makeShareable(
+    jsi::Runtime &rt,
+    const jsi::Value &value) {
   return ShareableValue::adapt(rt, value, this)->getValue(rt);
 }
 
-jsi::Value NativeReanimatedModule::makeMutable(jsi::Runtime &rt, const jsi::Value &value)
-{
-  return ShareableValue::adapt(rt, value, this, ValueType::MutableValueType)->getValue(rt);
+jsi::Value NativeReanimatedModule::makeMutable(
+    jsi::Runtime &rt,
+    const jsi::Value &value) {
+  return ShareableValue::adapt(rt, value, this, ValueType::MutableValueType)
+      ->getValue(rt);
 }
 
-jsi::Value NativeReanimatedModule::makeRemote(jsi::Runtime &rt, const jsi::Value &value)
-{
-  return ShareableValue::adapt(rt, value, this, ValueType::RemoteObjectType)->getValue(rt);
+jsi::Value NativeReanimatedModule::makeRemote(
+    jsi::Runtime &rt,
+    const jsi::Value &value) {
+  return ShareableValue::adapt(rt, value, this, ValueType::RemoteObjectType)
+      ->getValue(rt);
 }
 
-jsi::Value NativeReanimatedModule::startMapper(jsi::Runtime &rt, const jsi::Value &worklet, const jsi::Value &inputs, const jsi::Value &outputs)
-{
+jsi::Value NativeReanimatedModule::startMapper(
+    jsi::Runtime &rt,
+    const jsi::Value &worklet,
+    const jsi::Value &inputs,
+    const jsi::Value &outputs,
+    const jsi::Value &updater,
+    const jsi::Value &viewDescriptors) {
   static unsigned long MAPPER_ID = 1;
 
   unsigned long newMapperId = MAPPER_ID++;
   auto mapperShareable = ShareableValue::adapt(rt, worklet, this);
-  auto inputMutables = extractMutablesFromArray(rt, inputs.asObject(rt).asArray(rt), this);
-  auto outputMutables = extractMutablesFromArray(rt, outputs.asObject(rt).asArray(rt), this);
+  auto inputMutables =
+      extractMutablesFromArray(rt, inputs.asObject(rt).asArray(rt), this);
+  auto outputMutables =
+      extractMutablesFromArray(rt, outputs.asObject(rt).asArray(rt), this);
+
+  int optimalizationLvl = 0;
+  auto optimalization =
+      updater.asObject(rt).getProperty(rt, "__optimalization");
+  if (optimalization.isNumber()) {
+    optimalizationLvl = optimalization.asNumber();
+  }
+  auto updaterSV = ShareableValue::adapt(rt, updater, this);
+  auto viewDescriptorsSV = ShareableValue::adapt(rt, viewDescriptors, this);
 
   scheduler->scheduleOnUI([=] {
-    auto mapperFunction = mapperShareable->getValue(*runtime).asObject(*runtime).asFunction(*runtime);
-    std::shared_ptr<jsi::Function> mapperFunctionPointer = std::make_shared<jsi::Function>(std::move(mapperFunction));
-    std::shared_ptr<Mapper> mapperPointer = std::make_shared<Mapper>(this, newMapperId, mapperFunctionPointer, inputMutables, outputMutables);
+    auto mapperFunction =
+        mapperShareable->getValue(*runtime).asObject(*runtime).asFunction(
+            *runtime);
+    std::shared_ptr<jsi::Function> mapperFunctionPointer =
+        std::make_shared<jsi::Function>(std::move(mapperFunction));
+
+    std::shared_ptr<Mapper> mapperPointer = std::make_shared<Mapper>(
+        this,
+        newMapperId,
+        mapperFunctionPointer,
+        inputMutables,
+        outputMutables);
+    if (optimalizationLvl > 0) {
+      mapperPointer->enableFastMode(
+          optimalizationLvl, updaterSV, viewDescriptorsSV);
+    }
     mapperRegistry->startMapper(mapperPointer);
     maybeRequestRender();
   });
 
-  return jsi::Value((double)newMapperId);
+  return jsi::Value(static_cast<double>(newMapperId));
 }
 
-void NativeReanimatedModule::stopMapper(jsi::Runtime &rt, const jsi::Value &mapperId)
-{
+void NativeReanimatedModule::stopMapper(
+    jsi::Runtime &rt,
+    const jsi::Value &mapperId) {
   unsigned long id = mapperId.asNumber();
   scheduler->scheduleOnUI([=] {
     mapperRegistry->stopMapper(id);
@@ -131,8 +179,10 @@ void NativeReanimatedModule::stopMapper(jsi::Runtime &rt, const jsi::Value &mapp
   });
 }
 
-jsi::Value NativeReanimatedModule::registerEventHandler(jsi::Runtime &rt, const jsi::Value &eventHash, const jsi::Value &worklet)
-{
+jsi::Value NativeReanimatedModule::registerEventHandler(
+    jsi::Runtime &rt,
+    const jsi::Value &eventHash,
+    const jsi::Value &worklet) {
   static unsigned long EVENT_HANDLER_ID = 1;
 
   unsigned long newRegistrationId = EVENT_HANDLER_ID++;
@@ -140,37 +190,45 @@ jsi::Value NativeReanimatedModule::registerEventHandler(jsi::Runtime &rt, const 
   auto handlerShareable = ShareableValue::adapt(rt, worklet, this);
 
   scheduler->scheduleOnUI([=] {
-    auto handlerFunction = handlerShareable->getValue(*runtime).asObject(*runtime).asFunction(*runtime);
-    auto handler = std::make_shared<WorkletEventHandler>(newRegistrationId, eventName, std::move(handlerFunction));
+    auto handlerFunction =
+        handlerShareable->getValue(*runtime).asObject(*runtime).asFunction(
+            *runtime);
+    auto handler = std::make_shared<WorkletEventHandler>(
+        newRegistrationId, eventName, std::move(handlerFunction));
     eventHandlerRegistry->registerEventHandler(handler);
   });
 
-  return jsi::Value((double)newRegistrationId);
+  return jsi::Value(static_cast<double>(newRegistrationId));
 }
 
-void NativeReanimatedModule::unregisterEventHandler(jsi::Runtime &rt, const jsi::Value &registrationId)
-{
+void NativeReanimatedModule::unregisterEventHandler(
+    jsi::Runtime &rt,
+    const jsi::Value &registrationId) {
   unsigned long id = registrationId.asNumber();
-  scheduler->scheduleOnUI([=] {
-    eventHandlerRegistry->unregisterEventHandler(id);
-  });
+  scheduler->scheduleOnUI(
+      [=] { eventHandlerRegistry->unregisterEventHandler(id); });
 }
 
-jsi::Value NativeReanimatedModule::getViewProp(jsi::Runtime &rt, const jsi::Value &viewTag, const jsi::Value &propName, const jsi::Value &callback)
-{
-
-  const int viewTagInt = (int)viewTag.asNumber();
+jsi::Value NativeReanimatedModule::getViewProp(
+    jsi::Runtime &rt,
+    const jsi::Value &viewTag,
+    const jsi::Value &propName,
+    const jsi::Value &callback) {
+  const int viewTagInt = static_cast<int>(viewTag.asNumber());
   std::string propNameStr = propName.asString(rt).utf8(rt);
   jsi::Function fun = callback.getObject(rt).asFunction(rt);
-  std::shared_ptr<jsi::Function> funPtr = std::make_shared<jsi::Function>(std::move(fun));
+  std::shared_ptr<jsi::Function> funPtr =
+      std::make_shared<jsi::Function>(std::move(fun));
 
   scheduler->scheduleOnUI([&rt, viewTagInt, funPtr, this, propNameStr]() {
-    const jsi::String propNameValue = jsi::String::createFromUtf8(rt, propNameStr);
+    const jsi::String propNameValue =
+        jsi::String::createFromUtf8(rt, propNameStr);
     jsi::Value result = propObtainer(rt, viewTagInt, propNameValue);
     std::string resultStr = result.asString(rt).utf8(rt);
 
     scheduler->scheduleOnJS([&rt, resultStr, funPtr]() {
-      const jsi::String resultValue = jsi::String::createFromUtf8(rt, resultStr);
+      const jsi::String resultValue =
+          jsi::String::createFromUtf8(rt, resultStr);
       funPtr->call(rt, resultValue);
     });
   });
@@ -178,75 +236,66 @@ jsi::Value NativeReanimatedModule::getViewProp(jsi::Runtime &rt, const jsi::Valu
   return jsi::Value::undefined();
 }
 
-void NativeReanimatedModule::onEvent(std::string eventName, std::string eventAsString)
-{
-   try
-    {
-      eventHandlerRegistry->processEvent(*runtime, eventName, eventAsString);
-      mapperRegistry->execute(*runtime);
-      if (mapperRegistry->needRunOnRender())
-      {
-        maybeRequestRender();
-      }
+jsi::Value NativeReanimatedModule::enableLayoutAnimations(
+    jsi::Runtime &rt,
+    const jsi::Value &config) {
+  FeaturesConfig::setLayoutAnimationEnabled(config.getBool());
+  return jsi::Value::undefined();
+}
+
+void NativeReanimatedModule::onEvent(
+    std::string eventName,
+    std::string eventAsString) {
+  try {
+    eventHandlerRegistry->processEvent(*runtime, eventName, eventAsString);
+    mapperRegistry->execute(*runtime);
+    if (mapperRegistry->needRunOnRender()) {
+      maybeRequestRender();
     }
-    catch(std::exception &e) {
-     std::string str = e.what();
-     this->errorHandler->setError(str);
-     this->errorHandler->raise();
-   } catch(...) {
-     std::string str = "OnEvent error";
-     this->errorHandler->setError(str);
-     this->errorHandler->raise();
+  } catch (std::exception &e) {
+    std::string str = e.what();
+    this->errorHandler->setError(str);
+    this->errorHandler->raise();
+  } catch (...) {
+    std::string str = "OnEvent error";
+    this->errorHandler->setError(str);
+    this->errorHandler->raise();
   }
 }
 
-bool NativeReanimatedModule::isAnyHandlerWaitingForEvent(std::string eventName) {
+bool NativeReanimatedModule::isAnyHandlerWaitingForEvent(
+    std::string eventName) {
   return eventHandlerRegistry->isAnyHandlerWaitingForEvent(eventName);
 }
 
-
-void NativeReanimatedModule::maybeRequestRender()
-{
-  if (!renderRequested)
-  {
+void NativeReanimatedModule::maybeRequestRender() {
+  if (!renderRequested) {
     renderRequested = true;
-    requestRender([this](double timestampMs) {
-      this->renderRequested = false;
-      this->onRender(timestampMs);
-    }, *this->runtime);
+    requestRender(onRenderCallback, *this->runtime);
   }
 }
 
-void NativeReanimatedModule::onRender(double timestampMs)
-{
-  try
-  {
+void NativeReanimatedModule::onRender(double timestampMs) {
+  try {
     std::vector<FrameCallback> callbacks = frameCallbacks;
     frameCallbacks.clear();
-    for (auto callback : callbacks)
-    {
+    for (auto &callback : callbacks) {
       callback(timestampMs);
     }
     mapperRegistry->execute(*runtime);
 
-    if (mapperRegistry->needRunOnRender())
-    {
+    if (mapperRegistry->needRunOnRender()) {
       maybeRequestRender();
     }
-  } catch(std::exception &e) {
+  } catch (std::exception &e) {
     std::string str = e.what();
     this->errorHandler->setError(str);
     this->errorHandler->raise();
-  } catch(...) {
+  } catch (...) {
     std::string str = "OnRender error";
     this->errorHandler->setError(str);
     this->errorHandler->raise();
   }
-}
-
-NativeReanimatedModule::~NativeReanimatedModule()
-{
-  StoreUser::clearStore();
 }
 
 } // namespace reanimated

--- a/ios/vendored/sdk44/react-native-reanimated/Common/cpp/NativeModules/NativeReanimatedModuleSpec.cpp
+++ b/ios/vendored/sdk44/react-native-reanimated/Common/cpp/NativeModules/NativeReanimatedModuleSpec.cpp
@@ -2,13 +2,14 @@
 
 namespace ABI44_0_0reanimated {
 
-static jsi::Value __hostFunction_NativeReanimatedModuleSpec_installCoreFunctions(
+static jsi::Value
+__hostFunction_NativeReanimatedModuleSpec_installCoreFunctions(
     jsi::Runtime &rt,
     TurboModule &turboModule,
     const jsi::Value *args,
     size_t count) {
   static_cast<NativeReanimatedModuleSpec *>(&turboModule)
-    ->installCoreFunctions(rt, std::move(args[0]));
+      ->installCoreFunctions(rt, std::move(args[0]));
   return jsi::Value::undefined();
 }
 
@@ -20,7 +21,7 @@ static jsi::Value __hostFunction_NativeReanimatedModuleSpec_makeShareable(
     const jsi::Value *args,
     size_t count) {
   return static_cast<NativeReanimatedModuleSpec *>(&turboModule)
-    ->makeShareable(rt, std::move(args[0]));
+      ->makeShareable(rt, std::move(args[0]));
 }
 
 static jsi::Value __hostFunction_NativeReanimatedModuleSpec_makeMutable(
@@ -29,7 +30,7 @@ static jsi::Value __hostFunction_NativeReanimatedModuleSpec_makeMutable(
     const jsi::Value *args,
     size_t count) {
   return static_cast<NativeReanimatedModuleSpec *>(&turboModule)
-    ->makeMutable(rt, std::move(args[0]));
+      ->makeMutable(rt, std::move(args[0]));
 }
 
 static jsi::Value __hostFunction_NativeReanimatedModuleSpec_makeRemote(
@@ -38,7 +39,7 @@ static jsi::Value __hostFunction_NativeReanimatedModuleSpec_makeRemote(
     const jsi::Value *args,
     size_t count) {
   return static_cast<NativeReanimatedModuleSpec *>(&turboModule)
-    ->makeRemote(rt, std::move(args[0]));
+      ->makeRemote(rt, std::move(args[0]));
 }
 
 static jsi::Value __hostFunction_NativeReanimatedModuleSpec_startMapper(
@@ -47,7 +48,13 @@ static jsi::Value __hostFunction_NativeReanimatedModuleSpec_startMapper(
     const jsi::Value *args,
     size_t count) {
   return static_cast<NativeReanimatedModuleSpec *>(&turboModule)
-      ->startMapper(rt, std::move(args[0]), std::move(args[1]), std::move(args[2]));
+      ->startMapper(
+          rt,
+          std::move(args[0]),
+          std::move(args[1]),
+          std::move(args[2]),
+          std::move(args[3]),
+          std::move(args[4]));
 }
 
 static jsi::Value __hostFunction_NativeReanimatedModuleSpec_stopMapper(
@@ -60,7 +67,8 @@ static jsi::Value __hostFunction_NativeReanimatedModuleSpec_stopMapper(
   return jsi::Value::undefined();
 }
 
-static jsi::Value __hostFunction_NativeReanimatedModuleSpec_registerEventHandler(
+static jsi::Value
+__hostFunction_NativeReanimatedModuleSpec_registerEventHandler(
     jsi::Runtime &rt,
     TurboModule &turboModule,
     const jsi::Value *args,
@@ -69,7 +77,8 @@ static jsi::Value __hostFunction_NativeReanimatedModuleSpec_registerEventHandler
       ->registerEventHandler(rt, std::move(args[0]), std::move(args[1]));
 }
 
-static jsi::Value __hostFunction_NativeReanimatedModuleSpec_unregisterEventHandler(
+static jsi::Value
+__hostFunction_NativeReanimatedModuleSpec_unregisterEventHandler(
     jsi::Runtime &rt,
     TurboModule &turboModule,
     const jsi::Value *args,
@@ -85,37 +94,49 @@ static jsi::Value __hostFunction_NativeReanimatedModuleSpec_getViewProp(
     const jsi::Value *args,
     size_t count) {
   static_cast<NativeReanimatedModuleSpec *>(&turboModule)
-        ->getViewProp(rt, std::move(args[0]), std::move(args[1]), std::move(args[2]));
-    return jsi::Value::undefined();
+      ->getViewProp(
+          rt, std::move(args[0]), std::move(args[1]), std::move(args[2]));
+  return jsi::Value::undefined();
 }
 
-NativeReanimatedModuleSpec::NativeReanimatedModuleSpec(std::shared_ptr<CallInvoker> jsInvoker)
+static jsi::Value
+__hostFunction_NativeReanimatedModuleSpec_enableLayoutAnimations(
+    jsi::Runtime &rt,
+    TurboModule &turboModule,
+    const jsi::Value *args,
+    size_t count) {
+  static_cast<NativeReanimatedModuleSpec *>(&turboModule)
+      ->enableLayoutAnimations(rt, std::move(args[0]));
+  return jsi::Value::undefined();
+}
+
+NativeReanimatedModuleSpec::NativeReanimatedModuleSpec(
+    std::shared_ptr<CallInvoker> jsInvoker)
     : TurboModule("NativeReanimated", jsInvoker) {
   methodMap_["installCoreFunctions"] = MethodMetadata{
-    1, __hostFunction_NativeReanimatedModuleSpec_installCoreFunctions};
-
+      1, __hostFunction_NativeReanimatedModuleSpec_installCoreFunctions};
 
   methodMap_["makeShareable"] = MethodMetadata{
       1, __hostFunction_NativeReanimatedModuleSpec_makeShareable};
-  methodMap_["makeMutable"] = MethodMetadata{
-      1, __hostFunction_NativeReanimatedModuleSpec_makeMutable};
-  methodMap_["makeRemote"] = MethodMetadata{
-      1, __hostFunction_NativeReanimatedModuleSpec_makeRemote};
-      
+  methodMap_["makeMutable"] =
+      MethodMetadata{1, __hostFunction_NativeReanimatedModuleSpec_makeMutable};
+  methodMap_["makeRemote"] =
+      MethodMetadata{1, __hostFunction_NativeReanimatedModuleSpec_makeRemote};
 
-  methodMap_["startMapper"] = MethodMetadata{
-    3, __hostFunction_NativeReanimatedModuleSpec_startMapper};
-  methodMap_["stopMapper"] = MethodMetadata{
-    1, __hostFunction_NativeReanimatedModuleSpec_stopMapper};
+  methodMap_["startMapper"] =
+      MethodMetadata{5, __hostFunction_NativeReanimatedModuleSpec_startMapper};
+  methodMap_["stopMapper"] =
+      MethodMetadata{1, __hostFunction_NativeReanimatedModuleSpec_stopMapper};
 
   methodMap_["registerEventHandler"] = MethodMetadata{
-    2, __hostFunction_NativeReanimatedModuleSpec_registerEventHandler};
+      2, __hostFunction_NativeReanimatedModuleSpec_registerEventHandler};
   methodMap_["unregisterEventHandler"] = MethodMetadata{
-    1, __hostFunction_NativeReanimatedModuleSpec_unregisterEventHandler};
+      1, __hostFunction_NativeReanimatedModuleSpec_unregisterEventHandler};
 
-  methodMap_["getViewProp"] = MethodMetadata{
-    3, __hostFunction_NativeReanimatedModuleSpec_getViewProp};
+  methodMap_["getViewProp"] =
+      MethodMetadata{3, __hostFunction_NativeReanimatedModuleSpec_getViewProp};
+  methodMap_["enableLayoutAnimations"] = MethodMetadata{
+      2, __hostFunction_NativeReanimatedModuleSpec_enableLayoutAnimations};
 }
 
-}
-
+} // namespace reanimated

--- a/ios/vendored/sdk44/react-native-reanimated/Common/cpp/Registries/EventHandlerRegistry.cpp
+++ b/ios/vendored/sdk44/react-native-reanimated/Common/cpp/Registries/EventHandlerRegistry.cpp
@@ -3,7 +3,8 @@
 
 namespace ABI44_0_0reanimated {
 
-void EventHandlerRegistry::registerEventHandler(std::shared_ptr<WorkletEventHandler> eventHandler) {
+void EventHandlerRegistry::registerEventHandler(
+    std::shared_ptr<WorkletEventHandler> eventHandler) {
   const std::lock_guard<std::mutex> lock(instanceMutex);
   eventMappings[eventHandler->eventName][eventHandler->id] = eventHandler;
   eventHandlers[eventHandler->id] = eventHandler;
@@ -21,7 +22,10 @@ void EventHandlerRegistry::unregisterEventHandler(unsigned long id) {
   }
 }
 
-void EventHandlerRegistry::processEvent(jsi::Runtime &rt, std::string eventName, std::string eventPayload) {
+void EventHandlerRegistry::processEvent(
+    jsi::Runtime &rt,
+    std::string eventName,
+    std::string eventPayload) {
   std::vector<std::shared_ptr<WorkletEventHandler>> handlersForEvent;
   {
     const std::lock_guard<std::mutex> lock(instanceMutex);
@@ -38,15 +42,18 @@ void EventHandlerRegistry::processEvent(jsi::Runtime &rt, std::string eventName,
   std::string delimimter = "NativeMap:";
   auto positionToSplit = eventPayload.find(delimimter) + delimimter.size();
   auto lastBracketCharactedPosition = eventPayload.size() - positionToSplit - 1;
-  auto eventJSON = eventPayload.substr(positionToSplit,  lastBracketCharactedPosition);
+  auto eventJSON =
+      eventPayload.substr(positionToSplit, lastBracketCharactedPosition);
 
   if (eventJSON.compare(std::string("null")) == 0) {
     return;
   }
 
-  auto eventObject = jsi::Value::createFromJsonUtf8(rt, (uint8_t*)(&eventJSON[0]), eventJSON.size());
+  auto eventObject = jsi::Value::createFromJsonUtf8(
+      rt, reinterpret_cast<uint8_t *>(&eventJSON[0]), eventJSON.size());
 
-  eventObject.asObject(rt).setProperty(rt, "eventName", jsi::String::createFromUtf8(rt, eventName));
+  eventObject.asObject(rt).setProperty(
+      rt, "eventName", jsi::String::createFromUtf8(rt, eventName));
   for (auto handler : handlersForEvent) {
     handler->process(rt, eventObject);
   }
@@ -55,7 +62,7 @@ void EventHandlerRegistry::processEvent(jsi::Runtime &rt, std::string eventName,
 bool EventHandlerRegistry::isAnyHandlerWaitingForEvent(std::string eventName) {
   const std::lock_guard<std::mutex> lock(instanceMutex);
   auto it = eventMappings.find(eventName);
-  return (it != eventMappings.end()) and (!(it->second).empty());
+  return (it != eventMappings.end()) && (!(it->second).empty());
 }
 
-}
+} // namespace reanimated

--- a/ios/vendored/sdk44/react-native-reanimated/Common/cpp/Registries/MapperRegistry.cpp
+++ b/ios/vendored/sdk44/react-native-reanimated/Common/cpp/Registries/MapperRegistry.cpp
@@ -1,8 +1,8 @@
 #include "MapperRegistry.h"
-#include "Mapper.h"
-#include <map>
 #include <array>
+#include <map>
 #include <set>
+#include "Mapper.h"
 
 namespace ABI44_0_0reanimated {
 
@@ -21,7 +21,7 @@ void MapperRegistry::execute(jsi::Runtime &rt) {
     updateOrder();
     updatedSinceLastExecute = false;
   }
-  for (auto & mapper : sortedMappers) {
+  for (auto &mapper : sortedMappers) {
     if (mapper->dirty) {
       mapper->execute(rt);
     }
@@ -39,16 +39,18 @@ void MapperRegistry::updateOrder() { // Topological sorting
     std::shared_ptr<Mapper> mapper;
     std::shared_ptr<MutableValue> mutableValue;
 
-    NodeID(std::shared_ptr<Mapper> mapper) {
+    explicit NodeID(std::shared_ptr<Mapper> mapper) {
       if (mapper == nullptr) {
-        throw std::runtime_error("Graph couldn't be sorted (Mapper cannot be nullptr)");
+        throw std::runtime_error(
+            "Graph couldn't be sorted (Mapper cannot be nullptr)");
       }
       this->mapper = mapper;
     }
 
-    NodeID(std::shared_ptr<MutableValue> mutableValue) {
+    explicit NodeID(std::shared_ptr<MutableValue> mutableValue) {
       if (mutableValue == nullptr) {
-        throw std::runtime_error("Graph couldn't be sorted (Mutable cannot be nullptr)");
+        throw std::runtime_error(
+            "Graph couldn't be sorted (Mutable cannot be nullptr)");
       }
       this->mutableValue = mutableValue;
     }
@@ -57,8 +59,7 @@ void MapperRegistry::updateOrder() { // Topological sorting
       return mutableValue != nullptr;
     }
 
-    bool operator<(const NodeID& other) const
-    {
+    bool operator<(const NodeID &other) const {
       if (isMutable() != other.isMutable())
         return isMutable() < other.isMutable();
 
@@ -72,29 +73,31 @@ void MapperRegistry::updateOrder() { // Topological sorting
 
   std::map<NodeID, int> deg;
 
-  std::map<std::shared_ptr<MutableValue>, std::vector<std::shared_ptr<Mapper>>> mappersThatUseSharedValue;
+  std::map<std::shared_ptr<MutableValue>, std::vector<std::shared_ptr<Mapper>>>
+      mappersThatUseSharedValue;
 
   std::set<std::pair<int, NodeID>> nodes;
 
-  std::function<void(NodeID)> update = [&] (NodeID id) {
+  std::function<void(NodeID)> update = [&](NodeID id) {
     auto entry = std::make_pair(deg[id], id);
-    if (nodes.find(entry) == nodes.end()) return;
+    if (nodes.find(entry) == nodes.end())
+      return;
     nodes.erase(entry);
     entry.first--;
     deg[id]--;
     nodes.insert(entry);
   };
 
-  for (auto & entry : mappers) {
+  for (auto &entry : mappers) {
     auto id = NodeID(entry.second);
-    auto & mapper = entry.second;
+    auto &mapper = entry.second;
     deg[id] = mapper->inputs.size();
     nodes.insert(std::make_pair(deg[id], id));
 
     for (auto sharedValue : mapper->inputs) {
       auto sharedValueID = NodeID(sharedValue);
       mappersThatUseSharedValue[sharedValue].push_back(mapper);
-      if (deg.count(sharedValue) == 0) {
+      if (deg.count(sharedValueID) == 0) {
         deg[sharedValueID] = 0;
       }
     }
@@ -104,14 +107,14 @@ void MapperRegistry::updateOrder() { // Topological sorting
     }
   }
 
-  for (auto & entry : deg) {
+  for (auto &entry : deg) {
     auto id = entry.first;
     if (id.isMutable()) {
       nodes.insert(std::make_pair(entry.second, id));
     }
   }
 
-  while (nodes.size() > 0 and nodes.begin()->first == 0) {
+  while (nodes.size() > 0 && nodes.begin()->first == 0) {
     auto entry = *nodes.begin();
     nodes.erase(entry);
 
@@ -120,7 +123,7 @@ void MapperRegistry::updateOrder() { // Topological sorting
 
     if (id.isMutable()) {
       for (auto id : mappersThatUseSharedValue[id.mutableValue]) {
-        toUpdate.push_back(id);
+        toUpdate.push_back(NodeID(id));
       }
     } else {
       for (auto sharedValue : id.mapper->outputs) {
@@ -130,7 +133,8 @@ void MapperRegistry::updateOrder() { // Topological sorting
       sortedMappers.push_back(id.mapper);
     }
 
-    for (auto & id : toUpdate) update(id);
+    for (auto &id : toUpdate)
+      update(id);
   }
 
   if (nodes.size() > 0) {
@@ -138,4 +142,4 @@ void MapperRegistry::updateOrder() { // Topological sorting
   }
 }
 
-}
+} // namespace reanimated

--- a/ios/vendored/sdk44/react-native-reanimated/Common/cpp/Registries/WorkletsCache.cpp
+++ b/ios/vendored/sdk44/react-native-reanimated/Common/cpp/Registries/WorkletsCache.cpp
@@ -1,31 +1,38 @@
 #include "WorkletsCache.h"
-#include "ShareableValue.h"
 #include "FrozenObject.h"
+#include "ShareableValue.h"
 
 using namespace ABI44_0_0facebook;
 
-namespace ABI44_0_0reanimated
-{
+namespace ABI44_0_0reanimated {
 
 jsi::Value eval(jsi::Runtime &rt, const char *code) {
   return rt.global().getPropertyAsFunction(rt, "eval").call(rt, code);
 }
 
-jsi::Function function(jsi::Runtime &rt, const std::string& code) {
+jsi::Function function(jsi::Runtime &rt, const std::string &code) {
   return eval(rt, ("(" + code + ")").c_str()).getObject(rt).getFunction(rt);
 }
 
-std::shared_ptr<jsi::Function> WorkletsCache::getFunction(jsi::Runtime &rt, std::shared_ptr<FrozenObject> frozenObj) {
-  long long workletHash = ValueWrapper::asNumber(frozenObj->map["__workletHash"]->valueContainer);
+std::shared_ptr<jsi::Function> WorkletsCache::getFunction(
+    jsi::Runtime &rt,
+    std::shared_ptr<FrozenObject> frozenObj) {
+  long long workletHash =
+      ValueWrapper::asNumber(frozenObj->map["__workletHash"]->valueContainer);
   if (worklets.count(workletHash) == 0) {
-    jsi::Function fun = function(
-      rt,
-      ValueWrapper::asString(frozenObj->map["asString"]->valueContainer)
-    );
-    std::shared_ptr<jsi::Function> funPtr = std::make_shared<jsi::Function>(std::move(fun));
-    worklets[workletHash] = funPtr;
+    auto codeBuffer = std::make_shared<const jsi::StringBuffer>(
+        "(" +
+        ValueWrapper::asString(frozenObj->map["asString"]->valueContainer) +
+        ")");
+    auto func = rt.evaluateJavaScript(
+                      codeBuffer,
+                      ValueWrapper::asString(
+                          frozenObj->map["__location"]->valueContainer))
+                    .asObject(rt)
+                    .asFunction(rt);
+    worklets[workletHash] = std::make_shared<jsi::Function>(std::move(func));
   }
   return worklets[workletHash];
 }
 
-}
+} // namespace reanimated

--- a/ios/vendored/sdk44/react-native-reanimated/Common/cpp/SharedItems/FrozenObject.cpp
+++ b/ios/vendored/sdk44/react-native-reanimated/Common/cpp/SharedItems/FrozenObject.cpp
@@ -1,26 +1,35 @@
 #include "FrozenObject.h"
-#include "SharedParent.h"
-#include "ShareableValue.h"
 #include "RuntimeManager.h"
+#include "ShareableValue.h"
+#include "SharedParent.h"
 
 namespace ABI44_0_0reanimated {
 
-FrozenObject::FrozenObject(jsi::Runtime &rt, const jsi::Object &object, RuntimeManager *runtimeManager) {
+FrozenObject::FrozenObject(
+    jsi::Runtime &rt,
+    const jsi::Object &object,
+    RuntimeManager *runtimeManager) {
   auto propertyNames = object.getPropertyNames(rt);
-  for (size_t i = 0, count = propertyNames.size(rt); i < count; i++) {
+  const size_t count = propertyNames.size(rt);
+  namesOrder.reserve(count);
+  for (size_t i = 0; i < count; i++) {
     auto propertyName = propertyNames.getValueAtIndex(rt, i).asString(rt);
+    namesOrder.push_back(propertyName.utf8(rt));
     std::string nameStr = propertyName.utf8(rt);
-    map[nameStr] = ShareableValue::adapt(rt, object.getProperty(rt, propertyName), runtimeManager);
+    map[nameStr] = ShareableValue::adapt(
+        rt, object.getProperty(rt, propertyName), runtimeManager);
     this->containsHostFunction |= map[nameStr]->containsHostFunction;
   }
 }
 
 jsi::Object FrozenObject::shallowClone(jsi::Runtime &rt) {
   jsi::Object object(rt);
-  for (auto prop : map) {
-    object.setProperty(rt, jsi::String::createFromUtf8(rt, prop.first), prop.second->getValue(rt));
+  for (auto propName : namesOrder) {
+    auto value = map[propName];
+    object.setProperty(
+        rt, jsi::String::createFromUtf8(rt, propName), value->getValue(rt));
   }
   return object;
 }
 
-}
+} // namespace reanimated

--- a/ios/vendored/sdk44/react-native-reanimated/Common/cpp/SharedItems/MutableValue.cpp
+++ b/ios/vendored/sdk44/react-native-reanimated/Common/cpp/SharedItems/MutableValue.cpp
@@ -1,8 +1,8 @@
 #include "MutableValue.h"
-#include "SharedParent.h"
-#include "ShareableValue.h"
-#include "RuntimeManager.h"
 #include "RuntimeDecorator.h"
+#include "RuntimeManager.h"
+#include "ShareableValue.h"
+#include "SharedParent.h"
 
 namespace ABI44_0_0reanimated {
 
@@ -11,7 +11,7 @@ void MutableValue::setValue(jsi::Runtime &rt, const jsi::Value &newValue) {
   value = ShareableValue::adapt(rt, newValue, runtimeManager);
 
   std::shared_ptr<MutableValue> thiz = shared_from_this();
-  auto notifyListeners = [thiz] () {
+  auto notifyListeners = [thiz]() {
     for (auto listener : thiz->listeners) {
       listener.second();
     }
@@ -19,9 +19,8 @@ void MutableValue::setValue(jsi::Runtime &rt, const jsi::Value &newValue) {
   if (RuntimeDecorator::isUIRuntime(rt)) {
     notifyListeners();
   } else {
-    runtimeManager->scheduler->scheduleOnUI([notifyListeners] {
-      notifyListeners();
-    });
+    runtimeManager->scheduler->scheduleOnUI(
+        [notifyListeners] { notifyListeners(); });
   }
 }
 
@@ -30,26 +29,36 @@ jsi::Value MutableValue::getValue(jsi::Runtime &rt) {
   return value->getValue(rt);
 }
 
-void MutableValue::set(jsi::Runtime &rt, const jsi::PropNameID &name, const jsi::Value &newValue) {
+void MutableValue::set(
+    jsi::Runtime &rt,
+    const jsi::PropNameID &name,
+    const jsi::Value &newValue) {
   auto propName = name.utf8(rt);
   if (!runtimeManager->valueSetter) {
-    throw jsi::JSError(rt, "Value-Setter is not yet configured! Make sure the core-functions are installed.");
+    throw jsi::JSError(
+        rt,
+        "Value-Setter is not yet configured! Make sure the core-functions are installed.");
   }
 
   if (RuntimeDecorator::isUIRuntime(rt)) {
     // UI thread
     if (propName == "value") {
-      auto setterProxy = jsi::Object::createFromHostObject(rt, std::make_shared<MutableValueSetterProxy>(shared_from_this()));
+      auto setterProxy = jsi::Object::createFromHostObject(
+          rt, std::make_shared<MutableValueSetterProxy>(shared_from_this()));
       runtimeManager->valueSetter->getValue(rt)
-      .asObject(rt)
-      .asFunction(rt)
-      .callWithThis(rt, setterProxy, newValue);
+          .asObject(rt)
+          .asFunction(rt)
+          .callWithThis(rt, setterProxy, newValue);
     } else if (propName == "_animation") {
       // TODO: assert to allow animation to be set from UI only
       if (animation.expired()) {
         animation = getWeakRef(rt);
       }
       *animation.lock() = jsi::Value(rt, newValue);
+    } else if (propName == "_value") {
+      auto setter =
+          std::make_shared<MutableValueSetterProxy>(shared_from_this());
+      setter->set(rt, jsi::PropNameID::forAscii(rt, "_value"), newValue);
     }
   } else {
     // ABI44_0_0React-JS Thread or another threaded Runtime.
@@ -57,16 +66,16 @@ void MutableValue::set(jsi::Runtime &rt, const jsi::PropNameID &name, const jsi:
       auto shareable = ShareableValue::adapt(rt, newValue, runtimeManager);
       runtimeManager->scheduler->scheduleOnUI([this, shareable] {
         jsi::Runtime &rt = *this->runtimeManager->runtime.get();
-        auto setterProxy = jsi::Object::createFromHostObject(rt, std::make_shared<MutableValueSetterProxy>(shared_from_this()));
+        auto setterProxy = jsi::Object::createFromHostObject(
+            rt, std::make_shared<MutableValueSetterProxy>(shared_from_this()));
         jsi::Value newValue = shareable->getValue(rt);
         runtimeManager->valueSetter->getValue(rt)
-          .asObject(rt)
-          .asFunction(rt)
-          .callWithThis(rt, setterProxy, newValue);
+            .asObject(rt)
+            .asFunction(rt)
+            .callWithThis(rt, setterProxy, newValue);
       });
     }
   }
-
 }
 
 jsi::Value MutableValue::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
@@ -98,11 +107,18 @@ std::vector<jsi::PropNameID> MutableValue::getPropertyNames(jsi::Runtime &rt) {
   return result;
 }
 
-MutableValue::MutableValue(jsi::Runtime &rt, const jsi::Value &initial, RuntimeManager *runtimeManager, std::shared_ptr<Scheduler> s):
-StoreUser(s), runtimeManager(runtimeManager), value(ShareableValue::adapt(rt, initial, runtimeManager)) {
-}
+MutableValue::MutableValue(
+    jsi::Runtime &rt,
+    const jsi::Value &initial,
+    RuntimeManager *runtimeManager,
+    std::shared_ptr<Scheduler> s)
+    : StoreUser(s, *runtimeManager),
+      runtimeManager(runtimeManager),
+      value(ShareableValue::adapt(rt, initial, runtimeManager)) {}
 
-unsigned long int MutableValue::addListener(unsigned long id, std::function<void ()> listener) {
+unsigned long int MutableValue::addListener(
+    unsigned long id,
+    std::function<void()> listener) {
   listeners[id] = listener;
   return id;
 }
@@ -113,5 +129,4 @@ void MutableValue::removeListener(unsigned long listenerId) {
   }
 }
 
-
-}
+} // namespace reanimated

--- a/ios/vendored/sdk44/react-native-reanimated/Common/cpp/SharedItems/MutableValueSetterProxy.cpp
+++ b/ios/vendored/sdk44/react-native-reanimated/Common/cpp/SharedItems/MutableValueSetterProxy.cpp
@@ -1,17 +1,18 @@
 #include "MutableValueSetterProxy.h"
-#include "SharedParent.h"
-#include "MutableValue.h"
 #include <ABI44_0_0jsi/ABI44_0_0jsi.h>
+#include "MutableValue.h"
+#include "SharedParent.h"
 
 using namespace ABI44_0_0facebook;
 
 namespace ABI44_0_0reanimated {
 
-void MutableValueSetterProxy::set(jsi::Runtime &rt, const jsi::PropNameID &name, const jsi::Value &newValue) {
+void MutableValueSetterProxy::set(
+    jsi::Runtime &rt,
+    const jsi::PropNameID &name,
+    const jsi::Value &newValue) {
   auto propName = name.utf8(rt);
-  if (propName == "value") {
-    // you call `this.value` inside of value setter, we should throw
-  } else if (propName == "_value") {
+  if (propName == "_value") {
     mutableValue->setValue(rt, newValue);
   } else if (propName == "_animation") {
     // TODO: assert to allow animation to be set from UI only
@@ -19,10 +20,14 @@ void MutableValueSetterProxy::set(jsi::Runtime &rt, const jsi::PropNameID &name,
       mutableValue->animation = mutableValue->getWeakRef(rt);
     }
     *mutableValue->animation.lock() = jsi::Value(rt, newValue);
+  } else if (propName == "value") {
+    // you call `this.value` inside of value setter, we should throw
   }
 }
 
-jsi::Value MutableValueSetterProxy::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
+jsi::Value MutableValueSetterProxy::get(
+    jsi::Runtime &rt,
+    const jsi::PropNameID &name) {
   auto propName = name.utf8(rt);
 
   if (propName == "value") {
@@ -39,5 +44,4 @@ jsi::Value MutableValueSetterProxy::get(jsi::Runtime &rt, const jsi::PropNameID 
   return jsi::Value::undefined();
 }
 
-}
-
+} // namespace reanimated

--- a/ios/vendored/sdk44/react-native-reanimated/Common/cpp/SharedItems/RemoteObject.cpp
+++ b/ios/vendored/sdk44/react-native-reanimated/Common/cpp/SharedItems/RemoteObject.cpp
@@ -1,7 +1,7 @@
 #include "RemoteObject.h"
-#include "SharedParent.h"
-#include "RuntimeDecorator.h"
 #include <ABI44_0_0jsi/ABI44_0_0jsi.h>
+#include "RuntimeDecorator.h"
+#include "SharedParent.h"
 
 using namespace ABI44_0_0facebook;
 
@@ -22,7 +22,10 @@ jsi::Value RemoteObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
   return jsi::Value::undefined();
 }
 
-void RemoteObject::set(jsi::Runtime &rt, const jsi::PropNameID &name, const jsi::Value &value) {
+void RemoteObject::set(
+    jsi::Runtime &rt,
+    const jsi::PropNameID &name,
+    const jsi::Value &value) {
   if (RuntimeDecorator::isWorkletRuntime(rt)) {
     backing.lock()->getObject(rt).setProperty(rt, name, value);
   }
@@ -33,9 +36,10 @@ std::vector<jsi::PropNameID> RemoteObject::getPropertyNames(jsi::Runtime &rt) {
   std::vector<jsi::PropNameID> res;
   auto propertyNames = backing.lock()->getObject(rt).getPropertyNames(rt);
   for (size_t i = 0, size = propertyNames.size(rt); i < size; i++) {
-    res.push_back(jsi::PropNameID::forString(rt, propertyNames.getValueAtIndex(rt, i).asString(rt)));
+    res.push_back(jsi::PropNameID::forString(
+        rt, propertyNames.getValueAtIndex(rt, i).asString(rt)));
   }
   return res;
 }
 
-}
+} // namespace reanimated

--- a/ios/vendored/sdk44/react-native-reanimated/Common/cpp/SharedItems/ShareableValue.cpp
+++ b/ios/vendored/sdk44/react-native-reanimated/Common/cpp/SharedItems/ShareableValue.cpp
@@ -1,30 +1,31 @@
-#include "ShareableValue.h"
-#include "SharedParent.h"
-#include "RuntimeManager.h"
+#include <cxxabi.h>
+#include "FrozenObject.h"
 #include "MutableValue.h"
 #include "MutableValueSetterProxy.h"
 #include "RemoteObject.h"
-#include "FrozenObject.h"
 #include "RuntimeDecorator.h"
+#include "RuntimeManager.h"
+#include "SharedParent.h"
 
 namespace ABI44_0_0reanimated {
-
+class ShareableValue;
 const char *HIDDEN_HOST_OBJECT_PROP = "__reanimatedHostObjectRef";
-const char *ALREADY_CONVERTED= "__alreadyConverted";
+const char *ALREADY_CONVERTED = "__alreadyConverted";
 const char *CALL_ASYNC = "__callAsync";
 const char *PRIMAL_FUNCTION = "__primalFunction";
-std::string CALLBACK_ERROR_SUFFIX = R"(
+const char *CALLBACK_ERROR_SUFFIX =
+    "\n\nPossible solutions are:\n"
+    "a) If you want to synchronously execute this method, mark it as a Worklet\n"
+    "b) If you want to execute this method on the JS thread, wrap it using runOnJS";
 
-Possible solutions are:
-a) If you want to synchronously execute this method, mark it as a Worklet
-b) If you want to execute this method on the JS thread, wrap it using runOnJS )";
-
-void addHiddenProperty(jsi::Runtime &rt,
-                       jsi::Value &&value,
-                       jsi::Object &obj,
-                       const char *name) {
+void addHiddenProperty(
+    jsi::Runtime &rt,
+    jsi::Value &&value,
+    const jsi::Object &obj,
+    const char *name) {
   jsi::Object globalObject = rt.global().getPropertyAsObject(rt, "Object");
-  jsi::Function defineProperty = globalObject.getPropertyAsFunction(rt, "defineProperty");
+  jsi::Function defineProperty =
+      globalObject.getPropertyAsFunction(rt, "defineProperty");
   jsi::String internalPropName = jsi::String::createFromUtf8(rt, name);
   jsi::Object paramForDefineProperty(rt);
   paramForDefineProperty.setProperty(rt, "enumerable", false);
@@ -32,15 +33,16 @@ void addHiddenProperty(jsi::Runtime &rt,
   defineProperty.call(rt, obj, internalPropName, paramForDefineProperty);
 }
 
-void freeze(jsi::Runtime &rt, jsi::Object &obj) {
+void freeze(jsi::Runtime &rt, const jsi::Object &obj) {
   jsi::Object globalObject = rt.global().getPropertyAsObject(rt, "Object");
   jsi::Function freeze = globalObject.getPropertyAsFunction(rt, "freeze");
   freeze.call(rt, obj);
 }
 
 void ShareableValue::adaptCache(jsi::Runtime &rt, const jsi::Value &value) {
-  // when adapting from host object we can assign cached value immediately such that we avoid
-  // running `toJSValue` in the future when given object is accessed
+  // when adapting from host object we can assign cached value immediately such
+  // that we avoid running `toJSValue` in the future when given object is
+  // accessed
   if (RuntimeDecorator::isWorkletRuntime(rt)) {
     if (remoteValue.expired()) {
       remoteValue = getWeakRef(rt);
@@ -51,8 +53,10 @@ void ShareableValue::adaptCache(jsi::Runtime &rt, const jsi::Value &value) {
   }
 }
 
-void ShareableValue::adapt(jsi::Runtime &rt, const jsi::Value &value, ValueType objectType) {
-  bool isRNRuntime = RuntimeDecorator::isReactRuntime(rt);
+void ShareableValue::adapt(
+    jsi::Runtime &rt,
+    const jsi::Value &value,
+    ValueType objectType) {
   if (value.isObject()) {
     jsi::Object object = value.asObject(rt);
     jsi::Value hiddenValue = object.getProperty(rt, HIDDEN_HOST_OBJECT_PROP);
@@ -64,8 +68,7 @@ void ShareableValue::adapt(jsi::Runtime &rt, const jsi::Value &value, ValueType 
           type = ValueType::WorkletFunctionType;
         }
         valueContainer = std::make_unique<FrozenObjectWrapper>(
-          hiddenProperty.getHostObject<FrozenObject>(rt)
-        );
+            hiddenProperty.getHostObject<FrozenObject>(rt));
         if (object.hasProperty(rt, ALREADY_CONVERTED)) {
           adaptCache(rt, value);
         }
@@ -76,9 +79,9 @@ void ShareableValue::adapt(jsi::Runtime &rt, const jsi::Value &value, ValueType 
 
   if (objectType == ValueType::MutableValueType) {
     type = ValueType::MutableValueType;
-    valueContainer = std::make_unique<MutableValueWrapper>(
-      std::make_shared<MutableValue>(rt, value, runtimeManager, runtimeManager->scheduler)
-    );
+    valueContainer =
+        std::make_unique<MutableValueWrapper>(std::make_shared<MutableValue>(
+            rt, value, runtimeManager, runtimeManager->scheduler));
   } else if (value.isUndefined()) {
     type = ValueType::UndefinedType;
   } else if (value.isNull()) {
@@ -91,7 +94,8 @@ void ShareableValue::adapt(jsi::Runtime &rt, const jsi::Value &value, ValueType 
     valueContainer = std::make_unique<NumberValueWrapper>(value.asNumber());
   } else if (value.isString()) {
     type = ValueType::StringType;
-    valueContainer = std::make_unique<StringValueWrapper>(value.asString(rt).utf8(rt));
+    valueContainer =
+        std::make_unique<StringValueWrapper>(value.asString(rt).utf8(rt));
   } else if (value.isObject()) {
     auto object = value.asObject(rt);
     if (object.isFunction(rt)) {
@@ -100,32 +104,39 @@ void ShareableValue::adapt(jsi::Runtime &rt, const jsi::Value &value, ValueType 
         type = ValueType::HostFunctionType;
         containsHostFunction = true;
 
-        //Check if it's a hostFunction wrapper
+        // Check if it's a hostFunction wrapper
         jsi::Value primalFunction = object.getProperty(rt, PRIMAL_FUNCTION);
         if (!primalFunction.isUndefined()) {
-            jsi::Object handlerAsObject = primalFunction.asObject(rt);
-            std::shared_ptr<HostFunctionHandler> handler = handlerAsObject.getHostObject<HostFunctionHandler>(rt);
-            valueContainer = std::make_unique<HostFunctionWrapper>(handler);
+          jsi::Object handlerAsObject = primalFunction.asObject(rt);
+          std::shared_ptr<HostFunctionHandler> handler =
+              handlerAsObject.getHostObject<HostFunctionHandler>(rt);
+          valueContainer = std::make_unique<HostFunctionWrapper>(handler);
         } else {
-            valueContainer = std::make_unique<HostFunctionWrapper>(
-              std::make_shared<HostFunctionHandler>(std::make_shared<jsi::Function>(object.asFunction(rt)), rt));
+          valueContainer = std::make_unique<HostFunctionWrapper>(
+              std::make_shared<HostFunctionHandler>(
+                  std::make_shared<jsi::Function>(object.asFunction(rt)), rt));
         }
 
       } else {
         // a worklet
         type = ValueType::WorkletFunctionType;
-        valueContainer = std::make_unique<FrozenObjectWrapper>(std::make_shared<FrozenObject>(rt, object, runtimeManager));
-        auto& frozenObject = ValueWrapper::asFrozenObject(valueContainer);
+        valueContainer = std::make_unique<FrozenObjectWrapper>(
+            std::make_shared<FrozenObject>(rt, object, runtimeManager));
+        auto &frozenObject = ValueWrapper::asFrozenObject(valueContainer);
         containsHostFunction |= frozenObject->containsHostFunction;
-        if (isRNRuntime && !containsHostFunction) {
-          addHiddenProperty(rt, createHost(rt, frozenObject), object, HIDDEN_HOST_OBJECT_PROP);
+        if (RuntimeDecorator::isReactRuntime(rt) && !containsHostFunction) {
+          addHiddenProperty(
+              rt,
+              createHost(rt, frozenObject),
+              object,
+              HIDDEN_HOST_OBJECT_PROP);
         }
       }
     } else if (object.isArray(rt)) {
       type = ValueType::FrozenArrayType;
       auto array = object.asArray(rt);
       valueContainer = std::make_unique<FrozenArrayWrapper>();
-      auto& frozenArray = ValueWrapper::asFrozenArray(valueContainer);
+      auto &frozenArray = ValueWrapper::asFrozenArray(valueContainer);
       for (size_t i = 0, size = array.size(rt); i < size; i++) {
         auto sv = adapt(rt, array.getValueAtIndex(rt, i), runtimeManager);
         containsHostFunction |= sv->containsHostFunction;
@@ -133,79 +144,98 @@ void ShareableValue::adapt(jsi::Runtime &rt, const jsi::Value &value, ValueType 
       }
     } else if (object.isHostObject<MutableValue>(rt)) {
       type = ValueType::MutableValueType;
-      valueContainer = std::make_unique<MutableValueWrapper>(object.getHostObject<MutableValue>(rt));
+      valueContainer = std::make_unique<MutableValueWrapper>(
+          object.getHostObject<MutableValue>(rt));
       adaptCache(rt, value);
     } else if (object.isHostObject<RemoteObject>(rt)) {
       type = ValueType::RemoteObjectType;
       valueContainer = std::make_unique<RemoteObjectWrapper>(
-         object.getHostObject<RemoteObject>(rt)
-      );
+          object.getHostObject<RemoteObject>(rt));
       adaptCache(rt, value);
     } else if (objectType == ValueType::RemoteObjectType) {
       type = ValueType::RemoteObjectType;
-      valueContainer = std::make_unique<RemoteObjectWrapper>(
-        std::make_shared<RemoteObject>(rt, object, runtimeManager, runtimeManager->scheduler)
-      );
+      valueContainer =
+          std::make_unique<RemoteObjectWrapper>(std::make_shared<RemoteObject>(
+              rt, object, runtimeManager, runtimeManager->scheduler));
     } else {
       // create frozen object based on a copy of a given object
       type = ValueType::FrozenObjectType;
       valueContainer = std::make_unique<FrozenObjectWrapper>(
-        std::make_shared<FrozenObject>(rt, object, runtimeManager)
-      );
-      auto& frozenObject = ValueWrapper::asFrozenObject(valueContainer);
+          std::make_shared<FrozenObject>(rt, object, runtimeManager));
+      auto &frozenObject = ValueWrapper::asFrozenObject(valueContainer);
       containsHostFunction |= frozenObject->containsHostFunction;
-      if (isRNRuntime) {
+      if (RuntimeDecorator::isReactRuntime(rt)) {
         if (!containsHostFunction) {
-          addHiddenProperty(rt, createHost(rt, frozenObject), object, HIDDEN_HOST_OBJECT_PROP);
+          addHiddenProperty(
+              rt,
+              createHost(rt, frozenObject),
+              object,
+              HIDDEN_HOST_OBJECT_PROP);
         }
         freeze(rt, object);
       }
     }
   } else if (value.isSymbol()) {
     type = ValueType::StringType;
-    valueContainer = std::make_unique<StringValueWrapper>(value.asSymbol(rt).toString(rt));
+    valueContainer =
+        std::make_unique<StringValueWrapper>(value.asSymbol(rt).toString(rt));
   } else {
     throw "Invalid value type";
   }
 }
 
-std::shared_ptr<ShareableValue> ShareableValue::adapt(jsi::Runtime &rt, const jsi::Value &value, RuntimeManager *runtimeManager, ValueType valueType) {
-  auto sv = std::shared_ptr<ShareableValue>(new ShareableValue(runtimeManager, runtimeManager->scheduler));
+std::shared_ptr<ShareableValue> ShareableValue::adapt(
+    jsi::Runtime &rt,
+    const jsi::Value &value,
+    RuntimeManager *runtimeManager,
+    ValueType valueType) {
+  auto sv = std::shared_ptr<ShareableValue>(
+      new ShareableValue(runtimeManager, runtimeManager->scheduler));
   sv->adapt(rt, value, valueType);
   return sv;
 }
 
 jsi::Value ShareableValue::getValue(jsi::Runtime &rt) {
-  // TODO: maybe we can cache toJSValue results on a per-runtime basis, need to avoid ref loops
-  if (RuntimeDecorator::isWorkletRuntime(rt)) {
+  // TODO: maybe we can cache toJSValue results on a per-runtime basis, need to
+  // avoid ref loops
+  if (&rt == runtimeManager->runtime.get()) {
+    // Getting value on the same runtime where it was created, prepare
+    // remoteValue
     if (remoteValue.expired()) {
-      auto ref = getWeakRef(rt);
-      remoteValue = ref;
+      remoteValue = getWeakRef(rt);
     }
 
     if (remoteValue.lock()->isUndefined()) {
-      (*remoteValue.lock()) = jsi::Value(rt, toJSValue(rt));
+      (*remoteValue.lock()) = toJSValue(rt);
     }
     return jsi::Value(rt, *remoteValue.lock());
   } else {
+    // Getting value on a different runtime than where it was created from,
+    // prepare hostValue
     if (hostValue.get() == nullptr) {
-      hostValue = std::make_unique<jsi::Value>(rt, toJSValue(rt));
+      hostValue = std::make_unique<jsi::Value>(toJSValue(rt));
     }
     return jsi::Value(rt, *hostValue);
   }
 }
 
-jsi::Object ShareableValue::createHost(jsi::Runtime &rt, std::shared_ptr<jsi::HostObject> host) {
+jsi::Object ShareableValue::createHost(
+    jsi::Runtime &rt,
+    std::shared_ptr<jsi::HostObject> host) {
   return jsi::Object::createFromHostObject(rt, host);
 }
 
-jsi::Value createFrozenWrapper(jsi::Runtime &rt, std::shared_ptr<FrozenObject> frozenObject) {
-  jsi::Object __reanimatedHiddenHost = jsi::Object::createFromHostObject(rt, frozenObject);
+jsi::Value createFrozenWrapper(
+    jsi::Runtime &rt,
+    std::shared_ptr<FrozenObject> frozenObject) {
+  jsi::Object __reanimatedHiddenHost =
+      jsi::Object::createFromHostObject(rt, frozenObject);
   jsi::Object obj = frozenObject->shallowClone(rt);
   jsi::Object globalObject = rt.global().getPropertyAsObject(rt, "Object");
   jsi::Function freeze = globalObject.getPropertyAsFunction(rt, "freeze");
   if (!frozenObject->containsHostFunction) {
-    addHiddenProperty(rt, std::move(__reanimatedHiddenHost), obj, HIDDEN_HOST_OBJECT_PROP);
+    addHiddenProperty(
+        rt, std::move(__reanimatedHiddenHost), obj, HIDDEN_HOST_OBJECT_PROP);
     addHiddenProperty(rt, true, obj, ALREADY_CONVERTED);
   }
   return freeze.call(rt, obj);
@@ -222,15 +252,15 @@ jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {
     case ValueType::NumberType:
       return jsi::Value(ValueWrapper::asNumber(valueContainer));
     case ValueType::StringType: {
-      auto& stringValue = ValueWrapper::asString(valueContainer);
+      auto &stringValue = ValueWrapper::asString(valueContainer);
       return jsi::Value(rt, jsi::String::createFromUtf8(rt, stringValue));
     }
     case ValueType::FrozenObjectType: {
-      auto& frozenObject = ValueWrapper::asFrozenObject(valueContainer);
+      auto &frozenObject = ValueWrapper::asFrozenObject(valueContainer);
       return createFrozenWrapper(rt, frozenObject);
     }
     case ValueType::FrozenArrayType: {
-      auto& frozenArray = ValueWrapper::asFrozenArray(valueContainer);
+      auto &frozenArray = ValueWrapper::asFrozenArray(valueContainer);
       jsi::Array array(rt, frozenArray.size());
       for (size_t i = 0; i < frozenArray.size(); i++) {
         array.setValueAtIndex(rt, i, frozenArray[i]->toJSValue(rt));
@@ -238,45 +268,50 @@ jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {
       return array;
     }
     case ValueType::RemoteObjectType: {
-      auto& remoteObject = ValueWrapper::asRemoteObject(valueContainer);
+      auto &remoteObject = ValueWrapper::asRemoteObject(valueContainer);
       if (RuntimeDecorator::isWorkletRuntime(rt)) {
         remoteObject->maybeInitializeOnWorkletRuntime(rt);
       }
       return createHost(rt, remoteObject);
     }
     case ValueType::MutableValueType: {
-      auto& mutableObject = ValueWrapper::asMutableValue(valueContainer);
+      auto &mutableObject = ValueWrapper::asMutableValue(valueContainer);
       return createHost(rt, mutableObject);
     }
     case ValueType::HostFunctionType: {
-      auto hostFunctionWrapper = ValueWrapper::asHostFunctionWrapper(valueContainer);
-      auto& hostRuntime = hostFunctionWrapper->value->hostRuntime;
+      auto hostFunctionWrapper =
+          ValueWrapper::asHostFunctionWrapper(valueContainer);
+      auto &hostRuntime = hostFunctionWrapper->value->hostRuntime;
       if (hostRuntime == &rt) {
-        // function is accessed from the same runtime it was crated, we just return same function obj
-        return jsi::Value(rt, *hostFunctionWrapper->value->getPureFunction().get());
+        // function is accessed from the same runtime it was crated, we just
+        // return same function obj
+        return jsi::Value(
+            rt, *hostFunctionWrapper->value->getPureFunction().get());
       } else {
-        // function is accessed from a different runtime, we wrap function in host func that'd enqueue
-        // call on an appropriate thread
+        // function is accessed from a different runtime, we wrap function in
+        // host func that'd enqueue call on an appropriate thread
 
         auto runtimeManager = this->runtimeManager;
         auto hostFunction = hostFunctionWrapper->value;
 
         auto warnFunction = [runtimeManager, hostFunction](
-            jsi::Runtime &rt,
-            const jsi::Value &thisValue,
-            const jsi::Value *args,
-            size_t count
-            ) -> jsi::Value {
-
+                                jsi::Runtime &rt,
+                                const jsi::Value &thisValue,
+                                const jsi::Value *args,
+                                size_t count) -> jsi::Value {
           jsi::Value jsThis = rt.global().getProperty(rt, "jsThis");
-          std::string workletLocation = jsThis.asObject(rt).getProperty(rt, "__location").toString(rt).utf8(rt);
+          std::string workletLocation = jsThis.asObject(rt)
+                                            .getProperty(rt, "__location")
+                                            .toString(rt)
+                                            .utf8(rt);
           std::string exceptionMessage = "Tried to synchronously call ";
-          if(hostFunction->functionName.empty()) {
+          if (hostFunction->functionName.empty()) {
             exceptionMessage += "anonymous function";
           } else {
             exceptionMessage += "function {" + hostFunction->functionName + "}";
           }
-          exceptionMessage += " from a different thread.\n\nOccurred in worklet location: ";
+          exceptionMessage +=
+              " from a different thread.\n\nOccurred in worklet location: ";
           exceptionMessage += workletLocation;
           exceptionMessage += CALLBACK_ERROR_SUFFIX;
           runtimeManager->errorHandler->setError(exceptionMessage);
@@ -286,127 +321,150 @@ jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {
         };
 
         auto clb = [runtimeManager, hostFunction, hostRuntime](
-            jsi::Runtime &rt,
-            const jsi::Value &thisValue,
-            const jsi::Value *args,
-            size_t count
-            ) -> jsi::Value {
-          // TODO: we should find thread based on runtime such that we could also call UI methods
-          // from RN and not only RN methods from UI
+                       jsi::Runtime &rt,
+                       const jsi::Value &thisValue,
+                       const jsi::Value *args,
+                       size_t count) -> jsi::Value {
+          // TODO: we should find thread based on runtime such that we could
+          // also call UI methods from RN and not only RN methods from UI
 
           std::vector<std::shared_ptr<ShareableValue>> params;
           for (int i = 0; i < count; ++i) {
-            params.push_back(ShareableValue::adapt(rt, args[i], runtimeManager));
+            params.push_back(
+                ShareableValue::adapt(rt, args[i], runtimeManager));
           }
 
           std::function<void()> job = [hostFunction, hostRuntime, params] {
-            jsi::Value * args = new jsi::Value[params.size()];
+            jsi::Value *args = new jsi::Value[params.size()];
             for (int i = 0; i < params.size(); ++i) {
               args[i] = params[i]->getValue(*hostRuntime);
             }
-            jsi::Value returnedValue = hostFunction->getPureFunction().get()->call(*hostRuntime,
-                                                static_cast<const jsi::Value*>(args),
-                                                (size_t)params.size());
+            jsi::Value returnedValue =
+                hostFunction->getPureFunction().get()->call(
+                    *hostRuntime,
+                    static_cast<const jsi::Value *>(args),
+                    static_cast<size_t>(params.size()));
 
-            delete [] args;
+            delete[] args;
             // ToDo use returned value to return promise
           };
 
           runtimeManager->scheduler->scheduleOnJS(job);
           return jsi::Value::undefined();
         };
-        jsi::Function wrapperFunction = jsi::Function::createFromHostFunction(rt, jsi::PropNameID::forAscii(rt, "hostFunction"), 0, warnFunction);
-        jsi::Function res = jsi::Function::createFromHostFunction(rt, jsi::PropNameID::forAscii(rt, "hostFunction"), 0, clb);
+        jsi::Function wrapperFunction = jsi::Function::createFromHostFunction(
+            rt, jsi::PropNameID::forAscii(rt, "hostFunction"), 0, warnFunction);
+        jsi::Function res = jsi::Function::createFromHostFunction(
+            rt, jsi::PropNameID::forAscii(rt, "hostFunction"), 0, clb);
         addHiddenProperty(rt, std::move(res), wrapperFunction, CALL_ASYNC);
-        jsi::Object functionHandler = createHost(rt, hostFunctionWrapper->value);
-        addHiddenProperty(rt, std::move(functionHandler), wrapperFunction, PRIMAL_FUNCTION);
+        jsi::Object functionHandler =
+            createHost(rt, hostFunctionWrapper->value);
+        addHiddenProperty(
+            rt, std::move(functionHandler), wrapperFunction, PRIMAL_FUNCTION);
         return wrapperFunction;
       }
     }
     case ValueType::WorkletFunctionType: {
       auto runtimeManager = this->runtimeManager;
-      auto& frozenObject = ValueWrapper::asFrozenObject(this->valueContainer);
+      auto &frozenObject = ValueWrapper::asFrozenObject(this->valueContainer);
       if (RuntimeDecorator::isWorkletRuntime(rt)) {
         // when running on worklet thread we prep a function
 
-        auto jsThis = std::make_shared<jsi::Object>(frozenObject->shallowClone(*runtimeManager->runtime));
-        std::shared_ptr<jsi::Function> funPtr(runtimeManager->workletsCache->getFunction(rt, frozenObject));
+        auto jsThis = std::make_shared<jsi::Object>(
+            frozenObject->shallowClone(*runtimeManager->runtime));
+        std::shared_ptr<jsi::Function> funPtr(
+            runtimeManager->workletsCache->getFunction(rt, frozenObject));
         auto name = funPtr->getProperty(rt, "name").asString(rt).utf8(rt);
 
-        auto clb = [=](
-                   jsi::Runtime &rt,
-                   const jsi::Value &thisValue,
-                   const jsi::Value *args,
-                   size_t count
-                   ) mutable -> jsi::Value {
-           jsi::Value oldJSThis = rt.global().getProperty(rt, "jsThis");
-           rt.global().setProperty(rt, "jsThis", *jsThis); //set jsThis
+        auto clb = [=](jsi::Runtime &rt,
+                       const jsi::Value &thisValue,
+                       const jsi::Value *args,
+                       size_t count) mutable -> jsi::Value {
+          const jsi::String jsThisName =
+              jsi::String::createFromAscii(rt, "jsThis");
+          jsi::Object global = rt.global();
+          jsi::Value oldJSThis = global.getProperty(rt, jsThisName);
+          global.setProperty(rt, jsThisName, *jsThis); // set jsThis
 
-           jsi::Value res = jsi::Value::undefined();
-           try {
-             if (thisValue.isObject()) {
-               res = funPtr->callWithThis(rt, thisValue.asObject(rt), args, count);
-             } else {
-               res = funPtr->call(rt, args, count);
-             }
-           } catch(jsi::JSError &e) {
-              throw e;
-           } catch(...) {
-              // TODO find out a way to get the error's message on hermes
-              jsi::Value location = jsThis->getProperty(rt, "__location");
-              std::string str = "Javascript worklet error";
-              if (location.isString()) {
-                str += "\nIn file: " + location.asString(rt).utf8(rt);
-              }
-              runtimeManager->errorHandler->setError(str);
-              runtimeManager->errorHandler->raise();
+          jsi::Value res = jsi::Value::undefined();
+          try {
+            if (thisValue.isObject()) {
+              res =
+                  funPtr->callWithThis(rt, thisValue.asObject(rt), args, count);
+            } else {
+              res = funPtr->call(rt, args, count);
             }
-
-           rt.global().setProperty(rt, "jsThis", oldJSThis); //clean jsThis
-           return res;
+          } catch (jsi::JSError &e) {
+            throw e;
+          } catch (...) {
+            if (demangleExceptionName(
+                    abi::__cxa_current_exception_type()->name()) ==
+                "ABI44_0_0facebook::jsi::JSError") {
+              throw jsi::JSError(rt, "Javascript worklet error");
+            }
+            // TODO find out a way to get the error's message on hermes
+            jsi::Value location = jsThis->getProperty(rt, "__location");
+            std::string str = "Javascript worklet error";
+            if (location.isString()) {
+              str += "\nIn file: " + location.asString(rt).utf8(rt);
+            }
+            runtimeManager->errorHandler->setError(str);
+            runtimeManager->errorHandler->raise();
+          }
+          global.setProperty(rt, jsThisName, oldJSThis); // clean jsThis
+          return res;
         };
-        return jsi::Function::createFromHostFunction(rt, jsi::PropNameID::forAscii(rt, name.c_str()), 0, clb);
+        return jsi::Function::createFromHostFunction(
+            rt, jsi::PropNameID::forAscii(rt, name.c_str()), 0, clb);
       } else {
         // when run outside of UI thread we enqueue a call on the UI thread
-        auto clb = [=](
-            jsi::Runtime &rt,
-            const jsi::Value &thisValue,
-            const jsi::Value *args,
-            size_t count
-            ) -> jsi::Value {
-          // TODO: we should find thread based on runtime such that we could also call UI methods
-          // from RN and not only RN methods from UI
+        auto clb = [=](jsi::Runtime &rt,
+                       const jsi::Value &thisValue,
+                       const jsi::Value *args,
+                       size_t count) -> jsi::Value {
+          // TODO: we should find thread based on runtime such that we could
+          // also call UI methods from RN and not only RN methods from UI
 
           std::vector<std::shared_ptr<ShareableValue>> params;
           for (int i = 0; i < count; ++i) {
-            params.push_back(ShareableValue::adapt(rt, args[i], runtimeManager));
+            params.push_back(
+                ShareableValue::adapt(rt, args[i], runtimeManager));
           }
 
           runtimeManager->scheduler->scheduleOnUI([=] {
             jsi::Runtime &rt = *runtimeManager->runtime.get();
             auto jsThis = createFrozenWrapper(rt, frozenObject).getObject(rt);
-            auto code = jsThis.getProperty(rt, "asString").asString(rt).utf8(rt);
-            std::shared_ptr<jsi::Function> funPtr(runtimeManager->workletsCache->getFunction(rt, frozenObject));
+            auto code =
+                jsThis.getProperty(rt, "asString").asString(rt).utf8(rt);
+            std::shared_ptr<jsi::Function> funPtr(
+                runtimeManager->workletsCache->getFunction(rt, frozenObject));
 
-            jsi::Value * args = new jsi::Value[params.size()];
+            jsi::Value *args = new jsi::Value[params.size()];
             for (int i = 0; i < params.size(); ++i) {
               args[i] = params[i]->getValue(rt);
             }
 
             jsi::Value returnedValue;
-
-            jsi::Value oldJSThis = rt.global().getProperty(rt, "jsThis");
-            rt.global().setProperty(rt, "jsThis", jsThis); //set jsThis
+            const jsi::String jsThisName =
+                jsi::String::createFromAscii(rt, "jsThis");
+            jsi::Object global = rt.global();
+            jsi::Value oldJSThis = global.getProperty(rt, jsThisName);
+            global.setProperty(rt, jsThisName, jsThis); // set jsThis
             try {
-              returnedValue = funPtr->call(rt,
-                                             static_cast<const jsi::Value*>(args),
-                                             (size_t)params.size());
-
-            } catch(std::exception &e) {
+              returnedValue = funPtr->call(
+                  rt,
+                  static_cast<const jsi::Value *>(args),
+                  static_cast<size_t>(params.size()));
+            } catch (std::exception &e) {
               std::string str = e.what();
               runtimeManager->errorHandler->setError(str);
               runtimeManager->errorHandler->raise();
-            } catch(...) {
+            } catch (...) {
+              if (demangleExceptionName(
+                      abi::__cxa_current_exception_type()->name()) ==
+                  "ABI44_0_0facebook::jsi::JSError") {
+                throw jsi::JSError(rt, "Javascript worklet error");
+              }
               // TODO find out a way to get the error's message on hermes
               jsi::Value location = jsThis.getProperty(rt, "__location");
               std::string str = "Javascript worklet error";
@@ -416,14 +474,15 @@ jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {
               runtimeManager->errorHandler->setError(str);
               runtimeManager->errorHandler->raise();
             }
-            rt.global().setProperty(rt, "jsThis", oldJSThis); //clean jsThis
+            global.setProperty(rt, jsThisName, oldJSThis); // clean jsThis
 
-            delete [] args;
+            delete[] args;
             // ToDo use returned value to return promise
           });
           return jsi::Value::undefined();
         };
-        return jsi::Function::createFromHostFunction(rt, jsi::PropNameID::forAscii(rt, "_workletFunction"), 0, clb);
+        return jsi::Function::createFromHostFunction(
+            rt, jsi::PropNameID::forAscii(rt, "_workletFunction"), 0, clb);
       }
     }
     default: {
@@ -433,4 +492,16 @@ jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {
   throw "convert error";
 }
 
+std::string ShareableValue::demangleExceptionName(std::string toDemangle) {
+  int status = 0;
+  char *buff =
+      __cxxabiv1::__cxa_demangle(toDemangle.c_str(), nullptr, nullptr, &status);
+  if (!buff) {
+    return toDemangle;
+  }
+  std::string demangled = buff;
+  std::free(buff);
+  return demangled;
 }
+
+} // namespace reanimated

--- a/ios/vendored/sdk44/react-native-reanimated/Common/cpp/Tools/FeaturesConfig.cpp
+++ b/ios/vendored/sdk44/react-native-reanimated/Common/cpp/Tools/FeaturesConfig.cpp
@@ -1,0 +1,5 @@
+#include "FeaturesConfig.h"
+
+namespace ABI44_0_0reanimated {
+bool FeaturesConfig::_isLayoutAnimationEnabled = false;
+}

--- a/ios/vendored/sdk44/react-native-reanimated/Common/cpp/Tools/JSIStoreValueUser.cpp
+++ b/ios/vendored/sdk44/react-native-reanimated/Common/cpp/Tools/JSIStoreValueUser.cpp
@@ -1,43 +1,55 @@
 #include "JSIStoreValueUser.h"
+#include "RuntimeManager.h"
+#ifdef ONANDROID
+#include <AndroidScheduler.h>
+#endif
 
 namespace ABI44_0_0reanimated {
 
-std::atomic<int> StoreUser::ctr;
-std::recursive_mutex StoreUser::storeMutex;
-std::unordered_map<int, std::vector<std::shared_ptr<jsi::Value>>> StoreUser::store;
-
 std::weak_ptr<jsi::Value> StoreUser::getWeakRef(jsi::Runtime &rt) {
-  const std::lock_guard<std::recursive_mutex> lock(storeMutex);
-  if (StoreUser::store.count(identifier) == 0) {
-    StoreUser::store[identifier] = std::vector<std::shared_ptr<jsi::Value>>();
+  const std::lock_guard<std::recursive_mutex> lock(storeUserData->storeMutex);
+  if (storeUserData->store.count(identifier) == 0) {
+    storeUserData->store[identifier] =
+        std::vector<std::shared_ptr<jsi::Value>>();
   }
-  std::shared_ptr<jsi::Value> sv = std::make_shared<jsi::Value>(rt, jsi::Value::undefined());
-  StoreUser::store[identifier].push_back(sv);
-  
+  std::shared_ptr<jsi::Value> sv =
+      std::make_shared<jsi::Value>(rt, jsi::Value::undefined());
+  storeUserData->store[identifier].push_back(sv);
+
   return sv;
 }
 
-StoreUser::StoreUser(std::shared_ptr<Scheduler> s): scheduler(s) {
-  identifier = StoreUser::ctr++;
+StoreUser::StoreUser(
+    std::shared_ptr<Scheduler> s,
+    const RuntimeManager &runtimeManager)
+    : scheduler(s) {
+  storeUserData = runtimeManager.storeUserData;
+  identifier = storeUserData->ctr++;
 }
 
 StoreUser::~StoreUser() {
   int id = identifier;
   std::shared_ptr<Scheduler> strongScheduler = scheduler.lock();
   if (strongScheduler != nullptr) {
-    strongScheduler->scheduleOnUI([id]() {
-      const std::lock_guard<std::recursive_mutex> lock(storeMutex);
-      if (StoreUser::store.count(id) > 0) {
-        StoreUser::store.erase(id);
+    std::shared_ptr<StaticStoreUser> sud = storeUserData;
+#ifdef ONANDROID
+    jni::ThreadScope::WithClassLoader([&] {
+      strongScheduler->scheduleOnUI([id, sud]() {
+        const std::lock_guard<std::recursive_mutex> lock(sud->storeMutex);
+        if (sud->store.count(id) > 0) {
+          sud->store.erase(id);
+        }
+      });
+    });
+#else
+    strongScheduler->scheduleOnUI([id, sud]() {
+      const std::lock_guard<std::recursive_mutex> lock(sud->storeMutex);
+      if (sud->store.count(id) > 0) {
+        sud->store.erase(id);
       }
     });
+#endif
   }
 }
 
-
-void StoreUser::clearStore() {
-  const std::lock_guard<std::recursive_mutex> lock(storeMutex);
-  StoreUser::store.clear();
-}
-
-}
+} // namespace reanimated

--- a/ios/vendored/sdk44/react-native-reanimated/Common/cpp/Tools/Mapper.cpp
+++ b/ios/vendored/sdk44/react-native-reanimated/Common/cpp/Tools/Mapper.cpp
@@ -1,19 +1,16 @@
 #include "Mapper.h"
-#include "SharedParent.h"
 #include "MutableValue.h"
+#include "SharedParent.h"
 
 namespace ABI44_0_0reanimated {
 
-Mapper::Mapper(NativeReanimatedModule *module,
-               unsigned long id,
-               std::shared_ptr<jsi::Function> mapper,
-               std::vector<std::shared_ptr<MutableValue>> inputs,
-               std::vector<std::shared_ptr<MutableValue>> outputs):
-id(id),
-module(module),
-mapper(mapper),
-inputs(inputs),
-outputs(outputs) {
+Mapper::Mapper(
+    NativeReanimatedModule *module,
+    unsigned long id,
+    std::shared_ptr<jsi::Function> mapper,
+    std::vector<std::shared_ptr<MutableValue>> inputs,
+    std::vector<std::shared_ptr<MutableValue>> outputs)
+    : id(id), module(module), mapper(mapper), inputs(inputs), outputs(outputs) {
   auto markDirty = [this, module]() {
     this->dirty = true;
     module->maybeRequestRender();
@@ -25,7 +22,40 @@ outputs(outputs) {
 
 void Mapper::execute(jsi::Runtime &rt) {
   dirty = false;
-  mapper->callWithThis(rt, *mapper);
+  if (optimalizationLvl == 0) {
+    mapper->callWithThis(rt, *mapper); // call styleUpdater
+  } else {
+    jsi::Object newStyle = userUpdater->call(rt).asObject(rt);
+    auto jsViewDescriptorArray = viewDescriptors->getValue(rt)
+                                     .getObject(rt)
+                                     .getProperty(rt, "value")
+                                     .asObject(rt)
+                                     .getArray(rt);
+    for (int i = 0; i < jsViewDescriptorArray.length(rt); ++i) {
+      auto jsViewDescriptor =
+          jsViewDescriptorArray.getValueAtIndex(rt, i).getObject(rt);
+      (*updateProps)(
+          rt,
+          static_cast<int>(jsViewDescriptor.getProperty(rt, "tag").asNumber()),
+          jsViewDescriptor.getProperty(rt, "name"),
+          newStyle);
+    }
+  }
+}
+
+void Mapper::enableFastMode(
+    const int optimalizationLvl,
+    const std::shared_ptr<ShareableValue> &updater,
+    const std::shared_ptr<ShareableValue> &jsViewDescriptors) {
+  if (optimalizationLvl == 0) {
+    return;
+  }
+  viewDescriptors = jsViewDescriptors;
+  this->optimalizationLvl = optimalizationLvl;
+  updateProps = &module->updaterFunction;
+  jsi::Runtime *rt = module->runtime.get();
+  userUpdater = std::make_shared<jsi::Function>(
+      updater->getValue(*rt).asObject(*rt).asFunction(*rt));
 }
 
 Mapper::~Mapper() {
@@ -34,4 +64,4 @@ Mapper::~Mapper() {
   }
 }
 
-}
+} // namespace reanimated

--- a/ios/vendored/sdk44/react-native-reanimated/Common/cpp/Tools/RuntimeDecorator.cpp
+++ b/ios/vendored/sdk44/react-native-reanimated/Common/cpp/Tools/RuntimeDecorator.cpp
@@ -1,38 +1,58 @@
 #include "RuntimeDecorator.h"
-#include "ReanimatedHiddenHeaders.h"
-#include <unordered_map>
+#include <chrono>
 #include <memory>
+#include <unordered_map>
+#include "LayoutAnimationsProxy.h"
+#include "MutableValue.h"
+#include "ReanimatedHiddenHeaders.h"
 
 namespace ABI44_0_0reanimated {
 
-void RuntimeDecorator::decorateRuntime(jsi::Runtime &rt, std::string label) {
-  // This property will be used to find out if a runtime is a custom worklet runtime (e.g. UI, VisionCamera frame processor, ...)
+std::unordered_map<RuntimePointer, RuntimeType>
+    &RuntimeDecorator::runtimeRegistry() {
+  static std::unordered_map<RuntimePointer, RuntimeType> runtimeRegistry;
+  return runtimeRegistry;
+}
+
+void RuntimeDecorator::registerRuntime(
+    jsi::Runtime *runtime,
+    RuntimeType runtimeType) {
+  runtimeRegistry().insert({runtime, runtimeType});
+}
+
+void RuntimeDecorator::decorateRuntime(
+    jsi::Runtime &rt,
+    const std::string &label) {
+  // This property will be used to find out if a runtime is a custom worklet
+  // runtime (e.g. UI, VisionCamera frame processor, ...)
   rt.global().setProperty(rt, "_WORKLET", jsi::Value(true));
   // This property will be used for debugging
-  rt.global().setProperty(rt, "_LABEL", jsi::String::createFromAscii(rt, label));
+  rt.global().setProperty(
+      rt, "_LABEL", jsi::String::createFromAscii(rt, label));
 
   jsi::Object dummyGlobal(rt);
-  auto dummyFunction = [](
-                          jsi::Runtime &rt,
+  auto dummyFunction = [](jsi::Runtime &rt,
                           const jsi::Value &thisValue,
                           const jsi::Value *args,
-                          size_t count
-                          ) -> jsi::Value {
+                          size_t count) -> jsi::Value {
     return jsi::Value::undefined();
   };
-  jsi::Function __reanimatedWorkletInit = jsi::Function::createFromHostFunction(rt, jsi::PropNameID::forAscii(rt, "__reanimatedWorkletInit"), 1, dummyFunction);
+  jsi::Function __reanimatedWorkletInit = jsi::Function::createFromHostFunction(
+      rt,
+      jsi::PropNameID::forAscii(rt, "__reanimatedWorkletInit"),
+      1,
+      dummyFunction);
 
-  dummyGlobal.setProperty(rt, "__reanimatedWorkletInit", __reanimatedWorkletInit);
+  dummyGlobal.setProperty(
+      rt, "__reanimatedWorkletInit", __reanimatedWorkletInit);
   rt.global().setProperty(rt, "global", dummyGlobal);
 
   rt.global().setProperty(rt, "jsThis", jsi::Value::undefined());
 
-  auto callback = [](
-                     jsi::Runtime &rt,
+  auto callback = [](jsi::Runtime &rt,
                      const jsi::Value &thisValue,
                      const jsi::Value *args,
-                     size_t count
-                     ) -> jsi::Value {
+                     size_t count) -> jsi::Value {
     const jsi::Value *value = &args[0];
     if (value->isString()) {
       Logger::log(value->getString(rt).utf8(rt).c_str());
@@ -45,121 +65,184 @@ void RuntimeDecorator::decorateRuntime(jsi::Runtime &rt, std::string label) {
     }
     return jsi::Value::undefined();
   };
-  jsi::Value log = jsi::Function::createFromHostFunction(rt, jsi::PropNameID::forAscii(rt, "_log"), 1, callback);
+  jsi::Value log = jsi::Function::createFromHostFunction(
+      rt, jsi::PropNameID::forAscii(rt, "_log"), 1, callback);
   rt.global().setProperty(rt, "_log", log);
 
-  auto setGlobalConsole = [](
-                             jsi::Runtime &rt,
+  auto setGlobalConsole = [](jsi::Runtime &rt,
                              const jsi::Value &thisValue,
                              const jsi::Value *args,
-                             size_t count
-                             ) -> jsi::Value {
+                             size_t count) -> jsi::Value {
     rt.global().setProperty(rt, "console", args[0]);
     return jsi::Value::undefined();
   };
-  rt.global().setProperty(rt, "_setGlobalConsole", jsi::Function::createFromHostFunction(rt, jsi::PropNameID::forAscii(rt, "_setGlobalConsole"), 1, setGlobalConsole));
+  rt.global().setProperty(
+      rt,
+      "_setGlobalConsole",
+      jsi::Function::createFromHostFunction(
+          rt,
+          jsi::PropNameID::forAscii(rt, "_setGlobalConsole"),
+          1,
+          setGlobalConsole));
+
+  rt.global().setProperty(
+      rt,
+      "_chronoNow",
+      jsi::Function::createFromHostFunction(
+          rt,
+          jsi::PropNameID::forAscii(rt, "_chronoNow"),
+          0,
+          [](jsi::Runtime &rt,
+             const jsi::Value &thisValue,
+             const jsi::Value *args,
+             size_t count) -> jsi::Value {
+            double now = std::chrono::system_clock::now().time_since_epoch() /
+                std::chrono::milliseconds(1);
+            return jsi::Value(now);
+          }));
 }
 
-void RuntimeDecorator::decorateUIRuntime(jsi::Runtime &rt,
-                                         UpdaterFunction updater,
-                                         RequestFrameFunction requestFrame,
-                                         ScrollToFunction scrollTo,
-                                         MeasuringFunction measure,
-                                         TimeProviderFunction getCurrentTime) {
+void RuntimeDecorator::decorateUIRuntime(
+    jsi::Runtime &rt,
+    const UpdaterFunction updater,
+    const RequestFrameFunction requestFrame,
+    const ScrollToFunction scrollTo,
+    const MeasuringFunction measure,
+    const TimeProviderFunction getCurrentTime,
+    const SetGestureStateFunction setGestureState,
+    std::shared_ptr<LayoutAnimationsProxy> layoutAnimationsProxy) {
   RuntimeDecorator::decorateRuntime(rt, "UI");
   rt.global().setProperty(rt, "_UI", jsi::Value(true));
 
   auto clb = [updater](
-                       jsi::Runtime &rt,
-                       const jsi::Value &thisValue,
-                       const jsi::Value *args,
-                       size_t count
-                       ) -> jsi::Value {
+                 jsi::Runtime &rt,
+                 const jsi::Value &thisValue,
+                 const jsi::Value *args,
+                 const size_t count) -> jsi::Value {
     const auto viewTag = args[0].asNumber();
-    const jsi::Value* viewName = &args[1];
+    const jsi::Value *viewName = &args[1];
     const auto params = args[2].asObject(rt);
     updater(rt, viewTag, *viewName, params);
     return jsi::Value::undefined();
   };
-  jsi::Value updateProps = jsi::Function::createFromHostFunction(rt, jsi::PropNameID::forAscii(rt, "_updateProps"), 2, clb);
+  jsi::Value updateProps = jsi::Function::createFromHostFunction(
+      rt, jsi::PropNameID::forAscii(rt, "_updateProps"), 2, clb);
   rt.global().setProperty(rt, "_updateProps", updateProps);
 
-
   auto clb2 = [requestFrame](
-                             jsi::Runtime &rt,
-                             const jsi::Value &thisValue,
-                             const jsi::Value *args,
-                             size_t count
-                             ) -> jsi::Value {
-    auto fun = std::make_shared<jsi::Function>(args[0].asObject(rt).asFunction(rt));
+                  jsi::Runtime &rt,
+                  const jsi::Value &thisValue,
+                  const jsi::Value *args,
+                  const size_t count) -> jsi::Value {
+    auto fun =
+        std::make_shared<jsi::Function>(args[0].asObject(rt).asFunction(rt));
     requestFrame([&rt, fun](double timestampMs) {
       fun->call(rt, jsi::Value(timestampMs));
     });
     return jsi::Value::undefined();
   };
-  jsi::Value requestAnimationFrame = jsi::Function::createFromHostFunction(rt, jsi::PropNameID::forAscii(rt, "requestAnimationFrame"), 1, clb2);
+  jsi::Value requestAnimationFrame = jsi::Function::createFromHostFunction(
+      rt, jsi::PropNameID::forAscii(rt, "requestAnimationFrame"), 1, clb2);
   rt.global().setProperty(rt, "requestAnimationFrame", requestAnimationFrame);
 
   auto clb3 = [scrollTo](
-                         jsi::Runtime &rt,
-                         const jsi::Value &thisValue,
-                         const jsi::Value *args,
-                         size_t count
-                         ) -> jsi::Value {
-    int viewTag = (int)args[0].asNumber();
+                  jsi::Runtime &rt,
+                  const jsi::Value &thisValue,
+                  const jsi::Value *args,
+                  const size_t count) -> jsi::Value {
+    int viewTag = static_cast<int>(args[0].asNumber());
     double x = args[1].asNumber();
     double y = args[2].asNumber();
     bool animated = args[3].getBool();
     scrollTo(viewTag, x, y, animated);
     return jsi::Value::undefined();
   };
-  jsi::Value scrollToFunction = jsi::Function::createFromHostFunction(rt, jsi::PropNameID::forAscii(rt, "_scrollTo"), 4, clb3);
+  jsi::Value scrollToFunction = jsi::Function::createFromHostFunction(
+      rt, jsi::PropNameID::forAscii(rt, "_scrollTo"), 4, clb3);
   rt.global().setProperty(rt, "_scrollTo", scrollToFunction);
 
   auto clb4 = [measure](
-                        jsi::Runtime &rt,
-                        const jsi::Value &thisValue,
-                        const jsi::Value *args,
-                        size_t count
-                        ) -> jsi::Value {
-    int viewTag = (int)args[0].asNumber();
+                  jsi::Runtime &rt,
+                  const jsi::Value &thisValue,
+                  const jsi::Value *args,
+                  const size_t count) -> jsi::Value {
+    int viewTag = static_cast<int>(args[0].asNumber());
     auto result = measure(viewTag);
     jsi::Object resultObject(rt);
-    for (auto &i:result) {
+    for (auto &i : result) {
       resultObject.setProperty(rt, i.first.c_str(), i.second);
     }
     return resultObject;
   };
-  jsi::Value measureFunction = jsi::Function::createFromHostFunction(rt, jsi::PropNameID::forAscii(rt, "_measure"), 1, clb4);
+  jsi::Value measureFunction = jsi::Function::createFromHostFunction(
+      rt, jsi::PropNameID::forAscii(rt, "_measure"), 1, clb4);
   rt.global().setProperty(rt, "_measure", measureFunction);
 
   auto clb6 = [getCurrentTime](
-                               jsi::Runtime &rt,
-                               const jsi::Value &thisValue,
-                               const jsi::Value *args,
-                               size_t count
-                               ) -> jsi::Value {
+                  jsi::Runtime &rt,
+                  const jsi::Value &thisValue,
+                  const jsi::Value *args,
+                  const size_t count) -> jsi::Value {
     return getCurrentTime();
   };
-  jsi::Value timeFun = jsi::Function::createFromHostFunction(rt, jsi::PropNameID::forAscii(rt, "_getCurrentTime"), 0, clb6);
+  jsi::Value timeFun = jsi::Function::createFromHostFunction(
+      rt, jsi::PropNameID::forAscii(rt, "_getCurrentTime"), 0, clb6);
   rt.global().setProperty(rt, "_getCurrentTime", timeFun);
 
   rt.global().setProperty(rt, "_frameTimestamp", jsi::Value::undefined());
   rt.global().setProperty(rt, "_eventTimestamp", jsi::Value::undefined());
+
+  // layout animation
+  std::weak_ptr<LayoutAnimationsProxy> layoutProxy = layoutAnimationsProxy;
+  auto clb7 = [layoutProxy](
+                  jsi::Runtime &rt,
+                  const jsi::Value &thisValue,
+                  const jsi::Value *args,
+                  size_t count) -> jsi::Value {
+    std::shared_ptr<LayoutAnimationsProxy> proxy = layoutProxy.lock();
+    if (layoutProxy.expired()) {
+      return jsi::Value::undefined();
+    }
+    proxy->startObserving(
+        args[0].asNumber(),
+        args[1].asObject(rt).getHostObject<MutableValue>(rt),
+        rt);
+    return jsi::Value::undefined();
+  };
+  jsi::Value _startObservingProgress = jsi::Function::createFromHostFunction(
+      rt, jsi::PropNameID::forAscii(rt, "_startObservingProgress"), 0, clb7);
+  rt.global().setProperty(
+      rt, "_startObservingProgress", _startObservingProgress);
+
+  auto clb8 = [layoutProxy](
+                  jsi::Runtime &rt,
+                  const jsi::Value &thisValue,
+                  const jsi::Value *args,
+                  size_t count) -> jsi::Value {
+    std::shared_ptr<LayoutAnimationsProxy> proxy = layoutProxy.lock();
+    if (layoutProxy.expired()) {
+      return jsi::Value::undefined();
+    }
+    proxy->stopObserving(args[0].asNumber(), args[1].getBool());
+    return jsi::Value::undefined();
+  };
+  jsi::Value _stopObservingProgress = jsi::Function::createFromHostFunction(
+      rt, jsi::PropNameID::forAscii(rt, "_stopObservingProgress"), 0, clb8);
+  rt.global().setProperty(rt, "_stopObservingProgress", _stopObservingProgress);
+
+  auto clb9 = [setGestureState](
+                  jsi::Runtime &rt,
+                  const jsi::Value &thisValue,
+                  const jsi::Value *args,
+                  size_t count) -> jsi::Value {
+    int handlerTag = static_cast<int>(args[0].asNumber());
+    int newState = static_cast<int>(args[1].asNumber());
+    setGestureState(handlerTag, newState);
+    return jsi::Value::undefined();
+  };
+  jsi::Value setGestureStateFunction = jsi::Function::createFromHostFunction(
+      rt, jsi::PropNameID::forAscii(rt, "_setGestureState"), 2, clb9);
+  rt.global().setProperty(rt, "_setGestureState", setGestureStateFunction);
 }
 
-bool RuntimeDecorator::isUIRuntime(jsi::Runtime& rt) {
-  auto isUi = rt.global().getProperty(rt, "_UI");
-  return isUi.isBool() && isUi.getBool();
-}
-
-bool RuntimeDecorator::isWorkletRuntime(jsi::Runtime& rt) {
-  auto isWorklet = rt.global().getProperty(rt, "_WORKLET");
-  return isWorklet.isBool() && isWorklet.getBool();
-}
-
-bool RuntimeDecorator::isReactRuntime(jsi::Runtime& rt) {
-  return !isWorkletRuntime(rt);
-}
-
-}
+} // namespace reanimated

--- a/ios/vendored/sdk44/react-native-reanimated/Common/cpp/Tools/Scheduler.cpp
+++ b/ios/vendored/sdk44/react-native-reanimated/Common/cpp/Tools/Scheduler.cpp
@@ -1,7 +1,6 @@
 #include "Scheduler.h"
 
-namespace ABI44_0_0reanimated
-{
+namespace ABI44_0_0reanimated {
 
 void Scheduler::scheduleOnUI(std::function<void()> job) {
   uiJobs.push(std::move(job));
@@ -12,18 +11,27 @@ void Scheduler::scheduleOnJS(std::function<void()> job) {
 }
 
 void Scheduler::triggerUI() {
-  auto job = uiJobs.pop();
-  job();
+  scheduledOnUI = false;
+  while (uiJobs.getSize()) {
+    auto job = uiJobs.pop();
+    job();
+  }
 }
 
-void Scheduler::setJSCallInvoker(std::shared_ptr<ABI44_0_0facebook::ABI44_0_0React::CallInvoker> jsCallInvoker) {
+void Scheduler::setJSCallInvoker(
+    std::shared_ptr<ABI44_0_0facebook::ABI44_0_0React::CallInvoker> jsCallInvoker) {
   jsCallInvoker_ = jsCallInvoker;
 }
 
-void Scheduler::setRuntimeManager(std::shared_ptr<RuntimeManager> runtimeManager) {
+void Scheduler::setRuntimeManager(
+    std::shared_ptr<RuntimeManager> runtimeManager) {
   this->runtimeManager = runtimeManager;
 }
 
 Scheduler::~Scheduler() {}
 
+Scheduler::Scheduler() {
+  this->scheduledOnUI = false;
 }
+
+} // namespace reanimated

--- a/ios/vendored/sdk44/react-native-reanimated/Common/cpp/Tools/WorkletEventHandler.cpp
+++ b/ios/vendored/sdk44/react-native-reanimated/Common/cpp/Tools/WorkletEventHandler.cpp
@@ -2,8 +2,10 @@
 
 namespace ABI44_0_0reanimated {
 
-void WorkletEventHandler::process(jsi::Runtime &rt, jsi::Value &eventValue) {
+void WorkletEventHandler::process(
+    jsi::Runtime &rt,
+    const jsi::Value &eventValue) {
   handler.callWithThis(rt, handler, eventValue);
 }
 
-}
+} // namespace reanimated

--- a/ios/vendored/sdk44/react-native-reanimated/Common/cpp/headers/LayoutAnimations/LayoutAnimationsProxy.h
+++ b/ios/vendored/sdk44/react-native-reanimated/Common/cpp/headers/LayoutAnimations/LayoutAnimationsProxy.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <ABI44_0_0jsi/ABI44_0_0jsi.h>
+#include <stdio.h>
+#include <functional>
+#include <map>
+#include <memory>
+
+namespace ABI44_0_0reanimated {
+
+using namespace ABI44_0_0facebook;
+
+class MutableValue;
+
+class LayoutAnimationsProxy {
+ public:
+  LayoutAnimationsProxy(
+      std::function<void(int, jsi::Object newProps)> _notifyAboutProgress,
+      std::function<void(int, bool)> _notifyAboutEnd);
+
+  void
+  startObserving(int tag, std::shared_ptr<MutableValue> sv, jsi::Runtime &rt);
+  void stopObserving(int tag, bool finished);
+  void notifyAboutCancellation(int tag);
+
+ private:
+  std::function<void(int, jsi::Object newProps)> notifyAboutProgress;
+  std::function<void(int, bool)> notifyAboutEnd;
+  std::map<int, std::shared_ptr<MutableValue>> observedValues;
+};
+
+} // namespace reanimated

--- a/ios/vendored/sdk44/react-native-reanimated/Common/cpp/headers/NativeModules/NativeReanimatedModule.h
+++ b/ios/vendored/sdk44/react-native-reanimated/Common/cpp/headers/NativeModules/NativeReanimatedModule.h
@@ -1,17 +1,19 @@
 #pragma once
 
-#include "NativeReanimatedModuleSpec.h"
-#include "Scheduler.h"
-#include "ErrorHandler.h"
-#include "RuntimeDecorator.h"
-#include "PlatformDepMethodsHolder.h"
 #include <unistd.h>
 #include <memory>
+#include <string>
 #include <vector>
-#include "RuntimeManager.h"
 
-namespace ABI44_0_0reanimated
-{
+#include "ErrorHandler.h"
+#include "LayoutAnimationsProxy.h"
+#include "NativeReanimatedModuleSpec.h"
+#include "PlatformDepMethodsHolder.h"
+#include "RuntimeDecorator.h"
+#include "RuntimeManager.h"
+#include "Scheduler.h"
+
+namespace ABI44_0_0reanimated {
 
 using FrameCallback = std::function<void(double)>;
 
@@ -20,48 +22,73 @@ class MutableValue;
 class MapperRegistry;
 class EventHandlerRegistry;
 
-class NativeReanimatedModule : public NativeReanimatedModuleSpec, public RuntimeManager
-{
+class NativeReanimatedModule : public NativeReanimatedModuleSpec,
+                               public RuntimeManager {
   friend ShareableValue;
   friend MutableValue;
-  
-public:
-  NativeReanimatedModule(std::shared_ptr<CallInvoker> jsInvoker,
-                         std::shared_ptr<Scheduler> scheduler,
-                         std::unique_ptr<jsi::Runtime> rt,
-                         std::shared_ptr<ErrorHandler> errorHandler,
-                         std::function<jsi::Value(jsi::Runtime &, const int, const jsi::String &)> propObtainer,
-                         PlatformDepMethodsHolder platformDepMethodsHolder);
 
-  virtual ~NativeReanimatedModule();
+ public:
+  NativeReanimatedModule(
+      std::shared_ptr<CallInvoker> jsInvoker,
+      std::shared_ptr<Scheduler> scheduler,
+      std::shared_ptr<jsi::Runtime> rt,
+      std::shared_ptr<ErrorHandler> errorHandler,
+      std::function<jsi::Value(jsi::Runtime &, const int, const jsi::String &)>
+          propObtainer,
+      std::shared_ptr<LayoutAnimationsProxy> layoutAnimationsProxy,
+      PlatformDepMethodsHolder platformDepMethodsHolder);
 
-  void installCoreFunctions(jsi::Runtime &rt, const jsi::Value &valueSetter) override;
+  void installCoreFunctions(jsi::Runtime &rt, const jsi::Value &valueSetter)
+      override;
 
   jsi::Value makeShareable(jsi::Runtime &rt, const jsi::Value &value) override;
   jsi::Value makeMutable(jsi::Runtime &rt, const jsi::Value &value) override;
   jsi::Value makeRemote(jsi::Runtime &rt, const jsi::Value &value) override;
 
-  jsi::Value startMapper(jsi::Runtime &rt, const jsi::Value &worklet, const jsi::Value &inputs, const jsi::Value &outputs) override;
+  jsi::Value startMapper(
+      jsi::Runtime &rt,
+      const jsi::Value &worklet,
+      const jsi::Value &inputs,
+      const jsi::Value &outputs,
+      const jsi::Value &updater,
+      const jsi::Value &viewDescriptors) override;
   void stopMapper(jsi::Runtime &rt, const jsi::Value &mapperId) override;
 
-  jsi::Value registerEventHandler(jsi::Runtime &rt, const jsi::Value &eventHash, const jsi::Value &worklet) override;
-  void unregisterEventHandler(jsi::Runtime &rt, const jsi::Value &registrationId) override;
+  jsi::Value registerEventHandler(
+      jsi::Runtime &rt,
+      const jsi::Value &eventHash,
+      const jsi::Value &worklet) override;
+  void unregisterEventHandler(
+      jsi::Runtime &rt,
+      const jsi::Value &registrationId) override;
 
-  jsi::Value getViewProp(jsi::Runtime &rt, const jsi::Value &viewTag, const jsi::Value &propName, const jsi::Value &callback) override;
+  jsi::Value getViewProp(
+      jsi::Runtime &rt,
+      const jsi::Value &viewTag,
+      const jsi::Value &propName,
+      const jsi::Value &callback) override;
+
+  jsi::Value enableLayoutAnimations(jsi::Runtime &rt, const jsi::Value &config)
+      override;
 
   void onRender(double timestampMs);
   void onEvent(std::string eventName, std::string eventAsString);
   bool isAnyHandlerWaitingForEvent(std::string eventName);
 
   void maybeRequestRender();
-private:
+  UpdaterFunction updaterFunction;
+
+ private:
   std::shared_ptr<MapperRegistry> mapperRegistry;
   std::shared_ptr<EventHandlerRegistry> eventHandlerRegistry;
-  std::function<void(FrameCallback, jsi::Runtime&)> requestRender;
+  std::function<void(FrameCallback &, jsi::Runtime &)> requestRender;
   std::shared_ptr<jsi::Value> dummyEvent;
   std::vector<FrameCallback> frameCallbacks;
   bool renderRequested = false;
-  std::function<jsi::Value(jsi::Runtime &, const int, const jsi::String &)> propObtainer;
+  std::function<jsi::Value(jsi::Runtime &, const int, const jsi::String &)>
+      propObtainer;
+  std::function<void(double)> onRenderCallback;
+  std::shared_ptr<LayoutAnimationsProxy> layoutAnimationsProxy;
 };
 
 } // namespace reanimated

--- a/ios/vendored/sdk44/react-native-reanimated/Common/cpp/headers/NativeModules/NativeReanimatedModuleSpec.h
+++ b/ios/vendored/sdk44/react-native-reanimated/Common/cpp/headers/NativeModules/NativeReanimatedModuleSpec.h
@@ -5,9 +5,9 @@
 #include <vector>
 
 #ifdef ONANDROID
-  #include "TurboModule.h"
+#include "TurboModule.h"
 #else
-  #include <ABI44_0_0ReactCommon/ABI44_0_0TurboModule.h>
+#include <ABI44_0_0ReactCommon/ABI44_0_0TurboModule.h>
 #endif
 
 #include <ABI44_0_0ReactCommon/ABI44_0_0CallInvoker.h>
@@ -15,31 +15,54 @@
 using namespace ABI44_0_0facebook;
 using namespace ABI44_0_0React;
 
-namespace ABI44_0_0reanimated
-{
+namespace ABI44_0_0reanimated {
 
 class JSI_EXPORT NativeReanimatedModuleSpec : public TurboModule {
  protected:
-  NativeReanimatedModuleSpec(std::shared_ptr<CallInvoker> jsInvoker);
+  explicit NativeReanimatedModuleSpec(std::shared_ptr<CallInvoker> jsInvoker);
 
  public:
-  virtual void installCoreFunctions(jsi::Runtime &rt, const jsi::Value &valueSetter) = 0;
+  virtual void installCoreFunctions(
+      jsi::Runtime &rt,
+      const jsi::Value &valueSetter) = 0;
 
   // SharedValue
-  virtual jsi::Value makeShareable(jsi::Runtime &rt, const jsi::Value &value) = 0;
+  virtual jsi::Value makeShareable(
+      jsi::Runtime &rt,
+      const jsi::Value &value) = 0;
   virtual jsi::Value makeMutable(jsi::Runtime &rt, const jsi::Value &value) = 0;
   virtual jsi::Value makeRemote(jsi::Runtime &rt, const jsi::Value &value) = 0;
 
   // mappers
-  virtual jsi::Value startMapper(jsi::Runtime &rt, const jsi::Value &worklet, const jsi::Value &inputs, const jsi::Value &outputs) = 0;
+  virtual jsi::Value startMapper(
+      jsi::Runtime &rt,
+      const jsi::Value &worklet,
+      const jsi::Value &inputs,
+      const jsi::Value &outputs,
+      const jsi::Value &updater,
+      const jsi::Value &viewDescriptors) = 0;
   virtual void stopMapper(jsi::Runtime &rt, const jsi::Value &mapperId) = 0;
 
   // events
-  virtual jsi::Value registerEventHandler(jsi::Runtime &rt, const jsi::Value &eventHash, const jsi::Value &worklet) = 0;
-  virtual void unregisterEventHandler(jsi::Runtime &rt, const jsi::Value &registrationId) = 0;
+  virtual jsi::Value registerEventHandler(
+      jsi::Runtime &rt,
+      const jsi::Value &eventHash,
+      const jsi::Value &worklet) = 0;
+  virtual void unregisterEventHandler(
+      jsi::Runtime &rt,
+      const jsi::Value &registrationId) = 0;
 
   // views
-  virtual jsi::Value getViewProp(jsi::Runtime &rt, const jsi::Value &viewTag, const jsi::Value &propName, const jsi::Value &callback) = 0;
+  virtual jsi::Value getViewProp(
+      jsi::Runtime &rt,
+      const jsi::Value &viewTag,
+      const jsi::Value &propName,
+      const jsi::Value &callback) = 0;
+
+  // other
+  virtual jsi::Value enableLayoutAnimations(
+      jsi::Runtime &rt,
+      const jsi::Value &config) = 0;
 };
 
 } // namespace reanimated

--- a/ios/vendored/sdk44/react-native-reanimated/Common/cpp/headers/Registries/EventHandlerRegistry.h
+++ b/ios/vendored/sdk44/react-native-reanimated/Common/cpp/headers/Registries/EventHandlerRegistry.h
@@ -1,12 +1,13 @@
 #pragma once
 
-#include <vector>
-#include <map>
-#include <set>
-#include <unordered_map>
-#include <string>
 #include <ABI44_0_0jsi/ABI44_0_0jsi.h>
+#include <map>
+#include <memory>
 #include <mutex>
+#include <set>
+#include <string>
+#include <unordered_map>
+#include <vector>
 
 using namespace ABI44_0_0facebook;
 
@@ -15,16 +16,22 @@ namespace ABI44_0_0reanimated {
 class WorkletEventHandler;
 
 class EventHandlerRegistry {
-  std::map<std::string, std::unordered_map<unsigned long, std::shared_ptr<WorkletEventHandler>>> eventMappings;
+  std::map<
+      std::string,
+      std::unordered_map<unsigned long, std::shared_ptr<WorkletEventHandler>>>
+      eventMappings;
   std::map<unsigned long, std::shared_ptr<WorkletEventHandler>> eventHandlers;
   std::mutex instanceMutex;
 
-public:
+ public:
   void registerEventHandler(std::shared_ptr<WorkletEventHandler> eventHandler);
   void unregisterEventHandler(unsigned long id);
 
-  void processEvent(jsi::Runtime &rt, std::string eventName, std::string eventPayload);
+  void processEvent(
+      jsi::Runtime &rt,
+      std::string eventName,
+      std::string eventPayload);
   bool isAnyHandlerWaitingForEvent(std::string eventName);
 };
 
-}
+} // namespace reanimated

--- a/ios/vendored/sdk44/react-native-reanimated/Common/cpp/headers/Registries/MapperRegistry.h
+++ b/ios/vendored/sdk44/react-native-reanimated/Common/cpp/headers/Registries/MapperRegistry.h
@@ -1,8 +1,9 @@
 #pragma once
 
-#include <vector>
-#include <unordered_map>
 #include <ABI44_0_0jsi/ABI44_0_0jsi.h>
+#include <memory>
+#include <unordered_map>
+#include <vector>
 
 using namespace ABI44_0_0facebook;
 
@@ -16,7 +17,7 @@ class MapperRegistry {
   void updateOrder();
   bool updatedSinceLastExecute = false;
 
-public:
+ public:
   void startMapper(std::shared_ptr<Mapper> mapper);
   void stopMapper(unsigned long id);
 
@@ -25,4 +26,4 @@ public:
   bool needRunOnRender();
 };
 
-}
+} // namespace reanimated

--- a/ios/vendored/sdk44/react-native-reanimated/Common/cpp/headers/Registries/WorkletsCache.h
+++ b/ios/vendored/sdk44/react-native-reanimated/Common/cpp/headers/Registries/WorkletsCache.h
@@ -1,22 +1,24 @@
 #pragma once
 
-#include <stdio.h>
-#include <unordered_map>
 #include <ABI44_0_0jsi/ABI44_0_0jsi.h>
+#include <stdio.h>
 #include <memory>
+#include <unordered_map>
 
-namespace ABI44_0_0reanimated
-{
+namespace ABI44_0_0reanimated {
 
 using namespace ABI44_0_0facebook;
 
 class FrozenObject;
 
 class WorkletsCache {
-private:
+ private:
   std::unordered_map<long long, std::shared_ptr<jsi::Function>> worklets;
-public:
-  std::shared_ptr<jsi::Function> getFunction(jsi::Runtime & rt, std::shared_ptr<ABI44_0_0reanimated::FrozenObject> frozenObj);
+
+ public:
+  std::shared_ptr<jsi::Function> getFunction(
+      jsi::Runtime &rt,
+      std::shared_ptr<ABI44_0_0reanimated::FrozenObject> frozenObj);
 };
 
 } // namespace reanimated

--- a/ios/vendored/sdk44/react-native-reanimated/Common/cpp/headers/SharedItems/FrozenObject.h
+++ b/ios/vendored/sdk44/react-native-reanimated/Common/cpp/headers/SharedItems/FrozenObject.h
@@ -1,9 +1,13 @@
 #pragma once
 
-#include "WorkletsCache.h"
-#include "SharedParent.h"
-#include "RuntimeManager.h"
 #include <ABI44_0_0jsi/ABI44_0_0jsi.h>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+#include "RuntimeManager.h"
+#include "SharedParent.h"
+#include "WorkletsCache.h"
 
 using namespace ABI44_0_0facebook;
 
@@ -11,18 +15,22 @@ namespace ABI44_0_0reanimated {
 
 class FrozenObject : public jsi::HostObject {
   friend WorkletsCache;
-  friend void extractMutables(jsi::Runtime &rt,
-                              std::shared_ptr<ShareableValue> sv,
-                              std::vector<std::shared_ptr<MutableValue>> &res);
+  friend void extractMutables(
+      jsi::Runtime &rt,
+      std::shared_ptr<ShareableValue> sv,
+      std::vector<std::shared_ptr<MutableValue>> &res);
 
-  private:
+ private:
   std::unordered_map<std::string, std::shared_ptr<ShareableValue>> map;
+  std::vector<std::string> namesOrder;
 
-  public:
-
-  FrozenObject(jsi::Runtime &rt, const jsi::Object &object, RuntimeManager *runtimeManager);
+ public:
+  FrozenObject(
+      jsi::Runtime &rt,
+      const jsi::Object &object,
+      RuntimeManager *runtimeManager);
   jsi::Object shallowClone(jsi::Runtime &rt);
   bool containsHostFunction = false;
 };
 
-}
+} // namespace reanimated

--- a/ios/vendored/sdk44/react-native-reanimated/Common/cpp/headers/SharedItems/HostFunctionHandler.h
+++ b/ios/vendored/sdk44/react-native-reanimated/Common/cpp/headers/SharedItems/HostFunctionHandler.h
@@ -1,6 +1,10 @@
 #pragma once
 
 #include <ABI44_0_0jsi/ABI44_0_0jsi.h>
+#include <memory>
+#include <string>
+
+using namespace ABI44_0_0facebook;
 
 namespace ABI44_0_0reanimated {
 
@@ -8,17 +12,17 @@ struct HostFunctionHandler : jsi::HostObject {
   std::shared_ptr<jsi::Function> pureFunction;
   std::string functionName;
   jsi::Runtime *hostRuntime;
-    jsi::HostObject a;
-    
+  jsi::HostObject a;
+
   HostFunctionHandler(std::shared_ptr<jsi::Function> f, jsi::Runtime &rt) {
     pureFunction = f;
     functionName = f->getProperty(rt, "name").asString(rt).utf8(rt);
     hostRuntime = &rt;
   }
-  
+
   std::shared_ptr<jsi::Function> getPureFunction() {
     return pureFunction;
   }
 };
 
-}
+} // namespace reanimated

--- a/ios/vendored/sdk44/react-native-reanimated/Common/cpp/headers/SharedItems/MutableValue.h
+++ b/ios/vendored/sdk44/react-native-reanimated/Common/cpp/headers/SharedItems/MutableValue.h
@@ -1,21 +1,27 @@
 #pragma once
 
-#include "SharedParent.h"
-#include "MutableValueSetterProxy.h"
-#include <mutex>
 #include <ABI44_0_0jsi/ABI44_0_0jsi.h>
 #include <map>
+#include <memory>
+#include <mutex>
+#include <vector>
 #include "JSIStoreValueUser.h"
+#include "LayoutAnimationsProxy.h"
+#include "MutableValueSetterProxy.h"
 #include "RuntimeManager.h"
+#include "SharedParent.h"
 
 using namespace ABI44_0_0facebook;
 
 namespace ABI44_0_0reanimated {
 
-class MutableValue : public jsi::HostObject, public std::enable_shared_from_this<MutableValue>, public StoreUser {
-private:
+class MutableValue : public jsi::HostObject,
+                     public std::enable_shared_from_this<MutableValue>,
+                     public StoreUser {
+ private:
   friend MutableValueSetterProxy;
   RuntimeManager *runtimeManager;
+  friend LayoutAnimationsProxy;
   std::mutex readWriteMutex;
   std::shared_ptr<ShareableValue> value;
   std::weak_ptr<jsi::Value> animation;
@@ -24,15 +30,22 @@ private:
   void setValue(jsi::Runtime &rt, const jsi::Value &newValue);
   jsi::Value getValue(jsi::Runtime &rt);
 
-public:
-  MutableValue(jsi::Runtime &rt, const jsi::Value &initial, RuntimeManager *runtimeManager, std::shared_ptr<Scheduler> s);
+ public:
+  MutableValue(
+      jsi::Runtime &rt,
+      const jsi::Value &initial,
+      RuntimeManager *runtimeManager,
+      std::shared_ptr<Scheduler> s);
 
-public:
-  void set(jsi::Runtime &rt, const jsi::PropNameID &name, const jsi::Value &value);
+ public:
+  void
+  set(jsi::Runtime &rt, const jsi::PropNameID &name, const jsi::Value &value);
   jsi::Value get(jsi::Runtime &rt, const jsi::PropNameID &name);
   std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime &rt);
-  unsigned long addListener(unsigned long listenerId, std::function<void()> listener);
+  unsigned long addListener(
+      unsigned long listenerId,
+      std::function<void()> listener);
   void removeListener(unsigned long listenerId);
 };
 
-}
+} // namespace reanimated

--- a/ios/vendored/sdk44/react-native-reanimated/Common/cpp/headers/SharedItems/MutableValueSetterProxy.h
+++ b/ios/vendored/sdk44/react-native-reanimated/Common/cpp/headers/SharedItems/MutableValueSetterProxy.h
@@ -1,20 +1,25 @@
 #pragma once
 
-#include "SharedParent.h"
 #include <ABI44_0_0jsi/ABI44_0_0jsi.h>
+#include <memory>
+#include <utility>
+#include "SharedParent.h"
 
 using namespace ABI44_0_0facebook;
 
 namespace ABI44_0_0reanimated {
 
-class MutableValueSetterProxy: public jsi::HostObject {
-private:
+class MutableValueSetterProxy : public jsi::HostObject {
+ private:
   friend MutableValue;
   std::shared_ptr<MutableValue> mutableValue;
-public:
-  MutableValueSetterProxy(std::shared_ptr<MutableValue> mutableValue): mutableValue(std::move(mutableValue)) {}
-  void set(jsi::Runtime &rt, const jsi::PropNameID &name, const jsi::Value &value);
+
+ public:
+  explicit MutableValueSetterProxy(std::shared_ptr<MutableValue> mutableValue)
+      : mutableValue(std::move(mutableValue)) {}
+  void
+  set(jsi::Runtime &rt, const jsi::PropNameID &name, const jsi::Value &value);
   jsi::Value get(jsi::Runtime &rt, const jsi::PropNameID &name);
 };
 
-}
+} // namespace reanimated

--- a/ios/vendored/sdk44/react-native-reanimated/Common/cpp/headers/SharedItems/RemoteObject.h
+++ b/ios/vendored/sdk44/react-native-reanimated/Common/cpp/headers/SharedItems/RemoteObject.h
@@ -1,24 +1,35 @@
 #pragma once
 
-#include "SharedParent.h"
+#include <memory>
+#include <vector>
+
 #include "FrozenObject.h"
 #include "JSIStoreValueUser.h"
+#include "SharedParent.h"
 
 using namespace ABI44_0_0facebook;
 
 namespace ABI44_0_0reanimated {
 
-class RemoteObject: public jsi::HostObject, public StoreUser {
-private:
+class RemoteObject : public jsi::HostObject, public StoreUser {
+ private:
   std::weak_ptr<jsi::Value> backing;
   std::unique_ptr<FrozenObject> initializer;
-public:
+
+ public:
   void maybeInitializeOnWorkletRuntime(jsi::Runtime &rt);
-  RemoteObject(jsi::Runtime &rt, jsi::Object &object, RuntimeManager *runtimeManager, std::shared_ptr<Scheduler> s):
-     StoreUser(s), initializer(std::make_unique<FrozenObject>(rt, object, runtimeManager)) {}
-  void set(jsi::Runtime &rt, const jsi::PropNameID &name, const jsi::Value &value);
+  RemoteObject(
+      jsi::Runtime &rt,
+      const jsi::Object &object,
+      RuntimeManager *runtimeManager,
+      std::shared_ptr<Scheduler> s)
+      : StoreUser(s, *runtimeManager),
+        initializer(
+            std::make_unique<FrozenObject>(rt, object, runtimeManager)) {}
+  void
+  set(jsi::Runtime &rt, const jsi::PropNameID &name, const jsi::Value &value);
   jsi::Value get(jsi::Runtime &rt, const jsi::PropNameID &name);
   std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime &rt);
 };
 
-}
+} // namespace reanimated

--- a/ios/vendored/sdk44/react-native-reanimated/Common/cpp/headers/SharedItems/RuntimeManager.h
+++ b/ios/vendored/sdk44/react-native-reanimated/Common/cpp/headers/SharedItems/RuntimeManager.h
@@ -1,11 +1,13 @@
 #pragma once
 
-#include "ShareableValue.h"
-#include "ErrorHandler.h"
-#include "Scheduler.h"
-#include "WorkletsCache.h"
 #include <ABI44_0_0jsi/ABI44_0_0jsi.h>
 #include <memory>
+#include "ErrorHandler.h"
+#include "JSIStoreValueUser.h"
+#include "RuntimeDecorator.h"
+#include "Scheduler.h"
+#include "ShareableValue.h"
+#include "WorkletsCache.h"
 
 namespace ABI44_0_0reanimated {
 
@@ -15,32 +17,59 @@ using namespace ABI44_0_0facebook;
  A class that manages a jsi::Runtime apart from the ABI44_0_0React-JS runtime.
  */
 class RuntimeManager {
-public:
-  RuntimeManager(std::unique_ptr<jsi::Runtime>&& runtime,
-                 std::shared_ptr<ErrorHandler> errorHandler,
-                 std::shared_ptr<Scheduler> scheduler): runtime(std::move(runtime)), errorHandler(errorHandler), scheduler(scheduler), workletsCache(std::make_unique<WorkletsCache>()) { }
-public:
+ public:
+  RuntimeManager(
+      std::shared_ptr<jsi::Runtime> runtime,
+      std::shared_ptr<ErrorHandler> errorHandler,
+      std::shared_ptr<Scheduler> scheduler,
+      RuntimeType runtimeType = RuntimeType::Worklet)
+      : runtime(runtime),
+        errorHandler(errorHandler),
+        scheduler(scheduler),
+        workletsCache(std::make_unique<WorkletsCache>()),
+        storeUserData(std::make_shared<StaticStoreUser>()) {
+    RuntimeDecorator::registerRuntime(this->runtime.get(), runtimeType);
+  }
+
+  virtual ~RuntimeManager() {
+    clearStore();
+  }
+
+ public:
   /**
-   Holds the jsi::Function worklet that is responsible for updating values in JS.
-   Can be null.
+   Holds the jsi::Function worklet that is responsible for updating values in
+   JS. Can be null.
    */
   std::shared_ptr<ShareableValue> valueSetter;
   /**
    Holds the jsi::Runtime this RuntimeManager is managing.
    */
-  std::unique_ptr<jsi::Runtime> runtime;
+  std::shared_ptr<jsi::Runtime> runtime;
   /**
    Holds the error handler that will be invoked when any kind of error occurs.
    */
   std::shared_ptr<ErrorHandler> errorHandler;
   /**
-   Holds the Scheduler that is responsible for scheduling work on the UI- or ABI44_0_0React-JS Thread.
+   Holds the Scheduler that is responsible for scheduling work on the UI- or
+   ABI44_0_0React-JS Thread.
    */
   std::shared_ptr<Scheduler> scheduler;
   /**
-   Holds a list of adapted Worklets which are cached to avoid unneccessary recreation.
+   Holds a list of adapted Worklets which are cached to avoid unneccessary
+   recreation.
    */
   std::unique_ptr<WorkletsCache> workletsCache;
+  /**
+   Holds the JSI-Value Store where JSI::Values are cached on a
+   per-RuntimeManager basis.
+   */
+  std::shared_ptr<StaticStoreUser> storeUserData;
+
+ private:
+  void clearStore() {
+    const std::lock_guard<std::recursive_mutex> lock(storeUserData->storeMutex);
+    storeUserData->store.clear();
+  }
 };
 
-}
+} // namespace reanimated

--- a/ios/vendored/sdk44/react-native-reanimated/Common/cpp/headers/SharedItems/ShareableValue.h
+++ b/ios/vendored/sdk44/react-native-reanimated/Common/cpp/headers/SharedItems/ShareableValue.h
@@ -1,52 +1,60 @@
 #pragma once
 
-#include "WorkletsCache.h"
-#include "SharedParent.h"
-#include "ValueWrapper.h"
+#include <ABI44_0_0jsi/ABI44_0_0jsi.h>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
 #include "HostFunctionHandler.h"
 #include "JSIStoreValueUser.h"
+#include "LayoutAnimationsProxy.h"
 #include "RuntimeManager.h"
 #include "Scheduler.h"
-#include <string>
-#include <mutex>
-#include <unordered_map>
-#include <ABI44_0_0jsi/ABI44_0_0jsi.h>
+#include "SharedParent.h"
+#include "ValueWrapper.h"
+#include "WorkletsCache.h"
 
 using namespace ABI44_0_0facebook;
 
 namespace ABI44_0_0reanimated {
 
-class ShareableValue: public std::enable_shared_from_this<ShareableValue>, public StoreUser {
-friend WorkletsCache;
-friend FrozenObject;
-friend void extractMutables(jsi::Runtime &rt,
-                            std::shared_ptr<ShareableValue> sv,
-                            std::vector<std::shared_ptr<MutableValue>> &res);
+class ShareableValue : public std::enable_shared_from_this<ShareableValue>,
+                       public StoreUser {
+  friend WorkletsCache;
+  friend FrozenObject;
+  friend LayoutAnimationsProxy;
+  friend void extractMutables(
+      jsi::Runtime &rt,
+      std::shared_ptr<ShareableValue> sv,
+      std::vector<std::shared_ptr<MutableValue>> &res);
 
-private:
+ private:
   RuntimeManager *runtimeManager;
   std::unique_ptr<ValueWrapper> valueContainer;
   std::unique_ptr<jsi::Value> hostValue;
   std::weak_ptr<jsi::Value> remoteValue;
   bool containsHostFunction = false;
 
-  ShareableValue(RuntimeManager *runtimeManager, std::shared_ptr<Scheduler> s): StoreUser(s), runtimeManager(runtimeManager) {}
+  ShareableValue(RuntimeManager *runtimeManager, std::shared_ptr<Scheduler> s)
+      : StoreUser(s, *runtimeManager), runtimeManager(runtimeManager) {}
 
   jsi::Value toJSValue(jsi::Runtime &rt);
-  jsi::Object createHost(jsi::Runtime &rt, std::shared_ptr<jsi::HostObject> host);
+  jsi::Object createHost(
+      jsi::Runtime &rt,
+      std::shared_ptr<jsi::HostObject> host);
   void adapt(jsi::Runtime &rt, const jsi::Value &value, ValueType objectType);
   void adaptCache(jsi::Runtime &rt, const jsi::Value &value);
+  std::string demangleExceptionName(std::string toDemangle);
 
-public:
+ public:
   ValueType type = ValueType::UndefinedType;
   static std::shared_ptr<ShareableValue> adapt(
-    jsi::Runtime &rt,
-    const jsi::Value &value,
-    RuntimeManager *runtimeManager,
-    ValueType objectType = ValueType::UndefinedType
-  );
+      jsi::Runtime &rt,
+      const jsi::Value &value,
+      RuntimeManager *runtimeManager,
+      ValueType objectType = ValueType::UndefinedType);
   jsi::Value getValue(jsi::Runtime &rt);
-
 };
 
-}
+} // namespace reanimated

--- a/ios/vendored/sdk44/react-native-reanimated/Common/cpp/headers/SharedItems/SharedParent.h
+++ b/ios/vendored/sdk44/react-native-reanimated/Common/cpp/headers/SharedItems/SharedParent.h
@@ -8,12 +8,15 @@ enum class ValueType {
   BoolType,
   NumberType,
   StringType,
-  RemoteObjectType, /* object that can be instantiated on host side and modified on the remote (worklet) side */
-  MutableValueType, /* object with 'value' property that can be updated and read from any thread */
-  HostFunctionType, /* function that will be executed asynchronously on the host runtime */
-  WorkletFunctionType, /* function that gets run on the UI thread */
-  FrozenObjectType, /* frozen object, can only be set and never modified */
-  FrozenArrayType, /* frozen array, can only be set and never modified */
+  RemoteObjectType, // object that can be instantiated on host side and modified
+                    // on the remote (worklet) side
+  MutableValueType, // object with 'value' property that can be updated and read
+                    // from any thread
+  HostFunctionType, // function that will be executed asynchronously on the host
+                    // runtime
+  WorkletFunctionType, // function that gets run on the UI thread
+  FrozenObjectType, // frozen object, can only be set and never modified
+  FrozenArrayType, // frozen array, can only be set and never modified
 };
 
 class ShareableValue;
@@ -21,4 +24,4 @@ class MutableValue;
 class RemoteObject;
 class NativeReanimatedModule;
 
-}
+} // namespace reanimated

--- a/ios/vendored/sdk44/react-native-reanimated/Common/cpp/headers/SharedItems/ValueWrapper.h
+++ b/ios/vendored/sdk44/react-native-reanimated/Common/cpp/headers/SharedItems/ValueWrapper.h
@@ -1,132 +1,155 @@
 #pragma once
 
-#include "WorkletsCache.h"
-#include "SharedParent.h"
 #include <ABI44_0_0jsi/ABI44_0_0jsi.h>
+#include <memory>
 #include <string>
-#include "JSIStoreValueUser.h"
+#include <vector>
 #include "HostFunctionHandler.h"
+#include "JSIStoreValueUser.h"
+#include "SharedParent.h"
+#include "WorkletsCache.h"
 
 namespace ABI44_0_0reanimated {
 
 class HostFunctionWrapper;
 
 class ValueWrapper {
-public:
-  ValueWrapper() {};
-  ValueWrapper(ValueType _type) : type(_type) {};
+ public:
+  ValueWrapper() {}
+  explicit ValueWrapper(ValueType _type) : type(_type) {}
   ValueType getType() const {
     return type;
   }
 
   virtual ~ValueWrapper() {}
 
-  static inline bool asBoolean(const std::unique_ptr<ValueWrapper>& valueContainer);
-  static inline double asNumber(const std::unique_ptr<ValueWrapper>& valueContainer);
-  static inline const std::string& asString(const std::unique_ptr<ValueWrapper>& valueContainer);
-  static inline const std::shared_ptr<HostFunctionHandler>& asHostFunction(const std::unique_ptr<ValueWrapper>& valueContainer);
-  static inline const std::shared_ptr<FrozenObject>& asFrozenObject(const std::unique_ptr<ValueWrapper>& valueContainer);
-  static inline const std::shared_ptr<RemoteObject>& asRemoteObject(const std::unique_ptr<ValueWrapper>& valueContainer);
-  static inline std::vector<std::shared_ptr<ShareableValue>>& asFrozenArray(const std::unique_ptr<ValueWrapper>& valueContainer);
-  static inline const std::shared_ptr<MutableValue>& asMutableValue(const std::unique_ptr<ValueWrapper>& valueContainer);
+  static inline bool asBoolean(
+      const std::unique_ptr<ValueWrapper> &valueContainer);
+  static inline double asNumber(
+      const std::unique_ptr<ValueWrapper> &valueContainer);
+  static inline const std::string &asString(
+      const std::unique_ptr<ValueWrapper> &valueContainer);
+  static inline const std::shared_ptr<HostFunctionHandler> &asHostFunction(
+      const std::unique_ptr<ValueWrapper> &valueContainer);
+  static inline const std::shared_ptr<FrozenObject> &asFrozenObject(
+      const std::unique_ptr<ValueWrapper> &valueContainer);
+  static inline const std::shared_ptr<RemoteObject> &asRemoteObject(
+      const std::unique_ptr<ValueWrapper> &valueContainer);
+  static inline std::vector<std::shared_ptr<ShareableValue>> &asFrozenArray(
+      const std::unique_ptr<ValueWrapper> &valueContainer);
+  static inline const std::shared_ptr<MutableValue> &asMutableValue(
+      const std::unique_ptr<ValueWrapper> &valueContainer);
 
-  static const HostFunctionWrapper* asHostFunctionWrapper(const std::unique_ptr<ValueWrapper>& valueContainer);
+  static const HostFunctionWrapper *asHostFunctionWrapper(
+      const std::unique_ptr<ValueWrapper> &valueContainer);
 
-protected:
-    ValueType type;
+ protected:
+  ValueType type;
 };
 
 class BooleanValueWrapper : public ValueWrapper {
-public:
-  BooleanValueWrapper(const bool _value)
-    : ValueWrapper(ValueType::BoolType), value(_value) {};
+ public:
+  explicit BooleanValueWrapper(const bool _value)
+      : ValueWrapper(ValueType::BoolType), value(_value) {}
   bool value;
 };
 
 class NumberValueWrapper : public ValueWrapper {
-public:
-  NumberValueWrapper(const double _value)
-    : ValueWrapper(ValueType::NumberType), value(_value) {};
+ public:
+  explicit NumberValueWrapper(const double _value)
+      : ValueWrapper(ValueType::NumberType), value(_value) {}
   double value;
 };
 
 class StringValueWrapper : public ValueWrapper {
-public:
-  StringValueWrapper(const std::string & _value)
-    : ValueWrapper(ValueType::StringType), value(_value) {};
+ public:
+  explicit StringValueWrapper(const std::string &_value)
+      : ValueWrapper(ValueType::StringType), value(_value) {}
   std::string value;
 };
 
 class HostFunctionWrapper : public ValueWrapper {
-public:
-  HostFunctionWrapper(const std::shared_ptr<HostFunctionHandler> & _value)
-    : ValueWrapper(ValueType::HostFunctionType), value(_value) {};
+ public:
+  explicit HostFunctionWrapper(
+      const std::shared_ptr<HostFunctionHandler> &_value)
+      : ValueWrapper(ValueType::HostFunctionType), value(_value) {}
   std::shared_ptr<HostFunctionHandler> value;
 };
 
 class FrozenObjectWrapper : public ValueWrapper {
-public:
-  FrozenObjectWrapper(const std::shared_ptr<FrozenObject> & _value)
-    : ValueWrapper(ValueType::FrozenObjectType), value(_value) {};
+ public:
+  explicit FrozenObjectWrapper(const std::shared_ptr<FrozenObject> &_value)
+      : ValueWrapper(ValueType::FrozenObjectType), value(_value) {}
   std::shared_ptr<FrozenObject> value;
 };
 
 class RemoteObjectWrapper : public ValueWrapper {
-public:
-  RemoteObjectWrapper(const std::shared_ptr<RemoteObject> & _value)
-    : ValueWrapper(ValueType::RemoteObjectType), value(_value) {};
+ public:
+  explicit RemoteObjectWrapper(const std::shared_ptr<RemoteObject> &_value)
+      : ValueWrapper(ValueType::RemoteObjectType), value(_value) {}
   std::shared_ptr<RemoteObject> value;
 };
 
 class FrozenArrayWrapper : public ValueWrapper {
-public:
-  FrozenArrayWrapper() : ValueWrapper(ValueType::FrozenArrayType) {};
-  FrozenArrayWrapper(const std::vector<std::shared_ptr<ShareableValue>> & _value)
-    : ValueWrapper(ValueType::FrozenArrayType), value(_value) {};
+ public:
+  FrozenArrayWrapper() : ValueWrapper(ValueType::FrozenArrayType) {}
+  explicit FrozenArrayWrapper(
+      const std::vector<std::shared_ptr<ShareableValue>> &_value)
+      : ValueWrapper(ValueType::FrozenArrayType), value(_value) {}
   std::vector<std::shared_ptr<ShareableValue>> value;
 };
 
 class MutableValueWrapper : public ValueWrapper {
-public:
-  MutableValueWrapper(const std::shared_ptr<MutableValue> & _value)
-    : ValueWrapper(ValueType::MutableValueType), value(_value) {};
+ public:
+  explicit MutableValueWrapper(const std::shared_ptr<MutableValue> &_value)
+      : ValueWrapper(ValueType::MutableValueType), value(_value) {}
   std::shared_ptr<MutableValue> value;
 };
 
-inline bool ValueWrapper::asBoolean(const std::unique_ptr<ValueWrapper>& valueContainer) {
-  return static_cast<BooleanValueWrapper*>(valueContainer.get())->value;
-};
-
-inline double ValueWrapper::asNumber(const std::unique_ptr<ValueWrapper>& valueContainer) {
-  return static_cast<NumberValueWrapper*>(valueContainer.get())->value;
-};
-
-inline const std::string& ValueWrapper::asString(const std::unique_ptr<ValueWrapper>& valueContainer) {
-  return static_cast<StringValueWrapper*>(valueContainer.get())->value;
-};
-
-inline const std::shared_ptr<HostFunctionHandler>& ValueWrapper::asHostFunction(const std::unique_ptr<ValueWrapper>& valueContainer) {
-  return static_cast<HostFunctionWrapper*>(valueContainer.get())->value;
-};
-
-inline const std::shared_ptr<FrozenObject>& ValueWrapper::asFrozenObject(const std::unique_ptr<ValueWrapper>& valueContainer) {
-  return static_cast<FrozenObjectWrapper*>(valueContainer.get())->value;
-};
-
-inline const std::shared_ptr<RemoteObject>& ValueWrapper::asRemoteObject(const std::unique_ptr<ValueWrapper>& valueContainer) {
-  return static_cast<RemoteObjectWrapper*>(valueContainer.get())->value;
-};
-
-inline std::vector<std::shared_ptr<ShareableValue>>& ValueWrapper::asFrozenArray(const std::unique_ptr<ValueWrapper>& valueContainer) {
-  return static_cast<FrozenArrayWrapper*>(valueContainer.get())->value;
-};
-
-inline const std::shared_ptr<MutableValue>& ValueWrapper::asMutableValue(const std::unique_ptr<ValueWrapper>& valueContainer) {
-  return static_cast<MutableValueWrapper*>(valueContainer.get())->value;
-};
-
-inline const HostFunctionWrapper* ValueWrapper::asHostFunctionWrapper(const std::unique_ptr<ValueWrapper>& valueContainer) {
-  return static_cast<HostFunctionWrapper*>(valueContainer.get());
-};
-
+inline bool ValueWrapper::asBoolean(
+    const std::unique_ptr<ValueWrapper> &valueContainer) {
+  return static_cast<BooleanValueWrapper *>(valueContainer.get())->value;
 }
+
+inline double ValueWrapper::asNumber(
+    const std::unique_ptr<ValueWrapper> &valueContainer) {
+  return static_cast<NumberValueWrapper *>(valueContainer.get())->value;
+}
+
+inline const std::string &ValueWrapper::asString(
+    const std::unique_ptr<ValueWrapper> &valueContainer) {
+  return static_cast<StringValueWrapper *>(valueContainer.get())->value;
+}
+
+inline const std::shared_ptr<HostFunctionHandler> &ValueWrapper::asHostFunction(
+    const std::unique_ptr<ValueWrapper> &valueContainer) {
+  return static_cast<HostFunctionWrapper *>(valueContainer.get())->value;
+}
+
+inline const std::shared_ptr<FrozenObject> &ValueWrapper::asFrozenObject(
+    const std::unique_ptr<ValueWrapper> &valueContainer) {
+  return static_cast<FrozenObjectWrapper *>(valueContainer.get())->value;
+}
+
+inline const std::shared_ptr<RemoteObject> &ValueWrapper::asRemoteObject(
+    const std::unique_ptr<ValueWrapper> &valueContainer) {
+  return static_cast<RemoteObjectWrapper *>(valueContainer.get())->value;
+}
+
+inline std::vector<std::shared_ptr<ShareableValue>>
+    &ValueWrapper::asFrozenArray(
+        const std::unique_ptr<ValueWrapper> &valueContainer) {
+  return static_cast<FrozenArrayWrapper *>(valueContainer.get())->value;
+}
+
+inline const std::shared_ptr<MutableValue> &ValueWrapper::asMutableValue(
+    const std::unique_ptr<ValueWrapper> &valueContainer) {
+  return static_cast<MutableValueWrapper *>(valueContainer.get())->value;
+}
+
+inline const HostFunctionWrapper *ValueWrapper::asHostFunctionWrapper(
+    const std::unique_ptr<ValueWrapper> &valueContainer) {
+  return static_cast<HostFunctionWrapper *>(valueContainer.get());
+}
+
+} // namespace reanimated

--- a/ios/vendored/sdk44/react-native-reanimated/Common/cpp/headers/SpecTools/ErrorHandler.h
+++ b/ios/vendored/sdk44/react-native-reanimated/Common/cpp/headers/SpecTools/ErrorHandler.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include "Scheduler.h"
+#include <memory>
 #include <string>
+#include "Scheduler.h"
 
-namespace ABI44_0_0reanimated
-{
+namespace ABI44_0_0reanimated {
 
 struct ErrorWrapper {
   std::string message = "";
@@ -12,22 +12,21 @@ struct ErrorWrapper {
 };
 
 class ErrorHandler {
-  public:
-    bool raise() {
-      if (getError()->handled) {
-        return false;
-      }
-      this->getScheduler()->scheduleOnUI([this]() mutable {
-        this->raiseSpec();
-      });
-      return true;
+ public:
+  bool raise() {
+    if (getError()->handled) {
+      return false;
     }
-    virtual std::shared_ptr<Scheduler> getScheduler() = 0;
-    virtual std::shared_ptr<ErrorWrapper> getError() = 0;
-    virtual void setError(std::string message) = 0;
-    virtual ~ErrorHandler() {}
-  protected:
-    virtual void raiseSpec() = 0;
+    this->getScheduler()->scheduleOnUI([this]() mutable { this->raiseSpec(); });
+    return true;
+  }
+  virtual std::shared_ptr<Scheduler> getScheduler() = 0;
+  virtual std::shared_ptr<ErrorWrapper> getError() = 0;
+  virtual void setError(std::string message) = 0;
+  virtual ~ErrorHandler() {}
+
+ protected:
+  virtual void raiseSpec() = 0;
 };
 
-}
+} // namespace reanimated

--- a/ios/vendored/sdk44/react-native-reanimated/Common/cpp/headers/Tools/FeaturesConfig.h
+++ b/ios/vendored/sdk44/react-native-reanimated/Common/cpp/headers/Tools/FeaturesConfig.h
@@ -1,0 +1,19 @@
+#pragma once
+#include <string>
+
+namespace ABI44_0_0reanimated {
+
+class FeaturesConfig {
+ public:
+  static inline bool isLayoutAnimationEnabled() {
+    return _isLayoutAnimationEnabled;
+  }
+  static inline void setLayoutAnimationEnabled(bool isLayoutAnimationEnabled) {
+    _isLayoutAnimationEnabled = isLayoutAnimationEnabled;
+  }
+
+ private:
+  static bool _isLayoutAnimationEnabled;
+};
+
+} // namespace reanimated

--- a/ios/vendored/sdk44/react-native-reanimated/Common/cpp/headers/Tools/JSIStoreValueUser.h
+++ b/ios/vendored/sdk44/react-native-reanimated/Common/cpp/headers/Tools/JSIStoreValueUser.h
@@ -1,35 +1,37 @@
-#ifndef JSIStoreValueUser_h
-#define JSIStoreValueUser_h
+#pragma once
 
+#include <ABI44_0_0jsi/ABI44_0_0jsi.h>
 #include <stdio.h>
 #include <memory>
-#include <vector>
-#include <unordered_map>
-#include <ABI44_0_0jsi/ABI44_0_0jsi.h>
 #include <mutex>
+#include <unordered_map>
+#include <vector>
 #include "Scheduler.h"
 
 using namespace ABI44_0_0facebook;
 
 namespace ABI44_0_0reanimated {
 
+class RuntimeManager;
+
+struct StaticStoreUser {
+  std::atomic<int> ctr;
+  std::unordered_map<int, std::vector<std::shared_ptr<jsi::Value>>> store;
+  std::recursive_mutex storeMutex;
+};
+
 class StoreUser {
   int identifier = 0;
-  static std::atomic<int> ctr;
-  static std::unordered_map<int, std::vector<std::shared_ptr<jsi::Value>>> store;
-  static std::recursive_mutex storeMutex;
   std::weak_ptr<Scheduler> scheduler;
-  
-public:
-  StoreUser(std::shared_ptr<Scheduler> s);
-  
+  std::shared_ptr<StaticStoreUser> storeUserData;
+
+ public:
+  StoreUser(std::shared_ptr<Scheduler> s, const RuntimeManager &runtimeManager);
+
   std::weak_ptr<jsi::Value> getWeakRef(jsi::Runtime &rt);
   void removeRefs();
-  
-  static void clearStore();
+
   virtual ~StoreUser();
 };
 
-}
-
-#endif /* JSIStoreValueUser_h */
+} // namespace reanimated

--- a/ios/vendored/sdk44/react-native-reanimated/Common/cpp/headers/Tools/Mapper.h
+++ b/ios/vendored/sdk44/react-native-reanimated/Common/cpp/headers/Tools/Mapper.h
@@ -1,9 +1,11 @@
 #pragma once
 
-#include "ShareableValue.h"
-#include "NativeReanimatedModule.h"
-#include <stdio.h>
 #include <ABI44_0_0jsi/ABI44_0_0jsi.h>
+#include <stdio.h>
+#include <memory>
+#include <vector>
+#include "NativeReanimatedModule.h"
+#include "ShareableValue.h"
 
 using namespace ABI44_0_0facebook;
 
@@ -11,24 +13,39 @@ namespace ABI44_0_0reanimated {
 
 class MapperRegistry;
 
+struct ViewDescriptor {
+  int tag;
+  jsi::Value name;
+};
+
 class Mapper : public std::enable_shared_from_this<Mapper> {
   friend MapperRegistry;
-private:
+
+ private:
   unsigned long id;
   NativeReanimatedModule *module;
   std::shared_ptr<jsi::Function> mapper;
   std::vector<std::shared_ptr<MutableValue>> inputs;
   std::vector<std::shared_ptr<MutableValue>> outputs;
   bool dirty = true;
+  std::shared_ptr<jsi::Function> userUpdater;
+  UpdaterFunction *updateProps;
+  int optimalizationLvl = 0;
+  std::shared_ptr<ShareableValue> viewDescriptors;
 
-public:
-  Mapper(NativeReanimatedModule *module,
-         unsigned long id,
-         std::shared_ptr<jsi::Function> mapper,
-         std::vector<std::shared_ptr<MutableValue>> inputs,
-         std::vector<std::shared_ptr<MutableValue>> outputs);
+ public:
+  Mapper(
+      NativeReanimatedModule *module,
+      unsigned long id,
+      std::shared_ptr<jsi::Function> mapper,
+      std::vector<std::shared_ptr<MutableValue>> inputs,
+      std::vector<std::shared_ptr<MutableValue>> outputs);
   void execute(jsi::Runtime &rt);
+  void enableFastMode(
+      const int optimalizationLvl,
+      const std::shared_ptr<ShareableValue> &updater,
+      const std::shared_ptr<ShareableValue> &jsViewDescriptors);
   virtual ~Mapper();
 };
 
-}
+} // namespace reanimated

--- a/ios/vendored/sdk44/react-native-reanimated/Common/cpp/headers/Tools/PlatformDepMethodsHolder.h
+++ b/ios/vendored/sdk44/react-native-reanimated/Common/cpp/headers/Tools/PlatformDepMethodsHolder.h
@@ -1,18 +1,27 @@
 #pragma once
 
-#include <stdio.h>
 #include <ABI44_0_0jsi/ABI44_0_0jsi.h>
+#include <stdio.h>
+#include <string>
+#include <utility>
+#include <vector>
 
 using namespace ABI44_0_0facebook;
 
-namespace ABI44_0_0reanimated
-{
+namespace ABI44_0_0reanimated {
 
-using UpdaterFunction = std::function<void(jsi::Runtime &rt, int viewTag, const jsi::Value &viewName, const jsi::Object &object)>;
-using RequestRender = std::function<void(std::function<void(double)>, jsi::Runtime &rt)>;
+using UpdaterFunction = std::function<void(
+    jsi::Runtime &rt,
+    int viewTag,
+    const jsi::Value &viewName,
+    const jsi::Object &object)>;
+using RequestRender =
+    std::function<void(std::function<void(double)>, jsi::Runtime &rt)>;
 using ScrollToFunction = std::function<void(int, double, double, bool)>;
-using MeasuringFunction = std::function<std::vector<std::pair<std::string, double>>(int)>;
+using MeasuringFunction =
+    std::function<std::vector<std::pair<std::string, double>>(int)>;
 using TimeProviderFunction = std::function<double(void)>;
+using SetGestureStateFunction = std::function<void(int, int)>;
 
 struct PlatformDepMethodsHolder {
   RequestRender requestRender;
@@ -20,6 +29,7 @@ struct PlatformDepMethodsHolder {
   ScrollToFunction scrollToFunction;
   MeasuringFunction measuringFunction;
   TimeProviderFunction getCurrentTime;
+  SetGestureStateFunction setGestureStateFunction;
 };
 
-}
+} // namespace reanimated

--- a/ios/vendored/sdk44/react-native-reanimated/Common/cpp/headers/Tools/ReanimatedHiddenHeaders.h
+++ b/ios/vendored/sdk44/react-native-reanimated/Common/cpp/headers/Tools/ReanimatedHiddenHeaders.h
@@ -1,15 +1,11 @@
-
-#ifndef ABI44_0_0REANIMATEDEXAMPLE_REANIMATEDHIDDEN_H
-#define ABI44_0_0REANIMATEDEXAMPLE_REANIMATEDHIDDEN_H
+#pragma once
 
 #if defined(ONANDROID)
-    #include "Logger.h"
-    #include "LoggerInterface.h"
-    #include "SpeedChecker.h"
+#include "Logger.h"
+#include "LoggerInterface.h"
+#include "SpeedChecker.h"
 #else
-    #include "Common/cpp/hidden_headers/Logger.h"
-    #include "Common/cpp/hidden_headers/LoggerInterface.h"
-    #include "Common/cpp/hidden_headers/SpeedChecker.h"
+#include "Common/cpp/hidden_headers/Logger.h"
+#include "Common/cpp/hidden_headers/LoggerInterface.h"
+#include "Common/cpp/hidden_headers/SpeedChecker.h"
 #endif
-
-#endif //ABI44_0_0REANIMATEDEXAMPLE_REANIMATEDHIDDEN_H

--- a/ios/vendored/sdk44/react-native-reanimated/Common/cpp/headers/Tools/RuntimeDecorator.h
+++ b/ios/vendored/sdk44/react-native-reanimated/Common/cpp/headers/Tools/RuntimeDecorator.h
@@ -1,8 +1,12 @@
 #pragma once
 
-#include "PlatformDepMethodsHolder.h"
-#include <stdio.h>
 #include <ABI44_0_0jsi/ABI44_0_0jsi.h>
+#include <stdio.h>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include "LayoutAnimationsProxy.h"
+#include "PlatformDepMethodsHolder.h"
 
 using namespace ABI44_0_0facebook;
 
@@ -10,28 +14,74 @@ namespace ABI44_0_0reanimated {
 
 using RequestFrameFunction = std::function<void(std::function<void(double)>)>;
 
+enum RuntimeType {
+  /**
+   Represents any runtime that supports the concept of workletization
+   */
+  Worklet,
+  /**
+   Represents the Reanimated UI worklet runtime specifically
+   */
+  UI
+};
+typedef jsi::Runtime *RuntimePointer;
+
 class RuntimeDecorator {
-public:
-  static void decorateRuntime(jsi::Runtime &rt, std::string label);
-  static void decorateUIRuntime(jsi::Runtime &rt,
-                                UpdaterFunction updater,
-                                RequestFrameFunction requestFrame,
-                                ScrollToFunction scrollTo,
-                                MeasuringFunction measure,
-                                TimeProviderFunction getCurrentTime);
-  
+ public:
+  static void decorateRuntime(jsi::Runtime &rt, const std::string &label);
+  static void decorateUIRuntime(
+      jsi::Runtime &rt,
+      const UpdaterFunction updater,
+      const RequestFrameFunction requestFrame,
+      const ScrollToFunction scrollTo,
+      const MeasuringFunction measure,
+      const TimeProviderFunction getCurrentTime,
+      const SetGestureStateFunction setGestureState,
+      std::shared_ptr<LayoutAnimationsProxy> layoutAnimationsProxy);
+
   /**
    Returns true if the given Runtime is the Reanimated UI-Thread Runtime.
    */
-  static bool isUIRuntime(jsi::Runtime &rt);
+  inline static bool isUIRuntime(jsi::Runtime &rt);
   /**
-   Returns true if the given Runtime is a Runtime that supports Workletization. (REA, Vision, ...)
+   Returns true if the given Runtime is a Runtime that supports the concept of
+   Workletization. (REA, Vision, ...)
    */
-  static bool isWorkletRuntime(jsi::Runtime &rt);
+  inline static bool isWorkletRuntime(jsi::Runtime &rt);
   /**
    Returns true if the given Runtime is the default ABI44_0_0React-JS Runtime.
    */
-  static bool isReactRuntime(jsi::Runtime &rt);
+  inline static bool isReactRuntime(jsi::Runtime &rt);
+  /**
+   Register the given Runtime. This function is required for every
+   RuntimeManager, otherwise future runtime checks will fail.
+   */
+  static void registerRuntime(jsi::Runtime *runtime, RuntimeType runtimeType);
+
+ private:
+  static std::unordered_map<RuntimePointer, RuntimeType> &runtimeRegistry();
 };
 
+inline bool RuntimeDecorator::isUIRuntime(jsi::Runtime &rt) {
+  auto iterator = runtimeRegistry().find(&rt);
+  if (iterator == runtimeRegistry().end())
+    return false;
+  return iterator->second == RuntimeType::UI;
 }
+
+inline bool RuntimeDecorator::isWorkletRuntime(jsi::Runtime &rt) {
+  auto iterator = runtimeRegistry().find(&rt);
+  if (iterator == runtimeRegistry().end())
+    return false;
+  auto type = iterator->second;
+  return type == RuntimeType::UI || type == RuntimeType::Worklet;
+}
+
+inline bool RuntimeDecorator::isReactRuntime(jsi::Runtime &rt) {
+  auto iterator = runtimeRegistry().find(&rt);
+  if (iterator == runtimeRegistry().end())
+    return true;
+  return false;
+}
+
+} // namespace reanimated

--- a/ios/vendored/sdk44/react-native-reanimated/Common/cpp/headers/Tools/WorkletEventHandler.h
+++ b/ios/vendored/sdk44/react-native-reanimated/Common/cpp/headers/Tools/WorkletEventHandler.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <string>
 #include <ABI44_0_0jsi/ABI44_0_0jsi.h>
+#include <string>
+#include <utility>
 
 using namespace ABI44_0_0facebook;
 
@@ -12,16 +13,18 @@ class EventHandlerRegistry;
 class WorkletEventHandler {
   friend EventHandlerRegistry;
 
-private:
+ private:
   unsigned long id;
   std::string eventName;
   jsi::Function handler;
 
-public:
-  WorkletEventHandler(unsigned long id,
-               std::string eventName,
-               jsi::Function &&handler): id(id), eventName(eventName), handler(std::move(handler)) {}
-  void process(jsi::Runtime &rt, jsi::Value &eventValue);
+ public:
+  WorkletEventHandler(
+      unsigned long id,
+      std::string eventName,
+      jsi::Function &&handler)
+      : id(id), eventName(eventName), handler(std::move(handler)) {}
+  void process(jsi::Runtime &rt, const jsi::Value &eventValue);
 };
 
-}
+} // namespace reanimated

--- a/ios/vendored/sdk44/react-native-reanimated/Common/cpp/hidden_headers/Logger.h
+++ b/ios/vendored/sdk44/react-native-reanimated/Common/cpp/hidden_headers/Logger.h
@@ -1,22 +1,22 @@
 #pragma once
 
-#include "./LoggerInterface.h"
 #include <memory>
+#include "./LoggerInterface.h"
 
-namespace ABI44_0_0reanimated
-{
+namespace ABI44_0_0reanimated {
 
 class Logger {
-  public:
-  template<typename T>
-    static void log(T value) {
-      if (instance == nullptr) {
-        throw std::runtime_error("no logger specified");
-      }
-      instance->log(value);
-    };
-  private:
-    static std::unique_ptr<LoggerInterface> instance;
+ public:
+  template <typename T>
+  static void log(T value) {
+    if (instance == nullptr) {
+      throw std::runtime_error("no logger specified");
+    }
+    instance->log(value);
+  }
+
+ private:
+  static std::unique_ptr<LoggerInterface> instance;
 };
 
-}
+} // namespace reanimated

--- a/ios/vendored/sdk44/react-native-reanimated/Common/cpp/hidden_headers/LoggerInterface.h
+++ b/ios/vendored/sdk44/react-native-reanimated/Common/cpp/hidden_headers/LoggerInterface.h
@@ -1,15 +1,14 @@
 #pragma once
 
-namespace ABI44_0_0reanimated
-{
+namespace ABI44_0_0reanimated {
 
 class LoggerInterface {
-  public:
-    virtual void log(const char* str) = 0;
-    virtual void log(double d) = 0;
-    virtual void log(int i) = 0;
-    virtual void log(bool b) = 0;
-    virtual ~LoggerInterface() {}
+ public:
+  virtual void log(const char *str) = 0;
+  virtual void log(double d) = 0;
+  virtual void log(int i) = 0;
+  virtual void log(bool b) = 0;
+  virtual ~LoggerInterface() {}
 };
 
-}
+} // namespace reanimated

--- a/ios/vendored/sdk44/react-native-reanimated/Common/cpp/hidden_headers/SpeedChecker.h
+++ b/ios/vendored/sdk44/react-native-reanimated/Common/cpp/hidden_headers/SpeedChecker.h
@@ -1,17 +1,17 @@
 #pragma once
 
-#define CHECK_SPEED 0
+#define CHECK_SPEED 1
 
-#include "./Logger.h"
-#include <memory>
+#include <chrono>
 #include <functional>
+#include <memory>
 #include <string>
+#include "./Logger.h"
 
-namespace ABI44_0_0reanimated
-{
+namespace ABI44_0_0reanimated {
 
 class SpeedChecker {
-public:
+ public:
   static void checkSpeed(std::string tag, std::function<void()> fun) {
 #if CHECK_SPEED
     auto start = std::chrono::system_clock::now();
@@ -19,11 +19,11 @@ public:
     fun();
 #if CHECK_SPEED
     auto end = std::chrono::system_clock::now();
-    std::chrono::duration<double> elapsed_seconds = end-start;
+    std::chrono::duration<double> elapsed_seconds = end - start;
     tag += " " + std::to_string(elapsed_seconds.count()) + "s";
     Logger::log(tag.c_str());
 #endif
   }
 };
 
-}
+} // namespace reanimated

--- a/ios/vendored/sdk44/react-native-reanimated/ios/ABI44_0_0REAEventDispatcher.m
+++ b/ios/vendored/sdk44/react-native-reanimated/ios/ABI44_0_0REAEventDispatcher.m
@@ -1,17 +1,17 @@
 #import "ABI44_0_0REAEventDispatcher.h"
-#import <ABI44_0_0React/ABI44_0_0RCTDefines.h>
-#import <ABI44_0_0React/ABI44_0_0RCTBridge+Private.h>
 #import <ABI44_0_0RNReanimated/ABI44_0_0REAModule.h>
+#import <ABI44_0_0React/ABI44_0_0RCTBridge+Private.h>
+#import <ABI44_0_0React/ABI44_0_0RCTDefines.h>
 
 @implementation ABI44_0_0REAEventDispatcher
 
 - (void)sendEvent:(id<ABI44_0_0RCTEvent>)event
 {
-  [[ABI44_0_0_bridge_reanimated moduleForName:@"ReanimatedModule"] eventDispatcherWillDispatchEvent:event];
+  [[[self bridge] moduleForName:@"ReanimatedModule"] eventDispatcherWillDispatchEvent:event];
   [super sendEvent:event];
 }
 
-+ (NSString*)moduleName
++ (NSString *)moduleName
 {
   return NSStringFromClass([ABI44_0_0RCTEventDispatcher class]);
 }

--- a/ios/vendored/sdk44/react-native-reanimated/ios/ABI44_0_0REAModule.h
+++ b/ios/vendored/sdk44/react-native-reanimated/ios/ABI44_0_0REAModule.h
@@ -7,8 +7,6 @@
 
 #import "ABI44_0_0REAValueNode.h"
 
-extern ABI44_0_0RCTBridge *ABI44_0_0_bridge_reanimated;
-
 @interface ABI44_0_0REAModule : ABI44_0_0RCTEventEmitter <ABI44_0_0RCTBridgeModule, ABI44_0_0RCTEventDispatcherObserver, ABI44_0_0RCTUIManagerObserver>
 
 @property (nonatomic, readonly) ABI44_0_0REANodesManager *nodesManager;

--- a/ios/vendored/sdk44/react-native-reanimated/ios/ABI44_0_0REAModule.m
+++ b/ios/vendored/sdk44/react-native-reanimated/ios/ABI44_0_0REAModule.m
@@ -6,10 +6,7 @@
 
 typedef void (^AnimatedOperation)(ABI44_0_0REANodesManager *nodesManager);
 
-ABI44_0_0RCTBridge *ABI44_0_0_bridge_reanimated = nil;
-
-@implementation ABI44_0_0REAModule
-{
+@implementation ABI44_0_0REAModule {
   NSMutableArray<AnimatedOperation> *_operations;
   ABI44_0_0REATransitionManager *_transitionManager;
 }
@@ -18,7 +15,6 @@ ABI44_0_0RCT_EXPORT_MODULE(ReanimatedModule);
 
 - (void)invalidate
 {
-  ABI44_0_0_bridge_reanimated = nil;
   _transitionManager = nil;
   [_nodesManager invalidate];
   [self.bridge.uiManager.observerCoordinator removeObserver:self];
@@ -36,8 +32,7 @@ ABI44_0_0RCT_EXPORT_MODULE(ReanimatedModule);
 {
   [super setBridge:bridge];
 
-  _nodesManager = [[ABI44_0_0REANodesManager alloc] initWithModule:self
-                                                uiManager:self.bridge.uiManager];
+  _nodesManager = [[ABI44_0_0REANodesManager alloc] initWithModule:self uiManager:self.bridge.uiManager];
   _operations = [NSMutableArray new];
 
   _transitionManager = [[ABI44_0_0REATransitionManager alloc] initWithUIManager:self.bridge.uiManager];
@@ -45,55 +40,51 @@ ABI44_0_0RCT_EXPORT_MODULE(ReanimatedModule);
   [bridge.uiManager.observerCoordinator addObserver:self];
 }
 
-#pragma mark -- Transitioning API
+#pragma mark-- Transitioning API
 
-ABI44_0_0RCT_EXPORT_METHOD(animateNextTransition:(nonnull NSNumber *)rootTag config:(NSDictionary *)config)
+ABI44_0_0RCT_EXPORT_METHOD(animateNextTransition : (nonnull NSNumber *)rootTag config : (NSDictionary *)config)
 {
   [_transitionManager animateNextTransitionInRoot:rootTag withConfig:config];
 }
 
-#pragma mark -- API
+#pragma mark-- API
 
-ABI44_0_0RCT_EXPORT_METHOD(createNode:(nonnull NSNumber *)nodeID
-                  config:(NSDictionary<NSString *, id> *)config)
+ABI44_0_0RCT_EXPORT_METHOD(createNode : (nonnull NSNumber *)nodeID config : (NSDictionary<NSString *, id> *)config)
 {
   [self addOperationBlock:^(ABI44_0_0REANodesManager *nodesManager) {
     [nodesManager createNode:nodeID config:config];
   }];
 }
 
-ABI44_0_0RCT_EXPORT_METHOD(dropNode:(nonnull NSNumber *)nodeID)
+ABI44_0_0RCT_EXPORT_METHOD(dropNode : (nonnull NSNumber *)nodeID)
 {
   [self addOperationBlock:^(ABI44_0_0REANodesManager *nodesManager) {
     [nodesManager dropNode:nodeID];
   }];
 }
 
-ABI44_0_0RCT_EXPORT_METHOD(getValue:(nonnull NSNumber *)nodeID
-                  callback:(ABI44_0_0RCTResponseSenderBlock)callback) {
+ABI44_0_0RCT_EXPORT_METHOD(getValue : (nonnull NSNumber *)nodeID callback : (ABI44_0_0RCTResponseSenderBlock)callback)
+{
   [self addOperationBlock:^(ABI44_0_0REANodesManager *nodesManager) {
     [nodesManager getValue:nodeID callback:(ABI44_0_0RCTResponseSenderBlock)callback];
   }];
 }
 
-ABI44_0_0RCT_EXPORT_METHOD(connectNodes:(nonnull NSNumber *)parentID
-                  childTag:(nonnull NSNumber *)childID)
+ABI44_0_0RCT_EXPORT_METHOD(connectNodes : (nonnull NSNumber *)parentID childTag : (nonnull NSNumber *)childID)
 {
   [self addOperationBlock:^(ABI44_0_0REANodesManager *nodesManager) {
     [nodesManager connectNodes:parentID childID:childID];
   }];
 }
 
-ABI44_0_0RCT_EXPORT_METHOD(disconnectNodes:(nonnull NSNumber *)parentID
-                  childTag:(nonnull NSNumber *)childID)
+ABI44_0_0RCT_EXPORT_METHOD(disconnectNodes : (nonnull NSNumber *)parentID childTag : (nonnull NSNumber *)childID)
 {
   [self addOperationBlock:^(ABI44_0_0REANodesManager *nodesManager) {
     [nodesManager disconnectNodes:parentID childID:childID];
   }];
 }
 
-ABI44_0_0RCT_EXPORT_METHOD(connectNodeToView:(nonnull NSNumber *)nodeID
-                  viewTag:(nonnull NSNumber *)viewTag)
+ABI44_0_0RCT_EXPORT_METHOD(connectNodeToView : (nonnull NSNumber *)nodeID viewTag : (nonnull NSNumber *)viewTag)
 {
   NSString *viewName = [self.bridge.uiManager viewNameForABI44_0_0ReactTag:viewTag];
   [self addOperationBlock:^(ABI44_0_0REANodesManager *nodesManager) {
@@ -101,43 +92,43 @@ ABI44_0_0RCT_EXPORT_METHOD(connectNodeToView:(nonnull NSNumber *)nodeID
   }];
 }
 
-ABI44_0_0RCT_EXPORT_METHOD(disconnectNodeFromView:(nonnull NSNumber *)nodeID
-                  viewTag:(nonnull NSNumber *)viewTag)
+ABI44_0_0RCT_EXPORT_METHOD(disconnectNodeFromView : (nonnull NSNumber *)nodeID viewTag : (nonnull NSNumber *)viewTag)
 {
   [self addOperationBlock:^(ABI44_0_0REANodesManager *nodesManager) {
     [nodesManager disconnectNodeFromView:nodeID viewTag:viewTag];
   }];
 }
 
-ABI44_0_0RCT_EXPORT_METHOD(attachEvent:(nonnull NSNumber *)viewTag
-                  eventName:(nonnull NSString *)eventName
-                  eventNodeID:(nonnull NSNumber *)eventNodeID)
+ABI44_0_0RCT_EXPORT_METHOD(attachEvent
+                  : (nonnull NSNumber *)viewTag eventName
+                  : (nonnull NSString *)eventName eventNodeID
+                  : (nonnull NSNumber *)eventNodeID)
 {
   [self addOperationBlock:^(ABI44_0_0REANodesManager *nodesManager) {
     [nodesManager attachEvent:viewTag eventName:eventName eventNodeID:eventNodeID];
   }];
 }
 
-ABI44_0_0RCT_EXPORT_METHOD(detachEvent:(nonnull NSNumber *)viewTag
-                  eventName:(nonnull NSString *)eventName
-                  eventNodeID:(nonnull NSNumber *)eventNodeID)
+ABI44_0_0RCT_EXPORT_METHOD(detachEvent
+                  : (nonnull NSNumber *)viewTag eventName
+                  : (nonnull NSString *)eventName eventNodeID
+                  : (nonnull NSNumber *)eventNodeID)
 {
   [self addOperationBlock:^(ABI44_0_0REANodesManager *nodesManager) {
     [nodesManager detachEvent:viewTag eventName:eventName eventNodeID:eventNodeID];
   }];
 }
 
-ABI44_0_0RCT_EXPORT_METHOD(configureProps:(nonnull NSArray<NSString *> *)nativeProps
-                         uiProps:(nonnull NSArray<NSString *> *)uiProps)
+ABI44_0_0RCT_EXPORT_METHOD(configureProps
+                  : (nonnull NSArray<NSString *> *)nativeProps uiProps
+                  : (nonnull NSArray<NSString *> *)uiProps)
 {
   [self addOperationBlock:^(ABI44_0_0REANodesManager *nodesManager) {
     [nodesManager configureProps:[NSSet setWithArray:nativeProps] uiProps:[NSSet setWithArray:uiProps]];
   }];
 }
 
-ABI44_0_0RCT_EXPORT_METHOD(setValue:(nonnull NSNumber *)nodeID
-                  newValue:(nonnull NSNumber *)newValue
-                  )
+ABI44_0_0RCT_EXPORT_METHOD(setValue : (nonnull NSNumber *)nodeID newValue : (nonnull NSNumber *)newValue)
 {
   [self addOperationBlock:^(ABI44_0_0REANodesManager *nodesManager) {
     [nodesManager setValueForNodeID:nodeID value:newValue];
@@ -151,7 +142,7 @@ ABI44_0_0RCT_EXPORT_METHOD(triggerRender)
   }];
 }
 
-#pragma mark -- Batch handling
+#pragma mark-- Batch handling
 
 - (void)addOperationBlock:(AnimatedOperation)operation
 {
@@ -179,11 +170,11 @@ ABI44_0_0RCT_EXPORT_METHOD(triggerRender)
   }];
 }
 
-#pragma mark -- Events
+#pragma mark-- Events
 
 - (NSArray<NSString *> *)supportedEvents
 {
-  return @[@"onReanimatedCall", @"onReanimatedPropsChange"];
+  return @[ @"onReanimatedCall", @"onReanimatedPropsChange" ];
 }
 
 - (void)eventDispatcherWillDispatchEvent:(id<ABI44_0_0RCTEvent>)event

--- a/ios/vendored/sdk44/react-native-reanimated/ios/ABI44_0_0REANodesManager.h
+++ b/ios/vendored/sdk44/react-native-reanimated/ios/ABI44_0_0REANodesManager.h
@@ -1,8 +1,8 @@
 #import <Foundation/Foundation.h>
 
-#import "ABI44_0_0REANode.h"
 #import <ABI44_0_0React/ABI44_0_0RCTBridgeModule.h>
 #import <ABI44_0_0React/ABI44_0_0RCTUIManager.h>
+#import "ABI44_0_0REANode.h"
 
 @class ABI44_0_0REAModule;
 
@@ -19,10 +19,9 @@ typedef void (^ABI44_0_0REAEventHandler)(NSString *eventName, id<ABI44_0_0RCTEve
 @property (nonatomic, nullable) NSSet<NSString *> *uiProps;
 @property (nonatomic, nullable) NSSet<NSString *> *nativeProps;
 
-- (nonnull instancetype)initWithModule:(ABI44_0_0REAModule *)reanimatedModule
-                             uiManager:(nonnull ABI44_0_0RCTUIManager *)uiManager;
+- (nonnull instancetype)initWithModule:(ABI44_0_0REAModule *)reanimatedModule uiManager:(nonnull ABI44_0_0RCTUIManager *)uiManager;
 
-- (ABI44_0_0REANode* _Nullable)findNodeByID:(nonnull ABI44_0_0REANodeID)nodeID;
+- (ABI44_0_0REANode *_Nullable)findNodeByID:(nonnull ABI44_0_0REANodeID)nodeID;
 
 - (void)invalidate;
 
@@ -34,31 +33,26 @@ typedef void (^ABI44_0_0REAEventHandler)(NSString *eventName, id<ABI44_0_0RCTEve
 - (void)postRunUpdatesAfterAnimation;
 - (void)registerEventHandler:(ABI44_0_0REAEventHandler)eventHandler;
 - (void)enqueueUpdateViewOnNativeThread:(nonnull NSNumber *)ABI44_0_0ReactTag
-                               viewName:(NSString *) viewName
+                               viewName:(NSString *)viewName
                             nativeProps:(NSMutableDictionary *)nativeProps
                        trySynchronously:(BOOL)trySync;
-- (void)getValue:(ABI44_0_0REANodeID)nodeID
-        callback:(ABI44_0_0RCTResponseSenderBlock)callback;
+- (void)getValue:(ABI44_0_0REANodeID)nodeID callback:(ABI44_0_0RCTResponseSenderBlock)callback;
 
 // graph
 
-- (void)createNode:(nonnull ABI44_0_0REANodeID)tag
-            config:(NSDictionary<NSString *, id> *__nonnull)config;
+- (void)createNode:(nonnull ABI44_0_0REANodeID)tag config:(NSDictionary<NSString *, id> *__nonnull)config;
 
 - (void)dropNode:(nonnull ABI44_0_0REANodeID)tag;
 
-- (void)connectNodes:(nonnull ABI44_0_0REANodeID)parentID
-             childID:(nonnull ABI44_0_0REANodeID)childID;
+- (void)connectNodes:(nonnull ABI44_0_0REANodeID)parentID childID:(nonnull ABI44_0_0REANodeID)childID;
 
-- (void)disconnectNodes:(nonnull ABI44_0_0REANodeID)parentID
-                childID:(nonnull ABI44_0_0REANodeID)childID;
+- (void)disconnectNodes:(nonnull ABI44_0_0REANodeID)parentID childID:(nonnull ABI44_0_0REANodeID)childID;
 
 - (void)connectNodeToView:(nonnull ABI44_0_0REANodeID)nodeID
                   viewTag:(nonnull NSNumber *)viewTag
                  viewName:(nonnull NSString *)viewName;
 
-- (void)disconnectNodeFromView:(nonnull ABI44_0_0REANodeID)nodeID
-                       viewTag:(nonnull NSNumber *)viewTag;
+- (void)disconnectNodeFromView:(nonnull ABI44_0_0REANodeID)nodeID viewTag:(nonnull NSNumber *)viewTag;
 
 - (void)attachEvent:(nonnull NSNumber *)viewTag
           eventName:(nonnull NSString *)eventName
@@ -70,15 +64,13 @@ typedef void (^ABI44_0_0REAEventHandler)(NSString *eventName, id<ABI44_0_0RCTEve
 
 // configuration
 
-- (void)configureProps:(nonnull NSSet<NSString *> *)nativeProps
-               uiProps:(nonnull NSSet<NSString *> *)uiProps;
+- (void)configureProps:(nonnull NSSet<NSString *> *)nativeProps uiProps:(nonnull NSSet<NSString *> *)uiProps;
 
 - (void)updateProps:(nonnull NSDictionary *)props
       ofViewWithTag:(nonnull NSNumber *)viewTag
            withName:(nonnull NSString *)viewName;
 
-- (NSString*)obtainProp:(nonnull NSNumber *)viewTag
-          propName:(nonnull NSString *)propName;
+- (NSString *)obtainProp:(nonnull NSNumber *)viewTag propName:(nonnull NSString *)propName;
 
 // events
 

--- a/ios/vendored/sdk44/react-native-reanimated/ios/ABI44_0_0REANodesManager.m
+++ b/ios/vendored/sdk44/react-native-reanimated/ios/ABI44_0_0REANodesManager.m
@@ -2,27 +2,27 @@
 
 #import <ABI44_0_0React/ABI44_0_0RCTConvert.h>
 
+#import <ABI44_0_0React/ABI44_0_0RCTShadowView.h>
+#import "Nodes/ABI44_0_0REAAlwaysNode.h"
+#import "Nodes/ABI44_0_0REABezierNode.h"
+#import "Nodes/ABI44_0_0REABlockNode.h"
+#import "Nodes/ABI44_0_0REACallFuncNode.h"
+#import "Nodes/ABI44_0_0REAClockNodes.h"
+#import "Nodes/ABI44_0_0REAConcatNode.h"
+#import "Nodes/ABI44_0_0REACondNode.h"
+#import "Nodes/ABI44_0_0READebugNode.h"
+#import "Nodes/ABI44_0_0REAEventNode.h"
+#import "Nodes/ABI44_0_0REAFunctionNode.h"
+#import "Nodes/ABI44_0_0REAJSCallNode.h"
 #import "Nodes/ABI44_0_0REANode.h"
+#import "Nodes/ABI44_0_0REAOperatorNode.h"
+#import "Nodes/ABI44_0_0REAParamNode.h"
 #import "Nodes/ABI44_0_0REAPropsNode.h"
+#import "Nodes/ABI44_0_0REASetNode.h"
 #import "Nodes/ABI44_0_0REAStyleNode.h"
 #import "Nodes/ABI44_0_0REATransformNode.h"
 #import "Nodes/ABI44_0_0REAValueNode.h"
-#import "Nodes/ABI44_0_0REABlockNode.h"
-#import "Nodes/ABI44_0_0REACondNode.h"
-#import "Nodes/ABI44_0_0REAOperatorNode.h"
-#import "Nodes/ABI44_0_0REASetNode.h"
-#import "Nodes/ABI44_0_0READebugNode.h"
-#import "Nodes/ABI44_0_0REAClockNodes.h"
-#import "Nodes/ABI44_0_0REAJSCallNode.h"
-#import "Nodes/ABI44_0_0REABezierNode.h"
-#import "Nodes/ABI44_0_0REAEventNode.h"
 #import "ABI44_0_0REAModule.h"
-#import "Nodes/ABI44_0_0REAAlwaysNode.h"
-#import "Nodes/ABI44_0_0REAConcatNode.h"
-#import "Nodes/ABI44_0_0REAParamNode.h"
-#import "Nodes/ABI44_0_0REAFunctionNode.h"
-#import "Nodes/ABI44_0_0REACallFuncNode.h"
-#import <ABI44_0_0React/ABI44_0_0RCTShadowView.h>
 
 // Interface below has been added in order to use private methods of ABI44_0_0RCTUIManager,
 // ABI44_0_0RCTUIManager#UpdateView is a ABI44_0_0React Method which is exported to JS but in
@@ -32,9 +32,7 @@
 
 @interface ABI44_0_0RCTUIManager ()
 
-- (void)updateView:(nonnull NSNumber *)ABI44_0_0ReactTag
-          viewName:(NSString *)viewName
-             props:(NSDictionary *)props;
+- (void)updateView:(nonnull NSNumber *)ABI44_0_0ReactTag viewName:(NSString *)viewName props:(NSDictionary *)props;
 
 - (void)setNeedsLayout;
 
@@ -84,13 +82,11 @@
 
 @end
 
-@interface ABI44_0_0REANodesManager() <ABI44_0_0RCTUIManagerObserver>
+@interface ABI44_0_0REANodesManager () <ABI44_0_0RCTUIManagerObserver>
 
 @end
 
-
-@implementation ABI44_0_0REANodesManager
-{
+@implementation ABI44_0_0REANodesManager {
   NSMutableDictionary<ABI44_0_0REANodeID, ABI44_0_0REANode *> *_nodes;
   NSMapTable<NSString *, ABI44_0_0REANode *> *_eventMapping;
   NSMutableArray<id<ABI44_0_0RCTEvent>> *_eventQueue;
@@ -105,8 +101,7 @@
   volatile void (^_mounting)(void);
 }
 
-- (instancetype)initWithModule:(ABI44_0_0REAModule *)reanimatedModule
-                     uiManager:(ABI44_0_0RCTUIManager *)uiManager
+- (instancetype)initWithModule:(ABI44_0_0REAModule *)reanimatedModule uiManager:(ABI44_0_0RCTUIManager *)uiManager
 {
   if ((self = [super init])) {
     _reanimatedModule = reanimatedModule;
@@ -119,8 +114,9 @@
     _onAnimationCallbacks = [NSMutableArray new];
     _operationsInBatch = [NSMutableArray new];
   }
-    
+
   _displayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(onAnimationFrame:)];
+  _displayLink.preferredFramesPerSecond = 120; // will fallback to 60 fps for devices without Pro Motion display
   [_displayLink addToRunLoop:[NSRunLoop mainRunLoop] forMode:NSRunLoopCommonModes];
   [_displayLink setPaused:true];
   return self;
@@ -172,14 +168,14 @@
 
 - (void)startUpdatingOnAnimationFrame
 {
-    // Setting _currentAnimationTimestamp here is connected with manual triggering of performOperations
-    // in operationsBatchDidComplete. If new node has been created and clock has not been started,
-    // _displayLink won't be initialized soon enough and _displayLink.timestamp will be 0.
-    // However, CADisplayLink is using CACurrentMediaTime so if there's need to perform one more
-    // evaluation, it could be used it here. In usual case, CACurrentMediaTime is not being used in
-    // favor of setting it with _displayLink.timestamp in onAnimationFrame method.
-    _currentAnimationTimestamp = CACurrentMediaTime();
-    [_displayLink setPaused:false];
+  // Setting _currentAnimationTimestamp here is connected with manual triggering of performOperations
+  // in operationsBatchDidComplete. If new node has been created and clock has not been started,
+  // _displayLink won't be initialized soon enough and _displayLink.timestamp will be 0.
+  // However, CADisplayLink is using CACurrentMediaTime so if there's need to perform one more
+  // evaluation, it could be used it here. In usual case, CACurrentMediaTime is not being used in
+  // favor of setting it with _displayLink.timestamp in onAnimationFrame method.
+  _currentAnimationTimestamp = CACurrentMediaTime();
+  [_displayLink setPaused:false];
 }
 
 - (void)stopUpdatingOnAnimationFrame
@@ -217,7 +213,8 @@
   }
 }
 
-- (BOOL)uiManager:(ABI44_0_0RCTUIManager *)manager performMountingWithBlock:(ABI44_0_0RCTUIManagerMountingBlock)block {
+- (BOOL)uiManager:(ABI44_0_0RCTUIManager *)manager performMountingWithBlock:(ABI44_0_0RCTUIManagerMountingBlock)block
+{
   ABI44_0_0RCTAssert(_mounting == nil, @"Mouting block is expected to not be set");
   _mounting = block;
   return YES;
@@ -234,7 +231,7 @@
 
     BOOL trySynchronously = _tryRunBatchUpdatesSynchronously;
     _tryRunBatchUpdatesSynchronously = NO;
-    
+
     __weak typeof(self) weakSelf = self;
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
     ABI44_0_0RCTExecuteOnUIManagerQueue(^{
@@ -243,27 +240,27 @@
         return;
       }
       BOOL canUpdateSynchronously = trySynchronously && ![strongSelf.uiManager hasEnqueuedUICommands];
-      
+
       if (!canUpdateSynchronously) {
         dispatch_semaphore_signal(semaphore);
       }
-      
+
       for (int i = 0; i < copiedOperationsQueue.count; i++) {
         copiedOperationsQueue[i](strongSelf.uiManager);
       }
-      
+
       if (canUpdateSynchronously) {
         [strongSelf.uiManager runSyncUIUpdatesWithObserver:self];
         dispatch_semaphore_signal(semaphore);
       }
-      //In case canUpdateSynchronously=true we still have to send uiManagerWillPerformMounting event 
-      //to observers because some components (e.g. TextInput) update their UIViews only on that event.
+      // In case canUpdateSynchronously=true we still have to send uiManagerWillPerformMounting event
+      // to observers because some components (e.g. TextInput) update their UIViews only on that event.
       [strongSelf.uiManager setNeedsLayout];
     });
     if (trySynchronously) {
       dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
     }
-    
+
     if (_mounting) {
       _mounting();
       _mounting = nil;
@@ -273,9 +270,10 @@
 }
 
 - (void)enqueueUpdateViewOnNativeThread:(nonnull NSNumber *)ABI44_0_0ReactTag
-                               viewName:(NSString *) viewName
+                               viewName:(NSString *)viewName
                             nativeProps:(NSMutableDictionary *)nativeProps
-                       trySynchronously:(BOOL)trySync {
+                       trySynchronously:(BOOL)trySync
+{
   if (trySync) {
     _tryRunBatchUpdatesSynchronously = YES;
   }
@@ -284,49 +282,48 @@
   }];
 }
 
-- (void)getValue:(ABI44_0_0REANodeID)nodeID
-        callback:(ABI44_0_0RCTResponseSenderBlock)callback
+- (void)getValue:(ABI44_0_0REANodeID)nodeID callback:(ABI44_0_0RCTResponseSenderBlock)callback
 {
   id val = _nodes[nodeID].value;
   if (val) {
-    callback(@[val]);
+    callback(@[ val ]);
   } else {
     // NULL is not an object and it's not possible to pass it as callback's argument
-    callback(@[[NSNull null]]);
+    callback(@[ [NSNull null] ]);
   }
 }
 
-#pragma mark -- Graph
+#pragma mark-- Graph
 
-- (void)createNode:(ABI44_0_0REANodeID)nodeID
-            config:(NSDictionary<NSString *, id> *)config
+- (void)createNode:(ABI44_0_0REANodeID)nodeID config:(NSDictionary<NSString *, id> *)config
 {
   static NSDictionary *map;
   static dispatch_once_t mapToken;
   dispatch_once(&mapToken, ^{
-    map = @{@"props": [ABI44_0_0REAPropsNode class],
-            @"style": [ABI44_0_0REAStyleNode class],
-            @"transform": [ABI44_0_0REATransformNode class],
-            @"value": [ABI44_0_0REAValueNode class],
-            @"block": [ABI44_0_0REABlockNode class],
-            @"cond": [ABI44_0_0REACondNode class],
-            @"op": [ABI44_0_0REAOperatorNode class],
-            @"set": [ABI44_0_0REASetNode class],
-            @"debug": [ABI44_0_0READebugNode class],
-            @"clock": [ABI44_0_0REAClockNode class],
-            @"clockStart": [ABI44_0_0REAClockStartNode class],
-            @"clockStop": [ABI44_0_0REAClockStopNode class],
-            @"clockTest": [ABI44_0_0REAClockTestNode class],
-            @"call": [ABI44_0_0REAJSCallNode class],
-            @"bezier": [ABI44_0_0REABezierNode class],
-            @"event": [ABI44_0_0REAEventNode class],
-            @"always": [ABI44_0_0REAAlwaysNode class],
-            @"concat": [ABI44_0_0REAConcatNode class],
-            @"param": [ABI44_0_0REAParamNode class],
-            @"func": [ABI44_0_0REAFunctionNode class],
-            @"callfunc": [ABI44_0_0REACallFuncNode class]
-//            @"listener": nil,
-            };
+    map = @{
+      @"props" : [ABI44_0_0REAPropsNode class],
+      @"style" : [ABI44_0_0REAStyleNode class],
+      @"transform" : [ABI44_0_0REATransformNode class],
+      @"value" : [ABI44_0_0REAValueNode class],
+      @"block" : [ABI44_0_0REABlockNode class],
+      @"cond" : [ABI44_0_0REACondNode class],
+      @"op" : [ABI44_0_0REAOperatorNode class],
+      @"set" : [ABI44_0_0REASetNode class],
+      @"debug" : [ABI44_0_0READebugNode class],
+      @"clock" : [ABI44_0_0REAClockNode class],
+      @"clockStart" : [ABI44_0_0REAClockStartNode class],
+      @"clockStop" : [ABI44_0_0REAClockStopNode class],
+      @"clockTest" : [ABI44_0_0REAClockTestNode class],
+      @"call" : [ABI44_0_0REAJSCallNode class],
+      @"bezier" : [ABI44_0_0REABezierNode class],
+      @"event" : [ABI44_0_0REAEventNode class],
+      @"always" : [ABI44_0_0REAAlwaysNode class],
+      @"concat" : [ABI44_0_0REAConcatNode class],
+      @"param" : [ABI44_0_0REAParamNode class],
+      @"func" : [ABI44_0_0REAFunctionNode class],
+      @"callfunc" : [ABI44_0_0REACallFuncNode class]
+      //            @"listener": nil,
+    };
   });
 
   NSString *nodeType = [ABI44_0_0RCTConvert NSString:config[@"type"]];
@@ -378,9 +375,7 @@
   [parentNode removeChild:childNode];
 }
 
-- (void)connectNodeToView:(ABI44_0_0REANodeID)nodeID
-                  viewTag:(NSNumber *)viewTag
-                 viewName:(NSString *)viewName
+- (void)connectNodeToView:(ABI44_0_0REANodeID)nodeID viewTag:(NSNumber *)viewTag viewName:(NSString *)viewName
 {
   ABI44_0_0RCTAssertParam(nodeID);
   ABI44_0_0REANode *node = _nodes[nodeID];
@@ -391,8 +386,7 @@
   }
 }
 
-- (void)disconnectNodeFromView:(ABI44_0_0REANodeID)nodeID
-                       viewTag:(NSNumber *)viewTag
+- (void)disconnectNodeFromView:(ABI44_0_0REANodeID)nodeID viewTag:(NSNumber *)viewTag
 {
   ABI44_0_0RCTAssertParam(nodeID);
   ABI44_0_0REANode *node = _nodes[nodeID];
@@ -403,36 +397,26 @@
   }
 }
 
-- (void)attachEvent:(NSNumber *)viewTag
-          eventName:(NSString *)eventName
-        eventNodeID:(ABI44_0_0REANodeID)eventNodeID
+- (void)attachEvent:(NSNumber *)viewTag eventName:(NSString *)eventName eventNodeID:(ABI44_0_0REANodeID)eventNodeID
 {
   ABI44_0_0RCTAssertParam(eventNodeID);
   ABI44_0_0REANode *eventNode = _nodes[eventNodeID];
   ABI44_0_0RCTAssert([eventNode isKindOfClass:[ABI44_0_0REAEventNode class]], @"Event node is of an invalid type");
 
-  NSString *key = [NSString stringWithFormat:@"%@%@",
-                   viewTag,
-                   ABI44_0_0RCTNormalizeInputEventName(eventName)];
+  NSString *key = [NSString stringWithFormat:@"%@%@", viewTag, ABI44_0_0RCTNormalizeInputEventName(eventName)];
   ABI44_0_0RCTAssert([_eventMapping objectForKey:key] == nil, @"Event handler already set for the given view and event type");
   [_eventMapping setObject:eventNode forKey:key];
 }
 
-- (void)detachEvent:(NSNumber *)viewTag
-          eventName:(NSString *)eventName
-        eventNodeID:(ABI44_0_0REANodeID)eventNodeID
+- (void)detachEvent:(NSNumber *)viewTag eventName:(NSString *)eventName eventNodeID:(ABI44_0_0REANodeID)eventNodeID
 {
-  NSString *key = [NSString stringWithFormat:@"%@%@",
-                   viewTag,
-                   ABI44_0_0RCTNormalizeInputEventName(eventName)];
+  NSString *key = [NSString stringWithFormat:@"%@%@", viewTag, ABI44_0_0RCTNormalizeInputEventName(eventName)];
   [_eventMapping removeObjectForKey:key];
 }
 
 - (void)processEvent:(id<ABI44_0_0RCTEvent>)event
 {
-  NSString *key = [NSString stringWithFormat:@"%@%@",
-                   event.viewTag,
-                   ABI44_0_0RCTNormalizeInputEventName(event.eventName)];
+  NSString *key = [NSString stringWithFormat:@"%@%@", event.viewTag, ABI44_0_0RCTNormalizeInputEventName(event.eventName)];
   ABI44_0_0REAEventNode *eventNode = [_eventMapping objectForKey:key];
   [eventNode processEvent:event];
 }
@@ -465,18 +449,14 @@
 
 - (void)dispatchEvent:(id<ABI44_0_0RCTEvent>)event
 {
-  NSString *key = [NSString stringWithFormat:@"%@%@",
-                   event.viewTag,
-                   ABI44_0_0RCTNormalizeInputEventName(event.eventName)];
+  NSString *key = [NSString stringWithFormat:@"%@%@", event.viewTag, ABI44_0_0RCTNormalizeInputEventName(event.eventName)];
 
-  NSString *eventHash = [NSString stringWithFormat:@"%@%@",
-  event.viewTag,
-  event.eventName];
+  NSString *eventHash = [NSString stringWithFormat:@"%@%@", event.viewTag, event.eventName];
 
   if (_eventHandler != nil) {
     __weak ABI44_0_0REAEventHandler eventHandler = _eventHandler;
     __weak typeof(self) weakSelf = self;
-    ABI44_0_0RCTExecuteOnMainQueue(^void(){
+    ABI44_0_0RCTExecuteOnMainQueue(^void() {
       __typeof__(self) strongSelf = weakSelf;
       if (strongSelf == nil) {
         return;
@@ -506,8 +486,7 @@
   }
 }
 
-- (void)configureProps:(NSSet<NSString *> *)nativeProps
-               uiProps:(NSSet<NSString *> *)uiProps
+- (void)configureProps:(NSSet<NSString *> *)nativeProps uiProps:(NSSet<NSString *> *)uiProps
 {
   _uiProps = uiProps;
   _nativeProps = nativeProps;
@@ -532,7 +511,7 @@
   NSMutableDictionary *nativeProps = [NSMutableDictionary new];
   NSMutableDictionary *jsProps = [NSMutableDictionary new];
 
-  void (^addBlock)(NSString *key, id obj, BOOL * stop) = ^(NSString *key, id obj, BOOL * stop){
+  void (^addBlock)(NSString *key, id obj, BOOL *stop) = ^(NSString *key, id obj, BOOL *stop) {
     if ([self.uiProps containsObject:key]) {
       uiProps[key] = obj;
     } else if ([self.nativeProps containsObject:key]) {
@@ -545,36 +524,33 @@
   [props enumerateKeysAndObjectsUsingBlock:addBlock];
 
   if (uiProps.count > 0) {
-    [self.uiManager
-     synchronouslyUpdateViewOnUIThread:viewTag
-     viewName:viewName
-     props:uiProps];
-    }
-    if (nativeProps.count > 0) {
-      [self enqueueUpdateViewOnNativeThread:viewTag viewName:viewName nativeProps:nativeProps trySynchronously:YES];
-    }
-    if (jsProps.count > 0) {
-      [self.reanimatedModule sendEventWithName:@"onReanimatedPropsChange"
-                                          body:@{@"viewTag": viewTag, @"props": jsProps }];
-    }
+    [self.uiManager synchronouslyUpdateViewOnUIThread:viewTag viewName:viewName props:uiProps];
+  }
+  if (nativeProps.count > 0) {
+    [self enqueueUpdateViewOnNativeThread:viewTag viewName:viewName nativeProps:nativeProps trySynchronously:YES];
+  }
+  if (jsProps.count > 0) {
+    [self.reanimatedModule sendEventWithName:@"onReanimatedPropsChange"
+                                        body:@{@"viewTag" : viewTag, @"props" : jsProps}];
+  }
 }
 
-- (NSString*)obtainProp:(nonnull NSNumber *)viewTag
-               propName:(nonnull NSString *)propName
+- (NSString *)obtainProp:(nonnull NSNumber *)viewTag propName:(nonnull NSString *)propName
 {
-    UIView* view = [self.uiManager viewForABI44_0_0ReactTag:viewTag];
-    
-    NSString* result = [NSString stringWithFormat:@"error: unknown propName %@, currently supported: opacity, zIndex", propName];
-    
-    if ([propName isEqualToString:@"opacity"]) {
-        CGFloat alpha = view.alpha;
-        result = [@(alpha) stringValue];
-    } else if ([propName isEqualToString:@"zIndex"]) {
-        NSInteger zIndex = view.ABI44_0_0ReactZIndex;
-        result = [@(zIndex) stringValue];
-    }
-    
-    return result;
+  UIView *view = [self.uiManager viewForABI44_0_0ReactTag:viewTag];
+
+  NSString *result =
+      [NSString stringWithFormat:@"error: unknown propName %@, currently supported: opacity, zIndex", propName];
+
+  if ([propName isEqualToString:@"opacity"]) {
+    CGFloat alpha = view.alpha;
+    result = [@(alpha) stringValue];
+  } else if ([propName isEqualToString:@"zIndex"]) {
+    NSInteger zIndex = view.ABI44_0_0ReactZIndex;
+    result = [@(zIndex) stringValue];
+  }
+
+  return result;
 }
 
 @end

--- a/ios/vendored/sdk44/react-native-reanimated/ios/ABI44_0_0REAUtils.h
+++ b/ios/vendored/sdk44/react-native-reanimated/ios/ABI44_0_0REAUtils.h
@@ -1,5 +1,7 @@
 #import <Foundation/Foundation.h>
 
-#define ABI44_0_0REA_LOG_ERROR_IF_NIL(value, errorMsg) ({\
-  if (value == nil) ABI44_0_0RCTLogError(errorMsg);\
-})
+#define ABI44_0_0REA_LOG_ERROR_IF_NIL(value, errorMsg) \
+  ({                                          \
+    if (value == nil)                         \
+      ABI44_0_0RCTLogError(errorMsg);                  \
+  })

--- a/ios/vendored/sdk44/react-native-reanimated/ios/ABI44_0_0RNGestureHandlerStateManager.h
+++ b/ios/vendored/sdk44/react-native-reanimated/ios/ABI44_0_0RNGestureHandlerStateManager.h
@@ -1,0 +1,5 @@
+@protocol ABI44_0_0RNGestureHandlerStateManager
+
+- (void)setGestureState:(int)state forHandler:(int)handlerTag;
+
+@end

--- a/ios/vendored/sdk44/react-native-reanimated/ios/LayoutReanimation/ABI44_0_0REAAnimationsManager.h
+++ b/ios/vendored/sdk44/react-native-reanimated/ios/LayoutReanimation/ABI44_0_0REAAnimationsManager.h
@@ -1,0 +1,32 @@
+#import <Foundation/Foundation.h>
+#import <ABI44_0_0React/ABI44_0_0RCTUIManager.h>
+#import "ABI44_0_0REASnapshot.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef NS_ENUM(NSInteger, ViewState) {
+  Appearing,
+  Disappearing,
+  Layout,
+  Inactive,
+  ToRemove,
+};
+
+@interface ABI44_0_0REAAnimationsManager : NSObject
+
+- (instancetype)initWithUIManager:(ABI44_0_0RCTUIManager *)uiManager;
+- (void)setRemovingConfigBlock:(void (^)(NSNumber *tag))block;
+- (void)setAnimationStartingBlock:
+    (void (^)(NSNumber *tag, NSString *type, NSDictionary *target, NSNumber *depth))startAnimation;
+- (void)notifyAboutProgress:(NSDictionary *)newStyle tag:(NSNumber *)tag;
+- (void)notifyAboutEnd:(NSNumber *)tag cancelled:(BOOL)cancelled;
+- (void)invalidate;
+- (void)onViewRemoval:(UIView *)view before:(ABI44_0_0REASnapshot *)before;
+- (void)onViewCreate:(UIView *)view after:(ABI44_0_0REASnapshot *)after;
+- (void)onViewUpdate:(UIView *)view before:(ABI44_0_0REASnapshot *)before after:(ABI44_0_0REASnapshot *)after;
+- (void)setToBeRemovedRegistry:(NSMutableDictionary<NSNumber *, NSMutableSet<id<ABI44_0_0RCTComponent>> *> *)toBeRemovedRegister;
+- (void)removeLeftovers;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/vendored/sdk44/react-native-reanimated/ios/LayoutReanimation/ABI44_0_0REAAnimationsManager.m
+++ b/ios/vendored/sdk44/react-native-reanimated/ios/LayoutReanimation/ABI44_0_0REAAnimationsManager.m
@@ -1,0 +1,346 @@
+#import "ABI44_0_0REAAnimationsManager.h"
+#import <ABI44_0_0React/ABI44_0_0RCTComponentData.h>
+#import <ABI44_0_0React/ABI44_0_0RCTTextView.h>
+#import <ABI44_0_0React/ABI44_0_0UIView+Private.h>
+#import <ABI44_0_0React/ABI44_0_0UIView+React.h>
+#import "ABI44_0_0REAUIManager.h"
+
+@interface ABI44_0_0REAAnimationsManager ()
+
+typedef NS_ENUM(NSInteger, FrameConfigType) { EnteringFrame, ExitingFrame };
+
+@property (atomic, nullable) void (^startAnimationForTag)(NSNumber *, NSString *, NSDictionary *, NSNumber *);
+@property (atomic, nullable) void (^removeConfigForTag)(NSNumber *);
+
+- (void)removeLeftovers;
+- (void)scheduleCleaning;
+
+@end
+
+@implementation ABI44_0_0REAAnimationsManager {
+  ABI44_0_0RCTUIManager *_uiManager;
+  ABI44_0_0REAUIManager *_reaUiManager;
+  NSMutableDictionary<NSNumber *, NSNumber *> *_states;
+  NSMutableDictionary<NSNumber *, UIView *> *_viewForTag;
+  NSMutableSet<NSNumber *> *_toRemove;
+  NSMutableArray<NSString *> *_targetKeys;
+  NSMutableArray<NSString *> *_currentKeys;
+  BOOL _cleaningScheduled;
+}
+
++ (NSArray *)layoutKeys
+{
+  static NSArray *_array;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    _array = @[ @"originX", @"originY", @"width", @"height" ];
+  });
+  return _array;
+}
+
+- (instancetype)initWithUIManager:(ABI44_0_0RCTUIManager *)uiManager
+{
+  if (self = [super init]) {
+    _uiManager = uiManager;
+    _reaUiManager = (ABI44_0_0REAUIManager *)uiManager;
+    _states = [NSMutableDictionary new];
+    _viewForTag = [NSMutableDictionary new];
+    _toRemove = [NSMutableSet new];
+    _cleaningScheduled = false;
+
+    _targetKeys = [NSMutableArray new];
+    _currentKeys = [NSMutableArray new];
+    for (NSString *key in [[self class] layoutKeys]) {
+      [_targetKeys addObject:[NSString stringWithFormat:@"target%@", [key capitalizedString]]];
+      [_currentKeys addObject:[NSString stringWithFormat:@"current%@", [key capitalizedString]]];
+    }
+  }
+  return self;
+}
+
+- (void)invalidate
+{
+  _startAnimationForTag = nil;
+  _removeConfigForTag = nil;
+  _uiManager = nil;
+  _states = nil;
+  _viewForTag = nil;
+  _toRemove = nil;
+  _cleaningScheduled = false;
+  _targetKeys = nil;
+  _currentKeys = nil;
+}
+
+- (void)setAnimationStartingBlock:
+    (void (^)(NSNumber *tag, NSString *type, NSDictionary *yogaValues, NSNumber *depth))startAnimation
+{
+  _startAnimationForTag = startAnimation;
+}
+
+- (void)setRemovingConfigBlock:(void (^)(NSNumber *tag))block
+{
+  _removeConfigForTag = block;
+}
+
+- (void)scheduleCleaning
+{
+  if (_cleaningScheduled) {
+    return;
+  }
+  _cleaningScheduled = true;
+
+  __weak ABI44_0_0REAAnimationsManager *weakSelf = self;
+  dispatch_async(dispatch_get_main_queue(), ^{
+    self->_cleaningScheduled = false;
+    if (weakSelf == nil) {
+      return;
+    }
+    [self removeLeftovers];
+  });
+}
+
+- (void)findRoot:(UIView *)view roots:(NSMutableSet<NSNumber *> *)roots
+{
+  UIView *currentView = view;
+  NSNumber *lastToRemoveTag = nil;
+  while (currentView != nil) {
+    ViewState state = [_states[currentView.ABI44_0_0ReactTag] intValue];
+    if (state == Disappearing) {
+      return;
+    }
+    if (state == ToRemove) {
+      lastToRemoveTag = currentView.ABI44_0_0ReactTag;
+    }
+    currentView = currentView.superview;
+  }
+  if (lastToRemoveTag != nil) {
+    [roots addObject:lastToRemoveTag];
+  }
+}
+
+- (BOOL)dfs:(UIView *)root view:(UIView *)view cands:(NSMutableSet<NSNumber *> *)cands
+{
+  NSNumber *tag = view.ABI44_0_0ReactTag;
+  if (tag == nil) {
+    return true;
+  }
+  if (![cands containsObject:tag] && _states[tag] != nil) {
+    return true;
+  }
+  BOOL cannotStripe = false;
+  NSArray<UIView *> *toRemoveCopy = [view.ABI44_0_0ReactSubviews copy];
+  for (UIView *child in toRemoveCopy) {
+    if (![view isKindOfClass:[ABI44_0_0RCTTextView class]]) {
+      cannotStripe |= [self dfs:root view:child cands:cands];
+    }
+  }
+  if (!cannotStripe) {
+    if (view.ABI44_0_0ReactSuperview != nil) {
+      [_reaUiManager unregisterView:view];
+    }
+    [_states removeObjectForKey:tag];
+    [_viewForTag removeObjectForKey:tag];
+    [_toRemove removeObject:tag];
+  }
+  return cannotStripe;
+}
+
+- (void)removeLeftovers
+{
+  NSMutableSet<NSNumber *> *roots = [NSMutableSet new];
+  for (NSNumber *viewTag in _toRemove) {
+    UIView *view = _viewForTag[viewTag];
+    [self findRoot:view roots:roots];
+  }
+  for (NSNumber *viewTag in roots) {
+    UIView *view = _viewForTag[viewTag];
+    [self dfs:view view:view cands:_toRemove];
+  }
+}
+
+- (void)notifyAboutEnd:(NSNumber *)tag cancelled:(BOOL)cancelled
+{
+  if (!cancelled) {
+    ViewState state = [_states[tag] intValue];
+    if (state == Appearing) {
+      _states[tag] = [NSNumber numberWithInt:Layout];
+    }
+    if (state == Disappearing) {
+      _states[tag] = [NSNumber numberWithInt:ToRemove];
+      if (tag != nil) {
+        [_toRemove addObject:tag];
+      }
+      [self scheduleCleaning];
+    }
+  }
+}
+
+- (void)notifyAboutProgress:(NSDictionary *)newStyle tag:(NSNumber *)tag
+{
+  if (_states[tag] == nil) {
+    return;
+  }
+  ViewState state = [_states[tag] intValue];
+  if (state == Inactive) {
+    _states[tag] = [NSNumber numberWithInt:Appearing];
+  }
+
+  NSMutableDictionary *dataComponenetsByName = [_uiManager valueForKey:@"_componentDataByName"];
+  ABI44_0_0RCTComponentData *componentData = dataComponenetsByName[@"ABI44_0_0RCTView"];
+  [self setNewProps:[newStyle mutableCopy] forView:_viewForTag[tag] withComponentData:componentData];
+}
+
+- (void)setNewProps:(NSMutableDictionary *)newProps
+              forView:(UIView *)view
+    withComponentData:(ABI44_0_0RCTComponentData *)componentData
+{
+  if (newProps[@"height"]) {
+    double height = [newProps[@"height"] doubleValue];
+    double oldHeight = view.bounds.size.height;
+    view.bounds = CGRectMake(0, 0, view.bounds.size.width, height);
+    view.center = CGPointMake(view.center.x, view.center.y - oldHeight / 2.0 + view.bounds.size.height / 2.0);
+    [newProps removeObjectForKey:@"height"];
+  }
+  if (newProps[@"width"]) {
+    double width = [newProps[@"width"] doubleValue];
+    double oldWidth = view.bounds.size.width;
+    view.bounds = CGRectMake(0, 0, width, view.bounds.size.height);
+    view.center = CGPointMake(view.center.x + view.bounds.size.width / 2.0 - oldWidth / 2.0, view.center.y);
+    [newProps removeObjectForKey:@"width"];
+  }
+  if (newProps[@"originX"]) {
+    double originX = [newProps[@"originX"] doubleValue];
+    view.center = CGPointMake(originX + view.bounds.size.width / 2.0, view.center.y);
+    [newProps removeObjectForKey:@"originX"];
+  }
+  if (newProps[@"originY"]) {
+    double originY = [newProps[@"originY"] doubleValue];
+    view.center = CGPointMake(view.center.x, originY + view.bounds.size.height / 2.0);
+    [newProps removeObjectForKey:@"originY"];
+  }
+  [componentData setProps:newProps forView:view];
+}
+
+- (NSDictionary *)prepareDataForAnimatingWorklet:(NSMutableDictionary *)values frameConfig:(FrameConfigType)frameConfig
+{
+  UIView *windowView = UIApplication.sharedApplication.keyWindow;
+  if (frameConfig == EnteringFrame) {
+    NSDictionary *preparedData = @{
+      @"targetWidth" : values[@"width"],
+      @"targetHeight" : values[@"height"],
+      @"targetOriginX" : values[@"originX"],
+      @"targetOriginY" : values[@"originY"],
+      @"targetGlobalOriginX" : values[@"globalOriginX"],
+      @"targetGlobalOriginY" : values[@"globalOriginY"],
+      @"windowWidth" : [NSNumber numberWithDouble:windowView.bounds.size.width],
+      @"windowHeight" : [NSNumber numberWithDouble:windowView.bounds.size.height]
+    };
+    return preparedData;
+  } else {
+    NSDictionary *preparedData = @{
+      @"currentWidth" : values[@"width"],
+      @"currentHeight" : values[@"height"],
+      @"currentOriginX" : values[@"originX"],
+      @"currentOriginY" : values[@"originY"],
+      @"currentGlobalOriginX" : values[@"globalOriginX"],
+      @"currentGlobalOriginY" : values[@"globalOriginY"],
+      @"windowWidth" : [NSNumber numberWithDouble:windowView.bounds.size.width],
+      @"windowHeight" : [NSNumber numberWithDouble:windowView.bounds.size.height]
+    };
+    return preparedData;
+  }
+}
+
+- (NSDictionary *)prepareDataForLayoutAnimatingWorklet:(NSMutableDictionary *)currentValues
+                                          targetValues:(NSMutableDictionary *)targetValues
+{
+  UIView *windowView = UIApplication.sharedApplication.keyWindow;
+  NSDictionary *preparedData = @{
+    @"currentWidth" : currentValues[@"width"],
+    @"currentHeight" : currentValues[@"height"],
+    @"currentOriginX" : currentValues[@"originX"],
+    @"currentOriginY" : currentValues[@"originY"],
+    @"currentGlobalOriginX" : currentValues[@"globalOriginX"],
+    @"currentGlobalOriginY" : currentValues[@"globalOriginY"],
+    @"targetWidth" : targetValues[@"width"],
+    @"targetHeight" : targetValues[@"height"],
+    @"targetOriginX" : targetValues[@"originX"],
+    @"targetOriginY" : targetValues[@"originY"],
+    @"targetGlobalOriginX" : targetValues[@"globalOriginX"],
+    @"targetGlobalOriginY" : targetValues[@"globalOriginY"],
+    @"windowWidth" : [NSNumber numberWithDouble:windowView.bounds.size.width],
+    @"windowHeight" : [NSNumber numberWithDouble:windowView.bounds.size.height]
+  };
+  return preparedData;
+}
+
+- (void)onViewRemoval:(UIView *)view before:(ABI44_0_0REASnapshot *)before
+{
+  NSNumber *tag = view.ABI44_0_0ReactTag;
+  ViewState state = [_states[tag] intValue];
+  if (state == Disappearing || state == ToRemove || tag == nil) {
+    return;
+  }
+  NSMutableDictionary<NSString *, NSObject *> *startValues = before.values;
+  if (state == Inactive) {
+    if (startValues != nil) {
+      _states[tag] = [NSNumber numberWithInt:ToRemove];
+      [_toRemove addObject:tag];
+      [self scheduleCleaning];
+    }
+    return;
+  }
+  _states[tag] = [NSNumber numberWithInt:Disappearing];
+  NSDictionary *preparedValues = [self prepareDataForAnimatingWorklet:startValues frameConfig:ExitingFrame];
+  _startAnimationForTag(tag, @"exiting", preparedValues, @(0));
+}
+
+- (void)onViewCreate:(UIView *)view after:(ABI44_0_0REASnapshot *)after
+{
+  _reaUiManager.flushUiOperations();
+  NSNumber *tag = view.ABI44_0_0ReactTag;
+  if (_states[tag] == nil) {
+    _states[tag] = [NSNumber numberWithInt:Inactive];
+    _viewForTag[tag] = view;
+  }
+  NSMutableDictionary *targetValues = after.values;
+  ViewState state = [_states[tag] intValue];
+  if (state == Inactive) {
+    if (targetValues != nil) {
+      NSDictionary *preparedValues = [self prepareDataForAnimatingWorklet:targetValues frameConfig:EnteringFrame];
+      _startAnimationForTag(tag, @"entering", preparedValues, @(0));
+    }
+    return;
+  }
+}
+
+- (void)onViewUpdate:(UIView *)view before:(ABI44_0_0REASnapshot *)before after:(ABI44_0_0REASnapshot *)after
+{
+  NSNumber *tag = view.ABI44_0_0ReactTag;
+  NSMutableDictionary *targetValues = after.values;
+  NSMutableDictionary *currentValues = before.values;
+  if (_states[tag] == nil) {
+    return;
+  }
+  ViewState state = [_states[tag] intValue];
+  if (state == Disappearing || state == ToRemove || state == Inactive) {
+    return;
+  }
+  if (state == Appearing) {
+    BOOL doNotStartLayout = true;
+    for (int i = 0; i < [[self class] layoutKeys].count; ++i) {
+      if ([((NSNumber *)currentValues[_currentKeys[i]]) doubleValue] !=
+          [((NSNumber *)targetValues[_targetKeys[i]]) doubleValue]) {
+        doNotStartLayout = false;
+      }
+    }
+    if (doNotStartLayout) {
+      return;
+    }
+  }
+  _states[view.ABI44_0_0ReactTag] = [NSNumber numberWithInt:Layout];
+  NSDictionary *preparedValues = [self prepareDataForLayoutAnimatingWorklet:currentValues targetValues:targetValues];
+  _startAnimationForTag(view.ABI44_0_0ReactTag, @"layout", preparedValues, @(0));
+}
+
+@end

--- a/ios/vendored/sdk44/react-native-reanimated/ios/LayoutReanimation/ABI44_0_0REASnapshot.h
+++ b/ios/vendored/sdk44/react-native-reanimated/ios/LayoutReanimation/ABI44_0_0REASnapshot.h
@@ -1,0 +1,13 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ABI44_0_0REASnapshot : NSObject
+
+@property NSMutableDictionary *values;
+
+- (instancetype)init:(UIView *)view;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/vendored/sdk44/react-native-reanimated/ios/LayoutReanimation/ABI44_0_0REASnapshot.m
+++ b/ios/vendored/sdk44/react-native-reanimated/ios/LayoutReanimation/ABI44_0_0REASnapshot.m
@@ -1,0 +1,29 @@
+#import "ABI44_0_0REASnapshot.h"
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@implementation ABI44_0_0REASnapshot {
+  UIView *_view;
+}
+
+- (instancetype)init:(UIView *)view
+{
+  self = [super init];
+  _view = view;
+  UIView *windowView = UIApplication.sharedApplication.keyWindow;
+  CGPoint originFromRootPerspective = [[view superview] convertPoint:view.center toView:windowView];
+  _values = [NSMutableDictionary new];
+  _values[@"width"] = [NSNumber numberWithDouble:(double)(view.bounds.size.width)];
+  _values[@"height"] = [NSNumber numberWithDouble:(double)(view.bounds.size.height)];
+  _values[@"originX"] = [NSNumber numberWithDouble:view.center.x - view.bounds.size.width / 2.0];
+  _values[@"originY"] = [NSNumber numberWithDouble:view.center.y - view.bounds.size.height / 2.0];
+  _values[@"globalOriginX"] = [NSNumber numberWithDouble:originFromRootPerspective.x - view.bounds.size.width / 2.0];
+  _values[@"globalOriginY"] = [NSNumber numberWithDouble:originFromRootPerspective.y - view.bounds.size.height / 2.0];
+
+  return self;
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/vendored/sdk44/react-native-reanimated/ios/LayoutReanimation/ABI44_0_0REAUIManager.h
+++ b/ios/vendored/sdk44/react-native-reanimated/ios/LayoutReanimation/ABI44_0_0REAUIManager.h
@@ -1,0 +1,16 @@
+#import <ABI44_0_0React/ABI44_0_0RCTBridge+Private.h>
+#import <ABI44_0_0React/ABI44_0_0RCTDefines.h>
+#import <ABI44_0_0React/ABI44_0_0RCTUIManager.h>
+#import "ABI44_0_0REAAnimationsManager.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ABI44_0_0REAUIManager : ABI44_0_0RCTUIManager
+@property BOOL ABI44_0_0blockSetter;
+- (void)setBridge:(ABI44_0_0RCTBridge *)bridge;
+- (void)setUp:(ABI44_0_0REAAnimationsManager *)animationsManager;
+- (void)unregisterView:(id<ABI44_0_0RCTComponent>)view;
+@property (nonatomic, copy) void (^flushUiOperations)();
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/vendored/sdk44/react-native-reanimated/ios/LayoutReanimation/ABI44_0_0REAUIManager.mm
+++ b/ios/vendored/sdk44/react-native-reanimated/ios/LayoutReanimation/ABI44_0_0REAUIManager.mm
@@ -1,0 +1,387 @@
+#import "ABI44_0_0REAUIManager.h"
+#import <Foundation/Foundation.h>
+#include "FeaturesConfig.h"
+#import <ABI44_0_0React/ABI44_0_0RCTComponentData.h>
+#import <ABI44_0_0React/ABI44_0_0RCTLayoutAnimation.h>
+#import <ABI44_0_0React/ABI44_0_0RCTLayoutAnimationGroup.h>
+#import <ABI44_0_0React/ABI44_0_0RCTModalHostView.h>
+#import <ABI44_0_0React/ABI44_0_0RCTRootShadowView.h>
+#import <ABI44_0_0React/ABI44_0_0RCTRootViewInternal.h>
+#import <ABI44_0_0React/ABI44_0_0RCTUIManagerObserverCoordinator.h>
+#import "ABI44_0_0REAIOSScheduler.h"
+#include "Scheduler.h"
+
+#if __has_include(<ABI44_0_0RNScreens/ABI44_0_0RNSScreen.h>)
+#import <ABI44_0_0RNScreens/ABI44_0_0RNSScreen.h>
+#endif
+
+@interface ABI44_0_0RCTUIManager (REA)
+- (void)_manageChildren:(NSNumber *)containerTag
+        moveFromIndices:(NSArray<NSNumber *> *)moveFromIndices
+          moveToIndices:(NSArray<NSNumber *> *)moveToIndices
+      addChildABI44_0_0ReactTags:(NSArray<NSNumber *> *)addChildABI44_0_0ReactTags
+           addAtIndices:(NSArray<NSNumber *> *)addAtIndices
+        removeAtIndices:(NSArray<NSNumber *> *)removeAtIndices
+               registry:(NSMutableDictionary<NSNumber *, id<ABI44_0_0RCTComponent>> *)registry;
+
+- (NSArray<id<ABI44_0_0RCTComponent>> *)_childrenToRemoveFromContainer:(id<ABI44_0_0RCTComponent>)container
+                                                    atIndices:(NSArray<NSNumber *> *)atIndices;
+@end
+
+@implementation ABI44_0_0REAUIManager
+
+BOOL ABI44_0_0blockSetter = false;
+NSMutableDictionary<NSNumber *, NSMutableSet<id<ABI44_0_0RCTComponent>> *> *ABI44_0_0_toBeRemovedRegister;
+NSMutableDictionary<NSNumber *, NSNumber *> *ABI44_0_0_parentMapper;
+ABI44_0_0REAAnimationsManager *ABI44_0_0_animationsManager;
+std::weak_ptr<ABI44_0_0reanimated::Scheduler> ABI44_0_0_scheduler;
+
++ (NSString *)moduleName
+{
+  return NSStringFromClass([ABI44_0_0RCTUIManager class]);
+}
+
+- (void)setBridge:(ABI44_0_0RCTBridge *)bridge
+{
+  if (!_ABI44_0_0blockSetter) {
+    _ABI44_0_0blockSetter = true;
+
+    self.bridge = bridge;
+    [super setValue:bridge forKey:@"_bridge"];
+    [self setValue:[bridge.uiManager valueForKey:@"_shadowViewRegistry"] forKey:@"_shadowViewRegistry"];
+    [self setValue:[bridge.uiManager valueForKey:@"_viewRegistry"] forKey:@"_viewRegistry"];
+    [self setValue:[bridge.uiManager valueForKey:@"_nativeIDRegistry"] forKey:@"_nativeIDRegistry"];
+    [self setValue:[bridge.uiManager valueForKey:@"_shadowViewsWithUpdatedProps"]
+            forKey:@"_shadowViewsWithUpdatedProps"];
+    [self setValue:[bridge.uiManager valueForKey:@"_shadowViewsWithUpdatedChildren"]
+            forKey:@"_shadowViewsWithUpdatedChildren"];
+    [self setValue:[bridge.uiManager valueForKey:@"_pendingUIBlocks"] forKey:@"_pendingUIBlocks"];
+    [self setValue:[bridge.uiManager valueForKey:@"_rootViewTags"] forKey:@"_rootViewTags"];
+    [self setValue:[bridge.uiManager valueForKey:@"_observerCoordinator"] forKey:@"_observerCoordinator"];
+    [self setValue:[bridge.uiManager valueForKey:@"_componentDataByName"] forKey:@"_componentDataByName"];
+
+    _ABI44_0_0blockSetter = false;
+  }
+}
+
+- (void)_manageChildren:(NSNumber *)containerTag
+        moveFromIndices:(NSArray<NSNumber *> *)moveFromIndices
+          moveToIndices:(NSArray<NSNumber *> *)moveToIndices
+      addChildABI44_0_0ReactTags:(NSArray<NSNumber *> *)addChildABI44_0_0ReactTags
+           addAtIndices:(NSArray<NSNumber *> *)addAtIndices
+        removeAtIndices:(NSArray<NSNumber *> *)removeAtIndices
+               registry:(NSMutableDictionary<NSNumber *, id<ABI44_0_0RCTComponent>> *)registry
+{
+  if (!ABI44_0_0reanimated::FeaturesConfig::isLayoutAnimationEnabled()) {
+    [super _manageChildren:containerTag
+           moveFromIndices:moveFromIndices
+             moveToIndices:moveToIndices
+         addChildABI44_0_0ReactTags:addChildABI44_0_0ReactTags
+              addAtIndices:addAtIndices
+           removeAtIndices:removeAtIndices
+                  registry:registry];
+    return;
+  }
+
+  // Reanimated changes /start
+  BOOL isUIViewRegistry = ((id)registry == (id)[self valueForKey:@"_viewRegistry"]);
+  id<ABI44_0_0RCTComponent> container;
+  NSMutableArray<id<ABI44_0_0RCTComponent>> *permanentlyRemovedChildren;
+  if (isUIViewRegistry) {
+    container = registry[containerTag];
+    for (id<ABI44_0_0RCTComponent> toRemoveChild in ABI44_0_0_toBeRemovedRegister[containerTag]) {
+      [container removeABI44_0_0ReactSubview:toRemoveChild];
+    }
+
+    permanentlyRemovedChildren = (NSMutableArray *)[super _childrenToRemoveFromContainer:container
+                                                                               atIndices:removeAtIndices];
+    if (permanentlyRemovedChildren != nil) {
+      for (id<ABI44_0_0RCTComponent> permanentlyRemovedChild in permanentlyRemovedChildren) {
+        if (ABI44_0_0_toBeRemovedRegister[containerTag] == nil) {
+          ABI44_0_0_toBeRemovedRegister[containerTag] = [[NSMutableSet<id<ABI44_0_0RCTComponent>> alloc] init];
+        }
+        [ABI44_0_0_toBeRemovedRegister[containerTag] addObject:permanentlyRemovedChild];
+      }
+    }
+  }
+  // Reanimated changes /end
+
+  [super _manageChildren:containerTag
+         moveFromIndices:moveFromIndices
+           moveToIndices:moveToIndices
+       addChildABI44_0_0ReactTags:addChildABI44_0_0ReactTags
+            addAtIndices:addAtIndices
+         removeAtIndices:removeAtIndices
+                registry:registry];
+
+  // Reanimated changes /start
+  if (isUIViewRegistry) {
+    NSMutableDictionary<NSNumber *, id<ABI44_0_0RCTComponent>> *viewRegistry = [self valueForKey:@"_viewRegistry"];
+    for (id<ABI44_0_0RCTComponent> toRemoveChild in ABI44_0_0_toBeRemovedRegister[containerTag]) {
+      NSInteger lastIndex = [container ABI44_0_0ReactSubviews].count - 1;
+      if (lastIndex < 0) {
+        lastIndex = 0;
+      }
+      if ([toRemoveChild isKindOfClass:[ABI44_0_0RCTModalHostView class]]
+#if __has_include(<ABI44_0_0RNScreens/ABI44_0_0RNSScreen.h>)
+          || ([toRemoveChild isKindOfClass:[ABI44_0_0RNSScreenView class]])
+#endif
+      ) {
+        // we don't want layout animations when removing modals or Screens of native-stack since it brings buggy
+        // behavior
+        [ABI44_0_0_toBeRemovedRegister[container.ABI44_0_0ReactTag] removeObject:toRemoveChild];
+        [permanentlyRemovedChildren removeObject:toRemoveChild];
+
+      } else {
+        [container insertABI44_0_0ReactSubview:toRemoveChild atIndex:lastIndex];
+        viewRegistry[toRemoveChild.ABI44_0_0ReactTag] = toRemoveChild;
+      }
+    }
+
+    for (UIView *removedChild in permanentlyRemovedChildren) {
+      [self callAnimationForTree:removedChild parentTag:containerTag];
+    }
+  }
+  // Reanimated changes /end
+}
+
+- (void)callAnimationForTree:(UIView *)view parentTag:(NSNumber *)parentTag
+{
+  ABI44_0_0REASnapshot *snapshot = [[ABI44_0_0REASnapshot alloc] init:view];
+  ABI44_0_0_parentMapper[view.ABI44_0_0ReactTag] = parentTag;
+  [ABI44_0_0_animationsManager onViewRemoval:view before:snapshot];
+
+  for (UIView *subView in view.ABI44_0_0ReactSubviews) {
+    [self callAnimationForTree:subView parentTag:view.ABI44_0_0ReactTag];
+  }
+}
+
+// Overrided https://github.com/facebook/react-native/blob/v0.65.0/ABI44_0_0React/Modules/ABI44_0_0RCTUIManager.m#L530
+- (ABI44_0_0RCTViewManagerUIBlock)uiBlockWithLayoutUpdateForRootView:(ABI44_0_0RCTRootShadowView *)rootShadowView
+{
+  NSHashTable<ABI44_0_0RCTShadowView *> *affectedShadowViews = [NSHashTable weakObjectsHashTable];
+  [rootShadowView layoutWithAffectedShadowViews:affectedShadowViews];
+
+  if (!affectedShadowViews.count) {
+    // no frame change results in no UI update block
+    return nil;
+  }
+
+  typedef struct {
+    CGRect frame;
+    UIUserInterfaceLayoutDirection layoutDirection;
+    BOOL isNew;
+    BOOL parentIsNew;
+    ABI44_0_0RCTDisplayType displayType;
+  } ABI44_0_0RCTFrameData;
+
+  // Construct arrays then hand off to main thread
+  NSUInteger count = affectedShadowViews.count;
+  NSMutableArray *ABI44_0_0ReactTags = [[NSMutableArray alloc] initWithCapacity:count];
+  NSMutableData *framesData = [[NSMutableData alloc] initWithLength:sizeof(ABI44_0_0RCTFrameData) * count];
+  {
+    NSUInteger index = 0;
+    ABI44_0_0RCTFrameData *frameDataArray = (ABI44_0_0RCTFrameData *)framesData.mutableBytes;
+    for (ABI44_0_0RCTShadowView *shadowView in affectedShadowViews) {
+      ABI44_0_0ReactTags[index] = shadowView.ABI44_0_0ReactTag;
+      ABI44_0_0RCTLayoutMetrics layoutMetrics = shadowView.layoutMetrics;
+      frameDataArray[index++] = (ABI44_0_0RCTFrameData){
+          layoutMetrics.frame,
+          layoutMetrics.layoutDirection,
+          shadowView.isNewView,
+          shadowView.superview.isNewView,
+          layoutMetrics.displayType};
+    }
+  }
+
+  for (ABI44_0_0RCTShadowView *shadowView in affectedShadowViews) {
+    // We have to do this after we build the parentsAreNew array.
+    shadowView.newView = NO;
+
+    NSNumber *ABI44_0_0ReactTag = shadowView.ABI44_0_0ReactTag;
+
+    if (shadowView.onLayout) {
+      CGRect frame = shadowView.layoutMetrics.frame;
+      shadowView.onLayout(@{
+        @"layout" : @{
+          @"x" : @(frame.origin.x),
+          @"y" : @(frame.origin.y),
+          @"width" : @(frame.size.width),
+          @"height" : @(frame.size.height),
+        },
+      });
+    }
+
+    if (ABI44_0_0RCTIsABI44_0_0ReactRootView(ABI44_0_0ReactTag) && [shadowView isKindOfClass:[ABI44_0_0RCTRootShadowView class]]) {
+      CGSize contentSize = shadowView.layoutMetrics.frame.size;
+
+      ABI44_0_0RCTExecuteOnMainQueue(^{
+        NSMutableDictionary<NSNumber *, UIView *> *viewRegistry = [self valueForKey:@"_viewRegistry"];
+        UIView *view = viewRegistry[ABI44_0_0ReactTag];
+        ABI44_0_0RCTAssert(view != nil, @"view (for ID %@) not found", ABI44_0_0ReactTag);
+
+        ABI44_0_0RCTRootView *rootView = (ABI44_0_0RCTRootView *)[view superview];
+        if ([rootView isKindOfClass:[ABI44_0_0RCTRootView class]]) {
+          rootView.intrinsicContentSize = contentSize;
+        }
+      });
+    }
+  }
+
+  // Perform layout (possibly animated)
+  return ^(__unused ABI44_0_0RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
+    const ABI44_0_0RCTFrameData *frameDataArray = (const ABI44_0_0RCTFrameData *)framesData.bytes;
+    ABI44_0_0RCTLayoutAnimationGroup *layoutAnimationGroup = [uiManager valueForKey:@"_layoutAnimationGroup"];
+
+    __block NSUInteger completionsCalled = 0;
+
+    NSInteger index = 0;
+    for (NSNumber *ABI44_0_0ReactTag in ABI44_0_0ReactTags) {
+      ABI44_0_0RCTFrameData frameData = frameDataArray[index++];
+
+      UIView *view = viewRegistry[ABI44_0_0ReactTag];
+      CGRect frame = frameData.frame;
+
+      UIUserInterfaceLayoutDirection layoutDirection = frameData.layoutDirection;
+      BOOL isNew = frameData.isNew;
+      ABI44_0_0RCTLayoutAnimation *updatingLayoutAnimation = isNew ? nil : layoutAnimationGroup.updatingLayoutAnimation;
+      BOOL shouldAnimateCreation = isNew && !frameData.parentIsNew;
+      ABI44_0_0RCTLayoutAnimation *creatingLayoutAnimation =
+          shouldAnimateCreation ? layoutAnimationGroup.creatingLayoutAnimation : nil;
+      BOOL isHidden = frameData.displayType == ABI44_0_0RCTDisplayTypeNone;
+
+      void (^completion)(BOOL) = ^(BOOL finished) {
+        completionsCalled++;
+        if (layoutAnimationGroup.callback && completionsCalled == count) {
+          layoutAnimationGroup.callback(@[ @(finished) ]);
+
+          // It's unsafe to call this callback more than once, so we nil it out here
+          // to make sure that doesn't happen.
+          layoutAnimationGroup.callback = nil;
+        }
+      };
+
+      if (view.ABI44_0_0ReactLayoutDirection != layoutDirection) {
+        view.ABI44_0_0ReactLayoutDirection = layoutDirection;
+      }
+
+      if (view.isHidden != isHidden) {
+        view.hidden = isHidden;
+      }
+
+      // Reanimated changes /start
+      ABI44_0_0REASnapshot *snapshotBefore;
+      if (ABI44_0_0reanimated::FeaturesConfig::isLayoutAnimationEnabled()) {
+        snapshotBefore = [[ABI44_0_0REASnapshot alloc] init:view];
+      }
+      // Reanimated changes /end
+
+      if (creatingLayoutAnimation) {
+        // Animate view creation
+        [view ABI44_0_0ReactSetFrame:frame];
+
+        CATransform3D finalTransform = view.layer.transform;
+        CGFloat finalOpacity = view.layer.opacity;
+
+        NSString *property = creatingLayoutAnimation.property;
+        if ([property isEqualToString:@"scaleXY"]) {
+          view.layer.transform = CATransform3DMakeScale(0, 0, 0);
+        } else if ([property isEqualToString:@"scaleX"]) {
+          view.layer.transform = CATransform3DMakeScale(0, 1, 0);
+        } else if ([property isEqualToString:@"scaleY"]) {
+          view.layer.transform = CATransform3DMakeScale(1, 0, 0);
+        } else if ([property isEqualToString:@"opacity"]) {
+          view.layer.opacity = 0.0;
+        } else {
+          ABI44_0_0RCTLogError(@"Unsupported layout animation createConfig property %@", creatingLayoutAnimation.property);
+        }
+
+        [creatingLayoutAnimation
+              performAnimations:^{
+                if ([property isEqualToString:@"scaleX"] || [property isEqualToString:@"scaleY"] ||
+                    [property isEqualToString:@"scaleXY"]) {
+                  view.layer.transform = finalTransform;
+                } else if ([property isEqualToString:@"opacity"]) {
+                  view.layer.opacity = finalOpacity;
+                }
+              }
+            withCompletionBlock:completion];
+
+      } else if (updatingLayoutAnimation) {
+        // Animate view update
+        [updatingLayoutAnimation
+              performAnimations:^{
+                [view ABI44_0_0ReactSetFrame:frame];
+              }
+            withCompletionBlock:completion];
+
+      } else {
+        // Update without animation
+        [view ABI44_0_0ReactSetFrame:frame];
+        completion(YES);
+      }
+
+      // Reanimated changes /start
+      if (ABI44_0_0reanimated::FeaturesConfig::isLayoutAnimationEnabled()) {
+        if (isNew) {
+          ABI44_0_0REASnapshot *snapshot = [[ABI44_0_0REASnapshot alloc] init:view];
+          [ABI44_0_0_animationsManager onViewCreate:view after:snapshot];
+        } else {
+          ABI44_0_0REASnapshot *snapshotAfter = [[ABI44_0_0REASnapshot alloc] init:view];
+          [ABI44_0_0_animationsManager onViewUpdate:view before:snapshotBefore after:snapshotAfter];
+        }
+      }
+    }
+
+    [ABI44_0_0_animationsManager removeLeftovers];
+    // Clean up
+    // uiManager->_layoutAnimationGroup = nil;
+    [uiManager setValue:nil forKey:@"_layoutAnimationGroup"];
+    // Reanimated changes /end
+  };
+}
+
+- (Class)class
+{
+  return [ABI44_0_0RCTUIManager class];
+}
+
++ (Class)class
+{
+  return [ABI44_0_0RCTUIManager class];
+}
+
+- (void)setUp:(ABI44_0_0REAAnimationsManager *)animationsManager
+{
+  ABI44_0_0_animationsManager = animationsManager;
+  ABI44_0_0_toBeRemovedRegister = [[NSMutableDictionary<NSNumber *, NSMutableSet<id<ABI44_0_0RCTComponent>> *> alloc] init];
+  ABI44_0_0_parentMapper = [[NSMutableDictionary<NSNumber *, NSNumber *> alloc] init];
+}
+
+- (void)unregisterView:(id<ABI44_0_0RCTComponent>)view
+{
+  NSNumber *tag = ABI44_0_0_parentMapper[view.ABI44_0_0ReactTag];
+  if (tag == nil) {
+    return;
+  }
+
+  [ABI44_0_0_toBeRemovedRegister[tag] removeObject:view];
+  if (ABI44_0_0_toBeRemovedRegister[tag].count == 0) {
+    [ABI44_0_0_toBeRemovedRegister removeObjectForKey:tag];
+  }
+  NSMutableDictionary<NSNumber *, id<ABI44_0_0RCTComponent>> *viewRegistry = [self valueForKey:@"_viewRegistry"];
+  [view.ABI44_0_0ReactSuperview removeABI44_0_0ReactSubview:view];
+  id<ABI44_0_0RCTComponent> parentView = viewRegistry[tag];
+  @try {
+    [parentView removeABI44_0_0ReactSubview:view];
+  } @catch (id anException) {
+  }
+#if __has_include(<ABI44_0_0RNScreens/ABI44_0_0RNSScreen.h>)
+  if ([view isKindOfClass:[ABI44_0_0RNSScreenView class]]) {
+    [parentView didUpdateABI44_0_0ReactSubviews];
+  }
+#endif
+  [viewRegistry removeObjectForKey:view.ABI44_0_0ReactTag];
+}
+
+@end

--- a/ios/vendored/sdk44/react-native-reanimated/ios/Nodes/ABI44_0_0REAAlwaysNode.m
+++ b/ios/vendored/sdk44/react-native-reanimated/ios/Nodes/ABI44_0_0REAAlwaysNode.m
@@ -1,24 +1,24 @@
 #import "ABI44_0_0REAAlwaysNode.h"
-#import "ABI44_0_0REAUtils.h"
+#import <ABI44_0_0React/ABI44_0_0RCTConvert.h>
+#import <ABI44_0_0React/ABI44_0_0RCTLog.h>
+#import <ABI44_0_0React/ABI44_0_0RCTUIManager.h>
+#import "ABI44_0_0REAModule.h"
 #import "ABI44_0_0REANodesManager.h"
 #import "ABI44_0_0REAStyleNode.h"
-#import "ABI44_0_0REAModule.h"
-#import <ABI44_0_0React/ABI44_0_0RCTLog.h>
-#import <ABI44_0_0React/ABI44_0_0RCTConvert.h>
-#import <ABI44_0_0React/ABI44_0_0RCTUIManager.h>
+#import "ABI44_0_0REAUtils.h"
 
-@implementation ABI44_0_0REAAlwaysNode
-{
-  NSNumber * _nodeToBeEvaluated;
+@implementation ABI44_0_0REAAlwaysNode {
+  NSNumber *_nodeToBeEvaluated;
 }
 
-- (instancetype)initWithID:(ABI44_0_0REANodeID)nodeID config:(NSDictionary<NSString *,id> *)config
+- (instancetype)initWithID:(ABI44_0_0REANodeID)nodeID config:(NSDictionary<NSString *, id> *)config
 {
-    if ((self = [super initWithID:nodeID config:config])) {
-      _nodeToBeEvaluated = [ABI44_0_0RCTConvert NSNumber:config[@"what"]];
-      ABI44_0_0REA_LOG_ERROR_IF_NIL(_nodeToBeEvaluated, @"Reanimated: First argument passed to always node is either of wrong type or is missing.");
-    }
-    return self;
+  if ((self = [super initWithID:nodeID config:config])) {
+    _nodeToBeEvaluated = [ABI44_0_0RCTConvert NSNumber:config[@"what"]];
+    ABI44_0_0REA_LOG_ERROR_IF_NIL(
+        _nodeToBeEvaluated, @"Reanimated: First argument passed to always node is either of wrong type or is missing.");
+  }
+  return self;
 }
 
 - (id)evaluate
@@ -33,4 +33,3 @@
 }
 
 @end
-

--- a/ios/vendored/sdk44/react-native-reanimated/ios/Nodes/ABI44_0_0REABezierNode.m
+++ b/ios/vendored/sdk44/react-native-reanimated/ios/Nodes/ABI44_0_0REABezierNode.m
@@ -1,10 +1,10 @@
 #include <tgmath.h>
 
-#import "ABI44_0_0REABezierNode.h"
-#import "ABI44_0_0REAUtils.h"
-#import "ABI44_0_0REANodesManager.h"
 #import <ABI44_0_0React/ABI44_0_0RCTConvert.h>
 #import <ABI44_0_0React/ABI44_0_0RCTLog.h>
+#import "ABI44_0_0REABezierNode.h"
+#import "ABI44_0_0REANodesManager.h"
+#import "ABI44_0_0REAUtils.h"
 
 #define EPS 1e-5
 
@@ -13,11 +13,12 @@
   NSNumber *_inputNodeID;
 }
 
-- (instancetype)initWithID:(ABI44_0_0REANodeID)nodeID config:(NSDictionary<NSString *,id> *)config
+- (instancetype)initWithID:(ABI44_0_0REANodeID)nodeID config:(NSDictionary<NSString *, id> *)config
 {
   if ((self = [super initWithID:nodeID config:config])) {
     _inputNodeID = [ABI44_0_0RCTConvert NSNumber:config[@"input"]];
-    ABI44_0_0REA_LOG_ERROR_IF_NIL(_inputNodeID, @"Reanimated: First argument passed to bezier node is either of wrong type or is missing.");
+    ABI44_0_0REA_LOG_ERROR_IF_NIL(
+        _inputNodeID, @"Reanimated: First argument passed to bezier node is either of wrong type or is missing.");
 
     CGFloat mX1 = [config[@"mX1"] doubleValue];
     CGFloat mY1 = [config[@"mY1"] doubleValue];
@@ -27,7 +28,7 @@
     // Calculate the polynomial coefficients, implicit first and last control points are (0,0) and (1,1).
     cx = 3.0 * mX1;
     bx = 3.0 * (mX2 - mX1) - cx;
-    ax = 1.0 - cx -bx;
+    ax = 1.0 - cx - bx;
 
     cy = 3.0 * mY1;
     by = 3.0 * (mY2 - mY1) - cy;
@@ -60,7 +61,7 @@
   // First try a few iterations of Newton's method -- normally very fast.
   for (t2 = x, i = 0; i < 8; i++) {
     x2 = [self sampleCurveX:t2] - x;
-    if (fabs (x2) < epsilon)
+    if (fabs(x2) < epsilon)
       return t2;
     d2 = [self sampleCurveDerivativeX:t2];
     if (fabs(d2) < 1e-6)

--- a/ios/vendored/sdk44/react-native-reanimated/ios/Nodes/ABI44_0_0REABlockNode.m
+++ b/ios/vendored/sdk44/react-native-reanimated/ios/Nodes/ABI44_0_0REABlockNode.m
@@ -5,7 +5,7 @@
   NSArray<NSNumber *> *_block;
 }
 
-- (instancetype)initWithID:(ABI44_0_0REANodeID)nodeID config:(NSDictionary<NSString *,id> *)config
+- (instancetype)initWithID:(ABI44_0_0REANodeID)nodeID config:(NSDictionary<NSString *, id> *)config
 {
   if ((self = [super initWithID:nodeID config:config])) {
     _block = config[@"block"];

--- a/ios/vendored/sdk44/react-native-reanimated/ios/Nodes/ABI44_0_0REACallFuncNode.h
+++ b/ios/vendored/sdk44/react-native-reanimated/ios/Nodes/ABI44_0_0REACallFuncNode.h
@@ -4,4 +4,3 @@
 @interface ABI44_0_0REACallFuncNode : ABI44_0_0REANode
 
 @end
-

--- a/ios/vendored/sdk44/react-native-reanimated/ios/Nodes/ABI44_0_0REACallFuncNode.m
+++ b/ios/vendored/sdk44/react-native-reanimated/ios/Nodes/ABI44_0_0REACallFuncNode.m
@@ -2,22 +2,23 @@
 
 #import "ABI44_0_0REACallFuncNode.h"
 #import "ABI44_0_0REAFunctionNode.h"
-#import "ABI44_0_0REAUtils.h"
-#import "ABI44_0_0REAParamNode.h"
 #import "ABI44_0_0REANodesManager.h"
+#import "ABI44_0_0REAParamNode.h"
+#import "ABI44_0_0REAUtils.h"
 
 @implementation ABI44_0_0REACallFuncNode {
   NSNumber *_whatNodeID;
   NSArray<NSNumber *> *_args;
   NSArray<NSNumber *> *_params;
-  NSString* _prevCallID;
+  NSString *_prevCallID;
 }
 
-- (instancetype)initWithID:(ABI44_0_0REANodeID)nodeID config:(NSDictionary<NSString *,id> *)config
+- (instancetype)initWithID:(ABI44_0_0REANodeID)nodeID config:(NSDictionary<NSString *, id> *)config
 {
   if ((self = [super initWithID:nodeID config:config])) {
     _whatNodeID = config[@"what"];
-    ABI44_0_0REA_LOG_ERROR_IF_NIL(_whatNodeID, @"Reanimated: First argument passed to callFunc node is either of wrong type or is missing.");
+    ABI44_0_0REA_LOG_ERROR_IF_NIL(
+        _whatNodeID, @"Reanimated: First argument passed to callFunc node is either of wrong type or is missing.");
     _args = config[@"args"];
     _params = config[@"params"];
     _prevCallID = NULL;
@@ -27,13 +28,14 @@
 
 - (void)beginContext
 {
-  // To ensure that functions can be called multiple times in the same animation frame 
+  // To ensure that functions can be called multiple times in the same animation frame
   // (functions might have different parameters and might be called multiple times)
   // we inform the current update context about where we are called from by setting the
   // current call id - this will ensure that memoization is correct for function nodes.
   _prevCallID = self.updateContext.callID;
-  self.updateContext.callID = [NSString stringWithFormat:@"%@/%@", self.updateContext.callID, [self.nodeID stringValue]];
-  
+  self.updateContext.callID =
+      [NSString stringWithFormat:@"%@/%@", self.updateContext.callID, [self.nodeID stringValue]];
+
   // A CallFuncNode has a reference to a function node which holds the node graph that should
   // be updated. A Function node has a list of ParamNodes which are basically nodes that can
   // reference other nodes. When we start a new function call we update the parameter nodes

--- a/ios/vendored/sdk44/react-native-reanimated/ios/Nodes/ABI44_0_0REAClockNodes.m
+++ b/ios/vendored/sdk44/react-native-reanimated/ios/Nodes/ABI44_0_0REAClockNodes.m
@@ -1,9 +1,9 @@
 #import "ABI44_0_0REAClockNodes.h"
-#import "ABI44_0_0REAUtils.h"
-#import "ABI44_0_0REANodesManager.h"
-#import "ABI44_0_0REAParamNode.h"
 #import <ABI44_0_0React/ABI44_0_0RCTConvert.h>
 #import <ABI44_0_0React/ABI44_0_0RCTLog.h>
+#import "ABI44_0_0REANodesManager.h"
+#import "ABI44_0_0REAParamNode.h"
+#import "ABI44_0_0REAUtils.h"
 
 @interface ABI44_0_0REAClockNode ()
 
@@ -13,7 +13,7 @@
 
 @implementation ABI44_0_0REAClockNode
 
-- (instancetype)initWithID:(ABI44_0_0REANodeID)nodeID config:(NSDictionary<NSString *,id> *)config
+- (instancetype)initWithID:(ABI44_0_0REANodeID)nodeID config:(NSDictionary<NSString *, id> *)config
 {
   if ((self = [super initWithID:nodeID config:config])) {
     _isRunning = NO;
@@ -23,7 +23,8 @@
 
 - (void)start
 {
-  if (_isRunning) return;
+  if (_isRunning)
+    return;
   _isRunning = YES;
 
   __block __weak void (^weak_animationClb)(CADisplayLink *displayLink);
@@ -31,7 +32,8 @@
   __weak ABI44_0_0REAClockNode *weakSelf = self;
 
   weak_animationClb = animationClb = ^(CADisplayLink *displayLink) {
-    if (!weakSelf.isRunning) return;
+    if (!weakSelf.isRunning)
+      return;
     [weakSelf markUpdated];
     [weakSelf.nodesManager postOnAnimation:weak_animationClb];
   };
@@ -55,18 +57,19 @@
   NSNumber *_clockNodeID;
 }
 
-- (instancetype)initWithID:(ABI44_0_0REANodeID)nodeID config:(NSDictionary<NSString *,id> *)config
+- (instancetype)initWithID:(ABI44_0_0REANodeID)nodeID config:(NSDictionary<NSString *, id> *)config
 {
   if ((self = [super initWithID:nodeID config:config])) {
     _clockNodeID = [ABI44_0_0RCTConvert NSNumber:config[@"clock"]];
-    ABI44_0_0REA_LOG_ERROR_IF_NIL(_clockNodeID, @"Reanimated: First argument passed to clock node is either of wrong type or is missing.");
+    ABI44_0_0REA_LOG_ERROR_IF_NIL(
+        _clockNodeID, @"Reanimated: First argument passed to clock node is either of wrong type or is missing.");
   }
   return self;
 }
 
-- (ABI44_0_0REANode*)clockNode
+- (ABI44_0_0REANode *)clockNode
 {
-  return (ABI44_0_0REANode*)[self.nodesManager findNodeByID:_clockNodeID];
+  return (ABI44_0_0REANode *)[self.nodesManager findNodeByID:_clockNodeID];
 }
 
 @end
@@ -75,11 +78,11 @@
 
 - (id)evaluate
 {
-  ABI44_0_0REANode* node = [self clockNode];
+  ABI44_0_0REANode *node = [self clockNode];
   if ([node isKindOfClass:[ABI44_0_0REAParamNode class]]) {
-    [(ABI44_0_0REAParamNode* )node start];
+    [(ABI44_0_0REAParamNode *)node start];
   } else {
-    [(ABI44_0_0REAClockNode* )node start];
+    [(ABI44_0_0REAClockNode *)node start];
   }
   return @(0);
 }
@@ -90,15 +93,14 @@
 
 - (id)evaluate
 {
-  ABI44_0_0REANode* node = [self clockNode];
+  ABI44_0_0REANode *node = [self clockNode];
   if ([node isKindOfClass:[ABI44_0_0REAParamNode class]]) {
-    [(ABI44_0_0REAParamNode* )node stop];
+    [(ABI44_0_0REAParamNode *)node stop];
   } else {
-    [(ABI44_0_0REAClockNode* )node stop];
+    [(ABI44_0_0REAClockNode *)node stop];
   }
   return @(0);
 }
-
 
 @end
 
@@ -106,11 +108,11 @@
 
 - (id)evaluate
 {
-  ABI44_0_0REANode* node = [self clockNode];
+  ABI44_0_0REANode *node = [self clockNode];
   if ([node isKindOfClass:[ABI44_0_0REAParamNode class]]) {
-    return @(((ABI44_0_0REAParamNode* )node).isRunning ? 1 : 0);
+    return @(((ABI44_0_0REAParamNode *)node).isRunning ? 1 : 0);
   }
-  return @([(ABI44_0_0REAClockNode* )node isRunning] ? 1 : 0);
+  return @([(ABI44_0_0REAClockNode *)node isRunning] ? 1 : 0);
 }
 
 @end

--- a/ios/vendored/sdk44/react-native-reanimated/ios/Nodes/ABI44_0_0REAConcatNode.h
+++ b/ios/vendored/sdk44/react-native-reanimated/ios/Nodes/ABI44_0_0REAConcatNode.h
@@ -3,4 +3,3 @@
 @interface ABI44_0_0REAConcatNode : ABI44_0_0REANode
 
 @end
-

--- a/ios/vendored/sdk44/react-native-reanimated/ios/Nodes/ABI44_0_0REAConcatNode.m
+++ b/ios/vendored/sdk44/react-native-reanimated/ios/Nodes/ABI44_0_0REAConcatNode.m
@@ -1,12 +1,12 @@
 #import "ABI44_0_0REAConcatNode.h"
-#import "ABI44_0_0REAValueNode.h"
 #import "ABI44_0_0REANodesManager.h"
+#import "ABI44_0_0REAValueNode.h"
 
 @implementation ABI44_0_0REAConcatNode {
   NSArray<NSNumber *> *_input;
 }
 
-- (instancetype)initWithID:(ABI44_0_0REANodeID)nodeID config:(NSDictionary<NSString *,id> *)config
+- (instancetype)initWithID:(ABI44_0_0REANodeID)nodeID config:(NSDictionary<NSString *, id> *)config
 {
   if ((self = [super initWithID:nodeID config:config])) {
     _input = config[@"input"];

--- a/ios/vendored/sdk44/react-native-reanimated/ios/Nodes/ABI44_0_0REACondNode.m
+++ b/ios/vendored/sdk44/react-native-reanimated/ios/Nodes/ABI44_0_0REACondNode.m
@@ -1,8 +1,8 @@
 #import "ABI44_0_0REACondNode.h"
-#import "ABI44_0_0REANodesManager.h"
 #import <ABI44_0_0React/ABI44_0_0RCTConvert.h>
-#import "ABI44_0_0REAUtils.h"
 #import <ABI44_0_0React/ABI44_0_0RCTLog.h>
+#import "ABI44_0_0REANodesManager.h"
+#import "ABI44_0_0REAUtils.h"
 
 @implementation ABI44_0_0REACondNode {
   NSNumber *_condNodeID;
@@ -10,13 +10,15 @@
   NSNumber *_elseBlockID;
 }
 
-- (instancetype)initWithID:(ABI44_0_0REANodeID)nodeID config:(NSDictionary<NSString *,id> *)config
+- (instancetype)initWithID:(ABI44_0_0REANodeID)nodeID config:(NSDictionary<NSString *, id> *)config
 {
   if ((self = [super initWithID:nodeID config:config])) {
     _condNodeID = [ABI44_0_0RCTConvert NSNumber:config[@"cond"]];
-    ABI44_0_0REA_LOG_ERROR_IF_NIL(_condNodeID, @"Reanimated: First argument passed to cond node is either of wrong type or is missing.");
+    ABI44_0_0REA_LOG_ERROR_IF_NIL(
+        _condNodeID, @"Reanimated: First argument passed to cond node is either of wrong type or is missing.");
     _ifBlockID = [ABI44_0_0RCTConvert NSNumber:config[@"ifBlock"]];
-    ABI44_0_0REA_LOG_ERROR_IF_NIL(_ifBlockID, @"Reanimated: Second argument passed to cond node is either of wrong type or is missing.");
+    ABI44_0_0REA_LOG_ERROR_IF_NIL(
+        _ifBlockID, @"Reanimated: Second argument passed to cond node is either of wrong type or is missing.");
     _elseBlockID = [ABI44_0_0RCTConvert NSNumber:config[@"elseBlock"]];
   }
   return self;

--- a/ios/vendored/sdk44/react-native-reanimated/ios/Nodes/ABI44_0_0READebugNode.m
+++ b/ios/vendored/sdk44/react-native-reanimated/ios/Nodes/ABI44_0_0READebugNode.m
@@ -1,20 +1,21 @@
 #import "ABI44_0_0READebugNode.h"
-#import "ABI44_0_0REAUtils.h"
-#import "ABI44_0_0REANodesManager.h"
 #import <ABI44_0_0React/ABI44_0_0RCTConvert.h>
 #import <ABI44_0_0React/ABI44_0_0RCTLog.h>
+#import "ABI44_0_0REANodesManager.h"
+#import "ABI44_0_0REAUtils.h"
 
 @implementation ABI44_0_0READebugNode {
   NSNumber *_valueNodeID;
   NSString *_message;
 }
 
-- (instancetype)initWithID:(ABI44_0_0REANodeID)nodeID config:(NSDictionary<NSString *,id> *)config
+- (instancetype)initWithID:(ABI44_0_0REANodeID)nodeID config:(NSDictionary<NSString *, id> *)config
 {
   if ((self = [super initWithID:nodeID config:config])) {
     _message = [ABI44_0_0RCTConvert NSString:config[@"message"]];
     _valueNodeID = [ABI44_0_0RCTConvert NSNumber:config[@"value"]];
-    ABI44_0_0REA_LOG_ERROR_IF_NIL(_valueNodeID, @"Reanimated: Second argument passed to debug node is either of wrong type or is missing.");
+    ABI44_0_0REA_LOG_ERROR_IF_NIL(
+        _valueNodeID, @"Reanimated: Second argument passed to debug node is either of wrong type or is missing.");
   }
   return self;
 }

--- a/ios/vendored/sdk44/react-native-reanimated/ios/Nodes/ABI44_0_0REAEventNode.m
+++ b/ios/vendored/sdk44/react-native-reanimated/ios/Nodes/ABI44_0_0REAEventNode.m
@@ -6,7 +6,7 @@
   NSArray *_argMapping;
 }
 
-- (instancetype)initWithID:(ABI44_0_0REANodeID)nodeID config:(NSDictionary<NSString *,id> *)config
+- (instancetype)initWithID:(ABI44_0_0REANodeID)nodeID config:(NSDictionary<NSString *, id> *)config
 {
   if ((self = [super initWithID:nodeID config:config])) {
     _argMapping = config[@"argMapping"];

--- a/ios/vendored/sdk44/react-native-reanimated/ios/Nodes/ABI44_0_0REAFunctionNode.h
+++ b/ios/vendored/sdk44/react-native-reanimated/ios/Nodes/ABI44_0_0REAFunctionNode.h
@@ -4,4 +4,3 @@
 @interface ABI44_0_0REAFunctionNode : ABI44_0_0REANode
 
 @end
-

--- a/ios/vendored/sdk44/react-native-reanimated/ios/Nodes/ABI44_0_0REAFunctionNode.m
+++ b/ios/vendored/sdk44/react-native-reanimated/ios/Nodes/ABI44_0_0REAFunctionNode.m
@@ -1,13 +1,13 @@
 
 #import "ABI44_0_0REAFunctionNode.h"
-#import "ABI44_0_0REAParamNode.h"
 #import "ABI44_0_0REANodesManager.h"
+#import "ABI44_0_0REAParamNode.h"
 
 @implementation ABI44_0_0REAFunctionNode {
   NSNumber *_nodeToBeEvaluated;
 }
 
-- (instancetype)initWithID:(ABI44_0_0REANodeID)nodeID config:(NSDictionary<NSString *,id> *)config
+- (instancetype)initWithID:(ABI44_0_0REANodeID)nodeID config:(NSDictionary<NSString *, id> *)config
 {
   if ((self = [super initWithID:nodeID config:config])) {
     _nodeToBeEvaluated = config[@"what"];

--- a/ios/vendored/sdk44/react-native-reanimated/ios/Nodes/ABI44_0_0REAJSCallNode.m
+++ b/ios/vendored/sdk44/react-native-reanimated/ios/Nodes/ABI44_0_0REAJSCallNode.m
@@ -1,12 +1,12 @@
 #import "ABI44_0_0REAJSCallNode.h"
-#import "ABI44_0_0REANodesManager.h"
 #import "ABI44_0_0REAModule.h"
+#import "ABI44_0_0REANodesManager.h"
 
 @implementation ABI44_0_0REAJSCallNode {
   NSArray<NSNumber *> *_input;
 }
 
-- (instancetype)initWithID:(ABI44_0_0REANodeID)nodeID config:(NSDictionary<NSString *,id> *)config
+- (instancetype)initWithID:(ABI44_0_0REANodeID)nodeID config:(NSDictionary<NSString *, id> *)config
 {
   if ((self = [super initWithID:nodeID config:config])) {
     _input = config[@"input"];
@@ -21,9 +21,8 @@
     args[i] = [[self.nodesManager findNodeByID:_input[i]] value];
   }
 
-  [self.nodesManager.reanimatedModule
-   sendEventWithName:@"onReanimatedCall"
-   body:@{@"id": self.nodeID, @"args": args }];
+  [self.nodesManager.reanimatedModule sendEventWithName:@"onReanimatedCall"
+                                                   body:@{@"id" : self.nodeID, @"args" : args}];
 
   return @(0);
 }

--- a/ios/vendored/sdk44/react-native-reanimated/ios/Nodes/ABI44_0_0REANode.h
+++ b/ios/vendored/sdk44/react-native-reanimated/ios/Nodes/ABI44_0_0REANode.h
@@ -3,7 +3,7 @@
 
 @class ABI44_0_0REANodesManager;
 
-typedef NSNumber* ABI44_0_0REANodeID;
+typedef NSNumber *ABI44_0_0REANodeID;
 
 @protocol ABI44_0_0REAFinalNode
 
@@ -12,15 +12,14 @@ typedef NSNumber* ABI44_0_0REANodeID;
 @end
 
 @interface ABI44_0_0REAUpdateContext : NSObject
-@property (nonatomic) NSString* callID;
+@property (nonatomic) NSString *callID;
 @end
 
 @interface ABI44_0_0REANode : NSObject
 
 + (void)runPropUpdates:(nonnull ABI44_0_0REAUpdateContext *)context;
 
-- (instancetype)initWithID:(ABI44_0_0REANodeID)nodeID
-                    config:(NSDictionary<NSString *, id> *)config NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithID:(ABI44_0_0REANodeID)nodeID config:(NSDictionary<NSString *, id> *)config NS_DESIGNATED_INITIALIZER;
 
 @property (nonatomic, weak, nullable) ABI44_0_0REANodesManager *nodesManager;
 @property (nonatomic, nullable) ABI44_0_0REAUpdateContext *updateContext;

--- a/ios/vendored/sdk44/react-native-reanimated/ios/Nodes/ABI44_0_0REANode.m
+++ b/ios/vendored/sdk44/react-native-reanimated/ios/Nodes/ABI44_0_0REANode.m
@@ -6,7 +6,7 @@
 @interface ABI44_0_0REAUpdateContext ()
 
 @property (nonatomic, nonnull) NSMutableArray<ABI44_0_0REANode *> *updatedNodes;
-@property (nonatomic) NSNumber* loopID;
+@property (nonatomic) NSNumber *loopID;
 
 @end
 
@@ -24,18 +24,17 @@
 
 @end
 
-
 @interface ABI44_0_0REANode ()
 
-@property (nonatomic) NSMutableDictionary<ABI44_0_0REANodeID, NSNumber*>* lastLoopID;
-@property (nonatomic) NSMutableDictionary<ABI44_0_0REANodeID, id>* memoizedValue;
+@property (nonatomic) NSMutableDictionary<ABI44_0_0REANodeID, NSNumber *> *lastLoopID;
+@property (nonatomic) NSMutableDictionary<ABI44_0_0REANodeID, id> *memoizedValue;
 @property (nonatomic, nullable) NSMutableArray<ABI44_0_0REANode *> *childNodes;
 
 @end
 
 @implementation ABI44_0_0REANode
 
-- (instancetype)initWithID:(ABI44_0_0REANodeID)nodeID config:(NSDictionary<NSString *,id> *)config
+- (instancetype)initWithID:(ABI44_0_0REANodeID)nodeID config:(NSDictionary<NSString *, id> *)config
 {
   if ((self = [super init])) {
     _nodeID = nodeID;
@@ -46,7 +45,7 @@
   return self;
 }
 
-ABI44_0_0RCT_NOT_IMPLEMENTED(- (instancetype)init)
+ABI44_0_0RCT_NOT_IMPLEMENTED(-(instancetype)init)
 
 - (void)dangerouslyRescheduleEvaluate
 {
@@ -67,7 +66,8 @@ ABI44_0_0RCT_NOT_IMPLEMENTED(- (instancetype)init)
 
 - (id)value
 {
-  if (![_lastLoopID objectForKey:_updateContext.callID] || [[_lastLoopID objectForKey:_updateContext.callID] longValue] < [_updateContext.loopID longValue]) {
+  if (![_lastLoopID objectForKey:_updateContext.callID] ||
+      [[_lastLoopID objectForKey:_updateContext.callID] longValue] < [_updateContext.loopID longValue]) {
     [_lastLoopID setObject:_updateContext.loopID forKey:_updateContext.callID];
     id val = [self evaluate];
     [_memoizedValue setObject:(val == nil ? [NSNull null] : val) forKey:_updateContext.callID];
@@ -133,9 +133,7 @@ ABI44_0_0RCT_NOT_IMPLEMENTED(- (instancetype)init)
   NSMutableSet<ABI44_0_0REANode *> *visitedNodes = [NSMutableSet new];
   NSMutableArray<id<ABI44_0_0REAFinalNode>> *finalNodes = [NSMutableArray new];
   for (NSUInteger i = 0; i < context.updatedNodes.count; i++) {
-    [self findAndUpdateNodes:context.updatedNodes[i]
-              withVisitedSet:visitedNodes
-              withFinalNodes:finalNodes];
+    [self findAndUpdateNodes:context.updatedNodes[i] withVisitedSet:visitedNodes withFinalNodes:finalNodes];
     if (i == context.updatedNodes.count - 1) {
       while (finalNodes.count > 0) {
         // NSMutableArray used for stack implementation
@@ -151,7 +149,7 @@ ABI44_0_0RCT_NOT_IMPLEMENTED(- (instancetype)init)
 
 - (void)onDrop
 {
-  //noop
+  // noop
 }
 
 @end

--- a/ios/vendored/sdk44/react-native-reanimated/ios/Nodes/ABI44_0_0REAOperatorNode.m
+++ b/ios/vendored/sdk44/react-native-reanimated/ios/Nodes/ABI44_0_0REAOperatorNode.m
@@ -1,29 +1,32 @@
 #include <tgmath.h>
 
-#import "ABI44_0_0REAOperatorNode.h"
 #import "ABI44_0_0REANodesManager.h"
+#import "ABI44_0_0REAOperatorNode.h"
 
 typedef id (^ABI44_0_0REAOperatorBlock)(NSArray<ABI44_0_0REANode *> *inputNodes);
 
-#define ABI44_0_0REA_REDUCE(OP) ^(NSArray<ABI44_0_0REANode *> *inputNodes) { \
-double acc = [[inputNodes[0] value] doubleValue]; \
-for (NSUInteger i = 1; i < inputNodes.count; i++) { \
-  double a = acc, b = [[inputNodes[i] value] doubleValue]; \
-  acc = OP; \
-} \
-return @(acc); \
-}
+#define ABI44_0_0REA_REDUCE(OP)                                         \
+  ^(NSArray<ABI44_0_0REANode *> * inputNodes) {                         \
+    double acc = [[inputNodes[0] value] doubleValue];          \
+    for (NSUInteger i = 1; i < inputNodes.count; i++) {        \
+      double a = acc, b = [[inputNodes[i] value] doubleValue]; \
+      acc = OP;                                                \
+    }                                                          \
+    return @(acc);                                             \
+  }
 
-#define ABI44_0_0REA_SINGLE(OP) ^(NSArray<ABI44_0_0REANode *> *inputNodes) { \
-double a = [[inputNodes[0] value] doubleValue]; \
-return @(OP); \
-}
+#define ABI44_0_0REA_SINGLE(OP)                              \
+  ^(NSArray<ABI44_0_0REANode *> * inputNodes) {              \
+    double a = [[inputNodes[0] value] doubleValue]; \
+    return @(OP);                                   \
+  }
 
-#define ABI44_0_0REA_INFIX(OP) ^(NSArray<ABI44_0_0REANode *> *inputNodes) { \
-double a = [[inputNodes[0] value] doubleValue]; \
-double b = [[inputNodes[1] value] doubleValue]; \
-return @(OP); \
-}
+#define ABI44_0_0REA_INFIX(OP)                               \
+  ^(NSArray<ABI44_0_0REANode *> * inputNodes) {              \
+    double a = [[inputNodes[0] value] doubleValue]; \
+    double b = [[inputNodes[1] value] doubleValue]; \
+    return @(OP);                                   \
+  }
 
 @implementation ABI44_0_0REAOperatorNode {
   NSArray<NSNumber *> *_input;
@@ -31,55 +34,54 @@ return @(OP); \
   ABI44_0_0REAOperatorBlock _op;
 }
 
-- (instancetype)initWithID:(ABI44_0_0REANodeID)nodeID config:(NSDictionary<NSString *,id> *)config
+- (instancetype)initWithID:(ABI44_0_0REANodeID)nodeID config:(NSDictionary<NSString *, id> *)config
 {
   static NSDictionary *OPS;
   static dispatch_once_t opsToken;
   dispatch_once(&opsToken, ^{
-    OPS = @{
-            // arithmetic
-            @"add": ABI44_0_0REA_REDUCE(a + b),
-            @"sub": ABI44_0_0REA_REDUCE(a - b),
-            @"multiply": ABI44_0_0REA_REDUCE(a * b),
-            @"divide": ABI44_0_0REA_REDUCE(a / b),
-            @"pow": ABI44_0_0REA_REDUCE(pow(a, b)),
-            @"modulo": ABI44_0_0REA_REDUCE(fmod(fmod(a, b) + b, b)),
-            @"sqrt": ABI44_0_0REA_SINGLE(sqrt(a)),
-            @"log": ABI44_0_0REA_SINGLE(log(a)),
-            @"sin": ABI44_0_0REA_SINGLE(sin(a)),
-            @"cos": ABI44_0_0REA_SINGLE(cos(a)),
-            @"tan": ABI44_0_0REA_SINGLE(tan(a)),
-            @"acos": ABI44_0_0REA_SINGLE(acos(a)),
-            @"asin": ABI44_0_0REA_SINGLE(asin(a)),
-            @"atan": ABI44_0_0REA_SINGLE(atan(a)),
-            @"exp": ABI44_0_0REA_SINGLE(exp(a)),
-            @"round": ABI44_0_0REA_SINGLE(round(a)),
-            @"abs": ABI44_0_0REA_SINGLE(fabs(a)),
-            @"ceil": ABI44_0_0REA_SINGLE(ceil(a)),
-            @"floor": ABI44_0_0REA_SINGLE(floor(a)),
-            @"max": ABI44_0_0REA_REDUCE(MAX(a, b)),
-            @"min": ABI44_0_0REA_REDUCE(MIN(a, b)),
+    OPS = @{// arithmetic
+            @"add" : ABI44_0_0REA_REDUCE(a + b),
+            @"sub" : ABI44_0_0REA_REDUCE(a - b),
+            @"multiply" : ABI44_0_0REA_REDUCE(a * b),
+            @"divide" : ABI44_0_0REA_REDUCE(a / b),
+            @"pow" : ABI44_0_0REA_REDUCE(pow(a, b)),
+            @"modulo" : ABI44_0_0REA_REDUCE(fmod(fmod(a, b) + b, b)),
+            @"sqrt" : ABI44_0_0REA_SINGLE(sqrt(a)),
+            @"log" : ABI44_0_0REA_SINGLE(log(a)),
+            @"sin" : ABI44_0_0REA_SINGLE(sin(a)),
+            @"cos" : ABI44_0_0REA_SINGLE(cos(a)),
+            @"tan" : ABI44_0_0REA_SINGLE(tan(a)),
+            @"acos" : ABI44_0_0REA_SINGLE(acos(a)),
+            @"asin" : ABI44_0_0REA_SINGLE(asin(a)),
+            @"atan" : ABI44_0_0REA_SINGLE(atan(a)),
+            @"exp" : ABI44_0_0REA_SINGLE(exp(a)),
+            @"round" : ABI44_0_0REA_SINGLE(round(a)),
+            @"abs" : ABI44_0_0REA_SINGLE(fabs(a)),
+            @"ceil" : ABI44_0_0REA_SINGLE(ceil(a)),
+            @"floor" : ABI44_0_0REA_SINGLE(floor(a)),
+            @"max" : ABI44_0_0REA_REDUCE(MAX(a, b)),
+            @"min" : ABI44_0_0REA_REDUCE(MIN(a, b)),
 
             // logical
-            @"and": ^(NSArray<ABI44_0_0REANode *> *inputNodes) {
-              BOOL res = [[inputNodes[0] value] doubleValue];
-              for (NSUInteger i = 1; i < inputNodes.count && res; i++) {
-                res = res && [[inputNodes[i] value] doubleValue];
-              }
-              return res ? @(1.) : @(0.);
+            @"and" : ^(NSArray<ABI44_0_0REANode *> *inputNodes){
+                BOOL res = [[inputNodes[0] value] doubleValue];
+    for (NSUInteger i = 1; i < inputNodes.count && res; i++) {
+      res = res && [[inputNodes[i] value] doubleValue];
+    }
+    return res ? @(1.) : @(0.);
             },
             @"or": ^(NSArray<ABI44_0_0REANode *> *inputNodes) {
-              BOOL res = [[inputNodes[0] value] doubleValue];
-              for (NSUInteger i = 1; i < inputNodes.count && !res; i++) {
-                res = res || [[inputNodes[i] value] doubleValue];
-              }
-              return res ? @(1.) : @(0.);
+    BOOL res = [[inputNodes[0] value] doubleValue];
+    for (NSUInteger i = 1; i < inputNodes.count && !res; i++) {
+      res = res || [[inputNodes[i] value] doubleValue];
+    }
+    return res ? @(1.) : @(0.);
             },
             @"not": ABI44_0_0REA_SINGLE(!a),
             @"defined": ^(NSArray<ABI44_0_0REANode *> *inputNodes) {
-              id val = [inputNodes[0] value];
-              id res = @(val != nil && !([val isKindOfClass:[NSNumber class]] && isnan([val doubleValue])));
-              return res;
+    id val = [inputNodes[0] value];
+    id res = @(val != nil && !([val isKindOfClass:[NSNumber class]] && isnan([val doubleValue])));
+    return res;
             },
 
             // comparing
@@ -89,17 +91,17 @@ return @(OP); \
             @"lessOrEq": ABI44_0_0REA_INFIX(a <= b),
             @"greaterOrEq": ABI44_0_0REA_INFIX(a >= b),
              @"neq": ABI44_0_0REA_INFIX(a != b),
-            };
-  });
-  if ((self = [super initWithID:nodeID config:config])) {
-    _input = config[@"input"];
-    _inputNodes = [NSMutableArray arrayWithCapacity:_input.count];
-    _op = OPS[config[@"op"]];
-    if (!_op) {
-      ABI44_0_0RCTLogError(@"Operator '%@' not found", config[@"op"]);
-    }
+};
+});
+if ((self = [super initWithID:nodeID config:config])) {
+  _input = config[@"input"];
+  _inputNodes = [NSMutableArray arrayWithCapacity:_input.count];
+  _op = OPS[config[@"op"]];
+  if (!_op) {
+    ABI44_0_0RCTLogError(@"Operator '%@' not found", config[@"op"]);
   }
-  return self;
+}
+return self;
 }
 
 - (id)evaluate
@@ -111,4 +113,3 @@ return @(OP); \
 }
 
 @end
-

--- a/ios/vendored/sdk44/react-native-reanimated/ios/Nodes/ABI44_0_0REAParamNode.h
+++ b/ios/vendored/sdk44/react-native-reanimated/ios/Nodes/ABI44_0_0REAParamNode.h
@@ -2,11 +2,9 @@
 
 @interface ABI44_0_0REAParamNode : ABI44_0_0REAValueNode
 
-- (void)beginContext:(NSNumber*) ref
-          prevCallID:(NSNumber*) prevCallID;
+- (void)beginContext:(NSNumber *)ref prevCallID:(NSNumber *)prevCallID;
 - (void)endContext;
 - (void)start;
 - (void)stop;
 - (BOOL)isRunning;
 @end
-

--- a/ios/vendored/sdk44/react-native-reanimated/ios/Nodes/ABI44_0_0REAParamNode.m
+++ b/ios/vendored/sdk44/react-native-reanimated/ios/Nodes/ABI44_0_0REAParamNode.m
@@ -1,14 +1,14 @@
 #import "ABI44_0_0REAParamNode.h"
-#import "ABI44_0_0REAValueNode.h"
-#import "ABI44_0_0REANodesManager.h"
 #import "ABI44_0_0REAClockNodes.h"
+#import "ABI44_0_0REANodesManager.h"
+#import "ABI44_0_0REAValueNode.h"
 
 @implementation ABI44_0_0REAParamNode {
   NSMutableArray<ABI44_0_0REANodeID> *_argstack;
   NSString *_prevCallID;
 }
 
-- (instancetype)initWithID:(ABI44_0_0REANodeID)nodeID config:(NSDictionary<NSString *,id> *)config
+- (instancetype)initWithID:(ABI44_0_0REANodeID)nodeID config:(NSDictionary<NSString *, id> *)config
 {
   if ((self = [super initWithID:nodeID config:config])) {
     _argstack = [NSMutableArray<ABI44_0_0REANodeID> arrayWithCapacity:0];
@@ -21,13 +21,12 @@
   ABI44_0_0REANode *node = [self.nodesManager findNodeByID:[_argstack lastObject]];
   NSString *callID = self.updateContext.callID;
   self.updateContext.callID = _prevCallID;
-  [(ABI44_0_0REAValueNode*)node setValue:value];
+  [(ABI44_0_0REAValueNode *)node setValue:value];
   self.updateContext.callID = callID;
   [self forceUpdateMemoizedValue:value];
 }
 
-- (void)beginContext:(NSNumber*) ref
-          prevCallID:(NSString*) prevCallID
+- (void)beginContext:(NSNumber *)ref prevCallID:(NSString *)prevCallID
 {
   _prevCallID = prevCallID;
   [_argstack addObject:ref];
@@ -38,12 +37,11 @@
   [_argstack removeLastObject];
 }
 
-
 - (id)evaluate
 {
   NSString *callID = self.updateContext.callID;
   self.updateContext.callID = _prevCallID;
-  ABI44_0_0REANode * node = [self.nodesManager findNodeByID:[_argstack lastObject]];
+  ABI44_0_0REANode *node = [self.nodesManager findNodeByID:[_argstack lastObject]];
   id val = [node value];
   self.updateContext.callID = callID;
   return val;
@@ -51,31 +49,31 @@
 
 - (void)start
 {
-  ABI44_0_0REANode* node = [self.nodesManager findNodeByID:[_argstack lastObject]];
+  ABI44_0_0REANode *node = [self.nodesManager findNodeByID:[_argstack lastObject]];
   if ([node isKindOfClass:[ABI44_0_0REAParamNode class]]) {
-    [(ABI44_0_0REAParamNode* )node start];
+    [(ABI44_0_0REAParamNode *)node start];
   } else {
-    [(ABI44_0_0REAClockNode* )node start];
+    [(ABI44_0_0REAClockNode *)node start];
   }
 }
 
 - (void)stop
 {
-  ABI44_0_0REANode* node = [self.nodesManager findNodeByID:[_argstack lastObject]];
+  ABI44_0_0REANode *node = [self.nodesManager findNodeByID:[_argstack lastObject]];
   if ([node isKindOfClass:[ABI44_0_0REAParamNode class]]) {
-    [(ABI44_0_0REAParamNode* )node stop];
+    [(ABI44_0_0REAParamNode *)node stop];
   } else {
-    [(ABI44_0_0REAClockNode* )node stop];
+    [(ABI44_0_0REAClockNode *)node stop];
   }
 }
 
 - (BOOL)isRunning
 {
-  ABI44_0_0REANode* node = [self.nodesManager findNodeByID:[_argstack lastObject]];
+  ABI44_0_0REANode *node = [self.nodesManager findNodeByID:[_argstack lastObject]];
   if ([node isKindOfClass:[ABI44_0_0REAParamNode class]]) {
-    return [(ABI44_0_0REAParamNode* )node isRunning];
+    return [(ABI44_0_0REAParamNode *)node isRunning];
   }
-  return [(ABI44_0_0REAClockNode* )node isRunning];
+  return [(ABI44_0_0REAClockNode *)node isRunning];
 }
 
 @end

--- a/ios/vendored/sdk44/react-native-reanimated/ios/Nodes/ABI44_0_0REAPropsNode.h
+++ b/ios/vendored/sdk44/react-native-reanimated/ios/Nodes/ABI44_0_0REAPropsNode.h
@@ -2,10 +2,8 @@
 
 @interface ABI44_0_0REAPropsNode : ABI44_0_0REANode <ABI44_0_0REAFinalNode>
 
-- (void)connectToView:(NSNumber *_Nonnull)viewTag
-             viewName:(NSString *_Nonnull)viewName;
+- (void)connectToView:(NSNumber *_Nonnull)viewTag viewName:(NSString *_Nonnull)viewName;
 
 - (void)disconnectFromView:(NSNumber *_Nonnull)viewTag;
 
 @end
-

--- a/ios/vendored/sdk44/react-native-reanimated/ios/Nodes/ABI44_0_0REAPropsNode.m
+++ b/ios/vendored/sdk44/react-native-reanimated/ios/Nodes/ABI44_0_0REAPropsNode.m
@@ -1,22 +1,20 @@
 #import "ABI44_0_0REAPropsNode.h"
 
+#import "ABI44_0_0REAModule.h"
 #import "ABI44_0_0REANodesManager.h"
 #import "ABI44_0_0REAStyleNode.h"
-#import "ABI44_0_0REAModule.h"
 
 #import <ABI44_0_0React/ABI44_0_0RCTLog.h>
 #import <ABI44_0_0React/ABI44_0_0RCTUIManager.h>
-#import "ABI44_0_0React/ABI44_0_0RCTComponentData.h"
+#import <ABI44_0_0React/ABI44_0_0RCTComponentData.h>
 
-@implementation ABI44_0_0REAPropsNode
-{
+@implementation ABI44_0_0REAPropsNode {
   NSNumber *_connectedViewTag;
   NSString *_connectedViewName;
   NSMutableDictionary<NSString *, ABI44_0_0REANodeID> *_propsConfig;
 }
 
-- (instancetype)initWithID:(ABI44_0_0REANodeID)nodeID
-                    config:(NSDictionary<NSString *,id> *)config
+- (instancetype)initWithID:(ABI44_0_0REANodeID)nodeID config:(NSDictionary<NSString *, id> *)config
 {
   if (self = [super initWithID:nodeID config:config]) {
     _propsConfig = config[@"props"];
@@ -24,8 +22,7 @@
   return self;
 }
 
-- (void)connectToView:(NSNumber *)viewTag
-             viewName:(NSString *)viewName
+- (void)connectToView:(NSNumber *)viewTag viewName:(NSString *)viewName
 {
   _connectedViewTag = viewTag;
   _connectedViewName = viewName;
@@ -43,8 +40,8 @@
   NSMutableDictionary *uiProps = [NSMutableDictionary new];
   NSMutableDictionary *nativeProps = [NSMutableDictionary new];
   NSMutableDictionary *jsProps = [NSMutableDictionary new];
-  
-  void (^addBlock)(NSString *key, id obj, BOOL * stop) = ^(NSString *key, id obj, BOOL * stop){
+
+  void (^addBlock)(NSString *key, id obj, BOOL *stop) = ^(NSString *key, id obj, BOOL *stop) {
     if ([self.nodesManager.uiProps containsObject:key]) {
       uiProps[key] = obj;
     } else if ([self.nodesManager.nativeProps containsObject:key]) {
@@ -53,34 +50,35 @@
       jsProps[key] = obj;
     }
   };
-  
+
   for (NSString *prop in _propsConfig) {
     ABI44_0_0REANode *propNode = [self.nodesManager findNodeByID:_propsConfig[prop]];
-    
+
     if ([propNode isKindOfClass:[ABI44_0_0REAStyleNode class]]) {
       [[propNode value] enumerateKeysAndObjectsUsingBlock:addBlock];
     } else {
       addBlock(prop, [propNode value], nil);
     }
   }
-  
+
   if (_connectedViewTag != nil) {
     if (uiProps.count > 0) {
-      [self.nodesManager.uiManager
-       synchronouslyUpdateViewOnUIThread:_connectedViewTag
-       viewName:_connectedViewName
-       props:uiProps];
+      [self.nodesManager.uiManager synchronouslyUpdateViewOnUIThread:_connectedViewTag
+                                                            viewName:_connectedViewName
+                                                               props:uiProps];
     }
     if (nativeProps.count > 0) {
-      [self.nodesManager enqueueUpdateViewOnNativeThread:_connectedViewTag viewName:_connectedViewName nativeProps:nativeProps trySynchronously:NO];
+      [self.nodesManager enqueueUpdateViewOnNativeThread:_connectedViewTag
+                                                viewName:_connectedViewName
+                                             nativeProps:nativeProps
+                                        trySynchronously:NO];
     }
     if (jsProps.count > 0) {
-      [self.nodesManager.reanimatedModule
-       sendEventWithName:@"onReanimatedPropsChange"
-       body:@{@"viewTag": _connectedViewTag, @"props": jsProps }];
+      [self.nodesManager.reanimatedModule sendEventWithName:@"onReanimatedPropsChange"
+                                                       body:@{@"viewTag" : _connectedViewTag, @"props" : jsProps}];
     }
   }
-  
+
   return @(0);
 }
 
@@ -98,4 +96,3 @@
 }
 
 @end
-

--- a/ios/vendored/sdk44/react-native-reanimated/ios/Nodes/ABI44_0_0REASetNode.h
+++ b/ios/vendored/sdk44/react-native-reanimated/ios/Nodes/ABI44_0_0REASetNode.h
@@ -3,4 +3,3 @@
 @interface ABI44_0_0REASetNode : ABI44_0_0REANode
 
 @end
-

--- a/ios/vendored/sdk44/react-native-reanimated/ios/Nodes/ABI44_0_0REASetNode.m
+++ b/ios/vendored/sdk44/react-native-reanimated/ios/Nodes/ABI44_0_0REASetNode.m
@@ -1,22 +1,24 @@
 #import "ABI44_0_0REASetNode.h"
-#import "ABI44_0_0REAUtils.h"
 #import <ABI44_0_0React/ABI44_0_0RCTConvert.h>
 #import <ABI44_0_0React/ABI44_0_0RCTLog.h>
-#import "ABI44_0_0REAValueNode.h"
 #import "ABI44_0_0REANodesManager.h"
+#import "ABI44_0_0REAUtils.h"
+#import "ABI44_0_0REAValueNode.h"
 
 @implementation ABI44_0_0REASetNode {
   NSNumber *_whatNodeID;
   NSNumber *_valueNodeID;
 }
 
-- (instancetype)initWithID:(ABI44_0_0REANodeID)nodeID config:(NSDictionary<NSString *,id> *)config
+- (instancetype)initWithID:(ABI44_0_0REANodeID)nodeID config:(NSDictionary<NSString *, id> *)config
 {
   if ((self = [super initWithID:nodeID config:config])) {
     _whatNodeID = [ABI44_0_0RCTConvert NSNumber:config[@"what"]];
-    ABI44_0_0REA_LOG_ERROR_IF_NIL(_whatNodeID, @"Reanimated: First argument passed to set node is either of wrong type or is missing.");
+    ABI44_0_0REA_LOG_ERROR_IF_NIL(
+        _whatNodeID, @"Reanimated: First argument passed to set node is either of wrong type or is missing.");
     _valueNodeID = [ABI44_0_0RCTConvert NSNumber:config[@"value"]];
-    ABI44_0_0REA_LOG_ERROR_IF_NIL(_valueNodeID, @"Reanimated: Second argument passed to set node is either of wrong type or is missing.");
+    ABI44_0_0REA_LOG_ERROR_IF_NIL(
+        _valueNodeID, @"Reanimated: Second argument passed to set node is either of wrong type or is missing.");
   }
   return self;
 }

--- a/ios/vendored/sdk44/react-native-reanimated/ios/Nodes/ABI44_0_0REAStyleNode.h
+++ b/ios/vendored/sdk44/react-native-reanimated/ios/Nodes/ABI44_0_0REAStyleNode.h
@@ -3,4 +3,3 @@
 @interface ABI44_0_0REAStyleNode : ABI44_0_0REANode
 
 @end
-

--- a/ios/vendored/sdk44/react-native-reanimated/ios/Nodes/ABI44_0_0REAStyleNode.m
+++ b/ios/vendored/sdk44/react-native-reanimated/ios/Nodes/ABI44_0_0REAStyleNode.m
@@ -2,13 +2,11 @@
 
 #import "ABI44_0_0REANodesManager.h"
 
-@implementation ABI44_0_0REAStyleNode
-{
+@implementation ABI44_0_0REAStyleNode {
   NSMutableDictionary<NSString *, ABI44_0_0REANodeID> *_styleConfig;
 }
 
-- (instancetype)initWithID:(ABI44_0_0REANodeID)nodeID
-                    config:(NSDictionary<NSString *, id> *)config;
+- (instancetype)initWithID:(ABI44_0_0REANodeID)nodeID config:(NSDictionary<NSString *, id> *)config;
 {
   if ((self = [super initWithID:nodeID config:config])) {
     _styleConfig = config[@"style"];

--- a/ios/vendored/sdk44/react-native-reanimated/ios/Nodes/ABI44_0_0REATransformNode.h
+++ b/ios/vendored/sdk44/react-native-reanimated/ios/Nodes/ABI44_0_0REATransformNode.h
@@ -3,4 +3,3 @@
 @interface ABI44_0_0REATransformNode : ABI44_0_0REANode
 
 @end
-

--- a/ios/vendored/sdk44/react-native-reanimated/ios/Nodes/ABI44_0_0REATransformNode.m
+++ b/ios/vendored/sdk44/react-native-reanimated/ios/Nodes/ABI44_0_0REATransformNode.m
@@ -2,12 +2,11 @@
 #import <ABI44_0_0React/ABI44_0_0RCTConvert.h>
 #import "ABI44_0_0REANodesManager.h"
 
-@implementation ABI44_0_0REATransformNode
-{
+@implementation ABI44_0_0REATransformNode {
   NSArray<id> *_transformConfigs;
 }
 
-- (instancetype)initWithID:(ABI44_0_0REANodeID)nodeID config:(NSDictionary<NSString *,id> *)config
+- (instancetype)initWithID:(ABI44_0_0REANodeID)nodeID config:(NSDictionary<NSString *, id> *)config
 {
   if ((self = [super initWithID:nodeID config:config])) {
     _transformConfigs = config[@"transform"];
@@ -28,11 +27,10 @@
     } else {
       value = transformConfig[@"value"];
     }
-    [transform addObject:@{property: value}];
+    [transform addObject:@{property : value}];
   }
 
   return transform;
 }
 
 @end
-

--- a/ios/vendored/sdk44/react-native-reanimated/ios/Nodes/ABI44_0_0REAValueNode.m
+++ b/ios/vendored/sdk44/react-native-reanimated/ios/Nodes/ABI44_0_0REAValueNode.m
@@ -4,13 +4,12 @@
   NSNumber *_value;
 }
 
-- (instancetype)initWithID:(ABI44_0_0REANodeID)nodeID
-                    config:(NSDictionary<NSString *, id> *)config
+- (instancetype)initWithID:(ABI44_0_0REANodeID)nodeID config:(NSDictionary<NSString *, id> *)config
 {
-    if (self = [super initWithID:nodeID config:config]) {
-        _value = config[@"value"];
-    }
-    return self;
+  if (self = [super initWithID:nodeID config:config]) {
+    _value = config[@"value"];
+  }
+  return self;
 }
 
 - (void)setValue:(NSNumber *)value
@@ -25,4 +24,3 @@
 }
 
 @end
-

--- a/ios/vendored/sdk44/react-native-reanimated/ios/Transitioning/ABI44_0_0RCTConvert+REATransition.m
+++ b/ios/vendored/sdk44/react-native-reanimated/ios/Transitioning/ABI44_0_0RCTConvert+REATransition.m
@@ -2,36 +2,52 @@
 
 @implementation ABI44_0_0RCTConvert (ABI44_0_0REATransition)
 
-ABI44_0_0RCT_ENUM_CONVERTER(ABI44_0_0REATransitionType, (@{
-                                         @"none": @(ABI44_0_0REATransitionTypeNone),
-                                         @"group": @(ABI44_0_0REATransitionTypeGroup),
-                                         @"in": @(ABI44_0_0REATransitionTypeIn),
-                                         @"out": @(ABI44_0_0REATransitionTypeOut),
-                                         @"change": @(ABI44_0_0REATransitionTypeChange),
-                                         }), ABI44_0_0REATransitionTypeNone, integerValue)
+ABI44_0_0RCT_ENUM_CONVERTER(
+    ABI44_0_0REATransitionType,
+    (@{
+      @"none" : @(ABI44_0_0REATransitionTypeNone),
+      @"group" : @(ABI44_0_0REATransitionTypeGroup),
+      @"in" : @(ABI44_0_0REATransitionTypeIn),
+      @"out" : @(ABI44_0_0REATransitionTypeOut),
+      @"change" : @(ABI44_0_0REATransitionTypeChange),
+    }),
+    ABI44_0_0REATransitionTypeNone,
+    integerValue)
 
-ABI44_0_0RCT_ENUM_CONVERTER(ABI44_0_0REATransitionAnimationType, (@{
-                                                  @"none": @(ABI44_0_0REATransitionAnimationTypeNone),
-                                                  @"fade": @(ABI44_0_0REATransitionAnimationTypeFade),
-                                                  @"scale": @(ABI44_0_0REATransitionAnimationTypeScale),
-                                                  @"slide-top": @(ABI44_0_0REATransitionAnimationTypeSlideTop),
-                                                  @"slide-bottom": @(ABI44_0_0REATransitionAnimationTypeSlideBottom),
-                                                  @"slide-right": @(ABI44_0_0REATransitionAnimationTypeSlideRight),
-                                                  @"slide-left": @(ABI44_0_0REATransitionAnimationTypeSlideLeft)
-                                                  }), ABI44_0_0REATransitionAnimationTypeNone, integerValue)
+ABI44_0_0RCT_ENUM_CONVERTER(
+    ABI44_0_0REATransitionAnimationType,
+    (@{
+      @"none" : @(ABI44_0_0REATransitionAnimationTypeNone),
+      @"fade" : @(ABI44_0_0REATransitionAnimationTypeFade),
+      @"scale" : @(ABI44_0_0REATransitionAnimationTypeScale),
+      @"slide-top" : @(ABI44_0_0REATransitionAnimationTypeSlideTop),
+      @"slide-bottom" : @(ABI44_0_0REATransitionAnimationTypeSlideBottom),
+      @"slide-right" : @(ABI44_0_0REATransitionAnimationTypeSlideRight),
+      @"slide-left" : @(ABI44_0_0REATransitionAnimationTypeSlideLeft)
+    }),
+    ABI44_0_0REATransitionAnimationTypeNone,
+    integerValue)
 
-ABI44_0_0RCT_ENUM_CONVERTER(ABI44_0_0REATransitionInterpolationType, (@{
-                                                      @"linear": @(ABI44_0_0REATransitionInterpolationLinear),
-                                                      @"easeIn": @(ABI44_0_0REATransitionInterpolationEaseIn),
-                                                      @"easeOut": @(ABI44_0_0REATransitionInterpolationEaseOut),
-                                                      @"easeInOut": @(ABI44_0_0REATransitionInterpolationEaseInOut),
-                                                      }), ABI44_0_0REATransitionInterpolationLinear, integerValue)
+ABI44_0_0RCT_ENUM_CONVERTER(
+    ABI44_0_0REATransitionInterpolationType,
+    (@{
+      @"linear" : @(ABI44_0_0REATransitionInterpolationLinear),
+      @"easeIn" : @(ABI44_0_0REATransitionInterpolationEaseIn),
+      @"easeOut" : @(ABI44_0_0REATransitionInterpolationEaseOut),
+      @"easeInOut" : @(ABI44_0_0REATransitionInterpolationEaseInOut),
+    }),
+    ABI44_0_0REATransitionInterpolationLinear,
+    integerValue)
 
-ABI44_0_0RCT_ENUM_CONVERTER(ABI44_0_0REATransitionPropagationType, (@{
-                                                    @"none": @(ABI44_0_0REATransitionPropagationNone),
-                                                    @"top": @(ABI44_0_0REATransitionPropagationTop),
-                                                    @"bottom": @(ABI44_0_0REATransitionPropagationBottom),
-                                                    @"left": @(ABI44_0_0REATransitionPropagationLeft),
-                                                    @"right": @(ABI44_0_0REATransitionPropagationRight)
-                                                    }), ABI44_0_0REATransitionPropagationNone, integerValue)
+ABI44_0_0RCT_ENUM_CONVERTER(
+    ABI44_0_0REATransitionPropagationType,
+    (@{
+      @"none" : @(ABI44_0_0REATransitionPropagationNone),
+      @"top" : @(ABI44_0_0REATransitionPropagationTop),
+      @"bottom" : @(ABI44_0_0REATransitionPropagationBottom),
+      @"left" : @(ABI44_0_0REATransitionPropagationLeft),
+      @"right" : @(ABI44_0_0REATransitionPropagationRight)
+    }),
+    ABI44_0_0REATransitionPropagationNone,
+    integerValue)
 @end

--- a/ios/vendored/sdk44/react-native-reanimated/ios/Transitioning/ABI44_0_0REAAllTransitions.h
+++ b/ios/vendored/sdk44/react-native-reanimated/ios/Transitioning/ABI44_0_0REAAllTransitions.h
@@ -8,8 +8,8 @@
 
 @interface ABI44_0_0REAVisibilityTransition : ABI44_0_0REATransition
 @property (nonatomic) ABI44_0_0REATransitionAnimationType animationType;
-- (ABI44_0_0REATransitionAnimation *)appearView:(UIView*)view inParent:(UIView*)parent;
-- (ABI44_0_0REATransitionAnimation *)disappearView:(UIView*)view fromParent:(UIView*)parent;
+- (ABI44_0_0REATransitionAnimation *)appearView:(UIView *)view inParent:(UIView *)parent;
+- (ABI44_0_0REATransitionAnimation *)disappearView:(UIView *)view fromParent:(UIView *)parent;
 - (instancetype)initWithConfig:(NSDictionary *)config;
 @end
 

--- a/ios/vendored/sdk44/react-native-reanimated/ios/Transitioning/ABI44_0_0REAAllTransitions.m
+++ b/ios/vendored/sdk44/react-native-reanimated/ios/Transitioning/ABI44_0_0REAAllTransitions.m
@@ -1,7 +1,7 @@
 #import <ABI44_0_0React/ABI44_0_0RCTViewManager.h>
 
-#import "ABI44_0_0REAAllTransitions.h"
 #import "ABI44_0_0RCTConvert+REATransition.h"
+#import "ABI44_0_0REAAllTransitions.h"
 
 @interface ABI44_0_0REASnapshotRemover : NSObject <CAAnimationDelegate>
 @end
@@ -33,7 +33,7 @@
   if (self = [super initWithConfig:config]) {
     _sequence = [ABI44_0_0RCTConvert BOOL:config[@"sequence"]];
     NSArray *transitions = [ABI44_0_0RCTConvert NSArray:config[@"transitions"]];
-    NSMutableArray<ABI44_0_0REATransition*> *inflated = [NSMutableArray new];
+    NSMutableArray<ABI44_0_0REATransition *> *inflated = [NSMutableArray new];
     for (NSDictionary *transitionConfig in transitions) {
       [inflated addObject:[ABI44_0_0REATransition inflate:transitionConfig]];
       inflated.lastObject.parent = self;
@@ -51,9 +51,10 @@
   return self;
 }
 
-- (NSArray<ABI44_0_0REATransitionAnimation *> *)animationsForTransitioning:(NSMutableDictionary<NSNumber *,ABI44_0_0REATransitionValues *> *)startValues
-                                                           endValues:(NSMutableDictionary<NSNumber *,ABI44_0_0REATransitionValues *> *)endValues
-                                                             forRoot:(UIView *)root
+- (NSArray<ABI44_0_0REATransitionAnimation *> *)
+    animationsForTransitioning:(NSMutableDictionary<NSNumber *, ABI44_0_0REATransitionValues *> *)startValues
+                     endValues:(NSMutableDictionary<NSNumber *, ABI44_0_0REATransitionValues *> *)endValues
+                       forRoot:(UIView *)root
 {
   CFTimeInterval delay = self.delay;
   NSMutableArray *animations = [NSMutableArray new];
@@ -74,7 +75,6 @@
 
 @end
 
-
 @implementation ABI44_0_0REAVisibilityTransition
 
 - (instancetype)initWithConfig:(NSDictionary *)config
@@ -85,23 +85,19 @@
   return self;
 }
 
-- (ABI44_0_0REATransitionAnimation *)appearView:(UIView *)view
-                                 inParent:(UIView *)parent
-                                  forRoot:(UIView *)root
+- (ABI44_0_0REATransitionAnimation *)appearView:(UIView *)view inParent:(UIView *)parent forRoot:(UIView *)root
 {
   return nil;
 }
 
-- (ABI44_0_0REATransitionAnimation *)disappearView:(UIView *)view
-                                  fromParent:(UIView *)parent
-                                     forRoot:(UIView *)root
+- (ABI44_0_0REATransitionAnimation *)disappearView:(UIView *)view fromParent:(UIView *)parent forRoot:(UIView *)root
 {
   return nil;
 }
 
 - (ABI44_0_0REATransitionAnimation *)animationForTransitioning:(ABI44_0_0REATransitionValues *)startValues
-                                               endValues:(ABI44_0_0REATransitionValues *)endValues
-                                                 forRoot:(UIView *)root
+                                            endValues:(ABI44_0_0REATransitionValues *)endValues
+                                              forRoot:(UIView *)root
 {
   BOOL isViewAppearing = (startValues == nil);
   if (isViewAppearing && !IS_LAYOUT_ONLY(endValues.view)) {
@@ -123,7 +119,6 @@
 
 @end
 
-
 @implementation ABI44_0_0REAInTransition
 - (instancetype)initWithConfig:(NSDictionary *)config
 {
@@ -132,9 +127,7 @@
   return self;
 }
 
-- (ABI44_0_0REATransitionAnimation *)appearView:(UIView *)view
-                                 inParent:(UIView *)parent
-                                  forRoot:(UIView *)root
+- (ABI44_0_0REATransitionAnimation *)appearView:(UIView *)view inParent:(UIView *)parent forRoot:(UIView *)root
 {
   CABasicAnimation *animation;
   switch (self.animationType) {
@@ -186,7 +179,6 @@
 }
 @end
 
-
 @implementation ABI44_0_0REAOutTransition
 - (instancetype)initWithConfig:(NSDictionary *)config
 {
@@ -195,9 +187,7 @@
   return self;
 }
 
-- (ABI44_0_0REATransitionAnimation *)disappearView:(UIView *)view
-                               fromParent:(UIView *)parent
-                                  forRoot:(UIView *)root
+- (ABI44_0_0REATransitionAnimation *)disappearView:(UIView *)view fromParent:(UIView *)parent forRoot:(UIView *)root
 {
   if (self.animationType == ABI44_0_0REATransitionAnimationTypeNone) {
     return nil;
@@ -262,12 +252,11 @@
 }
 @end
 
-
 @implementation ABI44_0_0REAChangeTransition
 
 - (ABI44_0_0REATransitionAnimation *)animationForTransitioning:(ABI44_0_0REATransitionValues *)startValues
-                                               endValues:(ABI44_0_0REATransitionValues *)endValues
-                                                 forRoot:(UIView *)root
+                                            endValues:(ABI44_0_0REATransitionValues *)endValues
+                                              forRoot:(UIView *)root
 {
   if (startValues == nil || endValues == nil || endValues.view.window == nil) {
     return nil;

--- a/ios/vendored/sdk44/react-native-reanimated/ios/Transitioning/ABI44_0_0REATransition.h
+++ b/ios/vendored/sdk44/react-native-reanimated/ios/Transitioning/ABI44_0_0REATransition.h
@@ -1,6 +1,6 @@
-#import <UIKit/UIKit.h>
 #import <QuartzCore/QuartzCore.h>
 #import <ABI44_0_0React/ABI44_0_0RCTView.h>
+#import <UIKit/UIKit.h>
 
 #import "ABI44_0_0REATransitionAnimation.h"
 #import "ABI44_0_0REATransitionValues.h"
@@ -53,12 +53,13 @@ typedef NS_ENUM(NSInteger, ABI44_0_0REATransitionPropagationType) {
 - (void)playInRoot:(UIView *)root;
 - (ABI44_0_0REATransitionValues *)findStartValuesForKey:(NSNumber *)key;
 - (ABI44_0_0REATransitionValues *)findEndValuesForKey:(NSNumber *)key;
-- (ABI44_0_0REATransitionAnimation *)animationForTransitioning:(ABI44_0_0REATransitionValues*)startValues
-                                               endValues:(ABI44_0_0REATransitionValues*)endValues
-                                                 forRoot:(UIView *)root;
-- (NSArray<ABI44_0_0REATransitionAnimation*> *)animationsForTransitioning:(NSMutableDictionary<NSNumber*, ABI44_0_0REATransitionValues*> *)startValues
-                                                          endValues:(NSMutableDictionary<NSNumber*, ABI44_0_0REATransitionValues*> *)endValues
-                                                            forRoot:(UIView *)root;
+- (ABI44_0_0REATransitionAnimation *)animationForTransitioning:(ABI44_0_0REATransitionValues *)startValues
+                                            endValues:(ABI44_0_0REATransitionValues *)endValues
+                                              forRoot:(UIView *)root;
+- (NSArray<ABI44_0_0REATransitionAnimation *> *)
+    animationsForTransitioning:(NSMutableDictionary<NSNumber *, ABI44_0_0REATransitionValues *> *)startValues
+                     endValues:(NSMutableDictionary<NSNumber *, ABI44_0_0REATransitionValues *> *)endValues
+                       forRoot:(UIView *)root;
 
 + (ABI44_0_0REATransition *)inflate:(NSDictionary *)config;
 @end

--- a/ios/vendored/sdk44/react-native-reanimated/ios/Transitioning/ABI44_0_0REATransition.m
+++ b/ios/vendored/sdk44/react-native-reanimated/ios/Transitioning/ABI44_0_0REATransition.m
@@ -1,11 +1,11 @@
-#import <UIKit/UIKit.h>
 #import <QuartzCore/QuartzCore.h>
 #import <ABI44_0_0React/ABI44_0_0RCTConvert.h>
 #import <ABI44_0_0React/ABI44_0_0RCTViewManager.h>
+#import <UIKit/UIKit.h>
 
+#import "ABI44_0_0RCTConvert+REATransition.h"
 #import "ABI44_0_0REATransition.h"
 #import "ABI44_0_0REATransitionValues.h"
-#import "ABI44_0_0RCTConvert+REATransition.h"
 
 #define DEFAULT_PROPAGATION_SPEED 3
 
@@ -17,8 +17,8 @@
 
 @interface ABI44_0_0REAVisibilityTransition : ABI44_0_0REATransition
 @property (nonatomic) ABI44_0_0REATransitionAnimationType animationType;
-- (ABI44_0_0REATransitionAnimation *)appearView:(UIView*)view inParent:(UIView*)parent;
-- (ABI44_0_0REATransitionAnimation *)disappearView:(UIView*)view fromParent:(UIView*)parent;
+- (ABI44_0_0REATransitionAnimation *)appearView:(UIView *)view inParent:(UIView *)parent;
+- (ABI44_0_0REATransitionAnimation *)disappearView:(UIView *)view fromParent:(UIView *)parent;
 - (instancetype)initWithConfig:(NSDictionary *)config;
 @end
 
@@ -36,8 +36,8 @@
 
 @implementation ABI44_0_0REATransition {
   __weak UIView *_root;
-  NSMutableDictionary<NSNumber*, ABI44_0_0REATransitionValues*> *_startValues;
-  NSMutableDictionary<NSNumber*, ABI44_0_0REATransitionValues*> *_endValues;
+  NSMutableDictionary<NSNumber *, ABI44_0_0REATransitionValues *> *_startValues;
+  NSMutableDictionary<NSNumber *, ABI44_0_0REATransitionValues *> *_endValues;
 }
 
 + (ABI44_0_0REATransition *)inflate:(NSDictionary *)config
@@ -70,7 +70,9 @@
   return self;
 }
 
-- (void)captureRecursiveIn:(UIView *)view to:(NSMutableDictionary<NSNumber*, ABI44_0_0REATransitionValues*> *)map forRoot:(UIView *)root
+- (void)captureRecursiveIn:(UIView *)view
+                        to:(NSMutableDictionary<NSNumber *, ABI44_0_0REATransitionValues *> *)map
+                   forRoot:(UIView *)root
 {
   NSNumber *tag = view.ABI44_0_0ReactTag;
   if (tag != nil) {
@@ -91,9 +93,7 @@
 {
   _endValues = [NSMutableDictionary new];
   [self captureRecursiveIn:root to:_endValues forRoot:root];
-  NSArray *animations = [self animationsForTransitioning:_startValues
-                                               endValues:_endValues
-                                                 forRoot:root];
+  NSArray *animations = [self animationsForTransitioning:_startValues endValues:_endValues forRoot:root];
   for (ABI44_0_0REATransitionAnimation *animation in animations) {
     [animation play];
   }
@@ -164,15 +164,16 @@
 }
 
 - (ABI44_0_0REATransitionAnimation *)animationForTransitioning:(ABI44_0_0REATransitionValues *)startValues
-                                               endValues:(ABI44_0_0REATransitionValues *)endValues
-                                                 forRoot:(UIView *)root
+                                            endValues:(ABI44_0_0REATransitionValues *)endValues
+                                              forRoot:(UIView *)root
 {
   return nil;
 }
 
-- (NSArray<ABI44_0_0REATransitionAnimation*> *)animationsForTransitioning:(NSMutableDictionary<NSNumber *,ABI44_0_0REATransitionValues *> *)startValues
-                                                          endValues:(NSMutableDictionary<NSNumber *,ABI44_0_0REATransitionValues *> *)endValues
-                                                            forRoot:(UIView *)root
+- (NSArray<ABI44_0_0REATransitionAnimation *> *)
+    animationsForTransitioning:(NSMutableDictionary<NSNumber *, ABI44_0_0REATransitionValues *> *)startValues
+                     endValues:(NSMutableDictionary<NSNumber *, ABI44_0_0REATransitionValues *> *)endValues
+                       forRoot:(UIView *)root
 {
   NSMutableArray *animations = [NSMutableArray new];
   [startValues enumerateKeysAndObjectsUsingBlock:^(NSNumber *key, ABI44_0_0REATransitionValues *startValue, BOOL *stop) {
@@ -182,7 +183,9 @@
       animation.animation.timingFunction = self.mediaTiming;
       animation.animation.duration = self.duration;
       [animation delayBy:self.delay];
-      CFTimeInterval propagationDelay = [self propagationDelayForTransitioning:startValue endValues:endValue forRoot:root];
+      CFTimeInterval propagationDelay = [self propagationDelayForTransitioning:startValue
+                                                                     endValues:endValue
+                                                                       forRoot:root];
       [animation delayBy:propagationDelay];
       //      animation.animation.duration -= propagationDelay;
       [animations addObject:animation];

--- a/ios/vendored/sdk44/react-native-reanimated/ios/Transitioning/ABI44_0_0REATransitionAnimation.h
+++ b/ios/vendored/sdk44/react-native-reanimated/ios/Transitioning/ABI44_0_0REATransitionAnimation.h
@@ -8,7 +8,7 @@
 
 + (ABI44_0_0REATransitionAnimation *)transitionWithAnimation:(CAAnimation *)animation
                                               layer:(CALayer *)layer
-                                         andKeyPath:(NSString*)keyPath;
+                                         andKeyPath:(NSString *)keyPath;
 - (void)play;
 - (void)delayBy:(CFTimeInterval)delay;
 - (CFTimeInterval)finishTime;

--- a/ios/vendored/sdk44/react-native-reanimated/ios/Transitioning/ABI44_0_0REATransitionAnimation.m
+++ b/ios/vendored/sdk44/react-native-reanimated/ios/Transitioning/ABI44_0_0REATransitionAnimation.m
@@ -2,7 +2,6 @@
 
 #import "ABI44_0_0REATransitionAnimation.h"
 
-
 #define DEFAULT_DURATION 0.25
 
 #if TARGET_IPHONE_SIMULATOR
@@ -31,7 +30,7 @@ CGFloat ABI44_0_0SimAnimationDragCoefficient()
 
 + (ABI44_0_0REATransitionAnimation *)transitionWithAnimation:(CAAnimation *)animation
                                               layer:(CALayer *)layer
-                                         andKeyPath:(NSString*)keyPath;
+                                         andKeyPath:(NSString *)keyPath;
 {
   ABI44_0_0REATransitionAnimation *anim = [ABI44_0_0REATransitionAnimation new];
   anim.animation = animation;
@@ -47,7 +46,7 @@ CGFloat ABI44_0_0SimAnimationDragCoefficient()
   it calls mach_absolute_time() which is based on the last time the device booted
   which might cause the delay
   */
-  if (_delay > 0){
+  if (_delay > 0) {
     _animation.beginTime = CACurrentMediaTime() + _delay * ABI44_0_0SimAnimationDragCoefficient();
   }
   _animation.duration = self.duration * ABI44_0_0SimAnimationDragCoefficient();

--- a/ios/vendored/sdk44/react-native-reanimated/ios/Transitioning/ABI44_0_0REATransitionManager.m
+++ b/ios/vendored/sdk44/react-native-reanimated/ios/Transitioning/ABI44_0_0REATransitionManager.m
@@ -35,7 +35,7 @@
 
 - (void)uiManagerWillPerformMounting:(ABI44_0_0RCTUIManager *)manager
 {
-  [manager addUIBlock:^(ABI44_0_0RCTUIManager *uiManager, NSDictionary<NSNumber *,UIView *> *viewRegistry) {
+  [manager addUIBlock:^(ABI44_0_0RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
     [_pendingTransition playInRoot:_pendingTransitionRoot];
     _pendingTransitionRoot = nil;
     _pendingTransition = nil;
@@ -45,7 +45,7 @@
 - (void)animateNextTransitionInRoot:(NSNumber *)ABI44_0_0ReactTag withConfig:(NSDictionary *)config
 {
   [_uiManager.observerCoordinator addObserver:self];
-  [_uiManager prependUIBlock:^(ABI44_0_0RCTUIManager *uiManager, NSDictionary<NSNumber *,UIView *> *viewRegistry) {
+  [_uiManager prependUIBlock:^(ABI44_0_0RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
     UIView *view = viewRegistry[ABI44_0_0ReactTag];
     NSArray *transitionConfigs = [ABI44_0_0RCTConvert NSArray:config[@"transitions"]];
     for (id transitionConfig in transitionConfigs) {
@@ -54,7 +54,7 @@
     }
   }];
   __weak id weakSelf = self;
-  [_uiManager addUIBlock:^(ABI44_0_0RCTUIManager *uiManager, NSDictionary<NSNumber *,UIView *> *viewRegistry) {
+  [_uiManager addUIBlock:^(ABI44_0_0RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
     [uiManager.observerCoordinator removeObserver:weakSelf];
   }];
 }

--- a/ios/vendored/sdk44/react-native-reanimated/ios/native/ABI44_0_0REAIOSErrorHandler.h
+++ b/ios/vendored/sdk44/react-native-reanimated/ios/native/ABI44_0_0REAIOSErrorHandler.h
@@ -1,20 +1,23 @@
 #pragma once
 
+#include <memory>
+#include <string>
 #include "ErrorHandler.h"
 #include "Scheduler.h"
 
 namespace ABI44_0_0reanimated {
 
 class ABI44_0_0REAIOSErrorHandler : public ErrorHandler {
-    std::shared_ptr<Scheduler> scheduler;
-    void raiseSpec() override;
-    std::shared_ptr<ErrorWrapper> error;
-    public:
-      ABI44_0_0REAIOSErrorHandler(std::shared_ptr<Scheduler> scheduler);
-      std::shared_ptr<Scheduler> getScheduler() override;
-      std::shared_ptr<ErrorWrapper> getError() override;
-      void setError(std::string message) override;
-      virtual ~ABI44_0_0REAIOSErrorHandler() {}
+  std::shared_ptr<Scheduler> scheduler;
+  void raiseSpec() override;
+  std::shared_ptr<ErrorWrapper> error;
+
+ public:
+  ABI44_0_0REAIOSErrorHandler(std::shared_ptr<Scheduler> scheduler);
+  std::shared_ptr<Scheduler> getScheduler() override;
+  std::shared_ptr<ErrorWrapper> getError() override;
+  void setError(std::string message) override;
+  virtual ~ABI44_0_0REAIOSErrorHandler() {}
 };
 
-}
+} // namespace reanimated

--- a/ios/vendored/sdk44/react-native-reanimated/ios/native/ABI44_0_0REAIOSErrorHandler.mm
+++ b/ios/vendored/sdk44/react-native-reanimated/ios/native/ABI44_0_0REAIOSErrorHandler.mm
@@ -2,31 +2,35 @@
 #import <Foundation/Foundation.h>
 #import <ABI44_0_0React/ABI44_0_0RCTLog.h>
 
-
 namespace ABI44_0_0reanimated {
 
-ABI44_0_0REAIOSErrorHandler::ABI44_0_0REAIOSErrorHandler(std::shared_ptr<Scheduler> scheduler) {
-    this->scheduler = scheduler;
-    error = std::make_shared<ErrorWrapper>();
+ABI44_0_0REAIOSErrorHandler::ABI44_0_0REAIOSErrorHandler(std::shared_ptr<Scheduler> scheduler)
+{
+  this->scheduler = scheduler;
+  error = std::make_shared<ErrorWrapper>();
 }
 
-void ABI44_0_0REAIOSErrorHandler::raiseSpec() {
-    if (error->handled) {
-        return;
-    }
-    ABI44_0_0RCTLogError(@(error->message.c_str()));
-    this->error->handled = true;
+void ABI44_0_0REAIOSErrorHandler::raiseSpec()
+{
+  if (error->handled) {
+    return;
+  }
+  ABI44_0_0RCTLogError(@(error->message.c_str()));
+  this->error->handled = true;
 }
 
-std::shared_ptr<Scheduler> ABI44_0_0REAIOSErrorHandler::getScheduler() {
-    return this->scheduler;
+std::shared_ptr<Scheduler> ABI44_0_0REAIOSErrorHandler::getScheduler()
+{
+  return this->scheduler;
 }
 
-std::shared_ptr<ErrorWrapper> ABI44_0_0REAIOSErrorHandler::getError() {
-    return this->error;
+std::shared_ptr<ErrorWrapper> ABI44_0_0REAIOSErrorHandler::getError()
+{
+  return this->error;
 }
 
-void ABI44_0_0REAIOSErrorHandler::setError(std::string message) {
+void ABI44_0_0REAIOSErrorHandler::setError(std::string message)
+{
   if (error->handled) {
     error->message = message;
     error->handled = false;

--- a/ios/vendored/sdk44/react-native-reanimated/ios/native/ABI44_0_0REAIOSLogger.h
+++ b/ios/vendored/sdk44/react-native-reanimated/ios/native/ABI44_0_0REAIOSLogger.h
@@ -1,17 +1,17 @@
 #pragma once
 
-#include "ReanimatedHiddenHeaders.h"
 #include <stdio.h>
+#include "ReanimatedHiddenHeaders.h"
 
 namespace ABI44_0_0reanimated {
 
 class ABI44_0_0REAIOSLogger : public LoggerInterface {
-  public:
-    void log(const char* str) override;
-    void log(double d) override;
-    void log(int i) override;
-    void log(bool b) override;
-    virtual ~ABI44_0_0REAIOSLogger() {}
+ public:
+  void log(const char *str) override;
+  void log(double d) override;
+  void log(int i) override;
+  void log(bool b) override;
+  virtual ~ABI44_0_0REAIOSLogger() {}
 };
 
-}
+} // namespace reanimated

--- a/ios/vendored/sdk44/react-native-reanimated/ios/native/ABI44_0_0REAIOSLogger.mm
+++ b/ios/vendored/sdk44/react-native-reanimated/ios/native/ABI44_0_0REAIOSLogger.mm
@@ -5,20 +5,24 @@ namespace ABI44_0_0reanimated {
 
 std::unique_ptr<LoggerInterface> Logger::instance = std::make_unique<ABI44_0_0REAIOSLogger>();
 
-void ABI44_0_0REAIOSLogger::log(const char* str) {
+void ABI44_0_0REAIOSLogger::log(const char *str)
+{
   NSLog(@"%@", [NSString stringWithCString:str encoding:[NSString defaultCStringEncoding]]);
 }
 
-void ABI44_0_0REAIOSLogger::log(double d) {
+void ABI44_0_0REAIOSLogger::log(double d)
+{
   NSLog(@"%lf", d);
 }
 
-void ABI44_0_0REAIOSLogger::log(int i) {
-   NSLog(@"%i", i);
+void ABI44_0_0REAIOSLogger::log(int i)
+{
+  NSLog(@"%i", i);
 }
 
-void ABI44_0_0REAIOSLogger::log(bool b) {
-  const char* str = (b)? "true" : "false";
+void ABI44_0_0REAIOSLogger::log(bool b)
+{
+  const char *str = (b) ? "true" : "false";
   NSLog(@"%@", [NSString stringWithCString:str encoding:[NSString defaultCStringEncoding]]);
 }
 

--- a/ios/vendored/sdk44/react-native-reanimated/ios/native/ABI44_0_0REAIOSScheduler.h
+++ b/ios/vendored/sdk44/react-native-reanimated/ios/native/ABI44_0_0REAIOSScheduler.h
@@ -1,18 +1,18 @@
 #pragma once
 
-#include <stdio.h>
-#include "Scheduler.h"
-#import <ABI44_0_0ReactCommon/ABI44_0_0CallInvoker.h>
 #import <ABI44_0_0React/ABI44_0_0RCTUIManager.h>
+#import <ABI44_0_0ReactCommon/ABI44_0_0CallInvoker.h>
+#include <stdio.h>
+#include <memory>
+#include "Scheduler.h"
 
-namespace ABI44_0_0reanimated
-{
+namespace ABI44_0_0reanimated {
 
 using namespace ABI44_0_0facebook;
 using namespace ABI44_0_0React;
 
 class ABI44_0_0REAIOSScheduler : public Scheduler {
-  public:
+ public:
   ABI44_0_0REAIOSScheduler(std::shared_ptr<CallInvoker> jsInvoker);
   void scheduleOnUI(std::function<void()> job) override;
   virtual ~ABI44_0_0REAIOSScheduler();

--- a/ios/vendored/sdk44/react-native-reanimated/ios/native/ABI44_0_0REAIOSScheduler.mm
+++ b/ios/vendored/sdk44/react-native-reanimated/ios/native/ABI44_0_0REAIOSScheduler.mm
@@ -6,34 +6,43 @@ namespace ABI44_0_0reanimated {
 using namespace ABI44_0_0facebook;
 using namespace ABI44_0_0React;
 
-ABI44_0_0REAIOSScheduler::ABI44_0_0REAIOSScheduler(std::shared_ptr<CallInvoker> jsInvoker) {
+ABI44_0_0REAIOSScheduler::ABI44_0_0REAIOSScheduler(std::shared_ptr<CallInvoker> jsInvoker)
+{
   this->jsCallInvoker_ = jsInvoker;
 }
 
-void ABI44_0_0REAIOSScheduler::scheduleOnUI(std::function<void()> job) {
+void ABI44_0_0REAIOSScheduler::scheduleOnUI(std::function<void()> job)
+{
   if (runtimeManager.lock() == nullptr) {
     return;
   }
 
-  if([NSThread isMainThread]) {
-    if (runtimeManager.lock()) job();
+  if ([NSThread isMainThread]) {
+    if (runtimeManager.lock()) {
+      job();
+    }
     return;
   }
 
   Scheduler::scheduleOnUI(job);
-  if([NSThread isMainThread]) {
-    if (runtimeManager.lock()) triggerUI();
+  if ([NSThread isMainThread]) {
+    if (runtimeManager.lock()) {
+      triggerUI();
+    }
     return;
   }
 
-  __block std::weak_ptr<RuntimeManager> blockRuntimeManager = runtimeManager;
+  if (!this->scheduledOnUI) {
+    __block std::weak_ptr<RuntimeManager> blockRuntimeManager = runtimeManager;
 
-  dispatch_async(dispatch_get_main_queue(), ^{
-    if (blockRuntimeManager.lock()) triggerUI();
-  });
+    dispatch_async(dispatch_get_main_queue(), ^{
+      if (blockRuntimeManager.lock()) {
+        triggerUI();
+      }
+    });
+  }
 }
 
-ABI44_0_0REAIOSScheduler::~ABI44_0_0REAIOSScheduler(){
-}
+ABI44_0_0REAIOSScheduler::~ABI44_0_0REAIOSScheduler() {}
 
 }

--- a/ios/vendored/sdk44/react-native-reanimated/ios/native/ABI44_0_0REAInitializer.h
+++ b/ios/vendored/sdk44/react-native-reanimated/ios/native/ABI44_0_0REAInitializer.h
@@ -1,0 +1,37 @@
+//
+//  ABI44_0_0REAInitializer.h
+//  ABI44_0_0RNReanimated
+//
+//  Created by Szymon Kapala on 27/07/2021.
+//
+
+#import <Foundation/Foundation.h>
+#import <ABI44_0_0RNReanimated/NativeProxy.h>
+#import <ABI44_0_0RNReanimated/ABI44_0_0REAEventDispatcher.h>
+#import <ABI44_0_0RNReanimated/ABI44_0_0REAModule.h>
+#import <ABI44_0_0React/ABI44_0_0RCTBridge+Private.h>
+#import <ABI44_0_0React/ABI44_0_0RCTCxxBridgeDelegate.h>
+#import <ABI44_0_0ReactCommon/ABI44_0_0RCTTurboModuleManager.h>
+#import <jsireact/JSIExecutor.h>
+
+#if RNVERSION >= 64
+#import <ABI44_0_0React/ABI44_0_0RCTJSIExecutorRuntimeInstaller.h>
+#endif
+
+#if RNVERSION < 63
+#import <ABI44_0_0ReactCommon/ABI44_0_0BridgeJSCallInvoker.h>
+#endif
+
+NS_ASSUME_NONNULL_BEGIN
+
+namespace ABI44_0_0reanimated {
+
+using namespace ABI44_0_0facebook;
+using namespace ABI44_0_0React;
+
+JSIExecutor::RuntimeInstaller ABI44_0_0REAJSIExecutorRuntimeInstaller(
+    ABI44_0_0RCTBridge *bridge,
+    JSIExecutor::RuntimeInstaller runtimeInstallerToWrap);
+
+} // namespace reanimated
+NS_ASSUME_NONNULL_END

--- a/ios/vendored/sdk44/react-native-reanimated/ios/native/ABI44_0_0REAInitializer.mm
+++ b/ios/vendored/sdk44/react-native-reanimated/ios/native/ABI44_0_0REAInitializer.mm
@@ -1,0 +1,65 @@
+#import "ABI44_0_0REAInitializer.h"
+#import "ABI44_0_0REAUIManager.h"
+
+@interface ABI44_0_0RCTEventDispatcher (Reanimated)
+
+- (void)setBridge:(ABI44_0_0RCTBridge *)bridge;
+
+@end
+
+namespace ABI44_0_0reanimated {
+
+using namespace ABI44_0_0facebook;
+using namespace ABI44_0_0React;
+
+JSIExecutor::RuntimeInstaller ABI44_0_0REAJSIExecutorRuntimeInstaller(
+    ABI44_0_0RCTBridge *bridge,
+    JSIExecutor::RuntimeInstaller runtimeInstallerToWrap)
+{
+  [bridge moduleForClass:[ABI44_0_0RCTUIManager class]];
+  ABI44_0_0REAUIManager *reaUiManager = [ABI44_0_0REAUIManager new];
+  [reaUiManager setBridge:bridge];
+  ABI44_0_0RCTUIManager *uiManager = reaUiManager;
+  [bridge updateModuleWithInstance:uiManager];
+
+  [bridge moduleForClass:[ABI44_0_0RCTEventDispatcher class]];
+  ABI44_0_0RCTEventDispatcher *eventDispatcher = [ABI44_0_0REAEventDispatcher new];
+#if RNVERSION >= 66
+  ABI44_0_0RCTCallableJSModules *callableJSModules = [ABI44_0_0RCTCallableJSModules new];
+  [bridge setValue:callableJSModules forKey:@"_callableJSModules"];
+  [callableJSModules setBridge:bridge];
+  [eventDispatcher setValue:callableJSModules forKey:@"_callableJSModules"];
+  [eventDispatcher setValue:bridge forKey:@"_bridge"];
+  [eventDispatcher initialize];
+#else
+  [eventDispatcher setBridge:bridge];
+#endif
+  [bridge updateModuleWithInstance:eventDispatcher];
+  const auto runtimeInstaller = [bridge, runtimeInstallerToWrap](ABI44_0_0facebook::jsi::Runtime &runtime) {
+    if (!bridge) {
+      return;
+    }
+#if RNVERSION >= 63
+    auto reanimatedModule = ABI44_0_0reanimated::createReanimatedModule(bridge, bridge.jsCallInvoker);
+#else
+    auto callInvoker = std::make_shared<ABI44_0_0React::BridgeJSCallInvoker>(bridge.reactInstance);
+    auto reanimatedModule = ABI44_0_0reanimated::createReanimatedModule(bridge, callInvoker);
+#endif
+    runtime.global().setProperty(
+        runtime,
+        "_WORKLET_RUNTIME",
+        static_cast<double>(reinterpret_cast<std::uintptr_t>(reanimatedModule->runtime.get())));
+
+    runtime.global().setProperty(
+        runtime,
+        jsi::PropNameID::forAscii(runtime, "__reanimatedModuleProxy"),
+        jsi::Object::createFromHostObject(runtime, reanimatedModule));
+
+    if (runtimeInstallerToWrap) {
+      runtimeInstallerToWrap(runtime);
+    }
+  };
+  return runtimeInstaller;
+}
+
+}

--- a/ios/vendored/sdk44/react-native-reanimated/ios/native/NativeMethods.h
+++ b/ios/vendored/sdk44/react-native-reanimated/ios/native/NativeMethods.h
@@ -1,11 +1,26 @@
 #import <Foundation/Foundation.h>
-#import <vector>
-#import <string>
 #import <ABI44_0_0React/ABI44_0_0RCTUIManager.h>
+#include <string>
+#import <string>
+#include <utility>
+#include <vector>
+#import <vector>
+#import "ABI44_0_0RNGestureHandlerStateManager.h"
 
 namespace ABI44_0_0reanimated {
 
-std::vector<std::pair<std::string,double>> measure(int viewTag, ABI44_0_0RCTUIManager *uiManager);
-void scrollTo(int scrollViewTag, ABI44_0_0RCTUIManager *uiManager, double x, double y, bool animated);
+std::vector<std::pair<std::string, double>> measure(
+    int viewTag,
+    ABI44_0_0RCTUIManager *uiManager);
+void scrollTo(
+    int scrollViewTag,
+    ABI44_0_0RCTUIManager *uiManager,
+    double x,
+    double y,
+    bool animated);
+void setGestureState(
+    id<ABI44_0_0RNGestureHandlerStateManager> gestureHandlerStateManager,
+    int handlerTag,
+    int newState);
 
-}
+} // namespace reanimated

--- a/ios/vendored/sdk44/react-native-reanimated/ios/native/NativeMethods.mm
+++ b/ios/vendored/sdk44/react-native-reanimated/ios/native/NativeMethods.mm
@@ -1,10 +1,11 @@
 #import "NativeMethods.h"
-#import <ABI44_0_0React/ABI44_0_0RCTScrollView.h>
 #import <ABI44_0_0React/ABI44_0_0RCTEventDispatcher.h>
+#import <ABI44_0_0React/ABI44_0_0RCTScrollView.h>
 
 namespace ABI44_0_0reanimated {
 
-std::vector<std::pair<std::string,double>> measure(int viewTag, ABI44_0_0RCTUIManager *uiManager) {
+std::vector<std::pair<std::string, double>> measure(int viewTag, ABI44_0_0RCTUIManager *uiManager)
+{
   UIView *view = [uiManager viewForABI44_0_0ReactTag:@(viewTag)];
 
   UIView *rootView = view;
@@ -17,7 +18,7 @@ std::vector<std::pair<std::string,double>> measure(int viewTag, ABI44_0_0RCTUIMa
     rootView = rootView.superview;
   }
 
-  if (rootView == nil || (![rootView isABI44_0_0ReactRootView])) {
+  if (rootView == nil) {
     return std::vector<std::pair<std::string, double>>(1, std::make_pair("x", -1234567.0));
   }
 
@@ -36,11 +37,18 @@ std::vector<std::pair<std::string,double>> measure(int viewTag, ABI44_0_0RCTUIMa
   return result;
 }
 
-
-void scrollTo(int scrollViewTag, ABI44_0_0RCTUIManager *uiManager, double x, double y, bool animated) {
+void scrollTo(int scrollViewTag, ABI44_0_0RCTUIManager *uiManager, double x, double y, bool animated)
+{
   UIView *view = [uiManager viewForABI44_0_0ReactTag:@(scrollViewTag)];
-  ABI44_0_0RCTScrollView *scrollView = (ABI44_0_0RCTScrollView *) view;
+  ABI44_0_0RCTScrollView *scrollView = (ABI44_0_0RCTScrollView *)view;
   [scrollView scrollToOffset:(CGPoint){(CGFloat)x, (CGFloat)y} animated:animated];
+}
+
+void setGestureState(id<ABI44_0_0RNGestureHandlerStateManager> gestureHandlerStateManager, int handlerTag, int newState)
+{
+  if (gestureHandlerStateManager != nil) {
+    [gestureHandlerStateManager setGestureState:newState forHandler:handlerTag];
+  }
 }
 
 }

--- a/ios/vendored/sdk44/react-native-reanimated/ios/native/NativeProxy.h
+++ b/ios/vendored/sdk44/react-native-reanimated/ios/native/NativeProxy.h
@@ -1,12 +1,14 @@
 #import <ABI44_0_0React/ABI44_0_0RCTEventDispatcher.h>
 
 #if __cplusplus
-
 #import <ABI44_0_0RNReanimated/NativeReanimatedModule.h>
+#include <memory>
 
 namespace ABI44_0_0reanimated {
- 
-std::shared_ptr<ABI44_0_0reanimated::NativeReanimatedModule> createReanimatedModule(std::shared_ptr<ABI44_0_0facebook::ABI44_0_0React::CallInvoker> jsInvoker);
+
+std::shared_ptr<ABI44_0_0reanimated::NativeReanimatedModule> createReanimatedModule(
+    ABI44_0_0RCTBridge *bridge,
+    std::shared_ptr<ABI44_0_0facebook::ABI44_0_0React::CallInvoker> jsInvoker);
 
 }
 

--- a/ios/vendored/sdk44/react-native-reanimated/ios/native/NativeProxy.mm
+++ b/ios/vendored/sdk44/react-native-reanimated/ios/native/NativeProxy.mm
@@ -1,14 +1,22 @@
-#import "NativeProxy.h"
-#import "ABI44_0_0REAIOSScheduler.h"
-#import "ABI44_0_0REAIOSErrorHandler.h"
-#import "ABI44_0_0REAModule.h"
-#import "ABI44_0_0REANodesManager.h"
-#import "NativeMethods.h"
-#import <folly/json.h>
+
 #import <ABI44_0_0React/ABI44_0_0RCTFollyConvert.h>
 #import <ABI44_0_0React/ABI44_0_0RCTUIManager.h>
+#import <folly/json.h>
 
-#if __has_include(<hermes/hermes.h>)
+#import "LayoutAnimationsProxy.h"
+#import "NativeMethods.h"
+#import "NativeProxy.h"
+#import "ABI44_0_0REAAnimationsManager.h"
+#import "ABI44_0_0REAIOSErrorHandler.h"
+#import "ABI44_0_0REAIOSScheduler.h"
+#import "ABI44_0_0REAModule.h"
+#import "ABI44_0_0REANodesManager.h"
+#import "ABI44_0_0REAUIManager.h"
+#import "ABI44_0_0RNGestureHandlerStateManager.h"
+
+#if __has_include(<reacthermes/ABI44_0_0HermesExecutorFactory.h>)
+#import <reacthermes/ABI44_0_0HermesExecutorFactory.h>
+#elif __has_include(<hermes/hermes.h>)
 #import <hermes/hermes.h>
 #else
 #import <ABI44_0_0jsi/ABI44_0_0JSCRuntime.h>
@@ -18,7 +26,6 @@ namespace ABI44_0_0reanimated {
 
 using namespace ABI44_0_0facebook;
 using namespace ABI44_0_0React;
-
 
 // COPIED FROM ABI44_0_0RCTTurboModule.mm
 static id convertJSIValueToObjCObject(jsi::Runtime &runtime, const jsi::Value &value);
@@ -44,15 +51,13 @@ static NSDictionary *convertJSIObjectToNSDictionary(jsi::Runtime &runtime, const
   return [result copy];
 }
 
-static NSArray *
-convertJSIArrayToNSArray(jsi::Runtime &runtime, const jsi::Array &value)
+static NSArray *convertJSIArrayToNSArray(jsi::Runtime &runtime, const jsi::Array &value)
 {
   size_t size = value.size(runtime);
   NSMutableArray *result = [NSMutableArray new];
   for (size_t i = 0; i < size; i++) {
     // Insert kCFNull when it's `undefined` value to preserve the indices.
-    [result
-        addObject:convertJSIValueToObjCObject(runtime, value.getValueAtIndex(runtime, i)) ?: (id)kCFNull];
+    [result addObject:convertJSIValueToObjCObject(runtime, value.getValueAtIndex(runtime, i)) ?: (id)kCFNull];
   }
   return [result copy];
 }
@@ -82,17 +87,22 @@ static id convertJSIValueToObjCObject(jsi::Runtime &runtime, const jsi::Value &v
   throw std::runtime_error("Unsupported jsi::jsi::Value kind");
 }
 
-std::shared_ptr<NativeReanimatedModule> createReanimatedModule(std::shared_ptr<CallInvoker> jsInvoker) {
-  ABI44_0_0RCTBridge *bridge = ABI44_0_0_bridge_reanimated;
+std::shared_ptr<NativeReanimatedModule> createReanimatedModule(
+    ABI44_0_0RCTBridge *bridge,
+    std::shared_ptr<CallInvoker> jsInvoker)
+{
   ABI44_0_0REAModule *reanimatedModule = [bridge moduleForClass:[ABI44_0_0REAModule class]];
 
-  auto propUpdater = [reanimatedModule](jsi::Runtime &rt, int viewTag, const jsi::Value& viewName, const jsi::Object &props) -> void {
-    NSString *nsViewName = [NSString stringWithCString:viewName.asString(rt).utf8(rt).c_str() encoding:[NSString defaultCStringEncoding]];
+  auto propUpdater = [reanimatedModule](
+                         jsi::Runtime &rt, int viewTag, const jsi::Value &viewName, const jsi::Object &props) -> void {
+    NSString *nsViewName = [NSString stringWithCString:viewName.asString(rt).utf8(rt).c_str()
+                                              encoding:[NSString defaultCStringEncoding]];
 
     NSDictionary *propsDict = convertJSIObjectToNSDictionary(rt, props);
-    [reanimatedModule.nodesManager updateProps:propsDict ofViewWithTag:[NSNumber numberWithInt:viewTag] withName:nsViewName];
+    [reanimatedModule.nodesManager updateProps:propsDict
+                                 ofViewWithTag:[NSNumber numberWithInt:viewTag]
+                                      withName:nsViewName];
   };
-
 
   ABI44_0_0RCTUIManager *uiManager = reanimatedModule.nodesManager.uiManager;
   auto measuringFunction = [uiManager](int viewTag) -> std::vector<std::pair<std::string, double>> {
@@ -103,52 +113,134 @@ std::shared_ptr<NativeReanimatedModule> createReanimatedModule(std::shared_ptr<C
     scrollTo(viewTag, uiManager, x, y, animated);
   };
 
-  auto propObtainer = [reanimatedModule](jsi::Runtime &rt, const int viewTag, const jsi::String &propName) -> jsi::Value {
-    NSString* propNameConverted = [NSString stringWithFormat:@"%s",propName.utf8(rt).c_str()];
-      std::string resultStr = std::string([[reanimatedModule.nodesManager obtainProp:[NSNumber numberWithInt:viewTag] propName:propNameConverted] UTF8String]);
-      jsi::Value val = jsi::String::createFromUtf8(rt, resultStr);
-      return val;
+  id<ABI44_0_0RNGestureHandlerStateManager> gestureHandlerStateManager = [bridge moduleForName:@"ABI44_0_0RNGestureHandlerModule"];
+  auto setGestureStateFunction = [gestureHandlerStateManager](int handlerTag, int newState) {
+    setGestureState(gestureHandlerStateManager, handlerTag, newState);
   };
 
+  auto propObtainer = [reanimatedModule](
+                          jsi::Runtime &rt, const int viewTag, const jsi::String &propName) -> jsi::Value {
+    NSString *propNameConverted = [NSString stringWithFormat:@"%s", propName.utf8(rt).c_str()];
+    std::string resultStr = std::string([[reanimatedModule.nodesManager obtainProp:[NSNumber numberWithInt:viewTag]
+                                                                          propName:propNameConverted] UTF8String]);
+    jsi::Value val = jsi::String::createFromUtf8(rt, resultStr);
+    return val;
+  };
 
-#if __has_include(<hermes/hermes.h>)
-  std::unique_ptr<jsi::Runtime> animatedRuntime = ABI44_0_0facebook::hermes::makeHermesRuntime();
+#if __has_include(<reacthermes/ABI44_0_0HermesExecutorFactory.h>)
+  std::shared_ptr<jsi::Runtime> animatedRuntime = ABI44_0_0facebook::hermes::makeHermesRuntime();
+#elif __has_include(<hermes/hermes.h>)
+  std::shared_ptr<jsi::Runtime> animatedRuntime = ABI44_0_0facebook::hermes::makeHermesRuntime();
 #else
-  std::unique_ptr<jsi::Runtime> animatedRuntime = ABI44_0_0facebook::jsc::makeJSCRuntime();
+  std::shared_ptr<jsi::Runtime> animatedRuntime = ABI44_0_0facebook::jsc::makeJSCRuntime();
 #endif
 
   std::shared_ptr<Scheduler> scheduler = std::make_shared<ABI44_0_0REAIOSScheduler>(jsInvoker);
   std::shared_ptr<ErrorHandler> errorHandler = std::make_shared<ABI44_0_0REAIOSErrorHandler>(scheduler);
   std::shared_ptr<NativeReanimatedModule> module;
 
+  __block std::weak_ptr<Scheduler> weakScheduler = scheduler;
+  ((ABI44_0_0REAUIManager *)uiManager).flushUiOperations = ^void() {
+    std::shared_ptr<Scheduler> scheduler = weakScheduler.lock();
+    if (scheduler != nullptr) {
+      scheduler->triggerUI();
+    }
+  };
+
   auto requestRender = [reanimatedModule, &module](std::function<void(double)> onRender, jsi::Runtime &rt) {
     [reanimatedModule.nodesManager postOnAnimation:^(CADisplayLink *displayLink) {
       double frameTimestamp = displayLink.targetTimestamp * 1000;
-      rt.global().setProperty(rt, "_frameTimestamp", frameTimestamp);
+      jsi::Object global = rt.global();
+      jsi::String frameTimestampName = jsi::String::createFromAscii(rt, "_frameTimestamp");
+      global.setProperty(rt, frameTimestampName, frameTimestamp);
       onRender(frameTimestamp);
-      rt.global().setProperty(rt, "_frameTimestamp", jsi::Value::undefined());
+      global.setProperty(rt, frameTimestampName, jsi::Value::undefined());
     }];
   };
 
-  auto getCurrentTime = []() {
-    return CACurrentMediaTime() * 1000;
+  auto getCurrentTime = []() { return CACurrentMediaTime() * 1000; };
+
+  // Layout Animations start
+  ABI44_0_0REAUIManager *reaUiManagerNoCast = [bridge moduleForClass:[ABI44_0_0REAUIManager class]];
+  ABI44_0_0RCTUIManager *reaUiManager = reaUiManagerNoCast;
+  ABI44_0_0REAAnimationsManager *animationsManager = [[ABI44_0_0REAAnimationsManager alloc] initWithUIManager:reaUiManager];
+  [reaUiManagerNoCast setUp:animationsManager];
+
+  auto notifyAboutProgress = [=](int tag, jsi::Object newStyle) {
+    if (animationsManager) {
+      NSDictionary *propsDict = convertJSIObjectToNSDictionary(*animatedRuntime, newStyle);
+      [animationsManager notifyAboutProgress:propsDict tag:[NSNumber numberWithInt:tag]];
+    }
   };
+
+  auto notifyAboutEnd = [=](int tag, bool isCancelled) {
+    if (animationsManager) {
+      [animationsManager notifyAboutEnd:[NSNumber numberWithInt:tag] cancelled:isCancelled];
+    }
+  };
+
+  std::shared_ptr<LayoutAnimationsProxy> layoutAnimationsProxy =
+      std::make_shared<LayoutAnimationsProxy>(notifyAboutProgress, notifyAboutEnd);
+  std::weak_ptr<jsi::Runtime> wrt = animatedRuntime;
+  [animationsManager setAnimationStartingBlock:^(
+                         NSNumber *_Nonnull tag, NSString *type, NSDictionary *_Nonnull values, NSNumber *depth) {
+    std::shared_ptr<jsi::Runtime> rt = wrt.lock();
+    if (wrt.expired()) {
+      return;
+    }
+    jsi::Object yogaValues(*rt);
+    for (NSString *key in values.allKeys) {
+      NSNumber *value = values[key];
+      yogaValues.setProperty(*rt, [key UTF8String], [value doubleValue]);
+    }
+
+    jsi::Value layoutAnimationRepositoryAsValue =
+        rt->global().getPropertyAsObject(*rt, "global").getProperty(*rt, "LayoutAnimationRepository");
+    if (!layoutAnimationRepositoryAsValue.isUndefined()) {
+      jsi::Function startAnimationForTag =
+          layoutAnimationRepositoryAsValue.getObject(*rt).getPropertyAsFunction(*rt, "startAnimationForTag");
+      startAnimationForTag.call(
+          *rt,
+          jsi::Value([tag intValue]),
+          jsi::String::createFromAscii(*rt, std::string([type UTF8String])),
+          yogaValues,
+          jsi::Value([depth intValue]));
+    }
+  }];
+
+  [animationsManager setRemovingConfigBlock:^(NSNumber *_Nonnull tag) {
+    std::shared_ptr<jsi::Runtime> rt = wrt.lock();
+    if (wrt.expired()) {
+      return;
+    }
+    jsi::Value layoutAnimationRepositoryAsValue =
+        rt->global().getPropertyAsObject(*rt, "global").getProperty(*rt, "LayoutAnimationRepository");
+    if (!layoutAnimationRepositoryAsValue.isUndefined()) {
+      jsi::Function removeConfig =
+          layoutAnimationRepositoryAsValue.getObject(*rt).getPropertyAsFunction(*rt, "removeConfig");
+      removeConfig.call(*rt, jsi::Value([tag intValue]));
+    }
+  }];
+
+  // Layout Animations end
 
   PlatformDepMethodsHolder platformDepMethodsHolder = {
-    requestRender,
-    propUpdater,
-    scrollToFunction,
-    measuringFunction,
-    getCurrentTime,
+      requestRender,
+      propUpdater,
+      scrollToFunction,
+      measuringFunction,
+      getCurrentTime,
+      setGestureStateFunction,
   };
 
-  module = std::make_shared<NativeReanimatedModule>(jsInvoker,
-                                                    scheduler,
-                                                    std::move(animatedRuntime),
-                                                    errorHandler,
-                                                    propObtainer,
-                                                    platformDepMethodsHolder
-                                                    );
+  module = std::make_shared<NativeReanimatedModule>(
+      jsInvoker,
+      scheduler,
+      animatedRuntime,
+      errorHandler,
+      propObtainer,
+      layoutAnimationsProxy,
+      platformDepMethodsHolder);
 
   scheduler->setRuntimeManager(module);
 
@@ -156,10 +248,12 @@ std::shared_ptr<NativeReanimatedModule> createReanimatedModule(std::shared_ptr<C
     std::string eventNameString([eventName UTF8String]);
     std::string eventAsString = folly::toJson(convertIdToFollyDynamic([event arguments][2]));
 
-    eventAsString = "{ NativeMap:"  + eventAsString + "}";
-    module->runtime->global().setProperty(*module->runtime, "_eventTimestamp", CACurrentMediaTime() * 1000);
+    eventAsString = "{ NativeMap:" + eventAsString + "}";
+    jsi::Object global = module->runtime->global();
+    jsi::String eventTimestampName = jsi::String::createFromAscii(*module->runtime, "_eventTimestamp");
+    global.setProperty(*module->runtime, eventTimestampName, CACurrentMediaTime() * 1000);
     module->onEvent(eventNameString, eventAsString);
-    module->runtime->global().setProperty(*module->runtime, "_eventTimestamp", jsi::Value::undefined());
+    global.setProperty(*module->runtime, eventTimestampName, jsi::Value::undefined());
   }];
 
   return module;

--- a/tools/src/versioning/ios/transforms/vendoredModulesTransforms.ts
+++ b/tools/src/versioning/ios/transforms/vendoredModulesTransforms.ts
@@ -71,7 +71,7 @@ export default function vendoredModulesTransformsFactory(prefix: string): Config
         },
         {
           paths: '*.h',
-          find: /ReactCommon\//g,
+          find: new RegExp(`ReactCommon/(?!${prefix})`, 'g'),
           replaceWith: `ReactCommon/${prefix}`,
         },
         {
@@ -80,13 +80,24 @@ export default function vendoredModulesTransformsFactory(prefix: string): Config
           replaceWith: 'RCTConvert+REATransition.h',
         },
         {
-          find: /(_bridge_reanimated)/g,
+          paths: 'REAUIManager.{h,mm}',
+          find: /(blockSetter|_toBeRemovedRegister|_parentMapper|_animationsManager|_scheduler)/g,
           replaceWith: `${prefix}$1`,
         },
         {
           paths: 'REATransitionAnimation.m',
           find: /(SimAnimationDragCoefficient)\(/g,
           replaceWith: `${prefix}$1(`,
+        },
+        {
+          paths: 'REAAnimationsManager.m',
+          find: /^(#import <.*React)\/UIView\+(.+)\.h>/gm,
+          replaceWith: `$1/${prefix}UIView+$2.h>`,
+        },
+        {
+          paths: 'REAAnimationsManager.m',
+          find: `UIView+${prefix}React.h`,
+          replaceWith: `UIView+React.h`,
         },
       ],
     },

--- a/tools/src/versioning/ios/versionVendoredModules.ts
+++ b/tools/src/versioning/ios/versionVendoredModules.ts
@@ -129,7 +129,7 @@ function baseTransformsFactory(prefix: string): Required<FileTransforms> {
       {
         // Objective-C only, see the comment in the rule below.
         paths: '*.{h,m,mm}',
-        find: /r(eactTag|eactSubviews|eactSuperview|eactViewController|eactSetFrame|eactAddControllerToClosestParent|eactZIndex)/gi,
+        find: /r(eactTag|eactSubviews|eactSuperview|eactViewController|eactSetFrame|eactAddControllerToClosestParent|eactZIndex|eactLayoutDirection)/gi,
         replaceWith: `${prefix}R$1`,
       },
       {
@@ -155,6 +155,10 @@ function baseTransformsFactory(prefix: string): Required<FileTransforms> {
         replaceWith: `is${prefix}ReactRootView`,
       },
       {
+        find: /IsReactRootView/g,
+        replaceWith: `Is${prefix}ReactRootView`,
+      },
+      {
         // Prefix only unindented `@objc` (notice `^` and `m` flag in the pattern). Method names shouldn't get prefixed.
         paths: '*.swift',
         find: /^@objc\(([^)]+)\)/gm,
@@ -169,6 +173,10 @@ function baseTransformsFactory(prefix: string): Required<FileTransforms> {
         paths: '*.podspec.json',
         find: new RegExp(`${prefix}React-Core\\/${prefix}RCT`, 'g'),
         replaceWith: `${prefix}React-Core/RCT`,
+      },
+      {
+        find: `${prefix}${prefix}`,
+        replaceWith: `${prefix}`,
       },
     ],
   };


### PR DESCRIPTION
# Why

@Kudo opened https://github.com/expo/expo/pull/15479 to version react-native-reanimated@2.3.0 for SDK 44, but it's not yet working in release builds on Android. Layout Animations are also not working in versioned code on either platform at the moment. We'll follow up and fix this, but for now let's move ahead with getting Expo Go for iOS ready on TestFlight - we can patch it with the Layout Animation fix later on and document this issue in beta post if it's not ready at that time.

# How

Take the commits from https://github.com/expo/expo/pull/15479 that were relevant to iOS.

We can either revert this commit before landing https://github.com/expo/expo/pull/15479, or we can update that branch accordingly. Whatever works best for @Kudo and @tsapeta.

# Test Plan

https://github.com/expo/expo/pull/15479