### PR TITLE
Updates variables.md with secrets hierarchy info

### DIFF
--- a/docs/pages/build-reference/variables.md
+++ b/docs/pages/build-reference/variables.md
@@ -241,7 +241,9 @@ The following are two possible alternative approaches, each with different trade
 
 <div style={{marginTop: -20, display: 'block'}} />
 
-> ⚠️  Secrets set on the Expo website or through the EAS CLI will override any env variables with the same name set within your eas.json or app.config.js files. 
+### How are naming collisions between secrets and the `env` field in eas.json handled?
+
+A secret created on the Expo website or with `eas secret:create` will take precedence over an environment variables of the same name that is set through the `env` field in **eas.json**. For example, if you create a secret with name `MY_TOKEN` and value `secret` and also set `"env": { "MY_TOKEN": "public" }` in your **eas.json**, then `process.env.MY_TOKEN` on EAS Build will evaluate to `secret`.
 
 ### How do environment variables work for my Expo Development Client builds?
 

--- a/docs/pages/build-reference/variables.md
+++ b/docs/pages/build-reference/variables.md
@@ -243,7 +243,9 @@ The following are two possible alternative approaches, each with different trade
 
 ### How are naming collisions between secrets and the `env` field in eas.json handled?
 
-A secret created on the Expo website or with `eas secret:create` will take precedence over an environment variables of the same name that is set through the `env` field in **eas.json**. For example, if you create a secret with name `MY_TOKEN` and value `secret` and also set `"env": { "MY_TOKEN": "public" }` in your **eas.json**, then `process.env.MY_TOKEN` on EAS Build will evaluate to `secret`.
+A secret created on the Expo website or with `eas secret:create` will take precedence over an environment variable of the same name that is set through the `env` field in **eas.json**.
+
+For example, if you create a secret with name `MY_TOKEN` and value `secret` and also set `"env": { "MY_TOKEN": "public" }` in your **eas.json**, then `process.env.MY_TOKEN` on EAS Build will evaluate to `secret`.
 
 ### How do environment variables work for my Expo Development Client builds?
 

--- a/docs/pages/build-reference/variables.md
+++ b/docs/pages/build-reference/variables.md
@@ -241,6 +241,8 @@ The following are two possible alternative approaches, each with different trade
 
 <div style={{marginTop: -20, display: 'block'}} />
 
+> ⚠️  Secrets set on the Expo website or through the EAS CLI will override any secrets set within your eas.json or app.config.js files. 
+
 ### How do environment variables work for my Expo Development Client builds?
 
 Environment variables set in your build profile that impact **app.config.js** will be used for configuring the development build. When you run `expo start` to load your app inside of your development build, only environment variables that are available on your development machine will be used for the app manifest; this becomes the same situation as described above for **expo start**.

--- a/docs/pages/build-reference/variables.md
+++ b/docs/pages/build-reference/variables.md
@@ -241,7 +241,7 @@ The following are two possible alternative approaches, each with different trade
 
 <div style={{marginTop: -20, display: 'block'}} />
 
-> ⚠️  Secrets set on the Expo website or through the EAS CLI will override any secrets set within your eas.json or app.config.js files. 
+> ⚠️  Secrets set on the Expo website or through the EAS CLI will override any env variables with the same name set within your eas.json or app.config.js files. 
 
 ### How do environment variables work for my Expo Development Client builds?
 


### PR DESCRIPTION
# Why
I moved to add environment related variables to my eas.json file, but the app still built with my secrets on the expo.dev site, I was aware that this might occur so I caught it, but I think it's important to communicate the hierarchy of these methods to avoid confusion in the future when individuals expect to see different environment variables being used and don't understand why.

# How
Just added a line of text to clarify that secrets set on the website will override secrets set in eas.json or app.config.js files.

# Test Plan
I built my project with env variables in my EAS.json file and left the existing stored env variables on the website. I then checked the "spin up build environment" logs and observed it was using the stored variables. I then deleted the stored variables and rebuilt the project, checked the same logs and they were now using the values from my eas.json file.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
