### PR TITLE
[ios][file-system] fixed a crash where CFRelease called with a null v…

### DIFF
--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -8,13 +8,9 @@
 
 ### 🐛 Bug fixes
 
+- Fixed simulator runtime crash on arm64 devices caused by `CFRelease(NULL)`. ([#15496](https://github.com/expo/expo/pull/15496) by [@daxaxelrod](https://github.com/daxaxelrod))
+
 ### 💡 Others
-
-## 13.1.1 - 2021-12-09
-
-### 🐛 Bug fixes
-
-- Fixed simulator runtime crash on arm64 devices caused by CFRelease(NULL) ([#15496](https://github.com/expo/expo/pull/15496) by [@daxaxelrod](https://github.com/daxaxelrod))
 
 ## 13.1.0 — 2021-11-17
 

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -10,6 +10,12 @@
 
 ### 💡 Others
 
+## 13.1.1 - 2021-12-09
+
+### 🐛 Bug fixes
+
+- Fixed simulator runtime crash on arm64 devices caused by CFRelease(NULL) ([#15496](https://github.com/expo/expo/pull/15496) by [@daxaxelrod](https://github.com/daxaxelrod))
+
 ## 13.1.0 — 2021-11-17
 
 ### 🐛 Bug fixes

--- a/packages/expo-file-system/ios/EXFileSystem/EXFileSystem.m
+++ b/packages/expo-file-system/ios/EXFileSystem/EXFileSystem.m
@@ -815,7 +815,9 @@ EX_EXPORT_METHOD_AS(getTotalDiskCapacityAsync, getTotalDiskCapacityAsyncWithReso
 {
   CFStringRef UTI = UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, (__bridge CFStringRef)[path pathExtension], NULL);
   CFStringRef MIMEType = UTTypeCopyPreferredTagWithClass(UTI, kUTTagClassMIMEType);
-  CFRelease(UTI);
+  if (UTI) {
+    CFRelease(UTI);
+  }
   if (!MIMEType) {
     return @"application/octet-stream";
   }


### PR DESCRIPTION
…alue

# Why

Fixed a bug my team (all credit goes to @ilyausorov) experienced with FileSystem.uploadAsync. [Apple docs](https://developer.apple.com/documentation/corefoundation/1521153-cfrelease) specify that CFRelease can cause a runtime crash if called with NULL, which is what we find to be happening
> Special Considerations
If cf is NULL, this will cause a runtime error and your application will crash.

Reproduced crash here: https://github.com/ilyausorov/test_upload

# How
Adding an if () check before releasing UTI. Fix recommendation taken from [here](https://github.com/rnmods/react-native-document-picker/issues/394#issuecomment-818599489)

# Test Plan
Existing 2 test suites pass. Tested manually and crash no long occurs.

