### PR TITLE
[expo-update][ios] Fix manifest headers in multipart responses

### DIFF
--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.m
@@ -144,6 +144,7 @@ NSString * const EXUpdatesMultipartExtensionsPartName = @"extensions";
                                    successBlock:successBlock
                                      errorBlock:errorBlock];
   } else {
+    // can use valueForHTTPHeaderField after dropping iOS 12 support
     NSDictionary *responseHeaders = [httpResponse allHeaderFields];
     EXUpdatesManifestHeaders *manifestHeaders = [[EXUpdatesManifestHeaders alloc] initWithProtocolVersion:responseHeaders[@"expo-protocol-version"]
                                                                                      serverDefinedHeaders:responseHeaders[@"expo-server-defined-headers"]

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesManifestHeaders.h
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesManifestHeaders.h
@@ -1,0 +1,22 @@
+//  Copyright © 2019 650 Industries. All rights reserved.
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface EXUpdatesManifestHeaders : NSObject
+
+@property (nonatomic, strong, readonly, nullable) NSString *protocolVersion;
+@property (nonatomic, strong, readonly, nullable) NSString *serverDefinedHeaders;
+@property (nonatomic, strong, readonly, nullable) NSString *manifestFilters;
+@property (nonatomic, strong, readonly, nullable) NSString *manifestSignature;
+
+- (instancetype)init NS_UNAVAILABLE;
+- (instancetype)initWithProtocolVersion:(nullable NSString *)protocolVersion
+                   serverDefinedHeaders:(nullable NSString *)serverDefinedHeaders
+                        manifestFilters:(nullable NSString *)manifestFilters
+                      manifestSignature:(nullable NSString *)manifestSignature NS_DESIGNATED_INITIALIZER;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesManifestHeaders.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesManifestHeaders.m
@@ -1,0 +1,20 @@
+//  Copyright © 2019 650 Industries. All rights reserved.
+
+#import <EXUpdates/EXUpdatesManifestHeaders.h>
+
+@implementation EXUpdatesManifestHeaders
+
+- (instancetype)initWithProtocolVersion:(nullable NSString *)protocolVersion
+                   serverDefinedHeaders:(nullable NSString *)serverDefinedHeaders
+                        manifestFilters:(nullable NSString *)manifestFilters
+                      manifestSignature:(nullable NSString *)manifestSignature {
+  if (self = [super init]) {
+    _protocolVersion = protocolVersion;
+    _serverDefinedHeaders = serverDefinedHeaders;
+    _manifestFilters = manifestFilters;
+    _manifestSignature = manifestSignature;
+  }
+  return self;
+}
+
+@end

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesNewUpdate.h
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesNewUpdate.h
@@ -1,6 +1,7 @@
 //  Copyright © 2019 650 Industries. All rights reserved.
 
 #import <EXUpdates/EXUpdatesUpdate.h>
+#import <EXUpdates/EXUpdatesManifestHeaders.h>
 #import <EXManifests/EXManifestsNewManifest.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -8,7 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface EXUpdatesNewUpdate : NSObject
 
 + (EXUpdatesUpdate *)updateWithNewManifest:(EXManifestsNewManifest *)manifest
-                                   headers:(NSDictionary *)headers
+                           manifestHeaders:(EXUpdatesManifestHeaders *)manifestHeaders
                                 extensions:(NSDictionary *)extensions
                                     config:(EXUpdatesConfig *)config
                                   database:(EXUpdatesDatabase *)database;

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesNewUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesNewUpdate.m
@@ -12,7 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation EXUpdatesNewUpdate
 
 + (EXUpdatesUpdate *)updateWithNewManifest:(EXManifestsNewManifest *)manifest
-                                   headers:(NSDictionary *)headers
+                           manifestHeaders:(EXUpdatesManifestHeaders *)manifestHeaders
                                 extensions:(NSDictionary *)extensions
                                     config:(EXUpdatesConfig *)config
                                   database:(EXUpdatesDatabase *)database
@@ -91,8 +91,8 @@ NS_ASSUME_NONNULL_BEGIN
   update.bundleUrl = bundleUrl;
   update.assets = processedAssets;
   update.manifestJSON = manifest.rawManifestJSON;
-  update.serverDefinedHeaders = [[self class] dictionaryWithStructuredHeader:headers[@"expo-server-defined-headers"]];
-  update.manifestFilters = [[self class] dictionaryWithStructuredHeader:headers[@"expo-manifest-filters"]];
+  update.serverDefinedHeaders = [[self class] dictionaryWithStructuredHeader:manifestHeaders.serverDefinedHeaders];
+  update.manifestFilters = [[self class] dictionaryWithStructuredHeader:manifestHeaders.manifestFilters];
   return update;
 }
 

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate.h
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate.h
@@ -2,6 +2,7 @@
 
 #import <EXUpdates/EXUpdatesAsset.h>
 #import <EXUpdates/EXUpdatesConfig.h>
+#import <EXUpdates/EXUpdatesManifestHeaders.h>
 #import <EXManifests/EXManifestsManifest.h>
 
 @class EXUpdatesDatabase;
@@ -76,7 +77,7 @@ typedef NS_ENUM(NSInteger, EXUpdatesUpdateStatus) {
                     database:(EXUpdatesDatabase *)database;
 
 + (instancetype)updateWithManifest:(NSDictionary *)manifest
-                           headers:(NSDictionary *)headers
+                   manifestHeaders:(EXUpdatesManifestHeaders *)manifestHeaders
                         extensions:(NSDictionary *)extensions
                             config:(EXUpdatesConfig *)config
                           database:(EXUpdatesDatabase *)database

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate.m
@@ -63,13 +63,13 @@ NSString * const EXUpdatesUpdateErrorDomain = @"EXUpdatesUpdate";
 }
 
 + (instancetype)updateWithManifest:(NSDictionary *)manifest
-                           headers:(NSDictionary *)headers
+                   manifestHeaders:(EXUpdatesManifestHeaders *)manifestHeaders
                         extensions:(NSDictionary *)extensions
                             config:(EXUpdatesConfig *)config
                           database:(EXUpdatesDatabase *)database
                              error:(NSError ** _Nullable)error
 {
-  NSString *expoProtocolVersion = headers[@"expo-protocol-version"];
+  NSString *expoProtocolVersion = manifestHeaders.protocolVersion;
 
   if (expoProtocolVersion == nil) {
     return [EXUpdatesLegacyUpdate updateWithLegacyManifest:[[EXManifestsLegacyManifest alloc] initWithRawManifestJSON:manifest]
@@ -77,7 +77,7 @@ NSString * const EXUpdatesUpdateErrorDomain = @"EXUpdatesUpdate";
                                                   database:database];
   } else if (expoProtocolVersion.integerValue == 0) {
     return [EXUpdatesNewUpdate updateWithNewManifest:[[EXManifestsNewManifest alloc] initWithRawManifestJSON:manifest]
-                                             headers:headers
+                                     manifestHeaders:manifestHeaders
                                           extensions:extensions
                                               config:config
                                             database:database];

--- a/packages/expo-updates/ios/Tests/EXUpdatesBuildDataTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesBuildDataTests.m
@@ -79,9 +79,18 @@ static NSString * const scopeKey = @"test";
   _configReleaseChannelTestTwo = [EXUpdatesConfig configWithDictionary:_configReleaseChannelTestTwoDictionary
   ];
   
+  EXUpdatesManifestHeaders *manifestHeaders = [[EXUpdatesManifestHeaders alloc] initWithProtocolVersion:nil
+                                                                                   serverDefinedHeaders:nil
+                                                                                        manifestFilters:nil
+                                                                                      manifestSignature:nil];
+  
   // start every test with an update
   dispatch_sync(_db.databaseQueue, ^{
-    EXUpdatesUpdate *update = [EXUpdatesNewUpdate updateWithNewManifest:_manifest headers:@{} extensions:@{} config:_configChannelTest database:_db];
+    EXUpdatesUpdate *update = [EXUpdatesNewUpdate updateWithNewManifest:_manifest
+                                                        manifestHeaders:manifestHeaders
+                                                             extensions:@{}
+                                                                 config:_configChannelTest
+                                                               database:_db];
 
     NSError *updatesError;
     [_db addUpdate:update error:&updatesError];

--- a/packages/expo-updates/ios/Tests/EXUpdatesDatabaseTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesDatabaseTests.m
@@ -61,7 +61,14 @@
 - (void)testForeignKeys
 {
   __block NSError *expectedError;
-  EXUpdatesUpdate *update = [EXUpdatesNewUpdate updateWithNewManifest:_manifest headers:@{} extensions:@{} config:_config database:_db];
+  EXUpdatesManifestHeaders *manifestHeaders = [[EXUpdatesManifestHeaders alloc] initWithProtocolVersion:nil
+                                                                                   serverDefinedHeaders:nil
+                                                                                        manifestFilters:nil
+                                                                                      manifestSignature:nil];
+  EXUpdatesUpdate *update = [EXUpdatesNewUpdate updateWithNewManifest:_manifest
+                                                      manifestHeaders:manifestHeaders
+                                                           extensions:@{}
+                                                               config:_config database:_db];
   dispatch_sync(_db.databaseQueue, ^{
     NSError *updatesError;
     [_db addUpdate:update error:&updatesError];
@@ -80,20 +87,30 @@
 
 - (void)testSetMetadata_OverwriteAllFields
 {
-  NSDictionary *headers1 = @{
-    @"expo-manifest-filters": @"branch-name=\"rollout-1\",test=\"value\""
-  };
-  EXUpdatesUpdate *update1 = [EXUpdatesNewUpdate updateWithNewManifest:_manifest headers:headers1 extensions:@{} config:_config database:_db];
+  EXUpdatesManifestHeaders *manifestHeaders1 = [[EXUpdatesManifestHeaders alloc] initWithProtocolVersion:nil
+                                                                                   serverDefinedHeaders:nil
+                                                                                        manifestFilters:@"branch-name=\"rollout-1\",test=\"value\""
+                                                                                      manifestSignature:nil];
+  EXUpdatesUpdate *update1 = [EXUpdatesNewUpdate updateWithNewManifest:_manifest
+                                                       manifestHeaders:manifestHeaders1
+                                                            extensions:@{}
+                                                                config:_config
+                                                              database:_db];
   __block NSError *error1;
   dispatch_sync(_db.databaseQueue, ^{
     [_db setMetadataWithManifest:update1 error:&error1];
   });
   XCTAssertNil(error1);
 
-  NSDictionary *headers2 = @{
-    @"expo-manifest-filters": @"branch-name=\"rollout-2\""
-  };
-  EXUpdatesUpdate *update2 = [EXUpdatesNewUpdate updateWithNewManifest:_manifest headers:headers2 extensions:@{} config:_config database:_db];
+  EXUpdatesManifestHeaders *manifestHeaders2 = [[EXUpdatesManifestHeaders alloc] initWithProtocolVersion:nil
+                                                                                   serverDefinedHeaders:nil
+                                                                                        manifestFilters:@"branch-name=\"rollout-2\""
+                                                                                      manifestSignature:nil];
+  EXUpdatesUpdate *update2 = [EXUpdatesNewUpdate updateWithNewManifest:_manifest
+                                                       manifestHeaders:manifestHeaders2
+                                                            extensions:@{}
+                                                                config:_config
+                                                              database:_db];
   __block NSError *error2;
   dispatch_sync(_db.databaseQueue, ^{
     [_db setMetadataWithManifest:update2 error:&error2];
@@ -113,20 +130,30 @@
 
 - (void)testSetMetadata_OverwriteEmpty
 {
-  NSDictionary *headers1 = @{
-    @"expo-manifest-filters": @"branch-name=\"rollout-1\""
-  };
-  EXUpdatesUpdate *update1 = [EXUpdatesNewUpdate updateWithNewManifest:_manifest headers:headers1 extensions:@{} config:_config database:_db];
+  EXUpdatesManifestHeaders *manifestHeaders1 = [[EXUpdatesManifestHeaders alloc] initWithProtocolVersion:nil
+                                                                                   serverDefinedHeaders:nil
+                                                                                        manifestFilters:@"branch-name=\"rollout-1\""
+                                                                                      manifestSignature:nil];
+  EXUpdatesUpdate *update1 = [EXUpdatesNewUpdate updateWithNewManifest:_manifest
+                                                       manifestHeaders:manifestHeaders1
+                                                            extensions:@{}
+                                                                config:_config
+                                                              database:_db];
   __block NSError *error1;
   dispatch_sync(_db.databaseQueue, ^{
     [_db setMetadataWithManifest:update1 error:&error1];
   });
   XCTAssertNil(error1);
 
-  NSDictionary *headers2 = @{
-    @"expo-manifest-filters": @""
-  };
-  EXUpdatesUpdate *update2 = [EXUpdatesNewUpdate updateWithNewManifest:_manifest headers:headers2 extensions:@{} config:_config database:_db];
+  EXUpdatesManifestHeaders *manifestHeaders2 = [[EXUpdatesManifestHeaders alloc] initWithProtocolVersion:nil
+                                                                                   serverDefinedHeaders:nil
+                                                                                        manifestFilters:@""
+                                                                                      manifestSignature:nil];
+  EXUpdatesUpdate *update2 = [EXUpdatesNewUpdate updateWithNewManifest:_manifest
+                                                       manifestHeaders:manifestHeaders2
+                                                            extensions:@{}
+                                                                config:_config
+                                                              database:_db];
   __block NSError *error2;
   dispatch_sync(_db.databaseQueue, ^{
     [_db setMetadataWithManifest:update2 error:&error2];
@@ -146,17 +173,30 @@
 
 - (void)testSetMetadata_OverwriteNull
 {
-  NSDictionary *headers1 =@{
-    @"expo-manifest-filters": @"branch-name=\"rollout-1\""
-  };
-  EXUpdatesUpdate *update1 = [EXUpdatesNewUpdate updateWithNewManifest:_manifest headers:headers1 extensions:@{} config:_config database:_db];
+  EXUpdatesManifestHeaders *manifestHeaders1 = [[EXUpdatesManifestHeaders alloc] initWithProtocolVersion:nil
+                                                                                   serverDefinedHeaders:nil
+                                                                                        manifestFilters:@"branch-name=\"rollout-1\""
+                                                                                      manifestSignature:nil];
+  EXUpdatesUpdate *update1 = [EXUpdatesNewUpdate updateWithNewManifest:_manifest
+                                                       manifestHeaders:manifestHeaders1
+                                                            extensions:@{}
+                                                                config:_config
+                                                              database:_db];
   __block NSError *error1;
   dispatch_sync(_db.databaseQueue, ^{
     [_db setMetadataWithManifest:update1 error:&error1];
   });
   XCTAssertNil(error1);
 
-  EXUpdatesUpdate *update2 = [EXUpdatesNewUpdate updateWithNewManifest:_manifest headers:@{} extensions:@{} config:_config database:_db];
+  EXUpdatesManifestHeaders *manifestHeaders2 = [[EXUpdatesManifestHeaders alloc] initWithProtocolVersion:nil
+                                                                                   serverDefinedHeaders:nil
+                                                                                        manifestFilters:nil
+                                                                                      manifestSignature:nil];
+  EXUpdatesUpdate *update2 = [EXUpdatesNewUpdate updateWithNewManifest:_manifest
+                                                       manifestHeaders:manifestHeaders2
+                                                            extensions:@{}
+                                                                config:_config
+                                                              database:_db];
   __block NSError *error2;
   dispatch_sync(_db.databaseQueue, ^{
     [_db setMetadataWithManifest:update2 error:&error2];
@@ -198,8 +238,20 @@
   asset2.filename = @"same-filename.png";
   asset3.filename = @"same-filename.png";
 
-  EXUpdatesUpdate *update1 = [EXUpdatesNewUpdate updateWithNewManifest:manifest1 headers:@{} extensions:@{} config:_config database:_db];
-  EXUpdatesUpdate *update2 = [EXUpdatesNewUpdate updateWithNewManifest:manifest2 headers:@{} extensions:@{} config:_config database:_db];
+  EXUpdatesManifestHeaders *manifestHeaders = [[EXUpdatesManifestHeaders alloc] initWithProtocolVersion:nil
+                                                                                   serverDefinedHeaders:nil
+                                                                                        manifestFilters:nil
+                                                                                      manifestSignature:nil];
+  EXUpdatesUpdate *update1 = [EXUpdatesNewUpdate updateWithNewManifest:manifest1
+                                                       manifestHeaders:manifestHeaders
+                                                            extensions:@{}
+                                                                config:_config
+                                                              database:_db];
+  EXUpdatesUpdate *update2 = [EXUpdatesNewUpdate updateWithNewManifest:manifest2
+                                                       manifestHeaders:manifestHeaders
+                                                            extensions:@{}
+                                                                config:_config
+                                                              database:_db];
 
   dispatch_sync(_db.databaseQueue, ^{
     NSError *update1Error;

--- a/packages/expo-updates/ios/Tests/EXUpdatesNewUpdateTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesNewUpdateTests.m
@@ -40,7 +40,15 @@
     @"createdAt": @"2020-11-11T00:17:54.797Z",
     @"launchAsset": @{@"url": @"https://url.to/bundle.js", @"contentType": @"application/javascript"}
   }];
-  XCTAssert([EXUpdatesNewUpdate updateWithNewManifest:manifest headers:@{} extensions:@{} config:_config database:_database] != nil);
+  EXUpdatesManifestHeaders *manifestHeaders = [[EXUpdatesManifestHeaders alloc] initWithProtocolVersion:nil
+                                                                                   serverDefinedHeaders:nil
+                                                                                        manifestFilters:nil
+                                                                                      manifestSignature:nil];
+  XCTAssert([EXUpdatesNewUpdate updateWithNewManifest:manifest
+                                      manifestHeaders:manifestHeaders
+                                           extensions:@{}
+                                               config:_config
+                                             database:_database] != nil);
 }
 
 - (void)testUpdateWithNewManifest_NoRuntimeVersion
@@ -50,7 +58,15 @@
     @"createdAt": @"2020-11-11T00:17:54.797Z",
     @"launchAsset": @{@"url": @"https://url.to/bundle.js", @"contentType": @"application/javascript"}
   }];
-  XCTAssertThrows([EXUpdatesNewUpdate updateWithNewManifest:manifest headers:@{} extensions:@{} config:_config database:_database]);
+  EXUpdatesManifestHeaders *manifestHeaders = [[EXUpdatesManifestHeaders alloc] initWithProtocolVersion:nil
+                                                                                   serverDefinedHeaders:nil
+                                                                                        manifestFilters:nil
+                                                                                      manifestSignature:nil];
+  XCTAssertThrows([EXUpdatesNewUpdate updateWithNewManifest:manifest
+                                            manifestHeaders:manifestHeaders
+                                                 extensions:@{}
+                                                     config:_config
+                                                   database:_database]);
 }
 
 - (void)testUpdateWithNewManifest_NoId
@@ -60,7 +76,15 @@
     @"createdAt": @"2020-11-11T00:17:54.797Z",
     @"launchAsset": @{@"url": @"https://url.to/bundle.js", @"contentType": @"application/javascript"}
   }];
-  XCTAssertThrows([EXUpdatesNewUpdate updateWithNewManifest:manifest headers:@{} extensions:@{} config:_config database:_database]);
+  EXUpdatesManifestHeaders *manifestHeaders = [[EXUpdatesManifestHeaders alloc] initWithProtocolVersion:nil
+                                                                                   serverDefinedHeaders:nil
+                                                                                        manifestFilters:nil
+                                                                                      manifestSignature:nil];
+  XCTAssertThrows([EXUpdatesNewUpdate updateWithNewManifest:manifest
+                                            manifestHeaders:manifestHeaders
+                                                 extensions:@{}
+                                                     config:_config
+                                                   database:_database]);
 }
 
 - (void)testUpdateWithNewManifest_NoCreatedAt
@@ -70,7 +94,15 @@
     @"id": @"0eef8214-4833-4089-9dff-b4138a14f196",
     @"launchAsset": @{@"url": @"https://url.to/bundle.js", @"contentType": @"application/javascript"}
   }];
-  XCTAssertThrows([EXUpdatesNewUpdate updateWithNewManifest:manifest headers:@{} extensions:@{} config:_config database:_database]);
+  EXUpdatesManifestHeaders *manifestHeaders = [[EXUpdatesManifestHeaders alloc] initWithProtocolVersion:nil
+                                                                                   serverDefinedHeaders:nil
+                                                                                        manifestFilters:nil
+                                                                                      manifestSignature:nil];
+  XCTAssertThrows([EXUpdatesNewUpdate updateWithNewManifest:manifest
+                                            manifestHeaders:manifestHeaders
+                                                 extensions:@{}
+                                                     config:_config
+                                                   database:_database]);
 }
 
 - (void)testUpdateWithNewManifest_NoLaunchAsset
@@ -80,7 +112,14 @@
     @"id": @"0eef8214-4833-4089-9dff-b4138a14f196",
     @"createdAt": @"2020-11-11T00:17:54.797Z"
   }];
-  XCTAssertThrows([EXUpdatesNewUpdate updateWithNewManifest:manifest headers:@{} extensions:@{} config:_config database:_database]);
+  EXUpdatesManifestHeaders *manifestHeaders = [[EXUpdatesManifestHeaders alloc] initWithProtocolVersion:nil
+                                                                                   serverDefinedHeaders:nil
+                                                                                        manifestFilters:nil
+                                                                                      manifestSignature:nil];
+  XCTAssertThrows([EXUpdatesNewUpdate updateWithNewManifest:manifest
+                                            manifestHeaders:manifestHeaders
+                                                 extensions:@{}
+                                                     config:_config database:_database]);
 }
 
 - (void)testDictionaryWithStructuredHeader_SupportedTypes

--- a/packages/expo-updates/ios/Tests/EXUpdatesSelectionPolicyFilterAwareTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesSelectionPolicyFilterAwareTests.m
@@ -50,6 +50,10 @@
     @"EXUpdatesScopeKey": scopeKey
   }];
   EXUpdatesDatabase *database = [EXUpdatesDatabase new];
+  EXUpdatesManifestHeaders *manifestHeaders = [[EXUpdatesManifestHeaders alloc] initWithProtocolVersion:nil
+                                                                                   serverDefinedHeaders:nil
+                                                                                        manifestFilters:nil
+                                                                                      manifestSignature:nil];
 
   _updateRollout0 = [EXUpdatesNewUpdate updateWithNewManifest:[[EXManifestsNewManifest alloc] initWithRawManifestJSON:@{
     @"id": @"079cde35-8433-4c17-81c8-7117c1513e71",
@@ -58,7 +62,7 @@
     @"launchAsset": launchAsset,
     @"assets": @[imageAsset],
     @"metadata": @{@"branchName": @"rollout"}
-  }] headers:@{} extensions:@{} config:config database:database];
+  }] manifestHeaders:manifestHeaders extensions:@{} config:config database:database];
 
   _updateDefault1 = [EXUpdatesNewUpdate updateWithNewManifest:[[EXManifestsNewManifest alloc] initWithRawManifestJSON:@{
     @"id": @"079cde35-8433-4c17-81c8-7117c1513e72",
@@ -67,7 +71,7 @@
     @"launchAsset": launchAsset,
     @"assets": @[imageAsset],
     @"metadata": @{@"branchName": @"default"}
-  }] headers:@{} extensions:@{} config:config database:database];
+  }] manifestHeaders:manifestHeaders extensions:@{} config:config database:database];
 
   _updateRollout1 = [EXUpdatesNewUpdate updateWithNewManifest:[[EXManifestsNewManifest alloc] initWithRawManifestJSON:@{
     @"id": @"079cde35-8433-4c17-81c8-7117c1513e73",
@@ -76,7 +80,7 @@
     @"launchAsset": launchAsset,
     @"assets": @[imageAsset],
     @"metadata": @{@"branchName": @"rollout"}
-  }] headers:@{} extensions:@{} config:config database:database];
+  }] manifestHeaders:manifestHeaders extensions:@{} config:config database:database];
 
   _updateDefault2 = [EXUpdatesNewUpdate updateWithNewManifest:[[EXManifestsNewManifest alloc] initWithRawManifestJSON:@{
     @"id": @"079cde35-8433-4c17-81c8-7117c1513e74",
@@ -85,7 +89,7 @@
     @"launchAsset": launchAsset,
     @"assets": @[imageAsset],
     @"metadata": @{@"branchName": @"default"}
-  }] headers:@{} extensions:@{} config:config database:database];
+  }] manifestHeaders:manifestHeaders extensions:@{} config:config database:database];
 
   _updateRollout2 = [EXUpdatesNewUpdate updateWithNewManifest:[[EXManifestsNewManifest alloc] initWithRawManifestJSON:@{
     @"id": @"079cde35-8433-4c17-81c8-7117c1513e75",
@@ -94,7 +98,7 @@
     @"launchAsset": launchAsset,
     @"assets": @[imageAsset],
     @"metadata": @{@"branchName": @"rollout"}
-  }] headers:@{} extensions:@{} config:config database:database];
+  }] manifestHeaders:manifestHeaders extensions:@{} config:config database:database];
 
   _updateMultipleFilters = [EXUpdatesNewUpdate updateWithNewManifest:[[EXManifestsNewManifest alloc] initWithRawManifestJSON:@{
     @"id": @"079cde35-8433-4c17-81c8-7117c1513e72",
@@ -103,7 +107,7 @@
     @"launchAsset": launchAsset,
     @"assets": @[imageAsset],
     @"metadata": @{@"firstKey": @"value1", @"secondKey": @"value2"}
-  }] headers:@{} extensions:@{} config:config database:database];
+  }] manifestHeaders:manifestHeaders extensions:@{} config:config database:database];
 
   _updateNoMetadata = [EXUpdatesNewUpdate updateWithNewManifest:[[EXManifestsNewManifest alloc] initWithRawManifestJSON:@{
     @"id": @"079cde35-8433-4c17-81c8-7117c1513e72",
@@ -111,7 +115,7 @@
     @"runtimeVersion": @"1.0",
     @"launchAsset": launchAsset,
     @"assets": @[imageAsset]
-  }] headers:@{} extensions:@{} config:config database:database];
+  }] manifestHeaders:manifestHeaders extensions:@{} config:config database:database];
 
   _selectionPolicy = [EXUpdatesSelectionPolicyFactory filterAwarePolicyWithRuntimeVersion:runtimeVersion];
   _manifestFilters = @{@"branchname": @"rollout"};

--- a/packages/expo-updates/ios/Tests/EXUpdatesUpdateTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesUpdateTests.m
@@ -8,6 +8,7 @@
 #import <EXUpdates/EXUpdatesLegacyUpdate.h>
 #import <EXUpdates/EXUpdatesNewUpdate.h>
 #import <EXUpdates/EXUpdatesUpdate.h>
+#import <EXUpdates/EXUpdatesManifestHeaders.h>
 
 @interface EXUpdatesUpdateTests : XCTestCase
 
@@ -58,21 +59,48 @@
 - (void)testUpdateWithManifest_Legacy
 {
   NSError *error;
-  EXUpdatesUpdate *update = [EXUpdatesUpdate updateWithManifest:_legacyManifest headers:@{} extensions:@{} config:_config database:_database error:&error];
+  EXUpdatesManifestHeaders *manifestHeaders = [[EXUpdatesManifestHeaders alloc] initWithProtocolVersion:nil
+                                                                                   serverDefinedHeaders:nil
+                                                                                        manifestFilters:nil
+                                                                                      manifestSignature:nil];
+  EXUpdatesUpdate *update = [EXUpdatesUpdate updateWithManifest:_legacyManifest
+                                                manifestHeaders:manifestHeaders
+                                                     extensions:@{}
+                                                         config:_config
+                                                       database:_database
+                                                          error:&error];
   XCTAssert(update != nil);
 }
 
 - (void)testUpdateWithManifest_New
 {
   NSError *error;
-  EXUpdatesUpdate *update = [EXUpdatesUpdate updateWithManifest:_easNewManifest headers:@{@"expo-protocol-version" : @"0"} extensions:@{} config:_config database:_database error:&error];
+  EXUpdatesManifestHeaders *manifestHeaders = [[EXUpdatesManifestHeaders alloc] initWithProtocolVersion:@"0"
+                                                                                   serverDefinedHeaders:nil
+                                                                                        manifestFilters:nil
+                                                                                      manifestSignature:nil];
+  EXUpdatesUpdate *update = [EXUpdatesUpdate updateWithManifest:_easNewManifest
+                                                manifestHeaders:manifestHeaders
+                                                     extensions:@{}
+                                                         config:_config
+                                                       database:_database
+                                                          error:&error];
   XCTAssert(update != nil);
 }
 
 - (void)testUpdateWithManifest_UnsupportedProtocolVersion
 {
   NSError *error;
-  EXUpdatesUpdate *update = [EXUpdatesUpdate updateWithManifest:_easNewManifest headers:@{@"expo-protocol-version" : @"1"} extensions:@{} config:_config database:_database error:&error];
+  EXUpdatesManifestHeaders *manifestHeaders = [[EXUpdatesManifestHeaders alloc] initWithProtocolVersion:@"1"
+                                                                                   serverDefinedHeaders:nil
+                                                                                        manifestFilters:nil
+                                                                                      manifestSignature:nil];
+  EXUpdatesUpdate *update = [EXUpdatesUpdate updateWithManifest:_easNewManifest
+                                                manifestHeaders:manifestHeaders
+                                                     extensions:@{}
+                                                         config:_config
+                                                       database:_database
+                                                          error:&error];
   XCTAssert(error != nil);
   XCTAssert(update == nil);
 }


### PR DESCRIPTION
# Why

iOS equivalent of https://github.com/expo/expo/pull/15497.

# How

Same strategy as https://github.com/expo/expo/pull/15497 (add manifest-response-format-agnostic container for headers).

# Test Plan

Same as https://github.com/expo/expo/pull/15497.