### PR TITLE
[expo-dev-launcher] pass deviceId through bundle and improve dev session request logic

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - Add persisted installation ID and include in manifest requests. ([#15538](https://github.com/expo/expo/pull/15538) by [@esamelson](https://github.com/esamelson))
+- Improve dev session request logic and use device ID when available. ([#15542](https://github.com/expo/expo/pull/15542) by [@esamelson](https://github.com/esamelson))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/modules/DevLauncherInternalModule.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/modules/DevLauncherInternalModule.kt
@@ -5,6 +5,7 @@ import android.content.pm.PackageManager
 import android.graphics.drawable.AdaptiveIconDrawable
 import android.graphics.drawable.Drawable
 import android.net.Uri
+import android.os.Build
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
@@ -51,8 +52,11 @@ class DevLauncherInternalModule(reactContext: ReactApplicationContext?)
   override fun hasConstants(): Boolean = true
 
   override fun getConstants(): Map<String, Any> {
+    val isRunningOnGenymotion = Build.FINGERPRINT.contains("vbox")
+    val isRunningOnStockEmulator = Build.FINGERPRINT.contains("generic")
     return mapOf(
-      "installationID" to installationIDHelper.getOrCreateInstallationID(reactApplicationContext)
+      "installationID" to installationIDHelper.getOrCreateInstallationID(reactApplicationContext),
+      "isDevice" to (!isRunningOnGenymotion && !isRunningOnStockEmulator)
     )
   }
 

--- a/packages/expo-dev-launcher/bundle/DevLauncherInternal.ts
+++ b/packages/expo-dev-launcher/bundle/DevLauncherInternal.ts
@@ -26,3 +26,5 @@ export function addDeepLinkListener(callback: (string) => void): EventSubscripti
 }
 
 export const clientUrlScheme = DevLauncher.clientUrlScheme;
+export const installationID = DevLauncher.installationID;
+export const isDevice = !!DevLauncher.isDevice;

--- a/packages/expo-dev-launcher/bundle/DevMenu.ts
+++ b/packages/expo-dev-launcher/bundle/DevMenu.ts
@@ -18,8 +18,8 @@ export async function queryMyProjectsAsync(): Promise<any> {
   return await DevMenu.queryMyProjectsAsync();
 }
 
-export async function queryDevSessionsAsync(): Promise<any> {
-  return await DevMenu.queryDevSessionsAsync();
+export async function queryDevSessionsAsync(deviceID?: string): Promise<any> {
+  return await DevMenu.queryDevSessionsAsync(deviceID ?? null);
 }
 
 export async function isLoggedInAsync(): Promise<boolean> {

--- a/packages/expo-dev-launcher/bundle/native-modules/DevLauncherInternal.ts
+++ b/packages/expo-dev-launcher/bundle/native-modules/DevLauncherInternal.ts
@@ -37,9 +37,10 @@ export async function getBuildInfoAsync(): Promise<BuildInfo> {
   return DevLauncher.getBuildInfo();
 }
 
-
 export async function copyToClipboardAsync(content: string): Promise<null> {
   return DevLauncher.copyToClipboard(content);
 }
 
 export const clientUrlScheme = DevLauncher.clientUrlScheme;
+export const installationID = DevLauncher.installationID;
+export const isDevice = !!DevLauncher.isDevice;

--- a/packages/expo-dev-launcher/bundle/native-modules/DevMenu.ts
+++ b/packages/expo-dev-launcher/bundle/native-modules/DevMenu.ts
@@ -1,0 +1,7 @@
+import { NativeModules } from 'react-native';
+
+const DevMenu = NativeModules.ExpoDevMenu;
+
+export async function queryDevSessionsAsync(deviceID?: string): Promise<any> {
+  return await DevMenu.queryDevSessionsAsync(deviceID ?? null);
+}

--- a/packages/expo-dev-launcher/bundle/native-modules/__mocks__/DevLauncherInternal.ts
+++ b/packages/expo-dev-launcher/bundle/native-modules/__mocks__/DevLauncherInternal.ts
@@ -1,5 +1,7 @@
 export const loadApp = jest.fn();
 export const clientUrlScheme = '123';
+export const installationID = '00000000-0000-0000-0000-000000000000';
+export const isDevice = false;
 export const getBuildInfoAsync = jest.fn().mockResolvedValue({
   appName: '',
   appVersion: 1,

--- a/packages/expo-dev-launcher/bundle/native-modules/__mocks__/DevMenu.ts
+++ b/packages/expo-dev-launcher/bundle/native-modules/__mocks__/DevMenu.ts
@@ -1,0 +1,1 @@
+export const queryDevSessionsAsync = jest.fn().mockResolvedValue('{"data":[]}');

--- a/packages/expo-dev-launcher/bundle/screens/LauncherMainScreen.tsx
+++ b/packages/expo-dev-launcher/bundle/screens/LauncherMainScreen.tsx
@@ -57,16 +57,16 @@ class LauncherMainScreen extends React.Component<Props, State> {
     pendingDeepLink: null,
   };
 
-  private onNewDeepLink = DevLauncher.addDeepLinkListener(link =>
+  private onNewDeepLink = DevLauncher.addDeepLinkListener((link) =>
     this.setState({ pendingDeepLink: link })
   );
 
   componentDidMount() {
-    DevLauncher.getPendingDeepLink().then(pendingDeepLink => {
+    DevLauncher.getPendingDeepLink().then((pendingDeepLink) => {
       this.setState({ pendingDeepLink });
     });
 
-    DevLauncher.getRecentlyOpenedApps().then(openedProjects => {
+    DevLauncher.getRecentlyOpenedApps().then((openedProjects) => {
       const newOpenedProjects = [];
       for (const [url, name] of Object.entries(openedProjects)) {
         newOpenedProjects.push({
@@ -116,25 +116,22 @@ class LauncherMainScreen extends React.Component<Props, State> {
   };
 
   private fetchDevelopmentSessions = async () => {
-    if (!this.props.isUserLoggedIn) {
-      const localPackagers = await this.detectLocalPackagers();
-      if (this.props.isUserLoggedIn) {
-        return;
-      }
-      this.setState({
-        onlineProjects: localPackagers,
-      });
-      return;
+    let devSessions: any[];
+    if (this.props.isUserLoggedIn) {
+      const data = await queryDevSessionsAsync();
+      devSessions = JSON.parse(data).data;
     }
-
-    const data = await queryDevSessionsAsync();
-    const { data: projects } = JSON.parse(data);
-    if (!this.props.isUserLoggedIn) {
-      return;
+    if (!devSessions || !devSessions.length) {
+      const deviceID = DevLauncher.installationID;
+      const data = await queryDevSessionsAsync(deviceID);
+      devSessions = JSON.parse(data).data;
+    }
+    if ((!devSessions || !devSessions.length) && !DevLauncher.isDevice) {
+      devSessions = await this.detectLocalPackagers();
     }
 
     this.setState({
-      onlineProjects: projects,
+      onlineProjects: devSessions,
     });
   };
 
@@ -144,7 +141,7 @@ class LauncherMainScreen extends React.Component<Props, State> {
     this.setState({ isRefreshing: false });
   };
 
-  private loadApp = async url => {
+  private loadApp = async (url) => {
     try {
       this.setState({ loadingApp: true });
       await DevLauncher.loadApp(url);
@@ -199,8 +196,8 @@ class LauncherMainScreen extends React.Component<Props, State> {
   private renderRecentlyInDevelopment() {
     const onlineProjects = this.state.onlineProjects
       // We're temporarily skipping snack projects
-      .filter(project => project.source !== 'snack')
-      .map(project => {
+      .filter((project) => project.source !== 'snack')
+      .map((project) => {
         const { url, description } = project;
         return (
           <ListItem
@@ -234,7 +231,7 @@ class LauncherMainScreen extends React.Component<Props, State> {
   }
 
   private renderOpenedProjects() {
-    const openedProjects = this.state.openedProjects.map(project => {
+    const openedProjects = this.state.openedProjects.map((project) => {
       const { url, name } = project;
       const title = name ?? url;
       return (

--- a/packages/expo-dev-launcher/bundle/screens/__tests__/HomeScreen.test.tsx
+++ b/packages/expo-dev-launcher/bundle/screens/__tests__/HomeScreen.test.tsx
@@ -2,13 +2,16 @@ import * as React from 'react';
 
 import { getLocalPackagersAsync, Packager } from '../../functions/getLocalPackagersAsync';
 import { clientUrlScheme, loadApp } from '../../native-modules/DevLauncherInternal';
+import { queryDevSessionsAsync } from '../../native-modules/DevMenu';
 import { render, waitFor, fireEvent, act } from '../../test-utils';
 import { HomeScreen, HomeScreenProps } from '../HomeScreen';
 
 jest.mock('../../functions/getLocalPackagersAsync');
 jest.mock('../../hooks/useDebounce');
+jest.mock('../../native-modules/DevMenu');
 
 const mockGetLocalPackagersAsync = getLocalPackagersAsync as jest.Mock;
+const mockQueryDevSessionsAsync = queryDevSessionsAsync as jest.Mock;
 
 function mockGetPackagersResponse(response: Packager[]) {
   return mockGetLocalPackagersAsync.mockResolvedValueOnce(response);
@@ -79,21 +82,21 @@ describe('<HomeScreen />', () => {
       initialPackagers: [],
     });
 
-    mockGetLocalPackagersAsync.mockClear();
+    mockQueryDevSessionsAsync.mockClear();
 
     await act(async () => {
       await waitFor(() => getByText(refetchPackagersRegex));
       fireEvent.press(getByText(refetchPackagersRegex));
-      expect(getLocalPackagersAsync).toHaveBeenCalledTimes(1);
+      expect(queryDevSessionsAsync).toHaveBeenCalledTimes(1);
     });
 
     // ensure button is disabled when fetching
     await act(async () => {
       fireEvent.press(getByText(fetchingPackagersRegex));
       await waitFor(() => getByText(refetchPackagersRegex));
-      expect(getLocalPackagersAsync).toHaveBeenCalledTimes(testPollAmount);
+      expect(queryDevSessionsAsync).toHaveBeenCalledTimes(testPollAmount);
       fireEvent.press(getByText(refetchPackagersRegex));
-      expect(getLocalPackagersAsync).toHaveBeenCalledTimes(testPollAmount + 1);
+      expect(queryDevSessionsAsync).toHaveBeenCalledTimes(testPollAmount + 1);
     });
   });
 

--- a/packages/expo-dev-launcher/ios/EXDevLauncherInternal.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherInternal.m
@@ -64,9 +64,14 @@ NSString *ON_NEW_DEEP_LINK_EVENT = @"expo.modules.devlauncher.onnewdeeplink";
 
 - (NSDictionary *)constantsToExport
 {
+  BOOL isDevice = YES;
+#if TARGET_IPHONE_SIMULATOR
+  isDevice = NO;
+#endif
   return @{
     @"clientUrlScheme": self.findClientUrlScheme ?: [NSNull null],
-    @"installationID": [EXDevLauncherController.sharedInstance.installationIDHelper getOrCreateInstallationID] ?: [NSNull null]
+    @"installationID": [EXDevLauncherController.sharedInstance.installationIDHelper getOrCreateInstallationID] ?: [NSNull null],
+    @"isDevice": @(isDevice)
   };
 }
 


### PR DESCRIPTION
# Why

PR 2/2 for ENG-1989

# How

- Pass the exported `installationID` from DevLauncherInternal into DevMenu's `queryDevSessionsAsync` method to fulfill ENG-1989
- Update the logic around fetching dev sessions to the following, in both the old and new dev launcher apps: (1) if user is authed, try fetching dev sessions using auth; (2) if not, or if there are no active sessions, try fetching sessions using the installation ID; (3) if there are still no sessions and we are on a simulator, try the `getLocalPackagers` method.
- Add `DevLauncherInternal.isDevice` constant, since it doesn't make sense to try polling the localhost/10.0.0.2 ports if we're on a device.

@ajsmth especially curious if this seems like the right place to implement this in the redesign; or do we want to bypass the polling logic, for example, when making the server call? Or if this implementation looks right to you, what do you think about renaming `useLocalPackagers` to `useDevSessions`?

# Test Plan

Tested manually on both platforms by modifying expo-cli to create a development session with a particular ID. Tested the following cases:
✅ local packager shows up on simulator when signed out and no session exists with installation ID
✅ no packagers show up on device in the same scenario
✅ dev session shows up on simulator and device when signed out, and session was created by expo-cli with installation ID
✅ dev session shows up on simulator and device when signed in, and session was created by expo-cli with installation ID
✅ dev session shows up on simulator and device when signed in, and no session exists with installation ID
✅ dev session shows up on simulator and device when signed in, and session was created with same installation ID by expo-cli signed into a different account
✅ local packager disappears on simulator as soon as a dev session is found

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
