### PR TITLE
[ios] fix reanimated layout animation broken from versioning error

### DIFF
--- a/ios/vendored/sdk44/react-native-reanimated/ios/LayoutReanimation/ABI44_0_0REAAnimationsManager.m
+++ b/ios/vendored/sdk44/react-native-reanimated/ios/LayoutReanimation/ABI44_0_0REAAnimationsManager.m
@@ -186,7 +186,7 @@ typedef NS_ENUM(NSInteger, FrameConfigType) { EnteringFrame, ExitingFrame };
   }
 
   NSMutableDictionary *dataComponenetsByName = [_uiManager valueForKey:@"_componentDataByName"];
-  ABI44_0_0RCTComponentData *componentData = dataComponenetsByName[@"ABI44_0_0RCTView"];
+  ABI44_0_0RCTComponentData *componentData = dataComponenetsByName[@"RCTView"];
   [self setNewProps:[newStyle mutableCopy] forView:_viewForTag[tag] withComponentData:componentData];
 }
 

--- a/tools/src/versioning/ios/transforms/vendoredModulesTransforms.ts
+++ b/tools/src/versioning/ios/transforms/vendoredModulesTransforms.ts
@@ -99,6 +99,13 @@ export default function vendoredModulesTransformsFactory(prefix: string): Config
           find: `UIView+${prefix}React.h`,
           replaceWith: `UIView+React.h`,
         },
+        {
+          paths: 'REAAnimationsManager.m',
+          // `dataComponenetsByName[@"ABI44_0_0RCTView"];` -> `dataComponenetsByName[@"RCTView"];`
+          // the RCTComponentData internal view name is not versioned
+          find: new RegExp(`(RCTComponentData .+)\\[@"${prefix}(RCT.+)"\\];`, 'g'),
+          replaceWith: '$1[@"$2"];'
+        }
       ],
     },
     'react-native-gesture-handler': {


### PR DESCRIPTION
# Why

`RCTComponentData` saves unversioned component name in internal `_componentDataByName` map. accidentally versioning `RCTView` will cause the incorrect component data and break reanimated layout animation.

# How

rollback the versioning for `ABI44_0_0RCTComponentData *componentData = dataComponenetsByName[@"ABI44_0_0RCTView"];`

# Test Plan

ios versioned expo go + layout animation test

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
