### PR TITLE
[expo-updates][android] Add code signing

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.kt
@@ -138,7 +138,7 @@ class ExpoUpdatesAppLoader @JvmOverloads constructor(
       }
     }
     configMap[UpdatesConfiguration.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY] = requestHeaders
-    configMap["expectsSignedManifest"] = true
+    configMap[UpdatesConfiguration.UPDATES_CONFIGURATION_EXPECTS_EXPO_SIGNED_MANIFEST] = true
     val configuration = UpdatesConfiguration().loadValuesFromMap(configMap)
     val sdkVersionsList = mutableListOf<String>().apply {
       (Constants.SDK_VERSIONS_LIST + listOf(RNObject.UNVERSIONED)).forEach {

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -37,6 +37,7 @@
 - Enhance node binary resolution for Xcode build phases scripts by the vendoring source-login-scripts.sh. ([#15336](https://github.com/expo/expo/pull/15336) by [@kudo](https://github.com/kudo))
 - Add android support for multipart manifest responses. ([#15401](https://github.com/expo/expo/pull/15401) by [@wschurman](https://github.com/wschurman))
 - Add iOS support for multipart manifest responses. ([#15426](https://github.com/expo/expo/pull/15426) by [@wschurman](https://github.com/wschurman))
+- Add android support for code signing. ([#15514](https://github.com/expo/expo/pull/15514) by [@wschurman](https://github.com/wschurman))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-updates/README.md
+++ b/packages/expo-updates/README.md
@@ -87,6 +87,13 @@ The condition under which `expo-updates` should automatically check for (and dow
 
 The number of milliseconds `expo-updates` should delay the app launch and stay on the splash screen while trying to download an update, before falling back to a previously downloaded version. Setting this to `0` will cause the app to always launch with a previously downloaded update and will result in the fastest app launch possible.
 
+| iOS plist/dictionary key | Android Map key          | Android meta-data name                             | Default | Required? |
+| ------------------------ | ------------------------ | -------------------------------------------------- | ------- | --------- |
+| TBD                      | `codeSigningCertificate` | `expo.modules.updates.CODE_SIGNING_CERTIFICATE`    | (none)  | ❌        |
+| TBD                      | `codeSigningMetadata`    | `expo.modules.updates.CODE_SIGNING_METADATA`       | (none)  | ❌        |
+
+If `codeSigningCertificate` present, enforce manifest code signing using the certificate.
+
 ## Customizing automatic setup
 
 In `expo-updates@0.9.0` and above, we support automatic installation of the module in the iOS AppDelegate.m and Android MainApplication.java classes. If you want to customize the installation, e.g. to enable updates only in some build variants, you can add custom logic in AppDelegate/MainApplication and set the following keys to `false` in order to disable the automatic setup.

--- a/packages/expo-updates/README.md
+++ b/packages/expo-updates/README.md
@@ -92,7 +92,11 @@ The number of milliseconds `expo-updates` should delay the app launch and stay o
 | TBD                      | `codeSigningCertificate` | `expo.modules.updates.CODE_SIGNING_CERTIFICATE`    | (none)  | ❌        |
 | TBD                      | `codeSigningMetadata`    | `expo.modules.updates.CODE_SIGNING_METADATA`       | (none)  | ❌        |
 
-If `codeSigningCertificate` present, enforce manifest code signing using the certificate.
+If `codeSigningCertificate` is present, `expo-updates` will enforce manifest code signing using the certificate and any metadata associated with it.
+- `codeSigningCertificate` must be a valid PEM formatted X.509 certificate with code signing extended key usage.
+- `codeSigningMetadata` (optional) must be a JSON object containing:
+    - `alg` - Algorithm used to generate manifest signature. Only `rsa-v1_5-sha256` is currently supported.
+    - `keyid` - Identifier for the key in `codeSigningCertificate`. Used to instruct signing mechanisms when signing or verifying signatures.
 
 ## Customizing automatic setup
 

--- a/packages/expo-updates/android/build.gradle
+++ b/packages/expo-updates/android/build.gradle
@@ -103,6 +103,7 @@ dependencies {
   implementation("com.squareup.okhttp3:okhttp:3.12.1")
   implementation("com.squareup.okhttp3:okhttp-urlconnection:3.12.1")
   implementation("com.squareup.okio:okio:1.15.0")
+  implementation("commons-codec:commons-codec:1.10")
   implementation("commons-io:commons-io:2.6")
   implementation("commons-fileupload:commons-fileupload:1.4")
   implementation("org.apache.commons:commons-lang3:3.9")

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/UpdatesUtilsInstrumentationTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/UpdatesUtilsInstrumentationTest.kt
@@ -47,7 +47,7 @@ class UpdatesUtilsInstrumentationTest {
   @Test
   @Throws(Exception::class)
   fun testgetHeadersMapFromJSONString_empty() {
-    val emptyMap = UpdatesUtils.getHeadersMapFromJSONString("{}")
+    val emptyMap = UpdatesUtils.getMapFromJSONString("{}")
     Assert.assertEquals(emptyMap, mapOf<String, String>())
   }
 
@@ -55,25 +55,25 @@ class UpdatesUtilsInstrumentationTest {
   @Throws(Exception::class)
   fun testgetHeadersMapFromJSONString_expectedFormat() {
     val expected = mapOf("expo-channel-name" to "main")
-    val emptyMap = UpdatesUtils.getHeadersMapFromJSONString("{\"expo-channel-name\":\"main\"}")
+    val emptyMap = UpdatesUtils.getMapFromJSONString("{\"expo-channel-name\":\"main\"}")
     Assert.assertEquals(emptyMap, expected)
   }
 
   @Test(expected = Exception::class)
   @Throws(Exception::class)
   fun testgetHeadersMapFromJSONString_throwsIntegerValue() {
-    UpdatesUtils.getHeadersMapFromJSONString("{\"expo-channel-name\": 5}")
+    UpdatesUtils.getMapFromJSONString("{\"expo-channel-name\": 5}")
   }
 
   @Test(expected = Exception::class)
   @Throws(Exception::class)
   fun testgetHeadersMapFromJSONString_throwsNonStringValue() {
-    UpdatesUtils.getHeadersMapFromJSONString("{\"expo-channel-name\":[\"main\"]}")
+    UpdatesUtils.getMapFromJSONString("{\"expo-channel-name\":[\"main\"]}")
   }
 
   @Test(expected = Exception::class)
   @Throws(Exception::class)
   fun testgetHeadersMapFromJSONString_throwsNonStringKey() {
-    UpdatesUtils.getHeadersMapFromJSONString("{7:[\"main\"]}")
+    UpdatesUtils.getMapFromJSONString("{7:[\"main\"]}")
   }
 }

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/db/UpdatesDatabaseMigrationTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/db/UpdatesDatabaseMigrationTest.kt
@@ -380,13 +380,46 @@ class UpdatesDatabaseMigrationTest {
 
     // schema changes automatically verified, we just need to verify data integrity
     val cursorAssets1 =
-      db.query("SELECT * FROM `assets` WHERE `id` = 2 AND `url` = 'https://url.to/b56cf690e0afa93bd4dc7756d01edd3e' AND `key` = 'b56cf690e0afa93bd4dc7756d01edd3e.png' AND `headers` IS NULL AND `type` = 'image/png' AND `metadata` IS NULL AND `download_time` = 1614137309295 AND `relative_path` = 'b56cf690e0afa93bd4dc7756d01edd3e.png' AND `hash` IS NULL AND `hash_type` = 0 AND `marked_for_deletion` = 0")
+      db.query("SELECT * FROM `assets` WHERE `id` = 2 AND `url` = 'https://url.to/b56cf690e0afa93bd4dc7756d01edd3e' AND `key` = 'b56cf690e0afa93bd4dc7756d01edd3e.png' AND `headers` IS NULL AND `type` = 'image/png' AND `metadata` IS NULL AND `download_time` = 1614137309295 AND `relative_path` = 'b56cf690e0afa93bd4dc7756d01edd3e.png' AND `hash` IS NULL AND `hash_type` = 0 AND `marked_for_deletion` = 0 AND `extra_request_headers` IS NULL")
     Assert.assertEquals(1, cursorAssets1.count.toLong())
     val cursorAssets2 =
-      db.query("SELECT * FROM `assets` WHERE `id` = 3 AND `url` = 'https://url.to/bundle-1614137308871' AND `key` = 'bundle-1614137308871' AND `headers` IS NULL AND `type` = 'application/javascript' AND `metadata` IS NULL AND `download_time` = 1614137309513 AND `relative_path` = 'bundle-1614137308871' AND `hash` IS NULL AND `hash_type` = 0 AND `marked_for_deletion` = 0")
+      db.query("SELECT * FROM `assets` WHERE `id` = 3 AND `url` = 'https://url.to/bundle-1614137308871' AND `key` = 'bundle-1614137308871' AND `headers` IS NULL AND `type` = 'application/javascript' AND `metadata` IS NULL AND `download_time` = 1614137309513 AND `relative_path` = 'bundle-1614137308871' AND `hash` IS NULL AND `hash_type` = 0 AND `marked_for_deletion` = 0 AND `extra_request_headers` IS NULL")
     Assert.assertEquals(1, cursorAssets2.count.toLong())
     val cursorAssets3 =
-      db.query("SELECT * FROM `assets` WHERE `id` = 4 AND `url` IS NULL AND `key` IS NULL AND `headers` IS NULL AND `type` = 'js' AND `metadata` IS NULL AND `download_time` = 1614137406588 AND `relative_path` = 'bundle-1614137401950' AND `hash` IS NULL AND `hash_type` = 0 AND `marked_for_deletion` = 0")
+      db.query("SELECT * FROM `assets` WHERE `id` = 4 AND `url` IS NULL AND `key` IS NULL AND `headers` IS NULL AND `type` = 'js' AND `metadata` IS NULL AND `download_time` = 1614137406588 AND `relative_path` = 'bundle-1614137401950' AND `hash` IS NULL AND `hash_type` = 0 AND `marked_for_deletion` = 0 AND `extra_request_headers` IS NULL")
+    Assert.assertEquals(1, cursorAssets3.count.toLong())
+  }
+
+  @Test
+  @Throws(IOException::class)
+  fun testMigrate9To10() {
+    var db = helper.createDatabase(TEST_DB, 9)
+
+    // db has schema version 8. insert some data using SQL queries.
+    // cannot use DAO classes because they expect the latest schema.
+    db.execSQL(
+      """INSERT INTO "assets" ("id","url","key","headers","type","metadata","download_time","relative_path","hash","hash_type","marked_for_deletion","extra_request_headers") VALUES (2,'https://url.to/b56cf690e0afa93bd4dc7756d01edd3e','b56cf690e0afa93bd4dc7756d01edd3e.png',NULL,'image/png',NULL,1614137309295,'b56cf690e0afa93bd4dc7756d01edd3e.png',NULL,0,0,NULL),
+ (3,'https://url.to/bundle-1614137308871','bundle-1614137308871',NULL,'application/javascript',NULL,1614137309513,'bundle-1614137308871',NULL,0,0,NULL),
+ (4,NULL,NULL,NULL,'js',NULL,1614137406588,'bundle-1614137401950',NULL,0,0,NULL)"""
+    )
+
+    // Prepare for the next version.
+    db.close()
+
+    // Re-open the database with version 8 and provide
+    // MIGRATION_8_9 as the migration process.
+    db = helper.runMigrationsAndValidate(TEST_DB, 10, true, UpdatesDatabase.MIGRATION_9_10)
+    db.execSQL("PRAGMA foreign_keys=ON")
+
+    // schema changes automatically verified, we just need to verify data integrity
+    val cursorAssets1 =
+      db.query("SELECT * FROM `assets` WHERE `id` = 2 AND `url` = 'https://url.to/b56cf690e0afa93bd4dc7756d01edd3e' AND `key` = 'b56cf690e0afa93bd4dc7756d01edd3e.png' AND `headers` IS NULL AND `type` = 'image/png' AND `metadata` IS NULL AND `download_time` = 1614137309295 AND `relative_path` = 'b56cf690e0afa93bd4dc7756d01edd3e.png' AND `hash` IS NULL AND `hash_type` = 0 AND `marked_for_deletion` = 0 AND `extra_request_headers` IS NULL AND `expected_hash` IS NULL")
+    Assert.assertEquals(1, cursorAssets1.count.toLong())
+    val cursorAssets2 =
+      db.query("SELECT * FROM `assets` WHERE `id` = 3 AND `url` = 'https://url.to/bundle-1614137308871' AND `key` = 'bundle-1614137308871' AND `headers` IS NULL AND `type` = 'application/javascript' AND `metadata` IS NULL AND `download_time` = 1614137309513 AND `relative_path` = 'bundle-1614137308871' AND `hash` IS NULL AND `hash_type` = 0 AND `marked_for_deletion` = 0 AND `extra_request_headers` IS NULL AND `expected_hash` IS NULL")
+    Assert.assertEquals(1, cursorAssets2.count.toLong())
+    val cursorAssets3 =
+      db.query("SELECT * FROM `assets` WHERE `id` = 4 AND `url` IS NULL AND `key` IS NULL AND `headers` IS NULL AND `type` = 'js' AND `metadata` IS NULL AND `download_time` = 1614137406588 AND `relative_path` = 'bundle-1614137401950' AND `hash` IS NULL AND `hash_type` = 0 AND `marked_for_deletion` = 0 AND `extra_request_headers` IS NULL AND `expected_hash` IS NULL")
     Assert.assertEquals(1, cursorAssets3.count.toLong())
   }
 

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/CryptoTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/CryptoTest.kt
@@ -1,0 +1,85 @@
+package expo.modules.updates.loader
+
+import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.lang.Error
+
+private const val testBody = "{\"id\":\"0754dad0-d200-d634-113c-ef1f26106028\",\"createdAt\":\"2021-11-23T00:57:14.437Z\",\"runtimeVersion\":\"1\",\"assets\":[{\"hash\":\"cb65fafb5ed456fc3ed8a726cf4087d37b875184eba96f33f6d99104e6e2266d\",\"key\":\"489ea2f19fa850b65653ab445637a181.jpg\",\"contentType\":\"image/jpeg\",\"url\":\"http://192.168.64.1:3000/api/assets?asset=updates/1/assets/489ea2f19fa850b65653ab445637a181&runtimeVersion=1&platform=android\",\"fileExtension\":\".jpg\"}],\"launchAsset\":{\"hash\":\"323ddd1968ee76d4ddbb16b04fb2c3f1b6d1ab9b637d819699fecd6fa0ffb1a8\",\"key\":\"696a70cf7035664c20ea86f67dae822b.bundle\",\"contentType\":\"application/javascript\",\"url\":\"http://192.168.64.1:3000/api/assets?asset=updates/1/bundles/android-696a70cf7035664c20ea86f67dae822b.js&runtimeVersion=1&platform=android\",\"fileExtension\":\".bundle\"}}"
+private const val testCertificate = "-----BEGIN CERTIFICATE-----\nMIIDfzCCAmegAwIBAgIJLGiqnjmA9JmpMA0GCSqGSIb3DQEBCwUAMGkxFDASBgNV\nBAMTC2V4YW1wbGUub3JnMQswCQYDVQQGEwJVUzERMA8GA1UECBMIVmlyZ2luaWEx\nEzARBgNVBAcTCkJsYWNrc2J1cmcxDTALBgNVBAoTBFRlc3QxDTALBgNVBAsTBFRl\nc3QwHhcNMjExMTIyMTc0NzQzWhcNMjIxMTIyMTc0NzQzWjBpMRQwEgYDVQQDEwtl\neGFtcGxlLm9yZzELMAkGA1UEBhMCVVMxETAPBgNVBAgTCFZpcmdpbmlhMRMwEQYD\nVQQHEwpCbGFja3NidXJnMQ0wCwYDVQQKEwRUZXN0MQ0wCwYDVQQLEwRUZXN0MIIB\nIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAucg/fRwgYLxO4fDG1W/ew4Wu\nkqp2+j9mLyA18sd8noCT0eSJwxMTLJJq4biNx6kJEVSQdodN3e/qSJndz+ZHA7b1\n6Do3Ecg5oRvl3HEwaH4AkM2Lj87VjgfxPUsiSHtPd+RTbxnOy9lGupQa/j71WrAq\nzJpNmhP70vzkY4EVejn52kzRPZB3kTxkjggFrG/f18Bcf4VYxN3aLML32jih+UC0\n6fv57HNZZ3ewGSJrLcUdEgctBWiz1gzwF6YdXtEJ14eQbgHgsLsXaEQeg2ncGGxF\n/3rIhsnlWjeIIya7TS0nvqZHNKznZV9EWpZQBFVoLGGrvOdU3pTmP39qbmY0nwID\nAQABoyowKDAOBgNVHQ8BAf8EBAMCB4AwFgYDVR0lAQH/BAwwCgYIKwYBBQUHAwMw\nDQYJKoZIhvcNAQELBQADggEBAALcH9Jb3wq64YkNxUIa25T9umhr4uRe94ESHujM\nIRrBbbqu1p3Vs8N3whZNhcL6Djb4ob18m/aGKbF+UQBMvhn23qRCG6KKzIeDY6Os\n8tYyIwush2XeOFA7S5syPqVBI6PrRBDMCLmAJO4qTM2p0f+zyFXFuytCXOv2fA3M\n88aYVmU7NIfBTFdqNIgSt1yj7FKvd5zgoUyu7mTVdzY59xQzkzYTsnobY2XrTcvY\n6wyRqOAQ86wR8OvDjHB5y/YN2Pdg7d9jUFBCX6Ohr7W3GHrjAadKwq+kbH1aP0oB\nQTFLQQfl3gtJ3Dl/5iBQD38sCIkA54FPSsKTRw3mC4DImBQ=\n-----END CERTIFICATE-----"
+private const val testSignature = "sig=\"VpuLfRlB0DizR+hRWmedPGHdx/nzNJ8OomMZNGHwqx64zrx1XezriBoItup/icOlXFrqs6FHaul4g5m41JfEWCUbhXC4x+iNk//bxozEYJHmjbcAtC6xhWbMMYQQaUjuYk7rEL987AbOWyUI2lMhrhK7LNzBaT8RGqBcpEyAqIOMuEKcK0faySnWJylc7IzxHmO8jlx5ufzio8301wej8mNW5dZd7PFOX8Dz015tIpF00VGi29ShDNFbpnalch7f92NFs08Z0g9LXndmrGjNL84Wqd4kq5awRGQObrCuDHU4uFdZjtr4ew0JaNlVuyUrrjyDloBdq0aR804vuDXacQ==\""
+
+@RunWith(AndroidJUnit4ClassRunner::class)
+class CryptoTest {
+  @Test
+  fun test_parseSignatureHeader_ParsesCodeSigningInfo() {
+    val codeSigningInfo = Crypto.parseSignatureHeader("sig=\"12345\", keyid=\"test\", alg=\"rsa-v1_5-sha256\"")
+    Assert.assertEquals(codeSigningInfo.signature, "12345")
+    Assert.assertEquals(codeSigningInfo.keyId, "test")
+    Assert.assertEquals(codeSigningInfo.algorithm, Crypto.CodeSigningAlgorithm.RSA_SHA256)
+  }
+
+  @Test
+  fun test_parseSignatureHeader_DefaultsKeyIdAndAlg() {
+    val codeSigningInfo = Crypto.parseSignatureHeader("sig=\"12345\"")
+    Assert.assertEquals(codeSigningInfo.signature, "12345")
+    Assert.assertEquals(codeSigningInfo.keyId, "root")
+    Assert.assertEquals(codeSigningInfo.algorithm, Crypto.CodeSigningAlgorithm.RSA_SHA256)
+  }
+
+  @Test(expected = Error::class)
+  @Throws(Error::class)
+  fun test_parseSignatureHeader_ThrowsForInvalidAlg() {
+    Crypto.parseSignatureHeader("sig=\"12345\", alg=\"blah\"")
+  }
+
+  @Test
+  fun test_createAcceptSignatureHeader_CreatesSignatureHeaderDefaultValues() {
+    val configuration = Crypto.CodeSigningConfiguration(testCertificate, mapOf())
+    val signatureHeader = Crypto.createAcceptSignatureHeader(configuration)
+    Assert.assertEquals(signatureHeader, "sig, keyid=\"root\", alg=\"rsa-v1_5-sha256\"")
+  }
+
+  @Test
+  fun test_createAcceptSignatureHeader_CreatesSignatureHeaderValuesFromConfig() {
+    val configuration = Crypto.CodeSigningConfiguration(
+      testCertificate,
+      mapOf(
+        Crypto.CODE_SIGNING_METADATA_ALGORITHM_KEY to "rsa-v1_5-sha256",
+        Crypto.CODE_SIGNING_METADATA_KEY_ID_KEY to "test"
+      )
+    )
+    val signatureHeader = Crypto.createAcceptSignatureHeader(configuration)
+    Assert.assertEquals(signatureHeader, "sig, keyid=\"test\", alg=\"rsa-v1_5-sha256\"")
+  }
+
+  @Test(expected = Error::class)
+  @Throws(Error::class)
+  fun test_createAcceptSignatureHeader_ThrowsInvalidAlg() {
+    val configuration = Crypto.CodeSigningConfiguration(
+      testCertificate,
+      mapOf(
+        Crypto.CODE_SIGNING_METADATA_ALGORITHM_KEY to "fake",
+        Crypto.CODE_SIGNING_METADATA_KEY_ID_KEY to "test"
+      )
+    )
+    Crypto.createAcceptSignatureHeader(configuration)
+  }
+
+  @Test
+  fun test_verifyCodeSigning_Verifies() {
+    val codeSigningConfiguration = Crypto.CodeSigningConfiguration(testCertificate, mapOf())
+    val codesigningInfo = Crypto.parseSignatureHeader(testSignature)
+    val isValid = Crypto.verifyCodeSigning(codeSigningConfiguration, codesigningInfo, testBody.toByteArray())
+    Assert.assertTrue(isValid)
+  }
+
+  @Test
+  fun test_verifyCodeSigning_ReturnsFalseWhenSignatureIsInvalid() {
+    val codeSigningConfiguration = Crypto.CodeSigningConfiguration(testCertificate, mapOf())
+    val codesigningInfo = Crypto.parseSignatureHeader("sig=\"aGVsbG8=\"")
+    val isValid = Crypto.verifyCodeSigning(codeSigningConfiguration, codesigningInfo, testBody.toByteArray())
+    Assert.assertFalse(isValid)
+  }
+}

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/CryptoTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/CryptoTest.kt
@@ -71,7 +71,7 @@ class CryptoTest {
   fun test_verifyCodeSigning_Verifies() {
     val codeSigningConfiguration = Crypto.CodeSigningConfiguration(testCertificate, mapOf())
     val codesigningInfo = Crypto.parseSignatureHeader(testSignature)
-    val isValid = Crypto.verifyCodeSigning(codeSigningConfiguration, codesigningInfo, testBody.toByteArray())
+    val isValid = Crypto.isSignatureValid(codeSigningConfiguration, codesigningInfo, testBody.toByteArray())
     Assert.assertTrue(isValid)
   }
 
@@ -79,7 +79,20 @@ class CryptoTest {
   fun test_verifyCodeSigning_ReturnsFalseWhenSignatureIsInvalid() {
     val codeSigningConfiguration = Crypto.CodeSigningConfiguration(testCertificate, mapOf())
     val codesigningInfo = Crypto.parseSignatureHeader("sig=\"aGVsbG8=\"")
-    val isValid = Crypto.verifyCodeSigning(codeSigningConfiguration, codesigningInfo, testBody.toByteArray())
+    val isValid = Crypto.isSignatureValid(codeSigningConfiguration, codesigningInfo, testBody.toByteArray())
     Assert.assertFalse(isValid)
+  }
+
+  @Test(expected = Error::class)
+  @Throws(Error::class)
+  fun test_verifyCodeSigning_ThrowsWhenKeyDoesNotMatch() {
+    val codeSigningConfiguration = Crypto.CodeSigningConfiguration(
+      testCertificate,
+      mapOf(
+        Crypto.CODE_SIGNING_METADATA_KEY_ID_KEY to "test"
+      )
+    )
+    val codesigningInfo = Crypto.parseSignatureHeader("sig=\"aGVsbG8=\", keyid=\"other\"")
+    Crypto.isSignatureValid(codeSigningConfiguration, codesigningInfo, testBody.toByteArray())
   }
 }

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/FileDownloaderManifestParsingTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/FileDownloaderManifestParsingTest.kt
@@ -14,10 +14,14 @@ import org.junit.Assert
 import org.junit.Test
 import org.junit.runner.RunWith
 
+private const val classicJSON = "{\"sdkVersion\":\"39.0.0\",\"releaseId\":\"0eef8214-4833-4089-9dff-b4138a14f196\",\"commitTime\":\"2020-11-11T00:17:54.797Z\",\"bundleUrl\":\"https://url.to/bundle.js\"}"
+
+private const val newJSON = "{\"id\":\"0754dad0-d200-d634-113c-ef1f26106028\",\"createdAt\":\"2021-11-23T00:57:14.437Z\",\"runtimeVersion\":\"1\",\"assets\":[{\"hash\":\"cb65fafb5ed456fc3ed8a726cf4087d37b875184eba96f33f6d99104e6e2266d\",\"key\":\"489ea2f19fa850b65653ab445637a181.jpg\",\"contentType\":\"image/jpeg\",\"url\":\"http://192.168.64.1:3000/api/assets?asset=updates/1/assets/489ea2f19fa850b65653ab445637a181&runtimeVersion=1&platform=android\",\"fileExtension\":\".jpg\"}],\"launchAsset\":{\"hash\":\"323ddd1968ee76d4ddbb16b04fb2c3f1b6d1ab9b637d819699fecd6fa0ffb1a8\",\"key\":\"696a70cf7035664c20ea86f67dae822b.bundle\",\"contentType\":\"application/javascript\",\"url\":\"http://192.168.64.1:3000/api/assets?asset=updates/1/bundles/android-696a70cf7035664c20ea86f67dae822b.js&runtimeVersion=1&platform=android\",\"fileExtension\":\".bundle\"}}"
+private const val newJSONCertificate = "-----BEGIN CERTIFICATE-----\nMIIDfzCCAmegAwIBAgIJLGiqnjmA9JmpMA0GCSqGSIb3DQEBCwUAMGkxFDASBgNV\nBAMTC2V4YW1wbGUub3JnMQswCQYDVQQGEwJVUzERMA8GA1UECBMIVmlyZ2luaWEx\nEzARBgNVBAcTCkJsYWNrc2J1cmcxDTALBgNVBAoTBFRlc3QxDTALBgNVBAsTBFRl\nc3QwHhcNMjExMTIyMTc0NzQzWhcNMjIxMTIyMTc0NzQzWjBpMRQwEgYDVQQDEwtl\neGFtcGxlLm9yZzELMAkGA1UEBhMCVVMxETAPBgNVBAgTCFZpcmdpbmlhMRMwEQYD\nVQQHEwpCbGFja3NidXJnMQ0wCwYDVQQKEwRUZXN0MQ0wCwYDVQQLEwRUZXN0MIIB\nIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAucg/fRwgYLxO4fDG1W/ew4Wu\nkqp2+j9mLyA18sd8noCT0eSJwxMTLJJq4biNx6kJEVSQdodN3e/qSJndz+ZHA7b1\n6Do3Ecg5oRvl3HEwaH4AkM2Lj87VjgfxPUsiSHtPd+RTbxnOy9lGupQa/j71WrAq\nzJpNmhP70vzkY4EVejn52kzRPZB3kTxkjggFrG/f18Bcf4VYxN3aLML32jih+UC0\n6fv57HNZZ3ewGSJrLcUdEgctBWiz1gzwF6YdXtEJ14eQbgHgsLsXaEQeg2ncGGxF\n/3rIhsnlWjeIIya7TS0nvqZHNKznZV9EWpZQBFVoLGGrvOdU3pTmP39qbmY0nwID\nAQABoyowKDAOBgNVHQ8BAf8EBAMCB4AwFgYDVR0lAQH/BAwwCgYIKwYBBQUHAwMw\nDQYJKoZIhvcNAQELBQADggEBAALcH9Jb3wq64YkNxUIa25T9umhr4uRe94ESHujM\nIRrBbbqu1p3Vs8N3whZNhcL6Djb4ob18m/aGKbF+UQBMvhn23qRCG6KKzIeDY6Os\n8tYyIwush2XeOFA7S5syPqVBI6PrRBDMCLmAJO4qTM2p0f+zyFXFuytCXOv2fA3M\n88aYVmU7NIfBTFdqNIgSt1yj7FKvd5zgoUyu7mTVdzY59xQzkzYTsnobY2XrTcvY\n6wyRqOAQ86wR8OvDjHB5y/YN2Pdg7d9jUFBCX6Ohr7W3GHrjAadKwq+kbH1aP0oB\nQTFLQQfl3gtJ3Dl/5iBQD38sCIkA54FPSsKTRw3mC4DImBQ=\n-----END CERTIFICATE-----"
+private const val newJSONSignature = "sig=\"VpuLfRlB0DizR+hRWmedPGHdx/nzNJ8OomMZNGHwqx64zrx1XezriBoItup/icOlXFrqs6FHaul4g5m41JfEWCUbhXC4x+iNk//bxozEYJHmjbcAtC6xhWbMMYQQaUjuYk7rEL987AbOWyUI2lMhrhK7LNzBaT8RGqBcpEyAqIOMuEKcK0faySnWJylc7IzxHmO8jlx5ufzio8301wej8mNW5dZd7PFOX8Dz015tIpF00VGi29ShDNFbpnalch7f92NFs08Z0g9LXndmrGjNL84Wqd4kq5awRGQObrCuDHU4uFdZjtr4ew0JaNlVuyUrrjyDloBdq0aR804vuDXacQ==\""
+
 @RunWith(AndroidJUnit4ClassRunner::class)
 class FileDownloaderManifestParsingTest {
-  private val classicJSON = "{\"sdkVersion\":\"39.0.0\",\"releaseId\":\"0eef8214-4833-4089-9dff-b4138a14f196\",\"commitTime\":\"2020-11-11T00:17:54.797Z\",\"bundleUrl\":\"https://url.to/bundle.js\"}"
-
   @Test
   @Throws(JSONException::class)
   fun testManifestParsing_JSONBody() {
@@ -31,7 +35,7 @@ class FileDownloaderManifestParsingTest {
 
     val configuration = UpdatesConfiguration().loadValuesFromMap(
       mapOf(
-        "updateUrl" to Uri.parse("https://exp.host/@test/test"),
+        UpdatesConfiguration.UPDATES_CONFIGURATION_UPDATE_URL_KEY to Uri.parse("https://exp.host/@test/test"),
       )
     )
 
@@ -90,7 +94,130 @@ class FileDownloaderManifestParsingTest {
 
     val configuration = UpdatesConfiguration().loadValuesFromMap(
       mapOf(
-        "updateUrl" to Uri.parse("https://exp.host/@test/test"),
+        UpdatesConfiguration.UPDATES_CONFIGURATION_UPDATE_URL_KEY to Uri.parse("https://exp.host/@test/test"),
+      )
+    )
+
+    var errorOccurred = false
+    var resultUpdateManifest: UpdateManifest? = null
+
+    FileDownloader(context).parseManifestResponse(
+      response, configuration,
+      object : FileDownloader.ManifestDownloadCallback {
+        override fun onFailure(message: String, e: Exception) {
+          errorOccurred = true
+        }
+
+        override fun onSuccess(updateManifest: UpdateManifest) {
+          resultUpdateManifest = updateManifest
+        }
+      }
+    )
+
+    Assert.assertFalse(errorOccurred)
+    Assert.assertNotNull(resultUpdateManifest)
+  }
+
+  @Test
+  @Throws(JSONException::class)
+  fun testManifestParsing_JSONBodySigned() {
+    val contentType = "application/json"
+    val headersMap = mapOf(
+      "expo-protocol-version" to "0",
+      "expo-sfv-version" to "0",
+      "content-type" to contentType,
+      "expo-signature" to newJSONSignature
+    )
+
+    val context = InstrumentationRegistry.getInstrumentation().targetContext
+
+    val response = mockk<Response>().apply {
+      headersMap.forEach {
+        every { header(it.key) } returns it.value
+      }
+      every { headers() } returns Headers.of(headersMap)
+      every { body() } returns ResponseBody.create(MediaType.parse("application/json; charset=utf-8"), newJSON)
+    }
+
+    val configuration = UpdatesConfiguration().loadValuesFromMap(
+      mapOf(
+        UpdatesConfiguration.UPDATES_CONFIGURATION_UPDATE_URL_KEY to Uri.parse("https://exp.host/@test/test"),
+        UpdatesConfiguration.UPDATES_CONFIGURATION_CODE_SIGNING_CERTIFICATE to newJSONCertificate,
+        UpdatesConfiguration.UPDATES_CONFIGURATION_CODE_SIGNING_METADATA to mapOf<String, String>(),
+      )
+    )
+
+    var errorOccurred = false
+    var resultUpdateManifest: UpdateManifest? = null
+
+    FileDownloader(context).parseManifestResponse(
+      response, configuration,
+      object : FileDownloader.ManifestDownloadCallback {
+        override fun onFailure(message: String, e: Exception) {
+          errorOccurred = true
+        }
+
+        override fun onSuccess(updateManifest: UpdateManifest) {
+          resultUpdateManifest = updateManifest
+        }
+      }
+    )
+
+    Assert.assertFalse(errorOccurred)
+    Assert.assertNotNull(resultUpdateManifest)
+  }
+
+  @Test
+  @Throws(JSONException::class)
+  fun testManifestParsing_MultipartBodySigned() {
+    val context = InstrumentationRegistry.getInstrumentation().targetContext
+    val boundary = "blah"
+    val contentType = "multipart/mixed; boundary=$boundary"
+
+    val headersMap = mapOf(
+      "expo-protocol-version" to "0",
+      "expo-sfv-version" to "0",
+      "content-type" to contentType,
+    )
+
+    val extensions = "{}"
+
+    val multipartBody = MultipartBody.Builder(boundary)
+      .setType(MultipartBody.MIXED)
+      .addPart(
+        Headers.of(mapOf("Content-Disposition" to "form-data; name=\"extraneous\"; filename=\"hello1\"")),
+        RequestBody.create(MediaType.parse("text/plain; charset=utf-8"), "hello")
+      )
+      .addPart(
+        Headers.of(
+          mapOf(
+            "Content-Disposition" to "form-data; name=\"manifest\"; filename=\"hello2\"",
+            "expo-signature" to newJSONSignature
+          )
+        ),
+        RequestBody.create(MediaType.parse("application/json; charset=utf-8"), newJSON)
+      )
+      .addPart(
+        Headers.of(mapOf("Content-Disposition" to "form-data; name=\"extensions\"; filename=\"hello3\"")),
+        RequestBody.create(MediaType.parse("application/json; charset=utf-8"), extensions)
+      )
+      .build()
+
+    val contentBuffer = Buffer().also { multipartBody.writeTo(it) }
+
+    val response = mockk<Response>().apply {
+      headersMap.forEach {
+        every { header(it.key) } returns it.value
+      }
+      every { headers() } returns Headers.of(headersMap)
+      every { body() } returns ResponseBody.create(MultipartBody.MIXED, contentBuffer.readByteArray())
+    }
+
+    val configuration = UpdatesConfiguration().loadValuesFromMap(
+      mapOf(
+        UpdatesConfiguration.UPDATES_CONFIGURATION_UPDATE_URL_KEY to Uri.parse("https://exp.host/@test/test"),
+        UpdatesConfiguration.UPDATES_CONFIGURATION_CODE_SIGNING_CERTIFICATE to newJSONCertificate,
+        UpdatesConfiguration.UPDATES_CONFIGURATION_CODE_SIGNING_METADATA to mapOf<String, String>(),
       )
     )
 

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/FileDownloaderTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/FileDownloaderTest.kt
@@ -6,12 +6,17 @@ import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
 import androidx.test.platform.app.InstrumentationRegistry
 import expo.modules.updates.UpdatesConfiguration
 import expo.modules.updates.db.entity.AssetEntity
+import io.mockk.every
+import io.mockk.mockk
+import okhttp3.*
 import org.json.JSONException
 import org.json.JSONObject
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.io.File
+import java.util.*
 
 @RunWith(AndroidJUnit4ClassRunner::class)
 class FileDownloaderTest {
@@ -83,6 +88,7 @@ class FileDownloaderTest {
     // serverDefinedHeaders should not be able to override preset headers
     val extraHeaders = JSONObject()
     extraHeaders.put("expo-platform", "ios")
+
     val actual = FileDownloader.createRequestForManifest(config, extraHeaders, context)
     Assert.assertEquals("android", actual.header("expo-platform"))
     Assert.assertEquals("custom", actual.header("expo-updates-environment"))
@@ -110,5 +116,54 @@ class FileDownloaderTest {
     val actual = FileDownloader.createRequestForAsset(assetEntity, config)
     Assert.assertEquals("android", actual.header("expo-platform"))
     Assert.assertEquals("custom", actual.header("expo-updates-environment"))
+  }
+
+  @Test
+  fun test_downloadAsset_mismatchedAssetHash() {
+    val configMap = mapOf<String, Any>(
+      UpdatesConfiguration.UPDATES_CONFIGURATION_UPDATE_URL_KEY to Uri.parse("https://u.expo.dev/00000000-0000-0000-0000-000000000000"),
+      UpdatesConfiguration.UPDATES_CONFIGURATION_RUNTIME_VERSION_KEY to "1.0",
+    )
+
+    val config = UpdatesConfiguration().loadValuesFromMap(configMap)
+
+    val assetEntity = AssetEntity(UUID.randomUUID().toString(), "jpg").apply {
+      url = Uri.parse("https://example.com")
+      extraRequestHeaders = JSONObject().apply { put("expo-platform", "ios") }
+      expectedHash = "badhash"
+    }
+
+    val client = mockk<OkHttpClient>() {
+      every { newCall(any()) } returns mockk {
+        every { enqueue(any()) } answers {
+          firstArg<Callback>().onResponse(
+            mockk(),
+            mockk {
+              every { isSuccessful } returns true
+              every { body() } returns ResponseBody.create(MediaType.parse("text/plain; charset=utf-8"), "hello")
+            }
+          )
+        }
+      }
+    }
+
+    var error: Exception? = null
+    var didSucceed = false
+
+    FileDownloader(client).downloadAsset(
+      assetEntity, File(context.cacheDir, "test"), config,
+      object : FileDownloader.AssetDownloadCallback {
+        override fun onFailure(e: Exception, assetEntity: AssetEntity) {
+          error = e
+        }
+
+        override fun onSuccess(assetEntity: AssetEntity, isNew: Boolean) {
+          didSucceed = true
+        }
+      }
+    )
+
+    Assert.assertTrue(error!!.message!!.contains("Asset hash invalid"))
+    Assert.assertFalse(didSucceed)
   }
 }

--- a/packages/expo-updates/android/src/androidTest/schemas/expo.modules.updates.db.UpdatesDatabase/10.json
+++ b/packages/expo-updates/android/src/androidTest/schemas/expo.modules.updates.db.UpdatesDatabase/10.json
@@ -1,0 +1,339 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 10,
+    "identityHash": "31dd21ebb478946b3d4dde78b2bccf6f",
+    "entities": [
+      {
+        "tableName": "updates",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`launch_asset_id` INTEGER, `manifest` TEXT, `status` INTEGER NOT NULL, `keep` INTEGER NOT NULL, `last_accessed` INTEGER NOT NULL, `successful_launch_count` INTEGER NOT NULL DEFAULT 0, `failed_launch_count` INTEGER NOT NULL DEFAULT 0, `id` BLOB NOT NULL, `commit_time` INTEGER NOT NULL, `runtime_version` TEXT NOT NULL, `scope_key` TEXT NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`launch_asset_id`) REFERENCES `assets`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "launchAssetId",
+            "columnName": "launch_asset_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "manifest",
+            "columnName": "manifest",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "keep",
+            "columnName": "keep",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessed",
+            "columnName": "last_accessed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "successfulLaunchCount",
+            "columnName": "successful_launch_count",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "failedLaunchCount",
+            "columnName": "failed_launch_count",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "commitTime",
+            "columnName": "commit_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "runtimeVersion",
+            "columnName": "runtime_version",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scopeKey",
+            "columnName": "scope_key",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_updates_launch_asset_id",
+            "unique": false,
+            "columnNames": [
+              "launch_asset_id"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_updates_launch_asset_id` ON `${TABLE_NAME}` (`launch_asset_id`)"
+          },
+          {
+            "name": "index_updates_scope_key_commit_time",
+            "unique": true,
+            "columnNames": [
+              "scope_key",
+              "commit_time"
+            ],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_updates_scope_key_commit_time` ON `${TABLE_NAME}` (`scope_key`, `commit_time`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "assets",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "launch_asset_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "updates_assets",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`update_id` BLOB NOT NULL, `asset_id` INTEGER NOT NULL, PRIMARY KEY(`update_id`, `asset_id`), FOREIGN KEY(`update_id`) REFERENCES `updates`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`asset_id`) REFERENCES `assets`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "updateId",
+            "columnName": "update_id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "assetId",
+            "columnName": "asset_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "update_id",
+            "asset_id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_updates_assets_asset_id",
+            "unique": false,
+            "columnNames": [
+              "asset_id"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_updates_assets_asset_id` ON `${TABLE_NAME}` (`asset_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "updates",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "update_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "assets",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "asset_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "assets",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `url` TEXT, `headers` TEXT, `extra_request_headers` TEXT, `metadata` TEXT, `download_time` INTEGER, `relative_path` TEXT, `hash` BLOB, `hash_type` INTEGER NOT NULL, `expected_hash` TEXT, `marked_for_deletion` INTEGER NOT NULL, `key` TEXT, `type` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "headers",
+            "columnName": "headers",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "extraRequestHeaders",
+            "columnName": "extra_request_headers",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "metadata",
+            "columnName": "metadata",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "downloadTime",
+            "columnName": "download_time",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "relativePath",
+            "columnName": "relative_path",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "hash",
+            "columnName": "hash",
+            "affinity": "BLOB",
+            "notNull": false
+          },
+          {
+            "fieldPath": "hashType",
+            "columnName": "hash_type",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expectedHash",
+            "columnName": "expected_hash",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "markedForDeletion",
+            "columnName": "marked_for_deletion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_assets_key",
+            "unique": true,
+            "columnNames": [
+              "key"
+            ],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_assets_key` ON `${TABLE_NAME}` (`key`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "json_data",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `key` TEXT NOT NULL, `value` TEXT NOT NULL, `last_updated` INTEGER NOT NULL, `scope_key` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUpdated",
+            "columnName": "last_updated",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scopeKey",
+            "columnName": "scope_key",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_json_data_scope_key",
+            "unique": false,
+            "columnNames": [
+              "scope_key"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_json_data_scope_key` ON `${TABLE_NAME}` (`scope_key`)"
+          }
+        ],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '31dd21ebb478946b3d4dde78b2bccf6f')"
+    ]
+  }
+}

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesConfiguration.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesConfiguration.kt
@@ -149,9 +149,9 @@ class UpdatesConfiguration {
       codeSigningCertificate = codeSigningCertificateFromMap
     }
 
-    val codeSigningMetadataFromMap = map.readValueCheckingType<Map<*, *>>(UPDATES_CONFIGURATION_CODE_SIGNING_METADATA)
+    val codeSigningMetadataFromMap = map.readValueCheckingType<Map<String, String>>(UPDATES_CONFIGURATION_CODE_SIGNING_METADATA)
     if (codeSigningMetadataFromMap != null) {
-      codeSigningMetadata = codeSigningMetadataFromMap as Map<String, String>?
+      codeSigningMetadata = codeSigningMetadataFromMap
     }
 
     return this
@@ -178,10 +178,11 @@ class UpdatesConfiguration {
     }
   }
 
-  val codeSigningConfiguration: Crypto.CodeSigningConfiguration?
-    get() = codeSigningCertificate?.let {
+  val codeSigningConfiguration: Crypto.CodeSigningConfiguration? by lazy {
+    codeSigningCertificate?.let {
       Crypto.CodeSigningConfiguration(it, codeSigningMetadata)
     }
+  }
 
   companion object {
     private val TAG = UpdatesConfiguration::class.java.simpleName

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesConfiguration.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesConfiguration.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.pm.PackageManager
 import android.net.Uri
 import android.util.Log
+import expo.modules.updates.loader.Crypto
 
 class UpdatesConfiguration {
   enum class CheckAutomaticallyConfiguration {
@@ -32,6 +33,9 @@ class UpdatesConfiguration {
   var requestHeaders = mapOf<String, String>()
     private set
 
+  private var codeSigningCertificate: String? = null
+  private var codeSigningMetadata: Map<String, String>? = null
+
   val isMissingRuntimeVersion: Boolean
     get() = (runtimeVersion == null || runtimeVersion!!.isEmpty()) &&
       (sdkVersion == null || sdkVersion!!.isEmpty())
@@ -48,6 +52,14 @@ class UpdatesConfiguration {
       launchWaitMs = ai.metaData.getInt("expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS", 0)
       runtimeVersion = ai.metaData["expo.modules.updates.EXPO_RUNTIME_VERSION"]?.toString()?.replaceFirst("^string:".toRegex(), "")
 
+      codeSigningCertificate = ai.metaData["expo.modules.updates.CODE_SIGNING_CERTIFICATE"]?.toString()
+      codeSigningMetadata = UpdatesUtils.getMapFromJSONString(
+        ai.metaData.getString(
+          "expo.modules.updates.CODE_SIGNING_METADATA",
+          "{}"
+        )
+      )
+
       val checkOnLaunchString = ai.metaData.getString("expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH", "ALWAYS")
       checkOnLaunch = try {
         CheckAutomaticallyConfiguration.valueOf(checkOnLaunchString)
@@ -59,7 +71,7 @@ class UpdatesConfiguration {
         CheckAutomaticallyConfiguration.ALWAYS
       }
 
-      requestHeaders = UpdatesUtils.getHeadersMapFromJSONString(
+      requestHeaders = UpdatesUtils.getMapFromJSONString(
         ai.metaData.getString(
           "expo.modules.updates.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY",
           "{}"
@@ -80,7 +92,7 @@ class UpdatesConfiguration {
       isEnabled = isEnabledFromMap
     }
 
-    expectsSignedManifest = map.readValueCheckingType("expectsSignedManifest") ?: false
+    expectsSignedManifest = map.readValueCheckingType(UPDATES_CONFIGURATION_EXPECTS_EXPO_SIGNED_MANIFEST) ?: false
 
     val updateUrlFromMap = map.readValueCheckingType<Uri>(UPDATES_CONFIGURATION_UPDATE_URL_KEY)
     if (updateUrlFromMap != null) {
@@ -132,6 +144,16 @@ class UpdatesConfiguration {
       hasEmbeddedUpdate = hasEmbeddedUpdateFromMap
     }
 
+    val codeSigningCertificateFromMap = map.readValueCheckingType<String>(UPDATES_CONFIGURATION_CODE_SIGNING_CERTIFICATE)
+    if (codeSigningCertificateFromMap != null) {
+      codeSigningCertificate = codeSigningCertificateFromMap
+    }
+
+    val codeSigningMetadataFromMap = map.readValueCheckingType<Map<*, *>>(UPDATES_CONFIGURATION_CODE_SIGNING_METADATA)
+    if (codeSigningMetadataFromMap != null) {
+      codeSigningMetadata = codeSigningMetadataFromMap as Map<String, String>?
+    }
+
     return this
   }
 
@@ -156,6 +178,11 @@ class UpdatesConfiguration {
     }
   }
 
+  val codeSigningConfiguration: Crypto.CodeSigningConfiguration?
+    get() = codeSigningCertificate?.let {
+      Crypto.CodeSigningConfiguration(it, codeSigningMetadata)
+    }
+
   companion object {
     private val TAG = UpdatesConfiguration::class.java.simpleName
 
@@ -169,6 +196,10 @@ class UpdatesConfiguration {
     const val UPDATES_CONFIGURATION_CHECK_ON_LAUNCH_KEY = "checkOnLaunch"
     const val UPDATES_CONFIGURATION_LAUNCH_WAIT_MS_KEY = "launchWaitMs"
     const val UPDATES_CONFIGURATION_HAS_EMBEDDED_UPDATE_KEY = "hasEmbeddedUpdate"
+    const val UPDATES_CONFIGURATION_EXPECTS_EXPO_SIGNED_MANIFEST = "expectsSignedManifest"
+    const val UPDATES_CONFIGURATION_CODE_SIGNING_CERTIFICATE = "codeSigningCertificate"
+    const val UPDATES_CONFIGURATION_CODE_SIGNING_METADATA = "codeSigningMetadata"
+
     private const val UPDATES_CONFIGURATION_RELEASE_CHANNEL_DEFAULT_VALUE = "default"
     private const val UPDATES_CONFIGURATION_LAUNCH_WAIT_MS_DEFAULT_VALUE = 0
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesPackage.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesPackage.kt
@@ -27,12 +27,6 @@ class UpdatesPackage : Package {
   override fun createReactNativeHostHandlers(context: Context): List<ReactNativeHostHandler> {
     val handler: ReactNativeHostHandler = object : ReactNativeHostHandler {
       private var mShouldAutoSetup: Boolean? = null
-      override fun createReactInstanceManager(useDeveloperSupport: Boolean): ReactInstanceManager? {
-        if (shouldAutoSetup(context) && !useDeveloperSupport) {
-          UpdatesController.initialize(context)
-        }
-        return null
-      }
 
       override fun getJSBundleFile(useDeveloperSupport: Boolean): String? {
         return if (shouldAutoSetup(context) && !useDeveloperSupport) UpdatesController.instance.launchAssetFile else null
@@ -42,17 +36,17 @@ class UpdatesPackage : Package {
         return if (shouldAutoSetup(context) && !useDeveloperSupport) UpdatesController.instance.bundleAssetName else null
       }
 
-//      override fun onWillCreateReactInstanceManager(useDeveloperSupport: Boolean) {
-//        if (shouldAutoSetup(context) && !useDeveloperSupport) {
-//          UpdatesController.initialize(context)
-//        }
-//      }
-//
-//      override fun onDidCreateReactInstanceManager(reactInstanceManager: ReactInstanceManager, useDeveloperSupport: Boolean) {
-//        if (shouldAutoSetup(context) && !useDeveloperSupport) {
-//          UpdatesController.instance.onDidCreateReactInstanceManager(reactInstanceManager)
-//        }
-//      }
+      override fun onWillCreateReactInstanceManager(useDeveloperSupport: Boolean) {
+        if (shouldAutoSetup(context) && !useDeveloperSupport) {
+          UpdatesController.initialize(context)
+        }
+      }
+
+      override fun onDidCreateReactInstanceManager(reactInstanceManager: ReactInstanceManager, useDeveloperSupport: Boolean) {
+        if (shouldAutoSetup(context) && !useDeveloperSupport) {
+          UpdatesController.instance.onDidCreateReactInstanceManager(reactInstanceManager)
+        }
+      }
 
       @UiThread
       private fun shouldAutoSetup(context: Context): Boolean {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesPackage.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesPackage.kt
@@ -27,6 +27,12 @@ class UpdatesPackage : Package {
   override fun createReactNativeHostHandlers(context: Context): List<ReactNativeHostHandler> {
     val handler: ReactNativeHostHandler = object : ReactNativeHostHandler {
       private var mShouldAutoSetup: Boolean? = null
+      override fun createReactInstanceManager(useDeveloperSupport: Boolean): ReactInstanceManager? {
+        if (shouldAutoSetup(context) && !useDeveloperSupport) {
+          UpdatesController.initialize(context)
+        }
+        return null
+      }
 
       override fun getJSBundleFile(useDeveloperSupport: Boolean): String? {
         return if (shouldAutoSetup(context) && !useDeveloperSupport) UpdatesController.instance.launchAssetFile else null
@@ -36,17 +42,17 @@ class UpdatesPackage : Package {
         return if (shouldAutoSetup(context) && !useDeveloperSupport) UpdatesController.instance.bundleAssetName else null
       }
 
-      override fun onWillCreateReactInstanceManager(useDeveloperSupport: Boolean) {
-        if (shouldAutoSetup(context) && !useDeveloperSupport) {
-          UpdatesController.initialize(context)
-        }
-      }
-
-      override fun onDidCreateReactInstanceManager(reactInstanceManager: ReactInstanceManager, useDeveloperSupport: Boolean) {
-        if (shouldAutoSetup(context) && !useDeveloperSupport) {
-          UpdatesController.instance.onDidCreateReactInstanceManager(reactInstanceManager)
-        }
-      }
+//      override fun onWillCreateReactInstanceManager(useDeveloperSupport: Boolean) {
+//        if (shouldAutoSetup(context) && !useDeveloperSupport) {
+//          UpdatesController.initialize(context)
+//        }
+//      }
+//
+//      override fun onDidCreateReactInstanceManager(reactInstanceManager: ReactInstanceManager, useDeveloperSupport: Boolean) {
+//        if (shouldAutoSetup(context) && !useDeveloperSupport) {
+//          UpdatesController.instance.onDidCreateReactInstanceManager(reactInstanceManager)
+//        }
+//      }
 
       @UiThread
       private fun shouldAutoSetup(context: Context): Boolean {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesUtils.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesUtils.kt
@@ -34,7 +34,7 @@ object UpdatesUtils {
   private const val UPDATES_EVENT_NAME = "Expo.nativeUpdatesEvent"
 
   @Throws(Exception::class)
-  fun getHeadersMapFromJSONString(stringifiedJSON: String): Map<String, String> {
+  fun getMapFromJSONString(stringifiedJSON: String): Map<String, String> {
     val jsonObject = JSONObject(stringifiedJSON)
     val keys = jsonObject.keys()
     val newMap = mutableMapOf<String, String>()
@@ -104,7 +104,7 @@ object UpdatesUtils {
   }
 
   @Throws(NoSuchAlgorithmException::class, IOException::class)
-  fun sha256AndWriteToFile(inputStream: InputStream?, destination: File): ByteArray {
+  fun sha256AndWriteToFile(inputStream: InputStream, destination: File): ByteArray {
     DigestInputStream(inputStream, MessageDigest.getInstance("SHA-256")).use { digestInputStream ->
       // write file atomically by writing it to a temporary path and then renaming
       // this protects us against partially written files if the process is interrupted

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/UpdatesDatabase.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/UpdatesDatabase.kt
@@ -18,8 +18,8 @@ import java.util.*
 
 @Database(
   entities = [UpdateEntity::class, UpdateAssetEntity::class, AssetEntity::class, JSONDataEntity::class],
-  exportSchema = false,
-  version = 9
+  exportSchema = true,
+  version = 10
 )
 @TypeConverters(Converters::class)
 abstract class UpdatesDatabase : RoomDatabase() {
@@ -42,6 +42,7 @@ abstract class UpdatesDatabase : RoomDatabase() {
           .addMigrations(MIGRATION_6_7)
           .addMigrations(MIGRATION_7_8)
           .addMigrations(MIGRATION_8_9)
+          .addMigrations(MIGRATION_9_10)
           .fallbackToDestructiveMigration()
           .allowMainThreadQueries()
           .build()
@@ -171,6 +172,24 @@ abstract class UpdatesDatabase : RoomDatabase() {
           database.beginTransaction()
           try {
             database.execSQL("ALTER TABLE `assets` ADD COLUMN `extra_request_headers` TEXT")
+            database.setTransactionSuccessful()
+          } finally {
+            database.endTransaction()
+          }
+        } finally {
+          database.execSQL("PRAGMA foreign_keys=ON")
+        }
+      }
+    }
+
+    val MIGRATION_9_10: Migration = object : Migration(9, 10) {
+      override fun migrate(database: SupportSQLiteDatabase) {
+        // https://www.sqlite.org/lang_altertable.html#otheralter
+        try {
+          database.execSQL("PRAGMA foreign_keys=OFF")
+          database.beginTransaction()
+          try {
+            database.execSQL("ALTER TABLE `assets` ADD COLUMN `expected_hash` TEXT")
             database.setTransactionSuccessful()
           } finally {
             database.endTransaction()

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/entity/AssetEntity.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/entity/AssetEntity.kt
@@ -31,6 +31,9 @@ class AssetEntity(@field:ColumnInfo(name = "key") var key: String?, var type: St
   @ColumnInfo(name = "hash_type")
   var hashType = HashType.SHA256
 
+  @ColumnInfo(name = "expected_hash")
+  var expectedHash: String? = null
+
   @ColumnInfo(name = "marked_for_deletion")
   var markedForDeletion = false
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/Crypto.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/Crypto.kt
@@ -132,7 +132,7 @@ object Crypto {
         return when (str) {
           RSA_SHA256.algorithmName -> RSA_SHA256
           null -> RSA_SHA256
-          else -> throw Error("Invalid code signing algorithm name: $str")
+          else -> throw Exception("Invalid code signing algorithm name: $str")
         }
       }
     }
@@ -180,7 +180,7 @@ object Crypto {
 
   fun parseSignatureHeader(signatureHeader: String?): SignatureHeaderInfo {
     if (signatureHeader == null) {
-      throw Error("No expo-signature header specified")
+      throw Exception("No expo-signature header specified")
     }
 
     val signatureMap = Parser(signatureHeader).parseDictionary().get()
@@ -191,7 +191,7 @@ object Crypto {
 
     val signature = if (sigFieldValue is StringItem) {
       sigFieldValue.get()
-    } else throw Error("Structured field $CODE_SIGNING_SIGNATURE_STRUCTURED_FIELD_KEY_SIGNATURE not found in expo-signature header")
+    } else throw Exception("Structured field $CODE_SIGNING_SIGNATURE_STRUCTURED_FIELD_KEY_SIGNATURE not found in expo-signature header")
     val keyId = if (keyIdFieldValue is StringItem) {
       keyIdFieldValue.get()
     } else CODE_SIGNING_METADATA_DEFAULT_KEY_ID
@@ -206,7 +206,7 @@ object Crypto {
     // check that the key used to sign the response is the same as the key embedded in the configuration
     // TODO(wschurman): this may change for child certificates and development certificates
     if (info.keyId != configuration.keyId) {
-      throw Error("Key with keyid=${info.keyId} from signature not found in client configuration")
+      throw Exception("Key with keyid=${info.keyId} from signature not found in client configuration")
     }
 
     // note that a mismatched algorithm doesn't fail early. it still tries to verify the signature with the

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/Crypto.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/Crypto.kt
@@ -3,28 +3,46 @@ package expo.modules.updates.loader
 import android.annotation.SuppressLint
 import android.security.keystore.KeyProperties
 import android.util.Base64
+import expo.modules.structuredheaders.BooleanItem
+import expo.modules.structuredheaders.Dictionary
 import okhttp3.*
 import java.io.IOException
 import java.security.*
+import java.security.cert.CertificateException
+import java.security.cert.CertificateFactory
+import java.security.cert.X509Certificate
 import java.security.spec.InvalidKeySpecException
 import java.security.spec.X509EncodedKeySpec
+import expo.modules.structuredheaders.Parser
+import expo.modules.structuredheaders.StringItem
 
 object Crypto {
-  private const val PUBLIC_KEY_URL = "https://exp.host/--/manifest-public-key"
+  const val CODE_SIGNING_METADATA_ALGORITHM_KEY = "alg"
+  const val CODE_SIGNING_METADATA_KEY_ID_KEY = "keyid"
 
-  fun verifyPublicRSASignature(
-    plainText: String,
-    cipherText: String,
+  const val CODE_SIGNING_METADATA_DEFAULT_KEY_ID = "root"
+  const val CODE_SIGNING_SIGNATURE_STRUCTURED_FIELD_KEY_SIGNATURE = "sig"
+  const val CODE_SIGNING_SIGNATURE_STRUCTURED_FIELD_KEY_KEY_ID = "keyid"
+  const val CODE_SIGNING_SIGNATURE_STRUCTURED_FIELD_KEY_ALGORITHM = "alg"
+
+  private const val EXPO_PUBLIC_KEY_URL = "https://exp.host/--/manifest-public-key"
+
+  // ASN.1 path to the extended key usage info within a CERT
+  private const val CODE_SIGNING_OID = "1.3.6.1.5.5.7.3.3"
+
+  fun verifyExpoPublicRSASignature(
     fileDownloader: FileDownloader,
+    data: String,
+    signature: String,
     listener: RSASignatureListener
   ) {
-    fetchPublicKeyAndVerifyPublicRSASignature(true, plainText, cipherText, fileDownloader, listener)
+    fetchExpoPublicKeyAndVerifyPublicRSASignature(true, data, signature, fileDownloader, listener)
   }
 
   // On first attempt use cache. If verification fails try a second attempt without
   // cache in case the keys were actually rotated.
   // On second attempt reject promise if it fails.
-  private fun fetchPublicKeyAndVerifyPublicRSASignature(
+  private fun fetchExpoPublicKeyAndVerifyPublicRSASignature(
     isFirstAttempt: Boolean,
     plainText: String,
     cipherText: String,
@@ -33,7 +51,7 @@ object Crypto {
   ) {
     val cacheControl = if (isFirstAttempt) CacheControl.FORCE_CACHE else CacheControl.FORCE_NETWORK
     val request = Request.Builder()
-      .url(PUBLIC_KEY_URL)
+      .url(EXPO_PUBLIC_KEY_URL)
       .cacheControl(cacheControl)
       .build()
     fileDownloader.downloadData(
@@ -46,16 +64,14 @@ object Crypto {
         @Throws(IOException::class)
         override fun onResponse(call: Call, response: Response) {
           val exception: Exception = try {
-            val isValid = verifyPublicRSASignature(
-              response.body()!!.string(), plainText, cipherText
-            )
+            val isValid = verifyPublicRSASignature(response.body()!!.string(), plainText, cipherText)
             listener.onCompleted(isValid)
             return
           } catch (e: Exception) {
             e
           }
           if (isFirstAttempt) {
-            fetchPublicKeyAndVerifyPublicRSASignature(
+            fetchExpoPublicKeyAndVerifyPublicRSASignature(
               false,
               plainText,
               cipherText,
@@ -103,5 +119,94 @@ object Crypto {
   interface RSASignatureListener {
     fun onError(exception: Exception, isNetworkError: Boolean)
     fun onCompleted(isValid: Boolean)
+  }
+
+  enum class CodeSigningAlgorithm(val algorithmName: String) {
+    RSA_SHA256("rsa-v1_5-sha256");
+
+    companion object {
+      fun parseFromString(str: String?): CodeSigningAlgorithm {
+        return when (str) {
+          RSA_SHA256.algorithmName -> RSA_SHA256
+          null -> RSA_SHA256
+          else -> throw Error("Invalid code signing algorithm name: $str")
+        }
+      }
+    }
+  }
+
+  data class CodeSigningConfiguration(private val certificateString: String, private val metadata: Map<String, String>?) {
+    val embeddedCertificate: X509Certificate by lazy {
+      val certificateFactory = CertificateFactory.getInstance("X.509")
+      val certificate = certificateFactory.generateCertificate(certificateString.byteInputStream()) as X509Certificate
+      certificate.checkValidity()
+
+      val keyUsage = certificate.keyUsage
+      if (keyUsage.isEmpty() || !keyUsage[0]) {
+        throw CertificateException("X509v3 Key Usage: Digital Signature not present")
+      }
+
+      val extendedKeyUsage = certificate.extendedKeyUsage
+      if (!extendedKeyUsage.contains(CODE_SIGNING_OID)) {
+        throw CertificateException("X509v3 Extended Key Usage: Code Signing not present")
+      }
+
+      certificate
+    }
+
+    val algorithm: CodeSigningAlgorithm by lazy {
+      CodeSigningAlgorithm.parseFromString(metadata?.get(CODE_SIGNING_METADATA_ALGORITHM_KEY))
+    }
+
+    val keyId: String by lazy {
+      metadata?.get(CODE_SIGNING_METADATA_KEY_ID_KEY) ?: CODE_SIGNING_METADATA_DEFAULT_KEY_ID
+    }
+  }
+
+  data class CodeSigningInfo(val signature: String, val keyId: String?, val algorithm: CodeSigningAlgorithm?)
+
+  fun createAcceptSignatureHeader(codeSigningConfiguration: CodeSigningConfiguration): String {
+    return Dictionary.valueOf(
+      mapOf(
+        CODE_SIGNING_SIGNATURE_STRUCTURED_FIELD_KEY_SIGNATURE to BooleanItem.valueOf(true),
+        CODE_SIGNING_SIGNATURE_STRUCTURED_FIELD_KEY_KEY_ID to StringItem.valueOf(codeSigningConfiguration.keyId),
+        CODE_SIGNING_SIGNATURE_STRUCTURED_FIELD_KEY_ALGORITHM to StringItem.valueOf(codeSigningConfiguration.algorithm.algorithmName)
+      )
+    ).serialize()
+  }
+
+  fun parseSignatureHeader(signatureField: String?): CodeSigningInfo {
+    if (signatureField == null) {
+      throw Error("No expo-signature header specified")
+    }
+
+    val signatureMap = Parser(signatureField).parseDictionary().get()
+
+    val sigFieldValue = signatureMap[CODE_SIGNING_SIGNATURE_STRUCTURED_FIELD_KEY_SIGNATURE]
+    val keyIdFieldValue = signatureMap[CODE_SIGNING_SIGNATURE_STRUCTURED_FIELD_KEY_KEY_ID]
+    val algFieldValue = signatureMap[CODE_SIGNING_SIGNATURE_STRUCTURED_FIELD_KEY_ALGORITHM]
+
+    val signature = if (sigFieldValue is StringItem) {
+      sigFieldValue.get()
+    } else throw Error("Structured field $CODE_SIGNING_SIGNATURE_STRUCTURED_FIELD_KEY_SIGNATURE not found in expo-signature header")
+    val keyId = if (keyIdFieldValue is StringItem) {
+      keyIdFieldValue.get()
+    } else CODE_SIGNING_METADATA_DEFAULT_KEY_ID
+    val alg = if (algFieldValue is StringItem) {
+      algFieldValue.get()
+    } else null
+
+    return CodeSigningInfo(signature, keyId, CodeSigningAlgorithm.parseFromString(alg))
+  }
+
+  fun verifyCodeSigning(configuration: CodeSigningConfiguration, info: CodeSigningInfo, bytes: ByteArray): Boolean {
+    return Signature.getInstance(
+      when (configuration.algorithm) {
+        CodeSigningAlgorithm.RSA_SHA256 -> "SHA256withRSA"
+      }
+    ).apply {
+      initVerify(configuration.embeddedCertificate.publicKey)
+      update(bytes)
+    }.verify(Base64.decode(info.signature, Base64.DEFAULT))
   }
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.kt
@@ -391,7 +391,7 @@ open class FileDownloader() {
     ) {
       try {
         configuration.codeSigningConfiguration?.let {
-          val isSignatureValid = Crypto.verifyCodeSigning(
+          val isSignatureValid = Crypto.isSignatureValid(
             it,
             Crypto.parseSignatureHeader(manifestHeaderData.signature),
             bodyString.toByteArray()

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.kt
@@ -14,6 +14,7 @@ import expo.modules.updates.manifest.ManifestHeaderData
 import expo.modules.updates.manifest.UpdateManifest
 import expo.modules.updates.selectionpolicy.SelectionPolicies
 import okhttp3.*
+import org.apache.commons.codec.binary.Hex
 import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
@@ -25,8 +26,16 @@ import org.apache.commons.fileupload.MultipartStream
 import org.apache.commons.fileupload.ParameterParser
 import java.io.ByteArrayOutputStream
 
-open class FileDownloader(context: Context) {
-  private val client = OkHttpClient.Builder().cache(getCache(context)).build()
+open class FileDownloader() {
+  private lateinit var client: OkHttpClient
+
+  constructor(context: Context) : this() {
+    client = OkHttpClient.Builder().cache(getCache(context)).build()
+  }
+
+  constructor(client: OkHttpClient) : this() {
+    this.client = client
+  }
 
   interface FileDownloadCallback {
     fun onFailure(e: Exception)
@@ -106,6 +115,7 @@ open class FileDownloader(context: Context) {
         manifestFilters = responseHeaders["expo-manifest-filters"],
         serverDefinedHeaders = responseHeaders["expo-server-defined-headers"],
         manifestSignature = responseHeaders["expo-manifest-signature"],
+        signature = responseHeaders["expo-signature"]
       )
 
       parseManifest(response.body()!!.string(), manifestHeaderData, null, configuration, callback)
@@ -184,6 +194,7 @@ open class FileDownloader(context: Context) {
       manifestFilters = responseHeaders["expo-manifest-filters"],
       serverDefinedHeaders = responseHeaders["expo-server-defined-headers"],
       manifestSignature = responseHeaders["expo-manifest-signature"],
+      signature = manifestPartBodyAndHeaders.second["expo-signature"]
     )
 
     parseManifest(manifestPartBodyAndHeaders.first, manifestHeaderData, extensions, configuration, callback)
@@ -208,18 +219,21 @@ open class FileDownloader(context: Context) {
        *   signature: string;
        * }
        */
-      val manifestString =
-        if (isSignatureInBody) updateResponseJson.getString("manifestString") else manifestBody
+      val manifestString = if (isSignatureInBody) {
+        updateResponseJson.getString("manifestString")
+      } else {
+        manifestBody
+      }
       val preManifest = JSONObject(manifestString)
 
       // XDL serves unsigned manifests with the `signature` key set to "UNSIGNED".
       // We should treat these manifests as unsigned rather than signed with an invalid signature.
       val isUnsignedFromXDL = "UNSIGNED" == signature
       if (signature != null && !isUnsignedFromXDL) {
-        Crypto.verifyPublicRSASignature(
+        Crypto.verifyExpoPublicRSASignature(
+          this@FileDownloader,
           manifestString,
           signature,
-          this@FileDownloader,
           object : RSASignatureListener {
             override fun onError(exception: Exception, isNetworkError: Boolean) {
               callback.onFailure("Could not validate signed manifest", exception)
@@ -228,7 +242,7 @@ open class FileDownloader(context: Context) {
             override fun onCompleted(isValid: Boolean) {
               if (isValid) {
                 try {
-                  createManifest(preManifest, manifestHeaderData, extensions, true, configuration, callback)
+                  createManifest(manifestBody, preManifest, manifestHeaderData, extensions, true, configuration, callback)
                 } catch (e: Exception) {
                   callback.onFailure("Failed to parse manifest data", e)
                 }
@@ -242,7 +256,7 @@ open class FileDownloader(context: Context) {
           }
         )
       } else {
-        createManifest(preManifest, manifestHeaderData, extensions, false, configuration, callback)
+        createManifest(manifestBody, preManifest, manifestHeaderData, extensions, false, configuration, callback)
       }
     } catch (e: Exception) {
       callback.onFailure(
@@ -319,6 +333,12 @@ open class FileDownloader(context: Context) {
             }
 
             override fun onSuccess(file: File, hash: ByteArray) {
+              val hashHexString = String(Hex.encodeHex(hash))
+              if (asset.expectedHash != null && !asset.expectedHash.equals(hashHexString)) {
+                callback.onFailure(Exception("Asset hash invalid: ${asset.key}; expectedHash: ${asset.expectedHash}; actualHash: $hashHexString"), asset)
+                return
+              }
+
               asset.downloadTime = Date()
               asset.relativePath = filename
               asset.hash = hash
@@ -361,6 +381,7 @@ open class FileDownloader(context: Context) {
 
     @Throws(Exception::class)
     private fun createManifest(
+      bodyString: String,
       preManifest: JSONObject,
       manifestHeaderData: ManifestHeaderData,
       extensions: JSONObject?,
@@ -368,6 +389,22 @@ open class FileDownloader(context: Context) {
       configuration: UpdatesConfiguration,
       callback: ManifestDownloadCallback
     ) {
+      try {
+        configuration.codeSigningConfiguration?.let {
+          val isSignatureValid = Crypto.verifyCodeSigning(
+            it,
+            Crypto.parseSignatureHeader(manifestHeaderData.signature),
+            bodyString.toByteArray()
+          )
+          if (!isSignatureValid) {
+            throw IOException("File download was successful, but signature was incorrect")
+          }
+        }
+      } catch (e: Exception) {
+        callback.onFailure("Downloaded manifest signature is invalid", e)
+        return
+      }
+
       if (configuration.expectsSignedManifest) {
         preManifest.put("isVerified", isVerified)
       }
@@ -483,6 +520,11 @@ open class FileDownloader(context: Context) {
         .apply {
           for ((key, value) in configuration.requestHeaders) {
             header(key, value)
+          }
+        }
+        .apply {
+          configuration.codeSigningConfiguration?.let {
+            header("expo-expects-signature", Crypto.createAcceptSignatureHeader(it))
           }
         }
         .build()

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ManifestHeaderData.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ManifestHeaderData.kt
@@ -4,5 +4,12 @@ data class ManifestHeaderData(
   val protocolVersion: String? = null,
   val serverDefinedHeaders: String? = null,
   val manifestFilters: String? = null,
-  val manifestSignature: String? = null
+  /**
+   * Classic updates Expo Go manifest signature
+   */
+  val manifestSignature: String? = null,
+  /**
+   * Code signing manifest signature
+   */
+  val signature: String? = null
 )

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/NewUpdateManifest.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/NewUpdateManifest.kt
@@ -68,6 +68,7 @@ class NewUpdateManifest private constructor(
           extraRequestHeaders = assetHeaders[mLaunchAsset.getString("key")]
           isLaunchAsset = true
           embeddedAssetFilename = EmbeddedLoader.BUNDLE_FILENAME
+          expectedHash = mLaunchAsset.getString("hash")
         }
       )
     } catch (e: JSONException) {
@@ -85,6 +86,7 @@ class NewUpdateManifest private constructor(
               url = Uri.parse(assetObject.getString("url"))
               extraRequestHeaders = assetHeaders[assetObject.getString("key")]
               embeddedAssetFilename = assetObject.getNullable("embeddedAssetFilename")
+              expectedHash = mLaunchAsset.getString("hash")
             }
           )
         } catch (e: JSONException) {


### PR DESCRIPTION
# Why

This is the android implementation of the code signing portion of #14853.

# How

This introduces two new fields to the update config:
- `expo.modules.updates.CODE_SIGNING_CERTIFICATE` - required config (when code signing is desired) containing an X.509 certificate. The certificate is structured the same as the values set by default when a code signing certificate is generated in Apple Keychain Access, which seems to be pretty standard. To be valid, it must:
     - be valid (dates)
     - have digital signature (key usage)
     - have the code signing extended key usage
- `expo.modules.updates.CODE_SIGNING_METADATA` - optional JSON object containing:
    - `alg` algorithm that should be used to verify the manifest signature. Note that this can differ from the algorithm used to sign the certificate even if the same key is used (rsa-sha256 vs rsa-sha512 for example use the same key but different hashes). This is also used by the client to hint to the server what algorithm it is planning to use to verify the signature.
    - `keyid` an identifier for the key present in the certificate. Defaults to `root` (maybe we should rethink this). This is used by the client to hint to the server what key it is planning to use to verify the signature.

The signature verification process is as follows:
1. Check for certificate. If not present, assume code signing is not enabled and proceed without signature verification.
2. Validate certificate and metadata.
3. Send manifest request with `expo-expects-signature` header following the spec.
3. Upon receiving manifest response (in either json or multipart format), extract the signature.
4. Before constructing the manifest object, verify the signature against the manifest body bytes. If it is valid, continue, else throw.

This also adds an important piece to asset downloading which is to verify that the hash of the downloaded asset matches the expected hash from the manifest. This way the assets are also transitively signed by a signed manifest.

# Test Plan

Run tests.

Also follow the following steps:
1. `yarn link` the local `expo-updates` package
2. Modify `UpdatesPackage.kt` so that linked stuff works.
3. Use in https://github.com/expo/custom-expo-updates-server/pull/2 which uses multipart and code signing.
4. Create and release updates, ensure signing works.