### PR TITLE
[ENG-2679][image-picker] Fix unresolved promise when dismissed on iOS

### DIFF
--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix unresolved promise when picker was dismissed with a swipe-down on iOS.
+
 ### 💡 Others
 
 ## 12.0.0 — 2021-12-03

--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix unresolved promise when picker was dismissed with a swipe-down on iOS.
+- Fix unresolved promise when picker was dismissed with a swipe-down on iOS. ([#15511](https://github.com/expo/expo/pull/15511) by [@barthap](https://github.com/barthap))
 
 ### 💡 Others
 

--- a/packages/expo-image-picker/ios/EXImagePicker/EXImagePicker.h
+++ b/packages/expo-image-picker/ios/EXImagePicker/EXImagePicker.h
@@ -7,6 +7,6 @@ typedef NS_ENUM(NSInteger, EXImagePickerTarget) {
   EXImagePickerTargetLibrarySingleImage,
 };
 
-@interface EXImagePicker : EXExportedModule <UINavigationControllerDelegate, UIImagePickerControllerDelegate, EXModuleRegistryConsumer>
+@interface EXImagePicker : EXExportedModule <UIAdaptivePresentationControllerDelegate, UINavigationControllerDelegate, UIImagePickerControllerDelegate, EXModuleRegistryConsumer>
 
 @end

--- a/packages/expo-image-picker/ios/EXImagePicker/EXImagePicker.m
+++ b/packages/expo-image-picker/ios/EXImagePicker/EXImagePicker.m
@@ -213,6 +213,7 @@ EX_EXPORT_METHOD_AS(launchImageLibraryAsync, launchImageLibraryAsync:(NSDictiona
       self.picker.modalPresentationStyle = UIModalPresentationAutomatic;
     }
     self.picker.delegate = self;
+    self.picker.presentationController.delegate = self;
 
     [self maybePreserveVisibilityAndHideStatusBar:[[self.options objectForKey:@"allowsEditing"] boolValue]];
     id<EXUtilitiesInterface> utils = [self.moduleRegistry getModuleImplementingProtocol:@protocol(EXUtilitiesInterface)];
@@ -458,6 +459,7 @@ EX_EXPORT_METHOD_AS(launchImageLibraryAsync, launchImageLibraryAsync:(NSDictiona
   [response setObject:exif forKey:@"exif"];
 }
 
+// called when user pressed cancel button
 - (void)imagePickerControllerDidCancel:(UIImagePickerController *)picker
 {
   dispatch_async(dispatch_get_main_queue(), ^{
@@ -466,6 +468,12 @@ EX_EXPORT_METHOD_AS(launchImageLibraryAsync, launchImageLibraryAsync:(NSDictiona
       self.resolve(@{@"cancelled": @YES});
     }];
   });
+}
+
+// called when user dismissed modal with swipe-down
+- (void)presentationControllerDidDismiss:(UIPresentationController *)presentationController {
+  [self maybeRestoreStatusBarVisibility];
+  self.resolve(@{@"cancelled": @YES});
 }
 
 - (void)maybePreserveVisibilityAndHideStatusBar:(BOOL)editingEnabled


### PR DESCRIPTION
# Why

Fixes #13221 

# How

It turns out that `[UIImagePickerController imagePickerControllerDidCancel]` is not called when the picker sheet is swiped down. I implemented `UIAdaptivePresentationControllerDelegate` protocol which supports this event.

More info in [this SO answer](https://stackoverflow.com/a/60810496).

# Test Plan

NCL

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).

# Next step

The author of the original issue (#13221) mentioned that other libraries can be affected. They should be checked too:
- ~expo-document-picker~ - checked, it's cancelled as expected
- ?

