### PR TITLE
[bare-expo] fix launch crash from admob

### DIFF
--- a/apps/bare-expo/android/settings.gradle
+++ b/apps/bare-expo/android/settings.gradle
@@ -9,11 +9,7 @@ project(":expo-dev-client").projectDir = new File("../../../packages/expo-dev-cl
 
 // Include Expo modules
 apply from: new File(["node", "--print", "require.resolve('expo/package.json')"].execute(null, rootDir).text.trim(), "../scripts/autolinking.gradle");
-useExpoModules([
-  exclude: [
-    'react-native-reanimated',
-  ]
-])
+useExpoModules()
 
 rootProject.name = 'BareExpo'
 

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -41,7 +41,8 @@
         "expo-ads-admob",
         "expo-apple-authentication",
         "expo-updates",
-        "expo-module-template"
+        "expo-module-template",
+        "react-native-reanimated"
       ],
       "ios": {
         "flags": {

--- a/apps/bare-sandbox/android/settings.gradle
+++ b/apps/bare-sandbox/android/settings.gradle
@@ -1,11 +1,7 @@
 rootProject.name = 'bare-sandbox'
 
 apply from: new File(["node", "--print", "require.resolve('expo/package.json')"].execute(null, rootDir).text.trim(), "../scripts/autolinking.gradle");
-useExpoModules([
-  exclude: [
-    'react-native-reanimated',
-  ]
-])
+useExpoModules()
 
 apply from: new File(["node", "--print", "require.resolve('@react-native-community/cli-platform-android/package.json')"].execute(null, rootDir).text.trim(), "../native_modules.gradle");
 applyNativeModulesSettingsGradle(settings)

--- a/apps/bare-sandbox/package.json
+++ b/apps/bare-sandbox/package.json
@@ -103,7 +103,8 @@
         "expo-ads-facebook",
         "expo-branch",
         "expo-module-template",
-        "expo-web-browser"
+        "expo-web-browser",
+        "recat-native-reanimated"
       ]
     }
   },


### PR DESCRIPTION
# Why

expo autolinking `exclude` setting from settings.gradle will override exclude from package.json, then `expo-ads-admob` be accidentally included and crash from incorrect project setup.

# How

move `react-native-reanimated` exclude from settings.gradle to package.json

# Test Plan

android test-suite passed

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
