### PR TITLE
[docs] removes --force-manifest-type flag

### DIFF
--- a/docs/pages/eas-update/getting-started.md
+++ b/docs/pages/eas-update/getting-started.md
@@ -88,12 +88,14 @@ Once you have a build running on your device or in a simulator, we'll be ready t
 
 ## Make changes locally
 
-Once we've created a build, we're ready to iterate on our project.
-
-When we run our project locally, Expo CLI creates a manifest locally that Expo Go or a development build will run. To make sure our project starts with Expo's modern manifest protocol, start your local server with:
+Once we've created a build, we're ready to iterate on our project. Start a local development server with:
 
 ```bash
-yarn start --force-manifest-type=expo-updates
+yarn start
+
+# or
+
+expo start
 ```
 
 Then, make any desired changes to your project's JavaScript, styling, or image assets.

--- a/docs/pages/eas-update/known-issues.md
+++ b/docs/pages/eas-update/known-issues.md
@@ -10,7 +10,7 @@ Known issues:
 
 - `eas update` will not create or send source maps to Sentry. This will result in less informative error reports from Sentry.
 - If you use the `defaultSource` prop on the `<Image />` component from `react-native`, your app will crash. Removing that prop resolves the issue.
-- When using the new manifest format with Expo Go (`yarn start --force-manifest-type=expo-updates`), the project's name will appear as "Untitled experience" in the dev menu.
+- When using the new manifest format with Expo Go, the project's name will appear as "Untitled experience" in the dev menu.
 - The `eas update` command has an `--auto` flag, which will use the current git branch and the latest commit message and make them the EAS branch and message while publishing. This flag does not work on CI services, like GitHub Actions.
 - It is not possible to load an update published with EAS Update inside of Expo Go.
 - If you publish a update with code that is incompatible with a build's native code, the build will try to load the update and will crash on launch. This will result in an end-user needing to delete and reinstall the app after a new update with a fix is published. To avoid this, we recommend using the `"runtimeVersion": { "policy": "sdkVersion" }` configuration in your project's app config (**app.json**/**app.config.js**). Also, if you introduce an new native modules, you must update the `"runtimeVersion"` to a new version. To avoid this whole class of errors, test your project after making changes with a preview build before sending the update to production builds. Read more on [configuring your project's runtime version](/eas-update/runtime-versions).

--- a/docs/pages/eas-update/migrate-to-eas-update.md
+++ b/docs/pages/eas-update/migrate-to-eas-update.md
@@ -74,10 +74,14 @@ The changes above affect the native code layer inside builds, which means we'll 
 
 ## Developing locally
 
-EAS Update uses a [modern manifest format](/technical-specs/expo-updates-0). When developing locally, Expo CLI can serve the modern manifest format to Expo Go or a development build. This will ensure that the code you develop locally will work as an update when published later. You can start a local development session with the modern manifest with:
+EAS Update uses a [modern manifest format](/technical-specs/expo-updates-0). When you have a EAS Update url in your app config at `updates.url`, Expo CLI will automatically serve the correct manifest format for your project. This will ensure that the code you develop locally will work as an update when published later. You can start a localy development session just like before, with:
 
 ```bash
-yarn start --force-manifest-type=expo-updates
+yarn start
+
+# or
+
+expo start
 ```
 
 ## Publishing an update


### PR DESCRIPTION
In Expo CLI 5.0.0-rc.4 and above, we no longer need to use the `--force-manifest-type` flag, since Expo CLI can now detect an EAS Update url and serve the modern manifest automatically. This PR removes those instructions from the EAS Update docs.