### PR TITLE
[ios] Add EXErrorView text colors to avoid dark mode issues

### DIFF
--- a/ios/Exponent/Kernel/Views/EXErrorView.m
+++ b/ios/Exponent/Kernel/Views/EXErrorView.m
@@ -35,6 +35,7 @@
     _lblError.numberOfLines = 0;
     _lblError.textAlignment = NSTextAlignmentCenter;
     _lblError.font = [UIFont systemFontOfSize:14.0f];
+    _lblError.textColor = [UIColor blackColor];
     [_vContainer addSubview:_lblError];
     
     // retry button
@@ -64,6 +65,7 @@
     self.lblErrorDetail = [[UILabel alloc] init];
     _lblErrorDetail.numberOfLines = 0;
     _lblErrorDetail.textAlignment = NSTextAlignmentCenter;
+    _lblErrorDetail.textColor = [UIColor darkGrayColor];
     [_vContainer addSubview:_lblErrorDetail];
     
     for (UILabel *lblToStyle in @[ _lblUrl, _lblErrorDetail ]) {


### PR DESCRIPTION
# Why

When running the device in dark mode, it automatically changes the text color and status bar. This is great, but not if the view itself is not built for dark mode 🤷  It results in white text on white backgrounds.

# How

This is a quick fix to "force these labels into light mode", based on `EXLoadingView` ([status label](https://github.com/expo/expo/blob/master/ios/Exponent/Kernel/Views/Loading/EXAppLoadingCancelView.m#L74), and [advice label](https://github.com/expo/expo/blob/master/ios/Exponent/Kernel/Views/Loading/EXAppLoadingCancelView.m#L82)).

The best fix would be to make these kernel views support dark mode, the status bar is also not doing great. I'm a bit too unfamiliar with iOS code, but if anyone wants to convert it I'd be happy to pair!

Here is a screenshot what it would look like with the fix:

<img src="https://user-images.githubusercontent.com/1203991/145698139-af349cde-7919-40d9-a57e-15d0abd819f0.PNG" width="250" />

# Test Plan

- Start any Expo project locally
- Load it in the app
- Stop the bundler
- Reopen app and tap the "recently in use" one
- This error screen should pop up

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
