### PR TITLE
[expo-auth-session] - Allow server side PKCE with secret verifier

### DIFF
--- a/packages/expo-auth-session/src/AuthRequest.ts
+++ b/packages/expo-auth-session/src/AuthRequest.ts
@@ -55,6 +55,7 @@ export class AuthRequest implements Omit<AuthRequestConfig, 'state'> {
     this.state = request.state ?? PKCE.generateRandom(10);
     this.extraParams = request.extraParams ?? {};
     this.codeChallengeMethod = request.codeChallengeMethod ?? CodeChallengeMethod.S256;
+    this.codeChallenge = request.codeChallenge;
     // PKCE defaults to true
     this.usePKCE = request.usePKCE ?? true;
 

--- a/packages/expo-auth-session/src/AuthRequest.ts
+++ b/packages/expo-auth-session/src/AuthRequest.ts
@@ -263,7 +263,7 @@ export class AuthRequest implements Omit<AuthRequestConfig, 'state'> {
   }
 
   private async ensureCodeIsSetupAsync(): Promise<void> {
-    if (this.codeVerifier) {
+    if (this.codeChallenge) {
       return;
     }
 


### PR DESCRIPTION






# Why

In authorisation flows where the oath 'client' is a server and will ultimately do the code for token exchange, it is more secure for the code verifier and code challenge to be generated server side, and for the verifier to never be sent to the client.

Currently within AuthRequest it is not possible to only use a pre-generated code challenge, as the code I am changing here checks to see if codeVerifier is null, and if so generates both a new code verifier and a code challenge.

# How

Changing this check to codeChallenge means it is possible to skip a new pair being generated if my auth sever has already sent me a code challenge to use. It can later use the matching verifier which has never been sent out to the client.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
