### PR TITLE
[expo-updates][ios] Fix manifest accept header to accept multipart/mixed

### DIFF
--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.m
@@ -514,7 +514,7 @@ NSString * const EXUpdatesMultipartExtensionsPartName = @"extensions";
     }
   }
 
-  [request setValue:@"application/expo+json,application/json" forHTTPHeaderField:@"Accept"];
+  [request setValue:@"multipart/mixed,application/expo+json,application/json" forHTTPHeaderField:@"Accept"];
   [request setValue:@"ios" forHTTPHeaderField:@"Expo-Platform"];
   [request setValue:@"1" forHTTPHeaderField:@"Expo-API-Version"];
   [request setValue:@"BARE" forHTTPHeaderField:@"Expo-Updates-Environment"];


### PR DESCRIPTION
# Why

Forgot to include `multipart/mixed` in the accept header in https://github.com/expo/expo/pull/15426 (the android counterpart had it).

# How

Make the accept header the same as android.

# Test Plan

Build Expo Go from master, put a breakpoint in the multipart parsing stuff, load published EAS update, see breakpoint is now hit (wouldn't get hit before this change).