### PR TITLE
[expo-updates] Fix headers location in expo-updates multipart response spec

### DIFF
--- a/docs/pages/technical-specs/expo-updates-0.md
+++ b/docs/pages/technical-specs/expo-updates-0.md
@@ -130,7 +130,7 @@ type Asset = {
 
 A manifest response of this format is defined by the `multipart/mixed` MIME type as defined by [RFC 2046](https://tools.ietf.org/html/rfc2046#section-5.1).
 
-Headers for this response format are the same as [manifest response headers](#manifest-response-headers), with the exception of `content-type`, which is specified in the `multipart/mixed` MIME type as defined by [RFC 2046](https://tools.ietf.org/html/rfc2046#section-5.1).
+Headers for this response format are the same as [manifest response headers](#manifest-response-headers), with the exception of `content-type`, which is specified as the `multipart/mixed` media type as defined by [RFC 2046](https://tools.ietf.org/html/rfc2046#section-5.1).
 
 Each part is defined as follows:
 1. REQUIRED `"manifest"` part:

--- a/docs/pages/technical-specs/expo-updates-0.md
+++ b/docs/pages/technical-specs/expo-updates-0.md
@@ -128,14 +128,18 @@ type Asset = {
 
 ### Multipart Manifest Response
 
-A manifest response of this format is defined by the `multipart/mixed` MIME type as defined by [RFC 2046](https://tools.ietf.org/html/rfc2046#section-5.1). Each part is defined as follows:
+A manifest response of this format is defined by the `multipart/mixed` MIME type as defined by [RFC 2046](https://tools.ietf.org/html/rfc2046#section-5.1).
+
+Headers for this response format are the same as [manifest response headers](#manifest-response-headers), with the exception of `content-type`, which is specified in the `multipart/mixed` MIME type as defined by [RFC 2046](https://tools.ietf.org/html/rfc2046#section-5.1).
+
+Each part is defined as follows:
 1. REQUIRED `"manifest"` part:
-    - MUST have a `content-disposition` header with a name parameter equal to `manifest`. e.g. `content-disposition: inline; name="manifest"`.
-    - The [manifest headers](#manifest-response-headers) MUST be sent in the part headers.
+    - MUST have part header `content-disposition: inline; name="manifest"`.
+    - MUST have part header `content-type: application/json` or `application/expo+json`.
     - The [manifest body](#manifest-response-body) MUST be sent in the part body.
 2. OPTIONAL `"extensions"` part:
-    - MUST have `content-disposition` header with a name parameter equal to `extensions`. e.g. `content-disposition: inline; name="extensions"`.
-    - MUST have header `content-type: application/json`.
+    - MUST have part header `content-disposition: inline; name="extensions"`.
+    - MUST have part header `content-type: application/json`.
     - The [manifest extensions](#manifest-extensions) MUST be sent in the part body.
 
 ### Manifest Extensions


### PR DESCRIPTION
# Why

As was written, all manifest headers would go in the manifest part when the response is of type multipart. This was incorrect as headers like `expo-protocol-version` should describe the whole response, not just one part.

# How

The full list of headers we have currently:
```
expo-protocol-version: 0
expo-sfv-version: 0
expo-manifest-filters: &lt;expo-sfv&gt;
expo-server-defined-headers: &lt;expo-sfv&gt;
cache-control: *
content-type: *
```

Some additional headers that we'll be adding soon:
```
expo-signature: *
```
(being defined in https://github.com/expo/expo/pull/14853)

This PR changes it so that all of our existing headers go in the outer response HTTP headers (with the exception of `content-type` being `multipart/...`), and then in the other PR we'll change it so the `expo-signature` goes in the `manifest` part header.

# Test Plan

Read the spec.