### PR TITLE
[core][ios] Recursively convert dictionaries into records

### DIFF
--- a/packages/expo-modules-core/ios/Swift/Records/AnyField.swift
+++ b/packages/expo-modules-core/ios/Swift/Records/AnyField.swift
@@ -12,5 +12,12 @@ internal protocol AnyFieldInternal: AnyField {
   var key: String? { get }
   var options: Set<FieldOption> { get set }
 
+  /**
+   Whether the value for this field must be explicitly provided.
+   The record throws an error when the source dictionary is missing a required value.
+   Note that it's NOT the opposite to `isOptional`.
+   */
+  var isRequired: Bool { get }
+
   func set(_ newValue: Any?) throws
 }

--- a/packages/expo-modules-core/ios/Swift/Records/Record.swift
+++ b/packages/expo-modules-core/ios/Swift/Records/Record.swift
@@ -37,8 +37,16 @@ public extension Record {
   init(from dict: Dict) throws {
     self.init()
 
+    let dictKeys = dict.keys
+
     try fieldsOf(self).forEach { field in
-      try field.set(dict[field.key!])
+      guard let key = field.key else {
+        // This should never happen, but just in case skip fields without the key.
+        return
+      }
+      if dictKeys.contains(key) || field.isRequired {
+        try field.set(dict[key])
+      }
     }
   }
 


### PR DESCRIPTION
# Why

Requirement for #15277 
So far we've been creating records very naively using native type casting. Now we have good mechanisms to support recursive conversions.

# How

Each `Field` instance holds the `ArgumentType` wrapper for its subtype. The wrapper is then used in `set` function to convert source value into the expected type.
Also fixed the behavior of optional/required fields — when the param is missing in the dictionary and its field is not required, we shouldn't even try to set the underlying value (because it may throw an error).

# Test Plan

Unit tests are passing and it worked well with #15277 
