### PR TITLE
[expo-dev-launcher] fix config plugin when expo-updates isn't found

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fix plugin when `MainActivity.onNewIntent` exists. ([#15459](https://github.com/expo/expo/pull/15459) by [@janicduplessis](https://github.com/janicduplessis))
+- Fix plugin when `expo-updates` is not present. ([#15541](https://github.com/expo/expo/pull/15541) by [@esamelson](https://github.com/esamelson))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/plugin/build/resolveExpoUpdatesVersion.js
+++ b/packages/expo-dev-launcher/plugin/build/resolveExpoUpdatesVersion.js
@@ -8,7 +8,14 @@ const fs_1 = __importDefault(require("fs"));
 const path_1 = __importDefault(require("path"));
 const resolve_from_1 = __importDefault(require("resolve-from"));
 function resolveExpoUpdatesVersion(projectRoot) {
-    const expoUpdatesBuildPath = (0, resolve_from_1.default)(projectRoot, 'expo-updates');
+    let expoUpdatesBuildPath;
+    try {
+        expoUpdatesBuildPath = (0, resolve_from_1.default)(projectRoot, 'expo-updates');
+    }
+    catch (e) {
+        // this is expected in projects that don't have expo-updates installed
+        return null;
+    }
     if (!expoUpdatesBuildPath) {
         return null;
     }

--- a/packages/expo-dev-launcher/plugin/src/resolveExpoUpdatesVersion.ts
+++ b/packages/expo-dev-launcher/plugin/src/resolveExpoUpdatesVersion.ts
@@ -3,7 +3,13 @@ import path from 'path';
 import resolveFrom from 'resolve-from';
 
 export function resolveExpoUpdatesVersion(projectRoot: string): string | null {
-  const expoUpdatesBuildPath = resolveFrom(projectRoot, 'expo-updates');
+  let expoUpdatesBuildPath;
+  try {
+    expoUpdatesBuildPath = resolveFrom(projectRoot, 'expo-updates');
+  } catch (e) {
+    // this is expected in projects that don't have expo-updates installed
+    return null;
+  }
   if (!expoUpdatesBuildPath) {
     return null;
   }


### PR DESCRIPTION
# Why

Brent reported the dev launcher config plugin was failing with the following error in projects without expo-updates:

```
» ios: expo-dev-launcher: Failed to check compatibility with expo-updates - Error: Cannot find module 'expo-updates'
Require stack:
- /Users/brentvatne/code/stackexample/noop.js
```

As of SDK 44, expo-updates is no longer included in the bare template project, whereas previously it was in every project, so this case likely just wasn't properly tested before now.

# How

Verified the error is coming from the `resolveFrom` module, put a try-catch around it.

# Test Plan

I was getting weird behavior when trying to test this locally; the "Config syncing" step would totally hang (not even Ctrl-C could stop it). However, before this change I did indeed see the same warning as Brent, and after pasting this file into node_modules and trying again, I no longer saw the warning.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
