### PR TITLE
[expo-dev-menu][expo-dev-menu-interface] add deviceId parameter to dev sessions query

### DIFF
--- a/packages/expo-dev-menu-interface/android/src/main/java/expo/interfaces/devmenu/expoapi/DevMenuExpoApiClientInterface.kt
+++ b/packages/expo-dev-menu-interface/android/src/main/java/expo/interfaces/devmenu/expoapi/DevMenuExpoApiClientInterface.kt
@@ -14,7 +14,7 @@ interface DevMenuExpoApiClientInterface {
   fun isLoggedIn(): Boolean
   fun setSessionSecret(newSessionSecret: String?)
   suspend fun queryMyProjects(options: DevMenuGraphQLOptions = DevMenuGraphQLOptions()): okhttp3.Response
-  suspend fun queryDevSessions(): okhttp3.Response
+  suspend fun queryDevSessions(deviceID: String?): okhttp3.Response
   suspend fun queryUpdateChannels(
     appId: String,
     options: DevMenuGraphQLOptions = DevMenuGraphQLOptions()

--- a/packages/expo-dev-menu-interface/ios/ExpoApiClient/DevMenuExpoApiClientProtocol.swift
+++ b/packages/expo-dev-menu-interface/ios/ExpoApiClient/DevMenuExpoApiClientProtocol.swift
@@ -32,7 +32,7 @@ public protocol DevMenuExpoApiClientProtocol {
   func setSessionSecret(_ sessionSecret: String?)
   
   @objc
-  func queryDevSessionsAsync(_ completionHandler: @escaping HTTPCompletionHandler)
+  func queryDevSessionsAsync(_ installationID: String?, completionHandler: @escaping HTTPCompletionHandler)
   
   @objc
   func queryUpdateChannels(

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - Vendor react-native-safe-area-context. ([#15382](https://github.com/expo/expo/pull/15382) by [@ajsmth](https://github.com/ajsmth))
+- Add ability to query development sessions with a device ID. ([#15539](https://github.com/expo/expo/pull/15539) by [@esamelson](https://github.com/esamelson))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/api/DevMenuExpoApiClient.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/api/DevMenuExpoApiClient.kt
@@ -9,6 +9,7 @@ import expo.interfaces.devmenu.expoapi.DevMenuExpoApiClientInterface
 import expo.interfaces.devmenu.expoapi.DevMenuGraphQLOptions
 import expo.interfaces.devmenu.expoapi.Response
 import expo.modules.devmenu.constants.AuthHeader
+import expo.modules.devmenu.constants.DeviceIDQuery
 import expo.modules.devmenu.constants.GraphQLEndpoint
 import expo.modules.devmenu.constants.RESTEndpoint
 import expo.modules.devmenu.helpers.await
@@ -26,15 +27,18 @@ class DevMenuExpoApiClient : DevMenuExpoApiClientInterface {
     sessionSecret = newSessionSecret
   }
 
-  override suspend fun queryDevSessions(): okhttp3.Response {
-    val secret = ensureUserIsSignIn()
+  override suspend fun queryDevSessions(deviceID: String?): okhttp3.Response {
+    val builder = RESTEndpoint
+      .buildUpon()
+      .appendPath("development-sessions")
+
+    if (deviceID != null) {
+      builder.appendQueryParameter(DeviceIDQuery, deviceID)
+    }
 
     return fetch(
-      RESTEndpoint
-        .buildUpon()
-        .appendPath("development-sessions")
-        .build(),
-      AuthHeader to secret
+      builder.build(),
+      if (sessionSecret != null) AuthHeader to sessionSecret!! else null
     ).await(httpClient)
   }
 

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/constants/DevMenuExpoApiConstants.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/constants/DevMenuExpoApiConstants.kt
@@ -5,5 +5,6 @@ import android.net.Uri
 private const val origin = "https://exp.host"
 
 internal const val AuthHeader = "expo-session"
+internal const val DeviceIDQuery = "deviceId"
 internal val GraphQLEndpoint = Uri.parse("$origin/--/graphql")
 internal val RESTEndpoint = Uri.parse("$origin/--/api/v2/")

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/modules/DevMenuModule.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/modules/DevMenuModule.kt
@@ -51,12 +51,12 @@ class DevMenuModule(reactContext: ReactApplicationContext) :
   }
 
   @ReactMethod
-  fun queryDevSessionsAsync(promise: Promise) {
+  fun queryDevSessionsAsync(deviceID: String?, promise: Promise) {
     devMenuManager.coroutineScope.launch {
       try {
         devMenuManager
           .getExpoApiClient()
-          .queryDevSessions()
+          .queryDevSessions(deviceID)
           .use {
             @Suppress("DEPRECATION_ERROR")
             promise.resolve(it.body()?.charStream()?.readText() ?: "")

--- a/packages/expo-dev-menu/ios/DevMenuExpoApiClient.swift
+++ b/packages/expo-dev-menu/ios/DevMenuExpoApiClient.swift
@@ -20,8 +20,14 @@ class DevMenuExpoApiClient: NSObject, DevMenuExpoApiClientProtocol {
     self.sessionSecret = sessionSecret
   }
   
-  func queryDevSessionsAsync(_ completionHandler: @escaping HTTPCompletionHandler) {
-    fetch(URL(string: "development-sessions", relativeTo: DevMenuExpoApiClient.restEndpoint)!, completionHandler: completionHandler)
+  func queryDevSessionsAsync(_ installationID: String?, completionHandler: @escaping HTTPCompletionHandler) {
+    var url = URL(string: "development-sessions", relativeTo: DevMenuExpoApiClient.restEndpoint)!
+    if (installationID != nil) {
+      var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: true)
+      urlComponents?.queryItems = [URLQueryItem(name: "deviceId", value: installationID)]
+      url = urlComponents?.url ?? url
+    }
+    fetch(url, completionHandler: completionHandler)
   }
   
   func queryUpdateChannels(

--- a/packages/expo-dev-menu/ios/Modules/DevMenuModule.m
+++ b/packages/expo-dev-menu/ios/Modules/DevMenuModule.m
@@ -14,7 +14,7 @@ RCT_EXTERN_METHOD(openProfile)
 RCT_EXTERN_METHOD(openSettings)
 
 RCT_EXTERN_METHOD(isLoggedInAsync:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
-RCT_EXTERN_METHOD(queryDevSessionsAsync:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(queryDevSessionsAsync:(NSString *)installationID resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(queryUpdateChannels:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(queryUpdateBranches:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 

--- a/packages/expo-dev-menu/ios/Modules/DevMenuModule.swift
+++ b/packages/expo-dev-menu/ios/Modules/DevMenuModule.swift
@@ -26,8 +26,8 @@ open class DevMenuModule: NSObject {
   }
   
   @objc
-  func queryDevSessionsAsync(_ resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
-    DevMenuManager.shared.expoApiClient.queryDevSessionsAsync({ (data, response, error) in
+  func queryDevSessionsAsync(_ installationID: String?, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    DevMenuManager.shared.expoApiClient.queryDevSessionsAsync(installationID, completionHandler: { (data, response, error) in
       guard error == nil else {
         reject("ERR_DEVMENU_CANNOT_GET_DEV_SESSIONS", error.debugDescription, error)
         return

--- a/packages/expo-dev-menu/ios/Tests/DevMenuExpoApiClientTests.swift
+++ b/packages/expo-dev-menu/ios/Tests/DevMenuExpoApiClientTests.swift
@@ -29,7 +29,7 @@ fileprivate class MockedSession: URLSession {
 }
 
 class DevMenuExpoApiClientTests: XCTestCase {
-  func test_queryDevSessionAsync() {
+  func test_queryDevSessionsAsync() {
     let expectedData = Data()
     let expect = expectation(description: "request callback should be called")
     let apiClient = DevMenuExpoApiClient()
@@ -43,11 +43,33 @@ class DevMenuExpoApiClientTests: XCTestCase {
     }
     apiClient.session = mockedSession
 
-    apiClient.queryDevSessionsAsync { data, response, error in
+    apiClient.queryDevSessionsAsync(nil, completionHandler: { data, response, error in
       XCTAssertIdentical(data as AnyObject, expectedData as AnyObject)
       expect.fulfill()
-    }
+    })
     
+    waitForExpectations(timeout: 0)
+  }
+
+  func test_queryDevSessionsAsync_installationID() {
+    let expectedData = Data()
+    let expect = expectation(description: "request callback should be called")
+    let apiClient = DevMenuExpoApiClient()
+    let mockedSession = MockedSession()
+    mockedSession.requestInspector = {
+      XCTAssertEqual($0.url?.absoluteString, "https://exp.host/--/api/v2/development-sessions?deviceId=test-installation-id")
+      XCTAssertEqual($0.httpMethod, "GET")
+    }
+    mockedSession.completionHandlerSeeder = {
+      $0(expectedData, nil, nil)
+    }
+    apiClient.session = mockedSession
+
+    apiClient.queryDevSessionsAsync("test-installation-id", completionHandler: { data, response, error in
+      XCTAssertIdentical(data as AnyObject, expectedData as AnyObject)
+      expect.fulfill()
+    })
+
     waitForExpectations(timeout: 0)
   }
   
@@ -69,9 +91,9 @@ class DevMenuExpoApiClientTests: XCTestCase {
     }
     apiClient.session = mockedSession
     
-    apiClient.queryDevSessionsAsync { data, response, error in
+    apiClient.queryDevSessionsAsync(nil, completionHandler: { data, response, error in
       expect.fulfill()
-    }
+    })
     
     waitForExpectations(timeout: 0)
   }


### PR DESCRIPTION
# Why

PR 1/2 for ENG-1989

# How

Update the `DevMenu.queryDevSessionsAsync` method to accept an optional `deviceID` parameter, and, if given, include this as a query parameter in the request. (The www endpoint already handles this particular query parameter; it's currently used by Snack.)

On Android, I also updated the method to not require authentication, as this new flow is intended for users who aren't yet signed into the dev client.

The next PR will update the JS bundle to take advantage of this capability.

# Test Plan

Added a new test case to the existing unit test case on iOS. Also tested manually on both platforms (along with the forthcoming JS change) by modifying expo-cli to create a development session with a particular device ID and then ensuring it shows up on the device using this method.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
