### PR TITLE
[docs] EAS Update docs QA feedback

### DIFF
--- a/docs/pages/eas-update/bare-react-native.md
+++ b/docs/pages/eas-update/bare-react-native.md
@@ -1,0 +1,102 @@
+---
+title: Using EAS Update with a bare React Native project
+---
+
+EAS update works with projects created with `react-native init` and with Expo projects that are ejected. These projects have **android** and **ios** directories so that we can modify native files directly.
+
+The steps for configuring a bare React Native project are identical to the steps for configuring an Expo project. However, you may need to edit some of the code `eas update:configure` and `eas build:configure` generates depending on how you build and run your project.
+
+## App config
+
+The `eas update:configure` will add two values to our project's app config (**app.json**/**app.config.js**).
+
+```json
+{
+  "expo": {
+    "runtimeVersion": "1.0.0",
+    "updates": {
+      "url": "https://u.expo.dev/..."
+      ...
+    }
+    ...
+  }
+}
+```
+
+The `runtimeVerson` property guarantees compatibility between a build's native code and an update. For bare React Native projects, it's necessary to set this value manually whenever you make a change to any native code in your project. Read [our doc on runtime versions](/eas-update/runtime-versions/#custom--runtimeversion) and learn how to [avoid publishing bad updates](/eas-update/runtime-versions/#avoiding-crashes-with-incompatible-updates).
+
+The `updates.url` property will eventually tell your app to query against for updates. This `url` is our "https://u.expo.dev" domain, followed by your project's ID on EAS' servers. If you go to the URL directly, you'll see an error about missing a header. You can see a manifest by adding three query parameters to the URL: `runtime-version`, `channel-name`, and `platform`. If we published an update with a runtime version of `1.0.0`, a channel of `production` and a platform of `android`, the full URL you could visit would be similar to this:
+
+```
+https://u.expo.dev/your-project-id?runtime-version=1.0.0&channel-name=production&platform=android
+```
+
+## EAS config and native files
+
+To generate an EAS config (**eas.json**), run `eas build:configure`. This command will create the **eas.json** file and it will also modify the **AndroidManifest.xml** file inside the **android** directory and the **Expo.plist** file inside the **ios** directory.
+
+Inside **eas.json**, we'll want to add `channel` properties to each build profile we'd like to send updates to. Assuming we're using the default **eas.json** configuration, we recommend adding `channel` properties to the `preview` and `production` build profiles.
+
+```json
+{
+  "build": {
+    "preview": {
+      "channel": "preview",
+      ...
+    },
+    "production": {
+      "channel": "production",
+      ...
+    }
+    ...
+  }
+}
+```
+
+Inside **AndroidManifest.xml**, we'll see the following additions:
+
+```xml
+<meta-data android:name="expo.modules.updates.EXPO_UPDATE_URL" android:value="<https://u.expo.dev/your-project-id>"/>
+<meta-data android:name="expo.modules.updates.EXPO_RUNTIME_VERSION" android:value="1.0.0"/>
+```
+
+The `EXPO_UPDATE_URL` value should contain your project's ID.
+
+Inside **Expo.plist**, we'll see the following additions:
+
+```xml
+<key>EXUpdatesRuntimeVersion</key>
+<string>1.0.0</string>
+<key>EXUpdatesURL</key>
+<string><https://u.expo.dev/your-project-id></string>
+```
+
+The `EXUpdatesURL` value should contain your project's ID.
+
+Once we've built our project into a build, the `expo-updates` library will make requests for manifests with the native configuration defined above, along with the channel specified in **eas.json**.
+
+## Configuring the channel manually
+
+If we create a build with EAS Build, the channel name from **eas.json** will automatically be added to our build's **AndroidManifest.xml** and **Expo.plist** at build time. If you're using EAS Build, the following steps are not necessary.
+
+If your project is not using EAS Build or you are creating release builds with either `expo run:ios --configuration Release` or `expo run:android --configuration release`, you'll need to set the channel configuration manually inside both **AndroidManifest.xml** and **Expo.plist**.
+
+In **AndroidManifest.xml**, you'll need to add the following, replacing `your-channel-name` with the channel that matches your project:
+
+```xml
+<meta-data android:name="expo.modules.updates.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY" android:value="{'expo-channel-name':'your-channel-name'}"/>
+```
+
+In **Expo.plist**, you'll need to add the following, replacing `your-channel-name` with the channel that matches your project:
+
+```xml
+<key>EXUpdatesRequestHeaders</key>
+<dict>
+  <key>expo-channel-name</key>
+  <string>your-channel-name</string>
+</dict>
+```
+
+## What's next
+
+Once our project is set up with EAS Update, eventually we'll make native changes to your project. Whenever that happens, we'll need to update the `runtimeVersion` in our project's app config. Then, we'll need to run `eas build:configure`, which will update **AndroidManifest.xml** and **Expo.plist** with the new runtime version. Once that's done, we'll need to make new builds, after which, we'll be able to send updates with `eas update`.

--- a/docs/pages/eas-update/debug-updates.md
+++ b/docs/pages/eas-update/debug-updates.md
@@ -10,9 +10,9 @@ It's important to be able to tell the current state of our app at any given time
 
 We use the term _deployments_ to refer to the entire system of builds and their updates. The system includes builds, channels, branches, updates, runtime versions, and platforms. Let's inspect these attributes.
 
-### Viewing deployments
+<!-- ### Viewing deployments
 
-The EAS website has a page that shows the current state of our apps. We can view it at [https://expo.dev/accounts/[account]/projects/[project]/deployments](https://expo.dev/accounts/[account]/projects/[project]/deployments).
+The EAS website has a page that shows the current state of our apps. We can view it at [https://expo.dev/accounts/[account]/projects/[project]/deployments](https://expo.dev/accounts/[account]/projects/[project]/deployments). -->
 
 ### Inspecting builds
 
@@ -71,6 +71,18 @@ The output will display the message of the update, when it was created and by wh
 When we publish an update with EAS Update, it creates a **/dist** folder in the root of your project locally, which includes the assets that were uploaded as a part of the update.
 
 <ImageSpotlight alt="Dist directory" src="/static/images/eas-update/dist.png" />
+
+### Inspecting manifests
+
+When an update is published with EAS Update, we create a manifest that end-user app's request. The manifest has information like which assets and versions are needed for an update to load. We can inspect the manifest by going to a specific URL in a browser or by using `curl`.
+
+Inside our project's app config (**app.json**/**app.config.json**), the URL we can GET is under `updates.url`.
+
+This `url` is EAS' "https://u.expo.dev" domain, followed by the project's ID on EAS' servers. If we go to the URL directly, we'll see an error about missing a header. We can view a manifest by adding three query parameters to the URL: `runtime-version`, `channel-name`, and `platform`. If we published an update with a runtime version of `1.0.0`, a channel of `production` and a platform of `android`, the full URL you could visit would be similar to this:
+
+```
+https://u.expo.dev/your-project-id?runtime-version=1.0.0&channel-name=production&platform=android
+```
 
 ## Undoing a bad publish
 

--- a/docs/pages/eas-update/getting-started.md
+++ b/docs/pages/eas-update/getting-started.md
@@ -51,20 +51,13 @@ EAS Update is in "preview", meaning that we may still make breaking developer-fa
    eas update:configure
    ```
 
-   After this command, you should have a new field in your app config (**app.json**) at `expo.updates.url`, which is the URL where your app will fetch new updates.
-   <br/><br/>
-
-   > There is also a `fallbackToCacheTimeout` property under `expo.updates`. If you'd like your app to attempt to load new updates when a user opens the app, set this to something other than zero, like `3000` (3 seconds). A value of `3000` would mean that your app will attempt to download a new update for up to 3 seconds before loading the previous update it already has locally. If the app is able to download the update within 3 seconds, your users will see the changes in the newest update immediately.
-
 3. To set up the configuration file for builds, run:
 
    ```bash
    eas build:configure
    ```
 
-   Then follow the prompts.
-
-   This will create a file named **eas.json**.
+   This command will create a file named **eas.json**.
 
 4. Inside the `preview` and `production` build profiles in **eas.json**, add a `channel` property for each:
 
@@ -89,29 +82,38 @@ EAS Update is in "preview", meaning that we may still make breaking developer-fa
 
 ## Create a build for the project
 
-Next, we'll need to create a build for Android or iOS. [Learn more](/build/setup). Once you have a build running on your device or in a simulator, we'll be ready to send it an update.
+Next, we'll need to create a build for Android or iOS. [Learn more](/build/setup).
+
+We recommend creating a build with the `preview` build profile first. [Learn more](/build/internal-distribution) about setting up your devices for internal distribution.
+
+Once you have a build running on your device or in a simulator, we'll be ready to send it an update.
+
+## Make changes locally
+
+Once we've created a build, we're ready to iterate on our project.
+
+When we run our project locally, Expo CLI creates a manifest locally that Expo Go or a development build will run. To make sure our project starts with Expo's modern manifest protocol, start your local server with:
+
+```bash
+yarn start --force-manifest-type=expo-updates
+```
+
+Then, make any desired changes to your project's JavaScript, styling, or image assets.
 
 ## Publish an update
 
-Now we're ready to publish an update to the builds created in the previous step.
+Now we're ready to publish an update to the build created in the previous step.
 
-1. When we run our project locally, Expo CLI creates a manifest locally that Expo Go or a development build will run. To make sure our project starts with Expo's modern manifest protocol, start your local server with:
+Then publish an update with the following command:
 
-   ```bash
-   yarn start --force-manifest-type=expo-updates
-   ```
+```bash
+eas update --branch [branch] --message [message]
 
-2. Then, make any desired changes to your project's JavaScript, styling, or image assets.
-3. Then publish an update with the following command:
+# Example
+eas update --branch preview --message "Updating the app"
+```
 
-   ```bash
-   eas update --branch [branch] --message [message]
-
-   # Example
-   eas update --branch production --message "Updating the app"
-   ```
-
-4. Once the update is built and uploaded to EAS and the command completes, force close and reopen your app up to two times to download and view the update.
+Once the update is built and uploaded to EAS and the command completes, force close and reopen your app up to two times to download and view the update.
 
 ## Next
 

--- a/docs/pages/eas-update/getting-started.md
+++ b/docs/pages/eas-update/getting-started.md
@@ -68,23 +68,24 @@ EAS Update is in "preview", meaning that we may still make breaking developer-fa
 
 4. Inside the `preview` and `production` build profiles in **eas.json**, add a `channel` property for each:
 
-   ```bash
+   ```json
    {
      "build": {
         "preview": {
-          ...
           "channel": "preview"
+          ...
         },
         "production": {
-          ...
           "channel": "production"
-        },
-       ...
+          ...
+        }
      }
    }
    ```
 
    This `channel` property will allow you to point updates at builds. For example, if you set up a GitHub Action to publish changes on merge, it will make it so we can merge code into the "production" branch, then those commits will publish an update that will be made available to builds with the channel "production".
+
+5. Optional: If your project is a bare React Native project, [read the doc](/eas-update/bare-react-native) on extra configuration you may need.
 
 ## Create a build for the project
 

--- a/docs/pages/eas-update/getting-started.md
+++ b/docs/pages/eas-update/getting-started.md
@@ -14,7 +14,7 @@ EAS Update is in "preview", meaning that we may still make breaking developer-fa
    npm install --global eas-cli expo-cli
    ```
 
-   EAS Update requires EAS CLI >= 0.40.0 and Expo CLI >= 4.13.0.
+   EAS Update requires EAS CLI >= 0.40.0 and Expo CLI >= 4.13.0. Your project must also be on Expo SDK 43 or above. To upgrade, run `expo upgrade`.
 
 ## Create an Expo account
 
@@ -29,13 +29,11 @@ EAS Update is in "preview", meaning that we may still make breaking developer-fa
 
 ## Create a project
 
-1. Create a project with Expo CLI by running:
+Create a project with Expo CLI by running:
 
-   ```bash
-   expo init
-   ```
-
-2. Select "Managed workflow > blank".
+```bash
+expo init
+```
 
 ## Configure your project
 

--- a/docs/pages/eas-update/github-actions.md
+++ b/docs/pages/eas-update/github-actions.md
@@ -63,6 +63,6 @@ We can configure GitHub Actions to run on any GitHub event. One of the most comm
    5. Click "New repository secret"
    6. Make the secret's name "EXPO_TOKEN", then paste the access token in as the value.
 
-Your GitHub Action should be set up now. Every time when someone merges code into the "production" branch, this action will build an update and publish it, making it available to all of our users with builds that have access to the "production" branch on EAS.
+Your GitHub Action should be set up now. Every time when someone merges code into the "production" branch, this action will build an update and publish it, making it available to all of our devices with builds that have access to the "production" branch on EAS.
 
 > Some repositories or organizations might need to explicitly enable GitHub Workflows and allow third-party Actions.

--- a/docs/pages/eas-update/migrate-to-eas-update.md
+++ b/docs/pages/eas-update/migrate-to-eas-update.md
@@ -40,28 +40,33 @@ You'll need to make the following changes to your project:
 
 3. To ensure that updates are compatible with the underlying native code inside a build, EAS Update uses a new field named `runtimeVersion` that replaces the `sdkVersion` field in your project's app config (**app.json**/**app.config.js**). Remove the `expo.sdkVersion` property from your app config.
 
-4. To allow updates to apply to builds built with EAS, update your EAS build profiles in **eas.json** to include channel names. These channels should replace any `releaseChannel` properties. We find it convenient to name the `channel` after the profile's name. For instance, the `preview` profile has a `channel` named `"preview"`.
+4. Next, set your project up with EAS Build by running:
 
-   ```json
-   {
-     "build": {
-       "development": {
-         "developmentClient": true,
-         "distribution": "internal",
-         "channel": "development"
-       },
-       "preview": {
-         "distribution": "internal",
-         "channel": "preview"
-       },
-       "production": {
-         "channel": "production"
-       }
-     }
-   }
+   ```bash
+   eas build:configure
    ```
 
-   > Tip: if you don't have an **eas.json** file, you can generate it with `eas build:configure`.
+5. To allow updates to apply to builds built with EAS, update your EAS build profiles in **eas.json** to include channel properties. These channels should replace any `releaseChannel` properties. We find it convenient to name the `channel` after the profile's name. For instance, the `preview` profile has a `channel` named `"preview"` and the `production` profile has a `channel` named `"production"`.
+
+```json
+{
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal"
+    },
+    "preview": {
+      "distribution": "internal",
+      "channel": "preview"
+    },
+    "production": {
+      "channel": "production"
+    }
+  }
+}
+```
+
+6. Optional: If your project is a bare React Native project, [read the doc](/eas-update/bare-react-native) on extra configuration you may need.
 
 ## Create new builds
 

--- a/docs/pages/eas-update/migrate-to-eas-update.md
+++ b/docs/pages/eas-update/migrate-to-eas-update.md
@@ -12,7 +12,7 @@ EAS Update is the next generation of Expo's updates service. If you're using Cla
    npm install --global eas-cli expo-cli
    ```
 
-   EAS Update requires EAS CLI >= 0.40.0 and Expo CLI >= 4.13.0.
+   EAS Update requires EAS CLI >= 0.40.0 and Expo CLI >= 4.13.0. Your project must also be on Expo SDK 43 or above. To upgrade, run `expo upgrade`.
 
 2. Then, log in with your expo account:
 


### PR DESCRIPTION
Incorporates QA feedback from internal EAS Update preview testing. The biggest change is that it adds a doc on configuring EAS Update with bare React Native projects.